### PR TITLE
[PAY-2449] USDC purchase access migration

### DIFF
--- a/packages/commands/src/upload-track.mjs
+++ b/packages/commands/src/upload-track.mjs
@@ -62,12 +62,16 @@ const getStreamConditions = async ({
 
 const getDownloadConditions = async ({
   streamConditions,
+  parsedStreamConditions,
   downloadConditions,
   downloadPrice: downloadPriceString,
   audiusLibs
 }) => {
   if (streamConditions) {
     return JSON.parse(streamConditions)
+  }
+  if (parsedStreamConditions) {
+    return parsedStreamConditions
   }
   if (downloadConditions) {
     return JSON.parse(downloadConditions)
@@ -132,7 +136,10 @@ program
     'Manually set a stream conditions object. Cannot be used with -u',
     ''
   )
-  .option('-o, --is-downloadable <is downloadable>', 'Whether track is downloadable')
+  .option(
+    '-o, --is-downloadable <is downloadable>',
+    'Whether track is downloadable'
+  )
   .option(
     '-dp, --download-price <download price>',
     'Generate a download conditions object with the given price in cents. Cannot be used with -dc'
@@ -194,6 +201,7 @@ program
         })
         const parsedDownloadConditions = await getDownloadConditions({
           streamConditions,
+          parsedStreamConditions,
           downloadConditions,
           downloadPrice,
           audiusLibs
@@ -212,7 +220,7 @@ program
             genre:
               genre ||
               Genre[
-              Object.keys(Genre)[randomInt(Object.keys(Genre).length - 1)]
+                Object.keys(Genre)[randomInt(Object.keys(Genre).length - 1)]
               ],
             mood: mood || `mood ${rand}`,
             credits_splits: '',

--- a/packages/discovery-provider/ddl/migrations/0051_usdc_purchase_access.sql
+++ b/packages/discovery-provider/ddl/migrations/0051_usdc_purchase_access.sql
@@ -1,0 +1,18 @@
+begin;
+
+  -- disable triggers
+  alter table usdc_purchases disable trigger on_usdc_purchase;
+
+  -- add columns to usdc_purchases
+  alter table usdc_purchases
+  add column if not exists is_streamable boolean default true;
+  alter table usdc_purchases
+  add column if not exists is_downloadable boolean default true;
+
+  -- enable triggers
+  alter table usdc_purchases enable trigger on_usdc_purchase;
+
+  -- add access column to track_price_history
+  alter table track_price_history
+  add column if not exists access varchar not null default 'stream';
+commit;


### PR DESCRIPTION
### Description
Migration to add columns for `access` in `usdc_purchases` and `track_price_history` tables in order to facilitate purchases of downloadable-assets-only.

### How Has This Been Tested?

Tested on local stack:
before:
<img width="1728" alt="Screenshot 2024-02-05 at 4 36 27 PM" src="https://github.com/AudiusProject/audius-protocol/assets/3893871/45f58001-ef2b-4a2c-bc08-209990e30f5f">

after:
<img width="1728" alt="Screenshot 2024-02-05 at 4 36 39 PM" src="https://github.com/AudiusProject/audius-protocol/assets/3893871/fec7dfaf-7383-424b-b8d7-7a67407e87c9">
