### PR TITLE
Fix typography header xl font-size and line-height

### DIFF
--- a/packages/harmony/src/components/text/Text/Text.tsx
+++ b/packages/harmony/src/components/text/Text/Text.tsx
@@ -29,8 +29,8 @@ export const variantStylesMap = {
     fontWeight: { default: 'bold', strong: 'heavy' }
   },
   heading: {
-    fontSize: { s: 'xl', m: '2xl', l: '3xl', xl: '3xl' },
-    lineHeight: { s: 'l', m: 'xl', l: 'xl', xl: 'xl' },
+    fontSize: { s: 'xl', m: '2xl', l: '3xl', xl: '5xl' },
+    lineHeight: { s: 'l', m: 'xl', l: 'xl', xl: '2xl' },
     fontWeight: { default: 'bold', strong: 'heavy' }
   },
   title: {


### PR DESCRIPTION
### Description

Fixes incorrect font-size and line-height for heading xl

### How Has This Been Tested?

Confirmed in figma