### PR TITLE
[C-3080] Hide artwork for collection uploads

### DIFF
--- a/packages/web/src/pages/upload-page/components/FinishPageNew.tsx
+++ b/packages/web/src/pages/upload-page/components/FinishPageNew.tsx
@@ -6,7 +6,8 @@ import {
   imageBlank as placeholderArt,
   Progress,
   ProgressStatus,
-  uploadSelectors
+  uploadSelectors,
+  UploadType
 } from '@audius/common'
 import {
   HarmonyPlainButton,
@@ -61,13 +62,21 @@ const ProgressIndicator = (props: { status?: ProgressStatus }) => {
 type UploadTrackItemProps = {
   index: number
   displayIndex?: boolean
+  displayArtwork?: boolean
   track: TrackForUpload
   trackProgress?: Progress
   hasError: boolean
 }
 
 const UploadTrackItem = (props: UploadTrackItemProps) => {
-  const { index, hasError, track, trackProgress, displayIndex = false } = props
+  const {
+    index,
+    hasError,
+    track,
+    trackProgress,
+    displayIndex = false,
+    displayArtwork = false
+  } = props
   // @ts-ignore - Artwork exists on track metadata object
   const artworkUrl = track.metadata.artwork.url
 
@@ -83,10 +92,12 @@ const UploadTrackItem = (props: UploadTrackItemProps) => {
         }
       />
       {displayIndex ? <Text size='small'>{index + 1}</Text> : null}
-      <DynamicImage
-        wrapperClassName={styles.trackItemArtwork}
-        image={artworkUrl || placeholderArt}
-      />
+      {displayArtwork ? (
+        <DynamicImage
+          wrapperClassName={styles.trackItemArtwork}
+          image={artworkUrl || placeholderArt}
+        />
+      ) : null}
       <Text size='small'>{track.metadata.title}</Text>
     </div>
   )
@@ -99,7 +110,7 @@ type FinishPageProps = {
 
 export const FinishPageNew = (props: FinishPageProps) => {
   const { formState, onContinue } = props
-  const { tracks } = formState
+  const { tracks, uploadType } = formState
   const accountUser = useSelector(getAccountUser)
   const upload = useSelector((state: CommonState) => state.upload)
   const user = useSelector(getAccountUser)
@@ -174,6 +185,10 @@ export const FinishPageNew = (props: FinishPageProps) => {
                 displayIndex={tracks.length > 1}
                 index={idx}
                 trackProgress={trackProgress}
+                displayArtwork={
+                  uploadType === UploadType.INDIVIDUAL_TRACK ||
+                  uploadType === UploadType.INDIVIDUAL_TRACKS
+                }
                 hasError={trackError !== undefined}
               />
             )


### PR DESCRIPTION
### Description

Per design, artwork should be hidden on collection tracks in the upload progress display
<img width="583" alt="Screenshot 2023-09-13 at 12 23 36 PM" src="https://github.com/AudiusProject/audius-protocol/assets/2358254/2e4e6e9a-01df-43ea-8672-7657f3112f99">


### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._
