### PR TITLE
Fix ISO date format for dayjs

### DIFF
--- a/packages/discovery-provider/src/api/v1/helpers.py
+++ b/packages/discovery-provider/src/api/v1/helpers.py
@@ -931,7 +931,7 @@ def get_default_max(value, default, max=None):
 def format_aggregate_monthly_plays_for_user(aggregate_monthly_plays_for_user=[]):
     formatted_response_data = {}
     for aggregate_monthly_play in aggregate_monthly_plays_for_user:
-        month = aggregate_monthly_play["timestamp"].strftime("%Y-%m-%dT%H:%M:%S Z")
+        month = aggregate_monthly_play["timestamp"].strftime("%Y-%m-%dT%H:%M:%SZ")
         if month not in formatted_response_data:
             formatted_response_data[month] = {}
             formatted_response_by_month = formatted_response_data[month]

--- a/packages/discovery-provider/src/api/v1/users_unit_test.py
+++ b/packages/discovery-provider/src/api/v1/users_unit_test.py
@@ -31,29 +31,29 @@ def test_user_listen_counts_monthly_get_formats_correctly(
     mock_decoder, mock_success_response, mock_get_user_listen_counts_monthly
 ):
     expected_formatted_listen_counts = {
-        "2022-02-01T00:00:00 Z": {
+        "2022-02-01T00:00:00Z": {
             "totalListens": 18,
             "trackIds": [4, 5],
             "listenCounts": [
                 {
                     "trackId": 4,
-                    "date": "2022-02-01T00:00:00 Z",
+                    "date": "2022-02-01T00:00:00Z",
                     "listens": 10,
                 },
                 {
                     "trackId": 5,
-                    "date": "2022-02-01T00:00:00 Z",
+                    "date": "2022-02-01T00:00:00Z",
                     "listens": 8,
                 },
             ],
         },
-        "2022-01-01T00:00:00 Z": {
+        "2022-01-01T00:00:00Z": {
             "totalListens": 7,
             "trackIds": [1],
             "listenCounts": [
                 {
                     "trackId": 1,
-                    "date": "2022-01-01T00:00:00 Z",
+                    "date": "2022-01-01T00:00:00Z",
                     "listens": 7,
                 }
             ],

--- a/packages/discovery-provider/src/api_helpers.py
+++ b/packages/discovery-provider/src/api_helpers.py
@@ -29,7 +29,7 @@ class DateTimeEncoder(json.JSONEncoder):
     def default(self, o):  # pylint: disable=E0202
         if isinstance(o, (datetime.date, datetime.datetime)):
             # the Z is required in JS date format
-            return o.isoformat() + " Z"
+            return o.isoformat() + "Z"
         return json.JSONEncoder.default(self, o)
 
 

--- a/packages/discovery-provider/src/app.py
+++ b/packages/discovery-provider/src/app.py
@@ -215,7 +215,7 @@ def configure_flask(test_config, app, mode="app"):
         def default(self, o):
             if isinstance(o, datetime.datetime):
                 # ISO-8601 timestamp format
-                return o.strftime("%Y-%m-%dT%H:%M:%S Z")
+                return o.strftime("%Y-%m-%dT%H:%M:%SZ")
             return JSONEncoder.default(self, o)
 
     app.json_encoder = TimestampJSONEncoder


### PR DESCRIPTION
### Description
C-3629 Invalid date on collections.

https://github.com/AudiusProject/audius-protocol/blob/9ab8a1c3c8789892f2ecc281423f21008c8c1851/packages/web/src/components/collection/desktop/CollectionHeader.tsx#L152-L153

Here, when the response includes a date like `formatDate('2027-01-01T12:00:00 Z')` dayjs will fail to parse. `formatDate('2027-01-01T12:00:00Z')` or `formatDate('2027-01-01 12:00:00')` are acceptable. Interestingly, moment is able to parse `formatDate('2027-01-01T12:00:00 Z')` so the issue comes from removing moment from common here https://github.com/AudiusProject/audius-protocol/pull/.

Also note, that currently this bug manifests only when you go to a profile -> albums -> specific album because the albums page will hit `https://discoveryprovider2.staging.audius.co/playlists?limit=100&offset=0&user_id=957015831&with_users=true` which caches the flask TimestampJSONEncoder. If you reload, going through the v1 API would correct the date. Our API is still somewhat inconsistent for some reason but at least both of these forms are parse-able by dayjs `formatDate('2027-01-01T12:00:00Z')` or `formatDate('2027-01-01 12:00:00')`. Not sure where the latter is getting through atm. 


### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._

Ran this one line change in sandbox and staging. Confirmed tracks / playlists have correct dates.