### PR TITLE
Add missing GH context to deploy msg job

### DIFF
--- a/.circleci/src/jobs/alert-slack-push-success.yml
+++ b/.circleci/src/jobs/alert-slack-push-success.yml
@@ -2,9 +2,15 @@ resource_class: small
 docker:
   - image: cimg/base:2023.01
 steps:
+  - gh/setup:
+      version: 2.23.0
   - add_ssh_keys:
       fingerprints:
         - 'd0:0b:a0:19:ac:46:58:e4:6c:ac:34:99:f6:1b:31:bb' # github.com
+  - run:
+      name: Add github.com to known_hosts
+      command: |
+        echo 'github.com ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEAq2A7hRGmdnm9tUDbO9IDSwBK6TbQa+PXYPCPy6rbTrTtw7PHkccKrpp0yVhp5HdEIcKr6pLlVDBfOLX9QUsyCOV0wzfjIJNlGEYsdlLJizHhbn2mUjvSAHQqZETYP81eFzLQNnPHt4EVVUh7VfDESU84KezmD5QlWpXLmvU31/yMf+Se8xhHTvKSCZIFImWwoG6mbUoWf9nzpIoaSjB+weqqUUmpaaasXVal72J+UX2B+2RPW3RcT0eOzQgqlJL3RKrTJvdsjE3JEAvGq3lGHSZXy28G3skua2SmVi/w4yCE6gbODqnTWlg7+wC604ydGXA8VJiS5ap43JXiUFFAaQ==' >> ~/.ssh/known_hosts
   - run:
       name: Set git config
       command: |

--- a/.circleci/src/workflows/release.yml
+++ b/.circleci/src/workflows/release.yml
@@ -75,7 +75,7 @@ jobs:
         - release-governance-trigger
   
   - alert-slack-push-success:
-      context: slack-secrets
+      context: [slack-secrets, github]
       requires:
         - push-identity-service
         - push-mediorum


### PR DESCRIPTION
### Description
The daily deploy Slack alert job was not able to push the commit message for today's release because I forgot to give it the necessary secrets. Failure message: `Username for 'https://github.com': fatal: could not read Username for 'https://github.com': Success`

### How Has This Been Tested?
I can't test without the secrets, so I plan to run another trigger on the hour to make sure it's able to push the commit this time.
