### PR TITLE
Fix monorepo package lock

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -462,6 +462,8 @@ workflows:
             .circleci/.* run-stems-workflow true
             .circleci/.* run-harmony-workflow true
             .circleci/.* run-embed-workflow true
+            package-lock.json run-sdk-workflow true
+            package-lock.json run-harmony-workflow true
             .* run-release-workflow false
             .* run-integration-workflow true
             packages/discovery-provider/.* run-discovery-workflow true


### PR DESCRIPTION
### Description
- Fixes monorepo package-lock.json so it has the necessary dependencies to build the harmony package
- Makes CI run the SDK and Harmony workflows on any PR branch that changes the root package-lock.json