### PR TITLE
Readall when serving image.

### DIFF
--- a/mediorum/server/serve_blob.go
+++ b/mediorum/server/serve_blob.go
@@ -24,7 +24,7 @@ import (
 	"golang.org/x/exp/slices"
 )
 
-func (ss *MediorumServer) getBlobLocation(c echo.Context) error {
+func (ss *MediorumServer) serveBlobLocation(c echo.Context) error {
 	cid := c.Param("cid")
 	preferred, _ := ss.rendezvousAllHosts(cid)
 
@@ -92,7 +92,7 @@ func (ss *MediorumServer) getBlobLocation(c echo.Context) error {
 	})
 }
 
-func (ss *MediorumServer) getBlobInfo(c echo.Context) error {
+func (ss *MediorumServer) serveBlobInfo(c echo.Context) error {
 	ctx := c.Request().Context()
 	cid := c.Param("cid")
 	key := cidutil.ShardCID(cid)
@@ -129,7 +129,7 @@ func (ss *MediorumServer) ensureNotDelisted(next echo.HandlerFunc) echo.HandlerF
 	}
 }
 
-func (ss *MediorumServer) getBlob(c echo.Context) error {
+func (ss *MediorumServer) serveBlob(c echo.Context) error {
 	ctx := c.Request().Context()
 	cid := c.Param("cid")
 
@@ -388,7 +388,7 @@ func (s *MediorumServer) requireRegisteredSignature(next echo.HandlerFunc) echo.
 	}
 }
 
