### PR TITLE
Make ddex tRPC Dockerfile run

### DIFF
--- a/packages/ddex/.dockerignore
+++ b/packages/ddex/.dockerignore
@@ -1,4 +1,4 @@
-Dockerfile
-Dockerfile.fast
+README.md
+Dockerfile*
 node_modules/
 dist/

--- a/packages/ddex/Dockerfile
+++ b/packages/ddex/Dockerfile
@@ -6,8 +6,14 @@ ENV TURBO_TEAM=$TURBO_TEAM
 ARG TURBO_TOKEN
 ENV TURBO_TOKEN=$TURBO_TOKEN
 
-# Prune turbo dependencies
-FROM base AS builder
+# First stage: Set up a minimal monorepo
+FROM base AS turbo-builder
+
+RUN apk add --no-cache libc6-compat
+RUN apk update
+
+WORKDIR /app
+RUN npm install turbo --global
 
 RUN apk add --no-cache libc6-compat
 RUN apk update
@@ -18,32 +24,42 @@ RUN npm install turbo --global
 COPY . .
 RUN turbo prune --scope=@audius/ddex-client --scope=@audius/ddex-server --docker
 
-# Install and build client and server dists and run app
-FROM base AS runner
+# Second stage: Install and build client and server dists
+FROM base AS app-builder
 
 WORKDIR /app
-
 RUN apk add --no-cache python3 py3-pip make g++ curl bash libc6-compat
 RUN apk update
 
 # First install dependencies (as they change less often)
 COPY .gitignore .gitignore
-COPY --from=builder /app/out/json/ .
-COPY --from=builder /app/out/package-lock.json ./package-lock.json
-COPY --from=builder /app/scripts ./scripts
+COPY --from=turbo-builder /app/out/json/ .
+COPY --from=turbo-builder /app/out/package-lock.json ./package-lock.json
+COPY --from=turbo-builder /app/scripts ./scripts
 
 RUN CI=true npm i
 
 # Build the app and its dependencies
-COPY --from=builder /app/out/full/ .
+COPY --from=turbo-builder /app/out/full/ .
 COPY svgr-template.js svgr-template.js
 COPY turbo.json turbo.json
 RUN npx turbo run build --filter=@audius/ddex-client --filter=@audius/ddex-server
 
-CMD ["sh"]
-# COPY packages/ddex/client/dist /app/packages/ddex/server/public
+# Make a smaller image by removing all src directories (except for in node_modules)
+RUN mv packages/ddex/client/dist packages/ddex/server/public
+RUN rm -rf packages/ddex/client
+RUN find packages -path '*/node_modules/*' -prune -o -name 'src' -type d -exec rm -rf {} +
 
-# WORKDIR /app/packages/ddex/server
+# Final stage: Create a runnable image
+FROM node:18-alpine AS runner
 
-# EXPOSE 8926
-# CMD [ "node", "dist/index.js" ]
+RUN addgroup --system --gid 1001 nodejs
+RUN adduser --system --uid 1001 nodejs
+USER nodejs
+
+WORKDIR /app
+COPY --from=app-builder --chown=nodejs:nodejs /app .
+WORKDIR /app/packages/ddex/server
+
+EXPOSE 8926
+CMD ["node", "dist/index.js"]

--- a/packages/ddex/Dockerfile
+++ b/packages/ddex/Dockerfile
@@ -15,12 +15,6 @@ RUN apk update
 WORKDIR /app
 RUN npm install turbo --global
 
-RUN apk add --no-cache libc6-compat
-RUN apk update
-
-WORKDIR /app
-RUN npm install turbo --global
-
 COPY . .
 RUN turbo prune --scope=@audius/ddex-client --scope=@audius/ddex-server --docker
 

--- a/packages/ddex/server/src/services/dbService.ts
+++ b/packages/ddex/server/src/services/dbService.ts
@@ -1,58 +1,57 @@
 import type { Sql } from 'postgres'
 import postgres from 'postgres'
