### PR TITLE
[PAY-1922] Add pay extra fields to notifications

### DIFF
--- a/discovery-provider/integration_tests/queries/test_notifications/test_usdc_purchase_notification.py
+++ b/discovery-provider/integration_tests/queries/test_notifications/test_usdc_purchase_notification.py
@@ -102,6 +102,7 @@ def test_extended_usdc_purchase_notification(app):
                     "buyer_user_id": 2,
                     "seller_user_id": 1,
                     "amount": 1000000,
+                    "extra_amount": 0,
                     "content_type": PurchaseType.track,
                     "content_id": 1,
                 }
@@ -129,6 +130,7 @@ def test_extended_usdc_purchase_notification(app):
                 "buyer_user_id": "ML51L",
                 "seller_user_id": "7eP5n",
                 "amount": "1000000",
+                "extra_amount": "0",
                 "content_id": "7eP5n",
             }
 
@@ -151,5 +153,6 @@ def test_extended_usdc_purchase_notification(app):
                 "buyer_user_id": "ML51L",
                 "seller_user_id": "7eP5n",
                 "amount": "1000000",
+                "extra_amount": "0",
                 "content_id": "7eP5n",
             }

--- a/discovery-provider/plugins/notifications/src/__tests__/mappings/usdcPurchaseBuyer.test.ts
+++ b/discovery-provider/plugins/notifications/src/__tests__/mappings/usdcPurchaseBuyer.test.ts
@@ -140,8 +140,8 @@ describe('USDC Purchase Buyer', () => {
         data: {
           buyer_user_id: 2,
           seller_user_id: 1,
-          amount: '1000',
-          extra_amount: '0',
+          amount: 1000,
+          extra_amount: 0,
           content_id: 10
         },
         user_ids: [2],

--- a/discovery-provider/plugins/notifications/src/__tests__/mappings/usdcPurchaseSeller.test.ts
+++ b/discovery-provider/plugins/notifications/src/__tests__/mappings/usdcPurchaseSeller.test.ts
@@ -141,8 +141,8 @@ describe('USDC Purchase Seller', () => {
         data: {
           buyer_user_id: 2,
           seller_user_id: 1,
-          amount: '1000000',
-          extra_amount: '0',
+          amount: 1000000,
+          extra_amount: 0,
           content_id: 10
         },
         user_ids: [1],

--- a/discovery-provider/plugins/notifications/src/processNotifications/mappers/usdcPurchaseSeller.ts
+++ b/discovery-provider/plugins/notifications/src/processNotifications/mappers/usdcPurchaseSeller.ts
@@ -100,7 +100,7 @@ export class USDCPurchaseSeller extends BaseNotification<USDCPurchaseSellerRow> 
     const buyerHandle = users[this.buyerUserId]?.handle
     const sellerUsername = users[this.notificationReceiverUserId]?.name
     const sellerHandle = users[this.notificationReceiverUserId]?.handle
-    const price = this.amount
+    const price = this.totalAmount
 
     await sendBrowserNotification(
       isBrowserPushEnabled,
@@ -210,8 +210,7 @@ export class USDCPurchaseSeller extends BaseNotification<USDCPurchaseSellerRow> 
     return {
       type: this.notification.type,
       users: [user],
-      // TODO : convert this amount w/ right precision
-      amount: this.amount,
+      amount: this.totalAmount,
       entity
     }
   }

--- a/discovery-provider/src/api/v1/utils/extend_notification.py
+++ b/discovery-provider/src/api/v1/utils/extend_notification.py
@@ -464,6 +464,7 @@ def extend_usdc_purchase_seller(action: NotificationAction):
             "buyer_user_id": encode_int_id(data["buyer_user_id"]),
             "seller_user_id": encode_int_id(data["seller_user_id"]),
             "amount": str(data["amount"]),
+            "extra_amount": str(data["extra_amount"]),
             "content_id": encode_int_id(data["content_id"]),
         },
     }
@@ -483,6 +484,7 @@ def extend_usdc_purchase_buyer(action: NotificationAction):
             "buyer_user_id": encode_int_id(data["buyer_user_id"]),
             "seller_user_id": encode_int_id(data["seller_user_id"]),
             "amount": str(data["amount"]),
+            "extra_amount": str(data["extra_amount"]),
             "content_id": encode_int_id(data["content_id"]),
         },
     }

--- a/discovery-provider/src/queries/get_notifications.py
+++ b/discovery-provider/src/queries/get_notifications.py
@@ -398,6 +398,7 @@ class UsdcPurchaseSellerNotification(TypedDict):
     buyer_user_id: int
     seller_user_id: int
     amount: int
+    extra_amount: int
 
 
 class UsdcPurchaseBuyerNotification(TypedDict):
@@ -406,6 +407,7 @@ class UsdcPurchaseBuyerNotification(TypedDict):
     buyer_user_id: int
     seller_user_id: int
     amount: int
+    extra_amount: int
 
 
 class AnnouncementNotification(TypedDict):

