### PR TITLE
Make weekly cap migration idempotent

### DIFF
--- a/packages/discovery-provider/ddl/migrations/0036_add_challenge_disbursement_cap.sql
+++ b/packages/discovery-provider/ddl/migrations/0036_add_challenge_disbursement_cap.sql
@@ -1,12 +1,12 @@
 begin;
 
 alter table challenge_disbursements 
-add column created_at timestamp with time zone default now();
+add column if not exists created_at timestamp with time zone default now();
 
-create index idx_challenge_disbursements_created_at 
+create index if not exists idx_challenge_disbursements_created_at 
 on challenge_disbursements (created_at);
 
 alter table challenges
-add column weekly_pool integer default null;
+add column if not exists weekly_pool integer default null;
 
 commit;


### PR DESCRIPTION
### Description
This migration wasn't idempotent which was causing errors when trying to add another migration.

### How Has This Been Tested?

Ran `pg_migrate.sh` locally.
<img width="762" alt="Screenshot 2023-10-12 at 1 54 08 PM" src="https://github.com/AudiusProject/audius-protocol/assets/3893871/a6996db6-f352-4f8f-a0f9-3a89b39717cc">
