### PR TITLE
Add auto upgrade logs to vector

### DIFF
--- a/monitoring/vector/vector.toml
+++ b/monitoring/vector/vector.toml
@@ -24,6 +24,10 @@
     "postgres", # Temporary to stop spam from one SP. TODO: Move back to include_containers
   ]
 
+[sources.auto_upgrade]
+  type = "file"
+  include = ["/auto-upgrade.log"]
+
 [transforms.parse]
   type = "remap"
   inputs = ["logs"]
@@ -47,9 +51,16 @@
     del(.otelTraceID)
   '''
 
+[transforms.parse_auto_upgrade]
+  type = "remap"
+  inputs = ["auto_upgrade"]
+  source = '''
+    .node = "$node"
+  '''
+
 [transforms.throttle]
   type = "throttle"
-  inputs = ["parse"]
+  inputs = ["parse", "parse_auto_upgrade"]
   # throttle ~3mm logs per node per 24 hour period (2000 * 60 * 24)
   # 3mm is at the upper range of average node log volume at this current time
   key_field = "node"   
@@ -63,7 +74,7 @@
 #   encoding.codec = "json"
 
 [sinks.axiom]
-  inputs = [ "parse" ]
+  inputs = [ "parse", "parse_auto_upgrade" ]
   type = "axiom"
   token = "$audius_axiom_token"
   dataset = "$audius_axiom_dataset"

--- a/monitoring/vector/vector.toml
+++ b/monitoring/vector/vector.toml
@@ -27,6 +27,7 @@
 [sources.auto_upgrade]
   type = "file"
   include = ["/auto-upgrade.log"]
+  ignore_checkpoints = true
 
 [transforms.parse]
   type = "remap"


### PR DESCRIPTION
### Description
Add auto upgrade logs as a source for vector so we can observe in axiom.

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._

Tested on sandbox.
This is what it looks like
https://app.axiom.co/audius-Lu52/stream/discovery?caseSensitive=0&ig=&q=%7B%22children%22%3A%5B%7B%22field%22%3A%22file%22%2C%22op%22%3A%22%3D%3D%22%2C%22value%22%3A%22%2Fauto-upgrade.log%22%7D%5D%2C%22field%22%3A%22%22%2C%22op%22%3A%22and%22%7D&qr=1h&rowId=0cyiz2fp7ko7t-06e54b55390043e4-2d1f