### PR TITLE
Fix stage deploy path typo

### DIFF
--- a/.circleci/src/jobs/deploy-stage-nodes.yml
+++ b/.circleci/src/jobs/deploy-stage-nodes.yml
@@ -25,7 +25,7 @@ steps:
       command: |
         git clone --branch stage https://github.com/AudiusProject/audius-docker-compose.git audius-docker-compose
         cd audius-docker-compose
-        sed -i "s/{TAG:-.*}/{TAG:-$CIRCLE_SHA1}/" << parameters.service >>/docker-compose/*.yml
+        sed -i "s/{TAG:-.*}/{TAG:-$CIRCLE_SHA1}/" << parameters.service >>/docker-compose*.yml
         git add */docker-compose*.yml
         git commit -m "Update tag to $CIRCLE_SHA1 for << parameters.service >>"
         git push origin stage


### PR DESCRIPTION
One-line fix for stage deploys with an extra `/` in the path.