### PR TITLE
[PAY-2315] Explicitly cancel transaction when closing coinflow drawer

### DIFF
--- a/packages/mobile/src/components/coinflow-onramp-drawer/CoinflowOnrampDrawer.tsx
+++ b/packages/mobile/src/components/coinflow-onramp-drawer/CoinflowOnrampDrawer.tsx
@@ -45,7 +45,7 @@ const useStyles = makeStyles(({ spacing, palette }) => ({
   }
 }))
 
-const { transactionSucceeded } = coinflowModalUIActions
+const { transactionCanceled, transactionSucceeded } = coinflowModalUIActions
 
 const CoinflowOnrampDrawerHeader = ({ onClose }: { onClose: () => void }) => {
   const styles = useStyles()
@@ -94,6 +94,11 @@ export const CoinflowOnrampDrawer = () => {
     onClose()
   }, [dispatch, onClose])
 
+  const handleClose = useCallback(() => {
+    dispatch(transactionCanceled({}))
+    onClose()
+  }, [dispatch, onClose])
+
   const showContent = isOpen && adapter
 
   return (
@@ -104,7 +109,7 @@ export const CoinflowOnrampDrawer = () => {
       modalName={MODAL_NAME}
       isGestureSupported={false}
       isFullscreen
-      onClose={onClose}
+      onClose={handleClose}
     >
       {showContent ? (
         <CoinflowPurchase


### PR DESCRIPTION
### Description
We missed adding the explicit cancel/close for the coinflow drawer (we do this for the strip drawer). It causes the purchase form to get stuck in a state where it can't be closed.

fixes PAY-2315

### How Has This Been Tested?
Tested locally on simulator against staging.
