### PR TITLE
[ONC-10] Fix styles for ArtistRecommendations pictures

### DIFF
--- a/packages/web/src/components/artist-recommendations/ArtistRecommendations.tsx
+++ b/packages/web/src/components/artist-recommendations/ArtistRecommendations.tsx
@@ -69,14 +69,17 @@ const ArtistProfilePictureWrapper = ({
   const isMobile = useIsMobile()
   if (isMobile) {
     return (
-      <DynamicImage className={styles.profilePicture} image={profilePicture} />
+      <DynamicImage
+        wrapperClassName={styles.profilePicture}
+        image={profilePicture}
+      />
     )
   }
   return (
     <ArtistPopover mount={MountPlacement.PARENT} handle={handle}>
       <div>
         <DynamicImage
-          className={styles.profilePicture}
+          wrapperClassName={styles.profilePicture}
           image={profilePicture}
         />
       </div>


### PR DESCRIPTION
### Description

https://linear.app/audius/issue/ONC-10/[qa]-suggested-artists-modal-missing-profile-pictures

Artist recommendations pictures were not showing up because of a change in DynamicImage to use the harmony box component. `wrapperClassName` needed to be used instead of `className`

![image](https://github.com/AudiusProject/audius-protocol/assets/19916043/672a9b52-ac55-4483-bf71-8aae1e7e94cf)

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._
