### PR TITLE
repair.go skip image variants

### DIFF
--- a/mediorum/server/db.go
+++ b/mediorum/server/db.go
@@ -6,7 +6,6 @@ import (
 	"mediorum/ddl"
 	"time"
 
-	"github.com/oklog/ulid/v2"
 	"gocloud.dev/blob"
 	"golang.org/x/exp/slog"
 	"gorm.io/driver/postgres"
@@ -76,26 +75,4 @@ func dbMigrate(crud *crudr.Crudr, bucket *blob.Bucket, myHost string) {
 
 	slog.Info("db: migrate done")
 
-}
-
-// delete blobs ops from other hosts that are > one week old
-func dbPruneOldOps(db *gorm.DB, myHost string) {
-
-	tooOld, err := ulid.New(uint64(time.Now().AddDate(0, 0, -7).UnixMilli()), nil)
-	if err != nil {
-		panic(err)
-	}
-
-	res := db.Exec(`
-		delete from ops
-		where "table" = 'blobs'
-		and "host" <> $1
-		and "ulid" < $2
-	`, myHost, tooOld.String())
-
-	if res.Error != nil {
-		slog.Error("dbPruneOldOps failed", "err", res.Error)
-	} else {
-		slog.Info("dbPruneOldOps OK", "row_count", res.RowsAffected)
-	}
 }

--- a/mediorum/server/server.go
+++ b/mediorum/server/server.go
@@ -224,7 +224,6 @@ func New(config MediorumConfig) (*MediorumServer, error) {
 		peerHosts = append(peerHosts, peer.Host)
 	}
 	crud := crudr.New(config.Self.Host, config.privateKey, peerHosts, db)
-	dbPruneOldOps(db, config.Self.Host)
 	dbMigrate(crud, bucket, config.Self.Host)
 
 	// req.cool http client


### PR DESCRIPTION
### Description

Image variants generated dynamically, so repair.go can skip them.
