### PR TITLE
Dispatch $AUDIO matching challenges in non-prod envs

### DIFF
--- a/discovery-provider/src/tasks/index_user_bank.py
+++ b/discovery-provider/src/tasks/index_user_bank.py
@@ -38,6 +38,7 @@ from src.solana.constants import (
     FETCH_TX_SIGNATURES_BATCH_SIZE,
     TX_SIGNATURES_MAX_BATCHES,
     TX_SIGNATURES_RESIZE_LENGTH,
+    USDC_DECIMALS,
 )
 from src.solana.solana_client_manager import SolanaClientManager
 from src.solana.solana_helpers import (
@@ -654,25 +655,29 @@ def process_transfer_instruction(
                     "index_user_bank.py | Found purchase event but purchase_metadata is None"
                 )
                 return
-            # amount = int(
-            #     round(balance_changes[receiver_account]["change"]) / 10**USDC_DECIMALS
-            # )
-            # challenge_event_bus.dispatch(
-            #     ChallengeEvent.audio_matching_buyer,
-            #     slot,
-            #     sender_user_id,
-            #     {"track_id": purchase_metadata["id"], "amount": amount},
-            # )
-            # challenge_event_bus.dispatch(
-            #     ChallengeEvent.audio_matching_seller,
-            #     slot,
-            #     receiver_user_id,
-            #     {
-            #         "track_id": purchase_metadata["id"],
-            #         "sender_user_id": sender_user_id,
-            #         "amount": amount,
-            #     },
-            # )
+
+            env = shared_config["discprov"]["env"]
+            if env != "prod":
+                amount = int(
+                    round(balance_changes[receiver_account]["change"])
+                    / 10**USDC_DECIMALS
+                )
+                challenge_event_bus.dispatch(
+                    ChallengeEvent.audio_matching_buyer,
+                    slot,
+                    sender_user_id,
+                    {"track_id": purchase_metadata["id"], "amount": amount},
+                )
+                challenge_event_bus.dispatch(
+                    ChallengeEvent.audio_matching_seller,
+                    slot,
+                    receiver_user_id,
+                    {
+                        "track_id": purchase_metadata["id"],
+                        "sender_user_id": sender_user_id,
+                        "amount": amount,
+                    },
+                )
 
 
 class CreateTokenAccount(TypedDict):

--- a/discovery-provider/src/tasks/index_user_bank.py
+++ b/discovery-provider/src/tasks/index_user_bank.py
@@ -658,7 +658,7 @@ def process_transfer_instruction(
 
             # TODO: Remove on launch: https://linear.app/audius/issue/PAY-1987/remove-check-to-only-disburse-dollaraudio-matching-challenges-in-non
             env = shared_config["discprov"]["env"]
-            if env != "prod":
+            if env in ("stage", "dev"):
                 amount = int(
                     round(balance_changes[receiver_account]["change"])
                     / 10**USDC_DECIMALS

--- a/discovery-provider/src/tasks/index_user_bank.py
+++ b/discovery-provider/src/tasks/index_user_bank.py
@@ -656,6 +656,7 @@ def process_transfer_instruction(
                 )
                 return
 
+            # TODO: Remove on launch: https://linear.app/audius/issue/PAY-1987/remove-check-to-only-disburse-dollaraudio-matching-challenges-in-non
             env = shared_config["discprov"]["env"]
             if env != "prod":
                 amount = int(


### PR DESCRIPTION
### Description
Dispatch the $AUDIO matching challenges in `index_user_bank.py` but only if the env is not prod, so that we can test on stage and local.

### How Has This Been Tested?

Local stack