### PR TITLE
[PAY-2060] Fix wrong challenge claimed so far amounts

### DIFF
--- a/packages/common/src/models/AudioRewards.ts
+++ b/packages/common/src/models/AudioRewards.ts
@@ -11,6 +11,7 @@ export type UserChallenge = {
   specifier: Specifier
   user_id: string
   amount: number
+  disbursed_amount: number
 }
 
 export type Specifier = string

--- a/packages/common/src/services/audius-api-client/AudiusAPIClient.ts
+++ b/packages/common/src/services/audius-api-client/AudiusAPIClient.ts
@@ -401,6 +401,7 @@ type UserChallengesResponse = [
     max_steps: number
     challenge_type: string
     amount: string
+    disbursed_amount: number
     metadata: object
   }
 ]

--- a/packages/common/src/utils/challenges.ts
+++ b/packages/common/src/utils/challenges.ts
@@ -245,6 +245,14 @@ export const isAudioMatchingChallenge = (
   )
 }
 
+// TODO: currently only $AUDIO matching challenges have cooldown
+// so this works, but really we should check if `cooldown_period` exists on the
+// challenge instead of using `!isAudioMatchingChallenge`. PAY-2030
 export const isCooldownChallengeClaimable = (
   challenge: UndisbursedUserChallenge
-) => dayjs.utc().diff(dayjs.utc(challenge.created_at), 'day') >= 7
+) => {
+  return (
+    !isAudioMatchingChallenge(challenge.challenge_id) ||
+    dayjs.utc().diff(dayjs.utc(challenge.created_at), 'day') >= 7
+  )
+}

--- a/packages/discovery-provider/src/api/v1/models/users.py
+++ b/packages/discovery-provider/src/api/v1/models/users.py
@@ -1,6 +1,6 @@
 from flask_restx import fields
 
-from .common import ns, StringEnumToLower
+from .common import StringEnumToLower, ns
 from .playlist_library import playlist_library
 
 # DEPRECATED
@@ -120,6 +120,7 @@ challenge_response = ns.model(
         "max_steps": fields.Integer(),
         "challenge_type": fields.String(required=True),
         "amount": fields.String(required=True),
+        "disbursed_amount": fields.Integer(required=True),
         "metadata": fields.Raw(required=True),
     },
 )

--- a/packages/discovery-provider/src/queries/get_challenges.py
+++ b/packages/discovery-provider/src/queries/get_challenges.py
@@ -9,7 +9,7 @@ from src.challenges.challenge_event_bus import ChallengeEventBus
 from src.models.rewards.challenge import Challenge, ChallengeType
 from src.models.rewards.challenge_disbursement import ChallengeDisbursement
 from src.models.rewards.user_challenge import UserChallenge
-from src.utils.spl_audio import from_wei
+from src.utils.spl_audio import from_lamports
 
 
 class ChallengeResponse(TypedDict):
@@ -37,7 +37,7 @@ def get_disbursed_amount(disbursements: List[ChallengeDisbursement]) -> int:
     if disbursements is None:
         return 0
     return sum(
-        from_wei(disbursement.amount)
+        from_lamports(disbursement.amount)
         for disbursement in filter(lambda x: x is not None, disbursements)
     )
 

--- a/packages/discovery-provider/src/utils/spl_audio.py
+++ b/packages/discovery-provider/src/utils/spl_audio.py
@@ -4,6 +4,8 @@ from typing import Union
 SPL_TO_WEI = 10**10
 SPL_TO_WEI_PADDING = "0" * 10
 
+WEI_TO_INT = 10**8
+
 
 def to_wei(balance: Union[int, str]):
     return int(balance) * SPL_TO_WEI if balance else 0
@@ -11,3 +13,7 @@ def to_wei(balance: Union[int, str]):
 
 def to_wei_string(spl_amount: Union[int, str]):
     return f"{spl_amount}{SPL_TO_WEI_PADDING}"
+
+
+def from_wei(spl_amount: str):
+    return int(spl_amount) / WEI_TO_INT if spl_amount else 0

--- a/packages/discovery-provider/src/utils/spl_audio.py
+++ b/packages/discovery-provider/src/utils/spl_audio.py
@@ -4,7 +4,7 @@ from typing import Union
 SPL_TO_WEI = 10**10
 SPL_TO_WEI_PADDING = "0" * 10
 
-WEI_TO_INT = 10**8
+LAMPORTS_PER_SOL = 10**8
 
 
 def to_wei(balance: Union[int, str]):
@@ -15,5 +15,5 @@ def to_wei_string(spl_amount: Union[int, str]):
     return f"{spl_amount}{SPL_TO_WEI_PADDING}"
 
 
-def from_wei(spl_amount: str):
-    return int(spl_amount) / WEI_TO_INT if spl_amount else 0
+def from_lamports(spl_amount: str):
+    return int(spl_amount) / LAMPORTS_PER_SOL if spl_amount else 0

