### PR TITLE
Fix structured data

### DIFF
--- a/packages/web/src/components/meta-tags/MetaTags.tsx
+++ b/packages/web/src/components/meta-tags/MetaTags.tsx
@@ -87,13 +87,17 @@ export const MetaTags = (props: MetaTagsProps) => {
         </Helmet>
       ) : null}
 
-      <meta property='og:type' content='website' />
-      <meta name='twitter:card' content='summary' />
+      <Helmet encodeSpecialCharacters={false}>
+        <meta property='og:type' content='website' />
+        <meta name='twitter:card' content='summary' />
+      </Helmet>
 
       {structuredData ? (
-        <script type='application/ld+json'>
-          {JSON.stringify(structuredData)}
-        </script>
+        <Helmet encodeSpecialCharacters={false}>
+          <script type='application/ld+json'>
+            {JSON.stringify(structuredData)}
+          </script>
+        </Helmet>
       ) : null}
     </>
   )


### PR DESCRIPTION
### Description

Google search console alerted us about unparsable structured data:
<img width="1224" alt="image" src="https://github.com/AudiusProject/audius-protocol/assets/19916043/74a017b4-2ab6-4233-862d-281f837adac1">

This was because the structured data script (and a couple other meta tags) were not enclosed in `Helmet`, causing them not to get injected into the header and the json to get incorrectly encoded

### How Has This Been Tested?

Confirmed that structured data is in header and properly encoded
