### PR TITLE
[PAY-2036] Reduce spam from websocket errors

### DIFF
--- a/packages/common/src/models/Analytics.ts
+++ b/packages/common/src/models/Analytics.ts
@@ -364,7 +364,8 @@ export enum Name {
   MESSAGE_UNFURL_PLAYLIST = 'Message Unfurl: Playlist',
   TIP_UNLOCKED_CHAT = 'Unlocked Chat: Tip',
   CHAT_REPORT_USER = 'Report User: Chat',
-  CHAT_ENTRY_POINT = 'Chat Entry Point'
+  CHAT_ENTRY_POINT = 'Chat Entry Point',
+  CHAT_WEBSOCKET_ERROR = 'Chat Websocket Error'
 }
 
 type PageView = {
@@ -1737,6 +1738,11 @@ type ChatEntryPoint = {
   source: 'banner' | 'navmenu' | 'share' | 'profile'
 }
 
+type ChatWebsocketError = {
+  eventName: Name.CHAT_WEBSOCKET_ERROR
+  code?: string
+}
+
 export type BaseAnalyticsEvent = { type: typeof ANALYTICS_TRACK_EVENT }
 
 export type AllTrackingEvents =
@@ -1974,3 +1980,4 @@ export type AllTrackingEvents =
   | DeveloperAppDeleteSuccess
   | DeveloperAppDeleteError
   | ChatEntryPoint
+  | ChatWebsocketError

--- a/packages/common/src/store/pages/chat/middleware.ts
+++ b/packages/common/src/store/pages/chat/middleware.ts
@@ -6,6 +6,7 @@ import { getUserId } from 'store/account/selectors'
 import { encodeHashId } from 'utils/hashIds'
 
 import { actions as chatActions } from './slice'
+import { ChatWebsocketError } from './types'
 
 const { connect, disconnect, addMessage, setMessageReactionSucceeded } =
   chatActions
@@ -56,6 +57,11 @@ export const chatMiddleware =
           }
           errorListener = (e) => {
             console.debug('[chats] WebSocket error.', e)
+            store.dispatch(
+              chatActions.logError({
+                error: new ChatWebsocketError(e.target.url, e.code)
+              })
+            )
           }
           sdk.chats.addEventListener('open', openListener)
           sdk.chats.addEventListener('message', messageListener)

--- a/packages/common/src/store/pages/chat/middleware.ts
+++ b/packages/common/src/store/pages/chat/middleware.ts
@@ -57,11 +57,15 @@ export const chatMiddleware =
           }
           errorListener = (e) => {
             console.debug('[chats] WebSocket error.', e)
-            store.dispatch(
-              chatActions.logError({
-                error: new ChatWebsocketError(e.target.url, e.code)
-              })
-            )
+            // Most errors received here have no `code` and are not actionable, so only
+            // log the outliers.
+            if (e.code) {
+              store.dispatch(
+                chatActions.logError({
+                  error: new ChatWebsocketError(e.code, e.target.url)
+                })
+              )
+            }
           }
           sdk.chats.addEventListener('open', openListener)
           sdk.chats.addEventListener('message', messageListener)

--- a/packages/common/src/store/pages/chat/middleware.ts
+++ b/packages/common/src/store/pages/chat/middleware.ts
@@ -17,6 +17,7 @@ export const chatMiddleware =
     let reactionListener: ChatEvents['reaction'] | null = null
     let openListener: ChatEvents['open'] | null = null
     let closeListener: ChatEvents['close'] | null = null
+    let errorListener: ChatEvents['error'] | null = null
 
     let hasConnected = false
     return (next) => (action) => {
@@ -53,10 +54,14 @@ export const chatMiddleware =
             console.debug('[chats] WebSocket closed. Reconnecting...')
             await sdk.chats.listen()
           }
+          errorListener = (e) => {
+            console.debug('[chats] WebSocket error.', e)
+          }
           sdk.chats.addEventListener('open', openListener)
           sdk.chats.addEventListener('message', messageListener)
           sdk.chats.addEventListener('reaction', reactionListener)
           sdk.chats.addEventListener('close', closeListener)
+          sdk.chats.addEventListener('error', errorListener)
           console.debug('[chats] Listening...')
           return sdk.chats.listen()
         }
