### PR TITLE
tabbed SDK doc example

### DIFF
--- a/docs/docs/developers/sdk/Tracks.md
+++ b/docs/docs/developers/sdk/Tracks.md
@@ -1,20 +1,17 @@
+import Tabs from '@theme/Tabs'
+import TabItem from '@theme/TabItem'
+
 ### getTrack
 
 #### getTrack(`params`)
 
 Get a track by id.
 
-Example:
-
-```typescript
-const { data: track } = await audiusSdk.tracks.getTrack({
-  trackId: "D7KyD",
-});
-
-console.log(track);
-```
-
-#### Params
+<Tabs
+  block={true}
+  defaultValue="request"
+  values={[{"label":"Params","value":"request"},{"label":"Example","value":"example"},{"label":"Response","value":"response"}]}>
+<TabItem value="request">
 
 Create an object with the following fields and pass it as the first argument, as shown in the example above.
 
@@ -22,7 +19,21 @@ Create an object with the following fields and pass it as the first argument, as
 | :-------- | :------- | :------------------ | :----------- |
 | `trackId` | `string` | The ID of the track | **Required** |
 
-#### Returns
+</TabItem>
+
+<TabItem value="example">
+
+```typescript title="Typescript example"
+const { data: track } = await audiusSdk.tracks.getTrack({
+  trackId: 'D7KyD',
+})
+
+console.log(track)
+```
+
+</TabItem>
+
+<TabItem value="response">
 
 Returns a `Promise` containing an object with a `data` field. `data` contains information about the track as described below.
 
@@ -85,6 +96,9 @@ Returns a `Promise` containing an object with a `data` field. `data` contains in
   };
 };
 ```
+
+</TabItem>
+</Tabs>
 
 ---
 


### PR DESCRIPTION
### Description

Quick Pass at utilizing Docusaurus tabs for SDK documentation layouts.

Used [getTrack](https://docs.audius.org/developers/sdk/Tracks#gettrack) as an example

Was going to run through them all, but figured I'd get a check on if this is even wanted bofore I update this to be a larger PR.

### How Has This Been Tested?

Stock setup from clean fork of repo. Able to run locally using from within the `/docs` directory.

### Demo Video

Quick screen capture of what these tabs look like and how they work 👇 

https://github.com/AudiusProject/audius-protocol/assets/1404219/65fc9cf8-4842-4ffc-891d-7493eb8b8922
