### PR TITLE
Add sign up white screen progress header C-3320

### DIFF
--- a/packages/web/src/components/stepped-progress/SteppedProgress.module.css
+++ b/packages/web/src/components/stepped-progress/SteppedProgress.module.css
@@ -1,0 +1,17 @@
+.connector {
+  width: var(--harmony-spacing-xl);
+  min-width: unset;
+}
+
+.underline {
+  position: absolute;
+  bottom: -3px;
+  display: block;
+  height: 3px;
+  border-bottom-right-radius: 5px;
+  border-bottom-left-radius: 5px;
+  background-color: var(--harmony-primary);
+  transition-property: all;
+  transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
+  transition-duration: 300ms;
+}

--- a/packages/web/src/components/stepped-progress/SteppedProgress.tsx
+++ b/packages/web/src/components/stepped-progress/SteppedProgress.tsx
@@ -1,0 +1,103 @@
+import { forwardRef, useEffect, useRef, useState } from 'react'
+
+import { Flex, IconComponent, Text } from '@audius/harmony'
+
+import { Divider } from 'components/divider'
+
+import styles from './SteppedProgress.module.css'
+
+type StepProps = {
+  icon: IconComponent
+  label: string
+  isActive: boolean
+}
+
+const Step = forwardRef<HTMLDivElement, StepProps>(
+  (
+    {
+      icon: Icon,
+      label,
+      isActive
+    }: {
+      icon: IconComponent
+      label: string
+      isActive: boolean
+    },
+    ref
+  ) => {
+    return (
+      <Flex ref={ref} gap='xs' ph='s' pv='m' alignItems='center'>
+        <Icon size='l' color={isActive ? 'default' : 'subdued'} />
+        <Text
+          variant='label'
+          size='m'
+          color={isActive ? 'default' : 'subdued'}
+          strength='strong'
+        >
+          {label}
+        </Text>
+      </Flex>
+    )
+  }
+)
+
+type StepData = {
+  key: string
+  label: string
+  icon: IconComponent
+}
+
+type SteppedProgressProps = {
+  steps: StepData[]
+  activeStep: string
+}
+
+export const SteppedProgress = ({
+  steps,
+  activeStep
+}: SteppedProgressProps) => {
+  const stepsRef = useRef<HTMLDivElement[]>([])
+  const [stepUnderlineWidth, setStepUnderlineWidth] = useState(0)
+  const [stepUnderlineLeft, setStepUnderlineLeft] = useState(0)
+  useEffect(() => {
+    function setTabPosition() {
+      const currentTab =
+        stepsRef.current[steps.findIndex((s) => s.key === activeStep)]
+      setStepUnderlineLeft(currentTab?.offsetLeft ?? 0)
+      setStepUnderlineWidth(currentTab?.clientWidth ?? 0)
+    }
+
+    setTabPosition()
+    window.addEventListener('resize', setTabPosition)
+
+    return () => window.removeEventListener('resize', setTabPosition)
+  }, [activeStep, steps])
+  return (
+    <>
+      <Flex alignItems='center' gap='s'>
+        {steps.map((s, i) => (
+          <>
+            <Step
+              ref={(el) => {
+                if (el) {
+                  stepsRef.current[i] = el
+                }
+              }}
+              icon={s.icon}
+              label={s.label}
+              isActive={activeStep === s.key}
+              key={s.key}
+            />
+            {i !== steps.length - 1 ? (
+              <Divider className={styles.connector} variant='default' />
+            ) : null}
+          </>
+        ))}
+      </Flex>
+      <span
+        className={styles.underline}
+        style={{ left: stepUnderlineLeft, width: stepUnderlineWidth }}
+      />
+    </>
+  )
+}

--- a/packages/web/src/pages/sign-up-page/SignUpRootPage.tsx
+++ b/packages/web/src/pages/sign-up-page/SignUpRootPage.tsx
@@ -15,6 +15,7 @@ import {
   TRENDING_PAGE
 } from 'utils/route'
 
+import { ProgressHeader } from './components/ProgressHeader'
 import { CreatePasswordPage } from './pages/CreatePasswordPage'
 import { FinishProfilePage } from './pages/FinishProfilePage'
 import { PickHandlePage } from './pages/PickHandlePage'
