### PR TITLE
Surface image cid cache in feed endpoints

### DIFF
--- a/discovery-provider/src/api/v1/helpers.py
+++ b/discovery-provider/src/api/v1/helpers.py
@@ -31,51 +31,19 @@ redis = get_redis()
 logger = logging.getLogger(__name__)
 
 
-PROFILE_PICTURE_SIZES = ["150x150", "480x480", "1000x1000"]
-PROFILE_COVER_PHOTO_SIZES = ["640x", "2000x"]
-COVER_ART_SIZES = ["150x150", "480x480", "1000x1000"]
-
-
 def make_image(endpoint, cid, width="", height=""):
     return f"{endpoint}/content/{cid}/{width}x{height}.jpg"
-
-
-def init_rendezvous(user, cid):
-    if not cid:
-        return ""
-    healthy_nodes = get_all_healthy_content_nodes_cached(redis)
-    if not healthy_nodes:
-        logger.error(
-            f"No healthy Content Nodes found for fetching cid for {user.user_id}: {cid}"
-        )
-        return ""
-
-    return RendezvousHash(
-        *[re.sub("/$", "", node["endpoint"].lower()) for node in healthy_nodes]
-    )
-
-
-def get_primary_endpoint(user, cid):
-    rendezvous = init_rendezvous(user, cid)
-    if not rendezvous:
-        return ""
-    return rendezvous.get(cid)
-
-
-def get_n_primary_endpoints(user, cid, n):
-    rendezvous = init_rendezvous(user, cid)
-    if not rendezvous:
-        return ""
-    return rendezvous.get_n(n, cid)
 
 
 def add_track_artwork(track):
     if "user" not in track:
         return track
     cid = track["cover_art_sizes"]
-    cover_cids = get_image_cids(track["user"], cid, COVER_ART_SIZES)
+    cover_cids = api_helpers.get_image_cids(
+        track["user"], cid, api_helpers.COVER_ART_SIZES
+    )
     track["cover_art_cids"] = cover_cids
-    endpoint = get_primary_endpoint(track["user"], cid)
+    endpoint = api_helpers.get_primary_endpoint(track["user"], cid)
     artwork = get_image_urls(track["user"], cover_cids)
     if endpoint and not artwork:
         # Fallback to legacy image url format with dumb endpoint
@@ -93,9 +61,11 @@ def add_playlist_artwork(playlist):
         return playlist
 
     cid = playlist["playlist_image_sizes_multihash"]
-    cover_cids = get_image_cids(playlist["user"], cid, COVER_ART_SIZES)
+    cover_cids = api_helpers.get_image_cids(
+        playlist["user"], cid, api_helpers.COVER_ART_SIZES
+    )
     playlist["cover_art_cids"] = cover_cids
-    endpoint = get_primary_endpoint(playlist["user"], cid)
+    endpoint = api_helpers.get_primary_endpoint(playlist["user"], cid)
     artwork = get_image_urls(playlist["user"], cover_cids)
     if endpoint and not artwork:
         # Fallback to legacy image url format with dumb endpoint
@@ -129,9 +99,11 @@ def add_user_artwork(user):
     user["profile_picture_legacy"] = user.get("profile_picture")
 
     profile_cid = user.get("profile_picture_sizes")
-    profile_endpoint = get_primary_endpoint(user, profile_cid)
+    profile_endpoint = api_helpers.get_primary_endpoint(user, profile_cid)
     if profile_cid:
-        profile_cids = get_image_cids(user, profile_cid, PROFILE_PICTURE_SIZES)
+        profile_cids = api_helpers.get_image_cids(
+            user, profile_cid, api_helpers.PROFILE_PICTURE_SIZES
+        )
         user["profile_picture_cids"] = profile_cids
         profile = get_image_urls(user, profile_cids)
         if profile_endpoint and not profile:
@@ -143,9 +115,11 @@ def add_user_artwork(user):
             }
         user["profile_picture"] = profile
     cover_cid = user.get("cover_photo_sizes")
-    cover_endpoint = get_primary_endpoint(user, cover_cid)
+    cover_endpoint = api_helpers.get_primary_endpoint(user, cover_cid)
     if cover_cid:
