### PR TITLE
Fix schedule release gating

### DIFF
--- a/packages/mobile/src/components/lineup-tile/LineupTile.tsx
+++ b/packages/mobile/src/components/lineup-tile/LineupTile.tsx
@@ -73,7 +73,7 @@ export const LineupTile = ({
   const isArtistPick = artist_pick_track_id === id
   const { doesUserHaveAccess } = usePremiumContentAccess(isTrack ? item : null)
   const isScheduledRelease = item.release_date
-    ? moment(item.release_date).isAfter(moment())
+    ? moment.utc(item.release_date).isAfter(moment())
     : false
   const dogEarType = getDogEarType({
     premiumConditions,

--- a/packages/mobile/src/screens/edit-track-screen/EditTrackForm.tsx
+++ b/packages/mobile/src/screens/edit-track-screen/EditTrackForm.tsx
@@ -1,6 +1,6 @@
 import { useCallback } from 'react'
 
-import { type UploadTrack } from '@audius/common'
+import { FeatureFlags, type UploadTrack } from '@audius/common'
 import { Keyboard } from 'react-native'
 import { KeyboardAwareScrollView } from 'react-native-keyboard-aware-scroll-view'
 import { useDispatch } from 'react-redux'
@@ -13,10 +13,10 @@ import { InputErrorMessage } from 'app/components/core/InputErrorMessage'
 import { PickArtworkField, TextField } from 'app/components/fields'
 import { useNavigation } from 'app/hooks/useNavigation'
 import { useOneTimeDrawer } from 'app/hooks/useOneTimeDrawer'
+import { useFeatureFlag } from 'app/hooks/useRemoteConfig'
 import { setVisibility } from 'app/store/drawers/slice'
 import { makeStyles } from 'app/styles'
 
-import { messages as completeTrackMessage } from '../../screens/upload-screen'
 import { TopBarIconButton } from '../app-screen'
 
 import { CancelEditTrackDrawer, FormScreen } from './components'
@@ -94,6 +94,10 @@ export const EditTrackForm = (props: EditTrackFormProps) => {
     }
   }, [dirty, navigation, dispatch])
 
+  const { isEnabled: isScheduledReleasesEnabled } = useFeatureFlag(
+    FeatureFlags.SCHEDULED_RELEASES
+  )
+
   return (
     <>
       <FormScreen
@@ -141,11 +145,7 @@ export const EditTrackForm = (props: EditTrackFormProps) => {
               <DescriptionField />
               <SubmenuList removeBottomDivider>
                 <AccessAndSaleField />
-                {completeTrackMessage.title === props.title ? (
-                  <ReleaseDateField />
-                ) : (
-                  <></>
-                )}
+                {isScheduledReleasesEnabled ? <ReleaseDateField /> : <></>}
                 <RemixSettingsField />
                 <AdvancedOptionsField />
               </SubmenuList>

--- a/packages/web/src/components/scheduled-release-label/ScheduledReleaseLabel.tsx
+++ b/packages/web/src/components/scheduled-release-label/ScheduledReleaseLabel.tsx
@@ -16,7 +16,7 @@ export const ScheduledReleaseLabel = ({
   released,
   isUnlisted
 }: ScheduledReleaseLabelProps) => {
-  if (!released || !isUnlisted) {
+  if (!released || !isUnlisted || moment.utc(released).isBefore(moment())) {
     return null
   }
   return (
@@ -41,7 +41,7 @@ export const ScheduledReleaseGiantLabel = ({
   released,
   isUnlisted
 }: ScheduledReleaseLabelProps) => {
-  if (!released || !isUnlisted) {
+  if (!released || !isUnlisted || moment.utc(released).isBefore(moment())) {
     return null
   }
 
@@ -54,8 +54,9 @@ export const ScheduledReleaseGiantLabel = ({
     >
       <IconCalendarMonth />
       <Text color='accent' variant='title'>
-        Releases on{' '}
-        {moment.utc(released).local().format('M/D/YY [@] h:mm A') +
+        Releases
+        {' ' +
+          moment.utc(released).local().format('M/D/YY [@] h:mm A') +
           ' ' +
           getLocalTimezone()}
       </Text>

--- a/packages/web/src/components/track/desktop/TrackTile.tsx
+++ b/packages/web/src/components/track/desktop/TrackTile.tsx
@@ -155,6 +155,10 @@ const TrackTile = ({
     FeatureFlags.PODCAST_CONTROL_UPDATES_ENABLED,
     FeatureFlags.PODCAST_CONTROL_UPDATES_ENABLED_FALLBACK
   )
+  const { isEnabled: isScheduledReleasesEnabled } = useFlag(
+    FeatureFlags.SCHEDULED_RELEASES
+  )
+
   const currentUserId = useSelector(getUserId)
   const trackPositionInfo = useSelector((state: CommonState) =>
     getTrackPosition(state, { trackId, userId: currentUserId })
@@ -251,10 +255,11 @@ const TrackTile = ({
           {messages.artistPick}
         </div>
       )
+    } else if (isScheduledReleasesEnabled) {
+      scheduledReleaseLabel = (
+        <ScheduledReleaseLabel released={releaseDate} isUnlisted={isUnlisted} />
+      )
     }
-    scheduledReleaseLabel = (
-      <ScheduledReleaseLabel released={releaseDate} isUnlisted={isUnlisted} />
-    )
   }
 
   return (

--- a/packages/web/src/components/track/desktop/TrackTile.tsx
+++ b/packages/web/src/components/track/desktop/TrackTile.tsx
@@ -233,7 +233,7 @@ const TrackTile = ({
         isOwner,
         isUnlisted:
           isUnlisted &&
-          (!releaseDate || moment(releaseDate).isBefore(moment())),
+          (!releaseDate || moment.utc(releaseDate).isBefore(moment())),
         premiumConditions
       })
 


### PR DESCRIPTION
### Description
A couple places where scheduled releases gating wasn't properly set or time comparisons were slightly off because of timezone offset.

Will improve on this by adding a field for is_scheduled_release instead of relying on comparisons but wanted to get this in before then.

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._

Tested against stage. Verified create/edit track and track tiles on web/mobile.