### PR TITLE
Openresty container

### DIFF
--- a/.circleci/src/workflows/discovery.yml
+++ b/.circleci/src/workflows/discovery.yml
@@ -8,6 +8,13 @@ jobs:
         branches:
           only: main
   - push-docker-image:
+      name: push-discovery-provider-openresty
+      context: [Vercel, dockerhub]
+      service: discovery-provider-openresty
+      filters:
+        branches:
+          only: main
+  - push-docker-image:
       name: push-discovery-provider-notifications
       context: [Vercel, dockerhub]
       service: discovery-provider-notifications
@@ -130,7 +137,7 @@ jobs:
           only: main
       requires:
         - push-pedalboard-trending-challenge-rewards
-    
+
   - push-arm-image:
       name: push-pedalboard-relay-arm
       context: [Vercel, dockerhub]
@@ -211,7 +218,6 @@ jobs:
       requires:
         - push-ddex
 
-
   # Deploy audius-protocol `main` branch (stage)
   - deploy-stage-nodes:
       name: deploy-stage-discovery-provider
@@ -220,6 +226,7 @@ jobs:
         - test-discovery-provider
         - test-discovery-provider-notifications
         - push-discovery-provider
+        - push-discovery-provider-openresty
         - push-discovery-provider-notifications
         - push-pedalboard-trending-challenge-rewards
         - push-pedalboard-relay

--- a/dev-tools/compose/docker-compose.discovery.dev.yml
+++ b/dev-tools/compose/docker-compose.discovery.dev.yml
@@ -21,6 +21,7 @@ services:
     extends:
       file: docker-compose.discovery.prod.yml
       service: es-indexer
+
   trpc:
     extends:
       file: docker-compose.discovery.prod.yml
@@ -30,6 +31,11 @@ services:
     extends:
       file: docker-compose.discovery.prod.yml
       service: discovery-provider-elasticsearch
+
+  discovery-provider-openresty:
+    extends:
+      file: docker-compose.discovery.prod.yml
+      service: discovery-provider-openresty
 
   discovery-provider:
     extends:

--- a/dev-tools/compose/docker-compose.discovery.prod.yml
+++ b/dev-tools/compose/docker-compose.discovery.prod.yml
@@ -39,6 +39,12 @@ services:
     profiles:
       - notifications
 
+  discovery-provider-openresty:
+    build:
+      context: ${PROJECT_ROOT}/packages/discovery-provider
+      dockerfile: Dockerfile.nginx
+    restart: unless-stopped
+
   comms:
     build:
       context: ${PROJECT_ROOT}/comms

--- a/dev-tools/compose/docker-compose.yml
+++ b/dev-tools/compose/docker-compose.yml
@@ -130,6 +130,12 @@ services:
       service: discovery-provider
     <<: *common
 
+  discovery-provider-openresty:
+    extends:
+      file: docker-compose.discovery.${DOCKERCOMPOSE_ENV_TYPE:-dev}.yml
+      service: discovery-provider-openresty
+    <<: *common
+
   comms:
     # Used for pushing to docker hub in CI
     extends:

--- a/packages/discovery-provider/Dockerfile.nginx
+++ b/packages/discovery-provider/Dockerfile.nginx
@@ -1,0 +1,46 @@
+FROM alpine:3.18
+
+ENV INSTALL_PATH /audius-discovery-provider
+WORKDIR $INSTALL_PATH
+
+ENV PROMETHEUS_MULTIPROC_DIR /prometheus_data
+RUN mkdir -p ${PROMETHEUS_MULTIPROC_DIR}
+
+# Add the wait script to the image
+# Script originally from https://github.com/ufoscout/docker-compose-wait/releases/download/2.4.0/wait
+COPY scripts/wait /wait
+
+RUN apk update && \
+  apk add --no-cache \
+  alpine-sdk \
+  bash \
+  curl \
+  docker \
+  libffi-dev \
+  libseccomp-dev \
+  libxml2-dev \
+  libxslt-dev \
+  linux-headers \
+  rsyslog \
+  sudo \
+  gcc \
+  python3 \
+  musl-dev
+
+
+RUN curl -O 'http://openresty.org/package/admin@openresty.com-5ea678a6.rsa.pub' && \
+  mv 'admin@openresty.com-5ea678a6.rsa.pub' /etc/apk/keys/ && \
+  echo "http://openresty.org/package/alpine/v3.15/main" | tee -a /etc/apk/repositories && \
+  apk update && \
+  apk add openresty=1.21.4.3-r0 openresty-opm && \
+  opm get spacewander/lua-resty-rsa && \
+  opm get ledgetech/lua-resty-http && \
+  opm get bsiara/dkjson && \
+  mkdir /usr/local/openresty/conf /usr/local/openresty/logs
+
+COPY nginx_conf /usr/local/openresty/conf/
+COPY scripts scripts/
+
+EXPOSE 5000
+
+CMD ["bash", "scripts/openresty.sh"]

