### PR TITLE
Don't render InputAccessoryView on non-iOS platforms

### DIFF
--- a/packages/mobile/src/harmony-native/components/input/TextInput/TextInputAccessoryView.tsx
+++ b/packages/mobile/src/harmony-native/components/input/TextInput/TextInputAccessoryView.tsx
@@ -1,7 +1,7 @@
 import { css } from '@emotion/native'
 import { BlurView } from '@react-native-community/blur'
 import type { InputAccessoryViewProps } from 'react-native'
-import { InputAccessoryView, Keyboard } from 'react-native'
+import { InputAccessoryView, Keyboard, Platform } from 'react-native'
 
 import { useTheme } from '@audius/harmony-native'
 import { TextButton } from 'app/components/core'
@@ -12,6 +12,11 @@ const messages = {
 
 export const TextInputAccessoryView = (props: InputAccessoryViewProps) => {
   const { type, spacing } = useTheme()
+
+  if (Platform.OS !== 'ios') {
+    // InputAccessoryView is only available on iOS
+    return null
+  }
 
   return (
     <InputAccessoryView {...props}>


### PR DESCRIPTION
### Description

Conditionally not render `InputAccessoryView` based on platform