### PR TITLE
fix ddex-publisher ci

### DIFF
--- a/dev-tools/compose/docker-compose.yml
+++ b/dev-tools/compose/docker-compose.yml
@@ -208,6 +208,12 @@ services:
       service: ddex-parser
     <<: *common
 
+  ddex-publisher:
+    extends:
+      file: docker-compose.ddex.yml
+      service: ddex-publisher
+    <<: *common
+
   ddex-mongo:
     extends:
       file: docker-compose.ddex.yml


### PR DESCRIPTION
### Description
Forgot to add ddex-publisher to the top level docker compose yml. 
https://app.circleci.com/pipelines/github/AudiusProject/audius-protocol/51443/workflows/b15d5091-6bce-48b7-ab79-0be0cdd7522f/jobs/674538

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._
