### PR TITLE
feat: Add mediaSession API listener to PlayBar

### DIFF
--- a/packages/web/src/components/play-bar/desktop/PlayBar.jsx
+++ b/packages/web/src/components/play-bar/desktop/PlayBar.jsx
@@ -95,7 +95,7 @@ class PlayBar extends Component {
       },
       /* throttle= */ 200
     )
-    // Listen for keyboard APIs if available
+    // Listen for keyboard play/pause/next/previous APIs (if present)
     if (navigator && 'mediaSession' in navigator) {
       navigator.mediaSession.setActionHandler('play', () => {
         this.togglePlay()

--- a/packages/web/src/components/play-bar/desktop/PlayBar.jsx
+++ b/packages/web/src/components/play-bar/desktop/PlayBar.jsx
@@ -95,6 +95,24 @@ class PlayBar extends Component {
       },
       /* throttle= */ 200
     )
+    // Listen for keyboard APIs if available
+    if (navigator && 'mediaSession' in navigator) {
+      navigator.mediaSession.setActionHandler('play', () => {
+        this.togglePlay()
+      })
+
+      navigator.mediaSession.setActionHandler('pause', () => {
+        this.togglePlay()
+      })
+
+      navigator.mediaSession.setActionHandler('previoustrack', () => {
+        this.onPrevious()
+      })
+
+      navigator.mediaSession.setActionHandler('nexttrack', () => {
+        this.onNext()
+      })
+    }
   }
 
   componentDidUpdate(prevProps) {

--- a/packages/web/src/components/remix-settings-modal/RemixSettingsModal.tsx
+++ b/packages/web/src/components/remix-settings-modal/RemixSettingsModal.tsx
@@ -127,7 +127,8 @@ const RemixSettingsModal = ({
 
   const [url, setUrl] = useState<string | null>(null)
 
-  const isUSDCPurchaseGated = isPremiumContentUSDCPurchaseGated(premiumConditions)
+  const isUSDCPurchaseGated =
+    isPremiumContentUSDCPurchaseGated(premiumConditions)
   const isHideRemixesDisabled = isPremium && !isUSDCPurchaseGated
 
   useEffect(() => {
@@ -192,12 +193,13 @@ const RemixSettingsModal = ({
         {isPremium ? (
           <HelpCallout
             className={styles.disableInfo}
-            content={`${messages.changeAvailabilityPrefix} ${isUSDCPurchaseGated
-              ? messages.premium
-              : isPremiumContentCollectibleGated(premiumConditions)
+            content={`${messages.changeAvailabilityPrefix} ${
+              isUSDCPurchaseGated
+                ? messages.premium
+                : isPremiumContentCollectibleGated(premiumConditions)
                 ? messages.collectibleGated
                 : messages.specialAccess
-              }${messages.changeAvailabilitySuffix}`}
+            }${messages.changeAvailabilitySuffix}`}
           />
         ) : null}
         <div className={styles.toggleRow}>
@@ -246,7 +248,9 @@ const RemixSettingsModal = ({
         <div className={styles.divider} />
 
         <div className={styles.toggleRow}>
-          <span className={cn({ [styles.remixDisabled]: isHideRemixesDisabled })}>
+          <span
+            className={cn({ [styles.remixDisabled]: isHideRemixesDisabled })}
+          >
             {messages.hideOtherRemixes}
           </span>
           <Switch


### PR DESCRIPTION
### Description

Adds listeners to the [MediaSession API](https://developer.mozilla.org/en-US/docs/Web/API/MediaSession) to handle the player function keys on devices (e.g. F7/8/9 on a Mac keyboard)


Demo:
https://www.loom.com/share/a46dd0d17a5343408375d83704d456e2

### How Has This Been Tested?

Pressing the function buttons locally
