### PR TITLE
Fix react-native-svg version

### DIFF
--- a/packages/mobile/ios/Podfile.lock
+++ b/packages/mobile/ios/Podfile.lock
@@ -1282,7 +1282,7 @@ PODS:
     - Sentry/HybridSDK (= 8.17.1)
   - RNShare (8.0.0):
     - React-Core
-  - RNSVG (14.0.0):
+  - RNSVG (12.3.0):
     - React-Core
   - SDWebImage (5.11.1):
     - SDWebImage/Core (= 5.11.1)
@@ -1435,7 +1435,7 @@ DEPENDENCIES:
   - RNScreens (from `../../../node_modules/react-native-screens`)
   - "RNSentry (from `../../../node_modules/@sentry/react-native`)"
   - RNShare (from `../../../node_modules/react-native-share`)
-  - RNSVG (from `../node_modules/react-native-svg`)
+  - RNSVG (from `../../../node_modules/react-native-svg`)
   - "snap-kit-react-native (from `../../../node_modules/@snapchat/snap-kit-react-native`)"
   - SRSRadialGradient (from `../../../node_modules/react-native-radial-gradient/ios`)
   - Yoga (from `../node_modules/react-native/ReactCommon/yoga`)
@@ -1671,7 +1671,7 @@ EXTERNAL SOURCES:
   RNShare:
     :path: "../../../node_modules/react-native-share"
   RNSVG:
-    :path: "../node_modules/react-native-svg"
+    :path: "../../../node_modules/react-native-svg"
   snap-kit-react-native:
     :path: "../../../node_modules/@snapchat/snap-kit-react-native"
   SRSRadialGradient:
@@ -1799,7 +1799,7 @@ SPEC CHECKSUMS:
   RNScreens: b582cb834dc4133307562e930e8fa914b8c04ef2
   RNSentry: a6202c19ca31b69969dface2ea0db093e36c97a3
   RNShare: 36aa3e6958373a0ad1c95a1c960adef589da3794
-  RNSVG: 255767813dac22db1ec2062c8b7e7b856d4e5ae6
+  RNSVG: 302bfc9905bd8122f08966dc2ce2d07b7b52b9f8
   SDWebImage: a7f831e1a65eb5e285e3fb046a23fcfbf08e696d
   SDWebImageWebPCoder: 908b83b6adda48effe7667cd2b7f78c897e5111d
   Sentry: d9f99f9cc13777c5d938650c1e1c85047bb4f0d1

--- a/packages/mobile/package.json
+++ b/packages/mobile/package.json
@@ -148,7 +148,7 @@
     "react-native-safe-area-context": "4.5.3",
     "react-native-screens": "3.29.0",
     "react-native-share": "8.0.0",
-    "react-native-svg": "14.0.0",
+    "react-native-svg": "12.3.0",
     "react-native-svg-transformer": "1.3.0",
     "react-native-tab-view": "3.5.2",
     "react-native-tiktok": "1.1.1",


### PR DESCRIPTION
### Description

There is weirdness with react-native-svg 14 in relation to wallet-connect. Reverting to 12.3 in the meantime until we migrate off old wallet-connect
