### PR TITLE
[C-3369] Add checkbox/radio types to SelectablePill

### DIFF
--- a/packages/harmony/src/components/input/SelectablePill/SelectablePill.mdx
+++ b/packages/harmony/src/components/input/SelectablePill/SelectablePill.mdx
@@ -62,7 +62,11 @@ Only Large pills can have a leading icon.
 
 </Heading>
 
-<Canvas of={SelectablePillStories.States} />
+<Canvas of={SelectablePillStories.LeadingIcon} />
+
+### Pill as input
+
+<Canvas of={SelectablePillStories.PillAsInput} />
 
 ## Use cases and examples
 

--- a/packages/harmony/src/components/input/SelectablePill/SelectablePill.stories.tsx
+++ b/packages/harmony/src/components/input/SelectablePill/SelectablePill.stories.tsx
@@ -20,7 +20,7 @@ type Story = StoryObj<typeof SelectablePill>
 export const Primary: Story = {
   render: (props) => (
     <Flex gap='4xl' alignItems='center'>
-      <SelectablePill {...props} size='default' />
+      <SelectablePill {...props} size='small' />
       <SelectablePill {...props} size='large' />
     </Flex>
   )
@@ -31,7 +31,7 @@ export const Size: Story = {
     <Flex direction='column' gap='2xl'>
       <Flex gap='4xl' alignItems='center'>
         <Text>Small</Text>
-        <SelectablePill {...props} size='default' />
+        <SelectablePill {...props} size='small' />
       </Flex>
       <Flex gap='4xl' alignItems='center'>
         <Text>Large</Text>
@@ -43,12 +43,32 @@ export const Size: Story = {
 
 export const States: Story = {
   render: () => (
-    <Flex gap='4xl' alignItems='center'>
-      <SelectablePill label='Default' />
-      <SelectablePill label='Hover' _isHovered />
-      <SelectablePill label='Active' isSelected />
-      <SelectablePill label='Disabled' isSelected={false} disabled />
-      <SelectablePill label='Active Disabled' isSelected disabled />
+    <Flex direction='column' gap='2xl'>
+      <Flex gap='4xl' alignItems='center'>
+        <SelectablePill label='Default' />
+        <SelectablePill label='Hover' _isHovered />
+        <SelectablePill label='Active' isSelected />
+        <SelectablePill label='Disabled' isSelected={false} disabled />
+        <SelectablePill label='Active Disabled' isSelected disabled />
+      </Flex>
+
+      <Flex gap='4xl' alignItems='center'>
+        <SelectablePill size='large' label='Default' />
+        <SelectablePill size='large' label='Hover' _isHovered />
+        <SelectablePill size='large' label='Active' isSelected />
+        <SelectablePill
+          size='large'
+          label='Disabled'
+          isSelected={false}
+          disabled
+        />
+        <SelectablePill
+          size='large'
+          label='Active Disabled'
+          isSelected
+          disabled
+        />
+      </Flex>
     </Flex>
   )
 }
@@ -59,4 +79,19 @@ export const PillAsMenu: Story = {
 
 export const LeadingIcon: Story = {
   render: (props) => <SelectablePill icon={IconHeart} {...props} />
+}
+
+export const PillAsInput: Story = {
+  render: () => (
+    <Flex direction='column' gap='2xl'>
+      <Flex gap='4xl' alignItems='center'>
+        <Text css={{ width: 50 }}>Radio</Text>
+        <SelectablePill type='radio' label='Radio' />
+      </Flex>
+      <Flex gap='4xl' alignItems='center'>
+        <Text css={{ width: 50 }}>Checkbox</Text>
+        <SelectablePill type='checkbox' label='Checkbox' />
+      </Flex>
+    </Flex>
+  )
 }

--- a/packages/harmony/src/components/input/SelectablePill/SelectablePill.tsx
+++ b/packages/harmony/src/components/input/SelectablePill/SelectablePill.tsx
@@ -5,8 +5,33 @@ import { Text } from 'components/text'
 
 import type { SelectablePillProps } from './types'
 
-const SelectablePillRoot = styled.button<SelectablePillProps>((props) => {
-  const { theme, isSelected, size, _isHovered } = props
+const InputRoot = styled.input({
+  cursor: 'inherit',
+  position: 'absolute',
+  opacity: 0,
+  width: '100%',
+  height: '100%',
+  top: 0,
+  left: 0,
+  margin: 0,
+  padding: 0,
+  zIndex: 1
+})
+
+export const SelectablePill = (props: SelectablePillProps) => {
+  const {
+    isSelected,
+    size = 'small',
+    _isHovered,
+    label,
+    icon: Icon,
+    ...other
+  } = props
+
+  const { disabled, type } = other
+
+  const theme = useTheme()
+  const { spacing } = theme
 
   const hoverCss: CSSObject = {
     backgroundColor: theme.color.secondary.s200,
@@ -29,39 +54,37 @@ const SelectablePillRoot = styled.button<SelectablePillProps>((props) => {
     })
   }
 
-  return {
+  const css: CSSObject = {
     display: 'inline-flex',
     alignItems: 'center',
     justifyContent: 'center',
     gap: theme.spacing.xs,
-    height: theme.spacing.unit6,
-    backgroundColor: theme.color.special.white,
-    paddingInline: theme.spacing.unit3,
-    color: theme.color.text.subdued,
+    color: theme.color.text.default,
+    backgroundColor: theme.color.background.white,
     cursor: 'pointer',
     userSelect: 'none',
     transition: 'all 0.12s ease-out',
+    textWrap: 'nowrap',
     border: `1px solid ${theme.color.border.strong}`,
     borderRadius: theme.cornerRadius['2xl'],
-
+    ...(size === 'small' && {
+      height: theme.spacing.unit6,
+      paddingInline: theme.spacing.unit3
+    }),
     ...(size === 'large' && {
       height: theme.spacing.unit8,
       paddingInline: theme.spacing.unit4,
-      color: theme.color.text.default,
       boxShadow: theme.shadows.near
     }),
-
+    ...(disabled && { opacity: 0.45 }),
     ...(_isHovered && hoverCss),
     ...(isSelected && activeCss),
-
+    ...((disabled || _isHovered) && {
+      pointerEvents: 'none'
+    }),
     ':hover': hoverCss,
     ':active': activeCss
   }
-})
-
-export const SelectablePill = (props: SelectablePillProps) => {
-  const { label, icon: Icon } = props
-  const { spacing } = useTheme()
 
   const iconCss = {
     marginRight: spacing.unit1,
@@ -73,12 +96,34 @@ export const SelectablePill = (props: SelectablePillProps) => {
     }
   }
 
-  return (
-    <SelectablePillRoot {...props}>
+  const pillContent = (
+    <>
       {Icon ? <Icon css={iconCss} /> : null}
       <Text variant='body' tag='span'>
         {label}
       </Text>
-    </SelectablePillRoot>
+    </>
   )
+
+  if (type === 'checkbox' || type === 'radio') {
+    return (
+      <label css={[css, { position: 'relative' }]}>
+        <InputRoot
+          {...other}
+          checked={type === 'checkbox' ? isSelected : undefined}
+        />
+        {pillContent}
+      </label>
+    )
+  }
+
+  if (!type || type === 'button' || type === 'reset' || type === 'submit') {
+    return (
+      <button css={css} {...other}>
+        {pillContent}
+      </button>
+    )
+  }
+
+  return null
 }

--- a/packages/harmony/src/components/input/SelectablePill/SelectablePill.tsx
+++ b/packages/harmony/src/components/input/SelectablePill/SelectablePill.tsx
@@ -54,8 +54,9 @@ export const SelectablePill = (props: SelectablePillProps) => {
     })
   }
 
-  const css: CSSObject = {
+  const rootCss: CSSObject = {
     display: 'inline-flex',
+    position: 'relative',
     alignItems: 'center',
     justifyContent: 'center',
     gap: theme.spacing.xs,
@@ -68,12 +69,12 @@ export const SelectablePill = (props: SelectablePillProps) => {
     border: `1px solid ${theme.color.border.strong}`,
     borderRadius: theme.cornerRadius['2xl'],
     ...(size === 'small' && {
-      height: theme.spacing.unit6,
-      paddingInline: theme.spacing.unit3
+      height: theme.spacing.xl,
+      paddingInline: theme.spacing.m
     }),
     ...(size === 'large' && {
-      height: theme.spacing.unit8,
-      paddingInline: theme.spacing.unit4,
+      height: theme.spacing['2xl'],
+      paddingInline: theme.spacing.l,
       boxShadow: theme.shadows.near
     }),
     ...(disabled && { opacity: 0.45 }),
@@ -87,9 +88,9 @@ export const SelectablePill = (props: SelectablePillProps) => {
   }
 
   const iconCss = {
-    marginRight: spacing.unit1,
-    width: spacing.unit4,
-    height: spacing.unit4,
+    marginRight: spacing.xs,
+    width: spacing.l,
+    height: spacing.l,
 
     '& path': {
       fill: 'currentColor'
@@ -105,25 +106,28 @@ export const SelectablePill = (props: SelectablePillProps) => {
     </>
   )
 
-  if (type === 'checkbox' || type === 'radio') {
-    return (
-      <label css={[css, { position: 'relative' }]}>
-        <InputRoot
-          {...other}
-          checked={type === 'checkbox' ? isSelected : undefined}
-        />
-        {pillContent}
-      </label>
-    )
+  switch (type) {
+    case 'checkbox':
+    case 'radio': {
+      return (
+        <label css={rootCss}>
+          <InputRoot
+            {...other}
+            checked={type === 'checkbox' ? isSelected : undefined}
+          />
+          {pillContent}
+        </label>
+      )
+    }
+    case 'button':
+    case 'reset':
+    case 'submit':
+    default: {
+      return (
+        <button css={rootCss} {...other}>
+          {pillContent}
+        </button>
+      )
+    }
   }
-
-  if (!type || type === 'button' || type === 'reset' || type === 'submit') {
-    return (
-      <button css={css} {...other}>
-        {pillContent}
-      </button>
-    )
-  }
-
-  return null
 }

--- a/packages/harmony/src/components/input/SelectablePill/types.ts
+++ b/packages/harmony/src/components/input/SelectablePill/types.ts
@@ -9,11 +9,20 @@ type InternalProps = {
   _isHovered?: boolean
 }
 
-export type SelectablePillProps = {
-  size?: 'default' | 'large'
+type BaseProps = {
+  size?: 'small' | 'large'
   isSelected?: boolean
   label: string
   disabled?: boolean
   icon?: IconComponent
-} & InternalProps &
-  Omit<ComponentPropsWithoutRef<'button'>, 'children'>
+}
+
+type InputProps =
+  | ({
+      type: 'checkbox' | 'radio'
+    } & Omit<ComponentPropsWithoutRef<'input'>, 'chiildren' | 'size'>)
+  | ({
+      type?: 'button' | 'submit' | 'reset' | undefined
+    } & Omit<ComponentPropsWithoutRef<'button'>, 'children'>)
+
+export type SelectablePillProps = BaseProps & InternalProps & InputProps

--- a/packages/web/src/pages/saved-page/components/desktop/LibraryCategorySelectionMenu.tsx
+++ b/packages/web/src/pages/saved-page/components/desktop/LibraryCategorySelectionMenu.tsx
@@ -69,7 +69,7 @@ export const LibraryCategorySelectionMenu = ({
       {categories.map((c) => (
         <SelectablePill
           role='radio'
-          size={variant === 'mobile' ? 'default' : 'large'}
+          size={variant === 'mobile' ? 'small' : 'large'}
           aria-checked={selectedCategory === c.value ? 'true' : 'false'}
           icon={variant === 'mobile' ? undefined : c.icon}
           key={c.value}


### PR DESCRIPTION
### Description

Adds checkbox/radio type options to SelectablePill, which will change underlying implementation with label + input + all input props.
passing type='button' | 'submit' | 'reset' will render it as a button like existing behavior