### PR TITLE
[C-3821] Fix native double save

### DIFF
--- a/packages/mobile/src/screens/favorites-screen/TracksTab.tsx
+++ b/packages/mobile/src/screens/favorites-screen/TracksTab.tsx
@@ -123,6 +123,7 @@ export const TracksTab = () => {
     // Need to fetch saves when the filterValue or selectedCategory (by way of fetchSaves) changes
     if (isReachable) {
       fetchSaves()
+      setFetchPage((fetchPage) => fetchPage + 1)
     }
   }, [isReachable, fetchSaves])
 

--- a/packages/web/src/common/store/pages/saved/lineups/sagas.ts
+++ b/packages/web/src/common/store/pages/saved/lineups/sagas.ts
@@ -60,9 +60,10 @@ function* getTracks({ offset, limit }: { offset: number; limit: number }) {
   }, {})
 
   const localLibraryAdditions = yield* select(getSelectedCategoryLocalTrackAdds)
-  const localLibraryAdditionsTrackIds = Object.keys(
-    localLibraryAdditions
-  ).filter((savedTrackId) => !savedTrackTimestamps[savedTrackId])
+  const localLibraryAdditionsTrackIds = Object.keys(localLibraryAdditions)
+    .filter((savedTrackId) => !savedTrackTimestamps[savedTrackId])
+    .map((trackId) => parseInt(trackId, 10))
+
   const localLibraryAdditionsTimestamps = localLibraryAdditionsTrackIds.reduce(
     (map, saveId) => {
       map[saveId] = Date.now()
@@ -75,7 +76,7 @@ function* getTracks({ offset, limit }: { offset: number; limit: number }) {
 
   if (isNativeMobile && offset !== 0) {
     allSavedTrackIds = savedTrackIds.filter(
-      (s) => !localLibraryAdditionsTrackIds.includes(String(s))
+      (s) => !localLibraryAdditionsTrackIds.includes(s)
     )
   } else {
     allSavedTrackIds = uniq([

--- a/packages/web/src/common/store/pages/saved/lineups/sagas.ts
+++ b/packages/web/src/common/store/pages/saved/lineups/sagas.ts
@@ -71,10 +71,19 @@ function* getTracks({ offset, limit }: { offset: number; limit: number }) {
     {}
   )
 
-  const allSavedTrackIds = uniq([
-    ...localLibraryAdditionsTrackIds,
-    ...savedTrackIds
-  ])
+  let allSavedTrackIds: (number | string)[] = []
+
+  if (isNativeMobile && offset !== 0) {
+    allSavedTrackIds = savedTrackIds.filter(
+      (s) => !localLibraryAdditionsTrackIds.includes(String(s))
+    )
+  } else {
+    allSavedTrackIds = uniq([
+      ...localLibraryAdditionsTrackIds,
+      ...savedTrackIds
+    ])
+  }
+
   const allSavedTrackTimestamps = {
     ...localLibraryAdditionsTimestamps,
     ...savedTrackTimestamps

--- a/packages/web/src/common/store/pages/saved/lineups/sagas.ts
+++ b/packages/web/src/common/store/pages/saved/lineups/sagas.ts
@@ -62,7 +62,7 @@ function* getTracks({ offset, limit }: { offset: number; limit: number }) {
   const localLibraryAdditions = yield* select(getSelectedCategoryLocalTrackAdds)
   const localLibraryAdditionsTrackIds = Object.keys(localLibraryAdditions)
     .filter((savedTrackId) => !savedTrackTimestamps[savedTrackId])
-    .map((trackId) => parseInt(trackId, 10))
+    .map((trackId) => Number(trackId))
 
   const localLibraryAdditionsTimestamps = localLibraryAdditionsTrackIds.reduce(
     (map, saveId) => {

--- a/packages/web/src/common/store/pages/signon/sagas.ts
+++ b/packages/web/src/common/store/pages/signon/sagas.ts
@@ -516,7 +516,7 @@ function* signUp() {
 
         if (isNativeMobile && !isSignUpRedesignEnabled) {
           yield* put(requestPushNotificationPermissions())
-        } else if (!isNativeMobile) {
+        } else {
           // Set the has request browser permission to true as the signon provider will open it
           setHasRequestedBrowserPermission()
         }

--- a/packages/web/src/common/store/pages/signon/sagas.ts
+++ b/packages/web/src/common/store/pages/signon/sagas.ts
@@ -516,7 +516,7 @@ function* signUp() {
 
         if (isNativeMobile && !isSignUpRedesignEnabled) {
           yield* put(requestPushNotificationPermissions())
-        } else {
+        } else if (!isNativeMobile) {
           // Set the has request browser permission to true as the signon provider will open it
           setHasRequestedBrowserPermission()
         }


### PR DESCRIPTION
### Description

Fixes a few issues where local saves and remote saves can be duplicated.

The first issue was due to an issue where we dont increase the favorited tracks lineup page after the first request, this means that we accidently fire off two "fetchLineup" requests back to back, since the "fetchMore" function always fetches since page is still at 0.

The second issue was related to the saved/lineup/saga.ts always adding localLibrary additions to the beginning of the fetched tracks, meaning every paginated request would unconditionally include localLibrary tracks, which we actually only want on the first fetch.

Additionally we fixed an issue where localLibraryTrackIds was `string[]` and savedTrackIds was `number[]` meaning our `uniq()` call would technically never remove duplicate tracks.

Taken together this should reduce the probability of duplicate favorited tracks appearing in the users library!