### PR TITLE
Remove yield* in JS file

### DIFF
--- a/packages/web/src/common/store/upload/sagas.js
+++ b/packages/web/src/common/store/upload/sagas.js
@@ -859,7 +859,7 @@ function* uploadCollection(tracks, userId, collectionMetadata, isAlbum) {
             }
           })
         )
-        yield* put(
+        yield put(
           addLocalCollection({
             collectionId: confirmedPlaylist.playlist_id,
             isAlbum: confirmedPlaylist.is_album,


### PR DESCRIPTION
Prevent error in uploading albums due to using yield* on non-typescript file

Unknown if this is the error that our user hit as it doesn't send me to the /error page, but worth fixing!

Made the change on github ui, haven't tested