@@ -77,6 +82,9 @@ export const chatMiddleware =
           }
           if (closeListener) {
             sdk.chats.removeEventListener('close', closeListener)
+          }
+          if (errorListener) {
+            sdk.chats.removeEventListener('error', errorListener)
           }
         }
         fn()

--- a/packages/common/src/store/pages/chat/sagas.ts
+++ b/packages/common/src/store/pages/chat/sagas.ts
@@ -740,21 +740,16 @@ function* doDeleteChat(action: ReturnType<typeof deleteChat>) {
 
 function* doLogError({ payload: { error } }: ReturnType<typeof logError>) {
   const { track, make } = yield* getContext('analytics')
-  // TODO: This spams like crazy if the websocket retries. Find a way
-  // to prevent sending the same error over and over again.
-  // * Configure sentry to limit based on type?
-  // * Store the error in slice and only send if it's different? (the url changes often)
-  // ORRRR consider ditching this altogether and change the middleware to only throw the error if it has a code?
-  // const reportToSentry = yield* getContext('reportToSentry')
-  const { code /* url */ } = error
-  // reportToSentry({
-  //   level: ErrorLevel.Error,
-  //   error,
-  //   additionalInfo: {
-  //     code,
-  //     url
-  //   }
-  // })
+  const reportToSentry = yield* getContext('reportToSentry')
+  const { code, url } = error
+  reportToSentry({
+    level: ErrorLevel.Error,
+    error,
+    additionalInfo: {
+      code,
+      url
+    }
+  })
   yield* call(track, make({ eventName: Name.CHAT_WEBSOCKET_ERROR, code }))
 }
 

--- a/packages/common/src/store/pages/chat/sagas.ts
+++ b/packages/common/src/store/pages/chat/sagas.ts
@@ -740,14 +740,18 @@ function* doDeleteChat(action: ReturnType<typeof deleteChat>) {
 
 function* doLogError({ payload: { error } }: ReturnType<typeof logError>) {
   const { track, make } = yield* getContext('analytics')
+  // TODO: This spams like crazy if the websocket retries. Find a way
+  // to prevent sending the same error over and over again.
+  // * Configure sentry to limit based on type?
+  // * Store the error in slice and only send if it's different? (the url changes often)
   const reportToSentry = yield* getContext('reportToSentry')
-  const { code, target } = error
+  const { code, url } = error
   reportToSentry({
     level: ErrorLevel.Error,
-    error: new Error('Chat websocket error'),
+    error,
     additionalInfo: {
       code,
-      url: target?.url
+      url
     }
   })
   yield* call(track, make({ eventName: Name.CHAT_WEBSOCKET_ERROR, code }))

--- a/packages/common/src/store/pages/chat/sagas.ts
+++ b/packages/common/src/store/pages/chat/sagas.ts
@@ -54,6 +54,7 @@ const {
   setMessageReaction,
   setMessageReactionSucceeded,
   setMessageReactionFailed,
+  logError,
   markChatAsRead,
   markChatAsReadSucceeded,
   markChatAsReadFailed,
@@ -737,6 +738,21 @@ function* doDeleteChat(action: ReturnType<typeof deleteChat>) {
   }
 }
 
+function* doLogError({ payload: { error } }: ReturnType<typeof logError>) {
+  const { track, make } = yield* getContext('analytics')
+  const reportToSentry = yield* getContext('reportToSentry')
+  const { code, target } = error
+  reportToSentry({
+    level: ErrorLevel.Error,
+    error: new Error('Chat websocket error'),
+    additionalInfo: {
+      code,
+      url: target?.url
+    }
+  })
+  yield* call(track, make({ eventName: Name.CHAT_WEBSOCKET_ERROR, code }))
+}
+
 function* watchFetchUnreadMessagesCount() {
   yield takeLatest(fetchUnreadMessagesCount, () => doFetchUnreadMessagesCount())
 }
@@ -811,6 +827,10 @@ function* watchDeleteChat() {
   yield takeEvery(deleteChat, doDeleteChat)
 }
 
+function* watchLogError() {
+  yield takeEvery(logError, doLogError)
+}
+
 export const sagas = () => {
   return [
     watchFetchUnreadMessagesCount,
@@ -830,6 +850,7 @@ export const sagas = () => {
     watchUnblockUser,
     watchFetchPermissions,
     watchFetchLinkUnfurlMetadata,
-    watchDeleteChat
+    watchDeleteChat,
+    watchLogError
   ]
 }

--- a/packages/common/src/store/pages/chat/sagas.ts
+++ b/packages/common/src/store/pages/chat/sagas.ts
@@ -744,16 +744,17 @@ function* doLogError({ payload: { error } }: ReturnType<typeof logError>) {
   // to prevent sending the same error over and over again.
   // * Configure sentry to limit based on type?
   // * Store the error in slice and only send if it's different? (the url changes often)
-  const reportToSentry = yield* getContext('reportToSentry')
-  const { code, url } = error
-  reportToSentry({
-    level: ErrorLevel.Error,
-    error,
-    additionalInfo: {
-      code,
-      url
-    }
-  })
+  // ORRRR consider ditching this altogether and change the middleware to only throw the error if it has a code?
+  // const reportToSentry = yield* getContext('reportToSentry')
+  const { code /* url */ } = error
+  // reportToSentry({
+  //   level: ErrorLevel.Error,
+  //   error,
+  //   additionalInfo: {
+  //     code,
+  //     url
+  //   }
+  // })
   yield* call(track, make({ eventName: Name.CHAT_WEBSOCKET_ERROR, code }))
 }
 

--- a/packages/common/src/store/pages/chat/slice.ts
+++ b/packages/common/src/store/pages/chat/slice.ts
@@ -21,6 +21,8 @@ import { signOut } from 'store/sign-out/slice'
 import { hasTail } from 'utils/chatUtils'
 import { encodeHashId } from 'utils/hashIds'
 
+import { ChatWebsocketError } from './types'
+
 type UserChatWithMessagesStatus = UserChat & {
   messagesStatus?: Status
   messagesSummary?: TypedCommsResponse<ChatMessage>['summary']
@@ -614,8 +616,10 @@ const slice = createSlice({
       chatsAdapter.removeOne(state.chats, chatId)
       chatMessagesAdapter.removeAll(state.messages[chatId])
     },
-    // TODO: Expect error/code/url/etc to be already passed or handle event directly?
-    logError: (_state, _action: PayloadAction<{ error: any }>) => {
+    logError: (
+      _state,
+      _action: PayloadAction<{ error: ChatWebsocketError }>
+    ) => {
       // triggers saga
     }
   },

--- a/packages/common/src/store/pages/chat/slice.ts
+++ b/packages/common/src/store/pages/chat/slice.ts
@@ -613,6 +613,10 @@ const slice = createSlice({
       const { chatId } = action.payload
       chatsAdapter.removeOne(state.chats, chatId)
       chatMessagesAdapter.removeAll(state.messages[chatId])
+    },
+    // TODO: Expect error/code/url/etc to be already passed or handle event directly?
+    logError: (_state, _action: PayloadAction<{ error: any }>) => {
+      // triggers saga
     }
   },
   extraReducers: {

--- a/packages/common/src/store/pages/chat/types.ts
+++ b/packages/common/src/store/pages/chat/types.ts
@@ -21,3 +21,9 @@ export type ChatMessageTileProps = {
   onSuccess?: () => void
   className?: string
 }
+
+export class ChatWebsocketError extends Error {
+  constructor(public url?: string, public code?: string) {
+    super(`Chat Websocket Error, code: ${code}`)
+  }
+}

--- a/packages/common/src/store/pages/chat/types.ts
+++ b/packages/common/src/store/pages/chat/types.ts
@@ -23,7 +23,7 @@ export type ChatMessageTileProps = {
 }
 
 export class ChatWebsocketError extends Error {
-  constructor(public url?: string, public code?: string) {
+  constructor(public code: string = 'UNKNOWN', public url?: string) {
     super(`Chat Websocket Error, code: ${code}`)
   }
 }


### PR DESCRIPTION
### Description
We see a high volume of unhandled errors from the Chats API event emitter. They aren't a useful signal most of the time. But we _do_ want to log errors with a `code` value, since those would indicate unexpected issues with the _data_ sent through the websocket.

Fixes PAY-2036

### How Has This Been Tested?
Tested locally in Chrome against Staging.
