### PR TITLE
Update crawler regex to include all crawlers

### DIFF
--- a/packages/web/scripts/workers-site/index.js
+++ b/packages/web/scripts/workers-site/index.js
@@ -49,7 +49,7 @@ function checkIsBot(val) {
     return false
   }
   const botTest =
-    /altavista|baiduspider|bingbot|discordbot|duckduckbot|facebookexternalhit|gigabot|ia_archiver|linkbot|linkedinbot|msnbot|nextgensearchbot|reaper|slackbot|snap url preview service|telegrambot|twitterbot|whatsapp|whatsup|yahoo|yandex|yeti|yodaobot|zend|zoominfobot|embedly/i
+    /discordbot|facebookexternalhit|gigabot|ia_archiver|linkbot|linkedinbot|reaper|slackbot|snap url preview service|telegrambot|twitterbot|whatsapp|whatsup|yeti|yodaobot|zend|zoominfobot|embedly/i
   return botTest.test(val)
 }
 
@@ -57,7 +57,8 @@ function checkIsCrawler(val) {
   if (!val) {
     return false
   }
-  const crawlerTest = /Googlebot|forceSsr/i
+  const crawlerTest =
+    /forcessr|ahrefs(bot|siteaudit)|altavista|baiduspider|bingbot|duckduckbot|googlebot|msnbot|nextgensearchbot|yahoo|yandex/i
   return crawlerTest.test(val)
 }
 


### PR DESCRIPTION
### Description

Update crawler regex to include ahrefs, bing, yahoo, etc. These crawlers will no longer get redirected to GA but instead get the ssr experience which has meta tags for the track page. This should make these crawler results consistent with google

### How Has This Been Tested?

Confirmed that crawler user agents match the regex
