### PR TITLE
[PAY-1850] Remove fn callback from withdraw USDC action

### DIFF
--- a/packages/common/src/store/ui/modals/withdraw-usdc-modal/index.ts
+++ b/packages/common/src/store/ui/modals/withdraw-usdc-modal/index.ts
@@ -10,8 +10,6 @@ export enum WithdrawUSDCModalPages {
 
 export type WithdrawUSDCModalState = {
   page: WithdrawUSDCModalPages
-  // Completed transaction signature
-  signature?: string
 }
 
 const withdrawUSDCModal = createModal<WithdrawUSDCModalState>({
@@ -23,5 +21,8 @@ const withdrawUSDCModal = createModal<WithdrawUSDCModalState>({
   sliceSelector: (state) => state.ui.modals
 })
 
-export const { hook: useWithdrawUSDCModal, reducer: withdrawUSDCModalReducer } =
-  withdrawUSDCModal
+export const {
+  hook: useWithdrawUSDCModal,
+  reducer: withdrawUSDCModalReducer,
+  actions: withdrawUSDCModalActions
+} = withdrawUSDCModal

--- a/packages/common/src/store/ui/withdraw-usdc/selectors.ts
+++ b/packages/common/src/store/ui/withdraw-usdc/selectors.ts
@@ -19,3 +19,7 @@ export const getWithdrawAmountError = (state: CommonState) => {
 export const getWithdrawStatus = (state: CommonState) => {
   return state.withdrawUSDC.withdrawStatus
 }
+
+export const getWithdrawTransaction = (state: CommonState) => {
+  return state.withdrawUSDC.withdrawTransaction
+}

--- a/packages/common/src/store/ui/withdraw-usdc/slice.ts
+++ b/packages/common/src/store/ui/withdraw-usdc/slice.ts
@@ -7,6 +7,7 @@ type WithdrawUSDCState = {
   destinationAddress?: string
   amount?: number
   withdrawError?: Error
+  withdrawTransaction?: string
   destinationError?: Error
   amountError?: Error
 }
@@ -27,12 +28,15 @@ const slice = createSlice({
         /** Transfer amount in cents */
         amount: number
         destinationAddress: string
-        onSuccess: (transaction: string) => void
       }>
     ) => {
       state.withdrawStatus = Status.LOADING
     },
-    withdrawUSDCSucceeded: (state) => {
+    withdrawUSDCSucceeded: (
+      state,
+      action: PayloadAction<{ transaction: string }>
+    ) => {
+      state.withdrawTransaction = action.payload.transaction
       state.withdrawError = undefined
       state.withdrawStatus = Status.SUCCESS
     },

--- a/packages/web/src/components/withdraw-usdc-modal/WithdrawUSDCModal.tsx
+++ b/packages/web/src/components/withdraw-usdc-modal/WithdrawUSDCModal.tsx
@@ -128,16 +128,6 @@ export const WithdrawUSDCModal = () => {
     }
   }, [balanceNumberCents, priorBalanceCents, setPriorBalanceCents])
 
-  const onSuccess = useCallback(
-    (signature: string) => {
-      setData({
-        page: WithdrawUSDCModalPages.TRANSFER_SUCCESSFUL,
-        signature
-      })
-    },
-    [setData]
-  )
-
   useEffect(() => {
     if (withdrawalStatus === Status.ERROR) {
       setData({
@@ -152,12 +142,11 @@ export const WithdrawUSDCModal = () => {
         beginWithdrawUSDC({
           amount,
           currentBalance: balanceNumberCents,
-          destinationAddress: address,
-          onSuccess
+          destinationAddress: address
         })
       )
     },
-    [balanceNumberCents, dispatch, onSuccess]
+    [balanceNumberCents, dispatch]
   )
 
   let formPage

--- a/packages/web/src/components/withdraw-usdc-modal/components/TransferSuccessful.tsx
+++ b/packages/web/src/components/withdraw-usdc-modal/components/TransferSuccessful.tsx
@@ -3,11 +3,11 @@ import { useCallback } from 'react'
 import {
   useUSDCBalance,
   BNUSDC,
-  useWithdrawUSDCModal,
   formatUSDCWeiToFloorCentsNumber,
   makeSolanaTransactionLink,
   decimalIntegerToHumanReadable,
   Status,
+  withdrawUSDCSelectors,
   Name
 } from '@audius/common'
 import {
@@ -31,6 +31,9 @@ import { make, track } from 'services/analytics'
 
 import { TextRow } from './TextRow'
 import styles from './TransferSuccessful.module.css'
+import { useSelector } from 'react-redux'
+
+const { getWithdrawTransaction } = withdrawUSDCSelectors
 
 const messages = {
   priorBalance: 'Prior Balance',
@@ -55,7 +58,7 @@ export const TransferSuccessful = ({
   priorBalanceCents: number
 }) => {
   const { data: balance, balanceStatus } = useUSDCBalance()
-  const { data: modalData } = useWithdrawUSDCModal()
+  const signature = useSelector(getWithdrawTransaction)
   const balanceNumber = formatUSDCWeiToFloorCentsNumber(
     (balance ?? new BN(0)) as BNUSDC
   )
@@ -64,9 +67,8 @@ export const TransferSuccessful = ({
   const [{ value: amountValue }] = useField<number>(AMOUNT)
   const [{ value: addressValue }] = useField<string>(ADDRESS)
 
-  const { signature = '' } = modalData
-
   const handleClickTransactionLink = useCallback(() => {
+    if (!signature) return
     openExplorer(signature)
     track(
       make({


### PR DESCRIPTION
### Description
Previously had a function callback passed to the redux state for USDC withdrawals. Redux actions should be serializable, so replaced that with passing the transaction signature instead.

### How Has This Been Tested?

Local web stage:

https://github.com/AudiusProject/audius-protocol/assets/3893871/0ff3e1e0-6500-4a06-8d69-ba2f87399134