--- a/packages/libs/src/services/discoveryProvider/DiscoveryProvider.ts
+++ b/packages/libs/src/services/discoveryProvider/DiscoveryProvider.ts
@@ -91,6 +91,7 @@ type DiscoveryNodeChallenge = {
   wallet: string
   completed_blocknumber: number
   created_at: string
+  disbursed_amount: number
 }
 
 export type DiscoveryRelayBody = {

--- a/packages/web/src/common/store/pages/audio-rewards/store.test.ts
+++ b/packages/web/src/common/store/pages/audio-rewards/store.test.ts
@@ -475,7 +475,8 @@ describe('Rewards Page Sagas', () => {
         max_steps: 7,
         challenge_type: 'numeric',
         specifier: '1',
-        user_id: '1'
+        user_id: '1',
+        disbursed_amount: 7
       },
       {
         challenge_id: 'referrals',
@@ -487,7 +488,8 @@ describe('Rewards Page Sagas', () => {
         max_steps: 5,
         challenge_type: 'numeric',
         specifier: '1',
-        user_id: '1'
+        user_id: '1',
+        disbursed_amount: 5
       },
       {
         challenge_id: 'track-upload',
@@ -499,7 +501,8 @@ describe('Rewards Page Sagas', () => {
         max_steps: 3,
         challenge_type: 'numeric',
         specifier: '1',
-        user_id: '1'
+        user_id: '1',
+        disbursed_amount: 3
       }
     ]
     const fetchUserChallengesProvisions: StaticProvider[] = [
@@ -607,7 +610,8 @@ describe('Rewards Page Sagas', () => {
         max_steps: 7,
         challenge_type: 'numeric',
         specifier: '1',
-        user_id: '1'
+        user_id: '1',
+        disbursed_amount: 7
       }
     ]
 
@@ -659,7 +663,8 @@ describe('Rewards Page Sagas', () => {
         max_steps: 7,
         challenge_type: 'numeric',
         specifier: '1',
-        user_id: '1'
+        user_id: '1',
+        disbursed_amount: 2
       }
     ]
 

--- a/packages/web/src/pages/audio-rewards-page/components/modals/ChallengeRewardsModal/AudioMatchingRewardsModalContent.tsx
+++ b/packages/web/src/pages/audio-rewards-page/components/modals/ChallengeRewardsModal/AudioMatchingRewardsModalContent.tsx
@@ -5,7 +5,8 @@ import {
   OptimisticUserChallenge,
   challengeRewardsConfig,
   formatNumberCommas,
-  useAudioMatchingChallengeCooldownSchedule
+  useAudioMatchingChallengeCooldownSchedule,
+  challengesSelectors
 } from '@audius/common'
 import { IconArrowRight, IconCloudUpload, Text } from '@audius/harmony'
 import {
@@ -16,6 +17,7 @@ import {
 import cn from 'classnames'
 import dayjs from 'dayjs'
 import utc from 'dayjs/plugin/utc'
+import { useSelector } from 'react-redux'
 
 import LoadingSpinner from 'components/loading-spinner/LoadingSpinner'
 import { SummaryTable } from 'components/summary-table'
@@ -27,6 +29,8 @@ import { EXPLORE_PREMIUM_TRACKS_PAGE, UPLOAD_PAGE } from 'utils/route'
 import { ProgressDescription } from './ProgressDescription'
 import { ProgressReward } from './ProgressReward'
 import styles from './styles.module.css'
+
+const { getOptimisticUserChallenges } = challengesSelectors
 
 dayjs.extend(utc)
 
@@ -97,11 +101,7 @@ export const AudioMatchingRewardsModalContent = ({
   const { fullDescription } = challengeRewardsConfig[challengeName]
   const { cooldownChallenges, claimableAmount, cooldownChallengesSummary } =
     useAudioMatchingChallengeCooldownSchedule(challenge?.challenge_id)
-
-  const audioClaimedSoFar = challenge
-    ? challenge.amount * challenge.current_step_count -
-      challenge.claimableAmount
-    : 0
+  const userChallenge = useSelector(getOptimisticUserChallenges)[challengeName]
 
   const progressDescription = (
     <ProgressDescription
@@ -123,11 +123,11 @@ export const AudioMatchingRewardsModalContent = ({
   )
 
   const progressStatusLabel =
-    audioClaimedSoFar > 0 ? (
+    userChallenge && userChallenge?.disbursed_amount > 0 ? (
       <div className={styles.audioMatchingTotalContainer}>
         <Text variant='label' size='l' strength='strong' color='subdued'>
           {messages.totalEarned(
-            formatNumberCommas(audioClaimedSoFar.toString())
+            formatNumberCommas(userChallenge.disbursed_amount.toString())
           )}
         </Text>
       </div>


### PR DESCRIPTION
### Description
Fixes a bug discovered during QA where the challenge would show a "total claimed so far" amount even before the challenge was claimed, and after claiming the value was also incorrect.

This ended up being more of a rabbit hole than I wanted but it works now! And in the process I discovered that my previous changes had broken referrals (other aggregate challenge that's not $AUDIO matching), which is also fixed now.

Dragon:
I am using `IsAudioMatchingChallenge` as a proxy for whether the challenge has a cooldown period. This works for now because only $AUDIO matching challenges have cooldowns. But if/when that changes this will break. Should really cross-ref with the challenge and whether or not is has a `cooldown_days` field as a way to know whether it has a cooldown period or not, but that requires more plumbing. Linked the TODO to https://linear.app/audius/issue/PAY-2030/use-cooldown-days-from-api-instead-of-isaudiomatchingchallenge.

### How Has This Been Tested?

Tested on local stack:
- confirmed referrals challenge works (non-audio-matching aggregate challenge)
- confirmed other non-aggregate challenge behavior didn't change