### PR TITLE
[PAY-2121] Don't skip previews in lineups

### DIFF
--- a/packages/web/src/common/store/lineup/sagas.js
+++ b/packages/web/src/common/store/lineup/sagas.js
@@ -17,7 +17,8 @@ import {
   isPremiumContentUSDCPurchaseGated,
   doesUserHaveTrackAccess,
   StringKeys,
-  premiumTracksPageLineupActions
+  premiumTracksPageLineupActions,
+  accountSelectors
 } from '@audius/common'
 import {
   all,
@@ -41,6 +42,7 @@ const { getUid: getCurrentPlayerTrackUid, getPlaying } = playerSelectors
 const { getUsers } = cacheUsersSelectors
 const { getTrack, getTracks } = cacheTracksSelectors
 const { getCollection } = cacheCollectionsSelectors
+const { getUserId } = accountSelectors
 
 const getEntryId = (entry) => `${entry.kind}:${entry.id}`
 
@@ -291,6 +293,7 @@ function* fetchLineupMetadatasAsync(
       if (trackSubscribers.length > 0) {
         yield put(cacheActions.subscribe(Kind.TRACKS, trackSubscribers))
       }
+      const currentUserId = yield select(getUserId)
       // Retain specified info in the lineup itself and resolve with success.
       const lineupEntries = allMetadatas
         .map(retainSelector)
@@ -300,7 +303,7 @@ function* fetchLineupMetadatasAsync(
           return {
             ...m,
             uid: m.uid || lineupEntry.uid || uids[i],
-            isPreview: isPreview(lineupEntry)
+            isPreview: isPreview(lineupEntry, currentUserId)
           }
         })
         .filter((metadata, idx) => {

--- a/packages/web/src/common/store/lineup/sagas.js
+++ b/packages/web/src/common/store/lineup/sagas.js
@@ -34,6 +34,7 @@ import {
 
 import { getToQueue } from 'common/store/queue/sagas'
 import { isMobileWeb } from 'common/utils/isMobileWeb'
+import { isPreview } from 'common/utils/isPreview'
 
 const { getSource, getUid, getPositions } = queueSelectors
 const { getUid: getCurrentPlayerTrackUid, getPlaying } = playerSelectors
@@ -45,6 +46,7 @@ const getEntryId = (entry) => `${entry.kind}:${entry.id}`
 
 const flatten = (list) =>
   list.reduce((a, b) => a.concat(Array.isArray(b) ? flatten(b) : b), [])
+
 function* filterDeletes(tracksMetadata, removeDeleted, lineupPrefix) {
   const tracks = yield select(getTracks)
   const users = yield select(getUsers)
@@ -295,7 +297,11 @@ function* fetchLineupMetadatasAsync(
         .map((m, i) => {
           const lineupEntry = allMetadatas[i]
           // Use metadata.uid, entry.uid, computed new uid in that order of precedence
-          return { ...m, uid: m.uid || lineupEntry.uid || uids[i] }
+          return {
+            ...m,
+            uid: m.uid || lineupEntry.uid || uids[i],
+            isPreview: isPreview(lineupEntry)
+          }
         })
         .filter((metadata, idx) => {
           if (lineup.dedupe && lineup.entryIds) {

--- a/packages/web/src/common/utils/isPreview.ts
+++ b/packages/web/src/common/utils/isPreview.ts
@@ -1,0 +1,9 @@
+import { Track, accountSelectors } from '@audius/common'
+import { select } from 'typed-redux-saga'
+
+const { getUserId } = accountSelectors
+
+export function* isPreview(track: Track) {
+  const currentUserId = yield* select(getUserId)
+  return !!track.preview_cid && track.owner_id !== currentUserId
+}

--- a/packages/web/src/common/utils/isPreview.ts
+++ b/packages/web/src/common/utils/isPreview.ts
@@ -1,9 +1,5 @@
-import { Track, accountSelectors } from '@audius/common'
-import { select } from 'typed-redux-saga'
+import { ID, Track } from '@audius/common'
 
-const { getUserId } = accountSelectors
-
-export function* isPreview(track: Track) {
-  const currentUserId = yield* select(getUserId)
+export const isPreview = (track: Track, currentUserId: ID | null) => {
   return !!track.preview_cid && track.owner_id !== currentUserId
 }


### PR DESCRIPTION
### Description
Previously, previews were skipped in lineups. This PR makes it so that previews can be played and auto-played in a lineup.

Dragon: unsure about usage of generator for `isPreview` and using it with/without `yield`.

### How Has This Been Tested?

Test cases:
3 cases: locked premium track, unlocked premium track, normal track
Click play on a track from each case
Click next/previous through each of the three cases
Let autoplay go to the next track for each of the cases
Test playing through lineup on user's own tracks and confirmed they play the full version and not the preview.
Test explicitly clicking the preview button on a user's own tracks -> play preview and not full track
Test playing tracks while not signed -> play only previews.

Local web stage:

https://github.com/AudiusProject/audius-protocol/assets/3893871/5f1aa4d6-b636-4a55-8424-384138af153f


