### PR TITLE
Make mobile buy buttons stick to bottom

### DIFF
--- a/packages/mobile/src/components/premium-track-purchase-drawer/PremiumTrackPurchaseDrawer.tsx
+++ b/packages/mobile/src/components/premium-track-purchase-drawer/PremiumTrackPurchaseDrawer.tsx
@@ -86,10 +86,16 @@ const messages = {
       }
     </>
   ),
-  termsOfUse: 'Terms of Use.'
+  termsOfUse: 'Terms of Use.',
+  goBack: 'Go Back'
 }
 
 const useStyles = makeStyles(({ spacing, typography, palette }) => ({
+  root: {
+    height: '100%',
+    justifyContent: 'space-between',
+    justifySelf: 'flex-end'
+  },
   formContainer: {
     flex: 1
   },
@@ -262,7 +268,6 @@ const RenderForm = ({
 
   const { page, stage, error, isUnlocking, purchaseSummaryValues } =
     usePurchaseContentFormState({ price })
-  const { amountDue } = purchaseSummaryValues
 
   const isPurchaseSuccessful = stage === PurchaseContentStage.FINISH
 
@@ -282,65 +287,94 @@ const RenderForm = ({
     dispatch(setPurchasePage({ page: PurchaseContentPage.PURCHASE }))
   }, [dispatch])
 
-  return page === PurchaseContentPage.PURCHASE ? (
-    <>
-      <ScrollView contentContainerStyle={styles.formContentContainer}>
-        {stage !== PurchaseContentStage.FINISH ? (
-          <AudioMatchSection amount={Math.round(price / 100)} />
-        ) : null}
-        <View style={styles.formContentSection}>
-          <TrackDetailsTile trackId={track.track_id} />
-          {isPurchaseSuccessful ? null : (
-            <PayExtraFormSection
-              amountPresets={presetValues}
-              disabled={isUnlocking}
-            />
-          )}
-          <View style={styles.bottomSection}>
-            <PurchaseSummaryTable
-              {...purchaseSummaryValues}
-              totalPriceInCents={totalPriceInCents}
-            />
-            {isIOSDisabled || isUnlocking || isPurchaseSuccessful ? null : (
-              <PaymentMethod
-                selectedType={purchaseMethod}
-                setSelectedType={setPurchaseMethod}
-                balance={balance}
-                isExistingBalanceDisabled={isExistingBalanceDisabled}
-                showExistingBalance
-              />
-            )}
-          </View>
-          {isIOSDisabled ? (
-            <PurchaseUnavailable />
-          ) : isPurchaseSuccessful ? (
-            <PurchaseSuccess onPressViewTrack={onClose} track={track} />
-          ) : isUnlocking ? null : (
-            <View>
-              <View style={styles.payToUnlockTitleContainer}>
-                <Text weight='heavy' textTransform='uppercase' fontSize='small'>
-                  {messages.payToUnlock}
-                </Text>
-                <LockedStatusBadge locked />
-              </View>
-              <Text style={styles.disclaimer}>
-                {messages.disclaimer(
-                  <Text colorValue={primary} onPress={handleTermsPress}>
-                    {messages.termsOfUse}
-                  </Text>
+  const handleGoBackPress = useCallback(() => {
+    dispatch(setPurchasePage({ page: PurchaseContentPage.PURCHASE }))
+  }, [dispatch])
+
+  return (
+    <View style={styles.root}>
+      {page === PurchaseContentPage.PURCHASE ? (
+        <>
+          <ScrollView contentContainerStyle={styles.formContentContainer}>
+            {stage !== PurchaseContentStage.FINISH ? (
+              <AudioMatchSection amount={Math.round(price / 100)} />
+            ) : null}
+            <View style={styles.formContentSection}>
+              <TrackDetailsTile trackId={track.track_id} />
+              {isPurchaseSuccessful ? null : (
+                <PayExtraFormSection
+                  amountPresets={presetValues}
+                  disabled={isUnlocking}
+                />
+              )}
+              <View style={styles.bottomSection}>
+                <PurchaseSummaryTable
+                  {...purchaseSummaryValues}
+                  totalPriceInCents={totalPriceInCents}
+                />
+                {isIOSDisabled || isUnlocking || isPurchaseSuccessful ? null : (
+                  <PaymentMethod
+                    selectedType={purchaseMethod}
+                    setSelectedType={setPurchaseMethod}
+                    balance={balance}
+                    isExistingBalanceDisabled={isExistingBalanceDisabled}
+                    showExistingBalance
+                  />
                 )}
-              </Text>
+              </View>
+              {isIOSDisabled ? (
+                <PurchaseUnavailable />
+              ) : isPurchaseSuccessful ? (
+                <PurchaseSuccess onPressViewTrack={onClose} track={track} />
+              ) : isUnlocking ? null : (
+                <View>
+                  <View style={styles.payToUnlockTitleContainer}>
+                    <Text
+                      weight='heavy'
+                      textTransform='uppercase'
+                      fontSize='small'
+                    >
+                      {messages.payToUnlock}
+                    </Text>
+                    <LockedStatusBadge locked />
+                  </View>
+                  <Text style={styles.disclaimer}>
+                    {messages.disclaimer(
+                      <Text colorValue={primary} onPress={handleTermsPress}>
+                        {messages.termsOfUse}
+                      </Text>
+                    )}
+                  </Text>
+                </View>
+              )}
             </View>
-          )}
+          </ScrollView>
+        </>
+      ) : (
+        <View style={styles.paddingTop}>
+          <USDCManualTransfer
+            onClose={handleUSDCManualTransferClose}
+            amountInCents={totalPriceInCents}
+            onSuccess={submitForm}
+          />
         </View>
-      </ScrollView>
+      )}
       {isPurchaseSuccessful || isIOSDisabled ? null : (
         <View style={styles.formActions}>
           {error ? <RenderError error={error} /> : null}
+          {page === PurchaseContentPage.TRANSFER ? (
+            <Button
+              title={messages.goBack}
+              onPress={handleGoBackPress}
+              variant='common'
+              size='large'
+              fullWidth
+            />
+          ) : null}
           <Button
             onPress={submitForm}
             disabled={isUnlocking}
-            title={getButtonText(isUnlocking, amountDue)}
+            title={getButtonText(isUnlocking, totalPriceInCents)}
             variant={'primary'}
             size='large'
             color={specialLightGreen}
@@ -350,14 +384,6 @@ const RenderForm = ({
           />
         </View>
       )}
-    </>
-  ) : (
-    <View style={styles.paddingTop}>
-      <USDCManualTransfer
-        onClose={handleUSDCManualTransferClose}
-        amountInCents={totalPriceInCents}
-        onSuccess={submitForm}
-      />
     </View>
   )
 }

--- a/packages/mobile/src/components/premium-track-purchase-drawer/PremiumTrackPurchaseDrawer.tsx
+++ b/packages/mobile/src/components/premium-track-purchase-drawer/PremiumTrackPurchaseDrawer.tsx
@@ -93,8 +93,7 @@ const messages = {
 const useStyles = makeStyles(({ spacing, typography, palette }) => ({
   root: {
     height: '100%',
-    justifyContent: 'space-between',
-    justifySelf: 'flex-end'
+    justifyContent: 'space-between'
   },
   formContainer: {
     flex: 1

--- a/packages/mobile/src/components/usdc-manual-transfer/USDCManualTransfer.tsx
+++ b/packages/mobile/src/components/usdc-manual-transfer/USDCManualTransfer.tsx
@@ -103,21 +103,14 @@ export const USDCManualTransfer = ({
   onSuccess?: () => void
 }) => {
   const styles = useStyles()
-  const { neutral, specialLightGreen } = useThemeColors()
+  const { neutral } = useThemeColors()
   const { toast } = useToast()
 
   const { onPress: onPressLearnMore } = useLink(USDCLearnMore)
-
-  const stage = useSelector(getPurchaseContentFlowStage)
-  const error = useSelector(getPurchaseContentError)
-  const isUnlocking = !error && isContentPurchaseInProgress(stage)
   const { data: balanceBN } = useUSDCBalance({
     isPolling: true,
     pollingInterval: 1000
   })
-  const balance = USDC(balanceBN ?? new BN(0)).value
-  const amount = USDC((amountInCents ?? 0) / 100).value
-  const isBuyButtonDisabled = isUnlocking || balance < amount
 
   useCreateUserbankIfNeeded({
     recordAnalytics: track,

--- a/packages/mobile/src/components/usdc-manual-transfer/USDCManualTransfer.tsx
+++ b/packages/mobile/src/components/usdc-manual-transfer/USDCManualTransfer.tsx
@@ -1,18 +1,11 @@
 import { useCallback, useMemo } from 'react'
 
-import {
-  Name,
-  isContentPurchaseInProgress,
-  purchaseContentSelectors,
-  useCreateUserbankIfNeeded,
-  useUSDCBalance
-} from '@audius/common'
+import { Name, useCreateUserbankIfNeeded, useUSDCBalance } from '@audius/common'
 import { USDC } from '@audius/fixed-decimal'
 import Clipboard from '@react-native-clipboard/clipboard'
 import BN from 'bn.js'
 import { View } from 'react-native'
 import QRCode from 'react-qr-code'
-import { useSelector } from 'react-redux'
 import { useAsync } from 'react-use'
 
 import IconError from 'app/assets/images/iconError.svg'
@@ -28,9 +21,6 @@ import type { AllEvents } from 'app/types/analytics'
 import { useThemeColors } from 'app/utils/theme'
 
 import { AddressTile } from '../core/AddressTile'
-
-const { getPurchaseContentFlowStage, getPurchaseContentError } =
-  purchaseContentSelectors
 
 const USDCLearnMore =
   'https://support.audius.co/help/Understanding-USDC-on-Audius'

--- a/packages/mobile/src/components/usdc-manual-transfer/USDCManualTransfer.tsx
+++ b/packages/mobile/src/components/usdc-manual-transfer/USDCManualTransfer.tsx
@@ -43,8 +43,7 @@ const messages = {
   goBack: 'Go Back',
   learnMore: 'Learn More',
   copied: 'Copied to Clipboard!',
-  usdcBalance: 'USDC Balance',
-  buy: (amount: string) => `Buy $${amount}`
+  usdcBalance: 'USDC Balance'
 }
 
 const useStyles = makeStyles(({ spacing, palette, typography }) => ({
@@ -206,26 +205,7 @@ export const USDCManualTransfer = ({
               fullWidth
             />
           </>
-        ) : (
-          <>
-            <Button
-              title={messages.goBack}
-              onPress={onClose}
-              variant='common'
-              size='large'
-              fullWidth
-            />
-            <Button
-              title={messages.buy(USDC(amount).ceil(2).toFixed(2))}
-              onPress={onSuccess}
-              variant='primary'
-              color={specialLightGreen}
-              size='large'
-              disabled={isBuyButtonDisabled}
-              fullWidth
-            />
-          </>
-        )}
+        ) : null}
       </View>
     </View>
   )


### PR DESCRIPTION
### Description
Per Design's request, make the buy buttons sticky at the bottom when switching content inside the purchase drawer.

### How Has This Been Tested?

Local ios stage

https://github.com/AudiusProject/audius-protocol/assets/3893871/878b539d-80c7-447b-be51-acc6e4a43782

