### PR TITLE
[C-3729] Move top genre query to use aggregates

### DIFF
--- a/packages/discovery-provider/integration_tests/queries/test_get_top_genre_users.py
+++ b/packages/discovery-provider/integration_tests/queries/test_get_top_genre_users.py
@@ -1,0 +1,46 @@
+import logging
+
+from integration_tests.utils import populate_mock_db
+from src.queries.get_top_genre_users import _get_top_genre_users
+from src.tasks.update_aggregates import _update_aggregates
+from src.utils.db_session import get_db
+
+logger = logging.getLogger(__name__)
+
+
+def test_get_top_genre_users(app):
+    with app.app_context():
+        db = get_db()
+
+    entities = {
+        "tracks": [
+            {"track_id": 1, "owner_id": 1, "genre": "Electronic"},
+            {"track_id": 2, "owner_id": 2, "genre": "Electronic"},
+            {"track_id": 3, "owner_id": 2, "genre": "Pop"},
+            {"track_id": 4, "owner_id": 2, "genre": "Pop"},
+            {"track_id": 5, "owner_id": 3, "genre": "Pop"},
+            {"track_id": 6, "owner_id": 4, "genre": "Electronic"},
+        ],
+        "users": [{"user_id": 1}, {"user_id": 2}, {"user_id": 3}, {"user_id": 4}],
+        "follows": [
+            {"follower_user_id": 1, "followee_user_id": 2},
+            {"follower_user_id": 2, "followee_user_id": 1},
+            {"follower_user_id": 2, "followee_user_id": 3},
+            {"follower_user_id": 3, "followee_user_id": 2},
+            {"follower_user_id": 3, "followee_user_id": 4},
+        ],
+    }
+
+    populate_mock_db(db, entities)
+    with db.scoped_session() as session:
+        _update_aggregates(session)
+
+    with db.scoped_session() as session:
+        users = _get_top_genre_users(session, {"genre": "Pop"})
+        assert users[0]["user_id"] == 2
+        assert users[1]["user_id"] == 3
+
+        users = _get_top_genre_users(session, {"genre": "Electronic"})
+        # Tie break goes to user 1 over user 4
+        assert users[0]["user_id"] == 1
+        assert users[1]["user_id"] == 4

--- a/packages/discovery-provider/src/api/v1/users.py
+++ b/packages/discovery-provider/src/api/v1/users.py
@@ -1427,7 +1427,7 @@ class FullTopGenreUsers(Resource):
         if args["genre"] is not None:
             get_top_genre_users_args["genre"] = args["genre"]
         top_users = get_top_genre_users(get_top_genre_users_args)
