### PR TITLE
Hide ToS when purchase is in progress

### DIFF
--- a/packages/mobile/src/components/premium-track-purchase-drawer/PremiumTrackPurchaseDrawer.tsx
+++ b/packages/mobile/src/components/premium-track-purchase-drawer/PremiumTrackPurchaseDrawer.tsx
@@ -276,10 +276,7 @@ const RenderForm = ({ track }: { track: PurchasableTrackMetadata }) => {
               </View>
               <Text style={styles.disclaimer}>
                 {messages.disclaimer(
-                  <Text
-                    colorValue={secondary}
-                    onPress={isInProgress ? undefined : handleTermsPress}
-                  >
+                  <Text colorValue={secondary} onPress={handleTermsPress}>
                     {messages.termsOfUse}
                   </Text>
                 )}

--- a/packages/mobile/src/components/premium-track-purchase-drawer/PremiumTrackPurchaseDrawer.tsx
+++ b/packages/mobile/src/components/premium-track-purchase-drawer/PremiumTrackPurchaseDrawer.tsx
@@ -266,7 +266,7 @@ const RenderForm = ({ track }: { track: PurchasableTrackMetadata }) => {
             <PurchaseUnavailable />
           ) : isPurchaseSuccessful ? (
             <PurchaseSuccess track={track} />
-          ) : (
+          ) : isInProgress ? null : (
             <View>
               <View style={styles.payToUnlockTitleContainer}>
                 <Text weight='heavy' textTransform='uppercase' fontSize='small'>

--- a/packages/web/src/components/premium-content-purchase-modal/components/PayToUnlockInfo.module.css
+++ b/packages/web/src/components/premium-content-purchase-modal/components/PayToUnlockInfo.module.css
@@ -8,7 +8,3 @@
   display: flex;
   justify-content: space-between;
 }
-
-.disabled {
-  pointer-events: none;
-}

--- a/packages/web/src/components/premium-content-purchase-modal/components/PayToUnlockInfo.tsx
+++ b/packages/web/src/components/premium-content-purchase-modal/components/PayToUnlockInfo.tsx
@@ -1,4 +1,3 @@
-import cn from 'classnames'
 import { Link } from 'react-router-dom'
 
 import { LockedStatusBadge } from 'components/track/LockedStatusBadge'
@@ -16,7 +15,7 @@ const messages = {
     '. Your purchase will be made in USDC via 3rd party payment provider. Additional payment provider fees may apply. Any remaining USDC balance in your Audius wallet will be applied to this transaction. Once your payment is confirmed, your premium content will be unlocked and available to stream.'
 }
 
-export const PayToUnlockInfo = ({ disabled }: { disabled: boolean }) => {
+export const PayToUnlockInfo = () => {
   return (
     <div className={styles.container}>
       <Text
@@ -31,7 +30,7 @@ export const PayToUnlockInfo = ({ disabled }: { disabled: boolean }) => {
       <Text className={styles.copy}>
         <span>{messages.copyPart1}</span>
         <Link
-          className={cn(typeStyles.link, { [styles.disabled]: disabled })}
+          className={typeStyles.link}
           to={TERMS_OF_SERVICE}
           target='_blank'
           rel='noreferrer'

--- a/packages/web/src/components/premium-content-purchase-modal/components/PurchaseContentFormFields.tsx
+++ b/packages/web/src/components/premium-content-purchase-modal/components/PurchaseContentFormFields.tsx
@@ -61,7 +61,7 @@ export const PurchaseContentFormFields = ({
         {...purchaseSummaryValues}
         isPurchased={isPurchased}
       />
-      <PayToUnlockInfo />
+      {isInProgress ? null : <PayToUnlockInfo />}
     </>
   )
 }

--- a/packages/web/src/components/premium-content-purchase-modal/components/PurchaseContentFormFields.tsx
+++ b/packages/web/src/components/premium-content-purchase-modal/components/PurchaseContentFormFields.tsx
@@ -61,7 +61,7 @@ export const PurchaseContentFormFields = ({
         {...purchaseSummaryValues}
         isPurchased={isPurchased}
       />
-      <PayToUnlockInfo disabled={isInProgress} />
+      <PayToUnlockInfo />
     </>
   )
 }


### PR DESCRIPTION
### Description
Hide the ToS completely when the purchase is in progress (spoke with design offline).

### How Has This Been Tested?

Local web + ios stage

https://github.com/AudiusProject/audius-protocol/assets/3893871/84ef795f-4557-4633-a56f-7a70b9594655


https://github.com/AudiusProject/audius-protocol/assets/3893871/247e96a8-4580-4bb2-ab6f-0419930085e5

