### PR TITLE
Fix mobile web purchase drawer UI

### DIFF
--- a/packages/web/src/components/add-funds/AddFunds.tsx
+++ b/packages/web/src/components/add-funds/AddFunds.tsx
@@ -132,8 +132,6 @@ export const AddFunds = ({
             withRadioOptions
             onRadioChange={handleChangeOption}
             selectedRadioOption={selectedPurchaseMethod}
-            rowClassName={mobile ? styles.summaryTableRow : undefined}
-            rowValueClassName={mobile ? styles.summaryTableRowValue : undefined}
           />
           <Button
             variant={ButtonType.PRIMARY}

--- a/packages/web/src/components/premium-content-purchase-modal/components/PurchaseContentFormFields.module.css
+++ b/packages/web/src/components/premium-content-purchase-modal/components/PurchaseContentFormFields.module.css
@@ -15,12 +15,3 @@
   justify-content: center;
   width: var(--unit-4);
 }
-
-.summaryTableRow {
-  flex-direction: column;
-  align-items: flex-start;
-}
-
-.summaryTableRowValue {
-  width: 100%;
-}

--- a/packages/web/src/components/premium-content-purchase-modal/components/PurchaseContentFormFields.tsx
+++ b/packages/web/src/components/premium-content-purchase-modal/components/PurchaseContentFormFields.tsx
@@ -172,7 +172,6 @@ export const PurchaseContentFormFields = ({
         selectedRadioOption={purchaseMethod}
         items={options}
         rowClassName={mobile ? styles.summaryTableRow : undefined}
-        rowValueClassName={mobile ? styles.summaryTableRowValue : undefined}
       />
       {isUnlocking ? null : <PayToUnlockInfo />}
     </>

--- a/packages/web/src/components/premium-content-purchase-modal/components/PurchaseContentFormFields.tsx
+++ b/packages/web/src/components/premium-content-purchase-modal/components/PurchaseContentFormFields.tsx
@@ -171,7 +171,6 @@ export const PurchaseContentFormFields = ({
         onRadioChange={handleChange}
         selectedRadioOption={purchaseMethod}
         items={options}
-        rowClassName={mobile ? styles.summaryTableRow : undefined}
       />
       {isUnlocking ? null : <PayToUnlockInfo />}
     </>

--- a/packages/web/src/components/summary-table/SummaryTable.module.css
+++ b/packages/web/src/components/summary-table/SummaryTable.module.css
@@ -15,10 +15,6 @@
   transition: height var(--harmony-expressive);
 }
 
-.row {
-  border-top: 1px solid var(--border-default);
-}
-
 .radioGroup {
   width: 100%;
 }

--- a/packages/web/src/components/summary-table/SummaryTable.tsx
+++ b/packages/web/src/components/summary-table/SummaryTable.tsx
@@ -56,8 +56,6 @@ export type SummaryTableProps = {
   withRadioOptions?: boolean
   selectedRadioOption?: string
   onRadioChange?: (method: string) => void
-  rowClassName?: string
-  rowValueClassName?: string
 }
 
 export const SummaryTable = ({
@@ -70,9 +68,7 @@ export const SummaryTable = ({
   summaryValueColor = 'secondary',
   withRadioOptions,
   selectedRadioOption,
-  onRadioChange,
-  rowClassName,
-  rowValueClassName
+  onRadioChange
 }: SummaryTableProps) => {
   const { color } = useTheme()
   // Collapsible is collapsed by default
@@ -96,14 +92,14 @@ export const SummaryTable = ({
           justifyContent='space-between'
           pv='m'
           ph='xl'
-          className={cn(styles.row, rowClassName)}
           css={{ opacity: disabled ? 0.5 : 1 }}
+          borderTop='default'
         >
           <Flex
             onClick={() => onRadioChange?.(id)}
             css={{ cursor: 'pointer' }}
             alignItems='center'
-            justifyContent='center'
+            justifyContent='space-between'
             gap='s'
           >
             {withRadioOptions ? (
@@ -116,18 +112,18 @@ export const SummaryTable = ({
             ) : null}
             <Text>{label}</Text>
           </Flex>
-          <Text className={rowValueClassName}>{value}</Text>
+          <Text>{value}</Text>
         </Flex>
       ))}
       {summaryItem !== undefined ? (
         <Flex
-          className={styles.row}
           css={{ backgroundColor: color.background.surface1 }}
           alignItems='center'
           alignSelf='stretch'
           justifyContent='space-between'
           pv='m'
           ph='xl'
+          borderTop='default'
         >
           <Text variant='title' size='medium' color={summaryLabelColor}>
             {summaryItem.label}


### PR DESCRIPTION
### Description
Small UI fix for mobile web purchase flow

Don't think the `rowClassName` and `rowValueClassName` props are needed anymore.

### How Has This Been Tested?

Local web stage

Before:
<img width="1728" alt="Screenshot 2023-11-21 at 4 32 46 PM" src="https://github.com/AudiusProject/audius-protocol/assets/3893871/e34d7aa1-597d-4f6c-9736-4227954fb8fc">

After:
<img width="1728" alt="Screenshot 2023-11-21 at 4 27 47 PM" src="https://github.com/AudiusProject/audius-protocol/assets/3893871/18fdc4a2-2b98-4faf-8947-527254329cb4">
<img width="1728" alt="Screenshot 2023-11-21 at 4 27 12 PM" src="https://github.com/AudiusProject/audius-protocol/assets/3893871/788292cd-0fe7-42f2-a309-f6fe1c881969">


Non-mobile web still works:
<img width="1728" alt="Screenshot 2023-11-21 at 4 30 19 PM" src="https://github.com/AudiusProject/audius-protocol/assets/3893871/e6ce8fab-1d4c-4d2b-b21d-c95e997019f2">
<img width="1728" alt="Screenshot 2023-11-21 at 4 30 28 PM" src="https://github.com/AudiusProject/audius-protocol/assets/3893871/dab2043f-7323-403c-9944-6937cf6aed26">
