### PR TITLE
Lower thresholds for prune and full prune on self-hosted ci machines

### DIFF
--- a/.circleci/scripts/periodic-cleanup
+++ b/.circleci/scripts/periodic-cleanup
@@ -2,8 +2,8 @@
 
 set -eo pipefail
 
-PRUNE_THRESHOLD=80
-FULL_PRUNE_THRESHOLD=60
+PRUNE_THRESHOLD=70
+FULL_PRUNE_THRESHOLD=50
 
 function disk_usage_above_threshold() {
     threshold="$1"


### PR DESCRIPTION
### Description

CI machine disk usage has hit 100% in two instances in the last couple of months, lowering the threshold should make that less likely.

### How Has This Been Tested?

Green builds