### PR TITLE
[C-3092] Add error on empty file upload

### DIFF
--- a/packages/mobile/src/screens/upload-screen/utils/processTrackFile.ts
+++ b/packages/mobile/src/screens/upload-screen/utils/processTrackFile.ts
@@ -12,7 +12,12 @@ export const processTrackFile = async (
   trackFile: DocumentPickerResponse
 ): Promise<UploadTrack> => {
   const { name, size, fileCopyUri, uri, type } = trackFile
-  if (size && size > ALLOWED_MAX_AUDIO_SIZE_BYTES) {
+  if (!size || size <= 0) {
+    throw new Error(
+      'File is corrupted. Please ensure it is playable and stored locally.'
+    )
+  }
+  if (size > ALLOWED_MAX_AUDIO_SIZE_BYTES) {
     throw new Error('File too large')
   }
   // Check file extension (heuristic for failure)

--- a/packages/web/src/components/upload/InvalidFileType.js
+++ b/packages/web/src/components/upload/InvalidFileType.js
@@ -3,10 +3,14 @@ import PropTypes from 'prop-types'
 // eslint-disable-next-line no-restricted-imports -- TODO: migrate to @react-spring/web
 import { Spring } from 'react-spring/renderprops'
 
+import { Text } from 'components/typography'
+
 import styles from './InvalidFileType.module.css'
 
 const messages = {
   type: 'Unsupported File Type',
+  corrupted:
+    'File is corrupted. Please ensure it is playable and stored locally.',
   size: 'File Too Large (Max 250MB)'
 }
 
@@ -25,7 +29,14 @@ const InvalidFileType = (props) => {
             [props.className]: !!props.className
           })}
         >
-          {messages[props.reason]}
+          <Text
+            className={styles.message}
+            size='large'
+            strength='strong'
+            color='staticWhite'
+          >
+            {messages[props.reason]}
+          </Text>
         </div>
       )}
     </Spring>

--- a/packages/web/src/components/upload/InvalidFileType.module.css
+++ b/packages/web/src/components/upload/InvalidFileType.module.css
@@ -1,6 +1,6 @@
 .invalidFileType {
-  height: 32px;
-  width: 210px;
+  max-width: 320px;
+  padding: var(--unit-2) var(--unit-4);
   border-radius: 8px;
   background-color: var(--accent-red);
   color: var(--white);
@@ -10,4 +10,8 @@
   font-family: var(--font-family);
   font-size: var(--font-s);
   font-weight: var(--font-demi-bold);
+}
+
+.message {
+  text-align: center;
 }

--- a/packages/web/src/pages/upload-page/components/SelectPageNew.tsx
+++ b/packages/web/src/pages/upload-page/components/SelectPageNew.tsx
@@ -17,7 +17,7 @@ import { UploadFormState } from '../types'
 import styles from './SelectPage.module.css'
 import { TracksPreviewNew } from './TracksPreviewNew'
 
-type ErrorType = { reason: 'size' | 'type' } | null
+type ErrorType = { reason: 'corrupted' | 'size' | 'type' } | null
 
 type SelectPageProps = {
   formState: UploadFormState

--- a/packages/web/src/pages/upload-page/fields/SourceFilesField.tsx
+++ b/packages/web/src/pages/upload-page/fields/SourceFilesField.tsx
@@ -152,7 +152,10 @@ const SourceFilesMenuFields = () => {
   const [{ value: stemsValue }, , { setValue: setStems }] =
     useField<StemUpload[]>(STEMS)
 
-  const invalidAudioFile = (name: string, reason: 'size' | 'type') => {
+  const invalidAudioFile = (
+    name: string,
+    reason: 'corrupted' | 'size' | 'type'
+  ) => {
     console.error('Invalid Audio File', { name, reason })
     // TODO: show file error
   }

--- a/packages/web/src/pages/upload-page/store/utils/processFiles.ts
+++ b/packages/web/src/pages/upload-page/store/utils/processFiles.ts
@@ -36,9 +36,16 @@ const createArtwork = async (selectedFiles: File[]) => {
 
 export const processFiles = (
   selectedFiles: File[],
-  handleInvalid: (fileName: string, errorType: 'size' | 'type') => void
+  handleInvalid: (
+    fileName: string,
+    errorType: 'corrupted' | 'size' | 'type'
+  ) => void
 ) => {
   return selectedFiles.map(async (file) => {
+    if (file.size <= 0) {
+      handleInvalid(file.name, 'corrupted')
+      return null
+    }
     if (file.size > ALLOWED_MAX_AUDIO_SIZE_BYTES) {
       handleInvalid(file.name, 'size')
       return null


### PR DESCRIPTION
### Description

- Adds error when user attempts to upload an empty file
	- Covers case where dropbox sync'd files appear as empty files on local disk

<img width='49%' src='https://github.com/AudiusProject/audius-protocol/assets/2358254/635c1d4c-c4ef-42b2-b8bf-8482dba67075' />
<img width='50%' src='https://github.com/AudiusProject/audius-protocol/assets/2358254/4e20df1b-3954-46cf-88f1-685555192b63' />

<img width="446" alt="Screenshot 2023-09-14 at 4 01 34 PM" src="https://github.com/AudiusProject/audius-protocol/assets/2358254/acb5cb45-a636-44d4-893c-6dd9738f5914">



### How Has This Been Tested?
local web
am now dropbox pro user 😢