### PR TITLE
[C-3632] Return null instead of NOT_FOUND in trpc-server

### DIFF
--- a/packages/trpc-server/src/routers/playlist-router.ts
+++ b/packages/trpc-server/src/routers/playlist-router.ts
@@ -1,12 +1,11 @@
 import { z } from 'zod'
 import { publicProcedure, router } from '../trpc'
-import { TRPCError } from '@trpc/server'
 
 export const playlistRouter = router({
   get: publicProcedure.input(z.string()).query(async ({ ctx, input }) => {
     const row = await ctx.loaders.playlistLoader.load(parseInt(input))
     if (!row) {
-      throw new TRPCError({ code: 'NOT_FOUND' })
+      return null;
     }
     return row
   }),

--- a/packages/trpc-server/src/routers/track-router.ts
+++ b/packages/trpc-server/src/routers/track-router.ts
@@ -1,6 +1,5 @@
 import { z } from 'zod'
 import { publicProcedure, router } from '../trpc'
-import { TRPCError } from '@trpc/server'
 import { sql } from '../db'
 import { UserRow } from '../db-tables'
 import { esc } from './search-router'
@@ -15,7 +14,7 @@ export const trackRouter = router({
   get: publicProcedure.input(z.string()).query(async ({ ctx, input }) => {
     const row = await ctx.loaders.trackLoader.load(parseInt(input))
     if (!row) {
-      throw new TRPCError({ code: 'NOT_FOUND' })
+      return null;
     }
     return row
   }),
@@ -88,7 +87,7 @@ export const trackRouter = router({
 
       const hits = found.hits.hits.map((h) => h._source)
       if (hits.length === 0) {
-        throw new TRPCError({ code: 'NOT_FOUND' })
+        return null;
       }
       return hits[0]
     }),

--- a/packages/trpc-server/src/routers/user-router.ts
+++ b/packages/trpc-server/src/routers/user-router.ts
@@ -1,4 +1,3 @@
-import { TRPCError } from '@trpc/server'
 import { z } from 'zod'
 import {
   selectPlaylistsCamel,
@@ -6,17 +5,14 @@ import {
   selectUsersCamel,
   sql
 } from '../db'
-import { AggregateUserRow, AggregateUserTipRow } from '../db-tables'
+import { AggregateUserTipRow } from '../db-tables'
 import { publicProcedure, router } from '../trpc'
 
 export const userRouter = router({
   get: publicProcedure.input(z.string()).query(async ({ ctx, input }) => {
     const user = await ctx.loaders.userLoader.load(parseInt(input))
     if (!user) {
-      throw new TRPCError({
-        code: 'NOT_FOUND',
-        message: `user ${input} not found`
-      })
+      return null;
     }
     return user
   }),

--- a/packages/trpc-server/test/router.test.ts
+++ b/packages/trpc-server/test/router.test.ts
@@ -15,6 +15,7 @@ test('get user', async () => {
   const caller = await testRouter(101)
 
   const steve = await caller.users.get('101')
+  if (!steve) throw new Error('steve not found')
   expect(steve.handle).toEqual('steve')
   expect(steve.trackCount).toEqual(2)
   expect(steve.playlistCount).toEqual(1)
@@ -22,6 +23,7 @@ test('get user', async () => {
   expect(steve.followingCount).toEqual(1)
 
   const dave = await caller.users.get('102')
+  if (!dave) throw new Error('dave not found')
   expect(dave.handle).toEqual('dave')
   expect(dave.followerCount).toEqual(1)
   expect(dave.followingCount).toEqual(0)
@@ -45,6 +47,7 @@ test('get user', async () => {
 test('get track', async () => {
   const caller = await testRouter(101)
   const t = await caller.tracks.get('201')
+  if (!t) throw new Error('track not found')
   expect(t.title).toEqual('Who let the dogs out')
 })
 
@@ -52,6 +55,7 @@ test("dave tries to get steve's private track", async () => {
   // TODO: this should probably 404...
   const daveRouter = await testRouter(201)
   const t = await daveRouter.tracks.get('202')
+  if (!t) throw new Error('track not found')
   expect(t.title).toEqual("Steve's unlisted dogs track")
   expect(t.isUnlisted).toEqual(true)
 })


### PR DESCRIPTION
### Description

Decided with @stereosteve that we can/should return `null` instead of throwing 404s here.
The 404 errors end up flooding the client logs, and there isn't a great place to put a handler since we're calling the trpc query hooks directly.

### How Has This Been Tested?

local trpc-server build and tests passing