### PR TITLE
[PAY-2003] Fix challenge disbursement with variable amounts

### DIFF
--- a/packages/common/src/models/AudioRewards.ts
+++ b/packages/common/src/models/AudioRewards.ts
@@ -109,6 +109,8 @@ export type UserChallengeState =
   | 'completed'
   | 'disbursed'
 
+export type SpecifierMap<T> = Record<Specifier, T>
+
 /**
  * A User Challenge that has been updated by the client to optimistically include any updates
  */
@@ -120,5 +122,5 @@ export type OptimisticUserChallenge = Omit<
   state: UserChallengeState
   totalAmount: number
   claimableAmount: number
-  undisbursedSpecifiers: Specifier[]
+  undisbursedSpecifiers: SpecifierMap<number>
 }

--- a/packages/common/src/services/audius-backend/AudiusBackend.ts
+++ b/packages/common/src/services/audius-backend/AudiusBackend.ts
@@ -3153,19 +3153,21 @@ export const audiusBackend = ({
     handle,
     recipientEthAddress,
     oracleEthAddress,
-    amount,
     quorumSize,
     endpoints,
     AAOEndpoint,
     parallelization,
     feePayerOverride
   }: {
-    challenges: { challenge_id: ChallengeRewardID; specifier: string }[]
+    challenges: {
+      challenge_id: ChallengeRewardID
+      specifier: string
+      amount: number
+    }[]
     userId: ID
     handle: string
     recipientEthAddress: string
     oracleEthAddress: string
-    amount: number
     quorumSize: number
     endpoints: string[]
     AAOEndpoint: string
@@ -3198,7 +3200,7 @@ export const audiusBackend = ({
       })
 
       const res = await attester.processChallenges(
-        challenges.map(({ specifier, challenge_id: challengeId }) => ({
+        challenges.map(({ specifier, challenge_id: challengeId, amount }) => ({
           specifier,
           challengeId,
           userId: encodedUserId,

--- a/packages/common/src/store/challenges/selectors/optimistic-challenges.ts
+++ b/packages/common/src/store/challenges/selectors/optimistic-challenges.ts
@@ -9,6 +9,7 @@ import { removeNullable } from 'utils/typeUtils'
 import {
   ChallengeRewardID,
   OptimisticUserChallenge,
+  SpecifierMap,
   UserChallenge,
   UserChallengeState
 } from '../../../models/AudioRewards'
@@ -109,7 +110,14 @@ const toOptimisticChallenge = (
         ? totalAmount
         : 0
       : undisbursed.reduce<number>((acc, val) => acc + val.amount, 0)
-  const undisbursedSpecifiers = undisbursed.map((c) => c.specifier)
+
+  const undisbursedSpecifiers: SpecifierMap<number> = undisbursed.reduce(
+    (acc, c) => {
+      acc[c.specifier] = c.amount
+      return acc
+    },
+    {} as SpecifierMap<number>
+  )
 
   return {
     ...challengeOverridden,

--- a/packages/common/src/store/pages/audio-rewards/slice.ts
+++ b/packages/common/src/store/pages/audio-rewards/slice.ts
@@ -1,6 +1,11 @@
 import { createSlice, PayloadAction } from '@reduxjs/toolkit'
 
-import { UserChallenge, ChallengeRewardID, Specifier } from '../../../models'
+import {
+  UserChallenge,
+  ChallengeRewardID,
+  Specifier,
+  SpecifierMap
+} from '../../../models'
 
 import {
   AudioRewardsClaim,
@@ -90,7 +95,7 @@ const slice = createSlice({
       state,
       action: PayloadAction<{
         challengeId: ChallengeRewardID
-        specifiers: Specifier[]
+        specifiers: SpecifierMap<number>
       }>
     ) => {
       const { challengeId, specifiers } = action.payload
@@ -105,7 +110,7 @@ const slice = createSlice({
       if (userChallenge.challenge_type === 'aggregate') {
         state.disbursedChallenges[challengeId] = ([] as string[]).concat(
           state.disbursedChallenges[challengeId] ?? [],
-          specifiers
+          Object.entries(specifiers).map(([s, _]) => s)
         )
         // All completed challenges that are disbursed are fully disbursed
         if (userChallenge?.is_complete) {

--- a/packages/common/src/store/pages/audio-rewards/types.ts
+++ b/packages/common/src/store/pages/audio-rewards/types.ts
@@ -1,4 +1,4 @@
-import { UserChallenge, ChallengeRewardID, Specifier } from '../../../models'
+import { UserChallenge, ChallengeRewardID, SpecifierMap } from '../../../models'
 
 export type TrendingRewardsModalType = 'tracks' | 'playlists' | 'underground'
 export type ChallengeRewardsModalType = ChallengeRewardID
@@ -13,7 +13,7 @@ export type ClaimState =
 
 export type AudioRewardsClaim = {
   challengeId: ChallengeRewardID
-  specifiers: Specifier[]
+  specifiers: SpecifierMap<number>
   amount: number
 }
 

--- a/packages/mobile/src/components/challenge-rewards-drawer/ChallengeRewardsDrawerProvider.tsx
+++ b/packages/mobile/src/components/challenge-rewards-drawer/ChallengeRewardsDrawerProvider.tsx
@@ -109,7 +109,7 @@ export const ChallengeRewardsDrawerProvider = () => {
         claim: {
           challengeId: modalType,
           specifiers: [challenge?.specifier ?? ''],
-          amount: challenge?.amount ?? 0
+          amount: challenge?.claimableAmount ?? 0
         },
         retryOnFailure: true
       })

--- a/packages/mobile/src/components/challenge-rewards-drawer/ChallengeRewardsDrawerProvider.tsx
+++ b/packages/mobile/src/components/challenge-rewards-drawer/ChallengeRewardsDrawerProvider.tsx
@@ -104,16 +104,18 @@ export const ChallengeRewardsDrawerProvider = () => {
   const AAOEndpoint = useRemoteVar(StringKeys.ORACLE_ENDPOINT)
   const hasConfig = (oracleEthAddress && AAOEndpoint && quorumSize > 0) || true
   const onClaim = useCallback(() => {
-    dispatch(
-      claimChallengeReward({
-        claim: {
-          challengeId: modalType,
-          specifiers: [challenge?.specifier ?? ''],
-          amount: challenge?.claimableAmount ?? 0
-        },
-        retryOnFailure: true
-      })
-    )
+    if (challenge) {
+      dispatch(
+        claimChallengeReward({
+          claim: {
+            challengeId: modalType,
+            specifiers: { [challenge.specifier]: challenge.amount },
+            amount: challenge?.claimableAmount ?? 0
+          },
+          retryOnFailure: true
+        })
+      )
+    }
   }, [dispatch, modalType, challenge])
 
   useEffect(() => {

--- a/packages/web/src/common/store/pages/audio-rewards/sagas.ts
+++ b/packages/web/src/common/store/pages/audio-rewards/sagas.ts
@@ -250,10 +250,13 @@ function* claimChallengeRewardAsync(
   }
   let aaoErrorCode
   try {
-    const challenges = specifiers.map((specifier) => ({
-      challenge_id: challengeId,
-      specifier
-    }))
+    const challenges = Object.entries(specifiers).map(
+      ([specifier, amount]) => ({
+        challenge_id: challengeId,
+        specifier,
+        amount
+      })
+    )
 
     const response: { error?: string; aaoErrorCode?: number } = yield* call(
       audiusBackendInstance.submitAndEvaluateAttestations,
@@ -263,7 +266,6 @@ function* claimChallengeRewardAsync(
         handle: currentUser.handle,
         recipientEthAddress: currentUser.wallet,
         oracleEthAddress,
-        amount,
         quorumSize,
         endpoints,
         AAOEndpoint,

--- a/packages/web/src/common/store/pages/audio-rewards/sagas.ts
+++ b/packages/web/src/common/store/pages/audio-rewards/sagas.ts
@@ -318,7 +318,7 @@ function* claimChallengeRewardAsync(
 
             // If this was an aggregate challenges with multiple specifiers,
             // then libs handles the retries and we shouldn't retry here.
-            if (specifiers.length > 1) {
+            if (specifiers.size > 1) {
               yield put(claimChallengeRewardFailed())
               break
             }

--- a/packages/web/src/common/store/pages/audio-rewards/store.test.ts
+++ b/packages/web/src/common/store/pages/audio-rewards/store.test.ts
@@ -70,7 +70,7 @@ function* saga() {
 
 const testClaim: AudioRewardsClaim = {
   challengeId: 'connect-verified',
-  specifiers: ['1'],
+  specifiers: { '1': 10 },
   amount: 10
 }
 const testUser = {

--- a/packages/web/src/pages/audio-rewards-page/components/modals/ChallengeRewards.tsx
+++ b/packages/web/src/pages/audio-rewards-page/components/modals/ChallengeRewards.tsx
@@ -334,7 +334,7 @@ const ChallengeRewardsBody = ({ dismissModal }: BodyProps) => {
             specifiers:
               challenge.challenge_type === 'aggregate'
                 ? challenge.undisbursedSpecifiers
-                : [challenge.specifier],
+                : { [challenge.specifier]: challenge.amount },
             amount: challenge.claimableAmount
           },
           retryOnFailure: true

--- a/packages/web/src/pages/audio-rewards-page/components/modals/ChallengeRewards.tsx
+++ b/packages/web/src/pages/audio-rewards-page/components/modals/ChallengeRewards.tsx
@@ -335,7 +335,7 @@ const ChallengeRewardsBody = ({ dismissModal }: BodyProps) => {
               challenge.challenge_type === 'aggregate'
                 ? challenge.undisbursedSpecifiers
                 : [challenge.specifier],
-            amount: challenge.amount
+            amount: challenge.claimableAmount
           },
           retryOnFailure: true
         })


### PR DESCRIPTION
### Description
Plumbs amount mapped per-specifier down to libs to attempt to claim the correct amounts.

Probably got a bit too fancy with this `SpecifierMap` thing when a `{specifier: string, amount: number}[]` would've been simpler. Not sure I like seeing `Object.entries` everywhere. Thoughts?

### How Has This Been Tested?

Successfully claimed 2 challenges with different amounts on local stack!
<img width="918" alt="Screenshot 2023-10-12 at 1 56 41 AM" src="https://github.com/AudiusProject/audius-protocol/assets/3893871/2ae025d8-6d1f-4b49-b36c-78381b9173a5">
