### PR TITLE
[PAY-2457] Fix bad conditional for showing transaction link

### DIFF
--- a/packages/web/src/components/withdraw-usdc-modal/components/TransferSuccessful.tsx
+++ b/packages/web/src/components/withdraw-usdc-modal/components/TransferSuccessful.tsx
@@ -99,7 +99,7 @@ export const TransferSuccessful = ({
           balanceStatus === Status.SUCCESS ? `$${balanceFormatted}` : undefined
         }
       />
-      {methodValue !== WithdrawMethod.MANUAL_TRANSFER && signature ? (
+      {methodValue === WithdrawMethod.MANUAL_TRANSFER && signature ? (
         <>
           <Divider style={{ margin: 0 }} />
           <div className={styles.destination}>


### PR DESCRIPTION
### Description
The check for whether to show the destination address and transaction link at the end of the withdrawal process got its condition inverted somehow, such that we fail to show the link for a manual transfer and then show the signature for the bank withdrawal flow.

fixes PAY-2457

### How Has This Been Tested?
Tested locally against staging
