### PR TITLE
[PAY-1796] Fix reposted/saved albums not showing in library

### DIFF
--- a/dev-tools/commands/src/auth-headers.mjs
+++ b/dev-tools/commands/src/auth-headers.mjs
@@ -8,9 +8,9 @@ program
   .description(
     "Output auth headers (for use with curl: `curl -H @<(audius-cmd auth-headers)`)"
   )
-  .option("[account]", "The account to for which to generate auth headers")
-  .action(async ({ account }) => {
-    const audiusLibs = await initializeAudiusLibs(account);
+  .option("-f, --from [from]", "The account for which to generate auth headers")
+  .action(async ({ from }) => {
+    const audiusLibs = await initializeAudiusLibs(from);
 
     try {
       const unixTimestamp = Math.round(new Date().getTime() / 1000);

--- a/discovery-provider/src/queries/get_collection_library.py
+++ b/discovery-provider/src/queries/get_collection_library.py
@@ -90,7 +90,8 @@ def _get_collection_library(args: GetCollectionLibraryArgs, session):
         Save.user_id == user_id,
         Save.is_current == True,
         Save.is_delete == False,
-        Save.save_type == SaveType[collection_type],
+        # Both albums and playlists have SaveType.playlist at the moment, will filter albums with the join as necessary
+        or_(Save.save_type == SaveType.playlist, Save.save_type == SaveType.album),
     )
 
     reposts_base = session.query(
@@ -100,7 +101,11 @@ def _get_collection_library(args: GetCollectionLibraryArgs, session):
         Repost.user_id == user_id,
         Repost.is_current == True,
         Repost.is_delete == False,
-        Repost.repost_type == RepostType[collection_type],
+        # Both albums and playlists have RepostType.playlist at the moment, will filter albums with the join as necessary
+        or_(
+            Repost.repost_type == RepostType.playlist,
+            Repost.repost_type == RepostType.album,
+        ),
     )
 
     # Union everything for the "all" query


### PR DESCRIPTION
### Description

Due to the way saves/reposts are stored for albums as `RepostType.playlist` or `SaveType.playlist`, they were getting filtered out from the library queries.

@isaacsolo I seem to remember you came across this recently as well? Is the savetype/reposttype album ever used?

### How Has This Been Tested?

Tested by using `audius-cmd` to create users and upload tracks etc, and then also running client against dev to upload an album and saving/reposting that. Then double checked the output after pasting headers into the "Try it out!" autogen'd thing on Discovery which was mighty convenient