### PR TITLE
[INF-453] Remove npm link

### DIFF
--- a/dev-tools/setup-dev.sh
+++ b/dev-tools/setup-dev.sh
@@ -10,10 +10,3 @@ for dir in contracts eth-contracts packages/identity-service libs; do
     cd "$PROTOCOL_DIR/$dir"
     nvm install
 done
-
-# Link libs
-cd $PROTOCOL_DIR/packages/libs
-nvm use
-npm i
-npm run build
-npm link


### PR DESCRIPTION
### Description

* Remove last usage of `npm link`. This is no longer needed due to monorepo & npm workspaces

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._
