### PR TITLE
[C-3631] Fix social image uploads by reformatting the types

### DIFF
--- a/packages/common/src/store/account/types.ts
+++ b/packages/common/src/store/account/types.ts
@@ -51,11 +51,3 @@ export type TikTokProfile = {
   avatar_large_url?: string
   is_verified: boolean
 }
-
-export type AccountImage = { url: string; file: any } | undefined
-
-export type NativeAccountImage = {
-  uri: string
-  name: string
-  type?: string
-}

--- a/packages/mobile/src/screens/sign-on-screen/components/SignUpFlowInstagramAuth.tsx
+++ b/packages/mobile/src/screens/sign-on-screen/components/SignUpFlowInstagramAuth.tsx
@@ -56,9 +56,12 @@ const useSetProfileFromInstagram = () => {
         profile,
         profile.profile_pic_url_hd
           ? {
-              uri: profile.profile_pic_url_hd,
-              name: 'ProfileImage',
-              type: 'image/jpeg'
+              url: profile.profile_pic_url_hd,
+              file: {
+                uri: profile.profile_pic_url_hd,
+                name: 'ProfileImage',
+                type: 'image/jpeg'
+              }
             }
           : null
       )

--- a/packages/mobile/src/screens/signon/ProfileAuto.tsx
+++ b/packages/mobile/src/screens/signon/ProfileAuto.tsx
@@ -205,26 +205,34 @@ const ProfileAuto = ({ navigation }: ProfileAutoProps) => {
 
   const setOAuthInfo = useCallback(() => {
     if (twitterInfo) {
+      // Replace twitter's returned image (which may vary) with the hd one
+      const hdTwitterImageUrl =
+        twitterInfo.profile.profile_image_url_https.replace(
+          /_(normal|bigger|mini)/g,
+          ''
+        )
       dispatch(
         signOnActions.setTwitterProfile(
           twitterInfo.uuid,
           twitterInfo.profile,
           twitterInfo.profile.profile_image_url_https
             ? {
-                // Replace twitter's returned image (which may vary) with the hd one
-                uri: twitterInfo.profile.profile_image_url_https.replace(
-                  /_(normal|bigger|mini)/g,
-                  ''
-                ),
-                name: 'ProfileImage',
-                type: 'image/jpeg'
+                url: hdTwitterImageUrl,
+                file: {
+                  uri: hdTwitterImageUrl,
+                  name: 'ProfileImage',
+                  type: 'image/jpeg'
+                }
               }
             : null,
           twitterInfo.profile.profile_banner_url
             ? {
-                uri: twitterInfo.profile.profile_banner_url,
-                name: 'ProfileBanner',
-                type: 'image/png'
+                url: twitterInfo.profile.profile_banner_url,
+                file: {
+                  uri: twitterInfo.profile.profile_banner_url,
+                  name: 'ProfileBanner',
+                  type: 'image/png'
+                }
               }
             : null
         )
@@ -236,9 +244,12 @@ const ProfileAuto = ({ navigation }: ProfileAutoProps) => {
           instagramInfo.profile,
           instagramInfo.profile.profile_pic_url_hd
             ? {
-                uri: instagramInfo.profile.profile_pic_url_hd,
-                name: 'ProfileImage',
-                type: 'image/jpeg'
+                url: instagramInfo.profile.profile_pic_url_hd,
+                file: {
+                  uri: instagramInfo.profile.profile_pic_url_hd,
+                  name: 'ProfileImage',
+                  type: 'image/jpeg'
+                }
               }
             : null
         )
@@ -250,9 +261,12 @@ const ProfileAuto = ({ navigation }: ProfileAutoProps) => {
           tikTokInfo.profile,
           tikTokInfo.profile.avatar_large_url
             ? {
-                uri: tikTokInfo.profile.avatar_large_url,
-                name: 'ProfileImage',
-                type: 'image/jpeg'
+                url: tikTokInfo.profile.avatar_large_url,
+                file: {
+                  uri: tikTokInfo.profile.avatar_large_url,
+                  name: 'ProfileImage',
+                  type: 'image/jpeg'
+                }
               }
             : null
         )

--- a/packages/mobile/src/screens/signon/ProfileAuto.tsx
+++ b/packages/mobile/src/screens/signon/ProfileAuto.tsx
@@ -206,20 +206,21 @@ const ProfileAuto = ({ navigation }: ProfileAutoProps) => {
   const setOAuthInfo = useCallback(() => {
     if (twitterInfo) {
       // Replace twitter's returned image (which may vary) with the hd one
-      const hdTwitterImageUrl =
-        twitterInfo.profile.profile_image_url_https.replace(
-          /_(normal|bigger|mini)/g,
-          ''
-        )
+      const twitterProfileImageUrl = twitterInfo.profile.profile_image_url_https
+        ? twitterInfo.profile.profile_image_url_https.replace(
+            /_(normal|bigger|mini)/g,
+            ''
+          )
+        : null
       dispatch(
         signOnActions.setTwitterProfile(
           twitterInfo.uuid,
           twitterInfo.profile,
-          twitterInfo.profile.profile_image_url_https
+          twitterProfileImageUrl
             ? {
-                url: hdTwitterImageUrl,
+                url: twitterProfileImageUrl,
                 file: {
-                  uri: hdTwitterImageUrl,
+                  uri: twitterProfileImageUrl,
                   name: 'ProfileImage',
                   type: 'image/jpeg'
                 }

--- a/packages/mobile/src/store/oauth/actions.ts
+++ b/packages/mobile/src/store/oauth/actions.ts
@@ -62,7 +62,7 @@ type SetTwitterInfoAction = {
   uuid: any
   profile: TwitterProfile
   profileImage: Image
-  profileBanner: Image
+  profileBanner: Image | undefined
   requiresUserReview: any
 }
 type SetTwitterErrorAction = {
@@ -86,7 +86,7 @@ type SetTikTokInfoAction = {
   type: typeof SET_TIKTOK_INFO
   uuid: any
   profile: TikTokProfile
-  profileImage: Image
+  profileImage: Image | undefined
   requiresUserReview: any
 }
 type SetTikTokErrorAction = {
@@ -164,7 +164,7 @@ export const setTwitterInfo = (
   uuid: string,
   profile: TwitterProfile,
   profileImage: Image,
-  profileBanner: Image,
+  profileBanner: Image | undefined,
   requiresUserReview: boolean
 ): SetTwitterInfoAction => ({
   type: SET_TWITTER_INFO,
@@ -199,7 +199,7 @@ export const setInstagramError = (error: any): SetInstagramErrorAction => ({
 export const setTikTokInfo = (
   uuid: string,
   profile: TikTokProfile,
-  profileImage: Image,
+  profileImage: Image | undefined,
   requiresUserReview: boolean
 ): SetTikTokInfoAction => ({
   type: SET_TIKTOK_INFO,

--- a/packages/mobile/src/store/oauth/actions.ts
+++ b/packages/mobile/src/store/oauth/actions.ts
@@ -1,8 +1,8 @@
 import type {
-  AccountImage,
   InstagramAccountPayload,
   TwitterProfile,
-  TikTokProfile
+  TikTokProfile,
+  Image
 } from '@audius/common'
 
 import type { Provider } from './reducer'
@@ -61,8 +61,8 @@ type SetTwitterInfoAction = {
   type: typeof SET_TWITTER_INFO
   uuid: any
   profile: TwitterProfile
-  profileImage: AccountImage
-  profileBanner: AccountImage
+  profileImage: Image
+  profileBanner: Image
   requiresUserReview: any
 }
 type SetTwitterErrorAction = {
@@ -74,7 +74,7 @@ type SetInstagramInfoAction = {
   type: typeof SET_INSTAGRAM_INFO
   uuid: any
   profile: InstagramAccountPayload
-  profileImage: AccountImage
+  profileImage: Image
   requiresUserReview: any
 }
 type SetInstagramErrorAction = {
@@ -86,7 +86,7 @@ type SetTikTokInfoAction = {
   type: typeof SET_TIKTOK_INFO
   uuid: any
   profile: TikTokProfile
-  profileImage: AccountImage
+  profileImage: Image
   requiresUserReview: any
 }
 type SetTikTokErrorAction = {
@@ -163,8 +163,8 @@ export const closePopup = (abandoned: boolean): ClosePopupAction => ({
 export const setTwitterInfo = (
   uuid: string,
   profile: TwitterProfile,
-  profileImage: AccountImage,
-  profileBanner: AccountImage,
+  profileImage: Image,
+  profileBanner: Image,
   requiresUserReview: boolean
 ): SetTwitterInfoAction => ({
   type: SET_TWITTER_INFO,
@@ -182,7 +182,7 @@ export const setTwitterError = (error: any): SetTwitterErrorAction => ({
 export const setInstagramInfo = (
   uuid: string,
   profile: InstagramAccountPayload,
-  profileImage: AccountImage,
+  profileImage: Image,
   requiresUserReview: boolean
 ): SetInstagramInfoAction => ({
   type: SET_INSTAGRAM_INFO,
@@ -199,7 +199,7 @@ export const setInstagramError = (error: any): SetInstagramErrorAction => ({
 export const setTikTokInfo = (
   uuid: string,
   profile: TikTokProfile,
-  profileImage: AccountImage,
+  profileImage: Image,
   requiresUserReview: boolean
 ): SetTikTokInfoAction => ({
   type: SET_TIKTOK_INFO,

--- a/packages/mobile/src/store/oauth/reducer.ts
+++ b/packages/mobile/src/store/oauth/reducer.ts
@@ -1,4 +1,4 @@
-import type { TikTokProfile } from '@audius/common'
+import type { Image, TikTokProfile } from '@audius/common'
 
 import type { OAuthActions } from './actions'
 import {
@@ -17,7 +17,7 @@ import type { AUTH_RESPONSE_MESSAGE_TYPE } from './types'
 export type TwitterInfo = {
   uuid: any
   profile: any
-  profileImage: any
+  profileImage: Image
   profileBanner: any
   requiresUserReview: any
   twitterId?: any
@@ -26,7 +26,7 @@ export type TwitterInfo = {
 export type InstagramInfo = {
   uuid: any
   profile: any
-  profileImage: any
+  profileImage: Image
   requiresUserReview: any
   instagramId?: any
 }
@@ -34,7 +34,7 @@ export type InstagramInfo = {
 type TikTokInfo = {
   uuid: string
   profile: TikTokProfile
-  profileImage: { url: string; file: File } | undefined
+  profileImage: Image | undefined
   requiresUserReview: boolean
 }
 

--- a/packages/web/src/common/store/pages/signon/actions.ts
+++ b/packages/web/src/common/store/pages/signon/actions.ts
@@ -1,11 +1,10 @@
 import {
   ID,
   User,
-  AccountImage,
   InstagramProfile,
   TwitterProfile,
-  NativeAccountImage,
-  TikTokProfile
+  TikTokProfile,
+  Image
 } from '@audius/common'
 
 import { UiErrorCode } from 'store/errors/actions'
@@ -321,8 +320,8 @@ export function setFinishedPhase1(finished: boolean) {
 export function setTwitterProfile(
   twitterId: string,
   profile: TwitterProfile,
-  profileImage?: AccountImage | NativeAccountImage | null,
-  coverPhoto?: AccountImage | NativeAccountImage | null
+  profileImage?: Image | null,
+  coverPhoto?: Image | null
 ) {
   return {
     type: SET_TWITTER_PROFILE,
@@ -340,7 +339,7 @@ export function setTwitterProfileError(error: string) {
 export function setInstagramProfile(
   instagramId: string,
   profile: InstagramProfile,
-  profileImage?: AccountImage | NativeAccountImage | null
+  profileImage?: Image | null
 ) {
   return {
     type: SET_INSTAGRAM_PROFILE,
@@ -357,7 +356,7 @@ export function setInstagramProfileError(error: string) {
 export function setTikTokProfile(
   tikTokId: string,
   profile: TikTokProfile,
-  profileImage?: AccountImage | NativeAccountImage | null
+  profileImage?: Image | null
 ) {
   return {
     type: SET_TIKTOK_PROFILE,

--- a/packages/web/src/pages/sign-on/SignOnProvider.tsx
+++ b/packages/web/src/pages/sign-on/SignOnProvider.tsx
@@ -6,7 +6,7 @@ import {
   User,
   accountSelectors,
   InstagramProfile,
-  AccountImage,
+  Image,
   TwitterProfile,
   accountActions,
   TikTokProfile
@@ -338,8 +338,8 @@ export class SignOnProvider extends Component<SignOnProps, SignOnState> {
   setTwitterProfile = (
     twitterId: string,
     profile: TwitterProfile,
-    profileImg?: AccountImage,
-    coverBannerImg?: AccountImage,
+    profileImg?: Image,
+    coverBannerImg?: Image,
     skipEdit?: boolean
   ) => {
     const {
@@ -374,7 +374,7 @@ export class SignOnProvider extends Component<SignOnProps, SignOnState> {
   setInstagramProfile = (
     instagramId: string,
     profile: InstagramProfile,
-    profileImg?: AccountImage,
+    profileImg?: Image,
     skipEdit?: boolean
   ) => {
     const {
@@ -395,7 +395,7 @@ export class SignOnProvider extends Component<SignOnProps, SignOnState> {
   setTikTokProfile = (
     tikTokId: string,
     profile: TikTokProfile,
-    profileImg?: AccountImage,
+    profileImg?: Image,
     skipEdit?: boolean
   ) => {
     const {
@@ -517,8 +517,8 @@ function mapDispatchToProps(dispatch: Dispatch) {
     setTwitterProfile: (
       twitterId: string,
       profile: TwitterProfile,
-      profileImage?: AccountImage,
-      coverPhoto?: AccountImage
+      profileImage?: Image,
+      coverPhoto?: Image
     ) =>
       dispatch(
         signOnAction.setTwitterProfile(
@@ -531,7 +531,7 @@ function mapDispatchToProps(dispatch: Dispatch) {
     setInstagramProfile: (
       instagramId: string,
       profile: InstagramProfile,
-      profileImage?: AccountImage
+      profileImage?: Image
     ) =>
       dispatch(
         signOnAction.setInstagramProfile(instagramId, profile, profileImage)
@@ -539,7 +539,7 @@ function mapDispatchToProps(dispatch: Dispatch) {
     setTikTokProfile: (
       tikTokId: string,
       profile: TikTokProfile,
-      profileImage?: AccountImage
+      profileImage?: Image
     ) =>
       dispatch(signOnAction.setTikTokProfile(tikTokId, profile, profileImage)),
     validateEmail: (email: string) =>

--- a/packages/web/src/pages/sign-on/components/ProfilePage.tsx
+++ b/packages/web/src/pages/sign-on/components/ProfilePage.tsx
@@ -1,7 +1,7 @@
 import { useState, useCallback, KeyboardEvent, useContext } from 'react'
 
 import {
-  AccountImage,
+  Image,
   InstagramProfile,
   TwitterProfile,
   formatInstagramProfile,
@@ -31,7 +31,7 @@ const messages = {
 }
 
 type ProfilePageProps = {
-  profileImage?: AccountImage
+  profileImage?: Image
   twitterId: any
   isVerified: boolean
   onNextPage: () => void
@@ -39,20 +39,20 @@ type ProfilePageProps = {
   setTwitterProfile: (
     uuid: string,
     profile: TwitterProfile,
-    profileImg?: AccountImage,
-    coverBannerImg?: AccountImage,
+    profileImg?: Image,
+    coverBannerImg?: Image,
     skipEdit?: boolean
   ) => void
   setInstagramProfile: (
     uuid: string,
     profile: InstagramProfile,
-    profileImg?: AccountImage,
+    profileImg?: Image,
     skipEdit?: boolean
   ) => void
   setTikTokProfile: (
     uuid: string,
     profile: TikTokProfile,
-    profileImg?: AccountImage,
+    profileImg?: Image,
     skipEdit?: boolean
   ) => void
   recordTwitterStart: () => void

--- a/packages/web/src/pages/sign-on/components/desktop/SignOnPage.tsx
+++ b/packages/web/src/pages/sign-on/components/desktop/SignOnPage.tsx
@@ -5,7 +5,7 @@ import {
   Status,
   User,
   accountSelectors,
-  AccountImage,
+  Image,
   InstagramProfile,
   TwitterProfile,
   TikTokProfile
@@ -81,20 +81,20 @@ export type SignOnProps = {
   setTwitterProfile: (
     uuid: string,
     profile: TwitterProfile,
-    profileImg?: AccountImage,
-    coverBannerImg?: AccountImage,
+    profileImg?: Image,
+    coverBannerImg?: Image,
     skipEdit?: boolean
   ) => void
   setInstagramProfile: (
     uuid: string,
     profile: InstagramProfile,
-    profileImg?: AccountImage,
+    profileImg?: Image,
     skipEdit?: boolean
   ) => void
   setTikTokProfile: (
     uuid: string,
     profile: TikTokProfile,
-    profileImg?: AccountImage,
+    profileImg?: Image,
     skipEdit?: boolean
   ) => void
   validateHandle: (

--- a/packages/web/src/pages/sign-on/components/mobile/SignOnPage.tsx
+++ b/packages/web/src/pages/sign-on/components/mobile/SignOnPage.tsx
@@ -3,7 +3,7 @@ import { useEffect } from 'react'
 import {
   ID,
   User,
-  AccountImage,
+  Image,
   InstagramProfile,
   TwitterProfile,
   TikTokProfile
@@ -53,20 +53,20 @@ export type SignOnProps = {
   setTwitterProfile: (
     uuid: string,
     profile: TwitterProfile,
-    profileImg?: AccountImage,
-    coverBannerImg?: AccountImage,
+    profileImg?: Image,
+    coverBannerImg?: Image,
     skipEdit?: boolean
   ) => void
   setInstagramProfile: (
     uuid: string,
     profile: InstagramProfile,
-    profileImg?: AccountImage,
+    profileImg?: Image,
     skipEdit?: boolean
   ) => void
   setTikTokProfile: (
     uuid: string,
     profile: TikTokProfile,
-    profileImg?: AccountImage,
+    profileImg?: Image,
     skipEdit?: boolean
   ) => void
   recordInstagramStart: () => void


### PR DESCRIPTION
### Description

- Our native social image uploads were using a different format, so I just standardized the image format coming from the social flows and used the more standard `Image` type

### How Has This Been Tested?

TikTok on iOS simulator staging/prod - was able to sign up and profile pic shows up
Instagram on iOS simulator prod - was able to sign up and profile pic shows up
Twitter on iOS simulator prod - was able to sign up and profile pic shows up

NOTE: having some trouble reusing these socials and getting to the "Handle is already taken" flow 😬 
