### PR TITLE
[C-3762] Unblock stage deploy by uploading sourcemaps to s3

### DIFF
--- a/.circleci/src/commands/@web-commands.yml
+++ b/.circleci/src/commands/@web-commands.yml
@@ -172,8 +172,8 @@ web-deploy-cloudflare:
         name: Move sourcemaps
         command: |
           cd packages/web
-          mkdir -p sourcemaps/static/js
-          mv build-<< parameters.build-type >>/static/js/*.map sourcemaps/static/js
+          mkdir -p sourcemaps/assets
+          mv build-<< parameters.build-type >>/assets/*.map sourcemaps/assets
     - run:
         name: Move build
         command: |

--- a/.circleci/src/commands/@web-commands.yml
+++ b/.circleci/src/commands/@web-commands.yml
@@ -169,6 +169,12 @@ web-deploy-cloudflare:
     - attach_workspace:
         at: ./
     - run:
+        name: Move sourcemaps
+        command: |
+          cd packages/web
+          mkdir -p sourcemaps/static/js
+          mv build-<< parameters.build-type >>/static/js/*.map sourcemaps/static/js
+    - run:
         name: Move build
         command: |
           cd packages/web

--- a/.circleci/src/jobs/@web-jobs.yml
+++ b/.circleci/src/jobs/@web-jobs.yml
@@ -184,7 +184,7 @@ web-deploy-staging-cloudflare:
         build-type: staging
         environment: staging
         copy-robots: false
-    # - web-deploy-sourcemaps-s3
+    - web-deploy-sourcemaps-s3
 
 web-deploy-release-candidate:
   working_directory: ~/audius-protocol
@@ -195,7 +195,7 @@ web-deploy-release-candidate:
         build-type: production
         environment: release
         copy-robots: true
-    # - web-deploy-sourcemaps-s3
+    - web-deploy-sourcemaps-s3
 
 web-deploy-staging-release-candidate:
   working_directory: ~/audius-protocol
@@ -206,7 +206,7 @@ web-deploy-staging-release-candidate:
         build-type: staging
         environment: staging-release
         copy-robots: true
-    # - web-deploy-sourcemaps-s3
+    - web-deploy-sourcemaps-s3
 
 web-deploy-production-s3:
   working_directory: ~/audius-protocol

--- a/.circleci/src/workflows/web.yml
+++ b/.circleci/src/workflows/web.yml
@@ -72,9 +72,9 @@ jobs:
       requires:
         - web-build-staging
         - web-build-ssr-staging
-      # filters:
-      #   branches:
-      #     only: /^main$/
+      filters:
+        branches:
+          only: /^main$/
 
   - web-deploy-release-candidate:
       context: Audius Client

--- a/.circleci/src/workflows/web.yml
+++ b/.circleci/src/workflows/web.yml
@@ -72,9 +72,9 @@ jobs:
       requires:
         - web-build-staging
         - web-build-ssr-staging
-      filters:
-        branches:
-          only: /^main$/
+      # filters:
+      #   branches:
+      #     only: /^main$/
 
   - web-deploy-release-candidate:
       context: Audius Client

--- a/packages/web/vite.config.ts
+++ b/packages/web/vite.config.ts
@@ -12,6 +12,8 @@ import svgr from 'vite-plugin-svgr'
 import { env as APP_ENV } from './src/services/env'
 import path from 'path'
 
+const SOURCEMAP_URL = 'https://s3.us-west-1.amazonaws.com/sourcemaps.audius.co/'
+
 const fixAcceptHeader404 = () => ({
   // Fix issue with vite dev server and `wait-on`
   // https://github.com/vitejs/vite/issues/9520
@@ -42,6 +44,12 @@ export default defineConfig(({ mode }) => {
       commonjsOptions: {
         include: [/node_modules/],
         transformMixedEsModules: true
+      },
+      rollupOptions: {
+        output: {
+          sourcemapBaseUrl:
+            env.VITE_ENV === 'production' ? SOURCEMAP_URL : undefined
+        }
       }
     },
     define: {


### PR DESCRIPTION
### Description

We were doing this before but disabled it during the CRA -> vite migration because the sourcemap size decreases significantly. Now sourcemaps are back over 25 MB so had to re-enable

### How Has This Been Tested?

Confirmed stage deploy works on CI
