### PR TITLE
Optimize pkeys and indices by dropping is_current

### DIFF
--- a/discovery-provider/ddl/migrations/0031_drop_current_indices.sql
+++ b/discovery-provider/ddl/migrations/0031_drop_current_indices.sql
@@ -1,3 +1,90 @@
-begin;
+-- Drop is_current from any primary keys or indices with is_current
+-- Improves performance and storage utilization
+BEGIN;
 
-commit;
+DO $$ 
+DECLARE
+    v_table_name text;
+    v_constraint_name text;
+    v_columns text;
+    drop_constraint_sql text;
+    create_constraint_sql text;
+BEGIN
+    FOR v_table_name, v_constraint_name, v_columns IN (
+        SELECT table_name, constraint_name, array_to_string(array_remove(a.constraint_columns, 'is_current'), ', ')
+        FROM (
+            SELECT
+                table_name,
+                constraint_name,
+                array_agg(column_name) AS constraint_columns
+            FROM information_schema.key_column_usage
+            GROUP BY table_name, constraint_name
+        ) a
+        WHERE 'is_current' = ANY(SELECT UNNEST(a.constraint_columns))
+        --         table_name   |   constraint_name   |               array_to_string                
+        -- ----------------+---------------------+----------------------------------------------
+        -- grants         | grants_pkey         | grantee_address, user_id, txhash
+        -- users          | users_new_pkey      | user_id, txhash
+        -- reposts        | reposts_new_pkey    | user_id, repost_item_id, repost_type, txhash
+        -- playlist_seen  | playlist_seen_pkey  | user_id, playlist_id, seen_at
+        -- subscriptions  | subscriptions_pkey  | subscriber_id, user_id, txhash
+        -- tracks         | tracks_pkey         | track_id, txhash
+        -- follows        | follows_pkey        | follower_user_id, followee_user_id, txhash
+        -- saves          | saves_new_pkey      | user_id, save_item_id, save_type, txhash
+        -- developer_apps | developer_apps_pkey | address, txhash
+        -- playlists      | playlists_pkey      | playlist_id, txhash
+    )
+    LOOP
+        drop_constraint_sql := 'ALTER TABLE ' || v_table_name || ' DROP CONSTRAINT ' || v_constraint_name || ';';
+        create_constraint_sql := 'ALTER TABLE ' || v_table_name || ' ADD PRIMARY KEY (' || v_columns || ');';
+        
+        RAISE NOTICE 'Dropping and recreating primary key for table %', v_table_name;
+        RAISE NOTICE 'Drop SQL: %', drop_constraint_sql;
+        RAISE NOTICE 'Create SQL: %', create_constraint_sql;
+        
+        -- Uncomment the next two lines to actually execute the drop and recreate SQL statements
+        EXECUTE drop_constraint_sql;
+        EXECUTE create_constraint_sql;
+    END LOOP;
+END $$;
+
+-- don't need this index anymore "users_new_created_at_user_id_idx" btree (created_at, user_id) WHERE is_current 
+DROP INDEX IF EXISTS users_new_created_at_user_id_idx;
+
+DROP INDEX IF EXISTS track_is_premium_idx;
+CREATE INDEX track_is_premium_idx ON public.tracks USING btree (is_premium, is_delete);
+
+DROP INDEX IF EXISTS users_new_is_deactivated_is_current_handle_lc_is_available_idx;
+CREATE INDEX users_new_is_deactivated_handle_lc_is_available_idx ON public.users USING btree (is_deactivated, handle_lc, is_available) WHERE ((is_deactivated = false) AND (handle_lc IS NOT NULL) AND (is_available = true));
+
+DROP INDEX IF EXISTS public.tracks_ai_attribution_user_id;
+CREATE INDEX tracks_ai_attribution_user_id ON public.tracks USING btree (ai_attribution_user_id) WHERE (ai_attribution_user_id IS NOT NULL);
+
+DROP INDEX IF EXISTS public.follows_inbound_idx;
+CREATE INDEX follows_inbound_idx ON public.follows USING btree (followee_user_id, follower_user_id, is_delete);
+
+DROP INDEX IF EXISTS public.tracks_track_cid_idx;
+CREATE INDEX tracks_track_cid_idx ON public.tracks USING btree (track_cid, is_delete);
+
+DROP INDEX IF EXISTS public.user_events_user_id_idx;
+CREATE INDEX user_events_user_id_idx ON public.user_events USING btree (user_id);
+
+DROP INDEX IF EXISTS public.track_routes_track_id_idx;
+CREATE INDEX track_routes_track_id_idx ON public.track_routes USING btree (track_id);
+
+DROP INDEX IF EXISTS public.fix_tracks_top_genre_users_idx;
+CREATE INDEX fix_tracks_top_genre_users_idx ON public.tracks USING btree (track_id, owner_id, genre, is_unlisted, is_delete) WHERE (stem_of IS NULL);
+
+DROP INDEX IF EXISTS public.ix_associated_wallets_user_id;
+CREATE INDEX ix_associated_wallets_user_id ON public.associated_wallets USING btree (user_id);
+
+DROP INDEX IF EXISTS public.ix_associated_wallets_wallet;
+CREATE INDEX ix_associated_wallets_wallet ON public.associated_wallets USING btree (wallet);
+
+DROP INDEX IF EXISTS public.fix_tracks_status_flags_idx;
+CREATE INDEX fix_tracks_status_flags_idx ON public.tracks USING btree (track_id, is_unlisted, is_delete);
+
+DROP INDEX IF EXISTS public.playlist_routes_playlist_id_idx;
+CREATE INDEX playlist_routes_playlist_id_idx ON public.playlist_routes USING btree (playlist_id);
+
+COMMIT;

