### PR TITLE
[PAY-2208] Make payment router test e2e

### DIFF
--- a/solana-programs/payment-router/Anchor.toml
+++ b/solana-programs/payment-router/Anchor.toml
@@ -2,7 +2,7 @@
 seeds = false
 skip-lint = false
 [programs.mainnet]
-payment_router = "6pca6uGGV5GYKY8W9aGfJbWPx4pe5mW8wLaP9c3LUNpp"
+payment_router = "paytYpX3LPN98TAeen6bFFeraGSuWnomZmCXjAsoqPa"
 
 [registry]
 url = "https://api.apr.dev"
@@ -14,4 +14,5 @@ wallet = "id.json"
 [scripts]
 test = "yarn run ts-mocha -p ./tsconfig.json -t 1000000 tests/**/*.ts"
 test-create-payment-router-balance-pda= "yarn run ts-mocha -g 'pda' -p ./tsconfig.json -t 1000000 tests/**/*.ts"
-test-route= "yarn run ts-mocha -g 'routes' -p ./tsconfig.json -t 1000000 tests/**/*.ts"
+test-route-audio= "yarn run ts-mocha -g 'routes AUDIO' -p ./tsconfig.json -t 1000000 tests/**/*.ts"
+test-route-usdc= "yarn run ts-mocha -g 'routes USDC' -p ./tsconfig.json -t 1000000 tests/**/*.ts"

--- a/solana-programs/payment-router/README.md
+++ b/solana-programs/payment-router/README.md
@@ -6,7 +6,7 @@ The program derives a PDA to own tokens as an intermediary before paying out.
 
 This program and its Anchor tests are set up to only work with the Solana mainnet cluster at the moment.
 
