### PR TITLE
delay cn2 migration

### DIFF
--- a/mediorum/ddl/ddl.go
+++ b/mediorum/ddl/ddl.go
@@ -87,11 +87,14 @@ func schedulePartitionOpsMigration(db *sql.DB, myHost string) {
 	randomTime := time.Minute * time.Duration(rand.Intn(max+1-min)+min)
 	// manually schedule foundation nodes so can disable monitoring
 	// appropriately
-	if myHost == "https://creatornode.audius.co" || myHost == "https://creatornode2.audius.co" {
+	if myHost == "https://creatornode.audius.co" {
 		randomTime = time.Minute * time.Duration(20)
 	}
 	if myHost == "https://creatornode3.audius.co" || myHost == "https://usermetadata.audius.co" {
 		randomTime = time.Minute * time.Duration(110)
+	}
+	if myHost == "https://creatornode2.audius.co" {
+		randomTime = time.Minute * time.Duration(240)
 	}
 	slog.Info("checking if we need to schedule the partition ops migration...")
 	var partitioned bool


### PR DESCRIPTION
### Description
cn3 is migrating ops right now and taking longer than expected and we want either cn2 and cn3 to be up at all times, since they store a lot of legacy data. delay cn2's migration time to 4 hours after startup to give cn3 more leeway. right now cn2 tries to migrate 20 minutes after startup, so i have to keep deleting the scheduled migration every 20 minutes until cn3 finishes.

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._
