### PR TITLE
Configure bootstrap dev CNs in sdk consumer

### DIFF
--- a/sdk-consumer/index.ts
+++ b/sdk-consumer/index.ts
@@ -34,6 +34,8 @@ import {
   UnrepostAlbumRequest,
   UpdateProfileRequest,
   Logger,
+  StorageNodeSelector,
+  AppAuth,
 } from "@audius/sdk";
 import express from "express";
 import multer from "multer";
@@ -52,7 +54,9 @@ const discoveryNodeSelector = new DiscoveryNodeSelector({
   initialSelectedNode: "http://audius-protocol-discovery-provider-1",
 });
 
-const logger = new Logger({ logLevel: "info" });
+const logger = new Logger({ logLevel: "info" })
+const apiKey = ""
+const apiSecret = ""
 
 const audiusSdk = sdk({
   services: {
@@ -62,13 +66,18 @@ const audiusSdk = sdk({
       web3ProviderUrl: developmentConfig.web3ProviderUrl,
       contractAddress: developmentConfig.entityManagerContractAddress,
       identityServiceUrl: developmentConfig.identityServiceUrl,
-      logger,
+      useDiscoveryRelay: true,
+      logger
     }),
-    logger,
+    storageNodeSelector: new StorageNodeSelector({
+      auth: new AppAuth(apiKey, apiSecret),
+      discoveryNodeSelector: discoveryNodeSelector,
+      bootstrapNodes: developmentConfig.storageNodes
+    })
   },
-  apiKey: "",
-  apiSecret: "",
-});
+  apiKey,
+  apiSecret
+})
 
 app.listen(port, () => {
   console.log(`sdk-consumer listening on port ${port}`);


### PR DESCRIPTION
### Description
If an SDK action is taken before it's fully initialized, it will use production CNs by default. this passes in a StorageNodeSelector with the correct dev CNs.

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._
Ran locally and confirmed bootstrap nodes are configured and upload track works.