### PR TITLE
[PAY-2035] Only claim challenges past cooldown period

### DIFF
--- a/packages/common/src/store/pages/audio-rewards/selectors.ts
+++ b/packages/common/src/store/pages/audio-rewards/selectors.ts
@@ -1,6 +1,6 @@
 import { createSelector } from 'reselect'
 
-import { ChallengeRewardID, Specifier } from '../../../models/AudioRewards'
+import { ChallengeRewardID } from '../../../models/AudioRewards'
 import { CommonState } from '../../commonStore'
 
 import { ClaimStatus } from './types'

--- a/packages/common/src/store/pages/audio-rewards/selectors.ts
+++ b/packages/common/src/store/pages/audio-rewards/selectors.ts
@@ -36,14 +36,6 @@ export const getUndisbursedUserChallenges = (state: CommonState) =>
     ).includes(challenge.specifier)
   })
 
-export const getUndisbursedUserChallengeBySpecifier = createSelector(
-  getUndisbursedUserChallenges,
-  (_: CommonState, specifier: Specifier) => specifier,
-  (challenges, specifier) => {
-    return challenges.filter((c) => c.specifier === specifier)
-  }
-)
-
 export const getUserChallenge = (
   state: CommonState,
   props: { challengeId: ChallengeRewardID }

--- a/packages/common/src/store/pages/audio-rewards/selectors.ts
+++ b/packages/common/src/store/pages/audio-rewards/selectors.ts
@@ -1,6 +1,6 @@
 import { createSelector } from 'reselect'
 
-import { ChallengeRewardID } from '../../../models/AudioRewards'
+import { ChallengeRewardID, Specifier } from '../../../models/AudioRewards'
 import { CommonState } from '../../commonStore'
 
 import { ClaimStatus } from './types'
@@ -35,6 +35,14 @@ export const getUndisbursedUserChallenges = (state: CommonState) =>
       state.pages.audioRewards.disbursedChallenges[challenge.challenge_id] ?? []
     ).includes(challenge.specifier)
   })
+
+export const getUndisbursedUserChallengeBySpecifier = createSelector(
+  getUndisbursedUserChallenges,
+  (_: CommonState, specifier: Specifier) => specifier,
+  (challenges, specifier) => {
+    return challenges.filter((c) => c.specifier === specifier)
+  }
+)
 
 export const getUserChallenge = (
   state: CommonState,


### PR DESCRIPTION
### Description
Filter out challenges that are not past the cooldown period and don't attempt to claim them.

### How Has This Been Tested?

Local stack with 3 DNs + AAO - confirmed only challenge past cooldown was disbursed, and no errors from trying to claim other challenges that were not past cooldown.
