### PR TITLE
[C-3234] Update today date to include time so that tracks uploaded on the same day don't mix

### DIFF
--- a/packages/web/src/components/data-entry/ReleaseDateTriggerLegacy.tsx
+++ b/packages/web/src/components/data-entry/ReleaseDateTriggerLegacy.tsx
@@ -55,8 +55,7 @@ export const ReleaseDateTriggerLegacy = (
   const initialValues = useMemo(() => {
     return {
       [RELEASE_DATE]:
-        trackReleaseDateState ??
-        moment(trackReleaseDateState).startOf('day').toString(),
+        trackReleaseDateState ?? moment(trackReleaseDateState).toString(),
       [RELEASE_DATE_HOUR]: trackReleaseDateState
         ? moment(trackReleaseDateState).format('h:mm')
         : moment().format('h:mm'),

--- a/packages/web/src/pages/upload-page/fields/ReleaseDateField.tsx
+++ b/packages/web/src/pages/upload-page/fields/ReleaseDateField.tsx
@@ -96,7 +96,7 @@ export const ReleaseDateField = () => {
 
   const initialValues = useMemo(() => {
     return {
-      [RELEASE_DATE]: trackReleaseDate ?? moment().startOf('day').toString(),
+      [RELEASE_DATE]: trackReleaseDate ?? moment().toString(),
       [RELEASE_DATE_HOUR]: trackReleaseDate
         ? moment(trackReleaseDate).format('h:mm')
         : moment().format('h:mm'),

--- a/packages/web/src/pages/upload-page/forms/EditCollectionForm.tsx
+++ b/packages/web/src/pages/upload-page/forms/EditCollectionForm.tsx
@@ -50,7 +50,7 @@ export const EditCollectionForm = (props: EditCollectionFormProps) => {
     artwork: null,
     playlist_name: '',
     description: '',
-    release_date: moment().startOf('day').toString(),
+    release_date: moment().toString(),
     trackDetails: {
       genre: null,
       mood: null,

--- a/packages/web/src/pages/upload-page/forms/EditTrackForm.tsx
+++ b/packages/web/src/pages/upload-page/forms/EditTrackForm.tsx
@@ -67,7 +67,7 @@ export const EditTrackForm = (props: EditTrackFormProps) => {
       trackMetadatas: tracks.map((track) => ({
         ...track.metadata,
         description: '',
-        releaseDate: new Date(moment().startOf('day').toString()),
+        releaseDate: new Date(moment().toString()),
         tags: '',
         field_visibility: {
           ...defaultHiddenFields,


### PR DESCRIPTION
### Description
Include the time in the form when uploading tracks and collections so that tracks that have been uploaded on the same day don't mix on the artists profile

NOTE: This PR doesn't fix the issue of the same tracks in an collection appearing in a different order

### How Has This Been Tested?

Locally tested
