### PR TITLE
Fix patch of rive-react-native

### DIFF
--- a/package.json
+++ b/package.json
@@ -100,7 +100,8 @@
   },
   "dependencies": {
     "@escape.tech/mookme": "2.4.1",
-    "pg": "8.8.0"
+    "pg": "8.8.0",
+    "rive-react-native": "6.2.1"
   },
   "overrides": {
     "@types/prop-types": "15.7.5",

--- a/packages/mobile/ios/Podfile.lock
+++ b/packages/mobile/ios/Podfile.lock
@@ -1418,7 +1418,7 @@ DEPENDENCIES:
   - React-runtimescheduler (from `../node_modules/react-native/ReactCommon/react/renderer/runtimescheduler`)
   - React-utils (from `../node_modules/react-native/ReactCommon/react/utils`)
   - ReactCommon/turbomodule/core (from `../node_modules/react-native/ReactCommon`)
-  - rive-react-native (from `../node_modules/rive-react-native`)
+  - rive-react-native (from `../../../node_modules/rive-react-native`)
   - rn-fetch-blob (from `../../../node_modules/rn-fetch-blob`)
   - RNBootSplash (from `../node_modules/react-native-bootsplash`)
   - "RNCAsyncStorage (from `../../../node_modules/@react-native-async-storage/async-storage`)"
@@ -1633,7 +1633,7 @@ EXTERNAL SOURCES:
   ReactCommon:
     :path: "../node_modules/react-native/ReactCommon"
   rive-react-native:
-    :path: "../node_modules/rive-react-native"
+    :path: "../../../node_modules/rive-react-native"
   rn-fetch-blob:
     :path: "../../../node_modules/rn-fetch-blob"
   RNBootSplash:
@@ -1703,7 +1703,7 @@ SPEC CHECKSUMS:
   Flipper-PeerTalk: 116d8f857dc6ef55c7a5a75ea3ceaafe878aadc9
   FlipperKit: 9f6df8cb028c2acd537ce24c1993aba142eceaf0
   fmt: ff9d55029c625d3757ed641535fd4a75fedc7ce9
-  glog: 035f1e36e53b355cf70f6434d161b36e7d21fecd
+  glog: c5d68082e772fa1c511173d6b30a9de2c05a69a2
   google-cast-sdk-dynamic-xcframework-no-bluetooth: 09d47191ef8821d82e813e754bcf98bc61a3dbc9
   hermes-engine: 34df9d5034e90bd9bf1505e1ca198760373935af
   JWT: ef71dfb03e1f842081e64dc42eef0e164f35d251


### PR DESCRIPTION
### Description
https://audius-internal.slack.com/archives/C03AC9YNR5M/p1707522052832709

Patches are failing to apply causing a build error on main. This happened bc `rive-react-native` was unhoisted in this pr https://github.com/AudiusProject/audius-protocol/commit/15d6102273fdeaa4cf96e67098d1d8d0f9b35fcd

Fix is to manually hoist rive-react-native

Hopefully will have a working mvp of PNPM soon which would solve the underlying issue. Also another issue I want to address is that when 1 patch fails the others fail, and CI continues as though it was successful: https://linear.app/audius/issue/INF-644/fix-issue-where-one-failing-patch-causes-others-not-to-apply-in-ci

### How Has This Been Tested?

Confirmed patches apply successfully
