### PR TITLE
Scheduled Emails Query Improvement

### DIFF
--- a/discovery-provider/plugins/notifications/src/email/notifications/index.ts
+++ b/discovery-provider/plugins/notifications/src/email/notifications/index.ts
@@ -356,7 +356,7 @@ export async function processEmailNotifications(
       const now = Date.now()
       if (now > timeout) return
       logger.info(
-        `processEmailNotifications | gathering users for ${frequency} query ${startOffset} ${pageCount}`
+        `processEmailNotifications | gathering users for ${frequency} query ${startOffset} ${lastUser} ${pageCount}`
       )
       const userRows: { blockchainUserId: number; email: string }[] =
         await getUsersCanNotifyQuery(
@@ -387,7 +387,7 @@ export async function processEmailNotifications(
       logger.info(
         `processEmailNotifications | Beginning processing ${
           Object.keys(emailUsers).length
-        } users at ${frequency} frequency`
+        } users at ${frequency} frequency [${lastUser}-${lastUser + Object.keys(emailUsers).length}]`
       )
 
       await processGroupOfEmails(

--- a/discovery-provider/plugins/notifications/src/email/notifications/index.ts
+++ b/discovery-provider/plugins/notifications/src/email/notifications/index.ts
@@ -48,8 +48,9 @@ export const getUsersCanNotifyQuery = async (
   frequency: EmailFrequency,
   pageCount: number,
   lastUser: number
-) =>
-  await identityDb
+) => {
+  const userIds = Array.from({ length: pageCount }, (_, index) => index + lastUser + 1)
+  return await identityDb
     .with(
       'lastEmailSentAt',
       identityDb.raw(`
@@ -57,6 +58,7 @@ export const getUsersCanNotifyQuery = async (
           "userId",
           "timestamp"
         FROM "NotificationEmails"
+        WHERE "userId" IN (${userIds.join(', ')})
         ORDER BY "userId", "timestamp" DESC
       `)
     )
@@ -102,6 +104,7 @@ export const getUsersCanNotifyQuery = async (
     .where('Users.blockchainUserId', '>', lastUser)
     .limit(pageCount)
     .orderBy('Users.blockchainUserId')
+}
 
 const appNotificationsSql = `
 WITH latest_user_seen AS (

--- a/discovery-provider/plugins/notifications/src/email/notifications/index.ts
+++ b/discovery-provider/plugins/notifications/src/email/notifications/index.ts
@@ -181,6 +181,8 @@ const getNotifications = async (
   })
   let appNotifications: EmailNotification[] = appNotificationsResp.rows
 
+  logger.info(`got app notifs resp ${startOffset}`)
+
   // filter for only enabled notifications in MappingFeatureName
   // on optimizely
   appNotifications = appNotifications.filter((notification) => {
@@ -226,6 +228,7 @@ const getNotifications = async (
     end_offset: messageEndOffset,
     user_ids: [[messageUserIds]]
   })
+  logger.info(`got msg notifs resp ${startOffset}`)
   const messages: { sender_user_id: number; receiver_user_id: number }[] =
     messagesResp.rows
   const messageNotifications: DMEmailNotification[] = messages.map((n) => ({
@@ -238,6 +241,8 @@ const getNotifications = async (
     end_offset: messageEndOffset,
     user_ids: [[messageUserIds]]
   })
+
+  logger.info(`got reaction notifs resp ${startOffset}`)
   const reactions: { sender_user_id: number; receiver_user_id: number }[] =
     reactionsResp.rows
   const reactionNotifications: DMEmailNotification[] = reactions.map((n) => ({
@@ -406,6 +411,8 @@ const processGroupOfEmails = async (
     Object.keys(users).map(Number)
   )
 
+  logger.info(`got notification settings for users ${startOffset}`)
+
   const notifications = await getNotifications(
     dnDb,
     frequency,
@@ -413,6 +420,7 @@ const processGroupOfEmails = async (
     Object.keys(users),
     remoteConfig
   )
+  logger.info(`got notifications for users ${startOffset}`)
   const groupedNotifications = groupNotifications(notifications, users)
 
   const currentUtcTime = moment.utc()


### PR DESCRIPTION
### Description
What I have next learned is that the join here may have been very expensive because it was returning a notifications instance per user in the user array. This may have been filling up a ton of unnecessary memory. Breaking this apart into three pieces, two queries and then merging the notifs and users at runtime results in way better performance. Doing it this way flies through thousands of users especially when there's no matches found.
 
### How Has This Been Tested?

Ran on prod dn1, logs of a partial run: (email addresses omitted) 
```
{"level":30,"time":"2023-08-26T00:37:18.375Z","name":"notifications","msg":"Processing daily emails..."}
{"level":30,"time":"2023-08-26T00:37:18.378Z","name":"notifications","msg":"processEmailNotifications | gathering users for daily query Fri Aug 25 2023 00:37:18 GMT+0000 0 1000"}
{"level":30,"time":"2023-08-26T00:37:19.008Z","name":"notifications","msg":"processEmailNotifications | Beginning processing 1000 users at daily frequency [2217-3217]"}
{"level":30,"time":"2023-08-26T00:37:19.175Z","name":"notifications","msg":"got notification settings for users Fri Aug 25 2023 00:37:18 GMT+0000"}
{"level":30,"time":"2023-08-26T00:37:19.822Z","name":"notifications","msg":"got app notifs resp Fri Aug 25 2023 00:37:18 GMT+0000"}
{"level":30,"time":"2023-08-26T00:37:19.832Z","name":"notifications","msg":"got msg notifs resp Fri Aug 25 2023 00:37:18 GMT+0000"}
{"level":30,"time":"2023-08-26T00:37:19.838Z","name":"notifications","msg":"got reaction notifs resp Fri Aug 25 2023 00:37:18 GMT+0000"}
{"level":30,"time":"2023-08-26T00:37:19.838Z","name":"notifications","msg":"got notifications for users Fri Aug 25 2023 00:37:18 GMT+0000"}
{"level":30,"time":"2023-08-26T00:37:19.839Z","name":"notifications","msg":"processEmailNotifications | finished looping over users to send notification emails, sent 0 daily emails"}
{"level":30,"time":"2023-08-26T00:37:19.840Z","name":"notifications","msg":"processEmailNotifications | gathering users for daily query Fri Aug 25 2023 00:37:18 GMT+0000 2217 1000"}
{"level":30,"time":"2023-08-26T00:37:19.963Z","name":"notifications","msg":"processEmailNotifications | Beginning processing 1000 users at daily frequency [4510-5510]"}
{"level":30,"time":"2023-08-26T00:37:20.052Z","name":"notifications","msg":"got notification settings for users Fri Aug 25 2023 00:37:18 GMT+0000"}
{"level":30,"time":"2023-08-26T00:37:20.584Z","name":"notifications","msg":"got app notifs resp Fri Aug 25 2023 00:37:18 GMT+0000"}
{"level":30,"time":"2023-08-26T00:37:20.590Z","name":"notifications","msg":"got msg notifs resp Fri Aug 25 2023 00:37:18 GMT+0000"}
{"level":30,"time":"2023-08-26T00:37:20.595Z","name":"notifications","msg":"got reaction notifs resp Fri Aug 25 2023 00:37:18 GMT+0000"}
{"level":30,"time":"2023-08-26T00:37:20.595Z","name":"notifications","msg":"got notifications for users Fri Aug 25 2023 00:37:18 GMT+0000"}
{"level":30,"time":"2023-08-26T00:37:20.596Z","name":"notifications","msg":"processEmailNotifications | finished looping over users to send notification emails, sent 0 daily emails"}
{"level":30,"time":"2023-08-26T00:37:20.596Z","name":"notifications","msg":"processEmailNotifications | gathering users for daily query Fri Aug 25 2023 00:37:18 GMT+0000 4510 1000"}
{"level":30,"time":"2023-08-26T00:37:20.704Z","name":"notifications","msg":"processEmailNotifications | Beginning processing 1000 users at daily frequency [6788-7788]"}
{"level":30,"time":"2023-08-26T00:37:20.798Z","name":"notifications","msg":"got notification settings for users Fri Aug 25 2023 00:37:18 GMT+0000"}
{"level":30,"time":"2023-08-26T00:37:21.330Z","name":"notifications","msg":"got app notifs resp Fri Aug 25 2023 00:37:18 GMT+0000"}
{"level":30,"time":"2023-08-26T00:37:21.335Z","name":"notifications","msg":"got msg notifs resp Fri Aug 25 2023 00:37:18 GMT+0000"}
{"level":30,"time":"2023-08-26T00:37:21.340Z","name":"notifications","msg":"got reaction notifs resp Fri Aug 25 2023 00:37:18 GMT+0000"}
{"level":30,"time":"2023-08-26T00:37:21.340Z","name":"notifications","msg":"got notifications for users Fri Aug 25 2023 00:37:18 GMT+0000"}
{"level":30,"time":"2023-08-26T00:37:21.341Z","name":"notifications","msg":"processEmailNotifications | finished looping over users to send notification emails, sent 0 daily emails"}
{"level":30,"time":"2023-08-26T00:37:21.341Z","name":"notifications","msg":"processEmailNotifications | gathering users for daily query Fri Aug 25 2023 00:37:18 GMT+0000 6788 1000"}
{"level":30,"time":"2023-08-26T00:37:21.453Z","name":"notifications","msg":"processEmailNotifications | Beginning processing 1000 users at daily frequency [9186-10186]"}
{"level":30,"time":"2023-08-26T00:37:21.547Z","name":"notifications","msg":"got notification settings for users Fri Aug 25 2023 00:37:18 GMT+0000"}
{"level":30,"time":"2023-08-26T00:37:22.179Z","name":"notifications","msg":"got app notifs resp Fri Aug 25 2023 00:37:18 GMT+0000"}
{"level":30,"time":"2023-08-26T00:37:22.185Z","name":"notifications","msg":"got msg notifs resp Fri Aug 25 2023 00:37:18 GMT+0000"}
{"level":30,"time":"2023-08-26T00:37:22.190Z","name":"notifications","msg":"got reaction notifs resp Fri Aug 25 2023 00:37:18 GMT+0000"}
{"level":30,"time":"2023-08-26T00:37:22.190Z","name":"notifications","msg":"got notifications for users Fri Aug 25 2023 00:37:18 GMT+0000"}
{"level":30,"time":"2023-08-26T00:37:22.498Z","name":"notifications","job":"renderAndSendNotificationEmail","msg":"renderAndSendNotificationEmail | sent email to 8958 at ****@gmail.com"}
{"level":30,"time":"2023-08-26T00:37:22.521Z","name":"notifications","msg":"processEmailNotifications | finished looping over users to send notification emails, sent 1 daily emails"}
{"level":30,"time":"2023-08-26T00:37:22.521Z","name":"notifications","msg":"processEmailNotifications | gathering users for daily query Fri Aug 25 2023 00:37:18 GMT+0000 9186 1000"}
{"level":30,"time":"2023-08-26T00:37:22.601Z","name":"notifications","msg":"processEmailNotifications | Beginning processing 1000 users at daily frequency [11725-12725]"}
{"level":30,"time":"2023-08-26T00:37:22.699Z","name":"notifications","msg":"got notification settings for users Fri Aug 25 2023 00:37:18 GMT+0000"}
{"level":30,"time":"2023-08-26T00:37:24.493Z","name":"notifications","msg":"got app notifs resp Fri Aug 25 2023 00:37:18 GMT+0000"}
{"level":30,"time":"2023-08-26T00:37:24.501Z","name":"notifications","msg":"got msg notifs resp Fri Aug 25 2023 00:37:18 GMT+0000"}
{"level":30,"time":"2023-08-26T00:37:24.508Z","name":"notifications","msg":"got reaction notifs resp Fri Aug 25 2023 00:37:18 GMT+0000"}
{"level":30,"time":"2023-08-26T00:37:24.508Z","name":"notifications","msg":"got notifications for users Fri Aug 25 2023 00:37:18 GMT+0000"}
{"level":30,"time":"2023-08-26T00:37:24.509Z","name":"notifications","msg":"processEmailNotifications | finished looping over users to send notification emails, sent 0 daily emails"}
{"level":30,"time":"2023-08-26T00:37:24.509Z","name":"notifications","msg":"processEmailNotifications | gathering users for daily query Fri Aug 25 2023 00:37:18 GMT+0000 11725 1000"}
{"level":30,"time":"2023-08-26T00:37:24.612Z","name":"notifications","msg":"processEmailNotifications | Beginning processing 1000 users at daily frequency [13414-14414]"}
{"level":30,"time":"2023-08-26T00:37:24.709Z","name":"notifications","msg":"got notification settings for users Fri Aug 25 2023 00:37:18 GMT+0000"}
{"level":30,"time":"2023-08-26T00:37:25.441Z","name":"notifications","msg":"got app notifs resp Fri Aug 25 2023 00:37:18 GMT+0000"}
{"level":30,"time":"2023-08-26T00:37:25.448Z","name":"notifications","msg":"got msg notifs resp Fri Aug 25 2023 00:37:18 GMT+0000"}
{"level":30,"time":"2023-08-26T00:37:25.455Z","name":"notifications","msg":"got reaction notifs resp Fri Aug 25 2023 00:37:18 GMT+0000"}
{"level":30,"time":"2023-08-26T00:37:25.455Z","name":"notifications","msg":"got notifications for users Fri Aug 25 2023 00:37:18 GMT+0000"}
{"level":30,"time":"2023-08-26T00:37:25.455Z","name":"notifications","msg":"processEmailNotifications | finished looping over users to send notification emails, sent 0 daily emails"}
{"level":30,"time":"2023-08-26T00:37:25.455Z","name":"notifications","msg":"processEmailNotifications | gathering users for daily query Fri Aug 25 2023 00:37:18 GMT+0000 13414 1000"}
{"level":30,"time":"2023-08-26T00:37:25.563Z","name":"notifications","msg":"processEmailNotifications | Beginning processing 1000 users at daily frequency [15437-16437]"}
{"level":30,"time":"2023-08-26T00:37:25.656Z","name":"notifications","msg":"got notification settings for users Fri Aug 25 2023 00:37:18 GMT+0000"}
{"level":30,"time":"2023-08-26T00:37:26.300Z","name":"notifications","msg":"got app notifs resp Fri Aug 25 2023 00:37:18 GMT+0000"}
{"level":30,"time":"2023-08-26T00:37:26.308Z","name":"notifications","msg":"got msg notifs resp Fri Aug 25 2023 00:37:18 GMT+0000"}
{"level":30,"time":"2023-08-26T00:37:26.315Z","name":"notifications","msg":"got reaction notifs resp Fri Aug 25 2023 00:37:18 GMT+0000"}
{"level":30,"time":"2023-08-26T00:37:26.315Z","name":"notifications","msg":"got notifications for users Fri Aug 25 2023 00:37:18 GMT+0000"}
{"level":30,"time":"2023-08-26T00:37:26.446Z","name":"notifications","job":"renderAndSendNotificationEmail","msg":"renderAndSendNotificationEmail | sent email to 14840 at ****@gmail.com"}
{"level":30,"time":"2023-08-26T00:37:26.448Z","name":"notifications","job":"renderAndSendNotificationEmail","msg":"renderAndSendNotificationEmail | sent email to 14811 at ****@gmail.com"}
{"level":30,"time":"2023-08-26T00:37:26.471Z","name":"notifications","msg":"processEmailNotifications | finished looping over users to send notification emails, sent 2 daily emails"}
{"level":30,"time":"2023-08-26T00:37:26.471Z","name":"notifications","msg":"processEmailNotifications | gathering users for daily query Fri Aug 25 2023 00:37:18 GMT+0000 15437 1000"}
{"level":30,"time":"2023-08-26T00:37:26.554Z","name":"notifications","msg":"processEmailNotifications | Beginning processing 1000 users at daily frequency [17294-18294]"}
{"level":30,"time":"2023-08-26T00:37:26.644Z","name":"notifications","msg":"got notification settings for users Fri Aug 25 2023 00:37:18 GMT+0000"}
{"level":30,"time":"2023-08-26T00:37:27.183Z","name":"notifications","msg":"got app notifs resp Fri Aug 25 2023 00:37:18 GMT+0000"}
{"level":30,"time":"2023-08-26T00:37:27.188Z","name":"notifications","msg":"got msg notifs resp Fri Aug 25 2023 00:37:18 GMT+0000"}
{"level":30,"time":"2023-08-26T00:37:27.192Z","name":"notifications","msg":"got reaction notifs resp Fri Aug 25 2023 00:37:18 GMT+0000"}
{"level":30,"time":"2023-08-26T00:37:27.192Z","name":"notifications","msg":"got notifications for users Fri Aug 25 2023 00:37:18 GMT+0000"}
{"level":30,"time":"2023-08-26T00:37:27.192Z","name":"notifications","msg":"processEmailNotifications | finished looping over users to send notification emails, sent 0 daily emails"}
{"level":30,"time":"2023-08-26T00:37:27.192Z","name":"notifications","msg":"processEmailNotifications | gathering users for daily query Fri Aug 25 2023 00:37:18 GMT+0000 17294 1000"}
{"level":30,"time":"2023-08-26T00:37:27.301Z","name":"notifications","msg":"processEmailNotifications | Beginning processing 1000 users at daily frequency [19304-20304]"}
{"level":30,"time":"2023-08-26T00:37:27.397Z","name":"notifications","msg":"got notification settings for users Fri Aug 25 2023 00:37:18 GMT+0000"}
{"level":30,"time":"2023-08-26T00:37:27.944Z","name":"notifications","msg":"got app notifs resp Fri Aug 25 2023 00:37:18 GMT+0000"}
{"level":30,"time":"2023-08-26T00:37:27.950Z","name":"notifications","msg":"got msg notifs resp Fri Aug 25 2023 00:37:18 GMT+0000"}
{"level":30,"time":"2023-08-26T00:37:27.954Z","name":"notifications","msg":"got reaction notifs resp Fri Aug 25 2023 00:37:18 GMT+0000"}
{"level":30,"time":"2023-08-26T00:37:27.954Z","name":"notifications","msg":"got notifications for users Fri Aug 25 2023 00:37:18 GMT+0000"}
{"level":30,"time":"2023-08-26T00:37:27.955Z","name":"notifications","msg":"processEmailNotifications | finished looping over users to send notification emails, sent 0 daily emails"}
{"level":30,"time":"2023-08-26T00:37:27.955Z","name":"notifications","msg":"processEmailNotifications | gathering users for daily query Fri Aug 25 2023 00:37:18 GMT+0000 19304 1000"}
{"level":30,"time":"2023-08-26T00:37:28.019Z","name":"notifications","msg":"processEmailNotifications | Beginning processing 1000 users at daily frequency [22154-23154]"}
{"level":30,"time":"2023-08-26T00:37:28.107Z","name":"notifications","msg":"got notification settings for users Fri Aug 25 2023 00:37:18 GMT+0000"}
{"level":30,"time":"2023-08-26T00:37:28.222Z","name":"notifications","msg":"got app notifs resp Fri Aug 25 2023 00:37:18 GMT+0000"}
{"level":30,"time":"2023-08-26T00:37:28.227Z","name":"notifications","msg":"got msg notifs resp Fri Aug 25 2023 00:37:18 GMT+0000"}
{"level":30,"time":"2023-08-26T00:37:28.231Z","name":"notifications","msg":"got reaction notifs resp Fri Aug 25 2023 00:37:18 GMT+0000"}
{"level":30,"time":"2023-08-26T00:37:28.232Z","name":"notifications","msg":"got notifications for users Fri Aug 25 2023 00:37:18 GMT+0000"}
{"level":30,"time":"2023-08-26T00:37:28.284Z","name":"notifications","job":"renderAndSendNotificationEmail","msg":"renderAndSendNotificationEmail | sent email to 21139 at ****@gmail.com"}
{"level":30,"time":"2023-08-26T00:37:28.305Z","name":"notifications","msg":"processEmailNotifications | finished looping over users to send notification emails, sent 1 daily emails"}
{"level":30,"time":"2023-08-26T00:37:28.306Z","name":"notifications","msg":"processEmailNotifications | gathering users for daily query Fri Aug 25 2023 00:37:18 GMT+0000 22154 1000"}
{"level":30,"time":"2023-08-26T00:37:28.381Z","name":"notifications","msg":"processEmailNotifications | Beginning processing 1000 users at daily frequency [25733-26733]"}
{"level":30,"time":"2023-08-26T00:37:28.471Z","name":"notifications","msg":"got notification settings for users Fri Aug 25 2023 00:37:18 GMT+0000"}
{"level":30,"time":"2023-08-26T00:37:28.945Z","name":"notifications","msg":"got app notifs resp Fri Aug 25 2023 00:37:18 GMT+0000"}
{"level":30,"time":"2023-08-26T00:37:28.950Z","name":"notifications","msg":"got msg notifs resp Fri Aug 25 2023 00:37:18 GMT+0000"}
{"level":30,"time":"2023-08-26T00:37:28.955Z","name":"notifications","msg":"got reaction notifs resp Fri Aug 25 2023 00:37:18 GMT+0000"}
{"level":30,"time":"2023-08-26T00:37:28.955Z","name":"notifications","msg":"got notifications for users Fri Aug 25 2023 00:37:18 GMT+0000"}
{"level":30,"time":"2023-08-26T00:37:28.955Z","name":"notifications","msg":"processEmailNotifications | finished looping over users to send notification emails, sent 0 daily emails"}
{"level":30,"time":"2023-08-26T00:37:28.955Z","name":"notifications","msg":"processEmailNotifications | gathering users for daily query Fri Aug 25 2023 00:37:18 GMT+0000 25733 1000"}
{"level":30,"time":"2023-08-26T00:37:29.018Z","name":"notifications","msg":"processEmailNotifications | Beginning processing 1000 users at daily frequency [28739-29739]"}
{"level":30,"time":"2023-08-26T00:37:29.107Z","name":"notifications","msg":"got notification settings for users Fri Aug 25 2023 00:37:18 GMT+0000"}
{"level":30,"time":"2023-08-26T00:37:29.568Z","name":"notifications","msg":"got app notifs resp Fri Aug 25 2023 00:37:18 GMT+0000"}
{"level":30,"time":"2023-08-26T00:37:29.572Z","name":"notifications","msg":"got msg notifs resp Fri Aug 25 2023 00:37:18 GMT+0000"}
{"level":30,"time":"2023-08-26T00:37:29.576Z","name":"notifications","msg":"got reaction notifs resp Fri Aug 25 2023 00:37:18 GMT+0000"}
{"level":30,"time":"2023-08-26T00:37:29.577Z","name":"notifications","msg":"got notifications for users Fri Aug 25 2023 00:37:18 GMT+0000"}
{"level":30,"time":"2023-08-26T00:37:29.577Z","name":"notifications","msg":"processEmailNotifications | finished looping over users to send notification emails, sent 0 daily emails"}
{"level":30,"time":"2023-08-26T00:37:29.577Z","name":"notifications","msg":"processEmailNotifications | gathering users for daily query Fri Aug 25 2023 00:37:18 GMT+0000 28739 1000"}
{"level":30,"time":"2023-08-26T00:37:29.674Z","name":"notifications","msg":"processEmailNotifications | Beginning processing 1000 users at daily frequency [30855-31855]"}
{"level":30,"time":"2023-08-26T00:37:29.762Z","name":"notifications","msg":"got notification settings for users Fri Aug 25 2023 00:37:18 GMT+0000"}
{"level":30,"time":"2023-08-26T00:37:30.283Z","name":"notifications","msg":"got app notifs resp Fri Aug 25 2023 00:37:18 GMT+0000"}
{"level":30,"time":"2023-08-26T00:37:30.288Z","name":"notifications","msg":"got msg notifs resp Fri Aug 25 2023 00:37:18 GMT+0000"}
{"level":30,"time":"2023-08-26T00:37:30.292Z","name":"notifications","msg":"got reaction notifs resp Fri Aug 25 2023 00:37:18 GMT+0000"}
{"level":30,"time":"2023-08-26T00:37:30.292Z","name":"notifications","msg":"got notifications for users Fri Aug 25 2023 00:37:18 GMT+0000"}
{"level":30,"time":"2023-08-26T00:37:30.292Z","name":"notifications","msg":"processEmailNotifications | finished looping over users to send notification emails, sent 0 daily emails"}
{"level":30,"time":"2023-08-26T00:37:30.292Z","name":"notifications","msg":"processEmailNotifications | gathering users for daily query Fri Aug 25 2023 00:37:18 GMT+0000 30855 1000"}
{"level":30,"time":"2023-08-26T00:37:30.359Z","name":"notifications","msg":"processEmailNotifications | Beginning processing 1000 users at daily frequency [33919-34919]"}
{"level":30,"time":"2023-08-26T00:37:30.454Z","name":"notifications","msg":"got notification settings for users Fri Aug 25 2023 00:37:18 GMT+0000"}
{"level":30,"time":"2023-08-26T00:37:30.941Z","name":"notifications","msg":"got app notifs resp Fri Aug 25 2023 00:37:18 GMT+0000"}
{"level":30,"time":"2023-08-26T00:37:30.948Z","name":"notifications","msg":"got msg notifs resp Fri Aug 25 2023 00:37:18 GMT+0000"}
{"level":30,"time":"2023-08-26T00:37:30.952Z","name":"notifications","msg":"got reaction notifs resp Fri Aug 25 2023 00:37:18 GMT+0000"}
{"level":30,"time":"2023-08-26T00:37:30.953Z","name":"notifications","msg":"got notifications for users Fri Aug 25 2023 00:37:18 GMT+0000"}
{"level":30,"time":"2023-08-26T00:37:30.953Z","name":"notifications","msg":"processEmailNotifications | finished looping over users to send notification emails, sent 0 daily emails"}
{"level":30,"time":"2023-08-26T00:37:30.953Z","name":"notifications","msg":"processEmailNotifications | gathering users for daily query Fri Aug 25 2023 00:37:18 GMT+0000 33919 1000"}
{"level":30,"time":"2023-08-26T00:37:31.081Z","name":"notifications","msg":"processEmailNotifications | Beginning processing 1000 users at daily frequency [37103-38103]"}
```