-        cover_cids = get_image_cids(user, cover_cid, PROFILE_COVER_PHOTO_SIZES)
+        cover_cids = api_helpers.get_image_cids(
+            user, cover_cid, api_helpers.PROFILE_COVER_PHOTO_SIZES
+        )
         user["cover_photo_cids"] = cover_cids
         cover = get_image_urls(user, cover_cids)
         if cover_endpoint and not cover:
@@ -162,73 +136,6 @@ def add_user_artwork(user):
 # Helpers
 
 
-async def fetch_url(url):
-    loop = asyncio.get_event_loop()
-    future = loop.run_in_executor(None, requests.get, url)
-    response = await future
-    return response
-
-
-async def race_requests(urls, timeout):
-    tasks = [asyncio.create_task(fetch_url(url)) for url in urls]
-    done, pending = await asyncio.wait(
-        tasks, return_when=asyncio.ALL_COMPLETED, timeout=timeout
-    )
-    for task in done:
-        response = task.result()
-        if response.status_code == 200:
-            return response
-    raise Exception(f"No 200 responses for urls {urls}")
-
-
-# Get cids corresponding to each transcoded variant for the given upload_id.
-# Cache upload_id -> cids mappings.
-def get_image_cids(user, upload_id, variants):
-    if not upload_id:
-        return {}
-    try:
-        image_cids = {}
-        if upload_id.startswith("Qm"):
-            # Legacy path - no need to query content nodes for image variant cids
-            image_cids = {variant: f"{upload_id}/{variant}.jpg" for variant in variants}
-        else:
-            redis_key = f"image_cids:{upload_id}"
-            image_cids = redis.hgetall(redis_key)
-            if image_cids:
-                image_cids = {
-                    variant.decode("utf-8"): cid.decode("utf-8")
-                    for variant, cid in image_cids.items()
-                }
-            else:
-                # Query content for the transcoded cids corresponding to this upload id and
-                # cache upload_id -> { variant: cid, ... }
-                endpoints = get_n_primary_endpoints(user, upload_id, 3)
-                urls = list(
-                    map(lambda endpoint: f"{endpoint}/uploads/{upload_id}", endpoints)
-                )
-
-                # Race requests in a new event loop
-                new_loop = asyncio.new_event_loop()
-                asyncio.set_event_loop(new_loop)
-                resp = new_loop.run_until_complete(race_requests(urls, 1))
-                new_loop.close()
-
-                resp.raise_for_status()
-                image_cids = resp.json().get("results", {})
-                if not image_cids:
-                    return image_cids
-
-                image_cids = {
-                    variant.strip(".jpg"): cid for variant, cid in image_cids.items()
-                }
-                redis.hset(redis_key, mapping=image_cids)
-                redis.expire(redis_key, 86400)  # 24 hour ttl
-        return image_cids
-    except Exception as e:
-        logger.error(f"Exception fetching image cids for id: {upload_id}: {e}")
-        return {}
-
-
 # Map each image cid to a url with its preferred node. This reduces
 # redirects from initially attempting to query the wrong node.
 def get_image_urls(user, image_cids):
@@ -239,7 +146,7 @@ def get_image_urls(user, image_cids):
     for variant, cid in image_cids.items():
         if variant == "original":
             continue
