### PR TITLE
Revert "Disable usdc bank split in dev mode (#6300)"

### DIFF
--- a/packages/web/src/common/store/upload/sagaHelpers.ts
+++ b/packages/web/src/common/store/upload/sagaHelpers.ts
@@ -13,7 +13,6 @@ import {
   getContext
 } from '@audius/common/store'
 import { BN_USDC_CENT_WEI } from '@audius/common/utils'
-import { PublicKey } from '@solana/web3.js'
 import BN from 'bn.js'
 import { range } from 'lodash'
 import { all, call, put, select } from 'typed-redux-saga'
@@ -117,12 +116,7 @@ export function* processTracksForUpload(tracks: TrackForUpload[]) {
 
   const ownerAccount = yield* select(getAccountUser)
   const wallet = ownerAccount?.erc_wallet ?? ownerAccount?.wallet
-
-  // TODO: Figure out how to support USDC properly in dev.
-  let ownerUserbank: PublicKey
-  if (ENVIRONMENT !== 'development') {
-    ownerUserbank = yield* getUSDCUserBank(wallet)
-  }
+  const ownerUserbank = yield* getUSDCUserBank(wallet)
 
   tracks.forEach((track) => {
     const streamConditions = track.metadata.stream_conditions
@@ -143,7 +137,7 @@ export function* processTracksForUpload(tracks: TrackForUpload[]) {
       downloadConditions.usdc_purchase = {
         price: priceCents,
         splits: {
-          [ownerUserbank?.toString() ?? '']: priceWei
+          [ownerUserbank.toString()]: priceWei
         }
       }
     }

--- a/packages/web/src/common/store/upload/sagaHelpers.ts
+++ b/packages/web/src/common/store/upload/sagaHelpers.ts
@@ -106,7 +106,6 @@ export function* recordGatedTracks(tracks: (TrackForUpload | TrackMetadata)[]) {
 }
 
 export function* processTracksForUpload(tracks: TrackForUpload[]) {
-  const { ENVIRONMENT } = yield* getContext('env')
   const getFeatureEnabled = yield* getContext('getFeatureEnabled')
   const isUsdcPurchaseEnabled = yield* call(
     getFeatureEnabled,


### PR DESCRIPTION
This reverts commit 8cda5499137d85204ba9bb4213b22e589564b0cf.

### Description
Seems like usdc on dev env works now, don't totally remember the context for why the original PR existed in the first place.

### How Has This Been Tested?

Uploading premium tracks + purchasing them on local dev works.