### PR TITLE
[C-3149 C-3122 C-3051 C-3625 C-3481] Fix add track to playlist

### DIFF
--- a/packages/web/src/pages/collection-page/CollectionPageProvider.tsx
+++ b/packages/web/src/pages/collection-page/CollectionPageProvider.tsx
@@ -805,9 +805,8 @@ function makeMapStateToProps() {
   const getCurrentQueueItem = makeGetCurrent()
 
   const mapStateToProps = (state: AppState) => {
-    const theTracks = getTracksLineup(state)
     return {
-      tracks: theTracks,
+      tracks: getTracksLineup(state),
       trackCount: (getCollection(state) as Collection)?.playlist_contents
         .track_ids.length,
       collectionUid: getCollectionUid(state) || '',

--- a/packages/web/src/pages/collection-page/CollectionPageProvider.tsx
+++ b/packages/web/src/pages/collection-page/CollectionPageProvider.tsx
@@ -307,12 +307,11 @@ class CollectionPage extends Component<
       }
     }
 
-    // check if a track has been added to collection
-    if (
-      metadata &&
-      prevMetadata &&
-      metadata.track_count > prevMetadata.track_count
-    ) {
+    const currentTrackCount = this.props.trackCount
+    const previousTrackCount = prevProps.trackCount
+
+    // Refetch tracks if a track has been added to collection
+    if (currentTrackCount > previousTrackCount) {
       this.props.fetchTracks()
     }
 
@@ -806,8 +805,11 @@ function makeMapStateToProps() {
   const getCurrentQueueItem = makeGetCurrent()
 
   const mapStateToProps = (state: AppState) => {
+    const theTracks = getTracksLineup(state)
     return {
-      tracks: getTracksLineup(state),
+      tracks: theTracks,
+      trackCount: (getCollection(state) as Collection)?.playlist_contents
+        .track_ids.length,
       collectionUid: getCollectionUid(state) || '',
       collection: getCollection(state) as Collection,
       collectionPermalink: getCollectionPermalink(state),


### PR DESCRIPTION
### Description

Fixes issues where addTrackToPlaylist from suggested tracks and drag-n-drop did not add track to collection lineup. This was due to issues with "shouldComponentUpdate" not recognizing differences in the metadata object, most likely because it's a deeply nested object.
