### PR TITLE
Bump python version patch to fix audius-compose build

### DIFF
--- a/discovery-provider/Dockerfile
+++ b/discovery-provider/Dockerfile
@@ -24,8 +24,8 @@ RUN apk update && \
         linux-headers \
         nodejs \
         npm \
-        python3=3.11.4-r0 \
-        python3-dev=3.11.4-r0 \
+        python3=3.11.5-r0 \
+        python3-dev=3.11.5-r0 \
         py3-numpy \
         py3-pip \
         py3-scipy \


### PR DESCRIPTION
### Description

Running `audius-compose build` fails because the apk installation specifies python 3.11.4, which introduces an incompatible "world" python package.

### How Has This Been Tested?

Output of `audius-compose build` before fix:

```
 => ERROR [discovery-provider stage-1  5/17] RUN apk update &&     apk add --no-cache         alpine-sdk         bash         cu  1.6s
------
 > [discovery-provider stage-1  5/17] RUN apk update &&     apk add --no-cache         alpine-sdk         bash         curl         docker         libffi-dev         libseccomp-dev         libxml2-dev         libxslt-dev         linux-headers         nodejs         npm         python3=3.11.4-r0         python3-dev=3.11.4-r0         py3-numpy         py3-pip         py3-scipy         py3-wheel         redis         rsyslog         sudo         gcc         musl-dev         gfortran         openblas-dev:
0.159 fetch https://dl-cdn.alpinelinux.org/alpine/v3.18/main/aarch64/APKINDEX.tar.gz
0.536 fetch https://dl-cdn.alpinelinux.org/alpine/v3.18/community/aarch64/APKINDEX.tar.gz
0.793 v3.18.3-154-g9fca9473248 [https://dl-cdn.alpinelinux.org/alpine/v3.18/main]
0.793 v3.18.3-155-g0152ad397a8 [https://dl-cdn.alpinelinux.org/alpine/v3.18/community]
0.793 OK: 19939 distinct packages available
0.816 fetch https://dl-cdn.alpinelinux.org/alpine/v3.18/main/aarch64/APKINDEX.tar.gz
1.195 fetch https://dl-cdn.alpinelinux.org/alpine/v3.18/community/aarch64/APKINDEX.tar.gz
1.424 ERROR: unable to select packages:
1.424   python3-3.11.5-r0:
1.424     breaks: world[python3=3.11.4-r0]
1.424     satisfies: py3-charset-normalizer-3.1.0-r1[python3]
1.424                py3-charset-normalizer-3.1.0-r1[python3~3.11]
1.424                py3-certifi-pyc-2023.5.7-r0[python3]

...

1.424   python3-dev-3.11.5-r0:
1.424     breaks: world[python3-dev=3.11.4-r0]
1.424     satisfies: py3-numpy-f2py-1.24.4-r0[python3-dev]
------
failed to solve: process "/bin/sh -c apk update &&     apk add --no-cache         alpine-sdk         bash         curl         docker         libffi-dev         libseccomp-dev         libxml2-dev         libxslt-dev         linux-headers         nodejs         npm         python3=3.11.4-r0         python3-dev=3.11.4-r0         py3-numpy         py3-pip         py3-scipy         py3-wheel         redis
        rsyslog         sudo         gcc         musl-dev         gfortran         openblas-dev" did not complete successfully: exit code: 24
Error: Failed to build images
```


`audius-compose build` succeeds after the change.