### PR TITLE
[PAY-2276] Selectable amounts for coinflow add funds web

### DIFF
--- a/packages/common/src/hooks/purchaseContent/usePayExtraPresets.ts
+++ b/packages/common/src/hooks/purchaseContent/usePayExtraPresets.ts
@@ -8,8 +8,8 @@ import { useRemoteVar } from '../useRemoteVar'
 import { PayExtraAmountPresetValues, PayExtraPreset } from './types'
 
 /** Extracts and parses the Pay Extra presets from remote config */
-export const usePayExtraPresets = () => {
-  const configValue = useRemoteVar(StringKeys.PAY_EXTRA_PRESET_CENT_AMOUNTS)
+export const usePayExtraPresets = (key: StringKeys) => {
+  const configValue = useRemoteVar(key)
   return useMemo<PayExtraAmountPresetValues>(() => {
     const [low, medium, high] = parseIntList(configValue)
     return {

--- a/packages/common/src/messages/sign-on/pages.ts
+++ b/packages/common/src/messages/sign-on/pages.ts
@@ -72,7 +72,7 @@ export const finishProfilePageMessages = {
 }
 
 export const selectGenresPageMessages = {
-    header: 'Select Your Genres',
-    description: 'Start by picking some of your favorite genres.',
-    continue: 'Continue'
+  header: 'Select Your Genres',
+  description: 'Start by picking some of your favorite genres.',
+  continue: 'Continue'
 }

--- a/packages/common/src/services/remote-config/defaults.ts
+++ b/packages/common/src/services/remote-config/defaults.ts
@@ -90,6 +90,7 @@ export const remoteConfigStringDefaults: {
   [StringKeys.STRIPE_ALLOWED_COUNTRIES_2_LETTER]: '',
   [StringKeys.AUDIO_FEATURES_DEGRADED_TEXT]: null,
   [StringKeys.PAY_EXTRA_PRESET_CENT_AMOUNTS]: '200,500,1000',
+  [StringKeys.COINFLOW_ADD_FUNDS_PRESET_CENT_AMOUNTS]: '200,500,1000',
   [StringKeys.EXPLORE_PREMIUM_DENIED_USERS]: ''
 }
 

--- a/packages/common/src/services/remote-config/types.ts
+++ b/packages/common/src/services/remote-config/types.ts
@@ -390,7 +390,10 @@ export enum StringKeys {
   PAY_EXTRA_PRESET_CENT_AMOUNTS = 'PAY_EXTRA_PRESET_CENT_AMOUNTS',
 
   /** Denylist of user ids for explore premium tracks page */
-  EXPLORE_PREMIUM_DENIED_USERS = 'EXPLORE_PREMIUM_DENIED_USERS'
+  EXPLORE_PREMIUM_DENIED_USERS = 'EXPLORE_PREMIUM_DENIED_USERS',
+
+  /** Add funds preset amounts for Coinflow */
+  COINFLOW_ADD_FUNDS_PRESET_CENT_AMOUNTS = 'COINFLOW_ADD_FUNDS_PRESET_CENT_AMOUNTS'
 }
 
 export type AllRemoteConfigKeys =

--- a/packages/mobile/src/components/premium-track-purchase-drawer/PremiumTrackPurchaseDrawer.tsx
+++ b/packages/mobile/src/components/premium-track-purchase-drawer/PremiumTrackPurchaseDrawer.tsx
@@ -23,7 +23,8 @@ import {
   usePurchaseContentFormConfiguration,
   usePurchaseMethod,
   useUSDCBalance,
-  PURCHASE_VENDOR
+  PURCHASE_VENDOR,
+  StringKeys
 } from '@audius/common'
 import { Formik, useField, useFormikContext } from 'formik'
 import {
@@ -234,7 +235,9 @@ const RenderForm = ({
   const styles = useStyles()
   const dispatch = useDispatch()
   const { specialLightGreen, primary } = useThemeColors()
-  const presetValues = usePayExtraPresets()
+  const presetValues = usePayExtraPresets(
+    StringKeys.PAY_EXTRA_PRESET_CENT_AMOUNTS
+  )
   const { isEnabled: isIOSUSDCPurchaseEnabled } = useFeatureFlag(
     FeatureFlags.IOS_USDC_PURCHASE_ENABLED
   )
@@ -398,7 +401,10 @@ export const PremiumTrackPurchaseDrawer = () => {
   const styles = useStyles()
   const dispatch = useDispatch()
   const isUSDCEnabled = useIsUSDCEnabled()
-  const presetValues = usePayExtraPresets()
+  const presetValues = usePayExtraPresets(
+    StringKeys.PAY_EXTRA_PRESET_CENT_AMOUNTS
+  )
+
   const {
     data: { contentId: trackId },
     isOpen,

--- a/packages/mobile/src/components/premium-track-purchase-drawer/hooks/usePurchaseSummaryValues.ts
+++ b/packages/mobile/src/components/premium-track-purchase-drawer/hooks/usePurchaseSummaryValues.ts
@@ -6,7 +6,8 @@ import {
   getPurchaseSummaryValues,
   PayExtraPreset,
   usePayExtraPresets,
-  useUSDCPurchaseConfig
+  useUSDCPurchaseConfig,
+  StringKeys
 } from '@audius/common'
 import { useField } from 'formik'
 
@@ -19,7 +20,9 @@ export const usePurchaseSummaryValues = ({
 }) => {
   const [{ value: customAmount }] = useField(CUSTOM_AMOUNT)
   const [{ value: amountPreset }] = useField(AMOUNT_PRESET)
-  const presetValues = usePayExtraPresets()
+  const presetValues = usePayExtraPresets(
+    StringKeys.PAY_EXTRA_PRESET_CENT_AMOUNTS
+  )
   const { minUSDCPurchaseAmountCents } = useUSDCPurchaseConfig()
 
   const extraAmount = getExtraAmount({

--- a/packages/web/src/components/add-funds-modal/constants.ts
+++ b/packages/web/src/components/add-funds-modal/constants.ts
@@ -1,0 +1,9 @@
+export const AMOUNT_PRESET = 'amountPreset'
+export const CUSTOM_AMOUNT = 'customAmount'
+
+// Pay between $1 and $100 extra
+export const minimumPayExtraAmountCents = 100
+export const maximumPayExtraAmountCents = 10000
+
+export const CENTS_TO_USDC_MULTIPLIER = 10000
+export const DEFAULT_PURCHASE_AMOUNT_CENTS = 10 * 100

--- a/packages/web/src/components/add-funds-modal/types.ts
+++ b/packages/web/src/components/add-funds-modal/types.ts
@@ -1,0 +1,14 @@
+/** Denotes the 3 preset amounts to show on the form, values are in cents. */
+export type PayExtraAmountPresetValues = {
+  [PayExtraPreset.LOW]: number
+  [PayExtraPreset.MEDIUM]: number
+  [PayExtraPreset.HIGH]: number
+}
+
+export enum PayExtraPreset {
+  LOW = 'low',
+  MEDIUM = 'medium',
+  HIGH = 'high',
+  CUSTOM = 'custom',
+  NONE = 'none'
+}

--- a/packages/web/src/components/add-funds-modal/validation.ts
+++ b/packages/web/src/components/add-funds-modal/validation.ts
@@ -1,0 +1,40 @@
+import { z } from 'zod'
+
+import {
+  AMOUNT_PRESET,
+  CUSTOM_AMOUNT,
+  maximumPayExtraAmountCents,
+  minimumPayExtraAmountCents
+} from './constants'
+import { PayExtraPreset } from './types'
+
+const messages = {
+  amountInvalid: 'Please specify an amount between $1 and $100'
+}
+
+const createPurchaseContentSchema = () => {
+  return z
+    .object({
+      [CUSTOM_AMOUNT]: z
+        .number({
+          required_error: messages.amountInvalid,
+          invalid_type_error: messages.amountInvalid
+        })
+        .optional(),
+      [AMOUNT_PRESET]: z.nativeEnum(PayExtraPreset)
+    })
+    .refine(
+      ({ amountPreset, customAmount }) => {
+        if (amountPreset !== PayExtraPreset.CUSTOM) return true
+        return (
+          customAmount &&
+          customAmount >= minimumPayExtraAmountCents &&
+          customAmount <= maximumPayExtraAmountCents
+        )
+      },
+      { message: messages.amountInvalid, path: [CUSTOM_AMOUNT] }
+    )
+}
+
+export const AddFundsSchema = createPurchaseContentSchema()
+export type AddFundsValues = z.input<typeof AddFundsSchema>

--- a/packages/web/src/components/add-funds/AddFunds.tsx
+++ b/packages/web/src/components/add-funds/AddFunds.tsx
@@ -4,7 +4,9 @@ import {
   PurchaseMethod,
   PurchaseVendor,
   useCreateUserbankIfNeeded,
-  useUSDCBalance
+  useUSDCBalance,
+  PayExtraPreset,
+  CUSTOM_AMOUNT
 } from '@audius/common'
 import { USDC } from '@audius/fixed-decimal'
 import {
@@ -17,7 +19,9 @@ import {
 } from '@audius/harmony'
 import { BN } from 'bn.js'
 import cn from 'classnames'
+import { useField } from 'formik'
 
+import { AMOUNT_PRESET } from 'components/add-funds-modal/constants'
 import { PaymentMethod } from 'components/payment-method/PaymentMethod'
 import { track } from 'services/analytics'
 import { audiusBackendInstance } from 'services/audius-backend/audius-backend-instance'
@@ -33,10 +37,17 @@ const messages = {
 export const AddFunds = ({
   onContinue
 }: {
-  onContinue: (
-    purchaseMethod: PurchaseMethod,
+  onContinue: ({
+    purchaseMethod,
+    purchaseVendor,
+    amountPreset,
+    customAmount
+  }: {
+    purchaseMethod: PurchaseMethod
     purchaseVendor?: PurchaseVendor
-  ) => void
+    amountPreset?: PayExtraPreset
+    customAmount?: number
+  }) => void
 }) => {
   useCreateUserbankIfNeeded({
     recordAnalytics: track,
@@ -48,6 +59,8 @@ export const AddFunds = ({
   const [selectedPurchaseVendor, setSelectedPurchaseVendor] = useState<
     PurchaseVendor | undefined
   >(undefined)
+  const [{ value: amountPreset }, ,] = useField(AMOUNT_PRESET)
+  const [{ value: customAmount }, ,] = useField<number>(CUSTOM_AMOUNT)
 
   const mobile = isMobile()
   const { data: balanceBN } = useUSDCBalance({ isPolling: true })
@@ -82,14 +95,21 @@ export const AddFunds = ({
           </Box>
           <PaymentMethod
             selectedMethod={selectedPurchaseMethod}
+            selectedVendor={selectedPurchaseVendor}
             setSelectedMethod={setSelectedPurchaseMethod}
             setSelectedVendor={setSelectedPurchaseVendor}
+            showCoinflowAmounts={true}
           />
           <Button
             variant={ButtonType.PRIMARY}
             fullWidth
             onClick={() =>
-              onContinue(selectedPurchaseMethod, selectedPurchaseVendor)
+              onContinue({
+                purchaseMethod: selectedPurchaseMethod,
+                purchaseVendor: selectedPurchaseVendor,
+                amountPreset,
+                customAmount
+              })
             }
           >
             {messages.continue}

--- a/packages/web/src/components/payment-method/PaymentMethod.tsx
+++ b/packages/web/src/components/payment-method/PaymentMethod.tsx
@@ -1,4 +1,4 @@
-import { CSSProperties, ChangeEvent, useCallback, useState } from 'react'
+import { CSSProperties, ChangeEvent, useCallback } from 'react'
 
 import {
   BNUSDC,
@@ -11,7 +11,6 @@ import {
   useFeatureFlag,
   usePayExtraPresets,
   StringKeys,
-  PayExtraPreset,
   AMOUNT_PRESET
 } from '@audius/common'
 import {

--- a/packages/web/src/components/payment-method/PaymentMethod.tsx
+++ b/packages/web/src/components/payment-method/PaymentMethod.tsx
@@ -1,4 +1,4 @@
-import { CSSProperties, ChangeEvent, useCallback } from 'react'
+import { CSSProperties, ChangeEvent, useCallback, useState } from 'react'
 
 import {
   BNUSDC,
@@ -8,7 +8,11 @@ import {
   PurchaseVendor,
   formatCurrencyBalance,
   formatUSDCWeiToFloorCentsNumber,
-  useFeatureFlag
+  useFeatureFlag,
+  usePayExtraPresets,
+  StringKeys,
+  PayExtraPreset,
+  AMOUNT_PRESET
 } from '@audius/common'
 import {
   FilterButton,
@@ -22,6 +26,7 @@ import { RadioButton, RadioButtonGroup } from '@audius/stems'
 import BN from 'bn.js'
 
 import { MobileFilterButton } from 'components/mobile-filter-button/MobileFilterButton'
+import { PayExtraFormSection } from 'components/premium-content-purchase-modal/components/PayExtraFormSection'
 import { SummaryTable, SummaryTableItem } from 'components/summary-table'
 import { Text } from 'components/typography'
 import { isMobile } from 'utils/clientUtil'
@@ -31,25 +36,30 @@ const messages = {
   paymentMethod: 'Payment Method',
   withExistingBalance: 'Existing balance',
   withCard: 'Pay with card',
-  withCrypto: 'Add via crypto transfer'
+  withCrypto: 'Add via crypto transfer',
+  amountPickerTitle: 'Select desired amount'
 }
 
 type PaymentMethodProps = {
   selectedMethod: Nullable<PurchaseMethod>
   setSelectedMethod: (method: PurchaseMethod) => void
+  selectedVendor?: Nullable<PurchaseVendor>
   setSelectedVendor: (vendor: PurchaseVendor) => void
   balance?: Nullable<BNUSDC>
   isExistingBalanceDisabled?: boolean
   showExistingBalance?: boolean
+  showCoinflowAmounts?: boolean
 }
 
 export const PaymentMethod = ({
   selectedMethod,
   setSelectedMethod,
+  selectedVendor,
   setSelectedVendor,
   balance,
   isExistingBalanceDisabled,
-  showExistingBalance
+  showExistingBalance,
+  showCoinflowAmounts
 }: PaymentMethodProps) => {
   const { isEnabled: isCoinflowEnabled } = useFeatureFlag(
     FeatureFlags.BUY_WITH_COINFLOW
@@ -63,6 +73,12 @@ export const PaymentMethod = ({
     ...(isCoinflowEnabled ? [{ label: PurchaseVendor.COINFLOW }] : []),
     { label: PurchaseVendor.STRIPE }
   ]
+  const amountPresets = usePayExtraPresets(
+    StringKeys.COINFLOW_ADD_FUNDS_PRESET_CENT_AMOUNTS
+  )
+
+  const shouldShowCoinflowAmountPicker =
+    showCoinflowAmounts && selectedVendor === PurchaseVendor.COINFLOW
 
   const handleSelectVendor = useCallback(
     (label: string) => {
@@ -115,7 +131,16 @@ export const PaymentMethod = ({
               popupZIndex={zIndex.USDC_ADD_FUNDS_FILTER_BUTTON_POPUP}
             />
           )
-        ) : null
+        ) : null,
+      extraContent: shouldShowCoinflowAmountPicker ? (
+        <Flex w='100%'>
+          <PayExtraFormSection
+            title={messages.amountPickerTitle}
+            amountPresets={amountPresets}
+            fieldName={AMOUNT_PRESET}
+          />
+        </Flex>
+      ) : null
     },
     {
       id: PurchaseMethod.CRYPTO,
@@ -155,39 +180,47 @@ export const PaymentMethod = ({
         onChange={handleRadioChange}
         style={{ width: '100%' }}
       >
-        {options.map(({ id, label, icon: Icon, value, disabled }) => (
-          <Flex
-            key={id}
-            {...getFlexProps(id as PurchaseMethod)}
-            pv='m'
-            ph='xl'
-            css={{ opacity: disabled ? 0.5 : 1 }}
-            borderTop='default'
-          >
+        {options.map(
+          ({ id, label, icon: Icon, value, disabled, extraContent }) => (
             <Flex
-              onClick={() => setSelectedMethod(id as PurchaseMethod)}
-              css={{ cursor: 'pointer' }}
-              alignItems='center'
-              justifyContent='space-between'
-              gap='s'
+              key={id}
+              pv='m'
+              ph='xl'
+              css={{ opacity: disabled ? 0.5 : 1 }}
+              borderTop='default'
+              {...getFlexProps(id as PurchaseMethod)}
+              direction='column'
+              gap='l'
             >
-              <RadioButton value={id} disabled={disabled} />
-              {Icon ? (
-                <Flex alignItems='center' ml='s'>
-                  <Icon color='default' />
+              <Flex {...getFlexProps(id as PurchaseMethod)} w='100%'>
+                <Flex
+                  onClick={() => setSelectedMethod(id as PurchaseMethod)}
+                  css={{ cursor: 'pointer' }}
+                  alignItems='center'
+                  justifyContent='space-between'
+                  gap='s'
+                >
+                  <RadioButton value={id} disabled={disabled} />
+                  {Icon ? (
+                    <Flex alignItems='center' ml='s'>
+                      <Icon color='default' />
+                    </Flex>
+                  ) : null}
+                  <Text>{label}</Text>
                 </Flex>
-              ) : null}
-              <Text>{label}</Text>
+                <Text
+                  css={{
+                    width:
+                      mobile && id === PurchaseMethod.CARD ? '100%' : 'auto'
+                  }}
+                >
+                  {value}
+                </Text>
+              </Flex>
+              {extraContent}
             </Flex>
-            <Text
-              css={{
-                width: mobile && id === PurchaseMethod.CARD ? '100%' : 'auto'
-              }}
-            >
-              {value}
-            </Text>
-          </Flex>
-        ))}
+          )
+        )}
       </RadioButtonGroup>
     )
   }

--- a/packages/web/src/components/premium-content-purchase-modal/PremiumContentPurchaseModal.tsx
+++ b/packages/web/src/components/premium-content-purchase-modal/PremiumContentPurchaseModal.tsx
@@ -13,7 +13,8 @@ import {
   purchaseContentSelectors,
   isContentPurchaseInProgress,
   usePayExtraPresets,
-  PurchaseContentPage
+  PurchaseContentPage,
+  StringKeys
 } from '@audius/common'
 import { USDC } from '@audius/fixed-decimal'
 import { Box, Flex } from '@audius/harmony'
@@ -179,7 +180,9 @@ export const PremiumContentPurchaseModal = () => {
   const stage = useSelector(getPurchaseContentFlowStage)
   const error = useSelector(getPurchaseContentError)
   const isUnlocking = !error && isContentPurchaseInProgress(stage)
-  const presetValues = usePayExtraPresets()
+  const presetValues = usePayExtraPresets(
+    StringKeys.PAY_EXTRA_PRESET_CENT_AMOUNTS
+  )
 
   const { data: track } = useGetTrackById(
     { id: trackId! },

--- a/packages/web/src/components/premium-content-purchase-modal/components/PayExtraFormSection.tsx
+++ b/packages/web/src/components/premium-content-purchase-modal/components/PayExtraFormSection.tsx
@@ -1,5 +1,4 @@
 import {
-  AMOUNT_PRESET,
   CUSTOM_AMOUNT,
   PayExtraAmountPresetValues,
   PayExtraPreset
@@ -12,7 +11,6 @@ import { PriceField } from 'components/form-fields/PriceField'
 import styles from './PayExtraFormSection.module.css'
 
 const messages = {
-  payExtra: 'Pay Extra',
   customAmount: 'Custom Amount',
   other: 'Other',
   placeholder: 'Enter a value'
@@ -21,29 +19,33 @@ const messages = {
 const formatPillAmount = (val: number) => `$${Math.floor(val / 100)}`
 
 export type PayExtraFormSectionProps = {
+  title: string
+  fieldName: string
   amountPresets: PayExtraAmountPresetValues
   disabled?: boolean
 }
 
 export const PayExtraFormSection = ({
+  title,
+  fieldName,
   amountPresets,
   disabled
 }: PayExtraFormSectionProps) => {
-  const [{ value: preset }, , { setValue: setPreset }] = useField(AMOUNT_PRESET)
+  const [{ value: preset }, , { setValue: setPreset }] = useField(fieldName)
 
   const handleClickPreset = (newPreset: PayExtraPreset) => {
     setPreset(newPreset === preset ? PayExtraPreset.NONE : newPreset)
   }
 
   return (
-    <Flex gap='s' direction='column'>
+    <Flex gap='s' direction='column' w='100%'>
       <Text
         variant='label'
         strength='strong'
         color='subdued'
         className={styles.title}
       >
-        {messages.payExtra}
+        {title}
       </Text>
       <Flex gap='s' w='100%'>
         <SelectablePill

--- a/packages/web/src/components/premium-content-purchase-modal/components/PurchaseContentFormFields.tsx
+++ b/packages/web/src/components/premium-content-purchase-modal/components/PurchaseContentFormFields.tsx
@@ -10,8 +10,7 @@ import {
   usePurchaseMethod,
   PurchaseMethod,
   StringKeys,
-  AMOUNT_PRESET,
-  CUSTOM_AMOUNT
+  AMOUNT_PRESET
 } from '@audius/common'
 import { Flex } from '@audius/harmony'
 import { IconCheck } from '@audius/stems'
@@ -50,13 +49,7 @@ export const PurchaseContentFormFields = ({
   )
   const [{ value: purchaseMethod }, , { setValue: setPurchaseMethod }] =
     useField(PURCHASE_METHOD)
-  const [{ value: preset }, , { setValue: setPreset }] = useField(AMOUNT_PRESET)
   const [, , { setValue: setPurchaseVendor }] = useField(PURCHASE_VENDOR)
-  const [
-    { value: customAmount },
-    ,
-    { setValue: setCustomAmount, setTouched: setCustomAmountTouched }
-  ] = useField<number>(CUSTOM_AMOUNT)
   const isPurchased = stage === PurchaseContentStage.FINISH
 
   const { data: balanceBN } = useUSDCBalance({ isPolling: true })

--- a/packages/web/src/components/premium-content-purchase-modal/components/PurchaseContentFormFields.tsx
+++ b/packages/web/src/components/premium-content-purchase-modal/components/PurchaseContentFormFields.tsx
@@ -8,7 +8,10 @@ import {
   PurchaseVendor,
   PURCHASE_VENDOR,
   usePurchaseMethod,
-  PurchaseMethod
+  PurchaseMethod,
+  StringKeys,
+  AMOUNT_PRESET,
+  CUSTOM_AMOUNT
 } from '@audius/common'
 import { Flex } from '@audius/harmony'
 import { IconCheck } from '@audius/stems'
@@ -27,6 +30,7 @@ import styles from './PurchaseContentFormFields.module.css'
 import { PurchaseSummaryTable } from './PurchaseSummaryTable'
 
 const messages = {
+  payExtraTitle: 'Pay Extra',
   purchaseSuccessful: 'Your Purchase Was Successful!'
 }
 
@@ -41,10 +45,18 @@ export const PurchaseContentFormFields = ({
   stage,
   isUnlocking
 }: PurchaseContentFormFieldsProps) => {
-  const payExtraAmountPresetValues = usePayExtraPresets()
+  const payExtraAmountPresetValues = usePayExtraPresets(
+    StringKeys.PAY_EXTRA_PRESET_CENT_AMOUNTS
+  )
   const [{ value: purchaseMethod }, , { setValue: setPurchaseMethod }] =
     useField(PURCHASE_METHOD)
+  const [{ value: preset }, , { setValue: setPreset }] = useField(AMOUNT_PRESET)
   const [, , { setValue: setPurchaseVendor }] = useField(PURCHASE_VENDOR)
+  const [
+    { value: customAmount },
+    ,
+    { setValue: setCustomAmount, setTouched: setCustomAmountTouched }
+  ] = useField<number>(CUSTOM_AMOUNT)
   const isPurchased = stage === PurchaseContentStage.FINISH
 
   const { data: balanceBN } = useUSDCBalance({ isPolling: true })
@@ -90,8 +102,10 @@ export const PurchaseContentFormFields = ({
     <>
       {isUnlocking || isPurchased ? null : (
         <PayExtraFormSection
+          title={messages.payExtraTitle}
           amountPresets={payExtraAmountPresetValues}
           disabled={isUnlocking}
+          fieldName={AMOUNT_PRESET}
         />
       )}
       <PurchaseSummaryTable

--- a/packages/web/src/components/premium-content-purchase-modal/hooks/usePurchaseSummaryValues.ts
+++ b/packages/web/src/components/premium-content-purchase-modal/hooks/usePurchaseSummaryValues.ts
@@ -7,7 +7,8 @@ import {
   getPurchaseSummaryValues,
   PayExtraPreset,
   usePayExtraPresets,
-  useUSDCPurchaseConfig
+  useUSDCPurchaseConfig,
+  StringKeys
 } from '@audius/common'
 import { useField } from 'formik'
 
@@ -20,7 +21,9 @@ export const usePurchaseSummaryValues = ({
 }) => {
   const [{ value: customAmount }] = useField(CUSTOM_AMOUNT)
   const [{ value: amountPreset }] = useField(AMOUNT_PRESET)
-  const presetValues = usePayExtraPresets()
+  const presetValues = usePayExtraPresets(
+    StringKeys.PAY_EXTRA_PRESET_CENT_AMOUNTS
+  )
   const { minUSDCPurchaseAmountCents } = useUSDCPurchaseConfig()
 
   const extraAmount = getExtraAmount({

--- a/packages/web/src/components/summary-table/SummaryTable.tsx
+++ b/packages/web/src/components/summary-table/SummaryTable.tsx
@@ -16,6 +16,7 @@ export type SummaryTableItem = {
   icon?: IconComponent
   value?: ReactNode
   disabled?: boolean
+  extraContent?: ReactNode
 }
 
 const Expandable = ({


### PR DESCRIPTION
### Description
Implements an amount picker that appears when coinflow is the selected vendor in the add funds modal.

This is somewhat wet and I'm sure could use some cleanup, I took the fastest path to getting a working solution.

Note - this is for web + mobile-web only, didn't have time to get to mobile.

### How Has This Been Tested?

Local web

https://github.com/AudiusProject/audius-protocol/assets/3893871/f052bf94-6504-474e-bf36-e902dc9ef921

<img width="1728" alt="Screenshot 2023-12-15 at 12 26 32 AM" src="https://github.com/AudiusProject/audius-protocol/assets/3893871/e878d652-75cb-49e6-8129-54095493c97f">
