### PR TITLE
[PAY-2215] Play full purchased tracks from mobile library

### DIFF
--- a/packages/web/src/common/store/queue/sagas.ts
+++ b/packages/web/src/common/store/queue/sagas.ts
@@ -89,11 +89,12 @@ export function* getToQueue(prefix: string, entry: { kind: Kind; uid: UID }) {
     const track = yield* select(getTrack, { uid: entry.uid })
     const currentUserId = yield* select(getUserId)
     if (!track) return {}
+    const doesUserHaveAccess = yield* call(doesUserHaveTrackAccess, track)
     return {
       id: track.track_id,
       uid: entry.uid,
       source: prefix,
-      isPreview: isPreview(track, currentUserId)
+      isPreview: isPreview(track, currentUserId) && !doesUserHaveAccess
     }
   }
 }


### PR DESCRIPTION
### Description
This fixes a bug on mobile where if you allowed the lineup to play through from saved tracks screen, only previews would play even on purchased tracks.

Not sure why this wasn't an issue on web.

### How Has This Been Tested?

Confirmed playing un-purchased tracks still plays the previews (via either allowing autoplay to go through, or from pressing previous/next) on both web and mobile.
Confirmed user is able to play full tracks of own uploaded premium tracks.

Video of fix here - previously when the next track played, it would be a preview.

https://github.com/AudiusProject/audius-protocol/assets/3893871/6f56ec12-b075-4899-a10b-63ec6455d693
