### PR TITLE
Improve Connect MetaMask UX, esp. when both MetaMask and Phantom are installed [C-3750]

### DIFF
--- a/protocol-dashboard/src/components/AppBar/AppBar.module.css
+++ b/protocol-dashboard/src/components/AppBar/AppBar.module.css
@@ -77,10 +77,6 @@
 
 /* Right Nav */
 
-.userAccountSnippetContainer {
-  cursor: pointer;
-}
-
 /* User Account Snippet */
 .snippetContainer {
   display: inline-flex;
@@ -197,11 +193,10 @@
   display: inline-flex;
   align-items: center;
   padding: 12px 0px;
-  cursor: pointer;
 }
 
-.misconfigured {
-  cursor: default;
+.cursorPointer {
+  cursor: pointer;
 }
 
 .connectMetaMaskDot {
@@ -209,8 +204,17 @@
   height: 14px;
   border-radius: 50%;
   margin-right: 8px;
-  background: #f15064;
+  background-color: #f15064;
   border: 2px solid rgba(255, 255, 255, 0.5);
+  transition: background-color 500ms linear;
+}
+
+.connectMetaMaskDot.yellow {
+  background-color: var(--accent-orange-light-1);
+}
+
+.connectMetaMaskDot.green {
+  background-color: var(--accent-green-dark-1);
 }
 
 .connectMetaMask {
@@ -221,4 +225,8 @@
   letter-spacing: 1px;
   text-transform: uppercase;
   color: var(--static-white);
+}
+
+.loadingText {
+  opacity: 0.7;
 }

--- a/protocol-dashboard/src/components/AppBar/AppBar.tsx
+++ b/protocol-dashboard/src/components/AppBar/AppBar.tsx
@@ -8,7 +8,13 @@ import ConnectMetaMaskModal from 'components/ConnectMetaMaskModal'
 import UserImage from 'components/UserImage'
 import UserBadges from 'components/UserInfo/AudiusProfileBadges'
 import { useDashboardWalletUser } from 'hooks/useDashboardWalletUsers'
-import React, { ReactNode, useCallback, useEffect, useState } from 'react'
+import React, {
+  ReactNode,
+  useCallback,
+  useEffect,
+  useRef,
+  useState
+} from 'react'
 import { useLocation } from 'react-router-dom'
 import { useAccount } from 'store/account/hooks'
 import { useEthBlockNumber } from 'store/cache/protocol/hooks'
@@ -155,6 +161,7 @@ type AppBarProps = {}
 const AppBar: React.FC<AppBarProps> = () => {
   const isMobile = useIsMobile()
   const { isLoggedIn, wallet } = useAccount()
+  const timeoutIdRef = useRef<NodeJS.Timeout>(null)
   const [isAudiusClientSetup, setIsAudiusClientSetup] = useState(false)
   const [isMisconfigured, setIsMisconfigured] = useState(false)
   const [
@@ -172,7 +179,7 @@ const AppBar: React.FC<AppBarProps> = () => {
   const showBlock = isCryptoPage(pathname) && ethBlock
 
   const waitForSetup = async () => {
-    setTimeout(() => {
+    timeoutIdRef.current = setTimeout(() => {
       if (!isAudiusClientSetup) {
         setIsRetrievingAccountTimingOut(true)
       }
@@ -189,6 +196,11 @@ const AppBar: React.FC<AppBarProps> = () => {
 
   useEffect(() => {
     waitForSetup()
+    return () => {
+      if (timeoutIdRef.current) {
+        clearTimeout(timeoutIdRef.current)
+      }
+    }
   }, [])
 
   let accountSnippetContent: ReactNode

--- a/protocol-dashboard/src/components/AppBar/AppBar.tsx
+++ b/protocol-dashboard/src/components/AppBar/AppBar.tsx
@@ -37,7 +37,7 @@ const messages = {
   staked: 'STAKED',
   profileAlt: 'User Profile',
   connectProfile: 'Connect Audius Profile',
-  loading: 'Loading...'
+  loading: 'Loading Account...'
 }
 
 // TODO:
@@ -74,19 +74,9 @@ const Misconfigured = ({ isMisconfigured }: MisconfiguredProps) => {
   )
 }
 
-type LoadingProps = {
-  status: 'green' | 'yellow'
-}
-
-const Loading = ({ status }: LoadingProps) => {
+const LoadingAccount = () => {
   return (
     <div className={styles.connectMetaMaskContainer}>
-      <div
-        className={clsx(styles.connectMetaMaskDot, {
-          [styles.yellow]: status === 'yellow',
-          [styles.green]: status === 'green'
-        })}
-      ></div>
       <div className={clsx(styles.connectMetaMask, styles.loadingText)}>
         {messages.loading}
       </div>
@@ -105,7 +95,7 @@ const UserAccountSnippet = ({ wallet }: UserAccountSnippetProps) => {
   }, [user, pushRoute])
 
   if (status === Status.Loading) {
-    return <Loading status="green" />
+    return <LoadingAccount />
   }
   if (!user) return null
 
@@ -214,9 +204,7 @@ const AppBar: React.FC<AppBarProps> = () => {
     accountSnippetContent = <UserAccountSnippet wallet={wallet} />
   } else if (window.ethereum) {
     isAccountSnippetContentClickable = false
-    accountSnippetContent = (
-      <Loading status={window.aud.hasValidAccount ? 'green' : 'yellow'} />
-    )
+    accountSnippetContent = <LoadingAccount />
   } else {
     isAccountSnippetContentClickable = false
     accountSnippetContent = null

--- a/protocol-dashboard/src/components/ConnectMetaMaskModal/ConnectMetaMaskModal.module.css
+++ b/protocol-dashboard/src/components/ConnectMetaMaskModal/ConnectMetaMaskModal.module.css
@@ -3,7 +3,7 @@
   font-weight: var(--font-bold);
   font-size: var(--font-m);
   text-align: center;
-  color: #BEC5E0;
+  color: #bec5e0;
   margin: 27px auto;
 }
 
@@ -13,9 +13,21 @@
 }
 
 .okayBtn {
-  margin-right: 8px
+  margin-right: 8px;
 }
 
 .openMetaMaskBtn {
-  margin-left: 8px
+  margin-left: 8px;
+}
+
+.externalLink {
+  color: var(--neutral);
+}
+
+.externalLink:hover {
+  opacity: 0.8;
+}
+
+.externalLink:active {
+  opacity: 0.5;
 }

--- a/protocol-dashboard/src/components/ConnectMetaMaskModal/ConnectMetaMaskModal.tsx
+++ b/protocol-dashboard/src/components/ConnectMetaMaskModal/ConnectMetaMaskModal.tsx
@@ -6,6 +6,7 @@ import {
   ETH_NETWORK_ID,
   decimalNetworkIdToHexNetworkId
 } from 'utils/switchNetwork'
+import { getMetamaskChainId } from 'services/Audius/setup'
 
 const messages = {
   connectTitle: 'Connect MetaMask to Continue',
@@ -13,6 +14,7 @@ const messages = {
   description: 'Please sign in with MetaMask to continue.',
   okayBtn: 'OKAY',
   openMetaMaskBtn: 'Open MetaMask',
+  openExtensionBtn: 'Open Wallet',
   chooseMetaMaskOnPhantom:
     'Please choose MetaMask as the extension you want to connect with.',
   ifNoPopupWindow:
@@ -118,10 +120,15 @@ const MisconfiguredMetaMaskContent = ({
     window.phantom?.solana?.isPhantom || !!window.ethereum.isPhantom
 
   const onOpenMetaMask = async () => {
-    await window.ethereum.request({
-      method: 'wallet_switchEthereumChain',
-      params: [{ chainId: decimalNetworkIdToHexNetworkId(ETH_NETWORK_ID) }]
-    })
+    const chainId = await getMetamaskChainId()
+    if (chainId !== ETH_NETWORK_ID) {
+      window.ethereum.request({
+        method: 'wallet_switchEthereumChain',
+        params: [{ chainId: decimalNetworkIdToHexNetworkId(ETH_NETWORK_ID) }]
+      })
+    } else {
+      window.ethereum.enable()
+    }
   }
   return (
     <>
@@ -151,7 +158,7 @@ const MisconfiguredMetaMaskContent = ({
         />
 
         <Button
-          text={messages.openMetaMaskBtn}
+          text={messages.openExtensionBtn}
           className={styles.openMetaMaskBtn}
           type={ButtonType.PRIMARY}
           onClick={onOpenMetaMask}

--- a/protocol-dashboard/src/components/ConnectMetaMaskModal/ConnectMetaMaskModal.tsx
+++ b/protocol-dashboard/src/components/ConnectMetaMaskModal/ConnectMetaMaskModal.tsx
@@ -1,40 +1,97 @@
-import React, { useCallback } from 'react'
+import React, { ReactNode, useCallback, useEffect } from 'react'
 import Modal from 'components/Modal'
 import Button, { ButtonType } from 'components/Button'
 import styles from './ConnectMetaMaskModal.module.css'
+import {
+  ETH_NETWORK_ID,
+  decimalNetworkIdToHexNetworkId
+} from 'utils/switchNetwork'
 
 const messages = {
-  title: 'Connect MetaMask to Continue',
-  description: 'Please sign in with MetaMask to continue',
+  connectTitle: 'Connect MetaMask to Continue',
+  misconfiguredTitle: 'Your MetaMask is Misconfigured',
+  description: 'Please sign in with MetaMask to continue.',
   okayBtn: 'OKAY',
-  openMetaMaskBtn: 'Open MetaMask'
+  openMetaMaskBtn: 'Open MetaMask',
+  chooseMetaMaskOnPhantom:
+    'Please choose MetaMask as the extension you want to connect with.',
+  ifNoPopupWindow:
+    'If you do not see the prompt to select your extension, open Phantom and ',
+  setMetaMaskDefault: 'set MetaMask as your default app wallet',
+  setMetaMaskDefaultSuffix: ' in your Phantom settings.',
+  openPhantomPrompt: 'It looks like you have Phantom installed - make sure to ',
+  openPhantomPromptAddition:
+    'It looks like you have Phantom installed, so make sure to also ',
+  setMetaMaskDefaultAdditionSuffix: ' in your Phantom settings.',
+  setEthereumMainnet:
+    'Please make sure you set the network on MetaMask to Ethereum Mainnet.'
 }
 
 type OwnProps = {
   isOpen: boolean
   onClose: () => void
+  isMisconfigured?: boolean
 }
 
-type ConnectMetaMaskModalProps = OwnProps
-
-const ConnectMetaMaskModal: React.FC<ConnectMetaMaskModalProps> = ({
-  isOpen,
-  onClose
-}: ConnectMetaMaskModalProps) => {
+type ConnectMetaMaskContentProps = {
+  onClose: () => void
+}
+const ConnectMetaMaskContent = ({ onClose }: ConnectMetaMaskContentProps) => {
   const onOpenMetaMask = useCallback(() => {
     if (window.ethereum) {
       window.ethereum.request({ method: 'eth_requestAccounts' })
     }
   }, [])
+  const isPhantomInstalled = window.phantom?.solana?.isPhantom
+
+  const isSelectingExtensionOnPhantom =
+    isPhantomInstalled && window.ethereum.isSelectingExtension
+  let description: ReactNode
+  if (isPhantomInstalled) {
+    if (isSelectingExtensionOnPhantom) {
+      description = (
+        <>
+          <p>{messages.chooseMetaMaskOnPhantom}</p>
+          <p>
+            {messages.ifNoPopupWindow}
+            <a
+              className={styles.externalLink}
+              target="_blank"
+              rel="noreferrer"
+              href="https://help.phantom.app/hc/en-us/articles/12182813094163-How-to-use-Phantom-Extension-Alongside-Other-Crypto-Wallets"
+            >
+              {messages.setMetaMaskDefault}
+            </a>
+            {messages.setMetaMaskDefaultSuffix}
+          </p>
+        </>
+      )
+    } else {
+      description = (
+        <>
+          <p>{messages.description}</p>
+          <p>
+            {messages.openPhantomPrompt}
+            <a
+              className={styles.externalLink}
+              target="_blank"
+              rel="noreferrer"
+              href="https://help.phantom.app/hc/en-us/articles/12182813094163-How-to-use-Phantom-Extension-Alongside-Other-Crypto-Wallets"
+            >
+              {messages.setMetaMaskDefault}
+            </a>
+            {messages.setMetaMaskDefaultSuffix}
+          </p>
+        </>
+      )
+    }
+  } else {
+    description = messages.description
+  }
+
   return (
-    <Modal
-      title={messages.title}
-      className={styles.container}
-      isOpen={isOpen}
-      onClose={onClose}
-      isCloseable={true}
-    >
-      <div className={styles.description}>{messages.description}</div>
+    <>
+      <div className={styles.description}>{description}</div>
       <div className={styles.btnContainer}>
         <Button
           text={messages.okayBtn}
@@ -42,6 +99,7 @@ const ConnectMetaMaskModal: React.FC<ConnectMetaMaskModalProps> = ({
           type={ButtonType.PRIMARY_ALT}
           onClick={onClose}
         />
+
         <Button
           text={messages.openMetaMaskBtn}
           className={styles.openMetaMaskBtn}
@@ -49,6 +107,82 @@ const ConnectMetaMaskModal: React.FC<ConnectMetaMaskModalProps> = ({
           onClick={onOpenMetaMask}
         />
       </div>
+    </>
+  )
+}
+
+const MisconfiguredMetaMaskContent = ({
+  onClose
+}: ConnectMetaMaskContentProps) => {
+  const isPhantomInstalled =
+    window.phantom?.solana?.isPhantom || !!window.ethereum.isPhantom
+
+  const onOpenMetaMask = async () => {
+    await window.ethereum.request({
+      method: 'wallet_switchEthereumChain',
+      params: [{ chainId: decimalNetworkIdToHexNetworkId(ETH_NETWORK_ID) }]
+    })
+  }
+  return (
+    <>
+      <div className={styles.description}>
+        <p>{messages.setEthereumMainnet}</p>
+        {isPhantomInstalled ? (
+          <p>
+            {messages.openPhantomPromptAddition}{' '}
+            <a
+              className={styles.externalLink}
+              target="_blank"
+              rel="noreferrer"
+              href="https://help.phantom.app/hc/en-us/articles/12182813094163-How-to-use-Phantom-Extension-Alongside-Other-Crypto-Wallets"
+            >
+              {messages.setMetaMaskDefault}
+            </a>
+            {messages.setMetaMaskDefaultAdditionSuffix}
+          </p>
+        ) : null}
+      </div>
+      <div className={styles.btnContainer}>
+        <Button
+          text={messages.okayBtn}
+          className={styles.okayBtn}
+          type={ButtonType.PRIMARY_ALT}
+          onClick={onClose}
+        />
+
+        <Button
+          text={messages.openMetaMaskBtn}
+          className={styles.openMetaMaskBtn}
+          type={ButtonType.PRIMARY}
+          onClick={onOpenMetaMask}
+        />
+      </div>
+    </>
+  )
+}
+
+type ConnectMetaMaskModalProps = OwnProps
+
+const ConnectMetaMaskModal: React.FC<ConnectMetaMaskModalProps> = ({
+  isOpen,
+  onClose,
+  isMisconfigured
+}: ConnectMetaMaskModalProps) => {
+  return (
+    <Modal
+      title={
+        isMisconfigured ? messages.misconfiguredTitle : messages.connectTitle
+      }
+      className={styles.container}
+      isOpen={isOpen}
+      onClose={onClose}
+      isCloseable={true}
+    >
+      {isMisconfigured ? (
+        <MisconfiguredMetaMaskContent onClose={onClose} />
+      ) : (
+        <ConnectMetaMaskContent onClose={onClose} />
+      )}
     </Modal>
   )
 }

--- a/protocol-dashboard/src/services/Audius/AudiusClient.ts
+++ b/protocol-dashboard/src/services/Audius/AudiusClient.ts
@@ -26,7 +26,8 @@ import {
   toChecksumAddress,
   onSetup,
   onSetupFinished,
-  decodeCallData
+  decodeCallData,
+  onMetaMaskAccountLoaded
 } from './helpers'
 import { getUserDelegates } from './wrappers'
 
@@ -58,7 +59,11 @@ export class AudiusClient {
   _setupPromiseResolve: undefined | (() => void)
   isSetupPromise: undefined | Promise<void>
 
+  metaMaskAccountLoadedPromise: undefined | Promise<string>
+  _metaMaskAccountLoadedResolve: undefined | ((account: string | null) => void)
+
   isSetup = false // If the setup is complete
+  isMetaMaskAccountLoaded = false // If we're done trying to load the metamask account
   hasValidAccount = false // If metamask is set up correctly
   isAccountMisconfigured = false // If metamask is present and account is not connected
   isMisconfigured = false // If metamask is present and misconfigured (wrong network)
@@ -70,6 +75,7 @@ export class AudiusClient {
 
   onSetup = onSetup
   onSetupFinished = onSetupFinished
+  onMetaMaskAccountLoaded = onMetaMaskAccountLoaded
 
   // Wrapper functions
   getUserDelegates = getUserDelegates

--- a/protocol-dashboard/src/services/Audius/helpers.ts
+++ b/protocol-dashboard/src/services/Audius/helpers.ts
@@ -19,10 +19,28 @@ export function onSetup(this: AudiusClient) {
   this.isSetupPromise = new Promise(resolve => {
     this._setupPromiseResolve = resolve
   })
+  this.metaMaskAccountLoadedPromise = new Promise(resolve => {
+    this._metaMaskAccountLoadedResolve = resolve
+  })
+}
+
+export function onMetaMaskAccountLoaded(
+  this: AudiusClient,
+  account: string | null
+) {
+  this.isMetaMaskAccountLoaded = true
+  if (this._metaMaskAccountLoadedResolve) {
+    this._metaMaskAccountLoadedResolve(account)
+  }
 }
 
 export function onSetupFinished(this: AudiusClient) {
-  if (this._setupPromiseResolve) this._setupPromiseResolve()
+  if (this._setupPromiseResolve) {
+    this._setupPromiseResolve()
+  }
+  if (!this.isMetaMaskAccountLoaded) {
+    this.onMetaMaskAccountLoaded(null)
+  }
 }
 
 export async function awaitSetup(this: AudiusClient): Promise<void> {

--- a/protocol-dashboard/src/services/Audius/setup.ts
+++ b/protocol-dashboard/src/services/Audius/setup.ts
@@ -58,10 +58,8 @@ const IS_STAGING =
 let willReload = false
 
 const getMetamaskChainId = async () => {
-  return parseInt(
-    await window.ethereum.request({ method: 'eth_chainId' }),
-    16
-  ).toString()
+  const chainId = await window.ethereum.request({ method: 'eth_chainId' })
+  return parseInt(chainId, 16).toString()
 }
 
 /**
@@ -85,7 +83,7 @@ const getMetamaskIsOnEthMainnet = async () => {
 }
 
 export async function setup(this: AudiusClient): Promise<void> {
-  if (!window.web3 || !window.ethereum) {
+  if (!window.ethereum) {
     // Metamask is not installed
     this.isViewOnly = true
     this.libs = await configureReadOnlyLibs()
@@ -118,13 +116,20 @@ export async function setup(this: AudiusClient): Promise<void> {
           })
         }, 2000)
       }
-
       const isOnMainnetEth = await getMetamaskIsOnEthMainnet()
       if (!isOnMainnetEth) {
         this.isMisconfigured = true
+        this.onMetaMaskAccountLoaded(null)
         this.libs = await configureReadOnlyLibs()
       } else {
-        this.libs = await configureLibsWithAccount()
+        this.libs = await configureLibsWithAccount({
+          onMetaMaskAccountLoaded: (account: string) => {
+            if (!account) {
+              this.isAccountMisconfigured = true
+            }
+            this.onMetaMaskAccountLoaded(account)
+          }
+        })
         this.hasValidAccount = true
 
         // Failed to pull necessary info from metamask, configure read only
@@ -136,8 +141,9 @@ export async function setup(this: AudiusClient): Promise<void> {
       }
     } catch (err) {
       console.error(err)
-      this.libs = await configureReadOnlyLibs()
       this.isMisconfigured = true
+      this.onMetaMaskAccountLoaded(null)
+      this.libs = await configureReadOnlyLibs()
     }
   }
 
@@ -207,7 +213,11 @@ const configWeb3 = async (web3Provider: any, networkId: string) => {
   }
 }
 
-const configureLibsWithAccount = async () => {
+const configureLibsWithAccount = async ({
+  onMetaMaskAccountLoaded
+}: {
+  onMetaMaskAccountLoaded: (account: string) => void
+}) => {
   // @ts-ignore
   // let configuredMetamaskWeb3 = await AudiusLibs.configExternalWeb3(
   //   registryAddress!,
@@ -231,6 +241,8 @@ const configureLibsWithAccount = async () => {
     )
   })
   let metamaskAccount = metamaskAccounts[0]
+
+  onMetaMaskAccountLoaded(metamaskAccount)
 
   // Not connected or no accounts, return
   if (!metamaskAccount) {

--- a/protocol-dashboard/src/services/Audius/setup.ts
+++ b/protocol-dashboard/src/services/Audius/setup.ts
@@ -57,7 +57,7 @@ const IS_STAGING =
 // Used to prevent two callbacks from firing triggering reload
 let willReload = false
 
-const getMetamaskChainId = async () => {
+export const getMetamaskChainId = async () => {
   const chainId = await window.ethereum.request({ method: 'eth_chainId' })
   return parseInt(chainId, 16).toString()
 }


### PR DESCRIPTION
### Description
This PR fixes issues w/ connecting MetaMask to the protocol dashboard when Phantom is installed along with MetaMask, which was previously problematic. It also makes it easier for users to troubleshoot the "MetaMask Misconfigured" state.

Important context:
If both Phantom and MetaMask are installed, Phantom will prompt the user to pick either MetaMask or Phantom as their wallet extension UNLESS the user has their settings set to use Phantom by default or MetaMask by default. If the prompt is ignored, or the user picks Phantom, the protocol dashboard will of course not work correctly.

Changes in this PR:
1. Fixes issue where dashboard didn't think you had MetaMask installed at all if you had both MetaMask and Phantom installed

2. If user has both MetaMask and Phantom installed:
    a. If user ignores prompt from Phantom to choose a wallet extension, show the "Connect MetaMask" status with modal instructing them to choose MetaMask

    If "select extension" popup is active:
<img width="981" alt="Screenshot 2024-02-08 at 3 19 53 PM" src="https://github.com/AudiusProject/audius-protocol/assets/36916764/e75db148-51de-4229-87ce-40f2b0ba9a1c">

   If "select extension" popup has been closed:
<img width="1024" alt="Screenshot 2024-02-08 at 1 26 19 PM" src="https://github.com/AudiusProject/audius-protocol/assets/36916764/d726c29f-60dc-410a-997a-8470fefc0a4b">
  
  b. If Phantom is chosen as their wallet extension (or set as the default) show "MetaMask Misconfigured" status (existing behavior) with new modal (see item 3) 

3. Introduce "MetaMask Misconfigured" modal (previously this status was un-clickable)
    a. This will show up if user connected Phantom instead of MetaMask, if the network chosen is incorrect, or if something wrong happened with setting up MetaMask. 
<img width="977" alt="Screenshot 2024-02-08 at 6 13 56 PM" src="https://github.com/AudiusProject/audius-protocol/assets/36916764/f67b9322-edc4-4fe2-b100-7f1819e110f4">

Above: The bottom paragraph in screenshot will only show if Phantom is installed.

![switchmainnet](https://github.com/AudiusProject/audius-protocol/assets/36916764/0d18d682-31da-4618-a446-4deffd15c799)

Above: If the network is incorrect, the "Open Wallet" button will prompt the user to switch networks

5. Show loading state when MetaMask account is being loaded (since this takes a while and could cause confusion)
    a. Note we don't show this if MetaMask is not installed at all

6. Show MetaMask Connect status as soon as we know whether the user's account is connected successfully. Previously, the status didn't pop up until libs was finished setting up (which takes much longer). Now, if MetaMask is misconfigured or not connected, the user will be able to fix it much sooner.


### How Has This Been Tested?
Tested all scenarios locally.

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._
