### PR TITLE
[DVRL-10] Add auth_middleware to history route

### DIFF
--- a/packages/libs/src/sdk/api/generated/full/models/StemFull.ts
+++ b/packages/libs/src/sdk/api/generated/full/models/StemFull.ts
@@ -56,6 +56,12 @@ export interface StemFull {
      * @memberof StemFull
      */
     blocknumber: number;
+    /**
+     * 
+     * @type {string}
+     * @memberof StemFull
+     */
+    origFilename: string;
 }
 
 /**
@@ -69,6 +75,7 @@ export function instanceOfStemFull(value: object): boolean {
     isInstance = isInstance && "cid" in value;
     isInstance = isInstance && "userId" in value;
     isInstance = isInstance && "blocknumber" in value;
+    isInstance = isInstance && "origFilename" in value;
 
     return isInstance;
 }
@@ -89,6 +96,7 @@ export function StemFullFromJSONTyped(json: any, ignoreDiscriminator: boolean): 
         'cid': json['cid'],
         'userId': json['user_id'],
         'blocknumber': json['blocknumber'],
+        'origFilename': json['orig_filename'],
     };
 }
 
@@ -107,6 +115,7 @@ export function StemFullToJSON(value?: StemFull | null): any {
         'cid': value.cid,
         'user_id': value.userId,
         'blocknumber': value.blocknumber,
+        'orig_filename': value.origFilename,
     };
 }
 


### PR DESCRIPTION
### Description

Add `auth_middleware` decorator to history routes.

This makes it so that a signed request coming from sdk can be used to fetch track listening history for a given user as opposed to the status quo which allows anyone to fetch it, provided that they pass a "user_id" along, e.g.
https://discoveryprovider.audius.co/v1/users/7eP5n/history/tracks?user_id=7eP5n

We would like to not expose that in the same way and instead ensure that 7eP5n signs a request to the endpoint
https://discoveryprovider.audius.co/v1/users/7eP5n/history/tracks

Generated sdk changes are unrelated, but 
```
cd packages/libs
npm run gen:dev
```
was run to ensure that adding auth_middleware added no other changes.

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._

```
npm run protocol
```