### PR TITLE
[PAY-2352][PAY-2396] Fix transactions table state after withdrawal

### DIFF
--- a/packages/common/src/api/user.ts
+++ b/packages/common/src/api/user.ts
@@ -7,7 +7,6 @@ import {
   USDCTransactionMethod,
   USDCTransactionType
 } from '~/models/USDCTransactions'
-import { getRootSolanaAccount } from '~/services/audius-backend/solana'
 import { Nullable } from '~/utils/typeUtils'
 
 import { Id } from './utils'
@@ -25,27 +24,15 @@ type GetUSDCTransactionListArgs = {
 /**
  * Parser to reformat transactions as they come back from the API.
  * @param transaction the transaction to parse
- * @param rootSolanaAccount? Optionally a root solana account can be passed
- *  to reformat the metadata field to include specific contextual information.
- *  In the case of withdrawals, this is useful in recognizing a "self-send",
- *  which is a cash transfer out.
  */
 const parseTransaction = ({
-  transaction,
-  rootSolanaAccount
+  transaction
 }: {
   transaction: full.TransactionDetails
-  rootSolanaAccount?: string
 }): USDCTransactionDetails => {
-  const { change, balance, transactionType, method, metadata, ...rest } =
-    transaction
+  const { change, balance, transactionType, method, ...rest } = transaction
   return {
     ...rest,
-    metadata: !rootSolanaAccount
-      ? metadata
-      : rootSolanaAccount === metadata.toString()
-      ? 'Cash'
-      : metadata,
     transactionType: transactionType as USDCTransactionType,
     method: method as USDCTransactionMethod,
     change: change as StringUSDC,
@@ -149,18 +136,7 @@ const userApi = createApi({
           encodedDataSignature
         })
 
-        let rootSolanaAccount: string
-        if (
-          type === full.GetUSDCTransactionsTypeEnum.Transfer &&
-          method === full.GetUSDCTransactionCountMethodEnum.Send
-        ) {
-          rootSolanaAccount = (
-            await getRootSolanaAccount(context.audiusBackend)
-          ).publicKey.toString()
-        }
-        return data.map((transaction) =>
-          parseTransaction({ transaction, rootSolanaAccount })
-        )
+        return data.map((transaction) => parseTransaction({ transaction }))
       },
       options: { retry: true }
     },

--- a/packages/common/src/api/user.ts
+++ b/packages/common/src/api/user.ts
@@ -201,3 +201,4 @@ export const {
 export const userApiReducer = userApi.reducer
 export const userApiFetch = userApi.fetch
 export const userApiActions = userApi.actions
+export const userApiUtils = userApi.util

--- a/packages/common/src/audius-query/createApi.ts
+++ b/packages/common/src/audius-query/createApi.ts
@@ -118,7 +118,14 @@ export const createApi = <
         if (updateAction) {
           dispatch(updateAction({ fetchArgs, nonNormalizedData: newState }))
         }
+      },
+    reset: (endpointName) => (dispatch: Dispatch) => {
+      const resetAction =
+        slice.actions[`reset${capitalize(endpointName as string)}`]
+      if (resetAction) {
+        dispatch(resetAction())
       }
+    }
   }
 
   return api

--- a/packages/common/src/audius-query/hooks/usePaginatedQuery.ts
+++ b/packages/common/src/audius-query/hooks/usePaginatedQuery.ts
@@ -43,7 +43,7 @@ export const usePaginatedQuery = <
       result.data?.length === pageSize
   }
 }
-
+// TODO: Add forceRefresh support here
 export const useAllPaginatedQuery = <
   Data,
   ArgsType extends { limit: number; offset: number }

--- a/packages/common/src/audius-query/hooks/usePaginatedQuery.ts
+++ b/packages/common/src/audius-query/hooks/usePaginatedQuery.ts
@@ -120,17 +120,13 @@ export const useAllPaginatedQuery = <
     setPage(page + 1)
   }, [stillLoadingCurrentPage, page])
 
-  const forceRefresh = useCallback(() => {
-    reset()
-  }, [])
-
   return {
     ...result,
     // TODO: add another status for reloading
     status: allData?.length > 0 ? Status.SUCCESS : status,
     data: allData,
     isLoadingMore: stillLoadingCurrentPage,
-    forceRefresh,
+    reset,
     loadMore,
     hasMore
   }

