### PR TITLE
Fix cooldown schedule

### DIFF
--- a/packages/common/src/hooks/purchaseContent/useChallengeCooldownSchedule.ts
+++ b/packages/common/src/hooks/purchaseContent/useChallengeCooldownSchedule.ts
@@ -44,9 +44,9 @@ export const useChallengeCooldownSchedule = (
 
 const getAudioMatchingCooldownLabel = (now: Dayjs, created_at: Dayjs) => {
   const diff = now.diff(created_at, 'day')
-  if (diff === COOLDOWN_DAYS - 1) {
+  if (diff === COOLDOWN_DAYS) {
     return messages.laterToday
-  } else if (diff === COOLDOWN_DAYS - 2) {
+  } else if (diff === COOLDOWN_DAYS - 1) {
     return messages.tomorrow
   }
   return created_at.local().add(COOLDOWN_DAYS, 'day').format('ddd (M/D)')
@@ -55,7 +55,7 @@ const getAudioMatchingCooldownLabel = (now: Dayjs, created_at: Dayjs) => {
 const formatAudioMatchingChallengeCooldownSchedule = (
   challenges: UndisbursedUserChallenge[]
 ) => {
-  const now = dayjs.utc().startOf('day')
+  const now = dayjs.utc().endOf('day')
   const cooldownChallenges = new Array(7)
   challenges.forEach((c) => {
     const createdAtUTC = dayjs.utc(c.created_at)


### PR DESCRIPTION
### Description
The previous implementation had a bug where it was grouping challenges completed _yesterday_ and _today_ together erroneously. This PR fixes the problem by clamping the date used to compare against the challenge completion date to the _end of_ the day.

### How Has This Been Tested?

Local web stage. Logged out completion dates of challenges and confirmed that the claimable dates are as expected.
after:
<img width="565" alt="Screenshot 2023-10-26 at 5 56 51 PM" src="https://github.com/AudiusProject/audius-protocol/assets/3893871/abfaecf2-be94-404a-ac95-be14e8a75f20">
before:
<img width="572" alt="Screenshot 2023-10-26 at 5 47 38 PM" src="https://github.com/AudiusProject/audius-protocol/assets/3893871/42fd7946-5df6-4143-afbf-889ea7c5c4c5">

