### PR TITLE
Disable triggers while migration runs

### DIFF
--- a/packages/discovery-provider/ddl/migrations/0044_set_release_to_created_where_null.sql
+++ b/packages/discovery-provider/ddl/migrations/0044_set_release_to_created_where_null.sql
@@ -1,10 +1,16 @@
 begin;
 
+alter table tracks disable trigger on_track;
+alter table tracks disable trigger trg_tracks;
+
 SELECT pg_cancel_backend(pid) FROM pg_stat_activity WHERE state = 'active' and pid <> pg_backend_pid();
 lock table tracks in access exclusive mode;
 
 UPDATE tracks
 SET release_date = created_at
 WHERE release_date IS NULL;
+
+alter table tracks enable trigger on_track;
+alter table tracks enable trigger trg_tracks;
 
 commit;


### PR DESCRIPTION
### Description
Temporarily disables triggers on the tracks table while a migration is running. Without this, the migration takes unfeasibly long.

### How Has This Been Tested?
Ran on stage DN4.