### PR TITLE
Add time limit for payment router

### DIFF
--- a/packages/discovery-provider/src/tasks/index_payment_router.py
+++ b/packages/discovery-provider/src/tasks/index_payment_router.py
@@ -916,7 +916,7 @@ def process_payment_router_txs() -> None:
 
 
 # ####### CELERY TASKS ####### #
-@celery.task(name="index_payment_router", time_limit=60, bind=True)
+@celery.task(name="index_payment_router", time_limit=300, bind=True)
 @save_duration_metric(metric_group="celery_task")
 def index_payment_router(self):
     # Cache custom task class properties

--- a/packages/discovery-provider/src/tasks/index_payment_router.py
+++ b/packages/discovery-provider/src/tasks/index_payment_router.py
@@ -916,7 +916,7 @@ def process_payment_router_txs() -> None:
 
 
 # ####### CELERY TASKS ####### #
-@celery.task(name="index_payment_router", bind=True)
+@celery.task(name="index_payment_router", time_limit=60, bind=True)
 @save_duration_metric(metric_group="celery_task")
 def index_payment_router(self):
     # Cache custom task class properties


### PR DESCRIPTION
### Description

I think there's a memory leak in payment router maybe in this change https://github.com/AudiusProject/audius-protocol/pull/7510/files. This task appears to be bringing down the whole discovery node. Adding a hard time_limit to the task to try to prevent this. 5 minutes seems ample.

https://docs.celeryq.dev/en/stable/reference/celery.app.task.html#celery.app.task.Task.time_limit


### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._

Tested on stage DN1. index_payment_router is indexing.