### PR TITLE
[C-3198] Improve ContextualMenu submit pattern

### DIFF
--- a/packages/web/src/components/data-entry/ContextualMenu.tsx
+++ b/packages/web/src/components/data-entry/ContextualMenu.tsx
@@ -42,7 +42,7 @@ type MenuFormProps = {
 
 const MenuForm = (props: MenuFormProps) => {
   const { isOpen, onClose, label, icon, menuFields } = props
-  const { handleSubmit, resetForm } = useFormikContext()
+  const { resetForm } = useFormikContext()
 
   const handleCancel = useCallback(() => {
     resetForm()
@@ -55,13 +55,11 @@ const MenuForm = (props: MenuFormProps) => {
         <ModalTitle title={label} icon={icon} />
       </ModalHeader>
       <ModalContent>
-        <Form>{menuFields}</Form>
+        <Form id={label}>{menuFields}</Form>
       </ModalContent>
       <ModalFooter>
         <Button
-          onClick={() => {
-            handleSubmit()
-          }}
+          form={label}
           type={ButtonType.PRIMARY}
           text={messages.save}
           buttonType='submit'


### PR DESCRIPTION
### Description

Improves ContextualMenu submit pattern by associating the "submit" button with the form. If a submit button is in a form, it automatically gets connected, but in this case, the button is outside the form, so we have to manually associate using "id" and "form" props