### PR TITLE
[PAY-2038] Catch errors creating stripe session and cancel purchase

### DIFF
--- a/packages/common/src/models/Analytics.ts
+++ b/packages/common/src/models/Analytics.ts
@@ -321,6 +321,7 @@ export enum Name {
   // Buy USDC
   BUY_USDC_ON_RAMP_OPENED = 'Buy USDC: On Ramp Opened',
   BUY_USDC_ON_RAMP_CANCELED = 'Buy USDC: On Ramp Canceled',
+  BUY_USDC_ON_RAMP_FAILURE = 'Buy USDC: On Ramp Failed',
   BUY_USDC_ON_RAMP_SUCCESS = 'Buy USDC: On Ramp Success',
   BUY_USDC_SUCCESS = 'Buy USDC: Success',
   BUY_USDC_FAILURE = 'Buy USDC: Failure',
@@ -1559,6 +1560,12 @@ type BuyUSDCOnRampCanceled = {
   provider: string
 }
 
+type BuyUSDCOnRampFailed = {
+  eventName: Name.BUY_USDC_ON_RAMP_FAILURE
+  error: string
+  provider: string
+}
+
 type BuyUSDCOnRampSuccess = {
   eventName: Name.BUY_USDC_ON_RAMP_SUCCESS
   provider: string
@@ -1933,6 +1940,7 @@ export type AllTrackingEvents =
   | BuyUSDCOnRampOpened
   | BuyUSDCOnRampSuccess
   | BuyUSDCOnRampCanceled
+  | BuyUSDCOnRampFailed
   | BuyUSDCSuccess
   | BuyUSDCFailure
   | BuyUSDCRecoveryInProgress

--- a/packages/common/src/services/audius-backend/stripe.ts
+++ b/packages/common/src/services/audius-backend/stripe.ts
@@ -10,7 +10,9 @@ export const createStripeSession = async (
   audiusBackendInstance: AudiusBackend,
   config: CreateStripeSessionArgs
 ) => {
-  return (
-    await audiusBackendInstance.getAudiusLibs()
-  ).identityService?.createStripeSession(config)
+  const libs = await audiusBackendInstance.getAudiusLibsTyped()
+  if (!libs.identityService) {
+    throw new Error('createStripeSession: Unexpected missing identity service')
+  }
+  return libs.identityService.createStripeSession(config)
 }

--- a/packages/common/src/store/buy-usdc/slice.ts
+++ b/packages/common/src/store/buy-usdc/slice.ts
@@ -59,8 +59,11 @@ const slice = createSlice({
     onrampSucceeded: (state) => {
       state.stage = BuyUSDCStage.CONFIRMING_PURCHASE
     },
-    buyUSDCFlowFailed: (state) => {
-      state.error = new Error('USDC purchase failed')
+    onrampFailed: (state, action: PayloadAction<{ error: Error }>) => {
+      state.error = new Error(`Stripe onramp failed: ${action.payload}`)
+    },
+    buyUSDCFlowFailed: (state, action: PayloadAction<{ error: Error }>) => {
+      state.error = action.payload.error
     },
     buyUSDCFlowSucceeded: (state) => {
       state.stage = BuyUSDCStage.FINISH
@@ -91,6 +94,7 @@ export const {
   purchaseStarted,
   onrampSucceeded,
   onrampCanceled,
+  onrampFailed,
   stripeSessionStatusChanged,
   startRecoveryIfNecessary,
   recoveryStatusChanged,

--- a/packages/common/src/store/ui/stripe-modal/slice.ts
+++ b/packages/common/src/store/ui/stripe-modal/slice.ts
@@ -1,4 +1,4 @@
-import { Action, createSlice, PayloadAction } from '@reduxjs/toolkit'
+import { createSlice, PayloadAction } from '@reduxjs/toolkit'
 
 import {
   StripeSessionStatus,
@@ -10,8 +10,9 @@ type InitializeStripeModalPayload = {
   amount: string
   destinationCurrency: StripeDestinationCurrencyType
   destinationWallet: string
-  onrampSucceeded: Action
-  onrampCanceled: Action
+  onrampFailed: StripeModalState['onrampFailed']
+  onrampSucceeded: StripeModalState['onrampSucceeded']
+  onrampCanceled: StripeModalState['onrampCanceled']
 }
 
 const initialState: StripeModalState = {}
@@ -25,6 +26,7 @@ const slice = createSlice({
       action: PayloadAction<InitializeStripeModalPayload>
     ) => {
       state.stripeSessionStatus = 'initialized'
+      state.onrampFailed = action.payload.onrampFailed
       state.onrampSucceeded = action.payload.onrampSucceeded
       state.onrampCanceled = action.payload.onrampCanceled
     },

--- a/packages/common/src/store/ui/stripe-modal/types.ts
+++ b/packages/common/src/store/ui/stripe-modal/types.ts
@@ -12,6 +12,7 @@ export type StripeDestinationCurrencyType = 'sol' | 'usdc'
 export type StripeModalState = {
   onrampSucceeded?: Action
   onrampCanceled?: Action
+  onrampFailed?: Action
   stripeSessionStatus?: StripeSessionStatus
   stripeClientSecret?: string
 }

--- a/packages/web/src/components/buy-audio-modal/components/StripeBuyAudioButton.tsx
+++ b/packages/web/src/components/buy-audio-modal/components/StripeBuyAudioButton.tsx
@@ -49,6 +49,7 @@ export const StripeBuyAudioButton = () => {
           amount,
           onrampSucceeded,
           onrampCanceled,
+          onrampFailed: onrampCanceled,
           destinationCurrency: 'sol',
           destinationWallet
         })


### PR DESCRIPTION
### Description
fixes PAY-2038

This cleans up a TODO for catching errors when initializing the Stripe session. We will now pipe them back up to the USDC purchase saga and merge into the error flow there. This has the result of canceling the purchasing state and showing an error at the bottom of the modal. We will log the errors to analytics.

There are future tickets to pipe more detailed information back from the createSession call.

### How Has This Been Tested?
Tested locally on Chrome against staging
