### PR TITLE
[PROTO-1638] Use static nodes in uptime reporting

### DIFF
--- a/protocol-dashboard/src/components/IndividualNodeUptimeChart/IndividualNodeUptimeChart.tsx
+++ b/protocol-dashboard/src/components/IndividualNodeUptimeChart/IndividualNodeUptimeChart.tsx
@@ -3,18 +3,21 @@ import React from 'react'
 import { useIndividualNodeUptime } from 'store/cache/analytics/hooks'
 import { Bucket, MetricError } from 'store/cache/analytics/slice'
 import { DataObject } from 'components/TrackerChart'
+import { ServiceType } from 'types'
 
 type OwnProps = {
+  nodeType: ServiceType
   node: string
 }
 
 type IndividualNodeUptimeChartProps = OwnProps
 
 const IndividualNodeUptimeChart: React.FC<IndividualNodeUptimeChartProps> = ({
+  nodeType,
   node
 }) => {
   let error, subtitle: string, data: DataObject[]
-  const { uptime } = useIndividualNodeUptime(node, Bucket.DAY)
+  const { uptime } = useIndividualNodeUptime(nodeType, node, Bucket.DAY)
   if (uptime === MetricError.ERROR) {
     error = true
     data = []

--- a/protocol-dashboard/src/components/ServiceTable/ServiceTable.tsx
+++ b/protocol-dashboard/src/components/ServiceTable/ServiceTable.tsx
@@ -50,7 +50,7 @@ const ServiceTable: React.FC<ServiceTableProps> = ({
 
   const renderRow = (data: NodeService) => {
     let error: boolean, uptimeData: DataObject[]
-    const { uptime } = useIndividualNodeUptime(data.endpoint, Bucket.DAY)
+    const { uptime } = useIndividualNodeUptime(data.type, data.endpoint, Bucket.DAY)
     if (uptime === MetricError.ERROR) {
       error = true
       uptimeData = []

--- a/protocol-dashboard/src/containers/Node/Node.tsx
+++ b/protocol-dashboard/src/containers/Node/Node.tsx
@@ -62,7 +62,7 @@ const ContentNode: React.FC<ContentNodeProps> = ({
       </div>
       {contentNode ? (
         <div className={clsx(styles.section, styles.chart)}>
-          <IndividualNodeUptimeChart node={contentNode.endpoint} />
+          <IndividualNodeUptimeChart nodeType={ServiceType.ContentNode} node={contentNode.endpoint} />
         </div>
       ) : null}
     </>
@@ -109,7 +109,7 @@ const DiscoveryNode: React.FC<DiscoveryNodeProps> = ({
             <IndividualServiceUniqueUsersChart node={discoveryNode?.endpoint} />
           </div>
           <div className={clsx(styles.section, styles.chart)}>
-            <IndividualNodeUptimeChart node={discoveryNode.endpoint} />
+            <IndividualNodeUptimeChart nodeType={ServiceType.DiscoveryProvider} node={discoveryNode.endpoint} />
           </div>
         </>
       ) : null}

--- a/protocol-dashboard/src/store/cache/analytics/slice.ts
+++ b/protocol-dashboard/src/store/cache/analytics/slice.ts
@@ -1,4 +1,5 @@
 import { createSlice, PayloadAction } from '@reduxjs/toolkit'
+import { ServiceType } from 'types'
 
 export type TimeSeriesRecord = {
   timestamp: string
@@ -84,6 +85,7 @@ type SetTrailingTopGenres = {
 }
 type SetTrailingApiCalls = { metric: CountRecord | MetricError; bucket: Bucket }
 type SetIndividualNodeUptime = {
+  nodeType: ServiceType
   node: string
   metric: UptimeRecord | MetricError
   bucket: Bucket


### PR DESCRIPTION
### Description
Changes the protocol dashboard from using each node's self-reported uptime to querying a static set of nodes for every other node's uptime. Uses the result of whichever node returns the highest uptime %.

Note that discovery nodes only check uptime of other discovery nodes, and content nodes only check uptime of other content nodes.

### How Has This Been Tested?
`npm run start:prod` shows nearly all green uptimes now.

<img width="958" alt="uptime charts" src="https://github.com/AudiusProject/audius-protocol/assets/4657956/38fec7cd-7597-4590-b170-7d105c685b84">
