### PR TITLE
Remove DDEX .gitignore

### DIFF
--- a/packages/ddex/.gitignore
+++ b/packages/ddex/.gitignore
@@ -1,1 +1,0 @@
-uploads


### PR DESCRIPTION
### Description
Not needed since we don't use the ddex/uploads folder after https://github.com/AudiusProject/audius-protocol/pull/7102

### How Has This Been Tested?
