### PR TITLE
[PROTO-1326] Add more delist reasons

### DIFF
--- a/mediorum/ddl/add_delist_reasons.sql
+++ b/mediorum/ddl/add_delist_reasons.sql
@@ -1,27 +1,4 @@
-BEGIN;
-
-DO $$ BEGIN
-    ALTER TYPE delist_track_reason ADD VALUE IF NOT EXISTS 'ACR_COUNTER_NOTICE';
-EXCEPTION
-    WHEN duplicate_object THEN null;
-END $$;
-
-DO $$ BEGIN
-    ALTER TYPE delist_track_reason ADD VALUE IF NOT EXISTS 'DMCA_RETRACTION';
-EXCEPTION
-    WHEN duplicate_object THEN null;
-END $$;
-
-DO $$ BEGIN
-    ALTER TYPE delist_track_reason ADD VALUE IF NOT EXISTS 'DMCA_COUNTER_NOTICE';
-EXCEPTION
-    WHEN duplicate_object THEN null;
-END $$;
-
-DO $$ BEGIN
-    ALTER TYPE delist_track_reason ADD VALUE IF NOT EXISTS 'DMCA_AND_ACR_COUNTER_NOTICE';
-EXCEPTION
-    WHEN duplicate_object THEN null;
-END $$;
-
-COMMIT;
+ALTER TYPE delist_track_reason ADD VALUE IF NOT EXISTS 'ACR_COUNTER_NOTICE';
+ALTER TYPE delist_track_reason ADD VALUE IF NOT EXISTS 'DMCA_RETRACTION';
+ALTER TYPE delist_track_reason ADD VALUE IF NOT EXISTS 'DMCA_COUNTER_NOTICE';
+ALTER TYPE delist_track_reason ADD VALUE IF NOT EXISTS 'DMCA_AND_ACR_COUNTER_NOTICE';

--- a/mediorum/ddl/add_delist_reasons.sql
+++ b/mediorum/ddl/add_delist_reasons.sql
@@ -1,0 +1,27 @@
+BEGIN;
+
+DO $$ BEGIN
+    ALTER TYPE delist_track_reason ADD VALUE IF NOT EXISTS 'ACR_COUNTER_NOTICE';
+EXCEPTION
+    WHEN duplicate_object THEN null;
+END $$;
+
+DO $$ BEGIN
+    ALTER TYPE delist_track_reason ADD VALUE IF NOT EXISTS 'DMCA_RETRACTION';
+EXCEPTION
+    WHEN duplicate_object THEN null;
+END $$;
+
+DO $$ BEGIN
+    ALTER TYPE delist_track_reason ADD VALUE IF NOT EXISTS 'DMCA_COUNTER_NOTICE';
+EXCEPTION
+    WHEN duplicate_object THEN null;
+END $$;
+
+DO $$ BEGIN
+    ALTER TYPE delist_track_reason ADD VALUE IF NOT EXISTS 'DMCA_AND_ACR_COUNTER_NOTICE';
+EXCEPTION
+    WHEN duplicate_object THEN null;
+END $$;
+
+COMMIT;