--- a/packages/discovery-provider/nginx_conf/nginx_container.conf
+++ b/packages/discovery-provider/nginx_conf/nginx_container.conf
@@ -1,0 +1,390 @@
+# This config rate limits and redirect requests that exceed the rate limit to other discovery providers.
+
+# The requests are rate limited by only allowing config.limit_to_rps requests every second to the discovery node; requests are redirected to other discovery nodes following this.
+
+# To avoid infinite redirection, we set redirect_nonce, redirect_sig, and redirect_from when redirecting; the discovery provider receiving the redirect verifies this signature. We have a nonce to avoid an attacker from being able to get a valid redirect_sig since that could be used to focus a DDoS attack on a single node.
+
+worker_processes 1;
+
+error_log logs/error.log notice;
+
+env audius_openresty_accept_redirect_from;
+env audius_discprov_url;
+env audius_openresty_rps;
+env audius_openresty_redirect_targets;
+env audius_openresty_rsa_private_key;
+env audius_openresty_rsa_public_key;
+env REGISTERED_PLUGINS;
+
+events {
+    worker_connections 4096;
+}
+
+http {
+    # set dns nginx should use for resolving external domains
+    resolver 1.1.1.1;
+
+    # set lua_socket_keepalive_timeout to 3 mins to fix problems when fetching redirect_weights
+    lua_socket_keepalive_timeout 180s;
+
+    proxy_cache_path /usr/local/openresty/cache levels=1:2 keys_zone=cache:10m max_size=1g inactive=1m use_temp_path=off;
+
+    proxy_read_timeout 600; # 10 mins in seconds
+
+    lua_package_path "/usr/local/openresty/conf/?.lua;;";
+
+    lua_shared_dict limit_count_store 100m;
+    lua_shared_dict locks 12k;
+    lua_shared_dict nonce_store 10m;
+    lua_shared_dict request_count 10m;
+    lua_shared_dict rsa_public_key_store 10m;
+    log_format custom_format '{"remote_addr":"$remote_addr",'
+                            '"time_local":"$time_local",'
+                            '"request":"$request",'
+                            '"status":$status,'
+                            '"body_bytes_sent":$body_bytes_sent,'
+                            '"http_referer":"$http_referer",'
+                            '"http_user_agent":"$http_user_agent",'
+                            '"request_time":$request_time}';
+
+    init_worker_by_lua_block {
+        local main = require "main"
+        main.start_update_redirect_weights_timer()
+    }
+
+    server {
+        listen 5000;
+        gzip on;
+        gzip_types text/plain application/xml application/json;
+        access_log /usr/local/openresty/logs/access.log custom_format;
+
+        proxy_set_header Host $http_host;
+        proxy_set_header X-Forwarded-For $remote_addr;
+
+        location = /openresty_pubkey {
+            content_by_lua_block {
+                local config = require "config"
+                ngx.say(config.rsa_public_key)
+            }
+        }
+
+        location = /request_count {
+            content_by_lua_block {
+                local count = ngx.shared.request_count:get("request-count")
+                if count == nil then
+                    ngx.say(0)
+                else
+                    ngx.say(count)
+                end
+            }
+        }
+
+        location /v1/metrics {
+            resolver 127.0.0.11 valid=30s;
+            set $upstream server:3000;
+            proxy_pass http://$upstream;
+            proxy_set_header Host $http_host;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        }
+
+        # $upstream references the audius-docker-compose network'd containers
+        location /prometheus/postgres {
+            resolver 127.0.0.11 valid=30s;
+            set $upstream exporter_postgres:9187;
+            proxy_pass http://$upstream/metrics;
+            proxy_set_header Host $http_host;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        }
+
+        location /prometheus/postgres/read-replica {
+            resolver 127.0.0.11 valid=30s;
+            set $upstream exporter_postgres_read_replica:9187;
+            proxy_pass http://$upstream/metrics;
+            proxy_set_header Host $http_host;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        }
+
+        location /prometheus/redis {
+            resolver 127.0.0.11 valid=30s;
+            set $upstream exporter_redis:9121;
+            proxy_pass http://$upstream/metrics;
+            proxy_set_header Host $http_host;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        }
+
+        location /prometheus/docker {
+            resolver 127.0.0.11 valid=30s;
+            set $upstream exporter_docker:9104;
+            proxy_pass http://$upstream/metrics;
+            proxy_set_header Host $http_host;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        }
+
+        location /v1/tracks/unclaimed_id {
+            access_by_lua_block {
+                local main = require "main"
+                main.mark_request_processing()
+                return main.limit_to_rps()
+            }
+
+            log_by_lua_block {
+                local main = require "main"
+                main.mark_request_processed()
+            }
+
+            resolver 127.0.0.11 valid=30s;
+            set $upstream server:3000;
+            proxy_pass http://$upstream;
+            proxy_set_header Host $http_host;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            add_header Cache-Control no-cache;
+        }
+
+        location /v1/playlists/unclaimed_id {
+            access_by_lua_block {
+                local main = require "main"
+                main.mark_request_processing()
+                return main.limit_to_rps()
+            }
+
+            log_by_lua_block {
+                local main = require "main"
+                main.mark_request_processed()
+            }
+
+            resolver 127.0.0.11 valid=30s;
+            set $upstream server:3000;
+            proxy_pass http://$upstream;
+            proxy_set_header Host $http_host;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            add_header Cache-Control no-cache;
+        }
+
+        location /v1/users/unclaimed_id {
+            access_by_lua_block {
+                local main = require "main"
+                main.mark_request_processing()
+                return main.limit_to_rps()
+            }
+
+            log_by_lua_block {
+                local main = require "main"
+                main.mark_request_processed()
+            }
+
+            resolver 127.0.0.11 valid=30s;
+            set $upstream server:3000;
+            proxy_pass http://$upstream;
+            proxy_set_header Host $http_host;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            add_header Cache-Control no-cache;
+        }
+
+        # Do not redirect any /v1/challenges/... requests, which need to resolve
+        # to the node that the request was intended for. Selection of
+        # nodes to respond to challenge attestations is intentional.
+        location /v1/challenges {
+            resolver 127.0.0.11 valid=30s;
+            set $upstream server:3000;
+            proxy_pass http://$upstream;
+            proxy_set_header Host $http_host;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        }
+
+        location ~* .*/trending/.* {
+            access_by_lua_block {
+                local main = require "main"
+                main.mark_request_processing()
+                return main.limit_to_rps()
+            }
+
+            log_by_lua_block {
+                local main = require "main"
+                main.mark_request_processed()
+            }
+
+            # Don't use cache if user_id or X-User-ID is set
+            proxy_cache_bypass $arg_user_id$http_x_user_id;
+            proxy_no_cache $arg_user_id$http_x_user_id;
+
+            proxy_cache_valid any 5m;
+            proxy_cache cache;
+            proxy_cache_revalidate on;
+            proxy_cache_min_uses 1;
+            proxy_cache_lock on;
+
+            resolver 127.0.0.11 valid=30s;
+            set $upstream server:3000;
+            proxy_pass http://$upstream;
+        }
+
+        location ~* .*/search/.* {
+            access_by_lua_block {
+                local main = require "main"
+                main.mark_request_processing()
+                return main.limit_to_rps()
+            }
+
+            log_by_lua_block {
+                local main = require "main"
+                main.mark_request_processed()
+            }
+
+            # Don't use cache if user_id or X-User-ID is set
+            proxy_cache_bypass $arg_user_id$http_x_user_id;
+            proxy_no_cache $arg_user_id$http_x_user_id;
+
+            proxy_cache_valid any 60s;
+            proxy_cache cache;
+            proxy_cache_revalidate on;
+            proxy_cache_min_uses 1;
+            proxy_cache_lock on;
+
+            resolver 127.0.0.11 valid=30s;
+            set $upstream server:3000;
+            proxy_pass http://$upstream;
+        }
+
+        location /v1 {
+            access_by_lua_block {
+                local main = require "main"
+                main.mark_request_processing()
+                return main.limit_to_rps()
+            }
+
+            log_by_lua_block {
+                local main = require "main"
+                main.mark_request_processed()
+            }
+
+            proxy_cache_valid any 1s;
+            proxy_cache cache;
+            proxy_cache_revalidate on;
+            proxy_cache_min_uses 1;
+            proxy_cache_lock on;
+
+            resolver 127.0.0.11 valid=30s;
+            set $upstream server:3000;
+            proxy_pass http://$upstream;
+            proxy_set_header Host $http_host;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        }
+
+        location /sitemaps/ {
+            proxy_cache cache;
+            proxy_cache_use_stale updating;
+            proxy_cache_background_update on;
+
+            resolver 127.0.0.11 valid=30s;
+            set $upstream server:3000;
+            proxy_pass http://$upstream;
+            proxy_set_header Host $http_host;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        }
+
+        location /comms {
+            client_max_body_size 500M;
+            resolver 127.0.0.11 valid=30s;
+            set $upstream comms:8925;
+            proxy_pass http://$upstream;
+            proxy_set_header Host $http_host;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            # for websockets:
+            proxy_http_version 1.1;
+            proxy_set_header Upgrade $http_upgrade;
+            proxy_set_header Connection "upgrade";
+        }
+
+        location /d {
+            resolver 127.0.0.11 valid=30s;
+            set $upstream uptime:1996;
+            proxy_pass http://$upstream;
+            proxy_set_header Host $http_host;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        }
+
+        location /trpc/ {
+            resolver 127.0.0.11 valid=30s;
+            proxy_pass http://trpc:2022/;
+            proxy_set_header Host $http_host;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        }
+
+        location ^~ /healthz {
+            resolver 127.0.0.11 valid=30s;
+            proxy_pass http://healthz;
+            proxy_set_header Host $http_host;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        }
+
+        location ~ ^/relay(/.*)?$ {
+            resolver 127.0.0.11 valid=30s;
+            proxy_pass http://relay:6001/relay$1;
+            proxy_set_header Host $http_host;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        }
+
+        location ~ ^/solana(/.*)?$ {
+            resolver 127.0.0.11 valid=30s;
+            proxy_pass http://solana-relay:6002/solana$1;
+            proxy_set_header Host $http_host;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        }
+
+
+        location ~* ^/(nethermind|chain)/peer {
+            add_header 'Access-Control-Allow-Origin' '*';
+            add_header 'Access-Control-Allow-Methods' '*';
+            resolver 127.0.0.11 valid=30s;
+            content_by_lua_block {
+                local port = require "port"
+                local ip = port.get_public_ip()
+                local can_connect = port.get_is_port_exposed(ip, 30300)
+                if can_connect then
+                    ngx.status = ngx.HTTP_OK
+                else
+                    ngx.status = ngx.HTTP_INTERNAL_SERVER_ERROR
+                end
+                ngx.say(can_connect)
+            }
+        }
+
+        location ~* ^/(nethermind|chain) {
+            access_by_lua_block {
+                local main = require "main"
+                return main.validate_nethermind_rpc_request()
+            }
+
+            resolver 127.0.0.11 valid=30s;
+            set $upstream chain:8545;
+            proxy_pass http://$upstream/;
+            proxy_set_header Host $http_host;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        }
+
+        location = /plugins {
+            add_header 'Access-Control-Allow-Origin' '*';
+            add_header 'Access-Control-Allow-Methods' '*';
+            content_by_lua_block {
+                local plugins = require "plugins"
+                local json = plugins.get_health_check()
+                ngx.say(json)
+            }
+        }
+
+        location ~ ^/plugins/(?<upstream>\w+)/(.*)$ {
+            resolver 127.0.0.11 valid=30s;
+            proxy_pass http://$upstream:6000/$2;
+            proxy_set_header Host $http_host;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        }
+
+        location / {
+            resolver 127.0.0.11 valid=30s;
+            set $upstream server:3000;
+            proxy_pass http://$upstream;
+            proxy_set_header Host $http_host;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        }
+    }
+}

