### PR TITLE
Perform full disk cleanup hourly for self-hosted runners

### DIFF
--- a/.circleci/scripts/circleci-startup-script.sh
+++ b/.circleci/scripts/circleci-startup-script.sh
@@ -91,12 +91,6 @@ chmod 755 /usr/local/sbin/periodic-cleanup
 
 cat <<EOT > /etc/cron.hourly/audius-ci-hourly
 #!/bin/sh
-/usr/local/sbin/periodic-cleanup | logger -t cleanup
-EOT
-chmod 755 /etc/cron.hourly/audius-ci-hourly
-
-cat <<EOT > /etc/cron.daily/audius-ci-daily
-#!/bin/sh
 /usr/local/sbin/periodic-cleanup --full | logger -t cleanup
 EOT
-chmod 755 /etc/cron.daily/audius-ci-daily
+chmod 755 /etc/cron.hourly/audius-ci-hourly


### PR DESCRIPTION
### Description

We can rely on the thresholds to determine how ofter `docker system prune -a` should run (vs without `-a`) and we don't need to have separate hourly and daily scripts.

### How Has This Been Tested?

Will restart runner 7 when landed.
