### PR TITLE
comms dev mode: no peers, always healthy

### DIFF
--- a/comms/discovery/config/config.go
+++ b/comms/discovery/config/config.go
@@ -18,6 +18,7 @@ type DiscoveryConfig struct {
 	MyWallet           string
 	MyPrivateKey       *ecdsa.PrivateKey `json:"-"`
 	IsStaging          bool
+	IsDev              bool
 	IsRegisteredWallet bool
 
 	mu    sync.RWMutex
@@ -42,6 +43,7 @@ func Parse() *DiscoveryConfig {
 
 	c.MyHost = misc.TrimTrailingSlash(os.Getenv("audius_discprov_url"))
 	c.IsStaging = os.Getenv("AUDIUS_IS_STAGING") == "true"
+	c.IsDev = os.Getenv("comms_dev_mode") == "true"
 
 	pk, err := parsePrivateKey(os.Getenv("audius_delegate_private_key"))
 	if err != nil {

--- a/comms/discovery/discovery_main.go
+++ b/comms/discovery/discovery_main.go
@@ -88,6 +88,11 @@ func backgroundRefreshRegisteredPeers(discoveryConfig *config.DiscoveryConfig) {
 }
 
 func refreshRegisteredPeers(discoveryConfig *config.DiscoveryConfig) error {
+	if discoveryConfig.IsDev {
+		discoveryConfig.IsRegisteredWallet = true
+		return nil
+	}
+
 	peers, err := the_graph.Query(discoveryConfig.IsStaging, false)
 	if err != nil {
 		return err

--- a/comms/discovery/server/server.go
+++ b/comms/discovery/server/server.go
@@ -118,6 +118,9 @@ func (s *ChatServer) getStatus(c echo.Context) error {
 }
 
 func (s *ChatServer) isHealthy() bool {
+	if s.config.IsDev {
+		return true
+	}
 	return s.config.IsRegisteredWallet && s.websocketError == nil
 }
 

--- a/dev-tools/compose/docker-compose.discovery.yml
+++ b/dev-tools/compose/docker-compose.discovery.yml
@@ -35,6 +35,7 @@ services:
     command: discovery
     restart: unless-stopped
     environment:
+      comms_dev_mode: true
       audius_delegate_private_key: "c82ad757622db5a148089e0a8fc1741cefa8677ab56a2ac9e38dac905c5ad7c7"
       audius_db_url: "postgresql://postgres:postgres@db:5432/discovery_provider_1"
     depends_on:


### PR DESCRIPTION
Prior to this PR, comms showed as unhealthy on the discovery health check endpoint. This would cause SDK to fail to select a discovery node. This change simply adds an environment variable that will force the comms server to show as healthy when in dev mode to make development easier, bypassing registration checks etc.