### PR TITLE
Hotfix double gzip on mobile for Content Nodes

### DIFF
--- a/mediorum/server/server.go
+++ b/mediorum/server/server.go
@@ -370,8 +370,10 @@ func New(config MediorumConfig) (*MediorumServer, error) {
 }
 
 func setResponseACAOHeaderFromRequest(req http.Request, resp echo.Response) {
-	resp.Header().Set(echo.HeaderAccessControlAllowOrigin,
-		req.Header.Get(echo.HeaderOrigin))
+	resp.Header().Set(
+		echo.HeaderAccessControlAllowOrigin,
+		req.Header.Get(echo.HeaderOrigin),
+	)
 }
 
 func ACAOHeaderOverwriteMiddleware(next echo.HandlerFunc) echo.HandlerFunc {

--- a/monitoring/uptime/uptime.go
+++ b/monitoring/uptime/uptime.go
@@ -78,7 +78,6 @@ func (u *Uptime) Start() {
 	e.Use(middleware.Recover())
 	e.Use(middleware.Logger())
 	e.Use(middleware.CORS())
-	e.Use(middleware.Gzip())
 
 	e.Static("/up", "/app/node-ui/dist")
 


### PR DESCRIPTION
### Description
Tiny hotfix for `/up` not loading on mobile for Content Nodes because there are 2 golang echo servers which both set Content-Encoding to gzip (mediorum's echo server reverse proxies to the uptime container's echo server, which serves the static assets). Desktop is able to handle this, but mobile browsers don't dedupe and instead twice, which makes the website look like alien text.

### How Has This Been Tested?
Tested on desktop and mobile for Discovery and Content. Mediorum and Discovery's nginx both set gzip already, so it makes sense to not have it in the uptime container. Now, they both have a single Content-Encoding header set to gzip.