### PR TITLE
[PAY-1980] Fix pay extra form validation

### DIFF
--- a/packages/common/src/store/purchase-content/utils.ts
+++ b/packages/common/src/store/purchase-content/utils.ts
@@ -33,6 +33,14 @@ type GetPurchaseSummaryValuesArgs = {
   extraAmount?: number
 }
 
+/**
+ * Gets values for a purchase summary
+ *  - amountDue
+ *  - existingBalance
+ *  - basePrice
+ *  - extraAmount
+ * Throws if number bounds are exceeded
+ */
 export const getPurchaseSummaryValues = ({
   price,
   currentBalance,
@@ -44,7 +52,7 @@ export const getPurchaseSummaryValues = ({
     currentBalance && currentBalance.gt(BN_USDC_CENT_WEI)
       ? currentBalance
       : zeroBalance()
-  const amountDueBN = new BN(amountDue).mul(BN_USDC_CENT_WEI)
+  const amountDueBN = new BN(amountDue.toString()).mul(BN_USDC_CENT_WEI)
 
   if (balanceBN.gte(amountDueBN)) {
     existingBalance = amountDue

--- a/packages/mobile/src/components/fields/PriceField.tsx
+++ b/packages/mobile/src/components/fields/PriceField.tsx
@@ -18,6 +18,11 @@ import { Text } from '../core/Text'
 import type { TextFieldProps } from './TextField'
 import { TextField } from './TextField'
 
+// Maximum field length to safeguard against numeric overflow:
+// -1 (for len max int)
+// -2 (to account for digits added to include cents)
+const MAX_LENGTH = Number.MAX_SAFE_INTEGER.toString().length - 3
+
 const messages = {
   dollars: '$'
 }
@@ -65,8 +70,7 @@ export const PriceField = (props: TextFieldProps) => {
           {messages.dollars}
         </Text>
       }
-      // Safeguard against numeric overflow, -1 (for len max int), -2 (to account for cents)
-      maxLength={Number.MAX_SAFE_INTEGER.toString().length - 3}
+      maxLength={MAX_LENGTH}
       {...props}
       value={humanizedValue ?? undefined}
       onChange={handlePriceChange}

--- a/packages/mobile/src/components/fields/PriceField.tsx
+++ b/packages/mobile/src/components/fields/PriceField.tsx
@@ -65,6 +65,8 @@ export const PriceField = (props: TextFieldProps) => {
           {messages.dollars}
         </Text>
       }
+      // Safeguard against numeric overflow, -1 (for len max int), -2 (to account for cents)
+      maxLength={Number.MAX_SAFE_INTEGER.toString().length - 3}
       {...props}
       value={humanizedValue ?? undefined}
       onChange={handlePriceChange}

--- a/packages/mobile/src/components/premium-track-purchase-drawer/PayExtraFormSection.tsx
+++ b/packages/mobile/src/components/premium-track-purchase-drawer/PayExtraFormSection.tsx
@@ -50,7 +50,8 @@ export const PayExtraFormSection = ({
   amountPresets
 }: PayExtraFormSectionProps) => {
   const [{ value: preset }, , { setValue: setPreset }] = useField(AMOUNT_PRESET)
-  const [{ value: customAmount }] = useField(CUSTOM_AMOUNT)
+  const [{ value: customAmount }, { error: customAmountError }] =
+    useField(CUSTOM_AMOUNT)
   const styles = useStyles()
 
   const handleClickPreset = (newPreset: PayExtraPreset) => {
@@ -99,6 +100,7 @@ export const PayExtraFormSection = ({
           label={messages.customAmount}
           value={String(customAmount)}
           placeholder={messages.placeholder}
+          errorMessage={customAmountError}
           noGutter
         />
       ) : null}

--- a/packages/web/src/components/form-fields/PriceField.tsx
+++ b/packages/web/src/components/form-fields/PriceField.tsx
@@ -16,6 +16,11 @@ import { useField } from 'formik'
 
 import { TextField, TextFieldProps } from './TextField'
 
+// Maximum field length to safeguard against numeric overflow:
+// -1 (for len max int)
+// -2 (to account for digits added to include cents)
+const MAX_LENGTH = Number.MAX_SAFE_INTEGER.toString().length - 3
+
 const messages = {
   dollars: '$'
 }
@@ -58,7 +63,7 @@ export const PriceField = (props: TextFieldProps) => {
     <TextField
       {...props}
       // Safeguard against numeric overflow, -1 (for len max int), -2 (to account for cents)
-      maxLength={Number.MAX_SAFE_INTEGER.toString().length - 3}
+      maxLength={MAX_LENGTH}
       value={humanizedValue ?? undefined}
       startAdornment={messages.dollars}
       onChange={handlePriceChange}

--- a/packages/web/src/components/form-fields/PriceField.tsx
+++ b/packages/web/src/components/form-fields/PriceField.tsx
@@ -21,7 +21,9 @@ const messages = {
 }
 
 export const PriceField = (props: TextFieldProps) => {
-  const [{ value }, , { setValue: setPrice }] = useField<number>(props.name)
+  const [{ value }, , { setValue: setPrice, setTouched }] = useField<number>(
+    props.name
+  )
   const [humanizedValue, setHumanizedValue] = useState(
     value ? decimalIntegerToHumanReadable(value) : null
   )
@@ -40,8 +42,9 @@ export const PriceField = (props: TextFieldProps) => {
       const { human, value } = filterDecimalString(e.target.value)
       setHumanizedValue(human)
       setPrice(value)
+      setTouched(true, false)
     },
-    [setPrice, setHumanizedValue]
+    [setPrice, setHumanizedValue, setTouched]
   )
 
   const handlePriceBlur: FocusEventHandler<HTMLInputElement> = useCallback(
@@ -54,6 +57,8 @@ export const PriceField = (props: TextFieldProps) => {
   return (
     <TextField
       {...props}
+      // Safeguard against numeric overflow, -1 (for len max int), -2 (to account for cents)
+      maxLength={Number.MAX_SAFE_INTEGER.toString().length - 3}
       value={humanizedValue ?? undefined}
       startAdornment={messages.dollars}
       onChange={handlePriceChange}

--- a/packages/web/src/components/premium-content-purchase-modal/components/PayExtraFormSection.tsx
+++ b/packages/web/src/components/premium-content-purchase-modal/components/PayExtraFormSection.tsx
@@ -32,6 +32,7 @@ export const PayExtraFormSection = ({
   const handleClickPreset = (newPreset: PayExtraPreset) => {
     setPreset(newPreset === preset ? PayExtraPreset.NONE : newPreset)
   }
+
   return (
     <div className={styles.container}>
       <Text variant='title' color='neutralLight4' className={styles.title}>


### PR DESCRIPTION
### Description

Also fixes PAY-2048

Fix a couple issues with pay extra custom amount form validation
Behavior is as follows
1. User clicks custom amount, validation passes at `undefined` input
2. If the user clicks "Buy" validation fails
3. If the user types a 1, validation passes
4. If the user types over 100, validation fails
5. If the user loses input focus, `.00` is added
6. If the user enters a number > 13 chars (len(2^53), if you include the cents), the input stops letting new numbers go in so we don't crash the app on numeric bounds issues

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._

Above use case on web & mobile