### PR TITLE
Make npm run protocol work without up

### DIFF
--- a/packages/compose/package.json
+++ b/packages/compose/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.1",
   "private": true,
   "scripts": {
-    "start": "cmd=\"${*:2:-up}\" && audius-compose $cmd"
+    "start": "./start.sh"
   },
   "dependencies": {
     "@audius/sdk": "*",

--- a/packages/compose/start.sh
+++ b/packages/compose/start.sh
@@ -1,0 +1,2 @@
+cmd="${@:-up}"
+audius-compose $cmd


### PR DESCRIPTION
### Description

Fix `npm run protocol`
I believe this is the best we can do without some crazy gymnastics.
`--` is necessary for the args because otherwise they are just params to `npm` itself

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._


```
npm run protocol
['/Users/ray/.local/bin/audius-compose', 'up']

npm run protocol up
['/Users/ray/.local/bin/audius-compose', 'up']

npm run protocol test up discovery-provider
['/Users/ray/.local/bin/audius-compose', 'test', 'up', 'discovery-provider']

npm run protocol up -- -d 3
['/Users/ray/.local/bin/audius-compose', 'up', '-d', '-3']
```

