### PR TITLE
[PAY-2404] Display correct file extensions when selecting download quality

### DIFF
--- a/packages/common/src/utils/fileUtils.ts
+++ b/packages/common/src/utils/fileUtils.ts
@@ -1,5 +1,7 @@
 import { Buffer } from 'buffer'
 
+import { Nullable } from './typeUtils'
+
 /** Convert a base64 string to a file object */
 export const dataURLtoFile = async (
   dataUrl: string,
@@ -16,4 +18,20 @@ export const dataURLtoFile = async (
   const mime = mimeArr[1]
   const buff = Buffer.from(arr[1], 'base64')
   return new File([buff], fileName, { type: mime })
+}
+
+export const getDownloadFilename = ({
+  filename,
+  isOriginal
+}: {
+  filename?: Nullable<string>
+  isOriginal: boolean
+}) => {
+  if (!filename) return ''
+  if (isOriginal) return filename
+  else {
+    const split = filename.split('.')
+    split.pop()
+    return `${split.join('.')}.mp3`
+  }
 }

--- a/packages/mobile/src/screens/track-screen/DownloadRow.tsx
+++ b/packages/mobile/src/screens/track-screen/DownloadRow.tsx
@@ -1,6 +1,7 @@
 import type { ID, DownloadQuality } from '@audius/common/models'
 import type { CommonState } from '@audius/common/store'
 import { cacheTracksSelectors } from '@audius/common/store'
+import { getDownloadFilename } from '@audius/common/utils'
 import { css } from '@emotion/native'
 import { useSelector } from 'react-redux'
 
@@ -16,20 +17,18 @@ const messages = {
 
 type DownloadRowProps = {
   trackId: ID
-  parentTrackId?: ID
-  quality: DownloadQuality
   hideDownload?: boolean
   index: number
   onDownload: (args: { trackIds: ID[]; parentTrackId?: ID }) => void
+  isOriginal: boolean
 }
 
 export const DownloadRow = ({
   trackId,
-  parentTrackId,
-  quality,
   hideDownload,
   index,
-  onDownload
+  onDownload,
+  isOriginal = true
 }: DownloadRowProps) => {
   const track = useSelector((state: CommonState) =>
     getTrack(state, { id: trackId })
@@ -64,7 +63,10 @@ export const DownloadRow = ({
             ellipsizeMode='tail'
             numberOfLines={1}
           >
-            {track?.orig_filename}
+            {getDownloadFilename({
+              filename: track?.orig_filename,
+              isOriginal
+            })}
           </Text>
         </Flex>
       </Flex>

--- a/packages/mobile/src/screens/track-screen/DownloadRow.tsx
+++ b/packages/mobile/src/screens/track-screen/DownloadRow.tsx
@@ -1,4 +1,4 @@
-import type { ID, DownloadQuality } from '@audius/common/models'
+import type { ID } from '@audius/common/models'
 import type { CommonState } from '@audius/common/store'
 import { cacheTracksSelectors } from '@audius/common/store'
 import { getDownloadFilename } from '@audius/common/utils'

--- a/packages/mobile/src/screens/track-screen/DownloadSection.tsx
+++ b/packages/mobile/src/screens/track-screen/DownloadSection.tsx
@@ -213,16 +213,15 @@ export const DownloadSection = ({ trackId }: { trackId: ID }) => {
         {track?.is_downloadable ? (
           <DownloadRow
             trackId={trackId}
-            quality={quality}
             index={ORIGINAL_TRACK_INDEX}
             hideDownload={shouldHideDownload}
             onDownload={handleDownload}
+            isOriginal={quality === DownloadQuality.ORIGINAL}
           />
         ) : null}
         {stemTracks?.map((s, i) => (
           <DownloadRow
             trackId={s.id}
-            parentTrackId={trackId}
             key={s.id}
             index={
               i +
@@ -230,9 +229,9 @@ export const DownloadSection = ({ trackId }: { trackId: ID }) => {
                 ? STEM_INDEX_OFFSET_WITH_ORIGINAL_TRACK
                 : STEM_INDEX_OFFSET_WITHOUT_ORIGINAL_TRACK)
             }
-            quality={quality}
             hideDownload={shouldHideDownload}
             onDownload={handleDownload}
+            isOriginal={quality === DownloadQuality.ORIGINAL}
           />
         ))}
         {shouldDisplayDownloadAll ? (

--- a/packages/web/src/components/track/DownloadRow.tsx
+++ b/packages/web/src/components/track/DownloadRow.tsx
@@ -1,9 +1,9 @@
 import { useDownloadableContentAccess } from '@audius/common/hooks'
 import { ID } from '@audius/common/models'
 import { cacheTracksSelectors, CommonState } from '@audius/common/store'
+import { getDownloadFilename, formatBytes } from '@audius/common/utils'
 import { Flex, IconReceive, PlainButton, Text } from '@audius/harmony'
 import { shallowEqual, useSelector } from 'react-redux'
-import { formatBytes } from '@audius/common/utils'
 
 import { Icon } from 'components/Icon'
 import Tooltip from 'components/tooltip/Tooltip'
@@ -21,6 +21,7 @@ type DownloadRowProps = {
   hideDownload?: boolean
   index: number
   size?: number
+  isOriginal: boolean
 }
 
 export const DownloadRow = ({
@@ -28,7 +29,8 @@ export const DownloadRow = ({
   onDownload,
   hideDownload,
   index,
-  size
+  size,
+  isOriginal
 }: DownloadRowProps) => {
   const track = useSelector(
     (state: CommonState) => getTrack(state, { id: trackId }),
@@ -68,7 +70,10 @@ export const DownloadRow = ({
             {track?.stem_of?.category ?? messages.fullTrack}
           </Text>
           <Text variant='body' color='subdued'>
-            {track?.orig_filename}
+            {getDownloadFilename({
+              filename: track?.orig_filename,
+              isOriginal
+            })}
           </Text>
         </Flex>
       </Flex>

--- a/packages/web/src/components/track/DownloadSection.tsx
+++ b/packages/web/src/components/track/DownloadSection.tsx
@@ -31,12 +31,12 @@ import { useModalState } from 'common/hooks/useModalState'
 import { TrackEvent, make } from 'common/store/analytics/actions'
 import { Icon } from 'components/Icon'
 import { Expandable } from 'components/expandable/Expandable'
-import { audiusSdk } from 'services/audius-sdk'
 import {
   useAuthenticatedCallback,
   useAuthenticatedClickCallback
 } from 'hooks/useAuthenticatedCallback'
 import { useIsMobile } from 'hooks/useIsMobile'
+import { audiusSdk } from 'services/audius-sdk'
 
 import { DownloadRow } from './DownloadRow'
 
@@ -263,6 +263,7 @@ export const DownloadSection = ({ trackId }: DownloadSectionProps) => {
                 index={ORIGINAL_TRACK_INDEX}
                 hideDownload={shouldHideDownload}
                 size={fileSizes[trackId]}
+                isOriginal={quality === DownloadQuality.ORIGINAL}
               />
             ) : null}
             {stemTracks.map((s, i) => (
@@ -278,6 +279,7 @@ export const DownloadSection = ({ trackId }: DownloadSectionProps) => {
                     ? STEM_INDEX_OFFSET_WITH_ORIGINAL_TRACK
                     : STEM_INDEX_OFFSET_WITHOUT_ORIGINAL_TRACK)
                 }
+                isOriginal={quality === DownloadQuality.ORIGINAL}
               />
             ))}
             {/* Only display this row if original quality is not available,


### PR DESCRIPTION
### Description
Display `.mp3` when selecting mp3 quality and the original file extension when selecting original file quality.

### How Has This Been Tested?

https://github.com/AudiusProject/audius-protocol/assets/3893871/7b14d839-147c-4785-ac1b-99d73f834e8b

