### PR TITLE
[PAY-1825] Wait to render dashboard on listen data

### DIFF
--- a/packages/web/src/pages/artist-dashboard-page/ArtistDashboardPage.tsx
+++ b/packages/web/src/pages/artist-dashboard-page/ArtistDashboardPage.tsx
@@ -198,7 +198,7 @@ export const ArtistDashboardPage = () => {
       contentClassName={styles.pageContainer}
       header={header}
     >
-      {!account || !balance || status === Status.LOADING ? (
+      {!account || !balance || !listenData || status === Status.LOADING ? (
         <LoadingSpinner className={styles.spinner} />
       ) : (
         <>


### PR DESCRIPTION
### Description

Currently there is an intermediary loading state where the dashboard starts rendering, but the table is not ready. Make it so we fail for all the data while we show the spinner. Probably skeletons here would be nice someday.

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._

`npm run web:stage`