### PR TITLE
[PAY-1973] Fix Android crash and buy button text for purchase flow

### DIFF
--- a/packages/mobile/src/components/fields/PriceField.tsx
+++ b/packages/mobile/src/components/fields/PriceField.tsx
@@ -68,7 +68,7 @@ export const PriceField = (props: TextFieldProps) => {
       {...props}
       value={humanizedValue ?? undefined}
       onChange={handlePriceChange}
-      onBlur={handlePriceBlur}
+      onEndEditing={handlePriceBlur}
     />
   )
 }

--- a/packages/mobile/src/components/premium-track-purchase-drawer/PremiumTrackPurchaseDrawer.tsx
+++ b/packages/mobile/src/components/premium-track-purchase-drawer/PremiumTrackPurchaseDrawer.tsx
@@ -46,7 +46,7 @@ const { getPurchaseContentFlowStage, getPurchaseContentError } =
 const PREMIUM_TRACK_PURCHASE_MODAL_NAME = 'PremiumTrackPurchase'
 
 const messages = {
-  buy: (price: string) => `Buy $${price}`,
+  buy: 'Buy',
   title: 'Complete Purchase',
   summary: 'Summary',
   artistCut: 'Artist Cut',
@@ -169,6 +169,13 @@ const PremiumTrackPurchaseDrawerHeader = ({
   )
 }
 
+const getButtonText = (isUnlocking: boolean, amountDue: number) =>
+  isUnlocking
+    ? messages.purchasing
+    : amountDue > 0
+    ? `${messages.buy} $${formatPrice(amountDue)}`
+    : messages.buy
+
 // The bulk of the form rendering is in a nested component because we want access
 // to the FormikContext, which can only be used in a component which is a descendant
 // of the `<Formik />` component
@@ -191,6 +198,7 @@ const RenderForm = ({ track }: { track: PurchasableTrackMetadata }) => {
 
   const { stage, error, isUnlocking, purchaseSummaryValues } =
     usePurchaseContentFormState({ price })
+  const { amountDue } = purchaseSummaryValues
 
   const isPurchaseSuccessful = stage === PurchaseContentStage.FINISH
 
@@ -260,11 +268,7 @@ const RenderForm = ({ track }: { track: PurchasableTrackMetadata }) => {
           <Button
             onPress={submitForm}
             disabled={isUnlocking}
-            title={
-              isUnlocking
-                ? messages.purchasing
-                : messages.buy(formatPrice(price))
-            }
+            title={getButtonText(isUnlocking, amountDue)}
             variant={'primary'}
             size='large'
             color={specialLightGreen}


### PR DESCRIPTION
### Description
Fixes PAY-1973

Pretty simple issue: I am not a seasoned RN developer and did not realize that [you shouldn't attempt to read text from `onBlur` events](https://reactnative.dev/docs/textinput#onblur) 😅 . 

I also noticed that the buy button was not showing the correct values on mobile and fixed that while I was at it.

### How Has This Been Tested?
Tested on Pixel 5 and iOS simulator against staging
