### PR TITLE
SummaryTable don't gray out last row if no SummaryItem

### DIFF
--- a/packages/mobile/src/components/summary-table/SummaryTable.tsx
+++ b/packages/mobile/src/components/summary-table/SummaryTable.tsx
@@ -25,7 +25,7 @@ const useStyles = makeStyles(({ spacing, palette, typography }) => ({
   lastRow: {
     borderBottomWidth: 0
   },
-  greyRow: {
+  grayRow: {
     backgroundColor: palette.neutralLight10
   }
 }))
@@ -57,7 +57,7 @@ export const SummaryTable = ({
   const nonNullItems = items.filter(removeNullable)
   return (
     <View style={styles.container}>
-      <View style={[styles.row, styles.greyRow]}>
+      <View style={[styles.row, styles.grayRow]}>
         <Text weight='bold'>{title}</Text>
         <Text variant='body' fontSize='large' weight='bold'>
           {secondaryTitle}
@@ -78,7 +78,7 @@ export const SummaryTable = ({
         </View>
       ))}
       {summaryItem !== undefined ? (
-        <View style={[styles.row, styles.lastRow, styles.greyRow]}>
+        <View style={[styles.row, styles.lastRow, styles.grayRow]}>
           <Text
             variant='body'
             fontSize='medium'

--- a/packages/web/src/components/summary-table/SummaryTable.module.css
+++ b/packages/web/src/components/summary-table/SummaryTable.module.css
@@ -22,7 +22,10 @@
   border-top: 1px solid var(--border-default);
 }
 
-.row:first-child,
-.row:last-child {
+.row:first-child {
+  background: var(--background-surface-1);
+}
+
+.rowGrayBackground {
   background: var(--background-surface-1);
 }

--- a/packages/web/src/components/summary-table/SummaryTable.tsx
+++ b/packages/web/src/components/summary-table/SummaryTable.tsx
@@ -1,6 +1,7 @@
 import { ReactNode } from 'react'
 
 import { ColorValue } from '@audius/stems'
+import cn from 'classnames'
 
 import { Text } from 'components/typography'
 
@@ -46,7 +47,7 @@ export const SummaryTable = ({
         </div>
       ))}
       {summaryItem !== undefined ? (
-        <div className={styles.row}>
+        <div className={cn(styles.row, styles.rowGrayBackground)}>
           <Text variant='title' size='medium' color={summaryLabelColor}>
             {summaryItem.label}
           </Text>


### PR DESCRIPTION
### Description
Because we were using CSS last-child to add the grey background to the last row, the last row was always grayed out. But we don't want to gray out the last row if there is no summary (showing amount that is claimable now).

Also updating "grey" to "gray" in mobile SummaryTable for consistency.

### How Has This Been Tested?

Local web
PurchaseSummaryTable UI stays the same:
<img width="722" alt="Screenshot 2023-10-23 at 2 18 05 PM" src="https://github.com/AudiusProject/audius-protocol/assets/3893871/519fee9a-9313-47c0-886c-10bad084eb66">
CooldownSummaryTable updated:
<img width="715" alt="Screenshot 2023-10-23 at 2 18 12 PM" src="https://github.com/AudiusProject/audius-protocol/assets/3893871/ee952bdb-acb3-41e7-95de-d24fbeccdecf">
