### PR TITLE
Integrate ddex into CI auto-upgrade

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -519,6 +519,7 @@ workflows:
             .* run-stems-workflow true
             .* run-harmony-workflow true
             .* run-probers-workflow true
+            .* run-ddex-stage-workflow true
             .circleci/.* run-web-workflow true
             .circleci/.* run-mobile-workflow true
             packages/common/.* run-common-workflow true

--- a/.circleci/src/@continue_config.yml
+++ b/.circleci/src/@continue_config.yml
@@ -76,6 +76,9 @@ parameters:
   run-ddex-publisher-workflow:
     type: boolean
     default: false
+  run-ddex-stage-workflow:
+    type: boolean
+    default: false
 # Can enable recurring probers against stage at some point
 # workflows:
 #   version: 2.1

--- a/.circleci/src/jobs/commit-audius-docker-compose-and-notify.yml
+++ b/.circleci/src/jobs/commit-audius-docker-compose-and-notify.yml
@@ -117,6 +117,7 @@ steps:
           sed -i "s/\({TAG:-\)[^}]*\}/\1$CIRCLE_SHA1}/" creator-node/docker-compose*.yml
           sed -i "s/\({TAG:-\)[^}]*\}/\1$CIRCLE_SHA1}/" discovery-provider/docker-compose*.yml
           sed -i "s/\({TAG:-\)[^}]*\}/\1$CIRCLE_SHA1}/" identity-service/docker-compose*.yml
+          sed -i "s/\({TAG:-\)[^}]*\}/\1$CIRCLE_SHA1}/" ddex/docker-compose*.yml
           git add */docker-compose*.yml
           git commit -m "$CIRCLE_BRANCH auto-deploy"
           git push origin stage

--- a/.circleci/src/jobs/deploy-stage-nodes.yml
+++ b/.circleci/src/jobs/deploy-stage-nodes.yml
@@ -1,6 +1,6 @@
 parameters:
   service:
-    description: 'Service to deploy (creator-node, discovery-provider, identity-service)'
+    description: 'Service to deploy (creator-node, discovery-provider, identity-service, ddex)'
     type: string
 resource_class: small
 docker:

--- a/.circleci/src/workflows/ddex-stage.yml
+++ b/.circleci/src/workflows/ddex-stage.yml
@@ -1,26 +1,26 @@
 when: << pipeline.parameters.run-ddex-stage-workflow >>
 jobs:
   - push-docker-image:
-    name: push-ddex-web
-    context: [Vercel, dockerhub]
-    service: ddex-web
-    filters:
-      branches:
-        only: main
+      name: push-ddex-web
+      context: [Vercel, dockerhub]
+      service: ddex-web
+      filters:
+        branches:
+          only: main
   - push-docker-image:
-    name: push-ddex-ingester
-    context: [Vercel, dockerhub]
-    service: ddex-ingester
-    filters:
-      branches:
-        only: main
+      name: push-ddex-ingester
+      context: [Vercel, dockerhub]
+      service: ddex-ingester
+      filters:
+        branches:
+          only: main
   - push-docker-image:
-    name: push-ddex-publisher
-    context: [Vercel, dockerhub]
-    service: ddex-publisher
-    filters:
-      branches:
-        only: main
+      name: push-ddex-publisher
+      context: [Vercel, dockerhub]
+      service: ddex-publisher
+      filters:
+        branches:
+          only: main
   - deploy-stage-nodes:
       name: deploy-stage-ddex
       requires:

--- a/.circleci/src/workflows/ddex-stage.yml
+++ b/.circleci/src/workflows/ddex-stage.yml
@@ -1,0 +1,34 @@
+when: << pipeline.parameters.run-ddex-stage-workflow >>
+jobs:
+  - push-docker-image:
+    name: push-ddex-web
+    context: [Vercel, dockerhub]
+    service: ddex-web
+    filters:
+      branches:
+        only: main
+  - push-docker-image:
+    name: push-ddex-ingester
+    context: [Vercel, dockerhub]
+    service: ddex-ingester
+    filters:
+      branches:
+        only: main
+  - push-docker-image:
+    name: push-ddex-publisher
+    context: [Vercel, dockerhub]
+    service: ddex-publisher
+    filters:
+      branches:
+        only: main
+  - deploy-stage-nodes:
+      name: deploy-stage-ddex
+      requires:
+        - push-ddex-web
+        - push-ddex-ingester
+        - push-ddex-publisher
+      filters:
+        branches:
+          only: main
+      context: github
+      service: ddex


### PR DESCRIPTION
### Description
Makes DDEX push containers and update audius-docker-compose commit SHAs when:
- commits merge to the `main` brain (for deploying to stage)
- a new release is cut

This is needed for ddex to auto-upgrade now that it's treated as its own node type.