### PR TITLE
[C-3168] Add missing submit type on button

### DIFF
--- a/packages/web/src/pages/upload-page/fields/MultiTrackSidebar.tsx
+++ b/packages/web/src/pages/upload-page/fields/MultiTrackSidebar.tsx
@@ -50,6 +50,7 @@ export const MultiTrackSidebar = () => {
               text={messages.complete}
               variant={HarmonyButtonType.PRIMARY}
               iconRight={IconUpload}
+              type='submit'
               fullWidth
             />
           </div>

--- a/packages/web/src/pages/upload-page/fields/SelectGenreField.tsx
+++ b/packages/web/src/pages/upload-page/fields/SelectGenreField.tsx
@@ -25,6 +25,7 @@ export const SelectGenreField = (props: SelectGenreFieldProps) => {
       mount='parent'
       menu={menu}
       size='large'
+      isRequired
       {...props}
     />
   )


### PR DESCRIPTION
### Description

No idea why this broke with latest release build. It works in prod and broken on rc but we haven't found any relevant changes in these files since then.

### How Has This Been Tested?

Local web. Works with type submit and breaks without it