### PR TITLE
Rt usdc luts

### DIFF
--- a/identity-service/src/routes/solana.js
+++ b/identity-service/src/routes/solana.js
@@ -131,15 +131,15 @@ solanaRouter.post(
       retry
     })
 
-    const asdf = true
     if (error) {
-      // if (isTransactionTooLargeError(error)) {
-      if (asdf) {
+      if (isTransactionTooLargeError(error)) {
         console.log('REED got tx too large error, retrying with v0 tx')
+        const feePayerKeypair = getFeePayerKeypair(false, feePayerOverride)
+        console.log('REED found feepayerKeypair: ', feePayerKeypair)
         sendV0Transaction(
           libs.solanaWeb3Manager.connection,
           instructions,
-          feePayerOverride
+          feePayerKeypair
         )
       }
       // if the tx fails, store it in redis with a 24 hour expiration

--- a/identity-service/src/routes/solana.js
+++ b/identity-service/src/routes/solana.js
@@ -137,6 +137,21 @@ solanaRouter.post(
       if (isTransactionTooLargeError(error)) {
         console.log('REED got tx too large error, retrying with v0 tx')
         const feePayerKeypair = getFeePayerKeypair(false, feePayerOverride)
+        console.log('REED got feePayerKeyPair', feePayerKeypair)
+        console.log('REED feePayerKeyPair.publicKey', feePayerKeypair.publicKey)
+        console.log(
+          'REED feePayerKeyPair.privateKey',
+          feePayerKeypair.privateKey
+        )
+        console.log(
+          'REED feePayerKeyPair.publicKey()',
+          feePayerKeypair.publicKey()
+        )
+        console.log(
+          'REED feePayerKeyPair.privateKey()',
+          feePayerKeypair.privateKey()
+        )
+
         sendTransactionWithLookupTable(
           libs.solanaWeb3Manager.connection,
           instructions,

--- a/identity-service/src/routes/solana.js
+++ b/identity-service/src/routes/solana.js
@@ -137,14 +137,8 @@ solanaRouter.post(
       if (isTransactionTooLargeError(error)) {
         console.log('REED got tx too large error, retrying with v0 tx')
         const feePayerKeypair = getFeePayerKeypair(false, feePayerOverride)
-        console.log('REED got feePayerKeyPair', feePayerKeypair)
-        console.log('REED feePayerKeyPair.publicKey', feePayerKeypair.publicKey)
 
-        sendTransactionWithLookupTable(
-          libs.solanaWeb3Manager.connection,
-          instructions,
-          feePayerKeypair
-        )
+        sendTransactionWithLookupTable(instructions, feePayerKeypair)
       }
       // if the tx fails, store it in redis with a 24 hour expiration
       await redis.setex(

--- a/identity-service/src/routes/solana.js
+++ b/identity-service/src/routes/solana.js
@@ -152,8 +152,9 @@ solanaRouter.post(
     })
 
     if (error) {
+      // if the tx fails due to being too large, retry with v0 tx
       if (isTransactionTooLargeError(error)) {
-        await handleV0Tx(instructions, feePayerOverride, signatures)
+        return await handleV0Tx(instructions, feePayerOverride, signatures)
       }
       // if the tx fails, store it in redis with a 24 hour expiration
       await redis.setex(

--- a/identity-service/src/routes/solana.js
+++ b/identity-service/src/routes/solana.js
@@ -139,18 +139,6 @@ solanaRouter.post(
         const feePayerKeypair = getFeePayerKeypair(false, feePayerOverride)
         console.log('REED got feePayerKeyPair', feePayerKeypair)
         console.log('REED feePayerKeyPair.publicKey', feePayerKeypair.publicKey)
-        console.log(
-          'REED feePayerKeyPair.privateKey',
-          feePayerKeypair.privateKey
-        )
-        console.log(
-          'REED feePayerKeyPair.publicKey()',
-          feePayerKeypair.publicKey()
-        )
-        console.log(
-          'REED feePayerKeyPair.privateKey()',
-          feePayerKeypair.privateKey()
-        )
 
         sendTransactionWithLookupTable(
           libs.solanaWeb3Manager.connection,

--- a/identity-service/src/routes/solana.js
+++ b/identity-service/src/routes/solana.js
@@ -1,5 +1,6 @@
 const express = require('express')
 const crypto = require('crypto')
+// const { sendV0Transaction } = require('../utils/solanaAddressLookupTable')
 
 const { parameterizedAuthMiddleware } = require('../authMiddleware')
 const {
@@ -25,6 +26,12 @@ const isValidInstruction = (instr) => {
     return false
   if (!instr.keys.every((key) => !!key.pubkey)) return false
   return true
+}
+
+const isTransactionTooLargeError = (error) => {
+  const matcher = /(?:Transaction too large)(.*)$/
+  const res = error.match(matcher)
+  return !!res
 }
 
 solanaRouter.post(
@@ -124,7 +131,17 @@ solanaRouter.post(
       retry
     })
 
+    const asdf = true
     if (error) {
+      // if (isTransactionTooLargeError(error)) {
+      if (asdf) {
+        console.log('REED got tx too large error, retrying with v0 tx')
+        // sendV0Transaction(
+        //   libs.solanaWeb3Manager.connection,
+        //   instructions,
+        //   feePayerOverride
+        // )
+      }
       // if the tx fails, store it in redis with a 24 hour expiration
       await redis.setex(
         `solanaFailedTx:${reqBodySHA}`,

--- a/identity-service/src/routes/solana.js
+++ b/identity-service/src/routes/solana.js
@@ -137,8 +137,17 @@ solanaRouter.post(
       if (isTransactionTooLargeError(error)) {
         console.log('REED got tx too large error, retrying with v0 tx')
         const feePayerKeypair = getFeePayerKeypair(false, feePayerOverride)
-
-        sendTransactionWithLookupTable(instructions, feePayerKeypair)
+        try {
+          sendTransactionWithLookupTable(
+            instructions,
+            feePayerKeypair,
+            signatures
+          )
+        } catch (e) {
+          console.log('REED error sending v0 tx:', e)
+          const errorString = 'Error sending v0 tx'
+          return errorResponseServerError(errorString, { error: e })
+        }
       }
       // if the tx fails, store it in redis with a 24 hour expiration
       await redis.setex(

--- a/identity-service/src/routes/solana.js
+++ b/identity-service/src/routes/solana.js
@@ -1,6 +1,6 @@
 const express = require('express')
 const crypto = require('crypto')
-// const { sendV0Transaction } = require('../utils/solanaAddressLookupTable')
+const { sendV0Transaction } = require('../utils/solanaAddressLookupTable')
 
 const { parameterizedAuthMiddleware } = require('../authMiddleware')
 const {
@@ -136,11 +136,11 @@ solanaRouter.post(
       // if (isTransactionTooLargeError(error)) {
       if (asdf) {
         console.log('REED got tx too large error, retrying with v0 tx')
-        // sendV0Transaction(
-        //   libs.solanaWeb3Manager.connection,
-        //   instructions,
-        //   feePayerOverride
-        // )
+        sendV0Transaction(
+          libs.solanaWeb3Manager.connection,
+          instructions,
+          feePayerOverride
+        )
       }
       // if the tx fails, store it in redis with a 24 hour expiration
       await redis.setex(

--- a/identity-service/src/routes/solana.js
+++ b/identity-service/src/routes/solana.js
@@ -39,6 +39,7 @@ const isTransactionTooLargeError = (error) => {
 const handleV0Tx = async (instructions, feePayerOverride, signatures) => {
   console.log('REED got tx too large error, retrying with v0 tx')
   const feePayerKeypair = getFeePayerKeypair(false, feePayerOverride)
+  console.log('REED got feePayerKeypair:', feePayerKeypair)
   try {
     const transactionSignature = await sendTransactionWithLookupTable(
       instructions,
@@ -152,7 +153,7 @@ solanaRouter.post(
 
     if (error) {
       if (isTransactionTooLargeError(error)) {
-        handleV0Tx(instructions, feePayerOverride, signatures)
+        await handleV0Tx(instructions, feePayerOverride, signatures)
       }
       // if the tx fails, store it in redis with a 24 hour expiration
       await redis.setex(

--- a/identity-service/src/routes/solana.js
+++ b/identity-service/src/routes/solana.js
@@ -1,6 +1,8 @@
 const express = require('express')
 const crypto = require('crypto')
-const { sendV0Transaction } = require('../utils/solanaAddressLookupTable')
+const {
+  sendTransactionWithLookupTable
+} = require('../utils/solanaAddressLookupTable')
 
 const { parameterizedAuthMiddleware } = require('../authMiddleware')
 const {
@@ -135,8 +137,7 @@ solanaRouter.post(
       if (isTransactionTooLargeError(error)) {
         console.log('REED got tx too large error, retrying with v0 tx')
         const feePayerKeypair = getFeePayerKeypair(false, feePayerOverride)
-        console.log('REED found feepayerKeypair: ', feePayerKeypair)
-        sendV0Transaction(
+        sendTransactionWithLookupTable(
           libs.solanaWeb3Manager.connection,
           instructions,
           feePayerKeypair

--- a/identity-service/src/routes/solana.js
+++ b/identity-service/src/routes/solana.js
@@ -71,11 +71,11 @@ solanaRouter.post(
       instructions,
       optimizelyClient
     )
-    if (!isRelayAllowed) {
-      return errorResponseServerError(`Invalid relay instructions`, {
-        error: `Invalid relay instructions`
-      })
-    }
+    // if (!isRelayAllowed) {
+    //   return errorResponseServerError(`Invalid relay instructions`, {
+    //     error: `Invalid relay instructions`
+    //   })
+    // }
 
     // Social proof checks
     if (socialProofRequiredToSend && isSendInstruction(instructions)) {

--- a/identity-service/src/solana-client.js
+++ b/identity-service/src/solana-client.js
@@ -126,6 +126,7 @@ function getFeePayerKeypair(singleFeePayer = true, pubkey = null) {
       console.error('Fee payer for given public key not found')
       return feePayerKeypair
     }
+    console.log('REED feePayerKeypair', pubkey, 'was at index', feePayerIndex)
     return feePayerKeypairs[feePayerIndex]
   }
 

--- a/identity-service/src/solana-client.js
+++ b/identity-service/src/solana-client.js
@@ -96,7 +96,7 @@ let feePayerKeypairs = null
 
 // Optionally returns the existing singleFeePayer
 // Ensures other usages of this function do not break as we upgrade to multiple
-function getFeePayerKeypair(singleFeePayer = true) {
+function getFeePayerKeypair(singleFeePayer = true, pubkey = null) {
   if (!feePayerKeypairs) {
     feePayerKeypairs = config.get('solanaFeePayerWallets')
       ? config
@@ -116,6 +116,17 @@ function getFeePayerKeypair(singleFeePayer = true) {
     feePayerKeypairs.length === 0
   ) {
     return feePayerKeypair
+  }
+
+  if (pubkey) {
+    const feePayerIndex = feePayerKeypairs.findIndex(
+      (keypair) => keypair.publicKey.toString() === pubkey
+    )
+    if (feePayerIndex === -1) {
+      console.error('Fee payer for given public key not found')
+      return feePayerKeypair
+    }
+    return feePayerKeypairs[feePayerIndex]
   }
 
   const randomFeePayerIndex = Math.floor(

--- a/identity-service/src/utils/solanaAddressLookupTable.js
+++ b/identity-service/src/utils/solanaAddressLookupTable.js
@@ -3,7 +3,8 @@ const {
   TransactionMessage,
   AddressLookupTableProgram,
   VersionedTransaction,
-  Transaction
+  Transaction,
+  Keypair
 } = require('@solana/web3.js')
 
 const sendV0Transaction = async (connection, instructions, feePayerAccount) => {
@@ -15,7 +16,11 @@ const sendV0Transaction = async (connection, instructions, feePayerAccount) => {
     instructions
   }).compileToV0Message()
   const tx = new VersionedTransaction(message)
-  tx.sign([feePayerAccount])
+  console.log('REED got feePayerKeyPair', feePayerAccount)
+  console.log('REED feePayerKeyPair.publicKey', feePayerAccount.publicKey)
+  console.log('REED feePayerKeyPair.secretKey', feePayerAccount.secretKey)
+  const k = Keypair.fromSecretKey(feePayerAccount.secretKey)
+  tx.sign([k])
   return await connection.sendTransaction(tx)
 }
 

--- a/identity-service/src/utils/solanaAddressLookupTable.js
+++ b/identity-service/src/utils/solanaAddressLookupTable.js
@@ -62,6 +62,10 @@ const sendTransactionWithLookupTable = async (
     'REED successfully sent table transaction first half',
     txIdFirstHalf
   )
+  for (let i = 0; i < lookupTableAccount.state.addresses.length; i++) {
+    const address = lookupTableAccount.state.addresses[i]
+    console.log('REED addresses in table:', i, address.toString())
+  }
 
   const extendInstructionSecondHalf =
     AddressLookupTableProgram.extendLookupTable({

--- a/identity-service/src/utils/solanaAddressLookupTable.js
+++ b/identity-service/src/utils/solanaAddressLookupTable.js
@@ -14,12 +14,17 @@ const sendV0Transaction = async (connection, instructions, feePayerAccount) => {
     recentBlockhash,
     instructions
   }).compileToV0Message()
+  console.log('REED message created:', message)
   const tx = new VersionedTransaction(message)
+  console.log('REED tx created:', tx)
   tx.sign([feePayerAccount])
+  console.log('REED tx signed:', tx)
   const serialized = tx.serialize()
+  console.log('REED tx serialized:', serialized)
   const txId = await connection.sendRawTransaction(serialized, {
     max_retries: MAX_RETRIES
   })
+  console.log('REED tx sent:', txId)
 
   const confirmation = await connection.confirmTransaction({
     signature: txId,
@@ -29,6 +34,7 @@ const sendV0Transaction = async (connection, instructions, feePayerAccount) => {
   if (confirmation.value.err) {
     throw new Error('V0 Transaction not confirmed: txId', txId)
   }
+  console.log('REED tx confirmed:', confirmation)
 }
 
 const sendTransactionWithLookupTable = async (
@@ -44,6 +50,12 @@ const sendTransactionWithLookupTable = async (
       recentSlot: slot
     })
   console.log('REED lookup table address:', lookupTableAddress.toBase58())
+  const createTableTxId = await sendV0Transaction(
+    connection,
+    [lookupTableInst],
+    feePayerAccount
+  )
+  console.log('REED successfully created table:', createTableTxId)
 
   const set = new Set()
   instructions.forEach((i) => i.keys.map((k) => set.add(k.pubkey)))
@@ -64,7 +76,7 @@ const sendTransactionWithLookupTable = async (
     })
   const txIdFirstHalf = await sendV0Transaction(
     connection,
-    [lookupTableInst, extendInstructionFirstHalf],
+    [extendInstructionFirstHalf],
     feePayerAccount
   )
   console.log(

--- a/identity-service/src/utils/solanaAddressLookupTable.js
+++ b/identity-service/src/utils/solanaAddressLookupTable.js
@@ -8,20 +8,18 @@ const {
 } = require('@solana/web3.js')
 
 const sendV0Transaction = async (connection, instructions, feePayerAccount) => {
-  const recentBlockhash = (await connection.getLatestBlockhash('confirmed'))
+  const recentBlockhash = (await connection.getLatestBlockhash('finalized'))
     .blockhash
   const message = new TransactionMessage({
     payerKey: feePayerAccount.publicKey,
     recentBlockhash,
     instructions
   }).compileToV0Message()
-  const tx = new VersionedTransaction(message)
-  console.log('REED got feePayerKeyPair', feePayerAccount)
-  console.log('REED feePayerKeyPair.publicKey', feePayerAccount.publicKey)
-  console.log('REED feePayerKeyPair.secretKey', feePayerAccount.secretKey)
-  const k = Keypair.fromSecretKey(feePayerAccount.secretKey)
-  tx.sign([k])
-  return await connection.sendTransaction(tx)
+  // const tx = new VersionedTransaction(message)
+  // tx.sign([feePayerAccount])
+  // const serialized = tx.serialize()
+  // return await connection.sendRawTransaction(serialized)
+  return await connection.sendTransaction(message, [feePayerAccount])
 }
 
 const sendTransactionWithLookupTable = async (
@@ -70,12 +68,9 @@ const sendTransactionWithLookupTable = async (
       payer: feePayerAccount.publicKey,
       authority: feePayerAccount.publicKey,
       lookupTable: lookupTableAddress,
-      addresses: [
-        feePayerAccount.publicKey,
-        SystemProgram.programId,
-        ...secondHalf
-      ]
+      addresses: secondHalf
     })
+  console.log('REED second half instruction:', extendInstructionSecondHalf)
   const txIdSecondHalf = await sendV0Transaction(
     connection,
     [extendInstructionSecondHalf],

--- a/identity-service/src/utils/solanaAddressLookupTable.js
+++ b/identity-service/src/utils/solanaAddressLookupTable.js
@@ -26,15 +26,17 @@ const sendV0Transaction = async (connection, instructions, feePayerAccount) => {
   })
   console.log('REED tx sent:', txId)
 
-  const confirmation = await connection.confirmTransaction({
-    signature: txId,
-    blockhash: recentBlockhash.blockhash,
-    lastValidBlockHeight: recentBlockhash.lastValidBlockHeight
-  })
+  // const confirmation = await connection.confirmTransaction({
+  //   signature: txId,
+  //   blockhash: recentBlockhash.blockhash,
+  //   lastValidBlockHeight: recentBlockhash.lastValidBlockHeight
+  // })
+  const confirmation = await connection.confirmTransaction(txId)
   if (confirmation.value.err) {
     throw new Error('V0 Transaction not confirmed: txId', txId)
   }
   console.log('REED tx confirmed:', confirmation)
+  return txId
 }
 
 const sendTransactionWithLookupTable = async (

--- a/identity-service/src/utils/solanaAddressLookupTable.js
+++ b/identity-service/src/utils/solanaAddressLookupTable.js
@@ -15,14 +15,19 @@ const sendV0Transaction = async (
   lookupTableAccount = undefined
 ) => {
   const recentBlockhash = await connection.getLatestBlockhash('finalized')
+  console.log('REED recentBlockhash:', recentBlockhash)
   const message = new TransactionMessage({
     payerKey: feePayerAccount.publicKey,
     recentBlockhash: recentBlockhash.blockhash,
     instructions
   }).compileToV0Message([lookupTableAccount])
+  console.log('REED message:', message)
   const tx = new VersionedTransaction(message)
+  console.log('REED tx:', tx)
   tx.sign([feePayerAccount])
+  console.log('REED signed tx:', tx)
   const serialized = tx.serialize()
+  console.log('REED serialized tx:', serialized)
   const txId = await connection.sendRawTransaction(serialized, {
     max_retries: MAX_RETRIES
   })

--- a/identity-service/src/utils/solanaAddressLookupTable.js
+++ b/identity-service/src/utils/solanaAddressLookupTable.js
@@ -18,19 +18,19 @@ const sendV0Transaction = async (
   signatures = []
 ) => {
   const recentBlockhash = await connection.getLatestBlockhash('finalized')
-  console.log('REED recentBlockhash:', recentBlockhash)
   const message = new TransactionMessage({
     payerKey: feePayerAccount.publicKey,
     recentBlockhash: recentBlockhash.blockhash,
     instructions
   }).compileToV0Message(lookupTableArray)
-  console.log('REED message:', message)
   const tx = new VersionedTransaction(message)
-  console.log('REED tx:', tx)
   tx.sign([feePayerAccount])
+  console.log('REED tx with feePayer signed:', tx)
   if (Array.isArray(signatures)) {
     signatures.forEach(({ publicKey, signature }) => {
-      tx.addSignature(new PublicKey(publicKey), signature)
+      console.log('REED adding signature:', publicKey, signature)
+      console.log('REED signature.data:', signature.data)
+      tx.addSignature(new PublicKey(publicKey), signature.data)
     })
   }
   console.log('REED signed tx:', tx)
@@ -89,7 +89,6 @@ const sendTransactionWithLookupTable = async (
     instructions,
     feePayerAccount
   )
-
   await sleep(SLEEP_TIME)
   const lookupTableAccount = (
     await connection.getAddressLookupTable(lookupTableAddress)
@@ -99,11 +98,6 @@ const sendTransactionWithLookupTable = async (
     throw new Error(
       `Failed to get lookupTableAccount after waiting ${SLEEP_TIME} seconds`
     )
-  }
-  console.log('REED num addresses:', lookupTableAccount.state.addresses.length)
-  for (let i = 0; i < lookupTableAccount.state.addresses.length; i++) {
-    const address = lookupTableAccount.state.addresses[i]
-    console.log('REED addresses in account:', i, address.toBase58())
   }
 
   console.log('REED signatures:', signatures)
@@ -117,6 +111,7 @@ const sendTransactionWithLookupTable = async (
   console.log(
     `REED successfully sent swap transaction: https://explorer.solana.com/tx/${txId}`
   )
+  return txId
 }
 
 function sleep(s) {

--- a/identity-service/src/utils/solanaAddressLookupTable.js
+++ b/identity-service/src/utils/solanaAddressLookupTable.js
@@ -101,15 +101,49 @@ const sendTransactionWithLookupTable = async (
   }
 
   console.log('REED signatures:', signatures)
-  const txId = await sendV0Transaction(
+  const txId = 'asdf'
+  // const txId = await sendV0Transaction(
+  //   connection,
+  //   instructions,
+  //   feePayerAccount,
+  //   [lookupTableAccount],
+  //   signatures
+  // )
+  console.log(
+    `REED successfully sent swap transaction: https://explorer.solana.com/tx/${txId}`
+  )
+
+  const deactivateInstruction = AddressLookupTableProgram.deactivateLookupTable(
+    {
+      lookupTable: lookupTableAddress,
+      authority: feePayerAccount.publicKey
+    }
+  )
+  const deactivateTxId = await sendV0Transaction(
     connection,
-    instructions,
+    [deactivateInstruction],
     feePayerAccount,
     [lookupTableAccount],
     signatures
   )
   console.log(
-    `REED successfully sent swap transaction: https://explorer.solana.com/tx/${txId}`
+    `REED successfully sent deactivate transaction: https://explorer.solana.com/tx/${deactivateTxId}`
+  )
+  sleep(600)
+  const closeInstruction = AddressLookupTableProgram.closeLookupTable({
+    lookupTable: lookupTableAddress,
+    authority: feePayerAccount.publicKey,
+    recipient: feePayerAccount.publicKey
+  })
+  const closeTxId = await sendV0Transaction(
+    connection,
+    [closeInstruction],
+    feePayerAccount,
+    [lookupTableAccount],
+    signatures
+  )
+  console.log(
+    `REED successfully sent close transaction: https://explorer.solana.com/tx/${closeTxId}`
   )
   return txId
 }

--- a/identity-service/src/utils/solanaAddressLookupTable.js
+++ b/identity-service/src/utils/solanaAddressLookupTable.js
@@ -94,6 +94,7 @@ const sendTransactionWithLookupTable = async (
   const lookupTableAccount = (
     await connection.getAddressLookupTable(lookupTableAddress)
   ).value
+  console.log('REED got lookupTableAccount:', lookupTableAccount)
   if (!lookupTableAccount) {
     throw new Error(
       `Failed to get lookupTableAccount after waiting ${SLEEP_TIME} seconds`

--- a/identity-service/src/utils/solanaAddressLookupTable.js
+++ b/identity-service/src/utils/solanaAddressLookupTable.js
@@ -1,0 +1,75 @@
+const {
+  SystemProgram,
+  TransactionMessage,
+  AddressLookupTableProgram,
+  VersionedTransaction
+} = require('@solana/web3.js')
+const audiusLibsWrapper = require('../audiusLibsInstance')
+
+const sendV0Transaction = async (connection, instructions, feePayerAccount) => {
+  console.log('REED at top of sendV0Transaction')
+  const slot = await connection.getSlot()
+  const [lookupTableInst, lookupTableAddress] =
+    AddressLookupTableProgram.createLookupTable({
+      authority: feePayerAccount.publicKey,
+      payer: feePayerAccount.publicKey,
+      recentSlot: slot
+    })
+  console.log('REED lookup table address:', lookupTableAddress.toBase58())
+
+  const addresses = instructions.map((inst) => [...inst])
+  console.log('REED addresses:', addresses)
+  const extendInstruction = AddressLookupTableProgram.extendLookupTable({
+    payer: feePayerAccount.publicKey,
+    authority: feePayerAccount.publicKey,
+    lookupTable: lookupTableAddress,
+    addresses: [
+      feePayerAccount.publicKey,
+      SystemProgram.programId,
+      ...addresses
+    ]
+  })
+  console.log('REED extend Instruction:', extendInstruction)
+  extendInstruction.feePayerAccount = feePayerAccount.publicKey
+  extendInstruction.sign(feePayerAccount)
+  const extendTxId = await connection.sendRawTransaction(
+    extendInstruction.serialize()
+  )
+  console.log(
+    `Extend Transaction successfully sent: https://explorer.solana.com/tx/${extendTxId}`
+  )
+
+  const lookupTableAccount = await connection
+    .getAddressLookupTable(lookupTableAddress)
+    .then((res) => res.value)
+
+  for (let i = 0; i < lookupTableAccount.state.addresses.length; i++) {
+    const address = lookupTableAccount.state.addresses[i]
+    console.log(i, address.toBase58())
+  }
+
+  const recentBlockhash = (await connection.getLatestBlockhash('confirmed'))
+    .blockhash
+  const messageV0 = new TransactionMessage({
+    payerKey: feePayerAccount.publicKey,
+    recentBlockhash,
+    instructions // note this is an array of instructions
+  }).compileToV0Message([lookupTableAccount])
+
+  // create a v0 transaction from the v0 message
+  const transactionV0 = new VersionedTransaction(messageV0)
+
+  // sign the v0 transaction using the file system wallet we created named `payer`
+  transactionV0.sign([feePayerAccount])
+  transactionV0.serialize()
+
+  // send and confirm the transaction
+  // (NOTE: There is NOT an array of Signers here; see the note below...)
+  const txid = await connection.sendRawTransaction(transactionV0)
+
+  console.log(`Transaction: https://explorer.solana.com/tx/${txid}`)
+}
+
+module.exports = {
+  sendV0Transaction
+}

--- a/identity-service/src/utils/solanaAddressLookupTable.js
+++ b/identity-service/src/utils/solanaAddressLookupTable.js
@@ -54,48 +54,18 @@ const sendTransactionWithLookupTable = async (
   )
   console.log('REED set:', set, set.size)
   console.log('REED addresses:', addresses, addresses.length)
-  const halfIndex = Math.floor(addresses.length / 2)
-  const firstHalf = addresses.slice(0, halfIndex)
-  const secondHalf = addresses.slice(halfIndex)
-  const extendInstructionFirstHalf =
-    AddressLookupTableProgram.extendLookupTable({
-      payer: feePayerAccount.publicKey,
-      authority: feePayerAccount.publicKey,
-      lookupTable: lookupTableAddress,
-      addresses: [
-        feePayerAccount.publicKey,
-        SystemProgram.programId,
-        ...firstHalf
-      ]
-    })
-  const txIdFirstHalf = await sendV0Transaction(
+  const extendInstruction = AddressLookupTableProgram.extendLookupTable({
+    payer: feePayerAccount.publicKey,
+    authority: feePayerAccount.publicKey,
+    lookupTable: lookupTableAddress,
+    addresses: [feePayerAccount.publicKey, SystemProgram.programId, addresses]
+  })
+  const tableTxId = await sendV0Transaction(
     connection,
-    [extendInstructionFirstHalf],
+    [lookupTableInst, extendInstruction],
     feePayerAccount
   )
-  console.log(
-    'REED successfully sent table transaction first half',
-    txIdFirstHalf
-  )
-
-  const extendInstructionSecondHalf =
-    AddressLookupTableProgram.extendLookupTable({
-      payer: feePayerAccount.publicKey,
-      authority: feePayerAccount.publicKey,
-      lookupTable: lookupTableAddress,
-      addresses: secondHalf
-    })
-
-  console.log('REED second half instruction:', extendInstructionSecondHalf)
-  const txIdSecondHalf = await sendV0Transaction(
-    connection,
-    [extendInstructionSecondHalf],
-    feePayerAccount
-  )
-  console.log(
-    'REED successfully sent table transaction second half',
-    txIdSecondHalf
-  )
+  console.log('REED successfully sent table transaction', tableTxId)
 
   const lookupTableAccount = await connection
     .getAddressLookupTable(lookupTableAddress)

--- a/identity-service/src/utils/solanaAddressLookupTable.js
+++ b/identity-service/src/utils/solanaAddressLookupTable.js
@@ -11,7 +11,7 @@ const sendV0Transaction = async (connection, instructions, feePayerAccount) => {
   const recentBlockhash = await connection.getLatestBlockhash('finalized')
   const message = new TransactionMessage({
     payerKey: feePayerAccount.publicKey,
-    recentBlockhash,
+    recentBlockhash: recentBlockhash.blockhash,
     instructions
   }).compileToV0Message()
   console.log('REED message created:', message)

--- a/identity-service/src/utils/solanaAddressLookupTable.js
+++ b/identity-service/src/utils/solanaAddressLookupTable.js
@@ -31,16 +31,22 @@ const sendV0Transaction = async (connection, instructions, feePayerAccount) => {
       ...addresses
     ]
   })
+  console.log('REED create Instruction:', lookupTableInst)
   console.log('REED extend Instruction:', extendInstruction)
+
   const recentBlockhash = (await connection.getLatestBlockhash('confirmed'))
     .blockhash
-  const tx = new Transaction({ recentBlockhash })
-  tx.add(extendInstruction)
-  tx.feePayerAccount = feePayerAccount.publicKey
-  tx.sign(feePayerAccount)
-  const extendTxId = await connection.sendRawTransaction(tx.serialize())
+  const message = new TransactionMessage({
+    payerKey: feePayerAccount.publicKey,
+    recentBlockhash: recentBlockhash,
+    instructions: [lookupTableInst, extendInstruction]
+  }).compileToV0Message()
+
+  const transaction = new VersionedTransaction(message)
+  transaction.sign([feePayerAccount])
+  const tableTxId = await connection.sendTransaction(transaction)
   console.log(
-    `Extend Transaction successfully sent: https://explorer.solana.com/tx/${extendTxId}`
+    `Extend Transaction successfully sent: https://explorer.solana.com/tx/${tableTxId}`
   )
 
   const lookupTableAccount = await connection

--- a/identity-service/src/utils/solanaAddressLookupTable.js
+++ b/identity-service/src/utils/solanaAddressLookupTable.js
@@ -48,6 +48,7 @@ const sendV0Transaction = async (connection, instructions, feePayerAccount) => {
   console.log(
     `Extend Transaction successfully sent: https://explorer.solana.com/tx/${tableTxId}`
   )
+  console.log('REED successfully sent table transaction')
 
   const lookupTableAccount = await connection
     .getAddressLookupTable(lookupTableAddress)
@@ -55,8 +56,9 @@ const sendV0Transaction = async (connection, instructions, feePayerAccount) => {
 
   for (let i = 0; i < lookupTableAccount.state.addresses.length; i++) {
     const address = lookupTableAccount.state.addresses[i]
-    console.log(i, address.toBase58())
+    console.log('REED addresses in account:', i, address.toBase58())
   }
+  sleep(1)
 
   const recentBlockhashV0 = (await connection.getLatestBlockhash('confirmed'))
     .blockhash
@@ -78,6 +80,10 @@ const sendV0Transaction = async (connection, instructions, feePayerAccount) => {
   const txid = await connection.sendRawTransaction(transactionV0)
 
   console.log(`Transaction: https://explorer.solana.com/tx/${txid}`)
+}
+
+function sleep(s) {
+  return new Promise((resolve) => setTimeout(resolve, s * 1000))
 }
 
 module.exports = {

--- a/identity-service/src/utils/solanaAddressLookupTable.js
+++ b/identity-service/src/utils/solanaAddressLookupTable.js
@@ -37,12 +37,6 @@ const sendTransactionWithLookupTable = async (
       recentSlot: slot
     })
   console.log('REED lookup table address:', lookupTableAddress.toBase58())
-  const createTableTxId = await sendV0Transaction(
-    connection,
-    [lookupTableInst],
-    feePayerAccount
-  )
-  console.log('REED successfully created table:', createTableTxId)
 
   const set = new Set()
   const addresses = []
@@ -58,7 +52,7 @@ const sendTransactionWithLookupTable = async (
     payer: feePayerAccount.publicKey,
     authority: feePayerAccount.publicKey,
     lookupTable: lookupTableAddress,
-    addresses: [feePayerAccount.publicKey, SystemProgram.programId, addresses]
+    addresses: addresses
   })
   const tableTxId = await sendV0Transaction(
     connection,

--- a/identity-service/src/utils/solanaAddressLookupTable.js
+++ b/identity-service/src/utils/solanaAddressLookupTable.js
@@ -30,7 +30,7 @@ const sendV0Transaction = async (
     signatures.forEach(({ publicKey, signature }) => {
       console.log('REED adding signature:', publicKey, signature)
       console.log('REED signature.data:', signature.data)
-      tx.addSignature(new PublicKey(publicKey), signature.data)
+      tx.addSignature(new PublicKey(publicKey), new Uint8Array(signature.data))
     })
   }
   console.log('REED signed tx:', tx)

--- a/identity-service/src/utils/solanaAddressLookupTable.js
+++ b/identity-service/src/utils/solanaAddressLookupTable.js
@@ -45,13 +45,18 @@ const sendTransactionWithLookupTable = async (
   console.log('REED successfully created table:', createTableTxId)
 
   const set = new Set()
-  instructions.forEach((i) => i.keys.map((k) => set.add(k.pubkey)))
-  const addresses = Array.from(set)
+  const addresses = []
+  instructions.forEach((i) =>
+    i.keys.map((k) => {
+      if (!set.has(k.pubkey.toString())) addresses.push(k.pubkey)
+      set.add(k.pubkey.toString())
+    })
+  )
+  console.log('REED set:', set, set.size)
+  console.log('REED addresses:', addresses, addresses.length)
   const halfIndex = Math.floor(addresses.length / 2)
   const firstHalf = addresses.slice(0, halfIndex)
   const secondHalf = addresses.slice(halfIndex)
-  console.log('REED first half:', firstHalf)
-  console.log('REED second half:', secondHalf)
   const extendInstructionFirstHalf =
     AddressLookupTableProgram.extendLookupTable({
       payer: feePayerAccount.publicKey,

--- a/identity-service/src/utils/solanaAddressLookupTable.js
+++ b/identity-service/src/utils/solanaAddressLookupTable.js
@@ -67,6 +67,7 @@ const sendTransactionWithLookupTable = async (
       lookupTable: lookupTableAddress,
       addresses: secondHalf
     })
+
   console.log('REED second half instruction:', extendInstructionSecondHalf)
   const txIdSecondHalf = await sendV0Transaction(
     connection,

--- a/identity-service/src/utils/withdrawUSDCInstructionsHelpers.js
+++ b/identity-service/src/utils/withdrawUSDCInstructionsHelpers.js
@@ -86,6 +86,7 @@ const isUSDCWithdrawalTransaction = (instructions) => {
     checkCloseAccountInstruction(instructions[instructions.length - 1])
   )
 
+  console.log('REED validations:', validations)
   return validations.every((validation) => validation)
 }
 


### PR DESCRIPTION
### Description
Due to transaction size limits, a lookup table can only be extended by 20 addresses at a time ([see here](https://docs.solana.com/developing/lookup-tables#add-addresses-to-a-lookup-table)). We have more than 20 addresses in the swap instructions, so we need to extend it twice. You can see in the code that in the first tx, I'm sending `lookupTableInst` (to create the lookup table) and 1 `extendLookupTable` instruction with half the addresses in it. This goes through fine ([example](https://explorer.solana.com/tx/4YEjuAKxHoFwCUp7FNSiyKrNVphEgJzQo7LCgkV2SSYmUqeftF97QGgHLYHKZWyHGDD4sXMaKVFUUxnxUnZCvre5#ix-1)). The 2nd one containing the rest of the addresses fails with this error:
```Unhandled Rejection at: Promise {
  <rejected> SendTransactionError: failed to send transaction: Transaction simulation failed: Error processing Instruction 0: Invalid account owner
      at Connection.sendEncodedTransaction (/usr/src/app/node_modules/@audius/sdk/node_modules/@solana/web3.js/lib/index.cjs.js:6929:13)
      at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
      at async Connection.sendRawTransaction (/usr/src/app/node_modules/@audius/sdk/node_modules/@solana/web3.js/lib/index.cjs.js:6890:20)
      at async sendV0Transaction (/usr/src/app/build/src/utils/solanaAddressLookupTable.js:14:12)
      at async sendTransactionWithLookupTable (/usr/src/app/build/src/utils/solanaAddressLookupTable.js:50:28) {
    logs: [
      'Program AddressLookupTab1e1111111111111111111111111 invoke [1]',
      'Program AddressLookupTab1e1111111111111111111111111 failed: Invalid account owner'
    ]
  },
  [Symbol(async_id_symbol)]: 9101,
  [Symbol(trigger_async_id_symbol)]: 9100,
  [Symbol(kResourceStore)]: BaseContext {
    _currentContext: Map(2) {
      Symbol(OpenTelemetry Context Key SPAN) => [Span],
      Symbol(OpenTelemetry SDK Context Key RPC_METADATA) => [Object]
    },
    getValue: [Function (anonymous)],
    setValue: [Function (anonymous)],
    deleteValue: [Function (anonymous)]
  }
} reason: SendTransactionError: failed to send transaction: Transaction simulation failed: Error processing Instruction 0: Invalid account owner
    at Connection.sendEncodedTransaction (/usr/src/app/node_modules/@audius/sdk/node_modules/@solana/web3.js/lib/index.cjs.js:6929:13)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
    at async Connection.sendRawTransaction (/usr/src/app/node_modules/@audius/sdk/node_modules/@solana/web3.js/lib/index.cjs.js:6890:20)
    at async sendV0Transaction (/usr/src/app/build/src/utils/solanaAddressLookupTable.js:14:12)
    at async sendTransactionWithLookupTable (/usr/src/app/build/src/utils/solanaAddressLookupTable.js:50:28) {
  logs: [
    'Program AddressLookupTab1e1111111111111111111111111 invoke [1]',
    'Program AddressLookupTab1e1111111111111111111111111 failed: Invalid account owner'
  ]
}
```
Here are the 2 extend instructions for comparison (they look the same to me):
1st one:
```
REED first half extend instruction: TransactionInstruction {
  keys: [
    {
  pubkey: [PublicKey [PublicKey(GAwCwoJ1dk4vxK3LcLiHz6PDx3pwGzKdscaWb5QjZaeB)]],
  isSigner: false,
  isWritable: true
    },
    {
  pubkey: [PublicKey [PublicKey(3QXghAFWYnHZaKJnPTATUod7GmbSkAa7TAuZJ3MWybWj)]],
  isSigner: true,
  isWritable: false
    },
    {
  pubkey: [PublicKey [PublicKey(3QXghAFWYnHZaKJnPTATUod7GmbSkAa7TAuZJ3MWybWj)]],
  isSigner: true,
  isWritable: true
    },
{
  pubkey: [PublicKey [PublicKey(11111111111111111111111111111111)]],
  isSigner: false,
  isWritable: false
    }
  ],
  programId: PublicKey [PublicKey(AddressLookupTab1e1111111111111111111111111)] {
_bn: <BN: 277a6af97339b7ac88d1892c90446f50002309266f62e53c118244982000000>
  },
data: <Buffer 02 00 00 00 17 00 00 00 00 00 00 00 23 be 6d 68 07 d2 a0 54 e5 be 40 9d 9e f3 8a a3 fa 5e 90 59 8b b4 1e 1f a0 0d ed 1f 81 cc 64 94 00 00 00 00 00 00 ... 698 more bytes>
}
```
2nd one:
```
REED second half instruction: TransactionInstruction {
  keys: [
{
  pubkey: [PublicKey [PublicKey(GAwCwoJ1dk4vxK3LcLiHz6PDx3pwGzKdscaWb5QjZaeB)]],
  isSigner: false,
  isWritable: true
},
{
  pubkey: [PublicKey [PublicKey(3QXghAFWYnHZaKJnPTATUod7GmbSkAa7TAuZJ3MWybWj)]],
  isSigner: true,
  isWritable: false
},
    {
  pubkey: [PublicKey [PublicKey(3QXghAFWYnHZaKJnPTATUod7GmbSkAa7TAuZJ3MWybWj)]],
  isSigner: true,
  isWritable: true
},
{
  pubkey: [PublicKey [PublicKey(11111111111111111111111111111111)]],
  isSigner: false,
  isWritable: false
    }
  ],
programId: PublicKey [PublicKey(AddressLookupTab1e1111111111111111111111111)] {
    _bn: <BN: 277a6af97339b7ac88d1892c90446f50002309266f62e53c118244982000000>
},
  data: <Buffer 02 00 00 00 15 00 00 00 00 00 00 00 06 dd f6 e1 d7 65 a1 93 d9 cb e1 46 ce eb 79 ac 1c b4 85 ed 5f 5b 37 91 3a 8c f5 85 7e ff 00 a9 ee 94 2f 60 0a 1d ... 634 more bytes>}
```
### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._
