### PR TITLE
Fix tag search navigating on web

### DIFF
--- a/packages/web/src/components/search-bar/ConnectedSearchBar.jsx
+++ b/packages/web/src/components/search-bar/ConnectedSearchBar.jsx
@@ -79,14 +79,22 @@ class ConnectedSearchBar extends Component {
 
   onSubmit = (value) => {
     // Encode everything besides tag searches
-    if (!value.startsWith('#')) {
+    const pathname = '/search'
+    if (value.startsWith('#')) {
+      // perform tag search
+      const pathname = `/search`
+      this.props.history.push({
+        hash: value.split('#')[1].replace(/\s+/g, ''),
+        pathname,
+        state: {}
+      })
+    } else {
       value = encodeURIComponent(value)
+      this.props.history.push({
+        pathname: pathname + value,
+        state: {}
+      })
     }
-    const pathname = `/search/${value}`
-    this.props.history.push({
-      pathname,
-      state: {}
-    })
   }
 
   onSelect = (value) => {

--- a/packages/web/src/components/search-bar/ConnectedSearchBar.jsx
+++ b/packages/web/src/components/search-bar/ConnectedSearchBar.jsx
@@ -83,7 +83,7 @@ class ConnectedSearchBar extends Component {
     if (value.startsWith('#')) {
       // perform tag search
       this.props.history.push({
-        hash: value.split('#')[1].replace(/\s+/g, ''),
+        hash: value.split('#')[1],
         pathname,
         state: {}
       })

--- a/packages/web/src/components/search-bar/ConnectedSearchBar.jsx
+++ b/packages/web/src/components/search-bar/ConnectedSearchBar.jsx
@@ -82,7 +82,6 @@ class ConnectedSearchBar extends Component {
     const pathname = '/search'
     if (value.startsWith('#')) {
       // perform tag search
-      const pathname = `/search`
       this.props.history.push({
         hash: value.split('#')[1].replace(/\s+/g, ''),
         pathname,
@@ -91,7 +90,7 @@ class ConnectedSearchBar extends Component {
     } else {
       value = encodeURIComponent(value)
       this.props.history.push({
-        pathname: pathname + value,
+        pathname: pathname + '/' + value,
         state: {}
       })
     }


### PR DESCRIPTION
### Description

Searching by #hashtags was not performing a Tag Search, it's merely searching as if it wasn't a tag. The only way to Tag Search on web atm is to click on a tag. This is because onSubmit does not structure the history in the tag search form. 

Fixes PROTO-1659

Mobile doesn't have this issue.

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._

Ran locally against prod, comparing tag searches
After vs. Before
<img width="1773" alt="Screenshot 2024-02-07 at 10 11 05 AM" src="https://github.com/AudiusProject/audius-protocol/assets/6413636/45efdb60-85ab-4108-880a-cb579c786125">

Now you get results that don't just have `onss` in the name but actually results relevant to #onss. Users with #onss in their profile or tracks.