### PR TITLE
[PAY-2051] Show preview UI when playing your own preview

### DIFF
--- a/packages/mobile/src/components/now-playing-drawer/Artwork.tsx
+++ b/packages/mobile/src/components/now-playing-drawer/Artwork.tsx
@@ -3,7 +3,8 @@ import {
   DogEarType,
   SquareSizes,
   averageColorSelectors,
-  usePremiumContentAccess
+  usePremiumContentAccess,
+  playerSelectors
 } from '@audius/common'
 import { Dimensions } from 'react-native'
 import { useSelector } from 'react-redux'
@@ -11,6 +12,7 @@ import { useSelector } from 'react-redux'
 import { DogEar, Shadow } from 'app/components/core'
 import { TrackImage } from 'app/components/image/TrackImage'
 import { makeStyles } from 'app/styles'
+const { getPreviewing } = playerSelectors
 const { getDominantColorsByTrack } = averageColorSelectors
 
 const dimensions = Dimensions.get('window')
@@ -56,10 +58,11 @@ export const Artwork = ({ track }: ArtworkProps) => {
   }
 
   const { doesUserHaveAccess } = usePremiumContentAccess(track)
+  const isPreviewing = useSelector(getPreviewing)
   const shouldShowDogEar =
     track?.premium_conditions &&
     'usdc_purchase' in track.premium_conditions &&
