### PR TITLE
[C-3651] Add box-shadow to text-input

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -81580,6 +81580,18 @@
         "react-native": ">=0.56"
       }
     },
+    "node_modules/react-native-inset-shadow": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/react-native-inset-shadow/-/react-native-inset-shadow-1.0.3.tgz",
+      "integrity": "sha512-4UXuSrenJtOWKcV0zSqHLQ47Oxn+BXdmxFxYXf5rE8KletbTvQq8ziZsX8MSEegUGWDcJJ3Mw+1OVbPJxm4lZg==",
+      "dependencies": {
+        "prop-types": "^15.7.2"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "react-native": "*"
+      }
+    },
     "node_modules/react-native-iphone-x-helper": {
       "version": "1.3.1",
       "license": "MIT",
@@ -132788,6 +132800,7 @@
         "react-native-image-crop-picker": "0.40.2",
         "react-native-image-picker": "7.1.0",
         "react-native-in-app-review": "4.3.3",
+        "react-native-inset-shadow": "^1.0.3",
         "react-native-keyboard-aware-scroll-view": "0.9.5",
         "react-native-linear-gradient": "2.8.3",
         "react-native-markdown-display": "7.0.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -132800,7 +132800,7 @@
         "react-native-image-crop-picker": "0.40.2",
         "react-native-image-picker": "7.1.0",
         "react-native-in-app-review": "4.3.3",
-        "react-native-inset-shadow": "^1.0.3",
+        "react-native-inset-shadow": "1.0.3",
         "react-native-keyboard-aware-scroll-view": "0.9.5",
         "react-native-linear-gradient": "2.8.3",
         "react-native-markdown-display": "7.0.2",

--- a/packages/harmony/src/components/input/TextInput/TextInput.module.css
+++ b/packages/harmony/src/components/input/TextInput/TextInput.module.css
@@ -16,6 +16,8 @@
   background-color: var(--harmony-bg-surface-1);
   transition: border ease-in-out 0.1s;
   box-sizing: border-box;
+  box-shadow: 1px 1px 4px 0px rgba(0, 0, 0, 0.02) inset,
+    1px 1px 2px 0px rgba(0, 0, 0, 0.02) inset;
 
   & svg path {
     fill: var(--harmony-text-subdued);
@@ -26,6 +28,10 @@
 .contentContainer:hover,
 .contentContainer.hover {
   border-color: var(--harmony-border-strong);
+}
+
+.contentContainer.disabled {
+  opacity: 0.6;
 }
 
 /* small input size */

--- a/packages/mobile/package.json
+++ b/packages/mobile/package.json
@@ -132,7 +132,7 @@
     "react-native-image-crop-picker": "0.40.2",
     "react-native-image-picker": "7.1.0",
     "react-native-in-app-review": "4.3.3",
-    "react-native-inset-shadow": "^1.0.3",
+    "react-native-inset-shadow": "1.0.3",
     "react-native-keyboard-aware-scroll-view": "0.9.5",
     "react-native-linear-gradient": "2.8.3",
     "react-native-markdown-display": "7.0.2",

--- a/packages/mobile/package.json
+++ b/packages/mobile/package.json
@@ -132,6 +132,7 @@
     "react-native-image-crop-picker": "0.40.2",
     "react-native-image-picker": "7.1.0",
     "react-native-in-app-review": "4.3.3",
+    "react-native-inset-shadow": "^1.0.3",
     "react-native-keyboard-aware-scroll-view": "0.9.5",
     "react-native-linear-gradient": "2.8.3",
     "react-native-markdown-display": "7.0.2",

--- a/packages/mobile/src/harmony-native/components/input/TextInput/TextInput.tsx
+++ b/packages/mobile/src/harmony-native/components/input/TextInput/TextInput.tsx
@@ -9,6 +9,7 @@ import type {
 } from 'react-native'
 import { Platform, Pressable, TextInput as RNTextInput } from 'react-native'
 import { Gesture, GestureDetector, State } from 'react-native-gesture-handler'
+import InsetShadow from 'react-native-inset-shadow'
 import Animated, {
   FadeIn,
   FadeOut,
@@ -82,7 +83,7 @@ export const TextInput = forwardRef(
 
     const innerInputRef = useRef<RNTextInput>(null)
 
-    const { typography, color, motion } = useTheme()
+    const { typography, color, motion, cornerRadius } = useTheme()
 
     let endAdornment: null | ReactNode
     if (EndIcon != null) {
@@ -237,113 +238,128 @@ export const TextInput = forwardRef(
           pointerEvents={disabled || _disablePointerEvents ? 'none' : undefined}
         >
           <GestureDetector gesture={tap}>
-            <AnimatedFlex
-              h={isSmall ? 34 : 64}
-              w='100%'
-              direction='row'
-              alignItems='center'
-              border={disabled ? 'default' : 'strong'}
-              borderRadius='s'
-              backgroundColor='surface1'
-              ph='l'
-              gap={isSmall ? 's' : 'm'}
-              style={animatedRootStyles}
+            <InsetShadow
+              containerStyle={css({
+                width: '100%',
+                height: isSmall ? 34 : 64,
+                borderRadius: cornerRadius.s
+              })}
+              shadowOpacity={0.05}
+              shadowColor='#000000'
+              shadowRadius={4}
             >
-              {StartIcon ? (
-                <StartIcon size='m' color='subdued' {...IconProps} />
-              ) : null}
-              <Flex
-                direction='column'
-                gap='xs'
-                justifyContent='center'
-                flex={1}
+              <AnimatedFlex
+                h='100%'
+                w='100%'
+                direction='row'
+                alignItems='center'
+                border={disabled ? 'default' : 'strong'}
+                borderRadius='s'
+                backgroundColor='surface1'
+                ph='l'
+                gap={isSmall ? 's' : 'm'}
+                style={animatedRootStyles}
               >
-                {shouldShowLabel ? (
+                {StartIcon ? (
+                  <StartIcon size='m' color='subdued' {...IconProps} />
+                ) : null}
+                <Flex
+                  direction='column'
+                  gap='xs'
+                  justifyContent='center'
+                  flex={1}
+                >
+                  {shouldShowLabel ? (
+                    <Flex
+                      direction='row'
+                      alignItems='center'
+                      justifyContent='space-between'
+                      gap='s'
+                    >
+                      <AnimatedText
+                        nativeID={id}
+                        variant='body'
+                        color='subdued'
+                        style={[
+                          css({ overflow: 'hidden', zIndex: 2 }),
+                          animatedLabelStyle
+                        ]}
+                        ellipsizeMode='tail'
+                      >
+                        {labelText}
+                      </AnimatedText>
+                      {shouldShowMaxLengthText ? (
+                        <Text
+                          variant='body'
+                          size='xs'
+                          color={maxLengthTextColor}
+                        >
+                          {characterCount}/{maxLength}
+                        </Text>
+                      ) : null}
+                    </Flex>
+                  ) : null}
+
                   <Flex
                     direction='row'
                     alignItems='center'
                     justifyContent='space-between'
-                    gap='s'
+                    gap='2xs'
                   >
-                    <AnimatedText
-                      nativeID={id}
-                      variant='body'
-                      color='subdued'
-                      style={[
-                        css({ overflow: 'hidden', zIndex: 2 }),
-                        animatedLabelStyle
-                      ]}
-                      ellipsizeMode='tail'
-                    >
-                      {labelText}
-                    </AnimatedText>
-                    {shouldShowMaxLengthText ? (
-                      <Text variant='body' size='xs' color={maxLengthTextColor}>
-                        {characterCount}/{maxLength}
+                    {startAdornmentText && shouldShowAdornments ? (
+                      <Text
+                        variant='label'
+                        size='l'
+                        color='subdued'
+                        style={css({ lineHeight: 0 })}
+                      >
+                        {startAdornmentText}
+                      </Text>
+                    ) : null}
+                    <RNTextInput
+                      ref={mergeRefs([innerInputRef, ref])}
+                      value={value}
+                      accessibilityLabel={
+                        Platform.OS === 'ios' ? labelProp : undefined
+                      }
+                      accessibilityLabelledBy={
+                        Platform.OS === 'android' ? id : undefined
+                      }
+                      maxLength={maxLength}
+                      placeholder={
+                        shouldShowPlaceholder ? placeholderText : undefined
+                      }
+                      placeholderTextColor={color.text.subdued}
+                      underlineColorAndroid='transparent'
+                      aria-label={ariaLabel ?? labelText}
+                      style={css({
+                        flex: 1,
+                        fontSize: typography.size[isSmall ? 's' : 'l'],
+                        fontFamily: typography.fontByWeight.medium,
+                        color: color.text[disabled ? 'subdued' : 'default']
+                      })}
+                      onChange={handleChange}
+                      onFocus={onFocus}
+                      onBlur={onBlur}
+                      selectionColor={color.secondary.secondary}
+                      inputAccessoryViewID={inputAccessoryViewID}
+                      {...other}
+                    />
+                    {endAdornmentText && shouldShowAdornments ? (
+                      <Text
+                        variant='label'
+                        size='l'
+                        color='subdued'
+                        style={css({ lineHeight: 0 })}
+                      >
+                        {endAdornmentText}
                       </Text>
                     ) : null}
                   </Flex>
-                ) : null}
-
-                <Flex
-                  direction='row'
-                  alignItems='center'
-                  justifyContent='space-between'
-                  gap='2xs'
-                >
-                  {startAdornmentText && shouldShowAdornments ? (
-                    <Text
-                      variant='label'
-                      size='l'
-                      color='subdued'
-                      style={css({ lineHeight: 0 })}
-                    >
-                      {startAdornmentText}
-                    </Text>
-                  ) : null}
-                  <RNTextInput
-                    ref={mergeRefs([innerInputRef, ref])}
-                    value={value}
-                    accessibilityLabel={
-                      Platform.OS === 'ios' ? labelProp : undefined
-                    }
-                    accessibilityLabelledBy={
-                      Platform.OS === 'android' ? id : undefined
-                    }
-                    maxLength={maxLength}
-                    placeholder={
-                      shouldShowPlaceholder ? placeholderText : undefined
-                    }
-                    placeholderTextColor={color.text.subdued}
-                    underlineColorAndroid='transparent'
-                    aria-label={ariaLabel ?? labelText}
-                    style={css({
-                      flex: 1,
-                      fontSize: typography.size[isSmall ? 's' : 'l'],
-                      fontFamily: typography.fontByWeight.medium,
-                      color: color.text[disabled ? 'subdued' : 'default']
-                    })}
-                    onChange={handleChange}
-                    onFocus={onFocus}
-                    onBlur={onBlur}
-                    selectionColor={color.secondary.secondary}
-                    inputAccessoryViewID={inputAccessoryViewID}
-                    {...other}
-                  />
-                  {endAdornmentText && shouldShowAdornments ? (
-                    <Text
-                      variant='label'
-                      size='l'
-                      color='subdued'
-                      style={css({ lineHeight: 0 })}
-                    >
-                      {endAdornmentText}
-                    </Text>
-                  ) : null}
                 </Flex>
-              </Flex>
-              {endAdornment}
-            </AnimatedFlex>
+                {endAdornment}
+              </AnimatedFlex>
+            </InsetShadow>
           </GestureDetector>
         </Pressable>
         {helperText ? (


### PR DESCRIPTION
### Description

Adds box-shadow to harmony and harmony-native text-inputs to dramatically improve readability and align with figma

@audius/harmony: 
<img width="1065" alt="image" src="https://github.com/AudiusProject/audius-protocol/assets/8230000/10bb3e89-fe0c-4450-8f7c-488545229bce">


@audius/harmony-native: 
<img width="395" alt="Sign Up For Audius" src="https://github.com/AudiusProject/audius-protocol/assets/8230000/a4e3850c-e83a-43b6-8866-27cb1832f1a7">
