### PR TITLE
[PAY-2270] Show vendor button only if more than 1 vendor

### DIFF
--- a/packages/mobile/src/components/payment-method/PaymentMethod.tsx
+++ b/packages/mobile/src/components/payment-method/PaymentMethod.tsx
@@ -7,7 +7,8 @@ import {
   formatCurrencyBalance,
   FeatureFlags,
   useFeatureFlag,
-  PurchaseVendor
+  PurchaseVendor,
+  removeNullable
 } from '@audius/common'
 import BN from 'bn.js'
 import { FlatList, View, TouchableOpacity } from 'react-native'
@@ -87,6 +88,10 @@ export const PaymentMethod = ({
   const purchaseVendor = useSelector(getPurchaseVendor)
   const { isEnabled: isCoinflowEnabled, isLoaded: isCoinflowEnabledLoaded } =
     useFeatureFlag(FeatureFlags.BUY_WITH_COINFLOW)
+  const vendorOptions = [
+    isCoinflowEnabled ? PurchaseVendor.COINFLOW : null,
+    PurchaseVendor.STRIPE
+  ].filter(removeNullable)
 
   // Initial state is coinflow by default, but set to stripe if coinflow is disabled.
   useEffect(() => {
@@ -105,7 +110,10 @@ export const PaymentMethod = ({
         </Text>
       ),
       icon: IconCreditCard,
-      content: <CardSelectionButton selectedVendor={purchaseVendor} />
+      content:
+        vendorOptions.length > 1 ? (
+          <CardSelectionButton selectedVendor={purchaseVendor} />
+        ) : null
     },
     {
       id: PurchaseMethod.CRYPTO,

--- a/packages/mobile/src/components/premium-track-purchase-drawer/PremiumTrackPurchaseDrawer.tsx
+++ b/packages/mobile/src/components/premium-track-purchase-drawer/PremiumTrackPurchaseDrawer.tsx
@@ -325,7 +325,7 @@ const RenderForm = ({
                     setSelectedMethod={setPurchaseMethod}
                     balance={balance}
                     isExistingBalanceDisabled={isExistingBalanceDisabled}
-                    showExistingBalance={!balance?.isZero}
+                    showExistingBalance={!balance?.isZero()}
                   />
                 )}
               </View>


### PR DESCRIPTION
### Description
Tried to make it match web:
https://github.com/AudiusProject/audius-protocol/blob/0b69f756b99cab53fcc2f1dba21de7134814e9d8/packages/web/src/components/payment-method/PaymentMethod.tsx#L62

Bonus: sneaking in a small bug fix where we forgot to call the `isZero` fn.

### How Has This Been Tested?

![Simulator Screenshot - iPhone 14 Pro - 2023-12-14 at 14 17 42](https://github.com/AudiusProject/audius-protocol/assets/3893871/1557d215-e738-4af4-a222-8a997a2ae306)
