### PR TITLE
Fix associated wallets indexing without is_current false

### DIFF
--- a/discovery-provider/src/tasks/entity_manager/entity_manager.py
+++ b/discovery-provider/src/tasks/entity_manager/entity_manager.py
@@ -666,10 +666,10 @@ def fetch_existing_entities(session: Session, entities_to_fetch: EntitiesToFetch
             .all()
         )
         existing_entities[EntityType.ASSOCIATED_WALLET] = {
-            (wallet.user_id, wallet.chain): wallet for wallet, _ in associated_wallets
+            wallet.wallet: wallet for wallet, _ in associated_wallets
         }
         existing_entities_in_json[EntityType.ASSOCIATED_WALLET] = {
-            (wallet_json["user_id"], wallet_json["chain"]): wallet_json
+            (wallet_json["wallet"]): wallet_json
             for _, wallet_json in associated_wallets
         }
 


### PR DESCRIPTION
### Description
Associated wallets indexing is impacted by the migration to index without historical records. This table breaks our typical pattern where 1 transaction -> 1 row because in this case 1 user update can trigger multiple rows per wallet. The bug lies in assuming 1 wallet per user ID and chain and updating is_current false. Now, we just need to fetch every wallet relevant to the user and update associated wallets table to reflect the metadata exactly. This isn't optimal performance wise but it's a quick solution to get it working. Stems / Remixes operate in a similar way.

### How Has This Been Tested?
Tested on a prod sandbox confirmed updating multiple wallets across chains works. Will do more testing before merging.

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._
