### PR TITLE
Fix electron w/ vite

### DIFF
--- a/packages/libs/rollup.config.ts
+++ b/packages/libs/rollup.config.ts
@@ -17,7 +17,8 @@ const external = [
   ...Object.keys(pkg.devDependencies),
   'ethers/lib/utils',
   'ethers/lib/index',
-  'hashids/cjs'
+  'hashids/cjs',
+  'readable-stream'
 ]
 
 const pluginTypescript = typescript({ tsconfig: './tsconfig.json' })


### PR DESCRIPTION
### Description

The version of `readable-stream` used in libs has circular dependencies that break when vite uses it. Externalize `readable-stream` fixes this

### How Has This Been Tested?
Tested electron app locally
