### PR TITLE
Fix payment router recovery indexing using wrong address for comparison

### DIFF
--- a/packages/discovery-provider/integration_tests/tasks/test_index_payment_router.py
+++ b/packages/discovery-provider/integration_tests/tasks/test_index_payment_router.py
@@ -351,7 +351,7 @@ def test_process_payment_router_tx_details_transfer_recovery(app):
             "method": USDCTransactionMethod.send,
             "change": -1000000,
             "balance": 0,
-            "tx_metadata": transactionSenderUsdcAccount,
+            "tx_metadata": transactionSenderAddress,
         }
     ]
 
@@ -400,7 +400,7 @@ def test_process_payment_router_tx_details_transfer_partial_recovery(
             "method": USDCTransactionMethod.send,
             "change": -2000000,
             "balance": 0,
-            "tx_metadata": transactionSenderUsdcAccount,
+            "tx_metadata": transactionSenderAddress,
         }
     ]
 
@@ -451,7 +451,7 @@ def test_process_payment_router_tx_details_transfer_over_recovery(
             "method": USDCTransactionMethod.send,
             "change": -500000,
             "balance": 0,
-            "tx_metadata": transactionSenderUsdcAccount,
+            "tx_metadata": transactionSenderAddress,
         }
     ]
 

--- a/packages/discovery-provider/integration_tests/tasks/test_index_payment_router.py
+++ b/packages/discovery-provider/integration_tests/tasks/test_index_payment_router.py
@@ -37,7 +37,7 @@ thirdPartyId = 3
 thirdPartyUserBank = "7dw7W4Yv7F1uWb9dVH1CFPm39mePyypuCji2zxcFA556"
 
 # Used as the source wallet for all the mock transactions
-transactionSenderAddress = "HXLN9UWwAjMPgHaFZDfgabT79SmLSdTeu2fUha2xHz9W"
+transactionSenderOwnerAccount = "HXLN9UWwAjMPgHaFZDfgabT79SmLSdTeu2fUha2xHz9W"
 
 test_entries = {
     "users": [
@@ -258,7 +258,7 @@ def test_process_payment_router_tx_details_transfer_without_purchase(
         assert transaction_record.method == USDCTransactionMethod.receive
         assert transaction_record.change == 1000000
         # For transfers, source is the owning wallet unless it's a transfer from a user bank
-        assert transaction_record.tx_metadata == transactionSenderAddress
+        assert transaction_record.tx_metadata == transactionSenderOwnerAccount
 
 
 def test_process_payment_router_tx_details_transfer_from_user_bank_without_purchase(
@@ -350,7 +350,7 @@ def test_process_payment_router_tx_details_transfer_recovery(app):
             "method": USDCTransactionMethod.send,
             "change": -1000000,
             "balance": 0,
-            "tx_metadata": transactionSenderAddress,
+            "tx_metadata": transactionSenderOwnerAccount,
         }
     ]
 
@@ -399,7 +399,7 @@ def test_process_payment_router_tx_details_transfer_partial_recovery(
             "method": USDCTransactionMethod.send,
             "change": -2000000,
             "balance": 0,
-            "tx_metadata": transactionSenderAddress,
+            "tx_metadata": transactionSenderOwnerAccount,
         }
     ]
 
@@ -419,7 +419,9 @@ def test_process_payment_router_tx_details_transfer_partial_recovery(
             session.query(USDCTransactionsHistory)
             .filter(USDCTransactionsHistory.signature == "existingWithdrawal")
             .filter(USDCTransactionsHistory.user_bank == trackOwnerUserBank)
-            .filter(USDCTransactionsHistory.tx_metadata == transactionSenderAddress)
+            .filter(
+                USDCTransactionsHistory.tx_metadata == transactionSenderOwnerAccount
+            )
             .first()
         )
         # Recovery transaction was for half of the original amount, expect the difference
@@ -450,7 +452,7 @@ def test_process_payment_router_tx_details_transfer_over_recovery(
             "method": USDCTransactionMethod.send,
             "change": -500000,
             "balance": 0,
-            "tx_metadata": transactionSenderAddress,
+            "tx_metadata": transactionSenderOwnerAccount,
         }
     ]
 
