### PR TITLE
Debug ganache flakiness with verbose logging

### DIFF
--- a/eth-contracts/scripts/setup-predeployed-ganache.sh
+++ b/eth-contracts/scripts/setup-predeployed-ganache.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env sh
 
 set -e
+set -x
 
 cd $(dirname "$(readlink -f "$0")")/..
 
@@ -17,7 +18,7 @@ if [ -z "networkId" ]; then
 fi
 
 mkdir -p $dbPath
-npx ganache --logging.quiet --wallet.deterministic --wallet.totalAccounts 50 --database.dbPath "$dbPath" --miner.blockTime 1 --chain.networkId "$networkId" &
+npx ganache --wallet.deterministic --wallet.totalAccounts 50 --database.dbPath "$dbPath" --miner.blockTime 1 --chain.networkId "$networkId" &
 ganache_pid=$!
 
 npx truffle migrate --network predeploy


### PR DESCRIPTION
### Description

We are seeing flaky tests when attempting to build eth-ganache due to the setup-predeployed-ganache.sh script failing. [Example](https://app.circleci.com/pipelines/github/AudiusProject/audius-protocol/43636/workflows/f277865d-5788-4eae-a631-75deb88e8e89/jobs/561644)

### How Has This Been Tested?

CI