### PR TITLE
[C-3520] Add Visit Album links to track menus

### DIFF
--- a/packages/common/src/store/pages/chat/selectors.ts
+++ b/packages/common/src/store/pages/chat/selectors.ts
@@ -172,7 +172,7 @@ export const getSingleOtherChatUser = (
  * Gets a list of the users the current user has chats with.
  * Note that this only takes the first user of each chat that doesn't match the current one,
  * so this will need to be adjusted when we do group chats.
- */
+ **/
 export const getUserList = createSelector(
   [getUserId, getChats, getHasMoreChats, getChatsStatus],
   (currentUserId, chats, hasMore, chatsStatus) => {

--- a/packages/mobile/src/components/lineup-tile/TrackTile.tsx
+++ b/packages/mobile/src/components/lineup-tile/TrackTile.tsx
@@ -26,6 +26,7 @@ import {
 } from '@audius/common'
 import { useNavigationState } from '@react-navigation/native'
 import { useDispatch, useSelector } from 'react-redux'
+import { trpc } from 'utils/trpcClientWeb'
 
 import { TrackImage } from 'app/components/image/TrackImage'
 import type { LineupItemProps } from 'app/components/lineup-tile/types'
@@ -130,6 +131,11 @@ export const TrackTileComponent = ({
     [track]
   )
 
+  const { data: albumInfo } = trpc.tracks.getAlbumBacklink.useQuery(
+    { trackId: track_id },
+    { enabled: !!track_id }
+  )
+
   const handlePress = useCallback(() => {
     togglePlay({
       uid: lineupTileProps.uid,
@@ -158,6 +164,7 @@ export const TrackTileComponent = ({
       isNewPodcastControlsEnabled && isLongFormContent
         ? OverflowAction.VIEW_EPISODE_PAGE
         : OverflowAction.VIEW_TRACK_PAGE,
+      isEditAlbumsEnabled && albumInfo ? OverflowAction.VIEW_ALBUM_PAGE : null,
       isNewPodcastControlsEnabled && isLongFormContent
         ? playbackPositionInfo?.status === 'COMPLETED'
           ? OverflowAction.MARK_AS_UNPLAYED
@@ -185,6 +192,7 @@ export const TrackTileComponent = ({
     isOwner,
     isPremium,
     isNewPodcastControlsEnabled,
+    albumInfo,
     playbackPositionInfo?.status,
     isOnArtistsTracksTab,
     track?.is_scheduled_release,

--- a/packages/mobile/src/components/now-playing-drawer/ActionsBar.tsx
+++ b/packages/mobile/src/components/now-playing-drawer/ActionsBar.tsx
@@ -26,6 +26,7 @@ import {
 import { View, Platform } from 'react-native'
 import { CastButton } from 'react-native-google-cast'
 import { useDispatch, useSelector } from 'react-redux'
+import { trpc } from 'utils/trpcClientWeb'
 
 import IconAirplay from 'app/assets/images/iconAirplay.svg'
 import IconChromecast from 'app/assets/images/iconChromecast.svg'
@@ -118,6 +119,11 @@ export const ActionsBar = ({ track }: ActionsBarProps) => {
   const { onOpen: openPremiumContentPurchaseModal } =
     usePremiumContentPurchaseModal()
 
+  const { data: albumInfo } = trpc.tracks.getAlbumBacklink.useQuery(
+    { trackId: track?.track_id ?? 0 },
+    { enabled: !!track?.track_id }
+  )
+
   const handlePurchasePress = useCallback(() => {
     if (track?.track_id) {
       openPremiumContentPurchaseModal(
@@ -190,6 +196,9 @@ export const ActionsBar = ({ track }: ActionsBarProps) => {
         isNewPodcastControlsEnabled && isLongFormContent
           ? OverflowAction.VIEW_EPISODE_PAGE
           : OverflowAction.VIEW_TRACK_PAGE,
+        isEditAlbumsEnabled && albumInfo
+          ? OverflowAction.VIEW_ALBUM_PAGE
+          : null,
         isNewPodcastControlsEnabled && isLongFormContent
           ? playbackPositionInfo?.status === 'COMPLETED'
             ? OverflowAction.MARK_AS_UNPLAYED
@@ -211,6 +220,7 @@ export const ActionsBar = ({ track }: ActionsBarProps) => {
     isEditAlbumsEnabled,
     isOwner,
     isNewPodcastControlsEnabled,
+    albumInfo,
     playbackPositionInfo?.status,
     dispatch
   ])

--- a/packages/mobile/src/components/overflow-menu-drawer/TrackOverflowMenuDrawer.tsx
+++ b/packages/mobile/src/components/overflow-menu-drawer/TrackOverflowMenuDrawer.tsx
@@ -21,6 +21,7 @@ import {
   mobileOverflowMenuUISelectors
 } from '@audius/common'
 import { useDispatch, useSelector } from 'react-redux'
+import { trpc } from 'utils/trpcClientWeb'
 
 import { useDrawer } from 'app/hooks/useDrawer'
 import { useNavigation } from 'app/hooks/useNavigation'
@@ -66,6 +67,11 @@ const TrackOverflowMenuDrawer = ({ render }: Props) => {
   )
   const playlistTrackInfo = playlist?.playlist_contents.track_ids.find(
     (t) => t.track === track?.track_id
+  )
+
+  const { data: albumInfo } = trpc.tracks.getAlbumBacklink.useQuery(
+    { trackId: id },
+    { enabled: !!id }
   )
 
   const user = useSelector((state: CommonState) =>
@@ -123,6 +129,9 @@ const TrackOverflowMenuDrawer = ({ render }: Props) => {
     [OverflowAction.VIEW_EPISODE_PAGE]: () => {
       closeNowPlayingDrawer()
       navigation?.push('Track', { id })
+    },
+    [OverflowAction.VIEW_ALBUM_PAGE]: () => {
+      albumInfo && navigation?.push('Collection', { id: albumInfo.playlist_id })
     },
     [OverflowAction.VIEW_ARTIST_PAGE]: () => {
       closeNowPlayingDrawer()

--- a/packages/mobile/src/components/track-list/TrackListItem.tsx
+++ b/packages/mobile/src/components/track-list/TrackListItem.tsx
@@ -24,6 +24,7 @@ import type {
 } from 'react-native'
 import { Text, TouchableOpacity, View } from 'react-native'
 import { useDispatch, useSelector } from 'react-redux'
+import { trpc } from 'utils/trpcClientWeb'
 
 import IconDrag from 'app/assets/images/iconDrag.svg'
 import IconKebabHorizontal from 'app/assets/images/iconKebabHorizontal.svg'
@@ -296,6 +297,11 @@ const TrackListItemComponent = (props: TrackListItemComponentProps) => {
     getTrackPosition(state, { trackId: track_id, userId: currentUserId })
   )
 
+  const { data: albumInfo } = trpc.tracks.getAlbumBacklink.useQuery(
+    { trackId: track_id },
+    { enabled: !!track_id }
+  )
+
   const handleOpenOverflowMenu = useCallback(() => {
     const overflowActions = [
       OverflowAction.SHARE,
@@ -314,6 +320,7 @@ const TrackListItemComponent = (props: TrackListItemComponentProps) => {
       isNewPodcastControlsEnabled && isLongFormContent
         ? OverflowAction.VIEW_EPISODE_PAGE
         : OverflowAction.VIEW_TRACK_PAGE,
+      isEditAlbumsEnabled && albumInfo ? OverflowAction.VIEW_ALBUM_PAGE : null,
       isNewPodcastControlsEnabled && isLongFormContent
         ? playbackPositionInfo?.status === 'COMPLETED'
           ? OverflowAction.MARK_AS_UNPLAYED
@@ -340,6 +347,7 @@ const TrackListItemComponent = (props: TrackListItemComponentProps) => {
     isPremium,
     isNewPodcastControlsEnabled,
     isLongFormContent,
+    albumInfo,
     playbackPositionInfo?.status,
     isContextPlaylistOwner,
     dispatch,

--- a/packages/mobile/src/screens/track-screen/TrackScreenDetailsTile.tsx
+++ b/packages/mobile/src/screens/track-screen/TrackScreenDetailsTile.tsx
@@ -37,6 +37,7 @@ import moment from 'moment'
 import { Image, View } from 'react-native'
 import LinearGradient from 'react-native-linear-gradient'
 import { useDispatch, useSelector } from 'react-redux'
+import { trpc } from 'utils/trpcClientWeb'
 
 import IconCart from 'app/assets/images/iconCart.svg'
 import IconCollectible from 'app/assets/images/iconCollectible.svg'
@@ -269,6 +270,11 @@ export const TrackScreenDetailsTile = ({
 
   const filteredTags = (tags || '').split(',').filter(Boolean)
 
+  const { data: albumInfo } = trpc.tracks.getAlbumBacklink.useQuery(
+    { trackId: track_id },
+    { enabled: !!track_id }
+  )
+
   const details: DetailsTileDetail[] = [
     { label: 'Duration', value: formatSeconds(duration) },
     {
@@ -412,6 +418,7 @@ export const TrackScreenDetailsTile = ({
           ? OverflowAction.MARK_AS_UNPLAYED
           : OverflowAction.MARK_AS_PLAYED
         : null,
+      isEditAlbumsEnabled && albumInfo ? OverflowAction.VIEW_ALBUM_PAGE : null,
       OverflowAction.VIEW_ARTIST_PAGE,
       isOwner ? OverflowAction.EDIT_TRACK : null,
       isOwner && track?.is_scheduled_release && track?.is_unlisted

--- a/packages/web/src/components/menu/TrackMenu.tsx
+++ b/packages/web/src/components/menu/TrackMenu.tsx
@@ -28,7 +28,8 @@ import { ToastContext } from 'components/toast/ToastContext'
 import { useFlag } from 'hooks/useRemoteConfig'
 import { showSetAsArtistPickConfirmation } from 'store/application/ui/setAsArtistPickConfirmation/actions'
 import { AppState } from 'store/types'
-import { profilePage } from 'utils/route'
+import { albumPage, profilePage } from 'utils/route'
+import { trpc } from 'utils/trpcClientWeb'
 const { requestOpen: openAddToCollection } = addToCollectionUIActions
 const { saveTrack, unsaveTrack, repostTrack, undoRepostTrack, shareTrack } =
   tracksSocialActions
@@ -143,6 +144,10 @@ const TrackMenu = (props: TrackMenuProps) => {
       unsetArtistPick
     } = props
 
+    const { data: albumInfo } = trpc.tracks.getAlbumBacklink.useQuery(
+      { trackId },
+      { enabled: !!trackId }
+    )
     const isLongFormContent =
       genre === Genre.PODCASTS || genre === Genre.AUDIOBOOKS
 
@@ -229,11 +234,14 @@ const TrackMenu = (props: TrackMenuProps) => {
       }
     }
 
-    // TODO: Add back go to album when we have better album linking.
-    // const albumPageMenuItem = {
-    //   text: 'Visit Album Page',
-    //   onClick: () => goToRoute(albumPage(handle, albumName, albumId))
-    // }
+    const albumPageMenuItem = {
+      text: 'Visit Album Page',
+      onClick: () =>
+        albumInfo &&
+        goToRoute(
+          albumPage(handle, albumInfo?.playlist_name, albumInfo?.playlist_id)
+        )
+    }
 
     const artistPageMenuItem = {
       text: messages.visitArtistPage,
@@ -288,10 +296,9 @@ const TrackMenu = (props: TrackMenuProps) => {
     if (trackId && isOwner && includeArtistPick && !isDeleted) {
       menu.items.push(artistPickMenuItem)
     }
-    // TODO: Add back go to album when we have better album linking.
-    // if (albumId && albumName) {
-    //   menu.items.push(albumPageMenuItem)
-    // }
+    if (albumInfo && includeAddToAlbum && isEditAlbumsEnabled) {
+      menu.items.push(albumPageMenuItem)
+    }
     if (handle && !isOwnerDeactivated) {
       menu.items.push(artistPageMenuItem)
     }

--- a/packages/web/src/components/now-playing/NowPlaying.tsx
+++ b/packages/web/src/components/now-playing/NowPlaying.tsx
@@ -59,6 +59,7 @@ import {
   collectibleDetailsPage
 } from 'utils/route'
 import { isDarkMode, isMatrix } from 'utils/theme/theme'
+import { trpc } from 'utils/trpcClientWeb'
 import { withNullGuard } from 'utils/withNullGuard'
 
 import styles from './NowPlaying.module.css'
@@ -137,6 +138,11 @@ const NowPlaying = g(
     const { isEnabled: isEditAlbumsEnabled } = useFlag(FeatureFlags.EDIT_ALBUMS)
 
     const { uid, track, user, collectible } = currentQueueItem
+
+    const { data: albumInfo } = trpc.tracks.getAlbumBacklink.useQuery(
+      { trackId: track?.track_id ?? 0 },
+      { enabled: !!track?.track_id }
+    )
 
     // Keep a ref for the artwork and dynamically resize the width of the
     // image as the height changes (which is flexed).
@@ -314,6 +320,10 @@ const NowPlaying = g(
           ? OverflowAction.ADD_TO_PLAYLIST
           : null,
         track && OverflowAction.VIEW_TRACK_PAGE,
+        isEditAlbumsEnabled && albumInfo
+          ? OverflowAction.VIEW_ALBUM_PAGE
+          : null,
+
         collectible && OverflowAction.VIEW_COLLECTIBLE_PAGE,
         OverflowAction.VIEW_ARTIST_PAGE
       ].filter(Boolean) as OverflowAction[]
@@ -333,6 +343,7 @@ const NowPlaying = g(
       has_current_user_saved,
       isEditAlbumsEnabled,
       track,
+      albumInfo,
       onClose,
       clickOverflow,
       track_id

--- a/packages/web/src/components/track/mobile/ConnectedTrackListItem.tsx
+++ b/packages/web/src/components/track/mobile/ConnectedTrackListItem.tsx
@@ -18,6 +18,7 @@ import { Dispatch } from 'redux'
 
 import { useFlag } from 'hooks/useRemoteConfig'
 import { AppState } from 'store/types'
+import { trpc } from 'utils/trpcClientWeb'
 
 import TrackListItem, { TrackListItemProps } from './TrackListItem'
 
@@ -35,7 +36,10 @@ type ConnectedTrackListItemProps = OwnProps & StateProps & DispatchProps
 
 const ConnectedTrackListItem = (props: ConnectedTrackListItemProps) => {
   const { isEnabled: isEditAlbumsEnabled } = useFlag(FeatureFlags.EDIT_ALBUMS)
-
+  const { data: albumInfo } = trpc.tracks.getAlbumBacklink.useQuery(
+    { trackId: props.trackId },
+    { enabled: !!props.trackId }
+  )
   const onClickOverflow = () => {
     const overflowActions = [
       props.isLocked
@@ -53,6 +57,7 @@ const ConnectedTrackListItem = (props: ConnectedTrackListItemProps) => {
         : null,
       !props.isPremium ? OverflowAction.ADD_TO_PLAYLIST : null,
       OverflowAction.VIEW_TRACK_PAGE,
+      isEditAlbumsEnabled && albumInfo ? OverflowAction.VIEW_ALBUM_PAGE : null,
       OverflowAction.VIEW_ARTIST_PAGE
     ].filter(Boolean) as OverflowAction[]
     props.clickOverflow(props.trackId, overflowActions)

--- a/packages/web/src/components/track/mobile/ConnectedTrackTile.tsx
+++ b/packages/web/src/components/track/mobile/ConnectedTrackTile.tsx
@@ -32,6 +32,7 @@ import { useFlag } from 'hooks/useRemoteConfig'
 import { AppState } from 'store/types'
 import { REPOSTING_USERS_ROUTE, FAVORITING_USERS_ROUTE } from 'utils/route'
 import { isMatrix, shouldShowDark } from 'utils/theme/theme'
+import { trpc } from 'utils/trpcClientWeb'
 
 import { getTrackWithFallback, getUserWithFallback } from '../helpers'
 
@@ -142,7 +143,10 @@ const ConnectedTrackTile = ({
     FeatureFlags.PODCAST_CONTROL_UPDATES_ENABLED_FALLBACK
   )
   const { isEnabled: isEditAlbumsEnabled } = useFlag(FeatureFlags.EDIT_ALBUMS)
-
+  const { data: albumInfo } = trpc.tracks.getAlbumBacklink.useQuery(
+    { trackId: track_id },
+    { enabled: !!track_id }
+  )
   const { isUserAccessTBD, doesUserHaveAccess } =
     usePremiumContentAccess(trackWithFallback)
   const loading = isLoading || isUserAccessTBD
@@ -209,6 +213,7 @@ const ConnectedTrackTile = ({
       isNewPodcastControlsEnabled && isLongFormContent
         ? OverflowAction.VIEW_EPISODE_PAGE
         : OverflowAction.VIEW_TRACK_PAGE,
+      isEditAlbumsEnabled && albumInfo ? OverflowAction.VIEW_ALBUM_PAGE : null,
       OverflowAction.VIEW_ARTIST_PAGE
     ].filter(Boolean) as OverflowAction[]
 

--- a/packages/web/src/pages/track-page/components/mobile/TrackHeader.tsx
+++ b/packages/web/src/pages/track-page/components/mobile/TrackHeader.tsx
@@ -47,6 +47,7 @@ import { useFlag } from 'hooks/useRemoteConfig'
 import { useTrackCoverArt } from 'hooks/useTrackCoverArt'
 import { moodMap } from 'utils/Moods'
 import { isDarkMode } from 'utils/theme/theme'
+import { trpc } from 'utils/trpcClientWeb'
 
 import HiddenTrackHeader from '../HiddenTrackHeader'
 
@@ -194,6 +195,10 @@ const TrackHeader = ({
   const showPlay = isUSDCPurchaseGated ? doesUserHaveAccess : true
   const showListenCount =
     isOwner || (!isPremium && (isUnlisted || fieldVisibility.play_count))
+  const { data: albumInfo } = trpc.tracks.getAlbumBacklink.useQuery(
+    { trackId },
+    { enabled: !!trackId }
+  )
 
   const image = useTrackCoverArt(
     trackId,
@@ -239,6 +244,7 @@ const TrackHeader = ({
         : OverflowAction.FAVORITE,
       isEditAlbumsEnabled && isOwner ? OverflowAction.ADD_TO_ALBUM : null,
       !isPremium ? OverflowAction.ADD_TO_PLAYLIST : null,
+      isEditAlbumsEnabled && albumInfo ? OverflowAction.VIEW_ALBUM_PAGE : null,
       isFollowing
         ? OverflowAction.UNFOLLOW_ARTIST
         : OverflowAction.FOLLOW_ARTIST,


### PR DESCRIPTION
### Description

Add `Visit Album Page` to track overflow menus for web and mobile

![Screenshot 2024-01-11 at 11 38 27 PM](https://github.com/AudiusProject/audius-protocol/assets/2358254/f66cf3f7-c559-48fc-b803-f9520ecb61b0)

![Screenshot 2024-01-12 at 12 07 13 AM](https://github.com/AudiusProject/audius-protocol/assets/2358254/96c1fad2-cd6a-4bda-ae1d-bb7ec2f13255)

### How Has This Been Tested?

local web and ios sim