### PR TITLE
[C-3113] Fix edit-track modal state

### DIFF
--- a/packages/common/src/store/ui/modals/edit-track-modal/index.ts
+++ b/packages/common/src/store/ui/modals/edit-track-modal/index.ts
@@ -8,7 +8,7 @@ export type EditTrackModalState = {
 }
 
 const editTrackModal = createModal<EditTrackModalState>({
-  reducerPath: 'EditPlaylist',
+  reducerPath: 'EditTrack',
   initialState: {
     isOpen: false,
     trackId: null
@@ -17,9 +17,9 @@ const editTrackModal = createModal<EditTrackModalState>({
 })
 
 export const {
-  hook: useEditTracktModal,
-  actions: editTracktModalActions,
-  reducer: editTracktModalReducer
+  hook: useEditTrackModal,
+  actions: editTrackModalActions,
+  reducer: editTrackModalReducer
 } = editTrackModal
 
 export * as editTrackModalSelectors from './selectors'

--- a/packages/common/src/store/ui/modals/reducers.ts
+++ b/packages/common/src/store/ui/modals/reducers.ts
@@ -3,7 +3,7 @@ import { Action, combineReducers, Reducer } from '@reduxjs/toolkit'
 import { createChatModalReducer } from './create-chat-modal'
 import { BaseModalState } from './createModal'
 import { editPlaylistModalReducer } from './edit-playlist-modal'
-import { editTracktModalReducer } from './edit-track-modal'
+import { editTrackModalReducer } from './edit-track-modal'
 import { inboxUnavailableModalReducer } from './inbox-unavailable-modal'
 import { leavingAudiusModalReducer } from './leaving-audius-modal'
 import parentReducer, { initialState } from './parentSlice'
@@ -28,7 +28,7 @@ const noOpReducers = Object.keys(initialState).reduce((prev, curr) => {
 const combinedReducers = combineReducers({
   ...noOpReducers,
   EditPlaylist: editPlaylistModalReducer,
-  EditTrack: editTracktModalReducer,
+  EditTrack: editTrackModalReducer,
   CreateChatModal: createChatModalReducer,
   InboxUnavailableModal: inboxUnavailableModalReducer,
   LeavingAudiusModal: leavingAudiusModalReducer,

--- a/packages/web/src/components/edit-track/EditTrackModal.tsx
+++ b/packages/web/src/components/edit-track/EditTrackModal.tsx
@@ -11,7 +11,7 @@ import {
   stemsUploadSelectors,
   stemsUploadActions,
   editTrackModalSelectors,
-  useEditTracktModal
+  useEditTrackModal
 } from '@audius/common'
 import { push as pushRoute } from 'connected-react-router'
 import { connect } from 'react-redux'
@@ -27,7 +27,7 @@ import { AppState } from 'store/types'
 import { FEED_PAGE, getPathname } from 'utils/route'
 const { startStemUploads } = stemsUploadActions
 const { getCurrentUploads } = stemsUploadSelectors
-const { getMetadata, getIsOpen, getStems } = editTrackModalSelectors
+const { getMetadata, getStems } = editTrackModalSelectors
 
 const messages = {
   deleteTrack: 'DELETE TRACK'
@@ -41,7 +41,6 @@ type EditTrackModalProps = OwnProps &
   RouteComponentProps
 
 const EditTrackModal = ({
-  isOpen,
   metadata,
   onEdit,
   onDelete,
@@ -51,7 +50,7 @@ const EditTrackModal = ({
   uploadStems,
   currentUploads
 }: EditTrackModalProps) => {
-  const { onClose } = useEditTracktModal()
+  const { isOpen, onClose } = useEditTrackModal()
   const [isModalOpen, setIsModalOpen] = useState(false)
   useEffect(() => {
     // Delay opening the modal until after we have track metadata as well
@@ -215,7 +214,6 @@ function mapStateToProps(state: AppState) {
   const metadata = getMetadata(state)
   return {
     metadata,
-    isOpen: getIsOpen(state),
     stems: getStems(state),
     currentUploads: metadata?.track_id
       ? getCurrentUploads(state, metadata.track_id)

--- a/packages/web/src/components/menu/TrackMenu.tsx
+++ b/packages/web/src/components/menu/TrackMenu.tsx
@@ -16,7 +16,7 @@ import {
   Genre,
   FeatureFlags,
   CommonState,
-  useEditTracktModal
+  useEditTrackModal
 } from '@audius/common'
 import { PopupMenuItem } from '@audius/stems'
 import { push as pushRoute } from 'connected-react-router'
@@ -95,7 +95,7 @@ const TrackMenu = (props: TrackMenuProps) => {
   const { toast } = useContext(ToastContext)
   const dispatch = useDispatch()
   const currentUserId = useSelector(getUserId)
-  const { onOpen } = useEditTracktModal()
+  const { onOpen } = useEditTrackModal()
   const { isEnabled: isNewPodcastControlsEnabled } = useFlag(
     FeatureFlags.PODCAST_CONTROL_UPDATES_ENABLED,
     FeatureFlags.PODCAST_CONTROL_UPDATES_ENABLED_FALLBACK


### PR DESCRIPTION
### Description

Fixes issue where edit-tractk modal state was referencing the editplaylist modal state, causing crossed wires.