### PR TITLE
Re-add download buttons to mobile track page

### DIFF
--- a/packages/mobile/src/components/details-tile/DetailsTile.tsx
+++ b/packages/mobile/src/components/details-tile/DetailsTile.tsx
@@ -230,12 +230,9 @@ export const DetailsTile = ({
     track?.is_scheduled_release && track?.is_unlisted
   const showPreviewButton =
     isUSDCPurchaseGated && (isOwner || !hasStreamAccess) && onPressPreview
-  const isLosslessDownloadsEnabled = useFeatureFlag(
+  const { isEnabled: isLosslessDownloadsEnabled } = useFeatureFlag(
     FeatureFlags.LOSSLESS_DOWNLOADS_ENABLED
   )
-  const hasDownloadableAssets =
-    (track as Track).is_downloadable ||
-    ((track as Track)?._stems?.length ?? 0) > 0
 
   const handlePressArtistName = useCallback(() => {
     if (!user) {
@@ -388,7 +385,7 @@ export const DetailsTile = ({
                 !isOwner &&
                 streamConditions &&
                 trackId &&
-                !(isLosslessDownloadsEnabled && hasDownloadableAssets) ? (
+                !isLosslessDownloadsEnabled ? (
                   <DetailsTileNoAccess
                     trackId={trackId}
                     streamConditions={streamConditions}
@@ -411,7 +408,7 @@ export const DetailsTile = ({
                 ) : null}
                 {(hasStreamAccess || isOwner) &&
                 streamConditions &&
-                !(isLosslessDownloadsEnabled && hasDownloadableAssets) ? (
+                !isLosslessDownloadsEnabled ? (
                   <DetailsTileHasAccess
                     streamConditions={streamConditions}
                     isOwner={isOwner}

--- a/packages/mobile/src/components/details-tile/DetailsTile.tsx
+++ b/packages/mobile/src/components/details-tile/DetailsTile.tsx
@@ -230,9 +230,6 @@ export const DetailsTile = ({
     track?.is_scheduled_release && track?.is_unlisted
   const showPreviewButton =
     isUSDCPurchaseGated && (isOwner || !hasStreamAccess) && onPressPreview
-  const { isEnabled: isLosslessDownloadsEnabled } = useFeatureFlag(
-    FeatureFlags.LOSSLESS_DOWNLOADS_ENABLED
-  )
 
   const handlePressArtistName = useCallback(() => {
     if (!user) {
@@ -381,11 +378,7 @@ export const DetailsTile = ({
                 <DetailsProgressInfo track={track} />
               ) : null}
               <View style={styles.buttonSection}>
-                {!hasStreamAccess &&
-                !isOwner &&
-                streamConditions &&
-                trackId &&
-                !isLosslessDownloadsEnabled ? (
+                {!hasStreamAccess && !isOwner && streamConditions && trackId ? (
                   <DetailsTileNoAccess
                     trackId={trackId}
                     streamConditions={streamConditions}
@@ -406,9 +399,7 @@ export const DetailsTile = ({
                     fullWidth
                   />
                 ) : null}
-                {(hasStreamAccess || isOwner) &&
-                streamConditions &&
-                !isLosslessDownloadsEnabled ? (
+                {(hasStreamAccess || isOwner) && streamConditions ? (
                   <DetailsTileHasAccess
                     streamConditions={streamConditions}
                     isOwner={isOwner}

--- a/packages/mobile/src/screens/track-screen/TrackScreenDetailsTile.tsx
+++ b/packages/mobile/src/screens/track-screen/TrackScreenDetailsTile.tsx
@@ -269,7 +269,7 @@ export const TrackScreenDetailsTile = ({
   const isScheduledRelease = release_date
     ? moment(release_date).isAfter(moment.now())
     : false
-  const isLosslessDownloadsEnabled = useFeatureFlag(
+  const { isEnabled: isLosslessDownloadsEnabled } = useFeatureFlag(
     FeatureFlags.LOSSLESS_DOWNLOADS_ENABLED
   )
   const hasDownloadableAssets =

--- a/packages/mobile/src/screens/track-screen/TrackScreenDetailsTile.tsx
+++ b/packages/mobile/src/screens/track-screen/TrackScreenDetailsTile.tsx
@@ -62,6 +62,7 @@ import { moodMap } from 'app/utils/moods'
 import { useThemeColors } from 'app/utils/theme'
 
 import { DownloadSection } from './DownloadSection'
+import { TrackScreenDownloadButtons } from './TrackScreenDownloadButtons'
 const { getPlaying, getTrackId, getPreviewing } = playerSelectors
 const { setFavorite } = favoritesUserListActions
 const { setRepost } = repostsUserListActions
@@ -208,7 +209,9 @@ export const TrackScreenDetailsTile = ({
   uid,
   isLineupLoading
 }: TrackScreenDetailsTileProps) => {
-  const { hasStreamAccess } = useGatedContentAccess(track as Track) // track is of type Track | SearchTrack but we only care about some of their common fields, maybe worth refactoring later
+  const { hasStreamAccess, hasDownloadAccess } = useGatedContentAccess(
+    track as Track
+  ) // track is of type Track | SearchTrack but we only care about some of their common fields, maybe worth refactoring later
   const { isEnabled: isNewPodcastControlsEnabled } = useFeatureFlag(
     FeatureFlags.PODCAST_CONTROL_UPDATES_ENABLED,
     FeatureFlags.PODCAST_CONTROL_UPDATES_ENABLED_FALLBACK
@@ -567,10 +570,22 @@ export const TrackScreenDetailsTile = ({
     ) : null
   }
 
+  const renderDownloadButtons = () => {
+    return (
+      <TrackScreenDownloadButtons
+        following={user.does_current_user_follow}
+        hasDownloadAccess={hasDownloadAccess}
+        isOwner={isOwner}
+        trackId={track_id}
+      />
+    )
+  }
+
   const renderBottomContent = () => {
     return (
       <View style={styles.bottomContent}>
         {renderTags()}
+        {!isLosslessDownloadsEnabled ? renderDownloadButtons() : null}
         {isLosslessDownloadsEnabled && hasDownloadableAssets ? (
           <DownloadSection trackId={track_id} />
         ) : null}

--- a/packages/mobile/src/screens/track-screen/TrackScreenDownloadButtons.tsx
+++ b/packages/mobile/src/screens/track-screen/TrackScreenDownloadButtons.tsx
@@ -1,0 +1,144 @@
+import { useCallback } from 'react'
+
+import {
+  Name,
+  ButtonState,
+  useDownloadTrackButtons,
+  tracksSocialActions
+} from '@audius/common'
+import type { ID, ButtonType as DownloadButtonType } from '@audius/common'
+import { View } from 'react-native'
+import { useDispatch } from 'react-redux'
+
+import IconDownload from 'app/assets/images/iconDownload.svg'
+import { Button } from 'app/components/core'
+import LoadingSpinner from 'app/components/loading-spinner'
+import { useToast } from 'app/hooks/useToast'
+import { make, track } from 'app/services/analytics'
+import { makeStyles } from 'app/styles'
+const { downloadTrack } = tracksSocialActions
+
+export type DownloadButtonProps = {
+  state: ButtonState
+  type: DownloadButtonType
+  label: string
+  hasDownloadAccess: boolean
+  onClick?: () => void
+}
+
+export const messages = {
+  followToDownload: 'Must follow artist to download',
+  addDownloadPrefix: (label: string) => `Download ${label}`,
+  mustHaveAccess: 'Must have access to download'
+}
+
+const useStyles = makeStyles(() => ({
+  buttonContainer: {
+    alignSelf: 'center',
+    marginBottom: 6
+  }
+}))
+
+const DownloadButton = ({
+  label,
+  state,
+  hasDownloadAccess,
+  onClick = () => {}
+}: DownloadButtonProps) => {
+  const { toast } = useToast()
+
+  const styles = useStyles()
+  const requiresFollow = state === ButtonState.REQUIRES_FOLLOW
+  const isProcessing = state === ButtonState.PROCESSING
+  const isDisabled =
+    !hasDownloadAccess || state === ButtonState.PROCESSING || requiresFollow
+
+  const handlePress = useCallback(() => {
+    if (requiresFollow) {
+      toast({ content: messages.followToDownload })
+    }
+
+    if (!hasDownloadAccess) {
+      toast({ content: messages.mustHaveAccess })
+    }
+
+    if (isDisabled) {
+      return
+    }
+
+    onClick()
+  }, [isDisabled, onClick, requiresFollow, hasDownloadAccess, toast])
+
+  // Manually handling disabled state in order to show a toast
+  // when a follow is required
+  return (
+    <Button
+      variant='common'
+      icon={isProcessing ? LoadingSpinner : IconDownload}
+      iconPosition='left'
+      title={messages.addDownloadPrefix(label)}
+      styles={{
+        root: styles.buttonContainer,
+        button: isDisabled && { opacity: 0.5 }
+      }}
+      onPress={handlePress}
+      size='small'
+    />
+  )
+}
+
+type TrackScreenDownloadButtonsProps = {
+  following: boolean
+  hasDownloadAccess: boolean
+  isHidden?: boolean
+  isOwner: boolean
+  trackId: ID
+}
+
+export const TrackScreenDownloadButtons = ({
+  following,
+  hasDownloadAccess,
+  isOwner,
+  trackId
+}: TrackScreenDownloadButtonsProps) => {
+  const dispatch = useDispatch()
+
+  const handleDownload = useCallback(
+    (id: ID, category?: string, parentTrackId?: ID) => {
+      dispatch(downloadTrack(id, category))
+      track(
+        make({
+          eventName: Name.TRACK_PAGE_DOWNLOAD,
+          id,
+          category,
+          parent_track_id: parentTrackId
+        })
+      )
+    },
+    [dispatch]
+  )
+
+  const buttons = useDownloadTrackButtons({
+    trackId,
+    onDownload: handleDownload,
+    isOwner,
+    following
+  })
+
+  const shouldHide = buttons.length === 0
+  if (shouldHide) {
+    return null
+  }
+
+  return (
+    <View style={{ marginBottom: 12 }}>
+      {buttons.map((props) => (
+        <DownloadButton
+          {...props}
+          hasDownloadAccess={hasDownloadAccess}
+          key={props.label}
+        />
+      ))}
+    </View>
+  )
+}


### PR DESCRIPTION
### Description
Instead of removing the download buttons entirely I should have kept them around for before the lossless feature flag is enabled.

### How Has This Been Tested?

local ios stage
![Simulator Screenshot - iPhone 14 Pro - 2024-01-19 at 16 34 13](https://github.com/AudiusProject/audius-protocol/assets/3893871/6be8e045-e080-48fa-b846-95a148251f96)
