### PR TITLE
[C-3572] Update WelcomeModal to prevent blur flashing when button is hovered

### DIFF
--- a/packages/web/src/components/welcome-modal/WelcomeModal.tsx
+++ b/packages/web/src/components/welcome-modal/WelcomeModal.tsx
@@ -58,7 +58,13 @@ export const WelcomeModal = () => {
       >
         <Avatar variant='strong' src={profileImage?.url} />
       </Box>
-      <Flex direction='column' p='xl' pt='3xl' gap='xl'>
+      <Flex
+        direction='column'
+        p='xl'
+        pt='3xl'
+        gap='xl'
+        css={{ overflow: 'hidden' }}
+      >
         <Flex direction='column' css={{ textAlign: 'center' }} gap='l'>
           <Text variant='label' size='xl' strength='strong' id='welcome-title'>
             {fillString(messages.welcome, userName ? `, ${userName}` : '')}


### PR DESCRIPTION
### Description
Adding `overflow: hidden` to isolate animations within the body of the welcome modal to not affect the blurred background of the top part.

NOTE: Chrome has a lot of weird visual bugs with blurred background so this is mostly a bandaid solution, but this is conjunction with the buttons not scaling up on hover should fix this well enough.

### How Has This Been Tested?
Tested locally
