### PR TITLE
Fix cooldown summary table

### DIFF
--- a/packages/common/src/hooks/purchaseContent/useChallengeCooldownSchedule.ts
+++ b/packages/common/src/hooks/purchaseContent/useChallengeCooldownSchedule.ts
@@ -91,6 +91,8 @@ export const useAudioMatchingChallengeCooldownSchedule = (
     cooldownChallengesSummary:
       claimableAmount > 0
         ? getAudioMatchingChallengeCooldownSummary(claimableAmount)
-        : undefined
+        : undefined,
+    isEmpty:
+      cooldownChallenges.every((c) => c === undefined) && claimableAmount === 0
   }
 }

--- a/packages/mobile/src/components/challenge-rewards-drawer/CooldownSummaryTable.tsx
+++ b/packages/mobile/src/components/challenge-rewards-drawer/CooldownSummaryTable.tsx
@@ -18,7 +18,7 @@ export const CooldownSummaryTable = ({
 }) => {
   const { cooldownChallenges, cooldownChallengesSummary } =
     useAudioMatchingChallengeCooldownSchedule(challengeId)
-  return cooldownChallengesSummary ? (
+  return cooldownChallenges ? (
     <SummaryTable
       title={messages.upcomingRewards}
       secondaryTitle={messages.audio}

--- a/packages/mobile/src/components/challenge-rewards-drawer/CooldownSummaryTable.tsx
+++ b/packages/mobile/src/components/challenge-rewards-drawer/CooldownSummaryTable.tsx
@@ -16,9 +16,9 @@ export const CooldownSummaryTable = ({
 }: {
   challengeId: ChallengeRewardID
 }) => {
-  const { cooldownChallenges, cooldownChallengesSummary } =
+  const { cooldownChallenges, cooldownChallengesSummary, isEmpty } =
     useAudioMatchingChallengeCooldownSchedule(challengeId)
-  return cooldownChallenges ? (
+  return !isEmpty ? (
     <SummaryTable
       title={messages.upcomingRewards}
       secondaryTitle={messages.audio}

--- a/packages/web/src/pages/audio-rewards-page/components/modals/ChallengeRewardsModal/AudioMatchingRewardsModalContent.tsx
+++ b/packages/web/src/pages/audio-rewards-page/components/modals/ChallengeRewardsModal/AudioMatchingRewardsModalContent.tsx
@@ -96,8 +96,12 @@ export const AudioMatchingRewardsModalContent = ({
   const wm = useWithMobileStyle(styles.mobile)
   const navigateToPage = useNavigateToPage()
   const { fullDescription } = challengeRewardsConfig[challengeName]
-  const { cooldownChallenges, claimableAmount, cooldownChallengesSummary } =
-    useAudioMatchingChallengeCooldownSchedule(challenge?.challenge_id)
+  const {
+    cooldownChallenges,
+    claimableAmount,
+    cooldownChallengesSummary,
+    isEmpty: isCooldownChallengesEmpty
+  } = useAudioMatchingChallengeCooldownSchedule(challenge?.challenge_id)
   const userChallenge = useSelector(getOptimisticUserChallenges)[challengeName]
 
   const progressDescription = (
@@ -158,7 +162,7 @@ export const AudioMatchingRewardsModalContent = ({
             </div>
             {progressStatusLabel}
           </div>
-          {cooldownChallenges ? (
+          {!isCooldownChallengesEmpty ? (
             <SummaryTable
               title={messages.upcomingRewards}
               items={cooldownChallenges}

--- a/packages/web/src/pages/audio-rewards-page/components/modals/ChallengeRewardsModal/AudioMatchingRewardsModalContent.tsx
+++ b/packages/web/src/pages/audio-rewards-page/components/modals/ChallengeRewardsModal/AudioMatchingRewardsModalContent.tsx
@@ -158,7 +158,7 @@ export const AudioMatchingRewardsModalContent = ({
             </div>
             {progressStatusLabel}
           </div>
-          {cooldownChallengesSummary ? (
+          {cooldownChallenges ? (
             <SummaryTable
               title={messages.upcomingRewards}
               items={cooldownChallenges}


### PR DESCRIPTION
### Description
Sometimes the `cooldownChallengesSummary` doesn't exist bc none of the challenges are claimable yet, but there are still challenges waiting for the cooldown period that should be displayed.

How to check if array initialized with `new Array(x)` is empty:
<img width="260" alt="Screenshot 2023-10-24 at 2 36 33 PM" src="https://github.com/AudiusProject/audius-protocol/assets/3893871/4e1abb8d-c156-49dd-a73e-00ce6ae60abb">


### How Has This Been Tested?

Local web
With no cooldown challenges:
<img width="716" alt="Screenshot 2023-10-24 at 2 45 40 PM" src="https://github.com/AudiusProject/audius-protocol/assets/3893871/3a11e20a-9328-4c81-80cc-b452fbc82cd2">
With cooldown challenges:
<img width="717" alt="Screenshot 2023-10-24 at 2 45 08 PM" src="https://github.com/AudiusProject/audius-protocol/assets/3893871/9b58a2ca-563b-4ceb-9367-d0a16b918d7f">
With summary only:
<img width="718" alt="Screenshot 2023-10-24 at 2 45 04 PM" src="https://github.com/AudiusProject/audius-protocol/assets/3893871/16745225-1a78-4eb8-8a9b-533e4de65dce">

