### PR TITLE
Build openresty image on release

### DIFF
--- a/.circleci/src/workflows/release.yml
+++ b/.circleci/src/workflows/release.yml
@@ -21,6 +21,11 @@ jobs:
       service: discovery-provider-notifications
       notify_slack_on_failure: true
   - push-docker-image:
+      name: push-discovery-provider-openresty
+      context: [Vercel, dockerhub]
+      service: discovery-provider-openresty
+      notify_slack_on_failure: true
+  - push-docker-image:
       name: push-pedalboard-trending-challenge-rewards
       context: [Vercel, dockerhub, slack-secrets]
       service: trending-challenge-rewards
@@ -180,6 +185,7 @@ jobs:
         - push-identity-service
         - push-mediorum
         - push-discovery-provider
+        - push-discovery-provider-openresty
         - push-discovery-provider-notifications
         - push-pedalboard-trending-challenge-rewards
         - push-pedalboard-relay


### PR DESCRIPTION
### Description
Builds the openresty container in the release workflow and pushes it so that we don't have the following error anymore: `Error response from daemon: manifest for audius/discovery-provider-openresty:e8d15311bb3978c988ef672ceb6b46fc8f6d990d not found: manifest unknown: manifest unknown`