### PR TITLE
[C-3702 C-3672] Fix sign-up cover-photo issues

### DIFF
--- a/packages/common/src/messages/sign-on/pages.ts
+++ b/packages/common/src/messages/sign-on/pages.ts
@@ -122,9 +122,9 @@ export const selectArtstsPageMessages = {
 }
 
 export const welcomeModalMessages = {
-  welcome: 'Welcome to Audius! 🎉',
+  welcome: 'Welcome to Audius%0! 🎉',
   startListening: 'Start Listening',
   upload: 'Upload',
   youreIn:
-    'You’re in! Discover music from our talented DJs, producers, and artists.'
+    "You're in! Discover music from our talented DJs, producers, and artists."
 }

--- a/packages/web/src/components/welcome-modal/WelcomeModal.tsx
+++ b/packages/web/src/components/welcome-modal/WelcomeModal.tsx
@@ -42,6 +42,7 @@ export const WelcomeModal = () => {
     userId as number,
     SquareSizes.SIZE_150_BY_150
   )
+
   const userName = nameField ?? accountName
   const [isOpen, setIsOpen] = useModalState('Welcome')
 
@@ -83,8 +84,14 @@ export const WelcomeModal = () => {
         css={{ overflow: 'hidden' }}
       >
         <Flex direction='column' css={{ textAlign: 'center' }} gap='l'>
-          <Text variant='label' size='xl' strength='strong' id='welcome-title'>
-            {fillString(messages.welcome, userName ? `, ${userName}` : '')}
+          <Text
+            variant='label'
+            size='xl'
+            strength='strong'
+            id='welcome-title'
+            color='accent'
+          >
+            {fillString(messages.welcome, userName ? `, ${userName}` : ' ')}
           </Text>
           <Text variant='body' size='l'>
             {messages.youreIn}

--- a/packages/web/src/pages/sign-up-page/components/AccountHeader.tsx
+++ b/packages/web/src/pages/sign-up-page/components/AccountHeader.tsx
@@ -37,6 +37,8 @@ type AccountHeaderProps = {
   formProfileImage?: ImageFieldValue
   onProfileImageChange?: (value: ImageFieldValue) => void
   onCoverPhotoChange?: (value: ImageFieldValue) => void
+  // If true, the banner will be rendered as a paper header
+  isPaperHeader?: boolean
 }
 
 const ProfileImageAvatar = ({
@@ -88,7 +90,8 @@ export const AccountHeader = (props: AccountHeaderProps) => {
     formProfileImage,
     onProfileImageChange,
     onCoverPhotoChange,
-    size
+    size,
+    isPaperHeader
   } = props
   const profileImageField = useSelector(getProfileImageField)
   const { value: displayNameField } = useSelector(getNameField)
@@ -150,11 +153,12 @@ export const AccountHeader = (props: AccountHeaderProps) => {
                 coverPhotoUrl={uploadedImage?.url}
                 profileImageUrl={formProfileImage?.url}
                 isEditing
+                isPaperHeader={isPaperHeader}
               />
             )}
           </ImageField>
         ) : (
-          <CoverPhotoBanner />
+          <CoverPhotoBanner isPaperHeader={isPaperHeader} />
         )}
       </Box>
       <Flex

