### PR TITLE
[C-3639] Fix empty album tab state

### DIFF
--- a/packages/web/src/pages/profile-page/components/desktop/ProfilePage.tsx
+++ b/packages/web/src/pages/profile-page/components/desktop/ProfilePage.tsx
@@ -310,7 +310,7 @@ const ProfilePage = ({
         }}
       />
     ))
-    if (isOwner && isEditAlbumsEnabled) {
+    if (isOwner) {
       albumCards.unshift(
         <UploadChip
           key='upload-chip'

--- a/packages/web/src/pages/profile-page/components/desktop/ProfilePage.tsx
+++ b/packages/web/src/pages/profile-page/components/desktop/ProfilePage.tsx
@@ -14,8 +14,7 @@ import {
   profilePageFeedLineupActions as feedActions,
   badgeTiers,
   useSelectTierInfo,
-  CreatePlaylistSource,
-  FeatureFlags
+  CreatePlaylistSource
 } from '@audius/common'
 
 import IconAlbum from 'assets/img/iconAlbum.svg'
@@ -35,7 +34,6 @@ import ConnectedProfileCompletionHeroCard from 'components/profile-progress/Conn
 import { ProfileMode, StatBanner } from 'components/stat-banner/StatBanner'
 import { StatProps } from 'components/stats/Stats'
 import UploadChip from 'components/upload/UploadChip'
-import { useFlag } from 'hooks/useRemoteConfig'
 import useTabs, { TabHeader, useTabRecalculator } from 'hooks/useTabs/useTabs'
 import { BlockUserConfirmationModal } from 'pages/chat-page/components/BlockUserConfirmationModal'
 import { UnblockUserConfirmationModal } from 'pages/chat-page/components/UnblockUserConfirmationModal'
@@ -240,7 +238,6 @@ const ProfilePage = ({
   setNotificationSubscription,
   didChangeTabsFrom
 }: ProfilePageProps) => {
-  const { isEnabled: isEditAlbumsEnabled } = useFlag(FeatureFlags.EDIT_ALBUMS)
   const renderProfileCompletionCard = () => {
     return isOwner ? <ConnectedProfileCompletionHeroCard /> : null
   }


### PR DESCRIPTION
### Description

Own profile was showing empty state with no cards and no message. Rolling forward to display the new upload chip component that will create an album on click.

![Screenshot 2024-01-17 at 2 21 14 PM](https://github.com/AudiusProject/audius-protocol/assets/2358254/fb8abbd4-62e3-497d-addd-5fa5b924a2d9)

### How Has This Been Tested?

local web