### PR TITLE
Refactor to use Harmony PasswordInput in native

### DIFF
--- a/packages/mobile/src/components/enter-password/EnterPassword.tsx
+++ b/packages/mobile/src/components/enter-password/EnterPassword.tsx
@@ -3,8 +3,8 @@ import { useState } from 'react'
 import commonPasswordList from 'fxa-common-password-list'
 import { View } from 'react-native'
 
-import { IconArrowRight } from '@audius/harmony-native'
-import { Button, TextInput } from 'app/components/core'
+import { IconArrowRight, PasswordInput } from '@audius/harmony-native'
+import { Button } from 'app/components/core'
 import LoadingSpinner from 'app/components/loading-spinner'
 import { StatusMessage } from 'app/components/status-message'
 import { makeStyles } from 'app/styles'
@@ -61,8 +61,7 @@ const messages = {
 
 const useStyles = makeStyles(({ spacing }) => ({
   input: {
-    marginTop: spacing(3),
-    paddingVertical: spacing(3)
+    marginTop: spacing(3)
   },
   button: {
     width: '100%',
@@ -191,23 +190,19 @@ export const EnterPassword = (props: EnterPasswordProps) => {
 
   return (
     <View style={{ width: '100%' }}>
-      <TextInput
+      <PasswordInput
         style={styles.input}
-        placeholder={messages.passwordPlaceholder}
+        label={messages.passwordPlaceholder}
         value={password}
         onChangeText={handlePasswordChange}
         onBlur={handlePasswordBlur}
-        textContentType='password'
-        secureTextEntry
       />
-      <TextInput
+      <PasswordInput
         style={styles.input}
-        placeholder={messages.confirmationPlaceholder}
+        label={messages.confirmationPlaceholder}
         value={passwordConfirmation}
         onChangeText={handlePasswordConfirmationChange}
         onBlur={handleConfirmationBlur}
-        textContentType='password'
-        secureTextEntry
       />
       <View style={styles.checkContainer}>
         {pwdChecks.map((check, i) => (

--- a/packages/mobile/src/components/status-message/StatusMessage.tsx
+++ b/packages/mobile/src/components/status-message/StatusMessage.tsx
@@ -60,7 +60,11 @@ export const StatusMessage = ({
 
   return (
     <View style={[styles.root, style, stylesProp.root]}>
-      <Icon style={[styles.iconPlaceholder, styles.icon]} />
+      <Icon
+        style={[styles.iconPlaceholder, styles.icon]}
+        height={16}
+        width={16}
+      />
       <Text
         style={[
           styles.label,

--- a/packages/mobile/src/screens/change-password-screen/ConfirmCredentials.tsx
+++ b/packages/mobile/src/screens/change-password-screen/ConfirmCredentials.tsx
@@ -5,11 +5,15 @@ import {
   changePasswordSelectors,
   changePasswordActions
 } from '@audius/common'
-import { View } from 'react-native'
 import { useDispatch, useSelector } from 'react-redux'
 
-import { IconArrowRight } from '@audius/harmony-native'
-import { Button, TextInput } from 'app/components/core'
+import {
+  Flex,
+  IconArrowRight,
+  PasswordInput,
+  TextInput
+} from '@audius/harmony-native'
+import { Button } from 'app/components/core'
 import LoadingSpinner from 'app/components/loading-spinner'
 import { StatusMessage } from 'app/components/status-message'
 import { makeStyles } from 'app/styles'
@@ -33,19 +37,8 @@ const messages = {
   errorText: 'Invalid Credentials'
 }
 
-const useStyles = makeStyles(({ spacing }) => ({
-  input: {
-    marginTop: spacing(3),
-    paddingVertical: spacing(3)
-  },
-  button: {
-    marginTop: spacing(4)
-  }
-}))
-
 export const ConfirmCredentials = ({ onComplete }: ConfirmCredentialsProps) => {
   const dispatch = useDispatch()
-  const styles = useStyles()
   const [email, setEmail] = useState('')
   const [password, setPassword] = useState('')
   const [errorSeen, setErrorSeen] = useState(false)
@@ -75,22 +68,18 @@ export const ConfirmCredentials = ({ onComplete }: ConfirmCredentialsProps) => {
   }, [email, hasSubmitted, onComplete, password, status])
 
   return (
-    <View style={{ width: '100%' }}>
+    <Flex w='100%' gap='l' mt='xl'>
       <TextInput
-        style={styles.input}
         onChangeText={handleEmailChange}
         onKeyPress={handleKeyPress}
         textContentType='emailAddress'
-        placeholder={messages.emailPlaceholder}
+        label={messages.emailPlaceholder}
         value={email}
       />
-      <TextInput
-        style={styles.input}
+      <PasswordInput
         onChangeText={handlePasswordChange}
         onKeyPress={handleKeyPress}
-        textContentType='password'
-        secureTextEntry
-        placeholder={messages.passwordPlaceholder}
+        label={messages.passwordPlaceholder}
         value={password}
       />
       {status === Status.ERROR && !errorSeen ? (
@@ -98,7 +87,6 @@ export const ConfirmCredentials = ({ onComplete }: ConfirmCredentialsProps) => {
       ) : null}
       <Button
         styles={{
-          root: styles.button,
           button: {
             width: '100%',
             borderRadius: 4,
@@ -111,6 +99,6 @@ export const ConfirmCredentials = ({ onComplete }: ConfirmCredentialsProps) => {
         iconPosition='right'
         title={messages.buttonText}
       />
-    </View>
+    </Flex>
   )
 }

--- a/packages/mobile/src/screens/change-password-screen/ConfirmCredentials.tsx
+++ b/packages/mobile/src/screens/change-password-screen/ConfirmCredentials.tsx
@@ -16,7 +16,6 @@ import {
 import { Button } from 'app/components/core'
 import LoadingSpinner from 'app/components/loading-spinner'
 import { StatusMessage } from 'app/components/status-message'
-import { makeStyles } from 'app/styles'
 import { useThemeColors } from 'app/utils/theme'
 const { confirmCredentials } = changePasswordActions
 const { getConfirmCredentialsStatus } = changePasswordSelectors


### PR DESCRIPTION
### Description

- Use Harmony `PasswordInput` for the change password screens
- Fix a lingering icon bug
- Didnt change old sign up since this is going away soon
<img width="300" alt="image" src="https://github.com/AudiusProject/audius-protocol/assets/6711655/4a08b808-b45b-4390-932c-1138f6e6fecc">
<img width="300" alt="image" src="https://github.com/AudiusProject/audius-protocol/assets/6711655/9e0b1f42-2386-453a-a481-5ced4447e5e6">



### How Has This Been Tested?

local ios:stage
