### PR TITLE
[PAY-2245] Fix purchase radio buttons on android

### DIFF
--- a/packages/mobile/src/components/payment-method/PaymentMethod.tsx
+++ b/packages/mobile/src/components/payment-method/PaymentMethod.tsx
@@ -5,8 +5,7 @@ import {
   formatCurrencyBalance
 } from '@audius/common'
 import BN from 'bn.js'
-import { FlatList, View } from 'react-native'
-import { TouchableOpacity } from 'react-native-gesture-handler'
+import { FlatList, View, TouchableOpacity } from 'react-native'
 
 import IconCreditCard from 'app/assets/images/iconCreditCard.svg'
 import IconDonate from 'app/assets/images/iconDonate.svg'


### PR DESCRIPTION
### Description
Previously the radio items in `PurchaseMethod` were not selectable on Android.

### How Has This Been Tested?

Tested that they work on both android and ios emulators.