### PR TITLE
Fix timestamp comparison for sched releases

### DIFF
--- a/packages/discovery-provider/src/tasks/publish_scheduled_releases.py
+++ b/packages/discovery-provider/src/tasks/publish_scheduled_releases.py
@@ -37,10 +37,9 @@ def _publish_scheduled_releases(session, redis):
             release_date_day = candidate_track.release_date
         except Exception:
             continue
-        candidate_created_at_day = candidate_track.created_at.date()
         if (
             current_timestamp >= release_date_day.timestamp()
-            and release_date_day > candidate_created_at_day
+            and release_date_day.timestamp() > candidate_track.created_at.timestamp() + 60
         ):
             candidate_track.is_unlisted = False
 

--- a/packages/discovery-provider/src/tasks/publish_scheduled_releases.py
+++ b/packages/discovery-provider/src/tasks/publish_scheduled_releases.py
@@ -39,7 +39,7 @@ def _publish_scheduled_releases(session, redis):
             continue
         if (
             current_timestamp >= release_date_day.timestamp()
-            and release_date_day.timestamp() > candidate_track.created_at.timestamp() + 60
+            and release_date_day.timestamp() > candidate_track.created_at.timestamp()
         ):
             candidate_track.is_unlisted = False
 


### PR DESCRIPTION
### Description
Error was comparing date vs datetime. This just compares datetime to datetime.


### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._

Ran in staging environment without error/
