### PR TITLE
Redirect root with hash routing

### DIFF
--- a/mediorum/server/server.go
+++ b/mediorum/server/server.go
@@ -271,16 +271,10 @@ func New(config MediorumConfig) (*MediorumServer, error) {
 	routes := echoServer.Group(apiBasePath)
 
 	routes.GET("", func(c echo.Context) error {
-		if config.Env == "prod" {
-			return c.Redirect(http.StatusMovedPermanently, "/health_check")
-		}
-		return c.Redirect(http.StatusMovedPermanently, "/dashboard/services/content-node?endpoint="+config.Self.Host)
+		return c.Redirect(http.StatusFound, "/dashboard/#/services/content-node?endpoint="+config.Self.Host)
 	})
 	routes.GET("/", func(c echo.Context) error {
-		if config.Env == "prod" {
-			return c.Redirect(http.StatusMovedPermanently, "/health_check")
-		}
-		return c.Redirect(http.StatusMovedPermanently, "/dashboard/services/content-node?endpoint="+config.Self.Host)
+		return c.Redirect(http.StatusFound, "/dashboard/#/services/content-node?endpoint="+config.Self.Host)
 	})
 
 	// public: uploads

--- a/packages/discovery-provider/src/api/v1/root_path.py
+++ b/packages/discovery-provider/src/api/v1/root_path.py
@@ -22,5 +22,5 @@ def redirect_protocol_dashboard():
     base_url = request.base_url
     if base_url.endswith('/'):
         base_url = base_url[:-1]
-    proto_dash = f"/dashboard/services/discovery-node?endpoint={base_url}"
-    return redirect(proto_dash, code=301)
+    proto_dash = f"/dashboard/#/services/discovery-node?endpoint={base_url}"
+    return redirect(proto_dash, code=302)


### PR DESCRIPTION
- Adds missing `#` to protocol dashboard url
- Uses temporary redirect (mediorum already used permanent in the past for /health_check, so it's too late for browsers that already have that cached)
- Other environment issues aren't working on stage even though they work locally. Those will be fixed separately
