### PR TITLE
[PAY-2112] Don't attempt to use balance if total amount due drops below minimum

### DIFF
--- a/packages/common/src/store/purchase-content/utils.test.ts
+++ b/packages/common/src/store/purchase-content/utils.test.ts
@@ -120,7 +120,7 @@ describe('store/purchase-content/utils', () => {
       ).toEqual(expect.objectContaining(expected))
     }
   )
-  describe('getPurchaseSummaryValues', () => {})
+
   test.each([
     {
       description: 'no balance, full price needed',

--- a/packages/common/src/store/purchase-content/utils.test.ts
+++ b/packages/common/src/store/purchase-content/utils.test.ts
@@ -1,6 +1,8 @@
 import BN from 'bn.js'
+
 import { BNUSDC } from 'models/Wallet'
 import { BN_USDC_CENT_WEI } from 'utils/wallet'
+
 import { getBalanceNeeded, getPurchaseSummaryValues } from './utils'
 
 function centsToBN(cents: number) {

--- a/packages/common/src/store/purchase-content/utils.test.ts
+++ b/packages/common/src/store/purchase-content/utils.test.ts
@@ -1,0 +1,175 @@
+import BN from 'bn.js'
+import { BNUSDC } from 'models/Wallet'
+import { BN_USDC_CENT_WEI } from 'utils/wallet'
+import { getBalanceNeeded, getPurchaseSummaryValues } from './utils'
+
+function centsToBN(cents: number) {
+  return new BN(cents).mul(BN_USDC_CENT_WEI) as BNUSDC
+}
+
+const minPurchaseAmountCents = 100
+
+describe('store/purchase-content/utils', () => {
+  test.each([
+    {
+      description: 'no balance, no extra amount, full price due',
+      price: 100,
+      currentBalance: centsToBN(0),
+      extraAmount: 0,
+      minPurchaseAmountCents,
+      expected: { amountDue: 100, existingBalance: 0 }
+    },
+    {
+      description: 'no balance, extra amount, full total due',
+      price: 100,
+      currentBalance: centsToBN(0),
+      extraAmount: 100,
+      minPurchaseAmountCents,
+      expected: { amountDue: 200, existingBalance: 0 }
+    },
+    {
+      description: 'price - balance less than minimum, full price due',
+      price: 100,
+      currentBalance: centsToBN(1),
+      extraAmount: 0,
+      minPurchaseAmountCents,
+      expected: { amountDue: 100, existingBalance: 0 }
+    },
+    {
+      description: 'price - balance less than minimum, full price due',
+      price: 100,
+      currentBalance: centsToBN(99),
+      extraAmount: 0,
+      minPurchaseAmountCents,
+      expected: { amountDue: 100, existingBalance: 0 }
+    },
+    {
+      description:
+        'price + extraAmount - balance less than minimum, full price due',
+      price: 100,
+      currentBalance: centsToBN(101),
+      extraAmount: 100,
+      minPurchaseAmountCents,
+      expected: { amountDue: 200, existingBalance: 0 }
+    },
+    {
+      description: 'no extra amount, balance equals price, nothing due',
+      price: 100,
+      currentBalance: centsToBN(100),
+      extraAmount: 0,
+      minPurchaseAmountCents,
+      expected: { amountDue: 0, existingBalance: 100 }
+    },
+    {
+      description: 'no extra amount, balance exceeds price, nothing due',
+      price: 100,
+      currentBalance: centsToBN(101),
+      extraAmount: 0,
+      minPurchaseAmountCents,
+      expected: { amountDue: 0, existingBalance: 100 }
+    },
+    {
+      description: 'with extra amount, balance covers price, nothing due',
+      price: 100,
+      currentBalance: centsToBN(200),
+      extraAmount: 100,
+      minPurchaseAmountCents,
+      expected: { amountDue: 0, existingBalance: 200 }
+    },
+    {
+      description: 'with extra amount, balance exceeds price, nothing due',
+      price: 100,
+      currentBalance: centsToBN(201),
+      extraAmount: 100,
+      minPurchaseAmountCents,
+      expected: { amountDue: 0, existingBalance: 200 }
+    },
+    {
+      description: 'balance covers part of purchase, remainder due',
+      price: 200,
+      currentBalance: centsToBN(50),
+      extraAmount: 0,
+      minPurchaseAmountCents,
+      expected: { amountDue: 150, existingBalance: 50 }
+    },
+    {
+      description:
+        'with extraAmount, balance covers part of purchase, remainder due',
+      price: 100,
+      currentBalance: centsToBN(50),
+      extraAmount: 100,
+      minPurchaseAmountCents,
+      expected: { amountDue: 150, existingBalance: 50 }
+    }
+  ])(
+    `getPurchaseSummaryValues: $description`,
+    ({
+      price,
+      currentBalance,
+      extraAmount,
+      minPurchaseAmountCents,
+      expected
+    }) => {
+      expect(
+        getPurchaseSummaryValues({
+          price,
+          extraAmount,
+          currentBalance,
+          minPurchaseAmountCents
+        })
+      ).toEqual(expect.objectContaining(expected))
+    }
+  )
+  describe('getPurchaseSummaryValues', () => {})
+  test.each([
+    {
+      description: 'no balance, full price needed',
+      amountDue: centsToBN(100),
+      balance: centsToBN(0),
+      minPurchaseAmountCents,
+      expected: 100
+    },
+    {
+      description: 'balance brings price below minimum, full price needed',
+      amountDue: centsToBN(100),
+      balance: centsToBN(1),
+      minPurchaseAmountCents,
+      expected: 100
+    },
+    {
+      description: 'balance brings price below minimum, full price needed',
+      amountDue: centsToBN(100),
+      balance: centsToBN(99),
+      minPurchaseAmountCents,
+      expected: 100
+    },
+    {
+      description: 'balance equals price, no additional balance needed',
+      amountDue: centsToBN(100),
+      balance: centsToBN(100),
+      minPurchaseAmountCents,
+      expected: 0
+    },
+    {
+      description: 'balance exceeds price, no additional balance needed',
+      amountDue: centsToBN(100),
+      balance: centsToBN(101),
+      minPurchaseAmountCents,
+      expected: 0
+    },
+    {
+      description: 'balance covers part of purchase price, remainder needed',
+      amountDue: centsToBN(150),
+      balance: centsToBN(50),
+      minPurchaseAmountCents,
+      expected: 100
+    }
+  ])(
+    `getBalanceNeeded: $description`,
+    ({ amountDue, balance, minPurchaseAmountCents, expected }) => {
+      expect(
+        getBalanceNeeded(amountDue, balance, minPurchaseAmountCents)
+      ).toEqual(centsToBN(expected))
+    }
+  )
+})

--- a/packages/common/src/store/purchase-content/utils.test.ts
+++ b/packages/common/src/store/purchase-content/utils.test.ts
@@ -20,7 +20,7 @@ describe('store/purchase-content/utils', () => {
       expected: { amountDue: 100, existingBalance: 0 }
     },
     {
-      description: 'no balance, extra amount, full total due',
+      description: 'no balance, extra amount, full price due',
       price: 100,
       currentBalance: centsToBN(0),
       extraAmount: 100,
@@ -41,7 +41,7 @@ describe('store/purchase-content/utils', () => {
       currentBalance: centsToBN(99),
       extraAmount: 0,
       minPurchaseAmountCents,
-      expected: { amountDue: 100, existingBalance: 0 }
+      expected: { amountDue: 100, existingBalance: undefined }
     },
     {
       description:
@@ -50,7 +50,7 @@ describe('store/purchase-content/utils', () => {
       currentBalance: centsToBN(101),
       extraAmount: 100,
       minPurchaseAmountCents,
-      expected: { amountDue: 200, existingBalance: 0 }
+      expected: { amountDue: 200, existingBalance: undefined }
     },
     {
       description: 'no extra amount, balance equals price, nothing due',

--- a/packages/mobile/src/components/premium-track-purchase-drawer/hooks/usePurchaseSummaryValues.ts
+++ b/packages/mobile/src/components/premium-track-purchase-drawer/hooks/usePurchaseSummaryValues.ts
@@ -1,4 +1,4 @@
-import type { Nullable, BNUSDC } from '@audius/common'
+import { Nullable, BNUSDC, useUSDCPurchaseConfig } from '@audius/common'
 import {
   CUSTOM_AMOUNT,
   AMOUNT_PRESET,
@@ -21,6 +21,7 @@ export const usePurchaseSummaryValues = ({
   const [{ value: customAmount }] = useField(CUSTOM_AMOUNT)
   const [{ value: amountPreset }] = useField(AMOUNT_PRESET)
   const presetValues = usePayExtraPresets(useRemoteVar)
+  const { minUSDCPurchaseAmountCents } = useUSDCPurchaseConfig(useRemoteVar)
 
   const extraAmount = getExtraAmount({
     amountPreset,
@@ -34,7 +35,8 @@ export const usePurchaseSummaryValues = ({
     // to reflect that until they explicitly select no preset
     extraAmount: amountPreset === PayExtraPreset.NONE ? undefined : extraAmount,
     price,
-    currentBalance
+    currentBalance,
+    minPurchaseAmountCents: minUSDCPurchaseAmountCents
   })
 
   return purchaseSummaryValues

--- a/packages/mobile/src/components/premium-track-purchase-drawer/hooks/usePurchaseSummaryValues.ts
+++ b/packages/mobile/src/components/premium-track-purchase-drawer/hooks/usePurchaseSummaryValues.ts
@@ -1,11 +1,12 @@
-import { Nullable, BNUSDC, useUSDCPurchaseConfig } from '@audius/common'
+import type { Nullable, BNUSDC } from '@audius/common'
 import {
   CUSTOM_AMOUNT,
   AMOUNT_PRESET,
   getExtraAmount,
   getPurchaseSummaryValues,
   PayExtraPreset,
-  usePayExtraPresets
+  usePayExtraPresets,
+  useUSDCPurchaseConfig
 } from '@audius/common'
 import { useField } from 'formik'
 

--- a/packages/web/src/components/premium-content-purchase-modal/hooks/usePurchaseSummaryValues.ts
+++ b/packages/web/src/components/premium-content-purchase-modal/hooks/usePurchaseSummaryValues.ts
@@ -6,7 +6,8 @@ import {
   getExtraAmount,
   getPurchaseSummaryValues,
   PayExtraPreset,
-  usePayExtraPresets
+  usePayExtraPresets,
+  useUSDCPurchaseConfig
 } from '@audius/common'
 import { useField } from 'formik'
 
@@ -22,6 +23,7 @@ export const usePurchaseSummaryValues = ({
   const [{ value: customAmount }] = useField(CUSTOM_AMOUNT)
   const [{ value: amountPreset }] = useField(AMOUNT_PRESET)
   const presetValues = usePayExtraPresets(useRemoteVar)
+  const { minUSDCPurchaseAmountCents } = useUSDCPurchaseConfig(useRemoteVar)
 
   const extraAmount = getExtraAmount({
     amountPreset,
@@ -35,7 +37,8 @@ export const usePurchaseSummaryValues = ({
     // to reflect that until they explicitly select no preset
     extraAmount: amountPreset === PayExtraPreset.NONE ? undefined : extraAmount,
     price,
-    currentBalance
+    currentBalance,
+    minPurchaseAmountCents: minUSDCPurchaseAmountCents
   })
 
   return purchaseSummaryValues


### PR DESCRIPTION
### Description
Our payment onramp has a minimum purchase amount. There are situation where users end up with a small balance that would make them unable to complete checkout. In those situations, we will not attempt to use the balance.
This does introduce some corner cases where you have a larger balance and the math of (price+extraAmount-balance) works out to less than the minimum and forces you to pay the full price or bump up your pay extra amount. But those should be more rare than the current issue and we can land changes later to make it a little more sophisticated.

Fixes PAY-2112

### How Has This Been Tested?
Tested locally in browser and iOS simulator against staging

**Note** I temporarily baseed this on #6549 to get Jest working and ensure my tests pass. But I don't want to necessarily block this PR on that one, so the tests won't run in this branch as-is. They will, however, be part of verification for future changes once that other PR is merged.
