### PR TITLE
Gate client release version and add slack notifs

### DIFF
--- a/.circleci/src/commands/@mobile-commands.yml
+++ b/.circleci/src/commands/@mobile-commands.yml
@@ -109,6 +109,23 @@ mobile-release-ios:
     - run:
         name: fastlane build and upload
         command: cd packages/mobile/ios && bundle exec fastlane build_and_upload bundle_id:<<parameters.bundle-id>>
+    - run:
+        name: slack announce
+        command: |
+          cd packages/mobile
+          deploying_version=$(jq -r '.version' package.json)
+          job_url="https://app.circleci.com/pipelines/workflows/$CIRCLE_WORKFLOW_ID"
+          environment=<<parameters.bundle-id>>
+
+          json_content="{ \"blocks\": ["
+          json_content+="{ \"type\": \"section\", \"text\": { \"type\": \"mrkdwn\", \"text\": \"Deployed $environment v$<${job_url}|$deploying_version> to mobile ios \n\" } }"
+          json_content+="]}"
+          echo "Text to send to slack: $json_content"
+
+          # Send Slack message
+          curl -f -X POST -H 'Content-type: application/json' \
+            --data "$json_content" \
+            $SLACK_DAILY_DEPLOY_WEBHOOK
 
 # Prepare to build/upload/release Android
 mobile-prepare-android:
@@ -199,6 +216,23 @@ mobile-release-android:
         command: |
           cd packages/mobile/android
           bundle exec fastlane <<parameters.upload-type>> track:<<parameters.track>>
+    - run:
+        name: slack announce
+        command: |
+          cd packages/mobile
+          deploying_version=$(jq -r '.version' package.json)
+          environment=<<parameters.upload-type>>
+          job_url="https://app.circleci.com/pipelines/workflows/$CIRCLE_WORKFLOW_ID"
+
+          json_content="{ \"blocks\": ["
+          json_content+="{ \"type\": \"section\", \"text\": { \"type\": \"mrkdwn\", \"text\": \"Deployed $environment v$<${job_url}|$deploying_version> to mobile android \n\" } }"
+          json_content+="]}"
+          echo "Text to send to slack: $json_content"
+
+          # Send Slack message
+          curl -f -X POST -H 'Content-type: application/json' \
+            --data "$json_content" \
+            $SLACK_DAILY_DEPLOY_WEBHOOK
 
 # Deploy Solana saga dApp store
 mobile-release-saga-dapp-store:
@@ -272,3 +306,19 @@ mobile-release-saga-dapp-store:
           git add packages/mobile/dapp-store/.asset-manifest.json packages/mobile/dapp-store/config.yaml
           git commit -m 'Update dapp-store build artifacts'
           git push origin main
+    - run:
+        name: slack announce
+        command: |
+          cd packages/mobile
+          deploying_version=$(jq -r '.version' package.json)
+          job_url="https://app.circleci.com/pipelines/workflows/$CIRCLE_WORKFLOW_ID"
+
+          json_content="{ \"blocks\": ["
+          json_content+="{ \"type\": \"section\", \"text\": { \"type\": \"mrkdwn\", \"text\": \"Deployed v$<${job_url}|$deploying_version> to mobile saga \n\" } }"
+          json_content+="]}"
+          echo "Text to send to slack: $json_content"
+
+          # Send Slack message
+          curl -f -X POST -H 'Content-type: application/json' \
+            --data "$json_content" \
+            $SLACK_DAILY_DEPLOY_WEBHOOK

--- a/.circleci/src/commands/@web-commands.yml
+++ b/.circleci/src/commands/@web-commands.yml
@@ -95,6 +95,9 @@ web-distribute:
     environment:
       default: 'prod'
       type: string
+    os:
+      default: 'mac'
+      type: string
   steps:
     - checkout
     - attach_workspace:
@@ -107,7 +110,7 @@ web-distribute:
         command: |
           cd packages/web
           environment="<< parameters.environment >>"
-          if [ "$environment" = "prod" ]; then
+          if [ "$environment" = "production" ]; then
             host="audius.co"
           else
             host="staging.audius.co"
