### PR TITLE
Remove track_segments data, default to []

### DIFF
--- a/packages/discovery-provider/ddl/migrations/0040_rm_track_segments.sql
+++ b/packages/discovery-provider/ddl/migrations/0040_rm_track_segments.sql
@@ -1,0 +1,13 @@
+SELECT pg_size_pretty( pg_total_relation_size('tracks') );
+
+\timing
+
+begin;
+lock table tracks in access exclusive mode;
+alter table tracks drop column track_segments;
+alter table tracks add column track_segments jsonb not null default '[]';
+commit;
+
+vacuum full tracks;
+
+SELECT pg_size_pretty( pg_total_relation_size('tracks') );


### PR DESCRIPTION
### Description

track_segments is no longer used.

This pr keeps the column but sets all values to `[]` to ensure no downstream breakage.

Benefits:
* reclaim disk space for both postgres + elasticsearch (cids are mostly uncompressable)
* reduce TOAST overhead when selecting from tracks table
* reduce payload size for sending track records to client (cids are mostly uncompressable)

### How Has This Been Tested?

Tested on isaac sandbox.  Tracks table went from 10 GB to 1.8 GB