### PR TITLE
[PROTO-1356] Tear down containers following self-hosted test

### DIFF
--- a/.circleci/src/jobs/test-audius-cmd.yml
+++ b/.circleci/src/jobs/test-audius-cmd.yml
@@ -7,4 +7,17 @@ steps:
   - run:
       name: audius-cmd test
       no_output_timeout: 15m
-      command: . ~/.profile; audius-compose up --prod && audius-cmd test
+      command: |
+        . ~/.profile
+        if ! (audius-compose up --prod && audius-cmd test); then
+          echo
+          echo "TEST FAILURE"
+          echo "Performing cleanup"
+          echo
+          audius-compose down
+          false
+        fi
+  - run:
+      name: cleanup
+      no_output_timeout: 15m
+      command: . ~/.profile; audius-compose down


### PR DESCRIPTION
### Description

Containers will stay running if we don't perform cleanup at the end of self-hosted tests.

### How Has This Been Tested?

[CI success](https://app.circleci.com/pipelines/github/AudiusProject/audius-protocol/44294/workflows/030e57f8-3377-47ad-95d8-846c9c42b09e/jobs/570695)