### PR TITLE
[PAY-1737] Add notification for usdc withdrawal

### DIFF
--- a/discovery-provider/ddl/functions/handle_usdc_withdrawal.sql
+++ b/discovery-provider/ddl/functions/handle_usdc_withdrawal.sql
@@ -9,7 +9,7 @@ begin
     from users
     join usdc_user_bank_accounts
       on users.wallet = usdc_user_bank_accounts.ethereum_address
-    where usdc_user_bank_accounts.user_bank = new.user_bank;    
+    where usdc_user_bank_accounts.bank_account = new.user_bank;    
 
     -- Insert the new notification
     insert into notification

--- a/discovery-provider/ddl/functions/handle_usdc_withdrawal.sql
+++ b/discovery-provider/ddl/functions/handle_usdc_withdrawal.sql
@@ -23,11 +23,11 @@ begin
         users_row.user_id,
         'usdc_withdrawal:' || users_row.user_id,
         json_build_object(
-          'user_id': users_row.user_id,
-          'user_bank': new.user_bank,
-          'signature': new.signature,
-          'change': new.change,
-          'balance': new.balance
+          'user_id', users_row.user_id,
+          'user_bank', new.user_bank,
+          'signature', new.signature,
+          'change', new.change,
+          'balance', new.balance
         )
       )
       on conflict do nothing;
@@ -40,7 +40,7 @@ begin
         return null;
 
 end;
-$$ langauge plpgsql;
+$$ language plpgsql;
 
 do $$ begin
   create trigger on_usdc_withdrawal

--- a/discovery-provider/ddl/functions/handle_usdc_withdrawal.sql
+++ b/discovery-provider/ddl/functions/handle_usdc_withdrawal.sql
@@ -1,0 +1,51 @@
+create or replace function handle_usdc_withdrawal() returns trigger as $$
+DECLARE
+    users_row users%ROWTYPE;
+begin
+
+  if new.transaction_type = 'transfer' and new.method = 'send' then
+    -- Fetch the corresponding user based on the wallet
+    select into users_row users.*
+    from users
+    join usdc_user_bank_accounts
+      on users.wallet = usdc_user_bank_accounts.ethereum_address
+    where usdc_user_bank_accounts.user_bank = new.user_bank;    
+
+    -- Insert the new notification
+    insert into notification
+      (slot, user_ids, timestamp, type, specifier, group_id, data)
+    values
+      (
+        new.slot,
+        ARRAY [users_row.user_id],
+        new.created_at,
+        'usdc_withdrawal',
+        users_row.user_id,
+        'usdc_withdrawal:' || users_row.user_id,
+        json_build_object(
+          'user_id': users_row.user_id,
+          'user_bank': new.user_bank,
+          'signature': new.signature,
+          'change': new.change,
+          'balance': new.balance
+        )
+      )
+      on conflict do nothing;
+  end if;
+
+  return null;
+  exception
+    when others then
+        raise warning 'An error occurred in %: %', tg_name, sqlerrm;
+        return null;
+
+end;
+$$ langauge plpgsql;
+
+do $$ begin
+  create trigger on_usdc_withdrawal
+  after insert on usdc_transactions_history
+  for each row execute procedure handle_usdc_withdrawal();
+exception
+  when others then null;
+end $$;

--- a/discovery-provider/ddl/migrations/0025_add_track_price_history_fkey.sql
+++ b/discovery-provider/ddl/migrations/0025_add_track_price_history_fkey.sql
@@ -1,4 +1,12 @@
 -- add this fkey constraint to cascade delete track_price_history on revert
 begin;
-alter table track_price_history add constraint track_price_history_blocknumber_fkey foreign key (blocknumber) references blocks (number) on delete cascade;
+
+do $$
+begin
+   if not exists (select 1 from pg_constraint where conname = 'track_price_history_blocknumber_fkey') then
+    alter table track_price_history add constraint track_price_history_blocknumber_fkey foreign key (blocknumber) references blocks (number) on delete cascade;
+  end if;
+
+end $$;
+
 commit;

