### PR TITLE
[PAY-2096] Validate remixability of premium content in DN indexing

### DIFF
--- a/packages/discovery-provider/src/premium_content/signature.py
+++ b/packages/discovery-provider/src/premium_content/signature.py
@@ -1,6 +1,8 @@
 import json
 from datetime import datetime
-from typing import NotRequired, Optional, TypedDict
+from typing import Optional, TypedDict
+
+from typing_extensions import NotRequired
 
 from src.api_helpers import generate_signature
 from src.premium_content.premium_content_types import PremiumContentType

--- a/packages/discovery-provider/src/tasks/entity_manager/entities/track.py
+++ b/packages/discovery-provider/src/tasks/entity_manager/entities/track.py
@@ -1,5 +1,5 @@
 from datetime import datetime
-from typing import Dict, Union
+from typing import Dict, List, Union
 
 from sqlalchemy import desc
 from sqlalchemy.orm.session import Session
@@ -14,6 +14,10 @@ from src.models.tracks.track import Track
 from src.models.tracks.track_price_history import TrackPriceHistory
 from src.models.tracks.track_route import TrackRoute
 from src.models.users.user import User
+from src.premium_content.premium_content_access_checker import (
+    PremiumContentAccessBatchArgs,
+    PremiumContentAccessChecker,
+)
 from src.premium_content.premium_content_constants import USDC_PURCHASE_KEY
 from src.tasks.entity_manager.utils import (
     CHARACTER_LIMIT_DESCRIPTION,
@@ -299,6 +303,8 @@ def validate_track_tx(params: ManageEntityParameters):
             raise IndexingValidationError(
                 f"Track {track_id} description exceeds character limit {CHARACTER_LIMIT_DESCRIPTION}"
             )
+        validate_remixability(params)
+
     if params.action == Action.UPDATE or params.action == Action.DELETE:
         # update / delete specific validations
         if track_id not in params.existing_records["Track"]:
@@ -453,3 +459,61 @@ def delete_track(params: ManageEntityParameters):
     params.session.query(Stem).filter_by(child_track_id=track_id).delete()
 
     params.add_record(track_id, deleted_track)
+
+
+def validate_remixability(params: ManageEntityParameters):
+    track_metadata = params.metadata
+    user_id = params.user_id
+    session = params.session
+
+    track_ids = get_remix_parent_track_ids(track_metadata)
+    if not track_ids:
+        return
+
+    args: List[PremiumContentAccessBatchArgs] = list(
+        map(
+            lambda track_id: {
+                "user_id": user_id,
+                "premium_content_id": track_id,
+                "premium_content_type": "track",
+            },
+            track_ids,
+        )
+    )
+    premium_content_batch_access = (
+        PremiumContentAccessChecker.check_access_for_batch(session, args)
+    )
+    if "track" not in premium_content_batch_access:
+        return
+    if user_id not in premium_content_batch_access["track"]:
+        return
+
+    for track_id in premium_content_batch_access["track"][user_id]:
+        access = premium_content_batch_access["track"][user_id][track_id]
+        if not access["does_user_have_access"]:
+            raise IndexingValidationError(
+                f"User {user_id} does not have access to premium track {track_id}"
+            )
+
+
+def get_remix_parent_track_ids(track_metadata):
+    if not "remix_of" in track_metadata:
+        return
+    if not isinstance(track_metadata["remix_of"], dict):
+        return
+
+    tracks = track_metadata["remix_of"].get("tracks")
+    if not tracks:
+        return
+    if not isinstance(tracks, list):
+        return
+
+    parent_track_ids = []
+    for track in tracks:
+        if not isinstance(track, dict):
+            continue
+        parent_track_id = track.get("parent_track_id")
+        if isinstance(parent_track_id, int):
+            parent_track_ids.append(parent_track_id)
+
+    return parent_track_ids

--- a/packages/discovery-provider/src/tasks/entity_manager/entities/track.py
+++ b/packages/discovery-provider/src/tasks/entity_manager/entities/track.py
@@ -16,7 +16,7 @@ from src.models.tracks.track_route import TrackRoute
 from src.models.users.user import User
 from src.premium_content.premium_content_access_checker import (
     PremiumContentAccessBatchArgs,
-    PremiumContentAccessChecker,
+    premium_content_access_checker,
 )
 from src.premium_content.premium_content_constants import USDC_PURCHASE_KEY
 from src.tasks.entity_manager.utils import (
@@ -478,7 +478,7 @@ def validate_remixability(params: ManageEntityParameters):
         )
     )
     premium_content_batch_access = (
-        PremiumContentAccessChecker.check_access_for_batch(session, args)
+        premium_content_access_checker.check_access_for_batch(session, args)
     )
     if "track" not in premium_content_batch_access:
         return
