### PR TITLE
[PAY-2486] Change Email: Copy changes and current email screen on mobile

### DIFF
--- a/packages/mobile/src/screens/change-email-screen/SubScreens.tsx
+++ b/packages/mobile/src/screens/change-email-screen/SubScreens.tsx
@@ -13,7 +13,7 @@ import { SubScreenHeader } from '../change-password-screen/SubScreenHeader'
 
 const messages = {
   changeYourEmail: 'Change Your Email',
-  confirmPasswordHelp: 'Please enter your current email and password.',
+  confirmPasswordHelp: 'Please enter your current password.',
   currentEmail: 'Current Email',
   currentPassword: 'Current Password',
   newEmailHelp: 'Enter the new email you would like to use on Audius.',
@@ -75,6 +75,12 @@ export const NewEmailSubScreen = () => {
         title={messages.changeYourEmail}
         description={messages.newEmailHelp}
       />
+      <Box>
+        <Text variant='label' size={'xs'}>
+          {messages.currentEmail}
+        </Text>
+        <CurrentEmail />
+      </Box>
       <HarmonyTextField
         name='email'
         label={messages.newEmail}

--- a/packages/web/src/components/change-email/ChangeEmailModal.tsx
+++ b/packages/web/src/components/change-email/ChangeEmailModal.tsx
@@ -36,7 +36,7 @@ import styles from './ChangeEmailModal.module.css'
 
 const messages = {
   changeEmail: 'Change Email',
-  confirmPasswordHelp: 'Please enter your current email and password.',
+  confirmPasswordHelp: 'Please enter your current password.',
   currentEmail: 'Current Email',
   currentPassword: 'Current Password',
   newEmailHelp: 'Enter the new email you would like to use on Audius.',


### PR DESCRIPTION
### Description

PAY-2486

- Change copy from "Please enter your current email and password." to "Please enter your current password."
- Add current email on the "new email" screen on mobile (whoops!)
