### PR TITLE
Fix search personalization in client

### DIFF
--- a/packages/common/src/services/audius-api-client/helper.ts
+++ b/packages/common/src/services/audius-api-client/helper.ts
@@ -8,33 +8,9 @@ import { removeNullable } from '~/utils'
 import * as adapter from './ResponseAdapter'
 import { APIResponse, APISearch } from './types'
 
-const SEARCH_MAX_SAVED_RESULTS = 10
 const SEARCH_MAX_TOTAL_RESULTS = 50
 
-const AUTOCOMPLETE_MAX_SAVED_RESULTS = 2
 const AUTOCOMPLETE_TOTAL_RESULTS = 3
-
-/**
- * Combines two lists by concatting `maxSaved` results from the `savedList` onto the head of `normalList`,
- * ensuring that no item is duplicated in the resulting list (deduped by `uniqueKey`). The final list length is capped
- * at `maxTotal` items.
- */
-const combineLists = <T>(
-  savedList: Array<T>,
-  normalList: Array<T>,
-  uniqueKey: string,
-  maxSaved: number,
-  maxTotal: number
-) => {
-  const truncatedSavedList = savedList.slice(
-    0,
-    Math.min(maxSaved, savedList.length)
-  )
-  const saveListsSet = new Set(truncatedSavedList.map((s) => s[uniqueKey]))
-  const filteredList = normalList.filter((n) => !saveListsSet.has(n[uniqueKey]))
-  const combinedLists = savedList.concat(filteredList)
-  return combinedLists.slice(0, Math.min(maxTotal, combinedLists.length))
-}
 
 type ProcessSearchResultsArgs = {
   tracks?: UserTrackMetadata[]
@@ -89,51 +65,16 @@ export const processSearchResults = async ({
   albums = [],
   playlists = [],
   users = [],
-  saved_tracks: savedTracks = [],
-  saved_albums: savedAlbums = [],
-  saved_playlists: savedPlaylists = [],
-  followed_users: followedUsers = [],
   isAutocomplete = false
 }: ProcessSearchResultsArgs) => {
-  const maxSaved = isAutocomplete
-    ? AUTOCOMPLETE_MAX_SAVED_RESULTS
-    : SEARCH_MAX_SAVED_RESULTS
   const maxTotal = isAutocomplete
     ? AUTOCOMPLETE_TOTAL_RESULTS
     : SEARCH_MAX_TOTAL_RESULTS
-  const combinedTracks = combineLists(
-    savedTracks,
-    tracks,
-    'track_id',
-    maxSaved,
-    maxTotal
-  )
-  const combinedAlbums = combineLists(
-    savedAlbums,
-    albums,
-    'playlist_id',
-    maxSaved,
-    maxTotal
-  )
-  const combinedPlaylists = combineLists(
-    savedPlaylists,
-    playlists,
-    'playlist_id',
-    maxSaved,
-    maxTotal
-  )
-  const combinedUsers = combineLists(
-    followedUsers,
-    users,
-    'user_id',
-    maxSaved,
-    maxTotal
-  )
 
   return {
-    tracks: combinedTracks,
-    albums: combinedAlbums,
-    playlists: combinedPlaylists,
-    users: combinedUsers
+    tracks: tracks.slice(0, Math.min(maxTotal, tracks.length)),
+    albums: albums.slice(0, Math.min(maxTotal, albums.length)),
+    playlists: playlists.slice(0, Math.min(maxTotal, playlists.length)),
+    users: users.slice(0, Math.min(maxTotal, users.length))
   }
 }

--- a/packages/web/src/pages/search-page/components/desktop/SearchPageContent.jsx
+++ b/packages/web/src/pages/search-page/components/desktop/SearchPageContent.jsx
@@ -122,6 +122,7 @@ class SearchPageContent extends Component {
       search: { status },
       recordSearchResultClick
     } = this.props
+    console.log('asdf artists:', { artists })
     const { cardToast } = this.state
     const searchTitle = isTagSearch ? `Tag Search` : `Search`
     const artistCards = artists.map((artist, ind) => {

--- a/packages/web/src/pages/search-page/components/desktop/SearchPageContent.jsx
+++ b/packages/web/src/pages/search-page/components/desktop/SearchPageContent.jsx
@@ -122,7 +122,6 @@ class SearchPageContent extends Component {
       search: { status },
       recordSearchResultClick
     } = this.props
-    console.log('asdf artists:', { artists })
     const { cardToast } = this.state
     const searchTitle = isTagSearch ? `Tag Search` : `Search`
     const artistCards = artists.map((artist, ind) => {


### PR DESCRIPTION
### Description
Fixes PROTO-1656

The client is unnecessarily forcing all saved entities to the top leading to bad results across users, tracks, etc. The intention is to boost personalized results but Elasticsearch already takes care of that here:

https://github.com/AudiusProject/audius-protocol/blob/5ae87faf0e5916157156d5704712bfa29e64f33b/packages/discovery-provider/src/queries/search_es.py#L435-L440

This also allows us to remove an extra round trip to get only saved entities, server-side. 

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._

Before + After running locally against prod
<img width="1811" alt="Screenshot 2024-02-07 at 9 11 33 AM" src="https://github.com/AudiusProject/audius-protocol/assets/6413636/cae876a7-5c88-4330-aaec-ea9d38328126">
<img width="1715" alt="Screenshot 2024-02-07 at 9 16 31 AM" src="https://github.com/AudiusProject/audius-protocol/assets/6413636/06e3bc2f-3a95-4ec1-80fc-19d7f4bea592">

