### PR TITLE
[C-3345] Fix TOC links

### DIFF
--- a/packages/harmony/src/storybook/components/TypographyPanel.tsx
+++ b/packages/harmony/src/storybook/components/TypographyPanel.tsx
@@ -36,7 +36,9 @@ export const TypographyCard = (props: TypographyCardProps) => {
         {strength ? `-${strength}` : ''}
       </Text>
       <Unstyled>
-        <Text {...props}>Ag</Text>
+        <Text tag='p' {...props}>
+          Ag
+        </Text>
       </Unstyled>
       <Text>
         Font Size: {fontSize}px, Line-height: {lineHeight}, Spacing:{' '}


### PR DESCRIPTION
### Description

Fixes odd issue on typography page where some of the text elements render h3, which then gets added into TOC links. Fix was to update all underlying tags to 'p' for that doc