### PR TITLE
Better asyncio event loop handling when caching images in discovery

### DIFF
--- a/discovery-provider/src/api/v1/helpers.py
+++ b/discovery-provider/src/api/v1/helpers.py
@@ -208,10 +208,11 @@ def get_image_cids(user, upload_id, variants):
                 )
 
                 # Race requests in a new event loop
-                new_loop = asyncio.new_event_loop()
-                asyncio.set_event_loop(new_loop)
-                resp = new_loop.run_until_complete(race_requests(urls, 0.5))
-                new_loop.close()
+                try:
+                    loop = asyncio.get_event_loop()
+                    resp = loop.run_until_complete(race_requests(urls, 0.5))
+                except RuntimeError:
+                    resp = asyncio.run(race_requests(urls, 0.5))
 
                 resp.raise_for_status()
                 image_cids = resp.json().get("results", {})


### PR DESCRIPTION
### Description
use current event loop to request upload info from content if one exists, otherwise spawn a new event loop.

### How Has This Been Tested?
tested on a stage dn, verified no errors when viewing uncached image