### PR TITLE
[C-3108, C-3111] Fix collection upload

### DIFF
--- a/packages/web/src/pages/upload-page/UploadPageLegacy.js
+++ b/packages/web/src/pages/upload-page/UploadPageLegacy.js
@@ -244,20 +244,13 @@ class Upload extends Component {
   }
 
   publish = () => {
-    console.log(
-      'sup',
+    this.props.uploadTracks(
       this.state.tracks,
       this.state.metadata,
       this.state.uploadType,
       this.state.stems
     )
-    // this.props.uploadTracks(
-    //   this.state.tracks,
-    //   this.state.metadata,
-    //   this.state.uploadType,
-    //   this.state.stems
-    // )
-    // this.changePage(Pages.FINISH)
+    this.changePage(Pages.FINISH)
   }
 
   reset = () => {

--- a/packages/web/src/pages/upload-page/UploadPageLegacy.js
+++ b/packages/web/src/pages/upload-page/UploadPageLegacy.js
@@ -244,13 +244,20 @@ class Upload extends Component {
   }
 
   publish = () => {
-    this.props.uploadTracks(
+    console.log(
+      'sup',
       this.state.tracks,
       this.state.metadata,
       this.state.uploadType,
       this.state.stems
     )
-    this.changePage(Pages.FINISH)
+    // this.props.uploadTracks(
+    //   this.state.tracks,
+    //   this.state.metadata,
+    //   this.state.uploadType,
+    //   this.state.stems
+    // )
+    // this.changePage(Pages.FINISH)
   }
 
   reset = () => {

--- a/packages/web/src/pages/upload-page/UploadPageNew.tsx
+++ b/packages/web/src/pages/upload-page/UploadPageNew.tsx
@@ -189,8 +189,10 @@ export const UploadPageNew = (props: UploadPageProps) => {
       uploadTracks(
         // @ts-ignore - This has artwork on it
         tracks,
-        // NOTE: Need to add metadata for collections here for collection upload
-        undefined,
+        formState.uploadType === UploadType.ALBUM ||
+          formState.uploadType === UploadType.PLAYLIST
+          ? formState.metadata
+          : undefined,
         tracks.length > 1
           ? UploadType.INDIVIDUAL_TRACKS
           : UploadType.INDIVIDUAL_TRACK,

--- a/packages/web/src/pages/upload-page/UploadPageNew.tsx
+++ b/packages/web/src/pages/upload-page/UploadPageNew.tsx
@@ -193,9 +193,7 @@ export const UploadPageNew = (props: UploadPageProps) => {
           formState.uploadType === UploadType.PLAYLIST
           ? formState.metadata
           : undefined,
-        tracks.length > 1
-          ? UploadType.INDIVIDUAL_TRACKS
-          : UploadType.INDIVIDUAL_TRACK,
+        formState.uploadType,
         trackStems
       )
     )

--- a/packages/web/src/pages/upload-page/components/FinishPageNew.tsx
+++ b/packages/web/src/pages/upload-page/components/FinishPageNew.tsx
@@ -40,7 +40,7 @@ const messages = {
   uploadInProgress: 'Upload In Progress',
   uploadComplete: 'Upload Complete',
   uploadMore: 'Upload More',
-  finishingUpload: 'Finializing Upload',
+  finishingUpload: 'Finalizing Upload',
   visitProfile: 'Visit Your Profile',
   visitTrack: 'Visit Track Page',
   visitAlbum: 'Visit Album Page',

--- a/packages/web/src/pages/upload-page/fields/CollectionTrackFieldArray.tsx
+++ b/packages/web/src/pages/upload-page/fields/CollectionTrackFieldArray.tsx
@@ -20,7 +20,7 @@ export const CollectionTrackFieldArray = () => {
           }}
         >
           <Droppable droppableId='tracks'>
-            {(provided, snapshot) => (
+            {(provided) => (
               <div {...provided.droppableProps} ref={provided.innerRef}>
                 {tracks.map((track, index) => (
                   <Draggable
@@ -28,7 +28,7 @@ export const CollectionTrackFieldArray = () => {
                     draggableId={track.file.name}
                     index={index}
                   >
-                    {(provided, snapshot) => (
+                    {(provided) => (
                       <div
                         ref={provided.innerRef}
                         {...provided.draggableProps}

--- a/packages/web/src/pages/upload-page/forms/EditCollectionForm.tsx
+++ b/packages/web/src/pages/upload-page/forms/EditCollectionForm.tsx
@@ -67,8 +67,17 @@ export const EditCollectionForm = (props: EditCollectionFormProps) => {
         ...collectionMetadata
       } = values
 
+      console.log('tracks?', tracks, ignoredTrackDetails, {
+        ...collectionMetadata,
+        ...ignoredTrackDetails
+      })
+
       // @ts-expect-error more issues with tracks
-      onContinue({ uploadType, tracks, metadata: collectionMetadata })
+      onContinue({
+        uploadType,
+        tracks,
+        metadata: { ...collectionMetadata, ...ignoredTrackDetails }
+      })
     },
     [onContinue, uploadType]
   )

--- a/packages/web/src/pages/upload-page/forms/EditCollectionForm.tsx
+++ b/packages/web/src/pages/upload-page/forms/EditCollectionForm.tsx
@@ -67,15 +67,11 @@ export const EditCollectionForm = (props: EditCollectionFormProps) => {
         ...collectionMetadata
       } = values
 
-      console.log('tracks?', tracks, ignoredTrackDetails, {
-        ...collectionMetadata,
-        ...ignoredTrackDetails
-      })
-
-      // @ts-expect-error more issues with tracks
       onContinue({
         uploadType,
+        // @ts-expect-error more issues with tracks
         tracks,
+        // @ts-expect-error more issues with tracks
         metadata: { ...collectionMetadata, ...ignoredTrackDetails }
       })
     },


### PR DESCRIPTION
### Description

Fixes several core issues with collection upload:
- We now upload using `uploadCollection` instead of `uploadMultipleTracks` saga path
	- We weren't passing the collection upload type all the way through
- Propagating metadata to tracks through the collection form onSubmit
![Screenshot 2023-09-19 at 4 01 03 PM](https://github.com/AudiusProject/audius-protocol/assets/2358254/b69a47ed-4525-45c6-a125-1dfeb9820bad)

### How Has This Been Tested?

Albums now upload fully and the Visit Album link works properly.
The resulting tracks are part of the album and inherit artwork from the album's art.