### PR TITLE
Make CI sed more specific

### DIFF
--- a/.circleci/src/jobs/commit-audius-docker-compose-and-notify.yml
+++ b/.circleci/src/jobs/commit-audius-docker-compose-and-notify.yml
@@ -114,9 +114,9 @@ steps:
           git clone --branch stage https://github.com/AudiusProject/audius-docker-compose.git audius-docker-compose
           cd audius-docker-compose
           last_release_commit=$(git log --format=format:%H --grep='^release-v.*auto-deploy$' -1)
-          sed -i "s/{TAG:-.*}/{TAG:-$CIRCLE_SHA1}/" creator-node/docker-compose*.yml
-          sed -i "s/{TAG:-.*}/{TAG:-$CIRCLE_SHA1}/" discovery-provider/docker-compose*.yml
-          sed -i "s/{TAG:-.*}/{TAG:-$CIRCLE_SHA1}/" identity-service/docker-compose*.yml
+          sed -i "s/\({TAG:-\)[^}]*\}/\1$CIRCLE_SHA1}/" creator-node/docker-compose*.yml
+          sed -i "s/\({TAG:-\)[^}]*\}/\1$CIRCLE_SHA1}/" discovery-provider/docker-compose*.yml
+          sed -i "s/\({TAG:-\)[^}]*\}/\1$CIRCLE_SHA1}/" identity-service/docker-compose*.yml
           git add */docker-compose*.yml
           git commit -m "$CIRCLE_BRANCH auto-deploy"
           git push origin stage

--- a/.circleci/src/jobs/deploy-stage-nodes.yml
+++ b/.circleci/src/jobs/deploy-stage-nodes.yml
@@ -25,7 +25,7 @@ steps:
       command: |
         git clone --branch stage https://github.com/AudiusProject/audius-docker-compose.git audius-docker-compose
         cd audius-docker-compose
-        sed -i "s/{TAG:-.*}/{TAG:-$CIRCLE_SHA1}/" << parameters.service >>/docker-compose*.yml
+        sed -i "s/\({TAG:-\)[^}]*\}/\1$CIRCLE_SHA1}/" << parameters.service >>/docker-compose*.yml
         git add */docker-compose*.yml
         git commit -m "Update tag to $CIRCLE_SHA1 for << parameters.service >>"
         git push origin stage


### PR DESCRIPTION
### Description
Makes the tag replacement `sed` command more specific so it doesn't bulldoze tags like [this](https://github.com/AudiusProject/audius-docker-compose/commit/67efc6a70c98991ffb963570e98ddbafc3d78744#diff-227d46fd22bb26c20dc3bc63a7eed90ad0ef1cef6c5a50fd1c6c1b97c413c649L369).

### How Has This Been Tested?
Tested with various examples:
- Basic replacement `echo 'image: audius/dashboard:${TAG:-5652852c216ffdd58b6d3d7e8db54d32a3870209}' | sed "s/\({TAG:-\)[^}]*\}/\1abcdef1234567890}/"`
- Replacement with the tag it bulldozed previously: `echo 'image: audius/dashboard:${TAG:-5652852c216ffdd58b6d3d7e8db54d32a3870209}-${NETWORK:-prod}' | sed "s/\({TAG:-\)[^}]*\}/\1abcdef1234567890}/"`
- Multiple placeholders: `echo 'image: audius/service:${SOME_TAG:-default}-${TAG:-previousvalue}-${NETWORK:-prod}' | sed "s/\({TAG:-\)[^}]*\}/\1abcdef1234567890}/"`
