### PR TITLE
Fix desktop track tile title width

### DIFF
--- a/packages/web/src/components/track/desktop/TrackTile.module.css
+++ b/packages/web/src/components/track/desktop/TrackTile.module.css
@@ -115,8 +115,8 @@
 
 .text {
   overflow: hidden;
-  text-overflow: ellipsis;
   white-space: nowrap;
+  text-overflow: ellipsis;
 }
 
 .topSection {
@@ -143,6 +143,7 @@
   user-select: none;
   margin-right: 132px;
   padding-bottom: 2px;
+  display: flex;
 }
 
 .titleRow .skeleton {
@@ -159,7 +160,9 @@
 }
 
 .title {
-  width: 100%;
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
 }
 
 .isActive .title {

--- a/packages/web/src/components/track/mobile/TrackTile.module.css
+++ b/packages/web/src/components/track/mobile/TrackTile.module.css
@@ -137,8 +137,8 @@
 
 .text {
   overflow: hidden;
-  text-overflow: ellipsis;
   white-space: nowrap;
+  text-overflow: ellipsis;
 }
 
 .titlesSkeleton div,
@@ -149,7 +149,9 @@
 .title {
   margin-top: auto;
   padding-right: 5px;
-  width: 100%;
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
 }
 
 .playIcon {


### PR DESCRIPTION
### Description

Fixes issue where ellipses change required the title to be full width, messing with the touch targets. This fix ensures the title only takes up the space it needs, and also adds ellipses when needed.

Mobile web still a little wonky, but i think that's okay for now.
