### PR TITLE
[PAY-2088] Hide play counts on premium on mobile

### DIFF
--- a/packages/mobile/src/screens/track-screen/TrackScreenDetailsTile.tsx
+++ b/packages/mobile/src/screens/track-screen/TrackScreenDetailsTile.tsx
@@ -581,7 +581,9 @@ export const TrackScreenDetailsTile = ({
       hideShare={(is_unlisted && !isOwner) || !field_visibility?.share}
       hideOverflow={!isReachable}
       hideFavoriteCount={is_unlisted}
-      hideListenCount={!isOwner && is_unlisted && !field_visibility?.play_count}
+      hideListenCount={
+        (!isOwner && is_unlisted && !field_visibility?.play_count) || isPremium
+      }
       hideRepostCount={is_unlisted}
       isPlaying={isPlaying && isPlayingId}
       isPreviewing={isPreviewing}


### PR DESCRIPTION
### Description

No longer showing for premium
<img src="https://github.com/AudiusProject/audius-protocol/assets/2731362/63bf6ec8-c31c-4293-9081-7dddf6218f03" width="200" />

Makes logic consistent with https://github.com/AudiusProject/audius-protocol/blob/3acd0665a7fa4d7a621863ee1cf0dbd601f3646c/packages/web/src/pages/track-page/components/mobile/TrackHeader.tsx#L191


### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._
