### PR TITLE
[C-3169] Make mac app universal

### DIFF
--- a/packages/web/scripts/dist.js
+++ b/packages/web/scripts/dist.js
@@ -148,7 +148,11 @@ const makeBuildParams = (isProduction) => {
         icon: icns,
         hardenedRuntime: true,
         entitlements: 'resources/entitlements.mac.plist',
-        entitlementsInherit: 'resources/entitlements.mac.plist'
+        entitlementsInherit: 'resources/entitlements.mac.plist',
+        target: {
+          target: 'default',
+          arch: 'universal'
+        }
       },
       dmg: {
         icon: dmgIcns,


### PR DESCRIPTION
### Description

Updates our mac app build to enable arm64 builds. Should result in major perf improvements for our mac electron app.
