### PR TITLE
Polish social media flow, other QA [C-3418]

### DIFF
--- a/packages/web/src/common/store/pages/signon/actions.ts
+++ b/packages/web/src/common/store/pages/signon/actions.ts
@@ -36,12 +36,16 @@ export const SIGN_IN_FAILED = 'SIGN_ON/SIGN_IN_FAILED'
 
 export const SIGN_UP = 'SIGN_ON/SIGN_UP'
 export const START_SIGN_UP = 'SIGN_ON/START_SIGN_UP'
+
+/** @deprecated */
 export const FINISH_SIGN_UP = 'SIGN_ON/FINISH_SIGN_UP'
+
 export const SIGN_UP_SUCCEEDED = 'SIGN_ON/SIGN_UP_SUCCEEDED'
 export const SIGN_UP_SUCCEEDED_WITH_ID = 'SIGN_ON/SIGN_UP_SUCCEEDED_WITH_ID'
 export const SIGN_UP_FAILED = 'SIGN_ON/SIGN_UP_FAILED'
 export const SIGN_UP_TIMEOUT = 'SIGN_ON/SIGN_UP_TIMEOUT'
 
+export const SET_FINISHED_PHASE_1 = 'SIGN_ON/SET_FINISHED_PHASE_1'
 export const SET_LINKED_SOCIAL_ON_FIRST_PAGE =
   'SIGN_ON/SET_LINKED_SOCIAL_ON_FIRST_PAGE'
 export const SET_TWITTER_PROFILE = 'SIGN_ON/SET_TWITTER_PROFILE'
@@ -50,6 +54,7 @@ export const SET_INSTAGRAM_PROFILE = 'SIGN_ON/SET_INSTAGRAM_PROFILE'
 export const SET_INSTAGRAM_PROFILE_ERROR = 'SIGN_ON/SET_INSTAGRAM_PROFILE_ERROR'
 export const SET_TIKTOK_PROFILE = 'SIGN_ON/SET_TIKTOK_PROFILE'
 export const SET_TIKTOK_PROFILE_ERROR = 'SIGN_ON/SET_TIKTOK_PROFILE_ERROR'
+export const UNSET_SOCIAL_PROFILE = 'SIGN_ON/UNSET_SOCIAL_PROFILE'
 
 export const SET_STATUS = 'SIGN_ON/SET_STATUS'
 export const CONFIGURE_META_MASK = 'SIGN_ON/CONFIGURE_META_MASK'
@@ -297,6 +302,19 @@ export function setLinkedSocialOnFirstPage(linkedSocialOnFirstPage: boolean) {
   return {
     type: SET_LINKED_SOCIAL_ON_FIRST_PAGE,
     linkedSocialOnFirstPage
+  }
+}
+
+export function unsetSocialProfile() {
+  return {
+    type: UNSET_SOCIAL_PROFILE
+  }
+}
+
+export function setFinishedPhase1(finished: boolean) {
+  return {
+    type: SET_FINISHED_PHASE_1,
+    finishedPhase1: finished
   }
 }
 

