### PR TITLE
Add expected content size to healthz

### DIFF
--- a/mediorum/server/serve_health.go
+++ b/mediorum/server/serve_health.go
@@ -37,6 +37,7 @@ type healthCheckResponseData struct {
 	MediorumPathSize          uint64                     `json:"mediorumPathSize"` // bytes
 	DatabaseSize              uint64                     `json:"databaseSize"`     // bytes
 	DbSizeErr                 string                     `json:"dbSizeErr"`
+	BytesShouldStore          int64                      `json:"bytesShouldStore"`
 	UploadsCount              int64                      `json:"uploadsCount"`
 	UploadsCountErr           string                     `json:"uploadsCountErr"`
 	AutoUpgradeEnabled        bool                       `json:"autoUpgradeEnabled"`
@@ -102,6 +103,7 @@ func (ss *MediorumServer) serveHealthCheck(c echo.Context) error {
 		MediorumPathSize:          ss.mediorumPathSize,
 		DatabaseSize:              ss.databaseSize,
 		DbSizeErr:                 ss.dbSizeErr,
+		BytesShouldStore:          ss.bytesShouldStore,
 		UploadsCount:              ss.uploadsCount,
 		UploadsCountErr:           ss.uploadsCountErr,
 		AutoUpgradeEnabled:        ss.Config.AutoUpgradeEnabled,

--- a/mediorum/server/serve_health.go
+++ b/mediorum/server/serve_health.go
@@ -37,7 +37,7 @@ type healthCheckResponseData struct {
 	MediorumPathSize          uint64                     `json:"mediorumPathSize"` // bytes
 	DatabaseSize              uint64                     `json:"databaseSize"`     // bytes
 	DbSizeErr                 string                     `json:"dbSizeErr"`
-	BytesShouldStore          int64                      `json:"bytesShouldStore"`
+	ExpectedContentSize       int64                      `json:"expectedContentSize"`
 	UploadsCount              int64                      `json:"uploadsCount"`
 	UploadsCountErr           string                     `json:"uploadsCountErr"`
 	AutoUpgradeEnabled        bool                       `json:"autoUpgradeEnabled"`
@@ -103,7 +103,7 @@ func (ss *MediorumServer) serveHealthCheck(c echo.Context) error {
 		MediorumPathSize:          ss.mediorumPathSize,
 		DatabaseSize:              ss.databaseSize,
 		DbSizeErr:                 ss.dbSizeErr,
-		BytesShouldStore:          ss.bytesShouldStore,
+		ExpectedContentSize:       ss.expectedContentSize,
 		UploadsCount:              ss.uploadsCount,
 		UploadsCountErr:           ss.uploadsCountErr,
 		AutoUpgradeEnabled:        ss.Config.AutoUpgradeEnabled,

--- a/mediorum/server/serve_health_test.go
+++ b/mediorum/server/serve_health_test.go
@@ -25,7 +25,7 @@ func TestHealthCheck(t *testing.T) {
 		MediorumPathUsed:    88888,
 		MediorumPathSize:    888888888,
 		DatabaseSize:        99999,
-		BytesShouldStore:    777777,
+		ExpectedContentSize: 777777,
 		AutoUpgradeEnabled:  true,
 
 		StartedAt:         time,
@@ -40,7 +40,7 @@ func TestHealthCheck(t *testing.T) {
 		TrustedNotifierID: 1,
 	}
 
-	expected := `{"audiusDockerCompose":"123456","autoUpgradeEnabled":true,"blobStorePrefix":"file","builtAt":"","databaseSize":99999,"dbSizeErr":"","bytesShouldStore":777777,"dir":"/dir","env":"DEV","git":"123456","healthy":true,"isSeeding":false,"lastRepairCleanTookMins":0,"lastRepairCleanupTime":"0001-01-01T00:00:00Z","listenPort":"1991","mediorumPathSize":888888888,"mediorumPathUsed":88888,"moveFromBlobStorePrefix":"","peerHealths":null,"replicationFactor":3,"self":{"host":"test1.com","wallet":"0xtest1"},"service":"content-node","signers":[{"host":"test2.com","wallet":"0xtest2"}],"spID":1,"spOwnerWallet":"0xtest1","startedAt":"2023-06-07T08:25:30Z","storagePathSize":999999999,"storagePathUsed":99999,"storeAll":false,"trustedNotifier":{"email":"dmca@notifier.com","endpoint":"http://notifier.com","wallet":"0xnotifier"},"trustedNotifierId":1,"unreachablePeers":null,"uploadsCount":0,"uploadsCountErr":"","version":"1.0.0","wallet_is_registered":false}`
+	expected := `{"audiusDockerCompose":"123456","autoUpgradeEnabled":true,"blobStorePrefix":"file","builtAt":"","databaseSize":99999,"dbSizeErr":"","expectedContentSize":777777,"dir":"/dir","env":"DEV","git":"123456","healthy":true,"isSeeding":false,"lastRepairCleanTookMins":0,"lastRepairCleanupTime":"0001-01-01T00:00:00Z","listenPort":"1991","mediorumPathSize":888888888,"mediorumPathUsed":88888,"moveFromBlobStorePrefix":"","peerHealths":null,"replicationFactor":3,"self":{"host":"test1.com","wallet":"0xtest1"},"service":"content-node","signers":[{"host":"test2.com","wallet":"0xtest2"}],"spID":1,"spOwnerWallet":"0xtest1","startedAt":"2023-06-07T08:25:30Z","storagePathSize":999999999,"storagePathUsed":99999,"storeAll":false,"trustedNotifier":{"email":"dmca@notifier.com","endpoint":"http://notifier.com","wallet":"0xnotifier"},"trustedNotifierId":1,"unreachablePeers":null,"uploadsCount":0,"uploadsCountErr":"","version":"1.0.0","wallet_is_registered":false}`
 	dataBytes, err := json.Marshal(data)
 	if err != nil {
 		t.Error(err)

--- a/mediorum/server/serve_health_test.go
+++ b/mediorum/server/serve_health_test.go
@@ -25,6 +25,7 @@ func TestHealthCheck(t *testing.T) {
 		MediorumPathUsed:    88888,
 		MediorumPathSize:    888888888,
 		DatabaseSize:        99999,
+		BytesShouldStore:    777777,
 		AutoUpgradeEnabled:  true,
 
 		StartedAt:         time,
@@ -39,7 +40,7 @@ func TestHealthCheck(t *testing.T) {
 		TrustedNotifierID: 1,
 	}
 
-	expected := `{"audiusDockerCompose":"123456","autoUpgradeEnabled":true,"blobStorePrefix":"file","builtAt":"","databaseSize":99999,"dbSizeErr":"","dir":"/dir","env":"DEV","git":"123456","healthy":true,"isSeeding":false,"lastRepairCleanTookMins":0,"lastRepairCleanupTime":"0001-01-01T00:00:00Z","listenPort":"1991","mediorumPathSize":888888888,"mediorumPathUsed":88888,"moveFromBlobStorePrefix":"","peerHealths":null,"replicationFactor":3,"self":{"host":"test1.com","wallet":"0xtest1"},"service":"content-node","signers":[{"host":"test2.com","wallet":"0xtest2"}],"spID":1,"spOwnerWallet":"0xtest1","startedAt":"2023-06-07T08:25:30Z","storagePathSize":999999999,"storagePathUsed":99999,"storeAll":false,"trustedNotifier":{"email":"dmca@notifier.com","endpoint":"http://notifier.com","wallet":"0xnotifier"},"trustedNotifierId":1,"unreachablePeers":null,"uploadsCount":0,"uploadsCountErr":"","version":"1.0.0","wallet_is_registered":false}`
+	expected := `{"audiusDockerCompose":"123456","autoUpgradeEnabled":true,"blobStorePrefix":"file","builtAt":"","databaseSize":99999,"dbSizeErr":"","bytesShouldStore":777777,"dir":"/dir","env":"DEV","git":"123456","healthy":true,"isSeeding":false,"lastRepairCleanTookMins":0,"lastRepairCleanupTime":"0001-01-01T00:00:00Z","listenPort":"1991","mediorumPathSize":888888888,"mediorumPathUsed":88888,"moveFromBlobStorePrefix":"","peerHealths":null,"replicationFactor":3,"self":{"host":"test1.com","wallet":"0xtest1"},"service":"content-node","signers":[{"host":"test2.com","wallet":"0xtest2"}],"spID":1,"spOwnerWallet":"0xtest1","startedAt":"2023-06-07T08:25:30Z","storagePathSize":999999999,"storagePathUsed":99999,"storeAll":false,"trustedNotifier":{"email":"dmca@notifier.com","endpoint":"http://notifier.com","wallet":"0xnotifier"},"trustedNotifierId":1,"unreachablePeers":null,"uploadsCount":0,"uploadsCountErr":"","version":"1.0.0","wallet_is_registered":false}`
 	dataBytes, err := json.Marshal(data)
 	if err != nil {
 		t.Error(err)

--- a/mediorum/server/server.go
+++ b/mediorum/server/server.go
@@ -91,9 +91,9 @@ type MediorumServer struct {
 	mediorumPathSize uint64
 	mediorumPathFree uint64
 
-	databaseSize     uint64
-	dbSizeErr        string
-	bytesShouldStore int64
+	databaseSize        uint64
+	dbSizeErr           string
+	expectedContentSize int64
 
 	uploadsCount    int64
 	uploadsCountErr string

--- a/mediorum/server/server.go
+++ b/mediorum/server/server.go
@@ -91,8 +91,9 @@ type MediorumServer struct {
 	mediorumPathSize uint64
 	mediorumPathFree uint64
 
-	databaseSize uint64
-	dbSizeErr    string
+	databaseSize     uint64
+	dbSizeErr        string
+	bytesShouldStore int64
 
 	uploadsCount    int64
 	uploadsCountErr string

--- a/monitoring/healthz/src/DiscoveryHealth.tsx
+++ b/monitoring/healthz/src/DiscoveryHealth.tsx
@@ -34,7 +34,7 @@ export function DiscoveryHealth() {
             {isDiscovery && <th>Storage</th>}
             {isContent && <th>Storage (legacy)</th>}
             {isContent && <th>Storage (mediorum)</th>}
-            {isContent && <th>Expected content storage (from repair.go)</th>}
+            {isContent && <th>Expected Content Size (from repair.go)</th>}
             <th>DB Size</th>
             <th>Your IP</th>
             {isDiscovery && <th>ACDC Health</th>}

--- a/monitoring/healthz/src/DiscoveryHealth.tsx
+++ b/monitoring/healthz/src/DiscoveryHealth.tsx
@@ -139,7 +139,7 @@ function HealthRow({ isContent, sp }: { isContent: boolean; sp: SP }) {
   const isBehind = health.block_difference > 5 ? 'is-behind' : ''
   const dbSize =
     bytesToGb(health.database_size) || bytesToGb(health.databaseSize)
-  const bytesShouldStore = bytesToGb(health.bytesShouldStore)
+  const expectedContentSize = bytesToGb(health.expectedContentSize)
   const autoUpgradeEnabled =
     health.auto_upgrade_enabled || health.autoUpgradeEnabled
   const getPeers = (str: string | undefined) => {
@@ -210,7 +210,7 @@ function HealthRow({ isContent, sp }: { isContent: boolean; sp: SP }) {
         </td>
       )}
       {isContent && (
-        <td>{`${bytesShouldStore} GB`}</td>
+        <td>{`${expectedContentSize} GB`}</td>
       )}
       <td>{`${dbSize} GB`}</td>
       <td>{`${yourIp}`}</td>

--- a/monitoring/healthz/src/DiscoveryHealth.tsx
+++ b/monitoring/healthz/src/DiscoveryHealth.tsx
@@ -34,6 +34,7 @@ export function DiscoveryHealth() {
             {isDiscovery && <th>Storage</th>}
             {isContent && <th>Storage (legacy)</th>}
             {isContent && <th>Storage (mediorum)</th>}
+            {isContent && <th>Expected content storage (from repair.go)</th>}
             <th>DB Size</th>
             <th>Your IP</th>
             {isDiscovery && <th>ACDC Health</th>}
@@ -138,6 +139,7 @@ function HealthRow({ isContent, sp }: { isContent: boolean; sp: SP }) {
   const isBehind = health.block_difference > 5 ? 'is-behind' : ''
   const dbSize =
     bytesToGb(health.database_size) || bytesToGb(health.databaseSize)
+  const bytesShouldStore = bytesToGb(health.bytesShouldStore)
   const autoUpgradeEnabled =
     health.auto_upgrade_enabled || health.autoUpgradeEnabled
   const getPeers = (str: string | undefined) => {
@@ -206,6 +208,9 @@ function HealthRow({ isContent, sp }: { isContent: boolean; sp: SP }) {
             {mediorumUsed} / {mediorumSize} GB
           </span>
         </td>
+      )}
+      {isContent && (
+        <td>{`${bytesShouldStore} GB`}</td>
       )}
       <td>{`${dbSize} GB`}</td>
       <td>{`${yourIp}`}</td>


### PR DESCRIPTION
### Description
Total the expected size of all content stored on a node in `repair.go` and display in healthz

### How Has This Been Tested?
Deploy to a stage node