@@ -110,17 +111,37 @@ export const SignUpRootPage = () => {
         <SignUpRoute exact path={SIGN_UP_PASSWORD_PAGE}>
           <CreatePasswordPage />
         </SignUpRoute>
-        <SignUpRoute exact path={SIGN_UP_HANDLE_PAGE}>
-          <PickHandlePage />
-        </SignUpRoute>
-        <SignUpRoute exact path={SIGN_UP_FINISH_PROFILE_PAGE}>
-          <FinishProfilePage />
-        </SignUpRoute>
-        <SignUpRoute exact path={SIGN_UP_GENRES_PAGE}>
-          <SelectGenrePage />
-        </SignUpRoute>
-        <SignUpRoute exact path={SIGN_UP_ARTISTS_PAGE}>
-          <SelectArtistsPage />
+        {/* White screen routes */}
+        <SignUpRoute
+          exact
+          path={[
+            SIGN_UP_HANDLE_PAGE,
+            SIGN_UP_FINISH_PROFILE_PAGE,
+            SIGN_UP_GENRES_PAGE,
+            SIGN_UP_ARTISTS_PAGE
+          ]}
+        >
+          <ProgressHeader />
+          <Switch>
+            <SignUpRoute exact path={SIGN_UP_HANDLE_PAGE}>
+              <PickHandlePage />
+            </SignUpRoute>
+          </Switch>
+          <Switch>
+            <SignUpRoute exact path={SIGN_UP_FINISH_PROFILE_PAGE}>
+              <FinishProfilePage />
+            </SignUpRoute>
+          </Switch>
+          <Switch>
+            <SignUpRoute exact path={SIGN_UP_GENRES_PAGE}>
+              <SelectGenrePage />
+            </SignUpRoute>
+          </Switch>
+          <Switch>
+            <SignUpRoute exact path={SIGN_UP_ARTISTS_PAGE}>
+              <SelectArtistsPage />
+            </SignUpRoute>
+          </Switch>
         </SignUpRoute>
       </Switch>
     </div>

--- a/packages/web/src/pages/sign-up-page/components/ProgressHeader.module.css
+++ b/packages/web/src/pages/sign-up-page/components/ProgressHeader.module.css
@@ -1,0 +1,12 @@
+.container {
+  height: var(--harmony-spacing-4xl);
+  position: relative;
+  border-bottom: solid 1px var(--harmony-n-150);
+}
+
+.logoContainer {
+  padding-left: inherit;
+  padding-right: inherit;
+  position: absolute;
+  left: 0;
+}

--- a/packages/web/src/pages/sign-up-page/components/ProgressHeader.module.css
+++ b/packages/web/src/pages/sign-up-page/components/ProgressHeader.module.css
@@ -1,7 +1,7 @@
 .container {
   height: var(--harmony-spacing-4xl);
   position: relative;
-  border-bottom: solid 1px var(--harmony-n-150);
+  border-bottom: solid 1px var(--harmony-border-default);
 }
 
 .logoContainer {

--- a/packages/web/src/pages/sign-up-page/components/ProgressHeader.tsx
+++ b/packages/web/src/pages/sign-up-page/components/ProgressHeader.tsx
@@ -1,0 +1,74 @@
+import {
+  Box,
+  Flex,
+  IconAudiusLogoHorizontal,
+  IconComponent,
+  IconNote,
+  IconUser,
+  IconUserFollow
+} from '@audius/harmony'
+import { useRouteMatch } from 'react-router-dom'
+
+import { SteppedProgress } from 'components/stepped-progress/SteppedProgress'
+import {
+  SIGN_UP_ARTISTS_PAGE,
+  SIGN_UP_FINISH_PROFILE_PAGE,
+  SIGN_UP_GENRES_PAGE,
+  SIGN_UP_HANDLE_PAGE
+} from 'utils/route'
+
+import styles from './ProgressHeader.module.css'
+
+type ProgressHeaderStep = 'customize' | 'genres' | 'artists'
+
+const messages = {
+  customize: 'Customize',
+  genres: 'Genres',
+  artists: 'Artists'
+}
+
+const STEPS: {
+  key: ProgressHeaderStep
+  label: string
+  icon: IconComponent
+}[] = [
+  { key: 'customize', label: messages.customize, icon: IconUser },
+  { key: 'genres', label: messages.genres, icon: IconNote },
+  { key: 'artists', label: messages.artists, icon: IconUserFollow }
+]
+
+export const ProgressHeader = () => {
+  const match = useRouteMatch()
+  let activeStep: ProgressHeaderStep
+
+  switch (match.path) {
+    case SIGN_UP_HANDLE_PAGE:
+    case SIGN_UP_FINISH_PROFILE_PAGE:
+      activeStep = 'customize'
+      break
+    case SIGN_UP_GENRES_PAGE:
+      activeStep = 'genres'
+      break
+    case SIGN_UP_ARTISTS_PAGE:
+      activeStep = 'artists'
+      break
+    default:
+      activeStep = 'customize'
+  }
+
+  return (
+    <Flex
+      alignItems='center'
+      justifyContent='center'
+      ph='xl'
+      className={styles.container}
+    >
+      <div className={styles.logoContainer}>
+        <IconAudiusLogoHorizontal height={24} width={100} color='subdued' />
+      </div>
+      <Box alignSelf='flex-end'>
+        <SteppedProgress steps={STEPS} activeStep={activeStep} />
+      </Box>
+    </Flex>
+  )
+}

--- a/packages/web/src/pages/sign-up-page/pages/PickHandlePage.module.css
+++ b/packages/web/src/pages/sign-up-page/pages/PickHandlePage.module.css
@@ -1,3 +1,8 @@
+.container {
+  max-width: 610px;
+  margin: 0 auto;
+}
+
 .hideTwitterButton {
   cursor: pointer;
   background: none;

--- a/packages/web/src/pages/sign-up-page/pages/PickHandlePage.tsx
+++ b/packages/web/src/pages/sign-up-page/pages/PickHandlePage.tsx
@@ -115,51 +115,53 @@ export const PickHandlePage = () => {
   }
 
   return (
-    <Formik
-      innerRef={formikRef}
-      initialValues={initialValues}
-      validationSchema={validationSchema}
-      onSubmit={handleSubmit}
-      validateOnChange={false}
-    >
-      {({ isSubmitting, isValid, isValidating }) => (
-        <Form>
-          <Box>
-            <Flex gap='l' direction='column'>
-              <Box>
-                <Text size='s' variant='label' color='subdued'>
-                  1 {messages.outOf} 2
-                </Text>
+    <Box pv='3xl' className={styles.container}>
+      <Formik
+        innerRef={formikRef}
+        initialValues={initialValues}
+        validationSchema={validationSchema}
+        onSubmit={handleSubmit}
+        validateOnChange={false}
+      >
+        {({ isSubmitting, isValid, isValidating }) => (
+          <Form>
+            <Box>
+              <Flex gap='l' direction='column'>
+                <Box>
+                  <Text size='s' variant='label' color='subdued'>
+                    1 {messages.outOf} 2
+                  </Text>
+                </Box>
+                <Box>
+                  <Text
+                    color='heading'
+                    size='l'
+                    strength='default'
+                    variant='heading'
+                  >
+                    {messages.pickYourHandle}
+                  </Text>
+                </Box>
+                <Box>
+                  <Text size='l' variant='body'>
+                    {messages.handleDescription}
+                  </Text>
+                </Box>
+              </Flex>
+              <Box mt='2xl'>
+                <HandleField />
               </Box>
-              <Box>
-                <Text
-                  color='heading'
-                  size='l'
-                  strength='default'
-                  variant='heading'
-                >
-                  {messages.pickYourHandle}
-                </Text>
-              </Box>
-              <Box>
-                <Text size='l' variant='body'>
-                  {messages.handleDescription}
-                </Text>
-              </Box>
-            </Flex>
-            <Box mt='2xl'>
-              <HandleField />
+              <Button
+                type='submit'
+                disabled={!isValid || isSubmitting}
+                isLoading={isSubmitting || isValidating}
+              >
+                {messages.continue}
+              </Button>
             </Box>
-            <Button
-              type='submit'
-              disabled={!isValid || isSubmitting}
-              isLoading={isSubmitting || isValidating}
-            >
-              {messages.continue}
-            </Button>
-          </Box>
-        </Form>
-      )}
-    </Formik>
+          </Form>
+        )}
+      </Formik>
+    </Box>
   )
 }


### PR DESCRIPTION
### Description
Add the progress header used on the final 4 sign up pages (includes underline animation)

<img width="1486" alt="Screenshot 2023-11-10 at 12 49 36 PM" src="https://github.com/AudiusProject/audius-protocol/assets/36916764/e411d832-3251-4051-93e6-2a3453bd8f45">


### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._
