### PR TITLE
[PAY-1841] Fix some issues with setting preview start times

### DIFF
--- a/packages/common/src/schemas/index.ts
+++ b/packages/common/src/schemas/index.ts
@@ -28,6 +28,7 @@ const trackMetadataSchema = {
   is_unlisted: false,
   is_premium: false,
   premium_conditions: null,
+  preview_start_seconds: null,
   field_visibility: {
     genre: true,
     mood: true,

--- a/packages/web/src/components/track/EditTrackModal.js
+++ b/packages/web/src/components/track/EditTrackModal.js
@@ -121,6 +121,7 @@ const EditTrackModal = ({
           showHideTrackSectionInModal={false}
           onOpenArtworkPopup={onOpenArtworkPopup}
           onCloseArtworkPopup={onCloseArtworkPopup}
+          trackLength={metadata ? metadata.duration : null}
         />
         <div className={styles.buttons}>
           <div className={styles.buttonsLeft}>

--- a/packages/web/src/pages/upload-page/fields/AccessAndSaleField.tsx
+++ b/packages/web/src/pages/upload-page/fields/AccessAndSaleField.tsx
@@ -165,7 +165,9 @@ export const AccessAndSaleFormSchema = (trackLength: number) =>
         if (isPremiumContentUSDCPurchaseGated(formValues[PREMIUM_CONDITIONS])) {
           return (
             formValues[PREVIEW] === undefined ||
-            (formValues[PREVIEW] >= 0 && formValues[PREVIEW] < trackLength - 30)
+            (formValues[PREVIEW] >= 0 &&
+              formValues[PREVIEW] < trackLength - 30) ||
+            (trackLength <= 30 && formValues[PREVIEW] < trackLength)
           )
         }
         return true


### PR DESCRIPTION
### Description
1. We need to ignore the > 30 seconds from the end requirement if the track isn't at least 30 seconds long
2. We did not have `preview_start_seconds` as one of the fields in our validation metadata, so it was being stripped during update calls. There is still an issue where the preview stream isn't being updated, but we are at least setting the right metadata now.

### How Has This Been Tested?
Tested locally against staging in Chrome
