### PR TITLE
Fix developer app metrics C-3248

### DIFF
--- a/packages/discovery-provider/src/tasks/entity_manager/entity_manager.py
+++ b/packages/discovery-provider/src/tasks/entity_manager/entity_manager.py
@@ -74,6 +74,7 @@ from src.tasks.entity_manager.utils import (
     expect_cid_metadata_json,
     get_record_key,
     parse_metadata,
+    reset_entity_manager_event_tx_context,
     save_cid_metadata,
 )
 from src.utils import helpers
@@ -195,7 +196,7 @@ def entity_manager_update(
                     )
 
                     # update logger context with this tx event
-                    logger.update_context(event["args"])
+                    reset_entity_manager_event_tx_context(logger, event["args"])
 
                     if (
                         params.action == Action.CREATE

--- a/packages/discovery-provider/src/tasks/entity_manager/utils.py
+++ b/packages/discovery-provider/src/tasks/entity_manager/utils.py
@@ -391,6 +391,14 @@ def copy_record(
     return record_copy
 
 
+# Resets all context fields attached to last processed event.
+def reset_entity_manager_event_tx_context(logger: StructuredLogger, eventArgs: dict):
+    logger.update_context(eventArgs)
+    logger.reset_context_key("isApp")
+    logger.reset_context_key("appName")
+    logger.reset_context_key("userHandle")
+
+
 def validate_signer(params: ManageEntityParameters):
     # Ensure the signer is either the user or authorized to perform action for the user
     if params.user_id not in params.existing_records["User"]:


### PR DESCRIPTION
### Description
Before:
EM developer app transactions were being logged incorrectly - see the dashboard below and Sebastian's comment:
```In Top Developer Apps (Writes) AudiusCast is the only app doing writes. The userHandle column is the user that the write is being performed for (this should maybe be changed to the user who owns the app), but the _signer column has a bunch of different signers. Why would there be 11 different signers for a single app?```
https://app.axiom.co/audius-Lu52/dashboards/TsHgf8G40aTneXKE7w/edit/8566e9dd-b1a3-4009-ae98-00a7314a419f

Problem:
Our logging relies on `validate_signer` to add the proper developer app context for each EM event. But `validate_signer` isn't called in all processing flows such as create/delete grant, and we weren't clearing the developer app context after processing each EM event. So sometimes the developer app context would incorrectly stick around for the next event.

Solution:
Clear developer app context after each tx is processed. 

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._
