### PR TITLE
Color unhealthy nodes red in healthz

### DIFF
--- a/monitoring/healthz/Caddyfile
+++ b/monitoring/healthz/Caddyfile
@@ -1,0 +1,2 @@
+:80
+reverse_proxy /healthz* :9559

--- a/monitoring/healthz/Caddyfile
+++ b/monitoring/healthz/Caddyfile
@@ -1,2 +1,0 @@
-:80
-reverse_proxy /healthz* :9559

--- a/monitoring/healthz/src/DiscoveryHealth.tsx
+++ b/monitoring/healthz/src/DiscoveryHealth.tsx
@@ -62,7 +62,9 @@ export function DiscoveryHealth() {
 }
 
 function HealthRow({ isContent, sp }: { isContent: boolean; sp: SP }) {
-  const path = isContent ? '/health_check' : '/health_check?verbose=true&enforce_block_diff=true&healthy_block_diff=250&plays_count_max_drift=720'
+  // TODO(michelle): after all nodes updated, change this to
+  // const path = isContent ? '/health_check' : '/health_check?verbose=true&enforce_block_diff=true&healthy_block_diff=250&plays_count_max_drift=720'
+  const path = isContent ? '/health_check' : '/health_check?enforce_block_diff=true&healthy_block_diff=250'
   const { data, error } = useSWR(sp.endpoint + path, fetcher)
   const { data: ipCheck, error: ipCheckError } = useSWR(
     sp.endpoint + '/ip_check',
@@ -77,7 +79,7 @@ function HealthRow({ isContent, sp }: { isContent: boolean; sp: SP }) {
     return (
       <tr>
         <td>
-          <a href={sp.endpoint + '/health_check'} target="_blank">
+          <a href={sp.endpoint + path} target="_blank">
             {sp.endpoint.replace('https://', '')}
           </a>
         </td>
@@ -99,6 +101,7 @@ function HealthRow({ isContent, sp }: { isContent: boolean; sp: SP }) {
     }
   }
 
+  // TODO(michelle) after all nodes updated, change DN check to health.discovery_node_healthy
   const isHealthy = isContent ? health.healthy : !health.errors || (Array.isArray(health.errors) && health.errors.length === 0)
   const unreachablePeers = health.unreachablePeers?.join(', ')
 
@@ -153,7 +156,7 @@ function HealthRow({ isContent, sp }: { isContent: boolean; sp: SP }) {
   return (
     <tr className={isHealthy ? '' : 'is-unhealthy'}>
       <td>
-        <a href={sp.endpoint + '/health_check'} target="_blank">
+        <a href={sp.endpoint + path} target="_blank">
           {sp.endpoint.replace('https://', '')}
         </a>
       </td>

--- a/monitoring/healthz/src/DiscoveryHealth.tsx
+++ b/monitoring/healthz/src/DiscoveryHealth.tsx
@@ -62,7 +62,8 @@ export function DiscoveryHealth() {
 }
 
 function HealthRow({ isContent, sp }: { isContent: boolean; sp: SP }) {
-  const { data, error } = useSWR(sp.endpoint + '/health_check', fetcher)
+  const path = isContent ? '/health_check' : '/health_check?verbose=true&enforce_block_diff=true&healthy_block_diff=250&plays_count_max_drift=720'
+  const { data, error } = useSWR(sp.endpoint + path, fetcher)
   const { data: ipCheck, error: ipCheckError } = useSWR(
     sp.endpoint + '/ip_check',
     fetcher
@@ -97,6 +98,8 @@ function HealthRow({ isContent, sp }: { isContent: boolean; sp: SP }) {
       }
     }
   }
+
+  const isHealthy = isContent ? health.healthy : Array.isArray(health.errors) && health.errors.length === 0
   const unreachablePeers = health.unreachablePeers?.join(', ')
 
   const isCompose = health.infra_setup || health.audiusContentInfraSetup
@@ -112,7 +115,7 @@ function HealthRow({ isContent, sp }: { isContent: boolean; sp: SP }) {
   const mediorumPercent = mediorumUsed / mediorumSize
   const legacyDirUsed = bytesToGb(health.legacyDirUsed)
   const mediorumDirUsed = bytesToGb(health.mediorumDirUsed)
-  const isBehind = health.block_difference > 5 ? 'is-behind' : ''
+  const isBehind = health.block_difference > 5 ? 'is-unhealthy' : ''
   const dbSize =
     bytesToGb(health.database_size) || bytesToGb(health.databaseSize)
   const expectedContentSize = bytesToGb(health.lastSuccessfulRepair?.ContentSize ?? 0)
@@ -148,7 +151,7 @@ function HealthRow({ isContent, sp }: { isContent: boolean; sp: SP }) {
     health.chain_health?.entries['node-health'].description
 
   return (
-    <tr>
+    <tr className={isHealthy ? '' : 'is-unhealthy'}>
       <td>
         <a href={sp.endpoint + '/health_check'} target="_blank">
           {sp.endpoint.replace('https://', '')}

--- a/monitoring/healthz/src/DiscoveryHealth.tsx
+++ b/monitoring/healthz/src/DiscoveryHealth.tsx
@@ -99,7 +99,7 @@ function HealthRow({ isContent, sp }: { isContent: boolean; sp: SP }) {
     }
   }
 
-  const isHealthy = isContent ? health.healthy : Array.isArray(health.errors) && health.errors.length === 0
+  const isHealthy = isContent ? health.healthy : !health.errors || (Array.isArray(health.errors) && health.errors.length === 0)
   const unreachablePeers = health.unreachablePeers?.join(', ')
 
   const isCompose = health.infra_setup || health.audiusContentInfraSetup

--- a/monitoring/healthz/src/index.css
+++ b/monitoring/healthz/src/index.css
@@ -62,8 +62,9 @@ body {
   background: var(--is-unhealthy-color);
 }
 
-table tr:hover td.is-unhealthy {
-  background: var(--is-unhealthy-hover-color);
+table tr:hover td.is-unhealthy,
+table tr.is-unhealthy:hover td {
+    background: var(--is-unhealthy-hover-color);
 }
 
 td.matrix-cell:hover {

--- a/monitoring/healthz/src/index.css
+++ b/monitoring/healthz/src/index.css
@@ -11,8 +11,8 @@
   --text-color: #000000;
   --link-color: #007bff;
   --hover-background-color: #f0f0f0;
-  --is-behind-color: #fff0f0;
-  --is-behind-hover-color: rgba(255, 200, 200, 0.4);
+  --is-unhealthy-color: #fff0f0;
+  --is-unhealthy-hover-color: rgba(255, 200, 200, 0.4);
   --matrix-hover-color: #fff5cc;
 }
 
@@ -26,8 +26,8 @@
     --text-color: #f5f5f5;
     --link-color: #1e90ff;
     --hover-background-color: #222222;
-    --is-behind-color: #440000;
-    --is-behind-hover-color: rgba(255, 50, 50, 0.4);
+    --is-unhealthy-color: #440000;
+    --is-unhealthy-hover-color: rgba(255, 50, 50, 0.4);
     --matrix-hover-color: #333300;
   }
 }
@@ -58,12 +58,12 @@ body {
   background: var(--hover-background-color);
 }
 
-.is-behind {
-  background: var(--is-behind-color);
+.is-unhealthy {
+  background: var(--is-unhealthy-color);
 }
 
-table tr:hover td.is-behind {
-  background: var(--is-behind-hover-color);
+table tr:hover td.is-unhealthy {
+  background: var(--is-unhealthy-hover-color);
 }
 
 td.matrix-cell:hover {


### PR DESCRIPTION
### Description
Display node row in healthz in red if the node is unhealthy.
For DNs, this means if blockdiff > 250, if solana play count drift is > 720, trusted notifier delists are unhealthy, chain is unhealthy, etc. Specific errors will be specified in the errors field of the healthcheck resp.

For CNs, this is if healthy: false in the healthcheck resp.

### How Has This Been Tested?
ran local healthz
dns:
![image](https://github.com/AudiusProject/audius-protocol/assets/25782182/1d3f4265-ed79-4d86-9d45-140dcf54cff8)
cns:
![image](https://github.com/AudiusProject/audius-protocol/assets/25782182/538860cc-c486-463e-851f-bcc8a7f78fc5)
