### PR TITLE
[PAY-1962] Disable selectable pills during purchase

### DIFF
--- a/packages/harmony/src/components/input/SelectablePill/SelectablePill.module.css
+++ b/packages/harmony/src/components/input/SelectablePill/SelectablePill.module.css
@@ -21,28 +21,37 @@
   box-shadow: var(--harmony-shadow-near);
 }
 
-.pill:hover {
+.pill:not(.disabled):hover {
   background-color: var(--harmony-s-200);
   color: var(--harmony-static-white);
   border: 1px solid var(--harmony-secondary);
 }
 
-.large:hover {
+.large:not(.disabled):hover {
   background-color: var(--harmony-s-100);
   border: 1px solid var(--harmony-s-200);
   box-shadow: none;
 }
 
 .selected,
-.pill:active {
+.pill:not(.disabled):active {
   background-color: var(--harmony-s-400);
   color: var(--harmony-static-white);
   border: 1px solid var(--harmony-s-400);
 }
 
-.large:active,
+.large:not(.disabled):active,
 .large.selected {
   box-shadow: none;
+}
+
+.disabled {
+  opacity: 0.45;
+}
+
+.disabled:hover {
+  background-color: var(--harmony-white);
+  border: 1px solid var(--harmony-border-strong);
 }
 
 .icon path {

--- a/packages/harmony/src/components/input/SelectablePill/SelectablePill.module.css
+++ b/packages/harmony/src/components/input/SelectablePill/SelectablePill.module.css
@@ -21,26 +21,30 @@
   box-shadow: var(--harmony-shadow-near);
 }
 
-.pill:not(.disabled):hover {
+.pill:hover {
   background-color: var(--harmony-s-200);
   color: var(--harmony-static-white);
   border: 1px solid var(--harmony-secondary);
 }
 
-.large:not(.disabled):hover {
+.large:hover {
   background-color: var(--harmony-s-100);
   border: 1px solid var(--harmony-s-200);
   box-shadow: none;
 }
 
 .selected,
-.pill:not(.disabled):active {
+.pill:active {
   background-color: var(--harmony-s-400);
   color: var(--harmony-static-white);
   border: 1px solid var(--harmony-s-400);
 }
 
-.large:not(.disabled):active,
+.pill.disabled {
+  pointer-events: none;
+}
+
+.large:active,
 .large.selected {
   box-shadow: none;
 }

--- a/packages/harmony/src/components/input/SelectablePill/SelectablePill.tsx
+++ b/packages/harmony/src/components/input/SelectablePill/SelectablePill.tsx
@@ -16,6 +16,7 @@ export const SelectablePill = forwardRef<
       size = 'default',
       isSelected,
       label,
+      isDisabled,
       icon: IconComponent,
       className,
       ...restProps
@@ -28,7 +29,8 @@ export const SelectablePill = forwardRef<
           styles.pill,
           {
             [styles.large]: size === 'large',
-            [styles.selected]: isSelected
+            [styles.selected]: isSelected,
+            [styles.disabled]: isDisabled
           },
           className
         )}

--- a/packages/harmony/src/components/input/SelectablePill/SelectablePill.tsx
+++ b/packages/harmony/src/components/input/SelectablePill/SelectablePill.tsx
@@ -16,7 +16,7 @@ export const SelectablePill = forwardRef<
       size = 'default',
       isSelected,
       label,
-      isDisabled,
+      disabled,
       icon: IconComponent,
       className,
       ...restProps
@@ -30,7 +30,7 @@ export const SelectablePill = forwardRef<
           {
             [styles.large]: size === 'large',
             [styles.selected]: isSelected,
-            [styles.disabled]: isDisabled
+            [styles.disabled]: disabled
           },
           className
         )}

--- a/packages/harmony/src/components/input/SelectablePill/types.ts
+++ b/packages/harmony/src/components/input/SelectablePill/types.ts
@@ -6,5 +6,6 @@ export type SelectablePillProps = {
   size?: 'default' | 'large'
   isSelected: boolean
   label: string
+  isDisabled?: boolean
   icon?: IconComponent
 } & Omit<ComponentPropsWithoutRef<'button'>, 'children'>

--- a/packages/harmony/src/components/input/SelectablePill/types.ts
+++ b/packages/harmony/src/components/input/SelectablePill/types.ts
@@ -6,6 +6,6 @@ export type SelectablePillProps = {
   size?: 'default' | 'large'
   isSelected: boolean
   label: string
-  isDisabled?: boolean
+  disabled?: boolean
   icon?: IconComponent
 } & Omit<ComponentPropsWithoutRef<'button'>, 'children'>

--- a/packages/mobile/src/components/core/HarmonySelectablePill.tsx
+++ b/packages/mobile/src/components/core/HarmonySelectablePill.tsx
@@ -67,7 +67,7 @@ type HarmonySelectablePillProps = Omit<ButtonProps, 'title'> &
     icon?: React.ReactElement
     label: string
     size?: 'default' | 'large'
-    isDisabled?: boolean
+    disabled?: boolean
   } & StylesProps<{ root: ViewStyle }>
 
 export const HarmonySelectablePill = (props: HarmonySelectablePillProps) => {
@@ -79,7 +79,7 @@ export const HarmonySelectablePill = (props: HarmonySelectablePillProps) => {
     onPressIn,
     onPressOut,
     size,
-    isDisabled,
+    disabled,
     style,
     ...other
   } = props
@@ -92,20 +92,18 @@ export const HarmonySelectablePill = (props: HarmonySelectablePillProps) => {
 
   const handlePressIn = useCallback(
     (event: GestureResponderEvent) => {
-      if (isDisabled) return
       onPressIn?.(event)
       handlePressInScale()
     },
-    [handlePressInScale, isDisabled, onPressIn]
+    [handlePressInScale, onPressIn]
   )
 
   const handlePressOut = useCallback(
     (event: GestureResponderEvent) => {
-      if (isDisabled) return
       onPressOut?.(event)
       handlePressOutScale()
     },
-    [handlePressOutScale, isDisabled, onPressOut]
+    [handlePressOutScale, onPressOut]
   )
 
   return (
@@ -114,16 +112,16 @@ export const HarmonySelectablePill = (props: HarmonySelectablePillProps) => {
         styles.pill,
         size === 'large' ? styles.pillLarge : undefined,
         isSelected ? styles.pressed : undefined,
-        isDisabled ? { opacity: 0.45 } : undefined,
+        disabled ? { opacity: 0.45 } : undefined,
         { transform: [{ scale }] },
         style
       ]}
     >
       <Pressable
         accessibilityRole='button'
-        onPressIn={handlePressIn}
-        onPressOut={handlePressOut}
-        disabled={isDisabled}
+        onPressIn={disabled ? null : handlePressIn}
+        onPressOut={disabled ? null : handlePressOut}
+        disabled={disabled}
         style={[
           styles.pressable,
           size === 'large' ? styles.pressableLarge : undefined

--- a/packages/mobile/src/components/core/HarmonySelectablePill.tsx
+++ b/packages/mobile/src/components/core/HarmonySelectablePill.tsx
@@ -67,7 +67,6 @@ type HarmonySelectablePillProps = Omit<ButtonProps, 'title'> &
     icon?: React.ReactElement
     label: string
     size?: 'default' | 'large'
-    disabled?: boolean
   } & StylesProps<{ root: ViewStyle }>
 
 export const HarmonySelectablePill = (props: HarmonySelectablePillProps) => {
@@ -119,8 +118,8 @@ export const HarmonySelectablePill = (props: HarmonySelectablePillProps) => {
     >
       <Pressable
         accessibilityRole='button'
-        onPressIn={disabled ? null : handlePressIn}
-        onPressOut={disabled ? null : handlePressOut}
+        onPressIn={disabled ? undefined : handlePressIn}
+        onPressOut={disabled ? undefined : handlePressOut}
         disabled={disabled}
         style={[
           styles.pressable,

--- a/packages/mobile/src/components/core/HarmonySelectablePill.tsx
+++ b/packages/mobile/src/components/core/HarmonySelectablePill.tsx
@@ -67,6 +67,7 @@ type HarmonySelectablePillProps = Omit<ButtonProps, 'title'> &
     icon?: React.ReactElement
     label: string
     size?: 'default' | 'large'
+    isDisabled?: boolean
   } & StylesProps<{ root: ViewStyle }>
 
 export const HarmonySelectablePill = (props: HarmonySelectablePillProps) => {
@@ -78,6 +79,7 @@ export const HarmonySelectablePill = (props: HarmonySelectablePillProps) => {
     onPressIn,
     onPressOut,
     size,
+    isDisabled,
     style,
     ...other
   } = props
@@ -90,18 +92,20 @@ export const HarmonySelectablePill = (props: HarmonySelectablePillProps) => {
 
   const handlePressIn = useCallback(
     (event: GestureResponderEvent) => {
+      if (isDisabled) return
       onPressIn?.(event)
       handlePressInScale()
     },
-    [handlePressInScale, onPressIn]
+    [handlePressInScale, isDisabled, onPressIn]
   )
 
   const handlePressOut = useCallback(
     (event: GestureResponderEvent) => {
+      if (isDisabled) return
       onPressOut?.(event)
       handlePressOutScale()
     },
-    [handlePressOutScale, onPressOut]
+    [handlePressOutScale, isDisabled, onPressOut]
   )
 
   return (
@@ -110,6 +114,7 @@ export const HarmonySelectablePill = (props: HarmonySelectablePillProps) => {
         styles.pill,
         size === 'large' ? styles.pillLarge : undefined,
         isSelected ? styles.pressed : undefined,
+        isDisabled ? { opacity: 0.45 } : undefined,
         { transform: [{ scale }] },
         style
       ]}
@@ -118,6 +123,7 @@ export const HarmonySelectablePill = (props: HarmonySelectablePillProps) => {
         accessibilityRole='button'
         onPressIn={handlePressIn}
         onPressOut={handlePressOut}
+        disabled={isDisabled}
         style={[
           styles.pressable,
           size === 'large' ? styles.pressableLarge : undefined

--- a/packages/mobile/src/components/premium-track-purchase-drawer/PayExtraFormSection.tsx
+++ b/packages/mobile/src/components/premium-track-purchase-drawer/PayExtraFormSection.tsx
@@ -44,12 +44,12 @@ const formatPillAmount = (val: number) => `$${Math.floor(val / 100)}`
 
 export type PayExtraFormSectionProps = {
   amountPresets: PayExtraAmountPresetValues
-  isDisabled?: boolean
+  disabled?: boolean
 }
 
 export const PayExtraFormSection = ({
   amountPresets,
-  isDisabled
+  disabled
 }: PayExtraFormSectionProps) => {
   const [{ value: preset }, , { setValue: setPreset }] = useField(AMOUNT_PRESET)
   const [{ value: customAmount }, { error: customAmountError }] =
@@ -71,7 +71,7 @@ export const PayExtraFormSection = ({
             style={styles.pill}
             isSelected={preset === PayExtraPreset.LOW}
             label={formatPillAmount(amountPresets[PayExtraPreset.LOW])}
-            isDisabled={isDisabled}
+            disabled={disabled}
             onPress={() => handleClickPreset(PayExtraPreset.LOW)}
           />
           <HarmonySelectablePill
@@ -79,7 +79,7 @@ export const PayExtraFormSection = ({
             style={styles.pill}
             isSelected={preset === PayExtraPreset.MEDIUM}
             label={formatPillAmount(amountPresets[PayExtraPreset.MEDIUM])}
-            isDisabled={isDisabled}
+            disabled={disabled}
             onPress={() => handleClickPreset(PayExtraPreset.MEDIUM)}
           />
           <HarmonySelectablePill
@@ -87,7 +87,7 @@ export const PayExtraFormSection = ({
             style={styles.pill}
             isSelected={preset === PayExtraPreset.HIGH}
             label={formatPillAmount(amountPresets[PayExtraPreset.HIGH])}
-            isDisabled={isDisabled}
+            disabled={disabled}
             onPress={() => handleClickPreset(PayExtraPreset.HIGH)}
           />
         </View>
@@ -96,7 +96,7 @@ export const PayExtraFormSection = ({
           style={styles.pill}
           isSelected={preset === PayExtraPreset.CUSTOM}
           label={messages.customAmount}
-          isDisabled={isDisabled}
+          disabled={disabled}
           onPress={() => handleClickPreset(PayExtraPreset.CUSTOM)}
         />
       </View>

--- a/packages/mobile/src/components/premium-track-purchase-drawer/PayExtraFormSection.tsx
+++ b/packages/mobile/src/components/premium-track-purchase-drawer/PayExtraFormSection.tsx
@@ -44,10 +44,12 @@ const formatPillAmount = (val: number) => `$${Math.floor(val / 100)}`
 
 export type PayExtraFormSectionProps = {
   amountPresets: PayExtraAmountPresetValues
+  isDisabled?: boolean
 }
 
 export const PayExtraFormSection = ({
-  amountPresets
+  amountPresets,
+  isDisabled
 }: PayExtraFormSectionProps) => {
   const [{ value: preset }, , { setValue: setPreset }] = useField(AMOUNT_PRESET)
   const [{ value: customAmount }, { error: customAmountError }] =
@@ -69,6 +71,7 @@ export const PayExtraFormSection = ({
             style={styles.pill}
             isSelected={preset === PayExtraPreset.LOW}
             label={formatPillAmount(amountPresets[PayExtraPreset.LOW])}
+            isDisabled={isDisabled}
             onPress={() => handleClickPreset(PayExtraPreset.LOW)}
           />
           <HarmonySelectablePill
@@ -76,6 +79,7 @@ export const PayExtraFormSection = ({
             style={styles.pill}
             isSelected={preset === PayExtraPreset.MEDIUM}
             label={formatPillAmount(amountPresets[PayExtraPreset.MEDIUM])}
+            isDisabled={isDisabled}
             onPress={() => handleClickPreset(PayExtraPreset.MEDIUM)}
           />
           <HarmonySelectablePill
@@ -83,6 +87,7 @@ export const PayExtraFormSection = ({
             style={styles.pill}
             isSelected={preset === PayExtraPreset.HIGH}
             label={formatPillAmount(amountPresets[PayExtraPreset.HIGH])}
+            isDisabled={isDisabled}
             onPress={() => handleClickPreset(PayExtraPreset.HIGH)}
           />
         </View>
@@ -91,6 +96,7 @@ export const PayExtraFormSection = ({
           style={styles.pill}
           isSelected={preset === PayExtraPreset.CUSTOM}
           label={messages.customAmount}
+          isDisabled={isDisabled}
           onPress={() => handleClickPreset(PayExtraPreset.CUSTOM)}
         />
       </View>

--- a/packages/mobile/src/components/premium-track-purchase-drawer/PremiumTrackPurchaseDrawer.tsx
+++ b/packages/mobile/src/components/premium-track-purchase-drawer/PremiumTrackPurchaseDrawer.tsx
@@ -217,6 +217,7 @@ const RenderForm = ({ track }: { track: PurchasableTrackMetadata }) => {
   const { amountDue } = purchaseSummaryValues
 
   const isPurchaseSuccessful = stage === PurchaseContentStage.FINISH
+  const isInProgress = isContentPurchaseInProgress(stage)
 
   // Navigate to track screen in the background if purchase is successful
   useEffect(() => {
@@ -240,7 +241,10 @@ const RenderForm = ({ track }: { track: PurchasableTrackMetadata }) => {
         ) : null}
         <View style={styles.formContentSection}>
           {isPurchaseSuccessful ? null : (
-            <PayExtraFormSection amountPresets={presetValues} />
+            <PayExtraFormSection
+              amountPresets={presetValues}
+              isDisabled={isInProgress}
+            />
           )}
           <PurchaseSummaryTable
             {...purchaseSummaryValues}

--- a/packages/mobile/src/components/premium-track-purchase-drawer/PremiumTrackPurchaseDrawer.tsx
+++ b/packages/mobile/src/components/premium-track-purchase-drawer/PremiumTrackPurchaseDrawer.tsx
@@ -243,7 +243,7 @@ const RenderForm = ({ track }: { track: PurchasableTrackMetadata }) => {
           {isPurchaseSuccessful ? null : (
             <PayExtraFormSection
               amountPresets={presetValues}
-              isDisabled={isInProgress}
+              disabled={isInProgress}
             />
           )}
           <PurchaseSummaryTable

--- a/packages/web/src/components/premium-content-purchase-modal/components/PayExtraFormSection.tsx
+++ b/packages/web/src/components/premium-content-purchase-modal/components/PayExtraFormSection.tsx
@@ -86,7 +86,7 @@ export const PayExtraFormSection = ({
           placeholder={messages.placeholder}
           label={messages.customAmount}
           name={CUSTOM_AMOUNT}
-          isDisabled={isDisabled}
+          disabled={isDisabled}
         />
       ) : null}
     </div>

--- a/packages/web/src/components/premium-content-purchase-modal/components/PayExtraFormSection.tsx
+++ b/packages/web/src/components/premium-content-purchase-modal/components/PayExtraFormSection.tsx
@@ -22,17 +22,16 @@ const formatPillAmount = (val: number) => `$${Math.floor(val / 100)}`
 
 export type PayExtraFormSectionProps = {
   amountPresets: PayExtraAmountPresetValues
-  isDisabled?: boolean
+  disabled?: boolean
 }
 
 export const PayExtraFormSection = ({
   amountPresets,
-  isDisabled = false
+  disabled = false
 }: PayExtraFormSectionProps) => {
   const [{ value: preset }, , { setValue: setPreset }] = useField(AMOUNT_PRESET)
 
   const handleClickPreset = (newPreset: PayExtraPreset) => {
-    if (isDisabled) return
     setPreset(newPreset === preset ? PayExtraPreset.NONE : newPreset)
   }
 
@@ -50,7 +49,7 @@ export const PayExtraFormSection = ({
             size='large'
             type='button'
             onClick={() => handleClickPreset(PayExtraPreset.LOW)}
-            isDisabled={isDisabled}
+            disabled={disabled}
           />
           <SelectablePill
             className={styles.presetPill}
@@ -59,7 +58,7 @@ export const PayExtraFormSection = ({
             size='large'
             type='button'
             onClick={() => handleClickPreset(PayExtraPreset.MEDIUM)}
-            isDisabled={isDisabled}
+            disabled={disabled}
           />
           <SelectablePill
             className={styles.presetPill}
@@ -68,7 +67,7 @@ export const PayExtraFormSection = ({
             size='large'
             type='button'
             onClick={() => handleClickPreset(PayExtraPreset.HIGH)}
-            isDisabled={isDisabled}
+            disabled={disabled}
           />
         </div>
         <SelectablePill
@@ -78,7 +77,7 @@ export const PayExtraFormSection = ({
           size='large'
           type='button'
           onClick={() => handleClickPreset(PayExtraPreset.CUSTOM)}
-          isDisabled={isDisabled}
+          disabled={disabled}
         />
       </div>
       {preset === PayExtraPreset.CUSTOM ? (
@@ -86,7 +85,7 @@ export const PayExtraFormSection = ({
           placeholder={messages.placeholder}
           label={messages.customAmount}
           name={CUSTOM_AMOUNT}
-          disabled={isDisabled}
+          disabled={disabled}
         />
       ) : null}
     </div>

--- a/packages/web/src/components/premium-content-purchase-modal/components/PayExtraFormSection.tsx
+++ b/packages/web/src/components/premium-content-purchase-modal/components/PayExtraFormSection.tsx
@@ -27,7 +27,7 @@ export type PayExtraFormSectionProps = {
 
 export const PayExtraFormSection = ({
   amountPresets,
-  disabled = false
+  disabled
 }: PayExtraFormSectionProps) => {
   const [{ value: preset }, , { setValue: setPreset }] = useField(AMOUNT_PRESET)
 

--- a/packages/web/src/components/premium-content-purchase-modal/components/PayExtraFormSection.tsx
+++ b/packages/web/src/components/premium-content-purchase-modal/components/PayExtraFormSection.tsx
@@ -22,14 +22,17 @@ const formatPillAmount = (val: number) => `$${Math.floor(val / 100)}`
 
 export type PayExtraFormSectionProps = {
   amountPresets: PayExtraAmountPresetValues
+  isDisabled?: boolean
 }
 
 export const PayExtraFormSection = ({
-  amountPresets
+  amountPresets,
+  isDisabled = false
 }: PayExtraFormSectionProps) => {
   const [{ value: preset }, , { setValue: setPreset }] = useField(AMOUNT_PRESET)
 
   const handleClickPreset = (newPreset: PayExtraPreset) => {
+    if (isDisabled) return
     setPreset(newPreset === preset ? PayExtraPreset.NONE : newPreset)
   }
 
@@ -47,6 +50,7 @@ export const PayExtraFormSection = ({
             size='large'
             type='button'
             onClick={() => handleClickPreset(PayExtraPreset.LOW)}
+            isDisabled={isDisabled}
           />
           <SelectablePill
             className={styles.presetPill}
@@ -55,6 +59,7 @@ export const PayExtraFormSection = ({
             size='large'
             type='button'
             onClick={() => handleClickPreset(PayExtraPreset.MEDIUM)}
+            isDisabled={isDisabled}
           />
           <SelectablePill
             className={styles.presetPill}
@@ -63,6 +68,7 @@ export const PayExtraFormSection = ({
             size='large'
             type='button'
             onClick={() => handleClickPreset(PayExtraPreset.HIGH)}
+            isDisabled={isDisabled}
           />
         </div>
         <SelectablePill
@@ -72,6 +78,7 @@ export const PayExtraFormSection = ({
           size='large'
           type='button'
           onClick={() => handleClickPreset(PayExtraPreset.CUSTOM)}
+          isDisabled={isDisabled}
         />
       </div>
       {preset === PayExtraPreset.CUSTOM ? (
@@ -79,6 +86,7 @@ export const PayExtraFormSection = ({
           placeholder={messages.placeholder}
           label={messages.customAmount}
           name={CUSTOM_AMOUNT}
+          isDisabled={isDisabled}
         />
       ) : null}
     </div>

--- a/packages/web/src/components/premium-content-purchase-modal/components/PurchaseContentFormFields.tsx
+++ b/packages/web/src/components/premium-content-purchase-modal/components/PurchaseContentFormFields.tsx
@@ -55,7 +55,7 @@ export const PurchaseContentFormFields = ({
     <>
       <PayExtraFormSection
         amountPresets={payExtraAmountPresetValues}
-        isDisabled={isInProgress}
+        disabled={isInProgress}
       />
       <PurchaseSummaryTable
         {...purchaseSummaryValues}

--- a/packages/web/src/components/premium-content-purchase-modal/components/PurchaseContentFormFields.tsx
+++ b/packages/web/src/components/premium-content-purchase-modal/components/PurchaseContentFormFields.tsx
@@ -1,4 +1,8 @@
-import { PurchaseContentStage, usePayExtraPresets } from '@audius/common'
+import {
+  PurchaseContentStage,
+  isContentPurchaseInProgress,
+  usePayExtraPresets
+} from '@audius/common'
 import { IconCheck } from '@audius/stems'
 
 import { Icon } from 'components/Icon'
@@ -27,6 +31,7 @@ export const PurchaseContentFormFields = ({
 }: PurchaseContentFormFieldsProps) => {
   const payExtraAmountPresetValues = usePayExtraPresets(useRemoteVar)
   const isPurchased = stage === PurchaseContentStage.FINISH
+  const isInProgress = isContentPurchaseInProgress(stage)
 
   if (isPurchased) {
     return (
@@ -48,7 +53,10 @@ export const PurchaseContentFormFields = ({
   }
   return (
     <>
-      <PayExtraFormSection amountPresets={payExtraAmountPresetValues} />
+      <PayExtraFormSection
+        amountPresets={payExtraAmountPresetValues}
+        isDisabled={isInProgress}
+      />
       <PurchaseSummaryTable
         {...purchaseSummaryValues}
         isPurchased={isPurchased}


### PR DESCRIPTION
### Description
Adds disabled variants for `SelectablePill` on mobile and web, display those while the purchase transaction is underway.

Preferring `disabled` instead of `isDisabled`.

### How Has This Been Tested?

Local web + ios stage
confirmed the buttons are not clickable
![Simulator Screenshot - iPhone 14 Pro - 2023-10-24 at 15 16 23](https://github.com/AudiusProject/audius-protocol/assets/3893871/0a3f123f-5481-4290-b1d7-ab05c92bd7d6)
<img width="729" alt="Screenshot 2023-10-24 at 3 15 06 PM" src="https://github.com/AudiusProject/audius-protocol/assets/3893871/7b8d9946-1b71-4de9-85c9-c8116123eeed">

