### PR TITLE
Fix remixes for usdc purchase tracks

### DIFF
--- a/packages/web/src/pages/upload-page/fields/RemixSettingsField/RemixSettingsField.tsx
+++ b/packages/web/src/pages/upload-page/fields/RemixSettingsField/RemixSettingsField.tsx
@@ -1,11 +1,12 @@
-import { useCallback, useMemo } from 'react'
+import { useCallback, useEffect, useMemo } from 'react'
 
 import {
   Nullable,
   ID,
   useGetTrackById,
   FieldVisibility,
-  Remix
+  Remix,
+  isPremiumContentUSDCPurchaseGated
 } from '@audius/common'
 import { get, set } from 'lodash'
 import { toFormikValidationSchema } from 'zod-formik-adapter'
@@ -90,6 +91,18 @@ export const RemixSettingsField = () => {
     isPremium,
     premiumConditions
   ])
+
+  const isUSDCPurchaseGated = isPremiumContentUSDCPurchaseGated(premiumConditions)
+
+  // If the track is public or usdc purchase gated, default to showing remixes.
+  // Otherwise, default to hiding remixes.
+  useEffect(() => {
+    if (!isPremium || isUSDCPurchaseGated) {
+      setShowRemixes(true)
+    } else if (isPremium) {
+      setShowRemixes(false)
+    }
+  }, [isPremium, isUSDCPurchaseGated])
 
   const handleSubmit = useCallback(
     (values: RemixSettingsFormValues) => {

--- a/packages/web/src/pages/upload-page/fields/RemixSettingsField/RemixSettingsMenuFields.tsx
+++ b/packages/web/src/pages/upload-page/fields/RemixSettingsField/RemixSettingsMenuFields.tsx
@@ -64,19 +64,46 @@ export const RemixSettingsMenuFields = () => {
 
   const [, , { setValue: setParentTrackId }] = useField('parentTrackId')
 
+  const isUSDCPurchaseGated = isPremiumContentUSDCPurchaseGated(premiumConditions)
+
   useEffect(() => {
     setParentTrackId(trackId)
     setCanRemixParent(canRemixParent)
   }, [trackId, setParentTrackId, canRemixParent, setCanRemixParent])
 
+  const renderGatedContentCallout = () => {
+    if (isPremium && !isUSDCPurchaseGated) {
+      return (
+        <HelpCallout
+          content={`${messages.changeAvailabilityPrefix} ${isPremiumContentCollectibleGated(premiumConditions)
+            ? messages.collectibleGated
+            : messages.specialAccess
+            }${messages.changeAvailabilitySuffix}`}
+        />
+      )
+    }
+    return null
+  }
+
+  const renderUsdcPurchaseGatedContentCallout = () => {
+    if (isUSDCPurchaseGated) {
+      return (
+        <HelpCallout
+          content={`${messages.changeAvailabilityPrefix} ${messages.premium}${messages.changeAvailabilitySuffix}`}
+        />
+      )
+    }
+    return null
+  }
+
   const renderHideRemixesField = () => {
-    if (isPremium) {
+    if (isPremium && !isUSDCPurchaseGated) {
       return (
         <SwitchRowField
           name={SHOW_REMIXES}
           header={messages.hideRemix.header}
           description={messages.hideRemix.description}
-          inverted={false}
+          inverted
           checked
           disabled
         />
@@ -94,19 +121,10 @@ export const RemixSettingsMenuFields = () => {
 
   return (
     <div className={styles.fields}>
-      {isPremium ? (
-        <HelpCallout
-          content={`${messages.changeAvailabilityPrefix} ${
-            isPremiumContentUSDCPurchaseGated(premiumConditions)
-              ? messages.premium
-              : isPremiumContentCollectibleGated(premiumConditions)
-              ? messages.collectibleGated
-              : messages.specialAccess
-          }${messages.changeAvailabilitySuffix}`}
-        />
-      ) : null}
+      {renderGatedContentCallout()}
       {renderHideRemixesField()}
       <Divider />
+      {renderUsdcPurchaseGatedContentCallout()}
       <SwitchRowField
         name={IS_REMIX}
         header={messages.remixOf.header}


### PR DESCRIPTION
### Description

Allow showing remixes for usdc purchase tracks.
Default to showing remixes for public and usdc purchase tracks. Otherwise, if gated, default to hiding remixes.

### How Has This Been Tested?

On local v stage
