### PR TITLE
Relax timeout for re-doing transcode

### DIFF
--- a/mediorum/server/transcode.go
+++ b/mediorum/server/transcode.go
@@ -170,22 +170,22 @@ func (ss *MediorumServer) findMissedJobs(work chan *Upload, myHost string, retra
 		if myRank == 2 {
 			// no recent update?
 			timedOut = upload.Status == busyStatus &&
-				time.Since(upload.TranscodedAt) > time.Minute
+				time.Since(upload.TranscodedAt) > time.Minute*3
 
 			// never started?
 			neverStarted = upload.Status == newStatus &&
-				time.Since(upload.CreatedAt) > time.Minute*2
+				time.Since(upload.CreatedAt) > time.Minute*6
 		}
 
 		// for #3 rank worker:
 		if myRank == 3 {
 			// no recent update?
 			timedOut = upload.Status == busyStatus &&
-				time.Since(upload.TranscodedAt) > time.Minute*5
+				time.Since(upload.TranscodedAt) > time.Minute*7
 
 			// never started?
 			neverStarted = upload.Status == newStatus &&
-				time.Since(upload.CreatedAt) > time.Minute*5
+				time.Since(upload.CreatedAt) > time.Minute*14
 		}
 
 		if timedOut {

--- a/mediorum/server/upload_client.go
+++ b/mediorum/server/upload_client.go
@@ -59,6 +59,10 @@ func (ss *MediorumServer) startUploadScroller() {
 				uploadCursor.After = upload.CreatedAt
 			}
 
+			if len(uploads) == 0 {
+				continue
+			}
+
 			// write overwrites
 			err = ss.crud.DB.Clauses(clause.OnConflict{UpdateAll: true}).Create(overwrites).Error
 			if err != nil {


### PR DESCRIPTION
### Description

Quick fix for a situation where #2 mirror was retranscoding the same file repeatedly...

Because R=5 and file is sent to peers one at a time, for a large audio file it can take over a minute to send to all peers, but the  `findMissedJobs` would run and if it had been 1 minute since last update, #2 would restart job.

So increase that timeout a bit.

Some better fixes:
* mirror files in parallel
* add a upload lock in local transcode queue, don't re-add an item if it's in the pipeline

Also:
* only send transcode progress updates if `progress - lastProgress > 0.1` to chill out the crudr push frequency a bit