### PR TITLE
Fix missing string format on payment router indexing

### DIFF
--- a/packages/discovery-provider/src/tasks/index_payment_router.py
+++ b/packages/discovery-provider/src/tasks/index_payment_router.py
@@ -488,7 +488,7 @@ def process_route_instruction(
         # We can have a USDC payment router transfer with no purchase attached
         if purchase_metadata is None:
             logger.info(
-                "index_payment_router.py | No purchase metadata found on {tx_sig}"
+                f"index_payment_router.py | No purchase metadata found on {tx_sig}"
             )
             return
 


### PR DESCRIPTION
### Description
I missed a `f` prefix on a string and it results in logs which aren't the most useful :-) 

### How Has This Been Tested?
None
