### PR TITLE
[PAY-1998] Hide feed tip tile when USDC purchases is on

### DIFF
--- a/packages/mobile/src/screens/feed-screen/FeedScreen.tsx
+++ b/packages/mobile/src/screens/feed-screen/FeedScreen.tsx
@@ -4,7 +4,8 @@ import {
   Name,
   lineupSelectors,
   feedPageLineupActions as feedActions,
-  feedPageSelectors
+  feedPageSelectors,
+  FeatureFlags
 } from '@audius/common'
 import { useDispatch } from 'react-redux'
 
@@ -14,6 +15,7 @@ import { FeedTipTile } from 'app/components/feed-tip-tile'
 import { Lineup } from 'app/components/lineup'
 import { OnlineOnly } from 'app/components/offline-placeholder/OnlineOnly'
 import { useAppTabScreen } from 'app/hooks/useAppTabScreen'
+import { useFeatureFlag } from 'app/hooks/useRemoteConfig'
 import { make, track } from 'app/services/analytics'
 
 import { EmptyFeedSuggestedFollows } from './EmptyFeedSuggestedFollows'
@@ -30,6 +32,9 @@ const messages = {
 
 export const FeedScreen = () => {
   useAppTabScreen()
+  const { isEnabled: isUsdcEnabled } = useFeatureFlag(
+    FeatureFlags.USDC_PURCHASES
+  )
 
   const dispatch = useDispatch()
 
@@ -53,7 +58,7 @@ export const FeedScreen = () => {
           pullToRefresh
           delineate
           selfLoad
-          header={<FeedTipTile />}
+          header={isUsdcEnabled ? null : <FeedTipTile />}
           hideHeaderOnEmpty
           ListFooterComponent={<EndOfFeedNotice />}
           LineupEmptyComponent={<EmptyFeedSuggestedFollows />}

--- a/packages/web/src/components/lineup/LineupProvider.tsx
+++ b/packages/web/src/components/lineup/LineupProvider.tsx
@@ -200,7 +200,7 @@ export interface LineupProviderProps {
   isTrending?: boolean
 
   /** Whether we are in the feed lineup */
-  isFeed?: boolean
+  showFeedTipTile?: boolean
 
   /** How many icons to show for top ranked entries in the lineup. Defaults to 0, showing none */
   rankIconCount?: number
@@ -479,7 +479,7 @@ class LineupProvider extends PureComponent<CombinedProps, LineupProviderState> {
       lineup: { isMetadataLoading, page, entries = [] },
       numPlaylistSkeletonRows,
       isTrending = false,
-      isFeed = false,
+      showFeedTipTile = false,
       rankIconCount = 0
     } = this.props
     const status = lineup.status
@@ -529,7 +529,7 @@ class LineupProvider extends PureComponent<CombinedProps, LineupProviderState> {
             hasLoaded: this.hasLoaded,
             isTrending,
             showRankIcon: index < rankIconCount,
-            isFeed
+            showFeedTipTile
           }
           if (entry.id === leadingElementId) {
             trackProps = { ...trackProps, ...leadingElementTileProps }
@@ -554,7 +554,7 @@ class LineupProvider extends PureComponent<CombinedProps, LineupProviderState> {
             numLoadingSkeletonRows: numPlaylistSkeletonRows,
             isTrending,
             showRankIcon: index < rankIconCount,
-            isFeed
+            showFeedTipTile
           }
 
           return <this.props.playlistTile key={index} {...playlistProps} />
@@ -774,7 +774,7 @@ class LineupProvider extends PureComponent<CombinedProps, LineupProviderState> {
               threshold={loadMoreThreshold}
               element='ol'
             >
-              {isFeed ? <FeedTipTile /> : null}
+              {showFeedTipTile ? <FeedTipTile /> : null}
               {tiles.map((tile, index) => (
                 <li key={index}>{tile}</li>
               ))}

--- a/packages/web/src/pages/feed-page/components/desktop/FeedPageContent.tsx
+++ b/packages/web/src/pages/feed-page/components/desktop/FeedPageContent.tsx
@@ -1,7 +1,8 @@
 import {
   Name,
   FeedFilter,
-  feedPageLineupActions as feedActions
+  feedPageLineupActions as feedActions,
+  FeatureFlags
 } from '@audius/common'
 
 import { make, useRecord } from 'common/store/analytics/actions'
@@ -14,6 +15,7 @@ import {
 } from 'components/lineup/LineupProvider'
 import { LineupVariant } from 'components/lineup/types'
 import Page from 'components/page/Page'
+import { useFlag } from 'hooks/useRemoteConfig'
 import EmptyFeed from 'pages/feed-page/components/EmptyFeed'
 import { FeedPageContentProps } from 'pages/feed-page/types'
 
@@ -45,6 +47,8 @@ const FeedPageContent = ({
   setFeedFilter,
   resetFeedLineup
 }: FeedPageContentProps) => {
+  const { isEnabled: isUSDCEnabled } = useFlag(FeatureFlags.USDC_PURCHASES)
+
   const mainLineupProps = {
     variant: LineupVariant.MAIN
   }
@@ -108,7 +112,7 @@ const FeedPageContent = ({
         }
         endOfLineup={<EndOfLineup key='endOfLineup' />}
         key='feed'
-        isFeed
+        showFeedTipTile={!isUSDCEnabled}
         {...feedLineupProps}
         {...mainLineupProps}
       />


### PR DESCRIPTION
### Description

Feed tip tile should not show when USDC purchases is on.

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._

```
npm run web:stage

npm run mobile
npm run ios:stage
```