### PR TITLE
Improve user search on exact matches

### DIFF
--- a/packages/discovery-provider/src/queries/search_es.py
+++ b/packages/discovery-provider/src/queries/search_es.py
@@ -126,7 +126,6 @@ def search_es_full(args: dict):
 
     mdsl_limit_offset(mdsl, limit, offset)
     mfound = esclient.msearch(searches=mdsl)
-    logger.info(f"asdf mfound: {mfound}")
 
     response: Dict = {
         "tracks": [],
@@ -369,7 +368,7 @@ def default_function_score(dsl, ranking_field):
                 "query": {"bool": dsl},
                 "field_value_factor": {
                     "field": ranking_field,
-                    "factor": .1,
+                    "factor": 0.1,
                     "modifier": "sqrt",
                 },
                 "boost_mode": "multiply",

--- a/packages/discovery-provider/src/queries/search_es.py
+++ b/packages/discovery-provider/src/queries/search_es.py
@@ -368,11 +368,10 @@ def default_function_score(dsl, ranking_field):
                 "query": {"bool": dsl},
                 "field_value_factor": {
                     "field": ranking_field,
-                    "factor": 0.1,
-                    "modifier": "sqrt",
+                    "factor": 20,
+                    "modifier": "ln2p",
                 },
                 "boost_mode": "multiply",
-                "max_boost": 10,
             }
         }
     }
@@ -427,9 +426,9 @@ def user_dsl(search_str, current_user_id, must_saved=False):
         "must_not": [],
         "should": [
             *base_match(search_str, operator="and", extra_fields=["handle"]),
-            {"term": {"handle": {"value": search_str, "boost": 1.2}}},
-            {"term": {"name": {"value": search_str, "boost": 1.2}}},
-            {"term": {"is_verified": {"value": True}}},
+            {"term": {"handle": {"value": search_str, "boost": 0.2}}},
+            {"term": {"name": {"value": search_str, "boost": 0.2}}},
+            {"term": {"is_verified": {"value": True, "boost": 1.5}}},
         ],
     }
 


### PR DESCRIPTION
### Description
Fixes PROTO-683

Exact name and handles are currently buried in user search results. This change adds exact matches for handle and name while adjusting existing parameters to even out.

Replacing custom script score with function score simplifies and improves performance.

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._

`v1/full/search/full?query=isaac&kind=users&limit=4&includePurchaseable=true`

Search for various users while adjusting limit 3 (auto complete), 4 (search page), 40 (full user list).
Tuning parameters until there's a fair balance, improving search quality.