### PR TITLE
Add checks for AMM and serum market addresses in staking-bridge

### DIFF
--- a/solana-programs/staking-bridge/programs/staking-bridge/src/constant.rs
+++ b/solana-programs/staking-bridge/programs/staking-bridge/src/constant.rs
@@ -1,17 +1,24 @@
 // Audius ETH Governance Address
 pub const ETH_RECIPIENT_ADDRESS_PADDED_32_BYTES: &str = "0000000000000000000000004DEcA517D6817B6510798b7328F2314d3003AbAC";
+
 // https://docs.raydium.io/raydium/protocol/developers/addresses
 pub const RAYDIUM_AMM_PROGRAM_ADDRESS: &str = "675kPX9MHTjS2zt1qfr1NYHuzeLXfQM9H24wFSUt1Mp8";
+
 // https://github.com/project-serum/serum-dex/blob/master/README.md#program-deployments
 pub const SERUM_DEX_PROGRAM_ADDRESS: &str = "9xQeWvG816bUx9EPjHmaT23yvVM2ZWbrrpZb9PusVFin";
-// https://explorer.solana.com/address/9LzCMqDgTKYz9Drzqnpgee3SGa89up3a247ypMj2xrqM
+
+// https://solscan.io/token/9LzCMqDgTKYz9Drzqnpgee3SGa89up3a247ypMj2xrqM
 pub const SOL_AUDIO_TOKEN_ADDRESS: &str = "9LzCMqDgTKYz9Drzqnpgee3SGa89up3a247ypMj2xrqM";
+
 // https://etherscan.io/token/0x18aAA7115705e8be94bfFEBDE57Af9BFc265B998
 pub const ETH_AUDIO_TOKEN_ADDRESS_PADDED_32_BYTES: &str = "00000000000000000000000018aAA7115705e8be94bfFEBDE57Af9BFc265B998";
-// https://explorer.solana.com/address/FxquLRmVMPXiS84FFSp8q5fbVExhLkX85yiXucyu7xSC
-pub const SERUM_MARKET_ADDRESS: &str = "FxquLRmVMPXiS84FFSp8q5fbVExhLkX85yiXucyu7xSC";
-// https://explorer.solana.com/address/4EbdAfaShVDNeHm6GbXZX3xsKccRHdTbR5962Bvya8xt
-pub const USDC_AUDIO_OPENBOOK_AMM_ADDRESS: &str = "4EbdAfaShVDNeHm6GbXZX3xsKccRHdTbR5962Bvya8xt";
+
+// https://solscan.io/account/FxquLRmVMPXiS84FFSp8q5fbVExhLkX85yiXucyu7xSC
+pub const AUDIO_USDC_SERUM_MARKET_ADDRESS: &str = "FxquLRmVMPXiS84FFSp8q5fbVExhLkX85yiXucyu7xSC";
+
+// https://solscan.io/account/4EbdAfaShVDNeHm6GbXZX3xsKccRHdTbR5962Bvya8xt
+pub const AUDIO_USDC_RAYDIUM_AMM_ADDRESS: &str = "4EbdAfaShVDNeHm6GbXZX3xsKccRHdTbR5962Bvya8xt";
+
 // https://book.wormhole.com/reference/contracts.html
 pub const WORMHOLE_CORE_BRIDGE_ID: &str = "worm2ZoG2kUd4vFXhvjh93UUH596ayRfgQ2MgjNMTth";
 pub const WORMHOLE_TOKEN_BRIDGE_ID: &str = "wormDTUJ6AWPNvk59vGQbDvGJmqbDTdgWgAqcLBCgUb";

--- a/solana-programs/staking-bridge/programs/staking-bridge/src/constant.rs
+++ b/solana-programs/staking-bridge/programs/staking-bridge/src/constant.rs
@@ -8,6 +8,10 @@ pub const SERUM_DEX_PROGRAM_ADDRESS: &str = "9xQeWvG816bUx9EPjHmaT23yvVM2ZWbrrpZ
 pub const SOL_AUDIO_TOKEN_ADDRESS: &str = "9LzCMqDgTKYz9Drzqnpgee3SGa89up3a247ypMj2xrqM";
 // https://etherscan.io/token/0x18aAA7115705e8be94bfFEBDE57Af9BFc265B998
 pub const ETH_AUDIO_TOKEN_ADDRESS_PADDED_32_BYTES: &str = "00000000000000000000000018aAA7115705e8be94bfFEBDE57Af9BFc265B998";
