### PR TITLE
[PAY-2132] Premium content explore page denylist

### DIFF
--- a/packages/common/src/services/remote-config/defaults.ts
+++ b/packages/common/src/services/remote-config/defaults.ts
@@ -90,7 +90,7 @@ export const remoteConfigStringDefaults: {
   [StringKeys.STRIPE_ALLOWED_COUNTRIES_2_LETTER]: '',
   [StringKeys.AUDIO_FEATURES_DEGRADED_TEXT]: null,
   [StringKeys.PAY_EXTRA_PRESET_CENT_AMOUNTS]: '200,500,1000',
-  [StringKeys.EXPLORE_PREMIUM_ALLOWED_USERS]: ''
+  [StringKeys.EXPLORE_PREMIUM_DENIED_USERS]: ''
 }
 
 export const remoteConfigDoubleDefaults: {

--- a/packages/common/src/services/remote-config/types.ts
+++ b/packages/common/src/services/remote-config/types.ts
@@ -389,8 +389,8 @@ export enum StringKeys {
   /** Preset amounts for the Pay Extra feature in USDC purchases, specified in cents */
   PAY_EXTRA_PRESET_CENT_AMOUNTS = 'PAY_EXTRA_PRESET_CENT_AMOUNTS',
 
-  /** Allowlist of user ids for explore premium tracks page */
-  EXPLORE_PREMIUM_ALLOWED_USERS = 'EXPLORE_PREMIUM_ALLOWED_USERS'
+  /** Denylist of user ids for explore premium tracks page */
+  EXPLORE_PREMIUM_DENIED_USERS = 'EXPLORE_PREMIUM_DENIED_USERS'
 }
 
 export type AllRemoteConfigKeys =

--- a/packages/web/src/common/store/lineup/sagas.js
+++ b/packages/web/src/common/store/lineup/sagas.js
@@ -59,8 +59,9 @@ function* filterDeletes(tracksMetadata, removeDeleted, lineupPrefix) {
   const isUSDCGatedContentEnabled = yield getFeatureEnabled(
     FeatureFlags.USDC_PURCHASES
   )
-  const allowedHandles = remoteConfig
-    .getRemoteVar(StringKeys.EXPLORE_PREMIUM_ALLOWED_USERS)
+
+  const deniedHandles = remoteConfig
+    .getRemoteVar(StringKeys.EXPLORE_PREMIUM_DENIED_USERS)
     ?.split(',')
 
   return tracksMetadata
@@ -88,7 +89,7 @@ function* filterDeletes(tracksMetadata, removeDeleted, lineupPrefix) {
         lineupPrefix === premiumTracksPageLineupActions.prefix &&
         metadata.is_premium &&
         isPremiumContentUSDCPurchaseGated(metadata.premium_conditions) &&
-        !allowedHandles.includes(users[metadata.owner_id].handle)
+        deniedHandles.includes(users[metadata.owner_id].handle)
       ) {
         return null
       }


### PR DESCRIPTION
### Description
Change the premium content explore page allowlist to a denylist.

The plan is to leave the allowlist optimizely var around for old clients for a bit.

Current list (which I believe is comprehensive): marcus_audius,dharit,FerrariJetpack,ehwutupdawg,turtle999,utterk,LabyrinthFlamingoPeculiar,ScaryHamburger,KaleidoscopeQuasarCandelabra,elephantspiralharmonica,___l___,confusedcat,professr

### How Has This Been Tested?

Local web stage + prod
Screenshot is stage with reedtest and reed3 on the denylist:
<img width="1728" alt="Screenshot 2023-12-11 at 4 05 00 PM" src="https://github.com/AudiusProject/audius-protocol/assets/3893871/2b2f7e67-acdc-424f-8335-e7de8a7b1265">
