### PR TITLE
[PAY-2013] Send event when purchase TOS clicked

### DIFF
--- a/packages/common/src/models/Analytics.ts
+++ b/packages/common/src/models/Analytics.ts
@@ -350,6 +350,7 @@ export enum Name {
   PURCHASE_CONTENT_SUCCESS = 'Purchase Content: Success',
   PURCHASE_CONTENT_FAILURE = 'Purchase Content: Failure',
   PURCHASE_CONTENT_TWITTER_SHARE = 'Purchase Content: Twitter Share',
+  PURCHASE_CONTENT_TOS_CLICKED = 'Purchase Content: Terms of Service Link Clicked',
 
   // Rate & Review CTA
   RATE_CTA_DISPLAYED = 'Rate CTA: Displayed',
@@ -1706,6 +1707,10 @@ type PurchaseContentTwitterShare = {
   text: string
 }
 
+type PurchaseContentTOSClicked = {
+  eventName: Name.PURCHASE_CONTENT_TOS_CLICKED
+}
+
 type RateCtaDisplayed = {
   eventName: Name.RATE_CTA_DISPLAYED
 }
@@ -2050,6 +2055,7 @@ export type AllTrackingEvents =
   | PurchaseContentSuccess
   | PurchaseContentFailure
   | PurchaseContentTwitterShare
+  | PurchaseContentTOSClicked
   | RateCtaDisplayed
   | RateCtaResponseNo
   | RateCtaResponseYes

--- a/packages/mobile/src/components/premium-track-purchase-drawer/PremiumTrackPurchaseDrawer.tsx
+++ b/packages/mobile/src/components/premium-track-purchase-drawer/PremiumTrackPurchaseDrawer.tsx
@@ -241,8 +241,8 @@ const RenderForm = ({ track }: { track: PurchasableTrackMetadata }) => {
   }, [isPurchaseSuccessful, navigation, track.track_id])
 
   const handleTermsPress = useCallback(() => {
-    trackEvent(make({ eventName: Name.PURCHASE_CONTENT_TOS_CLICKED }))
     Linking.openURL('https://audius.co/legal/terms-of-use')
+    trackEvent(make({ eventName: Name.PURCHASE_CONTENT_TOS_CLICKED }))
   }, [])
 
   return (

--- a/packages/mobile/src/components/premium-track-purchase-drawer/PremiumTrackPurchaseDrawer.tsx
+++ b/packages/mobile/src/components/premium-track-purchase-drawer/PremiumTrackPurchaseDrawer.tsx
@@ -6,6 +6,7 @@ import type {
 } from '@audius/common'
 import {
   FeatureFlags,
+  Name,
   PurchaseContentStage,
   formatPrice,
   isContentPurchaseInProgress,
@@ -38,6 +39,7 @@ import { useDrawer } from 'app/hooks/useDrawer'
 import { useIsUSDCEnabled } from 'app/hooks/useIsUSDCEnabled'
 import { useNavigation } from 'app/hooks/useNavigation'
 import { useFeatureFlag, useRemoteVar } from 'app/hooks/useRemoteConfig'
+import { make, track as trackEvent } from 'app/services/analytics'
 import { flexRowCentered, makeStyles } from 'app/styles'
 import { spacing } from 'app/styles/spacing'
 import { useThemeColors } from 'app/utils/theme'
@@ -239,6 +241,7 @@ const RenderForm = ({ track }: { track: PurchasableTrackMetadata }) => {
   }, [isPurchaseSuccessful, navigation, track.track_id])
 
   const handleTermsPress = useCallback(() => {
+    trackEvent(make({ eventName: Name.PURCHASE_CONTENT_TOS_CLICKED }))
     Linking.openURL('https://audius.co/legal/terms-of-use')
   }, [])
 

--- a/packages/web/src/components/premium-content-purchase-modal/components/PayToUnlockInfo.tsx
+++ b/packages/web/src/components/premium-content-purchase-modal/components/PayToUnlockInfo.tsx
@@ -1,8 +1,12 @@
+import { useCallback } from 'react'
+
+import { Name } from '@audius/common'
 import { Link } from 'react-router-dom'
 
 import { LockedStatusBadge } from 'components/track/LockedStatusBadge'
 import { Text } from 'components/typography'
 import typeStyles from 'components/typography/typography.module.css'
+import { make, track } from 'services/analytics'
 import { TERMS_OF_SERVICE } from 'utils/route'
 
 import styles from './PayToUnlockInfo.module.css'
@@ -16,6 +20,9 @@ const messages = {
 }
 
 export const PayToUnlockInfo = () => {
+  const handleClickTOSLink = useCallback(() => {
+    track(make({ eventName: Name.PURCHASE_CONTENT_TOS_CLICKED }))
+  }, [])
   return (
     <div className={styles.container}>
       <Text
@@ -30,6 +37,7 @@ export const PayToUnlockInfo = () => {
       <Text className={styles.copy}>
         <span>{messages.copyPart1}</span>
         <Link
+          onClick={handleClickTOSLink}
           className={typeStyles.link}
           to={TERMS_OF_SERVICE}
           target='_blank'


### PR DESCRIPTION
### Description
Adds an event for when the user clicks/presses the TOS link in the purchase flow.

fixes PAY-2013
### How Has This Been Tested?
Tested locally in Chrome and simulator against staging
