### PR TITLE
[PAY-2191] Bring crypto transfer drawer and address tile up to spec

### DIFF
--- a/packages/mobile/src/components/core/AddressTile.tsx
+++ b/packages/mobile/src/components/core/AddressTile.tsx
@@ -4,10 +4,10 @@ import Clipboard from '@react-native-clipboard/clipboard'
 import { View, TouchableOpacity } from 'react-native'
 
 import IconCopy2 from 'app/assets/images/iconCopy2.svg'
-import { Text } from 'app/components/core'
+import { Text } from 'app/harmony-native/foundations/typography/Text'
 import { useToast } from 'app/hooks/useToast'
 import { make, track as trackEvent } from 'app/services/analytics'
-import { flexRowCentered, makeStyles } from 'app/styles'
+import { makeStyles } from 'app/styles'
 import { spacing } from 'app/styles/spacing'
 import type { AllEvents } from 'app/types/analytics'
 import { useColor } from 'app/utils/theme'
@@ -16,35 +16,51 @@ const messages = {
   copied: 'Copied to Clipboard!'
 }
 
-const useStyles = makeStyles(({ spacing, palette, typography }) => ({
-  addressContainer: {
-    ...flexRowCentered(),
+const useStyles = makeStyles(({ spacing, palette }) => ({
+  root: {
     borderWidth: 1,
     borderColor: palette.borderDefault,
     borderRadius: spacing(1),
+    flexDirection: 'column'
+  },
+  topContainer: {
+    padding: spacing(4),
+    flexDirection: 'row',
+    gap: spacing(2),
+    alignItems: 'center',
+    justifyContent: 'center'
+  },
+  title: {
+    alignItems: 'center',
+    justifyContent: 'center',
+    flex: 1
+  },
+  bottomContainer: {
+    borderTopWidth: 1,
+    flexDirection: 'row',
+    gap: spacing(2),
+    borderColor: palette.borderDefault,
     backgroundColor: palette.backgroundSurface
   },
-  rightContainer: {
+  address: {
     paddingVertical: spacing(4),
-    paddingHorizontal: spacing(6)
+    paddingHorizontal: spacing(6),
+    flexShrink: 1
   },
-  middleContainer: {
+  rightIcon: {
+    alignItems: 'center',
+    justifyContent: 'center',
     paddingHorizontal: spacing(6),
     paddingVertical: spacing(4),
     borderLeftWidth: 1,
-    borderRightWidth: 1,
-    borderColor: palette.borderDefault,
-    flexShrink: 1,
-    alignItems: 'center'
-  },
-  leftContainer: {
-    paddingVertical: spacing(4),
-    paddingHorizontal: spacing(6)
+    borderLeftColor: palette.borderDefault
   }
 }))
 
 type AddressTileProps = {
   address: string
+  title: string
+  balance: string
   left?: ReactNode
   right?: ReactNode
   analytics?: AllEvents
@@ -52,6 +68,8 @@ type AddressTileProps = {
 
 export const AddressTile = ({
   address,
+  title,
+  balance,
   left,
   right,
   analytics
@@ -67,23 +85,31 @@ export const AddressTile = ({
   }, [address, analytics, toast])
 
   return (
-    <View style={styles.addressContainer}>
-      <View style={styles.leftContainer}>{left}</View>
-      <View style={styles.middleContainer}>
-        <Text numberOfLines={1} ellipsizeMode='middle'>
-          {address}
+    <View style={styles.root}>
+      <View style={styles.topContainer}>
+        <View>{left}</View>
+        <Text style={styles.title} variant='title' size='m' strength='default'>
+          {title}
         </Text>
+        <Text variant='title' size='l' strength='strong'>{`$${balance}`}</Text>
       </View>
-      <View style={styles.rightContainer}>
-        {right ?? (
-          <TouchableOpacity onPress={handleCopyPress} hitSlop={spacing(6)}>
-            <IconCopy2
-              fill={textSubdued}
-              width={spacing(4)}
-              height={spacing(4)}
-            />
-          </TouchableOpacity>
-        )}
+      <View style={styles.bottomContainer}>
+        <View style={styles.address}>
+          <Text numberOfLines={1} ellipsizeMode='middle'>
+            {address}
+          </Text>
+        </View>
+        <View style={styles.rightIcon}>
+          {right ?? (
+            <TouchableOpacity onPress={handleCopyPress} hitSlop={spacing(6)}>
+              <IconCopy2
+                fill={textSubdued}
+                width={spacing(4)}
+                height={spacing(4)}
+              />
+            </TouchableOpacity>
+          )}
+        </View>
       </View>
     </View>
   )

--- a/packages/mobile/src/components/usdc-manual-transfer-drawer/USDCManualTransferDrawer.tsx
+++ b/packages/mobile/src/components/usdc-manual-transfer-drawer/USDCManualTransferDrawer.tsx
@@ -40,12 +40,13 @@ const USDCLearnMore =
 const messages = {
   title: 'Manual Crypto Transfer',
   explainer:
-    'You can add funds manually by transferring USDC tokens to your Audius Wallet.\n\n\n Use caution to avoid errors and lost funds.',
-  splOnly: 'You can only send Solana based (SPL) USDC tokens to this address.',
+    'Add funds by sending  Solana based (SPL) USDC to your Audius account.',
+  hint: 'Use caution to avoid errors and lost funds.',
   copy: 'Copy Wallet Address',
   goBack: 'Go Back',
   learnMore: 'Learn More',
   copied: 'Copied to Clipboard!',
+  usdcBalance: 'USDC Balance',
   buy: (amount: string) => `Buy ${amount}`
 }
 
@@ -88,10 +89,10 @@ const useStyles = makeStyles(({ spacing, palette, typography }) => ({
     textDecorationLine: 'underline'
   },
   explainer: {
-    textAlign: 'center',
+    textAlign: 'left',
     lineHeight: typography.fontSize.medium * 1.25
   },
-  splContainer: {
+  hintContainer: {
     gap: spacing(3),
     flexShrink: 1
   },
@@ -180,9 +181,13 @@ export const USDCManualTransferDrawer = () => {
           ) : null}
         </View>
         <AddressTile
+          title={messages.usdcBalance}
           address={USDCUserBank ?? ''}
           left={<LogoUSDC height={spacing(6)} />}
           analytics={analytics}
+          balance={USDC(balanceBN ?? new BN(0)).toLocaleString('en-US', {
+            roundingMode: 'floor'
+          })}
         />
         <View style={styles.disclaimerContainer}>
           <IconError
@@ -191,9 +196,9 @@ export const USDCManualTransferDrawer = () => {
             fill={neutral}
             style={styles.icon}
           />
-          <View style={styles.splContainer}>
+          <View style={styles.hintContainer}>
             <View style={styles.shrink}>
-              <Text style={styles.disclaimer}>{messages.splOnly}</Text>
+              <Text style={styles.disclaimer}>{messages.hint}</Text>
             </View>
             <Text
               style={styles.learnMore}

--- a/packages/mobile/src/components/usdc-manual-transfer-drawer/USDCManualTransferDrawer.tsx
+++ b/packages/mobile/src/components/usdc-manual-transfer-drawer/USDCManualTransferDrawer.tsx
@@ -40,7 +40,7 @@ const USDCLearnMore =
 const messages = {
   title: 'Manual Crypto Transfer',
   explainer:
-    'Add funds by sending  Solana based (SPL) USDC to your Audius account.',
+    'Add funds by sending Solana based (SPL) USDC to your Audius account.',
   hint: 'Use caution to avoid errors and lost funds.',
   copy: 'Copy Wallet Address',
   goBack: 'Go Back',

--- a/packages/mobile/src/harmony-native/foundations/typography/Text.tsx
+++ b/packages/mobile/src/harmony-native/foundations/typography/Text.tsx
@@ -47,6 +47,7 @@ const generateVariantStyles = (config: VariantConfig, theme: HarmonyTheme) => {
         fontSize: typography.size[fontSize[fontSizeKey]],
         lineHeight: typography.lineHeight[lineHeight[fontSizeKey]],
         fontWeight: typography.weight[fontWeight[fontWeightKey]],
+        fontFamily: typography.fontByWeight[fontWeight[fontWeightKey]],
         ...style
       }
     }


### PR DESCRIPTION
### Description

Bring mobile crypto transfer drawer and address tile up to spec

Use new harmony-native <Text> component to get there, which required a tiny change to get Avenir

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._
<img src="https://github.com/AudiusProject/audius-protocol/assets/2731362/4853c45c-6cc4-4fe0-9ef5-e484f7b47f5d" width=200 />