--- a/packages/common/src/audius-query/types.ts
+++ b/packages/common/src/audius-query/types.ts
@@ -47,6 +47,9 @@ export type Api<EndpointDefinitions extends DefaultEndpointDefinitions> = {
         >
       ) => void
     ) => ThunkAction<any, any, any, any>
+    reset: <EndpointName extends keyof EndpointDefinitions>(
+      endpointName: EndpointName
+    ) => ThunkAction<any, any, any, any>
   }
   /**
    * Allows for pre-fetching of related data into the cache. Does not return the data.

--- a/packages/common/src/models/USDCTransactions.ts
+++ b/packages/common/src/models/USDCTransactions.ts
@@ -5,7 +5,8 @@ import { StringUSDC } from './Wallet'
 export enum USDCTransactionType {
   PURCHASE_STRIPE = 'purchase_stripe',
   PURCHASE_CONTENT = 'purchase_content',
-  TRANSFER = 'transfer'
+  TRANSFER = 'transfer',
+  WITHDRAWAL = 'withdrawal'
 }
 
 export enum USDCTransactionMethod {

--- a/packages/common/src/store/ui/withdraw-usdc/selectors.ts
+++ b/packages/common/src/store/ui/withdraw-usdc/selectors.ts
@@ -27,3 +27,7 @@ export const getCoinflowState = (state: CommonState) => {
 export const getWithdrawTransaction = (state: CommonState) => {
   return state.withdrawUSDC.withdrawTransaction
 }
+
+export const getLastCompletedTransactionSignature = (state: CommonState) => {
+  return state.withdrawUSDC.lastCompletedTransactionSignature
+}

--- a/packages/common/src/store/ui/withdraw-usdc/slice.ts
+++ b/packages/common/src/store/ui/withdraw-usdc/slice.ts
@@ -14,6 +14,7 @@ type WithdrawUSDCState = {
   withdrawTransaction?: string
   destinationError?: Error
   amountError?: Error
+  lastCompletedTransactionSignature?: string
 }
 
 const initialState: WithdrawUSDCState = {
@@ -61,6 +62,7 @@ const slice = createSlice({
       state.withdrawTransaction = action.payload.transaction
       state.withdrawError = undefined
       state.withdrawStatus = Status.SUCCESS
+      state.lastCompletedTransactionSignature = action.payload.transaction
     },
     withdrawUSDCFailed: (state, action: PayloadAction<{ error: Error }>) => {
       state.withdrawStatus = Status.ERROR

--- a/packages/web/src/components/track/DownloadRow.tsx
+++ b/packages/web/src/components/track/DownloadRow.tsx
@@ -1,9 +1,9 @@
 import { useDownloadableContentAccess } from '@audius/common/hooks'
 import { ID } from '@audius/common/models'
 import { cacheTracksSelectors, CommonState } from '@audius/common/store'
+import { formatBytes } from '@audius/common/utils'
 import { Flex, IconReceive, PlainButton, Text } from '@audius/harmony'
 import { shallowEqual, useSelector } from 'react-redux'
-import { formatBytes } from '@audius/common/utils'
 
 import { Icon } from 'components/Icon'
 import Tooltip from 'components/tooltip/Tooltip'

--- a/packages/web/src/components/track/DownloadSection.tsx
+++ b/packages/web/src/components/track/DownloadSection.tsx
@@ -31,12 +31,12 @@ import { useModalState } from 'common/hooks/useModalState'
 import { TrackEvent, make } from 'common/store/analytics/actions'
 import { Icon } from 'components/Icon'
 import { Expandable } from 'components/expandable/Expandable'
-import { audiusSdk } from 'services/audius-sdk'
 import {
   useAuthenticatedCallback,
   useAuthenticatedClickCallback
 } from 'hooks/useAuthenticatedCallback'
 import { useIsMobile } from 'hooks/useIsMobile'
+import { audiusSdk } from 'services/audius-sdk'
 
 import { DownloadRow } from './DownloadRow'
 
@@ -85,7 +85,10 @@ export const DownloadSection = ({ trackId }: DownloadSectionProps) => {
     useModalState('LockedContent')
   const { onOpen: openPremiumContentPurchaseModal } =
     usePremiumContentPurchaseModal()
-  const fileSizes = useFileSizes({ audiusSdk, trackIds: [trackId, ...stemTracks.map(s => s.id)] })
+  const fileSizes = useFileSizes({
+    audiusSdk,
+    trackIds: [trackId, ...stemTracks.map((s) => s.id)]
+  })
   const { onOpen: openWaitForDownloadModal } = useWaitForDownloadModal()
 
   const onToggleExpand = useCallback(() => setExpanded((val) => !val), [])

--- a/packages/web/src/pages/pay-and-earn-page/components/WithdrawalsTab.tsx
+++ b/packages/web/src/pages/pay-and-earn-page/components/WithdrawalsTab.tsx
@@ -4,7 +4,9 @@ import {
   useGetUSDCTransactions,
   useGetUSDCTransactionsCount,
   Id,
-  userApiFetch
+  userApiFetch,
+  userApiActions,
+  userApiUtils
 } from '@audius/common/api'
 import {
   AudiusQueryContext,
@@ -48,6 +50,7 @@ import {
   WithdrawalsTableSortDirection,
   WithdrawalsTableSortMethod
 } from './WithdrawalsTable'
+import { useDispatch } from 'react-redux'
 
 const { getUserId } = accountSelectors
 
@@ -175,6 +178,7 @@ const useWithdrawalTransactionPoller = () => {
 
 export const useWithdrawals = () => {
   const userId = useSelector(getUserId)
+  const dispatch = useDispatch()
   const lastCompletedTransaction = useSelector(
     withdrawUSDCSelectors.getLastCompletedTransactionSignature
   )
@@ -191,7 +195,8 @@ export const useWithdrawals = () => {
     status: dataStatus,
     data: transactions,
     hasMore,
-    loadMore
+    loadMore,
+    forceRefresh
   } = useAllPaginatedQuery(
     useGetUSDCTransactions,
     {
@@ -224,10 +229,14 @@ export const useWithdrawals = () => {
         onSuccess: () => {
           setSortMethod(full.GetUSDCTransactionsSortMethodEnum.Date)
           setSortDirection(full.GetUSDCTransactionsSortDirectionEnum.Desc)
+          // TODO: Figure out why types don't work
+          dispatch(userApiUtils.reset('getUSDCTransactions') as any)
+          dispatch(userApiUtils.reset('getUSDCTransactionsCount') as any)
+          forceRefresh()
         }
       })
     }
-  }, [lastCompletedTransaction, userId, beginPolling])
+  }, [lastCompletedTransaction, userId, beginPolling, forceRefresh, dispatch])
 
   const onSort = useCallback(
     (

--- a/packages/web/src/pages/pay-and-earn-page/components/WithdrawalsTab.tsx
+++ b/packages/web/src/pages/pay-and-earn-page/components/WithdrawalsTab.tsx
@@ -196,7 +196,7 @@ export const useWithdrawals = () => {
     data: transactions,
     hasMore,
     loadMore,
-    forceRefresh
+    reset
   } = useAllPaginatedQuery(
     useGetUSDCTransactions,
     {
@@ -232,11 +232,11 @@ export const useWithdrawals = () => {
           // TODO: Figure out why types don't work
           dispatch(userApiUtils.reset('getUSDCTransactions') as any)
           dispatch(userApiUtils.reset('getUSDCTransactionsCount') as any)
-          forceRefresh()
+          reset()
         }
       })
     }
-  }, [lastCompletedTransaction, userId, beginPolling, forceRefresh, dispatch])
+  }, [lastCompletedTransaction, userId, beginPolling, reset, dispatch])
 
   const onSort = useCallback(
     (

--- a/packages/web/src/pages/pay-and-earn-page/components/WithdrawalsTab.tsx
+++ b/packages/web/src/pages/pay-and-earn-page/components/WithdrawalsTab.tsx
@@ -5,12 +5,11 @@ import {
   useGetUSDCTransactionsCount,
   Id,
   userApiFetch,
-  userApiActions,
   userApiUtils
 } from '@audius/common/api'
 import {
-  AudiusQueryContext,
-  useAllPaginatedQuery
+  useAllPaginatedQuery,
+  useAudiusQueryContext
 } from '@audius/common/audius-query'
 import { useUSDCBalance } from '@audius/common/hooks'
 import {
@@ -51,6 +50,7 @@ import {
   WithdrawalsTableSortMethod
 } from './WithdrawalsTable'
 import { useDispatch } from 'react-redux'
+import { ThunkDispatch } from 'redux-thunk'
 
 const { getUserId } = accountSelectors
 
@@ -113,7 +113,7 @@ const NoWithdrawals = () => {
 }
 
 const useWithdrawalTransactionPoller = () => {
-  const audiusQueryContext = useContext(AudiusQueryContext)
+  const audiusQueryContext = useAudiusQueryContext()
   const [isPolling, setIsPolling] = useState(false)
 
   const beginPolling = useCallback(
@@ -178,7 +178,8 @@ const useWithdrawalTransactionPoller = () => {
 
 export const useWithdrawals = () => {
   const userId = useSelector(getUserId)
-  const dispatch = useDispatch()
+  // Type override required because we're dispatching thunk actions below
+  const dispatch = useDispatch<ThunkDispatch<any, any, any>>()
   const lastCompletedTransaction = useSelector(
     withdrawUSDCSelectors.getLastCompletedTransactionSignature
   )
@@ -230,8 +231,8 @@ export const useWithdrawals = () => {
           setSortMethod(full.GetUSDCTransactionsSortMethodEnum.Date)
           setSortDirection(full.GetUSDCTransactionsSortDirectionEnum.Desc)
           // TODO: Figure out why types don't work
-          dispatch(userApiUtils.reset('getUSDCTransactions') as any)
-          dispatch(userApiUtils.reset('getUSDCTransactionsCount') as any)
+          dispatch(userApiUtils.reset('getUSDCTransactions'))
+          dispatch(userApiUtils.reset('getUSDCTransactionsCount'))
           reset()
         }
       })

--- a/packages/web/src/pages/pay-and-earn-page/components/WithdrawalsTable.tsx
+++ b/packages/web/src/pages/pay-and-earn-page/components/WithdrawalsTable.tsx
@@ -1,6 +1,9 @@
 import { MouseEvent, useCallback, useMemo } from 'react'
 
-import { USDCTransactionDetails } from '@audius/common/models'
+import {
+  USDCTransactionDetails,
+  USDCTransactionType
+} from '@audius/common/models'
 import { formatUSDCWeiToUSDString } from '@audius/common/utils'
 import moment from 'moment'
 
@@ -10,6 +13,10 @@ import { TransactionCell, TransactionRow } from '../types'
 import { isEmptyTransactionRow } from '../utils'
 
 import styles from './WithdrawalsTable.module.css'
+
+const messages = {
+  cash: 'Cash'
+}
 
 export type WithdrawalsTableColumn =
   | 'destination'
@@ -47,9 +54,13 @@ const defaultColumns: WithdrawalsTableColumn[] = [
 
 // Cell Render Functions
 const renderDestinationCell = (cellInfo: TransactionCell) => {
-  const { metadata } = cellInfo.row.original
-  return typeof metadata === 'string' ? (
-    <span className={styles.text}>{metadata}</span>
+  const { metadata, transactionType } = cellInfo.row.original
+  const destination =
+    transactionType === USDCTransactionType.WITHDRAWAL
+      ? messages.cash
+      : metadata
+  return typeof destination === 'string' ? (
+    <span className={styles.text}>{destination}</span>
   ) : (
     ''
   )


### PR DESCRIPTION
### Description
Adds polling logic after a USDC withdrawal transaction successfully completes. This is accomplished by storing the most recently completed transaction signature in redux state, then using it to trigger an effect that will force refresh the withdrawals table when it changes.
Forcing a refresh on the withdrawals table means resetting the pagination state and then clearing the cached data for the pages so that the first page will auto-fetch again. Note: This isn't quite a full "refresh all the pages we've fetched" implementation. But that should be okay for this case since scrolling will trigger the subsequent pages to fetch.


fixes PAY-2352
fixes PAY-2396

### How Has This Been Tested?
Tested locally against staging by submitting manual transfer transactions.
