### PR TITLE
Fix mobile track pages due to collection check

### DIFF
--- a/packages/mobile/src/components/details-tile/DetailsTileActionButtons.tsx
+++ b/packages/mobile/src/components/details-tile/DetailsTileActionButtons.tsx
@@ -91,10 +91,13 @@ export const DetailsTileActionButtons = ({
     getIsCollectionEmpty(state, { id: collectionId })
   )
   const { data: currentUserId } = useGetCurrentUserId({})
-  const { data: collection } = useGetPlaylistById({
-    playlistId: collectionId!,
-    currentUserId
-  })
+  const { data: collection } = useGetPlaylistById(
+    {
+      playlistId: collectionId!,
+      currentUserId
+    },
+    { disabled: !collectionId || !isCollection }
+  )
   const collectionHasHiddenTracks = useSelector((state: CommonState) =>
     getCollecitonHasHiddenTracks(state, { id: collectionId })
   )
@@ -164,7 +167,7 @@ export const DetailsTileActionButtons = ({
     />
   )
 
-  const isAlbum = collection.is_album
+  const isAlbum = isCollection && collection?.is_album
   const isCollectionOwner = isCollection && isOwner
 
   return (


### PR DESCRIPTION
### Description

Fixes issue where track pages on mobile due to collection.is_album check, which should only occur when "isCollection" is passed down as a prop.
