### PR TITLE
[C-3780] Fix track history api call

### DIFF
--- a/packages/web/src/common/store/pages/history/lineups/sagas.ts
+++ b/packages/web/src/common/store/pages/history/lineups/sagas.ts
@@ -22,7 +22,7 @@ function* getHistoryTracks() {
     const currentUserId = yield* select(getUserId)
     if (!currentUserId) return []
 
-    const activity = yield* call(apiClient.getUserTrackHistory, {
+    const activity = yield* call([apiClient, apiClient.getUserTrackHistory], {
       currentUserId,
       userId: currentUserId,
       limit: 100


### PR DESCRIPTION
### Description

We were calling the api wrong.

Did a search for `yield* call(apiClient.` and this was the only remaining usage.

### How Has This Been Tested?

wasn't working now it's working