### PR TITLE
Add orig_filename to track/stems endpoint

### DIFF
--- a/packages/discovery-provider/src/api/v1/helpers.py
+++ b/packages/discovery-provider/src/api/v1/helpers.py
@@ -400,12 +400,14 @@ def stem_from_track(track):
     track_id = encode_int_id(track["track_id"])
     parent_id = encode_int_id(track["stem_of"]["parent_track_id"])
     category = track["stem_of"]["category"]
+    orig_filename = track["orig_filename"]
     return {
         "id": track_id,
         "parent_id": parent_id,
         "category": category,
         "cid": track["download"]["cid"],
         "user_id": encode_int_id(track["owner_id"]),
+        "orig_filename": orig_filename,
         "blocknumber": track["blocknumber"],
     }
 


### PR DESCRIPTION
### Description
`orig_filename` was still missing from stem tracks on client cache, think we need to add it here.

### How Has This Been Tested?

Untested - ran into problems with uploading tracks on local dev stack, this seems like a safe change so going to just test on stage.
