### PR TITLE
[C-3802] Match Avatar styles more closely to prod

### DIFF
--- a/packages/mobile/src/screens/app-drawer-screen/left-nav-drawer/AccountDetails.tsx
+++ b/packages/mobile/src/screens/app-drawer-screen/left-nav-drawer/AccountDetails.tsx
@@ -62,6 +62,7 @@ export const AccountDetails = () => {
           userId={accountUser.user_id}
           style={styles.accountImage}
           mb='l'
+          strokeWidth='thin'
         />
         <View style={styles.accountName}>
           <Text numberOfLines={1} style={styles.name} variant='h1' noGutter>

--- a/packages/mobile/src/screens/app-screen/AccountPictureHeader.tsx
+++ b/packages/mobile/src/screens/app-screen/AccountPictureHeader.tsx
@@ -67,6 +67,7 @@ export const AccountPictureHeader = (props: AccountPictureHeaderProps) => {
           userId={accountId}
           style={styles.root}
           imagePriority='high'
+          strokeWidth='thin'
         />
         {showNotificationBubble ? (
           <View style={styles.notificationBubbleRoot}>

--- a/packages/mobile/src/screens/chat-screen/ChatScreen.tsx
+++ b/packages/mobile/src/screens/chat-screen/ChatScreen.tsx
@@ -579,6 +579,7 @@ export const ChatScreen = () => {
                   userId={otherUser.user_id}
                   size='small'
                   mr='s'
+                  strokeWidth='thin'
                 />
                 <UserBadges
                   user={otherUser}

--- a/packages/mobile/src/screens/notifications-screen/Notification/NotificationProfilePicture.tsx
+++ b/packages/mobile/src/screens/notifications-screen/Notification/NotificationProfilePicture.tsx
@@ -45,6 +45,7 @@ export const NotificationProfilePicture = (
       userId={profile.user_id}
       size='medium'
       style={[css({ marginRight: spacing.s }), style]}
+      strokeWidth='thin'
       {...other}
     />
   )

--- a/packages/mobile/src/screens/profile-screen/ArtistRecommendations/ArtistRecommendations.tsx
+++ b/packages/mobile/src/screens/profile-screen/ArtistRecommendations/ArtistRecommendations.tsx
@@ -178,8 +178,9 @@ export const ArtistRecommendations = (props: ArtistRecommendationsProps) => {
               style={css({
                 height: spacing.unit13,
                 width: spacing.unit13,
-                mr: -spacing.s
+                marginRight: -spacing.s
               })}
+              strokeWidth='thin'
             />
           </TouchableOpacity>
         ))}

--- a/packages/mobile/src/screens/profile-screen/ProfileHeader/SupportingTile.tsx
+++ b/packages/mobile/src/screens/profile-screen/ProfileHeader/SupportingTile.tsx
@@ -145,6 +145,7 @@ export const SupportingTile = (props: SupportingTileProps) => {
                 height: harmonySpacing.unit8
               })}
               mr='s'
+              strokeWidth='thin'
               userId={user.user_id}
             />
             <Text

--- a/packages/mobile/src/screens/search-screen/SearchResults/SearchItem.tsx
+++ b/packages/mobile/src/screens/search-screen/SearchResults/SearchItem.tsx
@@ -57,7 +57,7 @@ const UserSearchResult = (props: UserSearchResultProps) => {
 
   return (
     <SearchResultItem onPress={handlePress}>
-      <ProfilePicture userId={user.user_id} size='medium' />
+      <ProfilePicture userId={user.user_id} size='medium' strokeWidth='thin' />
       <UserBadges
         style={styles.badgeContainer}
         nameStyle={styles.name}

--- a/packages/mobile/src/screens/settings-screen/AccountSettingsRow.tsx
+++ b/packages/mobile/src/screens/settings-screen/AccountSettingsRow.tsx
@@ -48,6 +48,7 @@ export const AccountSettingsRow = () => {
         <ProfilePicture
           userId={accountUser.user_id}
           style={css({ width: spacing.unit13, height: spacing.unit13 })}
+          strokeWidth='thin'
         />
         <View style={styles.info}>
           <Text style={styles.name}>{name}</Text>


### PR DESCRIPTION
### Description

#7404 replaced all non-harmony avatars on native mobile. I came across a few minor styling issues and fixed them:

* The default `strokeWidth` on harmony `Avatar` is thicker than the prod avatar stroke in a lot of places. Use `strokeWidth='thin'` for these cases
* The stacking of top supporters was broken bc `mr` was being used in an emotion `css` call. This only works on Box components I believe!
* Outstanding: The supporting tile avatar has a dark stroke in dark mode, which is not the case on prod. Waiting on design to get back to me on which route to take here

Link to slack discussion: https://audius-internal.slack.com/archives/C05MUGKK4AG/p1707514008364739

### How Has This Been Tested?

Navigated to all changed avatars in #7404 and confirmed styles looked correct in light/dark mode
