### PR TITLE
Fix duplicate unregistered SPs on healthz overview

### DIFF
--- a/monitoring/healthz/src/useServiceProviders.ts
+++ b/monitoring/healthz/src/useServiceProviders.ts
@@ -56,13 +56,10 @@ export function useServiceProviders(
   type: 'content' | 'discovery',
   excludeUnregistered = false
 ) {
-  const { data: sps, error } = useSWR<SP[]>([env, type], async () => {
+  const { data: sps, error } = useSWR<SP[]>([env, type, excludeUnregistered], async () => {
     const sps = await apiGatewayFetcher(env, type)
     hostSort(sps)
-    if (type === 'discovery' && !excludeUnregistered) {
-      sps.push(...unregisteredNodes(env === 'prod'))
-    }
-    return sps
+    return excludeUnregistered || type === 'content' ? sps : [...sps, ...unregisteredNodes(env === 'prod')]
   })
   return { data: sps, error }
 }


### PR DESCRIPTION
### Description
When switching back and forth between stage/prod and discovery/content on the healthz nodes overview, duplicate unregistered nodes would show up. This PR fixes the caching issue which caused the duplicate display.

### How Has This Been Tested?
This is deployed to prod healthz.audius.co where the UI now works as expected.