### PR TITLE
Fix stale usdc purchases and withdrawals data

### DIFF
--- a/packages/common/src/api/purchases.ts
+++ b/packages/common/src/api/purchases.ts
@@ -163,3 +163,4 @@ export const {
   useGetSalesCount
 } = purchasesApi.hooks
 export const purchasesApiReducer = purchasesApi.reducer
+export const purchasesApiActions = purchasesApi.actions

--- a/packages/common/src/api/user.ts
+++ b/packages/common/src/api/user.ts
@@ -115,3 +115,4 @@ export const {
   useGetUSDCTransactionsCount
 } = userApi.hooks
 export const userApiReducer = userApi.reducer
+export const userApiActions = userApi.actions

--- a/packages/common/src/audius-query/createApi.ts
+++ b/packages/common/src/audius-query/createApi.ts
@@ -40,7 +40,8 @@ import {
   PerEndpointState,
   PerKeyState,
   SliceConfig,
-  QueryHookResults
+  QueryHookResults,
+  FetchResetAction
 } from './types'
 import { capitalize, getKeyFromFetchArgs, selectCommonEntityMap } from './utils'
 
@@ -78,6 +79,7 @@ export const createApi = <
   }
 
   api.reducer = slice.reducer
+  api.actions = slice.actions
   api.util = {
     updateQueryData:
       (endpointName, fetchArgs, updateRecipe) =>
@@ -138,6 +140,12 @@ const addEndpointToSlice = <NormalizedData>(
       scopedState.status = Status.SUCCESS
       scopedState.nonNormalizedData = nonNormalizedData
       state[endpointName][key] = scopedState
+    },
+    [`reset${capitalize(endpointName)}`]: (
+      state: ApiState,
+      _action: FetchResetAction
+    ) => {
+      state[endpointName] = {}
     }
   }
 }

--- a/packages/common/src/audius-query/types.ts
+++ b/packages/common/src/audius-query/types.ts
@@ -1,5 +1,6 @@
 import {
   Action,
+  CaseReducerActions,
   CreateSliceOptions,
   Draft,
   PayloadAction,
@@ -19,6 +20,7 @@ export type DefaultEndpointDefinitions = {
 
 export type Api<EndpointDefinitions extends DefaultEndpointDefinitions> = {
   reducer: Reducer<any, Action>
+  actions: CaseReducerActions<any>
   hooks: {
     [Property in keyof EndpointDefinitions as `use${Capitalize<
       string & Property
@@ -110,6 +112,7 @@ export type FetchSucceededAction = PayloadAction<
     nonNormalizedData: any
   }
 >
+export type FetchResetAction = PayloadAction<FetchBaseAction & {}>
 
 export type ApiState = {
   [key: string]: PerEndpointState<any>

--- a/packages/common/src/store/purchase-content/sagas.ts
+++ b/packages/common/src/store/purchase-content/sagas.ts
@@ -234,8 +234,7 @@ function* doStartPurchaseContentFlow({
     }
 
     // clear the purchases so next query will fetch from source
-    // @ts-ignore
-    yield* put(purchasesApiActions.resetGetPurchases())
+    yield* put(purchasesApiActions.resetGetPurchases!())
 
     // finish
     yield* put(purchaseConfirmed())

--- a/packages/common/src/store/purchase-content/sagas.ts
+++ b/packages/common/src/store/purchase-content/sagas.ts
@@ -11,6 +11,7 @@ import {
   getTokenAccountInfo,
   purchaseContent
 } from 'services/audius-backend/solana'
+import { purchasesApiActions } from 'src/api'
 import { accountSelectors } from 'store/account'
 import {
   buyUSDCFlowFailed,
@@ -231,6 +232,10 @@ function* doStartPurchaseContentFlow({
     if (contentType === ContentType.TRACK) {
       yield* put(saveTrack(contentId, FavoriteSource.IMPLICIT))
     }
+
+    // clear the purchases so next query will fetch from source
+    // @ts-ignore
+    yield* put(purchasesApiActions.resetGetPurchases())
 
     // finish
     yield* put(purchaseConfirmed())

--- a/packages/web/src/store/application/ui/withdraw-usdc/sagas.ts
+++ b/packages/web/src/store/application/ui/withdraw-usdc/sagas.ts
@@ -247,8 +247,7 @@ function* doWithdrawUSDC({
     yield* put(withdrawUSDCSucceeded())
 
     // clear the withdrawals so next query will fetch from source
-    // @ts-ignore
-    yield* put(userApiActions.resetGetUSDCTransactions())
+    yield* put(userApiActions.resetGetUSDCTransactions!())
   } catch (e: unknown) {
     console.error('Withdraw USDC failed', e)
     const reportToSentry = yield* getContext('reportToSentry')

--- a/packages/web/src/store/application/ui/withdraw-usdc/sagas.ts
+++ b/packages/web/src/store/application/ui/withdraw-usdc/sagas.ts
@@ -8,7 +8,8 @@ import {
   TOKEN_LISTING_MAP,
   getUserbankAccountInfo,
   BNUSDC,
-  formatUSDCWeiToFloorDollarNumber
+  formatUSDCWeiToFloorDollarNumber,
+  userApiActions
 } from '@audius/common'
 import {
   createAssociatedTokenAccountInstruction,
@@ -244,6 +245,10 @@ function* doWithdrawUSDC({
     )
     yield* call(onSuccess, transferSignature)
     yield* put(withdrawUSDCSucceeded())
+
+    // clear the withdrawals so next query will fetch from source
+    // @ts-ignore
+    yield* put(userApiActions.resetGetUSDCTransactions())
   } catch (e: unknown) {
     console.error('Withdraw USDC failed', e)
     const reportToSentry = yield* getContext('reportToSentry')


### PR DESCRIPTION
### Description

PAY-1821

Fix stale usdc purchases and withdrawals data after confirmed purchase or withdrawal.
The issue here was that once the data was already fetched, audius-query would always use the cached data for every subsequent render.
This PR introduces a reset action in the reducer that is used in our sagas, so that next time audius-query needs the data, it will have to refetch from the DN.

### How Has This Been Tested?

Local vs stage. Tested both purchases and withdrawals. After purchase/withdrawal, navigating to the purchases/withdrawals renders the loading screen as it refetches the data, then display the fresh data.
