### PR TITLE
Add file-loader to fix harmony storybook

### DIFF
--- a/packages/harmony/package.json
+++ b/packages/harmony/package.json
@@ -63,6 +63,7 @@
     "css-loader": "6.8.1",
     "eslint": "8.19.0",
     "eslint-plugin-storybook": "0.6.13",
+    "file-loader": "6.2.0",
     "lodash": "4.17.21",
     "prettier": "2.7.1",
     "react": "18.2.0",


### PR DESCRIPTION
### Description

Fixes issue where file-loader is missing when trying to run storybook