-        primary_endpoint = get_primary_endpoint(user, cid)
+        primary_endpoint = api_helpers.get_primary_endpoint(user, cid)
         if not primary_endpoint:
             raise Exception(
                 "Could not get primary endpoint for user {user.user_id}, cid {cid}"

--- a/discovery-provider/src/api/v1/helpers.py
+++ b/discovery-provider/src/api/v1/helpers.py
@@ -1,10 +1,7 @@
-import asyncio
 import logging
-import re
 from datetime import datetime
 from typing import Dict, Union, cast
 
-import requests
 from flask_restx import reqparse
 
 from src import api_helpers
@@ -21,10 +18,8 @@ from src.queries.query_helpers import (
 )
 from src.queries.reactions import ReactionResponse
 from src.utils.auth_middleware import MESSAGE_HEADER, SIGNATURE_HEADER
-from src.utils.get_all_other_nodes import get_all_healthy_content_nodes_cached
 from src.utils.helpers import decode_string_id, encode_int_id
 from src.utils.redis_connection import get_redis
-from src.utils.rendezvous import RendezvousHash
 from src.utils.spl_audio import to_wei_string
 
 redis = get_redis()

--- a/discovery-provider/src/api/v1/models/users.py
+++ b/discovery-provider/src/api/v1/models/users.py
@@ -1,6 +1,6 @@
 from flask_restx import fields
 
-from .common import ns, StringEnumToLower
+from .common import StringEnumToLower, ns
 from .playlist_library import playlist_library
 
 # DEPRECATED

--- a/discovery-provider/src/queries/query_helpers.py
+++ b/discovery-provider/src/queries/query_helpers.py
@@ -8,8 +8,7 @@ from sqlalchemy import Integer, and_, bindparam, cast, desc, func, text
 from sqlalchemy.orm.session import Session
 from sqlalchemy.sql.expression import or_
 
-from src import exceptions
-from src.api.v1 import helpers as v1Helpers
+from src import api_helpers, exceptions
 from src.models.playlists.aggregate_playlist import AggregatePlaylist
 from src.models.playlists.playlist import Playlist
 from src.models.social.follow import Follow
@@ -303,14 +302,14 @@ def populate_user_metadata(
         # Convert image cid to cids for each image size variant
         profile_cid = user.get("profile_picture_sizes")
         if profile_cid:
-            profile_cids = v1Helpers.get_image_cids(
-                user, profile_cid, v1Helpers.PROFILE_PICTURE_SIZES
+            profile_cids = api_helpers.get_image_cids(
+                user, profile_cid, api_helpers.PROFILE_PICTURE_SIZES
             )
             user["profile_picture_cids"] = profile_cids
         cover_cid = user.get("cover_photo_sizes")
         if cover_cid:
-            cover_cids = v1Helpers.get_image_cids(
-                user, cover_cid, v1Helpers.PROFILE_COVER_PHOTO_SIZES
+            cover_cids = api_helpers.get_image_cids(
+                user, cover_cid, api_helpers.PROFILE_COVER_PHOTO_SIZES
             )
             user["cover_photo_cids"] = cover_cids
 
@@ -515,8 +514,8 @@ def populate_track_metadata(
         # Convert cover art cid to cids for each image size variant
         cover_cid = track.get("cover_art_sizes")
         if cover_cid:
-            cover_cids = v1Helpers.get_image_cids(
-                track["user"], cover_cid, v1Helpers.COVER_ART_SIZES
+            cover_cids = api_helpers.get_image_cids(
+                track["user"], cover_cid, api_helpers.COVER_ART_SIZES
             )
             track["cover_art_cids"] = cover_cids
 
@@ -894,8 +893,8 @@ def populate_playlist_metadata(
         # Convert cover art cid to cids for each image size variant
         cover_cid = playlist.get("playlist_image_sizes_multihash")
         if cover_cid:
-            cover_cids = v1Helpers.get_image_cids(
-                playlist["user"], cover_cid, v1Helpers.COVER_ART_SIZES
+            cover_cids = api_helpers.get_image_cids(
+                playlist["user"], cover_cid, api_helpers.COVER_ART_SIZES
             )
             playlist["cover_art_cids"] = cover_cids
 

--- a/discovery-provider/src/tasks/entity_manager/entities/user.py
+++ b/discovery-provider/src/tasks/entity_manager/entities/user.py
@@ -486,7 +486,9 @@ def update_user_associated_wallets(
                     blockhash=user_record.blockhash,
                 )
                 added_wallets.append(associated_wallet_entry)
-        is_updated_wallets = set([prev_wallet.wallet for prev_wallet in previous_wallets]) != set([wallet.wallet for wallet in added_wallets])
+        is_updated_wallets = set(
+            [prev_wallet.wallet for prev_wallet in previous_wallets]
+        ) != set([wallet.wallet for wallet in added_wallets])
 
         if is_updated_wallets:
             for wallet in added_wallets:

--- a/discovery-provider/src/utils/elasticdsl.py
+++ b/discovery-provider/src/utils/elasticdsl.py
@@ -3,6 +3,7 @@ import os
 
 from elasticsearch import Elasticsearch, logger, logging
 
+from src.api.v1 import helpers
 from src.utils.spl_audio import to_wei
 
 logger.setLevel(logging.WARNING)
@@ -49,6 +50,20 @@ def populate_user_metadata_es(user, current_user):
         + to_wei(user.get("waudio", "0") or 0)
     )
 
+    # Convert image cid to cids for each image size variant
+    profile_cid = user.get("profile_picture_sizes")
+    if profile_cid:
+        profile_cids = helpers.get_image_cids(
+            user, profile_cid, helpers.PROFILE_PICTURE_SIZES
+        )
+        user["profile_picture_cids"] = profile_cids
+    cover_cid = user.get("cover_photo_sizes")
+    if cover_cid:
+        cover_cids = helpers.get_image_cids(
+            user, cover_cid, helpers.PROFILE_COVER_PHOTO_SIZES
+        )
+        user["cover_photo_cids"] = cover_cids
+
     # Mutual box on profile page will fetch the data to compute this number
     # using the /v1/full/users/xyz/related?user_id=abc endpoint
     # Avoid extra round trips by not computing it here
@@ -69,6 +84,16 @@ def populate_user_metadata_es(user, current_user):
 
 
 def populate_track_or_playlist_metadata_es(item, current_user):
+    # Convert cover art cid to cids for each image size variant
+    cover_cid = item.get("cover_art_sizes") or item.get(
+        "playlist_image_sizes_multihash"
+    )
+    if cover_cid:
+        cover_cids = helpers.get_image_cids(
+            item["user"], cover_cid, helpers.COVER_ART_SIZES
+        )
+        item["cover_art_cids"] = cover_cids
+
     if current_user:
         my_id = current_user["user_id"]
         item["has_current_user_reposted"] = my_id in item["reposted_by"]

--- a/discovery-provider/src/utils/elasticdsl.py
+++ b/discovery-provider/src/utils/elasticdsl.py
@@ -3,7 +3,7 @@ import os
 
 from elasticsearch import Elasticsearch, logger, logging
 
-from src.api.v1 import helpers
+from src import api_helpers
 from src.utils.spl_audio import to_wei
 
 logger.setLevel(logging.WARNING)
@@ -53,14 +53,14 @@ def populate_user_metadata_es(user, current_user):
     # Convert image cid to cids for each image size variant
     profile_cid = user.get("profile_picture_sizes")
     if profile_cid:
-        profile_cids = helpers.get_image_cids(
-            user, profile_cid, helpers.PROFILE_PICTURE_SIZES
+        profile_cids = api_helpers.get_image_cids(
+            user, profile_cid, api_helpers.PROFILE_PICTURE_SIZES
         )
         user["profile_picture_cids"] = profile_cids
     cover_cid = user.get("cover_photo_sizes")
     if cover_cid:
-        cover_cids = helpers.get_image_cids(
-            user, cover_cid, helpers.PROFILE_COVER_PHOTO_SIZES
+        cover_cids = api_helpers.get_image_cids(
+            user, cover_cid, api_helpers.PROFILE_COVER_PHOTO_SIZES
         )
         user["cover_photo_cids"] = cover_cids
 
@@ -89,8 +89,8 @@ def populate_track_or_playlist_metadata_es(item, current_user):
         "playlist_image_sizes_multihash"
     )
     if cover_cid:
-        cover_cids = helpers.get_image_cids(
-            item["user"], cover_cid, helpers.COVER_ART_SIZES
+        cover_cids = api_helpers.get_image_cids(
+            item["user"], cover_cid, api_helpers.COVER_ART_SIZES
         )
         item["cover_art_cids"] = cover_cids
 

--- a/discovery-provider/src/utils/helpers.py
+++ b/discovery-provider/src/utils/helpers.py
@@ -10,9 +10,9 @@ import unicodedata
 from functools import reduce
 from json.encoder import JSONEncoder
 from typing import List, Optional, TypedDict, cast
-import psutil
 
 import base58
+import psutil
 import requests
 from flask import g, request
 from hashids import Hashids
@@ -166,7 +166,7 @@ class CustomJsonFormatter(JsonFormatter):
             # Get memory usage
             process = psutil.Process()
             memory_info = process.memory_info()
-            rss = memory_info.rss / (1024 ** 2)  # Resident Set Size in MB
+            rss = memory_info.rss / (1024**2)  # Resident Set Size in MB
 
             # Include CPU and memory usage in log record
             record.cpu = cpu_percent


### PR DESCRIPTION
### Description
The user feed in the client is still using non-direct URLs for images because the feed API resp (which uses es-indexer) doesn't have the cached cid fields.

### How Has This Been Tested?
Deployed to stage, tested feed used direct image URLs.