### PR TITLE
[C-3712, C-3719] Fix loading of suggested tracks

### DIFF
--- a/packages/common/src/api/suggestedTracks.ts
+++ b/packages/common/src/api/suggestedTracks.ts
@@ -43,7 +43,8 @@ const skeletons = [...Array(suggestedTrackCount)].map((_, index) => ({
 
 const selectSuggestedTracks = (
   state: CommonState,
-  ids: ID[]
+  ids: ID[],
+  maxLength = suggestedTrackCount
 ): SuggestedTrack[] => {
   const suggestedTracks = ids
     .map((id) => {
@@ -56,7 +57,7 @@ const selectSuggestedTracks = (
 
   return [...suggestedTracks, ...skeletons].slice(
     0,
-    Math.min(ids.length, suggestedTrackCount)
+    Math.min(maxLength, suggestedTrackCount)
   )
 }
 
@@ -98,7 +99,8 @@ export const useGetSuggestedAlbumTracks = (collectionId: ID) => {
     (state: CommonState) =>
       selectSuggestedTracks(
         state,
-        suggestedTrackIds.slice(0, suggestedTrackCount)
+        suggestedTrackIds.slice(0, suggestedTrackCount),
+        suggestedTrackIds.length
       ),
     isEqual
   )

--- a/packages/common/src/api/suggestedTracks.ts
+++ b/packages/common/src/api/suggestedTracks.ts
@@ -2,7 +2,6 @@ import { useCallback, useEffect, useState } from 'react'
 
 import { difference, isEqual, shuffle } from 'lodash'
 import { useSelector, useDispatch } from 'react-redux'
-import { useCustomCompareEffect } from 'react-use'
 
 import { usePaginatedQuery } from 'audius-query'
 import { ID } from 'models/Identifiers'
@@ -37,8 +36,8 @@ export type SuggestedTrack =
   | { isLoading: true; id: ID; key: ID }
   | { isLoading: false; id: ID; track: Track; key: ID }
 
-const skeletons = [...Array(5)].map((_, index) => ({
-  key: index + 5,
+const skeletons = [...Array(suggestedTrackCount)].map((_, index) => ({
+  key: index + suggestedTrackCount,
   isLoading: true as const
 }))
 
@@ -55,7 +54,10 @@ const selectSuggestedTracks = (
     })
     .filter(removeNullable)
 
-  return [...suggestedTracks, ...skeletons].slice(0, 5)
+  return [...suggestedTracks, ...skeletons].slice(
+    0,
+    Math.min(ids.length, suggestedTrackCount)
+  )
 }
 
 const selectCollectionTrackIds = (state: CommonState, collectionId: ID) => {
@@ -79,20 +81,18 @@ export const useGetSuggestedAlbumTracks = (collectionId: ID) => {
     { disabled: !currentUserId }
   )
 
-  useCustomCompareEffect(
-    () => {
-      if (status === Status.SUCCESS && ownTracks) {
-        const suggestedTrackIds = difference(
-          shuffle(ownTracks).map((track) => track.track_id),
-          collectionTrackIds
-        )
-        setSuggestedTrackIds(suggestedTrackIds)
-      }
-      // eslint-disable-next-line react-hooks/exhaustive-deps
-    },
-    [status, ownTracks?.length],
-    isEqual
-  )
+  const reset = useCallback(() => {
+    if (status === Status.SUCCESS && ownTracks) {
+      const suggestedTrackIds = difference(
+        shuffle(ownTracks).map((track) => track.track_id),
+        collectionTrackIds
+      )
+      setSuggestedTrackIds(suggestedTrackIds)
+    }
+  }, [collectionTrackIds, ownTracks, status])
+
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  useEffect(reset, [status, ownTracks?.length])
 
   const suggestedTracks = useSelector(
     (state: CommonState) =>
@@ -104,9 +104,14 @@ export const useGetSuggestedAlbumTracks = (collectionId: ID) => {
   )
 
   const handleRefresh = useCallback(() => {
+    // Reset and shuffle owned tracks if we get too close to the end
+    if (suggestedTrackIds.length <= 2 * suggestedTrackCount - 1) {
+      reset()
+      return
+    }
     setSuggestedTrackIds(suggestedTrackIds.slice(suggestedTrackCount))
     setIsRefreshing(true)
-  }, [suggestedTrackIds])
+  }, [reset, suggestedTrackIds])
 
   useEffect(() => {
     if (suggestedTracks.every((suggestedTrack) => !suggestedTrack.isLoading)) {
@@ -185,7 +190,7 @@ export const useGetSuggestedPlaylistTracks = (collectionId: ID) => {
   }, [trendingStatus])
 
   useEffect(() => {
-    if (suggestedTrackIds.length < 5) {
+    if (suggestedTrackIds.length < suggestedTrackCount) {
       loadMore()
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/packages/web/src/components/suggested-tracks/components/SuggestedTracks.tsx
+++ b/packages/web/src/components/suggested-tracks/components/SuggestedTracks.tsx
@@ -27,8 +27,6 @@ import styles from './SuggestedTracks.module.css'
 
 const { getUser } = cacheUsersSelectors
 
-const contentHeight = 423
-
 const messages = {
   title: 'Add some tracks',
   addTrack: 'Add',
@@ -107,6 +105,7 @@ export const SuggestedTracks = (props: SuggestedTracksProps) => {
 
   const divider = <Divider className={styles.trackDivider} />
 
+  const contentHeight = 66 + suggestedTracks.length * 74
   const contentStyles = useSpring({
     height: isExpanded ? contentHeight : 0
   })


### PR DESCRIPTION
### Description

- Remove usage of `useCustomCompareEffect`
- Fix loading of suggested tracks
	- Don't show loading skeletons when there are no more owned tracks to load
	- Shrink suggested tracks height on accounts with fewer than 5 tracks to match content
	- Reload ownTracks before hitting the last page of the lineup; reshuffle and start over instead

### How Has This Been Tested?

local web and mobile both exhibiting correct loading behavior for suggested tracks