### PR TITLE
[Native] Fix OTP paste on mobile [C-3692]

### DIFF
--- a/packages/mobile/src/screens/signon/SignOn.tsx
+++ b/packages/mobile/src/screens/signon/SignOn.tsx
@@ -581,7 +581,7 @@ const SignOn = ({ navigation }: SignOnProps) => {
     return <></>
   }
 
-  const otpInputField = ({ show }: { show: boolean }) => {
+  const OtpInputField = ({ show }: { show: boolean }) => {
     const [value, setValue] = useState('')
 
     if (!show) {
@@ -784,7 +784,7 @@ const SignOn = ({ navigation }: SignOnProps) => {
               />
               {passwordInputField()}
               {errorView()}
-              {otpInputField({
+              {OtpInputField({
                 show: requiresOtp || (!!otpField.value && isWorking)
               })}
               <MainButton isWorking={isWorking} isSignin={isSignin} />

--- a/packages/mobile/src/screens/signon/SignOn.tsx
+++ b/packages/mobile/src/screens/signon/SignOn.tsx
@@ -1,5 +1,6 @@
 import { useState, useRef, useEffect, useCallback } from 'react'
 
+import { formatOtp } from '@audius/common/schemas'
 import { accountSelectors } from '@audius/common/store'
 import Clipboard from '@react-native-clipboard/clipboard'
 import type { NativeStackScreenProps } from '@react-navigation/native-stack'
@@ -580,7 +581,12 @@ const SignOn = ({ navigation }: SignOnProps) => {
     return <></>
   }
 
-  const otpInputField = () => {
+  const otpInputField = ({ show }: { show: boolean }) => {
+    const [value, setValue] = useState('')
+
+    if (!show) {
+      return null
+    }
     return (
       <TextInput
         style={[styles.inputPass, { borderColor: otpBorderColor }]}
@@ -591,11 +597,15 @@ const SignOn = ({ navigation }: SignOnProps) => {
         autoCorrect={false}
         autoCapitalize='characters'
         enablesReturnKeyAutomatically={true}
-        maxLength={6}
+        keyboardType='number-pad'
         inputMode='numeric'
         textContentType='oneTimeCode'
-        onChangeText={(newText) => {
-          dispatch(signOnActions.setValueField('otp', newText))
+        value={value}
+        onChangeText={(text) => {
+          const formatted = formatOtp(text)
+          setValue(formatted)
+          const sanitized = formatted.replace(/\s/g, '')
+          dispatch(signOnActions.setValueField('otp', sanitized))
         }}
         onFocus={() => {
           setOtpBorderColor('#7E1BCC')
@@ -774,7 +784,9 @@ const SignOn = ({ navigation }: SignOnProps) => {
               />
               {passwordInputField()}
               {errorView()}
-              {requiresOtp ? otpInputField() : null}
+              {otpInputField({
+                show: requiresOtp || (!!otpField.value && isWorking)
+              })}
               <MainButton isWorking={isWorking} isSignin={isSignin} />
             </View>
           </Animated.View>


### PR DESCRIPTION
### Description
Before: In legacy signup, last digit of OTP code would be cut off in mobile. Also the OTP input would disappear when you hit submit.

After: Fixed

https://github.com/AudiusProject/audius-protocol/assets/36916764/d7b02cba-ecb9-4ecb-a022-26ecd33494d3

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._
