### PR TITLE
[PAY-2032] Clean up userbank analytics events

### DIFF
--- a/packages/common/src/models/Analytics.ts
+++ b/packages/common/src/models/Analytics.ts
@@ -1287,14 +1287,16 @@ type CreateUserBankRequest = {
 
 type CreateUserBankSuccess = {
   eventName: Name.CREATE_USER_BANK_SUCCESS
-  userId: ID
+  mint: string
+  recipientEthAddress: string
 }
 
 type CreateUserBankFailure = {
   eventName: Name.CREATE_USER_BANK_FAILURE
-  userId: ID
+  mint: string
+  recipientEthAddress: string
   errorCode: string
-  error: string
+  errorMessage: string
 }
 
 type RewardsClaimStart = {

--- a/packages/common/src/services/audius-backend/solana.ts
+++ b/packages/common/src/services/audius-backend/solana.ts
@@ -216,15 +216,10 @@ export const createUserBankIfNeeded = async (
       console.info(`Userbank doesn't exist, attempted to create...`)
 
       recordAnalytics({
-        eventName: Name.CREATE_USER_BANK_REQUEST,
+        eventName: Name.CREATE_USER_BANK_SUCCESS,
         properties: { mint, recipientEthAddress }
       })
     }
-
-    recordAnalytics({
-      eventName: Name.CREATE_USER_BANK_SUCCESS,
-      properties: { mint, recipientEthAddress }
-    })
     return res.userbank
   } catch (err: any) {
     // Catching error here for analytics purposes


### PR DESCRIPTION
### Description
The original user bank events were designed for a slightly different flow. The current flow doesn't have a way for us to hook into the "request" part, we just know afterwards if there was an error and whether the userbank had to be created. So I adjusted the code to send a success event if the user bank is created and then send along any failures encountered.

The event structure also didn't match what we are currently sending, which doesn't impact our ability to ingest them. But I updated it to be accurate anyway. We will need to do a bit of an overhaul on events later on.

fixes PAY-2032

### How Has This Been Tested?
Tested locally in Chrome against staging
