### PR TITLE
[C-3763] Restrict harmony imports in mobile

### DIFF
--- a/packages/harmony/src/components/icon.ts
+++ b/packages/harmony/src/components/icon.ts
@@ -1,6 +1,7 @@
 import type { ComponentType, SVGProps } from 'react'
 
-import type { IconColors, ShadowOptions } from 'foundations'
+import type { IconColors } from '../foundations/color/semantic'
+import type { ShadowOptions } from '../foundations/shadows'
 
 export const iconSizes = {
   xs: 14,

--- a/packages/harmony/src/components/input/TextInput/TextInput.tsx
+++ b/packages/harmony/src/components/input/TextInput/TextInput.tsx
@@ -3,7 +3,7 @@ import { ReactNode, forwardRef, useId } from 'react'
 import cn from 'classnames'
 
 import { Text, TextSize } from 'components/text'
-import type { TextColors } from 'foundations'
+import type { TextColors } from 'foundations/color/semantic'
 
 import { Flex } from '../../layout'
 import { useFocusState } from '../useFocusState'

--- a/packages/harmony/src/components/layout/Box/Box.tsx
+++ b/packages/harmony/src/components/layout/Box/Box.tsx
@@ -1,6 +1,6 @@
 import styled from '@emotion/styled'
 
-import type { SpacingOptions } from 'foundations/spacing'
+import type { SpacingOptions } from '../../../foundations/spacing'
 
 import type { BoxProps } from './types'
 

--- a/packages/harmony/src/components/layout/Box/index.ts
+++ b/packages/harmony/src/components/layout/Box/index.ts
@@ -1,2 +1,2 @@
 export { Box } from './Box'
-export { BaseBoxProps, BoxProps } from './types'
+export type { BaseBoxProps, BoxProps } from './types'

--- a/packages/harmony/src/components/layout/Box/types.ts
+++ b/packages/harmony/src/components/layout/Box/types.ts
@@ -1,9 +1,9 @@
 import type { CSSProperties, ComponentPropsWithoutRef } from 'react'
 
-import type { BackgroundColors, BorderColors } from 'foundations/color'
-import type { CornerRadiusOptions } from 'foundations/corner-radius'
-import type { ShadowOptions } from 'foundations/shadows'
-import type { SpacingOptions } from 'foundations/spacing'
+import type { BackgroundColors, BorderColors } from '../../../foundations/color'
+import type { CornerRadiusOptions } from '../../../foundations/corner-radius'
+import type { ShadowOptions } from '../../../foundations/shadows'
+import type { SpacingOptions } from '../../../foundations/spacing'
 
 // Custom box props without HTML <div> properties
 export type BaseBoxProps = {

--- a/packages/harmony/src/components/layout/Flex/index.ts
+++ b/packages/harmony/src/components/layout/Flex/index.ts
@@ -1,2 +1,2 @@
 export { Flex } from './Flex'
-export { FlexProps, BaseFlexProps } from './types'
+export type { FlexProps, BaseFlexProps } from './types'

--- a/packages/harmony/src/components/layout/Flex/types.ts
+++ b/packages/harmony/src/components/layout/Flex/types.ts
@@ -1,7 +1,6 @@
 import type { CSSProperties } from 'react'
 
-import type { SpacingOptions } from 'foundations/spacing'
-
+import type { SpacingOptions } from '../../../foundations/spacing'
 import type { BoxProps } from '../Box'
 
 export type BaseFlexProps = {

--- a/packages/harmony/src/components/layout/Paper/types.ts
+++ b/packages/harmony/src/components/layout/Paper/types.ts
@@ -1,9 +1,6 @@
-import type {
-  BorderColors,
-  CornerRadiusOptions,
-  ShadowOptions
-} from 'foundations'
-
+import type { BorderColors } from '../../../foundations/color/semantic'
+import type { CornerRadiusOptions } from '../../../foundations/corner-radius'
+import type { ShadowOptions } from '../../../foundations/shadows'
 import type { FlexProps } from '../Flex'
 
 /**

--- a/packages/harmony/src/components/text/Text/Text.tsx
+++ b/packages/harmony/src/components/text/Text/Text.tsx
@@ -1,9 +1,9 @@
 import { ElementType, ForwardedRef, forwardRef } from 'react'
 
-import { CSSObject, useTheme } from '@emotion/react'
+import { useTheme } from '@emotion/react'
 import { Slot } from '@radix-ui/react-slot'
 
-import { typography } from 'foundations'
+import { typography } from '../../../foundations/typography'
 
 import { variantStylesMap, variantTagMap } from './constants'
 import type { TextProps } from './types'
@@ -29,7 +29,7 @@ export const Text = forwardRef(
     const theme = useTheme()
 
     const variantConfig = variant && variantStylesMap[variant]
-    const styles: CSSObject = {
+    const styles = {
       fontFamily: `'Avenir Next LT Pro', 'Helvetica Neue', Helvetica,
     Arial, sans-serif`,
       position: 'relative',
@@ -45,11 +45,11 @@ export const Text = forwardRef(
         }),
       ...(color && color !== 'heading' && { color: theme.color.text[color] }),
       ...(variantConfig && {
-        // @ts-expect-error
+        // @ts-ignore
         fontSize: typography.size[variantConfig.fontSize[size]],
-        // @ts-expect-error
+        // @ts-ignore
         lineHeight: typography.lineHeight[variantConfig.lineHeight[size]],
-        // @ts-expect-error
+        // @ts-ignore
         fontWeight: typography.weight[variantConfig.fontWeight[strength]],
         ...('css' in variantConfig && variantConfig.css),
         ...(shadow && {
@@ -59,7 +59,7 @@ export const Text = forwardRef(
       })
     }
 
-    // @ts-expect-error
+    // @ts-ignore
     const variantTag = variant && variantTagMap[variant]?.[size]
 
     const Tag: ElementType = asChild ? Slot : tag ?? variantTag ?? 'p'

--- a/packages/harmony/src/components/text/Text/types.ts
+++ b/packages/harmony/src/components/text/Text/types.ts
@@ -5,7 +5,7 @@ import type {
   ReactNode
 } from 'react'
 
-import type { TextColors } from 'foundations'
+import type { TextColors } from '../../../foundations/color/semantic'
 
 export type BaseTextProps<TextComponentType extends ElementType = 'p'> = {
   tag?: TextComponentType

--- a/packages/mobile/.eslintrc.js
+++ b/packages/mobile/.eslintrc.js
@@ -31,6 +31,7 @@ module.exports = {
       }
     }
   },
+  ignorePatterns: ['**/harmony/**/*'],
   rules: {
     '@typescript-eslint/consistent-type-imports': [
       'error',

--- a/packages/mobile/.eslintrc.js
+++ b/packages/mobile/.eslintrc.js
@@ -46,6 +46,18 @@ module.exports = {
         message:
           'Do NOT use `Promise.allSettled` as it will be undefined. Use `allSettled` from `@audius/common` instead.'
       }
+    ],
+    'no-restricted-imports': [
+      'error',
+      {
+        paths: [
+          {
+            name: '@audius/harmony',
+            message:
+              'Use @audius/harmony-native instead. If needing to access an @audius/harmony export, reference it directly with @audius/harmony/src/..'
+          }
+        ]
+      }
     ]
   }
 }

--- a/packages/mobile/src/components/drawer/Drawer.tsx
+++ b/packages/mobile/src/components/drawer/Drawer.tsx
@@ -1,7 +1,6 @@
 import type { ComponentType, ReactNode } from 'react'
 import { useMemo, useCallback, useEffect, useRef, useState } from 'react'
 
-import type { IconComponent } from '@audius/harmony'
 import type {
   GestureResponderEvent,
   ImageSourcePropType,
@@ -19,6 +18,7 @@ import {
 import type { Edge } from 'react-native-safe-area-context'
 import { useSafeAreaInsets, SafeAreaView } from 'react-native-safe-area-context'
 
+import type { IconComponent } from '@audius/harmony-native'
 import { makeStyles } from 'app/styles'
 import { attachToDy } from 'app/utils/animation'
 

--- a/packages/mobile/src/components/drawer/DrawerHeader.tsx
+++ b/packages/mobile/src/components/drawer/DrawerHeader.tsx
@@ -1,9 +1,9 @@
 import type { ReactNode } from 'react'
 
-import type { IconComponent } from '@audius/harmony'
 import type { ImageSourcePropType } from 'react-native'
 import { TouchableOpacity, View, Image } from 'react-native'
 
+import type { IconComponent } from '@audius/harmony-native'
 import { Flex, IconClose } from '@audius/harmony-native'
 import { Text } from 'app/components/core'
 import { makeStyles } from 'app/styles'

--- a/packages/mobile/src/harmony-native/components/Avatar/Avatar.tsx
+++ b/packages/mobile/src/harmony-native/components/Avatar/Avatar.tsx
@@ -1,5 +1,5 @@
 import type { PickRename } from '@audius/common/utils'
-import type { AvatarProps as HarmonyAvatarProps } from '@audius/harmony'
+import type { AvatarProps as HarmonyAvatarProps } from '@audius/harmony/src/components/avatar/types'
 import { css } from '@emotion/native'
 import { View } from 'react-native'
 import type { SetRequired } from 'type-fest'

--- a/packages/mobile/src/harmony-native/components/Button/BaseButton/types.ts
+++ b/packages/mobile/src/harmony-native/components/Button/BaseButton/types.ts
@@ -9,7 +9,7 @@ import type {
 import type { SharedValue } from 'react-native-reanimated'
 
 import type { LoadingSpinnerProps } from 'app/components/loading-spinner/LoadingSpinner'
-import type { Icon, IconProps } from 'app/harmony-native/icons'
+import type { IconComponent, IconProps } from 'app/harmony-native/icons'
 
 import type { TextProps } from '../../Text/Text'
 
@@ -29,12 +29,12 @@ export type BaseButtonProps = {
   /**
    * Optional icon element to include on the left side of the button
    */
-  iconLeft?: Icon
+  iconLeft?: IconComponent
 
   /**
    * Optional icon element to include on the right side of the button
    */
-  iconRight?: Icon
+  iconRight?: IconComponent
 
   /**
    * When true, do not override icon's fill colors

--- a/packages/mobile/src/harmony-native/components/Button/Button/Button.tsx
+++ b/packages/mobile/src/harmony-native/components/Button/Button/Button.tsx
@@ -1,6 +1,5 @@
 import { useMemo, useState } from 'react'
 
-import type { IconColors } from '@audius/harmony'
 import type { ReactNativeStyle } from '@emotion/native'
 import Color from 'color'
 import type { TextStyle, ViewStyle } from 'react-native'
@@ -10,6 +9,7 @@ import {
   useSharedValue
 } from 'react-native-reanimated'
 
+import type { IconColors } from '@audius/harmony-native'
 import type { IconProps } from 'app/harmony-native/icons'
 
 import { useTheme } from '../../../foundations/theme'

--- a/packages/mobile/src/harmony-native/components/Button/Button/types.ts
+++ b/packages/mobile/src/harmony-native/components/Button/Button/types.ts
@@ -1,5 +1,6 @@
-import type { SpecialColors } from '@audius/harmony'
 import type { StyleProp, ViewStyle } from 'react-native'
+
+import type { SpecialColors } from '@audius/harmony-native'
 
 import type { BaseButtonProps } from '../BaseButton/types'
 

--- a/packages/mobile/src/harmony-native/components/Button/IconButton/IconButton.tsx
+++ b/packages/mobile/src/harmony-native/components/Button/IconButton/IconButton.tsx
@@ -6,13 +6,13 @@ import {
 } from 'react-native-reanimated'
 
 import { useTheme } from 'app/harmony-native/foundations/theme'
-import type { Icon, IconProps } from 'app/harmony-native/icons'
+import type { IconComponent, IconProps } from 'app/harmony-native/icons'
 
 import { BaseButton } from '../BaseButton/BaseButton'
 import type { BaseButtonProps } from '../BaseButton/types'
 
 export type IconButtonProps = {
-  icon: Icon
+  icon: IconComponent
   ripple?: boolean
   style?: StyleProp<ViewStyle>
 } & Pick<IconProps, 'color' | 'size' | 'shadow'> &

--- a/packages/mobile/src/harmony-native/components/CompletionCheck/CompletionCheck.stories.tsx
+++ b/packages/mobile/src/harmony-native/components/CompletionCheck/CompletionCheck.stories.tsx
@@ -1,8 +1,8 @@
-import type { CompletionCheckProps } from '@audius/harmony'
 import type { Meta, StoryObj } from '@storybook/react-native'
 
 import { Flex } from '../layout/Flex/Flex'
 
+import type { CompletionCheckProps } from './CompletionCheck'
 import { CompletionCheck } from './CompletionCheck'
 
 const meta: Meta<CompletionCheckProps> = {

--- a/packages/mobile/src/harmony-native/components/CompletionCheck/CompletionCheck.tsx
+++ b/packages/mobile/src/harmony-native/components/CompletionCheck/CompletionCheck.tsx
@@ -1,4 +1,4 @@
-import type { CompletionCheckProps } from '@audius/harmony'
+import type { CompletionCheckProps } from '@audius/harmony/src/components/completion-check/types'
 import styled, { css } from '@emotion/native'
 import Animated, {
   Easing,
@@ -86,3 +86,5 @@ export const CompletionCheck = (props: CompletionCheckProps) => {
     </Flex>
   )
 }
+
+export type { CompletionCheckProps }

--- a/packages/mobile/src/harmony-native/components/CoverPhoto/CoverPhoto.tsx
+++ b/packages/mobile/src/harmony-native/components/CoverPhoto/CoverPhoto.tsx
@@ -1,7 +1,6 @@
 import type { ReactNode } from 'react'
 
 import type { Image } from '@audius/common/store'
-import type { CornerRadiusOptions } from '@audius/harmony'
 import { css } from '@emotion/native'
 import { BlurView } from '@react-native-community/blur'
 import { isEmpty } from 'lodash'
@@ -13,6 +12,8 @@ import type {
 } from 'react-native'
 import { ImageBackground, View } from 'react-native'
 import LinearGradient from 'react-native-linear-gradient'
+
+import type { CornerRadiusOptions } from '@audius/harmony-native'
 
 import { useTheme } from '../../foundations/theme'
 

--- a/packages/mobile/src/harmony-native/components/Hint/Hint.tsx
+++ b/packages/mobile/src/harmony-native/components/Hint/Hint.tsx
@@ -1,11 +1,11 @@
-import type { Icon } from 'app/harmony-native/icons'
+import type { IconComponent } from 'app/harmony-native/icons'
 
 import { Text } from '../Text/Text'
 import type { PaperProps } from '../layout'
 import { Paper } from '../layout'
 
 export type HintProps = {
-  icon: Icon
+  icon: IconComponent
 } & PaperProps
 
 export const Hint = (props: HintProps) => {

--- a/packages/mobile/src/harmony-native/components/Text/Text.tsx
+++ b/packages/mobile/src/harmony-native/components/Text/Text.tsx
@@ -1,7 +1,7 @@
 import { forwardRef } from 'react'
 
-import type { BaseTextProps } from '@audius/harmony'
-import { variantStylesMap } from '@audius/harmony'
+import { variantStylesMap } from '@audius/harmony/src/components/text'
+import type { BaseTextProps } from '@audius/harmony/src/components/text'
 import { css } from '@emotion/native'
 import type { TextProps as NativeTextProps, TextStyle } from 'react-native'
 import { Text as TextBase } from 'react-native'
@@ -60,4 +60,4 @@ export const Text = forwardRef<TextBase, TextProps>((props, ref) => {
 })
 
 export { variantStylesMap }
-export type { TextSize, TextColors } from '@audius/harmony'
+export type { TextSize } from '@audius/harmony/src/components/text/Text/types'

--- a/packages/mobile/src/harmony-native/components/input/SelectablePill/SelectablePill.tsx
+++ b/packages/mobile/src/harmony-native/components/input/SelectablePill/SelectablePill.tsx
@@ -1,6 +1,5 @@
 import React, { useCallback, useEffect, useState } from 'react'
 
-import { cornerRadius } from '@audius/harmony'
 import { css } from '@emotion/native'
 import { Pressable } from 'react-native'
 import type { GestureResponderEvent } from 'react-native'
@@ -37,7 +36,7 @@ export const SelectablePill = (props: SelectablePillProps) => {
     fullWidth,
     ...other
   } = props
-  const { color, motion } = useTheme()
+  const { color, motion, cornerRadius } = useTheme()
   const pressed = useSharedValue(0)
   const selected = useSharedValue(0)
   const [isPressing, setIsPressing] = useState(false)

--- a/packages/mobile/src/harmony-native/components/input/SelectablePill/types.ts
+++ b/packages/mobile/src/harmony-native/components/input/SelectablePill/types.ts
@@ -1,6 +1,6 @@
 import type { PressableProps, ViewProps } from 'react-native'
 
-import type { Icon } from 'app/harmony-native/icons'
+import type { IconComponent } from 'app/harmony-native/icons'
 
 export type SelectablePillProps = {
   type: 'button' | 'checkbox' | 'radio'
@@ -8,7 +8,7 @@ export type SelectablePillProps = {
   isSelected?: boolean
   label: string
   value?: string
-  icon?: Icon
+  icon?: IconComponent
   onChange?: (value: string) => void
   fullWidth?: boolean
 } & Pick<PressableProps, 'disabled' | 'onPress'> &

--- a/packages/mobile/src/harmony-native/components/input/TextInput/TextInput.tsx
+++ b/packages/mobile/src/harmony-native/components/input/TextInput/TextInput.tsx
@@ -20,12 +20,13 @@ import Animated, {
   withTiming
 } from 'react-native-reanimated'
 
+import type { TextColors } from '@audius/harmony-native'
 import { useTheme } from '@audius/harmony-native'
 
 import { useControlled } from '../../../hooks/useControlled'
 import { useFocusState } from '../../../hooks/useFocusState'
 import { mergeRefs } from '../../../utils/mergeRefs'
-import type { TextColors, TextSize } from '../../Text/Text'
+import type { TextSize } from '../../Text/Text'
 import { Text } from '../../Text/Text'
 import { Flex } from '../../layout'
 

--- a/packages/mobile/src/harmony-native/components/input/TextInput/types.ts
+++ b/packages/mobile/src/harmony-native/components/input/TextInput/types.ts
@@ -2,7 +2,7 @@ import type { ReactNode } from 'react'
 
 import type { TextInputProps as RNTextInputProps } from 'react-native'
 
-import type { Icon, IconProps } from '../../../icons'
+import type { IconComponent, IconProps } from '../../../icons'
 
 export enum TextInputSize {
   SMALL = 'small',
@@ -72,11 +72,11 @@ export type TextInputProps = RNTextInputProps & {
   /**
    * Floating icon on the lefthand side of the input. Note: will float to the left of the label & content
    */
-  startIcon?: Icon
+  startIcon?: IconComponent
   /**
    * Floating icon on the righthand side of the input
    */
-  endIcon?: Icon
+  endIcon?: IconComponent
   /**
    * Override props to supply the start or end Icon
    */

--- a/packages/mobile/src/harmony-native/components/layout/Box/types.ts
+++ b/packages/mobile/src/harmony-native/components/layout/Box/types.ts
@@ -1,4 +1,4 @@
-import type { BaseBoxProps } from '@audius/harmony'
+import type { BaseBoxProps } from '@audius/harmony/src/components/layout/Box/types'
 import type { ViewProps, ViewStyle } from 'react-native'
 
 export type BoxProps = Omit<BaseBoxProps, 'flex' | 'alignSelf'> & {

--- a/packages/mobile/src/harmony-native/components/layout/Flex/types.ts
+++ b/packages/mobile/src/harmony-native/components/layout/Flex/types.ts
@@ -1,4 +1,4 @@
-import type { BaseFlexProps } from '@audius/harmony'
+import type { BaseFlexProps } from '@audius/harmony/src/components/layout/Flex/types'
 import type { ViewStyle } from 'react-native'
 
 import type { BoxProps } from '../Box/types'

--- a/packages/mobile/src/harmony-native/components/layout/Paper/types.ts
+++ b/packages/mobile/src/harmony-native/components/layout/Paper/types.ts
@@ -1,4 +1,4 @@
-import type { BasePaperProps } from '@audius/harmony'
+import type { BasePaperProps } from '@audius/harmony/src/components/layout/Paper/types'
 
 import type { FlexProps } from '../Flex/types'
 

--- a/packages/mobile/src/harmony-native/foundations/color/color.ts
+++ b/packages/mobile/src/harmony-native/foundations/color/color.ts
@@ -1,8 +1,7 @@
-import {
-  themes as harmonyThemes,
-  primitiveTheme as harmonyPrimitiveTheme
-} from '@audius/harmony'
+import { primitiveTheme as harmonyPrimitiveTheme } from '@audius/harmony/src/foundations/color/primitive'
+import { themes as harmonyThemes } from '@audius/harmony/src/foundations/theme/theme'
 import { merge } from 'lodash'
+
 // linear-gradient at 315deg
 const baseLinearGradient = {
   start: { x: 0, y: 1 },
@@ -117,3 +116,9 @@ export const primitiveTheme = merge(
   harmonyPrimitiveTheme,
   primitiveOverrides
 )
+
+export type {
+  IconColors,
+  SpecialColors,
+  TextColors
+} from '@audius/harmony/src/foundations/color'

--- a/packages/mobile/src/harmony-native/foundations/index.ts
+++ b/packages/mobile/src/harmony-native/foundations/index.ts
@@ -1,1 +1,4 @@
 export * from './theme'
+export * from './color/color'
+export * from '@audius/harmony/src/foundations/corner-radius'
+export * from '@audius/harmony/src/foundations/spacing'

--- a/packages/mobile/src/harmony-native/foundations/theme/ThemeProvider.tsx
+++ b/packages/mobile/src/harmony-native/foundations/theme/ThemeProvider.tsx
@@ -1,6 +1,6 @@
 import type { ReactNode } from 'react'
 
-import type { Theme } from '@audius/harmony'
+import type { Theme } from '@audius/harmony/src/foundations/theme/types'
 import { ThemeProvider as EmotionThemeProvider } from '@emotion/react'
 
 import { theme } from './theme'

--- a/packages/mobile/src/harmony-native/foundations/theme/theme.ts
+++ b/packages/mobile/src/harmony-native/foundations/theme/theme.ts
@@ -1,4 +1,4 @@
-import { themes as harmonyThemes } from '@audius/harmony'
+import { themes as harmonyThemes } from '@audius/harmony/src/foundations/theme/theme'
 import { mapValues } from 'lodash'
 
 import { colorTheme } from '../color/color'

--- a/packages/mobile/src/harmony-native/icons.ts
+++ b/packages/mobile/src/harmony-native/icons.ts
@@ -1,10 +1,10 @@
 import type { FunctionComponent } from 'react'
 
-import { type IconProps as HarmonyIconProps } from '@audius/harmony'
+import { type IconProps as HarmonyIconProps } from '@audius/harmony/src/components/icon'
 import type { SvgProps } from 'react-native-svg'
 
 export type IconProps = SvgProps & HarmonyIconProps & { fillSecondary?: string }
-export type Icon = FunctionComponent<IconProps>
+export type IconComponent = FunctionComponent<IconProps>
 
 export { default as IconAlbum } from '@audius/harmony/src/assets/icons/Album.svg'
 export { default as IconFilter } from '@audius/harmony/src/assets/icons/Filter.svg'

--- a/packages/mobile/src/harmony-native/utils/styleProps.ts
+++ b/packages/mobile/src/harmony-native/utils/styleProps.ts
@@ -1,6 +1,7 @@
-import type { SpacingOptions } from '@audius/harmony'
 import { css } from '@emotion/native'
 import { useTheme } from '@emotion/react'
+
+import type { SpacingOptions } from '../foundations'
 
 export type MarginProps = {
   m?: SpacingOptions
@@ -11,6 +12,7 @@ export type MarginProps = {
   mx?: SpacingOptions
   my?: SpacingOptions
 }
+
 export const useMargin = <T extends MarginProps>(props: T) => {
   const { spacing } = useTheme()
   return css({

--- a/packages/mobile/src/screens/sign-on-screen/components/AudiusValues.tsx
+++ b/packages/mobile/src/screens/sign-on-screen/components/AudiusValues.tsx
@@ -1,6 +1,6 @@
 import Animated, { FadeIn, FadeOut } from 'react-native-reanimated'
 
-import type { Icon } from '@audius/harmony-native'
+import type { IconComponent } from '@audius/harmony-native'
 import {
   Flex,
   Text,
@@ -20,7 +20,7 @@ const messages = {
   adFree: 'Ad-Free, Offline Listening'
 }
 
-type AudiusValueProps = { icon: Icon; text: string }
+type AudiusValueProps = { icon: IconComponent; text: string }
 
 /**
  * Each individual audius value text + icon row

--- a/packages/mobile/src/screens/sign-on-screen/screens/SelectArtistScreen/FollowArtistCard.tsx
+++ b/packages/mobile/src/screens/sign-on-screen/screens/SelectArtistScreen/FollowArtistCard.tsx
@@ -13,7 +13,7 @@ import LottieView from 'lottie-react-native'
 import { Pressable } from 'react-native'
 import { useDispatch, useSelector } from 'react-redux'
 
-import type { Icon } from '@audius/harmony-native'
+import type { IconComponent } from '@audius/harmony-native'
 import {
   Box,
   Flex,
@@ -86,7 +86,7 @@ export const FollowArtistCard = (props: FollowArtistCardProps) => {
 
   // The play/pause icon over the user avatar
   const renderPreviewElement = () => {
-    let PreviewIcon: Icon | null = null
+    let PreviewIcon: IconComponent | null = null
 
     if (showPreviewHint && !hasPlayed) {
       PreviewIcon = IconPlay

--- a/packages/mobile/tsconfig.json
+++ b/packages/mobile/tsconfig.json
@@ -41,5 +41,6 @@
     // Update these when no longer dependent on audius-client.
     // Issue is due to absolute paths into audius-client
     "strict": false
-  }
+  },
+    "exclude": ["node_modules", "harmony"],
 }


### PR DESCRIPTION
### Description

We should restrict @audius/harmony imports in mobile to only be `@audius/harmony/src/...` to ensure we don't include all harmony code in mobile. We really only need the various constants/icons. One extra difficulty I came across was ensuring we don't import from barrel files as much as we can.