### PR TITLE
Add dist and .git directories to .dockerignore to speedup build times

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,6 @@
 **/node_modules
+**/dist
 npm-debug.log
+.git
 
 packages/mobile/ios/Pods


### PR DESCRIPTION
### Description

After noticing that the load build context step takes up to a minute transfering multiple GBs when building images like relay or identity-service ([example here](https://app.circleci.com/pipelines/github/AudiusProject/audius-protocol/50915/workflows/245ad248-5582-4457-be15-3da0292e1151/jobs/665301/parallel-runs/0/steps/0-103)), I narrowed down the problem to being that `.git` and `dist` folders are being included in the build context and copied needlessly into images.

This will save us at least 2GB of data being needlessly piped through the docker daemon and stored on container images, speeding up build times and lowering image sizes.

Note that the top-level .gitignore already includes all dist directories.

### How Has This Been Tested?

Green CI