### PR TITLE
Remove sdk autopublish

### DIFF
--- a/.circleci/src/workflows/sdk.yml
+++ b/.circleci/src/workflows/sdk.yml
@@ -12,22 +12,6 @@ jobs:
       instance-name: circleci-test-audius-libs-$CIRCLE_BUILD_NUM
       service: audius-sdk
 
-  # Prerelease from main
-  - release-audius-sdk:
-      requires:
-        - test-audius-libs
-        - test-audius-sdk
-      name: release-audius-sdk-prerelease
-      filters:
-        branches:
-          only: /^main$/
-      sdk-release-commit: $CIRCLE_SHA1
-      sdk-release-version: prerelease
-      sdk-release-preid: beta
-      context:
-        - Audius Client
-        - slack-secrets
-
   # Patch via trigger
   - release-audius-sdk-trigger:
       requires:


### PR DESCRIPTION
### Description

Currently we are running sdk autopublish after every commit due to #6112 

We don't really need to autopublish now bc most things are npm workspaces. If we need a libs update in something like healthz we will need to manually publish for now

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._