--- a/packages/web/src/pages/sign-up-page/components/CoverPhotoBanner.tsx
+++ b/packages/web/src/pages/sign-up-page/components/CoverPhotoBanner.tsx
@@ -19,13 +19,16 @@ type CoverPhotoBannerProps = {
   coverPhotoUrl?: string
   profileImageUrl?: string
   isEditing?: boolean
+  // If true, the banner will be rendered as a paper header
+  isPaperHeader?: boolean
 }
 
 export const CoverPhotoBanner = (props: CoverPhotoBannerProps) => {
   const {
     coverPhotoUrl: propsCoverPhotoUrl,
     profileImageUrl: propsProfileImageUrl,
-    isEditing
+    isEditing,
+    isPaperHeader
   } = props
   const coverPhotoField = useSelector(getCoverPhotoField)
   const profileImageField = useSelector(getProfileImageField)
@@ -40,7 +43,11 @@ export const CoverPhotoBanner = (props: CoverPhotoBannerProps) => {
     WidthSizes.SIZE_640
   )
   const accountCoverPhoto =
-    accountCoverPhotoObj.source === '' ? undefined : accountCoverPhotoObj.source
+    accountCoverPhotoObj.source === ''
+      ? undefined
+      : accountCoverPhotoObj.shouldBlur
+      ? undefined
+      : accountCoverPhotoObj.source
 
   const { color, spacing, cornerRadius } = useTheme()
   const coverPhoto =
@@ -48,14 +55,14 @@ export const CoverPhotoBanner = (props: CoverPhotoBannerProps) => {
   const profileImage =
     propsProfileImageUrl ?? profileImageField?.url ?? accountProfilePic
   const hasImage = coverPhoto || profileImage
+
+  const hasCurvedBorder = isEditing || isPaperHeader
+
   return (
     <Box
       h='100%'
       w='100%'
-      borderRadius={isEditing ? 'm' : undefined}
       css={{
-        borderBottomLeftRadius: 0,
-        borderBottomRightRadius: 0,
         '&:before': {
           content: '""',
           position: 'absolute',
@@ -72,7 +79,7 @@ export const CoverPhotoBanner = (props: CoverPhotoBannerProps) => {
                 backdropFilter: 'blur(25px)'
               }
             : undefined),
-          ...(isEditing && {
+          ...(hasCurvedBorder && {
             overflow: 'hidden',
             cursor: 'pointer',
             borderTopLeftRadius: cornerRadius.m,

--- a/packages/web/src/pages/sign-up-page/components/SocialMediaLoginOptions.tsx
+++ b/packages/web/src/pages/sign-up-page/components/SocialMediaLoginOptions.tsx
@@ -68,8 +68,8 @@ export const SocialMediaLoginOptions = ({
         >
           <SocialButton
             type='button'
-            fullWidth
             socialType='twitter'
+            css={{ width: '100%' }}
             aria-label={socialMediaMessages.signUpTwitter}
           />
         </SignupFlowTwitterAuth>
@@ -83,9 +83,8 @@ export const SocialMediaLoginOptions = ({
         >
           <SocialButton
             type='button'
-            fullWidth
             socialType='instagram'
-            css={{ flex: 1 }}
+            css={{ width: '100%' }}
             aria-label={socialMediaMessages.signUpInstagram}
           />
         </SignupFlowInstagramAuth>
@@ -99,8 +98,8 @@ export const SocialMediaLoginOptions = ({
           >
             <SocialButton
               type='button'
-              fullWidth
               socialType='tiktok'
+              css={{ width: '100%' }}
               aria-label={socialMediaMessages.signUpTikTok}
             />
           </SignupFlowTikTokAuth>

--- a/packages/web/src/pages/sign-up-page/pages/ReviewHandlePage.tsx
+++ b/packages/web/src/pages/sign-up-page/pages/ReviewHandlePage.tsx
@@ -86,7 +86,7 @@ export const ReviewHandlePage = () => {
           />
           {hasImages ? (
             <Paper gap='xl' direction='column'>
-              <AccountHeader mode='viewing' size='small' />
+              <AccountHeader mode='viewing' size='small' isPaperHeader />
               <HandleField autoFocus css={{ padding: spacing.l }} />
             </Paper>
           ) : (


### PR DESCRIPTION
### Description

- Fixes issue where welcome-modal cover-photo wasn't blurring. This is due to `useCoverPhoto` returning `shouldBlur` attribute that wasn't being taken into account. Long term we should improve cover-photo to be a component that handles everything correctly
- Fixes issue were "review handle" cover-photo didn't have border-radius. We assumed "isEditing" a sufficient condition for showing border-radius, but it's more to do with being in a Paper component. Don't love the solve, which is to add a `isInPaper` like prop, but given how close we are to launch this was easiest.
- Fixes issue where social buttons don't have scale animation cause `fullWidth` was true... this is a good case of blocking scale animation on fullWidth is wrong. for now just added width: 100% manually, which is what fullWidth does.
