### PR TITLE
Remove COOLDOWN_CHALLENGE_IDS in get_attestation.py

### DIFF
--- a/packages/discovery-provider/src/queries/get_attestation.py
+++ b/packages/discovery-provider/src/queries/get_attestation.py
@@ -31,7 +31,6 @@ REWARDS_MANAGER_ACCOUNT = shared_config["solana"]["rewards_manager_account"]
 REWARDS_MANAGER_ACCOUNT_PUBLIC_KEY = None
 if REWARDS_MANAGER_ACCOUNT:
     REWARDS_MANAGER_ACCOUNT_PUBLIC_KEY = Pubkey.from_string(REWARDS_MANAGER_ACCOUNT)
-COOLDOWN_CHALLENGE_IDS = ["s", "b"]
 DATETIME_FORMAT_STRING = "%Y-%m-%d %H:%M:%S.%f+00"
 
 
@@ -167,7 +166,7 @@ def get_attestation(
     if disbursement:
         raise AttestationError(ALREADY_DISBURSED)
     now_utc = datetime.now(pytz.UTC)
-    if challenge_id in COOLDOWN_CHALLENGE_IDS and challenge.cooldown_days:
+    if challenge.cooldown_days:
         time_passed = now_utc - user_challenge.created_at
         if time_passed.days < challenge.cooldown_days:
             raise AttestationError(WAIT_FOR_COOLDOWN)


### PR DESCRIPTION
### Description
Don't need this anymore, can just use whether or not `cooldown_days` exists in the challenge.

### How Has This Been Tested?

Claimed challenges on local dev and confirmed they fail with `WAIT_FOR_COOLDOWN`.