### PR TITLE
Filter out 0-amount challenges

### DIFF
--- a/packages/web/src/common/store/pages/audio-rewards/sagas.ts
+++ b/packages/web/src/common/store/pages/audio-rewards/sagas.ts
@@ -256,11 +256,13 @@ function* claimChallengeRewardAsync(
   }
   let aaoErrorCode
   try {
-    const challenges = specifiers.map(({ specifier, amount }) => ({
-      challenge_id: challengeId,
-      specifier,
-      amount
-    }))
+    const challenges = specifiers
+      .map(({ specifier, amount }) => ({
+        challenge_id: challengeId,
+        specifier,
+        amount
+      }))
+      .filter(({ amount }) => amount > 0) // We shouldn't have any 0 amount challenges, but just in case.
 
     const response: { error?: string; aaoErrorCode?: number } = yield* call(
       audiusBackendInstance.submitAndEvaluateAttestations,


### PR DESCRIPTION
### Description
Attempting to claim a challenge with amount 0 will result in an error (invalid amount) - filter out these challenges on client side so we never claim them. Theoretically we should never have 0-amount challenges at all but this is a safeguard.

### How Has This Been Tested?

Local web stage

https://github.com/AudiusProject/audius-protocol/assets/3893871/1ede64ee-6671-4d34-bff9-eb031807b2fa

Logging the 0-amount challenges:
<img width="618" alt="Screenshot 2023-10-27 at 12 58 43 PM" src="https://github.com/AudiusProject/audius-protocol/assets/3893871/ea909007-1e23-4250-b3cd-53f9b4c1bf43">
