### PR TITLE
[C-3099] Fix bad width calculation on segmented control

### DIFF
--- a/packages/stems/src/components/SegmentedControl/SegmentedControl.tsx
+++ b/packages/stems/src/components/SegmentedControl/SegmentedControl.tsx
@@ -1,4 +1,4 @@
-import { createRef, Fragment, useState, useEffect, useRef } from 'react'
+import { createRef, Fragment, useState, useRef, useEffect } from 'react'
 
 import cn from 'classnames'
 import { mergeRefs } from 'react-merge-refs'
@@ -36,6 +36,14 @@ export const SegmentedControl = <T extends string>(
     polyfill: ResizeObserver
   })
 
+  const [forceRefresh, setForceRefresh] = useState(false)
+  useEffect(() => {
+    setTimeout(() => {
+      setForceRefresh(!forceRefresh)
+    }, props.forceRefreshAfterMs)
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
+
   useEffect(() => {
     let selectedRefIdx = props.options.findIndex(
       (option) => option.key === selectedOption
@@ -58,7 +66,9 @@ export const SegmentedControl = <T extends string>(
     setAnimatedProps,
     selected,
     optionRefs,
-    bounds
+    bounds,
+    // Additional deps
+    forceRefresh
   ])
 
   return (

--- a/packages/stems/src/components/SegmentedControl/types.ts
+++ b/packages/stems/src/components/SegmentedControl/types.ts
@@ -39,4 +39,9 @@ export type SegmentedControlProps<T extends string> = {
    */
   label?: string
   'aria-labelledby'?: string
+
+  /**
+   * A hack to allow shifting animations to settle before recalculating the tab width
+   */
+  forceRefreshAfterMs?: number
 }

--- a/packages/web/src/pages/upload-page/components/TracksPreviewNew.tsx
+++ b/packages/web/src/pages/upload-page/components/TracksPreviewNew.tsx
@@ -67,6 +67,8 @@ export const TracksPreviewNew = (props: TracksPreviewProps) => {
             { key: String(UploadType.ALBUM), text: 'Album' },
             { key: String(UploadType.PLAYLIST), text: 'Playlist' }
           ]}
+          // Matches 0.18s entry animation
+          forceRefreshAfterMs={180}
         />
         <Text>{uploadDescriptions[props.uploadType]}</Text>
       </div>


### PR DESCRIPTION
### Description

#### Problem:
The selected tab was loading during the entry animation for the tracks sidebar. This caused the calculation to be based on the wrong width and the tab to be too small.
<img width="1246" alt="image" src="https://github.com/AudiusProject/audius-protocol/assets/2358254/6cb0b4ea-22c7-49fe-944c-a2fa0b80216b">

#### Solution:
Defer segmented tab calc until animations finish

https://www.loom.com/share/3a0393788b3b4ccdb6666aadd27a6b85

Less hacky alternate solutions:
- Use a different animation that keeps the size of the entering element constant
- Find a better condition for the useEffect that calculates the tab size (instead of `forceRefreshAfterMs`)

### How Has This Been Tested?

local web