### PR TITLE
Disk cleanup cron job for self-hosted runners

### DIFF
--- a/.circleci/scripts/circleci-startup-script.sh
+++ b/.circleci/scripts/circleci-startup-script.sh
@@ -55,3 +55,7 @@ WantedBy = multi-user.target
 EOT
 systemctl enable circleci.service
 systemctl start circleci.service
+
+# Periodically clean up local docker registry
+# Runs every hour, checks if disk usage exceeds 80%, then runs docker system prune
+echo '5 * * * * root [ $(df | grep /dev/root | awk '"'"'{print $5}'"'"' | grep -oP "^\d+") -gt 80 ] && docker system prune -f | logger -t dockerprune' >> /etc/crontab


### PR DESCRIPTION
### Description

To prevent the docker cache from eventually filling up the disk, we will occasionally prune. Note that this will not remove all cached layers so we still benefit from speedup even on jobs that run following a prune.

### How Has This Been Tested?

Cron job is successfully configured on existing self-hosted runner. Syslog output:

```
Oct 20 04:06:57 circleci-runner-instance-2 dockerprune: Total reclaimed space: 51.77GB
```