### PR TITLE
Transaction handler: Catch and return tx serialization errors

### DIFF
--- a/libs/src/services/solana/transactionHandler.ts
+++ b/libs/src/services/solana/transactionHandler.ts
@@ -207,7 +207,23 @@ export class TransactionHandler {
       })
     }
 
-    const rawTransaction = tx.serialize()
+    let rawTransaction: Buffer
+    try {
+      rawTransaction = tx.serialize()
+    } catch (e) {
+      logger.warn(`transactionHandler: transaction serialization failed: ${e}`)
+      let errorCode = null
+      let error = null
+      if (e instanceof Error) {
+        error = e.message
+        errorCode = this._parseSolanaErrorCode(error)
+      }
+      return {
+        res: null,
+        error,
+        errorCode
+      }
+    }
 
     // Send the txn
 


### PR DESCRIPTION
### Description
Need this to catch "tx too large" errors on relay.

### How Has This Been Tested?
Tested by manually sending a large tx through `TransactionHandler` and confirming we see the error:
<img width="900" alt="Screenshot 2023-09-07 at 4 39 46 PM" src="https://github.com/AudiusProject/audius-protocol/assets/3893871/6e65ad7c-b990-4755-a065-685d4010535d">

