### PR TITLE
Add purchased track to library; fix favoriting purchased tracks PAY-1829 PAY-1788

### DIFF
--- a/packages/web/src/common/store/pages/saved/lineups/sagas.js
+++ b/packages/web/src/common/store/pages/saved/lineups/sagas.js
@@ -195,7 +195,7 @@ function* watchRemoveFromLibrary() {
     const { trackId, type } = action
     const removedTrackSelector =
       type === UNSAVE_TRACK ? getLocalTrackFavorite : getLocalTrackRepost
-    const removedTrackUid = yield select(removedTrackSelector, {
+    const localSaveUid = yield select(removedTrackSelector, {
       id: trackId
     })
     const currentCategory = yield select(getCategory, {
@@ -218,13 +218,13 @@ function* watchRemoveFromLibrary() {
     ) {
       const playerUid = yield select(getPlayerUid)
       const queueSource = yield select(getSource)
-      if (removedTrackUid) {
-        yield put(savedTracksActions.remove(Kind.TRACKS, removedTrackUid))
+      if (localSaveUid) {
+        yield put(savedTracksActions.remove(Kind.TRACKS, localSaveUid))
         if (
-          removedTrackUid !== playerUid &&
+          localSaveUid !== playerUid &&
           queueSource === QueueSource.SAVED_TRACKS
         ) {
-          yield put(queueActions.remove({ uid: removedTrackUid }))
+          yield put(queueActions.remove({ uid: localSaveUid }))
         }
       }
       const lineupSaveUid = yield select(getSavedTracksLineupUid, {


### PR DESCRIPTION
### Description
- Add track to library upon purchasing
- Fix "local state when favoriting purchased tracks not being tracked correctly" by making sure we only add the track to the current lineup when we're on the relevant category 
 
### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._
