### PR TITLE
Use defaults for trending track checks

### DIFF
--- a/packages/discovery-provider/src/queries/query_helpers.py
+++ b/packages/discovery-provider/src/queries/query_helpers.py
@@ -578,7 +578,7 @@ def _populate_gated_track_metadata(session, tracks, current_user_id):
     gated_track_access = {track["track_id"]: defaultdict() for track in tracks}
     gated_tracks = list(
         filter(
-            lambda track: track["stream_conditions"] or track["download_conditions"],
+            lambda track: track.get("stream_conditions") or track.get("download_conditions"),
             tracks,
         )
     )


### PR DESCRIPTION
### Description
Use `.get()` to have a default `None` when checking tracks in the `/v1/trending` endpoint.