### PR TITLE
[PROTO-1293] Reverse proxy to healthz from mediorum server

### DIFF
--- a/mediorum/server/server.go
+++ b/mediorum/server/server.go
@@ -312,6 +312,17 @@ func New(config MediorumConfig) (*MediorumServer, error) {
 	routes.POST("/delist_status/insert", ss.serveInsertDelistStatus, ss.requireBodySignedByOwner)
 
 	// -------------------
+	// healthz
+	healthzUrl, err := url.Parse("http://healthz")
+	if err != nil {
+		log.Fatal("Invalid healthz URL: ", err)
+	}
+	healthz := routes.Group("/healthz")
+	healthz.Use(middleware.Proxy(middleware.NewRandomBalancer([]*middleware.ProxyTarget{
+		{ URL: healthzUrl },
+	})))
+
+	// -------------------
 	// internal
 	internalApi := routes.Group("/internal")
 


### PR DESCRIPTION
### Description

To allow the /healthz endpoint to be accessible on all content nodes that don't use audius-docker-compose Caddy, we will reverse proxy directly from mediorum.

### How Has This Been Tested?

Ran `audius-compose up` and verified that healthz was accessible via `localhost:1991/healthz` including subroutes.