### PR TITLE
Add per service charts to protocol-dashboard

### DIFF
--- a/protocol-dashboard/src/components/IndividualServiceApiCallsChart/IndividualServiceApiCallsChart.tsx
+++ b/protocol-dashboard/src/components/IndividualServiceApiCallsChart/IndividualServiceApiCallsChart.tsx
@@ -22,10 +22,8 @@ const IndividualServiceApiCallsChart: React.FC<IndividualServiceApiCallsChartPro
     data = []
   } else {
     labels =
-      apiCalls?.map(
-        a => new Date(parseInt(a.timestamp, 10) * 1000).getTime() / 1000
-      ) ?? null
-    data = apiCalls?.map(a => a.count) ?? null
+      apiCalls?.map(a => new Date(a.timestamp).getTime() / 1000) ?? null
+    data = apiCalls?.map(a => a.total_count) ?? null
   }
   return (
     <LineChart

--- a/protocol-dashboard/src/components/IndividualServiceApiCallsChart/IndividualServiceApiCallsChart.tsx
+++ b/protocol-dashboard/src/components/IndividualServiceApiCallsChart/IndividualServiceApiCallsChart.tsx
@@ -1,0 +1,45 @@
+import LineChart from 'components/LineChart'
+import React, { useState } from 'react'
+import { useIndividualServiceApiCalls } from 'store/cache/analytics/hooks'
+import { Bucket, MetricError } from 'store/cache/analytics/slice'
+
+type OwnProps = {
+  node: string
+}
+
+type IndividualServiceApiCallsChartProps = OwnProps
+
+const IndividualServiceApiCallsChart: React.FC<IndividualServiceApiCallsChartProps> = ({
+  node
+}) => {
+  const [bucket, setBucket] = useState(Bucket.MONTH)
+
+  const { apiCalls } = useIndividualServiceApiCalls(node, bucket)
+  let error, labels, data
+  if (apiCalls === MetricError.ERROR) {
+    error = true
+    labels = []
+    data = []
+  } else {
+    labels =
+      apiCalls?.map(
+        a => new Date(parseInt(a.timestamp, 10) * 1000).getTime() / 1000
+      ) ?? null
+    data = apiCalls?.map(a => a.count) ?? null
+  }
+  return (
+    <LineChart
+      title="API Calls"
+      tooltipTitle="API Calls"
+      error={error}
+      data={data}
+      labels={labels}
+      selection={bucket}
+      options={[Bucket.ALL_TIME, Bucket.MONTH, Bucket.WEEK]}
+      onSelectOption={(option: string) => setBucket(option as Bucket)}
+      showLeadingDay
+    />
+  )
+}
+
+export default IndividualServiceApiCallsChart

--- a/protocol-dashboard/src/components/IndividualServiceApiCallsChart/IndividualServiceApiCallsChart.tsx
+++ b/protocol-dashboard/src/components/IndividualServiceApiCallsChart/IndividualServiceApiCallsChart.tsx
@@ -21,8 +21,7 @@ const IndividualServiceApiCallsChart: React.FC<IndividualServiceApiCallsChartPro
     labels = []
     data = []
   } else {
-    labels =
-      apiCalls?.map(a => new Date(a.timestamp).getTime() / 1000) ?? null
+    labels = apiCalls?.map(a => new Date(a.timestamp).getTime() / 1000) ?? null
     data = apiCalls?.map(a => a.total_count) ?? null
   }
   return (

--- a/protocol-dashboard/src/components/IndividualServiceApiCallsChart/index.tsx
+++ b/protocol-dashboard/src/components/IndividualServiceApiCallsChart/index.tsx
@@ -1,0 +1,1 @@
+export { default } from './IndividualServiceApiCallsChart'

--- a/protocol-dashboard/src/components/IndividualServiceUniqueUsersChart/IndividualServiceUniqueUsersChart.tsx
+++ b/protocol-dashboard/src/components/IndividualServiceUniqueUsersChart/IndividualServiceUniqueUsersChart.tsx
@@ -22,9 +22,7 @@ const IndividualServiceUniqueUsersChart: React.FC<IndividualServiceUniqueUsersCh
     data = []
   } else {
     labels =
-      apiCalls?.map(
-        a => new Date(parseInt(a.timestamp, 10) * 1000).getTime() / 1000
-      ) ?? null
+      apiCalls?.map(a => new Date(a.timestamp).getTime() / 1000) ?? null
     data = apiCalls?.map(a => a.unique_count) ?? null
   }
   return (

--- a/protocol-dashboard/src/components/IndividualServiceUniqueUsersChart/IndividualServiceUniqueUsersChart.tsx
+++ b/protocol-dashboard/src/components/IndividualServiceUniqueUsersChart/IndividualServiceUniqueUsersChart.tsx
@@ -1,0 +1,45 @@
+import LineChart from 'components/LineChart'
+import React, { useState } from 'react'
+import { useIndividualServiceApiCalls } from 'store/cache/analytics/hooks'
+import { Bucket, MetricError } from 'store/cache/analytics/slice'
+
+type OwnProps = {
+  node: string
+}
+
+type IndividualServiceUniqueUsersChartProps = OwnProps
+
+const IndividualServiceUniqueUsersChart: React.FC<IndividualServiceUniqueUsersChartProps> = ({
+  node
+}) => {
+  const [bucket, setBucket] = useState(Bucket.MONTH)
+
+  const { apiCalls } = useIndividualServiceApiCalls(node, bucket)
+  let error, labels, data
+  if (apiCalls === MetricError.ERROR) {
+    error = true
+    labels = []
+    data = []
+  } else {
+    labels =
+      apiCalls?.map(
+        a => new Date(parseInt(a.timestamp, 10) * 1000).getTime() / 1000
+      ) ?? null
+    data = apiCalls?.map(a => a.unique_count) ?? null
+  }
+  return (
+    <LineChart
+      title="Unique Users"
+      tooltipTitle="Unique Users"
+      error={error}
+      data={data}
+      labels={labels}
+      selection={bucket}
+      options={[Bucket.ALL_TIME, Bucket.MONTH, Bucket.WEEK]}
+      onSelectOption={(option: string) => setBucket(option as Bucket)}
+      showLeadingDay
+    />
+  )
+}
+
+export default IndividualServiceUniqueUsersChart

--- a/protocol-dashboard/src/components/IndividualServiceUniqueUsersChart/IndividualServiceUniqueUsersChart.tsx
+++ b/protocol-dashboard/src/components/IndividualServiceUniqueUsersChart/IndividualServiceUniqueUsersChart.tsx
@@ -21,8 +21,7 @@ const IndividualServiceUniqueUsersChart: React.FC<IndividualServiceUniqueUsersCh
     labels = []
     data = []
   } else {
-    labels =
-      apiCalls?.map(a => new Date(a.timestamp).getTime() / 1000) ?? null
+    labels = apiCalls?.map(a => new Date(a.timestamp).getTime() / 1000) ?? null
     data = apiCalls?.map(a => a.unique_count) ?? null
   }
   return (

--- a/protocol-dashboard/src/components/IndividualServiceUniqueUsersChart/index.tsx
+++ b/protocol-dashboard/src/components/IndividualServiceUniqueUsersChart/index.tsx
@@ -1,0 +1,1 @@
+export { default } from './IndividualServiceUniqueUsersChart'

--- a/protocol-dashboard/src/components/NodeOverview/NodeOverview.module.css
+++ b/protocol-dashboard/src/components/NodeOverview/NodeOverview.module.css
@@ -5,6 +5,13 @@
   display: inline-flex;
   flex-direction: column;
   box-sizing: border-box;
+  min-height: 240px;
+}
+
+.loading {
+  margin: 42px auto 0;
+  justify-content: center;
+  align-items: center;
 }
 
 .header {

--- a/protocol-dashboard/src/components/NodeOverview/NodeOverview.tsx
+++ b/protocol-dashboard/src/components/NodeOverview/NodeOverview.tsx
@@ -92,7 +92,7 @@ const NodeOverview = ({
   delegateOwnerWallet,
   isOwner,
   isDeregistered,
-  isUnregistered
+  isUnregistered,
   isLoading
 }: NodeOverviewProps) => {
   const { isOpen, onClick, onClose } = useModalControls()

--- a/protocol-dashboard/src/components/NodeOverview/NodeOverview.tsx
+++ b/protocol-dashboard/src/components/NodeOverview/NodeOverview.tsx
@@ -80,6 +80,7 @@ type NodeOverviewProps = {
   isOwner?: boolean
   isDeregistered?: boolean
   isUnregistered?: boolean
+  isLoading: boolean
 }
 
 const NodeOverview = ({
@@ -92,6 +93,7 @@ const NodeOverview = ({
   isOwner,
   isDeregistered,
   isUnregistered
+  isLoading
 }: NodeOverviewProps) => {
   const { isOpen, onClick, onClose } = useModalControls()
   const { health, status, error } = useNodeHealth(endpoint, serviceType)
@@ -252,76 +254,82 @@ const NodeOverview = ({
 
   return (
     <Paper className={styles.container}>
-      <div className={styles.header}>
-        <div className={styles.serviceType}>
-          {serviceType === ServiceType.DiscoveryProvider
-            ? messages.dp
-            : messages.cn}
-        </div>
-        {isDeregistered && (
-          <div className={styles.deregistered}>{messages.deregistered}</div>
-        )}
-        {!isDeregistered && (
-          <div className={styles.version}>
-            {`${messages.version} ${health?.version || version || 'unknown'}`}
+      {isLoading ? (
+        <Loading className={styles.loading} />
+      ) : (
+        <>
+          <div className={styles.header}>
+            <div className={styles.serviceType}>
+              {serviceType === ServiceType.DiscoveryProvider
+                ? messages.dp
+                : messages.cn}
+            </div>
+            {isDeregistered && (
+              <div className={styles.deregistered}>{messages.deregistered}</div>
+            )}
+            {!isDeregistered && (
+              <div className={styles.version}>
+                {`${messages.version} ${health?.version || version || 'unknown'}`}
+              </div>
+            )}
+            {!isDeregistered && isUnregistered && (
+              <>
+                <Button
+                  onClick={onClick}
+                  leftIcon={<IconArrowWhite />}
+                  type={ButtonType.PRIMARY}
+                  text={messages.register}
+                  className={clsx(styles.registerBtn)}
+                  textClassName={styles.registerBtnText}
+                />
+                <RegisterServiceModal
+                  isOpen={isOpen}
+                  onClose={onClose}
+                  defaultDelegateOwnerWallet={
+                    delegateOwnerWallet || health?.delegateOwnerWallet || ''
+                  }
+                  defaultEndpoint={endpoint}
+                  defaultServiceType={serviceType}
+                />
+              </>
+            )}
+            {!isDeregistered && isOwner && (
+              <>
+                <Button
+                  onClick={onClick}
+                  leftIcon={<IconPencil />}
+                  type={ButtonType.PRIMARY_ALT}
+                  text={messages.modify}
+                  className={clsx(styles.modifyBtn)}
+                  textClassName={styles.modifyBtnText}
+                />
+                <ModifyServiceModal
+                  isOpen={isOpen}
+                  onClose={onClose}
+                  spID={spID}
+                  serviceType={serviceType}
+                  endpoint={endpoint}
+                  delegateOwnerWallet={health?.delegateOwnerWallet}
+                />
+              </>
+            )}
           </div>
-        )}
-        {!isDeregistered && isUnregistered && (
-          <>
-            <Button
-              onClick={onClick}
-              leftIcon={<IconArrowWhite />}
-              type={ButtonType.PRIMARY}
-              text={messages.register}
-              className={clsx(styles.registerBtn)}
-              textClassName={styles.registerBtnText}
+          <ServiceDetail label={messages.endpoint} value={endpoint} />
+          {(operatorWallet || health?.operatorWallet) && (
+            <ServiceDetail
+              label={messages.operator}
+              value={operatorWallet || health?.operatorWallet}
             />
-            <RegisterServiceModal
-              isOpen={isOpen}
-              onClose={onClose}
-              defaultDelegateOwnerWallet={
-                delegateOwnerWallet || health?.delegateOwnerWallet || ''
-              }
-              defaultEndpoint={endpoint}
-              defaultServiceType={serviceType}
+          )}
+          {(delegateOwnerWallet || health?.delegateOwnerWallet) && (
+            <ServiceDetail
+              label={messages.delegate}
+              value={delegateOwnerWallet || health.delegateOwnerWallet}
             />
-          </>
-        )}
-        {!isDeregistered && isOwner && (
-          <>
-            <Button
-              onClick={onClick}
-              leftIcon={<IconPencil />}
-              type={ButtonType.PRIMARY_ALT}
-              text={messages.modify}
-              className={clsx(styles.modifyBtn)}
-              textClassName={styles.modifyBtnText}
-            />
-            <ModifyServiceModal
-              isOpen={isOpen}
-              onClose={onClose}
-              spID={spID}
-              serviceType={serviceType}
-              endpoint={endpoint}
-              delegateOwnerWallet={health?.delegateOwnerWallet}
-            />
-          </>
-        )}
-      </div>
-      <ServiceDetail label={messages.endpoint} value={endpoint} />
-      {(operatorWallet || health?.operatorWallet) && (
-        <ServiceDetail
-          label={messages.operator}
-          value={operatorWallet || health?.operatorWallet}
-        />
+          )}
+          {healthDetails}
+        </>
       )}
-      {(delegateOwnerWallet || health?.delegateOwnerWallet) && (
-        <ServiceDetail
-          label={messages.delegate}
-          value={delegateOwnerWallet || health.delegateOwnerWallet}
-        />
-      )}
-      {healthDetails}
     </Paper>
   )
 }

--- a/protocol-dashboard/src/containers/Node/Node.module.css
+++ b/protocol-dashboard/src/containers/Node/Node.module.css
@@ -1,4 +1,19 @@
 .container {
-  display: inline-flex;
   width: 100%;
+}
+
+.section {
+  margin-bottom: 16px;
+  display: flex;
+  margin-left: -8px;
+  margin-right: -8px;
+}
+
+.section > * {
+  width: 100%;
+  margin: 0 8px;
+}
+
+.chart {
+  min-height: 340px;
 }

--- a/protocol-dashboard/src/containers/Node/Node.tsx
+++ b/protocol-dashboard/src/containers/Node/Node.tsx
@@ -14,6 +14,9 @@ import {
   SERVICES,
   NOT_FOUND
 } from 'utils/routes'
+import IndividualServiceApiCallsChart from 'components/IndividualServiceApiCallsChart'
+import clsx from 'clsx'
+import IndividualServiceUniqueUsersChart from 'components/IndividualServiceUniqueUsersChart'
 
 const messages = {
   title: 'SERVICE',
@@ -22,59 +25,72 @@ const messages = {
 }
 
 type ContentNodeProps = { spID: number; accountWallet: Address | undefined }
-const ContentNode = ({ spID, accountWallet }: ContentNodeProps) => {
+const ContentNode: React.FC<ContentNodeProps> = ({
+  spID,
+  accountWallet
+}: ContentNodeProps) => {
   const { node: contentNode, status } = useContentNode({ spID })
 
   if (status === Status.Failure) {
     return null
-  } else if (status === Status.Loading) {
-    return null
   }
 
-  // TODO: compare owner with the current user
-  const isOwner = accountWallet === contentNode!.owner
+  const isOwner = accountWallet === contentNode?.owner ?? false
 
   return (
     <NodeOverview
       spID={spID}
       serviceType={ServiceType.ContentNode}
-      version={contentNode!.version}
-      endpoint={contentNode!.endpoint}
-      operatorWallet={contentNode!.owner}
-      delegateOwnerWallet={contentNode!.delegateOwnerWallet}
+      version={contentNode?.version}
+      endpoint={contentNode?.endpoint}
+      operatorWallet={contentNode?.owner}
+      delegateOwnerWallet={contentNode?.delegateOwnerWallet}
       isOwner={isOwner}
-      isDeregistered={contentNode!.isDeregistered}
+      isDeregistered={contentNode?.isDeregistered}
+      isLoading={status === Status.Loading}
     />
   )
 }
 
-type DiscoveryProviderProps = {
+type DiscoveryNodeProps = {
   spID: number
   accountWallet: Address | undefined
 }
-const DiscoveryProvider = ({ spID, accountWallet }: DiscoveryProviderProps) => {
-  const { node: discoveryProvider, status } = useDiscoveryProvider({ spID })
+const DiscoveryNode: React.FC<DiscoveryNodeProps> = ({
+  spID,
+  accountWallet
+}: DiscoveryNodeProps) => {
+  const { node: discoveryNode, status } = useDiscoveryProvider({ spID })
   const pushRoute = usePushRoute()
   if (status === Status.Failure) {
     pushRoute(NOT_FOUND)
     return null
-  } else if (status === Status.Loading) {
-    return null
   }
 
-  const isOwner = accountWallet === discoveryProvider!.owner
+  const isOwner = accountWallet === discoveryNode?.owner ?? false
 
   return (
-    <NodeOverview
-      spID={spID}
-      serviceType={ServiceType.DiscoveryProvider}
-      version={discoveryProvider!.version}
-      endpoint={discoveryProvider!.endpoint}
-      operatorWallet={discoveryProvider!.owner}
-      delegateOwnerWallet={discoveryProvider!.delegateOwnerWallet}
-      isOwner={isOwner}
-      isDeregistered={discoveryProvider!.isDeregistered}
-    />
+    <>
+      <div className={styles.section}>
+        <NodeOverview
+          spID={spID}
+          serviceType={ServiceType.DiscoveryProvider}
+          version={discoveryNode?.version}
+          endpoint={discoveryNode?.endpoint}
+          operatorWallet={discoveryNode?.owner}
+          delegateOwnerWallet={discoveryNode?.delegateOwnerWallet}
+          isOwner={isOwner}
+          isDeregistered={discoveryNode?.isDeregistered}
+          isLoading={status === Status.Loading}
+        />
+      </div>
+      {discoveryNode ? (
+        <div className={clsx(styles.section, styles.chart)}>
+          <IndividualServiceApiCallsChart node={discoveryNode?.endpoint} />
+          <IndividualServiceUniqueUsersChart node={discoveryNode?.endpoint} />
+        </div>
+      ) : null}
+    </>
   )
 }
 
@@ -92,7 +108,7 @@ const Node = () => {
       defaultPreviousPageRoute={SERVICES}
     >
       {isDiscovery ? (
-        <DiscoveryProvider spID={spID} accountWallet={accountWallet} />
+        <DiscoveryNode spID={spID} accountWallet={accountWallet} />
       ) : (
         <ContentNode spID={spID} accountWallet={accountWallet} />
       )}

--- a/protocol-dashboard/src/store/cache/analytics/hooks.ts
+++ b/protocol-dashboard/src/store/cache/analytics/hooks.ts
@@ -180,7 +180,6 @@ async function fetchTimeSeries(
     if (route === 'routes') {
       endpoint = `${node}/v1/metrics/aggregates/${route}/${bucket}?bucket_size=${bucketSize}`
     }
-    console.log(`MICHELLE BUCKET ${bucket} BUCKET SIZE ${bucketSize}`)
     if (node) {
       data = (
         await fetchWithTimeout(endpoint)

--- a/protocol-dashboard/src/store/cache/analytics/hooks.ts
+++ b/protocol-dashboard/src/store/cache/analytics/hooks.ts
@@ -176,11 +176,14 @@ async function fetchTimeSeries(
   try {
     const bucketSize = BUCKET_GRANULARITY_MAP[bucket]
     let data
+    let endpoint = `${node}/v1/metrics/${route}?bucket_size=${bucketSize}&start_time=${startTime}` 
+    if (route === 'routes') {
+      endpoint = `${node}/v1/metrics/aggregates/${route}/${bucket}?bucket_size=${bucketSize}`
+    }
+    console.log(`MICHELLE BUCKET ${bucket} BUCKET SIZE ${bucketSize}`)
     if (node) {
       data = (
-        await fetchWithTimeout(
-          `${node}/v1/metrics/${route}?bucket_size=${bucketSize}&start_time=${startTime}`
-        )
+        await fetchWithTimeout(endpoint)
       ).data.slice(1) // Trim off the first day so we don't show partial data
     } else {
       data = await fetchWithLibs({

--- a/protocol-dashboard/src/store/cache/analytics/hooks.ts
+++ b/protocol-dashboard/src/store/cache/analytics/hooks.ts
@@ -178,7 +178,7 @@ async function fetchTimeSeries(
     let data
     let endpoint = `${node}/v1/metrics/${route}?bucket_size=${bucketSize}&start_time=${startTime}`
     if (route === 'routes') {
-      endpoint = `${node}/v1/metrics/aggregates/${route}/${bucket}?bucket_size=${bucketSize}`
+      endpoint = `${node}/v1/metrics/routes/${bucket}?bucket_size=${bucketSize}`
     }
     if (node) {
       data = (await fetchWithTimeout(endpoint)).data.slice(1) // Trim off the first day so we don't show partial data

--- a/protocol-dashboard/src/store/cache/analytics/hooks.ts
+++ b/protocol-dashboard/src/store/cache/analytics/hooks.ts
@@ -16,13 +16,14 @@ import {
   CountRecord,
   setTopApps,
   setTrailingTopGenres,
-  MetricError
+  MetricError,
+  setIndividualServiceApiCalls
 } from './slice'
 import { useEffect, useState } from 'react'
 import { useAverageBlockTime, useEthBlockNumber } from '../protocol/hooks'
 import { weiAudToAud } from 'utils/numeric'
 import { ELECTRONIC_SUB_GENRES } from './genres'
-import { fetchWithLibs } from 'utils/fetch'
+import { fetchWithLibs, fetchWithTimeout } from 'utils/fetch'
 import { AnyAction } from '@reduxjs/toolkit'
 dayjs.extend(duration)
 
@@ -118,6 +119,10 @@ export const getTrailingTopGenres = (
     : null
 export const getTopApps = (state: AppState, { bucket }: { bucket: Bucket }) =>
   state.cache.analytics.topApps ? state.cache.analytics.topApps[bucket] : null
+export const getIndividualServiceApiCalls = (
+  state: AppState,
+  { node, bucket }: { node: string; bucket: Bucket }
+) => state.cache.analytics.individualServiceApiCalls?.[node]?.[bucket] ?? null
 
 // -------------------------------- Thunk Actions  ---------------------------------
 
@@ -151,20 +156,38 @@ export function fetchApiCalls(
   }
 }
 
+/**
+ * Fetches time series data from a discovery node
+ * @param route The route to fetch from (plays, routes)
+ * @param bucket The bucket size
+ * @param clampDays Whether or not to remove partial current day
+ * @param node An optional node to make the request against
+ * @returns the metric itself or a MetricError
+ */
 async function fetchTimeSeries(
   route: string,
   bucket: Bucket,
-  clampDays: boolean = true
+  clampDays: boolean = true,
+  node?: string
 ) {
   const startTime = getStartTime(bucket, clampDays)
   let error = false
   let metric: TimeSeriesRecord[] = []
   try {
     const bucketSize = BUCKET_GRANULARITY_MAP[bucket]
-    const data = (await fetchWithLibs({
-      endpoint: `v1/metrics/${route}`,
-      queryParams: { bucket_size: bucketSize, start_time: startTime }
-    })) as any
+    let data
+    if (node) {
+      data = (
+        await fetchWithTimeout(
+          `${node}/v1/metrics/${route}?bucket_size=${bucketSize}&start_time=${startTime}`
+        )
+      ).data.slice(1) // Trim off the first day so we don't show partial data
+    } else {
+      data = await fetchWithLibs({
+        endpoint: `v1/metrics/${route}`,
+        queryParams: { bucket_size: bucketSize, start_time: startTime }
+      })
+    }
     metric = data.reverse()
   } catch (e) {
     console.error(e)
@@ -189,6 +212,16 @@ export function fetchPlays(
       )
     }
     dispatch(setPlays({ metric, bucket }))
+  }
+}
+
+export function fetchIndividualServiceRouteMetrics(
+  node: string,
+  bucket: Bucket
+): ThunkAction<void, AppState, Audius, Action<string>> {
+  return async dispatch => {
+    const metric = await fetchTimeSeries('routes', bucket, true, node)
+    dispatch(setIndividualServiceApiCalls({ node, metric, bucket }))
   }
 }
 
@@ -394,6 +427,28 @@ export const useApiCalls = (bucket: Bucket) => {
       dispatch(fetchApiCalls(bucket))
     }
   }, [dispatch, apiCalls, bucket, doOnce])
+
+  useEffect(() => {
+    if (apiCalls) {
+      setDoOnce(null)
+    }
+  }, [apiCalls, setDoOnce])
+
+  return { apiCalls }
+}
+
+export const useIndividualServiceApiCalls = (node: string, bucket: Bucket) => {
+  const [doOnce, setDoOnce] = useState<Bucket | null>(null)
+  const apiCalls = useSelector(state =>
+    getIndividualServiceApiCalls(state as AppState, { node, bucket })
+  )
+  const dispatch = useDispatch()
+  useEffect(() => {
+    if (doOnce !== bucket && (apiCalls === null || apiCalls === undefined)) {
+      setDoOnce(bucket)
+      dispatch(fetchIndividualServiceRouteMetrics(node, bucket))
+    }
+  }, [dispatch, apiCalls, bucket, node, doOnce])
 
   useEffect(() => {
     if (apiCalls) {

--- a/protocol-dashboard/src/store/cache/analytics/hooks.ts
+++ b/protocol-dashboard/src/store/cache/analytics/hooks.ts
@@ -176,14 +176,12 @@ async function fetchTimeSeries(
   try {
     const bucketSize = BUCKET_GRANULARITY_MAP[bucket]
     let data
-    let endpoint = `${node}/v1/metrics/${route}?bucket_size=${bucketSize}&start_time=${startTime}` 
+    let endpoint = `${node}/v1/metrics/${route}?bucket_size=${bucketSize}&start_time=${startTime}`
     if (route === 'routes') {
       endpoint = `${node}/v1/metrics/aggregates/${route}/${bucket}?bucket_size=${bucketSize}`
     }
     if (node) {
-      data = (
-        await fetchWithTimeout(endpoint)
-      ).data.slice(1) // Trim off the first day so we don't show partial data
+      data = (await fetchWithTimeout(endpoint)).data.slice(1) // Trim off the first day so we don't show partial data
     } else {
       data = await fetchWithLibs({
         endpoint: `v1/metrics/${route}`,

--- a/protocol-dashboard/src/store/cache/analytics/slice.ts
+++ b/protocol-dashboard/src/store/cache/analytics/slice.ts
@@ -39,6 +39,10 @@ export type State = {
   topApps: CountMetric
   trailingTopGenres: CountMetric
   trailingApiCalls: CountMetric
+  individualServiceApiCalls: {
+    // Mapping of node endpoint to TimeSeriesMetric
+    [node: string]: TimeSeriesMetric
+  }
 }
 
 export const initialState: State = {
@@ -47,7 +51,8 @@ export const initialState: State = {
   plays: {},
   topApps: {},
   trailingTopGenres: {},
-  trailingApiCalls: {}
+  trailingApiCalls: {},
+  individualServiceApiCalls: {}
 }
 
 type SetApiCalls = { metric: TimeSeriesRecord[] | MetricError; bucket: Bucket }
@@ -62,6 +67,11 @@ type SetTrailingTopGenres = {
   bucket: Bucket
 }
 type SetTrailingApiCalls = { metric: CountRecord | MetricError; bucket: Bucket }
+type SetIndividualServiceApiCalls = {
+  node: string
+  metric: TimeSeriesRecord[] | MetricError
+  bucket: Bucket
+}
 
 const slice = createSlice({
   name: 'analytics',
@@ -96,6 +106,16 @@ const slice = createSlice({
     ) => {
       const { metric, bucket } = action.payload
       state.trailingApiCalls[bucket] = metric
+    },
+    setIndividualServiceApiCalls: (
+      state,
+      action: PayloadAction<SetIndividualServiceApiCalls>
+    ) => {
+      const { node, metric, bucket } = action.payload
+      if (!state.individualServiceApiCalls[node]) {
+        state.individualServiceApiCalls[node] = {}
+      }
+      state.individualServiceApiCalls[node][bucket] = metric
     }
   }
 })
@@ -106,7 +126,8 @@ export const {
   setPlays,
   setTopApps,
   setTrailingTopGenres,
-  setTrailingApiCalls
+  setTrailingApiCalls,
+  setIndividualServiceApiCalls
 } = slice.actions
 
 export default slice.reducer


### PR DESCRIPTION
### Description
Move https://github.com/AudiusProject/protocol-dashboard/pull/123 to the monorepo.
I didn't rename all src files like in the original PR since all the dashboard source code is already under protocol-dashboard/ in the monorepo.

### How Has This Been Tested?
npm run start:stage
<img width="1084" alt="image" src="https://github.com/AudiusProject/audius-protocol/assets/25782182/ff3956f1-64c1-4400-96f7-5d856dd1b086">

