### PR TITLE
Discovery Relay: re-add feature flag

### DIFF
--- a/packages/common/src/services/audius-backend/AudiusBackend.ts
+++ b/packages/common/src/services/audius-backend/AudiusBackend.ts
@@ -675,6 +675,13 @@ export const audiusBackend = ({
       monitoringCallbacks.contentNode
     )
 
+
+    const useDiscoveryRelay = await getFeatureEnabled(
+      FeatureFlags.DISCOVERY_RELAY
+    )
+
+    console.info({ useDiscoveryRelay }, `discovery relay${useDiscoveryRelay ? ' ' : ' not '}enabled`)
+
     try {
       audiusLibs = new AudiusLibs({
         localStorage,
@@ -722,10 +729,16 @@ export const audiusBackend = ({
         preferHigherPatchForSecondaries: await getFeatureEnabled(
           FeatureFlags.PREFER_HIGHER_PATCH_FOR_SECONDARIES
         ),
-        hedgehogConfig
+        hedgehogConfig,
+        useDiscoveryRelay
       })
       await audiusLibs.init()
       onLibsInit(audiusLibs)
+
+      if (useDiscoveryRelay) {
+        // libs not respecting the flag, mod web3 manager manually
+        audiusLibs.web3Manager.discoveryProvider = audiusLibs.discoveryProvider
+      }
 
       sanityChecks(audiusLibs)
     } catch (err) {

--- a/packages/common/src/services/audius-backend/AudiusBackend.ts
+++ b/packages/common/src/services/audius-backend/AudiusBackend.ts
@@ -675,12 +675,14 @@ export const audiusBackend = ({
       monitoringCallbacks.contentNode
     )
 
-
     const useDiscoveryRelay = await getFeatureEnabled(
       FeatureFlags.DISCOVERY_RELAY
     )
 
-    console.info({ useDiscoveryRelay }, `discovery relay${useDiscoveryRelay ? ' ' : ' not '}enabled`)
+    console.info(
+      { useDiscoveryRelay },
+      `discovery relay${useDiscoveryRelay ? ' ' : ' not '}enabled`
+    )
 
     try {
       audiusLibs = new AudiusLibs({

--- a/packages/common/src/services/remote-config/feature-flags.ts
+++ b/packages/common/src/services/remote-config/feature-flags.ts
@@ -47,7 +47,8 @@ export enum FeatureFlags {
   DEVELOPER_APPS_PAGE = 'developer_apps_page',
   UPLOAD_REDESIGN_ENABLED = 'upload_redesign_enabled',
   USDC_PURCHASES = 'usdc_purchases',
-  NEW_PLAYLIST_ROUTES = 'new_playlist_routes'
+  NEW_PLAYLIST_ROUTES = 'new_playlist_routes',
+  DISCOVERY_RELAY = 'discovery_relay'
 }
 
 type FlagDefaults = Record<FeatureFlags, boolean>
@@ -110,5 +111,6 @@ export const flagDefaults: FlagDefaults = {
   [FeatureFlags.DEVELOPER_APPS_PAGE]: false,
   [FeatureFlags.UPLOAD_REDESIGN_ENABLED]: false,
   [FeatureFlags.USDC_PURCHASES]: false,
-  [FeatureFlags.NEW_PLAYLIST_ROUTES]: false
+  [FeatureFlags.NEW_PLAYLIST_ROUTES]: false,
+  [FeatureFlags.DISCOVERY_RELAY]: false,
 }

--- a/packages/common/src/services/remote-config/feature-flags.ts
+++ b/packages/common/src/services/remote-config/feature-flags.ts
@@ -112,5 +112,5 @@ export const flagDefaults: FlagDefaults = {
   [FeatureFlags.UPLOAD_REDESIGN_ENABLED]: false,
   [FeatureFlags.USDC_PURCHASES]: false,
   [FeatureFlags.NEW_PLAYLIST_ROUTES]: false,
-  [FeatureFlags.DISCOVERY_RELAY]: false,
+  [FeatureFlags.DISCOVERY_RELAY]: false
 }

--- a/packages/libs/src/AudiusLibs.ts
+++ b/packages/libs/src/AudiusLibs.ts
@@ -545,7 +545,7 @@ export class AudiusLibs {
       if (this.web3Config && this.useDiscoveryRelay) {
         const web3Manager = this.web3Manager
         if (web3Manager === undefined || web3Manager === null) {
-          console.warn("useDiscoveryRelay is set to true but web3Manager is not configured")
+          console.info("useDiscoveryRelay is set to true but web3Manager is not configured")
         } else {
           this.web3Manager?.setDiscoveryProvider(this.discoveryProvider)
         }


### PR DESCRIPTION
### Description
Original PR got closed for some reason, this adds it back and is why stage doesn't use discovery relay yet.

### How Has This Been Tested?
In an incognito window went through user sign up flow, successfully created user, then did some things like favorite, repost, etc.

