### PR TITLE
Fix mobile init

### DIFF
--- a/packages/mobile/tsconfig.json
+++ b/packages/mobile/tsconfig.json
@@ -16,7 +16,8 @@
       "schemas": ["../../node_modules/audius-client/src/common/schemas"],
       "services/*": ["../../node_modules/audius-client/src/services/*"],
       "store/*": ["../../node_modules/audius-client/src/store/*"],
-      "utils/*": ["../../node_modules/audius-client/src/utils/*"]
+      "utils/*": ["../../node_modules/audius-client/src/utils/*"],
+      "workers/*": ["../../node_modules/audius-client/src/workers/*"]
     },
     "strictNullChecks": true,
     "types": ["vite/client", "jest"],


### PR DESCRIPTION
### Description

Add `workers` to the tsconfig paths in mobile. Not sure why this was working before, or why it doesn't fail locally

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._
