### PR TITLE
Limit mediorum ffmpeg CPU and logs

### DIFF
--- a/mediorum/server/transcode.go
+++ b/mediorum/server/transcode.go
@@ -355,7 +355,8 @@ func (ss *MediorumServer) transcodeFullAudio(upload *Upload, temp *os.File, logg
 		"-f", "mp3", // force output to mp3
 		"-metadata", fmt.Sprintf(`fileName="%s"`, upload.OrigFileName),
 		"-metadata", fmt.Sprintf(`uuid="%s"`, upload.ID), // make each upload unique so artists can re-upload same file with different CID if it gets delisted
-		"-vn", // no video
+		"-vn",           // no video
+		"-threads", "2", // limit to 2 threads per worker to avoid CPU spikes
 		"-progress", "pipe:2",
 		destPath)
 
@@ -457,6 +458,26 @@ func (ss *MediorumServer) transcodeAudioPreview(upload *Upload, temp *os.File, l
 	return nil
 }
 
+func filterErrorLines(input string, errorTypes []string, maxCount int) string {
+	lines := strings.Split(input, "\n")
+	var builder strings.Builder
+	errorCounts := make(map[string]int)
+
+	for _, line := range lines {
+		for _, errorType := range errorTypes {
+			if strings.Contains(line, errorType) {
+				if errorCounts[errorType] < maxCount {
+					errorCounts[errorType]++
+					builder.WriteString(line + "\n")
+				}
+				break
+			}
+		}
+	}
+
+	return builder.String()
+}
+
 func (ss *MediorumServer) transcode(upload *Upload) error {
 	upload.TranscodedBy = ss.Config.Self.Host
 	upload.TranscodedAt = time.Now().UTC()
@@ -477,7 +498,20 @@ func (ss *MediorumServer) transcode(upload *Upload) error {
 	logger := ss.logger.With("template", upload.Template, "cid", fileHash)
 
 	onError := func(err error, uploadStatus string, info ...string) error {
-		errMsg := fmt.Errorf("%s %s", err, strings.Join(info, " "))
+		// limit repetitive lines
+		errorTypes := []string{
+			"Header missing",
+			"Error while decoding",
+			"Invalid data",
+			"Application provided invalid",
+			"nout_time_ms=",
+			"nout_time_us",
+			"bitrate=",
+			"progress=",
+		}
+		filteredError := filterErrorLines(err.Error(), errorTypes, 10)
+		errMsg := fmt.Errorf("%s %s", filteredError, strings.Join(info, " "))
+
 		upload.Error = errMsg.Error()
 		if uploadStatus == JobStatusRetranscode || uploadStatus == JobStatusBusyRetranscode {
 			upload.Status = JobStatusErrorRetranscode
@@ -486,7 +520,6 @@ func (ss *MediorumServer) transcode(upload *Upload) error {
 		}
 		upload.ErrorCount = upload.ErrorCount + 1
 		ss.crud.Update(upload)
-		logger.Error("transcode error", "err", errMsg.Error())
 		return errMsg
 	}
 


### PR DESCRIPTION
### Description
- Filters out log lines that are duplicated >10 times
- Limits threads to 2 per ffmpeg worker (2 workers). This could instead do it based on available resources, but I figured 2*2 threads is a good lower estimate

### How Has This Been Tested?
TODO: more stage testing