### PR TITLE
[PAY-2277][PAY-2272] Fix purchase modaldrawer scroll and safe areas

### DIFF
--- a/packages/stems/src/components/Modal/ModalContentPages.tsx
+++ b/packages/stems/src/components/Modal/ModalContentPages.tsx
@@ -10,6 +10,8 @@ import { ModalContent } from './ModalContent'
 import styles from './ModalContentPages.module.css'
 import { ModalContentProps } from './types'
 
+const INNER_HEIGHT_PADDING = 100
+
 const defaultTransitions = {
   initial: { opacity: 1, transform: 'translate3d(0%, 0, 0)' },
   enter: { opacity: 1, transform: 'translate3d(0%, 0 ,0)' }
@@ -53,6 +55,14 @@ export const ModalContentPages = ({
     polyfill: ResizeObserver
   })
 
+  // A bit of a hack, but instead of resizing the height to the result from
+  // useMeasure, clamp it to the window height minus a padding.
+  // This makes it so that when inside a "Drawer," safe areas are respected.
+  const computedHeight = Math.min(
+    height,
+    window.innerHeight - INNER_HEIGHT_PADDING
+  )
+
   if (lastPage !== currentPage) {
     setTransitions(
       getSwipeTransitions(currentPage > lastPage ? 'forward' : 'back')
@@ -68,7 +78,7 @@ export const ModalContentPages = ({
       className={styles.transitionContainer}
       style={{
         width: width ? `${width}px` : '100%',
-        height: height ? `${height}px` : '100%'
+        height: computedHeight ? `${computedHeight}px` : '100%'
       }}
     >
       <Transition

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -94,7 +94,7 @@
     "array-range": "1.0.1",
     "bitski": "0.10.9",
     "bn.js": "5.1.0",
-    "body-scroll-lock": "2.7.1",
+    "body-scroll-lock": "4.0.0-beta.0",
     "canvas-loop": "1.0.7",
     "chart.js": "2.9.3",
     "clamp": "1.0.1",

--- a/packages/web/src/components/drawer/Drawer.module.css
+++ b/packages/web/src/components/drawer/Drawer.module.css
@@ -19,8 +19,7 @@
 .fullDrawer {
   top: 0px;
   height: 100vh;
-  overflow-x: hidden;
-  overflow-y: scroll;
+  overflow: hidden;
   touch-action: auto;
 }
 

--- a/packages/web/src/components/premium-content-purchase-modal/PremiumContentPurchaseModal.tsx
+++ b/packages/web/src/components/premium-content-purchase-modal/PremiumContentPurchaseModal.tsx
@@ -103,55 +103,53 @@ const RenderForm = ({
   const mobile = isMobile()
 
   return (
-    <ModalForm className={styles.root}>
-      <Box>
-        <ModalHeader
-          className={cn(styles.modalHeader, { [styles.mobile]: mobile })}
-          onClose={onClose}
-          showDismissButton={!mobile}
+    <ModalForm>
+      <ModalHeader
+        className={cn(styles.modalHeader, { [styles.mobile]: mobile })}
+        onClose={onClose}
+        showDismissButton={!mobile}
+      >
+        <Text
+          variant='label'
+          color='neutralLight2'
+          size='xLarge'
+          strength='strong'
+          className={styles.title}
         >
-          <Text
-            variant='label'
-            color='neutralLight2'
-            size='xLarge'
-            strength='strong'
-            className={styles.title}
-          >
-            <Icon size='large' icon={IconCart} />
-            {messages.completePurchase}
-          </Text>
-        </ModalHeader>
-        <ModalContentPages
-          contentClassName={styles.content}
-          className={styles.content}
-          currentPage={currentPageIndex}
-        >
-          <>
-            {stage !== PurchaseContentStage.FINISH ? (
-              <AudioMatchSection
-                amount={USDC(price / 100)
-                  .round()
-                  .toShorthand()}
+          <Icon size='large' icon={IconCart} />
+          {messages.completePurchase}
+        </Text>
+      </ModalHeader>
+      <ModalContentPages
+        contentClassName={styles.content}
+        className={styles.content}
+        currentPage={currentPageIndex}
+      >
+        <>
+          {stage !== PurchaseContentStage.FINISH ? (
+            <AudioMatchSection
+              amount={USDC(price / 100)
+                .round()
+                .toShorthand()}
+            />
+          ) : null}
+          <Flex p={mobile ? 'l' : 'xl'}>
+            <Flex direction='column' gap='xl' w='100%'>
+              <LockedTrackDetailsTile
+                track={track as unknown as Track}
+                owner={track.user}
               />
-            ) : null}
-            <Flex p={mobile ? 'l' : 'xl'}>
-              <Flex direction='column' gap='xl' w='100%'>
-                <LockedTrackDetailsTile
-                  track={track as unknown as Track}
-                  owner={track.user}
-                />
-                <PurchaseContentFormFields
-                  stage={stage}
-                  purchaseSummaryValues={purchaseSummaryValues}
-                  isUnlocking={isUnlocking}
-                  price={price}
-                />
-              </Flex>
+              <PurchaseContentFormFields
+                stage={stage}
+                purchaseSummaryValues={purchaseSummaryValues}
+                isUnlocking={isUnlocking}
+                price={price}
+              />
             </Flex>
-          </>
-          <USDCManualTransfer onClose={handleClose} amountInCents={price} />
-        </ModalContentPages>
-      </Box>
+          </Flex>
+        </>
+        <USDCManualTransfer onClose={handleClose} amountInCents={price} />
+      </ModalContentPages>
       <ModalFooter className={styles.footer}>
         {page === PurchaseContentPage.PURCHASE ? (
           <PurchaseContentFormFooter

--- a/packages/web/src/components/premium-content-purchase-modal/PremiumContentPurchaseModal.tsx
+++ b/packages/web/src/components/premium-content-purchase-modal/PremiumContentPurchaseModal.tsx
@@ -16,7 +16,7 @@ import {
   PurchaseContentPage
 } from '@audius/common'
 import { USDC } from '@audius/fixed-decimal'
-import { Box, Flex } from '@audius/harmony'
+import { Flex } from '@audius/harmony'
 import {
   IconCart,
   ModalContentPages,

--- a/packages/web/src/pages/upload-page/fields/AccessAndSaleField.tsx
+++ b/packages/web/src/pages/upload-page/fields/AccessAndSaleField.tsx
@@ -340,8 +340,7 @@ export const AccessAndSaleField = (props: AccessAndSaleFieldProps) => {
     isPremium,
     tempPremiumConditions,
     fieldVisibility,
-    preview,
-    setIsUnlistedValue
+    preview
   ])
 
   const handleSubmit = useCallback(


### PR DESCRIPTION
### Description

Currently there are a few very broken things with purchase web/mobile web modal/drawer
* Not scrollable (so small screens get wrecked)
* Purchase button isn't floating/fixed anymore, maybe never really was in mobile web drawer
* Body scroll lock is pretty much not working (old version) for mobile web drawers

The fix needed a few things, including a bit of a hack. I spent a long while trying to rework the modal content setup, but at risk of a bigger change and messing with a lot of things, I feel that this is relatively safe.

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._

Extensively on web (chrome & safari)
* Create app modals
* Premium content modals
* Add to playlist modals
* Withdrawal modal
to name a few

Mobile (chrome & safari)
* Purchase drawers (including coinflow)
* Action drawers
* Trending genre picker

Example:


https://github.com/AudiusProject/audius-protocol/assets/2731362/e7aa1fba-3507-40e3-a11a-cccbf7b7eb43


