### PR TITLE
Miscellaneous data fetching fixes for Pay and Earn page

### DIFF
--- a/packages/common/src/api/purchases.ts
+++ b/packages/common/src/api/purchases.ts
@@ -76,10 +76,12 @@ const purchasesApi = createApi({
             ({ contentType }) => contentType === USDCContentPurchaseType.TRACK
           )
           .map(({ contentId }) => contentId)
-        await trackApiFetch.getTracksByIds(
-          { ids: trackIdsToFetch, currentUserId: userId },
-          context
-        )
+        if (trackIdsToFetch.length > 0) {
+          await trackApiFetch.getTracksByIds(
+            { ids: trackIdsToFetch, currentUserId: userId },
+            context
+          )
+        }
         return purchases
       },
       options: { retry: true }
@@ -135,10 +137,12 @@ const purchasesApi = createApi({
             ({ contentType }) => contentType === USDCContentPurchaseType.TRACK
           )
           .map(({ contentId }) => contentId)
-        await trackApiFetch.getTracksByIds(
-          { ids: trackIdsToFetch, currentUserId: userId },
-          context
-        )
+        if (trackIdsToFetch.length > 0) {
+          await trackApiFetch.getTracksByIds(
+            { ids: trackIdsToFetch, currentUserId: userId },
+            context
+          )
+        }
         return purchases
       },
       options: { retry: true }

--- a/packages/web/src/pages/pay-and-earn-page/components/PurchasesTab.tsx
+++ b/packages/web/src/pages/pay-and-earn-page/components/PurchasesTab.tsx
@@ -107,7 +107,7 @@ export const usePurchases = () => {
     {
       userId
     },
-    { force: true }
+    { disabled: !userId, force: true }
   )
 
   const status = combineStatuses([dataStatus, countStatus])

--- a/packages/web/src/pages/pay-and-earn-page/components/SalesTab.tsx
+++ b/packages/web/src/pages/pay-and-earn-page/components/SalesTab.tsx
@@ -105,7 +105,7 @@ export const useSales = () => {
 
   const { status: countStatus, data: count } = useGetSalesCount(
     { userId },
-    { force: true }
+    { disabled: !userId, force: true }
   )
 
   const status = combineStatuses([dataStatus, countStatus])

--- a/packages/web/src/pages/pay-and-earn-page/components/WithdrawalsTab.tsx
+++ b/packages/web/src/pages/pay-and-earn-page/components/WithdrawalsTab.tsx
@@ -217,7 +217,7 @@ export const useWithdrawals = () => {
       userId,
       method: full.GetUSDCTransactionsMethodEnum.Send
     },
-    { force: true }
+    { disabled: !userId, force: true }
   )
 
   const status = combineStatuses([dataStatus, countStatus])


### PR DESCRIPTION
### Description
This takes care of a few console errors I've been seeing while testing the Pay and Earn page. None of these cause any actual problems with the experience. But some of them were generating invalid API calls for certain users that would just be useless requests.

* Updated count API usage on all three tabs to be disabled until we've fetched the user. This was generating validation errors since the API implementation uses zod to attempt to parse `null` to a number before making the request. Good news is that the validation served its intended purpose!
* Updated the purchases and sales APIs to only make the eager fetch requests for tracks if the returned list actually had a length. For users with no sales/purchases, this was generating an API call with no `id` list for the tracks, which gets thrown back as a 400.

### How Has This Been Tested?
Tested locally against staging. Verified that the page still works as intended for users with and without purchases/sales, and that we no longer have console/request errors.
