### PR TITLE
Filter out usdc create notifs from endpoint

### DIFF
--- a/packages/discovery-provider/src/queries/get_notifications.py
+++ b/packages/discovery-provider/src/queries/get_notifications.py
@@ -529,7 +529,7 @@ def get_notifications(session: Session, args: GetNotificationArgs):
                 ):
                     # Filter out the notification
                     break
-                filtered.append(notification)
+            filtered.append(notification)
         return filtered
 
     return notifications_and_actions

--- a/packages/discovery-provider/src/queries/get_notifications.py
+++ b/packages/discovery-provider/src/queries/get_notifications.py
@@ -205,6 +205,7 @@ def get_notification_groups(session: Session, args: GetNotificationArgs):
     """
     Gets the user's notifications in the database
     """
+    valid_types = args.get("valid_types", default_valid_types)
     limit = args.get("limit") or DEFAULT_LIMIT
     limit = min(limit, MAX_LIMIT)  # type: ignore
 
@@ -215,7 +216,7 @@ def get_notification_groups(session: Session, args: GetNotificationArgs):
             "limit": limit,
             "timestamp_offset": args.get("timestamp", None),
             "group_id_offset": args.get("group_id", None),
-            "valid_types": args.get("valid_types", None),
+            "valid_types": valid_types,
         },
     )
 

--- a/packages/discovery-provider/src/queries/get_notifications.py
+++ b/packages/discovery-provider/src/queries/get_notifications.py
@@ -7,6 +7,8 @@ from typing import Dict, List, Optional, TypedDict, Union
 from sqlalchemy import bindparam, text
 from sqlalchemy.orm.session import Session
 
+from src.models.tracks.track import Track
+
 logger = logging.getLogger(__name__)
 
 
@@ -206,9 +208,6 @@ def get_notification_groups(session: Session, args: GetNotificationArgs):
     limit = args.get("limit") or DEFAULT_LIMIT
     limit = min(limit, MAX_LIMIT)  # type: ignore
 
-    # Set valid types
-    args["valid_types"] = args.get("valid_types", []) + default_valid_types  # type: ignore
-
     rows = session.execute(
         notification_groups_sql,
         {
@@ -232,6 +231,7 @@ def get_notification_groups(session: Session, args: GetNotificationArgs):
         }
         for r in rows
     ]
+
     return res
 
 
@@ -481,6 +481,8 @@ notifications_sql = notifications_sql.bindparams(
 
 
 def get_notifications(session: Session, args: GetNotificationArgs):
+    args["valid_types"] = args.get("valid_types", []) + default_valid_types  # type: ignore
+
     notifications = get_notification_groups(session, args)
     notification_ids = []
     for notification in notifications:
@@ -508,6 +510,28 @@ def get_notifications(session: Session, args: GetNotificationArgs):
         }
         for notification in notifications
     ]
+
+    # TODO(PAY-1880): Remove this check after launch
+    if NotificationType.USDC_PURCHASE_BUYER not in args["valid_types"]:  # type: ignore
+        # Filter out usdc create tracks
+        filtered: List[NotificationGroup] = []
+        for notification in notifications_and_actions:
+            if notification["type"] == NotificationType.CREATE:
+                res = (
+                    session.query(Track).filter(
+                        Track.track_id == notification["actions"][0]["data"]["track_id"]
+                    )
+                ).one_or_none()
+                if (
+                    res
+                    and res.premium_conditions
+                    and "usdc_purchase" in res.premium_conditions
+                ):
+                    # Filter out the notification
+                    break
+                filtered.append(notification)
+        return filtered
+
     return notifications_and_actions
 
 

--- a/packages/discovery-provider/src/tasks/entity_manager/entities/track.py
+++ b/packages/discovery-provider/src/tasks/entity_manager/entities/track.py
@@ -446,9 +446,8 @@ def delete_track(params: ManageEntityParameters):
         params.block_datetime,
     )
     deleted_track.is_delete = True
+    # Detach this track from the parent if it is a stem
     deleted_track.stem_of = null()
-    deleted_track.remix_of = null()
-    deleted_track.premium_conditions = null()
 
     # delete stems record
     params.session.query(Stem).filter_by(child_track_id=track_id).delete()


### PR DESCRIPTION
### Description

This was missing in previous implementations.
It adds an extra query that will slow things down a bit, but generally speaking, it'll all fit within a page size and be good enough to take us through release.

Checked with @sddioulde  about the deleting of premium_conditions fields when a track is deleted

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._

stage dn5
