### PR TITLE
Remove premium conditions for non-premium tracks

### DIFF
--- a/discovery-provider/ddl/migrations/0028_fix_non_gated_track_premiun_conditions.sql
+++ b/discovery-provider/ddl/migrations/0028_fix_non_gated_track_premiun_conditions.sql
@@ -1,0 +1,4 @@
+-- tracks where is_premium == false should have premium_conditions == null
+begin;
+update tracks set premium_conditions = null where is_premium = false;
+commit;

--- a/discovery-provider/ddl/migrations/0028_fix_non_gated_track_premiun_conditions.sql
+++ b/discovery-provider/ddl/migrations/0028_fix_non_gated_track_premiun_conditions.sql
@@ -1,4 +1,8 @@
 -- tracks where is_premium == false should have premium_conditions == null
 begin;
-update tracks set premium_conditions = null where is_premium = false;
+update tracks set premium_conditions = null where track_id in (
+  select track_id from (
+    select * from tracks where premium_conditions is not null and is_current is true
+  ) pt where pt.is_premium is false and pt.is_current is true
+) and is_current is true;
 commit;


### PR DESCRIPTION
### Description

Some regression caused a few non-premium tracks to have premium conditions. This migration fixes it by setting those conditions to null, as they should be.
Query looks overly weird because the simple oneliner takes forever. We may be missing indexes, but I didn't want to dive too deep on this at this moment.

### How Has This Been Tested?

Testing on stage DN2.

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._
