### PR TITLE
[PROTO-1458] Expose postgres upgrade logs in mediorum

### DIFF
--- a/mediorum/server/serve_metrics.go
+++ b/mediorum/server/serve_metrics.go
@@ -195,3 +195,7 @@ func (ss *MediorumServer) getPartitionOpsLog(c echo.Context) error {
 func (ss *MediorumServer) getReaperLog(c echo.Context) error {
 	return ss.getLogfile(c, "reaper.txt")
 }
+
+func (ss *MediorumServer) getPgUpgradeLog(c echo.Context) error {
+	return ss.getLogfile(c, "pg_upgrade.txt")
+}

--- a/mediorum/server/server.go
+++ b/mediorum/server/server.go
@@ -362,6 +362,7 @@ func New(config MediorumConfig) (*MediorumServer, error) {
 	internalApi.GET("/logs/reaper", ss.getReaperLog)
 	internalApi.GET("/logs/repair", ss.serveRepairLog)
 	internalApi.GET("/logs/storageAndDb", ss.serveStorageAndDbLogs)
+	internalApi.GET("/logs/pg-upgrade", ss.getPgUpgradeLog)
 
 	// internal: testing
 	internalApi.GET("/proxy_health_check", ss.proxyHealthCheck)


### PR DESCRIPTION
### Description
Adds `/internal/logs/pg-upgrade` to display the results of a postgres upgrade on a Content Node.