### PR TITLE
bump DN dockerfile python3 dependency to 3.11.6

### DIFF
--- a/discovery-provider/Dockerfile
+++ b/discovery-provider/Dockerfile
@@ -24,8 +24,8 @@ RUN apk update && \
     linux-headers \
     nodejs \
     npm \
-    python3=3.11.5-r0 \
-    python3-dev=3.11.5-r0 \
+    python3=3.11.6-r0 \
+    python3-dev=3.11.6-r0 \
     py3-numpy \
     py3-pip \
     py3-scipy \


### PR DESCRIPTION
### Description
Resolves
```
 => ERROR [discovery-provider stage-1  5/17] RUN apk update &&     apk add --no-cache     alpine-sdk     bash     curl     docker     libffi-dev     libseccomp-dev     libxml2-dev     libxslt-dev     linux-headers     nodejs     npm     python3=3.11.5-r0     python3-dev=3.11.5-r0     py3-numpy     py3-pip     py3-scipy     py3-wheel     redis     rsyslo  1.9s
------
 > [discovery-provider stage-1  5/17] RUN apk update &&     apk add --no-cache     alpine-sdk     bash     curl     docker     libffi-dev     libseccomp-dev     libxml2-dev     libxslt-dev     linux-headers     nodejs     npm     python3=3.11.5-r0     python3-dev=3.11.5-r0     py3-numpy     py3-pip     py3-scipy     py3-wheel     redis     rsyslog     sudo
 gcc     musl-dev     gfortran     openblas-dev:
0.116 fetch https://dl-cdn.alpinelinux.org/alpine/v3.18/main/aarch64/APKINDEX.tar.gz
0.457 fetch https://dl-cdn.alpinelinux.org/alpine/v3.18/community/aarch64/APKINDEX.tar.gz
1.046 v3.18.4-13-g32138bd20c6 [https://dl-cdn.alpinelinux.org/alpine/v3.18/main]
1.046 v3.18.4-16-g62592204bdf [https://dl-cdn.alpinelinux.org/alpine/v3.18/community]
1.046 OK: 19941 distinct packages available
1.069 fetch https://dl-cdn.alpinelinux.org/alpine/v3.18/main/aarch64/APKINDEX.tar.gz
1.352 fetch https://dl-cdn.alpinelinux.org/alpine/v3.18/community/aarch64/APKINDEX.tar.gz
1.780 ERROR: unable to select packages:
1.781   python3-3.11.6-r0:
1.781     breaks: world[python3=3.11.5-r0]
```

### How Has This Been Tested?
`audius-compose up`