### PR TITLE
Drop blobs table, gossip upload crudr events

### DIFF
--- a/mediorum/Makefile
+++ b/mediorum/Makefile
@@ -11,7 +11,8 @@ dev2::
 	LIVE_UI=true goreman -set-ports=false start
 
 test:: pg.bounce
-	go test ./... -count=1 -timeout 60s
+	rm -rf /tmp/mediorum_test
+	go test -v ./server -count=1 -timeout 60s
 
 
 tools::

--- a/mediorum/Makefile
+++ b/mediorum/Makefile
@@ -12,7 +12,7 @@ dev2::
 
 test:: pg.bounce
 	rm -rf /tmp/mediorum_test
-	go test -v ./server -count=1 -timeout 60s
+	go test ./... -count=1 -timeout 60s
 
 
 tools::

--- a/mediorum/crudr/client.go
+++ b/mediorum/crudr/client.go
@@ -144,6 +144,12 @@ func (p *PeerClient) doSweep() error {
 	}
 
 	for _, op := range ops {
+		// ignore old blobs ops
+		if op.Table == "blobs" {
+			lastUlid = op.ULID
+			continue
+		}
+
 		err := p.crudr.ApplyOp(op)
 		if err != nil {
 			p.logger.Error("failed to apply op", "op", op, "err", err)

--- a/mediorum/ddl/drop_blobs.sql
+++ b/mediorum/ddl/drop_blobs.sql
@@ -1,9 +1,12 @@
 begin;
 
+-- ensure there is a blobs table
+-- (so this can work on an empty db)
 create table if not exists blobs (
   "key" text primary key
 );
 
+-- our unique list of Qm CIDs
 create table if not exists qm_cids (
   "key" text primary key
 );
@@ -15,8 +18,14 @@ where "key" ilike 'qm%'
 on conflict do nothing
 ;
 
-drop table blobs;
+-- do this later when confident all good:
+-- drop table blobs;
 
+-- remove all the noisy blob history
 delete from ops where "table" = 'blobs';
+
+-- reset ops cursors...
+-- now that ops is "gossip" style this will ensure historical Uploads are created if missing
+truncate cursors;
 
 commit;

--- a/mediorum/ddl/drop_blobs.sql
+++ b/mediorum/ddl/drop_blobs.sql
@@ -18,14 +18,16 @@ where "key" ilike 'qm%'
 on conflict do nothing
 ;
 
--- do this later when confident all good:
+-- todo: do this later when confident all good:
 -- drop table blobs;
 
 -- remove all the noisy blob history
 delete from ops where "table" = 'blobs';
 
+
 -- reset ops cursors...
 -- now that ops is "gossip" style this will ensure historical Uploads are created if missing
-truncate cursors;
+-- todo: do this next deploy after blobs ops have been cut down... so that we just revisit uploads
+-- truncate cursors;
 
 commit;

--- a/mediorum/ddl/drop_blobs.sql
+++ b/mediorum/ddl/drop_blobs.sql
@@ -1,0 +1,22 @@
+begin;
+
+create table if not exists blobs (
+  "key" text primary key
+);
+
+create table if not exists qm_cids (
+  "key" text primary key
+);
+
+insert into qm_cids ("key")
+select distinct "key"
+from blobs
+where "key" ilike 'qm%'
+on conflict do nothing
+;
+
+drop table blobs;
+
+delete from ops where "table" = 'blobs';
+
+commit;

--- a/mediorum/server/db.go
+++ b/mediorum/server/db.go
@@ -13,12 +13,6 @@ import (
 	"gorm.io/gorm"
 )
 
-type Blob struct {
-	Key       string    `json:"key" gorm:"primaryKey;not null;default:null"`
-	Host      string    `json:"host" gorm:"primaryKey;not null;default:null"`
-	CreatedAt time.Time `json:"created_at"`
-}
-
 type Upload struct {
 	ID string `json:"id"` // base32 file hash
 
@@ -66,13 +60,13 @@ func dbMustDial(dbPath string) *gorm.DB {
 func dbMigrate(crud *crudr.Crudr, bucket *blob.Bucket, myHost string) {
 	// Migrate the schema
 	slog.Info("db: gorm automigrate")
-	err := crud.DB.AutoMigrate(&Blob{}, &Upload{})
+	err := crud.DB.AutoMigrate(&Upload{})
 	if err != nil {
 		panic(err)
 	}
 
 	// register any models to be managed by crudr
-	crud.RegisterModels(&Blob{}, &Upload{})
+	crud.RegisterModels(&Upload{})
 
 	sqlDb, _ := crud.DB.DB()
 	gormDB := crud.DB

--- a/mediorum/server/repair.go
+++ b/mediorum/server/repair.go
@@ -13,186 +13,48 @@ import (
 )
 
 func (ss *MediorumServer) startRepairer() {
-
-	// wait 10m after boot to start repair (plus up to 10 more minutes to space out nodes)
-	time.Sleep(time.Minute*10 + time.Minute*time.Duration(rand.Intn(10)))
-
+	// loop forever
 	for i := 1; ; i++ {
+		// wait between 10 and 30 minutes between repair runs
+		time.Sleep(time.Minute*10 + time.Minute*time.Duration(rand.Intn(20)))
+
+		// 10% percent of time... clean up over-replicated and pull under-replicated
+		cleanupMode := i%10 == 0
+
+		logger := ss.logger.With("task", "repair", "run", i, "cleanupMode", cleanupMode)
+
 		// check that network is valid (should have more peers than replication factor)
 		if healthyPeers := ss.findHealthyPeers(5 * time.Minute); len(healthyPeers) < ss.Config.ReplicationFactor {
-			ss.logger.Warn("not enough healthy peers to run repair",
+			logger.Warn("not enough healthy peers to run repair",
 				"R", ss.Config.ReplicationFactor,
 				"peers", len(healthyPeers))
 			continue
 		}
 
-		replicateMode := ss.shouldReplicate()
-		// 10% percent of time... clean up over-replicated and pull under-replicated
-		cleanupMode := false
-		if i%10 == 0 {
-			cleanupMode = true
-		}
-
-		logger := ss.logger.With("task", "repair", "run", i, "cleanupMode", cleanupMode)
-		took := time.Duration(0)
-		if replicateMode || cleanupMode {
-			repairStart := time.Now()
-			logger.Info("repair starting")
-			err := ss.runRepair(replicateMode, cleanupMode)
-			took = time.Since(repairStart)
-			if err != nil {
-				logger.Error("repair failed", "err", err, "took", took)
-			} else {
-				logger.Info("repair OK", "took", took)
-			}
-		} else {
+		// check that disk has space
+		if !ss.diskHasSpace() {
 			logger.Warn("disk has <200GB remaining and is not in cleanup mode. skipping repair")
+			continue
 		}
 
-		// sleep for as long as the job took
-		// if you wanted to aproximate max(1/5) of network running repair at same time...
-		// you could make this node run repair ~1/5 of the time
-		// (with some bounds)
-		sleep := clampDuration(time.Minute*5, took*5, time.Hour*12)
-		logger.Info("repair sleeping", "sleep", sleep)
-		time.Sleep(sleep)
+		repairStart := time.Now()
+		logger.Info("repair starting")
+		err := ss.runRepair(cleanupMode)
+		took := time.Since(repairStart)
+		if err != nil {
+			logger.Error("repair failed", "err", err, "took", took)
+		} else {
+			logger.Info("repair OK", "took", took)
+		}
 
 	}
 }
 
-func (ss *MediorumServer) runRepair(replicateMode, cleanupMode bool) error {
+func (ss *MediorumServer) runRepair(cleanupMode bool) error {
 	ctx := context.Background()
 
-	logger := ss.logger.With("task", "repair", "replicateMode", replicateMode, "cleanupMode", cleanupMode)
-
-	repairCid := func(cid string) {
-		logger := logger.With("cid", cid)
-
-		preferredHosts, isMine := ss.rendezvousAllHosts(cid)
-		preferredHealthyHosts, isMineHealthy := ss.rendezvousHealthyHosts(cid)
-
-		// use preferredHealthyHosts when determining my rank because we want to check if we're in the top N*2 healthy nodes not the top N*2 unhealthy nodes
-		myRank := slices.Index(preferredHealthyHosts, ss.Config.Self.Host)
-
-		key := cidutil.ShardCID(cid)
-		alreadyHave := true
-		attrs, err := ss.bucket.Attributes(ctx, key)
-		if err != nil {
-			if gcerrors.Code(err) == gcerrors.NotFound {
-				alreadyHave = false
-				attrs = &blob.Attributes{}
-			} else {
-				logger.Error("exist check failed", "err", err)
-				return
-			}
-		}
-
-		// in cleanup mode do some extra checks:
-		// - validate CID, delete if invalid (doesn't apply to Qm keys because their hash is not the CID)
-		if cleanupMode && alreadyHave && !cidutil.IsLegacyCID(cid) {
-			if r, err := ss.bucket.NewReader(ctx, key, nil); err == nil {
-				err := cidutil.ValidateCID(cid, r)
-				r.Close()
-				if err != nil {
-					logger.Error("deleting invalid CID", "err", err)
-					ss.bucket.Delete(ctx, key)
-					alreadyHave = false
-				}
-			}
-		}
-
-		// get blobs that I should have (regardless of health of other nodes)
-		if replicateMode && isMine && !alreadyHave {
-			success := false
-			// loop preferredHosts (not preferredHealthyHosts) because pullFileFromHost can still give us a file even if we thought the host was unhealthy
-			for _, host := range preferredHosts {
-				if host == ss.Config.Self.Host {
-					continue
-				}
-				err := ss.pullFileFromHost(host, cid)
-				if err != nil {
-					logger.Error("pull failed (blob I should have)", "err", err, "host", host)
-				} else {
-					logger.Info("pull OK (blob I should have)", "host", host)
-					success = true
-					break
-				}
-			}
-			if !success {
-				logger.Warn("failed to pull from any host", "hosts", preferredHosts)
-			}
-		}
-
-		// delete over-replicated blobs:
-		// check all healthy nodes ahead of me in the preferred order to ensure they have it.
-		// if R+1 healthy nodes in front of me have it, I can safely delete.
-		// don't delete if we replicated the blob within the past 24 hours
-		wasReplicatedToday := attrs.CreateTime.After(time.Now().Add(-24 * time.Hour))
-		if cleanupMode && (!isMine || !isMineHealthy) && alreadyHave && !wasReplicatedToday {
-			depth := 0
-			// loop preferredHealthyHosts (not preferredHosts) because we don't mind storing a blob a little while longer if it's not on enough healthy nodes
-			for _, host := range preferredHealthyHosts {
-				if ss.hostHasBlob(host, cid) {
-					depth++
-				}
-				if host == ss.Config.Self.Host {
-					break
-				}
-			}
-
-			// if i'm the first node that over-replicated, keep the file for a week as a buffer since a node ahead of me in the preferred order will likely be down temporarily at some point
-			wasReplicatedThisWeek := attrs.CreateTime.After(time.Now().Add(-24 * 7 * time.Hour))
-			if depth > ss.Config.ReplicationFactor+1 || depth == ss.Config.ReplicationFactor+1 && !wasReplicatedThisWeek {
-				logger.Info("deleting", "depth", depth, "hosts", preferredHosts, "healthyHosts", preferredHealthyHosts)
-				err = ss.dropFromMyBucket(cid)
-				if err != nil {
-					logger.Error("delete failed", "err", err)
-				} else {
-					logger.Info("delete OK")
-				}
-			}
-		}
-
-		// replicate under-replicated blobs:
-		// even tho this blob isn't "mine"
-		// in cleanup mode the top N*2 healthy nodes will check to see if it's under-replicated
-		// and pull file if under-replicated
-		if replicateMode && cleanupMode && !isMine && !alreadyHave && myRank >= 0 && myRank < ss.Config.ReplicationFactor*2 {
-			hasIt := []string{}
-			// loop preferredHosts (not preferredHealthyHosts) because hostHasBlob is the real source of truth for if a node can serve a blob (not our health info about the host, which could be outdated)
-			for _, host := range preferredHosts {
-				if ss.hostHasBlob(host, cid) {
-					if host == ss.Config.Self.Host {
-						continue
-					}
-					hasIt = append(hasIt, host)
-					if len(hasIt) == ss.Config.ReplicationFactor {
-						break
-					}
-				}
-			}
-
-			if len(hasIt) < ss.Config.ReplicationFactor {
-				// get it
-				success := false
-				for _, host := range hasIt {
-					err := ss.pullFileFromHost(host, cid)
-					if err != nil {
-						logger.Error("pull failed (under-replicated)", err, "host", host)
-					} else {
-						logger.Info("pull OK (under-replicated)", "host", host)
-						success = true
-						break
-					}
-				}
-				if !success {
-					logger.Warn("failed to pull from any host", "hosts", preferredHosts)
-				}
-			}
-		}
-	}
-
 	// scroll uploads and repair CIDs
+	// (later this can clean up "derivative" images if we make image resizing dynamic)
 	for uploadCursor := ""; ; {
 		var uploads []Upload
 		ss.crud.DB.Where("id > ?", uploadCursor).Limit(5000).Find(&uploads)
@@ -201,14 +63,14 @@ func (ss *MediorumServer) runRepair(replicateMode, cleanupMode bool) error {
 		}
 		for _, u := range uploads {
 			uploadCursor = u.ID
-			repairCid(u.OrigFileCID)
+			ss.repairCid(u.OrigFileCID, cleanupMode)
 			for key := range u.TranscodeResults {
-				repairCid(key)
+				ss.repairCid(key, cleanupMode)
 			}
 		}
 	}
 
-	// scroll qm_cids table and repair
+	// scroll older qm_cids table and repair
 	for cidCursor := ""; ; {
 		var cidBatch []string
 		err := pgxscan.Select(ctx, ss.pgPool, &cidBatch,
@@ -226,19 +88,139 @@ func (ss *MediorumServer) runRepair(replicateMode, cleanupMode bool) error {
 		}
 		for _, cid := range cidBatch {
 			cidCursor = cid
-			repairCid(cid)
+			ss.repairCid(cid, cleanupMode)
 		}
 	}
 
 	return nil
 }
 
-func clampDuration(min time.Duration, val time.Duration, max time.Duration) time.Duration {
-	if val < min {
-		return min
+func (ss *MediorumServer) repairCid(cid string, cleanupMode bool) error {
+	ctx := context.Background()
+	logger := ss.logger.With("task", "repair", "cid", cid, "cleanup", cleanupMode)
+
+	preferredHosts, isMine := ss.rendezvousAllHosts(cid)
+	preferredHealthyHosts, isMineHealthy := ss.rendezvousHealthyHosts(cid)
+
+	// use preferredHealthyHosts when determining my rank because we want to check if we're in the top N*2 healthy nodes not the top N*2 unhealthy nodes
+	myRank := slices.Index(preferredHealthyHosts, ss.Config.Self.Host)
+
+	key := cidutil.ShardCID(cid)
+	alreadyHave := true
+	attrs, err := ss.bucket.Attributes(ctx, key)
+	if err != nil {
+		if gcerrors.Code(err) == gcerrors.NotFound {
+			alreadyHave = false
+			attrs = &blob.Attributes{}
+		} else {
+			logger.Error("exist check failed", "err", err)
+			return err
+		}
 	}
-	if val > max {
-		return max
+
+	// in cleanup mode do some extra checks:
+	// - validate CID, delete if invalid (doesn't apply to Qm keys because their hash is not the CID)
+	if cleanupMode && alreadyHave && !cidutil.IsLegacyCID(cid) {
+		if r, err := ss.bucket.NewReader(ctx, key, nil); err == nil {
+			err := cidutil.ValidateCID(cid, r)
+			r.Close()
+			if err != nil {
+				logger.Error("deleting invalid CID", "err", err)
+				ss.bucket.Delete(ctx, key)
+				alreadyHave = false
+			}
+		}
 	}
-	return val
+
+	// get blobs that I should have (regardless of health of other nodes)
+	if isMine && !alreadyHave {
+		success := false
+		// loop preferredHosts (not preferredHealthyHosts) because pullFileFromHost can still give us a file even if we thought the host was unhealthy
+		for _, host := range preferredHosts {
+			if host == ss.Config.Self.Host {
+				continue
+			}
+			err := ss.pullFileFromHost(host, cid)
+			if err != nil {
+				logger.Error("pull failed (blob I should have)", "err", err, "host", host)
+			} else {
+				logger.Info("pull OK (blob I should have)", "host", host)
+				success = true
+				break
+			}
+		}
+		if !success {
+			logger.Warn("failed to pull from any host", "hosts", preferredHosts)
+		}
+	}
+
+	// delete over-replicated blobs:
+	// check all healthy nodes ahead of me in the preferred order to ensure they have it.
+	// if R+1 healthy nodes in front of me have it, I can safely delete.
+	// don't delete if we replicated the blob within the past 24 hours
+	wasReplicatedToday := attrs.CreateTime.After(time.Now().Add(-24 * time.Hour))
+	if cleanupMode && (!isMine || !isMineHealthy) && alreadyHave && !wasReplicatedToday {
+		depth := 0
+		// loop preferredHealthyHosts (not preferredHosts) because we don't mind storing a blob a little while longer if it's not on enough healthy nodes
+		for _, host := range preferredHealthyHosts {
+			if ss.hostHasBlob(host, cid) {
+				depth++
+			}
+			if host == ss.Config.Self.Host {
+				break
+			}
+		}
+
+		// if i'm the first node that over-replicated, keep the file for a week as a buffer since a node ahead of me in the preferred order will likely be down temporarily at some point
+		wasReplicatedThisWeek := attrs.CreateTime.After(time.Now().Add(-24 * 7 * time.Hour))
+		if depth > ss.Config.ReplicationFactor+1 || depth == ss.Config.ReplicationFactor+1 && !wasReplicatedThisWeek {
+			logger.Info("deleting", "depth", depth, "hosts", preferredHosts, "healthyHosts", preferredHealthyHosts)
+			err = ss.dropFromMyBucket(cid)
+			if err != nil {
+				logger.Error("delete failed", "err", err)
+			} else {
+				logger.Info("delete OK")
+			}
+		}
+	}
+
+	// replicate under-replicated blobs:
+	// even tho this blob isn't "mine"
+	// in cleanup mode the top N*2 healthy nodes will check to see if it's under-replicated
+	// and pull file if under-replicated
+	if cleanupMode && !isMine && !alreadyHave && myRank >= 0 && myRank < ss.Config.ReplicationFactor*2 {
+		hasIt := []string{}
+		// loop preferredHosts (not preferredHealthyHosts) because hostHasBlob is the real source of truth for if a node can serve a blob (not our health info about the host, which could be outdated)
+		for _, host := range preferredHosts {
+			if ss.hostHasBlob(host, cid) {
+				if host == ss.Config.Self.Host {
+					continue
+				}
+				hasIt = append(hasIt, host)
+				if len(hasIt) == ss.Config.ReplicationFactor {
+					break
+				}
+			}
+		}
+
+		if len(hasIt) < ss.Config.ReplicationFactor {
+			// get it
+			success := false
+			for _, host := range hasIt {
+				err := ss.pullFileFromHost(host, cid)
+				if err != nil {
+					logger.Error("pull failed (under-replicated)", err, "host", host)
+				} else {
+					logger.Info("pull OK (under-replicated)", "host", host)
+					success = true
+					break
+				}
+			}
+			if !success {
+				logger.Warn("failed to pull from any host", "hosts", preferredHosts)
+			}
+		}
+	}
+
+	return nil
 }

--- a/mediorum/server/repair.go
+++ b/mediorum/server/repair.go
@@ -2,7 +2,6 @@ package server
 
 import (
 	"context"
-	"fmt"
 	"math/rand"
 	"mediorum/cidutil"
 	"time"
@@ -19,6 +18,14 @@ func (ss *MediorumServer) startRepairer() {
 	time.Sleep(time.Minute*10 + time.Minute*time.Duration(rand.Intn(10)))
 
 	for i := 1; ; i++ {
+		// check that network is valid (should have more peers than replication factor)
+		if healthyPeers := ss.findHealthyPeers(5 * time.Minute); len(healthyPeers) < ss.Config.ReplicationFactor {
+			ss.logger.Warn("not enough healthy peers to run repair",
+				"R", ss.Config.ReplicationFactor,
+				"peers", len(healthyPeers))
+			continue
+		}
+
 		replicateMode := ss.shouldReplicate()
 		// 10% percent of time... clean up over-replicated and pull under-replicated
 		cleanupMode := false
@@ -58,82 +65,122 @@ func (ss *MediorumServer) runRepair(replicateMode, cleanupMode bool) error {
 
 	logger := ss.logger.With("task", "repair", "replicateMode", replicateMode, "cleanupMode", cleanupMode)
 
-	// check that network is valid (should have more peers than replication factor)
-	if healthyPeers := ss.findHealthyPeers(5 * time.Minute); len(healthyPeers) < ss.Config.ReplicationFactor {
-		return fmt.Errorf("invalid network: not enough healthy peers for R%d: %v", ss.Config.ReplicationFactor, healthyPeers)
-	}
+	repairCid := func(cid string) {
+		logger := logger.With("cid", cid)
 
-	cidCursor := ""
-	for {
-		// scroll over all extant CIDs in batches
-		// atm this uses `blobs` table for sake of repair_test.go
-		// but if we drop blobs, this could also read out CIDs from the upload records
-		var cidBatch []string
-		err := pgxscan.Select(ctx, ss.pgPool, &cidBatch,
-			`select distinct key
-			 from blobs
-			 where key > $1
-			 order by key
-			 limit 1000`, cidCursor)
+		preferredHosts, isMine := ss.rendezvousAllHosts(cid)
+		preferredHealthyHosts, isMineHealthy := ss.rendezvousHealthyHosts(cid)
 
+		// use preferredHealthyHosts when determining my rank because we want to check if we're in the top N*2 healthy nodes not the top N*2 unhealthy nodes
+		myRank := slices.Index(preferredHealthyHosts, ss.Config.Self.Host)
+
+		key := cidutil.ShardCID(cid)
+		alreadyHave := true
+		attrs, err := ss.bucket.Attributes(ctx, key)
 		if err != nil {
-			return err
+			if gcerrors.Code(err) == gcerrors.NotFound {
+				alreadyHave = false
+				attrs = &blob.Attributes{}
+			} else {
+				logger.Error("exist check failed", "err", err)
+				return
+			}
 		}
-		if len(cidBatch) == 0 {
-			break
-		}
 
-		for _, cid := range cidBatch {
-			cidCursor = cid
-
-			logger := logger.With("cid", cid)
-
-			preferredHosts, isMine := ss.rendezvousAllHosts(cid)
-			preferredHealthyHosts, isMineHealthy := ss.rendezvousHealthyHosts(cid)
-
-			// use preferredHealthyHosts when determining my rank because we want to check if we're in the top N*2 healthy nodes not the top N*2 unhealthy nodes
-			myRank := slices.Index(preferredHealthyHosts, ss.Config.Self.Host)
-
-			key := cidutil.ShardCID(cid)
-			alreadyHave := true
-			attrs, err := ss.bucket.Attributes(ctx, key)
-			if err != nil {
-				if gcerrors.Code(err) == gcerrors.NotFound {
+		// in cleanup mode do some extra checks:
+		// - validate CID, delete if invalid (doesn't apply to Qm keys because their hash is not the CID)
+		if cleanupMode && alreadyHave && !cidutil.IsLegacyCID(cid) {
+			if r, err := ss.bucket.NewReader(ctx, key, nil); err == nil {
+				err := cidutil.ValidateCID(cid, r)
+				r.Close()
+				if err != nil {
+					logger.Error("deleting invalid CID", "err", err)
+					ss.bucket.Delete(ctx, key)
 					alreadyHave = false
-					attrs = &blob.Attributes{}
-				} else {
-					logger.Error("exist check failed", "err", err)
+				}
+			}
+		}
+
+		// get blobs that I should have (regardless of health of other nodes)
+		if replicateMode && isMine && !alreadyHave {
+			success := false
+			// loop preferredHosts (not preferredHealthyHosts) because pullFileFromHost can still give us a file even if we thought the host was unhealthy
+			for _, host := range preferredHosts {
+				if host == ss.Config.Self.Host {
 					continue
 				}
+				err := ss.pullFileFromHost(host, cid)
+				if err != nil {
+					logger.Error("pull failed (blob I should have)", "err", err, "host", host)
+				} else {
+					logger.Info("pull OK (blob I should have)", "host", host)
+					success = true
+					break
+				}
 			}
+			if !success {
+				logger.Warn("failed to pull from any host", "hosts", preferredHosts)
+			}
+		}
 
-			// in cleanup mode do some extra checks:
-			// - validate CID, delete if invalid (doesn't apply to Qm keys because their hash is not the CID)
-			if cleanupMode && alreadyHave && !cidutil.IsLegacyCID(cid) {
-				if r, err := ss.bucket.NewReader(ctx, key, nil); err == nil {
-					err := cidutil.ValidateCID(cid, r)
-					r.Close()
-					if err != nil {
-						logger.Error("deleting invalid CID", "err", err)
-						ss.bucket.Delete(ctx, key)
-						alreadyHave = false
-					}
+		// delete over-replicated blobs:
+		// check all healthy nodes ahead of me in the preferred order to ensure they have it.
+		// if R+1 healthy nodes in front of me have it, I can safely delete.
+		// don't delete if we replicated the blob within the past 24 hours
+		wasReplicatedToday := attrs.CreateTime.After(time.Now().Add(-24 * time.Hour))
+		if cleanupMode && (!isMine || !isMineHealthy) && alreadyHave && !wasReplicatedToday {
+			depth := 0
+			// loop preferredHealthyHosts (not preferredHosts) because we don't mind storing a blob a little while longer if it's not on enough healthy nodes
+			for _, host := range preferredHealthyHosts {
+				if ss.hostHasBlob(host, cid) {
+					depth++
+				}
+				if host == ss.Config.Self.Host {
+					break
 				}
 			}
 
-			// get blobs that I should have (regardless of health of other nodes)
-			if replicateMode && isMine && !alreadyHave {
-				success := false
-				// loop preferredHosts (not preferredHealthyHosts) because pullFileFromHost can still give us a file even if we thought the host was unhealthy
-				for _, host := range preferredHosts {
+			// if i'm the first node that over-replicated, keep the file for a week as a buffer since a node ahead of me in the preferred order will likely be down temporarily at some point
+			wasReplicatedThisWeek := attrs.CreateTime.After(time.Now().Add(-24 * 7 * time.Hour))
+			if depth > ss.Config.ReplicationFactor+1 || depth == ss.Config.ReplicationFactor+1 && !wasReplicatedThisWeek {
+				logger.Info("deleting", "depth", depth, "hosts", preferredHosts, "healthyHosts", preferredHealthyHosts)
+				err = ss.dropFromMyBucket(cid)
+				if err != nil {
+					logger.Error("delete failed", "err", err)
+				} else {
+					logger.Info("delete OK")
+				}
+			}
+		}
+
+		// replicate under-replicated blobs:
+		// even tho this blob isn't "mine"
+		// in cleanup mode the top N*2 healthy nodes will check to see if it's under-replicated
+		// and pull file if under-replicated
+		if replicateMode && cleanupMode && !isMine && !alreadyHave && myRank >= 0 && myRank < ss.Config.ReplicationFactor*2 {
+			hasIt := []string{}
+			// loop preferredHosts (not preferredHealthyHosts) because hostHasBlob is the real source of truth for if a node can serve a blob (not our health info about the host, which could be outdated)
+			for _, host := range preferredHosts {
+				if ss.hostHasBlob(host, cid) {
 					if host == ss.Config.Self.Host {
 						continue
 					}
+					hasIt = append(hasIt, host)
+					if len(hasIt) == ss.Config.ReplicationFactor {
+						break
+					}
+				}
+			}
+
+			if len(hasIt) < ss.Config.ReplicationFactor {
+				// get it
+				success := false
+				for _, host := range hasIt {
 					err := ss.pullFileFromHost(host, cid)
 					if err != nil {
-						logger.Error("pull failed (blob I should have)", "err", err, "host", host)
+						logger.Error("pull failed (under-replicated)", err, "host", host)
 					} else {
-						logger.Info("pull OK (blob I should have)", "host", host)
+						logger.Info("pull OK (under-replicated)", "host", host)
 						success = true
 						break
 					}
@@ -142,74 +189,44 @@ func (ss *MediorumServer) runRepair(replicateMode, cleanupMode bool) error {
 					logger.Warn("failed to pull from any host", "hosts", preferredHosts)
 				}
 			}
+		}
+	}
 
-			// delete over-replicated blobs:
-			// check all healthy nodes ahead of me in the preferred order to ensure they have it.
-			// if R+1 healthy nodes in front of me have it, I can safely delete.
-			// don't delete if we replicated the blob within the past 24 hours
-			wasReplicatedToday := attrs.CreateTime.After(time.Now().Add(-24 * time.Hour))
-			if cleanupMode && (!isMine || !isMineHealthy) && alreadyHave && !wasReplicatedToday {
-				depth := 0
-				// loop preferredHealthyHosts (not preferredHosts) because we don't mind storing a blob a little while longer if it's not on enough healthy nodes
-				for _, host := range preferredHealthyHosts {
-					if ss.hostHasBlob(host, cid) {
-						depth++
-					}
-					if host == ss.Config.Self.Host {
-						break
-					}
-				}
-
-				// if i'm the first node that over-replicated, keep the file for a week as a buffer since a node ahead of me in the preferred order will likely be down temporarily at some point
-				wasReplicatedThisWeek := attrs.CreateTime.After(time.Now().Add(-24 * 7 * time.Hour))
-				if depth > ss.Config.ReplicationFactor+1 || depth == ss.Config.ReplicationFactor+1 && !wasReplicatedThisWeek {
-					logger.Info("deleting", "depth", depth, "hosts", preferredHosts, "healthyHosts", preferredHealthyHosts)
-					err = ss.dropFromMyBucket(cid)
-					if err != nil {
-						logger.Error("delete failed", "err", err)
-					} else {
-						logger.Info("delete OK")
-					}
-				}
+	// scroll uploads and repair CIDs
+	for uploadCursor := ""; ; {
+		var uploads []Upload
+		ss.crud.DB.Where("id > ?", uploadCursor).Limit(5000).Find(&uploads)
+		if len(uploads) == 0 {
+			break
+		}
+		for _, u := range uploads {
+			uploadCursor = u.ID
+			repairCid(u.OrigFileCID)
+			for key := range u.TranscodeResults {
+				repairCid(key)
 			}
+		}
+	}
 
-			// replicate under-replicated blobs:
-			// even tho this blob isn't "mine"
-			// in cleanup mode the top N*2 healthy nodes will check to see if it's under-replicated
-			// and pull file if under-replicated
-			if replicateMode && cleanupMode && !isMine && !alreadyHave && myRank >= 0 && myRank < ss.Config.ReplicationFactor*2 {
-				hasIt := []string{}
-				// loop preferredHosts (not preferredHealthyHosts) because hostHasBlob is the real source of truth for if a node can serve a blob (not our health info about the host, which could be outdated)
-				for _, host := range preferredHosts {
-					if ss.hostHasBlob(host, cid) {
-						if host == ss.Config.Self.Host {
-							continue
-						}
-						hasIt = append(hasIt, host)
-						if len(hasIt) == ss.Config.ReplicationFactor {
-							break
-						}
-					}
-				}
+	// scroll qm_cids table and repair
+	for cidCursor := ""; ; {
+		var cidBatch []string
+		err := pgxscan.Select(ctx, ss.pgPool, &cidBatch,
+			`select key
+			 from qm_cids
+			 where key > $1
+			 order by key
+			 limit 5000`, cidCursor)
 
-				if len(hasIt) < ss.Config.ReplicationFactor {
-					// get it
-					success := false
-					for _, host := range hasIt {
-						err := ss.pullFileFromHost(host, cid)
-						if err != nil {
-							logger.Error("pull failed (under-replicated)", err, "host", host)
-						} else {
-							logger.Info("pull OK (under-replicated)", "host", host)
-							success = true
-							break
-						}
-					}
-					if !success {
-						logger.Warn("failed to pull from any host", "hosts", preferredHosts)
-					}
-				}
-			}
+		if err != nil {
+			return err
+		}
+		if len(cidBatch) == 0 {
+			break
+		}
+		for _, cid := range cidBatch {
+			cidCursor = cid
+			repairCid(cid)
 		}
 	}
 

--- a/mediorum/server/repair_test.go
+++ b/mediorum/server/repair_test.go
@@ -48,6 +48,12 @@ func TestRepair(t *testing.T) {
 	err = ss.replicateToMyBucket(cid, bytes.NewReader(data))
 	assert.NoError(t, err)
 
+	// create a dummy upload for it?
+	ss.crud.Create(Upload{
+		ID:          "testing",
+		OrigFileCID: cid,
+	})
+
 	// force sweep (since blob changes SkipBroadcast)
 	for _, s := range testNetwork {
 		s.crud.ForceSweep()

--- a/mediorum/server/repair_test.go
+++ b/mediorum/server/repair_test.go
@@ -19,7 +19,7 @@ func TestRepair(t *testing.T) {
 		for _, s := range testNetwork {
 			s := s
 			go func() {
-				err := s.runRepair(true, cleanup)
+				err := s.runRepair(cleanup)
 				assert.NoError(t, err)
 				wg.Done()
 			}()
@@ -117,22 +117,22 @@ func TestRepair(t *testing.T) {
 
 		// normally a standby server wouldn't pull this file
 		standby := rendezvousOrder[replicationFactor+2]
-		err = standby.runRepair(true, false)
+		err = standby.runRepair(false)
 		assert.NoError(t, err)
 		assert.False(t, standby.hostHasBlob(standby.Config.Self.Host, cid))
 
 		// running repair in cleanup mode... standby will observe that #1 doesn't have blob so will pull it
-		err = standby.runRepair(true, true)
+		err = standby.runRepair(true)
 		assert.NoError(t, err)
 		assert.True(t, standby.hostHasBlob(standby.Config.Self.Host, cid))
 
 		// leader re-gets lost file when repair runs
-		err = leader.runRepair(true, false)
+		err = leader.runRepair(false)
 		assert.NoError(t, err)
 		assert.True(t, leader.hostHasBlob(leader.Config.Self.Host, cid))
 
 		// standby drops file after leader has it back
-		err = standby.runRepair(true, true)
+		err = standby.runRepair(true)
 		assert.NoError(t, err)
 		assert.False(t, standby.hostHasBlob(standby.Config.Self.Host, cid))
 	}

--- a/mediorum/server/replicate.go
+++ b/mediorum/server/replicate.go
@@ -222,7 +222,7 @@ func (ss *MediorumServer) pullFileFromHost(host, cid string) error {
 }
 
 // if the node is using local (disk) storage, do not replicate if there is <200GB remaining (i.e. 10% of 2TB)
-func (ss *MediorumServer) shouldReplicate() bool {
+func (ss *MediorumServer) diskHasSpace() bool {
 	// don't worry about running out of space on dev or stage
 	if ss.Config.Env != "prod" {
 		return true

--- a/mediorum/server/serve_blob.go
+++ b/mediorum/server/serve_blob.go
@@ -22,12 +22,9 @@ import (
 
 func (ss *MediorumServer) getBlobLocation(c echo.Context) error {
 	cid := c.Param("cid")
-	locations := []Blob{}
-	ss.crud.DB.Where(Blob{Key: cid}).Find(&locations)
 	preferred, _ := ss.rendezvousAllHosts(cid)
 	return c.JSON(200, map[string]any{
 		"cid":       cid,
-		"locations": locations,
 		"preferred": preferred,
 	})
 }

--- a/mediorum/server/serve_blob.go
+++ b/mediorum/server/serve_blob.go
@@ -324,7 +324,7 @@ func (ss *MediorumServer) serveInternalBlobPull(c echo.Context) error {
 }
 
 func (ss *MediorumServer) postBlob(c echo.Context) error {
-	if !ss.shouldReplicate() {
+	if !ss.diskHasSpace() {
 		return c.String(http.StatusServiceUnavailable, "disk is too full to accept new blobs")
 	}
 

--- a/mediorum/server/serve_crud.go
+++ b/mediorum/server/serve_crud.go
@@ -13,7 +13,7 @@ func (ss *MediorumServer) serveCrudSweep(c echo.Context) error {
 	after := c.QueryParam("after")
 	var ops []*crudr.Op
 	ss.crud.DB.
-		Where("host = ? AND ulid > ?", ss.Config.Self.Host, after).
+		Where("ulid > ?", after).
 		Limit(PullLimit).
 		Order("ulid asc").
 		Find(&ops)

--- a/mediorum/server/serve_upload.go
+++ b/mediorum/server/serve_upload.go
@@ -154,7 +154,7 @@ type UpdateUploadBody struct {
 }
 
 func (ss *MediorumServer) updateUpload(c echo.Context) error {
-	if !ss.shouldReplicate() {
+	if !ss.diskHasSpace() {
 		return c.String(http.StatusServiceUnavailable, "disk is too full to accept new uploads")
 	}
 
@@ -215,7 +215,7 @@ func (ss *MediorumServer) updateUpload(c echo.Context) error {
 }
 
 func (ss *MediorumServer) postUpload(c echo.Context) error {
-	if !ss.shouldReplicate() {
+	if !ss.diskHasSpace() {
 		return c.String(http.StatusServiceUnavailable, "disk is too full to accept new uploads")
 	}
 


### PR DESCRIPTION
### Description

* removes `blobs` table + crudr events.
* create `qm_cids` table with unique full list of historical Qm CIDs (from blobs table)
* repair.go runs in two phases:
  * scrolls over all Uploads repairs orig CID and derivative CIDs
  * scrolls over `qm_cids` and repairs historical records
* makes crudr `ops` gossip style similar to DMs
* resets crudr cursor to backfill any missing Upload records from nodes without route between them.

### How Has This Been Tested?

todo: deploy to single staging node to double check works with other servers running `main`
