### PR TITLE
[QA-733] Dedupe albums and playlists on profile

### DIFF
--- a/packages/common/src/store/pages/profile/selectors.ts
+++ b/packages/common/src/store/pages/profile/selectors.ts
@@ -1,3 +1,5 @@
+import { uniq } from 'lodash'
+
 import { getCollections } from 'store/cache/collections/selectors'
 import { getUser, getUsers } from 'store/cache/users/selectors'
 import type { CommonState } from 'store/commonStore'
@@ -104,12 +106,12 @@ export const getProfileCollections = createDeepEqualSelector(
 
 export const getProfileAlbums = createDeepEqualSelector(
   [getProfileCollections],
-  (collections) => collections?.filter(({ is_album }) => is_album)
+  (collections) => uniq(collections?.filter(({ is_album }) => is_album))
 )
 
 export const getProfilePlaylists = createDeepEqualSelector(
   [getProfileCollections],
-  (collections) => collections?.filter(({ is_album }) => !is_album)
+  (collections) => uniq(collections?.filter(({ is_album }) => !is_album))
 )
 
 const sortByDateDesc = (a: Collection, b: Collection) =>

--- a/packages/web/src/pages/profile-page/ProfilePageProvider.tsx
+++ b/packages/web/src/pages/profile-page/ProfilePageProvider.tsx
@@ -42,6 +42,7 @@ import {
 } from '@audius/common'
 import { push as pushRoute, replace } from 'connected-react-router'
 import { UnregisterCallback } from 'history'
+import { uniq } from 'lodash'
 import moment from 'moment'
 import { connect } from 'react-redux'
 import { withRouter, RouteComponentProps } from 'react-router-dom'
@@ -904,8 +905,8 @@ class ProfilePage extends PureComponent<ProfilePageProps, ProfilePageState> {
 
       profile,
       status: profileLoadingStatus,
-      albums,
-      playlists,
+      albums: uniq(albums),
+      playlists: uniq(playlists),
       artistTracks,
       playArtistTrack,
       pauseArtistTrack,


### PR DESCRIPTION
### Description

Wasn't able to repro this bug, so slapping a fix on it for now.

Selector change covers mobile
Provider gets web and mobile web

### How Has This Been Tested?

profiles loading normally