### PR TITLE
[PAY-1842] Update usdc twitter shares to pass track URLs correctly

### DIFF
--- a/packages/mobile/src/components/premium-track-purchase-drawer/PurchaseSuccess.tsx
+++ b/packages/mobile/src/components/premium-track-purchase-drawer/PurchaseSuccess.tsx
@@ -8,14 +8,15 @@ import { Text } from 'app/components/core'
 import { flexRowCentered, makeStyles } from 'app/styles'
 import { spacing } from 'app/styles/spacing'
 import { EventNames } from 'app/types/analytics'
+import { getTrackRoute } from 'app/utils/routes'
 import { useThemeColors } from 'app/utils/theme'
 
 import { TwitterButton } from '../twitter-button'
 
 const messages = {
   success: 'Your purchase was successful!',
-  shareTwitterText: (trackTitle: string, handle: string, trackUrl: string) =>
-    `I bought the track ${trackTitle} by ${handle} on Audius! #AudiusPremium ${trackUrl}`
+  shareTwitterText: (trackTitle: string, handle: string) =>
+    `I bought the track ${trackTitle} by ${handle} on Audius! #AudiusPremium`
 }
 
 const useStyles = makeStyles(({ spacing, typography, palette }) => ({
@@ -35,11 +36,12 @@ export const PurchaseSuccess = ({ track }: { track: UserTrackMetadata }) => {
   const styles = useStyles()
   const { specialGreen, staticWhite } = useThemeColors()
   const { handle } = track.user
-  const { permalink, title } = track
+  const { title } = track
+  const link = getTrackRoute(track, true)
 
   const handleTwitterShare = useCallback(
     (handle: string) => {
-      const shareText = messages.shareTwitterText(title, handle, permalink)
+      const shareText = messages.shareTwitterText(title, handle)
       return {
         shareText,
         analytics: {
@@ -48,7 +50,7 @@ export const PurchaseSuccess = ({ track }: { track: UserTrackMetadata }) => {
         } as const
       }
     },
-    [permalink, title]
+    [title]
   )
 
   return (
@@ -65,6 +67,7 @@ export const PurchaseSuccess = ({ track }: { track: UserTrackMetadata }) => {
       <TwitterButton
         fullWidth
         type='dynamic'
+        url={link}
         shareData={handleTwitterShare}
         handle={handle}
         size='large'

--- a/packages/mobile/src/screens/notifications-screen/Notifications/USDCPurchaseBuyerNotification.tsx
+++ b/packages/mobile/src/screens/notifications-screen/Notifications/USDCPurchaseBuyerNotification.tsx
@@ -21,6 +21,7 @@ import {
   UserNameLink,
   EntityLink
 } from '../Notification'
+import { getEntityRoute } from '../Notification/utils'
 
 const { getNotificationUsers, getNotificationEntity } = notificationsSelectors
 
@@ -29,12 +30,8 @@ const messages = {
   youJustPurchased: 'You just purchased ',
   from: ' from ',
   exclamation: '!',
-  twitterShare: (
-    trackTitle: string,
-    sellerHandle: string,
-    trackPermalink: string
-  ) =>
-    `I bought the track ${trackTitle} by ${sellerHandle} on Audius! #AudiusPremium https://audius.co${trackPermalink}`
+  twitterShare: (trackTitle: string, sellerHandle: string) =>
+    `I bought the track ${trackTitle} by ${sellerHandle} on Audius! #AudiusPremium`
 }
 type USDCPurchaseBuyerNotificationProps = {
   notification: USDCPurchaseBuyerNotificationType
@@ -55,11 +52,7 @@ export const USDCPurchaseBuyerNotification = ({
   const handleShare = useCallback(
     (sellerHandle: string) => {
       const trackTitle = track?.title || ''
-      const shareText = messages.twitterShare(
-        trackTitle,
-        sellerHandle,
-        track?.permalink || ''
-      )
+      const shareText = messages.twitterShare(trackTitle, sellerHandle)
       const analytics = make(
         Name.NOTIFICATIONS_CLICK_USDC_PURCHASE_TWITTER_SHARE,
         { text: shareText }
@@ -89,6 +82,7 @@ export const USDCPurchaseBuyerNotification = ({
       </NotificationText>
       <NotificationTwitterButton
         type='dynamic'
+        url={getEntityRoute(track)}
         handle={sellerUser.handle}
         shareData={handleShare}
       />

--- a/packages/mobile/src/screens/notifications-screen/Notifications/USDCPurchaseBuyerNotification.tsx
+++ b/packages/mobile/src/screens/notifications-screen/Notifications/USDCPurchaseBuyerNotification.tsx
@@ -82,7 +82,7 @@ export const USDCPurchaseBuyerNotification = ({
       </NotificationText>
       <NotificationTwitterButton
         type='dynamic'
-        url={getEntityRoute(track)}
+        url={getEntityRoute(track, true)}
         handle={sellerUser.handle}
         shareData={handleShare}
       />

--- a/packages/web/src/components/notification/Notification/USDCPurchaseBuyerNotification.tsx
+++ b/packages/web/src/components/notification/Notification/USDCPurchaseBuyerNotification.tsx
@@ -32,12 +32,8 @@ const messages = {
   youJustPurchased: 'You just purchased ',
   from: ' from ',
   exclamation: '!',
-  twitterShare: (
-    trackTitle: string,
-    sellerUsername: string,
-    trackPermalink: string
-  ) =>
-    `I bought the track ${trackTitle} by ${sellerUsername} on Audius! #AudiusPremium https://audius.co${trackPermalink}`
+  twitterShare: (trackTitle: string, sellerUsername: string) =>
+    `I bought the track ${trackTitle} by ${sellerUsername} on Audius! #AudiusPremium`
 }
 
 type USDCPurchaseBuyerNotificationProps = {
@@ -65,11 +61,7 @@ export const USDCPurchaseBuyerNotification = (
   const handleShare = useCallback(
     (sellerHandle: string) => {
       const trackTitle = track?.title || ''
-      const shareText = messages.twitterShare(
-        trackTitle,
-        sellerHandle,
-        track?.permalink || ''
-      )
+      const shareText = messages.twitterShare(trackTitle, sellerHandle)
       const analytics = make(
         Name.NOTIFICATIONS_CLICK_USDC_PURCHASE_TWITTER_SHARE,
         { text: shareText }
@@ -93,6 +85,7 @@ export const USDCPurchaseBuyerNotification = (
       </NotificationBody>
       <TwitterShareButton
         type='dynamic'
+        url={getEntityLink(track, true)}
         handle={sellerUser.handle}
         shareData={handleShare}
       />

--- a/packages/web/src/components/premium-content-purchase-modal/components/PurchaseDetailsPage.tsx
+++ b/packages/web/src/components/premium-content-purchase-modal/components/PurchaseDetailsPage.tsx
@@ -89,7 +89,7 @@ export const PurchaseDetailsPage = ({
   const stage = useSelector(getPurchaseContentFlowStage)
   const error = useSelector(getPurchaseContentError)
   const isUnlocking = !error && isContentPurchaseInProgress(stage)
-  const isPurchased = stage !== PurchaseContentStage.FINISH
+  const isPurchased = stage === PurchaseContentStage.FINISH
   const { handle } = track.user
   const { permalink, title } = track
 

--- a/packages/web/src/components/premium-content-purchase-modal/components/PurchaseDetailsPage.tsx
+++ b/packages/web/src/components/premium-content-purchase-modal/components/PurchaseDetailsPage.tsx
@@ -31,7 +31,7 @@ import LoadingSpinner from 'components/loading-spinner/LoadingSpinner'
 import { LockedTrackDetailsTile } from 'components/track/LockedTrackDetailsTile'
 import { TwitterShareButton } from 'components/twitter-share-button/TwitterShareButton'
 import { Text } from 'components/typography'
-import { pushUniqueRoute } from 'utils/route'
+import { fullTrackPage, pushUniqueRoute } from 'utils/route'
 
 import { FormatPrice } from './FormatPrice'
 import { PayToUnlockInfo } from './PayToUnlockInfo'
@@ -47,10 +47,9 @@ const messages = {
   purchasing: 'Purchasing',
   purchaseSuccessful: 'Your Purchase Was Successful!',
   error: 'Your purchase was unsuccessful.',
-  // TODO: PAY-1723
   shareButtonContent: 'I just purchased a track on Audius!',
-  shareTwitterText: (trackTitle: string, handle: string, trackUrl: string) =>
-    `I bought the track ${trackTitle} by ${handle} on Audius! #AudiusPremium ${trackUrl}`,
+  shareTwitterText: (trackTitle: string, handle: string) =>
+    `I bought the track ${trackTitle} by ${handle} on Audius! #AudiusPremium`,
   viewTrack: 'View Track'
 }
 
@@ -90,7 +89,7 @@ export const PurchaseDetailsPage = ({
   const stage = useSelector(getPurchaseContentFlowStage)
   const error = useSelector(getPurchaseContentError)
   const isUnlocking = !error && isContentPurchaseInProgress(stage)
-  const isPurchased = stage === PurchaseContentStage.FINISH
+  const isPurchased = stage !== PurchaseContentStage.FINISH
   const { handle } = track.user
   const { permalink, title } = track
 
@@ -109,13 +108,13 @@ export const PurchaseDetailsPage = ({
 
   const handleTwitterShare = useCallback(
     (handle: string) => {
-      const shareText = messages.shareTwitterText(title, handle, permalink)
+      const shareText = messages.shareTwitterText(title, handle)
       const analytics = make(Name.PURCHASE_CONTENT_TWITTER_SHARE, {
         text: shareText
       })
       return { shareText, analytics }
     },
-    [permalink, title]
+    [title]
   )
 
   if (!isPremiumContentUSDCPurchaseGated(track.premium_conditions)) {
@@ -169,6 +168,7 @@ export const PurchaseDetailsPage = ({
           <TwitterShareButton
             fullWidth
             type='dynamic'
+            url={fullTrackPage(permalink)}
             shareData={handleTwitterShare}
             handle={handle}
           />


### PR DESCRIPTION
### Description
We have a few different patterns for how to pass URLs to twitter share messages 😅 . But the most common seems to be passing a `url` prop to the button and letting it use the built-in utility to add a URL via query param when launching the intent. This seems like the correct behavior[ indicated by the docs](https://developer.twitter.com/en/docs/twitter-for-websites/tweet-button/guides/web-intent)

### How Has This Been Tested?
Tested locally in Chrome and simulator against staging
