### PR TITLE
Fix broken useAccountHasClaimableRewards

### DIFF
--- a/packages/common/src/hooks/useAccountHasClaimableRewards.ts
+++ b/packages/common/src/hooks/useAccountHasClaimableRewards.ts
@@ -6,6 +6,7 @@ import { useProxySelector } from './useProxySelector'
 export const useAccountHasClaimableRewards = (challengeRewardsIds: string) => {
   return useProxySelector(
     (state) => {
+      if (challengeRewardsIds === null) return false
       const optimisticUserChallenges = getOptimisticUserChallenges(state)
       const activeRewardIds = challengeRewardsIds.split(
         ','


### PR DESCRIPTION
### Description
Not sure how typescript didn't catch this, but this should fix for now.

### How Has This Been Tested?

I couldn't repro the bug locally but rewards/nav functions normally for me with this fix.
