### PR TITLE
Improve harmony font consistency

### DIFF
--- a/packages/harmony/src/foundations/reset/reset.css
+++ b/packages/harmony/src/foundations/reset/reset.css
@@ -127,3 +127,11 @@ table {
   border-collapse: collapse;
   border-spacing: 0;
 }
+
+/* Ensure fonts are consistent across browser environments */
+:root {
+  font-synthesis: none;
+  text-rendering: optimizeLegibility;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}


### PR DESCRIPTION
### Description

Currently, the Avenir font will render differently on different browsers & in different environments because our reset.css doesn't cover aliasing, etc.

These are standards borrowed from the "create vite app" reset and match similarly what we have done in the web client & protocol dashboard.

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._

```
npm run storybook
```

Confirmed things look consistent -- and this change also fixed the embed player.


Before:
<img width="660" alt="image" src="https://github.com/AudiusProject/audius-protocol/assets/2731362/33e8641b-350f-46fa-b22f-a5877a41c233">

After:
<img width="676" alt="image" src="https://github.com/AudiusProject/audius-protocol/assets/2731362/f5f3a42e-0670-45dc-863b-de43dc814287">