--- a/discovery-provider/ddl/migrations/0031_drop_current_indices.sql
+++ b/discovery-provider/ddl/migrations/0031_drop_current_indices.sql
@@ -1,0 +1,3 @@
+begin;
+
+commit;

--- a/discovery-provider/integration_tests/queries/test_undisbursed_challeges.py
+++ b/discovery-provider/integration_tests/queries/test_undisbursed_challeges.py
@@ -38,23 +38,6 @@ def setup_challenges(app):
             ),
         ]
 
-        non_current_users = [
-            User(
-                blockhash=hex(99),
-                blocknumber=99,
-                txhash=f"xyz{i}",
-                user_id=i,
-                is_current=False,
-                handle=f"TestHandle{i}",
-                handle_lc=f"testhandle{i}",
-                wallet=f"0x{i}",
-                is_verified=False,
-                name=f"test_name{i}",
-                created_at=datetime.now(),
-                updated_at=datetime.now(),
-            )
-            for i in range(7)
-        ]
         users = [
             User(
                 blockhash=hex(99),
@@ -130,7 +113,6 @@ def setup_challenges(app):
         with db.scoped_session() as session:
             session.add_all(challenges)
             session.flush()
-            session.add_all(non_current_users)
             session.add_all(users)
             session.add_all(user_bank_accounts)
             session.add_all(user_challenges)

--- a/discovery-provider/integration_tests/queries/test_user_playlist_update.py
+++ b/discovery-provider/integration_tests/queries/test_user_playlist_update.py
@@ -67,7 +67,6 @@ def test_user_playlist_update(app):
                 {"is_current": True, "user_id": 1, "playlist_id": 1, "seen_at": t1},
                 {"is_current": True, "user_id": 1, "playlist_id": 2, "seen_at": t2},
                 {"is_current": True, "user_id": 1, "playlist_id": 3, "seen_at": t3},
-                {"is_current": False, "user_id": 1, "playlist_id": 4, "seen_at": t1},
                 {"is_current": True, "user_id": 1, "playlist_id": 4, "seen_at": t1},
             ],
         }


### PR DESCRIPTION
### Description
is_current is still referenced from some pkeys and indices even though all rows are is_current true. 

### How Has This Been Tested?
Tested on sandbox. Confirmed migration made the right modifications and indexing is working.

Before
```
audius_discovery=> explain analyze  select * from users where user_id = 1;
                                                          QUERY PLAN                                                           
-------------------------------------------------------------------------------------------------------------------------------
 Index Scan using users_new_pkey on users  (cost=0.56..192059.25 rows=1 width=781) (actual time=0.013..131.900 rows=1 loops=1)
   Index Cond: (user_id = 1)
 Planning Time: 0.102 ms
 Execution Time: 131.931 ms
(4 rows)


audius_discovery=> SELECT
    pg_size_pretty(pg_database_size(current_database())) AS database_size;
 database_size 
---------------
 117 GB

```

After
```
audius_discovery=> explain analyze  select * from users where user_id = 1;
                                                     QUERY PLAN                                                     
--------------------------------------------------------------------------------------------------------------------
 Index Scan using users_pkey on users  (cost=0.56..8.57 rows=1 width=781) (actual time=0.018..0.019 rows=1 loops=1)
   Index Cond: (user_id = 1)
 Planning Time: 0.143 ms
 Execution Time: 0.042 ms


audius_discovery=> SELECT
    pg_size_pretty(pg_database_size(current_database())) AS database_size;
 database_size 
---------------
 106 GB

```


_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._
