### PR TITLE
Actually fix follow artists step in sign up flow C-3206

### DIFF
--- a/packages/mobile/src/screens/signon/FirstFollows.tsx
+++ b/packages/mobile/src/screens/signon/FirstFollows.tsx
@@ -38,7 +38,6 @@ const FirstFollows = (props: FirstFollowsProps) => {
 
   const handleArtistsSelected = () => {
     dispatch(signOnActions.finishSignUp())
-    dispatch(signOnActions.followArtists(followArtists.selectedUserIds))
 
     track(
       make({

--- a/packages/web/src/common/store/pages/signon/sagas.js
+++ b/packages/web/src/common/store/pages/signon/sagas.js
@@ -498,6 +498,7 @@ function* signUp() {
         yield put(signOnActions.signUpSucceeded())
         yield put(signOnActions.sendWelcomeEmail(name))
         yield call(fetchAccountAsync, { isSignUp: true })
+        yield put(signOnActions.followArtists())
       },
       function* ({ timeout }) {
         if (timeout) {
@@ -739,14 +740,7 @@ function* watchConfigureMetaMask() {
 }
 
 function* watchFollowArtists() {
-  while (
-    yield all([
-      take(accountActions.fetchAccountSucceeded.type),
-      take(signOnActions.FOLLOW_ARTISTS)
-    ])
-  ) {
-    yield call(followArtists)
-  }
+  yield takeLatest(signOnActions.FOLLOW_ARTISTS, followArtists)
 }
 
 function* watchShowToast() {

--- a/packages/web/src/pages/sign-on/SignOnProvider.tsx
+++ b/packages/web/src/pages/sign-on/SignOnProvider.tsx
@@ -217,7 +217,6 @@ export class SignOnProvider extends Component<SignOnProps, SignOnState> {
         email,
         handle
       } = this.props.fields
-      this.props.followArtists(selectedUserIds)
       this.props.recordCompleteFollow(
         selectedUserIds.join('|'),
         selectedUserIds.length,
@@ -561,8 +560,6 @@ function mapDispatchToProps(dispatch: Dispatch) {
     nextPage: (isMobile: boolean) => dispatch(signOnAction.nextPage(isMobile)),
     previousPage: () => dispatch(signOnAction.previousPage()),
     goToPage: (page: Pages) => dispatch(signOnAction.goToPage(page)),
-    followArtists: (userIds: ID[]) =>
-      dispatch(signOnAction.followArtists(userIds)),
     addFollows: (userIds: ID[]) =>
       dispatch(signOnAction.addFollowArtists(userIds)),
     removeFollows: (userIds: ID[]) =>


### PR DESCRIPTION
### Description
Before:
- Artist follows failed upon signup if you started the session signed into another account

After:
- Fixed

### How Has This Been Tested?

Tested on mobile and web for two cases:
1. Started session fresh (signed out)
2. Started session signed into another account, then sign out or delete account and sign up with new account

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._
