### PR TITLE
[PAY-1939] Convert purchase content drawer to full screen variant

### DIFF
--- a/packages/mobile/src/components/drawer/Drawer.tsx
+++ b/packages/mobile/src/components/drawer/Drawer.tsx
@@ -194,6 +194,9 @@ export type DrawerProps = {
    */
   drawerStyle?: ViewStyle
 
+  /**
+   * Optional replacement component for the drawer header
+   */
   drawerHeader?: ComponentType<{ onClose: () => void }>
 
   translationAnim?: Animated.Value
@@ -263,7 +266,7 @@ export const Drawer: DrawerComponent = ({
   shouldCloseToInitialOffset,
   shouldHaveRoundedBordersAtInitialOffset = false,
   zIndex = 5,
-  drawerHeader,
+  drawerHeader: CustomDrawerHeader,
   drawerStyle,
   shouldShowShadow = true,
   shouldAnimateShadow,
@@ -657,13 +660,17 @@ export const Drawer: DrawerComponent = ({
         }}
         {...edgeProps}
       >
-        <DrawerHeader
-          onClose={onClose}
-          title={title}
-          titleIcon={titleIcon}
-          titleImage={titleImage}
-          isFullscreen={isFullscreen}
-        />
+        {CustomDrawerHeader ? (
+          <CustomDrawerHeader onClose={onClose} />
+        ) : (
+          <DrawerHeader
+            onClose={onClose}
+            title={title}
+            titleIcon={titleIcon}
+            titleImage={titleImage}
+            isFullscreen={isFullscreen}
+          />
+        )}
         {children}
       </ViewComponent>
     )

--- a/packages/mobile/src/components/drawer/Drawer.tsx
+++ b/packages/mobile/src/components/drawer/Drawer.tsx
@@ -194,6 +194,8 @@ export type DrawerProps = {
    */
   drawerStyle?: ViewStyle
 
+  drawerHeader?: ComponentType<{ onClose: () => void }>
+
   translationAnim?: Animated.Value
 }
 
@@ -261,6 +263,7 @@ export const Drawer: DrawerComponent = ({
   shouldCloseToInitialOffset,
   shouldHaveRoundedBordersAtInitialOffset = false,
   zIndex = 5,
+  drawerHeader,
   drawerStyle,
   shouldShowShadow = true,
   shouldAnimateShadow,

--- a/packages/mobile/src/components/drawer/DrawerHeader.tsx
+++ b/packages/mobile/src/components/drawer/DrawerHeader.tsx
@@ -9,7 +9,7 @@ import { makeStyles } from 'app/styles'
 import type { SvgProps } from 'app/types/svg'
 import { useColor } from 'app/utils/theme'
 
-export type DrawerHeaderProps = {
+type DrawerHeaderProps = {
   onClose: () => void
   title?: ReactNode
   titleIcon?: ComponentType<SvgProps>

--- a/packages/mobile/src/components/drawer/DrawerHeader.tsx
+++ b/packages/mobile/src/components/drawer/DrawerHeader.tsx
@@ -9,7 +9,7 @@ import { makeStyles } from 'app/styles'
 import type { SvgProps } from 'app/types/svg'
 import { useColor } from 'app/utils/theme'
 
-type DrawerHeaderProps = {
+export type DrawerHeaderProps = {
   onClose: () => void
   title?: ReactNode
   titleIcon?: ComponentType<SvgProps>

--- a/packages/mobile/src/components/premium-track-purchase-drawer/PremiumTrackPurchaseDrawer.tsx
+++ b/packages/mobile/src/components/premium-track-purchase-drawer/PremiumTrackPurchaseDrawer.tsx
@@ -12,7 +12,7 @@ import {
   usePurchaseContentFormConfiguration
 } from '@audius/common'
 import { Formik, useFormikContext } from 'formik'
-import { Linking, View } from 'react-native'
+import { Linking, View, ScrollView } from 'react-native'
 import { useDispatch } from 'react-redux'
 import { toFormikValidationSchema } from 'zod-formik-adapter'
 
@@ -63,17 +63,30 @@ const messages = {
 
 const useStyles = makeStyles(({ spacing, typography, palette }) => ({
   drawer: {
-    paddingTop: spacing(6),
-    paddingHorizontal: spacing(4),
-    paddingBottom: spacing(8),
-    gap: spacing(6),
+    flex: 1,
     backgroundColor: palette.white
   },
+  formContainer: {
+    flex: 1,
+    paddingHorizontal: spacing(4)
+  },
+  formContentContainer: {
+    borderTopWidth: 1,
+    borderTopColor: palette.neutralLight8,
+    paddingVertical: spacing(6),
+    gap: spacing(4)
+  },
+  formActions: {
+    flex: 0,
+    paddingTop: spacing(4),
+    paddingBottom: spacing(6),
+    columnGap: spacing(4)
+  },
   titleContainer: {
-    ...flexRowCentered(),
-    gap: spacing(2),
-    marginBottom: spacing(2),
-    alignSelf: 'center'
+    // padding: undefined,
+    // paddingHorizontal: spacing(8),
+    paddingTop: spacing(6),
+    paddingBottom: spacing(4)
   },
   title: {
     fontSize: typography.fontSize.xl,
@@ -140,21 +153,17 @@ const RenderForm = ({ track }: { track: PurchasableTrackMetadata }) => {
   }, [])
 
   return (
-    <View style={styles.drawer}>
-      <View style={styles.titleContainer}>
-        <IconCart fill={neutralLight2} />
-        <Text style={styles.title}>{messages.title}</Text>
-      </View>
-      <TrackDetailsTile trackId={track.track_id} />
-      <PayExtraFormSection amountPresets={payExtraAmountPresetValues} />
-      <PurchaseSummaryTable
-        {...purchaseSummaryValues}
-        isPurchaseSuccessful={isPurchaseSuccessful}
-      />
-      {isPurchaseSuccessful ? (
-        <PurchaseSuccess track={track} />
-      ) : (
-        <>
+    <>
+      <ScrollView contentContainerStyle={styles.formContentContainer}>
+        <TrackDetailsTile trackId={track.track_id} />
+        <PayExtraFormSection amountPresets={payExtraAmountPresetValues} />
+        <PurchaseSummaryTable
+          {...purchaseSummaryValues}
+          isPurchaseSuccessful={isPurchaseSuccessful}
+        />
+        {isPurchaseSuccessful ? (
+          <PurchaseSuccess track={track} />
+        ) : (
           <View>
             <View style={styles.payToUnlockTitleContainer}>
               <Text weight='heavy' textTransform='uppercase' fontSize='small'>
@@ -170,32 +179,36 @@ const RenderForm = ({ track }: { track: PurchasableTrackMetadata }) => {
               )}
             </Text>
           </View>
-          <Button
-            onPress={submitForm}
-            disabled={isUnlocking}
-            title={
-              isUnlocking
-                ? messages.purchasing
-                : messages.buy(formatPrice(price))
-            }
-            variant={'primary'}
-            size='large'
-            color={specialLightGreen}
-            iconPosition='left'
-            icon={isUnlocking ? LoadingSpinner : undefined}
-            fullWidth
-          />
-        </>
-      )}
-      {error ? (
-        <View style={styles.errorContainer}>
-          <IconError fill={accentRed} width={spacing(5)} height={spacing(5)} />
-          <Text weight='medium' colorValue={accentRed}>
-            {messages.error}
-          </Text>
-        </View>
-      ) : null}
-    </View>
+        )}
+      </ScrollView>
+      <View style={styles.formActions}>
+        {error ? (
+          <View style={styles.errorContainer}>
+            <IconError
+              fill={accentRed}
+              width={spacing(5)}
+              height={spacing(5)}
+            />
+            <Text weight='medium' colorValue={accentRed}>
+              {messages.error}
+            </Text>
+          </View>
+        ) : null}
+        <Button
+          onPress={submitForm}
+          disabled={isUnlocking}
+          title={
+            isUnlocking ? messages.purchasing : messages.buy(formatPrice(price))
+          }
+          variant={'primary'}
+          size='large'
+          color={specialLightGreen}
+          iconPosition='left'
+          icon={isUnlocking ? LoadingSpinner : undefined}
+          fullWidth
+        />
+      </View>
+    </>
   )
 }
 
@@ -223,21 +236,28 @@ export const PremiumTrackPurchaseDrawer = () => {
 
   return (
     <NativeDrawer
+      // drawerStyle={styles.drawer}
+      title={messages.title}
+      titleIcon={IconCart}
       drawerName={PREMIUM_TRACK_PURCHASE_MODAL_NAME}
       onClosed={handleClosed}
+      isGestureSupported={false}
+      isFullscreen
     >
       {isLoading ? (
         <View style={styles.spinnerContainer}>
           <LoadingSpinner />
         </View>
       ) : (
-        <Formik
-          initialValues={initialValues}
-          validationSchema={toFormikValidationSchema(validationSchema)}
-          onSubmit={onSubmit}
-        >
-          <RenderForm track={track} />
-        </Formik>
+        <View style={styles.formContainer}>
+          <Formik
+            initialValues={initialValues}
+            validationSchema={toFormikValidationSchema(validationSchema)}
+            onSubmit={onSubmit}
+          >
+            <RenderForm track={track} />
+          </Formik>
+        </View>
       )}
     </NativeDrawer>
   )

--- a/packages/mobile/src/components/premium-track-purchase-drawer/PremiumTrackPurchaseDrawer.tsx
+++ b/packages/mobile/src/components/premium-track-purchase-drawer/PremiumTrackPurchaseDrawer.tsx
@@ -12,11 +12,12 @@ import {
   usePurchaseContentFormConfiguration
 } from '@audius/common'
 import { Formik, useFormikContext } from 'formik'
-import { Linking, View, ScrollView } from 'react-native'
+import { Linking, View, ScrollView, TouchableOpacity } from 'react-native'
 import { useDispatch } from 'react-redux'
 import { toFormikValidationSchema } from 'zod-formik-adapter'
 
 import IconCart from 'app/assets/images/iconCart.svg'
+import IconCloseAlt from 'app/assets/images/iconCloseAlt.svg'
 import IconError from 'app/assets/images/iconError.svg'
 import { Button, LockedStatusBadge, Text } from 'app/components/core'
 import { NativeDrawer } from 'app/components/drawer'
@@ -63,16 +64,12 @@ const messages = {
 
 const useStyles = makeStyles(({ spacing, typography, palette }) => ({
   drawer: {
-    flex: 1,
-    backgroundColor: palette.white
-  },
-  formContainer: {
-    flex: 1,
     paddingHorizontal: spacing(4)
   },
+  formContainer: {
+    flex: 1
+  },
   formContentContainer: {
-    borderTopWidth: 1,
-    borderTopColor: palette.neutralLight8,
     paddingVertical: spacing(6),
     gap: spacing(4)
   },
@@ -82,18 +79,22 @@ const useStyles = makeStyles(({ spacing, typography, palette }) => ({
     paddingBottom: spacing(6),
     columnGap: spacing(4)
   },
-  titleContainer: {
-    // padding: undefined,
-    // paddingHorizontal: spacing(8),
-    paddingTop: spacing(6),
-    paddingBottom: spacing(4)
+  headerContainer: {
+    borderBottomWidth: 1,
+    borderBottomColor: palette.neutralLight8,
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'flex-start',
+    paddingVertical: spacing(4)
   },
-  title: {
-    fontSize: typography.fontSize.xl,
-    fontFamily: typography.fontByWeight.heavy,
-    color: palette.neutralLight2,
-    textTransform: 'uppercase',
-    lineHeight: typography.fontSize.xl * 1.25
+  titleContainer: {
+    ...flexRowCentered(),
+    gap: spacing(2),
+    flexDirection: 'row',
+    flex: 1,
+    justifyContent: 'center',
+    // Matches close icon width
+    paddingRight: spacing(6)
   },
   trackTileContainer: {
     ...flexRowCentered(),
@@ -124,13 +125,45 @@ const useStyles = makeStyles(({ spacing, typography, palette }) => ({
   }
 }))
 
+const PremiumTrackPurchaseDrawerHeader = ({
+  onClose
+}: {
+  onClose: () => void
+}) => {
+  const styles = useStyles()
+  const { neutralLight2, neutralLight4 } = useThemeColors()
+  return (
+    <View style={styles.headerContainer}>
+      <TouchableOpacity activeOpacity={0.7} onPress={onClose}>
+        <IconCloseAlt
+          width={spacing(6)}
+          height={spacing(6)}
+          fill={neutralLight4}
+        />
+      </TouchableOpacity>
+      <View style={styles.titleContainer}>
+        <IconCart width={spacing(6)} height={spacing(6)} fill={neutralLight2} />
+        <Text
+          variant='label'
+          fontSize='large'
+          color='neutralLight2'
+          weight='heavy'
+          textTransform='uppercase'
+          noGutter
+        >
+          {messages.title}
+        </Text>
+      </View>
+    </View>
+  )
+}
+
 // The bulk of the form rendering is in a nested component because we want access
 // to the FormikContext, which can only be used in a component which is a descendant
 // of the `<Formik />` component
 const RenderForm = ({ track }: { track: PurchasableTrackMetadata }) => {
   const styles = useStyles()
-  const { specialLightGreen, neutralLight2, accentRed, secondary } =
-    useThemeColors()
+  const { specialLightGreen, accentRed, secondary } = useThemeColors()
 
   const { submitForm, resetForm } = useFormikContext()
 
@@ -236,9 +269,10 @@ export const PremiumTrackPurchaseDrawer = () => {
 
   return (
     <NativeDrawer
-      // drawerStyle={styles.drawer}
-      title={messages.title}
-      titleIcon={IconCart}
+      drawerStyle={styles.drawer}
+      drawerHeader={PremiumTrackPurchaseDrawerHeader}
+      // title={messages.title}
+      // titleIcon={IconCart}
       drawerName={PREMIUM_TRACK_PURCHASE_MODAL_NAME}
       onClosed={handleClosed}
       isGestureSupported={false}

--- a/packages/mobile/src/components/premium-track-purchase-drawer/PremiumTrackPurchaseDrawer.tsx
+++ b/packages/mobile/src/components/premium-track-purchase-drawer/PremiumTrackPurchaseDrawer.tsx
@@ -271,8 +271,6 @@ export const PremiumTrackPurchaseDrawer = () => {
     <NativeDrawer
       drawerStyle={styles.drawer}
       drawerHeader={PremiumTrackPurchaseDrawerHeader}
-      // title={messages.title}
-      // titleIcon={IconCart}
       drawerName={PREMIUM_TRACK_PURCHASE_MODAL_NAME}
       onClosed={handleClosed}
       isGestureSupported={false}


### PR DESCRIPTION
### Description
This converts the premium content purchase drawer to be full screen. It required a little bit of style tweaking and implementation of a custom header to get the spacing/styling correct. 

fixes PAY-1939

### How Has This Been Tested?
Tested locally on simulator against staging

![Kapture 2023-10-03 at 14 18 45](https://github.com/AudiusProject/audius-protocol/assets/1815175/a4f3ea94-2cec-4532-b800-55cab7e1c816)

