### PR TITLE
[PAY-2423] Render download options in equal-sized tabs

### DIFF
--- a/packages/harmony/src/components/segmented-control/SegmentedControl.mdx
+++ b/packages/harmony/src/components/segmented-control/SegmentedControl.mdx
@@ -36,6 +36,10 @@ import * as SegmentedControlStories from './SegmentedControl.stories'
 
 <Canvas of={SegmentedControlStories.FullWidth} />
 
+### Equal Width
+
+<Canvas of={SegmentedControlStories.EqualWidth} />
+
 ### Mobile
 
 <Canvas of={SegmentedControlStories.IsMobile} />

--- a/packages/harmony/src/components/segmented-control/SegmentedControl.module.css
+++ b/packages/harmony/src/components/segmented-control/SegmentedControl.module.css
@@ -7,12 +7,15 @@
   justify-content: space-between;
   align-items: center;
   padding: 3px;
+  /* This gives us a gap of --harmony-spacing-s (8px) between tabs, accounting
+  for the separators being siblings of the tabs and occupying 1px of width */
+  gap: 3.5px;
 }
 
 .tab {
   z-index: 3;
   flex: 1 1 auto;
-  padding: var(--harmony-unit-2);
+  padding: var(--harmony-unit-2) var(--harmony-unit-4);
   border-radius: 4px;
   cursor: pointer;
   user-select: none;

--- a/packages/harmony/src/components/segmented-control/SegmentedControl.stories.tsx
+++ b/packages/harmony/src/components/segmented-control/SegmentedControl.stories.tsx
@@ -42,6 +42,10 @@ export const FullWidth: Story = {
   render: (props) => <SegmentedControl {...props} fullWidth />
 }
 
+export const EqualWidth: Story = {
+  render: (props) => <SegmentedControl {...props} equalWidth />
+}
+
 export const IsMobile: Story = {
   render: (props) => <SegmentedControl {...props} isMobile />
 }

--- a/packages/harmony/src/components/segmented-control/SegmentedControl.tsx
+++ b/packages/harmony/src/components/segmented-control/SegmentedControl.tsx
@@ -125,17 +125,19 @@ export const SegmentedControl = <T extends string>(
               />
               {option.text}
             </label>
-            <div
-              className={cn(styles.separator, {
-                [styles.invisible]:
-                  // Hide separator right of the selected option
-                  selectedOption === option.key ||
-                  // Hide separator right of the last option
-                  idx === props.options.length - 1 ||
-                  // Hide separator right of an option if the next one is selected
-                  selectedOption === props.options[idx + 1].key
-              })}
-            />
+            {idx !== props.options.length - 1 ? (
+              <div
+                className={cn(styles.separator, {
+                  [styles.invisible]:
+                    // Hide separator right of the selected option
+                    selectedOption === option.key ||
+                    // Hide separator right of the last option
+                    idx === props.options.length - 1 ||
+                    // Hide separator right of an option if the next one is selected
+                    selectedOption === props.options[idx + 1].key
+                })}
+              />
+            ) : null}
           </Fragment>
         )
       })}

--- a/packages/harmony/src/components/segmented-control/SegmentedControl.tsx
+++ b/packages/harmony/src/components/segmented-control/SegmentedControl.tsx
@@ -21,6 +21,7 @@ export const SegmentedControl = <T extends string>(
     props.options.map((_) => createRef<HTMLLabelElement>())
   )
   const [selected, setSelected] = useState(props.options[0].key)
+  const [maxOptionWidth, setMaxOptionWidth] = useState(0)
 
   const selectedOption = props.selected || selected
 
@@ -33,6 +34,15 @@ export const SegmentedControl = <T extends string>(
   const [tabProps, tabApi] = useSpring(() => ({
     to: { left: '0px', width: '0px' }
   }))
+
+  useEffect(() => {
+    setMaxOptionWidth(
+      optionRefs.current.reduce((currentMax, ref) => {
+        const rect = ref.current?.getBoundingClientRect()
+        return Math.max(rect?.width ?? 0, currentMax)
+      }, 0)
+    )
+  }, [])
 
   // Watch for resizes and repositions so that we move and resize the slider appropriately
   const [selectedRef, bounds] = useMeasure({
@@ -63,6 +73,7 @@ export const SegmentedControl = <T extends string>(
     })
   }, [
     props.options,
+    props.equalWidth,
     selectedOption,
     props.selected,
     tabApi,
@@ -97,6 +108,11 @@ export const SegmentedControl = <T extends string>(
                 [styles.tabFullWidth]: !!props.fullWidth,
                 [styles.isMobile]: props.isMobile
               })}
+              style={
+                props.equalWidth && maxOptionWidth
+                  ? { width: `${maxOptionWidth}px` }
+                  : undefined
+              }
             >
               {option.icon}
               <input

