### PR TITLE
Fix tastemaker mobile deep linking from push notif

### DIFF
--- a/discovery-provider/plugins/notifications/src/__tests__/mappings/tastemaker.test.ts
+++ b/discovery-provider/plugins/notifications/src/__tests__/mappings/tastemaker.test.ts
@@ -80,7 +80,13 @@ describe('Tastemaker Notification', () => {
       {
         title: `You're a Tastemaker!`,
         body: `track_title_3 is now trending thanks to you! Great work 🙌🏽`,
-        data: {}
+        data: {
+          id: 'timestamp:1589373217:group_id:tastemaker_user_id:10:tastemaker_item_id:3',
+          type: 'FavoriteOfRepost',
+          userIds: [10],
+          entityType: 'Track',
+          entityId: 3
+        }
       }
     )
   })

--- a/discovery-provider/plugins/notifications/src/__tests__/mappings/tastemaker.test.ts
+++ b/discovery-provider/plugins/notifications/src/__tests__/mappings/tastemaker.test.ts
@@ -82,7 +82,7 @@ describe('Tastemaker Notification', () => {
         body: `track_title_3 is now trending thanks to you! Great work 🙌🏽`,
         data: {
           id: 'timestamp:1589373217:group_id:tastemaker_user_id:10:tastemaker_item_id:3',
-          type: 'FavoriteOfRepost',
+          type: 'Tastemaker',
           userIds: [10],
           entityType: 'Track',
           entityId: 3

--- a/discovery-provider/plugins/notifications/src/processNotifications/mappers/tastemaker.ts
+++ b/discovery-provider/plugins/notifications/src/processNotifications/mappers/tastemaker.ts
@@ -15,6 +15,7 @@ import {
 import { sendBrowserNotification } from '../../web'
 import { sendNotificationEmail } from '../../email/notifications/sendEmail'
 import { disableDeviceArns } from '../../utils/disableArnEndpoint'
+import { capitalize } from 'lodash'
 
 type TastemakerNotificationRow = Omit<NotificationRow, 'data'> & {
   data: TastemakerNotification
@@ -91,7 +92,8 @@ export class Tastemaker extends BaseNotification<TastemakerNotificationRow> {
       .first()
 
     const entityName = track.title
-
+    const entityId = track.track_id
+    const entityType = 'track'
     const devices: Device[] = userNotificationSettings.getDevices(
       this.receiverUserId
     )
@@ -112,7 +114,6 @@ export class Tastemaker extends BaseNotification<TastemakerNotificationRow> {
         receiverUserId: this.receiverUserId
       })
     ) {
-      // If the user's settings for the reposts notification is set to true, proceed
       const pushes = await Promise.all(
         devices.map((device) => {
           return sendPushNotification(
@@ -125,7 +126,15 @@ export class Tastemaker extends BaseNotification<TastemakerNotificationRow> {
             {
               title,
               body,
-              data: {}
+              data: {
+                id: `timestamp:${this.getNotificationTimestamp()}:group_id:${
+                  this.notification.group_id
+                }`,
+                userIds: [this.receiverUserId],
+                type: 'Tastemaker',
+                entityId,
+                entityType: capitalize(entityType)
+              }
             }
           )
         })


### PR DESCRIPTION
### Description
we weren't sending any data to the client for mobile deep linking to know where to navigate on opening apush notif, adding that data here. matches fav of repost data which also uses the same handler in use notif navigation on the client side
### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._
