### PR TITLE
[PROTO-1269] Alert about daily deploys

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -115,12 +115,56 @@ jobs:
             mv /tmp/.version.json discovery-provider/.version.json
             git add discovery-provider/.version.json
 
+            # Escape double quotes in commit message and replace git log's platform-specific newlines with @@DELIM@@
+            GIT_DIFF=$(git log --pretty=format:'• %an - %s [<https://github.com/AudiusProject/audius-protocol/commit/%H|%h>]' --abbrev-commit origin/release-v$OLD_VERSION..HEAD -- mediorum discovery-provider identity-service comms | sed 's/"/\"/g' | tr -d '\r' | sed ':a;N;$!ba;s/\n/@@DELIM@@/g')
             git commit -m "Bump version to $NEW_VERSION"
 
             git branch "release-v$NEW_VERSION"
             git checkout "release-v$NEW_VERSION"
 
             git push --set-upstream origin main "release-v$NEW_VERSION"
+
+            # Slack has a limit of 3000 characters per block, so we need to split the diff into multiple blocks
+            max_lines=8
+            json_content="{ \"blocks\": ["
+            json_content+="{ \"type\": \"header\", \"text\": { \"type\": \"plain_text\", \"text\": \"New Protocol Release Branch (v0.4.9)\n\" } },"
+            json_content+="{ \"type\": \"section\", \"text\": { \"type\": \"mrkdwn\", \"text\": \"*These changes will be released to SPs at 11am PST:*\n\" } },"
+            line_count=0
+            block_content=""
+
+            # Use @@ as Internal Field Separator, so @@DELIM@@ effectively becomes the delimiter for us to build blocks
+            IFS='@@'
+            read -ra ADDR \<<< "$GIT_DIFF"
+            for line in "${ADDR[@]}"; do
+                if [[ $line == "DELIM" ]]; then
+                    continue
+                fi
+
+                block_content+="$line\n"
+                line_count=$((line_count+1))
+
+                if (( line_count == max_lines )); then
+                    json_content+="{ \"type\": \"section\", \"text\": { \"type\": \"mrkdwn\", \"text\": \"${block_content}\" } },"
+                    line_count=0
+                    block_content=""
+                fi
+            done
+
+            if (( line_count > 0 )); then
+                json_content+="{ \"type\": \"section\", \"text\": { \"type\": \"mrkdwn\", \"text\": \"${block_content}\" } },"
+            fi
+
+            json_content=${json_content%,}
+            json_content+="]}"
+            
+            # The next step of this job will read this file and send it to Slack
+            echo $json_content > /tmp/slack_message.json
+      - run:
+          name: Send Slack Daily Deploy Message
+          command: |
+            curl -f -X POST -H 'Content-type: application/json' \
+              --data @/tmp/slack_message.json \
+              $SLACK_DAILY_DEPLOY_WEBHOOK
 
   generate-client-release:
     working_directory: ~/audius-protocol
@@ -295,7 +339,8 @@ workflows:
         - equal: [scheduled_pipeline, << pipeline.trigger_source >>]
         - equal: ['release-create-branch', << pipeline.schedule.name >>]
     jobs:
-      - generate-release
+      - generate-release:
+          context: slack-secrets
 
   release-client-create-branch:
     when:


### PR DESCRIPTION
### Description
I set the `generate-release` job to run at 8am PST every day. This PR makes it also calculate the git diff for the release and notify in Slack. It filters to only include changes in protocol directories (excludes client).

Note:
* Can't use a CircleCI Orb because they only allow env vars which they sanitize. This would be fine if it all fit into 1 block, but the block limit is 3000 characters (we exceeded that on today's deploy, although it probably won't happen often). So we need to build the JSON blocks which breaks when the Orb sanitizes (even if we try to base64-encode it, they only allow reading an env var with no other manipulation).
* Doesn't tag commitooors yet. I'm thinking this would be nice to do by keeping a mapping of GitHub username to Slack ID. This can be done as a context secret if we consider Slack IDs to be sensitive.

