### PR TITLE
[C-3353] Add WelcomeModal for the new sign up flow for both web and mobile web

### DIFF
--- a/packages/common/src/store/ui/modals/parentSlice.ts
+++ b/packages/common/src/store/ui/modals/parentSlice.ts
@@ -55,7 +55,8 @@ export const initialState: BasicModalsState = {
   USDCPurchaseDetailsModal: { isOpen: false },
   USDCTransactionDetailsModal: { isOpen: false },
   USDCManualTransferModal: { isOpen: false },
-  AddFundsModal: { isOpen: false }
+  AddFundsModal: { isOpen: false },
+  Welcome: { isOpen: false }
 }
 
 const slice = createSlice({

--- a/packages/common/src/store/ui/modals/types.ts
+++ b/packages/common/src/store/ui/modals/types.ts
@@ -62,6 +62,7 @@ export type Modals =
   | 'USDCTransactionDetailsModal'
   | 'USDCManualTransferModal'
   | 'AddFundsModal'
+  | 'Welcome'
 
 export type BasicModalsState = {
   [modal in Modals]: BaseModalState

--- a/packages/harmony/src/components/button/BaseButton/BaseButton.tsx
+++ b/packages/harmony/src/components/button/BaseButton/BaseButton.tsx
@@ -62,7 +62,9 @@ export const BaseButton = forwardRef<HTMLButtonElement, BaseButtonProps>(
       whiteSpace: 'nowrap',
       transition: `
         transform ${motion.hover},
-        border-color ${motion.hover}
+        border-color ${motion.hover},
+        background-color ${motion.hover},
+        color ${motion.hover}
       `,
 
       ...(fullWidth && {

--- a/packages/harmony/src/components/button/Button/Button.tsx
+++ b/packages/harmony/src/components/button/Button/Button.tsx
@@ -86,6 +86,9 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
 
     // Variant Styles
     const primaryStyles: CSSObject = {
+      '&:hover': { color: themeColors.static.white },
+
+      ...((_isHovered || _isPressed) && { color: themeColors.static.white }),
       ...(isDisabled && {
         backgroundColor: themeColors.neutral.n150,
         boxShadow: 'none'
@@ -114,11 +117,13 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
 
     const tertiaryHoverStyles: CSSObject = {
       backgroundColor: themeColors.background.white,
-      boxShadow: `0 0 0 1px inset ${themeColors.border.strong}, ${shadows.mid}`
+      boxShadow: `0 0 0 1px inset ${themeColors.border.strong}, ${shadows.mid}`,
+      color: themeColors.text.default
     }
     const tertiaryActiveStyles: CSSObject = {
       backgroundColor: themeColors.background.surface2,
       backdropFilter: 'none',
+      color: themeColors.text.default,
       boxShadow: `0 0 0 1px inset ${themeColors.border.strong}`
     }
     const tertiaryStyles: CSSObject = {

--- a/packages/web/src/components/drawer/Drawer.module.css
+++ b/packages/web/src/components/drawer/Drawer.module.css
@@ -7,6 +7,7 @@
   background: var(--white);
   margin-bottom: 0px;
   padding-top: 0px;
+  overflow: hidden;
 
   user-select: none;
   touch-action: none;

--- a/packages/web/src/components/welcome-modal/WelcomeModal.tsx
+++ b/packages/web/src/components/welcome-modal/WelcomeModal.tsx
@@ -1,0 +1,98 @@
+import { useCallback } from 'react'
+
+import { fillString } from '@audius/common'
+import {
+  Button,
+  ButtonType,
+  Flex,
+  IconArrowRight,
+  Text,
+  IconCloudUpload,
+  Avatar
+} from '@audius/harmony'
+import { Modal } from '@audius/stems'
+import { useSelector } from 'react-redux'
+import { Link } from 'react-router-dom'
+
+import { useModalState } from 'common/hooks/useModalState'
+import {
+  getNameField,
+  getProfileImageField
+} from 'common/store/pages/signon/selectors'
+import Drawer from 'components/drawer/Drawer'
+import { useMedia } from 'hooks/useMedia'
+import { TRENDING_PAGE, UPLOAD_PAGE } from 'utils/route'
+
+const messages = {
+  welcome: 'Welcome to Audius%0! 🎉',
+  startListening: 'Start Listening',
+  upload: 'Upload',
+  youreIn:
+    'You’re in! Discover music from our talented DJs, producers, and artists.'
+}
+
+export const WelcomeModal = () => {
+  const { isMobile } = useMedia()
+  const { value: userName } = useSelector(getNameField)
+  const profileImage = useSelector(getProfileImageField)
+  const [isOpen, setIsOpen] = useModalState('Welcome')
+
+  const Root = isMobile ? Drawer : Modal
+  const onClose = useCallback(() => {
+    setIsOpen(false)
+  }, [setIsOpen])
+
+  return (
+    <Root isOpen={isOpen} onClose={onClose} size='small'>
+      <Flex
+        h={96}
+        justifyContent='center'
+        css={({ color }) => ({
+          zIndex: 1,
+          backgroundColor: color.background.default,
+          background: `url("${profileImage?.url}")`,
+          ...(!isMobile && {
+            '::before': {
+              content: '""',
+              position: 'absolute',
+              top: 0,
+              left: 0,
+              height: '100%',
+              width: '100%',
+              backdropFilter: 'blur(25px)'
+            }
+          })
+        })}
+      >
+        <Avatar
+          variant='strong'
+          src={profileImage?.url}
+          css={{ position: 'absolute', top: 40, height: 96, width: 96 }}
+        />
+      </Flex>
+      <Flex direction='column' p='xl' pt='3xl' gap='xl'>
+        <Flex direction='column' css={{ textAlign: 'center' }} gap='l'>
+          <Text variant='label' size='xl' strength='strong'>
+            {fillString(messages.welcome, userName ? `, ${userName}` : '')}
+          </Text>
+          <Text variant='body' size='l'>
+            {messages.youreIn}
+          </Text>
+        </Flex>
+        <Flex direction='column' gap='s'>
+          <Button iconRight={IconArrowRight} onClick={onClose} asChild>
+            <Link to={TRENDING_PAGE}>{messages.startListening}</Link>
+          </Button>
+          <Button
+            variant={ButtonType.SECONDARY}
+            iconLeft={IconCloudUpload}
+            onClick={onClose}
+            asChild
+          >
+            <Link to={UPLOAD_PAGE}>{messages.upload}</Link>
+          </Button>
+        </Flex>
+      </Flex>
+    </Root>
+  )
+}

--- a/packages/web/src/pages/modals/Modals.tsx
+++ b/packages/web/src/pages/modals/Modals.tsx
@@ -36,6 +36,7 @@ import { USDCPurchaseDetailsModal } from 'components/usdc-purchase-details-modal
 import { USDCTransactionDetailsModal } from 'components/usdc-transaction-details-modal/USDCTransactionDetailsModal'
 import TierExplainerModal from 'components/user-badges/TierExplainerModal'
 import ConnectedUserListModal from 'components/user-list-modal/ConnectedUserListModal'
+import { WelcomeModal } from 'components/welcome-modal/WelcomeModal'
 import { WithdrawUSDCModal } from 'components/withdraw-usdc-modal/WithdrawUSDCModal'
 import AudioBreakdownModal from 'pages/audio-rewards-page/components/modals/AudioBreakdownModal'
 import { ChallengeRewardsModal } from 'pages/audio-rewards-page/components/modals/ChallengeRewardsModal'
@@ -96,6 +97,7 @@ const commonModalsMap: { [Modal in ModalTypes]?: ComponentType } = {
   BrowserPushPermissionConfirmation: BrowserPushConfirmationModal,
   ShareSoundToTikTok: ShareSoundToTikTokModal,
   AiAttributionSettings: AiAttributionSettingsModal,
+  Welcome: WelcomeModal,
   PremiumContentPurchaseModal,
   LeavingAudiusModal,
   CreateChatModal,

--- a/packages/web/src/pages/sign-up-page/SignUpRootPage.tsx
+++ b/packages/web/src/pages/sign-up-page/SignUpRootPage.tsx
@@ -63,7 +63,6 @@ const determineAllowedRoute = (
   if (signUpState.followArtists?.selectedUserIds?.length >= 3) {
     // Already have 3 artists followed
     // Done with sign up if at this point so we return early (none of these routes are allowed anymore)
-    // TODO: trigger welcome modal when redirecting from here
     return { isAllowedRoute: false, correctedRoute: TRENDING_PAGE }
   }
 

--- a/packages/web/src/pages/sign-up-page/pages/SelectArtistsPage.tsx
+++ b/packages/web/src/pages/sign-up-page/pages/SelectArtistsPage.tsx
@@ -10,6 +10,7 @@ import { Button } from '@audius/harmony'
 import { Form, Formik } from 'formik'
 import { useDispatch } from 'react-redux'
 
+import { useModalState } from 'common/hooks/useModalState'
 import { addFollowArtists } from 'common/store/pages/signon/actions'
 import { getGenres } from 'common/store/pages/signon/selectors'
 import { useNavigateToPage } from 'hooks/useNavigateToPage'
@@ -35,6 +36,7 @@ const initialValues: SelectArtistsValues = {
 
 export const SelectArtistsPage = () => {
   const genres = useSelector((state) => ['Featured', ...getGenres(state)])
+  const [, setIsWelcomeModalOpen] = useModalState('Welcome')
   const [currentGenre, setCurrentGenre] = useState('Featured')
   const dispatch = useDispatch()
   const navigate = useNavigateToPage()
@@ -47,10 +49,10 @@ export const SelectArtistsPage = () => {
     (values: SelectArtistsValues) => {
       const { artists } = values
       dispatch(addFollowArtists(artists))
-      // TODO: trigger CTA modal on trending page
       navigate(TRENDING_PAGE)
+      setIsWelcomeModalOpen(true)
     },
-    [dispatch, navigate]
+    [dispatch, navigate, setIsWelcomeModalOpen]
   )
 
   const isFeaturedArtists = currentGenre === 'Featured'


### PR DESCRIPTION
### Description
Update the state for modals and added the WelcomeModal component that is used for both desktop and mobile web. (Same content, but renders within a Modal or Drawer depending on desktop vs mobile web)

<img width="660" alt="Screenshot 2023-11-15 at 6 32 14 PM" src="https://github.com/AudiusProject/audius-protocol/assets/23732287/6286d3c1-03f4-44fe-b906-5a45ebd7d0c8">
<img width="512" alt="Screenshot 2023-11-15 at 6 32 56 PM" src="https://github.com/AudiusProject/audius-protocol/assets/23732287/315ab7fd-8354-48ac-848a-a3075de37e34">

Note: Dispatching an action to open the drawer when the user continues from the artist select page. Not sure if this is the best way to handle this or if there should be a something else listening on trending or something to open the drawer. Open to suggestions here

Note 2: Tried looking into a scheduler for modals, but it looked like there would some work to handle this case, but also other cases where we do want modals that overlap so making a ticket to look into this later.

### How Has This Been Tested?
Could not accurately test by going through the sign up flow as things were not working for me locally
Tested locally by dispatching a few actions to set use info and open the modal.
Things looked good on both desktop and mobile web 
