### PR TITLE
Fix primary key for DashboardWalletUsers

### DIFF
--- a/packages/discovery-provider/ddl/migrations/0043_add_dashboard_wallet_users.sql
+++ b/packages/discovery-provider/ddl/migrations/0043_add_dashboard_wallet_users.sql
@@ -1,15 +1,14 @@
 begin;
 
 CREATE TABLE IF NOT EXISTS dashboard_wallet_users (
-    wallet varchar not null,
+    wallet varchar PRIMARY KEY,
     user_id integer not null,
     is_delete boolean not null default false,
     updated_at timestamp not null,
     created_at timestamp not null,
     blockhash varchar references blocks(blockhash),
     blocknumber integer references blocks(number),
-    txhash varchar not null,
-    primary key (user_id, wallet)
+    txhash varchar not null
 );
 
 commit;


### PR DESCRIPTION
### Description
Only one user per wallet, so the pkey should be the wallet

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._
