### PR TITLE
[C-3199] Fix Remix Settings Not Saving (Web)

### DIFF
--- a/packages/web/src/pages/upload-page/fields/RemixSettingsField/types.ts
+++ b/packages/web/src/pages/upload-page/fields/RemixSettingsField/types.ts
@@ -15,7 +15,7 @@ export const RemixSettingsFieldSchema = z
     [SHOW_REMIXES]: z.optional(z.boolean()),
     [IS_REMIX]: z.boolean(),
     [REMIX_LINK]: z.optional(z.string()),
-    parentTrackId: z.number().nullable()
+    parentTrackId: z.optional(z.number())
   })
   .refine((form) => !form[IS_REMIX] || form.parentTrackId, {
     message: messages.remixLinkError,


### PR DESCRIPTION
### Description

Remix settings modal was failing to save due to the parent remix id being nullable instead of optional

### How Has This Been Tested?

locally against prod