### PR TITLE
[PAY-2465] Fix contextual menu stems

### DIFF
--- a/packages/mobile/src/components/core/ContextualMenu.tsx
+++ b/packages/mobile/src/components/core/ContextualMenu.tsx
@@ -84,8 +84,8 @@ export const ContextualMenu = (props: ContextualMenuProps) => {
 
     return (
       <View style={styles.optionPills}>
-        {values.map((value) => (
-          <Pill key={value} style={styles.pill}>
+        {values.map((value, i) => (
+          <Pill key={`${value}-${i}`} style={styles.pill}>
             <Text
               fontSize='small'
               weight='demiBold'

--- a/packages/web/src/pages/upload-page/fields/StemsAndDownloadsField.tsx
+++ b/packages/web/src/pages/upload-page/fields/StemsAndDownloadsField.tsx
@@ -57,7 +57,7 @@ const { getUserId } = accountSelectors
 const messages = {
   title: 'Stems & Downloads',
   description:
-    'Upload your track’s source files and customize how fans download your files.',
+    "Upload your track's source files and customize how fans download your files.",
   values: {
     allowDownload: 'Full Track Available',
     allowOriginal: 'Lossless Files Available',
@@ -307,10 +307,12 @@ export const StemsAndDownloadsField = ({
 
     return (
       <SelectedValues>
-        {values.map((value) => {
+        {values.map((value, i) => {
           const valueProps =
             typeof value === 'string' ? { label: value } : value
-          return <SelectedValue key={valueProps.label} {...valueProps} />
+          return (
+            <SelectedValue key={`${valueProps.label}-${i}`} {...valueProps} />
+          )
         })}
       </SelectedValues>
     )


### PR DESCRIPTION
### Description

Because `value` was used as the key for this react component, you could end up with duplicated line items for stems with the same names.

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._

```
npm run web:stage
npm run ios:stage
```