### PR TITLE
[PROTO-1478] Add finalPOABlock support to discovery relay

### DIFF
--- a/packages/discovery-provider/plugins/pedalboard/apps/relay/src/config/config.ts
+++ b/packages/discovery-provider/plugins/pedalboard/apps/relay/src/config/config.ts
@@ -21,6 +21,7 @@ export type Config = {
   aao: AntiAbuseConfig;
   rateLimitAllowList: string[];
   rateLimitBlockList: string[];
+  finalPoaBlock: number;
 };
 
 // reads .env file based on environment
@@ -46,6 +47,7 @@ export const readConfig = (): Config => {
     audius_use_aao: bool({ default: false }),
     relay_server_host: str({ default: "0.0.0.0" }),
     relay_server_port: num({ default: 6001 }),
+    audius_final_poa_block: num({ default: 0 })
   });
   return {
     environment: env.audius_discprov_env,
@@ -59,5 +61,6 @@ export const readConfig = (): Config => {
     aao: newAntiAbuseConfig(env.audius_aao_endpoint, env.audius_use_aao),
     rateLimitAllowList: allowListPublicKeys(),
     rateLimitBlockList: blockListPublicKeys(),
+    finalPoaBlock: env.audius_final_poa_block
   };
 };

--- a/packages/discovery-provider/plugins/pedalboard/apps/relay/src/txRelay.ts
+++ b/packages/discovery-provider/plugins/pedalboard/apps/relay/src/txRelay.ts
@@ -1,4 +1,4 @@
-import { wallets, web3 } from ".";
+import { config, wallets, web3 } from ".";
 import { internalError } from "./error";
 import { logger } from "./logger";
 import { confirm } from "./web3";
@@ -42,6 +42,7 @@ export const relayTransaction = async (
   // query chain until tx is mined
   try {
     const receipt = await confirm(submit.hash);
+    receipt.blockNumber += config.finalPoaBlock
     res.send({ receipt });
   } catch (e) {
     internalError(next, e as string);


### PR DESCRIPTION
### Description

`finalPOABlock` was missing, which causes confirmers to try to confirm the response against the wrong number in the db.

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._

Will test on stage