### PR TITLE
Migrate some buttons to Harmony [C-3751]

### DIFF
--- a/packages/web/src/components/ai-attribution-modal/AiAttributionButton.tsx
+++ b/packages/web/src/components/ai-attribution-modal/AiAttributionButton.tsx
@@ -1,5 +1,4 @@
-import { IconRobot } from '@audius/harmony'
-import { Button, ButtonProps, ButtonSize, ButtonType } from '@audius/stems'
+import { IconRobot, Button, ButtonProps } from '@audius/harmony'
 
 const messages = {
   aiAttribution: 'AI Attribution',
@@ -12,11 +11,12 @@ export const AiAttributionButton = (props: AiAttributionButtonProps) => {
   return (
     <Button
       {...props}
-      type={ButtonType.COMMON_ALT}
       name='aiAttribution'
-      size={ButtonSize.SMALL}
-      text={messages.aiAttribution}
-      leftIcon={<IconRobot />}
-    />
+      size='small'
+      variant='secondary'
+      iconLeft={IconRobot}
+    >
+      {messages.aiAttribution}
+    </Button>
   )
 }

--- a/packages/web/src/components/ai-attribution-modal/AiAttributionModal.tsx
+++ b/packages/web/src/components/ai-attribution-modal/AiAttributionModal.tsx
@@ -2,11 +2,8 @@ import { useCallback, useState } from 'react'
 
 import { ID } from '@audius/common/models'
 import { Nullable } from '@audius/common/utils'
-import { Switch, IconRobot } from '@audius/harmony'
+import { Button, Switch, IconRobot } from '@audius/harmony'
 import {
-  Button,
-  ButtonSize,
-  ButtonType,
   Modal,
   ModalContent,
   ModalHeader,
@@ -71,13 +68,14 @@ export const AiAttributionModal = (props: AiAttributionModalProps) => {
           />
         ) : null}
         <Button
-          text={messages.done}
-          type={ButtonType.PRIMARY}
-          size={ButtonSize.MEDIUM}
+          variant='primary'
+          size='default'
           className={styles.doneButton}
           onClick={handleChange}
           disabled={isAttributable && !aiAttributedUserId}
-        />
+        >
+          {messages.done}
+        </Button>
       </ModalContent>
     </Modal>
   )

--- a/packages/web/src/components/ai-generated-button/AiGeneratedCallout.module.css
+++ b/packages/web/src/components/ai-generated-button/AiGeneratedCallout.module.css
@@ -49,33 +49,3 @@
 .iconRobot path {
   fill: var(--static-white);
 }
-
-.button {
-  padding: 12px;
-}
-
-.buttonText {
-  font-size: var(--font-s);
-}
-
-.iconArrow {
-  width: 10px !important;
-  height: 10px !important;
-  margin-left: 4px;
-}
-
-.iconArrow path {
-  fill: var(--neutral-light-4) !important;
-}
-
-.button:hover .iconArrow path {
-  fill: var(--secondary) !important;
-}
-
-.buttonText {
-  color: var(--neutral-light-4);
-}
-
-.button:hover .buttonText {
-  color: var(--secondary);
-}

--- a/packages/web/src/components/ai-generated-button/AiGeneratedCallout.tsx
+++ b/packages/web/src/components/ai-generated-button/AiGeneratedCallout.tsx
@@ -1,7 +1,7 @@
 import { useCallback } from 'react'
 
 import { IconArrowRight as IconArrow, IconRobot } from '@audius/harmony'
-import { Button, ButtonType } from '@audius/stems'
+import { PlainButton, Box } from '@audius/harmony'
 import { push as pushRoute } from 'connected-react-router'
 import { useDispatch } from 'react-redux'
 
@@ -30,13 +30,15 @@ export const AiGeneratedCallout = ({ handle }: { handle: string }) => {
       </div>
       <div className={styles.body}>
         <div className={styles.description}>{messages.description}</div>
-        <Button
-          className={styles.button}
-          type={ButtonType.TEXT}
-          rightIcon={<IconArrow className={styles.iconArrow} />}
-          text={<div className={styles.buttonText}>{messages.listenNow}</div>}
-          onClick={handleClick}
-        />
+        <Box pl='xs' mt='m'>
+          <PlainButton
+            variant='subdued'
+            iconRight={IconArrow}
+            onClick={handleClick}
+          >
+            {messages.listenNow}
+          </PlainButton>
+        </Box>
       </div>
     </div>
   )

