### PR TITLE
[PAY-2012] Add analytics for purchase start/success/failure

### DIFF
--- a/packages/common/src/models/Analytics.ts
+++ b/packages/common/src/models/Analytics.ts
@@ -1600,24 +1600,29 @@ type BuyUSDCRecoveryFailure = {
   error: string
 }
 
-type PurchaseContentStarted = {
+type ContentPurchaseMetadata = {
+  price: number
+  contentId: number
+  contentName: string
+  contentType: string
+  payExtraAmount?: number
+  payExtraPreset?: string
+  artistHandle: string
+  isVerifiedArtist: boolean
+}
+
+type PurchaseContentStarted = ContentPurchaseMetadata & {
   eventName: Name.PURCHASE_CONTENT_STARTED
-  extraAmount?: number
-  extraAmountPreset?: string
-  contentId: number
-  contentType: string
 }
-type PurchaseContentSuccess = {
+type PurchaseContentSuccess = ContentPurchaseMetadata & {
   eventName: Name.PURCHASE_CONTENT_SUCCESS
-  contentId: number
-  contentType: string
 }
-type PurchaseContentFailure = {
+
+type PurchaseContentFailure = ContentPurchaseMetadata & {
   eventName: Name.PURCHASE_CONTENT_FAILURE
-  contentId: number
-  contentType: string
   error: string
 }
+
 type PurchaseContentTwitterShare = {
   eventName: Name.PURCHASE_CONTENT_TWITTER_SHARE
   text: string

--- a/packages/common/src/models/Analytics.ts
+++ b/packages/common/src/models/Analytics.ts
@@ -1605,7 +1605,7 @@ type ContentPurchaseMetadata = {
   contentId: number
   contentName: string
   contentType: string
-  payExtraAmount?: number
+  payExtraAmount: number
   payExtraPreset?: string
   artistHandle: string
   isVerifiedArtist: boolean

--- a/packages/common/src/store/purchase-content/sagas.ts
+++ b/packages/common/src/store/purchase-content/sagas.ts
@@ -64,7 +64,6 @@ function* getContentInfo({ contentId, contentType }: GetPurchaseConfigArgs) {
     throw new Error('Failed to retrieve content owner')
   }
 
-  // Renaming most of this info to match analytics event properties
   const {
     premium_conditions: {
       usdc_purchase: { price }

--- a/packages/common/src/store/purchase-content/sagas.ts
+++ b/packages/common/src/store/purchase-content/sagas.ts
@@ -156,13 +156,13 @@ function* doStartPurchaseContentFlow({
   })
 
   const analyticsInfo = {
-    price,
+    price: price / 100,
     contentId,
     contentType,
     contentName: title,
     artistHandle: artistInfo.handle,
     isVerifiedArtist: artistInfo.is_verified,
-    payExtraAmount: extraAmount,
+    payExtraAmount: extraAmount ? extraAmount / 100 : 0,
     payExtraPreset: extraAmountPreset
   }
 


### PR DESCRIPTION
### Description
This rounds out the analytics info we want for starting and finishing the purchase flow

fixes PAY-2012

### How Has This Been Tested?
Tested locally against staging in Chrome.
