### PR TITLE
[PAY-2236] USDC Balance in mobile nav updates after purchase

### DIFF
--- a/packages/mobile/src/components/premium-track-purchase-drawer/PremiumTrackPurchaseDrawer.tsx
+++ b/packages/mobile/src/components/premium-track-purchase-drawer/PremiumTrackPurchaseDrawer.tsx
@@ -252,7 +252,7 @@ const RenderForm = ({
   const [{ value: purchaseMethod }, , { setValue: setPurchaseMethod }] =
     useField(PURCHASE_METHOD)
 
-  const { data: balance } = useUSDCBalance()
+  const { data: balance } = useUSDCBalance({ isPolling: true })
   const { extraAmount } = usePurchaseSummaryValues({
     price,
     currentBalance: balance

--- a/packages/mobile/src/components/usdc-manual-transfer/USDCManualTransfer.tsx
+++ b/packages/mobile/src/components/usdc-manual-transfer/USDCManualTransfer.tsx
@@ -97,10 +97,7 @@ export const USDCManualTransfer = ({
   const { toast } = useToast()
 
   const { onPress: onPressLearnMore } = useLink(USDCLearnMore)
-  const { data: balanceBN } = useUSDCBalance({
-    isPolling: true,
-    pollingInterval: 1000
-  })
+  const { data: balanceBN } = useUSDCBalance()
 
   useCreateUserbankIfNeeded({
     recordAnalytics: track,


### PR DESCRIPTION
### Description
Make the USDC balance poll inside the `PremiumContentPurchaseDrawer`. Remove the polling downstream inside `USDCManualTransfer` (both usages of this component have polling upstream).

This ensures that the USDC balance pill in the left nav bar updates after a purchase is complete.

### How Has This Been Tested?


https://github.com/AudiusProject/audius-protocol/assets/3893871/e1fc9e04-79bb-4ce7-b3cb-80359ef34ab5


