### PR TITLE
Track number of blobs served from mediorum and expose metric endpoint

### DIFF
--- a/mediorum/server/db.go
+++ b/mediorum/server/db.go
@@ -40,6 +40,27 @@ type Upload struct {
 	// UpldateULID - this is the last ULID that change this thing
 }
 
+type MetricAction string
+
+const (
+	TrackStream MetricAction = "TRACK_STREAM"
+	ServeImage  MetricAction = "SERVE_IMAGE"
+)
+
+type DailyMetrics struct {
+	Timestamp time.Time    `gorm:"primaryKey"`
+	Action    MetricAction `gorm:"type:enum('TRACK_STREAM', 'SERVE_IMAGE');primaryKey"`
+	Count     int64        `gorm:"not null"`
+	CreatedAt time.Time    `json:"created_at" gorm:"not null"`
+}
+
+type MonthlyMetrics struct {
+	Timestamp time.Time    `gorm:"primaryKey"`
+	Action    MetricAction `gorm:"type:enum('TRACK_STREAM', 'SERVE_IMAGE');primaryKey"`
+	Count     int64        `gorm:"not null"`
+	CreatedAt time.Time    `json:"created_at" gorm:"not null"`
+}
+
 type UploadCursor struct {
 	Host  string `gorm:"primaryKey"`
 	After time.Time
@@ -62,7 +83,7 @@ func dbMustDial(dbPath string) *gorm.DB {
 func dbMigrate(crud *crudr.Crudr, bucket *blob.Bucket, myHost string) {
 	// Migrate the schema
 	slog.Info("db: gorm automigrate")
-	err := crud.DB.AutoMigrate(&Upload{}, &RepairTracker{}, &UploadCursor{}, &StorageAndDbSize{})
+	err := crud.DB.AutoMigrate(&Upload{}, &RepairTracker{}, &UploadCursor{}, &StorageAndDbSize{}, &DailyMetrics{}, &MonthlyMetrics{})
 	if err != nil {
 		panic(err)
 	}

--- a/mediorum/server/serve_blob.go
+++ b/mediorum/server/serve_blob.go
@@ -16,6 +16,7 @@ import (
 	"time"
 
 	"github.com/AudiusProject/audius-protocol/mediorum/server/signature"
+	"gorm.io/gorm"
 
 	"github.com/AudiusProject/audius-protocol/mediorum/cidutil"
 
@@ -201,6 +202,7 @@ func (ss *MediorumServer) serveBlob(c echo.Context) error {
 		}
 
 		if isAudioFile {
+			ss.recordMetric(TrackStream)
 			http.ServeContent(c.Response(), c.Request(), cid, blob.ModTime(), blob)
 			return nil
 		}
@@ -209,6 +211,7 @@ func (ss *MediorumServer) serveBlob(c echo.Context) error {
 		if err != nil {
 			return err
 		}
+		ss.recordMetric(ServeImage)
 		return c.Blob(200, blob.ContentType(), blobData)
 	}
 
@@ -228,6 +231,63 @@ func (ss *MediorumServer) serveBlob(c echo.Context) error {
 	}
 
 	return c.String(404, "blob not found")
+}
+
+func (ss *MediorumServer) recordMetric(action MetricAction) {
+	today := time.Now().UTC().Truncate(24 * time.Hour)
+	firstOfMonth := time.Date(today.Year(), today.Month(), 1, 0, 0, 0, 0, time.UTC)
+
+	// Increment daily metric
+	err := ss.crud.DB.Transaction(func(tx *gorm.DB) error {
+		var metric DailyMetrics
+
+		if err := tx.FirstOrCreate(&metric, DailyMetrics{
+			Timestamp: today,
+			Action:    action,
+		}).Error; err != nil {
+			return err
+		}
+
+		// Increment the count
+		metric.Count += 1
+
+		// Save the updated record
+		if err := tx.Save(&metric).Error; err != nil {
+			return err
+		}
+
+		return nil
+	})
+
+	if err != nil {
+		ss.logger.Error("unable to increment daily metric", "err", err, "action", action)
+	}
+
+	// Increment monthly metric
+	err = ss.crud.DB.Transaction(func(tx *gorm.DB) error {
+		var metric MonthlyMetrics
+
+		if err := tx.FirstOrCreate(&metric, MonthlyMetrics{
+			Timestamp: firstOfMonth,
+			Action:    action,
+		}).Error; err != nil {
+			return err
+		}
+
+		// Increment the count
+		metric.Count += 1
+
+		// Save the updated record
+		if err := tx.Save(&metric).Error; err != nil {
+			return err
+		}
+
+		return nil
+	})
+
+	if err != nil {
+		ss.logger.Error("unable to increment monthly metric", "err", err, "action", action)
+	}
 }
 
 func (ss *MediorumServer) findNodeToServeBlob(ctx context.Context, key string) string {

--- a/mediorum/server/serve_metrics.go
+++ b/mediorum/server/serve_metrics.go
@@ -5,8 +5,10 @@ import (
 	"net/http"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/labstack/echo/v4"
+	"golang.org/x/exp/slices"
 )
 
 type Metrics struct {
@@ -16,12 +18,161 @@ type Metrics struct {
 	RedirectCacheSize int            `json:"redirect_cache_size"`
 }
 
+type BlobMetric struct {
+	Timestamp time.Time `json:"timestamp" gorm:"primaryKey"`
+	Count     int64     `json:"count"`
+}
+
+type BlobMetrics struct {
+	Data []BlobMetric `json:"data"`
+}
+
+var (
+	validBucketSizes = map[string][]string{
+		"week":     {"day"},
+		"month":    {"day", "week"},
+		"all_time": {"month", "week"},
+	}
+	validBlobMetricActions = []string{"track_stream", "serve_image", "all"}
+)
+
 func (ss *MediorumServer) getMetrics(c echo.Context) error {
 	m := Metrics{}
 	m.Host = ss.Config.Self.Host
 	m.Uploads = ss.uploadsCount
 	m.OutboxSizes = ss.crud.GetOutboxSizes()
 	m.RedirectCacheSize = ss.redirectCache.Len()
+
+	return c.JSON(200, m)
+}
+
+func (ss *MediorumServer) getBlobsServedMetrics(c echo.Context) error {
+	timeRange := c.Param("timeRange")
+	if timeRange == "" || len(validBucketSizes[timeRange]) == 0 {
+		return c.String(400, fmt.Sprintf("Error: bad path param %s", timeRange))
+	}
+	bucket := c.QueryParam("bucket_size")
+	if bucket == "" || !slices.Contains(validBucketSizes[timeRange], bucket) {
+		return c.String(400, fmt.Sprintf("Error: bad request param bucket: %s", bucket))
+	}
+	action := c.QueryParam("action")
+	if action != "" && !slices.Contains(validBlobMetricActions, action) {
+		return c.String(400, fmt.Sprintf("Error: bad request param action: %s", action))
+	}
+
+	m := BlobMetrics{}
+	today := time.Now().UTC().Truncate(24 * time.Hour)
+	sevenDaysAgo := today.AddDate(0, 0, -7)
+	thirtyDaysAgo := today.AddDate(0, 0, -30)
+	firstOfMonth := time.Date(today.Year(), today.Month(), 1, 0, 0, 0, 0, time.UTC)
+	if timeRange == "week" {
+		if bucket == "day" {
+			var metrics []BlobMetric
+			query := ss.crud.DB.
+				Model(&DailyMetrics{}).
+				Where("timestamp >= ? AND timestamp < ?", sevenDaysAgo, today)
+			if action != "" && action != "all" {
+				query = query.Select("timestamp, count").Where("action = ?", strings.ToUpper(action))
+			} else {
+				// sum counts from all actions together
+				query = query.Select("timestamp, sum(count) as count").Group("timestamp")
+			}
+			err := query.Order("timestamp asc").Find(&metrics).Error
+			if err != nil {
+				return c.JSON(400, map[string]string{
+					"error": err.Error(),
+				})
+			}
+
+			m.Data = metrics
+		}
+	}
+
+	if timeRange == "month" {
+		if bucket == "day" {
+			var metrics []BlobMetric
+			query := ss.crud.DB.
+				Model(&DailyMetrics{}).
+				Where("timestamp >= ? AND timestamp < ?", thirtyDaysAgo, today)
+			if action != "" && action != "all" {
+				query = query.Select("timestamp, count").Where("action = ?", strings.ToUpper(action))
+			} else {
+				// sum counts from all actions together
+				query = query.Select("timestamp, sum(count) as count").Group("timestamp")
+			}
+			err := query.Order("timestamp asc").Find(&metrics).Error
+			if err != nil {
+				return c.JSON(400, map[string]string{
+					"error": err.Error(),
+				})
+			}
+
+			m.Data = metrics
+		} else if bucket == "week" {
+			var metrics []BlobMetric
+			groupBy := `date(timestamp, 'weekday 1', '-7 days')`
+			query := ss.crud.DB.
+				Model(&DailyMetrics{}).
+				Select(groupBy+` as timestamp, sum(count) as count`).
+				Where("timestamp >= ? AND timestamp < ?", thirtyDaysAgo, today).
+				Group(groupBy)
+
+			if action != "all" {
+				query = query.Where("action = ?", strings.ToUpper(action))
+			}
+			err := query.Order("timestamp asc").Find(&metrics).Error
+			if err != nil {
+				return c.JSON(400, map[string]string{
+					"error": err.Error(),
+				})
+			}
+
+			m.Data = metrics
+		}
+	}
+
+	if timeRange == "all_time" {
+		if bucket == "month" {
+			var metrics []BlobMetric
+			query := ss.crud.DB.
+				Model(&MonthlyMetrics{}).
+				Where("timestamp < ?", firstOfMonth)
+			if action != "" && action != "all" {
+				query = query.Select("timestamp, count").Where("action = ?", strings.ToUpper(action))
+			} else {
+				// sum counts from all actions together
+				query = query.Select("timestamp, sum(count) as count").Group("timestamp")
+			}
+			err := query.Order("timestamp asc").Find(&metrics).Error
+			if err != nil {
+				return c.JSON(400, map[string]string{
+					"error": err.Error(),
+				})
+			}
+
+			m.Data = metrics
+		} else if bucket == "week" {
+			var metrics []BlobMetric
+			groupBy := `date(timestamp, 'weekday 1', '-7 days')`
+			query := ss.crud.DB.
+				Model(&DailyMetrics{}).
+				Select(groupBy+` as timestamp, sum(count) as count`).
+				Where("timestamp < ?", today).
+				Group(groupBy)
+
+			if action != "all" {
+				query = query.Where("action = ?", strings.ToUpper(action))
+			}
+			err := query.Order("timestamp asc").Find(&metrics).Error
+			if err != nil {
+				return c.JSON(400, map[string]string{
+					"error": err.Error(),
+				})
+			}
+
+			m.Data = metrics
+		}
+	}
 
 	return c.JSON(200, m)
 }

--- a/mediorum/server/server.go
+++ b/mediorum/server/server.go
@@ -357,6 +357,7 @@ func New(config MediorumConfig) (*MediorumServer, error) {
 
 	// WIP internal: metrics
 	internalApi.GET("/metrics", ss.getMetrics)
+	internalApi.GET("/metrics/blobs-served/:timeRange", ss.getBlobsServedMetrics)
 	internalApi.GET("/logs/partition-ops", ss.getPartitionOpsLog)
 	internalApi.GET("/logs/reaper", ss.getReaperLog)
 	internalApi.GET("/logs/repair", ss.serveRepairLog)


### PR DESCRIPTION
### Description
Query via `/internal/metrics/blobs-served/:timeRange?bucket_size=...&action=...`
`timeRange`: `week`, `month`, `all_time`
action (defaults to `all` if not provided): `track_steam`, `serve_image`, or `all`
e.g. `/internal/metrics/blobs-served/week?bucket_size=day` to get the count of successful track streams and image serves from this node, bucketed by day, in the past week.

### How Has This Been Tested?
TODO deploy to a stage node and test