### PR TITLE
Default retry for verified user bot

### DIFF
--- a/packages/discovery-provider/plugins/verified-uploads/src/handlers/users.js
+++ b/packages/discovery-provider/plugins/verified-uploads/src/handlers/users.js
@@ -69,16 +69,11 @@ export default async ({ user_id, blocknumber }) => {
             .catch(console.error)
 
           if (Object.keys(data).length === 0) {
-            // wait for identity to load
-            await new Promise((resolve) => {
-              setTimeout(resolve, 5000)
-            })
             throw new Error('social handles not in identity yet')
           }
 
           return data
         },
-        { retries: 100 }
       )
       const { twitterVerified, instagramVerified, tikTokVerified } = data
 


### PR DESCRIPTION
### Description
Previously, retries were meant to allow some time for identity to catch up https://github.com/AudiusProject/audius-protocol/pull/6306/files.

But we went from a few seconds to practically infinite given the exponential backoff default. Somehow a few from last month managed to finish retrying (not sure how). Some were before a verification patch but some are users in a weird state without social handles (possibly a mobile sign up verify bug) but they have mostly gone unnoticed infinitely retrying. 
https://github.com/tim-kos/node-retry#retrytimeoutsoptions

Also, setTimeout is not necessary since retry takes care of that already as well.

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._

Ran on stage along with some logs to confirm cumulative delay within ~25 mins.
```
{
  current: { handle: 'isaactest', is_verified: true },
  old: undefined,
  user_id: 38872,
  blocknumber: 56620706
}
{
  user_id: 38872,
  existing_user_became_verified: false,
  new_user_is_verified: true,
  is_new_user: true,
  is_existing_user: false
}
retrying  { user_id: 38872 } at 2023-11-27T18:14:25.187Z
data  { data: {} } at 2023-11-27T18:14:25.396Z
retrying  { user_id: 38872 } at 2023-11-27T18:14:26.979Z
data  { data: {} } at 2023-11-27T18:14:27.138Z
retrying  { user_id: 38872 } at 2023-11-27T18:14:29.894Z
data  { data: {} } at 2023-11-27T18:14:30.178Z
retrying  { user_id: 38872 } at 2023-11-27T18:14:34.809Z
data  { data: {} } at 2023-11-27T18:14:34.955Z
retrying  { user_id: 38872 } at 2023-11-27T18:14:47.186Z
data  { data: {} } at 2023-11-27T18:14:47.336Z
retrying  { user_id: 38872 } at 2023-11-27T18:15:12.465Z
data  { data: {} } at 2023-11-27T18:15:12.597Z
retrying  { user_id: 38872 } at 2023-11-27T18:16:12.906Z
data  { data: {} } at 2023-11-27T18:16:13.068Z
retrying  { user_id: 38872 } at 2023-11-27T18:17:51.502Z
data  { data: {} } at 2023-11-27T18:17:51.722Z
retrying  { user_id: 38872 } at 2023-11-27T18:20:18.550Z
data  { data: {} } at 2023-11-27T18:20:18.712Z
retrying  { user_id: 38872 } at 2023-11-27T18:25:16.630Z
data  { data: {} } at 2023-11-27T18:25:16.830Z
retrying  { user_id: 38872 } at 2023-11-27T18:40:57.651Z
data  { data: {} } at 2023-11-27T18:40:57.924Z
error at 2023-11-27T18:40:57.939Z
Error: social handles not in identity yet
    at file:///verified_uploads/src/handlers/users.js:75:19
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
    at async default (file:///verified_uploads/src/handlers/users.js:66:20)
    at async Client.<anonymous> (file:///verified_uploads/src/db.js:38:5)
{
  to_slack: {
    userId: 38872,
    handle: 'isaactest',
    link: 'https://audius.co/isaactest',
    source: 'could not figure out source!'
  }
} user verification
done with  { user_id: 38872 }
```
