### PR TITLE
Require init step before triggering workflows

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -231,6 +231,7 @@ workflows:
             .* run-probers-workflow true
           requires:
             - generate-config
+            - init
           workspace_path: ../workspace
 
       - path-filtering/filter:
@@ -252,6 +253,7 @@ workflows:
             .* run-sdk-workflow true
           requires:
             - generate-config
+            - init
           workspace_path: ../workspace
 
       - path-filtering/filter:
@@ -268,6 +270,7 @@ workflows:
             .* run-probers-workflow false
           requires:
             - generate-config
+            - init
           workspace_path: ../workspace
 
   release-create-branch:


### PR DESCRIPTION
### Description

Add `init` as a required step before continuing workflows

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._
