### PR TITLE
[C-3213] Add deprecated label to HarmonyButton

### DIFF
--- a/packages/stems/src/components/Button/Button.tsx
+++ b/packages/stems/src/components/Button/Button.tsx
@@ -30,7 +30,9 @@ const TYPE_STYLE_MAP = {
   [Type.DESTRUCTIVE]: styles.destructive
 }
 
-/** @deprecated (use `HarmonyButton` for new code)
+/**
+ * @deprecated
+ * Deprecated: (use `Button` from \@audius/harmony)
  *
  * A common Button component. Includes a few variants and options to
  * include and position icons.

--- a/packages/stems/src/components/HarmonyButton/HarmonyButton.tsx
+++ b/packages/stems/src/components/HarmonyButton/HarmonyButton.tsx
@@ -40,6 +40,9 @@ const TYPE_STYLE_MAP: { [k in HarmonyButtonType]: string } = {
 }
 
 /**
+ * @deprecated
+ * Deprecated: (use `Button` from \@audius/harmony)
+ *
  * A common Button component. Includes a few variants and options to
  * include and position icons.
  */


### PR DESCRIPTION
### Description

Adds deprecation warning to HarmonyButton and updates the suggested use for the stems/Button deprecation warning.