### PR TITLE
[PAY-2434][PAY-2427] Fix miscellaneous lossless issues

### DIFF
--- a/packages/common/src/hooks/useDownloadTrackButtons.ts
+++ b/packages/common/src/hooks/useDownloadTrackButtons.ts
@@ -145,12 +145,14 @@ export const useFileSizes = ({
   return sizes
 }
 
-const useUploadingStems = ({ trackId }: { trackId: ID }) => {
+export const useUploadingStems = ({ trackId }: { trackId: ID }) => {
   const currentUploads = useSelector(
     (state: CommonState) => getCurrentUploads(state, trackId),
     shallowEqual
   )
   const uploadingTracks = currentUploads.map((u) => ({
+    name: u.file.name,
+    size: u.file.size,
     category: u.category,
     downloadable: false
   }))

--- a/packages/common/src/store/stems-upload/selectors.ts
+++ b/packages/common/src/store/stems-upload/selectors.ts
@@ -1,23 +1,8 @@
-import { createSelector } from 'reselect'
-
 import { CommonState } from '~/store/commonStore'
 
 import { ID } from '../../models/Identifiers'
 
 const getBase = (state: CommonState) => state.stemsUpload
-
-export const selectCurrentUploads = createSelector(
-  [
-    (state: CommonState) => getBase(state).uploadsInProgress,
-    (_: CommonState, trackId: ID | undefined) => trackId
-  ],
-  (uploadsInProgress, trackId) => {
-    if (!trackId) return []
-    const uploads = uploadsInProgress[trackId]
-    if (!uploads) return []
-    return Object.values(uploads).flat()
-  }
-)
 
 export const getCurrentUploads = (state: CommonState, parentTrackId: ID) => {
   const uploads = getBase(state).uploadsInProgress[parentTrackId]

--- a/packages/mobile/src/screens/edit-track-screen/EditTrackScreen.tsx
+++ b/packages/mobile/src/screens/edit-track-screen/EditTrackScreen.tsx
@@ -284,7 +284,7 @@ export const EditTrackScreen = (props: EditTrackScreenProps) => {
         metadata.is_download_gated = true
       }
 
-      // set the redundant download json field for consistent
+      // set the redundant download json field for consistency
       // this will be cleaned up soon
       metadata.download = {
         is_downloadable: isDownloadable,

--- a/packages/mobile/src/screens/upload-screen/screens/UploadingTracksScreen.tsx
+++ b/packages/mobile/src/screens/upload-screen/screens/UploadingTracksScreen.tsx
@@ -65,25 +65,7 @@ export const UploadingTracksScreen = () => {
   const dispatch = useDispatch()
 
   useEffectOnce(() => {
-    // set download gate based on stream gate
-    // this will be updated once the UI for download gated tracks is implemented
-    const tracksToUpload = tracks.map((track) => {
-      const isDownloadable = !!track.metadata.download?.is_downloadable
-      const isDownloadGated = track.metadata.is_stream_gated
-      const downloadConditions = track.metadata.stream_conditions
-      return {
-        ...track,
-        metadata: {
-          ...track.metadata,
-          is_downloadable: isDownloadable,
-          is_download_gated: isDownloadGated,
-          download_conditions: downloadConditions
-        }
-      }
-    })
-    dispatch(
-      uploadTracks(tracksToUpload, undefined, UploadType.INDIVIDUAL_TRACK)
-    )
+    dispatch(uploadTracks(tracks, undefined, UploadType.INDIVIDUAL_TRACK))
   })
 
   const trackUploadProgress = useSelector(getCombinedUploadPercentage)

--- a/packages/web/src/components/edit-track/EditTrackModal.tsx
+++ b/packages/web/src/components/edit-track/EditTrackModal.tsx
@@ -172,22 +172,25 @@ const EditTrackModal = ({
     []
   )
 
-  const onAddStems = async (selectedStems: File[]) => {
-    const processedFiles = processFiles(selectedStems, () => {})
-    const newStems = (await Promise.all(processedFiles))
-      .filter(removeNullable)
-      .map((processedFile) => {
-        const category = detectCategory(processedFile.file.name)
-        return {
-          ...processedFile,
-          category,
-          allowDelete: true,
-          allowCategorySwitch: true
-        }
-      })
+  const onAddStems = useCallback(
+    async (selectedStems: File[]) => {
+      const processedFiles = processFiles(selectedStems, () => {})
+      const newStems = (await Promise.all(processedFiles))
+        .filter(removeNullable)
+        .map((processedFile) => {
+          const category = detectCategory(processedFile.file.name)
+          return {
+            ...processedFile,
+            category,
+            allowDelete: true,
+            allowCategorySwitch: true
+          }
+        })
 
-    setPendingUploads((s) => [...s, ...newStems])
-  }
+      setPendingUploads((s) => [...s, ...newStems])
+    },
+    [detectCategory]
+  )
 
   const { combinedStems, onDeleteStem } = (() => {
     // Filter out pending deletes from the existing stems

--- a/packages/web/src/components/edit-track/EditTrackModal.tsx
+++ b/packages/web/src/components/edit-track/EditTrackModal.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react'
+import { useCallback, useEffect, useState } from 'react'
 
 import {
   StemCategory,
@@ -160,15 +160,19 @@ const EditTrackModal = ({
     })
   }
 
-  const onAddStems = async (selectedStems: File[]) => {
-    const detectCategory = (filename: string): Nullable<StemCategory> => {
+  const detectCategory = useCallback(
+    (filename: string): Nullable<StemCategory> => {
       const lowerCaseFilename = filename.toLowerCase()
       return (
         stemDropdownRows.find((category) =>
           lowerCaseFilename.includes(category.toString().toLowerCase())
         ) ?? null
       )
-    }
+    },
+    []
+  )
+
+  const onAddStems = async (selectedStems: File[]) => {
     const processedFiles = processFiles(selectedStems, () => {})
     const newStems = (await Promise.all(processedFiles))
       .filter(removeNullable)

--- a/packages/web/src/components/stem-files-modal/StemFilesModal.module.css
+++ b/packages/web/src/components/stem-files-modal/StemFilesModal.module.css
@@ -11,7 +11,7 @@
 }
 
 .modalContainer {
-  max-width: 536px;
+  width: 720px;
   /* Need to account for the dropdown outside modal */
   overflow-y: visible !important;
   overflow-x: visible !important;

--- a/packages/web/src/components/stem-files-modal/StemFilesModal.tsx
+++ b/packages/web/src/components/stem-files-modal/StemFilesModal.tsx
@@ -23,6 +23,7 @@ import {
 } from '@audius/stems'
 import cn from 'classnames'
 
+import { Divider } from 'components/divider'
 import LoadingSpinner from 'components/loading-spinner/LoadingSpinner'
 import Dropdown from 'components/navigation/Dropdown'
 import { Dropzone } from 'components/upload/Dropzone'
@@ -31,16 +32,22 @@ import { getFeatureEnabled } from 'services/remote-config/featureFlagHelpers'
 import { stemDropdownRows } from 'utils/stems'
 
 import styles from './StemFilesModal.module.css'
+import { Nullable } from '@audius/common/utils'
 
 const MAX_ROWS = 10
 
 const messages = {
   title: 'STEMS & DOWNLOADS',
-  subtitle: 'Allow Users to download MP3 copies of your track',
   additionalFiles: 'UPLOAD ADDITIONAL FILES',
-  allowDownloads: 'Allow Downloads',
+  description:
+    'Upload your stems and source files to allow fans to remix your track. This does not affect users ability to listen offline.',
+  allowDownloads: 'Allow Full Track Download',
+  allowDownloadsDescription:
+    'Allow your fans to download a copy of your full track.',
   requireFollowToDownload: 'Require Follow to Download',
   provideLosslessFiles: 'Provide Lossless Files',
+  provideLosslessFilesDescription:
+    'Provide your fans with the Lossless files you upload in addition to an mp3.',
   done: 'DONE',
   maxCapacity: 'Reached upload limit of 10 files.',
   stemTypeHeader: 'Select Stem Type',
@@ -236,7 +243,7 @@ type DownloadSectionProps = {
   onUpdateDownloadSettings: (downloadSettings: Download) => void
 }
 
-const DownloadSection = ({
+const SwitchSection = ({
   isOriginalAvailable,
   onUpdateIsOriginalAvailable,
   downloadSettings,
@@ -285,28 +292,43 @@ const DownloadSection = ({
   }, [onUpdateDownloadSettings, downloadSettings])
 
   return (
-    <div className={styles.downloadSettings}>
-      <div className={styles.downloadSetting}>
-        <div className={styles.label}>{messages.allowDownloads}</div>
-        <Switch
-          checked={downloadSettings?.is_downloadable ?? false}
-          onChange={toggleIsDownloadable}
-        />
-      </div>
+    <Flex direction='column' ph='xl' pt='xl' gap='l'>
+      <Flex direction='column' gap='l' w='100%'>
+        <Flex justifyContent='space-between'>
+          <HarmonyText variant='title' size='l'>
+            {messages.allowDownloads}
+          </HarmonyText>
+          <Switch
+            checked={downloadSettings?.is_downloadable ?? false}
+            onChange={toggleIsDownloadable}
+          />
+        </Flex>
+        <HarmonyText variant='body'>
+          {messages.allowDownloadsDescription}
+        </HarmonyText>
+      </Flex>
+      <Divider />
       <div className={styles.downloadSetting}>
         {isLosslessDownloadsEnabled ? (
-          <>
-            <div className={styles.label}>{messages.provideLosslessFiles}</div>
-            <Switch
-              checked={isOriginalAvailable}
-              onChange={toggleIsOriginalAvailable}
-            />
-          </>
+          <Flex direction='column' gap='l' w='100%'>
+            <Flex justifyContent='space-between'>
+              <HarmonyText variant='title' size='l'>
+                {messages.provideLosslessFiles}
+              </HarmonyText>
+              <Switch
+                checked={isOriginalAvailable}
+                onChange={toggleIsOriginalAvailable}
+              />
+            </Flex>
+            <HarmonyText variant='body'>
+              {messages.allowDownloadsDescription}
+            </HarmonyText>
+          </Flex>
         ) : (
           <>
-            <div className={styles.label}>
+            <HarmonyText variant='title' size='l'>
               {messages.requireFollowToDownload}
-            </div>
+            </HarmonyText>
             <Switch
               checked={downloadSettings?.requires_follow ?? false}
               onChange={toggleRequiresFollow}
@@ -349,7 +371,6 @@ export const StemFilesModal = ({
       onClose={onClose}
       showTitleHeader
       title={messages.title}
-      subtitle={messages.subtitle}
       dismissOnClickOutside
       showDismissButton
       // Since this can be nested in the edit track modal

--- a/packages/web/src/components/stem-files-modal/StemFilesModal.tsx
+++ b/packages/web/src/components/stem-files-modal/StemFilesModal.tsx
@@ -32,7 +32,6 @@ import { getFeatureEnabled } from 'services/remote-config/featureFlagHelpers'
 import { stemDropdownRows } from 'utils/stems'
 
 import styles from './StemFilesModal.module.css'
-import { Nullable } from '@audius/common/utils'
 
 const MAX_ROWS = 10
 
@@ -243,7 +242,7 @@ type DownloadSectionProps = {
   onUpdateDownloadSettings: (downloadSettings: Download) => void
 }
 
-const SwitchSection = ({
+const DownloadSection = ({
   isOriginalAvailable,
   onUpdateIsOriginalAvailable,
   downloadSettings,
@@ -336,7 +335,7 @@ const SwitchSection = ({
           </>
         )}
       </div>
-    </div>
+    </Flex>
   )
 }
 

--- a/packages/web/src/components/track/DownloadRow.module.css
+++ b/packages/web/src/components/track/DownloadRow.module.css
@@ -1,0 +1,9 @@
+.spinner {
+  width: var(--unit-4) !important;
+  height: var(--unit-4) !important;
+  margin: 0 6px;
+}
+
+.spinner path {
+  stroke: var(--neutral) !important;
+}

--- a/packages/web/src/components/track/DownloadRow.tsx
+++ b/packages/web/src/components/track/DownloadRow.tsx
@@ -1,12 +1,23 @@
 import { useDownloadableContentAccess } from '@audius/common/hooks'
-import { ID, stemCategoryFriendlyNames } from '@audius/common/models'
+import {
+  ID,
+  StemCategory,
+  stemCategoryFriendlyNames
+} from '@audius/common/models'
 import { cacheTracksSelectors, CommonState } from '@audius/common/store'
-import { getDownloadFilename, formatBytes } from '@audius/common/utils'
+import {
+  getDownloadFilename,
+  formatBytes,
+  Nullable
+} from '@audius/common/utils'
 import { Flex, IconReceive, PlainButton, Text } from '@audius/harmony'
 import { shallowEqual, useSelector } from 'react-redux'
 
 import { Icon } from 'components/Icon'
+import LoadingSpinner from 'components/loading-spinner/LoadingSpinner'
 import Tooltip from 'components/tooltip/Tooltip'
+
+import styles from './DownloadRow.module.css'
 
 const { getTrack } = cacheTracksSelectors
 
@@ -16,35 +27,43 @@ const messages = {
 }
 
 type DownloadRowProps = {
-  trackId: ID
   onDownload: (args: { trackIds: ID[]; parentTrackId?: ID }) => void
+  isOriginal: boolean
+  trackId?: ID
   hideDownload?: boolean
   index: number
   size?: number
-  isOriginal: boolean
+  category?: StemCategory
+  filename?: string
+  isLoading?: boolean
 }
 
 export const DownloadRow = ({
-  trackId,
   onDownload,
+  isOriginal,
+  trackId,
   hideDownload,
   index,
   size,
-  isOriginal
+  category,
+  filename,
+  isLoading
 }: DownloadRowProps) => {
   const track = useSelector(
     (state: CommonState) => getTrack(state, { id: trackId }),
     shallowEqual
   )
-  const { shouldDisplayDownloadFollowGated } = useDownloadableContentAccess({
-    trackId
-  })
+  const { shouldDisplayDownloadFollowGated } = trackId
+    ? useDownloadableContentAccess({
+        trackId
+      })
+    : { shouldDisplayDownloadFollowGated: false }
 
   const downloadButton = () => (
     <PlainButton
       onClick={() =>
         onDownload({
-          trackIds: [trackId]
+          trackIds: trackId ? [trackId] : []
         })
       }
       disabled={shouldDisplayDownloadFollowGated}
@@ -67,13 +86,15 @@ export const DownloadRow = ({
         </Text>
         <Flex direction='column' gap='xs'>
           <Text variant='body' strength='default'>
-            {track?.stem_of?.category
+            {category
+              ? stemCategoryFriendlyNames[category]
+              : track?.stem_of?.category
               ? stemCategoryFriendlyNames[track?.stem_of?.category]
               : messages.fullTrack}
           </Text>
           <Text variant='body' color='subdued'>
             {getDownloadFilename({
-              filename: track?.orig_filename,
+              filename: filename ?? track?.orig_filename,
               isOriginal
             })}
           </Text>
@@ -96,6 +117,8 @@ export const DownloadRow = ({
                 {/* Need wrapping flex for the tooltip to appear for some reason */}
                 <Flex>{downloadButton()}</Flex>
               </Tooltip>
+            ) : isLoading ? (
+              <LoadingSpinner className={styles.spinner} />
             ) : (
               downloadButton()
             )}

--- a/packages/web/src/components/track/DownloadRow.tsx
+++ b/packages/web/src/components/track/DownloadRow.tsx
@@ -5,11 +5,7 @@ import {
   stemCategoryFriendlyNames
 } from '@audius/common/models'
 import { cacheTracksSelectors, CommonState } from '@audius/common/store'
-import {
-  getDownloadFilename,
-  formatBytes,
-  Nullable
-} from '@audius/common/utils'
+import { getDownloadFilename, formatBytes } from '@audius/common/utils'
 import { Flex, IconReceive, PlainButton, Text } from '@audius/harmony'
 import { shallowEqual, useSelector } from 'react-redux'
 

--- a/packages/web/src/components/track/DownloadRow.tsx
+++ b/packages/web/src/components/track/DownloadRow.tsx
@@ -49,10 +49,11 @@ export const DownloadRow = ({
     (state: CommonState) => getTrack(state, { id: trackId }),
     shallowEqual
   )
+  const downloadableContentAccess = useDownloadableContentAccess({
+    trackId: trackId ?? 0
+  })
   const { shouldDisplayDownloadFollowGated } = trackId
-    ? useDownloadableContentAccess({
-        trackId
-      })
+    ? downloadableContentAccess
     : { shouldDisplayDownloadFollowGated: false }
 
   const downloadButton = () => (

--- a/packages/web/src/components/track/DownloadSection.tsx
+++ b/packages/web/src/components/track/DownloadSection.tsx
@@ -4,9 +4,16 @@ import {
   useCurrentStems,
   useFileSizes,
   useDownloadableContentAccess,
-  useGatedContentAccess
+  useGatedContentAccess,
+  useUploadingStems
 } from '@audius/common/hooks'
-import { Name, ModalSource, DownloadQuality, ID } from '@audius/common/models'
+import {
+  Name,
+  ModalSource,
+  DownloadQuality,
+  ID,
+  StemCategory
+} from '@audius/common/models'
 import {
   cacheTracksSelectors,
   usePremiumContentPurchaseModal,
@@ -74,6 +81,7 @@ export const DownloadSection = ({ trackId }: DownloadSectionProps) => {
   )
   const { stemTracks } = useCurrentStems({ trackId })
   const { hasDownloadAccess } = useGatedContentAccess(track)
+  const { uploadingTracks: uploadingStems } = useUploadingStems({ trackId })
   const {
     price,
     shouldDisplayPremiumDownloadLocked,
@@ -306,6 +314,25 @@ export const DownloadSection = ({ trackId }: DownloadSectionProps) => {
                     : STEM_INDEX_OFFSET_WITHOUT_ORIGINAL_TRACK)
                 }
                 isOriginal={quality === DownloadQuality.ORIGINAL}
+              />
+            ))}
+            {uploadingStems.map((s, i) => (
+              <DownloadRow
+                key={`uploading-stem-${i}`}
+                onDownload={() => {}}
+                hideDownload={shouldHideDownload}
+                size={s.size}
+                index={
+                  i +
+                  stemTracks.length +
+                  (track?.is_downloadable
+                    ? STEM_INDEX_OFFSET_WITH_ORIGINAL_TRACK
+                    : STEM_INDEX_OFFSET_WITHOUT_ORIGINAL_TRACK)
+                }
+                isOriginal={quality === DownloadQuality.ORIGINAL}
+                category={s.category ?? StemCategory.OTHER}
+                filename={s.name}
+                isLoading
               />
             ))}
             {/* Only display this row if original quality is not available,

--- a/packages/web/src/pages/upload-page/fields/StemsAndDownloadsMenuFields.tsx
+++ b/packages/web/src/pages/upload-page/fields/StemsAndDownloadsMenuFields.tsx
@@ -235,16 +235,20 @@ export const StemsAndDownloadsMenuFields = () => {
     // TODO: show file error
   }
 
+  const detectCategory = useCallback(
+    (filename: string): Nullable<StemCategory> => {
+      const lowerCaseFilename = filename.toLowerCase()
+      return (
+        stemDropdownRows.find((category) =>
+          lowerCaseFilename.includes(category.toString().toLowerCase())
+        ) ?? null
+      )
+    },
+    []
+  )
+
   const onAddStemsToTrack = useCallback(
     async (selectedStems: File[]) => {
-      const detectCategory = (filename: string): Nullable<StemCategory> => {
-        const lowerCaseFilename = filename.toLowerCase()
-        return (
-          stemDropdownRows.find((category) =>
-            lowerCaseFilename.includes(category.toString().toLowerCase())
-          ) ?? null
-        )
-      }
       const processedFiles = processFiles(selectedStems, invalidAudioFile)
       const newStems = (await Promise.all(processedFiles))
         .filter(removeNullable)

--- a/packages/web/src/pages/upload-page/fields/StemsAndDownloadsMenuFields.tsx
+++ b/packages/web/src/pages/upload-page/fields/StemsAndDownloadsMenuFields.tsx
@@ -263,7 +263,7 @@ export const StemsAndDownloadsMenuFields = () => {
         })
       setStems([...stemsValue, ...newStems])
     },
-    [setStems, stemsValue]
+    [detectCategory, setStems, stemsValue]
   )
 
   return (


### PR DESCRIPTION
### Description

- Default mobile usdc pruchase gate to make track downloadable and lossless files available, unless track was already download purchase gated, in which case those fields do not change on mobile track edit.
- Show pending stem upload in web track edit

<img width="880" alt="Screenshot 2024-02-07 at 7 22 20 PM" src="https://github.com/AudiusProject/audius-protocol/assets/9600175/3cf58616-fb15-472d-ae5a-4076a85337d9">

### How Has This Been Tested?

local web and mobile dapps vs stage
