### PR TITLE
Wire up purchase flow to payment router

### DIFF
--- a/packages/common/src/services/audius-backend/solana.ts
+++ b/packages/common/src/services/audius-backend/solana.ts
@@ -405,6 +405,39 @@ export const purchaseContentWithPaymentRouter = async (
   return tx
 }
 
+export type PurchaseContentWithPaymentRouterUserBankArgs = {
+  id: number
+  type: 'track'
+  splits: Record<string, number>
+  extraAmount?: number
+  blocknumber: number
+  recentBlockhash?: string
+  purchaserUserId: ID
+}
+
+export const purchaseContentWithPaymentRouterUserBank = async (
+  audiusBackendInstance: AudiusBackend,
+  {
+    id,
+    type,
+    blocknumber,
+    extraAmount = 0,
+    purchaserUserId,
+    splits
+  }: PurchaseContentWithPaymentRouterUserBankArgs
+) => {
+  const solanaWeb3Manager = (await audiusBackendInstance.getAudiusLibs())
+    .solanaWeb3Manager!
+  await solanaWeb3Manager.purchaseContentWithPaymentRouterUserBank({
+    id,
+    type,
+    blocknumber,
+    extraAmount,
+    splits,
+    purchaserUserId
+  })
+}
+
 export const findAssociatedTokenAddress = async (
   audiusBackendInstance: AudiusBackend,
   { solanaAddress, mint }: { solanaAddress: string; mint: MintName }

--- a/packages/common/src/store/purchase-content/sagas.ts
+++ b/packages/common/src/store/purchase-content/sagas.ts
@@ -12,8 +12,8 @@ import {
   getRecentBlockhash,
   getRootSolanaAccount,
   getTokenAccountInfo,
-  purchaseContent,
-  purchaseContentWithPaymentRouter
+  purchaseContentWithPaymentRouter,
+  purchaseContentWithPaymentRouterUserBank
 } from 'services/audius-backend/solana'
 import { FeatureFlags } from 'services/remote-config/feature-flags'
 import { accountSelectors } from 'store/account'
@@ -383,14 +383,18 @@ function* doStartPurchaseContentFlow({
 
     if (balanceNeeded.lten(0)) {
       // No balance needed, perform the purchase right away
-      yield* call(purchaseContent, audiusBackendInstance, {
-        id: contentId,
-        blocknumber,
-        extraAmount: extraAmountBN,
-        splits,
-        type: 'track',
-        purchaserUserId
-      })
+      yield* call(
+        purchaseContentWithPaymentRouterUserBank,
+        audiusBackendInstance,
+        {
+          id: contentId,
+          blocknumber,
+          extraAmount,
+          splits,
+          type: 'track',
+          purchaserUserId
+        }
+      )
     } else {
       // We need to acquire USDC before the purchase can continue
 
@@ -420,14 +424,18 @@ function* doStartPurchaseContentFlow({
         case PurchaseVendor.STRIPE:
           // Buy USDC with Stripe. Once funded, continue with purchase.
           yield* call(purchaseUSDCWithStripe, { balanceNeeded })
-          yield* call(purchaseContent, audiusBackendInstance, {
-            id: contentId,
-            blocknumber,
-            extraAmount: extraAmountBN,
-            splits,
-            type: 'track',
-            purchaserUserId
-          })
+          yield* call(
+            purchaseContentWithPaymentRouterUserBank,
+            audiusBackendInstance,
+            {
+              id: contentId,
+              blocknumber,
+              extraAmount,
+              splits,
+              type: 'track',
+              purchaserUserId
+            }
+          )
           break
       }
     }


### PR DESCRIPTION
### Description
Wires up ordinary (non-coinflow) purchase flow to use the payment router methods.

Note - will hold off merging this until payment router indexing is complete.

### How Has This Been Tested?

Successful purchase: https://solscan.io/tx/4kS3NUvVkusL8pXGYEuan4HzH532SehPEVojh2WA1dfhL1o4UGRjAaJDn9unnNZtxU3xLHdmw4U1eYRoV75bgh1t