### PR TITLE
Enable schedule release job

### DIFF
--- a/packages/discovery-provider/src/app.py
+++ b/packages/discovery-provider/src/app.py
@@ -323,8 +323,8 @@ def configure_celery(celery, test_config=None):
             "src.tasks.update_delist_statuses",
             "src.tasks.cache_current_nodes",
             "src.tasks.update_aggregates",
-            "src.tasks.cache_entity_counts"
-            # "src.tasks.publish_scheduled_releases",
+            "src.tasks.cache_entity_counts",
+            "src.tasks.publish_scheduled_releases",
         ],
         beat_schedule={
             "aggregate_metrics": {
@@ -439,10 +439,10 @@ def configure_celery(celery, test_config=None):
                 "task": "index_latest_block",
                 "schedule": timedelta(seconds=5),
             },
-            # "publish_scheduled_releases": {
-            #     "task": "publish_scheduled_releases",
-            #     "schedule": timedelta(minutes=1),
-            # },
+            "publish_scheduled_releases": {
+                "task": "publish_scheduled_releases",
+                "schedule": timedelta(minutes=1),
+            },
         },
         task_serializer="json",
         accept_content=["json"],
@@ -501,7 +501,7 @@ def configure_celery(celery, test_config=None):
     redis_inst.delete(INDEX_REACTIONS_LOCK)
     redis_inst.delete(UPDATE_DELIST_STATUSES_LOCK)
     redis_inst.delete("update_aggregates_lock")
-    # redis_inst.delete("publish_scheduled_releases")
+    redis_inst.delete("publish_scheduled_releases_lock")
     # delete cached final_poa_block in case it has changed
     redis_inst.delete(final_poa_block_redis_key)
 

--- a/packages/discovery-provider/src/tasks/publish_scheduled_releases.py
+++ b/packages/discovery-provider/src/tasks/publish_scheduled_releases.py
@@ -4,51 +4,33 @@ from src.models.tracks.track import Track
 from src.tasks.celery_app import celery
 from src.utils.structured_logger import StructuredLogger, log_duration
 from src.utils.web3_provider import get_eth_web3
+from sqlalchemy import func
 
 logger = StructuredLogger(__name__)
 web3 = get_eth_web3()
 publish_scheduled_releases_cursor_key = "publish_scheduled_releases_cursor"
-batch_size = 1000
+batch_size = 100
 
 
 @log_duration(logger)
-def _publish_scheduled_releases(session, redis):
-    latest_block = web3.eth.get_block("latest")
-    current_timestamp = latest_block.timestamp
-    redis_value = redis.get(publish_scheduled_releases_cursor_key)
-    previous_cursor = (
-        datetime.fromtimestamp(int(float(redis_value))) if redis_value else datetime.min
-    )
-
-    candidate_tracks = (
+def _publish_scheduled_releases(session):
+    tracks_to_release = (
         session.query(Track)
         .filter(
-            Track.is_unlisted,
-            Track.release_date.isnot(None),  # Filter for non-null release_date
-            Track.created_at >= previous_cursor,
+            Track.is_unlisted == True,
+            Track.is_scheduled_release == True,
+            Track.release_date != None,  # Filter for non-null release_date
+            Track.release_date < func.current_timestamp(),
         )
         .order_by(Track.created_at.asc())
         .limit(batch_size)
         .all()
     )
-    # convert release date to utc
-    for candidate_track in candidate_tracks:
-        try:
-            release_date_day = candidate_track.release_date
-        except Exception:
-            continue
-        if (
-            current_timestamp >= release_date_day.timestamp()
-            and release_date_day.timestamp() > candidate_track.created_at.timestamp()
-        ):
-            candidate_track.is_unlisted = False
+    logger.info(f"Found {len(tracks_to_release)} tracks ready for release")
 
-    if candidate_tracks:
-        redis.set(
-            publish_scheduled_releases_cursor_key,
-            candidate_tracks[-1].created_at.timestamp(),
-        )
-    return
+    for track in tracks_to_release:
+        logger.info(f"Releasing track {track.track_id}")
+        track.is_unlisted = False
 
 
 # ####### CELERY TASKS ####### #
@@ -67,7 +49,7 @@ def publish_scheduled_releases(self):
         have_lock = update_lock.acquire(blocking=False)
         if have_lock:
             with db.scoped_session() as session:
-                _publish_scheduled_releases(session, redis)
+                _publish_scheduled_releases(session)
 
         else:
             logger.info("Failed to acquire lock")

--- a/packages/discovery-provider/src/tasks/publish_scheduled_releases.py
+++ b/packages/discovery-provider/src/tasks/publish_scheduled_releases.py
@@ -1,10 +1,9 @@
-from datetime import datetime
+from sqlalchemy import func
 
 from src.models.tracks.track import Track
 from src.tasks.celery_app import celery
 from src.utils.structured_logger import StructuredLogger, log_duration
 from src.utils.web3_provider import get_eth_web3
-from sqlalchemy import func
 
 logger = StructuredLogger(__name__)
 web3 = get_eth_web3()


### PR DESCRIPTION
### Description
Re-enable and simplify logic. Only release tracks with is_scheduled_release True and a release_date that has passed.

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._

Running on sandbox and was able to publish scheduled releases. No other tracks are published.