### PR TITLE
[C-2190] Fix track player interruptions

### DIFF
--- a/packages/mobile/src/app/App.tsx
+++ b/packages/mobile/src/app/App.tsx
@@ -64,7 +64,7 @@ const App = () => {
   useEffectOnce(() => {
     setLibs(null)
     subscribeToNetworkStatusUpdates()
-    TrackPlayer.setupPlayer()
+    TrackPlayer.setupPlayer({ autoHandleInterruptions: true })
   })
 
   useEnterForeground(() => {


### PR DESCRIPTION
### Description

Fixes a long-standing issue where phone-calls/siri/google assistant interruptions wouldn't pause/play our media correctly. This was a limitation of react-native-track-player v3. Now that we have migrated to v4 to fix an android issue, we can apply this setting! Should result in much better experience for users 🥳 
