### PR TITLE
Fix usdc search filter

### DIFF
--- a/discovery-provider/src/api/v1/helpers.py
+++ b/discovery-provider/src/api/v1/helpers.py
@@ -816,7 +816,7 @@ full_search_parser.add_argument(
 full_search_parser.add_argument(
     "includePurchaseable",
     required=False,
-    type=bool,
+    type=str,
     description="Whether or not to include purchaseable content",
 )
 

--- a/discovery-provider/src/api/v1/search.py
+++ b/discovery-provider/src/api/v1/search.py
@@ -8,6 +8,7 @@ from src.api.v1.helpers import (
     full_search_parser,
     get_current_user_id,
     make_full_response,
+    parse_bool_param,
     success_response,
 )
 from src.api.v1.models.search import search_model
@@ -43,6 +44,7 @@ class FullSearch(Resource):
         offset = format_offset(args)
         limit = format_limit(args)
         current_user_id = get_current_user_id(args)
+        include_purchaseable = parse_bool_param(args.get("includePurchaseable"))
 
         search_args = {
             "is_auto_complete": False,
@@ -53,7 +55,7 @@ class FullSearch(Resource):
             "limit": limit,
             "offset": offset,
             "only_downloadable": False,
-            "include_purchaseable": args.get("includePurchaseable", False),
+            "include_purchaseable": include_purchaseable,
         }
         resp = search(search_args)
         return success_response(resp)
@@ -84,6 +86,7 @@ class FullSearchAutocomplete(Resource):
         offset = format_offset(args)
         limit = format_limit(args)
         current_user_id = get_current_user_id(args)
+        include_purchaseable = parse_bool_param(args.get("includePurchaseable"))
 
         search_args = {
             "is_auto_complete": True,
@@ -94,7 +97,7 @@ class FullSearchAutocomplete(Resource):
             "limit": limit,
             "offset": offset,
             "only_downloadable": False,
-            "include_purchaseable": args.get("includePurchaseable", False),
+            "include_purchaseable": include_purchaseable,
         }
         resp = search(search_args)
         return success_response(resp)

--- a/discovery-provider/src/api/v1/utils/extend_notification.py
+++ b/discovery-provider/src/api/v1/utils/extend_notification.py
@@ -464,7 +464,9 @@ def extend_usdc_purchase_seller(action: NotificationAction):
             "buyer_user_id": encode_int_id(data["buyer_user_id"]),
             "seller_user_id": encode_int_id(data["seller_user_id"]),
             "amount": str(data["amount"]),
-            "extra_amount": str(data["extra_amount"]),
+            "extra_amount": str(data["extra_amount"])
+            if "extra_amount" in data
+            else "0",
             "content_id": encode_int_id(data["content_id"]),
         },
     }
@@ -484,7 +486,9 @@ def extend_usdc_purchase_buyer(action: NotificationAction):
             "buyer_user_id": encode_int_id(data["buyer_user_id"]),
             "seller_user_id": encode_int_id(data["seller_user_id"]),
             "amount": str(data["amount"]),
-            "extra_amount": str(data["extra_amount"]),
+            "extra_amount": str(data["extra_amount"])
+            if "extra_amount" in data
+            else "0",
             "content_id": encode_int_id(data["content_id"]),
         },
     }

--- a/discovery-provider/src/queries/search_es.py
+++ b/discovery-provider/src/queries/search_es.py
@@ -175,7 +175,7 @@ def search_tags_es(q: str, kind="all", current_user_id=None, limit=10, offset=0)
             "query": {
                 "bool": {
                     "must": [{"match": {fieldname: {"query": q}}}],
-                    "must_not": [],
+                    "must_not": [{"term": {"purchaseable": {"value": True}}}],
                     "should": [],
                 }
             },


### PR DESCRIPTION
### Description

* Broken because of improper bool filter
* Add filter to tag search - this is redundant since there's only a client-side lineup view for tag search, but figured for now we could do this and then revert the change down the line.

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._


```
 curl 'http://audius-protocol-discovery-provider-1/v1/full/search/autocomplete?includePurchaseable=false&limit=3&offset=0&query=buy&user_id=D809W'

 curl 'http://audius-protocol-discovery-provider-1/v1/full/search/autocomplete?includePurchaseable=true&limit=3&offset=0&query=buy&user_id=D809W'

 curl 'http://audius-protocol-discovery-provider-1/v1/full/search/autocomplete?limit=3&offset=0&query=buy&user_id=D809W'
```

confirmed via logs that the proper DSL is sent