### PR TITLE
[PAY-2473] Change 'original' copy to 'lossless' in download section

### DIFF
--- a/packages/mobile/src/screens/track-screen/DownloadSection.tsx
+++ b/packages/mobile/src/screens/track-screen/DownloadSection.tsx
@@ -43,7 +43,7 @@ const messages = {
   title: 'Stems & Downloads',
   choose: 'Choose File Quality',
   mp3: 'MP3',
-  original: 'Original',
+  lossless: 'Lossless',
   downloadAll: 'Download All',
   unlockAll: (price: string) => `Unlock All $${price}`,
   purchased: 'purchased',
@@ -211,7 +211,7 @@ export const DownloadSection = ({ trackId }: { trackId: ID }) => {
     },
     {
       key: DownloadQuality.ORIGINAL,
-      text: messages.original
+      text: messages.lossless
     }
   ]
 

--- a/packages/web/src/components/track/DownloadSection.tsx
+++ b/packages/web/src/components/track/DownloadSection.tsx
@@ -59,7 +59,7 @@ const messages = {
   title: 'Stems & Downloads',
   choose: 'Choose File Quality',
   mp3: 'MP3',
-  original: 'Original',
+  lossless: 'Lossless',
   downloadAll: 'Download All',
   unlockAll: (price: string) => `Unlock All $${price}`,
   purchased: 'purchased',
@@ -170,7 +170,7 @@ export const DownloadSection = ({ trackId }: DownloadSectionProps) => {
     },
     {
       key: DownloadQuality.ORIGINAL,
-      text: messages.original
+      text: messages.lossless
     }
   ]
 


### PR DESCRIPTION
### Description
Was there anywhere else we wanted to update this? Perhaps in upload flow?

### How Has This Been Tested?
<img width="228" alt="Screenshot 2024-02-08 at 3 34 39 PM" src="https://github.com/AudiusProject/audius-protocol/assets/3893871/35760b79-a002-462f-a537-59f2b825d90b">

