### PR TITLE
Dedupe tracks in album and fix broken import

### DIFF
--- a/packages/ddex/ingester/parser/parser.go
+++ b/packages/ddex/ingester/parser/parser.go
@@ -83,6 +83,11 @@ func (p *Parser) processDelivery(changeStream *mongo.ChangeStream) {
 	}
 	p.logger.Info("Parsed delivery", "createTrackRelease", fmt.Sprintf("%+v", createTrackRelease), "createAlbumRelease", fmt.Sprintf("%+v", createAlbumRelease))
 
+	// If there's an album release, the tracks we parsed out are actually part of the album release
+	if len(createAlbumRelease) > 0 {
+		createTrackRelease = []common.CreateTrackRelease{}
+	}
+
 	// TODO: We can loop through each release and validate if its URLs exist in the delivery.
 	//       However, the DDEX spec actually says that a delivery can leave out the assets and just have the metadata (assuming they'll do another delivery with the assets closer to release date).
 
@@ -101,7 +106,7 @@ func (p *Parser) processDelivery(changeStream *mongo.ChangeStream) {
 				"upload_etag":          delivery.UploadETag,
 				"delivery_id":          delivery.ID,
 				"create_track_release": track,
-				"publish_date":         track.Metadata.ReleaseDate, // TODO: Use time instead of string so it can be queried properly
+				"publish_date":         track.Metadata.ReleaseDate,
 				"created_at":           time.Now(),
 			}
 			result, err := p.pendingReleasesColl.InsertOne(p.ctx, pendingRelease)
@@ -116,7 +121,7 @@ func (p *Parser) processDelivery(changeStream *mongo.ChangeStream) {
 				"upload_etag":          delivery.UploadETag,
 				"delivery_id":          delivery.ID,
 				"create_album_release": album,
-				"publish_date":         album.Metadata.ReleaseDate, // TODO: Use time instead of string so it can be queried properly
+				"publish_date":         album.Metadata.ReleaseDate,
 				"created_at":           time.Now(),
 			}
 			result, err := p.pendingReleasesColl.InsertOne(p.ctx, pendingRelease)

--- a/packages/ddex/publisher/src/services/publisherService.ts
+++ b/packages/ddex/publisher/src/services/publisherService.ts
@@ -1,5 +1,3 @@
-/* eslint-disable @typescript-eslint/no-unused-vars */
-import aws from 'aws-sdk'
 import mongoose from 'mongoose'
 import Deliveries from '../models/deliveries'
 import PendingReleases from '../models/pendingReleases'
@@ -19,6 +17,7 @@ import type {
 } from '@audius/sdk/dist/sdk/index.d.ts'
 import createS3 from './s3Service'
 
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 const getUserId = async (audiusSdk: AudiusSdkType, artistName: string) => {
   // TODO: We previously did it like this, but the results are too random and don't return the user with an exact match as users[0].
   // In the future, we could check all OAuthed usernames for an exact match and cross-reference SDK's search results to find a rough match if no exact match was found


### PR DESCRIPTION
### Description
- Removes an old leftover import which was breaking CI
- Avoids uploading individual tracks when a delivery contains an album release, which is my interpretation of [this](https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-releaseresourcework-metadata/trackreleases/) and [this](https://kb.ddex.net/implementing-each-standard/best-practices-for-all-ddex-standards/guidance-on-releaseresourcework-metadata/release-types-for-trackreleases/). This will have to be more thorough in the future to use the actual `Deal` elements to determine visibility of each track in the album, but the matching up of `DealType`s to our metadata isn't figured out yet.