### PR TITLE
[C-3399] Fix trending links and twitter embed

### DIFF
--- a/packages/web/vite.config.ts
+++ b/packages/web/vite.config.ts
@@ -20,7 +20,8 @@ export default defineConfig(({ mode }) => {
       outDir: 'build',
       sourcemap: true,
       commonjsOptions: {
-        include: [/libs\/dist\/web-libs/, /node_modules/]
+        include: [/libs\/dist\/web-libs/, /node_modules/],
+        transformMixedEsModules: true
       }
     },
     define: {


### PR DESCRIPTION
### Description

Fixes issue where all our trending tweet-embed views were broken. This is due to an issue with vite build incompatibility with node-style `require`, which is used in this node_module

Some documentation on the issue:
https://github.com/saurabhnemade/react-twitter-embed/issues/128
https://github.com/vitejs/vite/issues/3409

The comment this fix is based on: 
https://github.com/vitejs/vite/issues/3409#issuecomment-1138202247

### How Has This Been Tested?

Built locally and confirmed on dylan.audius.co
https://dylan.audius.co/
