### PR TITLE
Float audio matching challenges to the top

### DIFF
--- a/packages/common/src/utils/challenges.ts
+++ b/packages/common/src/utils/challenges.ts
@@ -209,6 +209,9 @@ export const makeOptimisticChallengeSortComparator = (
     const userChallenge1 = userChallenges[id1]
     const userChallenge2 = userChallenges[id2]
 
+    if (isAudioMatchingChallenge(id1)) {
+      return -1
+    }
     if (!userChallenge1 || !userChallenge2) {
       return 0
     }


### PR DESCRIPTION
### Description
Make it so that audio matching challenges appear at the top of the challenge list.

### How Has This Been Tested?

Local stack
