### PR TITLE
Fix dashboard prod deploy

### DIFF
--- a/protocol-dashboard/scripts/updateBuild.cjs
+++ b/protocol-dashboard/scripts/updateBuild.cjs
@@ -65,6 +65,7 @@ const pinFromFs = async (cid) => {
   try {
     const result = await pinata.pinFromFS(sourcePath, options)
     console.log(result)
+    return result
   } catch (e) {
     console.log(e)
   }
@@ -74,8 +75,8 @@ const run = async () => {
   try {
     await updateGABuild()
     const cid = await pinGABuild()
-    await pinFromFs(cid)
-    fs.writeFileSync(`./build_cid.txt`, cid.IpfsHash)
+    const { IpfsHash } = await pinFromFs(cid)
+    fs.writeFileSync(`./build_cid.txt`, IpfsHash)
     process.exit()
   } catch (err) {
     console.log(err)


### PR DESCRIPTION
### Description
Prod deploy currently broken at the `fs.writeFileSync('./build_cid.txt', cid.IpfsHash)` line: https://app.circleci.com/pipelines/github/AudiusProject/audius-protocol/46711/workflows/945defb4-d08d-44db-8f2e-64ba0dac916f/jobs/606059

From the logs, it appears `cid` is just a string. We want to get `IpfsHash` form the result of `pinata.pinFromFS`

### How Has This Been Tested?
