### PR TITLE
Skip jupiter tx in user bank withdrawal indexing

### DIFF
--- a/packages/discovery-provider/src/solana/solana_helpers.py
+++ b/packages/discovery-provider/src/solana/solana_helpers.py
@@ -38,3 +38,6 @@ METADATA_PROGRAM_ID_PK = Pubkey.from_string(METADATA_PROGRAM_ID)
 
 # Static Memo Program ID
 MEMO_PROGRAM_ID = "Memo1UhkJRfHyvLMcVucJwxXeuD728EqVDDwQDxFMNo"
+
+# Static Jupiter Swap Program ID
+JUPITER_PROGRAM_ID = "JUP6LkbZbjS1jKKwapdHNy74zcZ3tLUZoi5QNyVTaV4"

--- a/packages/discovery-provider/src/tasks/index_user_bank.py
+++ b/packages/discovery-provider/src/tasks/index_user_bank.py
@@ -47,6 +47,7 @@ from src.solana.constants import (
 )
 from src.solana.solana_client_manager import SolanaClientManager
 from src.solana.solana_helpers import (
+    JUPITER_PROGRAM_ID,
     SPL_TOKEN_ID_PK,
     get_address_pair,
     get_base_address,
@@ -95,6 +96,8 @@ USDC_MINT_PUBKEY = Pubkey.from_string(USDC_MINT) if USDC_MINT else None
 PAYMENT_ROUTER_PUBKEY = (
     Pubkey.from_string(PAYMENT_ROUTER_ADDRESS) if PAYMENT_ROUTER_ADDRESS else None
 )
+
+JUPITER_PROGRAM_ID_PUBKEY = Pubkey.from_string(JUPITER_PROGRAM_ID)
 
 # Transfer instructions don't have a mint acc arg but do have userbank authority.
 # So re-derive the claimable token PDAs for each mint here to help us determine mint later.
@@ -679,6 +682,8 @@ def process_transfer_instruction(
     # not the claimable tokens program, so we will always have a sender_user_id
     if receiver_user_id is None:
         transaction_type = get_transfer_type_from_memo(memos=memos)
+        if JUPITER_PROGRAM_ID_PUBKEY in account_keys:
+            transaction_type = USDCTransactionType.prepare_withdrawal
 
         # Attempt to look up account owner, fallback to recipient address
         receiver_account_owner = (


### PR DESCRIPTION
### Description

If we don't skip this transaction, we may end up sending an email that looks like a withdrawal

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._

```
import json
from solders.signature import Signature
from solana.rpc.api import Client
from solders.pubkey import Pubkey
c = Client('https://solana-mainnet.g.alchemy.com/v2/9j3Y1hc042MCH0_TqunwotlaFLHF6K4l')
s = Signature.from_string('5mxD7bfs6nrDFKzShg8gJGeQHMhujePWYMpNtDEDdLbsgKMFk62dC8spFmCn6WArPGyFDtFhkWsfGZP1Z8teEbZ1')
tx = c.get_transaction(s, 'json', max_supported_transaction_version=0)


Pubkey.from_string('JUP6LkbZbjS1jKKwapdHNy74zcZ3tLUZoi5QNyVTaV4') in tx.value.transaction.transaction.message.account_keys
```