### PR TITLE
PAY-2119: Fix Stripe Drawer zIndex on Android

### DIFF
--- a/packages/mobile/src/app/Drawers.tsx
+++ b/packages/mobile/src/app/Drawers.tsx
@@ -111,6 +111,9 @@ const commonDrawersMap: { [Modal in Modals]?: ComponentType } = {
   ProfileActions: ProfileActionsDrawer,
   PlaybackRate: PlaybackRateDrawer,
   PublishPlaylistConfirmation: PublishPlaylistDrawer,
+  // Disabled to allow the proper zIndex sibling order for multiple purchases on Android.
+  // See: https://linear.app/audius/issue/PAY-2119/stripe-drawer-appearing-behind-purchase-drawer
+  // PremiumTrackPurchase: PremiumTrackPurchaseDrawer,
   StripeOnRamp: StripeOnrampDrawer,
   InboxUnavailableModal: InboxUnavailableDrawer,
   LeavingAudiusModal: LeavingAudiusDrawer
@@ -135,7 +138,9 @@ const nativeDrawersMap: { [DrawerName in Drawer]?: ComponentType } = {
   BlockMessages: BlockMessagesDrawer,
   DeleteChat: DeleteChatDrawer,
   SupportersInfo: SupportersInfoDrawer,
-  PremiumTrackPurchase: PremiumTrackPurchaseDrawer,
+  // Disabled to allow the proper zIndex sibling order for multiple purchases on Android.
+  // See: https://linear.app/audius/issue/PAY-2119/stripe-drawer-appearing-behind-purchase-drawer
+  // PremiumTrackPurchase: PremiumTrackPurchaseDrawer,
   USDCManualTransfer: USDCManualTransferDrawer
 }
 
@@ -164,6 +169,17 @@ export const Drawers = () => {
           drawer={Drawer}
         />
       ))}
+      {/**
+       * The Stripe drawer is opened while the purchase drawer is opened.
+       * We set a higher zIndex on the Stripe drawer, but on Android,
+       * this is only working for the first purchase. The second time,
+       * it seems to fall back on sibling order. Rather than make _all_ common
+       * drawers render after _all_ native drawers to get this to work,
+       * we made the tradeoff of not unmounting these drawers to reduce the
+       * risk of introducing other zIndex bugs in fixing this one.
+       */}
+      <PremiumTrackPurchaseDrawer />
+      <StripeOnrampDrawer />
     </>
   )
 }

--- a/packages/mobile/src/components/premium-track-purchase-drawer/PremiumTrackPurchaseDrawer.tsx
+++ b/packages/mobile/src/components/premium-track-purchase-drawer/PremiumTrackPurchaseDrawer.tsx
@@ -340,7 +340,7 @@ export const PremiumTrackPurchaseDrawer = () => {
   const isUSDCEnabled = useIsUSDCEnabled()
   const presetValues = usePayExtraPresets(useRemoteVar)
   const { data, isOpen } = useDrawer('PremiumTrackPurchase')
-  const { trackId } = data
+  const trackId = data?.trackId
   const { data: track, status: trackStatus } = useGetTrackById(
     { id: trackId },
     { disabled: !trackId }


### PR DESCRIPTION
### Description

We set a higher zIndex on the Stripe drawer, but on Android, this is only working for the first purchase. The second time, it seems to fall back on sibling order. Rather than make _all_ common drawers render after _all_ native drawers to get this to work, we made the tradeoff of not unmounting these drawers to reduce the risk of introducing other zIndex bugs in fixing this one.

See: PAY-2119
       
### How Has This Been Tested?

Android sim.

Repro:
- Open purchase drawer and subsequent Stripe drawer
- Close both
- Open purchase drawer and subsequent Stripe drawer