### PR TITLE
Update harmony tsconfig to allow for css module classnames without errors

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -97773,6 +97773,7 @@
         "storybook-addon-smart-knobs": "6.0.2",
         "tsconfig-paths-webpack-plugin": "3.5.2",
         "typescript": "4.9.4",
+        "typescript-plugin-css-modules": "^3.4.0",
         "webpack": "4.46.0"
       }
     },
@@ -103054,7 +103055,7 @@
     },
     "packages/libs": {
       "name": "@audius/sdk",
-      "version": "3.0.11-beta.4",
+      "version": "3.0.11-beta.5",
       "license": "Apache-2.0",
       "dependencies": {
         "@audius/hedgehog": "2.1.0",

--- a/packages/harmony/package.json
+++ b/packages/harmony/package.json
@@ -63,6 +63,7 @@
     "storybook-addon-smart-knobs": "6.0.2",
     "tsconfig-paths-webpack-plugin": "3.5.2",
     "typescript": "4.9.4",
+    "typescript-plugin-css-modules": "^3.4.0",
     "webpack": "4.46.0"
   },
   "dependencies": {

--- a/packages/harmony/package.json
+++ b/packages/harmony/package.json
@@ -63,7 +63,7 @@
     "storybook-addon-smart-knobs": "6.0.2",
     "tsconfig-paths-webpack-plugin": "3.5.2",
     "typescript": "4.9.4",
-    "typescript-plugin-css-modules": "^3.4.0",
+    "typescript-plugin-css-modules": "3.4.0",
     "webpack": "4.46.0"
   },
   "dependencies": {

--- a/packages/harmony/src/components/input/SelectablePill/SelectablePill.tsx
+++ b/packages/harmony/src/components/input/SelectablePill/SelectablePill.tsx
@@ -27,8 +27,8 @@ export const SelectablePill = forwardRef<
         className={cn(
           styles.pill,
           {
-            [styles.large!]: size === 'large',
-            [styles.selected!]: isSelected
+            [styles.large]: size === 'large',
+            [styles.selected]: isSelected
           },
           className
         )}

--- a/packages/harmony/tsconfig.json
+++ b/packages/harmony/tsconfig.json
@@ -4,6 +4,7 @@
     "lib": ["ES2020", "dom"],
     "module": "esnext",
     "checkJs": false,
+    "plugins": [{ "name": "typescript-plugin-css-modules" }],
     "allowJs": false,
     "jsx": "react-jsx",
     "resolveJsonModule": true,
@@ -11,15 +12,16 @@
     "typeRoots": [
       "./types",
       "./node_modules/@types",
-      "../../node_modules/@types"
+      "../../../node_modules/@types"
     ],
     "exactOptionalPropertyTypes": false,
     "declaration": true,
     "baseUrl": "./src",
     "outDir": "build",
     "declarationDir": "./",
-    "noPropertyAccessFromIndexSignature": false
+    "noPropertyAccessFromIndexSignature": false,
+    "noUncheckedIndexedAccess": false
   },
-  "exclude": ["dist, build"],
-  "include": ["src/**/*"]
+  "include": ["src"],
+  "exclude": ["node_modules", "build", "dist", "rollup.config.js"],
 }


### PR DESCRIPTION
### Description
Set tsconfig setting to false to remove checks for indexing into objects to allow for css module classnames without issues. This may be slightly unsafe, but it how web and stems operate currently

### How Has This Been Tested?
Rollup built without error
