### PR TITLE
[ONC-7] Move to opensea api v2

### DIFF
--- a/packages/common/src/hooks/useCoinflowAdapter.ts
+++ b/packages/common/src/hooks/useCoinflowAdapter.ts
@@ -74,7 +74,7 @@ export const useCoinflowWithdrawalAdapter = () => {
       })
     }
     initWallet()
-  }, [audiusBackend])
+  }, [audiusBackend, feePayerOverride])
 
   return adapter
 }

--- a/packages/common/src/models/OpenSea.ts
+++ b/packages/common/src/models/OpenSea.ts
@@ -27,11 +27,11 @@ type AssetContract = {
   payout_address: Nullable<string>
 }
 
-type AssetCollection = {
-  slug: string
+export type OpenSeaCollection = {
+  collection: string
   name: string
   description: string
-  external_url: string
+  project_url: string
   image_url: string
 }
 
@@ -43,41 +43,56 @@ type AssetPerson = {
 } | null
 type AssetOwner = AssetPerson
 type AssetCreator = AssetPerson
-export type OpenSeaAsset = {
-  token_id: string
-  name: Nullable<string>
-  description: Nullable<string>
-  external_link: Nullable<string>
-  permalink: Nullable<string>
-  image_url: Nullable<string>
-  image_preview_url: Nullable<string>
-  image_thumbnail_url: Nullable<string>
-  image_original_url: Nullable<string>
-  animation_url: Nullable<string>
-  animation_original_url: Nullable<string>
-  youtube_url: Nullable<string>
-  background_color: Nullable<string>
-  owner: Nullable<AssetOwner>
-  creator: Nullable<AssetCreator>
-  asset_contract: Nullable<AssetContract>
-  collection: Nullable<AssetCollection>
+
+// This metadata object is absurd. It is the combination of
+// some real standards and some just random fields we get back.
+// Use it to try to display whatever we can. Yay NFTs.
+export type OpenSeaNftMetadata = {
+  token_id?: string
+  name?: string
+  description?: string
+  external_url?: string
+  permalink?: string
+  image?: string
+  image_url?: string
+  image_preview_url?: string
+  image_thumbnail_url?: string
+  image_original_url?: string
+  animation_url?: string
+  animation_original_url?: string
+  youtube_url?: string
+  background_color?: string
+  owner?: AssetOwner
+  creator?: AssetCreator
+  asset_contract?: AssetContract
 }
 
-export type OpenSeaAssetExtended = OpenSeaAsset & { wallet: string }
+export type OpenSeaNft = {
+  identifier: string
+  collection: string
+  contract: string
+  token_standard: string
+  name: string
+  description: string
+  image_url: string
+  metadata_url: string
+  opensea_url: string
+  // Audius added fields
+  wallet: string
+}
+
+export type OpenSeaNftExtended = OpenSeaNft &
+  OpenSeaNftMetadata & { collectionMetadata?: OpenSeaCollection }
 
 export type OpenSeaEvent = {
   id: number
-  created_date: string
-  from_account: {
-    address: string
-  }
-  to_account: {
-    address: string
-  }
-  asset: OpenSeaAsset
+  event_timestamp: number
+  from_address: string
+  to_address: string
+  nft: OpenSeaNft
+  wallet: string
 }
 
-export type OpenSeaEventExtended = Omit<OpenSeaEvent, 'asset'> & {
-  asset: OpenSeaAssetExtended
-  wallet: string
+export type OpenSeaEventExtended = Omit<OpenSeaEvent, 'nft'> & {
+  nft: OpenSeaNftExtended
 }

--- a/packages/common/src/services/opensea-client/OpenSeaClient.ts
+++ b/packages/common/src/services/opensea-client/OpenSeaClient.ts
@@ -1,18 +1,21 @@
+import dayjs from 'dayjs'
+
 import { allSettled } from '~/utils/allSettled'
 
 import {
   Collectible,
   CollectibleState,
-  OpenSeaAsset,
-  OpenSeaAssetExtended,
+  OpenSeaNftMetadata,
+  OpenSeaNftExtended,
   OpenSeaEvent,
-  OpenSeaEventExtended
+  OpenSeaEventExtended,
+  OpenSeaNft,
+  OpenSeaCollection
 } from '../../models'
 
 import {
   isAssetValid,
   assetToCollectible,
-  creationEventToCollectible,
   transferEventToCollectible,
   isNotFromNullAddress
 } from './ethCollectibleHelpers'
@@ -28,16 +31,32 @@ export class OpenSeaClient {
   async getTransferredCollectiblesForWallet(
     wallet: string,
     limit = OPENSEA_NUM_ASSETS_LIMIT
-  ): Promise<{ asset_events: OpenSeaEvent[] }> {
-    return fetch(
-      `${this.url}/events?account_address=${wallet}&limit=${limit}&event_type=transfer&only_opensea=false`
-    ).then((r) => r.json())
+  ): Promise<OpenSeaEvent[]> {
+    let res: Response
+    let json: { next: string | undefined; asset_events: OpenSeaEvent[] }
+    let events: OpenSeaEvent[]
+    let next: string | undefined
+    res = await fetch(
+      `${this.url}/api/v2/events?account=${wallet}&limit=${limit}&event_type=transfer&chain=ethereum`
+    )
+    json = await res.json()
+    next = json.next
+    events = json.asset_events
+    while (next) {
+      res = await fetch(
+        `${this.url}/api/v2/events?account=${wallet}&limit=${limit}&event_type=transfer&chain=ethereum`
+      )
+      json = await res.json()
+      next = json.next
+      events = [...events, ...json.asset_events]
+    }
+    return events.map((event) => ({ ...event, wallet }))
   }
 
   async getTransferredCollectiblesForMultipleWallets(
     wallets: string[],
     limit = OPENSEA_NUM_ASSETS_LIMIT
-  ): Promise<OpenSeaEventExtended[]> {
+  ): Promise<OpenSeaEvent[]> {
     return allSettled(
       wallets.map((wallet) =>
         this.getTransferredCollectiblesForWallet(wallet, limit)
@@ -48,221 +67,212 @@ export class OpenSeaClient {
         .filter(({ result }) => result.status === 'fulfilled')
         .map(
           ({ result, wallet }) =>
-            (
-              result as PromiseFulfilledResult<{
-                asset_events: OpenSeaEvent[]
-              }>
-            ).value.asset_events?.map((event) => ({
-              ...event,
-              asset: { ...event.asset, wallet },
-              wallet
-            })) || []
+            (result as PromiseFulfilledResult<OpenSeaEvent[]>).value?.map(
+              (event) => ({
+                ...event,
+                nft: { ...event.nft, wallet },
+                wallet
+              })
+            ) || []
         )
         .flat()
     )
   }
 
-  async getCreatedCollectiblesForWallet(
-    wallet: string,
-    limit = OPENSEA_NUM_ASSETS_LIMIT
-  ): Promise<{ asset_events: OpenSeaEvent[] }> {
-    return fetch(
-      `${this.url}/events?account_address=${wallet}&limit=${limit}&event_type=created&only_opensea=false`
-    ).then((r) => r.json())
-  }
-
-  async getCreatedCollectiblesForMultipleWallets(
-    wallets: string[],
-    limit = OPENSEA_NUM_ASSETS_LIMIT
-  ): Promise<OpenSeaEventExtended[]> {
-    return allSettled(
-      wallets.map((wallet) =>
-        this.getCreatedCollectiblesForWallet(wallet, limit)
+  async getCollectiblesForWallet(wallet: string): Promise<OpenSeaNft[]> {
+    let res: Response
+    let json: { next: string | undefined; nfts: OpenSeaNft[] }
+    let nfts: OpenSeaNft[]
+    let next: string | undefined
+    res = await fetch(
+      `${this.url}/api/v2/chain/ethereum/account/${wallet}/nfts`
+    )
+    json = await res.json()
+    next = json.next
+    nfts = json.nfts
+    while (next) {
+      res = await fetch(
+        `${this.url}/api/v2/chain/ethereum/account/${wallet}/nfts`
       )
-    ).then((results) =>
-      results
-        .map((result, i) => ({ result, wallet: wallets[i] }))
-        .filter(({ result }) => result.status === 'fulfilled')
-        .map(
-          ({ result, wallet }) =>
-            (
-              result as PromiseFulfilledResult<{
-                asset_events: OpenSeaEvent[]
-              }>
-            ).value.asset_events?.map((event) => ({
-              ...event,
-              asset: { ...event.asset, wallet },
-              wallet
-            })) || []
-        )
-        .flat()
-    )
-  }
-
-  async getCollectiblesForWallet(
-    wallet: string,
-    limit = OPENSEA_NUM_ASSETS_LIMIT
-  ): Promise<{ assets: OpenSeaAsset[] }> {
-    return fetch(`${this.url}/assets?owner=${wallet}&limit=${limit}`).then(
-      (r) => r.json()
-    )
+      json = await res.json()
+      next = json.next
+      nfts = [...nfts, ...json.nfts]
+    }
+    return nfts.map((nft) => ({ ...nft, wallet }))
   }
 
   async getCollectiblesForMultipleWallets(
-    wallets: string[],
-    limit = OPENSEA_NUM_ASSETS_LIMIT
-  ): Promise<OpenSeaAssetExtended[]> {
+    wallets: string[]
+  ): Promise<OpenSeaNft[]> {
     return allSettled(
-      wallets.map((wallet) => this.getCollectiblesForWallet(wallet, limit))
+      wallets.map((wallet) => this.getCollectiblesForWallet(wallet))
     ).then((results) =>
       results
         .map((result, i) => ({ result, wallet: wallets[i] }))
         .filter(({ result }) => result.status === 'fulfilled')
         .map(
           ({ result, wallet }) =>
-            (
-              result as PromiseFulfilledResult<{
-                assets: OpenSeaAsset[]
-              }>
-            ).value.assets?.map((asset) => ({ ...asset, wallet })) || []
+            (result as PromiseFulfilledResult<OpenSeaNft[]>).value?.map(
+              (nft) => ({ ...nft, wallet })
+            ) || []
         )
         .flat()
     )
   }
 
-  async getAllCollectibles(wallets: string[]): Promise<CollectibleState> {
-    const lowercasedWallets = wallets.map((wallet) => wallet.toLowerCase())
+  async addNftMetadata(nft: OpenSeaNft): Promise<OpenSeaNftExtended> {
+    let metadata: OpenSeaNftMetadata | undefined
+    try {
+      const res = await fetch(nft.metadata_url)
+      metadata = await res.json()
+    } catch (e) {
+      console.error(e)
+      metadata = undefined
+    }
 
+    let collectionMetadata: OpenSeaCollection | undefined
+    try {
+      const res = await fetch(
+        `${this.url}/api/v2/collections/${nft.collection}`
+      )
+      collectionMetadata = await res.json()
+    } catch (e) {
+      console.error(e)
+      collectionMetadata = undefined
+    }
+
+    return { ...nft, ...(metadata ?? {}), collectionMetadata }
+  }
+
+  async getAllCollectibles(wallets: string[]): Promise<CollectibleState> {
     return Promise.all([
       this.getCollectiblesForMultipleWallets(wallets),
-      this.getCreatedCollectiblesForMultipleWallets(wallets),
       this.getTransferredCollectiblesForMultipleWallets(wallets)
-    ]).then(async ([assets, creationEvents, transferEvents]) => {
-      const filteredAssets = assets.filter(
-        (asset) => asset && isAssetValid(asset)
-      )
-      const collectibles = await Promise.all(
-        filteredAssets.map(async (asset) => await assetToCollectible(asset))
-      )
-      const collectiblesMap: {
-        [key: string]: Collectible
-      } = collectibles.reduce(
-        (acc, curr) => ({
-          ...acc,
-          [curr.id]: curr
-        }),
-        {}
-      )
-      const ownedCollectibleKeySet = new Set(Object.keys(collectiblesMap))
-
-      // Handle transfers from NullAddress as if they were created events
-      const firstOwnershipTransferEvents = transferEvents
-        .filter(
-          (event) =>
-            event?.asset &&
-            isAssetValid(event.asset) &&
-            !isNotFromNullAddress(event)
+      // this.getCreatedCollectiblesForMultipleWallets(wallets)
+    ]).then(
+      async ([
+        nfts,
+        transferEvents
+        // , creationEvents
+      ]) => {
+        const assets = await Promise.all(
+          nfts.map(async (nft) => this.addNftMetadata(nft))
         )
-        .reduce((acc: { [key: string]: OpenSeaEventExtended }, curr) => {
-          const { token_id, asset_contract } = curr.asset
-          const id = `${token_id}:::${asset_contract?.address ?? ''}`
-          if (
-            acc[id] &&
-            acc[id].created_date.localeCompare(curr.created_date) > 0
-          ) {
-            return acc
-          }
-          return { ...acc, [id]: curr }
-        }, {})
-      await Promise.all(
-        Object.entries(firstOwnershipTransferEvents).map(async (entry) => {
-          const [id, event] = entry
-          if (ownedCollectibleKeySet.has(id)) {
-            collectiblesMap[id] = {
-              ...collectiblesMap[id],
-              dateLastTransferred: event.created_date
-            }
-          } else {
-            ownedCollectibleKeySet.add(id)
-            collectiblesMap[id] = await transferEventToCollectible(event, false)
-          }
-          return event
-        })
-      )
 
-      // Handle created events
-      await Promise.all(
-        creationEvents
-          .filter((event) => event?.asset && isAssetValid(event.asset))
-          .map(async (event) => {
-            const { token_id, asset_contract } = event.asset
-            const id = `${token_id}:::${asset_contract?.address ?? ''}`
-            if (!ownedCollectibleKeySet.has(id)) {
-              collectiblesMap[id] = await creationEventToCollectible(event)
+        const filteredAssets = assets.filter(
+          (asset) => asset && isAssetValid(asset)
+        )
+        const collectibles = await Promise.all(
+          filteredAssets.map(async (asset) => await assetToCollectible(asset))
+        )
+        const collectiblesMap: {
+          [key: string]: Collectible
+        } = collectibles.reduce(
+          (acc, curr) => ({
+            ...acc,
+            [curr.id]: curr
+          }),
+          {}
+        )
+        const ownedCollectibleKeySet = new Set(Object.keys(collectiblesMap))
+        const lowercasedWallets = wallets.map((wallet) => wallet.toLowerCase())
+
+        const transferEventsExtended: OpenSeaEventExtended[] =
+          await Promise.all(
+            transferEvents.map(async (event) => {
+              const nftMetadata = await this.addNftMetadata(event.nft)
+              return { ...event, nft: nftMetadata }
+            })
+          )
+        // Handle transfers from NullAddress as transferEventsExtended they were created events
+        const firstOwnershipTransferEvents = transferEventsExtended
+          .filter(
+            (event) =>
+              event?.nft &&
+              isAssetValid(event.nft) &&
+              !isNotFromNullAddress(event)
+          )
+          .reduce((acc: { [key: string]: OpenSeaEventExtended }, curr) => {
+            const { identifier, contract } = curr.nft
+            const id = `${identifier}:::${contract || ''}`
+            if (acc[id] && acc[id].event_timestamp - curr.event_timestamp > 0) {
+              return acc
+            }
+            return { ...acc, [id]: curr }
+          }, {})
+        await Promise.all(
+          Object.entries(firstOwnershipTransferEvents).map(async (entry) => {
+            const [id, event] = entry
+            if (ownedCollectibleKeySet.has(id)) {
+              collectiblesMap[id] = {
+                ...collectiblesMap[id],
+                dateLastTransferred: dayjs(event.event_timestamp).toString()
+              }
+            } else {
               ownedCollectibleKeySet.add(id)
+              collectiblesMap[id] = await transferEventToCollectible(
+                event,
+                false
+              )
             }
             return event
           })
-      )
-
-      // Handle transfers
-      const latestTransferEventsMap = transferEvents
-        .filter(
-          (event) =>
-            event?.asset &&
-            isAssetValid(event.asset) &&
-            isNotFromNullAddress(event)
         )
-        .reduce((acc: { [key: string]: OpenSeaEventExtended }, curr) => {
-          const { token_id, asset_contract } = curr.asset
-          const id = `${token_id}:::${asset_contract?.address ?? ''}`
-          if (
-            acc[id] &&
-            acc[id].created_date.localeCompare(curr.created_date) > 0
-          ) {
-            return acc
-          }
-          return { ...acc, [id]: curr }
-        }, {})
-      await Promise.all(
-        Object.values(latestTransferEventsMap).map(async (event) => {
-          const { token_id, asset_contract } = event.asset
-          const id = `${token_id}:::${asset_contract?.address ?? ''}`
-          if (ownedCollectibleKeySet.has(id)) {
-            // Remove collectible if it was transferred out from
-            // one of the user's wallets.
-            if (
-              lowercasedWallets.includes(
-                event.from_account.address.toLowerCase()
-              )
-            ) {
-              ownedCollectibleKeySet.delete(id)
-              delete collectiblesMap[id]
-            } else {
-              collectiblesMap[id] = {
-                ...collectiblesMap[id],
-                dateLastTransferred: event.created_date
-              }
-            }
-          } else if (
-            lowercasedWallets.includes(event.to_account.address.toLowerCase())
-          ) {
-            ownedCollectibleKeySet.add(id)
-            collectiblesMap[id] = await transferEventToCollectible(event)
-          }
-          return event
-        })
-      )
 
-      return Object.values(collectiblesMap).reduce(
-        (result, collectible) => ({
-          ...result,
-          [collectible.wallet]: (result[collectible.wallet] || []).concat([
-            collectible
-          ])
-        }),
-        {} as CollectibleState
-      )
-    })
+        // Handle transfers
+        const latestTransferEventsMap = transferEvents
+          .filter(
+            (event) =>
+              event?.nft &&
+              isAssetValid(event.nft) &&
+              isNotFromNullAddress(event)
+          )
+          .reduce((acc: { [key: string]: OpenSeaEventExtended }, curr) => {
+            const { identifier, contract } = curr.nft
+            const id = `${identifier}:::${contract || ''}`
+            if (acc[id] && acc[id].event_timestamp - curr.event_timestamp > 0) {
+              return acc
+            }
+            return { ...acc, [id]: curr }
+          }, {})
+        await Promise.all(
+          Object.values(latestTransferEventsMap).map(async (event) => {
+            const { identifier, contract } = event.nft
+            const id = `${identifier}:::${contract || ''}`
+            if (ownedCollectibleKeySet.has(id)) {
+              // Remove collectible if it was transferred out from
+              // one of the user's wallets.
+              if (
+                lowercasedWallets.includes(event.from_address.toLowerCase())
+              ) {
+                ownedCollectibleKeySet.delete(id)
+                delete collectiblesMap[id]
+              } else {
+                collectiblesMap[id] = {
+                  ...collectiblesMap[id],
+                  dateLastTransferred: dayjs(event.event_timestamp).toString()
+                }
+              }
+            } else if (
+              lowercasedWallets.includes(event.to_address.toLowerCase())
+            ) {
+              ownedCollectibleKeySet.add(id)
+              collectiblesMap[id] = await transferEventToCollectible(event)
+            }
+            return event
+          })
+        )
+
+        return Object.values(collectiblesMap).reduce(
+          (result, collectible) => ({
+            ...result,
+            [collectible.wallet]: (result[collectible.wallet] || []).concat([
+              collectible
+            ])
+          }),
+          {} as CollectibleState
+        )
+      }
+    )
   }
 }

--- a/packages/mobile/src/env/env.dev.ts
+++ b/packages/mobile/src/env/env.dev.ts
@@ -43,7 +43,7 @@ export const env: Env = {
   INSTAGRAM_APP_ID: '2875320099414320',
   INSTAGRAM_REDIRECT_URL: 'http://localhost:3000',
   METADATA_PROGRAM_ID: 'metaqbxxUerdq28cj1RbAWkYQm3ybzjb6a8bt518x1s',
-  OPENSEA_API_URL: 'https://rinkeby-api.opensea.io/api/v1',
+  OPENSEA_API_URL: 'https://rinkeby-api.opensea.io',
   OPTIMIZELY_KEY: 'MX4fYBgANQetvmBXGpuxzF',
   ORACLE_ETH_ADDRESSES:
     '0xF0D5BC18421fa04D0a2A2ef540ba5A9f04014BE3,0x325A621DeA613BCFb5B1A69a7aCED0ea4AfBD73A,0x3fD652C93dFA333979ad762Cf581Df89BaBa6795',

--- a/packages/mobile/src/env/env.prod.ts
+++ b/packages/mobile/src/env/env.prod.ts
@@ -45,7 +45,7 @@ export const env: Env = {
   INSTAGRAM_APP_ID: '189700309435573',
   INSTAGRAM_REDIRECT_URL: 'https://audius.co/',
   METADATA_PROGRAM_ID: 'metaqbxxUerdq28cj1RbAWkYQm3ybzjb6a8bt518x1s',
-  OPENSEA_API_URL: 'https://collectibles.audius.co/api/v1',
+  OPENSEA_API_URL: 'https://collectibles.audius.co',
   OPTIMIZELY_KEY: 'DAJbGEJBC21dzFRPv8snxs',
   ORACLE_ETH_ADDRESSES: '0x9811BA3eAB1F2Cd9A2dFeDB19e8c2a69729DC8b6',
   PAYMENT_ROUTER_PROGRAM_ID: 'paytYpX3LPN98TAeen6bFFeraGSuWnomZmCXjAsoqPa',

--- a/packages/mobile/src/env/env.stage.ts
+++ b/packages/mobile/src/env/env.stage.ts
@@ -45,7 +45,7 @@ export const env: Env = {
   INSTAGRAM_APP_ID: '2875320099414320',
   INSTAGRAM_REDIRECT_URL: 'https://staging.audius.co/',
   METADATA_PROGRAM_ID: 'metaqbxxUerdq28cj1RbAWkYQm3ybzjb6a8bt518x1s',
-  OPENSEA_API_URL: 'https://rinkeby-api.opensea.io/api/v1',
+  OPENSEA_API_URL: 'https://rinkeby-api.opensea.io',
   OPTIMIZELY_KEY: 'MX4fYBgANQetvmBXGpuxzF',
   ORACLE_ETH_ADDRESSES: '0x00b6462e955dA5841b6D9e1E2529B830F00f31Bf',
   PAYMENT_ROUTER_PROGRAM_ID: 'sp38CXGL9FoWPp9Avo4fevewEX4UqNkTSTFUPpQFRry',

--- a/packages/web/src/common/store/pages/token-dashboard/getWalletInfo.ts
+++ b/packages/web/src/common/store/pages/token-dashboard/getWalletInfo.ts
@@ -3,7 +3,7 @@ import { getContext } from '@audius/common/store'
 import { call } from 'typed-redux-saga'
 
 import {
-  fetchOpenSeaNftMetadatasForWallets,
+  fetchOpenSeaNftsForWallets,
   fetchSolanaCollectiblesForWallets
 } from 'common/store/profile/sagas'
 
@@ -20,7 +20,7 @@ export function* getWalletInfo(walletAddress: string, chain: Chain) {
 
   const collectiblesMap = (yield* call(
     chain === Chain.Eth
-      ? fetchOpenSeaNftMetadatasForWallets
+      ? fetchOpenSeaNftsForWallets
       : fetchSolanaCollectiblesForWallets,
     [walletAddress]
   )) as Record<string, string[]>

--- a/packages/web/src/common/store/pages/token-dashboard/getWalletInfo.ts
+++ b/packages/web/src/common/store/pages/token-dashboard/getWalletInfo.ts
@@ -3,7 +3,7 @@ import { getContext } from '@audius/common/store'
 import { call } from 'typed-redux-saga'
 
 import {
-  fetchOpenSeaAssetsForWallets,
+  fetchOpenSeaNftMetadatasForWallets,
   fetchSolanaCollectiblesForWallets
 } from 'common/store/profile/sagas'
 
@@ -20,7 +20,7 @@ export function* getWalletInfo(walletAddress: string, chain: Chain) {
 
   const collectiblesMap = (yield* call(
     chain === Chain.Eth
-      ? fetchOpenSeaAssetsForWallets
+      ? fetchOpenSeaNftMetadatasForWallets
       : fetchSolanaCollectiblesForWallets,
     [walletAddress]
   )) as Record<string, string[]>

--- a/packages/web/src/common/store/pages/token-dashboard/removeWalletSaga.ts
+++ b/packages/web/src/common/store/pages/token-dashboard/removeWalletSaga.ts
@@ -13,7 +13,7 @@ import {
 import { call, fork, put, select, takeLatest } from 'typed-redux-saga'
 
 import {
-  fetchOpenSeaNftMetadatas,
+  fetchOpenSeaNfts,
   fetchSolanaCollectibles
 } from 'common/store/profile/sagas'
 import { waitForWrite } from 'utils/sagaHelpers'
@@ -121,7 +121,7 @@ function* removeWallet(action: ConfirmRemoveWalletAction) {
     }
 
     yield* fork(fetchSolanaCollectibles, updatedMetadata)
-    yield* fork(fetchOpenSeaNftMetadatas, updatedMetadata)
+    yield* fork(fetchOpenSeaNfts, updatedMetadata)
   }
 
   function* onError() {

--- a/packages/web/src/common/store/pages/token-dashboard/removeWalletSaga.ts
+++ b/packages/web/src/common/store/pages/token-dashboard/removeWalletSaga.ts
@@ -13,7 +13,7 @@ import {
 import { call, fork, put, select, takeLatest } from 'typed-redux-saga'
 
 import {
-  fetchOpenSeaAssets,
+  fetchOpenSeaNftMetadatas,
   fetchSolanaCollectibles
 } from 'common/store/profile/sagas'
 import { waitForWrite } from 'utils/sagaHelpers'
@@ -121,7 +121,7 @@ function* removeWallet(action: ConfirmRemoveWalletAction) {
     }
 
     yield* fork(fetchSolanaCollectibles, updatedMetadata)
-    yield* fork(fetchOpenSeaAssets, updatedMetadata)
+    yield* fork(fetchOpenSeaNftMetadatas, updatedMetadata)
   }
 
   function* onError() {

--- a/packages/web/src/common/store/pages/token-dashboard/sagas.ts
+++ b/packages/web/src/common/store/pages/token-dashboard/sagas.ts
@@ -7,7 +7,7 @@ import {
 import { call, put, select, takeLatest } from 'typed-redux-saga'
 
 import {
-  fetchOpenSeaNftMetadatasForWallets,
+  fetchOpenSeaNftsForWallets,
   fetchSolanaCollectiblesForWallets
 } from 'common/store/profile/sagas'
 import { waitForRead } from 'utils/sagaHelpers'
@@ -27,7 +27,7 @@ function* fetchEthWalletInfo(wallets: string[]) {
   )
 
   const collectiblesMap = (yield* call(
-    fetchOpenSeaNftMetadatasForWallets,
+    fetchOpenSeaNftsForWallets,
     wallets
   )) as CollectibleState
 

--- a/packages/web/src/common/store/pages/token-dashboard/sagas.ts
+++ b/packages/web/src/common/store/pages/token-dashboard/sagas.ts
@@ -7,7 +7,7 @@ import {
 import { call, put, select, takeLatest } from 'typed-redux-saga'
 
 import {
-  fetchOpenSeaAssetsForWallets,
+  fetchOpenSeaNftMetadatasForWallets,
   fetchSolanaCollectiblesForWallets
 } from 'common/store/profile/sagas'
 import { waitForRead } from 'utils/sagaHelpers'
@@ -27,7 +27,7 @@ function* fetchEthWalletInfo(wallets: string[]) {
   )
 
   const collectiblesMap = (yield* call(
-    fetchOpenSeaAssetsForWallets,
+    fetchOpenSeaNftMetadatasForWallets,
     wallets
   )) as CollectibleState
 

--- a/packages/web/src/common/store/profile/sagas.js
+++ b/packages/web/src/common/store/profile/sagas.js
@@ -109,19 +109,19 @@ function* fetchProfileCustomizedCollectibles(user) {
   }
 }
 
-export function* fetchOpenSeaNftMetadatasForWallets(wallets) {
+export function* fetchOpenSeaNftsForWallets(wallets) {
   const openSeaClient = yield getContext('openSeaClient')
   return yield call([openSeaClient, openSeaClient.getAllCollectibles], wallets)
 }
 
-export function* fetchOpenSeaNftMetadatas(user) {
+export function* fetchOpenSeaNfts(user) {
   const apiClient = yield getContext('apiClient')
   const associatedWallets = yield apiClient.getAssociatedWallets({
     userID: user.user_id
   })
   if (associatedWallets) {
     const { wallets } = associatedWallets
-    const collectiblesMap = yield call(fetchOpenSeaNftMetadatasForWallets, [
+    const collectiblesMap = yield call(fetchOpenSeaNftsForWallets, [
       user.wallet,
       ...wallets
     ])
@@ -323,7 +323,7 @@ function* fetchProfileAsync(action) {
     }
 
     yield fork(fetchProfileCustomizedCollectibles, user)
-    yield fork(fetchOpenSeaNftMetadatas, user)
+    yield fork(fetchOpenSeaNfts, user)
     yield fork(fetchSolanaCollectibles, user)
 
     // Get current user notification & subscription status

--- a/packages/web/src/common/store/profile/sagas.js
+++ b/packages/web/src/common/store/profile/sagas.js
@@ -109,19 +109,19 @@ function* fetchProfileCustomizedCollectibles(user) {
   }
 }
 
-export function* fetchOpenSeaAssetsForWallets(wallets) {
+export function* fetchOpenSeaNftMetadatasForWallets(wallets) {
   const openSeaClient = yield getContext('openSeaClient')
   return yield call([openSeaClient, openSeaClient.getAllCollectibles], wallets)
 }
 
-export function* fetchOpenSeaAssets(user) {
+export function* fetchOpenSeaNftMetadatas(user) {
   const apiClient = yield getContext('apiClient')
   const associatedWallets = yield apiClient.getAssociatedWallets({
     userID: user.user_id
   })
   if (associatedWallets) {
     const { wallets } = associatedWallets
-    const collectiblesMap = yield call(fetchOpenSeaAssetsForWallets, [
+    const collectiblesMap = yield call(fetchOpenSeaNftMetadatasForWallets, [
       user.wallet,
       ...wallets
     ])
@@ -323,7 +323,7 @@ function* fetchProfileAsync(action) {
     }
 
     yield fork(fetchProfileCustomizedCollectibles, user)
-    yield fork(fetchOpenSeaAssets, user)
+    yield fork(fetchOpenSeaNftMetadatas, user)
     yield fork(fetchSolanaCollectibles, user)
 
     // Get current user notification & subscription status

--- a/packages/web/src/components/track/DownloadRow.tsx
+++ b/packages/web/src/components/track/DownloadRow.tsx
@@ -1,9 +1,9 @@
 import { useDownloadableContentAccess } from '@audius/common/hooks'
 import { ID } from '@audius/common/models'
 import { cacheTracksSelectors, CommonState } from '@audius/common/store'
+import { formatBytes } from '@audius/common/utils'
 import { Flex, IconReceive, PlainButton, Text } from '@audius/harmony'
 import { shallowEqual, useSelector } from 'react-redux'
-import { formatBytes } from '@audius/common/utils'
 
 import { Icon } from 'components/Icon'
 import Tooltip from 'components/tooltip/Tooltip'

--- a/packages/web/src/components/track/DownloadSection.tsx
+++ b/packages/web/src/components/track/DownloadSection.tsx
@@ -31,12 +31,12 @@ import { useModalState } from 'common/hooks/useModalState'
 import { TrackEvent, make } from 'common/store/analytics/actions'
 import { Icon } from 'components/Icon'
 import { Expandable } from 'components/expandable/Expandable'
-import { audiusSdk } from 'services/audius-sdk'
 import {
   useAuthenticatedCallback,
   useAuthenticatedClickCallback
 } from 'hooks/useAuthenticatedCallback'
 import { useIsMobile } from 'hooks/useIsMobile'
+import { audiusSdk } from 'services/audius-sdk'
 
 import { DownloadRow } from './DownloadRow'
 

--- a/packages/web/src/pages/private-key-exporter-page/AdvancedWalletDetails.tsx
+++ b/packages/web/src/pages/private-key-exporter-page/AdvancedWalletDetails.tsx
@@ -8,11 +8,10 @@ import pkg from 'bs58'
 
 import { make, useRecord } from 'common/store/analytics/actions'
 import { ToastContext } from 'components/toast/ToastContext'
+import { useIsMobile } from 'hooks/useIsMobile'
 import { waitForLibsInit } from 'services/audius-backend/eagerLoadUtils'
 import { copyToClipboard } from 'utils/clipboardUtil'
 import { useSelector } from 'utils/reducer'
-
-import { useIsMobile } from 'hooks/useIsMobile'
 
 const getAccountUser = accountSelectors.getAccountUser
 
@@ -72,7 +71,11 @@ const Key = ({ label, value, isPrivate }: KeyProps) => {
       <Divider orientation='vertical' />
       <Box p='xl' css={isMobile ? {} : { width: 464 }}>
         <Text variant='body'>
-          {isPrivate ? shortenSPLAddress(value, isMobile ? 4 : 18) : isMobile ? shortenSPLAddress(value, 4) : value}
+          {isPrivate
+            ? shortenSPLAddress(value, isMobile ? 4 : 18)
+            : isMobile
+            ? shortenSPLAddress(value, 4)
+            : value}
         </Text>
       </Box>
       <Divider orientation='vertical' />

--- a/packages/web/src/pages/private-key-exporter-page/PrivateKeyExporterModal.tsx
+++ b/packages/web/src/pages/private-key-exporter-page/PrivateKeyExporterModal.tsx
@@ -20,12 +20,12 @@ import {
 
 import { useModalState } from 'common/hooks/useModalState'
 import { make, useRecord } from 'common/store/analytics/actions'
-import { useSelector } from 'utils/reducer'
+import { useIsMobile } from 'hooks/useIsMobile'
 import ModalDrawer from 'pages/audio-rewards-page/components/modals/ModalDrawer'
+import { useSelector } from 'utils/reducer'
 
 import { AdvancedWalletDetails } from './AdvancedWalletDetails'
 import styles from './PrivateKeyExporterPage.module.css'
-import { useIsMobile } from 'hooks/useIsMobile'
 
 const getAccountUser = accountSelectors.getAccountUser
 
@@ -182,15 +182,17 @@ export const PrivateKeyExporterModal = () => {
       onClose={handleClose}
       isOpen={isVisible}
     >
-      {!isMobile ? <ModalHeader
-        onClose={handleClose}
-        dismissButtonClassName={styles.modalCloseIcon}
-      >
-        <ModalTitle
-          title={messages.privateKey}
-          titleClassName={styles.modalTitle}
-        />
-      </ModalHeader>: null }
+      {!isMobile ? (
+        <ModalHeader
+          onClose={handleClose}
+          dismissButtonClassName={styles.modalCloseIcon}
+        >
+          <ModalTitle
+            title={messages.privateKey}
+            titleClassName={styles.modalTitle}
+          />
+        </ModalHeader>
+      ) : null}
       <ModalContent>
         <Flex direction='column' gap='xl'>
           <KeepThisInformationSecure />
@@ -199,16 +201,18 @@ export const PrivateKeyExporterModal = () => {
           <AdditionalResources />
         </Flex>
       </ModalContent>
-      {!isMobile ? <ModalFooter>
-        <Button
-          variant='secondary'
-          onClick={handleClose}
-          css={{ marginLeft: 24, marginRight: 24 }}
-          fullWidth
-        >
-          {messages.close}
-        </Button>
-      </ModalFooter> : null }
+      {!isMobile ? (
+        <ModalFooter>
+          <Button
+            variant='secondary'
+            onClick={handleClose}
+            css={{ marginLeft: 24, marginRight: 24 }}
+            fullWidth
+          >
+            {messages.close}
+          </Button>
+        </ModalFooter>
+      ) : null}
     </ModalDrawer>
   )
 }

--- a/packages/web/src/services/env/env.dev.ts
+++ b/packages/web/src/services/env/env.dev.ts
@@ -42,7 +42,7 @@ export const env: Env = {
   INSTAGRAM_APP_ID: '2875320099414320',
   INSTAGRAM_REDIRECT_URL: 'http://localhost:3000',
   METADATA_PROGRAM_ID: 'metaqbxxUerdq28cj1RbAWkYQm3ybzjb6a8bt518x1s',
-  OPENSEA_API_URL: 'https://rinkeby-api.opensea.io/api/v1',
+  OPENSEA_API_URL: 'https://rinkeby-api.opensea.io',
   OPTIMIZELY_KEY: 'MX4fYBgANQetvmBXGpuxzF',
   ORACLE_ETH_ADDRESSES:
     '0xF0D5BC18421fa04D0a2A2ef540ba5A9f04014BE3,0x325A621DeA613BCFb5B1A69a7aCED0ea4AfBD73A,0x3fD652C93dFA333979ad762Cf581Df89BaBa6795',

--- a/packages/web/src/services/env/env.prod.ts
+++ b/packages/web/src/services/env/env.prod.ts
@@ -45,7 +45,7 @@ export const env: Env = {
   INSTAGRAM_APP_ID: '189700309435573',
   INSTAGRAM_REDIRECT_URL: 'https://audius.co/',
   METADATA_PROGRAM_ID: 'metaqbxxUerdq28cj1RbAWkYQm3ybzjb6a8bt518x1s',
-  OPENSEA_API_URL: 'https://collectibles.audius.co/api/v1',
+  OPENSEA_API_URL: 'https://collectibles.audius.co',
   OPTIMIZELY_KEY: 'DAJbGEJBC21dzFRPv8snxs',
   ORACLE_ETH_ADDRESSES: '0x9811BA3eAB1F2Cd9A2dFeDB19e8c2a69729DC8b6',
   PAYMENT_ROUTER_PROGRAM_ID: 'paytYpX3LPN98TAeen6bFFeraGSuWnomZmCXjAsoqPa',

--- a/packages/web/src/services/env/env.stage.ts
+++ b/packages/web/src/services/env/env.stage.ts
@@ -45,7 +45,7 @@ export const env: Env = {
   INSTAGRAM_APP_ID: '2875320099414320',
   INSTAGRAM_REDIRECT_URL: 'https://staging.audius.co/',
   METADATA_PROGRAM_ID: 'metaqbxxUerdq28cj1RbAWkYQm3ybzjb6a8bt518x1s',
-  OPENSEA_API_URL: 'https://rinkeby-api.opensea.io/api/v1',
+  OPENSEA_API_URL: 'https://rinkeby-api.opensea.io',
   OPTIMIZELY_KEY: 'MX4fYBgANQetvmBXGpuxzF',
   ORACLE_ETH_ADDRESSES: '0x00b6462e955dA5841b6D9e1E2529B830F00f31Bf',
   PAYMENT_ROUTER_PROGRAM_ID: 'sp38CXGL9FoWPp9Avo4fevewEX4UqNkTSTFUPpQFRry',

--- a/packages/web/src/store/token-dashboard/connectNewWalletSaga.ts
+++ b/packages/web/src/store/token-dashboard/connectNewWalletSaga.ts
@@ -8,7 +8,7 @@ import { associateNewWallet } from 'common/store/pages/token-dashboard/associate
 import { checkIsNewWallet } from 'common/store/pages/token-dashboard/checkIsNewWallet'
 import { getWalletInfo } from 'common/store/pages/token-dashboard/getWalletInfo'
 import {
-  fetchOpenSeaNftMetadatas,
+  fetchOpenSeaNfts,
   fetchSolanaCollectibles
 } from 'common/store/profile/sagas'
 
@@ -77,7 +77,7 @@ function* handleConnectNewWallet() {
     yield* addWalletToUser(updatedUserMetadata, disconnect)
 
     yield* fork(fetchSolanaCollectibles, updatedUserMetadata)
-    yield* fork(fetchOpenSeaNftMetadatas, updatedUserMetadata)
+    yield* fork(fetchOpenSeaNfts, updatedUserMetadata)
   } catch (e) {
     // Very likely we hit error path here i.e. user closes the web3 popup. Log it and restart
     const err = `Caught error during handleConnectNewWallet:  ${e}, resetting to initial state`

--- a/packages/web/src/store/token-dashboard/connectNewWalletSaga.ts
+++ b/packages/web/src/store/token-dashboard/connectNewWalletSaga.ts
@@ -8,7 +8,7 @@ import { associateNewWallet } from 'common/store/pages/token-dashboard/associate
 import { checkIsNewWallet } from 'common/store/pages/token-dashboard/checkIsNewWallet'
 import { getWalletInfo } from 'common/store/pages/token-dashboard/getWalletInfo'
 import {
-  fetchOpenSeaAssets,
+  fetchOpenSeaNftMetadatas,
   fetchSolanaCollectibles
 } from 'common/store/profile/sagas'
 
@@ -77,7 +77,7 @@ function* handleConnectNewWallet() {
     yield* addWalletToUser(updatedUserMetadata, disconnect)
 
     yield* fork(fetchSolanaCollectibles, updatedUserMetadata)
-    yield* fork(fetchOpenSeaAssets, updatedUserMetadata)
+    yield* fork(fetchOpenSeaNftMetadatas, updatedUserMetadata)
   } catch (e) {
     // Very likely we hit error path here i.e. user closes the web3 popup. Log it and restart
     const err = `Caught error during handleConnectNewWallet:  ${e}, resetting to initial state`


### PR DESCRIPTION
### Description

Opensea ended their v1 api, so this all breaks for many reasons. It also seems like they got rid of the "created" event, so the only way to detect creation of the nft is transfer from the NULL addr, which we already did have. 

This is a large change, but it has a limited splash damage.



### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._

![image (80)](https://github.com/AudiusProject/audius-protocol/assets/2731362/51158960-8984-45be-816b-52635b17ece8)

Previously did not load