### PR TITLE
[PROTO-1410] Self hosted ci: make startup script idempotent, perform full docker prune.

### DIFF
--- a/.circleci/scripts/circleci-startup-script.sh
+++ b/.circleci/scripts/circleci-startup-script.sh
@@ -99,4 +99,4 @@ cat <<EOT > /etc/cron.daily/audius-ci-daily
 #!/bin/sh
 /usr/local/sbin/periodic-cleanup --full | logger -t cleanup
 EOT
-chmod 755 /etc/cron.hourly/audius-ci-daily
+chmod 755 /etc/cron.daily/audius-ci-daily

--- a/.circleci/scripts/circleci-startup-script.sh
+++ b/.circleci/scripts/circleci-startup-script.sh
@@ -86,7 +86,7 @@ systemctl start circleci.service
 
 
 # Periodically clean up local docker registry
-curl -L https://raw.githubusercontent.com/AudiusProject/audius-protocol/phelpsdb-self-hosted-ci-cleanup/.circleci/scripts/periodic-cleanup -o /usr/local/sbin/periodic-cleanup
+curl -L https://raw.githubusercontent.com/AudiusProject/audius-protocol/main/.circleci/scripts/periodic-cleanup -o /usr/local/sbin/periodic-cleanup
 chmod 755 /usr/local/sbin/periodic-cleanup
 
 cat <<EOT > /etc/cron.hourly/audius-ci-hourly

--- a/.circleci/scripts/periodic-cleanup
+++ b/.circleci/scripts/periodic-cleanup
@@ -1,0 +1,23 @@
+#!/bin/env bash
+
+set -eo pipefail
+
+PRUNE_THRESHOLD=5
+FULL_PRUNE_THRESHOLD=5
+
+function disk_usage_above_threshold() {
+    threshold="$1"
+    disk_usage_pct="$(df | grep /dev/root | awk '{print $5}' | grep -oP "^\d+")"
+    echo "Disk usage at ${disk_usage_pct}%"
+    [ "$disk_usage_pct" -gt "$threshold" ]
+}
+
+if disk_usage_above_threshold $PRUNE_THRESHOLD; then
+    echo "Cleaning up docker..."
+    docker system prune -f
+fi
+
+if disk_usage_above_threshold $FULL_PRUNE_THRESHOLD && [[ $1 = "--full" ]]; then
+    echo "Disk usage exceeds full prune threshold, perfoming full cleanup..."
+    docker system prune -af
+fi

--- a/.circleci/scripts/periodic-cleanup
+++ b/.circleci/scripts/periodic-cleanup
@@ -2,8 +2,8 @@
 
 set -eo pipefail
 
-PRUNE_THRESHOLD=5
-FULL_PRUNE_THRESHOLD=5
+PRUNE_THRESHOLD=80
+FULL_PRUNE_THRESHOLD=60
 
 function disk_usage_above_threshold() {
     threshold="$1"


### PR DESCRIPTION
### Description

Because the push image workflow involves tagging images, the local docker registry eventually fills up even when `docker system prune` is run. This adds a daily check which runs `docker system prune -a` to mitigate this issue.

### How Has This Been Tested?

Stood up test ci host and stopped/restarted to ensure proper functionality of startup script.