### PR TITLE
Use retry logic for coinflow

### DIFF
--- a/packages/libs/src/services/solana/transactionHandler.ts
+++ b/packages/libs/src/services/solana/transactionHandler.ts
@@ -193,9 +193,10 @@ export class TransactionHandler {
       feePayerAccount?.publicKey ??
       (feePayerOverride ? new PublicKey(feePayerOverride) : null)
 
-    const alreadySigned = !signatures?.some(
+    const alreadySigned = signatures?.some(
       (s) =>
-        s.publicKey === feePayerOverride && !s.signature.every((b) => b === 0)
+        s.publicKey === feePayerOverride?.toString() &&
+        !s.signature.every((b) => b === 0)
     )
     if (!feePayerPubKey || (!feePayerAccount && !alreadySigned)) {
       logger.error(

--- a/packages/libs/src/services/solana/transactionHandler.ts
+++ b/packages/libs/src/services/solana/transactionHandler.ts
@@ -189,7 +189,15 @@ export class TransactionHandler {
 
     const feePayerAccount =
       feePayerKeypairOverride ?? this.feePayerKeypairs?.[0]
-    if (!feePayerAccount) {
+    const feePayerPubKey =
+      feePayerAccount?.publicKey ??
+      (feePayerOverride ? new PublicKey(feePayerOverride) : null)
+
+    const alreadySigned = !signatures?.some(
+      (s) =>
+        s.publicKey === feePayerOverride && !s.signature.every((b) => b === 0)
+    )
+    if (!feePayerPubKey || (!feePayerAccount && !alreadySigned)) {
       logger.error(
         'transactionHandler: Local feepayer keys missing for direct confirmation!'
       )
@@ -230,12 +238,14 @@ export class TransactionHandler {
         }
       }
       const message = new TransactionMessage({
-        payerKey: feePayerAccount.publicKey,
+        payerKey: feePayerPubKey,
         recentBlockhash,
         instructions
       }).compileToV0Message(lookupTableAccounts)
       const tx = new VersionedTransaction(message)
-      tx.sign([feePayerAccount])
+      if (feePayerAccount) {
+        tx.sign([feePayerAccount])
+      }
       if (Array.isArray(signatures)) {
         signatures.forEach(({ publicKey, signature }) => {
           tx.addSignature(new PublicKey(publicKey), signature)
@@ -247,8 +257,10 @@ export class TransactionHandler {
       const tx = new Transaction()
       tx.recentBlockhash = recentBlockhash
       instructions.forEach((i) => tx.add(i))
-      tx.feePayer = feePayerAccount.publicKey
-      tx.sign(feePayerAccount)
+      tx.feePayer = feePayerPubKey
+      if (feePayerAccount) {
+        tx.sign(feePayerAccount)
+      }
       if (Array.isArray(signatures)) {
         signatures.forEach(({ publicKey, signature }) => {
           tx.addSignature(new PublicKey(publicKey), signature)


### PR DESCRIPTION
### Description

Adjusts wallet adapter to use TransactionHandler so that we can use the retry logic. Adjusts TransactionHandler to not need to have the signer if the transaction already is signed.

### How Has This Been Tested?

Tested locally against prod on web.
