### PR TITLE
[C-3456] Improve mobile user-list loading

### DIFF
--- a/packages/mobile/src/components/user/FollowButton.tsx
+++ b/packages/mobile/src/components/user/FollowButton.tsx
@@ -1,15 +1,16 @@
 import { useCallback } from 'react'
 
-import type { FollowSource, User } from '@audius/common'
-import { usersSocialActions } from '@audius/common'
+import type { FollowSource, ID, User } from '@audius/common'
+import { cacheUsersSelectors, usersSocialActions } from '@audius/common'
 import type { GestureResponderEvent, StyleProp, ViewStyle } from 'react-native'
-import { useDispatch } from 'react-redux'
+import { useDispatch, useSelector } from 'react-redux'
 
 import IconFollow from 'app/assets/images/iconFollow.svg'
 import IconFollowing from 'app/assets/images/iconFollowing.svg'
 import type { ButtonProps } from 'app/components/core'
 import { Button } from 'app/components/core'
 const { followUser, unfollowUser } = usersSocialActions
+const { getUser } = cacheUsersSelectors
 
 const messages = {
   follow: 'follow',
@@ -43,6 +44,51 @@ export const FollowButton = (props: FollowButtonsProps) => {
       }
     },
     [onPress, dispatch, does_current_user_follow, user_id, followSource]
