### PR TITLE
[PAY-1847] UX fixes for USDC mobile/chat track tiles

### DIFF
--- a/packages/mobile/src/components/lineup-tile/LineupTile.tsx
+++ b/packages/mobile/src/components/lineup-tile/LineupTile.tsx
@@ -141,22 +141,21 @@ export const LineupTile = ({
         />
       </View>
       {children}
-      {!isReadonly ? (
-        <LineupTileActionButtons
-          hasReposted={has_current_user_reposted}
-          hasSaved={has_current_user_saved}
-          isOwner={isOwner}
-          isShareHidden={hideShare}
-          isUnlisted={isUnlisted}
-          trackId={trackId}
-          premiumConditions={premiumConditions}
-          doesUserHaveAccess={doesUserHaveAccess}
-          onPressOverflow={onPressOverflow}
-          onPressRepost={onPressRepost}
-          onPressSave={onPressSave}
-          onPressShare={onPressShare}
-        />
-      ) : null}
+      <LineupTileActionButtons
+        hasReposted={has_current_user_reposted}
+        hasSaved={has_current_user_saved}
+        isOwner={isOwner}
+        isShareHidden={hideShare}
+        isUnlisted={isUnlisted}
+        readonly={isReadonly}
+        trackId={trackId}
+        premiumConditions={premiumConditions}
+        doesUserHaveAccess={doesUserHaveAccess}
+        onPressOverflow={onPressOverflow}
+        onPressRepost={onPressRepost}
+        onPressSave={onPressSave}
+        onPressShare={onPressShare}
+      />
     </LineupTileRoot>
   )
 }

