### PR TITLE
[PAY-2478] Add overshoot clamping to drawer close

### DIFF
--- a/packages/mobile/src/components/drawer/Drawer.tsx
+++ b/packages/mobile/src/components/drawer/Drawer.tsx
@@ -368,6 +368,7 @@ export const Drawer: DrawerComponent = ({
         value: position,
         drawerHeight,
         animationStyle,
+        overshootClamping: true,
         finished: ({ finished }) => {
           if (finished) {
             onFinished?.()
@@ -381,7 +382,8 @@ export const Drawer: DrawerComponent = ({
           animation: borderRadiusAnim.current,
           value: BORDER_RADIUS,
           drawerHeight,
-          animationStyle
+          animationStyle,
+          overshootClamping: true
         })
       }
       if (shouldBackgroundDim) {


### PR DESCRIPTION
### Description

Currently when you close a drawer, there's a decent bit of time for the spring animation for settle and the `onClosed` handler to get called. This can give bugs like the one at hand where errors don't seem to clear from previous incarnations of the same drawer (though they are correctly cleared on the `onClosed` handler).

Adding overshoot clamping to the drawer slide-out animations solves this because `onClosed` fires much sooner (though still after the drawer slides out fully).

I don't think this has any adverse effects... but lmk if you have ideas!

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._

```
npm run ios:stage
```

Manually added a throw new Error() in the coinflow purchase flow and was able to repro the bug when closing and opening the drawer quickly.