### PR TITLE
Fix identity push

### DIFF
--- a/.circleci/src/jobs/push-docker-image.yml
+++ b/.circleci/src/jobs/push-docker-image.yml
@@ -44,4 +44,4 @@ steps:
             command: echo "$DOCKERHUB_PASS" | docker login -u "$DOCKERHUB_USERNAME" --password-stdin
         - run: AUDIUS_DEV=false bash ~/audius-protocol/dev-tools/setup.sh
         - run: . ~/.profile; audius-compose build --prod "<< parameters.service >>"
-        - run: . ~/.profile; audius-compose push "<< parameters.service >>"
+        - run: . ~/.profile; audius-compose push --prod "<< parameters.service >>"

--- a/dev-tools/audius-compose
+++ b/dev-tools/audius-compose
@@ -248,8 +248,13 @@ def build(
 
 @cli.command()
 @click.argument("services", nargs=-1)
+@click.option(
+    "--prod",
+    is_flag=True,
+    help="Use production containers which have all dependencies built in",
+)
 @click.pass_context
-def push(ctx, services):
+def push(ctx, services, prod):
     protocol_dir = ctx.obj
     services = services or ["mediorum", "discovery-provider", "identity-service"]
 
@@ -259,7 +264,7 @@ def push(ctx, services):
         raise click.ClickException("Failed to get git commit")
 
     # this is building w/o cache every time
-    ctx.invoke(build, services=services)
+    ctx.invoke(build, services=services, prod=prod)
 
     try:
         for service in services:


### PR DESCRIPTION
### Description

Identity hasn't been auto upgrading since #6160
This is because `audius-compose push` runs a full build and wasn't passed the `prod` flag. Thanks @theoilie for help debugging!

* Add `prod` flag to audius-compose push

### How Has This Been Tested?

Confirming push output in CI and then will confirm stage identity auto upgrades
