### PR TITLE
Support FixedDecimal on mobile

### DIFF
--- a/packages/fixed-decimal/package.json
+++ b/packages/fixed-decimal/package.json
@@ -5,6 +5,7 @@
   "description": "A data structure to represent fixed precision decimals",
   "main": "./dist/cjs/index.js",
   "module": "./dist/esm/index.js",
+  "exports": "./dist/esm/index.js",
   "types": "./dist/types/index.d.ts",
   "scripts": {
     "start": "tsc --build --verbose --watch tsconfig.build.json",

--- a/packages/fixed-decimal/src/FixedDecimal.test.ts
+++ b/packages/fixed-decimal/src/FixedDecimal.test.ts
@@ -596,5 +596,15 @@ describe('FixedDecimal', function () {
         new FixedDecimal('123456789.123456789').toLocaleString('en-IN')
       ).toBe('12,34,56,789.123456789')
     })
+
+    it('formats zero correctly', function () {
+      expect(
+        new FixedDecimal(0, 6).toLocaleString('en-US', {
+          maximumFractionDigits: 2,
+          minimumFractionDigits: 2,
+          trailingZeroDisplay: 'stripIfInteger'
+        })
+      ).toBe('0')
+    })
   })
 })

--- a/packages/fixed-decimal/src/FixedDecimal.ts
+++ b/packages/fixed-decimal/src/FixedDecimal.ts
@@ -433,18 +433,19 @@ export class FixedDecimal<
 
     // Localize with a decimal to extract the separator
     const wholeInt = BigInt(whole)
-    const wholeWithDecimal = wholeInt.toLocaleString(locale, {
+    whole = wholeInt.toLocaleString(locale, {
       ...options,
+      minimumFractionDigits: 0,
+      maximumFractionDigits: 0
+    })
+
+    // Annoyingly, React Native doesn't respect minimumFractionDigits for
+    // bigint formatting. Instead, get the decimalSeparator from a Number.
+    const decimalSeparator = Number(0).toLocaleString(locale, {
       minimumFractionDigits: 1,
       maximumFractionDigits: 1
-    })
-    // Get the separator character
-    const decimalSeparator = wholeWithDecimal.substring(
-      wholeWithDecimal.length - 2,
-      wholeWithDecimal.length - 1
-    )
-    // Remove the decimal
-    whole = wholeWithDecimal.substring(0, wholeWithDecimal.length - 2)
+    })[1]
+
     return decimal.length > 0 ? `${whole}${decimalSeparator}${decimal}` : whole
   }
 

--- a/packages/mobile/metro.config.js
+++ b/packages/mobile/metro.config.js
@@ -6,6 +6,7 @@ const clientPath = path.resolve(__dirname, '../web')
 const commonPath = path.resolve(__dirname, '../../packages/common')
 const sdkPath = path.resolve(__dirname, '../../packages/libs')
 const emptyPolyfill = path.resolve(__dirname, 'src/mocks/empty.ts')
+const fixedDecimalPath = path.resolve(__dirname, '../../packages/fixed-decimal')
 
 const resolveModule = (module) =>
   path.resolve(__dirname, '../../node_modules', module)
