### PR TITLE
[C-3110] Remove artwork progress from upload progress bar

### DIFF
--- a/packages/common/src/store/upload/selectors.ts
+++ b/packages/common/src/store/upload/selectors.ts
@@ -15,8 +15,8 @@ const UPLOAD_WEIGHT = 0.5
 const TRANSCODE_WEIGHT = 1 - UPLOAD_WEIGHT
 
 // Should sum to 1
-const ART_WEIGHT = 0.1
-const AUDIO_WEIGHT = 0.9
+const AUDIO_WEIGHT = 1
+const ART_WEIGHT = 0
 
 const getKeyUploadProgress = (state: CommonState, key: 'art' | 'audio') => {
   const uploadProgress = getUploadProgress(state)

--- a/packages/web/src/pages/upload-page/fields/SourceFilesField.tsx
+++ b/packages/web/src/pages/upload-page/fields/SourceFilesField.tsx
@@ -71,7 +71,6 @@ export const SourceFilesField = () => {
     useTrackField<Download[typeof ALLOW_DOWNLOAD_BASE]>(ALLOW_DOWNLOAD)
   const [{ value: followerGatedValue }, , { setValue: setFollowerGatedValue }] =
     useTrackField<Download[typeof FOLLOWER_GATED_BASE]>(FOLLOWER_GATED)
-  // TODO: Stems value should be submitted outside tracks in uploadTracks
   const [{ value: stemsValue }, , { setValue: setStemsValue }] =
     useTrackField<StemUpload[]>(STEMS)
 


### PR DESCRIPTION
### Description

Artwork upload time was negligible, and it wasn't being tracked for albums. Rather than get a perfect solution, let's just ignore artwork for now.

### How Has This Been Tested?

local web