### PR TITLE
[C-3215] Fix transaction table error

### DIFF
--- a/packages/web/src/components/table/Table.tsx
+++ b/packages/web/src/components/table/Table.tsx
@@ -475,18 +475,17 @@ export const Table = ({
       style: CSSProperties
     }) => {
       const row = rows[index]
+      if (!row) return
+
       prepareRow(row)
 
-      let render
-      if (isEmptyRow(row)) {
-        render = renderSkeletonRow
-      } else {
-        render = isReorderable
-          ? renderReorderableRow
-          : isTracksTable
-          ? renderDraggableRow
-          : renderTableRow
-      }
+      const render = isEmptyRow(row)
+        ? renderSkeletonRow
+        : isReorderable
+        ? renderReorderableRow
+        : isTracksTable
+        ? renderDraggableRow
+        : renderTableRow
       return render(row, key, { ...row.getRowProps({ style }) })
     },
     [


### PR DESCRIPTION
### Description

Fixes issue where quickly scrolling through a virtualized table can result in buffer overflow index issue. The fix is to just return null for overflow rows.