### PR TITLE
[PAY-1917] Add parens around seconds

### DIFF
--- a/packages/mobile/src/screens/edit-track-screen/fields/AccessAndSaleField/PremiumRadioField/TrackPreviewField.tsx
+++ b/packages/mobile/src/screens/edit-track-screen/fields/AccessAndSaleField/PremiumRadioField/TrackPreviewField.tsx
@@ -12,7 +12,7 @@ const messages = {
     'A 30 second preview will be generated. Specify a starting timestamp below.',
   label: 'Start Time',
   placeholder: 'Start Time',
-  seconds: 'Seconds'
+  seconds: '(Seconds)'
 }
 
 export const TrackPreviewField = () => {

--- a/packages/web/src/pages/upload-page/fields/availability/UsdcPurchaseFields.tsx
+++ b/packages/web/src/pages/upload-page/fields/availability/UsdcPurchaseFields.tsx
@@ -39,7 +39,7 @@ const messages = {
   },
   dollars: '$',
   usdc: '(USDC)',
-  seconds: 'Seconds'
+  seconds: '(Seconds)'
 }
 
 export enum UsdcPurchaseType {


### PR DESCRIPTION
### Description

<img width="758" alt="image" src="https://github.com/AudiusProject/audius-protocol/assets/2731362/2c2bc0b3-47be-4cc7-8099-545959c6a2e2">

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._

```
npm run web:stage
npm run ios:stage
```