### PR TITLE
[PAY-2340] Fix dms playlist unfurl

### DIFF
--- a/packages/mobile/src/screens/chat-screen/ChatMessagePlaylist.tsx
+++ b/packages/mobile/src/screens/chat-screen/ChatMessagePlaylist.tsx
@@ -10,11 +10,10 @@ import {
   getPathFromPlaylistUrl,
   makeUid,
   playerSelectors,
-  useGetPlaylistById,
   useGetTracksByIds,
   usePlayTrack,
   usePauseTrack,
-  parsePlaylistIdFromPermalink
+  useGetPlaylistByPermalink
 } from '@audius/common'
 import { useSelector } from 'react-redux'
 
@@ -35,15 +34,13 @@ export const ChatMessagePlaylist = ({
   const playingTrackId = useSelector(getTrackId)
   const playingUid = useSelector(getUid)
 
-  const playlistId = parsePlaylistIdFromPermalink(
-    getPathFromPlaylistUrl(link) ?? ''
-  )
-  const { data: playlist } = useGetPlaylistById(
+  const permalink = getPathFromPlaylistUrl(link) ?? ''
+  const { data: playlist } = useGetPlaylistByPermalink(
     {
-      playlistId,
-      currentUserId
+      permalink,
+      currentUserId: currentUserId!
     },
-    { disabled: !playlistId }
+    { disabled: !permalink || !currentUserId }
   )
 
   const collection = useMemo(() => {

--- a/packages/web/src/pages/chat-page/components/ChatMessagePlaylist.tsx
+++ b/packages/web/src/pages/chat-page/components/ChatMessagePlaylist.tsx
@@ -8,18 +8,17 @@ import {
   QueueSource,
   playerSelectors,
   getPathFromPlaylistUrl,
-  useGetPlaylistById,
   accountSelectors,
   useGetTracksByIds,
   usePlayTrack,
   usePauseTrack,
   ChatMessageTileProps,
-  parsePlaylistIdFromPermalink,
   SquareSizes,
   cacheCollectionsActions,
   cacheCollectionsSelectors,
   CommonState,
-  Name
+  Name,
+  useGetPlaylistByPermalink
 } from '@audius/common'
 import { useDispatch, useSelector } from 'react-redux'
 
@@ -41,15 +40,13 @@ export const ChatMessagePlaylist = ({
   const currentUserId = useSelector(getUserId)
   const playingTrackId = useSelector(getTrackId)
 
-  const playlistId = parsePlaylistIdFromPermalink(
-    getPathFromPlaylistUrl(link) ?? ''
-  )
-  const { data: playlist, status } = useGetPlaylistById(
+  const permalink = getPathFromPlaylistUrl(link) ?? ''
+  const { data: playlist, status } = useGetPlaylistByPermalink(
     {
-      playlistId,
+      permalink,
       currentUserId: currentUserId!
     },
-    { disabled: !playlistId || !currentUserId }
+    { disabled: !permalink || !currentUserId }
   )
 
   const collectionId = playlist?.playlist_id


### PR DESCRIPTION
### Description

Issue was that we were getting playlists by id, and the way to get the id was brittle. I think there was a project some time ago to migrate to using permalinks, but the UI didn't get updated once the project was done. Fix is simply to get playlist by permalink.

### How Has This Been Tested?

local web vs prod

<img width="473" alt="Screenshot 2024-01-09 at 8 21 37 AM" src="https://github.com/AudiusProject/audius-protocol/assets/9600175/d58ec8a4-866f-497a-9dec-b88f16440817">


