### PR TITLE
[INF-654] Fix mobile SSR render

### DIFF
--- a/packages/web/src/components/search-bar/SearchBar.tsx
+++ b/packages/web/src/components/search-bar/SearchBar.tsx
@@ -9,6 +9,7 @@ import loadingSpinner from 'assets/animations/loadingSpinner.json'
 import Tooltip from 'components/tooltip/Tooltip'
 
 import styles from './SearchBar.module.css'
+import { ClientOnly } from 'components/client-only/ClientOnly'
 
 interface SearchBarProps {
   className?: string
@@ -109,15 +110,17 @@ const SearchBar = ({
         onBlur={onBlur}
         {...(open ? {} : { disabled: true })}
       />
-      <div
-        className={cn(styles.searchWrapper, iconClassname)}
-        onMouseDown={handleClick}
-      >
-        <DetailIcon
-          tooltipText={tooltipText}
-          isLoading={status === Status.LOADING && open}
-        />
-      </div>
+      <ClientOnly>
+        <div
+          className={cn(styles.searchWrapper, iconClassname)}
+          onMouseDown={handleClick}
+        >
+          <DetailIcon
+            tooltipText={tooltipText}
+            isLoading={status === Status.LOADING && open}
+          />
+        </div>
+      </ClientOnly>
     </div>
   )
 }


### PR DESCRIPTION
### Description

Mobile SSR track page was failing to render due to a tooltip trying to render server-side. It's important that mobile renders properly because crawlers crawl as a mobile device. Going to update the Uptime Robot monitor to check for this

### How Has This Been Tested?

Confirmed mobile is render in SSR
