### PR TITLE
Bypass errors on health check for autoheal

### DIFF
--- a/packages/discovery-provider/Dockerfile.prod
+++ b/packages/discovery-provider/Dockerfile.prod
@@ -88,7 +88,4 @@ ENV audius_loggly_tags=$audius_loggly_tags
 
 EXPOSE 5000
 
-HEALTHCHECK --interval=5s --timeout=10s --retries=12 \
-  CMD pgrep pg_migrate || curl -f http://localhost:5000/health_check || exit 1
-
 CMD ["bash", "scripts/start.sh"]

--- a/packages/discovery-provider/src/queries/get_health.py
+++ b/packages/discovery-provider/src/queries/get_health.py
@@ -195,6 +195,7 @@ def get_health(args: GetHealthArgs, use_redis_cache: bool = True) -> Tuple[Dict,
     redis = redis_connection.get_redis()
     web3 = web3_provider.get_web3()
 
+    bypass_errors = args.get("bypass_errors")
     verbose = args.get("verbose")
     enforce_block_diff = args.get("enforce_block_diff")
     qs_healthy_block_diff = cast(Optional[int], args.get("healthy_block_diff"))
@@ -475,7 +476,7 @@ def get_health(args: GetHealthArgs, use_redis_cache: bool = True) -> Tuple[Dict,
         if not api_healthy:
             errors.append(f"api unhealthy: {reason}")
 
-    is_unhealthy = (
+    is_unhealthy = not bypass_errors and (
         unhealthy_blocks
         or unhealthy_challenges
         or play_health_info["is_unhealthy"]

--- a/packages/discovery-provider/src/queries/health_check.py
+++ b/packages/discovery-provider/src/queries/health_check.py
@@ -42,6 +42,7 @@ def version():
 @bp.route("/health_check", methods=["GET"])
 def health_check():
     args = {
+        "bypass_errors": parse_bool_param(request.args.get("bypass_errors")),
         "verbose": parse_bool_param(request.args.get("verbose")),
         "healthy_block_diff": request.args.get("healthy_block_diff", type=int),
         "enforce_block_diff": parse_bool_param(request.args.get("enforce_block_diff")),


### PR DESCRIPTION
### Description
Found cases where server container is stuck in a restart loop. If health check has any errors, it restarts from autoheal. The container health should represent if the server is reach-able, regardless of error status as those errors come from indexing. This should make the server container more stable. 

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._

Tested on sandbox. Forced errors and confirmed bypass_errors prevent restart loop.