### PR TITLE
Add db conn timeout to mediorum + mutex to crud sweep

### DIFF
--- a/mediorum/server/serve_crud.go
+++ b/mediorum/server/serve_crud.go
@@ -16,7 +16,7 @@ func (ss *MediorumServer) serveCrudSweep(c echo.Context) error {
 	ss.crudSweepMutex.Lock()
 	defer ss.crudSweepMutex.Unlock()
 
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Minute)
 	defer cancel()
 
 	after := c.QueryParam("after")

--- a/mediorum/server/serve_crud.go
+++ b/mediorum/server/serve_crud.go
@@ -1,8 +1,10 @@
 package server
 
 import (
+	"context"
 	"mediorum/crudr"
 	"net/http"
+	"time"
 
 	"github.com/labstack/echo/v4"
 )
@@ -13,9 +15,13 @@ func (ss *MediorumServer) serveCrudSweep(c echo.Context) error {
 	ss.crudSweepMutex.Lock()
 	defer ss.crudSweepMutex.Unlock()
 
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
 	after := c.QueryParam("after")
 	var ops []*crudr.Op
 	ss.crud.DB.
+		WithContext(ctx).
 		Where("ulid > ?", after).
 		Limit(PullLimit).
 		Order("ulid asc").

--- a/mediorum/server/serve_crud.go
+++ b/mediorum/server/serve_crud.go
@@ -10,6 +10,9 @@ import (
 const PullLimit = 10000
 
 func (ss *MediorumServer) serveCrudSweep(c echo.Context) error {
+	ss.crudSweepMutex.Lock()
+	defer ss.crudSweepMutex.Unlock()
+
 	after := c.QueryParam("after")
 	var ops []*crudr.Op
 	ss.crud.DB.

--- a/mediorum/server/serve_crud.go
+++ b/mediorum/server/serve_crud.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"context"
+	"fmt"
 	"mediorum/crudr"
 	"net/http"
 	"time"
@@ -20,12 +21,16 @@ func (ss *MediorumServer) serveCrudSweep(c echo.Context) error {
 
 	after := c.QueryParam("after")
 	var ops []*crudr.Op
-	ss.crud.DB.
+	err := ss.crud.DB.
 		WithContext(ctx).
 		Where("ulid > ?", after).
 		Limit(PullLimit).
 		Order("ulid asc").
-		Find(&ops)
+		Find(&ops).
+		Error
+	if err != nil {
+		return c.String(500, fmt.Sprintf("Failed to query ops: %v", err))
+	}
 	return c.JSON(200, ops)
 }
 

--- a/mediorum/server/server.go
+++ b/mediorum/server/server.go
@@ -219,10 +219,6 @@ func New(config MediorumConfig) (*MediorumServer, error) {
 	dbPruneOldOps(db, config.Self.Host)
 	dbMigrate(crud, bucket, config.Self.Host)
 
-	// set 5s db connection timeout after migrations are completed
-	sqlDb, _ := db.DB()
-	sqlDb.SetConnMaxLifetime(time.Duration(5) * time.Second)
-
 	// Read trusted notifier endpoint from chain
 	var trustedNotifier ethcontracts.NotifierInfo
 	if config.TrustedNotifierID > 0 {


### PR DESCRIPTION
### Description
1. Set 1 min timeout on sweep query
2. Add mutex to crudr sweeper handler so only 1 of this expensive query runs at a time

### How Has This Been Tested?
Deploy to a stage node