### PR TITLE
Clamp upload percentage

### DIFF
--- a/packages/common/src/store/upload/selectors.ts
+++ b/packages/common/src/store/upload/selectors.ts
@@ -1,4 +1,4 @@
-import { round } from 'lodash'
+import { round, clamp } from 'lodash'
 
 import { CommonState } from '../commonStore'
 
@@ -56,5 +56,5 @@ export const getCombinedUploadPercentage = (state: CommonState) => {
   const percent = round(
     100 * (ART_WEIGHT * artProgress + AUDIO_WEIGHT * audioProgress)
   )
-  return Math.min(percent, 100)
+  return clamp(percent, 0, 100)
 }

--- a/packages/common/src/store/upload/selectors.ts
+++ b/packages/common/src/store/upload/selectors.ts
@@ -56,5 +56,5 @@ export const getCombinedUploadPercentage = (state: CommonState) => {
   const percent = round(
     100 * (ART_WEIGHT * artProgress + AUDIO_WEIGHT * audioProgress)
   )
-  return percent
+  return Math.min(percent, 100)
 }


### PR DESCRIPTION
### Description

Fixes issue where upload percentage goes above 100, which can happen occasionally since the math calc is not always exact.
