### PR TITLE
Add ddex to audius-compose and improve its build

### DIFF
--- a/.circleci/src/workflows/release.yml
+++ b/.circleci/src/workflows/release.yml
@@ -69,7 +69,7 @@ jobs:
       name: push-ddex
       context: [GCP, dockerhub, slack-secrets]
       service: ddex
-      # notify_slack_on_failure: true
+      notify_slack_on_failure: true
 
   - push-arm-image:
       name: push-discovery-provider-arm
@@ -189,7 +189,7 @@ jobs:
         - push-healthz
         - push-protocol-dashboard
         - push-uptime
-        # - push-ddex
+        - push-ddex
         # uncomment these when arm builds are stable
         # - push-identity-service-arm
         # - push-mediorum-arm

--- a/dev-tools/audius-compose
+++ b/dev-tools/audius-compose
@@ -236,6 +236,7 @@ def build(
             "--profile=solana",
             "--profile=block-explorer",
             "--profile=uptime",
+            "--profile=ddex",
             "build",
             *args,
             *services,

--- a/dev-tools/compose/docker-compose.ddex.yml
+++ b/dev-tools/compose/docker-compose.ddex.yml
@@ -1,0 +1,14 @@
+version: '3.9'
+
+services:
+  ddex:
+    container_name: ddex
+    build:
+      context: ${PROJECT_ROOT}/packages/ddex
+      dockerfile: Dockerfile
+      args:
+        app_name: ddex
+        TURBO_TEAM: '${TURBO_TEAM}'
+        TURBO_TOKEN: '${TURBO_TOKEN}'
+    profiles:
+      - ddex

--- a/dev-tools/compose/docker-compose.yml
+++ b/dev-tools/compose/docker-compose.yml
@@ -175,6 +175,14 @@ services:
       service: sla-auditor
     <<: *common
 
+  # DDEX
+
+  ddex:
+    extends:
+      file: docker-compose.ddex.yml
+      service: ddex
+    <<: *common
+
   # Storage (content node)
 
   mediorum:

--- a/packages/ddex/.dockerignore
+++ b/packages/ddex/.dockerignore
@@ -1,0 +1,11 @@
+node_modules/
+dist/
+logs/
+.git/
+.gitignore
+.vscode/
+README.md
+Dockerfile
+.dockerignore
+.env
+.env.*

--- a/packages/ddex/Dockerfile
+++ b/packages/ddex/Dockerfile
@@ -1,14 +1,16 @@
-FROM node:18.17-slim
-
-RUN apt update && apt install -y python3 make gcc g++
-
-ENV WORKDIR /app
-WORKDIR ${WORKDIR}
-
-COPY index.html package.json postcss.config.js tailwind.config.js tsconfig.json tsconfig.node.json vite.config.ts ./
-ADD src ./src
-ADD public ./public
-ADD scripts ./scripts
-RUN chmod +x ./scripts/docker-entrypoint.sh
-
+FROM node:18.17-slim as builder
+RUN apt-get update && apt-get install -y python3 make gcc g++
+WORKDIR /app
+COPY package*.json ./
 RUN npm install
+COPY . .
+RUN npm run build
+
+FROM alpine:latest
+WORKDIR /app
+COPY --from=builder /app/dist /tmp/dist
+
+RUN apk add --no-cache findutils coreutils
+COPY ./scripts/docker-entrypoint.sh /usr/local/bin/
+RUN chmod +x /usr/local/bin/docker-entrypoint.sh
+ENTRYPOINT ["/usr/local/bin/docker-entrypoint.sh"]

--- a/packages/ddex/Dockerfile.fast
+++ b/packages/ddex/Dockerfile.fast
@@ -1,0 +1,14 @@
+# To use this file for testing on staging:
+# 0. npm i && npm run build
+# 1. in docker-compose.ddex.yml, set dockerfile to Dockerfile.fast
+# 2. comment out dist/ in .dockerignore
+# 3. run audius-compose push --prod "ddex" (first do env = os.environ.copy() and env["DOCKER_DEFAULT_PLATFORM"] = "linux/amd64") in the audius-compose build command code)
+
+FROM alpine:latest
+WORKDIR /app
+RUN apk add --no-cache findutils coreutils
+COPY dist /tmp/dist
+
+COPY ./scripts/docker-entrypoint.sh /usr/local/bin/
+RUN chmod +x /usr/local/bin/docker-entrypoint.sh
+ENTRYPOINT ["/usr/local/bin/docker-entrypoint.sh"]

--- a/packages/ddex/scripts/docker-entrypoint.sh
+++ b/packages/ddex/scripts/docker-entrypoint.sh
@@ -1,20 +1,29 @@
 #!/bin/sh
 
-FIRST_RUN_FLAG="./.firstrun"
+# Directory where build artifacts are stored in the image before being copied to the volume
+TEMP_BUILD_DIR="/tmp/dist"
 
-if [ ! -f "$FIRST_RUN_FLAG" ]; then
-    echo "Building dist..."
-    npm run build
+# Directory mounted as a volume
+VOLUME_DIR="/app/dist"
 
-    if [ $? -eq 0 ]; then
-        echo "Successfully built dist"
-        touch "$FIRST_RUN_FLAG"
-    else
-        echo "'npm run build' failed with exit code $?. Exiting..."
-        exit 1
-    fi
-else
-    echo "dist already built"
+# Calculate the current checksum of the temporary build directory
+CHECKSUM_FILE="$VOLUME_DIR/.checksum"
+current_checksum=$(find "$TEMP_BUILD_DIR" -type f -exec md5sum {} \; | md5sum | cut -d' ' -f1)
+
+# Read the last checksum (if it exists)
+last_checksum=""
+if [ -f "$CHECKSUM_FILE" ]; then
+    last_checksum=$(cat "$CHECKSUM_FILE")
 fi
 
-exec npm run serve
+# Compare checksums and copy if different
+if [ "$current_checksum" != "$last_checksum" ]; then
+    echo "Changes detected. Updating files in volume..."
+    cp -r $TEMP_BUILD_DIR/* $VOLUME_DIR/
+    echo "$current_checksum" > "$CHECKSUM_FILE"
+else
+    echo "No changes detected. No update needed."
+fi
+
+# Keep the container running by tailing /dev/null
+tail -f /dev/null


### PR DESCRIPTION
### Description
- Makes` audius-compose push --prod ddex` work
- Improves the ddex Dockerfile caching (not reinstalling packages if only the source changes but not packages.json)
- Makes the ddex Dockerfile have a much smaller output (5MB vs 470MB) and use the entrypoint to copy files instead of rebuilding (saves a ton of CPU+memory each time)

### How Has This Been Tested?
Tested on stage DN5, including updating the code to verify that it updates the mounted volume for changes but doesn't do anything when there are no changes.