### PR TITLE
Explicitly lock tables before migration

### DIFF
--- a/discovery-provider/ddl/migrations/0021_fix_album_repost_save.sql
+++ b/discovery-provider/ddl/migrations/0021_fix_album_repost_save.sql
@@ -6,6 +6,9 @@ begin;
 -- terminate all active queries to avoid
 SELECT pg_cancel_backend(pid) FROM pg_stat_activity WHERE state = 'active' and pid <> pg_backend_pid();
 
+LOCK TABLE reposts IN ACCESS EXCLUSIVE MODE;
+LOCK TABLE saves IN ACCESS EXCLUSIVE MODE;
+
 CREATE OR REPLACE FUNCTION log_message(message_text text)
 RETURNS void AS
 $$


### PR DESCRIPTION
### Description
Killing active queries at the beginning of the transaction didn't completely prevent deadlocks. Server read requests could still block this migration. It seems like postgres will acquire migrations as it goes through the transaction. Explicitly acquiring locks at the beginning will make sure it has priority before another request can acquire a read lock.

### How Has This Been Tested?

I ran this on prod DN3 but added a bogus statement at the end to make sure the transaction rolled back. This did not deadlock.
_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._