--- a/packages/harmony/src/components/segmented-control/types.ts
+++ b/packages/harmony/src/components/segmented-control/types.ts
@@ -14,7 +14,16 @@ export type SegmentedControlProps<T extends string> = {
   // Called on select option
   onSelectOption: (key: T) => void
 
+  /**
+   * Causes the control to take up the full width of the parent. Incompatible
+   * with `equalWidth`  */
   fullWidth?: boolean
+
+  /**
+   * Causes all tabs to be rendered at an equal width based on the largest natural
+   * content width. Incompatible with `fullWidth`
+   */
+  equalWidth?: boolean
 
   disabled?: boolean
 

--- a/packages/mobile/src/components/core/SegmentedControl.tsx
+++ b/packages/mobile/src/components/core/SegmentedControl.tsx
@@ -58,8 +58,7 @@ const useStyles = makeStyles(({ palette, typography, spacing }) => ({
     backgroundColor: palette.neutralLight7,
     flexDirection: 'row',
     alignItems: 'center',
-    padding: offset,
-    paddingRight: 0
+    padding: offset
   },
   tab: {
     paddingVertical: spacing(2),
@@ -224,12 +223,14 @@ export const SegmentedControl = <Value,>(
                 {option.text}
               </Text>
             </Pressable>
-            <View
-              style={[
-                styles.separator,
-                shouldHideSeparator && styles.hideSeparator
-              ]}
-            />
+            {index !== options.length - 1 ? (
+              <View
+                style={[
+                  styles.separator,
+                  shouldHideSeparator && styles.hideSeparator
+                ]}
+              />
+            ) : null}
           </Fragment>
         )
       })}

--- a/packages/mobile/src/components/core/SegmentedControl.tsx
+++ b/packages/mobile/src/components/core/SegmentedControl.tsx
@@ -28,6 +28,9 @@ export type SegmentedControlProps<Value> = {
   // Callback fired when new option is selected
   onSelectOption: (key: Value) => void
 
+  // If true, all tabs will have the same width
+  equalWidth?: boolean
+
   fullWidth?: boolean
 } & StylesProps<{
   root: ViewStyle
@@ -108,11 +111,13 @@ export const SegmentedControl = <Value,>(
     defaultSelected = options[0].key,
     onSelectOption,
     fullWidth,
+    equalWidth,
     style,
     styles: stylesProp
   } = props
   const styles = useStyles()
   const [optionWidths, setOptionWidths] = useState(options.map(() => 0))
+  const [maxOptionWidth, setMaxOptionWidth] = useState(0)
   const [initLeft, setInitLeft] = useState(false)
   const leftAnim = useRef(new Animated.Value(0)).current
   const widthAnim = useRef(new Animated.Value(0)).current
@@ -149,6 +154,7 @@ export const SegmentedControl = <Value,>(
   useEffect(() => {
     if (!initLeft && optionWidths.every((val) => val !== 0)) {
       leftAnim.setValue(getLeftValue())
+      setMaxOptionWidth(optionWidths.reduce((a, b) => Math.max(a, b), 0))
       setInitLeft(true)
     }
   }, [optionWidths, initLeft, options, leftAnim, selectedOption, getLeftValue])
@@ -203,7 +209,8 @@ export const SegmentedControl = <Value,>(
               style={[
                 styles.tab,
                 stylesProp?.tab,
-                fullWidth && styles.tabFullWidth
+                fullWidth && styles.tabFullWidth,
+                equalWidth && maxOptionWidth > 0 && { width: maxOptionWidth }
               ]}
               onPress={() => handleSelectOption(option.key)}
             >

--- a/packages/mobile/src/screens/track-screen/DownloadSection.tsx
+++ b/packages/mobile/src/screens/track-screen/DownloadSection.tsx
@@ -221,6 +221,7 @@ export const DownloadSection = ({ trackId }: { trackId: ID }) => {
               options={options}
               selected={quality}
               onSelectOption={(quality) => setQuality(quality)}
+              equalWidth
             />
           </Flex>
         ) : null}

--- a/packages/web/src/components/track/DownloadSection.tsx
+++ b/packages/web/src/components/track/DownloadSection.tsx
@@ -263,6 +263,7 @@ export const DownloadSection = ({ trackId }: DownloadSectionProps) => {
                     onSelectOption={(quality: DownloadQuality) =>
                       setQuality(quality)
                     }
+                    equalWidth
                   />
                 </Flex>
                 {shouldDisplayDownloadAll ? downloadAllButton() : null}


### PR DESCRIPTION
### Description
This adds optional behavior to SegmentedControl to force the tabs to be equal width. This is accomplished by measuring the tabs on first layout via the existing refs, storing the max width, and then setting all the tabs to use that width. We then use this new behavior in the `DownloadSection` to make the quality options the same size.

Some notes:
* The migrated SegmentedControl in Harmony doesn't _quite_ implement the standard yet. I updated it a little bit to get closer, but didn't want to change too much at the risk of breaking layout in all places that use it
* The mobile version doesn't use the correct gap. This is harder to fix due to the way we animate the background between items. I've decided to leave it for now
* Due to the way the width is calculated and set, using this will cause the tabs to no longer _shrink_ in small widths. This is a byproduct of how the width is computed originally. It includes the padding of each item. So we can't, for instance, set `flexBasis` to this value, as that's supposed to be the _content_ width. We could do some magic later on with using the padding/border in calculations and/or rendering the content separately with no padding or borders. But this feels sufficient for now.
* The existing control always rendered a separator after the last element and then just hid it. This produces incorrect layout when we use gap. I updated the logic to skip rendering the separator after the last element. And this involved removing a padding override on mobile that tries to account for it.

fixes PAY-2423

### How Has This Been Tested?
Tested locally in web and simulator against staging.

### Screenshots

**Web**
Before
![image](https://github.com/AudiusProject/audius-protocol/assets/1815175/4ae217fa-5cf2-456f-9275-11fe43d62eff)

After
![image](https://github.com/AudiusProject/audius-protocol/assets/1815175/3dc8be62-b1c1-48ae-9283-6d3637912d53)


**Mobile**
Before
![image](https://github.com/AudiusProject/audius-protocol/assets/1815175/b2e78247-a5e8-4ef5-939b-62160600fb55)

After 
![image](https://github.com/AudiusProject/audius-protocol/assets/1815175/8f7b289d-2a5f-418b-9614-cea666d26338)
