### PR TITLE
Add 8cpu resource class to circleci runners

### DIFF
--- a/.circleci/scripts/circleci-startup-script.sh
+++ b/.circleci/scripts/circleci-startup-script.sh
@@ -99,6 +99,6 @@ chmod 755 /usr/local/sbin/periodic-cleanup
 
 cat <<EOT > /etc/cron.hourly/audius-ci-hourly
 #!/bin/sh
-/usr/local/sbin/periodic-cleanup --full | logger -t cleanup
+/usr/local/sbin/periodic-cleanup | logger -t cleanup
 EOT
 chmod 755 /etc/cron.hourly/audius-ci-hourly

--- a/.circleci/scripts/circleci-startup-script.sh
+++ b/.circleci/scripts/circleci-startup-script.sh
@@ -12,6 +12,7 @@ systemctl disable circleci.service &>/dev/null || true
 # set platform used for circleci installer and token
 export platform="linux/amd64"
 gcp_key="circleci-auth-token"
+cpus="$(lscpu | grep -E '^CPU\(s\)\:\s+[0-9]+$' | awk '{print $2}')"
 
 case "$(uname -m)" in
     "arm64" | "aarch64" | "arm")
@@ -20,7 +21,14 @@ case "$(uname -m)" in
         ;;
     "x86_64" | *)
         platform="linux/amd64"
-        gcp_key="circleci-auth-token"
+        case "$cpus" in
+            8)
+            gcp_key="circleci-auth-token-gcp-n2-standard-8"
+            ;;
+            4 | *)
+            gcp_key="circleci-auth-token"
+            ;;
+        esac
         ;;
 esac
 

--- a/.circleci/scripts/periodic-cleanup
+++ b/.circleci/scripts/periodic-cleanup
@@ -15,9 +15,8 @@ function disk_usage_above_threshold() {
 if disk_usage_above_threshold $PRUNE_THRESHOLD; then
     echo "Cleaning up docker..."
     docker system prune -f
-fi
-
-if disk_usage_above_threshold $FULL_PRUNE_THRESHOLD && [[ $1 = "--full" ]]; then
-    echo "Disk usage exceeds full prune threshold, perfoming full cleanup..."
-    docker system prune -af
+    if disk_usage_above_threshold $FULL_PRUNE_THRESHOLD; then
+        echo "Disk usage exceeds full prune threshold, perfoming full cleanup..."
+        docker system prune -af
+    fi
 fi


### PR DESCRIPTION
### Description

New resource class for self-hosted runner that will be used with audius-d tests.

### How Has This Been Tested?

Ran the cpus subshell command on the host itself to ensure proper functionality. Ran the whole script through shellcheck utility to check for errors.