### PR TITLE
[ONC-15] Fix artist dashboard plays bucketing

### DIFF
--- a/packages/web/.gitignore
+++ b/packages/web/.gitignore
@@ -24,6 +24,9 @@ env/.env.dev.local
 /build-production
 /build-mobile-production
 /build-ssr
+/build-ssr-development
+/build-ssr-staging
+/build-ssr-production
 /storybook-static
 /build-ipfs-staging
 /build-ipfs-staging.zip

--- a/packages/web/src/pages/dashboard-page/store/sagas.ts
+++ b/packages/web/src/pages/dashboard-page/store/sagas.ts
@@ -22,7 +22,7 @@ const { getBalance } = walletActions
 const getAccountUser = accountSelectors.getAccountUser
 
 const formatMonth = (date: moment.Moment | string) =>
-  moment(date).format('MMM').toUpperCase()
+  moment.utc(date).format('MMM').toUpperCase()
 
 function* fetchDashboardTracksAsync(
   action: ReturnType<typeof dashboardActions.fetchTracks>


### PR DESCRIPTION
### Description

https://linear.app/audius/issue/ONC-15/artist-dashboard-showing-incorrect-streams-for-molly-mcphauls-tracks

Play counts looked to be offset by a month on the artist dashboard. The data coming from the api was correct.

We were using `moment(date)` to format the utc dates coming from the server into month strings to bucket the plays. `moment()` is local time so any timezone past utc resulted in the previous month:
![image](https://github.com/AudiusProject/audius-protocol/assets/19916043/a51a4cda-29e7-42c5-aa64-2013afea988b)

Fix was to use `moment.utc(date)`

### How Has This Been Tested?

Confimed play counts match release dates on artist dashboard:

![image](https://github.com/AudiusProject/audius-protocol/assets/19916043/faa83a86-cc04-477c-981f-480fef37d9c7)