@@ -141,6 +144,24 @@ web-distribute:
         command: |
           cd packages/web
           npm run dist:<< parameters.build-type >>
+    - run:
+        name: slack announce
+        command: |
+          cd packages/web
+          deploying_version=$(jq -r '.version' package.json)
+          environment="<< parameters.environment >>"
+          os="<< parameters.os >>"
+          job_url="https://app.circleci.com/pipelines/gh/AudiusProject/audius-protocol/$pipeline_number/workflows/$workflow_id"
+
+          json_content="{ \"blocks\": ["
+          json_content+="{ \"type\": \"section\", \"text\": { \"type\": \"mrkdwn\", \"text\": \"Deployed $environment v$<${job_url}|$deploying_version> to desktop $os \n\" } }"
+          json_content+="]}"
+          echo "Text to send to slack: $json_content"
+
+          # Send Slack message
+          curl -f -X POST -H 'Content-type: application/json' \
+            --data "$json_content" \
+            $SLACK_DAILY_DEPLOY_WEBHOOK
 
 web-install-wrangler:
   steps:
@@ -199,6 +220,23 @@ web-deploy-cloudflare:
           cd packages/web
           echo ${GA_ACCESS_TOKEN} | npx wrangler secret put GA_ACCESS_TOKEN --env << parameters.environment >>
           npx wrangler publish --env << parameters.environment >>
+    - run:
+        name: slack announce
+        command: |
+          cd packages/web
+          deploying_version=$(jq -r '.version' package.json)
+          environment="<< parameters.environment >>"
+          job_url="https://app.circleci.com/pipelines/gh/AudiusProject/audius-protocol/$pipeline_number/workflows/$workflow_id"
+
+          json_content="{ \"blocks\": ["
+          json_content+="{ \"type\": \"section\", \"text\": { \"type\": \"mrkdwn\", \"text\": \"Deployed $environment v$<${job_url}|$deploying_version> to web \n\" } }"
+          json_content+="]}"
+          echo "Text to send to slack: $json_content"
+
+          # Send Slack message
+          curl -f -X POST -H 'Content-type: application/json' \
+            --data "$json_content" \
+            $SLACK_DAILY_DEPLOY_WEBHOOK
 
 web-deploy-sourcemaps-s3:
   steps:

--- a/.circleci/src/commands/@web-commands.yml
+++ b/.circleci/src/commands/@web-commands.yml
@@ -92,6 +92,9 @@ web-distribute:
     install-license:
       default: false
       type: boolean
+    environment:
+      default: 'prod'
+      type: string
   steps:
     - checkout
     - attach_workspace:
@@ -99,6 +102,24 @@ web-distribute:
     - run:
         name: Install dependencies
         command: rm -rf node_modules && SKIP_POD_INSTALL=true npm ci
