### PR TITLE
Fix empty state for offline tracks C-3188

### DIFF
--- a/packages/mobile/src/screens/favorites-screen/TracksTab.tsx
+++ b/packages/mobile/src/screens/favorites-screen/TracksTab.tsx
@@ -1,13 +1,6 @@
 import { useCallback, useEffect, useMemo, useState } from 'react'
 
-import type {
-  CommonState,
-  ID,
-  Nullable,
-  Track,
-  UID,
-  User
-} from '@audius/common'
+import type { ID, Nullable, Track, UID, User } from '@audius/common'
 import {
   FavoriteSource,
   LibraryCategory,
@@ -224,7 +217,6 @@ export const TracksTab = () => {
   }, [])
 
   const loadingSpinner = <LoadingMoreSpinner />
-  console.log(isLoading, filteredTrackUids, filterValue, 'beepy')
   return (
     <VirtualizedScrollView>
       {!isLoading && filteredTrackUids.length === 0 && !filterValue ? (

--- a/packages/mobile/src/screens/favorites-screen/TracksTab.tsx
+++ b/packages/mobile/src/screens/favorites-screen/TracksTab.tsx
@@ -1,11 +1,18 @@
 import { useCallback, useEffect, useMemo, useState } from 'react'
 
-import type { ID, Nullable, Track, UID, User } from '@audius/common'
+import type {
+  CommonState,
+  ID,
+  Nullable,
+  Track,
+  UID,
+  User
+} from '@audius/common'
 import {
-  LibraryCategory,
-  SavedPageTabs,
   FavoriteSource,
+  LibraryCategory,
   PlaybackSource,
+  SavedPageTabs,
   Status,
   cacheTracksSelectors,
   cacheUsersSelectors,
@@ -25,6 +32,7 @@ import { FilterInput } from 'app/components/filter-input'
 import { TrackList } from 'app/components/track-list'
 import type { TrackMetadata } from 'app/components/track-list/types'
 import { WithLoader } from 'app/components/with-loader/WithLoader'
+import { getIsDoneLoadingFromDisk } from 'app/store/offline-downloads/selectors'
 import { makeStyles } from 'app/styles'
 
 import { LoadingMoreSpinner } from './LoadingMoreSpinner'
@@ -83,7 +91,15 @@ export const TracksTab = () => {
   const selectedCategory = useSelector((state) =>
     getCategory(state, { currentTab: SavedPageTabs.TRACKS })
   )
-  const savedTracksStatus = useSelector(getSavedTracksStatus)
+  const savedTracksStatus = useSelector((state) => {
+    const onlineSavedTracksStatus = getSavedTracksStatus(state)
+    const isDoneLoadingFromDisk = getIsDoneLoadingFromDisk(state)
+    const offlineSavedTracksStatus = isDoneLoadingFromDisk
+      ? Status.SUCCESS
+      : Status.LOADING
+    return isReachable ? onlineSavedTracksStatus : offlineSavedTracksStatus
+  })
+
   const initialFetch = useSelector(getInitialFetchStatus)
   const isFetchingMore = useSelector(getIsFetchingMore)
   const saves = useSelector(getTrackSaves)
@@ -208,7 +224,7 @@ export const TracksTab = () => {
   }, [])
 
   const loadingSpinner = <LoadingMoreSpinner />
-
+  console.log(isLoading, filteredTrackUids, filterValue, 'beepy')
   return (
     <VirtualizedScrollView>
       {!isLoading && filteredTrackUids.length === 0 && !filterValue ? (


### PR DESCRIPTION
Before: Empty state for offline tracks wouldn't show up

<img width="355" alt="Screenshot 2023-10-04 at 9 14 34 PM" src="https://github.com/AudiusProject/audius-protocol/assets/36916764/9fcc6d90-7f75-43e5-ab15-7395a594c51b">


After: Empty state now shows up

<img width="371" alt="Screenshot 2023-10-04 at 9 14 19 PM" src="https://github.com/AudiusProject/audius-protocol/assets/36916764/73666d4a-3043-43a7-8d1e-27ce5cbfce8e">


### Description

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._
