### PR TITLE
Remove extra horizontal padding from SegmentedControl tabs

### DIFF
--- a/packages/harmony/src/components/segmented-control/SegmentedControl.module.css
+++ b/packages/harmony/src/components/segmented-control/SegmentedControl.module.css
@@ -15,7 +15,7 @@
 .tab {
   z-index: 3;
   flex: 1 1 auto;
-  padding: var(--harmony-unit-2) var(--harmony-unit-4);
+  padding: var(--harmony-unit-2);
   border-radius: 4px;
   cursor: pointer;
   user-select: none;


### PR DESCRIPTION
### Description
The extra padding breaks layout in at least one place that uses SegmentedControl. It's not necessary for now, and all the usages can be updated when we formally migrate SegmentedControl to its Harmony spec.

### How Has This Been Tested?
Verified locally against staging.
