### PR TITLE
Negative error codes for allowing

### DIFF
--- a/packages/discovery-provider/plugins/pedalboard/apps/relay/src/config/antiAbuseConfig.ts
+++ b/packages/discovery-provider/plugins/pedalboard/apps/relay/src/config/antiAbuseConfig.ts
@@ -13,7 +13,7 @@ export const newAntiAbuseConfig = (
 ): AntiAbuseConfig => {
   return {
     antiAbuseOracleUrl: url,
-    allowRules: new Set([14, 17]),
+    allowRules: new Set([-17, -18]),
     blockRelayAbuseErrorCodes: new Set([0, 8, 10, 13, 15, 18]),
     blockNotificationsErrorCodes: new Set([7, 9]),
     blockEmailsErrorCodes: new Set([0, 1, 2, 3, 4, 8, 10, 13, 15]),

--- a/packages/identity-service/src/utils/antiAbuse.js
+++ b/packages/identity-service/src/utils/antiAbuse.js
@@ -6,7 +6,7 @@ const models = require('../models')
 const aaoEndpoint =
   config.get('aaoEndpoint') || 'https://antiabuseoracle.audius.co'
 
-const allowRules = new Set([14, 17])
+const allowRules = new Set([-17, -18])
 const blockRelayAbuseErrorCodes = new Set([0, 8, 10, 13, 15, 18])
 const blockNotificationsErrorCodes = new Set([7, 9])
 const blockEmailsErrorCodes = new Set([0, 1, 2, 3, 4, 8, 10, 13, 15])


### PR DESCRIPTION
### Description
AAO is now using negative error codes for allowing. Modify identity/discovery relay to accept those.

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._

Will test on stage.