### PR TITLE
[C-3678, C-3657] Fix android radial-gradient bug, Fix sign-up panel top border-radius

### DIFF
--- a/packages/mobile/src/harmony-native/components/RadialGradient/RadialGradient.tsx
+++ b/packages/mobile/src/harmony-native/components/RadialGradient/RadialGradient.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react'
 
 import { css } from '@emotion/native'
-import { View } from 'react-native'
+import { Platform, View } from 'react-native'
 import type { RadialGradientProps } from 'react-native-radial-gradient'
 import RNRadialGradient from 'react-native-radial-gradient'
 
@@ -10,20 +10,31 @@ const fullSize = css({ height: '100%', width: '100%' })
 // RadialGradient that uses percentages instead of pixels for center and radius
 // This makes RadialGradient much more useful and dynamic
 export const RadialGradient = (props: RadialGradientProps) => {
-  const { center: centerProp, radius: radiusProp, style, ...other } = props
+  const {
+    center: centerProp = [50, 50],
+    radius: radiusProp,
+    style,
+    ...other
+  } = props
   const [{ height, width }, setDimensions] = useState({
     height: 0,
     width: 0
   })
 
-  // Note using x,y coordinates because it allows dynamic updates
-  // This technically works even though the types don't allow it
-  const center = centerProp
-    ? ({
-        x: (centerProp[0] * width) / 100,
-        y: (centerProp[1] * height) / 100
-      } as unknown as RadialGradientProps['center'])
+  let center = centerProp
+    ? [(centerProp[0] * width) / 100, (centerProp[1] * height) / 100]
     : undefined
+
+  // We update the center prop to use x,y coordinates on iOS due to
+  // bug where center prop cannot be updated on iOS
+  if (Platform.OS === 'ios') {
+    center = center
+      ? ({
+          x: center[0],
+          y: center[1]
+        } as unknown as RadialGradientProps['center'])
+      : undefined
+  }
 
   // Since we cant have ellipse gradients, we use the average of height and width
   const radius = radiusProp

--- a/packages/mobile/src/screens/sign-on-screen/screens/SignOnScreen.tsx
+++ b/packages/mobile/src/screens/sign-on-screen/screens/SignOnScreen.tsx
@@ -3,7 +3,7 @@ import { useState } from 'react'
 
 import { css } from '@emotion/native'
 import { Dimensions, ImageBackground, SafeAreaView } from 'react-native'
-import RadialGradient from 'react-native-radial-gradient'
+import RadialGradientOld from 'react-native-radial-gradient'
 import Animated, {
   CurvedTransition,
   FadeIn,
@@ -18,8 +18,10 @@ import {
   Flex,
   IconAudiusLogoHorizontalColor,
   Paper,
+  RadialGradient,
   Text,
-  TextLink
+  TextLink,
+  useTheme
 } from '@audius/harmony-native'
 import DJBackground from 'app/assets/images/DJportrait.jpg'
 
@@ -80,21 +82,14 @@ const Background = () => {
       })}
     >
       <RadialGradient
-        style={css({
-          // NOTE: Width/Height styles are mandatory for gradient to work. Otherwise it will crash the whole app 🫠
-          width: '100%',
-          height: '100%',
-          position: 'absolute',
-          bottom: 0,
-          zIndex: 2
-        })}
+        style={css({ position: 'absolute', zIndex: 1 })}
         colors={[
           'rgba(91, 35, 225, 0.8)',
           'rgba(113, 41, 230, 0.64)',
           'rgba(162, 47, 235, 0.5)'
         ]}
-        stops={[0.1, 0.67, 1]}
-        radius={Dimensions.get('window').width / 1.2}
+        stops={[0, 0.67, 1]}
+        radius={100}
       />
       <ImageBackground
         source={DJBackground}
@@ -117,12 +112,17 @@ type ExpandablePanelProps = {
 const ExpandablePanel = (props: ExpandablePanelProps) => {
   const { children } = props
   const insets = useSafeAreaInsets()
+  const { cornerRadius } = useTheme()
   return (
     <AnimatedPaper
       entering={SlideInUp.duration(PANEL_EXPAND_DURATION)}
       layout={CurvedTransition}
-      borderRadius='3xl'
-      style={css({ overflow: 'hidden', paddingTop: insets.top })}
+      style={css({
+        overflow: 'hidden',
+        paddingTop: insets.top,
+        borderBottomLeftRadius: cornerRadius['3xl'],
+        borderBottomRightRadius: cornerRadius['3xl']
+      })}
     >
       <Flex gap='2xl' ph='l' pv='2xl'>
         {children}
@@ -152,7 +152,7 @@ export const SignOnScreen = (props: SignOnScreenProps) => {
     <>
       <Background />
       {isSplashScreenDismissed ? (
-        <Flex flex={1} style={css({ flexGrow: 1 })} h='100%'>
+        <Flex flex={1} style={css({ flexGrow: 1, zIndex: 2 })} h='100%'>
           <ExpandablePanel>
             <IconAudiusLogoHorizontalColor
               style={css({ alignSelf: 'center' })}

--- a/packages/mobile/src/screens/sign-on-screen/screens/SignOnScreen.tsx
+++ b/packages/mobile/src/screens/sign-on-screen/screens/SignOnScreen.tsx
@@ -2,8 +2,7 @@ import type { ReactNode } from 'react'
 import { useState } from 'react'
 
 import { css } from '@emotion/native'
-import { Dimensions, ImageBackground, SafeAreaView } from 'react-native'
-import RadialGradientOld from 'react-native-radial-gradient'
+import { ImageBackground, SafeAreaView } from 'react-native'
 import Animated, {
   CurvedTransition,
   FadeIn,


### PR DESCRIPTION
### Description

- Fixes issue where new radial-gradient is incompatible with android. required updating the "center" prop for ios and android differently.
- Fixes issue with sign-up expandible panel's border radius was incompatible with devices with no top screen radius
- Fixes issue with zIndexes on android