### PR TITLE
[CON-828] Replicate Qm CIDs

### DIFF
--- a/mediorum/server/placement.go
+++ b/mediorum/server/placement.go
@@ -1,7 +1,6 @@
 package server
 
 import (
-	"mediorum/cidutil"
 	"time"
 
 	"github.com/tysonmote/rendezvous"
@@ -33,9 +32,6 @@ func (ss *MediorumServer) rendezvousHosts(key string, hosts []string) ([]string,
 
 	if ss.Config.StoreAll {
 		isMine = true
-	} else if cidutil.IsLegacyCID(key) {
-		// TODO(theo): Don't store Qm CIDs for now unless STORE_ALL is true. Remove this once all nodes have enough space to store Qm CIDs
-		isMine = false
 	}
 	return orderedHosts, isMine
 }

--- a/mediorum/server/repair.go
+++ b/mediorum/server/repair.go
@@ -94,11 +94,6 @@ func (ss *MediorumServer) runRepair(replicateMode, cleanupMode bool) error {
 			// use preferredHealthyHosts when determining my rank because we want to check if we're in the top N*2 healthy nodes not the top N*2 unhealthy nodes
 			myRank := slices.Index(preferredHealthyHosts, ss.Config.Self.Host)
 
-			// TODO(theo): Don't repair Qm keys for now (isMine will still be true). Remove this once all nodes have enough space to store Qm keys
-			if cidutil.IsLegacyCID(cid) {
-				myRank = 999
-			}
-
 			// fast path if we're not in cleanup mode:
 			// only worry about blobs that we _should_ have
 			if !cleanupMode && !isMine && !isMineHealthy {
@@ -130,7 +125,6 @@ func (ss *MediorumServer) runRepair(replicateMode, cleanupMode bool) error {
 						alreadyHave = false
 					}
 				}
-
 			}
 
 			// get blobs that I should have (regardless of health of other nodes)


### PR DESCRIPTION
### Description
Makes repair.go start replicating Qm CIDs.

### How Has This Been Tested?
- `make test` works.
- I'll roll out to staging and then foundation nodes first.
- The headroom cap is still in place (nodes stop replicating when there's <200GB of disk remaining).