### PR TITLE
DDEX dockerfile uses turbo

### DIFF
--- a/dev-tools/compose/docker-compose.ddex.yml
+++ b/dev-tools/compose/docker-compose.ddex.yml
@@ -4,8 +4,8 @@ services:
   ddex:
     container_name: ddex
     build:
-      context: ${PROJECT_ROOT}/packages
-      dockerfile: Dockerfile.ddex
+      context: ${PROJECT_ROOT}
+      dockerfile: ${PROJECT_ROOT}/packages/Dockerfile.ddex
       args:
         app_name: ddex
         TURBO_TEAM: '${TURBO_TEAM}'

--- a/packages/Dockerfile.ddex
+++ b/packages/Dockerfile.ddex
@@ -1,25 +1,55 @@
 # Build stage for DDEX frontend
 FROM node:18.17-slim AS frontend-dist
+
+ARG TURBO_TEAM
+ENV TURBO_TEAM=$TURBO_TEAM
+
+ARG TURBO_TOKEN
+ENV TURBO_TOKEN=$TURBO_TOKEN
+ 
 RUN apt-get update && apt-get install -y \
     python3 \
     make \
     g++ \
     && rm -rf /var/lib/apt/lists/*
+
 WORKDIR /app
+
 COPY ddex-frontend/package*.json ddex-frontend/*config*.js ddex-frontend/tsconfig*.json ddex-frontend/vite.config.ts ./
-RUN npm install
 COPY ddex-frontend/src ./src
 COPY ddex-frontend/public ./public
 COPY ddex-frontend/index.html .
-RUN npm run build
+
+RUN npm install turbo --global
+RUN turbo prune --scope=@audius/ddex-frontend --docker
+
+RUN CI=true npm i
+
+# Build the project and its dependencies
+# COPY turbo.json turbo.json
+RUN npx turbo run build --filter=@audius/ddex-frontend
 
 # Build stage for DDEX backend
 FROM node:18.17-slim AS backend-dist
+
+ARG TURBO_TEAM
+ENV TURBO_TEAM=$TURBO_TEAM
+
+ARG TURBO_TOKEN
+ENV TURBO_TOKEN=$TURBO_TOKEN
+ 
 WORKDIR /backend
 COPY ddex/package*.json ddex/tsconfig.json ./
-RUN npm install
 COPY ddex/src ./src
-RUN npm run build
+
+RUN npm install turbo --global
+RUN turbo prune --scope=@audius/ddex --docker
+
+RUN CI=true npm i
+
+# Build the project and its dependencies
+# COPY turbo.json turbo.json
+RUN npx turbo run build --filter=@audius/ddex
 
 # Final stage
 FROM node:18.17-slim

--- a/packages/Dockerfile.ddex
+++ b/packages/Dockerfile.ddex
@@ -7,26 +7,25 @@ ENV TURBO_TEAM=$TURBO_TEAM
 ARG TURBO_TOKEN
 ENV TURBO_TOKEN=$TURBO_TOKEN
  
-RUN apt-get update && apt-get install -y \
-    python3 \
-    make \
-    g++ \
-    && rm -rf /var/lib/apt/lists/*
-
 WORKDIR /app
 
-COPY ddex-frontend/package*.json ddex-frontend/*config*.js ddex-frontend/tsconfig*.json ddex-frontend/vite.config.ts ./
-COPY ddex-frontend/src ./src
-COPY ddex-frontend/public ./public
-COPY ddex-frontend/index.html .
-
 RUN npm install turbo --global
+COPY . .
 RUN turbo prune --scope=@audius/ddex-frontend --docker
+
+RUN apt-get update && apt-get install -y \
+    python3 \
+    python3-pip \
+    make \
+    g++ \
+    curl \
+    bash \
+    && rm -rf /var/lib/apt/lists/*
 
 RUN CI=true npm i
 
 # Build the project and its dependencies
-# COPY turbo.json turbo.json
+COPY turbo.json turbo.json
 RUN npx turbo run build --filter=@audius/ddex-frontend
 
 # Build stage for DDEX backend
@@ -39,24 +38,32 @@ ARG TURBO_TOKEN
 ENV TURBO_TOKEN=$TURBO_TOKEN
  
 WORKDIR /backend
-COPY ddex/package*.json ddex/tsconfig.json ./
-COPY ddex/src ./src
 
 RUN npm install turbo --global
+COPY . .
 RUN turbo prune --scope=@audius/ddex --docker
+
+RUN apt-get update && apt-get install -y \
+    python3 \
+    python3-pip \
+    make \
+    g++ \
+    curl \
+    bash \
+    && rm -rf /var/lib/apt/lists/*
 
 RUN CI=true npm i
 
 # Build the project and its dependencies
-# COPY turbo.json turbo.json
+COPY turbo.json turbo.json
 RUN npx turbo run build --filter=@audius/ddex
 
 # Final stage
 FROM node:18.17-slim
 WORKDIR /usr/src/app
-COPY --from=frontend-dist /app/dist ./public
-COPY --from=backend-dist /backend/dist ./dist
-COPY --from=backend-dist /backend/node_modules ./node_modules
+COPY --from=frontend-dist /app/packages/ddex-frontend/dist ./public
+COPY --from=backend-dist /backend/packages/ddex/dist ./dist
+COPY --from=backend-dist /backend/packages/ddex/node_modules ./node_modules
 
 EXPOSE 8926
 CMD [ "node", "dist/index.js" ]

--- a/packages/Dockerfile.ddex.fast
+++ b/packages/Dockerfile.ddex.fast
@@ -9,19 +9,34 @@
 # Build DDEX backend
 FROM node:18.17-slim AS backend-dist
 WORKDIR /backend
-COPY ddex/package*.json ddex/tsconfig.json ./
-RUN npm install
-COPY ddex/src ./src
-RUN npm run build
+# COPY packages/ddex/package*.json packages/ddex/tsconfig.json ./
+# COPY packages/ddex/src ./src
+
+RUN npm install turbo --global
+COPY . .
+RUN turbo prune --scope=@audius/ddex --docker
+
+RUN apt-get update && apt-get install -y \
+    python3 \
+    python3-pip \
+    make \
+    g++ \
+    curl \
+    bash \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN CI=true npm i
+COPY turbo.json turbo.json
+RUN npx turbo run build --filter=@audius/ddex
 
 # Final stage
 FROM node:18.17-slim
 WORKDIR /usr/src/app
-COPY --from=backend-dist /backend/dist ./dist
-COPY --from=backend-dist /backend/node_modules ./node_modules
+COPY --from=backend-dist /backend/packages/ddex/dist ./dist
+COPY --from=backend-dist /backend/packages/ddex/node_modules ./node_modules
 
 # Copy the frontend dist from local filesystem instead of building it in Docker, which hangs
-COPY ddex-frontend/dist/ ./public
+COPY packages/ddex-frontend/dist/ ./public
 
 EXPOSE 8926
 CMD [ "node", "dist/index.js" ]


### PR DESCRIPTION
### Description
Required for ddex to build with harmony, which is not yet published to npm.

### How Has This Been Tested?
built Dockerfile.ddex and Dockerfile.ddex.fast locally
audius-compose push --prod "ddex"
built on a stage node