### PR TITLE
[C-3082] Fix track extension on select page

### DIFF
--- a/packages/web/src/components/upload/TrackPreviewNew.tsx
+++ b/packages/web/src/components/upload/TrackPreviewNew.tsx
@@ -51,8 +51,6 @@ export const TrackPreviewNew = (props: TrackPreviewProps) => {
     onRemove
   } = props
 
-  const fileExtension = fileType.split('/')[1] ?? null
-
   return (
     <div className={styles.trackPreviewNew}>
       {displayIndex ? (
@@ -67,7 +65,6 @@ export const TrackPreviewNew = (props: TrackPreviewProps) => {
       />
       <Text className={styles.titleText} size='small'>
         {trackTitle}
-        {fileExtension ? `.${fileExtension}` : null}
       </Text>
       <div className={styles.sizeContainer}>
         <Text

--- a/packages/web/src/pages/upload-page/components/TracksPreviewNew.tsx
+++ b/packages/web/src/pages/upload-page/components/TracksPreviewNew.tsx
@@ -81,7 +81,7 @@ export const TracksPreviewNew = (props: TracksPreviewProps) => {
             index={i}
             displayIndex={tracks.length > 1}
             key={track.metadata.title + i}
-            trackTitle={track.metadata.title}
+            trackTitle={track.file.name}
             fileType={track.file.type}
             fileSize={track.file.size}
             onRemove={() => onRemove(i)}


### PR DESCRIPTION
### Description

Trust the file name to have the correct extension already. Doesn't necessarily have to match the mime type.

Before:
![image](https://github.com/AudiusProject/audius-protocol/assets/2358254/d60a9bd9-2dc9-4ed3-9487-7e469932e245)

After:
<img width="561" alt="image" src="https://github.com/AudiusProject/audius-protocol/assets/2358254/ce2a2cc5-7ac1-4c66-bb26-0c0135987ec2">


### How Has This Been Tested?
local web