### PR TITLE
[PAY-2363] Re-add downloads when lossless downloads flag disabled

### DIFF
--- a/packages/web/src/components/track/GiantTrackTile.tsx
+++ b/packages/web/src/components/track/GiantTrackTile.tsx
@@ -61,6 +61,7 @@ import styles from './GiantTrackTile.module.css'
 import { GiantTrackTileProgressInfo } from './GiantTrackTileProgressInfo'
 import InfoLabel from './InfoLabel'
 import { PlayPauseButton } from './PlayPauseButton'
+import DownloadButtons from 'components/download-buttons/DownloadButtons'
 
 const { requestOpen: openPublishTrackConfirmationModal } =
   publishTrackConfirmationModalUIActions
@@ -503,9 +504,23 @@ export const GiantTrackTile = ({
       </>
     )
   }
+
   const renderScheduledReleaseRow = () => {
     return (
       <ScheduledReleaseGiantLabel released={released} isUnlisted={isUnlisted} />
+    )
+  }
+
+  const renderDownloadButtons = () => {
+    return (
+      <DownloadButtons
+        className={styles.downloadButtonsContainer}
+        trackId={trackId}
+        isOwner={isOwner}
+        following={following}
+        hasDownloadAccess={hasDownloadAccess}
+        onDownload={onDownload}
+      />
     )
   }
 
@@ -715,6 +730,7 @@ export const GiantTrackTile = ({
           </UserGeneratedText>
         ) : null}
         {renderTags()}
+        {!isLosslessDownloadsEnabled ? renderDownloadButtons() : null}
         {isLosslessDownloadsEnabled && hasDownloadableAssets ? (
           <Box pt='l' w='100%'>
             <DownloadSection trackId={trackId} onDownload={onDownload} />

--- a/packages/web/src/components/track/GiantTrackTile.tsx
+++ b/packages/web/src/components/track/GiantTrackTile.tsx
@@ -683,10 +683,7 @@ export const GiantTrackTile = ({
         </div>
       </div>
 
-      {isStreamGated &&
-      streamConditions &&
-      isLosslessDownloadsEnabled &&
-      !hasDownloadableAssets ? (
+      {isStreamGated && streamConditions ? (
         <GatedTrackSection
           isLoading={isLoading}
           trackId={trackId}


### PR DESCRIPTION
### Description
Accidentally deleted these instead of keeping them around before we enable the lossless ff.

### How Has This Been Tested?

Local web stage.
<img width="1105" alt="Screenshot 2024-01-18 at 4 49 53 PM" src="https://github.com/AudiusProject/audius-protocol/assets/3893871/ccd2aa0e-d8a0-4f9f-89c8-548a775b0b05">

