### PR TITLE
Fix node aggregation after changes to get_all_discovery_nodes_cached

### DIFF
--- a/packages/discovery-provider/src/tasks/index_metrics.py
+++ b/packages/discovery-provider/src/tasks/index_metrics.py
@@ -138,7 +138,7 @@ def consolidate_metrics_from_other_nodes(self, db, redis):
         )
         start_time_obj = datetime.strptime(start_time_str, datetime_format_secondary)
         start_time = int(start_time_obj.timestamp())
-        new_route_metrics, new_app_metrics = get_metrics(node, start_time)
+        new_route_metrics, new_app_metrics = get_metrics(node["endpoint"], start_time)
 
         logger.debug(
             f"did attempt to receive route and app metrics from {node} at {start_time_obj} ({start_time})"
@@ -158,7 +158,7 @@ def consolidate_metrics_from_other_nodes(self, db, redis):
         merge_app_metrics(new_app_metrics or {}, end_time, db)
 
         if new_route_metrics is not None and new_app_metrics is not None:
-            visited_node_timestamps[node] = end_time
+            visited_node_timestamps[node["endpoint"]] = end_time
             redis.set(metrics_visited_nodes, json.dumps(visited_node_timestamps))
 
     # persist updated summed unique counts


### PR DESCRIPTION
### Description

The signature of `get_all_discovery_nodes_cached` changed in https://github.com/AudiusProject/audius-protocol/pull/7026/files#diff-682a4444deeb78fc9a99081f685697e21ba0db849ed4ec3e38f52f512eb8f983 to return the `delegateOwnerWallet` in addition to the `endpoint`

The celery task `index_metrics` was only expecting an array of strings of the endpoints and was getting piped the whole JSON blob as the url, resulting in a failure.

This change accesses the `endpoint` field of the JSON blob and passes it to the request handler so that the request works now.

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._

Will confirm on staging