### PR TITLE
[PAY-2041] Connect stripe session creation errors to analytics

### DIFF
--- a/packages/common/src/models/Analytics.ts
+++ b/packages/common/src/models/Analytics.ts
@@ -335,6 +335,9 @@ export enum Name {
   BUY_USDC_RECOVERY_SUCCESS = 'Buy USDC: Recovery Success',
   BUY_USDC_RECOVERY_FAILURE = 'Buy USDC: Recovery Failure',
 
+  // Stripe Tracking
+  STRIPE_SESSION_CREATION_ERROR = 'Stripe: Session Creation Error',
+
   // Purchase Content
   PURCHASE_CONTENT_STARTED = 'Purchase Content: Started',
   PURCHASE_CONTENT_SUCCESS = 'Purchase Content: Success',
@@ -1574,6 +1577,7 @@ type BuyAudioRecoveryFailure = {
   error: string
 }
 
+// Buy USDC
 type BuyUSDCOnRampOpened = {
   eventName: Name.BUY_USDC_ON_RAMP_OPENED
   provider: string
@@ -1622,6 +1626,18 @@ type BuyUSDCRecoveryFailure = {
   eventName: Name.BUY_USDC_RECOVERY_FAILURE
   error: string
 }
+
+// Stripe
+type StripeSessionCreationError = {
+  eventName: Name.STRIPE_SESSION_CREATION_ERROR
+  amount: string
+  destinationCurrency: string
+  code: string
+  message: string
+  type: string
+}
+
+// Content Purchase
 
 type ContentPurchaseMetadata = {
   price: number
@@ -1983,6 +1999,7 @@ export type AllTrackingEvents =
   | BuyUSDCRecoveryInProgress
   | BuyUSDCRecoverySuccess
   | BuyUSDCRecoveryFailure
+  | StripeSessionCreationError
   | PurchaseContentStarted
   | PurchaseContentSuccess
   | PurchaseContentFailure

--- a/packages/common/src/models/Analytics.ts
+++ b/packages/common/src/models/Analytics.ts
@@ -1633,7 +1633,7 @@ type StripeSessionCreationError = {
   amount: string
   destinationCurrency: string
   code: string
-  message: string
+  errorMessage: string
   type: string
 }
 

--- a/packages/common/src/models/Analytics.ts
+++ b/packages/common/src/models/Analytics.ts
@@ -1633,7 +1633,7 @@ type StripeSessionCreationError = {
   amount: string
   destinationCurrency: string
   code: string
-  errorMessage: string
+  stripeErrorMessage: string
   type: string
 }
 

--- a/packages/common/src/store/buy-usdc/utils.ts
+++ b/packages/common/src/store/buy-usdc/utils.ts
@@ -1,7 +1,7 @@
 import { call, select } from 'typed-redux-saga'
 
 import { createUserBankIfNeeded } from 'services/audius-backend/solana'
-import { IntKeys } from 'services/index'
+import { IntKeys } from 'services/remote-config'
 import {
   MAX_CONTENT_PRICE_CENTS,
   MAX_USDC_PURCHASE_AMOUNT_CENTS,

--- a/packages/common/src/store/ui/stripe-modal/sagas.ts
+++ b/packages/common/src/store/ui/stripe-modal/sagas.ts
@@ -37,12 +37,12 @@ function* handleInitializeStripeModal({
   } catch (e) {
     const {
       code,
-      message: errorMessage,
+      message: stripeErrorMessage,
       type
     } = ((e as IdentityRequestError).response?.data ??
       {}) as StripeSessionCreationErrorResponseData
 
-    const error = new StripeSessionCreationError(code, errorMessage, type)
+    const error = new StripeSessionCreationError(code, stripeErrorMessage, type)
 
     if (onrampFailed) {
       yield* put({
@@ -56,7 +56,7 @@ function* handleInitializeStripeModal({
       error,
       additionalInfo: {
         code,
-        errorMessage,
+        stripeErrorMessage,
         type,
         amount,
         destinationCurrency
@@ -69,7 +69,7 @@ function* handleInitializeStripeModal({
         amount,
         code,
         destinationCurrency,
-        errorMessage,
+        stripeErrorMessage,
         type
       })
     )

--- a/packages/common/src/store/ui/stripe-modal/sagas.ts
+++ b/packages/common/src/store/ui/stripe-modal/sagas.ts
@@ -35,10 +35,14 @@ function* handleInitializeStripeModal({
     })
     yield* put(stripeSessionCreated({ clientSecret: res.client_secret }))
   } catch (e) {
-    const { code, message, type } = ((e as IdentityRequestError).response
-      ?.data ?? {}) as StripeSessionCreationErrorResponseData
+    const {
+      code,
+      message: errorMessage,
+      type
+    } = ((e as IdentityRequestError).response?.data ??
+      {}) as StripeSessionCreationErrorResponseData
 
-    const error = new StripeSessionCreationError(code, message, type)
+    const error = new StripeSessionCreationError(code, errorMessage, type)
 
     if (onrampFailed) {
       yield* put({
@@ -52,7 +56,7 @@ function* handleInitializeStripeModal({
       error,
       additionalInfo: {
         code,
-        message,
+        errorMessage,
         type,
         amount,
         destinationCurrency
@@ -65,7 +69,7 @@ function* handleInitializeStripeModal({
         amount,
         code,
         destinationCurrency,
-        message,
+        errorMessage,
         type
       })
     )

--- a/packages/common/src/store/ui/stripe-modal/types.ts
+++ b/packages/common/src/store/ui/stripe-modal/types.ts
@@ -16,3 +16,20 @@ export type StripeModalState = {
   stripeSessionStatus?: StripeSessionStatus
   stripeClientSecret?: string
 }
+
+export type StripeSessionCreationErrorResponse = {
+  error: string
+  code: string
+  message: string
+  type: string
+}
+
+export class StripeSessionCreationError extends Error {
+  constructor(
+    public code: string,
+    public message: string,
+    public type: string
+  ) {
+    super(`Failed to create Stripe session: ${message}`)
+  }
+}

--- a/packages/common/src/store/ui/stripe-modal/types.ts
+++ b/packages/common/src/store/ui/stripe-modal/types.ts
@@ -17,7 +17,7 @@ export type StripeModalState = {
   stripeClientSecret?: string
 }
 
-export type StripeSessionCreationErrorResponse = {
+export type StripeSessionCreationErrorResponseData = {
   error: string
   code: string
   message: string
@@ -27,9 +27,10 @@ export type StripeSessionCreationErrorResponse = {
 export class StripeSessionCreationError extends Error {
   constructor(
     public code: string,
-    public message: string,
+    // Avoiding `message` to not shadow the `message` property on Error
+    public errorMessage: string,
     public type: string
   ) {
-    super(`Failed to create Stripe session: ${message}`)
+    super(`Failed to create Stripe session: ${errorMessage}`)
   }
 }

--- a/packages/common/src/store/ui/stripe-modal/types.ts
+++ b/packages/common/src/store/ui/stripe-modal/types.ts
@@ -28,9 +28,9 @@ export class StripeSessionCreationError extends Error {
   constructor(
     public code: string,
     // Avoiding `message` to not shadow the `message` property on Error
-    public errorMessage: string,
+    public stripeErrorMessage: string,
     public type: string
   ) {
-    super(`Failed to create Stripe session: ${errorMessage}`)
+    super(`Failed to create Stripe session: ${stripeErrorMessage}`)
   }
 }

--- a/packages/libs/src/AudiusLibs.ts
+++ b/packages/libs/src/AudiusLibs.ts
@@ -27,6 +27,7 @@ import { EthContracts } from './services/ethContracts'
 import { EthWeb3Config, EthWeb3Manager } from './services/ethWeb3Manager'
 import { Hedgehog, HedgehogConfig } from './services/hedgehog'
 import { IdentityService } from './services/identity'
+import type { IdentityRequestError } from './services/identity'
 import { Schemas, SchemaValidator } from './services/schemaValidator'
 import {
   SolanaWeb3Manager,
@@ -637,6 +638,7 @@ export class AudiusLibs {
 }
 
 export { AudiusABIDecoder, Utils, SolanaUtils, CreatorNode }
+export { IdentityRequestError }
 
 export { SanityChecks } from './sanityChecks'
 export { RewardsAttester, DEFAULT_MINT, MintName } from './services/solana'

--- a/packages/libs/src/services/identity/IdentityService.ts
+++ b/packages/libs/src/services/identity/IdentityService.ts
@@ -46,6 +46,8 @@ export type RelayTransactionData = {
   lookupTableAddresses?: string[]
 }
 
+export type IdentityRequestError = AxiosError
+
 type AttestationResult = {
   status: string
   userId: string


### PR DESCRIPTION
### Description
Follow-up to #6461, this connects the extended error info to analytics so we can track errors in stripe session creation.

* Added a type export from libs so that we have a slight bit more type safety. Identity just re-throws Axios errors, so we need to pull the info out of `response.data`. I'm not using the `AxiosError` type directly because:
  1. Axios is not currently a dependency of `common`.
  2. I wanted to keep the inner details of how Identity generates errors decoupled.
* Added custom error class for stripe session errors with the fields we get back from the API
* Added analytics event

(Bonus: Fixed a circular dependency that I introduced in a previous PR)

### How Has This Been Tested?
Tested locally in Chrome against staging.
