### PR TITLE
[PAY-1819] Allow transferring to existing USDC ATAs

### DIFF
--- a/packages/web/src/services/solana/solana.ts
+++ b/packages/web/src/services/solana/solana.ts
@@ -38,6 +38,27 @@ export const isSolWallet = async (destinationWallet: SolanaWalletAddress) => {
 }
 
 /**
+ * Checks if the given account address is an associated token account
+ */
+export const isTokenAccount = async ({
+  accountAddress,
+  mint
+}: {
+  accountAddress: SolanaWalletAddress
+  mint: MintName
+}) => {
+  try {
+    await getTokenAccountInfo({
+      tokenAccount: new PublicKey(accountAddress),
+      mint
+    })
+    return true
+  } catch (e) {
+    return false
+  }
+}
+
+/**
  * Gets the current user's root solana account.
  */
 export const getRootSolanaAccount = async () => {

--- a/packages/web/src/services/solana/solana.ts
+++ b/packages/web/src/services/solana/solana.ts
@@ -47,15 +47,11 @@ export const isTokenAccount = async ({
   accountAddress: SolanaWalletAddress
   mint: MintName
 }) => {
-  try {
-    await getTokenAccountInfo({
-      tokenAccount: new PublicKey(accountAddress),
-      mint
-    })
-    return true
-  } catch (e) {
-    return false
-  }
+  const info = await getTokenAccountInfo({
+    tokenAccount: new PublicKey(accountAddress),
+    mint
+  })
+  return info !== null
 }
 
 /**


### PR DESCRIPTION
### Description

- Changes the `isSolWallet` check to instead check for a token account
- Sends the final transfer via relay so no SOL is required

### How Has This Been Tested?

Tested against local stack