### PR TITLE
Only claim challenges past cooldown on mobile

### DIFF
--- a/packages/common/src/utils/challenges.ts
+++ b/packages/common/src/utils/challenges.ts
@@ -259,3 +259,16 @@ export const isCooldownChallengeClaimable = (
     dayjs.utc().diff(dayjs.utc(challenge.created_at), 'day') >= 7
   )
 }
+/* Filter for only claimable challenges */
+export const getClaimableChallengeSpecifiers = (
+  specifiers: SpecifierWithAmount[],
+  undisbursedUserChallenges: UndisbursedUserChallenge[]
+) => {
+  return specifiers.filter((s) => {
+    const challenge = undisbursedUserChallenges.filter(
+      (c) => c.specifier === s.specifier
+    )[0] // specifiers are unique
+    return isCooldownChallengeClaimable(challenge)
+  })
+}
+

--- a/packages/common/src/utils/challenges.ts
+++ b/packages/common/src/utils/challenges.ts
@@ -6,7 +6,8 @@ import {
   ChallengeRewardID,
   UserChallenge,
   OptimisticUserChallenge,
-  ChallengeName
+  ChallengeName,
+  SpecifierWithAmount
 } from '../models'
 
 import { formatNumberCommas } from './formatUtil'
@@ -271,4 +272,3 @@ export const getClaimableChallengeSpecifiers = (
     return isCooldownChallengeClaimable(challenge)
   })
 }
-

--- a/packages/mobile/src/components/challenge-rewards-drawer/ChallengeRewardsDrawerProvider.tsx
+++ b/packages/mobile/src/components/challenge-rewards-drawer/ChallengeRewardsDrawerProvider.tsx
@@ -8,7 +8,8 @@ import {
   audioRewardsPageActions,
   ClaimStatus,
   audioRewardsPageSelectors,
-  isAudioMatchingChallenge
+  isAudioMatchingChallenge,
+  getClaimableChallengeSpecifiers
 } from '@audius/common'
 import { useDispatch, useSelector } from 'react-redux'
 
@@ -25,8 +26,12 @@ import { AudioMatchingChallengeDrawerContent } from './AudioMatchingChallengeDra
 import { ChallengeRewardsDrawerContent } from './ChallengeRewardsDrawerContent'
 import { ProfileCompletionChecks } from './ProfileCompletionChecks'
 import { ReferralRewardContents } from './ReferralRewardContents'
-const { getChallengeRewardsModalType, getClaimStatus, getAAOErrorCode } =
-  audioRewardsPageSelectors
+const {
+  getChallengeRewardsModalType,
+  getClaimStatus,
+  getAAOErrorCode,
+  getUndisbursedUserChallenges
+} = audioRewardsPageSelectors
 const { claimChallengeReward, resetAndCancelClaimReward } =
   audioRewardsPageActions
 const { getOptimisticUserChallenges } = challengesSelectors
@@ -51,6 +56,7 @@ export const ChallengeRewardsDrawerProvider = () => {
   const userChallenges = useSelector((state: CommonState) =>
     getOptimisticUserChallenges(state, true)
   )
+  const undisbursedUserChallenges = useSelector(getUndisbursedUserChallenges)
 
   const handleClose = useCallback(() => {
     dispatch(resetAndCancelClaimReward())
@@ -111,12 +117,15 @@ export const ChallengeRewardsDrawerProvider = () => {
         claimChallengeReward({
           claim: {
             challengeId: modalType,
-            specifiers: [
-              {
-                specifier: challenge.specifier,
-                amount: challenge.amount
-              }
-            ],
+            specifiers:
+              challenge.challenge_type === 'aggregate'
+                ? getClaimableChallengeSpecifiers(
+                    challenge.undisbursedSpecifiers,
+                    undisbursedUserChallenges
+                  )
+                : [
+                    { specifier: challenge.specifier, amount: challenge.amount }
+                  ],
             amount: challenge?.claimableAmount ?? 0
           },
           retryOnFailure: true

--- a/packages/web/src/pages/audio-rewards-page/components/modals/ChallengeRewardsModal/ChallengeRewardsModal.tsx
+++ b/packages/web/src/pages/audio-rewards-page/components/modals/ChallengeRewardsModal/ChallengeRewardsModal.tsx
@@ -13,9 +13,7 @@ import {
   musicConfettiActions,
   challengeRewardsConfig,
   isAudioMatchingChallenge,
-  isCooldownChallengeClaimable,
-  SpecifierWithAmount,
-  UndisbursedUserChallenge
+  getClaimableChallengeSpecifiers
 } from '@audius/common'
 import {
   Button,
@@ -217,19 +215,6 @@ const getErrorMessage = (aaoErrorCode?: number) => {
     )
   }
   return <>{messages.claimError}</>
-}
-
-/* Filter for only claimable challenges */
-const getClaimableChallengeSpecifiers = (
-  specifiers: SpecifierWithAmount[],
-  undisbursedUserChallenges: UndisbursedUserChallenge[]
-) => {
-  return specifiers.filter((s) => {
-    const challenge = undisbursedUserChallenges.filter(
-      (c) => c.specifier === s.specifier
-    )[0] // specifiers are unique
-    return isCooldownChallengeClaimable(challenge)
-  })
 }
 
 type BodyProps = {


### PR DESCRIPTION
### Description
Fixes a bug on mobile where claiming an $AUDIO matching challenge would have attempted to claim challenges not yet past the cooldown period.

### How Has This Been Tested?

Local ios dev, confirmed that only challenges past cooldown are claimed.