### PR TITLE
[INF-538] Fix filetype icons in upload broken due to vite migration

### DIFF
--- a/packages/web/src/components/upload/TrackPreviewNew.tsx
+++ b/packages/web/src/components/upload/TrackPreviewNew.tsx
@@ -51,6 +51,8 @@ export const TrackPreviewNew = (props: TrackPreviewProps) => {
     onRemove
   } = props
 
+  const Icon = fileTypeIcon(fileType)
+
   return (
     <div className={styles.trackPreviewNew}>
       {displayIndex ? (
@@ -58,11 +60,7 @@ export const TrackPreviewNew = (props: TrackPreviewProps) => {
           {index + 1}
         </Text>
       ) : null}
-      <img
-        className={styles.trackPreviewImage}
-        src={fileTypeIcon(fileType)}
-        alt='File type icon'
-      />
+      <Icon className={styles.trackPreviewImage} />
       <Text className={styles.titleText} size='small'>
         {trackTitle}
       </Text>


### PR DESCRIPTION
### Description

Vite svgr imports the svg as a js module, setting it as the src of an image tag doesn't work.

@Kyle-Shanks do you know if there was a specific reason we opted to use `img` instead of the svg components itself like we do in most places? Using the component directly like this seems to work fine, but another option is to import the svg using the `?raw` suffix like:
```ts
import iconFileMp3 from 'assets/img/iconFileMp3.svg?raw'
```
if we want to stick with the `img` tag

### How Has This Been Tested?

Tested that various filetype images look correct in the upload flow
![image](https://github.com/AudiusProject/audius-protocol/assets/19916043/a2854d83-d6ec-4851-8853-8ce828ee94b9)