--- a/packages/discovery-provider/scripts/openresty.sh
+++ b/packages/discovery-provider/scripts/openresty.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+set -e
+
+openresty -p /usr/local/openresty -c /usr/local/openresty/conf/nginx_container.conf
+  tail -f /usr/local/openresty/logs/error.log | python3 scripts/openresty_log_convertor.py ERROR &
+  tail -f /usr/local/openresty/logs/access.log


### PR DESCRIPTION
### Description

`nginx_container.conf` is a copy of `nginx.confg` that will resolve container names instead of using `127.0.0.1:3000`.  This is to allow a short transition period.  After `audius-docker-compose` is updated to use the built openresty container, `nginx.conf` can be removed (along with corresponding entry point stuff in `start.sh`)

### How Has This Been Tested?

Manual build and push:

```
DOCKER_DEFAULT_PLATFORM=linux/amd64  docker build . -f Dockerfile.nginx -t audius/discovery-provider-openresty:v0 && \
docker push audius/discovery-provider-openresty:v0
```

Docker compose entry like:

```
  openresty:
    image: audius/discovery-provider-openresty:v0
    container_name: openresty
    <<: *extra-hosts
    restart: unless-stopped
    env_file:
      - ${OVERRIDE_PATH:-override.env}
    networks:
      - discovery-provider-network
    ports:
      - "5123:5000"
```

Pull + restart:

```
docker compose pull openresty && docker compose up -d && docker logs -f openresty
```