### PR TITLE
Remove anon v1 full trending tracks cache

### DIFF
--- a/discovery-provider/src/api/v1/tracks.py
+++ b/discovery-provider/src/api/v1/tracks.py
@@ -65,7 +65,7 @@ from src.queries.get_track_stream_info import get_track_stream_info
 from src.queries.get_track_stream_signature import get_track_stream_signature
 from src.queries.get_tracks import RouteArgs, get_tracks
 from src.queries.get_tracks_including_unlisted import get_tracks_including_unlisted
-from src.queries.get_trending import get_full_trending, get_trending
+from src.queries.get_trending import get_trending
 from src.queries.get_trending_ids import get_trending_ids
 from src.queries.get_trending_tracks import TRENDING_LIMIT, TRENDING_TTL_SEC
 from src.queries.get_unclaimed_id import get_unclaimed_id
@@ -683,7 +683,7 @@ class FullTrending(Resource):
         strategy = trending_strategy_factory.get_strategy(
             TrendingType.TRACKS, version_list[0]
         )
-        trending_tracks = get_full_trending(request, args, strategy)
+        trending_tracks = get_trending(args, strategy)
         return success_response(trending_tracks)
 
 

--- a/discovery-provider/src/queries/get_trending.py
+++ b/discovery-provider/src/queries/get_trending.py
@@ -1,16 +1,14 @@
 import logging
 
-from src.api.v1.helpers import extend_track, format_limit, format_offset, to_dict
+from src.api.v1.helpers import extend_track, format_limit, format_offset
 from src.premium_content.premium_content_constants import (
     SHOULD_TRENDING_EXCLUDE_PREMIUM_TRACKS,
 )
 from src.queries.get_trending_tracks import (
     TRENDING_LIMIT,
-    TRENDING_TTL_SEC,
     get_trending_tracks,
 )
 from src.utils.helpers import decode_string_id  # pylint: disable=C0302
-from src.utils.redis_cache import get_trending_cache_key, use_redis_cache
 
 logger = logging.getLogger(__name__)
 
@@ -39,16 +37,3 @@ def get_trending(args, strategy):
 
     tracks = get_trending_tracks(args, strategy)
     return list(map(extend_track, tracks))
-
-
-def get_full_trending(request, args, strategy):
-    key = get_trending_cache_key(to_dict(request.args), request.path)
-
-    # Attempt to use the cached tracks list
-    if args["user_id"] is not None:
-        full_trending = get_trending(args, strategy)
-    else:
-        full_trending = use_redis_cache(
-            key, TRENDING_TTL_SEC, lambda: get_trending(args, strategy)
-        )
-    return full_trending


### PR DESCRIPTION
### Description
Before, we would populate/cache the entire trending list but this optimization https://github.com/AudiusProject/audius-protocol/pull/6199 made it cache according to a limit and return the cached result no matter the limit / offset.

We still cache unpopulated trending tracks so impact on perf is negligible https://github.com/AudiusProject/audius-protocol/blob/e243d46f682378d72000eab520ae615ce7989a75/discovery-provider/src/queries/get_trending_tracks.py#L342.



### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._

Tested on sandbox and paging through trending works.