### PR TITLE
Fix trpc-server ci cache

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -83,6 +83,7 @@ jobs:
             - ./packages/es-indexer/node_modules
             - ./packages/ddex/node_modules
             - ./packages/ddex-frontend/node_modules
+            - ./packages/trpc-server/node_modules
 
   generate-release-branch:
     working_directory: ~/audius-protocol

--- a/package-lock.json
+++ b/package-lock.json
@@ -3,7 +3,7 @@
   "version": "1.5.59",
   "lockfileVersion": 3,
   "requires": true,
-  "cacheBust": true,
+  "cacheBust": false,
   "packages": {
     "": {
       "name": "root",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,6 @@
     "packages/discovery-provider/plugins/pedalboard/packages/*",
     "packages/es-indexer"
   ],
-  "cacheBust": 2,
   "private": true,
   "scripts": {
     "build": "turbo run build",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "packages/discovery-provider/plugins/pedalboard/packages/*",
     "packages/es-indexer"
   ],
-  "cacheBust": 1,
+  "cacheBust": 2,
   "private": true,
   "scripts": {
     "build": "turbo run build",


### PR DESCRIPTION
### Description

Fixes issue where trpc-server node_modules cache was not being restored, leading to missing dependencies in the install