### PR TITLE
[Harmony] Allow passing in number as spacing

### DIFF
--- a/packages/harmony/src/components/layout/Box/Box.tsx
+++ b/packages/harmony/src/components/layout/Box/Box.tsx
@@ -2,6 +2,13 @@ import styled from '@emotion/styled'
 
 import type { BoxProps } from './types'
 
+const getSpacingVar = (value: number | string) => {
+  if (!isNaN(value)) {
+    return `--harmony-unit-${value}`
+  }
+  return `--harmony-spacing-${value}`
+}
+
 /** Base layout component used as a building block for creating pages and other components. */
 export const Box = styled.div(
   ({
@@ -41,14 +48,14 @@ export const Box = styled.div(
       height: h,
       width: w,
       boxShadow: shadow && `var(--harmony-shadow-${shadow})`,
-      paddingTop: padT && `var(--harmony-spacing-${padT})`,
-      paddingLeft: padL && `var(--harmony-spacing-${padL})`,
-      paddingRight: padR && `var(--harmony-spacing-${padR})`,
-      paddingBottom: padB && `var(--harmony-spacing-${padB})`,
-      marginTop: marginT && `var(--harmony-spacing-${marginT})`,
-      marginLeft: marginL && `var(--harmony-spacing-${marginL})`,
-      marginRight: marginR && `var(--harmony-spacing-${marginR})`,
-      marginBottom: marginB && `var(--harmony-spacing-${marginB})`,
+      paddingTop: padT && getSpacingVar(padT),
+      paddingLeft: padL && getSpacingVar(padL),
+      paddingRight: padR && getSpacingVar(padR),
+      paddingBottom: padB && getSpacingVar(padB),
+      marginTop: marginT && getSpacingVar(marginT),
+      marginLeft: marginL && getSpacingVar(marginL),
+      marginRight: marginR && getSpacingVar(marginR),
+      marginBottom: marginB && getSpacingVar(marginB),
       border: border && `1px solid var(--harmony-border-${border})`,
       borderRadius:
         borderRadius && `var(--harmony-border-radius-${borderRadius})`

--- a/packages/harmony/src/components/layout/Box/types.ts
+++ b/packages/harmony/src/components/layout/Box/types.ts
@@ -14,34 +14,34 @@ export type BoxProps = {
   w?: CSSProperties['width']
 
   /** Padding */
-  p?: SpacingValue
+  p?: SpacingValue | number
   /** Padding Horizontal */
-  ph?: SpacingValue
+  ph?: SpacingValue | number
   /** Padding Vertical */
-  pv?: SpacingValue
+  pv?: SpacingValue | number
   /** Padding Top */
-  pt?: SpacingValue
+  pt?: SpacingValue | number
   /** Padding Left */
-  pl?: SpacingValue
+  pl?: SpacingValue | number
   /** Padding Right */
-  pr?: SpacingValue
+  pr?: SpacingValue | number
   /** Padding Bottom */
-  pb?: SpacingValue
+  pb?: SpacingValue | number
 
   /** Margin */
-  m?: SpacingValue
+  m?: SpacingValue | number
   /** Margin Horizontal */
-  mh?: SpacingValue
+  mh?: SpacingValue | number
   /** Margin Vertical */
-  mv?: SpacingValue
+  mv?: SpacingValue | number
   /** Margin Top */
-  mt?: SpacingValue
+  mt?: SpacingValue | number
   /** Margin Left */
-  ml?: SpacingValue
+  ml?: SpacingValue | number
   /** Margin Right */
-  mr?: SpacingValue
+  mr?: SpacingValue | number
   /** Margin Bottom */
-  mb?: SpacingValue
+  mb?: SpacingValue | number
 
   /** Border */
   border?: BorderValue


### PR DESCRIPTION
### Description
- Allow passing in number as spacing for `Box`, because sometimes the value you need is not one of the standard spacings (encountered this situation just now)
So for example, you can do `<Box p={10} />` and this would give you a padding of 40.

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._
