### PR TITLE
[INF-501] Disable mobile prod builds on main

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -502,6 +502,8 @@ workflows:
             packages/eslint-config-audius/.* run-mobile-workflow true
             packages/libs/.* run-web-workflow true
             packages/libs/.* run-mobile-workflow true
+            packages/harmony/.* run-web-workflow true
+            packages/harmony/.* run-mobile-workflow true
             packages/mobile/.* run-mobile-workflow true
             packages/web/.* run-web-workflow true
           requires:

--- a/.circleci/src/workflows/mobile.yml
+++ b/.circleci/src/workflows/mobile.yml
@@ -41,13 +41,13 @@ jobs:
         branches:
           only: /(^release.*)$/
 
-  - mobile-build-production-ios:
-      context: Audius Mobile Client
-      requires:
-        - mobile-init
-      filters:
-        branches:
-          only: /^main$/
+  # - mobile-build-production-ios:
+  #     context: Audius Mobile Client
+  #     requires:
+  #       - mobile-init
+  #     filters:
+  #       branches:
+  #         only: /^main$/
 
   - mobile-build-upload-production-ios-if-full-release:
       context: Audius Mobile Client
@@ -105,13 +105,13 @@ jobs:
         branches:
           only: /(^release.*)$/
 
-  - mobile-build-production-android:
-      context: Audius Mobile Client
-      requires:
-        - mobile-init
-      filters:
-        branches:
-          only: /^main$/
+  # - mobile-build-production-android:
+  #     context: Audius Mobile Client
+  #     requires:
+  #       - mobile-init
+  #     filters:
+  #       branches:
+  #         only: /^main$/
 
   - mobile-build-upload-production-android-if-full-release:
       context: Audius Mobile Client


### PR DESCRIPTION
### Description

We run `mobile-build-production-ios` and `mobile-build-production-android` on main and they are very expensive. 

![image](https://github.com/AudiusProject/audius-protocol/assets/19916043/420ebd37-bf59-45ea-9531-16d0386f0ac6)

* Disable prod builds on main. This in combination with #6142 should put us in a good spot cost-wise
  * Stage builds still run (less expensive)
  * Prod builds run on release branches
* Ensure web + mobile workflows run on main when harmony changes
 
### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._
