### PR TITLE
Disable slack notify if full release when sent to app store

### DIFF
--- a/.circleci/src/commands/@mobile-commands.yml
+++ b/.circleci/src/commands/@mobile-commands.yml
@@ -110,6 +110,9 @@ mobile-release-ios:
     env:
       default: '.env.prod'
       type: string
+    slack-notify:
+      default: true
+      type: boolean
   steps:
     - run:
         name: fastlane build and upload
@@ -117,23 +120,25 @@ mobile-release-ios:
     - run:
         name: slack announce
         command: |
-          cd packages/mobile
-          deploying_version=$(jq -r '.version' package.json)
-          job_url="https://app.circleci.com/pipelines/workflows/$CIRCLE_WORKFLOW_ID"
-          environment=<<parameters.bundle-id>>
-          if [ "$environment" = 'co.audius.audiusmusic' ] ||
-             [ "$environment" = 'co.audius.audiusmusic.releasecandidate' ] ||
-             [ "$environment" = 'co.audius.audiusmusic.staging.releasecandidate' ]; then
+          if [ <<parameters.slack-notify>> = true ]; then
+            cd packages/mobile
+            deploying_version=$(jq -r '.version' package.json)
+            job_url="https://app.circleci.com/pipelines/workflows/$CIRCLE_WORKFLOW_ID"
+            environment=<<parameters.bundle-id>>
+            if [ "$environment" = 'co.audius.audiusmusic' ] ||
+              [ "$environment" = 'co.audius.audiusmusic.releasecandidate' ] ||
+              [ "$environment" = 'co.audius.audiusmusic.staging.releasecandidate' ]; then
 
-            json_content="{ \"blocks\": ["
-            json_content+="{ \"type\": \"section\", \"text\": { \"type\": \"mrkdwn\", \"text\": \"Deployed $environment <${job_url}|v$deploying_version> to mobile ios \n\" } }"
-            json_content+="]}"
-            echo "Text to send to slack: $json_content"
+              json_content="{ \"blocks\": ["
+              json_content+="{ \"type\": \"section\", \"text\": { \"type\": \"mrkdwn\", \"text\": \"Deployed $environment <${job_url}|v$deploying_version> to mobile ios \n\" } }"
+              json_content+="]}"
+              echo "Text to send to slack: $json_content"
 
-            # Send Slack message
-            curl -f -X POST -H 'Content-type: application/json' \
-              --data "$json_content" \
-              $SLACK_DAILY_DEPLOY_WEBHOOK
+              # Send Slack message
+              curl -f -X POST -H 'Content-type: application/json' \
+                --data "$json_content" \
+                $SLACK_DAILY_DEPLOY_WEBHOOK
+            fi
           fi
 
 # Prepare to build/upload/release Android
@@ -225,6 +230,9 @@ mobile-release-android:
     track:
       default: 'alpha'
       type: string
+    slack-notify:
+      default: true
+      type: boolean
   steps:
     - run:
         name: Symlink react-native
@@ -239,24 +247,26 @@ mobile-release-android:
     - run:
         name: slack announce
         command: |
-          cd packages/mobile
-          deploying_version=$(jq -r '.version' package.json)
-          job_url="https://app.circleci.com/pipelines/workflows/$CIRCLE_WORKFLOW_ID"
-          environment=<<parameters.upload-type>>
+          if [ <<parameters.slack-notify>> = true ]; then
+            cd packages/mobile
+            deploying_version=$(jq -r '.version' package.json)
+            job_url="https://app.circleci.com/pipelines/workflows/$CIRCLE_WORKFLOW_ID"
+            environment=<<parameters.upload-type>>
 
-          if [ "$environment" = 'prod' ] ||
-             [ "$environment" = 'releaseCandidate' ] ||
-             [ "$environment" = 'stagingReleaseCandidate' ]; then
+            if [ "$environment" = 'prod' ] ||
+              [ "$environment" = 'releaseCandidate' ] ||
+              [ "$environment" = 'stagingReleaseCandidate' ]; then
 
-            json_content="{ \"blocks\": ["
-            json_content+="{ \"type\": \"section\", \"text\": { \"type\": \"mrkdwn\", \"text\": \"Deployed $environment <${job_url}|v$deploying_version> to mobile android \n\" } }"
-            json_content+="]}"
-            echo "Text to send to slack: $json_content"
+              json_content="{ \"blocks\": ["
+              json_content+="{ \"type\": \"section\", \"text\": { \"type\": \"mrkdwn\", \"text\": \"Deployed $environment <${job_url}|v$deploying_version> to mobile android \n\" } }"
+              json_content+="]}"
+              echo "Text to send to slack: $json_content"
 
-            # Send Slack message
-            curl -f -X POST -H 'Content-type: application/json' \
-              --data "$json_content" \
-              $SLACK_DAILY_DEPLOY_WEBHOOK
+              # Send Slack message
+              curl -f -X POST -H 'Content-type: application/json' \
+                --data "$json_content" \
+                $SLACK_DAILY_DEPLOY_WEBHOOK
+            fi
           fi
 
 # Deploy Solana saga dApp store

--- a/.circleci/src/jobs/@mobile-jobs.yml
+++ b/.circleci/src/jobs/@mobile-jobs.yml
@@ -140,6 +140,7 @@ mobile-build-upload-production-ios-if-full-release:
         build-directory: 'build-mobile-production'
         bundle-id: 'co.audius.audiusmusic'
         env: '.env.prod'
+        slack-notify: false
 
 mobile-deploy-codepush-production-ios-if-ota-release:
   working_directory: ~/audius-protocol
@@ -289,6 +290,7 @@ mobile-build-upload-production-android-if-full-release:
         build-directory: 'build-mobile-production'
         upload-type: 'prod'
         track: 'alpha'
+        slack-notify: false
 
 mobile-deploy-codepush-production-android-if-ota-release:
   working_directory: ~/audius-protocol


### PR DESCRIPTION
### Description

Currently a full app release just sends things to the store for review - it doesn't actually deploy it to prod.
In the case of a full release, skip notifying slack.

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._

Will be tested alongside this week's upcoming release-client-v1.5.58