### PR TITLE
[PAY-2183] Fetch USDC balance on web app load

### DIFF
--- a/packages/web/src/app/web-player/WebPlayer.jsx
+++ b/packages/web/src/app/web-player/WebPlayer.jsx
@@ -183,6 +183,8 @@ import { getTheme as getSystemTheme } from 'utils/theme/theme'
 
 import styles from './App.module.css'
 
+import { USDCBalanceFetcher } from 'components/usdc-balance-fetcher/USDCBalanceFetcher'
+
 const { setTheme } = themeActions
 const { getTheme } = themeSelectors
 
@@ -463,6 +465,7 @@ class WebPlayer extends Component {
           ) : null}
         </AppBannerWrapper>
         {this.props.isChatEnabled ? <ChatListener /> : null}
+        <USDCBalanceFetcher />
         <div className={cn(styles.app, { [styles.mobileApp]: isMobileClient })}>
           {this.props.showCookieBanner ? <CookieBanner /> : null}
           <Notice />

--- a/packages/web/src/app/web-player/WebPlayer.jsx
+++ b/packages/web/src/app/web-player/WebPlayer.jsx
@@ -50,6 +50,7 @@ import { RewardClaimedToast } from 'components/reward-claimed-toast/RewardClaime
 import DesktopRoute from 'components/routes/DesktopRoute'
 import MobileRoute from 'components/routes/MobileRoute'
 import TrendingGenreSelectionPage from 'components/trending-genre-selection/TrendingGenreSelectionPage'
+import { USDCBalanceFetcher } from 'components/usdc-balance-fetcher/USDCBalanceFetcher'
 import {
   MainContentContext,
   MainContentContextProvider,
@@ -182,8 +183,6 @@ import {
 import { getTheme as getSystemTheme } from 'utils/theme/theme'
 
 import styles from './App.module.css'
-
-import { USDCBalanceFetcher } from 'components/usdc-balance-fetcher/USDCBalanceFetcher'
 
 const { setTheme } = themeActions
 const { getTheme } = themeSelectors

--- a/packages/web/src/components/usdc-balance-fetcher/USDCBalanceFetcher.tsx
+++ b/packages/web/src/components/usdc-balance-fetcher/USDCBalanceFetcher.tsx
@@ -1,6 +1,5 @@
 import { useUSDCBalance } from '@audius/common'
 
 export const USDCBalanceFetcher = () => {
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  const { data } = useUSDCBalance()
+  useUSDCBalance()
 }

--- a/packages/web/src/components/usdc-balance-fetcher/USDCBalanceFetcher.tsx
+++ b/packages/web/src/components/usdc-balance-fetcher/USDCBalanceFetcher.tsx
@@ -1,0 +1,6 @@
+import { useUSDCBalance } from '@audius/common'
+
+export const USDCBalanceFetcher = () => {
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  const { data } = useUSDCBalance()
+}


### PR DESCRIPTION
### Description

Fetches USDC balance on app load

Mobile doesn't have this issue as we're already loading the balance elsewhere (probably from nav)

### How Has This Been Tested?

Local web stage
- confirmed purchase modal now defaults to existing balance option
- confirmed non-signed-in user doesn't experience any errors