### PR TITLE
Filter users by followers in sitemaps

### DIFF
--- a/discovery-provider/integration_tests/queries/test_get_sitemap.py
+++ b/discovery-provider/integration_tests/queries/test_get_sitemap.py
@@ -62,8 +62,11 @@ def test_get_sitemaps(mock_set_base_url, mock_get_client_base_url, app):
                 for i in range(10)
             ],
             "users": [{"user_id": i, "handle": f"user_{i}"} for i in range(20)],
+        }
+        test_aggregate_user_entities = {
             "aggregate_user": [{"user_id": i, "follower_count": 10} for i in range(20)]
         }
+        populate_mock_db(db, test_aggregate_user_entities)
 
         populate_mock_db(db, test_entities)
 
@@ -179,7 +182,10 @@ def test_get_sitemaps_correct_counts(mock_set_base_url, mock_get_client_base_url
             ],
             "users": [{"user_id": i, "handle": f"user_{i}"} for i in range(20)],
         }
-
+        test_aggregate_user_entities = {
+            "aggregate_user": [{"user_id": i, "follower_count": 10} for i in range(20)]
+        }
+        populate_mock_db(db, test_aggregate_user_entities)
         populate_mock_db(db, test_entities)
 
         with db.scoped_session() as session:

--- a/discovery-provider/integration_tests/queries/test_get_sitemap.py
+++ b/discovery-provider/integration_tests/queries/test_get_sitemap.py
@@ -62,6 +62,7 @@ def test_get_sitemaps(mock_set_base_url, mock_get_client_base_url, app):
                 for i in range(10)
             ],
             "users": [{"user_id": i, "handle": f"user_{i}"} for i in range(20)],
+            "aggregate_user": [{"user_id": i, "follower_count": 10} for i in range(20)]
         }
 
         populate_mock_db(db, test_entities)

--- a/discovery-provider/src/queries/get_sitemap.py
+++ b/discovery-provider/src/queries/get_sitemap.py
@@ -192,6 +192,8 @@ def get_track_slugs(session: Session, limit: int, offset: int):
         session.query(User.handle, TrackRoute.slug)
         .join(Track, TrackRoute.track_id == Track.track_id)
         .join(User, TrackRoute.owner_id == User.user_id)
+        .join(AggregateUser, User.user_id == AggregateUser.user_id)
+        .filter(AggregateUser.follower_count >= 10)
         .filter(
             Track.is_current == True,
             Track.stem_of == None,
@@ -212,8 +214,10 @@ def get_playlist_slugs(session: Session, limit: int, offset: int):
     slugs: List[Tuple[str, str, bool]] = (
         # Handle, not handle_lc is the cannonical URL
         session.query(User.handle, PlaylistRoute.slug, Playlist.is_album)
+        .join(AggregateUser, User.user_id == AggregateUser.user_id)
         .join(User, User.user_id == PlaylistRoute.owner_id)
         .join(Playlist, PlaylistRoute.playlist_id == Playlist.playlist_id)
+        .filter(AggregateUser.follower_count >= 10)
         .filter(
             User.is_current == True,
             PlaylistRoute.is_current == True,
@@ -238,6 +242,7 @@ def get_user_slugs(session: Session, limit: int, offset: int):
         .filter(
             User.is_current == True,
             User.is_deactivated == False,
+            # Filter on handle_lc for performance reasons
             User.handle_lc != None,
             User.is_available == True,
         )

--- a/discovery-provider/src/queries/get_sitemap.py
+++ b/discovery-provider/src/queries/get_sitemap.py
@@ -214,9 +214,9 @@ def get_playlist_slugs(session: Session, limit: int, offset: int):
     slugs: List[Tuple[str, str, bool]] = (
         # Handle, not handle_lc is the cannonical URL
         session.query(User.handle, PlaylistRoute.slug, Playlist.is_album)
-        .join(AggregateUser, User.user_id == AggregateUser.user_id)
         .join(User, User.user_id == PlaylistRoute.owner_id)
         .join(Playlist, PlaylistRoute.playlist_id == Playlist.playlist_id)
+        .join(AggregateUser, User.user_id == AggregateUser.user_id)
         .filter(AggregateUser.follower_count >= 10)
         .filter(
             User.is_current == True,


### PR DESCRIPTION
### Description
Only return users with >= 10 followers in user sitemaps for performance.

### How Has This Been Tested?
Tested on sandbox.
_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._
