### PR TITLE
Add CI workflow to patch a SHA outside of release

### DIFF
--- a/.circleci/src/@continue_config.yml
+++ b/.circleci/src/@continue_config.yml
@@ -42,6 +42,12 @@ parameters:
   run-release-workflow:
     type: boolean
     default: false
+  run-patch-release-workflow:
+    type: boolean
+    default: false
+  patch-release-commit-sha:
+    type: string
+    default: ""
 
   run-web-workflow:
     type: boolean

--- a/.circleci/src/@continue_config.yml
+++ b/.circleci/src/@continue_config.yml
@@ -42,9 +42,6 @@ parameters:
   run-release-workflow:
     type: boolean
     default: false
-  run-patch-release-workflow:
-    type: boolean
-    default: false
   patch-release-commit-sha:
     type: string
     default: ""

--- a/.circleci/src/jobs/deploy-foundation-nodes.yml
+++ b/.circleci/src/jobs/deploy-foundation-nodes.yml
@@ -21,7 +21,14 @@ steps:
       command: |
         git clone --branch stage https://github.com/AudiusProject/audius-docker-compose.git audius-docker-compose
         cd audius-docker-compose
-        release_commit_hash=$(git log --all --grep="$CIRCLE_BRANCH auto-deploy" --pretty=format:"%H" -1)
+
+        # Use custom commit hash if provided. Otherwise, determine based on auto-deploy branch
+        if [ -n "<< pipeline.parameters.patch-release-commit-sha >>" ]; then
+          release_commit_hash=<< pipeline.parameters.patch-release-commit-sha >>
+        else
+          release_commit_hash=$(git log --all --grep="$CIRCLE_BRANCH auto-deploy" --pretty=format:"%H" -1)
+        fi
+
         git fetch origin foundation:foundation
         git checkout foundation
         git merge $release_commit_hash --no-edit

--- a/.circleci/src/jobs/release-audius-docker-compose.yml
+++ b/.circleci/src/jobs/release-audius-docker-compose.yml
@@ -21,7 +21,14 @@ steps:
       command: |
         git clone --branch foundation https://github.com/AudiusProject/audius-docker-compose.git audius-docker-compose
         cd audius-docker-compose
-        release_commit_hash=$(git log --all --grep="$CIRCLE_BRANCH auto-deploy" --pretty=format:"%H" -1)
+
+        # Use custom commit hash if provided. Otherwise, determine based on auto-deploy branch
+        if [ -n "<< pipeline.parameters.patch-release-commit-sha >>" ]; then
+          release_commit_hash=<< pipeline.parameters.patch-release-commit-sha >>
+        else
+          release_commit_hash=$(git log --all --grep="$CIRCLE_BRANCH auto-deploy" --pretty=format:"%H" -1)
+        fi
+
         git fetch origin main:main
         git checkout main
         git merge $release_commit_hash --no-edit

--- a/.circleci/src/workflows/patch-release.yml
+++ b/.circleci/src/workflows/patch-release.yml
@@ -1,0 +1,16 @@
+when: << pipeline.parameters.run-patch-release-workflow >>
+jobs:
+  - deploy-foundation-nodes-trigger:
+      type: approval
+  - deploy-foundation-nodes:
+      context: github
+      requires:
+        - deploy-foundation-nodes-trigger
+  - release-audius-docker-compose-trigger:
+      requires:
+        - deploy-foundation-nodes
+      type: approval
+  - release-audius-docker-compose:
+      context: github
+      requires:
+        - release-audius-docker-compose-trigger

--- a/.circleci/src/workflows/patch-release.yml
+++ b/.circleci/src/workflows/patch-release.yml
@@ -1,4 +1,4 @@
-when: << pipeline.parameters.run-patch-release-workflow >>
+when: << pipeline.parameters.patch-release-commit-sha >>
 jobs:
   - deploy-foundation-nodes-trigger:
       type: approval


### PR DESCRIPTION
### Description
I'm not sure if it's possible for a non-CI GitHub user to deploy a patch to the audius-docker-compose `main` branch due to branch protections. If it's not, this PR gives a way to do off-release patches by manually triggering a job with the parameter `patch-release-commit-sha`=`<desired audius-docker-compose SHA>`.

### How Has This Been Tested?
TODO