### PR TITLE
Fix defaults when coinflow disabled + android purchase vendor drawer

### DIFF
--- a/packages/mobile/src/components/payment-method/CardSelectionButton.tsx
+++ b/packages/mobile/src/components/payment-method/CardSelectionButton.tsx
@@ -2,7 +2,7 @@ import { useCallback } from 'react'
 
 import type { PurchaseVendor } from '@audius/common'
 import { modalsActions } from '@audius/common'
-import { TouchableOpacity } from 'react-native-gesture-handler'
+import { TouchableOpacity } from 'react-native'
 import { useDispatch } from 'react-redux'
 
 import IconCaretDown from 'app/assets/images/iconCaretDown.svg'
@@ -41,6 +41,7 @@ export const CardSelectionButton = ({
           }
         }}
         fullWidth
+        onPress={handlePress}
       />
     </TouchableOpacity>
   )


### PR DESCRIPTION
### Description
- When coinflow was disabled, we were still showing coinflow as the default option on mobile because that's what it was set to in initial redux state.
- Android `CardSelectionButton` `TouchableOpacity` wasn't registering the presses probably because it's behind the `Button`, so added the press handler to the Button as well (still works on ios).

### How Has This Been Tested?

Tested both ios and android against prod.