### PR TITLE
[C-3261] Add mobile web signin UI

### DIFF
--- a/packages/harmony/src/assets/styles/border-radius.css
+++ b/packages/harmony/src/assets/styles/border-radius.css
@@ -8,5 +8,5 @@ root {
   --harmony-border-radius-m: 8px;
   --harmony-border-radius-l: 12px;
   --harmony-border-radius-xl: 16px;
-  --harmony-border-radius-2xl: 320px;
+  --harmony-border-radius-2xl: 32px;
 }

--- a/packages/web/src/pages/sign-in-page/SignInPage.tsx
+++ b/packages/web/src/pages/sign-in-page/SignInPage.tsx
@@ -1,35 +1,13 @@
 import { useCallback } from 'react'
 
-import {
-  Box,
-  Button,
-  Flex,
-  IconArrowRight,
-  IconVisibilityHidden,
-  Text
-} from '@audius/harmony'
-import { Button as ButtonTmp } from '@audius/stems'
-import { Form, Formik } from 'formik'
+import { Formik } from 'formik'
 import { useDispatch } from 'react-redux'
-import { Link } from 'react-router-dom'
 
-import audiusLogoColored from 'assets/img/audiusLogoColored.png'
 import { signIn } from 'common/store/pages/signon/actions'
-import { HarmonyTextField } from 'components/form-fields/HarmonyTextField'
-import PreloadImage from 'components/preload-image/PreloadImage'
-import { PageWithAudiusValues } from 'pages/sign-on/components/desktop/PageWithAudiusValues'
-import { SIGN_UP_PAGE } from 'utils/route'
+import { useMedia } from 'hooks/useMedia'
 
-import styles from './SignInPage.module.css'
-
-const messages = {
-  title: 'Sign Into Audius',
-  emailLabel: 'Email',
-  passwordLabel: 'Password',
-  signIn: 'Sign In',
-  createAccount: 'Create An Account',
-  forgotPassword: 'Forgot password?'
-}
+import { SignInPageDesktop } from './SignInPageDesktop'
+import { SignInPageMobile } from './SignInPageMobile'
 
 type SignInValues = {
   email: string
@@ -51,75 +29,12 @@ export const SignInPage = () => {
     [dispatch]
   )
 
+  const { isMobile } = useMedia()
+  const SignInPageComponent = isMobile ? SignInPageMobile : SignInPageDesktop
+
   return (
-    <Flex h='100%' alignItems='center' justifyContent='center'>
-      <PageWithAudiusValues>
-        <Flex
-          className={styles.root}
-          h='100%'
-          w={480}
-          // want 80px but don't have var for it
-          pv='4xl'
-          ph='2xl'
-          direction='column'
-          gap='2xl'
-          justifyContent='space-between'
-        >
-          {/* TODO: confirm 40px spacing value */}
-          <Flex direction='column' gap='2xl' alignItems='center'>
-            <PreloadImage
-              src={audiusLogoColored}
-              className={styles.logo}
-              alt='Audius Colored Logo'
-            />
-            <Flex w='100%' direction='row' justifyContent='flex-start'>
-              <Text variant='heading' size='l' tag='h1' color='heading'>
-                {messages.title}
-              </Text>
-            </Flex>
-            <Formik initialValues={initialValues} onSubmit={handleSubmit}>
-              <Box w='100%'>
-                <Form>
-                  <Flex direction='column' gap='2xl' w='100%'>
-                    <Flex direction='column' gap='l'>
-                      {/* TODO: replace old TextField */}
-                      <HarmonyTextField
-                        name='email'
-                        label={messages.emailLabel}
-                      />
-                      {/* TODO: password visibility icon and toggle */}
-                      <HarmonyTextField
-                        name='password'
-                        label={messages.passwordLabel}
-                        endIcon={IconVisibilityHidden}
-                        type='password'
-                      />
-                    </Flex>
-                    <Flex direction='column' gap='l'>
-                      <Button iconRight={IconArrowRight} type='submit'>
-                        {messages.signIn}
-                      </Button>
-                      <Flex direction='row' alignItems='flexStart'>
-                        <Text color='heading'>
-                          {/* TODO: link destination */}
-                          <Link to={''}>{messages.forgotPassword}</Link>
-                        </Text>
-                      </Flex>
-                    </Flex>
-                  </Flex>
-                </Form>
-              </Box>
-            </Formik>
-          </Flex>
-          {/* TODO: switch to stems button when we have asChild support */}
-          <ButtonTmp
-            // @ts-ignore
-            as={Link}
-            to={SIGN_UP_PAGE}
-            text={messages.createAccount}
-          />{' '}
-        </Flex>
-      </PageWithAudiusValues>
-    </Flex>
+    <Formik initialValues={initialValues} onSubmit={handleSubmit}>
+      <SignInPageComponent />
+    </Formik>
   )
 }

