### PR TITLE
Purchases API should return encoded ids

### DIFF
--- a/discovery-provider/src/api/v1/helpers.py
+++ b/discovery-provider/src/api/v1/helpers.py
@@ -522,6 +522,14 @@ def extend_transaction_details(transaction_details):
     return new_transaction_details
 
 
+def extend_purchase(purchase):
+    new_purchase = purchase.copy()
+    new_purchase["buyer_user_id"] = encode_int_id(purchase["buyer_user_id"])
+    new_purchase["seller_user_id"] = encode_int_id(purchase["seller_user_id"])
+    new_purchase["content_id"] = encode_int_id(purchase["content_id"])
+    return new_purchase
+
+
 def abort_bad_path_param(param, namespace):
     namespace.abort(400, f"Oh no! Bad path parameter {param}.")
 

--- a/discovery-provider/src/api/v1/users.py
+++ b/discovery-provider/src/api/v1/users.py
@@ -16,6 +16,7 @@ from src.api.v1.helpers import (
     extend_activity,
     extend_challenge_response,
     extend_favorite,
+    extend_purchase,
     extend_supporter,
     extend_supporting,
     extend_track,
@@ -2153,7 +2154,7 @@ class FullPurchases(Resource):
             "sort_direction": args.get("sort_direction", None),
         }
         purchases = get_usdc_purchases(args)
-        return success_response(purchases)
+        return success_response(list(map(extend_purchase, purchases)))
 
 
 @full_ns.route("/<string:id>/purchases/count")
@@ -2205,7 +2206,7 @@ class FullSales(Resource):
             "sort_direction": args.get("sort_direction", None),
         }
         purchases = get_usdc_purchases(args)
-        return success_response(purchases)
+        return success_response(list(map(extend_purchase, purchases)))
 
 
 @full_ns.route("/<string:id>/sales/count")


### PR DESCRIPTION
### Description

Prior to this PR, integer IDs were exposed in the purchase  API

### How Has This Been Tested?

Verified using insomnia. note the types in SDK are unchanged
