### PR TITLE
[C-3340] Fix do's and don'ts styling

### DIFF
--- a/packages/harmony/src/storybook/components/ComponentRule.tsx
+++ b/packages/harmony/src/storybook/components/ComponentRule.tsx
@@ -44,12 +44,12 @@ export const ComponentRule = (props: ComponentRuleProps) => {
     <Flex
       as='section'
       direction='column'
-      gap='xl'
+      gap='l'
       flex={1}
       css={{ minWidth: 400 }}
     >
-      <Flex direction='column' gap='m'>
-        <Text variant='title' tag='h4' css={{ textTransform: 'uppercase' }}>
+      <Flex direction='column' gap='s'>
+        <Text variant='title' tag='h4'>
           <TitleIcon css={{ marginRight: '4px' }} /> {title}
         </Text>
         <Text tag='section' css={{ height: '40px', overflow: 'hidden' }}>


### PR DESCRIPTION
### Description

- Un-capitalize title
- Update spacing between title and description, description and example

Didn't find a good way to make the gap between description and example variable depending on length of text, so just hedged and took the gap down a bit.

<img width="1046" alt="image" src="https://github.com/AudiusProject/audius-protocol/assets/2358254/6064aca8-b370-4802-b79d-75936e59d404">

### How Has This Been Tested?

storybook