### PR TITLE
Use self-hosted runners for pushing images

### DIFF
--- a/.circleci/src/jobs/push-docker-image.yml
+++ b/.circleci/src/jobs/push-docker-image.yml
@@ -6,9 +6,8 @@ parameters:
     description: 'Whether to notify Slack on failure'
     type: boolean
     default: false
-resource_class: large
-machine:
-  image: ubuntu-2204:current
+machine: true
+resource_class: audiusproject/gcp-n2-standard-4
 steps:
   - checkout:
       path: '~/audius-protocol'
@@ -18,6 +17,10 @@ steps:
       command: echo "$DOCKERHUB_PASS" | docker login -u "$DOCKERHUB_USERNAME" --password-stdin
   - run: . ~/.profile; audius-compose build --prod "<< parameters.service >>"
   - run: . ~/.profile; audius-compose push --prod "<< parameters.service >>"
+  - run:
+      when: always
+      name: Log out of Docker
+      command: docker logout
   - run:
       when: on_fail
       name: Alert Slack of failure


### PR DESCRIPTION
### Description

Self-hosted runners have been working reliably so far. Adding the push-docker-image jobs will further speed up ci while saving circleci credits.

### How Has This Been Tested?

Will monitor CI - push jobs are only active on main.