### PR TITLE
[PAY-1858] Add saga support for 'pay extra'

### DIFF
--- a/packages/common/src/models/Analytics.ts
+++ b/packages/common/src/models/Analytics.ts
@@ -1576,6 +1576,7 @@ type BuyUSDCFailure = {
 
 type PurchaseContentStarted = {
   eventName: Name.PURCHASE_CONTENT_STARTED
+  extraAmount?: number
   contentId: number
   contentType: string
 }

--- a/packages/common/src/services/audius-backend/solana.ts
+++ b/packages/common/src/services/audius-backend/solana.ts
@@ -271,6 +271,7 @@ export const pollForBalanceChange = async (
 export type PurchaseContentArgs = {
   id: number
   blocknumber: number
+  extraAmount?: number | BN
   type: 'track'
   splits: Record<string, number | BN>
 }

--- a/packages/common/src/store/purchase-content/sagas.ts
+++ b/packages/common/src/store/purchase-content/sagas.ts
@@ -129,7 +129,7 @@ function* pollForPurchaseConfirmation({
 }
 
 function* doStartPurchaseContentFlow({
-  payload: { contentId, contentType = ContentType.TRACK }
+  payload: { extraAmount, contentId, contentType = ContentType.TRACK }
 }: ReturnType<typeof startPurchaseContentFlow>) {
   const audiusBackendInstance = yield* getContext('audiusBackendInstance')
   const reportToSentry = yield* getContext('reportToSentry')
@@ -138,7 +138,12 @@ function* doStartPurchaseContentFlow({
   // Record start
   yield* call(
     track,
-    make({ eventName: Name.PURCHASE_CONTENT_STARTED, contentId, contentType })
+    make({
+      eventName: Name.PURCHASE_CONTENT_STARTED,
+      extraAmount,
+      contentId,
+      contentType
+    })
   )
 
   try {
@@ -165,9 +170,10 @@ function* doStartPurchaseContentFlow({
     const { amount: initialBalance } = tokenAccountInfo
 
     const priceBN = new BN(price).mul(BN_USDC_CENT_WEI)
-    const balanceNeeded: BNUSDC = priceBN.sub(
-      new BN(initialBalance.toString())
-    ) as BNUSDC
+    const extraAmountBN = new BN(extraAmount ?? 0).mul(BN_USDC_CENT_WEI)
+    const balanceNeeded: BNUSDC = priceBN
+      .add(extraAmountBN)
+      .sub(new BN(initialBalance.toString())) as BNUSDC
 
     // buy USDC if necessary
     if (balanceNeeded.gtn(0)) {
@@ -212,6 +218,7 @@ function* doStartPurchaseContentFlow({
     yield* call(purchaseContent, audiusBackendInstance, {
       id: contentId,
       blocknumber,
+      extraAmount: extraAmountBN,
       splits,
       type: 'track'
     })

--- a/packages/common/src/store/purchase-content/slice.ts
+++ b/packages/common/src/store/purchase-content/slice.ts
@@ -13,6 +13,8 @@ type PurchaseContentState = {
   stage: PurchaseContentStage
   contentType: ContentType
   contentId: ID
+  /** Pay extra amount in cents */
+  extraAmount?: number
   error?: Error
   onSuccess?: OnSuccess
 }
@@ -20,6 +22,7 @@ type PurchaseContentState = {
 const initialState: PurchaseContentState = {
   contentType: ContentType.TRACK,
   contentId: -1,
+  extraAmount: undefined,
   error: undefined,
   stage: PurchaseContentStage.START
 }
@@ -31,6 +34,7 @@ const slice = createSlice({
     startPurchaseContentFlow: (
       state,
       action: PayloadAction<{
+        extraAmount?: number
         contentId: ID
         contentType?: ContentType
         onSuccess?: OnSuccess
@@ -38,6 +42,7 @@ const slice = createSlice({
     ) => {
       state.stage = PurchaseContentStage.START
       state.error = undefined
+      state.extraAmount = action.payload.extraAmount
       state.contentId = action.payload.contentId
       state.contentType = action.payload.contentType ?? ContentType.TRACK
       state.onSuccess = action.payload.onSuccess


### PR DESCRIPTION
### Description
Adds slice/saga logic for passing an `extraAmount` field and propagating that down to libs to include in the transaction.

fixes PAY-1809

### How Has This Been Tested?
I temporarily modified the purchase modal to pass along a fixed extra amount and verified that it was sent along in the transaction

