### PR TITLE
Reinstall pino to fix missing on-exit-leak-free in @pedalboard/relay

### DIFF
--- a/packages/commands/test/common-setup.bash
+++ b/packages/commands/test/common-setup.bash
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 _common_setup() {
-    load '../node_modules/bats-support/load'
+    load '../../../node_modules/bats-support/load'
     load '../../../node_modules/bats-assert/load'
 
     PROJECT_ROOT="$(cd "$(dirname "$BATS_TEST_FILENAME")/.." >/dev/null 2>&1 && pwd)"

--- a/packages/discovery-provider/plugins/pedalboard/apps/relay/package.json
+++ b/packages/discovery-provider/plugins/pedalboard/apps/relay/package.json
@@ -34,7 +34,7 @@
     "http-status-codes": "^2.2.0",
     "knex": "^2.4.2",
     "morgan": "^1.10.0",
-    "pino": "^8.14.1",
+    "pino": "^8.16.1",
     "rate-limiter-flexible": "^2.4.1",
     "uuid": "^9.0.0"
   },


### PR DESCRIPTION
### Description

The extraneous package-lock.json in relay was removed in #6567 . This caused:
```
Cannot find module 'on-exit-leak-free'
```
Even though `pino` declares `on-exit-leak-free` as a dependency, it was nowhere to be found in the root package-lock.json. The only way I was able to get it to properly install is by reinstalling pino (with a minor version upgrade). 

### How Has This Been Tested?

Relay runs properly now
