### PR TITLE
Fix race condition in compose deploy

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -104,14 +104,17 @@ jobs:
             OLD_VERSION=$(jq -r .version packages/discovery-provider/.version.json)
             NEW_VERSION=$(echo ${OLD_VERSION} | awk -F. '{$NF = $NF + 1;} 1' | sed 's/ /./g')
 
+            # Bump version for content node
             jq --arg version "$NEW_VERSION" '.version=$version' mediorum/.version.json > /tmp/.version.json
             mv /tmp/.version.json mediorum/.version.json
             git add mediorum/.version.json
 
+            # Bump version for discovery node
             jq --arg version "$NEW_VERSION" '.version=$version' packages/discovery-provider/.version.json > /tmp/.version.json
             mv /tmp/.version.json packages/discovery-provider/.version.json
             git add packages/discovery-provider/.version.json
 
+            # Weird way to push both to main and the new release branch
             git commit -m "Bump version to $NEW_VERSION"
             git branch "release-v$NEW_VERSION"
             git checkout "release-v$NEW_VERSION"

--- a/.circleci/src/jobs/alert-slack-push-success.yml
+++ b/.circleci/src/jobs/alert-slack-push-success.yml
@@ -109,14 +109,20 @@ steps:
           fi
 
 
-          # Generate git diff for audius-docker-compose commits from last "release-vX.Y.Z auto-deploy" commit to HEAD
+          # Update tags in audius-docker-compose stage branch
           cd ..
           git clone --branch stage https://github.com/AudiusProject/audius-docker-compose.git audius-docker-compose
           cd audius-docker-compose
           last_release_commit=$(git log --format=format:%H --grep='^release-v.*auto-deploy$' -1)
-          GIT_DIFF=$(git log --pretty=format:'%an - %s [<https://github.com/AudiusProject/audius-docker-compose/commit/%H|%h>]' --abbrev-commit $last_release_commit..HEAD | grep -v '^audius-infra - Update tag to' | sed 's/"/\\"/g' | tr -d '\r' | sed ':a;N;$!ba;s/\n/=DELIM@/g')
-          git commit --allow-empty -m "$CIRCLE_BRANCH auto-deploy"
+          sed -i "s/{TAG:-.*}/{TAG:-$CIRCLE_SHA1}/" creator-node/docker-compose*.yml
+          sed -i "s/{TAG:-.*}/{TAG:-$CIRCLE_SHA1}/" discovery-provider/docker-compose*.yml
+          sed -i "s/{TAG:-.*}/{TAG:-$CIRCLE_SHA1}/" identity-service/docker-compose*.yml
+          git add */docker-compose*.yml
+          git commit -m "$CIRCLE_BRANCH auto-deploy"
           git push origin stage
+
+          # Generate git diff for audius-docker-compose commits from last "release-vX.Y.Z auto-deploy" commit to HEAD
+          GIT_DIFF=$(git log --pretty=format:'%an - %s [<https://github.com/AudiusProject/audius-docker-compose/commit/%H|%h>]' --abbrev-commit $last_release_commit..HEAD | grep -v '^audius-infra - Update tag to' | sed 's/"/\\"/g' | tr -d '\r' | sed ':a;N;$!ba;s/\n/=DELIM@/g')
           most_recent_commit=$(git rev-parse --verify HEAD)
           audius_docker_compose_commit_blocks=$(generate_json_content "$GIT_DIFF")
           if [ -z "$audius_docker_compose_commit_blocks" ]; then

--- a/.circleci/src/jobs/commit-audius-docker-compose-and-notify.yml
+++ b/.circleci/src/jobs/commit-audius-docker-compose-and-notify.yml
@@ -17,7 +17,7 @@ steps:
         git config --global user.email "audius-infra@audius.co"
         git config --global user.name "audius-infra"
   - run:
-      name: Alert Slack of changelog
+      name: Set tag in audius-docker-compose and alert Slack of changelog
       command: |
         generate_json_content() {
           GIT_DIFF="$1"

--- a/.circleci/src/jobs/deploy-stage-nodes.yml
+++ b/.circleci/src/jobs/deploy-stage-nodes.yml
@@ -1,6 +1,6 @@
 parameters:
   service:
-    description: 'Service to deploy (creator-node discovery-provider, identity-service)'
+    description: 'Service to deploy (creator-node, discovery-provider, identity-service)'
     type: string
 resource_class: small
 docker:

--- a/.circleci/src/workflows/release.yml
+++ b/.circleci/src/workflows/release.yml
@@ -74,7 +74,7 @@ jobs:
       requires:
         - release-governance-trigger
   
-  - alert-slack-push-success:
+  - commit-audius-docker-compose-and-notify:
       context: [slack-secrets, github]
       requires:
         - push-identity-service
@@ -90,7 +90,7 @@ jobs:
 
   - deploy-foundation-nodes-trigger:
       requires:
-        - alert-slack-push-success
+        - commit-audius-docker-compose-and-notify
       type: approval
   - deploy-foundation-nodes:
       context: github


### PR DESCRIPTION
### Description
Fixes a race condition with auto-deploy:
1. Commit on `main` is what triggers CI to update the tag for each service in audius-docker-compose (via the `deploy-stage-nodes` job which runs for every commit on main)
2. Commit on `release-vX.Y.Z` branch is what triggers CI to push a commit to mark the release in audius-docker-compose
    - This completes after the tag gets set for CN, but DN takes longer to build so it uses the tag that's right before the commit (same actual code but without the cosmetic version bump)

Fixed by having the release branch CI set the tag when it pushes the commit to mark the release on audius-docker-compose.