### PR TITLE
Use 0.0.0.0 default host for vite app

### DIFF
--- a/packages/web/vite.config.ts
+++ b/packages/web/vite.config.ts
@@ -109,6 +109,7 @@ export default defineConfig(({ mode }) => {
       }
     },
     server: {
+      host: '0.0.0.0',
       port
     },
     test: {


### PR DESCRIPTION
### Description

This is a nice devx thing because it lets you turn on internet sharing on your mac and then when your phone is connected to the same network, you can access name.local:300x from your phone and test mobile web.

Was very helpful for this PR https://github.com/AudiusProject/audius-protocol/pull/6941

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._

```
npm run web:prod
```
raymont.local:3002 from my phone :)