### PR TITLE
mediorum: redirect cache

### DIFF
--- a/mediorum/go.mod
+++ b/mediorum/go.mod
@@ -4,12 +4,14 @@ go 1.20
 
 require (
 	github.com/disintegration/imaging v1.6.2
+	github.com/erni27/imcache v1.1.0
 	github.com/ethereum/go-ethereum v1.11.4
 	github.com/georgysavva/scany/v2 v2.0.0
 	github.com/gowebpki/jcs v1.0.0
 	github.com/ipfs/go-cid v0.3.2
 	github.com/jackc/pgx/v5 v5.3.1
 	github.com/labstack/echo/v4 v4.10.0
+	github.com/lib/pq v1.10.9
 	github.com/multiformats/go-multihash v0.2.1
 	github.com/oklog/ulid/v2 v2.1.0
 	github.com/seiflotfy/cuckoofilter v0.0.0-20220411075957-e3b120b3f5fb
@@ -86,7 +88,6 @@ require (
 	github.com/klauspost/cpuid/v2 v2.0.9 // indirect
 	github.com/kylelemons/godebug v1.1.0 // indirect
 	github.com/labstack/gommon v0.4.0 // indirect
-	github.com/lib/pq v1.10.9 // indirect
 	github.com/mattn/go-colorable v0.1.13 // indirect
 	github.com/mattn/go-isatty v0.0.17 // indirect
 	github.com/minio/sha256-simd v1.0.0 // indirect

--- a/mediorum/go.sum
+++ b/mediorum/go.sum
@@ -850,6 +850,8 @@ github.com/envoyproxy/go-control-plane v0.10.3/go.mod h1:fJJn/j26vwOu972OllsvAgJ
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
 github.com/envoyproxy/protoc-gen-validate v0.6.7/go.mod h1:dyJXwwfPK2VSqiB9Klm1J6romD608Ba7Hij42vrOBCo=
 github.com/envoyproxy/protoc-gen-validate v0.6.13/go.mod h1:qEySVqXrEugbHKvmhI8ZqtQi75/RHSSRNpffvB4I6Bw=
+github.com/erni27/imcache v1.1.0 h1:Atak8HV/vsRtQXO0WajZtriT63gAII1qKHD8MgORH4I=
+github.com/erni27/imcache v1.1.0/go.mod h1:KNUCBr1U9nOFTyUEC9CsMKZE33NboYTPavsQsuEufoA=
 github.com/ethereum/go-ethereum v1.11.4 h1:KG81SnUHXWk8LJB3mBcHg/E2yLvXoiPmRMCIRxgx3cE=
 github.com/ethereum/go-ethereum v1.11.4/go.mod h1:it7x0DWnTDMfVFdXcU6Ti4KEFQynLHVRarcSlPr0HBo=
 github.com/evanphx/json-patch v4.9.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
@@ -1385,7 +1387,6 @@ github.com/lib/pq v1.0.0/go.mod h1:5WUZQaWbwv1U+lTReE5YruASi9Al49XbQIvNi/34Woo=
 github.com/lib/pq v1.1.0/go.mod h1:5WUZQaWbwv1U+lTReE5YruASi9Al49XbQIvNi/34Woo=
 github.com/lib/pq v1.2.0/go.mod h1:5WUZQaWbwv1U+lTReE5YruASi9Al49XbQIvNi/34Woo=
 github.com/lib/pq v1.10.2/go.mod h1:AlVN5x4E4T544tWzH6hKfbfQvm3HdbOxrmggDNAPY9o=
-github.com/lib/pq v1.10.7 h1:p7ZhMD+KsSRozJr34udlUrhboJwWAgCg34+/ZZNvZZw=
 github.com/lib/pq v1.10.7/go.mod h1:AlVN5x4E4T544tWzH6hKfbfQvm3HdbOxrmggDNAPY9o=
 github.com/lib/pq v1.10.9 h1:YXG7RB+JIjhP29X+OtkiDnYaXQwpS4JEWq7dtCCRUEw=
 github.com/lib/pq v1.10.9/go.mod h1:AlVN5x4E4T544tWzH6hKfbfQvm3HdbOxrmggDNAPY9o=

--- a/mediorum/server/serve_blob.go
+++ b/mediorum/server/serve_blob.go
@@ -195,8 +195,6 @@ func (ss *MediorumServer) findNodeToServeBlob(key string) (string, error) {
 	if host, ok := ss.redirectCache.Get(key); ok {
 		// verify host is all good
 		if ss.hostHasBlob(host, key) {
-			// reset expire countdown on each access
-			ss.redirectCache.Set(key, host, imcache.WithDefaultExpiration())
 			return host, nil
 		} else {
 			ss.redirectCache.Remove(key)

--- a/mediorum/server/serve_blob.go
+++ b/mediorum/server/serve_blob.go
@@ -206,7 +206,9 @@ func (ss *MediorumServer) findNodeToServeBlob(key string) (string, error) {
 	// just race all hosts
 	hosts := make([]string, 0, len(ss.Config.Peers))
 	for _, p := range ss.Config.Peers {
-		hosts = append(hosts, p.Host)
+		if p.Host != ss.Config.Self.Host {
+			hosts = append(hosts, p.Host)
+		}
 	}
 
 	winner := ss.raceHostHasBlob(key, hosts)
@@ -392,14 +394,4 @@ func (ss *MediorumServer) postBlob(c echo.Context) error {
 	}
 
 	return c.JSON(200, "ok")
-}
-
-func diff[S ~[]E, E comparable](sliceA, sliceB S) S {
-	diff := S{}
-	for _, a := range sliceA {
-		if !slices.Contains(sliceB, a) {
-			diff = append(diff, a)
-		}
-	}
-	return diff
 }

--- a/mediorum/server/serve_metrics.go
+++ b/mediorum/server/serve_metrics.go
@@ -10,9 +10,10 @@ import (
 )
 
 type Metrics struct {
-	Host        string         `json:"host"`
-	Uploads     int64          `json:"uploads"`
-	OutboxSizes map[string]int `json:"outbox_sizes"`
+	Host              string         `json:"host"`
+	Uploads           int64          `json:"uploads"`
+	OutboxSizes       map[string]int `json:"outbox_sizes"`
+	RedirectCacheSize int            `json:"redirect_cache_size"`
 }
 
 func (ss *MediorumServer) getMetrics(c echo.Context) error {
@@ -20,6 +21,7 @@ func (ss *MediorumServer) getMetrics(c echo.Context) error {
 	m.Host = ss.Config.Self.Host
 	m.Uploads = ss.uploadsCount
 	m.OutboxSizes = ss.crud.GetOutboxSizes()
+	m.RedirectCacheSize = ss.redirectCache.Len()
 
 	return c.JSON(200, m)
 }

--- a/mediorum/server/server.go
+++ b/mediorum/server/server.go
@@ -344,7 +344,6 @@ func (ss *MediorumServer) MustStart() {
 	go ss.startTranscoder()
 
 	go ss.startCuckooBuilder()
-	go ss.startCuckooFetcher()
 	createUploadsCache()
 	go ss.buildUploadsCache()
 

--- a/mediorum/server/server.go
+++ b/mediorum/server/server.go
@@ -21,6 +21,7 @@ import (
 
 	_ "embed"
 
+	"github.com/erni27/imcache"
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/labstack/echo/v4"
 	"github.com/labstack/echo/v4/middleware"
@@ -99,6 +100,7 @@ type MediorumServer struct {
 	peerHealthsMutex sync.RWMutex
 	peerHealths      map[string]*PeerHealth
 	unreachablePeers []string
+	redirectCache    *imcache.Cache[string, string]
 
 	StartedAt time.Time
 	Config    MediorumConfig
@@ -246,7 +248,8 @@ func New(config MediorumConfig) (*MediorumServer, error) {
 		trustedNotifier: &trustedNotifier,
 		isSeeding:       config.Env == "stage" || config.Env == "prod",
 
-		peerHealths: map[string]*PeerHealth{},
+		peerHealths:   map[string]*PeerHealth{},
+		redirectCache: imcache.New[string, string](imcache.WithDefaultExpirationOption[string, string](time.Hour * 24)),
 
 		StartedAt: time.Now().UTC(),
 		Config:    config,

--- a/mediorum/server/server.go
+++ b/mediorum/server/server.go
@@ -249,7 +249,7 @@ func New(config MediorumConfig) (*MediorumServer, error) {
 		isSeeding:       config.Env == "stage" || config.Env == "prod",
 
 		peerHealths:   map[string]*PeerHealth{},
-		redirectCache: imcache.New[string, string](imcache.WithDefaultExpirationOption[string, string](time.Hour * 24)),
+		redirectCache: imcache.New[string, string](imcache.WithMaxEntriesOption[string, string](100_000)),
 
 		StartedAt: time.Now().UTC(),
 		Config:    config,


### PR DESCRIPTION
### Description

Replaces various cid "lookup" strategies (cuckoo / blobs table / healthy / unhealthy) with a simpler one that simply races all hosts 5 at a time and caches result on success.

Since discovery will ask nodes one at a time in rendezvous order, that means in practice each server should only be caching 1/N of CIDs, which improves cache coherence and eveness.