--- a/packages/web/src/pages/sign-in-page/SignInPageDesktop.tsx
+++ b/packages/web/src/pages/sign-in-page/SignInPageDesktop.tsx
@@ -1,0 +1,100 @@
+import {
+  Box,
+  Button,
+  Flex,
+  IconArrowRight,
+  IconVisibilityHidden,
+  Text
+} from '@audius/harmony'
+import { Button as ButtonTmp } from '@audius/stems'
+import { Form } from 'formik'
+import { Link } from 'react-router-dom'
+
+import audiusLogoColored from 'assets/img/audiusLogoColored.png'
+import { HarmonyTextField } from 'components/form-fields/HarmonyTextField'
+import PreloadImage from 'components/preload-image/PreloadImage'
+import { PageWithAudiusValues } from 'pages/sign-on/components/desktop/PageWithAudiusValues'
+import { SIGN_UP_PAGE } from 'utils/route'
+
+import styles from './SignInPage.module.css'
+
+const messages = {
+  title: 'Sign Into Audius',
+  emailLabel: 'Email',
+  passwordLabel: 'Password',
+  signIn: 'Sign In',
+  createAccount: 'Create An Account',
+  forgotPassword: 'Forgot password?'
+}
+
+export const SignInPageDesktop = () => {
+  return (
+    <Flex h='100%' alignItems='center' justifyContent='center'>
+      <PageWithAudiusValues>
+        <Flex
+          className={styles.root}
+          h='100%'
+          w={480}
+          // want 80px but don't have var for it
+          pv='4xl'
+          ph='2xl'
+          direction='column'
+          gap='2xl'
+          justifyContent='space-between'
+        >
+          {/* TODO: confirm 40px spacing value */}
+          <Flex direction='column' gap='2xl' alignItems='center'>
+            <PreloadImage
+              src={audiusLogoColored}
+              className={styles.logo}
+              alt='Audius Colored Logo'
+            />
+            <Flex w='100%' direction='row' justifyContent='flex-start'>
+              <Text variant='heading' size='l' tag='h1' color='heading'>
+                {messages.title}
+              </Text>
+            </Flex>
+            <Box w='100%'>
+              <Form>
+                <Flex direction='column' gap='2xl' w='100%'>
+                  <Flex direction='column' gap='l'>
+                    {/* TODO: replace old TextField */}
+                    <HarmonyTextField
+                      name='email'
+                      label={messages.emailLabel}
+                    />
+                    {/* TODO: password visibility icon and toggle */}
+                    <HarmonyTextField
+                      name='password'
+                      label={messages.passwordLabel}
+                      endIcon={IconVisibilityHidden}
+                      type='password'
+                    />
+                  </Flex>
+                  <Flex direction='column' gap='l'>
+                    <Button iconRight={IconArrowRight} type='submit'>
+                      {messages.signIn}
+                    </Button>
+                    <Flex direction='row' alignItems='flexStart'>
+                      <Text color='heading'>
+                        {/* TODO: link destination */}
+                        <Link to={''}>{messages.forgotPassword}</Link>
+                      </Text>
+                    </Flex>
+                  </Flex>
+                </Flex>
+              </Form>
+            </Box>
+          </Flex>
+          {/* TODO: switch to stems button when we have asChild support */}
+          <ButtonTmp
+            // @ts-ignore
+            as={Link}
+            to={SIGN_UP_PAGE}
+            text={messages.createAccount}
+          />{' '}
+        </Flex>
+      </PageWithAudiusValues>
+    </Flex>
+  )
+}