+    - run:
+        name: Verify version
+        command: |
+          cd packages/web
+          environment="<< parameters.environment >>"
+          if [ "$environment" = "prod" ]; then
+            host="audius.co"
+          else
+            host="staging.audius.co"
+          fi
+
+          live_version=$(curl -s https://s3.us-west-1.amazonaws.com/$host/package.json | jq -r '.version')
+          deploying_version=$(jq -r '.version' package.json)
+
+          version_is_ok=$(npx semver -r ">=$live_version" $deploying_version)
+          if [ -z "$version_is_ok" ]; then
+            circleci-agent step halt
+          fi
     - when:
         condition: << parameters.install-license >>
         steps:
@@ -149,6 +170,17 @@ web-deploy-cloudflare:
     #       cd packages/web
     #       mkdir -p sourcemaps/static/js
     #       mv build-<< parameters.build-type >>/static/js/*.map sourcemaps/static/js
+    - run:
+        name: Verify version
+        command: |
+          cd packages/web
+          live_version=$(curl -s https://audius.co/package.json | jq -r '.version')
+          deploying_version=$(jq -r '.version' package.json)
+
+          version_is_ok=$(npx semver -r ">=$live_version" $deploying_version)
+          if [ -z "$version_is_ok" ]; then
+            circleci-agent step halt
+          fi
     - run:
         name: Set up workers site
         command: |

--- a/.circleci/src/commands/@web-commands.yml
+++ b/.circleci/src/commands/@web-commands.yml
@@ -105,24 +105,6 @@ web-distribute:
     - run:
         name: Install dependencies
         command: rm -rf node_modules && SKIP_POD_INSTALL=true npm ci
-    - run:
-        name: Verify version
-        command: |
-          cd packages/web
-          environment="<< parameters.environment >>"
-          if [ "$environment" = "production" ]; then
-            host="audius.co"
-          else
-            host="staging.audius.co"
-          fi
-
-          live_version=$(curl -s https://s3.us-west-1.amazonaws.com/$host/package.json | jq -r '.version')
-          deploying_version=$(jq -r '.version' package.json)
-
-          version_is_ok=$(npx semver -r ">=$live_version" $deploying_version)
-          if [ -z "$version_is_ok" ]; then
-            circleci-agent step halt
-          fi
     - when:
         condition: << parameters.install-license >>
         steps:
@@ -191,17 +173,6 @@ web-deploy-cloudflare:
     #       cd packages/web
     #       mkdir -p sourcemaps/static/js
     #       mv build-<< parameters.build-type >>/static/js/*.map sourcemaps/static/js
-    - run:
-        name: Verify version
-        command: |
-          cd packages/web
-          live_version=$(curl -s https://audius.co/package.json | jq -r '.version')
-          deploying_version=$(jq -r '.version' package.json)
-
-          version_is_ok=$(npx semver -r ">=$live_version" $deploying_version)
-          if [ -z "$version_is_ok" ]; then
-            circleci-agent step halt
-          fi
     - run:
         name: Set up workers site
         command: |

--- a/.circleci/src/jobs/@web-jobs.yml
+++ b/.circleci/src/jobs/@web-jobs.yml
@@ -254,6 +254,7 @@ web-dist-mac-staging:
     - web-distribute:
         build-type: mac-publish
         install-license: true
+        environment: 'stage'
 
 web-dist-win-staging:
   working_directory: ~/audius-protocol
@@ -262,6 +263,7 @@ web-dist-win-staging:
   steps:
     - web-distribute:
         build-type: win-publish
+        environment: 'stage'
 
 web-dist-linux-staging:
   working_directory: ~/audius-protocol
@@ -270,6 +272,7 @@ web-dist-linux-staging:
   steps:
     - web-distribute:
         build-type: linux-publish
+        environment: 'stage'
 
 web-dist-mac-production:
   working_directory: ~/audius-protocol
@@ -284,6 +287,7 @@ web-dist-mac-production:
     - web-distribute:
         build-type: mac-publish-production
         install-license: true
+        environment: 'prod'
 
 web-dist-win-production:
   working_directory: ~/audius-protocol
@@ -292,6 +296,7 @@ web-dist-win-production:
   steps:
     - web-distribute:
         build-type: win-publish-production
+        environment: 'prod'
 
 web-dist-linux-production:
   working_directory: ~/audius-protocol
@@ -300,3 +305,4 @@ web-dist-linux-production:
   steps:
     - web-distribute:
         build-type: linux-publish-production
+        environment: 'prod'

--- a/.circleci/src/jobs/@web-jobs.yml
+++ b/.circleci/src/jobs/@web-jobs.yml
@@ -254,7 +254,8 @@ web-dist-mac-staging:
     - web-distribute:
         build-type: mac-publish
         install-license: true
-        environment: 'stage'
+        environment: 'staging'
+        os: 'mac'
 
 web-dist-win-staging:
   working_directory: ~/audius-protocol
@@ -263,7 +264,8 @@ web-dist-win-staging:
   steps:
     - web-distribute:
         build-type: win-publish
-        environment: 'stage'
+        environment: 'staging'
+        os: 'win'
 
 web-dist-linux-staging:
   working_directory: ~/audius-protocol
@@ -272,7 +274,8 @@ web-dist-linux-staging:
   steps:
     - web-distribute:
         build-type: linux-publish
-        environment: 'stage'
+        environment: 'staging'
+        os: 'linux'
 
 web-dist-mac-production:
   working_directory: ~/audius-protocol
@@ -287,7 +290,8 @@ web-dist-mac-production:
     - web-distribute:
         build-type: mac-publish-production
         install-license: true
-        environment: 'prod'
+        environment: 'production'
+        os: 'mac'
 
 web-dist-win-production:
   working_directory: ~/audius-protocol
@@ -296,7 +300,8 @@ web-dist-win-production:
   steps:
     - web-distribute:
         build-type: win-publish-production
-        environment: 'prod'
+        environment: 'production'
+        os: 'win'
 
 web-dist-linux-production:
   working_directory: ~/audius-protocol
@@ -305,4 +310,5 @@ web-dist-linux-production:
   steps:
     - web-distribute:
         build-type: linux-publish-production
-        environment: 'prod'
+        environment: 'production'
+        os: 'linux'

--- a/.circleci/src/workflows/mobile.yml
+++ b/.circleci/src/workflows/mobile.yml
@@ -66,7 +66,9 @@ jobs:
           only: /(^release.*)$/
 
   - mobile-deploy-codepush-production-ios-if-ota-release:
-      context: Audius Mobile Client
+      context:
+        - Audius Mobile Client
+        - slack-secrets
       requires:
         - mobile-hold-deploy-codepush-ios-if-ota-release
       filters:
@@ -130,7 +132,9 @@ jobs:
           only: /(^release.*)$/
 
   - mobile-deploy-codepush-production-android-if-ota-release:
-      context: Audius Mobile Client
+      context:
+        - Audius Mobile Client
+        - slack-secrets
       requires:
         - mobile-hold-deploy-codepush-android-if-ota-release
       filters:
@@ -146,7 +150,9 @@ jobs:
           only: /(^release.*)$/
 
   - mobile-deploy-saga-dapp-store:
-      context: Audius Mobile Client
+      context:
+        - Audius Mobile Client
+        - slack-secrets
       requires:
         - mobile-hold-deploy-saga-dapp-store
       filters:

--- a/.circleci/src/workflows/web.yml
+++ b/.circleci/src/workflows/web.yml
@@ -50,7 +50,9 @@ jobs:
           only: /^main$/
 
   - web-deploy-staging-cloudflare:
-      context: Audius Client
+      context:
+        - Audius Client
+        - slack-secrets
       requires:
         - web-build-staging
       filters:
@@ -91,7 +93,9 @@ jobs:
         branches:
           only: /(^release.*)$/
   - web-deploy-production-cloudflare:
-      context: Audius Client
+      context:
+        - Audius Client
+        - slack-secrets
       requires:
         - web-hold-production
       filters:
@@ -112,6 +116,7 @@ jobs:
       context:
         - Audius Client
         - Vercel
+        - slack-secrets
       requires:
         - web-build-staging
       filters:
@@ -121,6 +126,7 @@ jobs:
       context:
         - Audius Client
         - Vercel
+        - slack-secrets
       requires:
         - web-build-staging
       filters:
@@ -130,6 +136,7 @@ jobs:
       context:
         - Audius Client
         - Vercel
+        - slack-secrets
       requires:
         - web-build-staging
       filters:
@@ -148,6 +155,7 @@ jobs:
       context:
         - Audius Client
         - Vercel
+        - slack-secrets
       requires:
         - web-hold-dist-mac-production
       filters:
@@ -164,6 +172,7 @@ jobs:
       context:
         - Audius Client
         - Vercel
+        - slack-secrets
       requires:
         - web-hold-dist-win-production
       filters:
@@ -180,6 +189,7 @@ jobs:
       context:
         - Audius Client
         - Vercel
+        - slack-secrets
       requires:
         - web-hold-dist-linux-production
       filters:


### PR DESCRIPTION
### Description

Curious for feedback

* Web & desktop won't push if you're trying to push a version behind. In the case where this is necessary we can always comment out the check and push it. Blocking mobile upload is a little trickier because it requires getting the released version and also dealing with codepush considerations
* Add slack notifs after deploys to web, mobile, and desktop. Borrowed from daily deploy bot code @theoilie wrote

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._

Tested by running commands in an ssh'd instance on circleci. Probably not perfect, but will iterate as it gets used.