### PR TITLE
Remove partition migration again

### DIFF
--- a/dev-tools/compose/docker-compose.storagev2.yml
+++ b/dev-tools/compose/docker-compose.storagev2.yml
@@ -43,6 +43,6 @@ services:
           'curl --fail http://localhost:1991/health_check || exit 1'
         ]
       interval: 10s
-      start_period: 30s
+      start_period: 600s
       timeout: 5s
       retries: 20

--- a/dev-tools/compose/docker-compose.storagev2.yml
+++ b/dev-tools/compose/docker-compose.storagev2.yml
@@ -43,6 +43,6 @@ services:
           'curl --fail http://localhost:1991/health_check || exit 1'
         ]
       interval: 10s
-      start_period: 60s
+      start_period: 120s
       timeout: 5s
       retries: 20

--- a/dev-tools/compose/docker-compose.storagev2.yml
+++ b/dev-tools/compose/docker-compose.storagev2.yml
@@ -43,6 +43,6 @@ services:
           'curl --fail http://localhost:1991/health_check || exit 1'
         ]
       interval: 10s
-      start_period: 600s
+      start_period: 1200s
       timeout: 5s
       retries: 20

--- a/dev-tools/compose/docker-compose.storagev2.yml
+++ b/dev-tools/compose/docker-compose.storagev2.yml
@@ -43,6 +43,6 @@ services:
           'curl --fail http://localhost:1991/health_check || exit 1'
         ]
       interval: 10s
-      start_period: 600s
+      start_period: 60s
       timeout: 5s
       retries: 20

--- a/dev-tools/compose/docker-compose.storagev2.yml
+++ b/dev-tools/compose/docker-compose.storagev2.yml
@@ -43,6 +43,6 @@ services:
           'curl --fail http://localhost:1991/health_check || exit 1'
         ]
       interval: 10s
-      start_period: 1200s
+      start_period: 600s
       timeout: 5s
       retries: 20

--- a/dev-tools/compose/docker-compose.storagev2.yml
+++ b/dev-tools/compose/docker-compose.storagev2.yml
@@ -43,6 +43,6 @@ services:
           'curl --fail http://localhost:1991/health_check || exit 1'
         ]
       interval: 10s
-      start_period: 120s
+      start_period: 60s
       timeout: 5s
       retries: 20

--- a/dev-tools/compose/docker-compose.test.yml
+++ b/dev-tools/compose/docker-compose.test.yml
@@ -324,9 +324,10 @@ services:
       dbUrlTemplate: 'postgres://postgres:example@mediorum-db:5432/m%d'
       devNetworkCount: '5'
     healthcheck:
-      test: ['CMD', 'curl', 'http://localhost:1991/health_check']
-      interval: 3s
-      timeout: 3s
+      test: ["CMD", "curl", "http://localhost:1991/health_check"]
+      interval: 10s
+      start_period: 60s
+      timeout: 5s
     logging: *default-logging
     profiles:
       - mediorum

--- a/dev-tools/compose/docker-compose.test.yml
+++ b/dev-tools/compose/docker-compose.test.yml
@@ -302,6 +302,8 @@ services:
 
   mediorum-db:
     image: postgres:11.4
+    shm_size: 5g
+    command: postgres -c shared_buffers=5GB
     environment:
       POSTGRES_PASSWORD: example
     healthcheck:
@@ -359,7 +361,7 @@ services:
     entrypoint: sh -c '[ ! "$$1" = "test" ] && sleep inf || (shift; go test ./... -count 1 -timeout 60s "$$@")' -
     environment:
       dbUrlTemplate: 'postgres://postgres:example@mediorum-db:5432/m%d'
-      dbUrl: 'postgres://postgres:example@mediorum-db:5432/m1'
+      dbUrl: 'postgres://postgres:example@mediorum-db:5432/mediorum_test'
     profiles:
       - mediorum-unittests
     depends_on:

