### PR TITLE
[PAY-2472] Make USDCManualTransfer modal buy button actually buy

### DIFF
--- a/packages/web/src/components/premium-content-purchase-modal/PremiumContentPurchaseModal.tsx
+++ b/packages/web/src/components/premium-content-purchase-modal/PremiumContentPurchaseModal.tsx
@@ -7,9 +7,11 @@ import {
   usePayExtraPresets,
   isTrackStreamPurchaseable,
   isTrackDownloadPurchaseable,
-  PurchaseableTrackMetadata
+  PurchaseableTrackMetadata,
+  PURCHASE_METHOD
 } from '@audius/common/hooks'
 import {
+  PurchaseMethod,
   PurchaseVendor,
   Track,
   USDCPurchaseConditions
@@ -28,7 +30,7 @@ import { USDC } from '@audius/fixed-decimal'
 import { Flex, IconCart } from '@audius/harmony'
 import { ModalContentPages, ModalFooter, ModalHeader } from '@audius/stems'
 import cn from 'classnames'
-import { Formik, useFormikContext } from 'formik'
+import { Formik, useField, useFormikContext } from 'formik'
 import { useDispatch, useSelector } from 'react-redux'
 import { toFormikValidationSchema } from 'zod-formik-adapter'
 
@@ -89,9 +91,10 @@ const RenderForm = ({
   } = purchaseConditions
   const { error, isUnlocking, purchaseSummaryValues, stage, page } =
     usePurchaseContentFormState({ price })
+  const [, , { setValue: setPurchaseMethod }] = useField(PURCHASE_METHOD)
   const currentPageIndex = pageToPageIndex(page)
 
-  const { resetForm } = useFormikContext()
+  const { submitForm, resetForm } = useFormikContext()
   const { history } = useHistoryContext()
 
   // Reset form on track change
@@ -104,9 +107,14 @@ const RenderForm = ({
     }
   }, [stage, permalink, dispatch, history])
 
-  const handleClose = useCallback(() => {
+  const handleUSDCManualTransferClose = useCallback(() => {
     dispatch(setPurchasePage({ page: PurchaseContentPage.PURCHASE }))
   }, [dispatch])
+
+  const handleUSDCManualTransferPurchase = useCallback(() => {
+    setPurchaseMethod(PurchaseMethod.BALANCE)
+    submitForm()
+  }, [submitForm, setPurchaseMethod])
 
   return (
     <ModalForm className={cn(styles.modalRoot, { [styles.mobile]: isMobile })}>
@@ -156,7 +164,11 @@ const RenderForm = ({
             </Flex>
           </Flex>
         </>
-        <USDCManualTransfer onClose={handleClose} amountInCents={price} />
+        <USDCManualTransfer
+          onClose={handleUSDCManualTransferClose}
+          amountInCents={price}
+          onPurchase={handleUSDCManualTransferPurchase}
+        />
       </ModalContentPages>
       <ModalFooter className={styles.footer}>
         {page === PurchaseContentPage.PURCHASE ? (

--- a/packages/web/src/components/usdc-manual-transfer/USDCManualTransfer.tsx
+++ b/packages/web/src/components/usdc-manual-transfer/USDCManualTransfer.tsx
@@ -46,10 +46,12 @@ const messages = {
 
 export const USDCManualTransfer = ({
   onClose,
-  amountInCents
+  amountInCents,
+  onPurchase
 }: {
   onClose: () => void
   amountInCents?: number
+  onPurchase?: () => void
 }) => {
   const stage = useSelector(getPurchaseContentFlowStage)
   const error = useSelector(getPurchaseContentError)
@@ -130,6 +132,7 @@ export const USDCManualTransfer = ({
               color='lightGreen'
               disabled={isBuyButtonDisabled}
               type='submit'
+              onClick={onPurchase}
             >
               {messages.buy(
                 USDC(amount).toLocaleString('en-us', {


### PR DESCRIPTION
### Description

This was never wired up

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._

```
npm run web:stage
```
1. Visit $2 track w/ $1 in balance
2. Select Manual Crypto Transfer
3. Send $1 when and then click Buy when the button turns green
4. Purchase goes through