### PR TITLE
Misc DDEX cleanup + publisher sets delivery status

### DIFF
--- a/dev-tools/compose/docker-compose.ddex.yml
+++ b/dev-tools/compose/docker-compose.ddex.yml
@@ -13,6 +13,7 @@ services:
     environment:
       - DDEX_PORT=9000
       - DDEX_MONGODB_URL=mongodb://mongo:mongo@ddex-mongo:27017/ddex?authSource=admin&replicaSet=rs0
+    env_file: .env
     ports:
       - "9000:9000"
     networks:
@@ -27,6 +28,7 @@ services:
       dockerfile: ${PROJECT_ROOT}/packages/ddex/ingester/Dockerfile
     environment:
       - DDEX_MONGODB_URL=mongodb://mongo:mongo@ddex-mongo:27017/ddex?authSource=admin&replicaSet=rs0
+    env_file: .env
     depends_on:
       ddex-mongo:
         condition: service_healthy
@@ -43,6 +45,7 @@ services:
       dockerfile: ${PROJECT_ROOT}/packages/ddex/ingester/Dockerfile
     environment:
       - DDEX_MONGODB_URL=mongodb://mongo:mongo@ddex-mongo:27017/ddex?authSource=admin&replicaSet=rs0
+    env_file: .env
     depends_on:
       ddex-mongo:
         condition: service_healthy
@@ -59,6 +62,7 @@ services:
       dockerfile: ${PROJECT_ROOT}/packages/ddex/ingester/Dockerfile
     environment:
       - DDEX_MONGODB_URL=mongodb://mongo:mongo@ddex-mongo:27017/ddex?authSource=admin&replicaSet=rs0
+    env_file: .env
     depends_on:
       ddex-mongo:
         condition: service_healthy
@@ -79,6 +83,7 @@ services:
         TURBO_TOKEN: '${TURBO_TOKEN}'
     environment:
       - DDEX_MONGODB_URL=mongodb://mongo:mongo@ddex-mongo:27017/ddex?authSource=admin&replicaSet=rs0
+    env_file: .env
     depends_on:
       ddex-mongo:
         condition: service_healthy

--- a/dev-tools/compose/docker-compose.ddex.yml
+++ b/dev-tools/compose/docker-compose.ddex.yml
@@ -1,25 +1,25 @@
 version: '3.9'
 
 services:
-  # ddex-web:
-  #   container_name: ddex-web
-  #   build:
-  #     context: ${PROJECT_ROOT}
-  #     dockerfile: ${PROJECT_ROOT}/packages/ddex/webapp/Dockerfile
-  #     args:
-  #       app_name: ddex-web
-  #       TURBO_TEAM: '${TURBO_TEAM}'
-  #       TURBO_TOKEN: '${TURBO_TOKEN}'
-  #   environment:
-  #     - DDEX_PORT=9000
-  #     - DDEX_MONGODB_URL=mongodb://mongo:mongo@ddex-mongo:27017/ddex?authSource=admin&replicaSet=rs0
-  #   env_file: .env
-  #   ports:
-  #     - "9000:9000"
-  #   networks:
-  #     - ddex-network
-  #   profiles:
-  #     - ddex
+  ddex-web:
+    container_name: ddex-web
+    build:
+      context: ${PROJECT_ROOT}
+      dockerfile: ${PROJECT_ROOT}/packages/ddex/webapp/Dockerfile
+      args:
+        app_name: ddex-web
+        TURBO_TEAM: '${TURBO_TEAM}'
+        TURBO_TOKEN: '${TURBO_TOKEN}'
+    environment:
+      - DDEX_PORT=9000
+      - DDEX_MONGODB_URL=mongodb://mongo:mongo@ddex-mongo:27017/ddex?authSource=admin&replicaSet=rs0
+    env_file: .env
+    ports:
+      - "9000:9000"
+    networks:
+      - ddex-network
+    profiles:
+      - ddex
 
   ddex-crawler:
     container_name: ddex-crawler

--- a/dev-tools/compose/docker-compose.ddex.yml
+++ b/dev-tools/compose/docker-compose.ddex.yml
@@ -1,25 +1,25 @@
 version: '3.9'
 
 services:
