### PR TITLE
[C-3332] Fix playlist edit after create

### DIFF
--- a/packages/web/src/components/create-playlist/PlaylistForm.tsx
+++ b/packages/web/src/components/create-playlist/PlaylistForm.tsx
@@ -1,4 +1,9 @@
-import { Collection, CollectionMetadata, SquareSizes } from '@audius/common'
+import {
+  Collection,
+  CollectionMetadata,
+  Nullable,
+  SquareSizes
+} from '@audius/common'
 import { Flex } from '@audius/harmony'
 import { Form, Formik } from 'formik'
 import { toFormikValidationSchema } from 'zod-formik-adapter'
@@ -25,13 +30,13 @@ const messages = {
   createPlaylistButtonText: 'Create Playlist'
 }
 
-export type EditPlaylistValuess = Collection & {
-  artwork: {
+export type EditPlaylistValues = Omit<Collection, 'artwork'> & {
+  artwork: Nullable<{
     file?: Blob
     url?: string
     source?: 'unsplash' | 'original' | 'generated'
     error?: string
-  }
+  }>
 }
 
 type PlaylistFormProps = {
@@ -65,10 +70,10 @@ const PlaylistForm = ({
   )
 
   return (
-    <Formik<EditPlaylistValuess>
+    <Formik<EditPlaylistValues>
       initialValues={{
         ...metadata,
-        artwork: { url: coverArtUrl },
+        artwork: coverArtUrl ? { url: coverArtUrl } : null,
         description: metadata.description ?? ''
       }}
       onSubmit={onSave}

--- a/packages/web/src/pages/upload-page/validation.ts
+++ b/packages/web/src/pages/upload-page/validation.ts
@@ -1,3 +1,4 @@
+import { imageBlank } from '@audius/common'
 import {
   Genre,
   HashId,
@@ -125,10 +126,14 @@ const createCollectionSchema = (collectionType: 'playlist' | 'album') =>
         url: z.string()
       })
       .nullable()
-
-      .refine((artwork) => artwork !== null, {
-        message: messages.artworkRequiredError
-      }),
+      .refine(
+        (artwork) => {
+          return artwork !== null && artwork.url !== imageBlank
+        },
+        {
+          message: messages.artworkRequiredError
+        }
+      ),
     playlist_name: z.string({
       required_error: messages[collectionType].nameRequiredError
     }),


### PR DESCRIPTION
### Description

Editing a playlist immediately after creating was causing a crash because a formik validation error object was being set as a react child.

* Only set artwork object if we have a coverArtUrl
* Fail validation if artwork url is imageBlank, forcing user to set an image if the playlist image is currently the fallback image

### How Has This Been Tested?

Ran through various playlist edit / creation flows on web
