### PR TITLE
[PAY-2321] Prevent crash if nsure RN module isn't available

### DIFF
--- a/packages/mobile/src/services/coinflow.ts
+++ b/packages/mobile/src/services/coinflow.ts
@@ -10,6 +10,13 @@ export const getCoinflowDeviceId = (): string => {
     return deviceId
   }
 
+  /* Bail early if native module isn't found */
+  if (!nsureSDK) {
+    console.warn('Native module NSureSDK not found')
+    deviceId = ''
+    return deviceId
+  }
+
   if (Platform.OS === 'ios') {
     nsureSDK.sharedInstanceWithAppID(
       env.COINFLOW_APP_ID,


### PR DESCRIPTION
### Description
Adds a safety check in case the RN module for nSure isn't available.

### How Has This Been Tested?
Tested locally on simulator by changing the export name for the module so that the lookup results in null.
