### PR TITLE
[PAY-2426] Fix native harmony text and buttons

### DIFF
--- a/packages/mobile/src/harmony-native/components/Button/Button/Button.tsx
+++ b/packages/mobile/src/harmony-native/components/Button/Button/Button.tsx
@@ -35,7 +35,6 @@ export const Button = (props: ButtonProps) => {
     type,
     color: themeColors,
     cornerRadius,
-    shadows,
     spacing,
     typography
   } = useTheme()

--- a/packages/mobile/src/harmony-native/components/Button/Button/Button.tsx
+++ b/packages/mobile/src/harmony-native/components/Button/Button/Button.tsx
@@ -46,10 +46,10 @@ export const Button = (props: ButtonProps) => {
     height: spacing.unit8,
     paddingHorizontal: spacing.m
   }
+  // title-s-default
   const smallTextStyles: TextStyle = {
     fontFamily: typography.fontByWeight.bold,
     fontSize: typography.size.s,
-    fontWeight: `${typography.weight.bold}` as TextStyle['fontWeight'],
     lineHeight: typography.lineHeight.s,
     textTransform: 'capitalize'
   }
@@ -59,10 +59,11 @@ export const Button = (props: ButtonProps) => {
     height: spacing.unit12,
     paddingHorizontal: spacing.xl
   }
+
+  // title-l-default
   const defaultTextStyles: TextStyle = {
     fontFamily: typography.fontByWeight.bold,
     fontSize: typography.size.l,
-    fontWeight: `${typography.weight.bold}` as TextStyle['fontWeight'],
     lineHeight: typography.lineHeight.l,
     textTransform: 'capitalize'
   }
@@ -72,10 +73,10 @@ export const Button = (props: ButtonProps) => {
     height: spacing.unit16,
     paddingHorizontal: spacing.xl
   }
+
   const largeTextStyles: TextStyle = {
     fontFamily: typography.fontByWeight.bold,
     fontSize: typography.size.xl,
-    fontWeight: `${typography.weight.bold}` as TextStyle['fontWeight'],
     lineHeight: typography.lineHeight.l,
     letterSpacing: 0.25,
     textTransform: 'uppercase'
@@ -204,7 +205,8 @@ export const Button = (props: ButtonProps) => {
     borderRadius: cornerRadius.s,
     alignItems: 'center',
     justifyContent: 'center',
-    ...shadows.near,
+    // TODO bring this back properly
+    // ...shadows.near,
     ...(variant === 'secondary'
       ? secondaryStyles
       : variant === 'tertiary'

--- a/packages/mobile/src/harmony-native/components/Text/Text.tsx
+++ b/packages/mobile/src/harmony-native/components/Text/Text.tsx
@@ -38,7 +38,6 @@ export const Text = forwardRef<TextBase, TextProps>((props, ref) => {
     ...(variantStyles && {
       fontSize: t.size[variantStyles.fontSize[size]],
       lineHeight: t.lineHeight[variantStyles.lineHeight[size]],
-      fontWeight: t.weight[variantStyles.fontWeight[strength]],
       fontFamily: t.fontByWeight[variantStyles.fontWeight[strength]],
       ...('css' in variantStyles ? variantStyles.css : {})
     }),

--- a/packages/mobile/src/harmony-native/components/input/TextInput/TextInput.tsx
+++ b/packages/mobile/src/harmony-native/components/input/TextInput/TextInput.tsx
@@ -335,9 +335,9 @@ export const TextInput = forwardRef(
                       underlineColorAndroid='transparent'
                       aria-label={ariaLabel ?? labelText}
                       style={css({
-                        padding: 0,
                         // Need absolute height to ensure consistency across platforms
                         height: !isSmall ? 23 : undefined,
+                        // Android has a default padding that needs to be removed
                         paddingVertical: 0,
                         fontSize: typography.size[isSmall ? 's' : 'l'],
                         fontFamily: typography.fontByWeight.medium,

--- a/packages/mobile/src/harmony-native/components/input/TextInput/TextInput.tsx
+++ b/packages/mobile/src/harmony-native/components/input/TextInput/TextInput.tsx
@@ -248,6 +248,7 @@ export const TextInput = forwardRef(
               shadowOpacity={0.05}
               shadowColor='#000000'
               shadowRadius={4}
+              elevation={2}
             >
               <AnimatedFlex
                 h='100%'
@@ -334,7 +335,10 @@ export const TextInput = forwardRef(
                       underlineColorAndroid='transparent'
                       aria-label={ariaLabel ?? labelText}
                       style={css({
-                        flex: 1,
+                        padding: 0,
+                        // Need absolute height to ensure consistency across platforms
+                        height: !isSmall ? 23 : undefined,
+                        paddingVertical: 0,
                         fontSize: typography.size[isSmall ? 's' : 'l'],
                         fontFamily: typography.fontByWeight.medium,
                         color: color.text[disabled ? 'subdued' : 'default']


### PR DESCRIPTION
### Description

Fixes issues with text and button styles on android. I will follow up with a shadow improvement for the buttons eventually, but for now it is very minor. The core issue had to do with mixing fontWeight and fontFamily.