### PR TITLE
[C-3728] Add dominant genre support to aggregate_user

### DIFF
--- a/packages/discovery-provider/ddl/migrations/0049_dominant_genre.sql
+++ b/packages/discovery-provider/ddl/migrations/0049_dominant_genre.sql
@@ -1,0 +1,7 @@
+begin;
+  alter table aggregate_user
+  add column if not exists dominant_genre varchar default null;
+
+  alter table aggregate_user
+  add column if not exists dominant_genre_count integer not null default 0;
+commit;

--- a/packages/discovery-provider/integration_tests/models/test_aggregate_counters.py
+++ b/packages/discovery-provider/integration_tests/models/test_aggregate_counters.py
@@ -101,6 +101,8 @@ def test_aggregate_counters(app):
                 track_save_count=0,
                 supporter_count=0,
                 supporting_count=0,
+                dominant_genre=None,
+                dominant_genre_count=0,
             ),
         )
 
@@ -117,6 +119,8 @@ def test_aggregate_counters(app):
                 track_save_count=1,
                 supporter_count=0,
                 supporting_count=0,
+                dominant_genre=None,
+                dominant_genre_count=0,
             ),
         )
 

--- a/packages/discovery-provider/integration_tests/tasks/test_update_aggregates.py
+++ b/packages/discovery-provider/integration_tests/tasks/test_update_aggregates.py
@@ -139,7 +139,12 @@ def test_update_aggregate_user(app):
             {"playlist_id": 2, "playlist_owner_id": 1, "is_album": True},
             {"playlist_id": 3, "playlist_owner_id": 2},
         ],
-        "tracks": [{"track_id": 1, "owner_id": 1}, {"track_id": 2, "owner_id": 2}],
+        "tracks": [
+            {"track_id": 1, "owner_id": 1, "genre": "Electronic"},
+            {"track_id": 2, "owner_id": 2, "genre": "Electronic"},
+            {"track_id": 3, "owner_id": 2, "genre": "Pop"},
+            {"track_id": 4, "owner_id": 2, "genre": "Pop"},
+        ],
         "user": [{"user_id": 1}, {"user_id": 2}],
         "follows": [
             {"follower_user_id": 1, "followee_user_id": 2},
@@ -172,6 +177,9 @@ def test_update_aggregate_user(app):
         assert aggregate_user.following_count == 1
         assert aggregate_user.repost_count == 1
         assert aggregate_user.track_save_count == 1
+        # Dominant genre does not update by triggers
+        assert aggregate_user.dominant_genre is None
+        assert aggregate_user.dominant_genre_count == 0
 
         aggregate_user.track_count = 0
         aggregate_user.playlist_count = 0
@@ -193,3 +201,17 @@ def test_update_aggregate_user(app):
         assert aggregate_user.following_count == 1
         assert aggregate_user.repost_count == 1
         assert aggregate_user.track_save_count == 1
+        assert aggregate_user.dominant_genre == "Electronic"
+        assert aggregate_user.dominant_genre_count == 1
+
+        aggregate_user2 = session.query(AggregateUser).filter_by(user_id=2).first()
+        assert aggregate_user2.user_id == 2
+        assert aggregate_user2.track_count == 3
+        assert aggregate_user2.playlist_count == 1
+        assert aggregate_user2.album_count == 0
+        assert aggregate_user2.follower_count == 1
+        assert aggregate_user2.following_count == 1
+        assert aggregate_user2.repost_count == 0
+        assert aggregate_user2.track_save_count == 0
+        assert aggregate_user2.dominant_genre == "Pop"
+        assert aggregate_user2.dominant_genre_count == 2

--- a/packages/discovery-provider/integration_tests/utils.py
+++ b/packages/discovery-provider/integration_tests/utils.py
@@ -454,6 +454,8 @@ def populate_mock_db(db, entities, block_offset=None):
                 following_count=aggregate_user_meta.get("following_count", 0),
                 repost_count=aggregate_user_meta.get("repost_count", 0),
                 track_save_count=aggregate_user_meta.get("track_save_count", 0),
+                dominant_genre=aggregate_user_meta.get("dominant_genre", None),
+                dominant_genre_count=aggregate_user_meta.get("dominant_genre_count", 0),
             )
             session.add(user)
 

--- a/packages/discovery-provider/src/models/users/aggregate_user.py
+++ b/packages/discovery-provider/src/models/users/aggregate_user.py
@@ -1,4 +1,4 @@
-from sqlalchemy import BigInteger, Column, Integer, text
+from sqlalchemy import BigInteger, Column, Integer, String, text
 
 from src.models.base import Base
 from src.models.model_utils import RepresentableMixin
@@ -17,3 +17,5 @@ class AggregateUser(Base, RepresentableMixin):
     track_save_count = Column(BigInteger, server_default=text("0"))
     supporter_count = Column(Integer, nullable=False, server_default=text("0"))
     supporting_count = Column(Integer, nullable=False, server_default=text("0"))
+    dominant_genre = Column(String, nullable=True)
+    dominant_genre_count = Column(Integer, nullable=False, server_default=text("0"))


### PR DESCRIPTION
### Description

Add dominant genre to each user

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._

```
audius-compose test up discovery-provider
docker exec -it audius-protocol-test-test-discovery-provider-1 /bin/sh
pytest integration_tests/tasks/test_update_aggregates.py
```