### PR TITLE
[PAY-1972] Filter out spammy accounts from explore premium tracks page

### DIFF
--- a/packages/common/src/services/remote-config/defaults.ts
+++ b/packages/common/src/services/remote-config/defaults.ts
@@ -87,7 +87,8 @@ export const remoteConfigStringDefaults: {
   [StringKeys.COINBASE_PAY_ALLOWED_COUNTRIES_2_LETTER]: '',
   [StringKeys.STRIPE_ALLOWED_COUNTRIES_2_LETTER]: '',
   [StringKeys.AUDIO_FEATURES_DEGRADED_TEXT]: null,
-  [StringKeys.PAY_EXTRA_PRESET_CENT_AMOUNTS]: '100,500,1000'
+  [StringKeys.PAY_EXTRA_PRESET_CENT_AMOUNTS]: '100,500,1000',
+  [StringKeys.EXPLORE_PREMIUM_ALLOWED_USER_IDS]: ''
 }
 
 export const remoteConfigDoubleDefaults: {

--- a/packages/common/src/services/remote-config/defaults.ts
+++ b/packages/common/src/services/remote-config/defaults.ts
@@ -88,7 +88,7 @@ export const remoteConfigStringDefaults: {
   [StringKeys.STRIPE_ALLOWED_COUNTRIES_2_LETTER]: '',
   [StringKeys.AUDIO_FEATURES_DEGRADED_TEXT]: null,
   [StringKeys.PAY_EXTRA_PRESET_CENT_AMOUNTS]: '100,500,1000',
-  [StringKeys.EXPLORE_PREMIUM_ALLOWED_USER_IDS]: ''
+  [StringKeys.EXPLORE_PREMIUM_ALLOWED_USERS]: ''
 }
 
 export const remoteConfigDoubleDefaults: {

--- a/packages/common/src/services/remote-config/types.ts
+++ b/packages/common/src/services/remote-config/types.ts
@@ -374,7 +374,10 @@ export enum StringKeys {
   AUDIO_FEATURES_DEGRADED_TEXT = 'AUDIO_FEATURES_DEGRADED_TEXT',
 
   /** Preset amounts for the Pay Extra feature in USDC purchases, specified in cents */
-  PAY_EXTRA_PRESET_CENT_AMOUNTS = 'PAY_EXTRA_PRESET_CENT_AMOUNTS'
+  PAY_EXTRA_PRESET_CENT_AMOUNTS = 'PAY_EXTRA_PRESET_CENT_AMOUNTS',
+
+  /** Allowlist of user ids for explore premium tracks page */
+  EXPLORE_PREMIUM_ALLOWED_USER_IDS = 'EXPLORE_PREMIUM_ALLOWED_USER_IDS'
 }
 
 export type AllRemoteConfigKeys =

--- a/packages/common/src/services/remote-config/types.ts
+++ b/packages/common/src/services/remote-config/types.ts
@@ -377,7 +377,7 @@ export enum StringKeys {
   PAY_EXTRA_PRESET_CENT_AMOUNTS = 'PAY_EXTRA_PRESET_CENT_AMOUNTS',
 
   /** Allowlist of user ids for explore premium tracks page */
-  EXPLORE_PREMIUM_ALLOWED_USER_IDS = 'EXPLORE_PREMIUM_ALLOWED_USER_IDS'
+  EXPLORE_PREMIUM_ALLOWED_USERS = 'EXPLORE_PREMIUM_ALLOWED_USERS'
 }
 
 export type AllRemoteConfigKeys =

--- a/packages/web/src/common/store/lineup/sagas.js
+++ b/packages/web/src/common/store/lineup/sagas.js
@@ -55,7 +55,7 @@ function* filterDeletes(tracksMetadata, removeDeleted, lineupPrefix) {
   const isUSDCGatedContentEnabled = yield getFeatureEnabled(
     FeatureFlags.USDC_PURCHASES
   )
-  const allowedHandles = yield remoteConfig
+  const allowedHandles = remoteConfig
     .getRemoteVar(StringKeys.EXPLORE_PREMIUM_ALLOWED_USERS)
     ?.split(',')
 

--- a/packages/web/src/common/store/lineup/sagas.js
+++ b/packages/web/src/common/store/lineup/sagas.js
@@ -78,7 +78,11 @@ function* filterDeletes(tracksMetadata, removeDeleted) {
         return null
       }
 
-      if (!allowedIds.includes(metadata.owner_id)) {
+      if (
+        metadata.is_premium &&
+        isPremiumContentUSDCPurchaseGated(metadata.premium_conditions) &&
+        !allowedIds.includes(metadata.owner_id)
+      ) {
         return null
       }
 

--- a/packages/web/src/common/store/lineup/sagas.js
+++ b/packages/web/src/common/store/lineup/sagas.js
@@ -15,7 +15,8 @@ import {
   getContext,
   FeatureFlags,
   isPremiumContentUSDCPurchaseGated,
-  doesUserHaveTrackAccess
+  doesUserHaveTrackAccess,
+  StringKeys
 } from '@audius/common'
 import {
   all,
@@ -53,6 +54,10 @@ function* filterDeletes(tracksMetadata, removeDeleted) {
   const isUSDCGatedContentEnabled = yield getFeatureEnabled(
     FeatureFlags.USDC_PURCHASES
   )
+  const allowedIds = yield remoteConfig
+    .getRemoteVar(StringKeys.EXPLORE_PREMIUM_ALLOWED_USER_IDS)
+    ?.split(',')
+    .map((id) => parseInt(id))
 
   return tracksMetadata
     .map((metadata) => {
@@ -70,6 +75,10 @@ function* filterDeletes(tracksMetadata, removeDeleted) {
         metadata.is_premium &&
         isPremiumContentUSDCPurchaseGated(metadata.premium_conditions)
       ) {
+        return null
+      }
+
+      if (!allowedIds.includes(metadata.owner_id)) {
         return null
       }
 


### PR DESCRIPTION
### Description
In explore premium tracks page, only show tracks from users that are in an allowlist, which is a remote var named `EXPLORE_PREMIUM_ALLOWED_USERS`.

### How Has This Been Tested?

Local web stage
single handle that appears very far down the unfiltered lineup:
<img width="1728" alt="Screenshot 2023-10-25 at 2 42 55 PM" src="https://github.com/AudiusProject/audius-protocol/assets/3893871/cca7b450-8ce5-4936-80c4-bf2c045c7c13">

2 handles:
<img width="1728" alt="Screenshot 2023-10-25 at 2 40 58 PM" src="https://github.com/AudiusProject/audius-protocol/assets/3893871/1cf78988-87fb-4a7e-9c7c-05117b686469">

empty (default):
<img width="1728" alt="Screenshot 2023-10-25 at 2 41 42 PM" src="https://github.com/AudiusProject/audius-protocol/assets/3893871/5651a8e4-4f3f-4e80-9ef6-1ef50c070166">