### How Has This Been Tested?
I added a custom job that I ran with `circleci local execute theo`. Under workflows.jobs, where there are lines for "- generate-config" and "- init," add a line for "- theo" and then add this definition under "jobs:"

<details>
  <summary>Testing Job (click)</summary>
  
  ```
theo:
   working_directory: ~/audius-protocol
   resource_class: small
   docker:
     - image: cimg/base:2023.01
   environment:
     OLD_VERSION: "0.4.9"
     SLACK_DAILY_DEPLOY_WEBHOOK: hidden
     GIT_DIFF: "• Steve Perkins - skip API image cid resolution step (#6050) [<https://github.com/AudiusProject/audius-protocol/commit/95b65f7e3537021e84663c4698252ba8ac2c0d89|95b65f7e3>]@@DELIM@@• audius-infra - Bump version to 0.4.9 [<https://github.com/AudiusProject/audius-protocol/commit/a5ebc16cf05f7f84154bec1f7f176a548abb1db3|a5ebc16cf>]@@DELIM@@• Steve Perkins - [PROTO-1264] Don't redirect to images (#6043) [<https://github.com/AudiusProject/audius-protocol/commit/8173922738483fd204fab5462428f1d1411445dd|817392273>]@@DELIM@@• Theo Ilie - [PROTO-1228] Persist and track repair.go (#6038) [<https://github.com/AudiusProject/audius-protocol/commit/4809782950de01be5a41e252aaac2b6c3da2b7ba|480978295>]@@DELIM@@• Alec Savvy - fix app notifs sql (#6029) [<https://github.com/AudiusProject/audius-protocol/commit/cfeacb2c5b924aef22bd18ebe292636637e45f5b|cfeacb2c5>]@@DELIM@@• Raymond Jacobson - Add central location for sql-ts (#6031) [<https://github.com/AudiusProject/audius-protocol/commit/6f1d4d24e63b177a77040db047d2aa7c138d8ad0|6f1d4d24e>]@@DELIM@@• Raymond Jacobson - No range images (#6028) [<https://github.com/AudiusProject/audius-protocol/commit/92346ebca7b0ca2be1157bd387f4ec8d888dafd8|92346ebca>]@@DELIM@@• Isaac Solo - Filter users by followers in sitemaps (#6015) [<https://github.com/AudiusProject/audius-protocol/commit/ef3dc6040fe0e5264d33fe826b020c9c8033f2e2|ef3dc6040>]@@DELIM@@• Isaac Solo - Optimize pkeys and indices by dropping is_current (#6020) [<https://github.com/AudiusProject/audius-protocol/commit/23a22c59b13ecd626d52172ad1497fcca457783d|23a22c59b>]@@DELIM@@• Sebastian Klingler - [INF-470] Move libs into packages/libs (#6027) [<https://github.com/AudiusProject/audius-protocol/commit/9db1a5ca8a389f595b6285841cc5cf8959d1949e|9db1a5ca8>]@@DELIM@@• Steve Perkins - Return status 422 if ffprobe fails (#6019) [<https://github.com/AudiusProject/audius-protocol/commit/493de19eaf0d2ecd43ee085aba4e81e1f5441356|493de19ea>]@@DELIM@@• Michelle Brier - Consolidate errors in discovery health check (#5976) [<https://github.com/AudiusProject/audius-protocol/commit/ba29d81db8c202ce2dcfded424cee15c2cf34875|ba29d81db>]@@DELIM@@• Michelle Brier - Better asyncio event loop handling when caching images in discovery (#6018) [<https://github.com/AudiusProject/audius-protocol/commit/d0638c94f722403ae2c360e96e393b5fcbee15a6|d0638c94f>]@@DELIM@@• Theo Ilie - Check db size before disk size (#6008) [<https://github.com/AudiusProject/audius-protocol/commit/2bbdddf60f17bcdd3c8033e8bacd333b68252555|2bbdddf60>]@@DELIM@@• Dylan Jeffers - [C-3037] Improve client bundle size (#5987) [<https://github.com/AudiusProject/audius-protocol/commit/45cc93cb02ba265c54542c2762c531752b04dca6|45cc93cb0>]@@DELIM@@• Reed - Update sdk on identity (upgraded solana in libs) (#6005) [<https://github.com/AudiusProject/audius-protocol/commit/d886d269c52c288a82d7a1183142b5178632e5b7|d886d269c>]@@DELIM@@• Michelle Brier - Revert \\\"Surface image cid cache in feed endpoints (#5910)\\\" (#5996) [<https://github.com/AudiusProject/audius-protocol/commit/2367c7a169a495cffff50756a954f9e54aade7f0|2367c7a16>]@@DELIM@@• Theo Ilie - Remove radix (#5993) [<https://github.com/AudiusProject/audius-protocol/commit/a3c5ef8d9480ab9f2b2588e3268237b406504b94|a3c5ef8d9>]@@DELIM@@• Raymond Jacobson - [PROTO-1250] Move celery to eventlets (#5975) [<https://github.com/AudiusProject/audius-protocol/commit/81b3bc017a83bc75659489c4dffa24d6f70a4b03|81b3bc017>]@@DELIM@@• Saliou Diallo - Add checks for USDC withdrawal jupiter swap flow (#5955) [<https://github.com/AudiusProject/audius-protocol/commit/7061570042940737fd5cfc18d2ad7970e6cbdaa5|706157004>]"
   steps:
     - run:
         name: Calculate GIT_DIFF
        command: |
           # git clone https://github.com/AudiusProject/audius-protocol.git
           # cd audius-protocol
           # git fetch --all


           # GIT_DIFF=$(git log --pretty=format:'• %an - %s [<https://github.com/AudiusProject/audius-protocol/commit/%H|%h>]' --abbrev-commit origin/release-v$OLD_VERSION..HEAD -- mediorum discovery-provider identity-service comms | sed 's/"/\"/g' | tr -d '\r' | sed ':a;N;$!ba;s/\n/@@DELIM@@/g')
           echo "generated new diff $GIT_DIFF"


           echo $GIT_DIFF


           max_lines=8


           json_content="{ \"blocks\": ["
           json_content+="{ \"type\": \"header\", \"text\": { \"type\": \"plain_text\", \"text\": \"New Protocol Release Branch (v0.4.9)\n\" } },"
           json_content+="{ \"type\": \"section\", \"text\": { \"type\": \"mrkdwn\", \"text\": \"*These changes will be released to SPs at 11am PST:*\n\" } },"
           line_count=0
           block_content=""


           IFS='@@' # Using @ as Internal Field Separator, so @@DELIM@@ effectively becomes the delimiter
           read -ra ADDR \<<< "$GIT_DIFF"
           for line in "${ADDR[@]}"; do
               if [[ $line == "DELIM" ]]; then
                   continue
               fi
              
               echo "line is $line"


               block_content+="$line\n"
               echo "block content is $block_content"
               line_count=$((line_count+1))
               echo "line count is $line_count"


               if (( line_count == max_lines )); then
                   echo "reached max_lines"
                   json_content+="{ \"type\": \"section\", \"text\": { \"type\": \"mrkdwn\", \"text\": \"${block_content}\" } },"
                   line_count=0
                   block_content=""
               fi
           done


           if (( line_count > 0 )); then
               json_content+="{ \"type\": \"section\", \"text\": { \"type\": \"mrkdwn\", \"text\": \"${block_content}\" } },"
           fi


           json_content=${json_content%,}
           json_content+="]}"


           echo $json_content


           echo $json_content > /tmp/slack_message.json
     - run:
         name: Notify Slack
        command: |
           echo "/tmp/slack_message.json is $(cat /tmp/slack_message.json)"
           curl -f -X POST -H 'Content-type: application/json' \
             --data @/tmp/slack_message.json \
             $SLACK_DAILY_DEPLOY_WEBHOOK
```
  
</details>

Output: 
<img width="655" alt="Screenshot 2023-09-19 at 6 47 11 PM" src="https://github.com/AudiusProject/audius-protocol/assets/4657956/3048b678-f05f-4975-a422-f28355c6f194">
