### PR TITLE
Register multiple DNs on local stack

### DIFF
--- a/dev-tools/compose/nginx_ingress.conf
+++ b/dev-tools/compose/nginx_ingress.conf
@@ -39,6 +39,62 @@ server {
 
 }
 
+
+server {
+    listen      80;
+    server_name audius-protocol-discovery-provider-2;
+
+    location / {
+        resolver 127.0.0.11 valid=30s;
+        set $upstream audius-protocol-discovery-provider-2:5000;
+        proxy_pass http://$upstream;
+        proxy_set_header Host $http_host;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    }
+
+    location ~ ^/relay(/.*)?$ {
+        resolver 127.0.0.11 valid=30s;
+        proxy_pass http://relay:6001/relay$1;
+        proxy_set_header Host $http_host;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    }
+
+    location ^~ /healthz {
+        resolver 127.0.0.11 valid=30s;
+        proxy_pass http://healthz;
+        proxy_set_header Host $http_host;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    }
+}
+
+server {
+    listen      80;
+    server_name audius-protocol-discovery-provider-3;
+
+    location / {
+        resolver 127.0.0.11 valid=30s;
+        set $upstream audius-protocol-discovery-provider-3:5000;
+        proxy_pass http://$upstream;
+        proxy_set_header Host $http_host;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    }
+
+    location ~ ^/relay(/.*)?$ {
+        resolver 127.0.0.11 valid=30s;
+        proxy_pass http://relay:6001/relay$1;
+        proxy_set_header Host $http_host;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    }
+
+    location ^~ /healthz {
+        resolver 127.0.0.11 valid=30s;
+        proxy_pass http://healthz;
+        proxy_set_header Host $http_host;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    }
+
+}
+
 #
 # CREATOR NODE (mediorum)
 #

--- a/packages/discovery-provider/scripts/register.py
+++ b/packages/discovery-provider/scripts/register.py
@@ -57,8 +57,6 @@ def main():
 
     # Wait for health check to pass
     discprov_url = os.getenv("audius_discprov_url")
-    while not health_check(discprov_url):
-        time.sleep(1)
 
     token.functions.approve(
         staking.address,

--- a/packages/discovery-provider/scripts/register.py
+++ b/packages/discovery-provider/scripts/register.py
@@ -3,7 +3,6 @@
 import json
 import os
 import pathlib
-import time
 import urllib.parse
 import urllib.request
 
@@ -54,9 +53,6 @@ def main():
             "abi"
         ],
     )
-
-    # Wait for health check to pass
-    discprov_url = os.getenv("audius_discprov_url")
 
     token.functions.approve(
         staking.address,

--- a/packages/web/src/common/store/pages/audio-rewards/sagas.ts
+++ b/packages/web/src/common/store/pages/audio-rewards/sagas.ts
@@ -131,9 +131,15 @@ const getClaimingConfig = (
   remoteConfigInstance: RemoteConfigInstance,
   env: Env
 ) => {
-  const quorumSize = remoteConfigInstance.getRemoteVar(
-    IntKeys.ATTESTATION_QUORUM_SIZE
-  )
+  const { ENVIRONMENT } = env
+  let quorumSize
+  if (ENVIRONMENT === 'development') {
+    quorumSize = 2
+  } else {
+    quorumSize = remoteConfigInstance.getRemoteVar(
+      IntKeys.ATTESTATION_QUORUM_SIZE
+    )
+  }
   const maxClaimRetries = remoteConfigInstance.getRemoteVar(
     IntKeys.MAX_CLAIM_RETRIES
   )

--- a/solana-programs/scripts/deploy.sh
+++ b/solana-programs/scripts/deploy.sh
@@ -215,6 +215,7 @@ echo "Initalizing reward manager..."
 audius-reward-manager-cli init \
     --keypair "$reward_manager_pda_keypair" \
     --token-keypair "$reward_manager_token_pda_keypair" \
+    # TODO: PAY-2001: Re-deploy this with min-votes 3
     --min-votes 2 \
     --token-mint "$(solana address -k $token_keypair)"
 echo


### PR DESCRIPTION
### Description
Config to register 2 more DNs and fixes a bug preventing registration.

Dragons:
- Is there any reason we'd need to wait for health check in `register.py`?
- We should probably push a new image with [this](https://github.com/AudiusProject/audius-protocol/blob/0657660ddd18fd7dae558ca7c322220e2e9377c1/solana-programs/scripts/deploy.sh#L218) set to 3 eventually! https://linear.app/audius/issue/PAY-2001/push-new-solana-validator-image-for-local-dev-with-min-votes-set-to-3

### How Has This Been Tested?

Tested local stack + claiming a challenge.