### PR TITLE
Remove scheduled release filter from sitemaps

### DIFF
--- a/packages/discovery-provider/src/queries/get_sitemap.py
+++ b/packages/discovery-provider/src/queries/get_sitemap.py
@@ -111,7 +111,6 @@ def get_max_track_count(session: Session) -> int:
             Track.is_current == True,
             Track.stem_of == None,
             Track.is_unlisted == False,
-            Track.is_scheduled_release == False,
             Track.is_available == True,
             User.is_current == True,
             TrackRoute.is_current == True,
@@ -204,7 +203,6 @@ def get_track_slugs(session: Session, limit: int, offset: int):
             Track.stem_of == None,
             Track.is_available == True,
             Track.is_unlisted == False,
-            Track.is_scheduled_release == False,
             User.is_current == True,
             TrackRoute.is_current == True,
         )


### PR DESCRIPTION
### Description
is_scheduled_release is still true after publishing. Publishing just flips is_unlisted from true to false. This is so we can easily see which tracks were scheduled releases, before and after publishing. 

https://github.com/AudiusProject/audius-protocol/blob/08b678bcc50c877bfe1fc48f8edebcd92126e464/packages/discovery-provider/src/tasks/publish_scheduled_releases.py#L32

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._
