### PR TITLE
Patch verified user on creation

### DIFF
--- a/packages/discovery-provider/integration_tests/tasks/entity_manager/test_user_entity_manager.py
+++ b/packages/discovery-provider/integration_tests/tasks/entity_manager/test_user_entity_manager.py
@@ -604,11 +604,30 @@ def test_index_invalid_users(app, mocker):
         "QmInvalidArtistPick": {
             "artist_pick_track_id": TRACK_ID_OFFSET + 1,
         },
+        "QmInvalidVerified": {
+            "is_verified": True,
+            "is_deactivated": False,
+            "name": "verified name",
+            "handle": "verifiedhandle",
+            "profile_picture": None,
+            "profile_picture_sizes": "QmYRHAJ4YuLjT4fLLRMg5STnQA4yDpiBmzk5R3iCDTmkmk",
+            "cover_photo": None,
+            "cover_photo_sizes": "QmUk61QDUTzhNqjnCAWipSp3jnMmXBmtTUC2mtF5F6VvUy",
+            "bio": "ðŸŒžðŸ‘„ðŸŒž",
+            "location": "verified location",
+            "creator_node_endpoint": "https://creatornode2.audius.co,https://creatornode3.audius.co,https://content-node.audius.co",
+            "associated_wallets": None,
+            "associated_sol_wallets": None,
+            "playlist_library": {"contents": []},
+            "events": {"is_mobile_user": True},
+            "user_id": USER_ID_OFFSET + 1,
+        },
     }
 
     create_user1_json = json.dumps(test_metadata["QmCreateUser1"])
     invalid_update_user_json = json.dumps(test_metadata["QmInvalidUserMetadataFields"])
     invalid_update_artist_pick_json = json.dumps(test_metadata["QmInvalidArtistPick"])
+    invalid_verified_user = json.dumps(test_metadata["QmInvalidVerified"])
 
     tx_receipts = {
         # invalid create
@@ -621,6 +640,20 @@ def test_index_invalid_users(app, mocker):
                         "_userId": 1,
                         "_action": "Create",
                         "_metadata": "",
+                        "_signer": "user1wallet",
+                    }
+                )
+            },
+        ],
+        "CreateUserInvalidVerified": [
+            {
+                "args": AttributeDict(
+                    {
+                        "_entityId": USER_ID_OFFSET + 1,
+                        "_entityType": "User",
+                        "_userId": USER_ID_OFFSET + 1,
+                        "_action": "Create",
+                        "_metadata": f'{{"cid": "QmUpdateUser2", "data": {invalid_verified_user}}}',
                         "_signer": "user1wallet",
                     }
                 )
@@ -827,13 +860,18 @@ def test_index_invalid_users(app, mocker):
 
         # validate db records
         all_users: List[User] = session.query(User).filter(User.is_current).all()
-        assert len(all_users) == 2  # no new users indexed
+        assert len(all_users) == 3
 
         existing_user_after_index: List[User] = (
             session.query(User).filter(User.user_id == 1).first()
         )
 
         assert existing_user == existing_user_after_index
+
+        invalid_verified_user: List[User] = (
+            session.query(User).filter(User.user_id == USER_ID_OFFSET + 1).first()
+        )
+        assert invalid_verified_user.is_verified == False  # ignored invalid metadata
 
 
 def test_index_verify_users(app, mocker):

--- a/packages/discovery-provider/src/tasks/entity_manager/entities/user.py
+++ b/packages/discovery-provider/src/tasks/entity_manager/entities/user.py
@@ -280,15 +280,13 @@ def update_user_metadata(user_record: User, metadata: Dict, params):
     redis = params.redis
     web3 = params.web3
     challenge_event_bus = params.challenge_bus
-    action = params.action
     # Iterate over the user_record keys
     user_record_attributes = user_record.get_attributes_dict()
     for key, _ in user_record_attributes.items():
         # Update the user_record when the corresponding field exists
         # in metadata
         if key in metadata:
-            if key in immutable_user_fields and action == Action.UPDATE:
-                # skip fields that cannot be modified after creation
+            if key in immutable_user_fields:
                 continue
             setattr(user_record, key, metadata[key])
 


### PR DESCRIPTION
### Description
Patches a vulnerability where verified can be set on user creation. Looked through other cases and couldn't find anything else. 

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._

Modified existing integration tests.