### PR TITLE
Fix $AUDIO purchase

### DIFF
--- a/packages/common/src/utils/wallet.ts
+++ b/packages/common/src/utils/wallet.ts
@@ -114,22 +114,22 @@ export const formatWei = (
   return formatNumberCommas(trimmed) as StringAudio
 }
 
-const convertBigIntToUIString = (amount: bigint, decimals: number) => {
-  const str = amount.toString()
-  return `${str.substring(0, str.length - decimals)}.${str.substring(
-    str.length - decimals
-  )}`
-}
-
 export const convertBigIntToAmountObject = (
   amount: bigint,
   decimals: number
 ): AmountObject => {
+  const divisor = BigInt(10 ** decimals)
+  const quotient = amount / divisor
+  const remainder = amount % divisor
+  const uiAmountString =
+    remainder > 0
+      ? `${quotient.toString()}.${remainder.toString().padStart(decimals, '0')}`
+      : quotient.toString()
   return {
     amount: Number(amount),
     amountString: amount.toString(),
     uiAmount: Number(amount) / 10 ** decimals,
-    uiAmountString: convertBigIntToUIString(amount, decimals)
+    uiAmountString
   }
 }
 


### PR DESCRIPTION
### Description

Previous implementation was broken
https://github.com/AudiusProject/audius-protocol/pull/6037/files#diff-52168295d11e3bce18265ac1c5997dd0242622baf3e6292622807ce73cca1bf4L113

If the value is < 9 decimals (or provided number of decimals), we don't pad the front so we would over charge.
This PR returns the implementation to what it was before, just using the BigInt relevant functions.

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._

Tested via locally running buy audio flow. Values convert as expected.

I really wish we could have working unit tests in client codebase. We'll work on that ASAP.