--- a/packages/common/src/services/audius-backend/AudiusBackend.ts
+++ b/packages/common/src/services/audius-backend/AudiusBackend.ts
@@ -2204,12 +2204,14 @@ export const audiusBackend = ({
       let entityId = 0
       let entityType = Entity.Track
       let amount = '' as StringUSDC
+      let extraAmount = '' as StringUSDC
       const userIds = notification.actions
         .map((action) => {
           const data = action.data
           entityId = decodeHashId(data.content_id) as number
           entityType = Entity.Track
           amount = data.amount
+          extraAmount = data.extra_amount
           return decodeHashId(data.buyer_user_id)
         })
         .filter(removeNullable)
@@ -2219,6 +2221,7 @@ export const audiusBackend = ({
         entityId,
         entityType,
         amount,
+        extraAmount,
         ...formatBaseNotification(notification)
       }
     } else if (notification.type === 'usdc_purchase_buyer') {

--- a/packages/common/src/store/notifications/types.ts
+++ b/packages/common/src/store/notifications/types.ts
@@ -248,6 +248,7 @@ export type DiscoveryUSDCPurchaseNotificationAction = {
   seller_user_id: string
   buyer_user_id: string
   amount: StringUSDC
+  extra_amount: StringUSDC
 }
 
 export type TrendingRange = 'week' | 'month' | 'year'
@@ -892,6 +893,7 @@ export type USDCPurchaseSellerNotification = BaseNotification & {
   userIds: ID[]
   entityType: string
   amount: StringUSDC
+  extraAmount: StringUSDC
 }
 
 export type USDCPurchaseBuyerNotification = BaseNotification & {

--- a/packages/common/src/utils/wallet.ts
+++ b/packages/common/src/utils/wallet.ts
@@ -44,6 +44,10 @@ export const stringWeiToBN = (stringWei: StringWei): BNWei => {
   return new BN(stringWei) as BNWei
 }
 
+export const stringUSDCToBN = (stringUSDC: StringUSDC): BNUSDC => {
+  return new BN(stringUSDC) as BNUSDC
+}
+
 export const stringAudioToBN = (stringAudio: StringAudio): BNAudio => {
   return new BN(stringAudio) as BNAudio
 }

--- a/packages/mobile/src/screens/notifications-screen/Notifications/USDCPurchaseSellerNotification.tsx
+++ b/packages/mobile/src/screens/notifications-screen/Notifications/USDCPurchaseSellerNotification.tsx
@@ -2,12 +2,14 @@ import { useCallback } from 'react'
 
 import type {
   Nullable,
+  StringUSDC,
   TrackEntity,
   USDCPurchaseSellerNotification as USDCPurchaseSellerNotificationType
 } from '@audius/common'
 import {
   formatUSDCWeiToUSDString,
-  notificationsSelectors
+  notificationsSelectors,
+  stringUSDCToBN
 } from '@audius/common'
 import { useSelector } from 'react-redux'
 
@@ -49,7 +51,7 @@ export const USDCPurchaseSellerNotification = (
     getNotificationUsers(state, notification, 1)
   )
   const buyerUser = notificationUsers ? notificationUsers[0] : null
-  const { amount } = notification
+  const { amount, extraAmount } = notification
 
   const handlePress = useCallback(() => {
     if (track) {
@@ -66,7 +68,11 @@ export const USDCPurchaseSellerNotification = (
       <NotificationText>
         {messages.congrats} <UserNameLink user={buyerUser} />{' '}
         {messages.justBoughtYourTrack} <EntityLink entity={track} /> for $
-        {formatUSDCWeiToUSDString(amount)}
+        {formatUSDCWeiToUSDString(
+          stringUSDCToBN(amount)
+            .add(stringUSDCToBN(extraAmount))
+            .toString() as StringUSDC
+        )}
         {messages.exclamation}
       </NotificationText>
     </NotificationTile>

--- a/packages/web/src/components/notification/Notification/USDCPurchaseSellerNotification.tsx
+++ b/packages/web/src/components/notification/Notification/USDCPurchaseSellerNotification.tsx
@@ -5,6 +5,8 @@ import {
   formatUSDCWeiToUSDString,
   notificationsSelectors,
   Nullable,
+  StringUSDC,
+  stringUSDCToBN,
   TrackEntity,
   USDCPurchaseSellerNotification as USDCPurchaseSellerNotificationType
 } from '@audius/common'
@@ -48,7 +50,7 @@ export const USDCPurchaseSellerNotification = (
     getNotificationUsers(state, notification, 1)
   )
   const buyerUser = notificationUsers ? notificationUsers[0] : null
-  const { amount } = notification
+  const { amount, extraAmount } = notification
   const handleClick = useCallback(() => {
     if (track) {
       dispatch(push(getEntityLink(track)))
@@ -65,7 +67,11 @@ export const USDCPurchaseSellerNotification = (
         <UserNameLink user={buyerUser} notification={notification} />{' '}
         {messages.justBoughtYourTrack}{' '}
         <EntityLink entity={track} entityType={Entity.Track} /> for $
-        {formatUSDCWeiToUSDString(amount)}
+        {formatUSDCWeiToUSDString(
+          stringUSDCToBN(amount)
+            .add(stringUSDCToBN(extraAmount))
+            .toString() as StringUSDC
+        )}
         {messages.exclamation}
       </NotificationBody>
     </NotificationTile>


### PR DESCRIPTION
### Description

Add pay extra fields to notifications (in app, push, email). Doesn't break current behavior -- may sort out some bugs after merge.

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._

```
npm run web:stage
```
and confirm that exiting values are correct without extra amount. 

Discovery unit tests pass