### PR TITLE
[PROTO-1250] Move celery to eventlets

### DIFF
--- a/discovery-provider/scripts/start.sh
+++ b/discovery-provider/scripts/start.sh
@@ -52,7 +52,7 @@ if [[ "$audius_discprov_dev_mode" == "true" ]]; then
         [ -e /var/celerybeat-schedule ] && rm /var/celerybeat-schedule
         [ -e /var/celerybeat.pid ] && rm /var/celerybeat.pid
         audius_service=beat celery -A src.worker.celery beat --schedule=/var/celerybeat-schedule --pidfile=/var/celerybeat.pid --loglevel WARNING 2>&1 | tee >(logger -t beat) &
-        audius_service=worker watchmedo auto-restart --directory ./ --pattern=*.py --recursive -- celery -A src.worker.celery worker --loglevel $audius_discprov_loglevel 2>&1 | tee >(logger -t worker) &
+        audius_service=worker watchmedo auto-restart --directory ./ --pattern=*.py --recursive -- celery -A src.worker.celery worker --pool eventlet --concurrency 50 --loglevel $audius_discprov_loglevel 2>&1 | tee >(logger -t worker) &
     fi
 else
     if [[ "$audius_no_server" != "true" ]] && [[ "$audius_no_server" != "1" ]]; then
@@ -64,7 +64,7 @@ else
         [ -e /var/celerybeat-schedule ] && rm /var/celerybeat-schedule
         [ -e /var/celerybeat.pid ] && rm /var/celerybeat.pid
         audius_service=beat celery -A src.worker.celery beat --schedule=/var/celerybeat-schedule --pidfile=/var/celerybeat.pid --loglevel WARNING 2>&1 | tee >(logger -t beat) &
-        audius_service=worker celery -A src.worker.celery worker --max-memory-per-child 300000 --loglevel $audius_discprov_loglevel 2>&1 | tee >(logger -t worker) &
+        audius_service=worker celery -A src.worker.celery worker --pool eventlet --concurrency 50 --loglevel $audius_discprov_loglevel 2>&1 | tee >(logger -t worker) &
     fi
 fi
 


### PR DESCRIPTION
### Description

Move celery to eventlets from prefork concurrency model.
Set --concurrency to 50 to be >= number of celery tasks we spawn.

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._

tested on stage discovery 1