### PR TITLE
Add maxsockets flag as workaround for constant npm ECONNRESET failures

### DIFF
--- a/packages/commands/Dockerfile.prod
+++ b/packages/commands/Dockerfile.prod
@@ -26,7 +26,7 @@ COPY --from=builder /app/out/json/ .
 COPY --from=builder /app/out/package-lock.json ./package-lock.json
 COPY --from=builder /app/scripts ./scripts
 
-RUN CI=true npm i
+RUN CI=true npm i --maxsockets 1
 
 # Build the project and its dependencies
 COPY --from=builder /app/out/full/ .

--- a/packages/discovery-provider/plugins/pedalboard/docker/Dockerfile.prod
+++ b/packages/discovery-provider/plugins/pedalboard/docker/Dockerfile.prod
@@ -41,7 +41,7 @@ COPY --from=builder /app/out/package-lock.json ./package-lock.json
 COPY --from=builder /app/scripts ./scripts
 
 RUN echo "installing deps for ${APP_NAME}"
-RUN CI=true npm i
+RUN CI=true npm i --maxsockets 1
 
 # Build the project and its dependencies
 COPY --from=builder /app/out/full/ .

--- a/packages/identity-service/Dockerfile.prod
+++ b/packages/identity-service/Dockerfile.prod
@@ -33,7 +33,7 @@ COPY --from=builder /app/out/package-lock.json ./package-lock.json
 COPY --from=builder /app/scripts ./scripts
 COPY --from=builder /app/packages/identity-service/patches ./packages/identity-service/patches
 
-RUN CI=true npm i
+RUN CI=true npm i --maxsockets 1
 
 # Build the project and its dependencies
 COPY --from=builder /app/out/full/ .


### PR DESCRIPTION
### Description

We're getting too many false negative CI results due to npm ECONNRESET errors. [Example](https://app.circleci.com/pipelines/github/AudiusProject/audius-protocol/51392/workflows/ded38c43-6290-4a16-a486-f8f20e3a11b0/jobs/673353/parallel-runs/0/steps/0-103).

According to [this](https://github.com/npm/cli/issues/4652), setting maxsockets to 1 is a potential workaround.

### How Has This Been Tested?

CI