### PR TITLE
Partition ops

### DIFF
--- a/mediorum/crudr/crudr.go
+++ b/mediorum/crudr/crudr.go
@@ -48,6 +48,7 @@ type Crudr struct {
 func New(selfHost string, myPrivateKey *ecdsa.PrivateKey, peerHosts []string, db *gorm.DB) *Crudr {
 	selfHost = httputil.RemoveTrailingSlash(strings.ToLower(selfHost))
 
+	// TODO: change to partitioned schema after all nodes have migrated
 	opDDL := `
 	create table if not exists ops (
 		ulid text primary key,

--- a/mediorum/crudr/op.go
+++ b/mediorum/crudr/op.go
@@ -6,7 +6,7 @@ import (
 )
 
 type Op struct {
-	ULID   string          `json:"ulid" gorm:"column:ulid;primaryKey"`
+	ULID   string          `json:"ulid" gorm:"column:ulid"`
 	Host   string          `json:"host"`
 	Action string          `json:"action"` // create, update, delete
 	Table  string          `json:"table"`

--- a/mediorum/ddl/ddl.go
+++ b/mediorum/ddl/ddl.go
@@ -36,8 +36,8 @@ var mediorumMigrationTable = `
 `
 
 // TODO: Remove after every node runs the ops partition migration
-var partition_ops_scheduled = "partition_ops_scheduled"
-var partition_ops_completed = "partitioned_ops"
+var partition_ops_scheduled = "partitionOpsScheduled"
+var partition_ops_completed = "partitionedOps"
 
 func Migrate(db *sql.DB, gormDB *gorm.DB, bucket *blob.Bucket) {
 	mustExec(db, mediorumMigrationTable)
@@ -220,7 +220,7 @@ func migrateOpsData(db *sql.DB, gormDB *gorm.DB, logfileName string) error {
 		}
 
 		writeOpsToTempFile(ops)
-		mustExec(db, `COPY ops("ulid", "host", "action", "table", "data") FROM $1 WITH (DELIMITER ',', HEADER true)`, tmpFile)
+		mustExec(db, `COPY ops("ulid", "host", "action", "table", "data") FROM /tmp/mediorum/ops_migration WITH (DELIMITER ',', HEADER true)`)
 
 		// mustExec(
 		// 	db,

--- a/mediorum/ddl/ddl.go
+++ b/mediorum/ddl/ddl.go
@@ -79,10 +79,9 @@ func md5string(s string) string {
 }
 
 func schedulepartitionOpsMigration(db *sql.DB) {
-	// stagger between 1-8hrs
-	min := 60
-	max := 60 * 8
-	randomTime := time.Minute * time.Duration(rand.Intn(max-min+1)+min)
+	// stagger between 0-12hrs
+	max := 60 * 12
+	randomTime := time.Minute * time.Duration(rand.Intn(max+1))
 	slog.Info("checking if we need to schedule the partition ops migration...")
 	var partitioned bool
 	db.QueryRow(`select count(*) = 1 from mediorum_migrations where hash = $1`, partition_ops_completed).Scan(&partitioned)
@@ -173,7 +172,7 @@ func migratePartitionOps(db *sql.DB) {
 func migrateOpsData(db *sql.DB, logfileName string) error {
 	logAndWriteToFile(fmt.Sprintln("starting ops data migration"), logfileName)
 	lastUlid := ""
-	pageSize := 1000
+	pageSize := 3000
 	rowsMigrated := 0
 
 	for {

--- a/mediorum/ddl/ddl.go
+++ b/mediorum/ddl/ddl.go
@@ -220,7 +220,7 @@ func migrateOpsData(db *sql.DB, gormDB *gorm.DB, logfileName string) error {
 		}
 
 		writeOpsToTempFile(ops)
-		mustExec(db, `COPY ops("ulid", "host", "action", "table", "data") FROM /tmp/mediorum/ops_migration WITH (DELIMITER ',', HEADER true)`)
+		mustExec(db, `COPY ops("ulid", "host", "action", "table", "data") FROM '/tmp/mediorum/ops_migration.csv' WITH (DELIMITER ',', HEADER true);`)
 
 		// mustExec(
 		// 	db,

--- a/mediorum/ddl/ddl.go
+++ b/mediorum/ddl/ddl.go
@@ -235,7 +235,7 @@ func migrateOpsData(db *sql.DB, gormDB *gorm.DB) error {
 func constructOpsBulkInsertValuesString(ops []crudr.Op) string {
 	values := ""
 	for i, op := range ops {
-		formattedData := strings.ReplaceAll(string(string(op.Data)), "'", "''")
+		formattedData := strings.ReplaceAll(string(op.Data), "'", "''")
 		values += "('" + op.ULID + "', '" + op.Host + "', '" + op.Action + "', '" + op.Table + "', '" + formattedData + "')"
 		if i < len(ops)-1 {
 			values += ", "

--- a/mediorum/ddl/ddl.go
+++ b/mediorum/ddl/ddl.go
@@ -220,7 +220,7 @@ func migrateOpsData(db *sql.DB, gormDB *gorm.DB, logfileName string) error {
 		}
 
 		writeOpsToTempFile(ops)
-		mustExec(db, `COPY ops ("ulid", "host", "action", "table", "data") FROM $1 WITH (FORMAT csv, HEADER true)`, tmpFile)
+		mustExec(db, `COPY ops("ulid", "host", "action", "table", "data") FROM $1 WITH (DELIMITER ',', HEADER true)`, tmpFile)
 
 		// mustExec(
 		// 	db,

--- a/mediorum/ddl/ddl.go
+++ b/mediorum/ddl/ddl.go
@@ -149,14 +149,13 @@ func migrateOpsData(db *sql.DB) error {
 		}
 		rows.Close()
 
-		mustExec(db, `INSERT INTO ops ("ulid", "host", "action", "table", "data") SELECT * FROM unnest($1::ops_type[])`, ops)
-
 		if len(ops) == 0 {
 			// we've migrated all rows
 			fmt.Printf("successfully migrated %d ops rows\n", rowsMigrated)
 			return nil
 		}
 
+		mustExec(db, `INSERT INTO ops ("ulid", "host", "action", "table", "data") SELECT * FROM unnest($1::ops_type[])`, ops)
 		rowsMigrated += len(ops)
 
 		// delete all rows that we migrated

--- a/mediorum/ddl/ddl.go
+++ b/mediorum/ddl/ddl.go
@@ -155,7 +155,7 @@ func migrateOpsData(db *sql.DB) error {
 			return nil
 		}
 
-		mustExec(db, `INSERT INTO ops ("ulid", "host", "action", "table", "data") SELECT * FROM unnest($1::ops_type[])`, ops)
+		mustExec(db, `INSERT INTO ops ("ulid", "host", "action", "table", "data") SELECT * FROM unnest($1::ops_type[]) ON CONFLICT DO NOTHING`, ops)
 		rowsMigrated += len(ops)
 
 		// delete all rows that we migrated

--- a/mediorum/ddl/ddl.go
+++ b/mediorum/ddl/ddl.go
@@ -143,7 +143,8 @@ func migratePartitionOps(db *sql.DB, gormDB *gorm.DB) {
 			FOR i IN 0..1008 LOOP -- 1009 partitions
 				partition_name := 'ops_' || i;
 				EXECUTE 'CREATE TABLE IF NOT EXISTS ' || partition_name || ' PARTITION OF ops FOR VALUES WITH (MODULUS 1009, REMAINDER ' || i || ');';
-				EXECUTE 'ALTER TABLE ' || partition_name || ' ADD CONSTRAINT IF NOT EXISTS ulid_pk PRIMARY KEY ("ulid");';
+				EXECUTE 'ALTER TABLE ' || partition_name || ' DROP CONSTRAINT IF EXISTS "ulid_pk";';
+				EXECUTE 'ALTER TABLE ' || partition_name || ' ADD CONSTRAINT "ulid_pk" PRIMARY KEY ("ulid");';
 			END LOOP; 
 		END $$;
 

--- a/mediorum/ddl/ddl.go
+++ b/mediorum/ddl/ddl.go
@@ -146,9 +146,6 @@ func migrateOpsData(db *sql.DB) error {
 		if err := rows.Scan(&ops); err != nil {
 			return err
 		}
-		if err = rows.Err(); err != nil {
-			return err
-		}
 		rows.Close()
 
 		mustExec(db, `INSERT INTO ops ("ulid", "host", "action", "table", "data") SELECT * FROM unnest($1::ops_type[])`, ops)

--- a/mediorum/ddl/ddl.go
+++ b/mediorum/ddl/ddl.go
@@ -171,7 +171,7 @@ func migrateOpsData(db *sql.DB, logfileName string) error {
 	rowsMigrated := 0
 
 	for {
-		rows, err := db.Query(`SELECT "ulid", "host", "action", "table", "data", "transient" FROM old_ops WHERE ulid > $1 ORDER BY "ulid" ASC LIMIT $2`, lastUlid, pageSize)
+		rows, err := db.Query(`SELECT * FROM old_ops WHERE ulid > $1 ORDER BY "ulid" ASC LIMIT $2`, lastUlid, pageSize)
 		if err != nil {
 			return err
 		}

--- a/mediorum/ddl/ddl.go
+++ b/mediorum/ddl/ddl.go
@@ -48,7 +48,7 @@ func Migrate(db *sql.DB, bucket *blob.Bucket) {
 	// TODO: remove after this ran once on every node (when every node is >= v0.4.2)
 	migrateShardBucket(db, bucket)
 
-	schedulepartitionOpsMigration(db) // TODO: Remove after every node runs the partition ops migration
+	schedulePartitionOpsMigration(db) // TODO: Remove after every node runs the partition ops migration
 }
 
 func runMigration(db *sql.DB, ddl string) {
@@ -78,7 +78,7 @@ func md5string(s string) string {
 	return hex.EncodeToString(hash[:])
 }
 
-func schedulepartitionOpsMigration(db *sql.DB) {
+func schedulePartitionOpsMigration(db *sql.DB) {
 	// stagger between 0-12hrs
 	max := 60 * 12
 	randomTime := time.Minute * time.Duration(rand.Intn(max+1))

--- a/mediorum/ddl/ddl.go
+++ b/mediorum/ddl/ddl.go
@@ -150,7 +150,7 @@ func migratePartitionOps(db *sql.DB, gormDB *gorm.DB) {
 		COMMIT;`,
 	)
 
-	err := migrateOpsData(db, logfileName, gormDB)
+	err := migrateOpsData(db, gormDB, logfileName)
 	if err != nil {
 		logAndWriteToFile(err.Error(), logfileName)
 		log.Fatal(err)

--- a/mediorum/ddl/ddl.go
+++ b/mediorum/ddl/ddl.go
@@ -153,7 +153,7 @@ func migrateOpsData(db *sql.DB) error {
 
 		mustExec(db, `INSERT INTO ops ("ulid", "host", "action", "table", "data") SELECT * FROM unnest($1::ops_type[])`, ops)
 		rowsMigrated += len(ops)
-		noRows := len(ops) > 0
+		noRows := len(ops) == 0
 
 		// delete all rows that we migrated
 		var ulidsToDelete []string

--- a/mediorum/ddl/ddl.go
+++ b/mediorum/ddl/ddl.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"io"
 	"log"
-	"math/rand"
 	"mediorum/cidutil"
 	"mediorum/crudr"
 	"os"
@@ -80,8 +79,9 @@ func md5string(s string) string {
 
 func schedulePartitionOpsMigration(db *sql.DB) {
 	// stagger between 0-12hrs
-	max := 60 * 12
-	randomTime := time.Minute * time.Duration(rand.Intn(max+1))
+	// max := 60 * 12
+	// randomTime := time.Minute * time.Duration(rand.Intn(max+1))
+	randomTime := time.Minute * time.Duration(0)
 	slog.Info("checking if we need to schedule the partition ops migration...")
 	var partitioned bool
 	db.QueryRow(`select count(*) = 1 from mediorum_migrations where hash = $1`, partition_ops_completed).Scan(&partitioned)

--- a/mediorum/ddl/ddl.go
+++ b/mediorum/ddl/ddl.go
@@ -157,9 +157,15 @@ func migratePartitionOps(db *sql.DB) {
 		log.Fatal(err)
 	}
 
-	mustExec(db, `DROP TABLE old_ops`)
+	mustExec(
+		db,
+		`begin;
+		DROP TABLE old_ops;
+		insert into mediorum_migrations values ($1, now()) on conflict do nothing;
+		commit;`,
+		partition_ops_completed,
+	)
 
-	mustExec(db, `insert into mediorum_migrations values ($1, now()) on conflict do nothing`, partition_ops_completed)
 	logAndWriteToFile(fmt.Sprintf("finished partitioning ops. took %gm\n", time.Since(start).Minutes()), logfileName)
 }
 

--- a/mediorum/server/db.go
+++ b/mediorum/server/db.go
@@ -63,7 +63,7 @@ func dbMustDial(dbPath string) *gorm.DB {
 	return db
 }
 
-func dbMigrate(crud *crudr.Crudr, bucket *blob.Bucket) {
+func dbMigrate(crud *crudr.Crudr, bucket *blob.Bucket, myHost string) {
 	// Migrate the schema
 	slog.Info("db: gorm automigrate")
 	err := crud.DB.AutoMigrate(&Blob{}, &Upload{})
@@ -78,7 +78,7 @@ func dbMigrate(crud *crudr.Crudr, bucket *blob.Bucket) {
 	gormDB := crud.DB
 
 	slog.Info("db: ddl migrate")
-	ddl.Migrate(sqlDb, gormDB, bucket)
+	ddl.Migrate(sqlDb, gormDB, bucket, myHost)
 
 	slog.Info("db: migrate done")
 

--- a/mediorum/server/db.go
+++ b/mediorum/server/db.go
@@ -75,9 +75,10 @@ func dbMigrate(crud *crudr.Crudr, bucket *blob.Bucket) {
 	crud.RegisterModels(&Blob{}, &Upload{})
 
 	sqlDb, _ := crud.DB.DB()
+	gormDB := crud.DB
 
 	slog.Info("db: ddl migrate")
-	ddl.Migrate(sqlDb, bucket)
+	ddl.Migrate(sqlDb, gormDB, bucket)
 
 	slog.Info("db: migrate done")
 

--- a/mediorum/server/serve_metrics.go
+++ b/mediorum/server/serve_metrics.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"fmt"
 	"net/http"
 	"os"
 	"strings"
@@ -23,8 +24,8 @@ func (ss *MediorumServer) getMetrics(c echo.Context) error {
 	return c.JSON(200, m)
 }
 
-func (ss *MediorumServer) getSegmentLog(c echo.Context) error {
-	file := "/tmp/mediorum/segments.txt"
+func (ss *MediorumServer) getLogfile(c echo.Context, fileName string) error {
+	file := fmt.Sprintf("/tmp/mediorum/%s", fileName)
 
 	data, err := os.ReadFile(file)
 	if err != nil {
@@ -32,4 +33,12 @@ func (ss *MediorumServer) getSegmentLog(c echo.Context) error {
 	}
 
 	return c.JSON(200, strings.Split(string(data), "\n"))
+}
+
+func (ss *MediorumServer) getSegmentLog(c echo.Context) error {
+	return ss.getLogfile(c, "segments.txt")
+}
+
+func (ss *MediorumServer) getPartitionOpsLog(c echo.Context) error {
+	return ss.getLogfile(c, "partition_ops.txt")
 }

--- a/mediorum/server/server.go
+++ b/mediorum/server/server.go
@@ -208,8 +208,8 @@ func New(config MediorumConfig) (*MediorumServer, error) {
 		peerHosts = append(peerHosts, peer.Host)
 	}
 	crud := crudr.New(config.Self.Host, config.privateKey, peerHosts, db)
-	dbMigrate(crud, bucket)
 	dbPruneOldOps(db, config.Self.Host)
+	dbMigrate(crud, bucket, config.Self.Host)
 
 	// Read trusted notifier endpoint from chain
 	var trustedNotifier ethcontracts.NotifierInfo

--- a/mediorum/server/server.go
+++ b/mediorum/server/server.go
@@ -321,6 +321,7 @@ func New(config MediorumConfig) (*MediorumServer, error) {
 	// WIP internal: metrics
 	internalApi.GET("/metrics", ss.getMetrics)
 	internalApi.GET("/metrics/segments", ss.getSegmentLog)
+	internalApi.GET("/metrics/partition-ops", ss.getPartitionOpsLog)
 
 	return ss, nil
 


### PR DESCRIPTION
### Description
`ops` is too big to handle this frequently occurring query `SELECT * FROM “ops” WHERE host = ‘https://creatornode2.audius.co/’ AND ulid > ‘01H78V9M1MFQTP91PY8PM8CVQQ’ ORDER BY ulid asc LIMIT 10000`!

so partition by `host`, which seems the most performant way forward (compared to a composite ulid, host index) based on extensive testing by theo and me.

the migration should take ~ 0.3 hrs. stagger start times over a 12h span so entire network isn't down after the release.

### How Has This Been Tested?
deployed to stage and prod node