### PR TITLE
Fix <p> descendent of <p> warnings in SummaryTable

### DIFF
--- a/packages/web/src/components/premium-content-purchase-modal/components/PurchaseContentFormFields.tsx
+++ b/packages/web/src/components/premium-content-purchase-modal/components/PurchaseContentFormFields.tsx
@@ -102,6 +102,7 @@ export const PurchaseContentFormFields = ({
       disabled: isExistingBalanceDisabled,
       value: (
         <Text
+          as='span' // Needed to avoid <p> inside <p> warning
           variant='title'
           color={
             purchaseMethod === PurchaseMethod.EXISTING_BALANCE

--- a/packages/web/src/components/premium-content-purchase-modal/components/PurchaseSummaryTable.tsx
+++ b/packages/web/src/components/premium-content-purchase-modal/components/PurchaseSummaryTable.tsx
@@ -57,7 +57,7 @@ export const PurchaseSummaryTable = ({
       items={items}
       title={isPurchased ? messages.youPaid : messages.total}
       secondaryTitle={
-        <Text variant='inherit' color='secondary'>
+        <Text as='span' variant='inherit' color='secondary'>
           {messages.price(formatPrice(amountDue))}
         </Text>
       }


### PR DESCRIPTION
### Description

`value` in `SummaryTable` is wrapped in a `Text`, so we were getting nested `<p>` components. Changing to `Text as 'span'` fixes this.

### How Has This Been Tested?

Local web stage