### PR TITLE
Add pay-gated upload test and re-enable stems test

### DIFF
--- a/packages/probers/cypress/config/dev.json
+++ b/packages/probers/cypress/config/dev.json
@@ -1,7 +1,7 @@
 {
-  "defaultCommandTimeout": 20000,
+  "defaultCommandTimeout": 30000,
   "baseUrl": "http://localhost:3001",
   "env": {
-    "initialLoadTimeout": 20000
+    "initialLoadTimeout": 30000
   }
 }

--- a/packages/probers/cypress/e2e/uploadTrack.cy.ts
+++ b/packages/probers/cypress/e2e/uploadTrack.cy.ts
@@ -4,17 +4,74 @@ import aiAttribution from '../fixtures/aiAttribution.json'
 import remix from '../fixtures/remix.json'
 const timestamp = dayjs().format('YYMMDD_HHmmss')
 
+const visitUpload = () => {
+  cy.login()
+  cy.findByRole('link', { name: /upload track/i }).click()
+  cy.findByRole('heading', { name: /upload your music/i, level: 1 }).should(
+    'exist'
+  )
+}
+
+const completeUpload = () => {
+  cy.findByRole('button', { name: /complete upload/i }).click()
+
+  cy.findByRole('dialog', { name: /confirm upload/i }).within(() => {
+    cy.findByRole('button', { name: /upload/i }).click()
+  })
+
+  cy.findByRole('heading', {
+    name: /uploading your track/i,
+    level: 1
+  }).should('exist')
+
+  cy.findByRole('main').within(() => {
+    cy.findByRole('progressbar', { name: /upload in progress/i }).should(
+      'have.attr',
+      'aria-valuenow',
+      '0'
+    )
+
+    const assertProgress = (progress: number) => {
+      cy.waitUntil(
+        () => {
+          return cy
+            .findByRole('progressbar', { name: /upload in progress/i })
+            .then((progressbar) => {
+              return Number(progressbar.attr('aria-valuenow')) > progress
+            })
+        },
+        { timeout: 100000, interval: 5000 }
+      )
+    }
+
+    assertProgress(0)
+    assertProgress(10)
+    assertProgress(20)
+    assertProgress(30)
+    assertProgress(40)
+    assertProgress(50)
+    assertProgress(60)
+    assertProgress(70)
+    assertProgress(80)
+    assertProgress(90)
+  })
+
+  cy.findByText(/finalizing upload/i).should('exist')
+
+  cy.findByRole('heading', {
+    name: /your upload is complete/i,
+    level: 3,
+    timeout: 100000
+  }).should('exist')
+}
+
 describe('Upload', () => {
   beforeEach(() => {
     localStorage.setItem('HAS_REQUESTED_BROWSER_PUSH_PERMISSION', 'true')
   })
 
   it('user should be able to upload a single track', () => {
-    cy.login()
-    cy.findByRole('link', { name: /upload track/i }).click()
-    cy.findByRole('heading', { name: /upload your music/i, level: 1 }).should(
-      'exist'
-    )
+    visitUpload()
 
     // Select track
 
@@ -130,68 +187,14 @@ describe('Upload', () => {
       cy.findByRole('button', { name: /save/i }).click()
     })
 
-    cy.findByRole('button', { name: /complete upload/i }).click()
-
-    cy.findByRole('dialog', { name: /confirm upload/i }).within(() => {
-      cy.findByRole('button', { name: /upload/i }).click()
-    })
-
-    cy.findByRole('heading', {
-      name: /uploading your track/i,
-      level: 1
-    }).should('exist')
-
-    cy.findByRole('main').within(() => {
-      cy.findByRole('progressbar', { name: /upload in progress/i }).should(
-        'have.attr',
-        'aria-valuenow',
-        '0'
-      )
-
-      const assertProgress = (progress: number) => {
-        cy.waitUntil(
-          () => {
-            return cy
-              .findByRole('progressbar', { name: /upload in progress/i })
-              .then((progressbar) => {
-                return Number(progressbar.attr('aria-valuenow')) > progress
-              })
-          },
-          { timeout: 100000, interval: 5000 }
-        )
-      }
-
-      assertProgress(0)
-      assertProgress(10)
-      assertProgress(20)
-      assertProgress(30)
-      assertProgress(40)
-      assertProgress(50)
-      assertProgress(60)
-      assertProgress(70)
-      assertProgress(80)
-      assertProgress(90)
-    })
-
-    cy.findByText(/finalizing upload/i).should('exist')
-
-    cy.findByRole('heading', {
-      name: /your upload is complete/i,
-      level: 3,
-      timeout: 100000
-    }).should('exist')
+    completeUpload()
 
     cy.findByRole('link', { name: /visit track page/i }).click()
-
     cy.findByRole('heading', { name: /track/i, level: 1 }).should('exist')
   })
 
   it('user should be able to upload a single track with stems', () => {
-    cy.login()
-    cy.findByRole('link', { name: /upload track/i }).click()
-    cy.findByRole('heading', { name: /upload your music/i, level: 1 }).should(
-      'exist'
-    )
+    visitUpload()
 
     // Select track
 
@@ -233,68 +236,14 @@ describe('Upload', () => {
       cy.findByRole('button', { name: /save/i }).click()
     })
 
-    cy.findByRole('button', { name: /complete upload/i }).click()
-
-    cy.findByRole('dialog', { name: /confirm upload/i }).within(() => {
-      cy.findByRole('button', { name: /upload/i }).click()
-    })
-
-    cy.findByRole('heading', {
-      name: /uploading your track/i,
-      level: 1
-    }).should('exist')
-
-    cy.findByRole('main').within(() => {
-      cy.findByRole('progressbar', { name: /upload in progress/i }).should(
-        'have.attr',
-        'aria-valuenow',
-        '0'
-      )
-
-      const assertProgress = (progress: number) => {
-        cy.waitUntil(
-          () => {
-            return cy
-              .findByRole('progressbar', { name: /upload in progress/i })
-              .then((progressbar) => {
-                return Number(progressbar.attr('aria-valuenow')) > progress
-              })
-          },
-          { timeout: 100000, interval: 5000 }
-        )
-      }
-
-      assertProgress(0)
-      assertProgress(10)
-      assertProgress(20)
-      assertProgress(30)
-      assertProgress(40)
-      assertProgress(50)
-      assertProgress(60)
-      assertProgress(70)
-      assertProgress(80)
-      assertProgress(90)
-    })
-
-    cy.findByText(/finalizing upload/i).should('exist')
-
-    cy.findByRole('heading', {
-      name: /your upload is complete/i,
-      level: 3,
-      timeout: 600000
-    }).should('exist')
+    completeUpload()
 
     cy.findByRole('link', { name: /visit track page/i }).click()
-
     cy.findByRole('heading', { name: /track/i, level: 1 }).should('exist')
   })
 
   it.only('user should be able to a single track with a pay-gate', () => {
-    cy.login()
-    cy.findByRole('link', { name: /upload track/i }).click()
-    cy.findByRole('heading', { name: /upload your music/i, level: 1 }).should(
-      'exist'
-    )
+    visitUpload()
 
     // Select track
 
@@ -333,59 +282,9 @@ describe('Upload', () => {
       cy.findByRole('button', { name: /save/i }).click()
     })
 
-    cy.findByRole('button', { name: /complete upload/i }).click()
-
-    cy.findByRole('dialog', { name: /confirm upload/i }).within(() => {
-      cy.findByRole('button', { name: /upload/i }).click()
-    })
-
-    cy.findByRole('heading', {
-      name: /uploading your track/i,
-      level: 1
-    }).should('exist')
-
-    cy.findByRole('main').within(() => {
-      cy.findByRole('progressbar', { name: /upload in progress/i }).should(
-        'have.attr',
-        'aria-valuenow',
-        '0'
-      )
-
-      const assertProgress = (progress: number) => {
-        cy.waitUntil(
-          () => {
-            return cy
-              .findByRole('progressbar', { name: /upload in progress/i })
-              .then((progressbar) => {
-                return Number(progressbar.attr('aria-valuenow')) > progress
-              })
-          },
-          { timeout: 100000, interval: 5000 }
-        )
-      }
-
-      assertProgress(0)
-      assertProgress(10)
-      assertProgress(20)
-      assertProgress(30)
-      assertProgress(40)
-      assertProgress(50)
-      assertProgress(60)
-      assertProgress(70)
-      assertProgress(80)
-      assertProgress(90)
-    })
-
-    cy.findByText(/finalizing upload/i).should('exist')
-
-    cy.findByRole('heading', {
-      name: /your upload is complete/i,
-      level: 3,
-      timeout: 100000
-    }).should('exist')
+    completeUpload()
 
     cy.findByRole('link', { name: /visit track page/i }).click()
-
     cy.findByRole('heading', { name: /pay-gated track/i, level: 1 }).should('exist')
     cy.findByRole('button', { name: /preview/i }).should('exist')
     cy.findByText(/premium track/i).should('exist')

--- a/packages/probers/cypress/e2e/uploadTrack.cy.ts
+++ b/packages/probers/cypress/e2e/uploadTrack.cy.ts
@@ -79,23 +79,6 @@ describe('Upload', () => {
       cy.findByRole('button', { name: /save/i }).click()
     })
 
-    // Disabled stems for flakiness
-
-    // cy.findByRole('button', { name: /stems & source files/i }).click()
-    // cy.findByRole('dialog', { name: /stems & source files/i }).within(() => {
-    //   cy.findByRole('checkbox', {
-    //     name: /make full mp3 track available/i
-    //   }).check()
-    //   cy.findByTestId('upload-dropzone').attachFile('track.mp3', {
-    //     subjectType: 'drag-n-drop'
-    //   })
-    //   cy.findByRole('listitem').within(() => {
-    //     cy.findByText(/instrumental/i).should('exist')
-    //     cy.findByText('track').should('exist')
-    //   })
-    //   cy.findByRole('button', { name: /save/i }).click()
-    // })
-
     cy.findByRole('button', { name: /access & sale/i }).click()
     cy.findByRole('dialog', { name: /access & sale/i }).within(() => {
       cy.findAllByRole('alert')
@@ -201,5 +184,212 @@ describe('Upload', () => {
     cy.findByRole('link', { name: /visit track page/i }).click()
 
     cy.findByRole('heading', { name: /track/i, level: 1 }).should('exist')
+  })
+
+  it('user should be able to upload a single track with stems', () => {
+    cy.login()
+    cy.findByRole('link', { name: /upload track/i }).click()
+    cy.findByRole('heading', { name: /upload your music/i, level: 1 }).should(
+      'exist'
+    )
+
+    // Select track
+
+    cy.findByTestId('upload-dropzone').attachFile('track.mp3', {
+      subjectType: 'drag-n-drop'
+    })
+    cy.findByRole('button', { name: /continue uploading/i }).click()
+
+    // Complete track form
+
+    cy.findByRole('heading', { name: /complete your track/i, level: 1 }).should(
+      'exist'
+    )
+    cy.findByRole('button', { name: /change/i }).click()
+
+    cy.findByTestId('upload-dropzone').attachFile('track-artwork.jpeg', {
+      subjectType: 'drag-n-drop'
+    })
+
+    cy.findByRole('textbox', { name: /track name/i })
+      .clear()
+      .type(`Test track stems ${timestamp}`)
+
+    cy.findByRole('combobox', { name: /pick a genre/i }).click()
+    cy.findByRole('option', { name: /alternative/i }).click()
+
+    cy.findByRole('button', { name: /stems & source files/i }).click()
+    cy.findByRole('dialog', { name: /stems & source files/i }).within(() => {
+      cy.findByRole('checkbox', {
+        name: /make full mp3 track available/i
+      }).check()
+      cy.findByTestId('upload-dropzone').attachFile('track.mp3', {
+        subjectType: 'drag-n-drop'
+      })
+      cy.findByRole('listitem').within(() => {
+        cy.findByText(/instrumental/i).should('exist')
+        cy.findByText('track').should('exist')
+      })
+      cy.findByRole('button', { name: /save/i }).click()
+    })
+
+    cy.findByRole('button', { name: /complete upload/i }).click()
+
+    cy.findByRole('dialog', { name: /confirm upload/i }).within(() => {
+      cy.findByRole('button', { name: /upload/i }).click()
+    })
+
+    cy.findByRole('heading', {
+      name: /uploading your track/i,
+      level: 1
+    }).should('exist')
+
+    cy.findByRole('main').within(() => {
+      cy.findByRole('progressbar', { name: /upload in progress/i }).should(
+        'have.attr',
+        'aria-valuenow',
+        '0'
+      )
+
+      const assertProgress = (progress: number) => {
+        cy.waitUntil(
+          () => {
+            return cy
+              .findByRole('progressbar', { name: /upload in progress/i })
+              .then((progressbar) => {
+                return Number(progressbar.attr('aria-valuenow')) > progress
+              })
+          },
+          { timeout: 100000, interval: 5000 }
+        )
+      }
+
+      assertProgress(0)
+      assertProgress(10)
+      assertProgress(20)
+      assertProgress(30)
+      assertProgress(40)
+      assertProgress(50)
+      assertProgress(60)
+      assertProgress(70)
+      assertProgress(80)
+      assertProgress(90)
+    })
+
+    cy.findByText(/finalizing upload/i).should('exist')
+
+    cy.findByRole('heading', {
+      name: /your upload is complete/i,
+      level: 3,
+      timeout: 600000
+    }).should('exist')
+
+    cy.findByRole('link', { name: /visit track page/i }).click()
+
+    cy.findByRole('heading', { name: /track/i, level: 1 }).should('exist')
+  })
+
+  it.only('user should be able to a single track with a pay-gate', () => {
+    cy.login()
+    cy.findByRole('link', { name: /upload track/i }).click()
+    cy.findByRole('heading', { name: /upload your music/i, level: 1 }).should(
+      'exist'
+    )
+
+    // Select track
+
+    cy.findByTestId('upload-dropzone').attachFile('track.mp3', {
+      subjectType: 'drag-n-drop'
+    })
+    cy.findByRole('button', { name: /continue uploading/i }).click()
+
+    // Complete track form
+
+    cy.findByRole('heading', { name: /complete your track/i, level: 1 }).should(
+      'exist'
+    )
+    cy.findByRole('button', { name: /change/i }).click()
+
+    cy.findByTestId('upload-dropzone').attachFile('track-artwork.jpeg', {
+      subjectType: 'drag-n-drop'
+    })
+
+    cy.findByRole('textbox', { name: /track name/i })
+      .clear()
+      .type(`Test premium pay-gated track ${timestamp}`)
+
+    cy.findByRole('combobox', { name: /pick a genre/i }).click()
+    cy.findByRole('option', { name: /alternative/i }).click()
+
+    // Set pay-gated
+    cy.findByRole('button', { name: /access & sale/i }).click()
+    cy.findByRole('dialog', { name: /access & sale/i }).within(() => {
+      cy.findByRole('radiogroup', { name: /access & sale/i }).within(() => {
+        cy.findByRole('radio', { name: /premium \(pay-to-unlock\)/i }).click()
+        cy.findByRole('textbox', { name: /cost to unlock/i }).type('1.05')
+        cy.findByRole('textbox', { name: /start time/i }).type('15')
+      })
+
+      cy.findByRole('button', { name: /save/i }).click()
+    })
+
+    cy.findByRole('button', { name: /complete upload/i }).click()
+
+    cy.findByRole('dialog', { name: /confirm upload/i }).within(() => {
+      cy.findByRole('button', { name: /upload/i }).click()
+    })
+
+    cy.findByRole('heading', {
+      name: /uploading your track/i,
+      level: 1
+    }).should('exist')
+
+    cy.findByRole('main').within(() => {
+      cy.findByRole('progressbar', { name: /upload in progress/i }).should(
+        'have.attr',
+        'aria-valuenow',
+        '0'
+      )
+
+      const assertProgress = (progress: number) => {
+        cy.waitUntil(
+          () => {
+            return cy
+              .findByRole('progressbar', { name: /upload in progress/i })
+              .then((progressbar) => {
+                return Number(progressbar.attr('aria-valuenow')) > progress
+              })
+          },
+          { timeout: 100000, interval: 5000 }
+        )
+      }
+
+      assertProgress(0)
+      assertProgress(10)
+      assertProgress(20)
+      assertProgress(30)
+      assertProgress(40)
+      assertProgress(50)
+      assertProgress(60)
+      assertProgress(70)
+      assertProgress(80)
+      assertProgress(90)
+    })
+
+    cy.findByText(/finalizing upload/i).should('exist')
+
+    cy.findByRole('heading', {
+      name: /your upload is complete/i,
+      level: 3,
+      timeout: 100000
+    }).should('exist')
+
+    cy.findByRole('link', { name: /visit track page/i }).click()
+
+    cy.findByRole('heading', { name: /pay-gated track/i, level: 1 }).should('exist')
+    cy.findByRole('button', { name: /preview/i }).should('exist')
+    cy.findByText(/premium track/i).should('exist')
+    cy.findByText(/users can unlock/i).should('exist')
+    cy.findByText(/purchase of \$1\.05/i).should('exist')
   })
 })


### PR DESCRIPTION
### Description

Add cypress test for premium content uploads.
Also re-enable stems, but in a separate tests since download options are probably going to want a few different tests in the future.

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._

```
npm run web:stage
cd packages/probers npm run cypress:open
```
