### PR TITLE
[PROTO-1239] Fix initting ClaimsManagerClient

### DIFF
--- a/packages/libs/src/services/ethContracts/ClaimsManagerClient.ts
+++ b/packages/libs/src/services/ethContracts/ClaimsManagerClient.ts
@@ -1,10 +1,7 @@
 import { Utils } from '../../utils'
 import { ContractClient } from '../contracts/ContractClient'
-import type { EthWeb3Manager } from '../ethWeb3Manager'
 
 export class ClaimsManagerClient extends ContractClient {
-  // @ts-expect-error defined in ContractClient
-  override web3Manager: EthWeb3Manager
   /* ------- GETTERS ------- */
 
   // Get the duration of a funding round in blocks


### PR DESCRIPTION
### Description
Fixes ClaimsManagerClient not having access to web3Manager, which prevents it from initializing. This is a blocker for updating the libs version in protocol dashboard.

### How Has This Been Tested?
`await audiusLibs.ethContracts.ClaimsManagerClient.getLastFundedBlock()` now returns the same number on `npm run web:prod` as on the current protocol dashboard (with outdated libs version). On audius.co, this function causes an error and is unable to return a block number.
