### PR TITLE
[C-3515] Fix desktop sign up page transitions

### DIFF
--- a/packages/web/src/components/form-fields/HarmonyTextField.tsx
+++ b/packages/web/src/components/form-fields/HarmonyTextField.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from 'react'
+import { Ref, forwardRef, useEffect } from 'react'
 
 import { useDebouncedCallback } from '@audius/common'
 import { TextInput, TextInputProps } from '@audius/harmony'
@@ -19,59 +19,62 @@ export type HarmonyTextFieldProps = TextInputProps & {
 }
 
 // TODO: rename to TextField and replace old usages
-export const HarmonyTextField = (props: HarmonyTextFieldProps) => {
-  const {
-    name,
-    clearErrorOnChange = true,
-    transformValueOnChange,
-    transformValueOnBlur,
-    debouncedValidationMs = 0,
-    helperText,
-    ...other
-  } = props
-  const [field, { touched, error }, { setError }] = useField(name)
-  const { value } = field
-  const { validateField, submitCount } = useFormikContext()
+export const HarmonyTextField = forwardRef(
+  (props: HarmonyTextFieldProps, ref: Ref<HTMLInputElement>) => {
+    const {
+      name,
+      clearErrorOnChange = true,
+      transformValueOnChange,
+      transformValueOnBlur,
+      debouncedValidationMs = 0,
+      helperText,
+      ...other
+    } = props
+    const [field, { touched, error }, { setError }] = useField(name)
+    const { value } = field
+    const { validateField, submitCount } = useFormikContext()
 
-  const debouncedValidateField = useDebouncedCallback(
-    (field: string) => validateField(field),
-    [validateField],
-    debouncedValidationMs
-  )
+    const debouncedValidateField = useDebouncedCallback(
+      (field: string) => validateField(field),
+      [validateField],
+      debouncedValidationMs
+    )
 
-  useEffect(() => {
-    if (debouncedValidationMs) {
-      debouncedValidateField(name)
-    }
-  }, [debouncedValidationMs, debouncedValidateField, name, value])
+    useEffect(() => {
+      if (debouncedValidationMs) {
+        debouncedValidateField(name)
+      }
+    }, [debouncedValidationMs, debouncedValidateField, name, value])
 
-  const hasError = Boolean(touched && error && submitCount > 0)
+    const hasError = Boolean(touched && error && submitCount > 0)
 
-  return (
-    <TextInput
-      {...field}
-      error={hasError}
-      helperText={helperText ?? (hasError ? error : undefined)}
-      onChange={(e) => {
-        if (clearErrorOnChange) {
-          setError(undefined)
-        }
-        if (transformValueOnChange) {
-          e.target.value = transformValueOnChange(e.target.value)
-        }
-        field.onChange(e)
-      }}
-      onBlur={(e) => {
-        if (clearErrorOnChange) {
-          setError(undefined)
-        }
-        if (transformValueOnBlur) {
-          e.target.value = transformValueOnBlur(e.target.value)
-        }
-        field.onChange(e)
-        field.onBlur(e)
-      }}
-      {...other}
-    />
-  )
-}
+    return (
+      <TextInput
+        ref={ref}
+        {...field}
+        error={hasError}
+        helperText={helperText ?? (hasError ? error : undefined)}
+        onChange={(e) => {
+          if (clearErrorOnChange) {
+            setError(undefined)
+          }
+          if (transformValueOnChange) {
+            e.target.value = transformValueOnChange(e.target.value)
+          }
+          field.onChange(e)
+        }}
+        onBlur={(e) => {
+          if (clearErrorOnChange) {
+            setError(undefined)
+          }
+          if (transformValueOnBlur) {
+            e.target.value = transformValueOnBlur(e.target.value)
+          }
+          field.onChange(e)
+          field.onBlur(e)
+        }}
+        {...other}
+      />
+    )
+  }
+)

