### PR TITLE
[PAY-2354] Specify quality during track download

### DIFF
--- a/packages/common/src/hooks/useDownloadTrackButtons.ts
+++ b/packages/common/src/hooks/useDownloadTrackButtons.ts
@@ -43,7 +43,17 @@ type LabeledStem = Omit<Stem, 'category'> & { label: string }
 type UseDownloadTrackButtonsArgs = {
   following: boolean
   isOwner: boolean
-  onDownload: (trackID: number, category?: string, parentTrackId?: ID) => void
+  onDownload: ({
+    trackId,
+    category,
+    original,
+    parentTrackId
+  }: {
+    trackId: number
+    category?: string
+    original?: boolean
+    parentTrackId?: ID
+  }) => void
   onNotLoggedInClick?: () => void
 }
 
@@ -165,7 +175,7 @@ const getStemButtons = ({
           if (!isLoggedIn) {
             onNotLoggedInClick?.()
           }
-          onDownload(id, u.label, parentTrackId)
+          onDownload({ trackId: id, category: u.label, parentTrackId })
         }
       } else {
         return undefined
@@ -223,7 +233,7 @@ const useMakeDownloadOriginalButton = ({
         if (!isLoggedIn) {
           onNotLoggedInClick?.()
         }
-        onDownload(track.track_id)
+        onDownload({ trackId: track.track_id })
       }
     }
   }, [

--- a/packages/common/src/services/track-download/TrackDownload.ts
+++ b/packages/common/src/services/track-download/TrackDownload.ts
@@ -11,7 +11,11 @@ export class TrackDownload {
     this.audiusBackend = config.audiusBackend
   }
 
-  async downloadTrack(_args: { url: string; filename: string }) {
+  async downloadTrack(_args: {
+    url: string
+    filename: string
+    original?: boolean
+  }) {
     throw new Error('downloadTrack not implemented')
   }
 }

--- a/packages/common/src/store/social/tracks/actions.ts
+++ b/packages/common/src/store/social/tracks/actions.ts
@@ -94,9 +94,10 @@ export const recordListen = createCustomAction(
 
 export const downloadTrack = createCustomAction(
   DOWNLOAD_TRACK,
-  (trackId: ID, stemName?: string) => ({
+  (trackId: ID, stemName?: string, original?: boolean) => ({
     trackId,
-    stemName
+    stemName,
+    original
   })
 )
 

--- a/packages/discovery-provider/src/queries/get_track_signature.py
+++ b/packages/discovery-provider/src/queries/get_track_signature.py
@@ -1,4 +1,5 @@
 import json
+import os
 import urllib.parse
 from typing import Optional, TypedDict
 
@@ -114,7 +115,11 @@ def get_track_download_signature(args: GetTrackDownloadSignature):
     is_original = args.get("is_original", False)
     filename = args.get("filename")
     if not filename:
-        filename = track.get("orig_filename", title) if is_original else f"{title}.mp3"
+        orig_filename = track.get("orig_filename", title)
+        orig_name_without_extension = os.path.splitext(orig_filename)[0]
+        filename = (
+            orig_filename if is_original else f"{orig_name_without_extension}.mp3"
+        )
     user_data = args["user_data"]
     user_signature = args["user_signature"]
     nft_access_signature = args["nft_access_signature"]

--- a/packages/mobile/src/screens/track-screen/DownloadSection.tsx
+++ b/packages/mobile/src/screens/track-screen/DownloadSection.tsx
@@ -186,6 +186,7 @@ export const DownloadSection = ({ trackId }: { trackId: ID }) => {
         {stemTracks?.map((s, i) => (
           <DownloadRow
             trackId={s.id}
+            parentTrackId={trackId}
             key={s.id}
             index={
               i +

--- a/packages/mobile/src/screens/track-screen/TrackScreenDownloadButtons.tsx
+++ b/packages/mobile/src/screens/track-screen/TrackScreenDownloadButtons.tsx
@@ -104,12 +104,21 @@ export const TrackScreenDownloadButtons = ({
   const dispatch = useDispatch()
 
   const handleDownload = useCallback(
-    (id: ID, category?: string, parentTrackId?: ID) => {
-      dispatch(downloadTrack(id, category))
+    ({
+      trackId,
+      category,
+      parentTrackId
+    }: {
+      trackId: ID
+      category?: string
+      parentTrackId?: ID
+      original?: boolean
+    }) => {
+      dispatch(downloadTrack(trackId, category))
       track(
         make({
           eventName: Name.TRACK_PAGE_DOWNLOAD,
-          id,
+          id: trackId,
           category,
           parent_track_id: parentTrackId
         })

--- a/packages/web/src/common/store/social/tracks/sagas.ts
+++ b/packages/web/src/common/store/social/tracks/sagas.ts
@@ -31,6 +31,7 @@ import { waitForRead, waitForWrite } from 'utils/sagaHelpers'
 
 import watchTrackErrors from './errorSagas'
 import { watchRecordListen } from './recordListen'
+import { FeatureFlags } from '@audius/common'
 const { getUser } = cacheUsersSelectors
 const { getTrack, getTracks } = cacheTracksSelectors
 const { getUserId, getUserHandle } = accountSelectors
@@ -640,10 +641,12 @@ export function* watchUnsetArtistPick() {
 
 function* downloadTrack({
   track,
-  filename
+  filename,
+  original
 }: {
   track: Track
-  filename: string
+  filename?: string
+  original?: boolean
 }) {
   try {
     const audiusBackendInstance = yield* getContext('audiusBackendInstance')
@@ -659,6 +662,7 @@ function* downloadTrack({
       nftAccessSignature
     })) as unknown as QueryParams
     queryParams.filename = filename
+    queryParams.original = original
 
     const encodedTrackId = encodeHashId(trackId)
     const url = apiClient.makeUrl(
@@ -680,6 +684,7 @@ function* watchDownloadTrack() {
     socialActions.DOWNLOAD_TRACK,
     function* (action: ReturnType<typeof socialActions.downloadTrack>) {
       yield* call(waitForRead)
+      const { trackId, original, stemName } = action
 
       // Check if there is a logged in account and if not,
       // wait for one so we can trigger the download immediately after
@@ -689,24 +694,41 @@ function* watchDownloadTrack() {
         yield* call(waitForValue, getUserId)
       }
 
-      const track = yield* select(getTrack, { id: action.trackId })
+      const track = yield* select(getTrack, { id: trackId })
       if (!track) return
 
       const userId = track.owner_id
       const user = yield* select(getUser, { id: userId })
       if (!user) return
 
+      const getFeatureEnabled = yield* getContext('getFeatureEnabled')
+      const isLosslessDownloadsEnabled = getFeatureEnabled(
+        FeatureFlags.LOSSLESS_DOWNLOADS_ENABLED
+      )
       let filename
-      if (track.stem_of?.parent_track_id) {
-        const parentTrack = yield* select(getTrack, {
-          id: track.stem_of?.parent_track_id
-        })
-        filename = `${parentTrack?.title} - ${action.stemName} - ${user.name} (Audius).mp3`
+      if (!isLosslessDownloadsEnabled) {
+        if (track.stem_of?.parent_track_id) {
+          const parentTrack = yield* select(getTrack, {
+            id: track.stem_of?.parent_track_id
+          })
+          filename = `${parentTrack?.title} - ${stemName} - ${user.name} (Audius).mp3`
+        } else {
+          filename = `${track.title} - ${user.name} (Audius).mp3`
+        }
       } else {
-        filename = `${track.title} - ${user.name} (Audius).mp3`
+        if (original) {
+          filename = `${track.orig_filename}`
+        } else {
+          const dotIndex = track.orig_filename.lastIndexOf('.')
+          filename =
+            dotIndex !== -1
+              ? track.orig_filename.substring(0, dotIndex)
+              : filename
+          filename += '.mp3'
+        }
       }
 
-      yield* call(downloadTrack, { track, filename })
+      yield* call(downloadTrack, { track, filename, original })
     }
   )
 }

--- a/packages/web/src/components/download-buttons/DownloadButtons.tsx
+++ b/packages/web/src/components/download-buttons/DownloadButtons.tsx
@@ -136,7 +136,17 @@ const DownloadButton = ({
 
 type DownloadButtonsProps = {
   trackId: ID
-  onDownload: (trackId: ID, category?: string, parentTrackId?: ID) => void
+  onDownload: ({
+    trackId,
+    category,
+    original,
+    parentTrackId
+  }: {
+    trackId: ID
+    category?: string
+    original?: boolean
+    parentTrackId?: ID
+  }) => void
   isOwner: boolean
   following: boolean
   hasDownloadAccess: boolean

--- a/packages/web/src/components/track/DownloadRow.tsx
+++ b/packages/web/src/components/track/DownloadRow.tsx
@@ -27,12 +27,17 @@ type DownloadRowProps = {
   trackId: ID
   parentTrackId?: ID
   quality: DownloadQuality
-  onDownload: (
-    trackId: ID,
-    category?: string,
-    original?: boolean,
+  onDownload: ({
+    trackId,
+    category,
+    original,
+    parentTrackId
+  }: {
+    trackId: ID
+    category?: string
+    original?: boolean
     parentTrackId?: ID
-  ) => void
+  }) => void
   hideDownload?: boolean
   index: number
 }
@@ -60,12 +65,12 @@ export const DownloadRow = ({
       // On mobile, show a toast instead of a tooltip
       dispatch(toast({ content: messages.followToDownload }))
     } else if (track && track.access.download) {
-      onDownload(
+      onDownload({
         trackId,
-        track.stem_of?.category,
-        quality === DownloadQuality.ORIGINAL,
+        category: track.stem_of?.category,
+        original: quality === DownloadQuality.ORIGINAL,
         parentTrackId
-      )
+      })
     }
   }, [
     isMobile,

--- a/packages/web/src/components/track/DownloadRow.tsx
+++ b/packages/web/src/components/track/DownloadRow.tsx
@@ -25,14 +25,22 @@ const messages = {
 
 type DownloadRowProps = {
   trackId: ID
+  parentTrackId?: ID
   quality: DownloadQuality
-  onDownload: (trackId: ID, category?: string, parentTrackId?: ID) => void
+  onDownload: (
+    trackId: ID,
+    category?: string,
+    original?: boolean,
+    parentTrackId?: ID
+  ) => void
   hideDownload?: boolean
   index: number
 }
 
 export const DownloadRow = ({
   trackId,
+  parentTrackId,
+  quality,
   onDownload,
   hideDownload,
   index
@@ -52,15 +60,22 @@ export const DownloadRow = ({
       // On mobile, show a toast instead of a tooltip
       dispatch(toast({ content: messages.followToDownload }))
     } else if (track && track.access.download) {
-      onDownload(trackId, track.stem_of?.category, trackId)
+      onDownload(
+        trackId,
+        track.stem_of?.category,
+        quality === DownloadQuality.ORIGINAL,
+        parentTrackId
+      )
     }
   }, [
-    dispatch,
     isMobile,
-    onDownload,
     shouldDisplayDownloadFollowGated,
     track,
-    trackId
+    dispatch,
+    onDownload,
+    trackId,
+    quality,
+    parentTrackId
   ])
 
   const downloadButton = () => (

--- a/packages/web/src/components/track/DownloadSection.tsx
+++ b/packages/web/src/components/track/DownloadSection.tsx
@@ -8,7 +8,8 @@ import {
   DownloadQuality,
   useDownloadableContentAccess,
   usePremiumContentPurchaseModal,
-  ModalSource
+  ModalSource,
+  Track
 } from '@audius/common'
 import { USDC } from '@audius/fixed-decimal'
 import {
@@ -48,7 +49,12 @@ const messages = {
 
 type DownloadSectionProps = {
   trackId: ID
-  onDownload: (trackId: ID, category?: string, parentTrackId?: ID) => void
+  onDownload: (
+    trackId: ID,
+    category?: string,
+    original?: boolean,
+    parentTrackId?: ID
+  ) => void
 }
 
 export const DownloadSection = ({
@@ -211,9 +217,10 @@ export const DownloadSection = ({
                 hideDownload={shouldHideDownload}
               />
             ) : null}
-            {stemTracks.map((s, i) => (
+            {stemTracks.map((s: Track, i: number) => (
               <DownloadRow
                 trackId={s.id}
+                parentTrackId={trackId}
                 key={s.id}
                 onDownload={onDownload}
                 quality={quality}

--- a/packages/web/src/components/track/DownloadSection.tsx
+++ b/packages/web/src/components/track/DownloadSection.tsx
@@ -48,12 +48,17 @@ const messages = {
 
 type DownloadSectionProps = {
   trackId: ID
-  onDownload: (
-    trackId: ID,
-    category?: string,
-    original?: boolean,
+  onDownload: ({
+    trackId,
+    category,
+    original,
+    parentTrackId
+  }: {
+    trackId: ID
+    category?: string
+    original?: boolean
     parentTrackId?: ID
-  ) => void
+  }) => void
 }
 
 export const DownloadSection = ({

--- a/packages/web/src/components/track/DownloadSection.tsx
+++ b/packages/web/src/components/track/DownloadSection.tsx
@@ -8,8 +8,7 @@ import {
   DownloadQuality,
   useDownloadableContentAccess,
   usePremiumContentPurchaseModal,
-  ModalSource,
-  Track
+  ModalSource
 } from '@audius/common'
 import { USDC } from '@audius/fixed-decimal'
 import {
@@ -217,7 +216,7 @@ export const DownloadSection = ({
                 hideDownload={shouldHideDownload}
               />
             ) : null}
-            {stemTracks.map((s: Track, i: number) => (
+            {stemTracks.map((s, i) => (
               <DownloadRow
                 trackId={s.id}
                 parentTrackId={trackId}

--- a/packages/web/src/components/track/GiantTrackTile.tsx
+++ b/packages/web/src/components/track/GiantTrackTile.tsx
@@ -119,7 +119,17 @@ export type GiantTrackTileProps = {
   mood: string
   onClickFavorites: () => void
   onClickReposts: () => void
-  onDownload: (trackId: ID, category?: string, parentTrackId?: ID) => void
+  onDownload: ({
+    trackId,
+    category,
+    original,
+    parentTrackId
+  }: {
+    trackId: ID
+    category?: string
+    original?: boolean
+    parentTrackId?: ID
+  }) => void
   onMakePublic: (trackId: ID) => void
   onFollow: () => void
   onPlay: () => void

--- a/packages/web/src/pages/track-page/TrackPageProvider.tsx
+++ b/packages/web/src/pages/track-page/TrackPageProvider.tsx
@@ -597,12 +597,17 @@ function mapDispatchToProps(dispatch: Dispatch) {
       ),
     onConfirmUnfollow: (userId: ID) =>
       dispatch(unfollowConfirmationActions.setOpen(userId)),
-    downloadTrack: (
-      trackId: ID,
-      category?: string,
-      original?: boolean,
+    downloadTrack: ({
+      trackId,
+      category,
+      original,
+      parentTrackId
+    }: {
+      trackId: ID
+      category?: string
+      original?: boolean
       parentTrackId?: ID
-    ) => {
+    }) => {
       dispatch(socialTracksActions.downloadTrack(trackId, category, original))
       const trackEvent: TrackEvent = make(Name.TRACK_PAGE_DOWNLOAD, {
         id: trackId,

--- a/packages/web/src/pages/track-page/TrackPageProvider.tsx
+++ b/packages/web/src/pages/track-page/TrackPageProvider.tsx
@@ -597,8 +597,13 @@ function mapDispatchToProps(dispatch: Dispatch) {
       ),
     onConfirmUnfollow: (userId: ID) =>
       dispatch(unfollowConfirmationActions.setOpen(userId)),
-    downloadTrack: (trackId: ID, category?: string, parentTrackId?: ID) => {
-      dispatch(socialTracksActions.downloadTrack(trackId, category))
+    downloadTrack: (
+      trackId: ID,
+      category?: string,
+      original?: boolean,
+      parentTrackId?: ID
+    ) => {
+      dispatch(socialTracksActions.downloadTrack(trackId, category, original))
       const trackEvent: TrackEvent = make(Name.TRACK_PAGE_DOWNLOAD, {
         id: trackId,
         category,

--- a/packages/web/src/pages/track-page/components/desktop/TrackPage.tsx
+++ b/packages/web/src/pages/track-page/components/desktop/TrackPage.tsx
@@ -61,7 +61,15 @@ export type OwnProps = {
   onClickFavorites: () => void
 
   onSaveTrack: (isSaved: boolean, trackId: ID) => void
-  onDownloadTrack: (trackId: ID, category?: string, parentTrackId?: ID) => void
+  onDownloadTrack: ({
+    trackId,
+    category,
+    parentTrackId
+  }: {
+    trackId: ID
+    category?: string
+    parentTrackId?: ID
+  }) => void
   makePublic: (trackId: ID) => void
   // Tracks Lineup Props
   tracks: LineupState<{ id: ID }>

--- a/packages/web/src/pages/track-page/components/mobile/TrackHeader.tsx
+++ b/packages/web/src/pages/track-page/components/mobile/TrackHeader.tsx
@@ -139,7 +139,15 @@ type TrackHeaderProps = {
   onShare: () => void
   onSave: () => void
   onRepost: () => void
-  onDownload: (trackId: ID, category?: string, parentTrackId?: ID) => void
+  onDownload: ({
+    trackId,
+    category,
+    parentTrackId
+  }: {
+    trackId: ID
+    category?: string
+    parentTrackId?: ID
+  }) => void
   goToFavoritesPage: (trackId: ID) => void
   goToRepostsPage: (trackId: ID) => void
 }

--- a/packages/web/src/pages/track-page/components/mobile/TrackPage.tsx
+++ b/packages/web/src/pages/track-page/components/mobile/TrackPage.tsx
@@ -63,7 +63,15 @@ export type OwnProps = {
   ) => void
 
   onSaveTrack: (isSaved: boolean, trackId: ID) => void
-  onDownloadTrack: (trackId: ID, category?: string, parentTrackId?: ID) => void
+  onDownloadTrack: ({
+    trackId,
+    category,
+    parentTrackId
+  }: {
+    trackId: ID
+    category?: string
+    parentTrackId?: ID
+  }) => void
   // Tracks Lineup Props
   tracks: LineupState<{ id: ID }>
   currentQueueItem: QueueItem


### PR DESCRIPTION
### Description
* Adds `original` query param to `download` request to specify quality.
* Hook this up to segmented control quality selector on both web and mobile.
* Change `onDownload` to object args cuz so annoying.
* Change default behavior on DN when no `filename` req param is specified to always use the original file name. Note: this code path is not currently exercised because we always supply the file name query param from client, but was tripping me up while developing.

### How Has This Been Tested?

Tested both web and mobile with lossless feature flag off and on. Confirmed that with ff on, we get original file names, and with ff off, we get old "Audius" file names.
