### PR TITLE
Fix follow-gated download row on web

### DIFF
--- a/packages/mobile/src/screens/track-screen/DownloadRow.tsx
+++ b/packages/mobile/src/screens/track-screen/DownloadRow.tsx
@@ -12,8 +12,7 @@ import { PlainButton } from 'app/harmony-native/components/Button/PlainButton/Pl
 const { getTrack } = cacheTracksSelectors
 
 const messages = {
-  fullTrack: 'Full Track',
-  followToDownload: 'Must follow artist to download.'
+  fullTrack: 'Full Track'
 }
 
 type DownloadRowProps = {

--- a/packages/web/src/components/track/DownloadRow.tsx
+++ b/packages/web/src/components/track/DownloadRow.tsx
@@ -26,6 +26,7 @@ type DownloadRowProps = {
   onDownload: (args: { trackIds: ID[]; parentTrackId?: ID }) => void
   isOriginal: boolean
   trackId?: ID
+  parentTrackId?: ID
   hideDownload?: boolean
   index: number
   size?: number
@@ -38,6 +39,7 @@ export const DownloadRow = ({
   onDownload,
   isOriginal,
   trackId,
+  parentTrackId,
   hideDownload,
   index,
   size,
@@ -50,9 +52,9 @@ export const DownloadRow = ({
     shallowEqual
   )
   const downloadableContentAccess = useDownloadableContentAccess({
-    trackId: trackId ?? 0
+    trackId: parentTrackId ?? trackId ?? 0
   })
-  const { shouldDisplayDownloadFollowGated } = trackId
+  const { shouldDisplayDownloadFollowGated } = parentTrackId
     ? downloadableContentAccess
     : { shouldDisplayDownloadFollowGated: false }
 

--- a/packages/web/src/components/track/DownloadSection.tsx
+++ b/packages/web/src/components/track/DownloadSection.tsx
@@ -299,6 +299,7 @@ export const DownloadSection = ({ trackId }: DownloadSectionProps) => {
             {track?.is_downloadable ? (
               <DownloadRow
                 trackId={trackId}
+                parentTrackId={trackId}
                 onDownload={handleDownload}
                 index={ORIGINAL_TRACK_INDEX}
                 hideDownload={shouldHideDownload}
@@ -309,6 +310,7 @@ export const DownloadSection = ({ trackId }: DownloadSectionProps) => {
             {stemTracks.map((s, i) => (
               <DownloadRow
                 trackId={s.id}
+                parentTrackId={trackId}
                 key={s.id}
                 onDownload={handleDownload}
                 hideDownload={shouldHideDownload}


### PR DESCRIPTION
### Description
Bug was that on tracks with follow-gated downloadable content, the stem rows would show the download button as enabled, while the original track's download button would be disabled. Fix is to pass in `parentTrackId` and calculate the UI flags from that.

### How Has This Been Tested?

<img width="1097" alt="Screenshot 2024-02-14 at 1 06 40 PM" src="https://github.com/AudiusProject/audius-protocol/assets/3893871/d8ace0c4-f41a-4ec7-93f7-5c052d7a7f11">

