### PR TITLE
Fix mobile upload download gated fields

### DIFF
--- a/packages/mobile/src/screens/upload-screen/screens/UploadingTracksScreen.tsx
+++ b/packages/mobile/src/screens/upload-screen/screens/UploadingTracksScreen.tsx
@@ -61,7 +61,25 @@ export const UploadingTracksScreen = () => {
   const dispatch = useDispatch()
 
   useEffectOnce(() => {
-    dispatch(uploadTracks(tracks, undefined, UploadType.INDIVIDUAL_TRACK))
+    // set download gate based on stream gate
+    // this will be updated once the UI for download gated tracks is implemented
+    const tracksToUpload = tracks.map((track) => {
+      const isDownloadable = !!track.metadata.download?.is_downloadable
+      const isDownloadGated = track.metadata.is_stream_gated
+      const downloadConditions = track.metadata.stream_conditions
+      return {
+        ...track,
+        metadata: {
+          ...track.metadata,
+          is_downloadable: isDownloadable,
+          is_download_gated: isDownloadGated,
+          download_conditions: downloadConditions
+        }
+      }
+    })
+    dispatch(
+      uploadTracks(tracksToUpload, undefined, UploadType.INDIVIDUAL_TRACK)
+    )
   })
 
   const trackUploadProgress = useSelector(getCombinedUploadPercentage)

--- a/packages/web/src/pages/upload-page/UploadPage.tsx
+++ b/packages/web/src/pages/upload-page/UploadPage.tsx
@@ -184,7 +184,7 @@ export const UploadPage = (props: UploadPageProps) => {
       return track.metadata.stems ?? []
     }, [])
 
-    // set download gate based on downloadability and stream gate
+    // set download gate based on stream gate
     // this will be updated once the UI for download gated tracks is implemented
     const tracksToUpload = tracks.map((track) => {
       const isDownloadable = !!track.metadata.download?.is_downloadable


### PR DESCRIPTION
### Description

Was missing the setting of `is_download_gated` and `download_conditions`. These changes are already on web.

### How Has This Been Tested?

Uploaded usdc premium track on ios and it worked. (didn't work before this change)
