### PR TITLE
[C-3079] Fixes blocking mobile upload validation error

### DIFF
--- a/packages/mobile/src/screens/edit-track-screen/EditTrackScreen.tsx
+++ b/packages/mobile/src/screens/edit-track-screen/EditTrackScreen.tsx
@@ -28,7 +28,6 @@ const EditTrackSchema = Yup.object().shape({
         .positive()
         .min(0.99, 'Price must be at least $0.99.')
         .max(9999.99, 'Price must be less than $9999.99.')
-        .required('Required')
     }).nullable()
   }).nullable(),
   duration: Yup.number(),


### PR DESCRIPTION
### Description

Fixes issue where interacting with access + sale screen prevents user from uploading. this has to do with not fully-fleshed out validation for the various premium conditions. When we finalize validation on desktop, we should migrate that over to mobile