+// https://explorer.solana.com/address/FxquLRmVMPXiS84FFSp8q5fbVExhLkX85yiXucyu7xSC
+pub const SERUM_MARKET_ADDRESS: &str = "FxquLRmVMPXiS84FFSp8q5fbVExhLkX85yiXucyu7xSC";
+// https://explorer.solana.com/address/4EbdAfaShVDNeHm6GbXZX3xsKccRHdTbR5962Bvya8xt
+pub const USDC_AUDIO_OPENBOOK_AMM_ADDRESS: &str = "4EbdAfaShVDNeHm6GbXZX3xsKccRHdTbR5962Bvya8xt";
 // https://book.wormhole.com/reference/contracts.html
 pub const WORMHOLE_CORE_BRIDGE_ID: &str = "worm2ZoG2kUd4vFXhvjh93UUH596ayRfgQ2MgjNMTth";
 pub const WORMHOLE_TOKEN_BRIDGE_ID: &str = "wormDTUJ6AWPNvk59vGQbDvGJmqbDTdgWgAqcLBCgUb";

--- a/solana-programs/staking-bridge/programs/staking-bridge/src/error.rs
+++ b/solana-programs/staking-bridge/programs/staking-bridge/src/error.rs
@@ -6,6 +6,10 @@ pub enum StakingBridgeErrorCode {
     NotCallingRaydiumAmmProgram,
     #[msg("Invalid serum DEX program.")]
     InvalidSerumDexProgram,
+    #[msg("Invalid USDC-$AUDIO AMM program")]
+    InvalidAmmProgram,
+    #[msg("Invalid serum market program.")]
+    InvalidSerumMarketProgram,
     #[msg("Not calling Wormhole Token Bridge program.")]
     NotCallingWormholeTokenBridgeProgram,
     #[msg("Invalid Wormhole Core Bridge program.")]

--- a/solana-programs/staking-bridge/programs/staking-bridge/src/lib.rs
+++ b/solana-programs/staking-bridge/programs/staking-bridge/src/lib.rs
@@ -62,7 +62,9 @@ pub mod staking_bridge {
 
         check_swap_programs(
             program_id.to_account_info(),
-            serum_program.to_account_info()
+            serum_program.to_account_info(),
+            &accounts.amm.to_account_info(),
+            &accounts.serum_market.to_account_info()
         )?;
         check_swap_pdas(
             accounts,

--- a/solana-programs/staking-bridge/programs/staking-bridge/src/lib.rs
+++ b/solana-programs/staking-bridge/programs/staking-bridge/src/lib.rs
@@ -63,8 +63,8 @@ pub mod staking_bridge {
         check_swap_programs(
             program_id.to_account_info(),
             serum_program.to_account_info(),
-            &accounts.amm.to_account_info(),
-            &accounts.serum_market.to_account_info()
+            accounts.amm.to_account_info(),
+            accounts.serum_market.to_account_info()
         )?;
         check_swap_pdas(
             accounts,

--- a/solana-programs/staking-bridge/programs/staking-bridge/src/raydium.rs
+++ b/solana-programs/staking-bridge/programs/staking-bridge/src/raydium.rs
@@ -11,8 +11,8 @@ use anchor_spl::token::spl_token;
 use crate::constant::{
     RAYDIUM_AMM_PROGRAM_ADDRESS,
     SERUM_DEX_PROGRAM_ADDRESS,
-    SERUM_MARKET_ADDRESS,
-    USDC_AUDIO_OPENBOOK_AMM_ADDRESS
+    AUDIO_USDC_SERUM_MARKET_ADDRESS,
+    AUDIO_USDC_RAYDIUM_AMM_ADDRESS
 };
 use crate::error::StakingBridgeErrorCode;
 use crate::{
@@ -21,8 +21,7 @@ use crate::{
 };
 
 /**
- * 1. Verify that we are calling the Raydium AMM program.
- * 2. Verify that the correct Serum DEX program was passed in.
+ * Verify that the programs used for the swap are correct.
  */
 pub fn check_swap_programs(
     program_id: AccountInfo,
@@ -39,11 +38,11 @@ pub fn check_swap_programs(
         return Err(StakingBridgeErrorCode::InvalidSerumDexProgram.into());
     }
     // 3. Verify that the correct USDC-Audio amm was passed in.
-    if amm.key().to_string() != USDC_AUDIO_OPENBOOK_AMM_ADDRESS.to_string() {
+    if amm.key().to_string() != AUDIO_USDC_RAYDIUM_AMM_ADDRESS.to_string() {
         return Err(StakingBridgeErrorCode::InvalidAmmProgram.into());
     }
     // 4. Verify that the correct Serum market was passed in.
-    if serum_market.key().to_string() != SERUM_MARKET_ADDRESS.to_string() {
+    if serum_market.key().to_string() != AUDIO_USDC_SERUM_MARKET_ADDRESS.to_string() {
         return Err(StakingBridgeErrorCode::InvalidSerumMarketProgram.into());
     }
 

--- a/solana-programs/staking-bridge/programs/staking-bridge/src/raydium.rs
+++ b/solana-programs/staking-bridge/programs/staking-bridge/src/raydium.rs
@@ -11,6 +11,8 @@ use anchor_spl::token::spl_token;
 use crate::constant::{
     RAYDIUM_AMM_PROGRAM_ADDRESS,
     SERUM_DEX_PROGRAM_ADDRESS,
+    SERUM_MARKET_ADDRESS,
+    USDC_AUDIO_OPENBOOK_AMM_ADDRESS
 };
 use crate::error::StakingBridgeErrorCode;
 use crate::{
@@ -25,6 +27,8 @@ use crate::{
 pub fn check_swap_programs(
     program_id: AccountInfo,
     serum_program: AccountInfo,
+    amm: AccountInfo,
+    serum_market: AccountInfo
 ) -> Result<()> {
     // 1. Verify that we are calling the Raydium AMM program.
     if program_id.key().to_string() != RAYDIUM_AMM_PROGRAM_ADDRESS.to_string() {
@@ -33,6 +37,14 @@ pub fn check_swap_programs(
     // 2. Verify that the correct Serum DEX program was passed in.
     if serum_program.key().to_string() != SERUM_DEX_PROGRAM_ADDRESS.to_string() {
         return Err(StakingBridgeErrorCode::InvalidSerumDexProgram.into());
+    }
+    // 3. Verify that the correct USDC-Audio amm was passed in.
+    if amm.key().to_string() != USDC_AUDIO_OPENBOOK_AMM_ADDRESS.to_string() {
+        return Err(StakingBridgeErrorCode::InvalidAmmProgram.into());
+    }
+    // 4. Verify that the correct Serum market was passed in.
+    if serum_market.key().to_string() != SERUM_MARKET_ADDRESS.to_string() {
+        return Err(StakingBridgeErrorCode::InvalidSerumMarketProgram.into());
     }
 
     Ok(())

--- a/solana-programs/staking-bridge/programs/staking-bridge/tests/raydium_tests.rs
+++ b/solana-programs/staking-bridge/programs/staking-bridge/tests/raydium_tests.rs
@@ -7,8 +7,8 @@ use staking_bridge::raydium::check_swap_programs;
 use staking_bridge::constant::{
     RAYDIUM_AMM_PROGRAM_ADDRESS,
     SERUM_DEX_PROGRAM_ADDRESS,
-    USDC_AUDIO_OPENBOOK_AMM_ADDRESS,
-    SERUM_MARKET_ADDRESS
+    AUDIO_USDC_RAYDIUM_AMM_ADDRESS,
+    AUDIO_USDC_SERUM_MARKET_ADDRESS
 };
 
 mod utils;
@@ -21,8 +21,8 @@ use utils::{
 fn test_swap_programs() {
     let raydium_key = &RAYDIUM_AMM_PROGRAM_ADDRESS.parse::<Pubkey>().unwrap();
     let serum_key = &SERUM_DEX_PROGRAM_ADDRESS.parse::<Pubkey>().unwrap();
-    let amm_key = &USDC_AUDIO_OPENBOOK_AMM_ADDRESS.parse::<Pubkey>().unwrap();
-    let market_key = &SERUM_MARKET_ADDRESS.parse::<Pubkey>().unwrap();
+    let amm_key = &AUDIO_USDC_RAYDIUM_AMM_ADDRESS.parse::<Pubkey>().unwrap();
+    let market_key = &AUDIO_USDC_SERUM_MARKET_ADDRESS.parse::<Pubkey>().unwrap();
     let other_key = &Pubkey::new_unique();
 
     let (raydium_lamports, raydium_data) = (&mut 0, &mut vec![]);

--- a/solana-programs/staking-bridge/programs/staking-bridge/tests/raydium_tests.rs
+++ b/solana-programs/staking-bridge/programs/staking-bridge/tests/raydium_tests.rs
@@ -7,6 +7,8 @@ use staking_bridge::raydium::check_swap_programs;
 use staking_bridge::constant::{
     RAYDIUM_AMM_PROGRAM_ADDRESS,
     SERUM_DEX_PROGRAM_ADDRESS,
+    USDC_AUDIO_OPENBOOK_AMM_ADDRESS,
+    SERUM_MARKET_ADDRESS
 };
 
 mod utils;
@@ -19,10 +21,14 @@ use utils::{
 fn test_swap_programs() {
     let raydium_key = &RAYDIUM_AMM_PROGRAM_ADDRESS.parse::<Pubkey>().unwrap();
     let serum_key = &SERUM_DEX_PROGRAM_ADDRESS.parse::<Pubkey>().unwrap();
+    let amm_key = &USDC_AUDIO_OPENBOOK_AMM_ADDRESS.parse::<Pubkey>().unwrap();
+    let market_key = &SERUM_MARKET_ADDRESS.parse::<Pubkey>().unwrap();
     let other_key = &Pubkey::new_unique();
 
     let (raydium_lamports, raydium_data) = (&mut 0, &mut vec![]);
     let (serum_lamports, serum_data) = (&mut 0, &mut vec![]);
+    let (amm_lamports, amm_data) = (&mut 0, &mut vec![]);
+    let (market_lamports, market_data) = (&mut 0, &mut vec![]);
     let (bad_lamports, bad_data) = (&mut 0, &mut vec![]);
     let raydium_program = &make_readonly_account_info(
         raydium_key,
@@ -36,6 +42,18 @@ fn test_swap_programs() {
         serum_data,
         other_key
     );
+    let amm_program = &make_readonly_account_info(
+        amm_key,
+        amm_lamports,
+        amm_data,
+        other_key
+    );
+    let market_program = &make_readonly_account_info(
+        market_key,
+        market_lamports,
+        market_data,
+        other_key
+    );
     let bad_account_info = &make_readonly_account_info(
         other_key,
         bad_lamports,
@@ -46,18 +64,40 @@ fn test_swap_programs() {
     let bad_raydium_program_result = check_swap_programs(
       bad_account_info.clone(),
       serum_program.clone(),
+      amm_program.clone(),
+      market_program.clone(),
     );
     assert_error(bad_raydium_program_result, StakingBridgeErrorCode::NotCallingRaydiumAmmProgram);
 
     let bad_serum_program_result = check_swap_programs(
       raydium_program.clone(),
       bad_account_info.clone(),
+      amm_program.clone(),
+      market_program.clone(),
     );
     assert_error(bad_serum_program_result, StakingBridgeErrorCode::InvalidSerumDexProgram);
+
+    let bad_amm_program_result = check_swap_programs(
+      raydium_program.clone(),
+      serum_program.clone(),
+      bad_account_info.clone(),
+      market_program.clone(),
+    );
+    assert_error(bad_amm_program_result, StakingBridgeErrorCode::InvalidAmmProgram);
+
+    let bad_market_program_result = check_swap_programs(
+      raydium_program.clone(),
+      serum_program.clone(),
+      amm_program.clone(),
+      bad_account_info.clone(),
+    );
+    assert_error(bad_market_program_result, StakingBridgeErrorCode::InvalidSerumMarketProgram);
 
     let result = check_swap_programs(
       raydium_program.clone(),
       serum_program.clone(),
+      amm_program.clone(),
+      market_program.clone(),
     );
     assert_eq!(result, Ok(()));
 }


### PR DESCRIPTION
### Description
Explicitly check that the program is being invoked with the expected AMM and market accounts.

### How Has This Been Tested?

```
cargo test-sbf
```