### PR TITLE
[C-3263] Add asChild to harmony Button

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -118297,6 +118297,7 @@
       "dependencies": {
         "@emotion/react": "11.11.1",
         "@emotion/styled": "11.11.0",
+        "@radix-ui/react-slot": "1.0.2",
         "classnames": "2.2.6",
         "react-lottie": "1.2.3",
         "react-merge-refs": "2.0.1",

--- a/packages/harmony/package.json
+++ b/packages/harmony/package.json
@@ -80,6 +80,7 @@
   "dependencies": {
     "@emotion/react": "11.11.1",
     "@emotion/styled": "11.11.0",
+    "@radix-ui/react-slot": "1.0.2",
     "classnames": "2.2.6",
     "react-lottie": "1.2.3",
     "react-merge-refs": "2.0.1",

--- a/packages/harmony/src/components/button/BaseButton.module.css
+++ b/packages/harmony/src/components/button/BaseButton.module.css
@@ -1,5 +1,6 @@
 /* ===Base Styles=== */
 .button {
+  font-family: var(--harmony-font-family);
   align-items: center;
   box-sizing: border-box;
   cursor: pointer;

--- a/packages/harmony/src/components/button/BaseButton.tsx
+++ b/packages/harmony/src/components/button/BaseButton.tsx
@@ -1,5 +1,6 @@
 import { forwardRef } from 'react'
 
+import { Slot, Slottable } from '@radix-ui/react-slot'
 import cn from 'classnames'
 
 import LoadingSpinner from 'components/loading-spinner/LoadingSpinner'
@@ -28,6 +29,7 @@ export const BaseButton = forwardRef<HTMLButtonElement, BaseButtonProps>(
       style,
       children,
       'aria-label': ariaLabelProp,
+      asChild,
       ...other
     } = props
     const { isMatch: isTextHidden } = useMediaQueryListener(
@@ -43,8 +45,10 @@ export const BaseButton = forwardRef<HTMLButtonElement, BaseButtonProps>(
       return undefined
     }
 
+    const ButtonComponent = asChild ? Slot : 'button'
+
     return (
-      <button
+      <ButtonComponent
         className={cn(
           baseStyles.button,
           styles.button,
@@ -56,7 +60,7 @@ export const BaseButton = forwardRef<HTMLButtonElement, BaseButtonProps>(
         )}
         disabled={disabled || isLoading}
         ref={ref}
-        type='button'
+        type={asChild ? undefined : 'button'}
         style={{
           minWidth: minWidth && !isTextHidden ? `${minWidth}px` : 'unset',
           ...style
@@ -65,15 +69,15 @@ export const BaseButton = forwardRef<HTMLButtonElement, BaseButtonProps>(
         {...other}
       >
         {isLoading ? (
-          <LoadingSpinner className={(baseStyles.spinner, styles.spinner)} />
+          <LoadingSpinner className={cn(baseStyles.spinner, styles.spinner)} />
         ) : LeftIconComponent ? (
           <LeftIconComponent className={cn(baseStyles.icon, styles.icon)} />
         ) : null}
-        {!isTextHidden ? children : null}
+        {!isTextHidden ? <Slottable>{children}</Slottable> : null}
         {RightIconComponent ? (
           <RightIconComponent className={cn(baseStyles.icon, styles.icon)} />
         ) : null}
-      </button>
+      </ButtonComponent>
     )
   }
 )

--- a/packages/harmony/src/components/button/Button.stories.tsx
+++ b/packages/harmony/src/components/button/Button.stories.tsx
@@ -1,4 +1,6 @@
+import { expect } from '@storybook/jest'
 import type { Meta, StoryObj } from '@storybook/react'
+import { within } from '@storybook/testing-library'
 
 import { Button } from './Button'
 import { ButtonProps, ButtonSize, ButtonType } from './types'
@@ -55,3 +57,29 @@ export const Destructive: Story = { args: { variant: ButtonType.DESTRUCTIVE } }
 
 // Hidden text at certain widths (e.g. mobile layouts)
 export const HiddenTextAtWidth: Story = { args: { widthToHideText: 900 } }
+
+export const Link: Story = {
+  args: { asChild: true },
+  render: (props: ButtonProps) => {
+    return (
+      <Button {...props} asChild>
+        <a
+          href='/'
+          onClick={(e) => {
+            e.preventDefault()
+          }}
+          style={{ textDecorationLine: 'unset' }}
+        >
+          Click Me
+        </a>
+      </Button>
+    )
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement)
+
+    await expect(
+      canvas.getByRole('link', { name: /click me/i })
+    ).toBeInTheDocument()
+  }
+}

--- a/packages/harmony/src/components/button/types.ts
+++ b/packages/harmony/src/components/button/types.ts
@@ -61,6 +61,12 @@ export type BaseButtonProps = {
    * Internal styling used by derived button components
    */
   styles: BaseButtonStyles
+
+  /**
+   * Change the default rendered element for the one passed as a child,
+   *  merging their props and behavior.
+   */
+  asChild?: boolean
 } & HTMLButtonProps
 
 export type ButtonProps = {


### PR DESCRIPTION
### Description

Adds asChild to Button to enable "link" type flows. We may want to build links into our buttons since it is such a common pattern. or potentially build a button-link implementation in web, since it would be based of react-router/dom's Link