### PR TITLE
[PROTO-1293] Proxy to healthz from discovery nginx

### DIFF
--- a/dev-tools/compose/docker-compose.healthz.yml
+++ b/dev-tools/compose/docker-compose.healthz.yml
@@ -1,0 +1,8 @@
+version: "3.9"
+
+services:
+  healthz:
+    build:
+      context: ${PROJECT_ROOT}/monitoring/healthz
+    deploy:
+      mode: global

--- a/dev-tools/compose/docker-compose.yml
+++ b/dev-tools/compose/docker-compose.yml
@@ -81,6 +81,14 @@ services:
       service: identity-service
     <<: *common
 
+  # Healthz
+
+  healthz:
+    extends:
+      file: docker-compose.healthz.yml
+      service: healthz
+    <<: *common
+
   # Discovery
 
   discovery-provider-notifications:

--- a/dev-tools/compose/nginx_ingress.conf
+++ b/dev-tools/compose/nginx_ingress.conf
@@ -29,6 +29,14 @@ server {
         proxy_set_header Host $http_host;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
     }
+
+    location ^~ /healthz {
+        resolver 127.0.0.11 valid=30s;
+        proxy_pass http://healthz;
+        proxy_set_header Host $http_host;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    }
+
 }
 
 #

--- a/discovery-provider/nginx_conf/nginx.conf
+++ b/discovery-provider/nginx_conf/nginx.conf
@@ -269,6 +269,13 @@ http {
             proxy_set_header Connection "upgrade";
         }
 
+        location ^~ /healthz {
+            resolver 127.0.0.11 valid=30s;
+            proxy_pass http://healthz;
+            proxy_set_header Host $http_host;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        }
+
         location ~ ^/relay(/.*)?$ {
             resolver 127.0.0.11 valid=30s;
             proxy_pass http://relay:6001/relay$1;

--- a/monitoring/healthz/Dockerfile
+++ b/monitoring/healthz/Dockerfile
@@ -5,7 +5,7 @@ RUN apt update && apt install -y python3 make gcc g++
 ENV WORKDIR /app
 WORKDIR ${WORKDIR}
 
-COPY index.html package.json package-lock.json tsconfig.json tsconfig.node.json vite.config.ts .
+COPY index.html package.json package-lock.json tsconfig.json tsconfig.node.json vite.config.ts postcss.config.js tailwind.config.js .
 ADD src ./src
 ADD workers-site ./workers-site
 


### PR DESCRIPTION
### Description

Some audius deployments rely on Caddy from audius-docker-compose while others route requests directly to the discovery service nginx. This should allow healthz to be reverse proxied in the latter case.

### How Has This Been Tested?

Tested locally with `audius-compose up` and verified that `http://audius-protocol-discovery-provider-1/healthz` works as expected.