### PR TITLE
Update package-lock to update ethereumjs-tx

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -116512,10 +116512,6 @@
         "safe-buffer": "^5.1.1"
       }
     },
-    "packages/identity-service/node_modules/ethereum-common": {
-      "version": "0.0.18",
-      "license": "MIT"
-    },
     "packages/identity-service/node_modules/ethereumjs-abi": {
       "version": "0.6.5",
       "license": "MIT",
@@ -116537,31 +116533,6 @@
         "elliptic": "^6.5.2",
         "ethereum-cryptography": "^0.1.3",
         "rlp": "^2.0.0"
-      }
-    },
-    "packages/identity-service/node_modules/ethereumjs-tx": {
-      "version": "1.3.7",
-      "license": "MPL-2.0",
-      "dependencies": {
-        "ethereum-common": "^0.0.18",
-        "ethereumjs-util": "^5.0.0"
-      }
-    },
-    "packages/identity-service/node_modules/ethereumjs-tx/node_modules/bn.js": {
-      "version": "4.12.0",
-      "license": "MIT"
-    },
-    "packages/identity-service/node_modules/ethereumjs-tx/node_modules/ethereumjs-util": {
-      "version": "5.2.1",
-      "license": "MPL-2.0",
-      "dependencies": {
-        "bn.js": "^4.11.0",
-        "create-hash": "^1.1.2",
-        "elliptic": "^6.5.2",
-        "ethereum-cryptography": "^0.1.3",
-        "ethjs-util": "^0.1.3",
-        "rlp": "^2.0.0",
-        "safe-buffer": "^5.1.1"
       }
     },
     "packages/identity-service/node_modules/ethereumjs-util": {
@@ -118996,14 +118967,6 @@
       },
       "engines": {
         "node": ">=8.0.0"
-      }
-    },
-    "packages/identity-service/node_modules/web3-eth-accounts/node_modules/ethereumjs-tx": {
-      "version": "2.1.2",
-      "license": "MPL-2.0",
-      "dependencies": {
-        "ethereumjs-common": "^1.5.0",
-        "ethereumjs-util": "^6.0.0"
       }
     },
     "packages/identity-service/node_modules/web3-eth-contract": {


### PR DESCRIPTION
### Description

The upgrade of ethereumjs-tx wasn't reflected in package-lock, because upgrading that dep changed it from not being hoisted to be hoisted. To resolve this I did:

```
cd packages/identity-service
npm remove ethereumjs-tx
npm install ethereumjs-tx@2.1.2
```

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._
