### PR TITLE
[PAY-1774] Fix previewing in web chat track tiles

### DIFF
--- a/packages/common/src/hooks/chats/useTrackPlayer.ts
+++ b/packages/common/src/hooks/chats/useTrackPlayer.ts
@@ -17,6 +17,7 @@ type RecordAnalytics = ({ name, id }: { name: TrackPlayback; id: ID }) => void
 type UseToggleTrack = {
   uid: Nullable<string>
   source: QueueSource
+  isPreview?: boolean
   recordAnalytics?: RecordAnalytics
   id?: Nullable<ID>
 }
@@ -34,11 +35,21 @@ export const usePlayTrack = (recordAnalytics?: RecordAnalytics) => {
   const playingUid = useSelector(getUid)
 
   const playTrack = useCallback(
-    ({ id, uid, entries }: { id?: ID; uid: string; entries: Queueable[] }) => {
+    ({
+      id,
+      uid,
+      isPreview,
+      entries
+    }: {
+      id?: ID
+      uid: string
+      isPreview?: boolean
+      entries: Queueable[]
+    }) => {
       if (playingUid !== uid) {
         dispatch(clear({}))
         dispatch(add({ entries }))
-        dispatch(play({ uid }))
+        dispatch(play({ uid, isPreview }))
       } else {
         dispatch(play({}))
       }
@@ -82,6 +93,7 @@ export const usePauseTrack = (recordAnalytics?: RecordAnalytics) => {
  * @typedef {Object} UseToggleTrackProps
  * @property {string} uid the uid of the track (nullable)
  * @property {string} source the queue source
+ * @property {boolean} isPreview whether the track is a preview
  * @property {Function} recordAnalytics the function that tracks the event
  * @property {number} id the id of the track (nullable and optional)
  */
@@ -107,6 +119,7 @@ export const usePauseTrack = (recordAnalytics?: RecordAnalytics) => {
 export const useToggleTrack = ({
   uid,
   source,
+  isPreview,
   recordAnalytics,
   id
 }: UseToggleTrack) => {
@@ -126,9 +139,14 @@ export const useToggleTrack = ({
     if (isTrackPlaying) {
       pauseTrack(id)
     } else {
-      playTrack({ id, uid, entries: [{ id, uid, source }] })
+      playTrack({
+        id,
+        uid,
+        isPreview,
+        entries: [{ id, uid, source, isPreview }]
+      })
     }
-  }, [playTrack, pauseTrack, isTrackPlaying, id, uid, source])
+  }, [playTrack, pauseTrack, isTrackPlaying, id, uid, isPreview, source])
 
   return { togglePlay, isTrackPlaying }
 }

--- a/packages/mobile/src/screens/chat-screen/ChatMessageTrack.tsx
+++ b/packages/mobile/src/screens/chat-screen/ChatMessageTrack.tsx
@@ -10,7 +10,8 @@ import {
   getPathFromTrackUrl,
   makeUid,
   useGetTrackByPermalink,
-  useToggleTrack
+  useToggleTrack,
+  usePremiumContentAccess
 } from '@audius/common'
 import { useSelector } from 'react-redux'
 
@@ -35,6 +36,9 @@ export const ChatMessageTrack = ({
     },
     { disabled: !permalink }
   )
+  const { doesUserHaveAccess } = usePremiumContentAccess(track ?? null)
+  const isPreview =
+    !!track?.is_premium && !!track?.preview_cid && !doesUserHaveAccess
 
   const user = useMemo(() => (track ? { ...track.user } : null), [track])
 
@@ -60,6 +64,7 @@ export const ChatMessageTrack = ({
   const { togglePlay } = useToggleTrack({
     id: track?.track_id,
     uid,
+    isPreview,
     source: QueueSource.CHAT_TRACKS,
     recordAnalytics
   })

--- a/packages/web/src/components/track/helpers.ts
+++ b/packages/web/src/components/track/helpers.ts
@@ -30,6 +30,7 @@ export const getTrackWithFallback = (track: Track | null) => {
       is_premium: false,
       premium_conditions: null,
       premium_content_signature: null,
+      preview_cid: null,
       activity_timestamp: '',
       _co_sign: undefined,
       _cover_art_sizes: {

--- a/packages/web/src/components/track/mobile/ConnectedTrackTile.tsx
+++ b/packages/web/src/components/track/mobile/ConnectedTrackTile.tsx
@@ -127,7 +127,8 @@ const ConnectedTrackTile = ({
     activity_timestamp,
     play_count,
     _co_sign,
-    duration
+    duration,
+    preview_cid
   } = trackWithFallback
 
   const { artist_pick_track_id, user_id, handle, name, is_verified } =
@@ -246,6 +247,7 @@ const ConnectedTrackTile = ({
       // Playback
       permalink={permalink}
       togglePlay={togglePlay}
+      hasPreview={!!preview_cid}
       isActive={uid === playingUid || isActive}
       isLoading={loading}
       isPlaying={uid === playingUid && isPlaying}

--- a/packages/web/src/components/track/mobile/TrackTile.tsx
+++ b/packages/web/src/components/track/mobile/TrackTile.tsx
@@ -54,6 +54,7 @@ type ExtraProps = {
   isMatrix: boolean
   isPremium: boolean
   premiumConditions?: Nullable<PremiumConditions>
+  hasPreview?: boolean
   doesUserHaveAccess: boolean
 }
 
@@ -174,7 +175,8 @@ const TrackTile = (props: CombinedProps) => {
     isPlaying,
     isBuffering,
     variant,
-    containerClassName
+    containerClassName,
+    hasPreview = false
   } = props
 
   const hideShare: boolean = props.fieldVisibility
@@ -226,7 +228,7 @@ const TrackTile = (props: CombinedProps) => {
   const handleClick = useCallback(() => {
     if (showSkeleton) return
 
-    if (trackId && !doesUserHaveAccess) {
+    if (trackId && !doesUserHaveAccess && !hasPreview) {
       dispatch(setLockedContentId({ id: trackId }))
       setModalVisibility(true)
       return
@@ -240,6 +242,7 @@ const TrackTile = (props: CombinedProps) => {
     id,
     trackId,
     doesUserHaveAccess,
+    hasPreview,
     dispatch,
     setModalVisibility
   ])

--- a/packages/web/src/pages/chat-page/components/ChatMessageTrack.tsx
+++ b/packages/web/src/pages/chat-page/components/ChatMessageTrack.tsx
@@ -15,7 +15,8 @@ import {
   ChatMessageTileProps,
   cacheTracksActions,
   SquareSizes,
-  Name
+  Name,
+  usePremiumContentAccess
 } from '@audius/common'
 import { useDispatch, useSelector } from 'react-redux'
 
@@ -42,6 +43,10 @@ export const ChatMessageTrack = ({
     },
     { disabled: !permalink || !currentUserId }
   )
+
+  const { doesUserHaveAccess } = usePremiumContentAccess(track ?? null)
+  const isPreview =
+    !!track?.is_premium && !!track?.preview_cid && !doesUserHaveAccess
 
   const trackId = track?.track_id
 
@@ -71,6 +76,7 @@ export const ChatMessageTrack = ({
   const { togglePlay, isTrackPlaying } = useToggleTrack({
     id: track?.track_id,
     uid,
+    isPreview,
     source: QueueSource.CHAT_TRACKS,
     recordAnalytics
   })


### PR DESCRIPTION
### Description
Enables previewing for track tiles in the chat view. This uses a different component and code path to queue things, which needs the previewing flags to be wired up.

### How Has This Been Tested?
Tested locally in Chrome against staging

### Screenshots

![Kapture 2023-09-13 at 11 33 46](https://github.com/AudiusProject/audius-protocol/assets/1815175/7270269d-ce4f-46a5-8f07-e4ca461cd5bf)

