### PR TITLE
Indexers fetch confirmed sol txs instead of finalized

### DIFF
--- a/packages/discovery-provider/src/solana/solana_client_manager.py
+++ b/packages/discovery-provider/src/solana/solana_client_manager.py
@@ -110,7 +110,7 @@ class SolanaClientManager:
                             before,
                             until,
                             limit,
-                            Commitment("finalized"),
+                            Commitment("confirmed"),
                         )
                     )
                     return transactions
@@ -141,7 +141,7 @@ class SolanaClientManager:
             num_retries = retries
             while num_retries > 0:
                 try:
-                    response = client.get_slot(Commitment("finalized"))
+                    response = client.get_slot(Commitment("confirmed"))
                     return response.value
                 except Exception as e:
                     logger.error(


### PR DESCRIPTION
### Description
This should be safe and should make indexing grab solana transactions quicker

"confirmed" should work: https://github.com/michaelhly/solana-py/blob/36ab2b5343d3f45cbe562df86e2d04101e101e71/src/solana/rpc/commitment.py#L16

### How Has This Been Tested?

Untested, test on stage