### PR TITLE
[INF-546] Ensure that vite base is set properly in prod builds

### DIFF
--- a/packages/web/vite.config.ts
+++ b/packages/web/vite.config.ts
@@ -15,7 +15,7 @@ export default defineConfig(({ mode }) => {
   env.VITE_PUBLIC_URL = env.VITE_PUBLIC_URL ?? ''
 
   return {
-    base: env.VITE_PUBLIC_URL,
+    base: env.VITE_PUBLIC_URL || '/',
     build: {
       outDir: 'build',
       sourcemap: true,


### PR DESCRIPTION
### Description

Related to https://github.com/AudiusProject/audius-protocol/pull/6630

Using empty string as the vite `base` works in dev mode but not for prod builds. This updates the vite `base` to `/` when public url is falsey (including empty string)

### How Has This Been Tested?

Tested that TOS and Privacy policy links work properly from landing page in both dev mode and on prod builds

Going to cherry pick once merged
