### PR TITLE
Hotfix Content Node view width and lint for CI

### DIFF
--- a/protocol-dashboard/src/components/NodeOverview/NodeOverview.tsx
+++ b/protocol-dashboard/src/components/NodeOverview/NodeOverview.tsx
@@ -269,7 +269,9 @@ const NodeOverview = ({
             )}
             {!isDeregistered && (
               <div className={styles.version}>
-                {`${messages.version} ${health?.version || version || 'unknown'}`}
+                {`${messages.version} ${health?.version ||
+                  version ||
+                  'unknown'}`}
               </div>
             )}
             {!isDeregistered && isUnregistered && (

--- a/protocol-dashboard/src/containers/Node/Node.tsx
+++ b/protocol-dashboard/src/containers/Node/Node.tsx
@@ -38,17 +38,19 @@ const ContentNode: React.FC<ContentNodeProps> = ({
   const isOwner = accountWallet === contentNode?.owner ?? false
 
   return (
-    <NodeOverview
-      spID={spID}
-      serviceType={ServiceType.ContentNode}
-      version={contentNode?.version}
-      endpoint={contentNode?.endpoint}
-      operatorWallet={contentNode?.owner}
-      delegateOwnerWallet={contentNode?.delegateOwnerWallet}
-      isOwner={isOwner}
-      isDeregistered={contentNode?.isDeregistered}
-      isLoading={status === Status.Loading}
-    />
+    <div className={styles.section}>
+      <NodeOverview
+        spID={spID}
+        serviceType={ServiceType.ContentNode}
+        version={contentNode?.version}
+        endpoint={contentNode?.endpoint}
+        operatorWallet={contentNode?.owner}
+        delegateOwnerWallet={contentNode?.delegateOwnerWallet}
+        isOwner={isOwner}
+        isDeregistered={contentNode?.isDeregistered}
+        isLoading={status === Status.Loading}
+      />
+    </div>
   )
 }
 


### PR DESCRIPTION
### Description
Fixes Content Node style in protocol dashboard services view not showing full width when it doesn't have charts. Also lints to unblock the failing CI init step, which is a prerequisite to deploying.