--- a/mediorum/ddl/ddl.go
+++ b/mediorum/ddl/ddl.go
@@ -1,18 +1,12 @@
 package ddl
 
 import (
-	"context"
 	"crypto/md5"
 	"database/sql"
 	"encoding/hex"
 	"fmt"
-	"io"
 	"log"
-	"mediorum/cidutil"
 	"os"
-	"strings"
-	"sync"
-	"time"
 
 	_ "embed"
 
@@ -22,6 +16,9 @@ import (
 
 //go:embed delist_statuses.sql
 var delistStatusesDDL string
+
+//go:embed add_delist_reasons.sql
+var addDelistReasonsDDL string
 
 //go:embed drop_blobs.sql
 var dropBlobs string
@@ -37,9 +34,7 @@ func Migrate(db *sql.DB, bucket *blob.Bucket, myHost string) {
 	mustExec(db, mediorumMigrationTable)
 
 	runMigration(db, delistStatusesDDL)
-
-	// TODO: remove after this ran once on every node (when every node is >= v0.4.2)
-	migrateShardBucket(db, bucket)
+	runMigration(db, addDelistReasonsDDL)
 
 	runMigration(db, dropBlobs)
 
@@ -71,71 +66,6 @@ func mustExec(db *sql.DB, ddl string, va ...interface{}) {
 func md5string(s string) string {
 	hash := md5.Sum([]byte(s))
 	return hex.EncodeToString(hash[:])
-}
-
-func migrateShardBucket(db *sql.DB, bucket *blob.Bucket) {
-	h := "shardBucket"
-
-	var alreadyRan bool
-	db.QueryRow(`select count(*) = 1 from mediorum_migrations where hash = $1`, h).Scan(&alreadyRan)
-	if alreadyRan {
-		fmt.Printf("hash %s exists skipping ddl \n", h)
-		return
-	}
-
-	fmt.Println("starting sharding of CDK bucket")
-	start := time.Now()
-	ctx := context.Background()
-
-	// collect all keys
-	keys := []string{}
-	iter := bucket.List(nil)
-	for {
-		obj, err := iter.Next(ctx)
-		if err == io.EOF {
-			break
-		}
-		if err != nil {
-			log.Fatalf("error listing bucket: %v", err)
-		}
-		// ignore "my_cuckoo" key and keys that already migrated (in case of restart halfway through)
-		// also ignore .tmp files that fileblob creates
-		if strings.HasPrefix(obj.Key, "ba") && !strings.Contains(obj.Key, "/") && !strings.HasSuffix(obj.Key, ".tmp") {
-			keys = append(keys, obj.Key)
-		}
-	}
-
-	var wg sync.WaitGroup
-	sem := make(chan struct{}, 10) // semaphore to limit 10 uploads at a time
-
-	// migrate keys to sharded locations
-	for _, key := range keys {
-		wg.Add(1)
-
-		go func(k string) {
-			defer wg.Done()
-
-			sem <- struct{}{}
-			defer func() { <-sem }()
-
-			newKey := cidutil.ShardCID(k)
-
-			err := bucket.Copy(ctx, newKey, k, nil)
-			if err != nil {
-				log.Fatalf("error copying unsharded key to sharded key: %v (migrating %s to %s)", err, k, newKey)
-			}
-
-			err = bucket.Delete(ctx, k)
-			if err != nil {
-				log.Fatalf("error deleting old blob: %v (migrating %s to %s)", err, k, newKey)
-			}
-		}(key)
-	}
-
-	wg.Wait()
-
-	mustExec(db, `insert into mediorum_migrations values ($1, now()) on conflict do nothing`, h)
-	fmt.Printf("finished sharding CDK bucket. took %gm\n", time.Since(start).Minutes())
 }
 
 func logAndWriteToFile(message string, fileName string) {

--- a/packages/discovery-provider/ddl/migrations/0037_add_delist_reasons.sql
+++ b/packages/discovery-provider/ddl/migrations/0037_add_delist_reasons.sql
@@ -1,27 +1,4 @@
-BEGIN;
-
-DO $$ BEGIN
-    ALTER TYPE delist_track_reason ADD VALUE IF NOT EXISTS 'ACR_COUNTER_NOTICE';
-EXCEPTION
-    WHEN duplicate_object THEN null;
-END $$;
-
-DO $$ BEGIN
-    ALTER TYPE delist_track_reason ADD VALUE IF NOT EXISTS 'DMCA_RETRACTION';
-EXCEPTION
-    WHEN duplicate_object THEN null;
-END $$;
-
-DO $$ BEGIN
-    ALTER TYPE delist_track_reason ADD VALUE IF NOT EXISTS 'DMCA_COUNTER_NOTICE';
-EXCEPTION
-    WHEN duplicate_object THEN null;
-END $$;
-
-DO $$ BEGIN
-    ALTER TYPE delist_track_reason ADD VALUE IF NOT EXISTS 'DMCA_AND_ACR_COUNTER_NOTICE';
-EXCEPTION
-    WHEN duplicate_object THEN null;
-END $$;
-
-COMMIT;
+ALTER TYPE delist_track_reason ADD VALUE IF NOT EXISTS 'ACR_COUNTER_NOTICE';
+ALTER TYPE delist_track_reason ADD VALUE IF NOT EXISTS 'DMCA_RETRACTION';
+ALTER TYPE delist_track_reason ADD VALUE IF NOT EXISTS 'DMCA_COUNTER_NOTICE';
+ALTER TYPE delist_track_reason ADD VALUE IF NOT EXISTS 'DMCA_AND_ACR_COUNTER_NOTICE';

--- a/packages/discovery-provider/ddl/migrations/0037_add_delist_reasons.sql
+++ b/packages/discovery-provider/ddl/migrations/0037_add_delist_reasons.sql
@@ -1,0 +1,27 @@
+BEGIN;
+
+DO $$ BEGIN
+    ALTER TYPE delist_track_reason ADD VALUE IF NOT EXISTS 'ACR_COUNTER_NOTICE';
+EXCEPTION
+    WHEN duplicate_object THEN null;
+END $$;
+
+DO $$ BEGIN
+    ALTER TYPE delist_track_reason ADD VALUE IF NOT EXISTS 'DMCA_RETRACTION';
+EXCEPTION
+    WHEN duplicate_object THEN null;
+END $$;
+
+DO $$ BEGIN
+    ALTER TYPE delist_track_reason ADD VALUE IF NOT EXISTS 'DMCA_COUNTER_NOTICE';
+EXCEPTION
+    WHEN duplicate_object THEN null;
+END $$;
+
+DO $$ BEGIN
+    ALTER TYPE delist_track_reason ADD VALUE IF NOT EXISTS 'DMCA_AND_ACR_COUNTER_NOTICE';
+EXCEPTION
+    WHEN duplicate_object THEN null;
+END $$;
+
+COMMIT;

--- a/packages/discovery-provider/plugins/notifications/src/types/dn.ts
+++ b/packages/discovery-provider/plugins/notifications/src/types/dn.ts
@@ -835,7 +835,11 @@ export enum delist_user_reason {
 export enum delist_track_reason {
   'DMCA' = 'DMCA',
   'ACR' = 'ACR',
-  'MANUAL' = 'MANUAL'
+  'MANUAL' = 'MANUAL',
+  'ACR_COUNTER_NOTICE' = 'ACR_COUNTER_NOTICE',
+  'DMCA_RETRACTION' = 'DMCA_RETRACTION',
+  'DMCA_COUNTER_NOTICE' = 'DMCA_COUNTER_NOTICE',
+  'DMCA_AND_ACR_COUNTER_NOTICE' = 'DMCA_AND_ACR_COUNTER_NOTICE'
 }
 export enum delist_entity {
   'TRACKS' = 'TRACKS',

--- a/packages/discovery-provider/src/models/delisting/track_delist_status.py
+++ b/packages/discovery-provider/src/models/delisting/track_delist_status.py
@@ -9,7 +9,11 @@ from src.models.model_utils import RepresentableMixin
 class DelistTrackReason(str, enum.Enum):
     DMCA = "DMCA"
     ACR = "ACR"
-    MANUAL = "MANUAL"
+    MANUAL = "MANUAL",
+    ACR_COUNTER_NOTICE = "ACR_COUNTER_NOTICE",
+    DMCA_RETRACTION = "DMCA_RETRACTION",
+    DMCA_COUNTER_NOTICE = "DMCA_COUNTER_NOTICE",
+    DMCA_AND_ACR_COUNTER_NOTICE = "DMCA_AND_ACR_COUNTER_NOTICE"
 
 
 class TrackDelistStatus(Base, RepresentableMixin):

--- a/packages/sql-ts/res/content-node.ts
+++ b/packages/sql-ts/res/content-node.ts
@@ -181,6 +181,10 @@ export enum delist_track_reason {
   'DMCA' = 'DMCA',
   'ACR' = 'ACR',
   'MANUAL' = 'MANUAL',
+  'ACR_COUNTER_NOTICE' = 'ACR_COUNTER_NOTICE',
+  'DMCA_RETRACTION' = 'DMCA_RETRACTION',
+  'DMCA_COUNTER_NOTICE' = 'DMCA_COUNTER_NOTICE',
+  'DMCA_AND_ACR_COUNTER_NOTICE' = 'DMCA_AND_ACR_COUNTER_NOTICE',
 }
 export enum delist_entity {
   'tracks' = 'tracks',

--- a/packages/sql-ts/res/discovery-node.ts
+++ b/packages/sql-ts/res/discovery-node.ts
@@ -835,6 +835,10 @@ export enum delist_track_reason {
   'DMCA' = 'DMCA',
   'ACR' = 'ACR',
   'MANUAL' = 'MANUAL',
+  'ACR_COUNTER_NOTICE' = 'ACR_COUNTER_NOTICE',
+  'DMCA_RETRACTION' = 'DMCA_RETRACTION',
+  'DMCA_COUNTER_NOTICE' = 'DMCA_COUNTER_NOTICE',
+  'DMCA_AND_ACR_COUNTER_NOTICE' = 'DMCA_AND_ACR_COUNTER_NOTICE',
 }
 export enum delist_entity {
   'TRACKS' = 'TRACKS',

--- a/packages/trpc-server/src/db-tables.ts
+++ b/packages/trpc-server/src/db-tables.ts
@@ -836,6 +836,10 @@ export enum delist_track_reason {
   'DMCA' = 'DMCA',
   'ACR' = 'ACR',
   'MANUAL' = 'MANUAL',
+  'ACR_COUNTER_NOTICE' = 'ACR_COUNTER_NOTICE',
+  'DMCA_RETRACTION' = 'DMCA_RETRACTION',
+  'DMCA_COUNTER_NOTICE' = 'DMCA_COUNTER_NOTICE',
+  'DMCA_AND_ACR_COUNTER_NOTICE' = 'DMCA_AND_ACR_COUNTER_NOTICE',
 }
 export enum delist_entity {
   'TRACKS' = 'TRACKS',


### PR DESCRIPTION
### Description
Expands enum for track delist reasons in CN and DN.

### How Has This Been Tested?
Checked the db types on stage DN5 and CN6, and confirmed that new track delist statuses get indexed (they infinitely retry on other nodes that don't have the new enums).

```sql
SELECT enumlabel 
FROM pg_enum 
WHERE enumtypid = 'delist_track_reason'::regtype;
```

The main concern is that if some nodes aren't on postgres 11+ then they won't be able to do an `ALTER TYPE` query. I think the solution is that those nodes should just be forced to upgrade.