### PR TITLE
Fix red icons + badge hover color in popup menu [C-3799] [C-3798]

### DIFF
--- a/packages/web/src/components/nav/desktop/NavPopupMenu.module.css
+++ b/packages/web/src/components/nav/desktop/NavPopupMenu.module.css
@@ -107,3 +107,8 @@
 .item:hover .usdcPill path {
   fill: #2775ca;
 }
+
+.item .audioPill path,
+.item:hover .audioPill path {
+  fill: revert-layer;
+}

--- a/packages/web/src/pages/profile-page/components/desktop/ProfileTopTags.tsx
+++ b/packages/web/src/pages/profile-page/components/desktop/ProfileTopTags.tsx
@@ -46,7 +46,7 @@ export const ProfileTopTags = () => {
     return (
       <div>
         <div className={styles.tagsTitleContainer}>
-          <IconTrending className={styles.topTagsIcon} />
+          <IconTrending color='default' className={styles.topTagsIcon} />
           <span className={styles.tagsTitleText}>{messages.topTags}</span>
           <span className={styles.tagsLine} />
         </div>

--- a/packages/web/src/pages/upload-page/fields/DatePickerField.module.css
+++ b/packages/web/src/pages/upload-page/fields/DatePickerField.module.css
@@ -18,7 +18,6 @@
   height: 20px;
   width: 20px;
   margin-right: var(--unit-4);
-  color: var(--neutral-light-4);
 }
 
 .input {

--- a/packages/web/src/pages/upload-page/fields/DatePickerField.tsx
+++ b/packages/web/src/pages/upload-page/fields/DatePickerField.tsx
@@ -44,7 +44,7 @@ export const DatePickerField = (props: DatePickerFieldProps) => {
         className={styles.datePickerField}
         onClick={() => setIsFocused(true)}
       >
-        <IconCalendarMonth className={styles.iconCalendar} />
+        <IconCalendarMonth color='subdued' className={styles.iconCalendar} />
         <div>
           <div className={styles.label}>{label}</div>
           <input


### PR DESCRIPTION
### Description
- Fix upload release date calendar red icon
- Fix top tags red icon
- Fix AUDIO badge fill changing on hovering the popup menu (this was due to changing it from png to SVG and the Stems popup menu component being overzealous in applying icon styles)

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._
