### PR TITLE
Harmony Text Input tweaks (design requests)

### DIFF
--- a/packages/harmony/src/components/input/TextInput/TextInput.module.css
+++ b/packages/harmony/src/components/input/TextInput/TextInput.module.css
@@ -61,14 +61,6 @@
   border-color: var(--harmony-red);
 }
 
-/* disabled styles */
-.contentContainer.disabled {
-  cursor: not-allowed;
-  & * {
-    cursor: not-allowed;
-  }
-}
-
 /* Actual input element */
 .input {
   padding: 0;
@@ -99,12 +91,15 @@
   font-size: var(--harmony-font-l);
 }
 
-/* Placeholder and label text styles (they are the same for the most part) */
+/* Placeholder and label text styles (they are the same minus color) */
 .input::placeholder,
 .label {
   color: var(--harmony-text-default);
   font-weight: var(--harmony-font-medium);
   font-family: var(--harmony-font-family);
+}
+.input::placeholder {
+  color: var(--harmony-text-subdued);
 }
 
 /** Position the label in the center when unfocussed **/


### PR DESCRIPTION
### Description

- Make the TextInput cursor on disabled be default (no longer not-allowed)
- Placeholder text color changed to `subdued` per design feedback

### How Has This Been Tested?

Manual storybook
