### PR TITLE
Improve local dev mediorum cpu use, enable hot reload

### DIFF
--- a/dev-tools/compose/docker-compose.storagev2.yml
+++ b/dev-tools/compose/docker-compose.storagev2.yml
@@ -4,6 +4,7 @@ services:
   storagev2:
     build:
       context: ${PROJECT_ROOT}/mediorum
+      dockerfile: Dockerfile.dev
       args:
         git_sha: '${GIT_COMMIT}'
     restart: unless-stopped
@@ -27,6 +28,7 @@ services:
     volumes:
       - mediorum:/data
       - legacy_creator_file_storage:/file_storage
+      - ${PROJECT_ROOT}/mediorum:/app
       - ${PROJECT_ROOT}/dev-tools:/tmp/dev-tools
       - ${PROJECT_ROOT}/packages/libs/src/eth-contracts:/tmp/eth-contracts # Used only in register script
     profiles:

--- a/dev-tools/startup/register.py
+++ b/dev-tools/startup/register.py
@@ -22,14 +22,16 @@ def main(replica):
     )
 
     serviceProviderFactory = w3.eth.contract(
-        address=registry.functions.getContract(b"ServiceProviderFactory").call(),
+        address=registry.functions.getContract(
+            b"ServiceProviderFactory".ljust(32, b"\0")
+        ).call(),
         abi=json.loads(
             (ETH_CONTRACTS_ABI_DIR / "ServiceProviderFactory.json").read_text()
         )["abi"],
     )
 
     staking = w3.eth.contract(
-        address=registry.functions.getContract(b"StakingProxy").call(),
+        address=registry.functions.getContract(b"StakingProxy".ljust(32, b"\0")).call(),
         abi=json.loads((ETH_CONTRACTS_ABI_DIR / "Staking.json").read_text())["abi"],
     )
 
@@ -47,7 +49,7 @@ def main(replica):
 
     try:
         serviceProviderFactory.functions.register(
-            b"content-node",
+            b"content-node".ljust(32, b"\0"),
             f"http://audius-protocol-creator-node-{replica}",
             200000 * (10 ** token.functions.decimals().call()),
             delegateOwnerWallet,

--- a/dev-tools/startup/storagev2.sh
+++ b/dev-tools/startup/storagev2.sh
@@ -21,4 +21,4 @@ if [ ! -f "/data/registered" ]; then
     touch /data/registered
 fi
 
-exec mediorum
+exec air

--- a/dev-tools/startup/storagev2.sh
+++ b/dev-tools/startup/storagev2.sh
@@ -10,9 +10,6 @@ fi
 if [ ! -f "/data/registered" ]; then
     num_nodes=$1
 
-    apk add --no-cache build-base python3-dev py3-pip
-    pip install 'web3==6.0.0b1'
-
     for i in $(seq 1 $num_nodes); do
       python3 /tmp/dev-tools/startup/register.py $i
     done

--- a/mediorum/Dockerfile
+++ b/mediorum/Dockerfile
@@ -20,7 +20,6 @@ COPY --from=builder /app/mediorum /bin/mediorum
 COPY --from=builder /app/mediorum-cmd /bin/mediorum-cmd
 
 # ARGs can be optionally defined with --build-arg while doing docker build eg in CI and then set to env vars
-# (copied from creator-node Dockerfile)
 ARG git_sha
 ENV GIT_SHA=$git_sha
 

--- a/mediorum/Dockerfile.dev
+++ b/mediorum/Dockerfile.dev
@@ -1,0 +1,18 @@
+FROM golang:alpine
+
+RUN apk add build-base make ffmpeg
+
+WORKDIR /app
+
+RUN go install github.com/cosmtrek/air@latest
+
+COPY go.mod go.sum ./
+RUN go mod graph | awk '{if ($1 !~ "@") print $2}' | xargs go get
+
+COPY . .
+RUN go build
+RUN go build -o mediorum-cmd cmd/main.go
+
+VOLUME ["/mediorum_data"]
+EXPOSE 1991
+ENTRYPOINT ["air"]

--- a/mediorum/Dockerfile.dev
+++ b/mediorum/Dockerfile.dev
@@ -1,6 +1,11 @@
-FROM golang:alpine
+FROM golang:alpine3.18
 
 RUN apk add build-base make ffmpeg
+
+# Required for service registration
+RUN apk add build-base python3-dev=3.11.6-r0 py3-pip
+RUN python3 -m pip install --upgrade pip
+RUN python3 -m pip install 'web3==6.6.1'
 
 WORKDIR /app
 

--- a/mediorum/Dockerfile.dev
+++ b/mediorum/Dockerfile.dev
@@ -3,7 +3,7 @@ FROM golang:alpine3.18
 RUN apk add build-base make ffmpeg
 
 # Required for service registration
-RUN apk add build-base python3-dev=3.11.6-r0 py3-pip
+RUN apk add curl build-base python3-dev=3.11.6-r0 py3-pip
 RUN python3 -m pip install --upgrade pip
 RUN python3 -m pip install 'web3==6.6.1'
 

--- a/mediorum/server/repair.go
+++ b/mediorum/server/repair.go
@@ -81,6 +81,8 @@ func (ss *MediorumServer) startRepairer() {
 			tracker.AbortedReason = "NOT_ENOUGH_PEERS"
 			tracker.FinishedAt = time.Now()
 			saveTracker()
+			// wait 1 minute before running again
+			time.Sleep(time.Minute * 1)
 			continue
 		}
 
@@ -90,6 +92,8 @@ func (ss *MediorumServer) startRepairer() {
 			tracker.AbortedReason = "DISK_FULL"
 			tracker.FinishedAt = time.Now()
 			saveTracker()
+			// wait 1 minute before running again
+			time.Sleep(time.Minute * 1)
 			continue
 		}
 


### PR DESCRIPTION
### Description

* When unable to find peers, mediorum spams itself to death and eats an entire CPU core. Add a smaller sleep than the normal 10min between repair runs
* Add new Dockerfile.dev for audius-compose. This enables hot-reloading with air (s/o theo for Q&A).

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._

```
npm run protocol
```

http://audius-protocol-creator-node-1/health_check
looks good.

```
audius-cmd create-user freddie_mercury
audius-cmd upload-track --from freddie_mercury --title "Bohemian Rhapsody"
```

When modifying a file, we see
```
server/repair.go has changed
building...
running...
```

**CPU Before:**
![image](https://github.com/AudiusProject/audius-protocol/assets/2731362/575cb175-24a7-4e4b-b146-b793d552b5e1)


**CPU After:**
<img width="667" alt="image" src="https://github.com/AudiusProject/audius-protocol/assets/2731362/42b74136-9b22-414b-931f-f8acc091cf31">
