### PR TITLE
Fix eth indexing log_index check

### DIFF
--- a/discovery-provider/src/eth_indexing/event_scanner.py
+++ b/discovery-provider/src/eth_indexing/event_scanner.py
@@ -148,7 +148,7 @@ class EventScanner:
         # and each one of those gets their own log index
 
         log_index = event["logIndex"]  # Log index within the block
-        if not log_index:
+        if log_index is None:
             raise Exception(f"logIndex not found on event {log_index}")
         txhash = event["transactionHash"]  # Transaction hash
         if not txhash:


### PR DESCRIPTION
### Description
index_eth is stuck right now. i only happened to notice and investigate but we need better monitoring around celery errors. i'm not sure the scope of the impact this has. i don't think we even need checks here because the EventData should enforce int but this will fix it.

log_index is 0 so it evaluates to false.

```
raised unexpected: Exception('logIndex not found on event 0')
```

### How Has This Been Tested?
tested on sandbox.

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._
