### PR TITLE
[C-3343] Simplify and fix theme switcher

### DIFF
--- a/packages/harmony/.storybook/docs.tsx
+++ b/packages/harmony/.storybook/docs.tsx
@@ -5,34 +5,17 @@ import { ThemeProvider } from '../src/foundations/theme'
 import { addons } from '@storybook/preview-api'
 import { UPDATE_DARK_MODE_EVENT_NAME, useDarkMode } from 'storybook-dark-mode'
 
-let previousTheme = undefined
-
 export const HarmonyDocsContainer = (props: DocsContainerProps) => {
   // @ts-ignore globals are available
   const currentTheme = props.context.store.globals.globals.theme || 'day'
   const isDark = useDarkMode()
 
   useEffect(() => {
-    if (!previousTheme) {
-      if (isDark && currentTheme === 'day') {
-        addons.getChannel().emit(UPDATE_DARK_MODE_EVENT_NAME)
-      } else if (!isDark && currentTheme !== 'day') {
-        addons.getChannel().emit(UPDATE_DARK_MODE_EVENT_NAME)
-      }
-    } else {
-      if (
-        (currentTheme === 'dark' || currentTheme === 'matrix') &&
-        previousTheme === 'day'
-      ) {
-        addons.getChannel().emit(UPDATE_DARK_MODE_EVENT_NAME)
-      } else if (
-        (previousTheme === 'dark' || previousTheme === 'matrix') &&
-        currentTheme === 'day'
-      ) {
-        addons.getChannel().emit(UPDATE_DARK_MODE_EVENT_NAME)
-      }
+    if (isDark && currentTheme === 'day') {
+      addons.getChannel().emit(UPDATE_DARK_MODE_EVENT_NAME)
+    } else if (!isDark && currentTheme !== 'day') {
+      addons.getChannel().emit(UPDATE_DARK_MODE_EVENT_NAME)
     }
-    previousTheme = currentTheme
   }, [currentTheme])
 
   return (

--- a/packages/harmony/.storybook/docs.tsx
+++ b/packages/harmony/.storybook/docs.tsx
@@ -1,16 +1,45 @@
-import React from 'react'
+import React, { useEffect } from 'react'
 import { harmonyDocsThemes } from '../src/storybook/theme'
 import { DocsContainer, DocsContainerProps } from '@storybook/addon-docs'
-import { useDarkMode } from 'storybook-dark-mode'
 import { ThemeProvider } from '../src/foundations/theme'
+import { addons } from '@storybook/preview-api'
+import { UPDATE_DARK_MODE_EVENT_NAME, useDarkMode } from 'storybook-dark-mode'
+
+let previousTheme = undefined
 
 export const HarmonyDocsContainer = (props: DocsContainerProps) => {
   // @ts-ignore globals are available
   const currentTheme = props.context.store.globals.globals.theme || 'day'
+  const isDark = useDarkMode()
+
+  useEffect(() => {
+    if (!previousTheme) {
+      if (isDark && currentTheme === 'day') {
+        addons.getChannel().emit(UPDATE_DARK_MODE_EVENT_NAME)
+      } else if (!isDark && currentTheme !== 'day') {
+        addons.getChannel().emit(UPDATE_DARK_MODE_EVENT_NAME)
+      }
+    } else {
+      if (
+        (currentTheme === 'dark' || currentTheme === 'matrix') &&
+        previousTheme === 'day'
+      ) {
+        addons.getChannel().emit(UPDATE_DARK_MODE_EVENT_NAME)
+      } else if (
+        (previousTheme === 'dark' || previousTheme === 'matrix') &&
+        currentTheme === 'day'
+      ) {
+        addons.getChannel().emit(UPDATE_DARK_MODE_EVENT_NAME)
+      }
+    }
+    previousTheme = currentTheme
+  }, [currentTheme])
 
   return (
-    <ThemeProvider theme={currentTheme}>
-      <DocsContainer {...props} theme={harmonyDocsThemes[currentTheme]} />
-    </ThemeProvider>
+    <div id='harmony-root' data-theme={currentTheme}>
+      <ThemeProvider theme={currentTheme}>
+        <DocsContainer {...props} theme={harmonyDocsThemes[currentTheme]} />
+      </ThemeProvider>
+    </div>
   )
 }

--- a/packages/harmony/.storybook/manager-head.html
+++ b/packages/harmony/.storybook/manager-head.html
@@ -51,4 +51,16 @@
     color: var(--harmony-docs-icon-selected-color) !important;
   }
 
+  /**
+   * Remove the storybook-dark-mode button since we are only using
+   * @storybook/addon-theme
+  */
+  button[title="Change theme to dark mode"] {
+    display: none;
+  }
+
+  button[title="Change theme to light mode"] {
+    display: none;
+  }
+
 </style>

--- a/packages/harmony/.storybook/preview.ts
+++ b/packages/harmony/.storybook/preview.ts
@@ -2,6 +2,7 @@ import {
   withThemeByDataAttribute,
   withThemeFromJSXProvider
 } from '@storybook/addon-themes'
+import { ComponentRules, RelatedComponents } from '../src/storybook/components'
 
 // This file is used to configure all stories
 import './global.css'
@@ -20,7 +21,7 @@ export const parameters = {
   darkMode: {
     light: harmonyDocsThemes.day,
     dark: harmonyDocsThemes.dark,
-    stylePreview: true
+    classTarget: 'html'
   }
 }
 

--- a/packages/harmony/src/components/avatar/Avatar.mdx
+++ b/packages/harmony/src/components/avatar/Avatar.mdx
@@ -32,6 +32,7 @@ import * as AvatarStories from './Avatar.stories'
   ## Overview
   <Description />
 </Heading>
+
 <Primary />
 
 ## Props

--- a/packages/harmony/src/components/avatar/Avatar.tsx
+++ b/packages/harmony/src/components/avatar/Avatar.tsx
@@ -2,6 +2,10 @@ import { CSSObject, useTheme } from '@emotion/react'
 
 import type { AvatarProps } from './types'
 
+/*
+ * The Avatar component is a visual indicator used to quickly identify a
+ * user’s account.
+ */
 export const Avatar = (props: AvatarProps) => {
   const {
     src,

--- a/packages/harmony/src/storybook/components/CardLink.tsx
+++ b/packages/harmony/src/storybook/components/CardLink.tsx
@@ -1,4 +1,6 @@
-import { Flex, Text, Link, IconComponent } from 'components'
+import { Flex, Text, IconComponent } from 'components'
+
+import { Link } from './Link'
 
 type CardLinkProps = {
   icon?: IconComponent

--- a/packages/harmony/src/storybook/components/ComponentRules.tsx
+++ b/packages/harmony/src/storybook/components/ComponentRules.tsx
@@ -28,7 +28,7 @@ export const ComponentRules = (props: ComponentRulesProps) => {
   const { rules = [] } = props
 
   return (
-    <Flex as='article' direction='column' gap='3xl' mt='3xl'>
+    <Flex as='article' direction='column' gap='3xl'>
       {rules.map((rule, index) => {
         const key = `rule-${index}`
 

--- a/packages/harmony/src/storybook/components/Subtitle.tsx
+++ b/packages/harmony/src/storybook/components/Subtitle.tsx
@@ -1,6 +1,6 @@
 import { styled } from '@storybook/theming'
 
-export const Subtitle = styled.span(({ theme }) => {
+export const Subtitle = styled.p(({ theme }) => {
   const css = { fontSize: `${theme.typography.size.m2}px !important` }
   return { ...css, p: css }
 })

--- a/packages/harmony/src/storybook/theme/colors.css
+++ b/packages/harmony/src/storybook/theme/colors.css
@@ -5,7 +5,8 @@
  * keyword. The number signifies an increasing value for the property, e.g.
  * -dark-2 is darker than -dark-1.
  */
-html {
+html,
+#harmony-root[data-theme='day'] {
   --harmony-docs-violet-v050: #f7f6fc;
   --harmony-docs-violet-v100: #f1efff;
   --harmony-docs-violet-v200: #c7bffd;
@@ -32,14 +33,19 @@ html {
   --harmony-docs-icon-color: var(--harmony-docs-violet-v400);
   --harmony-docs-icon-selected-color: var(--harmony-docs-violet-v050);
   --harmony-docs-deprecated-color: #ff2e2e;
+  color: var(--harmony-docs-text);
 }
 
 html[data-theme='dark'],
-body.dark:not(.sb-show-main) {
+html[data-theme='matrix'],
+#harmony-root[data-theme='dark'],
+#harmony-root[data-theme='matrix'],
+html.dark {
   --harmony-docs-text: var(--harmony-docs-neutral-n050);
   --harmony-docs-text-muted: var(--harmony-docs-neutral-n200);
   --harmony-docs-bar-text-color: var(--harmony-docs-violet-v050);
   --harmony-docs-bar-selected-color: var(--harmony-docs-violet-v300);
   --harmony-docs-bar-hover-color: var(--harmony-docs-violet-v500);
   --harmony-docs-icon-color: var(--harmony-docs-violet-v300);
+  color: var(--harmony-docs-text);
 }


### PR DESCRIPTION
### Description

Improves theme switcher by consolidating `storybook-dark-mode` and `@storybook/addon-themes` into a single user interface (uses addon-themes), but under the hood uses both. Now when user switches to dark or matrix mode, the entire app changes themes appropriately!

Also fixes underlying issue with dark-mode and addon-themes plugins where they weren't consistently updating html/body tags, which are needed for css-variables to change to light/dark mode. We are using our own version now with a div wrapper + data-theme attribute. Kinda annoying but nice and consistent now

https://github.com/AudiusProject/audius-protocol/assets/8230000/bf5220dd-5554-4027-bcab-f223a32d5cbe


