### PR TITLE
[C-3565] Reduce saga apk size

### DIFF
--- a/.circleci/src/commands/@mobile-commands.yml
+++ b/.circleci/src/commands/@mobile-commands.yml
@@ -321,7 +321,7 @@ mobile-release-saga-dapp-store:
         name: Build Android
         command: |
           cd packages/mobile/android
-          ./gradlew app:assembleRelease
+          ./gradlew app:assembleRelease -PreactNativeArchitectures=arm64-v8a
     - run:
         name: Validate release
         command: |

--- a/packages/mobile/dapp-store/README.md
+++ b/packages/mobile/dapp-store/README.md
@@ -48,7 +48,7 @@ The version code needs to be a monotonically increasing number.
 
 ### Preparing the apk
 cd ../android
-./gradlew app:assembleRelease
+./gradlew app:assembleRelease -PreactNativeArchitectures=arm64-v8a
 cd ../dapp-store
 
 ### Validating the release


### PR DESCRIPTION
### Description

Since the saga build only targets one phone, we can build an apk specificially for it's architecture, which is arm9. v8a is the corresponding android ABI
