### PR TITLE
[DVRL-14] - Integrate Google Analytics in Docs

### DIFF
--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -49,6 +49,10 @@ const config = {
         },
         theme: {
           customCss: './src/css/custom.css'
+        },
+        gtag: {
+          trackingID: 'G-XSRDQBKXVX',
+          anonymizeIP: true,
         }
       })
     ]

--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@docusaurus/core": "3.1.1",
+        "@docusaurus/plugin-google-gtag": "^3.1.1",
         "@docusaurus/preset-classic": "3.1.1",
         "@docusaurus/theme-mermaid": "^3.1.1",
         "@mdx-js/react": "^3.0.0",

--- a/docs/package.json
+++ b/docs/package.json
@@ -16,6 +16,7 @@
   },
   "dependencies": {
     "@docusaurus/core": "3.1.1",
+    "@docusaurus/plugin-google-gtag": "^3.1.1",
     "@docusaurus/preset-classic": "3.1.1",
     "@docusaurus/theme-mermaid": "^3.1.1",
     "@mdx-js/react": "^3.0.0",


### PR DESCRIPTION
### Description

Added Google Analytics integration for docs. Uses latest GA4 with [`@docusaurus/plugin-google-gtag`](https://docusaurus.io/docs/api/plugins/@docusaurus/plugin-google-gtag) config

<img width="479" alt="image" src="https://github.com/AudiusProject/audius-protocol/assets/1404219/0bf915cd-6e3f-4547-b3b8-e1735b154ca3">

### How Has This Been Tested?

> npm run build
