### PR TITLE
[PAY-2089] Add analytics events for users opening rewards claim modal

### DIFF
--- a/packages/common/src/models/Analytics.ts
+++ b/packages/common/src/models/Analytics.ts
@@ -299,6 +299,7 @@ export enum Name {
   REWARDS_CLAIM_HCAPTCHA = 'Rewards Claim: Hcaptcha',
   REWARDS_CLAIM_REJECTION = 'Rewards Claim: Rejection',
   REWARDS_CLAIM_UNKNOWN = 'Rewards Claim: Unknown',
+  REWARDS_CLAIM_DETAILS_OPENED = 'Rewards Claim: Details Opened',
 
   // Tipping
   TIP_AUDIO_REQUEST = 'Tip Audio: Request',
@@ -1391,6 +1392,11 @@ type RewardsClaimUnknown = {
   error: string
 }
 
+type RewardsClaimDetailsOpened = {
+  eventName: Name.REWARDS_CLAIM_DETAILS_OPENED
+  challengeId: string
+}
+
 export type TipSource =
   | 'profile'
   | 'feed'
@@ -2007,6 +2013,7 @@ export type AllTrackingEvents =
   | RewardsClaimFailure
   | RewardsClaimRejection
   | RewardsClaimUnknown
+  | RewardsClaimDetailsOpened
   | TipAudioRequest
   | TipAudioSuccess
   | TipAudioFailure

--- a/packages/mobile/src/screens/audio-screen/ChallengeRewards.tsx
+++ b/packages/mobile/src/screens/audio-screen/ChallengeRewards.tsx
@@ -14,7 +14,8 @@ import {
   modalsActions,
   makeOptimisticChallengeSortComparator,
   FeatureFlags,
-  ChallengeName
+  ChallengeName,
+  Name
 } from '@audius/common'
 import { useFocusEffect } from '@react-navigation/native'
 import { View } from 'react-native'
@@ -22,6 +23,7 @@ import { useDispatch, useSelector } from 'react-redux'
 
 import LoadingSpinner from 'app/components/loading-spinner'
 import { useFeatureFlag, useRemoteVar } from 'app/hooks/useRemoteConfig'
+import { make, track } from 'app/services/analytics'
 import { makeStyles } from 'app/styles'
 import { getChallengeConfig } from 'app/utils/challenges'
 
@@ -119,11 +121,20 @@ export const ChallengeRewards = () => {
     .sort(makeOptimisticChallengeSortComparator(optimisticUserChallenges))
     .map((id) => {
       const props = getChallengeConfig(id)
+      const onPress = () => {
+        openModal(id)
+        track(
+          make({
+            eventName: Name.REWARDS_CLAIM_DETAILS_OPENED,
+            challengeId: id
+          })
+        )
+      }
       return (
         <Panel
           {...props}
           challenge={optimisticUserChallenges[id]}
-          onPress={() => openModal(id)}
+          onPress={onPress}
           key={props.title}
         />
       )

--- a/packages/web/src/pages/audio-rewards-page/ChallengeRewardsTile.tsx
+++ b/packages/web/src/pages/audio-rewards-page/ChallengeRewardsTile.tsx
@@ -13,7 +13,8 @@ import {
   ChallengeName,
   audioRewardsPageSelectors,
   isAudioMatchingChallenge,
-  makeOptimisticChallengeSortComparator
+  makeOptimisticChallengeSortComparator,
+  Name
 } from '@audius/common'
 import {
   ProgressBar,
@@ -31,6 +32,7 @@ import { Text } from 'components/typography'
 import { useIsAudioMatchingChallengesEnabled } from 'hooks/useIsAudioMatchingChallengesEnabled'
 import { useRemoteVar } from 'hooks/useRemoteConfig'
 import { useWithMobileStyle } from 'hooks/useWithMobileStyle'
+import { make, track } from 'services/analytics'
 
 import styles from './RewardsTile.module.css'
 import { Tile } from './components/ExplainerTile'
@@ -75,7 +77,12 @@ const RewardPanel = ({
   const wm = useWithMobileStyle(styles.mobile)
   const userChallenges = useSelector(getOptimisticUserChallenges)
 
-  const openRewardModal = () => openModal(id)
+  const openRewardModal = () => {
+    openModal(id)
+    track(
+      make({ eventName: Name.REWARDS_CLAIM_DETAILS_OPENED, challengeId: id })
+    )
+  }
 
   const challenge = userChallenges[id]
   const shouldShowCompleted =


### PR DESCRIPTION
### Description
We already have a lot of eventing around rewards. This adds one more for the opening of the modal.

Fixes PAY-2089

### How Has This Been Tested?
Tested locally in Chrome/simulator against staging
