### PR TITLE
[PROTO-1356] Use self-hosted gcp runners for circleci

### DIFF
--- a/.circleci/scripts/circleci-startup-script.sh
+++ b/.circleci/scripts/circleci-startup-script.sh
@@ -1,0 +1,57 @@
+#!/bin/env bash
+set -ex
+
+# See https://circleci.com/docs/runner-installation-linux/
+# Self-hosted runners should link to this file as the startup script.
+
+apt install -y git coreutils curl
+
+# download and run circleci agent installer script
+curl -L https://raw.githubusercontent.com/CircleCI-Public/runner-installation-files/main/download-launch-agent.sh -o download-launch-agent.sh
+export platform=linux/amd64 && sh ./download-launch-agent.sh
+rm download-launch-agent.sh
+
+# setup user and dirs
+id -u circleci &>/dev/null || adduser --disabled-password --gecos GECOS circleci
+groupadd -f docker
+usermod -aG docker circleci
+mkdir -p /var/opt/circleci
+chmod 0750 /var/opt/circleci
+chown -R circleci /var/opt/circleci /opt/circleci
+
+# setup config
+mkdir -p /etc/opt/circleci && touch /etc/opt/circleci/launch-agent-config.yaml
+chown -R circleci: /etc/opt/circleci
+chmod 600 /etc/opt/circleci/launch-agent-config.yaml
+cat <<EOT >> /etc/opt/circleci/launch-agent-config.yaml
+api:
+  auth_token: $(gcloud secrets versions access 1 --secret=circleci-auth-token)
+
+runner:
+  name: $(hostname)
+  working_directory: /var/opt/circleci/workdir
+  cleanup_working_directory: true
+EOT
+
+# allow sudo
+echo "circleci ALL=(ALL) NOPASSWD:ALL" | tee -a /etc/sudoers
+
+# enable circleci systemd service
+touch /usr/lib/systemd/system/circleci.service
+chown root: /usr/lib/systemd/system/circleci.service
+chmod 755 /usr/lib/systemd/system/circleci.service
+cat <<EOT >> /usr/lib/systemd/system/circleci.service
+[Unit]
+Description=CircleCI Runner
+After=network.target
+[Service]
+ExecStart=/opt/circleci/circleci-launch-agent --config /etc/opt/circleci/launch-agent-config.yaml
+Restart=always
+User=circleci
+NotifyAccess=exec
+TimeoutStopSec=18300
+[Install]
+WantedBy = multi-user.target
+EOT
+systemctl enable circleci.service
+systemctl start circleci.service

--- a/.circleci/src/jobs/test-audius-cmd.yml
+++ b/.circleci/src/jobs/test-audius-cmd.yml
@@ -1,6 +1,5 @@
-machine:
-  image: ubuntu-2204:current
-resource_class: large
+machine: true
+resource_class: audiusproject/gcp-n2-standard-4
 steps:
   - checkout:
       path: '~/audius-protocol'

--- a/dev-tools/setup.sh
+++ b/dev-tools/setup.sh
@@ -1,30 +1,46 @@
 #!/usr/bin/env bash
 
+set -ex
+
 source /etc/os-release
 case "$ID" in
 debian | ubuntu)
     # Uninstall old versions of docker
-    sudo apt-get remove -y docker docker-engine docker.io containerd runc
+    set +e
+    for pkg in docker.io docker-doc docker-compose docker-compose-v2 podman-docker containerd runc; do sudo apt-get remove $pkg; done
+    set -e
 
     # Install packages to allow apt to use a repository over HTTPS
     sudo apt-get update
     sudo apt-get install -y ca-certificates curl gnupg lsb-release
 
+    # Add Docker's official GPG key:
+    if ! [ -f /etc/apt/keyrings/docker.gpg ]; then
+        sudo install -m 0755 -d /etc/apt/keyrings
+        curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo gpg --dearmor -o /etc/apt/keyrings/docker.gpg
+        sudo chmod a+r /etc/apt/keyrings/docker.gpg
+    fi
+
+    # Add the repository to Apt sources:
+    if ! [ -f /etc/apt/sources.list.d/docker.list ]; then
+        echo \
+            "deb [arch="$(dpkg --print-architecture)" signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu \
+            "$(. /etc/os-release && echo "$VERSION_CODENAME")" stable" | \
+            sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
+        sudo apt-get update
+    fi
+
     # Install dependencies
-    sudo apt-get update
-    sudo apt-get install -y \
+    sudo NEEDRESTART_MODE=a apt-get install -y \
         git \
         python3 \
         python3-pip \
         docker-ce \
         docker-ce-cli \
-        containerd.io
+        containerd.io \
+        docker-buildx-plugin \
+        docker-compose-plugin
 
-    mkdir -p ~/.docker/cli-plugins
-    curl -L "https://github.com/docker/buildx/releases/download/v0.10.4/buildx-v0.9.1.linux-$(dpkg --print-architecture)" -o ~/.docker/cli-plugins/docker-buildx
-    curl -L "https://github.com/docker/compose/releases/download/v2.17.3/docker-compose-linux-$(uname -m)" -o ~/.docker/cli-plugins/docker-compose
-    chmod +x ~/.docker/cli-plugins/docker-buildx
-    chmod +x ~/.docker/cli-plugins/docker-compose
 
     # Add user to docker group
     sudo usermod -aG docker "$USER"
@@ -70,7 +86,8 @@ ln -sf "$PROTOCOL_DIR/dev-tools/audius-compose" "$HOME/.local/bin/audius-compose
 ln -sf "$PROTOCOL_DIR/dev-tools/audius-cloud" "$HOME/.local/bin/audius-cloud"
 ln -sf "$PROTOCOL_DIR/dev-tools/audius-cmd" "$HOME/.local/bin/audius-cmd"
 
-echo "export PROTOCOL_DIR=$PROTOCOL_DIR" >>~/.profile
-echo "export PATH=$HOME/.local/bin:$PATH" >>~/.profile
+# Add env vars to .profile, avoiding duplication
+grep -q PROTOCOL_DIR ~/.profile || echo "export PROTOCOL_DIR=$PROTOCOL_DIR" >>~/.profile
+grep -q "export PATH=$HOME/.local/bin:" ~/.profile || echo "export PATH=$HOME/.local/bin:\$PATH" >>~/.profile
 
 [[ "$AUDIUS_DEV" != "false" ]] && . "$PROTOCOL_DIR/dev-tools/setup-dev.sh" || true


### PR DESCRIPTION
### Description

CircleCI Docker Layer Caching does not work. But by hosting our own job runners, we can achieve the same benefits more easily.

This diff enables self-hosted runners only for test-audius-cmd. Other tests will follow if this proves useful. 

### How Has This Been Tested?

[The first time](https://app.circleci.com/pipelines/github/AudiusProject/audius-protocol/44263/workflows/81c9da5f-3a1d-48cc-baab-7e7e9ce6b2b7/jobs/570262) the test workflow is run on a machine, there is no cache and the test takes ~20 minutes.

[The second time](https://app.circleci.com/pipelines/github/AudiusProject/audius-protocol/44263/workflows/288000a3-aba9-4365-949b-043125680648/jobs/570269), the test takes only ~2 minutes.