### PR TITLE
make mediorum module importable

### DIFF
--- a/mediorum/cmd/loadtest/client.go
+++ b/mediorum/cmd/loadtest/client.go
@@ -2,11 +2,12 @@ package loadtest
 
 import (
 	"fmt"
-	"mediorum/server"
 	"net/http"
 	"os"
 	"sync"
 	"time"
+
+	"github.com/AudiusProject/audius-protocol/mediorum/server"
 )
 
 type TestClient struct {

--- a/mediorum/cmd/loadtest/metrics.go
+++ b/mediorum/cmd/loadtest/metrics.go
@@ -4,10 +4,11 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
-	"mediorum/server"
 	"os"
 	"os/exec"
 	"time"
+
+	"github.com/AudiusProject/audius-protocol/mediorum/server"
 )
 
 // !! metrics.go is WIP - will revisit !!

--- a/mediorum/cmd/loadtest/report.go
+++ b/mediorum/cmd/loadtest/report.go
@@ -2,10 +2,11 @@ package loadtest
 
 import (
 	"fmt"
-	"mediorum/server"
 	"sort"
 	"sync"
 	"time"
+
+	"github.com/AudiusProject/audius-protocol/mediorum/server"
 )
 
 func (tc *TestClient) problems(wg *sync.WaitGroup, peer *server.Peer) {

--- a/mediorum/cmd/main.go
+++ b/mediorum/cmd/main.go
@@ -6,13 +6,14 @@ import (
 	"flag"
 	"fmt"
 	"log"
-	"mediorum/cmd/loadtest"
-	"mediorum/cmd/reaper"
-	"mediorum/cmd/segments"
-	"mediorum/registrar"
-	"mediorum/server"
 	"os"
 	"strconv"
+
+	"github.com/AudiusProject/audius-protocol/mediorum/cmd/loadtest"
+	"github.com/AudiusProject/audius-protocol/mediorum/cmd/reaper"
+	"github.com/AudiusProject/audius-protocol/mediorum/cmd/segments"
+	"github.com/AudiusProject/audius-protocol/mediorum/registrar"
+	"github.com/AudiusProject/audius-protocol/mediorum/server"
 )
 
 func getenvWithDefault(key string, fallback string) string {

--- a/mediorum/crudr/client.go
+++ b/mediorum/crudr/client.go
@@ -5,12 +5,13 @@ import (
 	"encoding/json"
 	"fmt"
 	"log"
-	"mediorum/httputil"
-	"mediorum/server/signature"
 	"net/http"
 	"strings"
 	"time"
 
+	"github.com/AudiusProject/audius-protocol/mediorum/httputil"
+
+	"github.com/AudiusProject/audius-protocol/mediorum/server/signature"
 	"github.com/oklog/ulid/v2"
 	"golang.org/x/exp/slog"
 	"gorm.io/gorm/clause"

--- a/mediorum/crudr/crudr.go
+++ b/mediorum/crudr/crudr.go
@@ -5,10 +5,11 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"mediorum/httputil"
 	"reflect"
 	"strings"
 	"sync"
+
+	"github.com/AudiusProject/audius-protocol/mediorum/httputil"
 
 	"github.com/oklog/ulid/v2"
 	"golang.org/x/exp/slog"

--- a/mediorum/ethcontracts/ethcontracts.go
+++ b/mediorum/ethcontracts/ethcontracts.go
@@ -7,7 +7,7 @@ import (
 	"math/big"
 	"os"
 
-	"mediorum/httputil"
+	"github.com/AudiusProject/audius-protocol/mediorum/httputil"
 
 	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/common"

--- a/mediorum/go.mod
+++ b/mediorum/go.mod
@@ -1,6 +1,8 @@
-module mediorum
+module github.com/AudiusProject/audius-protocol/mediorum
 
 go 1.20
+
+replace github.com/AudiusProject/audius-protocol/mediorum => /mediorum
 
 require (
 	github.com/disintegration/imaging v1.6.2
@@ -8,6 +10,7 @@ require (
 	github.com/ethereum/go-ethereum v1.11.4
 	github.com/georgysavva/scany/v2 v2.0.0
 	github.com/gowebpki/jcs v1.0.0
+	github.com/imroc/req/v3 v3.42.0
 	github.com/ipfs/go-cid v0.3.2
 	github.com/jackc/pgx/v5 v5.3.1
 	github.com/labstack/echo/v4 v4.10.0
@@ -85,7 +88,6 @@ require (
 	github.com/gorilla/websocket v1.5.0 // indirect
 	github.com/hashicorp/errwrap v1.1.0 // indirect
 	github.com/hashicorp/go-multierror v1.1.1 // indirect
-	github.com/imroc/req/v3 v3.42.0 // indirect
 	github.com/jackc/pgpassfile v1.0.0 // indirect
 	github.com/jackc/pgservicefile v0.0.0-20221227161230-091c0ba34f0a // indirect
 	github.com/jackc/puddle/v2 v2.2.0 // indirect

--- a/mediorum/go.mod
+++ b/mediorum/go.mod
@@ -2,8 +2,6 @@ module github.com/AudiusProject/audius-protocol/mediorum
 
 go 1.20
 
-replace github.com/AudiusProject/audius-protocol/mediorum => /mediorum
-
 require (
 	github.com/disintegration/imaging v1.6.2
 	github.com/erni27/imcache v1.1.0

--- a/mediorum/go.sum
+++ b/mediorum/go.sum
@@ -131,6 +131,7 @@ github.com/georgysavva/scany/v2 v2.0.0 h1:RGXqxDv4row7/FYoK8MRXAZXqoWF/NM+NP0q50
 github.com/georgysavva/scany/v2 v2.0.0/go.mod h1:sigOdh+0qb/+aOs3TVhehVT10p8qJL7K/Zhyz8vWo38=
 github.com/getsentry/sentry-go v0.18.0 h1:MtBW5H9QgdcJabtZcuJG80BMOwaBpkRDZkxRkNC1sN0=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
+github.com/go-logr/logr v1.2.4 h1:g01GSCwiDw2xSZfjJ2/T9M+S6pFdcNtFYsp+Y43HYDQ=
 github.com/go-ole/go-ole v1.2.1 h1:2lOsA72HgjxAuMlKpFiCbHTvu44PIVkZ5hqm3RSdI/E=
 github.com/go-ole/go-ole v1.2.1/go.mod h1:7FAglXiTm7HKlQRDeOQ6ZNUHidzCWXuZWq/1dTyBNF8=
 github.com/go-stack/stack v1.8.1 h1:ntEHSVwIt7PNXNpgPmVfMrNhLtgjlmnZha2kOpuRiDw=
@@ -230,7 +231,6 @@ github.com/jmespath/go-jmespath v0.4.0 h1:BEgLn5cpjn8UN1mAw4NjwDrS35OdebyEtFe+9Y
 github.com/jmespath/go-jmespath v0.4.0/go.mod h1:T8mJZnbsbmF+m6zOOFylbeCJqk5+pHWvzYPziyZiYoo=
 github.com/jmespath/go-jmespath/internal/testify v1.5.1 h1:shLQSRRSCCPj3f2gpwzGwWFoC7ycTf1rcQZHOlsJ6N8=
 github.com/jmespath/go-jmespath/internal/testify v1.5.1/go.mod h1:L3OGu8Wl2/fWfCI6z80xFu9LTZmf1ZRjMHUOPmWr69U=
-github.com/klauspost/compress v1.15.15 h1:EF27CXIuDsYJ6mmvtBRlEuB2UVOqHG1tAXgZ7yIO+lw=
 github.com/klauspost/compress v1.17.0 h1:Rnbp4K9EjcDuVuHtd0dgA4qNuv9yKDYKK1ulpJwgrqM=
 github.com/klauspost/compress v1.17.0/go.mod h1:ntbaceVETuRiXiv4DpjP66DpAtAGkEQskQzEyD//IeE=
 github.com/klauspost/cpuid/v2 v2.0.4/go.mod h1:FInQzS24/EEf25PyTYn52gqo7WaD8xa0213Md/qVLRg=
@@ -283,6 +283,7 @@ github.com/oklog/ulid/v2 v2.1.0/go.mod h1:rcEKHmBBKfef9DhnvX7y1HZBYxjXb0cP5ExxNs
 github.com/olekukonko/tablewriter v0.0.5 h1:P2Ga83D34wi1o9J6Wh1mRuqd4mF/x/lgBS7N7AbDhec=
 github.com/onsi/ginkgo/v2 v2.12.1 h1:uHNEO1RP2SpuZApSkel9nEh1/Mu+hmQe7Q+Pepg5OYA=
 github.com/onsi/ginkgo/v2 v2.12.1/go.mod h1:TE309ZR8s5FsKKpuB1YAQYBzCaAfUgatB/xlT/ETL/o=
+github.com/onsi/gomega v1.27.10 h1:naR28SdDFlqrG6kScpT8VWpu1xWY5nJRCF3XaYyBjhI=
 github.com/pborman/getopt v0.0.0-20170112200414-7148bc3a4c30/go.mod h1:85jBQOZwpVEaDAr341tbn15RS4fCAsIst0qp7i8ex1o=
 github.com/pkg/browser v0.0.0-20210911075715-681adbf594b8 h1:KoWmjvw+nsYOo29YJK9vDA65RGE3NrOnUtO7a+RF9HU=
 github.com/pkg/browser v0.0.0-20210911075715-681adbf594b8/go.mod h1:HKlIX3XHQyzLZPlr7++PzdhaXEj94dEiJgZDTsxEqUI=
@@ -358,13 +359,9 @@ golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPh
 golang.org/x/crypto v0.0.0-20210921155107-089bfa567519/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
 golang.org/x/crypto v0.0.0-20220314234659-1baeb1ce4c0b/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
 golang.org/x/crypto v0.6.0/go.mod h1:OFC/31mSvZgRz0V1QTNCzfAI1aIRzbiufJtkMIlEp58=
-golang.org/x/crypto v0.11.0 h1:6Ewdq3tDic1mg5xRO4milcWCfMVQhI4NkqWWvqejpuA=
-golang.org/x/crypto v0.11.0/go.mod h1:xgJhtzW8F9jGdVFWZESrid1U1bjeNy4zgy5cRr/CIio=
 golang.org/x/crypto v0.13.0 h1:mvySKfSWJ+UKUii46M40LOvyWfN0s2U+46/jDd0e6Ck=
 golang.org/x/crypto v0.13.0/go.mod h1:y6Z2r+Rw4iayiXXAIxJIDAJ1zMW4yaTpebo8fPOliYc=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
-golang.org/x/exp v0.0.0-20230522175609-2e198f4a06a1 h1:k/i9J1pBpvlfR+9QsetwPyERsqu1GIbi967PQMq3Ivc=
-golang.org/x/exp v0.0.0-20230522175609-2e198f4a06a1/go.mod h1:V1LtkGg67GoY2N1AnLN78QLrzxkLyJw7RJb1gzOOz9w=
 golang.org/x/exp v0.0.0-20230905200255-921286631fa9 h1:GoHiUyI/Tp2nVkLI2mCxVkOjsbSXD66ic0XW0js0R9g=
 golang.org/x/exp v0.0.0-20230905200255-921286631fa9/go.mod h1:S2oDrQGGwySpoQPVqRShND87VCbxmc6bL1Yd2oYrm6k=
 golang.org/x/image v0.0.0-20191009234506-e7c1f5e7dbb8/go.mod h1:FeLwcggjj3mMvU+oOTbSwawSJRM1uh48EjtB4UJZlP0=
@@ -393,8 +390,6 @@ golang.org/x/net v0.0.0-20211112202133-69e39bad7dc2/go.mod h1:9nx3DQGgdP8bBQD5qx
 golang.org/x/net v0.0.0-20220722155237-a158d28d115b/go.mod h1:XRhObCWvk6IyKnWLug+ECip1KBveYUHfp+8e9klMJ9c=
 golang.org/x/net v0.1.0/go.mod h1:Cx3nUiGt4eDBEyega/BKRp+/AlGL8hYe7U9odMt2Cco=
 golang.org/x/net v0.6.0/go.mod h1:2Tu9+aMcznHK/AK1HMvgo6xiTLG5rD5rZLDS+rp2Bjs=
-golang.org/x/net v0.13.0 h1:Nvo8UFsZ8X3BhAC9699Z1j7XQ3rsZnUUm7jfBEk1ueY=
-golang.org/x/net v0.13.0/go.mod h1:zEVYFnQC7m/vmpQFELhcD1EWkZlX69l4oqgmer6hfKA=
 golang.org/x/net v0.15.0 h1:ugBLEUaxABaB5AJqW9enI0ACdci2RUd4eP51NTBvuJ8=
 golang.org/x/net v0.15.0/go.mod h1:idbUs1IY1+zTqbi8yxTbhexhEEk5ur9LInksu6HrEpk=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
@@ -431,8 +426,6 @@ golang.org/x/sys v0.0.0-20220811171246-fbc7d0a398ab/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20220908164124-27713097b956/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.1.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.5.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.10.0 h1:SqMFp9UcQJZa+pmYuAKjd9xq1f0j5rLcDIk0mj4qAsA=
-golang.org/x/sys v0.10.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.12.0 h1:CM0HF96J0hcLAwsHPJZjfdNzs0gftsLfgKt57wWHJ0o=
 golang.org/x/sys v0.12.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
@@ -447,8 +440,6 @@ golang.org/x/text v0.3.7/go.mod h1:u+2+/6zg+i71rQMx5EYifcz6MCKuco9NR6JIITiCfzQ=
 golang.org/x/text v0.3.8/go.mod h1:E6s5w1FMmriuDzIBO73fBruAKo1PCIq6d2Q6DHfQ8WQ=
 golang.org/x/text v0.4.0/go.mod h1:mrYo+phRRbMaCq/xk9113O4dZlRixOauAjOtrjsXDZ8=
 golang.org/x/text v0.7.0/go.mod h1:mrYo+phRRbMaCq/xk9113O4dZlRixOauAjOtrjsXDZ8=
-golang.org/x/text v0.11.0 h1:LAntKIrcmeSKERyiOh0XMV39LXS8IE9UL2yP7+f5ij4=
-golang.org/x/text v0.11.0/go.mod h1:TvPlkZtksWOMsz7fbANvkp4WM8x/WCo/om8BMLbz+aE=
 golang.org/x/text v0.13.0 h1:ablQoSUd0tRdKxZewP80B+BaqeKJuVhuRxj/dkrun3k=
 golang.org/x/text v0.13.0/go.mod h1:TvPlkZtksWOMsz7fbANvkp4WM8x/WCo/om8BMLbz+aE=
 golang.org/x/time v0.3.0 h1:rg5rLMjNzMS1RkNLzCG38eapWhnYLFYXDXj2gOlr8j4=

--- a/mediorum/main.go
+++ b/mediorum/main.go
@@ -4,10 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"log"
-	"mediorum/ethcontracts"
-	"mediorum/httputil"
-	"mediorum/registrar"
-	"mediorum/server"
 	"os"
 	"strconv"
 	"strings"
@@ -16,6 +12,10 @@ import (
 
 	_ "embed"
 
+	"github.com/AudiusProject/audius-protocol/mediorum/ethcontracts"
+	"github.com/AudiusProject/audius-protocol/mediorum/httputil"
+	"github.com/AudiusProject/audius-protocol/mediorum/registrar"
+	"github.com/AudiusProject/audius-protocol/mediorum/server"
 	"golang.org/x/exp/slices"
 	"golang.org/x/exp/slog"
 	"golang.org/x/sync/errgroup"

--- a/mediorum/registrar/audius_api_gateway.go
+++ b/mediorum/registrar/audius_api_gateway.go
@@ -3,9 +3,11 @@ package registrar
 import (
 	"encoding/json"
 	"io/ioutil"
-	"mediorum/httputil"
-	"mediorum/server"
 	"strings"
+
+	"github.com/AudiusProject/audius-protocol/mediorum/httputil"
+
+	"github.com/AudiusProject/audius-protocol/mediorum/server"
 )
 
 type NodeResponse struct {

--- a/mediorum/registrar/multi.go
+++ b/mediorum/registrar/multi.go
@@ -2,7 +2,8 @@ package registrar
 
 import (
 	"errors"
-	"mediorum/server"
+
+	"github.com/AudiusProject/audius-protocol/mediorum/server"
 )
 
 func NewMultiStaging() PeerProvider {

--- a/mediorum/registrar/registrar.go
+++ b/mediorum/registrar/registrar.go
@@ -1,6 +1,6 @@
 package registrar
 
-import "mediorum/server"
+import "github.com/AudiusProject/audius-protocol/mediorum/server"
 
 type PeerProvider interface {
 	Peers() ([]server.Peer, error)

--- a/mediorum/registrar/static.go
+++ b/mediorum/registrar/static.go
@@ -1,6 +1,6 @@
 package registrar
 
-import "mediorum/server"
+import "github.com/AudiusProject/audius-protocol/mediorum/server"
 
 type staticProvider struct {
 	peers   []server.Peer

--- a/mediorum/registrar/the_graph.go
+++ b/mediorum/registrar/the_graph.go
@@ -5,11 +5,12 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"mediorum/httputil"
-	"mediorum/server"
 	"net/http"
 	"strings"
 	"time"
+
+	"github.com/AudiusProject/audius-protocol/mediorum/httputil"
+	"github.com/AudiusProject/audius-protocol/mediorum/server"
 )
 
 func NewGraphStaging() PeerProvider {

--- a/mediorum/server/db.go
+++ b/mediorum/server/db.go
@@ -2,10 +2,10 @@ package server
 
 import (
 	"database/sql"
-	"mediorum/crudr"
-	"mediorum/ddl"
 	"time"
 
+	"github.com/AudiusProject/audius-protocol/mediorum/crudr"
+	"github.com/AudiusProject/audius-protocol/mediorum/ddl"
 	"gocloud.dev/blob"
 	"golang.org/x/exp/slog"
 	"gorm.io/driver/postgres"

--- a/mediorum/server/delist_statuses.go
+++ b/mediorum/server/delist_statuses.go
@@ -10,11 +10,11 @@ import (
 	"net/url"
 	"time"
 
+	"github.com/AudiusProject/audius-protocol/mediorum/server/signature"
+
 	"github.com/jackc/pgx/v5"
 	"github.com/labstack/echo/v4"
 	"golang.org/x/exp/slog"
-
-	"mediorum/server/signature"
 )
 
 const (

--- a/mediorum/server/monitor.go
+++ b/mediorum/server/monitor.go
@@ -3,13 +3,13 @@ package server
 import (
 	"context"
 	"errors"
-	"mediorum/crudr"
 	"net/http"
 	"strconv"
 	"strings"
 	"syscall"
 	"time"
 
+	"github.com/AudiusProject/audius-protocol/mediorum/crudr"
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/labstack/echo/v4"
 	"golang.org/x/exp/slices"

--- a/mediorum/server/repair.go
+++ b/mediorum/server/repair.go
@@ -3,10 +3,11 @@ package server
 import (
 	"context"
 	"errors"
-	"mediorum/cidutil"
 	"net/http"
 	"strconv"
 	"time"
+
+	"github.com/AudiusProject/audius-protocol/mediorum/cidutil"
 
 	"github.com/georgysavva/scany/v2/pgxscan"
 	"github.com/labstack/echo/v4"

--- a/mediorum/server/repair_test.go
+++ b/mediorum/server/repair_test.go
@@ -3,10 +3,11 @@ package server
 import (
 	"bytes"
 	"context"
-	"mediorum/cidutil"
 	"sync"
 	"testing"
 	"time"
+
+	"github.com/AudiusProject/audius-protocol/mediorum/cidutil"
 
 	"github.com/stretchr/testify/assert"
 )

--- a/mediorum/server/replicate.go
+++ b/mediorum/server/replicate.go
@@ -5,13 +5,15 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"mediorum/cidutil"
-	"mediorum/server/signature"
 	"mime/multipart"
 	"net/http"
 	"net/url"
 	"strings"
 	"time"
+
+	"github.com/AudiusProject/audius-protocol/mediorum/server/signature"
+
+	"github.com/AudiusProject/audius-protocol/mediorum/cidutil"
 
 	"gocloud.dev/blob"
 )

--- a/mediorum/server/serve_blob.go
+++ b/mediorum/server/serve_blob.go
@@ -7,8 +7,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"mediorum/cidutil"
-	"mediorum/server/signature"
 	"mime"
 	"net/http"
 	"os"
@@ -16,6 +14,10 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/AudiusProject/audius-protocol/mediorum/server/signature"
+
+	"github.com/AudiusProject/audius-protocol/mediorum/cidutil"
 
 	"github.com/erni27/imcache"
 	"github.com/labstack/echo/v4"

--- a/mediorum/server/serve_crud.go
+++ b/mediorum/server/serve_crud.go
@@ -3,9 +3,10 @@ package server
 import (
 	"context"
 	"fmt"
-	"mediorum/crudr"
 	"net/http"
 	"time"
+
+	"github.com/AudiusProject/audius-protocol/mediorum/crudr"
 
 	"github.com/labstack/echo/v4"
 )

--- a/mediorum/server/serve_health.go
+++ b/mediorum/server/serve_health.go
@@ -4,12 +4,12 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
-	"mediorum/ethcontracts"
-	"mediorum/server/signature"
 	"strconv"
 	"strings"
 	"time"
 
+	"github.com/AudiusProject/audius-protocol/mediorum/ethcontracts"
+	"github.com/AudiusProject/audius-protocol/mediorum/server/signature"
 	"github.com/gowebpki/jcs"
 	"github.com/labstack/echo/v4"
 )

--- a/mediorum/server/serve_health_test.go
+++ b/mediorum/server/serve_health_test.go
@@ -2,11 +2,11 @@ package server
 
 import (
 	"encoding/json"
-	"mediorum/ethcontracts"
 	"reflect"
 	"testing"
 	"time"
 
+	"github.com/AudiusProject/audius-protocol/mediorum/ethcontracts"
 	"github.com/gowebpki/jcs"
 )
 

--- a/mediorum/server/serve_image.go
+++ b/mediorum/server/serve_image.go
@@ -3,10 +3,11 @@ package server
 import (
 	"fmt"
 	"io"
-	"mediorum/cidutil"
 	"mime"
 	"strings"
 	"time"
+
+	"github.com/AudiusProject/audius-protocol/mediorum/cidutil"
 
 	"github.com/labstack/echo/v4"
 	"gocloud.dev/blob"

--- a/mediorum/server/serve_image_test.go
+++ b/mediorum/server/serve_image_test.go
@@ -1,10 +1,11 @@
 package server
 
 import (
-	"mediorum/cidutil"
 	"net/http"
 	"os"
 	"testing"
+
+	"github.com/AudiusProject/audius-protocol/mediorum/cidutil"
 
 	"github.com/oklog/ulid/v2"
 	"github.com/stretchr/testify/assert"

--- a/mediorum/server/serve_upload.go
+++ b/mediorum/server/serve_upload.go
@@ -3,11 +3,12 @@ package server
 import (
 	"database/sql"
 	"fmt"
-	"mediorum/cidutil"
 	"net/http"
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/AudiusProject/audius-protocol/mediorum/cidutil"
 
 	"github.com/labstack/echo/v4"
 	"github.com/oklog/ulid/v2"

--- a/mediorum/server/server.go
+++ b/mediorum/server/server.go
@@ -5,10 +5,6 @@ import (
 	"crypto/ecdsa"
 	"fmt"
 	"log"
-	"mediorum/cidutil"
-	"mediorum/crudr"
-	"mediorum/ethcontracts"
-	"mediorum/persistence"
 	"net/http"
 	"net/http/httputil"
 	"net/url"
@@ -23,6 +19,10 @@ import (
 	_ "embed"
 	_ "net/http/pprof"
 
+	"github.com/AudiusProject/audius-protocol/mediorum/cidutil"
+	"github.com/AudiusProject/audius-protocol/mediorum/crudr"
+	"github.com/AudiusProject/audius-protocol/mediorum/ethcontracts"
+	"github.com/AudiusProject/audius-protocol/mediorum/persistence"
 	"github.com/erni27/imcache"
 	"github.com/imroc/req/v3"
 	"github.com/jackc/pgx/v5/pgxpool"
@@ -261,8 +261,8 @@ func New(config MediorumConfig) (*MediorumServer, error) {
 		isSeeding:       config.Env == "stage" || config.Env == "prod",
 
 		peerHealths:        map[string]*PeerHealth{},
-		redirectCache:      imcache.New[string, string](imcache.WithMaxEntriesOption[string, string](50_000)),
-		uploadOrigCidCache: imcache.New[string, string](imcache.WithMaxEntriesOption[string, string](50_000)),
+		redirectCache:      imcache.New(imcache.WithMaxEntriesOption[string, string](50_000)),
+		uploadOrigCidCache: imcache.New(imcache.WithMaxEntriesOption[string, string](50_000)),
 
 		StartedAt: time.Now().UTC(),
 		Config:    config,

--- a/mediorum/server/server_basic_auth.go
+++ b/mediorum/server/server_basic_auth.go
@@ -5,11 +5,12 @@ import (
 	"encoding/hex"
 	"fmt"
 	"io"
-	"mediorum/server/signature"
 	"net/http"
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/AudiusProject/audius-protocol/mediorum/server/signature"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/crypto"

--- a/mediorum/server/transcode.go
+++ b/mediorum/server/transcode.go
@@ -12,14 +12,15 @@ import (
 	"image/png"
 	"io"
 	"log"
-	"mediorum/cidutil"
-	"mediorum/crudr"
 	"mime/multipart"
 	"os"
 	"os/exec"
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/AudiusProject/audius-protocol/mediorum/cidutil"
+	"github.com/AudiusProject/audius-protocol/mediorum/crudr"
 
 	"github.com/disintegration/imaging"
 	"github.com/spf13/cast"


### PR DESCRIPTION
### Description
This allows external projects to import mediorum (and downstream packages) as dependencies!

so now people can use it like so: https://github.com/alecsavvy/gaudius/blob/main/uploads.go

### How Has This Been Tested?
imported "mediorum/server" in my own project and ran local tests for mediorum in "audius-protocol"
