### PR TITLE
Fix 10th track has 15s wait bug

### DIFF
--- a/packages/web/src/services/audio-player/AudioPlayer.ts
+++ b/packages/web/src/services/audio-player/AudioPlayer.ts
@@ -101,6 +101,7 @@ export class AudioPlayer {
         // Remove listeners first so src = '' does not throw an error
         // @ts-ignore
         this.audio.removeAllListeners?.()
+        this.audio.src = ''
         this.audio.removeAttribute('src')
         this.audio.remove()
       }


### PR DESCRIPTION
### Description
It seems like with both these `src` removal methods together, it fixes both the `player/error` bug and the having to wait 15s bug. Not sure why but let's give this a whirl.

Dragon - I noticed once that after leaving my browser tab open for a while and then coming back and hitting play, I got `player/error` + infinite spinner on play button and track never played. Not sure if just a byproduct of some local dev thing, or a real issue, and hard to test so let's try it on staging.

### How Has This Been Tested?

Local web stage - Tried many times to repro and could not.