### PR TITLE
[C-3480] Fix null description in Edit Playlist

### DIFF
--- a/packages/web/src/components/create-playlist/PlaylistForm.tsx
+++ b/packages/web/src/components/create-playlist/PlaylistForm.tsx
@@ -68,7 +68,8 @@ const PlaylistForm = ({
     <Formik<EditPlaylistValuess>
       initialValues={{
         ...metadata,
-        artwork: { url: coverArtUrl }
+        artwork: { url: coverArtUrl },
+        description: metadata.description ?? ''
       }}
       onSubmit={onSave}
       validationSchema={toFormikValidationSchema(playlistFormSchema)}


### PR DESCRIPTION
# NOTE: To be hotfixed onto today's release branch

### Description

Validation was breaking because the initial value for playlist description was `null` but the z.optional() expects string or undefined. Fixed by setting the initial value to `''` if it's missing

### How Has This Been Tested?

repro'd on local web, this change fixed the behavior