### PR TITLE
Dedupe reposts/saves from album bug

### DIFF
--- a/discovery-provider/ddl/migrations/0031_dedupe_repost_saves.sql
+++ b/discovery-provider/ddl/migrations/0031_dedupe_repost_saves.sql
@@ -1,0 +1,72 @@
+-- dedupe album reposts and saves
+-- keep the record with the most recent blocknumber
+begin;
+
+with cte as (
+    select
+        user_id,
+        repost_item_id,
+        repost_type,
+        blocknumber,
+        row_number() over (
+            partition by user_id,
+            repost_item_id,
+            repost_type
+            order by
+                blocknumber desc
+        ) as rn
+    from
+        reposts
+)
+delete from
+    reposts
+where
+    (
+        user_id,
+        repost_item_id,
+        repost_type,
+        blocknumber
+    ) in (
+        select
+            user_id,
+            repost_item_id,
+            repost_type,
+            blocknumber
+        from
+            cte
+        where
+            rn > 1
+    );
+
+with cte as (
+    select
+        user_id,
+        save_item_id,
+        save_type,
+        blocknumber,
+        row_number() over (
+            partition by user_id,
+            save_item_id,
+            save_type
+            order by
+                blocknumber desc
+        ) as rn
+    from
+        saves
+)
+delete from
+    saves
+where
+    (user_id, save_item_id, save_type, blocknumber) in (
+        select
+            user_id,
+            save_item_id,
+            save_type,
+            blocknumber
+        from
+            cte
+        where
+            rn > 1
+    );
+
+commit;


### PR DESCRIPTION
### Description
Dedupe a couple hundred reposts/saves from the album repost/save bug. Fix was already released https://github.com/AudiusProject/audius-protocol/pull/5767 but this cleans up the data.

Example of dupes. This playlist has aggregates that don't match the actual reposts/saves. This will dedupe and the update_aggregate task will correct the diffs.
https://audius.co/fmonkeyrock/album/sad-64257

### How Has This Been Tested?
Tested on sandbox. Confirmed migration ran in less than a minute and dupes were corrected including the example above.

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._
