### PR TITLE
Fix emotion and css-modules specificity

### DIFF
--- a/packages/harmony/src/foundations/theme/ThemeProvider.tsx
+++ b/packages/harmony/src/foundations/theme/ThemeProvider.tsx
@@ -1,9 +1,18 @@
 import type { ReactNode } from 'react'
 
-import { ThemeProvider as EmotionThemeProvider } from '@emotion/react'
+import createCache from '@emotion/cache'
+import {
+  CacheProvider,
+  ThemeProvider as EmotionThemeProvider
+} from '@emotion/react'
 
 import { themes } from './theme'
 import type { Theme } from './types'
+
+const harmonyCache = createCache({
+  key: 'harmony',
+  prepend: true
+})
 
 type ThemeProviderProps = {
   theme: Theme
@@ -14,8 +23,10 @@ export const ThemeProvider = (props: ThemeProviderProps) => {
   const { children, theme } = props
 
   return (
-    <EmotionThemeProvider theme={themes[theme]}>
-      {children}
-    </EmotionThemeProvider>
+    <CacheProvider value={harmonyCache}>
+      <EmotionThemeProvider theme={themes[theme]}>
+        {children}
+      </EmotionThemeProvider>
+    </CacheProvider>
   )
 }


### PR DESCRIPTION
### Description

Fixes issue where css-module classNames at same level of specificity as emotion classNames would always be overridden. This fix ensures emotion styles get "prepended" to the "body" tag, ensuring css-module classnames always come after, resulting in css-modules always overriding.


### How was this tested

After applying this code, i created a css module file like this:

```css
.root {
  background-color: green;
}
```
and then used in on the harmony button like so: 
```tsx
import {Button} from '@audius/harmony`
import styles from './Test.module.css'

...
<Button className={styles.root}>Green!</Button>
```

![Uploading image.png…]()
