### PR TITLE
[PAY-1999] Improve local stack, figure out issue creating usdc user banks

### DIFF
--- a/dev-tools/audius-compose
+++ b/dev-tools/audius-compose
@@ -364,7 +364,9 @@ def load_env(protocol_dir, service, environment):
 )
 @click.argument("services", nargs=-1)
 @click.pass_obj
+@click.pass_context
 def up(
+    ctx,
     protocol_dir,
     discovery_provider_replicas,
     elasticsearch_replicas,
@@ -383,6 +385,7 @@ def up(
 
     AAO_DIR = pathlib.Path(os.getenv("AAO_DIR", protocol_dir / "../anti-abuse-oracle"))
 
+    ctx.invoke(pull)
     sys.exit(
         subprocess.run(
             [

--- a/eth-contracts/Dockerfile
+++ b/eth-contracts/Dockerfile
@@ -12,10 +12,12 @@ COPY . .
 
 RUN npm run postinstall
 
+RUN ./scripts/setup-predeployed-ganache.sh /usr/db 1000000000000
+
 ARG CONTENT_NODE_VERSION
 ARG DISCOVERY_NODE_VERSION
 
-RUN ./scripts/setup-predeployed-ganache.sh /usr/db 1000000000000
+RUN ./scripts/setup-dev.sh /usr/db 1000000000000
 
 HEALTHCHECK --interval=5s --timeout=5s --retries=10 \
     CMD node -e "require('http').request('http://localhost:8545').end()" || exit 1

--- a/eth-contracts/scripts/setup-dev.sh
+++ b/eth-contracts/scripts/setup-dev.sh
@@ -21,6 +21,6 @@ mkdir -p $dbPath
 npx ganache --wallet.deterministic --wallet.totalAccounts 50 --database.dbPath "$dbPath" --miner.blockTime 1 --chain.networkId "$networkId" &
 ganache_pid=$!
 
-npx truffle migrate --network predeploy
+npx truffle exec --network predeploy scripts/setup-dev.js
 
 kill $ganache_pid


### PR DESCRIPTION
### Description

* Remove identity notifications (no longer used) - @alecsavvy for review there
* Make sure audius-compose up runs audius-compose pull first so you get the latest images. Since we tagged our solana test validator build as :latest, you need to explicitly run pull
* Separate setup-predeployed-ganache.sh from the actual service registration scripts in eth contracts. This will improve our startup time considerably because right now *every day* the discovery/content node version changes and forces you to rerun setup-predeployed-ganache.

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._

```
npm run protocol
```
