### PR TITLE
Format time duration string in log

### DIFF
--- a/mediorum/ddl/ddl.go
+++ b/mediorum/ddl/ddl.go
@@ -98,7 +98,7 @@ func schedulePartitionOpsMigration(db *sql.DB, myHost string) {
 	if partitioned {
 		slog.Info("already partitioned ops, skipping migration scheduling")
 	} else {
-		slog.Info("scheduling partition ops migration", "time", randomTime)
+		slog.Info("scheduling partition ops migration", "time", randomTime.String())
 		time.AfterFunc(randomTime, func() {
 			slog.Info("marking migrations table to partition ops after we restart...")
 			mustExec(db, `insert into mediorum_migrations values ($1, now()) on conflict do nothing`, partitionOpsScheduled)


### PR DESCRIPTION
### Description
is currently printing in nanoseconds which is kind of annoying

### How Has This Been Tested?
audius-compose up locally, check logs
`{"time":"2023-08-30T19:27:05.31085984Z","level":"INFO","source":{"function":"mediorum/ddl.schedulePartitionOpsMigration","file":"/app/ddl/ddl.go","line":101},"msg":"scheduling partition ops migration","time":"1h50m0s"}`