### PR TITLE
[INF-542] Fix vite_public_url

### DIFF
--- a/packages/web/vite.config.ts
+++ b/packages/web/vite.config.ts
@@ -12,9 +12,10 @@ export default defineConfig(({ mode }) => {
   const env = loadEnv(mode, process.cwd(), 'VITE_')
   const port = parseInt(env.VITE_PORT ?? '3000')
   const analyze = env.VITE_BUNDLE_ANALYZE === 'true'
+  env.VITE_PUBLIC_URL = env.VITE_PUBLIC_URL ?? ''
 
   return {
-    base: env.VITE_PUBLIC_URL ?? '/',
+    base: env.VITE_PUBLIC_URL,
     build: {
       outDir: 'build',
       sourcemap: true,


### PR DESCRIPTION
### Description

We were seeing `VITE_PUBLIC_URL` undefined on the landing page. This is mainly used for the frontend demo site, because the whole app is nested at a path for each CI branch. But in the case were it wasn't set, errors were being thrown. This pr defaults `VITE_PUBLIC_URL` to empty string, which is the same behavior we had before with react `PUBLIC_URL`

### How Has This Been Tested?

Testes that routing works properly, including landing page. Will confirm the frontend demo works once it builds!