### PR TITLE
Set FinishedAt before updating lastSuccessfulRepair

### DIFF
--- a/mediorum/server/repair.go
+++ b/mediorum/server/repair.go
@@ -95,6 +95,7 @@ func (ss *MediorumServer) startRepairer() {
 
 		logger.Info("repair starting")
 		err := ss.runRepair(&tracker)
+		tracker.FinishedAt = time.Now()
 		if err != nil {
 			logger.Error("repair failed", "err", err, "took", tracker.Duration)
 			tracker.AbortedReason = err.Error()
@@ -105,7 +106,6 @@ func (ss *MediorumServer) startRepairer() {
 				ss.lastSuccessfulCleanup = tracker
 			}
 		}
-		tracker.FinishedAt = time.Now()
 		saveTracker()
 
 		// wait 10 minutes before running again


### PR DESCRIPTION
### Description
One-line fix for the bug making healthz not show the last successful repair info... it needs to set `FinishedAt` before setting `lastSuccessfulRepair`.

### How Has This Been Tested?
I checked the db of stage CN9 to confirm this.