### PR TITLE
Lock tables during pkey index migration

### DIFF
--- a/discovery-provider/ddl/migrations/0031_drop_current_indices.sql
+++ b/discovery-provider/ddl/migrations/0031_drop_current_indices.sql
@@ -1,6 +1,20 @@
 -- Drop is_current from any primary keys or indices with is_current
 -- Improves performance and storage utilization
 BEGIN;
+SELECT pg_cancel_backend(pid) FROM pg_stat_activity WHERE state = 'active' and pid <> pg_backend_pid();
+
+LOCK TABLE grants IN ACCESS EXCLUSIVE MODE;
+LOCK TABLE users IN ACCESS EXCLUSIVE MODE;
+LOCK TABLE playlist_seen IN ACCESS EXCLUSIVE MODE;
+LOCK TABLE subscriptions IN ACCESS EXCLUSIVE MODE;
+LOCK TABLE tracks IN ACCESS EXCLUSIVE MODE;
+LOCK TABLE follows IN ACCESS EXCLUSIVE MODE;
+LOCK TABLE saves IN ACCESS EXCLUSIVE MODE;
+LOCK TABLE developer_apps IN ACCESS EXCLUSIVE MODE;
+LOCK TABLE playlists IN ACCESS EXCLUSIVE MODE;
+LOCK TABLE user_events IN ACCESS EXCLUSIVE MODE;
+LOCK TABLE associated_wallets IN ACCESS EXCLUSIVE MODE;
+LOCK TABLE playlist_routes IN ACCESS EXCLUSIVE MODE;
 
 DO $$ 
 DECLARE


### PR DESCRIPTION
### Description
Explicitly lock tables before this big migration to avoid deadlocks.

### How Has This Been Tested?
Ran on sandbox.
_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._
