### PR TITLE
[PAY-2466] Update  banner copy in purchase flow

### DIFF
--- a/packages/mobile/src/components/premium-track-purchase-drawer/AudioMatchSection.tsx
+++ b/packages/mobile/src/components/premium-track-purchase-drawer/AudioMatchSection.tsx
@@ -18,7 +18,7 @@ const useStyles = makeStyles(({ palette, spacing }) => ({
 }))
 
 const messages = {
-  earn: (amount: number) => `Earn ${amount} $AUDIO when you buy this track!`
+  earn: (amount: number) => `Earn ${amount} $AUDIO for this purchase!`
 }
 
 type AudioMatchSectionProps = {

--- a/packages/web/src/components/premium-content-purchase-modal/components/AudioMatchSection.tsx
+++ b/packages/web/src/components/premium-content-purchase-modal/components/AudioMatchSection.tsx
@@ -4,7 +4,7 @@ import { Text } from 'components/typography'
 import { useIsMobile } from 'hooks/useIsMobile'
 
 const messages = {
-  earn: (amount: string) => `Earn ${amount} $AUDIO when you buy this track!`
+  earn: (amount: string) => `Earn ${amount} $AUDIO for this purchase!`
 }
 
 type AudioMatchSectionProps = {


### PR DESCRIPTION
### Description
So that it makes sense for both track purchases and downloadable-content purchases.

### How Has This Been Tested?

![Simulator Screenshot - iPhone 14 Pro - 2024-02-08 at 15 35 40](https://github.com/AudiusProject/audius-protocol/assets/3893871/169a1f18-a682-4e5e-a9ac-8ddf051b3e83)
