### PR TITLE
Relay: update sdk version

### DIFF
--- a/discovery-provider/plugins/pedalboard/apps/relay/package.json
+++ b/discovery-provider/plugins/pedalboard/apps/relay/package.json
@@ -16,7 +16,7 @@
     "preset": "jest-presets/jest/node"
   },
   "dependencies": {
-    "@audius/sdk": "^3.0.3-beta.95",
+    "@audius/sdk": "^3.0.8-beta.4",
     "@fastify/type-provider-typebox": "^3.2.0",
     "@sinclair/typebox": "^0.29.4",
     "@types/compute-lcm": "^1.1.0",


### PR DESCRIPTION
### Description
updating SDK, this mainly removes those pesky health checks that aren't relevant on stage

### How Has This Been Tested?
ran locally and logs cleared up

```
npm run dev

> relay@0.1.0 dev
> ts-node-dev --respawn ./src/index.ts

[INFO] 11:16:47 ts-node-dev ver. 2.0.0 (using ts-node ver. 10.9.1, typescript ver. 4.9.5)
{"level":30,"time":"2023-09-01T17:16:49.958Z","name":"relay","msg":"running on dev network"}
{"level":40,"time":"2023-09-01T17:16:49.959Z","name":"relay","msg":"anti abuse not configured and won't be enforced"}
{"level":30,"time":"2023-09-01T17:16:51.225Z","name":"relay","msg":"regenerated all signing wallets"}
processes 5
{"level":30,"time":1693588611255,"pid":60364,"hostname":"alecs-MacBook-Pro","msg":"Server listening at http://0.0.0.0:6001"}
```
