### PR TITLE
Fix metamask help url

### DIFF
--- a/packages/web/src/components/banner/Web3ErrorBanner.tsx
+++ b/packages/web/src/components/banner/Web3ErrorBanner.tsx
@@ -15,7 +15,7 @@ const messages = {
 }
 
 const META_MASK_SETUP_URL =
-  'https://help.audius.co/help/configuring-metamask-for-use-with-audius-2d446'
+  'https://help.audius.co/help/Configuring-MetaMask-For-Use-With-Audius-2d446'
 
 /**
  * Displays an error banner if the user is trying to use Metamask but it's configured incorrectly

--- a/packages/web/src/pages/sign-on/SignOnProvider.tsx
+++ b/packages/web/src/pages/sign-on/SignOnProvider.tsx
@@ -61,7 +61,7 @@ const messages = {
 }
 
 const META_MASK_SETUP_URL =
-  'https://help.audius.co/help/configuring-metamask-for-use-with-audius-2d446'
+  'https://help.audius.co/help/Configuring-MetaMask-For-Use-With-Audius-2d446'
 
 type OwnProps = {
   children: ComponentType<MobileSignOnProps> | ComponentType<DesktopSignOnProps>


### PR DESCRIPTION
### Description
URL should be
https://help.audius.co/help/Configuring-MetaMask-For-Use-With-Audius-2d446

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._
