### PR TITLE
[PAY-1759] Allow Sales endpoint to be sortable buy buyer name

### DIFF
--- a/discovery-provider/integration_tests/queries/test_get_usdc_purchases.py
+++ b/discovery-provider/integration_tests/queries/test_get_usdc_purchases.py
@@ -149,7 +149,9 @@ def test_get_purchases(app):
     with app.app_context():
         db = get_db()
         populate_mock_db(db, test_entities)
-        sales = get_usdc_purchases({"seller_user_id": 10})
+        sales = get_usdc_purchases(
+            {"seller_user_id": 10, "sort_method": PurchaseSortMethod.date}
+        )
         assert len(sales) == 5
         assert sales[0]["content_id"] == 3
         assert sales[1]["content_id"] == 2
@@ -157,12 +159,18 @@ def test_get_purchases(app):
         assert not any(purchase["content_id"] == 5 for purchase in sales)
         assert all(purchase["seller_user_id"] == 10 for purchase in sales)
 
-        purchases = get_usdc_purchases({"buyer_user_id": 20})
+        purchases = get_usdc_purchases(
+            {"buyer_user_id": 20, "sort_method": PurchaseSortMethod.date}
+        )
         assert len(purchases) == 3
         assert all(purchase["buyer_user_id"] == 20 for purchase in purchases)
 
         specific_sale = get_usdc_purchases(
-            {"content_ids": 3, "content_type": PurchaseType.track}
+            {
+                "content_ids": 3,
+                "content_type": PurchaseType.track,
+                "sort_method": PurchaseSortMethod.date,
+            }
         )
         assert len(specific_sale) == 2
         assert specific_sale[0]["content_id"] == 3

--- a/discovery-provider/src/api/v1/users.py
+++ b/discovery-provider/src/api/v1/users.py
@@ -2149,7 +2149,7 @@ class FullPurchases(Resource):
             "buyer_user_id": decoded_id,
             "limit": limit,
             "offset": offset,
-            "sort_method": args.get("sort_method", None),
+            "sort_method": args.get("sort_method", PurchaseSortMethod.date),
             "sort_direction": args.get("sort_direction", None),
         }
         purchases = get_usdc_purchases(args)
@@ -2201,7 +2201,7 @@ class FullSales(Resource):
             "seller_user_id": decoded_id,
             "limit": limit,
             "offset": offset,
-            "sort_method": args.get("sort_method", None),
+            "sort_method": args.get("sort_method", PurchaseSortMethod.date),
             "sort_direction": args.get("sort_direction", None),
         }
         purchases = get_usdc_purchases(args)

--- a/discovery-provider/src/queries/query_helpers.py
+++ b/discovery-provider/src/queries/query_helpers.py
@@ -129,6 +129,7 @@ class SortMethod(str, enum.Enum):
 class PurchaseSortMethod(str, enum.Enum):
     content_title = "content_title"
     artist_name = "artist_name"
+    buyer_name = "buyer_name"
     date = "date"
 
 

--- a/libs/src/sdk/api/generated/full/apis/UsersApi.ts
+++ b/libs/src/sdk/api/generated/full/apis/UsersApi.ts
@@ -2122,6 +2122,7 @@ export type GetFavoritesSortDirectionEnum = typeof GetFavoritesSortDirectionEnum
 export const GetPurchasesSortMethodEnum = {
     ContentTitle: 'content_title',
     ArtistName: 'artist_name',
+    BuyerName: 'buyer_name',
     Date: 'date'
 } as const;
 export type GetPurchasesSortMethodEnum = typeof GetPurchasesSortMethodEnum[keyof typeof GetPurchasesSortMethodEnum];
@@ -2139,6 +2140,7 @@ export type GetPurchasesSortDirectionEnum = typeof GetPurchasesSortDirectionEnum
 export const GetSalesSortMethodEnum = {
     ContentTitle: 'content_title',
     ArtistName: 'artist_name',
+    BuyerName: 'buyer_name',
     Date: 'date'
 } as const;
 export type GetSalesSortMethodEnum = typeof GetSalesSortMethodEnum[keyof typeof GetSalesSortMethodEnum];


### PR DESCRIPTION
### Description

Adds `buyer_name` as a sort method for the sales table usecase of the purchases endpoint

### How Has This Been Tested?

It hasn't!