### PR TITLE
[PROTO-1524] Invalidate cache on refresh

### DIFF
--- a/packages/common/src/store/lineup/actions.ts
+++ b/packages/common/src/store/lineup/actions.ts
@@ -247,9 +247,11 @@ export class LineupActions {
   refreshInView(
     overwrite = false,
     payload?: unknown,
-    limit: number | null = null
+    limit: number | null = null,
+    other?: Record<string, unknown>
   ) {
     return {
+      ...other,
       type: addPrefix(this.prefix, REFRESH_IN_VIEW),
       overwrite,
       payload,

--- a/packages/mobile/src/components/lineup/Lineup.tsx
+++ b/packages/mobile/src/components/lineup/Lineup.tsx
@@ -216,7 +216,7 @@ export const Lineup = ({
   pullToRefresh,
   rankIconCount = 0,
   refresh: refreshProp,
-  refreshing: refreshingProp,
+  refreshing: refreshingProp = false,
   showLeadingElementArtistPick = true,
   start = 0,
   variant = LineupVariant.MAIN,
@@ -240,9 +240,11 @@ export const Lineup = ({
   const inView = lazy ? lineupInView : true
 
   const handleRefresh = useCallback(() => {
+    if (!refreshing) {
+      dispatch(actions.refreshInView(true, fetchPayload, 10, extraFetchOptions))
+    }
     setRefreshing(true)
-    dispatch(actions.refreshInView(true))
-  }, [dispatch, actions])
+  }, [refreshing, dispatch, actions, fetchPayload, extraFetchOptions])
 
   useEffect(() => {
     if (status !== Status.LOADING) {

--- a/packages/mobile/src/components/lineup/Lineup.tsx
+++ b/packages/mobile/src/components/lineup/Lineup.tsx
@@ -241,10 +241,12 @@ export const Lineup = ({
 
   const handleRefresh = useCallback(() => {
     if (!refreshing) {
-      dispatch(actions.refreshInView(true, fetchPayload, 10, extraFetchOptions))
+      dispatch(
+        actions.refreshInView(true, fetchPayload, limit, extraFetchOptions)
+      )
     }
     setRefreshing(true)
-  }, [refreshing, dispatch, actions, fetchPayload, extraFetchOptions])
+  }, [refreshing, dispatch, actions, fetchPayload, limit, extraFetchOptions])
 
   useEffect(() => {
     if (status !== Status.LOADING) {

--- a/packages/mobile/src/screens/profile-screen/ProfileTabs/RepostsTab.tsx
+++ b/packages/mobile/src/screens/profile-screen/ProfileTabs/RepostsTab.tsx
@@ -40,6 +40,7 @@ export const RepostsTab = () => {
     <Lineup
       selfLoad
       lazy={lazy}
+      pullToRefresh
       actions={feedActions}
       lineup={lineup}
       fetchPayload={fetchPayload}

--- a/packages/mobile/src/screens/profile-screen/ProfileTabs/TracksTab.tsx
+++ b/packages/mobile/src/screens/profile-screen/ProfileTabs/TracksTab.tsx
@@ -33,6 +33,7 @@ export const TracksTab = () => {
   return (
     <Lineup
       selfLoad
+      pullToRefresh
       leadingElementId={artist_pick_track_id}
       actions={tracksActions}
       lineup={lineup}

--- a/packages/web/src/common/store/lineup/sagas.js
+++ b/packages/web/src/common/store/lineup/sagas.js
@@ -702,7 +702,7 @@ export class LineupSagas {
   watchRefreshInView = () => {
     const instance = this
     return function* () {
-      yield takeEvery(
+      yield takeLatest(
         baseLineupActions.addPrefix(
           instance.prefix,
           baseLineupActions.REFRESH_IN_VIEW

--- a/packages/web/src/common/store/lineup/sagas.js
+++ b/packages/web/src/common/store/lineup/sagas.js
@@ -526,16 +526,16 @@ function* updateLineupOrder(lineupPrefix, sourceSelector, action) {
 
 function* refreshInView(lineupActions, lineupSelector, action) {
   const lineup = yield select(lineupSelector)
-  if (lineup.inView) {
-    yield put(
-      lineupActions.fetchLineupMetadatas(
-        0,
-        action.limit || lineup.total,
-        false,
-        action.payload
-      )
+  const { type: _ignoredType, limit, overwrite, payload, ...other } = action
+  yield put(
+    lineupActions.fetchLineupMetadatas(
+      0,
+      limit || lineup.total,
+      overwrite,
+      payload,
+      other
     )
-  }
+  )
 }
 
 const keepUidAndKind = (entry) => ({
@@ -702,7 +702,7 @@ export class LineupSagas {
   watchRefreshInView = () => {
     const instance = this
     return function* () {
-      yield takeLatest(
+      yield takeEvery(
         baseLineupActions.addPrefix(
           instance.prefix,
           baseLineupActions.REFRESH_IN_VIEW


### PR DESCRIPTION
### Description

Updates lineup refresh code to invalidate cache on refresh
Also fixes issue were refresh action wasn't getting "additional options"
