### PR TITLE
Use more supported migration for mediorum workaround

### DIFF
--- a/mediorum/ddl/add_delist_reasons.sql
+++ b/mediorum/ddl/add_delist_reasons.sql
@@ -1,4 +1,19 @@
-ALTER TYPE delist_track_reason ADD VALUE IF NOT EXISTS 'ACR_COUNTER_NOTICE';
-ALTER TYPE delist_track_reason ADD VALUE IF NOT EXISTS 'DMCA_RETRACTION';
-ALTER TYPE delist_track_reason ADD VALUE IF NOT EXISTS 'DMCA_COUNTER_NOTICE';
-ALTER TYPE delist_track_reason ADD VALUE IF NOT EXISTS 'DMCA_AND_ACR_COUNTER_NOTICE';
+BEGIN;
+
+ALTER TABLE track_delist_statuses ALTER COLUMN reason TYPE VARCHAR(255);
+
+DROP TYPE IF EXISTS delist_track_reason;
+CREATE TYPE delist_track_reason AS ENUM (
+    'DMCA', 
+    'ACR', 
+    'MANUAL', 
+    'ACR_COUNTER_NOTICE', 
+    'DMCA_RETRACTION', 
+    'DMCA_COUNTER_NOTICE', 
+    'DMCA_AND_ACR_COUNTER_NOTICE'
+);
+
+ALTER TABLE track_delist_statuses 
+ALTER COLUMN reason TYPE delist_track_reason USING (reason::delist_track_reason);
+
+COMMIT;

--- a/packages/discovery-provider/ddl/migrations/0037_add_delist_reasons.sql
+++ b/packages/discovery-provider/ddl/migrations/0037_add_delist_reasons.sql
@@ -1,4 +1,19 @@
-ALTER TYPE delist_track_reason ADD VALUE IF NOT EXISTS 'ACR_COUNTER_NOTICE';
-ALTER TYPE delist_track_reason ADD VALUE IF NOT EXISTS 'DMCA_RETRACTION';
-ALTER TYPE delist_track_reason ADD VALUE IF NOT EXISTS 'DMCA_COUNTER_NOTICE';
-ALTER TYPE delist_track_reason ADD VALUE IF NOT EXISTS 'DMCA_AND_ACR_COUNTER_NOTICE';
+BEGIN;
+
+ALTER TABLE track_delist_statuses ALTER COLUMN reason TYPE VARCHAR(255);
+
+DROP TYPE IF EXISTS delist_track_reason;
+CREATE TYPE delist_track_reason AS ENUM (
+    'DMCA', 
+    'ACR', 
+    'MANUAL', 
+    'ACR_COUNTER_NOTICE', 
+    'DMCA_RETRACTION', 
+    'DMCA_COUNTER_NOTICE', 
+    'DMCA_AND_ACR_COUNTER_NOTICE'
+);
+
+ALTER TABLE track_delist_statuses 
+ALTER COLUMN reason TYPE delist_track_reason USING (reason::delist_track_reason);
+
+COMMIT;


### PR DESCRIPTION
### Description
For some reason, content nodes are wrapping SQL in transactions even when setting `SkipDefaultTransaction=true`. This changes a migration to work inside a transaction (and to work before postgres 11 because `ALTER TYPE` wasn't supported before then). Also updates the discovery migration for consistency.

### How Has This Been Tested?
- Ran the full tag (not just SQL) on stage CN8 and prod CN5
- `audius-compose test run "mediorum-unittests"` now passes