### PR TITLE
Fix setup-dev.sh for users without .bashrc

### DIFF
--- a/dev-tools/setup-dev.sh
+++ b/dev-tools/setup-dev.sh
@@ -5,7 +5,7 @@
 # Install nvm and required node versions
 curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.1/install.sh | bash
 source ~/.nvm/nvm.sh
-source ~/.bashrc
+[ -f "~/.bashrc" ] && source ~/.bashrc
 for dir in contracts eth-contracts packages/identity-service packages/libs; do
     cd "$PROTOCOL_DIR/$dir"
     nvm install


### PR DESCRIPTION
### Description

Fixes issue where users without .bashrc have an error when running npm i. We could also check for .zshrc, but setup-dev.sh may just be removed in the future anyway, so this fix is just a stop-gap.
