### PR TITLE
[C-3626, C-3624, C-3628] Fix add to album toast message; Album info to end of track details

### DIFF
--- a/packages/web/src/common/store/cache/collections/addTrackToPlaylistSaga.ts
+++ b/packages/web/src/common/store/cache/collections/addTrackToPlaylistSaga.ts
@@ -35,7 +35,8 @@ const { setOptimisticChallengeCompleted } = audioRewardsPageActions
 const { toast } = toastActions
 
 const messages = {
-  addedTrack: 'Added track to playlist'
+  addedTrack: (collectionType: 'album' | 'playlist') =>
+    `Added track to ${collectionType}`
 }
 
 type AddTrackToPlaylistAction = ReturnType<
@@ -135,7 +136,11 @@ function* addTrackToPlaylistAsync(action: AddTrackToPlaylistAction) {
 
   yield* put(event)
 
-  yield* put(toast({ content: messages.addedTrack }))
+  yield* put(
+    toast({
+      content: messages.addedTrack(playlist.is_album ? 'album' : 'playlist')
+    })
+  )
 }
 
 function* confirmAddTrackToPlaylist(

--- a/packages/web/src/components/track/GiantTrackTile.tsx
+++ b/packages/web/src/components/track/GiantTrackTile.tsx
@@ -689,7 +689,6 @@ export const GiantTrackTile = ({
             labelValue={`${formatSeconds(duration)}`}
           />
           {renderReleased()}
-          {renderAlbum()}
           {renderGenre()}
           {renderMood()}
           {credits ? (
@@ -699,6 +698,7 @@ export const GiantTrackTile = ({
               labelValue={credits}
             />
           ) : null}
+          {renderAlbum()}
         </div>
         {description ? (
           <UserGeneratedText


### PR DESCRIPTION
### Description

- Fix `addToPlaylist` toast message to include the right collection type
- Move Album link to the end of track page detail fields

### How Has This Been Tested?

local web