### PR TITLE
[C-3622] Exclude 'Visit Album' from menus when already on album page

### DIFF
--- a/packages/mobile/src/components/track-list/TrackList.tsx
+++ b/packages/mobile/src/components/track-list/TrackList.tsx
@@ -90,7 +90,7 @@ export const TrackList = ({
               onDrag={drag}
               hideArt={hideArt}
               isReorderable={isReorderable}
-              isAlbumPage={isAlbumPage}
+              showViewAlbum={isAlbumPage}
               uid={uids && (item as UID)}
               prevUid={uids && uids[index - 1]}
               key={item}
@@ -108,6 +108,7 @@ export const TrackList = ({
         contextPlaylistId,
         hideArt,
         ids,
+        isAlbumPage,
         isReorderable,
         noDividerMargin,
         onRemove,

--- a/packages/mobile/src/components/track-list/TrackList.tsx
+++ b/packages/mobile/src/components/track-list/TrackList.tsx
@@ -25,6 +25,7 @@ type TrackListProps = {
   ids?: ID[]
   contextPlaylistId?: ID
   isReorderable?: boolean
+  isAlbumPage?: boolean
   onRemove?: (index: number) => void
   onReorder?: DraggableFlatListProps<UID | ID>['onDragEnd']
   showSkeleton?: boolean
@@ -48,6 +49,7 @@ export const TrackList = ({
   hideArt,
   ids,
   isReorderable,
+  isAlbumPage = false,
   noDividerMargin,
   onRemove,
   onReorder,
@@ -88,6 +90,7 @@ export const TrackList = ({
               onDrag={drag}
               hideArt={hideArt}
               isReorderable={isReorderable}
+              isAlbumPage={isAlbumPage}
               uid={uids && (item as UID)}
               prevUid={uids && uids[index - 1]}
               key={item}

--- a/packages/mobile/src/components/track-list/TrackListItem.tsx
+++ b/packages/mobile/src/components/track-list/TrackListItem.tsx
@@ -160,6 +160,7 @@ export type TrackListItemProps = {
   contextPlaylistId?: ID
   index: number
   isReorderable?: boolean
+  isAlbumPage?: boolean
   noDividerMargin?: boolean
   onRemove?: (index: number) => void
   prevUid?: UID
@@ -210,6 +211,7 @@ const TrackListItemComponent = (props: TrackListItemComponentProps) => {
     hideArt,
     index,
     isReorderable = false,
+    isAlbumPage = false,
     noDividerMargin,
     onRemove,
     prevUid,
@@ -320,7 +322,9 @@ const TrackListItemComponent = (props: TrackListItemComponentProps) => {
       isNewPodcastControlsEnabled && isLongFormContent
         ? OverflowAction.VIEW_EPISODE_PAGE
         : OverflowAction.VIEW_TRACK_PAGE,
-      isEditAlbumsEnabled && albumInfo ? OverflowAction.VIEW_ALBUM_PAGE : null,
+      isEditAlbumsEnabled && !isAlbumPage && albumInfo
+        ? OverflowAction.VIEW_ALBUM_PAGE
+        : null,
       isNewPodcastControlsEnabled && isLongFormContent
         ? playbackPositionInfo?.status === 'COMPLETED'
           ? OverflowAction.MARK_AS_UNPLAYED

--- a/packages/mobile/src/components/track-list/TrackListItem.tsx
+++ b/packages/mobile/src/components/track-list/TrackListItem.tsx
@@ -160,7 +160,7 @@ export type TrackListItemProps = {
   contextPlaylistId?: ID
   index: number
   isReorderable?: boolean
-  isAlbumPage?: boolean
+  showViewAlbum?: boolean
   noDividerMargin?: boolean
   onRemove?: (index: number) => void
   prevUid?: UID
@@ -211,7 +211,7 @@ const TrackListItemComponent = (props: TrackListItemComponentProps) => {
     hideArt,
     index,
     isReorderable = false,
-    isAlbumPage = false,
+    showViewAlbum = false,
     noDividerMargin,
     onRemove,
     prevUid,
@@ -322,7 +322,7 @@ const TrackListItemComponent = (props: TrackListItemComponentProps) => {
       isNewPodcastControlsEnabled && isLongFormContent
         ? OverflowAction.VIEW_EPISODE_PAGE
         : OverflowAction.VIEW_TRACK_PAGE,
-      isEditAlbumsEnabled && !isAlbumPage && albumInfo
+      isEditAlbumsEnabled && !showViewAlbum && albumInfo
         ? OverflowAction.VIEW_ALBUM_PAGE
         : null,
       isNewPodcastControlsEnabled && isLongFormContent

--- a/packages/mobile/src/screens/collection-screen/CollectionScreenDetailsTile.tsx
+++ b/packages/mobile/src/screens/collection-screen/CollectionScreenDetailsTile.tsx
@@ -238,6 +238,7 @@ export const CollectionScreenDetailsTile = ({
         showDivider
         showSkeleton={isLineupLoading}
         togglePlay={handlePressTrackListItemPlay}
+        isAlbumPage={isAlbum}
         uids={isLineupLoading ? Array(Math.min(5, trackCount ?? 0)) : trackUids}
         ListEmptyComponent={
           isLineupLoading ? null : (

--- a/packages/web/src/components/menu/TrackMenu.tsx
+++ b/packages/web/src/components/menu/TrackMenu.tsx
@@ -54,6 +54,7 @@ const messages = {
   unreposted: 'Un-Reposted!',
   unsetArtistPick: 'Unset as Artist Pick',
   visitArtistPage: 'Visit Artist Page',
+  visitAlbumPage: 'Visit Album Page',
   visitTrackPage: 'Visit Track Page',
   visitEpisodePage: 'Visit Episode Page',
   markAsPlayed: 'Mark as Played',
@@ -74,6 +75,7 @@ export type OwnProps = {
   includeFavorite?: boolean
   includeRepost?: boolean
   includeShare?: boolean
+  includeAlbumPage?: boolean
   includeTrackPage?: boolean
   isArtistPick?: boolean
   isDeleted?: boolean
@@ -121,6 +123,7 @@ const TrackMenu = (props: TrackMenuProps) => {
       includeFavorite,
       includeRepost,
       includeShare,
+      includeAlbumPage,
       includeTrackPage,
       isArtistPick,
       isDeleted,
@@ -235,7 +238,7 @@ const TrackMenu = (props: TrackMenuProps) => {
     }
 
     const albumPageMenuItem = {
-      text: 'Visit Album Page',
+      text: messages.visitAlbumPage,
       onClick: () =>
         albumInfo &&
         goToRoute(
@@ -296,7 +299,7 @@ const TrackMenu = (props: TrackMenuProps) => {
     if (trackId && isOwner && includeArtistPick && !isDeleted) {
       menu.items.push(artistPickMenuItem)
     }
-    if (albumInfo && includeAddToAlbum && isEditAlbumsEnabled) {
+    if (albumInfo && includeAlbumPage && isEditAlbumsEnabled) {
       menu.items.push(albumPageMenuItem)
     }
     if (handle && !isOwnerDeactivated) {
@@ -365,6 +368,7 @@ TrackMenu.defaultProps = {
   includeEdit: true,
   includeEmbed: true,
   includeFavorite: true,
+  includeAlbumPage: true,
   includeTrackPage: true,
   includeAddToAlbum: true,
   includeAddToPlaylist: true,

--- a/packages/web/src/components/tracks-table/TracksTable.tsx
+++ b/packages/web/src/components/tracks-table/TracksTable.tsx
@@ -76,6 +76,7 @@ type TracksTableProps = {
   isVirtualized?: boolean
   isPaginated?: boolean
   isReorderable?: boolean
+  isAlbumPage?: boolean
   loading?: boolean
   onClickFavorite?: (track: any) => void
   onClickRemove?: (
@@ -121,6 +122,7 @@ export const TracksTable = ({
   disabledTrackEdit = false,
   isPaginated = false,
   isReorderable = false,
+  isAlbumPage = false,
   fetchBatchSize,
   fetchMoreTracks,
   fetchPage,
@@ -381,6 +383,7 @@ export const TracksTable = ({
             className={styles.tableActionButton}
             isDeleted={deleted}
             includeEdit={!disabledTrackEdit}
+            includeAlbumPage={!isAlbumPage}
             includeAddToPlaylist={!isLocked}
             includeFavorite={!isLocked}
             onRemove={onClickRemove}
@@ -400,7 +403,14 @@ export const TracksTable = ({
         </div>
       )
     },
-    [trackAccessMap, disabledTrackEdit, onClickRemove, removeText, userId]
+    [
+      trackAccessMap,
+      disabledTrackEdit,
+      isAlbumPage,
+      onClickRemove,
+      removeText,
+      userId
+    ]
   )
 
   const renderTrackActions = useCallback(

--- a/packages/web/src/pages/collection-page/components/desktop/CollectionPage.tsx
+++ b/packages/web/src/pages/collection-page/components/desktop/CollectionPage.tsx
@@ -273,6 +273,7 @@ const CollectionPage = ({
               removeText={`${messages.remove} ${
                 isAlbum ? messages.type.album : messages.type.playlist
               }`}
+              isAlbumPage={isAlbum}
             />
           </div>
         )}


### PR DESCRIPTION
### Description

Exclude the `Visit Album Page` option for tracks in a tracks table on an album page. In this case you are necessarily already viewing the album.

### How Has This Been Tested?

local web and sim
option appears in other places but not on the album page
same track will show the option elsewhere and now playing track is unaffected even if you're on an album page