### PR TITLE
Fix logged out state track access on client

### DIFF
--- a/packages/common/src/hooks/useGatedContent.ts
+++ b/packages/common/src/hooks/useGatedContent.ts
@@ -37,6 +37,10 @@ export const useGatedContentAccess = (track: Nullable<Partial<Track>>) => {
       }
 
       const trackId = track.track_id
+      const {
+        is_stream_gated: isStreamGated,
+        is_download_gated: isDownloadGated
+      } = track
       const { stream, download } = track.access ?? {}
       const hasNftAccessSignature = !!(
         trackId && nftAccessSignatureMap[trackId]
@@ -54,8 +58,8 @@ export const useGatedContentAccess = (track: Nullable<Partial<Track>>) => {
 
       return {
         isFetchingNFTAccess: !hasNftAccessSignature && isSignatureToBeFetched,
-        hasStreamAccess: !!stream,
-        hasDownloadAccess: !!download
+        hasStreamAccess: !isStreamGated || !!stream,
+        hasDownloadAccess: !isDownloadGated || !!download
       }
     }, [track, nftAccessSignatureMap, user])
 
@@ -80,7 +84,6 @@ export const useGatedContentAccessMap = (tracks: Partial<Track>[]) => {
       }
 
       const trackId = track.track_id
-      const isStreamGated = track.is_stream_gated
       const hasNftAccessSignature = !!nftAccessSignatureMap[trackId]
       const isCollectibleGated = isContentCollectibleGated(
         track.stream_conditions
@@ -94,7 +97,7 @@ export const useGatedContentAccessMap = (tracks: Partial<Track>[]) => {
 
       map[trackId] = {
         isFetchingNFTAccess: !hasNftAccessSignature && isSignatureToBeFetched,
-        hasStreamAccess: !isStreamGated
+        hasStreamAccess: !track.is_stream_gated || !!track.access?.stream
       }
     })
 

