### PR TITLE
Fix native handle field floating on the wrong side

### DIFF
--- a/packages/mobile/src/harmony-native/components/input/TextInput/TextInput.tsx
+++ b/packages/mobile/src/harmony-native/components/input/TextInput/TextInput.tsx
@@ -335,6 +335,7 @@ export const TextInput = forwardRef(
                       underlineColorAndroid='transparent'
                       aria-label={ariaLabel ?? labelText}
                       style={css({
+                        flex: 1,
                         // Need absolute height to ensure consistency across platforms
                         height: !isSmall ? 23 : undefined,
                         // Android has a default padding that needs to be removed


### PR DESCRIPTION
### Description
Fixed the harmony handle field floating on the wrong side

![image](https://github.com/AudiusProject/audius-protocol/assets/6711655/85c0baf5-0310-4d05-bf8b-ef812f029589)


### How Has This Been Tested?

ios:stage
