### PR TITLE
[PAY-1974] Fix explore premium tracks bugs

### DIFF
--- a/discovery-provider/integration_tests/tasks/test_index_trending_notification.py
+++ b/discovery-provider/integration_tests/tasks/test_index_trending_notification.py
@@ -4,7 +4,9 @@ from sqlalchemy import asc
 
 from integration_tests.utils import populate_mock_db
 from src.models.notifications.notification import Notification
-from src.queries.generate_unpopulated_trending import make_trending_cache_key
+from src.queries.generate_unpopulated_trending_tracks import (
+    make_trending_tracks_cache_key,
+)
 from src.tasks.index_trending import (
     get_top_trending_to_notify,
     index_trending_notifications,
@@ -34,7 +36,7 @@ def test_index_trending_notification(app):
         trending_strategy = trending_strategy_factory.get_strategy(TrendingType.TRACKS)
         # Test that if there are no prev notifications, all trending in top are generated
 
-        trending_key = make_trending_cache_key("week", None, trending_strategy.version)
+        trending_key = make_trending_tracks_cache_key("week", None, trending_strategy.version)
         trending_tracks = [
             {
                 "track_id": i,

--- a/discovery-provider/integration_tests/tasks/test_index_trending_notification.py
+++ b/discovery-provider/integration_tests/tasks/test_index_trending_notification.py
@@ -4,7 +4,7 @@ from sqlalchemy import asc
 
 from integration_tests.utils import populate_mock_db
 from src.models.notifications.notification import Notification
-from src.queries.get_trending_tracks import make_trending_cache_key
+from src.queries.generate_unpopulated_trending import make_trending_cache_key
 from src.tasks.index_trending import (
     get_top_trending_to_notify,
     index_trending_notifications,

--- a/discovery-provider/integration_tests/tasks/test_trending_playlist_notifications.py
+++ b/discovery-provider/integration_tests/tasks/test_trending_playlist_notifications.py
@@ -5,7 +5,7 @@ from sqlalchemy import asc
 from integration_tests.utils import populate_mock_db
 from src.models.notifications.notification import Notification
 from src.models.playlists.playlist import Playlist
-from src.queries.get_trending_playlists import make_trending_cache_key
+from src.queries.get_trending_playlists import make_trending_playlists_cache_key
 from src.tasks.cache_trending_playlists import index_trending_playlist_notifications
 from src.trending_strategies.trending_strategy_factory import TrendingStrategyFactory
 from src.trending_strategies.trending_type_and_version import TrendingType
@@ -25,7 +25,7 @@ def cache_trending_playlists_mock(db, playlist_ids: list[int]) -> None:
     redis = get_redis()
     trending_strategy_factory = TrendingStrategyFactory()
     trending_strategy = trending_strategy_factory.get_strategy(TrendingType.PLAYLISTS)
-    trending_key = make_trending_cache_key("week", trending_strategy.version)
+    trending_key = make_trending_playlists_cache_key("week", trending_strategy.version)
 
     with db.scoped_session() as session:
         trending_playlists = (

--- a/discovery-provider/src/api/v1/tracks.py
+++ b/discovery-provider/src/api/v1/tracks.py
@@ -37,6 +37,10 @@ from src.api.v1.helpers import (
     trending_parser_paginated,
 )
 from src.api.v1.models.users import user_model_full
+from src.queries.generate_unpopulated_trending_tracks import (
+    TRENDING_TRACKS_LIMIT,
+    TRENDING_TRACKS_TTL_SEC,
+)
 from src.queries.get_feed import get_feed
 from src.queries.get_latest_entities import get_latest_entities
 from src.queries.get_premium_track_signatures import (
@@ -64,7 +68,6 @@ from src.queries.get_tracks import RouteArgs, get_tracks
 from src.queries.get_tracks_including_unlisted import get_tracks_including_unlisted
 from src.queries.get_trending import get_trending
 from src.queries.get_trending_ids import get_trending_ids
-from src.queries.get_trending_tracks import TRENDING_LIMIT, TRENDING_TTL_SEC
 from src.queries.get_unclaimed_id import get_unclaimed_id
 from src.queries.get_underground_trending import get_underground_trending
 from src.queries.search_queries import SearchKind, search
@@ -619,7 +622,7 @@ class Trending(Resource):
     @record_metrics
     @ns.expect(trending_parser)
     @ns.marshal_with(tracks_response)
-    @cache(ttl_sec=TRENDING_TTL_SEC)
+    @cache(ttl_sec=TRENDING_TRACKS_TTL_SEC)
     def get(self, version):
         trending_track_versions = trending_strategy_factory.get_versions_for_type(
             TrendingType.TRACKS
@@ -788,7 +791,7 @@ class RecommendedTrack(Resource):
     @record_metrics
     @ns.expect(recommended_track_parser)
     @ns.marshal_with(tracks_response)
-    @cache(ttl_sec=TRENDING_TTL_SEC)
+    @cache(ttl_sec=TRENDING_TRACKS_TTL_SEC)
     def get(self, version):
         trending_track_versions = trending_strategy_factory.get_versions_for_type(
             TrendingType.TRACKS
@@ -801,7 +804,7 @@ class RecommendedTrack(Resource):
 
         args = recommended_track_parser.parse_args()
         limit = format_limit(args, default_limit=DEFAULT_RECOMMENDED_LIMIT)
-        args["limit"] = max(TRENDING_LIMIT, limit)
+        args["limit"] = max(TRENDING_TRACKS_LIMIT, limit)
         args["exclude_premium"] = True
         strategy = trending_strategy_factory.get_strategy(
             TrendingType.TRACKS, version_list[0]
@@ -853,7 +856,7 @@ class FullRecommendedTracks(Resource):
 
         args = full_recommended_track_parser.parse_args()
         limit = format_limit(args, default_limit=DEFAULT_RECOMMENDED_LIMIT)
-        args["limit"] = max(TRENDING_LIMIT, limit)
+        args["limit"] = max(TRENDING_TRACKS_LIMIT, limit)
         strategy = trending_strategy_factory.get_strategy(
             TrendingType.TRACKS, version_list[0]
         )

--- a/discovery-provider/src/api/v1/tracks.py
+++ b/discovery-provider/src/api/v1/tracks.py
@@ -46,7 +46,7 @@ from src.queries.get_latest_entities import get_latest_entities
 from src.queries.get_premium_track_signatures import (
     get_nft_gated_premium_track_signatures,
 )
-from src.queries.get_premium_tracks import get_full_usdc_purchase_tracks
+from src.queries.get_premium_tracks import get_usdc_purchase_tracks
 from src.queries.get_random_tracks import get_random_tracks
 from src.queries.get_recommended_tracks import (
     DEFAULT_RECOMMENDED_LIMIT,
@@ -1381,8 +1381,8 @@ class FullUSDCPurchaseTracks(Resource):
         strategy = trending_strategy_factory.get_strategy(
             TrendingType.TRACKS, version_list[0]
         )
-        full_premium_tracks = get_full_usdc_purchase_tracks(request, args, strategy)
-        return success_response(full_premium_tracks)
+        premium_tracks = get_usdc_purchase_tracks(args, strategy)
+        return success_response(premium_tracks)
 
 
 @full_ns.route("/<string:user_id>/nft-gated-signatures")

--- a/discovery-provider/src/api/v1/tracks.py
+++ b/discovery-provider/src/api/v1/tracks.py
@@ -42,10 +42,7 @@ from src.queries.get_latest_entities import get_latest_entities
 from src.queries.get_premium_track_signatures import (
     get_nft_gated_premium_track_signatures,
 )
-from src.queries.get_premium_tracks import (
-    DEFAULT_PREMIUM_TRACKS_LIMIT,
-    get_full_usdc_purchase_tracks,
-)
+from src.queries.get_premium_tracks import get_full_usdc_purchase_tracks
 from src.queries.get_random_tracks import get_random_tracks
 from src.queries.get_recommended_tracks import (
     DEFAULT_RECOMMENDED_LIMIT,
@@ -1378,13 +1375,11 @@ class FullUSDCPurchaseTracks(Resource):
             abort_bad_path_param("version", full_ns)
 
         args = full_usdc_purchase_tracks_parser.parse_args()
-        limit = format_limit(args, default_limit=DEFAULT_PREMIUM_TRACKS_LIMIT)
-        args["limit"] = max(TRENDING_LIMIT, limit)
         strategy = trending_strategy_factory.get_strategy(
             TrendingType.TRACKS, version_list[0]
         )
         full_premium_tracks = get_full_usdc_purchase_tracks(request, args, strategy)
-        return success_response(full_premium_tracks[:limit])
+        return success_response(full_premium_tracks)
 
 
 @full_ns.route("/<string:user_id>/nft-gated-signatures")

--- a/discovery-provider/src/queries/generate_unpopulated_trending.py
+++ b/discovery-provider/src/queries/generate_unpopulated_trending.py
@@ -1,0 +1,300 @@
+import logging
+from typing import Optional
+
+from sqlalchemy import desc, text
+from sqlalchemy.orm.session import Session
+from sqlalchemy.sql.elements import not_, or_
+
+from src.models.tracks.track import Track
+from src.models.tracks.track_trending_score import TrackTrendingScore
+from src.premium_content.premium_content_constants import (
+    SHOULD_TRENDING_EXCLUDE_COLLECTIBLE_GATED_TRACKS,
+    SHOULD_TRENDING_EXCLUDE_PREMIUM_TRACKS,
+)
+from src.queries.get_trending_tracks import TRENDING_LIMIT
+from src.queries.get_unpopulated_tracks import get_unpopulated_tracks
+from src.tasks.generate_trending import generate_trending
+from src.trending_strategies.base_trending_strategy import BaseTrendingStrategy
+from src.trending_strategies.trending_strategy_factory import DEFAULT_TRENDING_VERSIONS
+from src.trending_strategies.trending_type_and_version import (
+    TrendingType,
+    TrendingVersion,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def make_trending_cache_key(
+    time_range, genre, version=DEFAULT_TRENDING_VERSIONS[TrendingType.TRACKS]
+):
+    """Makes a cache key resembling `generated-trending:week:electronic`"""
+    version_name = (
+        f":{version.name}"
+        if version != DEFAULT_TRENDING_VERSIONS[TrendingType.TRACKS]
+        else ""
+    )
+    return f"generated-trending{version_name}:{time_range}:{(genre.lower() if genre else '')}"
+
+
+def generate_unpopulated_trending(
+    session,
+    genre,
+    time_range,
+    strategy,
+    exclude_premium=SHOULD_TRENDING_EXCLUDE_PREMIUM_TRACKS,
+    exclude_collectible_gated=SHOULD_TRENDING_EXCLUDE_COLLECTIBLE_GATED_TRACKS,
+    usdc_purchase_only=False,
+    limit=TRENDING_LIMIT,
+):
+    # We use limit * 2 here to apply a soft limit so that
+    # when we later filter out premium or collectible gated tracks,
+    # we will probabilistically satisfy the given limit.
+    trending_tracks = generate_trending(
+        session, time_range, genre, limit * 2, 0, strategy.version
+    )
+
+    track_scores = [
+        strategy.get_track_score(time_range, track)
+        for track in trending_tracks["listen_counts"]
+    ]
+
+    # If usdc_purchase_only is true, then filter out track ids belonging to
+    # non-USDC purchase tracks before applying the limit.
+    if usdc_purchase_only:
+        ids = [track["track_id"] for track in track_scores]
+        usdc_purchase_track_ids = (
+            session.query(Track.track_id)
+            .filter(
+                Track.track_id.in_(ids),
+                Track.is_current == True,
+                Track.is_delete == False,
+                Track.stem_of == None,
+                Track.is_premium == True,
+                text("CAST(premium_conditions AS TEXT) LIKE '%usdc_purchase%'"),
+            )
+            .all()
+        )
+        usdc_purchase_track_id_set = set(map(lambda t: t[0], usdc_purchase_track_ids))
+        track_scores = list(
+            filter(lambda t: t["track_id"] in usdc_purchase_track_id_set, track_scores)
+        )
+    # If exclude_premium is true, then filter out track ids
+    # belonging to premium tracks before applying the limit.
+    elif exclude_premium:
+        ids = [track["track_id"] for track in track_scores]
+        non_premium_track_ids = (
+            session.query(Track.track_id)
+            .filter(
+                Track.track_id.in_(ids),
+                Track.is_current == True,
+                Track.is_delete == False,
+                Track.stem_of == None,
+                Track.is_premium == False,
+            )
+            .all()
+        )
+        non_premium_track_id_set = set(map(lambda t: t[0], non_premium_track_ids))
+        track_scores = list(
+            filter(lambda t: t["track_id"] in non_premium_track_id_set, track_scores)
+        )
+    elif exclude_collectible_gated:
+        ids = [track["track_id"] for track in track_scores]
+        non_collectible_gated_track_ids = (
+            session.query(Track.track_id)
+            .filter(
+                Track.track_id.in_(ids),
+                Track.is_current == True,
+                Track.is_delete == False,
+                Track.stem_of == None,
+                or_(
+                    Track.is_premium == False,
+                    not_(
+                        text("CAST(premium_conditions AS TEXT) LIKE '%nft_collection%'")
+                    ),
+                ),
+            )
+            .all()
+        )
+        non_collectible_gated_track_id_set = set(
+            map(lambda t: t[0], non_collectible_gated_track_ids)
+        )
+        track_scores = list(
+            filter(
+                lambda t: t["track_id"] in non_collectible_gated_track_id_set,
+                track_scores,
+            )
+        )
+
+    sorted_track_scores = sorted(
+        track_scores, key=lambda k: (k["score"], k["track_id"]), reverse=True
+    )
+    sorted_track_scores = sorted_track_scores[:limit]
+
+    # Get unpopulated metadata
+    track_ids = [track["track_id"] for track in sorted_track_scores]
+    tracks = get_unpopulated_tracks(session, track_ids, exclude_premium=exclude_premium)
+
+    return (tracks, track_ids)
+
+
+def generate_unpopulated_trending_from_mat_views(
+    session,
+    genre,
+    time_range,
+    strategy,
+    exclude_premium=SHOULD_TRENDING_EXCLUDE_PREMIUM_TRACKS,
+    exclude_collectible_gated=SHOULD_TRENDING_EXCLUDE_COLLECTIBLE_GATED_TRACKS,
+    usdc_purchase_only=False,
+    limit=TRENDING_LIMIT,
+):
+    # use all time instead of year for version EJ57D
+    if strategy.version == TrendingVersion.EJ57D and time_range == "year":
+        time_range = "allTime"
+    elif strategy.version != TrendingVersion.EJ57D and time_range == "allTime":
+        time_range = "year"
+
+    trending_track_ids_query = session.query(
+        TrackTrendingScore.track_id, TrackTrendingScore.score
+    ).filter(
+        TrackTrendingScore.type == strategy.trending_type.name,
+        TrackTrendingScore.version == strategy.version.name,
+        TrackTrendingScore.time_range == time_range,
+    )
+
+    if genre:
+        trending_track_ids_query = trending_track_ids_query.filter(
+            TrackTrendingScore.genre == genre
+        )
+
+    # If usdc_purchase_only is true, then filter out track ids belonging to
+    # non-USDC purchase tracks before applying the limit.
+    if usdc_purchase_only:
+        trending_track_ids_subquery = trending_track_ids_query.subquery()
+        trending_track_ids = (
+            session.query(
+                trending_track_ids_subquery.c.track_id,
+                trending_track_ids_subquery.c.score,
+                Track.track_id,
+            )
+            .join(
+                trending_track_ids_subquery,
+                Track.track_id == trending_track_ids_subquery.c.track_id,
+            )
+            .filter(
+                Track.is_current == True,
+                Track.is_delete == False,
+                Track.stem_of == None,
+                Track.is_premium == True,
+                text("CAST(premium_conditions AS TEXT) LIKE '%usdc_purchase%'"),
+            )
+            .order_by(
+                desc(trending_track_ids_subquery.c.score),
+                desc(trending_track_ids_subquery.c.track_id),
+            )
+            .limit(limit)
+            .all()
+        )
+    # If exclude_premium is true, then filter out track ids belonging to
+    # premium tracks before applying the limit.
+    elif exclude_premium:
+        trending_track_ids_subquery = trending_track_ids_query.subquery()
+        trending_track_ids = (
+            session.query(
+                trending_track_ids_subquery.c.track_id,
+                trending_track_ids_subquery.c.score,
+                Track.track_id,
+            )
+            .join(
+                trending_track_ids_subquery,
+                Track.track_id == trending_track_ids_subquery.c.track_id,
+            )
+            .filter(
+                Track.is_current == True,
+                Track.is_delete == False,
+                Track.stem_of == None,
+                Track.is_premium == False,
+            )
+            .order_by(
+                desc(trending_track_ids_subquery.c.score),
+                desc(trending_track_ids_subquery.c.track_id),
+            )
+            .limit(limit)
+            .all()
+        )
+    elif exclude_collectible_gated:
+        trending_track_ids_subquery = trending_track_ids_query.subquery()
+        trending_track_ids = (
+            session.query(
+                trending_track_ids_subquery.c.track_id,
+                trending_track_ids_subquery.c.score,
+                Track.track_id,
+            )
+            .join(
+                trending_track_ids_subquery,
+                Track.track_id == trending_track_ids_subquery.c.track_id,
+            )
+            .filter(
+                Track.is_current == True,
+                Track.is_delete == False,
+                Track.stem_of == None,
+                or_(
+                    Track.is_premium == False,
+                    not_(
+                        text("CAST(premium_conditions AS TEXT) LIKE '%nft_collection%'")
+                    ),
+                ),
+            )
+            .order_by(
+                desc(trending_track_ids_subquery.c.score),
+                desc(trending_track_ids_subquery.c.track_id),
+            )
+            .limit(limit)
+            .all()
+        )
+    else:
+        trending_track_ids = (
+            trending_track_ids_query.order_by(
+                desc(TrackTrendingScore.score), desc(TrackTrendingScore.track_id)
+            )
+            .limit(limit)
+            .all()
+        )
+
+    # Get unpopulated metadata
+    track_ids = [track_id[0] for track_id in trending_track_ids]
+    tracks = get_unpopulated_tracks(session, track_ids, exclude_premium=exclude_premium)
+
+    return (tracks, track_ids)
+
+
+def make_generate_unpopulated_trending(
+    session: Session,
+    genre: Optional[str],
+    time_range: str,
+    strategy: BaseTrendingStrategy,
+    exclude_premium: bool,
+    usdc_purchase_only=False,
+):
+    """Wraps a call for use in `use_redis_cache`, which
+    expects to be passed a function with no arguments."""
+
+    def wrapped():
+        if strategy.use_mat_view:
+            return generate_unpopulated_trending_from_mat_views(
+                session=session,
+                genre=genre,
+                time_range=time_range,
+                strategy=strategy,
+                exclude_premium=exclude_premium,
+                usdc_purchase_only=usdc_purchase_only,
+            )
+        return generate_unpopulated_trending(
+            session=session,
+            genre=genre,
+            time_range=time_range,
+            strategy=strategy,
+            exclude_premium=exclude_premium,
+            usdc_purchase_only=usdc_purchase_only,
+        )
+
+    return wrapped

--- a/discovery-provider/src/queries/generate_unpopulated_trending_tracks.py
+++ b/discovery-provider/src/queries/generate_unpopulated_trending_tracks.py
@@ -24,7 +24,7 @@ from src.trending_strategies.trending_type_and_version import (
 logger = logging.getLogger(__name__)
 
 
-def make_trending_cache_key(
+def make_trending_tracks_cache_key(
     time_range, genre, version=DEFAULT_TRENDING_VERSIONS[TrendingType.TRACKS]
 ):
     """Makes a cache key resembling `generated-trending:week:electronic`"""

--- a/discovery-provider/src/queries/generate_unpopulated_trending_tracks.py
+++ b/discovery-provider/src/queries/generate_unpopulated_trending_tracks.py
@@ -11,7 +11,6 @@ from src.premium_content.premium_content_constants import (
     SHOULD_TRENDING_EXCLUDE_COLLECTIBLE_GATED_TRACKS,
     SHOULD_TRENDING_EXCLUDE_PREMIUM_TRACKS,
 )
-from src.queries.get_trending_tracks import TRENDING_LIMIT
 from src.queries.get_unpopulated_tracks import get_unpopulated_tracks
 from src.tasks.generate_trending import generate_trending
 from src.trending_strategies.base_trending_strategy import BaseTrendingStrategy
@@ -22,6 +21,9 @@ from src.trending_strategies.trending_type_and_version import (
 )
 
 logger = logging.getLogger(__name__)
+
+TRENDING_TRACKS_LIMIT = 100
+TRENDING_TRACKS_TTL_SEC = 30 * 60
 
 
 def make_trending_tracks_cache_key(
@@ -44,7 +46,7 @@ def generate_unpopulated_trending(
     exclude_premium=SHOULD_TRENDING_EXCLUDE_PREMIUM_TRACKS,
     exclude_collectible_gated=SHOULD_TRENDING_EXCLUDE_COLLECTIBLE_GATED_TRACKS,
     usdc_purchase_only=False,
-    limit=TRENDING_LIMIT,
+    limit=TRENDING_TRACKS_LIMIT,
 ):
     # We use limit * 2 here to apply a soft limit so that
     # when we later filter out premium or collectible gated tracks,
@@ -145,7 +147,7 @@ def generate_unpopulated_trending_from_mat_views(
     exclude_premium=SHOULD_TRENDING_EXCLUDE_PREMIUM_TRACKS,
     exclude_collectible_gated=SHOULD_TRENDING_EXCLUDE_COLLECTIBLE_GATED_TRACKS,
     usdc_purchase_only=False,
-    limit=TRENDING_LIMIT,
+    limit=TRENDING_TRACKS_LIMIT,
 ):
     # use all time instead of year for version EJ57D
     if strategy.version == TrendingVersion.EJ57D and time_range == "year":

--- a/discovery-provider/src/queries/get_premium_tracks.py
+++ b/discovery-provider/src/queries/get_premium_tracks.py
@@ -1,7 +1,13 @@
 import logging  # pylint: disable=C0302
 
 from src.api.v1.helpers import extend_track, format_limit, format_offset, to_dict
-from src.queries.get_trending_tracks import TRENDING_TTL_SEC, get_trending_tracks
+from src.queries.generate_unpopulated_trending import (
+    make_generate_unpopulated_trending,
+    make_trending_cache_key,
+)
+from src.queries.get_trending_tracks import TRENDING_TTL_SEC
+from src.queries.query_helpers import add_users_to_tracks, populate_track_metadata
+from src.utils.db_session import get_db_read_replica
 from src.utils.helpers import decode_string_id
 from src.utils.redis_cache import get_trending_cache_key, use_redis_cache
 
@@ -10,34 +16,63 @@ logger = logging.getLogger(__name__)
 DEFAULT_PREMIUM_TRACKS_LIMIT = 100
 
 
-def get_usdc_purchase_tracks(args, strategy):
+def _get_usdc_purchase_tracks(args, strategy):
     """Gets USDC purchase tracks from trending by getting the currently cached tracks and then populating them."""
+
+    # Decode user_id if necessary
     current_user_id = args.get("user_id")
-    args = {
-        "time": args.get("time", "week"),
-        "genre": args.get("genre", None),
-        "limit": format_limit(args, DEFAULT_PREMIUM_TRACKS_LIMIT),
-        "offset": format_offset(args),
-        "exclude_premium": False,
-        "usdc_purchase_only": True,
-        "with_users": True,
-    }
+    current_user_id = decode_string_id(current_user_id) if current_user_id else None
+    limit = format_limit(args, DEFAULT_PREMIUM_TRACKS_LIMIT),
+    offset = format_offset(args),
+    time_range = args.get("time", "week"),
+    genre = args.get("genre", None),
 
-    # decode and add user_id if necessary
-    if current_user_id:
-        args["current_user_id"] = decode_string_id(current_user_id)
+    db = get_db_read_replica()
+    with db.scoped_session() as session:
+        key = make_trending_cache_key(time_range, genre, strategy.version)
+        key += ":usdc_purchase_only"
 
-    tracks = get_trending_tracks(args, strategy)
-    return list(map(extend_track, tracks))
+        # The index_trending task runs every 10 seconds, so we set the TTL to 10 seconds
+        ttl_sec = 10
+
+        # Will try to hit cached trending from task, falling back
+        # to generating it here if necessary and storing it with no TTL
+        (tracks, track_ids) = use_redis_cache(
+            key,
+            ttl_sec,
+            make_generate_unpopulated_trending(
+                session=session,
+                genre=genre,
+                time_range=time_range,
+                strategy=strategy,
+                exclude_premium=False,
+                usdc_purchase_only=True,
+            ),
+        )
+
+        # apply limit and offset
+        tracks = tracks[offset : limit + offset]
+        track_ids = track_ids[offset : limit + offset]
+
+        # populate track metadata
+        tracks = populate_track_metadata(session, track_ids, tracks, current_user_id)
+        tracks_map = {track["track_id"]: track for track in tracks}
+
+        # Re-sort the populated tracks b/c it loses sort order in sql query
+        sorted_tracks = [tracks_map[track_id] for track_id in track_ids]
+
+        add_users_to_tracks(session, tracks, current_user_id)
+
+        return list(map(extend_track, sorted_tracks))
 
 
 def get_full_usdc_purchase_tracks(request, args, strategy):
     # Attempt to use the cached tracks list
     if args["user_id"] is not None:
-        full_usdc_purchase_tracks = get_usdc_purchase_tracks(args, strategy)
+        full_usdc_purchase_tracks = _get_usdc_purchase_tracks(args, strategy)
     else:
         key = get_trending_cache_key(to_dict(request.args), request.path)
         full_usdc_purchase_tracks = use_redis_cache(
-            key, TRENDING_TTL_SEC, lambda: get_usdc_purchase_tracks(args, strategy)
+            key, TRENDING_TTL_SEC, lambda: _get_usdc_purchase_tracks(args, strategy)
         )
     return full_usdc_purchase_tracks

--- a/discovery-provider/src/queries/get_premium_tracks.py
+++ b/discovery-provider/src/queries/get_premium_tracks.py
@@ -1,9 +1,9 @@
 import logging  # pylint: disable=C0302
 
 from src.api.v1.helpers import extend_track, format_limit, format_offset, to_dict
-from src.queries.generate_unpopulated_trending import (
+from src.queries.generate_unpopulated_trending_tracks import (
     make_generate_unpopulated_trending,
-    make_trending_cache_key,
+    make_trending_tracks_cache_key,
 )
 from src.queries.get_trending_tracks import TRENDING_TTL_SEC
 from src.queries.query_helpers import add_users_to_tracks, populate_track_metadata
@@ -29,7 +29,7 @@ def _get_usdc_purchase_tracks(args, strategy):
 
     db = get_db_read_replica()
     with db.scoped_session() as session:
-        key = make_trending_cache_key(time_range, genre, strategy.version)
+        key = make_trending_tracks_cache_key(time_range, genre, strategy.version)
         key += ":usdc_purchase_only"
 
         # The index_trending task runs every 10 seconds, so we set the TTL to 10 seconds

--- a/discovery-provider/src/queries/get_premium_tracks.py
+++ b/discovery-provider/src/queries/get_premium_tracks.py
@@ -1,22 +1,21 @@
 import logging  # pylint: disable=C0302
 
-from src.api.v1.helpers import extend_track, format_limit, format_offset, to_dict
+from src.api.v1.helpers import extend_track, format_limit, format_offset
 from src.queries.generate_unpopulated_trending_tracks import (
-    TRENDING_TRACKS_TTL_SEC,
     make_generate_unpopulated_trending,
     make_trending_tracks_cache_key,
 )
 from src.queries.query_helpers import add_users_to_tracks, populate_track_metadata
 from src.utils.db_session import get_db_read_replica
 from src.utils.helpers import decode_string_id
-from src.utils.redis_cache import get_trending_cache_key, use_redis_cache
+from src.utils.redis_cache import use_redis_cache
 
 logger = logging.getLogger(__name__)
 
 DEFAULT_PREMIUM_TRACKS_LIMIT = 100
 
 
-def _get_usdc_purchase_tracks(args, strategy):
+def get_usdc_purchase_tracks(args, strategy):
     """Gets USDC purchase tracks from trending by getting the currently cached tracks and then populating them."""
 
     # Decode user_id if necessary
@@ -65,15 +64,3 @@ def _get_usdc_purchase_tracks(args, strategy):
         add_users_to_tracks(session, tracks, current_user_id)
 
         return list(map(extend_track, sorted_tracks))
-
-
-def get_full_usdc_purchase_tracks(request, args, strategy):
-    # Attempt to use the cached tracks list
-    if args["user_id"] is not None:
-        full_usdc_purchase_tracks = _get_usdc_purchase_tracks(args, strategy)
-    else:
-        key = get_trending_cache_key(to_dict(request.args), request.path)
-        full_usdc_purchase_tracks = use_redis_cache(
-            key, TRENDING_TRACKS_TTL_SEC, lambda: _get_usdc_purchase_tracks(args, strategy)
-        )
-    return full_usdc_purchase_tracks

--- a/discovery-provider/src/queries/get_premium_tracks.py
+++ b/discovery-provider/src/queries/get_premium_tracks.py
@@ -22,10 +22,11 @@ def _get_usdc_purchase_tracks(args, strategy):
     # Decode user_id if necessary
     current_user_id = args.get("user_id")
     current_user_id = decode_string_id(current_user_id) if current_user_id else None
-    limit = format_limit(args, DEFAULT_PREMIUM_TRACKS_LIMIT),
-    offset = format_offset(args),
-    time_range = args.get("time", "week"),
-    genre = args.get("genre", None),
+    limit = format_limit(args, DEFAULT_PREMIUM_TRACKS_LIMIT)
+    offset = format_offset(args)
+    time = args.get("time", "week")
+    time_range = "week" if time not in ["week", "month", "year", "allTime"] else time
+    genre = args.get("genre", None)
 
     db = get_db_read_replica()
     with db.scoped_session() as session:

--- a/discovery-provider/src/queries/get_premium_tracks.py
+++ b/discovery-provider/src/queries/get_premium_tracks.py
@@ -1,13 +1,13 @@
 import logging  # pylint: disable=C0302
 
-from src.api.v1.helpers import extend_track, to_dict
+from src.api.v1.helpers import extend_track, format_limit, format_offset, to_dict
 from src.queries.get_trending_tracks import TRENDING_TTL_SEC, get_trending_tracks
 from src.utils.helpers import decode_string_id
 from src.utils.redis_cache import get_trending_cache_key, use_redis_cache
 
 logger = logging.getLogger(__name__)
 
-DEFAULT_PREMIUM_TRACKS_LIMIT = 50
+DEFAULT_PREMIUM_TRACKS_LIMIT = 100
 
 
 def get_usdc_purchase_tracks(args, strategy):
@@ -16,8 +16,8 @@ def get_usdc_purchase_tracks(args, strategy):
     args = {
         "time": args.get("time", "week"),
         "genre": args.get("genre", None),
-        "limit": args.get("limit"),
-        "offset": 0,
+        "limit": format_limit(args, DEFAULT_PREMIUM_TRACKS_LIMIT),
+        "offset": format_offset(args),
         "exclude_premium": False,
         "usdc_purchase_only": True,
         "with_users": True,

--- a/discovery-provider/src/queries/get_premium_tracks.py
+++ b/discovery-provider/src/queries/get_premium_tracks.py
@@ -2,10 +2,10 @@ import logging  # pylint: disable=C0302
 
 from src.api.v1.helpers import extend_track, format_limit, format_offset, to_dict
 from src.queries.generate_unpopulated_trending_tracks import (
+    TRENDING_TRACKS_TTL_SEC,
     make_generate_unpopulated_trending,
     make_trending_tracks_cache_key,
 )
-from src.queries.get_trending_tracks import TRENDING_TTL_SEC
 from src.queries.query_helpers import add_users_to_tracks, populate_track_metadata
 from src.utils.db_session import get_db_read_replica
 from src.utils.helpers import decode_string_id
@@ -73,6 +73,6 @@ def get_full_usdc_purchase_tracks(request, args, strategy):
     else:
         key = get_trending_cache_key(to_dict(request.args), request.path)
         full_usdc_purchase_tracks = use_redis_cache(
-            key, TRENDING_TTL_SEC, lambda: _get_usdc_purchase_tracks(args, strategy)
+            key, TRENDING_TRACKS_TTL_SEC, lambda: _get_usdc_purchase_tracks(args, strategy)
         )
     return full_usdc_purchase_tracks

--- a/discovery-provider/src/queries/get_recommended_tracks.py
+++ b/discovery-provider/src/queries/get_recommended_tracks.py
@@ -2,7 +2,8 @@ import logging  # pylint: disable=C0302
 import random
 
 from src.api.v1.helpers import extend_track, to_dict
-from src.queries.get_trending_tracks import TRENDING_TTL_SEC, get_trending_tracks
+from src.queries.generate_unpopulated_trending_tracks import TRENDING_TRACKS_TTL_SEC
+from src.queries.get_trending_tracks import get_trending_tracks
 from src.utils.helpers import decode_string_id
 from src.utils.redis_cache import get_trending_cache_key, use_redis_cache
 
@@ -45,6 +46,6 @@ def get_full_recommended_tracks(request, args, strategy):
     else:
         key = get_trending_cache_key(to_dict(request.args), request.path)
         full_recommended = use_redis_cache(
-            key, TRENDING_TTL_SEC, lambda: get_recommended_tracks(args, strategy)
+            key, TRENDING_TRACKS_TTL_SEC, lambda: get_recommended_tracks(args, strategy)
         )
     return full_recommended

--- a/discovery-provider/src/queries/get_recommended_tracks.py
+++ b/discovery-provider/src/queries/get_recommended_tracks.py
@@ -23,7 +23,6 @@ def get_recommended_tracks(args, strategy):
         "limit": args.get("limit"),
         "offset": 0,
         "exclude_premium": True,
-        "usdc_purchase_only": False,
     }
 
     # decode and add user_id if necessary

--- a/discovery-provider/src/queries/get_trending.py
+++ b/discovery-provider/src/queries/get_trending.py
@@ -27,7 +27,6 @@ def get_trending(args, strategy):
         "exclude_premium": args.get(
             "exclude_premium", SHOULD_TRENDING_EXCLUDE_PREMIUM_TRACKS
         ),
-        "usdc_purchase_only": False,
     }
 
     # decode and add user_id if necessary

--- a/discovery-provider/src/queries/get_trending.py
+++ b/discovery-provider/src/queries/get_trending.py
@@ -4,10 +4,8 @@ from src.api.v1.helpers import extend_track, format_limit, format_offset
 from src.premium_content.premium_content_constants import (
     SHOULD_TRENDING_EXCLUDE_PREMIUM_TRACKS,
 )
-from src.queries.get_trending_tracks import (
-    TRENDING_LIMIT,
-    get_trending_tracks,
-)
+from src.queries.generate_unpopulated_trending_tracks import TRENDING_TRACKS_LIMIT
+from src.queries.get_trending_tracks import get_trending_tracks
 from src.utils.helpers import decode_string_id  # pylint: disable=C0302
 
 logger = logging.getLogger(__name__)
@@ -22,7 +20,7 @@ def get_trending(args, strategy):
         "time": time,
         "genre": args.get("genre", None),
         "with_users": True,
-        "limit": format_limit(args, TRENDING_LIMIT),
+        "limit": format_limit(args, TRENDING_TRACKS_LIMIT),
         "offset": format_offset(args),
         "exclude_premium": args.get(
             "exclude_premium", SHOULD_TRENDING_EXCLUDE_PREMIUM_TRACKS

--- a/discovery-provider/src/queries/get_trending_ids.py
+++ b/discovery-provider/src/queries/get_trending_ids.py
@@ -1,7 +1,7 @@
 import logging
 
+from src.queries.generate_unpopulated_trending_tracks import TRENDING_TRACKS_TTL_SEC
 from src.queries.get_trending import get_trending
-from src.queries.get_trending_tracks import TRENDING_TTL_SEC
 from src.trending_strategies.trending_strategy_factory import DEFAULT_TRENDING_VERSIONS
 from src.trending_strategies.trending_type_and_version import TrendingType
 from src.utils.redis_cache import extract_key, use_redis_cache
@@ -20,7 +20,7 @@ def get_time_trending(cache_args, time, limit, strategy):
 
     time_cache_key = extract_key(path, time_params.items())
     time_trending = use_redis_cache(
-        time_cache_key, TRENDING_TTL_SEC, lambda: get_trending(time_params, strategy)
+        time_cache_key, TRENDING_TRACKS_TTL_SEC, lambda: get_trending(time_params, strategy)
     )
     time_trending_track_ids = [
         {"track_id": track["track_id"]} for track in time_trending

--- a/discovery-provider/src/queries/get_trending_playlists.py
+++ b/discovery-provider/src/queries/get_trending_playlists.py
@@ -240,7 +240,7 @@ def make_get_unpopulated_playlists(session, time_range, strategy):
     return wrapped
 
 
-def make_trending_cache_key(
+def make_trending_playlists_cache_key(
     time_range, version=DEFAULT_TRENDING_VERSIONS[TrendingType.PLAYLISTS]
 ):
     version_name = (
@@ -267,7 +267,7 @@ def _get_trending_playlists_with_session(
     with_tracks = args.get("with_tracks", False)
     time = args.get("time")
     limit, offset = args.get("limit"), args.get("offset")
-    key = make_trending_cache_key(time, strategy.version)
+    key = make_trending_playlists_cache_key(time, strategy.version)
 
     # Get unpopulated playlists,
     # cached if it exists.

--- a/discovery-provider/src/queries/get_trending_tracks.py
+++ b/discovery-provider/src/queries/get_trending_tracks.py
@@ -1,24 +1,16 @@
 from typing import Optional, TypedDict
 
-from sqlalchemy import desc, text
 from sqlalchemy.orm.session import Session
-from sqlalchemy.sql.elements import not_, or_
 
-from src.models.tracks.track import Track
-from src.models.tracks.track_trending_score import TrackTrendingScore
 from src.premium_content.premium_content_constants import (
-    SHOULD_TRENDING_EXCLUDE_COLLECTIBLE_GATED_TRACKS,
     SHOULD_TRENDING_EXCLUDE_PREMIUM_TRACKS,
 )
-from src.queries.get_unpopulated_tracks import get_unpopulated_tracks
-from src.queries.query_helpers import add_users_to_tracks, populate_track_metadata
-from src.tasks.generate_trending import generate_trending
-from src.trending_strategies.base_trending_strategy import BaseTrendingStrategy
-from src.trending_strategies.trending_strategy_factory import DEFAULT_TRENDING_VERSIONS
-from src.trending_strategies.trending_type_and_version import (
-    TrendingType,
-    TrendingVersion,
+from src.queries.generate_unpopulated_trending import (
+    make_generate_unpopulated_trending,
+    make_trending_cache_key,
 )
+from src.queries.query_helpers import add_users_to_tracks, populate_track_metadata
+from src.trending_strategies.base_trending_strategy import BaseTrendingStrategy
 from src.utils.db_session import get_db_read_replica
 from src.utils.redis_cache import use_redis_cache
 
@@ -26,288 +18,11 @@ TRENDING_LIMIT = 100
 TRENDING_TTL_SEC = 30 * 60
 
 
-def make_trending_cache_key(
-    time_range, genre, version=DEFAULT_TRENDING_VERSIONS[TrendingType.TRACKS]
-):
-    """Makes a cache key resembling `generated-trending:week:electronic`"""
-    version_name = (
-        f":{version.name}"
-        if version != DEFAULT_TRENDING_VERSIONS[TrendingType.TRACKS]
-        else ""
-    )
-    return f"generated-trending{version_name}:{time_range}:{(genre.lower() if genre else '')}"
-
-
-def generate_unpopulated_trending(
-    session,
-    genre,
-    time_range,
-    strategy,
-    exclude_premium=SHOULD_TRENDING_EXCLUDE_PREMIUM_TRACKS,
-    exclude_collectible_gated=SHOULD_TRENDING_EXCLUDE_COLLECTIBLE_GATED_TRACKS,
-    usdc_purchase_only=False,
-    limit=TRENDING_LIMIT,
-):
-    # We use limit * 2 here to apply a soft limit so that
-    # when we later filter out premium or collectible gated tracks,
-    # we will probabilistically satisfy the given limit.
-    trending_tracks = generate_trending(
-        session, time_range, genre, limit * 2, 0, strategy.version
-    )
-
-    track_scores = [
-        strategy.get_track_score(time_range, track)
-        for track in trending_tracks["listen_counts"]
-    ]
-
-    # If usdc_purchase_only is true, then filter out track ids belonging to
-    # non-USDC purchase tracks before applying the limit.
-    if usdc_purchase_only:
-        ids = [track["track_id"] for track in track_scores]
-        usdc_purchase_track_ids = (
-            session.query(Track.track_id)
-            .filter(
-                Track.track_id.in_(ids),
-                Track.is_current == True,
-                Track.is_delete == False,
-                Track.stem_of == None,
-                Track.is_premium == True,
-                text("CAST(premium_conditions AS TEXT) LIKE '%usdc_purchase%'"),
-            )
-            .all()
-        )
-        usdc_purchase_track_id_set = set(map(lambda t: t[0], usdc_purchase_track_ids))
-        track_scores = list(
-            filter(lambda t: t["track_id"] in usdc_purchase_track_id_set, track_scores)
-        )
-    # If exclude_premium is true, then filter out track ids
-    # belonging to premium tracks before applying the limit.
-    elif exclude_premium:
-        ids = [track["track_id"] for track in track_scores]
-        non_premium_track_ids = (
-            session.query(Track.track_id)
-            .filter(
-                Track.track_id.in_(ids),
-                Track.is_current == True,
-                Track.is_delete == False,
-                Track.stem_of == None,
-                Track.is_premium == False,
-            )
-            .all()
-        )
-        non_premium_track_id_set = set(map(lambda t: t[0], non_premium_track_ids))
-        track_scores = list(
-            filter(lambda t: t["track_id"] in non_premium_track_id_set, track_scores)
-        )
-    elif exclude_collectible_gated:
-        ids = [track["track_id"] for track in track_scores]
-        non_collectible_gated_track_ids = (
-            session.query(Track.track_id)
-            .filter(
-                Track.track_id.in_(ids),
-                Track.is_current == True,
-                Track.is_delete == False,
-                Track.stem_of == None,
-                or_(
-                    Track.is_premium == False,
-                    not_(
-                        text("CAST(premium_conditions AS TEXT) LIKE '%nft_collection%'")
-                    ),
-                ),
-            )
-            .all()
-        )
-        non_collectible_gated_track_id_set = set(
-            map(lambda t: t[0], non_collectible_gated_track_ids)
-        )
-        track_scores = list(
-            filter(
-                lambda t: t["track_id"] in non_collectible_gated_track_id_set,
-                track_scores,
-            )
-        )
-
-    sorted_track_scores = sorted(
-        track_scores, key=lambda k: (k["score"], k["track_id"]), reverse=True
-    )
-    sorted_track_scores = sorted_track_scores[:limit]
-
-    # Get unpopulated metadata
-    track_ids = [track["track_id"] for track in sorted_track_scores]
-    tracks = get_unpopulated_tracks(session, track_ids, exclude_premium=exclude_premium)
-
-    return (tracks, track_ids)
-
-
-def generate_unpopulated_trending_from_mat_views(
-    session,
-    genre,
-    time_range,
-    strategy,
-    exclude_premium=SHOULD_TRENDING_EXCLUDE_PREMIUM_TRACKS,
-    exclude_collectible_gated=SHOULD_TRENDING_EXCLUDE_COLLECTIBLE_GATED_TRACKS,
-    usdc_purchase_only=False,
-    limit=TRENDING_LIMIT,
-):
-    # use all time instead of year for version EJ57D
-    if strategy.version == TrendingVersion.EJ57D and time_range == "year":
-        time_range = "allTime"
-    elif strategy.version != TrendingVersion.EJ57D and time_range == "allTime":
-        time_range = "year"
-
-    trending_track_ids_query = session.query(
-        TrackTrendingScore.track_id, TrackTrendingScore.score
-    ).filter(
-        TrackTrendingScore.type == strategy.trending_type.name,
-        TrackTrendingScore.version == strategy.version.name,
-        TrackTrendingScore.time_range == time_range,
-    )
-
-    if genre:
-        trending_track_ids_query = trending_track_ids_query.filter(
-            TrackTrendingScore.genre == genre
-        )
-
-    # If usdc_purchase_only is true, then filter out track ids belonging to
-    # non-USDC purchase tracks before applying the limit.
-    if usdc_purchase_only:
-        trending_track_ids_subquery = trending_track_ids_query.subquery()
-        trending_track_ids = (
-            session.query(
-                trending_track_ids_subquery.c.track_id,
-                trending_track_ids_subquery.c.score,
-                Track.track_id,
-            )
-            .join(
-                trending_track_ids_subquery,
-                Track.track_id == trending_track_ids_subquery.c.track_id,
-            )
-            .filter(
-                Track.is_current == True,
-                Track.is_delete == False,
-                Track.stem_of == None,
-                Track.is_premium == True,
-                text("CAST(premium_conditions AS TEXT) LIKE '%usdc_purchase%'"),
-            )
-            .order_by(
-                desc(trending_track_ids_subquery.c.score),
-                desc(trending_track_ids_subquery.c.track_id),
-            )
-            .limit(limit)
-            .all()
-        )
-    # If exclude_premium is true, then filter out track ids belonging to
-    # premium tracks before applying the limit.
-    elif exclude_premium:
-        trending_track_ids_subquery = trending_track_ids_query.subquery()
-        trending_track_ids = (
-            session.query(
-                trending_track_ids_subquery.c.track_id,
-                trending_track_ids_subquery.c.score,
-                Track.track_id,
-            )
-            .join(
-                trending_track_ids_subquery,
-                Track.track_id == trending_track_ids_subquery.c.track_id,
-            )
-            .filter(
-                Track.is_current == True,
-                Track.is_delete == False,
-                Track.stem_of == None,
-                Track.is_premium == False,
-            )
-            .order_by(
-                desc(trending_track_ids_subquery.c.score),
-                desc(trending_track_ids_subquery.c.track_id),
-            )
-            .limit(limit)
-            .all()
-        )
-    elif exclude_collectible_gated:
-        trending_track_ids_subquery = trending_track_ids_query.subquery()
-        trending_track_ids = (
-            session.query(
-                trending_track_ids_subquery.c.track_id,
-                trending_track_ids_subquery.c.score,
-                Track.track_id,
-            )
-            .join(
-                trending_track_ids_subquery,
-                Track.track_id == trending_track_ids_subquery.c.track_id,
-            )
-            .filter(
-                Track.is_current == True,
-                Track.is_delete == False,
-                Track.stem_of == None,
-                or_(
-                    Track.is_premium == False,
-                    not_(
-                        text("CAST(premium_conditions AS TEXT) LIKE '%nft_collection%'")
-                    ),
-                ),
-            )
-            .order_by(
-                desc(trending_track_ids_subquery.c.score),
-                desc(trending_track_ids_subquery.c.track_id),
-            )
-            .limit(limit)
-            .all()
-        )
-    else:
-        trending_track_ids = (
-            trending_track_ids_query.order_by(
-                desc(TrackTrendingScore.score), desc(TrackTrendingScore.track_id)
-            )
-            .limit(limit)
-            .all()
-        )
-
-    # Get unpopulated metadata
-    track_ids = [track_id[0] for track_id in trending_track_ids]
-    tracks = get_unpopulated_tracks(session, track_ids, exclude_premium=exclude_premium)
-
-    return (tracks, track_ids)
-
-
-def make_generate_unpopulated_trending(
-    session: Session,
-    genre: Optional[str],
-    time_range: str,
-    strategy: BaseTrendingStrategy,
-    exclude_premium: bool,
-    usdc_purchase_only: bool,
-):
-    """Wraps a call to `generate_unpopulated_trending` for use in `use_redis_cache`, which
-    expects to be passed a function with no arguments."""
-
-    def wrapped():
-        if strategy.use_mat_view:
-            return generate_unpopulated_trending_from_mat_views(
-                session=session,
-                genre=genre,
-                time_range=time_range,
-                strategy=strategy,
-                exclude_premium=exclude_premium,
-                usdc_purchase_only=usdc_purchase_only,
-            )
-        return generate_unpopulated_trending(
-            session=session,
-            genre=genre,
-            time_range=time_range,
-            strategy=strategy,
-            exclude_premium=exclude_premium,
-            usdc_purchase_only=usdc_purchase_only,
-        )
-
-    return wrapped
-
-
 class GetTrendingTracksArgs(TypedDict, total=False):
     current_user_id: Optional[int]
     genre: Optional[str]
     time: str
     exclude_premium: bool
-    usdc_purchase_only: bool
     limit: int
     offset: int
 
@@ -322,43 +37,28 @@ def get_trending_tracks(args: GetTrendingTracksArgs, strategy: BaseTrendingStrat
 def _get_trending_tracks_with_session(
     session: Session, args: GetTrendingTracksArgs, strategy: BaseTrendingStrategy
 ):
-    current_user_id, genre, time, exclude_premium, usdc_purchase_only, limit, offset = (
+    current_user_id, genre, time, exclude_premium, limit, offset = (
         args.get("current_user_id"),
         args.get("genre"),
         args.get("time", "week"),
         args.get("exclude_premium", SHOULD_TRENDING_EXCLUDE_PREMIUM_TRACKS),
-        args.get("usdc_purchase_only", False),
         args.get("limit", TRENDING_LIMIT),
         args.get("offset", 0)
     )
     time_range = "week" if time not in ["week", "month", "year", "allTime"] else time
     key = make_trending_cache_key(time_range, genre, strategy.version)
 
-    # Add a suffix to the key if usdc_purchase_only is true.
-    # This is so that we can cache both the regular trending and the usdc purchase trending
-    # and not return wrong tracks when usdc_purchase_only is true, which is used by
-    # the "Explore" Premium Tracks page which uses.
-    # Ideally, we want to decouple the logic for "Explore" Premium Tracks page from the Trending page,
-    # even if there may be a decent amount of repeated code.
-    # Otherwise, we are running into adding complexity to the already complex trending logic.
-    # But for now, we will just use the same logic and cache the results separately.
-    if usdc_purchase_only:
-        key += ":usdc_purchase_only"
-    # The index_trending task runs every 10 seconds, so we set the TTL to 10 seconds
-    ttl_sec = 10 if usdc_purchase_only else None
-
     # Will try to hit cached trending from task, falling back
     # to generating it here if necessary and storing it with no TTL
     (tracks, track_ids) = use_redis_cache(
         key,
-        ttl_sec,
+        None,
         make_generate_unpopulated_trending(
             session=session,
             genre=genre,
             time_range=time_range,
             strategy=strategy,
             exclude_premium=exclude_premium,
-            usdc_purchase_only=usdc_purchase_only,
         ),
     )
     tracks = tracks[offset : limit + offset]

--- a/discovery-provider/src/queries/get_trending_tracks.py
+++ b/discovery-provider/src/queries/get_trending_tracks.py
@@ -5,9 +5,9 @@ from sqlalchemy.orm.session import Session
 from src.premium_content.premium_content_constants import (
     SHOULD_TRENDING_EXCLUDE_PREMIUM_TRACKS,
 )
-from src.queries.generate_unpopulated_trending import (
+from src.queries.generate_unpopulated_trending_tracks import (
     make_generate_unpopulated_trending,
-    make_trending_cache_key,
+    make_trending_tracks_cache_key,
 )
 from src.queries.query_helpers import add_users_to_tracks, populate_track_metadata
 from src.trending_strategies.base_trending_strategy import BaseTrendingStrategy
@@ -46,7 +46,7 @@ def _get_trending_tracks_with_session(
         args.get("offset", 0)
     )
     time_range = "week" if time not in ["week", "month", "year", "allTime"] else time
-    key = make_trending_cache_key(time_range, genre, strategy.version)
+    key = make_trending_tracks_cache_key(time_range, genre, strategy.version)
 
     # Will try to hit cached trending from task, falling back
     # to generating it here if necessary and storing it with no TTL

--- a/discovery-provider/src/queries/get_trending_tracks.py
+++ b/discovery-provider/src/queries/get_trending_tracks.py
@@ -6,6 +6,7 @@ from src.premium_content.premium_content_constants import (
     SHOULD_TRENDING_EXCLUDE_PREMIUM_TRACKS,
 )
 from src.queries.generate_unpopulated_trending_tracks import (
+    TRENDING_TRACKS_LIMIT,
     make_generate_unpopulated_trending,
     make_trending_tracks_cache_key,
 )
@@ -13,9 +14,6 @@ from src.queries.query_helpers import add_users_to_tracks, populate_track_metada
 from src.trending_strategies.base_trending_strategy import BaseTrendingStrategy
 from src.utils.db_session import get_db_read_replica
 from src.utils.redis_cache import use_redis_cache
-
-TRENDING_LIMIT = 100
-TRENDING_TTL_SEC = 30 * 60
 
 
 class GetTrendingTracksArgs(TypedDict, total=False):
@@ -42,7 +40,7 @@ def _get_trending_tracks_with_session(
         args.get("genre"),
         args.get("time", "week"),
         args.get("exclude_premium", SHOULD_TRENDING_EXCLUDE_PREMIUM_TRACKS),
-        args.get("limit", TRENDING_LIMIT),
+        args.get("limit", TRENDING_TRACKS_LIMIT),
         args.get("offset", 0)
     )
     time_range = "week" if time not in ["week", "month", "year", "allTime"] else time

--- a/discovery-provider/src/queries/get_underground_trending.py
+++ b/discovery-provider/src/queries/get_underground_trending.py
@@ -18,9 +18,10 @@ from src.premium_content.premium_content_constants import (
     SHOULD_TRENDING_EXCLUDE_PREMIUM_TRACKS,
 )
 from src.queries.generate_unpopulated_trending_tracks import (
+    TRENDING_TRACKS_LIMIT,
+    TRENDING_TRACKS_TTL_SEC,
     make_trending_tracks_cache_key,
 )
-from src.queries.get_trending_tracks import TRENDING_LIMIT, TRENDING_TTL_SEC
 from src.queries.get_unpopulated_tracks import get_unpopulated_tracks
 from src.queries.query_helpers import (
     get_karma,
@@ -281,7 +282,7 @@ def _get_underground_trending(args: GetUndergroundTrendingTrackArgs, strategy):
 
 
 def get_underground_trending(request, args, strategy):
-    offset, limit = format_offset(args), format_limit(args, TRENDING_LIMIT)
+    offset, limit = format_offset(args), format_limit(args, TRENDING_TRACKS_LIMIT)
     current_user_id = args.get("user_id")
     args = {"limit": limit, "offset": offset}
 
@@ -297,7 +298,7 @@ def get_underground_trending(request, args, strategy):
         # no args so we get the full list of tracks.
         key = get_trending_cache_key(to_dict(request.args), request.path)
         trending = use_redis_cache(
-            key, TRENDING_TTL_SEC, lambda: _get_underground_trending({}, strategy)
+            key, TRENDING_TRACKS_TTL_SEC, lambda: _get_underground_trending({}, strategy)
         )
         trending = trending[offset : limit + offset]
     return trending

--- a/discovery-provider/src/queries/get_underground_trending.py
+++ b/discovery-provider/src/queries/get_underground_trending.py
@@ -17,11 +17,8 @@ from src.premium_content.premium_content_constants import (
     SHOULD_TRENDING_EXCLUDE_COLLECTIBLE_GATED_TRACKS,
     SHOULD_TRENDING_EXCLUDE_PREMIUM_TRACKS,
 )
-from src.queries.get_trending_tracks import (
-    TRENDING_LIMIT,
-    TRENDING_TTL_SEC,
-    make_trending_cache_key,
-)
+from src.queries.generate_unpopulated_trending import make_trending_cache_key
+from src.queries.get_trending_tracks import TRENDING_LIMIT, TRENDING_TTL_SEC
 from src.queries.get_unpopulated_tracks import get_unpopulated_tracks
 from src.queries.query_helpers import (
     get_karma,

--- a/discovery-provider/src/queries/get_underground_trending.py
+++ b/discovery-provider/src/queries/get_underground_trending.py
@@ -17,7 +17,9 @@ from src.premium_content.premium_content_constants import (
     SHOULD_TRENDING_EXCLUDE_COLLECTIBLE_GATED_TRACKS,
     SHOULD_TRENDING_EXCLUDE_PREMIUM_TRACKS,
 )
-from src.queries.generate_unpopulated_trending import make_trending_cache_key
+from src.queries.generate_unpopulated_trending_tracks import (
+    make_trending_tracks_cache_key,
+)
 from src.queries.get_trending_tracks import TRENDING_LIMIT, TRENDING_TTL_SEC
 from src.queries.get_unpopulated_tracks import get_unpopulated_tracks
 from src.queries.query_helpers import (
@@ -74,7 +76,7 @@ def get_scorable_track_data(session, redis_instance, strategy):
     qr = score_params["qr"]
     xf = score_params["xf"]
     pt = score_params["pt"]
-    trending_key = make_trending_cache_key("week", None, strategy.version)
+    trending_key = make_trending_tracks_cache_key("week", None, strategy.version)
     track_ids = []
     old_trending = get_json_cached_key(redis_instance, trending_key)
     if old_trending:

--- a/discovery-provider/src/tasks/cache_trending_playlists.py
+++ b/discovery-provider/src/tasks/cache_trending_playlists.py
@@ -8,7 +8,7 @@ from src.models.notifications.notification import Notification
 from src.queries.get_trending_playlists import (
     _get_trending_playlists_with_session,
     make_get_unpopulated_playlists,
-    make_trending_cache_key,
+    make_trending_playlists_cache_key,
 )
 from src.tasks.celery_app import celery
 from src.trending_strategies.trending_strategy_factory import TrendingStrategyFactory
@@ -29,7 +29,7 @@ def cache_trending(db, redis, strategy):
     now = int(datetime.now().timestamp())
     with db.scoped_session() as session:
         for time_range in TIME_RANGES:
-            key = make_trending_cache_key(time_range, strategy.version)
+            key = make_trending_playlists_cache_key(time_range, strategy.version)
             res = make_get_unpopulated_playlists(session, time_range, strategy)()
             set_json_cached_key(redis, key, res)
             if time_range == "week":

--- a/discovery-provider/src/tasks/calculate_trending_challenges.py
+++ b/discovery-provider/src/tasks/calculate_trending_challenges.py
@@ -97,7 +97,7 @@ def enqueue_trending_challenges(
                 TrendingType.TRACKS, version
             )
             top_tracks = _get_trending_tracks_with_session(
-                session, {"time": time_range, "exclude_premium": True, "usdc_purchase_only": False}, strategy
+                session, {"time": time_range, "exclude_premium": True}, strategy
             )
             top_tracks = top_tracks[:TRENDING_LIMIT]
             dispatch_trending_challenges(

--- a/discovery-provider/src/tasks/index_trending.py
+++ b/discovery-provider/src/tasks/index_trending.py
@@ -11,10 +11,10 @@ from web3 import Web3
 from src.models.indexing.block import Block
 from src.models.notifications.notification import Notification
 from src.models.tracks.track import Track
-from src.queries.generate_unpopulated_trending import (
+from src.queries.generate_unpopulated_trending_tracks import (
     generate_unpopulated_trending,
     generate_unpopulated_trending_from_mat_views,
-    make_trending_cache_key,
+    make_trending_tracks_cache_key,
 )
 from src.queries.get_trending_tracks import _get_trending_tracks_with_session
 from src.queries.get_underground_trending import (
@@ -125,7 +125,7 @@ def index_trending(self, db: SessionManager, redis: Redis, timestamp):
                             time_range=time_range,
                             strategy=strategy,
                         )
-                    key = make_trending_cache_key(time_range, genre, version)
+                    key = make_trending_tracks_cache_key(time_range, genre, version)
                     set_json_cached_key(redis, key, res)
                     cache_end_time = time.time()
                     total_time = cache_end_time - cache_start_time

--- a/discovery-provider/src/tasks/index_trending.py
+++ b/discovery-provider/src/tasks/index_trending.py
@@ -11,12 +11,12 @@ from web3 import Web3
 from src.models.indexing.block import Block
 from src.models.notifications.notification import Notification
 from src.models.tracks.track import Track
-from src.queries.get_trending_tracks import (
-    _get_trending_tracks_with_session,
+from src.queries.generate_unpopulated_trending import (
     generate_unpopulated_trending,
     generate_unpopulated_trending_from_mat_views,
     make_trending_cache_key,
 )
+from src.queries.get_trending_tracks import _get_trending_tracks_with_session
 from src.queries.get_underground_trending import (
     _get_underground_trending_with_session,
     make_get_unpopulated_tracks,
@@ -177,7 +177,7 @@ def get_top_trending_to_notify(db):
     with db.scoped_session() as session:
         trending_tracks = _get_trending_tracks_with_session(
             session,
-            {"time": "week", "exclude_premium": True, "usdc_purchase_only": False},
+            {"time": "week", "exclude_premium": True},
             trending_strategy_factory.get_strategy(TrendingType.TRACKS),
         )
         top_trending = trending_tracks[:NOTIFICATIONS_TRACK_LIMIT]

--- a/packages/web/src/pages/premium-tracks-page/PremiumTracksPage.tsx
+++ b/packages/web/src/pages/premium-tracks-page/PremiumTracksPage.tsx
@@ -1,7 +1,10 @@
+import { useEffect } from 'react'
+
 import {
   premiumTracksPageLineupActions,
   premiumTracksPageLineupSelectors
 } from '@audius/common'
+import { useDispatch } from 'react-redux'
 
 import EndOfLineup from 'components/lineup/EndOfLineup'
 import Lineup from 'components/lineup/Lineup'
@@ -27,6 +30,15 @@ const usePremiumTracksLineup = (containerRef: HTMLElement) => {
   })
 }
 
+const useLineupReset = () => {
+  const dispatch = useDispatch()
+  useEffect(() => {
+    return () => {
+      dispatch(premiumTracksPageLineupActions.reset())
+    }
+  }, [dispatch])
+}
+
 type PremiumTracksPageProps = {
   containerRef: HTMLElement
 }
@@ -37,6 +49,9 @@ export const PremiumTracksPage = ({ containerRef }: PremiumTracksPageProps) => {
   const Content = isMobile
     ? MobilePremiumTracksPageContent
     : DesktopPremiumTracksPageContent
+
+  useLineupReset()
+
   const renderLineup = () => {
     return (
       <Lineup


### PR DESCRIPTION
### Description

Issues:
**1. non usdc purchase tracks displaying in premium tracks explore page.**
This is because the trending logic first looks at the cache for the tracks, and if it misses, then it does the db query logic.
I overlooked updating the cache key for usdc purchase tracks so we ended up with non usdc tracks on the explore premium tracks page.
I didn't catch this bug because I mostly tested my original changes against local services, which didn't have enough tracks for me to notice. I did test a bit against stage, but i believe i missed it because of the timing factor between trending updates.

This PR not only fixes that bug, but it decouples the usdc purchase explore tracks from `get_trending_tracks`, and move the generation of unpopulated trending tracks to new file.
Ideally, we also decouple the trending generation from the `usdc_purchase_only`, `exclude_premium`, etc. flags, but that's for another time.

I also renamed some functions and vars to remove confusion between tracks vs playlists.

_Let's keep an eye on trending on stage as my code does refactor the logic a bit._

**2. premium tracks duplicating in lineup when navigating back and forth to premium tracks explore page.**
I was missing a reset lineup action trigger on unmount. This PR fixes it.

### How Has This Been Tested?

local dapps vs stage