+  )
+
+  return (
+    <Button
+      style={style}
+      title={isFollowing ? messages.following : messages.follow}
+      haptics={!isFollowing}
+      variant={variant}
+      icon={noIcon ? undefined : Icon}
+      iconPosition='left'
+      size='small'
+      onPress={handlePress}
+      {...other}
+    />
+  )
+}
+
+type FollowButton2Props = Partial<ButtonProps> & {
+  userId: ID
+  noIcon?: boolean
+  style?: StyleProp<ViewStyle>
+  followSource: FollowSource
+}
+
+export const FollowButton2 = (props: FollowButton2Props) => {
+  const { userId, noIcon, style, onPress, followSource, ...other } = props
+  const isFollowing = useSelector(
+    (state) => getUser(state, { id: userId })?.does_current_user_follow
+  )
+  const dispatch = useDispatch()
+
+  const Icon = isFollowing ? IconFollowing : IconFollow
+
+  const variant = isFollowing ? 'primary' : 'primaryAlt'
+
+  const handlePress = useCallback(
+    (event: GestureResponderEvent) => {
+      onPress?.(event)
+      if (isFollowing) {
+        dispatch(unfollowUser(userId, followSource))
+      } else {
+        dispatch(followUser(userId, followSource))
+      }
+    },
+    [dispatch, followSource, isFollowing, onPress, userId]
   )
 
   return (

--- a/packages/mobile/src/harmony-native/components/index.ts
+++ b/packages/mobile/src/harmony-native/components/index.ts
@@ -1,1 +1,3 @@
 export * from './Link'
+export * from './layout/Box/Box'
+export * from './layout/Flex/Flex'

--- a/packages/mobile/src/harmony-native/components/layout/Flex/Flex.tsx
+++ b/packages/mobile/src/harmony-native/components/layout/Flex/Flex.tsx
@@ -12,7 +12,7 @@ export const Flex = styled(Box, {
 })<NativeFlexProps>((props) => {
   const {
     theme,
-    direction,
+    direction = 'row',
     wrap,
     alignItems,
     justifyContent,

--- a/packages/mobile/src/screens/user-list-screen/UserList.tsx
+++ b/packages/mobile/src/screens/user-list-screen/UserList.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react'
 
 import type { ID, User, UserListStoreState, CommonState } from '@audius/common'
 import {
@@ -7,6 +7,7 @@ import {
   userListSelectors
 } from '@audius/common'
 import { useFocusEffect, useIsFocused } from '@react-navigation/native'
+import { range } from 'lodash'
 import { View } from 'react-native'
 import type { Selector } from 'react-redux'
 import { useDispatch, useSelector } from 'react-redux'
@@ -16,9 +17,22 @@ import LoadingSpinner from 'app/components/loading-spinner'
 import { makeStyles } from 'app/styles'
 
 import { UserListItem } from './UserListItem'
+import { UserListItemSkeleton } from './UserListItemSkeleton'
 const { makeGetOptimisticUserIdsIfNeeded } = userListSelectors
 const { loadMore, reset, setLoading } = userListActions
 const { getUsers } = cacheUsersSelectors
+
+const keyExtractor = (item: User) => item.user_id.toString()
+
+const skeletonData = range(6).map((index) => ({
+  _loading: true,
+  user_id: `skeleton ${index}`
+}))
+
+// Currently there is a lot of complex data that can change in users.
+// This is a nearly static list, with only follow/unfollow actions
+// The follow/unfollow action is handled by the follow button
+const MemoizedUserListItem = memo(UserListItem, () => true)
 
 const useStyles = makeStyles(({ spacing }) => ({
   spinner: {
@@ -108,6 +122,20 @@ export const UserList = (props: UserListProps) => {
     }
   }, [loading, users, isRefreshing])
 
+  const getItemLayout = useCallback(
+    (_data: User[], index: number) => {
+      const itemHeight = ['SUPPORTING', 'TOP SUPPORTERS'].includes(tag)
+        ? 167
+        : 147
+      return {
+        length: itemHeight,
+        offset: itemHeight * index,
+        index
+      }
+    },
+    [tag]
+  )
+
   const handleEndReached = useCallback(() => {
     if (hasMore && isFocused) {
       dispatch(setLoading(tag, true))
@@ -115,10 +143,23 @@ export const UserList = (props: UserListProps) => {
     }
   }, [hasMore, isFocused, dispatch, tag])
 
-  const data =
-    isEmpty || isRefreshing || loading || !isFocused
-      ? cachedUsers.current
-      : users
+  const shouldUseCachedData = isEmpty || isRefreshing || loading || !isFocused
+
+  const data = useMemo(() => {
+    const userData = shouldUseCachedData ? cachedUsers.current : users
+    return [...userData, ...skeletonData]
+  }, [shouldUseCachedData, users])
+
+  const renderItem = useCallback(
+    ({ item }) =>
+      '_loading' in item ? (
+        <UserListItemSkeleton tag={tag} />
+      ) : (
+        <MemoizedUserListItem user={item} tag={tag} />
+      ),
+
+    [tag]
+  )
 
   const loadingSpinner = (
     <LoadingSpinner
@@ -126,20 +167,18 @@ export const UserList = (props: UserListProps) => {
     />
   )
 
-  if ((loading || isRefreshing) && data.length === 0) {
-    return loadingSpinner
-  }
-
   const footer = <View style={styles.footer} />
 
   return (
     <FlatList
       style={styles.list}
       data={data}
-      renderItem={({ item }) => <UserListItem user={item} tag={tag} />}
-      keyExtractor={(item) => item.user_id.toString()}
+      renderItem={renderItem}
+      keyExtractor={keyExtractor}
+      getItemLayout={getItemLayout}
       ItemSeparatorComponent={Divider}
       onEndReached={handleEndReached}
+      onEndReachedThreshold={3}
       ListFooterComponent={loading || isRefreshing ? loadingSpinner : footer}
     />
   )

--- a/packages/mobile/src/screens/user-list-screen/UserListItem.tsx
+++ b/packages/mobile/src/screens/user-list-screen/UserListItem.tsx
@@ -8,7 +8,7 @@ import { useSelector } from 'react-redux'
 import IconUser from 'app/assets/images/iconUser.svg'
 import { Text } from 'app/components/core'
 import {
-  FollowButton,
+  FollowButton2,
   FollowsYouChip,
   ProfilePicture
 } from 'app/components/user'
@@ -124,8 +124,8 @@ export const UserListItem = (props: UserListItemProps) => {
           </View>
         </View>
         {currentUserId !== user_id ? (
-          <FollowButton
-            profile={user}
+          <FollowButton2
+            userId={user.user_id}
             followSource={FollowSource.USER_LIST}
             fullWidth
             corners='pill'

--- a/packages/mobile/src/screens/user-list-screen/UserListItemSkeleton.tsx
+++ b/packages/mobile/src/screens/user-list-screen/UserListItemSkeleton.tsx
@@ -1,0 +1,39 @@
+import { css } from '@emotion/native'
+
+import { Box, Flex } from '@audius/harmony-native'
+import { StaticSkeleton } from 'app/components/skeleton'
+
+type Props = {
+  tag: string
+  height?: number
+}
+
+const profileStyle = css({ height: 74, width: 74, borderRadius: 74 })
+
+export const UserListItemSkeleton = (props: Props) => {
+  const { tag } = props
+  const isSupporterTile = ['SUPPORTING', 'TOP SUPPORTERS'].includes(tag)
+  const itemHeight = isSupporterTile ? 167 : 147
+
+  return (
+    <Flex direction='column' p='l' gap='s' h={itemHeight}>
+      <Flex gap='s'>
+        <StaticSkeleton style={profileStyle} />
+        <Flex direction='column' gap='m' flex={1}>
+          <Flex direction='column' gap='s'>
+            <Box as={StaticSkeleton} w={100} h={16} />
+            <Box as={StaticSkeleton} w={100} h={16} />
+          </Flex>
+          <Box as={StaticSkeleton} w={200} h={18} />
+          {isSupporterTile ? (
+            <Flex justifyContent='space-between'>
+              <Box as={StaticSkeleton} w={100} h={18} />
+              <Box as={StaticSkeleton} w={100} h={18} />
+            </Flex>
+          ) : null}
+        </Flex>
+      </Flex>
+      <Box as={StaticSkeleton} w='100%' h={32} borderRadius='xl' />
+    </Flex>
+  )
+}


### PR DESCRIPTION
### Description

Massively improves user-list loading
Adds user-list skeletons to improve user feel
Adds faster "fetchMore" logic so users spend less time at bottom of list waiting
memoizes the entire user-list-item, since its mostly static content
Adds getItemLayout optimization since all items should be same size
Adds an updated follow-button that just needs userId

No more complains on react-dev side about large virtualized list!