-        users = list(map(extend_user, top_users["users"]))
+        users = list(map(extend_user, top_users))
         return success_response(users)
 
     @full_ns.doc(

--- a/packages/discovery-provider/src/api/v1/users.py
+++ b/packages/discovery-provider/src/api/v1/users.py
@@ -1413,7 +1413,7 @@ TOP_GENRE_ROUTE = "/genre/top"
 
 @full_ns.route(TOP_GENRE_ROUTE)
 class FullTopGenreUsers(Resource):
-    @cache(ttl_sec=60 * 60 * 24)
+    @cache(ttl_sec=60 * 60 * 1)
     def _get(self):
         args = top_genre_users_route_parser.parse_args()
         limit = get_default_max(args.get("limit"), 10, 100)
@@ -1466,7 +1466,7 @@ TOP_ROUTE = "/top"
 
 @full_ns.route(TOP_ROUTE)
 class FullTopUsers(Resource):
-    @cache(ttl_sec=60 * 60 * 24)
+    @cache(ttl_sec=60 * 60 * 1)
     def _get(self):
         args = pagination_with_current_user_parser.parse_args()
         current_user_id = get_current_user_id(args)

--- a/packages/discovery-provider/src/queries/get_top_genre_users.py
+++ b/packages/discovery-provider/src/queries/get_top_genre_users.py
@@ -1,101 +1,54 @@
 import logging
 
-from sqlalchemy import asc, desc, func
+from sqlalchemy import asc, desc
 
-from src.models.social.follow import Follow
-from src.models.tracks.track import Track
+from src.models.users.aggregate_user import AggregateUser
 from src.models.users.user import User
-from src.queries.get_unpopulated_users import get_unpopulated_users
-from src.queries.query_helpers import paginate_query, populate_user_metadata
+from src.queries.query_helpers import add_query_pagination, populate_user_metadata
+from src.utils import helpers
 from src.utils.db_session import get_db_read_replica
 
 logger = logging.getLogger(__name__)
 
 
 def get_top_genre_users(args):
+    db = get_db_read_replica()
+    with db.scoped_session() as session:
+        return _get_top_genre_users(session, args)
+
+
+def _get_top_genre_users(session, args):
     genres = []
     if "genre" in args:
         genres = args.get("genre")
         if isinstance(genres, str):
             genres = [genres]
 
-    # If the with_users url arg is provided, then populate the user metadata else return user ids
-    with_users = args.get("with_users", False)
+    with_users = args.get("with_users", True)
+    limit = args.get("limit", 10)
+    offset = args.get("offset", 0)
 
-    db = get_db_read_replica()
-    with db.scoped_session() as session:
-        with_genres = len(genres) != 0
-
-        # Associate the user w/ a genre by counting the total # of tracks per genre
-        # taking the genre w/ the most tracks (using genre name as secondary sort)
-        user_genre_count_query = (
-            session.query(
-                User.user_id.label("user_id"),
-                Track.genre.label("genre"),
-                func.row_number()
-                .over(
-                    partition_by=User.user_id,
-                    order_by=(desc(func.count(Track.genre)), asc(Track.genre)),
-                )
-                .label("row_number"),
-            )
-            .join(Track, Track.owner_id == User.user_id)
-            .filter(
-                User.is_current == True,
-                Track.is_unlisted == False,
-                Track.stem_of == None,
-                Track.is_current == True,
-                Track.is_delete == False,
-            )
-            .group_by(User.user_id, Track.genre)
-            .order_by(desc(func.count(Track.genre)), asc(Track.genre))
+    top_users_query = (
+        session.query(User)
+        .join(AggregateUser, User.user_id == AggregateUser.user_id)
+        .filter(
+            AggregateUser.dominant_genre.in_(genres),
+            User.is_deactivated == False,
+            User.is_available == True,
         )
+        .order_by(desc(AggregateUser.follower_count), asc(User.user_id))
+    )
+    users = add_query_pagination(top_users_query, limit, offset).all()
+    users = helpers.query_result_to_list(users)
+    print(users, limit, offset)
+    user_ids = list(map(lambda user: user["user_id"], users))
 
-        user_genre_count_query = user_genre_count_query.subquery(
-            "user_genre_count_query"
-        )
+    if with_users:
+        users = populate_user_metadata(session, user_ids, users, None)
 
-        user_genre_query = (
-            session.query(
-                user_genre_count_query.c.user_id.label("user_id"),
-                user_genre_count_query.c.genre.label("genre"),
-            )
-            .filter(user_genre_count_query.c.row_number == 1)
-            .subquery("user_genre_query")
-        )
+        # Sort the users so that it's in the same order as the previous query
+        user_map = {user["user_id"]: user for user in users}
+        users = [user_map[user_id] for user_id in user_ids]
+        return users
 
-        # Using the subquery of user to associated genre,
-        #   filter by the requested genres and
-        #   sort by user follower count
-        user_genre_followers_query = (
-            session.query(user_genre_query.c.user_id.label("user_id"))
-            .join(Follow, Follow.followee_user_id == user_genre_query.c.user_id)
-            .filter(Follow.is_current == True, Follow.is_delete == False)
-            .group_by(user_genre_query.c.user_id, user_genre_query.c.genre)
-            .order_by(
-                # desc('follower_count')
-                desc(func.count(Follow.follower_user_id))
-            )
-        )
-
-        if with_genres:
-            user_genre_followers_query = user_genre_followers_query.filter(
-                user_genre_query.c.genre.in_(genres)
-            )
-
-        # If the with_users flag is not set, respond with the user_ids
-        users = paginate_query(user_genre_followers_query).all()
-        user_ids = list(map(lambda user: user[0], users))
-
-        # If the with_users flag is used, retrieve the user metadata
-        if with_users:
-            users = get_unpopulated_users(session, user_ids)
-            queried_user_ids = list(map(lambda user: user["user_id"], users))
-            users = populate_user_metadata(session, queried_user_ids, users, None)
-
-            # Sort the users so that it's in the same order as the previous query
-            user_map = {user["user_id"]: user for user in users}
-            users = [user_map[user_id] for user_id in user_ids]
-            return {"users": users}
-
-        return {"user_ids": user_ids}
+    return user_ids

--- a/packages/discovery-provider/src/queries/queries.py
+++ b/packages/discovery-provider/src/queries/queries.py
@@ -556,7 +556,7 @@ def get_top_genre_users_route():
     if "with_users" in request.args:
         args["with_users"] = parse_bool_param(request.args.get("with_users"))
     users = get_top_genre_users(args)
-    return api_helpers.success_response({ "user_ids": users })
+    return api_helpers.success_response({"user_ids": users})
 
 
 # Get the tracks that are 'children' remixes of the requested track

--- a/packages/discovery-provider/src/queries/queries.py
+++ b/packages/discovery-provider/src/queries/queries.py
@@ -556,7 +556,7 @@ def get_top_genre_users_route():
     if "with_users" in request.args:
         args["with_users"] = parse_bool_param(request.args.get("with_users"))
     users = get_top_genre_users(args)
-    return api_helpers.success_response(users)
+    return api_helpers.success_response({ "user_ids": users })
 
 
 # Get the tracks that are 'children' remixes of the requested track

--- a/packages/discovery-provider/src/tasks/index_user_bank.py
+++ b/packages/discovery-provider/src/tasks/index_user_bank.py
@@ -579,7 +579,10 @@ def process_transfer_instruction(
         )
         return
 
-    if receiver_account == PAYMENT_ROUTER_USDC_ATA_ADDRESS or receiver_account == PAYMENT_ROUTER_WAUDIO_ATA_ADDRESS:
+    if (
+        receiver_account == PAYMENT_ROUTER_USDC_ATA_ADDRESS
+        or receiver_account == PAYMENT_ROUTER_WAUDIO_ATA_ADDRESS
+    ):
         logger.info(f"index_user_bank.py | Skipping payment router tx {tx_sig}")
         return
 


### PR DESCRIPTION
### Description

Move v1/full/users/genre/top?genre=Electronic queries to use the aggregate table.
Should be very fast now. Bring the cache down to an hour. Probably could be lower / zero, but will leave that to future.

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._

```
audius-compose test up discovery-provider
docker exec -it audius-protocol-test-test-discovery-provider-1 /bin/sh
pytest integration_tests/queries/test_get_top_genre_users.py
```