### PR TITLE
[PAY-2100] Hide manual transfer UI while purchase in progress

### DIFF
--- a/packages/mobile/src/components/premium-track-purchase-drawer/PremiumTrackPurchaseDrawer.tsx
+++ b/packages/mobile/src/components/premium-track-purchase-drawer/PremiumTrackPurchaseDrawer.tsx
@@ -279,7 +279,7 @@ const RenderForm = ({ track }: { track: PurchasableTrackMetadata }) => {
               {...purchaseSummaryValues}
               isPurchaseSuccessful={isPurchaseSuccessful}
             />
-            {isIOSDisabled ? null : (
+            {isIOSDisabled || isInProgress || isPurchaseSuccessful ? null : (
               <Text
                 color='primary'
                 fontSize='small'

--- a/packages/web/src/components/premium-content-purchase-modal/components/PurchaseContentFormFields.tsx
+++ b/packages/web/src/components/premium-content-purchase-modal/components/PurchaseContentFormFields.tsx
@@ -67,14 +67,16 @@ export const PurchaseContentFormFields = ({
           {...purchaseSummaryValues}
           isPurchased={isPurchased}
         />
-        <Text
-          as={PlainButton}
-          disabled={isInProgress}
-          onClick={() => openUsdcManualTransferModal()}
-          color='primary'
-        >
-          {messages.manualTransfer}
-        </Text>
+        {isInProgress || isPurchased ? null : (
+          <Text
+            as={PlainButton}
+            disabled={isInProgress}
+            onClick={() => openUsdcManualTransferModal()}
+            color='primary'
+          >
+            {messages.manualTransfer}
+          </Text>
+        )}
       </div>
       {isInProgress ? null : <PayToUnlockInfo />}
     </>


### PR DESCRIPTION
### Description
Hide the advanced manual transfer UI when the purchase is in progress or complete.

### How Has This Been Tested?

Local web stage + ios stage