### PR TITLE
[C-3627] Add toasts to removeTrackFromPlaylist

### DIFF
--- a/packages/common/src/store/ui/toast/slice.ts
+++ b/packages/common/src/store/ui/toast/slice.ts
@@ -35,6 +35,7 @@ const slice = createSlice({
       )
       // NOTE: Set the toast timeout to 0 so that the Toast component animates out and dismissed the toast
       // Used for mobile toasts
+      if (!state.toasts[toastIdx]) return
       state.toasts[toastIdx].timeout = 0
     },
     dismissToast: (state, action: DissmissToastAction) => {

--- a/packages/web/src/common/store/cache/collections/commonSagas.js
+++ b/packages/web/src/common/store/cache/collections/commonSagas.js
@@ -57,7 +57,9 @@ const { getTrack } = cacheTracksSelectors
 const { getAccountUser, getUserId } = accountSelectors
 
 const messages = {
-  editToast: 'Changes saved!'
+  editToast: 'Changes saved!',
+  removingTrack: 'Removing track...',
+  removedTrack: 'Removed track'
 }
 
 /** Counts instances of trackId in a playlist. */
@@ -221,6 +223,13 @@ function* removeTrackFromPlaylistAsync(action) {
   playlist.playlist_contents.track_ids.splice(index, 1)
   const count = countTrackIds(playlist.playlist_contents, trackId)
 
+  yield put(
+    toast({
+      content: messages.removingTrack,
+      key: `remove-track-${trackId}`
+    })
+  )
+
   yield call(
     confirmRemoveTrackFromPlaylist,
     userId,
@@ -307,6 +316,12 @@ function* confirmRemoveTrackFromPlaylist(
               metadata: confirmedPlaylist
             }
           ])
+        )
+        yield put(manualClearToast({ key: `remove-track-${trackId}` }))
+        yield put(
+          toast({
+            content: messages.removedTrack
+          })
         )
       },
       function* ({ error, timeout, message }) {


### PR DESCRIPTION
### Description

Add toasts when processing track removal from a collection. This is desirable because the action buttons are disabled while the confirmation is in progress. This helps explain why.

### How Has This Been Tested?

local web and mobile