### PR TITLE
[C-3307] Fix track count check for collections sagas

### DIFF
--- a/packages/web/src/common/store/pages/collection/sagas.js
+++ b/packages/web/src/common/store/pages/collection/sagas.js
@@ -62,7 +62,7 @@ function* watchFetchCollection() {
           collection.playlist_contents.track_ids.length
         )
       )
-      if (fetchLineup && collection.track_count > 0) {
+      if (fetchLineup && collection.playlist_contents.track_ids.length > 0) {
         yield put(tracksActions.fetchLineupMetadatas(0, 200, false, undefined))
       }
     } else {


### PR DESCRIPTION
### Description
Updated track count check from `track_count` field to `playlist_contents.track_ids.length`

### How Has This Been Tested?

Manually tested, playlists load tracks now
