### PR TITLE
Optimize trending requests

### DIFF
--- a/discovery-provider/src/queries/get_trending.py
+++ b/discovery-provider/src/queries/get_trending.py
@@ -25,7 +25,7 @@ def get_trending(args, strategy):
         "genre": args.get("genre", None),
         "with_users": True,
         "limit": format_limit(args, TRENDING_LIMIT),
-        "offset": 0,
+        "offset": format_offset(args),
         "exclude_premium": args.get(
             "exclude_premium", SHOULD_TRENDING_EXCLUDE_PREMIUM_TRACKS
         ),
@@ -41,8 +41,6 @@ def get_trending(args, strategy):
 
 
 def get_full_trending(request, args, strategy):
-    offset = format_offset(args)
-    limit = format_limit(args, TRENDING_LIMIT)
     key = get_trending_cache_key(to_dict(request.args), request.path)
 
     # Attempt to use the cached tracks list
@@ -52,5 +50,4 @@ def get_full_trending(request, args, strategy):
         full_trending = use_redis_cache(
             key, TRENDING_TTL_SEC, lambda: get_trending(args, strategy)
         )
-    trending_tracks = full_trending[offset : limit + offset]
-    return trending_tracks
+    return full_trending

--- a/discovery-provider/src/queries/get_trending.py
+++ b/discovery-provider/src/queries/get_trending.py
@@ -24,7 +24,7 @@ def get_trending(args, strategy):
         "time": time,
         "genre": args.get("genre", None),
         "with_users": True,
-        "limit": TRENDING_LIMIT,
+        "limit": format_limit(args, TRENDING_LIMIT),
         "offset": 0,
         "exclude_premium": args.get(
             "exclude_premium", SHOULD_TRENDING_EXCLUDE_PREMIUM_TRACKS

--- a/discovery-provider/src/queries/get_trending_tracks.py
+++ b/discovery-provider/src/queries/get_trending_tracks.py
@@ -225,6 +225,7 @@ def make_generate_unpopulated_trending(
     time_range: str,
     strategy: BaseTrendingStrategy,
     exclude_premium: bool,
+    limit: int
 ):
     """Wraps a call to `generate_unpopulated_trending` for use in `use_redis_cache`, which
     expects to be passed a function with no arguments."""
@@ -237,6 +238,7 @@ def make_generate_unpopulated_trending(
                 time_range=time_range,
                 strategy=strategy,
                 exclude_premium=exclude_premium,
+                limit=limit
             )
         return generate_unpopulated_trending(
             session=session,
@@ -244,6 +246,7 @@ def make_generate_unpopulated_trending(
             time_range=time_range,
             strategy=strategy,
             exclude_premium=exclude_premium,
+            limit=limit
         )
 
     return wrapped

--- a/discovery-provider/src/queries/get_trending_tracks.py
+++ b/discovery-provider/src/queries/get_trending_tracks.py
@@ -254,6 +254,8 @@ class GetTrendingTracksArgs(TypedDict, total=False):
     genre: Optional[str]
     time: str
     exclude_premium: bool
+    limit: int
+    offset: int
 
 
 def get_trending_tracks(args: GetTrendingTracksArgs, strategy: BaseTrendingStrategy):


### PR DESCRIPTION
### Description

I believe this is at least a 5x improvement on trending requests. The biggest bottleneck in trending is populating metadata. In some cases this can take 14 seconds alone.
```
{"level": "INFO", "msg": "got track play count completed 14.473582744598389", "timestamp": "2023-10-02 22:46:47,515", "service": "server", "otelSpanID": "8d775f5305530e6a", "otelTraceID": "18ac26b35ba35c53c24b3cea00435d6d", "otelServiceName": "discovery-provider", "path": "src.queries.query_helpers", "function": "populate_user_metadata"}
{"level": "INFO", "msg": "populate_track_metadata completed in 14.91640305519104", "timestamp": "2023-10-02 22:46:47,609", "service": "server", "otelSpanID": "8d775f5305530e6a", "otelTraceID": "18ac26b35ba35c53c24b3cea00435d6d", "otelServiceName": "discovery-provider", "path": "src.queries.query_helpers", "function": "populate_user_metadata", "duration": 14.91640305519104}
```

The main reason this is slow is because we're populating metadata for 100 tracks (the default limit of trending). Once we have those tracks fully populated, then we filter by the limit / offset. For the typical request of 10 trending tracks the client makes, this is 10x the work.

This would be optimized if we limit / offset before populating metadata.

Before:
It can take multiple seconds in bad cases but consistently .5 secs once postgres caches.
```
real	0m6.051s

ubuntu@isaac-sandbox:~/audius-docker-compose$ time curl 'localhost:5000/v1/full/tracks/trending?limit=4&offset=9&time=week&user_id=0MMZ6' > /dev/null
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 20262  100 20262    0     0   6908      0  0:00:02  0:00:02 --:--:--  6905

real	0m2.942s

ubuntu@isaac-sandbox:~/audius-docker-compose$ time curl 'localhost:5000/v1/full/tracks/trending?limit=4&offset=9&time=week&user_id=0MMZ6' > /dev/null
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 20262  100 20262    0     0  43952      0 --:--:-- --:--:-- --:--:-- 43952

real	0m0.468s
user	0m0.000s
sys	0m0.008s
```

After:
Always under .2 seconds.
```
ubuntu@isaac-sandbox:~/audius-docker-compose$ time curl 'localhost:5000/v1/full/tracks/trending?limit=4&offset=9&time=week&user_id=0MMZ6' > /dev/null
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 20208  100 20208    0     0   177k      0 --:--:-- --:--:-- --:--:--  177k

real	0m0.119s
user	0m0.004s
sys	0m0.004s
ubuntu@isaac-sandbox:~/audius-docker-compose$ time curl 'localhost:5000/v1/full/tracks/trending?limit=4&offset=9&time=week&user_id=0MMZ6' > /dev/null
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 20208  100 20208    0     0  19.2M      0 --:--:-- --:--:-- --:--:-- 19.2M

real	0m0.007s
user	0m0.007s
sys	0m0.000s
ubuntu@isaac-sandbox:~/audius-docker-compose$ time curl 'localhost:5000/v1/full/tracks/trending?limit=4&offset=9&time=week&user_id=0MMZ6' > /dev/null
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 20208  100 20208    0     0   112k      0 --:--:-- --:--:-- --:--:--  113k

real	0m0.182s
user	0m0.000s
sys	0m0.008s

```
### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._
Tested on sandbox, confirmed responses are consistent while adjusting offset / limit.