-Here is the [deployed program](https://explorer.solana.com/address/6pca6uGGV5GYKY8W9aGfJbWPx4pe5mW8wLaP9c3LUNpp).
+Here is the [deployed program](https://explorer.solana.com/address/paytYpX3LPN98TAeen6bFFeraGSuWnomZmCXjAsoqPa).
 
 ## Versions
 
@@ -72,13 +72,13 @@ For example,
 
 ### Testing the PDA creation
 
-Note that the PDA has already been created, so attempting to create it again will fail. Here is [the PDA account](https://explorer.solana.com/address/67EAQXgyWFzWWDuxwkZjV4FdH4rQ2AidBp5iB4M4kWth).
+Note that the PDA has already been created, so attempting to create it again will fail. Here is [the PDA account](https://explorer.solana.com/address/8L2FL5g9y9CzAFY1471tLAXBUsupdp1kNeFuP648mqxR).
 
 ```
 ./scripts/testCreatePaymentRouterBalancePda.sh
 ```
 
-### Testing the Wormhole transfer
+### Testing the Routing
 
 This will send 0.00001 AUDIO tokens to the wormhole for a given recipient to subsequently redeem.
 

--- a/solana-programs/payment-router/programs/payment-router/src/lib.rs
+++ b/solana-programs/payment-router/programs/payment-router/src/lib.rs
@@ -17,7 +17,7 @@ use crate::router::{
 #[cfg(not(feature = "no-entrypoint"))]
 use solana_security_txt::security_txt;
 
-declare_id!("6pca6uGGV5GYKY8W9aGfJbWPx4pe5mW8wLaP9c3LUNpp");
+declare_id!("paytYpX3LPN98TAeen6bFFeraGSuWnomZmCXjAsoqPa");
 
 #[program]
 pub mod payment_router {

--- a/solana-programs/payment-router/scripts/testRouteAudio.sh
+++ b/solana-programs/payment-router/scripts/testRouteAudio.sh
@@ -6,4 +6,4 @@ if [ -z "$keypair_path" ]; then
   exit 1
 fi
 
-feePayerSecret=$(cat $keypair_path) anchor run test-route -- --skip-deploy
+feePayerSecret=$(cat $keypair_path) anchor run test-route-audio -- --skip-deploy

--- a/solana-programs/payment-router/scripts/testRouteUsdc.sh
+++ b/solana-programs/payment-router/scripts/testRouteUsdc.sh
@@ -1,0 +1,9 @@
+solana_config=$(solana config get)
+keypair_path=$(echo "$solana_config" | grep "Keypair Path" | awk '{print $3}')
+
+if [ -z "$keypair_path" ]; then
+  echo "Error: fee payer keypair path not found"
+  exit 1
+fi
+
+feePayerSecret=$(cat $keypair_path) anchor run test-route-usdc -- --skip-deploy

--- a/solana-programs/payment-router/tests/constants.ts
+++ b/solana-programs/payment-router/tests/constants.ts
@@ -1,3 +1,7 @@
 // https://explorer.solana.com/address/9LzCMqDgTKYz9Drzqnpgee3SGa89up3a247ypMj2xrqM
-export const SOL_AUDIO_DECIMALS = 8
-export const SOL_AUDIO_TOKEN_ADDRESS = '9LzCMqDgTKYz9Drzqnpgee3SGa89up3a247ypMj2xrqM'
+export const SPL_AUDIO_DECIMALS = 8
+export const SPL_AUDIO_TOKEN_ADDRESS = '9LzCMqDgTKYz9Drzqnpgee3SGa89up3a247ypMj2xrqM'
+
+// https://explorer.solana.com/address/EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v
+export const SPL_USDC_DECIMALS = 6
+export const SPL_USDC_TOKEN_ADDRESS = 'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v'

--- a/solana-programs/payment-router/tests/payment-router.ts
+++ b/solana-programs/payment-router/tests/payment-router.ts
@@ -1,12 +1,14 @@
 import * as anchor from '@coral-xyz/anchor'
 import { Program } from '@coral-xyz/anchor'
 import { PaymentRouter } from '../target/types/payment_router'
-import { SOL_AUDIO_DECIMALS, SOL_AUDIO_TOKEN_ADDRESS } from './constants'
+import { SPL_AUDIO_DECIMALS, SPL_AUDIO_TOKEN_ADDRESS, SPL_USDC_DECIMALS, SPL_USDC_TOKEN_ADDRESS } from './constants'
 import {
   TOKEN_PROGRAM_ID,
+  createTransferCheckedInstruction,
   getOrCreateAssociatedTokenAccount,
 } from '@solana/spl-token'
 import { assert } from 'chai'
+import { TransactionMessage, VersionedTransaction } from '@solana/web3.js'
 
 const {
   Connection,
@@ -22,7 +24,8 @@ const feePayerKeypair = Keypair.fromSecretKey(
 )
 const feePayerPublicKey = feePayerKeypair.publicKey
 
-const SOL_AUDIO_TOKEN_ADDRESS_KEY = new PublicKey(SOL_AUDIO_TOKEN_ADDRESS)
+const SPL_AUDIO_TOKEN_ADDRESS_KEY = new PublicKey(SPL_AUDIO_TOKEN_ADDRESS)
+const SPL_USDC_TOKEN_ADDRESS_KEY = new PublicKey(SPL_USDC_TOKEN_ADDRESS)
 
 const endpoint = 'https://api.mainnet-beta.solana.com'
 const connection = new Connection(endpoint, 'finalized')
@@ -77,10 +80,8 @@ describe('payment-router', () => {
     }
   })
 
-  it('routes the amounts to the recipients', async () => {
-    // List of 10 recipient token accounts.
-    // The keys are some solana token accounts that can be used for testing.
-    // https://explorer.solana.com/address/E7vtghUxo3DwBHHBnkYzTyKgtRS4cL8BiRyufdPMQYUp
+  it('routes AUDIO amounts to the recipients', async () => {
+    // List of 10 recipient testing $AUDIO token accounts.
     const recipients = [
       'E7vtghUxo3DwBHHBnkYzTyKgtRS4cL8BiRyufdPMQYUp',
       'FJ9KXGM6EtZ8fpmMZwHZsa8aL5kZvB3yS2HQzJC3ss5h',
@@ -93,9 +94,10 @@ describe('payment-router', () => {
       'Aunpp6mQonYuKcmFPqhHsfRjrnF8MznHbVti2iVDp4MN',
       'CXeY4Yea4s78LDkXqwkvBmY65aMt4WTmeVeSaUgdz8Cf',
     ]
+    const amount = 0.00001
     const recipientAmounts: Record<string, number> = recipients
       .reduce((acc, recipient) => {
-        acc[recipient] = 0.00001
+        acc[recipient] = amount
         return acc
       },
       {}
@@ -105,50 +107,188 @@ describe('payment-router', () => {
     let audioTokenAccount = await getOrCreateAssociatedTokenAccount(
       connection,
       feePayerKeypair,
-      SOL_AUDIO_TOKEN_ADDRESS_KEY,
+      SPL_AUDIO_TOKEN_ADDRESS_KEY,
       paymentRouterPda,
       true // allowOwnerOffCurve: we need this since the owner is a program
     )
+    const feePayerAudioTokenAccount = await getOrCreateAssociatedTokenAccount(
+      connection,
+      feePayerKeypair,
+      SPL_AUDIO_TOKEN_ADDRESS_KEY,
+      feePayerPublicKey
+    )
+
     const pdaAtaKey = audioTokenAccount.address
     const audioAmountBeforeTransfer = Number(audioTokenAccount.amount)
 
     const amounts = Object.values(recipientAmounts)
-      .map(amount => new anchor.BN(amount * 10 ** SOL_AUDIO_DECIMALS))
+      .map(amount => new anchor.BN(amount * 10 ** SPL_AUDIO_DECIMALS))
     const totalAmount = amounts
       .reduce((a: anchor.BN, b: anchor.BN) => a.add(b), new anchor.BN(0))
 
-    const tx = await program.methods
-      .route(
-        paymentRouterPdaBump,
-        amounts,
-        totalAmount,
-      )
-      .accounts({
-        sender: pdaAtaKey,
-        senderOwner: paymentRouterPda,
-        splToken: TOKEN_PROGRAM_ID,
-      })
-      .remainingAccounts(
-        recipients
-          .map(recipient => ({
-            pubkey: new PublicKey(recipient),
-            isSigner: false,
-            isWritable: true
-          }))
-      )
-      .rpc()
-    console.log('Your transaction signature', tx)
+    const recentBlockhash = (await connection.getLatestBlockhash()).blockhash
+    const instructions = [
+      createTransferCheckedInstruction(
+        feePayerAudioTokenAccount.address,
+        SPL_AUDIO_TOKEN_ADDRESS_KEY,
+        pdaAtaKey,
+        feePayerPublicKey,
+        totalAmount.toNumber(),
+        SPL_AUDIO_DECIMALS
+      ),
+      await program.methods
+        .route(
+          paymentRouterPdaBump,
+          amounts,
+          totalAmount,
+        )
+        .accounts({
+          sender: pdaAtaKey,
+          senderOwner: paymentRouterPda,
+          splToken: TOKEN_PROGRAM_ID,
+        })
+        .remainingAccounts(
+          recipients
+            .map(recipient => ({
+              pubkey: new PublicKey(recipient),
+              isSigner: false,
+              isWritable: true
+            }))
+        )
+        .instruction()
+    ]
+    const message = new TransactionMessage({
+      payerKey: feePayerPublicKey,
+      recentBlockhash,
+      instructions
+    }).compileToV0Message()
+    const tx = new VersionedTransaction(message)
+    tx.sign([feePayerKeypair])
+    await connection.sendTransaction(tx)
+
+    const rawTransaction = tx.serialize()
+    await connection.sendRawTransaction(rawTransaction)
+    console.log(
+      'Your transaction signature',
+      Buffer.from(tx.signatures[0]).toString('hex')
+    )
 
     audioTokenAccount = await getOrCreateAssociatedTokenAccount(
       connection,
       feePayerKeypair,
-      SOL_AUDIO_TOKEN_ADDRESS_KEY,
+      SPL_AUDIO_TOKEN_ADDRESS_KEY,
       paymentRouterPda,
       true // allowOwnerOffCurve: we need this since the owner is a program
     )
     assert.equal(
       Number(audioTokenAccount.amount),
-      audioAmountBeforeTransfer - totalAmount.toNumber(),
+      audioAmountBeforeTransfer,
+      'Incorrect expected amount after transfer to recipients'
+    )
+  })
+
+  it('routes USDC amounts to the recipients', async () => {
+    // List of 10 recipient testing $USDC token accounts.
+    const recipients = [
+      '8q8MSG4cdyDLoDXRGBLQugA6oHtQmbCtVVV1aEuPdYTj',
+      'FMcMbnqupTbWmmyWJb8DhX2f1DHyHEqFf1rD87fRupaP',
+      '4hbyJjqpWAbarjCQhY8YSeptZz1WYSS88DGqG4BteE3v',
+      'C4DohgB7tKRrArNzofi5wkEaGWSWeifK4EruaWnA77D4',
+      'isZMQA3Ury9FkZXBn4Gt51hTLxc8dYsQD7bWz4Ek46E',
+      'DST1gMcKvrDrxmP4UhQkbJ8X6psL8WyuWnS3KWmqLRcu',
+      '3jnV4Xz7G6vLTNNScr86evmPdTSypP2uYGHtTzaHwGY2',
+      'A6Txt94EB7vPkT5YVAqQbkKFfXpLggkEMYLRtQrzkM13',
+      '2kasfxzRdYq7GC96ZFRdvp31JAc8MREG21mxEVhEDzot',
+      '6mGfojkDcTHzhZ68pwDgntqn32EYYNDw7otZfT1GCQYH',
+    ]
+    const recipientAmounts: Record<string, number> = recipients
+      .reduce((acc, recipient) => {
+        acc[recipient] = 0.00001
+        return acc
+      },
+      {}
+    )
+
+    // Associated token account owned by the PDA
+    let usdcTokenAccount = await getOrCreateAssociatedTokenAccount(
+      connection,
+      feePayerKeypair,
+      SPL_USDC_TOKEN_ADDRESS_KEY,
+      paymentRouterPda,
+      true // allowOwnerOffCurve: we need this since the owner is a program
+    )
+    const feePayerUsdcTokenAccount = await getOrCreateAssociatedTokenAccount(
+      connection,
+      feePayerKeypair,
+      SPL_USDC_TOKEN_ADDRESS_KEY,
+      feePayerPublicKey
+    )
+
+    const pdaAtaKey = usdcTokenAccount.address
+    const usdcAmountBeforeTransfer = Number(usdcTokenAccount.amount)
+
+    const amounts = Object.values(recipientAmounts)
+      .map(amount => new anchor.BN(amount * 10 ** SPL_AUDIO_DECIMALS))
+    const totalAmount = amounts
+      .reduce((a: anchor.BN, b: anchor.BN) => a.add(b), new anchor.BN(0))
+
+    const recentBlockhash = (await connection.getLatestBlockhash()).blockhash
+    const instructions = [
+      createTransferCheckedInstruction(
+        feePayerUsdcTokenAccount.address,
+        SPL_USDC_TOKEN_ADDRESS_KEY,
+        pdaAtaKey,
+        feePayerPublicKey,
+        totalAmount.toNumber(),
+        SPL_USDC_DECIMALS
+      ),
+      await program.methods
+        .route(
+          paymentRouterPdaBump,
+          amounts,
+          totalAmount,
+        )
+        .accounts({
+          sender: pdaAtaKey,
+          senderOwner: paymentRouterPda,
+          splToken: TOKEN_PROGRAM_ID,
+        })
+        .remainingAccounts(
+          recipients
+            .map(recipient => ({
+              pubkey: new PublicKey(recipient),
+              isSigner: false,
+              isWritable: true
+            }))
+        )
+        .instruction()
+    ]
+    const message = new TransactionMessage({
+      payerKey: feePayerPublicKey,
+      recentBlockhash,
+      instructions
+    }).compileToV0Message()
+    const tx = new VersionedTransaction(message)
+    tx.sign([feePayerKeypair])
+    await connection.sendTransaction(tx)
+
+    const rawTransaction = tx.serialize()
+    await connection.sendRawTransaction(rawTransaction)
+    console.log(
+      'Your transaction signature',
+      Buffer.from(tx.signatures[0]).toString('hex')
+    )
+
+    usdcTokenAccount = await getOrCreateAssociatedTokenAccount(
+      connection,
+      feePayerKeypair,
+      SPL_USDC_TOKEN_ADDRESS_KEY,
+      paymentRouterPda,
+      true // allowOwnerOffCurve: we need this since the owner is a program
+    )
+    assert.equal(
+      Number(usdcTokenAccount.amount),
+      usdcAmountBeforeTransfer,
       'Incorrect expected amount after transfer to recipients'
     )
   })

--- a/solana-programs/payment-router/yarn.lock
+++ b/solana-programs/payment-router/yarn.lock
@@ -76,7 +76,7 @@
     "@solana/buffer-layout-utils" "^0.2.0"
     buffer "^6.0.3"
 
-"@solana/web3.js@^1.32.0", "@solana/web3.js@^1.68.0", "@solana/web3.js@^1.78.4":
+"@solana/web3.js@1.78.4", "@solana/web3.js@^1.32.0", "@solana/web3.js@^1.68.0":
   version "1.78.4"
   resolved "https://registry.npmjs.org/@solana/web3.js/-/web3.js-1.78.4.tgz"
   integrity sha512-up5VG1dK+GPhykmuMIozJZBbVqpm77vbOG6/r5dS7NBGZonwHfTLdBbsYc3rjmaQ4DpCXUa3tUc4RZHRORvZrw==


### PR DESCRIPTION
### Description

* Set deploy program id to the latest one
* Make tests fully e2e: feepayer -> payment router PDA -> recipients
* Add USDC flavor of test

This code is useful now to be able to see the e2e flow like we would implement client side

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._

```
anchor build
./scripts/testRouteUsdc.sh
```
