### PR TITLE
add timeout to ga for faster healthz response

### DIFF
--- a/monitoring/healthz/src/useServiceProviders.ts
+++ b/monitoring/healthz/src/useServiceProviders.ts
@@ -24,10 +24,14 @@ export function apiGatewayFetcher(
   env: string,
   type: 'content' | 'discovery'
 ) {
-  return fetch(`${env == 'staging' ? stagingEndpoint : prodEndpoint}/${type}/verbose?all=true`)
+  // abort initial ga request in 5 seconds
+  const controller = new AbortController()
+  const reqTimeout = setTimeout(() => controller.abort(), 5000)
+  return fetch(`${env == 'staging' ? stagingEndpoint : prodEndpoint}/${type}/verbose?all=true`, { signal: controller.signal })
     .then(async (resp) => {
       const data = await resp.json()
       const sps = data.data as SP[]
+      clearTimeout(reqTimeout)
 
       const hostSortKey = (sp: SP) =>
         new URL(sp.endpoint).hostname.split('.').reverse().join('.')


### PR DESCRIPTION
### Description
timeout ga request to five seconds and load from chain, otherwise it's a lot longer to see nodes on healthz
### How Has This Been Tested?
npm run dev, check stage when stage ga is down
