### PR TITLE
Fix sdk not initializing on stage ddex

### DIFF
--- a/packages/ddex/ingester/Dockerfile
+++ b/packages/ddex/ingester/Dockerfile
@@ -19,4 +19,3 @@ WORKDIR /root/
 COPY --from=builder /app/ingester .
 
 CMD ["./ingester"]
-

--- a/packages/ddex/ingester/cmd/main.go
+++ b/packages/ddex/ingester/cmd/main.go
@@ -2,9 +2,13 @@ package main
 
 import (
 	"flag"
+	"fmt"
 	"ingester/crawler"
 	"ingester/indexer"
 	"ingester/parser"
+	"os"
+	"os/signal"
+	"syscall"
 )
 
 func main() {
@@ -19,6 +23,11 @@ func main() {
 	case "parser":
 		parser.Run()
 	default:
-		panic("unknown service: " + *service)
+		fmt.Println("Unknown service: " + *service)
+		// sleep
+		sigChan := make(chan os.Signal, 1)
+		signal.Notify(sigChan, syscall.SIGINT, syscall.SIGTERM)
+		sig := <-sigChan
+		fmt.Printf("Received signal: %v, shutting down...\n", sig)
 	}
 }

--- a/packages/ddex/webapp/client/src/providers/AudiusSdkProvider.tsx
+++ b/packages/ddex/webapp/client/src/providers/AudiusSdkProvider.tsx
@@ -100,7 +100,6 @@ export const AudiusSdkProvider = ({ children }: { children: ReactNode }) => {
 
   const initSdk = () => {
     if (!window.Web3 || !didInit) {
-      console.error(`Skipping sdk initialization: web3: ${window.Web3}, didInit: ${didInit}`)
       return
     }
 
@@ -121,7 +120,7 @@ export const AudiusSdkProvider = ({ children }: { children: ReactNode }) => {
       // Get keys
       if (!envVars.ddexKey) {
         setIsLoading(false)
-        console.error(`Skipping sdk initialization: ddexKey missing from env: ${JSON.stringify(envVars)}`)
+        console.error(`Skipping sdk initialization: ddexKey missing from env`)
         return
       }
 
@@ -168,9 +167,6 @@ export const AudiusSdkProvider = ({ children }: { children: ReactNode }) => {
         }
       })
       setAudiusSdk(sdkInst as AudiusSdkType)
-      console.log(`initialized SDK!`)
-    } else {
-      console.log(`sdk already initialized: ${audiusSdk}`)
     }
 
     setIsLoading(false)

--- a/packages/ddex/webapp/client/src/providers/AudiusSdkProvider.tsx
+++ b/packages/ddex/webapp/client/src/providers/AudiusSdkProvider.tsx
@@ -100,6 +100,7 @@ export const AudiusSdkProvider = ({ children }: { children: ReactNode }) => {
 
   const initSdk = () => {
     if (!window.Web3 || !didInit) {
+      console.error(`Skipping sdk initialization: web3: ${window.Web3}, didInit: ${didInit}`)
       return
     }
 
@@ -120,6 +121,7 @@ export const AudiusSdkProvider = ({ children }: { children: ReactNode }) => {
       // Get keys
       if (!envVars.ddexKey) {
         setIsLoading(false)
+        console.error(`Skipping sdk initialization: ddexKey missing from env: ${JSON.stringify(envVars)}`)
         return
       }
 
@@ -166,6 +168,9 @@ export const AudiusSdkProvider = ({ children }: { children: ReactNode }) => {
         }
       })
       setAudiusSdk(sdkInst as AudiusSdkType)
+      console.log(`initialized SDK!`)
+    } else {
+      console.log(`sdk already initialized: ${audiusSdk}`)
     }
 
     setIsLoading(false)

--- a/packages/ddex/webapp/client/src/providers/EnvVarsProvider.tsx
+++ b/packages/ddex/webapp/client/src/providers/EnvVarsProvider.tsx
@@ -38,7 +38,7 @@ export const EnvVarsProvider = ({ children }: { children: ReactNode }) => {
         if (!response.ok) {
           throw new Error('Network response was not ok')
         }
-        const data = (await response.json()) as EnvVars
+        const data = (await response.json()).data as EnvVars
         setEnvVars(data)
       } catch (error) {
         console.error('Error fetching env vars:', error)


### PR DESCRIPTION
### Description
Was saving `{ "data": {"ddexKey": ..., ... } }` from the `/api/env` resp as the `envVars` rather than `{"ddexKey": ..., ... }`. Whoops

### How Has This Been Tested?
Determined problem was the env vars by building and pushing some debug logs to the stage node. Ran locally with fix without manual env file passed in. Verified loaded correctly.