### PR TITLE
Tag protocol dashboard `-dev` image (for audius-d)

### DIFF
--- a/dev-tools/audius-compose
+++ b/dev-tools/audius-compose
@@ -294,17 +294,9 @@ def push(ctx, services, prod):
             base_tag = f"{protocol_dir.name}-{service}"
 
             if service == "dashboard" and prod:
-                # tag -dev image (for audius-d)
                 subprocess.run(["docker", "tag", f"{base_tag}:dev", f"audius/{service}:{git_commit}-dev"], check=True)
-                subprocess.run(["docker", "push", f"audius/{service}:{git_commit}-dev"], check=True)
-                
-                # tag -stage image
                 subprocess.run(["docker", "tag", f"{base_tag}:stage", f"audius/{service}:{git_commit}-stage"], check=True)
-                subprocess.run(["docker", "push", f"audius/{service}:{git_commit}-stage"], check=True)
-
-                # tag -prod image
                 subprocess.run(["docker", "tag", f"{base_tag}:prod", f"audius/{service}:{git_commit}-prod"], check=True)
-                subprocess.run(["docker", "push", f"audius/{service}:{git_commit}-prod"], check=True)
 
             subprocess.run(["docker", "tag", base_tag, f"audius/{service}:{git_commit}"], check=True)
             subprocess.run(["docker", "push", f"audius/{service}:{git_commit}"], check=True)


### PR DESCRIPTION
### Description

want this (from audius-docker-compose) to work when NETWORK=dev
can iterate on the specifics of the dev config within as required.

```
  dashboard:
    image: audius/dashboard:${TAG:-1380e772051b1d15707dc78c162808761853a0bf}-${NETWORK:-prod}
```
