### PR TITLE
[PAY-2468] Dedup filenames during download

### DIFF
--- a/packages/common/src/utils/fileUtils.ts
+++ b/packages/common/src/utils/fileUtils.ts
@@ -41,7 +41,10 @@ export const dedupFilenames = (files: DownloadFile[]) => {
   const filenameCounts = new Map<string, number>()
   for (const file of files) {
     const count = filenameCounts.get(file.filename) ?? 0
-    file.filename = count === 0 ? file.filename : `${file.filename}-${count}`
     filenameCounts.set(file.filename, count + 1)
+    const split = file.filename.split('.')
+    const extension = split.pop()
+    file.filename =
+      count === 0 ? file.filename : split.join('.') + `-${count}.${extension}`
   }
 }

--- a/packages/common/src/utils/fileUtils.ts
+++ b/packages/common/src/utils/fileUtils.ts
@@ -1,6 +1,7 @@
 import { Buffer } from 'buffer'
 
 import { Nullable } from './typeUtils'
+import { DownloadFile } from '~/services'
 
 /** Convert a base64 string to a file object */
 export const dataURLtoFile = async (
@@ -33,5 +34,14 @@ export const getDownloadFilename = ({
     const split = filename.split('.')
     split.pop()
     return `${split.join('.')}.mp3`
+  }
+}
+
+export const dedupFilenames = (files: DownloadFile[]) => {
+  const filenameCounts = new Map<string, number>()
+  for (const file of files) {
+    const count = filenameCounts.get(file.filename) ?? 0
+    file.filename = count === 0 ? file.filename : `${file.filename}-${count}`
+    filenameCounts.set(file.filename, count + 1)
   }
 }

--- a/packages/mobile/src/services/track-download.ts
+++ b/packages/mobile/src/services/track-download.ts
@@ -15,6 +15,7 @@ import { setFetchCancel, setFileInfo } from 'app/store/download/slice'
 import { setVisibility } from 'app/store/drawers/slice'
 
 import { audiusBackendInstance } from './audius-backend-instance'
+import { dedupFilenames } from '~/utils'
 
 const { downloadFinished } = tracksSocialActions
 
@@ -96,6 +97,7 @@ const downloadMany = async ({
   getFetchConfig: (filePath: string) => RNFetchBlobConfig
   onFetchComplete?: (path: string) => Promise<void>
 }) => {
+  dedupFilenames(files)
   try {
     const responsePromises = files.map(({ url, filename }) =>
       RNFetchBlob.config(getFetchConfig(directory + '/' + filename)).fetch(

--- a/packages/web/src/services/track-download.ts
+++ b/packages/web/src/services/track-download.ts
@@ -7,6 +7,7 @@ import { tracksSocialActions } from '@audius/common/store'
 import { downloadZip } from 'client-zip'
 
 import { audiusBackendInstance } from './audius-backend/audius-backend-instance'
+import { dedupFilenames } from '@audius/common/utils'
 
 const { downloadFinished } = tracksSocialActions
 
@@ -41,6 +42,7 @@ class TrackDownload extends TrackDownloadBase {
     rootDirectoryName,
     abortSignal
   }: DownloadTrackArgs) {
+    dedupFilenames(files)
     const responsePromises = files.map(
       async ({ url }) => await window.fetch(url, { signal: abortSignal })
     )


### PR DESCRIPTION
### Description
Append -1, -2 to filenames when there are multiples with the same name.
Haven't tested with more than 2 dups (upload currently broken on stage).

### How Has This Been Tested?

Tested on stage
<img width="473" alt="Screenshot 2024-02-12 at 2 59 17 PM" src="https://github.com/AudiusProject/audius-protocol/assets/3893871/5b7a6881-4647-4422-a2d3-c6bce07bd97f">

