### PR TITLE
Run comms locally via audius-compose

### DIFF
--- a/comms/Dockerfile
+++ b/comms/Dockerfile
@@ -20,4 +20,4 @@ COPY --from=builder /app/comms /bin/comms
 
 EXPOSE 4222
 VOLUME ["/tmp"]
-ENTRYPOINT ["comms"]
+CMD ["comms"]

--- a/comms/discovery/pubkeystore/recover.go
+++ b/comms/discovery/pubkeystore/recover.go
@@ -46,6 +46,13 @@ func Dial(discoveryConfig *config.DiscoveryConfig) error {
 		finalPoaBlock = 30000000
 	}
 
+	if discoveryConfig.IsDev {
+		acdcEndpoint = "http://audius-protocol-poa-ganache-1"
+		poaEndpoint = "http://audius-protocol-poa-ganache-1" // won't ever be used
+		verifyingContract = "0x254dffcd3277C0b1660F6d42EFbB754edaBAbC2B"
+		finalPoaBlock = -1
+	}
+
 	poaClient, err = ethclient.Dial(poaEndpoint)
 	if err != nil {
 		return err

--- a/contracts/contracts/EntityManager.sol
+++ b/contracts/contracts/EntityManager.sol
@@ -30,7 +30,7 @@ contract EntityManager is SigningLogicInitializable {
 
     function initialize(
         address _verifierAddress,
-        uint _networkId
+        uint _chainId
     ) public initializer
     {
         require(
@@ -41,7 +41,7 @@ contract EntityManager is SigningLogicInitializable {
         SigningLogicInitializable.initialize(
             "Entity Manager",
             "1",
-            _networkId
+            _chainId
         );
     }
 

--- a/contracts/migrations/2_entity_manager_migration.js
+++ b/contracts/migrations/2_entity_manager_migration.js
@@ -17,8 +17,8 @@ module.exports = (deployer, network, accounts) => {
     const config = contractConfig[network]
     const proxyAdminAddress =
       config.blacklisterAddress || accounts[accounts.length - 1]
-    const networkId = await web3.eth.net.getId()
-    console.log(`Deploying EntityManager to ${networkId}`)
+    const chainId = await web3.eth.getChainId()
+    console.log(`Deploying EntityManager to ${chainId}`)
     const deployLogicTx = await deployer.deploy(EntityManager)
     const logicContractAddress = deployLogicTx.address
     console.log(logicContractAddress)
@@ -26,7 +26,7 @@ module.exports = (deployer, network, accounts) => {
     const initializeData = encodeCall(
       'initialize',
       ['address', 'uint'],
-      [verifierAddress, networkId]
+      [verifierAddress, chainId]
     )
     // Deploy proxy contract with encoded initialize function
     let deployedProxyTx = await deployer.deploy(

--- a/dev-tools/compose/docker-compose.discovery.prod.yml
+++ b/dev-tools/compose/docker-compose.discovery.prod.yml
@@ -43,15 +43,19 @@ services:
     build:
       context: ${PROJECT_ROOT}/comms
       dockerfile: Dockerfile
-    command: discovery
+    command: sh -c ". /tmp/dev-tools/startup/startup.sh && comms discovery"
     restart: unless-stopped
+    env_file: .env # used by the startup script
     environment:
       comms_dev_mode: true
-      audius_delegate_private_key: 'c82ad757622db5a148089e0a8fc1741cefa8677ab56a2ac9e38dac905c5ad7c7'
-      audius_db_url: 'postgresql://postgres:postgres@db:5432/discovery_provider_1'
     depends_on:
       db:
         condition: service_healthy
+    deploy:
+      mode: replicated
+      replicas: '${DISCOVERY_PROVIDER_REPLICAS}'
+    volumes:
+      - ${PROJECT_ROOT}/dev-tools:/tmp/dev-tools
 
   trpc:
     build:

--- a/dev-tools/compose/docker-compose.test.yml
+++ b/dev-tools/compose/docker-compose.test.yml
@@ -292,7 +292,7 @@ services:
     build:
       context: ${PROJECT_ROOT}/comms
       dockerfile: Dockerfile
-    command: discovery-migrations
+    command: comms discovery-migrations
     environment:
       audius_db_url: 'postgres://postgres:postgres@discovery-provider-db:5432/discovery_provider?sslmode=disable'
     depends_on:

--- a/dev-tools/compose/docker-compose.yml
+++ b/dev-tools/compose/docker-compose.yml
@@ -11,9 +11,9 @@ x-common: &common
     driver: json-file
   extra_hosts:
     # Allows the containers can talk to each other via their hostnames routed through nginx
-    - 'audius-protocol-comms-discovery-1:host-gateway'
-    - 'audius-protocol-comms-discovery-2:host-gateway'
-    - 'audius-protocol-comms-discovery-3:host-gateway'
+    - 'audius-protocol-comms-1:host-gateway'
+    - 'audius-protocol-comms-2:host-gateway'
+    - 'audius-protocol-comms-3:host-gateway'
     - 'audius-protocol-creator-node-1:host-gateway'
     - 'audius-protocol-creator-node-2:host-gateway'
     - 'audius-protocol-creator-node-3:host-gateway'

--- a/dev-tools/compose/nginx_ingress.conf
+++ b/dev-tools/compose/nginx_ingress.conf
@@ -6,7 +6,12 @@
 # COMMS. Routes to containers for: audius-protocol-storage-1 audius-protocol-storage-2 audius-protocol-storage-3 audius-protocol-storage-4 audius-protocol-discovery-1 audius-protocol-discovery-2 audius-protocol-discovery-3
 # Comes from comms/nginx/ingress.conf
 #
-include comms_ingress.conf;
+# include comms_ingress.conf;
+
+map $http_upgrade $connection_upgrade {
+    default upgrade;
+    ''      close;
+}
 
 #
 # DISCOVERY PROVIDER. Uses port 5000 to forward to the same nginx that stage and prod use (i.e., discovery-provider/nginx_conf/nginx.conf)
@@ -37,6 +42,17 @@ server {
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
     }
 
+    location ~ ^/comms(/.*)?$ {
+        resolver 127.0.0.11 valid=30s;
+        proxy_pass http://audius-protocol-comms-1:8925/comms$1$is_args$args;
+        proxy_set_header Host $http_host;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        # for websockets:
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+    }
+
     location ^~ /healthz {
         resolver 127.0.0.11 valid=30s;
         proxy_pass http://healthz;
@@ -51,7 +67,6 @@ server {
         proxy_set_header Host $http_host;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
     }
-
 }
 
 
@@ -79,6 +94,17 @@ server {
         proxy_pass http://audius-protocol-solana-relay-2:6002/solana$1;
         proxy_set_header Host $http_host;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    }
+
+    location ~ ^/comms(/.*)?$ {
+        resolver 127.0.0.11 valid=30s;
+        proxy_pass http://audius-protocol-comms-2:8925/comms$1$is_args$args;
+        proxy_set_header Host $http_host;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        # for websockets:
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
     }
 
     location ^~ /healthz {
@@ -123,6 +149,17 @@ server {
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
     }
 
+    location ~ ^/comms(/.*)?$ {
+        resolver 127.0.0.11 valid=30s;
+        proxy_pass http://audius-protocol-comms-1:8925/comms$1$is_args$args;
+        proxy_set_header Host $http_host;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        # for websockets:
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+    }
+
     location ^~ /healthz {
         resolver 127.0.0.11 valid=30s;
         proxy_pass http://healthz;
@@ -137,7 +174,6 @@ server {
         proxy_set_header Host $http_host;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
     }
-
 }
 
 #

--- a/dev-tools/startup/comms.sh
+++ b/dev-tools/startup/comms.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env sh
+if [[ "$audius_db_url" == "" ]]; then
+    export audius_db_url="postgresql://postgres:postgres@audius-protocol-db-1:5432/discovery_provider_${replica}"
+    export audius_db_url_read_replica="postgresql://postgres:postgres@audius-protocol-db-1:5432/discovery_provider_${replica}"
+fi
+
+if [[ "$audius_redis_url" == "" ]]; then
+    export audius_redis_url="redis://audius-protocol-discovery-provider-redis-${replica}:6379/00"
+fi
+
+export audius_enable_rsyslog=false
+
+export audius_discprov_url="http://audius-protocol-discovery-provider-${replica}"
+
+export audius_delegate_owner_wallet=$(printenv "DP${replica}_DELEGATE_OWNER_ADDRESS")
+export audius_delegate_private_key=$(printenv "DP${replica}_DELEGATE_OWNER_PRIVATE_KEY")

--- a/dev-tools/startup/startup.sh
+++ b/dev-tools/startup/startup.sh
@@ -2,7 +2,7 @@
 
 # NOTE: This script is meant to be used from within docker containers
 
-name=$(nslookup $(hostname -i) | grep -o "\(discovery-provider\|identity-service\)-[0-9]\+")
+name=$(nslookup $(hostname -i) | grep -o "\(discovery-provider\|identity-service\|comms\)-[0-9]\+")
 replica=$(echo $name | grep -o "[0-9]\+")
 
 if [[ -f "/tmp/dev-tools/startup/$name.env" ]]; then

--- a/packages/libs/src/sdk/services/EntityManager/EntityManager.test.ts
+++ b/packages/libs/src/sdk/services/EntityManager/EntityManager.test.ts
@@ -20,9 +20,7 @@ jest.mock('../../utils/web3', () => {
   return jest.fn().mockImplementation(() => {
     return {
       eth: {
-        net: {
-          getId: () => ''
-        },
+        getChainId: () => '',
         Contract: jest.fn().mockImplementation(() => ({
           methods: {
             manageEntity: () => ({

--- a/packages/libs/src/sdk/services/EntityManager/EntityManager.ts
+++ b/packages/libs/src/sdk/services/EntityManager/EntityManager.ts
@@ -68,7 +68,7 @@ export class EntityManager implements EntityManagerService {
     Pick<TransactionReceipt, 'blockHash' | 'blockNumber'>
   > {
     const nonce = await signatureSchemas.getNonce()
-    const chainId = Number(await this.web3.eth.net.getId())
+    const chainId = Number(await this.web3.eth.getChainId())
     const signatureData = signatureSchemas.generators.getManageEntityData(
       chainId,
       this.config.contractAddress,

--- a/packages/libs/src/services/contracts/ContractClient.ts
+++ b/packages/libs/src/services/contracts/ContractClient.ts
@@ -227,9 +227,9 @@ export class ContractClient {
     return method
   }
 
-  async getEthNetId() {
+  async getEthChainId() {
     await this.init()
-    const netId = await this.web3Manager.getWeb3().eth.net.getId()
+    const netId = await this.web3Manager.getWeb3().eth.getChainId()
 
     return netId
   }

--- a/packages/libs/src/services/contracts/ContractClient.ts
+++ b/packages/libs/src/services/contracts/ContractClient.ts
@@ -229,9 +229,8 @@ export class ContractClient {
 
   async getEthChainId() {
     await this.init()
-    const netId = await this.web3Manager.getWeb3().eth.getChainId()
-
-    return netId
+    const chainId = await this.web3Manager.getWeb3().eth.getChainId()
+    return chainId
   }
 
   async getContract() {

--- a/packages/libs/src/services/dataContracts/EntityManagerClient.ts
+++ b/packages/libs/src/services/dataContracts/EntityManagerClient.ts
@@ -53,7 +53,7 @@ export class EntityManagerClient extends ContractClient {
     privateKey?: string
   ): Promise<[string, string]> {
     const nonce = await signatureSchemas.getNonce()
-    const chainId = await this.getEthNetId()
+    const chainId = await this.getEthChainId()
     const contractAddress = await this.getAddress()
     const signatureData = signatureSchemas.generators.getManageEntityData(
       chainId,
@@ -107,7 +107,7 @@ export class EntityManagerClient extends ContractClient {
     privateKey?: string
   ): Promise<{ txReceipt: TransactionReceipt }> {
     const nonce = await signatureSchemas.getNonce()
-    const chainId = await this.getEthNetId()
+    const chainId = await this.getEthChainId()
     const contractAddress = await this.getAddress()
     const nethermindContractAddress = await this.getNethermindAddress()
     const signatureData = signatureSchemas.generators.getManageEntityData(


### PR DESCRIPTION
### Description

- Makes comms run as replicated just like DN, and connected to respective DN db
- Adds nginx config to forward /comms requests to the comms container, including websockets

### How Has This Been Tested?

Tested locally by running `audius-compose up -d 2 -p --comms` and sending messages back and forth

> ~~Error I get when trying to do DMs related features (couldn't get pubkey):~~
> 
> ```
> map[_action:Create _entityId:63942403 _entityType:User _metadata:{"cid":"bagaaierayta27sm4vluxs6e3wvfauselncblgepbxc7yrwkl7lzwg7dbgvpa","data":{"is_deactivated":false,"name":"name C979","handle":"handleC979","profile_picture":null,"profile_picture_sizes":null,"cover_photo":null,"cover_photo_sizes":null,"bio":"account generated by audius-cmd C979","location":"locationC979","artist_pick_track_id":null,"creator_node_endpoint":null,"associated_wallets":null,"associated_sol_wallets":null,"collectibles":null,"playlist_library":null,"events":null,"allow_ai_attribution":null,"is_storage_v2":true,"wallet":"0xb8321db887513c1c1879140ff2b1892394ca42f2","user_id":63942403}} _nonce:[231 234 34 180 189 221 52 120 78 42 206 242 180 153 53 201 121 164 22 3 142 3 65 255 119 73 133 47 29 56 194 248] _subjectSig:[234 180 22 71 178 243 120 105 35 211 25 104 181 213 232 209 52 104 70 192 56 28 136 208 5 220 202 251 151 127 241 130 115 37 28 130 113 165 126 223 255 245 210 216 206 40 232 142 112 146 175 93 165 74 62 125 231 169 91 157 240 52 171 242 0] _userId:63942403] 0xD44F558aaBB2Ee0554b54c702c217022810e7e07 0xb8321db887513c1c1879140ff2b1892394ca42f2
> {"time":"2023-12-26T20:48:09.398053845Z","level":"WARN","source":{"function":"comms.audius.co/discovery/pubkeystore.RecoverUserPublicKeyBase64","file":"/app/discovery/pubkeystore/recover.go","line":145},"msg":"failed to recover pubkey for user","module":"pubkeystore","userId":63942403,"err":"wallets don't match"}
> map[_action:Create _entityId:275829332 _entityType:User _metadata:{"cid":"bagaaiera73ajfe4nivg7esv6jym6xhwe4iuus4kvgz3k7wfovdtwb3qqlxqa","data":{"is_deactivated":false,"name":"name 97C9","handle":"handle97C9","profile_picture":null,"profile_picture_sizes":null,"cover_photo":null,"cover_photo_sizes":null,"bio":"account generated by audius-cmd 97C9","location":"location97C9","artist_pick_track_id":null,"creator_node_endpoint":null,"associated_wallets":null,"associated_sol_wallets":null,"collectibles":null,"playlist_library":null,"events":null,"allow_ai_attribution":null,"is_storage_v2":true,"wallet":"0x2add080b4c79ca8052fd775b1b55df3c726e1e67","user_id":275829332}} _nonce:[26 207 93 229 104 244 165 246 40 54 90 27 61 62 5 139 76 148 216 174 237 241 121 113 52 111 92 86 119 61 36 7] _subjectSig:[46 14 30 30 21 223 14 94 186 62 127 206 144 58 234 56 111 98 145 181 8 5 133 96 228 255 4 127 7 107 213 166 19 151 116 114 122 84 12 216 237 72 19 64 201 19 16 199 190 185 121 12 223 219 189 141 241 31 150 183 31 5 198 99 0] _userId:275829332] 0x8b168624e1f290DcD1A149625be00ab5bD0f3008 0x2add080b4c79ca8052fd775b1b55df3c726e1e67
> {"time":"2023-12-26T20:48:09.402902512Z","level":"WARN","source":{"function":"comms.audius.co/discovery/pubkeystore.RecoverUserPublicKeyBase64","file":"/app/discovery/pubkeystore/recover.go","line":145},"msg":"failed to recover pubkey for user","module":"pubkeystore","userId":275829332,"err":"wallets don't match"}
> ```

The above error was caused by a discrepancy in how comms and the client signed data. The comms server used chainId while the client used networkId. The [proper thing](https://medium.com/@pedrouid/chainid-vs-networkid-how-do-they-differ-on-ethereum-eec2ed41635b) to sign with is the chainId, which is typically identical to network id, but for us it isn't on our local ganache setup (we explicitly set networkId to something else). Since the truth is we _should_ be using chainId, I modified the client to sign using that. However, I didn't realize the EntityManager _contract_ actually also recovers using the initialized network id, so I had to update that as well. We don't have to reinit our contracts on stage or prod as the chainId and networkId are the same on those environments.

![image](https://github.com/AudiusProject/audius-protocol/assets/3690498/580a175c-e05a-4012-a093-b0b853d58f45)