@@ -470,7 +472,9 @@ def test_process_payment_router_tx_details_transfer_over_recovery(
             session.query(USDCTransactionsHistory)
             .filter(USDCTransactionsHistory.signature == "existingWithdrawal")
             .filter(USDCTransactionsHistory.user_bank == trackOwnerUserBank)
-            .filter(USDCTransactionsHistory.tx_metadata == transactionSenderAddress)
+            .filter(
+                USDCTransactionsHistory.tx_metadata == transactionSenderOwnerAccount
+            )
             .first()
         )
         # Recovery transaction was for more than the original amount, expect original transaction to be unchanged
@@ -481,7 +485,9 @@ def test_process_payment_router_tx_details_transfer_over_recovery(
             session.query(USDCTransactionsHistory)
             .filter(USDCTransactionsHistory.signature == tx_sig_str)
             .filter(USDCTransactionsHistory.user_bank == trackOwnerUserBank)
-            .filter(USDCTransactionsHistory.tx_metadata == transactionSenderAddress)
+            .filter(
+                USDCTransactionsHistory.tx_metadata == transactionSenderOwnerAccount
+            )
             .first()
         )
 
@@ -561,7 +567,7 @@ def test_process_payment_router_tx_details_transfer_recovery_address_mismatch(
         assert transaction_record.method == USDCTransactionMethod.receive
         assert transaction_record.change == 1000000
         # For transfers, source is the owning wallet unless it's a transfer from a user bank
-        assert transaction_record.tx_metadata == transactionSenderAddress
+        assert transaction_record.tx_metadata == transactionSenderOwnerAccount
 
 
 def test_process_payment_router_tx_details_valid_purchase_with_pay_extra(app):
@@ -794,7 +800,7 @@ def test_process_payment_router_tx_details_invalid_purchase_bad_splits(app):
         assert owner_transaction_record.method == USDCTransactionMethod.receive
         assert owner_transaction_record.change == 1000000
         # For transfers, source is the owning wallet unless it's a transfer from a user bank
-        assert owner_transaction_record.tx_metadata == transactionSenderAddress
+        assert owner_transaction_record.tx_metadata == transactionSenderOwnerAccount
 
         third_party_transaction_record = (
             session.query(USDCTransactionsHistory)
@@ -811,7 +817,9 @@ def test_process_payment_router_tx_details_invalid_purchase_bad_splits(app):
         assert third_party_transaction_record.method == USDCTransactionMethod.receive
         assert third_party_transaction_record.change == 500000
         # For transfers, source is the owning wallet unless it's a transfer from a user bank
-        assert third_party_transaction_record.tx_metadata == transactionSenderAddress
+        assert (
+            third_party_transaction_record.tx_metadata == transactionSenderOwnerAccount
+        )
 
 
 # Transaction is for the correct amount, but one of the splits is missing
@@ -860,7 +868,7 @@ def test_process_payment_router_tx_details_invalid_purchase_missing_splits(app):
         assert owner_transaction_record.method == USDCTransactionMethod.receive
         assert owner_transaction_record.change == 2000000
         # For transfers, source is the owning wallet unless it's a transfer from a user bank
-        assert owner_transaction_record.tx_metadata == transactionSenderAddress
+        assert owner_transaction_record.tx_metadata == transactionSenderOwnerAccount
 
 
 def test_process_payment_router_tx_details_transfer_multiple_users_without_purchase(
@@ -909,7 +917,7 @@ def test_process_payment_router_tx_details_transfer_multiple_users_without_purch
         assert owner_transaction_record.method == USDCTransactionMethod.receive
         assert owner_transaction_record.change == 1000000
         # For transfers, source is the owning wallet unless it's a transfer from a user bank
-        assert owner_transaction_record.tx_metadata == transactionSenderAddress
+        assert owner_transaction_record.tx_metadata == transactionSenderOwnerAccount
 
         third_party_transaction_record = (
             session.query(USDCTransactionsHistory)
@@ -926,7 +934,9 @@ def test_process_payment_router_tx_details_transfer_multiple_users_without_purch
         assert third_party_transaction_record.method == USDCTransactionMethod.receive
         assert third_party_transaction_record.change == 1000000
         # For transfers, source is the owning wallet unless it's a transfer from a user bank
-        assert third_party_transaction_record.tx_metadata == transactionSenderAddress
+        assert (
+            third_party_transaction_record.tx_metadata == transactionSenderOwnerAccount
+        )
 
 
 def test_process_payment_router_txs_details_create_challenge_events_for_purchase(app):

--- a/packages/discovery-provider/src/tasks/index_payment_router.py
+++ b/packages/discovery-provider/src/tasks/index_payment_router.py
@@ -428,7 +428,8 @@ def attempt_index_recovery_transfer(
             and_(
                 USDCTransactionsHistory.user_bank == receiver_bank_account,
                 USDCTransactionsHistory.method == USDCTransactionMethod.send,
-                # External transfers are indexed on the owner of the token account
+                # The original transaction will be indexed with the owner account
+                # of the original recipient
                 USDCTransactionsHistory.tx_metadata == sender_account_owner,
             )
         )

--- a/packages/discovery-provider/src/tasks/index_payment_router.py
+++ b/packages/discovery-provider/src/tasks/index_payment_router.py
@@ -180,6 +180,16 @@ def get_highest_payment_router_tx_slot(session: Session):
     return slot
 
 
+def get_account_owner_from_balance_change(
+    sender_account: str, balance_changes: dict[str, BalanceChange]
+):
+    """Finds the owner of the sender account by looking at the balance changes"""
+    if sender_account in balance_changes:
+        return balance_changes[sender_account]["owner"]
+    else:
+        return None
+
+
 # Cache the latest value committed to DB in redis
 # Used for quick retrieval in health check
 def cache_latest_sol_payment_router_db_tx(redis: Redis, tx):
@@ -397,6 +407,14 @@ def attempt_index_recovery_transfer(
             f"Recovery transfer must have exactly one receiver account. Received: {','.join([a['user_bank_account'] for a in receiver_user_accounts])}"
         )
 
+    sender_account_owner = get_account_owner_from_balance_change(
+        sender_account=sender_account, balance_changes=balance_changes
+    )
+    if sender_account_owner is None:
+        raise Exception(
+            f"Unexpectedly found no owner account for sender account {sender_account}"
+        )
+
     receiver_user_account = receiver_user_accounts[0]
     receiver_bank_account = receiver_user_account["user_bank_account"]
     receiver_balance_change = balance_changes[receiver_bank_account]
@@ -410,7 +428,8 @@ def attempt_index_recovery_transfer(
             and_(
                 USDCTransactionsHistory.user_bank == receiver_bank_account,
                 USDCTransactionsHistory.method == USDCTransactionMethod.send,
-                USDCTransactionsHistory.tx_metadata == sender_account,
+                # External transfers are indexed on the owner of the token account
+                USDCTransactionsHistory.tx_metadata == sender_account_owner,
             )
         )
         .order_by(desc(USDCTransactionsHistory.transaction_created_at))
@@ -457,6 +476,16 @@ def index_transfer(
     timestamp: datetime,
     tx_sig: str,
 ):
+    sender_metadata_address = sender_account
+    # If sending account was a user bank, leave that as the address
+    # Otherwise, map it to an owning solana wallet
+    if sender_user_account is None:
+        sender_metadata_address = (
+            get_account_owner_from_balance_change(
+                sender_account=sender_account, balance_changes=balance_changes
+            )
+            or sender_account
+        )
     for user_account in receiver_user_accounts:
         balance_change = balance_changes[user_account["user_bank_account"]]
         usdc_tx_received = USDCTransactionsHistory(
@@ -468,7 +497,7 @@ def index_transfer(
             transaction_created_at=timestamp,
             change=Decimal(balance_change["change"]),
             balance=Decimal(balance_change["post_balance"]),
-            tx_metadata=sender_account,
+            tx_metadata=sender_metadata_address,
         )
         session.add(usdc_tx_received)
         logger.debug(


### PR DESCRIPTION
### Description
For external transfers from a user bank, our convention is to use the account owner address as the transaction metadata. However, the unit tests for the recovery logic had mistakenly created "existing transaction" mocks using the USDC token account instead. So while the tests passed, they were not testing the actual behavior.
This change updates the logic for indexing external transfers and recoveries in payment router to use the account owner address in cases where the account is not a user bank. This brings it in line with how the user bank indexer works.


### How Has This Been Tested?
Tested locally using (correct) integration tests 😅 
