### PR TITLE
[PAY-1581] Fix moweb drawer

### DIFF
--- a/packages/web/src/components/drawer/Drawer.tsx
+++ b/packages/web/src/components/drawer/Drawer.tsx
@@ -51,12 +51,6 @@ const stiff = {
   friction: 40
 }
 
-const fast = {
-  mass: 1,
-  tension: 300,
-  friction: 40
-}
-
 // Interpolates a single y-value into a string translate3d
 const interpY = (y: number) => `translate3d(0, ${y}px, 0)`
 


### PR DESCRIPTION
### Description

Many drawers were impacted by this on moweb - not entirely sure how this ever worked, but the crux of the issue boils down to not knowing the height to animate to when the animation begins. `setImmediate` is a nice fix. I tried to do DRAF (https://stackoverflow.com/questions/44145740/how-does-double-requestanimationframe-work), but it didn't quite work.

<img width="577" alt="image" src="https://github.com/AudiusProject/audius-protocol/assets/2731362/11119692-a784-4e57-bb53-5ec8eae212c3">

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._


```
npm run web:stage
```