### PR TITLE
Periodically check for and correct trusted notifier discrepancies in DN

### DIFF
--- a/packages/discovery-provider/src/queries/get_trusted_notifier_discrepancies.py
+++ b/packages/discovery-provider/src/queries/get_trusted_notifier_discrepancies.py
@@ -3,6 +3,7 @@ from datetime import datetime, timedelta, timezone
 
 from redis import Redis
 from sqlalchemy import desc
+from sqlalchemy.orm.session import Session
 from sqlalchemy.sql import text
 
 from src.models.delisting.delist_status_cursor import DelistEntity, DelistStatusCursor
@@ -24,7 +25,7 @@ from src.utils.structured_logger import StructuredLogger
 logger = StructuredLogger(__name__)
 
 
-def check_user_delist_status_cursor(redis: Redis):
+def check_user_delist_status_cursor(session: Session, redis: Redis):
     try:
         if redis is None:
             raise Exception("Invalid arguments for get_cursors")
@@ -50,27 +51,25 @@ def check_user_delist_status_cursor(redis: Redis):
                 else:
                     return user_delist_cursor_check
 
-        db = db_session.get_db_read_replica()
-        with db.scoped_session() as session:
-            latest_user_delist_cursor = (
-                session.query(DelistStatusCursor.created_at)
-                .filter(DelistStatusCursor.entity == DelistEntity.USERS)
-                .first()
-            )
-            latest_user_delist_status_timestamp = (
-                session.query(UserDelistStatus.created_at)
-                .order_by(desc(UserDelistStatus.created_at))
-                .first()
-            )
-            ok = "ok"
-            if latest_user_delist_cursor != latest_user_delist_status_timestamp:
-                ok = "not ok"
-            redis.set(
-                USER_DELIST_STATUS_CURSOR_CHECK_TIMESTAMP_KEY,
-                datetime.now(timezone.utc).timestamp(),
-            )
-            redis.set(USER_DELIST_STATUS_CURSOR_CHECK_KEY, ok)
-            return ok
+        latest_user_delist_cursor = (
+            session.query(DelistStatusCursor.created_at)
+            .filter(DelistStatusCursor.entity == DelistEntity.USERS)
+            .first()
+        )
+        latest_user_delist_status_timestamp = (
+            session.query(UserDelistStatus.created_at)
+            .order_by(desc(UserDelistStatus.created_at))
+            .first()
+        )
+        ok = "ok"
+        if latest_user_delist_cursor != latest_user_delist_status_timestamp:
+            ok = "not ok"
+        redis.set(
+            USER_DELIST_STATUS_CURSOR_CHECK_TIMESTAMP_KEY,
+            datetime.now(timezone.utc).timestamp(),
+        )
+        redis.set(USER_DELIST_STATUS_CURSOR_CHECK_KEY, ok)
+        return ok
     except Exception as e:
         logger.error(
             "get_trusted_notifier_discrepancies.py | issue with user delist cursor check %s",
@@ -79,7 +78,7 @@ def check_user_delist_status_cursor(redis: Redis):
         pass
 
 
-def check_track_delist_status_cursor(redis: Redis):
+def check_track_delist_status_cursor(session: Session, redis: Redis):
     try:
         if redis is None:
             raise Exception("Invalid arguments for get_cursors")
@@ -105,27 +104,25 @@ def check_track_delist_status_cursor(redis: Redis):
                 else:
                     return track_delist_cursor_check
 
-        db = db_session.get_db_read_replica()
-        with db.scoped_session() as session:
-            latest_track_delist_cursor = (
-                session.query(DelistStatusCursor.created_at)
-                .filter(DelistStatusCursor.entity == DelistEntity.TRACKS)
-                .first()
-            )
-            latest_track_delist_status_timestamp = (
-                session.query(TrackDelistStatus.created_at)
-                .order_by(desc(TrackDelistStatus.created_at))
-                .first()
-            )
-            ok = "ok"
-            if latest_track_delist_cursor != latest_track_delist_status_timestamp:
-                ok = "not ok"
-            redis.set(
-                TRACK_DELIST_STATUS_CURSOR_CHECK_TIMESTAMP_KEY,
-                datetime.now(timezone.utc).timestamp(),
-            )
-            redis.set(TRACK_DELIST_STATUS_CURSOR_CHECK_KEY, ok)
-            return ok
+        latest_track_delist_cursor = (
+            session.query(DelistStatusCursor.created_at)
+            .filter(DelistStatusCursor.entity == DelistEntity.TRACKS)
+            .first()
+        )
+        latest_track_delist_status_timestamp = (
+            session.query(TrackDelistStatus.created_at)
+            .order_by(desc(TrackDelistStatus.created_at))
+            .first()
+        )
+        ok = "ok"
+        if latest_track_delist_cursor != latest_track_delist_status_timestamp:
+            ok = "not ok"
+        redis.set(
+            TRACK_DELIST_STATUS_CURSOR_CHECK_TIMESTAMP_KEY,
+            datetime.now(timezone.utc).timestamp(),
+        )
+        redis.set(TRACK_DELIST_STATUS_CURSOR_CHECK_KEY, ok)
+        return ok
     except Exception as e:
         logger.error(
             "get_trusted_notifier_discrepancies.py | issue with track delist cursor check %s",
@@ -134,7 +131,7 @@ def check_track_delist_status_cursor(redis: Redis):
         pass
 
 
-def get_user_delist_discrepancies(redis: Redis):
+def get_user_delist_discrepancies(session: Session, redis: Redis):
     try:
         if redis is None:
             raise Exception("Invalid arguments for get_user_delist_discrepancies")
@@ -158,42 +155,40 @@ def get_user_delist_discrepancies(redis: Redis):
                 else:
                     return user_delist_discrepancies
 
-        db = db_session.get_db_read_replica()
-        with db.scoped_session() as session:
-            sql = text(
-                """
-                with user_delists as (
-                select distinct on (user_id)
-                    user_id,
-                    delisted,
-                    created_at
-                    from user_delist_statuses
-                    order by user_id, created_at desc
-                )
-                select
-                    users.user_id,
-                    users.is_available,
-                    user_delists.delisted,
-                    user_delists.created_at as delist_created_at
-                from users
-                join user_delists on users.user_id = user_delists.user_id
-                where users.is_current and users.is_available = user_delists.delisted;
-                """
+        sql = text(
+            """
+            with user_delists as (
+            select distinct on (user_id)
+                user_id,
+                delisted,
+                created_at
+                from user_delist_statuses
+                order by user_id, created_at desc
             )
-            result = session.execute(sql).fetchall()
-            user_delist_discrepancies = json.dumps(
-                [dict(row) for row in result], default=str
+            select
+                users.user_id,
+                users.is_available,
+                user_delists.delisted,
+                user_delists.created_at as delist_created_at
+            from users
+            join user_delists on users.user_id = user_delists.user_id
+            where users.is_current and users.is_available = user_delists.delisted;
+            """
+        )
+        result = session.execute(sql).fetchall()
+        user_delist_discrepancies = json.dumps(
+            [dict(row) for row in result], default=str
+        )
+        if user_delist_discrepancies != "[]":
+            logger.info(
+                f"get_trusted_notifier_discrepancies.py | found user delist discrepancies: {user_delist_discrepancies}"
             )
-            if user_delist_discrepancies != "[]":
-                logger.info(
-                    f"get_trusted_notifier_discrepancies.py | found user delist discrepancies: {user_delist_discrepancies}"
-                )
-            redis.set(
-                USER_DELIST_DISCREPANCIES_TIMESTAMP_KEY,
-                datetime.now(timezone.utc).timestamp(),
-            )
-            redis.set(USER_DELIST_DISCREPANCIES_KEY, user_delist_discrepancies)
-            return user_delist_discrepancies
+        redis.set(
+            USER_DELIST_DISCREPANCIES_TIMESTAMP_KEY,
+            datetime.now(timezone.utc).timestamp(),
+        )
+        redis.set(USER_DELIST_DISCREPANCIES_KEY, user_delist_discrepancies)
+        return user_delist_discrepancies
     except Exception as e:
         logger.error(
             "get_trusted_notifier_discrepancies.py | issue with user delist discrepancies %s",
@@ -202,7 +197,7 @@ def get_user_delist_discrepancies(redis: Redis):
         pass
 
 
-def get_track_delist_discrepancies(redis: Redis):
+def get_track_delist_discrepancies(session: Session, redis: Redis):
     try:
         if redis is None:
             raise Exception("Invalid arguments for get_track_delist_discrepancies")
@@ -226,42 +221,40 @@ def get_track_delist_discrepancies(redis: Redis):
                 else:
                     return track_delist_discrepancies
 
-        db = db_session.get_db_read_replica()
-        with db.scoped_session() as session:
-            sql = text(
-                """
-                with track_delists as (
-                select distinct on (track_id)
-                    track_id,
-                    delisted,
-                    created_at
-                    from track_delist_statuses
-                    order by track_id, created_at desc
-                )
-                select
-                    tracks.track_id,
-                    tracks.is_available,
-                    track_delists.delisted,
-                    track_delists.created_at as delist_created_at
-                from tracks
-                join track_delists on tracks.track_id = track_delists.track_id
-                where tracks.is_current and tracks.is_available = track_delists.delisted;
-                """
+        sql = text(
+            """
+            with track_delists as (
+            select distinct on (track_id)
+                track_id,
+                delisted,
+                created_at
+                from track_delist_statuses
+                order by track_id, created_at desc
             )
-            result = session.execute(sql).fetchall()
-            track_delist_discrepancies = json.dumps(
-                [dict(row) for row in result], default=str
+            select
+                tracks.track_id,
+                tracks.is_available,
+                track_delists.delisted,
+                track_delists.created_at as delist_created_at
+            from tracks
+            join track_delists on tracks.track_id = track_delists.track_id
+            where tracks.is_current and tracks.is_available = track_delists.delisted;
+            """
+        )
+        result = session.execute(sql).fetchall()
+        track_delist_discrepancies = json.dumps(
+            [dict(row) for row in result], default=str
+        )
+        if track_delist_discrepancies != "[]":
+            logger.info(
+                f"get_trusted_notifier_discrepancies.py | found track delist discrepancies: {track_delist_discrepancies}"
             )
-            if track_delist_discrepancies != "[]":
-                logger.info(
-                    f"get_trusted_notifier_discrepancies.py | found track delist discrepancies: {track_delist_discrepancies}"
-                )
-            redis.set(
-                TRACK_DELIST_DISCREPANCIES_TIMESTAMP_KEY,
-                datetime.now(timezone.utc).timestamp(),
-            )
-            redis.set(TRACK_DELIST_DISCREPANCIES_KEY, track_delist_discrepancies)
-            return track_delist_discrepancies
+        redis.set(
+            TRACK_DELIST_DISCREPANCIES_TIMESTAMP_KEY,
+            datetime.now(timezone.utc).timestamp(),
+        )
+        redis.set(TRACK_DELIST_DISCREPANCIES_KEY, track_delist_discrepancies)
+        return track_delist_discrepancies
     except Exception as e:
         logger.error(
             "get_trusted_notifier_discrepancies.py | issue with track delist discrepancies %s",
@@ -277,23 +270,25 @@ def get_trusted_notifier_discrepancies():
     Returns a tuple of health results and a boolean indicating an error
     """
     redis = redis_connection.get_redis()
-    user_delist_status_cursor_ok = check_user_delist_status_cursor(redis)
-    track_delist_status_cursor_ok = check_track_delist_status_cursor(redis)
-    user_delist_discrepancies = get_user_delist_discrepancies(redis)
-    track_delist_discrepancies = get_track_delist_discrepancies(redis)
-    health_results = {
-        "user_delist_status_cursor_caught_up": user_delist_status_cursor_ok,
-        "track_delist_status_cursor_caught_up": track_delist_status_cursor_ok,
-        "user_delist_discrepancies": user_delist_discrepancies,
-        "track_delist_discrepancies": track_delist_discrepancies,
-    }
-    is_unhealthy = (
-        user_delist_status_cursor_ok != "ok"
-        or track_delist_status_cursor_ok != "ok"
-        or user_delist_discrepancies != "[]"
-        or track_delist_discrepancies != "[]"
-    )
-    return health_results, is_unhealthy
+    db = db_session.get_db_read_replica()
+    with db.scoped_session() as session:
+        user_delist_status_cursor_ok = check_user_delist_status_cursor(session, redis)
+        track_delist_status_cursor_ok = check_track_delist_status_cursor(session, redis)
+        user_delist_discrepancies = get_user_delist_discrepancies(session, redis)
+        track_delist_discrepancies = get_track_delist_discrepancies(session, redis)
+        health_results = {
+            "user_delist_status_cursor_caught_up": user_delist_status_cursor_ok,
+            "track_delist_status_cursor_caught_up": track_delist_status_cursor_ok,
+            "user_delist_discrepancies": user_delist_discrepancies,
+            "track_delist_discrepancies": track_delist_discrepancies,
+        }
+        is_unhealthy = (
+            user_delist_status_cursor_ok != "ok"
+            or track_delist_status_cursor_ok != "ok"
+            or user_delist_discrepancies != "[]"
+            or track_delist_discrepancies != "[]"
+        )
+        return health_results, is_unhealthy
 
 
 def get_delist_statuses_ok():

--- a/packages/discovery-provider/src/queries/get_trusted_notifier_discrepancies.py
+++ b/packages/discovery-provider/src/queries/get_trusted_notifier_discrepancies.py
@@ -43,9 +43,9 @@ def check_user_delist_status_cursor(redis: Redis):
                 if user_delist_cursor_check is not None:
                     user_delist_cursor_check = user_delist_cursor_check.decode()
                 if user_delist_cursor_check != "ok":
-                    # If not ok, re-run query every 5 min to quickly suppress errors
+                    # If not ok, re-run query every 1 min to quickly suppress errors
                     # once resolved
-                    if latest_check > datetime.now(timezone.utc) - timedelta(minutes=5):
+                    if latest_check > datetime.now(timezone.utc) - timedelta(minutes=1):
                         return user_delist_cursor_check
                 else:
                     return user_delist_cursor_check
@@ -98,9 +98,9 @@ def check_track_delist_status_cursor(redis: Redis):
                 if track_delist_cursor_check is not None:
                     track_delist_cursor_check = track_delist_cursor_check.decode()
                 if track_delist_cursor_check != "ok":
-                    # If not ok, re-run query every 5 min to quickly suppress errors
+                    # If not ok, re-run query every 1 min to quickly suppress errors
                     # once resolved
-                    if latest_check > datetime.now(timezone.utc) - timedelta(minutes=5):
+                    if latest_check > datetime.now(timezone.utc) - timedelta(minutes=1):
                         return track_delist_cursor_check
                 else:
                     return track_delist_cursor_check
@@ -151,9 +151,9 @@ def get_user_delist_discrepancies(redis: Redis):
                 if user_delist_discrepancies is not None:
                     user_delist_discrepancies = user_delist_discrepancies.decode()
                 if user_delist_discrepancies != "[]":
-                    # If discrepancies, re-run query every 5 min to quickly suppress errors
+                    # If discrepancies, re-run query every 1 min to quickly suppress errors
                     # once resolved
-                    if latest_check > datetime.now(timezone.utc) - timedelta(minutes=5):
+                    if latest_check > datetime.now(timezone.utc) - timedelta(minutes=1):
                         return user_delist_discrepancies
                 else:
                     return user_delist_discrepancies
@@ -219,9 +219,9 @@ def get_track_delist_discrepancies(redis: Redis):
                 if track_delist_discrepancies is not None:
                     track_delist_discrepancies = track_delist_discrepancies.decode()
                 if track_delist_discrepancies != "[]":
-                    # If discrepancies, re-run query every 5 min to quickly suppress errors
+                    # If discrepancies, re-run query every 1 min to quickly suppress errors
                     # once resolved
-                    if latest_check > datetime.now(timezone.utc) - timedelta(minutes=5):
+                    if latest_check > datetime.now(timezone.utc) - timedelta(minutes=1):
                         return track_delist_discrepancies
                 else:
                     return track_delist_discrepancies

--- a/packages/discovery-provider/src/tasks/update_delist_statuses.py
+++ b/packages/discovery-provider/src/tasks/update_delist_statuses.py
@@ -1,7 +1,9 @@
+import json
 from datetime import datetime, timezone
 from typing import Dict, List, Set
 from urllib.parse import quote
 
+from redis import Redis
 from sqlalchemy.orm.session import Session
 from sqlalchemy.sql import text
 
@@ -13,6 +15,7 @@ from src.utils.auth_helpers import signed_get
 from src.utils.config import shared_config
 from src.utils.prometheus_metric import save_duration_metric
 from src.utils.structured_logger import StructuredLogger, log_duration
+from src.queries.get_trusted_notifier_discrepancies import get_track_delist_discrepancies, get_user_delist_discrepancies
 
 logger = StructuredLogger(__name__)
 
@@ -196,12 +199,12 @@ def update_track_is_available_statuses(
     for track_to_update in tracks_to_update:
         delisted = track_delist_map[track_to_update.track_id]["delisted"]
         if delisted:
-            # Deactivate active tracks that have been delisted
+            # Delist available tracks that have been delisted
             if track_to_update.is_available:
                 track_to_update.is_available = False
                 track_to_update.is_delete = True
         else:
-            # Re-activate deactivated tracks that have been un-delisted
+            # Relist unavailable tracks that have been relisted
             if not track_to_update.is_available:
                 track_to_update.is_available = True
                 track_to_update.is_delete = False
@@ -386,6 +389,74 @@ def get_trusted_notifier_endpoint(trusted_notifier_manager: Dict):
     return endpoint
 
 
+def correct_delist_discrepancies(session: Session, redis: Redis):
+    # Correct any cases where the indexer has overridden a delist
+    # because of the race condition between the async delister and
+    # indexer tasks.
+    track_delist_discrepancies_str = get_track_delist_discrepancies(redis)
+    if track_delist_discrepancies_str != "[]":
+        logger.info(
+            f"update_delist_statuses.py | correct_delist_discrepancies | Identified track delist discrepancies to correct: {track_delist_discrepancies_str}"
+        )
+        track_delist_discrepancies = json.loads(track_delist_discrepancies_str)
+
+        for row in track_delist_discrepancies:
+            track_id = row['track_id']
+            delisted = row['delisted']
+            tracks_to_update = query_tracks_by_track_ids(session, track_id)
+            for track_to_update in tracks_to_update:
+                if delisted:
+                    # Delist available tracks that have been delisted
+                    logger.info(
+                        f"update_delist_statuses.py | correct_delist_discrepancies | Delisting track {track_id}"
+                    )
+                    if track_to_update.is_available:
+                        track_to_update.is_available = False
+                        track_to_update.is_delete = True
+                else:
+                    # Relist unavailable tracks that have been relisted
+                    logger.info(
+                        f"update_delist_statuses.py | correct_delist_discrepancies | Re-listing track {track_id}"
+                    )
+                    if not track_to_update.is_available:
+                        track_to_update.is_available = True
+                        track_to_update.is_delete = False
+        logger.info(
+            "update_delist_statuses.py | correct_delist_discrepancies | Track delist discrepancies corrected"
+        )
+
+    user_delist_discrepancies_str = get_user_delist_discrepancies(redis)
+    if user_delist_discrepancies_str != "[]":
+        logger.info(
+            f"update_delist_statuses.py | correct_delist_discrepancies | Identified user delist discrepancies to correct: {user_delist_discrepancies_str}"
+        )
+        user_delist_discrepancies = json.loads(user_delist_discrepancies_str)
+        for row in user_delist_discrepancies:
+            user_id = row['user_id']
+            delisted = row['delisted']
+            users_to_update = query_users_by_user_ids(session, user_id)
+            for user_to_update in users_to_update:
+                if delisted:
+                    logger.info(
+                        f"update_delist_statuses.py | correct_delist_discrepancies | Deactivating user {user_id}"
+                    )
+                    # Deactivate active users that have been delisted
+                    if user_to_update.is_available:
+                        user_to_update.is_available = False
+                        user_to_update.is_deactivated = True
+                else:
+                    # Re-activate deactivated users that have been relisted
+                    logger.info(
+                        f"update_delist_statuses.py | correct_delist_discrepancies | Re-activating user {user_id}"
+                    )
+                    if not user_to_update.is_available:
+                        user_to_update.is_available = True
+                        user_to_update.is_deactivated = False
+        logger.info(
+            "update_delist_statuses.py | correct_delist_discrepancies | User delist discrepancies corrected"
+        )
+
+
 # ####### CELERY TASKS ####### #
 
 
@@ -515,6 +586,11 @@ def update_delist_statuses(self, current_block_timestamp: int) -> None:
                 process_delist_statuses(
                     session, trusted_notifier_endpoint, current_block_timestamp
                 )
+                # Address edge case from the race condition between
+                # the async indexer and delister tasks by checking every
+                # delist and identifying and correcting discrepancies
+                # in the tracks/users tables.
+                correct_delist_discrepancies(session, redis)
 
         except Exception as e:
             logger.error(

--- a/packages/discovery-provider/src/tasks/update_delist_statuses.py
+++ b/packages/discovery-provider/src/tasks/update_delist_statuses.py
@@ -10,12 +10,15 @@ from sqlalchemy.sql import text
 from src.models.delisting.delist_status_cursor import DelistEntity, DelistStatusCursor
 from src.models.tracks.track import Track
 from src.models.users.user import User
+from src.queries.get_trusted_notifier_discrepancies import (
+    get_track_delist_discrepancies,
+    get_user_delist_discrepancies,
+)
 from src.tasks.celery_app import celery
 from src.utils.auth_helpers import signed_get
 from src.utils.config import shared_config
 from src.utils.prometheus_metric import save_duration_metric
 from src.utils.structured_logger import StructuredLogger, log_duration
-from src.queries.get_trusted_notifier_discrepancies import get_track_delist_discrepancies, get_user_delist_discrepancies
 
 logger = StructuredLogger(__name__)
 
@@ -401,8 +404,8 @@ def correct_delist_discrepancies(session: Session, redis: Redis):
         track_delist_discrepancies = json.loads(track_delist_discrepancies_str)
 
         for row in track_delist_discrepancies:
-            track_id = row['track_id']
-            delisted = row['delisted']
+            track_id = row["track_id"]
+            delisted = row["delisted"]
             tracks_to_update = query_tracks_by_track_ids(session, track_id)
             for track_to_update in tracks_to_update:
                 if delisted:
@@ -432,8 +435,8 @@ def correct_delist_discrepancies(session: Session, redis: Redis):
         )
         user_delist_discrepancies = json.loads(user_delist_discrepancies_str)
         for row in user_delist_discrepancies:
-            user_id = row['user_id']
-            delisted = row['delisted']
+            user_id = row["user_id"]
+            delisted = row["delisted"]
             users_to_update = query_users_by_user_ids(session, user_id)
             for user_to_update in users_to_update:
                 if delisted:


### PR DESCRIPTION
### Description
Since the delist and indexer tasks run async, there is an edge case possible where the indexer overwrites a delist after reading stale data from the users/tracks table, since the entity manager reads then rewrites the entire record (including is_available) when any field needs to be updated. This leads to a "delist discrepancy" - the tracks/users table says the entity available or unavailable in contrast with what the node's delists table says.

Some context:
We already have a query checking for delist discrepancies using the `user_delist_statuses` / `users` and `track_delist_statuses` / `tracks` tables. If there are no discrepancies, the successful result is cached for 12h; if there are discrepancies, the result is cached for 1m . We use this in the health check to mark a node as unhealthy if there are delist discrepancies.

This PR runs these (cached - so no additional performance impact) discrepancies queries after the delist task completes every 100s. Depending on the redis caching, this will eventually (within 12h) identify and correct overwritten delists.

### How Has This Been Tested?
Create delist discrepancies locally, verify they self-resolve