### PR TITLE
[C-3513] Private albums + show PublishButton for albums

### DIFF
--- a/packages/common/src/services/audius-backend/AudiusBackend.ts
+++ b/packages/common/src/services/audius-backend/AudiusBackend.ts
@@ -1349,9 +1349,6 @@ export const audiusBackend = ({
     trackIds: ID[] = [],
     isPrivate = true
   ) {
-    // Creating an album is automatically public.
-    if (isAlbum) isPrivate = false
-
     try {
       const web3 = await audiusLibs.web3Manager.getWeb3()
       const currentBlockNumber = await web3.eth.getBlockNumber()

--- a/packages/web/src/components/collection/desktop/OwnerActionButtons.tsx
+++ b/packages/web/src/components/collection/desktop/OwnerActionButtons.tsx
@@ -21,7 +21,7 @@ export const OwnerActionButtons = (props: OwnerActionButtonProps) => {
   const collection = useSelector((state: CommonState) =>
     getCollection(state, { id: collectionId })
   ) as Collection
-  const { track_count, is_private, is_album } = collection ?? {}
+  const { track_count, is_private } = collection ?? {}
 
   const isDisabled = track_count === 0
 
@@ -39,7 +39,7 @@ export const OwnerActionButtons = (props: OwnerActionButtonProps) => {
         }
         widthToHideText={BUTTON_COLLAPSE_WIDTHS.third}
       />
-      {is_private && !is_album ? (
+      {is_private ? (
         <PublishButton
           collectionId={collectionId}
           widthToHideText={BUTTON_COLLAPSE_WIDTHS.fourth}

--- a/packages/web/src/components/collection/desktop/PublishButton.tsx
+++ b/packages/web/src/components/collection/desktop/PublishButton.tsx
@@ -23,8 +23,8 @@ const messages = {
   publish: 'Make Public',
   publishing: 'Making Public',
   emptyPlaylistTooltipText: 'You must add at least 1 song.',
-  hiddenTracksTooltipText:
-    'You cannot make a playlist with hidden tracks public.'
+  hiddenTracksTooltipText: (collectionType: 'playlist' | 'album') =>
+    `You cannot make a ${collectionType} with hidden tracks public.`
 }
 
 type PublishButtonProps = Partial<ButtonProps> & {
@@ -33,8 +33,8 @@ type PublishButtonProps = Partial<ButtonProps> & {
 
 export const PublishButton = (props: PublishButtonProps) => {
   const { collectionId, ...other } = props
-  const { _is_publishing, track_count } = useSelector((state: CommonState) =>
-    getCollection(state, { id: collectionId })
+  const { _is_publishing, track_count, is_album } = useSelector(
+    (state: CommonState) => getCollection(state, { id: collectionId })
   ) as Collection
   const hasHiddenTracks = useSelector((state: CommonState) =>
     getCollecitonHasHiddenTracks(state, { id: collectionId })
@@ -73,7 +73,9 @@ export const PublishButton = (props: PublishButtonProps) => {
         <Tooltip
           text={
             hasHiddenTracks
-              ? messages.hiddenTracksTooltipText
+              ? messages.hiddenTracksTooltipText(
+                  is_album ? 'album' : 'playlist'
+                )
               : messages.emptyPlaylistTooltipText
           }
         >

--- a/packages/web/src/components/collection/desktop/PublishConfirmationModal.tsx
+++ b/packages/web/src/components/collection/desktop/PublishConfirmationModal.tsx
@@ -1,6 +1,11 @@
 import { useCallback } from 'react'
 
-import { cacheCollectionsActions } from '@audius/common'
+import {
+  Collection,
+  CommonState,
+  cacheCollectionsActions,
+  collectionPageSelectors
+} from '@audius/common'
 import {
   Button,
   ButtonType,
@@ -13,16 +18,17 @@ import {
   ModalProps,
   ModalTitle
 } from '@audius/stems'
-import { useDispatch } from 'react-redux'
+import { useDispatch, useSelector } from 'react-redux'
 
 import styles from './PublishConfirmationModal.module.css'
+const { getCollection } = collectionPageSelectors
 
 const { publishPlaylist } = cacheCollectionsActions
 
 const messages = {
   title: 'Make Public',
-  description:
-    'Are you sure you want to make this playlist public? It will be shared to your feed and your subscribed followers will be notified.',
+  description: (collectionType: 'album' | 'playlist') =>
+    `Are you sure you want to make this ${collectionType} public? It will be shared to your feed and your subscribed followers will be notified.`,
   cancel: 'Cancel',
   publish: 'Make Public'
 }
@@ -38,6 +44,10 @@ export const PublishConfirmationModal = (
   const { onClose } = other
   const dispatch = useDispatch()
 
+  const { is_album } = useSelector((state: CommonState) =>
+    getCollection(state, { id: collectionId })
+  ) as Collection
+
   const handlePublish = useCallback(() => {
     dispatch(publishPlaylist(collectionId))
     onClose()
@@ -52,7 +62,9 @@ export const PublishConfirmationModal = (
         />
       </ModalHeader>
       <ModalContent>
-        <ModalContentText>{messages.description}</ModalContentText>
+        <ModalContentText>
+          {messages.description(is_album ? 'album' : 'playlist')}
+        </ModalContentText>
       </ModalContent>
       <ModalFooter className={styles.footer}>
         <Button


### PR DESCRIPTION
### Description

- Remove guards preventing albums from being private
- Removed guards preventing PublishButton from showing on albums
- Fixed copy

![image](https://github.com/AudiusProject/audius-protocol/assets/2358254/ee68d653-27a8-4b1d-b428-469c576b9e1c)


### How Has This Been Tested?

local web

confirmed that uploaded albums are still public (not relying on the libs default)