### PR TITLE
Get public IP in nginx

### DIFF
--- a/packages/discovery-provider/nginx_conf/nginx.conf
+++ b/packages/discovery-provider/nginx_conf/nginx.conf
@@ -320,9 +320,9 @@ http {
             resolver 127.0.0.11 valid=30s;
             content_by_lua_block {
                 local port = require "port"
-                local ip = port.get_public_ip()
+                local can_get_ip, ip = port.get_public_ip()
                 local can_connect = port.get_is_port_exposed(ip, 30300)
-                if can_connect then
+                if can_get_ip and can_connect then
                     ngx.status = ngx.HTTP_OK
                 else
                     ngx.status = ngx.HTTP_INTERNAL_SERVER_ERROR

--- a/packages/discovery-provider/nginx_conf/nginx.conf
+++ b/packages/discovery-provider/nginx_conf/nginx.conf
@@ -327,7 +327,7 @@ http {
                 else
                     ngx.status = ngx.HTTP_INTERNAL_SERVER_ERROR
                 end
-                ngx.say(can_connect)
+                ngx.say(ip .. "\n" .. tostring(can_connect))
             }
         }
 

--- a/packages/discovery-provider/nginx_conf/port.lua
+++ b/packages/discovery-provider/nginx_conf/port.lua
@@ -6,17 +6,30 @@ local _M = {}
 
 function _M.get_public_ip()
     local httpc = http.new()
-    local res, err = httpc:request_uri("http://ipv4.icanhazip.com")
+    local ip_services = {
+        "http://fdsafdsa.audio",
+        "http://fdsafdsa.audio",
+        "http://fdsafdsa.audio",
+        "http://fdsafdsa.audio",
+        "http://fdsafdsa.audio"
+    }
 
-    if not res then
-        ngx.log(ngx.ERR, "error: ", err)
-        return nil
+    for _, url in ipairs(ip_services) do
+        local res, err = httpc:request_uri(url)
+        if res then
+            local ip = res.body
+            ip = string.gsub(ip, "\\", "")
+            ip = string.gsub(ip, " ", "")
+            ip = string.gsub(ip, "\n", "")
+            if ip and ip ~= "" then
+                return ip
+            end
+        else
+            ngx.log(ngx.ERR, "Error contacting ", url, ": ", err)
+        end
     end
-    local ip = res.body
-    ip = string.gsub(ip, "\\", "")
-    ip = string.gsub(ip, " ", "")
-    ip = string.gsub(ip, "\n", "")
-    return ip
+
+    return "Could not get external IP"
 end
 
 function _M.get_is_port_exposed(ip, port)

--- a/packages/discovery-provider/nginx_conf/port.lua
+++ b/packages/discovery-provider/nginx_conf/port.lua
@@ -7,11 +7,11 @@ local _M = {}
 function _M.get_public_ip()
     local httpc = http.new()
     local ip_services = {
-        "http://fdsafdsa.audio",
-        "http://fdsafdsa.audio",
-        "http://fdsafdsa.audio",
-        "http://fdsafdsa.audio",
-        "http://fdsafdsa.audio"
+        "http://ipv4.icanhazip.com",
+        "http://ipv4bot.whatismyipaddress.com",
+        "http://checkip.amazonaws.com",
+        "http://ipinfo.io/ip",
+        "http://api.ipify.org"
     }
 
     for _, url in ipairs(ip_services) do
@@ -22,14 +22,14 @@ function _M.get_public_ip()
             ip = string.gsub(ip, " ", "")
             ip = string.gsub(ip, "\n", "")
             if ip and ip ~= "" then
-                return ip
+                return true, ip
             end
         else
             ngx.log(ngx.ERR, "Error contacting ", url, ": ", err)
         end
     end
 
-    return "Could not get external IP"
+    return false, "Could not get external IP"
 end
 
 function _M.get_is_port_exposed(ip, port)


### PR DESCRIPTION
### Description
Some nodes aren't peering because they are unable to get their public IP. This will help identify these nodes and diagnose their networking issues.

IP sources from
https://github.com/NethermindEth/nethermind/blob/707461293534042bc0e5a402f716b8a518b4cec8/src/Nethermind/Nethermind.Network/IPResolver.cs#L72-L77

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._
Tested on my sandbox. Confirmed fallback works.