### PR TITLE
[C-3769] Fix where condition for aggregate_user query.

### DIFF
--- a/packages/discovery-provider/src/tasks/update_aggregates.py
+++ b/packages/discovery-provider/src/tasks/update_aggregates.py
@@ -247,9 +247,7 @@ new_aggregate_user as (
     left join user_following ufollowing on ap.user_id = ufollowing.user_id
     left join user_save us on ap.user_id = us.user_id
     left join user_repost ur on ap.user_id = ur.user_id
-    left join ranked_genres rg on ap.user_id = rg.user_id
-  where
-    rg.genre_rank = 1
+    left join ranked_genres rg on ap.user_id = rg.user_id AND rg.genre_rank = 1
 )
 update
   aggregate_user au


### PR DESCRIPTION
The `where rg.genre_rank = 1` condition to select the dominant genre would omit updates for any [user with no tracks](https://linear.app/audius/issue/C-3769/%5Bqa%5D-profile-track-number-not-updating)...

Move this instead to a join condition on the left join.