### PR TITLE
[PAY-2168] Add better typechecking for FixedDecimal

### DIFF
--- a/packages/common/src/utils/formatUtil.test.ts
+++ b/packages/common/src/utils/formatUtil.test.ts
@@ -92,21 +92,21 @@ describe('formatUtil', function () {
   it('can convert float to wei', function () {
     const float = '12345.67890'
     const expected = '12345678900000000000000'
-    expect(AUDIO(float).value.toString()).toBe(expected)
+    expect(AUDIO(float).BigNumberBrand.toString()).toBe(expected)
     expect(convertFloatToWei(float)?.toString()).toBe(expected)
   })
 
   it('can parse wei number (integer)', function () {
     const weiNumber = '1234567890'
     const expected = '1234567890000000000000000000'
-    expect(AUDIO(weiNumber).value.toString()).toBe(expected)
+    expect(AUDIO(weiNumber).BigNumberBrand.toString()).toBe(expected)
     expect(parseWeiNumber(weiNumber)?.toString()).toBe(expected)
   })
 
   it('can parse wei number (floating point)', function () {
     const weiNumber = '1234.567890'
     const expected = '1234567890000000000000'
-    expect(AUDIO(weiNumber).value.toString()).toBe(expected)
+    expect(AUDIO(weiNumber).BigNumberBrand.toString()).toBe(expected)
     expect(parseWeiNumber(weiNumber)?.toString()).toBe(expected)
   })
 

--- a/packages/common/src/utils/formatUtil.test.ts
+++ b/packages/common/src/utils/formatUtil.test.ts
@@ -92,21 +92,21 @@ describe('formatUtil', function () {
   it('can convert float to wei', function () {
     const float = '12345.67890'
     const expected = '12345678900000000000000'
-    expect(AUDIO(float).BigNumberBrand.toString()).toBe(expected)
+    expect(AUDIO(float).value.toString()).toBe(expected)
     expect(convertFloatToWei(float)?.toString()).toBe(expected)
   })
 
   it('can parse wei number (integer)', function () {
     const weiNumber = '1234567890'
     const expected = '1234567890000000000000000000'
-    expect(AUDIO(weiNumber).BigNumberBrand.toString()).toBe(expected)
+    expect(AUDIO(weiNumber).value.toString()).toBe(expected)
     expect(parseWeiNumber(weiNumber)?.toString()).toBe(expected)
   })
 
   it('can parse wei number (floating point)', function () {
     const weiNumber = '1234.567890'
     const expected = '1234567890000000000000'
-    expect(AUDIO(weiNumber).BigNumberBrand.toString()).toBe(expected)
+    expect(AUDIO(weiNumber).value.toString()).toBe(expected)
     expect(parseWeiNumber(weiNumber)?.toString()).toBe(expected)
   })
 

--- a/packages/common/src/utils/wallet.test.ts
+++ b/packages/common/src/utils/wallet.test.ts
@@ -22,7 +22,7 @@ describe('wallet.ts currency formatting and conversion tests', function () {
   it('can parse audio input to wei', function () {
     const audioInput = '12345'
     const expected = '12345000000000000000000'
-    expect(AUDIO(audioInput).BigNumberBrand.toString()).toBe(expected)
+    expect(AUDIO(audioInput).value.toString()).toBe(expected)
     expect(parseAudioInputToWei(audioInput)?.toString()).toBe(expected)
   })
 
@@ -64,8 +64,8 @@ describe('wallet.ts currency formatting and conversion tests', function () {
     }
     const decimal = new FixedDecimal(amount, decimals)
     expect({
-      amount: Number(decimal.BigNumberBrand),
-      amountString: decimal.BigNumberBrand.toString(),
+      amount: Number(decimal.value),
+      amountString: decimal.value.toString(),
       uiAmount: Number(decimal.toString()),
       uiAmountString: decimal.toString()
     }).toMatchObject(expected)
@@ -77,28 +77,28 @@ describe('wallet.ts currency formatting and conversion tests', function () {
   it('can convert waudio to wei', function () {
     const waudio = new BN('123456789123456789')
     const expected = '1234567891234567890000000000'
-    expect(AUDIO(wAUDIO(waudio)).BigNumberBrand.toString()).toBe(expected)
+    expect(AUDIO(wAUDIO(waudio)).value.toString()).toBe(expected)
     expect(convertWAudioToWei(waudio).toString()).toBe(expected)
   })
 
   it('can convert wei to waudio', function () {
     const wei = new BN('123456789012345678901234567890')
     const expected = '12345678901234567890'
-    expect(wAUDIO(AUDIO(wei)).BigNumberBrand.toString()).toBe(expected)
+    expect(wAUDIO(AUDIO(wei)).value.toString()).toBe(expected)
     expect(convertWeiToWAudio(wei).toString()).toBe(expected)
   })
 
   it('can ceil usdc to nearest cent', function () {
     const usdc = new BN('1234567890')
     const expected = '1234570000'
-    expect(USDC(usdc).ceil(2).BigNumberBrand.toString()).toBe(expected)
+    expect(USDC(usdc).ceil(2).value.toString()).toBe(expected)
     expect(ceilingBNUSDCToNearestCent(usdc as BNUSDC).toString()).toBe(expected)
   })
 
   it('can floor usdc to nearest cent', function () {
     const usdc = new BN('1234567890')
     const expected = '1234560000'
-    expect(USDC(usdc).floor(2).BigNumberBrand.toString()).toBe(expected)
+    expect(USDC(usdc).floor(2).value.toString()).toBe(expected)
     expect(floorBNUSDCToNearestCent(usdc as BNUSDC).toString()).toBe(expected)
   })
 

--- a/packages/common/src/utils/wallet.test.ts
+++ b/packages/common/src/utils/wallet.test.ts
@@ -22,7 +22,7 @@ describe('wallet.ts currency formatting and conversion tests', function () {
   it('can parse audio input to wei', function () {
     const audioInput = '12345'
     const expected = '12345000000000000000000'
-    expect(AUDIO(audioInput).value.toString()).toBe(expected)
+    expect(AUDIO(audioInput).BigNumberBrand.toString()).toBe(expected)
     expect(parseAudioInputToWei(audioInput)?.toString()).toBe(expected)
   })
 
@@ -64,8 +64,8 @@ describe('wallet.ts currency formatting and conversion tests', function () {
     }
     const decimal = new FixedDecimal(amount, decimals)
     expect({
-      amount: Number(decimal.value),
-      amountString: decimal.value.toString(),
+      amount: Number(decimal.BigNumberBrand),
+      amountString: decimal.BigNumberBrand.toString(),
       uiAmount: Number(decimal.toString()),
       uiAmountString: decimal.toString()
     }).toMatchObject(expected)
@@ -77,28 +77,28 @@ describe('wallet.ts currency formatting and conversion tests', function () {
   it('can convert waudio to wei', function () {
     const waudio = new BN('123456789123456789')
     const expected = '1234567891234567890000000000'
-    expect(AUDIO(wAUDIO(waudio)).value.toString()).toBe(expected)
+    expect(AUDIO(wAUDIO(waudio)).BigNumberBrand.toString()).toBe(expected)
     expect(convertWAudioToWei(waudio).toString()).toBe(expected)
   })
 
   it('can convert wei to waudio', function () {
     const wei = new BN('123456789012345678901234567890')
     const expected = '12345678901234567890'
-    expect(wAUDIO(AUDIO(wei)).value.toString()).toBe(expected)
+    expect(wAUDIO(AUDIO(wei)).BigNumberBrand.toString()).toBe(expected)
     expect(convertWeiToWAudio(wei).toString()).toBe(expected)
   })
 
   it('can ceil usdc to nearest cent', function () {
     const usdc = new BN('1234567890')
     const expected = '1234570000'
-    expect(USDC(usdc).ceil(2).value.toString()).toBe(expected)
+    expect(USDC(usdc).ceil(2).BigNumberBrand.toString()).toBe(expected)
     expect(ceilingBNUSDCToNearestCent(usdc as BNUSDC).toString()).toBe(expected)
   })
 
   it('can floor usdc to nearest cent', function () {
     const usdc = new BN('1234567890')
     const expected = '1234560000'
-    expect(USDC(usdc).floor(2).value.toString()).toBe(expected)
+    expect(USDC(usdc).floor(2).BigNumberBrand.toString()).toBe(expected)
     expect(floorBNUSDCToNearestCent(usdc as BNUSDC).toString()).toBe(expected)
   })
 

--- a/packages/fixed-decimal/package.json
+++ b/packages/fixed-decimal/package.json
@@ -7,8 +7,9 @@
   "module": "./dist/esm/index.js",
   "types": "./dist/types/index.d.ts",
   "scripts": {
-    "start": "tsc --build --verbose --watch tsconfig.json",
-    "build": "tsc --build --verbose tsconfig.json",
+    "start": "tsc --build --verbose --watch tsconfig.build.json",
+    "build": "tsc --build --verbose tsconfig.build.json",
+    "typecheck": "tsc --noEmit",
     "test": "vitest"
   },
   "repository": {

--- a/packages/fixed-decimal/src/FixedDecimal.ts
+++ b/packages/fixed-decimal/src/FixedDecimal.ts
@@ -11,23 +11,23 @@ import { NoBrand } from './utilityTypes'
  * @param decimalPlaces The number of decimal places the result should have.
  * @returns
  */
-const parseFixedDecimalString = (
+const parseFixedDecimalString = <T extends bigint>(
   value: string,
   decimalPlaces?: number
-): FixedDecimalCtorArgs => {
+): FixedDecimalCtorArgs<T> => {
   let [whole, decimal] = value.split('.')
   decimal = decimal ?? ''
   if (decimalPlaces !== undefined) {
     decimal = decimal.padEnd(decimalPlaces, '0').substring(0, decimalPlaces)
   }
   return {
-    value: BigInt(`${whole}${decimal}`),
+    value: BigInt(`${whole}${decimal}`) as T,
     decimalPlaces: decimalPlaces ?? decimal.length
   }
 }
 
-type FixedDecimalCtorArgs = {
-  value: bigint
+type FixedDecimalCtorArgs<T extends bigint> = {
+  value: T
   decimalPlaces: number
 }
 
@@ -171,7 +171,7 @@ export class FixedDecimal<T extends bigint, K extends BN = BN> {
    */
   constructor(
     value:
-      | FixedDecimalCtorArgs
+      | FixedDecimalCtorArgs<T>
       | T
       | NoBrand<bigint>
       | number
@@ -188,27 +188,30 @@ export class FixedDecimal<T extends bigint, K extends BN = BN> {
         if (value.toString() === value.toExponential()) {
           throw new Error('Number must not be in scientific notation')
         }
-        const parsed = parseFixedDecimalString(value.toString(), decimalPlaces)
-        this.value = parsed.value as T
+        const parsed = parseFixedDecimalString<T>(
+          value.toString(),
+          decimalPlaces
+        )
+        this.value = parsed.value
         this.decimalPlaces = parsed.decimalPlaces
         break
       }
       case 'string': {
-        const parsed = parseFixedDecimalString(value, decimalPlaces)
-        this.value = parsed.value as T
+        const parsed = parseFixedDecimalString<T>(value, decimalPlaces)
+        this.value = parsed.value
         this.decimalPlaces = parsed.decimalPlaces
         break
       }
       case 'object': {
         if (value instanceof FixedDecimal) {
-          const parsed = parseFixedDecimalString(
+          const parsed = parseFixedDecimalString<T>(
             value.toString(),
             decimalPlaces
           )
-          this.value = parsed.value as T
+          this.value = parsed.value
           this.decimalPlaces = parsed.decimalPlaces
         } else if ('value' in value) {
-          this.value = value.value as T
+          this.value = value.value
           this.decimalPlaces = value.decimalPlaces
         } else {
           // Construct from BN.
@@ -243,7 +246,7 @@ export class FixedDecimal<T extends bigint, K extends BN = BN> {
     const divisor = BigInt(10 ** digitsToRemove)
     const bump = this.value % divisor > 0 ? BigInt(1) : BigInt(0)
     return new FixedDecimal<T, K>({
-      value: (this.value / divisor + bump) * divisor,
+      value: ((this.value / divisor + bump) * divisor) as T,
       decimalPlaces: this.decimalPlaces
     })
   }
@@ -268,7 +271,7 @@ export class FixedDecimal<T extends bigint, K extends BN = BN> {
         ? BigInt(-1 * 10 ** digitsToRemove)
         : BigInt(0)
     return new FixedDecimal<T, K>({
-      value: (this.value / divisor) * divisor + signOffset,
+      value: ((this.value / divisor) * divisor + signOffset) as T,
       decimalPlaces: this.decimalPlaces
     })
   }
@@ -289,7 +292,7 @@ export class FixedDecimal<T extends bigint, K extends BN = BN> {
     }
     const divisor = BigInt(10 ** digitsToRemove)
     return new FixedDecimal<T, K>({
-      value: (this.value / divisor) * divisor,
+      value: ((this.value / divisor) * divisor) as T,
       decimalPlaces: this.decimalPlaces
     })
   }

--- a/packages/fixed-decimal/src/FixedDecimal.ts
+++ b/packages/fixed-decimal/src/FixedDecimal.ts
@@ -113,7 +113,7 @@ type FixedDecimalFormatOptions = {
  * @see {@link FixedDecimalFormatOptions}
  * @see {@link https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/NumberFormat/NumberFormat#moreprecision MDN Documentation for Intl.NumberFormat}
  */
-const defaultFormatOptions = (value: FixedDecimal<any>) =>
+const defaultFormatOptions = (value: FixedDecimal) =>
   ({
     useGrouping: true,
     minimumFractionDigits: 0,
@@ -154,8 +154,11 @@ const defaultFormatOptions = (value: FixedDecimal<any>) =>
  * // Represent fractional dollars and round to cents
  * new FixedDecimal(1.32542).toFixed(2) // '1.33'
  */
-export class FixedDecimal<T extends bigint, K extends BN = BN> {
-  public value: T
+export class FixedDecimal<
+  BrandedBigInt extends bigint = bigint,
+  BrandedBN extends BN = BN
+> {
+  public value: BrandedBigInt
   public decimalPlaces: number
 
   /**
@@ -171,12 +174,12 @@ export class FixedDecimal<T extends bigint, K extends BN = BN> {
    */
   constructor(
     value:
-      | FixedDecimalCtorArgs<T>
-      | T
+      | FixedDecimalCtorArgs<BrandedBigInt>
+      | BrandedBigInt
       | NoBrand<bigint>
       | number
       | string
-      | K
+      | BrandedBN
       | NoBrand<BN>,
     decimalPlaces?: number
   ) {
@@ -188,7 +191,7 @@ export class FixedDecimal<T extends bigint, K extends BN = BN> {
         if (value.toString() === value.toExponential()) {
           throw new Error('Number must not be in scientific notation')
         }
-        const parsed = parseFixedDecimalString<T>(
+        const parsed = parseFixedDecimalString<BrandedBigInt>(
           value.toString(),
           decimalPlaces
         )
@@ -197,14 +200,17 @@ export class FixedDecimal<T extends bigint, K extends BN = BN> {
         break
       }
       case 'string': {
-        const parsed = parseFixedDecimalString<T>(value, decimalPlaces)
+        const parsed = parseFixedDecimalString<BrandedBigInt>(
+          value,
+          decimalPlaces
+        )
         this.value = parsed.value
         this.decimalPlaces = parsed.decimalPlaces
         break
       }
       case 'object': {
         if (value instanceof FixedDecimal) {
-          const parsed = parseFixedDecimalString<T>(
+          const parsed = parseFixedDecimalString<BrandedBigInt>(
             value.toString(),
             decimalPlaces
           )
@@ -218,13 +224,13 @@ export class FixedDecimal<T extends bigint, K extends BN = BN> {
           // Can't do `value instanceof BN` as the condition because BN is just
           // a type, instead get BN by elimination. Technically any object works
           // here that has a toString() that's a valid BigInt() arg.
-          this.value = BigInt(value.toString()) as T
+          this.value = BigInt(value.toString()) as BrandedBigInt
           this.decimalPlaces = decimalPlaces ?? 0
         }
         break
       }
       default:
-        this.value = value as T
+        this.value = value as BrandedBigInt
         this.decimalPlaces = decimalPlaces ?? 0
     }
   }
@@ -245,8 +251,8 @@ export class FixedDecimal<T extends bigint, K extends BN = BN> {
     }
     const divisor = BigInt(10 ** digitsToRemove)
     const bump = this.value % divisor > 0 ? BigInt(1) : BigInt(0)
-    return new FixedDecimal<T, K>({
-      value: ((this.value / divisor + bump) * divisor) as T,
+    return new FixedDecimal<BrandedBigInt, BrandedBN>({
+      value: ((this.value / divisor + bump) * divisor) as BrandedBigInt,
       decimalPlaces: this.decimalPlaces
     })
   }
@@ -270,8 +276,8 @@ export class FixedDecimal<T extends bigint, K extends BN = BN> {
       this.value < 0 && digitsToRemove > 0
         ? BigInt(-1 * 10 ** digitsToRemove)
         : BigInt(0)
-    return new FixedDecimal<T, K>({
-      value: ((this.value / divisor) * divisor + signOffset) as T,
+    return new FixedDecimal<BrandedBigInt, BrandedBN>({
+      value: ((this.value / divisor) * divisor + signOffset) as BrandedBigInt,
       decimalPlaces: this.decimalPlaces
     })
   }
@@ -291,8 +297,8 @@ export class FixedDecimal<T extends bigint, K extends BN = BN> {
       throw new RangeError('Digits must be non-negative')
     }
     const divisor = BigInt(10 ** digitsToRemove)
-    return new FixedDecimal<T, K>({
-      value: ((this.value / divisor) * divisor) as T,
+    return new FixedDecimal<BrandedBigInt, BrandedBN>({
+      value: ((this.value / divisor) * divisor) as BrandedBigInt,
       decimalPlaces: this.decimalPlaces
     })
   }
@@ -320,8 +326,8 @@ export class FixedDecimal<T extends bigint, K extends BN = BN> {
     // Divide by 10 to remove the rounding test digit
     quotient /= BigInt(10)
     // Multiply by the original divisor and 10 to get the number of digits back
-    return new FixedDecimal<T, K>(
-      (quotient * divisor * BigInt(10)) as T,
+    return new FixedDecimal<BrandedBigInt, BrandedBN>(
+      (quotient * divisor * BigInt(10)) as BrandedBigInt,
       this.decimalPlaces
     )
   }

--- a/packages/fixed-decimal/src/FixedDecimal.ts
+++ b/packages/fixed-decimal/src/FixedDecimal.ts
@@ -156,7 +156,7 @@ const defaultFormatOptions = (value: FixedDecimal) =>
  */
 export class FixedDecimal<
   BigIntBrand extends bigint = bigint,
-  K extends BN = BN
+  BNBrand extends BN = BN
 > {
   public value: BigIntBrand
   public decimalPlaces: number
@@ -179,7 +179,7 @@ export class FixedDecimal<
       | NoBrand<bigint>
       | number
       | string
-      | K
+      | BNBrand
       | NoBrand<BN>,
     decimalPlaces?: number
   ) {
@@ -251,7 +251,7 @@ export class FixedDecimal<
     }
     const divisor = BigInt(10 ** digitsToRemove)
     const bump = this.value % divisor > 0 ? BigInt(1) : BigInt(0)
-    return new FixedDecimal<BigIntBrand, K>({
+    return new FixedDecimal<BigIntBrand, BNBrand>({
       value: ((this.value / divisor + bump) * divisor) as BigIntBrand,
       decimalPlaces: this.decimalPlaces
     })
@@ -276,7 +276,7 @@ export class FixedDecimal<
       this.value < 0 && digitsToRemove > 0
         ? BigInt(-1 * 10 ** digitsToRemove)
         : BigInt(0)
-    return new FixedDecimal<BigIntBrand, K>({
+    return new FixedDecimal<BigIntBrand, BNBrand>({
       value: ((this.value / divisor) * divisor + signOffset) as BigIntBrand,
       decimalPlaces: this.decimalPlaces
     })
@@ -297,7 +297,7 @@ export class FixedDecimal<
       throw new RangeError('Digits must be non-negative')
     }
     const divisor = BigInt(10 ** digitsToRemove)
-    return new FixedDecimal<BigIntBrand, K>({
+    return new FixedDecimal<BigIntBrand, BNBrand>({
       value: ((this.value / divisor) * divisor) as BigIntBrand,
       decimalPlaces: this.decimalPlaces
     })
@@ -326,7 +326,7 @@ export class FixedDecimal<
     // Divide by 10 to remove the rounding test digit
     quotient /= BigInt(10)
     // Multiply by the original divisor and 10 to get the number of digits back
-    return new FixedDecimal<BigIntBrand, K>(
+    return new FixedDecimal<BigIntBrand, BNBrand>(
       (quotient * divisor * BigInt(10)) as BigIntBrand,
       this.decimalPlaces
     )

--- a/packages/fixed-decimal/src/FixedDecimal.ts
+++ b/packages/fixed-decimal/src/FixedDecimal.ts
@@ -390,24 +390,24 @@ export class FixedDecimal<T extends bigint, K extends BN = BN> {
    */
   public toLocaleString(locale?: string, options?: FixedDecimalFormatOptions) {
     // Apply defaults
-    options = {
+    const mergedOptions = {
       ...defaultFormatOptions(this),
       ...options
     }
     // Apply rounding method
     let str = ''
-    switch (options.roundingMode) {
+    switch (mergedOptions.roundingMode) {
       case 'ceil':
-        str = this.ceil(options.maximumFractionDigits).toString()
+        str = this.ceil(mergedOptions.maximumFractionDigits).toString()
         break
       case 'floor':
-        str = this.floor(options.maximumFractionDigits).toString()
+        str = this.floor(mergedOptions.maximumFractionDigits).toString()
         break
       case 'trunc':
-        str = this.trunc(options.maximumFractionDigits).toString()
+        str = this.trunc(mergedOptions.maximumFractionDigits).toString()
         break
       case 'halfExpand':
-        str = this.round(options.maximumFractionDigits).toString()
+        str = this.round(mergedOptions.maximumFractionDigits).toString()
         break
     }
 
@@ -416,12 +416,12 @@ export class FixedDecimal<T extends bigint, K extends BN = BN> {
     // Strip trailing zeros
     decimal = (decimal ?? '').replace(/0+$/, '')
 
-    if (options.minimumFractionDigits !== undefined) {
+    if (mergedOptions.minimumFractionDigits !== undefined) {
       if (
-        options.trailingZeroDisplay !== 'stripIfInteger' ||
+        mergedOptions.trailingZeroDisplay !== 'stripIfInteger' ||
         BigInt(decimal) !== BigInt(0)
       ) {
-        decimal = decimal.padEnd(options.minimumFractionDigits, '0')
+        decimal = decimal.padEnd(mergedOptions.minimumFractionDigits, '0')
       }
     }
 

--- a/packages/fixed-decimal/src/FixedDecimal.ts
+++ b/packages/fixed-decimal/src/FixedDecimal.ts
@@ -113,7 +113,7 @@ type FixedDecimalFormatOptions = {
  * @see {@link FixedDecimalFormatOptions}
  * @see {@link https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/NumberFormat/NumberFormat#moreprecision MDN Documentation for Intl.NumberFormat}
  */
-const defaultFormatOptions = (value: FixedDecimal<any>) =>
+const defaultFormatOptions = (value: FixedDecimal) =>
   ({
     useGrouping: true,
     minimumFractionDigits: 0,
@@ -154,8 +154,11 @@ const defaultFormatOptions = (value: FixedDecimal<any>) =>
  * // Represent fractional dollars and round to cents
  * new FixedDecimal(1.32542).toFixed(2) // '1.33'
  */
-export class FixedDecimal<T extends bigint, K extends BN = BN> {
-  public value: T
+export class FixedDecimal<
+  BigIntBrand extends bigint = bigint,
+  K extends BN = BN
+> {
+  public value: BigIntBrand
   public decimalPlaces: number
 
   /**
@@ -171,8 +174,8 @@ export class FixedDecimal<T extends bigint, K extends BN = BN> {
    */
   constructor(
     value:
-      | FixedDecimalCtorArgs<T>
-      | T
+      | FixedDecimalCtorArgs<bigint>
+      | BigIntBrand
       | NoBrand<bigint>
       | number
       | string
@@ -188,7 +191,7 @@ export class FixedDecimal<T extends bigint, K extends BN = BN> {
         if (value.toString() === value.toExponential()) {
           throw new Error('Number must not be in scientific notation')
         }
-        const parsed = parseFixedDecimalString<T>(
+        const parsed = parseFixedDecimalString<BigIntBrand>(
           value.toString(),
           decimalPlaces
         )
@@ -197,34 +200,37 @@ export class FixedDecimal<T extends bigint, K extends BN = BN> {
         break
       }
       case 'string': {
-        const parsed = parseFixedDecimalString<T>(value, decimalPlaces)
+        const parsed = parseFixedDecimalString<BigIntBrand>(
+          value,
+          decimalPlaces
+        )
         this.value = parsed.value
         this.decimalPlaces = parsed.decimalPlaces
         break
       }
       case 'object': {
         if (value instanceof FixedDecimal) {
-          const parsed = parseFixedDecimalString<T>(
+          const parsed = parseFixedDecimalString<BigIntBrand>(
             value.toString(),
             decimalPlaces
           )
           this.value = parsed.value
           this.decimalPlaces = parsed.decimalPlaces
         } else if ('value' in value) {
-          this.value = value.value
+          this.value = value.value as BigIntBrand
           this.decimalPlaces = value.decimalPlaces
         } else {
           // Construct from BN.
           // Can't do `value instanceof BN` as the condition because BN is just
           // a type, instead get BN by elimination. Technically any object works
           // here that has a toString() that's a valid BigInt() arg.
-          this.value = BigInt(value.toString()) as T
+          this.value = BigInt(value.toString()) as BigIntBrand
           this.decimalPlaces = decimalPlaces ?? 0
         }
         break
       }
       default:
-        this.value = value as T
+        this.value = value as BigIntBrand
         this.decimalPlaces = decimalPlaces ?? 0
     }
   }
@@ -245,8 +251,8 @@ export class FixedDecimal<T extends bigint, K extends BN = BN> {
     }
     const divisor = BigInt(10 ** digitsToRemove)
     const bump = this.value % divisor > 0 ? BigInt(1) : BigInt(0)
-    return new FixedDecimal<T, K>({
-      value: ((this.value / divisor + bump) * divisor) as T,
+    return new FixedDecimal<BigIntBrand, K>({
+      value: ((this.value / divisor + bump) * divisor) as BigIntBrand,
       decimalPlaces: this.decimalPlaces
     })
   }
@@ -270,8 +276,8 @@ export class FixedDecimal<T extends bigint, K extends BN = BN> {
       this.value < 0 && digitsToRemove > 0
         ? BigInt(-1 * 10 ** digitsToRemove)
         : BigInt(0)
-    return new FixedDecimal<T, K>({
-      value: ((this.value / divisor) * divisor + signOffset) as T,
+    return new FixedDecimal<BigIntBrand, K>({
+      value: ((this.value / divisor) * divisor + signOffset) as BigIntBrand,
       decimalPlaces: this.decimalPlaces
     })
   }
@@ -291,8 +297,8 @@ export class FixedDecimal<T extends bigint, K extends BN = BN> {
       throw new RangeError('Digits must be non-negative')
     }
     const divisor = BigInt(10 ** digitsToRemove)
-    return new FixedDecimal<T, K>({
-      value: ((this.value / divisor) * divisor) as T,
+    return new FixedDecimal<BigIntBrand, K>({
+      value: ((this.value / divisor) * divisor) as BigIntBrand,
       decimalPlaces: this.decimalPlaces
     })
   }
@@ -320,8 +326,8 @@ export class FixedDecimal<T extends bigint, K extends BN = BN> {
     // Divide by 10 to remove the rounding test digit
     quotient /= BigInt(10)
     // Multiply by the original divisor and 10 to get the number of digits back
-    return new FixedDecimal<T, K>(
-      (quotient * divisor * BigInt(10)) as T,
+    return new FixedDecimal<BigIntBrand, K>(
+      (quotient * divisor * BigInt(10)) as BigIntBrand,
       this.decimalPlaces
     )
   }

--- a/packages/fixed-decimal/src/currencies.test.ts
+++ b/packages/fixed-decimal/src/currencies.test.ts
@@ -1,20 +1,65 @@
-import { AUDIO, USDC, wAUDIO } from './currencies'
+import BN from 'bn.js'
+import { describe, it, expect } from 'vitest'
+
+import {
+  AUDIO,
+  AudioWei,
+  BNAudio,
+  BNUSDC,
+  USDC,
+  UsdcWei,
+  wAUDIO
+} from './currencies'
 
 describe('Currency tests', function () {
   it('can convert AUDIO to wAUDIO', function () {
     const audio = '123.123456789012345678'
     expect(wAUDIO(AUDIO(audio)).toString()).toBe('123.12345678')
   })
+
   it('can convert wAUDIO to AUDIO', function () {
     const audio = '123.123456789012345678'
     expect(AUDIO(wAUDIO(audio)).toString()).toBe('123.123456780000000000')
   })
+
   it('can convert USDC to USD', function () {
     const usdc = '123.123456'
     expect(USDC(usdc).toFixed(2)).toBe('123.12')
   })
+
   it('can convert USD to USDC', function () {
     const usd = '123.12'
     expect(USDC(usd).toString()).toBe('123.120000')
+  })
+
+  it('typechecks method signatures', function () {
+    const onlyUsdcWei = (a: UsdcWei) => {
+      return a === BigInt(1000000)
+    }
+    // Throw for unexpected brand of bigint
+    // @ts-expect-error
+    onlyUsdcWei(AUDIO(1).value)
+    // Don't throw for USDC bigints
+    onlyUsdcWei(USDC(1).value)
+  })
+
+  it('typechecks constructor bigint', function () {
+    // Throw for unexpected brand of bigint
+    // @ts-expect-error
+    USDC(BigInt(1) as AudioWei)
+    // Don't throw for raw bigint
+    USDC(BigInt(2))
+    // Don't throw for correct bigint brand
+    USDC(BigInt(3) as UsdcWei)
+  })
+
+  it('typechecks constructor BN', function () {
+    // Throw for unexpected brand of BN
+    // @ts-expect-error
+    USDC(new BN(1) as BNAudio)
+    // Don't throw for raw BN
+    USDC(new BN(2))
+    // Don't throw for correct BN brand
+    USDC(new BN(3) as BNUSDC)
   })
 })

--- a/packages/fixed-decimal/src/currencies.ts
+++ b/packages/fixed-decimal/src/currencies.ts
@@ -1,67 +1,86 @@
+import type BN from 'bn.js'
+
 import { FixedDecimal } from './FixedDecimal'
+import { Brand } from './utilityTypes'
 
 /**
  * Creates a {@link FixedDecimal} constructor for a currency.
  * @param decimalPlaces the number of decimal places for the currency
  */
 const createTokenConstructor =
-  <T extends FixedDecimal>(
-    decimalPlaces: ConstructorParameters<typeof FixedDecimal>[1]
+  <T extends bigint, K extends BN = BN>(
+    decimalPlaces: ConstructorParameters<typeof FixedDecimal<T, K>>[1]
   ) =>
-  (value: ConstructorParameters<typeof FixedDecimal>[0]): T =>
-    new FixedDecimal(value, decimalPlaces) as T
+  (value: ConstructorParameters<typeof FixedDecimal<T, K>>[0]) =>
+    new FixedDecimal<T, K>(value, decimalPlaces)
 
 /**
- * A {@link FixedDecimal} representing an amount of Ethereum ERC-20
- * AUDIO tokens, which have 18 decimal places.
- *
- * Used on the protocol dashboard and in the governance and staking systems.
- * Also used for balance totals after adding linked wallets on the Rewards page.
+ * A `bigint` representing an amount of Ethereum ERC-20 AUDIO tokens, which have
+ * 18 decimal places, as a count of the smallest possible denomination of AUDIO.
  */
-type AudioTokens = FixedDecimal & { _brand: 'AUDIO' }
+export type AudioWei = Brand<bigint, 'AUDIO'>
 /**
- * Constructs an amount of {@link AudioTokens} from a fixed decimal string,
- * decimal number, or a bigint or BN in the smallest denomination.
+ * Same as @audius/common BNWei.
+ * For backwards compatibility without circular dependency.
  */
-export const AUDIO = createTokenConstructor<AudioTokens>(18)
+export type BNWei = Brand<BN, 'BNWei'>
+/**
+ * Constructs an amount of {@link AudioWei} from a fixed decimal string,
+ * decimal number, or a bigint or BN in the smallest denomination of AUDIO.
+ *
+ * AUDIO is used on the protocol dashboard and in the governance and staking
+ * systems. Also used for calculating the balance totals of all connected
+ * wallets and the Hedgehog wallet on the Rewards page.
+ */
+export const AUDIO = createTokenConstructor<AudioWei, BNWei>(18)
 
 /**
- * A {@link FixedDecimal} representing an amount of Solana SPL AUDIO
- * tokens, which have 8 decimal places.
- *
- * Used for in-app experiences, like tipping and rewards.
+ * A `bigint` representing an amount of Solana SPL AUDIO tokens, which have
+ * 8 decimal places, as a count of the smallest possible denomination of wAUDIO.
  */
-type wAudioTokens = FixedDecimal & { _brand: 'wAUDIO' }
+export type wAudioWei = bigint & { _brand: 'wAUDIO' }
 /**
- * Constructs an amount of {@link wAudioTokens} from a fixed decimal string,
- * decimal number, or a bigint or BN in the smallest denomination.
+ * Same as @audius/common BNAudio.
+ * For backwards compatibility without circular dependency.
  */
-export const wAUDIO = createTokenConstructor<wAudioTokens>(8)
+export type BNAudio = Brand<BN, 'BNAudio'>
+/**
+ * Constructs an amount of {@link wAudioWei} from a fixed decimal string,
+ * decimal number, or a bigint or BN in the smallest denomination of wAUDIO.
+ *
+ * wAUDIO is used for in-app experiences, like tipping and rewards.
+ */
+export const wAUDIO = createTokenConstructor<wAudioWei, BNAudio>(8)
 
 /**
- * A {@link FixedDecimal} representing an amount of Solana native SOL
- * tokens, which have 9 decimal places.
- *
- * Used as an intermediary token for purchasing wAUDIO and for paying for fees
- * of Solana transactions on the platform.
+ * A `bigint` representing an amount of Solana native SOL tokens, which have
+ * 9 decimal places, as a count of the smallest possible denomination of SOL.
  */
-type SolTokens = FixedDecimal & { _brand: 'SOL' }
+export type SolWei = bigint & { _brand: 'SOL' }
 /**
- * Constructs an amount of {@link SolTokens} from a fixed decimal string,
- * decimal number, or a bigint or BN in the smallest denomination.
+ * Constructs an amount of {@link SolWei} from a fixed decimal string,
+ * decimal number, or a bigint or BN in the smallest denomination of SOL.
+ *
+ * SOL is used as an intermediary token for purchasing wAUDIO and for paying
+ * for fees of Solana transactions on the platform.
  */
-export const SOL = createTokenConstructor<SolTokens>(9)
+export const SOL = createTokenConstructor<SolWei>(9)
 
 /**
- * A {@link FixedDecimal} representing an amount of Solana SPL USDC
- * tokens, which have 6 decimal places.
- *
- * Used for purchasing content in-app, and getting "USD" prices via Jupiter
- * for the wAUDIO token and SOL.
+ * A `bigint` representing an amount of Solana SPL USDC tokens, which have
+ * 6 decimal places, as a count of the smallest possible denomination of USDC.
  */
-type UsdcTokens = FixedDecimal & { _brand: 'USDC' }
+export type UsdcWei = bigint & { _brand: 'USDC' }
 /**
- * Constructs an amount of {@link UsdcTokens} from a fixed decimal string,
- * decimal number, or a bigint or BN in the smallest denomination.
+ * Same as @audius/common BNUSDC.
+ * For backwards compatibility without circular dependency.
  */
-export const USDC = createTokenConstructor<UsdcTokens>(6)
+export type BNUSDC = Brand<BN, 'BNUSDC'>
+/**
+ * Constructs an amount of {@link UsdcWei} from a fixed decimal string,
+ * decimal number, or a bigint or BN in the smallest denomination of USDC.
+ *
+ * USDC is used for purchasing content in-app, and getting "USD" prices via
+ * Jupiter for the wAUDIO token and SOL.
+ */
+export const USDC = createTokenConstructor<UsdcWei, BNUSDC>(6)

--- a/packages/fixed-decimal/src/index.ts
+++ b/packages/fixed-decimal/src/index.ts
@@ -1,2 +1,11 @@
 export { FixedDecimal } from './FixedDecimal'
-export { SOL, wAUDIO, AUDIO, USDC } from './currencies'
+export {
+  SOL,
+  wAUDIO,
+  AUDIO,
+  USDC,
+  SolWei,
+  wAudioWei,
+  AudioWei,
+  UsdcWei
+} from './currencies'

--- a/packages/fixed-decimal/src/utilityTypes.ts
+++ b/packages/fixed-decimal/src/utilityTypes.ts
@@ -1,0 +1,18 @@
+/**
+ * `Brand` allows you to 'specialize' a type to introduce
+ * nominal typing to TS.
+ *
+ * Example:
+ * ```
+ * type USD = Brand<number, 'USD'>
+ * const balance = 3 as USD
+ * ```
+ * @see {@link file://./../../common/src/utils/typeUtils.ts typeUtils.ts}
+ * @see https://dev.to/andersonjoseph/typescript-tip-safer-functions-with-branded-types-14o4
+ */
+export type Brand<T, U extends string> = T & { _brand: U }
+/**
+ * Ensures the type parameter is unbranded.
+ * @see {@link Brand}
+ */
+export type NoBrand<T> = T & { _brand?: never }

--- a/packages/fixed-decimal/tsconfig.base.json
+++ b/packages/fixed-decimal/tsconfig.base.json
@@ -1,0 +1,24 @@
+{
+  "compilerOptions": {
+    "baseUrl": ".",
+    "module": "ESNext",
+    "target": "ESNext",
+    "moduleResolution": "Node",
+    "declarationDir": "dist/types",
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "noImplicitReturns": true,
+    "noImplicitThis": true,
+    "noImplicitAny": true,
+    "downlevelIteration": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true
+  },
+  "include": []
+}

--- a/packages/fixed-decimal/tsconfig.build.cjs.json
+++ b/packages/fixed-decimal/tsconfig.build.cjs.json
@@ -1,8 +1,7 @@
 {
-  "extends": "./tsconfig.base.json",
+  "extends": "./tsconfig.build.json",
   "include": ["src"],
   "compilerOptions": {
-    "composite": true,
     "rootDir": "src",
     "module": "CommonJS",
     "outDir": "dist/cjs"

--- a/packages/fixed-decimal/tsconfig.build.esm.json
+++ b/packages/fixed-decimal/tsconfig.build.esm.json
@@ -1,8 +1,7 @@
 {
-  "extends": "./tsconfig.base.json",
+  "extends": "./tsconfig.build.json",
   "include": ["src"],
   "compilerOptions": {
-    "composite": true,
     "rootDir": "src",
     "outDir": "dist/esm"
   }

--- a/packages/fixed-decimal/tsconfig.build.json
+++ b/packages/fixed-decimal/tsconfig.build.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.base.json",
+  "include": [],
+  "exclude": ["src/**/*.test.ts"],
+  "references": [
+    { "path": "./tsconfig.build.esm.json" },
+    { "path": "./tsconfig.build.cjs.json" }
+  ]
+}

--- a/packages/fixed-decimal/tsconfig.json
+++ b/packages/fixed-decimal/tsconfig.json
@@ -1,27 +1,11 @@
 {
+  "extends": "./tsconfig.base.json",
   "compilerOptions": {
     "composite": true,
-    "baseUrl": ".",
-    "module": "ESNext",
-    "target": "ESNext",
-    "moduleResolution": "Node",
-    "declarationDir": "dist/types",
-    "declaration": true,
-    "declarationMap": true,
-    "sourceMap": true,
-    "skipLibCheck": true,
-    "esModuleInterop": true,
-    "allowSyntheticDefaultImports": true,
-    "forceConsistentCasingInFileNames": true,
-    "strict": true,
-    "noImplicitReturns": true,
-    "noImplicitThis": true,
-    "noImplicitAny": true,
-    "downlevelIteration": true,
-    "noUnusedLocals": true,
-    "noUnusedParameters": true
+    "noEmit": true,
+    "skipLibCheck": true
   },
-  "include": [],
+  "include": ["src"],
   "references": [
     { "path": "./tsconfig.esm.json" },
     { "path": "./tsconfig.cjs.json" }


### PR DESCRIPTION
### Description

Followup on feedback from https://github.com/AudiusProject/audius-protocol/pull/6662

- Adds types to each `FixedDecimal` constructor helper to brand the `bigint`
- TypeError on using the wrong type in a `FixedDecimal` constructor (eg. using `AudioWei` to initialize a `FixedDecimal<wAudioWei>` or a `BNAudio` to initialize a `FixedDecimal<any, BNWei>`)
- Rename `AudioTokens` etc to `AudioWei` etc to be more clear about the value represented, and updated comments
- Add tsconfigs for linting vs building (linting includes test files, building does not)

### How Has This Been Tested?

Adds tests for using correct branding
