### PR TITLE
Fix balance formatting for usdc withdrawal events

### DIFF
--- a/packages/common/src/models/Analytics.ts
+++ b/packages/common/src/models/Analytics.ts
@@ -1678,6 +1678,7 @@ type BuyUSDCAddFundsManually = {
 // Withdraw USDC
 
 export type WithdrawUSDCEventFields = {
+  /** Balance in dollars */
   currentBalance: number
 }
 

--- a/packages/web/src/components/withdraw-usdc-modal/WithdrawUSDCModal.tsx
+++ b/packages/web/src/components/withdraw-usdc-modal/WithdrawUSDCModal.tsx
@@ -99,7 +99,7 @@ const TrackFormErrors = ({ currentBalance }: { currentBalance: number }) => {
           eventName: Name.WITHDRAW_USDC_FORM_ERROR,
           error: addressError,
           value: address,
-          currentBalance
+          currentBalance: currentBalance / 100
         })
       )
     }

--- a/packages/web/src/components/withdraw-usdc-modal/WithdrawUSDCModal.tsx
+++ b/packages/web/src/components/withdraw-usdc-modal/WithdrawUSDCModal.tsx
@@ -99,7 +99,7 @@ const TrackFormErrors = ({ currentBalance }: { currentBalance: number }) => {
           eventName: Name.WITHDRAW_USDC_FORM_ERROR,
           error: addressError,
           value: address,
-          currentBalance: currentBalance / 100
+          currentBalance
         })
       )
     }
@@ -151,7 +151,7 @@ export const WithdrawUSDCModal = () => {
       dispatch(
         beginWithdrawUSDC({
           amount,
-          currentBalance: balanceNumberCents / 100,
+          currentBalance: balanceNumberCents,
           destinationAddress: address,
           onSuccess
         })

--- a/packages/web/src/pages/dashboard-page/components/USDCCard.tsx
+++ b/packages/web/src/pages/dashboard-page/components/USDCCard.tsx
@@ -83,7 +83,7 @@ export const USDCCard = ({
     track(
       make({
         eventName: Name.WITHDRAW_USDC_MODAL_OPENED,
-        currentBalance: balanceCents
+        currentBalance: balanceCents / 100
       })
     )
   }

--- a/packages/web/src/store/application/ui/withdraw-usdc/sagas.ts
+++ b/packages/web/src/store/application/ui/withdraw-usdc/sagas.ts
@@ -184,6 +184,7 @@ function* doWithdrawUSDC({
   const analyticsFields: WithdrawUSDCTransferEventFields = {
     destinationAddress,
     amount: amount / 100,
+    // Incoming balance is in cents, analytics values are in dollars
     currentBalance: currentBalance / 100
   }
   try {


### PR DESCRIPTION
### Description
I noticed while writing some dashboards that some of the withdrawal events are double-dividing the current balance, which is less than helpful 😅 
This should get it in line for now, and I will think about how to structure this going forward to make sure it's easy to provide the right units for cases like this.

### How Has This Been Tested?
Tested locally in Chrome against staging
