### PR TITLE
Fix audio matching buyer challenge broken for verified users

### DIFF
--- a/packages/discovery-provider/src/challenges/audio_matching_challenge.py
+++ b/packages/discovery-provider/src/challenges/audio_matching_challenge.py
@@ -32,7 +32,7 @@ class AudioMatchingBuyerChallengeUpdater(ChallengeUpdater):
     def should_create_new_challenge(
         self, session, event: str, user_id: int, extra: Dict
     ) -> bool:
-        return does_user_exist_with_verification_status(session, user_id, False)
+        return True
 
     def should_show_challenge_for_user(self, session: Session, user_id: int) -> bool:
         return True


### PR DESCRIPTION
### Description
Fixes bug where $AUDIO matching challenge would only be created for non-verified users.

There are 16 purchases across 6 users that didn't get this challenge due to this bug. 2 of them are our own.

shoutout @rickyrombo for spotting the bug.

### How Has This Been Tested?

Will test on stage.
