### PR TITLE
[PROTO-1449] Make mediorum query eth directly for service providers

### DIFF
--- a/mediorum/main.go
+++ b/mediorum/main.go
@@ -181,6 +181,23 @@ func startSandbox() {
 		}()
 	}
 
+	g := registrar.NewEthChainProvider()
+	var peers, signers []server.Peer
+
+	eg := new(errgroup.Group)
+	eg.Go(func() error {
+		peers, err = g.Peers()
+		return err
+	})
+	eg.Go(func() error {
+		signers, err = g.Signers()
+		return err
+	})
+	if err := eg.Wait(); err != nil {
+		panic(err)
+	}
+	logger.Info("fetched registered nodes", "peers", len(peers), "signers", len(signers))
+
 	migrateQmCidIters, err := strconv.Atoi(getenvWithDefault("MIGRATE_QM_CID_ITERS", "0"))
 	if err != nil {
 		logger.Warn("failed to parse MIGRATE_QM_CID_ITERS; defaulting to 0", "err", err)
@@ -191,13 +208,9 @@ func startSandbox() {
 			Host:   httputil.RemoveTrailingSlash(strings.ToLower(creatorNodeEndpoint)),
 			Wallet: strings.ToLower(walletAddress),
 		},
-		ListenPort: "1991",
-		Peers: []server.Peer{
-			server.Peer{
-				Host:   httputil.RemoveTrailingSlash(strings.ToLower(creatorNodeEndpoint)),
-				Wallet: strings.ToLower(walletAddress),
-			},
-		},
+		ListenPort:           "1991",
+		Peers:                peers,
+		Signers:              signers,
 		ReplicationFactor:    5,
 		PrivateKey:           privateKeyHex,
 		Dir:                  "/tmp/mediorum",
@@ -220,6 +233,8 @@ func startSandbox() {
 		logger.Error("failed to create server", "err", err)
 		log.Fatal(err)
 	}
+
+	go refreshPeersAndSigners(ss, g)
 
 	ss.MustStart()
 }

--- a/mediorum/registrar/chain.go
+++ b/mediorum/registrar/chain.go
@@ -1,0 +1,47 @@
+package registrar
+
+import (
+	"strings"
+
+	"github.com/AudiusProject/audius-protocol/mediorum/ethcontracts"
+	"github.com/AudiusProject/audius-protocol/mediorum/httputil"
+
+	"github.com/AudiusProject/audius-protocol/mediorum/server"
+)
+
+func NewEthChainProvider() PeerProvider {
+	return &ethChainProvider{}
+}
+
+type ethChainProvider struct {
+}
+
+func (p *ethChainProvider) Peers() ([]server.Peer, error) {
+	serviceProviders, err := ethcontracts.GetServiceProviderList("content-node")
+	if err != nil {
+		return nil, err
+	}
+	peers := make([]server.Peer, len(serviceProviders))
+	for i, sp := range serviceProviders {
+		peers[i] = server.Peer{
+			Host:   httputil.RemoveTrailingSlash(strings.ToLower(sp.Endpoint)),
+			Wallet: strings.ToLower(sp.DelegateOwnerWallet),
+		}
+	}
+	return peers, nil
+}
+
+func (p *ethChainProvider) Signers() ([]server.Peer, error) {
+	serviceProviders, err := ethcontracts.GetServiceProviderList("discovery-node")
+	if err != nil {
+		return nil, err
+	}
+	signers := make([]server.Peer, len(serviceProviders))
+	for i, sp := range serviceProviders {
+		signers[i] = server.Peer{
+			Host:   httputil.RemoveTrailingSlash(strings.ToLower(sp.Endpoint)),
+			Wallet: strings.ToLower(sp.DelegateOwnerWallet),
+		}
+	}
+	return signers, nil
+}

--- a/mediorum/registrar/multi.go
+++ b/mediorum/registrar/multi.go
@@ -2,6 +2,7 @@ package registrar
 
 import (
 	"errors"
+	"fmt"
 
 	"github.com/AudiusProject/audius-protocol/mediorum/server"
 )
@@ -11,6 +12,7 @@ func NewMultiStaging() PeerProvider {
 		providers: []PeerProvider{
 			NewAudiusApiGatewayStaging(),
 			NewGraphStaging(),
+			NewEthChainProvider(),
 		},
 	}
 
@@ -21,6 +23,7 @@ func NewMultiProd() PeerProvider {
 		providers: []PeerProvider{
 			NewAudiusApiGatewayProd(),
 			NewGraphProd(),
+			NewEthChainProvider(),
 		},
 	}
 }
@@ -33,6 +36,8 @@ func (p multiProvider) Peers() ([]server.Peer, error) {
 	for _, provider := range p.providers {
 		if vals, err := provider.Peers(); err == nil {
 			return vals, nil
+		} else {
+			fmt.Println(err)
 		}
 	}
 	return nil, errors.New("all providers failed")
@@ -42,6 +47,8 @@ func (p multiProvider) Signers() ([]server.Peer, error) {
 	for _, provider := range p.providers {
 		if vals, err := provider.Signers(); err == nil {
 			return vals, nil
+		} else {
+			fmt.Println(err)
 		}
 	}
 	return nil, errors.New("all providers failed")


### PR DESCRIPTION
### Description
- Makes mediorum query chain directly as a fallback for staging+prod (only as a fallback because the other options are more economical)
- Changes the future audius-d `sandbox` entrypoint to use this instead of hardcoding
Leaves the single+cluster dev entrypoints because unit tests and other things need to be able to use them without ganache

### How Has This Been Tested?
- Tested on stage CN5 - the health check shows it using the correct peers and signers when commenting out fallbacks to API Gateway and The Graph
- Haven't tested sandbox entrypoint because it looks like it's not wired up to audius-d yet. But the audius-d config shows that it points `ethProviderUrl` to the local eth ganache container, which is all that's needed. cc @phelpsdb 
