### PR TITLE
[PAY-1905] Add type attribute to IconButton to prevent form submission

### DIFF
--- a/packages/stems/src/components/IconButton/IconButton.tsx
+++ b/packages/stems/src/components/IconButton/IconButton.tsx
@@ -40,6 +40,7 @@ export const IconButton = forwardRef<
 
   return (
     <button
+      type='button'
       className={className}
       ref={ref as React.Ref<HTMLButtonElement>}
       {...otherProps}


### PR DESCRIPTION
### Description
I made this change for other buttons used in the premium content form, but missed `IconButton`. Long term, we should probably make most if not all instances of a raw HTML `<button />` include this attribute to make them safe to use in forms, and/or we should only ever use Harmony components for buttons since they will include the type for us. But this fixes the issue for now.

fixes PAY-1905

### How Has This Been Tested?
Tested locally in Chrome against staging.
