### PR TITLE
[PAY-1960] Clean up withdrawals decimal places

### DIFF
--- a/packages/web/src/components/withdraw-usdc-modal/components/ConfirmTransferDetails.tsx
+++ b/packages/web/src/components/withdraw-usdc-modal/components/ConfirmTransferDetails.tsx
@@ -5,9 +5,8 @@ import {
   decimalIntegerToHumanReadable,
   useWithdrawUSDCModal,
   useUSDCBalance,
-  formatUSDCWeiToFloorDollarNumber,
-  BNUSDC,
-  formatCurrencyBalance
+  formatUSDCWeiToFloorCentsNumber,
+  BNUSDC
 } from '@audius/common'
 import {
   HarmonyButton,
@@ -56,10 +55,10 @@ export const ConfirmTransferDetails = () => {
   const [confirmField, { error: confirmError }] = useField(CONFIRM)
 
   const { data: balance } = useUSDCBalance()
-  const balanceNumber = formatUSDCWeiToFloorDollarNumber(
+  const balanceNumber = formatUSDCWeiToFloorCentsNumber(
     (balance ?? new BN(0)) as BNUSDC
   )
-  const balanceFormatted = formatCurrencyBalance(balanceNumber)
+  const balanceFormatted = decimalIntegerToHumanReadable(balanceNumber)
 
   const handleGoBack = useCallback(() => {
     setData({ page: WithdrawUSDCModalPages.ENTER_TRANSFER_DETAILS })

--- a/packages/web/src/components/withdraw-usdc-modal/components/EnterTransferDetails.tsx
+++ b/packages/web/src/components/withdraw-usdc-modal/components/EnterTransferDetails.tsx
@@ -7,11 +7,10 @@ import {
 
 import {
   useUSDCBalance,
-  formatCurrencyBalance,
   BNUSDC,
   useWithdrawUSDCModal,
   WithdrawUSDCModalPages,
-  formatUSDCWeiToFloorDollarNumber,
+  formatUSDCWeiToFloorCentsNumber,
   filterDecimalString,
   padDecimalValue,
   decimalIntegerToHumanReadable
@@ -56,10 +55,10 @@ export const EnterTransferDetails = () => {
   const { data: balance } = useUSDCBalance()
   const { setData } = useWithdrawUSDCModal()
 
-  const balanceNumber = formatUSDCWeiToFloorDollarNumber(
+  const balanceNumber = formatUSDCWeiToFloorCentsNumber(
     (balance ?? new BN(0)) as BNUSDC
   )
-  const balanceFormatted = formatCurrencyBalance(balanceNumber)
+  const balanceFormatted = decimalIntegerToHumanReadable(balanceNumber)
 
   const [
     { value },

--- a/packages/web/src/components/withdraw-usdc-modal/components/TransferInProgress.tsx
+++ b/packages/web/src/components/withdraw-usdc-modal/components/TransferInProgress.tsx
@@ -1,8 +1,7 @@
 import {
   useUSDCBalance,
-  formatCurrencyBalance,
   BNUSDC,
-  formatUSDCWeiToFloorDollarNumber,
+  formatUSDCWeiToFloorCentsNumber,
   decimalIntegerToHumanReadable
 } from '@audius/common'
 import BN from 'bn.js'
@@ -27,10 +26,10 @@ const messages = {
 
 export const TransferInProgress = () => {
   const { data: balance } = useUSDCBalance()
-  const balanceNumber = formatUSDCWeiToFloorDollarNumber(
+  const balanceNumber = formatUSDCWeiToFloorCentsNumber(
     (balance ?? new BN(0)) as BNUSDC
   )
-  const balanceFormatted = formatCurrencyBalance(balanceNumber)
+  const balanceFormatted = decimalIntegerToHumanReadable(balanceNumber)
 
   const [{ value: amountValue }] = useField(AMOUNT)
   const [{ value: addressValue }] = useField(ADDRESS)

--- a/packages/web/src/components/withdraw-usdc-modal/components/TransferSuccessful.tsx
+++ b/packages/web/src/components/withdraw-usdc-modal/components/TransferSuccessful.tsx
@@ -1,11 +1,11 @@
 import {
   useUSDCBalance,
-  formatCurrencyBalance,
   BNUSDC,
   useWithdrawUSDCModal,
-  formatUSDCWeiToFloorDollarNumber,
+  formatUSDCWeiToFloorCentsNumber,
   makeSolanaTransactionLink,
-  decimalIntegerToHumanReadable
+  decimalIntegerToHumanReadable,
+  Status
 } from '@audius/common'
 import {
   HarmonyPlainButton,
@@ -50,12 +50,12 @@ export const TransferSuccessful = ({
 }: {
   priorBalanceCents: number
 }) => {
-  const { data: balance } = useUSDCBalance()
+  const { data: balance, balanceStatus } = useUSDCBalance()
   const { data: modalData } = useWithdrawUSDCModal()
-  const balanceNumber = formatUSDCWeiToFloorDollarNumber(
+  const balanceNumber = formatUSDCWeiToFloorCentsNumber(
     (balance ?? new BN(0)) as BNUSDC
   )
-  const balanceFormatted = formatCurrencyBalance(balanceNumber)
+  const balanceFormatted = decimalIntegerToHumanReadable(balanceNumber)
 
   const [{ value: amountValue }] = useField(AMOUNT)
   const [{ value: addressValue }] = useField(ADDRESS)
@@ -74,7 +74,12 @@ export const TransferSuccessful = ({
         right={`-$${decimalIntegerToHumanReadable(amountValue)}`}
       />
       <Divider style={{ margin: 0 }} />
-      <TextRow left={messages.newBalance} right={`$${balanceFormatted}`} />
+      <TextRow
+        left={messages.newBalance}
+        right={
+          balanceStatus === Status.SUCCESS ? `$${balanceFormatted}` : undefined
+        }
+      />
       <Divider style={{ margin: 0 }} />
       <div className={styles.destination}>
         <TextRow left={messages.destinationAddress} />


### PR DESCRIPTION
### Description

* Fix up balance decimal places
* Do not render final balance until we get status success in the success screen (so we don't visibly jump from old balance => new balance)
* Reset form / state on modal close


### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._
![image (40)](https://github.com/AudiusProject/audius-protocol/assets/2731362/68f585e6-59df-43cd-aac8-01cd41c48048)

![image (39)](https://github.com/AudiusProject/audius-protocol/assets/2731362/a0956659-2aa4-422a-82d3-1e37ca44300a)

![image (38)](https://github.com/AudiusProject/audius-protocol/assets/2731362/a63d042f-84b7-49b4-a5f0-93a2a18632fe)