--- a/packages/web/src/common/store/pages/signon/reducer.js
+++ b/packages/web/src/common/store/pages/signon/reducer.js
@@ -20,6 +20,7 @@ import {
   OPEN_SIGN_ON,
   NEXT_PAGE,
   PREVIOUS_PAGE,
+  UNSET_SOCIAL_PROFILE,
   GO_TO_PAGE,
   SET_STATUS,
   SIGN_UP,
@@ -37,7 +38,8 @@ import {
   ADD_FOLLOW_ARTISTS,
   REMOVE_FOLLOW_ARTISTS,
   SET_REFERRER,
-  SET_LINKED_SOCIAL_ON_FIRST_PAGE
+  SET_LINKED_SOCIAL_ON_FIRST_PAGE,
+  SET_FINISHED_PHASE_1
 } from './actions'
 import { Pages, FollowArtistsCategory } from './types'
 
@@ -73,7 +75,10 @@ const initialState = {
   toastText: null,
   page: Pages.EMAIL,
   startedSignUpProcess: false,
+  /** @deprecated */
   finishedSignUpProcess: false,
+  /** Whether user finished the main part of the flow (before 'Select Genres'), upon which their account gets created */
+  finishedPhase1: false,
   followArtists: {
     selectedCategory: FollowArtistsCategory.FEATURED,
     categories: {},
@@ -196,6 +201,12 @@ const actionsMap = {
       }
     }
   },
+  [SET_FINISHED_PHASE_1](state, action) {
+    return {
+      ...state,
+      finishedPhase1: action.finishedPhase1
+    }
+  },
   [SET_LINKED_SOCIAL_ON_FIRST_PAGE](state, action) {
     return {
       ...state,
@@ -256,6 +267,23 @@ const actionsMap = {
       tikTokScreenName: action.profile.display_name,
       profileImage: action.profileImage || null,
       verified: action.profile.is_verified
+    }
+  },
+  [UNSET_SOCIAL_PROFILE](state) {
+    return {
+      ...state,
+      tikTokId: initialState.tikTokId,
+      tikTokProfile: initialState.tikTokProfile,
+      tikTokScreenName: initialState.tikTokScreenName,
+      instagramId: initialState.instagramId,
+      instagramScreenName: initialState.instagramScreenName,
+      twitterId: initialState.twitterId,
+      coverPhoto: initialState.coverPhoto,
+      twitterScreenName: initialState.twitterScreenName,
+      name: initialState.name,
+      handle: initialState.handle,
+      profileImage: initialState.profileImage,
+      verified: initialState.verified
     }
   },
   [VALIDATE_EMAIL](state, action) {

--- a/packages/web/src/common/store/pages/signon/types.ts
+++ b/packages/web/src/common/store/pages/signon/types.ts
@@ -67,6 +67,8 @@ export default interface SignOnPageState {
   isMobileSignOnVisible: boolean
   routeOnCompletion: boolean
   startedSignUpProcess: boolean
+  finishedPhase1: boolean
+  /** @deprecated */
   finishedSignUpProcess: boolean
   routeOnExit: boolean
   page: number

--- a/packages/web/src/pages/sign-up-page/components/HandleField.tsx
+++ b/packages/web/src/pages/sign-up-page/components/HandleField.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useContext } from 'react'
 
-import { socialMediaMessages } from '@audius/common'
+import { MAX_HANDLE_LENGTH, socialMediaMessages } from '@audius/common'
 import { TextLink } from '@audius/harmony'
 import { useField } from 'formik'
 
@@ -33,17 +33,25 @@ type HandleFieldProps = Partial<HarmonyTextFieldProps> & {
     handle: string
     platform: 'twitter' | 'instagram' | 'tiktok'
   }) => void
+  onStartSocialMediaLogin?: () => void
+  onErrorSocialMediaLogin?: () => void
 }
 
 export const HandleField = (props: HandleFieldProps) => {
-  const { onCompleteSocialMediaLogin, ...other } = props
-  const [{ value: handle }, { error }, { setError }] = useField('handle')
+  const {
+    onCompleteSocialMediaLogin,
+    onErrorSocialMediaLogin,
+    onStartSocialMediaLogin,
+    ...other
+  } = props
+  const [{ value: handle }, { error }] = useField('handle')
 
   const { toast } = useContext(ToastContext)
 
   const handleVerifyHandleError = useCallback(() => {
-    setError(socialMediaMessages.verificationError)
-  }, [setError])
+    toast(socialMediaMessages.verificationError)
+    onErrorSocialMediaLogin?.()
+  }, [onErrorSocialMediaLogin, toast])
 
   const handleLoginSuccess = useCallback(
     ({
@@ -71,9 +79,13 @@ export const HandleField = (props: HandleFieldProps) => {
     handle && error ? (
       <>
         {error}{' '}
-        {onCompleteSocialMediaLogin && AuthComponent ? (
+        {onCompleteSocialMediaLogin &&
+        onStartSocialMediaLogin &&
+        onErrorSocialMediaLogin &&
+        AuthComponent ? (
           <TextLink variant='visible' asChild>
             <AuthComponent
+              onStart={onStartSocialMediaLogin}
               onFailure={handleVerifyHandleError}
               onSuccess={handleLoginSuccess}
             >
@@ -90,6 +102,7 @@ export const HandleField = (props: HandleFieldProps) => {
       label={messages.handle}
       error={error && handle}
       helperText={helperText}
+      maxLength={MAX_HANDLE_LENGTH}
       startAdornmentText='@'
       placeholder={messages.handle}
       transformValue={(value) => value.replace(/\s/g, '')}

--- a/packages/web/src/pages/sign-up-page/components/SignupFlowInstagramAuth.tsx
+++ b/packages/web/src/pages/sign-up-page/components/SignupFlowInstagramAuth.tsx
@@ -16,10 +16,12 @@ type SignupFlowInstagramAuthProps = PropsWithChildren<{
     handle: string
     platform: 'instagram'
   }) => void
+  onStart: () => void
 }>
 
 export const SignupFlowInstagramAuth = ({
   className,
+  onStart,
   onFailure,
   onSuccess,
   children
@@ -58,6 +60,7 @@ export const SignupFlowInstagramAuth = ({
     <InstagramAuth
       className={className}
       onClick={() => {
+        onStart()
         dispatch(make(Name.CREATE_ACCOUNT_START_INSTAGRAM, {}))
       }}
       onFailure={handleError}

--- a/packages/web/src/pages/sign-up-page/components/SignupFlowTikTokAuth.tsx
+++ b/packages/web/src/pages/sign-up-page/components/SignupFlowTikTokAuth.tsx
@@ -9,6 +9,7 @@ import { TikTokAuth } from 'components/tiktok-auth/TikTokAuthButton'
 import { useSetProfileFromTikTok } from '../hooks/socialMediaLogin'
 
 type SignupFlowTikTokAuthProps = {
+  onStart: () => void
   onFailure: (e: unknown) => void
   onSuccess: (info: {
     requiresReview: boolean
@@ -19,6 +20,7 @@ type SignupFlowTikTokAuthProps = {
 }
 
 export const SignupFlowTikTokAuth = ({
+  onStart,
   onFailure,
   onSuccess,
   children
@@ -56,6 +58,7 @@ export const SignupFlowTikTokAuth = ({
   return (
     <TikTokAuth
       onClick={() => {
+        onStart()
         dispatch(make(Name.CREATE_ACCOUNT_START_INSTAGRAM, {}))
       }}
       onFailure={handleError}

--- a/packages/web/src/pages/sign-up-page/components/SignupFlowTwitterAuth.tsx
+++ b/packages/web/src/pages/sign-up-page/components/SignupFlowTwitterAuth.tsx
@@ -16,12 +16,14 @@ type SignupFlowTwitterAuthProps = PropsWithChildren<{
     handle: string
     platform: 'twitter'
   }) => void
+  onStart: () => void
 }>
 
 export const SignupFlowTwitterAuth = ({
   className,
   onFailure,
   onSuccess,
+  onStart,
   children
 }: SignupFlowTwitterAuthProps) => {
   const dispatch = useDispatch()
@@ -56,6 +58,7 @@ export const SignupFlowTwitterAuth = ({
       className={className}
       forceLogin
       onClick={() => {
+        onStart()
         dispatch(make(Name.CREATE_ACCOUNT_START_TWITTER, {}))
       }}
       onFailure={handleError}

--- a/packages/web/src/pages/sign-up-page/components/SocialMediaLoading.module.css
+++ b/packages/web/src/pages/sign-up-page/components/SocialMediaLoading.module.css
@@ -1,0 +1,8 @@
+.spinner {
+  width: var(--harmony-unit-10);
+  height: var(--harmony-unit-10);
+}
+
+.spinner g path {
+  stroke: var(--harmony-n-800);
+}

--- a/packages/web/src/pages/sign-up-page/components/SocialMediaLoading.tsx
+++ b/packages/web/src/pages/sign-up-page/components/SocialMediaLoading.tsx
@@ -1,0 +1,32 @@
+import { Box, Flex, Text } from '@audius/harmony'
+
+import LoadingSpinner from 'components/loading-spinner/LoadingSpinner'
+
+import styles from './SocialMediaLoading.module.css'
+
+const messages = {
+  hangTight: 'Hang tight!',
+  connectingSocialMedia: 'We’re connecting your social account'
+}
+
+export const SocialMediaLoading = () => {
+  return (
+    <Flex
+      direction='column'
+      alignItems='center'
+      h='100%'
+      justifyContent='center'
+      gap='2xl'
+      css={{ textAlign: 'center', marginBottom: '20%' }}
+    >
+      <Text variant='heading' size='l' color='accent'>
+        {messages.hangTight}
+        <br />
+        {messages.connectingSocialMedia}&hellip;
+      </Text>
+      <Box mb='2xl'>
+        <LoadingSpinner className={styles.spinner} />
+      </Box>
+    </Flex>
+  )
+}

--- a/packages/web/src/pages/sign-up-page/components/SocialMediaLoginOptions.tsx
+++ b/packages/web/src/pages/sign-up-page/components/SocialMediaLoginOptions.tsx
@@ -16,13 +16,19 @@ type SocialMediaLoginOptionsProps = {
     handle: string
     platform: 'twitter' | 'instagram' | 'tiktok'
   }) => void
+  onError: () => void
+  onStart: () => void
 }
 
 export const SocialMediaLoginOptions = ({
-  onCompleteSocialMediaLogin
+  onCompleteSocialMediaLogin,
+  onError,
+  onStart
 }: SocialMediaLoginOptionsProps) => {
   const { toast } = useContext(ToastContext)
+
   const handleFailure = () => {
+    onError()
     toast(socialMediaMessages.verificationError)
   }
 
@@ -56,6 +62,7 @@ export const SocialMediaLoginOptions = ({
       {isTwitterEnabled ? (
         <SignupFlowTwitterAuth
           css={{ flex: 1 }}
+          onStart={onStart}
           onFailure={handleFailure}
           onSuccess={handleSuccess}
         >
@@ -70,6 +77,7 @@ export const SocialMediaLoginOptions = ({
       {isInstagramEnabled ? (
         <SignupFlowInstagramAuth
           css={{ flex: 1 }}
+          onStart={onStart}
           onFailure={handleFailure}
           onSuccess={handleSuccess}
         >
@@ -85,6 +93,7 @@ export const SocialMediaLoginOptions = ({
       {isTikTokEnabled ? (
         <Box css={{ flex: 1 }}>
           <SignupFlowTikTokAuth
+            onStart={onStart}
             onFailure={handleFailure}
             onSuccess={handleSuccess}
           >

--- a/packages/web/src/pages/sign-up-page/components/layout.tsx
+++ b/packages/web/src/pages/sign-up-page/components/layout.tsx
@@ -218,7 +218,7 @@ export const PageFooter = (props: PageFooterProps) => {
 
 type ReadOnlyFieldProps = {
   label: string
-  value: string
+  value: string | ReactNode
 }
 
 export const ReadOnlyField = (props: ReadOnlyFieldProps) => {

--- a/packages/web/src/pages/sign-up-page/hooks/useSocialMediaLoader.ts
+++ b/packages/web/src/pages/sign-up-page/hooks/useSocialMediaLoader.ts
@@ -1,0 +1,38 @@
+import { useCallback, useEffect, useState } from 'react'
+
+import { useDispatch } from 'react-redux'
+import { AnyAction } from 'redux'
+
+export const useSocialMediaLoader = ({
+  linkedSocialOnThisPagePreviously,
+  resetAction
+}: {
+  linkedSocialOnThisPagePreviously: boolean
+  resetAction: () => AnyAction
+}) => {
+  const dispatch = useDispatch()
+  const [isWaitingForSocialLogin, setIsWaitingForSocialLogin] = useState(false)
+
+  useEffect(() => {
+    // If the user goes back to this page in the middle of the flow after they linked
+    // their social on this page previously, clear the sign on state.
+    if (linkedSocialOnThisPagePreviously) {
+      dispatch(resetAction())
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [dispatch])
+
+  const handleStartSocialMediaLogin = useCallback(() => {
+    setIsWaitingForSocialLogin(true)
+  }, [])
+
+  const handleErrorSocialMediaLogin = useCallback(() => {
+    setIsWaitingForSocialLogin(false)
+  }, [])
+
+  return {
+    isWaitingForSocialLogin,
+    handleStartSocialMediaLogin,
+    handleErrorSocialMediaLogin
+  }
+}

--- a/packages/web/src/pages/sign-up-page/pages/CreateEmailPage.tsx
+++ b/packages/web/src/pages/sign-up-page/pages/CreateEmailPage.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from 'react'
+import { useCallback } from 'react'
 
 import {
   emailSchema,
@@ -48,6 +48,7 @@ import {
 import { SignUpWithMetaMaskButton } from '../components/SignUpWithMetaMaskButton'
 import { SocialMediaLoading } from '../components/SocialMediaLoading'
 import { Heading, Page } from '../components/layout'
+import { useSocialMediaLoader } from '../hooks/useSocialMediaLoader'
 
 const EmailSchema = toFormikValidationSchema(emailSchema(audiusQueryContext))
 
@@ -60,29 +61,20 @@ export const CreateEmailPage = () => {
   const dispatch = useDispatch()
   const navigate = useNavigateToPage()
   const existingEmailValue = useSelector(getEmailField)
-  const [isWaitingForSocialLogin, setIsWaitingForSocialLogin] = useState(false)
   const alreadyLinkedSocial = useSelector(getLinkedSocialOnFirstPage)
 
   const initialValues = {
     email: existingEmailValue.value ?? ''
   }
 
-  useEffect(() => {
-    // If the user goes back to this page in the middle of the flow after they linked
-    // their social on this page previously, clear the sign on state.
-    if (alreadyLinkedSocial) {
-      dispatch(resetSignOn())
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [dispatch])
-
-  const handleStartSocialMediaLogin = useCallback(() => {
-    setIsWaitingForSocialLogin(true)
-  }, [])
-
-  const handleErrorSocialMediaLogin = useCallback(() => {
-    setIsWaitingForSocialLogin(false)
-  }, [])
+  const {
+    isWaitingForSocialLogin,
+    handleStartSocialMediaLogin,
+    handleErrorSocialMediaLogin
+  } = useSocialMediaLoader({
+    resetAction: resetSignOn,
+    linkedSocialOnThisPagePreviously: alreadyLinkedSocial
+  })
 
   const handleCompleteSocialMediaLogin = useCallback(
     (result: { requiresReview: boolean; handle: string }) => {

--- a/packages/web/src/pages/sign-up-page/pages/CreateLoginDetails.tsx
+++ b/packages/web/src/pages/sign-up-page/pages/CreateLoginDetails.tsx
@@ -1,11 +1,16 @@
 import { useCallback } from 'react'
 
-import { Flex } from '@audius/harmony'
+import { Flex, IconVerified, useTheme } from '@audius/harmony'
 import { Form, Formik } from 'formik'
-import { useDispatch } from 'react-redux'
+import { useDispatch, useSelector } from 'react-redux'
 import { toFormikValidationSchema } from 'zod-formik-adapter'
 
 import { setValueField } from 'common/store/pages/signon/actions'
+import {
+  getEmailField,
+  getHandleField,
+  getIsVerified
+} from 'common/store/pages/signon/selectors'
 import { HarmonyTextField } from 'components/form-fields/HarmonyTextField'
 import { PasswordField } from 'components/form-fields/PasswordField'
 import { useNavigateToPage } from 'hooks/useNavigateToPage'
@@ -13,21 +18,16 @@ import { SIGN_UP_FINISH_PROFILE_PAGE } from 'utils/route'
 
 import { CompletionChecklist } from '../components/CompletionChecklist'
 import { SignUpAgreementText } from '../components/SignUpPolicyText'
-import { Heading, Page, PageFooter } from '../components/layout'
+import { Heading, Page, PageFooter, ReadOnlyField } from '../components/layout'
 import { loginDetailsSchema } from '../utils/loginDetailsSchema'
 
 const messages = {
   title: 'Create Login Details',
   description: `Enter your email and create a password. Keep in mind that we can't reset your password.`,
   emailLabel: 'Email',
+  handleLabel: 'Handle',
   passwordLabel: 'Password',
   confirmPasswordLabel: 'Confirm Password'
-}
-
-const initialValues = {
-  email: '',
-  password: '',
-  confirmPassword: ''
 }
 
 export type CreateLoginDetailsValues = {
@@ -41,6 +41,18 @@ const loginDetailsFormikSchema = toFormikValidationSchema(loginDetailsSchema)
 export const CreateLoginDetailsPage = () => {
   const dispatch = useDispatch()
   const navigate = useNavigateToPage()
+  const handleField = useSelector(getHandleField)
+  const existingEmailValue = useSelector(getEmailField)
+
+  const { spacing } = useTheme()
+
+  const isVerified = useSelector(getIsVerified)
+
+  const initialValues = {
+    email: existingEmailValue.value ?? '',
+    password: '',
+    confirmPassword: ''
+  }
 
   const handleSubmit = useCallback(
     (values: CreateLoginDetailsValues) => {
@@ -66,6 +78,20 @@ export const CreateLoginDetailsPage = () => {
           />
           <Flex direction='column' h='100%' gap='l'>
             <Flex direction='column' gap='l'>
+              <ReadOnlyField
+                label={messages.handleLabel}
+                value={
+                  <Flex alignItems='center' gap='xs'>
+                    @{handleField.value}
+                    {isVerified ? (
+                      <IconVerified
+                        css={{ height: spacing.unit3, width: spacing.unit3 }}
+                      />
+                    ) : null}
+                  </Flex>
+                }
+                p
+              />
               <HarmonyTextField
                 name='email'
                 autoComplete='email'
@@ -83,7 +109,12 @@ export const CreateLoginDetailsPage = () => {
           <PageFooter
             shadow='flat'
             prefix={<SignUpAgreementText />}
-            buttonProps={{ disabled: !(dirty && isValid) }}
+            buttonProps={{
+              disabled: !(
+                (dirty || (initialValues.email && initialValues.password)) &&
+                isValid
+              )
+            }}
           />
         </Page>
       )}

--- a/packages/web/src/pages/sign-up-page/pages/CreateLoginDetails.tsx
+++ b/packages/web/src/pages/sign-up-page/pages/CreateLoginDetails.tsx
@@ -90,7 +90,6 @@ export const CreateLoginDetailsPage = () => {
                     ) : null}
                   </Flex>
                 }
-                p
               />
               <HarmonyTextField
                 name='email'

--- a/packages/web/src/pages/sign-up-page/pages/FinishProfilePage.tsx
+++ b/packages/web/src/pages/sign-up-page/pages/FinishProfilePage.tsx
@@ -16,6 +16,7 @@ import {
 import {
   getCoverPhotoField,
   getIsSocialConnected,
+  getLinkedSocialOnFirstPage,
   getNameField,
   getProfileImageField
 } from 'common/store/pages/signon/selectors'
@@ -66,6 +67,7 @@ export const FinishProfilePage = () => {
 
   const { value: savedDisplayName } = useSelector(getNameField)
   const isSocialConnected = useSelector(getIsSocialConnected)
+  const linkedSocialOnFirstPage = useSelector(getLinkedSocialOnFirstPage)
   const { value: savedCoverPhoto } = useSelector(getCoverPhotoField) ?? {}
   const { value: savedProfileImage } = useSelector(getProfileImageField) ?? {}
 
@@ -106,7 +108,9 @@ export const FinishProfilePage = () => {
         >
           <Heading
             prefix={
-              isMobile ? null : <OutOfText numerator={2} denominator={2} />
+              isMobile || linkedSocialOnFirstPage ? null : (
+                <OutOfText numerator={2} denominator={2} />
+              )
             }
             heading={messages.header}
             description={messages.description}

--- a/packages/web/src/pages/sign-up-page/pages/FinishProfilePage.tsx
+++ b/packages/web/src/pages/sign-up-page/pages/FinishProfilePage.tsx
@@ -1,5 +1,6 @@
 import { useCallback } from 'react'
 
+import { MAX_DISPLAY_NAME_LENGTH } from '@audius/common'
 import { Paper, PlainButton, PlainButtonType } from '@audius/harmony'
 import { Formik, Form } from 'formik'
 import { useDispatch, useSelector } from 'react-redux'
@@ -7,9 +8,14 @@ import { useHistory } from 'react-router-dom'
 import { z } from 'zod'
 import { toFormikValidationSchema } from 'zod-formik-adapter'
 
-import { setField, setValueField } from 'common/store/pages/signon/actions'
+import {
+  setField,
+  setValueField,
+  setFinishedPhase1
+} from 'common/store/pages/signon/actions'
 import {
   getCoverPhotoField,
+  getIsSocialConnected,
   getNameField,
   getProfileImageField
 } from 'common/store/pages/signon/selectors'
@@ -40,7 +46,7 @@ export type FinishProfileValues = {
 
 const formSchema = toFormikValidationSchema(
   z.object({
-    displayName: z.string(),
+    displayName: z.string().max(MAX_DISPLAY_NAME_LENGTH, ''),
     profileImage: z.object({
       url: z.string()
     }),
@@ -59,6 +65,7 @@ export const FinishProfilePage = () => {
   const navigate = useNavigateToPage()
 
   const { value: savedDisplayName } = useSelector(getNameField)
+  const isSocialConnected = useSelector(getIsSocialConnected)
   const { value: savedCoverPhoto } = useSelector(getCoverPhotoField) ?? {}
   const { value: savedProfileImage } = useSelector(getProfileImageField) ?? {}
 
@@ -76,6 +83,7 @@ export const FinishProfilePage = () => {
       if (coverPhoto) {
         dispatch(setField('coverPhoto', { value: coverPhoto }))
       }
+      dispatch(setFinishedPhase1(true))
       navigate(SIGN_UP_GENRES_PAGE)
     },
     [navigate, dispatch]
@@ -127,7 +135,7 @@ export const FinishProfilePage = () => {
             centered
             buttonProps={{ disabled: !isValid }}
             postfix={
-              isMobile ? null : (
+              isMobile || isSocialConnected ? null : (
                 <PlainButton
                   variant={PlainButtonType.SUBDUED}
                   onClick={history.goBack}

--- a/packages/web/src/pages/sign-up-page/pages/PickHandlePage.tsx
+++ b/packages/web/src/pages/sign-up-page/pages/PickHandlePage.tsx
@@ -29,6 +29,7 @@ import { OutOfText } from '../components/OutOfText'
 import { SocialMediaLoading } from '../components/SocialMediaLoading'
 import { SocialMediaLoginOptions } from '../components/SocialMediaLoginOptions'
 import { Heading, Page, PageFooter } from '../components/layout'
+import { useSocialMediaLoader } from '../hooks/useSocialMediaLoader'
 import { generateHandleSchema } from '../utils/handleSchema'
 
 const messages = {
@@ -101,14 +102,17 @@ export const PickHandlePage = () => {
   const { isMobile } = useMedia()
 
   const dispatch = useDispatch()
-  useEffect(() => {
-    // If the user goes back to this page in the middle of the flow after they linked
-    // their social on this page previously, clear the social media state.
-    if (alreadyLinkedSocial) {
-      dispatch(unsetSocialProfile())
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [dispatch])
+
+  const alreadyLinkedSocial = useSelector(getIsSocialConnected)
+  const {
+    isWaitingForSocialLogin,
+    handleStartSocialMediaLogin,
+    handleErrorSocialMediaLogin
+  } = useSocialMediaLoader({
+    resetAction: unsetSocialProfile,
+    linkedSocialOnThisPagePreviously: alreadyLinkedSocial
+  })
+
   const navigate = useNavigateToPage()
   const { toast } = useContext(ToastContext)
   const audiusQueryContext = useAudiusQueryContext()
@@ -117,19 +121,9 @@ export const PickHandlePage = () => {
       generateHandleSchema({ audiusQueryContext })
     )
   }, [audiusQueryContext])
-  const [isWaitingForSocialLogin, setIsWaitingForSocialLogin] = useState(false)
-  const alreadyLinkedSocial = useSelector(getIsSocialConnected)
 
   const { value: handle } = useSelector(getHandleField)
   const isLinkingSocialOnFirstPage = useSelector(getLinkedSocialOnFirstPage)
-
-  const handleStartSocialMediaLogin = useCallback(() => {
-    setIsWaitingForSocialLogin(true)
-  }, [])
-
-  const handleErrorSocialMediaLogin = useCallback(() => {
-    setIsWaitingForSocialLogin(false)
-  }, [])
 
   const handleSubmit = useCallback(
     (values: PickHandleValues) => {

--- a/packages/web/src/pages/sign-up-page/pages/PickHandlePage.tsx
+++ b/packages/web/src/pages/sign-up-page/pages/PickHandlePage.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useContext, useEffect, useMemo, useState } from 'react'
+import { useCallback, useContext, useMemo } from 'react'
 
 import { socialMediaMessages, useAudiusQueryContext } from '@audius/common'
 import { Divider, Flex, IconVerified, Paper, Text } from '@audius/harmony'

--- a/packages/web/src/pages/sign-up-page/utils/determineAllowedRoutes.ts
+++ b/packages/web/src/pages/sign-up-page/utils/determineAllowedRoutes.ts
@@ -27,14 +27,16 @@ export const determineAllowedRoute = (
 
     if (signUpState.password.value || signUpState.useMetaMask) {
       // Already have password
-      allowedRoutes.push(SignUpPath.pickHandle)
+      if (!signUpState.linkedSocialOnFirstPage) {
+        allowedRoutes.push(SignUpPath.pickHandle)
+      }
 
       if (signUpState.handle.value) {
         // Already have handle or it needs review
         allowedRoutes.push(SignUpPath.reviewHandle)
         allowedRoutes.push(SignUpPath.finishProfile)
 
-        if (signUpState.name.value) {
+        if (signUpState.finishedPhase1) {
           // Already have display name
 
           // At this point the account is fully created & logged in; now user can't back to account creation steps

--- a/packages/web/src/pages/sign-up-page/utils/handleSchema.ts
+++ b/packages/web/src/pages/sign-up-page/utils/handleSchema.ts
@@ -15,6 +15,7 @@ export const errorMessages = {
   genericReservedError: 'This verified handle is reserved.',
   unknownError: 'An unknown error occurred.',
   handleTakenError: 'That handle has already been taken.',
+  handleTooLong: 'That handle is too long.',
   missingHandleError: 'Please enter a handle.'
 }
 
@@ -28,7 +29,7 @@ export const generateHandleSchema = ({
   return z.object({
     handle: z
       .string()
-      .max(MAX_HANDLE_LENGTH)
+      .max(MAX_HANDLE_LENGTH, errorMessages.handleTooLong)
       .regex(/^[a-zA-Z0-9_.]*$/, errorMessages.badCharacterError)
       .refine(
         (handle) => !restrictedHandles.has(handle.toLowerCase()),


### PR DESCRIPTION
### Description
- Social media connect loading states on Create Email and Pick Handle pages
- Fix another allowedRoutes issue affecting the social media sign up flow
- If user navigates back to the page where they connected their social media, reset the state (so it’s as if they never connected it on that page)
- Add handle display to Create Login Details page
- Add in proper error message for if the handle is too long
- Fix existing email not loaded in if you nav back to "Create Login Details" page

![socialmedialogin](https://github.com/AudiusProject/audius-protocol/assets/36916764/bab072d8-3846-4271-8ac6-a0916dafc2f3)

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._
