### PR TITLE
Fix triggering patch-release workflow

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,6 +13,9 @@ parameters:
   workflow:
     type: string
     default: 'main'
+  patch-release-commit-sha:
+    type: string
+    default: ''
 
 commands:
   create_concatenated_patch_file:

--- a/.circleci/src/@continue_config.yml
+++ b/.circleci/src/@continue_config.yml
@@ -42,6 +42,9 @@ parameters:
   run-release-workflow:
     type: boolean
     default: false
+  patch-release-commit-sha:
+    type: string
+    default: ''
 
   run-web-workflow:
     type: boolean

--- a/.circleci/src/@continue_config.yml
+++ b/.circleci/src/@continue_config.yml
@@ -42,9 +42,6 @@ parameters:
   run-release-workflow:
     type: boolean
     default: false
-  patch-release-commit-sha:
-    type: string
-    default: ""
 
   run-web-workflow:
     type: boolean


### PR DESCRIPTION
### Description
The `patch-release-commit-sha` pipeline parameter was in the continue config, but in order to be manually triggered it needs to also be in the root config. This fixes that and is tested by triggering the job on this branch.