### PR TITLE
[PAY-1927] Cleanup redux state on purchase modal close

### DIFF
--- a/packages/web/src/components/premium-content-purchase-modal/PremiumContentPurchaseModal.tsx
+++ b/packages/web/src/components/premium-content-purchase-modal/PremiumContentPurchaseModal.tsx
@@ -63,6 +63,7 @@ const RenderForm = ({
   const handleClose = useCallback(() => {
     dispatch(cleanupUSDCRecovery())
     onClose()
+    dispatch(cleanup())
   }, [dispatch, onClose])
 
   // Navigate to track on successful purchase behind the modal
@@ -119,7 +120,6 @@ const RenderForm = ({
 }
 
 export const PremiumContentPurchaseModal = () => {
-  const dispatch = useDispatch()
   const {
     isOpen,
     onClose,
@@ -135,11 +135,6 @@ export const PremiumContentPurchaseModal = () => {
   const { initialValues, validationSchema, onSubmit } =
     usePurchaseContentFormConfiguration({ track })
 
-  const handleClose = useCallback(() => {
-    dispatch(cleanup())
-    onClose()
-  }, [dispatch, onClose])
-
   const isValidTrack = track && isTrackPurchasable(track)
 
   if (track && !isValidTrack) {
@@ -149,7 +144,7 @@ export const PremiumContentPurchaseModal = () => {
   return (
     <ModalDrawer
       isOpen={isOpen}
-      onClose={handleClose}
+      onClose={onClose}
       onClosed={onClosed}
       bodyClassName={styles.modal}
       isFullscreen

--- a/packages/web/src/components/premium-content-purchase-modal/PremiumContentPurchaseModal.tsx
+++ b/packages/web/src/components/premium-content-purchase-modal/PremiumContentPurchaseModal.tsx
@@ -8,7 +8,8 @@ import {
   useGetTrackById,
   usePremiumContentPurchaseModal,
   usePurchaseContentFormConfiguration,
-  buyUSDCActions
+  buyUSDCActions,
+  purchaseContentActions
 } from '@audius/common'
 import { IconCart, ModalContent, ModalFooter, ModalHeader } from '@audius/stems'
 import cn from 'classnames'
@@ -31,6 +32,7 @@ import { usePurchaseContentFormState } from './hooks/usePurchaseContentFormState
 
 const { startRecoveryIfNecessary, cleanup: cleanupUSDCRecovery } =
   buyUSDCActions
+const { cleanup } = purchaseContentActions
 
 const messages = {
   completePurchase: 'Complete Purchase'
@@ -117,6 +119,7 @@ const RenderForm = ({
 }
 
 export const PremiumContentPurchaseModal = () => {
+  const dispatch = useDispatch()
   const {
     isOpen,
     onClose,
@@ -132,6 +135,11 @@ export const PremiumContentPurchaseModal = () => {
   const { initialValues, validationSchema, onSubmit } =
     usePurchaseContentFormConfiguration({ track })
 
+  const handleClose = useCallback(() => {
+    dispatch(cleanup())
+    onClose()
+  }, [dispatch, onClose])
+
   const isValidTrack = track && isTrackPurchasable(track)
 
   if (track && !isValidTrack) {
@@ -141,7 +149,7 @@ export const PremiumContentPurchaseModal = () => {
   return (
     <ModalDrawer
       isOpen={isOpen}
-      onClose={onClose}
+      onClose={handleClose}
       onClosed={onClosed}
       bodyClassName={styles.modal}
       isFullscreen


### PR DESCRIPTION
### Description
Cleans up redux state when closing the purchase content modal, so that trying to purchase a different track shows a clean state.

### How Has This Been Tested?

Local web client