### PR TITLE
[PAY-2176] Implement remote config hooks via context

### DIFF
--- a/packages/common/src/context/appContext.ts
+++ b/packages/common/src/context/appContext.ts
@@ -4,6 +4,8 @@ import type { StorageNodeSelectorService } from '@audius/sdk'
 
 import { AnalyticsEvent, AllTrackingEvents } from 'models/Analytics'
 import { AudiusBackend } from 'services/audius-backend'
+import { LocalStorage } from 'services/local-storage'
+import { RemoteConfigInstance } from 'services/remote-config'
 
 type AppContextType = {
   analytics: {
@@ -22,6 +24,8 @@ type AppContextType = {
     ) => Promise<{ url: string; file: File }>
   }
   audiusBackend: AudiusBackend
+  remoteConfig: RemoteConfigInstance
+  localStorage: LocalStorage
 }
 
 export const AppContext = createContext<AppContextType | null>(null)

--- a/packages/common/src/hooks/helpers.ts
+++ b/packages/common/src/hooks/helpers.ts
@@ -1,0 +1,7 @@
+import { useSelector } from 'react-redux'
+
+import { getAccountUser } from 'store/account/selectors'
+import { isRemoteConfigLoaded } from 'store/remote-config/selectors'
+
+export const useHasAccount = () => !!useSelector(getAccountUser)
+export const useHasConfigLoaded = () => !!useSelector(isRemoteConfigLoaded)

--- a/packages/common/src/hooks/purchaseContent/usePayExtraPresets.ts
+++ b/packages/common/src/hooks/purchaseContent/usePayExtraPresets.ts
@@ -3,12 +3,12 @@ import { useMemo } from 'react'
 import { StringKeys } from 'services/remote-config'
 import { parseIntList } from 'utils/stringUtils'
 
-import { RemoteVarHook } from '../useRemoteVar'
+import { useRemoteVar } from '../useRemoteVar'
 
 import { PayExtraAmountPresetValues, PayExtraPreset } from './types'
 
 /** Extracts and parses the Pay Extra presets from remote config */
