### PR TITLE
Tweak Harmony Icon Docs

### DIFF
--- a/packages/harmony/src/icons/UtilityIcons.stories.mdx
+++ b/packages/harmony/src/icons/UtilityIcons.stories.mdx
@@ -25,11 +25,10 @@ Utility icons are simple, single-color glyphs that identify labels and actions a
 <Heading>
 ## Usage
 
-Recommended sizes for utility icons: 14px | 16px | 20px | 24px | 30px | 32px
-
 </Heading>
 
 <Flex direction='column' gap='m'>
+  Sizes
   <Flex alignItems='center' gap='2xl'>
     {Object.keys(iconSizes).map((size) => (
       <Flex direction='column' alignItems='center' gap='s'>

--- a/packages/harmony/src/icons/UtilityIcons.stories.mdx
+++ b/packages/harmony/src/icons/UtilityIcons.stories.mdx
@@ -31,8 +31,13 @@ Utility icons are simple, single-color glyphs that identify labels and actions a
   Sizes
   <Flex alignItems='center' gap='2xl'>
     {Object.keys(iconSizes).map((size) => (
-      <Flex direction='column' alignItems='center' gap='s'>
-        <Icons.IconNote key={size} size={size} key={`icon-${size}`} />
+      <Flex
+        direction='column'
+        alignItems='center'
+        gap='s'
+        key={`container-${size}`}
+      >
+        <Icons.IconNote size={size} key={`icon-${size}`} />
         <Text css={{ color: '#F00 !important', fontSize: '10px !important' }}>
           {size}
         </Text>

--- a/packages/harmony/src/icons/UtilityIcons.stories.mdx
+++ b/packages/harmony/src/icons/UtilityIcons.stories.mdx
@@ -32,21 +32,21 @@ Recommended sizes for utility icons: 14px | 16px | 20px | 24px | 30px | 32px
 <Flex direction='column' gap='m'>
   <Flex alignItems='center' gap='2xl'>
     {Object.keys(iconSizes).map((size) => (
-      <Icons.IconNote key={size} size={size} />
-    ))}
-  </Flex>
-  <Flex alignItems='center' gap='2xl'>
-    {Object.keys(iconSizes).map((size) => (
-      <Flex
-        key={size}
-        alignItems='center'
-        justifyContent='center'
-        h={iconSizes[size]}
-        w={iconSizes[size]}
-        css={{ background: 'rgba(255, 0, 0, 0.10)' }}
-      >
+      <Flex direction='column' alignItems='center' gap='s'>
+        <Icons.IconNote key={size} size={size} />
         <Text css={{ color: '#F00 !important', fontSize: '10px !important' }}>
-          {iconSizes[size]}
+          {size}
+        </Text>
+        <Flex
+          key={size}
+          alignItems='center'
+          justifyContent='center'
+          h={iconSizes[size]}
+          w={iconSizes[size]}
+          css={{ background: 'rgba(255, 0, 0, 0.10)' }}
+        />
+        <Text css={{ color: '#F00 !important', fontSize: '10px !important' }}>
+          {`${iconSizes[size]}px`}
         </Text>
       </Flex>
     ))}

--- a/packages/harmony/src/icons/UtilityIcons.stories.mdx
+++ b/packages/harmony/src/icons/UtilityIcons.stories.mdx
@@ -35,14 +35,13 @@ Utility icons are simple, single-color glyphs that identify labels and actions a
         direction='column'
         alignItems='center'
         gap='s'
-        key={`container-${size}`}
+        key={size}
       >
-        <Icons.IconNote size={size} key={`icon-${size}`} />
+        <Icons.IconNote size={size}} />
         <Text css={{ color: '#F00 !important', fontSize: '10px !important' }}>
           {size}
         </Text>
         <Flex
-          key={size}
           alignItems='center'
           justifyContent='center'
           h={iconSizes[size]}

--- a/packages/harmony/src/icons/UtilityIcons.stories.mdx
+++ b/packages/harmony/src/icons/UtilityIcons.stories.mdx
@@ -32,7 +32,7 @@ Utility icons are simple, single-color glyphs that identify labels and actions a
   <Flex alignItems='center' gap='2xl'>
     {Object.keys(iconSizes).map((size) => (
       <Flex direction='column' alignItems='center' gap='s'>
-        <Icons.IconNote key={size} size={size} />
+        <Icons.IconNote key={size} size={size} key={`icon-${size}`} />
         <Text css={{ color: '#F00 !important', fontSize: '10px !important' }}>
           {size}
         </Text>

--- a/packages/harmony/src/icons/UtilityIcons.stories.mdx
+++ b/packages/harmony/src/icons/UtilityIcons.stories.mdx
@@ -31,13 +31,8 @@ Utility icons are simple, single-color glyphs that identify labels and actions a
   Sizes
   <Flex alignItems='center' gap='2xl'>
     {Object.keys(iconSizes).map((size) => (
-      <Flex
-        direction='column'
-        alignItems='center'
-        gap='s'
-        key={size}
-      >
-        <Icons.IconNote size={size}} />
+      <Flex direction='column' alignItems='center' gap='s' key={size}>
+        <Icons.IconNote size={size} />
         <Text css={{ color: '#F00 !important', fontSize: '10px !important' }}>
           {size}
         </Text>


### PR DESCRIPTION
Per the all-hands demo, we should showcase the preset icon sizes
![image](https://github.com/AudiusProject/audius-protocol/assets/6711655/bb16e66f-b7b7-4342-baeb-40878898fe06)
