### PR TITLE
Add cooldown_days to challenges api response

### DIFF
--- a/packages/discovery-provider/integration_tests/queries/test_undisbursed_challenges.py
+++ b/packages/discovery-provider/integration_tests/queries/test_undisbursed_challenges.py
@@ -153,6 +153,7 @@ def test_undisbursed_challenges(app):
                 "handle": "TestHandle6",
                 "wallet": "0x6",
                 "created_at": "2023-10-16 17:51:31.105065+00:00",
+                "cooldown_days": None,
             },
             {
                 "challenge_id": "test_challenge_2",
@@ -163,6 +164,7 @@ def test_undisbursed_challenges(app):
                 "handle": "TestHandle4",
                 "wallet": "0x4",
                 "created_at": "2023-10-16 17:51:31.105065+00:00",
+                "cooldown_days": None,
             },
             {
                 "challenge_id": "test_challenge_2",
@@ -173,6 +175,7 @@ def test_undisbursed_challenges(app):
                 "handle": "TestHandle5",
                 "wallet": "0x5",
                 "created_at": "2023-10-16 17:51:31.105065+00:00",
+                "cooldown_days": None,
             },
         ]
         assert expected == undisbursed
@@ -193,6 +196,7 @@ def test_undisbursed_challenges(app):
                 "handle": "TestHandle6",
                 "wallet": "0x6",
                 "created_at": "2023-10-16 17:51:31.105065+00:00",
+                "cooldown_days": None,
             },
         ]
         assert expected == undisbursed

--- a/packages/discovery-provider/src/api/v1/challenges.py
+++ b/packages/discovery-provider/src/api/v1/challenges.py
@@ -247,6 +247,7 @@ class ChallengeInfo(Resource):
                     "starting_block": challenge.starting_block,
                     "weekly_pool": challenge.weekly_pool,
                     "weekly_pool_remaining": weekly_pool_remaining,
+                    "cooldown_days": challenge.cooldown_days,
                 }
                 if (
                     weekly_pool_min_amount

--- a/packages/discovery-provider/src/api/v1/models/challenges.py
+++ b/packages/discovery-provider/src/api/v1/models/challenges.py
@@ -21,6 +21,7 @@ undisbursed_challenge = ns.model(
         "handle": fields.String(required=True),
         "wallet": fields.String(required=True),
         "created_at": fields.String(required=True),
+        "cooldown_days": fields.Integer(required=False),
     },
 )
 
@@ -43,5 +44,6 @@ challenge_info = ns.model(
         "starting_block": fields.Integer(required=False),
         "weekly_pool": fields.String(required=False),
         "weekly_pool_remaining": fields.String(required=False),
+        "cooldown_days": fields.Integer(required=False),
     },
 )

--- a/packages/discovery-provider/src/queries/get_undisbursed_challenges.py
+++ b/packages/discovery-provider/src/queries/get_undisbursed_challenges.py
@@ -17,6 +17,7 @@ class UndisbursedChallengeResponse(TypedDict):
     handle: str
     wallet: str
     created_at: str
+    cooldown_days: Optional[int]
 
 
 def to_challenge_response(
@@ -34,6 +35,7 @@ def to_challenge_response(
         "handle": handle,
         "wallet": wallet,
         "created_at": str(user_challenge.created_at),
+        "cooldown_days": challenge.cooldown_days,
     }
 
 


### PR DESCRIPTION
### Description
Add `cooldown_days` to `challenges/undisbursed` and `challenges/<id>/info` endpoints.


### How Has This Been Tested?

Local dev stack

<img width="889" alt="Screenshot 2023-11-07 at 4 06 49 PM" src="https://github.com/AudiusProject/audius-protocol/assets/3893871/d481dacd-9b09-421d-9a1b-1453345d7169">

<img width="825" alt="Screenshot 2023-11-07 at 4 06 10 PM" src="https://github.com/AudiusProject/audius-protocol/assets/3893871/c1f9d746-fe31-41c2-ae0f-884b5472fc3e">