### PR TITLE
Update pg_restore to v15

### DIFF
--- a/packages/discovery-provider/Dockerfile.prod
+++ b/packages/discovery-provider/Dockerfile.prod
@@ -54,12 +54,11 @@ RUN curl -O 'http://openresty.org/package/admin@openresty.com-5ea678a6.rsa.pub' 
 RUN echo 'http://dl-cdn.alpinelinux.org/alpine/v3.10/main' >> /etc/apk/repositories && \
   apk update && \
   apk add \
-  libpq=11.12-r0 \
-  postgresql-client=11.12-r0 \
-  postgresql-contrib=11.12-r0 \
-  postgresql-dev=11.12-r0 \
-  postgresql-libs=11.12-r0 \
-  postgresql=11.12-r0
+  libpq=15.5-r0 \
+  postgresql15-client=15.5-r0 \
+  postgresql15-contrib=15.5-r0 \
+  postgresql15-dev=15.5-r0 \
+  postgresql15=15.5-r0
 
 RUN python3 -m pip install --upgrade pip
 


### PR DESCRIPTION
### Description
Upgrades pg_restore in the Discovery Dockerfile. The `seed` container uses this version to re-seed, so it must match the version that was used in `pg_dump`. I upgraded the `pg_dump` version 2 days ago, so now restores fail until they're upgraded to match.

### How Has This Been Tested?
Testing on stage DN3, which currently fails to restore: `pg_restore: [archiver] unsupported version (1.14) in file header`. I'll also test to make sure this doesn't break the Discovery image when used in the `server` and `indexer` containers.