### PR TITLE
PROTO-1299: scroll uploads for backfill

### DIFF
--- a/mediorum/server/db.go
+++ b/mediorum/server/db.go
@@ -40,10 +40,13 @@ type Upload struct {
 	// UpldateULID - this is the last ULID that change this thing
 }
 
+type UploadCursor struct {
+	Host  string `gorm:"primaryKey"`
+	After time.Time
+}
+
 func dbMustDial(dbPath string) *gorm.DB {
-	db, err := gorm.Open(postgres.Open(dbPath), &gorm.Config{
-		SkipDefaultTransaction: true,
-	})
+	db, err := gorm.Open(postgres.Open(dbPath), &gorm.Config{})
 	if err != nil {
 		panic(err)
 	}
@@ -59,7 +62,7 @@ func dbMustDial(dbPath string) *gorm.DB {
 func dbMigrate(crud *crudr.Crudr, bucket *blob.Bucket, myHost string) {
 	// Migrate the schema
 	slog.Info("db: gorm automigrate")
-	err := crud.DB.AutoMigrate(&Upload{}, &RepairTracker{})
+	err := crud.DB.AutoMigrate(&Upload{}, &UploadCursor{}, &RepairTracker{})
 	if err != nil {
 		panic(err)
 	}

--- a/mediorum/server/server.go
+++ b/mediorum/server/server.go
@@ -391,6 +391,8 @@ func (ss *MediorumServer) MustStart() {
 
 		go ss.pollForSeedingCompletion()
 
+		go ss.startUploadScroller()
+
 	} else {
 		go func() {
 			for range time.Tick(10 * time.Second) {

--- a/mediorum/server/upload_client.go
+++ b/mediorum/server/upload_client.go
@@ -1,0 +1,78 @@
+package server
+
+import (
+	"fmt"
+	"time"
+
+	"gorm.io/gorm/clause"
+)
+
+func (ss *MediorumServer) startUploadScroller() {
+	time.Sleep(time.Minute)
+
+	for {
+		for _, peer := range ss.Config.Peers {
+			if peer.Host == ss.Config.Self.Host {
+				continue
+			}
+
+			uploadCursor := &UploadCursor{
+				Host: peer.Host,
+			}
+
+			// load prior cursor for host
+			ss.crud.DB.First(&uploadCursor, "host = ?", peer.Host)
+			logger := ss.logger.With("task", "upload_scroll", "host", peer.Host, "after", uploadCursor.After)
+
+			// fetch uploads from host
+			var uploads []*Upload
+			u := apiPath(peer.Host, "uploads") + "?after=" + uploadCursor.After.Format(time.RFC3339Nano)
+
+			resp, err := ss.reqClient.R().
+				SetSuccessResult(&uploads).
+				Get(u)
+
+			if err != nil {
+				logger.Error("list uploads failed", "err", err)
+				continue
+			}
+			if resp.StatusCode != 200 {
+				err := fmt.Errorf("%s: %s %s", resp.Request.RawURL, resp.Status, string(resp.Bytes()))
+				logger.Error("list uploads failed", "err", err)
+				continue
+			}
+
+			var overwrites []*Upload
+			for _, upload := range uploads {
+				// get existing upload
+				var existing *Upload
+				ss.crud.DB.First(&existing, "id = ?", upload.ID)
+
+				overwrite := existing == nil || (existing.Status != JobStatusDone && upload.Status == JobStatusDone) || existing.TranscodedAt.Before(upload.TranscodedAt)
+				if overwrite {
+					overwrites = append(overwrites, upload)
+				}
+
+				// advance cursor
+				uploadCursor.After = upload.CreatedAt
+			}
+
+			// write overwrites
+			err = ss.crud.DB.Clauses(clause.OnConflict{UpdateAll: true}).Create(overwrites).Error
+			if err != nil {
+				ss.logger.Warn("overwrite upload failed", "err", err)
+			}
+
+			// save cursor
+			if err := ss.crud.DB.Clauses(clause.OnConflict{UpdateAll: true}).Create(uploadCursor).Error; err != nil {
+				logger.Error("save upload cursor failed", "err", err)
+			} else {
+				logger.Info("OK", "uploads", len(uploads), "overwrites", len(overwrites), "after", uploadCursor.After)
+			}
+
+		}
+
+		time.Sleep(time.Minute * 2)
+	}
+
+}


### PR DESCRIPTION
### Description

Scrolls historical upload records to backfill from the pre-gossip days.

This could eventually replace the crudr ops stuff with something simpler.

### How Has This Been Tested?

Deployed to stage DN 12