### PR TITLE
[C-3095] upload progress tweaks

### DIFF
--- a/packages/common/src/store/upload/selectors.ts
+++ b/packages/common/src/store/upload/selectors.ts
@@ -11,7 +11,7 @@ export const getIsUploading = (state: CommonState) => state.upload.uploading
 export const getShouldReset = (state: CommonState) => state.upload.shouldReset
 
 // Should sum to 1
-const UPLOAD_WEIGHT = 0.8
+const UPLOAD_WEIGHT = 0.5
 const TRANSCODE_WEIGHT = 1 - UPLOAD_WEIGHT
 
 // Should sum to 1

--- a/packages/web/src/pages/upload-page/components/FinishPageNew.tsx
+++ b/packages/web/src/pages/upload-page/components/FinishPageNew.tsx
@@ -204,7 +204,9 @@ export const FinishPageNew = (props: FinishPageProps) => {
             </Text>
             <div className={styles.headerProgressInfo}>
               <Text variant='label' size='small'>
-                {fullUploadPercent === 100 && !uploadComplete
+                {uploadComplete
+                  ? '100%'
+                  : fullUploadPercent === 100 && !uploadComplete
                   ? messages.finishingUpload
                   : `${fullUploadPercent}%`}
               </Text>


### PR DESCRIPTION
### Description

- Make sure we never show anything but 100% on the upload complete screen
- Change upload/transcode weights to 50/50

### How Has This Been Tested?
local web