### PR TITLE
[PAY-2403] Fix purchase drawer height on small iphones

### DIFF
--- a/packages/web/src/components/drawer/Drawer.module.css
+++ b/packages/web/src/components/drawer/Drawer.module.css
@@ -18,7 +18,8 @@
 
 .fullDrawer {
   top: 0px;
-  height: min(100dvh, 100vh);
+  height: 100vh;
+  height: 100dvh;
   overflow: hidden;
   touch-action: auto;
 }

--- a/packages/web/src/components/drawer/Drawer.module.css
+++ b/packages/web/src/components/drawer/Drawer.module.css
@@ -18,7 +18,7 @@
 
 .fullDrawer {
   top: 0px;
-  height: 100vh;
+  height: min(100dvh, 100vh);
   overflow: hidden;
   touch-action: auto;
 }


### PR DESCRIPTION
### Description

100dvh will handle the url bar correctly, but may not be supported in every mobile browser. Previously bottom bar was overlapping buy button -- see Linear.

@rickyrombo I think dvh is how we could rewrite modal to be good but leaving for a future date

### How Has This Been Tested?

<img width=200 src=https://github.com/AudiusProject/audius-protocol/assets/2731362/68f29c97-9049-460a-b071-fb9f1f62473d />