### PR TITLE
[proto-1259] update postman collection to test all read endpoints

### DIFF
--- a/discovery-provider/api-tests/Discovery API Tests.postman_collection.json
+++ b/discovery-provider/api-tests/Discovery API Tests.postman_collection.json
@@ -1,296 +1,5723 @@
 {
-	"info": {
-		"_postman_id": "37569e63-ecbc-4560-a996-3764d18828ae",
-		"name": "Discovery API Tests",
-		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
-		"_exporter_id": "28733713",
-		"_collection_link": "https://universal-escape-508405.postman.co/workspace/Audius-Workspace~0a6b2ea4-68e8-4507-8c1b-124114436ef5/collection/28733713-37569e63-ecbc-4560-a996-3764d18828ae?action=share&source=collection_link&creator=28733713"
-	},
-	"item": [
-		{
-			"name": "Get User",
-			"event": [
-				{
-					"listen": "test",
-					"script": {
-						"exec": [
-							""
-						],
-						"type": "text/javascript"
-					}
-				}
-			],
-			"request": {
-				"method": "GET",
-				"header": [],
-				"url": {
-					"raw": "{{test_base_url}}/v1/users/nlGNe",
-					"host": [
-						"{{test_base_url}}"
-					],
-					"path": [
-						"v1",
-						"users",
-						"nlGNe"
-					]
-				}
-			},
-			"response": []
-		},
-		{
-			"name": "Get Trending",
-			"event": [
-				{
-					"listen": "test",
-					"script": {
-						"exec": [
-							""
-						],
-						"type": "text/javascript"
-					}
-				},
-				{
-					"listen": "prerequest",
-					"script": {
-						"exec": [
-							""
-						],
-						"type": "text/javascript"
-					}
-				}
-			],
-			"request": {
-				"method": "GET",
-				"header": [],
-				"url": {
-					"raw": "{{test_base_url}}/v1/full/tracks/trending?time=week&limit=11&offset=0",
-					"host": [
-						"{{test_base_url}}"
-					],
-					"path": [
-						"v1",
-						"full",
-						"tracks",
-						"trending"
-					],
-					"query": [
-						{
-							"key": "time",
-							"value": "week"
-						},
-						{
-							"key": "limit",
-							"value": "11"
-						},
-						{
-							"key": "offset",
-							"value": "0"
-						}
-					]
-				}
-			},
-			"response": []
-		},
-		{
-			"name": "Get Playlist",
-			"request": {
-				"method": "GET",
-				"header": [],
-				"url": {
-					"raw": "{{test_base_url}}/v1/playlists/DOPRl",
-					"host": [
-						"{{test_base_url}}"
-					],
-					"path": [
-						"v1",
-						"playlists",
-						"DOPRl"
-					]
-				}
-			},
-			"response": []
-		},
-		{
-			"name": "Get Track",
-			"request": {
-				"method": "GET",
-				"header": [],
-				"url": {
-					"raw": "{{test_base_url}}/v1/tracks/D7KyD",
-					"host": [
-						"{{test_base_url}}"
-					],
-					"path": [
-						"v1",
-						"tracks",
-						"D7KyD"
-					]
-				}
-			},
-			"response": []
-		},
-		{
-			"name": "Get Tips",
-			"request": {
-				"method": "GET",
-				"header": [],
-				"url": {
-					"raw": "{{test_base_url}}/v1/tips",
-					"host": [
-						"{{test_base_url}}"
-					],
-					"path": [
-						"v1",
-						"tips"
-					]
-				}
-			},
-			"response": []
-		},
-		{
-			"name": "Get Bulk Tracks",
-			"request": {
-				"method": "GET",
-				"header": [],
-				"url": {
-					"raw": "{{test_base_url}}/v1/tracks?permalink=/TeamBandL/paauer-|-baauer-b2b-party-favor-|-bl-block-party-la-live-set-725&app_name=EXAMPLEAPP",
-					"host": [
-						"{{test_base_url}}"
-					],
-					"path": [
-						"v1",
-						"tracks"
-					],
-					"query": [
-						{
-							"key": "permalink",
-							"value": "/TeamBandL/paauer-|-baauer-b2b-party-favor-|-bl-block-party-la-live-set-725"
-						},
-						{
-							"key": "app_name",
-							"value": "EXAMPLEAPP"
-						}
-					]
-				}
-			},
-			"response": []
-		}
-	],
-	"event": [
-		{
-			"listen": "prerequest",
-			"script": {
-				"type": "text/javascript",
-				"exec": [
-					"// In the pre-request script of the request",
-					"",
-					"// Set the base URL based on the selected environment",
-					"const controlUrlHost = pm.environment.get('control_base_url');",
-					"let controlRequestCopy = pm.request.clone();",
-					"let controlRequestUrl = controlRequestCopy.url;",
-					"controlRequestUrl.host = controlUrlHost;",
-					"const controlRequestString = controlRequestUrl.toString();",
-					"",
-					"pm.sendRequest(controlRequestString, function (error, controlResponse) {",
-					"    if (error) {",
-					"        throw new Error(\"pre-requesite failed with \" + JSON.stringify(error));",
-					"    }",
-					"    // Capture the control sandbox response data and latency time",
-					"    pm.environment.set('control_response', controlResponse.json());",
-					"    pm.environment.set('control_latency', controlResponse.responseTime);",
-					"});",
-					""
-				]
-			}
-		},
-		{
-			"listen": "test",
-			"script": {
-				"type": "text/javascript",
-				"exec": [
-					"",
-					"// Retrieve the control sandbox response data and latency time",
-					"const controlResponseData = pm.environment.get('control_response');",
-					"const controlLatency = pm.environment.get('control_latency');",
-					"const testBaseUrl = pm.environment.get('test_base_url');",
-					"// Compare testResponseData with controlResponseData",
-					"// You can implement your custom logic for comparison here",
-					"",
-					"",
-					"// Function to flatten a nested JSON object",
-					"function flattenJsonObject(obj, parentKey = '') {",
-					"    let result = {};",
-					"",
-					"    for (const key in obj) {",
-					"        if (obj.hasOwnProperty(key)) {",
-					"            const newKey = parentKey ? `${parentKey}.${key}` : key;",
-					"            if (typeof obj[key] === 'object') {",
-					"                // Recursively flatten nested objects",
-					"                const nestedFlatten = flattenJsonObject(obj[key], newKey);",
-					"                result = { ...result, ...nestedFlatten };",
-					"            } else {",
-					"                result[newKey] = obj[key];",
-					"            }",
-					"        }",
-					"    }",
-					"",
-					"    return result;",
-					"}",
-					"",
-					"// Flatten both expected and actual JSON objects",
-					"const flattenedExpected = flattenJsonObject(controlResponseData.data);",
-					"const flattenedActual = flattenJsonObject(pm.response.json().data);",
-					"",
-					"// Function to calculate the similarity percentage between two flattened objects",
-					"function calculateSimilarityPercentage(expected, actual) {",
-					"    let matchingFields = 0;",
-					"    let totalFields = 0;",
-					"",
-					"    // Iterate over each field in the expected flattened object",
-					"    for (const key in expected) {",
-					"        if (expected.hasOwnProperty(key)) {",
-					"            totalFields++;",
-					"",
-					"            const expectedValue = expected[key];",
-					"            const actualValue = actual[key];",
-					"",
-					"            if (expectedValue === actualValue) {",
-					"                matchingFields++;",
-					"            } else {",
-					"                console.log(`${key}: expected [${expectedValue}] - actual [${actualValue}]`)",
-					"            }",
-					"        }",
-					"    }",
-					"",
-					"    // Calculate the similarity percentage",
-					"    const similarityPercentage = (matchingFields / totalFields) * 100;",
-					"    return similarityPercentage;",
-					"}",
-					"",
-					"// Calculate the similarity percentage for the flattened objects",
-					"const similarityPercentage = calculateSimilarityPercentage(flattenedExpected, flattenedActual);",
-					"",
-					"",
-					"pm.test(\"Check JSON similarity\", function () {",
-					"    const similarityThreshold = parseFloat(pm.environment.get(\"similarity_threshold\"))",
-					"    pm.expect(similarityPercentage).to.be.at.least(similarityThreshold);",
-					"});",
-					"",
-					"pm.test('Latency is Acceptable', function () {",
-					"    let maxLatencyThreshold = (controlLatency + pm.environment.get('latency_threshold_buffer')) * (1 + pm.environment.get('latency_threshold_percentage'));",
-					"    let adjustedTestLatency = pm.response.responseTime;",
-					"    pm.expect(adjustedTestLatency).to.be.below(maxLatencyThreshold)",
-					"",
-					"});",
-					""
-				]
-			}
-		}
-	],
-	"variable": [
-		{
-			"key": "test_base_url",
-			"value": "http://35.209.86.3:5000"
-		}
-	]
+    "info": {
+        "_postman_id": "c54d603e-7b80-493c-8480-3b9710473ff3",
+        "name": "API",
+        "description": "Audius V1 API",
+        "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
+        "_exporter_id": "29850636",
+        "_collection_link": "https://universal-escape-508405.postman.co/workspace/Audius-Workspace~0a6b2ea4-68e8-4507-8c1b-124114436ef5/collection/28733713-c54d603e-7b80-493c-8480-3b9710473ff3?action=share&source=collection_link&creator=29850636"
+    },
+    "item": [
+        {
+            "name": "developer_apps",
+            "item": [
+                {
+                    "name": "{address}",
+                    "item": [
+                        {
+                            "name": "Get Developer App",
+                            "request": {
+                                "method": "GET",
+                                "header": [
+                                    {
+                                        "key": "Accept",
+                                        "value": "application/json"
+                                    }
+                                ],
+                                "url": {
+                                    "raw": "{{test_base_url}}/developer_apps/:address",
+                                    "host": [
+                                        "{{test_base_url}}"
+                                    ],
+                                    "path": [
+                                        "developer_apps",
+                                        ":address"
+                                    ],
+                                    "variable": [
+                                        {
+                                            "key": "address",
+                                            "value": "<string>"
+                                        }
+                                    ]
+                                },
+                                "description": "Gets developer app matching given address (API key)"
+                            },
+                            "response": [
+                                {
+                                    "name": "Success",
+                                    "originalRequest": {
+                                        "method": "GET",
+                                        "header": [
+                                            {
+                                                "key": "Accept",
+                                                "value": "application/json"
+                                            }
+                                        ],
+                                        "url": {
+                                            "raw": "{{baseUrl}}/developer_apps/:address",
+                                            "host": [
+                                                "{{baseUrl}}"
+                                            ],
+                                            "path": [
+                                                "developer_apps",
+                                                ":address"
+                                            ],
+                                            "variable": [
+                                                {
+                                                    "key": "address"
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    "status": "OK",
+                                    "code": 200,
+                                    "_postman_previewlanguage": "json",
+                                    "header": [
+                                        {
+                                            "key": "Content-Type",
+                                            "value": "application/json"
+                                        }
+                                    ],
+                                    "cookie": [],
+                                    "body": "{\n  \"data\": {\n    \"address\": \"<string>\",\n    \"name\": \"<string>\",\n    \"user_id\": \"<string>\",\n    \"description\": \"<string>\"\n  }\n}"
+                                },
+                                {
+                                    "name": "Bad request",
+                                    "originalRequest": {
+                                        "method": "GET",
+                                        "header": [],
+                                        "url": {
+                                            "raw": "{{baseUrl}}/developer_apps/:address",
+                                            "host": [
+                                                "{{baseUrl}}"
+                                            ],
+                                            "path": [
+                                                "developer_apps",
+                                                ":address"
+                                            ],
+                                            "variable": [
+                                                {
+                                                    "key": "address"
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    "status": "Bad Request",
+                                    "code": 400,
+                                    "_postman_previewlanguage": "text",
+                                    "header": [],
+                                    "cookie": [],
+                                    "body": ""
+                                },
+                                {
+                                    "name": "Not found",
+                                    "originalRequest": {
+                                        "method": "GET",
+                                        "header": [],
+                                        "url": {
+                                            "raw": "{{baseUrl}}/developer_apps/:address",
+                                            "host": [
+                                                "{{baseUrl}}"
+                                            ],
+                                            "path": [
+                                                "developer_apps",
+                                                ":address"
+                                            ],
+                                            "variable": [
+                                                {
+                                                    "key": "address"
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    "status": "Not Found",
+                                    "code": 404,
+                                    "_postman_previewlanguage": "text",
+                                    "header": [],
+                                    "cookie": [],
+                                    "body": ""
+                                },
+                                {
+                                    "name": "Server error",
+                                    "originalRequest": {
+                                        "method": "GET",
+                                        "header": [],
+                                        "url": {
+                                            "raw": "{{baseUrl}}/developer_apps/:address",
+                                            "host": [
+                                                "{{baseUrl}}"
+                                            ],
+                                            "path": [
+                                                "developer_apps",
+                                                ":address"
+                                            ],
+                                            "variable": [
+                                                {
+                                                    "key": "address"
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    "status": "Internal Server Error",
+                                    "code": 500,
+                                    "_postman_previewlanguage": "text",
+                                    "header": [],
+                                    "cookie": [],
+                                    "body": ""
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "name": "playlists",
+            "item": [
+                {
+                    "name": "by_permalink",
+                    "item": [
+                        {
+                            "name": "{handle}",
+                            "item": [
+                                {
+                                    "name": "{slug}",
+                                    "item": [
+                                        {
+                                            "name": "Get Playlist By Handle and Slug",
+                                            "request": {
+                                                "method": "GET",
+                                                "header": [
+                                                    {
+                                                        "key": "Accept",
+                                                        "value": "application/json"
+                                                    }
+                                                ],
+                                                "url": {
+                                                    "raw": "{{test_base_url}}/playlists/by_permalink/:playlist_handle/:playlist_slug?user_id=<string>",
+                                                    "host": [
+                                                        "{{test_base_url}}"
+                                                    ],
+                                                    "path": [
+                                                        "playlists",
+                                                        "by_permalink",
+                                                        ":playlist_handle",
+                                                        ":playlist_slug"
+                                                    ],
+                                                    "query": [
+                                                        {
+                                                            "key": "user_id",
+                                                            "value": "<string>",
+                                                            "description": "The user ID of the user making the request"
+                                                        }
+                                                    ],
+                                                    "variable": [
+                                                        {
+                                                            "key": "playlist_handle",
+                                                            "value": "AudiusPlaylists"
+                                                        },
+                                                        {
+                                                            "key": "playlist_slug",
+                                                            "value": "lo-fi-nights-4629"
+                                                        }
+                                                    ]
+                                                },
+                                                "description": "Get a playlist by handle and slug"
+                                            },
+                                            "response": [
+                                                {
+                                                    "name": "Success",
+                                                    "originalRequest": {
+                                                        "method": "GET",
+                                                        "header": [
+                                                            {
+                                                                "key": "Accept",
+                                                                "value": "application/json"
+                                                            }
+                                                        ],
+                                                        "url": {
+                                                            "raw": "{{baseUrl}}/playlists/by_permalink/:handle/:slug?user_id=<string>",
+                                                            "host": [
+                                                                "{{baseUrl}}"
+                                                            ],
+                                                            "path": [
+                                                                "playlists",
+                                                                "by_permalink",
+                                                                ":handle",
+                                                                ":slug"
+                                                            ],
+                                                            "query": [
+                                                                {
+                                                                    "key": "user_id",
+                                                                    "value": "<string>",
+                                                                    "description": "The user ID of the user making the request"
+                                                                }
+                                                            ],
+                                                            "variable": [
+                                                                {
+                                                                    "key": "handle"
+                                                                },
+                                                                {
+                                                                    "key": "slug"
+                                                                }
+                                                            ]
+                                                        }
+                                                    },
+                                                    "status": "OK",
+                                                    "code": 200,
+                                                    "_postman_previewlanguage": "json",
+                                                    "header": [
+                                                        {
+                                                            "key": "Content-Type",
+                                                            "value": "application/json"
+                                                        }
+                                                    ],
+                                                    "cookie": [],
+                                                    "body": "{\n  \"data\": [\n    {\n      \"favorite_count\": \"<integer>\",\n      \"id\": \"<string>\",\n      \"is_album\": \"<boolean>\",\n      \"is_image_autogenerated\": \"<boolean>\",\n      \"playlist_contents\": [\n        {\n          \"metadata_timestamp\": \"<integer>\",\n          \"timestamp\": \"<integer>\",\n          \"track_id\": \"<string>\"\n        },\n        {\n          \"metadata_timestamp\": \"<integer>\",\n          \"timestamp\": \"<integer>\",\n          \"track_id\": \"<string>\"\n        }\n      ],\n      \"playlist_name\": \"<string>\",\n      \"repost_count\": \"<integer>\",\n      \"total_play_count\": \"<integer>\",\n      \"user\": {\n        \"album_count\": \"<integer>\",\n        \"erc_wallet\": \"<string>\",\n        \"followee_count\": \"<integer>\",\n        \"follower_count\": \"<integer>\",\n        \"handle\": \"<string>\",\n        \"id\": \"<string>\",\n        \"is_available\": \"<boolean>\",\n        \"is_deactivated\": \"<boolean>\",\n        \"is_verified\": \"<boolean>\",\n        \"name\": \"<string>\",\n        \"playlist_count\": \"<integer>\",\n        \"repost_count\": \"<integer>\",\n        \"spl_wallet\": \"<string>\",\n        \"supporter_count\": \"<integer>\",\n        \"supporting_count\": \"<integer>\",\n        \"total_audio_balance\": \"<integer>\",\n        \"track_count\": \"<integer>\",\n        \"artist_pick_track_id\": \"<string>\",\n        \"bio\": \"<string>\",\n        \"cover_photo\": {\n          \"640x\": \"<string>\",\n          \"2000x\": \"<string>\"\n        },\n        \"does_follow_current_user\": \"<boolean>\",\n        \"location\": \"<string>\",\n        \"profile_picture\": {\n          \"150x150\": \"<string>\",\n          \"480x480\": \"<string>\",\n          \"1000x1000\": \"<string>\"\n        }\n      },\n      \"artwork\": {\n        \"150x150\": \"<string>\",\n        \"480x480\": \"<string>\",\n        \"1000x1000\": \"<string>\"\n      },\n      \"description\": \"<string>\",\n      \"permalink\": \"<string>\"\n    },\n    {\n      \"favorite_count\": \"<integer>\",\n      \"id\": \"<string>\",\n      \"is_album\": \"<boolean>\",\n      \"is_image_autogenerated\": \"<boolean>\",\n      \"playlist_contents\": [\n        {\n          \"metadata_timestamp\": \"<integer>\",\n          \"timestamp\": \"<integer>\",\n          \"track_id\": \"<string>\"\n        },\n        {\n          \"metadata_timestamp\": \"<integer>\",\n          \"timestamp\": \"<integer>\",\n          \"track_id\": \"<string>\"\n        }\n      ],\n      \"playlist_name\": \"<string>\",\n      \"repost_count\": \"<integer>\",\n      \"total_play_count\": \"<integer>\",\n      \"user\": {\n        \"album_count\": \"<integer>\",\n        \"erc_wallet\": \"<string>\",\n        \"followee_count\": \"<integer>\",\n        \"follower_count\": \"<integer>\",\n        \"handle\": \"<string>\",\n        \"id\": \"<string>\",\n        \"is_available\": \"<boolean>\",\n        \"is_deactivated\": \"<boolean>\",\n        \"is_verified\": \"<boolean>\",\n        \"name\": \"<string>\",\n        \"playlist_count\": \"<integer>\",\n        \"repost_count\": \"<integer>\",\n        \"spl_wallet\": \"<string>\",\n        \"supporter_count\": \"<integer>\",\n        \"supporting_count\": \"<integer>\",\n        \"total_audio_balance\": \"<integer>\",\n        \"track_count\": \"<integer>\",\n        \"artist_pick_track_id\": \"<string>\",\n        \"bio\": \"<string>\",\n        \"cover_photo\": {\n          \"640x\": \"<string>\",\n          \"2000x\": \"<string>\"\n        },\n        \"does_follow_current_user\": \"<boolean>\",\n        \"location\": \"<string>\",\n        \"profile_picture\": {\n          \"150x150\": \"<string>\",\n          \"480x480\": \"<string>\",\n          \"1000x1000\": \"<string>\"\n        }\n      },\n      \"artwork\": {\n        \"150x150\": \"<string>\",\n        \"480x480\": \"<string>\",\n        \"1000x1000\": \"<string>\"\n      },\n      \"description\": \"<string>\",\n      \"permalink\": \"<string>\"\n    }\n  ]\n}"
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "name": "search",
+                    "item": [
+                        {
+                            "name": "Search Playlists",
+                            "event": [
+                                {
+                                    "listen": "prerequest",
+                                    "script": {
+                                        "exec": [
+                                            "pm.environment.set(\"similarity_threshold\", 50);"
+                                        ],
+                                        "type": "text/javascript"
+                                    }
+                                },
+                                {
+                                    "listen": "test",
+                                    "script": {
+                                        "exec": [
+                                            "pm.environment.set(\"similarity_threshold\", 95);"
+                                        ],
+                                        "type": "text/javascript"
+                                    }
+                                }
+                            ],
+                            "request": {
+                                "method": "GET",
+                                "header": [
+                                    {
+                                        "key": "Accept",
+                                        "value": "application/json"
+                                    }
+                                ],
+                                "url": {
+                                    "raw": "{{test_base_url}}/playlists/search?query=sad",
+                                    "host": [
+                                        "{{test_base_url}}"
+                                    ],
+                                    "path": [
+                                        "playlists",
+                                        "search"
+                                    ],
+                                    "query": [
+                                        {
+                                            "key": "query",
+                                            "value": "sad",
+                                            "description": "(Required) The search query"
+                                        }
+                                    ]
+                                },
+                                "description": "Search for a playlist"
+                            },
+                            "response": [
+                                {
+                                    "name": "Success",
+                                    "originalRequest": {
+                                        "method": "GET",
+                                        "header": [
+                                            {
+                                                "key": "Accept",
+                                                "value": "application/json"
+                                            }
+                                        ],
+                                        "url": {
+                                            "raw": "{{baseUrl}}/playlists/search?query=<string>",
+                                            "host": [
+                                                "{{baseUrl}}"
+                                            ],
+                                            "path": [
+                                                "playlists",
+                                                "search"
+                                            ],
+                                            "query": [
+                                                {
+                                                    "key": "query",
+                                                    "value": "<string>",
+                                                    "description": "(Required) The search query"
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    "status": "OK",
+                                    "code": 200,
+                                    "_postman_previewlanguage": "json",
+                                    "header": [
+                                        {
+                                            "key": "Content-Type",
+                                            "value": "application/json"
+                                        }
+                                    ],
+                                    "cookie": [],
+                                    "body": "{\n  \"data\": [\n    {\n      \"favorite_count\": \"<integer>\",\n      \"id\": \"<string>\",\n      \"is_album\": \"<boolean>\",\n      \"is_image_autogenerated\": \"<boolean>\",\n      \"playlist_contents\": [\n        {\n          \"metadata_timestamp\": \"<integer>\",\n          \"timestamp\": \"<integer>\",\n          \"track_id\": \"<string>\"\n        },\n        {\n          \"metadata_timestamp\": \"<integer>\",\n          \"timestamp\": \"<integer>\",\n          \"track_id\": \"<string>\"\n        }\n      ],\n      \"playlist_name\": \"<string>\",\n      \"repost_count\": \"<integer>\",\n      \"total_play_count\": \"<integer>\",\n      \"user\": {\n        \"album_count\": \"<integer>\",\n        \"erc_wallet\": \"<string>\",\n        \"followee_count\": \"<integer>\",\n        \"follower_count\": \"<integer>\",\n        \"handle\": \"<string>\",\n        \"id\": \"<string>\",\n        \"is_available\": \"<boolean>\",\n        \"is_deactivated\": \"<boolean>\",\n        \"is_verified\": \"<boolean>\",\n        \"name\": \"<string>\",\n        \"playlist_count\": \"<integer>\",\n        \"repost_count\": \"<integer>\",\n        \"spl_wallet\": \"<string>\",\n        \"supporter_count\": \"<integer>\",\n        \"supporting_count\": \"<integer>\",\n        \"total_audio_balance\": \"<integer>\",\n        \"track_count\": \"<integer>\",\n        \"artist_pick_track_id\": \"<string>\",\n        \"bio\": \"<string>\",\n        \"cover_photo\": {\n          \"640x\": \"<string>\",\n          \"2000x\": \"<string>\"\n        },\n        \"does_follow_current_user\": \"<boolean>\",\n        \"location\": \"<string>\",\n        \"profile_picture\": {\n          \"150x150\": \"<string>\",\n          \"480x480\": \"<string>\",\n          \"1000x1000\": \"<string>\"\n        }\n      },\n      \"artwork\": {\n        \"150x150\": \"<string>\",\n        \"480x480\": \"<string>\",\n        \"1000x1000\": \"<string>\"\n      },\n      \"description\": \"<string>\",\n      \"permalink\": \"<string>\"\n    },\n    {\n      \"favorite_count\": \"<integer>\",\n      \"id\": \"<string>\",\n      \"is_album\": \"<boolean>\",\n      \"is_image_autogenerated\": \"<boolean>\",\n      \"playlist_contents\": [\n        {\n          \"metadata_timestamp\": \"<integer>\",\n          \"timestamp\": \"<integer>\",\n          \"track_id\": \"<string>\"\n        },\n        {\n          \"metadata_timestamp\": \"<integer>\",\n          \"timestamp\": \"<integer>\",\n          \"track_id\": \"<string>\"\n        }\n      ],\n      \"playlist_name\": \"<string>\",\n      \"repost_count\": \"<integer>\",\n      \"total_play_count\": \"<integer>\",\n      \"user\": {\n        \"album_count\": \"<integer>\",\n        \"erc_wallet\": \"<string>\",\n        \"followee_count\": \"<integer>\",\n        \"follower_count\": \"<integer>\",\n        \"handle\": \"<string>\",\n        \"id\": \"<string>\",\n        \"is_available\": \"<boolean>\",\n        \"is_deactivated\": \"<boolean>\",\n        \"is_verified\": \"<boolean>\",\n        \"name\": \"<string>\",\n        \"playlist_count\": \"<integer>\",\n        \"repost_count\": \"<integer>\",\n        \"spl_wallet\": \"<string>\",\n        \"supporter_count\": \"<integer>\",\n        \"supporting_count\": \"<integer>\",\n        \"total_audio_balance\": \"<integer>\",\n        \"track_count\": \"<integer>\",\n        \"artist_pick_track_id\": \"<string>\",\n        \"bio\": \"<string>\",\n        \"cover_photo\": {\n          \"640x\": \"<string>\",\n          \"2000x\": \"<string>\"\n        },\n        \"does_follow_current_user\": \"<boolean>\",\n        \"location\": \"<string>\",\n        \"profile_picture\": {\n          \"150x150\": \"<string>\",\n          \"480x480\": \"<string>\",\n          \"1000x1000\": \"<string>\"\n        }\n      },\n      \"artwork\": {\n        \"150x150\": \"<string>\",\n        \"480x480\": \"<string>\",\n        \"1000x1000\": \"<string>\"\n      },\n      \"description\": \"<string>\",\n      \"permalink\": \"<string>\"\n    }\n  ]\n}"
+                                },
+                                {
+                                    "name": "Bad request",
+                                    "originalRequest": {
+                                        "method": "GET",
+                                        "header": [],
+                                        "url": {
+                                            "raw": "{{baseUrl}}/playlists/search?query=<string>",
+                                            "host": [
+                                                "{{baseUrl}}"
+                                            ],
+                                            "path": [
+                                                "playlists",
+                                                "search"
+                                            ],
+                                            "query": [
+                                                {
+                                                    "key": "query",
+                                                    "value": "<string>",
+                                                    "description": "(Required) The search query"
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    "status": "Bad Request",
+                                    "code": 400,
+                                    "_postman_previewlanguage": "text",
+                                    "header": [],
+                                    "cookie": [],
+                                    "body": ""
+                                },
+                                {
+                                    "name": "Server error",
+                                    "originalRequest": {
+                                        "method": "GET",
+                                        "header": [],
+                                        "url": {
+                                            "raw": "{{baseUrl}}/playlists/search?query=<string>",
+                                            "host": [
+                                                "{{baseUrl}}"
+                                            ],
+                                            "path": [
+                                                "playlists",
+                                                "search"
+                                            ],
+                                            "query": [
+                                                {
+                                                    "key": "query",
+                                                    "value": "<string>",
+                                                    "description": "(Required) The search query"
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    "status": "Internal Server Error",
+                                    "code": 500,
+                                    "_postman_previewlanguage": "text",
+                                    "header": [],
+                                    "cookie": [],
+                                    "body": ""
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "name": "trending",
+                    "item": [
+                        {
+                            "name": "Get Trending Playlists",
+                            "event": [
+                                {
+                                    "listen": "prerequest",
+                                    "script": {
+                                        "exec": [
+                                            "pm.environment.set(\"similarity_threshold\", 80);"
+                                        ],
+                                        "type": "text/javascript"
+                                    }
+                                },
+                                {
+                                    "listen": "test",
+                                    "script": {
+                                        "exec": [
+                                            "pm.environment.set(\"similarity_threshold\", 95);"
+                                        ],
+                                        "type": "text/javascript"
+                                    }
+                                }
+                            ],
+                            "request": {
+                                "method": "GET",
+                                "header": [
+                                    {
+                                        "key": "Accept",
+                                        "value": "application/json"
+                                    }
+                                ],
+                                "url": {
+                                    "raw": "{{test_base_url}}/playlists/trending?time=week",
+                                    "host": [
+                                        "{{test_base_url}}"
+                                    ],
+                                    "path": [
+                                        "playlists",
+                                        "trending"
+                                    ],
+                                    "query": [
+                                        {
+                                            "key": "time",
+                                            "value": "week",
+                                            "description": "Calculate trending over a specified time range"
+                                        }
+                                    ]
+                                },
+                                "description": "Gets trending playlists for a time period"
+                            },
+                            "response": [
+                                {
+                                    "name": "Success",
+                                    "originalRequest": {
+                                        "method": "GET",
+                                        "header": [
+                                            {
+                                                "key": "Accept",
+                                                "value": "application/json"
+                                            }
+                                        ],
+                                        "url": {
+                                            "raw": "{{baseUrl}}/playlists/trending?time=week",
+                                            "host": [
+                                                "{{baseUrl}}"
+                                            ],
+                                            "path": [
+                                                "playlists",
+                                                "trending"
+                                            ],
+                                            "query": [
+                                                {
+                                                    "key": "time",
+                                                    "value": "week",
+                                                    "description": "Calculate trending over a specified time range"
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    "status": "OK",
+                                    "code": 200,
+                                    "_postman_previewlanguage": "json",
+                                    "header": [
+                                        {
+                                            "key": "Content-Type",
+                                            "value": "application/json"
+                                        }
+                                    ],
+                                    "cookie": [],
+                                    "body": "{\n  \"data\": [\n    {\n      \"favorite_count\": \"<integer>\",\n      \"id\": \"<string>\",\n      \"is_album\": \"<boolean>\",\n      \"is_image_autogenerated\": \"<boolean>\",\n      \"playlist_contents\": [\n        {\n          \"metadata_timestamp\": \"<integer>\",\n          \"timestamp\": \"<integer>\",\n          \"track_id\": \"<string>\"\n        },\n        {\n          \"metadata_timestamp\": \"<integer>\",\n          \"timestamp\": \"<integer>\",\n          \"track_id\": \"<string>\"\n        }\n      ],\n      \"playlist_name\": \"<string>\",\n      \"repost_count\": \"<integer>\",\n      \"total_play_count\": \"<integer>\",\n      \"user\": {\n        \"album_count\": \"<integer>\",\n        \"erc_wallet\": \"<string>\",\n        \"followee_count\": \"<integer>\",\n        \"follower_count\": \"<integer>\",\n        \"handle\": \"<string>\",\n        \"id\": \"<string>\",\n        \"is_available\": \"<boolean>\",\n        \"is_deactivated\": \"<boolean>\",\n        \"is_verified\": \"<boolean>\",\n        \"name\": \"<string>\",\n        \"playlist_count\": \"<integer>\",\n        \"repost_count\": \"<integer>\",\n        \"spl_wallet\": \"<string>\",\n        \"supporter_count\": \"<integer>\",\n        \"supporting_count\": \"<integer>\",\n        \"total_audio_balance\": \"<integer>\",\n        \"track_count\": \"<integer>\",\n        \"artist_pick_track_id\": \"<string>\",\n        \"bio\": \"<string>\",\n        \"cover_photo\": {\n          \"640x\": \"<string>\",\n          \"2000x\": \"<string>\"\n        },\n        \"does_follow_current_user\": \"<boolean>\",\n        \"location\": \"<string>\",\n        \"profile_picture\": {\n          \"150x150\": \"<string>\",\n          \"480x480\": \"<string>\",\n          \"1000x1000\": \"<string>\"\n        }\n      },\n      \"artwork\": {\n        \"150x150\": \"<string>\",\n        \"480x480\": \"<string>\",\n        \"1000x1000\": \"<string>\"\n      },\n      \"description\": \"<string>\",\n      \"permalink\": \"<string>\"\n    },\n    {\n      \"favorite_count\": \"<integer>\",\n      \"id\": \"<string>\",\n      \"is_album\": \"<boolean>\",\n      \"is_image_autogenerated\": \"<boolean>\",\n      \"playlist_contents\": [\n        {\n          \"metadata_timestamp\": \"<integer>\",\n          \"timestamp\": \"<integer>\",\n          \"track_id\": \"<string>\"\n        },\n        {\n          \"metadata_timestamp\": \"<integer>\",\n          \"timestamp\": \"<integer>\",\n          \"track_id\": \"<string>\"\n        }\n      ],\n      \"playlist_name\": \"<string>\",\n      \"repost_count\": \"<integer>\",\n      \"total_play_count\": \"<integer>\",\n      \"user\": {\n        \"album_count\": \"<integer>\",\n        \"erc_wallet\": \"<string>\",\n        \"followee_count\": \"<integer>\",\n        \"follower_count\": \"<integer>\",\n        \"handle\": \"<string>\",\n        \"id\": \"<string>\",\n        \"is_available\": \"<boolean>\",\n        \"is_deactivated\": \"<boolean>\",\n        \"is_verified\": \"<boolean>\",\n        \"name\": \"<string>\",\n        \"playlist_count\": \"<integer>\",\n        \"repost_count\": \"<integer>\",\n        \"spl_wallet\": \"<string>\",\n        \"supporter_count\": \"<integer>\",\n        \"supporting_count\": \"<integer>\",\n        \"total_audio_balance\": \"<integer>\",\n        \"track_count\": \"<integer>\",\n        \"artist_pick_track_id\": \"<string>\",\n        \"bio\": \"<string>\",\n        \"cover_photo\": {\n          \"640x\": \"<string>\",\n          \"2000x\": \"<string>\"\n        },\n        \"does_follow_current_user\": \"<boolean>\",\n        \"location\": \"<string>\",\n        \"profile_picture\": {\n          \"150x150\": \"<string>\",\n          \"480x480\": \"<string>\",\n          \"1000x1000\": \"<string>\"\n        }\n      },\n      \"artwork\": {\n        \"150x150\": \"<string>\",\n        \"480x480\": \"<string>\",\n        \"1000x1000\": \"<string>\"\n      },\n      \"description\": \"<string>\",\n      \"permalink\": \"<string>\"\n    }\n  ]\n}"
+                                },
+                                {
+                                    "name": "Bad request",
+                                    "originalRequest": {
+                                        "method": "GET",
+                                        "header": [],
+                                        "url": {
+                                            "raw": "{{baseUrl}}/playlists/trending?time=week",
+                                            "host": [
+                                                "{{baseUrl}}"
+                                            ],
+                                            "path": [
+                                                "playlists",
+                                                "trending"
+                                            ],
+                                            "query": [
+                                                {
+                                                    "key": "time",
+                                                    "value": "week",
+                                                    "description": "Calculate trending over a specified time range"
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    "status": "Bad Request",
+                                    "code": 400,
+                                    "_postman_previewlanguage": "text",
+                                    "header": [],
+                                    "cookie": [],
+                                    "body": ""
+                                },
+                                {
+                                    "name": "Server error",
+                                    "originalRequest": {
+                                        "method": "GET",
+                                        "header": [],
+                                        "url": {
+                                            "raw": "{{baseUrl}}/playlists/trending?time=week",
+                                            "host": [
+                                                "{{baseUrl}}"
+                                            ],
+                                            "path": [
+                                                "playlists",
+                                                "trending"
+                                            ],
+                                            "query": [
+                                                {
+                                                    "key": "time",
+                                                    "value": "week",
+                                                    "description": "Calculate trending over a specified time range"
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    "status": "Internal Server Error",
+                                    "code": 500,
+                                    "_postman_previewlanguage": "text",
+                                    "header": [],
+                                    "cookie": [],
+                                    "body": ""
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "name": "{playlist_id}",
+                    "item": [
+                        {
+                            "name": "tracks",
+                            "item": [
+                                {
+                                    "name": "Get Playlist Tracks",
+                                    "request": {
+                                        "method": "GET",
+                                        "header": [
+                                            {
+                                                "key": "Accept",
+                                                "value": "application/json"
+                                            }
+                                        ],
+                                        "url": {
+                                            "raw": "{{test_base_url}}/playlists/{{playlist_id}}/tracks",
+                                            "host": [
+                                                "{{test_base_url}}"
+                                            ],
+                                            "path": [
+                                                "playlists",
+                                                "{{playlist_id}}",
+                                                "tracks"
+                                            ]
+                                        },
+                                        "description": "Fetch tracks within a playlist."
+                                    },
+                                    "response": [
+                                        {
+                                            "name": "Success",
+                                            "originalRequest": {
+                                                "method": "GET",
+                                                "header": [
+                                                    {
+                                                        "key": "Accept",
+                                                        "value": "application/json"
+                                                    }
+                                                ],
+                                                "url": {
+                                                    "raw": "{{baseUrl}}/playlists/:playlist_id/tracks",
+                                                    "host": [
+                                                        "{{baseUrl}}"
+                                                    ],
+                                                    "path": [
+                                                        "playlists",
+                                                        ":playlist_id",
+                                                        "tracks"
+                                                    ],
+                                                    "variable": [
+                                                        {
+                                                            "key": "playlist_id"
+                                                        }
+                                                    ]
+                                                }
+                                            },
+                                            "status": "OK",
+                                            "code": 200,
+                                            "_postman_previewlanguage": "json",
+                                            "header": [
+                                                {
+                                                    "key": "Content-Type",
+                                                    "value": "application/json"
+                                                }
+                                            ],
+                                            "cookie": [],
+                                            "body": "{\n  \"data\": [\n    {\n      \"duration\": \"<integer>\",\n      \"favorite_count\": \"<integer>\",\n      \"id\": \"<string>\",\n      \"play_count\": \"<integer>\",\n      \"repost_count\": \"<integer>\",\n      \"title\": \"<string>\",\n      \"user\": {\n        \"album_count\": \"<integer>\",\n        \"erc_wallet\": \"<string>\",\n        \"followee_count\": \"<integer>\",\n        \"follower_count\": \"<integer>\",\n        \"handle\": \"<string>\",\n        \"id\": \"<string>\",\n        \"is_available\": \"<boolean>\",\n        \"is_deactivated\": \"<boolean>\",\n        \"is_verified\": \"<boolean>\",\n        \"name\": \"<string>\",\n        \"playlist_count\": \"<integer>\",\n        \"repost_count\": \"<integer>\",\n        \"spl_wallet\": \"<string>\",\n        \"supporter_count\": \"<integer>\",\n        \"supporting_count\": \"<integer>\",\n        \"total_audio_balance\": \"<integer>\",\n        \"track_count\": \"<integer>\",\n        \"artist_pick_track_id\": \"<string>\",\n        \"bio\": \"<string>\",\n        \"cover_photo\": {\n          \"640x\": \"<string>\",\n          \"2000x\": \"<string>\"\n        },\n        \"does_follow_current_user\": \"<boolean>\",\n        \"location\": \"<string>\",\n        \"profile_picture\": {\n          \"150x150\": \"<string>\",\n          \"480x480\": \"<string>\",\n          \"1000x1000\": \"<string>\"\n        }\n      },\n      \"artwork\": {\n        \"150x150\": \"<string>\",\n        \"480x480\": \"<string>\",\n        \"1000x1000\": \"<string>\"\n      },\n      \"description\": \"<string>\",\n      \"genre\": \"<string>\",\n      \"track_cid\": \"<string>\",\n      \"preview_cid\": \"<string>\",\n      \"mood\": \"<string>\",\n      \"release_date\": \"<string>\",\n      \"remix_of\": {\n        \"tracks\": [\n          {\n            \"parent_track_id\": \"<string>\"\n          },\n          {\n            \"parent_track_id\": \"<string>\"\n          }\n        ]\n      },\n      \"tags\": \"<string>\",\n      \"downloadable\": \"<boolean>\",\n      \"permalink\": \"<string>\",\n      \"is_streamable\": \"<boolean>\"\n    },\n    {\n      \"duration\": \"<integer>\",\n      \"favorite_count\": \"<integer>\",\n      \"id\": \"<string>\",\n      \"play_count\": \"<integer>\",\n      \"repost_count\": \"<integer>\",\n      \"title\": \"<string>\",\n      \"user\": {\n        \"album_count\": \"<integer>\",\n        \"erc_wallet\": \"<string>\",\n        \"followee_count\": \"<integer>\",\n        \"follower_count\": \"<integer>\",\n        \"handle\": \"<string>\",\n        \"id\": \"<string>\",\n        \"is_available\": \"<boolean>\",\n        \"is_deactivated\": \"<boolean>\",\n        \"is_verified\": \"<boolean>\",\n        \"name\": \"<string>\",\n        \"playlist_count\": \"<integer>\",\n        \"repost_count\": \"<integer>\",\n        \"spl_wallet\": \"<string>\",\n        \"supporter_count\": \"<integer>\",\n        \"supporting_count\": \"<integer>\",\n        \"total_audio_balance\": \"<integer>\",\n        \"track_count\": \"<integer>\",\n        \"artist_pick_track_id\": \"<string>\",\n        \"bio\": \"<string>\",\n        \"cover_photo\": {\n          \"640x\": \"<string>\",\n          \"2000x\": \"<string>\"\n        },\n        \"does_follow_current_user\": \"<boolean>\",\n        \"location\": \"<string>\",\n        \"profile_picture\": {\n          \"150x150\": \"<string>\",\n          \"480x480\": \"<string>\",\n          \"1000x1000\": \"<string>\"\n        }\n      },\n      \"artwork\": {\n        \"150x150\": \"<string>\",\n        \"480x480\": \"<string>\",\n        \"1000x1000\": \"<string>\"\n      },\n      \"description\": \"<string>\",\n      \"genre\": \"<string>\",\n      \"track_cid\": \"<string>\",\n      \"preview_cid\": \"<string>\",\n      \"mood\": \"<string>\",\n      \"release_date\": \"<string>\",\n      \"remix_of\": {\n        \"tracks\": [\n          {\n            \"parent_track_id\": \"<string>\"\n          },\n          {\n            \"parent_track_id\": \"<string>\"\n          }\n        ]\n      },\n      \"tags\": \"<string>\",\n      \"downloadable\": \"<boolean>\",\n      \"permalink\": \"<string>\",\n      \"is_streamable\": \"<boolean>\"\n    }\n  ]\n}"
+                                        },
+                                        {
+                                            "name": "Bad request",
+                                            "originalRequest": {
+                                                "method": "GET",
+                                                "header": [],
+                                                "url": {
+                                                    "raw": "{{baseUrl}}/playlists/:playlist_id/tracks",
+                                                    "host": [
+                                                        "{{baseUrl}}"
+                                                    ],
+                                                    "path": [
+                                                        "playlists",
+                                                        ":playlist_id",
+                                                        "tracks"
+                                                    ],
+                                                    "variable": [
+                                                        {
+                                                            "key": "playlist_id"
+                                                        }
+                                                    ]
+                                                }
+                                            },
+                                            "status": "Bad Request",
+                                            "code": 400,
+                                            "_postman_previewlanguage": "text",
+                                            "header": [],
+                                            "cookie": [],
+                                            "body": ""
+                                        },
+                                        {
+                                            "name": "Server error",
+                                            "originalRequest": {
+                                                "method": "GET",
+                                                "header": [],
+                                                "url": {
+                                                    "raw": "{{baseUrl}}/playlists/:playlist_id/tracks",
+                                                    "host": [
+                                                        "{{baseUrl}}"
+                                                    ],
+                                                    "path": [
+                                                        "playlists",
+                                                        ":playlist_id",
+                                                        "tracks"
+                                                    ],
+                                                    "variable": [
+                                                        {
+                                                            "key": "playlist_id"
+                                                        }
+                                                    ]
+                                                }
+                                            },
+                                            "status": "Internal Server Error",
+                                            "code": 500,
+                                            "_postman_previewlanguage": "text",
+                                            "header": [],
+                                            "cookie": [],
+                                            "body": ""
+                                        }
+                                    ]
+                                }
+                            ]
+                        },
+                        {
+                            "name": "Get Playlist",
+                            "request": {
+                                "method": "GET",
+                                "header": [
+                                    {
+                                        "key": "Accept",
+                                        "value": "application/json"
+                                    }
+                                ],
+                                "url": {
+                                    "raw": "{{test_base_url}}/playlists/{{playlist_id}}?user_id={{user_id}}",
+                                    "host": [
+                                        "{{test_base_url}}"
+                                    ],
+                                    "path": [
+                                        "playlists",
+                                        "{{playlist_id}}"
+                                    ],
+                                    "query": [
+                                        {
+                                            "key": "user_id",
+                                            "value": "{{user_id}}",
+                                            "description": "The user ID of the user making the request"
+                                        }
+                                    ]
+                                },
+                                "description": "Get a playlist by ID"
+                            },
+                            "response": [
+                                {
+                                    "name": "Success",
+                                    "originalRequest": {
+                                        "method": "GET",
+                                        "header": [
+                                            {
+                                                "key": "Accept",
+                                                "value": "application/json"
+                                            }
+                                        ],
+                                        "url": {
+                                            "raw": "{{baseUrl}}/playlists/:playlist_id?user_id=<string>",
+                                            "host": [
+                                                "{{baseUrl}}"
+                                            ],
+                                            "path": [
+                                                "playlists",
+                                                ":playlist_id"
+                                            ],
+                                            "query": [
+                                                {
+                                                    "key": "user_id",
+                                                    "value": "<string>",
+                                                    "description": "The user ID of the user making the request"
+                                                }
+                                            ],
+                                            "variable": [
+                                                {
+                                                    "key": "playlist_id"
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    "status": "OK",
+                                    "code": 200,
+                                    "_postman_previewlanguage": "json",
+                                    "header": [
+                                        {
+                                            "key": "Content-Type",
+                                            "value": "application/json"
+                                        }
+                                    ],
+                                    "cookie": [],
+                                    "body": "{\n  \"data\": [\n    {\n      \"favorite_count\": \"<integer>\",\n      \"id\": \"<string>\",\n      \"is_album\": \"<boolean>\",\n      \"is_image_autogenerated\": \"<boolean>\",\n      \"playlist_contents\": [\n        {\n          \"metadata_timestamp\": \"<integer>\",\n          \"timestamp\": \"<integer>\",\n          \"track_id\": \"<string>\"\n        },\n        {\n          \"metadata_timestamp\": \"<integer>\",\n          \"timestamp\": \"<integer>\",\n          \"track_id\": \"<string>\"\n        }\n      ],\n      \"playlist_name\": \"<string>\",\n      \"repost_count\": \"<integer>\",\n      \"total_play_count\": \"<integer>\",\n      \"user\": {\n        \"album_count\": \"<integer>\",\n        \"erc_wallet\": \"<string>\",\n        \"followee_count\": \"<integer>\",\n        \"follower_count\": \"<integer>\",\n        \"handle\": \"<string>\",\n        \"id\": \"<string>\",\n        \"is_available\": \"<boolean>\",\n        \"is_deactivated\": \"<boolean>\",\n        \"is_verified\": \"<boolean>\",\n        \"name\": \"<string>\",\n        \"playlist_count\": \"<integer>\",\n        \"repost_count\": \"<integer>\",\n        \"spl_wallet\": \"<string>\",\n        \"supporter_count\": \"<integer>\",\n        \"supporting_count\": \"<integer>\",\n        \"total_audio_balance\": \"<integer>\",\n        \"track_count\": \"<integer>\",\n        \"artist_pick_track_id\": \"<string>\",\n        \"bio\": \"<string>\",\n        \"cover_photo\": {\n          \"640x\": \"<string>\",\n          \"2000x\": \"<string>\"\n        },\n        \"does_follow_current_user\": \"<boolean>\",\n        \"location\": \"<string>\",\n        \"profile_picture\": {\n          \"150x150\": \"<string>\",\n          \"480x480\": \"<string>\",\n          \"1000x1000\": \"<string>\"\n        }\n      },\n      \"artwork\": {\n        \"150x150\": \"<string>\",\n        \"480x480\": \"<string>\",\n        \"1000x1000\": \"<string>\"\n      },\n      \"description\": \"<string>\",\n      \"permalink\": \"<string>\"\n    },\n    {\n      \"favorite_count\": \"<integer>\",\n      \"id\": \"<string>\",\n      \"is_album\": \"<boolean>\",\n      \"is_image_autogenerated\": \"<boolean>\",\n      \"playlist_contents\": [\n        {\n          \"metadata_timestamp\": \"<integer>\",\n          \"timestamp\": \"<integer>\",\n          \"track_id\": \"<string>\"\n        },\n        {\n          \"metadata_timestamp\": \"<integer>\",\n          \"timestamp\": \"<integer>\",\n          \"track_id\": \"<string>\"\n        }\n      ],\n      \"playlist_name\": \"<string>\",\n      \"repost_count\": \"<integer>\",\n      \"total_play_count\": \"<integer>\",\n      \"user\": {\n        \"album_count\": \"<integer>\",\n        \"erc_wallet\": \"<string>\",\n        \"followee_count\": \"<integer>\",\n        \"follower_count\": \"<integer>\",\n        \"handle\": \"<string>\",\n        \"id\": \"<string>\",\n        \"is_available\": \"<boolean>\",\n        \"is_deactivated\": \"<boolean>\",\n        \"is_verified\": \"<boolean>\",\n        \"name\": \"<string>\",\n        \"playlist_count\": \"<integer>\",\n        \"repost_count\": \"<integer>\",\n        \"spl_wallet\": \"<string>\",\n        \"supporter_count\": \"<integer>\",\n        \"supporting_count\": \"<integer>\",\n        \"total_audio_balance\": \"<integer>\",\n        \"track_count\": \"<integer>\",\n        \"artist_pick_track_id\": \"<string>\",\n        \"bio\": \"<string>\",\n        \"cover_photo\": {\n          \"640x\": \"<string>\",\n          \"2000x\": \"<string>\"\n        },\n        \"does_follow_current_user\": \"<boolean>\",\n        \"location\": \"<string>\",\n        \"profile_picture\": {\n          \"150x150\": \"<string>\",\n          \"480x480\": \"<string>\",\n          \"1000x1000\": \"<string>\"\n        }\n      },\n      \"artwork\": {\n        \"150x150\": \"<string>\",\n        \"480x480\": \"<string>\",\n        \"1000x1000\": \"<string>\"\n      },\n      \"description\": \"<string>\",\n      \"permalink\": \"<string>\"\n    }\n  ]\n}"
+                                },
+                                {
+                                    "name": "Bad request",
+                                    "originalRequest": {
+                                        "method": "GET",
+                                        "header": [],
+                                        "url": {
+                                            "raw": "{{baseUrl}}/playlists/:playlist_id?user_id=<string>",
+                                            "host": [
+                                                "{{baseUrl}}"
+                                            ],
+                                            "path": [
+                                                "playlists",
+                                                ":playlist_id"
+                                            ],
+                                            "query": [
+                                                {
+                                                    "key": "user_id",
+                                                    "value": "<string>",
+                                                    "description": "The user ID of the user making the request"
+                                                }
+                                            ],
+                                            "variable": [
+                                                {
+                                                    "key": "playlist_id"
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    "status": "Bad Request",
+                                    "code": 400,
+                                    "_postman_previewlanguage": "text",
+                                    "header": [],
+                                    "cookie": [],
+                                    "body": ""
+                                },
+                                {
+                                    "name": "Server error",
+                                    "originalRequest": {
+                                        "method": "GET",
+                                        "header": [],
+                                        "url": {
+                                            "raw": "{{baseUrl}}/playlists/:playlist_id?user_id=<string>",
+                                            "host": [
+                                                "{{baseUrl}}"
+                                            ],
+                                            "path": [
+                                                "playlists",
+                                                ":playlist_id"
+                                            ],
+                                            "query": [
+                                                {
+                                                    "key": "user_id",
+                                                    "value": "<string>",
+                                                    "description": "The user ID of the user making the request"
+                                                }
+                                            ],
+                                            "variable": [
+                                                {
+                                                    "key": "playlist_id"
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    "status": "Internal Server Error",
+                                    "code": 500,
+                                    "_postman_previewlanguage": "text",
+                                    "header": [],
+                                    "cookie": [],
+                                    "body": ""
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "name": "resolve",
+            "item": [
+                {
+                    "name": "Resolves and redirects a provided Audius app URL to the API resource URL it represents",
+                    "request": {
+                        "method": "GET",
+                        "header": [],
+                        "url": {
+                            "raw": "{{test_base_url}}/resolve?url=https://audius.co/sabrinakiam/my-new-track",
+                            "host": [
+                                "{{test_base_url}}"
+                            ],
+                            "path": [
+                                "resolve"
+                            ],
+                            "query": [
+                                {
+                                    "key": "url",
+                                    "value": "https://audius.co/sabrinakiam/my-new-track"
+                                }
+                            ]
+                        },
+                        "description": "This endpoint allows you to lookup and access API resources when you only know the\naudius.co URL.\nTracks, Playlists, and Users are supported."
+                    },
+                    "response": [
+                        {
+                            "name": "Internal redirect",
+                            "originalRequest": {
+                                "method": "GET",
+                                "header": [],
+                                "url": {
+                                    "raw": "{{baseUrl}}/resolve?url=<string>",
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "path": [
+                                        "resolve"
+                                    ],
+                                    "query": [
+                                        {
+                                            "key": "url",
+                                            "value": "<string>",
+                                            "description": "(Required) URL to resolve. Either fully formed URL (https://audius.co) or just the absolute path"
+                                        }
+                                    ]
+                                }
+                            },
+                            "status": "Found",
+                            "code": 302,
+                            "_postman_previewlanguage": "text",
+                            "header": [],
+                            "cookie": [],
+                            "body": ""
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "name": "tips",
+            "item": [
+                {
+                    "name": "Get Tips",
+                    "request": {
+                        "method": "GET",
+                        "header": [
+                            {
+                                "key": "Accept",
+                                "value": "application/json"
+                            }
+                        ],
+                        "url": {
+                            "raw": "{{test_base_url}}/tips?offset=0&limit=10&user_id=vbPj6&receiver_min_followers=0&receiver_is_verified=false&current_user_follows=receiver&unique_by=receiver",
+                            "host": [
+                                "{{test_base_url}}"
+                            ],
+                            "path": [
+                                "tips"
+                            ],
+                            "query": [
+                                {
+                                    "key": "offset",
+                                    "value": "0",
+                                    "description": "The number of items to skip. Useful for pagination (page number * limit)"
+                                },
+                                {
+                                    "key": "limit",
+                                    "value": "10",
+                                    "description": "The number of items to fetch"
+                                },
+                                {
+                                    "key": "user_id",
+                                    "value": "vbPj6",
+                                    "description": "The user ID of the user making the request"
+                                },
+                                {
+                                    "key": "receiver_min_followers",
+                                    "value": "0",
+                                    "description": "Only include tips to recipients that have this many followers"
+                                },
+                                {
+                                    "key": "receiver_is_verified",
+                                    "value": "false",
+                                    "description": "Only include tips to recipients that are verified"
+                                },
+                                {
+                                    "key": "current_user_follows",
+                                    "value": "receiver",
+                                    "description": "Only include tips involving the user's followers in the given capacity. Requires user_id to be set."
+                                },
+                                {
+                                    "key": "unique_by",
+                                    "value": "receiver",
+                                    "description": "Only include the most recent tip for a user was involved in the given capacity.\n\nEg. 'sender' will ensure that each tip returned has a unique sender, using the most recent tip sent by a user if that user has sent multiple tips.\n    "
+                                }
+                            ]
+                        },
+                        "description": "Gets the most recent tips on the network"
+                    },
+                    "response": [
+                        {
+                            "name": "Success",
+                            "originalRequest": {
+                                "method": "GET",
+                                "header": [
+                                    {
+                                        "key": "Accept",
+                                        "value": "application/json"
+                                    }
+                                ],
+                                "url": {
+                                    "raw": "{{baseUrl}}/tips?offset=<integer>&limit=<integer>&user_id=<string>&receiver_min_followers=0&receiver_is_verified=false&current_user_follows=receiver&unique_by=receiver",
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "path": [
+                                        "tips"
+                                    ],
+                                    "query": [
+                                        {
+                                            "key": "offset",
+                                            "value": "<integer>",
+                                            "description": "The number of items to skip. Useful for pagination (page number * limit)"
+                                        },
+                                        {
+                                            "key": "limit",
+                                            "value": "<integer>",
+                                            "description": "The number of items to fetch"
+                                        },
+                                        {
+                                            "key": "user_id",
+                                            "value": "<string>",
+                                            "description": "The user ID of the user making the request"
+                                        },
+                                        {
+                                            "key": "receiver_min_followers",
+                                            "value": "0",
+                                            "description": "Only include tips to recipients that have this many followers"
+                                        },
+                                        {
+                                            "key": "receiver_is_verified",
+                                            "value": "false",
+                                            "description": "Only include tips to recipients that are verified"
+                                        },
+                                        {
+                                            "key": "current_user_follows",
+                                            "value": "receiver",
+                                            "description": "Only include tips involving the user's followers in the given capacity. Requires user_id to be set."
+                                        },
+                                        {
+                                            "key": "unique_by",
+                                            "value": "receiver",
+                                            "description": "Only include the most recent tip for a user was involved in the given capacity.\n\nEg. 'sender' will ensure that each tip returned has a unique sender, using the most recent tip sent by a user if that user has sent multiple tips.\n    "
+                                        }
+                                    ]
+                                }
+                            },
+                            "status": "OK",
+                            "code": 200,
+                            "_postman_previewlanguage": "json",
+                            "header": [
+                                {
+                                    "key": "Content-Type",
+                                    "value": "application/json"
+                                }
+                            ],
+                            "cookie": [],
+                            "body": "{\n  \"data\": [\n    {\n      \"amount\": \"<string>\",\n      \"created_at\": \"<string>\",\n      \"sender\": {\n        \"album_count\": \"<integer>\",\n        \"erc_wallet\": \"<string>\",\n        \"followee_count\": \"<integer>\",\n        \"follower_count\": \"<integer>\",\n        \"handle\": \"<string>\",\n        \"id\": \"<string>\",\n        \"is_available\": \"<boolean>\",\n        \"is_deactivated\": \"<boolean>\",\n        \"is_verified\": \"<boolean>\",\n        \"name\": \"<string>\",\n        \"playlist_count\": \"<integer>\",\n        \"repost_count\": \"<integer>\",\n        \"spl_wallet\": \"<string>\",\n        \"supporter_count\": \"<integer>\",\n        \"supporting_count\": \"<integer>\",\n        \"total_audio_balance\": \"<integer>\",\n        \"track_count\": \"<integer>\",\n        \"artist_pick_track_id\": \"<string>\",\n        \"bio\": \"<string>\",\n        \"cover_photo\": {\n          \"640x\": \"<string>\",\n          \"2000x\": \"<string>\"\n        },\n        \"does_follow_current_user\": \"<boolean>\",\n        \"location\": \"<string>\",\n        \"profile_picture\": {\n          \"150x150\": \"<string>\",\n          \"480x480\": \"<string>\",\n          \"1000x1000\": \"<string>\"\n        }\n      },\n      \"receiver\": {\n        \"album_count\": \"<integer>\",\n        \"erc_wallet\": \"<string>\",\n        \"followee_count\": \"<integer>\",\n        \"follower_count\": \"<integer>\",\n        \"handle\": \"<string>\",\n        \"id\": \"<string>\",\n        \"is_available\": \"<boolean>\",\n        \"is_deactivated\": \"<boolean>\",\n        \"is_verified\": \"<boolean>\",\n        \"name\": \"<string>\",\n        \"playlist_count\": \"<integer>\",\n        \"repost_count\": \"<integer>\",\n        \"spl_wallet\": \"<string>\",\n        \"supporter_count\": \"<integer>\",\n        \"supporting_count\": \"<integer>\",\n        \"total_audio_balance\": \"<integer>\",\n        \"track_count\": \"<integer>\",\n        \"artist_pick_track_id\": \"<string>\",\n        \"bio\": \"<string>\",\n        \"cover_photo\": {\n          \"640x\": \"<string>\",\n          \"2000x\": \"<string>\"\n        },\n        \"does_follow_current_user\": \"<boolean>\",\n        \"location\": \"<string>\",\n        \"profile_picture\": {\n          \"150x150\": \"<string>\",\n          \"480x480\": \"<string>\",\n          \"1000x1000\": \"<string>\"\n        }\n      }\n    },\n    {\n      \"amount\": \"<string>\",\n      \"created_at\": \"<string>\",\n      \"sender\": {\n        \"album_count\": \"<integer>\",\n        \"erc_wallet\": \"<string>\",\n        \"followee_count\": \"<integer>\",\n        \"follower_count\": \"<integer>\",\n        \"handle\": \"<string>\",\n        \"id\": \"<string>\",\n        \"is_available\": \"<boolean>\",\n        \"is_deactivated\": \"<boolean>\",\n        \"is_verified\": \"<boolean>\",\n        \"name\": \"<string>\",\n        \"playlist_count\": \"<integer>\",\n        \"repost_count\": \"<integer>\",\n        \"spl_wallet\": \"<string>\",\n        \"supporter_count\": \"<integer>\",\n        \"supporting_count\": \"<integer>\",\n        \"total_audio_balance\": \"<integer>\",\n        \"track_count\": \"<integer>\",\n        \"artist_pick_track_id\": \"<string>\",\n        \"bio\": \"<string>\",\n        \"cover_photo\": {\n          \"640x\": \"<string>\",\n          \"2000x\": \"<string>\"\n        },\n        \"does_follow_current_user\": \"<boolean>\",\n        \"location\": \"<string>\",\n        \"profile_picture\": {\n          \"150x150\": \"<string>\",\n          \"480x480\": \"<string>\",\n          \"1000x1000\": \"<string>\"\n        }\n      },\n      \"receiver\": {\n        \"album_count\": \"<integer>\",\n        \"erc_wallet\": \"<string>\",\n        \"followee_count\": \"<integer>\",\n        \"follower_count\": \"<integer>\",\n        \"handle\": \"<string>\",\n        \"id\": \"<string>\",\n        \"is_available\": \"<boolean>\",\n        \"is_deactivated\": \"<boolean>\",\n        \"is_verified\": \"<boolean>\",\n        \"name\": \"<string>\",\n        \"playlist_count\": \"<integer>\",\n        \"repost_count\": \"<integer>\",\n        \"spl_wallet\": \"<string>\",\n        \"supporter_count\": \"<integer>\",\n        \"supporting_count\": \"<integer>\",\n        \"total_audio_balance\": \"<integer>\",\n        \"track_count\": \"<integer>\",\n        \"artist_pick_track_id\": \"<string>\",\n        \"bio\": \"<string>\",\n        \"cover_photo\": {\n          \"640x\": \"<string>\",\n          \"2000x\": \"<string>\"\n        },\n        \"does_follow_current_user\": \"<boolean>\",\n        \"location\": \"<string>\",\n        \"profile_picture\": {\n          \"150x150\": \"<string>\",\n          \"480x480\": \"<string>\",\n          \"1000x1000\": \"<string>\"\n        }\n      }\n    }\n  ]\n}"
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "name": "tracks",
+            "item": [
+                {
+                    "name": "search",
+                    "item": [
+                        {
+                            "name": "Search Tracks",
+                            "request": {
+                                "method": "GET",
+                                "header": [
+                                    {
+                                        "key": "Accept",
+                                        "value": "application/json"
+                                    }
+                                ],
+                                "url": {
+                                    "raw": "{{test_base_url}}/tracks/search?query=test&only_downloadable=false",
+                                    "host": [
+                                        "{{test_base_url}}"
+                                    ],
+                                    "path": [
+                                        "tracks",
+                                        "search"
+                                    ],
+                                    "query": [
+                                        {
+                                            "key": "query",
+                                            "value": "test",
+                                            "description": "(Required) The search query"
+                                        },
+                                        {
+                                            "key": "only_downloadable",
+                                            "value": "false",
+                                            "description": "Return only downloadable tracks"
+                                        }
+                                    ]
+                                },
+                                "description": "Search for a track or tracks"
+                            },
+                            "response": [
+                                {
+                                    "name": "Success",
+                                    "originalRequest": {
+                                        "method": "GET",
+                                        "header": [
+                                            {
+                                                "key": "Accept",
+                                                "value": "application/json"
+                                            }
+                                        ],
+                                        "url": {
+                                            "raw": "{{baseUrl}}/tracks/search?query=<string>&only_downloadable=false",
+                                            "host": [
+                                                "{{baseUrl}}"
+                                            ],
+                                            "path": [
+                                                "tracks",
+                                                "search"
+                                            ],
+                                            "query": [
+                                                {
+                                                    "key": "query",
+                                                    "value": "<string>",
+                                                    "description": "(Required) The search query"
+                                                },
+                                                {
+                                                    "key": "only_downloadable",
+                                                    "value": "false",
+                                                    "description": "Return only downloadable tracks"
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    "status": "OK",
+                                    "code": 200,
+                                    "_postman_previewlanguage": "json",
+                                    "header": [
+                                        {
+                                            "key": "Content-Type",
+                                            "value": "application/json"
+                                        }
+                                    ],
+                                    "cookie": [],
+                                    "body": "{\n  \"data\": [\n    {\n      \"duration\": \"<integer>\",\n      \"favorite_count\": \"<integer>\",\n      \"id\": \"<string>\",\n      \"play_count\": \"<integer>\",\n      \"repost_count\": \"<integer>\",\n      \"title\": \"<string>\",\n      \"user\": {\n        \"album_count\": \"<integer>\",\n        \"erc_wallet\": \"<string>\",\n        \"followee_count\": \"<integer>\",\n        \"follower_count\": \"<integer>\",\n        \"handle\": \"<string>\",\n        \"id\": \"<string>\",\n        \"is_available\": \"<boolean>\",\n        \"is_deactivated\": \"<boolean>\",\n        \"is_verified\": \"<boolean>\",\n        \"name\": \"<string>\",\n        \"playlist_count\": \"<integer>\",\n        \"repost_count\": \"<integer>\",\n        \"spl_wallet\": \"<string>\",\n        \"supporter_count\": \"<integer>\",\n        \"supporting_count\": \"<integer>\",\n        \"total_audio_balance\": \"<integer>\",\n        \"track_count\": \"<integer>\",\n        \"artist_pick_track_id\": \"<string>\",\n        \"bio\": \"<string>\",\n        \"cover_photo\": {\n          \"640x\": \"<string>\",\n          \"2000x\": \"<string>\"\n        },\n        \"does_follow_current_user\": \"<boolean>\",\n        \"location\": \"<string>\",\n        \"profile_picture\": {\n          \"150x150\": \"<string>\",\n          \"480x480\": \"<string>\",\n          \"1000x1000\": \"<string>\"\n        }\n      },\n      \"artwork\": {\n        \"150x150\": \"<string>\",\n        \"480x480\": \"<string>\",\n        \"1000x1000\": \"<string>\"\n      },\n      \"description\": \"<string>\",\n      \"genre\": \"<string>\",\n      \"track_cid\": \"<string>\",\n      \"preview_cid\": \"<string>\",\n      \"mood\": \"<string>\",\n      \"release_date\": \"<string>\",\n      \"remix_of\": {\n        \"tracks\": [\n          {\n            \"parent_track_id\": \"<string>\"\n          },\n          {\n            \"parent_track_id\": \"<string>\"\n          }\n        ]\n      },\n      \"tags\": \"<string>\",\n      \"downloadable\": \"<boolean>\",\n      \"permalink\": \"<string>\",\n      \"is_streamable\": \"<boolean>\"\n    },\n    {\n      \"duration\": \"<integer>\",\n      \"favorite_count\": \"<integer>\",\n      \"id\": \"<string>\",\n      \"play_count\": \"<integer>\",\n      \"repost_count\": \"<integer>\",\n      \"title\": \"<string>\",\n      \"user\": {\n        \"album_count\": \"<integer>\",\n        \"erc_wallet\": \"<string>\",\n        \"followee_count\": \"<integer>\",\n        \"follower_count\": \"<integer>\",\n        \"handle\": \"<string>\",\n        \"id\": \"<string>\",\n        \"is_available\": \"<boolean>\",\n        \"is_deactivated\": \"<boolean>\",\n        \"is_verified\": \"<boolean>\",\n        \"name\": \"<string>\",\n        \"playlist_count\": \"<integer>\",\n        \"repost_count\": \"<integer>\",\n        \"spl_wallet\": \"<string>\",\n        \"supporter_count\": \"<integer>\",\n        \"supporting_count\": \"<integer>\",\n        \"total_audio_balance\": \"<integer>\",\n        \"track_count\": \"<integer>\",\n        \"artist_pick_track_id\": \"<string>\",\n        \"bio\": \"<string>\",\n        \"cover_photo\": {\n          \"640x\": \"<string>\",\n          \"2000x\": \"<string>\"\n        },\n        \"does_follow_current_user\": \"<boolean>\",\n        \"location\": \"<string>\",\n        \"profile_picture\": {\n          \"150x150\": \"<string>\",\n          \"480x480\": \"<string>\",\n          \"1000x1000\": \"<string>\"\n        }\n      },\n      \"artwork\": {\n        \"150x150\": \"<string>\",\n        \"480x480\": \"<string>\",\n        \"1000x1000\": \"<string>\"\n      },\n      \"description\": \"<string>\",\n      \"genre\": \"<string>\",\n      \"track_cid\": \"<string>\",\n      \"preview_cid\": \"<string>\",\n      \"mood\": \"<string>\",\n      \"release_date\": \"<string>\",\n      \"remix_of\": {\n        \"tracks\": [\n          {\n            \"parent_track_id\": \"<string>\"\n          },\n          {\n            \"parent_track_id\": \"<string>\"\n          }\n        ]\n      },\n      \"tags\": \"<string>\",\n      \"downloadable\": \"<boolean>\",\n      \"permalink\": \"<string>\",\n      \"is_streamable\": \"<boolean>\"\n    }\n  ]\n}"
+                                },
+                                {
+                                    "name": "Bad request",
+                                    "originalRequest": {
+                                        "method": "GET",
+                                        "header": [],
+                                        "url": {
+                                            "raw": "{{baseUrl}}/tracks/search?query=<string>&only_downloadable=false",
+                                            "host": [
+                                                "{{baseUrl}}"
+                                            ],
+                                            "path": [
+                                                "tracks",
+                                                "search"
+                                            ],
+                                            "query": [
+                                                {
+                                                    "key": "query",
+                                                    "value": "<string>",
+                                                    "description": "(Required) The search query"
+                                                },
+                                                {
+                                                    "key": "only_downloadable",
+                                                    "value": "false",
+                                                    "description": "Return only downloadable tracks"
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    "status": "Bad Request",
+                                    "code": 400,
+                                    "_postman_previewlanguage": "text",
+                                    "header": [],
+                                    "cookie": [],
+                                    "body": ""
+                                },
+                                {
+                                    "name": "Server error",
+                                    "originalRequest": {
+                                        "method": "GET",
+                                        "header": [],
+                                        "url": {
+                                            "raw": "{{baseUrl}}/tracks/search?query=<string>&only_downloadable=false",
+                                            "host": [
+                                                "{{baseUrl}}"
+                                            ],
+                                            "path": [
+                                                "tracks",
+                                                "search"
+                                            ],
+                                            "query": [
+                                                {
+                                                    "key": "query",
+                                                    "value": "<string>",
+                                                    "description": "(Required) The search query"
+                                                },
+                                                {
+                                                    "key": "only_downloadable",
+                                                    "value": "false",
+                                                    "description": "Return only downloadable tracks"
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    "status": "Internal Server Error",
+                                    "code": 500,
+                                    "_postman_previewlanguage": "text",
+                                    "header": [],
+                                    "cookie": [],
+                                    "body": ""
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "name": "trending",
+                    "item": [
+                        {
+                            "name": "underground",
+                            "item": [
+                                {
+                                    "name": "Get Underground Trending Tracks",
+                                    "request": {
+                                        "method": "GET",
+                                        "header": [
+                                            {
+                                                "key": "Accept",
+                                                "value": "application/json"
+                                            }
+                                        ],
+                                        "url": {
+                                            "raw": "{{test_base_url}}/tracks/trending/underground?offset=0&limit=4",
+                                            "host": [
+                                                "{{test_base_url}}"
+                                            ],
+                                            "path": [
+                                                "tracks",
+                                                "trending",
+                                                "underground"
+                                            ],
+                                            "query": [
+                                                {
+                                                    "key": "offset",
+                                                    "value": "0",
+                                                    "description": "The number of items to skip. Useful for pagination (page number * limit)"
+                                                },
+                                                {
+                                                    "key": "limit",
+                                                    "value": "4",
+                                                    "description": "The number of items to fetch"
+                                                }
+                                            ]
+                                        },
+                                        "description": "Gets the top 100 trending underground tracks on Audius"
+                                    },
+                                    "response": [
+                                        {
+                                            "name": "Success",
+                                            "originalRequest": {
+                                                "method": "GET",
+                                                "header": [
+                                                    {
+                                                        "key": "Accept",
+                                                        "value": "application/json"
+                                                    }
+                                                ],
+                                                "url": {
+                                                    "raw": "{{baseUrl}}/tracks/trending/underground?offset=<integer>&limit=<integer>",
+                                                    "host": [
+                                                        "{{baseUrl}}"
+                                                    ],
+                                                    "path": [
+                                                        "tracks",
+                                                        "trending",
+                                                        "underground"
+                                                    ],
+                                                    "query": [
+                                                        {
+                                                            "key": "offset",
+                                                            "value": "<integer>",
+                                                            "description": "The number of items to skip. Useful for pagination (page number * limit)"
+                                                        },
+                                                        {
+                                                            "key": "limit",
+                                                            "value": "<integer>",
+                                                            "description": "The number of items to fetch"
+                                                        }
+                                                    ]
+                                                }
+                                            },
+                                            "status": "OK",
+                                            "code": 200,
+                                            "_postman_previewlanguage": "json",
+                                            "header": [
+                                                {
+                                                    "key": "Content-Type",
+                                                    "value": "application/json"
+                                                }
+                                            ],
+                                            "cookie": [],
+                                            "body": "{\n  \"data\": [\n    {\n      \"duration\": \"<integer>\",\n      \"favorite_count\": \"<integer>\",\n      \"id\": \"<string>\",\n      \"play_count\": \"<integer>\",\n      \"repost_count\": \"<integer>\",\n      \"title\": \"<string>\",\n      \"user\": {\n        \"album_count\": \"<integer>\",\n        \"erc_wallet\": \"<string>\",\n        \"followee_count\": \"<integer>\",\n        \"follower_count\": \"<integer>\",\n        \"handle\": \"<string>\",\n        \"id\": \"<string>\",\n        \"is_available\": \"<boolean>\",\n        \"is_deactivated\": \"<boolean>\",\n        \"is_verified\": \"<boolean>\",\n        \"name\": \"<string>\",\n        \"playlist_count\": \"<integer>\",\n        \"repost_count\": \"<integer>\",\n        \"spl_wallet\": \"<string>\",\n        \"supporter_count\": \"<integer>\",\n        \"supporting_count\": \"<integer>\",\n        \"total_audio_balance\": \"<integer>\",\n        \"track_count\": \"<integer>\",\n        \"artist_pick_track_id\": \"<string>\",\n        \"bio\": \"<string>\",\n        \"cover_photo\": {\n          \"640x\": \"<string>\",\n          \"2000x\": \"<string>\"\n        },\n        \"does_follow_current_user\": \"<boolean>\",\n        \"location\": \"<string>\",\n        \"profile_picture\": {\n          \"150x150\": \"<string>\",\n          \"480x480\": \"<string>\",\n          \"1000x1000\": \"<string>\"\n        }\n      },\n      \"artwork\": {\n        \"150x150\": \"<string>\",\n        \"480x480\": \"<string>\",\n        \"1000x1000\": \"<string>\"\n      },\n      \"description\": \"<string>\",\n      \"genre\": \"<string>\",\n      \"track_cid\": \"<string>\",\n      \"preview_cid\": \"<string>\",\n      \"mood\": \"<string>\",\n      \"release_date\": \"<string>\",\n      \"remix_of\": {\n        \"tracks\": [\n          {\n            \"parent_track_id\": \"<string>\"\n          },\n          {\n            \"parent_track_id\": \"<string>\"\n          }\n        ]\n      },\n      \"tags\": \"<string>\",\n      \"downloadable\": \"<boolean>\",\n      \"permalink\": \"<string>\",\n      \"is_streamable\": \"<boolean>\"\n    },\n    {\n      \"duration\": \"<integer>\",\n      \"favorite_count\": \"<integer>\",\n      \"id\": \"<string>\",\n      \"play_count\": \"<integer>\",\n      \"repost_count\": \"<integer>\",\n      \"title\": \"<string>\",\n      \"user\": {\n        \"album_count\": \"<integer>\",\n        \"erc_wallet\": \"<string>\",\n        \"followee_count\": \"<integer>\",\n        \"follower_count\": \"<integer>\",\n        \"handle\": \"<string>\",\n        \"id\": \"<string>\",\n        \"is_available\": \"<boolean>\",\n        \"is_deactivated\": \"<boolean>\",\n        \"is_verified\": \"<boolean>\",\n        \"name\": \"<string>\",\n        \"playlist_count\": \"<integer>\",\n        \"repost_count\": \"<integer>\",\n        \"spl_wallet\": \"<string>\",\n        \"supporter_count\": \"<integer>\",\n        \"supporting_count\": \"<integer>\",\n        \"total_audio_balance\": \"<integer>\",\n        \"track_count\": \"<integer>\",\n        \"artist_pick_track_id\": \"<string>\",\n        \"bio\": \"<string>\",\n        \"cover_photo\": {\n          \"640x\": \"<string>\",\n          \"2000x\": \"<string>\"\n        },\n        \"does_follow_current_user\": \"<boolean>\",\n        \"location\": \"<string>\",\n        \"profile_picture\": {\n          \"150x150\": \"<string>\",\n          \"480x480\": \"<string>\",\n          \"1000x1000\": \"<string>\"\n        }\n      },\n      \"artwork\": {\n        \"150x150\": \"<string>\",\n        \"480x480\": \"<string>\",\n        \"1000x1000\": \"<string>\"\n      },\n      \"description\": \"<string>\",\n      \"genre\": \"<string>\",\n      \"track_cid\": \"<string>\",\n      \"preview_cid\": \"<string>\",\n      \"mood\": \"<string>\",\n      \"release_date\": \"<string>\",\n      \"remix_of\": {\n        \"tracks\": [\n          {\n            \"parent_track_id\": \"<string>\"\n          },\n          {\n            \"parent_track_id\": \"<string>\"\n          }\n        ]\n      },\n      \"tags\": \"<string>\",\n      \"downloadable\": \"<boolean>\",\n      \"permalink\": \"<string>\",\n      \"is_streamable\": \"<boolean>\"\n    }\n  ]\n}"
+                                        }
+                                    ]
+                                }
+                            ]
+                        },
+                        {
+                            "name": "Get Trending Tracks",
+                            "request": {
+                                "method": "GET",
+                                "header": [
+                                    {
+                                        "key": "Accept",
+                                        "value": "application/json"
+                                    }
+                                ],
+                                "url": {
+                                    "raw": "{{test_base_url}}/tracks/trending?genre=rock&time=week",
+                                    "host": [
+                                        "{{test_base_url}}"
+                                    ],
+                                    "path": [
+                                        "tracks",
+                                        "trending"
+                                    ],
+                                    "query": [
+                                        {
+                                            "key": "genre",
+                                            "value": "rock",
+                                            "description": "Filter trending to a specified genre"
+                                        },
+                                        {
+                                            "key": "time",
+                                            "value": "week",
+                                            "description": "Calculate trending over a specified time range"
+                                        }
+                                    ]
+                                },
+                                "description": "Gets the top 100 trending (most popular) tracks on Audius"
+                            },
+                            "response": [
+                                {
+                                    "name": "Success",
+                                    "originalRequest": {
+                                        "method": "GET",
+                                        "header": [
+                                            {
+                                                "key": "Accept",
+                                                "value": "application/json"
+                                            }
+                                        ],
+                                        "url": {
+                                            "raw": "{{baseUrl}}/tracks/trending?genre=<string>&time=week",
+                                            "host": [
+                                                "{{baseUrl}}"
+                                            ],
+                                            "path": [
+                                                "tracks",
+                                                "trending"
+                                            ],
+                                            "query": [
+                                                {
+                                                    "key": "genre",
+                                                    "value": "<string>",
+                                                    "description": "Filter trending to a specified genre"
+                                                },
+                                                {
+                                                    "key": "time",
+                                                    "value": "week",
+                                                    "description": "Calculate trending over a specified time range"
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    "status": "OK",
+                                    "code": 200,
+                                    "_postman_previewlanguage": "json",
+                                    "header": [
+                                        {
+                                            "key": "Content-Type",
+                                            "value": "application/json"
+                                        }
+                                    ],
+                                    "cookie": [],
+                                    "body": "{\n  \"data\": [\n    {\n      \"duration\": \"<integer>\",\n      \"favorite_count\": \"<integer>\",\n      \"id\": \"<string>\",\n      \"play_count\": \"<integer>\",\n      \"repost_count\": \"<integer>\",\n      \"title\": \"<string>\",\n      \"user\": {\n        \"album_count\": \"<integer>\",\n        \"erc_wallet\": \"<string>\",\n        \"followee_count\": \"<integer>\",\n        \"follower_count\": \"<integer>\",\n        \"handle\": \"<string>\",\n        \"id\": \"<string>\",\n        \"is_available\": \"<boolean>\",\n        \"is_deactivated\": \"<boolean>\",\n        \"is_verified\": \"<boolean>\",\n        \"name\": \"<string>\",\n        \"playlist_count\": \"<integer>\",\n        \"repost_count\": \"<integer>\",\n        \"spl_wallet\": \"<string>\",\n        \"supporter_count\": \"<integer>\",\n        \"supporting_count\": \"<integer>\",\n        \"total_audio_balance\": \"<integer>\",\n        \"track_count\": \"<integer>\",\n        \"artist_pick_track_id\": \"<string>\",\n        \"bio\": \"<string>\",\n        \"cover_photo\": {\n          \"640x\": \"<string>\",\n          \"2000x\": \"<string>\"\n        },\n        \"does_follow_current_user\": \"<boolean>\",\n        \"location\": \"<string>\",\n        \"profile_picture\": {\n          \"150x150\": \"<string>\",\n          \"480x480\": \"<string>\",\n          \"1000x1000\": \"<string>\"\n        }\n      },\n      \"artwork\": {\n        \"150x150\": \"<string>\",\n        \"480x480\": \"<string>\",\n        \"1000x1000\": \"<string>\"\n      },\n      \"description\": \"<string>\",\n      \"genre\": \"<string>\",\n      \"track_cid\": \"<string>\",\n      \"preview_cid\": \"<string>\",\n      \"mood\": \"<string>\",\n      \"release_date\": \"<string>\",\n      \"remix_of\": {\n        \"tracks\": [\n          {\n            \"parent_track_id\": \"<string>\"\n          },\n          {\n            \"parent_track_id\": \"<string>\"\n          }\n        ]\n      },\n      \"tags\": \"<string>\",\n      \"downloadable\": \"<boolean>\",\n      \"permalink\": \"<string>\",\n      \"is_streamable\": \"<boolean>\"\n    },\n    {\n      \"duration\": \"<integer>\",\n      \"favorite_count\": \"<integer>\",\n      \"id\": \"<string>\",\n      \"play_count\": \"<integer>\",\n      \"repost_count\": \"<integer>\",\n      \"title\": \"<string>\",\n      \"user\": {\n        \"album_count\": \"<integer>\",\n        \"erc_wallet\": \"<string>\",\n        \"followee_count\": \"<integer>\",\n        \"follower_count\": \"<integer>\",\n        \"handle\": \"<string>\",\n        \"id\": \"<string>\",\n        \"is_available\": \"<boolean>\",\n        \"is_deactivated\": \"<boolean>\",\n        \"is_verified\": \"<boolean>\",\n        \"name\": \"<string>\",\n        \"playlist_count\": \"<integer>\",\n        \"repost_count\": \"<integer>\",\n        \"spl_wallet\": \"<string>\",\n        \"supporter_count\": \"<integer>\",\n        \"supporting_count\": \"<integer>\",\n        \"total_audio_balance\": \"<integer>\",\n        \"track_count\": \"<integer>\",\n        \"artist_pick_track_id\": \"<string>\",\n        \"bio\": \"<string>\",\n        \"cover_photo\": {\n          \"640x\": \"<string>\",\n          \"2000x\": \"<string>\"\n        },\n        \"does_follow_current_user\": \"<boolean>\",\n        \"location\": \"<string>\",\n        \"profile_picture\": {\n          \"150x150\": \"<string>\",\n          \"480x480\": \"<string>\",\n          \"1000x1000\": \"<string>\"\n        }\n      },\n      \"artwork\": {\n        \"150x150\": \"<string>\",\n        \"480x480\": \"<string>\",\n        \"1000x1000\": \"<string>\"\n      },\n      \"description\": \"<string>\",\n      \"genre\": \"<string>\",\n      \"track_cid\": \"<string>\",\n      \"preview_cid\": \"<string>\",\n      \"mood\": \"<string>\",\n      \"release_date\": \"<string>\",\n      \"remix_of\": {\n        \"tracks\": [\n          {\n            \"parent_track_id\": \"<string>\"\n          },\n          {\n            \"parent_track_id\": \"<string>\"\n          }\n        ]\n      },\n      \"tags\": \"<string>\",\n      \"downloadable\": \"<boolean>\",\n      \"permalink\": \"<string>\",\n      \"is_streamable\": \"<boolean>\"\n    }\n  ]\n}"
+                                },
+                                {
+                                    "name": "Bad request",
+                                    "originalRequest": {
+                                        "method": "GET",
+                                        "header": [],
+                                        "url": {
+                                            "raw": "{{baseUrl}}/tracks/trending?genre=<string>&time=week",
+                                            "host": [
+                                                "{{baseUrl}}"
+                                            ],
+                                            "path": [
+                                                "tracks",
+                                                "trending"
+                                            ],
+                                            "query": [
+                                                {
+                                                    "key": "genre",
+                                                    "value": "<string>",
+                                                    "description": "Filter trending to a specified genre"
+                                                },
+                                                {
+                                                    "key": "time",
+                                                    "value": "week",
+                                                    "description": "Calculate trending over a specified time range"
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    "status": "Bad Request",
+                                    "code": 400,
+                                    "_postman_previewlanguage": "text",
+                                    "header": [],
+                                    "cookie": [],
+                                    "body": ""
+                                },
+                                {
+                                    "name": "Server error",
+                                    "originalRequest": {
+                                        "method": "GET",
+                                        "header": [],
+                                        "url": {
+                                            "raw": "{{baseUrl}}/tracks/trending?genre=<string>&time=week",
+                                            "host": [
+                                                "{{baseUrl}}"
+                                            ],
+                                            "path": [
+                                                "tracks",
+                                                "trending"
+                                            ],
+                                            "query": [
+                                                {
+                                                    "key": "genre",
+                                                    "value": "<string>",
+                                                    "description": "Filter trending to a specified genre"
+                                                },
+                                                {
+                                                    "key": "time",
+                                                    "value": "week",
+                                                    "description": "Calculate trending over a specified time range"
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    "status": "Internal Server Error",
+                                    "code": 500,
+                                    "_postman_previewlanguage": "text",
+                                    "header": [],
+                                    "cookie": [],
+                                    "body": ""
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "name": "{track_id}",
+                    "item": [
+                        {
+                            "name": "stream",
+                            "item": [
+                                {
+                                    "name": "Get the streamable MP3 file of a track",
+                                    "request": {
+                                        "method": "GET",
+                                        "header": [],
+                                        "url": {
+                                            "raw": "{{test_base_url}}/tracks/{{track_id}}/stream?user_data=Premium%20content%20user%20signature%20at%201695260651241&user_signature=0x69e825bdf1da4d191d7fc9ff9daa8d6be3ac5dffa97577050878978a274f636f66d7b0afe32b52232e84388ecf711a4fa158473984fc09c669f44414049c47dc1c",
+                                            "host": [
+                                                "{{test_base_url}}"
+                                            ],
+                                            "path": [
+                                                "tracks",
+                                                "{{track_id}}",
+                                                "stream"
+                                            ],
+                                            "query": [
+                                                {
+                                                    "key": "user_data",
+                                                    "value": "Premium%20content%20user%20signature%20at%201695260651241"
+                                                },
+                                                {
+                                                    "key": "user_signature",
+                                                    "value": "0x69e825bdf1da4d191d7fc9ff9daa8d6be3ac5dffa97577050878978a274f636f66d7b0afe32b52232e84388ecf711a4fa158473984fc09c669f44414049c47dc1c"
+                                                }
+                                            ]
+                                        },
+                                        "description": "This endpoint accepts the Range header for streaming.\nhttps://developer.mozilla.org/en-US/docs/Web/HTTP/Range_requests"
+                                    },
+                                    "response": [
+                                        {
+                                            "name": "Success",
+                                            "originalRequest": {
+                                                "method": "GET",
+                                                "header": [],
+                                                "url": {
+                                                    "raw": "{{baseUrl}}/tracks/:track_id/stream?preview=false&user_signature=<string>&user_data=<string>&premium_content_signature=<string>&filename=<string>&skip_play_count=false",
+                                                    "host": [
+                                                        "{{baseUrl}}"
+                                                    ],
+                                                    "path": [
+                                                        "tracks",
+                                                        ":track_id",
+                                                        "stream"
+                                                    ],
+                                                    "query": [
+                                                        {
+                                                            "key": "preview",
+                                                            "value": "false",
+                                                            "description": "Optional - true if streaming track preview"
+                                                        },
+                                                        {
+                                                            "key": "user_signature",
+                                                            "value": "<string>",
+                                                            "description": "Optional - signature from the requesting user's wallet.\n        This is needed to authenticate the user and verify access in case the track is premium."
+                                                        },
+                                                        {
+                                                            "key": "user_data",
+                                                            "value": "<string>",
+                                                            "description": "Optional - data which was used to generate the optional signature argument."
+                                                        },
+                                                        {
+                                                            "key": "premium_content_signature",
+                                                            "value": "<string>",
+                                                            "description": "Optional - premium content signature for this track which was previously generated by a registered DN.\n        This is so that track access won't have to be check; instead, we check that the user which generated the\n        user signature and the user for whom the DN signed are the same."
+                                                        },
+                                                        {
+                                                            "key": "filename",
+                                                            "value": "<string>",
+                                                            "description": "Optional - Filename in case user is trying to download track.\n        This is needed by the CN in order to set the Content-Disposition response header."
+                                                        },
+                                                        {
+                                                            "key": "skip_play_count",
+                                                            "value": "false",
+                                                            "description": "Optional - boolean that disables tracking of play counts."
+                                                        }
+                                                    ],
+                                                    "variable": [
+                                                        {
+                                                            "key": "track_id"
+                                                        }
+                                                    ]
+                                                }
+                                            },
+                                            "status": "OK",
+                                            "code": 200,
+                                            "_postman_previewlanguage": "text",
+                                            "header": [],
+                                            "cookie": [],
+                                            "body": ""
+                                        },
+                                        {
+                                            "name": "Partial content",
+                                            "originalRequest": {
+                                                "method": "GET",
+                                                "header": [],
+                                                "url": {
+                                                    "raw": "{{baseUrl}}/tracks/:track_id/stream?preview=false&user_signature=<string>&user_data=<string>&premium_content_signature=<string>&filename=<string>&skip_play_count=false",
+                                                    "host": [
+                                                        "{{baseUrl}}"
+                                                    ],
+                                                    "path": [
+                                                        "tracks",
+                                                        ":track_id",
+                                                        "stream"
+                                                    ],
+                                                    "query": [
+                                                        {
+                                                            "key": "preview",
+                                                            "value": "false",
+                                                            "description": "Optional - true if streaming track preview"
+                                                        },
+                                                        {
+                                                            "key": "user_signature",
+                                                            "value": "<string>",
+                                                            "description": "Optional - signature from the requesting user's wallet.\n        This is needed to authenticate the user and verify access in case the track is premium."
+                                                        },
+                                                        {
+                                                            "key": "user_data",
+                                                            "value": "<string>",
+                                                            "description": "Optional - data which was used to generate the optional signature argument."
+                                                        },
+                                                        {
+                                                            "key": "premium_content_signature",
+                                                            "value": "<string>",
+                                                            "description": "Optional - premium content signature for this track which was previously generated by a registered DN.\n        This is so that track access won't have to be check; instead, we check that the user which generated the\n        user signature and the user for whom the DN signed are the same."
+                                                        },
+                                                        {
+                                                            "key": "filename",
+                                                            "value": "<string>",
+                                                            "description": "Optional - Filename in case user is trying to download track.\n        This is needed by the CN in order to set the Content-Disposition response header."
+                                                        },
+                                                        {
+                                                            "key": "skip_play_count",
+                                                            "value": "false",
+                                                            "description": "Optional - boolean that disables tracking of play counts."
+                                                        }
+                                                    ],
+                                                    "variable": [
+                                                        {
+                                                            "key": "track_id"
+                                                        }
+                                                    ]
+                                                }
+                                            },
+                                            "code": 216,
+                                            "_postman_previewlanguage": "text",
+                                            "header": [],
+                                            "cookie": [],
+                                            "body": ""
+                                        },
+                                        {
+                                            "name": "Bad request",
+                                            "originalRequest": {
+                                                "method": "GET",
+                                                "header": [],
+                                                "url": {
+                                                    "raw": "{{baseUrl}}/tracks/:track_id/stream?preview=false&user_signature=<string>&user_data=<string>&premium_content_signature=<string>&filename=<string>&skip_play_count=false",
+                                                    "host": [
+                                                        "{{baseUrl}}"
+                                                    ],
+                                                    "path": [
+                                                        "tracks",
+                                                        ":track_id",
+                                                        "stream"
+                                                    ],
+                                                    "query": [
+                                                        {
+                                                            "key": "preview",
+                                                            "value": "false",
+                                                            "description": "Optional - true if streaming track preview"
+                                                        },
+                                                        {
+                                                            "key": "user_signature",
+                                                            "value": "<string>",
+                                                            "description": "Optional - signature from the requesting user's wallet.\n        This is needed to authenticate the user and verify access in case the track is premium."
+                                                        },
+                                                        {
+                                                            "key": "user_data",
+                                                            "value": "<string>",
+                                                            "description": "Optional - data which was used to generate the optional signature argument."
+                                                        },
+                                                        {
+                                                            "key": "premium_content_signature",
+                                                            "value": "<string>",
+                                                            "description": "Optional - premium content signature for this track which was previously generated by a registered DN.\n        This is so that track access won't have to be check; instead, we check that the user which generated the\n        user signature and the user for whom the DN signed are the same."
+                                                        },
+                                                        {
+                                                            "key": "filename",
+                                                            "value": "<string>",
+                                                            "description": "Optional - Filename in case user is trying to download track.\n        This is needed by the CN in order to set the Content-Disposition response header."
+                                                        },
+                                                        {
+                                                            "key": "skip_play_count",
+                                                            "value": "false",
+                                                            "description": "Optional - boolean that disables tracking of play counts."
+                                                        }
+                                                    ],
+                                                    "variable": [
+                                                        {
+                                                            "key": "track_id"
+                                                        }
+                                                    ]
+                                                }
+                                            },
+                                            "status": "Bad Request",
+                                            "code": 400,
+                                            "_postman_previewlanguage": "text",
+                                            "header": [],
+                                            "cookie": [],
+                                            "body": ""
+                                        },
+                                        {
+                                            "name": "Content range invalid",
+                                            "originalRequest": {
+                                                "method": "GET",
+                                                "header": [],
+                                                "url": {
+                                                    "raw": "{{baseUrl}}/tracks/:track_id/stream?preview=false&user_signature=<string>&user_data=<string>&premium_content_signature=<string>&filename=<string>&skip_play_count=false",
+                                                    "host": [
+                                                        "{{baseUrl}}"
+                                                    ],
+                                                    "path": [
+                                                        "tracks",
+                                                        ":track_id",
+                                                        "stream"
+                                                    ],
+                                                    "query": [
+                                                        {
+                                                            "key": "preview",
+                                                            "value": "false",
+                                                            "description": "Optional - true if streaming track preview"
+                                                        },
+                                                        {
+                                                            "key": "user_signature",
+                                                            "value": "<string>",
+                                                            "description": "Optional - signature from the requesting user's wallet.\n        This is needed to authenticate the user and verify access in case the track is premium."
+                                                        },
+                                                        {
+                                                            "key": "user_data",
+                                                            "value": "<string>",
+                                                            "description": "Optional - data which was used to generate the optional signature argument."
+                                                        },
+                                                        {
+                                                            "key": "premium_content_signature",
+                                                            "value": "<string>",
+                                                            "description": "Optional - premium content signature for this track which was previously generated by a registered DN.\n        This is so that track access won't have to be check; instead, we check that the user which generated the\n        user signature and the user for whom the DN signed are the same."
+                                                        },
+                                                        {
+                                                            "key": "filename",
+                                                            "value": "<string>",
+                                                            "description": "Optional - Filename in case user is trying to download track.\n        This is needed by the CN in order to set the Content-Disposition response header."
+                                                        },
+                                                        {
+                                                            "key": "skip_play_count",
+                                                            "value": "false",
+                                                            "description": "Optional - boolean that disables tracking of play counts."
+                                                        }
+                                                    ],
+                                                    "variable": [
+                                                        {
+                                                            "key": "track_id"
+                                                        }
+                                                    ]
+                                                }
+                                            },
+                                            "status": "Requested Range Not Satisfiable",
+                                            "code": 416,
+                                            "_postman_previewlanguage": "text",
+                                            "header": [],
+                                            "cookie": [],
+                                            "body": ""
+                                        },
+                                        {
+                                            "name": "Server error",
+                                            "originalRequest": {
+                                                "method": "GET",
+                                                "header": [],
+                                                "url": {
+                                                    "raw": "{{baseUrl}}/tracks/:track_id/stream?preview=false&user_signature=<string>&user_data=<string>&premium_content_signature=<string>&filename=<string>&skip_play_count=false",
+                                                    "host": [
+                                                        "{{baseUrl}}"
+                                                    ],
+                                                    "path": [
+                                                        "tracks",
+                                                        ":track_id",
+                                                        "stream"
+                                                    ],
+                                                    "query": [
+                                                        {
+                                                            "key": "preview",
+                                                            "value": "false",
+                                                            "description": "Optional - true if streaming track preview"
+                                                        },
+                                                        {
+                                                            "key": "user_signature",
+                                                            "value": "<string>",
+                                                            "description": "Optional - signature from the requesting user's wallet.\n        This is needed to authenticate the user and verify access in case the track is premium."
+                                                        },
+                                                        {
+                                                            "key": "user_data",
+                                                            "value": "<string>",
+                                                            "description": "Optional - data which was used to generate the optional signature argument."
+                                                        },
+                                                        {
+                                                            "key": "premium_content_signature",
+                                                            "value": "<string>",
+                                                            "description": "Optional - premium content signature for this track which was previously generated by a registered DN.\n        This is so that track access won't have to be check; instead, we check that the user which generated the\n        user signature and the user for whom the DN signed are the same."
+                                                        },
+                                                        {
+                                                            "key": "filename",
+                                                            "value": "<string>",
+                                                            "description": "Optional - Filename in case user is trying to download track.\n        This is needed by the CN in order to set the Content-Disposition response header."
+                                                        },
+                                                        {
+                                                            "key": "skip_play_count",
+                                                            "value": "false",
+                                                            "description": "Optional - boolean that disables tracking of play counts."
+                                                        }
+                                                    ],
+                                                    "variable": [
+                                                        {
+                                                            "key": "track_id"
+                                                        }
+                                                    ]
+                                                }
+                                            },
+                                            "status": "Internal Server Error",
+                                            "code": 500,
+                                            "_postman_previewlanguage": "text",
+                                            "header": [],
+                                            "cookie": [],
+                                            "body": ""
+                                        }
+                                    ]
+                                }
+                            ]
+                        },
+                        {
+                            "name": "Get Track",
+                            "request": {
+                                "method": "GET",
+                                "header": [
+                                    {
+                                        "key": "Accept",
+                                        "value": "application/json"
+                                    }
+                                ],
+                                "url": {
+                                    "raw": "{{test_base_url}}/tracks/{{track_id}}",
+                                    "host": [
+                                        "{{test_base_url}}"
+                                    ],
+                                    "path": [
+                                        "tracks",
+                                        "{{track_id}}"
+                                    ]
+                                },
+                                "description": "Gets a track by ID"
+                            },
+                            "response": [
+                                {
+                                    "name": "Success",
+                                    "originalRequest": {
+                                        "method": "GET",
+                                        "header": [
+                                            {
+                                                "key": "Accept",
+                                                "value": "application/json"
+                                            }
+                                        ],
+                                        "url": {
+                                            "raw": "{{baseUrl}}/tracks/:track_id",
+                                            "host": [
+                                                "{{baseUrl}}"
+                                            ],
+                                            "path": [
+                                                "tracks",
+                                                ":track_id"
+                                            ],
+                                            "variable": [
+                                                {
+                                                    "key": "track_id"
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    "status": "OK",
+                                    "code": 200,
+                                    "_postman_previewlanguage": "json",
+                                    "header": [
+                                        {
+                                            "key": "Content-Type",
+                                            "value": "application/json"
+                                        }
+                                    ],
+                                    "cookie": [],
+                                    "body": "{\n  \"data\": {\n    \"duration\": \"<integer>\",\n    \"favorite_count\": \"<integer>\",\n    \"id\": \"<string>\",\n    \"play_count\": \"<integer>\",\n    \"repost_count\": \"<integer>\",\n    \"title\": \"<string>\",\n    \"user\": {\n      \"album_count\": \"<integer>\",\n      \"erc_wallet\": \"<string>\",\n      \"followee_count\": \"<integer>\",\n      \"follower_count\": \"<integer>\",\n      \"handle\": \"<string>\",\n      \"id\": \"<string>\",\n      \"is_available\": \"<boolean>\",\n      \"is_deactivated\": \"<boolean>\",\n      \"is_verified\": \"<boolean>\",\n      \"name\": \"<string>\",\n      \"playlist_count\": \"<integer>\",\n      \"repost_count\": \"<integer>\",\n      \"spl_wallet\": \"<string>\",\n      \"supporter_count\": \"<integer>\",\n      \"supporting_count\": \"<integer>\",\n      \"total_audio_balance\": \"<integer>\",\n      \"track_count\": \"<integer>\",\n      \"artist_pick_track_id\": \"<string>\",\n      \"bio\": \"<string>\",\n      \"cover_photo\": {\n        \"640x\": \"<string>\",\n        \"2000x\": \"<string>\"\n      },\n      \"does_follow_current_user\": \"<boolean>\",\n      \"location\": \"<string>\",\n      \"profile_picture\": {\n        \"150x150\": \"<string>\",\n        \"480x480\": \"<string>\",\n        \"1000x1000\": \"<string>\"\n      }\n    },\n    \"artwork\": {\n      \"150x150\": \"<string>\",\n      \"480x480\": \"<string>\",\n      \"1000x1000\": \"<string>\"\n    },\n    \"description\": \"<string>\",\n    \"genre\": \"<string>\",\n    \"track_cid\": \"<string>\",\n    \"preview_cid\": \"<string>\",\n    \"mood\": \"<string>\",\n    \"release_date\": \"<string>\",\n    \"remix_of\": {\n      \"tracks\": [\n        {\n          \"parent_track_id\": \"<string>\"\n        },\n        {\n          \"parent_track_id\": \"<string>\"\n        }\n      ]\n    },\n    \"tags\": \"<string>\",\n    \"downloadable\": \"<boolean>\",\n    \"permalink\": \"<string>\",\n    \"is_streamable\": \"<boolean>\"\n  }\n}"
+                                },
+                                {
+                                    "name": "Bad request",
+                                    "originalRequest": {
+                                        "method": "GET",
+                                        "header": [],
+                                        "url": {
+                                            "raw": "{{baseUrl}}/tracks/:track_id",
+                                            "host": [
+                                                "{{baseUrl}}"
+                                            ],
+                                            "path": [
+                                                "tracks",
+                                                ":track_id"
+                                            ],
+                                            "variable": [
+                                                {
+                                                    "key": "track_id"
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    "status": "Bad Request",
+                                    "code": 400,
+                                    "_postman_previewlanguage": "text",
+                                    "header": [],
+                                    "cookie": [],
+                                    "body": ""
+                                },
+                                {
+                                    "name": "Server error",
+                                    "originalRequest": {
+                                        "method": "GET",
+                                        "header": [],
+                                        "url": {
+                                            "raw": "{{baseUrl}}/tracks/:track_id",
+                                            "host": [
+                                                "{{baseUrl}}"
+                                            ],
+                                            "path": [
+                                                "tracks",
+                                                ":track_id"
+                                            ],
+                                            "variable": [
+                                                {
+                                                    "key": "track_id"
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    "status": "Internal Server Error",
+                                    "code": 500,
+                                    "_postman_previewlanguage": "text",
+                                    "header": [],
+                                    "cookie": [],
+                                    "body": ""
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "name": "Get Bulk Tracks",
+                    "request": {
+                        "method": "GET",
+                        "header": [
+                            {
+                                "key": "Accept",
+                                "value": "application/json"
+                            }
+                        ],
+                        "url": {
+                            "raw": "{{test_base_url}}/tracks?permalink=<string>&permalink=<string>&id=<string>&id=<string>",
+                            "host": [
+                                "{{test_base_url}}"
+                            ],
+                            "path": [
+                                "tracks"
+                            ],
+                            "query": [
+                                {
+                                    "key": "permalink",
+                                    "value": "<string>",
+                                    "description": "The permalink of the track(s)"
+                                },
+                                {
+                                    "key": "permalink",
+                                    "value": "<string>",
+                                    "description": "The permalink of the track(s)"
+                                },
+                                {
+                                    "key": "id",
+                                    "value": "<string>",
+                                    "description": "The ID of the track(s)"
+                                },
+                                {
+                                    "key": "id",
+                                    "value": "<string>",
+                                    "description": "The ID of the track(s)"
+                                }
+                            ]
+                        },
+                        "description": "Gets a list of tracks using their IDs or permalinks"
+                    },
+                    "response": [
+                        {
+                            "name": "Success",
+                            "originalRequest": {
+                                "method": "GET",
+                                "header": [
+                                    {
+                                        "key": "Accept",
+                                        "value": "application/json"
+                                    }
+                                ],
+                                "url": {
+                                    "raw": "{{baseUrl}}/tracks?permalink=<string>&id=<string>",
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "path": [
+                                        "tracks"
+                                    ],
+                                    "query": [
+                                        {
+                                            "key": "permalink",
+                                            "value": "<string>",
+                                            "description": "The permalink of the track(s)"
+                                        },
+                                        {
+                                            "key": "id",
+                                            "value": "<string>",
+                                            "description": "The ID of the track(s)"
+                                        }
+                                    ]
+                                }
+                            },
+                            "status": "OK",
+                            "code": 200,
+                            "_postman_previewlanguage": "json",
+                            "header": [
+                                {
+                                    "key": "Content-Type",
+                                    "value": "application/json"
+                                }
+                            ],
+                            "cookie": [],
+                            "body": "{\n  \"data\": [\n    {\n      \"duration\": \"<integer>\",\n      \"favorite_count\": \"<integer>\",\n      \"id\": \"<string>\",\n      \"play_count\": \"<integer>\",\n      \"repost_count\": \"<integer>\",\n      \"title\": \"<string>\",\n      \"user\": {\n        \"album_count\": \"<integer>\",\n        \"erc_wallet\": \"<string>\",\n        \"followee_count\": \"<integer>\",\n        \"follower_count\": \"<integer>\",\n        \"handle\": \"<string>\",\n        \"id\": \"<string>\",\n        \"is_available\": \"<boolean>\",\n        \"is_deactivated\": \"<boolean>\",\n        \"is_verified\": \"<boolean>\",\n        \"name\": \"<string>\",\n        \"playlist_count\": \"<integer>\",\n        \"repost_count\": \"<integer>\",\n        \"spl_wallet\": \"<string>\",\n        \"supporter_count\": \"<integer>\",\n        \"supporting_count\": \"<integer>\",\n        \"total_audio_balance\": \"<integer>\",\n        \"track_count\": \"<integer>\",\n        \"artist_pick_track_id\": \"<string>\",\n        \"bio\": \"<string>\",\n        \"cover_photo\": {\n          \"640x\": \"<string>\",\n          \"2000x\": \"<string>\"\n        },\n        \"does_follow_current_user\": \"<boolean>\",\n        \"location\": \"<string>\",\n        \"profile_picture\": {\n          \"150x150\": \"<string>\",\n          \"480x480\": \"<string>\",\n          \"1000x1000\": \"<string>\"\n        }\n      },\n      \"artwork\": {\n        \"150x150\": \"<string>\",\n        \"480x480\": \"<string>\",\n        \"1000x1000\": \"<string>\"\n      },\n      \"description\": \"<string>\",\n      \"genre\": \"<string>\",\n      \"track_cid\": \"<string>\",\n      \"preview_cid\": \"<string>\",\n      \"mood\": \"<string>\",\n      \"release_date\": \"<string>\",\n      \"remix_of\": {\n        \"tracks\": [\n          {\n            \"parent_track_id\": \"<string>\"\n          },\n          {\n            \"parent_track_id\": \"<string>\"\n          }\n        ]\n      },\n      \"tags\": \"<string>\",\n      \"downloadable\": \"<boolean>\",\n      \"permalink\": \"<string>\",\n      \"is_streamable\": \"<boolean>\"\n    },\n    {\n      \"duration\": \"<integer>\",\n      \"favorite_count\": \"<integer>\",\n      \"id\": \"<string>\",\n      \"play_count\": \"<integer>\",\n      \"repost_count\": \"<integer>\",\n      \"title\": \"<string>\",\n      \"user\": {\n        \"album_count\": \"<integer>\",\n        \"erc_wallet\": \"<string>\",\n        \"followee_count\": \"<integer>\",\n        \"follower_count\": \"<integer>\",\n        \"handle\": \"<string>\",\n        \"id\": \"<string>\",\n        \"is_available\": \"<boolean>\",\n        \"is_deactivated\": \"<boolean>\",\n        \"is_verified\": \"<boolean>\",\n        \"name\": \"<string>\",\n        \"playlist_count\": \"<integer>\",\n        \"repost_count\": \"<integer>\",\n        \"spl_wallet\": \"<string>\",\n        \"supporter_count\": \"<integer>\",\n        \"supporting_count\": \"<integer>\",\n        \"total_audio_balance\": \"<integer>\",\n        \"track_count\": \"<integer>\",\n        \"artist_pick_track_id\": \"<string>\",\n        \"bio\": \"<string>\",\n        \"cover_photo\": {\n          \"640x\": \"<string>\",\n          \"2000x\": \"<string>\"\n        },\n        \"does_follow_current_user\": \"<boolean>\",\n        \"location\": \"<string>\",\n        \"profile_picture\": {\n          \"150x150\": \"<string>\",\n          \"480x480\": \"<string>\",\n          \"1000x1000\": \"<string>\"\n        }\n      },\n      \"artwork\": {\n        \"150x150\": \"<string>\",\n        \"480x480\": \"<string>\",\n        \"1000x1000\": \"<string>\"\n      },\n      \"description\": \"<string>\",\n      \"genre\": \"<string>\",\n      \"track_cid\": \"<string>\",\n      \"preview_cid\": \"<string>\",\n      \"mood\": \"<string>\",\n      \"release_date\": \"<string>\",\n      \"remix_of\": {\n        \"tracks\": [\n          {\n            \"parent_track_id\": \"<string>\"\n          },\n          {\n            \"parent_track_id\": \"<string>\"\n          }\n        ]\n      },\n      \"tags\": \"<string>\",\n      \"downloadable\": \"<boolean>\",\n      \"permalink\": \"<string>\",\n      \"is_streamable\": \"<boolean>\"\n    }\n  ]\n}"
+                        },
+                        {
+                            "name": "Bad request",
+                            "originalRequest": {
+                                "method": "GET",
+                                "header": [],
+                                "url": {
+                                    "raw": "{{baseUrl}}/tracks?permalink=<string>&id=<string>",
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "path": [
+                                        "tracks"
+                                    ],
+                                    "query": [
+                                        {
+                                            "key": "permalink",
+                                            "value": "<string>",
+                                            "description": "The permalink of the track(s)"
+                                        },
+                                        {
+                                            "key": "id",
+                                            "value": "<string>",
+                                            "description": "The ID of the track(s)"
+                                        }
+                                    ]
+                                }
+                            },
+                            "status": "Bad Request",
+                            "code": 400,
+                            "_postman_previewlanguage": "text",
+                            "header": [],
+                            "cookie": [],
+                            "body": ""
+                        },
+                        {
+                            "name": "Server error",
+                            "originalRequest": {
+                                "method": "GET",
+                                "header": [],
+                                "url": {
+                                    "raw": "{{baseUrl}}/tracks?permalink=<string>&id=<string>",
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "path": [
+                                        "tracks"
+                                    ],
+                                    "query": [
+                                        {
+                                            "key": "permalink",
+                                            "value": "<string>",
+                                            "description": "The permalink of the track(s)"
+                                        },
+                                        {
+                                            "key": "id",
+                                            "value": "<string>",
+                                            "description": "The ID of the track(s)"
+                                        }
+                                    ]
+                                }
+                            },
+                            "status": "Internal Server Error",
+                            "code": 500,
+                            "_postman_previewlanguage": "text",
+                            "header": [],
+                            "cookie": [],
+                            "body": ""
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "name": "users",
+            "item": [
+                {
+                    "name": "handle",
+                    "item": [
+                        {
+                            "name": "{handle}",
+                            "item": [
+                                {
+                                    "name": "tracks",
+                                    "item": [
+                                        {
+                                            "name": "ai_attributed",
+                                            "item": [
+                                                {
+                                                    "name": "Get AI Attributed Tracks by User Handle",
+                                                    "request": {
+                                                        "method": "GET",
+                                                        "header": [
+                                                            {
+                                                                "key": "Accept",
+                                                                "value": "application/json"
+                                                            }
+                                                        ],
+                                                        "url": {
+                                                            "raw": "{{test_base_url}}/users/handle/{{user_handle}}/tracks/ai_attributed?offset=0&limit=10&user_id={{user_id}}&sort=date&sort_method=release_date&sort_direction=asc&filter_tracks=all",
+                                                            "host": [
+                                                                "{{test_base_url}}"
+                                                            ],
+                                                            "path": [
+                                                                "users",
+                                                                "handle",
+                                                                "{{user_handle}}",
+                                                                "tracks",
+                                                                "ai_attributed"
+                                                            ],
+                                                            "query": [
+                                                                {
+                                                                    "key": "offset",
+                                                                    "value": "0",
+                                                                    "description": "The number of items to skip. Useful for pagination (page number * limit)"
+                                                                },
+                                                                {
+                                                                    "key": "limit",
+                                                                    "value": "10",
+                                                                    "description": "The number of items to fetch"
+                                                                },
+                                                                {
+                                                                    "key": "user_id",
+                                                                    "value": "{{user_id}}",
+                                                                    "description": "The user ID of the user making the request"
+                                                                },
+                                                                {
+                                                                    "key": "sort",
+                                                                    "value": "date",
+                                                                    "description": "[Deprecated] Field to sort by"
+                                                                },
+                                                                {
+                                                                    "key": "sort_method",
+                                                                    "value": "release_date",
+                                                                    "description": "The sort method"
+                                                                },
+                                                                {
+                                                                    "key": "sort_direction",
+                                                                    "value": "asc",
+                                                                    "description": "The sort direction"
+                                                                },
+                                                                {
+                                                                    "key": "filter_tracks",
+                                                                    "value": "all",
+                                                                    "description": "Filter by unlisted or public tracks"
+                                                                }
+                                                            ]
+                                                        },
+                                                        "description": "Gets the AI generated tracks attributed to a user using the user's handle"
+                                                    },
+                                                    "response": [
+                                                        {
+                                                            "name": "Success",
+                                                            "originalRequest": {
+                                                                "method": "GET",
+                                                                "header": [
+                                                                    {
+                                                                        "key": "Accept",
+                                                                        "value": "application/json"
+                                                                    }
+                                                                ],
+                                                                "url": {
+                                                                    "raw": "{{baseUrl}}/users/handle/:handle/tracks/ai_attributed?offset=<integer>&limit=<integer>&user_id=<string>&sort=date&query=<string>&sort_method=release_date&sort_direction=asc&filter_tracks=all",
+                                                                    "host": [
+                                                                        "{{baseUrl}}"
+                                                                    ],
+                                                                    "path": [
+                                                                        "users",
+                                                                        "handle",
+                                                                        ":handle",
+                                                                        "tracks",
+                                                                        "ai_attributed"
+                                                                    ],
+                                                                    "query": [
+                                                                        {
+                                                                            "key": "offset",
+                                                                            "value": "<integer>",
+                                                                            "description": "The number of items to skip. Useful for pagination (page number * limit)"
+                                                                        },
+                                                                        {
+                                                                            "key": "limit",
+                                                                            "value": "<integer>",
+                                                                            "description": "The number of items to fetch"
+                                                                        },
+                                                                        {
+                                                                            "key": "user_id",
+                                                                            "value": "<string>",
+                                                                            "description": "The user ID of the user making the request"
+                                                                        },
+                                                                        {
+                                                                            "key": "sort",
+                                                                            "value": "date",
+                                                                            "description": "[Deprecated] Field to sort by"
+                                                                        },
+                                                                        {
+                                                                            "key": "query",
+                                                                            "value": "<string>",
+                                                                            "description": "The filter query"
+                                                                        },
+                                                                        {
+                                                                            "key": "sort_method",
+                                                                            "value": "release_date",
+                                                                            "description": "The sort method"
+                                                                        },
+                                                                        {
+                                                                            "key": "sort_direction",
+                                                                            "value": "asc",
+                                                                            "description": "The sort direction"
+                                                                        },
+                                                                        {
+                                                                            "key": "filter_tracks",
+                                                                            "value": "all",
+                                                                            "description": "Filter by unlisted or public tracks"
+                                                                        }
+                                                                    ],
+                                                                    "variable": [
+                                                                        {
+                                                                            "key": "handle"
+                                                                        }
+                                                                    ]
+                                                                }
+                                                            },
+                                                            "status": "OK",
+                                                            "code": 200,
+                                                            "_postman_previewlanguage": "json",
+                                                            "header": [
+                                                                {
+                                                                    "key": "Content-Type",
+                                                                    "value": "application/json"
+                                                                }
+                                                            ],
+                                                            "cookie": [],
+                                                            "body": "{\n  \"data\": [\n    {\n      \"duration\": \"<integer>\",\n      \"favorite_count\": \"<integer>\",\n      \"id\": \"<string>\",\n      \"play_count\": \"<integer>\",\n      \"repost_count\": \"<integer>\",\n      \"title\": \"<string>\",\n      \"user\": {\n        \"album_count\": \"<integer>\",\n        \"erc_wallet\": \"<string>\",\n        \"followee_count\": \"<integer>\",\n        \"follower_count\": \"<integer>\",\n        \"handle\": \"<string>\",\n        \"id\": \"<string>\",\n        \"is_available\": \"<boolean>\",\n        \"is_deactivated\": \"<boolean>\",\n        \"is_verified\": \"<boolean>\",\n        \"name\": \"<string>\",\n        \"playlist_count\": \"<integer>\",\n        \"repost_count\": \"<integer>\",\n        \"spl_wallet\": \"<string>\",\n        \"supporter_count\": \"<integer>\",\n        \"supporting_count\": \"<integer>\",\n        \"total_audio_balance\": \"<integer>\",\n        \"track_count\": \"<integer>\",\n        \"artist_pick_track_id\": \"<string>\",\n        \"bio\": \"<string>\",\n        \"cover_photo\": {\n          \"640x\": \"<string>\",\n          \"2000x\": \"<string>\"\n        },\n        \"does_follow_current_user\": \"<boolean>\",\n        \"location\": \"<string>\",\n        \"profile_picture\": {\n          \"150x150\": \"<string>\",\n          \"480x480\": \"<string>\",\n          \"1000x1000\": \"<string>\"\n        }\n      },\n      \"artwork\": {\n        \"150x150\": \"<string>\",\n        \"480x480\": \"<string>\",\n        \"1000x1000\": \"<string>\"\n      },\n      \"description\": \"<string>\",\n      \"genre\": \"<string>\",\n      \"track_cid\": \"<string>\",\n      \"preview_cid\": \"<string>\",\n      \"mood\": \"<string>\",\n      \"release_date\": \"<string>\",\n      \"remix_of\": {\n        \"tracks\": [\n          {\n            \"parent_track_id\": \"<string>\"\n          },\n          {\n            \"parent_track_id\": \"<string>\"\n          }\n        ]\n      },\n      \"tags\": \"<string>\",\n      \"downloadable\": \"<boolean>\",\n      \"permalink\": \"<string>\",\n      \"is_streamable\": \"<boolean>\"\n    },\n    {\n      \"duration\": \"<integer>\",\n      \"favorite_count\": \"<integer>\",\n      \"id\": \"<string>\",\n      \"play_count\": \"<integer>\",\n      \"repost_count\": \"<integer>\",\n      \"title\": \"<string>\",\n      \"user\": {\n        \"album_count\": \"<integer>\",\n        \"erc_wallet\": \"<string>\",\n        \"followee_count\": \"<integer>\",\n        \"follower_count\": \"<integer>\",\n        \"handle\": \"<string>\",\n        \"id\": \"<string>\",\n        \"is_available\": \"<boolean>\",\n        \"is_deactivated\": \"<boolean>\",\n        \"is_verified\": \"<boolean>\",\n        \"name\": \"<string>\",\n        \"playlist_count\": \"<integer>\",\n        \"repost_count\": \"<integer>\",\n        \"spl_wallet\": \"<string>\",\n        \"supporter_count\": \"<integer>\",\n        \"supporting_count\": \"<integer>\",\n        \"total_audio_balance\": \"<integer>\",\n        \"track_count\": \"<integer>\",\n        \"artist_pick_track_id\": \"<string>\",\n        \"bio\": \"<string>\",\n        \"cover_photo\": {\n          \"640x\": \"<string>\",\n          \"2000x\": \"<string>\"\n        },\n        \"does_follow_current_user\": \"<boolean>\",\n        \"location\": \"<string>\",\n        \"profile_picture\": {\n          \"150x150\": \"<string>\",\n          \"480x480\": \"<string>\",\n          \"1000x1000\": \"<string>\"\n        }\n      },\n      \"artwork\": {\n        \"150x150\": \"<string>\",\n        \"480x480\": \"<string>\",\n        \"1000x1000\": \"<string>\"\n      },\n      \"description\": \"<string>\",\n      \"genre\": \"<string>\",\n      \"track_cid\": \"<string>\",\n      \"preview_cid\": \"<string>\",\n      \"mood\": \"<string>\",\n      \"release_date\": \"<string>\",\n      \"remix_of\": {\n        \"tracks\": [\n          {\n            \"parent_track_id\": \"<string>\"\n          },\n          {\n            \"parent_track_id\": \"<string>\"\n          }\n        ]\n      },\n      \"tags\": \"<string>\",\n      \"downloadable\": \"<boolean>\",\n      \"permalink\": \"<string>\",\n      \"is_streamable\": \"<boolean>\"\n    }\n  ]\n}"
+                                                        },
+                                                        {
+                                                            "name": "Bad request",
+                                                            "originalRequest": {
+                                                                "method": "GET",
+                                                                "header": [],
+                                                                "url": {
+                                                                    "raw": "{{baseUrl}}/users/handle/:handle/tracks/ai_attributed?offset=<integer>&limit=<integer>&user_id=<string>&sort=date&query=<string>&sort_method=release_date&sort_direction=asc&filter_tracks=all",
+                                                                    "host": [
+                                                                        "{{baseUrl}}"
+                                                                    ],
+                                                                    "path": [
+                                                                        "users",
+                                                                        "handle",
+                                                                        ":handle",
+                                                                        "tracks",
+                                                                        "ai_attributed"
+                                                                    ],
+                                                                    "query": [
+                                                                        {
+                                                                            "key": "offset",
+                                                                            "value": "<integer>",
+                                                                            "description": "The number of items to skip. Useful for pagination (page number * limit)"
+                                                                        },
+                                                                        {
+                                                                            "key": "limit",
+                                                                            "value": "<integer>",
+                                                                            "description": "The number of items to fetch"
+                                                                        },
+                                                                        {
+                                                                            "key": "user_id",
+                                                                            "value": "<string>",
+                                                                            "description": "The user ID of the user making the request"
+                                                                        },
+                                                                        {
+                                                                            "key": "sort",
+                                                                            "value": "date",
+                                                                            "description": "[Deprecated] Field to sort by"
+                                                                        },
+                                                                        {
+                                                                            "key": "query",
+                                                                            "value": "<string>",
+                                                                            "description": "The filter query"
+                                                                        },
+                                                                        {
+                                                                            "key": "sort_method",
+                                                                            "value": "release_date",
+                                                                            "description": "The sort method"
+                                                                        },
+                                                                        {
+                                                                            "key": "sort_direction",
+                                                                            "value": "asc",
+                                                                            "description": "The sort direction"
+                                                                        },
+                                                                        {
+                                                                            "key": "filter_tracks",
+                                                                            "value": "all",
+                                                                            "description": "Filter by unlisted or public tracks"
+                                                                        }
+                                                                    ],
+                                                                    "variable": [
+                                                                        {
+                                                                            "key": "handle"
+                                                                        }
+                                                                    ]
+                                                                }
+                                                            },
+                                                            "status": "Bad Request",
+                                                            "code": 400,
+                                                            "_postman_previewlanguage": "text",
+                                                            "header": [],
+                                                            "cookie": [],
+                                                            "body": ""
+                                                        },
+                                                        {
+                                                            "name": "Server error",
+                                                            "originalRequest": {
+                                                                "method": "GET",
+                                                                "header": [],
+                                                                "url": {
+                                                                    "raw": "{{baseUrl}}/users/handle/:handle/tracks/ai_attributed?offset=<integer>&limit=<integer>&user_id=<string>&sort=date&query=<string>&sort_method=release_date&sort_direction=asc&filter_tracks=all",
+                                                                    "host": [
+                                                                        "{{baseUrl}}"
+                                                                    ],
+                                                                    "path": [
+                                                                        "users",
+                                                                        "handle",
+                                                                        ":handle",
+                                                                        "tracks",
+                                                                        "ai_attributed"
+                                                                    ],
+                                                                    "query": [
+                                                                        {
+                                                                            "key": "offset",
+                                                                            "value": "<integer>",
+                                                                            "description": "The number of items to skip. Useful for pagination (page number * limit)"
+                                                                        },
+                                                                        {
+                                                                            "key": "limit",
+                                                                            "value": "<integer>",
+                                                                            "description": "The number of items to fetch"
+                                                                        },
+                                                                        {
+                                                                            "key": "user_id",
+                                                                            "value": "<string>",
+                                                                            "description": "The user ID of the user making the request"
+                                                                        },
+                                                                        {
+                                                                            "key": "sort",
+                                                                            "value": "date",
+                                                                            "description": "[Deprecated] Field to sort by"
+                                                                        },
+                                                                        {
+                                                                            "key": "query",
+                                                                            "value": "<string>",
+                                                                            "description": "The filter query"
+                                                                        },
+                                                                        {
+                                                                            "key": "sort_method",
+                                                                            "value": "release_date",
+                                                                            "description": "The sort method"
+                                                                        },
+                                                                        {
+                                                                            "key": "sort_direction",
+                                                                            "value": "asc",
+                                                                            "description": "The sort direction"
+                                                                        },
+                                                                        {
+                                                                            "key": "filter_tracks",
+                                                                            "value": "all",
+                                                                            "description": "Filter by unlisted or public tracks"
+                                                                        }
+                                                                    ],
+                                                                    "variable": [
+                                                                        {
+                                                                            "key": "handle"
+                                                                        }
+                                                                    ]
+                                                                }
+                                                            },
+                                                            "status": "Internal Server Error",
+                                                            "code": 500,
+                                                            "_postman_previewlanguage": "text",
+                                                            "header": [],
+                                                            "cookie": [],
+                                                            "body": ""
+                                                        }
+                                                    ]
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                },
+                                {
+                                    "name": "Get User by Handle",
+                                    "request": {
+                                        "method": "GET",
+                                        "header": [
+                                            {
+                                                "key": "Accept",
+                                                "value": "application/json"
+                                            }
+                                        ],
+                                        "url": {
+                                            "raw": "{{test_base_url}}/users/handle/{{user_handle}}?user_id={{user_id}}",
+                                            "host": [
+                                                "{{test_base_url}}"
+                                            ],
+                                            "path": [
+                                                "users",
+                                                "handle",
+                                                "{{user_handle}}"
+                                            ],
+                                            "query": [
+                                                {
+                                                    "key": "user_id",
+                                                    "value": "{{user_id}}",
+                                                    "description": "The user ID of the user making the request"
+                                                }
+                                            ]
+                                        },
+                                        "description": "Gets a single user by their handle"
+                                    },
+                                    "response": [
+                                        {
+                                            "name": "Success",
+                                            "originalRequest": {
+                                                "method": "GET",
+                                                "header": [
+                                                    {
+                                                        "key": "Accept",
+                                                        "value": "application/json"
+                                                    }
+                                                ],
+                                                "url": {
+                                                    "raw": "{{baseUrl}}/users/handle/:handle?user_id=<string>",
+                                                    "host": [
+                                                        "{{baseUrl}}"
+                                                    ],
+                                                    "path": [
+                                                        "users",
+                                                        "handle",
+                                                        ":handle"
+                                                    ],
+                                                    "query": [
+                                                        {
+                                                            "key": "user_id",
+                                                            "value": "<string>",
+                                                            "description": "The user ID of the user making the request"
+                                                        }
+                                                    ],
+                                                    "variable": [
+                                                        {
+                                                            "key": "handle"
+                                                        }
+                                                    ]
+                                                }
+                                            },
+                                            "status": "OK",
+                                            "code": 200,
+                                            "_postman_previewlanguage": "json",
+                                            "header": [
+                                                {
+                                                    "key": "Content-Type",
+                                                    "value": "application/json"
+                                                }
+                                            ],
+                                            "cookie": [],
+                                            "body": "{\n  \"data\": {\n    \"album_count\": \"<integer>\",\n    \"erc_wallet\": \"<string>\",\n    \"followee_count\": \"<integer>\",\n    \"follower_count\": \"<integer>\",\n    \"handle\": \"<string>\",\n    \"id\": \"<string>\",\n    \"is_available\": \"<boolean>\",\n    \"is_deactivated\": \"<boolean>\",\n    \"is_verified\": \"<boolean>\",\n    \"name\": \"<string>\",\n    \"playlist_count\": \"<integer>\",\n    \"repost_count\": \"<integer>\",\n    \"spl_wallet\": \"<string>\",\n    \"supporter_count\": \"<integer>\",\n    \"supporting_count\": \"<integer>\",\n    \"total_audio_balance\": \"<integer>\",\n    \"track_count\": \"<integer>\",\n    \"artist_pick_track_id\": \"<string>\",\n    \"bio\": \"<string>\",\n    \"cover_photo\": {\n      \"640x\": \"<string>\",\n      \"2000x\": \"<string>\"\n    },\n    \"does_follow_current_user\": \"<boolean>\",\n    \"location\": \"<string>\",\n    \"profile_picture\": {\n      \"150x150\": \"<string>\",\n      \"480x480\": \"<string>\",\n      \"1000x1000\": \"<string>\"\n    }\n  }\n}"
+                                        },
+                                        {
+                                            "name": "Bad request",
+                                            "originalRequest": {
+                                                "method": "GET",
+                                                "header": [],
+                                                "url": {
+                                                    "raw": "{{baseUrl}}/users/handle/:handle?user_id=<string>",
+                                                    "host": [
+                                                        "{{baseUrl}}"
+                                                    ],
+                                                    "path": [
+                                                        "users",
+                                                        "handle",
+                                                        ":handle"
+                                                    ],
+                                                    "query": [
+                                                        {
+                                                            "key": "user_id",
+                                                            "value": "<string>",
+                                                            "description": "The user ID of the user making the request"
+                                                        }
+                                                    ],
+                                                    "variable": [
+                                                        {
+                                                            "key": "handle"
+                                                        }
+                                                    ]
+                                                }
+                                            },
+                                            "status": "Bad Request",
+                                            "code": 400,
+                                            "_postman_previewlanguage": "text",
+                                            "header": [],
+                                            "cookie": [],
+                                            "body": ""
+                                        },
+                                        {
+                                            "name": "Server error",
+                                            "originalRequest": {
+                                                "method": "GET",
+                                                "header": [],
+                                                "url": {
+                                                    "raw": "{{baseUrl}}/users/handle/:handle?user_id=<string>",
+                                                    "host": [
+                                                        "{{baseUrl}}"
+                                                    ],
+                                                    "path": [
+                                                        "users",
+                                                        "handle",
+                                                        ":handle"
+                                                    ],
+                                                    "query": [
+                                                        {
+                                                            "key": "user_id",
+                                                            "value": "<string>",
+                                                            "description": "The user ID of the user making the request"
+                                                        }
+                                                    ],
+                                                    "variable": [
+                                                        {
+                                                            "key": "handle"
+                                                        }
+                                                    ]
+                                                }
+                                            },
+                                            "status": "Internal Server Error",
+                                            "code": 500,
+                                            "_postman_previewlanguage": "text",
+                                            "header": [],
+                                            "cookie": [],
+                                            "body": ""
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "name": "id",
+                    "item": [
+                        {
+                            "name": "Get User ID from Wallet",
+                            "request": {
+                                "method": "GET",
+                                "header": [
+                                    {
+                                        "key": "Accept",
+                                        "value": "application/json"
+                                    }
+                                ],
+                                "url": {
+                                    "raw": "{{test_base_url}}/users/id?associated_wallet=0x712f316713f5e859b58f63e1a4f55d432ad0b67f",
+                                    "host": [
+                                        "{{test_base_url}}"
+                                    ],
+                                    "path": [
+                                        "users",
+                                        "id"
+                                    ],
+                                    "query": [
+                                        {
+                                            "key": "associated_wallet",
+                                            "value": "0x712f316713f5e859b58f63e1a4f55d432ad0b67f",
+                                            "description": "(Required) Wallet address"
+                                        }
+                                    ]
+                                },
+                                "description": "Gets a User ID from an associated wallet address"
+                            },
+                            "response": [
+                                {
+                                    "name": "Success",
+                                    "originalRequest": {
+                                        "method": "GET",
+                                        "header": [
+                                            {
+                                                "key": "Accept",
+                                                "value": "application/json"
+                                            }
+                                        ],
+                                        "url": {
+                                            "raw": "{{baseUrl}}/users/id?associated_wallet=<string>",
+                                            "host": [
+                                                "{{baseUrl}}"
+                                            ],
+                                            "path": [
+                                                "users",
+                                                "id"
+                                            ],
+                                            "query": [
+                                                {
+                                                    "key": "associated_wallet",
+                                                    "value": "<string>",
+                                                    "description": "(Required) Wallet address"
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    "status": "OK",
+                                    "code": 200,
+                                    "_postman_previewlanguage": "json",
+                                    "header": [
+                                        {
+                                            "key": "Content-Type",
+                                            "value": "application/json"
+                                        }
+                                    ],
+                                    "cookie": [],
+                                    "body": "{\n  \"data\": {\n    \"user_id\": \"<string>\"\n  }\n}"
+                                },
+                                {
+                                    "name": "Bad request",
+                                    "originalRequest": {
+                                        "method": "GET",
+                                        "header": [],
+                                        "url": {
+                                            "raw": "{{baseUrl}}/users/id?associated_wallet=<string>",
+                                            "host": [
+                                                "{{baseUrl}}"
+                                            ],
+                                            "path": [
+                                                "users",
+                                                "id"
+                                            ],
+                                            "query": [
+                                                {
+                                                    "key": "associated_wallet",
+                                                    "value": "<string>",
+                                                    "description": "(Required) Wallet address"
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    "status": "Bad Request",
+                                    "code": 400,
+                                    "_postman_previewlanguage": "text",
+                                    "header": [],
+                                    "cookie": [],
+                                    "body": ""
+                                },
+                                {
+                                    "name": "Server error",
+                                    "originalRequest": {
+                                        "method": "GET",
+                                        "header": [],
+                                        "url": {
+                                            "raw": "{{baseUrl}}/users/id?associated_wallet=<string>",
+                                            "host": [
+                                                "{{baseUrl}}"
+                                            ],
+                                            "path": [
+                                                "users",
+                                                "id"
+                                            ],
+                                            "query": [
+                                                {
+                                                    "key": "associated_wallet",
+                                                    "value": "<string>",
+                                                    "description": "(Required) Wallet address"
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    "status": "Internal Server Error",
+                                    "code": 500,
+                                    "_postman_previewlanguage": "text",
+                                    "header": [],
+                                    "cookie": [],
+                                    "body": ""
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "name": "search",
+                    "item": [
+                        {
+                            "name": "Search Users",
+                            "request": {
+                                "method": "GET",
+                                "header": [
+                                    {
+                                        "key": "Accept",
+                                        "value": "application/json"
+                                    }
+                                ],
+                                "url": {
+                                    "raw": "{{test_base_url}}/users/search?query=sav",
+                                    "host": [
+                                        "{{test_base_url}}"
+                                    ],
+                                    "path": [
+                                        "users",
+                                        "search"
+                                    ],
+                                    "query": [
+                                        {
+                                            "key": "query",
+                                            "value": "sav",
+                                            "description": "(Required) The search query"
+                                        }
+                                    ]
+                                },
+                                "description": "Search for users that match the given query"
+                            },
+                            "response": [
+                                {
+                                    "name": "Success",
+                                    "originalRequest": {
+                                        "method": "GET",
+                                        "header": [
+                                            {
+                                                "key": "Accept",
+                                                "value": "application/json"
+                                            }
+                                        ],
+                                        "url": {
+                                            "raw": "{{baseUrl}}/users/search?query=<string>",
+                                            "host": [
+                                                "{{baseUrl}}"
+                                            ],
+                                            "path": [
+                                                "users",
+                                                "search"
+                                            ],
+                                            "query": [
+                                                {
+                                                    "key": "query",
+                                                    "value": "<string>",
+                                                    "description": "(Required) The search query"
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    "status": "OK",
+                                    "code": 200,
+                                    "_postman_previewlanguage": "json",
+                                    "header": [
+                                        {
+                                            "key": "Content-Type",
+                                            "value": "application/json"
+                                        }
+                                    ],
+                                    "cookie": [],
+                                    "body": "{\n  \"data\": [\n    {\n      \"album_count\": \"<integer>\",\n      \"erc_wallet\": \"<string>\",\n      \"followee_count\": \"<integer>\",\n      \"follower_count\": \"<integer>\",\n      \"handle\": \"<string>\",\n      \"id\": \"<string>\",\n      \"is_available\": \"<boolean>\",\n      \"is_deactivated\": \"<boolean>\",\n      \"is_verified\": \"<boolean>\",\n      \"name\": \"<string>\",\n      \"playlist_count\": \"<integer>\",\n      \"repost_count\": \"<integer>\",\n      \"spl_wallet\": \"<string>\",\n      \"supporter_count\": \"<integer>\",\n      \"supporting_count\": \"<integer>\",\n      \"total_audio_balance\": \"<integer>\",\n      \"track_count\": \"<integer>\",\n      \"artist_pick_track_id\": \"<string>\",\n      \"bio\": \"<string>\",\n      \"cover_photo\": {\n        \"640x\": \"<string>\",\n        \"2000x\": \"<string>\"\n      },\n      \"does_follow_current_user\": \"<boolean>\",\n      \"location\": \"<string>\",\n      \"profile_picture\": {\n        \"150x150\": \"<string>\",\n        \"480x480\": \"<string>\",\n        \"1000x1000\": \"<string>\"\n      }\n    },\n    {\n      \"album_count\": \"<integer>\",\n      \"erc_wallet\": \"<string>\",\n      \"followee_count\": \"<integer>\",\n      \"follower_count\": \"<integer>\",\n      \"handle\": \"<string>\",\n      \"id\": \"<string>\",\n      \"is_available\": \"<boolean>\",\n      \"is_deactivated\": \"<boolean>\",\n      \"is_verified\": \"<boolean>\",\n      \"name\": \"<string>\",\n      \"playlist_count\": \"<integer>\",\n      \"repost_count\": \"<integer>\",\n      \"spl_wallet\": \"<string>\",\n      \"supporter_count\": \"<integer>\",\n      \"supporting_count\": \"<integer>\",\n      \"total_audio_balance\": \"<integer>\",\n      \"track_count\": \"<integer>\",\n      \"artist_pick_track_id\": \"<string>\",\n      \"bio\": \"<string>\",\n      \"cover_photo\": {\n        \"640x\": \"<string>\",\n        \"2000x\": \"<string>\"\n      },\n      \"does_follow_current_user\": \"<boolean>\",\n      \"location\": \"<string>\",\n      \"profile_picture\": {\n        \"150x150\": \"<string>\",\n        \"480x480\": \"<string>\",\n        \"1000x1000\": \"<string>\"\n      }\n    }\n  ]\n}"
+                                },
+                                {
+                                    "name": "Bad request",
+                                    "originalRequest": {
+                                        "method": "GET",
+                                        "header": [],
+                                        "url": {
+                                            "raw": "{{baseUrl}}/users/search?query=<string>",
+                                            "host": [
+                                                "{{baseUrl}}"
+                                            ],
+                                            "path": [
+                                                "users",
+                                                "search"
+                                            ],
+                                            "query": [
+                                                {
+                                                    "key": "query",
+                                                    "value": "<string>",
+                                                    "description": "(Required) The search query"
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    "status": "Bad Request",
+                                    "code": 400,
+                                    "_postman_previewlanguage": "text",
+                                    "header": [],
+                                    "cookie": [],
+                                    "body": ""
+                                },
+                                {
+                                    "name": "Server error",
+                                    "originalRequest": {
+                                        "method": "GET",
+                                        "header": [],
+                                        "url": {
+                                            "raw": "{{baseUrl}}/users/search?query=<string>",
+                                            "host": [
+                                                "{{baseUrl}}"
+                                            ],
+                                            "path": [
+                                                "users",
+                                                "search"
+                                            ],
+                                            "query": [
+                                                {
+                                                    "key": "query",
+                                                    "value": "<string>",
+                                                    "description": "(Required) The search query"
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    "status": "Internal Server Error",
+                                    "code": 500,
+                                    "_postman_previewlanguage": "text",
+                                    "header": [],
+                                    "cookie": [],
+                                    "body": ""
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "name": "verify_token",
+                    "item": [
+                        {
+                            "name": "Verify ID Token",
+                            "request": {
+                                "method": "GET",
+                                "header": [
+                                    {
+                                        "key": "Accept",
+                                        "value": "application/json"
+                                    }
+                                ],
+                                "url": {
+                                    "raw": "{{test_base_url}}/users/verify_token?token=<string>",
+                                    "host": [
+                                        "{{test_base_url}}"
+                                    ],
+                                    "path": [
+                                        "users",
+                                        "verify_token"
+                                    ],
+                                    "query": [
+                                        {
+                                            "key": "token",
+                                            "value": "<string>",
+                                            "description": "(Required) JWT to verify"
+                                        }
+                                    ]
+                                },
+                                "description": "Verify if the given jwt ID token was signed by the subject (user) in the payload"
+                            },
+                            "response": [
+                                {
+                                    "name": "Success",
+                                    "originalRequest": {
+                                        "method": "GET",
+                                        "header": [
+                                            {
+                                                "key": "Accept",
+                                                "value": "application/json"
+                                            }
+                                        ],
+                                        "url": {
+                                            "raw": "{{baseUrl}}/users/verify_token?token=<string>",
+                                            "host": [
+                                                "{{baseUrl}}"
+                                            ],
+                                            "path": [
+                                                "users",
+                                                "verify_token"
+                                            ],
+                                            "query": [
+                                                {
+                                                    "key": "token",
+                                                    "value": "<string>",
+                                                    "description": "(Required) JWT to verify"
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    "status": "OK",
+                                    "code": 200,
+                                    "_postman_previewlanguage": "json",
+                                    "header": [
+                                        {
+                                            "key": "Content-Type",
+                                            "value": "application/json"
+                                        }
+                                    ],
+                                    "cookie": [],
+                                    "body": "{\n  \"data\": {\n    \"email\": \"<string>\",\n    \"handle\": \"<string>\",\n    \"iat\": \"<string>\",\n    \"name\": \"<string>\",\n    \"sub\": \"<string>\",\n    \"userId\": \"<string>\",\n    \"verified\": \"<boolean>\",\n    \"profilePicture\": {\n      \"150x150\": \"<string>\",\n      \"480x480\": \"<string>\",\n      \"1000x1000\": \"<string>\"\n    }\n  }\n}"
+                                },
+                                {
+                                    "name": "Bad input",
+                                    "originalRequest": {
+                                        "method": "GET",
+                                        "header": [],
+                                        "url": {
+                                            "raw": "{{baseUrl}}/users/verify_token?token=<string>",
+                                            "host": [
+                                                "{{baseUrl}}"
+                                            ],
+                                            "path": [
+                                                "users",
+                                                "verify_token"
+                                            ],
+                                            "query": [
+                                                {
+                                                    "key": "token",
+                                                    "value": "<string>",
+                                                    "description": "(Required) JWT to verify"
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    "status": "Bad Request",
+                                    "code": 400,
+                                    "_postman_previewlanguage": "text",
+                                    "header": [],
+                                    "cookie": [],
+                                    "body": ""
+                                },
+                                {
+                                    "name": "ID token not valid",
+                                    "originalRequest": {
+                                        "method": "GET",
+                                        "header": [],
+                                        "url": {
+                                            "raw": "{{baseUrl}}/users/verify_token?token=<string>",
+                                            "host": [
+                                                "{{baseUrl}}"
+                                            ],
+                                            "path": [
+                                                "users",
+                                                "verify_token"
+                                            ],
+                                            "query": [
+                                                {
+                                                    "key": "token",
+                                                    "value": "<string>",
+                                                    "description": "(Required) JWT to verify"
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    "status": "Not Found",
+                                    "code": 404,
+                                    "_postman_previewlanguage": "text",
+                                    "header": [],
+                                    "cookie": [],
+                                    "body": ""
+                                },
+                                {
+                                    "name": "Server error",
+                                    "originalRequest": {
+                                        "method": "GET",
+                                        "header": [],
+                                        "url": {
+                                            "raw": "{{baseUrl}}/users/verify_token?token=<string>",
+                                            "host": [
+                                                "{{baseUrl}}"
+                                            ],
+                                            "path": [
+                                                "users",
+                                                "verify_token"
+                                            ],
+                                            "query": [
+                                                {
+                                                    "key": "token",
+                                                    "value": "<string>",
+                                                    "description": "(Required) JWT to verify"
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    "status": "Internal Server Error",
+                                    "code": 500,
+                                    "_postman_previewlanguage": "text",
+                                    "header": [],
+                                    "cookie": [],
+                                    "body": ""
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "name": "{id}",
+                    "item": [
+                        {
+                            "name": "authorized_apps",
+                            "item": [
+                                {
+                                    "name": "Get Authorized Apps",
+                                    "request": {
+                                        "method": "GET",
+                                        "header": [
+                                            {
+                                                "key": "Accept",
+                                                "value": "application/json"
+                                            }
+                                        ],
+                                        "url": {
+                                            "raw": "{{test_base_url}}/users/{{user_id}}/authorized_apps",
+                                            "host": [
+                                                "{{test_base_url}}"
+                                            ],
+                                            "path": [
+                                                "users",
+                                                "{{user_id}}",
+                                                "authorized_apps"
+                                            ]
+                                        },
+                                        "description": "Get the apps that user has authorized to write to their account"
+                                    },
+                                    "response": [
+                                        {
+                                            "name": "Success",
+                                            "originalRequest": {
+                                                "method": "GET",
+                                                "header": [
+                                                    {
+                                                        "key": "Accept",
+                                                        "value": "application/json"
+                                                    }
+                                                ],
+                                                "url": {
+                                                    "raw": "{{baseUrl}}/users/:id/authorized_apps",
+                                                    "host": [
+                                                        "{{baseUrl}}"
+                                                    ],
+                                                    "path": [
+                                                        "users",
+                                                        ":id",
+                                                        "authorized_apps"
+                                                    ],
+                                                    "variable": [
+                                                        {
+                                                            "key": "id"
+                                                        }
+                                                    ]
+                                                }
+                                            },
+                                            "status": "OK",
+                                            "code": 200,
+                                            "_postman_previewlanguage": "json",
+                                            "header": [
+                                                {
+                                                    "key": "Content-Type",
+                                                    "value": "application/json"
+                                                }
+                                            ],
+                                            "cookie": [],
+                                            "body": "{\n  \"data\": [\n    {\n      \"address\": \"<string>\",\n      \"grant_created_at\": \"<string>\",\n      \"grant_updated_at\": \"<string>\",\n      \"grantor_user_id\": \"<string>\",\n      \"name\": \"<string>\",\n      \"description\": \"<string>\"\n    },\n    {\n      \"address\": \"<string>\",\n      \"grant_created_at\": \"<string>\",\n      \"grant_updated_at\": \"<string>\",\n      \"grantor_user_id\": \"<string>\",\n      \"name\": \"<string>\",\n      \"description\": \"<string>\"\n    }\n  ]\n}"
+                                        },
+                                        {
+                                            "name": "Bad request",
+                                            "originalRequest": {
+                                                "method": "GET",
+                                                "header": [],
+                                                "url": {
+                                                    "raw": "{{baseUrl}}/users/:id/authorized_apps",
+                                                    "host": [
+                                                        "{{baseUrl}}"
+                                                    ],
+                                                    "path": [
+                                                        "users",
+                                                        ":id",
+                                                        "authorized_apps"
+                                                    ],
+                                                    "variable": [
+                                                        {
+                                                            "key": "id"
+                                                        }
+                                                    ]
+                                                }
+                                            },
+                                            "status": "Bad Request",
+                                            "code": 400,
+                                            "_postman_previewlanguage": "text",
+                                            "header": [],
+                                            "cookie": [],
+                                            "body": ""
+                                        },
+                                        {
+                                            "name": "Server error",
+                                            "originalRequest": {
+                                                "method": "GET",
+                                                "header": [],
+                                                "url": {
+                                                    "raw": "{{baseUrl}}/users/:id/authorized_apps",
+                                                    "host": [
+                                                        "{{baseUrl}}"
+                                                    ],
+                                                    "path": [
+                                                        "users",
+                                                        ":id",
+                                                        "authorized_apps"
+                                                    ],
+                                                    "variable": [
+                                                        {
+                                                            "key": "id"
+                                                        }
+                                                    ]
+                                                }
+                                            },
+                                            "status": "Internal Server Error",
+                                            "code": 500,
+                                            "_postman_previewlanguage": "text",
+                                            "header": [],
+                                            "cookie": [],
+                                            "body": ""
+                                        }
+                                    ]
+                                }
+                            ]
+                        },
+                        {
+                            "name": "connected_wallets",
+                            "item": [
+                                {
+                                    "name": "Get connected wallets",
+                                    "request": {
+                                        "method": "GET",
+                                        "header": [
+                                            {
+                                                "key": "Accept",
+                                                "value": "application/json"
+                                            }
+                                        ],
+                                        "url": {
+                                            "raw": "{{test_base_url}}/users/{{user_id}}/connected_wallets",
+                                            "host": [
+                                                "{{test_base_url}}"
+                                            ],
+                                            "path": [
+                                                "users",
+                                                "{{user_id}}",
+                                                "connected_wallets"
+                                            ]
+                                        },
+                                        "description": "Get the User's ERC and SPL connected wallets"
+                                    },
+                                    "response": [
+                                        {
+                                            "name": "Success",
+                                            "originalRequest": {
+                                                "method": "GET",
+                                                "header": [
+                                                    {
+                                                        "key": "Accept",
+                                                        "value": "application/json"
+                                                    }
+                                                ],
+                                                "url": {
+                                                    "raw": "{{baseUrl}}/users/:id/connected_wallets",
+                                                    "host": [
+                                                        "{{baseUrl}}"
+                                                    ],
+                                                    "path": [
+                                                        "users",
+                                                        ":id",
+                                                        "connected_wallets"
+                                                    ],
+                                                    "variable": [
+                                                        {
+                                                            "key": "id"
+                                                        }
+                                                    ]
+                                                }
+                                            },
+                                            "status": "OK",
+                                            "code": 200,
+                                            "_postman_previewlanguage": "json",
+                                            "header": [
+                                                {
+                                                    "key": "Content-Type",
+                                                    "value": "application/json"
+                                                }
+                                            ],
+                                            "cookie": [],
+                                            "body": "{\n  \"data\": {\n    \"erc_wallets\": [\n      \"<string>\",\n      \"<string>\"\n    ],\n    \"spl_wallets\": [\n      \"<string>\",\n      \"<string>\"\n    ]\n  }\n}"
+                                        },
+                                        {
+                                            "name": "Bad request",
+                                            "originalRequest": {
+                                                "method": "GET",
+                                                "header": [],
+                                                "url": {
+                                                    "raw": "{{baseUrl}}/users/:id/connected_wallets",
+                                                    "host": [
+                                                        "{{baseUrl}}"
+                                                    ],
+                                                    "path": [
+                                                        "users",
+                                                        ":id",
+                                                        "connected_wallets"
+                                                    ],
+                                                    "variable": [
+                                                        {
+                                                            "key": "id"
+                                                        }
+                                                    ]
+                                                }
+                                            },
+                                            "status": "Bad Request",
+                                            "code": 400,
+                                            "_postman_previewlanguage": "text",
+                                            "header": [],
+                                            "cookie": [],
+                                            "body": ""
+                                        },
+                                        {
+                                            "name": "Server error",
+                                            "originalRequest": {
+                                                "method": "GET",
+                                                "header": [],
+                                                "url": {
+                                                    "raw": "{{baseUrl}}/users/:id/connected_wallets",
+                                                    "host": [
+                                                        "{{baseUrl}}"
+                                                    ],
+                                                    "path": [
+                                                        "users",
+                                                        ":id",
+                                                        "connected_wallets"
+                                                    ],
+                                                    "variable": [
+                                                        {
+                                                            "key": "id"
+                                                        }
+                                                    ]
+                                                }
+                                            },
+                                            "status": "Internal Server Error",
+                                            "code": 500,
+                                            "_postman_previewlanguage": "text",
+                                            "header": [],
+                                            "cookie": [],
+                                            "body": ""
+                                        }
+                                    ]
+                                }
+                            ]
+                        },
+                        {
+                            "name": "developer_apps",
+                            "item": [
+                                {
+                                    "name": "Get Developer Apps",
+                                    "request": {
+                                        "method": "GET",
+                                        "header": [
+                                            {
+                                                "key": "Accept",
+                                                "value": "application/json"
+                                            }
+                                        ],
+                                        "url": {
+                                            "raw": "{{test_base_url}}/users/{{user_id}}/developer_apps",
+                                            "host": [
+                                                "{{test_base_url}}"
+                                            ],
+                                            "path": [
+                                                "users",
+                                                "{{user_id}}",
+                                                "developer_apps"
+                                            ]
+                                        },
+                                        "description": "Gets the developer apps that the user owns"
+                                    },
+                                    "response": [
+                                        {
+                                            "name": "Success",
+                                            "originalRequest": {
+                                                "method": "GET",
+                                                "header": [
+                                                    {
+                                                        "key": "Accept",
+                                                        "value": "application/json"
+                                                    }
+                                                ],
+                                                "url": {
+                                                    "raw": "{{baseUrl}}/users/:id/developer_apps",
+                                                    "host": [
+                                                        "{{baseUrl}}"
+                                                    ],
+                                                    "path": [
+                                                        "users",
+                                                        ":id",
+                                                        "developer_apps"
+                                                    ],
+                                                    "variable": [
+                                                        {
+                                                            "key": "id"
+                                                        }
+                                                    ]
+                                                }
+                                            },
+                                            "status": "OK",
+                                            "code": 200,
+                                            "_postman_previewlanguage": "json",
+                                            "header": [
+                                                {
+                                                    "key": "Content-Type",
+                                                    "value": "application/json"
+                                                }
+                                            ],
+                                            "cookie": [],
+                                            "body": "{\n  \"data\": [\n    {\n      \"address\": \"<string>\",\n      \"name\": \"<string>\",\n      \"user_id\": \"<string>\",\n      \"description\": \"<string>\"\n    },\n    {\n      \"address\": \"<string>\",\n      \"name\": \"<string>\",\n      \"user_id\": \"<string>\",\n      \"description\": \"<string>\"\n    }\n  ]\n}"
+                                        },
+                                        {
+                                            "name": "Bad request",
+                                            "originalRequest": {
+                                                "method": "GET",
+                                                "header": [],
+                                                "url": {
+                                                    "raw": "{{baseUrl}}/users/:id/developer_apps",
+                                                    "host": [
+                                                        "{{baseUrl}}"
+                                                    ],
+                                                    "path": [
+                                                        "users",
+                                                        ":id",
+                                                        "developer_apps"
+                                                    ],
+                                                    "variable": [
+                                                        {
+                                                            "key": "id"
+                                                        }
+                                                    ]
+                                                }
+                                            },
+                                            "status": "Bad Request",
+                                            "code": 400,
+                                            "_postman_previewlanguage": "text",
+                                            "header": [],
+                                            "cookie": [],
+                                            "body": ""
+                                        },
+                                        {
+                                            "name": "Server error",
+                                            "originalRequest": {
+                                                "method": "GET",
+                                                "header": [],
+                                                "url": {
+                                                    "raw": "{{baseUrl}}/users/:id/developer_apps",
+                                                    "host": [
+                                                        "{{baseUrl}}"
+                                                    ],
+                                                    "path": [
+                                                        "users",
+                                                        ":id",
+                                                        "developer_apps"
+                                                    ],
+                                                    "variable": [
+                                                        {
+                                                            "key": "id"
+                                                        }
+                                                    ]
+                                                }
+                                            },
+                                            "status": "Internal Server Error",
+                                            "code": 500,
+                                            "_postman_previewlanguage": "text",
+                                            "header": [],
+                                            "cookie": [],
+                                            "body": ""
+                                        }
+                                    ]
+                                }
+                            ]
+                        },
+                        {
+                            "name": "favorites",
+                            "item": [
+                                {
+                                    "name": "Get Favorites",
+                                    "request": {
+                                        "method": "GET",
+                                        "header": [
+                                            {
+                                                "key": "Accept",
+                                                "value": "application/json"
+                                            }
+                                        ],
+                                        "url": {
+                                            "raw": "{{test_base_url}}/users/{{user_id}}/favorites",
+                                            "host": [
+                                                "{{test_base_url}}"
+                                            ],
+                                            "path": [
+                                                "users",
+                                                "{{user_id}}",
+                                                "favorites"
+                                            ]
+                                        },
+                                        "description": "Gets a user's favorite tracks"
+                                    },
+                                    "response": [
+                                        {
+                                            "name": "Success",
+                                            "originalRequest": {
+                                                "method": "GET",
+                                                "header": [
+                                                    {
+                                                        "key": "Accept",
+                                                        "value": "application/json"
+                                                    }
+                                                ],
+                                                "url": {
+                                                    "raw": "{{baseUrl}}/users/:id/favorites",
+                                                    "host": [
+                                                        "{{baseUrl}}"
+                                                    ],
+                                                    "path": [
+                                                        "users",
+                                                        ":id",
+                                                        "favorites"
+                                                    ],
+                                                    "variable": [
+                                                        {
+                                                            "key": "id"
+                                                        }
+                                                    ]
+                                                }
+                                            },
+                                            "status": "OK",
+                                            "code": 200,
+                                            "_postman_previewlanguage": "json",
+                                            "header": [
+                                                {
+                                                    "key": "Content-Type",
+                                                    "value": "application/json"
+                                                }
+                                            ],
+                                            "cookie": [],
+                                            "body": "{\n  \"data\": [\n    {\n      \"created_at\": \"<string>\",\n      \"favorite_item_id\": \"<string>\",\n      \"favorite_type\": \"<string>\",\n      \"user_id\": \"<string>\"\n    },\n    {\n      \"created_at\": \"<string>\",\n      \"favorite_item_id\": \"<string>\",\n      \"favorite_type\": \"<string>\",\n      \"user_id\": \"<string>\"\n    }\n  ]\n}"
+                                        },
+                                        {
+                                            "name": "Bad request",
+                                            "originalRequest": {
+                                                "method": "GET",
+                                                "header": [],
+                                                "url": {
+                                                    "raw": "{{baseUrl}}/users/:id/favorites",
+                                                    "host": [
+                                                        "{{baseUrl}}"
+                                                    ],
+                                                    "path": [
+                                                        "users",
+                                                        ":id",
+                                                        "favorites"
+                                                    ],
+                                                    "variable": [
+                                                        {
+                                                            "key": "id"
+                                                        }
+                                                    ]
+                                                }
+                                            },
+                                            "status": "Bad Request",
+                                            "code": 400,
+                                            "_postman_previewlanguage": "text",
+                                            "header": [],
+                                            "cookie": [],
+                                            "body": ""
+                                        },
+                                        {
+                                            "name": "Server error",
+                                            "originalRequest": {
+                                                "method": "GET",
+                                                "header": [],
+                                                "url": {
+                                                    "raw": "{{baseUrl}}/users/:id/favorites",
+                                                    "host": [
+                                                        "{{baseUrl}}"
+                                                    ],
+                                                    "path": [
+                                                        "users",
+                                                        ":id",
+                                                        "favorites"
+                                                    ],
+                                                    "variable": [
+                                                        {
+                                                            "key": "id"
+                                                        }
+                                                    ]
+                                                }
+                                            },
+                                            "status": "Internal Server Error",
+                                            "code": 500,
+                                            "_postman_previewlanguage": "text",
+                                            "header": [],
+                                            "cookie": [],
+                                            "body": ""
+                                        }
+                                    ]
+                                }
+                            ]
+                        },
+                        {
+                            "name": "followers",
+                            "item": [
+                                {
+                                    "name": "Get Followers",
+                                    "request": {
+                                        "method": "GET",
+                                        "header": [
+                                            {
+                                                "key": "Accept",
+                                                "value": "application/json"
+                                            }
+                                        ],
+                                        "url": {
+                                            "raw": "{{test_base_url}}/users/{{user_id}}/followers?offset=0&limit=10&user_id={{user_id}}",
+                                            "host": [
+                                                "{{test_base_url}}"
+                                            ],
+                                            "path": [
+                                                "users",
+                                                "{{user_id}}",
+                                                "followers"
+                                            ],
+                                            "query": [
+                                                {
+                                                    "key": "offset",
+                                                    "value": "0",
+                                                    "description": "The number of items to skip. Useful for pagination (page number * limit)"
+                                                },
+                                                {
+                                                    "key": "limit",
+                                                    "value": "10",
+                                                    "description": "The number of items to fetch"
+                                                },
+                                                {
+                                                    "key": "user_id",
+                                                    "value": "{{user_id}}",
+                                                    "description": "The user ID of the user making the request"
+                                                }
+                                            ]
+                                        },
+                                        "description": "All users that follow the provided user"
+                                    },
+                                    "response": [
+                                        {
+                                            "name": "Success",
+                                            "originalRequest": {
+                                                "method": "GET",
+                                                "header": [
+                                                    {
+                                                        "key": "Accept",
+                                                        "value": "application/json"
+                                                    }
+                                                ],
+                                                "url": {
+                                                    "raw": "{{baseUrl}}/users/:id/followers?offset=<integer>&limit=<integer>&user_id=<string>",
+                                                    "host": [
+                                                        "{{baseUrl}}"
+                                                    ],
+                                                    "path": [
+                                                        "users",
+                                                        ":id",
+                                                        "followers"
+                                                    ],
+                                                    "query": [
+                                                        {
+                                                            "key": "offset",
+                                                            "value": "<integer>",
+                                                            "description": "The number of items to skip. Useful for pagination (page number * limit)"
+                                                        },
+                                                        {
+                                                            "key": "limit",
+                                                            "value": "<integer>",
+                                                            "description": "The number of items to fetch"
+                                                        },
+                                                        {
+                                                            "key": "user_id",
+                                                            "value": "<string>",
+                                                            "description": "The user ID of the user making the request"
+                                                        }
+                                                    ],
+                                                    "variable": [
+                                                        {
+                                                            "key": "id"
+                                                        }
+                                                    ]
+                                                }
+                                            },
+                                            "status": "OK",
+                                            "code": 200,
+                                            "_postman_previewlanguage": "json",
+                                            "header": [
+                                                {
+                                                    "key": "Content-Type",
+                                                    "value": "application/json"
+                                                }
+                                            ],
+                                            "cookie": [],
+                                            "body": "{\n  \"data\": [\n    {\n      \"album_count\": \"<integer>\",\n      \"erc_wallet\": \"<string>\",\n      \"followee_count\": \"<integer>\",\n      \"follower_count\": \"<integer>\",\n      \"handle\": \"<string>\",\n      \"id\": \"<string>\",\n      \"is_available\": \"<boolean>\",\n      \"is_deactivated\": \"<boolean>\",\n      \"is_verified\": \"<boolean>\",\n      \"name\": \"<string>\",\n      \"playlist_count\": \"<integer>\",\n      \"repost_count\": \"<integer>\",\n      \"spl_wallet\": \"<string>\",\n      \"supporter_count\": \"<integer>\",\n      \"supporting_count\": \"<integer>\",\n      \"total_audio_balance\": \"<integer>\",\n      \"track_count\": \"<integer>\",\n      \"artist_pick_track_id\": \"<string>\",\n      \"bio\": \"<string>\",\n      \"cover_photo\": {\n        \"640x\": \"<string>\",\n        \"2000x\": \"<string>\"\n      },\n      \"does_follow_current_user\": \"<boolean>\",\n      \"location\": \"<string>\",\n      \"profile_picture\": {\n        \"150x150\": \"<string>\",\n        \"480x480\": \"<string>\",\n        \"1000x1000\": \"<string>\"\n      }\n    },\n    {\n      \"album_count\": \"<integer>\",\n      \"erc_wallet\": \"<string>\",\n      \"followee_count\": \"<integer>\",\n      \"follower_count\": \"<integer>\",\n      \"handle\": \"<string>\",\n      \"id\": \"<string>\",\n      \"is_available\": \"<boolean>\",\n      \"is_deactivated\": \"<boolean>\",\n      \"is_verified\": \"<boolean>\",\n      \"name\": \"<string>\",\n      \"playlist_count\": \"<integer>\",\n      \"repost_count\": \"<integer>\",\n      \"spl_wallet\": \"<string>\",\n      \"supporter_count\": \"<integer>\",\n      \"supporting_count\": \"<integer>\",\n      \"total_audio_balance\": \"<integer>\",\n      \"track_count\": \"<integer>\",\n      \"artist_pick_track_id\": \"<string>\",\n      \"bio\": \"<string>\",\n      \"cover_photo\": {\n        \"640x\": \"<string>\",\n        \"2000x\": \"<string>\"\n      },\n      \"does_follow_current_user\": \"<boolean>\",\n      \"location\": \"<string>\",\n      \"profile_picture\": {\n        \"150x150\": \"<string>\",\n        \"480x480\": \"<string>\",\n        \"1000x1000\": \"<string>\"\n      }\n    }\n  ]\n}"
+                                        },
+                                        {
+                                            "name": "Bad request",
+                                            "originalRequest": {
+                                                "method": "GET",
+                                                "header": [],
+                                                "url": {
+                                                    "raw": "{{baseUrl}}/users/:id/followers?offset=<integer>&limit=<integer>&user_id=<string>",
+                                                    "host": [
+                                                        "{{baseUrl}}"
+                                                    ],
+                                                    "path": [
+                                                        "users",
+                                                        ":id",
+                                                        "followers"
+                                                    ],
+                                                    "query": [
+                                                        {
+                                                            "key": "offset",
+                                                            "value": "<integer>",
+                                                            "description": "The number of items to skip. Useful for pagination (page number * limit)"
+                                                        },
+                                                        {
+                                                            "key": "limit",
+                                                            "value": "<integer>",
+                                                            "description": "The number of items to fetch"
+                                                        },
+                                                        {
+                                                            "key": "user_id",
+                                                            "value": "<string>",
+                                                            "description": "The user ID of the user making the request"
+                                                        }
+                                                    ],
+                                                    "variable": [
+                                                        {
+                                                            "key": "id"
+                                                        }
+                                                    ]
+                                                }
+                                            },
+                                            "status": "Bad Request",
+                                            "code": 400,
+                                            "_postman_previewlanguage": "text",
+                                            "header": [],
+                                            "cookie": [],
+                                            "body": ""
+                                        },
+                                        {
+                                            "name": "Server error",
+                                            "originalRequest": {
+                                                "method": "GET",
+                                                "header": [],
+                                                "url": {
+                                                    "raw": "{{baseUrl}}/users/:id/followers?offset=<integer>&limit=<integer>&user_id=<string>",
+                                                    "host": [
+                                                        "{{baseUrl}}"
+                                                    ],
+                                                    "path": [
+                                                        "users",
+                                                        ":id",
+                                                        "followers"
+                                                    ],
+                                                    "query": [
+                                                        {
+                                                            "key": "offset",
+                                                            "value": "<integer>",
+                                                            "description": "The number of items to skip. Useful for pagination (page number * limit)"
+                                                        },
+                                                        {
+                                                            "key": "limit",
+                                                            "value": "<integer>",
+                                                            "description": "The number of items to fetch"
+                                                        },
+                                                        {
+                                                            "key": "user_id",
+                                                            "value": "<string>",
+                                                            "description": "The user ID of the user making the request"
+                                                        }
+                                                    ],
+                                                    "variable": [
+                                                        {
+                                                            "key": "id"
+                                                        }
+                                                    ]
+                                                }
+                                            },
+                                            "status": "Internal Server Error",
+                                            "code": 500,
+                                            "_postman_previewlanguage": "text",
+                                            "header": [],
+                                            "cookie": [],
+                                            "body": ""
+                                        }
+                                    ]
+                                }
+                            ]
+                        },
+                        {
+                            "name": "following",
+                            "item": [
+                                {
+                                    "name": "Get Following",
+                                    "request": {
+                                        "method": "GET",
+                                        "header": [
+                                            {
+                                                "key": "Accept",
+                                                "value": "application/json"
+                                            }
+                                        ],
+                                        "url": {
+                                            "raw": "{{test_base_url}}/users/{{user_id}}/following?offset=0&limit=20&user_id={{user_id}}",
+                                            "host": [
+                                                "{{test_base_url}}"
+                                            ],
+                                            "path": [
+                                                "users",
+                                                "{{user_id}}",
+                                                "following"
+                                            ],
+                                            "query": [
+                                                {
+                                                    "key": "offset",
+                                                    "value": "0",
+                                                    "description": "The number of items to skip. Useful for pagination (page number * limit)"
+                                                },
+                                                {
+                                                    "key": "limit",
+                                                    "value": "20",
+                                                    "description": "The number of items to fetch"
+                                                },
+                                                {
+                                                    "key": "user_id",
+                                                    "value": "{{user_id}}",
+                                                    "description": "The user ID of the user making the request"
+                                                }
+                                            ]
+                                        },
+                                        "description": "All users that the provided user follows"
+                                    },
+                                    "response": [
+                                        {
+                                            "name": "Success",
+                                            "originalRequest": {
+                                                "method": "GET",
+                                                "header": [
+                                                    {
+                                                        "key": "Accept",
+                                                        "value": "application/json"
+                                                    }
+                                                ],
+                                                "url": {
+                                                    "raw": "{{baseUrl}}/users/:id/following?offset=<integer>&limit=<integer>&user_id=<string>",
+                                                    "host": [
+                                                        "{{baseUrl}}"
+                                                    ],
+                                                    "path": [
+                                                        "users",
+                                                        ":id",
+                                                        "following"
+                                                    ],
+                                                    "query": [
+                                                        {
+                                                            "key": "offset",
+                                                            "value": "<integer>",
+                                                            "description": "The number of items to skip. Useful for pagination (page number * limit)"
+                                                        },
+                                                        {
+                                                            "key": "limit",
+                                                            "value": "<integer>",
+                                                            "description": "The number of items to fetch"
+                                                        },
+                                                        {
+                                                            "key": "user_id",
+                                                            "value": "<string>",
+                                                            "description": "The user ID of the user making the request"
+                                                        }
+                                                    ],
+                                                    "variable": [
+                                                        {
+                                                            "key": "id"
+                                                        }
+                                                    ]
+                                                }
+                                            },
+                                            "status": "OK",
+                                            "code": 200,
+                                            "_postman_previewlanguage": "json",
+                                            "header": [
+                                                {
+                                                    "key": "Content-Type",
+                                                    "value": "application/json"
+                                                }
+                                            ],
+                                            "cookie": [],
+                                            "body": "{\n  \"data\": [\n    {\n      \"album_count\": \"<integer>\",\n      \"erc_wallet\": \"<string>\",\n      \"followee_count\": \"<integer>\",\n      \"follower_count\": \"<integer>\",\n      \"handle\": \"<string>\",\n      \"id\": \"<string>\",\n      \"is_available\": \"<boolean>\",\n      \"is_deactivated\": \"<boolean>\",\n      \"is_verified\": \"<boolean>\",\n      \"name\": \"<string>\",\n      \"playlist_count\": \"<integer>\",\n      \"repost_count\": \"<integer>\",\n      \"spl_wallet\": \"<string>\",\n      \"supporter_count\": \"<integer>\",\n      \"supporting_count\": \"<integer>\",\n      \"total_audio_balance\": \"<integer>\",\n      \"track_count\": \"<integer>\",\n      \"artist_pick_track_id\": \"<string>\",\n      \"bio\": \"<string>\",\n      \"cover_photo\": {\n        \"640x\": \"<string>\",\n        \"2000x\": \"<string>\"\n      },\n      \"does_follow_current_user\": \"<boolean>\",\n      \"location\": \"<string>\",\n      \"profile_picture\": {\n        \"150x150\": \"<string>\",\n        \"480x480\": \"<string>\",\n        \"1000x1000\": \"<string>\"\n      }\n    },\n    {\n      \"album_count\": \"<integer>\",\n      \"erc_wallet\": \"<string>\",\n      \"followee_count\": \"<integer>\",\n      \"follower_count\": \"<integer>\",\n      \"handle\": \"<string>\",\n      \"id\": \"<string>\",\n      \"is_available\": \"<boolean>\",\n      \"is_deactivated\": \"<boolean>\",\n      \"is_verified\": \"<boolean>\",\n      \"name\": \"<string>\",\n      \"playlist_count\": \"<integer>\",\n      \"repost_count\": \"<integer>\",\n      \"spl_wallet\": \"<string>\",\n      \"supporter_count\": \"<integer>\",\n      \"supporting_count\": \"<integer>\",\n      \"total_audio_balance\": \"<integer>\",\n      \"track_count\": \"<integer>\",\n      \"artist_pick_track_id\": \"<string>\",\n      \"bio\": \"<string>\",\n      \"cover_photo\": {\n        \"640x\": \"<string>\",\n        \"2000x\": \"<string>\"\n      },\n      \"does_follow_current_user\": \"<boolean>\",\n      \"location\": \"<string>\",\n      \"profile_picture\": {\n        \"150x150\": \"<string>\",\n        \"480x480\": \"<string>\",\n        \"1000x1000\": \"<string>\"\n      }\n    }\n  ]\n}"
+                                        },
+                                        {
+                                            "name": "Bad request",
+                                            "originalRequest": {
+                                                "method": "GET",
+                                                "header": [],
+                                                "url": {
+                                                    "raw": "{{baseUrl}}/users/:id/following?offset=<integer>&limit=<integer>&user_id=<string>",
+                                                    "host": [
+                                                        "{{baseUrl}}"
+                                                    ],
+                                                    "path": [
+                                                        "users",
+                                                        ":id",
+                                                        "following"
+                                                    ],
+                                                    "query": [
+                                                        {
+                                                            "key": "offset",
+                                                            "value": "<integer>",
+                                                            "description": "The number of items to skip. Useful for pagination (page number * limit)"
+                                                        },
+                                                        {
+                                                            "key": "limit",
+                                                            "value": "<integer>",
+                                                            "description": "The number of items to fetch"
+                                                        },
+                                                        {
+                                                            "key": "user_id",
+                                                            "value": "<string>",
+                                                            "description": "The user ID of the user making the request"
+                                                        }
+                                                    ],
+                                                    "variable": [
+                                                        {
+                                                            "key": "id"
+                                                        }
+                                                    ]
+                                                }
+                                            },
+                                            "status": "Bad Request",
+                                            "code": 400,
+                                            "_postman_previewlanguage": "text",
+                                            "header": [],
+                                            "cookie": [],
+                                            "body": ""
+                                        },
+                                        {
+                                            "name": "Server error",
+                                            "originalRequest": {
+                                                "method": "GET",
+                                                "header": [],
+                                                "url": {
+                                                    "raw": "{{baseUrl}}/users/:id/following?offset=<integer>&limit=<integer>&user_id=<string>",
+                                                    "host": [
+                                                        "{{baseUrl}}"
+                                                    ],
+                                                    "path": [
+                                                        "users",
+                                                        ":id",
+                                                        "following"
+                                                    ],
+                                                    "query": [
+                                                        {
+                                                            "key": "offset",
+                                                            "value": "<integer>",
+                                                            "description": "The number of items to skip. Useful for pagination (page number * limit)"
+                                                        },
+                                                        {
+                                                            "key": "limit",
+                                                            "value": "<integer>",
+                                                            "description": "The number of items to fetch"
+                                                        },
+                                                        {
+                                                            "key": "user_id",
+                                                            "value": "<string>",
+                                                            "description": "The user ID of the user making the request"
+                                                        }
+                                                    ],
+                                                    "variable": [
+                                                        {
+                                                            "key": "id"
+                                                        }
+                                                    ]
+                                                }
+                                            },
+                                            "status": "Internal Server Error",
+                                            "code": 500,
+                                            "_postman_previewlanguage": "text",
+                                            "header": [],
+                                            "cookie": [],
+                                            "body": ""
+                                        }
+                                    ]
+                                }
+                            ]
+                        },
+                        {
+                            "name": "purchases",
+                            "item": [
+                                {
+                                    "name": "download",
+                                    "item": [
+                                        {
+                                            "name": "Download Purchases as CSV",
+                                            "request": {
+                                                "method": "GET",
+                                                "header": [
+                                                    {
+                                                        "description": "(Required) The data that was signed by the user for signature recovery",
+                                                        "key": "Encoded-Data-Message",
+                                                        "value": "<string>"
+                                                    },
+                                                    {
+                                                        "description": "(Required) The signature of data, used for signature recovery",
+                                                        "key": "Encoded-Data-Signature",
+                                                        "value": "<string>"
+                                                    }
+                                                ],
+                                                "url": {
+                                                    "raw": "{{test_base_url}}/users/{{user_id}}/purchases/download?user_id={{user_id}}",
+                                                    "host": [
+                                                        "{{test_base_url}}"
+                                                    ],
+                                                    "path": [
+                                                        "users",
+                                                        "{{user_id}}",
+                                                        "purchases",
+                                                        "download"
+                                                    ],
+                                                    "query": [
+                                                        {
+                                                            "key": "user_id",
+                                                            "value": "{{user_id}}",
+                                                            "description": "The user ID of the user making the request"
+                                                        }
+                                                    ]
+                                                },
+                                                "description": "Downloads the purchases the user has made as a CSV file"
+                                            },
+                                            "response": [
+                                                {
+                                                    "name": "Success",
+                                                    "originalRequest": {
+                                                        "method": "GET",
+                                                        "header": [
+                                                            {
+                                                                "description": "(Required) The data that was signed by the user for signature recovery",
+                                                                "key": "Encoded-Data-Message",
+                                                                "value": "<string>"
+                                                            },
+                                                            {
+                                                                "description": "(Required) The signature of data, used for signature recovery",
+                                                                "key": "Encoded-Data-Signature",
+                                                                "value": "<string>"
+                                                            }
+                                                        ],
+                                                        "url": {
+                                                            "raw": "{{baseUrl}}/users/:id/purchases/download?user_id=<string>",
+                                                            "host": [
+                                                                "{{baseUrl}}"
+                                                            ],
+                                                            "path": [
+                                                                "users",
+                                                                ":id",
+                                                                "purchases",
+                                                                "download"
+                                                            ],
+                                                            "query": [
+                                                                {
+                                                                    "key": "user_id",
+                                                                    "value": "<string>",
+                                                                    "description": "The user ID of the user making the request"
+                                                                }
+                                                            ],
+                                                            "variable": [
+                                                                {
+                                                                    "key": "id"
+                                                                }
+                                                            ]
+                                                        }
+                                                    },
+                                                    "status": "OK",
+                                                    "code": 200,
+                                                    "_postman_previewlanguage": "text",
+                                                    "header": [],
+                                                    "cookie": [],
+                                                    "body": ""
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                }
+                            ]
+                        },
+                        {
+                            "name": "related",
+                            "item": [
+                                {
+                                    "name": "Get Related Users",
+                                    "request": {
+                                        "method": "GET",
+                                        "header": [
+                                            {
+                                                "key": "Accept",
+                                                "value": "application/json"
+                                            }
+                                        ],
+                                        "url": {
+                                            "raw": "{{test_base_url}}/users/{{user_id}}/related?offset=0&limit=10&user_id={{user_id}}",
+                                            "host": [
+                                                "{{test_base_url}}"
+                                            ],
+                                            "path": [
+                                                "users",
+                                                "{{user_id}}",
+                                                "related"
+                                            ],
+                                            "query": [
+                                                {
+                                                    "key": "offset",
+                                                    "value": "0",
+                                                    "description": "The number of items to skip. Useful for pagination (page number * limit)"
+                                                },
+                                                {
+                                                    "key": "limit",
+                                                    "value": "10",
+                                                    "description": "The number of items to fetch"
+                                                },
+                                                {
+                                                    "key": "user_id",
+                                                    "value": "{{user_id}}",
+                                                    "description": "The user ID of the user making the request"
+                                                }
+                                            ]
+                                        },
+                                        "description": "Gets a list of users that might be of interest to followers of this user."
+                                    },
+                                    "response": [
+                                        {
+                                            "name": "Success",
+                                            "originalRequest": {
+                                                "method": "GET",
+                                                "header": [
+                                                    {
+                                                        "key": "Accept",
+                                                        "value": "application/json"
+                                                    }
+                                                ],
+                                                "url": {
+                                                    "raw": "{{baseUrl}}/users/:id/related?offset=<integer>&limit=<integer>&user_id=<string>",
+                                                    "host": [
+                                                        "{{baseUrl}}"
+                                                    ],
+                                                    "path": [
+                                                        "users",
+                                                        ":id",
+                                                        "related"
+                                                    ],
+                                                    "query": [
+                                                        {
+                                                            "key": "offset",
+                                                            "value": "<integer>",
+                                                            "description": "The number of items to skip. Useful for pagination (page number * limit)"
+                                                        },
+                                                        {
+                                                            "key": "limit",
+                                                            "value": "<integer>",
+                                                            "description": "The number of items to fetch"
+                                                        },
+                                                        {
+                                                            "key": "user_id",
+                                                            "value": "<string>",
+                                                            "description": "The user ID of the user making the request"
+                                                        }
+                                                    ],
+                                                    "variable": [
+                                                        {
+                                                            "key": "id"
+                                                        }
+                                                    ]
+                                                }
+                                            },
+                                            "status": "OK",
+                                            "code": 200,
+                                            "_postman_previewlanguage": "json",
+                                            "header": [
+                                                {
+                                                    "key": "Content-Type",
+                                                    "value": "application/json"
+                                                }
+                                            ],
+                                            "cookie": [],
+                                            "body": "{\n  \"data\": [\n    {\n      \"album_count\": \"<integer>\",\n      \"erc_wallet\": \"<string>\",\n      \"followee_count\": \"<integer>\",\n      \"follower_count\": \"<integer>\",\n      \"handle\": \"<string>\",\n      \"id\": \"<string>\",\n      \"is_available\": \"<boolean>\",\n      \"is_deactivated\": \"<boolean>\",\n      \"is_verified\": \"<boolean>\",\n      \"name\": \"<string>\",\n      \"playlist_count\": \"<integer>\",\n      \"repost_count\": \"<integer>\",\n      \"spl_wallet\": \"<string>\",\n      \"supporter_count\": \"<integer>\",\n      \"supporting_count\": \"<integer>\",\n      \"total_audio_balance\": \"<integer>\",\n      \"track_count\": \"<integer>\",\n      \"artist_pick_track_id\": \"<string>\",\n      \"bio\": \"<string>\",\n      \"cover_photo\": {\n        \"640x\": \"<string>\",\n        \"2000x\": \"<string>\"\n      },\n      \"does_follow_current_user\": \"<boolean>\",\n      \"location\": \"<string>\",\n      \"profile_picture\": {\n        \"150x150\": \"<string>\",\n        \"480x480\": \"<string>\",\n        \"1000x1000\": \"<string>\"\n      }\n    },\n    {\n      \"album_count\": \"<integer>\",\n      \"erc_wallet\": \"<string>\",\n      \"followee_count\": \"<integer>\",\n      \"follower_count\": \"<integer>\",\n      \"handle\": \"<string>\",\n      \"id\": \"<string>\",\n      \"is_available\": \"<boolean>\",\n      \"is_deactivated\": \"<boolean>\",\n      \"is_verified\": \"<boolean>\",\n      \"name\": \"<string>\",\n      \"playlist_count\": \"<integer>\",\n      \"repost_count\": \"<integer>\",\n      \"spl_wallet\": \"<string>\",\n      \"supporter_count\": \"<integer>\",\n      \"supporting_count\": \"<integer>\",\n      \"total_audio_balance\": \"<integer>\",\n      \"track_count\": \"<integer>\",\n      \"artist_pick_track_id\": \"<string>\",\n      \"bio\": \"<string>\",\n      \"cover_photo\": {\n        \"640x\": \"<string>\",\n        \"2000x\": \"<string>\"\n      },\n      \"does_follow_current_user\": \"<boolean>\",\n      \"location\": \"<string>\",\n      \"profile_picture\": {\n        \"150x150\": \"<string>\",\n        \"480x480\": \"<string>\",\n        \"1000x1000\": \"<string>\"\n      }\n    }\n  ]\n}"
+                                        },
+                                        {
+                                            "name": "Bad request",
+                                            "originalRequest": {
+                                                "method": "GET",
+                                                "header": [],
+                                                "url": {
+                                                    "raw": "{{baseUrl}}/users/:id/related?offset=<integer>&limit=<integer>&user_id=<string>",
+                                                    "host": [
+                                                        "{{baseUrl}}"
+                                                    ],
+                                                    "path": [
+                                                        "users",
+                                                        ":id",
+                                                        "related"
+                                                    ],
+                                                    "query": [
+                                                        {
+                                                            "key": "offset",
+                                                            "value": "<integer>",
+                                                            "description": "The number of items to skip. Useful for pagination (page number * limit)"
+                                                        },
+                                                        {
+                                                            "key": "limit",
+                                                            "value": "<integer>",
+                                                            "description": "The number of items to fetch"
+                                                        },
+                                                        {
+                                                            "key": "user_id",
+                                                            "value": "<string>",
+                                                            "description": "The user ID of the user making the request"
+                                                        }
+                                                    ],
+                                                    "variable": [
+                                                        {
+                                                            "key": "id"
+                                                        }
+                                                    ]
+                                                }
+                                            },
+                                            "status": "Bad Request",
+                                            "code": 400,
+                                            "_postman_previewlanguage": "text",
+                                            "header": [],
+                                            "cookie": [],
+                                            "body": ""
+                                        },
+                                        {
+                                            "name": "Server error",
+                                            "originalRequest": {
+                                                "method": "GET",
+                                                "header": [],
+                                                "url": {
+                                                    "raw": "{{baseUrl}}/users/:id/related?offset=<integer>&limit=<integer>&user_id=<string>",
+                                                    "host": [
+                                                        "{{baseUrl}}"
+                                                    ],
+                                                    "path": [
+                                                        "users",
+                                                        ":id",
+                                                        "related"
+                                                    ],
+                                                    "query": [
+                                                        {
+                                                            "key": "offset",
+                                                            "value": "<integer>",
+                                                            "description": "The number of items to skip. Useful for pagination (page number * limit)"
+                                                        },
+                                                        {
+                                                            "key": "limit",
+                                                            "value": "<integer>",
+                                                            "description": "The number of items to fetch"
+                                                        },
+                                                        {
+                                                            "key": "user_id",
+                                                            "value": "<string>",
+                                                            "description": "The user ID of the user making the request"
+                                                        }
+                                                    ],
+                                                    "variable": [
+                                                        {
+                                                            "key": "id"
+                                                        }
+                                                    ]
+                                                }
+                                            },
+                                            "status": "Internal Server Error",
+                                            "code": 500,
+                                            "_postman_previewlanguage": "text",
+                                            "header": [],
+                                            "cookie": [],
+                                            "body": ""
+                                        }
+                                    ]
+                                }
+                            ]
+                        },
+                        {
+                            "name": "reposts",
+                            "item": [
+                                {
+                                    "name": "Get Reposts",
+                                    "request": {
+                                        "method": "GET",
+                                        "header": [
+                                            {
+                                                "key": "Accept",
+                                                "value": "application/json"
+                                            }
+                                        ],
+                                        "url": {
+                                            "raw": "{{test_base_url}}/users/{{user_id}}/reposts?offset=0&limit=10&user_id={{user_id}}",
+                                            "host": [
+                                                "{{test_base_url}}"
+                                            ],
+                                            "path": [
+                                                "users",
+                                                "{{user_id}}",
+                                                "reposts"
+                                            ],
+                                            "query": [
+                                                {
+                                                    "key": "offset",
+                                                    "value": "0",
+                                                    "description": "The number of items to skip. Useful for pagination (page number * limit)"
+                                                },
+                                                {
+                                                    "key": "limit",
+                                                    "value": "10",
+                                                    "description": "The number of items to fetch"
+                                                },
+                                                {
+                                                    "key": "user_id",
+                                                    "value": "{{user_id}}",
+                                                    "description": "The user ID of the user making the request"
+                                                }
+                                            ]
+                                        },
+                                        "description": "Gets the given user's reposts"
+                                    },
+                                    "response": [
+                                        {
+                                            "name": "Success",
+                                            "originalRequest": {
+                                                "method": "GET",
+                                                "header": [
+                                                    {
+                                                        "key": "Accept",
+                                                        "value": "application/json"
+                                                    }
+                                                ],
+                                                "url": {
+                                                    "raw": "{{baseUrl}}/users/:id/reposts?offset=<integer>&limit=<integer>&user_id=<string>",
+                                                    "host": [
+                                                        "{{baseUrl}}"
+                                                    ],
+                                                    "path": [
+                                                        "users",
+                                                        ":id",
+                                                        "reposts"
+                                                    ],
+                                                    "query": [
+                                                        {
+                                                            "key": "offset",
+                                                            "value": "<integer>",
+                                                            "description": "The number of items to skip. Useful for pagination (page number * limit)"
+                                                        },
+                                                        {
+                                                            "key": "limit",
+                                                            "value": "<integer>",
+                                                            "description": "The number of items to fetch"
+                                                        },
+                                                        {
+                                                            "key": "user_id",
+                                                            "value": "<string>",
+                                                            "description": "The user ID of the user making the request"
+                                                        }
+                                                    ],
+                                                    "variable": [
+                                                        {
+                                                            "key": "id"
+                                                        }
+                                                    ]
+                                                }
+                                            },
+                                            "status": "OK",
+                                            "code": 200,
+                                            "_postman_previewlanguage": "json",
+                                            "header": [
+                                                {
+                                                    "key": "Content-Type",
+                                                    "value": "application/json"
+                                                }
+                                            ],
+                                            "cookie": [],
+                                            "body": "{\n  \"data\": [\n    {\n      \"timestamp\": \"<string>\",\n      \"item_type\": {},\n      \"item\": {}\n    },\n    {\n      \"timestamp\": \"<string>\",\n      \"item_type\": {},\n      \"item\": {}\n    }\n  ]\n}"
+                                        },
+                                        {
+                                            "name": "Bad request",
+                                            "originalRequest": {
+                                                "method": "GET",
+                                                "header": [],
+                                                "url": {
+                                                    "raw": "{{baseUrl}}/users/:id/reposts?offset=<integer>&limit=<integer>&user_id=<string>",
+                                                    "host": [
+                                                        "{{baseUrl}}"
+                                                    ],
+                                                    "path": [
+                                                        "users",
+                                                        ":id",
+                                                        "reposts"
+                                                    ],
+                                                    "query": [
+                                                        {
+                                                            "key": "offset",
+                                                            "value": "<integer>",
+                                                            "description": "The number of items to skip. Useful for pagination (page number * limit)"
+                                                        },
+                                                        {
+                                                            "key": "limit",
+                                                            "value": "<integer>",
+                                                            "description": "The number of items to fetch"
+                                                        },
+                                                        {
+                                                            "key": "user_id",
+                                                            "value": "<string>",
+                                                            "description": "The user ID of the user making the request"
+                                                        }
+                                                    ],
+                                                    "variable": [
+                                                        {
+                                                            "key": "id"
+                                                        }
+                                                    ]
+                                                }
+                                            },
+                                            "status": "Bad Request",
+                                            "code": 400,
+                                            "_postman_previewlanguage": "text",
+                                            "header": [],
+                                            "cookie": [],
+                                            "body": ""
+                                        },
+                                        {
+                                            "name": "Server error",
+                                            "originalRequest": {
+                                                "method": "GET",
+                                                "header": [],
+                                                "url": {
+                                                    "raw": "{{baseUrl}}/users/:id/reposts?offset=<integer>&limit=<integer>&user_id=<string>",
+                                                    "host": [
+                                                        "{{baseUrl}}"
+                                                    ],
+                                                    "path": [
+                                                        "users",
+                                                        ":id",
+                                                        "reposts"
+                                                    ],
+                                                    "query": [
+                                                        {
+                                                            "key": "offset",
+                                                            "value": "<integer>",
+                                                            "description": "The number of items to skip. Useful for pagination (page number * limit)"
+                                                        },
+                                                        {
+                                                            "key": "limit",
+                                                            "value": "<integer>",
+                                                            "description": "The number of items to fetch"
+                                                        },
+                                                        {
+                                                            "key": "user_id",
+                                                            "value": "<string>",
+                                                            "description": "The user ID of the user making the request"
+                                                        }
+                                                    ],
+                                                    "variable": [
+                                                        {
+                                                            "key": "id"
+                                                        }
+                                                    ]
+                                                }
+                                            },
+                                            "status": "Internal Server Error",
+                                            "code": 500,
+                                            "_postman_previewlanguage": "text",
+                                            "header": [],
+                                            "cookie": [],
+                                            "body": ""
+                                        }
+                                    ]
+                                }
+                            ]
+                        },
+                        {
+                            "name": "sales",
+                            "item": [
+                                {
+                                    "name": "download",
+                                    "item": [
+                                        {
+                                            "name": "Download Sales as CSV",
+                                            "request": {
+                                                "method": "GET",
+                                                "header": [
+                                                    {
+                                                        "description": "(Required) The data that was signed by the user for signature recovery",
+                                                        "key": "Encoded-Data-Message",
+                                                        "value": "<string>"
+                                                    },
+                                                    {
+                                                        "description": "(Required) The signature of data, used for signature recovery",
+                                                        "key": "Encoded-Data-Signature",
+                                                        "value": "<string>"
+                                                    }
+                                                ],
+                                                "url": {
+                                                    "raw": "{{test_base_url}}/users/{{user_id}}/sales/download?user_id={{user_id}}",
+                                                    "host": [
+                                                        "{{test_base_url}}"
+                                                    ],
+                                                    "path": [
+                                                        "users",
+                                                        "{{user_id}}",
+                                                        "sales",
+                                                        "download"
+                                                    ],
+                                                    "query": [
+                                                        {
+                                                            "key": "user_id",
+                                                            "value": "{{user_id}}",
+                                                            "description": "The user ID of the user making the request"
+                                                        }
+                                                    ]
+                                                },
+                                                "description": "Downloads the sales the user has made as a CSV file"
+                                            },
+                                            "response": [
+                                                {
+                                                    "name": "Success",
+                                                    "originalRequest": {
+                                                        "method": "GET",
+                                                        "header": [
+                                                            {
+                                                                "description": "(Required) The data that was signed by the user for signature recovery",
+                                                                "key": "Encoded-Data-Message",
+                                                                "value": "<string>"
+                                                            },
+                                                            {
+                                                                "description": "(Required) The signature of data, used for signature recovery",
+                                                                "key": "Encoded-Data-Signature",
+                                                                "value": "<string>"
+                                                            }
+                                                        ],
+                                                        "url": {
+                                                            "raw": "{{baseUrl}}/users/:id/sales/download?user_id=<string>",
+                                                            "host": [
+                                                                "{{baseUrl}}"
+                                                            ],
+                                                            "path": [
+                                                                "users",
+                                                                ":id",
+                                                                "sales",
+                                                                "download"
+                                                            ],
+                                                            "query": [
+                                                                {
+                                                                    "key": "user_id",
+                                                                    "value": "<string>",
+                                                                    "description": "The user ID of the user making the request"
+                                                                }
+                                                            ],
+                                                            "variable": [
+                                                                {
+                                                                    "key": "id"
+                                                                }
+                                                            ]
+                                                        }
+                                                    },
+                                                    "status": "OK",
+                                                    "code": 200,
+                                                    "_postman_previewlanguage": "text",
+                                                    "header": [],
+                                                    "cookie": [],
+                                                    "body": ""
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                }
+                            ]
+                        },
+                        {
+                            "name": "subscribers",
+                            "item": [
+                                {
+                                    "name": "Get Subscribers",
+                                    "request": {
+                                        "method": "GET",
+                                        "header": [
+                                            {
+                                                "key": "Accept",
+                                                "value": "application/json"
+                                            }
+                                        ],
+                                        "url": {
+                                            "raw": "{{test_base_url}}/users/{{user_id}}/subscribers?offset=0&limit=10&user_id={{user_id}}",
+                                            "host": [
+                                                "{{test_base_url}}"
+                                            ],
+                                            "path": [
+                                                "users",
+                                                "{{user_id}}",
+                                                "subscribers"
+                                            ],
+                                            "query": [
+                                                {
+                                                    "key": "offset",
+                                                    "value": "0",
+                                                    "description": "The number of items to skip. Useful for pagination (page number * limit)"
+                                                },
+                                                {
+                                                    "key": "limit",
+                                                    "value": "10",
+                                                    "description": "The number of items to fetch"
+                                                },
+                                                {
+                                                    "key": "user_id",
+                                                    "value": "{{user_id}}",
+                                                    "description": "The user ID of the user making the request"
+                                                }
+                                            ]
+                                        },
+                                        "description": "All users that subscribe to the provided user"
+                                    },
+                                    "response": [
+                                        {
+                                            "name": "Success",
+                                            "originalRequest": {
+                                                "method": "GET",
+                                                "header": [
+                                                    {
+                                                        "key": "Accept",
+                                                        "value": "application/json"
+                                                    }
+                                                ],
+                                                "url": {
+                                                    "raw": "{{baseUrl}}/users/:id/subscribers?offset=<integer>&limit=<integer>&user_id=<string>",
+                                                    "host": [
+                                                        "{{baseUrl}}"
+                                                    ],
+                                                    "path": [
+                                                        "users",
+                                                        ":id",
+                                                        "subscribers"
+                                                    ],
+                                                    "query": [
+                                                        {
+                                                            "key": "offset",
+                                                            "value": "<integer>",
+                                                            "description": "The number of items to skip. Useful for pagination (page number * limit)"
+                                                        },
+                                                        {
+                                                            "key": "limit",
+                                                            "value": "<integer>",
+                                                            "description": "The number of items to fetch"
+                                                        },
+                                                        {
+                                                            "key": "user_id",
+                                                            "value": "<string>",
+                                                            "description": "The user ID of the user making the request"
+                                                        }
+                                                    ],
+                                                    "variable": [
+                                                        {
+                                                            "key": "id"
+                                                        }
+                                                    ]
+                                                }
+                                            },
+                                            "status": "OK",
+                                            "code": 200,
+                                            "_postman_previewlanguage": "json",
+                                            "header": [
+                                                {
+                                                    "key": "Content-Type",
+                                                    "value": "application/json"
+                                                }
+                                            ],
+                                            "cookie": [],
+                                            "body": "{\n  \"data\": [\n    {\n      \"album_count\": \"<integer>\",\n      \"erc_wallet\": \"<string>\",\n      \"followee_count\": \"<integer>\",\n      \"follower_count\": \"<integer>\",\n      \"handle\": \"<string>\",\n      \"id\": \"<string>\",\n      \"is_available\": \"<boolean>\",\n      \"is_deactivated\": \"<boolean>\",\n      \"is_verified\": \"<boolean>\",\n      \"name\": \"<string>\",\n      \"playlist_count\": \"<integer>\",\n      \"repost_count\": \"<integer>\",\n      \"spl_wallet\": \"<string>\",\n      \"supporter_count\": \"<integer>\",\n      \"supporting_count\": \"<integer>\",\n      \"total_audio_balance\": \"<integer>\",\n      \"track_count\": \"<integer>\",\n      \"artist_pick_track_id\": \"<string>\",\n      \"bio\": \"<string>\",\n      \"cover_photo\": {\n        \"640x\": \"<string>\",\n        \"2000x\": \"<string>\"\n      },\n      \"does_follow_current_user\": \"<boolean>\",\n      \"location\": \"<string>\",\n      \"profile_picture\": {\n        \"150x150\": \"<string>\",\n        \"480x480\": \"<string>\",\n        \"1000x1000\": \"<string>\"\n      }\n    },\n    {\n      \"album_count\": \"<integer>\",\n      \"erc_wallet\": \"<string>\",\n      \"followee_count\": \"<integer>\",\n      \"follower_count\": \"<integer>\",\n      \"handle\": \"<string>\",\n      \"id\": \"<string>\",\n      \"is_available\": \"<boolean>\",\n      \"is_deactivated\": \"<boolean>\",\n      \"is_verified\": \"<boolean>\",\n      \"name\": \"<string>\",\n      \"playlist_count\": \"<integer>\",\n      \"repost_count\": \"<integer>\",\n      \"spl_wallet\": \"<string>\",\n      \"supporter_count\": \"<integer>\",\n      \"supporting_count\": \"<integer>\",\n      \"total_audio_balance\": \"<integer>\",\n      \"track_count\": \"<integer>\",\n      \"artist_pick_track_id\": \"<string>\",\n      \"bio\": \"<string>\",\n      \"cover_photo\": {\n        \"640x\": \"<string>\",\n        \"2000x\": \"<string>\"\n      },\n      \"does_follow_current_user\": \"<boolean>\",\n      \"location\": \"<string>\",\n      \"profile_picture\": {\n        \"150x150\": \"<string>\",\n        \"480x480\": \"<string>\",\n        \"1000x1000\": \"<string>\"\n      }\n    }\n  ]\n}"
+                                        },
+                                        {
+                                            "name": "Bad request",
+                                            "originalRequest": {
+                                                "method": "GET",
+                                                "header": [],
+                                                "url": {
+                                                    "raw": "{{baseUrl}}/users/:id/subscribers?offset=<integer>&limit=<integer>&user_id=<string>",
+                                                    "host": [
+                                                        "{{baseUrl}}"
+                                                    ],
+                                                    "path": [
+                                                        "users",
+                                                        ":id",
+                                                        "subscribers"
+                                                    ],
+                                                    "query": [
+                                                        {
+                                                            "key": "offset",
+                                                            "value": "<integer>",
+                                                            "description": "The number of items to skip. Useful for pagination (page number * limit)"
+                                                        },
+                                                        {
+                                                            "key": "limit",
+                                                            "value": "<integer>",
+                                                            "description": "The number of items to fetch"
+                                                        },
+                                                        {
+                                                            "key": "user_id",
+                                                            "value": "<string>",
+                                                            "description": "The user ID of the user making the request"
+                                                        }
+                                                    ],
+                                                    "variable": [
+                                                        {
+                                                            "key": "id"
+                                                        }
+                                                    ]
+                                                }
+                                            },
+                                            "status": "Bad Request",
+                                            "code": 400,
+                                            "_postman_previewlanguage": "text",
+                                            "header": [],
+                                            "cookie": [],
+                                            "body": ""
+                                        },
+                                        {
+                                            "name": "Server error",
+                                            "originalRequest": {
+                                                "method": "GET",
+                                                "header": [],
+                                                "url": {
+                                                    "raw": "{{baseUrl}}/users/:id/subscribers?offset=<integer>&limit=<integer>&user_id=<string>",
+                                                    "host": [
+                                                        "{{baseUrl}}"
+                                                    ],
+                                                    "path": [
+                                                        "users",
+                                                        ":id",
+                                                        "subscribers"
+                                                    ],
+                                                    "query": [
+                                                        {
+                                                            "key": "offset",
+                                                            "value": "<integer>",
+                                                            "description": "The number of items to skip. Useful for pagination (page number * limit)"
+                                                        },
+                                                        {
+                                                            "key": "limit",
+                                                            "value": "<integer>",
+                                                            "description": "The number of items to fetch"
+                                                        },
+                                                        {
+                                                            "key": "user_id",
+                                                            "value": "<string>",
+                                                            "description": "The user ID of the user making the request"
+                                                        }
+                                                    ],
+                                                    "variable": [
+                                                        {
+                                                            "key": "id"
+                                                        }
+                                                    ]
+                                                }
+                                            },
+                                            "status": "Internal Server Error",
+                                            "code": 500,
+                                            "_postman_previewlanguage": "text",
+                                            "header": [],
+                                            "cookie": [],
+                                            "body": ""
+                                        }
+                                    ]
+                                }
+                            ]
+                        },
+                        {
+                            "name": "supporters",
+                            "item": [
+                                {
+                                    "name": "Get Supporters",
+                                    "request": {
+                                        "method": "GET",
+                                        "header": [
+                                            {
+                                                "key": "Accept",
+                                                "value": "application/json"
+                                            }
+                                        ],
+                                        "url": {
+                                            "raw": "{{test_base_url}}/users/{{user_id}}/supporters?offset=0&limit=30",
+                                            "host": [
+                                                "{{test_base_url}}"
+                                            ],
+                                            "path": [
+                                                "users",
+                                                "{{user_id}}",
+                                                "supporters"
+                                            ],
+                                            "query": [
+                                                {
+                                                    "key": "offset",
+                                                    "value": "0",
+                                                    "description": "The number of items to skip. Useful for pagination (page number * limit)"
+                                                },
+                                                {
+                                                    "key": "limit",
+                                                    "value": "30",
+                                                    "description": "The number of items to fetch"
+                                                }
+                                            ]
+                                        },
+                                        "description": "Gets the supporters of the given user"
+                                    },
+                                    "response": [
+                                        {
+                                            "name": "Success",
+                                            "originalRequest": {
+                                                "method": "GET",
+                                                "header": [
+                                                    {
+                                                        "key": "Accept",
+                                                        "value": "application/json"
+                                                    }
+                                                ],
+                                                "url": {
+                                                    "raw": "{{baseUrl}}/users/:id/supporters?offset=<integer>&limit=<integer>",
+                                                    "host": [
+                                                        "{{baseUrl}}"
+                                                    ],
+                                                    "path": [
+                                                        "users",
+                                                        ":id",
+                                                        "supporters"
+                                                    ],
+                                                    "query": [
+                                                        {
+                                                            "key": "offset",
+                                                            "value": "<integer>",
+                                                            "description": "The number of items to skip. Useful for pagination (page number * limit)"
+                                                        },
+                                                        {
+                                                            "key": "limit",
+                                                            "value": "<integer>",
+                                                            "description": "The number of items to fetch"
+                                                        }
+                                                    ],
+                                                    "variable": [
+                                                        {
+                                                            "key": "id"
+                                                        }
+                                                    ]
+                                                }
+                                            },
+                                            "status": "OK",
+                                            "code": 200,
+                                            "_postman_previewlanguage": "json",
+                                            "header": [
+                                                {
+                                                    "key": "Content-Type",
+                                                    "value": "application/json"
+                                                }
+                                            ],
+                                            "cookie": [],
+                                            "body": "{\n  \"data\": [\n    {\n      \"amount\": \"<string>\",\n      \"rank\": \"<integer>\",\n      \"sender\": {\n        \"album_count\": \"<integer>\",\n        \"erc_wallet\": \"<string>\",\n        \"followee_count\": \"<integer>\",\n        \"follower_count\": \"<integer>\",\n        \"handle\": \"<string>\",\n        \"id\": \"<string>\",\n        \"is_available\": \"<boolean>\",\n        \"is_deactivated\": \"<boolean>\",\n        \"is_verified\": \"<boolean>\",\n        \"name\": \"<string>\",\n        \"playlist_count\": \"<integer>\",\n        \"repost_count\": \"<integer>\",\n        \"spl_wallet\": \"<string>\",\n        \"supporter_count\": \"<integer>\",\n        \"supporting_count\": \"<integer>\",\n        \"total_audio_balance\": \"<integer>\",\n        \"track_count\": \"<integer>\",\n        \"artist_pick_track_id\": \"<string>\",\n        \"bio\": \"<string>\",\n        \"cover_photo\": {\n          \"640x\": \"<string>\",\n          \"2000x\": \"<string>\"\n        },\n        \"does_follow_current_user\": \"<boolean>\",\n        \"location\": \"<string>\",\n        \"profile_picture\": {\n          \"150x150\": \"<string>\",\n          \"480x480\": \"<string>\",\n          \"1000x1000\": \"<string>\"\n        }\n      }\n    },\n    {\n      \"amount\": \"<string>\",\n      \"rank\": \"<integer>\",\n      \"sender\": {\n        \"album_count\": \"<integer>\",\n        \"erc_wallet\": \"<string>\",\n        \"followee_count\": \"<integer>\",\n        \"follower_count\": \"<integer>\",\n        \"handle\": \"<string>\",\n        \"id\": \"<string>\",\n        \"is_available\": \"<boolean>\",\n        \"is_deactivated\": \"<boolean>\",\n        \"is_verified\": \"<boolean>\",\n        \"name\": \"<string>\",\n        \"playlist_count\": \"<integer>\",\n        \"repost_count\": \"<integer>\",\n        \"spl_wallet\": \"<string>\",\n        \"supporter_count\": \"<integer>\",\n        \"supporting_count\": \"<integer>\",\n        \"total_audio_balance\": \"<integer>\",\n        \"track_count\": \"<integer>\",\n        \"artist_pick_track_id\": \"<string>\",\n        \"bio\": \"<string>\",\n        \"cover_photo\": {\n          \"640x\": \"<string>\",\n          \"2000x\": \"<string>\"\n        },\n        \"does_follow_current_user\": \"<boolean>\",\n        \"location\": \"<string>\",\n        \"profile_picture\": {\n          \"150x150\": \"<string>\",\n          \"480x480\": \"<string>\",\n          \"1000x1000\": \"<string>\"\n        }\n      }\n    }\n  ]\n}"
+                                        }
+                                    ]
+                                }
+                            ]
+                        },
+                        {
+                            "name": "supporting",
+                            "item": [
+                                {
+                                    "name": "Get Supportings",
+                                    "request": {
+                                        "method": "GET",
+                                        "header": [
+                                            {
+                                                "key": "Accept",
+                                                "value": "application/json"
+                                            }
+                                        ],
+                                        "url": {
+                                            "raw": "{{test_base_url}}/users/{{user_id}}/supporting?offset=0&limit=10",
+                                            "host": [
+                                                "{{test_base_url}}"
+                                            ],
+                                            "path": [
+                                                "users",
+                                                "{{user_id}}",
+                                                "supporting"
+                                            ],
+                                            "query": [
+                                                {
+                                                    "key": "offset",
+                                                    "value": "0",
+                                                    "description": "The number of items to skip. Useful for pagination (page number * limit)"
+                                                },
+                                                {
+                                                    "key": "limit",
+                                                    "value": "10",
+                                                    "description": "The number of items to fetch"
+                                                }
+                                            ]
+                                        },
+                                        "description": "Gets the users that the given user supports"
+                                    },
+                                    "response": [
+                                        {
+                                            "name": "Success",
+                                            "originalRequest": {
+                                                "method": "GET",
+                                                "header": [
+                                                    {
+                                                        "key": "Accept",
+                                                        "value": "application/json"
+                                                    }
+                                                ],
+                                                "url": {
+                                                    "raw": "{{baseUrl}}/users/:id/supporting?offset=<integer>&limit=<integer>",
+                                                    "host": [
+                                                        "{{baseUrl}}"
+                                                    ],
+                                                    "path": [
+                                                        "users",
+                                                        ":id",
+                                                        "supporting"
+                                                    ],
+                                                    "query": [
+                                                        {
+                                                            "key": "offset",
+                                                            "value": "<integer>",
+                                                            "description": "The number of items to skip. Useful for pagination (page number * limit)"
+                                                        },
+                                                        {
+                                                            "key": "limit",
+                                                            "value": "<integer>",
+                                                            "description": "The number of items to fetch"
+                                                        }
+                                                    ],
+                                                    "variable": [
+                                                        {
+                                                            "key": "id"
+                                                        }
+                                                    ]
+                                                }
+                                            },
+                                            "status": "OK",
+                                            "code": 200,
+                                            "_postman_previewlanguage": "json",
+                                            "header": [
+                                                {
+                                                    "key": "Content-Type",
+                                                    "value": "application/json"
+                                                }
+                                            ],
+                                            "cookie": [],
+                                            "body": "{\n  \"data\": [\n    {\n      \"amount\": \"<string>\",\n      \"rank\": \"<integer>\",\n      \"receiver\": {\n        \"album_count\": \"<integer>\",\n        \"erc_wallet\": \"<string>\",\n        \"followee_count\": \"<integer>\",\n        \"follower_count\": \"<integer>\",\n        \"handle\": \"<string>\",\n        \"id\": \"<string>\",\n        \"is_available\": \"<boolean>\",\n        \"is_deactivated\": \"<boolean>\",\n        \"is_verified\": \"<boolean>\",\n        \"name\": \"<string>\",\n        \"playlist_count\": \"<integer>\",\n        \"repost_count\": \"<integer>\",\n        \"spl_wallet\": \"<string>\",\n        \"supporter_count\": \"<integer>\",\n        \"supporting_count\": \"<integer>\",\n        \"total_audio_balance\": \"<integer>\",\n        \"track_count\": \"<integer>\",\n        \"artist_pick_track_id\": \"<string>\",\n        \"bio\": \"<string>\",\n        \"cover_photo\": {\n          \"640x\": \"<string>\",\n          \"2000x\": \"<string>\"\n        },\n        \"does_follow_current_user\": \"<boolean>\",\n        \"location\": \"<string>\",\n        \"profile_picture\": {\n          \"150x150\": \"<string>\",\n          \"480x480\": \"<string>\",\n          \"1000x1000\": \"<string>\"\n        }\n      }\n    },\n    {\n      \"amount\": \"<string>\",\n      \"rank\": \"<integer>\",\n      \"receiver\": {\n        \"album_count\": \"<integer>\",\n        \"erc_wallet\": \"<string>\",\n        \"followee_count\": \"<integer>\",\n        \"follower_count\": \"<integer>\",\n        \"handle\": \"<string>\",\n        \"id\": \"<string>\",\n        \"is_available\": \"<boolean>\",\n        \"is_deactivated\": \"<boolean>\",\n        \"is_verified\": \"<boolean>\",\n        \"name\": \"<string>\",\n        \"playlist_count\": \"<integer>\",\n        \"repost_count\": \"<integer>\",\n        \"spl_wallet\": \"<string>\",\n        \"supporter_count\": \"<integer>\",\n        \"supporting_count\": \"<integer>\",\n        \"total_audio_balance\": \"<integer>\",\n        \"track_count\": \"<integer>\",\n        \"artist_pick_track_id\": \"<string>\",\n        \"bio\": \"<string>\",\n        \"cover_photo\": {\n          \"640x\": \"<string>\",\n          \"2000x\": \"<string>\"\n        },\n        \"does_follow_current_user\": \"<boolean>\",\n        \"location\": \"<string>\",\n        \"profile_picture\": {\n          \"150x150\": \"<string>\",\n          \"480x480\": \"<string>\",\n          \"1000x1000\": \"<string>\"\n        }\n      }\n    }\n  ]\n}"
+                                        }
+                                    ]
+                                }
+                            ]
+                        },
+                        {
+                            "name": "tags",
+                            "item": [
+                                {
+                                    "name": "Fetch most used tags in a user's tracks",
+                                    "request": {
+                                        "method": "GET",
+                                        "header": [
+                                            {
+                                                "key": "Accept",
+                                                "value": "application/json"
+                                            }
+                                        ],
+                                        "url": {
+                                            "raw": "{{test_base_url}}/users/{{user_id}}/tags?limit=0&user_id={{user_id}}",
+                                            "host": [
+                                                "{{test_base_url}}"
+                                            ],
+                                            "path": [
+                                                "users",
+                                                "{{user_id}}",
+                                                "tags"
+                                            ],
+                                            "query": [
+                                                {
+                                                    "key": "limit",
+                                                    "value": "0",
+                                                    "description": "The number of items to fetch"
+                                                },
+                                                {
+                                                    "key": "user_id",
+                                                    "value": "{{user_id}}",
+                                                    "description": "The user ID of the user making the request"
+                                                }
+                                            ]
+                                        },
+                                        "description": "Gets the most used track tags by a user."
+                                    },
+                                    "response": [
+                                        {
+                                            "name": "Success",
+                                            "originalRequest": {
+                                                "method": "GET",
+                                                "header": [
+                                                    {
+                                                        "key": "Accept",
+                                                        "value": "application/json"
+                                                    }
+                                                ],
+                                                "url": {
+                                                    "raw": "{{baseUrl}}/users/:id/tags?limit=<integer>&user_id=<string>",
+                                                    "host": [
+                                                        "{{baseUrl}}"
+                                                    ],
+                                                    "path": [
+                                                        "users",
+                                                        ":id",
+                                                        "tags"
+                                                    ],
+                                                    "query": [
+                                                        {
+                                                            "key": "limit",
+                                                            "value": "<integer>",
+                                                            "description": "The number of items to fetch"
+                                                        },
+                                                        {
+                                                            "key": "user_id",
+                                                            "value": "<string>",
+                                                            "description": "The user ID of the user making the request"
+                                                        }
+                                                    ],
+                                                    "variable": [
+                                                        {
+                                                            "key": "id"
+                                                        }
+                                                    ]
+                                                }
+                                            },
+                                            "status": "OK",
+                                            "code": 200,
+                                            "_postman_previewlanguage": "json",
+                                            "header": [
+                                                {
+                                                    "key": "Content-Type",
+                                                    "value": "application/json"
+                                                }
+                                            ],
+                                            "cookie": [],
+                                            "body": "{\n  \"data\": [\n    \"<string>\",\n    \"<string>\"\n  ]\n}"
+                                        },
+                                        {
+                                            "name": "Bad request",
+                                            "originalRequest": {
+                                                "method": "GET",
+                                                "header": [],
+                                                "url": {
+                                                    "raw": "{{baseUrl}}/users/:id/tags?limit=<integer>&user_id=<string>",
+                                                    "host": [
+                                                        "{{baseUrl}}"
+                                                    ],
+                                                    "path": [
+                                                        "users",
+                                                        ":id",
+                                                        "tags"
+                                                    ],
+                                                    "query": [
+                                                        {
+                                                            "key": "limit",
+                                                            "value": "<integer>",
+                                                            "description": "The number of items to fetch"
+                                                        },
+                                                        {
+                                                            "key": "user_id",
+                                                            "value": "<string>",
+                                                            "description": "The user ID of the user making the request"
+                                                        }
+                                                    ],
+                                                    "variable": [
+                                                        {
+                                                            "key": "id"
+                                                        }
+                                                    ]
+                                                }
+                                            },
+                                            "status": "Bad Request",
+                                            "code": 400,
+                                            "_postman_previewlanguage": "text",
+                                            "header": [],
+                                            "cookie": [],
+                                            "body": ""
+                                        },
+                                        {
+                                            "name": "Server error",
+                                            "originalRequest": {
+                                                "method": "GET",
+                                                "header": [],
+                                                "url": {
+                                                    "raw": "{{baseUrl}}/users/:id/tags?limit=<integer>&user_id=<string>",
+                                                    "host": [
+                                                        "{{baseUrl}}"
+                                                    ],
+                                                    "path": [
+                                                        "users",
+                                                        ":id",
+                                                        "tags"
+                                                    ],
+                                                    "query": [
+                                                        {
+                                                            "key": "limit",
+                                                            "value": "<integer>",
+                                                            "description": "The number of items to fetch"
+                                                        },
+                                                        {
+                                                            "key": "user_id",
+                                                            "value": "<string>",
+                                                            "description": "The user ID of the user making the request"
+                                                        }
+                                                    ],
+                                                    "variable": [
+                                                        {
+                                                            "key": "id"
+                                                        }
+                                                    ]
+                                                }
+                                            },
+                                            "status": "Internal Server Error",
+                                            "code": 500,
+                                            "_postman_previewlanguage": "text",
+                                            "header": [],
+                                            "cookie": [],
+                                            "body": ""
+                                        }
+                                    ]
+                                }
+                            ]
+                        },
+                        {
+                            "name": "tracks",
+                            "item": [
+                                {
+                                    "name": "Get Tracks by User",
+                                    "request": {
+                                        "method": "GET",
+                                        "header": [
+                                            {
+                                                "key": "Accept",
+                                                "value": "application/json"
+                                            }
+                                        ],
+                                        "url": {
+                                            "raw": "{{test_base_url}}/users/{{user_id}}/tracks?offset=0&limit=10&user_id={{user_id}}&sort=date&sort_method=release_date&sort_direction=asc&filter_tracks=all",
+                                            "host": [
+                                                "{{test_base_url}}"
+                                            ],
+                                            "path": [
+                                                "users",
+                                                "{{user_id}}",
+                                                "tracks"
+                                            ],
+                                            "query": [
+                                                {
+                                                    "key": "offset",
+                                                    "value": "0"
+                                                },
+                                                {
+                                                    "key": "limit",
+                                                    "value": "10",
+                                                    "description": "The number of items to fetch"
+                                                },
+                                                {
+                                                    "key": "user_id",
+                                                    "value": "{{user_id}}",
+                                                    "description": "The user ID of the user making the request"
+                                                },
+                                                {
+                                                    "key": "sort",
+                                                    "value": "date",
+                                                    "description": "[Deprecated] Field to sort by"
+                                                },
+                                                {
+                                                    "key": "sort_method",
+                                                    "value": "release_date",
+                                                    "description": "The sort method"
+                                                },
+                                                {
+                                                    "key": "sort_direction",
+                                                    "value": "asc",
+                                                    "description": "The sort direction"
+                                                },
+                                                {
+                                                    "key": "filter_tracks",
+                                                    "value": "all",
+                                                    "description": "Filter by unlisted or public tracks"
+                                                }
+                                            ]
+                                        },
+                                        "description": "Gets the tracks created by a user using their user ID"
+                                    },
+                                    "response": [
+                                        {
+                                            "name": "Success",
+                                            "originalRequest": {
+                                                "method": "GET",
+                                                "header": [
+                                                    {
+                                                        "key": "Accept",
+                                                        "value": "application/json"
+                                                    }
+                                                ],
+                                                "url": {
+                                                    "raw": "{{baseUrl}}/users/:id/tracks?offset=<integer>&limit=<integer>&user_id=<string>&sort=date&query=<string>&sort_method=release_date&sort_direction=asc&filter_tracks=all",
+                                                    "host": [
+                                                        "{{baseUrl}}"
+                                                    ],
+                                                    "path": [
+                                                        "users",
+                                                        ":id",
+                                                        "tracks"
+                                                    ],
+                                                    "query": [
+                                                        {
+                                                            "key": "offset",
+                                                            "value": "<integer>",
+                                                            "description": "The number of items to skip. Useful for pagination (page number * limit)"
+                                                        },
+                                                        {
+                                                            "key": "limit",
+                                                            "value": "<integer>",
+                                                            "description": "The number of items to fetch"
+                                                        },
+                                                        {
+                                                            "key": "user_id",
+                                                            "value": "<string>",
+                                                            "description": "The user ID of the user making the request"
+                                                        },
+                                                        {
+                                                            "key": "sort",
+                                                            "value": "date",
+                                                            "description": "[Deprecated] Field to sort by"
+                                                        },
+                                                        {
+                                                            "key": "query",
+                                                            "value": "<string>",
+                                                            "description": "The filter query"
+                                                        },
+                                                        {
+                                                            "key": "sort_method",
+                                                            "value": "release_date",
+                                                            "description": "The sort method"
+                                                        },
+                                                        {
+                                                            "key": "sort_direction",
+                                                            "value": "asc",
+                                                            "description": "The sort direction"
+                                                        },
+                                                        {
+                                                            "key": "filter_tracks",
+                                                            "value": "all",
+                                                            "description": "Filter by unlisted or public tracks"
+                                                        }
+                                                    ],
+                                                    "variable": [
+                                                        {
+                                                            "key": "id"
+                                                        }
+                                                    ]
+                                                }
+                                            },
+                                            "status": "OK",
+                                            "code": 200,
+                                            "_postman_previewlanguage": "json",
+                                            "header": [
+                                                {
+                                                    "key": "Content-Type",
+                                                    "value": "application/json"
+                                                }
+                                            ],
+                                            "cookie": [],
+                                            "body": "{\n  \"data\": [\n    {\n      \"duration\": \"<integer>\",\n      \"favorite_count\": \"<integer>\",\n      \"id\": \"<string>\",\n      \"play_count\": \"<integer>\",\n      \"repost_count\": \"<integer>\",\n      \"title\": \"<string>\",\n      \"user\": {\n        \"album_count\": \"<integer>\",\n        \"erc_wallet\": \"<string>\",\n        \"followee_count\": \"<integer>\",\n        \"follower_count\": \"<integer>\",\n        \"handle\": \"<string>\",\n        \"id\": \"<string>\",\n        \"is_available\": \"<boolean>\",\n        \"is_deactivated\": \"<boolean>\",\n        \"is_verified\": \"<boolean>\",\n        \"name\": \"<string>\",\n        \"playlist_count\": \"<integer>\",\n        \"repost_count\": \"<integer>\",\n        \"spl_wallet\": \"<string>\",\n        \"supporter_count\": \"<integer>\",\n        \"supporting_count\": \"<integer>\",\n        \"total_audio_balance\": \"<integer>\",\n        \"track_count\": \"<integer>\",\n        \"artist_pick_track_id\": \"<string>\",\n        \"bio\": \"<string>\",\n        \"cover_photo\": {\n          \"640x\": \"<string>\",\n          \"2000x\": \"<string>\"\n        },\n        \"does_follow_current_user\": \"<boolean>\",\n        \"location\": \"<string>\",\n        \"profile_picture\": {\n          \"150x150\": \"<string>\",\n          \"480x480\": \"<string>\",\n          \"1000x1000\": \"<string>\"\n        }\n      },\n      \"artwork\": {\n        \"150x150\": \"<string>\",\n        \"480x480\": \"<string>\",\n        \"1000x1000\": \"<string>\"\n      },\n      \"description\": \"<string>\",\n      \"genre\": \"<string>\",\n      \"track_cid\": \"<string>\",\n      \"preview_cid\": \"<string>\",\n      \"mood\": \"<string>\",\n      \"release_date\": \"<string>\",\n      \"remix_of\": {\n        \"tracks\": [\n          {\n            \"parent_track_id\": \"<string>\"\n          },\n          {\n            \"parent_track_id\": \"<string>\"\n          }\n        ]\n      },\n      \"tags\": \"<string>\",\n      \"downloadable\": \"<boolean>\",\n      \"permalink\": \"<string>\",\n      \"is_streamable\": \"<boolean>\"\n    },\n    {\n      \"duration\": \"<integer>\",\n      \"favorite_count\": \"<integer>\",\n      \"id\": \"<string>\",\n      \"play_count\": \"<integer>\",\n      \"repost_count\": \"<integer>\",\n      \"title\": \"<string>\",\n      \"user\": {\n        \"album_count\": \"<integer>\",\n        \"erc_wallet\": \"<string>\",\n        \"followee_count\": \"<integer>\",\n        \"follower_count\": \"<integer>\",\n        \"handle\": \"<string>\",\n        \"id\": \"<string>\",\n        \"is_available\": \"<boolean>\",\n        \"is_deactivated\": \"<boolean>\",\n        \"is_verified\": \"<boolean>\",\n        \"name\": \"<string>\",\n        \"playlist_count\": \"<integer>\",\n        \"repost_count\": \"<integer>\",\n        \"spl_wallet\": \"<string>\",\n        \"supporter_count\": \"<integer>\",\n        \"supporting_count\": \"<integer>\",\n        \"total_audio_balance\": \"<integer>\",\n        \"track_count\": \"<integer>\",\n        \"artist_pick_track_id\": \"<string>\",\n        \"bio\": \"<string>\",\n        \"cover_photo\": {\n          \"640x\": \"<string>\",\n          \"2000x\": \"<string>\"\n        },\n        \"does_follow_current_user\": \"<boolean>\",\n        \"location\": \"<string>\",\n        \"profile_picture\": {\n          \"150x150\": \"<string>\",\n          \"480x480\": \"<string>\",\n          \"1000x1000\": \"<string>\"\n        }\n      },\n      \"artwork\": {\n        \"150x150\": \"<string>\",\n        \"480x480\": \"<string>\",\n        \"1000x1000\": \"<string>\"\n      },\n      \"description\": \"<string>\",\n      \"genre\": \"<string>\",\n      \"track_cid\": \"<string>\",\n      \"preview_cid\": \"<string>\",\n      \"mood\": \"<string>\",\n      \"release_date\": \"<string>\",\n      \"remix_of\": {\n        \"tracks\": [\n          {\n            \"parent_track_id\": \"<string>\"\n          },\n          {\n            \"parent_track_id\": \"<string>\"\n          }\n        ]\n      },\n      \"tags\": \"<string>\",\n      \"downloadable\": \"<boolean>\",\n      \"permalink\": \"<string>\",\n      \"is_streamable\": \"<boolean>\"\n    }\n  ]\n}"
+                                        },
+                                        {
+                                            "name": "Bad request",
+                                            "originalRequest": {
+                                                "method": "GET",
+                                                "header": [],
+                                                "url": {
+                                                    "raw": "{{baseUrl}}/users/:id/tracks?offset=<integer>&limit=<integer>&user_id=<string>&sort=date&query=<string>&sort_method=release_date&sort_direction=asc&filter_tracks=all",
+                                                    "host": [
+                                                        "{{baseUrl}}"
+                                                    ],
+                                                    "path": [
+                                                        "users",
+                                                        ":id",
+                                                        "tracks"
+                                                    ],
+                                                    "query": [
+                                                        {
+                                                            "key": "offset",
+                                                            "value": "<integer>",
+                                                            "description": "The number of items to skip. Useful for pagination (page number * limit)"
+                                                        },
+                                                        {
+                                                            "key": "limit",
+                                                            "value": "<integer>",
+                                                            "description": "The number of items to fetch"
+                                                        },
+                                                        {
+                                                            "key": "user_id",
+                                                            "value": "<string>",
+                                                            "description": "The user ID of the user making the request"
+                                                        },
+                                                        {
+                                                            "key": "sort",
+                                                            "value": "date",
+                                                            "description": "[Deprecated] Field to sort by"
+                                                        },
+                                                        {
+                                                            "key": "query",
+                                                            "value": "<string>",
+                                                            "description": "The filter query"
+                                                        },
+                                                        {
+                                                            "key": "sort_method",
+                                                            "value": "release_date",
+                                                            "description": "The sort method"
+                                                        },
+                                                        {
+                                                            "key": "sort_direction",
+                                                            "value": "asc",
+                                                            "description": "The sort direction"
+                                                        },
+                                                        {
+                                                            "key": "filter_tracks",
+                                                            "value": "all",
+                                                            "description": "Filter by unlisted or public tracks"
+                                                        }
+                                                    ],
+                                                    "variable": [
+                                                        {
+                                                            "key": "id"
+                                                        }
+                                                    ]
+                                                }
+                                            },
+                                            "status": "Bad Request",
+                                            "code": 400,
+                                            "_postman_previewlanguage": "text",
+                                            "header": [],
+                                            "cookie": [],
+                                            "body": ""
+                                        },
+                                        {
+                                            "name": "Server error",
+                                            "originalRequest": {
+                                                "method": "GET",
+                                                "header": [],
+                                                "url": {
+                                                    "raw": "{{baseUrl}}/users/:id/tracks?offset=<integer>&limit=<integer>&user_id=<string>&sort=date&query=<string>&sort_method=release_date&sort_direction=asc&filter_tracks=all",
+                                                    "host": [
+                                                        "{{baseUrl}}"
+                                                    ],
+                                                    "path": [
+                                                        "users",
+                                                        ":id",
+                                                        "tracks"
+                                                    ],
+                                                    "query": [
+                                                        {
+                                                            "key": "offset",
+                                                            "value": "<integer>",
+                                                            "description": "The number of items to skip. Useful for pagination (page number * limit)"
+                                                        },
+                                                        {
+                                                            "key": "limit",
+                                                            "value": "<integer>",
+                                                            "description": "The number of items to fetch"
+                                                        },
+                                                        {
+                                                            "key": "user_id",
+                                                            "value": "<string>",
+                                                            "description": "The user ID of the user making the request"
+                                                        },
+                                                        {
+                                                            "key": "sort",
+                                                            "value": "date",
+                                                            "description": "[Deprecated] Field to sort by"
+                                                        },
+                                                        {
+                                                            "key": "query",
+                                                            "value": "<string>",
+                                                            "description": "The filter query"
+                                                        },
+                                                        {
+                                                            "key": "sort_method",
+                                                            "value": "release_date",
+                                                            "description": "The sort method"
+                                                        },
+                                                        {
+                                                            "key": "sort_direction",
+                                                            "value": "asc",
+                                                            "description": "The sort direction"
+                                                        },
+                                                        {
+                                                            "key": "filter_tracks",
+                                                            "value": "all",
+                                                            "description": "Filter by unlisted or public tracks"
+                                                        }
+                                                    ],
+                                                    "variable": [
+                                                        {
+                                                            "key": "id"
+                                                        }
+                                                    ]
+                                                }
+                                            },
+                                            "status": "Internal Server Error",
+                                            "code": 500,
+                                            "_postman_previewlanguage": "text",
+                                            "header": [],
+                                            "cookie": [],
+                                            "body": ""
+                                        }
+                                    ]
+                                }
+                            ]
+                        },
+                        {
+                            "name": "withdrawals",
+                            "item": [
+                                {
+                                    "name": "download",
+                                    "item": [
+                                        {
+                                            "name": "Download USDC Withdrawals as CSV",
+                                            "request": {
+                                                "method": "GET",
+                                                "header": [
+                                                    {
+                                                        "description": "(Required) The data that was signed by the user for signature recovery",
+                                                        "key": "Encoded-Data-Message",
+                                                        "value": "<string>"
+                                                    },
+                                                    {
+                                                        "description": "(Required) The signature of data, used for signature recovery",
+                                                        "key": "Encoded-Data-Signature",
+                                                        "value": "<string>"
+                                                    }
+                                                ],
+                                                "url": {
+                                                    "raw": "{{test_base_url}}/users/{{user_id}}/withdrawals/download?user_id={{user_id}}",
+                                                    "host": [
+                                                        "{{test_base_url}}"
+                                                    ],
+                                                    "path": [
+                                                        "users",
+                                                        "{{user_id}}",
+                                                        "withdrawals",
+                                                        "download"
+                                                    ],
+                                                    "query": [
+                                                        {
+                                                            "key": "user_id",
+                                                            "value": "{{user_id}}",
+                                                            "description": "The user ID of the user making the request"
+                                                        }
+                                                    ]
+                                                },
+                                                "description": "Downloads the USDC withdrawals the user has made as a CSV file"
+                                            },
+                                            "response": [
+                                                {
+                                                    "name": "Success",
+                                                    "originalRequest": {
+                                                        "method": "GET",
+                                                        "header": [
+                                                            {
+                                                                "description": "(Required) The data that was signed by the user for signature recovery",
+                                                                "key": "Encoded-Data-Message",
+                                                                "value": "<string>"
+                                                            },
+                                                            {
+                                                                "description": "(Required) The signature of data, used for signature recovery",
+                                                                "key": "Encoded-Data-Signature",
+                                                                "value": "<string>"
+                                                            }
+                                                        ],
+                                                        "url": {
+                                                            "raw": "{{baseUrl}}/users/:id/withdrawals/download?user_id=<string>",
+                                                            "host": [
+                                                                "{{baseUrl}}"
+                                                            ],
+                                                            "path": [
+                                                                "users",
+                                                                ":id",
+                                                                "withdrawals",
+                                                                "download"
+                                                            ],
+                                                            "query": [
+                                                                {
+                                                                    "key": "user_id",
+                                                                    "value": "<string>",
+                                                                    "description": "The user ID of the user making the request"
+                                                                }
+                                                            ],
+                                                            "variable": [
+                                                                {
+                                                                    "key": "id"
+                                                                }
+                                                            ]
+                                                        }
+                                                    },
+                                                    "status": "OK",
+                                                    "code": 200,
+                                                    "_postman_previewlanguage": "text",
+                                                    "header": [],
+                                                    "cookie": [],
+                                                    "body": ""
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                }
+                            ]
+                        },
+                        {
+                            "name": "Get User",
+                            "request": {
+                                "method": "GET",
+                                "header": [
+                                    {
+                                        "key": "Accept",
+                                        "value": "application/json"
+                                    }
+                                ],
+                                "url": {
+                                    "raw": "{{test_base_url}}/users/{{user_id}}",
+                                    "host": [
+                                        "{{test_base_url}}"
+                                    ],
+                                    "path": [
+                                        "users",
+                                        "{{user_id}}"
+                                    ]
+                                },
+                                "description": "Gets a single user by their user ID"
+                            },
+                            "response": [
+                                {
+                                    "name": "Success",
+                                    "originalRequest": {
+                                        "method": "GET",
+                                        "header": [
+                                            {
+                                                "key": "Accept",
+                                                "value": "application/json"
+                                            }
+                                        ],
+                                        "url": {
+                                            "raw": "{{baseUrl}}/users/:id",
+                                            "host": [
+                                                "{{baseUrl}}"
+                                            ],
+                                            "path": [
+                                                "users",
+                                                ":id"
+                                            ],
+                                            "variable": [
+                                                {
+                                                    "key": "id"
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    "status": "OK",
+                                    "code": 200,
+                                    "_postman_previewlanguage": "json",
+                                    "header": [
+                                        {
+                                            "key": "Content-Type",
+                                            "value": "application/json"
+                                        }
+                                    ],
+                                    "cookie": [],
+                                    "body": "{\n  \"data\": {\n    \"album_count\": \"<integer>\",\n    \"erc_wallet\": \"<string>\",\n    \"followee_count\": \"<integer>\",\n    \"follower_count\": \"<integer>\",\n    \"handle\": \"<string>\",\n    \"id\": \"<string>\",\n    \"is_available\": \"<boolean>\",\n    \"is_deactivated\": \"<boolean>\",\n    \"is_verified\": \"<boolean>\",\n    \"name\": \"<string>\",\n    \"playlist_count\": \"<integer>\",\n    \"repost_count\": \"<integer>\",\n    \"spl_wallet\": \"<string>\",\n    \"supporter_count\": \"<integer>\",\n    \"supporting_count\": \"<integer>\",\n    \"total_audio_balance\": \"<integer>\",\n    \"track_count\": \"<integer>\",\n    \"artist_pick_track_id\": \"<string>\",\n    \"bio\": \"<string>\",\n    \"cover_photo\": {\n      \"640x\": \"<string>\",\n      \"2000x\": \"<string>\"\n    },\n    \"does_follow_current_user\": \"<boolean>\",\n    \"location\": \"<string>\",\n    \"profile_picture\": {\n      \"150x150\": \"<string>\",\n      \"480x480\": \"<string>\",\n      \"1000x1000\": \"<string>\"\n    }\n  }\n}"
+                                },
+                                {
+                                    "name": "Bad request",
+                                    "originalRequest": {
+                                        "method": "GET",
+                                        "header": [],
+                                        "url": {
+                                            "raw": "{{baseUrl}}/users/:id",
+                                            "host": [
+                                                "{{baseUrl}}"
+                                            ],
+                                            "path": [
+                                                "users",
+                                                ":id"
+                                            ],
+                                            "variable": [
+                                                {
+                                                    "key": "id"
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    "status": "Bad Request",
+                                    "code": 400,
+                                    "_postman_previewlanguage": "text",
+                                    "header": [],
+                                    "cookie": [],
+                                    "body": ""
+                                },
+                                {
+                                    "name": "Server error",
+                                    "originalRequest": {
+                                        "method": "GET",
+                                        "header": [],
+                                        "url": {
+                                            "raw": "{{baseUrl}}/users/:id",
+                                            "host": [
+                                                "{{baseUrl}}"
+                                            ],
+                                            "path": [
+                                                "users",
+                                                ":id"
+                                            ],
+                                            "variable": [
+                                                {
+                                                    "key": "id"
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    "status": "Internal Server Error",
+                                    "code": 500,
+                                    "_postman_previewlanguage": "text",
+                                    "header": [],
+                                    "cookie": [],
+                                    "body": ""
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ]
+        }
+    ],
+    "event": [
+        {
+            "listen": "prerequest",
+            "script": {
+                "type": "text/javascript",
+                "exec": [
+                    "// In the pre-request script of the request",
+                    "",
+                    "// Set the base URL based on the selected environment",
+                    "const controlUrlHost = pm.environment.get('control_base_url');",
+                    "let controlRequestCopy = pm.request.clone();",
+                    "let controlRequestUrl = controlRequestCopy.url;",
+                    "controlRequestUrl.host = controlUrlHost;",
+                    "let controlRequestString = controlRequestUrl.toString();",
+                    "controlRequestString = pm.environment.replaceIn(controlRequestString);",
+                    "",
+                    "pm.sendRequest(controlRequestString, function (error, controlResponse) {",
+                    "    if (error) {",
+                    "        throw new Error(\"pre-requesite failed with \" + JSON.stringify(error));",
+                    "    }",
+                    "    // Capture the control sandbox response data and latency time",
+                    "    pm.environment.set('control_response', controlResponse.json());",
+                    "    pm.environment.set('control_latency', controlResponse.responseTime);",
+                    "});"
+                ]
+            }
+        },
+        {
+            "listen": "test",
+            "script": {
+                "type": "text/javascript",
+                "exec": [
+                    "",
+                    "// Retrieve the control sandbox response data and latency time",
+                    "const controlResponseData = pm.environment.get('control_response');",
+                    "const controlLatency = pm.environment.get('control_latency');",
+                    "const testBaseUrl = pm.environment.get('test_base_url');",
+                    "// Compare testResponseData with controlResponseData",
+                    "// You can implement your custom logic for comparison here",
+                    "",
+                    "",
+                    "// Function to flatten a nested JSON object",
+                    "function flattenJsonObject(obj, parentKey = '') {",
+                    "    let result = {};",
+                    "",
+                    "    for (const key in obj) {",
+                    "        if (obj.hasOwnProperty(key)) {",
+                    "            const newKey = parentKey ? `${parentKey}.${key}` : key;",
+                    "            if (typeof obj[key] === 'object') {",
+                    "                // Recursively flatten nested objects",
+                    "                const nestedFlatten = flattenJsonObject(obj[key], newKey);",
+                    "                result = { ...result, ...nestedFlatten };",
+                    "            } else {",
+                    "                result[newKey] = obj[key];",
+                    "            }",
+                    "        }",
+                    "    }",
+                    "",
+                    "    return result;",
+                    "}",
+                    "",
+                    "// Flatten both expected and actual JSON objects",
+                    "const flattenedExpected = flattenJsonObject(controlResponseData.data);",
+                    "const flattenedActual = flattenJsonObject(pm.response.json().data);",
+                    "",
+                    "// Function to calculate the similarity percentage between two flattened objects",
+                    "function calculateSimilarityPercentage(expected, actual) {",
+                    "    let matchingFields = 0;",
+                    "    let totalFields = 0;",
+                    "",
+                    "    // Iterate over each field in the expected flattened object",
+                    "    for (const key in expected) {",
+                    "        if (expected.hasOwnProperty(key)) {",
+                    "            totalFields++;",
+                    "",
+                    "            const expectedValue = expected[key];",
+                    "            const actualValue = actual[key];",
+                    "",
+                    "            if (expectedValue === actualValue) {",
+                    "                matchingFields++;",
+                    "            } else {",
+                    "                console.log(`${key}: expected [${expectedValue}] - actual [${actualValue}]`)",
+                    "            }",
+                    "        }",
+                    "    }",
+                    "",
+                    "    // Calculate the similarity percentage",
+                    "    const similarityPercentage = (matchingFields / totalFields) * 100;",
+                    "    return similarityPercentage;",
+                    "}",
+                    "",
+                    "// Calculate the similarity percentage for the flattened objects",
+                    "let similarityPercentage = calculateSimilarityPercentage(flattenedExpected, flattenedActual);",
+                    "",
+                    "// if expected and actual responses are empty, similarity is 100",
+                    "if (_.isEmpty(flattenedActual) && _.isEmpty(flattenedExpected)) {",
+                    "    similarityPercentage = 100;",
+                    "}",
+                    "",
+                    "pm.test(\"Check JSON similarity\", function () {",
+                    "    const similarityThreshold = parseFloat(pm.environment.get(\"similarity_threshold\"))",
+                    "    pm.expect(similarityPercentage).to.be.at.least(similarityThreshold);",
+                    "});",
+                    "",
+                    "pm.test('Latency is Acceptable', function () {",
+                    "    let maxLatencyThreshold = (controlLatency + pm.environment.get('latency_threshold_buffer')) * (1 + pm.environment.get('latency_threshold_percentage'));",
+                    "    let adjustedTestLatency = pm.response.responseTime;",
+                    "    pm.expect(adjustedTestLatency).to.be.below(maxLatencyThreshold)",
+                    "",
+                    "});",
+                    ""
+                ]
+            }
+        }
+    ],
+    "variable": [
+        {
+            "key": "baseUrl",
+            "value": "/v1"
+        },
+        {
+            "key": "user_id",
+            "value": "vbPj6",
+            "type": "string"
+        },
+        {
+            "key": "user_handle",
+            "value": "sabrinakiam",
+            "type": "string"
+        },
+        {
+            "key": "track_id",
+            "value": "kK4a5V3",
+            "type": "string"
+        },
+        {
+            "key": "playlist_id",
+            "value": "nqZmb",
+            "type": "string"
+        }
+    ]
 }

--- a/discovery-provider/api-tests/Test Sandbox.postman_environment.json
+++ b/discovery-provider/api-tests/Test Sandbox.postman_environment.json
@@ -1,57 +1,79 @@
 {
-	"id": "6dd2c8d5-3d91-4ed3-bf5c-359026a862b0",
-	"name": "Test Sandbox",
-	"values": [
-		{
-			"key": "test_base_url",
-			"value": "https://discoveryprovider4.audius.co",
-			"type": "default",
-			"enabled": true
-		},
-		{
-			"key": "control_base_url",
-			"value": "https://discoveryprovider4.audius.co",
-			"type": "default",
-			"enabled": true
-		},
-		{
-			"key": "control_response",
-			"value": "",
-			"type": "any",
-			"enabled": true
-		},
-		{
-			"key": "control_latency",
-			"value": "",
-			"type": "any",
-			"enabled": true
-		},
-		{
-			"key": "control_response_json",
-			"value": "",
-			"type": "any",
-			"enabled": true
-		},
-		{
-			"key": "latency_threshold_percentage",
-			"value": ".1",
-			"type": "default",
-			"enabled": true
-		},
-		{
-			"key": "latency_threshold_buffer",
-			"value": "200",
-			"type": "default",
-			"enabled": true
-		},
-		{
-			"key": "similarity_threshold",
-			"value": "95",
-			"type": "default",
-			"enabled": true
-		}
-	],
-	"_postman_variable_scope": "environment",
-	"_postman_exported_at": "2023-09-20T20:09:01.732Z",
-	"_postman_exported_using": "Postman/10.18.2"
+    "id": "6dd2c8d5-3d91-4ed3-bf5c-359026a862b0",
+    "name": "Test Sandbox",
+    "values": [
+        {
+            "key": "test_base_url",
+            "value": "https://discoveryprovider.sandbox.audius.co/v1",
+            "type": "default",
+            "enabled": true
+        },
+        {
+            "key": "control_base_url",
+            "value": "https://discoveryprovider4.audius.co/v1",
+            "type": "default",
+            "enabled": true
+        },
+        {
+            "key": "control_response",
+            "value": "",
+            "type": "any",
+            "enabled": true
+        },
+        {
+            "key": "control_latency",
+            "value": "",
+            "type": "any",
+            "enabled": true
+        },
+        {
+            "key": "control_response_json",
+            "value": "",
+            "type": "any",
+            "enabled": true
+        },
+        {
+            "key": "latency_threshold_percentage",
+            "value": ".1",
+            "type": "default",
+            "enabled": true
+        },
+        {
+            "key": "latency_threshold_buffer",
+            "value": "200",
+            "type": "default",
+            "enabled": true
+        },
+        {
+            "key": "similarity_threshold",
+            "value": "95",
+            "type": "default",
+            "enabled": true
+        },
+        {
+            "key": "user_id",
+            "value": "vbPj6",
+            "type": "default",
+            "enabled": true
+        },
+        {
+            "key": "user_handle",
+            "value": "sabrinakiam",
+            "type": "default",
+            "enabled": true
+        },
+        {
+            "key": "track_id",
+            "value": "kK4a5V3",
+            "enabled": true
+        },
+        {
+            "key": "playlist_id",
+            "value": "nqZmb",
+            "enabled": true
+        }
+    ],
+    "_postman_variable_scope": "environment",
+    "_postman_exported_at": "2023-09-21T18:27:04.761Z",
+    "_postman_exported_using": "Postman/10.18.4"
 }


### PR DESCRIPTION
### Description
this diff contains the json for testing 36 of our read endpoints for latency and json similarity to dn4 via postman. we expect a 95% similarity for json results from dn4 our control and sandbox dn 1 our test.

note that two tests have a looser similarity threshold (search playlist and trending playlists) because it is expected these endpoints tend to differ across nodes 

### How Has This Been Tested?
ran the postman collection via newman

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._
