### PR TITLE
[C-3533] Fix add track to collection toast

### DIFF
--- a/packages/web/src/components/add-to-collection/desktop/AddToCollectionModal.tsx
+++ b/packages/web/src/components/add-to-collection/desktop/AddToCollectionModal.tsx
@@ -103,19 +103,17 @@ const AddToCollectionModal = () => {
     } else {
       dispatch(addTrackToPlaylist(trackId, playlist.playlist_id))
       if (account && trackTitle) {
-        dispatch(
-          toast({
-            content: messages.addedToast,
-            link: collectionPage(
-              account.handle,
-              trackTitle,
-              playlist.playlist_id,
-              playlist.permalink,
-              playlist.is_album
-            ),
-            linkText: messages.view
-          })
-        )
+        toast({
+          content: messages.addedToast,
+          link: collectionPage(
+            account.handle,
+            trackTitle,
+            playlist.playlist_id,
+            playlist.permalink,
+            playlist.is_album
+          ),
+          linkText: messages.view
+        })
       }
     }
 
@@ -123,7 +121,7 @@ const AddToCollectionModal = () => {
   }
 
   const handleDisabledPlaylistClick = () => {
-    toast({ content: messages.hiddenAdd })
+    dispatch(toast({ content: messages.hiddenAdd }))
   }
 
   const handleCreateCollection = () => {

--- a/packages/web/src/components/add-to-collection/desktop/AddToCollectionModal.tsx
+++ b/packages/web/src/components/add-to-collection/desktop/AddToCollectionModal.tsx
@@ -103,17 +103,19 @@ const AddToCollectionModal = () => {
     } else {
       dispatch(addTrackToPlaylist(trackId, playlist.playlist_id))
       if (account && trackTitle) {
-        toast({
-          content: messages.addedToast,
-          link: collectionPage(
-            account.handle,
-            trackTitle,
-            playlist.playlist_id,
-            playlist.permalink,
-            playlist.is_album
-          ),
-          linkText: messages.view
-        })
+        dispatch(
+          toast({
+            content: messages.addedToast,
+            link: collectionPage(
+              account.handle,
+              trackTitle,
+              playlist.playlist_id,
+              playlist.permalink,
+              playlist.is_album
+            ),
+            linkText: messages.view
+          })
+        )
       }
     }
 


### PR DESCRIPTION
### Description

This toast was not displaying because the action creator for the toast was being called but not dispatched.

Seems like this has never worked in prod?

Did a quick audit of other toast usages in web, and all the others either call dispatch or use the `ToastContext` toast creator which does the dispatch for you.

![image](https://github.com/AudiusProject/audius-protocol/assets/2358254/065cb379-2dd7-47b1-a84e-b84efbdc1d53)


### How Has This Been Tested?

local web