### PR TITLE
Fix isrc/iswc regex

### DIFF
--- a/packages/web/src/pages/upload-page/fields/AttributionField.tsx
+++ b/packages/web/src/pages/upload-page/fields/AttributionField.tsx
@@ -106,8 +106,11 @@ const derivativeWorksValues = [
   { key: null, text: messages.derivativeWorks.options.null }
 ]
 
-const isrcRegex = /^[A-Z]{2}-[A-Z\d]{3}-\d{2}-\d{5}$/i
-const iswcRegex = /^T-\d{9}-\d$/i
+// Use standard ISRC and ISWC formats, but allow for optional periods and hyphens
+// ISRC: https://www.wikidata.org/wiki/Property:P1243
+// ISWC: https://www.wikidata.org/wiki/Property:P1827
+const isrcRegex = /^[A-Z]{2}-?[A-Z\d]{3}-?\d{2}-?\d{5}$/i
+const iswcRegex = /^T-?\d{3}.?\d{3}.?\d{3}.?-?\d$/i
 
 const AttributionFormSchema = z
   .object({


### PR DESCRIPTION
### Description

We are too heavy handed about enforcing hyphens and period. Not even the wikidata for ISRC requires them https://www.wikidata.org/wiki/Property:P1243

This change allows for optional hyphens for ISRC and period for ISWC. Additionally, ISWC may contain period which we were not capturing correctly either.

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._

![image](https://github.com/AudiusProject/audius-protocol/assets/2731362/5649a1d4-967e-4ab6-bbe0-cb2ebdcd8ff1)
![image](https://github.com/AudiusProject/audius-protocol/assets/2731362/a4663d56-3e4f-48a4-8f51-40873c867f82)

