### PR TITLE
Add rate limits for DashboardWalletUser relays

### DIFF
--- a/packages/identity-service/relay-rate-limit.json
+++ b/packages/identity-service/relay-rate-limit.json
@@ -143,5 +143,15 @@
     "owner": 5,
     "app": -1,
     "whitelist": 1000
+  },
+  "CreateDashboardWalletUser": {
+    "owner": 100,
+    "app": 100,
+    "whitelist": 1000
+  },
+  "DeleteDashboardWalletUser": {
+    "owner": 100,
+    "app": 100,
+    "whitelist": 1000
   }
 }


### PR DESCRIPTION
### Description
Rate limits are high because you can only have one wallet per user, and the wallet also has to sign the tx. 
Need to add this or else the relay for these txs fails.

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._
