### PR TITLE
Block future release dates on public tracks

### DIFF
--- a/packages/discovery-provider/integration_tests/tasks/entity_manager/test_track_entity_manager.py
+++ b/packages/discovery-provider/integration_tests/tasks/entity_manager/test_track_entity_manager.py
@@ -1,5 +1,6 @@
 import json
 import logging  # pylint: disable=C0302
+from datetime import datetime
 from typing import List
 
 from web3 import Web3
@@ -545,6 +546,9 @@ def test_index_invalid_tracks(app, mocker):
             "is_original_available": False,
         },
         "QmInvalidUnlistTrack1Update": {"is_unlisted": True},
+        "QmInvalidRescheduleReleaseDate": {
+            "release_date": "Fri Jan 26 2100 00:00:00 GMT+0000"
+        },
         "InvalidTrackIdUpdate": {"track_id": 1234, "bogus_field": "bogus"},
     }
     invalid_metadata_json = json.dumps(test_metadata["QmAIDisabled"])
@@ -874,7 +878,11 @@ def test_index_invalid_tracks(app, mocker):
             {"user_id": 2, "handle": "user-1", "wallet": "User2Wallet"},
         ],
         "tracks": [
-            {"track_id": TRACK_ID_OFFSET, "owner_id": 1},
+            {
+                "track_id": TRACK_ID_OFFSET,
+                "owner_id": 1,
+                "release_date": datetime(2019, 6, 17),
+            },
         ],
         "developer_apps": [
             {
@@ -924,6 +932,7 @@ def test_index_invalid_tracks(app, mocker):
         current_track: List[Track] = (
             session.query(Track).filter(Track.is_current == True).first()
         )
+        assert current_track.release_date == datetime(2019, 6, 17)
         assert current_track.track_id == TRACK_ID_OFFSET
 
 

--- a/packages/discovery-provider/integration_tests/tasks/entity_manager/test_track_entity_manager.py
+++ b/packages/discovery-provider/integration_tests/tasks/entity_manager/test_track_entity_manager.py
@@ -546,9 +546,6 @@ def test_index_invalid_tracks(app, mocker):
             "is_original_available": False,
         },
         "QmInvalidUnlistTrack1Update": {"is_unlisted": True},
-        "QmInvalidRescheduleReleaseDate": {
-            "release_date": "Fri Jan 26 2100 00:00:00 GMT+0000"
-        },
         "InvalidTrackIdUpdate": {"track_id": 1234, "bogus_field": "bogus"},
     }
     invalid_metadata_json = json.dumps(test_metadata["QmAIDisabled"])
@@ -878,11 +875,7 @@ def test_index_invalid_tracks(app, mocker):
             {"user_id": 2, "handle": "user-1", "wallet": "User2Wallet"},
         ],
         "tracks": [
-            {
-                "track_id": TRACK_ID_OFFSET,
-                "owner_id": 1,
-                "release_date": datetime(2019, 6, 17),
-            },
+            {"track_id": TRACK_ID_OFFSET, "owner_id": 1},
         ],
         "developer_apps": [
             {
@@ -932,7 +925,6 @@ def test_index_invalid_tracks(app, mocker):
         current_track: List[Track] = (
             session.query(Track).filter(Track.is_current == True).first()
         )
-        assert current_track.release_date == datetime(2019, 6, 17)
         assert current_track.track_id == TRACK_ID_OFFSET
 
 

--- a/packages/discovery-provider/src/tasks/entity_manager/entities/track.py
+++ b/packages/discovery-provider/src/tasks/entity_manager/entities/track.py
@@ -292,13 +292,18 @@ def populate_track_record_metadata(track_record: Track, track_metadata, handle, 
                 # casting to string because datetime doesn't work for some reason
                 parsed_release_date = parse_release_date(track_metadata["release_date"])
                 # postgres will convert to a timestamp
-                if (
-                    action == Action.UPDATE
-                    and track_record.is_unlisted == False
-                    and parsed_release_date > datetime.now()
-                ):
-                    # Public tracks cannot be rescheduled into the future
-                    continue
+
+                if parsed_release_date > datetime.now().astimezone(timezone.utc):
+                    # ignore release date if in the future
+                    # for creating or updating public tracks
+                    if (
+                        action == Action.UPDATE and track_record.is_unlisted == False
+                    ) or (
+                        action == Action.CREATE
+                        and track_metadata.get("is_unlisted") == False
+                    ):
+                        # Public tracks cannot be rescheduled into the future
+                        continue
 
                 if parsed_release_date:
                     track_record.release_date = str(parsed_release_date)  # type: ignore

--- a/packages/discovery-provider/src/tasks/entity_manager/entities/track.py
+++ b/packages/discovery-provider/src/tasks/entity_manager/entities/track.py
@@ -292,11 +292,16 @@ def populate_track_record_metadata(track_record: Track, track_metadata, handle, 
                 # casting to string because datetime doesn't work for some reason
                 parsed_release_date = parse_release_date(track_metadata["release_date"])
                 # postgres will convert to a timestamp
+                if (
+                    action == Action.UPDATE
+                    and track_record.is_unlisted == False
+                    and parsed_release_date > datetime.now()
+                ):
+                    # Public tracks cannot be rescheduled into the future
+                    continue
+
                 if parsed_release_date:
                     track_record.release_date = str(parsed_release_date)  # type: ignore
-                    logger.info(
-                        f"asdf set release_date {parsed_release_date} {track_record.release_date}"
-                    )
         elif key == "is_unlisted":
             if "is_unlisted" in track_metadata:
                 track_record.is_unlisted = track_metadata["is_unlisted"]

--- a/packages/discovery-provider/src/tasks/entity_manager/entities/track.py
+++ b/packages/discovery-provider/src/tasks/entity_manager/entities/track.py
@@ -293,16 +293,12 @@ def populate_track_record_metadata(track_record: Track, track_metadata, handle, 
                 parsed_release_date = parse_release_date(track_metadata["release_date"])
                 # postgres will convert to a timestamp
 
-                if parsed_release_date > datetime.now().astimezone(timezone.utc):
-                    # ignore release date if in the future
-                    # for creating or updating public tracks
-                    if (
-                        action == Action.UPDATE and track_record.is_unlisted == False
-                    ) or (
-                        action == Action.CREATE
-                        and track_metadata.get("is_unlisted") == False
-                    ):
-                        # Public tracks cannot be rescheduled into the future
+                if (
+                    parsed_release_date
+                    and parsed_release_date > datetime.now().astimezone(timezone.utc)
+                ):
+                    # ignore release date if in the future and updating public tracks
+                    if action == Action.UPDATE and track_record.is_unlisted == False:
                         continue
 
                 if parsed_release_date:


### PR DESCRIPTION
### Description
PROTO-1633

Ignore future release dates for public tracks. You should only be able to set a future release date on a hidden track. Client-side already behaves this way but this is just a check for indexing.

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._

Added more integration tests.