-  ddex-web:
-    container_name: ddex-web
-    build:
-      context: ${PROJECT_ROOT}
-      dockerfile: ${PROJECT_ROOT}/packages/ddex/webapp/Dockerfile
-      args:
-        app_name: ddex-web
-        TURBO_TEAM: '${TURBO_TEAM}'
-        TURBO_TOKEN: '${TURBO_TOKEN}'
-    environment:
-      - DDEX_PORT=9000
-      - DDEX_MONGODB_URL=mongodb://mongo:mongo@ddex-mongo:27017/ddex?authSource=admin&replicaSet=rs0
-    env_file: .env
-    ports:
-      - "9000:9000"
-    networks:
-      - ddex-network
-    profiles:
-      - ddex
+  # ddex-web:
+  #   container_name: ddex-web
+  #   build:
+  #     context: ${PROJECT_ROOT}
+  #     dockerfile: ${PROJECT_ROOT}/packages/ddex/webapp/Dockerfile
+  #     args:
+  #       app_name: ddex-web
+  #       TURBO_TEAM: '${TURBO_TEAM}'
+  #       TURBO_TOKEN: '${TURBO_TOKEN}'
+  #   environment:
+  #     - DDEX_PORT=9000
+  #     - DDEX_MONGODB_URL=mongodb://mongo:mongo@ddex-mongo:27017/ddex?authSource=admin&replicaSet=rs0
+  #   env_file: .env
+  #   ports:
+  #     - "9000:9000"
+  #   networks:
+  #     - ddex-network
+  #   profiles:
+  #     - ddex
 
   ddex-crawler:
     container_name: ddex-crawler

--- a/packages/ddex/README.md
+++ b/packages/ddex/README.md
@@ -14,7 +14,7 @@ To use dev envs: `cp .env.dev .env`
 
 Fill in all missing values. See the `Creating a bucket in S3` section below for how to set up S3.
 
-For docker compose to work: (At monorepo root) `cat packages/ddex/.env >> dev-tools/compose/.env`
+For docker compose to work: (at monorepo root) `cat packages/ddex/.env >> dev-tools/compose/.env`
 
 ### Setup
 1. (At the monorepo root) Generate a keyfile for mongodb:

--- a/packages/ddex/README.md
+++ b/packages/ddex/README.md
@@ -14,6 +14,8 @@ To use dev envs: `cp .env.dev .env`
 
 Fill in all missing values. See the `Creating a bucket in S3` section below for how to set up S3.
 