--- a/dev-tools/compose/docker-compose.yml
+++ b/dev-tools/compose/docker-compose.yml
@@ -38,6 +38,8 @@ services:
 
   db:
     image: postgres
+    shm_size: 2g
+    command: postgres -c shared_buffers=2GB
     restart: unless-stopped
     ports:
       - 5432:5432

--- a/mediorum/crudr/crudr.go
+++ b/mediorum/crudr/crudr.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"log"
 	"mediorum/httputil"
 	"reflect"
 	"strconv"
@@ -92,19 +91,9 @@ func migrateOps(db *gorm.DB) error {
 	// create partitions
 	totalPartitions := 1009
 	for i := 0; i < totalPartitions; i++ {
-		tx := db.Begin()
-		if tx.Error != nil {
-			log.Fatal(tx.Error)
-		}
-
 		partitionName := "ops_" + strconv.Itoa(i)
-		if err := migrateOpsPartition(tx, partitionName, totalPartitions, i); err != nil {
-			tx.Rollback()
+		if err := migrateOpsPartition(db, partitionName, totalPartitions, i); err != nil {
 			slog.Error(fmt.Sprintf("Could not create partition %s", partitionName), "err", err)
-			return err
-		}
-
-		if err := tx.Commit().Error; err != nil {
 			return err
 		}
 	}

--- a/mediorum/crudr/crudr.go
+++ b/mediorum/crudr/crudr.go
@@ -45,21 +45,57 @@ type Crudr struct {
 	callbacks []func(op *Op, records interface{})
 }
 
+// create partitioned ops table if it does not exist
+func migrateOps(db *gorm.DB) error {
+	opDDL := `
+	CREATE TABLE IF NOT EXISTS ops (
+		"ulid" TEXT,
+		"host" TEXT,
+		"action" TEXT,
+		"table" TEXT,
+		"data" JSONB)
+		PARTITION BY HASH ("host");
+	
+	COMMIT;
+
+	CREATE OR REPLACE FUNCTION create_partitions(min_i INTEGER, max_i INTEGER, total INTEGER)
+	RETURNS VOID AS
+	$$
+	DECLARE
+			i INTEGER;
+			partition_name TEXT;
+	BEGIN
+			FOR i IN min_i..max_i LOOP
+					partition_name := 'ops_' || i;
+					EXECUTE 'CREATE TABLE IF NOT EXISTS ' || partition_name || ' PARTITION OF ops FOR VALUES WITH (MODULUS ' || total || ', REMAINDER ' || i || ');';
+					BEGIN
+							EXECUTE 'ALTER TABLE ' || partition_name || ' ADD PRIMARY KEY ("ulid");';
+							EXCEPTION WHEN invalid_table_definition THEN NULL;
+					END;
+			END LOOP;
+	END;
+	$$
+	LANGUAGE plpgsql;
+
+  -- migrate and commit partitions in chunks to avoid running out of memory
+	SELECT create_partitions(0, 200, 1009);
+	COMMIT;
+	SELECT create_partitions(201, 400, 1009);
+	COMMIT;
+	SELECT create_partitions(401, 600, 1009);
+	COMMIT;
+	SELECT create_partitions(601, 800, 1009);
+	COMMIT;
+	SELECT create_partitions(801, 1008, 1009);
+	COMMIT;
+	`
+	return db.Exec(opDDL).Error
+}
+
 func New(selfHost string, myPrivateKey *ecdsa.PrivateKey, peerHosts []string, db *gorm.DB) *Crudr {
 	selfHost = httputil.RemoveTrailingSlash(strings.ToLower(selfHost))
 
-	// TODO: change to partitioned schema after all nodes have migrated
-	opDDL := `
-	create table if not exists ops (
-		ulid text primary key,
-		host text not null,
-		action text not null,
-		"table" text not null,
-		data json
-	);
-	`
-	err := db.Exec(opDDL).Error
-
+	err := migrateOps(db)
 	if err != nil {
 		panic(err)
 	}

--- a/mediorum/crudr/setup_test_db.go
+++ b/mediorum/crudr/setup_test_db.go
@@ -1,9 +1,10 @@
 package crudr
 
 import (
+	"os"
+
 	"gorm.io/driver/postgres"
 	"gorm.io/gorm"
-	"os"
 )
 
 func SetupTestDB() *gorm.DB {

--- a/mediorum/ddl/ddl.go
+++ b/mediorum/ddl/ddl.go
@@ -8,9 +8,7 @@ import (
 	"fmt"
 	"io"
 	"log"
-	"math/rand"
 	"mediorum/cidutil"
-	"mediorum/crudr"
 	"os"
 	"strings"
 	"sync"
@@ -20,7 +18,6 @@ import (
 
 	"gocloud.dev/blob"
 	"golang.org/x/exp/slog"
-	"gorm.io/gorm"
 )
 
 //go:embed delist_statuses.sql
@@ -36,15 +33,8 @@ var mediorumMigrationTable = `
 	);
 `
 
-// TODO: Remove after every node runs the ops partition migration
-var partitionOpsScheduled = "partitionOpsScheduled"
-var partitionOpsCompleted = "partitionedOps"
-var partitionOpsLogFile = "partition_ops.txt"
-
-func Migrate(db *sql.DB, gormDB *gorm.DB, bucket *blob.Bucket, myHost string) {
+func Migrate(db *sql.DB, bucket *blob.Bucket, myHost string) {
 	mustExec(db, mediorumMigrationTable)
-
-	migratePartitionOps(db, gormDB) // TODO: Remove after every node runs this
 
 	runMigration(db, delistStatusesDDL)
 
@@ -54,8 +44,6 @@ func Migrate(db *sql.DB, gormDB *gorm.DB, bucket *blob.Bucket, myHost string) {
 	runMigration(db, dropBlobs)
 
 	runMigration(db, `create index if not exists uploads_ts_idx on uploads(created_at, transcoded_at)`)
-
-	schedulePartitionOpsMigration(db, myHost) // TODO: Remove after every node runs the partition ops migration
 }
 
 func runMigration(db *sql.DB, ddl string) {
@@ -83,189 +71,6 @@ func mustExec(db *sql.DB, ddl string, va ...interface{}) {
 func md5string(s string) string {
 	hash := md5.Sum([]byte(s))
 	return hex.EncodeToString(hash[:])
-}
-
-func schedulePartitionOpsMigration(db *sql.DB, myHost string) {
-	// stagger between 0.5-12hrs
-	min := 30
-	max := 60 * 12
-	randomTime := time.Minute * time.Duration(rand.Intn(max+1-min)+min)
-	// manually schedule foundation nodes so can disable monitoring
-	// appropriately
-	if myHost == "https://creatornode.audius.co" {
-		randomTime = time.Minute * time.Duration(20)
-	}
-	if myHost == "https://creatornode3.audius.co" || myHost == "https://usermetadata.audius.co" {
-		randomTime = time.Minute * time.Duration(110)
-	}
-	if myHost == "https://creatornode2.audius.co" {
-		randomTime = time.Minute * time.Duration(240)
-	}
-	slog.Info("checking if we need to schedule the partition ops migration...")
-	var partitioned bool
-	db.QueryRow(`select count(*) = 1 from mediorum_migrations where hash = $1`, partitionOpsCompleted).Scan(&partitioned)
-	if partitioned {
-		slog.Info("already partitioned ops, skipping migration scheduling")
-	} else {
-		slog.Info("scheduling partition ops migration", "time", randomTime.String())
-		time.AfterFunc(randomTime, func() {
-			slog.Info("marking migrations table to partition ops after we restart...")
-			mustExec(db, `insert into mediorum_migrations values ($1, now()) on conflict do nothing`, partitionOpsScheduled)
-			os.Exit(0)
-		})
-	}
-}
-
-func migratePartitionOpsError(err error) {
-	logAndWriteToFile(err.Error(), partitionOpsLogFile)
-	log.Fatal(err)
-}
-
-func migratePartitionOps(db *sql.DB, gormDB *gorm.DB) {
-	slog.Info("checking if it's time to partition ops...")
-	var scheduled bool
-	db.QueryRow(`select count(*) = 1 from mediorum_migrations where hash = $1;`, partitionOpsScheduled).Scan(&scheduled)
-	if !scheduled {
-		slog.Info("partition ops migration not scheduled, skipping ddl")
-		return
-	}
-
-	logAndWriteToFile("starting partitioning of ops", partitionOpsLogFile)
-	start := time.Now()
-
-	_, err := db.Exec(
-		`BEGIN;
-
-		-- Kill all long-running sql queries
-		SELECT pg_terminate_backend(pg_stat_activity.pid) FROM pg_stat_activity WHERE state = 'active' AND now() - query_start > interval '1 minute';
-
-		DO $$
-		BEGIN
-				IF NOT EXISTS (SELECT 1 FROM information_schema.tables WHERE table_name = 'old_ops') THEN
-						ALTER TABLE IF EXISTS ops RENAME TO old_ops;
-				END IF;
-		END $$;
-
-		-- Create the new ops parent table
-		CREATE TABLE IF NOT EXISTS ops (
-			"ulid" TEXT,
-			"host" TEXT,
-			"action" TEXT,
-			"table" TEXT,
-			"data" JSONB)
-			PARTITION BY HASH ("host");
-
-		DO $$
-		DECLARE
-			i INTEGER;
-			partition_name TEXT;
-		BEGIN
-			FOR i IN 0..1008 LOOP -- 1009 partitions
-				partition_name := 'ops_' || i;
-				EXECUTE 'CREATE TABLE IF NOT EXISTS ' || partition_name || ' PARTITION OF ops FOR VALUES WITH (MODULUS 1009, REMAINDER ' || i || ');';
-
-        BEGIN
-					EXECUTE 'ALTER TABLE ' || partition_name || ' ADD PRIMARY KEY ("ulid");';
-					EXCEPTION WHEN invalid_table_definition THEN NULL;
-				END;
-
-			END LOOP;
-		END $$;
-
-		COMMIT;`,
-	)
-	if err != nil {
-		migratePartitionOpsError(err)
-	}
-
-	err = migrateOpsData(db, gormDB)
-	if err != nil {
-		migratePartitionOpsError(err)
-	}
-
-	ctx := context.Background()
-	tx, err := db.BeginTx(ctx, nil)
-	if err != nil {
-		migratePartitionOpsError(err)
-	}
-	defer tx.Rollback()
-	_, err = tx.ExecContext(
-		ctx,
-		`DROP TABLE old_ops;`,
-	)
-	_, err = tx.ExecContext(
-		ctx,
-		`INSERT INTO mediorum_migrations VALUES ($1, now()) ON CONFLICT DO NOTHING;`,
-		partitionOpsCompleted,
-	)
-	if err != nil {
-		migratePartitionOpsError(err)
-	}
-	_, err = tx.ExecContext(
-		ctx,
-		`DELETE FROM mediorum_migrations WHERE hash = $1;`,
-		partitionOpsScheduled,
-	)
-	if err != nil {
-		migratePartitionOpsError(err)
-	}
-	if err = tx.Commit(); err != nil {
-		migratePartitionOpsError(err)
-	}
-
-	logAndWriteToFile(fmt.Sprintf("finished partitioning ops. took %gm", time.Since(start).Minutes()), partitionOpsLogFile)
-}
-
-// copy data from old_ops to ops
-func migrateOpsData(db *sql.DB, gormDB *gorm.DB) error {
-	logAndWriteToFile("starting ops data migration", partitionOpsLogFile)
-	lastULID := ""
-	pageSize := 3000
-	rowsMigrated := 0
-
-	for {
-		var ops []crudr.Op
-
-		// select a batch of rows starting from the lastULID
-		err := gormDB.Table("old_ops").Where("ulid > ?", lastULID).Order("ulid asc").Limit(pageSize).Find(&ops).Error
-		if err != nil {
-			return err
-		}
-
-		if len(ops) == 0 {
-			// we've migrated all rows
-			logAndWriteToFile(fmt.Sprintf("successfully migrated %d ops rows\n", rowsMigrated), partitionOpsLogFile)
-			return nil
-		}
-
-		_, err = db.Exec(`INSERT INTO ops ("ulid", "host", "action", "table", "data") VALUES ` + constructOpsBulkInsertValuesString(ops) + ` ON CONFLICT DO NOTHING`)
-		if err != nil {
-			return err
-		}
-		rowsMigrated += len(ops)
-		lastULID = ops[len(ops)-1].ULID
-
-		// delete all rows that we migrated
-		_, err = db.Exec(`DELETE FROM old_ops WHERE ulid <= $1;`, lastULID)
-		if err != nil {
-			return err
-		}
-
-		// keep paginating
-		time.Sleep(time.Millisecond * 100)
-	}
-}
-
-func constructOpsBulkInsertValuesString(ops []crudr.Op) string {
-	values := ""
-	for i, op := range ops {
-		formattedData := strings.ReplaceAll(string(op.Data), "'", "''")
-		values += "('" + op.ULID + "', '" + op.Host + "', '" + op.Action + "', '" + op.Table + "', '" + formattedData + "')"
-		if i < len(ops)-1 {
-			values += ", "
-		}
-	}
-	return values
 }
 
 func migrateShardBucket(db *sql.DB, bucket *blob.Bucket) {

--- a/mediorum/server/db.go
+++ b/mediorum/server/db.go
@@ -71,10 +71,9 @@ func dbMigrate(crud *crudr.Crudr, bucket *blob.Bucket, myHost string) {
 	crud.RegisterModels(&Upload{}, &StorageAndDbSize{})
 
 	sqlDb, _ := crud.DB.DB()
-	gormDB := crud.DB
 
 	slog.Info("db: ddl migrate")
-	ddl.Migrate(sqlDb, gormDB, bucket, myHost)
+	ddl.Migrate(sqlDb, bucket, myHost)
 
 	slog.Info("db: migrate done")
 

--- a/mediorum/server/test_main_test.go
+++ b/mediorum/server/test_main_test.go
@@ -25,7 +25,7 @@ func setupTestNetwork(replicationFactor, serverCount int) []*MediorumServer {
 
 	for i := 1; i <= serverCount; i++ {
 		network = append(network, Peer{
-			Host:	fmt.Sprintf("http://127.0.0.1:%d", 1980+i),
+			Host:   fmt.Sprintf("http://127.0.0.1:%d", 1980+i),
 			Wallet: fmt.Sprintf("0xWallet%d", i), // todo keypair stuff
 		})
 	}

--- a/mediorum/server/test_main_test.go
+++ b/mediorum/server/test_main_test.go
@@ -64,7 +64,7 @@ func setupTestNetwork(replicationFactor, serverCount int) []*MediorumServer {
 }
 
 func TestMain(m *testing.M) {
-	testNetwork = setupTestNetwork(5, 9)
+	testNetwork = setupTestNetwork(5, 5)
 
 	exitVal := m.Run()
 	// todo: tear down testNetwork


### PR DESCRIPTION
### Description
Originally reverted because was breaking CI tests. Updated sql slightly to commit every create table operation + fixed mediorum unit tests.

For the unit tests, I lowered the number of test mediorum replicas since the number of ops tables for 9 replicas was consuming a lot of memory. Also fixed the test container's `dbUrl` to point to its own database rather than using `m1` and interfering with the server test using `m1`.

### How Has This Been Tested?
ran mediorum-unittests and audius-compose up locally, reran ci a few times to make sure tests consistently pass