### PR TITLE
Add checks for USDC withdrawal jupiter swap flow

### DIFF
--- a/identity-service/src/utils/relayHelpers.js
+++ b/identity-service/src/utils/relayHelpers.js
@@ -5,7 +5,6 @@ const {
 } = require('./withdrawUSDCInstructionsHelpers')
 const { getFeatureFlag, FEATURE_FLAGS } = require('../featureFlag')
 const {
-  allowedProgramIds,
   solanaClaimableTokenProgramAddress,
   solanaMintAddress,
   solanaRewardsManager,

--- a/identity-service/src/utils/relayUtils.js
+++ b/identity-service/src/utils/relayUtils.js
@@ -20,7 +20,7 @@ const allowedProgramIds = new Set([
   solanaClaimableTokenProgramAddress,
   solanaRewardsManagerProgramId,
   SECP256K1_PROGRAM_ID,
-  MEMO_PROGRAM_ID,
+  MEMO_PROGRAM_ID
 ])
 
 if (solanaAudiusAnchorDataProgramId) {

--- a/identity-service/src/utils/relayUtils.js
+++ b/identity-service/src/utils/relayUtils.js
@@ -13,11 +13,14 @@ const solanaAudiusAnchorDataProgramId = config.get(
   'solanaAudiusAnchorDataProgramId'
 )
 
+const SECP256K1_PROGRAM_ID = 'KeccakSecp256k11111111111111111111111111111'
+const MEMO_PROGRAM_ID = 'Memo1UhkJRfHyvLMcVucJwxXeuD728EqVDDwQDxFMNo'
+
 const allowedProgramIds = new Set([
   solanaClaimableTokenProgramAddress,
   solanaRewardsManagerProgramId,
-  /* secp */ 'KeccakSecp256k11111111111111111111111111111',
-  /* memo */ 'Memo1UhkJRfHyvLMcVucJwxXeuD728EqVDDwQDxFMNo'
+  SECP256K1_PROGRAM_ID,
+  MEMO_PROGRAM_ID,
 ])
 
 if (solanaAudiusAnchorDataProgramId) {

--- a/identity-service/src/utils/withdrawUSDCInstructionsHelpers.js
+++ b/identity-service/src/utils/withdrawUSDCInstructionsHelpers.js
@@ -6,7 +6,8 @@ const { Keypair } = require('@solana/web3.js')
 const config = require('../config')
 const { isRelayAllowedProgram, getInstructionEnum } = require('./relayUtils')
 
-const JUPITER_AGGREGATOR_V3_PROGRAM_ID = 'JUP3c2Uh3WA4Ng34tw6kPd2G4C5BB21Xo36Je1s32Ph'
+const JUPITER_AGGREGATOR_V3_PROGRAM_ID =
+  'JUP3c2Uh3WA4Ng34tw6kPd2G4C5BB21Xo36Je1s32Ph'
 
 const CLOSE_ACCOUNT_INSTRUCTION = 9
 const FEE_PAYER_ACCOUNT_INDEX = 1
@@ -64,7 +65,7 @@ const checkCloseAccountInstruction = (instruction) => {
 const jupiterSwapProgramIds = new Set([
   JUPITER_AGGREGATOR_V3_PROGRAM_ID,
   ASSOCIATED_TOKEN_PROGRAM_ID.toBase58(),
-  TOKEN_PROGRAM_ID.toBase58(),
+  TOKEN_PROGRAM_ID.toBase58()
 ])
 
 /**
@@ -78,63 +79,72 @@ const checkJupiterSwapInstructions = (instructions) => {
     JUPITER_CLOSE_ASSOCIATED_TOKEN_ACCOUNT_INSTRUCTION_INDEX
   )
   console.log(JSON.stringify(jupiterInstructions, null, 2))
-  const areJupiterAllowedPrograms = jupiterInstructions
-    .every((instruction) => jupiterSwapProgramIds.has(instruction.programId))
+  const areJupiterAllowedPrograms = jupiterInstructions.every((instruction) =>
+    jupiterSwapProgramIds.has(instruction.programId)
+  )
   if (!areJupiterAllowedPrograms) {
     return false
   }
 
-  const createAssociatedTokenAccountInstruction = instructions[
-    JUPITER_CREATE_ASSOCIATED_TOKEN_ACCOUNT_INSTRUCTION_INDEX
-  ]
-  const feePayerKey = createAssociatedTokenAccountInstruction.keys[
-    JUPITER_CREATE_ASSOCIATED_TOKEN_ACCOUNT_FEE_PAYER_ACCOUNT_INDEX
-  ]
-  const tempHoldingAccount = createAssociatedTokenAccountInstruction.keys[
-    JUPITER_CREATE_ASSOCIATED_TOKEN_ACCOUNT_TEMP_HOLDING_ACCOUNT_INDEX
-  ]
-  const tempHoldingAccountOwner = createAssociatedTokenAccountInstruction.keys[
-    JUPITER_CREATE_ASSOCIATED_TOKEN_ACCOUNT_TEMP_HOLDING_ACCOUNT_OWNER_INDEX
-  ]
-  const isCorrectFeePayer = feePayerKey.pubkey === tempHoldingAccountOwner.pubkey
+  const createAssociatedTokenAccountInstruction =
+    instructions[JUPITER_CREATE_ASSOCIATED_TOKEN_ACCOUNT_INSTRUCTION_INDEX]
+  const feePayerKey =
+    createAssociatedTokenAccountInstruction.keys[
+      JUPITER_CREATE_ASSOCIATED_TOKEN_ACCOUNT_FEE_PAYER_ACCOUNT_INDEX
+    ]
+  const tempHoldingAccount =
+    createAssociatedTokenAccountInstruction.keys[
+      JUPITER_CREATE_ASSOCIATED_TOKEN_ACCOUNT_TEMP_HOLDING_ACCOUNT_INDEX
+    ]
+  const tempHoldingAccountOwner =
+    createAssociatedTokenAccountInstruction.keys[
+      JUPITER_CREATE_ASSOCIATED_TOKEN_ACCOUNT_TEMP_HOLDING_ACCOUNT_OWNER_INDEX
+    ]
+  const isCorrectFeePayer =
+    feePayerKey.pubkey === tempHoldingAccountOwner.pubkey
   if (!isCorrectFeePayer) {
     return false
   }
 
-  const setTokenLedgerInstruction = instructions[
-    JUPITER_SET_TOKEN_LEDGER_INSTRUCTION_INDEX
-  ]
-  const isCorrectTokenLedgerTokenAccount = setTokenLedgerInstruction.keys[
-    JUPITER_SET_TOKEN_LEDGER_TOKEN_ACCOUNT_INDEX
-  ].pubkey === tempHoldingAccount.pubkey
+  const setTokenLedgerInstruction =
+    instructions[JUPITER_SET_TOKEN_LEDGER_INSTRUCTION_INDEX]
+  const isCorrectTokenLedgerTokenAccount =
+    setTokenLedgerInstruction.keys[JUPITER_SET_TOKEN_LEDGER_TOKEN_ACCOUNT_INDEX]
+      .pubkey === tempHoldingAccount.pubkey
   if (!isCorrectTokenLedgerTokenAccount) {
     return false
   }
 
   const swapInstruction = instructions[JUPITER_SWAP_INSTRUCTION_INDEX]
-  const isCorrectHoldingAccountOwner = swapInstruction.keys[
-    JUPITER_SWAP_TEMP_HOLDING_ACCOUNT_OWNER_INDEX
-  ].pubkey === tempHoldingAccountOwner.pubkey
-  const isCorrectHoldingAccount = swapInstruction.keys[
-    JUPITER_SWAP_TEMP_HOLDING_ACCOUNT_INDEX
-  ].pubkey === tempHoldingAccount.pubkey
+  const isCorrectHoldingAccountOwner =
+    swapInstruction.keys[JUPITER_SWAP_TEMP_HOLDING_ACCOUNT_OWNER_INDEX]
+      .pubkey === tempHoldingAccountOwner.pubkey
+  const isCorrectHoldingAccount =
+    swapInstruction.keys[JUPITER_SWAP_TEMP_HOLDING_ACCOUNT_INDEX].pubkey ===
+    tempHoldingAccount.pubkey
   if (!isCorrectHoldingAccountOwner || !isCorrectHoldingAccount) {
     return false
   }
 
-  const closeAssociatedTokenAccountInstruction = instructions[
-    JUPITER_CLOSE_ASSOCIATED_TOKEN_ACCOUNT_INSTRUCTION_INDEX
-  ]
-  const isCorrectClosedAccount = closeAssociatedTokenAccountInstruction.keys[
-    JUPITER_CLOSE_ASSOCIATED_TOKEN_ACCOUNT_TEMP_HOLDING_ACCOUNT_INDEX
-  ].pubkey === tempHoldingAccount.pubkey
-  const isCorrectClosedAccountDestination = closeAssociatedTokenAccountInstruction.keys[
-    JUPITER_CLOSE_ASSOCIATED_TOKEN_ACCOUNT_DESTINATION_INDEX
-  ].pubkey === tempHoldingAccountOwner.pubkey
-  const isCorrectClosedAccountOwner = closeAssociatedTokenAccountInstruction.keys[
-    JUPITER_CLOSE_ASSOCIATED_TOKEN_ACCOUNT_TEMP_HOLDING_ACCOUNT_OWNER_INDEX
-  ].pubkey === tempHoldingAccountOwner.pubkey
-  if (!isCorrectClosedAccount || !isCorrectClosedAccountDestination || !isCorrectClosedAccountOwner) {
+  const closeAssociatedTokenAccountInstruction =
+    instructions[JUPITER_CLOSE_ASSOCIATED_TOKEN_ACCOUNT_INSTRUCTION_INDEX]
+  const isCorrectClosedAccount =
+    closeAssociatedTokenAccountInstruction.keys[
+      JUPITER_CLOSE_ASSOCIATED_TOKEN_ACCOUNT_TEMP_HOLDING_ACCOUNT_INDEX
+    ].pubkey === tempHoldingAccount.pubkey
+  const isCorrectClosedAccountDestination =
+    closeAssociatedTokenAccountInstruction.keys[
+      JUPITER_CLOSE_ASSOCIATED_TOKEN_ACCOUNT_DESTINATION_INDEX
+    ].pubkey === tempHoldingAccountOwner.pubkey
+  const isCorrectClosedAccountOwner =
+    closeAssociatedTokenAccountInstruction.keys[
+      JUPITER_CLOSE_ASSOCIATED_TOKEN_ACCOUNT_TEMP_HOLDING_ACCOUNT_OWNER_INDEX
+    ].pubkey === tempHoldingAccountOwner.pubkey
+  if (
+    !isCorrectClosedAccount ||
+    !isCorrectClosedAccountDestination ||
+    !isCorrectClosedAccountOwner
+  ) {
     return false
   }
 


### PR DESCRIPTION
### Description

We already had checks for our other relay instructions. Now, with the introduction of USDC withdrawals, there will be occasional conditional creations of USDC associated token accounts, the process of which uses Jupiter to swap USDC to SOL at some point in the flow. This PR adds checks for that swap to make sure we are talking to the expected programs and interacts with the expected accounts.

### How Has This Been Tested?

... TBD

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._
