### PR TITLE
[PAY-2274] Update minWidths of pay extra pills to prevent clipping

### DIFF
--- a/packages/mobile/src/components/premium-track-purchase-drawer/PayExtraFormSection.tsx
+++ b/packages/mobile/src/components/premium-track-purchase-drawer/PayExtraFormSection.tsx
@@ -22,13 +22,18 @@ const useStyles = makeStyles(({ spacing }) => ({
   },
   presetContainer: {
     ...flexRowCentered(),
+    flexWrap: 'wrap',
     gap: spacing(2),
     width: '100%'
   },
   pill: {
     flexGrow: 1,
     flexShrink: 1,
-    flexBasis: 0
+    flexBasis: 0,
+    minWidth: spacing(10)
+  },
+  customPill: {
+    minWidth: spacing(20)
   },
   title: {
     letterSpacing: 0.5
@@ -99,7 +104,7 @@ export const PayExtraFormSection = ({
         />
         <HarmonySelectablePill
           size='large'
-          style={styles.pill}
+          style={[styles.pill, styles.customPill]}
           isSelected={preset === PayExtraPreset.CUSTOM}
           label={messages.other}
           disabled={disabled}


### PR DESCRIPTION
### Description
Fixes PAY-2274

This adds explicit minWidths to the pills in the "pay extra" section and adds wrapping ability to the container in case the pills take up too much space.

### How Has This Been Tested?
Tested on iOS simulator by increasing system font size and hard-coding larger min widths to trigger wrapping behavior.
