### PR TITLE
Add individual node (non-synchronized) route metrics back to DNs

### DIFF
--- a/packages/discovery-provider/integration_tests/queries/test_get_route_metrics.py
+++ b/packages/discovery-provider/integration_tests/queries/test_get_route_metrics.py
@@ -1,0 +1,258 @@
+from datetime import datetime, timedelta
+
+from src.models.metrics.route_metrics import RouteMetric
+from src.queries.get_route_metrics import _get_route_metrics
+from src.utils.db_session import get_db
+
+
+def populate_mock_db(db, date):
+    """Helper function to populate the mock DB with route metrics"""
+    mock_route_metrics = [
+        {
+            "version": "1",
+            "route_path": "tracks/some_hash",
+            "query_string": "",
+            "ip": "192.168.0.1",
+            "count": 3,
+            "timestamp": date,
+        },
+        {
+            "version": "1",
+            "route_path": "tracks/some_hash",
+            "query_string": "with_users=true",
+            "ip": "192.168.0.1",
+            "count": 2,
+            "timestamp": date,
+        },
+        {
+            "version": "1",
+            "route_path": "tracks/some_hash/stream",
+            "query_string": "",
+            "ip": "192.168.0.1",
+            "count": 4,
+            "timestamp": date,
+        },
+        {
+            "version": "1",
+            "route_path": "tracks/some_hash",
+            "query_string": "",
+            "ip": "192.168.0.2",
+            "count": 2,
+            "timestamp": date,
+        },
+    ]
+
+    with db.scoped_session() as session:
+        route_metric_obj = [
+            RouteMetric(
+                version=metric["version"],
+                route_path=metric["route_path"],
+                query_string=metric["query_string"],
+                ip=metric["ip"],
+                count=metric["count"],
+                timestamp=metric["timestamp"],
+            )
+            for metric in mock_route_metrics
+        ]
+
+        session.bulk_save_objects(route_metric_obj)
+
+
+def populate_mock_db_multiple_dates(db, date1, date2):
+    """Helper function to populate the mock DB with route metrics of multiple dates"""
+    mock_route_metrics = [
+        {
+            "version": "1",
+            "route_path": "tracks/some_hash",
+            "query_string": "",
+            "ip": "192.168.0.1",
+            "count": 3,
+            "timestamp": date1,
+        },
+        {
+            "version": "1",
+            "route_path": "tracks/some_hash",
+            "query_string": "",
+            "ip": "192.168.0.2",
+            "count": 2,
+            "timestamp": date2,
+        },
+    ]
+
+    with db.scoped_session() as session:
+        route_metric_obj = [
+            RouteMetric(
+                version=metric["version"],
+                route_path=metric["route_path"],
+                query_string=metric["query_string"],
+                ip=metric["ip"],
+                count=metric["count"],
+                timestamp=metric["timestamp"],
+            )
+            for metric in mock_route_metrics
+        ]
+
+        session.bulk_save_objects(route_metric_obj)
+
+
+def test_get_route_metrics_exact(app):
+    """Tests that the route metrics can queried by exact path match"""
+
+    date = datetime(2020, 10, 4).replace(minute=0, second=0, microsecond=0)
+    before_date = date + timedelta(hours=-1)
+
+    with app.app_context():
+        db = get_db()
+
+    populate_mock_db(db, date)
+
+    args = {
+        "limit": 10,
+        "start_time": before_date,
+        "path": "tracks/some_hash",
+        "exact": True,
+        "bucket_size": "hour",
+    }
+
+    with db.scoped_session() as session:
+        metrics = _get_route_metrics(session, args)
+
+    assert len(metrics) == 1
+    assert metrics[0]["count"] == 7
+    assert metrics[0]["unique_count"] == 2
+
+
+def test_get_route_metrics_non_exact(app):
+    """Tests that the route metrics can be queried by non-exact path match"""
+
+    date = datetime(2020, 10, 4).replace(minute=0, second=0, microsecond=0)
+    before_date = date + timedelta(hours=-1)
+
+    with app.app_context():
+        db = get_db()
+
+    populate_mock_db(db, date)
+
+    args = {
+        "limit": 10,
+        "start_time": before_date,
+        "path": "tracks/some_hash",
+        "exact": False,
+        "bucket_size": "hour",
+    }
+    with db.scoped_session() as session:
+        metrics = _get_route_metrics(session, args)
+
+    assert len(metrics) == 1
+    assert metrics[0]["count"] == 11
+    assert metrics[0]["unique_count"] == 2
+
+
+def test_get_route_metrics_query_string(app):
+    """Tests that the route metrics are queried with query_string parameter"""
+
+    date = datetime(2020, 10, 4).replace(minute=0, second=0, microsecond=0)
+    before_date = date + timedelta(hours=-1)
+
+    with app.app_context():
+        db = get_db()
+
+    populate_mock_db(db, date)
+
+    args = {
+        "limit": 10,
+        "start_time": before_date,
+        "path": "tracks/some_hash",
+        "query_string": "with_users=true",
+        "exact": False,
+        "bucket_size": "hour",
+    }
+    with db.scoped_session() as session:
+        metrics = _get_route_metrics(session, args)
+
+    assert len(metrics) == 1
+    assert metrics[0]["count"] == 2
+    assert metrics[0]["unique_count"] == 1
+
+
+def test_get_route_metrics_no_matches(app):
+    """Tests that route metrics returns nothing if no matching query_string"""
+
+    date = datetime(2020, 10, 4).replace(minute=0, second=0, microsecond=0)
+    before_date = date + timedelta(hours=-1)
+
+    with app.app_context():
+        db = get_db()
+
+    populate_mock_db(db, date)
+
+    args = {
+        "limit": 10,
+        "start_time": before_date,
+        "path": "tracks/some_hash",
+        "query_string": "with_users=WRONG",
+        "exact": False,
+        "bucket_size": "hour",
+    }
+    with db.scoped_session() as session:
+        metrics = _get_route_metrics(session, args)
+
+    assert not metrics
+
+
+def test_get_route_metrics_with_daily_buckets(app):
+    """Tests that the route metrics can be queried with daily buckets"""
+
+    date = datetime(2020, 10, 4).replace(minute=0, second=0, microsecond=0)
+    date1 = date + timedelta(hours=-1)
+    date2 = date + timedelta(days=-2)
+    before_date = date + timedelta(days=-3)
+
+    with app.app_context():
+        db = get_db()
+
+    populate_mock_db_multiple_dates(db, date1, date2)
+
+    args = {
+        "limit": 10,
+        "start_time": before_date,
+        "path": "tracks/some_hash",
+        "exact": False,
+        "bucket_size": "day",
+    }
+    with db.scoped_session() as session:
+        metrics = _get_route_metrics(session, args)
+
+    assert len(metrics) == 2
+    assert metrics[0]["count"] == 3
+    assert metrics[0]["unique_count"] == 1
+    assert metrics[1]["count"] == 2
+    assert metrics[1]["unique_count"] == 1
+
+
+def test_get_route_metrics_with_weekly_buckets(app):
+    """Tests that the route metrics can be queried with weekly buckets"""
+    # A Thursday
+    date = datetime(2020, 10, 1).replace(minute=0, second=0, microsecond=0)
+    date1 = date + timedelta(hours=-1)
+    date2 = date + timedelta(days=-2)
+    before_date = date + timedelta(days=-3)
+
+    with app.app_context():
+        db = get_db()
+
+    populate_mock_db_multiple_dates(db, date1, date2)
+
+    args = {
+        "limit": 10,
+        "start_time": before_date,
+        "path": "tracks/some_hash",
+        "exact": False,
+        "bucket_size": "week",
+    }
+    with db.scoped_session() as session:
+        metrics = _get_route_metrics(session, args)
+
+    assert len(metrics) == 1
+    assert metrics[0]["count"] == 5
+    assert metrics[0]["unique_count"] == 2

