### PR TITLE
Add uptime to node overview tables in protocol dashboard

### DIFF
--- a/protocol-dashboard/src/components/IndividualNodeUptimeChart/IndividualNodeUptimeChart.tsx
+++ b/protocol-dashboard/src/components/IndividualNodeUptimeChart/IndividualNodeUptimeChart.tsx
@@ -1,8 +1,8 @@
-import TrackerChart from 'components/TrackerChart'
+import { TrackerChart } from 'components/TrackerChart'
 import React from 'react'
 import { useIndividualNodeUptime } from 'store/cache/analytics/hooks'
 import { Bucket, MetricError } from 'store/cache/analytics/slice'
-import { DataObject } from 'components/TrackerChart'
+import type { DataObject } from 'components/TrackerChart'
 
 type OwnProps = {
   node: string

--- a/protocol-dashboard/src/components/ServiceTable/ServiceTable.module.css
+++ b/protocol-dashboard/src/components/ServiceTable/ServiceTable.module.css
@@ -5,13 +5,32 @@
   width: 100%;
 }
 
-.colEndpoint {
+.colVersion {
   flex: 1;
   min-width: 0;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
+  text-align: right;
   margin-right: 8px;
+}
+
+.colEndpoint {
+  flex: 2;
+  min-width: 0;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  margin-right: 8px;
+}
+
+.colUptime {
+  flex: 1;
+  min-width: 0;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  text-align: right;
 }
 
 .rowCol {
@@ -24,6 +43,8 @@
 }
 
 .error {
+  display: inline-flex;
+  justify-content: flex-end;
   height: 20px;
   width: 20px;
 }

--- a/protocol-dashboard/src/components/ServiceTable/ServiceTable.tsx
+++ b/protocol-dashboard/src/components/ServiceTable/ServiceTable.tsx
@@ -5,6 +5,11 @@ import { NodeService, ContentNode, DiscoveryProvider } from 'types'
 import styles from './ServiceTable.module.css'
 import Table from 'components/Table'
 import Error from 'components/Error'
+import { isMobile } from 'utils/mobile'
+import { useIndividualNodeUptime } from 'store/cache/analytics/hooks'
+import { Bucket, MetricError } from 'store/cache/analytics/slice'
+import type { DataObject } from 'components/TrackerChart'
+import { TrackerMini } from 'components/TrackerChart'
 
 type ServiceRow = {
   endpoint: string
@@ -40,10 +45,28 @@ const ServiceTable: React.FC<ServiceTableProps> = ({
 }: ServiceTableProps) => {
   const columns = [
     { title: 'Service Endpoint', className: styles.colEndpoint },
-    { title: 'Version', className: styles.colVersion }
+    { title: 'Version', className: styles.colVersion },
+    { title: 'Uptime', className: styles.colUptime },
   ]
 
   const renderRow = (data: NodeService) => {
+    let error: boolean, uptimeData: DataObject[]
+    const { uptime } = useIndividualNodeUptime(data.endpoint, Bucket.DAY)
+    if (uptime === MetricError.ERROR) {
+      error = true
+      uptimeData = []
+    } else if (uptime?.uptime_raw_data) {
+      uptimeData = []
+      const hoursToDisplay = isMobile() ? -7 : -9
+      for (const up of Object.values(uptime.uptime_raw_data).slice(hoursToDisplay)) {
+        uptimeData.push({
+          // TODO add harmony and use harmony css vars
+          color: up === 1 ? '#13c65a' : '#f9344c',
+          // color: up === 1 ? 'var(--harmony-light-green)' : 'var(--harmony-red)',
+        })
+      }
+    }
+
     return (
       <div className={styles.rowContainer}>
         <div className={clsx(styles.rowCol, styles.colEndpoint)}>
@@ -55,6 +78,12 @@ const ServiceTable: React.FC<ServiceTableProps> = ({
         </div>
         <div className={clsx(styles.rowCol, styles.colVersion)}>
           {data.version ? data.version : <Error className={styles.error} />}
+        </div>
+        <div className={clsx(styles.rowCol, styles.colUptime)}>
+          {error
+            ? (<Error className={styles.error} />)
+            : (<TrackerMini data={uptimeData} />)
+          }
         </div>
       </div>
     )

--- a/protocol-dashboard/src/components/TrackerChart/TrackerChart.module.css
+++ b/protocol-dashboard/src/components/TrackerChart/TrackerChart.module.css
@@ -51,6 +51,29 @@
   height: 128px;
 }
 
+.chartMini {
+  flex-grow: 1;
+  display: flex;
+  justify-content: flex-end;
+  align-items: center;
+}
+
+.trackerContainerMini {
+  display: flex;
+  flex-direction: column;
+  width: 64px;
+}
+
+.trackerCellsMini {
+  position: relative;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 5px;
+  width: 100%;
+  justify-content: space-evenly;
+  height: 30px;
+}
+
 .trackerCell {
   flex: 1 1 0;
   border-radius: 100px;

--- a/protocol-dashboard/src/components/TrackerChart/TrackerChart.tsx
+++ b/protocol-dashboard/src/components/TrackerChart/TrackerChart.tsx
@@ -10,25 +10,25 @@ import mobileStyles from './TrackerChartMobile.module.css'
 const styles = createStyles({ desktopStyles, mobileStyles })
 
 type OwnProps = {
-  title: string
+  title?: string
   subtitle?: string
   data: DataObject[] | null
   error?: boolean
 }
 
-type TrackerChartProps = OwnProps
+type TrackerProps = OwnProps
 
 export type DataObject = {
   color: string
-  tooltip: string
+  tooltip?: string
 }
 
-const TrackerChart: React.FC<TrackerChartProps> = ({
+export const TrackerChart: React.FC<TrackerProps> = ({
   title,
   subtitle,
   data,
   error
-}) => {
+}: TrackerProps) => {
   const [tooltipText, setTooltipText] = React.useState('')
   const [showTooltip, setShowTooltip] = React.useState(false)
 
@@ -77,4 +77,26 @@ const TrackerChart: React.FC<TrackerChartProps> = ({
   )
 }
 
-export default TrackerChart
+export const TrackerMini: React.FC<TrackerProps> = ({
+  data,
+}: TrackerProps) => {
+  return (
+    <div className={styles.chartMini}>
+      {data && data.length >= 2 ? (
+        <div className={styles.trackerContainerMini}>
+          <div className={styles.trackerCellsMini}>
+            {data.map((item, index) => (
+              <div
+                key={index}
+                className={styles.trackerCell}
+                style={{ backgroundColor: item.color }}
+              />
+            ))}
+          </div>
+        </div>
+      ) : (
+        <Loading className={styles.loading} />
+      )}
+    </div>
+  )
+}

--- a/protocol-dashboard/src/components/TrackerChart/TrackerChart.tsx
+++ b/protocol-dashboard/src/components/TrackerChart/TrackerChart.tsx
@@ -77,9 +77,7 @@ export const TrackerChart: React.FC<TrackerProps> = ({
   )
 }
 
-export const TrackerMini: React.FC<TrackerProps> = ({
-  data,
-}: TrackerProps) => {
+export const TrackerMini: React.FC<TrackerProps> = ({ data }: TrackerProps) => {
   return (
     <div className={styles.chartMini}>
       {data && data.length >= 2 ? (

--- a/protocol-dashboard/src/components/TrackerChart/TrackerChartMobile.module.css
+++ b/protocol-dashboard/src/components/TrackerChart/TrackerChartMobile.module.css
@@ -1,3 +1,9 @@
 .header {
   margin-bottom: 32px;
 }
+
+.trackerContainerMini {
+  display: flex;
+  flex-direction: column;
+  width: 48px;
+}

--- a/protocol-dashboard/src/components/TrackerChart/index.tsx
+++ b/protocol-dashboard/src/components/TrackerChart/index.tsx
@@ -1,1 +1,2 @@
-export { default } from './TrackerChart'
+export { TrackerChart, TrackerMini } from './TrackerChart'
+export type { DataObject } from './TrackerChart'


### PR DESCRIPTION
### Description
web:
![image](https://github.com/AudiusProject/audius-protocol/assets/25782182/21c73d36-4b02-4570-9d8c-4797178bdc84)
![image](https://github.com/AudiusProject/audius-protocol/assets/25782182/bb5ea8c8-7499-457b-bc47-e8df1b410161)
![image](https://github.com/AudiusProject/audius-protocol/assets/25782182/c0dfffc8-37c8-4198-a457-daab285969dc)

mobile:
![image](https://github.com/AudiusProject/audius-protocol/assets/25782182/95f81392-f15b-4e25-a853-0e7c0a6ec655)
![image](https://github.com/AudiusProject/audius-protocol/assets/25782182/bda7b535-6a5a-4c3f-af26-f65df65d32a0)
![image](https://github.com/AudiusProject/audius-protocol/assets/25782182/d57ed250-5f87-4579-86c2-183947ab9211)


### How Has This Been Tested?
Ran UI against stage and prod