### PR TITLE
[PROTO-1349] Build healthz in discovery workflow to ensure staging availability

### DIFF
--- a/.circleci/src/workflows/discovery.yml
+++ b/.circleci/src/workflows/discovery.yml
@@ -56,6 +56,13 @@ jobs:
       filters:
         branches:
           only: /^main$/
+  - push-docker-image:
+      name: push-healthz
+      context: [Vercel, dockerhub]
+      service: healthz
+      filters:
+        branches:
+          only: main
 
   - lint-discovery-provider:
       name: lint-discovery-provider
@@ -87,6 +94,7 @@ jobs:
         - push-pedalboard-sla-auditor
         - push-comms
         - push-trpc
+        - push-healthz
       filters:
         branches:
           only: main


### PR DESCRIPTION
### Description

Preemptive fix for [audius-docker-compose PR](https://github.com/AudiusProject/audius-docker-compose/pull/384). If audius-docker-compose is updated with a git sha that healthz hasn't been built for, pull will fail.

### How Has This Been Tested?

Will verify push-healthz is run on main when landed.