--- a/packages/web/src/components/form-fields/PasswordField.tsx
+++ b/packages/web/src/components/form-fields/PasswordField.tsx
@@ -1,3 +1,5 @@
+import { Ref, forwardRef } from 'react'
+
 import { PasswordInput, PasswordInputProps } from '@audius/harmony'
 import { useField } from 'formik'
 
@@ -5,11 +7,13 @@ export type PasswordFieldProps = PasswordInputProps & {
   name: string
 }
 
-export const PasswordField = (props: PasswordFieldProps) => {
-  const { name, ...other } = props
-  const [field, { touched, error }] = useField(name)
+export const PasswordField = forwardRef(
+  (props: PasswordFieldProps, ref: Ref<HTMLInputElement>) => {
+    const { name, ...other } = props
+    const [field, { touched, error }] = useField(name)
 
-  const hasError = Boolean(touched && error)
+    const hasError = Boolean(touched && error)
 
-  return <PasswordInput {...field} error={hasError} {...other} />
-}
+    return <PasswordInput ref={ref} {...field} error={hasError} {...other} />
+  }
+)

--- a/packages/web/src/pages/sign-in-page/SignInPage.tsx
+++ b/packages/web/src/pages/sign-in-page/SignInPage.tsx
@@ -23,7 +23,7 @@ import { HarmonyTextField } from 'components/form-fields/HarmonyTextField'
 import PreloadImage from 'components/preload-image/PreloadImage'
 import { useMedia } from 'hooks/useMedia'
 import { ForgotPasswordHelper } from 'pages/sign-on/components/desktop/ForgotPasswordHelper'
-import { Heading } from 'pages/sign-up-page/components/layout'
+import { Heading, ScrollView } from 'pages/sign-up-page/components/layout'
 import { useSelector } from 'utils/reducer'
 import { SIGN_UP_PAGE } from 'utils/route'
 
@@ -61,14 +61,13 @@ export const SignInPage = () => {
         <meta name='description' content={messages.metaDescription} />
       </Helmet>
       <Formik initialValues={initialValues} onSubmit={handleSubmit}>
-        <Flex
-          flex={1}
+        <ScrollView
           direction='column'
           justifyContent='space-between'
-          h='100%'
           p='2xl'
           pt='unit20'
           pb={!isMobile ? 'unit14' : undefined}
+          gap='l'
         >
           <Flex as={Form} direction='column' gap='2xl'>
             <Box alignSelf='center'>
@@ -120,7 +119,7 @@ export const SignInPage = () => {
               <Link to={SIGN_UP_PAGE}>{messages.createAccount}</Link>
             </Button>
           ) : null}
-        </Flex>
+        </ScrollView>
       </Formik>
       <ForgotPasswordHelper
         isOpen={showForgotPassword}

--- a/packages/web/src/pages/sign-up-page/components/EnterPasswordSection.tsx
+++ b/packages/web/src/pages/sign-up-page/components/EnterPasswordSection.tsx
@@ -1,3 +1,5 @@
+import { RefObject } from 'react'
+
 import { Flex } from '@audius/harmony'
 
 import { PasswordField } from 'components/form-fields/PasswordField'
@@ -9,10 +11,19 @@ const messages = {
   confirmPasswordLabel: 'Confirm Password'
 }
 
