### PR TITLE
[C-3370]  Fix harmony types

### DIFF
--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -76,8 +76,8 @@
     "rollup": "2.76.0",
     "rollup-plugin-dts": "4.2.2",
     "rollup-plugin-typescript2": "0.32.1",
-    "ttypescript": "^1.5.15",
-    "typescript-transform-paths": "^3.4.4"
+    "ttypescript": "1.5.15",
+    "typescript-transform-paths": "3.4.4"
   },
   "peerDependencies": {
     "@reduxjs/toolkit": "1.6.1",

--- a/packages/common/rollup.config.js
+++ b/packages/common/rollup.config.js
@@ -1,5 +1,6 @@
 import image from '@rollup/plugin-image'
 import rollupTypescript from 'rollup-plugin-typescript2'
+import ttypescript from 'ttypescript'
 
 import pkg from './package.json'
 
@@ -22,18 +23,7 @@ export default [
     ],
     plugins: [
       rollupTypescript({
-        typescript: require('ttypescript'),
-        tsconfigDefaults: {
-          compilerOptions: {
-            plugins: [
-              { transform: 'typescript-transform-paths' },
-              {
-                transform: 'typescript-transform-paths',
-                afterDeclarations: true
-              }
-            ]
-          }
-        }
+        typescript: ttypescript
       }),
       image()
     ],

--- a/packages/common/tsconfig.json
+++ b/packages/common/tsconfig.json
@@ -14,6 +14,10 @@
       "utils/*": ["src/utils/*"],
       "utils": ["src/utils"]
     },
+    "plugins": [
+      { "transform": "typescript-transform-paths" },
+      { "transform": "typescript-transform-paths", "afterDeclarations": true }
+    ],
     "module": "esnext",
     "target": "es6",
     "moduleResolution": "node",

--- a/packages/harmony/package.json
+++ b/packages/harmony/package.json
@@ -83,8 +83,9 @@
     "storybook-addon-smart-knobs": "6.0.2",
     "storybook-dark-mode": "3.0.1",
     "tsconfig-paths-webpack-plugin": "3.5.2",
-    "typescript": "4.9.4",
+    "ttypescript": "1.5.15",
     "typescript-plugin-css-modules": "3.4.0",
+    "typescript-transform-paths": "3.4.4",
     "webpack": "4.46.0"
   },
   "peerDependencies": {

--- a/packages/harmony/rollup.config.mjs
+++ b/packages/harmony/rollup.config.mjs
@@ -2,7 +2,7 @@ import svgr from '@svgr/rollup'
 import json from 'rollup-plugin-json'
 import postcss from 'rollup-plugin-postcss'
 import rollupTypescript from 'rollup-plugin-typescript2'
-import typescript from 'typescript'
+import ttypescript from 'ttypescript'
 
 import pkg from './package.json' assert { type: 'json' }
 
@@ -34,8 +34,8 @@ export default {
     }),
     svgr(),
     rollupTypescript({
-      clean: true,
-      typescript
+      typescript: ttypescript,
+      clean: true
     })
   ],
   external

--- a/packages/harmony/src/components/avatar/Avatar.stories.tsx
+++ b/packages/harmony/src/components/avatar/Avatar.stories.tsx
@@ -3,8 +3,8 @@ import type { Meta, StoryObj } from '@storybook/react'
 import { Box } from 'components/layout/Box'
 import { Flex } from 'components/layout/Flex'
 import { Paper } from 'components/layout/Paper'
-// TODO: Get final image assets from Sammie
 import shadowBackground from 'storybook/assets/shadowBackground.jpeg'
+// TODO: Get final image assets from Sammie
 
 import { Avatar } from './Avatar'
 

--- a/packages/harmony/src/components/icon/Icon.tsx
+++ b/packages/harmony/src/components/icon/Icon.tsx
@@ -15,12 +15,14 @@ export const iconSizes = {
 
 type IconSize = keyof typeof iconSizes
 
-type IconProps = {
+type BaseIconProps = SVGProps<SVGSVGElement>
+
+type IconProps = BaseIconProps & {
   color?: IconColors
   size?: IconSize
-} & SVGProps<SVGSVGElement>
+}
 
-export type IconComponent = ComponentType<IconProps>
+export type IconComponent = ComponentType<BaseIconProps | IconProps>
 
 /**
  * Renders a harmony Icon component

--- a/packages/harmony/tsconfig.json
+++ b/packages/harmony/tsconfig.json
@@ -22,7 +22,9 @@
       "icons": ["src/icons/index.ts"],
       "icons/*": ["src/icons/*"],
       "assets": ["src/assets/index.ts"],
-      "assets/*": ["src/assets/*"]
+      "assets/*": ["src/assets/*"],
+      "storybook": ["src/storybook/index.ts"],
+      "storybook/*": ["src/storybook/*"]
     },
     "plugins": [
       { "name": "typescript-plugin-css-modules" },

--- a/packages/harmony/tsconfig.json
+++ b/packages/harmony/tsconfig.json
@@ -5,7 +5,6 @@
     "module": "esnext",
     "sourceMap": true,
     "checkJs": false,
-    "plugins": [{ "name": "typescript-plugin-css-modules" }],
     "allowJs": false,
     "jsx": "react-jsx",
     "jsxImportSource": "@emotion/react",
@@ -14,7 +13,22 @@
     "exactOptionalPropertyTypes": false,
     "declaration": true,
     "declarationMap": true,
-    "baseUrl": "./src",
+    "baseUrl": "./",
+    "paths": {
+      "foundations": ["src/foundations/index.ts"],
+      "foundations/*": ["src/foundations/*"],
+      "components": ["src/components/index.ts"],
+      "components/*": ["src/components/*"],
+      "icons": ["src/icons/index.ts"],
+      "icons/*": ["src/icons/*"],
+      "assets": ["src/assets/index.ts"],
+      "assets/*": ["src/assets/*"]
+    },
+    "plugins": [
+      { "name": "typescript-plugin-css-modules" },
+      { "transform": "typescript-transform-paths" },
+      { "transform": "typescript-transform-paths", "afterDeclarations": true }
+    ],
     "outDir": "build",
     "declarationDir": "./",
     "noPropertyAccessFromIndexSignature": false,


### PR DESCRIPTION
### Description

Fixes harmony types due to internal absolute imports. The fix, like we did with common, is to add the transform-paths typescript plugin which rewrites absolute imports as relative imports when building

### How Has This Been Tested?

No typescript issues + we get proper type checking in web