### PR TITLE
Log active tasks and mem usage

### DIFF
--- a/packages/discovery-provider/scripts/start.sh
+++ b/packages/discovery-provider/scripts/start.sh
@@ -63,6 +63,15 @@ else
         # start other workers with remaining CPUs
         audius_service=worker celery -A src.worker.celery worker --max-memory-per-child 300000 --loglevel "$audius_discprov_loglevel" --concurrency=$(($(nproc) - 5)) 2>&1 | tee >(logger -t worker) &
 
+        while [[ "$audius_discprov_env" == "stage" ]]; do
+            # log active tasks and mem to find mem leaks
+            sleep 60
+            active_tasks=$(celery -A src.worker.celery inspect active --timeout 60)
+            mem_usage=$(top -b -n 1)
+            echo "$active_tasks"
+            echo "$mem_usage"
+        done &
+
     fi
 fi
 


### PR DESCRIPTION
### Description

We're seeing OOM in the indexer container coming from a non index_nethermind celery task. This will help find which tasks have a memory leak.

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._

Tested on sandbox. 