### PR TITLE
[C-3341] Clean up Harmony Button docs

### DIFF
--- a/packages/harmony/src/components/button/Button/Button.mdx
+++ b/packages/harmony/src/components/button/Button/Button.mdx
@@ -50,16 +50,11 @@ import * as ButtonStories from './Button.stories'
 
 ### Sizes
 
-Fixed height: 32px, 48px, 64px
-
 <Canvas>
   <Story of={ButtonStories.Sizes} />
 </Canvas>
 
 ### States
-
-Hover: transform scale: 1.04x, ease-out curve, 120ms
-Pressed: transform scale: 0.98x, ease-out curve, 120ms
 
 <Canvas>
   <Story of={ButtonStories.States} />
@@ -113,29 +108,40 @@ A link that looks like a button. Useful for buttons that trigger navigation
       positive: {
         description: 'Use 1 or 2 words, no longer than 4 words',
         size: 'small',
-        component: <Button>Sign Up!</Button>,
+        component: <Button>Sign Up!</Button>
       },
       negative: {
         description: 'Don’t use more than 20 characters including spaces.',
         size: 'small',
-        component: <Button>Get started and sign up for Audius</Button>,
+        component: <Button>Get started and sign up for Audius</Button>
       }
     },
     {
       positive: {
         description: 'Use title-case',
         size: 'small',
-        component: <Button>Get Started</Button>,
+        component: <Button>Get Started</Button>
       },
       negative: {
-        description: 'Don’t use all cap in small or medium buttons (exception: “PLAY”)',
+        description:
+          'Don’t use all cap in small or medium buttons (exception: “PLAY”)',
         size: 'small',
         component: (
           <Flex gap='l' alignItems='center'>
-            <Button size={ButtonSize.SMALL} style={{textTransform: 'uppercase'}}>Get Started</Button>
-            <Button size={ButtonSize.DEFAULT} style={{textTransform: 'uppercase'}}>Get Started</Button>
+            <Button
+              size={ButtonSize.SMALL}
+              style={{ textTransform: 'uppercase' }}
+            >
+              Get Started
+            </Button>
+            <Button
+              size={ButtonSize.DEFAULT}
+              style={{ textTransform: 'uppercase' }}
+            >
+              Get Started
+            </Button>
           </Flex>
-        ),
+        )
       }
     },
     {
@@ -147,53 +153,48 @@ A link that looks like a button. Useful for buttons that trigger navigation
             <Button variant={ButtonType.SECONDARY}>Go Back</Button>
             <Button>Continue</Button>
           </Flex>
-        ),
+        )
       },
       negative: {
-        description: 'Don’t use tertiary as the 3rd level of button hierarchy. Use plain instead',
+        description: 'Don’t use tertiary as the secondary action',
         size: 'small',
         component: (
           <Flex gap='l'>
             <Button variant={ButtonType.TERTIARY}>Go Back</Button>
             <Button>Continue</Button>
           </Flex>
-        ),
+        )
       }
     },
     {
       positive: {
-        description: 'Use teriary button exclusively on photos or colored backgrounds.',
+        description:
+          'Use teriary button exclusively on photos or colored backgrounds. ',
         size: 'small',
-        component: <Button>Get Started</Button>,
-      },
-      negative: {
-        description: 'Never place primary buttons actaions side-by-side ',
-        size: 'small',
-        component: <Button>Get Started</Button>,
-      }
-    },
-    {
-      positive: {
-        description: 'Use teriary button exclusively on photos or colored backgrounds. ',
         component: (
-          <Flex 
-            w='100%' 
-            justifyContent='center' 
-            p='2xl' 
+          <Flex
+            h='100%'
+            w='100%'
+            alignItems='center'
+            justifyContent='center'
             style={{
+              position: 'absolute',
+              top: 0,
+              left: 0,
               background: `url(${buttonBackground})`,
               backgroundSize: 'cover',
               backgroundPosition: 'center'
-            }}>
+            }}
+          >
             <Button variant={ButtonType.TERTIARY} iconLeft={IconCamera}>
               Change Cover Photo
             </Button>
           </Flex>
-        ),
-        css: {padding: 0}
+        )
       },
       negative: {
         description: 'Never place primary buttons actions side-by-side ',
+        size: 'small',
         component: (
           <Flex gap='l'>
             <Button>Go Back</Button>
@@ -201,9 +202,8 @@ A link that looks like a button. Useful for buttons that trigger navigation
           </Flex>
         )
       }
-    },
-
-]}
+    }
+  ]}
 />
 
 ## Related components

--- a/packages/harmony/src/components/button/Button/Button.stories.tsx
+++ b/packages/harmony/src/components/button/Button/Button.stories.tsx
@@ -2,7 +2,7 @@ import { expect } from '@storybook/jest'
 import type { Meta, StoryObj } from '@storybook/react'
 import { within } from '@storybook/testing-library'
 
-import { Box, Flex } from 'components/layout'
+import { Flex } from 'components/layout'
 import { Text } from 'components/text'
 import { IconArrowLeft, IconArrowRight } from 'icons'
 
