### PR TITLE
Sp prune ops

### DIFF
--- a/mediorum/crudr/crudr.go
+++ b/mediorum/crudr/crudr.go
@@ -93,6 +93,13 @@ func (c *Crudr) StartClients() {
 	}
 }
 
+// used for testing
+func (c *Crudr) ForceSweep() {
+	for _, p := range c.peerClients {
+		p.doSweep()
+	}
+}
+
 // RegisterModels accepts a instance of a GORM model and registers it
 // to work with Op apply.
 func (c *Crudr) RegisterModels(tables ...interface{}) *Crudr {
@@ -259,7 +266,7 @@ func (c *Crudr) ApplyOp(op *Op) error {
 	}
 
 	// broadcast if this host is origin...
-	if op.Host == c.host {
+	if op.Host == c.host && !op.SkipBroadcast {
 		msg, _ := json.Marshal(op)
 		c.broadcast(msg)
 	}

--- a/mediorum/crudr/op.go
+++ b/mediorum/crudr/op.go
@@ -12,7 +12,8 @@ type Op struct {
 	Table  string          `json:"table"`
 	Data   json.RawMessage `json:"data"`
 
-	Transient bool `json:"transient" gorm:"-"`
+	Transient     bool `json:"transient" gorm:"-"`
+	SkipBroadcast bool `json:"-" gorm:"-"`
 }
 
 type withOption = func(op *Op)
@@ -20,6 +21,12 @@ type withOption = func(op *Op)
 func WithTransient() withOption {
 	return func(op *Op) {
 		op.Transient = true
+	}
+}
+
+func WithSkipBroadcast() withOption {
+	return func(op *Op) {
+		op.SkipBroadcast = true
 	}
 }
 

--- a/mediorum/server/db.go
+++ b/mediorum/server/db.go
@@ -6,6 +6,7 @@ import (
 	"mediorum/ddl"
 	"time"
 
+	"github.com/oklog/ulid/v2"
 	"gocloud.dev/blob"
 	"golang.org/x/exp/slog"
 	"gorm.io/driver/postgres"
@@ -80,4 +81,26 @@ func dbMigrate(crud *crudr.Crudr, bucket *blob.Bucket) {
 
 	slog.Info("db: migrate done")
 
+}
+
+// delete blobs ops from other hosts that are > one week old
+func dbPruneOldOps(db *gorm.DB, myHost string) {
+
+	tooOld, err := ulid.New(uint64(time.Now().AddDate(0, 0, -7).UnixMilli()), nil)
+	if err != nil {
+		panic(err)
+	}
+
+	res := db.Exec(`
+		delete from ops
+		where "table" = 'blobs'
+		and "host" <> $1
+		and "ulid" < $2
+	`, myHost, tooOld.String())
+
+	if res.Error != nil {
+		slog.Error("dbPruneOldOps failed", "err", res.Error)
+	} else {
+		slog.Info("dbPruneOldOps OK", "row_count", res.RowsAffected)
+	}
 }

--- a/mediorum/server/replicate.go
+++ b/mediorum/server/replicate.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"mediorum/cidutil"
+	"mediorum/crudr"
 	"mediorum/server/signature"
 	"mime/multipart"
 	"net/http"
@@ -75,7 +76,7 @@ func (ss *MediorumServer) replicateToMyBucket(fileName string, file io.Reader) e
 			Host:      ss.Config.Self.Host,
 			Key:       fileName,
 			CreatedAt: time.Now().UTC(),
-		})
+		}, crudr.WithSkipBroadcast())
 	}
 
 	return nil
@@ -97,7 +98,7 @@ func (ss *MediorumServer) dropFromMyBucket(fileName string) error {
 	found := ss.crud.DB.Where("host = ? AND key = ?", ss.Config.Self.Host, fileName).First(&existingBlob)
 	if found.Error == nil {
 		logger.Info("deleting blob record")
-		return ss.crud.Delete(existingBlob)
+		return ss.crud.Delete(existingBlob, crudr.WithSkipBroadcast())
 	}
 
 	return nil

--- a/mediorum/server/server.go
+++ b/mediorum/server/server.go
@@ -208,6 +208,7 @@ func New(config MediorumConfig) (*MediorumServer, error) {
 	}
 	crud := crudr.New(config.Self.Host, config.privateKey, peerHosts, db)
 	dbMigrate(crud, bucket)
+	dbPruneOldOps(db, config.Self.Host)
 
 	// Read trusted notifier endpoint from chain
 	var trustedNotifier ethcontracts.NotifierInfo


### PR DESCRIPTION
### Description

As part of moving from `blobs` table to a simpler `cids` listing, this PR makes blobs ops cheaper by:

* adds `SkipBroadcast` option to crudr, and uses it for create / delete ops on `blobs` table.  (sweep will pick these up on 30s interval)
* adds code to prune `blobs` ops > 7 days old on boot.

### How Has This Been Tested?

updated tests to poll peer servers instead of inspecting blobs table.