### PR TITLE
Fix uptime optimizely env

### DIFF
--- a/monitoring/uptime/main.go
+++ b/monitoring/uptime/main.go
@@ -187,7 +187,7 @@ func startStagingOrProd(isProd bool, nodeType, env string) {
 		rewardsManagerProgramId = mustGetenv("audius_solana_rewards_manager_program_address")
 		rewardsManagerProgramPda = mustGetenv("audius_solana_rewards_manager_account")
 		rewardsManagerTokenPda = mustGetenv("audius_solana_rewards_manager_token_pda")
-		optimizelySdkKey = mustGetenv("OPTIMIZELY_SDK_KEY")
+		optimizelySdkKey = os.Getenv("OPTIMIZELY_SDK_KEY")
 	}
 
 	logger := slog.With("endpoint", myEndpoint)


### PR DESCRIPTION
### Description
OPTIMIZELY_SDK_KEY seems to only exist in prod node envs (not stage) and our existing code depends on falling back to a hardcoded key for stage if the value is "". Use os.Getenv rather than mustGetenv so the uptime container doesn't crash on stage.

### How Has This Been Tested?
Deploy to a stage node