### PR TITLE
[PAY-2484] Ensure temporary download files are always deleted

### DIFF
--- a/packages/mobile/ios/Podfile.lock
+++ b/packages/mobile/ios/Podfile.lock
@@ -1703,7 +1703,7 @@ SPEC CHECKSUMS:
   Flipper-PeerTalk: 116d8f857dc6ef55c7a5a75ea3ceaafe878aadc9
   FlipperKit: 9f6df8cb028c2acd537ce24c1993aba142eceaf0
   fmt: ff9d55029c625d3757ed641535fd4a75fedc7ce9
-  glog: 035f1e36e53b355cf70f6434d161b36e7d21fecd
+  glog: c5d68082e772fa1c511173d6b30a9de2c05a69a2
   google-cast-sdk-dynamic-xcframework-no-bluetooth: 09d47191ef8821d82e813e754bcf98bc61a3dbc9
   hermes-engine: 34df9d5034e90bd9bf1505e1ca198760373935af
   JWT: ef71dfb03e1f842081e64dc42eef0e164f35d251

--- a/packages/mobile/ios/Podfile.lock
+++ b/packages/mobile/ios/Podfile.lock
@@ -1703,7 +1703,7 @@ SPEC CHECKSUMS:
   Flipper-PeerTalk: 116d8f857dc6ef55c7a5a75ea3ceaafe878aadc9
   FlipperKit: 9f6df8cb028c2acd537ce24c1993aba142eceaf0
   fmt: ff9d55029c625d3757ed641535fd4a75fedc7ce9
-  glog: c5d68082e772fa1c511173d6b30a9de2c05a69a2
+  glog: 035f1e36e53b355cf70f6434d161b36e7d21fecd
   google-cast-sdk-dynamic-xcframework-no-bluetooth: 09d47191ef8821d82e813e754bcf98bc61a3dbc9
   hermes-engine: 34df9d5034e90bd9bf1505e1ca198760373935af
   JWT: ef71dfb03e1f842081e64dc42eef0e164f35d251

--- a/packages/mobile/src/services/track-download.ts
+++ b/packages/mobile/src/services/track-download.ts
@@ -28,6 +28,14 @@ const cancelDownloadTask = () => {
   })
 }
 
+const removePathIfExists = async (path: string) => {
+  try {
+    const exists = await RNFetchBlob.fs.exists(path)
+    if (!exists) return
+    await RNFetchBlob.fs.unlink(path)
+  } catch {}
+}
+
 /**
  * Download a file via RNFetchBlob
  */
@@ -36,16 +44,13 @@ const downloadOne = async ({
   filename,
   directory,
   getFetchConfig,
-  onFetchComplete,
-  flushOnComplete = false
+  onFetchComplete
 }: {
   fileUrl: string
   filename: string
   directory: string
   getFetchConfig: (filePath: string) => RNFetchBlobConfig
   onFetchComplete?: (path: string) => Promise<void>
-  /** Automatically remove cached download after onFetchComplete. Should be `true` if the cached response is not used directly (i.e. iOS share flow) */
-  flushOnComplete?: boolean
 }) => {
   const filePath = directory + '/' + filename
 
@@ -67,18 +72,10 @@ const downloadOne = async ({
     dispatch(setVisibility({ drawer: 'DownloadTrackProgress', visible: false }))
 
     await onFetchComplete?.(fetchRes.path())
-    if (flushOnComplete) {
-      fetchRes.flush()
-    }
   } catch (err) {
     console.error(err)
-
     // On failure attempt to delete the file
-    try {
-      const exists = await RNFetchBlob.fs.exists(filePath)
-      if (!exists) return
-      await RNFetchBlob.fs.unlink(filePath)
-    } catch {}
+    removePathIfExists(filePath)
   }
 }
 
@@ -114,13 +111,9 @@ const downloadMany = async ({
     responses.forEach((response) => response.flush())
   } catch (err) {
     console.error(err)
-
-    // On failure attempt to delete the files
-    try {
-      const exists = await RNFetchBlob.fs.exists(directory)
-      if (!exists) return
-      await RNFetchBlob.fs.unlink(directory)
-    } catch {}
+  } finally {
+    // Remove source directory at the end of the process regardless of what happens
+    removePathIfExists(directory)
   }
 }
 
@@ -153,10 +146,16 @@ const download = async ({
 
   if (Platform.OS === 'ios') {
     const onFetchComplete = async (path: string) => {
-      dispatch(downloadFinished())
-      await Share.share({
-        url: path
-      })
+      try {
+        dispatch(downloadFinished())
+        await Share.share({
+          url: path
+        })
+      } finally {
+        // The fetched file is temporary on iOS and we always want to be sure to
+        // remove it.
+        removePathIfExists(path)
+      }
     }
     if (files.length === 1) {
       const { url, filename } = files[0]
@@ -171,7 +170,6 @@ const download = async ({
           fileCache: true,
           path: filePath
         }),
-        flushOnComplete: true,
         onFetchComplete
       })
     } else {


### PR DESCRIPTION
### Description
This cleans up the logic in `downloadTracks` on mobile to make sure we aren't leaving behind any temporary files or directories. I also realized that the `flush` function we were calling just defers to `fs.unlink` under the hood. So we can just remove the file using the path in the iOS implementation of `onFetchComplete`.


fixes PAY-2484

### How Has This Been Tested?
Tested locally on physical Android device and iOS Simulator against staging
