### PR TITLE
Fix staging build web

### DIFF
--- a/packages/common/src/services/opensea-client/OpenSeaClient.ts
+++ b/packages/common/src/services/opensea-client/OpenSeaClient.ts
@@ -112,9 +112,10 @@ export class OpenSeaClient {
     wallets: string[],
     limit = OPENSEA_NUM_ASSETS_LIMIT
   ): Promise<OpenSeaAssetExtended[]> {
-    return allSettled(
-      wallets.map((wallet) => this.getCollectiblesForWallet(wallet, limit))
-    ).then((results) =>
+    const x = wallets.map((wallet) =>
+      this.getCollectiblesForWallet(wallet, limit)
+    )
+    return allSettled(x).then((results) =>
       results
         .map((result, i) => ({ result, wallet: wallets[i] }))
         .filter(({ result }) => result.status === 'fulfilled')

--- a/packages/common/src/services/opensea-client/OpenSeaClient.ts
+++ b/packages/common/src/services/opensea-client/OpenSeaClient.ts
@@ -112,10 +112,9 @@ export class OpenSeaClient {
     wallets: string[],
     limit = OPENSEA_NUM_ASSETS_LIMIT
   ): Promise<OpenSeaAssetExtended[]> {
-    const x = wallets.map((wallet) =>
-      this.getCollectiblesForWallet(wallet, limit)
-    )
-    return allSettled(x).then((results) =>
+    return allSettled(
+      wallets.map((wallet) => this.getCollectiblesForWallet(wallet, limit))
+    ).then((results) =>
       results
         .map((result, i) => ({ result, wallet: wallets[i] }))
         .filter(({ result }) => result.status === 'fulfilled')

--- a/packages/common/src/utils/allSettled.ts
+++ b/packages/common/src/utils/allSettled.ts
@@ -1,6 +1,6 @@
 export const allSettled =
   // eslint-disable-next-line no-restricted-properties
-  Promise.allSettled ||
+  Promise.allSettled.bind(Promise) ||
   ((promises: any[]) =>
     Promise.all(
       promises.map((p: Promise<any>) =>

--- a/packages/web/src/pages/visualizer/Visualizer.tsx
+++ b/packages/web/src/pages/visualizer/Visualizer.tsx
@@ -43,8 +43,6 @@ const Visualizer = ({
     }
   }, [isVisible])
 
-  console.log({ isVisible })
-
   const onToggleVisibility = useCallback(() => {
     // Don't toggle in the case that we are on a route that disables the visualizer
     if (NO_VISUALIZER_ROUTES.has(pathname)) return


### PR DESCRIPTION
### Description

This context matters.

Throws:
```
const allSettled = Promise.allSettled;
allSettled([Promise.resolve(1), Promise.reject('error')]).then(console.log);
```

Doesn't throw:
```
Promise.allSettled([Promise.resolve(1), Promise.reject('error')]).then(console.log);
```

What changed? Idk. Something upgraded.

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._

npm run web:stage