### PR TITLE
[C-2769] Migrate from altool to notarytool

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3484,6 +3484,56 @@
         "global-tunnel-ng": "^2.7.1"
       }
     },
+    "node_modules/@electron/notarize": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@electron/notarize/-/notarize-2.1.0.tgz",
+      "integrity": "sha512-Q02xem1D0sg4v437xHgmBLxI2iz/fc0D4K7fiVWHa/AnW8o7D751xyKNXgziA6HrTOme9ul1JfWN5ark8WH1xA==",
+      "dev": true,
+      "dependencies": {
+        "debug": "^4.1.1",
+        "fs-extra": "^9.0.1",
+        "promise-retry": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@electron/notarize/node_modules/fs-extra": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
+      "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
+      "dev": true,
+      "dependencies": {
+        "at-least-node": "^1.0.0",
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@electron/notarize/node_modules/jsonfile": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
+      "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
+      "dev": true,
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/@electron/notarize/node_modules/universalify": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
+      "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
+      "dev": true,
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
     "node_modules/@electron/universal": {
       "version": "1.2.0",
       "dev": true,
@@ -40550,15 +40600,6 @@
     "node_modules/electron-log": {
       "version": "3.0.9",
       "license": "MIT"
-    },
-    "node_modules/electron-notarize": {
-      "version": "0.1.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "debug": "^4.1.1",
-        "fs-extra": "^8.0.1"
-      }
     },
     "node_modules/electron-osx-sign": {
       "version": "0.6.0",
@@ -101829,6 +101870,7 @@
       "version": "5.4.2",
       "resolved": "https://registry.npmjs.org/@ethersproject/bignumber/-/bignumber-5.4.2.tgz",
       "integrity": "sha512-oIBDhsKy5bs7j36JlaTzFgNPaZjiNDOXsdSgSpXRucUl+UA6L/1YLlFeI3cPAoodcenzF4nxNPV13pcy7XbWjA==",
+      "extraneous": true,
       "funding": [
         {
           "type": "individual",
@@ -101845,15 +101887,11 @@
         "bn.js": "^4.11.9"
       }
     },
-    "packages/discovery-provider/plugins/pedalboard/apps/relay/node_modules/@audius/sdk/node_modules/@ethersproject/bignumber/node_modules/bn.js": {
-      "version": "4.12.0",
-      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
-      "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA=="
-    },
     "packages/discovery-provider/plugins/pedalboard/apps/relay/node_modules/@audius/sdk/node_modules/@ethersproject/bytes": {
       "version": "5.4.0",
       "resolved": "https://registry.npmjs.org/@ethersproject/bytes/-/bytes-5.4.0.tgz",
       "integrity": "sha512-H60ceqgTHbhzOj4uRc/83SCN9d+BSUnOkrr2intevqdtEMO1JFVZ1XL84OEZV+QjV36OaZYxtnt4lGmxcGsPfA==",
+      "extraneous": true,
       "funding": [
         {
           "type": "individual",
@@ -101872,6 +101910,7 @@
       "version": "5.4.0",
       "resolved": "https://registry.npmjs.org/@ethersproject/constants/-/constants-5.4.0.tgz",
       "integrity": "sha512-tzjn6S7sj9+DIIeKTJLjK9WGN2Tj0P++Z8ONEIlZjyoTkBuODN+0VfhAyYksKi43l1Sx9tX2VlFfzjfmr5Wl3Q==",
+      "extraneous": true,
       "funding": [
         {
           "type": "individual",
@@ -101890,6 +101929,7 @@
       "version": "5.4.0",
       "resolved": "https://registry.npmjs.org/@ethersproject/keccak256/-/keccak256-5.4.0.tgz",
       "integrity": "sha512-FBI1plWet+dPUvAzPAeHzRKiPpETQzqSUWR1wXJGHVWi4i8bOSrpC3NwpkPjgeXG7MnugVc1B42VbfnQikyC/A==",
+      "extraneous": true,
       "funding": [
         {
           "type": "individual",
@@ -101909,6 +101949,7 @@
       "version": "5.4.1",
       "resolved": "https://registry.npmjs.org/@ethersproject/logger/-/logger-5.4.1.tgz",
       "integrity": "sha512-DZ+bRinnYLPw1yAC64oRl0QyVZj43QeHIhVKfD/+YwSz4wsv1pfwb5SOFjz+r710YEWzU6LrhuSjpSO+6PeE4A==",
+      "extraneous": true,
       "funding": [
         {
           "type": "individual",
@@ -101924,6 +101965,7 @@
       "version": "5.4.0",
       "resolved": "https://registry.npmjs.org/@ethersproject/sha2/-/sha2-5.4.0.tgz",
       "integrity": "sha512-siheo36r1WD7Cy+bDdE1BJ8y0bDtqXCOxRMzPa4bV1TGt/eTUUt03BHoJNB6reWJD8A30E/pdJ8WFkq+/uz4Gg==",
+      "extraneous": true,
       "funding": [
         {
           "type": "individual",
@@ -101944,6 +101986,7 @@
       "version": "5.4.0",
       "resolved": "https://registry.npmjs.org/@ethersproject/strings/-/strings-5.4.0.tgz",
       "integrity": "sha512-k/9DkH5UGDhv7aReXLluFG5ExurwtIpUfnDNhQA29w896Dw3i4uDTz01Quaptbks1Uj9kI8wo9tmW73wcIEaWA==",
+      "extraneous": true,
       "funding": [
         {
           "type": "individual",
@@ -101965,6 +102008,7 @@
       "resolved": "https://registry.npmjs.org/eth-sig-util/-/eth-sig-util-2.5.4.tgz",
       "integrity": "sha512-aCMBwp8q/4wrW4QLsF/HYBOSA7TpLKmkVwP3pYQNkEEseW2Rr8Z5Uxc9/h6HX+OG3tuHo+2bINVSihIeBfym6A==",
       "deprecated": "Deprecated in favor of '@metamask/eth-sig-util'",
+      "extraneous": true,
       "dependencies": {
         "ethereumjs-abi": "0.6.8",
         "ethereumjs-util": "^5.1.1",
@@ -101972,29 +102016,11 @@
         "tweetnacl-util": "^0.15.0"
       }
     },
-    "packages/discovery-provider/plugins/pedalboard/apps/relay/node_modules/@audius/sdk/node_modules/eth-sig-util/node_modules/bn.js": {
-      "version": "4.12.0",
-      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
-      "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA=="
-    },
-    "packages/discovery-provider/plugins/pedalboard/apps/relay/node_modules/@audius/sdk/node_modules/eth-sig-util/node_modules/ethereumjs-util": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-5.2.1.tgz",
-      "integrity": "sha512-v3kT+7zdyCm1HIqWlLNrHGqHGLpGYIhjeHxQjnDXjLT2FyGJDsd3LWMYUo7pAFRrk86CR3nUJfhC81CCoJNNGQ==",
-      "dependencies": {
-        "bn.js": "^4.11.0",
-        "create-hash": "^1.1.2",
-        "elliptic": "^6.5.2",
-        "ethereum-cryptography": "^0.1.3",
-        "ethjs-util": "^0.1.3",
-        "rlp": "^2.0.0",
-        "safe-buffer": "^5.1.1"
-      }
-    },
     "packages/discovery-provider/plugins/pedalboard/apps/relay/node_modules/@audius/sdk/node_modules/ethers": {
       "version": "5.4.7",
       "resolved": "https://registry.npmjs.org/ethers/-/ethers-5.4.7.tgz",
       "integrity": "sha512-iZc5p2nqfWK1sj8RabwsPM28cr37Bpq7ehTQ5rWExBr2Y09Sn1lDKZOED26n+TsZMye7Y6mIgQ/1cwpSD8XZew==",
+      "extraneous": true,
       "funding": [
         {
           "type": "individual",
@@ -102036,28 +102062,6 @@
         "@ethersproject/wallet": "5.4.0",
         "@ethersproject/web": "5.4.0",
         "@ethersproject/wordlists": "5.4.0"
-      }
-    },
-    "packages/discovery-provider/plugins/pedalboard/apps/relay/node_modules/@audius/sdk/node_modules/ethers/node_modules/@ethersproject/solidity": {
-      "version": "5.4.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/solidity/-/solidity-5.4.0.tgz",
-      "integrity": "sha512-XFQTZ7wFSHOhHcV1DpcWj7VXECEiSrBuv7JErJvB9Uo+KfCdc3QtUZV+Vjh/AAaYgezUEKbCtE6Khjm44seevQ==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
-        },
-        {
-          "type": "individual",
-          "url": "https://www.buymeacoffee.com/ricmoo"
-        }
-      ],
-      "dependencies": {
-        "@ethersproject/bignumber": "^5.4.0",
-        "@ethersproject/bytes": "^5.4.0",
-        "@ethersproject/keccak256": "^5.4.0",
-        "@ethersproject/sha2": "^5.4.0",
-        "@ethersproject/strings": "^5.4.0"
       }
     },
     "packages/discovery-provider/plugins/pedalboard/apps/relay/node_modules/@babel/code-frame": {
@@ -102357,14 +102361,6 @@
         "node": ">= 6"
       }
     },
-    "packages/discovery-provider/plugins/pedalboard/apps/relay/node_modules/@types/bn.js": {
-      "version": "4.11.6",
-      "resolved": "https://registry.npmjs.org/@types/bn.js/-/bn.js-4.11.6.tgz",
-      "integrity": "sha512-pqr857jrp2kPuO9uRjZ3PwnJTjoQy+fcdxvBTvHm6dkmEL9q+hDD/2j/0ELOBPtPnS8LjCX0gI9nbl8lVkadpg==",
-      "dependencies": {
-        "@types/node": "*"
-      }
-    },
     "packages/discovery-provider/plugins/pedalboard/apps/relay/node_modules/@types/jest": {
       "version": "26.0.24",
       "resolved": "https://registry.npmjs.org/@types/jest/-/jest-26.0.24.tgz",
@@ -102378,7 +102374,8 @@
     "packages/discovery-provider/plugins/pedalboard/apps/relay/node_modules/@types/node": {
       "version": "15.14.9",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-15.14.9.tgz",
-      "integrity": "sha512-qjd88DrCxupx/kJD5yQgZdcYKZKSIGBVDIBE1/LTGcNm3d2Np/jxojkdePDdfnBHJc5W7vSMpbJ1aB7p/Py69A=="
+      "integrity": "sha512-qjd88DrCxupx/kJD5yQgZdcYKZKSIGBVDIBE1/LTGcNm3d2Np/jxojkdePDdfnBHJc5W7vSMpbJ1aB7p/Py69A==",
+      "dev": true
     },
     "packages/discovery-provider/plugins/pedalboard/apps/relay/node_modules/acorn-globals": {
       "version": "6.0.0",
@@ -102807,21 +102804,6 @@
       "engines": {
         "node": ">=4"
       }
-    },
-    "packages/discovery-provider/plugins/pedalboard/apps/relay/node_modules/eth-lib": {
-      "version": "0.2.8",
-      "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.8.tgz",
-      "integrity": "sha512-ArJ7x1WcWOlSpzdoTBX8vkwlkSQ85CjjifSZtV4co64vWxSV8geWfPI9x4SVYu3DSxnX4yWFVTtGL+j9DUFLNw==",
-      "dependencies": {
-        "bn.js": "^4.11.6",
-        "elliptic": "^6.4.0",
-        "xhr-request-promise": "^0.1.2"
-      }
-    },
-    "packages/discovery-provider/plugins/pedalboard/apps/relay/node_modules/eth-lib/node_modules/bn.js": {
-      "version": "4.12.0",
-      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
-      "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA=="
     },
     "packages/discovery-provider/plugins/pedalboard/apps/relay/node_modules/eth-sig-util": {
       "version": "3.0.1",
@@ -103462,11 +103444,6 @@
         }
       }
     },
-    "packages/discovery-provider/plugins/pedalboard/apps/relay/node_modules/eventemitter3": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.4.tgz",
-      "integrity": "sha512-rlaVLnVxtxvoyLsQQFBx53YmXHDxRIzzTLbdfxqi4yocpSjAxXwkU0cScM5JgSKMqEhrZpnvQ2D9gjylR0AimQ=="
-    },
     "packages/discovery-provider/plugins/pedalboard/apps/relay/node_modules/expect": {
       "version": "26.6.2",
       "resolved": "https://registry.npmjs.org/expect/-/expect-26.6.2.tgz",
@@ -103527,11 +103504,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "packages/discovery-provider/plugins/pedalboard/apps/relay/node_modules/hashids": {
-      "version": "2.2.10",
-      "resolved": "https://registry.npmjs.org/hashids/-/hashids-2.2.10.tgz",
-      "integrity": "sha512-nXnYums7F8B5Y+GSThutLPlKMaamW1yjWNZVt0WModiJfdjaDZHnhYTWblS+h1OoBx3yjwiBwxldPP3nIbFSSA=="
     },
     "packages/discovery-provider/plugins/pedalboard/apps/relay/node_modules/html-encoding-sniffer": {
       "version": "2.0.1",
@@ -104139,11 +104111,6 @@
         "node": ">=8"
       }
     },
-    "packages/discovery-provider/plugins/pedalboard/apps/relay/node_modules/js-sha3": {
-      "version": "0.5.7",
-      "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.5.7.tgz",
-      "integrity": "sha512-GII20kjaPX0zJ8wzkTbNDYMY7msuZcTWk8S5UOh6806Jq/wz1J8/bnr8uGU0DAUmYDjj2Mr4X1cW8v/GLYnR+g=="
-    },
     "packages/discovery-provider/plugins/pedalboard/apps/relay/node_modules/jsdom": {
       "version": "16.7.0",
       "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-16.7.0.tgz",
@@ -104213,12 +104180,6 @@
       "engines": {
         "node": ">=10"
       }
-    },
-    "packages/discovery-provider/plugins/pedalboard/apps/relay/node_modules/micro-aes-gcm": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/micro-aes-gcm/-/micro-aes-gcm-0.3.3.tgz",
-      "integrity": "sha512-wetPK288r0FyTzrWKkX9fNAKlJE+//bdQWpucWwx1Ei/MyFgBgN/0Ex1G3sTm4WR+2ATReGKzDQBYVpuwhho/A==",
-      "deprecated": "Switch to @noble/ciphers for security updates"
     },
     "packages/discovery-provider/plugins/pedalboard/apps/relay/node_modules/node-notifier": {
       "version": "8.0.2",
@@ -104532,371 +104493,6 @@
       "engines": {
         "node": ">=10"
       }
-    },
-    "packages/discovery-provider/plugins/pedalboard/apps/relay/node_modules/web3": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/web3/-/web3-1.7.1.tgz",
-      "integrity": "sha512-RKVdyZ5FuVEykj62C1o2tc0teJciSOh61jpVB9yb344dBHO3ZV4XPPP24s/PPqIMXmVFN00g2GD9M/v1SoHO/A==",
-      "hasInstallScript": true,
-      "dependencies": {
-        "web3-bzz": "1.7.1",
-        "web3-core": "1.7.1",
-        "web3-eth": "1.7.1",
-        "web3-eth-personal": "1.7.1",
-        "web3-net": "1.7.1",
-        "web3-shh": "1.7.1",
-        "web3-utils": "1.7.1"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
-    "packages/discovery-provider/plugins/pedalboard/apps/relay/node_modules/web3-bzz": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/web3-bzz/-/web3-bzz-1.7.1.tgz",
-      "integrity": "sha512-sVeUSINx4a4pfdnT+3ahdRdpDPvZDf4ZT/eBF5XtqGWq1mhGTl8XaQAk15zafKVm6Onq28vN8abgB/l+TrG8kA==",
-      "hasInstallScript": true,
-      "dependencies": {
-        "@types/node": "^12.12.6",
-        "got": "9.6.0",
-        "swarm-js": "^0.1.40"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
-    "packages/discovery-provider/plugins/pedalboard/apps/relay/node_modules/web3-bzz/node_modules/@types/node": {
-      "version": "12.20.55",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.55.tgz",
-      "integrity": "sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ=="
-    },
-    "packages/discovery-provider/plugins/pedalboard/apps/relay/node_modules/web3-core": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/web3-core/-/web3-core-1.7.1.tgz",
-      "integrity": "sha512-HOyDPj+4cNyeNPwgSeUkhtS0F+Pxc2obcm4oRYPW5ku6jnTO34pjaij0us+zoY3QEusR8FfAKVK1kFPZnS7Dzw==",
-      "dependencies": {
-        "@types/bn.js": "^4.11.5",
-        "@types/node": "^12.12.6",
-        "bignumber.js": "^9.0.0",
-        "web3-core-helpers": "1.7.1",
-        "web3-core-method": "1.7.1",
-        "web3-core-requestmanager": "1.7.1",
-        "web3-utils": "1.7.1"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
-    "packages/discovery-provider/plugins/pedalboard/apps/relay/node_modules/web3-core-helpers": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/web3-core-helpers/-/web3-core-helpers-1.7.1.tgz",
-      "integrity": "sha512-xn7Sx+s4CyukOJdlW8bBBDnUCWndr+OCJAlUe/dN2wXiyaGRiCWRhuQZrFjbxLeBt1fYFH7uWyYHhYU6muOHgw==",
-      "dependencies": {
-        "web3-eth-iban": "1.7.1",
-        "web3-utils": "1.7.1"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
-    "packages/discovery-provider/plugins/pedalboard/apps/relay/node_modules/web3-core-method": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/web3-core-method/-/web3-core-method-1.7.1.tgz",
-      "integrity": "sha512-383wu5FMcEphBFl5jCjk502JnEg3ugHj7MQrsX7DY76pg5N5/dEzxeEMIJFCN6kr5Iq32NINOG3VuJIyjxpsEg==",
-      "dependencies": {
-        "@ethersproject/transactions": "^5.0.0-beta.135",
-        "web3-core-helpers": "1.7.1",
-        "web3-core-promievent": "1.7.1",
-        "web3-core-subscriptions": "1.7.1",
-        "web3-utils": "1.7.1"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
-    "packages/discovery-provider/plugins/pedalboard/apps/relay/node_modules/web3-core-promievent": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/web3-core-promievent/-/web3-core-promievent-1.7.1.tgz",
-      "integrity": "sha512-Vd+CVnpPejrnevIdxhCkzMEywqgVbhHk/AmXXceYpmwA6sX41c5a65TqXv1i3FWRJAz/dW7oKz9NAzRIBAO/kA==",
-      "dependencies": {
-        "eventemitter3": "4.0.4"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
-    "packages/discovery-provider/plugins/pedalboard/apps/relay/node_modules/web3-core-requestmanager": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/web3-core-requestmanager/-/web3-core-requestmanager-1.7.1.tgz",
-      "integrity": "sha512-/EHVTiMShpZKiq0Jka0Vgguxi3vxq1DAHKxg42miqHdUsz4/cDWay2wGALDR2x3ofDB9kqp7pb66HsvQImQeag==",
-      "dependencies": {
-        "util": "^0.12.0",
-        "web3-core-helpers": "1.7.1",
-        "web3-providers-http": "1.7.1",
-        "web3-providers-ipc": "1.7.1",
-        "web3-providers-ws": "1.7.1"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
-    "packages/discovery-provider/plugins/pedalboard/apps/relay/node_modules/web3-core-subscriptions": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/web3-core-subscriptions/-/web3-core-subscriptions-1.7.1.tgz",
-      "integrity": "sha512-NZBsvSe4J+Wt16xCf4KEtBbxA9TOwSVr8KWfUQ0tC2KMdDYdzNswl0Q9P58xaVuNlJ3/BH+uDFZJJ5E61BSA1Q==",
-      "dependencies": {
-        "eventemitter3": "4.0.4",
-        "web3-core-helpers": "1.7.1"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
-    "packages/discovery-provider/plugins/pedalboard/apps/relay/node_modules/web3-core/node_modules/@types/node": {
-      "version": "12.20.55",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.55.tgz",
-      "integrity": "sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ=="
-    },
-    "packages/discovery-provider/plugins/pedalboard/apps/relay/node_modules/web3-eth": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/web3-eth/-/web3-eth-1.7.1.tgz",
-      "integrity": "sha512-Uz3gO4CjTJ+hMyJZAd2eiv2Ur1uurpN7sTMATWKXYR/SgG+SZgncnk/9d8t23hyu4lyi2GiVL1AqVqptpRElxg==",
-      "dependencies": {
-        "web3-core": "1.7.1",
-        "web3-core-helpers": "1.7.1",
-        "web3-core-method": "1.7.1",
-        "web3-core-subscriptions": "1.7.1",
-        "web3-eth-abi": "1.7.1",
-        "web3-eth-accounts": "1.7.1",
-        "web3-eth-contract": "1.7.1",
-        "web3-eth-ens": "1.7.1",
-        "web3-eth-iban": "1.7.1",
-        "web3-eth-personal": "1.7.1",
-        "web3-net": "1.7.1",
-        "web3-utils": "1.7.1"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
-    "packages/discovery-provider/plugins/pedalboard/apps/relay/node_modules/web3-eth-abi": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/web3-eth-abi/-/web3-eth-abi-1.7.1.tgz",
-      "integrity": "sha512-8BVBOoFX1oheXk+t+uERBibDaVZ5dxdcefpbFTWcBs7cdm0tP8CD1ZTCLi5Xo+1bolVHNH2dMSf/nEAssq5pUA==",
-      "dependencies": {
-        "@ethersproject/abi": "5.0.7",
-        "web3-utils": "1.7.1"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
-    "packages/discovery-provider/plugins/pedalboard/apps/relay/node_modules/web3-eth-abi/node_modules/@ethersproject/abi": {
-      "version": "5.0.7",
-      "resolved": "https://registry.npmjs.org/@ethersproject/abi/-/abi-5.0.7.tgz",
-      "integrity": "sha512-Cqktk+hSIckwP/W8O47Eef60VwmoSC/L3lY0+dIBhQPCNn9E4V7rwmm2aFrNRRDJfFlGuZ1khkQUOc3oBX+niw==",
-      "dependencies": {
-        "@ethersproject/address": "^5.0.4",
-        "@ethersproject/bignumber": "^5.0.7",
-        "@ethersproject/bytes": "^5.0.4",
-        "@ethersproject/constants": "^5.0.4",
-        "@ethersproject/hash": "^5.0.4",
-        "@ethersproject/keccak256": "^5.0.3",
-        "@ethersproject/logger": "^5.0.5",
-        "@ethersproject/properties": "^5.0.3",
-        "@ethersproject/strings": "^5.0.4"
-      }
-    },
-    "packages/discovery-provider/plugins/pedalboard/apps/relay/node_modules/web3-eth-accounts": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/web3-eth-accounts/-/web3-eth-accounts-1.7.1.tgz",
-      "integrity": "sha512-3xGQ2bkTQc7LFoqGWxp5cQDrKndlX05s7m0rAFVoyZZODMqrdSGjMPMqmWqHzJRUswNEMc+oelqSnGBubqhguQ==",
-      "dependencies": {
-        "@ethereumjs/common": "^2.5.0",
-        "@ethereumjs/tx": "^3.3.2",
-        "crypto-browserify": "3.12.0",
-        "eth-lib": "0.2.8",
-        "ethereumjs-util": "^7.0.10",
-        "scrypt-js": "^3.0.1",
-        "uuid": "3.3.2",
-        "web3-core": "1.7.1",
-        "web3-core-helpers": "1.7.1",
-        "web3-core-method": "1.7.1",
-        "web3-utils": "1.7.1"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
-    "packages/discovery-provider/plugins/pedalboard/apps/relay/node_modules/web3-eth-accounts/node_modules/uuid": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
-      "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==",
-      "deprecated": "Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.",
-      "bin": {
-        "uuid": "bin/uuid"
-      }
-    },
-    "packages/discovery-provider/plugins/pedalboard/apps/relay/node_modules/web3-eth-contract": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/web3-eth-contract/-/web3-eth-contract-1.7.1.tgz",
-      "integrity": "sha512-HpnbkPYkVK3lOyos2SaUjCleKfbF0SP3yjw7l551rAAi5sIz/vwlEzdPWd0IHL7ouxXbO0tDn7jzWBRcD3sTbA==",
-      "dependencies": {
-        "@types/bn.js": "^4.11.5",
-        "web3-core": "1.7.1",
-        "web3-core-helpers": "1.7.1",
-        "web3-core-method": "1.7.1",
-        "web3-core-promievent": "1.7.1",
-        "web3-core-subscriptions": "1.7.1",
-        "web3-eth-abi": "1.7.1",
-        "web3-utils": "1.7.1"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
-    "packages/discovery-provider/plugins/pedalboard/apps/relay/node_modules/web3-eth-ens": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/web3-eth-ens/-/web3-eth-ens-1.7.1.tgz",
-      "integrity": "sha512-DVCF76i9wM93DrPQwLrYiCw/UzxFuofBsuxTVugrnbm0SzucajLLNftp3ITK0c4/lV3x9oo5ER/wD6RRMHQnvw==",
-      "dependencies": {
-        "content-hash": "^2.5.2",
-        "eth-ens-namehash": "2.0.8",
-        "web3-core": "1.7.1",
-        "web3-core-helpers": "1.7.1",
-        "web3-core-promievent": "1.7.1",
-        "web3-eth-abi": "1.7.1",
-        "web3-eth-contract": "1.7.1",
-        "web3-utils": "1.7.1"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
-    "packages/discovery-provider/plugins/pedalboard/apps/relay/node_modules/web3-eth-iban": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/web3-eth-iban/-/web3-eth-iban-1.7.1.tgz",
-      "integrity": "sha512-XG4I3QXuKB/udRwZdNEhdYdGKjkhfb/uH477oFVMLBqNimU/Cw8yXUI5qwFKvBHM+hMQWfzPDuSDEDKC2uuiMg==",
-      "dependencies": {
-        "bn.js": "^4.11.9",
-        "web3-utils": "1.7.1"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
-    "packages/discovery-provider/plugins/pedalboard/apps/relay/node_modules/web3-eth-iban/node_modules/bn.js": {
-      "version": "4.12.0",
-      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
-      "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA=="
-    },
-    "packages/discovery-provider/plugins/pedalboard/apps/relay/node_modules/web3-eth-personal": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/web3-eth-personal/-/web3-eth-personal-1.7.1.tgz",
-      "integrity": "sha512-02H6nFBNfNmFjMGZL6xcDi0r7tUhxrUP91FTFdoLyR94eIJDadPp4rpXfG7MVES873i1PReh4ep5pSCHbc3+Pg==",
-      "dependencies": {
-        "@types/node": "^12.12.6",
-        "web3-core": "1.7.1",
-        "web3-core-helpers": "1.7.1",
-        "web3-core-method": "1.7.1",
-        "web3-net": "1.7.1",
-        "web3-utils": "1.7.1"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
-    "packages/discovery-provider/plugins/pedalboard/apps/relay/node_modules/web3-eth-personal/node_modules/@types/node": {
-      "version": "12.20.55",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.55.tgz",
-      "integrity": "sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ=="
-    },
-    "packages/discovery-provider/plugins/pedalboard/apps/relay/node_modules/web3-net": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/web3-net/-/web3-net-1.7.1.tgz",
-      "integrity": "sha512-8yPNp2gvjInWnU7DCoj4pIPNhxzUjrxKlODsyyXF8j0q3Z2VZuQp+c63gL++r2Prg4fS8t141/HcJw4aMu5sVA==",
-      "dependencies": {
-        "web3-core": "1.7.1",
-        "web3-core-method": "1.7.1",
-        "web3-utils": "1.7.1"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
-    "packages/discovery-provider/plugins/pedalboard/apps/relay/node_modules/web3-providers-http": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/web3-providers-http/-/web3-providers-http-1.7.1.tgz",
-      "integrity": "sha512-dmiO6G4dgAa3yv+2VD5TduKNckgfR97VI9YKXVleWdcpBoKXe2jofhdvtafd42fpIoaKiYsErxQNcOC5gI/7Vg==",
-      "dependencies": {
-        "web3-core-helpers": "1.7.1",
-        "xhr2-cookies": "1.1.0"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
-    "packages/discovery-provider/plugins/pedalboard/apps/relay/node_modules/web3-providers-ipc": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/web3-providers-ipc/-/web3-providers-ipc-1.7.1.tgz",
-      "integrity": "sha512-uNgLIFynwnd5M9ZC0lBvRQU5iLtU75hgaPpc7ZYYR+kjSk2jr2BkEAQhFVJ8dlqisrVmmqoAPXOEU0flYZZgNQ==",
-      "dependencies": {
-        "oboe": "2.1.5",
-        "web3-core-helpers": "1.7.1"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
-    "packages/discovery-provider/plugins/pedalboard/apps/relay/node_modules/web3-providers-ws": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/web3-providers-ws/-/web3-providers-ws-1.7.1.tgz",
-      "integrity": "sha512-Uj0n5hdrh0ESkMnTQBsEUS2u6Unqdc7Pe4Zl+iZFb7Yn9cIGsPJBl7/YOP4137EtD5ueXAv+MKwzcelpVhFiFg==",
-      "dependencies": {
-        "eventemitter3": "4.0.4",
-        "web3-core-helpers": "1.7.1",
-        "websocket": "^1.0.32"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
-    "packages/discovery-provider/plugins/pedalboard/apps/relay/node_modules/web3-shh": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/web3-shh/-/web3-shh-1.7.1.tgz",
-      "integrity": "sha512-NO+jpEjo8kYX6c7GiaAm57Sx93PLYkWYUCWlZmUOW7URdUcux8VVluvTWklGPvdM9H1WfDrol91DjuSW+ykyqg==",
-      "hasInstallScript": true,
-      "dependencies": {
-        "web3-core": "1.7.1",
-        "web3-core-method": "1.7.1",
-        "web3-core-subscriptions": "1.7.1",
-        "web3-net": "1.7.1"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
-    "packages/discovery-provider/plugins/pedalboard/apps/relay/node_modules/web3-utils": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.7.1.tgz",
-      "integrity": "sha512-fef0EsqMGJUgiHPdX+KN9okVWshbIumyJPmR+btnD1HgvoXijKEkuKBv0OmUqjbeqmLKP2/N9EiXKJel5+E1Dw==",
-      "dependencies": {
-        "bn.js": "^4.11.9",
-        "ethereum-bloom-filters": "^1.0.6",
-        "ethereumjs-util": "^7.1.0",
-        "ethjs-unit": "0.1.6",
-        "number-to-bn": "1.7.0",
-        "randombytes": "^2.1.0",
-        "utf8": "3.0.0"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
-    "packages/discovery-provider/plugins/pedalboard/apps/relay/node_modules/web3-utils/node_modules/bn.js": {
-      "version": "4.12.0",
-      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
-      "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA=="
     },
     "packages/discovery-provider/plugins/pedalboard/apps/relay/node_modules/webidl-conversions": {
       "version": "6.1.0",
@@ -127353,6 +126949,7 @@
       },
       "devDependencies": {
         "@babel/plugin-transform-react-jsx": "7.16.7",
+        "@electron/notarize": "2.1.0",
         "@pinata/sdk": "1.1.13",
         "@redux-devtools/extension": "^3.2.4",
         "@svgr/webpack": "5.5.0",
@@ -127397,7 +126994,6 @@
         "csstype": "3.1.1",
         "electron": "12.0.9",
         "electron-builder": "23.0.3",
-        "electron-notarize": "0.1.1",
         "env-cmd": "8.0.2",
         "eslint": "8.19.0",
         "fetch-mock": "9.9.1",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -200,6 +200,7 @@
   ],
   "devDependencies": {
     "@babel/plugin-transform-react-jsx": "7.16.7",
+    "@electron/notarize": "2.1.0",
     "@pinata/sdk": "1.1.13",
     "@redux-devtools/extension": "^3.2.4",
     "@svgr/webpack": "5.5.0",
@@ -244,7 +245,6 @@
     "csstype": "3.1.1",
     "electron": "12.0.9",
     "electron-builder": "23.0.3",
-    "electron-notarize": "0.1.1",
     "env-cmd": "8.0.2",
     "eslint": "8.19.0",
     "fetch-mock": "9.9.1",

--- a/packages/web/scripts/dist.js
+++ b/packages/web/scripts/dist.js
@@ -8,9 +8,9 @@
 const fs = require('fs')
 const path = require('path')
 
+const { notarize } = require('@electron/notarize')
 const program = require('commander')
 const builder = require('electron-builder')
-const notarize = require('electron-notarize').notarize
 const fse = require('fs-extra')
 
 const PRODUCTION_APP_ID = 'co.audius.app'


### PR DESCRIPTION
### Description

Apple requires us to move from altool to notarytool for notarizing our macos app. Upgrading to the latest @electron/notarize solves this problem, since they default to using notarytool behind the scenes

<img width="943" alt="image" src="https://github.com/AudiusProject/audius-protocol/assets/8230000/917e7abc-87a0-48f2-a81c-c5134b7292d5">

