### PR TITLE
Add correct type to manual transfer confirmation switch field

### DIFF
--- a/packages/web/src/components/withdraw-usdc-modal/components/ConfirmTransferDetails.tsx
+++ b/packages/web/src/components/withdraw-usdc-modal/components/ConfirmTransferDetails.tsx
@@ -57,7 +57,10 @@ export const ConfirmTransferDetails = () => {
   const [{ value: amountValue }] = useField(AMOUNT)
   const [{ value: addressValue }] = useField(ADDRESS)
   const [{ value: methodValue }] = useField(METHOD)
-  const [confirmField, { error: confirmError }] = useField(CONFIRM)
+  const [confirmField, { error: confirmError }] = useField({
+    name: CONFIRM,
+    type: 'checkbox'
+  })
 
   const { data: balance } = useUSDCBalance()
   const balanceNumber = formatUSDCWeiToFloorCentsNumber(


### PR DESCRIPTION
### Description
This got missed in the update to switches and doesn't render the correct style when "checked".

### How Has This Been Tested?
Tested locally against staging
