### PR TITLE
Email + pw page for social sign up flow, cleanup,  C-3395

### DIFF
--- a/packages/web/src/common/store/pages/signon/actions.ts
+++ b/packages/web/src/common/store/pages/signon/actions.ts
@@ -42,6 +42,8 @@ export const SIGN_UP_SUCCEEDED_WITH_ID = 'SIGN_ON/SIGN_UP_SUCCEEDED_WITH_ID'
 export const SIGN_UP_FAILED = 'SIGN_ON/SIGN_UP_FAILED'
 export const SIGN_UP_TIMEOUT = 'SIGN_ON/SIGN_UP_TIMEOUT'
 
+export const SET_LINKED_SOCIAL_ON_FIRST_PAGE =
+  'SIGN_ON/SET_LINKED_SOCIAL_ON_FIRST_PAGE'
 export const SET_TWITTER_PROFILE = 'SIGN_ON/SET_TWITTER_PROFILE'
 export const SET_TWITTER_PROFILE_ERROR = 'SIGN_ON/SET_TWITTER_PROFILE_ERROR'
 export const SET_INSTAGRAM_PROFILE = 'SIGN_ON/SET_INSTAGRAM_PROFILE'
@@ -289,6 +291,13 @@ export function setFollowAristsCategory(category: FollowArtistsCategory) {
  */
 export function fetchFollowArtistsFailed(error: string) {
   return { type: FETCH_FOLLOW_ARTISTS_FAILED, error }
+}
+
+export function setLinkedSocialOnFirstPage(linkedSocialOnFirstPage: boolean) {
+  return {
+    type: SET_LINKED_SOCIAL_ON_FIRST_PAGE,
+    linkedSocialOnFirstPage
+  }
 }
 
 export function setTwitterProfile(

--- a/packages/web/src/common/store/pages/signon/reducer.js
+++ b/packages/web/src/common/store/pages/signon/reducer.js
@@ -36,7 +36,8 @@ import {
   UPDATE_ROUTE_ON_EXIT,
   ADD_FOLLOW_ARTISTS,
   REMOVE_FOLLOW_ARTISTS,
-  SET_REFERRER
+  SET_REFERRER,
+  SET_LINKED_SOCIAL_ON_FIRST_PAGE
 } from './actions'
 import { Pages, FollowArtistsCategory } from './types'
 
@@ -54,6 +55,8 @@ const initialState = {
   name: createTextField(),
   password: createTextField(),
   handle: createTextField(),
+  /** Whether the user linked their social media account on the first page (email page) of the sign up flow */
+  linkedSocialOnFirstPage: false,
   accountAlreadyExisted: false,
   verified: false,
   useMetaMask: false,
@@ -191,6 +194,12 @@ const actionsMap = {
         error: '',
         status: 'editing'
       }
+    }
+  },
+  [SET_LINKED_SOCIAL_ON_FIRST_PAGE](state, action) {
+    return {
+      ...state,
+      linkedSocialOnFirstPage: action.linkedSocialOnFirstPage
     }
   },
   [SET_TWITTER_PROFILE](state, action) {

--- a/packages/web/src/common/store/pages/signon/selectors.ts
+++ b/packages/web/src/common/store/pages/signon/selectors.ts
@@ -24,6 +24,12 @@ export const getToastText = (state: AppState) => state.signOn.toastText
 export const getRouteOnCompletion = (state: AppState) =>
   state.signOn.routeOnCompletion
 export const getRouteOnExit = (state: AppState) => state.signOn.routeOnExit
+export const getLinkedSocialOnFirstPage = (state: AppState) =>
+  state.signOn.linkedSocialOnFirstPage
+export const getIsSocialConnected = (state: AppState) =>
+  !!state.signOn.twitterId ||
+  !!state.signOn.tikTokId ||
+  !!state.signOn.instagramId
 export const getAccountReady = (state: AppState) => state.signOn.accountReady
 export const getStartedSignUpProcess = (state: AppState) =>
   state.signOn.startedSignUpProcess

--- a/packages/web/src/common/store/pages/signon/types.ts
+++ b/packages/web/src/common/store/pages/signon/types.ts
@@ -50,6 +50,9 @@ export default interface SignOnPageState {
   useMetaMask: boolean
   accountReady: boolean
   twitterId: string
+  tikTokId: string
+  instagramId: string
+  linkedSocialOnFirstPage: boolean
   twitterScreenName: string
   profileImage: { file: File; url: string }
   coverPhoto: { file: File; url: string }

--- a/packages/web/src/pages/sign-up-page/SignUpPage.tsx
+++ b/packages/web/src/pages/sign-up-page/SignUpPage.tsx
@@ -55,7 +55,7 @@ const determineAllowedRoute = (
   const attemptedPath = requestedRoute.replace('/signup/', '')
   // Have to type as string[] to avoid too narrow of a type for comparing against
   let allowedRoutes: string[] = [SignUpPath.createEmail] // create email is available by default
-  if (signUpState.email.value) {
+  if (signUpState.email.value || signUpState.linkedSocialOnFirstPage) {
     // Already have email
     allowedRoutes.push(SignUpPath.createPassword)
   }

--- a/packages/web/src/pages/sign-up-page/components/SocialMediaLoginOptions.tsx
+++ b/packages/web/src/pages/sign-up-page/components/SocialMediaLoginOptions.tsx
@@ -1,8 +1,10 @@
 import { useContext } from 'react'
 
+import { BooleanKeys } from '@audius/common'
 import { Box, Flex, SocialButton } from '@audius/harmony'
 
 import { ToastContext } from 'components/toast/ToastContext'
+import { useRemoteVar } from 'hooks/useRemoteConfig'
 
 import { messages } from '../utils/socialMediaMessages'
 
@@ -43,53 +45,67 @@ export const SocialMediaLoginOptions = ({
       platform
     })
   }
-
+  const isTwitterEnabled = useRemoteVar(
+    BooleanKeys.DISPLAY_TWITTER_VERIFICATION_WEB_AND_DESKTOP
+  )
+  const isInstagramEnabled = useRemoteVar(
+    BooleanKeys.DISPLAY_INSTAGRAM_VERIFICATION_WEB_AND_DESKTOP
+  )
+  const isTikTokEnabled = useRemoteVar(
+    BooleanKeys.DISPLAY_TIKTOK_VERIFICATION_WEB_AND_DESKTOP
+  )
   return (
     <Flex direction='row' gap='s' w='100%'>
-      <SignupFlowTwitterAuth
-        className={styles.flex1}
-        onFailure={handleFailure}
-        onSuccess={({ handle, requiresReview }) =>
-          handleSuccess({ handle, requiresReview, platform: 'twitter' })
-        }
-      >
-        <SocialButton
-          type='button'
-          fullWidth
-          socialType='twitter'
-          aria-label={messages.signUpTwitter}
-        />
-      </SignupFlowTwitterAuth>
-      <SignupFlowInstagramAuth
-        className={styles.flex1}
-        onFailure={handleFailure}
-        onSuccess={({ handle, requiresReview }) =>
-          handleSuccess({ handle, requiresReview, platform: 'instagram' })
-        }
-      >
-        <SocialButton
-          type='button'
-          fullWidth
-          socialType='instagram'
+      {isTwitterEnabled ? (
+        <SignupFlowTwitterAuth
           className={styles.flex1}
-          aria-label={messages.signUpInstagram}
-        />
-      </SignupFlowInstagramAuth>
-      <Box className={styles.flex1}>
-        <SignupFlowTikTokAuth
           onFailure={handleFailure}
           onSuccess={({ handle, requiresReview }) =>
-            handleSuccess({ handle, requiresReview, platform: 'tiktok' })
+            handleSuccess({ handle, requiresReview, platform: 'twitter' })
           }
         >
           <SocialButton
             type='button'
             fullWidth
-            socialType='tiktok'
-            aria-label={messages.signUpTikTok}
+            socialType='twitter'
+            aria-label={messages.signUpTwitter}
           />
-        </SignupFlowTikTokAuth>
-      </Box>
+        </SignupFlowTwitterAuth>
+      ) : null}
+      {isInstagramEnabled ? (
+        <SignupFlowInstagramAuth
+          className={styles.flex1}
+          onFailure={handleFailure}
+          onSuccess={({ handle, requiresReview }) =>
+            handleSuccess({ handle, requiresReview, platform: 'instagram' })
+          }
+        >
+          <SocialButton
+            type='button'
+            fullWidth
+            socialType='instagram'
+            className={styles.flex1}
+            aria-label={messages.signUpInstagram}
+          />
+        </SignupFlowInstagramAuth>
+      ) : null}
+      {isTikTokEnabled ? (
+        <Box className={styles.flex1}>
+          <SignupFlowTikTokAuth
+            onFailure={handleFailure}
+            onSuccess={({ handle, requiresReview }) =>
+              handleSuccess({ handle, requiresReview, platform: 'tiktok' })
+            }
+          >
+            <SocialButton
+              type='button'
+              fullWidth
+              socialType='tiktok'
+              aria-label={messages.signUpTikTok}
+            />
+          </SignupFlowTikTokAuth>
+        </Box>
+      ) : null}
     </Flex>
   )
 }

--- a/packages/web/src/pages/sign-up-page/pages/CreateEmailPage/CreateEmailPage.tsx
+++ b/packages/web/src/pages/sign-up-page/pages/CreateEmailPage/CreateEmailPage.tsx
@@ -6,12 +6,20 @@ import { useDispatch, useSelector } from 'react-redux'
 import { z } from 'zod'
 import { toFormikValidationSchema } from 'zod-formik-adapter'
 
-import { setValueField } from 'common/store/pages/signon/actions'
+import {
+  setLinkedSocialOnFirstPage,
+  setValueField
+} from 'common/store/pages/signon/actions'
 import { getEmailField } from 'common/store/pages/signon/selectors'
 import { useMedia } from 'hooks/useMedia'
 import { useNavigateToPage } from 'hooks/useNavigateToPage'
 import { EMAIL_REGEX } from 'utils/email'
-import { SIGN_IN_PAGE, SIGN_UP_PASSWORD_PAGE } from 'utils/route'
+import {
+  SIGN_IN_PAGE,
+  SIGN_UP_FINISH_PROFILE_PAGE,
+  SIGN_UP_HANDLE_PAGE,
+  SIGN_UP_PASSWORD_PAGE
+} from 'utils/route'
 
 import { CreateEmailPageDesktop } from './CreateEmailPageDesktop'
 import { CreateEmailPageMobile } from './CreateEmailPageMobile'
@@ -21,11 +29,13 @@ export type SignUpEmailValues = {
   email: string
 }
 
+export const emailSchema = z
+  .string({ required_error: messages.invalidEmail })
+  .regex(EMAIL_REGEX, { message: messages.invalidEmail })
+
 const FormSchema = toFormikValidationSchema(
   z.object({
-    email: z
-      .string({ required_error: messages.invalidEmail })
-      .regex(EMAIL_REGEX, { message: messages.invalidEmail })
+    email: emailSchema
   })
 )
 
@@ -42,6 +52,16 @@ export const CreateEmailPage = () => {
   const initialValues = {
     email: existingEmailValue.value ?? ''
   }
+  const handleLinkedSocialMedia = useCallback(
+    ({ requiresReview }: { requiresReview: boolean }) => {
+      dispatch(setLinkedSocialOnFirstPage(true))
+      navigate(
+        requiresReview ? SIGN_UP_HANDLE_PAGE : SIGN_UP_FINISH_PROFILE_PAGE
+      )
+    },
+    [dispatch, navigate]
+  )
+
   const submitHandler = useCallback(
     async (
       values: SignUpEmailValues,
@@ -82,7 +102,15 @@ export const CreateEmailPage = () => {
       validateOnChange={false}
     >
       <Form css={{ width: '100%', height: '100%' }}>
-        {isDesktop ? <CreateEmailPageDesktop /> : <CreateEmailPageMobile />}
+        {isDesktop ? (
+          <CreateEmailPageDesktop
+            onLinkedSocialMedia={handleLinkedSocialMedia}
+          />
+        ) : (
+          <CreateEmailPageMobile
+            onLinkedSocialMedia={handleLinkedSocialMedia}
+          />
+        )}
       </Form>
     </Formik>
   )

--- a/packages/web/src/pages/sign-up-page/pages/CreateEmailPage/CreateEmailPageDesktop.tsx
+++ b/packages/web/src/pages/sign-up-page/pages/CreateEmailPage/CreateEmailPageDesktop.tsx
@@ -28,7 +28,13 @@ import styles from './CreateEmailPage.module.css'
 import { SignUpWithMetaMaskButton } from './SignUpWithMetaMaskButton'
 import { messages } from './messages'
 
-export const CreateEmailPageDesktop = () => {
+type CreateEmailPageDesktopProps = {
+  onLinkedSocialMedia: (result: { requiresReview: boolean }) => void
+}
+
+export const CreateEmailPageDesktop = ({
+  onLinkedSocialMedia
+}: CreateEmailPageDesktopProps) => {
   const { isSubmitting } = useFormikContext()
 
   return (
@@ -62,8 +68,7 @@ export const CreateEmailPageDesktop = () => {
             </Divider>
             <SocialMediaLoginOptions
               onCompleteSocialMediaLogin={(result) => {
-                console.info(result)
-                // TODO
+                onLinkedSocialMedia(result)
               }}
             />
           </Flex>

--- a/packages/web/src/pages/sign-up-page/pages/CreateEmailPage/CreateEmailPageMobile.tsx
+++ b/packages/web/src/pages/sign-up-page/pages/CreateEmailPage/CreateEmailPageMobile.tsx
@@ -5,7 +5,6 @@ import {
   Flex,
   IconArrowRight,
   IconAudiusLogoHorizontalColor,
-  SocialButton,
   Text,
   TextLink
 } from '@audius/harmony'
@@ -19,11 +18,18 @@ import {
 } from 'pages/sign-on/components/AudiusValues'
 import { MobileContentContainer } from 'pages/sign-on/components/desktop/MobileContentContainer'
 import { SignOnContainerMobile } from 'pages/sign-on/components/mobile/SignOnContainerMobile'
+import { SocialMediaLoginOptions } from 'pages/sign-up-page/components/SocialMediaLoginOptions'
 import { SIGN_IN_PAGE } from 'utils/route'
 
 import { messages } from './messages'
 
-export const CreateEmailPageMobile = () => {
+type CreateEmailPageMobileProps = {
+  onLinkedSocialMedia: (result: { requiresReview: boolean }) => void
+}
+
+export const CreateEmailPageMobile = ({
+  onLinkedSocialMedia
+}: CreateEmailPageMobileProps) => {
   const { isSubmitting } = useFormikContext()
   return (
     <SignOnContainerMobile>
@@ -63,23 +69,11 @@ export const CreateEmailPageMobile = () => {
                 {messages.socialsDividerText}
               </Text>
             </Divider>
-            <Flex direction='row' gap='s' w='100%'>
-              <SocialButton
-                socialType='twitter'
-                aria-label='Sign up with Twitter'
-                css={{ flex: 1 }}
-              />
-              <SocialButton
-                socialType='instagram'
-                aria-label='Sign up with Instagram'
-                css={{ flex: 1 }}
-              />
-              <SocialButton
-                socialType='tiktok'
-                aria-label='Sign up with TikTok'
-                css={{ flex: 1 }}
-              />
-            </Flex>
+            <SocialMediaLoginOptions
+              onCompleteSocialMediaLogin={(result) => {
+                onLinkedSocialMedia(result)
+              }}
+            />
           </Flex>
           <Flex
             direction='column'

--- a/packages/web/src/pages/sign-up-page/pages/CreatePasswordPage.tsx
+++ b/packages/web/src/pages/sign-up-page/pages/CreatePasswordPage.tsx
@@ -1,5 +1,6 @@
-import { useCallback, useState } from 'react'
+import { useCallback, useContext, useState } from 'react'
 
+import { AudiusQueryContext, signUpFetch } from '@audius/common'
 import {
   Box,
   Button,
@@ -11,15 +12,19 @@ import {
   Text
 } from '@audius/harmony'
 import { IconButton } from '@audius/stems'
-import { Form, Formik } from 'formik'
+import { Field, Form, Formik, FormikHelpers, useFormikContext } from 'formik'
 import { useDispatch, useSelector } from 'react-redux'
 
 import { setValueField } from 'common/store/pages/signon/actions'
-import { getEmailField } from 'common/store/pages/signon/selectors'
+import {
+  getEmailField,
+  getLinkedSocialOnFirstPage
+} from 'common/store/pages/signon/selectors'
 import {
   CompletionChecklistItem,
   CompletionChecklistItemStatus
 } from 'components/completion-checklist-item/CompletionChecklistItem'
+import { HarmonyTextField } from 'components/form-fields/HarmonyTextField'
 import { ExternalLink } from 'components/link'
 import { useNavigateToPage } from 'hooks/useNavigateToPage'
 import {
@@ -28,6 +33,7 @@ import {
 } from 'pages/sign-on/components/AudiusValues'
 import { LeftContentContainer } from 'pages/sign-on/components/desktop/LeftContentContainer'
 import { SignOnContainerDesktop } from 'pages/sign-on/components/desktop/SignOnContainerDesktop'
+import { AppState } from 'store/types'
 import {
   PRIVACY_POLICY,
   SIGN_UP_EMAIL_PAGE,
@@ -45,11 +51,15 @@ import {
   isRequirementsFulfilled
 } from '../utils/passwordRequirementUtils'
 
+import { emailSchema } from './CreateEmailPage/CreateEmailPage'
+import { messages as emailMessages } from './CreateEmailPage/messages'
+
 const messages = {
   createYourPassword: 'Create Your Password',
   createLoginDetails: 'Create Login Details',
-  description:
+  passwordDescription:
     'Create a password that’s secure and easy to remember! We can’t reset your password, so write it down or use a password manager.',
+  passwordAndEmailDescription: `Enter your email and create a password. Keep in mind that we can't reset your password.`,
   yourEmail: 'Your Email',
   passwordLabel: 'Password',
   confirmPasswordLabel: 'Confirm Password',
@@ -66,41 +76,196 @@ const messages = {
   termsOfService: 'Terms of Service',
   and: ' and ',
   privacyPolicy: 'Privacy Policy.',
-  goBack: 'Go back'
+  goBack: 'Go back',
+  emailInUse: 'That email is already used by another Audius account.',
+  ...emailMessages
 }
 
-const initialValues = {
+const baseInitialValues = {
   password: '',
-  confirmPassword: ''
+  confirmPassword: '',
+  email: ''
 }
 
 type CreatePasswordValues = {
   password: string
   confirmPassword: string
+  email: string
+}
+
+type PasswordFieldsProps = {
+  onStatusChange: (
+    setter: (currentStatus: {
+      [key in PasswordRequirementKey]: CompletionChecklistItemStatus
+    }) => {
+      [key in PasswordRequirementKey]: CompletionChecklistItemStatus
+    }
+  ) => void
+  autofocus: boolean
+  requirementsStatuses: {
+    [key in PasswordRequirementKey]: CompletionChecklistItemStatus
+  }
+}
+
+const PasswordFields = ({
+  requirementsStatuses,
+  onStatusChange,
+  autofocus
+}: PasswordFieldsProps) => {
+  const {
+    values,
+    handleBlur: formikHandleBlur,
+    touched,
+    setFieldValue
+  } = useFormikContext<CreatePasswordValues>()
+
+  const hasPasswordError =
+    requirementsStatuses.hasNumber === 'error' ||
+    requirementsStatuses.minLength === 'error' ||
+    requirementsStatuses.notCommon === 'error'
+  const hasConfirmPasswordError = requirementsStatuses.matches === 'error'
+
+  const handlePasswordChange = useCallback(
+    async ({
+      password,
+      confirmPassword
+    }: Omit<CreatePasswordValues, 'email'>) => {
+      const hasNumber = getNumberRequirementStatus({
+        password,
+        ignoreError: requirementsStatuses.hasNumber === 'incomplete'
+      })
+      const minLength = getLengthRequirementStatus({
+        password,
+        ignoreError: requirementsStatuses.minLength === 'incomplete'
+      })
+      const matches = getMatchRequirementStatus({ password, confirmPassword })
+      const notCommon = await getNotCommonRequirementStatus({
+        password,
+        ignoreError: requirementsStatuses.notCommon === 'incomplete'
+      })
+      onStatusChange((requirements) => ({
+        ...requirements,
+        hasNumber,
+        minLength,
+        matches,
+        notCommon
+      }))
+    },
+    [
+      requirementsStatuses.hasNumber,
+      requirementsStatuses.minLength,
+      requirementsStatuses.notCommon,
+      onStatusChange
+    ]
+  )
+
+  const handlePasswordBlur = useCallback(
+    async ({
+      password,
+      confirmPassword
+    }: Omit<CreatePasswordValues, 'email'>) => {
+      if (password) {
+        const notCommon = await getNotCommonRequirementStatus({ password })
+        onStatusChange((statuses) => ({
+          ...statuses,
+          hasNumber: getNumberRequirementStatus({ password }),
+          minLength: getLengthRequirementStatus({ password }),
+          notCommon,
+          matches: getMatchRequirementStatus({ password, confirmPassword })
+        }))
+      }
+    },
+    [onStatusChange]
+  )
+
+  const handleConfirmPasswordChange = useCallback(
+    ({ password, confirmPassword }: Omit<CreatePasswordValues, 'email'>) => {
+      if (
+        requirementsStatuses.matches !== 'incomplete' ||
+        password.length <= confirmPassword.length
+      ) {
+        onStatusChange((statuses) => ({
+          ...statuses,
+          matches: getMatchRequirementStatus({ password, confirmPassword })
+        }))
+      }
+    },
+    [requirementsStatuses.matches, onStatusChange]
+  )
+
+  const handleConfirmPasswordBlur = useCallback(
+    (values: CreatePasswordValues) => {
+      if (values.password && values.confirmPassword) {
+        onStatusChange((statuses) => ({
+          ...statuses,
+          matches: getMatchRequirementStatus({
+            password: values.password,
+            confirmPassword: values.confirmPassword,
+            enforceConfirmPasswordNotEmpty: true
+          })
+        }))
+      }
+    },
+    [onStatusChange]
+  )
+
+  return (
+    <>
+      <PasswordInput
+        name='password'
+        autoFocus={autofocus}
+        autoComplete='new-password'
+        onChange={(e) => {
+          setFieldValue('password', e.target.value)
+          handlePasswordChange({
+            password: e.target.value,
+            confirmPassword: values.confirmPassword
+          })
+        }}
+        onBlur={(e) => {
+          formikHandleBlur(e)
+          handlePasswordBlur(values)
+        }}
+        label={messages.passwordLabel}
+        value={values.password}
+        error={touched.password && hasPasswordError}
+      />
+      <PasswordInput
+        name='confirmPassword'
+        autoComplete='new-password'
+        onChange={(e) => {
+          setFieldValue('confirmPassword', e.target.value)
+          handleConfirmPasswordChange({
+            password: values.password,
+            confirmPassword: e.target.value
+          })
+        }}
+        onBlur={(e) => {
+          formikHandleBlur(e)
+          handleConfirmPasswordBlur(values)
+        }}
+        label={messages.confirmPasswordLabel}
+        value={values.confirmPassword}
+        error={touched.confirmPassword && hasConfirmPasswordError}
+      />
+    </>
+  )
 }
 
 export const CreatePasswordPage = () => {
+  const queryContext = useContext(AudiusQueryContext)
   const dispatch = useDispatch()
   const emailField = useSelector(getEmailField)
+  // If user "signed up with social" on the email page, they need to fill out their email on this page.
+  const showEmailField = useSelector((state: AppState) =>
+    getLinkedSocialOnFirstPage(state)
+  )
   const navigate = useNavigateToPage()
 
-  const handleClickBackIcon = useCallback(() => {
-    navigate(SIGN_UP_EMAIL_PAGE)
-  }, [navigate])
-
-  const handleSubmit = useCallback(
-    async ({ password, confirmPassword }: CreatePasswordValues) => {
-      const fulfillsRequirements = await isRequirementsFulfilled({
-        password,
-        confirmPassword
-      })
-      if (fulfillsRequirements) {
-        dispatch(setValueField('password', password))
-        navigate(SIGN_UP_HANDLE_PAGE)
-      }
-    },
-    [dispatch, navigate]
-  )
+  const initialValues = {
+    ...baseInitialValues,
+    email: emailField.value || ''
+  }
 
   const [requirementsStatuses, setRequirementsStatuses] = useState<{
     [key in PasswordRequirementKey]: CompletionChecklistItemStatus
@@ -142,82 +307,47 @@ export const CreatePasswordPage = () => {
     }
   ]
 
-  const handlePasswordChange = useCallback(
-    async ({ password, confirmPassword }: CreatePasswordValues) => {
-      const hasNumber = getNumberRequirementStatus({
-        password,
-        ignoreError: requirementsStatuses.hasNumber === 'incomplete'
-      })
-      const minLength = getLengthRequirementStatus({
-        password,
-        ignoreError: requirementsStatuses.minLength === 'incomplete'
-      })
-      const matches = getMatchRequirementStatus({ password, confirmPassword })
-      const notCommon = await getNotCommonRequirementStatus({
-        password,
-        ignoreError: requirementsStatuses.notCommon === 'incomplete'
-      })
-      setRequirementsStatuses((requirements) => ({
-        ...requirements,
-        hasNumber,
-        minLength,
-        matches,
-        notCommon
-      }))
-    },
-    [
-      requirementsStatuses.hasNumber,
-      requirementsStatuses.minLength,
-      requirementsStatuses.notCommon
-    ]
-  )
+  const handleClickBackIcon = useCallback(() => {
+    navigate(SIGN_UP_EMAIL_PAGE)
+  }, [navigate])
 
-  const handlePasswordBlur = useCallback(
-    async ({ password, confirmPassword }: CreatePasswordValues) => {
-      if (password) {
-        const notCommon = await getNotCommonRequirementStatus({ password })
-        setRequirementsStatuses((statuses) => ({
-          ...statuses,
-          hasNumber: getNumberRequirementStatus({ password }),
-          minLength: getLengthRequirementStatus({ password }),
-          notCommon,
-          matches: getMatchRequirementStatus({ password, confirmPassword })
-        }))
+  const handleSubmit = useCallback(
+    async (
+      { password, confirmPassword, email }: CreatePasswordValues,
+      { setErrors }: FormikHelpers<CreatePasswordValues>
+    ) => {
+      const [fulfillsPasswordRequirements, isEmailInUse] = await Promise.all([
+        isRequirementsFulfilled({
+          password,
+          confirmPassword
+        }),
+        showEmailField
+          ? signUpFetch.isEmailInUse({ email }, queryContext!)
+          : Promise.resolve(false)
+      ])
+      if (fulfillsPasswordRequirements && !isEmailInUse) {
+        if (showEmailField) {
+          dispatch(setValueField('email', email))
+        }
+        dispatch(setValueField('password', password))
+        navigate(SIGN_UP_HANDLE_PAGE)
+      } else if (isEmailInUse) {
+        setErrors({ email: messages.emailInUse })
       }
     },
-    []
+    [showEmailField, dispatch, navigate, queryContext]
   )
 
-  const handleConfirmPasswordChange = useCallback(
-    ({ password, confirmPassword }: CreatePasswordValues) => {
-      if (
-        requirementsStatuses.matches !== 'incomplete' ||
-        password.length <= confirmPassword.length
-      ) {
-        setRequirementsStatuses((statuses) => ({
-          ...statuses,
-          matches: getMatchRequirementStatus({ password, confirmPassword })
-        }))
-      }
-    },
-    [requirementsStatuses.matches]
-  )
+  const [emailIsValid, setEmailIsValid] = useState(showEmailField === false)
 
-  const handleConfirmPasswordBlur = useCallback(
-    (values: CreatePasswordValues) => {
-      if (values.password && values.confirmPassword) {
-        setRequirementsStatuses((statuses) => ({
-          ...statuses,
-          matches: getMatchRequirementStatus({
-            password: values.password,
-            confirmPassword: values.confirmPassword,
-            enforceConfirmPasswordNotEmpty: true
-          })
-        }))
-      }
-    },
-    []
-  )
+  const validateEmail = useCallback((value: string) => {
+    const result = emailSchema.safeParse(value)
+    if (!result.success) {
+      setEmailIsValid(false)
+      return result.error.format()._errors?.[0]
+    }
+    setEmailIsValid(true)
+  }, [])
 
   const hasPasswordError = requirements.some(
     (r) => r.status === 'error' && r.path === 'password'
@@ -227,7 +357,7 @@ export const CreatePasswordPage = () => {
     (r) => r.status === 'error' && r.path === 'confirmPassword'
   )
 
-  const isValid = !hasPasswordError && !hasConfirmPasswordError
+  const isValid = !hasPasswordError && !hasConfirmPasswordError && emailIsValid
 
   return (
     <Flex h='100%' alignItems='center' justifyContent='center'>
@@ -255,22 +385,28 @@ export const CreatePasswordPage = () => {
                 strength='default'
                 variant='heading'
               >
-                {messages.createYourPassword}
+                {showEmailField
+                  ? messages.createLoginDetails
+                  : messages.createYourPassword}
               </Text>
             </Box>
             <Box mt='l'>
               <Text color='default' size='l' variant='body'>
-                {messages.description}
+                {showEmailField
+                  ? messages.passwordAndEmailDescription
+                  : messages.passwordDescription}
               </Text>
             </Box>
-            <Box mt='2xl'>
-              <Text variant='label' size='xs'>
-                {messages.yourEmail}
-              </Text>
-              <Text variant='body' size='m'>
-                {emailField.value}
-              </Text>
-            </Box>
+            {showEmailField ? null : (
+              <Box mt='2xl'>
+                <Text variant='label' size='xs'>
+                  {messages.yourEmail}
+                </Text>
+                <Text variant='body' size='m'>
+                  {emailField.value}
+                </Text>
+              </Box>
+            )}
           </Box>
           <Box mt='l' className={styles.formOuterContainer}>
             <Formik initialValues={initialValues} onSubmit={handleSubmit}>
@@ -293,44 +429,20 @@ export const CreatePasswordPage = () => {
                         gap='l'
                         className={styles.inputsContainer}
                       >
-                        <PasswordInput
-                          name='password'
-                          autoFocus
-                          autoComplete='new-password'
-                          onChange={(e) => {
-                            setFieldValue('password', e.target.value)
-                            handlePasswordChange({
-                              password: e.target.value,
-                              confirmPassword: values.confirmPassword
-                            })
-                          }}
-                          onBlur={(e) => {
-                            formikHandleBlur(e)
-                            handlePasswordBlur(values)
-                          }}
-                          label={messages.passwordLabel}
-                          value={values.password}
-                          error={touched.password && hasPasswordError}
-                        />
-                        <PasswordInput
-                          name='confirmPassword'
-                          autoComplete='new-password'
-                          onChange={(e) => {
-                            setFieldValue('confirmPassword', e.target.value)
-                            handleConfirmPasswordChange({
-                              password: values.password,
-                              confirmPassword: e.target.value
-                            })
-                          }}
-                          onBlur={(e) => {
-                            formikHandleBlur(e)
-                            handleConfirmPasswordBlur(values)
-                          }}
-                          label={messages.confirmPasswordLabel}
-                          value={values.confirmPassword}
-                          error={
-                            touched.confirmPassword && hasConfirmPasswordError
-                          }
+                        {showEmailField ? (
+                          <Field
+                            as={HarmonyTextField}
+                            validate={validateEmail}
+                            name='email'
+                            autoFocus={showEmailField}
+                            autoComplete='email'
+                            label={messages.emailLabel}
+                          />
+                        ) : null}
+                        <PasswordFields
+                          requirementsStatuses={requirementsStatuses}
+                          onStatusChange={setRequirementsStatuses}
+                          autofocus={!showEmailField}
                         />
                       </Flex>
                       <Flex mt='l' gap='l' direction='column'>


### PR DESCRIPTION
### Description
<img width="1073" alt="Screenshot 2023-11-21 at 2 31 56 PM" src="https://github.com/AudiusProject/audius-protocol/assets/36916764/1d2a9a1b-c3ab-495e-94d6-dcfb9d8ca1bf">

-Go to combined email + pw page when socials are connected on the first page of sign up flow
 -> Logic so that you see this page again if you hit "back" on the subsequent pages
-Password page clean up

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._
