### PR TITLE
Add caddy Dockerfile

### DIFF
--- a/caddy/Dockerfile
+++ b/caddy/Dockerfile
@@ -1,0 +1,8 @@
+FROM caddy:2.7.4-builder AS builder
+
+RUN xcaddy build \
+  --with github.com/caddyserver/cache-handler
+
+FROM caddy:2.7.4
+
+COPY --from=builder /usr/bin/caddy /usr/bin/caddy

--- a/caddy/README.md
+++ b/caddy/README.md
@@ -1,0 +1,11 @@
+# Audius Caddy Container
+
+To build and push a new image for both arm64 and amd64:
+
+```bash
+docker buildx build \
+  --platform linux/arm64,linux/amd64 \
+  --tag audius/caddy:$(head -n1 Dockerfile | cut -f 2 -d ':' | cut -d '-' -f 1) \
+  --push \
+  .
+```


### PR DESCRIPTION
### Description

Add http cache module to caddy and build custom image for use in `audius-docker-compose`

https://github.com/AudiusProject/audius-docker-compose/compare/rj-caddy-cache?expand=1

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._

README steps

```
docker buildx build \
  --platform linux/arm64,linux/amd64 \
  --tag audius/caddy:$(head -n1 Dockerfile | cut -f 2 -d ':' | cut -d '-' -f 1) \
  --push \
  .
```

https://hub.docker.com/repository/docker/audius/caddy/general
