### PR TITLE
Fix electric subgenre select-artist requests

### DIFF
--- a/packages/web/src/pages/sign-up-page/pages/SelectArtistsPage.tsx
+++ b/packages/web/src/pages/sign-up-page/pages/SelectArtistsPage.tsx
@@ -175,7 +175,7 @@ export const SelectArtistsPage = () => {
                       name='genre'
                       label={convertGenreLabelToValue(genre as Genre)}
                       size={isMobile ? 'small' : 'large'}
-                      value={genre}
+                      value={convertGenreLabelToValue(genre as Genre)}
                       isSelected={currentGenre === genre}
                     />
                   ))}


### PR DESCRIPTION
### Description

Fixes issue where select-artist page for electronic sub genres weren't loading. this is because the request should use the subgenre directly, (trap, not electronic - trap)