### PR TITLE
[C-3521] Add option menu to create collection tile (web)

### DIFF
--- a/packages/common/src/models/Analytics.ts
+++ b/packages/common/src/models/Analytics.ts
@@ -833,7 +833,7 @@ type EmbedCopy = {
 // Track Upload
 type TrackUploadOpen = {
   eventName: Name.TRACK_UPLOAD_OPEN
-  source: 'nav' | 'profile' | 'signup'
+  source: 'nav' | 'profile' | 'signup' | 'library'
 }
 type TrackUploadStartUploading = {
   eventName: Name.TRACK_UPLOAD_START_UPLOADING

--- a/packages/web/src/components/tile/Tile.tsx
+++ b/packages/web/src/components/tile/Tile.tsx
@@ -1,4 +1,11 @@
-import { ReactNode, ComponentType, ComponentProps, ElementType } from 'react'
+import {
+  ReactNode,
+  ComponentType,
+  ComponentProps,
+  ElementType,
+  forwardRef,
+  Ref
+} from 'react'
 
 import { DogEarType } from '@audius/common'
 import cn from 'classnames'
@@ -19,40 +26,42 @@ export type TileProps<TileComponentType extends ElementType> =
   TileOwnProps<TileComponentType> &
     Omit<ComponentProps<TileComponentType>, keyof TileOwnProps>
 
-export const Tile = <
-  T extends ElementType = ComponentType<ComponentProps<'div'>>
->(
-  props: TileProps<T>
-) => {
-  const {
-    children,
-    size,
-    onClick,
-    as: RootComponent = onClick ? 'button' : 'div',
-    className,
-    dogEar,
-    elevation = 'near',
-    ...other
-  } = props
+export const Tile = forwardRef(
+  <T extends ElementType = ComponentType<ComponentProps<'div'>>>(
+    props: TileProps<T>,
+    ref: Ref<HTMLButtonElement>
+  ) => {
+    const {
+      children,
+      size,
+      onClick,
+      as: RootComponent = onClick ? 'button' : 'div',
+      className,
+      dogEar,
+      elevation = 'near',
+      ...other
+    } = props
 
-  return (
-    <RootComponent
-      className={cn(
-        styles.root,
-        size && styles[size],
-        styles[elevation],
-        className
-      )}
-      type={onClick ? 'button' : undefined}
-      onClick={onClick}
-      {...other}
-    >
-      {dogEar ? (
-        <div className={styles.borderOffset}>
-          <DogEar type={dogEar} />
-        </div>
-      ) : null}
-      {children}
-    </RootComponent>
-  )
-}
+    return (
+      <RootComponent
+        className={cn(
+          styles.root,
+          size && styles[size],
+          styles[elevation],
+          className
+        )}
+        type={onClick ? 'button' : undefined}
+        onClick={onClick}
+        ref={ref}
+        {...other}
+      >
+        {dogEar ? (
+          <div className={styles.borderOffset}>
+            <DogEar type={dogEar} />
+          </div>
+        ) : null}
+        {children}
+      </RootComponent>
+    )
+  }
+)

--- a/packages/web/src/components/upload/UploadChip.tsx
+++ b/packages/web/src/components/upload/UploadChip.tsx
@@ -2,6 +2,7 @@ import { Ref, useCallback, useMemo } from 'react'
 
 import {
   CreatePlaylistSource,
+  FeatureFlags,
   Name,
   cacheCollectionsActions
 } from '@audius/common'
@@ -18,6 +19,7 @@ import { useDispatch } from 'react-redux'
 
 import IconUpload from 'assets/img/iconUpload.svg'
 import { Tile } from 'components/tile'
+import { useFlag } from 'hooks/useRemoteConfig'
 import { track, make } from 'services/analytics'
 import { UPLOAD_PAGE } from 'utils/route'
 
@@ -56,6 +58,7 @@ const UploadChip = ({
   isFirst = false,
   source
 }: UploadChipProps) => {
+  const { isEnabled: isEditAlbumsEnabled } = useFlag(FeatureFlags.EDIT_ALBUMS)
   const messages = getMessages(type)
   const icon =
     type === 'track' || type === 'album' ? (
@@ -92,8 +95,10 @@ const UploadChip = ({
   const handleCreateCollection = useCallback(() => {
     dispatch(
       (type === 'album' ? createAlbum : createPlaylist)(
-        {},
-        source as CreatePlaylistSource
+        { playlist_name: `New ${type}` },
+        source as CreatePlaylistSource,
+        undefined,
+        'route'
       )
     )
   }, [dispatch, source, type])
@@ -133,7 +138,7 @@ const UploadChip = ({
     </Tile>
   )
 
-  return type === 'track' ? (
+  return !isEditAlbumsEnabled || type === 'track' ? (
     renderTile({ onClick: handleClickUpload })
   ) : (
     <PopupMenu

--- a/packages/web/src/components/upload/UploadChip.tsx
+++ b/packages/web/src/components/upload/UploadChip.tsx
@@ -7,11 +7,14 @@ import {
   cacheCollectionsActions
 } from '@audius/common'
 import {
+  Box,
   HTMLButtonProps,
   IconCloudUpload,
-  IconPlaylists
+  IconPlaylists,
+  IconPlus,
+  Text
 } from '@audius/harmony'
-import { IconMultiselectAdd, PopupMenu, PopupMenuItem } from '@audius/stems'
+import { PopupMenu, PopupMenuItem } from '@audius/stems'
 import cn from 'classnames'
 import { push as pushRoute } from 'connected-react-router'
 import { capitalize } from 'lodash'
@@ -61,10 +64,10 @@ const UploadChip = ({
   const { isEnabled: isEditAlbumsEnabled } = useFlag(FeatureFlags.EDIT_ALBUMS)
   const messages = getMessages(type)
   const icon =
-    type === 'track' || type === 'album' ? (
+    type === 'track' ? (
       <IconUpload className={styles.iconUpload} />
     ) : (
-      <IconMultiselectAdd className={styles.iconPlus} />
+      <IconPlus className={styles.iconPlus} color='subdued' />
     )
 
   let text: string
@@ -134,7 +137,11 @@ const UploadChip = ({
       {...props}
     >
       <span>{icon}</span>
-      <span className={styles.text}>{text}</span>
+      <Box w={100}>
+        <Text variant='title' size='m' color='subdued' strength='default'>
+          {text}
+        </Text>
+      </Box>
     </Tile>
   )
 

--- a/packages/web/src/pages/profile-page/components/desktop/ProfileLeftNav.tsx
+++ b/packages/web/src/pages/profile-page/components/desktop/ProfileLeftNav.tsx
@@ -1,12 +1,9 @@
-import { useCallback } from 'react'
-
-import { ID, Name, accountSelectors } from '@audius/common'
+import { ID, accountSelectors } from '@audius/common'
 import cn from 'classnames'
 // eslint-disable-next-line no-restricted-imports -- TODO: migrate to @react-spring/web
 import { animated } from 'react-spring'
 
 import { useSelector } from 'common/hooks/useSelector'
-import { make, useRecord } from 'common/store/analytics/actions'
 import { AiGeneratedCallout } from 'components/ai-generated-button/AiGeneratedCallout'
 import Input from 'components/data-entry/Input'
 import TextArea from 'components/data-entry/TextArea'
@@ -20,7 +17,6 @@ import ProfilePageBadge from 'components/user-badges/ProfilePageBadge'
 import { Type } from 'pages/profile-page/components/SocialLink'
 import SocialLinkInput from 'pages/profile-page/components/SocialLinkInput'
 import { ProfileTopTags } from 'pages/profile-page/components/desktop/ProfileTopTags'
-import { UPLOAD_PAGE } from 'utils/route'
 
 import { ProfileBio } from './ProfileBio'
 import { ProfileMutuals } from './ProfileMutuals'
@@ -45,7 +41,6 @@ type ProfileLeftNavProps = {
   loading: boolean
   isDeactivated: boolean
   allowAiAttribution: boolean
-  goToRoute: (route: string) => void
   twitterHandle: string
   onUpdateTwitterHandle: (handle: string) => void
   instagramHandle: string
@@ -76,7 +71,6 @@ export const ProfileLeftNav = (props: ProfileLeftNavProps) => {
     loading,
     isDeactivated,
     allowAiAttribution,
-    goToRoute,
     twitterHandle,
     onUpdateTwitterHandle,
     instagramHandle,
@@ -97,13 +91,7 @@ export const ProfileLeftNav = (props: ProfileLeftNavProps) => {
     isOwner
   } = props
 
-  const record = useRecord()
   const accountUser = useSelector(getAccountUser)
-
-  const onClickUploadChip = useCallback(() => {
-    goToRoute(UPLOAD_PAGE)
-    record(make(Name.TRACK_UPLOAD_OPEN, { source: 'profile' }))
-  }, [goToRoute, record])
 
   const renderTipAudioButton = (_: any, style: object) => (
     <animated.div className={styles.tipAudioButtonContainer} style={style}>
@@ -221,11 +209,7 @@ export const ProfileLeftNav = (props: ProfileLeftNavProps) => {
           <RelatedArtists />
           {isArtist ? <ProfileTopTags /> : null}
           {showUploadChip ? (
-            <UploadChip
-              type='track'
-              variant='nav'
-              onClick={onClickUploadChip}
-            />
+            <UploadChip type='track' variant='nav' source='nav' />
           ) : null}
         </div>
       </div>

--- a/packages/web/src/pages/profile-page/components/desktop/ProfilePage.tsx
+++ b/packages/web/src/pages/profile-page/components/desktop/ProfilePage.tsx
@@ -3,7 +3,6 @@ import { useCallback, memo, MouseEvent } from 'react'
 import {
   ID,
   UID,
-  Name,
   Collection,
   CoverPhotoSizes,
   ProfilePictureSizes,
@@ -14,7 +13,8 @@ import {
   ProfilePageTabs,
   profilePageFeedLineupActions as feedActions,
   badgeTiers,
-  useSelectTierInfo
+  useSelectTierInfo,
+  CreatePlaylistSource
 } from '@audius/common'
 
 import IconAlbum from 'assets/img/iconAlbum.svg'
@@ -22,7 +22,6 @@ import IconCollectibles from 'assets/img/iconCollectibles.svg'
 import IconNote from 'assets/img/iconNote.svg'
 import IconPlaylists from 'assets/img/iconPlaylists.svg'
 import IconReposts from 'assets/img/iconRepost.svg'
-import { make, useRecord } from 'common/store/analytics/actions'
 import Card from 'components/card/desktop/Card'
 import CollectiblesPage from 'components/collectibles/components/CollectiblesPage'
 import CoverPhoto from 'components/cover-photo/CoverPhoto'
@@ -40,13 +39,7 @@ import { BlockUserConfirmationModal } from 'pages/chat-page/components/BlockUser
 import { UnblockUserConfirmationModal } from 'pages/chat-page/components/UnblockUserConfirmationModal'
 import { MIN_COLLECTIBLES_TIER } from 'pages/profile-page/ProfilePageProvider'
 import EmptyTab from 'pages/profile-page/components/EmptyTab'
-import {
-  collectionPage,
-  UPLOAD_PAGE,
-  UPLOAD_ALBUM_PAGE,
-  UPLOAD_PLAYLIST_PAGE,
-  profilePage
-} from 'utils/route'
+import { collectionPage, profilePage } from 'utils/route'
 import { getUserPageSEOFields } from 'utils/seo'
 
 import { DeactivatedProfileTombstone } from '../DeactivatedProfileTombstone'
@@ -134,7 +127,6 @@ export type ProfilePageProps = {
     tracks: number,
     isPrivate?: boolean
   ) => string
-  createPlaylist: () => void
   updateProfile: (metadata: any) => void
   updateProfilePicture: (
     selectedFiles: any,
@@ -177,7 +169,6 @@ const ProfilePage = ({
   formatCardSecondaryText,
   loadMoreUserFeed,
   loadMoreArtistTracks,
-  createPlaylist,
   updateProfile,
 
   onFollow,
@@ -250,19 +241,6 @@ const ProfilePage = ({
   const renderProfileCompletionCard = () => {
     return isOwner ? <ConnectedProfileCompletionHeroCard /> : null
   }
-  const record = useRecord()
-  const onClickUploadAlbum = useCallback(() => {
-    goToRoute(UPLOAD_ALBUM_PAGE)
-    record(make(Name.TRACK_UPLOAD_OPEN, { source: 'profile' }))
-  }, [goToRoute, record])
-  const onClickUploadPlaylist = useCallback(() => {
-    goToRoute(UPLOAD_PLAYLIST_PAGE)
-    record(make(Name.TRACK_UPLOAD_OPEN, { source: 'profile' }))
-  }, [goToRoute, record])
-  const onClickUploadTrack = useCallback(() => {
-    goToRoute(UPLOAD_PAGE)
-    record(make(Name.TRACK_UPLOAD_OPEN, { source: 'profile' }))
-  }, [goToRoute, record])
 
   const { tierNumber } = useSelectTierInfo(userId ?? 0)
   const profileHasCollectiblesTierRequirement =
@@ -335,8 +313,8 @@ const ProfilePage = ({
           key='upload-chip'
           type='album'
           variant='card'
-          onClick={onClickUploadAlbum}
           isFirst={albumCards.length === 0}
+          source={CreatePlaylistSource.PROFILE_PAGE}
         />
       )
     }
@@ -389,9 +367,8 @@ const ProfilePage = ({
           key='upload-chip'
           type='playlist'
           variant='card'
-          onClick={onClickUploadPlaylist}
-          isArtist={isArtist}
           isFirst={playlistCards.length === 0}
+          source={CreatePlaylistSource.PROFILE_PAGE}
         />
       )
     }
@@ -401,7 +378,7 @@ const ProfilePage = ({
         key='upload-chip'
         type='track'
         variant='tile'
-        onClick={onClickUploadTrack}
+        source='profile'
       />
     ) : null
 
@@ -594,7 +571,7 @@ const ProfilePage = ({
       <UploadChip
         type='playlist'
         variant='card'
-        onClick={createPlaylist}
+        source={CreatePlaylistSource.PROFILE_PAGE}
         isFirst={playlistCards.length === 0}
       />
     )
@@ -753,7 +730,6 @@ const ProfilePage = ({
           onUpdateTikTokHandle={updateTikTokHandle}
           onUpdateWebsite={updateWebsite}
           onUpdateDonation={updateDonation}
-          goToRoute={goToRoute}
         />
         <CoverPhoto
           userId={userId}

--- a/packages/web/src/pages/profile-page/components/desktop/ProfileWrapping.tsx
+++ b/packages/web/src/pages/profile-page/components/desktop/ProfileWrapping.tsx
@@ -46,7 +46,6 @@ type ProfileWrappingProps = {
   onUpdateTikTokHandle: (handle: string) => void
   onUpdateWebsite: (website: string) => void
   onUpdateDonation: (donation: string) => void
-  goToRoute: (route: string) => void
 }
 
 const ProfileWrapping = (props: ProfileWrappingProps) => {
@@ -83,8 +82,7 @@ const ProfileWrapping = (props: ProfileWrappingProps) => {
     onUpdateInstagramHandle,
     onUpdateTikTokHandle,
     onUpdateWebsite,
-    onUpdateDonation,
-    goToRoute
+    onUpdateDonation
   } = props
 
   return (
@@ -155,7 +153,6 @@ const ProfileWrapping = (props: ProfileWrappingProps) => {
             onUpdateTikTokHandle={onUpdateTikTokHandle}
             onUpdateWebsite={onUpdateWebsite}
             onUpdateDonation={onUpdateDonation}
-            goToRoute={goToRoute}
           />
         )}
       </div>

--- a/packages/web/src/pages/saved-page/components/desktop/PlaylistsTabPage.tsx
+++ b/packages/web/src/pages/saved-page/components/desktop/PlaylistsTabPage.tsx
@@ -68,7 +68,7 @@ export const PlaylistsTabPage = () => {
       <UploadChip
         type='playlist'
         variant='card'
-        onClick={handleCreatePlaylist}
+        source={CreatePlaylistSource.LIBRARY_PAGE}
       />
     )
     return [
@@ -77,7 +77,7 @@ export const PlaylistsTabPage = () => {
         return <CollectionCard index={i} key={id} albumId={id} />
       })
     ]
-  }, [collections, handleCreatePlaylist])
+  }, [collections])
 
   if (isLoadingInitial) {
     return <LoadingSpinner className={styles.spinner} />


### PR DESCRIPTION
### Description

![Screenshot 2023-12-29 at 6 01 02 PM](https://github.com/AudiusProject/audius-protocol/assets/2358254/bdeba1f1-88ce-4f14-8e35-a9a8af2b7873)

#### Includes:
- Upload Track always takes you to upload with no menu
- Upload Album/Playlist will give you the option to go to upload flow or just create an empty one that you can start editing

#### Future work:
- Mobile coming in separate PR

### How Has This Been Tested?

local web

all instances tested and working with the new menu