### PR TITLE
[Discovery API] Add transaction signature to OAuth JWT payload type

### DIFF
--- a/packages/discovery-provider/src/api/v1/models/users.py
+++ b/packages/discovery-provider/src/api/v1/models/users.py
@@ -133,6 +133,14 @@ user_token_profile_picture = ns.model(
     },
 )
 
+tx_signature = ns.model(
+    "tx_signature",
+    {
+        "message": fields.String(required=True),
+        "signature": fields.String(required=True),
+    },
+)
+
 decoded_user_token = ns.model(
     "decoded_user_token",
     {
@@ -146,6 +154,9 @@ decoded_user_token = ns.model(
         ),
         "sub": fields.String(required=True),
         "iat": fields.String(required=True),
+        "txSignature": fields.Nested(
+            tx_signature, required=False, allow_null=True, skip_none=True
+        ),
     },
 )
 

--- a/packages/discovery-provider/src/api/v1/users.py
+++ b/packages/discovery-provider/src/api/v1/users.py
@@ -2044,11 +2044,6 @@ class GetReplicaSet(FullGetReplicaSet):
         return super()._get(id)
 
 
-verify_token_response = make_response(
-    "verify_token", ns, fields.Nested(decoded_user_token)
-)
-
-
 @ns.route("/unclaimed_id", doc=False)
 class GetUnclaimedUserId(Resource):
     @ns.doc(


### PR DESCRIPTION
### Description
The [JWT](https://docs.audius.org/developers/log-in-with-audius#3-verify-the-response) returned by Audius OAuth will now contain a `txSignature` when the user approves of one particular transaction.
For example, the flow to link a protocol dashboard wallet to an Audius user looks like this:
1. Protocol dashboard opens Audius OAuth and requests for user to approve connecting the wallet
2. User approves
3. Protocol dashboard receives and verifies the JWT, which contains the tx signature
4. Protocol dashboard sends `CreateDashboardWalletUser` transaction which requires the tx signature from the user. This tx is signed by the wallet.

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._
