### PR TITLE
Return 0 rps when undefined

### DIFF
--- a/discovery-provider/nginx_conf/nginx.conf
+++ b/discovery-provider/nginx_conf/nginx.conf
@@ -62,7 +62,12 @@ http {
 
         location = /request_count {
             content_by_lua_block {
-                ngx.say(ngx.shared.request_count:get("request-count"))
+                local count = ngx.shared.request_count:get("request-count")
+                if count == nil then
+                    ngx.say(0)
+                else
+                    ngx.say(count)
+                end
             }
         }
 


### PR DESCRIPTION
### Description

Catch `nil` value in RPS counter when there haven't been enough requests to endpoints that track RPS.

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._

On sandbox:
http://34.72.186.34:5000/request_count