### PR TITLE
[C-3197] Fixes being unable to reopen Upload modals on mobile

### DIFF
--- a/packages/mobile/src/components/core/ContextualMenu.tsx
+++ b/packages/mobile/src/components/core/ContextualMenu.tsx
@@ -74,7 +74,7 @@ export const ContextualMenu = (props: ContextualMenuProps) => {
   const navigation = useNavigation()
 
   const handlePress = useCallback(() => {
-    navigation.push(menuScreenName)
+    navigation.navigate(menuScreenName)
   }, [navigation, menuScreenName])
 
   const defaultRenderValue = (value: string | string[]) => {


### PR DESCRIPTION
### Description

By using our custom stack navigator push method, we were inadvertently hitting our custom check to see if the navigation was a duplicate (that prevents double navigation on double click) and not cleaning up after the navigation finished. By switching to navigate, we ignore this problem entirely.

### How Has This Been Tested?

tested on sim