### PR TITLE
[PAY-2102] Fix locked content modal not opening regression bug

### DIFF
--- a/packages/mobile/src/components/lineup-tile/LineupTileAccessStatus.tsx
+++ b/packages/mobile/src/components/lineup-tile/LineupTileAccessStatus.tsx
@@ -4,6 +4,7 @@ import type { ID, PremiumConditions } from '@audius/common'
 import {
   formatPrice,
   isPremiumContentUSDCPurchaseGated,
+  premiumContentActions,
   premiumContentSelectors
 } from '@audius/common'
 import { TouchableOpacity, View } from 'react-native'
@@ -19,6 +20,7 @@ import { spacing } from 'app/styles/spacing'
 import { useColor } from 'app/utils/theme'
 
 const { getPremiumTrackStatusMap } = premiumContentSelectors
+const { setLockedContentId } = premiumContentActions
 
 const messages = {
   unlocking: 'Unlocking',
@@ -65,20 +67,23 @@ export const LineupTileAccessStatus = ({
   const isUSDCPurchase =
     isUSDCEnabled && isPremiumContentUSDCPurchaseGated(premiumConditions)
 
-  const handlePurchasePress = useCallback(() => {
-    dispatch(
-      setVisibility({
-        drawer: 'PremiumTrackPurchase',
-        visible: true,
-        data: { trackId }
-      })
-    )
-  }, [dispatch, trackId])
+  const handlePress = useCallback(() => {
+    if (isUSDCPurchase) {
+      dispatch(
+        setVisibility({
+          drawer: 'PremiumTrackPurchase',
+          visible: true,
+          data: { trackId }
+        })
+      )
+    } else if (trackId) {
+      dispatch(setLockedContentId({ id: trackId }))
+      dispatch(setVisibility({ drawer: 'LockedContent', visible: true }))
+    }
+  }, [isUSDCPurchase, dispatch, trackId])
 
   return (
-    <TouchableOpacity
-      onPress={isUSDCPurchase ? handlePurchasePress : undefined}
-    >
+    <TouchableOpacity onPress={handlePress}>
       <View style={[styles.root, isUSDCPurchase ? styles.usdcPurchase : null]}>
         {premiumTrackStatus === 'UNLOCKING' ? (
           <LoadingSpinner style={styles.loadingSpinner} fill={staticWhite} />

--- a/packages/web/src/components/track/desktop/BottomRow.tsx
+++ b/packages/web/src/components/track/desktop/BottomRow.tsx
@@ -24,9 +24,7 @@ const { getPremiumTrackStatusMap } = premiumContentSelectors
 
 const messages = {
   repostLabel: 'Repost',
-  unrepostLabel: 'Unrepost',
-  unlocking: 'Unlocking',
-  locked: 'Locked'
+  unrepostLabel: 'Unrepost'
 }
 
 type BottomRowProps = {

--- a/packages/web/src/components/track/desktop/ConnectedTrackTile.tsx
+++ b/packages/web/src/components/track/desktop/ConnectedTrackTile.tsx
@@ -302,6 +302,11 @@ const ConnectedTrackTile = ({
     shareTrack(trackId)
   }, [shareTrack, trackId])
 
+  const openLockedContentModal = useCallback(() => {
+    dispatch(setLockedContentId({ id: trackId }))
+    setLockedContentVisibility(true)
+  }, [dispatch, trackId, setLockedContentVisibility])
+
   const onTogglePlay = useCallback(
     (e?: MouseEvent /* click event within TrackTile */) => {
       // Skip toggle play if click event happened within track menu container
@@ -319,8 +324,7 @@ const ConnectedTrackTile = ({
       // Show the locked content modal if gated track and user does not have access.
       // Also skip toggle play in this case.
       if (trackId && !doesUserHaveAccess && !hasPreview) {
-        dispatch(setLockedContentId({ id: trackId }))
-        setLockedContentVisibility(true)
+        openLockedContentModal()
         return
       }
 
@@ -332,8 +336,7 @@ const ConnectedTrackTile = ({
       uid,
       trackId,
       doesUserHaveAccess,
-      dispatch,
-      setLockedContentVisibility
+      openLockedContentModal
     ]
   )
 
@@ -383,6 +386,7 @@ const ConnectedTrackTile = ({
       onClickRepost={onClickRepost}
       onClickFavorite={onClickFavorite}
       onClickShare={onClickShare}
+      onClickLocked={openLockedContentModal}
       onTogglePlay={onTogglePlay}
       isTrending={isTrending}
       showRankIcon={showRankIcon}

--- a/packages/web/src/components/track/desktop/TrackTile.tsx
+++ b/packages/web/src/components/track/desktop/TrackTile.tsx
@@ -140,6 +140,7 @@ const TrackTile = ({
   onClickRepost,
   onClickFavorite,
   onClickShare,
+  onClickLocked,
   onTogglePlay,
   showRankIcon,
   permalink,
@@ -162,11 +163,20 @@ const TrackTile = ({
   const { onOpen: openPremiumContentPurchaseModal } =
     usePremiumContentPurchaseModal()
   const isPurchase = isPremiumContentUSDCPurchaseGated(premiumConditions)
+
   const onClickPremiumPill = useAuthenticatedClickCallback(() => {
     if (isPurchase && trackId) {
       openPremiumContentPurchaseModal({ contentId: trackId })
+    } else if (trackId && !doesUserHaveAccess && onClickLocked) {
+      onClickLocked()
     }
-  }, [isPurchase, trackId, openPremiumContentPurchaseModal])
+  }, [
+    isPurchase,
+    trackId,
+    openPremiumContentPurchaseModal,
+    doesUserHaveAccess,
+    onClickLocked
+  ])
 
   const getDurationText = () => {
     if (duration === null || duration === undefined) {

--- a/packages/web/src/components/track/mobile/TrackTile.tsx
+++ b/packages/web/src/components/track/mobile/TrackTile.tsx
@@ -217,11 +217,26 @@ const TrackTile = (props: CombinedProps) => {
     [onClickOverflow, id]
   )
 
+  const openLockedContentModal = useCallback(() => {
+    if (trackId) {
+      dispatch(setLockedContentId({ id: trackId }))
+      setModalVisibility(true)
+    }
+  }, [trackId, dispatch, setModalVisibility])
+
   const onClickPremiumPill = useAuthenticatedClickCallback(() => {
     if (isPurchase && trackId) {
       openPremiumContentPurchaseModal({ contentId: trackId })
+    } else if (trackId && !doesUserHaveAccess) {
+      openLockedContentModal()
     }
-  }, [isPurchase, trackId, openPremiumContentPurchaseModal])
+  }, [
+    isPurchase,
+    trackId,
+    openPremiumContentPurchaseModal,
+    doesUserHaveAccess,
+    openLockedContentModal
+  ])
 
   const [artworkLoaded, setArtworkLoaded] = useState(false)
   useEffect(() => {
@@ -239,8 +254,7 @@ const TrackTile = (props: CombinedProps) => {
     if (showSkeleton) return
 
     if (trackId && !doesUserHaveAccess && !hasPreview) {
-      dispatch(setLockedContentId({ id: trackId }))
-      setModalVisibility(true)
+      openLockedContentModal()
       return
     }
 
@@ -253,8 +267,7 @@ const TrackTile = (props: CombinedProps) => {
     trackId,
     doesUserHaveAccess,
     hasPreview,
-    dispatch,
-    setModalVisibility
+    openLockedContentModal
   ])
 
   const isReadonly = variant === 'readonly'

--- a/packages/web/src/components/track/types.ts
+++ b/packages/web/src/components/track/types.ts
@@ -215,6 +215,9 @@ export type DesktopTrackTileProps = {
   /** on click share icon */
   onClickShare: (e?: MouseEvent) => void
 
+  /** When the user clicks on the locked pill */
+  onClickLocked?: () => void
+
   /** On click track tile that's does not trigger another action (ie. button or text) */
   onTogglePlay: (e?: MouseEvent) => void
 


### PR DESCRIPTION
### Description

Open (non-premium/usdc) locked content modal on track tile locked pill click across web, native mobiel, mobile web.

### How Has This Been Tested?

local web, mobile web, and native mobile dapps vs stage

https://github.com/AudiusProject/audius-protocol/assets/9600175/8581ca06-a064-4205-b1ae-3318e41d2013

https://github.com/AudiusProject/audius-protocol/assets/9600175/219ba0ec-3a3c-48f9-9d13-1da930ec910a

https://github.com/AudiusProject/audius-protocol/assets/9600175/809ad334-c512-459b-a202-343dd6b4ab37


