### PR TITLE
[C-3709 C-3814] Fix native text aligment issues

### DIFF
--- a/packages/harmony/src/components/text/Text/constants.ts
+++ b/packages/harmony/src/components/text/Text/constants.ts
@@ -31,7 +31,7 @@ export const variantStylesMap = {
   },
   label: {
     fontSize: { xs: '2xs', s: 'xs', m: 's', l: 'm', xl: 'xl' },
-    lineHeight: { xs: 'xs', s: 'xs', m: 's', l: 's', xl: 'l' },
+    lineHeight: { xs: 'xs', s: 's', m: 's', l: 'm', xl: 'l' },
     fontWeight: { default: 'bold', strong: 'heavy' },
     css: { textTransform: 'uppercase' as const, letterSpacing: 0.5 }
   },

--- a/packages/mobile/src/harmony-native/components/Text/Text.tsx
+++ b/packages/mobile/src/harmony-native/components/Text/Text.tsx
@@ -4,7 +4,7 @@ import { variantStylesMap } from '@audius/harmony/src/components/text'
 import type { BaseTextProps } from '@audius/harmony/src/components/text'
 import { css } from '@emotion/native'
 import type { TextProps as NativeTextProps, TextStyle } from 'react-native'
-import { Text as TextBase } from 'react-native'
+import { Platform, Text as TextBase } from 'react-native'
 
 import { useTheme } from '../../foundations/theme'
 
@@ -34,6 +34,8 @@ export const Text = forwardRef<TextBase, TextProps>((props, ref) => {
   const variantStyles = variant && variantStylesMap[variant]
   const t = theme.typography
 
+  const fontWeight = variantStyles?.fontWeight[strength]
+
   const textStyles: TextStyle = css({
     ...(variantStyles && {
       fontSize: t.size[variantStyles.fontSize[size]],
@@ -43,7 +45,11 @@ export const Text = forwardRef<TextBase, TextProps>((props, ref) => {
     }),
     ...(color && { color }),
     ...(shadow && t.shadow[shadow]),
-    textAlign
+    textAlign,
+    // Fixes demiBold text misalignment on iOS
+    ...(fontWeight === 'demiBold' && Platform.OS === 'ios'
+      ? { marginTop: 2 }
+      : {})
   })
 
   const isHeading = variant === 'display' || variant === 'heading'


### PR DESCRIPTION
### Description

Fixes issue where label text other than medium size has poor alignment. This is due to the configured lineHeight. I updated it to a reasonable value that prevents the issue, and will follow up with design to officially change the line-height in harmony.

Fixes issue where demiBold text in iOS has a weird alignment issue, that is resolved by adding marginTop: 2px. This is pretty awkward so going to check with design if the font asset maybe has an issue.