-func (ss *MediorumServer) serveInternalBlobPull(c echo.Context) error {
+func (ss *MediorumServer) serveInternalBlobGET(c echo.Context) error {
 	ctx := c.Request().Context()
 	cid := c.Param("cid")
 	key := cidutil.ShardCID(cid)
@@ -402,7 +402,7 @@ func (ss *MediorumServer) serveInternalBlobPull(c echo.Context) error {
 	return c.Stream(200, blob.ContentType(), blob)
 }
 
-func (ss *MediorumServer) postBlob(c echo.Context) error {
+func (ss *MediorumServer) serveInternalBlobPOST(c echo.Context) error {
 	if !ss.diskHasSpace() {
 		return c.String(http.StatusServiceUnavailable, "disk is too full to accept new blobs")
 	}

--- a/mediorum/server/serve_image.go
+++ b/mediorum/server/serve_image.go
@@ -1,0 +1,145 @@
+package server
+
+import (
+	"fmt"
+	"io"
+	"mediorum/cidutil"
+	"mime"
+	"strings"
+	"time"
+
+	"github.com/labstack/echo/v4"
+	"gocloud.dev/blob"
+)
+
+func (ss *MediorumServer) serveImage(c echo.Context) error {
+	// images are small enough to always serve all at once (no 206 range responses)
+	c.Request().Header.Del("Range")
+
+	ctx := c.Request().Context()
+	jobID := c.Param("jobID")
+	variant := c.Param("variant")
+	isOriginalJpg := variant == "original.jpg"
+
+	// helper function... only sets cache-control header on success
+	serveSuccessWithReader := func(blob *blob.Reader) error {
+		blobData, err := io.ReadAll(blob)
+		if err != nil {
+			return err
+		}
+		blob.Close()
+		c.Response().Header().Set(echo.HeaderCacheControl, "public, max-age=2592000, immutable")
+		return c.Blob(200, blob.ContentType(), blobData)
+	}
+
+	serveSuccess := func(blobPath string) error {
+		if blob, err := ss.bucket.NewReader(ctx, blobPath, nil); err == nil {
+			return serveSuccessWithReader(blob)
+		} else {
+			return err
+		}
+	}
+
+	// if the client provided a filename, set it in the header to be auto-populated in download prompt
+	filenameForDownload := c.QueryParam("filename")
+	if filenameForDownload != "" {
+		contentDisposition := mime.QEncoding.Encode("utf-8", filenameForDownload)
+		c.Response().Header().Set("Content-Disposition", fmt.Sprintf(`attachment; filename="%s"`, contentDisposition))
+	}
+
+	// 1. resolve ulid to upload cid
+	if cid, err := ss.getUploadOrigCID(jobID); err == nil {
+		c.Response().Header().Set("x-orig-cid", cid)
+		jobID = cid
+	}
+
+	// 2. if is ba ... serve variant
+	if strings.HasPrefix(jobID, "ba") {
+		baCid := jobID
+
+		var variantStoragePath string
+
+		// parse 150x150 dimensions
+		// while still allowing original.jpg
+		w, h, err := parseVariantSize(variant)
+		if err == nil {
+			variantStoragePath = cidutil.ImageVariantPath(baCid, variant)
+		} else if isOriginalJpg {
+			variantStoragePath = cidutil.ShardCID(baCid)
+		} else {
+			return c.String(400, err.Error())
+		}
+
+		c.Response().Header().Set("x-variant-storage-path", variantStoragePath)
+
+		// we already have the resized version
+		if blob, err := ss.bucket.NewReader(ctx, variantStoragePath, nil); err == nil {
+			return serveSuccessWithReader(blob)
+		}
+
+		// open the orig for resizing
+		origReader, err := ss.bucket.NewReader(ctx, cidutil.ShardCID(baCid), nil)
+
+		// if we don't have orig, fetch from network
+		if err != nil {
+			startFetch := time.Now()
+			host, err := ss.findAndPullBlob(ctx, baCid)
+			if err != nil {
+				return c.String(404, err.Error())
+			}
+
+			c.Response().Header().Set("x-fetch-host", host)
+			c.Response().Header().Set("x-fetch-ok", fmt.Sprintf("%.2fs", time.Since(startFetch).Seconds()))
+
+			origReader, err = ss.bucket.NewReader(ctx, cidutil.ShardCID(baCid), nil)
+			if err != nil {
+				return err
+			}
+		}
+
+		// do resize if not original.jpg
+		if !isOriginalJpg {
+			resizeStart := time.Now()
+			resized, _, _ := Resized(".jpg", origReader, w, h, "fill")
+			w, _ := ss.bucket.NewWriter(ctx, variantStoragePath, nil)
+			io.Copy(w, resized)
+			w.Close()
+			c.Response().Header().Set("x-resize-ok", fmt.Sprintf("%.2fs", time.Since(resizeStart).Seconds()))
+		}
+		origReader.Close()
+
+		// ... serve it
+		return serveSuccess(variantStoragePath)
+	}
+
+	// 3. if Qm ... serve legacy
+	if cidutil.IsLegacyCID(jobID) {
+
+		// storage path for Qm images is like:
+		// QmDirMultihash/150x150.jpg
+		// (no sharding)
+		key := jobID + "/" + variant
+
+		c.Response().Header().Set("x-variant-storage-path", key)
+
+		// have it
+		if blob, err := ss.bucket.NewReader(ctx, key, nil); err == nil {
+			return serveSuccessWithReader(blob)
+		}
+
+		// pull blob from another host and store it at key
+		// keys like QmDirMultiHash/150x150.jpg works fine with findNodeToServeBlob
+		startFetch := time.Now()
+		host, err := ss.findAndPullBlob(ctx, key)
+		if err != nil {
+			return c.String(404, err.Error())
+		}
+
+		c.Response().Header().Set("x-fetch-host", host)
+		c.Response().Header().Set("x-fetch-ok", fmt.Sprintf("%.2fs", time.Since(startFetch).Seconds()))
+		return serveSuccess(key)
+	}
+
+	msg := fmt.Sprintf("variant %s not found for upload %s", variant, jobID)
+	return c.String(400, msg)
+}

--- a/mediorum/server/serve_upload.go
+++ b/mediorum/server/serve_upload.go
@@ -3,9 +3,7 @@ package server
 import (
 	"database/sql"
 	"fmt"
-	"io"
 	"mediorum/cidutil"
-	"mime"
 	"net/http"
 	"strconv"
 	"strings"
@@ -13,7 +11,6 @@ import (
 
 	"github.com/labstack/echo/v4"
 	"github.com/oklog/ulid/v2"
-	"gocloud.dev/blob"
 	"golang.org/x/sync/errgroup"
 )
 
@@ -21,7 +18,7 @@ var (
 	filesFormFieldName = "files"
 )
 
-func (ss *MediorumServer) getUpload(c echo.Context) error {
+func (ss *MediorumServer) serveUploadDetail(c echo.Context) error {
 	var upload *Upload
 	err := ss.crud.DB.First(&upload, "id = ?", c.Param("id")).Error
 	if err != nil {
@@ -217,133 +214,4 @@ func (ss *MediorumServer) postUpload(c echo.Context) error {
 	}
 
 	return c.JSON(status, uploads)
-}
-
-func (ss *MediorumServer) getBlobByJobIDAndVariant(c echo.Context) error {
-	// images are small enough to always serve all at once (no 206 range responses)
-	c.Request().Header.Del("Range")
-
-	ctx := c.Request().Context()
-	jobID := c.Param("jobID")
-	variant := c.Param("variant")
-	isOriginalJpg := variant == "original.jpg"
-
-	// helper function... only sets cache-control header on success
-	serveSuccessWithReader := func(blob *blob.Reader) error {
-		name := fmt.Sprintf("%s/%s", jobID, variant)
-		c.Response().Header().Set(echo.HeaderCacheControl, "public, max-age=2592000, immutable")
-		http.ServeContent(c.Response(), c.Request(), name, blob.ModTime(), blob)
-		return blob.Close()
-	}
-
-	serveSuccess := func(blobPath string) error {
-		if blob, err := ss.bucket.NewReader(ctx, blobPath, nil); err == nil {
-			return serveSuccessWithReader(blob)
-		} else {
-			return err
-		}
-	}
-
-	// if the client provided a filename, set it in the header to be auto-populated in download prompt
-	filenameForDownload := c.QueryParam("filename")
-	if filenameForDownload != "" {
-		contentDisposition := mime.QEncoding.Encode("utf-8", filenameForDownload)
-		c.Response().Header().Set("Content-Disposition", fmt.Sprintf(`attachment; filename="%s"`, contentDisposition))
-	}
-
-	// 1. resolve ulid to upload cid
-	if cid, err := ss.getUploadOrigCID(jobID); err == nil {
-		c.Response().Header().Set("x-orig-cid", cid)
-		jobID = cid
-	}
-
-	// 2. if is ba ... serve variant
-	if strings.HasPrefix(jobID, "ba") {
-		baCid := jobID
-
-		var variantStoragePath string
-
-		// parse 150x150 dimensions
-		// while still allowing original.jpg
-		w, h, err := parseVariantSize(variant)
-		if err == nil {
-			variantStoragePath = cidutil.ImageVariantPath(baCid, variant)
-		} else if isOriginalJpg {
-			variantStoragePath = cidutil.ShardCID(baCid)
-		} else {
-			return c.String(400, err.Error())
-		}
-
-		c.Response().Header().Set("x-variant-storage-path", variantStoragePath)
-
-		// we already have the resized version
-		if blob, err := ss.bucket.NewReader(ctx, variantStoragePath, nil); err == nil {
-			return serveSuccessWithReader(blob)
-		}
-
-		// open the orig for resizing
-		origReader, err := ss.bucket.NewReader(ctx, cidutil.ShardCID(baCid), nil)
-
-		// if we don't have orig, fetch from network
-		if err != nil {
-			startFetch := time.Now()
-			host, err := ss.findAndPullBlob(ctx, baCid)
-			if err != nil {
-				return c.String(404, err.Error())
-			}
-
-			c.Response().Header().Set("x-fetch-host", host)
-			c.Response().Header().Set("x-fetch-ok", fmt.Sprintf("%.2fs", time.Since(startFetch).Seconds()))
-
-			origReader, err = ss.bucket.NewReader(ctx, cidutil.ShardCID(baCid), nil)
-			if err != nil {
-				return err
-			}
-		}
-
-		// do resize if not original.jpg
-		if !isOriginalJpg {
-			resizeStart := time.Now()
-			resized, _, _ := Resized(".jpg", origReader, w, h, "fill")
-			w, _ := ss.bucket.NewWriter(ctx, variantStoragePath, nil)
-			io.Copy(w, resized)
-			w.Close()
-			c.Response().Header().Set("x-resize-ok", fmt.Sprintf("%.2fs", time.Since(resizeStart).Seconds()))
-		}
-		origReader.Close()
-
-		// ... serve it
-		return serveSuccess(variantStoragePath)
-	}
-
-	// 3. if Qm ... serve legacy
-	if cidutil.IsLegacyCID(jobID) {
-
-		// storage path for Qm images is like:
-		// QmDirMultihash/150x150.jpg
-		// (no sharding)
-		key := jobID + "/" + variant
-
-		c.Response().Header().Set("x-variant-storage-path", key)
-
-		// have it
-		if blob, err := ss.bucket.NewReader(ctx, key, nil); err == nil {
-			return serveSuccessWithReader(blob)
-		}
-
-		// pull blob from another host and store it at key
-		// keys like QmDirMultiHash/150x150.jpg works fine with findNodeToServeBlob
-		startFetch := time.Now()
-		host, err := ss.findAndPullBlob(ctx, key)
-		if err != nil {
-			return c.String(404, err.Error())
-		}
-
-		c.Response().Header().Set("x-fetch-host", host)
-		c.Response().Header().Set("x-fetch-ok", fmt.Sprintf("%.2fs", time.Since(startFetch).Seconds()))
-		return serveSuccess(key)
-	}
-
-	msg := fmt.Sprintf("variant %s not found for upload %s", variant, jobID)
-	return c.String(400, msg)
 }

--- a/mediorum/server/server.go
+++ b/mediorum/server/server.go
@@ -280,7 +280,7 @@ func New(config MediorumConfig) (*MediorumServer, error) {
 
 	// public: uploads
 	routes.GET("/uploads", ss.serveUploadList)
-	routes.GET("/uploads/:id", ss.getUpload, ss.requireHealthy)
+	routes.GET("/uploads/:id", ss.serveUploadDetail, ss.requireHealthy)
 	routes.POST("/uploads/:id", ss.updateUpload, ss.requireHealthy, ss.requireUserSignature)
 	routes.POST("/uploads", ss.postUpload, ss.requireHealthy)
 	// workaround because reverse proxy catches the browser's preflight OPTIONS request instead of letting our CORS middleware handle it
@@ -288,16 +288,20 @@ func New(config MediorumConfig) (*MediorumServer, error) {
 		return c.NoContent(http.StatusNoContent)
 	})
 
-	routes.HEAD("/ipfs/:cid", ss.getBlob, ss.requireHealthy, ss.ensureNotDelisted)
-	routes.GET("/ipfs/:cid", ss.getBlob, ss.requireHealthy, ss.ensureNotDelisted)
-	routes.HEAD("/content/:cid", ss.getBlob, ss.requireHealthy, ss.ensureNotDelisted)
-	routes.GET("/content/:cid", ss.getBlob, ss.requireHealthy, ss.ensureNotDelisted)
-	routes.HEAD("/ipfs/:jobID/:variant", ss.getBlobByJobIDAndVariant, ss.requireHealthy)
-	routes.GET("/ipfs/:jobID/:variant", ss.getBlobByJobIDAndVariant, ss.requireHealthy)
-	routes.HEAD("/content/:jobID/:variant", ss.getBlobByJobIDAndVariant, ss.requireHealthy)
-	routes.GET("/content/:jobID/:variant", ss.getBlobByJobIDAndVariant, ss.requireHealthy)
-	routes.HEAD("/tracks/cidstream/:cid", ss.getBlob, ss.requireHealthy, ss.ensureNotDelisted, ss.requireRegisteredSignature)
-	routes.GET("/tracks/cidstream/:cid", ss.getBlob, ss.requireHealthy, ss.ensureNotDelisted, ss.requireRegisteredSignature)
+	// serve blob (audio)
+	routes.HEAD("/ipfs/:cid", ss.serveBlob, ss.requireHealthy, ss.ensureNotDelisted)
+	routes.GET("/ipfs/:cid", ss.serveBlob, ss.requireHealthy, ss.ensureNotDelisted)
+	routes.HEAD("/content/:cid", ss.serveBlob, ss.requireHealthy, ss.ensureNotDelisted)
+	routes.GET("/content/:cid", ss.serveBlob, ss.requireHealthy, ss.ensureNotDelisted)
+	routes.HEAD("/tracks/cidstream/:cid", ss.serveBlob, ss.requireHealthy, ss.ensureNotDelisted, ss.requireRegisteredSignature)
+	routes.GET("/tracks/cidstream/:cid", ss.serveBlob, ss.requireHealthy, ss.ensureNotDelisted, ss.requireRegisteredSignature)
+
+	// serve image
+	routes.HEAD("/ipfs/:jobID/:variant", ss.serveImage, ss.requireHealthy)
+	routes.GET("/ipfs/:jobID/:variant", ss.serveImage, ss.requireHealthy)
+	routes.HEAD("/content/:jobID/:variant", ss.serveImage, ss.requireHealthy)
+	routes.GET("/content/:jobID/:variant", ss.serveImage, ss.requireHealthy)
+
 	routes.GET("/contact", ss.serveContact)
 	routes.GET("/health_check", ss.serveHealthCheck)
 	routes.HEAD("/health_check", ss.serveHealthCheck)
@@ -319,12 +323,12 @@ func New(config MediorumConfig) (*MediorumServer, error) {
 	internalApi.GET("/crud/sweep", ss.serveCrudSweep)
 	internalApi.POST("/crud/push", ss.serveCrudPush, middleware.BasicAuth(ss.checkBasicAuth))
 
-	internalApi.GET("/blobs/location/:cid", ss.getBlobLocation, cidutil.UnescapeCidParam)
-	internalApi.GET("/blobs/info/:cid", ss.getBlobInfo, cidutil.UnescapeCidParam)
+	internalApi.GET("/blobs/location/:cid", ss.serveBlobLocation, cidutil.UnescapeCidParam)
+	internalApi.GET("/blobs/info/:cid", ss.serveBlobInfo, cidutil.UnescapeCidParam)
 
 	// internal: blobs between peers
-	internalApi.GET("/blobs/:cid", ss.serveInternalBlobPull, cidutil.UnescapeCidParam, middleware.BasicAuth(ss.checkBasicAuth))
-	internalApi.POST("/blobs", ss.postBlob, middleware.BasicAuth(ss.checkBasicAuth))
+	internalApi.GET("/blobs/:cid", ss.serveInternalBlobGET, cidutil.UnescapeCidParam, middleware.BasicAuth(ss.checkBasicAuth))
+	internalApi.POST("/blobs", ss.serveInternalBlobPOST, middleware.BasicAuth(ss.checkBasicAuth))
 
 	// WIP internal: metrics
 	internalApi.GET("/metrics", ss.getMetrics)


### PR DESCRIPTION
To reduce chance that user sees partial image.  Also move stuff around and improve naming consistency.
