### PR TITLE
Add lock to tracks table for migration

### DIFF
--- a/packages/discovery-provider/ddl/migrations/0044_set_release_to_created_where_null.sql
+++ b/packages/discovery-provider/ddl/migrations/0044_set_release_to_created_where_null.sql
@@ -1,5 +1,6 @@
 begin;
 
+SELECT pg_cancel_backend(pid) FROM pg_stat_activity WHERE state = 'active' and pid <> pg_backend_pid();
 lock table tracks in access exclusive mode;
 
 UPDATE tracks

--- a/packages/discovery-provider/ddl/migrations/0044_set_release_to_created_where_null.sql
+++ b/packages/discovery-provider/ddl/migrations/0044_set_release_to_created_where_null.sql
@@ -1,5 +1,7 @@
 begin;
 
+lock table tracks in access exclusive mode;
+
 UPDATE tracks
 SET release_date = created_at
 WHERE release_date IS NULL;


### PR DESCRIPTION
### Description
Acquires a lock on the tracks table before starting the release_tracks migration. The modified migration was running indefinitely, likely because another container had a lock on the table.