### PR TITLE
Increase track stream redirect timeout to 5s and cache 30min

### DIFF
--- a/discovery-provider/src/api/v1/tracks.py
+++ b/discovery-provider/src/api/v1/tracks.py
@@ -1,4 +1,3 @@
-import asyncio
 import json
 import logging
 import re
@@ -6,7 +5,7 @@ import urllib.parse
 from typing import List
 from urllib.parse import urljoin
 
-from aiohttp import ClientSession, TCPConnector
+import requests
 from flask import redirect
 from flask.globals import request
 from flask_restx import Namespace, Resource, fields, inputs, marshal, reqparse
@@ -74,7 +73,7 @@ from src.trending_strategies.trending_strategy_factory import (
 )
 from src.trending_strategies.trending_type_and_version import TrendingType
 from src.utils import redis_connection
-from src.utils.get_all_other_nodes import get_all_other_content_nodes_cached
+from src.utils.get_all_other_nodes import get_all_healthy_content_nodes_cached
 from src.utils.redis_cache import cache
 from src.utils.redis_metrics import record_metrics
 from src.utils.rendezvous import RendezvousHash
@@ -424,37 +423,17 @@ def tranform_stream_cache(stream_url):
     return redirect(stream_url)
 
 
-async def try_stream_first_byte(session, content_node, path, queue, timeout_sec):
+def get_stream_url_from_content_node(content_node: str, path: str):
     stream_url = urljoin(content_node, path)
     headers = {"Range": "bytes=0-1"}
     try:
-        async with session.get(
-            stream_url + "&skip_play_count=True&localOnly=True",
-            allow_redirects=False,
-            headers=headers,
-            timeout=timeout_sec,
-        ) as response:
-            if response.status == 206:
-                await queue.put((stream_url, content_node))
+        response = requests.get(
+            stream_url + "&skip_play_count=True", headers=headers, timeout=5
+        )
+        if response.status_code == 206:
+            return stream_url
     except:
         pass
-
-
-# Race content nodes, 5 at a time, to see which one responds first with a 206 for the first byte of a track
-async def get_first_stream_url(content_nodes, path):
-    async with ClientSession(connector=TCPConnector(limit=5)) as session:
-        queue = asyncio.Queue()
-
-        tasks = [
-            try_stream_first_byte(session, node, path, queue, timeout_sec=2)
-            for node in content_nodes
-        ]
-        _, pending = await asyncio.wait(tasks, return_when=asyncio.FIRST_COMPLETED)
-
-        for task in pending:
-            task.cancel()
-
-        return await queue.get() if not queue.empty() else (None, None)
 
 
 @ns.route("/<string:track_id>/stream")
@@ -533,35 +512,29 @@ class TrackStream(Resource):
         cached_content_node = redis.get(redis_key)
         stream_url = None
         if cached_content_node:
-            stream_url, _ = try_stream_first_byte(
-                ClientSession(),
-                cached_content_node.decode("utf-8"),
-                path,
-                asyncio.Queue(),
-                timeout_sec=2,
-            )
+            cached_content_node = cached_content_node.decode("utf-8")
+            stream_url = get_stream_url_from_content_node(cached_content_node, path)
             if stream_url:
                 return stream_url
 
-        all_content_nodes = get_all_other_content_nodes_cached(redis)
-        if not all_content_nodes:
+        healthy_nodes = get_all_healthy_content_nodes_cached(redis)
+        if not healthy_nodes:
             logger.error(
-                f"tracks.py | stream | No Content Nodes found when streaming track ID {track_id}. Please investigate."
+                f"tracks.py | stream | No healthy Content Nodes found when streaming track ID {track_id}. Please investigate."
             )
             abort_not_found(track_id, ns)
 
         rendezvous = RendezvousHash(
-            *[re.sub("/$", "", node["endpoint"].lower()) for node in all_content_nodes]
+            *[re.sub("/$", "", node["endpoint"].lower()) for node in healthy_nodes]
         )
+
         content_nodes = rendezvous.get_n(9999999, cid)
-        loop = asyncio.get_event_loop()
-        stream_url, content_node = loop.run_until_complete(
-            get_first_stream_url(content_nodes, path)
-        )
-        if stream_url:
-            redis.set(redis_key, content_node)
-            redis.expire(redis_key, 600)  # 10 min ttl
-            return stream_url
+        for content_node in content_nodes:
+            stream_url = get_stream_url_from_content_node(content_node, path)
+            if stream_url:
+                redis.set(redis_key, content_node)
+                redis.expire(redis_key, 60 * 30)  # 30 min ttl
+                return stream_url
         abort_not_found(track_id, ns)
 
 


### PR DESCRIPTION
### Description
Try all nodes in rendezvous order, following redirects, with a 5s timeout and 30min cache.