### PR TITLE
Patch decimal return type serialization

### DIFF
--- a/packages/discovery-provider/src/queries/get_remixable_tracks.py
+++ b/packages/discovery-provider/src/queries/get_remixable_tracks.py
@@ -67,7 +67,8 @@ def get_remixable_tracks(args):
         tracks = []
         for result in results:
             track = result[0]
-            score = result[-1]
+            # Convert decimal to float for serialization
+            score = float(result[-1])
             track = helpers.model_to_dictionary(track)
             track["score"] = score
             tracks.append(track)

--- a/packages/discovery-provider/src/queries/get_top_playlists.py
+++ b/packages/discovery-provider/src/queries/get_top_playlists.py
@@ -138,7 +138,8 @@ def get_top_playlists_sql(kind: TopPlaylistKind, args: GetTopPlaylistsArgs):
             for result in playlist_results:
                 # The playlist is the portion of the query result before repost_count and score
                 playlist = result[0:-2]
-                score = result[-1]
+                # Convert decimal to float for serialization
+                score = float(result[-1])
 
                 # Convert the playlist row tuple into a dictionary keyed by column name
                 playlist = helpers.tuple_to_model_dictionary(playlist, Playlist)


### PR DESCRIPTION
### Description

Presumably something changed either in sql alchemy or postgres that leads score to be a `Decimal` class type rather than an integer. Python floats are 64 bit which is plenty, so this is safe.

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._

Manually edited stage dn1 and fixed the query
https://discoveryprovider.staging.audius.co/v1/full/tracks/remixables?limit=1&user_id=bQJdO&with_users=true