### PR TITLE
Add  matching challenges to claimable challenges

### DIFF
--- a/packages/common/src/hooks/useAccountHasClaimableRewards.ts
+++ b/packages/common/src/hooks/useAccountHasClaimableRewards.ts
@@ -14,8 +14,8 @@ const validRewardIds: Set<ChallengeRewardID> = new Set([
   'referred',
   'send-first-tip',
   'first-playlist',
-  ChallengeName.AudioMatchingSell, // $AUDIO matching seller
-  ChallengeName.AudioMatchingBuy // $AUDIO matching buyer
+  ChallengeName.AudioMatchingSell,
+  ChallengeName.AudioMatchingBuy
 ])
 
 /** Pulls rewards from remoteconfig */

--- a/packages/common/src/hooks/useAccountHasClaimableRewards.ts
+++ b/packages/common/src/hooks/useAccountHasClaimableRewards.ts
@@ -1,4 +1,4 @@
-import { ChallengeRewardID } from '../models'
+import { ChallengeName, ChallengeRewardID } from '../models'
 import { getOptimisticUserChallenges } from '../store/challenges/selectors'
 
 import { useProxySelector } from './useProxySelector'
@@ -13,7 +13,9 @@ const validRewardIds: Set<ChallengeRewardID> = new Set([
   'profile-completion',
   'referred',
   'send-first-tip',
-  'first-playlist'
+  'first-playlist',
+  ChallengeName.AudioMatchingSell, // $AUDIO matching seller
+  ChallengeName.AudioMatchingBuy // $AUDIO matching buyer
 ])
 
 /** Pulls rewards from remoteconfig */


### PR DESCRIPTION
### Description
Previously, if the $AUDIO matching challenges were the only challenges with claimable amounts, the "Claim rewards" pill would not appear.

### How Has This Been Tested?

Local web stage
<img width="1920" alt="Screenshot 2023-11-08 at 5 38 35 PM" src="https://github.com/AudiusProject/audius-protocol/assets/3893871/dc061893-a2da-45dd-b4db-d27828845904">