-export const EnterPasswordSection = () => {
+type EnterPasswordSectionProps = {
+  inputRef?: RefObject<HTMLInputElement>
+}
+
+export const EnterPasswordSection = (props: EnterPasswordSectionProps) => {
+  const { inputRef } = props
   return (
     <Flex direction='column' gap='l'>
-      <PasswordField name='password' label={messages.passwordLabel} autoFocus />
+      <PasswordField
+        name='password'
+        label={messages.passwordLabel}
+        ref={inputRef}
+      />
       <PasswordField
         name='confirmPassword'
         label={messages.confirmPasswordLabel}

--- a/packages/web/src/pages/sign-up-page/components/HandleField.tsx
+++ b/packages/web/src/pages/sign-up-page/components/HandleField.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useContext } from 'react'
+import { Ref, forwardRef, useCallback, useContext } from 'react'
 
 import {
   MAX_HANDLE_LENGTH,
@@ -39,76 +39,79 @@ type HandleFieldProps = Partial<HarmonyTextFieldProps> & {
   onErrorSocialMediaLogin?: () => void
 }
 
-export const HandleField = (props: HandleFieldProps) => {
-  const {
-    onCompleteSocialMediaLogin,
-    onErrorSocialMediaLogin,
-    onStartSocialMediaLogin,
-    ...other
-  } = props
-  const [{ value: handle }, { error }] = useField('handle')
+export const HandleField = forwardRef(
+  (props: HandleFieldProps, ref: Ref<HTMLInputElement>) => {
+    const {
+      onCompleteSocialMediaLogin,
+      onErrorSocialMediaLogin,
+      onStartSocialMediaLogin,
+      ...other
+    } = props
+    const [{ value: handle }, { error }] = useField('handle')
 
-  const { toast } = useContext(ToastContext)
+    const { toast } = useContext(ToastContext)
 
-  const handleVerifyHandleError = useCallback(() => {
-    toast(socialMediaMessages.verificationError)
-    onErrorSocialMediaLogin?.()
-  }, [onErrorSocialMediaLogin, toast])
+    const handleVerifyHandleError = useCallback(() => {
+      toast(socialMediaMessages.verificationError)
+      onErrorSocialMediaLogin?.()
+    }, [onErrorSocialMediaLogin, toast])
 
-  const handleLoginSuccess = useCallback(
-    ({
-      handle,
-      requiresReview,
-      platform
-    }: {
-      requiresReview: boolean
-      handle: string
-      platform: 'twitter' | 'instagram' | 'tiktok'
-    }) => {
-      toast(socialMediaMessages.socialMediaLoginSucess(platform))
-      onCompleteSocialMediaLogin?.({
+    const handleLoginSuccess = useCallback(
+      ({
         handle,
         requiresReview,
         platform
-      })
-    },
-    [onCompleteSocialMediaLogin, toast]
-  )
+      }: {
+        requiresReview: boolean
+        handle: string
+        platform: 'twitter' | 'instagram' | 'tiktok'
+      }) => {
+        toast(socialMediaMessages.socialMediaLoginSucess(platform))
+        onCompleteSocialMediaLogin?.({
+          handle,
+          requiresReview,
+          platform
+        })
+      },
+      [onCompleteSocialMediaLogin, toast]
+    )
 
-  const AuthComponent = error ? handleAuthMap[error] : undefined
+    const AuthComponent = error ? handleAuthMap[error] : undefined
 
-  const helperText =
-    handle && error ? (
-      <>
-        {error}{' '}
-        {onCompleteSocialMediaLogin &&
-        onStartSocialMediaLogin &&
-        onErrorSocialMediaLogin &&
-        AuthComponent ? (
-          <TextLink variant='visible' asChild>
-            <AuthComponent
-              onStart={onStartSocialMediaLogin}
-              onFailure={handleVerifyHandleError}
-              onSuccess={handleLoginSuccess}
-            >
-              <span>{messages.linkToClaim}</span>
-            </AuthComponent>
-          </TextLink>
-        ) : null}
-      </>
-    ) : null
+    const helperText =
+      handle && error ? (
+        <>
+          {error}{' '}
+          {onCompleteSocialMediaLogin &&
+          onStartSocialMediaLogin &&
+          onErrorSocialMediaLogin &&
+          AuthComponent ? (
+            <TextLink variant='visible' asChild>
+              <AuthComponent
+                onStart={onStartSocialMediaLogin}
+                onFailure={handleVerifyHandleError}
+                onSuccess={handleLoginSuccess}
+              >
+                <span>{messages.linkToClaim}</span>
+              </AuthComponent>
+            </TextLink>
+          ) : null}
+        </>
+      ) : null
 
-  return (
-    <HarmonyTextField
-      name='handle'
-      label={messages.handle}
-      helperText={helperText}
-      maxLength={MAX_HANDLE_LENGTH}
-      startAdornmentText='@'
-      placeholder={messages.handle}
-      transformValueOnChange={(value) => value.replace(/\s/g, '')}
-      debouncedValidationMs={1000}
-      {...other}
-    />
-  )
-}
+    return (
+      <HarmonyTextField
+        ref={ref}
+        name='handle'
+        label={messages.handle}
+        helperText={helperText}
+        maxLength={MAX_HANDLE_LENGTH}
+        startAdornmentText='@'
+        placeholder={messages.handle}
+        transformValueOnChange={(value) => value.replace(/\s/g, '')}
+        debouncedValidationMs={1000}
+        {...other}
+      />
+    )
+  }
+)

--- a/packages/web/src/pages/sign-up-page/components/layout.tsx
+++ b/packages/web/src/pages/sign-up-page/components/layout.tsx
@@ -37,7 +37,7 @@ type PageProps = FlexProps & {
   centered?: boolean
   transition?: 'horizontal' | 'vertical'
   transitionBack?: 'horizontal' | 'vertical'
-  inputRef?: RefObject<HTMLInputElement>
+  autoFocusInputRef?: RefObject<HTMLInputElement>
 }
 
 const transitionAxisConfig = {
@@ -54,7 +54,7 @@ export const Page = (props: PageProps) => {
     as,
     transition,
     transitionBack,
-    inputRef,
+    autoFocusInputRef,
     ...other
   } = props
   const { isMobile } = useMedia()
@@ -86,7 +86,7 @@ export const Page = (props: PageProps) => {
       transform: toTransform
     },
     onRest: () => {
-      inputRef?.current?.focus()
+      autoFocusInputRef?.current?.focus()
     }
   })
 

--- a/packages/web/src/pages/sign-up-page/components/layout.tsx
+++ b/packages/web/src/pages/sign-up-page/components/layout.tsx
@@ -4,7 +4,8 @@ import {
   ElementType,
   ReactNode,
   forwardRef,
-  useContext
+  useContext,
+  RefObject
 } from 'react'
 
 import { Maybe } from '@audius/common'
@@ -36,6 +37,7 @@ type PageProps = FlexProps & {
   centered?: boolean
   transition?: 'horizontal' | 'vertical'
   transitionBack?: 'horizontal' | 'vertical'
+  inputRef?: RefObject<HTMLInputElement>
 }
 
 const transitionAxisConfig = {
@@ -46,7 +48,15 @@ const transitionAxisConfig = {
 const AnimatedFlex = animated(Flex)
 
 export const Page = (props: PageProps) => {
-  const { centered, children, as, transition, transitionBack, ...other } = props
+  const {
+    centered,
+    children,
+    as,
+    transition,
+    transitionBack,
+    inputRef,
+    ...other
+  } = props
   const { isMobile } = useMedia()
   const { isGoBack } = useContext(RouteContext)
 
@@ -74,6 +84,9 @@ export const Page = (props: PageProps) => {
     to: {
       opacity: 1,
       transform: toTransform
+    },
+    onRest: () => {
+      inputRef?.current?.focus()
     }
   })
 

--- a/packages/web/src/pages/sign-up-page/pages/CreateEmailPage.tsx
+++ b/packages/web/src/pages/sign-up-page/pages/CreateEmailPage.tsx
@@ -112,7 +112,7 @@ export const CreateEmailPage = () => {
       validationSchema={EmailSchema}
       validateOnChange={false}
     >
-      {({ dirty, isSubmitting }) => (
+      {({ isSubmitting }) => (
         <Page as={Form} pt='unit20'>
           <Box alignSelf='center'>
             {isMobile ? (

--- a/packages/web/src/pages/sign-up-page/pages/CreatePasswordPage.tsx
+++ b/packages/web/src/pages/sign-up-page/pages/CreatePasswordPage.tsx
@@ -57,7 +57,7 @@ export const CreatePasswordPage = () => {
         <Page
           as={Form}
           transition={isMobile ? undefined : 'horizontal'}
-          inputRef={passwordInputRef}
+          autoFocusInputRef={passwordInputRef}
         >
           <Heading
             heading={messages.createYourPassword}

--- a/packages/web/src/pages/sign-up-page/pages/CreatePasswordPage.tsx
+++ b/packages/web/src/pages/sign-up-page/pages/CreatePasswordPage.tsx
@@ -1,4 +1,4 @@
-import { useCallback } from 'react'
+import { useCallback, useRef } from 'react'
 
 import {
   createPasswordPageMessages as messages,
@@ -36,6 +36,7 @@ export const CreatePasswordPage = () => {
   const emailField = useSelector(getEmailField)
   const navigate = useNavigateToPage()
   const { isMobile } = useMedia()
+  const passwordInputRef = useRef<HTMLInputElement>(null)
 
   const handleSubmit = useCallback(
     (values: CreatePasswordValues) => {
@@ -53,7 +54,11 @@ export const CreatePasswordPage = () => {
       validationSchema={passwordFormikSchema}
     >
       {({ isValid, dirty }) => (
-        <Page as={Form} transition={isMobile ? undefined : 'horizontal'}>
+        <Page
+          as={Form}
+          transition={isMobile ? undefined : 'horizontal'}
+          inputRef={passwordInputRef}
+        >
           <Heading
             heading={messages.createYourPassword}
             description={messages.description}
@@ -63,7 +68,7 @@ export const CreatePasswordPage = () => {
               label={messages.yourEmail}
               value={emailField.value}
             />
-            <EnterPasswordSection />
+            <EnterPasswordSection inputRef={passwordInputRef} />
           </Flex>
           <PageFooter
             shadow='flat'

--- a/packages/web/src/pages/sign-up-page/pages/FinishProfilePage.tsx
+++ b/packages/web/src/pages/sign-up-page/pages/FinishProfilePage.tsx
@@ -1,4 +1,4 @@
-import { useCallback } from 'react'
+import { useCallback, useRef } from 'react'
 
 import {
   finishProfileSchema,
@@ -51,6 +51,7 @@ export const FinishProfilePage = () => {
   const history = useHistory()
   const dispatch = useDispatch()
   const navigate = useNavigateToPage()
+  const displayNameInputRef = useRef<HTMLInputElement>(null)
 
   const { value: savedDisplayName } = useSelector(getNameField)
   const isSocialConnected = useSelector(getIsSocialConnected)
@@ -92,6 +93,7 @@ export const FinishProfilePage = () => {
           centered
           transition={isMobile ? 'horizontal' : 'vertical'}
           transitionBack='horizontal'
+          inputRef={displayNameInputRef}
         >
           <Heading
             prefix={
@@ -110,11 +112,11 @@ export const FinishProfilePage = () => {
               formProfileImage={values.profileImage}
             />
             <HarmonyTextField
+              ref={displayNameInputRef}
               name='displayName'
               label={messages.displayName}
               placeholder={messages.inputPlaceholder}
               required
-              autoFocus
               maxLength={32}
               css={(theme) => ({
                 padding: theme.spacing.l,

--- a/packages/web/src/pages/sign-up-page/pages/FinishProfilePage.tsx
+++ b/packages/web/src/pages/sign-up-page/pages/FinishProfilePage.tsx
@@ -93,7 +93,7 @@ export const FinishProfilePage = () => {
           centered
           transition={isMobile ? 'horizontal' : 'vertical'}
           transitionBack='horizontal'
-          inputRef={displayNameInputRef}
+          autoFocusInputRef={displayNameInputRef}
         >
           <Heading
             prefix={

--- a/packages/web/src/pages/sign-up-page/pages/PickHandlePage.tsx
+++ b/packages/web/src/pages/sign-up-page/pages/PickHandlePage.tsx
@@ -164,7 +164,7 @@ export const PickHandlePage = () => {
           as={Form}
           centered={!isMobile}
           transitionBack='vertical'
-          inputRef={handleInputRef}
+          autoFocusInputRef={handleInputRef}
         >
           <Heading
             prefix={

--- a/packages/web/src/pages/sign-up-page/pages/PickHandlePage.tsx
+++ b/packages/web/src/pages/sign-up-page/pages/PickHandlePage.tsx
@@ -1,7 +1,6 @@
-import { useCallback, useContext, useMemo } from 'react'
+import { useCallback, useContext, useRef } from 'react'
 
 import {
-  useAudiusQueryContext,
   socialMediaMessages,
   pickHandlePageMessages as messages,
   pickHandleSchema
@@ -11,6 +10,7 @@ import { Form, Formik } from 'formik'
 import { useDispatch, useSelector } from 'react-redux'
 import { toFormikValidationSchema } from 'zod-formik-adapter'
 
+import { audiusQueryContext } from 'app/AudiusQueryProvider'
 import {
   setValueField,
   unsetSocialProfile
@@ -51,11 +51,12 @@ type SocialMediaSectionProps = {
   onError: () => void
 }
 
-const SocialMediaSection = ({
-  onCompleteSocialMediaLogin,
-  onStart,
-  onError
-}: SocialMediaSectionProps) => {
+const PickHandleValidationSchema = toFormikValidationSchema(
+  pickHandleSchema({ audiusQueryContext, restrictedHandles })
+)
+
+const SocialMediaSection = (props: SocialMediaSectionProps) => {
+  const { onCompleteSocialMediaLogin, onStart, onError } = props
   const { isMobile } = useMedia()
 
   return (
@@ -92,7 +93,6 @@ const SocialMediaSection = ({
 
 export const PickHandlePage = () => {
   const { isMobile } = useMedia()
-
   const dispatch = useDispatch()
 
   const alreadyLinkedSocial = useSelector(getIsSocialConnected)
@@ -107,15 +107,10 @@ export const PickHandlePage = () => {
 
   const navigate = useNavigateToPage()
   const { toast } = useContext(ToastContext)
-  const audiusQueryContext = useAudiusQueryContext()
-  const validationSchema = useMemo(() => {
-    return toFormikValidationSchema(
-      pickHandleSchema({ audiusQueryContext, restrictedHandles })
-    )
-  }, [audiusQueryContext])
 
   const { value: handle } = useSelector(getHandleField)
   const isLinkingSocialOnFirstPage = useSelector(getLinkedSocialOnFirstPage)
+  const handleInputRef = useRef<HTMLInputElement>(null)
 
   const handleSubmit = useCallback(
     (values: PickHandleValues) => {
@@ -158,14 +153,19 @@ export const PickHandlePage = () => {
   return (
     <Formik
       initialValues={initialValues}
-      validationSchema={validationSchema}
+      validationSchema={PickHandleValidationSchema}
       onSubmit={handleSubmit}
       validateOnChange={false}
     >
       {isWaitingForSocialLogin ? (
         <SocialMediaLoading />
       ) : (
-        <Page as={Form} centered={!isMobile} transitionBack='vertical'>
+        <Page
+          as={Form}
+          centered={!isMobile}
+          transitionBack='vertical'
+          inputRef={handleInputRef}
+        >
           <Heading
             prefix={
               isMobile ? null : <OutOfText numerator={1} denominator={2} />
@@ -176,7 +176,7 @@ export const PickHandlePage = () => {
           />
           <Flex direction='column' gap={isMobile ? 'l' : 'xl'}>
             <HandleField
-              autoFocus
+              ref={handleInputRef}
               onCompleteSocialMediaLogin={handleCompleteSocialMediaLogin}
               onStartSocialMediaLogin={handleStartSocialMediaLogin}
               onErrorSocialMediaLogin={handleErrorSocialMediaLogin}


### PR DESCRIPTION
### Description
Interestingly, "autoFocus" a prop used to focus user cursor on an input when it renders, messes up our page transitions, which smoothly animate a page to the left/right as it enters. The fix was to replace autoFocus with a ref-based approach. In this new system we call `ref.current.focus()` when the page animation finishes, which is triggered by the "onRest" method of the react-spring `useSpring` config. Not only does this fix the issue, it actually looks much nicer because we get a nice page transition, and then shortly after we get a nice input focus animation, making it much clearer to the user where their focus should be.
