### PR TITLE
Fix copy icon color

### DIFF
--- a/packages/web/src/pages/private-key-exporter-page/AdvancedWalletDetails.tsx
+++ b/packages/web/src/pages/private-key-exporter-page/AdvancedWalletDetails.tsx
@@ -12,7 +12,6 @@ import { waitForLibsInit } from 'services/audius-backend/eagerLoadUtils'
 import { copyToClipboard } from 'utils/clipboardUtil'
 import { useSelector } from 'utils/reducer'
 
-import styles from './PrivateKeyExporterPage.module.css'
 import { useIsMobile } from 'hooks/useIsMobile'
 
 const getAccountUser = accountSelectors.getAccountUser
@@ -78,7 +77,7 @@ const Key = ({ label, value, isPrivate }: KeyProps) => {
       </Box>
       <Divider orientation='vertical' />
       <Box p='xl' css={{ width: 64 }}>
-        <IconCopy width={16} height={16} className={styles.copyIcon} />
+        <IconCopy width={16} height={16} color='default' />
       </Box>
     </Flex>
   )

--- a/packages/web/src/pages/private-key-exporter-page/PrivateKeyExporterModal.tsx
+++ b/packages/web/src/pages/private-key-exporter-page/PrivateKeyExporterModal.tsx
@@ -177,6 +177,7 @@ export const PrivateKeyExporterModal = () => {
   }, [isVisible, user, record])
   return (
     <ModalDrawer
+      useGradientTitle={false}
       bodyClassName={styles.modal}
       onClose={handleClose}
       isOpen={isVisible}

--- a/packages/web/src/pages/private-key-exporter-page/PrivateKeyExporterPage.module.css
+++ b/packages/web/src/pages/private-key-exporter-page/PrivateKeyExporterPage.module.css
@@ -3,10 +3,6 @@
   max-width: 132px;
 }
 
-.copyIcon path {
-  fill: var(--neutral-light-4);
-}
-
 .modal {
   min-width: 726px;
   max-width: 726px;


### PR DESCRIPTION
### Description

Apparently, `<ModalDrawer>` automatically mucks with the path styles of almost everything by default. That's weird.

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._
<img width="769" alt="image" src="https://github.com/AudiusProject/audius-protocol/assets/2731362/2a65416f-f151-4d87-ab3b-e76b2d618e80">
