### PR TITLE
Add stem orig_filename to tracks/<id>/stems

### DIFF
--- a/packages/common/src/models/Track.ts
+++ b/packages/common/src/models/Track.ts
@@ -248,6 +248,7 @@ export type OfflineTrackMetadata = {
 export type Stem = {
   track_id: ID
   category: StemCategory
+  orig_filename: string
 }
 
 export type ComputedTrackProperties = {

--- a/packages/common/src/services/audius-api-client/ResponseAdapter.ts
+++ b/packages/common/src/services/audius-api-client/ResponseAdapter.ts
@@ -477,7 +477,7 @@ export const makeStemTrack = (stem: APIStem): StemTrackMetadata | undefined => {
     access: { stream: true, download: true },
     track_cid: '',
     orig_file_cid: '',
-    orig_filename: '',
+    orig_filename: stem.orig_filename,
     is_downloadable: false,
     is_original_available: false,
     is_playlist_upload: false

--- a/packages/common/src/services/audius-api-client/types.ts
+++ b/packages/common/src/services/audius-api-client/types.ts
@@ -173,6 +173,7 @@ export type APIStem = {
   category: StemCategory
   cid: CID
   blocknumber: number
+  orig_filename: string
 }
 
 export type APIPlaylistAddedTimestamp = {

--- a/packages/discovery-provider/src/api/v1/models/tracks.py
+++ b/packages/discovery-provider/src/api/v1/models/tracks.py
@@ -183,7 +183,7 @@ stem_full = ns.model(
         "cid": fields.String(required=True),
         "user_id": fields.String(required=True),
         "blocknumber": fields.Integer(required=True),
-        "orig_filename": fields.String(required=False),
+        "orig_filename": fields.String(required=True),
     },
 )
 

--- a/packages/discovery-provider/src/api/v1/models/tracks.py
+++ b/packages/discovery-provider/src/api/v1/models/tracks.py
@@ -183,6 +183,7 @@ stem_full = ns.model(
         "cid": fields.String(required=True),
         "user_id": fields.String(required=True),
         "blocknumber": fields.Integer(required=True),
+        "orig_filename": fields.String(required=False),
     },
 )
 

--- a/packages/web/src/common/store/cache/tracks/utils/fetchAndProcessStems.ts
+++ b/packages/web/src/common/store/cache/tracks/utils/fetchAndProcessStems.ts
@@ -46,7 +46,8 @@ export function* fetchAndProcessStems(trackId: ID) {
   // Create the update
   const stemsUpdate: Stem[] = stems.map((s) => ({
     track_id: s.track_id,
-    category: StemCategory[s.stem_of.category]
+    category: StemCategory[s.stem_of.category],
+    orig_filename: s.orig_filename ?? ''
   }))
 
   yield put(


### PR DESCRIPTION
### Description
Add stem tracks' `orig_filename` to the API request and client models.

EDIT: answer is yes
Question - is it safe to add `orig_filename` as a required param? After the migration will orig_filename be a required field in our db model? I believe it's `Optional` now but do we plan to change that / functionally will it be true that every track will have an `orig_filename`? https://github.com/AudiusProject/audius-protocol/blob/90fd1b104e5321d8da8e50715f9472fa0b6185de/packages/discovery-provider/src/tasks/metadata.py#L43

### How Has This Been Tested?

Tested with stage DN 4 and local web:
<img width="598" alt="Screenshot 2024-02-01 at 3 34 16 PM" src="https://github.com/AudiusProject/audius-protocol/assets/3893871/86e5b68a-134e-494e-9881-eff70cd6acc7">