-    !doesUserHaveAccess
+    (!doesUserHaveAccess || isPreviewing)
 
   return (
     <Shadow opacity={0.2} radius={8} color={shadowColor} style={styles.root}>

--- a/packages/mobile/src/components/now-playing-drawer/PlayBar.tsx
+++ b/packages/mobile/src/components/now-playing-drawer/PlayBar.tsx
@@ -6,6 +6,7 @@ import {
   FavoriteSource,
   accountSelectors,
   tracksSocialActions,
+  playerSelectors,
   usePremiumContentAccess
 } from '@audius/common'
 import { TouchableOpacity, Animated, View, Dimensions } from 'react-native'
@@ -26,6 +27,7 @@ import { TrackingBar } from './TrackingBar'
 import { NOW_PLAYING_HEIGHT, PLAY_BAR_HEIGHT } from './constants'
 const { getAccountUser } = accountSelectors
 const { saveTrack, unsaveTrack } = tracksSocialActions
+const { getPreviewing } = playerSelectors
 
 const messages = {
   preview: 'PREVIEW'
@@ -128,10 +130,11 @@ export const PlayBar = (props: PlayBarProps) => {
   const staticWhite = useColor('staticWhite')
 
   const { doesUserHaveAccess } = usePremiumContentAccess(track)
+  const isPreviewing = useSelector(getPreviewing)
   const shouldShowPreviewLock =
     track?.premium_conditions &&
     'usdc_purchase' in track.premium_conditions &&
-    !doesUserHaveAccess
+    (!doesUserHaveAccess || isPreviewing)
 
   const onPressFavoriteButton = useCallback(() => {
     if (track) {

--- a/packages/mobile/src/components/now-playing-drawer/TrackInfo.tsx
+++ b/packages/mobile/src/components/now-playing-drawer/TrackInfo.tsx
@@ -2,14 +2,18 @@ import {
   usePremiumContentAccess,
   type Nullable,
   type Track,
-  type User
+  type User,
+  playerSelectors
 } from '@audius/common'
 import { TouchableOpacity, View } from 'react-native'
+import { useSelector } from 'react-redux'
 
 import { LockedStatusBadge, Text } from 'app/components/core'
 import UserBadges from 'app/components/user-badges/UserBadges'
 import { makeStyles } from 'app/styles'
 import type { GestureResponderHandler } from 'app/types/gesture'
+
+const { getPreviewing } = playerSelectors
 
 const messages = {
   preview: 'PREVIEW'
@@ -58,10 +62,11 @@ export const TrackInfo = ({
 }: TrackInfoProps) => {
   const styles = useStyles()
   const { doesUserHaveAccess } = usePremiumContentAccess(track)
+  const isPreviewing = useSelector(getPreviewing)
   const shouldShowPreviewLock =
     track?.premium_conditions &&
     'usdc_purchase' in track.premium_conditions &&
-    !doesUserHaveAccess
+    (!doesUserHaveAccess || isPreviewing)
 
   return (
     <View style={styles.root}>

--- a/packages/web/src/components/nav/desktop/NowPlayingArtworkTile.tsx
+++ b/packages/web/src/components/nav/desktop/NowPlayingArtworkTile.tsx
@@ -26,7 +26,7 @@ import { fullTrackPage } from 'utils/route'
 
 import styles from './NowPlayingArtworkTile.module.css'
 
-const { getTrackId, getCollectible } = playerSelectors
+const { getTrackId, getCollectible, getPreviewing } = playerSelectors
 const { getTrack } = cacheTracksSelectors
 const { getUserId } = accountSelectors
 const { getDominantColorsByTrack } = averageColorSelectors
@@ -69,10 +69,11 @@ export const NowPlayingArtworkTile = () => {
     getTrack(state, { id: trackId })
   )
   const { doesUserHaveAccess } = usePremiumContentAccess(track)
+  const isPreviewing = useSelector(getPreviewing)
   const shouldShowPurchaseDogEar =
     track?.premium_conditions &&
     'usdc_purchase' in track.premium_conditions &&
-    !doesUserHaveAccess
+    (!doesUserHaveAccess || isPreviewing)
 
   const isOwner = useSelector((state: CommonState) => {
     const ownerId = getTrack(state, { id: trackId })?.owner_id

--- a/packages/web/src/components/play-bar/desktop/components/PlayingTrackInfo.tsx
+++ b/packages/web/src/components/play-bar/desktop/components/PlayingTrackInfo.tsx
@@ -7,7 +7,8 @@ import {
   SquareSizes,
   CommonState,
   cacheTracksSelectors,
-  usePremiumContentAccess
+  usePremiumContentAccess,
+  playerSelectors
 } from '@audius/common'
 import cn from 'classnames'
 import { useSelector } from 'react-redux'
@@ -23,6 +24,7 @@ import { fullTrackPage } from 'utils/route'
 
 import styles from './PlayingTrackInfo.module.css'
 const { getTrack } = cacheTracksSelectors
+const { getPreviewing } = playerSelectors
 
 const messages = {
   preview: 'Preview'
@@ -69,10 +71,11 @@ const PlayingTrackInfo = ({
     getTrack(state, { id: trackId })
   )
   const { doesUserHaveAccess } = usePremiumContentAccess(track)
+  const isPreviewing = useSelector(getPreviewing)
   const shouldShowPreviewLock =
     track?.premium_conditions &&
     'usdc_purchase' in track.premium_conditions &&
-    !doesUserHaveAccess
+    (!doesUserHaveAccess || isPreviewing)
 
   const [artistSpringProps, setArtistSpringProps] = useSpring(() => springProps)
   const [trackSpringProps, setTrackSpringProps] = useSpring(() => springProps)

--- a/packages/web/src/components/play-bar/mobile/PlayBar.tsx
+++ b/packages/web/src/components/play-bar/mobile/PlayBar.tsx
@@ -14,7 +14,7 @@ import {
 } from '@audius/common'
 import { IconLock } from '@audius/stems'
 import cn from 'classnames'
-import { connect } from 'react-redux'
+import { connect, useSelector } from 'react-redux'
 import { Dispatch } from 'redux'
 
 import { make, useRecord } from 'common/store/analytics/actions'
@@ -31,7 +31,7 @@ import { isDarkMode, isMatrix } from 'utils/theme/theme'
 
 import styles from './PlayBar.module.css'
 const { makeGetCurrent } = queueSelectors
-const { getBuffering, getCounter, getPlaying } = playerSelectors
+const { getPreviewing, getBuffering, getCounter, getPlaying } = playerSelectors
 const { recordListen, saveTrack, unsaveTrack } = tracksSocialActions
 const { pause, play } = queueActions
 
@@ -88,10 +88,11 @@ const PlayBar = ({
     collectible?.gifUrl
 
   const { doesUserHaveAccess } = usePremiumContentAccess(track)
+  const isPreviewing = useSelector(getPreviewing)
   const shouldShowPreviewLock =
     track?.premium_conditions &&
     'usdc_purchase' in track.premium_conditions &&
-    !doesUserHaveAccess
+    (!doesUserHaveAccess || isPreviewing)
 
   if (((!uid || !track) && !collectible) || !user) return null
 

--- a/packages/web/src/components/track/LockedStatusBadge.module.css
+++ b/packages/web/src/components/track/LockedStatusBadge.module.css
@@ -38,5 +38,6 @@
 }
 
 .text {
+  color: var(--static-white);
   text-decoration: none;
 }


### PR DESCRIPTION
### Description

Fix PAY-2051.

Also fix a bug where if you're on the track page on mobile, clicking the `Preview` button plays and pauses the non preview version.

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._

Local simulator + web, tested tracks, previews, your own tracks, and your own previews