### PR TITLE
[C-3633] Fix upload tags

### DIFF
--- a/packages/web/src/common/store/upload/sagas.js
+++ b/packages/web/src/common/store/upload/sagas.js
@@ -80,19 +80,9 @@ const combineMetadata = (trackMetadata, collectionMetadata) => {
   if (!metadata.release_date)
     metadata.release_date = collectionMetadata.release_date
 
-  if (collectionMetadata.tags) {
-    if (!metadata.tags) {
-      // Take collection tags
-      metadata.tags = collectionMetadata.tags
-    } else {
-      // Combine tags and dedupe
-      metadata.tags = [
-        ...new Set([
-          ...metadata.tags.split(','),
-          ...collectionMetadata.tags.split(',')
-        ])
-      ].join(',')
-    }
+  if (metadata.tags === null && collectionMetadata.tags) {
+    // Take collection tags
+    metadata.tags = collectionMetadata.tags
   }
   return trackMetadata
 }


### PR DESCRIPTION
### Description

Fixes issue where album tags were incorrectly merging with track override tabs, leading to cases where tracks can have more than 10 tags.

Note we are checking that the track tags are explicitly null, ie not overridden, there is a world where user clears all ablum tags from the track, which we should preserve
