### PR TITLE
Delete remaining old fkeys on blocks table

### DIFF
--- a/discovery-provider/ddl/migrations/0030_drop_old_block_key.sql
+++ b/discovery-provider/ddl/migrations/0030_drop_old_block_key.sql
@@ -1,0 +1,35 @@
+-- cleanup keys and indices with is_current
+begin;
+
+CREATE OR REPLACE FUNCTION delete_constraints_referencing_blocks()
+RETURNS void AS
+$$
+DECLARE
+    constraint_record RECORD;
+BEGIN
+    FOR constraint_record IN (
+        SELECT
+            c.conname AS constraint_name,
+            conrelid::regclass AS referencing_table
+        FROM
+            pg_constraint c
+        JOIN
+            pg_attribute a ON a.attnum = ANY(c.conkey)
+        WHERE
+            confrelid = 'blocks'::regclass
+            AND contype = 'f'
+            AND pg_get_constraintdef(c.oid) NOT LIKE '%ON DELETE CASCADE%'
+        GROUP BY
+            c.conname, conrelid::regclass
+    )
+    LOOP
+        -- Drop the foreign key constraint
+        EXECUTE 'ALTER TABLE ' || constraint_record.referencing_table || ' DROP CONSTRAINT ' || constraint_record.constraint_name;
+    END LOOP;
+END;
+$$
+LANGUAGE plpgsql;
+
+select delete_constraints_referencing_blocks();
+
+commit;


### PR DESCRIPTION
### Description
My previous migration only delete fkeys based on the referencing table name like track_price_history_blocknumber_fkey but in this case the existing reference table name was  blocknumber_fkey. This existing fkey would prevent the new fkey to cascade delete.

There are a couple other cases like this: grants and developer_apps.

### How Has This Been Tested?
Tested on sandbox.
_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._
