### PR TITLE
[PAY-2019] Update premium content remixes and stems logic

### DIFF
--- a/packages/mobile/src/screens/edit-track-screen/screens/AccessAndSaleScreen.tsx
+++ b/packages/mobile/src/screens/edit-track-screen/screens/AccessAndSaleScreen.tsx
@@ -8,7 +8,8 @@ import {
   isPremiumContentTipGated,
   isPremiumContentCollectibleGated,
   FeatureFlags,
-  removeNullable
+  removeNullable,
+  isPremiumContentUSDCPurchaseGated
 } from '@audius/common'
 import { useField, useFormikContext } from 'formik'
 import { useSelector } from 'react-redux'
@@ -116,6 +117,8 @@ export const AccessAndSaleScreen = () => {
 
   const isInitiallyPublic =
     !isUpload && !initialValues.is_unlisted && !initialPremiumConditions
+  const isInitiallyUsdcGated =
+    !isUpload && isPremiumContentUSDCPurchaseGated(initialPremiumConditions)
   const isInitiallySpecialAccess =
     !isUpload &&
     !!(
@@ -126,18 +129,29 @@ export const AccessAndSaleScreen = () => {
     !isUpload && isPremiumContentCollectibleGated(initialPremiumConditions)
   const isInitiallyHidden = !isUpload && initialValues.is_unlisted
 
+  const noUsdcGate =
+    isInitiallyPublic ||
+    isInitiallySpecialAccess ||
+    isInitiallyCollectibleGated ||
+    isRemix ||
+    !isUsdcUploadEnabled
+
+  const noSpecialAccess =
+    isInitiallyPublic ||
+    isInitiallyUsdcGated ||
+    isInitiallyCollectibleGated ||
+    isRemix
+  const noSpecialAccessOptions =
+    noSpecialAccess || (!isUpload && !isInitiallyHidden)
+
   const noCollectibleGate =
     isInitiallyPublic ||
+    isInitiallyUsdcGated ||
     isInitiallySpecialAccess ||
     isRemix ||
     hasNoCollectibles
   const noCollectibleDropdown =
     noCollectibleGate || (!isUpload && !isInitiallyHidden)
-
-  const noSpecialAccess =
-    isInitiallyPublic || isInitiallyCollectibleGated || isRemix
-  const noSpecialAccessOptions =
-    noSpecialAccess || (!isUpload && !isInitiallyHidden)
 
   const noHidden = !isUpload && !initialValues.is_unlisted
 
@@ -157,7 +171,7 @@ export const AccessAndSaleScreen = () => {
       ? {
           label: premiumAvailability,
           value: premiumAvailability,
-          disabled: !isUsdcUploadEnabled
+          disabled: noUsdcGate
         }
       : null,
     {
@@ -189,8 +203,8 @@ export const AccessAndSaleScreen = () => {
     items[premiumAvailability] = (
       <PremiumRadioField
         selected={availability === TrackAvailabilityType.USDC_PURCHASE}
-        disabled={!isUsdcUploadEnabled}
-        disabledContent={!isUsdcUploadEnabled}
+        disabled={noUsdcGate}
+        disabledContent={noUsdcGate}
       />
     )
   }

--- a/packages/mobile/src/screens/edit-track-screen/screens/RemixSettingsScreen.tsx
+++ b/packages/mobile/src/screens/edit-track-screen/screens/RemixSettingsScreen.tsx
@@ -41,7 +41,7 @@ const messages = {
   done: 'Done',
   invalidRemixUrl: 'Please paste a valid Audius track URL',
   missingRemixUrl: 'Must include a link to the original track',
-  remixAccessError: 'Must have access to parent track to remix',
+  remixAccessError: 'Must have access to the original track',
   enterLink: 'Enter an Audius Link',
   changeAvailbilityPrefix: 'Availablity is set to',
   changeAvailbilitySuffix:

--- a/packages/mobile/src/screens/edit-track-screen/screens/RemixSettingsScreen.tsx
+++ b/packages/mobile/src/screens/edit-track-screen/screens/RemixSettingsScreen.tsx
@@ -193,11 +193,8 @@ export const RemixSettingsScreen = () => {
 
   const { doesUserHaveAccess } = usePremiumContentAccess(parentTrack)
   const hasErrors = Boolean(
-    isTrackRemix && (
-      isInvalidParentTrack ||
-      isRemixUrlMissing ||
-      !doesUserHaveAccess
-    )
+    isTrackRemix &&
+      (isInvalidParentTrack || isRemixUrlMissing || !doesUserHaveAccess)
   )
 
   return (

--- a/packages/mobile/src/screens/edit-track-screen/screens/RemixSettingsScreen.tsx
+++ b/packages/mobile/src/screens/edit-track-screen/screens/RemixSettingsScreen.tsx
@@ -5,7 +5,8 @@ import {
   createRemixOfMetadata,
   remixSettingsActions,
   remixSettingsSelectors,
-  Status
+  Status,
+  usePremiumContentAccess
 } from '@audius/common'
 import { useFocusEffect } from '@react-navigation/native'
 import { useField } from 'formik'
@@ -40,6 +41,7 @@ const messages = {
   done: 'Done',
   invalidRemixUrl: 'Please paste a valid Audius track URL',
   missingRemixUrl: 'Must include a link to the original track',
+  remixAccessError: 'Must have access to parent track to remix',
   enterLink: 'Enter an Audius Link',
   changeAvailbilityPrefix: 'Availablity is set to',
   changeAvailbilitySuffix:
@@ -189,8 +191,13 @@ export const RemixSettingsScreen = () => {
     }
   }, [remixOfInput, isTouched, parentTrack])
 
+  const { doesUserHaveAccess } = usePremiumContentAccess(parentTrack)
   const hasErrors = Boolean(
-    isTrackRemix && (isInvalidParentTrack || isRemixUrlMissing)
+    isTrackRemix && (
+      isInvalidParentTrack ||
+      isRemixUrlMissing ||
+      !doesUserHaveAccess
+    )
   )
 
   return (
@@ -248,7 +255,9 @@ export const RemixSettingsScreen = () => {
               {hasErrors ? (
                 <InputErrorMessage
                   message={
-                    isInvalidParentTrack
+                    !doesUserHaveAccess
+                      ? messages.remixAccessError
+                      : isInvalidParentTrack
                       ? messages.invalidRemixUrl
                       : messages.missingRemixUrl
                   }

--- a/packages/mobile/src/screens/track-screen/TrackScreenDownloadButtons.tsx
+++ b/packages/mobile/src/screens/track-screen/TrackScreenDownloadButtons.tsx
@@ -22,12 +22,14 @@ export type DownloadButtonProps = {
   state: ButtonState
   type: DownloadButtonType
   label: string
+  doesUserHaveAccess: boolean
   onClick?: () => void
 }
 
 export const messages = {
   followToDownload: 'Must follow artist to download',
-  addDownloadPrefix: (label: string) => `Download ${label}`
+  addDownloadPrefix: (label: string) => `Download ${label}`,
+  mustHaveAccess: 'Must have access to download'
 }
 
 const useStyles = makeStyles(() => ({
@@ -40,6 +42,7 @@ const useStyles = makeStyles(() => ({
 const DownloadButton = ({
   label,
   state,
+  doesUserHaveAccess,
   onClick = () => {}
 }: DownloadButtonProps) => {
   const { toast } = useToast()
@@ -47,11 +50,18 @@ const DownloadButton = ({
   const styles = useStyles()
   const requiresFollow = state === ButtonState.REQUIRES_FOLLOW
   const isProcessing = state === ButtonState.PROCESSING
-  const isDisabled = state === ButtonState.PROCESSING || requiresFollow
+  const isDisabled =
+    !doesUserHaveAccess ||
+    state === ButtonState.PROCESSING ||
+    requiresFollow
 
   const handlePress = useCallback(() => {
     if (requiresFollow) {
       toast({ content: messages.followToDownload })
+    }
+
+    if (!doesUserHaveAccess) {
+      toast({ content: messages.mustHaveAccess })
     }
 
     if (isDisabled) {
@@ -123,14 +133,14 @@ export const TrackScreenDownloadButtons = ({
     return null
   }
 
-  if (!isOwner && !doesUserHaveAccess) {
-    return null
-  }
-
   return (
     <View style={{ marginBottom: 12 }}>
       {buttons.map((props) => (
-        <DownloadButton {...props} key={props.label} />
+        <DownloadButton
+          {...props}
+          doesUserHaveAccess={doesUserHaveAccess}
+          key={props.label}
+        />
       ))}
     </View>
   )

--- a/packages/mobile/src/screens/track-screen/TrackScreenDownloadButtons.tsx
+++ b/packages/mobile/src/screens/track-screen/TrackScreenDownloadButtons.tsx
@@ -51,9 +51,7 @@ const DownloadButton = ({
   const requiresFollow = state === ButtonState.REQUIRES_FOLLOW
   const isProcessing = state === ButtonState.PROCESSING
   const isDisabled =
-    !doesUserHaveAccess ||
-    state === ButtonState.PROCESSING ||
-    requiresFollow
+    !doesUserHaveAccess || state === ButtonState.PROCESSING || requiresFollow
 
   const handlePress = useCallback(() => {
     if (requiresFollow) {
@@ -69,7 +67,7 @@ const DownloadButton = ({
     }
 
     onClick()
-  }, [isDisabled, onClick, requiresFollow, toast])
+  }, [isDisabled, onClick, requiresFollow, doesUserHaveAccess, toast])
 
   // Manually handling disabled state in order to show a toast
   // when a follow is required

--- a/packages/web/src/common/store/remix-settings/sagas.ts
+++ b/packages/web/src/common/store/remix-settings/sagas.ts
@@ -68,11 +68,6 @@ function* watchFetchTrack() {
           })) as unknown as Track
         }
         if (track) {
-          // Premium tracks cannot be used as remix track parents
-          if (track.is_premium) {
-            yield* put(fetchTrackFailed())
-            return
-          }
           yield* put(fetchTrackSucceeded({ trackId: track.track_id }))
           return
         }

--- a/packages/web/src/components/download-buttons/DownloadButtons.tsx
+++ b/packages/web/src/components/download-buttons/DownloadButtons.tsx
@@ -29,6 +29,7 @@ export type DownloadButtonProps = {
   state: ButtonState
   type: ButtonType
   label: string
+  doesUserHaveAccess: boolean
   onClick?: () => void
 }
 
@@ -38,6 +39,7 @@ export const messages = {
   followToDownload: 'Must follow artist to download',
   processingTrack: 'Processing',
   processingStem: 'Uploading',
+  mustHaveAccess: 'Must have access to download',
   addDownloadPrefix: (label: string) => `Download ${label}`
 }
 
@@ -45,14 +47,21 @@ const DownloadButton = ({
   label,
   state,
   type,
+  doesUserHaveAccess,
   onClick = () => {}
 }: DownloadButtonProps) => {
   const dispatch = useDispatch()
   const isMobile = useIsMobile()
   const isDisabled =
-    state === ButtonState.PROCESSING || state === ButtonState.REQUIRES_FOLLOW
+    !doesUserHaveAccess ||
+    state === ButtonState.PROCESSING ||
+    state === ButtonState.REQUIRES_FOLLOW
 
   const getTooltipText = useCallback(() => {
+    if (!doesUserHaveAccess) {
+      return messages.mustHaveAccess
+    }
+
     switch (state) {
       case ButtonState.PROCESSING:
         return type === ButtonType.STEM
@@ -69,7 +78,7 @@ const DownloadButton = ({
             return messages.downloadableTrack
         }
     }
-  }, [state, type])
+  }, [doesUserHaveAccess, state, type])
 
   const renderIcon = () => {
     if (state === ButtonState.PROCESSING) {
@@ -167,10 +176,6 @@ const DownloadButtons = ({
     return null
   }
 
-  if (!isOwner && !doesUserHaveAccess) {
-    return null
-  }
-
   return (
     <div
       className={cn({
@@ -178,7 +183,11 @@ const DownloadButtons = ({
       })}
     >
       {buttons.map((props) => (
-        <DownloadButton {...props} key={props.label} />
+        <DownloadButton
+          {...props}
+          doesUserHaveAccess={doesUserHaveAccess}
+          key={props.label}
+        />
       ))}
     </div>
   )

--- a/packages/web/src/components/remix-settings-modal/RemixSettingsModal.tsx
+++ b/packages/web/src/components/remix-settings-modal/RemixSettingsModal.tsx
@@ -6,7 +6,9 @@ import {
   PremiumConditions,
   SquareSizes,
   Track,
-  User
+  User,
+  isPremiumContentCollectibleGated,
+  isPremiumContentUSDCPurchaseGated
 } from '@audius/common'
 import {
   Modal,
@@ -44,6 +46,7 @@ const messages = {
   changeAvailabilityPrefix: 'Availablity is set to ',
   changeAvailabilitySuffix:
     '. To enable these options, change availability to Public.',
+  premium: 'Premium (Pay-to-Unlock)',
   collectibleGated: 'Collectible Gated',
   specialAccess: 'Special Access',
   markAsRemix: 'Mark This Track as a Remix',
@@ -187,10 +190,12 @@ const RemixSettingsModal = ({
           <HelpCallout
             className={styles.disableInfo}
             content={`${messages.changeAvailabilityPrefix} ${
-              'nft_collection' in (premiumConditions ?? {})
+              isPremiumContentUSDCPurchaseGated(premiumConditions)
+                ? messages.premium
+                : isPremiumContentCollectibleGated(premiumConditions)
                 ? messages.collectibleGated
                 : messages.specialAccess
-            } ${messages.changeAvailabilitySuffix}`}
+            }${messages.changeAvailabilitySuffix}`}
           />
         ) : null}
         <div className={styles.toggleRow}>

--- a/packages/web/src/pages/upload-page/fields/AccessAndSaleField.tsx
+++ b/packages/web/src/pages/upload-page/fields/AccessAndSaleField.tsx
@@ -450,7 +450,10 @@ export const AccessAndSaleMenuFields = (props: AccesAndSaleMenuFieldsProps) => {
     !isUpload && isPremiumContentCollectibleGated(initialPremiumConditions)
 
   const noSpecialAccess =
-    isInitiallyPublic || isInitiallyUsdcGated || isInitiallyCollectibleGated || isRemix
+    isInitiallyPublic ||
+    isInitiallyUsdcGated ||
+    isInitiallyCollectibleGated ||
+    isRemix
   const noSpecialAccessOptions =
     noSpecialAccess || (!isUpload && !isInitiallyUnlisted)
 

--- a/packages/web/src/pages/upload-page/fields/AccessAndSaleField.tsx
+++ b/packages/web/src/pages/upload-page/fields/AccessAndSaleField.tsx
@@ -442,11 +442,15 @@ export const AccessAndSaleMenuFields = (props: AccesAndSaleMenuFieldsProps) => {
     name: AVAILABILITY_TYPE
   })
 
+  const isInitiallyPublic =
+    !isUpload && !isInitiallyUnlisted && !initialPremiumConditions
+  const isInitiallyUsdcGated =
+    !isUpload && isPremiumContentUSDCPurchaseGated(initialPremiumConditions)
+  const isInitiallyCollectibleGated =
+    !isUpload && isPremiumContentCollectibleGated(initialPremiumConditions)
+
   const noSpecialAccess =
-    !isUpload &&
-    !isPremiumContentFollowGated(initialPremiumConditions) &&
-    !isPremiumContentTipGated(initialPremiumConditions) &&
-    !isInitiallyUnlisted
+    isInitiallyPublic || isInitiallyUsdcGated || isInitiallyCollectibleGated || isRemix
   const noSpecialAccessOptions =
     noSpecialAccess || (!isUpload && !isInitiallyUnlisted)
 
@@ -532,6 +536,7 @@ export const AccessAndSaleMenuFields = (props: AccesAndSaleMenuFieldsProps) => {
         />
         {isUsdcEnabled ? (
           <UsdcPurchaseGatedRadioField
+            isRemix={isRemix}
             isUpload={isUpload}
             initialPremiumConditions={initialPremiumConditions}
             isInitiallyUnlisted={isInitiallyUnlisted}

--- a/packages/web/src/pages/upload-page/fields/RemixSettingsField/RemixSettingsField.tsx
+++ b/packages/web/src/pages/upload-page/fields/RemixSettingsField/RemixSettingsField.tsx
@@ -34,6 +34,7 @@ import {
   SHOW_REMIXES,
   SHOW_REMIXES_BASE
 } from './types'
+import { IS_PREMIUM, PREMIUM_CONDITIONS } from '../AccessAndSaleField'
 
 const messages = {
   title: 'Remix Settings',
@@ -51,6 +52,10 @@ export const RemixSettingsField = () => {
     useTrackField<FieldVisibility[typeof SHOW_REMIXES_BASE]>(SHOW_REMIXES)
   const [{ value: remixOf }, , { setValue: setRemixOf }] =
     useTrackField<SingleTrackEditValues[typeof REMIX_OF]>(REMIX_OF)
+    const [{ value: isPremium }] =
+    useTrackField<SingleTrackEditValues[typeof IS_PREMIUM]>(IS_PREMIUM)
+  const [{ value: premiumConditions }] =
+    useTrackField<SingleTrackEditValues[typeof PREMIUM_CONDITIONS]>(PREMIUM_CONDITIONS)
 
   const parentTrackId = remixOf?.tracks[0].parent_track_id
   const { data: remixOfTrack } = useGetTrackById(
@@ -72,8 +77,10 @@ export const RemixSettingsField = () => {
     set(initialValues, SHOW_REMIXES, showRemixes)
     set(initialValues, IS_REMIX, isRemix)
     set(initialValues, REMIX_LINK, remixLink)
+    set(initialValues, IS_PREMIUM, isPremium)
+    set(initialValues, PREMIUM_CONDITIONS, premiumConditions)
     return initialValues as unknown as RemixSettingsFormValues
-  }, [showRemixes, isRemix, remixLink, parentTrackId])
+  }, [showRemixes, isRemix, remixLink, parentTrackId, isPremium, premiumConditions])
 
   const handleSubmit = useCallback(
     (values: RemixSettingsFormValues) => {

--- a/packages/web/src/pages/upload-page/fields/RemixSettingsField/RemixSettingsField.tsx
+++ b/packages/web/src/pages/upload-page/fields/RemixSettingsField/RemixSettingsField.tsx
@@ -25,6 +25,7 @@ import styles from './RemixSettingsField.module.css'
 import { RemixSettingsMenuFields } from './RemixSettingsMenuFields'
 import { TrackInfo } from './TrackInfo'
 import {
+  CAN_REMIX_PARENT,
   IS_REMIX,
   REMIX_LINK,
   REMIX_OF,
@@ -64,7 +65,10 @@ export const RemixSettingsField = () => {
   const isRemix = Boolean(remixOf && remixOf?.tracks.length > 0)
 
   const initialValues = useMemo(() => {
-    const initialValues = { parentTrackId }
+    const initialValues = {
+      parentTrackId,
+      [CAN_REMIX_PARENT]: true
+    }
     set(initialValues, SHOW_REMIXES, showRemixes)
     set(initialValues, IS_REMIX, isRemix)
     set(initialValues, REMIX_LINK, remixLink)

--- a/packages/web/src/pages/upload-page/fields/RemixSettingsField/RemixSettingsField.tsx
+++ b/packages/web/src/pages/upload-page/fields/RemixSettingsField/RemixSettingsField.tsx
@@ -20,6 +20,7 @@ import { fullTrackPage } from 'utils/route'
 
 import { useTrackField } from '../../hooks'
 import { SingleTrackEditValues } from '../../types'
+import { IS_PREMIUM, PREMIUM_CONDITIONS } from '../AccessAndSaleField'
 
 import styles from './RemixSettingsField.module.css'
 import { RemixSettingsMenuFields } from './RemixSettingsMenuFields'
@@ -34,7 +35,6 @@ import {
   SHOW_REMIXES,
   SHOW_REMIXES_BASE
 } from './types'
-import { IS_PREMIUM, PREMIUM_CONDITIONS } from '../AccessAndSaleField'
 
 const messages = {
   title: 'Remix Settings',
@@ -52,10 +52,12 @@ export const RemixSettingsField = () => {
     useTrackField<FieldVisibility[typeof SHOW_REMIXES_BASE]>(SHOW_REMIXES)
   const [{ value: remixOf }, , { setValue: setRemixOf }] =
     useTrackField<SingleTrackEditValues[typeof REMIX_OF]>(REMIX_OF)
-    const [{ value: isPremium }] =
+  const [{ value: isPremium }] =
     useTrackField<SingleTrackEditValues[typeof IS_PREMIUM]>(IS_PREMIUM)
   const [{ value: premiumConditions }] =
-    useTrackField<SingleTrackEditValues[typeof PREMIUM_CONDITIONS]>(PREMIUM_CONDITIONS)
+    useTrackField<SingleTrackEditValues[typeof PREMIUM_CONDITIONS]>(
+      PREMIUM_CONDITIONS
+    )
 
   const parentTrackId = remixOf?.tracks[0].parent_track_id
   const { data: remixOfTrack } = useGetTrackById(
@@ -80,7 +82,14 @@ export const RemixSettingsField = () => {
     set(initialValues, IS_PREMIUM, isPremium)
     set(initialValues, PREMIUM_CONDITIONS, premiumConditions)
     return initialValues as unknown as RemixSettingsFormValues
-  }, [showRemixes, isRemix, remixLink, parentTrackId, isPremium, premiumConditions])
+  }, [
+    showRemixes,
+    isRemix,
+    remixLink,
+    parentTrackId,
+    isPremium,
+    premiumConditions
+  ])
 
   const handleSubmit = useCallback(
     (values: RemixSettingsFormValues) => {

--- a/packages/web/src/pages/upload-page/fields/RemixSettingsField/RemixSettingsMenuFields.tsx
+++ b/packages/web/src/pages/upload-page/fields/RemixSettingsField/RemixSettingsMenuFields.tsx
@@ -4,7 +4,9 @@ import {
   getPathFromTrackUrl,
   useGetTrackByPermalink,
   accountSelectors,
-  usePremiumContentAccess
+  usePremiumContentAccess,
+  isPremiumContentUSDCPurchaseGated,
+  isPremiumContentCollectibleGated
 } from '@audius/common'
 import { useField } from 'formik'
 import { useSelector } from 'react-redux'
@@ -18,6 +20,8 @@ import { SwitchRowField } from '../SwitchRowField'
 import styles from './RemixSettingsField.module.css'
 import { TrackInfo } from './TrackInfo'
 import { CAN_REMIX_PARENT, IS_REMIX, REMIX_LINK, SHOW_REMIXES } from './types'
+import { HelpCallout } from 'components/help-callout/HelpCallout'
+import { IS_PREMIUM, PREMIUM_CONDITIONS } from '../AccessAndSaleField'
 const { getUserId } = accountSelectors
 
 const messages = {
@@ -31,10 +35,18 @@ const messages = {
     description:
       "Paste the original Audius track link if yours is a remix. Your remix will typically appear on the original track's page.",
     linkLabel: 'Link to Remix'
-  }
+  },
+  changeAvailabilityPrefix: 'Availablity is set to ',
+  changeAvailabilitySuffix:
+    '. To enable these options, change availability to Public.',
+  premium: 'Premium (Pay-to-Unlock)',
+  collectibleGated: 'Collectible Gated',
+  specialAccess: 'Special Access'
 }
 
 export const RemixSettingsMenuFields = () => {
+  const [{ value: isPremium }] = useField(IS_PREMIUM)
+  const [{ value: premiumConditions }] = useField(PREMIUM_CONDITIONS)
   const [{ value: trackUrl }] = useField(REMIX_LINK)
   const [, , { setValue: setCanRemixParent }] = useField(CAN_REMIX_PARENT)
   const permalink = useThrottle(getPathFromTrackUrl(trackUrl), 1000)
@@ -59,17 +71,31 @@ export const RemixSettingsMenuFields = () => {
 
   return (
     <div className={styles.fields}>
+      {isPremium ? (
+          <HelpCallout
+            content={`${messages.changeAvailabilityPrefix} ${
+              isPremiumContentUSDCPurchaseGated(premiumConditions)
+                ? messages.premium
+                : isPremiumContentCollectibleGated(premiumConditions)
+                ? messages.collectibleGated
+                : messages.specialAccess
+            }${messages.changeAvailabilitySuffix}`}
+          />
+        ) : null}
       <SwitchRowField
         name={SHOW_REMIXES}
         header={messages.hideRemix.header}
         description={messages.hideRemix.description}
-        inverted
+        disabled={isPremium}
+        checked={isPremium}
+        inverted={!isPremium}
       />
       <Divider />
       <SwitchRowField
         name={IS_REMIX}
         header={messages.remixOf.header}
         description={messages.remixOf.description}
+        disabled={isPremium}
       >
         <TextField name={REMIX_LINK} label={messages.remixOf.linkLabel} />
         {track ? <TrackInfo trackId={track.track_id} /> : null}

--- a/packages/web/src/pages/upload-page/fields/RemixSettingsField/RemixSettingsMenuFields.tsx
+++ b/packages/web/src/pages/upload-page/fields/RemixSettingsField/RemixSettingsMenuFields.tsx
@@ -3,7 +3,8 @@ import { useEffect } from 'react'
 import {
   getPathFromTrackUrl,
   useGetTrackByPermalink,
-  accountSelectors
+  accountSelectors,
+  usePremiumContentAccess
 } from '@audius/common'
 import { useField } from 'formik'
 import { useSelector } from 'react-redux'
@@ -16,7 +17,7 @@ import { SwitchRowField } from '../SwitchRowField'
 
 import styles from './RemixSettingsField.module.css'
 import { TrackInfo } from './TrackInfo'
-import { IS_REMIX, REMIX_LINK, SHOW_REMIXES } from './types'
+import { CAN_REMIX_PARENT, IS_REMIX, REMIX_LINK, SHOW_REMIXES } from './types'
 const { getUserId } = accountSelectors
 
 const messages = {
@@ -35,6 +36,7 @@ const messages = {
 
 export const RemixSettingsMenuFields = () => {
   const [{ value: trackUrl }] = useField(REMIX_LINK)
+  const [, , { setValue: setCanRemixParent }] = useField(CAN_REMIX_PARENT)
   const permalink = useThrottle(getPathFromTrackUrl(trackUrl), 1000)
   const currentUserId = useSelector(getUserId)
 
@@ -44,12 +46,16 @@ export const RemixSettingsMenuFields = () => {
   )
 
   const trackId = track?.track_id
+  const { doesUserHaveAccess: canRemixParent } = usePremiumContentAccess(
+    track ?? null
+  )
 
   const [, , { setValue: setParentTrackId }] = useField('parentTrackId')
 
   useEffect(() => {
     setParentTrackId(trackId)
-  }, [trackId, setParentTrackId])
+    setCanRemixParent(canRemixParent)
+  }, [trackId, setParentTrackId, canRemixParent, setCanRemixParent])
 
   return (
     <div className={styles.fields}>

--- a/packages/web/src/pages/upload-page/fields/RemixSettingsField/RemixSettingsMenuFields.tsx
+++ b/packages/web/src/pages/upload-page/fields/RemixSettingsField/RemixSettingsMenuFields.tsx
@@ -14,14 +14,14 @@ import { useThrottle } from 'react-use'
 
 import { Divider } from 'components/divider'
 import { TextField } from 'components/form-fields'
+import { HelpCallout } from 'components/help-callout/HelpCallout'
 
+import { IS_PREMIUM, PREMIUM_CONDITIONS } from '../AccessAndSaleField'
 import { SwitchRowField } from '../SwitchRowField'
 
 import styles from './RemixSettingsField.module.css'
 import { TrackInfo } from './TrackInfo'
 import { CAN_REMIX_PARENT, IS_REMIX, REMIX_LINK, SHOW_REMIXES } from './types'
-import { HelpCallout } from 'components/help-callout/HelpCallout'
-import { IS_PREMIUM, PREMIUM_CONDITIONS } from '../AccessAndSaleField'
 const { getUserId } = accountSelectors
 
 const messages = {
@@ -72,16 +72,16 @@ export const RemixSettingsMenuFields = () => {
   return (
     <div className={styles.fields}>
       {isPremium ? (
-          <HelpCallout
-            content={`${messages.changeAvailabilityPrefix} ${
-              isPremiumContentUSDCPurchaseGated(premiumConditions)
-                ? messages.premium
-                : isPremiumContentCollectibleGated(premiumConditions)
-                ? messages.collectibleGated
-                : messages.specialAccess
-            }${messages.changeAvailabilitySuffix}`}
-          />
-        ) : null}
+        <HelpCallout
+          content={`${messages.changeAvailabilityPrefix} ${
+            isPremiumContentUSDCPurchaseGated(premiumConditions)
+              ? messages.premium
+              : isPremiumContentCollectibleGated(premiumConditions)
+              ? messages.collectibleGated
+              : messages.specialAccess
+          }${messages.changeAvailabilitySuffix}`}
+        />
+      ) : null}
       <SwitchRowField
         name={SHOW_REMIXES}
         header={messages.hideRemix.header}

--- a/packages/web/src/pages/upload-page/fields/RemixSettingsField/types.ts
+++ b/packages/web/src/pages/upload-page/fields/RemixSettingsField/types.ts
@@ -5,9 +5,11 @@ export const SHOW_REMIXES_BASE = `remixes`
 export const SHOW_REMIXES = `field_visibility.remixes`
 export const IS_REMIX = 'is_remix'
 export const REMIX_LINK = 'remix_of_link'
+export const CAN_REMIX_PARENT = 'can_remix_parent'
 
 const messages = {
-  remixLinkError: 'Must provide valid remix link'
+  remixLinkError: 'Must provide valid remix link',
+  remixAccessError: 'Must have access to parent track to remix'
 }
 
 export const RemixSettingsFieldSchema = z
@@ -15,11 +17,21 @@ export const RemixSettingsFieldSchema = z
     [SHOW_REMIXES]: z.optional(z.boolean()),
     [IS_REMIX]: z.boolean(),
     [REMIX_LINK]: z.optional(z.string()),
+    [CAN_REMIX_PARENT]: z.optional(z.boolean()),
     parentTrackId: z.optional(z.number())
   })
   .refine((form) => !form[IS_REMIX] || form.parentTrackId, {
     message: messages.remixLinkError,
     path: [REMIX_LINK]
   })
+  .refine(
+    (form) => {
+      return form[CAN_REMIX_PARENT]
+    },
+    {
+      message: messages.remixAccessError,
+      path: [REMIX_LINK]
+    }
+  )
 
 export type RemixSettingsFormValues = z.input<typeof RemixSettingsFieldSchema>

--- a/packages/web/src/pages/upload-page/fields/RemixSettingsField/types.ts
+++ b/packages/web/src/pages/upload-page/fields/RemixSettingsField/types.ts
@@ -9,7 +9,7 @@ export const CAN_REMIX_PARENT = 'can_remix_parent'
 
 const messages = {
   remixLinkError: 'Must provide valid remix link',
-  remixAccessError: 'Must have access to parent track to remix'
+  remixAccessError: 'Must have access to the original track'
 }
 
 export const RemixSettingsFieldSchema = z

--- a/packages/web/src/pages/upload-page/fields/availability/collectible-gated/CollectibleGatedRadioField.tsx
+++ b/packages/web/src/pages/upload-page/fields/availability/collectible-gated/CollectibleGatedRadioField.tsx
@@ -2,7 +2,10 @@ import {
   PremiumConditions,
   TrackAvailabilityType,
   collectiblesSelectors,
-  isPremiumContentCollectibleGated
+  isPremiumContentCollectibleGated,
+  isPremiumContentFollowGated,
+  isPremiumContentTipGated,
+  isPremiumContentUSDCPurchaseGated
 } from '@audius/common'
 import { IconCollectible } from '@audius/stems'
 
@@ -42,12 +45,23 @@ export const CollectibleGatedRadioField = (
     return numEthCollectibles + numSolCollectibles > 0
   })
 
+  const isInitiallyPublic =
+    !isUpload && !isInitiallyUnlisted && !initialPremiumConditions
+  const isInitiallySpecialAccess =
+    !isUpload &&
+    !!(
+      isPremiumContentFollowGated(initialPremiumConditions) ||
+      isPremiumContentTipGated(initialPremiumConditions)
+    )
+  const isInitiallyUsdcGated =
+    !isUpload && isPremiumContentUSDCPurchaseGated(initialPremiumConditions)
+
   const disabled =
+    isInitiallyPublic ||
+    isInitiallyUsdcGated ||
+    isInitiallySpecialAccess ||
     isRemix ||
-    !hasCollectibles ||
-    (!isUpload &&
-      !isPremiumContentCollectibleGated(initialPremiumConditions) &&
-      !isInitiallyUnlisted)
+    !hasCollectibles
 
   const fieldsDisabled = disabled || (!isUpload && !isInitiallyUnlisted)
 

--- a/packages/web/src/pages/upload-page/fields/availability/collectible-gated/CollectibleGatedRadioField.tsx
+++ b/packages/web/src/pages/upload-page/fields/availability/collectible-gated/CollectibleGatedRadioField.tsx
@@ -2,7 +2,6 @@ import {
   PremiumConditions,
   TrackAvailabilityType,
   collectiblesSelectors,
-  isPremiumContentCollectibleGated,
   isPremiumContentFollowGated,
   isPremiumContentTipGated,
   isPremiumContentUSDCPurchaseGated

--- a/packages/web/src/pages/upload-page/fields/availability/usdc-purchase-gated/UsdcPurchaseGatedRadioField.tsx
+++ b/packages/web/src/pages/upload-page/fields/availability/usdc-purchase-gated/UsdcPurchaseGatedRadioField.tsx
@@ -4,8 +4,7 @@ import {
   TrackAvailabilityType,
   isPremiumContentCollectibleGated,
   isPremiumContentFollowGated,
-  isPremiumContentTipGated,
-  isPremiumContentUSDCPurchaseGated
+  isPremiumContentTipGated
 } from '@audius/common'
 import { IconCart, IconStars } from '@audius/stems'
 
@@ -38,7 +37,8 @@ type UsdcPurchaseGatedRadioFieldProps = {
 export const UsdcPurchaseGatedRadioField = (
   props: UsdcPurchaseGatedRadioFieldProps
 ) => {
-  const { isRemix, isUpload, initialPremiumConditions, isInitiallyUnlisted } = props
+  const { isRemix, isUpload, initialPremiumConditions, isInitiallyUnlisted } =
+    props
 
   const { isEnabled: isUsdcUploadEnabled } = useFlag(
     FeatureFlags.USDC_PURCHASES_UPLOAD

--- a/packages/web/src/pages/upload-page/fields/availability/usdc-purchase-gated/UsdcPurchaseGatedRadioField.tsx
+++ b/packages/web/src/pages/upload-page/fields/availability/usdc-purchase-gated/UsdcPurchaseGatedRadioField.tsx
@@ -2,6 +2,9 @@ import {
   FeatureFlags,
   PremiumConditions,
   TrackAvailabilityType,
+  isPremiumContentCollectibleGated,
+  isPremiumContentFollowGated,
+  isPremiumContentTipGated,
   isPremiumContentUSDCPurchaseGated
 } from '@audius/common'
 import { IconCart, IconStars } from '@audius/stems'
@@ -26,6 +29,7 @@ const messages = {
 }
 
 type UsdcPurchaseGatedRadioFieldProps = {
+  isRemix: boolean
   isUpload?: boolean
   initialPremiumConditions?: PremiumConditions
   isInitiallyUnlisted?: boolean
@@ -34,18 +38,29 @@ type UsdcPurchaseGatedRadioFieldProps = {
 export const UsdcPurchaseGatedRadioField = (
   props: UsdcPurchaseGatedRadioFieldProps
 ) => {
-  const { isUpload, initialPremiumConditions, isInitiallyUnlisted } = props
+  const { isRemix, isUpload, initialPremiumConditions, isInitiallyUnlisted } = props
 
   const { isEnabled: isUsdcUploadEnabled } = useFlag(
     FeatureFlags.USDC_PURCHASES_UPLOAD
   )
 
-  const noUsdcPurchase =
+  const isInitiallyPublic =
+    !isUpload && !isInitiallyUnlisted && !initialPremiumConditions
+  const isInitiallySpecialAccess =
     !isUpload &&
-    !isPremiumContentUSDCPurchaseGated(initialPremiumConditions) &&
-    !isInitiallyUnlisted
+    !!(
+      isPremiumContentFollowGated(initialPremiumConditions) ||
+      isPremiumContentTipGated(initialPremiumConditions)
+    )
+  const isInitiallyCollectibleGated =
+    !isUpload && isPremiumContentCollectibleGated(initialPremiumConditions)
 
-  const disabled = noUsdcPurchase || !isUsdcUploadEnabled
+  const disabled =
+    isInitiallyPublic ||
+    isInitiallySpecialAccess ||
+    isInitiallyCollectibleGated ||
+    isRemix ||
+    !isUsdcUploadEnabled
 
   const helpContent = (
     <div className={styles.helpContent}>


### PR DESCRIPTION
### Description

- Only allow stems downloads if user has access to track
- Only allow setting a track as a remix of a gated track if user has access to that gated track
- Fix regression on web that made it possible for gated tracks to also be remixes. Gated tracks should not be remixes of other tracks.

There is still a related [linear card](https://linear.app/audius/issue/PAY-2056/[usdc]-editing-premium-track-on-mobile-changing-access-super-broken) that needs to handle the access & sale fields to correctly reflect the selection of the user.

### How Has This Been Tested?

local web and native mobile dapps vs stage

<img width="460" alt="Screenshot 2023-10-18 at 11 22 34 PM" src="https://github.com/AudiusProject/audius-protocol/assets/9600175/903148ce-d99b-41da-aea5-9831c7dbae6a">

----------

![Screenshot 2023-10-18 at 10 49 24 PM](https://github.com/AudiusProject/audius-protocol/assets/9600175/2f0aba4c-0458-4305-9bd1-dc48b78aa48d)

----------

![simulator_screenshot_840F4246-9E33-4055-AC01-B6A32E688B98](https://github.com/AudiusProject/audius-protocol/assets/9600175/1ab3db6b-1f63-47f2-9d0f-35e421770466)

----------

![simulator_screenshot_C2FF4A00-2A67-4914-9353-DC0DBC7DE717](https://github.com/AudiusProject/audius-protocol/assets/9600175/f3f36bb3-f8fd-4b73-99a6-a921eca3d641)
