### PR TITLE
Fix svgr template when no theme

### DIFF
--- a/svgr-template.js
+++ b/svgr-template.js
@@ -41,17 +41,17 @@ const ${variables.componentName} = forwardRef((${variables.props}, ref) => {
     ...other
   } = props
 
-  const height = heightProp ?? theme.iconSizes[sizeH ?? size]
+  const height = heightProp ?? theme.iconSizes?.[sizeH ?? size]
   if (height) {
     other.height = height 
   }
 
-  const width = widthProp ?? theme.iconSizes[sizeW ?? size]
+  const width = widthProp ?? theme.iconSizes?.[sizeW ?? size]
   if (width) {
     other.width = width
   }
 
-  const fillColor = other.fill ?? theme.color.icon[color] ?? 'red'
+  const fillColor = other.fill ?? theme.color?.icon[color] ?? 'red'
 
   ${native ? nativeStyles : webStyles}
 


### PR DESCRIPTION
### Description

Fixes issue where icons without the harmony theme have a run-time error. We could wrap everything in harmony provider, but this seems reasonable too
