### PR TITLE
[PAY-2114] Show country is not supported message for purchases

### DIFF
--- a/packages/common/src/hooks/purchaseContent/usePurchaseContentErrorMessage.ts
+++ b/packages/common/src/hooks/purchaseContent/usePurchaseContentErrorMessage.ts
@@ -20,7 +20,8 @@ const messages = {
     `Total purchase amount must be between $${formatPrice(
       minAmount
     )} and ${formatPrice(maxAmount)}`,
-  countryNotSupported: "We're unable to support transactions in this country"
+  countryNotSupported:
+    'Stripe is unable to support transactions in this country'
 }
 
 export const usePurchaseContentErrorMessage = (

--- a/packages/common/src/hooks/purchaseContent/usePurchaseContentErrorMessage.ts
+++ b/packages/common/src/hooks/purchaseContent/usePurchaseContentErrorMessage.ts
@@ -19,7 +19,8 @@ const messages = {
   badAmount: (minAmount: number, maxAmount: number) =>
     `Total purchase amount must be between $${formatPrice(
       minAmount
-    )} and ${formatPrice(maxAmount)}`
+    )} and ${formatPrice(maxAmount)}`,
+  countryNotSupported: "We're unable to support transactions in this country"
 }
 
 export const usePurchaseContentErrorMessage = (
@@ -39,6 +40,8 @@ export const usePurchaseContentErrorMessage = (
         minUSDCPurchaseAmountCents,
         maxUSDCPurchaseAmountCents
       )
+    case BuyCryptoErrorCode.COUNTRY_NOT_SUPPORTED:
+      return messages.countryNotSupported
     case BuyCryptoErrorCode.BAD_FEE_PAYER:
     case BuyCryptoErrorCode.BAD_PROVIDER:
     case BuyCryptoErrorCode.BAD_TOKEN:

--- a/packages/common/src/hooks/purchaseContent/usePurchaseContentErrorMessage.ts
+++ b/packages/common/src/hooks/purchaseContent/usePurchaseContentErrorMessage.ts
@@ -35,13 +35,14 @@ export const usePurchaseContentErrorMessage = (
       return messages.minimumPurchase(minUSDCPurchaseAmountCents)
     case BuyUSDCErrorCode.MaxAmountExceeded:
       return messages.maximumPurchase(maxUSDCPurchaseAmountCents)
+    case BuyCryptoErrorCode.COUNTRY_NOT_SUPPORTED:
+    case BuyUSDCErrorCode.CountryNotSupported:
+      return messages.countryNotSupported
     case BuyCryptoErrorCode.BAD_AMOUNT:
       return messages.badAmount(
         minUSDCPurchaseAmountCents,
         maxUSDCPurchaseAmountCents
       )
-    case BuyCryptoErrorCode.COUNTRY_NOT_SUPPORTED:
-      return messages.countryNotSupported
     case BuyCryptoErrorCode.BAD_FEE_PAYER:
     case BuyCryptoErrorCode.BAD_PROVIDER:
     case BuyCryptoErrorCode.BAD_TOKEN:

--- a/packages/common/src/store/buy-crypto/sagas.ts
+++ b/packages/common/src/store/buy-crypto/sagas.ts
@@ -418,6 +418,15 @@ function* doBuyCryptoViaSol({
           error: errorString
         })
       )
+      if (
+        result.failure.payload?.error?.code ===
+        'crypto_onramp_unsupported_country'
+      ) {
+        throw new BuyCryptoError(
+          BuyCryptoErrorCode.COUNTRY_NOT_SUPPORTED,
+          errorString
+        )
+      }
       throw new BuyCryptoError(BuyCryptoErrorCode.ON_RAMP_ERROR, errorString)
     }
 

--- a/packages/common/src/store/buy-crypto/slice.ts
+++ b/packages/common/src/store/buy-crypto/slice.ts
@@ -3,8 +3,9 @@ import { createSlice, PayloadAction } from '@reduxjs/toolkit'
 import { MintName } from 'services/index'
 import { OnRampProvider } from 'store/ui/buy-audio/types'
 
-import { BuyCryptoError } from './types'
 import { StripeSessionCreationError } from '..'
+
+import { BuyCryptoError } from './types'
 
 type BuyCryptoPayload = {
   /**

--- a/packages/common/src/store/buy-crypto/slice.ts
+++ b/packages/common/src/store/buy-crypto/slice.ts
@@ -2,8 +2,7 @@ import { createSlice, PayloadAction } from '@reduxjs/toolkit'
 
 import { MintName } from 'services/index'
 import { OnRampProvider } from 'store/ui/buy-audio/types'
-
-import { StripeSessionCreationError } from '..'
+import { StripeSessionCreationError } from 'store/ui/stripe-modal/types'
 
 import { BuyCryptoError } from './types'
 

--- a/packages/common/src/store/buy-crypto/slice.ts
+++ b/packages/common/src/store/buy-crypto/slice.ts
@@ -4,6 +4,7 @@ import { MintName } from 'services/index'
 import { OnRampProvider } from 'store/ui/buy-audio/types'
 
 import { BuyCryptoError } from './types'
+import { StripeSessionCreationError } from '..'
 
 type BuyCryptoPayload = {
   /**
@@ -46,7 +47,10 @@ const slice = createSlice({
     /**
      * @internal used for tracking onramp state in saga
      */
-    onrampFailed: (_state, _action: PayloadAction<{ error: Error }>) => {
+    onrampFailed: (
+      _state,
+      _action: PayloadAction<{ error: StripeSessionCreationError }>
+    ) => {
       // handled by saga
     },
     /**

--- a/packages/common/src/store/buy-crypto/types.ts
+++ b/packages/common/src/store/buy-crypto/types.ts
@@ -31,6 +31,7 @@ export enum BuyCryptoErrorCode {
   BAD_FEE_PAYER = 'BadFeePayer',
   SWAP_ERROR = 'SwapError',
   ON_RAMP_ERROR = 'OnRampError',
+  COUNTRY_NOT_SUPPORTED = 'CountryNotSupported',
   UNKNOWN = 'UnknownError'
 }
 

--- a/packages/common/src/store/buy-usdc/sagas.ts
+++ b/packages/common/src/store/buy-usdc/sagas.ts
@@ -98,13 +98,13 @@ function* purchaseStep({
         error: errorString
       })
     )
+    // Throw up to the flow above this
     if (
       result.failure.payload?.error?.code ===
       'crypto_onramp_unsupported_country'
     ) {
       throw new BuyUSDCError(BuyUSDCErrorCode.CountryNotSupported, errorString)
     }
-    // Throw up to the flow above this
     throw new BuyUSDCError(BuyUSDCErrorCode.OnrampError, errorString)
   }
   yield* call(

--- a/packages/common/src/store/buy-usdc/sagas.ts
+++ b/packages/common/src/store/buy-usdc/sagas.ts
@@ -98,6 +98,12 @@ function* purchaseStep({
         error: errorString
       })
     )
+    if (
+      result.failure.payload?.error?.code ===
+      'crypto_onramp_unsupported_country'
+    ) {
+      throw new BuyUSDCError(BuyUSDCErrorCode.CountryNotSupported, errorString)
+    }
     // Throw up to the flow above this
     throw new BuyUSDCError(BuyUSDCErrorCode.OnrampError, errorString)
   }

--- a/packages/common/src/store/buy-usdc/slice.ts
+++ b/packages/common/src/store/buy-usdc/slice.ts
@@ -1,6 +1,6 @@
 import { Action, createSlice, PayloadAction } from '@reduxjs/toolkit'
 
-import { StripeSessionCreationError } from '..'
+import { StripeSessionCreationError } from 'store/ui/stripe-modal/types'
 
 import {
   BuyUSDCStage,

--- a/packages/common/src/store/buy-usdc/slice.ts
+++ b/packages/common/src/store/buy-usdc/slice.ts
@@ -1,12 +1,13 @@
 import { Action, createSlice, PayloadAction } from '@reduxjs/toolkit'
 
+import { StripeSessionCreationError } from '..'
+
 import {
   BuyUSDCStage,
   USDCOnRampProvider,
   PurchaseInfo,
   BuyUSDCError
 } from './types'
-import { StripeSessionCreationError } from '..'
 
 type StripeSessionStatus =
   | 'initialized'

--- a/packages/common/src/store/buy-usdc/slice.ts
+++ b/packages/common/src/store/buy-usdc/slice.ts
@@ -6,6 +6,7 @@ import {
   PurchaseInfo,
   BuyUSDCError
 } from './types'
+import { StripeSessionCreationError } from '..'
 
 type StripeSessionStatus =
   | 'initialized'
@@ -62,7 +63,10 @@ const slice = createSlice({
     onrampSucceeded: (state) => {
       state.stage = BuyUSDCStage.CONFIRMING_PURCHASE
     },
-    onrampFailed: (_state, _action: PayloadAction<{ error: Error }>) => {
+    onrampFailed: (
+      _state,
+      _action: PayloadAction<{ error: StripeSessionCreationError }>
+    ) => {
       // handled by saga
     },
     buyUSDCFlowFailed: (

--- a/packages/common/src/store/buy-usdc/types.ts
+++ b/packages/common/src/store/buy-usdc/types.ts
@@ -22,7 +22,8 @@ export enum BuyUSDCStage {
 export enum BuyUSDCErrorCode {
   MinAmountNotMet = 'MinAmountNotMet',
   MaxAmountExceeded = 'MaxAmountExceeded',
-  OnrampError = 'OnrampError'
+  OnrampError = 'OnrampError',
+  CountryNotSupported = 'CountryNotSupported'
 }
 
 export class BuyUSDCError extends Error {


### PR DESCRIPTION
### Description
Show a specific error message when the user attempts to purchase from a country stripe doesn't support.

### How Has This Been Tested?

Local web prod, tested with `BUY_USDC_VIA_SOL` both on and off.
haven't been able to get ios app running, but should share same code path in common.

https://github.com/AudiusProject/audius-protocol/assets/3893871/d29b515a-38b6-410d-8042-cc23fb43e5b8

