### PR TITLE
Fix race condition when initting sdk in ddex

### DIFF
--- a/packages/ddex/webapp/README.md
+++ b/packages/ddex/webapp/README.md
@@ -22,7 +22,7 @@ Notes:
 ### Creating a bucket in S3
 1. Create a new bucket in the S3 console with the name `ddex-[dev|staging]-<label/distributor>-raw`. Use all the defaults, including "ACLs disabled"
 2. Do the same for a bucket named `ddex-[dev|staging]-<label/distributor>-indexed`. Use all the defaults, including "ACLs disabled"
-3. Create an IAM Policy (here](https://us-east-1.console.aws.amazon.com/iamv2/home?region=us-west-2#/policies/create) (or search IAM and click Policies > Create Policy).
+3. Create an IAM Policy (here](https://us-east-1.console.aws.amazon.com/iamv2/home?region=us-west-2#/policies/create) (or search IAM and click Policies > Create Policy). Select S3.
     * Under `Read` choose `GetObject` and `GetObjectAttributes`.
     * Under `Write` choose `DeleteObject` and `PutObject`.
     * Under `List` choose `ListBucket`.


### PR DESCRIPTION
### Description
Makes the ddex webapp re-initialize sdk after it reads env vars from the backend. This should fix the error sometimes seen in console on staging (the /env call in the Network tab shows that ddex key isn't actually missing when this error happens):
<img width="393" alt="Screenshot 2024-02-05 at 8 27 54 AM" src="https://github.com/AudiusProject/audius-protocol/assets/4657956/4839b3e3-f519-4168-b52f-3318b241a98d">
