### PR TITLE
[PAY-2014] Add detailed purchase flow analytics

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -104659,6 +104659,7 @@
         "@reduxjs/toolkit": "1.6.1",
         "@solana/spl-token": "0.3.8",
         "@solana/web3.js": "1.78.4",
+        "@stripe/crypto": "0.0.4",
         "react": "^18.2.0",
         "redux-saga": "1.1.3"
       }

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -77,6 +77,7 @@
     "@solana/spl-token": "0.3.8",
     "@solana/web3.js": "1.78.4",
     "react": "^18.2.0",
-    "redux-saga": "1.1.3"
+    "redux-saga": "1.1.3",
+    "@stripe/crypto": "0.0.4"
   }
 }

--- a/packages/common/src/models/Analytics.ts
+++ b/packages/common/src/models/Analytics.ts
@@ -338,11 +338,12 @@ export enum Name {
   // Stripe Tracking
   STRIPE_SESSION_CREATION_ERROR = 'Stripe: Session Creation Error',
   STRIPE_SESSION_CREATED = 'Stripe Session: Created',
-  STRIPE_REQUIRES_PAYMENT = 'Stripe: Requires Payment',
-  STRIPE_FULLFILMENT_PROCESSING = 'Stripe: Fulfillment Processing',
-  STRIPE_FULLFILMENT_COMPLETE = 'Stripe: Fulfillment Complete',
-  STRIPE_ERROR = 'Stripe: Error',
-  STRIPE_REJECTED = 'Stripe: Rejected',
+  STRIPE_MODAL_INITIALIZED = 'Stripe Modal: Initialized',
+  STRIPE_REQUIRES_PAYMENT = 'Stripe Modal: Requires Payment',
+  STRIPE_FULLFILMENT_PROCESSING = 'Stripe Modal: Fulfillment Processing',
+  STRIPE_FULLFILMENT_COMPLETE = 'Stripe Modal: Fulfillment Complete',
+  STRIPE_ERROR = 'Stripe Modal: Error',
+  STRIPE_REJECTED = 'Stripe Modal: Rejected',
 
   // Purchase Content
   PURCHASE_CONTENT_STARTED = 'Purchase Content: Started',
@@ -1650,6 +1651,10 @@ type StripeSessionCreated = StripeEventFields & {
   eventName: Name.STRIPE_SESSION_CREATED
 }
 
+type StripeModalInitialized = StripeEventFields & {
+  eventName: Name.STRIPE_MODAL_INITIALIZED
+}
+
 type StripeRequiresPayment = StripeEventFields & {
   eventName: Name.STRIPE_REQUIRES_PAYMENT
 }
@@ -2035,6 +2040,7 @@ export type AllTrackingEvents =
   | BuyUSDCRecoveryFailure
   | StripeSessionCreationError
   | StripeSessionCreated
+  | StripeModalInitialized
   | StripeRequiresPayment
   | StripeFulfillmentProcessing
   | StripeFulfillmentComplete

--- a/packages/common/src/models/Analytics.ts
+++ b/packages/common/src/models/Analytics.ts
@@ -337,6 +337,12 @@ export enum Name {
 
   // Stripe Tracking
   STRIPE_SESSION_CREATION_ERROR = 'Stripe: Session Creation Error',
+  STRIPE_SESSION_CREATED = 'Stripe Session: Created',
+  STRIPE_REQUIRES_PAYMENT = 'Stripe: Requires Payment',
+  STRIPE_FULLFILMENT_PROCESSING = 'Stripe: Fulfillment Processing',
+  STRIPE_FULLFILMENT_COMPLETE = 'Stripe: Fulfillment Complete',
+  STRIPE_ERROR = 'Stripe: Error',
+  STRIPE_REJECTED = 'Stripe: Rejected',
 
   // Purchase Content
   PURCHASE_CONTENT_STARTED = 'Purchase Content: Started',
@@ -1628,13 +1634,40 @@ type BuyUSDCRecoveryFailure = {
 }
 
 // Stripe
-type StripeSessionCreationError = {
-  eventName: Name.STRIPE_SESSION_CREATION_ERROR
+export type StripeEventFields = {
   amount: string
   destinationCurrency: string
+}
+
+type StripeSessionCreationError = StripeEventFields & {
+  eventName: Name.STRIPE_SESSION_CREATION_ERROR
   code: string
   stripeErrorMessage: string
   type: string
+}
+
+type StripeSessionCreated = StripeEventFields & {
+  eventName: Name.STRIPE_SESSION_CREATED
+}
+
+type StripeRequiresPayment = StripeEventFields & {
+  eventName: Name.STRIPE_REQUIRES_PAYMENT
+}
+
+type StripeFulfillmentProcessing = StripeEventFields & {
+  eventName: Name.STRIPE_FULLFILMENT_PROCESSING
+}
+
+type StripeFulfillmentComplete = StripeEventFields & {
+  eventName: Name.STRIPE_FULLFILMENT_COMPLETE
+}
+
+type StripeError = StripeEventFields & {
+  eventName: Name.STRIPE_ERROR
+}
+
+type StripeRejected = StripeEventFields & {
+  eventName: Name.STRIPE_REJECTED
 }
 
 // Content Purchase
@@ -1646,6 +1679,7 @@ type ContentPurchaseMetadata = {
   contentType: string
   payExtraAmount: number
   payExtraPreset?: string
+  totalAmount: number
   artistHandle: string
   isVerifiedArtist: boolean
 }
@@ -2000,6 +2034,12 @@ export type AllTrackingEvents =
   | BuyUSDCRecoverySuccess
   | BuyUSDCRecoveryFailure
   | StripeSessionCreationError
+  | StripeSessionCreated
+  | StripeRequiresPayment
+  | StripeFulfillmentProcessing
+  | StripeFulfillmentComplete
+  | StripeError
+  | StripeRejected
   | PurchaseContentStarted
   | PurchaseContentSuccess
   | PurchaseContentFailure

--- a/packages/common/src/store/purchase-content/sagas.ts
+++ b/packages/common/src/store/purchase-content/sagas.ts
@@ -161,6 +161,7 @@ function* doStartPurchaseContentFlow({
     contentName: title,
     artistHandle: artistInfo.handle,
     isVerifiedArtist: artistInfo.is_verified,
+    totalAmount: (price + (extraAmount ?? 0)) / 100,
     payExtraAmount: extraAmount ? extraAmount / 100 : 0,
     payExtraPreset: extraAmountPreset
   }

--- a/packages/common/src/store/ui/stripe-modal/sagaHelpers.ts
+++ b/packages/common/src/store/ui/stripe-modal/sagaHelpers.ts
@@ -12,6 +12,10 @@ const cleanSession = (session: StripeSessionData) => {
   return cleaned
 }
 
+/** Extracts the required analytics fields from the session. Since a majority of
+ * the session is Nullable at any given time, it attempts to find preferred values
+ * from the quote and fixed_transaction objects, falling back to empty strings.
+ */
 const getStripeEventFields = (
   session: StripeSessionData
 ): StripeEventFields => ({

--- a/packages/common/src/store/ui/stripe-modal/sagaHelpers.ts
+++ b/packages/common/src/store/ui/stripe-modal/sagaHelpers.ts
@@ -1,0 +1,109 @@
+import { call } from 'typed-redux-saga'
+
+import { Name, StripeEventFields } from 'models/Analytics'
+import { ErrorLevel } from 'models/ErrorReporting'
+import { getContext } from 'store/effects'
+
+import { StripeSessionData } from './types'
+
+const EMPTY_SESSION: StripeSessionData = {
+  id: '',
+  quote: null,
+  status: 'initialized',
+  wallet_address: null
+}
+
+const cleanSession = (session: StripeSessionData) => {
+  const cleaned = { ...session }
+  delete cleaned.client_secret
+  return cleaned
+}
+
+const getStripeEventFields = (
+  session: StripeSessionData
+): StripeEventFields => ({
+  amount:
+    session.quote?.destination_amount ??
+    session.fixed_transaction_details?.destination_crypto_amount ??
+    '',
+  destinationCurrency:
+    session.fixed_transaction_details?.destination_currency ??
+    session.quote?.destination_currency.asset_code ??
+    ''
+})
+
+export function* reportStripeFlowAnalytics(
+  session: StripeSessionData,
+  previousSession: StripeSessionData = EMPTY_SESSION
+) {
+  const reportToSentry = yield* getContext('reportToSentry')
+  const { track, make } = yield* getContext('analytics')
+
+  if (session.status !== previousSession.status) {
+    const cleanedSession = cleanSession(session)
+    const eventFields = getStripeEventFields(session)
+    switch (session.status) {
+      case 'initialized':
+        break
+      case 'requires_payment':
+        yield* call(
+          track,
+          make({
+            eventName: Name.STRIPE_REQUIRES_PAYMENT,
+            ...eventFields
+          })
+        )
+        break
+      case 'rejected':
+        yield* call(reportToSentry, {
+          level: ErrorLevel.Error,
+          error: new Error('Stripe onramp session status: rejected'),
+          additionalInfo: {
+            session: cleanedSession
+          }
+        })
+        yield* call(
+          track,
+          make({
+            eventName: Name.STRIPE_REJECTED,
+            ...eventFields
+          })
+        )
+        break
+      case 'fulfillment_complete':
+        yield* call(
+          track,
+          make({
+            eventName: Name.STRIPE_FULLFILMENT_COMPLETE,
+            ...eventFields
+          })
+        )
+        break
+      case 'fulfillment_processing':
+        yield* call(
+          track,
+          make({
+            eventName: Name.STRIPE_FULLFILMENT_PROCESSING,
+            ...eventFields
+          })
+        )
+        break
+      case 'error':
+        yield* call(reportToSentry, {
+          level: ErrorLevel.Error,
+          error: new Error('Stripe onramp session status: error'),
+          additionalInfo: {
+            session: cleanedSession
+          }
+        })
+        yield* call(
+          track,
+          make({
+            eventName: Name.STRIPE_ERROR,
+            ...eventFields
+          })
+        )
+        break
+    }
+  }
+}

--- a/packages/common/src/store/ui/stripe-modal/slice.ts
+++ b/packages/common/src/store/ui/stripe-modal/slice.ts
@@ -1,9 +1,9 @@
 import { createSlice, PayloadAction } from '@reduxjs/toolkit'
 
 import {
-  StripeSessionStatus,
   StripeModalState,
-  StripeDestinationCurrencyType
+  StripeDestinationCurrencyType,
+  StripeSessionData
 } from './types'
 
 type InitializeStripeModalPayload = {
@@ -40,9 +40,11 @@ const slice = createSlice({
     cancelStripeOnramp: () => {},
     stripeSessionStatusChanged: (
       state,
-      action: PayloadAction<{ status: StripeSessionStatus }>
+      action: PayloadAction<{ session: StripeSessionData }>
     ) => {
-      state.stripeSessionStatus = action.payload.status
+      state.previousStripeSessionData = state.stripeSessionData
+      state.stripeSessionData = action.payload.session
+      state.stripeSessionStatus = action.payload.session.status
     }
   }
 })

--- a/packages/common/src/store/ui/stripe-modal/slice.ts
+++ b/packages/common/src/store/ui/stripe-modal/slice.ts
@@ -26,6 +26,8 @@ const slice = createSlice({
       action: PayloadAction<InitializeStripeModalPayload>
     ) => {
       state.stripeSessionStatus = 'initialized'
+      state.stripeSessionData = undefined
+      state.previousStripeSessionData = undefined
       state.onrampFailed = action.payload.onrampFailed
       state.onrampSucceeded = action.payload.onrampSucceeded
       state.onrampCanceled = action.payload.onrampCanceled

--- a/packages/common/src/store/ui/stripe-modal/types.ts
+++ b/packages/common/src/store/ui/stripe-modal/types.ts
@@ -1,11 +1,52 @@
 import { Action } from '@reduxjs/toolkit'
+import type {
+  SessionQuote as StripeSessionQuote,
+  Currency as StripeCurrency,
+  OnrampSessionStatus
+} from '@stripe/crypto'
 
-export type StripeSessionStatus =
-  | 'initialized'
-  | 'rejected'
-  | 'requires_payment'
-  | 'fulfillment_processing'
-  | 'fulfillment_complete'
+import { DeepNullable, Nullable } from 'utils/typeUtils'
+
+export type StripeSessionStatus = OnrampSessionStatus
+
+/** Represents properties of the transaction that were specified during
+ * session creation and are immutable. All values are optional
+ */
+export type StripeFixedTransactionDetails = DeepNullable<{
+  destination_amount: string
+  destination_crypto_amount: string
+  destination_currency: string
+  destination_network: string
+  lock_wallet_address: boolean
+  source_amount: string
+  source_currency: StripeCurrency
+  source_monetary_amount: string
+  supported_destination_currencies: string[]
+  supported_destination_networks: string[]
+  wallet_address: string
+  wallet_addresses: string[]
+}>
+
+export type StripeTransactionDetails = {
+  destination_amount: Nullable<string>
+  destination_crypto_amount: string
+  destination_network: string
+  destination_currency: string
+  wallet_address: string
+}
+
+export type StripeQuoteDetails = {
+  blockchain_tx_id: Nullable<string>
+}
+
+export type StripeSessionData = {
+  client_secret?: string
+  id: string
+  quote: Nullable<StripeSessionQuote>
+  fixed_transaction_details?: StripeFixedTransactionDetails
+  status: StripeSessionStatus
+  wallet_address: Nullable<string>
+}
 
 export type StripeDestinationCurrencyType = 'sol' | 'usdc'
 
@@ -13,6 +54,9 @@ export type StripeModalState = {
   onrampSucceeded?: Action
   onrampCanceled?: Action
   onrampFailed?: Action
+  /** Used as a comparison between updates to detect what changed */
+  previousStripeSessionData?: StripeSessionData
+  stripeSessionData?: StripeSessionData
   stripeSessionStatus?: StripeSessionStatus
   stripeClientSecret?: string
 }

--- a/packages/mobile/src/components/stripe-onramp-drawer/StripeOnrampEmbed.tsx
+++ b/packages/mobile/src/components/stripe-onramp-drawer/StripeOnrampEmbed.tsx
@@ -1,7 +1,7 @@
 import { useCallback } from 'react'
 
+import type { StripeSessionData } from '@audius/common'
 import { stripeModalUISelectors, stripeModalUIActions } from '@audius/common'
-import type { OnrampSessionResult } from '@stripe/crypto'
 import { View } from 'react-native'
 import { WebView } from 'react-native-webview'
 import { useDispatch, useSelector } from 'react-redux'
@@ -39,16 +39,11 @@ export const StripeOnrampEmbed = () => {
   const handleSessionUpdate = useCallback(
     (event) => {
       try {
-        const { status } = JSON.parse(
-          event.nativeEvent.data
-        ) as OnrampSessionResult
-
-        if (status) {
-          if (status === 'error') {
-            console.error('Received Stripe session error')
+        const session = JSON.parse(event.nativeEvent.data) as StripeSessionData
+        if (session) {
+          dispatch(stripeSessionStatusChanged({ session }))
+          if (session.status === 'error') {
             dispatch(cancelStripeOnramp())
-          } else {
-            dispatch(stripeSessionStatusChanged({ status }))
           }
         }
       } catch (e) {

--- a/packages/web/src/components/stripe-on-ramp-modal/StripeOnRampModal.tsx
+++ b/packages/web/src/components/stripe-on-ramp-modal/StripeOnRampModal.tsx
@@ -21,10 +21,9 @@ const MountStripeSession = ({ session }: { session: OnrampSession }) => {
 
   const handleSessionUpdate = useCallback(
     (e: any) => {
-      if (e?.payload?.session?.status) {
-        dispatch(
-          stripeSessionStatusChanged({ status: e.payload.session.status })
-        )
+      if (e?.payload?.session) {
+        console.debug('BZZT', e.payload.session)
+        dispatch(stripeSessionStatusChanged({ session: e.payload.session }))
       }
     },
     [dispatch]

--- a/packages/web/src/components/stripe-on-ramp-modal/StripeOnRampModal.tsx
+++ b/packages/web/src/components/stripe-on-ramp-modal/StripeOnRampModal.tsx
@@ -22,7 +22,6 @@ const MountStripeSession = ({ session }: { session: OnrampSession }) => {
   const handleSessionUpdate = useCallback(
     (e: any) => {
       if (e?.payload?.session) {
-        console.debug('BZZT', e.payload.session)
         dispatch(stripeSessionStatusChanged({ session: e.payload.session }))
       }
     },


### PR DESCRIPTION
### Description
* Rounded out the types for Stripe session info that we're receiving, mostly using the types from `@stripe/crypto` and modifying based on what I observed through logging the session objects.
* Pipe the whole session object to the slice, so we can use it for analytics
* Added saga helper to detect changes in state and pipe events as necessary
* Updated our purchase content events to include the total (price + pay extra) as an explicit field so we don't have to try and merge those values in reports
* Added sentry logging for rejection and error cases. 

Fixes PAY-2014

### How Has This Been Tested?
Tested locally in Chrome and Simulator against staging
Note: I can't finish the flow locally and will fully validate this on staging, but have confidence since we are only tracking a couple of fields and the status.