### PR TITLE
customized request logging relay

### DIFF
--- a/discovery-provider/plugins/pedalboard/apps/relay/src/logger.ts
+++ b/discovery-provider/plugins/pedalboard/apps/relay/src/logger.ts
@@ -1,3 +1,4 @@
+import { DoneFuncWithErrOrRes, FastifyReply, FastifyRequest } from "fastify";
 import pino, { stdTimeFunctions } from "pino";
 
 // set config for logger here
@@ -6,3 +7,20 @@ export const logger = pino({
   base: undefined,
   timestamp: stdTimeFunctions.isoTime,
 });
+
+export const logRequest = (request: FastifyRequest, reply: FastifyReply, done: DoneFuncWithErrOrRes) => {
+  request.log.info({
+    req: request
+  }, 'incoming request')
+  done()
+}
+
+export const logResponse = (request: FastifyRequest, reply: FastifyReply, done: DoneFuncWithErrOrRes) => {
+  const responseTime = reply.getResponseTime()
+  reply.log.info({
+    res: reply,
+    req: request,
+    responseTime
+  }, 'request completed')
+  done()
+}


### PR DESCRIPTION
### Description
created a custom request logger that uses the same thing as fastify internally, added request object to the reply as well so we can get graphs on the path and status of requests

### How Has This Been Tested?

ran locally
```
{"level":30,"time":1693585175509,"pid":49349,"hostname":"alecs-MacBook-Pro","reqId":"req-4","req":{"method":"GET","url":"/relay/health","hostname":"localhost:6001","remoteAddress":"127.0.0.1","remotePort":55920},"msg":"incoming request"}
{"level":30,"time":1693585175510,"pid":49349,"hostname":"alecs-MacBook-Pro","reqId":"req-4","res":{"statusCode":200},"req":{"method":"GET","url":"/relay/health","hostname":"localhost:6001","remoteAddress":"127.0.0.1","remotePort":55920},"responseTime":1.5115413665771484,"msg":"request completed"}
```
