### PR TITLE
Always delete gcp disks after workflow completion and instance removal

### DIFF
--- a/.circleci/src/commands/gcp-run.yml
+++ b/.circleci/src/commands/gcp-run.yml
@@ -58,7 +58,7 @@ steps:
       when: always
       shell: /tmp/bash.real
       command: |
-        gcloud compute instances delete --quiet --delete-disks=all "<< parameters.instance-name >>"
+        gcloud compute instances delete --quiet "<< parameters.instance-name >>"
         gcloud compute firewall-rules delete --quiet "<< parameters.instance-name >>"
 
         mv /bin/bash /tmp/bash.deleted

--- a/.circleci/src/commands/gcp-run.yml
+++ b/.circleci/src/commands/gcp-run.yml
@@ -58,12 +58,7 @@ steps:
       when: always
       shell: /tmp/bash.real
       command: |
-        if [[ -f /tmp/success ]]; then
-          gcloud compute instances delete --quiet "<< parameters.instance-name >>"
-        else
-          gcloud compute instances delete --quiet --delete-disks=all "<< parameters.instance-name >>"
-        fi
-
+        gcloud compute instances delete --quiet --delete-disks=all "<< parameters.instance-name >>"
         gcloud compute firewall-rules delete --quiet "<< parameters.instance-name >>"
 
         mv /bin/bash /tmp/bash.deleted

--- a/.circleci/src/jobs/build-gcp-image.yml
+++ b/.circleci/src/jobs/build-gcp-image.yml
@@ -31,7 +31,6 @@ steps:
         --machine-type=n2-custom-6-24576
         --boot-disk-size=160G
         --boot-disk-type=pd-ssd
-        --no-boot-disk-auto-delete
       steps:
         - gcp-checkout
         - run: AUDIUS_DEV=false bash ~/audius-protocol/dev-tools/setup.sh

--- a/.circleci/src/jobs/build-gcp-image.yml
+++ b/.circleci/src/jobs/build-gcp-image.yml
@@ -31,6 +31,7 @@ steps:
         --machine-type=n2-custom-6-24576
         --boot-disk-size=160G
         --boot-disk-type=pd-ssd
+        --no-boot-disk-auto-delete
       steps:
         - gcp-checkout
         - run: AUDIUS_DEV=false bash ~/audius-protocol/dev-tools/setup.sh

--- a/.circleci/src/jobs/gcp-cleanup.yml
+++ b/.circleci/src/jobs/gcp-cleanup.yml
@@ -6,7 +6,7 @@ steps:
   - run:
       name: Cleanup Instances
       command: |
-        old_instances=$(gcloud compute instances list --format="csv(name)[no-heading]" --filter="creationTimestamp < -P2H AND name~'circleci-.*'" --sort-by=creationTimestamp)
+        old_instances=$(gcloud compute instances list --format="csv(name)[no-heading]" --filter="creationTimestamp < -P1H AND name~'circleci-.*'" --sort-by=creationTimestamp)
         if [[ "$old_instances" != "" ]]; then
           echo "Deleting instances:" $old_instances
           gcloud compute instances delete --quiet $old_instances
@@ -22,7 +22,7 @@ steps:
   - run:
       name: Cleanup Firewall Rules
       command: |
-        old_firewalls=$(gcloud compute firewall-rules list --format="csv(name)[no-heading]" --filter="creationTimestamp < -P2H AND name~'circleci-.*'" --sort-by=creationTimestamp)
+        old_firewalls=$(gcloud compute firewall-rules list --format="csv(name)[no-heading]" --filter="creationTimestamp < -P1H AND name~'circleci-.*'" --sort-by=creationTimestamp)
         if [[ "$old_images" != "" ]]; then
           echo "Deleting firewalls:" $old_firewalls
           gcloud compute firewall-rules delete --quiet $old_firewalls


### PR DESCRIPTION
### Description

There is unneeded ambiguity regarding when disks should be deleted in gcp after a CircleCI workflow. We decided to enforce deletion.

### How Has This Been Tested?

Must verify CircleCI workflows delete instances properly