### PR TITLE
[CON-846] Race discovery track streams v2 image fallbacks

### DIFF
--- a/discovery-provider/src/api/v1/tracks.py
+++ b/discovery-provider/src/api/v1/tracks.py
@@ -1,3 +1,4 @@
+import asyncio
 import json
 import logging
 import re
@@ -5,7 +6,7 @@ import urllib.parse
 from typing import List
 from urllib.parse import urljoin
 
-import requests
+from aiohttp import ClientSession, TCPConnector
 from flask import redirect
 from flask.globals import request
 from flask_restx import Namespace, Resource, fields, inputs, marshal, reqparse
@@ -73,7 +74,7 @@ from src.trending_strategies.trending_strategy_factory import (
 )
 from src.trending_strategies.trending_type_and_version import TrendingType
 from src.utils import redis_connection
-from src.utils.get_all_other_nodes import get_all_healthy_content_nodes_cached
+from src.utils.get_all_other_nodes import get_all_other_content_nodes_cached
 from src.utils.redis_cache import cache
 from src.utils.redis_metrics import record_metrics
 from src.utils.rendezvous import RendezvousHash
@@ -423,20 +424,37 @@ def tranform_stream_cache(stream_url):
     return redirect(stream_url)
 
 
-def get_stream_url_from_content_node(content_node: str, path: str):
+async def try_stream_first_byte(session, content_node, path, queue, timeout_sec):
     stream_url = urljoin(content_node, path)
     headers = {"Range": "bytes=0-1"}
     try:
-        response = requests.get(
-            stream_url + "&skip_play_count=true&localOnly=true",
+        async with session.get(
+            stream_url + "&skip_play_count=True&localOnly=True",
             allow_redirects=False,
             headers=headers,
-            timeout=0.5,
-        )
-        if response.status_code == 206:
-            return stream_url
+            timeout=timeout_sec,
+        ) as response:
+            if response.status == 206:
+                await queue.put((stream_url, content_node))
     except:
         pass
+
+
+# Race content nodes, 5 at a time, to see which one responds first with a 206 for the first byte of a track
+async def get_first_stream_url(content_nodes, path):
+    async with ClientSession(connector=TCPConnector(limit=5)) as session:
+        queue = asyncio.Queue()
+
+        tasks = [
+            try_stream_first_byte(session, node, path, queue, timeout_sec=2)
+            for node in content_nodes
+        ]
+        _, pending = await asyncio.wait(tasks, return_when=asyncio.FIRST_COMPLETED)
+
+        for task in pending:
+            task.cancel()
+
+        return await queue.get() if not queue.empty() else (None, None)
 
 
 @ns.route("/<string:track_id>/stream")
@@ -515,32 +533,35 @@ class TrackStream(Resource):
         cached_content_node = redis.get(redis_key)
         stream_url = None
         if cached_content_node:
-            cached_content_node = cached_content_node.decode("utf-8")
-            stream_url = get_stream_url_from_content_node(cached_content_node, path)
+            stream_url, _ = try_stream_first_byte(
+                ClientSession(),
+                cached_content_node.decode("utf-8"),
+                path,
+                asyncio.Queue(),
+                timeout_sec=2,
+            )
             if stream_url:
                 return stream_url
 
-        healthy_nodes = get_all_healthy_content_nodes_cached(redis)
-        if not healthy_nodes:
+        all_content_nodes = get_all_other_content_nodes_cached(redis)
+        if not all_content_nodes:
             logger.error(
-                f"tracks.py | stream | No healthy Content Nodes found when streaming track ID {track_id}. Please investigate."
+                f"tracks.py | stream | No Content Nodes found when streaming track ID {track_id}. Please investigate."
             )
             abort_not_found(track_id, ns)
 
         rendezvous = RendezvousHash(
-            *[re.sub("/$", "", node["endpoint"].lower()) for node in healthy_nodes]
+            *[re.sub("/$", "", node["endpoint"].lower()) for node in all_content_nodes]
         )
