### PR TITLE
[C-3659] Float continue button above keyboard on native OTP

### DIFF
--- a/packages/mobile/src/components/core/KeyboardAvoidingView.tsx
+++ b/packages/mobile/src/components/core/KeyboardAvoidingView.tsx
@@ -14,7 +14,7 @@ const useStyles = makeStyles(({ spacing, palette, typography }) => ({
 }))
 
 type KeyboardAvoidingViewProps = {
-  style: StyleProp<ViewStyle>
+  style?: StyleProp<ViewStyle>
   keyboardShowingDuration?: number
   keyboardHidingDuration?: number
   // Offset is subtracted from the desired height when the keyboard is showing.

--- a/packages/mobile/src/screens/sign-on-screen/components/layout.tsx
+++ b/packages/mobile/src/screens/sign-on-screen/components/layout.tsx
@@ -86,7 +86,7 @@ export const PageFooter = (props: PageFooterProps) => {
     >
       {/* Prefixes float above the shadowed paper container  */}
       {prefix ? <Flex ph={gutterSize}>{prefix}</Flex> : null}
-      <KeyboardAvoidContainer style={{}} keyboardShowingOffset={spacing.unit5}>
+      <KeyboardAvoidContainer keyboardShowingOffset={spacing.unit5}>
         <Paper
           p='l'
           justifyContent='center'

--- a/packages/mobile/src/screens/sign-on-screen/components/layout.tsx
+++ b/packages/mobile/src/screens/sign-on-screen/components/layout.tsx
@@ -2,7 +2,7 @@ import type { ReactNode } from 'react'
 
 import { css } from '@emotion/native'
 import { useFormikContext } from 'formik'
-import { Dimensions } from 'react-native'
+import { Dimensions, View } from 'react-native'
 import { useSafeAreaInsets } from 'react-native-safe-area-context'
 
 import type {
@@ -11,7 +11,8 @@ import type {
   PaperProps,
   ButtonProps
 } from '@audius/harmony-native'
-import { Button, Flex, Paper, Text } from '@audius/harmony-native'
+import { Button, Flex, Paper, Text, useTheme } from '@audius/harmony-native'
+import { KeyboardAvoidingView } from 'app/components/core'
 
 const messages = {
   continue: 'Continue'
@@ -62,12 +63,15 @@ type PageFooterProps = {
   postfix?: ReactNode
   buttonProps?: Partial<ButtonProps>
   centered?: boolean
+  avoidKeyboard?: boolean
 } & Omit<PaperProps & BoxProps, 'prefix'>
 
 export const PageFooter = (props: PageFooterProps) => {
-  const { prefix, postfix, buttonProps, ...other } = props
+  const { prefix, postfix, buttonProps, avoidKeyboard, ...other } = props
   const insets = useSafeAreaInsets()
+  const { spacing } = useTheme()
   const { handleSubmit, dirty, isValid } = useFormikContext() ?? {}
+  const KeyboardAvoidContainer = avoidKeyboard ? KeyboardAvoidingView : View
 
   return (
     <Flex
@@ -82,30 +86,32 @@ export const PageFooter = (props: PageFooterProps) => {
     >
       {/* Prefixes float above the shadowed paper container  */}
       {prefix ? <Flex ph={gutterSize}>{prefix}</Flex> : null}
-      <Paper
-        p='l'
-        justifyContent='center'
-        gap='l'
-        alignItems='center'
-        direction='column'
-        shadow='midInverted'
-        style={css({
-          borderRadius: 0,
-          paddingBottom: insets.bottom
-        })}
-        {...other}
-      >
-        <Button
-          fullWidth
-          disabled={!dirty || !isValid}
-          onPress={() => handleSubmit?.()}
-          {...buttonProps}
+      <KeyboardAvoidContainer style={{}} keyboardShowingOffset={spacing.unit5}>
+        <Paper
+          p='l'
+          justifyContent='center'
+          gap='l'
+          alignItems='center'
+          direction='column'
+          shadow='midInverted'
+          style={css({
+            borderRadius: 0,
+            paddingBottom: insets.bottom
+          })}
+          {...other}
         >
-          {messages.continue}
-        </Button>
-        {/* postfixes live insde the paper */}
-        {postfix}
-      </Paper>
+          <Button
+            fullWidth
+            disabled={!dirty || !isValid}
+            onPress={() => handleSubmit?.()}
+            {...buttonProps}
+          >
+            {messages.continue}
+          </Button>
+          {/* postfixes live insde the paper */}
+          {postfix}
+        </Paper>
+      </KeyboardAvoidContainer>
     </Flex>
   )
 }

--- a/packages/mobile/src/screens/sign-on-screen/screens/ConfirmEmailScreen.tsx
+++ b/packages/mobile/src/screens/sign-on-screen/screens/ConfirmEmailScreen.tsx
@@ -17,7 +17,6 @@ import { useDispatch, useSelector } from 'react-redux'
 import { toFormikValidationSchema } from 'zod-formik-adapter'
 
 import { Text, TextLink } from '@audius/harmony-native'
-import { KeyboardAvoidingView } from 'app/components/core'
 import { HarmonyTextField } from 'app/components/fields'
 import { useToast } from 'app/hooks/useToast'
 

--- a/packages/mobile/src/screens/sign-on-screen/screens/ConfirmEmailScreen.tsx
+++ b/packages/mobile/src/screens/sign-on-screen/screens/ConfirmEmailScreen.tsx
@@ -17,6 +17,7 @@ import { useDispatch, useSelector } from 'react-redux'
 import { toFormikValidationSchema } from 'zod-formik-adapter'
 
 import { Text, TextLink } from '@audius/harmony-native'
+import { KeyboardAvoidingView } from 'app/components/core'
 import { HarmonyTextField } from 'app/components/fields'
 import { useToast } from 'app/hooks/useToast'
 
@@ -64,7 +65,11 @@ export const ConfirmEmailScreen = () => {
         <Text variant='body'>
           {confirmEmailMessages.noEmailNotice} <ResendCodeLink />
         </Text>
-        <PageFooter shadow='flat' buttonProps={{ isLoading: isSubmitting }} />
+        <PageFooter
+          shadow='flat'
+          buttonProps={{ isLoading: isSubmitting }}
+          avoidKeyboard
+        />
       </Page>
     </Formik>
   )


### PR DESCRIPTION
### Description

![2024-02-12 16 16 12](https://github.com/AudiusProject/audius-protocol/assets/6711655/db77623e-727b-4340-8482-c6e7dd507d6f)

### How Has This Been Tested?

ios:simulator
