### PR TITLE
Patch mobile release date format

### DIFF
--- a/packages/mobile/src/screens/track-screen/TrackScreenDetailsTile.tsx
+++ b/packages/mobile/src/screens/track-screen/TrackScreenDetailsTile.tsx
@@ -272,9 +272,7 @@ export const TrackScreenDetailsTile = ({
     {
       isHidden: is_unlisted,
       label: 'Released',
-      value: release_date
-        ? formatDate(release_date, 'ddd MMM DD YYYY HH:mm:ss')
-        : formatDate(created_at, 'YYYY-MM-DD HH:mm:ss')
+      value: release_date ? formatDate(release_date) : formatDate(created_at)
     },
     {
       icon:


### PR DESCRIPTION
### Description

Not sure why we were formatting release dates and created_at differently in this way before (maybe because release_dat was strings before), but I had made this change to format them the same here https://github.com/AudiusProject/audius-protocol/pull/6954. That change didn't get deployed yet. 

However in discovery, we did modify release_dates to default to created_at which has made it to prod, so we should be using release_date all the time. I think this was just an existing bug that hasn't surfaced until now. Still leaving the created_at in here for now even though it shouldn't be necessary. 

### How Has This Been Tested?

Tested on ios:prod. This format is identical to web.

![image](https://github.com/AudiusProject/audius-protocol/assets/6413636/25c93833-e530-495b-8e1b-ec2ce2698e19)