### PR TITLE
Make createAssociatedTokenAccount idempotent for root wallet

### DIFF
--- a/packages/web/src/services/solana/WithdrawUSDC.ts
+++ b/packages/web/src/services/solana/WithdrawUSDC.ts
@@ -2,7 +2,6 @@ import { getLookupTableAccounts, getRecentBlockhash } from '@audius/common'
 import { MintName } from '@audius/sdk'
 import {
   createCloseAccountInstruction,
-  createAssociatedTokenAccountInstruction,
   NATIVE_MINT,
   createAssociatedTokenAccountIdempotentInstruction,
   getAssociatedTokenAddressSync
@@ -71,7 +70,7 @@ export const createSwapUserbankToSolInstructions = async ({
 
   // 1. Create a temporary token account on the wallet
   const createTemporaryTokenAccountInstruction =
-    createAssociatedTokenAccountInstruction(
+    createAssociatedTokenAccountIdempotentInstruction(
       feePayer, // fee payer
       walletTokenAccount, // account to create
       wallet, // owner


### PR DESCRIPTION
### Description

Makes creating the token account for the root wallet idempotent, allowing it to have already existed.

### How Has This Been Tested?

It has not.