### PR TITLE
[C-3696] Fix lineups and recommendations

### DIFF
--- a/packages/web/src/common/store/queue/sagas.ts
+++ b/packages/web/src/common/store/queue/sagas.ts
@@ -123,7 +123,7 @@ function* handleQueueAutoplay({
   const length = yield* select(getLength)
   const shuffle = yield* select(getShuffle)
   const repeatMode = yield* select(getRepeat)
-  const isCloseToEndOfQueue = index + 9 >= length
+  const isCloseToEndOfQueue = index + 2 >= length
   const isNotRepeating =
     repeatMode === RepeatMode.OFF ||
     (repeatMode === RepeatMode.SINGLE && (skip || ignoreSkip))


### PR DESCRIPTION
### Description

Fixes issue where nearly every lineup that has progressive loading gets 20+ recommended songs added to the end when user clicks play. This not only affects performance as we have to load a bunch more data into the queue, it also means after 10ish songs, we continue playing from recommended tracks instead of the next lineup tracks.

I went with "two tracks from the end" as the heuristic to load recommended tracks, to avoid the issue where a user skips quickly to the end before recommended tracks can load, reference: https://github.com/AudiusProject/audius-client/pull/3353

Note there is still an improvement to be made by auto-fetching the next tracks in lineup when the queue gets near the end, but this will come in another pr.
