### PR TITLE
[PAY-2498] Fix multiple download warning in web

### DIFF
--- a/packages/web/src/components/track/DownloadSection.tsx
+++ b/packages/web/src/components/track/DownloadSection.tsx
@@ -139,13 +139,6 @@ export const DownloadSection = ({ trackId }: DownloadSectionProps) => {
           trackIds,
           quality
         })
-        dispatch(
-          socialTracksActions.downloadTrack({
-            trackIds,
-            parentTrackId,
-            original: quality === DownloadQuality.ORIGINAL
-          })
-        )
         const trackEvent: TrackEvent = make(Name.TRACK_PAGE_DOWNLOAD, {
           id: parentTrackId ?? trackIds[0],
           parent_track_id: parentTrackId

--- a/packages/web/src/components/track/DownloadSection.tsx
+++ b/packages/web/src/components/track/DownloadSection.tsx
@@ -19,7 +19,6 @@ import {
   usePremiumContentPurchaseModal,
   CommonState,
   useWaitForDownloadModal,
-  tracksSocialActions as socialTracksActions,
   toastActions
 } from '@audius/common/store'
 import { USDC } from '@audius/fixed-decimal'


### PR DESCRIPTION
### Description

Wasn't removed in https://github.com/AudiusProject/audius-protocol/pull/7583 which moved behavior to the wait for download modal.

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._

```
npm run web:stage
```
+ download all. chrome notif is no longer present for multiple downloads.