### PR TITLE
Fix manual transfer on android

### DIFF
--- a/packages/mobile/src/components/core/AddressTile.tsx
+++ b/packages/mobile/src/components/core/AddressTile.tsx
@@ -1,8 +1,9 @@
 import { useCallback, type ReactNode } from 'react'
+import { make, track as trackEvent } from 'app/services/analytics'
 
 import Clipboard from '@react-native-clipboard/clipboard'
 import { View } from 'react-native'
-import { TouchableOpacity } from 'react-native-gesture-handler'
+import { TouchableOpacity } from 'react-native'
 
 import IconCopy2 from 'app/assets/images/iconCopy2.svg'
 import { Text } from 'app/components/core'
@@ -10,6 +11,7 @@ import { useToast } from 'app/hooks/useToast'
 import { flexRowCentered, makeStyles } from 'app/styles'
 import { spacing } from 'app/styles/spacing'
 import { useColor } from 'app/utils/theme'
+import { AllEvents } from 'app/types/analytics'
 
 const messages = {
   copied: 'Copied to Clipboard!'
@@ -33,7 +35,8 @@ const useStyles = makeStyles(({ spacing, palette, typography }) => ({
     borderLeftWidth: 1,
     borderRightWidth: 1,
     borderColor: palette.borderDefault,
-    flexShrink: 1
+    flexShrink: 1,
+    alignItems: 'center'
   },
   leftContainer: {
     paddingVertical: spacing(4),
@@ -45,9 +48,15 @@ type AddressTileProps = {
   address: string
   left?: ReactNode
   right?: ReactNode
+  analytics?: AllEvents
 }
 
-export const AddressTile = ({ address, left, right }: AddressTileProps) => {
+export const AddressTile = ({
+  address,
+  left,
+  right,
+  analytics
+}: AddressTileProps) => {
   const styles = useStyles()
   const { toast } = useToast()
   const textSubdued = useColor('textIconSubdued')
@@ -55,6 +64,7 @@ export const AddressTile = ({ address, left, right }: AddressTileProps) => {
   const handleCopyPress = useCallback(() => {
     Clipboard.setString(address)
     toast({ content: messages.copied, type: 'info' })
+    if (analytics) trackEvent(make(analytics))
   }, [address, toast])
 
   return (
@@ -67,7 +77,7 @@ export const AddressTile = ({ address, left, right }: AddressTileProps) => {
       </View>
       <View style={styles.rightContainer}>
         {right ?? (
-          <TouchableOpacity onPress={handleCopyPress}>
+          <TouchableOpacity onPress={handleCopyPress} hitSlop={spacing(6)}>
             <IconCopy2
               fill={textSubdued}
               width={spacing(4)}

--- a/packages/mobile/src/components/usdc-manual-transfer-drawer/USDCManualTransferDrawer.tsx
+++ b/packages/mobile/src/components/usdc-manual-transfer-drawer/USDCManualTransferDrawer.tsx
@@ -19,6 +19,7 @@ import { spacing } from 'app/styles/spacing'
 
 import { AddressTile } from '../core/AddressTile'
 import { useColor } from 'app/utils/theme'
+import { AllEvents } from 'app/types/analytics'
 
 const USDCLearnMore =
   'https://support.audius.co/help/Understanding-USDC-on-Audius'
@@ -97,15 +98,15 @@ export const USDCManualTransferDrawer = () => {
     return USDCUserBankPubKey?.toString() ?? ''
   })
 
+  const analytics: AllEvents = {
+    eventName: Name.PURCHASE_CONTENT_USDC_USER_BANK_COPIED,
+    address: USDCUserBank ?? ''
+  }
+
   const handleConfirmPress = useCallback(() => {
     Clipboard.setString(USDCUserBank ?? '')
     toast({ content: messages.copied, type: 'info' })
-    trackEvent(
-      make({
-        eventName: Name.PURCHASE_CONTENT_USDC_USER_BANK_COPIED,
-        address: USDCUserBank ?? ''
-      })
-    )
+    trackEvent(make(analytics))
   }, [USDCUserBank, toast])
 
   const handleCancelPress = useCallback(() => {
@@ -139,6 +140,7 @@ export const USDCManualTransferDrawer = () => {
         <AddressTile
           address={USDCUserBank ?? ''}
           left={<LogoUSDC height={spacing(6)} />}
+          analytics={analytics}
         />
         <View style={styles.disclaimerContainer}>
           <IconError


### PR DESCRIPTION
### Description
`TouchableOpacity` from RNGH doesn't work on android, need to use the react-native one instead.

Also:
- increased hitslop
- fixed alignment of address text on android
- Added tracking when copy button is pressed

### How Has This Been Tested?

https://github.com/AudiusProject/audius-protocol/assets/3893871/97f2be15-6900-4716-86ab-52e589289604

