### PR TITLE
[C-3677] Fix onclick for upload a track chip

### DIFF
--- a/packages/web/src/components/upload/UploadChip.tsx
+++ b/packages/web/src/components/upload/UploadChip.tsx
@@ -146,7 +146,9 @@ const UploadChip = ({
   )
 
   return !isEditAlbumsEnabled || type === 'track' ? (
-    renderTile({ onClick: handleCreateCollection })
+    renderTile({
+      onClick: type === 'track' ? handleClickUpload : handleCreateCollection
+    })
   ) : (
     <PopupMenu
       items={items}


### PR DESCRIPTION
### Description

Broke the onclick on the recent refactor of UploadChip. Track was wrongly calling the create collection handler.

### How Has This Been Tested?

now it opens the upload page