### PR TITLE
Rewards indexer skips solana transaction fetch fails

### DIFF
--- a/discovery-provider/src/tasks/index_rewards_manager.py
+++ b/discovery-provider/src/tasks/index_rewards_manager.py
@@ -15,6 +15,7 @@ from solders.transaction_status import UiTransactionStatusMeta
 from sqlalchemy import desc
 from sqlalchemy.orm.session import Session
 
+from src.exceptions import SolanaTransactionFetchError
 from src.models.rewards.challenge import Challenge, ChallengeType
 from src.models.rewards.challenge_disbursement import ChallengeDisbursement
 from src.models.rewards.reward_manager import RewardManagerTransaction
@@ -274,6 +275,8 @@ def fetch_and_parse_sol_rewards_transfer_instruction(
             "postbalance": balance_changes[receiver_user_bank]["post_balance"],
         }
         return tx_metadata
+    except SolanaTransactionFetchError:
+        return None
     except Exception as e:
         logger.error(
             f"index_rewards_manager.py | Error processing {tx_sig}, {e}", exc_info=True

--- a/discovery-provider/src/tasks/index_rewards_manager.py
+++ b/discovery-provider/src/tasks/index_rewards_manager.py
@@ -215,7 +215,7 @@ def get_valid_instruction(
 
 def fetch_and_parse_sol_rewards_transfer_instruction(
     solana_client_manager: SolanaClientManager, tx_sig: str
-) -> RewardManagerTransactionInfo:
+) -> Optional[RewardManagerTransactionInfo]:
     """Fetches metadata for rewards transfer transactions and parses data
 
     Fetches the transaction metadata from solana using the tx signature


### PR DESCRIPTION
### Description
If we encounter a bad transaction ([example](https://solscan.io/tx/5FBJZAzd7mvKSncNJiTNoDE2V52yT4Sum13p6EMYa5nTQG7SKy8QV1ms7Ssft2AMccRBXpfQacdBA5u3WVhY3j6x)), the indexer will get stuck in a state where it repeatedly tries to fetch the transaction, errors, then tries to re-fetch the same tx. This will continue until there are enough "good" transactions to fill a whole batch, at which point the indexer will skip the bad tx, but also potentially skip other txs that occurred around the same time as the bad tx.

### How Has This Been Tested?
Not tested

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._
