### PR TITLE
[PAY-1867] Use v0 tx in buy audio flow

### DIFF
--- a/packages/libs/src/services/solana/transactionHandler.ts
+++ b/packages/libs/src/services/solana/transactionHandler.ts
@@ -4,7 +4,10 @@ import {
   PublicKey,
   Connection,
   Keypair,
-  TransactionInstruction
+  TransactionInstruction,
+  TransactionMessage,
+  AddressLookupTableAccount,
+  VersionedTransaction
 } from '@solana/web3.js'
 import type { IdentityService, RelayTransactionData } from '../identity'
 import type { Logger, Nullable } from '../../utils'
@@ -18,6 +21,7 @@ type HandleTransactionParams = {
   feePayerOverride?: Nullable<PublicKey>
   sendBlockhash?: boolean
   signatures?: Nullable<Array<{ publicKey: string; signature: Buffer }>>
+  lookupTableAddresses?: string[]
   retry?: boolean
 }
 
@@ -79,6 +83,7 @@ export class TransactionHandler {
     feePayerOverride = null,
     sendBlockhash = false,
     signatures = null,
+    lookupTableAddresses = [],
     retry = true
   }: HandleTransactionParams) {
     let result: {
@@ -104,6 +109,7 @@ export class TransactionHandler {
         skipPreflight,
         feePayerOverride,
         signatures,
+        lookupTableAddresses,
         retry
       )
     }
@@ -163,6 +169,7 @@ export class TransactionHandler {
     skipPreflight: boolean | null,
     feePayerOverride: Nullable<PublicKey> = null,
     signatures: Array<{ publicKey: string; signature: Buffer }> | null = null,
+    lookupTableAddresses: string[],
     retry = true
   ) {
     const feePayerKeypairOverride = (() => {
@@ -189,44 +196,63 @@ export class TransactionHandler {
     }
 
     // Get blockhash
-
     recentBlockhash =
       recentBlockhash ??
       (await this.connection.getLatestBlockhash('confirmed')).blockhash
+    let rawTransaction: Buffer | Uint8Array
 
-    // Construct the txn
-
-    const tx = new Transaction({ recentBlockhash })
-    instructions.forEach((i) => tx.add(i))
-    tx.feePayer = feePayerAccount.publicKey
-    tx.sign(feePayerAccount)
-
-    if (Array.isArray(signatures)) {
-      signatures.forEach(({ publicKey, signature }) => {
-        tx.addSignature(new PublicKey(publicKey), signature)
-      })
-    }
-
-    let rawTransaction: Buffer
-    try {
+    // Branch on whether to send a legacy or v0 transaction. Some duplicated code
+    // unfortunately due to type errors, eg `add` does not exist on VersionedTransaction.
+    if (lookupTableAddresses.length > 0) {
+      // Use v0 transaction if lookup table addresses were supplied
+      const lookupTableAccounts: AddressLookupTableAccount[] = []
+      // Need to use for loop instead of forEach to properly await async calls
+      for (let i = 0; i < lookupTableAddresses.length; i++) {
+        const address = lookupTableAddresses[i]
+        if (address === undefined) continue
+        const lookupTableAccount = await this.connection.getAddressLookupTable(
+          new PublicKey(address)
+        )
+        if (lookupTableAccount.value !== null) {
+          lookupTableAccounts.push(lookupTableAccount.value)
+        } else {
+          // Abort if a lookup table account is missing because the resulting transaction
+          // might be too large
+          return {
+            res: null,
+            error: `Missing lookup table account for address ${address}`,
+            errorCode: null
+          }
+        }
+      }
+      const message = new TransactionMessage({
+        payerKey: feePayerAccount.publicKey,
+        recentBlockhash,
+        instructions
+      }).compileToV0Message(lookupTableAccounts)
+      const tx = new VersionedTransaction(message)
+      if (Array.isArray(signatures)) {
+        signatures.forEach(({ publicKey, signature }) => {
+          tx.addSignature(new PublicKey(publicKey), signature)
+        })
+      }
       rawTransaction = tx.serialize()
-    } catch (e) {
-      logger.warn(`transactionHandler: transaction serialization failed: ${e}`)
-      let errorCode = null
-      let error = null
-      if (e instanceof Error) {
-        error = e.message
-        errorCode = this._parseSolanaErrorCode(error)
+    } else {
+      // Otherwise send a legacy transaction
+      const tx = new Transaction()
+      tx.recentBlockhash = recentBlockhash
+      instructions.forEach((i) => tx.add(i))
+      tx.feePayer = feePayerAccount.publicKey
+      tx.sign(feePayerAccount)
+      if (Array.isArray(signatures)) {
+        signatures.forEach(({ publicKey, signature }) => {
+          tx.addSignature(new PublicKey(publicKey), signature)
+        })
       }
-      return {
-        res: null,
-        error,
-        errorCode
-      }
+      rawTransaction = tx.serialize()
     }
 
     // Send the txn
-
     const sendRawTransaction = async () => {
       return await this.connection.sendRawTransaction(rawTransaction, {
         skipPreflight:

--- a/packages/libs/src/services/solana/transactionHandler.ts
+++ b/packages/libs/src/services/solana/transactionHandler.ts
@@ -207,8 +207,7 @@ export class TransactionHandler {
       // Use v0 transaction if lookup table addresses were supplied
       const lookupTableAccounts: AddressLookupTableAccount[] = []
       // Need to use for loop instead of forEach to properly await async calls
-      for (let i = 0; i < lookupTableAddresses.length; i++) {
-        const address = lookupTableAddresses[i]
+      for (const address of lookupTableAddresses) {
         if (address === undefined) continue
         const lookupTableAccount = await this.connection.getAddressLookupTable(
           new PublicKey(address)

--- a/packages/libs/src/services/solana/transactionHandler.ts
+++ b/packages/libs/src/services/solana/transactionHandler.ts
@@ -231,6 +231,7 @@ export class TransactionHandler {
         instructions
       }).compileToV0Message(lookupTableAccounts)
       const tx = new VersionedTransaction(message)
+      tx.sign([feePayerAccount])
       if (Array.isArray(signatures)) {
         signatures.forEach(({ publicKey, signature }) => {
           tx.addSignature(new PublicKey(publicKey), signature)

--- a/packages/web/src/services/solana/WithdrawUSDC.ts
+++ b/packages/web/src/services/solana/WithdrawUSDC.ts
@@ -40,7 +40,10 @@ export const getSwapUSDCUserBankInstructions = async ({
 }: {
   amount: number
   feePayer: PublicKey
-}): Promise<TransactionInstruction[]> => {
+}): Promise<{
+  instructions: TransactionInstruction[]
+  lookupTableAddresses: string[]
+}> => {
   const libs = await getLibs()
 
   const solanaRootAccount = await getRootSolanaAccount()
@@ -67,10 +70,11 @@ export const getSwapUSDCUserBankInstructions = async ({
     swapMode: 'ExactIn',
     onlyDirectRoutes: true
   })
-  const swapInstructions = await JupiterSingleton.getSwapInstructions({
-    quote: swapQuote.quote,
-    userPublicKey: solanaRootAccount.publicKey
-  })
+  const { instructions: swapInstructions, lookupTableAddresses } =
+    await JupiterSingleton.getSwapInstructions({
+      quote: swapQuote.quote,
+      userPublicKey: solanaRootAccount.publicKey
+    })
 
   const transferInstructions =
     await libs.solanaWeb3Manager!.createTransferInstructionsFromCurrentUser({
@@ -94,10 +98,13 @@ export const getSwapUSDCUserBankInstructions = async ({
     solanaRootAccount.publicKey //  owner
   )
 
-  return [
-    createInstruction,
-    ...transferInstructions,
-    ...swapInstructions,
-    closeInstruction
-  ]
+  return {
+    instructions: [
+      createInstruction,
+      ...transferInstructions,
+      ...swapInstructions,
+      closeInstruction
+    ],
+    lookupTableAddresses
+  }
 }

--- a/packages/web/src/store/application/ui/buy-audio/sagas.ts
+++ b/packages/web/src/store/application/ui/buy-audio/sagas.ts
@@ -33,10 +33,12 @@ import {
 import { TransactionHandler } from '@audius/sdk/dist/core'
 import { QuoteResponse } from '@jup-ag/api'
 import {
+  AddressLookupTableAccount,
   Connection,
   Keypair,
   LAMPORTS_PER_SOL,
-  PublicKey
+  PublicKey,
+  TransactionMessage
 } from '@solana/web3.js'
 import BN from 'bn.js'
 import dayjs from 'dayjs'
@@ -216,10 +218,11 @@ function* getTransactionFees({
 }) {
   let transactionFees = feesCache?.transactionFees ?? 0
   if (!transactionFees) {
-    const swapTransaction = yield* call(JupiterSingleton.getSwapTransaction, {
-      quote,
-      userPublicKey: rootAccount
-    })
+    const { instructions: swapInstructions, lookupTableAddresses } =
+      yield* call(JupiterSingleton.getSwapInstructions, {
+        quote,
+        userPublicKey: rootAccount
+      })
     const userBank = yield* call(deriveUserBankPubkey, audiusBackendInstance)
     const transferTransaction = yield* call(
       createTransferToUserBankTransaction,
@@ -233,25 +236,51 @@ function* getTransactionFees({
       }
     )
     const connection = yield* call(getSolanaConnection)
+
+    // Calculate fees for transfer transaction (legacy transaction)
     const latestBlockhashResult = yield* call(
       [connection, connection.getLatestBlockhash],
       'finalized'
     )
-    for (const transaction of [swapTransaction, transferTransaction]) {
-      if (transaction) {
-        if (!transaction.recentBlockhash) {
-          transaction.recentBlockhash = latestBlockhashResult.blockhash
-        }
-        if (!transaction.feePayer) {
-          transaction.feePayer = rootAccount
-        }
-        const fee = yield* call(
-          [transaction, transaction.getEstimatedFee],
-          connection
-        )
-        transactionFees += fee ?? 5000 // For some reason, swap transactions don't have fee estimates??
+    if (!transferTransaction.recentBlockhash) {
+      transferTransaction.recentBlockhash = latestBlockhashResult.blockhash
+    }
+    if (!transferTransaction.feePayer) {
+      transferTransaction.feePayer = rootAccount
+    }
+    transactionFees +=
+      (yield* call(
+        [transferTransaction, transferTransaction.getEstimatedFee],
+        connection
+      )) ?? 5000
+
+    // Calculate fees for swap transaction (v0 transaction)
+    const lookupTableAccounts: AddressLookupTableAccount[] = []
+    // Need to use for loop instead of forEach to properly await async calls
+    for (let i = 0; i < lookupTableAddresses.length; i++) {
+      const address = lookupTableAddresses[i]
+      if (address === undefined) continue
+      const lookupTableAccount = yield* call(
+        [connection, connection.getAddressLookupTable],
+        new PublicKey(address)
+      )
+      if (lookupTableAccount.value !== null) {
+        lookupTableAccounts.push(lookupTableAccount.value)
+      } else {
+        // Abort if a lookup table account is missing because the resulting transaction
+        // might be too large
+        throw new Error(`Missing lookup table account for ${address}`)
       }
     }
+    const message = new TransactionMessage({
+      payerKey: rootAccount,
+      recentBlockhash: latestBlockhashResult.blockhash,
+      instructions: swapInstructions
+    }).compileToV0Message(lookupTableAccounts)
+    transactionFees +=
+      (yield* call([connection, connection.getFeeForMessage], message)).value ??
+      5000
+
     yield* put(cacheTransactionFees({ transactionFees }))
   }
   return transactionFees
@@ -688,14 +717,19 @@ function* swapStep({
 
   // Swap the SOL for AUDIO
   yield* put(swapStarted())
-  const transaction = yield* call(JupiterSingleton.getSwapTransaction, {
-    quote: quote.quote,
-    userPublicKey: rootAccount.publicKey
-  })
+  const { instructions: swapInstructions, lookupTableAddresses } = yield* call(
+    JupiterSingleton.getSwapInstructions,
+    {
+      quote: quote.quote,
+      userPublicKey: rootAccount.publicKey
+    }
+  )
+
   const txId = yield* call(JupiterSingleton.executeExchange, {
-    transaction,
+    instructions: swapInstructions,
     feePayer: rootAccount.publicKey,
-    transactionHandler
+    transactionHandler,
+    lookupTableAddresses
   })
 
   // Write transaction details to local storage

--- a/packages/web/src/store/application/ui/withdraw-usdc/sagas.ts
+++ b/packages/web/src/store/application/ui/withdraw-usdc/sagas.ts
@@ -123,13 +123,11 @@ function* doWithdrawUSDC({
               feeAmount - (existingBalance - rootSolanaAccountRent)
             }`
           )
-          const swapInstructions = yield* call(
-            getSwapUSDCUserBankInstructions,
-            {
+          const { instructions: swapInstructions, lookupTableAddresses } =
+            yield* call(getSwapUSDCUserBankInstructions, {
               amount: feeAmount - existingBalance,
               feePayer: feePayerPubkey
-            }
-          )
+            })
           const swapRecentBlockhash = yield* call(getRecentBlockhash)
           const signatureWithPubkey = yield* call(getSignatureForTransaction, {
             instructions: swapInstructions,
@@ -148,7 +146,8 @@ function* doWithdrawUSDC({
                 signature: s.signature!,
                 publicKey: s.publicKey.toString()
               })),
-              recentBlockhash: swapRecentBlockhash
+              recentBlockhash: swapRecentBlockhash,
+              lookupTableAddresses
             }
           )
           if (swapError) {
@@ -173,7 +172,8 @@ function* doWithdrawUSDC({
 
         // Then create and fund the destination associated token account
         const createRecentBlockhash = yield* call(getRecentBlockhash)
-        const tx = new Transaction({ recentBlockhash: createRecentBlockhash })
+        const tx = new Transaction()
+        tx.recentBlockhash = createRecentBlockhash
         const createTokenAccountInstruction = yield* call(
           createAssociatedTokenAccountInstruction,
           rootSolanaAccount.publicKey, // fee payer


### PR DESCRIPTION
### Description
Update libs `TransactionHandler` to be able to send v0 transactions, and use the v0 transaction instructions returned by the Jupiter API to complete the swap step of the Buy $AUDIO flow.

- Using name `lookupTableAddresses` instead of `addressLookupTableAddresses` that Jupiter returns.
- Duplicated code to grab `AddressLookupTableAccount`s from a string of lookup table addresses in libs and web. Started going down the path of centralizing into a util fn in libs, but realized it was a lot of plumbing and I wanted slightly different error handling so decided to just go wet. Lmk if you think it's worthwhile to do this.

DRAGON: Noticed a new kind of error during testing - Jupiter `getQuote` frequently 500s with this error message:
```
Invalid caused by plan: [Trade { e: 58oQChx4yWmvKdwLLZzBi4ChoCc2fqCUWBkwMihLYQo2, u: So11111111111111111111111111111111111111112, amt_u: 236056509000000000, v: EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v, amt_v: 1518109313566, underlying_liquidities: Some({8BnEgHoWFysVcuFFX7QztDmzuH8r5ZFvyP3sYwn1XTh6}) }, Trade { e: EGZ7tiLeH62TPV1gL8WwbXGzEPa9zmcpVnnkPKKnrE2U, u: So11111111111111111111111111111111111111112, amt_u: 157371006000000000, v: EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v, amt_v: 1037171337184, underlying_liquidities: None }, Trade { e: 2arG3AznFJbLknAQUqk44PgeABZDHpBfcRsPmPWjjBPY, u: EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v, amt_u: 1036820693284, v: 9LzCMqDgTKYz9Drzqnpgee3SGa89up3a247ypMj2xrqM, amt_v: 111467471187558, underlying_liquidities: None }, Trade { e: 4EbdAfaShVDNeHm6GbXZX3xsKccRHdTbR5962Bvya8xt, u: EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v, amt_u: 1518459957466, v: 9LzCMqDgTKYz9Drzqnpgee3SGa89up3a247ypMj2xrqM, amt_v: 169036209232480, underlying_liquidities: Some({FxquLRmVMPXiS84FFSp8q5fbVExhLkX85yiXucyu7xSC}) }]
```
Might need to ask Jupiter folks about this.

### How Has This Been Tested?

Local web prod - faking it by dispatching redux action and depositing SOL into root solana account as a way to circumvent the Stripe/Coinbase flow.
example swap tx: https://solscan.io/tx/4JZ9JAkKzYWFGBoA76jjnd4pfRArHjWiTJnCmgjoFjeLvoPzPm6Q138u54tjoW3R5VCBXocjBsDLhkhYK8bFZais
<img width="1920" alt="Screenshot 2023-09-21 at 11 44 03 PM" src="https://github.com/AudiusProject/audius-protocol/assets/3893871/9a6c57dc-17f9-43f9-af5f-59ac2c6c88ec">

