### PR TITLE
[PAY-2052] Disabled TOS while purchase in progress

### DIFF
--- a/packages/mobile/src/components/premium-track-purchase-drawer/PremiumTrackPurchaseDrawer.tsx
+++ b/packages/mobile/src/components/premium-track-purchase-drawer/PremiumTrackPurchaseDrawer.tsx
@@ -262,7 +262,10 @@ const RenderForm = ({ track }: { track: PurchasableTrackMetadata }) => {
               </View>
               <Text style={styles.disclaimer}>
                 {messages.disclaimer(
-                  <Text colorValue={secondary} onPress={handleTermsPress}>
+                  <Text
+                    colorValue={secondary}
+                    onPress={isInProgress ? undefined : handleTermsPress}
+                  >
                     {messages.termsOfUse}
                   </Text>
                 )}

--- a/packages/web/src/components/premium-content-purchase-modal/components/PayToUnlockInfo.module.css
+++ b/packages/web/src/components/premium-content-purchase-modal/components/PayToUnlockInfo.module.css
@@ -8,3 +8,7 @@
   display: flex;
   justify-content: space-between;
 }
+
+.disabled {
+  pointer-events: none;
+}

--- a/packages/web/src/components/premium-content-purchase-modal/components/PayToUnlockInfo.tsx
+++ b/packages/web/src/components/premium-content-purchase-modal/components/PayToUnlockInfo.tsx
@@ -1,3 +1,4 @@
+import cn from 'classnames'
 import { Link } from 'react-router-dom'
 
 import { LockedStatusBadge } from 'components/track/LockedStatusBadge'
@@ -15,7 +16,7 @@ const messages = {
     '. Your purchase will be made in USDC via 3rd party payment provider. Additional payment provider fees may apply. Any remaining USDC balance in your Audius wallet will be applied to this transaction. Once your payment is confirmed, your premium content will be unlocked and available to stream.'
 }
 
-export const PayToUnlockInfo = () => {
+export const PayToUnlockInfo = ({ disabled }: { disabled: boolean }) => {
   return (
     <div className={styles.container}>
       <Text
@@ -30,7 +31,7 @@ export const PayToUnlockInfo = () => {
       <Text className={styles.copy}>
         <span>{messages.copyPart1}</span>
         <Link
-          className={typeStyles.link}
+          className={cn(typeStyles.link, { [styles.disabled]: disabled })}
           to={TERMS_OF_SERVICE}
           target='_blank'
           rel='noreferrer'

--- a/packages/web/src/components/premium-content-purchase-modal/components/PurchaseContentFormFields.tsx
+++ b/packages/web/src/components/premium-content-purchase-modal/components/PurchaseContentFormFields.tsx
@@ -61,7 +61,7 @@ export const PurchaseContentFormFields = ({
         {...purchaseSummaryValues}
         isPurchased={isPurchased}
       />
-      <PayToUnlockInfo />
+      <PayToUnlockInfo disabled={isInProgress} />
     </>
   )
 }


### PR DESCRIPTION
### Description
Make ToS unclickable while purchase is in progress. The UI won't look any different but won't be clickable.

### How Has This Been Tested?

Local web stage + ios stage