### PR TITLE
Add request time in json to server logs

### DIFF
--- a/discovery-provider/nginx_conf/log_json.lua
+++ b/discovery-provider/nginx_conf/log_json.lua
@@ -1,0 +1,22 @@
+local json = require("cjson.safe")
+
+local function log_json()
+    local log_data = {
+        remote_addr = ngx.var.remote_addr,
+        time_local = ngx.var.time_local,
+        request = ngx.var.request,
+        status = ngx.var.status,
+        body_bytes_sent = ngx.var.body_bytes_sent,
+        http_referer = ngx.var.http_referer,
+        http_user_agent = ngx.var.http_user_agent,
+        request_time = ngx.var.request_time
+    }
+    local serialized_data, err = json.encode(log_data)
+    if not err then
+        ngx.log(ngx.NOTICE, serialized_data)
+    else
+        ngx.log(ngx.ERR, "Failed to encode log data to JSON: ", err)
+    end
+end
+
+return log_json()

--- a/discovery-provider/nginx_conf/nginx.conf
+++ b/discovery-provider/nginx_conf/nginx.conf
@@ -38,6 +38,14 @@ http {
     lua_shared_dict nonce_store 10m;
     lua_shared_dict request_count 10m;
     lua_shared_dict rsa_public_key_store 10m;
+    log_format custom_format '{"remote_addr":"$remote_addr",'
+                            '"time_local":"$time_local",'
+                            '"request":"$request",'
+                            '"status":$status,'
+                            '"body_bytes_sent":$body_bytes_sent,'
+                            '"http_referer":"$http_referer",'
+                            '"http_user_agent":"$http_user_agent",'
+                            '"request_time":$request_time}';
 
     init_worker_by_lua_block {
         local main = require "main"
@@ -45,10 +53,10 @@ http {
     }
 
     server {
-        access_log off;
         listen 5000;
         gzip on;
         gzip_types text/plain application/xml application/json;
+        access_log /usr/local/openresty/logs/test-access.log custom_format;
 
         proxy_set_header Host $http_host;
         proxy_set_header X-Forwarded-For $remote_addr;

--- a/discovery-provider/scripts/prod-server.sh
+++ b/discovery-provider/scripts/prod-server.sh
@@ -27,20 +27,21 @@ audius_discprov_loglevel=${audius_discprov_loglevel:-info}
 if [[ "$audius_openresty_enable" == true ]]; then
   openresty -p /usr/local/openresty -c /usr/local/openresty/conf/nginx.conf
   tail -f /usr/local/openresty/logs/error.log | python3 scripts/openresty_log_convertor.py ERROR &
+  tail -f /usr/local/openresty/logs/access.log &
 
   # If a worker class is specified, use that. Otherwise, use sync workers.
   if [[ -z "${audius_gunicorn_worker_class}" ]]; then
-    exec gunicorn -b :3000 --access-logfile - --error-logfile - src.wsgi:app --log-level=$audius_discprov_loglevel --workers=$WORKERS --threads=$THREADS --timeout=600
+    exec gunicorn -b :3000 --error-logfile - src.wsgi:app --log-level=$audius_discprov_loglevel --workers=$WORKERS --threads=$THREADS --timeout=600
   else
     WORKER_CLASS="${audius_gunicorn_worker_class}"
-    exec gunicorn -b :3000 --access-logfile - --error-logfile - src.wsgi:app --log-level=$audius_discprov_loglevel --worker-class=$WORKER_CLASS --workers=$WORKERS --timeout=600
+    exec gunicorn -b :3000 --error-logfile - src.wsgi:app --log-level=$audius_discprov_loglevel --worker-class=$WORKER_CLASS --workers=$WORKERS --timeout=600
   fi
 else
   # If a worker class is specified, use that. Otherwise, use sync workers.
   if [[ -z "${audius_gunicorn_worker_class}" ]]; then
-    exec gunicorn -b :5000 --access-logfile - --error-logfile - src.wsgi:app --log-level=$audius_discprov_loglevel --workers=$WORKERS --threads=$THREADS --timeout=600
+    exec gunicorn -b :5000 --error-logfile - src.wsgi:app --log-level=$audius_discprov_loglevel --workers=$WORKERS --threads=$THREADS --timeout=600
   else
     WORKER_CLASS="${audius_gunicorn_worker_class}"
-    exec gunicorn -b :5000 --access-logfile - --error-logfile - src.wsgi:app --log-level=$audius_discprov_loglevel --worker-class=$WORKER_CLASS --workers=$WORKERS --timeout=600
+    exec gunicorn -b :5000 --error-logfile - src.wsgi:app --log-level=$audius_discprov_loglevel --worker-class=$WORKER_CLASS --workers=$WORKERS --timeout=600
   fi
 fi


### PR DESCRIPTION
### Description
This change structures nginx logs into json so we can query in axiom. It also adds request time. 

I removed gunicorn's access-log and added a tail for the the json formatted access-log to stdout. 

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._
Ran on sandbox and hit a few requests.

<img width="1250" alt="Screenshot 2023-10-04 at 1 51 31 PM" src="https://github.com/AudiusProject/audius-protocol/assets/6413636/22ff43d7-1c63-4271-ab6f-db518717c28e">
