### PR TITLE
Add end-of-lineup notice to premium tracks lineup

### DIFF
--- a/packages/mobile/src/components/core/AddressTile.tsx
+++ b/packages/mobile/src/components/core/AddressTile.tsx
@@ -1,17 +1,16 @@
 import { useCallback, type ReactNode } from 'react'
-import { make, track as trackEvent } from 'app/services/analytics'
 
 import Clipboard from '@react-native-clipboard/clipboard'
-import { View } from 'react-native'
-import { TouchableOpacity } from 'react-native'
+import { View, TouchableOpacity } from 'react-native'
 
 import IconCopy2 from 'app/assets/images/iconCopy2.svg'
 import { Text } from 'app/components/core'
 import { useToast } from 'app/hooks/useToast'
+import { make, track as trackEvent } from 'app/services/analytics'
 import { flexRowCentered, makeStyles } from 'app/styles'
 import { spacing } from 'app/styles/spacing'
+import type { AllEvents } from 'app/types/analytics'
 import { useColor } from 'app/utils/theme'
-import { AllEvents } from 'app/types/analytics'
 
 const messages = {
   copied: 'Copied to Clipboard!'

--- a/packages/mobile/src/components/lineup/EndOfLineupNotice.tsx
+++ b/packages/mobile/src/components/lineup/EndOfLineupNotice.tsx
@@ -7,23 +7,33 @@ import { useThemeColors } from 'app/utils/theme'
 
 const messages = {
   title: 'End of the line',
-  description: "Looks like you've reached the end of your feed..."
+  description: "Looks like you've reached the end of this list..."
 }
 
 const useStyles = makeStyles(({ spacing }) => ({
   root: {
     alignItems: 'center',
-    marginVertical: spacing(6)
+    marginVertical: spacing(6),
+    marginHorizontal: spacing(6)
   },
   icon: {
     marginBottom: spacing(2)
   },
   title: {
     letterSpacing: 2
+  },
+  description: {
+    textAlign: 'center'
   }
 }))
 
-export const EndOfFeedNotice = () => {
+type EndOfLineupNoticeProps = {
+  title?: string
+  description?: string
+}
+
+export const EndOfLineupNotice = (props: EndOfLineupNoticeProps) => {
+  const { title = messages.title, description = messages.description } = props
   const styles = useStyles()
   const { neutralLight4 } = useThemeColors()
   return (
@@ -40,10 +50,10 @@ export const EndOfFeedNotice = () => {
         color='neutralLight4'
         style={styles.title}
       >
-        {messages.title}
+        {title}
       </Text>
-      <Text fontSize='small' color='neutralLight4'>
-        {messages.description}
+      <Text fontSize='small' color='neutralLight4' style={styles.description}>
+        {description}
       </Text>
     </View>
   )

--- a/packages/mobile/src/components/lineup/Lineup.tsx
+++ b/packages/mobile/src/components/lineup/Lineup.tsx
@@ -226,6 +226,7 @@ export const Lineup = ({
   limit = Infinity,
   extraFetchOptions,
   ListFooterComponent,
+  EndOfLineupComponent,
   ...listProps
 }: LineupProps) => {
   const dispatch = useDispatch()
@@ -526,7 +527,11 @@ export const Lineup = ({
           hideHeaderOnEmpty && areSectionsEmpty ? undefined : header
         }
         ListFooterComponent={
-          lineup.hasMore ? <View style={{ height: 16 }} /> : ListFooterComponent
+          lineup.hasMore ? (
+            <View style={{ height: 16 }} />
+          ) : (
+            EndOfLineupComponent ?? ListFooterComponent
+          )
         }
         ListEmptyComponent={LineupEmptyComponent}
         onEndReached={handleEndReached}

--- a/packages/mobile/src/components/lineup/types.ts
+++ b/packages/mobile/src/components/lineup/types.ts
@@ -1,4 +1,4 @@
-import type { ReactElement } from 'react'
+import type { ReactComponent, ReactElement } from 'react'
 
 import type {
   ID,
@@ -167,6 +167,7 @@ export type LineupProps = {
    * When `true`, add pull-to-refresh capability
    */
   pullToRefresh?: boolean
+  EndOfLineupComponent?: ReactComponent<any> | ReactElement
 } & Pick<
   SectionListProps<unknown>,
   'showsVerticalScrollIndicator' | 'ListEmptyComponent' | 'ListFooterComponent'

--- a/packages/mobile/src/components/usdc-manual-transfer-drawer/USDCManualTransferDrawer.tsx
+++ b/packages/mobile/src/components/usdc-manual-transfer-drawer/USDCManualTransferDrawer.tsx
@@ -16,10 +16,10 @@ import { getUSDCUserBank } from 'app/services/buyCrypto'
 import { setVisibility } from 'app/store/drawers/slice'
 import { flexRowCentered, makeStyles } from 'app/styles'
 import { spacing } from 'app/styles/spacing'
+import type { AllEvents } from 'app/types/analytics'
+import { useColor } from 'app/utils/theme'
 
 import { AddressTile } from '../core/AddressTile'
-import { useColor } from 'app/utils/theme'
-import { AllEvents } from 'app/types/analytics'
 
 const USDCLearnMore =
   'https://support.audius.co/help/Understanding-USDC-on-Audius'

--- a/packages/mobile/src/screens/explore-screen/tabs/ForYouTab/PremiumTracksScreen.tsx
+++ b/packages/mobile/src/screens/explore-screen/tabs/ForYouTab/PremiumTracksScreen.tsx
@@ -9,13 +9,16 @@ import { useDispatch } from 'react-redux'
 
 import { Screen, ScreenContent, ScreenHeader } from 'app/components/core'
 import { Lineup } from 'app/components/lineup'
+import { EndOfLineupNotice } from 'app/components/lineup/EndOfLineupNotice'
 const { makeGetLineupMetadatas } = lineupSelectors
 const { getLineup } = premiumTracksPageLineupSelectors
 
 const getPremiumTracksLineup = makeGetLineupMetadatas(getLineup)
 
 const messages = {
-  header: 'Premium Tracks'
+  header: 'Premium Tracks',
+  endOfLineup:
+    'You have reached the end of the list. Check back soon for more premium tracks'
 }
 
 export const PremiumTracksScreen = () => {
@@ -42,6 +45,9 @@ export const PremiumTracksScreen = () => {
           actions={premiumTracksPageLineupActions}
           selfLoad
           pullToRefresh
+          EndOfLineupComponent={
+            <EndOfLineupNotice description={messages.endOfLineup} />
+          }
         />
       </ScreenContent>
     </Screen>

--- a/packages/mobile/src/screens/explore-screen/tabs/ForYouTab/PremiumTracksScreen.tsx
+++ b/packages/mobile/src/screens/explore-screen/tabs/ForYouTab/PremiumTracksScreen.tsx
@@ -17,8 +17,7 @@ const getPremiumTracksLineup = makeGetLineupMetadatas(getLineup)
 
 const messages = {
   header: 'Premium Tracks',
-  endOfLineup:
-    'You have reached the end of the list. Check back soon for more premium tracks'
+  endOfLineup: 'Check back soon for more premium tracks'
 }
 
 export const PremiumTracksScreen = () => {

--- a/packages/mobile/src/screens/feed-screen/FeedScreen.tsx
+++ b/packages/mobile/src/screens/feed-screen/FeedScreen.tsx
@@ -13,13 +13,13 @@ import IconFeed from 'app/assets/images/iconFeed.svg'
 import { Screen, ScreenContent, ScreenHeader } from 'app/components/core'
 import { FeedTipTile } from 'app/components/feed-tip-tile'
 import { Lineup } from 'app/components/lineup'
+import { EndOfLineupNotice } from 'app/components/lineup/EndOfLineupNotice'
 import { OnlineOnly } from 'app/components/offline-placeholder/OnlineOnly'
 import { useAppTabScreen } from 'app/hooks/useAppTabScreen'
 import { useFeatureFlag } from 'app/hooks/useRemoteConfig'
 import { make, track } from 'app/services/analytics'
 
 import { EmptyFeedSuggestedFollows } from './EmptyFeedSuggestedFollows'
-import { EndOfFeedNotice } from './EndOfFeedNotice'
 import { FeedFilterButton } from './FeedFilterButton'
 const { getDiscoverFeedLineup } = feedPageSelectors
 const { makeGetLineupMetadatas } = lineupSelectors
@@ -27,7 +27,8 @@ const { makeGetLineupMetadatas } = lineupSelectors
 const getFeedLineup = makeGetLineupMetadatas(getDiscoverFeedLineup)
 
 const messages = {
-  header: 'Your Feed'
+  header: 'Your Feed',
+  endOfFeed: "Looks like you've reached the end of your feed..."
 }
 
 export const FeedScreen = () => {
@@ -60,7 +61,9 @@ export const FeedScreen = () => {
           selfLoad
           header={isUsdcEnabled ? null : <FeedTipTile />}
           hideHeaderOnEmpty
-          ListFooterComponent={<EndOfFeedNotice />}
+          ListFooterComponent={
+            <EndOfLineupNotice description={messages.endOfFeed} />
+          }
           LineupEmptyComponent={<EmptyFeedSuggestedFollows />}
           actions={feedActions}
           lineupSelector={getFeedLineup}


### PR DESCRIPTION
### Description

Adds "end-of-lineup" notice for premium tracks lineup, to help make it clear to folks they are at the end of the list. Also adds a cta to check in later as more premium tracks will be added

<img width="461" alt="image" src="https://github.com/AudiusProject/audius-protocol/assets/8230000/4258fd3e-3e8b-4f44-9941-87d02fa9e9cc">