--- a/packages/web/src/common/store/lineup/sagas.js
+++ b/packages/web/src/common/store/lineup/sagas.js
@@ -382,7 +382,9 @@ function* play(lineupActions, lineupSelector, prefix, action) {
   // If preview isn't forced, check for track acccess and switch to preview
   // if the user doesn't have access but the track is previewable
   if (!isPreview && requestedPlayTrack?.is_stream_gated) {
-    const hasAccess = !!requestedPlayTrack?.access?.stream
+    const hasAccess =
+      !requestedPlayTrack?.is_stream_gated ||
+      !!requestedPlayTrack?.access?.stream
     isPreview = !hasAccess && !!requestedPlayTrack.preview_cid
   }
 

--- a/packages/web/src/common/store/pages/signon/selectors.ts
+++ b/packages/web/src/common/store/pages/signon/selectors.ts
@@ -42,7 +42,8 @@ export const getIsSocialConnected = (state: AppState) =>
   !!state.signOn.tikTokId ||
   !!state.signOn.instagramId
 export const getAccountReady = (state: AppState) => state.signOn.accountReady
-export const getAccountAlreadyExisted = (state: AppState) => state.signOn.accountAlreadyExisted
+export const getAccountAlreadyExisted = (state: AppState) =>
+  state.signOn.accountAlreadyExisted
 export const getStartedSignUpProcess = (state: AppState) =>
   state.signOn.startedSignUpProcess
 export const getFinishedSignUpProcess = (state: AppState) =>

--- a/packages/web/src/common/store/player/sagas.ts
+++ b/packages/web/src/common/store/player/sagas.ts
@@ -197,7 +197,8 @@ export function* watchPlay() {
 
     // Play if user has access to track.
     const track = yield* select(getTrack, { id: trackId })
-    const doesUserHaveStreamAccess = !!track?.access?.stream
+    const doesUserHaveStreamAccess =
+      !track?.is_stream_gated || !!track?.access?.stream
     if (!trackId || doesUserHaveStreamAccess || isPreview) {
       audioPlayer.play()
       yield* put(playSucceeded({ uid, trackId, isPreview }))

--- a/packages/web/src/common/store/queue/sagas.ts
+++ b/packages/web/src/common/store/queue/sagas.ts
@@ -89,7 +89,8 @@ export function* getToQueue(prefix: string, entry: { kind: Kind; uid: UID }) {
     const track = yield* select(getTrack, { uid: entry.uid })
     const currentUserId = yield* select(getUserId)
     if (!track) return {}
-    const doesUserHaveStreamAccess = !!track.access.stream
+    const doesUserHaveStreamAccess =
+      !track.is_stream_gated || !!track.access.stream
     return {
       id: track.track_id,
       uid: entry.uid,
@@ -336,7 +337,8 @@ export function* watchNext() {
     const track = yield* select(getTrack, { id })
     const user = yield* select(getUser, { id: track?.owner_id })
     const currentUserId = yield* select(getUserId)
-    const doesUserHaveStreamAccess = !!track?.access?.stream
+    const doesUserHaveStreamAccess =
+      !track?.is_stream_gated || !!track?.access?.stream
 
     // Skip deleted, owner deactivated, or locked gated track
     if (
@@ -447,7 +449,8 @@ export function* watchPrevious() {
       const source = yield* select(getSource)
       const user = yield* select(getUser, { id: track?.owner_id })
       const currentUserId = yield* select(getUserId)
-      const doesUserHaveStreamAccess = !!track?.access?.stream
+      const doesUserHaveStreamAccess =
+        !track?.is_stream_gated || !!track?.access?.stream
 
       // If we move to a previous song that's been
       // deleted or to which the user does not have access, skip over it.

--- a/packages/web/src/components/play-bar/desktop/PlayBar.jsx
+++ b/packages/web/src/components/play-bar/desktop/PlayBar.jsx
@@ -476,9 +476,10 @@ const makeMapStateToProps = () => {
       if (entry.kind !== Kind.TRACKS) return false
 
       const { id } = entry
-      const { access } = getTrack(state, { id }) ?? {}
+      const { access, is_stream_gated: isStreamGated } =
+        getTrack(state, { id }) ?? {}
 
-      return !!access?.stream
+      return !isStreamGated || !!access?.stream
     })
 
     return {

--- a/packages/web/src/pages/sign-up-page/utils/useDetermineAllowedRoutes.ts
+++ b/packages/web/src/pages/sign-up-page/utils/useDetermineAllowedRoutes.ts
@@ -2,7 +2,10 @@ import { accountSelectors } from '@audius/common'
 import { useSelector } from 'react-redux'
 
 import { useModalState } from 'common/hooks/useModalState'
-import { getAccountAlreadyExisted, getSignOn } from 'common/store/pages/signon/selectors'
+import {
+  getAccountAlreadyExisted,
+  getSignOn
+} from 'common/store/pages/signon/selectors'
 import { EditingStatus } from 'common/store/pages/signon/types'
 import { SignUpPath } from 'utils/route'
 
@@ -80,15 +83,15 @@ export const useDetermineAllowedRoute = () => {
 
     const isAllowedRoute = allowedRoutes.includes(attemptedPath)
     // If requested route is allowed return that, otherwise return the last step in the route stack
-    const correctedPath = 
+    const correctedPath =
       attemptedPath === '/signup' && hasAlreadySignedUp
-      ? allowedRoutes[allowedRoutes.length - 1]
-      : isAllowedRoute
-      ? attemptedPath
-      : // IF we attempted to go to /signup directly, that means it was a link from somewhere else in the app, so we should start back at the beginning
-      attemptedPath === '/signup'
-      ? allowedRoutes[0]
-      : allowedRoutes[allowedRoutes.length - 1]
+        ? allowedRoutes[allowedRoutes.length - 1]
+        : isAllowedRoute
+        ? attemptedPath
+        : // IF we attempted to go to /signup directly, that means it was a link from somewhere else in the app, so we should start back at the beginning
+        attemptedPath === '/signup'
+        ? allowedRoutes[0]
+        : allowedRoutes[allowedRoutes.length - 1]
 
     if (correctedPath === SignUpPath.completedRedirect) {
       setIsWelcomeModalOpen(true)


### PR DESCRIPTION
### Description

These changes highlight why fully relying on DN for track access is much better/simpler/less prone to bugs for clients.

- Have client check whether track is stream/download gated for access. This fixes the bug where tracks are locked when user is logged out.
- Fix bug where tables incorrectly show tracks as locked.

### How Has This Been Tested?

local web dapp vs stage
