### PR TITLE
[C-3117] Wait for collection upload before showing complete

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -91024,6 +91024,7 @@
       }
     },
     "packages/harmony": {
+      "name": "@audius/harmony",
       "version": "0.0.0",
       "license": "ISC",
       "devDependencies": {

--- a/packages/web/src/pages/upload-page/components/FinishPageNew.tsx
+++ b/packages/web/src/pages/upload-page/components/FinishPageNew.tsx
@@ -128,16 +128,13 @@ export const FinishPageNew = (props: FinishPageProps) => {
     if (!upload.uploadProgress || upload.uploading || !upload.success)
       return false
 
-    return (
-      upload.success &&
-      upload.uploadProgress.reduce((acc, progress) => {
-        return (
-          acc &&
-          progress.art.status === ProgressStatus.COMPLETE &&
-          progress.audio.status === ProgressStatus.COMPLETE
-        )
-      }, true)
-    )
+    return upload.uploadProgress.reduce((acc, progress) => {
+      return (
+        acc &&
+        progress.art.status === ProgressStatus.COMPLETE &&
+        progress.audio.status === ProgressStatus.COMPLETE
+      )
+    }, true)
   }, [upload])
 
   const handleUploadMoreClick = useCallback(() => {

--- a/packages/web/src/pages/upload-page/components/FinishPageNew.tsx
+++ b/packages/web/src/pages/upload-page/components/FinishPageNew.tsx
@@ -125,7 +125,9 @@ export const FinishPageNew = (props: FinishPageProps) => {
   const dispatch = useDispatch()
 
   const uploadComplete = useMemo(() => {
-    if (!upload.uploadProgress) return false
+    if (!upload.uploadProgress || upload.uploading || !upload.success)
+      return false
+
     return (
       upload.success &&
       upload.uploadProgress.reduce((acc, progress) => {


### PR DESCRIPTION
### Description

We were showing the upload complete page after all the tracks were uploaded but before the collection upload completed. This allowed the user to click `Visit Album` before the album was ready and would get a blank not found album page.

This change is to match the condition we used in the legacy upload flow.

### How Has This Been Tested?

local web using confirmer popup to check timing of album confirm vs showing the finish page