### PR TITLE
Fix failing root npm install

### DIFF
--- a/dev-tools/setup.sh
+++ b/dev-tools/setup.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-set -exu pipefail
+set -exo pipefail
 
 [ -f "/etc/os-release" ] && source /etc/os-release
 case "$ID" in


### PR DESCRIPTION
### Description
Fixes `npm i` at root failing due to:

```
+ '[' -f /etc/os-release ']'
+ case "$ID" in
./dev-tools/setup.sh: line 6: ID: unbound variable
npm ERR! code 1
npm ERR! path /Users/theo/workspace/audius-protocol
npm ERR! command failed
npm ERR! command sh -c bash ./scripts/postinstall.sh
```

The fix is to just allow unbounded variables. Probably a better fix would be to only run the `case "$ID" in"` block if `/etc/os-release` was able to be sourced.

### How Has This Been Tested?
```
git clone --branch theo-fix-setupsh https://github.com/AudiusProject/audius-protocol.git
cd audius-protocol
npm i
```