### PR TITLE
ONC-1: add metrics backfill

### DIFF
--- a/packages/discovery-provider/ddl/migrations/0050_backfill_dashboard_metrics.sql
+++ b/packages/discovery-provider/ddl/migrations/0050_backfill_dashboard_metrics.sql
@@ -1,0 +1,48 @@
+BEGIN;
+DO $$ BEGIN
+-- Prod gate so migration doesn't run on stage or dev
+IF EXISTS (SELECT * FROM "blocks" WHERE "blockhash" = '0x6d85ed08b546d192e0342efbf6e8007d449cb4c32a05a0fe27f19a475ab32127') THEN
+  -- Uniques 
+  UPDATE aggregate_daily_unique_users_metrics
+  SET summed_count = 117960, count = 77208
+  WHERE timestamp = '2024-01-25';
+
+  UPDATE aggregate_daily_unique_users_metrics
+  SET summed_count = 119635, count = 77431
+  WHERE timestamp = '2024-01-26';
+
+  UPDATE aggregate_daily_unique_users_metrics
+  SET summed_count = 121309, count = 77654
+  WHERE timestamp = '2024-01-27';
+
+  UPDATE aggregate_daily_unique_users_metrics
+  SET summed_count = 122983, count = 77877
+  WHERE timestamp = '2024-01-28';
+
+  UPDATE aggregate_daily_unique_users_metrics
+  SET summed_count = 124658, count = 78100
+  WHERE timestamp = '2024-01-29';
+
+  -- Totals
+  UPDATE aggregate_daily_total_users_metrics
+  SET count = 3171019
+  WHERE timestamp = '2024-01-25';
+
+  UPDATE aggregate_daily_total_users_metrics
+  SET count = 3196963
+  WHERE timestamp = '2024-01-26';
+
+  UPDATE aggregate_daily_total_users_metrics
+  SET count = 3222907
+  WHERE timestamp = '2024-01-27';
+
+  UPDATE aggregate_daily_total_users_metrics
+  SET count = 3248851
+  WHERE timestamp = '2024-01-28';
+
+  UPDATE aggregate_daily_total_users_metrics
+  SET count = 3274795
+  WHERE timestamp = '2024-01-29';
+END IF;
+END $$;
+COMMIT;


### PR DESCRIPTION
### Description
Backfills missing data introduced by the bug this PR fixed https://github.com/AudiusProject/audius-protocol/pull/7365. 

TLDR, this data has to be interpolated for accuracy as the metrics system we have did not keep the information we needed past a day. The method I used to get these numbers can be reproed here from this gist. https://gist.github.com/alecsavvy/4320c1d4cd6105533f47db8ed8f6abdf

The numbers I put in can be found in this table here, interpolated values are in green and should be left out when running with the script.
![Screenshot 2024-01-31 at 8 50 09 PM](https://github.com/AudiusProject/audius-protocol/assets/16739903/a0dddec4-2570-45f8-884b-2db12139bdea)

The issue: When nodes collect metrics there is two high level steps that happen. First a node on an interval will reach out to all other available registered nodes and pull in their metrics, adding it to its personal ones, and coming up with its own network wide aggregate view. Then on a longer interval a consensus occurs where the nodes go around and see who has the largest aggregate. Whoever has that, all the nodes pull into their own and that's how you get matching metrics across all nodes. The issue is during this first step the bug prevented all the nodes from gathering each others information and basically only held their own. However, nodes were still able to communicate for the consensus portion and after a bit reflected the metrics of the highest activity node.

Solution attempt one, get each nodes personal data from each day between Jan 25th -> Jan 29th 2024.
When going to [dashboard.audius.org ](https://dashboard.audius.org/#/analytics) and opening the network tab you will see that [this](https://discoveryprovider2.audius.co/v1/metrics/aggregates/routes/month?bucket_size=day) is called. This call is mostly what powers the two graphs you see. Originally I didn't know these were all matching across nodes. The first iteration of this I rounded up all the nodes, called this endpoint, and added up all the numerical fields. These resulted in numbers in the 10s of millions for API requests and super low user activity. Not correct. This is because of the consensus issue before. We basically multiplied the most active node * n available nodes in the network.

Solution attempt two, using the /metrics/historical endpoints. These were a little closer but still too far off. Somewhere around 1mil for API calls whereas we're expecting more like 3 million. Reconstructing aggregates I don't think is what these endpoints are for.

Solution attempt three, using the /routes/cached endpoints. These could be useful in the future but what made these not usable in this case is they fall off after ~24 hours. Had we kept data for a week this would've been a valid solution where we could reconstruct all the stats for specific days.

Solution (four): since none of the endpoints we have give us exactly what we need, interpolating the values is the closest we're going to get. Nothing drastic happened in this timeframe so these numbers are likely very close to what should've been present in the graph all along.


### How Has This Been Tested?
Will run on a sandbox machine and verify the endpoint returns as expected.