--- a/packages/web/src/components/ai-generated-button/AiGeneratedCallout.tsx
+++ b/packages/web/src/components/ai-generated-button/AiGeneratedCallout.tsx
@@ -1,7 +1,11 @@
 import { useCallback } from 'react'
 
-import { IconArrowRight as IconArrow, IconRobot } from '@audius/harmony'
-import { PlainButton, Box } from '@audius/harmony'
+import {
+  IconArrowRight as IconArrow,
+  IconRobot,
+  PlainButton,
+  Box
+} from '@audius/harmony'
 import { push as pushRoute } from 'connected-react-router'
 import { useDispatch } from 'react-redux'
 

--- a/packages/web/src/components/app-cta-modal/AppCTAModal.module.css
+++ b/packages/web/src/components/app-cta-modal/AppCTAModal.module.css
@@ -52,8 +52,3 @@
 .buttonContainer {
   margin-bottom: 30px;
 }
-
-.downloadButton .downloadButtonText {
-  font-size: var(--font-l);
-  font-weight: var(--font-bold);
-}

--- a/packages/web/src/components/app-cta-modal/AppCTAModal.tsx
+++ b/packages/web/src/components/app-cta-modal/AppCTAModal.tsx
@@ -1,8 +1,8 @@
 import { useCallback } from 'react'
 
 import { Name } from '@audius/common/models'
-import { IconCloudDownload } from '@audius/harmony'
-import { Modal, Button, ButtonType } from '@audius/stems'
+import { Button, IconCloudDownload } from '@audius/harmony'
+import { Modal } from '@audius/stems'
 import { useDispatch } from 'react-redux'
 
 import QRCode from 'assets/img/imageQR.png'
