### PR TITLE
fix: Update welcome modal cover photo to use saved cover photos

### DIFF
--- a/packages/web/src/components/welcome-modal/WelcomeModal.tsx
+++ b/packages/web/src/components/welcome-modal/WelcomeModal.tsx
@@ -12,7 +12,6 @@ import {
   Box
 } from '@audius/harmony'
 import { Modal } from '@audius/stems'
-import { useSelector } from 'react-redux'
 import { Link } from 'react-router-dom'
 
 import { useModalState } from 'common/hooks/useModalState'
@@ -22,6 +21,8 @@ import {
 } from 'common/store/pages/signon/selectors'
 import Drawer from 'components/drawer/Drawer'
 import { useMedia } from 'hooks/useMedia'
+import { CoverPhotoBanner } from 'pages/sign-up-page/components/CoverPhotoBanner'
+import { useSelector } from 'utils/reducer'
 import { TRENDING_PAGE, UPLOAD_PAGE } from 'utils/route'
 
 const messages = {
@@ -45,30 +46,22 @@ export const WelcomeModal = () => {
 
   return (
     <Root isOpen={isOpen} onClose={onClose} size='small'>
-      <Flex
-        h={96}
-        justifyContent='center'
-        css={({ color }) => ({
-          zIndex: 1,
-          backgroundColor: color.background.default,
-          background: `url("${profileImage?.url}")`,
-          ...(!isMobile && {
-            '::before': {
-              content: '""',
-              position: 'absolute',
-              top: 0,
-              left: 0,
-              height: '100%',
-              width: '100%',
-              backdropFilter: 'blur(25px)'
-            }
-          })
-        })}
-      >
-        <Box w={96} h={96} css={{ position: 'absolute', top: 40 }}>
-          <Avatar variant='strong' src={profileImage?.url} />
-        </Box>
+      <Flex w='100%' h={96} css={{ zIndex: 1 }}>
+        <CoverPhotoBanner />
       </Flex>
+      <Box
+        w={96}
+        h={96}
+        css={{
+          position: 'absolute',
+          top: 40,
+          left: '50%',
+          transform: 'translateX(-50%)',
+          zIndex: 2
+        }}
+      >
+        <Avatar variant='strong' src={profileImage?.url} />
+      </Box>
       <Flex direction='column' p='xl' pt='3xl' gap='xl'>
         <Flex direction='column' css={{ textAlign: 'center' }} gap='l'>
           <Text variant='label' size='xl' strength='strong'>

--- a/packages/web/src/pages/sign-up-page/components/AccountHeader.tsx
+++ b/packages/web/src/pages/sign-up-page/components/AccountHeader.tsx
@@ -1,15 +1,6 @@
-import {
-  Avatar,
-  Box,
-  Flex,
-  IconCamera,
-  IconImage,
-  Text,
-  useTheme
-} from '@audius/harmony'
+import { Avatar, Box, Flex, IconCamera, Text } from '@audius/harmony'
 
 import {
-  getCoverPhotoField,
   getHandleField,
   getNameField,
   getProfileImageField
@@ -17,66 +8,13 @@ import {
 import { useMedia } from 'hooks/useMedia'
 import { useSelector } from 'utils/reducer'
 
+import { CoverPhotoBanner } from './CoverPhotoBanner'
 import { ImageField, ImageFieldValue } from './ImageField'
 
 type AccountHeaderProps = {
   mode: 'editing' | 'viewing'
   formDisplayName?: string
   formProfileImage?: ImageFieldValue
-}
-
-const CoverPhotoBox = ({
-  imageUrl,
-  profileImageUrl,
-  isEditing
-}: {
-  imageUrl: string | undefined
-  profileImageUrl?: string | undefined
-  isEditing?: boolean
-}) => {
-  const { color } = useTheme()
-  const hasImage = imageUrl || profileImageUrl
-  return (
-    <Box
-      h='100%'
-      w='100%'
-      border='default'
-      css={{
-        '&:before': {
-          content: '""',
-          position: 'absolute',
-          top: 0,
-          left: 0,
-          height: '100%',
-          width: '100%',
-          // gradient overlay
-          background: `linear-gradient(0deg, rgba(0, 0, 0, 0.20) 0%, rgba(0, 0, 0, 0.00) 100%)`,
-          // When there is no cover photo we use the profile photo and heavily blur it
-          ...(hasImage && !imageUrl
-            ? {
-                backdropFilter: 'blur(25px)'
-              }
-            : undefined)
-        },
-        overflow: 'hidden',
-        ...(hasImage
-          ? {
-              backgroundImage: `url(${imageUrl ?? profileImageUrl})`,
-              backgroundPosition: 'center',
-              backgroundSize: '100%',
-              backgroundRepeat: 'no-repeat, no-repeat'
-            }
-          : { backgroundColor: color.neutral.n400 })
-      }}
-    >
-      {isEditing && !hasImage ? (
-        <IconImage
-          css={{ position: 'absolute', right: '16px', top: '16px' }}
-          color='staticWhite'
-        />
-      ) : null}
-    </Box>
-  )
 }
 
 const ProfileImageAvatar = ({
@@ -115,7 +53,6 @@ export const AccountHeader = ({
   formDisplayName,
   formProfileImage
 }: AccountHeaderProps) => {
-  const { value: coverPhoto } = { ...useSelector(getCoverPhotoField) }
   const { value: profileImage } = { ...useSelector(getProfileImageField) }
   const { value: storedDisplayName } = useSelector(getNameField)
   const { value: handle } = useSelector(getHandleField)
@@ -132,18 +69,15 @@ export const AccountHeader = ({
         {isEditing ? (
           <ImageField name='coverPhoto' imageResizeOptions={{ square: false }}>
             {(uploadedImage) => (
-              <CoverPhotoBox
-                imageUrl={uploadedImage?.url ?? coverPhoto?.url}
-                profileImageUrl={formProfileImage?.url ?? profileImage?.url}
-                isEditing
+              <CoverPhotoBanner
+                coverPhotoUrl={uploadedImage?.url}
+                profileImageUrl={formProfileImage?.url}
+                showPhotoIcon
               />
             )}
           </ImageField>
         ) : (
-          <CoverPhotoBox
-            imageUrl={coverPhoto?.url}
-            profileImageUrl={profileImage?.url}
-          />
+          <CoverPhotoBanner />
         )}
       </Box>
       <Flex

--- a/packages/web/src/pages/sign-up-page/components/CoverPhotoBanner.tsx
+++ b/packages/web/src/pages/sign-up-page/components/CoverPhotoBanner.tsx
@@ -1,0 +1,67 @@
+import { Box, useTheme } from '@audius/harmony'
+import { IconImage } from '@audius/stems'
+
+import {
+  getCoverPhotoField,
+  getProfileImageField
+} from 'common/store/pages/signon/selectors'
+import { useSelector } from 'utils/reducer'
+
+export const CoverPhotoBanner = ({
+  coverPhotoUrl: propsCoverPhotoUrl,
+  profileImageUrl: propsProfileImageUrl,
+  showPhotoIcon
+}: {
+  coverPhotoUrl?: string
+  profileImageUrl?: string
+  showPhotoIcon?: boolean
+}) => {
+  const { value: coverPhoto } = { ...useSelector(getCoverPhotoField) }
+  const { value: profileImage } = { ...useSelector(getProfileImageField) }
+
+  const { color } = useTheme()
+  const coverPhotoUrl = propsCoverPhotoUrl ?? coverPhoto?.url
+  const profileImageUrl = propsProfileImageUrl ?? profileImage?.url
+  const hasImage = coverPhotoUrl || profileImageUrl
+  return (
+    <Box
+      h='100%'
+      w='100%'
+      css={{
+        '&:before': {
+          content: '""',
+          position: 'absolute',
+          top: 0,
+          left: 0,
+          height: '100%',
+          width: '100%',
+          backgroundColor: color.background.default,
+          // gradient overlay
+          background: `linear-gradient(0deg, rgba(0, 0, 0, 0.20) 0%, rgba(0, 0, 0, 0.00) 100%)`,
+          // When there is no cover photo we use the profile photo and heavily blur it
+          ...(hasImage && !coverPhotoUrl
+            ? {
+                backdropFilter: 'blur(25px)'
+              }
+            : undefined)
+        },
+        overflow: 'hidden',
+        ...(hasImage
+          ? {
+              backgroundImage: `url(${coverPhotoUrl ?? profileImageUrl})`,
+              backgroundPosition: 'center',
+              backgroundSize: '100%',
+              backgroundRepeat: 'no-repeat, no-repeat'
+            }
+          : { backgroundColor: color.neutral.n400 })
+      }}
+    >
+      {showPhotoIcon && !hasImage ? (
+        <IconImage
+          css={{ position: 'absolute', right: '16px', top: '16px' }}
+          color='staticWhite'
+        />
+      ) : null}
+    </Box>
+  )
+}


### PR DESCRIPTION
### Description

![image](https://github.com/AudiusProject/audius-protocol/assets/6711655/ace80ffe-a647-4748-9ff7-c2cdabac3e42)

I noticed our new sign up welcome modal was only showing the blurry profile photo instead of using the cover photo when available. 

I updated it to use existing cover photo logic from the other pages

### How Has This Been Tested?

Tested mobile & desktop web with both cover photo and no cover photo (just profile image)
