### PR TITLE
[PAY-2227] Set min-width for NavPopupMenu

### DIFF
--- a/packages/mobile/src/components/audio-balance-pill/AUDIOBalancePill.tsx
+++ b/packages/mobile/src/components/audio-balance-pill/AUDIOBalancePill.tsx
@@ -47,8 +47,8 @@ export const AudioBalancePill = () => {
       <IconAudioBadge
         tier={tier}
         showNoTier
-        height={spacing(5)}
-        width={spacing(5)}
+        height={spacing(5.5)}
+        width={spacing(5.5)}
       />
       {isAudioBalanceLoading ? (
         <Skeleton

--- a/packages/web/src/components/audio-balance-pill/AUDIOBalancePill.module.css
+++ b/packages/web/src/components/audio-balance-pill/AUDIOBalancePill.module.css
@@ -7,6 +7,7 @@
   padding: 2px;
   padding-right: var(--unit-2);
   border-radius: var(--unit-12);
+  min-width: var(--unit-10);
 }
 
 .amount {

--- a/packages/web/src/components/audio-balance-pill/AUDIOBalancePill.module.css
+++ b/packages/web/src/components/audio-balance-pill/AUDIOBalancePill.module.css
@@ -7,7 +7,6 @@
   padding: 2px;
   padding-right: var(--unit-2);
   border-radius: var(--unit-12);
-  min-width: var(--unit-10);
 }
 
 .amount {
@@ -17,6 +16,6 @@
 }
 
 .skeleton {
-  width: var(unit--6);
+  width: var(--unit-8);
   height: 18px;
 }

--- a/packages/web/src/components/audio-balance-pill/AUDIOBalancePill.tsx
+++ b/packages/web/src/components/audio-balance-pill/AUDIOBalancePill.tsx
@@ -39,11 +39,11 @@ export const AudioBalancePill = ({ className }: AudioPillProps) => {
     <div className={cn(styles.container, className)}>
       {positiveTotalBalance && audioBadge ? (
         cloneElement(audioBadge, {
-          height: 16,
-          width: 16
+          height: 20,
+          width: 20
         })
       ) : (
-        <img alt='no tier' src={IconNoTierBadge} width='16' height='16' />
+        <img alt='no tier' src={IconNoTierBadge} width='20' height='20' />
       )}
       {isNullOrUndefined(totalBalance) ? (
         <Skeleton className={styles.skeleton} />

--- a/packages/web/src/components/nav/desktop/NavPopupMenu.module.css
+++ b/packages/web/src/components/nav/desktop/NavPopupMenu.module.css
@@ -6,6 +6,10 @@
   align-items: center;
 }
 
+.popupMenu {
+  min-width: 256px;
+}
+
 .icon {
   border: 1px solid var(--neutral-light-8);
   border-radius: 50%;

--- a/packages/web/src/components/nav/desktop/NavPopupMenu.tsx
+++ b/packages/web/src/components/nav/desktop/NavPopupMenu.tsx
@@ -150,6 +150,7 @@ const NavPopupMenu = () => {
       <PopupMenu
         items={menuItems}
         position={PopupPosition.BOTTOM_RIGHT}
+        className={styles.popupMenu}
         renderTrigger={(anchorRef, triggerPopup) => {
           return (
             <div className={styles.container}>

--- a/packages/web/src/components/usdc-balance-pill/USDCBalancePill.module.css
+++ b/packages/web/src/components/usdc-balance-pill/USDCBalancePill.module.css
@@ -7,6 +7,7 @@
   padding: 2px;
   padding-right: var(--unit-2);
   border-radius: var(--unit-12);
+  min-width: var(--unit-12);
 }
 
 .amount {

--- a/packages/web/src/components/usdc-balance-pill/USDCBalancePill.module.css
+++ b/packages/web/src/components/usdc-balance-pill/USDCBalancePill.module.css
@@ -7,7 +7,6 @@
   padding: 2px;
   padding-right: var(--unit-2);
   border-radius: var(--unit-12);
-  min-width: var(--unit-12);
 }
 
 .amount {
@@ -17,7 +16,7 @@
 }
 
 .skeleton {
-  width: var(unit--6);
+  width: var(--unit-8);
   height: 18px;
 }
 


### PR DESCRIPTION
### Description
Set a min-width for the NavPopupMenu to prevent it from growing once the balances load in.

Tried to use reasonable values for the various min-width's. It results in a wider-than-necessary popup when the user has low balances, but I think that's ok. Also if the user has super high balances the popup could still grow, but I think this is good enough for the majority of users.

Also noticed the $AUDIO balance pill was slightly too small, updated size to match USDC pill.

### How Has This Been Tested?

Local web stage
<img width="320" alt="Screenshot 2023-12-01 at 4 24 59 PM" src="https://github.com/AudiusProject/audius-protocol/assets/3893871/dd6e0250-4ac7-4550-be43-9f6fb2d48244">

https://github.com/AudiusProject/audius-protocol/assets/3893871/69121d4b-6c3b-465e-9e11-4f6e231661b3
<img width="309" alt="Screenshot 2023-12-01 at 4 31 21 PM" src="https://github.com/AudiusProject/audius-protocol/assets/3893871/7ae8c14f-bce3-4c16-a9d2-34eb57153f2c">

with larger $AUDIO pill:

<img width="271" alt="Screenshot 2023-12-01 at 4 51 47 PM" src="https://github.com/AudiusProject/audius-protocol/assets/3893871/e8729028-8e30-470c-a95c-10e5c3b985b3">