@@ -79,13 +79,12 @@ const AppCTAModal = () => {
         <div className={styles.desktop}>{messages.desktop}</div>
         <div className={styles.buttonContainer}>
           <Button
-            text={messages.buttonLabel}
-            rightIcon={<IconCloudDownload />}
-            type={ButtonType.PRIMARY_ALT}
+            iconRight={IconCloudDownload}
+            variant='primary'
             onClick={downloadDesktopApp}
-            textClassName={styles.downloadButtonText}
-            className={styles.downloadButton}
-          />
+          >
+            {messages.buttonLabel}
+          </Button>
         </div>
       </div>
     </Modal>

--- a/packages/web/src/components/browser-push-confirmation-modal/BrowserPushConfirmationModal.tsx
+++ b/packages/web/src/components/browser-push-confirmation-modal/BrowserPushConfirmationModal.tsx
@@ -7,8 +7,8 @@ import {
   modalsSelectors,
   modalsActions
 } from '@audius/common/store'
-import { Modal, Anchor } from '@audius/stems'
 import { Button } from '@audius/harmony'
+import { Modal, Anchor } from '@audius/stems'
 import cn from 'classnames'
 import { connect } from 'react-redux'
 import { Dispatch } from 'redux'

--- a/packages/web/src/components/browser-push-confirmation-modal/BrowserPushConfirmationModal.tsx
+++ b/packages/web/src/components/browser-push-confirmation-modal/BrowserPushConfirmationModal.tsx
@@ -7,7 +7,8 @@ import {
   modalsSelectors,
   modalsActions
 } from '@audius/common/store'
-import { Modal, Anchor, Button, ButtonType, ButtonSize } from '@audius/stems'
+import { Modal, Anchor } from '@audius/stems'
+import { Button } from '@audius/harmony'
 import cn from 'classnames'
 import { connect } from 'react-redux'
 import { Dispatch } from 'redux'
@@ -141,18 +142,22 @@ const ConnectedBrowserPushConfirmationModal = ({
         <div className={styles.buttons}>
           <Button
             className={styles.closeButton}
-            text={messages.close.toUpperCase()}
-            size={ButtonSize.MEDIUM}
-            type={ButtonType.COMMON}
+            variant='secondary'
+            size='default'
             onClick={onClose}
-          />
+            css={{ fontSize: 16 }}
+          >
+            {messages.close.toUpperCase()}
+          </Button>
           <Button
             className={styles.enableButton}
-            text={messages.confirm.toUpperCase()}
-            size={ButtonSize.MEDIUM}
-            type={ButtonType.PRIMARY_ALT}
+            variant='primary'
+            size='default'
             onClick={onEnabled}
-          />
+            css={{ fontSize: 16 }}
+          >
+            {messages.confirm.toUpperCase()}
+          </Button>
         </div>
       </div>
     </Modal>

--- a/packages/web/src/components/buy-audio-modal/components/CoinbaseBuyAudioButton.tsx
+++ b/packages/web/src/components/buy-audio-modal/components/CoinbaseBuyAudioButton.tsx
@@ -91,7 +91,6 @@ export const CoinbaseBuyAudioButton = () => {
           provider={OnRampProvider.COINBASE}
           className={styles.coinbasePayButton}
           disabled={isDisabled}
-          isDisabled={isDisabled}
           onClick={handleClick}
         />
       </div>

--- a/packages/web/src/components/buy-audio-modal/components/StripeBuyAudioButton.tsx
+++ b/packages/web/src/components/buy-audio-modal/components/StripeBuyAudioButton.tsx
@@ -71,7 +71,6 @@ export const StripeBuyAudioButton = () => {
     >
       <div>
         <OnRampButton
-          isDisabled={belowThreshold}
           disabled={belowThreshold}
           className={styles.button}
           provider={OnRampProvider.STRIPE}

--- a/packages/web/src/components/buy-audio-modal/components/SuccessPage.module.css
+++ b/packages/web/src/components/buy-audio-modal/components/SuccessPage.module.css
@@ -19,9 +19,6 @@
 .review {
   color: var(--neutral-light-4);
 }
-.review .reviewButtonIcon svg path {
-  fill: var(--neutral-light-4);
-}
 
 .results {
   display: flex;

--- a/packages/web/src/components/buy-audio-modal/components/SuccessPage.tsx
+++ b/packages/web/src/components/buy-audio-modal/components/SuccessPage.tsx
@@ -8,8 +8,7 @@ import {
   modalsActions
 } from '@audius/common/store'
 import { formatAudio, isNullOrUndefined } from '@audius/common/utils'
-import { IconInfo } from '@audius/harmony'
-import { Button, PlainButton } from '@audius/harmony'
+import { IconInfo, Button, PlainButton } from '@audius/harmony'
 import { useDispatch } from 'react-redux'
 
 import { useModalState } from 'common/hooks/useModalState'

--- a/packages/web/src/components/buy-audio-modal/components/SuccessPage.tsx
+++ b/packages/web/src/components/buy-audio-modal/components/SuccessPage.tsx
@@ -9,7 +9,7 @@ import {
 } from '@audius/common/store'
 import { formatAudio, isNullOrUndefined } from '@audius/common/utils'
 import { IconInfo } from '@audius/harmony'
-import { Button, ButtonSize, ButtonType } from '@audius/stems'
+import { Button, PlainButton } from '@audius/harmony'
 import { useDispatch } from 'react-redux'
 
 import { useModalState } from 'common/hooks/useModalState'
@@ -82,20 +82,18 @@ export const SuccessPage = () => {
           </div>
         )}
       </div>
-      <Button
-        text={onSuccess?.message ?? messages.done}
-        type={ButtonType.PRIMARY_ALT}
-        onClick={handleDoneClicked}
-      />
+      <Button onClick={handleDoneClicked}>
+        {onSuccess?.message ?? messages.done}
+      </Button>
       <div className={styles.review}>
-        <Button
-          iconClassName={styles.reviewButtonIcon}
-          type={ButtonType.TEXT}
-          size={ButtonSize.SMALL}
-          text={messages.review}
-          leftIcon={<IconInfo />}
+        <PlainButton
+          size='default'
+          iconLeft={IconInfo}
+          variant='subdued'
           onClick={handleReviewTransactionClicked}
-        />
+        >
+          {messages.review}
+        </PlainButton>
       </div>
     </div>
   )

--- a/packages/web/src/components/collapsible-content/CollapsibleContent.module.css
+++ b/packages/web/src/components/collapsible-content/CollapsibleContent.module.css
@@ -6,12 +6,3 @@
   margin: 0 -150px;
   transition: height var(--quick);
 }
-
-.toggleCollapsedButton {
-  color: var(--neutral-light-4);
-  margin: 0 auto;
-}
-
-.toggleCollapsedButton .toggleCollapsedButtonIcon path {
-  fill: var(--neutral-light-4);
-}

--- a/packages/web/src/components/collapsible-content/CollapsibleContent.tsx
+++ b/packages/web/src/components/collapsible-content/CollapsibleContent.tsx
@@ -1,10 +1,11 @@
 import { useState, useCallback } from 'react'
 
 import {
+  PlainButton,
   IconCaretDown as IconCaretDownLine,
-  IconCaretUp as IconCaretUpLine
+  IconCaretUp as IconCaretUpLine,
+  useTheme
 } from '@audius/harmony'
-import { Button, ButtonSize, ButtonType } from '@audius/stems'
 import { ResizeObserver } from '@juggle/resize-observer'
 import cn from 'classnames'
 import useMeasure from 'react-use-measure'
@@ -33,6 +34,7 @@ export const CollapsibleContent = ({
   children
 }: CollapsibleContentProps) => {
   const [isCollapsed, setIsCollapsed] = useState(!showByDefault)
+  const { spacing } = useTheme()
 
   const handleToggle = useCallback(() => {
     setIsCollapsed((isCollapsed) => !isCollapsed)
@@ -52,17 +54,21 @@ export const CollapsibleContent = ({
       >
         <div ref={ref}>{children}</div>
       </div>
-      <Button
+      <PlainButton
         className={cn(styles.toggleCollapsedButton, toggleButtonClassName)}
-        iconClassName={styles.toggleCollapsedButtonIcon}
+        css={{
+          paddingTop: spacing.l,
+          paddingBottom: spacing.l,
+          margin: '0 auto'
+        }}
         aria-controls={id}
         aria-expanded={!isCollapsed}
-        type={ButtonType.TEXT}
-        size={ButtonSize.SMALL}
-        text={isCollapsed ? showText : hideText}
-        rightIcon={isCollapsed ? <IconCaretDownLine /> : <IconCaretUpLine />}
+        iconRight={isCollapsed ? IconCaretDownLine : IconCaretUpLine}
         onClick={handleToggle}
-      />
+        variant='subdued'
+      >
+        {isCollapsed ? showText : hideText}
+      </PlainButton>
     </div>
   )
 }

--- a/packages/web/src/components/data-entry/ReleaseDateTriggerLegacy.tsx
+++ b/packages/web/src/components/data-entry/ReleaseDateTriggerLegacy.tsx
@@ -2,8 +2,7 @@ import { useMemo, useState } from 'react'
 
 import { Track } from '@audius/common/models'
 import { dayjs } from '@audius/common/utils'
-import { Flex, IconCalendarMonth } from '@audius/harmony'
-import { Button, ButtonSize, ButtonType } from '@audius/stems'
+import { Button, Flex, IconCalendarMonth } from '@audius/harmony'
 import moment from 'moment'
 import { toFormikValidationSchema } from 'zod-formik-adapter'
 
@@ -126,13 +125,14 @@ export const ReleaseDateTriggerLegacy = (
       previewOverride={(toggleMenu) => (
         <Button
           className={styles.releaseDateButton}
-          type={ButtonType.COMMON_ALT}
+          variant='secondary'
           name='releaseDateModal'
-          text={formatCalendarTime(trackReleaseDate, 'Scheduled for')}
-          size={ButtonSize.SMALL}
+          size='small'
           onClick={toggleMenu}
-          leftIcon={<IconCalendarMonth />}
-        />
+          iconLeft={IconCalendarMonth}
+        >
+          {formatCalendarTime(trackReleaseDate, 'Scheduled for')}
+        </Button>
       )}
     />
   )

--- a/packages/web/src/components/download-buttons/DownloadButtons.tsx
+++ b/packages/web/src/components/download-buttons/DownloadButtons.tsx
@@ -7,8 +7,7 @@ import {
 } from '@audius/common/hooks'
 import { ID } from '@audius/common/models'
 import { toastActions } from '@audius/common/store'
-import { IconCloudDownload } from '@audius/harmony'
-import { IconButton } from '@audius/stems'
+import { IconButton, IconCloudDownload } from '@audius/harmony'
 import cn from 'classnames'
 import { useDispatch } from 'react-redux'
 import { useHistory } from 'react-router-dom'
@@ -92,7 +91,7 @@ const DownloadButton = ({
 
     return (
       <div className={styles.iconDownload}>
-        <IconButton aria-label='Download' icon={<IconCloudDownload />} />
+        <IconButton aria-label='Download' icon={IconCloudDownload} />
       </div>
     )
   }

--- a/packages/web/src/components/on-ramp-button/OnRampButton.tsx
+++ b/packages/web/src/components/on-ramp-button/OnRampButton.tsx
@@ -1,6 +1,9 @@
 import { OnRampProvider } from '@audius/common/store'
-import { IconLogoLinkByStripe as LogoStripeLink } from '@audius/harmony'
-import { Button, ButtonProps, ButtonType } from '@audius/stems'
+import {
+  Button,
+  ButtonProps,
+  IconLogoLinkByStripe as LogoStripeLink
+} from '@audius/harmony'
 import cn from 'classnames'
 
 import CoinbasePayLogo from 'assets/img/coinbase-pay/LogoCoinbasePay.svg'
@@ -16,6 +19,7 @@ export const OnRampButton = (
   props: Omit<ButtonProps, 'text'> & {
     provider: OnRampProvider
     buttonPrefix?: string
+    textClassName?: string
   }
 ) => {
   const {
@@ -33,34 +37,30 @@ export const OnRampButton = (
   return (
     <Button
       aria-label={`${buttonPrefix} ${provider}`}
-      text={
-        <>
-          <span>{buttonPrefix}</span>
-          {isStripe ? (
-            <LogoStripeLink
-              className={styles.logo}
-              width={'6em'}
-              height={'1.33em'}
-            />
-          ) : (
-            <CoinbasePayLogo
-              className={styles.logo}
-              width={'5.75em'}
-              height={'0.75em'}
-            />
-          )}
-        </>
-      }
-      includeHoverAnimations
-      type={ButtonType.GLASS}
       className={cn(
         styles.button,
         { [styles.stripeButton]: isStripe },
         { [styles.coinbaseButton]: isCoinbase },
         className
       )}
-      textClassName={cn(styles.textClassName, textClassName)}
       {...otherProps}
-    />
+    >
+      <div className={cn(styles.textClassName, textClassName)}>
+        <span>{buttonPrefix}</span>
+        {isStripe ? (
+          <LogoStripeLink
+            className={styles.logo}
+            width={'6em'}
+            height={'1.33em'}
+          />
+        ) : (
+          <CoinbasePayLogo
+            className={styles.logo}
+            width={'5.75em'}
+            height={'0.75em'}
+          />
+        )}
+      </div>
+    </Button>
   )
 }

--- a/packages/web/src/components/remix-settings-modal/RemixSettingsModalTrigger.tsx
+++ b/packages/web/src/components/remix-settings-modal/RemixSettingsModalTrigger.tsx
@@ -1,5 +1,4 @@
-import { IconRemix } from '@audius/harmony'
-import { Button, ButtonSize, ButtonType } from '@audius/stems'
+import { IconRemix, Button } from '@audius/harmony'
 
 const messages = {
   remixSettings: 'Remix Settings',
@@ -19,12 +18,13 @@ export const RemixSettingsModalTrigger = (
   return (
     <Button
       className={props.className}
-      type={ButtonType.COMMON_ALT}
+      variant='secondary'
       name='remixSettings'
-      text={messages.remixSettings}
-      size={ButtonSize.SMALL}
+      size='small'
       onClick={props.onClick}
-      leftIcon={<IconRemix />}
-    />
+      iconLeft={IconRemix}
+    >
+      {messages.remixSettings}
+    </Button>
   )
 }

--- a/packages/web/src/pages/audio-rewards-page/components/WalletManagementTile.tsx
+++ b/packages/web/src/pages/audio-rewards-page/components/WalletManagementTile.tsx
@@ -227,7 +227,6 @@ const OnRampTooltipButton = ({
           provider={provider}
           className={styles.onRampButton}
           disabled={isDisabled}
-          isDisabled={isDisabled}
           onClick={onClick}
         />
       </div>

--- a/packages/web/src/pages/trending-page/components/RewardsBanner.tsx
+++ b/packages/web/src/pages/trending-page/components/RewardsBanner.tsx
@@ -7,7 +7,6 @@ import {
 import {
   IconArrowRight as IconArrow,
   IconCrown,
-  spacing,
   useTheme
 } from '@audius/harmony'
 import cn from 'classnames'


### PR DESCRIPTION
### Description
Migrate some buttons to Harmony. 

Note:
Did not migrate the button in `AppRedirectPopover` deliberately, as design wants to leave it as-is for now until they have time to revisit. 

### How Has This Been Tested?

Tested and verified in browser.

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._
