### PR TITLE
Fix SSR deploy cache

### DIFF
--- a/.circleci/src/jobs/@web-jobs.yml
+++ b/.circleci/src/jobs/@web-jobs.yml
@@ -87,11 +87,11 @@ web-build-ssr-staging:
         build-type: ssr:stage
         build-directory: packages/web/build-ssr-staging
         build-name: build-ssr-staging
+    # Need to persist vike auto importer so the CF worker finds the build
     - persist_to_workspace:
         root: ./
         paths:
-          - node_modules
-          - packages/web/node_modules
+          - node_modules/@brillout/vite-plugin-import-build/dist
 
 web-test-staging:
   working_directory: ~/audius-protocol
@@ -135,11 +135,11 @@ web-build-ssr-production:
         build-type: ssr:prod
         build-directory: packages/web/build-ssr-production
         build-name: build-ssr-production
+    # Need to persist vike auto importer so the CF worker finds the build
     - persist_to_workspace:
         root: ./
         paths:
-          - node_modules
-          - packages/web/node_modules
+          - node_modules/@brillout/vite-plugin-import-build/dist
 
 web-deploy-demo:
   working_directory: ~/audius-protocol

--- a/.circleci/src/workflows/web.yml
+++ b/.circleci/src/workflows/web.yml
@@ -72,9 +72,9 @@ jobs:
       requires:
         - web-build-staging
         - web-build-ssr-staging
-      # filters:
-      #   branches:
-      #     only: /^main$/
+      filters:
+        branches:
+          only: /^main$/
 
   - web-deploy-release-candidate:
       context: Audius Client

--- a/.circleci/src/workflows/web.yml
+++ b/.circleci/src/workflows/web.yml
@@ -72,9 +72,9 @@ jobs:
       requires:
         - web-build-staging
         - web-build-ssr-staging
-      filters:
-        branches:
-          only: /^main$/
+      # filters:
+      #   branches:
+      #     only: /^main$/
 
   - web-deploy-release-candidate:
       context: Audius Client

--- a/packages/web/turbo.json
+++ b/packages/web/turbo.json
@@ -2,7 +2,11 @@
   "extends": ["//"],
   "pipeline": {
     "build": {
-      "outputs": ["build/**", "build-ssr/**"],
+      "outputs": [
+        "build/**",
+        "build-ssr/**",
+        "../../node_modules/@brillout/vite-plugin-import-build/dist/autoImporter.js"
+      ],
       "dependsOn": ["^build"],
       "outputMode": "new-only",
       "env": ["VITE_ENVIRONMENT", "VITE_SSR"]


### PR DESCRIPTION
### Description

This had me scratching my head for a while. Every time the web build hit the turbo cache, the cloudflare ssr worker deploy was much smaller and errored with "Could not find server build"

Turns out we need to persist `node_modules/@brillout/vite-plugin-import-build/dist/autoImporter.js` (and include it in the turbo outputs) because vike updates this file to point at the build. I was able to figure this out by temporarily deleting gitignore and looking at the file changes cause by the vike build

### How Has This Been Tested?

Confirmed that ssr worker deploys properly even when turbo cache is hit
