### PR TITLE
[INF-650] Fix PublicSite history bug

### DIFF
--- a/packages/web/src/Root.tsx
+++ b/packages/web/src/Root.tsx
@@ -50,9 +50,9 @@ const AppOrPublicSite = () => {
   useEffect(() => {
     // TODO: listen to history and change routes based on history...
     window.onpopstate = () => {
-      setRenderPublicSite(isPublicSiteRoute(history.location))
+      setRenderPublicSite(isPublicSiteRoute(window.location as any))
     }
-  }, [history.location])
+  }, [])
 
   const shouldRedirectToApp =
     foundUser && !isPublicSiteSubRoute(history.location)

--- a/packages/web/src/public-site/PublicSite.tsx
+++ b/packages/web/src/public-site/PublicSite.tsx
@@ -4,7 +4,6 @@ import { Router, Route } from 'react-router-dom'
 
 import LoadingSpinnerFullPage from 'components/loading-spinner-full-page/LoadingSpinnerFullPage'
 import NavScreen from 'public-site/components/NavOverlay'
-import { env } from 'services/env'
 import {
   TRENDING_PAGE,
   SIGN_UP_PAGE,

--- a/packages/web/src/public-site/PublicSite.tsx
+++ b/packages/web/src/public-site/PublicSite.tsx
@@ -18,8 +18,6 @@ import { AppContextProvider } from '../app/AppContextProvider'
 import LandingPage from './pages/landing-page/LandingPage'
 import { useHistoryContext } from 'app/HistoryProvider'
 
-const BASENAME = env.BASENAME
-
 const PrivacyPolicyPage = lazy(
   () => import('./pages/privacy-policy-page/PrivacyPolicyPage')
 )

--- a/packages/web/src/public-site/PublicSite.tsx
+++ b/packages/web/src/public-site/PublicSite.tsx
@@ -1,6 +1,6 @@
 import { lazy, Suspense, useState, useCallback, useEffect } from 'react'
 
-import { BrowserRouter as Router, Route } from 'react-router-dom'
+import { Router, Route } from 'react-router-dom'
 
 import LoadingSpinnerFullPage from 'components/loading-spinner-full-page/LoadingSpinnerFullPage'
 import NavScreen from 'public-site/components/NavOverlay'
@@ -16,6 +16,7 @@ import {
 import { AppContextProvider } from '../app/AppContextProvider'
 
 import LandingPage from './pages/landing-page/LandingPage'
+import { useHistoryContext } from 'app/HistoryProvider'
 
 const BASENAME = env.BASENAME
 
@@ -42,6 +43,7 @@ type PublicSiteProps = {
 export const PublicSite = (props: PublicSiteProps) => {
   const { isMobile, setRenderPublicSite } = props
   const [isMobileOrNarrow, setIsMobileOrNarrow] = useState(isMobile)
+  const { history } = useHistoryContext()
   const handleMobileMediaQuery = useCallback(() => {
     if (MOBILE_WIDTH_MEDIA_QUERY.matches) setIsMobileOrNarrow(true)
     else setIsMobileOrNarrow(isMobile)
@@ -93,7 +95,7 @@ export const PublicSite = (props: PublicSiteProps) => {
 
       <Suspense fallback={<div style={{ width: '100vw', height: '100vh' }} />}>
         <AppContextProvider>
-          <Router basename={BASENAME}>
+          <Router history={history}>
             <NavScreen
               closeNavScreen={closeNavScreen}
               isOpen={isNavScreenOpen}


### PR DESCRIPTION
### Description

A bug was introduced with #7213 that prevented popping history state when going from signup to the landing page. The fix was:
1. Use the shared `history` object for routing in PublicSite
2. In the `window.onpopstate` handler, check the value of window.location rather than the history.location. This is because history.location hasn't updated yet

### How Has This Been Tested?

Confirmed that navigation works properly between the PublicSite and app now (specifically sign up)