-import crypto from 'crypto'
 
 export const createDbService = async (dbUrl: string): Promise<Sql> => {
   const sql = postgres(dbUrl)
 
-  const runMigrations = async () => {
-    // TODO: Remove after db schema stabilizes
-    // Drop ddex tables for now
-    await sql`DROP TABLE IF EXISTS releases`
-    await sql`DROP TABLE IF EXISTS xml_files`
-    await sql`DROP TABLE IF EXISTS ddex_migrations`
+  // const runMigrations = async () => {
+  //   // TODO: Remove after db schema stabilizes
+  //   // Drop ddex tables for now
+  //   await sql`DROP TABLE IF EXISTS releases`
+  //   await sql`DROP TABLE IF EXISTS xml_files`
+  //   await sql`DROP TABLE IF EXISTS ddex_migrations`
 
-    await sql`CREATE TABLE IF NOT EXISTS ddex_migrations (hash TEXT PRIMARY KEY)`
-    const migrationsTable = await sql`SELECT * FROM ddex_migrations`
-    const migrationsHashes = migrationsTable.map((m: any) => m.hash)
+  //   await sql`CREATE TABLE IF NOT EXISTS ddex_migrations (hash TEXT PRIMARY KEY)`
+  //   const migrationsTable = await sql`SELECT * FROM ddex_migrations`
+  //   const migrationsHashes = migrationsTable.map((m: any) => m.hash)
 
-    const migrationsHash = (s: string) =>
-      crypto.createHash('sha256').update(s).digest('hex')
+  //   const migrationsHash = (s: string) =>
+  //     crypto.createHash('sha256').update(s).digest('hex')
 
-    const runMigration = async (migration: string) => {
-      const hash = migrationsHash(migration)
-      if (migrationsHashes.includes(hash)) return
-      await sql.unsafe(migration)
-      await sql`INSERT INTO ddex_migrations (hash) VALUES (${hash})`
-    }
+  //   const runMigration = async (migration: string) => {
+  //     const hash = migrationsHash(migration)
+  //     if (migrationsHashes.includes(hash)) return
+  //     await sql.unsafe(migration)
+  //     await sql`INSERT INTO ddex_migrations (hash) VALUES (${hash})`
+  //   }
 
-    // TODO: Make statuses enums
-    const migrations = [
-      `CREATE TABLE IF NOT EXISTS xml_files (
-        id SERIAL PRIMARY KEY,
-        uploaded_by TEXT,
-        uploaded_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
-        from_zip_file UUID,
-        xml_contents TEXT NOT NULL,
-        status TEXT NOT NULL
-      );`,
+  //   // TODO: Make statuses enums
+  //   const migrations = [
+  //     `CREATE TABLE IF NOT EXISTS xml_files (
+  //       id SERIAL PRIMARY KEY,
+  //       uploaded_by TEXT,
+  //       uploaded_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+  //       from_zip_file UUID,
+  //       xml_contents TEXT NOT NULL,
+  //       status TEXT NOT NULL
+  //     );`,
 
-      `CREATE TABLE IF NOT EXISTS releases (
-        id SERIAL PRIMARY KEY,
-        from_xml_file INTEGER NOT NULL,
-        release_date TIMESTAMP WITH TIME ZONE NOT NULL,
-        data JSON NOT NULL,
-        status TEXT NOT NULL,
-        FOREIGN KEY (from_xml_file) REFERENCES xml_files(id)
-      );`,
-    ]
+  //     `CREATE TABLE IF NOT EXISTS releases (
+  //       id SERIAL PRIMARY KEY,
+  //       from_xml_file INTEGER NOT NULL,
+  //       release_date TIMESTAMP WITH TIME ZONE NOT NULL,
+  //       data JSON NOT NULL,
+  //       status TEXT NOT NULL,
+  //       FOREIGN KEY (from_xml_file) REFERENCES xml_files(id)
+  //     );`,
+  //   ]
 
-    for (const migration of migrations) {
-      await runMigration(migration)
-    }
-  }
+  //   for (const migration of migrations) {
+  //     await runMigration(migration)
+  //   }
+  // }
 
-  await runMigrations()
+  // await runMigrations()
 
   return sql
 }


### PR DESCRIPTION
### Description
Makes the Dockerfile for tRPC actually run (it was just "sh" before to unblock CI). Also adds proper permissions to the final runner image and prunes some unnecessary files which were causing bloat.

### How Has This Been Tested?
Tested by building on a stage node and running the image there. The UI has issues, and the backend has issues with the Postgres connection because that's in the process of changing to Mongo.