-
-        # change from 5 -> 500 to try all nodes
-        # since Qm CIDs are not migrated to rendezvous location yet
-        # can be made 5 when that is done
-        content_nodes = rendezvous.get_n(500, cid)
-        for content_node in content_nodes:
-            stream_url = get_stream_url_from_content_node(content_node, path)
-            if stream_url:
-                redis.set(redis_key, content_node)
-                redis.expire(redis_key, 120)  # 2 min ttl
-                return stream_url
+        content_nodes = rendezvous.get_n(9999999, cid)
+        loop = asyncio.get_event_loop()
+        stream_url, content_node = loop.run_until_complete(
+            get_first_stream_url(content_nodes, path)
+        )
+        if stream_url:
+            redis.set(redis_key, content_node)
+            redis.expire(redis_key, 600)  # 10 min ttl
+            return stream_url
         abort_not_found(track_id, ns)
 
 

--- a/mediorum/server/serve_blob.go
+++ b/mediorum/server/serve_blob.go
@@ -166,7 +166,8 @@ func (ss *MediorumServer) getBlob(c echo.Context) error {
 		return nil
 	}
 
-	if strings.ToLower(c.QueryParam("localOnly")) == "true" {
+	// don't redirect if the client only wants to know if we have it (ie localOnly query param is true)
+	if localOnly, _ := strconv.ParseBool(c.QueryParam("localOnly")); localOnly {
 		return c.String(404, "blob not found")
 	}
 
@@ -234,7 +235,7 @@ func (ss *MediorumServer) findNodeToServeBlob(key string) (string, error) {
 
 func (ss *MediorumServer) logTrackListen(c echo.Context) {
 
-	skipPlayCount := strings.ToLower(c.QueryParam("skip_play_count")) == "true"
+	skipPlayCount, _ := strconv.ParseBool(c.QueryParam("skip_play_count"))
 
 	if skipPlayCount ||
 		os.Getenv("identityService") == "" ||

--- a/mediorum/server/serve_upload.go
+++ b/mediorum/server/serve_upload.go
@@ -8,6 +8,7 @@ import (
 	"mediorum/cidutil"
 	"mime"
 	"net/http"
+	"net/url"
 	"strconv"
 	"strings"
 	"sync"
@@ -15,6 +16,8 @@ import (
 
 	"github.com/labstack/echo/v4"
 	"github.com/oklog/ulid/v2"
+	"golang.org/x/exp/slices"
+	"golang.org/x/sync/errgroup"
 )
 
 var (
@@ -395,18 +398,26 @@ func (ss *MediorumServer) getBlobByJobIDAndVariant(c echo.Context) error {
 
 				// since cultur3stake nodes can't talk to each other
 				// they might not get Upload crudr updates from each other
-				// so if one cultur3stake does transocde... sibiling might not get the updates
+				// so if one cultur3stake does transcode... sibiling might not get the updates
 				// so if this Upload doesn't have this variant... see if we can find a 200 from a different node
 				// TODO: crudr should gossip
-				if c.QueryParam("localOnly") != "true" {
+				if localOnly, _ := strconv.ParseBool(c.QueryParam("localOnly")); !localOnly {
 					healthyHosts := ss.findHealthyPeers(2 * time.Minute)
-					for _, host := range healthyHosts {
-						if host == ss.Config.Self.Host {
-							continue
+					dest := ss.raceIsUrl2xx(*c.Request().URL, healthyHosts)
+					if dest != "" {
+						return c.Redirect(302, dest)
+					}
+
+					// try redirecting to unhealthy host as a last resort
+					unhealthyHosts := []string{}
+					for _, peer := range ss.Config.Peers {
+						if peer.Host != ss.Config.Self.Host && !slices.Contains(healthyHosts, peer.Host) {
+							unhealthyHosts = append(unhealthyHosts, peer.Host)
 						}
-						if dest, is200 := ss.diskCheckUrl(*c.Request().URL, host); is200 {
-							return c.Redirect(302, dest)
-						}
+					}
+					dest = ss.raceIsUrl2xx(*c.Request().URL, unhealthyHosts)
+					if dest != "" {
+						return c.Redirect(302, dest)
 					}
 				}
 
@@ -423,4 +434,85 @@ func (ss *MediorumServer) getBlobByJobIDAndVariant(c echo.Context) error {
 		c.SetParamValues(cid)
 		return ss.getBlob(c)
 	}
+}
+
+// raceIsUrl200 tries batches of 5 hosts concurrently to find the first healthy host that returns a 200 instead of sequentially waiting for a 2s timeout from each host.
+func (ss *MediorumServer) raceIsUrl2xx(url url.URL, hostsToRace []string) string {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	g, _ := errgroup.WithContext(ctx)
+	g.SetLimit(5)
+	destWith2xx := make(chan string, 1)
+
+	for _, host := range hostsToRace {
+		if host == ss.Config.Self.Host {
+			continue
+		}
+		h := host
+		g.Go(func() error {
+			if dest, is2xx := ss.isUrl2xx(url, h); is2xx {
+				// write to channel and cancel context to stop other goroutines, or stop if context was already canceled
+				select {
+				case destWith2xx <- dest:
+					cancel()
+				case <-ctx.Done():
+				}
+			}
+			return nil
+		})
+	}
+
+	go func() {
+		g.Wait()
+		close(destWith2xx)
+	}()
+
+	dest, ok := <-destWith2xx
+	if ok {
+		return dest
+	}
+	return ""
+}
+
+// isUrl200 checks if dest returns 2xx for hostString when not following redirects.
+func (ss *MediorumServer) isUrl2xx(dest url.URL, hostString string) (string, bool) {
+	noRedirectClient := &http.Client{
+		// without this option, we'll incorrectly think Node A has it when really Node A was telling us to redirect to Node B
+		CheckRedirect: func(req *http.Request, via []*http.Request) error {
+			return http.ErrUseLastResponse
+		},
+		Timeout: 2 * time.Second,
+	}
+
+	logger := ss.logger.With("redirect", "url", dest.String(), "host", hostString)
+
+	hostUrl, err := url.Parse(hostString)
+	if err != nil {
+		return "", false
+	}
+
+	dest.Host = hostUrl.Host
+	dest.Scheme = hostUrl.Scheme
+	query := dest.Query()
+	query.Add("localOnly", "true")
+	dest.RawQuery = query.Encode()
+
+	req, err := http.NewRequest("GET", dest.String(), nil)
+	if err != nil {
+		logger.Error("invalid url", "err", err)
+		return "", false
+	}
+	req.Header.Set("User-Agent", "mediorum "+ss.Config.Self.Host)
+
+	resp, err := noRedirectClient.Do(req)
+	if err != nil {
+		logger.Error("request failed", "err", err)
+		return "", false
+	}
+	resp.Body.Close()
+	if resp.StatusCode == 200 || resp.StatusCode == 204 || resp.StatusCode == 206 {
+		return dest.String(), true
+	}
+
+	return "", false
 }

--- a/mediorum/server/server.go
+++ b/mediorum/server/server.go
@@ -285,6 +285,7 @@ func New(config MediorumConfig) (*MediorumServer, error) {
 	routes.GET("/tracks/cidstream/:cid", ss.getBlob, ss.requireHealthy, ss.ensureNotDelisted, ss.requireRegisteredSignature)
 	routes.GET("/contact", ss.serveContact)
 	routes.GET("/health_check", ss.serveHealthCheck)
+	routes.HEAD("/health_check", ss.serveHealthCheck)
 	routes.GET("/ip_check", func(c echo.Context) error {
 		return c.JSON(http.StatusOK, map[string]string{
 			"data": c.RealIP(), // client/requestor IP


### PR DESCRIPTION
### Description
- Discovery track streaming: try all nodes (including unhealthy) in rendezvous order, 5 at a time, with 2s timeout each. Cache for 10 minutes (up from 2 minutes)
- Mediorum legacy disk check: replace its usage in v2 image route with racing instead of sequential fallbacks, so we can remove the disk check function separately and easily when we're ready to fully remove legacy support

### How Has This Been Tested?
1. Deployed to stage cn9 and stage dn2. On staging client, press "d" and set it to stage dn2
2. Go to a profile and scroll back a bit to find some Qm tracks. They all seem to 302 pretty quickly, even if some of the 206s take a bit longer for whatever reason