@@ -41,7 +41,6 @@ export const Sizes: Story = {
         <Button size={ButtonSize.SMALL}>Small</Button>
         <Text>32px</Text>
       </Flex>
-
       <Flex direction='column' alignItems='center' gap='m'>
         <Button size={ButtonSize.DEFAULT}>Medium</Button>
         <Text>48px</Text>
@@ -126,14 +125,17 @@ export const Icons: Story = {
 
 export const LoadingState: Story = {
   render: () => (
-    <Flex justifyContent='space-between'>
-      <Flex direction='column' gap='2xl'>
-        <Button color='lightGreen'>Buy $1.99</Button>
-        <Button isLoading>Purchasing</Button>
-      </Flex>
-      <Box alignSelf='flex-end'>
-        <Text>Show loading state on click</Text>
-      </Box>
+    <Flex gap='2xl'>
+      <Button isLoading>Purchasing</Button>
+      <Button variant={ButtonType.SECONDARY} isLoading>
+        Uploading
+      </Button>
+      <Button variant={ButtonType.TERTIARY} isLoading>
+        Updating
+      </Button>
+      <Button variant={ButtonType.DESTRUCTIVE} isLoading>
+        Removing
+      </Button>
     </Flex>
   )
 }
@@ -141,79 +143,16 @@ export const LoadingState: Story = {
 export const ColorPropApplied: Story = {
   render: () => (
     <Flex gap='2xl'>
-      <Flex direction='column' gap='m' flex={1}>
-        <Box>
-          <Button color='blue'>Default</Button>
-        </Box>
-        <Flex as='ul' direction='column' gap='s'>
-          <Text asChild>
-            <li>Background: Color Value</li>
-          </Text>
-          <Text asChild>
-            <li>Shadow: Near</li>
-          </Text>
-          <Text asChild>
-            <li>Transform Scale: 1x</li>
-          </Text>
-        </Flex>
-      </Flex>
-
-      <Flex direction='column' gap='m' flex={1}>
-        <Box>
-          <Button color='blue' _isHovered>
-            Hover
-          </Button>
-        </Box>
-        <Flex as='ul' direction='column' gap='s'>
-          <Text asChild>
-            <li>Background: Color Value + White Overlay @ 10% Opacity</li>
-          </Text>
-          <Text asChild>
-            <li>Shadow: Mid</li>
-          </Text>
-          <Text asChild>
-            <li>Transform Scale: 1.04x</li>
-          </Text>
-        </Flex>
-      </Flex>
-
-      <Flex direction='column' gap='m' flex={1}>
-        <Box>
-          <Button color='blue' _isPressed>
-            Pressed
-          </Button>
-        </Box>
-        <Flex as='ul' direction='column' gap='s'>
-          <Text asChild>
-            <li>Background: Color Value + Black Overlay @ 20% Opacity</li>
-          </Text>
-          <Text asChild>
-            <li>Shadow: None</li>
-          </Text>
-          <Text asChild>
-            <li>Transform Scale: 0.98x</li>
-          </Text>
-        </Flex>
-      </Flex>
-
-      <Flex direction='column' gap='m' flex={1}>
-        <Box>
-          <Button color='blue' disabled>
-            Disabled
-          </Button>
-        </Box>
-        <Flex as='ul' direction='column' gap='s'>
-          <Text asChild>
-            <li>Background: n-150</li>
-          </Text>
-          <Text asChild>
-            <li>Shadow: None</li>
-          </Text>
-          <Text asChild>
-            <li>Transform Scale: 1x</li>
-          </Text>
-        </Flex>
-      </Flex>
+      <Button color='blue'>Default</Button>
+      <Button color='blue' _isHovered>
+        Hover
+      </Button>
+      <Button color='blue' _isPressed>
+        Pressed
+      </Button>
+      <Button color='blue' disabled>
+        Disabled
+      </Button>
     </Flex>
   )
 }

--- a/packages/harmony/src/components/button/Button/Button.tsx
+++ b/packages/harmony/src/components/button/Button/Button.tsx
@@ -158,7 +158,7 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
 
     const hoverStyles: CSSObject = {
       boxShadow: shadows.mid,
-      '::before': {
+      '&::before': {
         backgroundColor: 'rgba(255, 255, 255, 0.2)'
       }
     }

--- a/packages/harmony/src/storybook/components/ComponentRule.tsx
+++ b/packages/harmony/src/storybook/components/ComponentRule.tsx
@@ -68,6 +68,7 @@ export const ComponentRule = (props: ComponentRuleProps) => {
           border: `1px solid ${borderColor}`,
           borderRadius: cornerRadius.m,
           boxSizing: 'content-box',
+          overflow: 'hidden',
           '& img': {
             objectFit: 'scale-down',
             width: '100%',


### PR DESCRIPTION
### Description

Made fixes from harmony docs discussion:
- Remove text descriptions above stories
- Loading state story should just be the button in loading state
- Remove css descriptions from ‘color prop applied' stories
- Fix do/don’t height in the last pair
- Tertiary button unclear

### How Has This Been Tested?

Looks good in storybook