--- a/packages/discovery-provider/src/api/v1/models/metrics.py
+++ b/packages/discovery-provider/src/api/v1/models/metrics.py
@@ -11,3 +11,12 @@ plays_metric = ns.model(
 )
 
 genre_metric = ns.model("genre", {"name": fields.String, "count": fields.Integer})
+
+route_metric = ns.model(
+    "route_metric",
+    {
+        "timestamp": fields.String,
+        "count": fields.Integer,
+        "unique_count": fields.Integer,
+    },
+)

--- a/packages/discovery-provider/src/app.py
+++ b/packages/discovery-provider/src/app.py
@@ -329,6 +329,10 @@ def configure_celery(celery, test_config=None):
                 "task": "aggregate_metrics",
                 "schedule": timedelta(minutes=METRICS_INTERVAL),
             },
+            "update_metrics": {
+                "task": "update_metrics",
+                "schedule": timedelta(hours=1),
+            },
             "synchronize_metrics": {
                 "task": "synchronize_metrics",
                 "schedule": timedelta(minutes=SYNCHRONIZE_METRICS_INTERVAL),
@@ -472,6 +476,7 @@ def configure_celery(celery, test_config=None):
     redis_inst.delete("index_hourly_play_counts_lock")
     redis_inst.delete("update_discovery_lock")
     redis_inst.delete("aggregate_metrics_lock")
+    redis_inst.delete("update_metrics_lock")
     redis_inst.delete("synchronize_metrics_lock")
     redis_inst.delete("solana_plays_lock")
     redis_inst.delete("index_challenges_lock")

--- a/packages/discovery-provider/src/models/metrics/route_metrics.py
+++ b/packages/discovery-provider/src/models/metrics/route_metrics.py
@@ -1,0 +1,23 @@
+from sqlalchemy import Column, DateTime, Integer, String, text
+from src.models.base import Base
+from src.models.model_utils import RepresentableMixin
+
+
+class RouteMetric(Base, RepresentableMixin):
+    __tablename__ = "route_metrics"
+
+    route_path = Column(String, nullable=False)
+    version = Column(String, nullable=False)
+    query_string = Column(String, nullable=False, server_default="")
+    count = Column(Integer, nullable=False)
+    timestamp = Column(
+        DateTime, nullable=False, server_default=text("CURRENT_TIMESTAMP")
+    )
+    created_at = Column(
+        DateTime, nullable=False, server_default=text("CURRENT_TIMESTAMP")
+    )
+    updated_at = Column(
+        DateTime, nullable=False, server_default=text("CURRENT_TIMESTAMP")
+    )
+    id = Column(Integer, primary_key=True)
+    ip = Column(String)

--- a/packages/discovery-provider/src/models/metrics/route_metrics_day_matview.py
+++ b/packages/discovery-provider/src/models/metrics/route_metrics_day_matview.py
@@ -1,0 +1,11 @@
+from sqlalchemy import BigInteger, Column, DateTime, Table
+from src.models.base import Base
+
+# Materialized view
+t_route_metrics_day_bucket = Table(
+    "route_metrics_day_bucket",
+    Base.metadata,
+    Column("unique_count", BigInteger),
+    Column("count", BigInteger),
+    Column("time", DateTime),
+)

--- a/packages/discovery-provider/src/models/metrics/route_metrics_month_matview.py
+++ b/packages/discovery-provider/src/models/metrics/route_metrics_month_matview.py
@@ -1,0 +1,11 @@
+from sqlalchemy import BigInteger, Column, DateTime, Table
+from src.models.base import Base
+
+# Materialized view
+t_route_metrics_month_bucket = Table(
+    "route_metrics_month_bucket",
+    Base.metadata,
+    Column("unique_count", BigInteger),
+    Column("count", BigInteger),
+    Column("time", DateTime),
+)

--- a/packages/discovery-provider/src/queries/get_route_metrics.py
+++ b/packages/discovery-provider/src/queries/get_route_metrics.py
@@ -1,0 +1,108 @@
+import time
+from datetime import date, timedelta
+
+from sqlalchemy import desc, func, or_
+
+from src.models.metrics.route_metrics import RouteMetric
+from src.models.metrics.route_metrics_day_matview import t_route_metrics_day_bucket
+from src.models.metrics.route_metrics_month_matview import t_route_metrics_month_bucket
+from src.utils import db_session
+
+def get_route_metrics(args):
+    """
+    Returns the usage metrics for routes
+    Args:
+        args: dict The parsed args from the request
+        args.path: string The route path of the query
+        args.start_time: date The start of the query
+        args.query_string: optional string The query string to filter on
+        args.limit: number The max number of responses to return
+        args.bucket_size: string  date_trunc operation to aggregate timestamps by
+    Returns:
+        Array of dictionaries with the route, timestamp, count, and unique_count
+    """
+    db = db_session.get_db_read_replica()
+    with db.scoped_session() as session:
+        return _get_route_metrics(session, args)
+
+
+def _make_metrics_tuple(metric):
+    return {
+        "timestamp": int(time.mktime(metric.time.timetuple())),
+        "count": metric.count,
+        "unique_count": metric.unique_count,
+    }
+
+
+def _get_route_metrics(session, args):
+    # Protocol dashboard optimization:
+    # If we're in 'simple' mode (only asking for day/month bucket, no path or query string),
+    # query the corresponding matview instead of hitting the DB.
+    is_simple_args = (
+        args.get("path") == ""
+        and args.get("query_string") == None
+        and args.get("start_time")
+        and args.get("exact") == False
+        and args.get("version") == None
+    )
+    bucket_size = args.get("bucket_size")
+    if is_simple_args and bucket_size in ["day", "month"]:
+        query = None
+        if bucket_size == "day":
+            # subtract 1 day from the start_time so that the last day is fully complete
+            query = session.query(t_route_metrics_day_bucket).filter(
+                t_route_metrics_day_bucket.c.time
+                > (args.get("start_time") - timedelta(days=1))
+            )
+
+        else:
+            query = session.query(t_route_metrics_month_bucket).filter(
+                t_route_metrics_month_bucket.c.time > (args.get("start_time"))
+            )
+
+        query = query.order_by(desc("time")).limit(args.get("limit")).all()
+        metrics = list(map(_make_metrics_tuple, query))
+        return metrics
+
+    metrics_query = session.query(
+        func.date_trunc(args.get("bucket_size"), RouteMetric.timestamp).label(
+            "timestamp"
+        ),
+        func.sum(RouteMetric.count).label("count"),
+        func.count(RouteMetric.ip.distinct()).label("unique_count"),
+    ).filter(RouteMetric.timestamp > args.get("start_time"))
+    if args.get("exact") == True:
+        metrics_query = metrics_query.filter(RouteMetric.route_path == args.get("path"))
+    else:
+        metrics_query = metrics_query.filter(
+            RouteMetric.route_path.like(f"{args.get('path')}%")
+        )
+
+    if args.get("query_string", None) != None:
+        metrics_query = metrics_query.filter(
+            or_(
+                RouteMetric.query_string.like(f"%{args.get('query_string')}"),
+                RouteMetric.query_string.like(f"%{args.get('query_string')}&%"),
+            )
+        )
+
+    metrics_query = (
+        metrics_query.group_by(
+            func.date_trunc(args.get("bucket_size"), RouteMetric.timestamp)
+        )
+        .order_by(desc("timestamp"))
+        .limit(args.get("limit"))
+    )
+
+    metrics = metrics_query.all()
+
+    metrics = [
+        {
+            "timestamp": int(time.mktime(m[0].timetuple())),
+            "count": m[1],
+            "unique_count": m[2],
+        }
+        for m in metrics
+    ]
+
+    return metrics

--- a/packages/discovery-provider/src/tasks/index_metrics.py
+++ b/packages/discovery-provider/src/tasks/index_metrics.py
@@ -1,9 +1,11 @@
 import json
 import logging
+import time
 from datetime import datetime, timedelta
 
 import requests
 
+from src.models.metrics.route_metrics import RouteMetric
 from src.queries.update_historical_metrics import (
     update_historical_daily_app_metrics,
     update_historical_daily_route_metrics,
@@ -18,6 +20,10 @@ from src.utils.prometheus_metric import (
     save_duration_metric,
 )
 from src.utils.redis_metrics import (
+    metrics_prefix,
+    parse_metrics_key,
+    get_rounded_date_time,
+    metrics_routes,
     METRICS_INTERVAL,
     datetime_format_secondary,
     get_summed_unique_metrics,
@@ -32,6 +38,96 @@ from src.utils.redis_metrics import (
 logger = logging.getLogger(__name__)
 
 discovery_node_service_type = bytes("discovery-node", "utf-8")
+
+
+def process_route_keys(session, redis, key, ip, date):
+    """
+    For a redis hset storing a mapping of routes to the number of times they are hit,
+    parse each key out into the version, path, and query string.
+    Create a new entry in the DB for each route.
+    """
+    try:
+        route_metrics = []
+        routes = redis.hgetall(key)
+        for key_bstr in routes:
+            route = key_bstr.decode("utf-8").strip("/")
+            val = int(routes[key_bstr].decode("utf-8"))
+
+            version = "0"  # default value if version is not present
+            path = route
+            query_string = None
+
+            route_subpaths = route.split("/")
+
+            # Extract the version out of the path
+            if route_subpaths[0].startswith("v") and len(route_subpaths[0]) > 1:
+                version = route_subpaths[0][1:]
+                path = "/".join(route_subpaths[1:])
+
+            # Extract the query string out of the path
+            route_query = path.split("?")
+            if len(route_query) > 1:
+                path = route_query[0]
+                query_string = route_query[1]
+            route_metrics.append(
+                RouteMetric(
+                    version=version,
+                    route_path=path,
+                    query_string=query_string,
+                    count=val,
+                    ip=ip,
+                    timestamp=date,
+                )
+            )
+
+        if route_metrics:
+            session.bulk_save_objects(route_metrics)
+        redis.delete(key)
+    except Exception as e:
+        raise Exception(f"Error processing route key {key} with error {e}") from e
+
+
+def sweep_metrics(db, redis):
+    """
+    Move the metrics values from redis to the DB.
+    Get all the redis keys with the metrics prefix,
+    parse the key to get the timestamp in the key.
+    If it is before the current time, then process the redis hset.
+    """
+    with db.scoped_session() as session:
+        for key_byte in redis.scan_iter(f"{metrics_prefix}:*"):
+            key = key_byte.decode("utf-8")
+            try:
+                parsed_key = parse_metrics_key(key)
+
+                if parsed_key is None:
+                    raise KeyError(
+                        f"index_metrics.py | Unable to parse key {key} | Skipping process key"
+                    )
+                source, ip, key_date = parsed_key
+
+                current_date_time = get_rounded_date_time()
+
+                if key_date < current_date_time:
+                    if source == metrics_routes:
+                        process_route_keys(session, redis, key, ip, key_date)
+            except KeyError as e:
+                logger.warning(e)
+                redis.delete(key)
+            except Exception as e:
+                logger.error(e)
+                redis.delete(key)
+
+
+def refresh_metrics_matviews(db):
+    with db.scoped_session() as session:
+        start_time = time.time()
+        logger.info("index_metrics.py | refreshing metrics matviews")
+        session.execute("REFRESH MATERIALIZED VIEW route_metrics_day_bucket")
+        session.execute("REFRESH MATERIALIZED VIEW route_metrics_month_bucket")
+        logger.info(
+            f"index_metrics.py | refreshed metrics matviews in: {time.time()-start_time} sec"
+        )
 
 
 def get_metrics(endpoint, start_time):
@@ -263,6 +359,48 @@ def synchronize_all_node_metrics(self, db, redis):
 
 
 # ####### CELERY TASKS ####### #
+
+
+@celery.task(name="update_metrics", bind=True)
+@save_duration_metric(metric_group="celery_task")
+def update_metrics(self):
+    # Cache custom task class properties
+    # Details regarding custom task context can be found in wiki
+    # Custom Task definition can be found in src/app.py
+    db = update_metrics.db
+    redis = update_metrics.redis
+
+    # Define lock acquired boolean
+    have_lock = False
+
+    # Define redis lock object
+    update_lock = redis.lock("update_metrics_lock", blocking_timeout=25)
+    try:
+        # Attempt to acquire lock - do not block if unable to acquire
+        have_lock = update_lock.acquire(blocking=False)
+        if have_lock:
+            logger.info(
+                f"index_metrics.py | update_metrics | {self.request.id} | Acquired update_metrics_lock"
+            )
+            metric = PrometheusMetric(
+                PrometheusMetricNames.INDEX_METRICS_DURATION_SECONDS
+            )
+            sweep_metrics(db, redis)
+            refresh_metrics_matviews(db)
+            metric.save_time({"task_name": "update_metrics"})
+            logger.info(
+                f"index_metrics.py | update_metrics | {self.request.id} | Processing complete within session"
+            )
+        else:
+            logger.error(
+                f"index_metrics.py | update_metrics | {self.request.id} | Failed to acquire update_metrics_lock"
+            )
+    except Exception as e:
+        logger.error("Fatal error in main loop of update_metrics: %s", e, exc_info=True)
+        raise e
+    finally:
+        if have_lock:
+            update_lock.release()
 
 
 @celery.task(name="aggregate_metrics", bind=True)

--- a/packages/discovery-provider/src/tasks/index_metrics_unit_test.py
+++ b/packages/discovery-provider/src/tasks/index_metrics_unit_test.py
@@ -1,0 +1,92 @@
+from datetime import datetime, timedelta
+
+from src.models.metrics.route_metrics import RouteMetric
+from src.tasks.index_metrics import process_route_keys
+
+from src.utils.redis_metrics import datetime_format
+
+
+def test_process_route_keys(redis_mock, db_mock):
+    """Tests that a redis hash is parsed correctly to generate db rows and delete the redis key"""
+
+    routes = {
+        "/v1/users/search?query=ray": "3",
+        "/v1/tracks/trending?genre=rap&timeRange=week": "2",
+        "/v1/playlists/hash": "1",
+        "/tracks": "1",
+    }
+
+    key = "API_METRICS:routes:192.168.0.1:2020/08/06:19"
+
+    ip = "192.168.0.1"
+
+    redis_mock.hmset(key, routes)
+
+    date = datetime.utcnow()
+
+    with db_mock.scoped_session() as session:
+        RouteMetric.__table__.create(db_mock._engine)
+
+        process_route_keys(session, redis_mock, key, ip, date)
+
+        all_route_metrics = session.query(RouteMetric).all()
+        assert len(all_route_metrics) == 4
+
+        user_search = (
+            session.query(RouteMetric)
+            .filter(
+                RouteMetric.version == "1",
+                RouteMetric.route_path == "users/search",
+                RouteMetric.query_string == "query=ray",
+                RouteMetric.ip == "192.168.0.1",
+                RouteMetric.count == 3,
+                RouteMetric.timestamp == date,
+            )
+            .all()
+        )
+        assert len(user_search) == 1
+
+        trending_tracks = (
+            session.query(RouteMetric)
+            .filter(
+                RouteMetric.version == "1",
+                RouteMetric.route_path == "tracks/trending",
+                RouteMetric.query_string == "genre=rap&timeRange=week",
+                RouteMetric.ip == "192.168.0.1",
+                RouteMetric.count == 2,
+                RouteMetric.timestamp == date,
+            )
+            .all()
+        )
+        assert len(trending_tracks) == 1
+
+        playlist_route = (
+            session.query(RouteMetric)
+            .filter(
+                RouteMetric.version == "1",
+                RouteMetric.route_path == "playlists/hash",
+                RouteMetric.ip == "192.168.0.1",
+                RouteMetric.count == 1,
+                RouteMetric.timestamp == date,
+            )
+            .all()
+        )
+
+        assert len(playlist_route) == 1
+
+        no_version_tracks = (
+            session.query(RouteMetric)
+            .filter(
+                RouteMetric.version == "0",
+                RouteMetric.route_path == "tracks",
+                RouteMetric.ip == "192.168.0.1",
+                RouteMetric.count == 1,
+                RouteMetric.timestamp == date,
+            )
+            .all()
+        )
+
+        assert len(no_version_tracks) == 1
+
+    keys = redis_mock.keys(key)
+    assert not keys

--- a/packages/discovery-provider/src/utils/redis_metrics.py
+++ b/packages/discovery-provider/src/utils/redis_metrics.py
@@ -85,7 +85,7 @@ def get_request_ip(request_obj):
 def parse_metrics_key(key):
     """
     Validates that a key is correctly formatted and returns
-    the source: (routes|applications), ip address, and date of key
+    the source: (routes), ip address, and date of key
     """
     if not key.startswith(metrics_prefix):
         logger.warning(f"Bad redis key inserted w/out metrics prefix {key}")
@@ -99,8 +99,8 @@ def parse_metrics_key(key):
     _, source, ip, date, time = fragments
     # Replace the ipv6 _ delimiter back to :
     ip = ip.replace("_", ":")
-    if source not in (metrics_routes, metrics_applications):
-        logger.warning(f"Bad redis key inserted: must be routes or application {key}")
+    if source != metrics_routes:
+        logger.warning(f"Bad redis key inserted: must be routes {key}")
         return None
     date_time = datetime.strptime(f"{date}:{time}", datetime_format)
 


### PR DESCRIPTION
### Description
Persist number of unique visitors (ip addresses) + number of API calls to any route on a node. This was removed in https://github.com/AudiusProject/audius-protocol/pull/4482 along with some other metrics but we are interested in displaying this data in the protocol dashboard now. 

#### Schema:
The `route_metrics` table persists counts per route. Maintain `route_metrics_day_bucket` and `route_metrics_month_bucket` materialized views to quickly query unique visitor count and total count by day or month granularity. This schema was never dropped, just truncated, so these (empty) tables and matviews still exist on each node. 

It made more sense to me to use the old schema with materialized views to aggregate information rather than adding columns to the existing aggregate metrics tables, which only contain post-processed counts that are synchronized with the other nodes. This way we actually persist info on individual routes and ip addrs.

#### Recording when a route is hit:
Add to the existing `@record_metrics` decorator that records each time a route is hit to redis. Before the changes in this PR, `@record_metrics` only recorded info that we use for aggregate metrics, which doesn't include information about each route, just ip addresses and counts. Assuming we might be interested in recording data about each route, I added a new key/value format to write to redis to use specifically for these new individual node route metrics, rather than using the existing redis entries. The flip side is this approach takes up more space in redis.

An `update_metrics` celery task runs every hour. It flushes data from redis to the db and refreshes the materialized views.

#### Querying unique users and count of api calls on a node: 
Query these metrics via this endpoint: `/metrics/routes`.

### How Has This Been Tested?
Change celery task to flush redis to the db every 5 mins for testing. Soak on a stage DN. Query redis and db to make sure counts of visitors to each route are being persisted.
Make sure endpoint is working as expected.