### PR TITLE
Updates deprecated vscode settings

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -21,14 +21,14 @@
   "python.testing.unittestEnabled": false,
   "[python]": {
     "editor.codeActionsOnSave": {
-      "source.organizeImports": true
+      "source.organizeImports": "explicit"
     },
     "editor.defaultFormatter": "ms-python.black-formatter"
   },
   "editor.find.addExtraSpaceOnTop": false,
   "eslint.workingDirectories": [{ "pattern": "./packages/*/" }],
   "editor.codeActionsOnSave": {
-    "source.fixAll": true
+    "source.fixAll": "explicit"
   },
   "gitlens.advanced.fileHistoryFollowsRenames": true
 }

--- a/packages/discovery-provider/.vscode/settings.json
+++ b/packages/discovery-provider/.vscode/settings.json
@@ -15,7 +15,7 @@
   "python.testing.unittestEnabled": false,
   "[python]": {
     "editor.codeActionsOnSave": {
-      "source.organizeImports": true
+      "source.organizeImports": "explicit"
     },
     "editor.defaultFormatter": "ms-python.black-formatter"
   },


### PR DESCRIPTION
`fixAll` and `organizeImports` on save actions were updated in recent versions of VSCode to use `"explicit"` instead of `true`. This gets auto-fixed every time I open the repo, so I'm persisting it permanently :-) 