--- a/discovery-provider/integration_tests/notifications/test_usdc_withdrawal.py
+++ b/discovery-provider/integration_tests/notifications/test_usdc_withdrawal.py
@@ -13,20 +13,23 @@ def test_usdc_withdrawal_notification(app):
     with app.app_context():
         db = get_db()
 
-    entities = {
+    test_entities = {
         "users": [
             {"user_id": 1, "wallet": "0x2306d1abbbf961241fa7caeee65f1214d94ce262"}
         ],
         "usdc_user_bank_accounts": [
             {
-                "signature": "4HMtqP6k5ugi5jhCQo5CpqKzjxREhsZ4QTE2XDo48v4JBaDjS4kWXo7EixucKEFkwHxF9j3Qzp2ZjLdGpN4FRQVt",
                 "ethereum_address": "0x2306d1abbbf961241fa7caeee65f1214d94ce262",
                 "bank_account": "8q8MSG4cdyDLoDXRGBLQugA6oHtQmbCtVVV1aEuPdYTj",
             }
         ],
+    }
+    populate_mock_db(db, test_entities)
+    test_actions = {
         "usdc_transactions_history": [
             {
                 "slot": 4,
+                "signature": "4HMtqP6k5ugi5jhCQo5CpqKzjxREhsZ4QTE2XDo48v4JBaDjS4kWXo7EixucKEFkwHxF9j3Qzp2ZjLdGpN4FRQVt",
                 "user_bank": "8q8MSG4cdyDLoDXRGBLQugA6oHtQmbCtVVV1aEuPdYTj",
                 "transaction_type": "transfer",
                 "method": "send",
@@ -35,25 +38,21 @@ def test_usdc_withdrawal_notification(app):
             }
         ],
     }
-    populate_mock_db(db, entities)
+    populate_mock_db(db, test_actions)
 
     with db.scoped_session() as session:
-        notifications: List[Notification] = (
-            session.query(Notification)
-            .filter(Notification.type == "usdc_withdrawal")
-            .all()
-        )
+        notifications: List[Notification] = session.query(Notification).all()
         assert len(notifications) == 1
         notification = notifications[0]
         assert notification.user_ids == [1]
         assert notification.specifier == "1"
         assert notification.group_id == "usdc_withdrawal:1"
-        assert notification.slot == "asdf"
+        assert notification.slot == 4
 
         assert notification.data == {
             "user_id": 1,
-            "user_bank": "asdf",
-            "signature": "asdf",
+            "user_bank": "8q8MSG4cdyDLoDXRGBLQugA6oHtQmbCtVVV1aEuPdYTj",
+            "signature": "4HMtqP6k5ugi5jhCQo5CpqKzjxREhsZ4QTE2XDo48v4JBaDjS4kWXo7EixucKEFkwHxF9j3Qzp2ZjLdGpN4FRQVt",
             "change": -100,
             "balance": 100,
         }
@@ -63,7 +62,7 @@ def test_usdc_withdrawal_notification_not_withdrawal(app):
     with app.app_context():
         db = get_db()
 
-    entities = {
+    test_entities = {
         "users": [
             {"user_id": 1, "wallet": "0x2306d1abbbf961241fa7caeee65f1214d94ce262"}
         ],
@@ -74,6 +73,9 @@ def test_usdc_withdrawal_notification_not_withdrawal(app):
                 "bank_account": "8q8MSG4cdyDLoDXRGBLQugA6oHtQmbCtVVV1aEuPdYTj",
             }
         ],
+    }
+    populate_mock_db(db, test_entities)
+    test_actions = {
         "usdc_transactions_history": [
             {
                 "slot": 4,
@@ -85,7 +87,7 @@ def test_usdc_withdrawal_notification_not_withdrawal(app):
             }
         ],
     }
