### PR TITLE
Add text-shadow, fix avatar className, add 2xs spacing

### DIFF
--- a/packages/harmony/src/components/avatar/Avatar.tsx
+++ b/packages/harmony/src/components/avatar/Avatar.tsx
@@ -11,7 +11,8 @@ export const Avatar = (props: AvatarProps) => {
     src,
     strokeWidth = 'default',
     size = 'auto',
-    variant = 'default'
+    variant = 'default',
+    ...other
   } = props
   const { color } = useTheme()
 
@@ -42,5 +43,5 @@ export const Avatar = (props: AvatarProps) => {
     zIndex: 1
   }
 
-  return <div css={rootCss} />
+  return <div css={rootCss} {...other} />
 }

--- a/packages/harmony/src/components/avatar/types.ts
+++ b/packages/harmony/src/components/avatar/types.ts
@@ -1,4 +1,5 @@
 export type AvatarProps = {
+  className?: string
   /**
    * Url image source
    */

--- a/packages/harmony/src/components/text/Text/Text.tsx
+++ b/packages/harmony/src/components/text/Text/Text.tsx
@@ -62,6 +62,7 @@ export const Text = forwardRef(
       strength = 'default',
       size = 'm',
       color,
+      shadow,
       tag,
       asChild,
       ...other
@@ -92,7 +93,10 @@ export const Text = forwardRef(
         lineHeight: typography.lineHeight[variantConfig.lineHeight[size]],
         // @ts-expect-error
         fontWeight: typography.weight[variantConfig.fontWeight[strength]],
-        ...('css' in variantConfig && variantConfig.css)
+        ...('css' in variantConfig && variantConfig.css),
+        ...(shadow && {
+          textShadow: '0px 1px 5px rgba(0, 0, 0, 0.50)'
+        })
       })
     }
 

--- a/packages/harmony/src/components/text/Text/types.ts
+++ b/packages/harmony/src/components/text/Text/types.ts
@@ -1,9 +1,4 @@
-import type {
-  ComponentProps,
-  ElementType,
-  ForwardedRef,
-  ReactNode
-} from 'react'
+import type { ComponentProps, ElementType, ReactNode } from 'react'
 
 import type { TextColors } from 'foundations'
 
@@ -15,7 +10,7 @@ export type TextOwnProps<TextComponentType extends ElementType = 'p'> = {
   size?: TextSize
   strength?: TextStrength
   color?: TextColors
-  innerRef?: ForwardedRef<HTMLElement>
+  shadow?: TextShadow
   asChild?: boolean
 }
 
@@ -28,4 +23,5 @@ export type TextStrength = 'weak' | 'default' | 'strong'
 export type TextSize = 'xl' | 'l' | 'm' | 's' | 'xs'
 
 export type TextVariant = 'display' | 'heading' | 'title' | 'label' | 'body'
+export type TextShadow = 'emphasis'
 export type VariantSizeTagMap = Partial<Record<TextSize, ElementType>>

--- a/packages/harmony/src/foundations/spacing/spacing.ts
+++ b/packages/harmony/src/foundations/spacing/spacing.ts
@@ -31,6 +31,7 @@ export const spacing = {
   unit24: 96,
 
   /* --- Spacing Variables --- */
+  '2xs': 2,
   xs: 4,
   s: 8,
   m: 12,

--- a/packages/harmony/src/foundations/theme/index.ts
+++ b/packages/harmony/src/foundations/theme/index.ts
@@ -1,2 +1,3 @@
 export * from './ThemeProvider'
 export * from './theme'
+export { useTheme } from '@emotion/react'

--- a/packages/harmony/src/foundations/typography/Typography.mdx
+++ b/packages/harmony/src/foundations/typography/Typography.mdx
@@ -18,6 +18,7 @@ import {
 - [Text Colors](#text-colors)
 - [Weight Mappings](#weight-mappings)
 - [Usage and examples](#usage-and-examples)
+- [Do's and Dont's](#dos-and-donts)
 
 <Heading>
 ## Overview
@@ -123,6 +124,16 @@ export function Emp(props) {
 | Thin - 275            | Thin - 200                 |
 | Ultra Light - 250     | Ultra Light - 100          |
 
+## Shadows
+
+<Unstyled>
+  <Paper p='2xl' shadow='near'>
+    <Text variant='display' size='l' shadow='emphasis'>
+      Audius, freedom to listen and share.
+    </Text>
+  </Paper>
+</Unstyled>
+
 ## Usage and examples
 
 - Always use semantic text variables when applying color to typography.
@@ -132,6 +143,10 @@ export function Emp(props) {
 - Consider likeness of elements when spacing text of different sizes.
 
 <img src={typographyExample} />
+
+## Do's and Dont's
+
+- Display text should never go to two lines!
 
 ## Related Foundations
 


### PR DESCRIPTION
### Description

Adds a few harmony improvements:
- Adds text-shadow option to Text
- Allows passing css prop into Avatar
- Exports `useTheme` from harmony
- Adds '2xs' spacing option since im seeing some cases where we have gap: 2px

### Note
> We likely want to improve text-shadows value to work with existing shadows foundations, but it appears none of those are compatible with text-shadow