### PR TITLE
[C-3374] Fix play/pause on trending mobile

### DIFF
--- a/packages/web/src/components/lineup/LineupProvider.tsx
+++ b/packages/web/src/components/lineup/LineupProvider.tsx
@@ -9,7 +9,8 @@ import {
   Lineup,
   Status,
   LineupBaseActions,
-  tippingSelectors
+  tippingSelectors,
+  playerSelectors
 } from '@audius/common'
 import cn from 'classnames'
 import { push as pushRoute } from 'connected-react-router'
@@ -34,6 +35,7 @@ import styles from './Lineup.module.css'
 import { delineateByTime, delineateByFeatured } from './delineate'
 import { LineupVariant } from './types'
 const { getShowTip } = tippingSelectors
+const { getPlaying, getUid } = playerSelectors
 
 // The max number of tiles to load
 const MAX_TILES_COUNT = 1000
@@ -790,7 +792,9 @@ class LineupProvider extends PureComponent<CombinedProps, LineupProviderState> {
 function mapStateToProps(state: AppState) {
   return {
     isMobile: isMobile(),
-    showTip: getShowTip(state)
+    showTip: getShowTip(state),
+    playing: getPlaying(state),
+    playingUid: getUid(state)
   }
 }
 


### PR DESCRIPTION
### Description

For whatever reason, only trending mobile track tiles cannot pause a playing track. this is due to a weird "off-by-one" bug with the playingCid and playing boolean. When they are passed down from the provider, they don't trigger an update for some reason... Regardless the move should be to move these variables closer to where they are needed.