### PR TITLE
[PAY-2041] Return extended error information when stripe session creation fails

### DIFF
--- a/packages/identity-service/src/routes/stripe.js
+++ b/packages/identity-service/src/routes/stripe.js
@@ -65,9 +65,11 @@ module.exports = function (app) {
         return successResponse(response.data)
       } catch (e) {
         logger.error('Failed to create Stripe session:', e.response.data)
+        const { code, message, type } = e.response.data.error ?? {}
         return errorResponse(
           e.response.status,
-          'Failed to create Stripe session'
+          'Failed to create Stripe session',
+          { code, message, type }
         )
       }
     })


### PR DESCRIPTION
### Description
This catches the code/message/type fields from stripe session creation errors and returns them back as part of the response. This will allow us to catch those errors on the client and report more useful information.

There will be a follow-up PR to consume these messages in the client.

fixes PAY-2041

### How Has This Been Tested?
Tested with local identity service against testing environment for stripe
![image](https://github.com/AudiusProject/audius-protocol/assets/1815175/df0f3ec4-c6ae-4e51-98c9-4c1d3592d2d4)

