### PR TITLE
[INF-490] Update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,8 +39,8 @@ For details on operating an Audius service, getting started with the Token and t
 | [`libs`](./packages/libs)                                                                       | `@audius/sdk` and legacy shared utilities `libs`                                                                                                                                      |
 | [`mobile`](./packages/mobile)                                                                   | The Audius reference mobile application                                                                                                                                               |
 | [`probers`](./packages/probers)                                                                 | E2E web tests                                                                                                                                                                         |
-| [`spl`](./packages/spl)                                                                         | Handles Solana instructions for the Audius programs                                                                                                                                   |
 | [`solana-programs`](https://github.com/AudiusProject/audius-protocol/tree/main/solana-programs) | The Solana programs for the Audius protocol, encompassing user account, content listing, and content interaction functionality                                                        |
+| [`spl`](./packages/spl)                                                                         | Handles Solana instructions for the Audius programs                                                                                                                                   |
 | [`sql-ts`](./packages/sql-ts)                                                                   | A typescript database client                                                                                                                                                          |
 | [`stems`](./packages/stems)                                                                     | The Audius client component library                                                                                                                                                   |
 | [`trpc-server`](./packages/trpc-server)                                                         | tRPC server used for serving data                                                                                                                                                     |
@@ -48,25 +48,15 @@ For details on operating an Audius service, getting started with the Token and t
 
 ### Required Dependencies
 
-The following dependencies are required to run Audius:
-
-```
-node python ruby docker docker-compose
-```
-
-`npm install` will fail if they are not met. We recommend [homebrew](https://brew.sh/), [pyenv](https://github.com/pyenv/pyenv), and [rbenv](https://github.com/rbenv/rbenv). Don't forget to follow the instructions in the install command output (eg. adding things to your `.zshrc` or `bashrc` file).
+`npm install` will fail if certain dependencies are not met. We recommend using [homebrew](https://brew.sh/) to install them:
 
 ```bash
 brew install nvm pyenv rbenv homebrew/cask/docker docker-compose
-
-nvm install
-pyenv install
-rbenv install
 ```
 
-### Getting Started
+> Don't forget to follow the instructions in the install command output (eg. adding things to your `.zshrc` or `bashrc` file).
 
-After cloning run:
+### Getting Started
 
 ```bash
 npm install
@@ -74,7 +64,7 @@ npm install
 
 This will do the following:
 
-- Check that you have the correct versions of node, ruby, and python
+- Install the correct versions of node, ruby, and python
 - Install dependencies (npm packages, gems, pods, etc.)
 - Set up command line tools for interacting with the protocol ([dev-tools/README.md](./dev-tools/README.md))
 - Initialize git hooks

--- a/README.md
+++ b/README.md
@@ -48,13 +48,13 @@ For details on operating an Audius service, getting started with the Token and t
 
 ### Required Dependencies
 
-`npm install` will fail if certain dependencies are not met. We recommend using [homebrew](https://brew.sh/) to install them:
+We recommend using [homebrew](https://brew.sh/) to install the dependencies required to run Audius:
 
 ```bash
 brew install nvm pyenv rbenv homebrew/cask/docker docker-compose
 ```
 
-> Don't forget to follow the instructions in the install command output (eg. adding things to your `.zshrc` or `bashrc` file).
+> You will need to add some shell configuration for [`nvm`](https://github.com/nvm-sh/nvm#installing-and-updating), [`pyenv`](https://github.com/pyenv/pyenv#set-up-your-shell-environment-for-pyenv), and [`rbenv`](https://github.com/rbenv/rbenv#basic-git-checkout). Please refer to the respective documentation and the installation output
 
 ### Getting Started
 

--- a/README.md
+++ b/README.md
@@ -19,35 +19,45 @@
 
 Audius is a decentralized, community-owned music-sharing protocol
 
-For further details on operating an Audius service, getting started with the Token and the API, see [docs.audius.org](https://docs.audius.org/).
-
-## Apps
-
-| Name                          | Description                            |
-| ----------------------------- | -------------------------------------- |
-| [`web`](./packages/web)       | The Audius web and desktop application |
-| [`mobile`](./packages/mobile) | The Audius mobile application          |
+For details on operating an Audius service, getting started with the Token and the API, see [docs.audius.org](https://docs.audius.org/).
 
 ## Packages
 
-| Name                                                      | Description                         |
-| --------------------------------------------------------- | ----------------------------------- |
-| [`stems`](./packages/stems)                               | The Audius client component library |
-| [`common`](./packages/common)                             | Shared code between web and mobile  |
-| [`eslint-config-audius`](./packages/eslint-config-audius) | Shared lint configuration           |
+| Name                                                                                            | Description                                                                                                                                                                           |
+| ----------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [`commands`](./packages/commands)                                                               | CLI to perform actions against the protocol                                                                                                                                           |
+| [`common`](./packages/common)                                                                   | Shared code between web and mobile                                                                                                                                                    |
+| [`compose`](./packages/compose)                                                                 | Defines dependencies for audius-compose                                                                                                                                               |
+| [`contracts`](https://github.com/AudiusProject/audius-protocol/tree/main/contracts)             | The POA network smart contracts for the Audius protocol, encompassing user account, content listing, and content interaction functionality                                            |
+| [`creator-node`](mediorum)                                                                      | Maintains the availability of users' content via the Audius Storage Protocol, including user images and audio content. Also known as Content Node or mediorum.                        |
+| [`discovery-provider`](packages/discovery-provider)                                             | Indexes and stores the contents of the audius contracts on the Ethereum & Solana blockchains for clients to query via an API. Also known as Discovery Node.                           |
+| [`embed`](./packages/embed)                                                                     | Embed player that renders on third party sites                                                                                                                                        |
+| [`eslint-config-audius`](./packages/eslint-config-audius)                                       | Shared lint configuration                                                                                                                                                             |
+| [`eth-contracts`](https://github.com/AudiusProject/audius-protocol/tree/main/eth-contracts)     | The Ethereum smart contracts that run the Audius protocol, encompassing the Audius ERC20 token and functionality for staking, off-chain service registration / lookup, and governance |
+| [`harmony`](./packages/harmony)                                                                 | The Audius design system                                                                                                                                                              |
+| [`identity-service`](packages/identity-service)                                                 | Stores encrypted auth ciphertexts and handles oauth artifacts                                                                                                                         |
+| [`libs`](./packages/libs)                                                                       | `@audius/sdk` and legacy shared utilities `libs`                                                                                                                                      |
+| [`mobile`](./packages/mobile)                                                                   | The Audius reference mobile application                                                                                                                                               |
+| [`probers`](./packages/probers)                                                                 | E2E web tests                                                                                                                                                                         |
+| [`spl`](./packages/spl)                                                                         | Handles Solana instructions for the Audius programs                                                                                                                                   |
+| [`solana-programs`](https://github.com/AudiusProject/audius-protocol/tree/main/solana-programs) | The Solana programs for the Audius protocol, encompassing user account, content listing, and content interaction functionality                                                        |
+| [`sql-ts`](./packages/sql-ts)                                                                   | A typescript database client                                                                                                                                                          |
+| [`stems`](./packages/stems)                                                                     | The Audius client component library                                                                                                                                                   |
+| [`trpc-server`](./packages/trpc-server)                                                         | tRPC server used for serving data                                                                                                                                                     |
+| [`web`](./packages/web)                                                                         | The Audius reference web and desktop application                                                                                                                                      |
 
 ### Required Dependencies
 
-The following dependencies are required to run the Audius client:
+The following dependencies are required to run Audius:
 
 ```
-node python ruby
+node python ruby docker docker-compose
 ```
 
 `npm install` will fail if they are not met. We recommend [homebrew](https://brew.sh/), [pyenv](https://github.com/pyenv/pyenv), and [rbenv](https://github.com/rbenv/rbenv). Don't forget to follow the instructions in the install command output (eg. adding things to your `.zshrc` or `bashrc` file).
 
-```
-brew install nvm pyenv rbenv
+```bash
+brew install nvm pyenv rbenv homebrew/cask/docker docker-compose
 
 nvm install
 pyenv install
@@ -64,101 +74,34 @@ npm install
 
 This will do the following:
 
-- Check you have the correct versions of node, ruby, and python
-- Install root dependencies
-- Install all package dependencies
-- Initialize git hooks (`npx @escape.tech/mookme init --only-hook --skip-types-selection`)
-- Install ios pods
+- Check that you have the correct versions of node, ruby, and python
+- Install dependencies (npm packages, gems, pods, etc.)
+- Set up command line tools for interacting with the protocol ([dev-tools/README.md](./dev-tools/README.md))
+- Initialize git hooks
 
-### Running A Client
+### Running the Protocol
+
+```bash
+npm run protocol
+```
+
+For more details and troubleshooting please refer to [dev-tools/README.md](./dev-tools/README.md)
+
+### Running the Client
 
 Environments:
 
-- \*:dev runs against local services
-- \*:stage runs against the staging testnet
-- \*:prod runs against production infrastructure
+- `\*:dev` runs against local services
+- `\*:stage` runs against the staging testnet
+- `\*:prod` runs against production infrastructure
+
+For example:
 
 ```bash
-# web
-npm run web:dev
-npm run web:stage
 npm run web:prod
-
-# desktop
-npm run desktop:dev
-npm run desktop:stage
-npm run desktop:prod
-
-# mobile
-
-# ios
-npm run ios:dev
-npm run ios:stage
-npm run ios:prod
-# on a physical device
-xcrun xctrace list devices
-npm run ios:<env> -- --device "My iPhone"
-
-# android
-npm run android:dev
-npm run android:stage
-npm run android:prod
-# on a physical device
-adb devices
-npm run android:<env> -- --device "A38M608KHBK"
-
-# stems in watch mode
-npm run stems
-
-# common in watch mode
-npm run common
-
-# lint and typecheck
-npm run verify
 ```
 
-## Overview
-
-### Audius Services
-
-These off-chain services are run by community members via the Audius staking system:
-
-| Service                                    | Description                                                                                                                                                    |
-| ------------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| [`creator-node`](mediorum)                 | Maintains the availability of users' content via the Audius Storage Protocol, including user images and audio content. Also known as Content Node or mediorum. |
-| [`discovery-provider`](discovery-provider) | Indexes and stores the contents of the audius contracts on the Ethereum & Solana blockchains for clients to query via an API. Also known as Discovery Node.    |
-| [`identity-service`](identity-service)     | Stores encrypted auth ciphertexts and handles oauth artifacts                                                                                                  |
-
-### Smart Contracts & Programs
-
-The independent sets of smart contracts that power the on-chain aspects of the Audius protocol:
-
-| Contracts                                                                                       | Description                                                                                                                                                                           |
-| ----------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| [`eth-contracts`](https://github.com/AudiusProject/audius-protocol/tree/main/eth-contracts)     | The Ethereum smart contracts that run the Audius protocol, encompassing the Audius ERC20 token and functionality for staking, off-chain service registration / lookup, and governance |
-| [`solana-programs`](https://github.com/AudiusProject/audius-protocol/tree/main/solana-programs) | The Solana programs for the Audius protocol, encompassing user account, content listing, and content interaction functionality                                                        |
-| [`contracts`](https://github.com/AudiusProject/audius-protocol/tree/main/contracts)             | The POA network smart contracts for the Audius protocol, encompassing user account, content listing, and content interaction functionality                                            |
-
-### Audius Client Libraries
-
-Client-side libraries to provide a unified interface for interacting with the entire
-Audius protocol:
-
-| Library                                                                            | Description                                                                                                                           |
-| ---------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------- |
-| [`libs`](https://github.com/AudiusProject/audius-protocol/tree/main/packages/libs) | A complete javascript interface to the Audius smart contracts and Audius services: Identity Service, Discovery Provider, Creator Node |
-
-## Development
-
-### Prerequisites
-
-- Install docker & docker-compose [https://docs.docker.com/get-docker](https://docs.docker.com/get-docker)
-- Install rust https://rustup.rs/
-- Install nvm & node (v14.17.5) https://github.com/nvm-sh/nvm
-
-### Running the protocol
-
-Refer to [dev-tools/README.md](./dev-tools/README.md)
+For all available commands please see the [package.json scripts](https://github.com/AudiusProject/audius-protocol/blob/f850434ddca7d697f78a58d971f9bba1aba7f24d/package.json#L10) and the relevant package READMEs.
 
 ## Contributing
 

--- a/dev-tools/README.md
+++ b/dev-tools/README.md
@@ -2,9 +2,11 @@
 
 ## Setup
 
-Make sure you've done `npm i` at the root of the repo. This will run `dev-tools/setup.sh`
+Make sure you've done `npm i` at the root of the repo. This will run `dev-tools/setup.sh`.
 
-You can also install dev-tools without cloning the repo by doing:
+You may need to restart your shell, or do `. ~/.profile` to ensure everything is in your path.
+
+Alternatively, you can install dev-tools without cloning the repo by doing:
 
 ```bash
 curl "https://raw.githubusercontent.com/AudiusProject/audius-protocol/main/dev-tools/setup.sh" | bash
@@ -12,15 +14,17 @@ curl "https://raw.githubusercontent.com/AudiusProject/audius-protocol/main/dev-t
 
 ## Bring up the protocol
 
+Make sure Docker is running and do:
+
 ```
 npm run protocol
 ```
 
-You can use `watch audius-compose ps` to ensure that all services report "Status" as Healthy.
+You can use `audius-compose ps` to ensure that all services report "Status" as Healthy.
 
 > All options passed to `npm run protocol` will be passed to `audius-compose` under the hood.
 
-> You can also do `audius-compose up` directly, but this has the disadvantage of not building the required Javascript dependencies before bringing up the protocol. See (CLI Tools)(#cli-tools) for details
+> You can also do `audius-compose up` directly, but this has the disadvantage of not building the required Javascript dependencies before bringing up the protocol. See [CLI Tools](#cli-tools) for details
 
 ## Connect via hostname or client
 

--- a/dev-tools/README.md
+++ b/dev-tools/README.md
@@ -1,25 +1,92 @@
-# Summary
+# Audius Protocol Dev Tools
+
+## Setup
+
+Make sure you've done `npm i` at the root of the repo. This will run `dev-tools/setup.sh`
+
+You can also install dev-tools without cloning the repo by doing:
+
+```bash
+curl "https://raw.githubusercontent.com/AudiusProject/audius-protocol/main/dev-tools/setup.sh" | bash
+```
+
+## Bring up the protocol
+
+```
+npm run protocol
+```
+
+You can use `watch audius-compose ps` to ensure that all services report "Status" as Healthy.
+
+> All options passed to `npm run protocol` will be passed to `audius-compose` under the hood.
+
+> You can also do `audius-compose up` directly, but this has the disadvantage of not building the required Javascript dependencies before bringing up the protocol. See (CLI Tools)(#cli-tools) for details
+
+## Connect via hostname or client
+
+To use the client from a mac, we need to route hostnames to the audius-compose nginx reverse proxy by running:
+
+```
+audius-compose connect
+```
+
+## CLI Tools
 
 Use these CLI tools for Audius dev. Currently there are 3 tools available:
 
-`audius-cloud`: create a pre-configured GCP VM for dev
-`audius-compose`: start, stop, and manage Audius service containers
-`audius-cmd`: perform user actions, e.g. `create-user`, `upload-track`, `repost-playlist`
+- `audius-cloud`: create a pre-configured GCP VM for dev
+- `audius-compose`: start, stop, and manage Audius service containers
+- `audius-cmd`: perform user actions, e.g. `create-user`, `upload-track`, `repost-playlist`
 
 View all available commands for any of these tools with `--help`, e.g.
-```
+
+```bash
 > audius-cloud --help
 > audius-compose --help
 > audius-cmd --help
 ```
 
-# Setup Instructions
+### Perform actions with `audius-cmd`
 
-## Resource Requirements
+You can confirm that things are wired up correctly by running `audius-cmd create-user`.
+Note that `audius-cmd` requires the stack to be up and healthy, per [Bring up the protocol](#bring-up-the-protocol), and to have run `audius-compose connect`.
+
+Examples of available commands can be found [here](../packages/commands)
+
+# Helpful Commands
+
+Periodically prune docker cache
+
+```
+audius-compose prune
+```
+
+Get service logs
+
+```
+audius-compose logs discovery-provider-1 # get name from `docker ps`
+```
+
+Set environment variables
+
+```
+audius-compose set-env discovery-provider-1 audius_discprov_url https://discoveryprovider.testing.com/
+```
+
+Load environment variables
+
+```
+audius-compose load-env discovery-provider prod
+```
+
+# Troubleshooting
+
+## Increase Docker Resource Requirements
 
 Increase `docker` resource allocations to avoid OOM kills and your local docker image repository running out of space.
-Below are suggested minimum values.
-```
+Below are suggested minimum values:
+
+```bash
 Docker > Preferences > Resources > Advanced
 - CPUs 4
 - Memory 13 GB
@@ -28,97 +95,46 @@ Docker > Preferences > Resources > Advanced
 
 If you still run into issues, you may execute a `docker system prune` to free additional space.
 
-### Install dev-tools (this repo)
-
-This step only needs to be run once
-
-```
-curl "https://raw.githubusercontent.com/AudiusProject/audius-protocol/main/dev-tools/setup.sh" | bash
-
-# refresh terminal for docker
-exit
-
-# In new terminal
-audius-compose build # takes about 10 min
-```
-
-### Bring up protocol stack
-
-```
-audius-compose up
-```
-This command completes in 1-2 min, but use `watch docker ps -a` to ensure that all services report "Status" as Healthy. It currently takes ~6min for this to happen.
-
-## Connect via hostname or client
-
-To use the client from a mac, we need to route hostnames to the audius-compose nginx reverse proxy by running:
-```
-audius-compose connect
-```
-
-### Perform actions with `audius-cmd`
-
-You can confirm that things are wired up correctly by running `audius-cmd create-user`.
-Note that `audius-cmd` requires the stack to be up and healthy, per [Bring up protocol stack](#bring-up-protocol-stack), and to have run `audius-compose connect`.
-
-# Helpful Commands
-
-Periodically prune docker cache
-```
-audius-compose prune
-```
-
-Get service logs
-```
-audius-compose logs discovery-provider-1 # get name from `docker ps`
-```
-
-Set environment variables
-```
-audius-compose set-env discovery-provider-1 audius_discprov_url https://discoveryprovider.testing.com/
-```
-
-Load environment variables
-```
-audius-compose load-env discovery-provider prod
-```
-
 # Development
 
 ## audius-compose
-* The [audius-compose Python script](./audius-compose) in this directory handles all `audius-compose` command logic and subcommands. Any changes you make there will be reflected automatically - no reinstallation needed
-* `audius-compose up` is a wrapper for creating the top-level .env file (see the `generate_env()` function in the `audius-compose` Python script) and then running `docker compose up` with various services passed as args
+
+- The [audius-compose Python script](./audius-compose) in this directory handles all `audius-compose` command logic and subcommands. Any changes you make there will be reflected automatically - no reinstallation needed
+- `audius-compose up` is a wrapper for creating the top-level .env file (see the `generate_env()` function in the `audius-compose` Python script) and then running `docker compose up` with various services passed as args
 
 ## Docker services
-* Every Docker service is defined in one of the audius-protocol root-level .yml files (e.g., `docker-compose.discovery.yml` for services related to Discovery Node), and then it's imported into `docker-compose.yml` using [extends](https://docs.docker.com/compose/extends/#understand-the-extends-configuration) syntax
-  * This pattern prevents the top-level `docker-compose.yml` file from growing too large and allows every service to have standardized logging, `extra_hosts` (allows the containers to talk to each other), and memory limits (makes `docker stats` more readable) by using the `<<: *common` property. This property is YAML's "merge key" syntax which essentially adds every field from the `common` variable defined at the top of the file
-  * `docker-compose.test.yml` also imports `docker-compose.yml` services for building images and testing in CI
+
+- Every Docker service is defined in one of the audius-protocol root-level .yml files (e.g., `docker-compose.discovery.yml` for services related to Discovery Node), and then it's imported into `docker-compose.yml` using [extends](https://docs.docker.com/compose/extends/#understand-the-extends-configuration) syntax
+  - This pattern prevents the top-level `docker-compose.yml` file from growing too large and allows every service to have standardized logging, `extra_hosts` (allows the containers to talk to each other), and memory limits (makes `docker stats` more readable) by using the `<<: *common` property. This property is YAML's "merge key" syntax which essentially adds every field from the `common` variable defined at the top of the file
+  - `docker-compose.test.yml` also imports `docker-compose.yml` services for building images and testing in CI
 
 ## Networking
-* `audius-compose connect` allows you to access containers via hostname by appending hostnames to your `/etc/hosts` (one-time operation unless you change container names or add a new service)
-* This `/etc/hosts` change tells your browser (or CURL, or whatever) to go to `127.0.0.1`
-* The `ingress` container listens on `127.0.0.1` for port 80 and redirects every request to the desired container based on hostname
-  * For example, if you request `audius-protocol-discovery-provider-1/health_check`, the `ingress` container sees the hostname as `audius-protocol-discovery-provider-1` and directs it to the Discovery Node's container and port. This removes the need for you as the dev (or any application code except ingress) to ever worry about port numbers
-* The `extra_hosts` config that gets added to every service in `docker-compose.yml` is what allows this to happen from within containers. For example, the `extra_hosts` line that says `- "audius-protocol-discovery-provider-1:host-gateway"` tells every container, "When you see the hostname "audius-protocol-discovery-provider-1", resolve it using the machine's (not the container's) localhost (i.e., "host-gateway"). Your machine's localhost knows to direct "audius-protocol-discovery-provider-1" to 127.0.0.1:80 (thanks to `audius-compose connect`), where the nginx `ingress` container will be listening and will direct the request to the Discovery Node container
+
+- `audius-compose connect` allows you to access containers via hostname by appending hostnames to your `/etc/hosts` (one-time operation unless you change container names or add a new service)
+- This `/etc/hosts` change tells your browser (or CURL, or whatever) to go to `127.0.0.1`
+- The `ingress` container listens on `127.0.0.1` for port 80 and redirects every request to the desired container based on hostname
+  - For example, if you request `audius-protocol-discovery-provider-1/health_check`, the `ingress` container sees the hostname as `audius-protocol-discovery-provider-1` and directs it to the Discovery Node's container and port. This removes the need for you as the dev (or any application code except ingress) to ever worry about port numbers
+- The `extra_hosts` config that gets added to every service in `docker-compose.yml` is what allows this to happen from within containers. For example, the `extra_hosts` line that says `- "audius-protocol-discovery-provider-1:host-gateway"` tells every container, "When you see the hostname "audius-protocol-discovery-provider-1", resolve it using the machine's (not the container's) localhost (i.e., "host-gateway"). Your machine's localhost knows to direct "audius-protocol-discovery-provider-1" to 127.0.0.1:80 (thanks to `audius-compose connect`), where the nginx `ingress` container will be listening and will direct the request to the Discovery Node container
 
 ## Adding a service
+
 1. Configure the service in its own .yml file, either using an existing one (e.g., use `docker-compose.discovery.yml` if it's a Discovery-related service) or by creating a new one
-    * The typical pattern here is to have a `Dockerfile` in the service's directory, and then when configuring the service (e.g., in top-level `docker-compose.discovery.yml`) use:
-      ```
-      service-name:
-        build:
-            context: <service_directory containing Dockerfile (e.g., discovery-provider)>
-      ```
+   - The typical pattern here is to have a `Dockerfile` in the service's directory, and then when configuring the service (e.g., in top-level `docker-compose.discovery.yml`) use:
+     ```
+     service-name:
+       build:
+           context: <service_directory containing Dockerfile (e.g., discovery-provider)>
+     ```
 2. Add that service to the top-level `docker-compose.yml` file using the extends syntax, and then add `<<: *common`. Example:
-    ```
-    service-name:
-      extends:
-        file: docker-compose.service-name.yml
-        service: service-name
-      <<: *common
-    ```
+   ```
+   service-name:
+     extends:
+       file: docker-compose.service-name.yml
+       service: service-name
+     <<: *common
+   ```
 3. Allow all other containers to talk to the service via hostname by updating:
-    * `extra_hosts` in the "common" variable at the top of `docker-compose.yml` like: `- "service-name:host-gateway"`
-    * the list that `audius-compose connect` uses in the [audius-compose Python script](./audius-compose) in this directory to include `service-name`
+   - `extra_hosts` in the "common" variable at the top of `docker-compose.yml` like: `- "service-name:host-gateway"`
+   - the list that `audius-compose connect` uses in the [audius-compose Python script](./audius-compose) in this directory to include `service-name`
 4. Import the same service in `docker-compose.test.yml`, if needed, to build+test in CI
 5. Optionally, add a flag to the `up` subcommand in the [audius-compose Python script](./audius-compose) in this directory if you want to do something like skip bringing up this service by default (helpful for expensive services)

--- a/packages/commands/README.md
+++ b/packages/commands/README.md
@@ -5,6 +5,8 @@ audius-cmd --help
 audius-cmd <command> --help
 ```
 
+`audius-cmd` is a command line tool to perform actions against the Audius protocol. It is especially useful to seed data on an instance of the protocol running locally
+
 ## Examples
 
 **create-user**

--- a/scripts/postinstall.sh
+++ b/scripts/postinstall.sh
@@ -12,3 +12,6 @@ if [[ -z "${SKIP_POD_INSTALL}" ]]; then
     pod install
   fi
 fi
+
+cd ../../..
+./dev-tools/setup.sh

--- a/scripts/preinstall.sh
+++ b/scripts/preinstall.sh
@@ -6,7 +6,13 @@ if ! [ -z $CI ]; then
   exit 0
 fi
 
+export NVM_DIR=$HOME/.nvm;
+source $NVM_DIR/nvm.sh;
+
+nvm install
 cp .python-version-dev .python-version
+pyenv install -s
+rbenv install -s
 
 required_node_version=$(<.nvmrc)
 current_node_version=$(node --version)


### PR DESCRIPTION
### Description

* Update readme to be easier to understand in regards to the monorepo
  * The aim here was to keep the top level readme quite simple, with easy to follow setup instructions. Then more detail about each package can be found in the corresponding readme
* Automatically install the proper node, python, and ruby version in the preinstall script
  * This means `nvm`, `pyenv`, and `rbenv` are no longer suggestions but requirements
* Automatically run `dev-tools/setup.sh` in the postinstall, this makes it so that `npm run protocol` works out of the box
  * Thanks @phelpsdb for making this script idempotent!

### How Has This Been Tested?

Tested by creating a new macos user, and following the readme instructions to set everything up from scratch
