### PR TITLE
[C-3638] Fix saga ci

### DIFF
--- a/packages/mobile/dapp-store/package.json
+++ b/packages/mobile/dapp-store/package.json
@@ -10,5 +10,6 @@
   "license": "ISC",
   "devDependencies": {
     "@solana-mobile/dapp-store-cli": "0.5.0"
-  }
+  },
+  "packageManager": "pnpm@8.14.1"
 }


### PR DESCRIPTION
### Description

Fixes issue where saga ci failed to install because pnpm was not specified in it's package.json. This is needed now that turbo repo specifies npm in root package.json

### How Has This Been Tested?

Was able to deploy last weeks saga with this change
