### PR TITLE
[PAY-2414] Remove manual mime type specification for Android downloads

### DIFF
--- a/packages/mobile/src/services/track-download.ts
+++ b/packages/mobile/src/services/track-download.ts
@@ -200,7 +200,6 @@ const download = async ({
           addAndroidDownloads: {
             description: filename,
             mediaScannable: true,
-            mime: 'audio/mpeg',
             notification: true,
             path: filePath,
             title: filename,


### PR DESCRIPTION
### Description
We don't need to manually specify mime type for downloads. As we thought, the content type in the fetch request works just fine. I was able to download mp3s for compressed versions and both a WAV and AIFF for lossless versions on Android.

fixes PAY-2414

### How Has This Been Tested?
Tested locally on physical device against staging