--- a/packages/mobile/src/components/lineup-tile/LineupTile.tsx
+++ b/packages/mobile/src/components/lineup-tile/LineupTile.tsx
@@ -141,6 +141,7 @@ export const LineupTile = ({
         />
       </View>
       {children}
+
       <LineupTileActionButtons
         hasReposted={has_current_user_reposted}
         hasSaved={has_current_user_saved}

--- a/packages/mobile/src/components/lineup-tile/LineupTile.tsx
+++ b/packages/mobile/src/components/lineup-tile/LineupTile.tsx
@@ -29,6 +29,7 @@ export const LineupTile = ({
   coSign,
   duration,
   favoriteType,
+  hasPreview,
   hidePlays,
   hideShare,
   id,
@@ -80,13 +81,13 @@ export const LineupTile = ({
   })
 
   const handlePress = useCallback(() => {
-    if (trackId && !doesUserHaveAccess) {
+    if (trackId && !doesUserHaveAccess && !hasPreview) {
       dispatch(setLockedContentId({ id: trackId }))
       dispatch(setVisibility({ drawer: 'LockedContent', visible: true }))
     } else {
       onPress?.()
     }
-  }, [trackId, doesUserHaveAccess, dispatch, onPress])
+  }, [trackId, doesUserHaveAccess, hasPreview, dispatch, onPress])
 
   const isLongFormContent =
     isTrack &&

--- a/packages/mobile/src/components/lineup-tile/LineupTileActionButtons.tsx
+++ b/packages/mobile/src/components/lineup-tile/LineupTileActionButtons.tsx
@@ -1,3 +1,5 @@
+import type { ReactElement } from 'react'
+
 import {
   isPremiumContentUSDCPurchaseGated,
   type ID,
@@ -122,7 +124,7 @@ export const LineupTileActionButtons = ({
   const showPremiumAccessStatus = trackId && !doesUserHaveAccess
   const showLeftButtons = !showPremiumAccessStatus && !isUnlisted
 
-  let content
+  let content: ReactElement | null = null
   if (readonly) {
     if (isUSDCPurchase && showPremiumAccessStatus) {
       content = (

--- a/packages/mobile/src/components/lineup-tile/TrackTile.tsx
+++ b/packages/mobile/src/components/lineup-tile/TrackTile.tsx
@@ -21,13 +21,15 @@ import {
   mobileOverflowMenuUIActions,
   shareModalUIActions,
   RepostType,
-  playerSelectors
+  playerSelectors,
+  isPremiumContentUSDCPurchaseGated
 } from '@audius/common'
 import { useNavigationState } from '@react-navigation/native'
 import { useDispatch, useSelector } from 'react-redux'
 
 import { TrackImage } from 'app/components/image/TrackImage'
 import type { LineupItemProps } from 'app/components/lineup-tile/types'
+import { useIsUSDCEnabled } from 'app/hooks/useIsUSDCEnabled'
 import { useNavigation } from 'app/hooks/useNavigation'
 import { useFeatureFlag } from 'app/hooks/useRemoteConfig'
 
@@ -82,6 +84,7 @@ export const TrackTileComponent = ({
     FeatureFlags.PODCAST_CONTROL_UPDATES_ENABLED,
     FeatureFlags.PODCAST_CONTROL_UPDATES_ENABLED_FALLBACK
   )
+  const isUSDCEnabled = useIsUSDCEnabled()
   const dispatch = useDispatch()
   const navigation = useNavigation()
   const isOnArtistsTracksTab = useNavigationState((state) => {
@@ -106,8 +109,15 @@ export const TrackTileComponent = ({
     title,
     track_id,
     genre,
-    is_premium: isPremium
+    is_premium: isPremium,
+    premium_conditions,
+    preview_cid
   } = track
+
+  const hasPreview =
+    isUSDCEnabled &&
+    isPremiumContentUSDCPurchaseGated(premium_conditions) &&
+    !!preview_cid
 
   const renderImage = useCallback(
     (props: ImageProps) => (
@@ -216,6 +226,7 @@ export const TrackTileComponent = ({
       isPlayingUid={isPlayingUid}
       favoriteType={FavoriteType.TRACK}
       repostType={RepostType.TRACK}
+      hasPreview={hasPreview}
       hideShare={hideShare}
       hidePlays={hidePlays}
       id={track_id}

--- a/packages/mobile/src/components/lineup-tile/types.ts
+++ b/packages/mobile/src/components/lineup-tile/types.ts
@@ -86,6 +86,9 @@ export type LineupTileProps = Omit<LineupItemProps, 'togglePlay'> & {
   /** The item (track or collection) */
   item: Track | Collection
 
+  /** Indicates that item has preview content available */
+  hasPreview?: boolean
+
   /** Function to call when tile is pressed */
   onPress?: () => void
 

--- a/packages/web/src/components/track/mobile/BottomButtons.tsx
+++ b/packages/web/src/components/track/mobile/BottomButtons.tsx
@@ -1,6 +1,11 @@
 import { memo } from 'react'
 
-import { Nullable, PremiumConditions, PremiumTrackStatus } from '@audius/common'
+import {
+  Nullable,
+  PremiumConditions,
+  PremiumTrackStatus,
+  isPremiumContentUSDCPurchaseGated
+} from '@audius/common'
 import cn from 'classnames'
 
 import FavoriteButton from 'components/alt-button/FavoriteButton'
@@ -8,6 +13,7 @@ import MoreButton from 'components/alt-button/MoreButton'
 import RepostButton from 'components/alt-button/RepostButton'
 import ShareButton from 'components/alt-button/ShareButton'
 import typeStyles from 'components/typography/typography.module.css'
+import { useIsUSDCEnabled } from 'hooks/useIsUSDCEnabled'
 
 import { PremiumConditionsPill } from '../PremiumConditionsPill'
 
@@ -27,12 +33,22 @@ type BottomButtonsProps = {
   isShareHidden?: boolean
   isTrack?: boolean
   doesUserHaveAccess?: boolean
+  readonly?: boolean
   premiumConditions?: Nullable<PremiumConditions>
   premiumTrackStatus?: PremiumTrackStatus
   isMatrixMode: boolean
 }
 
 const BottomButtons = (props: BottomButtonsProps) => {
+  const isUSDCEnabled = useIsUSDCEnabled()
+  const isUSDCPurchase =
+    isUSDCEnabled && isPremiumContentUSDCPurchaseGated(props.premiumConditions)
+
+  // Readonly variant only renders content for locked USDC tracks
+  if (!!props.readonly && (!isUSDCPurchase || props.doesUserHaveAccess)) {
+    return null
+  }
+
   const moreButton = (
     <MoreButton
       wrapperClassName={styles.button}
@@ -64,7 +80,7 @@ const BottomButtons = (props: BottomButtonsProps) => {
             unlocking={props.premiumTrackStatus === 'UNLOCKING'}
           />
         </div>
-        {moreButton}
+        {props.readonly ? null : moreButton}
       </div>
     )
   }

--- a/packages/web/src/components/track/mobile/TrackTile.tsx
+++ b/packages/web/src/components/track/mobile/TrackTile.tsx
@@ -471,26 +471,25 @@ const TrackTile = (props: CombinedProps) => {
               : null}
           </div>
         </div>
-        {!isReadonly ? (
-          <BottomButtons
-            hasSaved={props.hasCurrentUserSaved}
-            hasReposted={props.hasCurrentUserReposted}
-            toggleRepost={onToggleRepost}
-            toggleSave={onToggleSave}
-            onShare={onClickShare}
-            onClickOverflow={onClickOverflowMenu}
-            isOwner={isOwner}
-            isLoading={isLoading}
-            isUnlisted={isUnlisted}
-            doesUserHaveAccess={doesUserHaveAccess}
-            premiumConditions={premiumConditions}
-            premiumTrackStatus={premiumTrackStatus}
-            isShareHidden={hideShare}
-            isDarkMode={darkMode}
-            isMatrixMode={isMatrix}
-            isTrack
-          />
-        ) : null}
+        <BottomButtons
+          hasSaved={props.hasCurrentUserSaved}
+          hasReposted={props.hasCurrentUserReposted}
+          toggleRepost={onToggleRepost}
+          toggleSave={onToggleSave}
+          onShare={onClickShare}
+          onClickOverflow={onClickOverflowMenu}
+          isOwner={isOwner}
+          readonly={isReadonly}
+          isLoading={isLoading}
+          isUnlisted={isUnlisted}
+          doesUserHaveAccess={doesUserHaveAccess}
+          premiumConditions={premiumConditions}
+          premiumTrackStatus={premiumTrackStatus}
+          isShareHidden={hideShare}
+          isDarkMode={darkMode}
+          isMatrixMode={isMatrix}
+          isTrack
+        />
       </div>
     </div>
   )


### PR DESCRIPTION
### Description
* Chat track tiles on mobile and web now show the premium conditions pill for USDC tracks when they are locked. This allows the user to tap/click on the pill to open the purchase flow
* Updated some code paths where we were missing logic to allow previews (mostly for chat message tiles)

Fixes PAY-1847

### How Has This Been Tested?
Tested locally in Chrome and simulator against staging


