### PR TITLE
[PAY-1923] Navigate to track screen in the background on successful purchase

### DIFF
--- a/packages/mobile/src/components/premium-track-purchase-drawer/PremiumTrackPurchaseDrawer.tsx
+++ b/packages/mobile/src/components/premium-track-purchase-drawer/PremiumTrackPurchaseDrawer.tsx
@@ -25,6 +25,7 @@ import { Button, LockedStatusBadge, Text } from 'app/components/core'
 import { NativeDrawer } from 'app/components/drawer'
 import { useDrawer } from 'app/hooks/useDrawer'
 import { useIsUSDCEnabled } from 'app/hooks/useIsUSDCEnabled'
+import { useNavigation } from 'app/hooks/useNavigation'
 import { flexRowCentered, makeStyles } from 'app/styles'
 import { spacing } from 'app/styles/spacing'
 import { useThemeColors } from 'app/utils/theme'
@@ -167,6 +168,7 @@ const PremiumTrackPurchaseDrawerHeader = ({
 // to the FormikContext, which can only be used in a component which is a descendant
 // of the `<Formik />` component
 const RenderForm = ({ track }: { track: PurchasableTrackMetadata }) => {
+  const navigation = useNavigation()
   const styles = useStyles()
   const { specialLightGreen, accentRed, secondary } = useThemeColors()
 
@@ -185,6 +187,13 @@ const RenderForm = ({ track }: { track: PurchasableTrackMetadata }) => {
     usePurchaseContentFormState({ price })
 
   const isPurchaseSuccessful = stage === PurchaseContentStage.FINISH
+
+  // Navigate to track screen in the background if purchase is successful
+  useEffect(() => {
+    if (isPurchaseSuccessful) {
+      navigation.navigate('Track', { id: track.track_id })
+    }
+  }, [isPurchaseSuccessful, navigation, track.track_id])
 
   const handleTermsPress = useCallback(() => {
     Linking.openURL('https://audius.co/legal/terms-of-use')

--- a/packages/mobile/src/components/premium-track-purchase-drawer/PurchaseSuccess.tsx
+++ b/packages/mobile/src/components/premium-track-purchase-drawer/PurchaseSuccess.tsx
@@ -38,15 +38,12 @@ const useStyles = makeStyles(({ spacing, palette }) => ({
   },
   viewTrackText: {
     color: palette.neutralLight4
-  },
-  viewTrackIcon: {
-    color: palette.neutralLight4
   }
 }))
 
 export const PurchaseSuccess = ({ track }: { track: UserTrackMetadata }) => {
   const styles = useStyles()
-  const { specialGreen, staticWhite } = useThemeColors()
+  const { specialGreen, staticWhite, neutralLight4 } = useThemeColors()
   const { onClose } = useDrawer('PremiumTrackPurchase')
   const { handle } = track.user
   const { title } = track
@@ -91,10 +88,9 @@ export const PurchaseSuccess = ({ track }: { track: UserTrackMetadata }) => {
         variant='commonAlt'
         styles={{
           root: styles.viewTrack,
-          text: styles.viewTrackText,
-          // @ts-ignore icon has ViewStyle prop for some reason, which does not understand the 'color' property
-          icon: styles.viewTrackIcon
+          text: styles.viewTrackText
         }}
+        IconProps={{ width: 20, height: 20, fill: neutralLight4 }}
         size='large'
         icon={IconCaretRight}
       />

--- a/packages/mobile/src/components/premium-track-purchase-drawer/PurchaseSuccess.tsx
+++ b/packages/mobile/src/components/premium-track-purchase-drawer/PurchaseSuccess.tsx
@@ -3,8 +3,10 @@ import { useCallback } from 'react'
 import type { UserTrackMetadata } from '@audius/common'
 import { View } from 'react-native'
 
+import IconCaretRight from 'app/assets/images/iconCaretRight.svg'
 import IconVerified from 'app/assets/images/iconVerified.svg'
-import { Text } from 'app/components/core'
+import { Button, Text } from 'app/components/core'
+import { useDrawer } from 'app/hooks/useDrawer'
 import { flexRowCentered, makeStyles } from 'app/styles'
 import { spacing } from 'app/styles/spacing'
 import { EventNames } from 'app/types/analytics'
@@ -16,10 +18,11 @@ import { TwitterButton } from '../twitter-button'
 const messages = {
   success: 'Your purchase was successful!',
   shareTwitterText: (trackTitle: string, handle: string) =>
-    `I bought the track ${trackTitle} by ${handle} on Audius! #AudiusPremium`
+    `I bought the track ${trackTitle} by ${handle} on Audius! #AudiusPremium`,
+  viewTrack: 'View Track'
 }
 
-const useStyles = makeStyles(({ spacing, typography, palette }) => ({
+const useStyles = makeStyles(({ spacing, palette }) => ({
   root: {
     paddingTop: spacing(2),
     gap: spacing(9),
@@ -29,12 +32,22 @@ const useStyles = makeStyles(({ spacing, typography, palette }) => ({
     ...flexRowCentered(),
     alignSelf: 'center',
     gap: spacing(2)
+  },
+  viewTrack: {
+    borderWidth: 0
+  },
+  viewTrackText: {
+    color: palette.neutralLight4
+  },
+  viewTrackIcon: {
+    color: palette.neutralLight4
   }
 }))
 
 export const PurchaseSuccess = ({ track }: { track: UserTrackMetadata }) => {
   const styles = useStyles()
   const { specialGreen, staticWhite } = useThemeColors()
+  const { onClose } = useDrawer('PremiumTrackPurchase')
   const { handle } = track.user
   const { title } = track
   const link = getTrackRoute(track, true)
@@ -71,6 +84,19 @@ export const PurchaseSuccess = ({ track }: { track: UserTrackMetadata }) => {
         shareData={handleTwitterShare}
         handle={handle}
         size='large'
+      />
+      <Button
+        onPress={onClose}
+        title={messages.viewTrack}
+        variant='commonAlt'
+        styles={{
+          root: styles.viewTrack,
+          text: styles.viewTrackText,
+          // @ts-ignore icon has ViewStyle prop for some reason, which does not understand the 'color' property
+          icon: styles.viewTrackIcon
+        }}
+        size='large'
+        icon={IconCaretRight}
       />
     </View>
   )


### PR DESCRIPTION
### Description

Native mobile.

Navigate to track screen in the background on successful purchase.
Add new "View Track" button below the twitter button on successful purchase.
Tapping on either this new button or closing the drawer with the X icon should take user to the track screen for the track they just purchased.

### How Has This Been Tested?

local native mobile dapp vs stage
