### PR TITLE
[C-3265] Ensure text-input doesn't need explicit role

### DIFF
--- a/packages/harmony/src/components/input/TextInput/TextInput.mdx
+++ b/packages/harmony/src/components/input/TextInput/TextInput.mdx
@@ -11,7 +11,11 @@ import {
 
 import { Flex } from 'components'
 import { IconSearch } from 'icons'
-import { ComponentRules, RelatedComponents } from 'storybook/components'
+import {
+  Heading,
+  ComponentRules,
+  RelatedComponents
+} from 'storybook/components'
 
 import { TextInput } from './TextInput'
 import * as TextInputStories from './TextInput.stories'
@@ -57,15 +61,21 @@ import { TextInputSize } from './types'
 
 <Canvas of={TextInputStories.AssistiveText} />
 
+<Heading>
 ### Validation and counter
 
 Use validation to give feedback when an invalid input is provided. The validation error should appear when the user is done typing and out of focus.
 
+</Heading>
+
 <Canvas of={TextInputStories.Validation} />
 
+<Heading>
 ### Special Inputs
 
 An input in which the trailing and leading icons are replaced with type (Title-large) and are positioned below the input’s label.
+
+</Heading>
 
 <Canvas of={TextInputStories.SpecialInputs} />
 

--- a/packages/harmony/src/components/input/TextInput/TextInput.stories.tsx
+++ b/packages/harmony/src/components/input/TextInput/TextInput.stories.tsx
@@ -1,25 +1,12 @@
-import { useState } from 'react'
-
+import { expect } from '@storybook/jest'
 import type { Meta, StoryObj } from '@storybook/react'
+import { within, userEvent } from '@storybook/testing-library'
 
 import { Flex } from 'components/layout'
 import { IconSearch, IconVisibilityHidden, IconFilter } from 'icons'
 
 import { TextInput } from './TextInput'
-import { TextInputProps, TextInputSize } from './types'
-
-const StoryRender = (props: TextInputProps) => {
-  const [value, setValue] = useState(props.value)
-  return (
-    <TextInput
-      {...props}
-      value={value}
-      onChange={(e) => {
-        setValue(e.target.value)
-      }}
-    />
-  )
-}
+import { TextInputSize } from './types'
 
 const meta: Meta<typeof TextInput> = {
   title: 'Inputs/TextInput',
@@ -30,8 +17,7 @@ const meta: Meta<typeof TextInput> = {
         exclude: ['inputRef', 'inputRootClassName', 'inputClassName']
       }
     }
-  },
-  render: StoryRender
+  }
 }
 
 export default meta
@@ -43,6 +29,18 @@ export const Default: Story = {
     label: 'Input label',
     helperText: 'This is assistive text.',
     placeholder: 'Placeholder'
+  },
+  render: (props) => <TextInput {...props} />,
+  play: async ({ canvasElement, step }) => {
+    const canvas = within(canvasElement)
+
+    const textInput = canvas.getByRole('textbox', { name: /input label/i })
+
+    await step('Enter text', async () => {
+      await userEvent.type(textInput, 'test')
+
+      await expect(textInput).toHaveValue('test')
+    })
   }
 }
 

--- a/packages/harmony/src/components/input/TextInput/TextInput.tsx
+++ b/packages/harmony/src/components/input/TextInput/TextInput.tsx
@@ -133,7 +133,6 @@ export const TextInput = forwardRef<HTMLInputElement, TextInputProps>(
           placeholder={shouldShowPlaceholder ? placeholderText : undefined}
           aria-label={props['aria-label'] ?? labelText}
           aria-required={required}
-          role='textbox'
           id={id}
           {...other}
         />

--- a/packages/harmony/src/storybook/components/ComponentRule.tsx
+++ b/packages/harmony/src/storybook/components/ComponentRule.tsx
@@ -31,7 +31,7 @@ export const ComponentRule = (props: ComponentRuleProps) => {
   const TitleIcon = isRecommended ? IconValidationCheck : IconValidationX
   const title = isRecommended ? messages.do : messages.dont
 
-  const { color, cornerRadius } = useTheme()
+  const { color } = useTheme()
   const borderColor = isRecommended ? color.status.success : color.status.error
 
   const sizeMap = {
@@ -61,12 +61,12 @@ export const ComponentRule = (props: ComponentRuleProps) => {
         as='figure'
         p='2xl'
         border='strong'
+        borderRadius='m'
         justifyContent='center'
         alignItems='center'
         h={sizeMap[size]}
         css={{
-          border: `1px solid ${borderColor}`,
-          borderRadius: cornerRadius.m,
+          borderColor,
           boxSizing: 'content-box',
           overflow: 'hidden',
           '& img': {


### PR DESCRIPTION
### Description

Ensures text-input doesn't need explicit role by adding a storybook test using `getByRole('textbox'..)`
Updates some text-input docs styles

<img width="1173" alt="image" src="https://github.com/AudiusProject/audius-protocol/assets/8230000/b8034062-8f03-428e-8e58-a2c74a89685d">
