### PR TITLE
[C-3071] Fix collection upload validation

### DIFF
--- a/packages/web/src/pages/upload-page/forms/EditCollectionForm.tsx
+++ b/packages/web/src/pages/upload-page/forms/EditCollectionForm.tsx
@@ -56,7 +56,6 @@ export const EditCollectionForm = (props: EditCollectionFormProps) => {
       mood: null,
       tags: ''
     },
-    // @ts-expect-error issues with track schema
     tracks: tracks.map((track) => ({ ...track, override: false }))
   }
 

--- a/packages/web/src/pages/upload-page/validation.ts
+++ b/packages/web/src/pages/upload-page/validation.ts
@@ -117,6 +117,8 @@ export const TrackMetadataFormSchema = TrackMetadataSchema.refine(
 
 export type TrackMetadata = z.input<typeof TrackMetadataSchema>
 
+const CollectionTrackMetadataSchema = TrackMetadataSchema.pick({ title: true })
+
 const createCollectionSchema = (collectionType: 'playlist' | 'album') =>
   z.object({
     artwork: z
@@ -143,7 +145,7 @@ const createCollectionSchema = (collectionType: 'playlist' | 'album') =>
       tags: z.optional(z.string())
     }),
     is_album: z.literal(collectionType === 'album'),
-    tracks: z.array(TrackMetadataSchema)
+    tracks: z.array(z.object({ metadata: CollectionTrackMetadataSchema }))
   })
 
 export const PlaylistSchema = createCollectionSchema('playlist')


### PR DESCRIPTION
### Description

Fixed hidden validation error causing the form to be un-submittable.

We were not unpacking the track's `.metadata` before validation. After that, we were failing on `description` which is optional here, so just picked the title field.

### How Has This Been Tested?

local web