### PR TITLE
[CON-846] Ensure mediorum fallbacks and request racing

### DIFF
--- a/libs/src/sdk/services/Storage/Storage.ts
+++ b/libs/src/sdk/services/Storage/Storage.ts
@@ -1,5 +1,5 @@
 import FormData from 'form-data'
-import axios from 'axios'
+import axios, { AxiosRequestConfig, AxiosResponse } from 'axios'
 
 import fetch from 'cross-fetch'
 import { wait } from '../../utils/wait'
@@ -121,17 +121,11 @@ export class Storage implements StorageService {
       file.name ?? 'blob'
     )
 
-    const contentNodeEndpoint = await this.storageNodeSelector.getSelectedNode()
-
-    if (!contentNodeEndpoint) {
-      throw new Error('No content node available for upload')
-    }
-
     // Using axios for now because it supports upload progress,
     // and Node doesn't support XmlHttpRequest
-    const response = await axios({
+    let response: AxiosResponse<any> | null = null
+    const request: AxiosRequestConfig = {
       method: 'post',
-      url: `${contentNodeEndpoint}/uploads`,
       maxContentLength: Infinity,
       data: formData,
       headers: formData.getBoundary
@@ -141,7 +135,23 @@ export class Storage implements StorageService {
         : undefined,
       onUploadProgress: (progressEvent) =>
         onProgress?.(progressEvent.loaded, progressEvent.total)
-    })
+    }
+
+    let lastErr
+    for (let selectedNode = await this.storageNodeSelector.getSelectedNode(); this.storageNodeSelector.triedSelectingAllNodes(); selectedNode = await this.storageNodeSelector.getSelectedNode(true)) {
+      request.url = `${selectedNode!}/uploads`
+      try {
+        response = await axios(request)
+      } catch (e: any) {
+        lastErr = e // keep trying other nodes
+      }
+    }
+
+    if (!response) {
+      const msg = `Error sending storagev2 upload request, tried all healthy storage nodes. Last error: ${lastErr}`
+      this.logger.error(msg)
+      throw new Error(msg)
+    }
 
     return await this.pollProcessingStatus(
       response.data[0].id,
@@ -198,8 +208,22 @@ export class Storage implements StorageService {
    * @returns the status, and the success or failed response if the job is complete
    */
   private async getProcessingStatus(id: string): Promise<UploadResponse> {
-    const contentNodeEndpoint = await this.storageNodeSelector.getSelectedNode()
-    const response = await fetch(`${contentNodeEndpoint}/uploads/${id}`)
-    return await response.json()
+    let lastErr
+    for (let selectedNode = await this.storageNodeSelector.getSelectedNode(); this.storageNodeSelector.triedSelectingAllNodes(); selectedNode = await this.storageNodeSelector.getSelectedNode(true)) {
+      try {
+        const response = await fetch(`${selectedNode}/uploads/${id}`)
+        if (response.ok) {
+          return await response.json()
+        } else {
+          lastErr = `HTTP error: ${response.status} ${response.statusText}, ${await response.text()}`
+        }
+      } catch (e: any) {
+        lastErr = e
+      }
+    }
+
+    const msg = `Error sending storagev2 uploads polling request, tried all healthy storage nodes. Last error: ${lastErr}`
+    this.logger.error(msg)
+    throw new Error(msg)
   }
 }

--- a/libs/src/sdk/services/StorageNodeSelector/StorageNodeSelector.ts
+++ b/libs/src/sdk/services/StorageNodeSelector/StorageNodeSelector.ts
@@ -23,6 +23,7 @@ export class StorageNodeSelector implements StorageNodeSelectorService {
   private orderedNodes?: string[] // endpoints (lowercase)
   private selectedNode?: string | null
   private selectedDiscoveryNode?: string | null
+  private selectionState: 'healthy_only' | 'failed_all'
   private readonly discoveryNodeSelector?: DiscoveryNodeSelectorService
   private readonly initialDiscoveryFetchPromise: Promise<void>
   private resolveInitialDiscoveryFetchPromise: () => void = () => {}
@@ -39,6 +40,7 @@ export class StorageNodeSelector implements StorageNodeSelectorService {
       '[storage-node-selector]'
     )
     this.nodes = this.config.bootstrapNodes ?? []
+    this.selectionState = 'healthy_only'
 
     this.discoveryNodeSelector?.addEventListener(
       'change',
@@ -83,11 +85,12 @@ export class StorageNodeSelector implements StorageNodeSelectorService {
     }
 
     this.nodes = contentNodes
+    this.selectionState = 'healthy_only'
     this.resolveInitialDiscoveryFetchPromise()
   }
 
-  public async getSelectedNode() {
-    if (this.selectedNode) {
+  public async getSelectedNode(forceReselect = false) {
+    if (this.selectedNode && !forceReselect) {
       return this.selectedNode
     }
 
@@ -108,19 +111,42 @@ export class StorageNodeSelector implements StorageNodeSelectorService {
     return await this.select()
   }
 
+  public triedSelectingAllNodes() {
+    return this.selectionState === 'failed_all'
+  }
+
   public getNodes(cid: string) {
     return this.orderNodes(cid)
   }
 
-  private async select() {
-    if (!this.orderedNodes) {
-      this.orderedNodes = await this.orderNodes(
+  private async select(): Promise<string | null> {
+    // We've selected all healthy nodes. Restart from the beginning of the ordered list
+    if (this.selectionState === 'failed_all') {
+      this.selectionState = 'healthy_only'
+    }
+
+    // Select the next node in rendezvous order from the list of all nodes
+    this.selectedNode = await this.selectUntilEndOfList() ?? null
+    this.logger.info('Selected content node', this.selectedNode)
+
+    if (!this.selectedNode) {
+      // We've selected all healthy nodes. Return null and start over next time select() is called
+      this.logger.info('Selected all healthy nodes. Returning null and starting over next time select() is called')
+      this.selectionState = 'failed_all'
+    }
+
+    return this.selectedNode
+  }
+
+  private async selectUntilEndOfList(): Promise<Maybe<string>> {
+    if (!this.orderedNodes?.length) {
+      this.orderedNodes = this.orderNodes(
         (await this.auth.getAddress()).toLowerCase()
       )
     }
 
     if (this.orderedNodes.length === 0) {
-      return null
+      return undefined
     }
 
     const currentNodeIndex = this.selectedNode
@@ -130,19 +156,17 @@ export class StorageNodeSelector implements StorageNodeSelectorService {
     let selectedNode: Maybe<string>
     let nextNodeIndex = currentNodeIndex
 
-    while (!selectedNode) {
-      nextNodeIndex = (nextNodeIndex + 1) % this.orderedNodes.length
-      if (nextNodeIndex === currentNodeIndex) break
+    while (nextNodeIndex !== this.orderedNodes.length - 1) {
+      nextNodeIndex++
       const nextNode = this.orderedNodes[nextNodeIndex]
-      if (!nextNode) continue
+      if (!nextNode) continue // should never happen unless this.orderedNodes has falsy values
       if (await isNodeHealthy(nextNode)) {
         selectedNode = nextNode
+        break
       }
     }
 
-    this.selectedNode = selectedNode
-    this.logger.info('Selected content node', this.selectedNode)
-    return this.selectedNode ?? null
+    return selectedNode
   }
 
   private orderNodes(key: string) {

--- a/libs/src/sdk/services/StorageNodeSelector/types.ts
+++ b/libs/src/sdk/services/StorageNodeSelector/types.ts
@@ -3,8 +3,9 @@ import type { DiscoveryNodeSelectorService } from '../DiscoveryNodeSelector'
 import type { LoggerService } from '../Logger'
 
 export type StorageNodeSelectorService = {
-  getSelectedNode: () => Promise<string | null>
+  getSelectedNode: (forceReselect?: boolean) => Promise<string | null>
   getNodes: (cid: string) => string[]
+  triedSelectingAllNodes: () => boolean
 }
 
 export type StorageNode = {

--- a/mediorum/server/serve_blob.go
+++ b/mediorum/server/serve_blob.go
@@ -235,7 +235,7 @@ func (ss *MediorumServer) findNodeToServeBlob(key string) (string, error) {
 
 func (ss *MediorumServer) logTrackListen(c echo.Context) {
 
-	skipPlayCount := strings.ToLower(c.QueryParam("skip_play_count")) == "true"
+	skipPlayCount, _ := strconv.ParseBool(c.QueryParam("skip_play_count"))
 
 	if skipPlayCount ||
 		os.Getenv("identityService") == "" ||

--- a/mediorum/server/serve_blob.go
+++ b/mediorum/server/serve_blob.go
@@ -166,7 +166,8 @@ func (ss *MediorumServer) getBlob(c echo.Context) error {
 		return nil
 	}
 
-	if strings.ToLower(c.QueryParam("localOnly")) == "true" {
+	// don't redirect if the client only wants to know if we have it (ie localOnly query param is true)
+	if localOnly, _ := strconv.ParseBool(c.QueryParam("localOnly")); localOnly {
 		return c.String(404, "blob not found")
 	}
 

--- a/mediorum/server/serve_upload.go
+++ b/mediorum/server/serve_upload.go
@@ -8,6 +8,7 @@ import (
 	"mediorum/cidutil"
 	"mime"
 	"net/http"
+	"net/url"
 	"strconv"
 	"strings"
 	"sync"
@@ -15,6 +16,8 @@ import (
 
 	"github.com/labstack/echo/v4"
 	"github.com/oklog/ulid/v2"
+	"golang.org/x/exp/slices"
+	"golang.org/x/sync/errgroup"
 )
 
 var (
@@ -395,18 +398,26 @@ func (ss *MediorumServer) getBlobByJobIDAndVariant(c echo.Context) error {
 
 				// since cultur3stake nodes can't talk to each other
 				// they might not get Upload crudr updates from each other
-				// so if one cultur3stake does transocde... sibiling might not get the updates
+				// so if one cultur3stake does transcode... sibiling might not get the updates
 				// so if this Upload doesn't have this variant... see if we can find a 200 from a different node
 				// TODO: crudr should gossip
-				if c.QueryParam("localOnly") != "true" {
+				if localOnly, _ := strconv.ParseBool(c.QueryParam("localOnly")); !localOnly {
 					healthyHosts := ss.findHealthyPeers(2 * time.Minute)
-					for _, host := range healthyHosts {
-						if host == ss.Config.Self.Host {
-							continue
+					dest := ss.raceIsUrl2xx(*c.Request().URL, healthyHosts)
+					if dest != "" {
+						return c.Redirect(302, dest)
+					}
+
+					// try redirecting to unhealthy host as a last resort
+					unhealthyHosts := []string{}
+					for _, peer := range ss.Config.Peers {
+						if peer.Host != ss.Config.Self.Host && !slices.Contains(healthyHosts, peer.Host) {
+							unhealthyHosts = append(unhealthyHosts, peer.Host)
 						}
-						if dest, is200 := ss.diskCheckUrl(*c.Request().URL, host); is200 {
-							return c.Redirect(302, dest)
-						}
+					}
+					dest = ss.raceIsUrl2xx(*c.Request().URL, unhealthyHosts)
+					if dest != "" {
+						return c.Redirect(302, dest)
 					}
 				}
 
@@ -423,4 +434,85 @@ func (ss *MediorumServer) getBlobByJobIDAndVariant(c echo.Context) error {
 		c.SetParamValues(cid)
 		return ss.getBlob(c)
 	}
+}
+
+// raceIsUrl200 tries batches of 5 hosts concurrently to find the first healthy host that returns a 200 instead of sequentially waiting for a 2s timeout from each host.
+func (ss *MediorumServer) raceIsUrl2xx(url url.URL, hostsToRace []string) string {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	g, _ := errgroup.WithContext(ctx)
+	g.SetLimit(5)
+	destWith2xx := make(chan string, 1)
+
+	for _, host := range hostsToRace {
+		if host == ss.Config.Self.Host {
+			continue
+		}
+		h := host
+		g.Go(func() error {
+			if dest, is2xx := ss.isUrl2xx(url, h); is2xx {
+				// write to channel and cancel context to stop other goroutines, or stop if context was already canceled
+				select {
+				case destWith2xx <- dest:
+					cancel()
+				case <-ctx.Done():
+				}
+			}
+			return nil
+		})
+	}
+
+	go func() {
+		g.Wait()
+		close(destWith2xx)
+	}()
+
+	dest, ok := <-destWith2xx
+	if ok {
+		return dest
+	}
+	return ""
+}
+
+// isUrl200 checks if dest returns 2xx for hostString when not following redirects.
+func (ss *MediorumServer) isUrl2xx(dest url.URL, hostString string) (string, bool) {
+	noRedirectClient := &http.Client{
+		// without this option, we'll incorrectly think Node A has it when really Node A was telling us to redirect to Node B
+		CheckRedirect: func(req *http.Request, via []*http.Request) error {
+			return http.ErrUseLastResponse
+		},
+		Timeout: 2 * time.Second,
+	}
+
+	logger := ss.logger.With("redirect", "url", dest.String(), "host", hostString)
+
+	hostUrl, err := url.Parse(hostString)
+	if err != nil {
+		return "", false
+	}
+
+	dest.Host = hostUrl.Host
+	dest.Scheme = hostUrl.Scheme
+	query := dest.Query()
+	query.Add("localOnly", "true")
+	dest.RawQuery = query.Encode()
+
+	req, err := http.NewRequest("GET", dest.String(), nil)
+	if err != nil {
+		logger.Error("invalid url", "err", err)
+		return "", false
+	}
+	req.Header.Set("User-Agent", "mediorum "+ss.Config.Self.Host)
+
+	resp, err := noRedirectClient.Do(req)
+	if err != nil {
+		logger.Error("request failed", "err", err)
+		return "", false
+	}
+	resp.Body.Close()
+	if resp.StatusCode == 200 || resp.StatusCode == 204 || resp.StatusCode == 206 {
+		return dest.String(), true
+	}
+
+	return "", false
 }

--- a/mediorum/server/server.go
+++ b/mediorum/server/server.go
@@ -285,6 +285,7 @@ func New(config MediorumConfig) (*MediorumServer, error) {
 	routes.GET("/tracks/cidstream/:cid", ss.getBlob, ss.requireHealthy, ss.ensureNotDelisted, ss.requireRegisteredSignature)
 	routes.GET("/contact", ss.serveContact)
 	routes.GET("/health_check", ss.serveHealthCheck)
+	routes.HEAD("/health_check", ss.serveHealthCheck)
 	routes.GET("/ip_check", func(c echo.Context) error {
 		return c.JSON(http.StatusOK, map[string]string{
 			"data": c.RealIP(), // client/requestor IP


### PR DESCRIPTION
### Description
For reads, ensure we try all nodes in rendezvous order with reasonable concurrency.
For writes, ensure we always have fallbacks.

- Discovery track streaming: try all nodes (including unhealthy) in rendezvous order, 5 at a time, with 2s timeout each
- Libs and SDK uploads: always do fallbacks, using reselection to re-use the same healthy node for future requests. Note that the list of nodes comes from Discovery health checks, so they're already filtered to healthy nodes.
- Mediorum legacy disk check: replace its usage in v2 image route with racing instead of sequential fallbacks, so we can remove the disk check function separately and easily when we're ready to fully remove legacy support


### How Has This Been Tested?
TODO: so much testing