### PR TITLE
Fix AudioPlayer missing src bug

### DIFF
--- a/packages/web/src/services/audio-player/AudioPlayer.ts
+++ b/packages/web/src/services/audio-player/AudioPlayer.ts
@@ -101,8 +101,7 @@ export class AudioPlayer {
         // Remove listeners first so src = '' does not throw an error
         // @ts-ignore
         this.audio.removeAllListeners?.()
-
-        this.audio.src = ''
+        this.audio.removeAttribute('src')
         this.audio.remove()
       }
 


### PR DESCRIPTION
### Description
Was noticing a lot of these error messages that we believe was causing occasional crashes (not confirmed).

For posterity:
The error:
<img width="605" alt="Screenshot 2023-11-02 at 8 59 32 PM" src="https://github.com/AudiusProject/audius-protocol/assets/3893871/afb649ec-563e-4de7-815f-15a8486564ec">

Logging the error:
```
this.audio.addEventListener('error', (e) => {
        console.debug(e?.target?.error)
      })
```

### How Has This Been Tested?

Local web stage (on brave)