### PR TITLE
[C-3216] Add react-slot, implement asChild for drag/drop

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9787,7 +9787,6 @@
     },
     "node_modules/@radix-ui/react-compose-refs": {
       "version": "1.0.1",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.13.10"
@@ -10100,8 +10099,8 @@
     },
     "node_modules/@radix-ui/react-slot": {
       "version": "1.0.2",
-      "dev": true,
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.0.2.tgz",
+      "integrity": "sha512-YeTpuq4deV+6DusvVUW4ivBgnkHwECUu0BiN43L5UCDFgdhsRUWAghhTF5MbvNTPzmiFOx90asDSUjWuCNapwg==",
       "dependencies": {
         "@babel/runtime": "^7.13.10",
         "@radix-ui/react-compose-refs": "1.0.1"
@@ -127306,6 +127305,7 @@
         "@optimizely/optimizely-sdk": "4.9.2",
         "@project-serum/anchor": "0.24.2",
         "@project-serum/sol-wallet-adapter": "0.2.5",
+        "@radix-ui/react-slot": "^1.0.2",
         "@react-spring/web": "9.7.2",
         "@reduxjs/toolkit": "1.6.1",
         "@sentry/browser": "7.65.0",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -67,6 +67,7 @@
     "@optimizely/optimizely-sdk": "4.9.2",
     "@project-serum/anchor": "0.24.2",
     "@project-serum/sol-wallet-adapter": "0.2.5",
+    "@radix-ui/react-slot": "^1.0.2",
     "@react-spring/web": "9.7.2",
     "@reduxjs/toolkit": "1.6.1",
     "@sentry/browser": "7.65.0",

--- a/packages/web/src/components/dragndrop/Draggable.tsx
+++ b/packages/web/src/components/dragndrop/Draggable.tsx
@@ -1,6 +1,7 @@
 import { DragEvent, ReactNode, useCallback } from 'react'
 
 import { ID } from '@audius/common'
+import { Slot } from '@radix-ui/react-slot'
 import { useDispatch } from 'react-redux'
 
 import { DragDropKind, drag, drop } from 'store/dragndrop/slice'
@@ -24,6 +25,7 @@ export type DraggableProps = {
   children: ReactNode
   onDrag?: () => void
   onDrop?: () => void
+  asChild?: boolean
 }
 
 export const Draggable = (props: DraggableProps) => {
@@ -38,6 +40,7 @@ export const Draggable = (props: DraggableProps) => {
     onDrag,
     onDrop,
     children,
+    asChild,
     ...otherProps // passed to child
   } = props
   const dispatch = useDispatch()
@@ -84,8 +87,10 @@ export const Draggable = (props: DraggableProps) => {
     onDrop?.()
   }, [dispatch, onDrop])
 
+  const Comp = asChild ? Slot : 'div'
+
   return (
-    <div
+    <Comp
       draggable={!isDisabled}
       className={styles.draggable}
       onDragStart={handleDragStart}
@@ -93,6 +98,6 @@ export const Draggable = (props: DraggableProps) => {
       {...otherProps}
     >
       {children}
-    </div>
+    </Comp>
   )
 }

--- a/packages/web/src/components/dragndrop/Droppable.tsx
+++ b/packages/web/src/components/dragndrop/Droppable.tsx
@@ -1,13 +1,13 @@
 import {
   useState,
   useCallback,
-  cloneElement,
   ReactElement,
   DragEvent,
   ReactNode
 } from 'react'
 
 import { ID, useDebouncedCallback } from '@audius/common'
+import { Slot } from '@radix-ui/react-slot'
 import cn from 'classnames'
 import { useSelector } from 'react-redux'
 
@@ -29,10 +29,10 @@ export type DroppableProps = {
   acceptOwner?: boolean
 } & (
   | {
-      forward: true
+      asChild: true
       children: ReactElement
     }
-  | { forward?: false; children: ReactNode }
+  | { asChild?: false; children: ReactNode }
 )
 
 export const Droppable = (props: DroppableProps) => {
@@ -46,7 +46,7 @@ export const Droppable = (props: DroppableProps) => {
     disabled,
     acceptOwner = true,
     children,
-    forward
+    asChild
   } = props
   const { id, kind, index, isOwner } = useSelector(selectDragnDropState)
   const [hovered, setHovered] = useState(false)
@@ -113,9 +113,7 @@ export const Droppable = (props: DroppableProps) => {
     ...(canDrop ? droppableHandlerProps : {})
   }
 
-  if (forward) {
-    return cloneElement(children, droppableProps)
-  }
+  const Comp = asChild ? Slot : 'div'
 
-  return <div {...droppableProps}>{children}</div>
+  return <Comp {...droppableProps}>{children}</Comp>
 }

--- a/packages/web/src/components/nav/desktop/LeftNavLink.tsx
+++ b/packages/web/src/components/nav/desktop/LeftNavLink.tsx
@@ -30,8 +30,8 @@ export const LeftNavLink = (props: LeftNavLinkProps) => {
 
 type LeftNavDroppableProps = SetOptional<
   DroppableProps,
-  'hoverClassName' | 'activeClassName' | 'inactiveClassName' | 'forward'
-> & { forward?: false }
+  'hoverClassName' | 'activeClassName' | 'inactiveClassName'
+>
 
 export const LeftNavDroppable = (props: LeftNavDroppableProps) => {
   const { kind } = useSelector(selectDragnDropState)


### PR DESCRIPTION
### Description

Adds `asChild` pattern using @radiux-ui/react-slot. This will be very helpful for harmony components, where we can change the underlying element of our components easily.

This will be used to improve the table render logic, by removing the wrapping divs that drag/drop used to force.

https://medium.com/@bryanmylee/aschild-in-react-svelte-vue-and-solid-for-render-delegation-645c73650ced