### PR TITLE
[Web] Enable connecting wallet to user via new OAuth `write_once` scope [C-3499]

### DIFF
--- a/packages/web/src/pages/oauth-login-page/OAuthLoginPage.module.css
+++ b/packages/web/src/pages/oauth-login-page/OAuthLoginPage.module.css
@@ -118,6 +118,7 @@
 }
 
 .permissionTextContainer {
+  overflow: auto;
   margin-left: var(--unit-4);
 }
 

--- a/packages/web/src/pages/oauth-login-page/OAuthLoginPage.tsx
+++ b/packages/web/src/pages/oauth-login-page/OAuthLoginPage.tsx
@@ -58,7 +58,8 @@ export const OAuthLoginPage = () => {
     apiKey,
     appName,
     userEmail,
-    authorize
+    authorize,
+    txParams
   } = useOAuthSetup()
 
   const clearErrors = () => {
@@ -228,6 +229,7 @@ export const OAuthLoginPage = () => {
           tx={tx as WriteOnceTx}
           userEmail={userEmail}
           isLoggedIn={isLoggedIn}
+          txParams={txParams}
         />
       )}
       {isLoggedIn ? (

--- a/packages/web/src/pages/oauth-login-page/OAuthLoginPage.tsx
+++ b/packages/web/src/pages/oauth-login-page/OAuthLoginPage.tsx
@@ -1,195 +1,32 @@
-import {
-  FormEvent,
-  ReactNode,
-  useCallback,
-  useEffect,
-  useLayoutEffect,
-  useState
-} from 'react'
+import { FormEvent, useCallback, useLayoutEffect, useState } from 'react'
 
 import {
   accountSelectors,
-  CommonState,
-  encodeHashId,
   ErrorLevel,
   Name,
-  signOutActions,
-  statusIsNotFinalized,
-  User
+  signOutActions
 } from '@audius/common'
-import {
-  Button,
-  ButtonProps,
-  IconArrow,
-  IconAtSign,
-  IconPencil,
-  IconValidationX,
-  IconVisibilityPublic
-} from '@audius/stems'
+import { IconValidationX } from '@audius/stems'
 import cn from 'classnames'
 import { useDispatch, useSelector } from 'react-redux'
-import { useHistory } from 'react-router-dom'
 
-import HorizontalLogo from 'assets/img/Horizontal-Logo-Full-Color.png'
 import { make, useRecord } from 'common/store/analytics/actions'
 import Input from 'components/data-entry/Input'
 import LoadingSpinner from 'components/loading-spinner/LoadingSpinner'
 import { ProfileInfo } from 'components/profile-info/ProfileInfo'
 import { audiusBackendInstance } from 'services/audius-backend/audius-backend-instance'
-import * as errorActions from 'store/errors/actions'
 import { reportToSentry } from 'store/errors/reportToSentry'
 import { SIGN_UP_PAGE } from 'utils/route'
 
 import styles from './OAuthLoginPage.module.css'
-import { useParsedQueryParams } from './hooks'
+import { CTAButton } from './components/CTAButton'
+import { ContentWrapper } from './components/ContentWrapper'
+import { PermissionsSection } from './components/PermissionsSection'
+import { useOAuthSetup } from './hooks'
 import { messages } from './messages'
-import {
-  authWrite,
-  formOAuthResponse,
-  getDeveloperApp,
-  getIsAppAuthorized
-} from './utils'
+import { WriteOnceTx } from './utils'
 const { signOut } = signOutActions
-const { getAccountUser, getAccountStatus } = accountSelectors
-
-const CTAButton = ({
-  isSubmitting,
-  ...restProps
-}: { isSubmitting: boolean } & ButtonProps) => {
-  return (
-    <Button
-      isDisabled={isSubmitting}
-      rightIcon={
-        isSubmitting ? (
-          <LoadingSpinner className={styles.buttonLoadingSpinner} />
-        ) : (
-          <IconArrow />
-        )
-      }
-      className={styles.ctaButton}
-      {...restProps}
-    />
-  )
-}
-
-const PermissionsSection = ({
-  scope,
-  isLoggedIn,
-  userEmail
-}: {
-  scope: string | string[] | null
-  isLoggedIn: boolean
-  userEmail?: string | null
-}) => {
-  return (
-    <>
-      <div className={styles.permsTitleContainer}>
-        <h3 className={styles.infoSectionTitle}>
-          {messages.permissionsRequestedHeader}
-        </h3>
-      </div>
-      <div className={styles.tile}>
-        <div className={styles.permissionContainer}>
-          <div
-            className={cn({
-              [styles.visibilityIconWrapper]: scope === 'read'
-            })}
-          >
-            {scope === 'write' ? (
-              <IconPencil
-                className={cn(styles.permissionIcon)}
-                width={18}
-                height={18}
-              />
-            ) : (
-              <IconVisibilityPublic
-                className={cn(styles.permissionIcon, styles.visibilityIcon)}
-                width={21}
-                height={22}
-              />
-            )}
-          </div>
-
-          <div className={styles.permissionTextContainer}>
-            <span className={styles.permissionText}>
-              {scope === 'write'
-                ? messages.writeAccountAccess
-                : messages.readOnlyAccountAccess}
-            </span>
-            {scope === 'read' ? null : (
-              <div className={cn(styles.permissionDetailTextContainer)}>
-                <p
-                  className={cn(
-                    styles.permissionText,
-                    styles.permissionDetailText
-                  )}
-                >
-                  {messages.doesNotGrantAccessTo}
-                  <br />
-                  {messages.walletsOrDMs}
-                </p>
-              </div>
-            )}
-          </div>
-        </div>
-        <div
-          className={cn(
-            styles.permissionContainer,
-            styles.nonFirstPermissionContainer
-          )}
-        >
-          <div>
-            <IconAtSign
-              width={15}
-              height={15}
-              className={cn(styles.permissionIcon, styles.atSignIcon)}
-            />
-          </div>
-          <div className={styles.permissionTextContainer}>
-            <span className={styles.permissionText}>
-              {messages.emailAddressAccess}
-            </span>
-            {isLoggedIn ? (
-              <div className={cn(styles.permissionDetailTextContainer)}>
-                <span
-                  className={cn(
-                    styles.permissionText,
-                    styles.permissionDetailText,
-                    {
-                      [styles.permissionTextExtraLight]: !userEmail
-                    }
-                  )}
-                >
-                  {userEmail == null ? (
-                    <>
-                      <LoadingSpinner className={styles.loadingSpinner} />{' '}
-                      {messages.emailLoading}&#8230;
-                    </>
-                  ) : (
-                    userEmail
-                  )}
-                </span>
-              </div>
-            ) : null}
-          </div>
-        </div>
-      </div>
-    </>
-  )
-}
-
-const ContentWrapper = ({ children }: { children: ReactNode }) => (
-  <div className={styles.wrapper}>
-    <div className={styles.container}>
-      <div className={styles.centeredContent}>
-        <div className={styles.logoContainer}>
-          <img src={HorizontalLogo} className={styles.logo} alt='Audius Logo' />
-        </div>
-      </div>
-      {children}
-    </div>
-  </div>
-)
+const { getAccountUser } = accountSelectors
 
 export const OAuthLoginPage = () => {
   useLayoutEffect(() => {
@@ -199,54 +36,30 @@ export const OAuthLoginPage = () => {
     }
   }, [])
   const record = useRecord()
-  const history = useHistory()
-  const dispatch = useDispatch()
-
-  const {
-    appName: queryParamAppName,
-    apiKey,
-    scope,
-    redirectUri,
-    state,
-    responseMode,
-    origin: originParam,
-    parsedRedirectUri,
-    isRedirectValid,
-    parsedOrigin,
-    error: initError
-  } = useParsedQueryParams()
-
-  const [isSubmitting, setIsSubmitting] = useState(false)
-  const accountIsLoading = useSelector((state: CommonState) => {
-    const status = getAccountStatus(state)
-    return statusIsNotFinalized(status)
-  })
   const account = useSelector(getAccountUser)
   const isLoggedIn = Boolean(account)
-  const [userEmail, setUserEmail] = useState<string | null>(null)
-  /** The fetched developer app name if write OAuth (we use `queryParamAppName` if read OAuth and no API key is given) */
-  const [registeredDeveloperAppName, setRegisteredDeveloperAppName] =
-    useState<string>()
-  const appName = registeredDeveloperAppName ?? queryParamAppName
 
-  const [userAlreadyWriteAuthorized, setUserAlreadyWriteAuthorized] =
-    useState<boolean>()
-  const [queryParamsError, setQueryParamsError] = useState<string | null>(
-    initError
-  )
+  const dispatch = useDispatch()
 
-  const loading =
-    accountIsLoading ||
-    (apiKey &&
-      (registeredDeveloperAppName === undefined ||
-        userAlreadyWriteAuthorized === undefined))
-
+  const [isSubmitting, setIsSubmitting] = useState(false)
   const [emailInput, setEmailInput] = useState('')
   const [passwordInput, setPasswordInput] = useState('')
   const [hasCredentialsError, setHasCredentialsError] = useState(false)
   const [generalSubmitError, setGeneralSubmitError] = useState<string | null>(
     null
   )
+
+  const {
+    scope,
+    tx,
+    queryParamsError,
+    loading,
+    userAlreadyWriteAuthorized,
+    apiKey,
+    appName,
+    userEmail,
+    authorize
+  } = useOAuthSetup()
 
   const clearErrors = () => {
     setGeneralSubmitError(null)
@@ -283,229 +96,21 @@ export const OAuthLoginPage = () => {
     )
   }
 
-  useEffect(() => {
-    if (!queryParamsError) {
-      record(
-        make(Name.AUDIUS_OAUTH_START, {
-          redirectUriParam:
-            parsedRedirectUri === 'postmessage' ? 'postmessage' : redirectUri!,
-          originParam,
-          responseMode,
-          scope: scope!,
-          apiKeyParam: apiKey,
-          appId: (apiKey || appName)!
-        })
-      )
-    }
-  }, [
-    appName,
-    originParam,
-    parsedRedirectUri,
-    queryParamsError,
-    record,
-    redirectUri,
-    responseMode,
-    apiKey,
-    scope
-  ])
-
-  useEffect(() => {
-    const fetchDeveloperAppName = async () => {
-      if (!apiKey || queryParamsError) {
-        return
-      }
-      let developerApp
-      try {
-        developerApp = await getDeveloperApp(apiKey as string)
-      } catch {
-        setQueryParamsError(messages.invalidApiKeyError)
-        return
-      }
-      if (!developerApp) {
-        setQueryParamsError(messages.invalidApiKeyError)
-        return
-      }
-      setRegisteredDeveloperAppName(developerApp.name)
-    }
-    fetchDeveloperAppName()
-  }, [apiKey, queryParamAppName, queryParamsError, scope])
-
-  const formResponseAndRedirect = useCallback(
-    async ({
-      account,
-      grantCreated
+  const handleAuthError = useCallback(
+    ({
+      isUserError,
+      errorMessage,
+      error
     }: {
-      account: User
-      grantCreated?: boolean | undefined
+      isUserError: boolean
+      errorMessage: string
+      error?: Error
     }) => {
-      const jwt = await formOAuthResponse({
-        account,
-        userEmail,
-        onError: () => {
-          dispatch(
-            errorActions.handleError({
-              name: 'Form OAuth Response Error',
-              message: 'Form OAuth Response Error',
-              shouldRedirect: true
-            })
-          )
-        }
-      })
-      if (jwt == null) {
-        setIsSubmitting(false)
-        setAndLogGeneralSubmitError(false, messages.miscError)
-        return
-      }
-      if (isRedirectValid === true) {
-        record(
-          make(Name.AUDIUS_OAUTH_COMPLETE, {
-            appId: (apiKey || appName)!,
-            scope: scope!,
-            alreadyAuthorized: grantCreated
-          })
-        )
-        if (parsedRedirectUri === 'postmessage') {
-          if (parsedOrigin) {
-            if (!window.opener) {
-              setAndLogGeneralSubmitError(false, messages.noWindowError)
-              setIsSubmitting(false)
-            } else {
-              window.opener.postMessage(
-                { state, token: jwt },
-                parsedOrigin.origin
-              )
-            }
-          }
-        } else {
-          if (responseMode && responseMode === 'query') {
-            if (state != null) {
-              parsedRedirectUri!.searchParams.append('state', state as string)
-            }
-            parsedRedirectUri!.searchParams.append('token', jwt)
-          } else {
-            const statePart = state != null ? `state=${state}&` : ''
-            parsedRedirectUri!.hash = `#${statePart}token=${jwt}`
-          }
-          window.location.href = parsedRedirectUri!.toString()
-        }
-      }
+      setIsSubmitting(false)
+      setAndLogGeneralSubmitError(isUserError, errorMessage, error)
     },
-    [
-      isRedirectValid,
-      parsedOrigin,
-      parsedRedirectUri,
-      record,
-      responseMode,
-      setAndLogGeneralSubmitError,
-      state,
-      userEmail,
-      apiKey,
-      appName,
-      scope,
-      dispatch
-    ]
+    [setAndLogGeneralSubmitError]
   )
-
-  useEffect(() => {
-    const getInitialAuthorizationStatus = async () => {
-      if (queryParamsError || !apiKey || !isLoggedIn) {
-        setUserAlreadyWriteAuthorized(false)
-        return
-      }
-      let appAlreadyAuthorized
-      try {
-        appAlreadyAuthorized = await getIsAppAuthorized({
-          userId: encodeHashId(account!.user_id), // We know account exists because isLoggedIn is true
-          apiKey: apiKey as string
-        })
-      } catch (e) {
-        if (e instanceof Error) {
-          reportToSentry({ level: ErrorLevel.Error, error: e })
-        }
-        dispatch(
-          errorActions.handleError({
-            name: 'Get Is App Authorized',
-            message: 'Get Is App Authorized',
-            shouldRedirect: true
-          })
-        )
-        return
-      }
-      setUserAlreadyWriteAuthorized(appAlreadyAuthorized)
-    }
-    getInitialAuthorizationStatus()
-  }, [
-    account,
-    apiKey,
-    formResponseAndRedirect,
-    history,
-    isLoggedIn,
-    queryParamsError,
-    scope,
-    dispatch
-  ])
-
-  useEffect(() => {
-    const getAndSetEmail = async () => {
-      let email: string
-      try {
-        email = await audiusBackendInstance.getUserEmail()
-      } catch {
-        setUserEmail(null)
-        dispatch(
-          errorActions.handleError({
-            name: 'Get User Email',
-            message: 'Get User Email',
-            shouldRedirect: true
-          })
-        )
-        return
-      }
-      setUserEmail(email)
-    }
-    if (isLoggedIn) {
-      getAndSetEmail()
-    } else {
-      setUserEmail(null)
-    }
-  }, [history, isLoggedIn, dispatch])
-
-  const authorize = async (account: User) => {
-    let shouldCreateWriteGrant
-
-    if (scope === 'write') {
-      try {
-        shouldCreateWriteGrant = await getIsAppAuthorized({
-          userId: encodeHashId(account.user_id),
-          apiKey: apiKey as string
-        })
-        if (!shouldCreateWriteGrant) {
-          await authWrite({
-            userId: encodeHashId(account.user_id),
-            appApiKey: apiKey as string
-          })
-        }
-      } catch (e: unknown) {
-        setIsSubmitting(false)
-        let errorMessage = 'Creating write grant failed'
-        if (typeof e === 'string') {
-          errorMessage = e.toUpperCase()
-        } else if (e instanceof Error) {
-          errorMessage = e.message
-        }
-        setAndLogGeneralSubmitError(
-          false,
-          errorMessage,
-          e instanceof Error ? e : undefined
-        )
-        return
-      }
-    }
-    await formResponseAndRedirect({
-      account,
-      grantCreated: shouldCreateWriteGrant
-    })
-  }
 
   const handleSignInFormSubmit = async (e: FormEvent) => {
     e.preventDefault()
@@ -543,7 +148,10 @@ export const OAuthLoginPage = () => {
       signInResponse.user.name
     ) {
       // Success - perform Oauth authorization
-      await authorize(signInResponse.user)
+      await authorize({
+        account: signInResponse.user,
+        onError: handleAuthError
+      })
     } else if (
       (!signInResponse.error &&
         signInResponse.user &&
@@ -571,7 +179,7 @@ export const OAuthLoginPage = () => {
       setAndLogGeneralSubmitError(false, messages.miscError)
     } else {
       setIsSubmitting(true)
-      authorize(account)
+      authorize({ account, onError: handleAuthError })
     }
   }
 
@@ -617,6 +225,7 @@ export const OAuthLoginPage = () => {
       {userAlreadyWriteAuthorized ? null : (
         <PermissionsSection
           scope={scope}
+          tx={tx as WriteOnceTx}
           userEmail={userEmail}
           isLoggedIn={isLoggedIn}
         />

--- a/packages/web/src/pages/oauth-login-page/components/CTAButton.tsx
+++ b/packages/web/src/pages/oauth-login-page/components/CTAButton.tsx
@@ -1,0 +1,25 @@
+import { Button, ButtonProps, IconArrow } from '@audius/stems'
+
+import LoadingSpinner from 'components/loading-spinner/LoadingSpinner'
+
+import styles from '../OAuthLoginPage.module.css'
+
+export const CTAButton = ({
+  isSubmitting,
+  ...restProps
+}: { isSubmitting: boolean } & ButtonProps) => {
+  return (
+    <Button
+      isDisabled={isSubmitting}
+      rightIcon={
+        isSubmitting ? (
+          <LoadingSpinner className={styles.buttonLoadingSpinner} />
+        ) : (
+          <IconArrow />
+        )
+      }
+      className={styles.ctaButton}
+      {...restProps}
+    />
+  )
+}

--- a/packages/web/src/pages/oauth-login-page/components/ContentWrapper.tsx
+++ b/packages/web/src/pages/oauth-login-page/components/ContentWrapper.tsx
@@ -1,0 +1,18 @@
+import { ReactNode } from 'react'
+
+import HorizontalLogo from 'assets/img/Horizontal-Logo-Full-Color.png'
+
+import styles from '../OAuthLoginPage.module.css'
+
+export const ContentWrapper = ({ children }: { children: ReactNode }) => (
+  <div className={styles.wrapper}>
+    <div className={styles.container}>
+      <div className={styles.centeredContent}>
+        <div className={styles.logoContainer}>
+          <img src={HorizontalLogo} className={styles.logo} alt='Audius Logo' />
+        </div>
+      </div>
+      {children}
+    </div>
+  </div>
+)

--- a/packages/web/src/pages/oauth-login-page/components/PermissionsSection.tsx
+++ b/packages/web/src/pages/oauth-login-page/components/PermissionsSection.tsx
@@ -1,3 +1,5 @@
+import { PropsWithChildren } from 'react'
+
 import { IconAtSign, IconPencil, IconVisibilityPublic } from '@audius/stems'
 import cn from 'classnames'
 
@@ -6,7 +8,6 @@ import LoadingSpinner from 'components/loading-spinner/LoadingSpinner'
 import styles from '../OAuthLoginPage.module.css'
 import { messages } from '../messages'
 import { WriteOnceParams, WriteOnceTx } from '../utils'
-import { PropsWithChildren } from 'react'
 
 type PermissionTextProps = PropsWithChildren<{}>
 const PermissionText = ({ children }: PermissionTextProps) => {

--- a/packages/web/src/pages/oauth-login-page/components/PermissionsSection.tsx
+++ b/packages/web/src/pages/oauth-login-page/components/PermissionsSection.tsx
@@ -1,0 +1,115 @@
+import { IconAtSign, IconPencil, IconVisibilityPublic } from '@audius/stems'
+import cn from 'classnames'
+
+import LoadingSpinner from 'components/loading-spinner/LoadingSpinner'
+
+import styles from '../OAuthLoginPage.module.css'
+import { messages } from '../messages'
+import { WriteOnceTx } from '../utils'
+
+export const PermissionsSection = ({
+  scope,
+  isLoggedIn,
+  userEmail
+}: {
+  scope: string | string[] | null
+  tx: WriteOnceTx | null
+  isLoggedIn: boolean
+  userEmail?: string | null
+}) => {
+  return (
+    <>
+      <div className={styles.permsTitleContainer}>
+        <h3 className={styles.infoSectionTitle}>
+          {messages.permissionsRequestedHeader}
+        </h3>
+      </div>
+      <div className={styles.tile}>
+        <div className={styles.permissionContainer}>
+          <div
+            className={cn({
+              [styles.visibilityIconWrapper]: scope === 'read'
+            })}
+          >
+            {scope === 'write' ? (
+              <IconPencil
+                className={cn(styles.permissionIcon)}
+                width={18}
+                height={18}
+              />
+            ) : (
+              <IconVisibilityPublic
+                className={cn(styles.permissionIcon, styles.visibilityIcon)}
+                width={21}
+                height={22}
+              />
+            )}
+          </div>
+
+          <div className={styles.permissionTextContainer}>
+            <span className={styles.permissionText}>
+              {scope === 'write'
+                ? messages.writeAccountAccess
+                : messages.readOnlyAccountAccess}
+            </span>
+            {scope !== 'write' ? null : (
+              <div className={cn(styles.permissionDetailTextContainer)}>
+                <p
+                  className={cn(
+                    styles.permissionText,
+                    styles.permissionDetailText
+                  )}
+                >
+                  {messages.doesNotGrantAccessTo}
+                  <br />
+                  {messages.walletsOrDMs}
+                </p>
+              </div>
+            )}
+          </div>
+        </div>
+        <div
+          className={cn(
+            styles.permissionContainer,
+            styles.nonFirstPermissionContainer
+          )}
+        >
+          <div>
+            <IconAtSign
+              width={15}
+              height={15}
+              className={cn(styles.permissionIcon, styles.atSignIcon)}
+            />
+          </div>
+          <div className={styles.permissionTextContainer}>
+            <span className={styles.permissionText}>
+              {messages.emailAddressAccess}
+            </span>
+            {isLoggedIn ? (
+              <div className={cn(styles.permissionDetailTextContainer)}>
+                <span
+                  className={cn(
+                    styles.permissionText,
+                    styles.permissionDetailText,
+                    {
+                      [styles.permissionTextExtraLight]: !userEmail
+                    }
+                  )}
+                >
+                  {userEmail == null ? (
+                    <>
+                      <LoadingSpinner className={styles.loadingSpinner} />{' '}
+                      {messages.emailLoading}&#8230;
+                    </>
+                  ) : (
+                    userEmail
+                  )}
+                </span>
+              </div>
+            ) : null}
+          </div>
+        </div>
+      </div>
+    </>
+  )
+}

--- a/packages/web/src/pages/oauth-login-page/components/PermissionsSection.tsx
+++ b/packages/web/src/pages/oauth-login-page/components/PermissionsSection.tsx
@@ -5,17 +5,44 @@ import LoadingSpinner from 'components/loading-spinner/LoadingSpinner'
 
 import styles from '../OAuthLoginPage.module.css'
 import { messages } from '../messages'
-import { WriteOnceTx } from '../utils'
+import { WriteOnceParams, WriteOnceTx } from '../utils'
+import { PropsWithChildren } from 'react'
+
+type PermissionTextProps = PropsWithChildren<{}>
+const PermissionText = ({ children }: PermissionTextProps) => {
+  return <span className={styles.permissionText}>{children}</span>
+}
+
+type PermissionDetailProps = PropsWithChildren<{
+  className?: string
+}>
+const PermissionDetail = ({ className, children }: PermissionDetailProps) => {
+  return (
+    <div className={cn(styles.permissionDetailTextContainer)}>
+      <span
+        className={cn(
+          styles.permissionText,
+          styles.permissionDetailText,
+          className
+        )}
+      >
+        {children}
+      </span>
+    </div>
+  )
+}
 
 export const PermissionsSection = ({
   scope,
   isLoggedIn,
-  userEmail
+  userEmail,
+  txParams
 }: {
   scope: string | string[] | null
   tx: WriteOnceTx | null
   isLoggedIn: boolean
   userEmail?: string | null
+  txParams?: WriteOnceParams
 }) => {
   return (
     <>
@@ -31,7 +58,7 @@ export const PermissionsSection = ({
               [styles.visibilityIconWrapper]: scope === 'read'
             })}
           >
-            {scope === 'write' ? (
+            {scope === 'write' || scope === 'write_once' ? (
               <IconPencil
                 className={cn(styles.permissionIcon)}
                 width={18}
@@ -47,25 +74,25 @@ export const PermissionsSection = ({
           </div>
 
           <div className={styles.permissionTextContainer}>
-            <span className={styles.permissionText}>
+            <PermissionText>
               {scope === 'write'
                 ? messages.writeAccountAccess
+                : scope === 'write_once'
+                ? messages.connectDashboardWalletAccess
                 : messages.readOnlyAccountAccess}
-            </span>
-            {scope !== 'write' ? null : (
-              <div className={cn(styles.permissionDetailTextContainer)}>
-                <p
-                  className={cn(
-                    styles.permissionText,
-                    styles.permissionDetailText
-                  )}
-                >
-                  {messages.doesNotGrantAccessTo}
-                  <br />
-                  {messages.walletsOrDMs}
-                </p>
-              </div>
-            )}
+            </PermissionText>
+            {scope === 'write' ? (
+              <PermissionDetail>
+                {messages.doesNotGrantAccessTo}
+                <br />
+                {messages.walletsOrDMs}
+              </PermissionDetail>
+            ) : null}
+            {scope === 'write_once' ? (
+              <PermissionDetail>
+                {txParams?.wallet.slice(0, 4)}...{txParams?.wallet.slice(-4)}
+              </PermissionDetail>
+            ) : null}
           </div>
         </div>
         <div
@@ -82,30 +109,24 @@ export const PermissionsSection = ({
             />
           </div>
           <div className={styles.permissionTextContainer}>
-            <span className={styles.permissionText}>
-              {messages.emailAddressAccess}
-            </span>
+            <PermissionText>{messages.emailAddressAccess}</PermissionText>
             {isLoggedIn ? (
-              <div className={cn(styles.permissionDetailTextContainer)}>
-                <span
-                  className={cn(
-                    styles.permissionText,
-                    styles.permissionDetailText,
-                    {
-                      [styles.permissionTextExtraLight]: !userEmail
-                    }
-                  )}
-                >
-                  {userEmail == null ? (
-                    <>
-                      <LoadingSpinner className={styles.loadingSpinner} />{' '}
-                      {messages.emailLoading}&#8230;
-                    </>
-                  ) : (
-                    userEmail
-                  )}
-                </span>
-              </div>
+              <PermissionDetail
+                className={
+                  userEmail == null
+                    ? styles.permissionTextExtraLight
+                    : undefined
+                }
+              >
+                {userEmail == null ? (
+                  <>
+                    <LoadingSpinner className={styles.loadingSpinner} />{' '}
+                    {messages.emailLoading}&#8230;
+                  </>
+                ) : (
+                  userEmail
+                )}
+              </PermissionDetail>
             ) : null}
           </div>
         </div>

--- a/packages/web/src/pages/oauth-login-page/hooks.ts
+++ b/packages/web/src/pages/oauth-login-page/hooks.ts
@@ -1,10 +1,36 @@
-import { useMemo } from 'react'
+import { useCallback, useEffect, useMemo, useState } from 'react'
 
+import {
+  accountSelectors,
+  CommonState,
+  encodeHashId,
+  ErrorLevel,
+  Name,
+  statusIsNotFinalized,
+  User
+} from '@audius/common'
 import * as queryString from 'query-string'
-import { useLocation } from 'react-router-dom'
+import { useDispatch, useSelector } from 'react-redux'
+import { useHistory, useLocation } from 'react-router-dom'
+
+import { make, useRecord } from 'common/store/analytics/actions'
+import { audiusBackendInstance } from 'services/audius-backend/audius-backend-instance'
+import * as errorActions from 'store/errors/actions'
+import { reportToSentry } from 'store/errors/reportToSentry'
 
 import { messages } from './messages'
-import { getIsRedirectValid, isValidApiKey } from './utils'
+import {
+  authWrite,
+  connectUserToDashboardWallet,
+  formOAuthResponse,
+  getDeveloperApp,
+  getIsAppAuthorized,
+  getIsRedirectValid,
+  isValidApiKey,
+  validateWriteOnceParams,
+  WriteOnceParams
+} from './utils'
+const { getAccountUser, getAccountStatus } = accountSelectors
 
 export const useParsedQueryParams = () => {
   const { search } = useLocation()
@@ -16,7 +42,9 @@ export const useParsedQueryParams = () => {
     app_name: appName,
     response_mode: responseMode,
     api_key: apiKey,
-    origin
+    origin,
+    tx,
+    ...rest
   } = queryString.parse(search)
 
   const parsedRedirectUri = useMemo<'postmessage' | URL | null>(() => {
@@ -48,33 +76,55 @@ export const useParsedQueryParams = () => {
     return null
   }, [origin])
 
-  let initError: string | null = null
-  if (isRedirectValid === false) {
-    initError = messages.redirectURIInvalidError
-  } else if (parsedRedirectUri === 'postmessage' && !parsedOrigin) {
-    // Only applicable if redirect URI set to `postMessage`
-    initError = messages.originInvalidError
-  } else if (scope !== 'read' && scope !== 'write') {
-    initError = messages.scopeError
-  } else if (
-    responseMode &&
-    responseMode !== 'query' &&
-    responseMode !== 'fragment'
-  ) {
-    initError = messages.responseModeError
-  } else if (scope === 'read') {
-    // Read scope-specific validations:
-    if (!appName && !apiKey) {
-      initError = messages.missingAppNameError
+  const { error, txParams } = useMemo(() => {
+    let error: string | null = null
+    let txParams: WriteOnceParams | null = null // Only used for scope=write_once
+    if (isRedirectValid === false) {
+      error = messages.redirectURIInvalidError
+    } else if (parsedRedirectUri === 'postmessage' && !parsedOrigin) {
+      // Only applicable if redirect URI set to `postMessage`
+      error = messages.originInvalidError
+    } else if (
+      scope !== 'read' &&
+      scope !== 'write' &&
+      scope !== 'write_once'
+    ) {
+      error = messages.scopeError
+    } else if (
+      responseMode &&
+      responseMode !== 'query' &&
+      responseMode !== 'fragment'
+    ) {
+      error = messages.responseModeError
+    } else if (scope === 'read') {
+      // Read scope-specific validations:
+      if (!appName && !apiKey) {
+        error = messages.missingAppNameError
+      }
+    } else if (scope === 'write') {
+      // Write scope-specific validations:
+      if (!apiKey) {
+        error = messages.missingApiKeyError
+      } else if (!isValidApiKey(apiKey)) {
+        error = messages.invalidApiKeyError
+      }
+    } else if (scope === 'write_once') {
+      // Write-once scope-specific validations:
+      const { error: writeOnceParamsError, txParams: txParamsRes } =
+        validateWriteOnceParams({
+          tx,
+          params: rest
+        })
+      txParams = txParamsRes
+
+      if (writeOnceParamsError) {
+        error = writeOnceParamsError
+      }
     }
-  } else if (scope === 'write') {
-    // Write scope-specific validations:
-    if (!apiKey) {
-      initError = messages.missingApiKeyError
-    } else if (!isValidApiKey(apiKey)) {
-      initError = messages.invalidApiKeyError
-    }
-  }
+    return { txParams, error }
+    // This is exhaustive despite what eslint thinks:
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isRedirectValid, parsedOrigin, parsedRedirectUri, search])
 
   return {
     apiKey,
@@ -87,6 +137,334 @@ export const useParsedQueryParams = () => {
     parsedRedirectUri,
     isRedirectValid,
     parsedOrigin,
+    error,
+    tx,
+    txParams
+  }
+}
+
+export const useOAuthSetup = () => {
+  const record = useRecord()
+  const history = useHistory()
+  const dispatch = useDispatch()
+  const {
+    appName: queryParamAppName,
+    apiKey,
+    scope,
+    redirectUri,
+    state,
+    responseMode,
+    origin: originParam,
+    parsedRedirectUri,
+    isRedirectValid,
+    parsedOrigin,
+    txParams,
+    tx,
     error: initError
+  } = useParsedQueryParams()
+  const accountIsLoading = useSelector((state: CommonState) => {
+    const status = getAccountStatus(state)
+    return statusIsNotFinalized(status)
+  })
+  const account = useSelector(getAccountUser)
+  const isLoggedIn = Boolean(account)
+  const [userEmail, setUserEmail] = useState<string | null>(null)
+  const [queryParamsError, setQueryParamsError] = useState<string | null>(
+    initError
+  )
+  /** The fetched developer app name if write OAuth (we use `queryParamAppName` if read or writeOnce OAuth and no API key is given) */
+  const [registeredDeveloperAppName, setRegisteredDeveloperAppName] =
+    useState<string>()
+  const appName = registeredDeveloperAppName ?? queryParamAppName
+
+  const [userAlreadyWriteAuthorized, setUserAlreadyWriteAuthorized] =
+    useState<boolean>()
+
+  const loading =
+    accountIsLoading ||
+    (apiKey &&
+      (registeredDeveloperAppName === undefined ||
+        userAlreadyWriteAuthorized === undefined))
+
+  useEffect(() => {
+    if (!queryParamsError) {
+      record(
+        make(Name.AUDIUS_OAUTH_START, {
+          redirectUriParam:
+            parsedRedirectUri === 'postmessage' ? 'postmessage' : redirectUri!,
+          originParam,
+          responseMode,
+          scope: scope!,
+          apiKeyParam: apiKey,
+          appId: (apiKey || appName)!
+        })
+      )
+    }
+  }, [
+    appName,
+    originParam,
+    parsedRedirectUri,
+    queryParamsError,
+    record,
+    redirectUri,
+    responseMode,
+    apiKey,
+    scope
+  ])
+
+  useEffect(() => {
+    const fetchDeveloperAppName = async () => {
+      if (!apiKey || queryParamsError) {
+        return
+      }
+      let developerApp
+      try {
+        developerApp = await getDeveloperApp(apiKey as string)
+      } catch {
+        setQueryParamsError(messages.invalidApiKeyError)
+        return
+      }
+      if (!developerApp) {
+        setQueryParamsError(messages.invalidApiKeyError)
+        return
+      }
+      setRegisteredDeveloperAppName(developerApp.name)
+    }
+    fetchDeveloperAppName()
+  }, [apiKey, queryParamAppName, queryParamsError, scope])
+
+  useEffect(() => {
+    const getAndSetEmail = async () => {
+      let email: string
+      try {
+        email = await audiusBackendInstance.getUserEmail()
+      } catch {
+        setUserEmail(null)
+        dispatch(
+          errorActions.handleError({
+            name: 'Get User Email',
+            message: 'Get User Email',
+            shouldRedirect: true
+          })
+        )
+        return
+      }
+      setUserEmail(email)
+    }
+    if (isLoggedIn) {
+      getAndSetEmail()
+    } else {
+      setUserEmail(null)
+    }
+  }, [history, isLoggedIn, dispatch])
+
+  const formResponseAndRedirect = useCallback(
+    async ({
+      account,
+      grantCreated,
+      onError
+    }: {
+      account: User
+      grantCreated?: boolean | undefined
+      onError: ({
+        isUserError,
+        errorMessage,
+        error
+      }: {
+        isUserError: boolean
+        errorMessage: string
+        error?: Error
+      }) => void
+    }) => {
+      const jwt = await formOAuthResponse({
+        account,
+        userEmail,
+        onError: () => {
+          dispatch(
+            errorActions.handleError({
+              name: 'Form OAuth Response Error',
+              message: 'Form OAuth Response Error',
+              shouldRedirect: true
+            })
+          )
+        }
+      })
+      if (jwt == null) {
+        onError({ isUserError: false, errorMessage: messages.miscError })
+        return
+      }
+      if (isRedirectValid === true) {
+        record(
+          make(Name.AUDIUS_OAUTH_COMPLETE, {
+            appId: (apiKey || appName)!,
+            scope: scope!,
+            alreadyAuthorized: grantCreated
+          })
+        )
+        if (parsedRedirectUri === 'postmessage') {
+          if (parsedOrigin) {
+            if (!window.opener) {
+              onError({
+                isUserError: false,
+                errorMessage: messages.noWindowError
+              })
+            } else {
+              window.opener.postMessage(
+                { state, token: jwt },
+                parsedOrigin.origin
+              )
+            }
+          }
+        } else {
+          if (responseMode && responseMode === 'query') {
+            if (state != null) {
+              parsedRedirectUri!.searchParams.append('state', state as string)
+            }
+            parsedRedirectUri!.searchParams.append('token', jwt)
+          } else {
+            const statePart = state != null ? `state=${state}&` : ''
+            parsedRedirectUri!.hash = `#${statePart}token=${jwt}`
+          }
+          window.location.href = parsedRedirectUri!.toString()
+        }
+      }
+    },
+    [
+      isRedirectValid,
+      parsedOrigin,
+      parsedRedirectUri,
+      record,
+      responseMode,
+      state,
+      userEmail,
+      apiKey,
+      appName,
+      scope,
+      dispatch
+    ]
+  )
+
+  useEffect(() => {
+    const getInitialAuthorizationStatus = async () => {
+      if (queryParamsError || !apiKey || !isLoggedIn) {
+        setUserAlreadyWriteAuthorized(false)
+        return
+      }
+      let appAlreadyAuthorized
+      try {
+        appAlreadyAuthorized = await getIsAppAuthorized({
+          userId: encodeHashId(account!.user_id), // We know account exists because isLoggedIn is true
+          apiKey: apiKey as string
+        })
+      } catch (e) {
+        if (e instanceof Error) {
+          reportToSentry({ level: ErrorLevel.Error, error: e })
+        }
+        dispatch(
+          errorActions.handleError({
+            name: 'Get Is App Authorized',
+            message: 'Get Is App Authorized',
+            shouldRedirect: true
+          })
+        )
+        return
+      }
+      setUserAlreadyWriteAuthorized(appAlreadyAuthorized)
+    }
+    getInitialAuthorizationStatus()
+  }, [
+    account,
+    apiKey,
+    formResponseAndRedirect,
+    history,
+    isLoggedIn,
+    queryParamsError,
+    scope,
+    dispatch
+  ])
+
+  const authorize = async ({
+    account,
+    onError
+  }: {
+    account: User
+    onError: ({
+      isUserError,
+      errorMessage,
+      error
+    }: {
+      isUserError: boolean
+      errorMessage: string
+      error?: Error
+    }) => void
+  }) => {
+    let shouldCreateWriteGrant = false
+
+    if (scope === 'write') {
+      try {
+        shouldCreateWriteGrant = !(await getIsAppAuthorized({
+          userId: encodeHashId(account.user_id),
+          apiKey: apiKey as string
+        }))
+        if (shouldCreateWriteGrant) {
+          await authWrite({
+            userId: encodeHashId(account.user_id),
+            appApiKey: apiKey as string
+          })
+        }
+      } catch (e: unknown) {
+        let error = 'Creating write grant failed'
+        if (typeof e === 'string') {
+          error = e.toUpperCase()
+        } else if (e instanceof Error) {
+          error = e.message
+        }
+        onError({
+          isUserError: false,
+          errorMessage: messages.miscError,
+          error: e instanceof Error ? e : new Error(error)
+        })
+        return
+      }
+    } else if (scope === 'write_once') {
+      // Note: Tx = 'connect_dashboard_wallet' since that's the only option available right now for write_once scope
+      try {
+        await connectUserToDashboardWallet({
+          userId: encodeHashId(account.user_id),
+          wallet: txParams!.wallet,
+          walletSignature: txParams!.wallet_signature
+        })
+      } catch (e: unknown) {
+        let error = 'Connecting dashboard wallet failed'
+        if (typeof e === 'string') {
+          error = e
+        } else if (e instanceof Error) {
+          error = e.message
+        }
+        onError({
+          isUserError: false,
+          errorMessage: messages.miscError,
+          error: e instanceof Error ? e : new Error(error)
+        })
+        return
+      }
+    }
+    await formResponseAndRedirect({
+      account,
+      grantCreated: shouldCreateWriteGrant,
+      onError
+    })
+  }
+
+  return {
+    scope,
+    queryParamsError,
+    loading,
+    userAlreadyWriteAuthorized,
+    apiKey,
+    appName,
+    userEmail,
+    authorize,
+    tx
   }
 }

--- a/packages/web/src/pages/oauth-login-page/messages.ts
+++ b/packages/web/src/pages/oauth-login-page/messages.ts
@@ -24,6 +24,9 @@ export const messages = {
     'Whoops, this is an invalid link (redirect URI missing or invalid).',
   missingAppNameError: 'Whoops, this is an invalid link (app name missing).',
   scopeError: `Whoops, this is an invalid link (scope missing or invalid).`,
+  writeOnceParamsError:
+    'Whoops, this is an invalid link (transaction params missing or invalid).',
+  writeOnceTxError: `Whoops, this is an invalid link ('tx' missing or invalid).`,
   missingFieldError: 'Whoops, you must enter both your email and password.',
   originInvalidError:
     'Whoops, this is an invalid link (redirect URI is set to `postMessage` but origin is missing).',

--- a/packages/web/src/pages/oauth-login-page/messages.ts
+++ b/packages/web/src/pages/oauth-login-page/messages.ts
@@ -6,6 +6,8 @@ export const messages = {
   alreadyAuthorizedContinuePrompt: (appName: string) => `Sign in to ${appName}`,
   permissionsRequestedHeader: 'This application will receive',
   readOnlyAccountAccess: 'Read-only access to your account',
+  connectDashboardWalletAccess:
+    'Permission to link this wallet to your account',
   writeAccountAccess: 'Read/Write access to your account',
   emailLoading: 'Email loading',
   emailAddressAccess: 'Your Email Address',

--- a/packages/web/src/pages/oauth-login-page/utils.ts
+++ b/packages/web/src/pages/oauth-login-page/utils.ts
@@ -1,10 +1,6 @@
-import { encodeHashId, User, SquareSizes } from '@audius/common'
-import {
-  CreateGrantRequest,
-  CreateDashboardWalletUserRequest
-} from '@audius/sdk'
+import { SquareSizes, User, encodeHashId } from '@audius/common'
+import { CreateGrantRequest } from '@audius/sdk'
 import base64url from 'base64url'
-import { isEmpty } from 'lodash'
 
 import { audiusBackendInstance } from 'services/audius-backend/audius-backend-instance'
 import { audiusSdk } from 'services/audius-sdk'
@@ -172,7 +168,7 @@ export const formOAuthResponse = async ({
     handle: account?.handle,
     verified: account?.is_verified,
     profilePicture,
-    ...(txSignature ? { txSignature: txSignature } : {}),
+    ...(txSignature ? { txSignature } : {}),
     sub: userId,
     iat: timestamp
   }


### PR DESCRIPTION
### Description
1. Move a lot of logic from `OAuthLoginPage` component into a separate hook for cleanliness, since it was getting unwieldy. This is why the PR looks so big, but a lot of it is just copy paste.

3. Introduce changes to support the "Connect User to Wallet" protocol dashboard feature.
    - Add new scope, `write_once`, which is to be used when a developer app needs the user to authorize/sign one transaction, which will then be sent by the Audius Client.
        - For this scope, the app needs to specify the `tx` in the query params as well as any other params needed for that tx. 
    - Add `tx=connect_dashboard_wallet` as the first available transaction for the `write_once` scope. For this tx, the app needs to also specify the `wallet` and `wallet_signature` in the query params.
        - Once the user signs in under these conditions, the Audius client will send the `ConnectDashboardWallet` EM transaction with the `wallet` and `wallet_signature` from the query params.

### How Has This Been Tested?
Tested in browser. Also tested old flows (read and write, signed in and not signed in, authorized and not yet authorized).

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._
