### PR TITLE
Fix action-button alignment

### DIFF
--- a/packages/mobile/src/components/details-tile/DetailsTileActionButtons.tsx
+++ b/packages/mobile/src/components/details-tile/DetailsTileActionButtons.tsx
@@ -134,6 +134,8 @@ export const DetailsTileActionButtons = ({
       onPress={onPressShare}
       aria-label={messages.shareButtonLabel}
       size='2xl'
+      // TODO: Remove after AnimatedButton uses IconButton
+      style={{ padding: 0 }}
     />
   )
 
@@ -144,6 +146,8 @@ export const DetailsTileActionButtons = ({
       onPress={onPressOverflow}
       aria-label={messages.overflowButtonLabel}
       size='2xl'
+      // TODO: Remove after AnimatedButton uses IconButton
+      style={{ padding: 0 }}
     />
   )
 


### PR DESCRIPTION
### Description

Fixes issue where action-buttons were misaligned due to IconButton and AnimatedButton having different default heights. Temporarily updates IconButton height to be equal to AnimatedButton in the action-button row. Long term, AnimatedButton should have same properties as IconButton.
