### PR TITLE
[PAY-1936] Allow preview timestamps to be set for "unpreviewable" tracks

### DIFF
--- a/packages/mobile/src/screens/edit-track-screen/EditTrackScreen.tsx
+++ b/packages/mobile/src/screens/edit-track-screen/EditTrackScreen.tsx
@@ -30,13 +30,13 @@ const EditTrackSchema = Yup.object().shape({
         .max(9999.99, 'Price must be less than $9999.99.')
     }).nullable()
   }).nullable(),
-  duration: Yup.number(),
+  duration: Yup.number().nullable(),
   preview_start_seconds: Yup.number()
     .test('isValidPreviewStart', '', function (value: number) {
       const duration = this.resolve(Yup.ref('duration')) as unknown as number
       // If duration is NaN, validation passes because we were
-      // unable to generate a browser-side preview to get duration
-      if (isNaN(duration)) return true
+      // unable to get duration from a track
+      if (isNaN(duration) || duration === null) return true
       if (duration > 30 && value > duration - 30) {
         return this.createError({
           message:

--- a/packages/mobile/src/screens/edit-track-screen/EditTrackScreen.tsx
+++ b/packages/mobile/src/screens/edit-track-screen/EditTrackScreen.tsx
@@ -35,7 +35,7 @@ const EditTrackSchema = Yup.object().shape({
     .test('isValidPreviewStart', '', function (value: number) {
       const duration = this.resolve(Yup.ref('duration')) as unknown as number
       // If duration is NaN, validation passes because we were
-      // unable to generate a preview
+      // unable to generate a browser-side preview to get duration
       if (isNaN(duration)) return true
       if (duration > 30 && value > duration - 30) {
         return this.createError({

--- a/packages/mobile/src/screens/edit-track-screen/EditTrackScreen.tsx
+++ b/packages/mobile/src/screens/edit-track-screen/EditTrackScreen.tsx
@@ -32,14 +32,25 @@ const EditTrackSchema = Yup.object().shape({
   }).nullable(),
   duration: Yup.number(),
   preview_start_seconds: Yup.number()
-    .max(
-      (Yup.ref('duration') as unknown as number) > 30
-        ? (Yup.ref('duration') as unknown as number) - 30
-        : 0,
-      (Yup.ref('duration') as unknown as number)
-        ? 'Preview must start at least 30 seconds before the end of the track.'
-        : 'Preview must start at 0 since the track is less than 30 seconds'
-    )
+    .test('isValidPreviewStart', '', function (value: number) {
+      const duration = this.resolve(Yup.ref('duration')) as unknown as number
+      // If duration is NaN, validation passes because we were
+      // unable to generate a preview
+      if (isNaN(duration)) return true
+      if (duration > 30 && value > duration - 30) {
+        return this.createError({
+          message:
+            'Preview must start at least 30 seconds before the end of the track.'
+        })
+      }
+      if (duration <= 30 && value !== 0) {
+        return this.createError({
+          message:
+            'Preview must start at 0 since the track is less than 30 seconds.'
+        })
+      }
+      return true
+    })
     .nullable()
 })
 

--- a/packages/web/src/components/data-entry/AccessAndSaleModalLegacy.tsx
+++ b/packages/web/src/components/data-entry/AccessAndSaleModalLegacy.tsx
@@ -50,18 +50,7 @@ const messages = {
   premium: 'Premium',
   specialAccess: 'Special Access',
   collectibleGated: 'Collectible Gated',
-  hidden: 'Hidden',
-  errors: {
-    price: {
-      tooLow: 'Price must be at least $0.99',
-      tooHigh: 'Price must be less than $9999.99'
-    },
-    preview: {
-      tooEarly: 'Preview must start during the track',
-      tooLate:
-        'Preview must start at least 30 seconds before the end of the track'
-    }
-  }
+  hidden: 'Hidden'
 }
 
 type AccessAndSaleModalLegacyProps = {

--- a/packages/web/src/pages/upload-page/components/PreviewButton.tsx
+++ b/packages/web/src/pages/upload-page/components/PreviewButton.tsx
@@ -1,0 +1,64 @@
+import { useCallback, useContext, useEffect, useState } from 'react'
+
+import {
+  HarmonyPlainButton,
+  HarmonyPlainButtonType,
+  IconPause,
+  IconPlay
+} from '@audius/stems'
+import { useField } from 'formik'
+
+import { CollectionTrackForUpload } from '../types'
+import { UploadPreviewContext } from '../utils/uploadPreviewContext'
+
+const messages = {
+  overrideLabel: 'Override details for this track',
+  preview: 'Preview',
+  delete: 'Delete'
+}
+
+type PreviewButtonProps = {
+  index: number
+  className?: string
+}
+
+export const PreviewButton = ({ index, className }: PreviewButtonProps) => {
+  const { playingPreviewIndex, togglePreview } =
+    useContext(UploadPreviewContext)
+  const [{ value: track }] = useField<CollectionTrackForUpload>(
+    `tracks.${index}`
+  )
+  const isPreviewPlaying = playingPreviewIndex === index
+
+  const [canPlayPreview, setCanPlayPreview] = useState(false)
+
+  const canPlay = useCallback(() => {
+    setCanPlayPreview(true)
+  }, [setCanPlayPreview])
+
+  useEffect(() => {
+    // 2 or more signifies playable
+    // https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement/readyState
+    if (track.preview.readyState >= 2) {
+      canPlay()
+    } else {
+      track.preview.addEventListener('canplay', canPlay)
+      return () => {
+        track.preview.removeEventListener('canplay', canPlay)
+      }
+    }
+  }, [track.preview, canPlay])
+
+  return canPlayPreview ? (
+    <HarmonyPlainButton
+      className={className}
+      variant={HarmonyPlainButtonType.SUBDUED}
+      type='button'
+      text={messages.preview}
+      iconLeft={isPreviewPlaying ? IconPause : IconPlay}
+      onClick={() => {
+        togglePreview(track.preview, index)
+      }}
+    />
+  ) : null
+}

--- a/packages/web/src/pages/upload-page/fields/AccessAndSaleField.tsx
+++ b/packages/web/src/pages/upload-page/fields/AccessAndSaleField.tsx
@@ -165,6 +165,7 @@ export const AccessAndSaleFormSchema = (trackLength: number) =>
         if (isPremiumContentUSDCPurchaseGated(formValues[PREMIUM_CONDITIONS])) {
           return (
             formValues[PREVIEW] === undefined ||
+            isNaN(trackLength) ||
             (formValues[PREVIEW] >= 0 &&
               formValues[PREVIEW] < trackLength - 30) ||
             (trackLength <= 30 && formValues[PREVIEW] < trackLength)

--- a/packages/web/src/pages/upload-page/fields/CollectionTrackField.tsx
+++ b/packages/web/src/pages/upload-page/fields/CollectionTrackField.tsx
@@ -4,8 +4,6 @@ import {
   HarmonyPlainButton,
   HarmonyPlainButtonType,
   IconDrag,
-  IconPause,
-  IconPlay,
   IconTrash
 } from '@audius/stems'
 import { useField } from 'formik'
@@ -16,6 +14,7 @@ import { SwitchField } from 'components/form-fields/SwitchField'
 import { Tile } from 'components/tile'
 import { Text } from 'components/typography'
 
+import { PreviewButton } from '../components/PreviewButton'
 import { SelectGenreField } from '../fields/SelectGenreField'
 import { SelectMoodField } from '../fields/SelectMoodField'
 import { TrackNameField } from '../fields/TrackNameField'
@@ -26,7 +25,6 @@ import styles from './CollectionTrackField.module.css'
 
 const messages = {
   overrideLabel: 'Override details for this track',
-  preview: 'Preview',
   delete: 'Delete'
 }
 
@@ -38,8 +36,7 @@ type CollectionTrackFieldProps = {
 
 export const CollectionTrackField = (props: CollectionTrackFieldProps) => {
   const { disableDelete = false, index, remove } = props
-  const { playingPreviewIndex, togglePreview, stopPreview } =
-    useContext(UploadPreviewContext)
+  const { playingPreviewIndex, stopPreview } = useContext(UploadPreviewContext)
   const [{ value: track }] = useField<CollectionTrackForUpload>(
     `tracks.${index}`
   )
@@ -91,15 +88,7 @@ export const CollectionTrackField = (props: CollectionTrackFieldProps) => {
           <Text>{messages.overrideLabel}</Text>
         </div>
         <div className={styles.actions}>
-          <HarmonyPlainButton
-            variant={HarmonyPlainButtonType.SUBDUED}
-            type='button'
-            text={messages.preview}
-            iconLeft={isPreviewPlaying ? IconPause : IconPlay}
-            onClick={() => {
-              togglePreview(track.preview, index)
-            }}
-          />
+          <PreviewButton index={index} />
           <HarmonyPlainButton
             variant={HarmonyPlainButtonType.SUBDUED}
             type='button'

--- a/packages/web/src/pages/upload-page/forms/EditTrackForm.tsx
+++ b/packages/web/src/pages/upload-page/forms/EditTrackForm.tsx
@@ -1,12 +1,6 @@
 import { useCallback, useContext, useMemo } from 'react'
 
-import {
-  HarmonyPlainButton,
-  HarmonyPlainButtonType,
-  IconCaretRight,
-  IconPause,
-  IconPlay
-} from '@audius/stems'
+import { HarmonyPlainButton, IconCaretRight } from '@audius/stems'
 import cn from 'classnames'
 import { Form, Formik, FormikProps, useField } from 'formik'
 import moment from 'moment'
@@ -21,6 +15,7 @@ import { Text } from 'components/typography'
 import { UploadFormScrollContext } from 'pages/upload-page/UploadPageNew'
 
 import { AnchoredSubmitRow } from '../components/AnchoredSubmitRow'
+import { PreviewButton } from '../components/PreviewButton'
 import { AccessAndSaleField } from '../fields/AccessAndSaleField'
 import { AttributionField } from '../fields/AttributionField'
 import { MultiTrackSidebar } from '../fields/MultiTrackSidebar'
@@ -30,7 +25,6 @@ import { SourceFilesField } from '../fields/SourceFilesField'
 import { TrackMetadataFields } from '../fields/TrackMetadataFields'
 import { defaultHiddenFields } from '../fields/availability/HiddenAvailabilityFields'
 import { TrackEditFormValues, TrackFormState } from '../types'
-import { UploadPreviewContext } from '../utils/uploadPreviewContext'
 import { TrackMetadataFormSchema } from '../validation'
 
 import styles from './EditTrackForm.module.css'
@@ -120,9 +114,6 @@ const TrackEditForm = (props: FormikProps<TrackEditFormValues>) => {
   const { values, dirty } = props
   const isMultiTrack = values.trackMetadatas.length > 1
   const trackIdx = values.trackMetadatasIndex
-  const { playingPreviewIndex, togglePreview } =
-    useContext(UploadPreviewContext)
-  const isPreviewPlaying = playingPreviewIndex === trackIdx
   const [, , { setValue: setIndex }] = useField('trackMetadatasIndex')
   useUnmount(() => {
     setIndex(0)
@@ -149,15 +140,11 @@ const TrackEditForm = (props: FormikProps<TrackEditFormValues>) => {
               <AccessAndSaleField isUpload />
               <AttributionField />
             </div>
-            <HarmonyPlainButton
+            <PreviewButton
+              // Since edit form is a single component, render a different preview for each track
+              key={trackIdx}
               className={styles.previewButton}
-              variant={HarmonyPlainButtonType.SUBDUED}
-              type='button'
-              text={messages.preview}
-              iconLeft={isPreviewPlaying ? IconPause : IconPlay}
-              onClick={() => {
-                togglePreview(values.tracks[trackIdx].preview, trackIdx)
-              }}
+              index={trackIdx}
             />
           </div>
           {isMultiTrack ? <MultiTrackFooter /> : null}

--- a/packages/web/src/pages/upload-page/store/utils/processFiles.ts
+++ b/packages/web/src/pages/upload-page/store/utils/processFiles.ts
@@ -86,7 +86,7 @@ export const processFiles = (
       )
     }
     const audio = new Audio()
-    // @ts-ignore
+    // @ts-ignore preview is present on `file` in the browser context
     audio.src = file.preview
     return {
       file,


### PR DESCRIPTION
### Description

Reader beware of confusing name overloading - using this terminology to help:
* Upload Preview: The preview button shown during upload to help you listen to what you're uploading
* Purchase Preview: The preview that is generated server side to help people listen prior to purchase

The bug:
* You cannot set the purchase review of AIF/FLAC/etc files

Why?
* The upload preview is invalid because the browser cannot play AIF/FLAC/etc files and there for zod/yup validation expects being able to collect the duration of the file to validate the purchase preview.

Solve (nearterm):
* On invalid upload preview, just let the user try
* On invalid upload preview, don't render the upload preview button
* On mobile, use ffmpeg instead of TrackPlayer to get duration. TrackPlayer is unreliable after some on device testing.


### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._

```
npm run web:stage

npm run mobile
npm run io:stage
```
And tried to upload and set preview of aiff file.

Additional screenshots:
![image (35)](https://github.com/AudiusProject/audius-protocol/assets/2731362/067633fe-f73e-48af-b20d-08fd547761eb)

<img width="791" alt="image" src="https://github.com/AudiusProject/audius-protocol/assets/2731362/bb2037cc-8624-4341-9fa2-d3afd194fe29">

