### PR TITLE
[PAY-2394][PAY-2391][PAY-2393] Address misc coinflow withdrawal ux

### DIFF
--- a/packages/web/src/components/withdraw-usdc-modal/WithdrawUSDCModal.tsx
+++ b/packages/web/src/components/withdraw-usdc-modal/WithdrawUSDCModal.tsx
@@ -59,6 +59,11 @@ const messages = {
 
 const MINIMUM_MANUAL_TRANSFER_AMOUNT_CENTS = 1
 
+const DISABLE_MODAL_CLOSE_PAGES = new Set([
+  WithdrawUSDCModalPages.PREPARE_TRANSFER,
+  WithdrawUSDCModalPages.TRANSFER_IN_PROGRESS
+])
+
 const WithdrawUSDCFormSchema = (
   userBalanceCents: number,
   minWithdrawBalanceCents: number
@@ -228,9 +233,13 @@ export const WithdrawUSDCModal = () => {
       isOpen={isOpen}
       onClose={onClose}
       onClosed={handleOnClosed}
+      dismissOnClickOutside={DISABLE_MODAL_CLOSE_PAGES.has(page)}
       bodyClassName={styles.modal}
     >
-      <ModalHeader onClose={onClose}>
+      <ModalHeader
+        onClose={onClose}
+        showDismissButton={DISABLE_MODAL_CLOSE_PAGES.has(page)}
+      >
         <Text
           variant='label'
           color='neutralLight2'

--- a/packages/web/src/components/withdraw-usdc-modal/WithdrawUSDCModal.tsx
+++ b/packages/web/src/components/withdraw-usdc-modal/WithdrawUSDCModal.tsx
@@ -233,12 +233,12 @@ export const WithdrawUSDCModal = () => {
       isOpen={isOpen}
       onClose={onClose}
       onClosed={handleOnClosed}
-      dismissOnClickOutside={DISABLE_MODAL_CLOSE_PAGES.has(page)}
+      dismissOnClickOutside={!DISABLE_MODAL_CLOSE_PAGES.has(page)}
       bodyClassName={styles.modal}
     >
       <ModalHeader
         onClose={onClose}
-        showDismissButton={DISABLE_MODAL_CLOSE_PAGES.has(page)}
+        showDismissButton={!DISABLE_MODAL_CLOSE_PAGES.has(page)}
       >
         <Text
           variant='label'

--- a/packages/web/src/components/withdraw-usdc-modal/WithdrawUSDCModal.tsx
+++ b/packages/web/src/components/withdraw-usdc-modal/WithdrawUSDCModal.tsx
@@ -61,7 +61,9 @@ const MINIMUM_MANUAL_TRANSFER_AMOUNT_CENTS = 1
 
 const DISABLE_MODAL_CLOSE_PAGES = new Set([
   WithdrawUSDCModalPages.PREPARE_TRANSFER,
-  WithdrawUSDCModalPages.TRANSFER_IN_PROGRESS
+  WithdrawUSDCModalPages.TRANSFER_IN_PROGRESS,
+  WithdrawUSDCModalPages.COINFLOW_TRANSFER,
+  WithdrawUSDCModalPages.CONFIRM_TRANSFER_DETAILS
 ])
 
 const WithdrawUSDCFormSchema = (

--- a/packages/web/src/components/withdraw-usdc-modal/components/TransferSuccessful.tsx
+++ b/packages/web/src/components/withdraw-usdc-modal/components/TransferSuccessful.tsx
@@ -104,7 +104,7 @@ export const TransferSuccessful = ({
           balanceStatus === Status.SUCCESS ? `$${balanceFormatted}` : undefined
         }
       />
-      {methodValue !== WithdrawMethod.MANUAL_TRANSFER ? (
+      {methodValue !== WithdrawMethod.MANUAL_TRANSFER && signature ? (
         <>
           <Divider style={{ margin: 0 }} />
           <div className={styles.destination}>


### PR DESCRIPTION
### Description

* Prevent modal from closing when on the "Hold" stages and "Coinflow" stages
* Recognize transfer in withdrawals to root account and display as Cash (wallet)
* Hide the link to the explorer in the success page

![image](https://github.com/AudiusProject/audius-protocol/assets/2731362/114b45cc-7013-4f1e-b30f-8f9b48723662)

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._

```
npm run web:prod
```