### PR TITLE
Misc Sign Up QA Fixes

### DIFF
--- a/packages/web/src/pages/sign-in-page/SignInPage.tsx
+++ b/packages/web/src/pages/sign-in-page/SignInPage.tsx
@@ -91,8 +91,8 @@ export const SignInPage = () => {
         <ScrollView
           direction='column'
           justifyContent='space-between'
-          ph={isMobile ? 'l' : '2xl'}
-          pt='unit20'
+          ph={isMobile ? 'm' : '2xl'}
+          pt='unit14'
           pb={isMobile ? '2xl' : 'unit14'}
           gap='l'
         >

--- a/packages/web/src/pages/sign-up-page/components/layout.tsx
+++ b/packages/web/src/pages/sign-up-page/components/layout.tsx
@@ -193,10 +193,10 @@ type PageFooterProps = {
 export const PageFooter = (props: PageFooterProps) => {
   const { prefix, postfix, buttonProps, centered, sticky, ...other } = props
   const { isMobile } = useMedia()
-  // On the MobileCTAPage we use this footer outside a formik context
-  const { isSubmitting, dirty, isValid } = useFormikContext() ?? {
+  // On the MobileCTAPage we use this footer outside a formik context, hence the default values
+  const { isSubmitting, touched, isValid } = useFormikContext() ?? {
     isSubmitting: false,
-    dirty: true,
+    touched: true,
     isValid: true
   }
 
@@ -227,7 +227,7 @@ export const PageFooter = (props: PageFooterProps) => {
         fullWidth
         isLoading={isSubmitting}
         css={!isMobile && centered && { width: 343 }}
-        disabled={!dirty || !isValid}
+        disabled={!touched || !isValid}
         {...buttonProps}
       >
         {messages.continue}

--- a/packages/web/src/pages/sign-up-page/pages/CreateEmailPage.tsx
+++ b/packages/web/src/pages/sign-up-page/pages/CreateEmailPage.tsx
@@ -114,7 +114,7 @@ export const CreateEmailPage = () => {
       validateOnChange={false}
     >
       {({ isSubmitting }) => (
-        <Page as={Form} pt='unit20'>
+        <Page as={Form} pt={isMobile ? 'xl' : 'unit13'}>
           <Box alignSelf='center'>
             {isMobile ? (
               <IconAudiusLogoHorizontalColor />

--- a/packages/web/src/pages/sign-up-page/pages/ReviewHandlePage.tsx
+++ b/packages/web/src/pages/sign-up-page/pages/ReviewHandlePage.tsx
@@ -79,7 +79,7 @@ export const ReviewHandlePage = () => {
       validateOnMount
     >
       {({ isValid }) => (
-        <Page as={Form} transition='horizontal'>
+        <Page as={Form} transition='horizontal' centered>
           <Heading
             heading={messages.heading}
             description={messages.description}

--- a/packages/web/src/pages/sign-up-page/pages/SelectGenresPage.tsx
+++ b/packages/web/src/pages/sign-up-page/pages/SelectGenresPage.tsx
@@ -62,7 +62,6 @@ export const SelectGenresPage = () => {
             <Flex
               direction='column'
               gap='2xl'
-              mt={isMobile ? '2xl' : '3xl'}
               css={!isMobile ? { maxWidth: '641px' } : undefined}
             >
               <Heading

--- a/packages/web/src/pages/sign-up-page/utils/useDetermineAllowedRoutes.ts
+++ b/packages/web/src/pages/sign-up-page/utils/useDetermineAllowedRoutes.ts
@@ -81,6 +81,9 @@ export const useDetermineAllowedRoute = () => {
     // If requested route is allowed return that, otherwise return the last step in the route stack
     const correctedPath = isAllowedRoute
       ? attemptedPath
+      : // IF we attempted to go to /signup directly, that means it was a link from somewhere else in the app, so we should start back at the beginning
+      attemptedPath === '/signup'
+      ? allowedRoutes[0]
       : allowedRoutes[allowedRoutes.length - 1]
 
     if (correctedPath === SignUpPath.completedRedirect) {


### PR DESCRIPTION
### Description

Batch of fixes from the internal QA findings

- [C-3695] - cant get back to create email after you've entered an email and go to /sign-in or close the modal
- [C-3673] - Padding on email screens
- [C-3674] - Genres and artists spacing issues
- [C-3662] - Review handle section continue button has weird shadow and floats in the middle of page


### How Has This Been Tested?

Local web
