### PR TITLE
increase timeframe for SP op partition migration

### DIFF
--- a/mediorum/ddl/ddl.go
+++ b/mediorum/ddl/ddl.go
@@ -81,20 +81,17 @@ func md5string(s string) string {
 }
 
 func schedulePartitionOpsMigration(db *sql.DB, myHost string) {
-	// stagger between 0.5-12hrs
-	min := 30
-	max := 60 * 12
-	randomTime := time.Minute * time.Duration(rand.Intn(max+1-min)+min)
+	// stagger between 0 - 4 days
+	min := 0
+	max := 24 * 4
+	randomTime := time.Hour * time.Duration(rand.Intn(max+1-min)+min)
 	// manually schedule foundation nodes so can disable monitoring
 	// appropriately
-	if myHost == "https://creatornode.audius.co" {
-		randomTime = time.Minute * time.Duration(20)
-	}
-	if myHost == "https://creatornode3.audius.co" || myHost == "https://usermetadata.audius.co" {
-		randomTime = time.Minute * time.Duration(110)
+	if myHost == "https://usermetadata.audius.co" {
+		randomTime = time.Minute * time.Duration(0)
 	}
 	if myHost == "https://creatornode2.audius.co" {
-		randomTime = time.Minute * time.Duration(240)
+		randomTime = time.Hour * time.Duration(24)
 	}
 	slog.Info("checking if we need to schedule the partition ops migration...")
 	var partitioned bool


### PR DESCRIPTION
### Description
increase timeframe in which SPs run their migrations to 4 days. 
also make cn2 migrate 24 hours after startup since cn3 seems only 25% done after almost 6 hours. can always start it manually earlier.

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._
