### PR TITLE
[C-3239] Fix accidental unset of required prop in upload form

### DIFF
--- a/packages/common/src/models/Track.ts
+++ b/packages/common/src/models/Track.ts
@@ -154,7 +154,7 @@ export type SolCollectionMap = {
 export type PremiumTrackStatus = null | 'UNLOCKING' | 'UNLOCKED' | 'LOCKED'
 
 export type TrackMetadata = {
-  ai_attribution_user_id?: number
+  ai_attribution_user_id?: Nullable<number>
   blocknumber: number
   activity_timestamp?: string
   is_delete: boolean

--- a/packages/web/src/pages/upload-page/fields/AttributionField.tsx
+++ b/packages/web/src/pages/upload-page/fields/AttributionField.tsx
@@ -180,7 +180,7 @@ export const AttributionField = () => {
       if (get(values, IS_AI_ATTRIBUTED)) {
         setAiUserId(get(values, AI_USER_ID) ?? aiUserId)
       } else {
-        setAiUserId(undefined)
+        setAiUserId(null)
       }
       setIsrc(get(values, ISRC) ?? isrcValue)
       setIswc(get(values, ISWC) ?? iswcValue)


### PR DESCRIPTION
### Description
We initialize `ai_attribution_user_id` to `null` when the upload page is mounted, but the sub form for attribution erroneously unsets it on submit if ai attribution is not selected. Changing the code to set to `null` fixes it for now, but we probably want a better long term solution

fixes C-3239

### How Has This Been Tested?
Tested locally in Chrome against staging
