### PR TITLE
Fix FixedDecimal.toShorthand() for numbers less than a tenth

### DIFF
--- a/packages/common/src/utils/formatUtil.test.ts
+++ b/packages/common/src/utils/formatUtil.test.ts
@@ -35,6 +35,7 @@ describe('formatUtil', function () {
   it('can format currency balance', function () {
     const testCases = [
       { input: 0, expected: '0' },
+      { input: 0.042, expected: '0.04' },
       { input: 410.1545, expected: '410.15' },
       // { input: 123456789.12345, expected: '123456K' } // note: existing method can't handle this size!
       { input: 452, expected: '452' },
@@ -45,7 +46,7 @@ describe('formatUtil', function () {
       // { input 23.4252, expected: '23.42' } // note: existing method incorrectly rounds this instead of truncating!
     ]
     for (const { input, expected } of testCases) {
-      expect(AUDIO(input).toShorthand()).toBe(expected)
+      // expect(AUDIO(input).toShorthand()).toBe(expected)
       expect(formatCurrencyBalance(input)).toBe(expected)
     }
   })

--- a/packages/common/src/utils/formatUtil.test.ts
+++ b/packages/common/src/utils/formatUtil.test.ts
@@ -46,7 +46,7 @@ describe('formatUtil', function () {
       // { input 23.4252, expected: '23.42' } // note: existing method incorrectly rounds this instead of truncating!
     ]
     for (const { input, expected } of testCases) {
-      // expect(AUDIO(input).toShorthand()).toBe(expected)
+      expect(AUDIO(input).toShorthand()).toBe(expected)
       expect(formatCurrencyBalance(input)).toBe(expected)
     }
   })

--- a/packages/fixed-decimal/src/FixedDecimal.test.ts
+++ b/packages/fixed-decimal/src/FixedDecimal.test.ts
@@ -412,6 +412,10 @@ describe('FixedDecimal', function () {
       expect(new FixedDecimal('0.00000').toShorthand()).toBe('0')
     })
 
+    it('shows values between zero and one correctly', function () {
+      expect(new FixedDecimal('0.042').toShorthand()).toBe('0.04')
+    })
+
     it('shows whole numbers correctly', function () {
       expect(new FixedDecimal('1234').toShorthand()).toBe('1234')
     })

--- a/packages/fixed-decimal/src/FixedDecimal.ts
+++ b/packages/fixed-decimal/src/FixedDecimal.ts
@@ -480,7 +480,9 @@ export class FixedDecimal<
     } else if (this.value % divisor === BigInt(0)) {
       return quotient.toString()
     } else {
-      const amountString = this.value.toString()
+      const amountString = this.value
+        .toString()
+        .padStart(this.decimalPlaces, '0')
       const decimalStart = amountString.length - this.decimalPlaces
       // Get the first two decimals (truncated)
       const decimal = amountString.substring(decimalStart, decimalStart + 2)


### PR DESCRIPTION
### Description

Values less than one tenth, eg. 0.04, were incorrectly showing as 10x their value in `toShorthand()`

### How Has This Been Tested?

Added tests
