### PR TITLE
Fix total audio claimed amount for aggregate challenges

### DIFF
--- a/packages/mobile/src/components/challenge-rewards-drawer/ChallengeRewardsDrawerProvider.tsx
+++ b/packages/mobile/src/components/challenge-rewards-drawer/ChallengeRewardsDrawerProvider.tsx
@@ -80,8 +80,7 @@ export const ChallengeRewardsDrawerProvider = () => {
   let audioClaimedSoFar = 0
   if (challenge?.challenge_type === 'aggregate') {
     audioToClaim = challenge.claimableAmount
-    audioClaimedSoFar =
-      challenge.amount * challenge.current_step_count - audioToClaim
+    audioClaimedSoFar = challenge.disbursed_amount
   } else if (challenge?.state === 'completed') {
     audioToClaim = challenge.totalAmount
     audioClaimedSoFar = 0

--- a/packages/web/src/pages/audio-rewards-page/components/modals/ChallengeRewardsModal/ChallengeRewardsModal.tsx
+++ b/packages/web/src/pages/audio-rewards-page/components/modals/ChallengeRewardsModal/ChallengeRewardsModal.tsx
@@ -320,8 +320,7 @@ const ChallengeRewardsBody = ({ dismissModal }: BodyProps) => {
   let audioClaimedSoFar = 0
   if (challenge?.challenge_type === 'aggregate') {
     audioToClaim = challenge.claimableAmount
-    audioClaimedSoFar =
-      challenge.amount * challenge.current_step_count - audioToClaim
+    audioClaimedSoFar = challenge.disbursed_amount
   } else if (challenge?.state === 'completed') {
     audioToClaim = challenge.totalAmount
     audioClaimedSoFar = 0


### PR DESCRIPTION
### Description
I had [added a `disbursed_amount` field to the challenge api response](https://github.com/AudiusProject/audius-protocol/pull/6398/files) but had forgotten to use it in this place on client.

### How Has This Been Tested?


<img width="714" alt="Screenshot 2023-11-08 at 12 21 17 PM" src="https://github.com/AudiusProject/audius-protocol/assets/3893871/4f28b12c-fc65-486a-a646-3013cbb4fee2">
<img width="714" alt="Screenshot 2023-11-08 at 12 21 17 PM" src="https://github.com/AudiusProject/audius-protocol/assets/3893871/17f07bb5-ce7b-4f1f-aab0-b4cdbf4ed6d5">
