### PR TITLE
[C-3716] Update sign up recovery flow for new sign up

### DIFF
--- a/packages/web/src/common/store/pages/signon/selectors.ts
+++ b/packages/web/src/common/store/pages/signon/selectors.ts
@@ -42,6 +42,7 @@ export const getIsSocialConnected = (state: AppState) =>
   !!state.signOn.tikTokId ||
   !!state.signOn.instagramId
 export const getAccountReady = (state: AppState) => state.signOn.accountReady
+export const getAccountAlreadyExisted = (state: AppState) => state.signOn.accountAlreadyExisted
 export const getStartedSignUpProcess = (state: AppState) =>
   state.signOn.startedSignUpProcess
 export const getFinishedSignUpProcess = (state: AppState) =>

--- a/packages/web/src/common/store/pages/signon/types.ts
+++ b/packages/web/src/common/store/pages/signon/types.ts
@@ -52,6 +52,7 @@ export default interface SignOnPageState {
   verified: boolean
   useMetaMask: boolean
   accountReady: boolean
+  accountAlreadyExisted: boolean
   twitterId: string
   tikTokId: string
   instagramId: string

--- a/packages/web/src/pages/sign-up-page/utils/useDetermineAllowedRoutes.ts
+++ b/packages/web/src/pages/sign-up-page/utils/useDetermineAllowedRoutes.ts
@@ -2,7 +2,7 @@ import { accountSelectors } from '@audius/common'
 import { useSelector } from 'react-redux'
 
 import { useModalState } from 'common/hooks/useModalState'
-import { getSignOn } from 'common/store/pages/signon/selectors'
+import { getAccountAlreadyExisted, getSignOn } from 'common/store/pages/signon/selectors'
 import { EditingStatus } from 'common/store/pages/signon/types'
 import { SignUpPath } from 'utils/route'
 
@@ -17,6 +17,7 @@ export const useDetermineAllowedRoute = () => {
   const [, setIsWelcomeModalOpen] = useModalState('Welcome')
   const signUpState = useSelector(getSignOn)
   const hasAccount = useSelector(getHasAccount)
+  const hasAlreadySignedUp = useSelector(getAccountAlreadyExisted)
 
   const pastAccountPhase = signUpState.finishedPhase1 || hasAccount
 
@@ -79,7 +80,10 @@ export const useDetermineAllowedRoute = () => {
 
     const isAllowedRoute = allowedRoutes.includes(attemptedPath)
     // If requested route is allowed return that, otherwise return the last step in the route stack
-    const correctedPath = isAllowedRoute
+    const correctedPath = 
+      attemptedPath === '/signup' && hasAlreadySignedUp
+      ? allowedRoutes[allowedRoutes.length - 1]
+      : isAllowedRoute
       ? attemptedPath
       : // IF we attempted to go to /signup directly, that means it was a link from somewhere else in the app, so we should start back at the beginning
       attemptedPath === '/signup'


### PR DESCRIPTION
### Description
Update the new sign in/sign up flow to allow users to properly fix their account when they've gotten into a bad state (identity record, but no DN record)

### How Has This Been Tested?

Manually tested
