### PR TITLE
Tune celery worker concurrency

### DIFF
--- a/packages/discovery-provider/scripts/start.sh
+++ b/packages/discovery-provider/scripts/start.sh
@@ -65,10 +65,10 @@ else
         [ -e /var/celerybeat.pid ] && rm /var/celerybeat.pid
         audius_service=beat celery -A src.worker.celery beat --schedule=/var/celerybeat-schedule --pidfile=/var/celerybeat.pid --loglevel WARNING 2>&1 | tee >(logger -t beat) &
         # start worker dedicated to indexing ACDC
-        audius_service=index_nethermind_worker celery -A src.worker.celery worker -Q index_nethermind --loglevel $audius_discprov_loglevel 2>&1 | tee >(logger -t index_nethermind_worker) &
+        audius_service=worker celery -A src.worker.celery worker -Q index_nethermind --loglevel $audius_discprov_loglevel --hostname=index_nethermind --concurrency 1 2>&1 | tee >(logger -t index_nethermind_worker) &
 
         # start other workers with remaining CPUs
-        audius_service=worker celery -A src.worker.celery worker --max-memory-per-child 300000 --loglevel $audius_discprov_loglevel --concurrency=$(($(nproc) - 1)) 2>&1 | tee >(logger -t worker) &
+        audius_service=worker celery -A src.worker.celery worker --max-memory-per-child 300000 --loglevel $audius_discprov_loglevel --concurrency=$(($(nproc) - 5)) 2>&1 | tee >(logger -t worker) &
 
     fi
 fi


### PR DESCRIPTION
### Description
Follow up to reduce memory usage. If a worker has 7 child processes with max mem of 300 MB each, that single worker can consume 2.1 GB. We've seen cases where a single worker can run out of memory and take down the whole server. This reduces memory usage for other tasks without impacting indexing ACDC.

The downside is it might impact how up to date other tasks are but I'm keeping an eye on that as well.

### How Has This Been Tested?
Tested on sandbox. Confirmed indexing and resource usage is healthy. Typical mem usage went from 2 GB to 1 GB.

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._
