### PR TITLE
Fix rewards layout issues after vite

### DIFF
--- a/packages/web/src/pages/audio-rewards-page/components/modals/ChallengeRewardsModal/styles.module.css
+++ b/packages/web/src/pages/audio-rewards-page/components/modals/ChallengeRewardsModal/styles.module.css
@@ -1,4 +1,3 @@
-/*  */
 .container {
   display: flex;
   flex-direction: column;
@@ -66,7 +65,7 @@
 .progressCard {
   width: 100%;
   display: flex;
-  flex: 1 1 0;
+  flex: 1 1 0%;
   flex-direction: column;
   border: 1px solid var(--border-strong);
   border-radius: 8px;
@@ -87,7 +86,7 @@
 .progressDescription {
   display: flex;
   flex-direction: column;
-  flex: 1 1 0;
+  flex: 1 1 0%;
   gap: var(--unit-3);
   padding: var(--unit-4) var(--unit-6);
 }
@@ -114,7 +113,7 @@
   padding: 24px 72px;
 }
 .progressBarSection.mobile {
-  flex: 1 1 0;
+  flex: 1 1 0%;
   border-top: none;
   border-left: 1px solid var(--border-strong);
   padding: 0 16px;


### PR DESCRIPTION
### Description

I don't understand how this fixes it.
The elements were all taking 0 height, possibly because the modal had to open first? Not sure how % changes anything. Some CSS expert please explain.

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._

<img width="826" alt="image" src="https://github.com/AudiusProject/audius-protocol/assets/2731362/f777dcb5-3323-4ffd-8ba9-eaa5fe24c514">
