### PR TITLE
[INF-487] Reduce CI cost by filtering web and mobile workflows

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -462,6 +462,9 @@ workflows:
             packages/libs/.* run-sdk-workflow true
             packages/libs/.* run-integration-workflow true
             packages/libs/.* run-gcp-workflow true
+            packages/libs/.* run-web-workflow true
+            packages/libs/.* run-mobile-workflow true
+            packages/libs/.* run-embed-workflow true
           requires:
             - generate-config
             - init
@@ -484,10 +487,18 @@ workflows:
             .* run-contracts-workflow true
             .* run-release-workflow false
             .* run-sdk-workflow true
-            .* run-web-workflow true
-            .* run-mobile-workflow true
             .* run-stems-workflow true
             .* run-probers-workflow true
+            .circleci/.* run-web-workflow true
+            .circleci/.* run-mobile-workflow true
+            packages/common/.* run-web-workflow true
+            packages/common/.* run-mobile-workflow true
+            packages/eslint-config-audius/.* run-web-workflow true
+            packages/eslint-config-audius/.* run-mobile-workflow true
+            packages/libs/.* run-web-workflow true
+            packages/libs/.* run-mobile-workflow true
+            packages/mobile/.* run-mobile-workflow true
+            packages/web/.* run-web-workflow true
           requires:
             - generate-config
             - init


### PR DESCRIPTION
### Description

Web and mobile workflows are by far our most expensive CI flows:
![image](https://github.com/AudiusProject/audius-protocol/assets/19916043/3a5e1ebf-8ce6-48d8-bc99-5fb4c05ba5c4)

![image](https://github.com/AudiusProject/audius-protocol/assets/19916043/d5371ea2-cb7d-4600-84cc-7a49c06466e8)

![image](https://github.com/AudiusProject/audius-protocol/assets/19916043/d70281a0-d4f4-4102-a6aa-4081312744d3)
https://app.circleci.com/insights/gh/AudiusProject/audius-protocol

We currently run `mobile-build-production-ios` for example, on every push to main even when nothing relevant has changed.

This PR updates the CI config to only run web and mobile workflows on main when relevant files have changed. This could be risky if there are hidden dependencies that we aren't capturing in the path filtering. Everything will continue to be run on the release branch as normal

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._