-    populate_mock_db(db, entities)
+    populate_mock_db(db, test_actions)
 
     with db.scoped_session() as session:
         notifications: List[Notification] = (

--- a/discovery-provider/integration_tests/notifications/test_usdc_withdrawal.py
+++ b/discovery-provider/integration_tests/notifications/test_usdc_withdrawal.py
@@ -1,0 +1,96 @@
+import logging
+from typing import List
+
+from integration_tests.utils import populate_mock_db
+from src.models.notifications.notification import Notification
+from src.utils.db_session import get_db
+
+logger = logging.getLogger(__name__)
+
+
+# ========================================== Start Tests ==========================================
+def test_usdc_withdrawal_notification(app):
+    with app.app_context():
+        db = get_db()
+
+    entities = {
+        "users": [
+            {"user_id": 1, "wallet": "0x2306d1abbbf961241fa7caeee65f1214d94ce262"}
+        ],
+        "usdc_user_bank_accounts": [
+            {
+                "signature": "4HMtqP6k5ugi5jhCQo5CpqKzjxREhsZ4QTE2XDo48v4JBaDjS4kWXo7EixucKEFkwHxF9j3Qzp2ZjLdGpN4FRQVt",
+                "ethereum_address": "0x2306d1abbbf961241fa7caeee65f1214d94ce262",
+                "bank_account": "8q8MSG4cdyDLoDXRGBLQugA6oHtQmbCtVVV1aEuPdYTj",
+            }
+        ],
+        "usdc_transactions_history": [
+            {
+                "slot": 4,
+                "user_bank": "8q8MSG4cdyDLoDXRGBLQugA6oHtQmbCtVVV1aEuPdYTj",
+                "transaction_type": "transfer",
+                "method": "send",
+                "change": -100,
+                "balance": 100,
+            }
+        ],
+    }
+    populate_mock_db(db, entities)
+
+    with db.scoped_session() as session:
+        notifications: List[Notification] = (
+            session.query(Notification)
+            .filter(Notification.type == "usdc_withdrawal")
+            .all()
+        )
+        assert len(notifications) == 1
+        notification = notifications[0]
+        assert notification.user_ids == [1]
+        assert notification.specifier == "1"
+        assert notification.group_id == "usdc_withdrawal:1"
+        assert notification.slot == "asdf"
+
+        assert notification.data == {
+            "user_id": 1,
+            "user_bank": "asdf",
+            "signature": "asdf",
+            "change": -100,
+            "balance": 100,
+        }
+
+
+def test_usdc_withdrawal_notification_not_withdrawal(app):
+    with app.app_context():
+        db = get_db()
+
+    entities = {
+        "users": [
+            {"user_id": 1, "wallet": "0x2306d1abbbf961241fa7caeee65f1214d94ce262"}
+        ],
+        "usdc_user_bank_accounts": [
+            {
+                "signature": "4HMtqP6k5ugi5jhCQo5CpqKzjxREhsZ4QTE2XDo48v4JBaDjS4kWXo7EixucKEFkwHxF9j3Qzp2ZjLdGpN4FRQVt",
+                "ethereum_address": "0x2306d1abbbf961241fa7caeee65f1214d94ce262",
+                "bank_account": "8q8MSG4cdyDLoDXRGBLQugA6oHtQmbCtVVV1aEuPdYTj",
+            }
+        ],
+        "usdc_transactions_history": [
+            {
+                "slot": 4,
+                "user_bank": "8q8MSG4cdyDLoDXRGBLQugA6oHtQmbCtVVV1aEuPdYTj",
+                "transaction_type": "transfer",
+                "method": "receive",
+                "change": -100,
+                "balance": 100,
+            }
+        ],
+    }
+    populate_mock_db(db, entities)
+
+    with db.scoped_session() as session:
+        notifications: List[Notification] = (
+            session.query(Notification)
+            .filter(Notification.type == "usdc_withdrawal")
+            .all()
+        )
+        assert len(notifications) == 0


### PR DESCRIPTION
### Description

Add notification for usdc withdrawal. Note that this will not be consumed in in-app emails, or consumed via push. At the moment the only receiver will the notifications plugin and email processing.

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._

```
audius-compose test discovery-provider
```