### PR TITLE
Uses selected DN node for trpc endpoint

### DIFF
--- a/packages/web/src/utils/trpcClientWeb.ts
+++ b/packages/web/src/utils/trpcClientWeb.ts
@@ -6,11 +6,14 @@ import { env } from 'services/env'
 
 export const trpc = createTRPCReact<AppRouter>()
 
-export function createAudiusTrpcClient(currentUserId: number | null) {
+export function createAudiusTrpcClient(
+  selectedEndpoint: string,
+  currentUserId: number | null
+) {
   return trpc.createClient({
     links: [
       httpBatchLink({
-        url: getTrpcEndpoint(),
+        url: selectedEndpoint || getTrpcEndpoint(),
         maxURLLength: 2083,
         headers() {
           if (!currentUserId) return {}


### PR DESCRIPTION
### Description

Uses DN selector `getSelectedNode` for tRPC client.

The biggest downside to this PR is that on first run, `selectedNode` will be `''` and it will instantiate trpc client with fallback (which is the hardcoded DN3 URL).

After `useEffect` runs and gets the selected DN, it will re-create trpc client with new endpoint, and re-request the data.  In practice on the feed, this means one duplicate request in practice when testing locally.

Moreover, if selected DN changes, this will keep using the old value.

This _could_ be a good use-case for [signals](https://preactjs.com/guide/v10/signals/) or some similar observable thing.

Anyway I think there must be a better way lmk if you have any ideas.
