### PR TITLE
non blocking notifs

### DIFF
--- a/discovery-provider/plugins/notifications/src/email/notifications/index.ts
+++ b/discovery-provider/plugins/notifications/src/email/notifications/index.ts
@@ -370,7 +370,7 @@ export async function processEmailNotifications(
       logger.info(
         `processEmailNotifications | Beginning processing ${
           Object.keys(emailUsers).length
-        } users at ${frequency} frequency`
+        } users at ${frequency} frequency ${pageOffset}`
       )
 
       await processGroupOfEmails(

--- a/discovery-provider/plugins/notifications/src/main.ts
+++ b/discovery-provider/plugins/notifications/src/main.ts
@@ -128,7 +128,7 @@ export class Processor {
           this.lastDailyEmailSent < moment.utc().subtract(1, 'days'))
       ) {
         logger.info('Processing daily emails...')
-        await processEmailNotifications(
+        processEmailNotifications(
           this.discoveryDB,
           this.identityDB,
           'daily',
@@ -143,7 +143,8 @@ export class Processor {
           this.lastWeeklyEmailSent < moment.utc().subtract(7, 'days'))
       ) {
         logger.info('Processing weekly emails')
-        await processEmailNotifications(
+        // fire and forget so other notifs can process
+        processEmailNotifications(
           this.discoveryDB,
           this.identityDB,
           'weekly',

--- a/discovery-provider/plugins/notifications/src/processNotifications/indexAppNotifications.ts
+++ b/discovery-provider/plugins/notifications/src/processNotifications/indexAppNotifications.ts
@@ -145,7 +145,7 @@ export class AppNotificationsProcessor {
         const isLiveEmailEnabled = this.getIsLiveEmailEnabled()
         const isBrowserPushEnabled = this.getIsBrowserPushEnabled()
         try {
-          notification.processNotification({
+          await notification.processNotification({
             isLiveEmailEnabled,
             isBrowserPushEnabled
           })

--- a/discovery-provider/plugins/notifications/src/processNotifications/indexAppNotifications.ts
+++ b/discovery-provider/plugins/notifications/src/processNotifications/indexAppNotifications.ts
@@ -145,7 +145,7 @@ export class AppNotificationsProcessor {
         const isLiveEmailEnabled = this.getIsLiveEmailEnabled()
         const isBrowserPushEnabled = this.getIsBrowserPushEnabled()
         try {
-          await notification.processNotification({
+          notification.processNotification({
             isLiveEmailEnabled,
             isBrowserPushEnabled
           })

--- a/discovery-provider/plugins/notifications/src/tasks/appNotifications.ts
+++ b/discovery-provider/plugins/notifications/src/tasks/appNotifications.ts
@@ -11,9 +11,8 @@ export async function sendAppNotifications(
     logger.info(
       `Processing ${pending.appNotifications.length} app notifications`
     )
-    await Promise.all([
-      appNotificationsProcessor.process(pending.appNotifications)
-    ])
+    
+    appNotificationsProcessor.process(pending.appNotifications)
     logger.info('Processed new app updates')
   }
 }

--- a/discovery-provider/plugins/notifications/src/tasks/appNotifications.ts
+++ b/discovery-provider/plugins/notifications/src/tasks/appNotifications.ts
@@ -12,7 +12,7 @@ export async function sendAppNotifications(
       `Processing ${pending.appNotifications.length} app notifications`
     )
     
-    appNotificationsProcessor.process(pending.appNotifications)
+    await appNotificationsProcessor.process(pending.appNotifications)
     logger.info('Processed new app updates')
   }
 }

--- a/discovery-provider/plugins/notifications/src/tasks/dmNotifications.ts
+++ b/discovery-provider/plugins/notifications/src/tasks/dmNotifications.ts
@@ -197,7 +197,7 @@ export async function sendDMNotifications(
 
     // Send push notifications
     for (const notification of notifications) {
-      await notification.processNotification({
+      notification.processNotification({
         isLiveEmailEnabled: false,
         isBrowserPushEnabled
       })


### PR DESCRIPTION
### Description
fires and forgets schedules emails so they don't block normal push processing

### How Has This Been Tested?
Ran on stage, you can see in these output logs that a push was sent to Sabrina while the process email notifs task was running. Even though the push itself failed you can see the IOS push attempt meaning that this notif was not a part of the scheduled emails cycle.

https://app.axiom.co/audius-Lu52/stream/stage-discovery?rowId=0cvnvopyb6971-06a6e2503e003fa0-9a07&context=1