### PR TITLE
Fix flaky follows on sign up, mobile C-2718

### DIFF
--- a/packages/common/src/utils/sagaHelpers.ts
+++ b/packages/common/src/utils/sagaHelpers.ts
@@ -119,6 +119,9 @@ export function* doEvery(
   return chan
 }
 
+/**
+ * Waits for account to finish loading, whether it fails or succeeds.
+ */
 export function* waitForAccount() {
   yield* call(
     waitForValue,

--- a/packages/web/src/common/store/pages/signon/sagas.js
+++ b/packages/web/src/common/store/pages/signon/sagas.js
@@ -742,7 +742,6 @@ function* watchConfigureMetaMask() {
 function* watchFollowArtists() {
   while (
     yield all([
-      take(signOnActions.SIGN_UP_SUCCEEDED),
       take(accountActions.fetchAccountSucceeded.type),
       take(signOnActions.FOLLOW_ARTISTS)
     ])

--- a/packages/web/src/utils/sagaHelpers.ts
+++ b/packages/web/src/utils/sagaHelpers.ts
@@ -8,7 +8,9 @@ import {
 } from 'store/reachability/sagas'
 
 /**
- * Required for all writes
+ * Required for all writes.
+ * NOTE: This does not ensure that the account exists. If the account is required
+ * for your operation, call `ensureLoggedIn` or an equivalent after calling `waitForWrite`.
  */
 export function* waitForWrite() {
   yield* call(waitForBackendSetup)


### PR DESCRIPTION
### Description
The saga where we follow the selected artists would sometimes execute before the new user's account was successfully loaded due to a race condition. 
Unclear why this race condition showed on mobile but not desktop, as both use the same sign up sagas and start with the same `accountStatus = ERROR` state if user is logged out. Perhaps just a difference in the redux saga or other internals between the two platforms.

### How Has This Been Tested?
Tested on mobile and desktop.

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._
