### PR TITLE
relay: fix error on no metadata

### DIFF
--- a/packages/discovery-provider/plugins/pedalboard/apps/relay/src/abi.ts
+++ b/packages/discovery-provider/plugins/pedalboard/apps/relay/src/abi.ts
@@ -184,7 +184,7 @@ export const decodeAbi = (data: string): ManageEntityParameters => {
     entityType,
     entityId,
     action,
-    metadata: JSON.parse(metadata),
+    metadata,
     nonce,
     subjectSig,
   };


### PR DESCRIPTION
### Description
Some relays don't have json metadata (follows in particular). This breaks the JSON.parse() even though a blank string is still valid json in the spec. https://www.json.org/json-en.html. Since we don't actually parse through the metadata right now there's no need for this parse anyway.

### How Has This Been Tested?
Ran with sandbox script and verified decode abi no longer crashes on follow events.
