### PR TITLE
[PAY-1954] Fix display of $0 existing balance on web purchase form

### DIFF
--- a/packages/mobile/src/components/premium-track-purchase-drawer/PurchaseSummaryTable.tsx
+++ b/packages/mobile/src/components/premium-track-purchase-drawer/PurchaseSummaryTable.tsx
@@ -1,4 +1,4 @@
-import { formatPrice } from '@audius/common'
+import { formatPrice, isNullOrUndefined } from '@audius/common'
 import { View } from 'react-native'
 
 import { Text } from 'app/components/core'
@@ -82,7 +82,7 @@ export const PurchaseSummaryTable = ({
             <Text>{messages.price(formatPrice(extraAmount))}</Text>
           </View>
         ) : null}
-        {existingBalance ? (
+        {!isNullOrUndefined(existingBalance) && existingBalance > 0 ? (
           <View style={styles.summaryRow}>
             <Text>{messages.existingBalance}</Text>
             <Text>{messages.subtractPrice(formatPrice(existingBalance))}</Text>

--- a/packages/web/src/components/premium-content-purchase-modal/components/PurchaseSummaryTable.tsx
+++ b/packages/web/src/components/premium-content-purchase-modal/components/PurchaseSummaryTable.tsx
@@ -1,4 +1,4 @@
-import { formatPrice, isNullOrUndefined } from '@audius/common'
+import { formatPrice } from '@audius/common'
 
 import { SummaryTable, SummaryTableItem } from 'components/summary-table'
 
@@ -42,7 +42,7 @@ export const PurchaseSummaryTable = ({
       value: messages.price(formatPrice(extraAmount))
     })
   }
-  if (!isNullOrUndefined(existingBalance)) {
+  if (existingBalance) {
     items.push({
       id: 'existingBalance',
       label: messages.existingBalance,

--- a/packages/web/src/components/premium-content-purchase-modal/components/PurchaseSummaryTable.tsx
+++ b/packages/web/src/components/premium-content-purchase-modal/components/PurchaseSummaryTable.tsx
@@ -1,4 +1,4 @@
-import { formatPrice } from '@audius/common'
+import { formatPrice, isNullOrUndefined } from '@audius/common'
 
 import { SummaryTable, SummaryTableItem } from 'components/summary-table'
 
@@ -42,7 +42,7 @@ export const PurchaseSummaryTable = ({
       value: messages.price(formatPrice(extraAmount))
     })
   }
-  if (existingBalance) {
+  if (!isNullOrUndefined(existingBalance) && existingBalance > 0) {
     items.push({
       id: 'existingBalance',
       label: messages.existingBalance,


### PR DESCRIPTION
### Description
Fixes PAY-1954

#6317 Changed the check in the web version of the premium content form to show the existing balance line if it's defined. We were leaning on the falsey check to exclude `0`. So this adds an explicit > 0 check and makes it consistent between web/mobile

### How Has This Been Tested?
Tested locally in Chrome against Staging
