### PR TITLE
Simplify claiming variable-amount challenges

### DIFF
--- a/packages/common/src/models/AudioRewards.ts
+++ b/packages/common/src/models/AudioRewards.ts
@@ -119,7 +119,7 @@ export type UserChallengeState =
   | 'completed'
   | 'disbursed'
 
-export type SpecifierMap<T> = Record<Specifier, T>
+export type SpecifierWithAmount = { specifier: string; amount: number }
 
 /**
  * A User Challenge that has been updated by the client to optimistically include any updates
@@ -132,5 +132,5 @@ export type OptimisticUserChallenge = Omit<
   state: UserChallengeState
   totalAmount: number
   claimableAmount: number
-  undisbursedSpecifiers: SpecifierMap<number>
+  undisbursedSpecifiers: SpecifierWithAmount[]
 }

--- a/packages/common/src/store/challenges/selectors/optimistic-challenges.ts
+++ b/packages/common/src/store/challenges/selectors/optimistic-challenges.ts
@@ -9,7 +9,7 @@ import { removeNullable } from 'utils/typeUtils'
 import {
   ChallengeRewardID,
   OptimisticUserChallenge,
-  SpecifierMap,
+  SpecifierWithAmount,
   UserChallenge,
   UserChallengeState
 } from '../../../models/AudioRewards'
@@ -111,12 +111,9 @@ const toOptimisticChallenge = (
         : 0
       : undisbursed.reduce<number>((acc, val) => acc + val.amount, 0)
 
-  const undisbursedSpecifiers: SpecifierMap<number> = undisbursed.reduce(
-    (acc, c) => {
-      acc[c.specifier] = c.amount
-      return acc
-    },
-    {} as SpecifierMap<number>
+  const undisbursedSpecifiers = undisbursed.reduce(
+    (acc, c) => [...acc, { specifier: c.specifier, amount: c.amount }],
+    [] as SpecifierWithAmount[]
   )
 
   return {

--- a/packages/common/src/store/pages/audio-rewards/slice.ts
+++ b/packages/common/src/store/pages/audio-rewards/slice.ts
@@ -4,7 +4,7 @@ import {
   UserChallenge,
   ChallengeRewardID,
   Specifier,
-  SpecifierMap
+  SpecifierWithAmount
 } from '../../../models'
 
 import {
@@ -95,7 +95,7 @@ const slice = createSlice({
       state,
       action: PayloadAction<{
         challengeId: ChallengeRewardID
-        specifiers: SpecifierMap<number>
+        specifiers: SpecifierWithAmount[]
       }>
     ) => {
       const { challengeId, specifiers } = action.payload
@@ -110,7 +110,7 @@ const slice = createSlice({
       if (userChallenge.challenge_type === 'aggregate') {
         state.disbursedChallenges[challengeId] = ([] as string[]).concat(
           state.disbursedChallenges[challengeId] ?? [],
-          Object.entries(specifiers).map(([s, _]) => s)
+          specifiers.map((s) => s.specifier)
         )
         // All completed challenges that are disbursed are fully disbursed
         if (userChallenge?.is_complete) {

--- a/packages/common/src/store/pages/audio-rewards/types.ts
+++ b/packages/common/src/store/pages/audio-rewards/types.ts
@@ -1,4 +1,8 @@
-import { UserChallenge, ChallengeRewardID, SpecifierMap } from '../../../models'
+import {
+  UserChallenge,
+  ChallengeRewardID,
+  SpecifierWithAmount
+} from '../../../models'
 
 export type TrendingRewardsModalType = 'tracks' | 'playlists' | 'underground'
 export type ChallengeRewardsModalType = ChallengeRewardID
@@ -13,7 +17,7 @@ export type ClaimState =
 
 export type AudioRewardsClaim = {
   challengeId: ChallengeRewardID
-  specifiers: SpecifierMap<number>
+  specifiers: SpecifierWithAmount[]
   amount: number
 }
 

--- a/packages/mobile/src/components/challenge-rewards-drawer/ChallengeRewardsDrawerProvider.tsx
+++ b/packages/mobile/src/components/challenge-rewards-drawer/ChallengeRewardsDrawerProvider.tsx
@@ -109,7 +109,12 @@ export const ChallengeRewardsDrawerProvider = () => {
         claimChallengeReward({
           claim: {
             challengeId: modalType,
-            specifiers: { [challenge.specifier]: challenge.amount },
+            specifiers: [
+              {
+                specifier: challenge.specifier,
+                amount: challenge.amount
+              }
+            ],
             amount: challenge?.claimableAmount ?? 0
           },
           retryOnFailure: true

--- a/packages/web/src/common/store/pages/audio-rewards/sagas.ts
+++ b/packages/web/src/common/store/pages/audio-rewards/sagas.ts
@@ -325,7 +325,7 @@ function* claimChallengeRewardAsync(
 
             // If this was an aggregate challenges with multiple specifiers,
             // then libs handles the retries and we shouldn't retry here.
-            if (specifiers.size > 1) {
+            if (specifiers.length > 1) {
               yield put(claimChallengeRewardFailed())
               break
             }

--- a/packages/web/src/common/store/pages/audio-rewards/sagas.ts
+++ b/packages/web/src/common/store/pages/audio-rewards/sagas.ts
@@ -256,13 +256,11 @@ function* claimChallengeRewardAsync(
   }
   let aaoErrorCode
   try {
-    const challenges = Object.entries(specifiers).map(
-      ([specifier, amount]) => ({
-        challenge_id: challengeId,
-        specifier,
-        amount
-      })
-    )
+    const challenges = specifiers.map(({ specifier, amount }) => ({
+      challenge_id: challengeId,
+      specifier,
+      amount
+    }))
 
     const response: { error?: string; aaoErrorCode?: number } = yield* call(
       audiusBackendInstance.submitAndEvaluateAttestations,

--- a/packages/web/src/common/store/pages/audio-rewards/store.test.ts
+++ b/packages/web/src/common/store/pages/audio-rewards/store.test.ts
@@ -70,7 +70,7 @@ function* saga() {
 
 const testClaim: AudioRewardsClaim = {
   challengeId: 'connect-verified',
-  specifiers: { '1': 10 },
+  specifiers: [{ specifier: '1', amount: 10 }],
   amount: 10
 }
 const testUser = {

--- a/packages/web/src/pages/audio-rewards-page/components/modals/ChallengeRewardsModal/ChallengeRewardsModal.tsx
+++ b/packages/web/src/pages/audio-rewards-page/components/modals/ChallengeRewardsModal/ChallengeRewardsModal.tsx
@@ -339,7 +339,9 @@ const ChallengeRewardsBody = ({ dismissModal }: BodyProps) => {
             specifiers:
               challenge.challenge_type === 'aggregate'
                 ? challenge.undisbursedSpecifiers
-                : { [challenge.specifier]: challenge.amount },
+                : [
+                    { specifier: challenge.specifier, amount: challenge.amount }
+                  ],
             amount: challenge.claimableAmount
           },
           retryOnFailure: true


### PR DESCRIPTION
### Description
Remove the unnecessarily fancy `SpecifierMap` type and use an array of `SpecifierWithAmount` instead (name suggestions?).
Just changing a type from https://github.com/AudiusProject/audius-protocol/pull/6316 really.

### How Has This Been Tested?

Confirmed claiming multiple rewards with varying amounts works on local stack.