### PR TITLE
Automate bundle install in postinstall script

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -113499,7 +113499,7 @@
         "babel-core": "6.26.3",
         "babel-loader": "8.3.0",
         "babel-runtime": "6.26.0",
-        "chromatic": "^7.4.0",
+        "chromatic": "7.4.0",
         "cross-env": "5.2.1",
         "css-loader": "3.6.0",
         "eslint": "8.19.0",

--- a/packages/mobile/README.md
+++ b/packages/mobile/README.md
@@ -4,16 +4,6 @@ The Audius React Native mobile client
 
 ## Setup
 
-### Extra iOS Setup
-
-```bash
-gem install cocoapods
-
-cd ios
-pod install
-cd ..
-```
-
 ## Running iOS
 
 ```bash

--- a/scripts/postinstall.sh
+++ b/scripts/postinstall.sh
@@ -11,6 +11,7 @@ if [[ -z "${SKIP_POD_INSTALL}" ]]; then
   cd packages/mobile/node_modules
   ln -s ../../../node_modules/react-native react-native
   cd ../ios
+  bundle check || bundle install 
   if command -v pod >/dev/null; then
     pod install
   fi


### PR DESCRIPTION
### Description

* Run `bundle install` for ios gems in postinstall script. This means we don't need to manually install a global version of `cocoapods`

### How Has This Been Tested?

Tested that remove the globally installed cocoapods and doing an npm i results in the gems & pods being installed correctly
