### PR TITLE
[PAY-2027] Implement new challenge badge for audio matching challenges

### DIFF
--- a/packages/mobile/src/screens/audio-screen/Panel.tsx
+++ b/packages/mobile/src/screens/audio-screen/Panel.tsx
@@ -9,6 +9,7 @@ import {
 } from '@audius/common'
 import { View, Image } from 'react-native'
 import { TouchableOpacity } from 'react-native-gesture-handler'
+import LinearGradient from 'react-native-linear-gradient'
 
 import IconArrow from 'app/assets/images/iconArrow.svg'
 import IconCheck from 'app/assets/images/iconCheck.svg'
@@ -22,7 +23,8 @@ const messages = {
   completeLabel: 'COMPLETE',
   claimReward: 'Claim Your Reward',
   readyToClaim: 'Ready to Claim',
-  viewDetails: 'View Details'
+  viewDetails: 'View Details',
+  new: 'New!'
 }
 
 const useStyles = makeStyles(({ spacing, palette, typography }) => ({
@@ -53,11 +55,18 @@ const useStyles = makeStyles(({ spacing, palette, typography }) => ({
     fontFamily: typography.fontByWeight.demiBold,
     lineHeight: spacing(4),
     color: palette.secondary,
-    backgroundColor: palette.background,
     borderWidth: 1,
     borderRadius: 12,
     borderColor: palette.backgroundSecondary,
     overflow: 'hidden'
+  },
+  readyToClaimPill: {
+    backgroundColor: palette.background
+  },
+  newChallengeText: {
+    textShadowOffset: { width: 0, height: 1.4 },
+    textShadowRadius: 8,
+    textShadowColor: 'rgba(0,0,0,0.2)'
   },
   header: {
     flexDirection: 'row',
@@ -129,6 +138,8 @@ export const Panel = ({
   const shouldShowProgressBar =
     stepCount > 1 && challenge?.challenge_type !== 'aggregate' && !hasDisbursed
   const needsDisbursement = challenge && challenge.claimableAmount > 0
+  const showNewChallengePill =
+    !needsDisbursement && isAudioMatchingChallenge(id)
 
   const shouldShowProgress = !!progressLabel
   let progressLabelFilled: string | null = null
@@ -180,6 +191,23 @@ export const Panel = ({
       <View style={styles.pillContainer}>
         {needsDisbursement ? (
           <Text style={styles.pillMessage}>{messages.readyToClaim}</Text>
+        ) : showNewChallengePill ? (
+          <LinearGradient
+            useAngle={true}
+            angle={125}
+            colors={['#19CCA2', '#61FA66']}
+            style={styles.pillMessage}
+          >
+            <Text
+              variant='body'
+              fontSize='medium'
+              weight='demiBold'
+              color='staticWhite'
+              style={styles.newChallengeText}
+            >
+              {messages.new}
+            </Text>
+          </LinearGradient>
         ) : null}
       </View>
       <View style={styles.content}>

--- a/packages/web/src/pages/audio-rewards-page/ChallengeRewardsTile.tsx
+++ b/packages/web/src/pages/audio-rewards-page/ChallengeRewardsTile.tsx
@@ -62,18 +62,6 @@ type RewardPanelProps = {
   id: ChallengeRewardID
 }
 
-const ReadyToClaimPill = () => (
-  <span className={styles.pillMessage}>{messages.readyToClaim}</span>
-)
-
-const NewChallengePill = () => (
-  <span className={styles.newChallengePill}>
-    <Text as='span' variant='body' strength='strong' color='staticWhite'>
-      {messages.new}
-    </Text>
-  </span>
-)
-
 const RewardPanel = ({
   id,
   title,
@@ -152,9 +140,17 @@ const RewardPanel = ({
       <div className={wm(styles.rewardPanelTop)}>
         <div className={wm(styles.pillContainer)}>
           {needsDisbursement ? (
-            <ReadyToClaimPill />
+            <span className={styles.pillMessage}>{messages.readyToClaim}</span>
           ) : showNewChallengePill ? (
-            <NewChallengePill />
+            <Text
+              as='span'
+              className={styles.newChallengePill}
+              variant='body'
+              strength='strong'
+              color='staticWhite'
+            >
+              {messages.new}
+            </Text>
           ) : null}
         </div>
         <span className={wm(styles.rewardTitle)}>

--- a/packages/web/src/pages/audio-rewards-page/ChallengeRewardsTile.tsx
+++ b/packages/web/src/pages/audio-rewards-page/ChallengeRewardsTile.tsx
@@ -27,6 +27,7 @@ import { useDispatch, useSelector } from 'react-redux'
 
 import { useSetVisibility } from 'common/hooks/useModalState'
 import LoadingSpinner from 'components/loading-spinner/LoadingSpinner'
+import { Text } from 'components/typography'
 import { useIsAudioMatchingChallengesEnabled } from 'hooks/useIsAudioMatchingChallengesEnabled'
 import { useRemoteVar } from 'hooks/useRemoteConfig'
 import { useWithMobileStyle } from 'hooks/useWithMobileStyle'
@@ -46,7 +47,8 @@ const messages = {
   completeLabel: 'COMPLETE',
   claimReward: 'Claim Your Reward',
   readyToClaim: 'Ready to Claim',
-  viewDetails: 'View Details'
+  viewDetails: 'View Details',
+  new: 'New!'
 }
 
 type RewardPanelProps = {
@@ -59,6 +61,18 @@ type RewardPanelProps = {
   openModal: (modalType: ChallengeRewardsModalType) => void
   id: ChallengeRewardID
 }
+
+const ReadyToClaimPill = () => (
+  <span className={styles.pillMessage}>{messages.readyToClaim}</span>
+)
+
+const NewChallengePill = () => (
+  <span className={styles.newChallengePill}>
+    <Text as='span' variant='body' strength='strong' color='staticWhite'>
+      {messages.new}
+    </Text>
+  </span>
+)
 
 const RewardPanel = ({
   id,
@@ -85,6 +99,8 @@ const RewardPanel = ({
     challenge.max_steps > 1 &&
     challenge.challenge_type !== 'aggregate' &&
     !hasDisbursed
+  const showNewChallengePill =
+    isAudioMatchingChallenge(id) && !needsDisbursement
 
   let progressLabelFilled: string
   if (shouldShowCompleted) {
@@ -135,11 +151,11 @@ const RewardPanel = ({
     >
       <div className={wm(styles.rewardPanelTop)}>
         <div className={wm(styles.pillContainer)}>
-          {needsDisbursement && (
-            <span className={wm(styles.pillMessage)}>
-              {messages.readyToClaim}
-            </span>
-          )}
+          {needsDisbursement ? (
+            <ReadyToClaimPill />
+          ) : showNewChallengePill ? (
+            <NewChallengePill />
+          ) : null}
         </div>
         <span className={wm(styles.rewardTitle)}>
           {icon}

--- a/packages/web/src/pages/audio-rewards-page/RewardsTile.module.css
+++ b/packages/web/src/pages/audio-rewards-page/RewardsTile.module.css
@@ -116,6 +116,17 @@
   background-color: var(--background);
 }
 
+.newChallengePill {
+  background: linear-gradient(125deg, #19cca2 0%, #61fa66 100%);
+  border: 1px solid var(--border-default);
+  border-radius: var(--unit-3);
+  align-items: center;
+  display: flex;
+  justify-content: center;
+  padding: var(--unit-1) var(--unit-2);
+  text-shadow: 0px 1.4px 8px rgba(0, 0, 0, 0.2), 0px 6px 15px rgba(0, 0, 0, 0.1);
+}
+
 .rewardTitle {
   color: var(--neutral);
   font-size: var(--font-2xl);


### PR DESCRIPTION
### Description
Adds the components for the 'New!' badge on web and mobile, which will show on audio matching challenges if they aren't currently claimable

### How Has This Been Tested?
Tested locally on chrome and iOS simulator against staging

Web
![image](https://github.com/AudiusProject/audius-protocol/assets/1815175/4ba7a068-cc97-4583-b53a-93a326a89082)

Mobile
![image](https://github.com/AudiusProject/audius-protocol/assets/1815175/f5178cce-a4ff-4d49-a76d-edc1ee0323e9)