--- a/packages/web/src/pages/sign-in-page/SignInPageMobile.module.css
+++ b/packages/web/src/pages/sign-in-page/SignInPageMobile.module.css
@@ -1,0 +1,22 @@
+.root {
+  background: radial-gradient(
+      77.16% 77.16% at 50% 51.81%,
+      rgba(91, 35, 225, 0.8) 0%,
+      rgba(113, 41, 230, 0.64) 67.96%,
+      rgba(162, 47, 235, 0.5) 100%
+    ),
+    url('../../assets/img/2-DJ-4-3.jpg'), lightgray 50% / cover no-repeat;
+  background-position-y: bottom;
+  background-position-x: -110px;
+  background-size: 150%;
+}
+
+.content {
+  background-color: var(--harmony-bg-white);
+  border-bottom-left-radius: var(--harmony-border-radius-2xl);
+  border-bottom-right-radius: var(--harmony-border-radius-2xl);
+}
+
+.createAccountRow {
+  color: var(--harmony-white);
+}

--- a/packages/web/src/pages/sign-in-page/SignInPageMobile.tsx
+++ b/packages/web/src/pages/sign-in-page/SignInPageMobile.tsx
@@ -1,0 +1,93 @@
+import {
+  Box,
+  Button,
+  Flex,
+  IconArrowRight,
+  IconAudiusLogoHorizontalColor,
+  IconVisibilityHidden,
+  Text
+} from '@audius/harmony'
+import { Form } from 'formik'
+import { Link } from 'react-router-dom'
+
+import { HarmonyTextField } from 'components/form-fields/HarmonyTextField'
+
+import styles from './SignInPageMobile.module.css'
+
+const messages = {
+  title: 'Sign Into Audius',
+  emailLabel: 'Email',
+  passwordLabel: 'Password',
+  signIn: 'Sign In',
+  newToAudius: 'New to Audius?',
+  createAccount: 'Create an Account',
+  forgotPassword: 'Forgot password?'
+}
+
+export const SignInPageMobile = () => {
+  return (
+    <Flex
+      className={styles.root}
+      direction='column'
+      w='100%'
+      h='100%'
+      justifyContent='space-between'
+      pb='4xl'
+    >
+      <Flex
+        className={styles.content}
+        w='100%'
+        pv='2xl'
+        ph='l'
+        direction='column'
+        gap='2xl'
+        justifyContent='space-between'
+      >
+        <Flex direction='column' gap='2xl' alignItems='center'>
+          <IconAudiusLogoHorizontalColor />
+          <Text variant='heading' size='l' tag='h1' color='heading'>
+            {messages.title}
+          </Text>
+          <Box w='100%'>
+            <Form>
+              <Flex direction='column' gap='2xl' w='100%'>
+                <Flex direction='column' gap='l'>
+                  {/* TODO: replace old TextField */}
+                  <HarmonyTextField name='email' label={messages.emailLabel} />
+                  {/* TODO: password visibility icon and toggle */}
+                  <HarmonyTextField
+                    name='password'
+                    label={messages.passwordLabel}
+                    endIcon={IconVisibilityHidden}
+                    type='password'
+                  />
+                </Flex>
+                <Flex direction='column' gap='l'>
+                  <Button iconRight={IconArrowRight} type='submit'>
+                    {messages.signIn}
+                  </Button>
+                  <Text color='heading' variant='body'>
+                    {/* TODO: link destination */}
+                    {messages.forgotPassword}
+                  </Text>
+                </Flex>
+              </Flex>
+            </Form>
+          </Box>
+        </Flex>
+      </Flex>
+      <Flex
+        className={styles.createAccountRow}
+        direction='row'
+        w='100%'
+        justifyContent='center'
+        gap='xs'
+        mb='4xl'
+      >
+        {/* TODO: args look good but style doesn't match design */}
+        <Text variant='title'>{messages.newToAudius}</Text>
+        <Link to={''}>{messages.createAccount}</Link>
+      </Flex>
+    </Flex>
+  )
+}


### PR DESCRIPTION
### Description

#### Includes
- Adds UI for mobile web sign in page
- Uses `useMedia` hook to switch between the two depending on screen size

![image](https://github.com/AudiusProject/audius-protocol/assets/2358254/74e72c9f-728a-423f-809d-77ddcb8fc88a)

#### Out of Scope
- The navbar does not currently switch out depending on screen size, so we'll get the mobile UI in web nav
- Link styling and functionality (Awaiting harmony Link component)
- Putting the mobile UI in an overlay drawer
- Spacing hacked for visibility above mobile navbar, but this will change when the whole thing is an overlay


![image](https://github.com/AudiusProject/audius-protocol/assets/2358254/72a15317-84ed-4453-b85a-b4f631c31a97)

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._
