### PR TITLE
Add is_scheduled_release field

### DIFF
--- a/packages/discovery-provider/ddl/migrations/0046_add_is_scheduled_release.sql
+++ b/packages/discovery-provider/ddl/migrations/0046_add_is_scheduled_release.sql
@@ -1,0 +1,11 @@
+begin;
+    alter table tracks disable trigger on_track;
+    alter table tracks disable trigger trg_tracks;
+
+
+    alter table tracks
+    add column if not exists is_scheduled_release boolean not null default false;
+
+    alter table tracks enable trigger on_track;
+    alter table tracks enable trigger trg_tracks;
+commit;

--- a/packages/discovery-provider/integration_tests/tasks/entity_manager/test_track_entity_manager.py
+++ b/packages/discovery-provider/integration_tests/tasks/entity_manager/test_track_entity_manager.py
@@ -126,7 +126,7 @@ def test_index_valid_track(app, mocker):
             "is_playlist_upload": True,
             "duration": 200,
         },
-        "QmCreateTrack3": {
+        "QmCreateTrack3": {  # scheduled release
             "owner_id": 1,
             "track_cid": "some-track-cid-3",
             "title": "track 3",
@@ -144,7 +144,8 @@ def test_index_valid_track(app, mocker):
             "track_segments": [],
             "has_current_user_reposted": False,
             "is_current": True,
-            "is_unlisted": False,
+            "is_scheduled_release": True,
+            "is_unlisted": False,  # is_unlisted is overriden by is_scheduled_release
             "is_premium": False,
             "premium_conditions": None,
             "field_visibility": {

--- a/packages/discovery-provider/integration_tests/tasks/entity_manager/test_utils.py
+++ b/packages/discovery-provider/integration_tests/tasks/entity_manager/test_utils.py
@@ -163,6 +163,7 @@ def test_valid_parse_metadata(app):
                     "requires_follow": False,
                 },
                 "remix_of": {"tracks": [{"parent_track_id": 75808}]},
+                "is_scheduled_release": False,
                 "is_unlisted": False,
                 "field_visibility": {
                     "mood": True,
@@ -298,6 +299,7 @@ def test_invalid_parse_metadata(app):
                 "requires_follow": False,
             },
             "remix_of": {"tracks": [{"parent_track_id": 75808}]},
+            "is_scheduled_release": False,
             "is_unlisted": False,
             "field_visibility": {
                 "mood": True,

--- a/packages/discovery-provider/src/api/v1/models/tracks.py
+++ b/packages/discovery-provider/src/api/v1/models/tracks.py
@@ -126,6 +126,7 @@ track_full = ns.clone(
         "field_visibility": fields.Nested(field_visibility),
         "followee_reposts": fields.List(fields.Nested(repost), required=True),
         "has_current_user_reposted": fields.Boolean(required=True),
+        "is_scheduled_release": fields.Boolean,
         "is_unlisted": fields.Boolean(required=True),
         "has_current_user_saved": fields.Boolean(required=True),
         "followee_favorites": fields.List(fields.Nested(favorite), required=True),

--- a/packages/discovery-provider/src/models/tracks/track.py
+++ b/packages/discovery-provider/src/models/tracks/track.py
@@ -61,6 +61,7 @@ class Track(Base, RepresentableMixin):
     updated_at = Column(DateTime, nullable=False)
     cover_art_sizes = Column(String)
     download = Column(JSONB())
+    is_scheduled_release = Column(Boolean, nullable=False, server_default=text("false"))
     is_unlisted = Column(Boolean, nullable=False, server_default=text("false"))
     field_visibility = Column(JSONB(True))
     route_id = Column(String)

--- a/packages/discovery-provider/src/tasks/entity_manager/entities/track.py
+++ b/packages/discovery-provider/src/tasks/entity_manager/entities/track.py
@@ -296,9 +296,16 @@ def populate_track_record_metadata(track_record: Track, track_metadata, handle, 
 
             # allow scheduled_releases to override is_unlisted value based on release date
             # only for CREATE because publish_scheduled releases will publish this once
-            if track_record.is_scheduled_release and action == Action.CREATE:
-                track_record.is_unlisted = track_record.release_date >= str(
-                    datetime.now()
+            if (
+                track_record.is_scheduled_release
+                and track_record.release_date
+                and action == Action.CREATE
+            ):
+                track_record.is_unlisted = (
+                    track_record.release_date
+                    >= str(  # type:ignore
+                        datetime.now()
+                    )
                 )
         else:
             # For most fields, update the track_record when the corresponding field exists

--- a/packages/discovery-provider/src/tasks/metadata.py
+++ b/packages/discovery-provider/src/tasks/metadata.py
@@ -61,6 +61,7 @@ class TrackMetadata(TypedDict):
     track_segments: List[TrackSegment]
     download: Any
     remix_of: Optional[TrackRemix]
+    is_scheduled_release: bool
     is_unlisted: bool
     field_visibility: Optional[TrackFieldVisibility]
     stem_of: Optional[TrackStem]
@@ -178,6 +179,7 @@ immutable_track_fields = immutable_fields | {
     "track_cid",
     "duration",
     "is_available",
+    "is_scheduled_release",
 }
 
 immutable_user_fields = immutable_fields | {

--- a/packages/discovery-provider/src/tasks/metadata.py
+++ b/packages/discovery-provider/src/tasks/metadata.py
@@ -99,6 +99,7 @@ track_metadata_format: TrackMetadata = {
         "cid": None,
     },
     "remix_of": None,
+    "is_scheduled_release": False,
     "is_unlisted": False,
     "field_visibility": None,
     "stem_of": None,


### PR DESCRIPTION
### Description

Add is_scheduled_release column. This is safer than relying on release_date > created_at to identify scheduled releases.

Expose this in tracks API.

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._
Existing scheduled releases tests pass. 