+For docker compose to work: (At monorepo root) `cat packages/ddex/.env >> dev-tools/compose/.env`
+
 ### Setup
 1. (At the monorepo root) Generate a keyfile for mongodb:
 ```

--- a/packages/ddex/ingester/common/types.go
+++ b/packages/ddex/ingester/common/types.go
@@ -10,6 +10,7 @@ type Upload struct {
 	ID         primitive.ObjectID `bson:"_id"`
 	UploadETag string             `bson:"upload_etag"`
 	Path       string             `bson:"path"`
+	CreatedAt  time.Time          `bson:"created_at"`
 }
 
 type Indexed struct {
@@ -19,6 +20,7 @@ type Indexed struct {
 	DeliveryStatus string             `bson:"delivery_status"`
 	XmlFilePath    string             `bson:"xml_file_path"`
 	XmlContent     primitive.Binary   `bson:"xml_content"`
+	CreatedAt      time.Time          `bson:"created_at"`
 }
 
 type Parsed struct {
@@ -27,6 +29,7 @@ type Parsed struct {
 	DeliveryID  string             `bson:"delivery_id"`
 	Entity      string             `bson:"entity"`
 	PublishDate time.Time          `bson:"publish_date"`
+	CreatedAt   time.Time          `bson:"created_at"`
 }
 
 type Published struct {
@@ -36,4 +39,5 @@ type Published struct {
 	Entity      string             `bson:"entity"`
 	PublishDate time.Time          `bson:"publish_date"`
 	EntityID    string             `bson:"entity_id"`
+	CreatedAt   time.Time          `bson:"created_at"`
 }

--- a/packages/ddex/ingester/common/types.go
+++ b/packages/ddex/ingester/common/types.go
@@ -1,0 +1,29 @@
+package common
+
+import (
+	"time"
+
+	"go.mongodb.org/mongo-driver/bson/primitive"
+)
+
+type Upload struct {
+	ID         primitive.ObjectID `bson:"_id"`
+	Path       string             `bson:"path"`
+	UploadETag string             `bson:"upload_etag"`
+}
+
+type Indexed struct {
+	ID          primitive.ObjectID `bson:"_id"`
+	DeliveryID  string             `bson:"delivery_id"`
+	UploadETag  string             `bson:"upload_etag"`
+	XmlFilePath string             `bson:"xml_file_path"`
+	XmlContent  primitive.Binary   `bson:"xml_content"`
+}
+
+type Parsed struct {
+	ID          primitive.ObjectID `bson:"_id"`
+	DeliveryID  string             `bson:"delivery_id"`
+	UploadETag  string             `bson:"upload_etag"`
+	Entity      string             `bson:"entity"`
+	PublishDate time.Time          `bson:"publish_date"`
+}

--- a/packages/ddex/ingester/common/types.go
+++ b/packages/ddex/ingester/common/types.go
@@ -8,22 +8,32 @@ import (
 
 type Upload struct {
 	ID         primitive.ObjectID `bson:"_id"`
-	Path       string             `bson:"path"`
 	UploadETag string             `bson:"upload_etag"`
+	Path       string             `bson:"path"`
 }
 
 type Indexed struct {
-	ID          primitive.ObjectID `bson:"_id"`
-	DeliveryID  string             `bson:"delivery_id"`
-	UploadETag  string             `bson:"upload_etag"`
-	XmlFilePath string             `bson:"xml_file_path"`
-	XmlContent  primitive.Binary   `bson:"xml_content"`
+	ID             primitive.ObjectID `bson:"_id"`
+	UploadETag     string             `bson:"upload_etag"`
+	DeliveryID     string             `bson:"delivery_id"`
+	DeliveryStatus string             `bson:"delivery_status"`
+	XmlFilePath    string             `bson:"xml_file_path"`
+	XmlContent     primitive.Binary   `bson:"xml_content"`
 }
 
 type Parsed struct {
 	ID          primitive.ObjectID `bson:"_id"`
-	DeliveryID  string             `bson:"delivery_id"`
 	UploadETag  string             `bson:"upload_etag"`
+	DeliveryID  string             `bson:"delivery_id"`
 	Entity      string             `bson:"entity"`
 	PublishDate time.Time          `bson:"publish_date"`
+}
+
+type Published struct {
+	ID          primitive.ObjectID `bson:"_id"`
+	UploadETag  string             `bson:"upload_etag"`
+	DeliveryID  string             `bson:"delivery_id"`
+	Entity      string             `bson:"entity"`
+	PublishDate time.Time          `bson:"publish_date"`
+	EntityID    string             `bson:"entity_id"`
 }

--- a/packages/ddex/ingester/constants/constants.go
+++ b/packages/ddex/ingester/constants/constants.go
@@ -5,4 +5,5 @@ const (
 	DeliveryStatusRejected           = "rejected"
 	DeliveryStatusValidating         = "validating"
 	DeliveryStatusAwaitingPublishing = "awaiting_publishing"
+	DeliveryStatusPublished          = "published"
 )

--- a/packages/ddex/ingester/crawler/crawler.go
+++ b/packages/ddex/ingester/crawler/crawler.go
@@ -20,8 +20,7 @@ func Run(ctx context.Context) {
 	defer mongoClient.Disconnect(ctx)
 
 	bucketName := common.MustGetenv("AWS_BUCKET_RAW")
-	// ticker := time.NewTicker(3 * time.Minute)
-	ticker := time.NewTicker(3 * time.Second)
+	ticker := time.NewTicker(3 * time.Minute)
 	defer ticker.Stop()
 
 	for {

--- a/packages/ddex/ingester/crawler/crawler.go
+++ b/packages/ddex/ingester/crawler/crawler.go
@@ -20,7 +20,8 @@ func Run(ctx context.Context) {
 	defer mongoClient.Disconnect(ctx)
 
 	bucketName := common.MustGetenv("AWS_BUCKET_RAW")
-	ticker := time.NewTicker(3 * time.Minute)
+	// ticker := time.NewTicker(3 * time.Minute)
+	ticker := time.NewTicker(3 * time.Second)
 	defer ticker.Stop()
 
 	for {

--- a/packages/ddex/ingester/crawler/crawler.go
+++ b/packages/ddex/ingester/crawler/crawler.go
@@ -117,7 +117,7 @@ func persistUploads(client *mongo.Client, bucket string, uploads []*s3.Object, c
 		etag := strings.Trim(*upload.ETag, "\"")
 		// Only insert if a document doesn't already exist with this path and etag
 		filter := bson.M{"path": path, "upload_etag": etag}
-		update := bson.M{"$setOnInsert": bson.M{"path": path, "upload_etag": etag}}
+		update := bson.M{"$setOnInsert": bson.M{"path": path, "upload_etag": etag, "created_at": upload.LastModified}}
 		opts := options.Update().SetUpsert(true)
 		_, err := uploadsColl.UpdateOne(ctx, filter, update, opts)
 		if err != nil {

--- a/packages/ddex/ingester/indexer/indexer.go
+++ b/packages/ddex/ingester/indexer/indexer.go
@@ -12,6 +12,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/s3"
@@ -176,6 +177,7 @@ func (i *Indexer) processDelivery(rootDir, dir, uploadETag string) error {
 		"delivery_status": constants.DeliveryStatusValidating,
 		"xml_file_path":   xmlRelativePath,
 		"xml_content":     primitive.Binary{Data: xmlBytes, Subtype: 0x00}, // Store directly as generic binary for high data integrity
+		"created_at":      time.Now(),
 	}
 	if _, err := i.indexedColl.InsertOne(i.ctx, deliveryDoc); err != nil {
 		return fmt.Errorf("failed to insert XML data into Mongo: %w", err)

--- a/packages/ddex/ingester/indexer/indexer.go
+++ b/packages/ddex/ingester/indexer/indexer.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"fmt"
 	"ingester/common"
+	"ingester/constants"
 	"io"
 	"log"
 	"log/slog"
@@ -170,10 +171,11 @@ func (i *Indexer) processDelivery(rootDir, dir, uploadETag string) error {
 
 	// Insert the delivery into the Mongo "indexed" collection
 	deliveryDoc := bson.M{
-		"delivery_id":   deliveryID,
-		"upload_etag":   uploadETag,
-		"xml_file_path": xmlRelativePath,
-		"xml_content":   primitive.Binary{Data: xmlBytes, Subtype: 0x00}, // Store directly as generic binary for high data integrity
+		"upload_etag":     uploadETag,
+		"delivery_id":     deliveryID,
+		"delivery_status": constants.DeliveryStatusValidating,
+		"xml_file_path":   xmlRelativePath,
+		"xml_content":     primitive.Binary{Data: xmlBytes, Subtype: 0x00}, // Store directly as generic binary for high data integrity
 	}
 	if _, err := i.indexedColl.InsertOne(i.ctx, deliveryDoc); err != nil {
 		return fmt.Errorf("failed to insert XML data into Mongo: %w", err)

--- a/packages/ddex/ingester/parser/parser.go
+++ b/packages/ddex/ingester/parser/parser.go
@@ -63,6 +63,7 @@ func parseIndexed(client *mongo.Client, indexed common.Indexed, ctx context.Cont
 			"delivery_id":  indexed.DeliveryID,
 			"entity":       "track",
 			"publish_date": time.Now(),
+			"created_at":   time.Now(),
 		}
 		result, err := parsedColl.InsertOne(ctx, parsedDoc)
 		if err != nil {

--- a/packages/ddex/ingester/parser/parser.go
+++ b/packages/ddex/ingester/parser/parser.go
@@ -26,12 +26,13 @@ func Run(ctx context.Context) {
 	defer changeStream.Close(ctx)
 
 	for changeStream.Next(ctx) {
-		var changeDoc bson.M
+		var changeDoc struct {
+			FullDocument common.Indexed `bson:"fullDocument"`
+		}
 		if err := changeStream.Decode(&changeDoc); err != nil {
 			log.Fatal(err)
 		}
-		fullDocument, _ := changeDoc["fullDocument"].(bson.M)
-		parseIndexed(mongoClient, fullDocument, ctx)
+		parseIndexed(mongoClient, changeDoc.FullDocument, ctx)
 	}
 
 	if err := changeStream.Err(); err != nil {
@@ -39,8 +40,8 @@ func Run(ctx context.Context) {
 	}
 }
 
-func parseIndexed(client *mongo.Client, fullDocument bson.M, ctx context.Context) {
-	log.Printf("Processing new indexed document: %v\n", fullDocument)
+func parseIndexed(client *mongo.Client, indexed common.Indexed, ctx context.Context) {
+	log.Printf("Processing new indexed document: %v\n", indexed)
 	indexedColl := client.Database("ddex").Collection("indexed")
 	parsedColl := client.Database("ddex").Collection("parsed")
 
@@ -49,7 +50,7 @@ func parseIndexed(client *mongo.Client, fullDocument bson.M, ctx context.Context
 
 	session, err := client.StartSession()
 	if err != nil {
-		failAndUpdateStatus(err, indexedColl, ctx, fullDocument["_id"].(primitive.ObjectID))
+		failAndUpdateStatus(err, indexedColl, ctx, indexed.ID)
 	}
 	err = mongo.WithSession(ctx, session, func(sessionContext mongo.SessionContext) error {
 		if err := session.StartTransaction(); err != nil {
@@ -58,8 +59,8 @@ func parseIndexed(client *mongo.Client, fullDocument bson.M, ctx context.Context
 
 		// 2. Write each release in "delivery_xml" in the indexed doc as a bson doc in the 'parsed' collection
 		parsedDoc := bson.M{
-			"upload_etag":  fullDocument["upload_etag"],
-			"delivery_id":  fullDocument["delivery_id"],
+			"upload_etag":  indexed.UploadETag,
+			"delivery_id":  indexed.DeliveryID,
 			"entity":       "track",
 			"publish_date": time.Now(),
 		}
@@ -71,7 +72,7 @@ func parseIndexed(client *mongo.Client, fullDocument bson.M, ctx context.Context
 		log.Println("New parsed release doc ID: ", result.InsertedID)
 
 		// 3. Set delivery status for delivery in 'indexed' collection
-		err = setDeliveryStatus(indexedColl, sessionContext, fullDocument["_id"].(primitive.ObjectID), constants.DeliveryStatusAwaitingPublishing)
+		err = setDeliveryStatus(indexedColl, sessionContext, indexed.ID, constants.DeliveryStatusAwaitingPublishing)
 		if err != nil {
 			session.AbortTransaction(sessionContext)
 			return err
@@ -81,7 +82,7 @@ func parseIndexed(client *mongo.Client, fullDocument bson.M, ctx context.Context
 	})
 
 	if err != nil {
-		failAndUpdateStatus(err, indexedColl, ctx, fullDocument["_id"].(primitive.ObjectID))
+		failAndUpdateStatus(err, indexedColl, ctx, indexed.ID)
 	}
 
 	session.EndSession(ctx)

--- a/packages/ddex/publisher/src/index.ts
+++ b/packages/ddex/publisher/src/index.ts
@@ -2,7 +2,7 @@ import dotenv from 'dotenv'
 import path from 'path'
 
 // Load env vars from ddex package root
-dotenv.config({ path: path.join(__dirname, '..', '..', '..', '.env') })
+dotenv.config({ path: path.join(__dirname, '..', '..', '.env') })
 
 import createApp from './app'
 import { dialDb } from './services/dbService'

--- a/packages/ddex/publisher/src/models/indexed.ts
+++ b/packages/ddex/publisher/src/models/indexed.ts
@@ -1,0 +1,15 @@
+import mongoose from 'mongoose'
+
+// DDEX deliveries indexed from DDEX uploads
+const indexedSchema = new mongoose.Schema({
+  id: mongoose.Schema.Types.ObjectId,
+  upload_etag: String,
+  delivery_id: String,
+  delivery_status: String,
+  xml_file_path: String,
+  xml_content: Buffer,
+})
+
+const Indexed = mongoose.model('Indexed', indexedSchema, 'Indexed')
+
+export default Indexed

--- a/packages/ddex/publisher/src/models/indexed.ts
+++ b/packages/ddex/publisher/src/models/indexed.ts
@@ -8,8 +8,9 @@ const indexedSchema = new mongoose.Schema({
   delivery_status: String,
   xml_file_path: String,
   xml_content: Buffer,
+  created_at: Date,
 })
 
-const Indexed = mongoose.model('Indexed', indexedSchema, 'Indexed')
+const Indexed = mongoose.model('Indexed', indexedSchema, 'indexed')
 
 export default Indexed

--- a/packages/ddex/publisher/src/models/parsed.ts
+++ b/packages/ddex/publisher/src/models/parsed.ts
@@ -2,6 +2,8 @@ import mongoose from 'mongoose'
 
 // Releases that parsed from indexed DDEX deliveries, awaiting publishing
 const parsedSchema = new mongoose.Schema({
+  id: mongoose.Schema.Types.ObjectId,
+  upload_etag: String,
   delivery_id: String,
   entity: String,
   publish_date: Date,

--- a/packages/ddex/publisher/src/models/parsed.ts
+++ b/packages/ddex/publisher/src/models/parsed.ts
@@ -7,6 +7,7 @@ const parsedSchema = new mongoose.Schema({
   delivery_id: String,
   entity: String,
   publish_date: Date,
+  created_at: Date,
 })
 
 const Parsed = mongoose.model('Parsed', parsedSchema, 'parsed')

--- a/packages/ddex/publisher/src/models/published.ts
+++ b/packages/ddex/publisher/src/models/published.ts
@@ -8,6 +8,7 @@ const publishedSchema = new mongoose.Schema({
   entity: String,
   publish_date: Date,
   entity_id: String,
+  created_at: Date,
 })
 
 const Published = mongoose.model('Published', publishedSchema, 'published')

--- a/packages/ddex/publisher/src/models/published.ts
+++ b/packages/ddex/publisher/src/models/published.ts
@@ -2,10 +2,12 @@ import mongoose from 'mongoose'
 
 // DDEX releases that have been published
 const publishedSchema = new mongoose.Schema({
+  id: mongoose.Schema.Types.ObjectId,
+  upload_etag: String,
   delivery_id: String,
   entity: String,
   publish_date: Date,
-  track_id: String,
+  entity_id: String,
 })
 
 const Published = mongoose.model('Published', publishedSchema, 'published')

--- a/packages/ddex/publisher/src/services/publisherService.ts
+++ b/packages/ddex/publisher/src/services/publisherService.ts
@@ -24,6 +24,7 @@ export const publishReleases = async () => {
         const publishedData = {
           ...doc.toObject(),
           entity_id: 'todo',
+          created_at: new Date(),
         }
         const publishedDoc = new Published(publishedData)
         await publishedDoc.save({ session })

--- a/packages/ddex/publisher/src/services/publisherService.ts
+++ b/packages/ddex/publisher/src/services/publisherService.ts
@@ -1,4 +1,5 @@
 import mongoose from 'mongoose'
+import Indexed from '../models/indexed'
 import Parsed from '../models/parsed'
 import Published from '../models/published'
 
@@ -16,17 +17,31 @@ export const publishReleases = async () => {
       }).session(session)
 
       for (const doc of documents) {
+        // TODO download audio/image files from "indexed" s3 bucket
         // TODO publish release using SDK
 
         // Move document to 'published' collection
         const publishedData = {
           ...doc.toObject(),
-          track_id: 'todo',
+          entity_id: 'todo',
         }
         const publishedDoc = new Published(publishedData)
         await publishedDoc.save({ session })
         await Parsed.deleteOne({ _id: doc._id }).session(session)
-        // TODO update indexed delivery_status to 'published'
+        // Update delivery_status to 'published' once all releases in the delivery are published
+        const remainingCount = await Parsed.countDocuments({
+          delivery_id: doc.delivery_id,
+          _id: { $ne: doc._id },
+        }).session(session)
+
+        if (remainingCount === 0) {
+          // Update delivery_status in indexed collection
+          await Indexed.updateOne(
+            { delivery_id: doc.delivery_id },
+            { $set: { delivery_status: 'published' } },
+            { session }
+          )
+        }
         console.log('Published release: ', publishedData)
       }
 

--- a/packages/ddex/webapp/client/src/components/Collection/Collection.module.css
+++ b/packages/ddex/webapp/client/src/components/Collection/Collection.module.css
@@ -23,7 +23,6 @@
 }
 
 .styledTable tbody tr:nth-of-type(even) {
-  /* background-color: #f3f3f3; */
   background-color: var(--harmony-background);
 }
 
@@ -31,8 +30,14 @@
   border-bottom: 2px solid var(--harmony-secondary);
 }
 
-.styledTable tbody tr.activeRow {
-  font-weight: bold;
-  color: var(--harmony-secondary);
+.styledTable tbody td.statusFailed {
+  background-color: #ffccbc;
 }
 
+.styledTable tbody td.statusPending {
+  background-color: #fff59d;
+}
+
+.styledTable tbody td.statusSuccess {
+  background-color: #c8e6c9;
+}

--- a/packages/ddex/webapp/client/src/components/Collection/Collection.tsx
+++ b/packages/ddex/webapp/client/src/components/Collection/Collection.tsx
@@ -33,28 +33,48 @@ export const Collection = ({ collection }: { collection: CollectionT }) => {
   let data: any, error, isLoading
   switch (collection) {
     case 'uploads':
-      ;({ data, error, isLoading } = trpc.uploads.listCollection.useQuery({
-        nextId,
-        prevId
-      }))
+      ;({ data, error, isLoading } = trpc.uploads.listCollection.useQuery(
+        {
+          nextId,
+          prevId
+        },
+        {
+          refetchInterval: 10000 // Refetch every 10000 milliseconds (10 seconds)
+        }
+      ))
       break
     case 'indexed':
-      ;({ data, error, isLoading } = trpc.indexed.listCollection.useQuery({
-        nextId,
-        prevId
-      }))
+      ;({ data, error, isLoading } = trpc.indexed.listCollection.useQuery(
+        {
+          nextId,
+          prevId
+        },
+        {
+          refetchInterval: 10000 // Refetch every 10000 milliseconds (10 seconds)
+        }
+      ))
       break
     case 'parsed':
-      ;({ data, error, isLoading } = trpc.parsed.listCollection.useQuery({
-        nextId,
-        prevId
-      }))
+      ;({ data, error, isLoading } = trpc.parsed.listCollection.useQuery(
+        {
+          nextId,
+          prevId
+        },
+        {
+          refetchInterval: 10000 // Refetch every 10000 milliseconds (10 seconds)
+        }
+      ))
       break
     case 'published':
-      ;({ data, error, isLoading } = trpc.published.listCollection.useQuery({
-        nextId,
-        prevId
-      }))
+      ;({ data, error, isLoading } = trpc.published.listCollection.useQuery(
+        {
+          nextId,
+          prevId
+        },
+        {
+          refetchInterval: 10000 // Refetch every 10000 milliseconds (10 seconds)
+        }
+      ))
       break
   }
 

--- a/packages/ddex/webapp/client/src/components/Collection/Collection.tsx
+++ b/packages/ddex/webapp/client/src/components/Collection/Collection.tsx
@@ -226,7 +226,7 @@ export const Collection = ({ collection }: { collection: CollectionT }) => {
           Text div after harmony fixes font styling */}
         <Text variant='body' color='default'>
           {isLoading && <div>Loading...</div>}
-          {error && <div>Error: {(error as Error).message}</div>}
+          {error && <div>Error: {error.message}</div>}
           {data && <Table collection={collection} data={data} />}
 
           <Flex justifyContent='space-between'>

--- a/packages/ddex/webapp/client/src/components/Collection/Collection.tsx
+++ b/packages/ddex/webapp/client/src/components/Collection/Collection.tsx
@@ -8,23 +8,136 @@ import styles from './Collection.module.css'
 
 type CollectionT = 'uploads' | 'indexed' | 'parsed' | 'published'
 
-const Table = ({ data }: { data: any }) => {
-  return (
-    <table className={styles.styledTable}>
-      <thead>
-        <tr>
-          <th>Items</th>
-        </tr>
-      </thead>
-      <tbody>
-        {data.items.map((item: any) => (
-          <tr key={item._id}>
-            <td>{JSON.stringify(item)}</td>
-          </tr>
-        ))}
-      </tbody>
-    </table>
-  )
+const Table = ({
+  collection,
+  data
+}: {
+  collection: CollectionT
+  data: any
+}) => {
+  const statusStyle = (deliveryStatus: string) => {
+    if (deliveryStatus === 'published') {
+      return styles.statusSuccess
+    } else if (
+      deliveryStatus === 'validating' ||
+      deliveryStatus === 'awaiting_publishing'
+    ) {
+      return styles.statusPending
+    } else if (deliveryStatus === 'error' || deliveryStatus === 'rejected') {
+      return styles.statusFailed
+    }
+  }
+
+  switch (collection) {
+    case 'uploads':
+      return (
+        <table className={styles.styledTable}>
+          <thead>
+            <tr>
+              <th>ID</th>
+              <th>Path</th>
+              <th>E-tag</th>
+              <th>Created At</th>
+            </tr>
+          </thead>
+          <tbody>
+            {data.items.map((item: any) => (
+              <tr key={item._id}>
+                <td>{item._id}</td>
+                <td>{item.path}</td>
+                <td>{item.upload_etag}</td>
+                <td>{item.created_at}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      )
+    case 'indexed':
+      return (
+        <table className={styles.styledTable}>
+          <thead>
+            <tr>
+              <th>ID</th>
+              <th>Upload E-tag</th>
+              <th>Delivery ID</th>
+              <th>Delivery Status</th>
+              <th>XML Filepath</th>
+              <th>Created At</th>
+            </tr>
+          </thead>
+          <tbody>
+            {data.items.map((item: any) => (
+              <tr key={item._id}>
+                <td>{item._id}</td>
+                <td>{item.upload_etag}</td>
+                <td>{item.delivery_id}</td>
+                <td className={statusStyle(item.delivery_status)}>
+                  {item.delivery_status}
+                </td>
+                <td>{item.xml_file_path}</td>
+                <td>{item.created_at}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      )
+    case 'parsed':
+      return (
+        <table className={styles.styledTable}>
+          <thead>
+            <tr>
+              <th>ID</th>
+              <th>Upload E-tag</th>
+              <th>Delivery ID</th>
+              <th>Entity</th>
+              <th>Publish Date</th>
+              <th>Created At</th>
+            </tr>
+          </thead>
+          <tbody>
+            {data.items.map((item: any) => (
+              <tr key={item._id}>
+                <td>{item._id}</td>
+                <td>{item.upload_etag}</td>
+                <td>{item.delivery_id}</td>
+                <td>{item.entity}</td>
+                <td>{item.publish_date}</td>
+                <td>{item.created_at}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      )
+    case 'published':
+      return (
+        <table className={styles.styledTable}>
+          <thead>
+            <tr>
+              <th>ID</th>
+              <th>Upload E-tag</th>
+              <th>Delivery ID</th>
+              <th>Entity</th>
+              <th>Publish Date</th>
+              <th>Entity ID</th>
+              <th>Created At</th>
+            </tr>
+          </thead>
+          <tbody>
+            {data.items.map((item: any) => (
+              <tr key={item.id}>
+                <td>{item._id}</td>
+                <td>{item.upload_etag}</td>
+                <td>{item.delivery_id}</td>
+                <td>{item.entity}</td>
+                <td>{item.publish_date}</td>
+                <td>{item.entity_id}</td>
+                <td>{item.created_at}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      )
+  }
 }
 
 export const Collection = ({ collection }: { collection: CollectionT }) => {
@@ -80,14 +193,14 @@ export const Collection = ({ collection }: { collection: CollectionT }) => {
 
   const handleNext = () => {
     if (data?.hasMoreNext) {
-      setNextId(data.items[0].id)
+      setNextId(data.items[data.items.length - 1]._id)
       setPrevId(undefined)
     }
   }
 
   const handlePrev = () => {
     if (data?.hasMorePrev) {
-      setPrevId(data.items[data.items.length - 1].id)
+      setPrevId(data.items[0]._id)
       setNextId(undefined)
     }
   }
@@ -103,7 +216,7 @@ export const Collection = ({ collection }: { collection: CollectionT }) => {
         <Text variant='body' color='default'>
           {isLoading && <div>Loading...</div>}
           {error && <div>Error: {error.message}</div>}
-          {data && <Table data={data} />}
+          {data && <Table collection={collection} data={data} />}
 
           <Flex justifyContent='space-between'>
             <Button

--- a/packages/ddex/webapp/client/src/pages/Upload/Upload.tsx
+++ b/packages/ddex/webapp/client/src/pages/Upload/Upload.tsx
@@ -217,7 +217,8 @@ const ZipImporter = ({
               )}
               {uploadSucceeded && (
                 <Text variant='body' className={styles.successText}>
-                  Upload success!
+                  Your files have been uploaded to S3 and will be processed
+                  soon.
                 </Text>
               )}
             </>

--- a/packages/ddex/webapp/server/src/controllers/collectionController.ts
+++ b/packages/ddex/webapp/server/src/controllers/collectionController.ts
@@ -22,11 +22,11 @@ export const getCollection = (collection: string) => {
       let flipResults = false
 
       if (nextId) {
-        query = { _id: { $gt: new mongoose.Types.ObjectId(nextId as string) } } // IDs greater than nextId
+        query = { _id: { $lt: new mongoose.Types.ObjectId(nextId as string) } } // IDs less than nextId
+      } else if (prevId) {
+        query = { _id: { $gt: new mongoose.Types.ObjectId(prevId as string) } } // IDs greater than prevId
         sort = { _id: 1 } // Ascending
         flipResults = true
-      } else if (prevId) {
-        query = { _id: { $lt: new mongoose.Types.ObjectId(prevId as string) } } // IDs less than prevId
       }
 
       const items = await mongoose.connection.db
@@ -37,7 +37,7 @@ export const getCollection = (collection: string) => {
         .toArray()
 
       if (flipResults) {
-        items.reverse() // Reverse items to desc order when nextId is used
+        items.reverse() // Reverse items to desc order when prevId is used
       }
 
       res.json(items)

--- a/packages/ddex/webapp/server/src/controllers/collectionController.ts
+++ b/packages/ddex/webapp/server/src/controllers/collectionController.ts
@@ -18,15 +18,15 @@ export const getCollection = (collection: string) => {
       }
 
       let query: Record<string, any> = {} // No pagination, fetch the first `limit` items
-      let sort: Sort = { _id: 1 } // Ascending
+      let sort: Sort = { _id: -1 } // Descending
       let flipResults = false
 
       if (nextId) {
         query = { _id: { $gt: new mongoose.Types.ObjectId(nextId as string) } } // IDs greater than nextId
+        sort = { _id: 1 } // Ascending
+        flipResults = true
       } else if (prevId) {
         query = { _id: { $lt: new mongoose.Types.ObjectId(prevId as string) } } // IDs less than prevId
-        sort = { _id: -1 } // Descending
-        flipResults = true
       }
 
       const items = await mongoose.connection.db
@@ -37,7 +37,7 @@ export const getCollection = (collection: string) => {
         .toArray()
 
       if (flipResults) {
-        items.reverse() // Reverse items to main correct asc order when prevId is used
+        items.reverse() // Reverse items to desc order when nextId is used
       }
 
       res.json(items)

--- a/packages/ddex/webapp/server/src/routers/collectionRouters.ts
+++ b/packages/ddex/webapp/server/src/routers/collectionRouters.ts
@@ -24,15 +24,15 @@ const createCollectionRouter = (collection: string) => {
         }
 
         let query: Record<string, any> = {} // No pagination, fetch the first `limit` items
-        let sort: Sort = { _id: 1 } // Ascending
+        let sort: Sort = { _id: -1 } // Descending
         let flipResults = false
 
         if (nextId) {
           query = { _id: { $gt: new mongoose.Types.ObjectId(nextId) } } // IDs greater than nextId
+          sort = { _id: 1 } // Ascending
+          flipResults = true
         } else if (prevId) {
           query = { _id: { $lt: new mongoose.Types.ObjectId(prevId) } } // IDs less than prevId
-          sort = { _id: -1 } // Descending
-          flipResults = true
         }
 
         const items = await mongoose.connection.db
@@ -55,7 +55,7 @@ const createCollectionRouter = (collection: string) => {
         }
 
         if (flipResults) {
-          items.reverse() // Reverse items to main correct asc order when prevId is used
+          items.reverse() // Reverse items to desc order when nextId is used
         }
 
         const firstItemId = items.length > 0 ? items[0]._id : null


### PR DESCRIPTION
### Description
- Organize tables in UI
- Fix UI sort + pagination
- UI polls collections for updates
- Added collection models for readability in ddex ingester + publisher
- Publisher sets delivery status to "published" once all releases in delivery have been published
- Docker compose reads env from directory-level .env (I think this won't break CI... I see this in some other compose ymls)

TODO in follow up PR(s)
- Publisher connects to s3 and downloads image and audio files. Mock out actual sdk upload step
- Change collection names: indexed -> deliveries, parsed -> pending_releases, published -> published_releases

### How Has This Been Tested?
Tested locally
<img width="1728" alt="image" src="https://github.com/AudiusProject/audius-protocol/assets/25782182/f0267993-d9ff-454e-9597-9d0a6be69f65">
<img width="1728" alt="image" src="https://github.com/AudiusProject/audius-protocol/assets/25782182/30128710-19fe-4db9-aafb-e8d77615c1f1">
<img width="1728" alt="image" src="https://github.com/AudiusProject/audius-protocol/assets/25782182/dcdc09d8-96fd-408a-ae55-e152a13cb306">