-export const usePayExtraPresets = (useRemoteVar: RemoteVarHook) => {
+export const usePayExtraPresets = () => {
   const configValue = useRemoteVar(StringKeys.PAY_EXTRA_PRESET_CENT_AMOUNTS)
   return useMemo<PayExtraAmountPresetValues>(() => {
     const [low, medium, high] = parseIntList(configValue)

--- a/packages/common/src/hooks/purchaseContent/usePurchaseContentErrorMessage.ts
+++ b/packages/common/src/hooks/purchaseContent/usePurchaseContentErrorMessage.ts
@@ -6,8 +6,6 @@ import {
 } from 'store/purchase-content'
 import { formatPrice } from 'utils/formatUtil'
 
-import { RemoteVarHook } from '../useRemoteVar'
-
 import { useUSDCPurchaseConfig } from './useUSDCPurchaseConfig'
 
 const messages = {
@@ -25,11 +23,10 @@ const messages = {
 }
 
 export const usePurchaseContentErrorMessage = (
-  errorCode: PurchaseContentErrorCode,
-  useRemoteVar: RemoteVarHook
+  errorCode: PurchaseContentErrorCode
 ) => {
   const { minUSDCPurchaseAmountCents, maxUSDCPurchaseAmountCents } =
-    useUSDCPurchaseConfig(useRemoteVar)
+    useUSDCPurchaseConfig()
 
   switch (errorCode) {
     case BuyUSDCErrorCode.MinAmountNotMet:

--- a/packages/common/src/hooks/purchaseContent/useUSDCPurchaseConfig.ts
+++ b/packages/common/src/hooks/purchaseContent/useUSDCPurchaseConfig.ts
@@ -2,14 +2,12 @@ import { useMemo } from 'react'
 
 import { IntKeys } from 'services/remote-config'
 
-import { RemoteVarHook } from '../useRemoteVar'
+import { useRemoteVar } from '../useRemoteVar'
 
 import { USDCPurchaseConfig } from './types'
 
 /** Fetches the USDC/purchase content remote config values */
-export const useUSDCPurchaseConfig = (
-  useRemoteVar: RemoteVarHook
-): USDCPurchaseConfig => {
+export const useUSDCPurchaseConfig = (): USDCPurchaseConfig => {
   const minContentPriceCents = useRemoteVar(IntKeys.MIN_CONTENT_PRICE_CENTS)
   const maxContentPriceCents = useRemoteVar(IntKeys.MAX_CONTENT_PRICE_CENTS)
   const minUSDCPurchaseAmountCents = useRemoteVar(

--- a/packages/common/src/hooks/useFeatureFlag.ts
+++ b/packages/common/src/hooks/useFeatureFlag.ts
@@ -2,9 +2,12 @@ import { useCallback, useEffect, useMemo, useState } from 'react'
 
 import { useEffectOnce } from 'react-use'
 
+import { useAppContext } from 'src/context/appContext'
 import { Maybe } from 'utils/typeUtils'
 
 import { FeatureFlags, RemoteConfigInstance } from '../services'
+
+import { useHasAccount, useHasConfigLoaded } from './helpers'
 
 export const FEATURE_FLAG_OVERRIDE_KEY = 'FeatureFlagOverride'
 
@@ -47,6 +50,7 @@ export const useRecomputeToggle = (
 }
 
 /**
+ * @deprecated use `useFeatureFlag` instead
  * Hooks into updates for a given feature flag.
  * Returns both `isLoaded` and `isEnabled` for more granular control
  * @param flag
@@ -111,3 +115,57 @@ export const createUseFeatureFlagHook =
       setOverride
     }
   }
+
+/** Fetches enabled status of a given feature flag with fallback. Result is memoized. */
+export const useFeatureFlag = (
+  flag: FeatureFlags,
+  fallbackFlag?: FeatureFlags
+) => {
+  const overrideKey = `${FEATURE_FLAG_OVERRIDE_KEY}:${flag}`
+  const configLoaded = useHasConfigLoaded()
+  const { localStorage, remoteConfig } = useAppContext()
+
+  const shouldRecompute = useRecomputeToggle(
+    useHasAccount,
+    configLoaded,
+    remoteConfig
+  )
+
+  const isEnabled = useMemo(
+    () => remoteConfig.getFeatureEnabled(flag, fallbackFlag),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [flag, fallbackFlag, shouldRecompute]
+  )
+
+  const setOverride = useCallback(
+    async (value: OverrideSetting) => {
+      return value === null
+        ? localStorage.removeItem(overrideKey)
+        : localStorage.setItem(overrideKey, value)
+    },
+    [overrideKey, localStorage]
+  )
+
+  const [isLocallyEnabled, setIsLocallyOverriden] = useState<Maybe<boolean>>()
+
+  useEffectOnce(() => {
+    const getOverride = async () => {
+      const override = await localStorage.getItem(overrideKey)
+      if (override === 'enabled') {
+        setIsLocallyOverriden(true)
+      }
+      if (override === 'disabled') {
+        setIsLocallyOverriden(false)
+      }
+
+      return undefined
+    }
+    getOverride()
+  })
+
+  return {
+    isLoaded: configLoaded,
+    isEnabled: isLocallyEnabled ?? isEnabled,
+    setOverride
+  }
+}

--- a/packages/common/src/hooks/useRemoteVar.ts
+++ b/packages/common/src/hooks/useRemoteVar.ts
@@ -1,10 +1,6 @@
 import { useMemo } from 'react'
 
-import { useSelector } from 'react-redux'
-
 import { useAppContext } from 'src/context'
-import { getAccountUser } from 'store/account/selectors'
-import { isRemoteConfigLoaded } from 'store/remote-config/selectors'
 
 import {
   AllRemoteConfigKeys,
@@ -15,6 +11,7 @@ import {
   RemoteConfigInstance
 } from '../services'
 
+import { useHasAccount, useHasConfigLoaded } from './helpers'
 import { useRecomputeToggle } from './useFeatureFlag'
 
 /** @deprecated Use `useRemoteVar` directly instead */
@@ -53,9 +50,6 @@ export const createUseRemoteVarHook = ({
 }
 
 export type RemoteVarHook = ReturnType<typeof createUseRemoteVarHook>
-
-const useHasAccount = () => !!useSelector(getAccountUser)
-const useHasConfigLoaded = () => !!useSelector(isRemoteConfigLoaded)
 
 /** Fetches a remote config variable with default fallback */
 export function useRemoteVar(key: IntKeys): number

--- a/packages/mobile/src/app/AppContextProvider.tsx
+++ b/packages/mobile/src/app/AppContextProvider.tsx
@@ -5,6 +5,8 @@ import { useAsync } from 'react-use'
 
 import * as analytics from 'app/services/analytics'
 import { audiusBackendInstance } from 'app/services/audius-backend-instance'
+import { localStorage } from 'app/services/local-storage'
+import { remoteConfigInstance } from 'app/services/remote-config/remote-config-instance'
 import { getStorageNodeSelector } from 'app/services/sdk/storageNodeSelector'
 import { generatePlaylistArtwork } from 'app/utils/generatePlaylistArtwork'
 
@@ -21,8 +23,10 @@ export const AppContextProvider = (props: AppContextProviderProps) => {
     () => ({
       analytics,
       storageNodeSelector,
+      localStorage,
       imageUtils: { generatePlaylistArtwork },
-      audiusBackend: audiusBackendInstance
+      audiusBackend: audiusBackendInstance,
+      remoteConfing: remoteConfigInstance
     }),
     [storageNodeSelector]
   )

--- a/packages/mobile/src/app/AppContextProvider.tsx
+++ b/packages/mobile/src/app/AppContextProvider.tsx
@@ -26,7 +26,7 @@ export const AppContextProvider = (props: AppContextProviderProps) => {
       localStorage,
       imageUtils: { generatePlaylistArtwork },
       audiusBackend: audiusBackendInstance,
-      remoteConfing: remoteConfigInstance
+      remoteConfig: remoteConfigInstance
     }),
     [storageNodeSelector]
   )

--- a/packages/mobile/src/components/premium-track-purchase-drawer/PremiumTrackPurchaseDrawer.tsx
+++ b/packages/mobile/src/components/premium-track-purchase-drawer/PremiumTrackPurchaseDrawer.tsx
@@ -41,7 +41,7 @@ import { Button, LockedStatusBadge, Text } from 'app/components/core'
 import Drawer from 'app/components/drawer'
 import { useIsUSDCEnabled } from 'app/hooks/useIsUSDCEnabled'
 import { useNavigation } from 'app/hooks/useNavigation'
-import { useFeatureFlag, useRemoteVar } from 'app/hooks/useRemoteConfig'
+import { useFeatureFlag } from 'app/hooks/useRemoteConfig'
 import { make, track as trackEvent } from 'app/services/analytics'
 import { flexRowCentered, makeStyles } from 'app/styles'
 import { spacing } from 'app/styles/spacing'
@@ -161,7 +161,7 @@ const RenderError = ({ error: { code } }: { error: PurchaseContentError }) => {
     <View style={styles.errorContainer}>
       <IconError fill={accentRed} width={spacing(5)} height={spacing(5)} />
       <Text weight='medium' color='accentRed'>
-        {usePurchaseContentErrorMessage(code, useRemoteVar)}
+        {usePurchaseContentErrorMessage(code)}
       </Text>
     </View>
   )
@@ -220,7 +220,7 @@ const RenderForm = ({
   const navigation = useNavigation()
   const styles = useStyles()
   const { specialLightGreen, primary } = useThemeColors()
-  const presetValues = usePayExtraPresets(useRemoteVar)
+  const presetValues = usePayExtraPresets()
   const { isEnabled: isIOSUSDCPurchaseEnabled } = useFeatureFlag(
     FeatureFlags.IOS_USDC_PURCHASE_ENABLED
   )
@@ -347,7 +347,7 @@ export const PremiumTrackPurchaseDrawer = () => {
   const styles = useStyles()
   const dispatch = useDispatch()
   const isUSDCEnabled = useIsUSDCEnabled()
-  const presetValues = usePayExtraPresets(useRemoteVar)
+  const presetValues = usePayExtraPresets()
   const {
     data: { contentId: trackId },
     isOpen,

--- a/packages/mobile/src/components/premium-track-purchase-drawer/hooks/usePurchaseSummaryValues.ts
+++ b/packages/mobile/src/components/premium-track-purchase-drawer/hooks/usePurchaseSummaryValues.ts
@@ -10,8 +10,6 @@ import {
 } from '@audius/common'
 import { useField } from 'formik'
 
-import { useRemoteVar } from 'app/hooks/useRemoteConfig'
-
 export const usePurchaseSummaryValues = ({
   price,
   currentBalance
@@ -21,8 +19,8 @@ export const usePurchaseSummaryValues = ({
 }) => {
   const [{ value: customAmount }] = useField(CUSTOM_AMOUNT)
   const [{ value: amountPreset }] = useField(AMOUNT_PRESET)
-  const presetValues = usePayExtraPresets(useRemoteVar)
-  const { minUSDCPurchaseAmountCents } = useUSDCPurchaseConfig(useRemoteVar)
+  const presetValues = usePayExtraPresets()
+  const { minUSDCPurchaseAmountCents } = useUSDCPurchaseConfig()
 
   const extraAmount = getExtraAmount({
     amountPreset,

--- a/packages/mobile/src/hooks/useIsUSDCEnabled.ts
+++ b/packages/mobile/src/hooks/useIsUSDCEnabled.ts
@@ -1,6 +1,4 @@
-import { FeatureFlags } from '@audius/common'
-
-import { useFeatureFlag } from './useRemoteConfig'
+import { FeatureFlags, useFeatureFlag } from '@audius/common'
 
 export const useIsUSDCEnabled = () =>
   useFeatureFlag(FeatureFlags.USDC_PURCHASES).isEnabled

--- a/packages/mobile/src/screens/edit-track-screen/EditTrackScreen.tsx
+++ b/packages/mobile/src/screens/edit-track-screen/EditTrackScreen.tsx
@@ -11,8 +11,6 @@ import { Formik } from 'formik'
 import { z } from 'zod'
 import { toFormikValidationSchema } from 'zod-formik-adapter'
 
-import { useRemoteVar } from 'app/hooks/useRemoteConfig'
-
 import { EditTrackNavigator } from './EditTrackNavigator'
 import { TRACK_PREVIEW } from './fields/AccessAndSaleField/PremiumRadioField/TrackPreviewField'
 import { TRACK_PRICE } from './fields/AccessAndSaleField/PremiumRadioField/TrackPriceField'
@@ -31,8 +29,7 @@ const errorMessages = {
 }
 
 const useEditTrackSchema = () => {
-  const { minContentPriceCents, maxContentPriceCents } =
-    useUSDCPurchaseConfig(useRemoteVar)
+  const { minContentPriceCents, maxContentPriceCents } = useUSDCPurchaseConfig()
   return useMemo(
     /**
      * The refine functions only get executed if the original object definition (before refine) validation passes.

--- a/packages/mobile/src/screens/edit-track-screen/fields/AccessAndSaleField/PremiumRadioField/PremiumRadioField.tsx
+++ b/packages/mobile/src/screens/edit-track-screen/fields/AccessAndSaleField/PremiumRadioField/PremiumRadioField.tsx
@@ -3,7 +3,8 @@ import { useCallback, useEffect, useMemo, useRef } from 'react'
 import {
   FeatureFlags,
   Name,
-  isPremiumContentUSDCPurchaseGated
+  isPremiumContentUSDCPurchaseGated,
+  useFeatureFlag
 } from '@audius/common'
 import { useField } from 'formik'
 import { Dimensions, View } from 'react-native'
@@ -12,7 +13,6 @@ import IconCart from 'app/assets/images/iconCart.svg'
 import IconStars from 'app/assets/images/iconStars.svg'
 import { Link, Tag, Text } from 'app/components/core'
 import { HelpCallout } from 'app/components/help-callout/HelpCallout'
-import { useFeatureFlag } from 'app/hooks/useRemoteConfig'
 import { useSetTrackAvailabilityFields } from 'app/hooks/useSetTrackAvailabilityFields'
 import { make, track } from 'app/services/analytics'
 import { makeStyles } from 'app/styles'

--- a/packages/mobile/src/screens/edit-track-screen/screens/AccessAndSaleScreen.tsx
+++ b/packages/mobile/src/screens/edit-track-screen/screens/AccessAndSaleScreen.tsx
@@ -9,7 +9,8 @@ import {
   FeatureFlags,
   removeNullable,
   isPremiumContentUSDCPurchaseGated,
-  useAccessAndRemixSettings
+  useAccessAndRemixSettings,
+  useFeatureFlag
 } from '@audius/common'
 import { useField, useFormikContext } from 'formik'
 import moment from 'moment'
@@ -19,7 +20,6 @@ import IconCart from 'app/assets/images/iconCart.svg'
 import { Button } from 'app/components/core'
 import { HelpCallout } from 'app/components/help-callout/HelpCallout'
 import { useNavigation } from 'app/hooks/useNavigation'
-import { useFeatureFlag } from 'app/hooks/useRemoteConfig'
 import { TopBarIconButton } from 'app/screens/app-screen'
 import { makeStyles } from 'app/styles'
 

--- a/packages/mobile/src/screens/feed-screen/FeedScreen.tsx
+++ b/packages/mobile/src/screens/feed-screen/FeedScreen.tsx
@@ -5,7 +5,8 @@ import {
   lineupSelectors,
   feedPageLineupActions as feedActions,
   feedPageSelectors,
-  FeatureFlags
+  FeatureFlags,
+  useFeatureFlag
 } from '@audius/common'
 import { useDispatch } from 'react-redux'
 
@@ -16,7 +17,6 @@ import { Lineup } from 'app/components/lineup'
 import { EndOfLineupNotice } from 'app/components/lineup/EndOfLineupNotice'
 import { OnlineOnly } from 'app/components/offline-placeholder/OnlineOnly'
 import { useAppTabScreen } from 'app/hooks/useAppTabScreen'
-import { useFeatureFlag } from 'app/hooks/useRemoteConfig'
 import { make, track } from 'app/services/analytics'
 
 import { EmptyFeedSuggestedFollows } from './EmptyFeedSuggestedFollows'

--- a/packages/web/src/app/AppContextProvider.tsx
+++ b/packages/web/src/app/AppContextProvider.tsx
@@ -6,6 +6,8 @@ import { useAsync } from 'react-use'
 import * as analytics from 'services/analytics'
 import { audiusBackendInstance } from 'services/audius-backend/audius-backend-instance'
 import { getStorageNodeSelector } from 'services/audius-sdk/storageNodeSelector'
+import { localStorage } from 'services/local-storage'
+import { remoteConfigInstance } from 'services/remote-config/remote-config-instance'
 import { generatePlaylistArtwork } from 'utils/imageProcessingUtil'
 
 type AppContextProviderProps = {
@@ -20,11 +22,13 @@ export const AppContextProvider = (props: AppContextProviderProps) => {
   const value = useMemo(
     () => ({
       analytics,
+      localStorage,
       storageNodeSelector,
       imageUtils: {
         generatePlaylistArtwork
       },
-      audiusBackend: audiusBackendInstance
+      audiusBackend: audiusBackendInstance,
+      remoteConfig: remoteConfigInstance
     }),
     [storageNodeSelector]
   )

--- a/packages/web/src/components/data-entry/AccessAndSaleTriggerLegacy.tsx
+++ b/packages/web/src/components/data-entry/AccessAndSaleTriggerLegacy.tsx
@@ -30,7 +30,6 @@ import { set, get } from 'lodash'
 import { useSelector } from 'react-redux'
 import { toFormikValidationSchema } from 'zod-formik-adapter'
 
-import { useRemoteVar } from 'hooks/useRemoteConfig'
 import { defaultFieldVisibility } from 'pages/track-page/utils'
 import {
   AVAILABILITY_TYPE,
@@ -134,7 +133,7 @@ export const AccessAndSaleTriggerLegacy = (
     [accountUserId, savedPremiumConditions]
   )
 
-  const usdcPurchaseConfig = useUSDCPurchaseConfig(useRemoteVar)
+  const usdcPurchaseConfig = useUSDCPurchaseConfig()
 
   const initialValues: AccessAndSaleFormValues = useMemo(() => {
     const isUsdcGated = isPremiumContentUSDCPurchaseGated(

--- a/packages/web/src/components/premium-content-purchase-modal/PremiumContentPurchaseModal.tsx
+++ b/packages/web/src/components/premium-content-purchase-modal/PremiumContentPurchaseModal.tsx
@@ -26,7 +26,6 @@ import { Icon } from 'components/Icon'
 import { ModalForm } from 'components/modal-form/ModalForm'
 import { LockedTrackDetailsTile } from 'components/track/LockedTrackDetailsTile'
 import { Text } from 'components/typography'
-import { useRemoteVar } from 'hooks/useRemoteConfig'
 import ModalDrawer from 'pages/audio-rewards-page/components/modals/ModalDrawer'
 import { isMobile } from 'utils/clientUtil'
 import { pushUniqueRoute } from 'utils/route'
@@ -148,7 +147,7 @@ export const PremiumContentPurchaseModal = () => {
   const stage = useSelector(getPurchaseContentFlowStage)
   const error = useSelector(getPurchaseContentError)
   const isUnlocking = !error && isContentPurchaseInProgress(stage)
-  const presetValues = usePayExtraPresets(useRemoteVar)
+  const presetValues = usePayExtraPresets()
 
   const { data: track } = useGetTrackById(
     { id: trackId! },

--- a/packages/web/src/components/premium-content-purchase-modal/components/PurchaseContentFormFields.tsx
+++ b/packages/web/src/components/premium-content-purchase-modal/components/PurchaseContentFormFields.tsx
@@ -27,7 +27,6 @@ import { Icon } from 'components/Icon'
 import { MobileFilterButton } from 'components/mobile-filter-button/MobileFilterButton'
 import { SummaryTable, SummaryTableItem } from 'components/summary-table'
 import { Text } from 'components/typography'
-import { useRemoteVar } from 'hooks/useRemoteConfig'
 import zIndex from 'utils/zIndex'
 
 import { PurchaseContentFormState } from '../hooks/usePurchaseContentFormState'
@@ -58,7 +57,7 @@ export const PurchaseContentFormFields = ({
   isUnlocking
 }: PurchaseContentFormFieldsProps) => {
   const mobile = isMobile()
-  const payExtraAmountPresetValues = usePayExtraPresets(useRemoteVar)
+  const payExtraAmountPresetValues = usePayExtraPresets()
   const [{ value: purchaseMethod }, , { setValue: setPurchaseMethod }] =
     useField(PURCHASE_METHOD)
   const isPurchased = stage === PurchaseContentStage.FINISH

--- a/packages/web/src/components/premium-content-purchase-modal/components/PurchaseContentFormFooter.tsx
+++ b/packages/web/src/components/premium-content-purchase-modal/components/PurchaseContentFormFooter.tsx
@@ -21,7 +21,6 @@ import { make } from 'common/store/analytics/actions'
 import { Icon } from 'components/Icon'
 import { TwitterShareButton } from 'components/twitter-share-button/TwitterShareButton'
 import { Text } from 'components/typography'
-import { useRemoteVar } from 'hooks/useRemoteConfig'
 import { fullTrackPage } from 'utils/route'
 
 import { PurchaseContentFormState } from '../hooks/usePurchaseContentFormState'
@@ -46,7 +45,7 @@ const ContentPurchaseError = ({
   return (
     <Text className={styles.errorContainer} color='accentRed'>
       <Icon icon={IconError} size='medium' />
-      {usePurchaseContentErrorMessage(code, useRemoteVar)}
+      {usePurchaseContentErrorMessage(code)}
     </Text>
   )
 }

--- a/packages/web/src/components/premium-content-purchase-modal/hooks/usePurchaseSummaryValues.ts
+++ b/packages/web/src/components/premium-content-purchase-modal/hooks/usePurchaseSummaryValues.ts
@@ -11,8 +11,6 @@ import {
 } from '@audius/common'
 import { useField } from 'formik'
 
-import { useRemoteVar } from 'hooks/useRemoteConfig'
-
 export const usePurchaseSummaryValues = ({
   price,
   currentBalance
@@ -22,8 +20,8 @@ export const usePurchaseSummaryValues = ({
 }) => {
   const [{ value: customAmount }] = useField(CUSTOM_AMOUNT)
   const [{ value: amountPreset }] = useField(AMOUNT_PRESET)
-  const presetValues = usePayExtraPresets(useRemoteVar)
-  const { minUSDCPurchaseAmountCents } = useUSDCPurchaseConfig(useRemoteVar)
+  const presetValues = usePayExtraPresets()
+  const { minUSDCPurchaseAmountCents } = useUSDCPurchaseConfig()
 
   const extraAmount = getExtraAmount({
     amountPreset,

--- a/packages/web/src/hooks/useIsUSDCEnabled.ts
+++ b/packages/web/src/hooks/useIsUSDCEnabled.ts
@@ -1,6 +1,4 @@
-import { FeatureFlags } from '@audius/common'
-
-import { useFlag } from './useRemoteConfig'
+import { useFeatureFlag, FeatureFlags } from '@audius/common'
 
 export const useIsUSDCEnabled = () =>
-  useFlag(FeatureFlags.USDC_PURCHASES).isEnabled
+  useFeatureFlag(FeatureFlags.USDC_PURCHASES).isEnabled

--- a/packages/web/src/pages/feed-page/components/desktop/FeedPageContent.tsx
+++ b/packages/web/src/pages/feed-page/components/desktop/FeedPageContent.tsx
@@ -2,7 +2,8 @@ import {
   Name,
   FeedFilter,
   feedPageLineupActions as feedActions,
-  FeatureFlags
+  FeatureFlags,
+  useFeatureFlag
 } from '@audius/common'
 
 import { make, useRecord } from 'common/store/analytics/actions'
@@ -15,7 +16,6 @@ import {
 } from 'components/lineup/LineupProvider'
 import { LineupVariant } from 'components/lineup/types'
 import Page from 'components/page/Page'
-import { useFlag } from 'hooks/useRemoteConfig'
 import EmptyFeed from 'pages/feed-page/components/EmptyFeed'
 import { FeedPageContentProps } from 'pages/feed-page/types'
 
@@ -47,7 +47,9 @@ const FeedPageContent = ({
   setFeedFilter,
   resetFeedLineup
 }: FeedPageContentProps) => {
-  const { isEnabled: isUSDCEnabled } = useFlag(FeatureFlags.USDC_PURCHASES)
+  const { isEnabled: isUSDCEnabled } = useFeatureFlag(
+    FeatureFlags.USDC_PURCHASES
+  )
 
   const mainLineupProps = {
     variant: LineupVariant.MAIN

--- a/packages/web/src/pages/upload-page/fields/AccessAndSaleField.tsx
+++ b/packages/web/src/pages/upload-page/fields/AccessAndSaleField.tsx
@@ -19,7 +19,8 @@ import {
   PremiumConditionsUSDCPurchase,
   PremiumConditionsFollowGated,
   PremiumConditionsTipGated,
-  ID
+  ID,
+  useFeatureFlag
 } from '@audius/common'
 import {
   IconCart,
@@ -559,7 +560,9 @@ export const AccessAndSaleMenuFields = (props: AccesAndSaleMenuFieldsProps) => {
     isScheduledRelease
   } = props
 
-  const { isEnabled: isUsdcEnabled } = useFlag(FeatureFlags.USDC_PURCHASES)
+  const { isEnabled: isUsdcEnabled } = useFeatureFlag(
+    FeatureFlags.USDC_PURCHASES
+  )
   const { isEnabled: isCollectibleGatedEnabled } = useFlag(
     FeatureFlags.COLLECTIBLE_GATED_ENABLED
   )

--- a/packages/web/src/pages/upload-page/fields/AccessAndSaleField.tsx
+++ b/packages/web/src/pages/upload-page/fields/AccessAndSaleField.tsx
@@ -47,7 +47,7 @@ import { HelpCallout } from 'components/help-callout/HelpCallout'
 import layoutStyles from 'components/layout/layout.module.css'
 import { ModalRadioItem } from 'components/modal-radio/ModalRadioItem'
 import { Text } from 'components/typography'
-import { useFlag, useRemoteVar } from 'hooks/useRemoteConfig'
+import { useFlag } from 'hooks/useRemoteConfig'
 import { defaultFieldVisibility } from 'pages/track-page/utils'
 
 import { HiddenAvailabilityFields } from '../fields/availability/HiddenAvailabilityFields'
@@ -255,7 +255,7 @@ export const AccessAndSaleField = (props: AccessAndSaleFieldProps) => {
   )
   const isScheduledRelease = moment(release_date).isAfter(moment())
 
-  const usdcPurchaseConfig = useUSDCPurchaseConfig(useRemoteVar)
+  const usdcPurchaseConfig = useUSDCPurchaseConfig()
 
   // Fields from the outer form
   const [{ value: isUnlisted }, , { setValue: setIsUnlistedValue }] =

--- a/packages/web/src/pages/upload-page/fields/availability/usdc-purchase-gated/UsdcPurchaseGatedRadioField.tsx
+++ b/packages/web/src/pages/upload-page/fields/availability/usdc-purchase-gated/UsdcPurchaseGatedRadioField.tsx
@@ -5,13 +5,13 @@ import {
   Name,
   PremiumConditions,
   TrackAvailabilityType,
-  useAccessAndRemixSettings
+  useAccessAndRemixSettings,
+  useFeatureFlag
 } from '@audius/common'
 import { IconCart, IconStars } from '@audius/stems'
 
 import { ExternalLink } from 'components/link'
 import { ModalRadioItem } from 'components/modal-radio/ModalRadioItem'
-import { useFlag } from 'hooks/useRemoteConfig'
 import { make, track } from 'services/analytics'
 
 import { UsdcPurchaseFields } from './UsdcPurchaseFields'
@@ -52,7 +52,7 @@ export const UsdcPurchaseGatedRadioField = (
     track(make({ eventName: Name.TRACK_UPLOAD_CLICK_USDC_WAITLIST_LINK }))
   }, [])
 
-  const { isEnabled: isUsdcUploadEnabled } = useFlag(
+  const { isEnabled: isUsdcUploadEnabled } = useFeatureFlag(
     FeatureFlags.USDC_PURCHASES_UPLOAD
   )
 


### PR DESCRIPTION
### Description
This removes the dependency injection pattern I implemented during the USDC feature in favor of pulling the necessary dependencies from `AppContext` instead. We're already using this pattern in common sagas. We just don't expose the as many dependencies in the React context version. 

The goal is to get away from the `createXHook` pattern where web and mobile generate their own versions of a common hook by passing in the necessary dependencies. This prevents us from writing and exposing hooks in `common` and leads to duplicated code.

fixes PAY-2176

### How Has This Been Tested?
Tested locally in Chrome and Simulator against staging. I updated one usage of the hooks in question to verify that it works correctly. Will follow up in future PRs to migrate usage of derived hooks. 
