### PR TITLE
[C-3181, C-3182] Fix collection loading, drawer closing, feature flag perf

### DIFF
--- a/packages/mobile/metro.config.js
+++ b/packages/mobile/metro.config.js
@@ -40,7 +40,9 @@ module.exports = (async () => {
 
   const defaultSourceExts = [...sourceExts, 'svg', 'cjs']
 
-  resolverMainFields.unshift('sbmodern')
+  if (process.env.RN_STORYBOOK) {
+    resolverMainFields.unshift('sbmodern')
+  }
 
   return {
     transformer: {
@@ -101,7 +103,9 @@ module.exports = (async () => {
         }
         return context.resolveRequest(context, moduleName, platform)
       },
-      resolverMainFields
+      resolverMainFields: process.env.RN_STORYBOOK
+        ? resolverMainFields
+        : undefined
     },
     maxWorkers: 2
   }

--- a/packages/mobile/metro.config.js
+++ b/packages/mobile/metro.config.js
@@ -38,13 +38,7 @@ module.exports = (async () => {
     resolver: { sourceExts, assetExts, resolverMainFields }
   } = await getDefaultConfig()
 
-  const defaultSourceExts = [...sourceExts, 'svg', 'cjs']
-
-  if (process.env.RN_STORYBOOK) {
-    resolverMainFields.unshift('sbmodern')
-  }
-
-  return {
+  const config = {
     transformer: {
       getTransformOptions: async () => ({
         transform: {
@@ -62,9 +56,7 @@ module.exports = (async () => {
     ],
     resolver: {
       assetExts: assetExts.filter((ext) => ext !== 'svg'),
-      sourceExts: process.env.RN_SRC_EXT
-        ? process.env.RN_SRC_EXT.split(',').concat(defaultSourceExts)
-        : defaultSourceExts,
+      sourceExts: [...sourceExts, 'svg', 'cjs'],
       extraNodeModules: {
         ...require('node-libs-react-native'),
         // Alias for 'src' to allow for absolute paths
@@ -102,11 +94,18 @@ module.exports = (async () => {
           }
         }
         return context.resolveRequest(context, moduleName, platform)
-      },
-      resolverMainFields: process.env.RN_STORYBOOK
-        ? resolverMainFields
-        : undefined
+      }
     },
     maxWorkers: 2
   }
+
+  if (process.env.RN_STORYBOOK) {
+    resolverMainFields.unshift('sbmodern')
+    config.resolver.resolverMainFields = resolverMainFields
+  }
+
+  if (process.env.RN_E2E)
+    config.resolver.sourceExts = ['e2e.ts', ...config.resolver.sourceExts]
+
+  return config
 })()

--- a/packages/mobile/package.json
+++ b/packages/mobile/package.json
@@ -30,6 +30,7 @@
     "codepush-android-history:staging": "appcenter codepush deployment history -a Audius-Music/Audius-Android Staging",
     "start": "react-native start",
     "start:e2e": "RN_SRC_EXT=e2e.ts react-native start",
+    "start:storybook": "RN_STORYBOOK=true react-native start",
     "test": "jest",
     "test:e2e": "detox test --configuration ios.sim.debug signUp.test.ts",
     "upgrade": "react-native upgrade",

--- a/packages/mobile/src/components/drawer/NativeDrawer.tsx
+++ b/packages/mobile/src/components/drawer/NativeDrawer.tsx
@@ -19,7 +19,7 @@ type NativeDrawerProps = SetOptional<DrawerProps, 'isOpen' | 'onClose'> & {
  */
 export const NativeDrawer = (props: NativeDrawerProps) => {
   const {
-    blockClose = true,
+    blockClose = false,
     drawerName,
     onClose: onCloseProp,
     ...other


### PR DESCRIPTION
### Description

1. Fixes issue where collections were not loading. This is due to an issue with metro.config.js and storybook. The fix is to only apply the storybook metro changes when user runs `npm run start:storybook`
2. Fixes issue with native drawers not closing, due to an incorrect default `blockClose` prop
3. Fixes issue with feature-flag perf, where we were getting "maximum depth exceeded" errors. Ultimately the fix was to separate the now-async `getLocalFeatureFlag` call from the `getFeatureFlag` on remote config. This reduces the number of rerenders by 3x, bringing it back in line with previous behavior.

Shoutout to @nicoback and @sliptype for debugging help