### PR TITLE
require push-uptime to deploy

### DIFF
--- a/.circleci/src/workflows/discovery.yml
+++ b/.circleci/src/workflows/discovery.yml
@@ -192,6 +192,7 @@ jobs:
         - push-comms
         - push-trpc
         - push-protocol-dashboard
+        - push-uptime
         - push-healthz
         # uncomment when arm builds are stable
         # - push-discovery-provider-arm

--- a/.circleci/src/workflows/release.yml
+++ b/.circleci/src/workflows/release.yml
@@ -168,6 +168,7 @@ jobs:
         - push-trpc
         - push-healthz
         - push-protocol-dashboard
+        - push-uptime
         # uncomment these when arm builds are stable
         # - push-identity-service-arm
         # - push-mediorum-arm


### PR DESCRIPTION
### Description
`uptime` is a required service, if the push fails, nodes aren't able to pull the new tag and upgrade. So `push-uptime` should be required to succeed before a deploy goes out.

### How Has This Been Tested?
