### PR TITLE
Use regular merge in deploys

### DIFF
--- a/.circleci/src/jobs/deploy-foundation-nodes.yml
+++ b/.circleci/src/jobs/deploy-foundation-nodes.yml
@@ -24,5 +24,5 @@ steps:
         release_commit_hash=$(git log --all --grep="$CIRCLE_BRANCH auto-deploy" --pretty=format:"%H" -1)
         git fetch origin foundation:foundation
         git checkout foundation
-        git reset --hard $release_commit_hash
-        git push origin foundation --force
+        git merge $release_commit_hash --no-edit
+        git push origin foundation

--- a/.circleci/src/jobs/release-audius-docker-compose.yml
+++ b/.circleci/src/jobs/release-audius-docker-compose.yml
@@ -24,5 +24,5 @@ steps:
         release_commit_hash=$(git log --all --grep="$CIRCLE_BRANCH auto-deploy" --pretty=format:"%H" -1)
         git fetch origin main:main
         git checkout main
-        git reset --hard $release_commit_hash
-        git push origin main --force
+        git merge $release_commit_hash --no-edit
+        git push origin main


### PR DESCRIPTION
Uses a regular merge instead of a hard-reset + force-push for auto-deploys. I thought we needed the hard reset due to merge conflicts in the past, but a regular merge should be fine as long as we go through the flow of merging everything to the `stage` branch and not pushing directly to the `foundation` branch.

Note that we still need to hard-reset audius-docker-compose `main` once to be even with `foundation`. Releases to `main` are blocked until then. From then on, all 3 branches (stage+foundation+main) will have the same history.