### PR TITLE
[PROTO-1661] Make ddex download from S3 and publish via Audius SDK

### DIFF
--- a/packages/ddex/ingester/common/sdk_types.go
+++ b/packages/ddex/ingester/common/sdk_types.go
@@ -1,5 +1,7 @@
 package common
 
+import "time"
+
 type Genre string
 
 const (
@@ -154,59 +156,9 @@ type NullableBool = *bool
 type NullableString = *string
 type NullableInt = *int
 
-type TrackSegment struct {
-	Duration  string `bson:"duration"`
-	Multihash CID    `bson:"multihash"`
-}
-
-type Download struct {
-	IsDownloadable NullableBool   `bson:"is_downloadable"`
-	RequiresFollow NullableBool   `bson:"requires_follow"`
-	CID            NullableString `bson:"cid"`
-}
-
-type TokenStandard string
-
-const (
-	ERC721  TokenStandard = "ERC721"
-	ERC1155 TokenStandard = "ERC1155"
-)
-
-type EthCollectibleGatedConditions struct {
-	Chain        string         `bson:"chain"`
-	Standard     TokenStandard  `bson:"standard"`
-	Address      string         `bson:"address"`
-	Name         string         `bson:"name"`
-	Slug         string         `bson:"slug"`
-	ImageUrl     NullableString `bson:"imageUrl"`
-	ExternalLink NullableString `bson:"externalLink"`
-}
-
-type SolCollectibleGatedConditions struct {
-	Chain        string         `bson:"chain"`
-	Address      string         `bson:"address"`
-	Name         string         `bson:"name"`
-	ImageUrl     NullableString `bson:"imageUrl"`
-	ExternalLink NullableString `bson:"externalLink"`
-}
-
-type USDCPurchaseConditions struct {
-	USDCPurchase *struct {
-		Price  float64            `bson:"price"`
-		Splits map[string]float64 `bson:"splits"`
-	} `bson:"usdc_purchase,omitempty"`
-}
-
-type GatedConditions struct {
-	NFTCollection *interface{} `bson:"nft_collection,omitempty"`
-	FollowUserID  NullableInt  `bson:"follow_user_id,omitempty"`
-	TipUserID     NullableInt  `bson:"tip_user_id,omitempty"`
-	USDCPurchaseConditions
-}
-
 type TrackMetadata struct {
 	Title               string         `bson:"title"`
-	ReleaseDate         string         `bson:"release_date"`
+	ReleaseDate         time.Time      `bson:"release_date"`
 	Genre               Genre          `bson:"genre"`
 	Duration            int            `bson:"duration"`
 	PreviewStartSeconds NullableInt    `bson:"preview_start_seconds,omitempty"`
@@ -221,12 +173,18 @@ type TrackMetadata struct {
 	Tags        NullableString `bson:"tags,omitempty"`
 
 	// Extra fields (not in SDK)
-	Artists             []Artist `bson:"artists"`
-	ArtistName          string   `bson:"artist_name"`
-	Copyright           string   `bson:"copyright"`
-	PreviewAudioFileURL string   `bson:"preview_audio_file_url"`
-	AudioFileURL        string   `bson:"audio_file_url"`
-	CoverArtURL         string   `bson:"cover_art_url"`
+	Artists                     []Artist `bson:"artists"`
+	ArtistName                  string   `bson:"artist_name"`
+	Copyright                   string   `bson:"copyright"`
+	PreviewAudioFileURL         string   `bson:"preview_audio_file_url"`
+	PreviewAudioFileURLHash     string   `bson:"preview_audio_file_url_hash"`
+	PreviewAudioFileURLHashAlgo string   `bson:"preview_audio_file_url_hash_algo"`
+	AudioFileURL                string   `bson:"audio_file_url"`
+	AudioFileURLHash            string   `bson:"audio_file_url_hash"`
+	AudioFileURLHashAlgo        string   `bson:"audio_file_url_hash_algo"`
+	CoverArtURL                 string   `bson:"cover_art_url"`
+	CoverArtURLHash             string   `bson:"cover_art_url_hash"`
+	CoverArtURLHashAlgo         string   `bson:"cover_art_url_hash_algo"`
 }
 
 // Not part of SDK
@@ -244,12 +202,14 @@ type CollectionMetadata struct {
 	Tags            NullableString `bson:"tags,omitempty"`
 	Genre           Genre          `bson:"genre"`
 	Mood            Mood           `bson:"mood"`
-	ReleaseDate     string         `bson:"release_date"`
+	ReleaseDate     time.Time      `bson:"release_date"`
 
 	// TODO: Handle these fields
 	License NullableString `bson:"license,omitempty"`
 	UPC     NullableString `bson:"upc,omitempty"`
 
 	// Extra fields (not in SDK)
-	CoverArtURL string `bson:"cover_art_url"`
+	CoverArtURL         string `bson:"cover_art_url"`
+	CoverArtURLHash     string `bson:"cover_art_url_hash"`
+	CoverArtURLHashAlgo string `bson:"cover_art_url_hash_algo"`
 }

--- a/packages/ddex/ingester/common/types.go
+++ b/packages/ddex/ingester/common/types.go
@@ -27,9 +27,9 @@ type PendingRelease struct {
 	UploadETag  string             `bson:"upload_etag"`
 	DeliveryID  primitive.ObjectID `bson:"delivery_id"`
 	PublishDate time.Time          `bson:"publish_date"`
-	CreatedAt   time.Time          `bson:"created_at"`
 	Track       CreateTrackRelease `bson:"create_track_release"`
 	Album       CreateAlbumRelease `bson:"create_album_release"`
+	CreatedAt   time.Time          `bson:"created_at"`
 }
 
 type PublishedRelease struct {
@@ -37,6 +37,11 @@ type PublishedRelease struct {
 	UploadETag  string             `bson:"upload_etag"`
 	DeliveryID  primitive.ObjectID `bson:"delivery_id"`
 	PublishDate time.Time          `bson:"publish_date"`
+	EntityID    string             `bson:"entity_id"`
+	Blockhash   string             `bson:"blockhash"`
+	Blocknumber int64              `bson:"blocknumber"`
+	Track       CreateTrackRelease `bson:"create_track_release"`
+	Album       CreateAlbumRelease `bson:"create_album_release"`
 	CreatedAt   time.Time          `bson:"created_at"`
 }
 

--- a/packages/ddex/ingester/parser/sony_parser.go
+++ b/packages/ddex/ingester/parser/sony_parser.go
@@ -106,7 +106,7 @@ type ResourceGroupContentItem struct {
 
 // parseSonyXML parses the given XML data and returns structured data including releases, sound recordings, and images.
 // NOTE: This expects the ERN 3 format. See https://kb.ddex.net/implementing-each-standard/electronic-release-notification-message-suite-(ern)/ern-3-explained/
-func parseSonyXML(xmlData []byte) (tracks []common.CreateTrackRelease, albums []common.CreateAlbumRelease, errs []error) {
+func parseSonyXML(xmlData []byte, indexedBucket, deliveryIDHex string) (tracks []common.CreateTrackRelease, albums []common.CreateAlbumRelease, errs []error) {
 	doc, err := xmlquery.Parse(bytes.NewReader(xmlData))
 	if err != nil {
 		errs = append(errs, err)
@@ -148,7 +148,7 @@ func parseSonyXML(xmlData []byte) (tracks []common.CreateTrackRelease, albums []
 	// Parse <Release>s from <ReleaseList>
 	releaseNodes := xmlquery.Find(doc, "//ReleaseList/Release")
 	for _, rNode := range releaseNodes {
-		track, album, err := processReleaseNode(rNode, &soundRecordings, &images)
+		track, album, err := processReleaseNode(rNode, &soundRecordings, &images, indexedBucket, deliveryIDHex)
 		if err != nil {
 			errs = append(errs, err)
 			continue
@@ -164,12 +164,23 @@ func parseSonyXML(xmlData []byte) (tracks []common.CreateTrackRelease, albums []
 }
 
 // processReleaseNode parses a <Release> into a CreateTrackRelease or CreateAlbumRelease struct.
-func processReleaseNode(rNode *xmlquery.Node, soundRecordings *[]SoundRecording, images *[]Image) (track *common.CreateTrackRelease, album *common.CreateAlbumRelease, err error) {
+func processReleaseNode(rNode *xmlquery.Node, soundRecordings *[]SoundRecording, images *[]Image, indexedBucket, deliveryIDHex string) (track *common.CreateTrackRelease, album *common.CreateAlbumRelease, err error) {
 	releaseRef := safeInnerText(rNode.SelectElement("ReleaseReference"))
-	releaseDate := safeInnerText(rNode.SelectElement("GlobalOriginalReleaseDate")) // TODO: This is deprecated. Need to use DealList
+	releaseDateStr := safeInnerText(rNode.SelectElement("GlobalOriginalReleaseDate")) // TODO: This is deprecated. Need to use DealList
 	durationISOStr := safeInnerText(rNode.SelectElement("Duration"))
 	isrc := safeInnerText(rNode.SelectElement("ReleaseId/ISRC"))
 	releaseType := safeInnerText(rNode.SelectElement("ReleaseType"))
+
+	// Convert releaseDate from string of format YYYY-MM-DD to time.Time
+	if releaseDateStr == "" {
+		err = fmt.Errorf("missing release date for <ReleaseReference>%s</ReleaseReference>", releaseRef)
+		return
+	}
+	releaseDate, releaseDateErr := time.Parse("2006-01-02", releaseDateStr)
+	if releaseDateErr != nil {
+		err = fmt.Errorf("failed to parse release date for <ReleaseReference>%s</ReleaseReference>: %s", releaseRef, releaseDateErr)
+		return
+	}
 
 	// Only use release info from the "Worldwide" territory
 	var releaseDetails *xmlquery.Node
@@ -242,11 +253,11 @@ func processReleaseNode(rNode *xmlquery.Node, soundRecordings *[]SoundRecording,
 		}
 
 		var tracks []common.TrackMetadata
-		var coverArtURL string
+		var coverArtURL, coverArtURLHash, coverArtURLHashAlgo string
 		for _, ci := range contentItems {
 			if ci.ResourceType == ResourceTypeSoundRecording {
 				var trackMetadata *common.TrackMetadata
-				trackMetadata, err = parseTrackMetadata(ci)
+				trackMetadata, err = parseTrackMetadata(ci, indexedBucket, deliveryIDHex)
 				if err != nil {
 					return
 				}
@@ -264,7 +275,9 @@ func processReleaseNode(rNode *xmlquery.Node, soundRecordings *[]SoundRecording,
 					if coverArtURL != "" {
 						fmt.Printf("Skipping duplicate audio file for Image %s\n", ci.Reference)
 					}
-					coverArtURL = d.FileDetails.FilePath + d.FileDetails.FileName
+					coverArtURL = fmt.Sprintf("s3://%s/%s/%s%s", indexedBucket, deliveryIDHex, d.FileDetails.FilePath, d.FileDetails.FileName)
+					coverArtURLHash = d.FileDetails.HashSum
+					coverArtURLHashAlgo = d.FileDetails.HashSumAlgorithmType
 				}
 			}
 		}
@@ -273,13 +286,15 @@ func processReleaseNode(rNode *xmlquery.Node, soundRecordings *[]SoundRecording,
 			DDEXReleaseRef: releaseRef,
 			Tracks:         tracks,
 			Metadata: common.CollectionMetadata{
-				PlaylistName:    title,
-				PlaylistOwnerID: artistName, // TODO: We don't have an ID here
-				ReleaseDate:     releaseDate,
-				Genre:           genre,
-				IsAlbum:         true,
-				IsPrivate:       false, // TODO: Use DealList to determine this. Same with releaseDate because I think the XML element it's reading is deprecated
-				CoverArtURL:     coverArtURL,
+				PlaylistName:        title,
+				PlaylistOwnerID:     artistName, // TODO: We don't have an ID here
+				ReleaseDate:         releaseDate,
+				Genre:               genre,
+				IsAlbum:             true,
+				IsPrivate:           false, // TODO: Use DealList to determine this. Same with releaseDate because I think the XML element it's reading is deprecated
+				CoverArtURL:         coverArtURL,
+				CoverArtURLHash:     coverArtURLHash,
+				CoverArtURLHashAlgo: coverArtURLHashAlgo,
 			},
 		}
 		return
@@ -293,10 +308,10 @@ func processReleaseNode(rNode *xmlquery.Node, soundRecordings *[]SoundRecording,
 
 		// Extract file links and other details from the audio and image resources
 		var trackMetadata *common.TrackMetadata
-		var coverArtURL string
+		var coverArtURL, coverArtURLHash, coverArtURLHashAlgo string
 		for _, ci := range contentItems {
 			if ci.ResourceType == ResourceTypeSoundRecording {
-				trackMetadata, err = parseTrackMetadata(ci)
+				trackMetadata, err = parseTrackMetadata(ci, indexedBucket, deliveryIDHex)
 				if err != nil {
 					return
 				}
@@ -313,7 +328,9 @@ func processReleaseNode(rNode *xmlquery.Node, soundRecordings *[]SoundRecording,
 					if coverArtURL != "" {
 						fmt.Printf("Skipping duplicate audio file for Image %s\n", ci.Reference)
 					}
-					coverArtURL = d.FileDetails.FilePath + d.FileDetails.FileName
+					coverArtURL = fmt.Sprintf("s3://%s/%s/%s%s", indexedBucket, deliveryIDHex, d.FileDetails.FilePath, d.FileDetails.FileName)
+					coverArtURLHash = d.FileDetails.HashSum
+					coverArtURLHashAlgo = d.FileDetails.HashSumAlgorithmType
 				}
 			}
 		}
@@ -356,6 +373,8 @@ func processReleaseNode(rNode *xmlquery.Node, soundRecordings *[]SoundRecording,
 		trackMetadata.ReleaseDate = releaseDate
 		trackMetadata.Copyright = copyright
 		trackMetadata.CoverArtURL = coverArtURL
+		trackMetadata.CoverArtURLHash = coverArtURLHash
+		trackMetadata.CoverArtURLHashAlgo = coverArtURLHashAlgo
 
 		track = &common.CreateTrackRelease{
 			DDEXReleaseRef: releaseRef,
@@ -368,7 +387,7 @@ func processReleaseNode(rNode *xmlquery.Node, soundRecordings *[]SoundRecording,
 }
 
 // parseTrackMetadata parses the metadata for a sound recording from a ResourceGroupContentItem.
-func parseTrackMetadata(ci ResourceGroupContentItem) (metadata *common.TrackMetadata, err error) {
+func parseTrackMetadata(ci ResourceGroupContentItem, indexedBucket, deliveryIDHex string) (metadata *common.TrackMetadata, err error) {
 	if ci.SoundRecording == nil {
 		err = fmt.Errorf("no <SoundRecording> found for <ResourceReference>%s</ResourceReference>", ci.Reference)
 		return
@@ -378,20 +397,24 @@ func parseTrackMetadata(ci ResourceGroupContentItem) (metadata *common.TrackMeta
 		return
 	}
 
-	var audioFileURL, previewAudioFileURL string
+	var audioFileURL, audioFileURLHash, audioFileURLHashAlgo, previewAudioFileURL, previewAudioFileURLHash, previewAudioFileURLHashAlgo string
 	var previewStartSec int
 
 	for _, d := range ci.SoundRecording.TechnicalDetails {
 		if d.IsPreview {
 			if previewAudioFileURL == "" {
-				previewAudioFileURL = d.FileDetails.FilePath + d.FileDetails.FileName
+				previewAudioFileURL = fmt.Sprintf("s3://%s/%s/%s%s", indexedBucket, deliveryIDHex, d.FileDetails.FilePath, d.FileDetails.FileName)
+				previewAudioFileURLHash = d.FileDetails.HashSum
+				previewAudioFileURLHashAlgo = d.FileDetails.HashSumAlgorithmType
 				previewStartSec = d.PreviewDetails.StartPoint
 			} else {
 				fmt.Printf("Skipping duplicate audio preview for SoundRecording %s\n", ci.Reference)
 			}
 		} else {
 			if audioFileURL == "" {
-				audioFileURL = d.FileDetails.FilePath + d.FileDetails.FileName
+				audioFileURL = fmt.Sprintf("s3://%s/%s/%s%s", indexedBucket, deliveryIDHex, d.FileDetails.FilePath, d.FileDetails.FileName)
+				audioFileURLHash = d.FileDetails.HashSum
+				audioFileURLHashAlgo = d.FileDetails.HashSumAlgorithmType
 			} else {
 				fmt.Printf("Skipping duplicate audio file for SoundRecording %s\n", ci.Reference)
 			}
@@ -400,13 +423,17 @@ func parseTrackMetadata(ci ResourceGroupContentItem) (metadata *common.TrackMeta
 
 	duration, _ := parseISODuration(ci.SoundRecording.Duration)
 	metadata = &common.TrackMetadata{
-		Title:               ci.SoundRecording.Title,
-		Duration:            int(duration.Seconds()),
-		PreviewStartSeconds: &previewStartSec,
-		ISRC:                &ci.SoundRecording.ISRC,
-		Artists:             ci.SoundRecording.Artists,
-		PreviewAudioFileURL: previewAudioFileURL,
-		AudioFileURL:        audioFileURL,
+		Title:                       ci.SoundRecording.Title,
+		Duration:                    int(duration.Seconds()),
+		PreviewStartSeconds:         &previewStartSec,
+		ISRC:                        &ci.SoundRecording.ISRC,
+		Artists:                     ci.SoundRecording.Artists,
+		PreviewAudioFileURL:         previewAudioFileURL,
+		PreviewAudioFileURLHash:     previewAudioFileURLHash,
+		PreviewAudioFileURLHashAlgo: previewAudioFileURLHashAlgo,
+		AudioFileURL:                audioFileURL,
+		AudioFileURLHash:            audioFileURLHash,
+		AudioFileURLHashAlgo:        audioFileURLHashAlgo,
 	}
 	if genre, ok := common.ToGenre(ci.SoundRecording.Genre); ok {
 		metadata.Genre = genre

--- a/packages/ddex/publisher/package.json
+++ b/packages/ddex/publisher/package.json
@@ -18,6 +18,7 @@
   "author": "Audius",
   "dependencies": {
     "@audius/sdk": "*",
+    "@aws-sdk/client-s3": "3.504.0",
     "dotenv": "16.3.1",
     "express": "4.18.2",
     "mongoose": "8.1.0",
@@ -25,11 +26,11 @@
   },
   "devDependencies": {
     "@types/express": "4.17.21",
-    "eslint-config-prettier": "9.1.0",
-    "eslint-plugin-prettier": "5.1.2",
+    "@types/node": "20.11.10",
     "@typescript-eslint/eslint-plugin": "6.17.0",
     "@typescript-eslint/parser": "6.17.0",
-    "@types/node": "20.11.10",
+    "eslint-config-prettier": "9.1.0",
+    "eslint-plugin-prettier": "5.1.2",
     "typescript": "5.3.3"
   }
 }

--- a/packages/ddex/publisher/package.json
+++ b/packages/ddex/publisher/package.json
@@ -17,9 +17,11 @@
   "keywords": [],
   "author": "Audius",
   "dependencies": {
+    "@audius/sdk": "*",
     "dotenv": "16.3.1",
     "express": "4.18.2",
-    "mongoose": "8.1.0"
+    "mongoose": "8.1.0",
+    "web3": "4.3.0"
   },
   "devDependencies": {
     "@types/express": "4.17.21",

--- a/packages/ddex/publisher/src/app.ts
+++ b/packages/ddex/publisher/src/app.ts
@@ -1,14 +1,7 @@
 import express, { Express, Request, Response } from 'express'
 
 export default function createApp() {
-  /*
-   * Setup app
-   */
   const app: Express = express()
-
-  /*
-   * Define API routes
-   */
 
   app.get('/api/health_check', (_req: Request, res: Response) => {
     res.status(200).send('DDEX publisher is alive!')

--- a/packages/ddex/publisher/src/index.ts
+++ b/packages/ddex/publisher/src/index.ts
@@ -8,6 +8,7 @@ dotenv.config({ path: path.join(__dirname, '..', '..', '.env') })
 import createApp from './app'
 import { dialDb } from './services/dbService'
 import { publishReleases } from './services/publisherService'
+import createS3 from './services/s3Service'
 
 const port = process.env.DDEX_PORT || 9001
 
@@ -18,10 +19,11 @@ const port = process.env.DDEX_PORT || 9001
       'mongodb://mongo:mongo@localhost:27017/ddex?authSource=admin&replicaSet=rs0'
     await dialDb(dbUrl)
     const sdkService = createSdkService()
+    const s3 = createS3()
 
     const app = createApp()
 
-    publishReleases(sdkService.getSdk())
+    publishReleases(sdkService.getSdk(), s3)
 
     app.listen(port, () => {
       console.log(`[server]: Server is running at http://localhost:${port}`)

--- a/packages/ddex/publisher/src/index.ts
+++ b/packages/ddex/publisher/src/index.ts
@@ -1,5 +1,6 @@
 import dotenv from 'dotenv'
 import path from 'path'
+import { createSdkService } from './services/sdkService'
 
 // Load env vars from ddex package root
 dotenv.config({ path: path.join(__dirname, '..', '..', '.env') })
@@ -16,10 +17,11 @@ const port = process.env.DDEX_PORT || 9001
       process.env.DDEX_MONGODB_URL ||
       'mongodb://mongo:mongo@localhost:27017/ddex?authSource=admin&replicaSet=rs0'
     await dialDb(dbUrl)
+    const sdkService = createSdkService()
 
     const app = createApp()
 
-    publishReleases()
+    publishReleases(sdkService.getSdk())
 
     app.listen(port, () => {
       console.log(`[server]: Server is running at http://localhost:${port}`)

--- a/packages/ddex/publisher/src/models/deliveries.ts
+++ b/packages/ddex/publisher/src/models/deliveries.ts
@@ -2,7 +2,7 @@ import mongoose from 'mongoose'
 
 // DDEX deliveries indexed from DDEX uploads
 const deliveriesSchema = new mongoose.Schema({
-  id: mongoose.Schema.Types.ObjectId,
+  _id: mongoose.Schema.Types.ObjectId,
   upload_etag: String,
   delivery_status: String,
   xml_file_path: String,

--- a/packages/ddex/publisher/src/models/pendingReleases.ts
+++ b/packages/ddex/publisher/src/models/pendingReleases.ts
@@ -79,34 +79,10 @@ const moods = [
   'Other',
 ]
 
-interface Artist {
-  name: string
-  roles: string[]
-}
-
 const artistSchema = new mongoose.Schema({
   name: { type: String, required: true },
   roles: [{ type: String }],
 })
-
-export interface TrackMetadata {
-  title: string
-  release_date: string // Assuming ISO date format as string
-  genre: string // This could be further refined to a union of the specific genre strings
-  duration: number
-  preview_start_seconds?: number
-  isrc?: string
-  license?: string
-  description?: string
-  mood?: string // This could be further refined to a union of the specific mood strings
-  tags?: string
-  artists: Artist[]
-  artist_name: string
-  copyright: string
-  preview_audio_file_url: string
-  audio_file_url: string
-  cover_art_url: string
-}
 
 const trackMetadataSchema = new mongoose.Schema({
   title: { type: String, required: true },
@@ -123,24 +99,17 @@ const trackMetadataSchema = new mongoose.Schema({
   artist_name: { type: String, required: true },
   copyright: { type: String, required: true },
   preview_audio_file_url: { type: String, required: true },
+  preview_audio_file_url_hash: { type: String, required: true },
+  preview_audio_file_url_hash_algo: { type: String, required: true },
   audio_file_url: { type: String, required: true },
+  audio_file_url_hash: { type: String, required: true },
+  audio_file_url_hash_algo: { type: String, required: true },
   cover_art_url: { type: String, required: true },
+  cover_art_url_hash: { type: String, required: true },
+  cover_art_url_hash_algo: { type: String, required: true },
 })
 
-export interface CollectionMetadata {
-  playlist_name: string
-  playlist_owner_id: string
-  description?: string
-  is_album: boolean
-  is_private: boolean
-  tags?: string
-  genre: string // Again, could be a specific union type
-  mood: string // Specific union type for moods
-  release_date: string
-  license?: string
-  upc?: string
-  cover_art_url: string
-}
+export type TrackMetadata = mongoose.InferSchemaType<typeof trackMetadataSchema>
 
 const collectionMetadataSchema = new mongoose.Schema({
   playlist_name: { type: String, required: true },
@@ -155,31 +124,34 @@ const collectionMetadataSchema = new mongoose.Schema({
   license: { type: String },
   upc: { type: String },
   cover_art_url: { type: String, required: true },
+  cover_art_url_hash: { type: String, required: true },
+  cover_art_url_hash_algo: { type: String, required: true },
 })
 
-export interface CreateTrackRelease {
-  ddex_release_ref: string
-  metadata: TrackMetadata
-}
+export type CollectionMetadata = mongoose.InferSchemaType<
+  typeof collectionMetadataSchema
+>
 
-const createTrackReleaseSchema = new mongoose.Schema({
+export const createTrackReleaseSchema = new mongoose.Schema({
   ddex_release_ref: { type: String, required: true },
   metadata: { type: trackMetadataSchema, required: true },
 })
 
-export interface CreateAlbumRelease {
-  ddex_release_ref: string
-  tracks: TrackMetadata[]
-  metadata: CollectionMetadata
-}
+export type CreateTrackRelease = mongoose.InferSchemaType<
+  typeof createTrackReleaseSchema
+>
 
-const createAlbumReleaseSchema = new mongoose.Schema({
+export const createAlbumReleaseSchema = new mongoose.Schema({
   ddex_release_ref: { type: String, required: true },
   tracks: [trackMetadataSchema],
   metadata: { type: collectionMetadataSchema, required: true },
 })
 
-const pendingReleasesSchema = new mongoose.Schema({
+export type CreateAlbumRelease = mongoose.InferSchemaType<
+  typeof createAlbumReleaseSchema
+>
+
+export const pendingReleasesSchema = new mongoose.Schema({
   _id: { type: mongoose.Schema.Types.ObjectId, required: true },
   upload_etag: { type: String, required: true },
   delivery_id: { type: mongoose.Schema.Types.ObjectId, required: true },

--- a/packages/ddex/publisher/src/models/pendingReleases.ts
+++ b/packages/ddex/publisher/src/models/pendingReleases.ts
@@ -1,15 +1,195 @@
 import mongoose from 'mongoose'
 
-// Releases parsed from indexed DDEX deliveries that are awaiting publishing
-const pendingReleasesSchema = new mongoose.Schema({
-  id: mongoose.Schema.Types.ObjectId,
-  upload_etag: String,
-  delivery_id: mongoose.Schema.Types.ObjectId,
-  entity: String,
-  publish_date: Date,
-  created_at: Date,
+const genres = [
+  'All Genres',
+  'Electronic',
+  'Rock',
+  'Metal',
+  'Alternative',
+  'Hip-Hop/Rap',
+  'Experimental',
+  'Punk',
+  'Folk',
+  'Pop',
+  'Ambient',
+  'Soundtrack',
+  'World',
+  'Jazz',
+  'Acoustic',
+  'Funk',
+  'R&B/Soul',
+  'Devotional',
+  'Classical',
+  'Reggae',
+  'Podcasts',
+  'Country',
+  'Spoken Word',
+  'Comedy',
+  'Blues',
+  'Kids',
+  'Audiobooks',
+  'Latin',
+  'Lo-Fi',
+  'Hyperpop',
+  'Techno',
+  'Trap',
+  'House',
+  'Tech House',
+  'Deep House',
+  'Disco',
+  'Electro',
+  'Jungle',
+  'Progressive House',
+  'Hardstyle',
+  'Glitch Hop',
+  'Trance',
+  'Future Bass',
+  'Future House',
+  'Tropical House',
+  'Downtempo',
+  'Drum & Bass',
+  'Dubstep',
+  'Jersey Club',
+  'Vaporwave',
+  'Moombahton',
+]
+const moods = [
+  'Peaceful',
+  'Romantic',
+  'Sentimental',
+  'Tender',
+  'Easygoing',
+  'Yearning',
+  'Sophisticated',
+  'Sensual',
+  'Cool',
+  'Gritty',
+  'Melancholy',
+  'Serious',
+  'Brooding',
+  'Fiery',
+  'Defiant',
+  'Aggressive',
+  'Rowdy',
+  'Excited',
+  'Energizing',
+  'Empowering',
+  'Stirring',
+  'Upbeat',
+  'Other',
+]
+
+interface Artist {
+  name: string
+  roles: string[]
+}
+
+const artistSchema = new mongoose.Schema({
+  name: { type: String, required: true },
+  roles: [{ type: String }],
 })
 
+export interface TrackMetadata {
+  title: string
+  release_date: string // Assuming ISO date format as string
+  genre: string // This could be further refined to a union of the specific genre strings
+  duration: number
+  preview_start_seconds?: number
+  isrc?: string
+  license?: string
+  description?: string
+  mood?: string // This could be further refined to a union of the specific mood strings
+  tags?: string
+  artists: Artist[]
+  artist_name: string
+  copyright: string
+  preview_audio_file_url: string
+  audio_file_url: string
+  cover_art_url: string
+}
+
+const trackMetadataSchema = new mongoose.Schema({
+  title: { type: String, required: true },
+  release_date: { type: String, required: true }, // Assuming ISO date format as string
+  genre: { type: String, enum: genres, required: true },
+  duration: { type: Number, required: true },
+  preview_start_seconds: { type: Number },
+  isrc: { type: String },
+  license: { type: String },
+  description: { type: String },
+  mood: { type: String, enum: moods },
+  tags: { type: String },
+  artists: [artistSchema],
+  artist_name: { type: String, required: true },
+  copyright: { type: String, required: true },
+  preview_audio_file_url: { type: String, required: true },
+  audio_file_url: { type: String, required: true },
+  cover_art_url: { type: String, required: true },
+})
+
+export interface CollectionMetadata {
+  playlist_name: string
+  playlist_owner_id: string
+  description?: string
+  is_album: boolean
+  is_private: boolean
+  tags?: string
+  genre: string // Again, could be a specific union type
+  mood: string // Specific union type for moods
+  release_date: string
+  license?: string
+  upc?: string
+  cover_art_url: string
+}
+
+const collectionMetadataSchema = new mongoose.Schema({
+  playlist_name: { type: String, required: true },
+  playlist_owner_id: { type: String, required: true },
+  description: { type: String },
+  is_album: { type: Boolean, required: true },
+  is_private: { type: Boolean, required: true },
+  tags: { type: String },
+  genre: { type: String, enum: genres, required: true },
+  mood: { type: String, enum: moods, required: true },
+  release_date: { type: String, required: true }, // Assuming ISO date format as string
+  license: { type: String },
+  upc: { type: String },
+  cover_art_url: { type: String, required: true },
+})
+
+export interface CreateTrackRelease {
+  ddex_release_ref: string
+  metadata: TrackMetadata
+}
+
+const createTrackReleaseSchema = new mongoose.Schema({
+  ddex_release_ref: { type: String, required: true },
+  metadata: { type: trackMetadataSchema, required: true },
+})
+
+export interface CreateAlbumRelease {
+  ddex_release_ref: string
+  tracks: TrackMetadata[]
+  metadata: CollectionMetadata
+}
+
+const createAlbumReleaseSchema = new mongoose.Schema({
+  ddex_release_ref: { type: String, required: true },
+  tracks: [trackMetadataSchema],
+  metadata: { type: collectionMetadataSchema, required: true },
+})
+
+const pendingReleasesSchema = new mongoose.Schema({
+  _id: { type: mongoose.Schema.Types.ObjectId, required: true },
+  upload_etag: { type: String, required: true },
+  delivery_id: { type: mongoose.Schema.Types.ObjectId, required: true },
+  publish_date: { type: Date, required: true },
+  created_at: { type: Date, required: true },
+  create_track_release: { type: createTrackReleaseSchema, required: true },
+  create_album_release: { type: createAlbumReleaseSchema, required: true },
+})
+
+// Releases parsed from indexed DDEX deliveries that are awaiting publishing
 const PendingReleases = mongoose.model(
   'PendingReleases',
   pendingReleasesSchema,

--- a/packages/ddex/publisher/src/models/publishedReleases.ts
+++ b/packages/ddex/publisher/src/models/publishedReleases.ts
@@ -1,13 +1,20 @@
 import mongoose from 'mongoose'
+import {
+  createTrackReleaseSchema,
+  createAlbumReleaseSchema,
+} from './pendingReleases'
 
 // DDEX releases that have been published
 const publishedReleasesSchema = new mongoose.Schema({
-  id: mongoose.Schema.Types.ObjectId,
+  _id: mongoose.Schema.Types.ObjectId,
   upload_etag: String,
   delivery_id: mongoose.Schema.Types.ObjectId,
-  entity: String,
   publish_date: Date,
   entity_id: String,
+  blockhash: String,
+  blocknumber: Number,
+  track: createTrackReleaseSchema,
+  album: createAlbumReleaseSchema,
   created_at: Date,
 })
 

--- a/packages/ddex/publisher/src/services/publisherService.ts
+++ b/packages/ddex/publisher/src/services/publisherService.ts
@@ -2,8 +2,103 @@ import mongoose from 'mongoose'
 import Deliveries from '../models/deliveries'
 import PendingReleases from '../models/pendingReleases'
 import PublishedReleases from '../models/publishedReleases'
+import type {
+  TrackMetadata,
+  CollectionMetadata,
+  CreateTrackRelease,
+  CreateAlbumRelease,
+} from '../models/publishedReleases'
+import type {
+  AudiusSdk as AudiusSdkType,
+  UploadTrackRequest,
+  UploadAlbumRequest,
+} from '@audius/sdk/dist/sdk/index.d.ts'
 
-export const publishReleases = async () => {
+const getUserId = async (audiusSdk: AudiusSdkType, artistName: string) => {
+  const { data: users } = await audiusSdk.users.searchUsers({
+    query: artistName,
+  })
+  if (!users || users.length === 0) {
+    throw new Error(`Could not find user ${artistName}`)
+  }
+  return users[0].id
+}
+
+const formatTrackMetadata = (metadata: TrackMetadata) => {
+  return {
+    ...metadata,
+    releaseDate: new Date(metadata.release_date),
+    isUnlisted: false,
+    isPremium: false,
+    fieldVisibility: {
+      genre: true,
+      mood: true,
+      tags: true,
+      share: true,
+      play_count: true,
+      remixes: true,
+    },
+  }
+}
+
+const formatAlbumMetadata = (metadata: CollectionMetadata) => {
+  return {
+    ...metadata,
+    releaseDate: new Date(metadata.release_date),
+  }
+}
+
+const uploadTrack = async (
+  audiusSdk: AudiusSdkType,
+  pendingTrack: CreateTrackRelease
+) => {
+  const userId = await getUserId(audiusSdk, pendingTrack.metadata.artist_name)
+  const metadata = formatTrackMetadata(pendingTrack.metadata)
+
+  const uploadTrackRequest: UploadTrackRequest = {
+    userId,
+    // TODO pull from s3
+    coverArtFile: {},
+    metadata,
+    onProgress: (progress: any) => console.log('Progress:', progress),
+    // TODO pull from s3
+    trackFile: {},
+  }
+  console.log(
+    `Uploading ${pendingTrack.metadata.title} by ${pendingTrack.metadata.artist_name} to Audius...`
+  )
+  const result = await audiusSdk.tracks.uploadTrack(uploadTrackRequest)
+  console.log(result)
+  return result
+}
+
+const uploadAlbum = async (
+  audiusSdk: AudiusSdkType,
+  pendingAlbum: CreateAlbumRelease
+) => {
+  const trackMetadatas = pendingAlbum.tracks.map(
+    (trackMetadata: TrackMetadata) => formatTrackMetadata(trackMetadata)
+  )
+
+  const uploadAlbumRequest: UploadAlbumRequest = {
+    // TODO pull from s3
+    coverArtFile: {},
+    metadata: formatAlbumMetadata(pendingAlbum.metadata),
+    onProgress: (progress: any) => console.log('Progress:', progress),
+    // TODO pull from s3
+    trackFiles: {},
+    trackMetadatas,
+    userId: pendingAlbum.playlist_owner_id,
+  }
+  console.log(
+    `Uploading ${pendingAlbum.metadata.playlist_name} by ${pendingAlbum.metadata.playlist_owner_id} to Audius...`
+  )
+  const result = await audiusSdk.albums.uploadAlbum(uploadAlbumRequest)
+  console.log(result)
+  return result
+}
+
+export const publishReleases = async (audiusSdk: AudiusSdkType) => {
   // eslint-disable-next-line no-constant-condition
   while (true) {
     const currentDate = new Date()
@@ -17,15 +112,36 @@ export const publishReleases = async () => {
       }).session(session)
 
       for (const doc of documents) {
-        // TODO download audio/image files from "indexed" s3 bucket
-        // TODO publish release using SDK
+        let publishedData
+        if (doc.create_track_release) {
+          const uploadResult = await uploadTrack(
+            audiusSdk,
+            doc.create_track_release
+          )
+          publishedData = {
+            ...doc.toObject(),
+            entity_id: uploadResult.trackId,
+            blockhash: uploadResult.blockHash,
+            blocknumber: uploadResult.blockNumber,
+            created_at: new Date(),
+          }
+        } else if (doc.create_album_release) {
+          const uploadResult = await uploadAlbum(
+            audiusSdk,
+            doc.create_album_release
+          )
+          publishedData = {
+            ...doc.toObject(),
+            entity_id: uploadResult.albumId,
+            blockhash: uploadResult.blockHash,
+            blocknumber: uploadResult.blockNumber,
+            created_at: new Date(),
+          }
+        } else {
+          throw new Error('Missing track or album in pending release')
+        }
 
         // Move document to 'published_releases' collection
-        const publishedData = {
-          ...doc.toObject(),
-          entity_id: 'todo',
-          created_at: new Date(),
-        }
         const publishedRelease = new PublishedReleases(publishedData)
         await publishedRelease.save({ session })
         await PendingReleases.deleteOne({ _id: doc._id }).session(session)
@@ -34,7 +150,6 @@ export const publishReleases = async () => {
           delivery_id: doc.delivery_id,
           _id: { $ne: doc._id },
         }).session(session)
-
         if (remainingCount === 0) {
           // Update delivery_status in deliveries collection
           await Deliveries.updateOne(

--- a/packages/ddex/publisher/src/services/s3Service.ts
+++ b/packages/ddex/publisher/src/services/s3Service.ts
@@ -1,0 +1,41 @@
+import { S3Client, GetObjectCommand, S3ClientConfig } from '@aws-sdk/client-s3'
+
+export default function createS3() {
+  if (!process.env.AWS_ACCESS_KEY_ID || !process.env.AWS_SECRET_ACCESS_KEY) {
+    throw new Error('AWS_ACCESS_KEY_ID or AWS_SECRET_ACCESS_KEY not found')
+  }
+
+  const config: S3ClientConfig = {
+    credentials: {
+      accessKeyId: process.env.AWS_ACCESS_KEY_ID,
+      secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY,
+    },
+    region: process.env.AWS_REGION,
+  }
+  const indexedBucket = process.env.AWS_BUCKET_INDEXED
+  const client = new S3Client(config)
+
+  const downloadFromS3Indexed = async (key: string) => {
+    if (key.startsWith(`s3://${indexedBucket}/`)) {
+      key = key.slice(`s3://${indexedBucket}/`.length)
+    } else {
+      throw new Error(`Invalid key ${key} (not in indexed bucket)`)
+    }
+
+    const command = new GetObjectCommand({
+      Bucket: indexedBucket,
+      Key: key,
+    })
+    try {
+      const response = await client.send(command)
+
+      // Audius SDK expects a Buffer not a stream (Readable)
+      const byteArr = await response.Body!.transformToByteArray()
+      return Buffer.from(byteArr)
+    } catch (err) {
+      console.error(err)
+    }
+  }
+
+  return { downloadFromS3Indexed }
+}

--- a/packages/ddex/publisher/src/services/sdkService.ts
+++ b/packages/ddex/publisher/src/services/sdkService.ts
@@ -1,0 +1,84 @@
+import type {
+  AudiusSdk as AudiusSdkType,
+  ServicesConfig,
+} from '@audius/sdk/dist/sdk/index.d.ts'
+import {
+  AppAuth,
+  DiscoveryNodeSelector,
+  EntityManager,
+  Logger,
+  StorageNodeSelector,
+  developmentConfig,
+  stagingConfig,
+  productionConfig,
+  sdk,
+} from '@audius/sdk'
+
+export const createSdkService = () => {
+  let sdkInstance: AudiusSdkType | null = null
+
+  const ddexKey = process.env.DDEX_KEY
+  const ddexSecret = process.env.DDEX_SECRET
+  const env = process.env.NODE_ENV || 'development'
+  if (ddexKey && ddexSecret) {
+    try {
+      const logger = new Logger({ logLevel: 'info' })
+
+      // Determine config to use
+      let config = developmentConfig as ServicesConfig
+      let initialSelectedNode = 'http://audius-protocol-discovery-provider-1'
+      if (env === 'prod') {
+        config = productionConfig as ServicesConfig
+        initialSelectedNode = 'https://discoveryprovider.audius.co'
+      } else if (env === 'stage') {
+        config = stagingConfig as ServicesConfig
+        initialSelectedNode = 'https://discoveryprovider.staging.audius.co'
+      }
+
+      // Init SDK
+      const discoveryNodeSelector = new DiscoveryNodeSelector({
+        initialSelectedNode,
+      })
+      const storageNodeSelector = new StorageNodeSelector({
+        auth: new AppAuth(ddexKey, ddexSecret),
+        discoveryNodeSelector: discoveryNodeSelector,
+        bootstrapNodes: config.storageNodes,
+        logger,
+      })
+      sdkInstance = sdk({
+        services: {
+          discoveryNodeSelector,
+          entityManager: new EntityManager({
+            discoveryNodeSelector,
+            web3ProviderUrl: config.web3ProviderUrl,
+            contractAddress: config.entityManagerContractAddress,
+            identityServiceUrl: config.identityServiceUrl,
+            useDiscoveryRelay: true,
+            logger,
+          }),
+          storageNodeSelector,
+          logger,
+        },
+        apiKey: ddexKey,
+        apiSecret: ddexSecret,
+        appName: 'DDEX Publisher',
+      })
+      console.log(`SDK initialized for ${env}`)
+    } catch (error) {
+      console.error(`SDK failed to initialize for ${env}:`, error)
+    }
+  } else {
+    console.log('DDEX keys not configured. Skipping SDK initialization')
+  }
+
+  const getSdk = () => {
+    if (!sdkInstance) {
+      throw new Error('SDK not initialized')
+    }
+    return sdkInstance as AudiusSdkType
+  }
+
+  return {
+    getSdk,
+  }
+}

--- a/packages/ddex/webapp/client/src/components/Collection/Collection.tsx
+++ b/packages/ddex/webapp/client/src/components/Collection/Collection.tsx
@@ -126,7 +126,10 @@ const Table = ({
               <th>Upload E-tag</th>
               <th>Delivery ID</th>
               <th>Entity</th>
+              <th>Entity ID</th>
               <th>Publish Date</th>
+              <th>Blockhash</th>
+              <th>Blocknumber</th>
               <th>Created At</th>
             </tr>
           </thead>
@@ -143,6 +146,9 @@ const Table = ({
                       ? 'album'
                       : 'unknown'}
                 </td>
+                <td>{item.entity_id}</td>
+                <td>{item.blockhash}</td>
+                <td>{item.blocknumber}</td>
                 <td>{item.publish_date}</td>
                 <td>{item.created_at}</td>
               </tr>


### PR DESCRIPTION
### Description
- Makes the DDEX publisher app download files from S3 so it can upload them to Audius
- Fixes miscellaneous type issues to make SDK (mostly) accept uploads
- Improves Mongoose types to be simpler and to be able to compare publish_date vs now() accurately
- There's still an error blocking upload due to relay trying to use the DDEX app's key to find a username (instead of the user's wallet)

### How Has This Been Tested?
Running the publisher locally downloads the correct files and kicks off the SDK upload (gets past previous errors but fails due to unrelated existing relay bug mentioned above).