### PR TITLE
[PAY-2283] Disable purchase button immediately after click

### DIFF
--- a/packages/common/src/store/purchase-content/sagas.ts
+++ b/packages/common/src/store/purchase-content/sagas.ts
@@ -232,21 +232,16 @@ function* purchaseWithCoinflow({
 
   // Return early for failure or cancellation
   if (result.canceled) {
-    yield* put(purchaseCanceled())
-    return
-  }
-  if (result.failed) {
-    yield* put(
-      // TODO: better error
-      purchaseContentFlowFailed({
-        error: new PurchaseContentError(
-          PurchaseErrorCode.Unknown,
-          'Coinflow transaction failed'
-        )
-      })
+    throw new PurchaseContentError(
+      PurchaseErrorCode.Canceled,
+      'Coinflow transaction canceled'
     )
   }
+  if (result.failed) {
+    throw result.failed.payload.error
+  }
 }
+
 type PurchaseUSDCWithStripeArgs = {
   /** Amount of USDC to purchase, as dollars */
   amount: number

--- a/packages/common/src/store/purchase-content/slice.ts
+++ b/packages/common/src/store/purchase-content/slice.ts
@@ -37,7 +37,7 @@ const initialState: PurchaseContentState = {
   extraAmount: undefined,
   extraAmountPreset: undefined,
   error: undefined,
-  stage: PurchaseContentStage.START,
+  stage: PurchaseContentStage.IDLE,
   purchaseMethod: PurchaseMethod.BALANCE,
   purchaseVendor: undefined
 }

--- a/packages/common/src/store/purchase-content/types.ts
+++ b/packages/common/src/store/purchase-content/types.ts
@@ -7,6 +7,7 @@ export enum ContentType {
 }
 
 export enum PurchaseContentStage {
+  IDLE = 'IDLE',
   START = 'START',
   BUY_USDC = 'BUY_USDC',
   PURCHASING = 'PURCHASING',

--- a/packages/common/src/store/purchase-content/utils.ts
+++ b/packages/common/src/store/purchase-content/utils.ts
@@ -10,6 +10,7 @@ export const zeroBalance = () => new BN(0) as BNUSDC
 
 export const isContentPurchaseInProgress = (stage: PurchaseContentStage) => {
   return [
+    PurchaseContentStage.START,
     PurchaseContentStage.BUY_USDC,
     PurchaseContentStage.PURCHASING,
     PurchaseContentStage.CONFIRMING_PURCHASE

--- a/packages/common/src/store/ui/coinflow-modal/slice.ts
+++ b/packages/common/src/store/ui/coinflow-modal/slice.ts
@@ -9,7 +9,7 @@ const slice = createSlice({
     transactionSucceeded: (_state, _action: PayloadAction<{}>) => {
       // Handled by saga
     },
-    transactionFailed: (_state, _action: PayloadAction<{}>) => {
+    transactionFailed: (_state, _action: PayloadAction<{ error: Error }>) => {
       // Handled by saga
     },
     transactionCanceled: (_state, _action: PayloadAction<{}>) => {

--- a/packages/web/src/components/coinflow-onramp-modal/CoinflowOnrampModal.tsx
+++ b/packages/web/src/components/coinflow-onramp-modal/CoinflowOnrampModal.tsx
@@ -14,7 +14,7 @@ import zIndex from 'utils/zIndex'
 
 import styles from './CoinflowOnrampModal.module.css'
 
-const { transactionSucceeded } = coinflowModalUIActions
+const { transactionSucceeded, transactionCanceled } = coinflowModalUIActions
 
 const MERCHANT_ID = process.env.VITE_COINFLOW_MERCHANT_ID
 const IS_PRODUCTION = process.env.VITE_ENVIRONMENT === 'production'
@@ -46,6 +46,11 @@ export const CoinflowOnrampModal = () => {
     }
   }, [serializedTransaction])
 
+  const handleClose = useCallback(() => {
+    dispatch(transactionCanceled({}))
+    onClose()
+  }, [dispatch, onClose])
+
   const handleSuccess = useCallback(() => {
     dispatch(transactionSucceeded({}))
     onClose()
@@ -60,7 +65,7 @@ export const CoinflowOnrampModal = () => {
       zIndex={zIndex.COINFLOW_ONRAMP_MODAL}
       isFullscreen
       isOpen={isOpen}
-      onClose={onClose}
+      onClose={handleClose}
       onClosed={onClosed}
     >
       {showContent ? (


### PR DESCRIPTION
### Description

Fixes PAY-2283

Disables the purchase button immediately upon the purchase action being fired.

### How Has This Been Tested?

Tested by commenting out the actual purchase and adding a console log, and verifying that even if I smashed that purchase button as fast as I could that I couldn't get the log to appear twice.