### PR TITLE
Upload includes download_conditions splits, orig_filename for stems

### DIFF
--- a/packages/web/src/common/store/upload/sagaHelpers.ts
+++ b/packages/web/src/common/store/upload/sagaHelpers.ts
@@ -124,10 +124,21 @@ export function* processTracksForUpload(tracks: TrackForUpload[]) {
 
   tracks.forEach((track) => {
     const streamConditions = track.metadata.stream_conditions
+    const downloadConditions = track.metadata.download_conditions
     if (isContentUSDCPurchaseGated(streamConditions)) {
       const priceCents = streamConditions.usdc_purchase.price
       const priceWei = new BN(priceCents).mul(BN_USDC_CENT_WEI).toNumber()
       streamConditions.usdc_purchase = {
+        price: priceCents,
+        splits: {
+          [ownerUserbank?.toString() ?? '']: priceWei
+        }
+      }
+    }
+    if (isContentUSDCPurchaseGated(downloadConditions)) {
+      const priceCents = downloadConditions.usdc_purchase.price
+      const priceWei = new BN(priceCents).mul(BN_USDC_CENT_WEI).toNumber()
+      downloadConditions.usdc_purchase = {
         price: priceCents,
         splits: {
           [ownerUserbank?.toString() ?? '']: priceWei

--- a/packages/web/src/pages/upload-page/store/utils/processFiles.ts
+++ b/packages/web/src/pages/upload-page/store/utils/processFiles.ts
@@ -93,7 +93,8 @@ export const processFiles = (
       preview: audio,
       metadata: newTrackMetadata({
         title,
-        artwork
+        artwork,
+        orig_filename: file.name
       })
     }
   })


### PR DESCRIPTION
### Description
These fields were missing from the track metadata during upload.

### How Has This Been Tested?

Uploaded locally, confirmed tracks table got correct values:

<img width="1176" alt="Screenshot 2024-01-31 at 5 28 41 PM" src="https://github.com/AudiusProject/audius-protocol/assets/3893871/da99dadd-1fa7-4c63-b568-72e52e0c8dfd">
