### PR TITLE
Revert "Bump version to 0.4.10"

### DIFF
--- a/discovery-provider/.version.json
+++ b/discovery-provider/.version.json
@@ -1,4 +1,4 @@
 {
-  "version": "0.4.10",
+  "version": "0.4.9",
   "service": "discovery-node"
 }

--- a/mediorum/.version.json
+++ b/mediorum/.version.json
@@ -1,4 +1,4 @@
 {
-  "version": "0.4.10",
+  "version": "0.4.9",
   "service": "content-node"
 }


### PR DESCRIPTION
This reverts commit 8687503b20162d4a51c20942ca357741e4c3446c because I want to re-run the automated job on the next hour (10am PST). It ran into an issue due to dirty workspace earlier, so it didn't get to reach the step where it notifies in Slack (which is the only step I actually wanted to test). I will also want to delete the release-v0.4.10 branch so the next job can re-create it.