@@ -52,7 +53,8 @@ module.exports = (async () => {
       path.resolve(__dirname, '../../node_modules'),
       clientPath,
       commonPath,
-      sdkPath
+      sdkPath,
+      fixedDecimalPath
     ],
     resolver: {
       assetExts: assetExts.filter((ext) => ext !== 'svg'),

--- a/packages/mobile/package.json
+++ b/packages/mobile/package.json
@@ -52,6 +52,7 @@
   "dependencies": {
     "@amplitude/react-native": "2.6.0",
     "@audius/common": "*",
+    "@audius/fixed-decimal": "*",
     "@audius/sdk": "*",
     "@emotion/native": "11.11.0",
     "@emotion/react": "11.11.1",

--- a/packages/mobile/src/components/usdc-balance-pill/UsdcBalancePill.tsx
+++ b/packages/mobile/src/components/usdc-balance-pill/UsdcBalancePill.tsx
@@ -1,5 +1,11 @@
-import { Status, useUSDCBalance } from '@audius/common'
-import { USDC } from '@audius/fixed-decimal'
+import type { BNUSDC } from '@audius/common'
+import {
+  Status,
+  formatCurrencyBalance,
+  formatUSDCWeiToFloorCentsNumber,
+  useUSDCBalance
+} from '@audius/common'
+import BN from 'bn.js'
 import { View } from 'react-native'
 
 import LogoUSDC from 'app/assets/images/logoUSDC.svg'
@@ -31,8 +37,10 @@ export const UsdcBalancePill = () => {
     useUSDCBalance({ isPolling: false })
   const isUsdcBalanceLoading =
     usdcBalance === null || usdcBalanceStatus === Status.LOADING
-  const usdcBalanceFormatted = USDC(usdcBalance ?? 0).toShorthand()
-
+  const balanceCents = formatUSDCWeiToFloorCentsNumber(
+    (usdcBalance ?? new BN(0)) as BNUSDC
+  )
+  const usdcBalanceFormatted = formatCurrencyBalance(balanceCents / 100)
   return (
     <View style={styles.root}>
       <LogoUSDC height={spacing(5)} width={spacing(5)} />

--- a/packages/mobile/src/components/usdc-balance-pill/UsdcBalancePill.tsx
+++ b/packages/mobile/src/components/usdc-balance-pill/UsdcBalancePill.tsx
@@ -1,4 +1,3 @@
-import type { BNUSDC } from '@audius/common'
 import { Status, useUSDCBalance } from '@audius/common'
 import { USDC } from '@audius/fixed-decimal'
 import { View } from 'react-native'
@@ -32,11 +31,7 @@ export const UsdcBalancePill = () => {
     useUSDCBalance({ isPolling: false })
   const isUsdcBalanceLoading =
     usdcBalance === null || usdcBalanceStatus === Status.LOADING
-  const usdcBalanceFormatted = USDC(usdcBalance ?? 0).toLocaleString('en-US', {
-    maximumFractionDigits: 2,
-    minimumFractionDigits: 2,
-    trailingZeroDisplay: 'stripIfInteger'
-  })
+  const usdcBalanceFormatted = USDC(usdcBalance ?? 0).toShorthand()
 
   return (
     <View style={styles.root}>

--- a/packages/mobile/src/components/usdc-balance-pill/UsdcBalancePill.tsx
+++ b/packages/mobile/src/components/usdc-balance-pill/UsdcBalancePill.tsx
@@ -1,11 +1,6 @@
 import type { BNUSDC } from '@audius/common'
-import {
-  Status,
-  formatCurrencyBalance,
-  formatUSDCWeiToFloorCentsNumber,
-  useUSDCBalance
-} from '@audius/common'
-import BN from 'bn.js'
+import { Status, useUSDCBalance } from '@audius/common'
+import { USDC } from '@audius/fixed-decimal'
 import { View } from 'react-native'
 
 import LogoUSDC from 'app/assets/images/logoUSDC.svg'
@@ -37,10 +32,11 @@ export const UsdcBalancePill = () => {
     useUSDCBalance({ isPolling: false })
   const isUsdcBalanceLoading =
     usdcBalance === null || usdcBalanceStatus === Status.LOADING
-  const balanceCents = formatUSDCWeiToFloorCentsNumber(
-    (usdcBalance ?? new BN(0)) as BNUSDC
-  )
-  const usdcBalanceFormatted = formatCurrencyBalance(balanceCents / 100)
+  const usdcBalanceFormatted = USDC(usdcBalance ?? 0).toLocaleString('en-US', {
+    maximumFractionDigits: 2,
+    minimumFractionDigits: 2,
+    trailingZeroDisplay: 'stripIfInteger'
+  })
 
   return (
     <View style={styles.root}>


### PR DESCRIPTION
### Description

Updates the `@audius/fixed-decimal` package to run on React Native, and updates the `audius-mobile-client` to know how to link it. Also updates `FixedDecimal` to work with React Native since React Native won't add decimals to `BigInt` when doing `toLocaleString()` (which is annoying but understandable).

EDIT:
Found a bug - Tracking down why this doesn't work (should be $0.04):
![image](https://github.com/AudiusProject/audius-protocol/assets/3690498/9d33b604-1cfe-46fa-a5aa-d66bf66a8ebd)


### How Has This Been Tested?

Added a usage to mobile. Ran tests.
