### PR TITLE
[PAY-1813] Add metadata to USDC transaction history table

### DIFF
--- a/discovery-provider/ddl/migrations/0029_usdc_transactions_metadata.sql
+++ b/discovery-provider/ddl/migrations/0029_usdc_transactions_metadata.sql
@@ -1,0 +1,4 @@
+ALTER TABLE
+    usdc_transactions_history
+ADD
+    COLUMN IF NOT EXISTS tx_metadata CHARACTER VARYING;

--- a/discovery-provider/src/api/v1/helpers.py
+++ b/discovery-provider/src/api/v1/helpers.py
@@ -419,7 +419,7 @@ def extend_transaction_details(transaction_details):
     new_transaction_details["transaction_date"] = transaction_details[
         "transaction_created_at"
     ]
-    if "metadata" in new_transaction_details:
+    if "tx_metadata" in transaction_details:
         new_transaction_details["metadata"] = str(transaction_details["tx_metadata"])
     return new_transaction_details
 

--- a/discovery-provider/src/models/users/usdc_transactions_history.py
+++ b/discovery-provider/src/models/users/usdc_transactions_history.py
@@ -34,3 +34,4 @@ class USDCTransactionsHistory(Base, RepresentableMixin):
     transaction_created_at = Column(DateTime, nullable=False)
     change = Column(Numeric, nullable=False)
     balance = Column(Numeric, nullable=False)
+    tx_metadata = Column(String, nullable=True)

--- a/discovery-provider/src/tasks/index_user_bank.py
+++ b/discovery-provider/src/tasks/index_user_bank.py
@@ -368,6 +368,7 @@ def index_purchase(
         transaction_created_at=timestamp,
         change=Decimal(balance_changes[sender_account]["change"]),
         balance=Decimal(balance_changes[sender_account]["post_balance"]),
+        tx_metadata=str(receiver_user_id),
     )
     logger.debug(
         f"index_user_bank.py | Creating usdc_tx_history send tx for purchase {usdc_tx_sent}"
@@ -382,6 +383,7 @@ def index_purchase(
         transaction_created_at=timestamp,
         change=Decimal(balance_changes[receiver_account]["change"]),
         balance=Decimal(balance_changes[receiver_account]["post_balance"]),
+        tx_metadata=str(sender_user_id),
     )
     session.add(usdc_tx_received)
     logger.debug(
@@ -430,6 +432,7 @@ def validate_and_index_purchase(
             transaction_created_at=timestamp,
             change=Decimal(balance_changes[sender_account]["change"]),
             balance=Decimal(balance_changes[sender_account]["post_balance"]),
+            tx_metadata=receiver_account,
         )
         logger.debug(f"index_user_bank.py | Creating transfer sent tx {usdc_tx_sent}")
         session.add(usdc_tx_sent)
@@ -442,6 +445,7 @@ def validate_and_index_purchase(
             transaction_created_at=timestamp,
             change=Decimal(balance_changes[receiver_account]["change"]),
             balance=Decimal(balance_changes[receiver_account]["post_balance"]),
+            tx_metadata=sender_account,
         )
         session.add(usdc_tx_received)
         logger.debug(
@@ -603,9 +607,8 @@ def process_transfer_instruction(
             transaction_created_at=timestamp,
             change=Decimal(balance_changes[sender_account]["change"]),
             balance=Decimal(balance_changes[sender_account]["post_balance"]),
+            tx_metadata=str(receiver_account),
         )
-        if isinstance(transfer_sent, AudioTransactionsHistory):
-            transfer_sent.tx_metadata = receiver_account
         logger.debug(f"index_user_bank.py | Creating transfer sent {transfer_sent}")
     # If there are two userbanks to update, it was a transfer from user to user
     else:


### PR DESCRIPTION
### Description

Originally when designing the schema for these tables, there was no withdrawals table. Despite planning for one anyway, we still left out the tx metadata as we figured the address only showed up in the modal for $AUDIO tx history, in which case we could load the recipient address via looking up the tx on the Solana RPC instead.

However, the new table has the recipient address in the table row, so it became more efficient and also easier to just have the data in our SQL table instead.

### How Has This Been Tested?

Tested purchases show up correctly. Need to test transfers but there's not a real easy way to do that without running client. Going to merge and test on stage?