### PR TITLE
Fix wrong bg color in mobile ready to claim pill

### DIFF
--- a/packages/mobile/src/screens/audio-screen/Panel.tsx
+++ b/packages/mobile/src/screens/audio-screen/Panel.tsx
@@ -191,7 +191,9 @@ export const Panel = ({
     >
       <View style={styles.pillContainer}>
         {needsDisbursement ? (
-          <Text style={styles.pillMessage}>{messages.readyToClaim}</Text>
+          <Text style={[styles.pillMessage, styles.readyToClaimPill]}>
+            {messages.readyToClaim}
+          </Text>
         ) : showNewChallengePill ? (
           <LinearGradient
             useAngle={true}


### PR DESCRIPTION
### Description
Unclear how this happened but this style was missing from the pill so it didn't have the purple background.

### How Has This Been Tested?

![Simulator Screenshot - iPhone 14 Pro - 2023-11-09 at 15 12 31](https://github.com/AudiusProject/audius-protocol/assets/3893871/20833710-c2e9-4b2a-a257-2736d2d76411)
