### PR TITLE
[C-3764] Use history in handleClickRoute

### DIFF
--- a/packages/web/src/components/search-bar/SearchBar.tsx
+++ b/packages/web/src/components/search-bar/SearchBar.tsx
@@ -6,10 +6,10 @@ import cn from 'classnames'
 import Lottie from 'react-lottie'
 
 import loadingSpinner from 'assets/animations/loadingSpinner.json'
+import { ClientOnly } from 'components/client-only/ClientOnly'
 import Tooltip from 'components/tooltip/Tooltip'
 
 import styles from './SearchBar.module.css'
-import { ClientOnly } from 'components/client-only/ClientOnly'
 
 interface SearchBarProps {
   className?: string

--- a/packages/web/src/public-site/components/Footer.tsx
+++ b/packages/web/src/public-site/components/Footer.tsx
@@ -7,6 +7,7 @@ import {
 } from '@audius/harmony'
 import cn from 'classnames'
 
+import { useHistoryContext } from 'app/HistoryProvider'
 import {
   HOME_PAGE,
   AUDIUS_TWITTER_LINK,
@@ -26,7 +27,6 @@ import {
 
 import styles from './Footer.module.css'
 import { handleClickRoute } from './handleClickRoute'
-import { useHistoryContext } from 'app/HistoryProvider'
 
 const bottomLinks = [
   {

--- a/packages/web/src/public-site/components/Footer.tsx
+++ b/packages/web/src/public-site/components/Footer.tsx
@@ -26,6 +26,7 @@ import {
 
 import styles from './Footer.module.css'
 import { handleClickRoute } from './handleClickRoute'
+import { useHistoryContext } from 'app/HistoryProvider'
 
 const bottomLinks = [
   {
@@ -94,6 +95,7 @@ type FooterProps = {
 }
 
 const Footer = (props: FooterProps) => {
+  const { history } = useHistoryContext()
   return (
     <div
       className={cn(styles.container, {
@@ -104,7 +106,11 @@ const Footer = (props: FooterProps) => {
         <div className={styles.logoLinkContainer}>
           <IconAudiusLogoHorizontalColor
             className={styles.logo}
-            onClick={handleClickRoute(HOME_PAGE, props.setRenderPublicSite)}
+            onClick={handleClickRoute(
+              HOME_PAGE,
+              props.setRenderPublicSite,
+              history
+            )}
           />
           <div className={styles.siteLinksContainer}>
             <div className={styles.siteLinksColumnContainer}>
@@ -112,7 +118,8 @@ const Footer = (props: FooterProps) => {
               <a
                 onClick={handleClickRoute(
                   TRENDING_PAGE,
-                  props.setRenderPublicSite
+                  props.setRenderPublicSite,
+                  history
                 )}
                 className={cn(styles.siteLink, styles.link)}
               >
@@ -180,7 +187,11 @@ const Footer = (props: FooterProps) => {
                   key={text}
                   href={link}
                   className={cn(styles.bottomLink, styles.link)}
-                  onClick={handleClickRoute(link, props.setRenderPublicSite)}
+                  onClick={handleClickRoute(
+                    link,
+                    props.setRenderPublicSite,
+                    history
+                  )}
                 >
                   {text}
                 </a>

--- a/packages/web/src/public-site/components/NavOverlay.tsx
+++ b/packages/web/src/public-site/components/NavOverlay.tsx
@@ -14,6 +14,7 @@ import cn from 'classnames'
 import ReactDOM from 'react-dom'
 import { Link } from 'react-router-dom'
 
+import { useHistoryContext } from 'app/HistoryProvider'
 import HeroBackground from 'assets/img/publicSite/HeroBG@2x.webp'
 import {
   AUDIUS_BLOG_LINK,
@@ -30,7 +31,6 @@ import {
 
 import styles from './NavOverlay.module.css'
 import { handleClickRoute } from './handleClickRoute'
-import { useHistoryContext } from 'app/HistoryProvider'
 
 const messages = {
   signUp: 'Sign Up',

--- a/packages/web/src/public-site/components/NavOverlay.tsx
+++ b/packages/web/src/public-site/components/NavOverlay.tsx
@@ -30,6 +30,7 @@ import {
 
 import styles from './NavOverlay.module.css'
 import { handleClickRoute } from './handleClickRoute'
+import { useHistoryContext } from 'app/HistoryProvider'
 
 const messages = {
   signUp: 'Sign Up',
@@ -123,6 +124,7 @@ const useModalRoot = () => {
 
 const NavOverlay = (props: NavOverlayProps) => {
   const modalRoot = useModalRoot()
+  const { history } = useHistoryContext()
 
   return (
     modalRoot &&
@@ -160,7 +162,11 @@ const NavOverlay = (props: NavOverlayProps) => {
               {dappLinks.map(({ icon, text, link }, idx) => (
                 <a
                   key={idx}
-                  onClick={handleClickRoute(link, props.setRenderPublicSite)}
+                  onClick={handleClickRoute(
+                    link,
+                    props.setRenderPublicSite,
+                    history
+                  )}
                   className={styles.dappLink}
                   href={link}
                   target='_blank'
@@ -177,7 +183,11 @@ const NavOverlay = (props: NavOverlayProps) => {
               <a
                 key={idx}
                 href={link}
-                onClick={handleClickRoute(link, props.setRenderPublicSite)}
+                onClick={handleClickRoute(
+                  link,
+                  props.setRenderPublicSite,
+                  history
+                )}
               >
                 <Icon className={styles.icon} />
               </a>

--- a/packages/web/src/public-site/components/handleClickRoute.ts
+++ b/packages/web/src/public-site/components/handleClickRoute.ts
@@ -1,5 +1,6 @@
-import { History } from 'history'
 import { MouseEvent } from 'react'
+
+import { History } from 'history'
 
 import {
   AUDIUS_PRESS_LINK,

--- a/packages/web/src/public-site/components/handleClickRoute.ts
+++ b/packages/web/src/public-site/components/handleClickRoute.ts
@@ -1,3 +1,4 @@
+import { History } from 'history'
 import { MouseEvent } from 'react'
 
 import {
@@ -30,7 +31,11 @@ const LANDING_PAGE_ROUTES = new Set([
  * @param setRenderPublicSite state setter to hide the public site
  */
 export const handleClickRoute =
-  (route: string, setRenderPublicSite: (shouldRender: boolean) => void) =>
+  (
+    route: string,
+    setRenderPublicSite: (shouldRender: boolean) => void,
+    history: History
+  ) =>
   (e?: MouseEvent) => {
     e?.preventDefault()
     // Http(s) routes and landing page routes should trigger a full window reload
@@ -40,6 +45,6 @@ export const handleClickRoute =
       pushWindowRoute(route)
     } else {
       setRenderPublicSite(false)
-      window.history.pushState('', '/', route)
+      history.push(route)
     }
   }

--- a/packages/web/src/public-site/pages/landing-page/components/CTAGetStarted.tsx
+++ b/packages/web/src/public-site/pages/landing-page/components/CTAGetStarted.tsx
@@ -15,6 +15,7 @@ import { TRENDING_PAGE } from 'utils/route'
 import { useMatchesBreakpoint } from 'utils/useMatchesBreakpoint'
 
 import styles from './CTAGetStarted.module.css'
+import { useHistoryContext } from 'app/HistoryProvider'
 
 const MOBILE_WIDTH_MEDIA_QUERY = window.matchMedia('(max-width: 1150px)')
 
@@ -31,6 +32,7 @@ type CTAGetStartedProps = {
 }
 
 const CTAGetStarted = (props: CTAGetStartedProps) => {
+  const { history } = useHistoryContext()
   const isNarrow = useMatchesBreakpoint({
     initialValue: props.isMobile,
     mediaQuery: MOBILE_WIDTH_MEDIA_QUERY
@@ -90,7 +92,11 @@ const CTAGetStarted = (props: CTAGetStartedProps) => {
         <div className={styles.textContent}>
           <div className={styles.title}>{messages.title}</div>
           <button
-            onClick={handleClickRoute(TRENDING_PAGE, props.setRenderPublicSite)}
+            onClick={handleClickRoute(
+              TRENDING_PAGE,
+              props.setRenderPublicSite,
+              history
+            )}
             className={styles.ctaButton}
           >
             {messages.cta}

--- a/packages/web/src/public-site/pages/landing-page/components/CTAGetStarted.tsx
+++ b/packages/web/src/public-site/pages/landing-page/components/CTAGetStarted.tsx
@@ -6,6 +6,7 @@ import { Parallax } from 'react-scroll-parallax'
 // eslint-disable-next-line no-restricted-imports -- TODO: migrate to @react-spring/web
 import { useChain, useTrail, animated } from 'react-spring'
 
+import { useHistoryContext } from 'app/HistoryProvider'
 import capshunBg from 'assets/img/publicSite/CapshunBG.webp'
 import capshunBg2 from 'assets/img/publicSite/CapshunBG@2x.webp'
 import capshunBg3 from 'assets/img/publicSite/CapshunBG@3x.webp'
@@ -15,7 +16,6 @@ import { TRENDING_PAGE } from 'utils/route'
 import { useMatchesBreakpoint } from 'utils/useMatchesBreakpoint'
 
 import styles from './CTAGetStarted.module.css'
-import { useHistoryContext } from 'app/HistoryProvider'
 
 const MOBILE_WIDTH_MEDIA_QUERY = window.matchMedia('(max-width: 1150px)')
 

--- a/packages/web/src/public-site/pages/landing-page/components/CTAStartListening.tsx
+++ b/packages/web/src/public-site/pages/landing-page/components/CTAStartListening.tsx
@@ -1,6 +1,7 @@
 import { IconCaretRight } from '@audius/harmony'
 import { Parallax } from 'react-scroll-parallax'
 
+import { useHistoryContext } from 'app/HistoryProvider'
 import footerBackgroundMobile from 'assets/img/publicSite/Footer-Background-mobile@2x.jpg'
 import footerBackground from 'assets/img/publicSite/Footer-Background@2x.jpg'
 import footerForeground from 'assets/img/publicSite/Footer-Foreground@2x.png'
@@ -9,7 +10,6 @@ import { handleClickRoute } from 'public-site/components/handleClickRoute'
 import { TRENDING_PAGE } from 'utils/route'
 
 import styles from './CTAStartListening.module.css'
-import { useHistoryContext } from 'app/HistoryProvider'
 
 const messages = {
   title: 'Artists Deserve More',

--- a/packages/web/src/public-site/pages/landing-page/components/CTAStartListening.tsx
+++ b/packages/web/src/public-site/pages/landing-page/components/CTAStartListening.tsx
@@ -9,6 +9,7 @@ import { handleClickRoute } from 'public-site/components/handleClickRoute'
 import { TRENDING_PAGE } from 'utils/route'
 
 import styles from './CTAStartListening.module.css'
+import { useHistoryContext } from 'app/HistoryProvider'
 
 const messages = {
   title: 'Artists Deserve More',
@@ -21,6 +22,7 @@ type CTAStartListeningProps = {
 }
 
 const CTAStartListening = (props: CTAStartListeningProps) => {
+  const { history } = useHistoryContext()
   if (props.isMobile) {
     return (
       <div className={styles.mobileContainer}>
@@ -41,7 +43,11 @@ const CTAStartListening = (props: CTAStartListeningProps) => {
         </div>
         <div className={styles.title}>{messages.title}</div>
         <div
-          onClick={handleClickRoute(TRENDING_PAGE, props.setRenderPublicSite)}
+          onClick={handleClickRoute(
+            TRENDING_PAGE,
+            props.setRenderPublicSite,
+            history
+          )}
           className={styles.ctaButton}
         >
           {messages.cta}
@@ -56,7 +62,11 @@ const CTAStartListening = (props: CTAStartListeningProps) => {
       <div className={styles.content}>
         <div className={styles.title}>{messages.title}</div>
         <button
-          onClick={handleClickRoute(TRENDING_PAGE, props.setRenderPublicSite)}
+          onClick={handleClickRoute(
+            TRENDING_PAGE,
+            props.setRenderPublicSite,
+            history
+          )}
           className={styles.ctaButton}
         >
           {messages.cta}

--- a/packages/web/src/public-site/pages/landing-page/components/CaseStudies.tsx
+++ b/packages/web/src/public-site/pages/landing-page/components/CaseStudies.tsx
@@ -13,6 +13,7 @@ import { handleClickRoute } from 'public-site/components/handleClickRoute'
 import { AUDIUS_REMIX_CONTESTS_LINK } from 'utils/route'
 
 import styles from './CaseStudies.module.css'
+import { useHistoryContext } from 'app/HistoryProvider'
 
 const messages = {
   title: 'Case Studies',
@@ -102,6 +103,7 @@ type CaseStudiesProps = {
 }
 
 const CaseStudies = (props: CaseStudiesProps) => {
+  const { history } = useHistoryContext()
   // Animate in the title and subtitle text
   const [hasViewed, refInView] = useHasViewed(0.8)
 
@@ -131,7 +133,11 @@ const CaseStudies = (props: CaseStudiesProps) => {
           <div
             key={i}
             className={cn(styles.mobileCard, card.containerClass)}
-            onClick={handleClickRoute(card.link, props.setRenderPublicSite)}
+            onClick={handleClickRoute(
+              card.link,
+              props.setRenderPublicSite,
+              history
+            )}
             style={{
               backgroundBlendMode: 'multiply',
               background: `url(${card.image}) center/cover, ${card.backgroundGradient}`
@@ -170,7 +176,11 @@ const CaseStudies = (props: CaseStudiesProps) => {
             <Card
               key={card.title}
               {...card}
-              onClick={handleClickRoute(card.link, props.setRenderPublicSite)}
+              onClick={handleClickRoute(
+                card.link,
+                props.setRenderPublicSite,
+                history
+              )}
             />
           ))}
         </div>

--- a/packages/web/src/public-site/pages/landing-page/components/CaseStudies.tsx
+++ b/packages/web/src/public-site/pages/landing-page/components/CaseStudies.tsx
@@ -5,6 +5,7 @@ import cn from 'classnames'
 // eslint-disable-next-line no-restricted-imports -- TODO: migrate to @react-spring/web
 import { useSpring, animated } from 'react-spring'
 
+import { useHistoryContext } from 'app/HistoryProvider'
 import imgMerch from 'assets/img/publicSite/ImgMerch.jpg'
 import imgRemix from 'assets/img/publicSite/ImgRemix.jpg'
 import useCardWeight from 'hooks/useCardWeight'
@@ -13,7 +14,6 @@ import { handleClickRoute } from 'public-site/components/handleClickRoute'
 import { AUDIUS_REMIX_CONTESTS_LINK } from 'utils/route'
 
 import styles from './CaseStudies.module.css'
-import { useHistoryContext } from 'app/HistoryProvider'
 
 const messages = {
   title: 'Case Studies',

--- a/packages/web/src/public-site/pages/landing-page/components/FeaturedContent.tsx
+++ b/packages/web/src/public-site/pages/landing-page/components/FeaturedContent.tsx
@@ -23,6 +23,7 @@ import { env } from 'services/env'
 import { collectionPage } from 'utils/route'
 
 import styles from './FeaturedContent.module.css'
+import { useHistoryContext } from 'app/HistoryProvider'
 
 const messages = {
   title: 'Featured Content',
@@ -145,6 +146,7 @@ const getImageUrl = (
 }
 
 const FeaturedContent = (props: FeaturedContentProps) => {
+  const { history } = useHistoryContext()
   const { storageNodeSelector } = useAppContext()
   const [trendingPlaylistsResponse, fetchTrendingPlaylists] =
     useAsyncFn(async () => {
@@ -192,7 +194,11 @@ const FeaturedContent = (props: FeaturedContentProps) => {
                 <MobilePlaylistTile
                   key={p.link}
                   {...p}
-                  onClick={handleClickRoute(p.link, props.setRenderPublicSite)}
+                  onClick={handleClickRoute(
+                    p.link,
+                    props.setRenderPublicSite,
+                    history
+                  )}
                 />
               ))
             : trendingPlaylistsResponse.value
@@ -216,7 +222,8 @@ const FeaturedContent = (props: FeaturedContentProps) => {
                         p.permalink,
                         p.is_album
                       ),
-                      props.setRenderPublicSite
+                      props.setRenderPublicSite,
+                      history
                     )}
                   />
                 ))}
@@ -245,7 +252,11 @@ const FeaturedContent = (props: FeaturedContentProps) => {
                 <DesktopPlaylistTile
                   key={p.title}
                   {...p}
-                  onClick={handleClickRoute(p.link, props.setRenderPublicSite)}
+                  onClick={handleClickRoute(
+                    p.link,
+                    props.setRenderPublicSite,
+                    history
+                  )}
                 />
               ))
             : trendingPlaylistsResponse.value
@@ -269,7 +280,8 @@ const FeaturedContent = (props: FeaturedContentProps) => {
                         p.permalink,
                         p.is_album
                       ),
-                      props.setRenderPublicSite
+                      props.setRenderPublicSite,
+                      history
                     )}
                   />
                 ))}

--- a/packages/web/src/public-site/pages/landing-page/components/FeaturedContent.tsx
+++ b/packages/web/src/public-site/pages/landing-page/components/FeaturedContent.tsx
@@ -8,6 +8,7 @@ import { StorageNodeSelectorService } from '@audius/sdk'
 import { useSpring, animated } from 'react-spring'
 import { useAsyncFn } from 'react-use'
 
+import { useHistoryContext } from 'app/HistoryProvider'
 import audiusExclusivesPlaylistImg from 'assets/img/publicSite/AudiusExclusivesPlaylistArt.png'
 import audiusWeeklyPlaylistImg from 'assets/img/publicSite/AudiusWeeklyPlaylistArt.png'
 import hotAndNewPlaylistImg from 'assets/img/publicSite/HotAndNewPlaylistArt.jpeg'
@@ -23,7 +24,6 @@ import { env } from 'services/env'
 import { collectionPage } from 'utils/route'
 
 import styles from './FeaturedContent.module.css'
-import { useHistoryContext } from 'app/HistoryProvider'
 
 const messages = {
   title: 'Featured Content',

--- a/packages/web/src/public-site/pages/landing-page/components/Hero.tsx
+++ b/packages/web/src/public-site/pages/landing-page/components/Hero.tsx
@@ -4,6 +4,7 @@ import { IconCaretRight, IconCloudDownload } from '@audius/harmony'
 import cn from 'classnames'
 import { Parallax, useParallaxController } from 'react-scroll-parallax'
 
+import { useHistoryContext } from 'app/HistoryProvider'
 import HeroBackgroundMobile from 'assets/img/publicSite/HeroBG.webp'
 import HeroBackground from 'assets/img/publicSite/HeroBG@2x.webp'
 import HeroBackgroundXL from 'assets/img/publicSite/HeroBG@3x.webp'
@@ -17,7 +18,6 @@ import { getIOSAppLink } from 'utils/appLinks'
 import { APP_REDIRECT, TRENDING_PAGE, DOWNLOAD_START_LINK } from 'utils/route'
 
 import styles from './Hero.module.css'
-import { useHistoryContext } from 'app/HistoryProvider'
 
 const messages = {
   title: 'Artists Deserve More',
@@ -37,7 +37,6 @@ const iOSDownloadLink = getIOSAppLink()
 export const Hero = (props: HeroProps) => {
   const parallaxController = useParallaxController()
   const { history } = useHistoryContext()
-  console.log('history', history)
   const { onImageLoad, isMobile } = props
   const onImgSet = useCallback(() => {
     if (!isMobile) parallaxController?.update()

--- a/packages/web/src/public-site/pages/landing-page/components/Hero.tsx
+++ b/packages/web/src/public-site/pages/landing-page/components/Hero.tsx
@@ -17,6 +17,7 @@ import { getIOSAppLink } from 'utils/appLinks'
 import { APP_REDIRECT, TRENDING_PAGE, DOWNLOAD_START_LINK } from 'utils/route'
 
 import styles from './Hero.module.css'
+import { useHistoryContext } from 'app/HistoryProvider'
 
 const messages = {
   title: 'Artists Deserve More',
@@ -35,6 +36,8 @@ const iOSDownloadLink = getIOSAppLink()
 
 export const Hero = (props: HeroProps) => {
   const parallaxController = useParallaxController()
+  const { history } = useHistoryContext()
+  console.log('history', history)
   const { onImageLoad, isMobile } = props
   const onImgSet = useCallback(() => {
     if (!isMobile) parallaxController?.update()
@@ -60,14 +63,22 @@ export const Hero = (props: HeroProps) => {
             <div>{messages.subtitle}</div>
           </div>
           <button
-            onClick={handleClickRoute(TRENDING_PAGE, props.setRenderPublicSite)}
+            onClick={handleClickRoute(
+              TRENDING_PAGE,
+              props.setRenderPublicSite,
+              history
+            )}
             className={styles.ctaButton}
           >
             <span className={styles.ctaMessage}>{messages.cta}</span>
             <IconCaretRight />
           </button>
           <button
-            onClick={handleClickRoute(APP_REDIRECT, props.setRenderPublicSite)}
+            onClick={handleClickRoute(
+              APP_REDIRECT,
+              props.setRenderPublicSite,
+              history
+            )}
             className={styles.downloadButton}
           >
             <IconCloudDownload />
@@ -154,7 +165,8 @@ export const Hero = (props: HeroProps) => {
             <button
               onClick={handleClickRoute(
                 TRENDING_PAGE,
-                props.setRenderPublicSite
+                props.setRenderPublicSite,
+                history
               )}
               className={styles.ctaButton}
             >
@@ -164,7 +176,8 @@ export const Hero = (props: HeroProps) => {
             <button
               onClick={handleClickRoute(
                 DOWNLOAD_START_LINK,
-                props.setRenderPublicSite
+                props.setRenderPublicSite,
+                history
               )}
               className={styles.downloadButton}
             >


### PR DESCRIPTION
### Description

"Start Listening" on the landing page was redirecting to sign up instead of trending. This was because `handlClickRoute` was still using `window.history` instead of the Context provided `history` object

Similar issue was fixed in #7356 

### How Has This Been Tested?

Confirmed that all links from public site behave properly. Going to cherry pick on 1.5.64 and 1.5.65
