### PR TITLE
[INF-571] Add sentry logging to SSR worker

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -35509,6 +35509,12 @@
       "version": "18.17.0",
       "license": "MIT"
     },
+    "node_modules/@types/node-cron": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/@types/node-cron/-/node-cron-3.0.11.tgz",
+      "integrity": "sha512-0ikrnug3/IyneSHqCBeslAhlK2aBfYek1fGo4bP4QnZPmiqSGRK+Oy7ZMisLWkesffJvQ1cqAcBnJC+8+nxIAg==",
+      "dev": true
+    },
     "node_modules/@types/node-fetch": {
       "version": "2.6.8",
       "dev": true,
@@ -70154,6 +70160,25 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/node-cron": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/node-cron/-/node-cron-3.0.3.tgz",
+      "integrity": "sha512-dOal67//nohNgYWb+nWmg5dkFdIwDm8EpeGYMekPMrngV3637lqnX0lbUcCtgibHTz6SEz7DAIjKvKDFYCnO1A==",
+      "dependencies": {
+        "uuid": "8.3.2"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/node-cron/node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
     "node_modules/node-dir": {
       "version": "0.1.17",
       "license": "MIT",
@@ -98714,6 +98739,62 @@
         "node": ">=6"
       }
     },
+    "node_modules/toucan-js": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/toucan-js/-/toucan-js-3.3.1.tgz",
+      "integrity": "sha512-9BpkHb/Pzsrtl1ItNq9OEQPnuUHwzce0nV2uG+DYFiQ4fPyiA6mKTBcDwQzcvNkfSER038U+8TzvdkCev+Maww==",
+      "dependencies": {
+        "@sentry/core": "7.76.0",
+        "@sentry/integrations": "7.76.0",
+        "@sentry/types": "7.76.0",
+        "@sentry/utils": "7.76.0"
+      }
+    },
+    "node_modules/toucan-js/node_modules/@sentry/core": {
+      "version": "7.76.0",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-7.76.0.tgz",
+      "integrity": "sha512-M+ptkCTeCNf6fn7p2MmEb1Wd9/JXUWxIT/0QEc+t11DNR4FYy1ZP2O9Zb3Zp2XacO7ORrlL3Yc+VIfl5JTgjfw==",
+      "dependencies": {
+        "@sentry/types": "7.76.0",
+        "@sentry/utils": "7.76.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/toucan-js/node_modules/@sentry/integrations": {
+      "version": "7.76.0",
+      "resolved": "https://registry.npmjs.org/@sentry/integrations/-/integrations-7.76.0.tgz",
+      "integrity": "sha512-4ea0PNZrGN9wKuE/8bBCRrxxw4Cq5T710y8rhdKHAlSUpbLqr/atRF53h8qH3Fi+ec0m38PB+MivKem9zUwlwA==",
+      "dependencies": {
+        "@sentry/core": "7.76.0",
+        "@sentry/types": "7.76.0",
+        "@sentry/utils": "7.76.0",
+        "localforage": "^1.8.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/toucan-js/node_modules/@sentry/types": {
+      "version": "7.76.0",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.76.0.tgz",
+      "integrity": "sha512-vj6z+EAbVrKAXmJPxSv/clpwS9QjPqzkraMFk2hIdE/kii8s8kwnkBwTSpIrNc8GnzV3qYC4r3qD+BXDxAGPaw==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/toucan-js/node_modules/@sentry/utils": {
+      "version": "7.76.0",
+      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-7.76.0.tgz",
+      "integrity": "sha512-40jFD+yfQaKpFYINghdhovzec4IEpB7aAuyH/GtE7E0gLpcqnC72r55krEIVILfqIR2Mlr5OKUzyeoCyWAU/yw==",
+      "dependencies": {
+        "@sentry/types": "7.76.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/touch": {
       "version": "3.1.0",
       "dev": true,
@@ -112625,6 +112706,7 @@
         "morgan": "^1.10.0",
         "pino": "^8.16.1",
         "rate-limiter-flexible": "^2.4.1",
+        "redis": "^4.6.12",
         "uuid": "^9.0.0"
       },
       "devDependencies": {
@@ -112957,6 +113039,19 @@
       },
       "engines": {
         "node": ">= 10.14.2"
+      }
+    },
+    "packages/discovery-provider/plugins/pedalboard/apps/relay/node_modules/@redis/client": {
+      "version": "1.5.13",
+      "resolved": "https://registry.npmjs.org/@redis/client/-/client-1.5.13.tgz",
+      "integrity": "sha512-epkUM9D0Sdmt93/8Ozk43PNjLi36RZzG+d/T1Gdu5AI8jvghonTeLYV69WVWdilvFo+PYxbP0TZ0saMvr6nscQ==",
+      "dependencies": {
+        "cluster-key-slot": "1.1.2",
+        "generic-pool": "3.9.0",
+        "yallist": "4.0.0"
+      },
+      "engines": {
+        "node": ">=14"
       }
     },
     "packages/discovery-provider/plugins/pedalboard/apps/relay/node_modules/@sinonjs/fake-timers": {
@@ -115229,6 +115324,19 @@
         "node": ">=8.10.0"
       }
     },
+    "packages/discovery-provider/plugins/pedalboard/apps/relay/node_modules/redis": {
+      "version": "4.6.12",
+      "resolved": "https://registry.npmjs.org/redis/-/redis-4.6.12.tgz",
+      "integrity": "sha512-41Xuuko6P4uH4VPe5nE3BqXHB7a9lkFL0J29AlxKaIfD6eWO8VO/5PDF9ad2oS+mswMsfFxaM5DlE3tnXT+P8Q==",
+      "dependencies": {
+        "@redis/bloom": "1.2.0",
+        "@redis/client": "1.5.13",
+        "@redis/graph": "1.1.1",
+        "@redis/json": "1.0.6",
+        "@redis/search": "1.1.6",
+        "@redis/time-series": "1.0.5"
+      }
+    },
     "packages/discovery-provider/plugins/pedalboard/apps/relay/node_modules/saxes": {
       "version": "5.0.1",
       "dev": true,
@@ -115526,7 +115634,6 @@
     },
     "packages/discovery-provider/plugins/pedalboard/apps/relay/node_modules/yallist": {
       "version": "4.0.0",
-      "dev": true,
       "license": "ISC"
     },
     "packages/discovery-provider/plugins/pedalboard/apps/relay/node_modules/yargs": {
@@ -119102,6 +119209,7 @@
         "knex": "^2.4.2",
         "moment": "^2.29.4",
         "morgan": "^1.10.0",
+        "node-cron": "^3.0.3",
         "ts-results": "^3.3.0"
       },
       "devDependencies": {
@@ -119111,6 +119219,7 @@
         "@types/jest": "^26.0.22",
         "@types/morgan": "^1.9.2",
         "@types/node": "^15.12.2",
+        "@types/node-cron": "^3.0.11",
         "@types/node-fetch": "^2.6.4",
         "@types/supertest": "^2.0.11",
         "esbuild": "^0.14.38",
@@ -142379,6 +142488,7 @@
         "scrollbar-width": "3.1.1",
         "semver": "6.3.0",
         "tar": "6.1.11",
+        "toucan-js": "3.3.1",
         "type-fest": "2.16.0",
         "typed-redux-saga": "1.3.1",
         "typesafe-actions": "5.1.0",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -181,6 +181,7 @@
     "scrollbar-width": "3.1.1",
     "semver": "6.3.0",
     "tar": "6.1.11",
+    "toucan-js": "3.3.1",
     "type-fest": "2.16.0",
     "typed-redux-saga": "1.3.1",
     "typesafe-actions": "5.1.0",

--- a/packages/web/src/ssr/worker.js
+++ b/packages/web/src/ssr/worker.js
@@ -8,14 +8,25 @@
 
 import { getAssetFromKV } from '@cloudflare/kv-asset-handler'
 import { renderPage } from 'vike/server'
+import { Toucan } from 'toucan-js'
 
 const DEBUG = false
 const BROWSER_CACHE_TTL_SECONDS = 60 * 60 * 24
 
 addEventListener('fetch', (event) => {
+  const sentry = env.SENTRY_DSN
+    ? new Toucan({
+        dsn: env.SENTRY_DSN,
+        context,
+        request
+      })
+    : null
   try {
     event.respondWith(handleEvent(event))
   } catch (e) {
+    if (sentry) {
+      sentry.captureException(e)
+    }
     if (DEBUG) {
       return event.respondWith(
         new Response(e.message || e.toString(), {

--- a/packages/web/src/ssr/worker.js
+++ b/packages/web/src/ssr/worker.js
@@ -14,11 +14,11 @@ const DEBUG = false
 const BROWSER_CACHE_TTL_SECONDS = 60 * 60 * 24
 
 addEventListener('fetch', (event) => {
-  const sentry = env.SENTRY_DSN
+  const sentry = SENTRY_DSN
     ? new Toucan({
-        dsn: env.SENTRY_DSN,
-        context,
-        request
+        dsn: SENTRY_DSN,
+        context: event,
+        request: event.request
       })
     : null
   try {

--- a/packages/web/src/ssr/worker.js
+++ b/packages/web/src/ssr/worker.js
@@ -7,8 +7,10 @@
  */
 
 import { getAssetFromKV } from '@cloudflare/kv-asset-handler'
-import { renderPage } from 'vike/server'
 import { Toucan } from 'toucan-js'
+import { renderPage } from 'vike/server'
+
+/* globals SENTRY_DSN */
 
 const DEBUG = false
 const BROWSER_CACHE_TTL_SECONDS = 60 * 60 * 24

--- a/packages/web/src/ssr/wrangler.toml
+++ b/packages/web/src/ssr/wrangler.toml
@@ -17,6 +17,7 @@ name = "audius-web-ssr-release-candidate"
 
 [env.production]
 name = "audius-web-ssr"
+vars = { SENTRY_DSN = "https://4db9c77b0bd7ae6a935f8bd58c06dad3@o260428.ingest.sentry.io/4506623015124992" }
 
 # Test environment, replace `test` with subdomain
 # Invoke with npx wrangler dev --env test


### PR DESCRIPTION
### Description

* Cloudflare has a sentry integration, but it gets overridden every time the worker is deployed 😂
![image](https://github.com/AudiusProject/audius-protocol/assets/19916043/4cde9694-afcd-46d8-b087-4912a9d4ee39)
* Use `toucan-js` on the worker as our sentry client instead

### How Has This Been Tested?

Confirmed that errors are reported to sentry and piped to #eng-incidents-ssr