@@ -494,7 +494,7 @@ def validate_remixability(params: ManageEntityParameters):
 
 
 def get_remix_parent_track_ids(track_metadata):
-    if not "remix_of" in track_metadata:
+    if "remix_of" not in track_metadata:
         return
     if not isinstance(track_metadata["remix_of"], dict):
         return

--- a/packages/web/src/components/withdraw-usdc-modal/components/TransferSuccessful.tsx
+++ b/packages/web/src/components/withdraw-usdc-modal/components/TransferSuccessful.tsx
@@ -18,6 +18,7 @@ import {
 } from '@audius/stems'
 import BN from 'bn.js'
 import { useField } from 'formik'
+import { useSelector } from 'react-redux'
 
 import IconExternalLink from 'assets/img/iconExternalLink.svg'
 import { Icon } from 'components/Icon'
@@ -31,7 +32,6 @@ import { make, track } from 'services/analytics'
 
 import { TextRow } from './TextRow'
 import styles from './TransferSuccessful.module.css'
-import { useSelector } from 'react-redux'
 
 const { getWithdrawTransaction } = withdrawUSDCSelectors
 

--- a/packages/web/src/pages/upload-page/fields/RemixSettingsField/RemixSettingsMenuFields.tsx
+++ b/packages/web/src/pages/upload-page/fields/RemixSettingsField/RemixSettingsMenuFields.tsx
@@ -69,6 +69,29 @@ export const RemixSettingsMenuFields = () => {
     setCanRemixParent(canRemixParent)
   }, [trackId, setParentTrackId, canRemixParent, setCanRemixParent])
 
+  const renderHideRemixesField = () => {
+    if (isPremium) {
+      return (
+        <SwitchRowField
+          name={SHOW_REMIXES}
+          header={messages.hideRemix.header}
+          description={messages.hideRemix.description}
+          inverted={false}
+          checked
+          disabled
+        />
+      )
+    }
+    return (
+      <SwitchRowField
+        name={SHOW_REMIXES}
+        header={messages.hideRemix.header}
+        description={messages.hideRemix.description}
+        inverted
+      />
+    )
+  }
+
   return (
     <div className={styles.fields}>
       {isPremium ? (
@@ -82,14 +105,7 @@ export const RemixSettingsMenuFields = () => {
           }${messages.changeAvailabilitySuffix}`}
         />
       ) : null}
-      <SwitchRowField
-        name={SHOW_REMIXES}
-        header={messages.hideRemix.header}
-        description={messages.hideRemix.description}
-        disabled={isPremium}
-        checked={isPremium}
-        inverted={!isPremium}
-      />
+      {renderHideRemixesField()}
       <Divider />
       <SwitchRowField
         name={IS_REMIX}


### PR DESCRIPTION
### Description

Only allow premium tracks to which user has access to be set as remix parents in DN indexing.

Also fix bug where hide remixes switch was not modifiable on web.

### How Has This Been Tested?

local web dapp vs stage.

tried uploading bad remix, where remix parent was a track that i dont have access to. it failed with
`"level": "ERROR", "msg": "failed to process transaction error User 14972 does not have access to premium track 2094004801", "timestamp": "2023-11-08 18:36:00,353"`

then uploaded good remix, and it went through
