### PR TITLE
[PAY-1875] Add Premium Tracks Explore Page - Part 2

### DIFF
--- a/packages/common/src/services/audius-api-client/AudiusAPIClient.ts
+++ b/packages/common/src/services/audius-api-client/AudiusAPIClient.ts
@@ -111,7 +111,8 @@ const FULL_ENDPOINT_MAP = {
   getSupporters: (userId: OpaqueID) => `/users/${userId}/supporters`,
   getTips: '/tips',
   getPremiumContentSignatures: (userId: OpaqueID) =>
-    `/tracks/${userId}/nft-gated-signatures`
+    `/tracks/${userId}/nft-gated-signatures`,
+  getPremiumTracks: '/tracks/usdc-purchase'
 }
 
 const ENDPOINT_MAP = {
@@ -259,6 +260,12 @@ type GetUserAiTracksByHandleArgs = {
   offset?: number
   limit?: number
   getUnlisted: boolean
+}
+
+type GetPremiumTracksArgs = {
+  currentUserId: Nullable<ID>
+  offset?: number
+  limit?: number
 }
 
 type GetRelatedArtistsArgs = PaginationArgs & {
@@ -1127,6 +1134,32 @@ export class AudiusAPIClient {
       true,
       PathType.VersionFullPath,
       headers
+    )
+
+    if (!response) return []
+
+    const adapted = response.data.map(adapter.makeTrack).filter(removeNullable)
+    return adapted
+  }
+
+  async getPremiumTracks({
+    currentUserId,
+    limit,
+    offset
+  }: GetPremiumTracksArgs) {
+    this._assertInitialized()
+    const encodedCurrentUserId = encodeHashId(currentUserId)
+    const params = {
+      user_id: encodedCurrentUserId || undefined,
+      limit,
+      offset
+    }
+
+    const response = await this._getResponse<APIResponse<APITrack[]>>(
+      FULL_ENDPOINT_MAP.getPremiumTracks,
+      params,
+      true,
+      PathType.VersionFullPath
     )
 
     if (!response) return []

--- a/packages/common/src/store/pages/index.ts
+++ b/packages/common/src/store/pages/index.ts
@@ -142,3 +142,7 @@ export * from './audio-rewards/types'
 export * from './deactivate-account'
 
 export * from './chat'
+
+export { default as premiumTracksPageLineupReducer } from './premium-tracks/lineup/reducer'
+export * as premiumTracksPageLineupSelectors from './premium-tracks/lineup/selectors'
+export { premiumTracksActions as premiumTracksPageLineupActions } from './premium-tracks/lineup/actions'

--- a/packages/common/src/store/pages/premium-tracks/lineup/actions.ts
+++ b/packages/common/src/store/pages/premium-tracks/lineup/actions.ts
@@ -1,0 +1,11 @@
+import { LineupActions } from '../../../../store/lineup/actions'
+
+export const PREFIX = 'EXPLORE_PREMIUM_TRACKS'
+
+class PremiumTracksActions extends LineupActions {
+  constructor() {
+    super(PREFIX)
+  }
+}
+
+export const premiumTracksActions = new PremiumTracksActions()

--- a/packages/common/src/store/pages/premium-tracks/lineup/reducer.ts
+++ b/packages/common/src/store/pages/premium-tracks/lineup/reducer.ts
@@ -1,0 +1,30 @@
+import { RESET_SUCCEEDED, stripPrefix } from 'store/lineup/actions'
+import { initialLineupState } from 'store/lineup/reducer'
+
+import { Track, LineupState } from '../../../../models'
+
+import { PREFIX } from './actions'
+
+export const initialState: LineupState<Track> = {
+  ...initialLineupState,
+  prefix: PREFIX
+}
+
+const actionsMap: { [key in string]: any } = {
+  [RESET_SUCCEEDED](_state: typeof initialState) {
+    const newState = initialState
+    return newState
+  }
+}
+
+const premiumTracksReducer = (
+  state = initialState,
+  action: { type: string }
+) => {
+  const baseActionType = stripPrefix(PREFIX, action.type)
+  const matchingReduceFunction = actionsMap[baseActionType]
+  if (!matchingReduceFunction) return state
+  return matchingReduceFunction(state, action)
+}
+
+export default premiumTracksReducer

--- a/packages/common/src/store/pages/premium-tracks/lineup/selectors.ts
+++ b/packages/common/src/store/pages/premium-tracks/lineup/selectors.ts
@@ -1,0 +1,4 @@
+import { CommonState } from 'store/commonStore'
+
+export const getLineup = (state: CommonState) =>
+  state.pages.premiumTracks.tracks

--- a/packages/common/src/store/pages/premium-tracks/slice.ts
+++ b/packages/common/src/store/pages/premium-tracks/slice.ts
@@ -1,0 +1,23 @@
+import { combineReducers, createSlice } from '@reduxjs/toolkit'
+
+import { asLineup } from 'store/lineup/reducer'
+
+import { PREFIX } from './lineup/actions'
+import premiumTracksReducer, {
+  initialState as initialLineupState
+} from './lineup/reducer'
+
+const initialState = { tracks: initialLineupState }
+
+const slice = createSlice({
+  name: 'application/pages/premiumTracks',
+  initialState,
+  reducers: {}
+})
+
+const premiumTracksLineupReducer = asLineup(PREFIX, premiumTracksReducer)
+
+export default combineReducers({
+  page: slice.reducer,
+  tracks: premiumTracksLineupReducer
+})

--- a/packages/common/src/store/reducers.ts
+++ b/packages/common/src/store/reducers.ts
@@ -39,6 +39,7 @@ import explorePageReducer from './pages/explore/slice'
 import feed from './pages/feed/reducer'
 import { FeedPageState } from './pages/feed/types'
 import historyPageReducer from './pages/history-page/reducer'
+import premiumTracks from './pages/premium-tracks/slice'
 import profileReducer from './pages/profile/reducer'
 import { ProfilePageState } from './pages/profile/types'
 import remixes from './pages/remixes/slice'
@@ -240,7 +241,8 @@ export const reducers = () => ({
     trendingPlaylists,
     trendingUnderground,
     settings,
-    remixes
+    remixes,
+    premiumTracks
   }),
 
   // Solana
@@ -365,6 +367,7 @@ export type CommonState = {
     trendingPlaylists: ReturnType<typeof trendingPlaylists>
     trendingUnderground: ReturnType<typeof trendingUnderground>
     remixes: ReturnType<typeof remixes>
+    premiumTracks: ReturnType<typeof premiumTracks>
   }
   solana: ReturnType<typeof solanaReducer>
 

--- a/packages/common/src/store/sagas.ts
+++ b/packages/common/src/store/sagas.ts
@@ -99,6 +99,8 @@ export const sagas = (_ctx: CommonStoreContext) => ({
   // pages/trending-page/store/lineups/trending/sagas.ts
   // pages/trending-underground-page/store/lineups/tracks/sagas.ts
   // pages/trending-underground-page/store/sagas.ts
+  // pages/premium-tracks/sagas.ts
+  // pages/premium-tracks/lineups/tracks/sagas.ts
   // pages/smart-collection/store/sagas.ts
   // store/application/ui/theme/sagas.ts
   // pages/search-page/store/sagas.ts

--- a/packages/libs/src/sdk/api/generated/full/apis/SearchApi.ts
+++ b/packages/libs/src/sdk/api/generated/full/apis/SearchApi.ts
@@ -32,6 +32,7 @@ export interface SearchRequest {
     limit?: number;
     userId?: string;
     kind?: SearchKindEnum;
+    includePurchaseable?: string;
 }
 
 export interface SearchAutocompleteRequest {
@@ -40,6 +41,7 @@ export interface SearchAutocompleteRequest {
     limit?: number;
     userId?: string;
     kind?: SearchAutocompleteKindEnum;
+    includePurchaseable?: string;
 }
 
 /**
@@ -76,6 +78,10 @@ export class SearchApi extends runtime.BaseAPI {
 
         if (params.kind !== undefined) {
             queryParameters['kind'] = params.kind;
+        }
+
+        if (params.includePurchaseable !== undefined) {
+            queryParameters['includePurchaseable'] = params.includePurchaseable;
         }
 
         const headerParameters: runtime.HTTPHeaders = {};
@@ -128,6 +134,10 @@ export class SearchApi extends runtime.BaseAPI {
 
         if (params.kind !== undefined) {
             queryParameters['kind'] = params.kind;
+        }
+
+        if (params.includePurchaseable !== undefined) {
+            queryParameters['includePurchaseable'] = params.includePurchaseable;
         }
 
         const headerParameters: runtime.HTTPHeaders = {};

--- a/packages/libs/src/sdk/api/generated/full/apis/TracksApi.ts
+++ b/packages/libs/src/sdk/api/generated/full/apis/TracksApi.ts
@@ -144,6 +144,23 @@ export interface GetTrendingTracksWithVersionRequest {
     time?: GetTrendingTracksWithVersionTimeEnum;
 }
 
+export interface GetTrendingUSDCPurchaseTracksRequest {
+    offset?: number;
+    limit?: number;
+    userId?: string;
+    genre?: string;
+    time?: GetTrendingUSDCPurchaseTracksTimeEnum;
+}
+
+export interface GetTrendingUSDCPurchaseTracksWithVersionRequest {
+    version: string;
+    offset?: number;
+    limit?: number;
+    userId?: string;
+    genre?: string;
+    time?: GetTrendingUSDCPurchaseTracksWithVersionTimeEnum;
+}
+
 export interface GetUnderTheRadarTracksRequest {
     offset?: number;
     limit?: number;
@@ -787,7 +804,7 @@ export class TracksApi extends runtime.BaseAPI {
 
     /**
      * @hidden
-     * Gets the top 100 trending (most popular tracks on Audius using a given trending strategy version
+     * Gets the top 100 trending (most popular) tracks on Audius using a given trending strategy version
      */
     async getTrendingTracksWithVersionRaw(params: GetTrendingTracksWithVersionRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<FullTracksResponse>> {
         if (params.version === null || params.version === undefined) {
@@ -829,10 +846,108 @@ export class TracksApi extends runtime.BaseAPI {
     }
 
     /**
-     * Gets the top 100 trending (most popular tracks on Audius using a given trending strategy version
+     * Gets the top 100 trending (most popular) tracks on Audius using a given trending strategy version
      */
     async getTrendingTracksWithVersion(params: GetTrendingTracksWithVersionRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<FullTracksResponse> {
         const response = await this.getTrendingTracksWithVersionRaw(params, initOverrides);
+        return await response.value();
+    }
+
+    /**
+     * @hidden
+     * Gets the top trending (most popular) USDC purchase tracks on Audius
+     */
+    async getTrendingUSDCPurchaseTracksRaw(params: GetTrendingUSDCPurchaseTracksRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<FullTracksResponse>> {
+        const queryParameters: any = {};
+
+        if (params.offset !== undefined) {
+            queryParameters['offset'] = params.offset;
+        }
+
+        if (params.limit !== undefined) {
+            queryParameters['limit'] = params.limit;
+        }
+
+        if (params.userId !== undefined) {
+            queryParameters['user_id'] = params.userId;
+        }
+
+        if (params.genre !== undefined) {
+            queryParameters['genre'] = params.genre;
+        }
+
+        if (params.time !== undefined) {
+            queryParameters['time'] = params.time;
+        }
+
+        const headerParameters: runtime.HTTPHeaders = {};
+
+        const response = await this.request({
+            path: `/tracks/usdc-purchase`,
+            method: 'GET',
+            headers: headerParameters,
+            query: queryParameters,
+        }, initOverrides);
+
+        return new runtime.JSONApiResponse(response, (jsonValue) => FullTracksResponseFromJSON(jsonValue));
+    }
+
+    /**
+     * Gets the top trending (most popular) USDC purchase tracks on Audius
+     */
+    async getTrendingUSDCPurchaseTracks(params: GetTrendingUSDCPurchaseTracksRequest = {}, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<FullTracksResponse> {
+        const response = await this.getTrendingUSDCPurchaseTracksRaw(params, initOverrides);
+        return await response.value();
+    }
+
+    /**
+     * @hidden
+     * Gets the top trending (most popular) USDC purchase tracks on Audius using a given trending strategy version
+     */
+    async getTrendingUSDCPurchaseTracksWithVersionRaw(params: GetTrendingUSDCPurchaseTracksWithVersionRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<FullTracksResponse>> {
+        if (params.version === null || params.version === undefined) {
+            throw new runtime.RequiredError('version','Required parameter params.version was null or undefined when calling getTrendingUSDCPurchaseTracksWithVersion.');
+        }
+
+        const queryParameters: any = {};
+
+        if (params.offset !== undefined) {
+            queryParameters['offset'] = params.offset;
+        }
+
+        if (params.limit !== undefined) {
+            queryParameters['limit'] = params.limit;
+        }
+
+        if (params.userId !== undefined) {
+            queryParameters['user_id'] = params.userId;
+        }
+
+        if (params.genre !== undefined) {
+            queryParameters['genre'] = params.genre;
+        }
+
+        if (params.time !== undefined) {
+            queryParameters['time'] = params.time;
+        }
+
+        const headerParameters: runtime.HTTPHeaders = {};
+
+        const response = await this.request({
+            path: `/tracks/usdc-purchase/{version}`.replace(`{${"version"}}`, encodeURIComponent(String(params.version))),
+            method: 'GET',
+            headers: headerParameters,
+            query: queryParameters,
+        }, initOverrides);
+
+        return new runtime.JSONApiResponse(response, (jsonValue) => FullTracksResponseFromJSON(jsonValue));
+    }
+
+    /**
+     * Gets the top trending (most popular) USDC purchase tracks on Audius using a given trending strategy version
+     */
+    async getTrendingUSDCPurchaseTracksWithVersion(params: GetTrendingUSDCPurchaseTracksWithVersionRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<FullTracksResponse> {
+        const response = await this.getTrendingUSDCPurchaseTracksWithVersionRaw(params, initOverrides);
         return await response.value();
     }
 
@@ -1097,6 +1212,26 @@ export const GetTrendingTracksWithVersionTimeEnum = {
     AllTime: 'allTime'
 } as const;
 export type GetTrendingTracksWithVersionTimeEnum = typeof GetTrendingTracksWithVersionTimeEnum[keyof typeof GetTrendingTracksWithVersionTimeEnum];
+/**
+ * @export
+ */
+export const GetTrendingUSDCPurchaseTracksTimeEnum = {
+    Week: 'week',
+    Month: 'month',
+    Year: 'year',
+    AllTime: 'allTime'
+} as const;
+export type GetTrendingUSDCPurchaseTracksTimeEnum = typeof GetTrendingUSDCPurchaseTracksTimeEnum[keyof typeof GetTrendingUSDCPurchaseTracksTimeEnum];
+/**
+ * @export
+ */
+export const GetTrendingUSDCPurchaseTracksWithVersionTimeEnum = {
+    Week: 'week',
+    Month: 'month',
+    Year: 'year',
+    AllTime: 'allTime'
+} as const;
+export type GetTrendingUSDCPurchaseTracksWithVersionTimeEnum = typeof GetTrendingUSDCPurchaseTracksWithVersionTimeEnum[keyof typeof GetTrendingUSDCPurchaseTracksWithVersionTimeEnum];
 /**
  * @export
  */

--- a/packages/mobile/src/components/navigation-container/NavigationContainer.tsx
+++ b/packages/mobile/src/components/navigation-container/NavigationContainer.tsx
@@ -129,6 +129,7 @@ const NavigationContainer = (props: NavigationContainerProps) => {
                       initialRouteName: 'Explore',
                       screens: {
                         Explore: 'explore',
+                        PremiumTracks: 'explore/premium-tracks',
                         TrendingPlaylists: 'explore/playlists',
                         TrendingUnderground: 'explore/underground',
                         LetThemDJ: 'explore/let-them-dj',

--- a/packages/mobile/src/screens/app-screen/ExploreTabScreen.tsx
+++ b/packages/mobile/src/screens/app-screen/ExploreTabScreen.tsx
@@ -16,6 +16,7 @@ import {
 } from 'app/screens/explore-screen/smartCollections'
 import {
   LetThemDJScreen,
+  PremiumTracksScreen,
   TopAlbumsScreen,
   TrendingPlaylistsScreen,
   TrendingUndergroundScreen
@@ -36,6 +37,7 @@ export type ExploreTabScreenParamList = AppTabScreenParamList & {
   BestNewReleases: undefined
   Remixables: undefined
   // Collection Screens
+  PremiumTracks: undefined
   TrendingUnderground: undefined
   LetThemDJ: undefined
   TopAlbums: undefined
@@ -69,6 +71,7 @@ export const ExploreTabScreen =
   createAppTabScreenStack<ExploreTabScreenParamList>((Stack) => (
     <>
       <Stack.Screen name='Explore' component={ExploreScreen} />
+      <Stack.Screen name='PremiumTracks' component={PremiumTracksScreen} />
       <Stack.Screen name='LetThemDJ' component={LetThemDJScreen} />
       <Stack.Screen name='TopAlbums' component={TopAlbumsScreen} />
       <Stack.Screen

--- a/packages/mobile/src/screens/explore-screen/collections.ts
+++ b/packages/mobile/src/screens/explore-screen/collections.ts
@@ -12,10 +12,12 @@ import IconCassette from 'app/assets/images/iconCassette.svg'
 import IconExploreDJ from 'app/assets/images/iconExploreDJ.svg'
 import IconExploreTopAlbums from 'app/assets/images/iconExploreTopAlbums.svg'
 import IconExploreTopPlaylists from 'app/assets/images/iconExploreTopPlaylists.svg'
+import IconCart from 'app/assets/images/iconCart.svg'
 
 import type { ExploreCollectionsVariant } from './types'
 
 export type CollectionScreen =
+  | 'PremiumTracks'
   | 'LetThemDJ'
   | 'TopAlbums'
   | 'TrendingPlaylists'
@@ -47,6 +49,18 @@ export type ExploreMoodCollection = ExploreCollection & {
 }
 
 // Just For You Collections
+export const PREMIUM_TRACKS: ExploreCollection = {
+  variant: 'Direct Link',
+  title: 'Premium Tracks',
+  screen: 'PremiumTracks',
+  description: 'Explore premium music available to purchase.',
+  gradientColors: ['#13C65A', '#16A653'],
+  gradientAngle: 135,
+  shadowColor: 'rgba(196,81,193)',
+  shadowOpacity: 0.25,
+  icon: IconCart
+}
+
 export const LET_THEM_DJ: ExploreCollection = {
   variant: 'Let Them DJ',
   title: 'Let Them DJ',

--- a/packages/mobile/src/screens/explore-screen/collections.ts
+++ b/packages/mobile/src/screens/explore-screen/collections.ts
@@ -8,11 +8,11 @@ import EmojiFire from 'app/assets/images/emojis/fire.png'
 import EmojiHeartWithArrow from 'app/assets/images/emojis/heart-with-arrow.png'
 import EmojiRaisedHands from 'app/assets/images/emojis/person-raising-both-hands-in-celebration.png'
 import EmojiThinkingFace from 'app/assets/images/emojis/thinking-face.png'
+import IconCart from 'app/assets/images/iconCart.svg'
 import IconCassette from 'app/assets/images/iconCassette.svg'
 import IconExploreDJ from 'app/assets/images/iconExploreDJ.svg'
 import IconExploreTopAlbums from 'app/assets/images/iconExploreTopAlbums.svg'
 import IconExploreTopPlaylists from 'app/assets/images/iconExploreTopPlaylists.svg'
-import IconCart from 'app/assets/images/iconCart.svg'
 
 import type { ExploreCollectionsVariant } from './types'
 

--- a/packages/mobile/src/screens/explore-screen/components/ColorTile.tsx
+++ b/packages/mobile/src/screens/explore-screen/components/ColorTile.tsx
@@ -18,10 +18,10 @@ import { useNavigation } from 'app/hooks/useNavigation'
 import { usePressScaleAnimation } from 'app/hooks/usePressScaleAnimation'
 import type { ExploreTabScreenParamList } from 'app/screens/app-screen/ExploreTabScreen'
 import { font, makeStyles } from 'app/styles'
+import { useColor } from 'app/utils/theme'
 
 import type { CollectionScreen, MoodScreen } from '../collections'
 import type { SmartCollectionScreen } from '../smartCollections'
-import { useColor } from 'app/utils/theme'
 
 type ColorTileProps = {
   style?: StyleProp<ViewStyle>
@@ -182,7 +182,12 @@ export const ColorTile = ({
             )}
             {Icon && (
               <View style={styles.icon}>
-                <Icon style={styles.iconSvg} height={260} width={260} fill={white} />
+                <Icon
+                  style={styles.iconSvg}
+                  height={260}
+                  width={260}
+                  fill={white}
+                />
               </View>
             )}
           </View>

--- a/packages/mobile/src/screens/explore-screen/components/ColorTile.tsx
+++ b/packages/mobile/src/screens/explore-screen/components/ColorTile.tsx
@@ -21,6 +21,7 @@ import { font, makeStyles } from 'app/styles'
 
 import type { CollectionScreen, MoodScreen } from '../collections'
 import type { SmartCollectionScreen } from '../smartCollections'
+import { useColor } from 'app/utils/theme'
 
 type ColorTileProps = {
   style?: StyleProp<ViewStyle>
@@ -132,6 +133,7 @@ export const ColorTile = ({
   isIncentivized
 }: ColorTileProps) => {
   const styles = useStyles()
+  const white = useColor('white')
   const navigation = useNavigation<ExploreTabScreenParamList>()
   const {
     scale,
@@ -180,7 +182,7 @@ export const ColorTile = ({
             )}
             {Icon && (
               <View style={styles.icon}>
-                <Icon style={styles.iconSvg} height={260} width={260} />
+                <Icon style={styles.iconSvg} height={260} width={260} fill={white} />
               </View>
             )}
           </View>

--- a/packages/mobile/src/screens/explore-screen/tabs/ForYouTab/ForYouTab.tsx
+++ b/packages/mobile/src/screens/explore-screen/tabs/ForYouTab/ForYouTab.tsx
@@ -11,7 +11,8 @@ import {
   LET_THEM_DJ,
   TRENDING_PLAYLISTS,
   TRENDING_UNDERGROUND,
-  TOP_ALBUMS
+  TOP_ALBUMS,
+  PREMIUM_TRACKS
 } from '../../collections'
 import { ColorTile } from '../../components/ColorTile'
 import { TabInfo } from '../../components/TabInfo'
@@ -55,6 +56,7 @@ const useStyles = makeStyles(({ spacing }) => ({
 }))
 
 const tiles = [
+  PREMIUM_TRACKS,
   TRENDING_PLAYLISTS,
   TRENDING_UNDERGROUND,
   HEAVY_ROTATION,
@@ -67,9 +69,9 @@ const tiles = [
   FEELING_LUCKY
 ]
 
-const tenTileLayout = {
-  halfTiles: [3, 4, 5, 6, 8, 9],
-  leftHalfTiles: [3, 5, 8]
+const elevenTileLayout = {
+  halfTiles: [4, 5, 6, 7, 9, 10],
+  leftHalfTiles: [4, 6, 9]
 }
 
 export const ForYouTab = () => {
@@ -91,8 +93,8 @@ export const ForYouTab = () => {
           <ColorTile
             style={[
               styles.tile,
-              tenTileLayout.halfTiles.includes(idx) && styles.halfTile,
-              tenTileLayout.leftHalfTiles.includes(idx) && styles.rightMargin
+              elevenTileLayout.halfTiles.includes(idx) && styles.halfTile,
+              elevenTileLayout.leftHalfTiles.includes(idx) && styles.rightMargin
             ]}
             key={tile.title}
             {...tile}

--- a/packages/mobile/src/screens/explore-screen/tabs/ForYouTab/ForYouTab.tsx
+++ b/packages/mobile/src/screens/explore-screen/tabs/ForYouTab/ForYouTab.tsx
@@ -24,6 +24,8 @@ import {
   REMIXABLES,
   FEELING_LUCKY
 } from '../../smartCollections'
+import { useIsUSDCEnabled } from 'app/hooks/useIsUSDCEnabled'
+import { ExploreCollectionsVariant } from '@audius/common'
 
 const messages = {
   infoHeader: 'Just For You',
@@ -85,11 +87,17 @@ export const ForYouTab = () => {
     })
   })
 
+  const isUSDCPurchasesEnabled = useIsUSDCEnabled()
+  const filteredTiles = tiles.filter(tile => {
+    const isPremiumTracksTile = tile.variant === ExploreCollectionsVariant.DIRECT_LINK && tile.title === PREMIUM_TRACKS.title
+    return !isPremiumTracksTile || isUSDCPurchasesEnabled
+  })
+
   return (
     <ScrollView style={styles.tabContainer} ref={scrollViewRef}>
       <TabInfo header={messages.infoHeader} text={messages.infoText} />
       <View style={styles.contentContainer}>
-        {tiles.map((tile, idx) => (
+        {filteredTiles.map((tile, idx) => (
           <ColorTile
             style={[
               styles.tile,

--- a/packages/mobile/src/screens/explore-screen/tabs/ForYouTab/ForYouTab.tsx
+++ b/packages/mobile/src/screens/explore-screen/tabs/ForYouTab/ForYouTab.tsx
@@ -1,9 +1,11 @@
 import { useRef } from 'react'
 
+import { ExploreCollectionsVariant } from '@audius/common'
 import { View } from 'react-native'
 
 import type { ScrollViewElement } from 'app/components/core'
 import { ScrollView } from 'app/components/core'
+import { useIsUSDCEnabled } from 'app/hooks/useIsUSDCEnabled'
 import { useScrollToTop } from 'app/hooks/useScrollToTop'
 import { makeStyles } from 'app/styles'
 
@@ -24,8 +26,6 @@ import {
   REMIXABLES,
   FEELING_LUCKY
 } from '../../smartCollections'
-import { useIsUSDCEnabled } from 'app/hooks/useIsUSDCEnabled'
-import { ExploreCollectionsVariant } from '@audius/common'
 
 const messages = {
   infoHeader: 'Just For You',
@@ -88,8 +88,10 @@ export const ForYouTab = () => {
   })
 
   const isUSDCPurchasesEnabled = useIsUSDCEnabled()
-  const filteredTiles = tiles.filter(tile => {
-    const isPremiumTracksTile = tile.variant === ExploreCollectionsVariant.DIRECT_LINK && tile.title === PREMIUM_TRACKS.title
+  const filteredTiles = tiles.filter((tile) => {
+    const isPremiumTracksTile =
+      tile.variant === ExploreCollectionsVariant.DIRECT_LINK &&
+      tile.title === PREMIUM_TRACKS.title
     return !isPremiumTracksTile || isUSDCPurchasesEnabled
   })
 

--- a/packages/mobile/src/screens/explore-screen/tabs/ForYouTab/PremiumTracksScreen.tsx
+++ b/packages/mobile/src/screens/explore-screen/tabs/ForYouTab/PremiumTracksScreen.tsx
@@ -1,0 +1,41 @@
+import {
+  premiumTracksPageLineupActions,
+  premiumTracksPageLineupSelectors,
+  lineupSelectors
+} from '@audius/common'
+import { useDispatch, useSelector } from 'react-redux'
+
+import { Screen, ScreenContent, ScreenHeader } from 'app/components/core'
+import { Lineup } from 'app/components/lineup'
+import { useCallback } from 'react'
+const { makeGetLineupMetadatas } = lineupSelectors
+const { getLineup } = premiumTracksPageLineupSelectors
+
+const getPremiumTracksLineup = makeGetLineupMetadatas(getLineup)
+
+const messages = {
+  header: 'Premium Tracks'
+}
+
+export const PremiumTracksScreen = () => {
+  const dispatch = useDispatch()
+  const lineup = useSelector(getPremiumTracksLineup)
+  const loadMore = useCallback(
+    (offset: number, limit: number, overwrite: boolean) => {
+      dispatch(premiumTracksPageLineupActions.fetchLineupMetadatas(offset, limit, overwrite))
+  }, [])
+  return (
+    <Screen>
+      <ScreenHeader text={messages.header} />
+      <ScreenContent>
+        <Lineup
+          loadMore={loadMore}
+          lineup={lineup}
+          actions={premiumTracksPageLineupActions}
+          selfLoad
+          pullToRefresh
+        />
+      </ScreenContent>
+    </Screen>
+  )
+}

--- a/packages/mobile/src/screens/explore-screen/tabs/ForYouTab/PremiumTracksScreen.tsx
+++ b/packages/mobile/src/screens/explore-screen/tabs/ForYouTab/PremiumTracksScreen.tsx
@@ -3,7 +3,7 @@ import {
   premiumTracksPageLineupSelectors,
   lineupSelectors
 } from '@audius/common'
-import { useDispatch, useSelector } from 'react-redux'
+import { useDispatch } from 'react-redux'
 
 import { Screen, ScreenContent, ScreenHeader } from 'app/components/core'
 import { Lineup } from 'app/components/lineup'
@@ -19,18 +19,17 @@ const messages = {
 
 export const PremiumTracksScreen = () => {
   const dispatch = useDispatch()
-  const lineup = useSelector(getPremiumTracksLineup)
   const loadMore = useCallback(
     (offset: number, limit: number, overwrite: boolean) => {
       dispatch(premiumTracksPageLineupActions.fetchLineupMetadatas(offset, limit, overwrite))
-  }, [])
+  }, [dispatch])
   return (
     <Screen>
       <ScreenHeader text={messages.header} />
       <ScreenContent>
         <Lineup
           loadMore={loadMore}
-          lineup={lineup}
+          lineupSelector={getPremiumTracksLineup}
           actions={premiumTracksPageLineupActions}
           selfLoad
           pullToRefresh

--- a/packages/mobile/src/screens/explore-screen/tabs/ForYouTab/PremiumTracksScreen.tsx
+++ b/packages/mobile/src/screens/explore-screen/tabs/ForYouTab/PremiumTracksScreen.tsx
@@ -1,3 +1,5 @@
+import { useCallback } from 'react'
+
 import {
   premiumTracksPageLineupActions,
   premiumTracksPageLineupSelectors,
@@ -7,7 +9,6 @@ import { useDispatch } from 'react-redux'
 
 import { Screen, ScreenContent, ScreenHeader } from 'app/components/core'
 import { Lineup } from 'app/components/lineup'
-import { useCallback } from 'react'
 const { makeGetLineupMetadatas } = lineupSelectors
 const { getLineup } = premiumTracksPageLineupSelectors
 
@@ -21,8 +22,16 @@ export const PremiumTracksScreen = () => {
   const dispatch = useDispatch()
   const loadMore = useCallback(
     (offset: number, limit: number, overwrite: boolean) => {
-      dispatch(premiumTracksPageLineupActions.fetchLineupMetadatas(offset, limit, overwrite))
-  }, [dispatch])
+      dispatch(
+        premiumTracksPageLineupActions.fetchLineupMetadatas(
+          offset,
+          limit,
+          overwrite
+        )
+      )
+    },
+    [dispatch]
+  )
   return (
     <Screen>
       <ScreenHeader text={messages.header} />

--- a/packages/mobile/src/screens/explore-screen/tabs/ForYouTab/index.ts
+++ b/packages/mobile/src/screens/explore-screen/tabs/ForYouTab/index.ts
@@ -1,4 +1,5 @@
 export * from './ForYouTab'
+export * from './PremiumTracksScreen'
 export * from './LetThemDJScreen'
 export * from './TopAlbumsScreen'
 export * from './TrendingPlaylistsScreen'

--- a/packages/mobile/src/screens/trending-screen/TrendingLineup.tsx
+++ b/packages/mobile/src/screens/trending-screen/TrendingLineup.tsx
@@ -72,7 +72,7 @@ export const TrendingLineup = (props: TrendingLineupProps) => {
   const handleLoadMore = useCallback(
     (offset: number, limit: number, overwrite: boolean) => {
       dispatch(trendingActions.fetchLineupMetadatas(offset, limit, overwrite))
-      track(make({ eventName: Name.FEED_PAGINATE, offset, limit }))
+      track(make({ eventName: Name.TRENDING_PAGINATE, offset, limit }))
     },
     [dispatch, trendingActions]
   )

--- a/packages/mobile/src/store/sagas.ts
+++ b/packages/mobile/src/store/sagas.ts
@@ -36,6 +36,7 @@ import exploreCollectionsPageSagas from 'common/store/pages/explore/exploreColle
 import explorePageSagas from 'common/store/pages/explore/sagas'
 import feedPageSagas from 'common/store/pages/feed/sagas'
 import historySagas from 'common/store/pages/history/sagas'
+import premiumTracksSagas from 'common/store/pages/premium-tracks/sagas'
 import remixesSagas from 'common/store/pages/remixes-page/sagas'
 import savedSagas from 'common/store/pages/saved/sagas'
 import searchResultsSagas from 'common/store/pages/search-page/sagas'
@@ -165,6 +166,7 @@ export default function* rootSaga() {
     ...rewardsPageSagas(),
     ...settingsSagas(),
     ...aiSagas(),
+    ...premiumTracksSagas(),
 
     // Cast
     ...castSagas(),

--- a/packages/web/src/common/store/lineup/sagas.d.ts
+++ b/packages/web/src/common/store/lineup/sagas.d.ts
@@ -9,7 +9,7 @@ export class LineupSagas {
   constructor(
     prefix: string,
     actions: LineupBaseActions,
-    feedSelector: (store: any) => LineupState<any>,
+    lineupSelector: (store: any) => LineupState<any>,
     getTracks: (config: {
       offset: number
       limit: number

--- a/packages/web/src/common/store/pages/premium-tracks/lineups/tracks/sagas.ts
+++ b/packages/web/src/common/store/pages/premium-tracks/lineups/tracks/sagas.ts
@@ -1,0 +1,51 @@
+import {
+  accountSelectors,
+  premiumTracksPageLineupActions,
+  premiumTracksPageLineupSelectors,
+  getContext
+} from '@audius/common'
+import { call, select } from 'typed-redux-saga'
+
+import { processAndCacheTracks } from 'common/store/cache/tracks/utils'
+import { LineupSagas } from 'common/store/lineup/sagas'
+import { waitForRead } from 'utils/sagaHelpers'
+
+const { getUserId } = accountSelectors
+const { getLineup } = premiumTracksPageLineupSelectors
+
+function* getPremiumTracks({
+  offset,
+  limit
+}: {
+  offset: number
+  limit: number
+}) {
+  yield* waitForRead()
+  const apiClient = yield* getContext('apiClient')
+  const currentUserId = yield* select(getUserId)
+  const tracks = yield* call([apiClient, apiClient.getPremiumTracks], {
+    offset,
+    limit,
+    currentUserId
+  })
+  const processedTracks = yield* call(processAndCacheTracks, tracks)
+  return processedTracks
+}
+
+class PremiumTracksSagas extends LineupSagas {
+  constructor() {
+    super(
+      premiumTracksPageLineupActions.prefix,
+      premiumTracksPageLineupActions,
+      getLineup,
+      getPremiumTracks,
+      undefined,
+      true,
+      undefined
+    )
+  }
+}
+
+export default function sagas() {
+  return new PremiumTracksSagas().getSagas()
+}

--- a/packages/web/src/common/store/pages/premium-tracks/sagas.ts
+++ b/packages/web/src/common/store/pages/premium-tracks/sagas.ts
@@ -1,0 +1,5 @@
+import premiumTracksSagas from './lineups/tracks/sagas'
+
+export default function sagas() {
+  return [...premiumTracksSagas()]
+}

--- a/packages/web/src/components/lineup/hooks.ts
+++ b/packages/web/src/components/lineup/hooks.ts
@@ -48,7 +48,7 @@ export const useLineupProps = ({
   const dispatch = useDispatch()
 
   // Create memoized selectors
-  const getPlaylistTrendingLineup = useMemo(
+  const getLineup = useMemo(
     () => makeGetLineupMetadatas(getLineupSelector),
     [getLineupSelector]
   )
@@ -57,7 +57,7 @@ export const useLineupProps = ({
 
   // Selectors
   const currentQueueItem = useSelector(getCurrentQueueItem)
-  const lineup = useSelector(getPlaylistTrendingLineup)
+  const lineup = useSelector(getLineup)
   const isPlaying = useSelector(getPlaying)
   const isBuffering = useSelector(getBuffering)
 

--- a/packages/web/src/components/perspective-card/PerspectiveCard.tsx
+++ b/packages/web/src/components/perspective-card/PerspectiveCard.tsx
@@ -13,6 +13,7 @@ type PerspectiveCardProps = {
   backgroundGradient?: string
   shadowColor?: string
   backgroundIcon?: ReactNode | JSX.Element
+  backgroundIconClassName?: string
   children?: JSX.Element | JSX.Element[]
   className?: string
   isDisabled?: boolean
@@ -26,6 +27,7 @@ const PerspectiveCard = ({
   backgroundGradient,
   shadowColor,
   backgroundIcon,
+  backgroundIconClassName,
   children,
   className,
   isDisabled,
@@ -68,7 +70,9 @@ const PerspectiveCard = ({
             </div>
           ) : null}
           {children}
-          <div className={styles.backgroundIcon}>{backgroundIcon}</div>
+          <div className={cn(styles.backgroundIcon, backgroundIconClassName)}>
+            {backgroundIcon}
+          </div>
         </div>
       </animated.div>
     </div>

--- a/packages/web/src/pages/App.js
+++ b/packages/web/src/pages/App.js
@@ -150,7 +150,8 @@ import {
   PROFILE_PAGE_AI_ATTRIBUTED_TRACKS,
   PURCHASES_PAGE,
   SALES_PAGE,
-  WITHDRAWALS_PAGE
+  WITHDRAWALS_PAGE,
+  EXPLORE_PREMIUM_TRACKS_PAGE
 } from 'utils/route'
 import { getTheme as getSystemTheme } from 'utils/theme/theme'
 
@@ -172,6 +173,7 @@ import ExploreCollectionsPage from './explore-page/ExploreCollectionsPage'
 import { FbSharePage } from './fb-share-page/FbSharePage'
 import FollowersPage from './followers-page/FollowersPage'
 import FollowingPage from './following-page/FollowingPage'
+import { PremiumTracksPage } from './premium-tracks-page/PremiumTracksPage'
 import { PurchasesPage, SalesPage } from './purchases-and-sales'
 import { WithdrawalsPage } from './purchases-and-sales/WithdrawalsPage'
 import SettingsPage from './settings-page/SettingsPage'
@@ -596,6 +598,15 @@ class App extends Component {
                   exact
                   path={AUDIO_NFT_PLAYLIST_PAGE}
                   render={() => <CollectiblesPlaylistPage />}
+                />
+                <Route
+                  exact
+                  path={EXPLORE_PREMIUM_TRACKS_PAGE}
+                  render={() => (
+                    <PremiumTracksPage
+                      containerRef={this.props.mainContentRef.current}
+                    />
+                  )}
                 />
                 <Route
                   exact

--- a/packages/web/src/pages/explore-page/collections.ts
+++ b/packages/web/src/pages/explore-page/collections.ts
@@ -1,6 +1,7 @@
 import { ComponentType, SVGProps } from 'react'
 
 import { ExploreCollectionsVariant } from '@audius/common'
+import { IconCart } from '@audius/stems'
 
 import { ReactComponent as IconCassette } from 'assets/img/iconCassette.svg'
 import { ReactComponent as IconExploreDJ } from 'assets/img/iconExploreDJ.svg'
@@ -8,6 +9,7 @@ import { ReactComponent as IconExploreTopAlbums } from 'assets/img/iconExploreTo
 import { ReactComponent as IconExploreTopPlaylists } from 'assets/img/iconExploreTopPlaylists.svg'
 import {
   EXPLORE_LET_THEM_DJ_PAGE,
+  EXPLORE_PREMIUM_TRACKS_PAGE,
   EXPLORE_TOP_ALBUMS_PAGE,
   exploreMoodPlaylistsPage,
   TRENDING_PLAYLISTS_PAGE,
@@ -33,6 +35,17 @@ export type ExploreMoodCollection = ExploreCollection & {
 
 // How much full width cards move
 const WIDE_CARD_SENSITIVTY = 0.04
+
+export const PREMIUM_TRACKS: ExploreCollection = {
+  variant: ExploreCollectionsVariant.DIRECT_LINK,
+  title: 'Premium Tracks',
+  subtitle: 'Explore premium music available to purchase.',
+  gradient: 'linear-gradient(95deg, #13C65A 0%, #16A653 100%)',
+  shadow: 'rgba(196,81,193,0.35)',
+  icon: IconCart,
+  link: EXPLORE_PREMIUM_TRACKS_PAGE,
+  cardSensitivity: WIDE_CARD_SENSITIVTY
+}
 
 export const LET_THEM_DJ: ExploreCollection = {
   variant: ExploreCollectionsVariant.LET_THEM_DJ,

--- a/packages/web/src/pages/explore-page/components/desktop/ExplorePage.module.css
+++ b/packages/web/src/pages/explore-page/components/desktop/ExplorePage.module.css
@@ -4,7 +4,7 @@
   margin-left: -16px;
 }
 
-.cardsContainer>* {
+.cardsContainer > * {
   margin: 6px;
 }
 
@@ -12,7 +12,7 @@
   margin: 0 auto;
 }
 
-.loadingSpinner>div {
+.loadingSpinner > div {
   display: flex;
   align-items: center;
   justify-content: center;

--- a/packages/web/src/pages/explore-page/components/desktop/ExplorePage.module.css
+++ b/packages/web/src/pages/explore-page/components/desktop/ExplorePage.module.css
@@ -3,7 +3,8 @@
   width: 100%;
   margin-left: -16px;
 }
-.cardsContainer > * {
+
+.cardsContainer>* {
   margin: 6px;
 }
 
@@ -11,7 +12,7 @@
   margin: 0 auto;
 }
 
-.loadingSpinner > div {
+.loadingSpinner>div {
   display: flex;
   align-items: center;
   justify-content: center;
@@ -24,4 +25,11 @@
 
 .loadingSpinner g path {
   stroke: var(--neutral-light-3) !important;
+}
+
+.premiumTracksBackgroundIcon {
+  width: 220px;
+  height: 200px;
+  right: 0 !important;
+  top: 0 !important;
 }

--- a/packages/web/src/pages/explore-page/components/desktop/ExplorePage.tsx
+++ b/packages/web/src/pages/explore-page/components/desktop/ExplorePage.tsx
@@ -26,6 +26,7 @@ import PerspectiveCard, {
   TextInterior,
   EmojiInterior
 } from 'components/perspective-card/PerspectiveCard'
+import { useIsUSDCEnabled } from 'hooks/useIsUSDCEnabled'
 import { useOrderedLoad } from 'hooks/useOrderedLoad'
 import {
   LET_THEM_DJ,
@@ -43,7 +44,6 @@ import { BASE_URL, EXPLORE_PAGE, stripBaseUrl } from 'utils/route'
 
 import styles from './ExplorePage.module.css'
 import Section, { Layout } from './Section'
-import { useIsUSDCEnabled } from 'hooks/useIsUSDCEnabled'
 
 const messages = {
   featuredPlaylists: 'Playlists We Love Right Now',
@@ -99,11 +99,12 @@ const ExplorePage = ({
   goToRoute
 }: ExplorePageProps) => {
   const isUSDCPurchasesEnabled = useIsUSDCEnabled()
-  const justForYouTiles = justForYou
-    .filter(tile => {
-      const isPremiumTracksTile = tile.variant === ExploreCollectionsVariant.DIRECT_LINK && tile.title === PREMIUM_TRACKS.title
-      return !isPremiumTracksTile || isUSDCPurchasesEnabled
-    })
+  const justForYouTiles = justForYou.filter((tile) => {
+    const isPremiumTracksTile =
+      tile.variant === ExploreCollectionsVariant.DIRECT_LINK &&
+      tile.title === PREMIUM_TRACKS.title
+    return !isPremiumTracksTile || isUSDCPurchasesEnabled
+  })
   const { isLoading: isLoadingPlaylist, setDidLoad: setDidLoadPlaylist } =
     useOrderedLoad(playlists.length)
   const { isLoading: isLoadingProfiles, setDidLoad: setDidLoadProfile } =

--- a/packages/web/src/pages/explore-page/components/desktop/ExplorePage.tsx
+++ b/packages/web/src/pages/explore-page/components/desktop/ExplorePage.tsx
@@ -36,7 +36,8 @@ import {
   UPBEAT_PLAYLISTS,
   INTENSE_PLAYLISTS,
   PROVOKING_PLAYLISTS,
-  INTIMATE_PLAYLISTS
+  INTIMATE_PLAYLISTS,
+  PREMIUM_TRACKS
 } from 'pages/explore-page/collections'
 import { BASE_URL, EXPLORE_PAGE, stripBaseUrl } from 'utils/route'
 
@@ -56,6 +57,7 @@ reposts, and follows. Refreshes often so if you like a track, favorite it.`,
 }
 
 export const justForYou = [
+  PREMIUM_TRACKS,
   TRENDING_PLAYLISTS,
   TRENDING_UNDERGROUND,
   HEAVY_ROTATION,
@@ -126,7 +128,7 @@ const ExplorePage = ({
       <Section
         title={messages.justForYou}
         subtitle={messages.justForYouSubtitle}
-        layout={Layout.TWO_COLUMN_DYNAMIC_WITH_DOUBLE_LEADING_ELEMENT}
+        layout={Layout.TWO_COLUMN_DYNAMIC_WITH_LEADING_ELEMENT}
       >
         {justForYou.map((i) => {
           const title =
@@ -144,6 +146,11 @@ const ExplorePage = ({
               }
               // @ts-ignore
               backgroundIcon={<Icon />}
+              backgroundIconClassName={
+                title === PREMIUM_TRACKS.title
+                  ? styles.premiumTracksBackgroundIcon
+                  : undefined
+              }
               onClick={() => onClickCard(i.link)}
               isIncentivized={!!i.incentivized}
               sensitivity={i.cardSensitivity}

--- a/packages/web/src/pages/explore-page/components/desktop/ExplorePage.tsx
+++ b/packages/web/src/pages/explore-page/components/desktop/ExplorePage.tsx
@@ -43,6 +43,7 @@ import { BASE_URL, EXPLORE_PAGE, stripBaseUrl } from 'utils/route'
 
 import styles from './ExplorePage.module.css'
 import Section, { Layout } from './Section'
+import { useIsUSDCEnabled } from 'hooks/useIsUSDCEnabled'
 
 const messages = {
   featuredPlaylists: 'Playlists We Love Right Now',
@@ -97,6 +98,12 @@ const ExplorePage = ({
   status,
   goToRoute
 }: ExplorePageProps) => {
+  const isUSDCPurchasesEnabled = useIsUSDCEnabled()
+  const justForYouTiles = justForYou
+    .filter(tile => {
+      const isPremiumTracksTile = tile.variant === ExploreCollectionsVariant.DIRECT_LINK && tile.title === PREMIUM_TRACKS.title
+      return !isPremiumTracksTile || isUSDCPurchasesEnabled
+    })
   const { isLoading: isLoadingPlaylist, setDidLoad: setDidLoadPlaylist } =
     useOrderedLoad(playlists.length)
   const { isLoading: isLoadingProfiles, setDidLoad: setDidLoadProfile } =
@@ -130,7 +137,7 @@ const ExplorePage = ({
         subtitle={messages.justForYouSubtitle}
         layout={Layout.TWO_COLUMN_DYNAMIC_WITH_LEADING_ELEMENT}
       >
-        {justForYou.map((i) => {
+        {justForYouTiles.map((i) => {
           const title =
             i.variant === CollectionVariant.SMART ? i.playlist_name : i.title
           const subtitle =

--- a/packages/web/src/pages/explore-page/components/desktop/Section.module.css
+++ b/packages/web/src/pages/explore-page/components/desktop/Section.module.css
@@ -37,80 +37,35 @@
   margin: 0px -8px;
 }
 
-.children > * {
+.children>* {
   margin: 8px;
 }
 
-.twoColumnDynamicWithLeadingElement .children > *:nth-child(1) {
+.twoColumnDynamicWithLeadingElement .children>*:nth-child(1) {
   width: 100%;
 }
 
-.twoColumnDynamicWithLeadingElement .children > *:nth-child(9n + 2),
-.twoColumnDynamicWithLeadingElement .children > *:nth-child(9n + 3) {
+.twoColumnDynamicWithLeadingElement .children>*:nth-child(2),
+.twoColumnDynamicWithLeadingElement .children>*:nth-child(3),
+.twoColumnDynamicWithLeadingElement .children>*:nth-child(4),
+.twoColumnDynamicWithLeadingElement .children>*:nth-child(5) {
   width: calc(50% - 16px);
 }
 
-.twoColumnDynamicWithLeadingElement .children > *:nth-child(9n + 4),
-.twoColumnDynamicWithLeadingElement .children > *:nth-child(9n + 5),
-.twoColumnDynamicWithLeadingElement .children > *:nth-child(9n + 6),
-.twoColumnDynamicWithLeadingElement .children > *:nth-child(9n + 8) {
+.twoColumnDynamicWithLeadingElement .children>*:nth-child(7),
+.twoColumnDynamicWithLeadingElement .children>*:nth-child(8),
+.twoColumnDynamicWithLeadingElement .children>*:nth-child(11) {
   width: calc(33.33% - 16px);
 }
 
-.twoColumnDynamicWithLeadingElement .children > *:nth-child(9n + 7) {
+.twoColumnDynamicWithLeadingElement .children>*:nth-child(6),
+.twoColumnDynamicWithLeadingElement .children>*:nth-child(9),
+.twoColumnDynamicWithLeadingElement .children>*:nth-child(10) {
   width: calc(66.66% - 16px);
 }
 
 @media screen and (max-width: 1020px) {
-  .twoColumnDynamicWithLeadingElement .children > *:nth-child(n) {
-    width: 100%;
-  }
-}
-
-.twoColumnDynamicWithDoubleLeadingElementTenTile
-  .children
-  > *:nth-child(10n + 1),
-.twoColumnDynamicWithDoubleLeadingElementTenTile
-  .children
-  > *:nth-child(10n + 2) {
-  width: 100%;
-}
-
-.twoColumnDynamicWithDoubleLeadingElementTenTile
-  .children
-  > *:nth-child(10n + 3),
-.twoColumnDynamicWithDoubleLeadingElementTenTile
-  .children
-  > *:nth-child(10n + 4) {
-  width: calc(50% - 16px);
-}
-
-.twoColumnDynamicWithDoubleLeadingElementTenTile
-  .children
-  > *:nth-child(10n + 6),
-.twoColumnDynamicWithDoubleLeadingElementTenTile
-  .children
-  > *:nth-child(10n + 7),
-.twoColumnDynamicWithDoubleLeadingElementTenTile
-  .children
-  > *:nth-child(10n + 10) {
-  width: calc(33.33% - 16px);
-}
-
-.twoColumnDynamicWithDoubleLeadingElementTenTile
-  .children
-  > *:nth-child(10n + 5),
-.twoColumnDynamicWithDoubleLeadingElementTenTile
-  .children
-  > *:nth-child(10n + 8),
-.twoColumnDynamicWithDoubleLeadingElementTenTile
-  .children
-  > *:nth-child(10n + 9) {
-  width: calc(66.66% - 16px);
-}
-
-@media screen and (max-width: 1020px) {
-  .twoColumnDynamicWithDoubleLeadingElementTenTile .children > *:nth-child(n) {
+  .twoColumnDynamicWithLeadingElement .children>*:nth-child(n) {
     width: 100%;
   }
 }
@@ -127,7 +82,7 @@
   transform: translate3d(0, 0, 0);
 }
 
-.expandable .children > * {
+.expandable .children>* {
   margin: 12px 10px;
 }
 

--- a/packages/web/src/pages/explore-page/components/desktop/Section.module.css
+++ b/packages/web/src/pages/explore-page/components/desktop/Section.module.css
@@ -37,35 +37,35 @@
   margin: 0px -8px;
 }
 
-.children>* {
+.children > * {
   margin: 8px;
 }
 
-.twoColumnDynamicWithLeadingElement .children>*:nth-child(1) {
+.twoColumnDynamicWithLeadingElement .children > *:nth-child(1) {
   width: 100%;
 }
 
-.twoColumnDynamicWithLeadingElement .children>*:nth-child(2),
-.twoColumnDynamicWithLeadingElement .children>*:nth-child(3),
-.twoColumnDynamicWithLeadingElement .children>*:nth-child(4),
-.twoColumnDynamicWithLeadingElement .children>*:nth-child(5) {
+.twoColumnDynamicWithLeadingElement .children > *:nth-child(2),
+.twoColumnDynamicWithLeadingElement .children > *:nth-child(3),
+.twoColumnDynamicWithLeadingElement .children > *:nth-child(4),
+.twoColumnDynamicWithLeadingElement .children > *:nth-child(5) {
   width: calc(50% - 16px);
 }
 
-.twoColumnDynamicWithLeadingElement .children>*:nth-child(7),
-.twoColumnDynamicWithLeadingElement .children>*:nth-child(8),
-.twoColumnDynamicWithLeadingElement .children>*:nth-child(11) {
+.twoColumnDynamicWithLeadingElement .children > *:nth-child(7),
+.twoColumnDynamicWithLeadingElement .children > *:nth-child(8),
+.twoColumnDynamicWithLeadingElement .children > *:nth-child(11) {
   width: calc(33.33% - 16px);
 }
 
-.twoColumnDynamicWithLeadingElement .children>*:nth-child(6),
-.twoColumnDynamicWithLeadingElement .children>*:nth-child(9),
-.twoColumnDynamicWithLeadingElement .children>*:nth-child(10) {
+.twoColumnDynamicWithLeadingElement .children > *:nth-child(6),
+.twoColumnDynamicWithLeadingElement .children > *:nth-child(9),
+.twoColumnDynamicWithLeadingElement .children > *:nth-child(10) {
   width: calc(66.66% - 16px);
 }
 
 @media screen and (max-width: 1020px) {
-  .twoColumnDynamicWithLeadingElement .children>*:nth-child(n) {
+  .twoColumnDynamicWithLeadingElement .children > *:nth-child(n) {
     width: 100%;
   }
 }
@@ -82,7 +82,7 @@
   transform: translate3d(0, 0, 0);
 }
 
-.expandable .children>* {
+.expandable .children > * {
   margin: 12px 10px;
 }
 

--- a/packages/web/src/pages/explore-page/components/desktop/Section.tsx
+++ b/packages/web/src/pages/explore-page/components/desktop/Section.tsx
@@ -45,8 +45,6 @@ const Section = ({
       className={cn(styles.section, className, {
         [styles.twoColumnDynamicWithLeadingElement]:
           layout === Layout.TWO_COLUMN_DYNAMIC_WITH_LEADING_ELEMENT,
-        [styles.twoColumnDynamicWithDoubleLeadingElementTenTile]:
-          layout === Layout.TWO_COLUMN_DYNAMIC_WITH_DOUBLE_LEADING_ELEMENT,
         [styles.expandable]: expandable,
         [styles.expanded]: isExpanded
       })}

--- a/packages/web/src/pages/explore-page/components/mobile/ExplorePage.module.css
+++ b/packages/web/src/pages/explore-page/components/mobile/ExplorePage.module.css
@@ -38,35 +38,36 @@
   padding: 0px 8px;
 }
 
-.section > *,
-.lifestyle > * {
+.section>*,
+.lifestyle>* {
   margin: 4px;
 }
 
-.section > *:nth-child(5n + 1) {
+.section>*:nth-child(5n + 1) {
   flex-basis: 100%;
 }
 
-.section > *:nth-child(5n + 2),
-.section > *:nth-child(5n + 3),
-.section > *:nth-child(5n + 4),
-.section > *:nth-child(5n + 5) {
+.section>*:nth-child(5n + 2),
+.section>*:nth-child(5n + 3),
+.section>*:nth-child(5n + 4),
+.section>*:nth-child(5n + 5) {
   flex-basis: calc(50% - 8px);
 }
 
-.tripleHeaderSectionTenTile > *:nth-child(5n + 1),
-.tripleHeaderSectionTenTile > *:nth-child(5n + 2),
-.tripleHeaderSectionTenTile > *:nth-child(5n + 3),
-.tripleHeaderSectionTenTile > *:nth-child(5n + 8) {
+.quadrupleHeaderSectionElevenTile>*:nth-child(1),
+.quadrupleHeaderSectionElevenTile>*:nth-child(2),
+.quadrupleHeaderSectionElevenTile>*:nth-child(3),
+.quadrupleHeaderSectionElevenTile>*:nth-child(4),
+.quadrupleHeaderSectionElevenTile>*:nth-child(9) {
   flex-basis: 100%;
 }
 
-.tripleHeaderSectionTenTile > *:nth-child(5n + 4),
-.tripleHeaderSectionTenTile > *:nth-child(5n + 5),
-.tripleHeaderSectionTenTile > *:nth-child(5n + 6),
-.tripleHeaderSectionTenTile > *:nth-child(5n + 7),
-.tripleHeaderSectionTenTile > *:nth-child(5n + 9),
-.tripleHeaderSectionTenTile > *:nth-child(5n + 10) {
+.quadrupleHeaderSectionElevenTile>*:nth-child(5),
+.quadrupleHeaderSectionElevenTile>*:nth-child(6),
+.quadrupleHeaderSectionElevenTile>*:nth-child(7),
+.quadrupleHeaderSectionElevenTile>*:nth-child(8),
+.quadrupleHeaderSectionElevenTile>*:nth-child(10),
+.quadrupleHeaderSectionElevenTile>*:nth-child(11) {
   flex-basis: calc(50% - 8px);
 }
 
@@ -103,4 +104,8 @@
 
 .lineupContainer {
   padding: 24px 11px 12px;
+}
+
+.premiumTracksBackgroundIcon path {
+  fill: var(--white);
 }

--- a/packages/web/src/pages/explore-page/components/mobile/ExplorePage.module.css
+++ b/packages/web/src/pages/explore-page/components/mobile/ExplorePage.module.css
@@ -38,36 +38,36 @@
   padding: 0px 8px;
 }
 
-.section>*,
-.lifestyle>* {
+.section > *,
+.lifestyle > * {
   margin: 4px;
 }
 
-.section>*:nth-child(5n + 1) {
+.section > *:nth-child(5n + 1) {
   flex-basis: 100%;
 }
 
-.section>*:nth-child(5n + 2),
-.section>*:nth-child(5n + 3),
-.section>*:nth-child(5n + 4),
-.section>*:nth-child(5n + 5) {
+.section > *:nth-child(5n + 2),
+.section > *:nth-child(5n + 3),
+.section > *:nth-child(5n + 4),
+.section > *:nth-child(5n + 5) {
   flex-basis: calc(50% - 8px);
 }
 
-.quadrupleHeaderSectionElevenTile>*:nth-child(1),
-.quadrupleHeaderSectionElevenTile>*:nth-child(2),
-.quadrupleHeaderSectionElevenTile>*:nth-child(3),
-.quadrupleHeaderSectionElevenTile>*:nth-child(4),
-.quadrupleHeaderSectionElevenTile>*:nth-child(9) {
+.quadrupleHeaderSectionElevenTile > *:nth-child(1),
+.quadrupleHeaderSectionElevenTile > *:nth-child(2),
+.quadrupleHeaderSectionElevenTile > *:nth-child(3),
+.quadrupleHeaderSectionElevenTile > *:nth-child(4),
+.quadrupleHeaderSectionElevenTile > *:nth-child(9) {
   flex-basis: 100%;
 }
 
-.quadrupleHeaderSectionElevenTile>*:nth-child(5),
-.quadrupleHeaderSectionElevenTile>*:nth-child(6),
-.quadrupleHeaderSectionElevenTile>*:nth-child(7),
-.quadrupleHeaderSectionElevenTile>*:nth-child(8),
-.quadrupleHeaderSectionElevenTile>*:nth-child(10),
-.quadrupleHeaderSectionElevenTile>*:nth-child(11) {
+.quadrupleHeaderSectionElevenTile > *:nth-child(5),
+.quadrupleHeaderSectionElevenTile > *:nth-child(6),
+.quadrupleHeaderSectionElevenTile > *:nth-child(7),
+.quadrupleHeaderSectionElevenTile > *:nth-child(8),
+.quadrupleHeaderSectionElevenTile > *:nth-child(10),
+.quadrupleHeaderSectionElevenTile > *:nth-child(11) {
   flex-basis: calc(50% - 8px);
 }
 

--- a/packages/web/src/pages/explore-page/components/mobile/ExplorePage.tsx
+++ b/packages/web/src/pages/explore-page/components/mobile/ExplorePage.tsx
@@ -33,6 +33,7 @@ import CardLineup from 'components/lineup/CardLineup'
 import LoadingSpinner from 'components/loading-spinner/LoadingSpinner'
 import MobilePageContainer from 'components/mobile-page-container/MobilePageContainer'
 import { useMainPageHeader } from 'components/nav/store/context'
+import { useIsUSDCEnabled } from 'hooks/useIsUSDCEnabled'
 import useTabs from 'hooks/useTabs/useTabs'
 import {
   CHILL_PLAYLISTS,
@@ -55,7 +56,6 @@ import { justForYou } from '../desktop/ExplorePage'
 
 import ColorTile from './ColorTile'
 import styles from './ExplorePage.module.css'
-import { useIsUSDCEnabled } from 'hooks/useIsUSDCEnabled'
 const { getTab } = explorePageSelectors
 const { setTab } = explorePageActions
 
@@ -140,9 +140,11 @@ const ExplorePage = ({
   useMainPageHeader()
 
   const isUSDCPurchasesEnabled = useIsUSDCEnabled()
-  const justForYouTiles = justForYou.map(
-    (t: SmartCollection | ExploreCollection) => {
-      const isPremiumTracksTile = t.variant === ExploreCollectionsVariant.DIRECT_LINK && t.title === PREMIUM_TRACKS.title
+  const justForYouTiles = justForYou
+    .map((t: SmartCollection | ExploreCollection) => {
+      const isPremiumTracksTile =
+        t.variant === ExploreCollectionsVariant.DIRECT_LINK &&
+        t.title === PREMIUM_TRACKS.title
       if (!isUSDCPurchasesEnabled && isPremiumTracksTile) {
         return null
       }
@@ -171,18 +173,21 @@ const ExplorePage = ({
             gradient={t.gradient}
             shadow={t.shadow}
             // @ts-ignore
-            icon={<Icon
-              className={t.title === PREMIUM_TRACKS.title
-                ? styles.premiumTracksBackgroundIcon
-                : undefined}
-            />}
+            icon={
+              <Icon
+                className={
+                  t.title === PREMIUM_TRACKS.title
+                    ? styles.premiumTracksBackgroundIcon
+                    : undefined
+                }
+              />
+            }
             goToRoute={goToRoute}
             isIncentivized={t.incentivized}
           />
         )
       }
-    }
-  )
+    })
     .filter(removeNullable)
 
   const lifestyleTiles = lifestyle.map((t: ExploreMoodCollection) => {
@@ -264,7 +269,12 @@ const ExplorePage = ({
         title={messages.justForYou}
         description={messages.justForYouDescription}
       >
-        <div className={cn(styles.section, styles.quadrupleHeaderSectionElevenTile)}>
+        <div
+          className={cn(
+            styles.section,
+            styles.quadrupleHeaderSectionElevenTile
+          )}
+        >
           {justForYouTiles}
         </div>
       </TabBodyHeader>,

--- a/packages/web/src/pages/explore-page/components/mobile/ExplorePage.tsx
+++ b/packages/web/src/pages/explore-page/components/mobile/ExplorePage.tsx
@@ -40,7 +40,8 @@ import {
   PROVOKING_PLAYLISTS,
   INTIMATE_PLAYLISTS,
   ExploreCollection,
-  ExploreMoodCollection
+  ExploreMoodCollection,
+  PREMIUM_TRACKS
 } from 'pages/explore-page/collections'
 import {
   collectionPage,
@@ -163,7 +164,11 @@ const ExplorePage = ({
             gradient={t.gradient}
             shadow={t.shadow}
             // @ts-ignore
-            icon={<Icon />}
+            icon={<Icon
+              className={t.title === PREMIUM_TRACKS.title
+                ? styles.premiumTracksBackgroundIcon
+                : undefined}
+            />}
             goToRoute={goToRoute}
             isIncentivized={t.incentivized}
           />
@@ -251,7 +256,7 @@ const ExplorePage = ({
         title={messages.justForYou}
         description={messages.justForYouDescription}
       >
-        <div className={cn(styles.section, styles.tripleHeaderSectionTenTile)}>
+        <div className={cn(styles.section, styles.quadrupleHeaderSectionElevenTile)}>
           {justForYouTiles}
         </div>
       </TabBodyHeader>,

--- a/packages/web/src/pages/explore-page/components/mobile/ExplorePage.tsx
+++ b/packages/web/src/pages/explore-page/components/mobile/ExplorePage.tsx
@@ -16,7 +16,8 @@ import {
   explorePageActions,
   ExplorePageTabs as ExploreTabs,
   ExploreCollectionsVariant,
-  explorePageSelectors
+  explorePageSelectors,
+  removeNullable
 } from '@audius/common'
 import cn from 'classnames'
 import { useDispatch, useSelector } from 'react-redux'
@@ -54,6 +55,7 @@ import { justForYou } from '../desktop/ExplorePage'
 
 import ColorTile from './ColorTile'
 import styles from './ExplorePage.module.css'
+import { useIsUSDCEnabled } from 'hooks/useIsUSDCEnabled'
 const { getTab } = explorePageSelectors
 const { setTab } = explorePageActions
 
@@ -137,8 +139,13 @@ const ExplorePage = ({
 }: ExplorePageProps) => {
   useMainPageHeader()
 
+  const isUSDCPurchasesEnabled = useIsUSDCEnabled()
   const justForYouTiles = justForYou.map(
     (t: SmartCollection | ExploreCollection) => {
+      const isPremiumTracksTile = t.variant === ExploreCollectionsVariant.DIRECT_LINK && t.title === PREMIUM_TRACKS.title
+      if (!isUSDCPurchasesEnabled && isPremiumTracksTile) {
+        return null
+      }
       const Icon = t.icon ? t.icon : Fragment
       if (t.variant === CollectionVariant.SMART) {
         return (
@@ -176,6 +183,7 @@ const ExplorePage = ({
       }
     }
   )
+    .filter(removeNullable)
 
   const lifestyleTiles = lifestyle.map((t: ExploreMoodCollection) => {
     return (

--- a/packages/web/src/pages/premium-tracks-page/PremiumTracksPage.tsx
+++ b/packages/web/src/pages/premium-tracks-page/PremiumTracksPage.tsx
@@ -1,0 +1,55 @@
+import {
+  premiumTracksPageLineupActions,
+  premiumTracksPageLineupSelectors
+} from '@audius/common'
+
+import EndOfLineup from 'components/lineup/EndOfLineup'
+import Lineup from 'components/lineup/Lineup'
+import { useLineupProps } from 'components/lineup/hooks'
+import { LineupVariant } from 'components/lineup/types'
+import { useIsMobile } from 'utils/clientUtil'
+
+import { PremiumTracksPageContent as DesktopPremiumTracksPageContent } from './desktop/PremiumTracksPageContent'
+import { PremiumTracksPageContent as MobilePremiumTracksPageContent } from './mobile/PremiumTracksPageContent'
+
+const { getLineup } = premiumTracksPageLineupSelectors
+
+const messages = {
+  endOfLineupDescription: "Looks like you've reached the end of this list..."
+}
+
+const usePremiumTracksLineup = (containerRef: HTMLElement) => {
+  return useLineupProps({
+    actions: premiumTracksPageLineupActions,
+    getLineupSelector: getLineup,
+    variant: LineupVariant.MAIN,
+    scrollParent: containerRef
+  })
+}
+
+type PremiumTracksPageProps = {
+  containerRef: HTMLElement
+}
+
+export const PremiumTracksPage = ({ containerRef }: PremiumTracksPageProps) => {
+  const lineupProps = usePremiumTracksLineup(containerRef)
+  const isMobile = useIsMobile()
+  const Content = isMobile
+    ? MobilePremiumTracksPageContent
+    : DesktopPremiumTracksPageContent
+  const renderLineup = () => {
+    return (
+      <Lineup
+        key='premium-tracks'
+        endOfLineup={
+          <EndOfLineup
+            key='endOfLineup'
+            description={messages.endOfLineupDescription}
+          />
+        }
+        {...lineupProps}
+      />
+    )
+  }
+  return <Content lineup={renderLineup()} />
+}

--- a/packages/web/src/pages/premium-tracks-page/desktop/PremiumTracksPageContent.tsx
+++ b/packages/web/src/pages/premium-tracks-page/desktop/PremiumTracksPageContent.tsx
@@ -1,0 +1,32 @@
+import DesktopHeader from 'components/header/desktop/Header'
+import { Page } from 'components/page/Page'
+import { BASE_URL, EXPLORE_PREMIUM_TRACKS_PAGE } from 'utils/route'
+import { createSeoDescription } from 'utils/seo'
+
+const messages = {
+  pageTitle: 'Premium Tracks',
+  pageDescription: createSeoDescription(
+    'Explore premium music available to purchase.'
+  )
+}
+
+type PremiumTracksPageContentProps = {
+  lineup: JSX.Element
+}
+
+export const PremiumTracksPageContent = ({
+  lineup
+}: PremiumTracksPageContentProps) => {
+  const header = <DesktopHeader primary={messages.pageTitle} variant='main' />
+  return (
+    <Page
+      title={messages.pageTitle}
+      description={messages.pageDescription}
+      canonicalUrl={`${BASE_URL}${EXPLORE_PREMIUM_TRACKS_PAGE}`}
+      size='large'
+      header={header}
+    >
+      {lineup}
+    </Page>
+  )
+}

--- a/packages/web/src/pages/premium-tracks-page/mobile/PremiumTracksPageContent.module.css
+++ b/packages/web/src/pages/premium-tracks-page/mobile/PremiumTracksPageContent.module.css
@@ -1,0 +1,4 @@
+.container {
+  padding: var(--unit-3) var(--unit-3) 0;
+  width: 100%;
+}

--- a/packages/web/src/pages/premium-tracks-page/mobile/PremiumTracksPageContent.tsx
+++ b/packages/web/src/pages/premium-tracks-page/mobile/PremiumTracksPageContent.tsx
@@ -1,0 +1,44 @@
+import { useContext, useEffect } from 'react'
+
+import Header from 'components/header/mobile/Header'
+import { HeaderContext } from 'components/header/mobile/HeaderContextProvider'
+import MobilePageContainer from 'components/mobile-page-container/MobilePageContainer'
+import { BASE_URL, EXPLORE_PREMIUM_TRACKS_PAGE } from 'utils/route'
+import { createSeoDescription } from 'utils/seo'
+
+import styles from './PremiumTracksPageContent.module.css'
+
+const messages = {
+  pageTitle: 'Premium Tracks',
+  pageDescription: createSeoDescription(
+    'Explore premium music available to purchase.'
+  )
+}
+
+type PremiumTracksPageContentProps = {
+  lineup: JSX.Element
+}
+
+export const PremiumTracksPageContent = ({
+  lineup
+}: PremiumTracksPageContentProps) => {
+  const { setHeader } = useContext(HeaderContext)
+  useEffect(() => {
+    setHeader(
+      <>
+        <Header title={messages.pageTitle} />
+      </>
+    )
+  }, [setHeader])
+
+  return (
+    <MobilePageContainer
+      title={messages.pageTitle}
+      description={messages.pageDescription}
+      canonicalUrl={`${BASE_URL}${EXPLORE_PREMIUM_TRACKS_PAGE}`}
+      hasDefaultHeader
+    >
+      <div className={styles.container}>{lineup}</div>
+    </MobilePageContainer>
+  )
+}

--- a/packages/web/src/store/sagas.ts
+++ b/packages/web/src/store/sagas.ts
@@ -42,6 +42,7 @@ import exploreCollectionsPageSagas from 'common/store/pages/explore/exploreColle
 import explorePageSagas from 'common/store/pages/explore/sagas'
 import feedPageSagas from 'common/store/pages/feed/sagas'
 import historySagas from 'common/store/pages/history/sagas'
+import premiumTracksSagas from 'common/store/pages/premium-tracks/sagas'
 import remixesSagas from 'common/store/pages/remixes-page/sagas'
 import savedSagas from 'common/store/pages/saved/sagas'
 import searchResultsSagas from 'common/store/pages/search-page/sagas'
@@ -146,6 +147,7 @@ export default function* rootSaga() {
     trendingPlaylistSagas(),
     trendingUndergroundSagas(),
     uploadSagas(),
+    premiumTracksSagas(),
 
     // Cache
     coreCacheSagas(),

--- a/packages/web/src/utils/route.ts
+++ b/packages/web/src/utils/route.ts
@@ -37,6 +37,7 @@ export const TRENDING_PAGE = '/trending'
 export const TRENDING_PLAYLISTS_PAGE_LEGACY = '/trending/playlists'
 
 export const EXPLORE_PAGE = '/explore'
+export const EXPLORE_PREMIUM_TRACKS_PAGE = '/explore/premium-tracks'
 export const EXPLORE_HEAVY_ROTATION_PAGE = '/explore/heavy-rotation'
 export const EXPLORE_LET_THEM_DJ_PAGE = '/explore/let-them-dj'
 export const EXPLORE_BEST_NEW_RELEASES_PAGE = '/explore/best-new-releases'


### PR DESCRIPTION
### Description

This PR has the changes that add the premium tracks (usdc purchase) explore page in the UI.
Changes include web, mobile web, and native mobile.

This PR merges into [this one](https://github.com/AudiusProject/audius-protocol/pull/6202) which has the DN changes.

### How Has This Been Tested?

Tested with local services, and also against stage.