### PR TITLE
Make finding slow queries compatible with pg 13+

### DIFF
--- a/packages/discovery-provider/src/monitors/database.py
+++ b/packages/discovery-provider/src/monitors/database.py
@@ -133,11 +133,24 @@ def get_slow_queries(**kwargs):
         redis: global redis instance
     """
     db = kwargs["db"]
+
+    version_query = sqlalchemy.text("SHOW server_version_num;")
     with db.scoped_session() as session:
-        q = sqlalchemy.text(
-            "SELECT query, mean_time FROM pg_stat_statements ORDER BY mean_time DESC LIMIT 100"
-        )
+        version = session.execute(version_query).scalar()
+        version = int(version)
+
+        if version >= 130000: # postgres 13 or later
+            query_text = """
+            SELECT query, mean_plan_time, mean_exec_time, (mean_plan_time + mean_exec_time) AS total_mean_time
+            FROM pg_stat_statements 
+            ORDER BY total_mean_time DESC 
+            LIMIT 100
+            """
+        else:
+            query_text = "SELECT query, mean_time FROM pg_stat_statements ORDER BY mean_time DESC LIMIT 100"
+
+        q = sqlalchemy.text(query_text)
         result = session.execute(q).fetchall()
         slow_queries = [dict(row) for row in result]
 
-        return json.dumps(slow_queries)
+    return json.dumps(slow_queries)

--- a/packages/discovery-provider/src/monitors/database.py
+++ b/packages/discovery-provider/src/monitors/database.py
@@ -139,7 +139,7 @@ def get_slow_queries(**kwargs):
         version = session.execute(version_query).scalar()
         version = int(version)
 
-        if version >= 130000: # postgres 13 or later
+        if version >= 130000:  # postgres 13 or later
             query_text = """
             SELECT query, mean_plan_time, mean_exec_time, (mean_plan_time + mean_exec_time) AS total_mean_time
             FROM pg_stat_statements 


### PR DESCRIPTION
### Description
As per [the docs](https://www.postgresql.org/docs/13/pgstatstatements.html), starting in Postgres 13, the pg_stat_statements mean_time column was split into mean_exec_time and mean_plan_time. This PR updates our query to find slow queries by taking into account the Postgres version and using the appropriate tables.

### How Has This Been Tested?
On a stage node, this code makes slow queries display in the verbose health check - now broken down by planning time vs execution time.

<img width="1605" alt="slow queries" src="https://github.com/AudiusProject/audius-protocol/assets/4657956/d648cde8-32fc-421a-9dd0-902516b99c7a">
