### PR TITLE
[PAY-2503] Fix mobile crypto transfer purchase flow

### DIFF
--- a/packages/common/src/store/purchase-content/sagas.ts
+++ b/packages/common/src/store/purchase-content/sagas.ts
@@ -481,7 +481,7 @@ function* doStartPurchaseContentFlow({
 
     switch (purchaseMethod) {
       case PurchaseMethod.BALANCE:
-      case PurchaseMethod.CRYPTO:
+      case PurchaseMethod.CRYPTO: {
         // Invariant: The user must have enough funds
         if (balanceNeeded.gtn(0)) {
           throw new PurchaseContentError(
@@ -500,7 +500,8 @@ function* doStartPurchaseContentFlow({
           purchaseAccess
         })
         break
-      case PurchaseMethod.CARD:
+      }
+      case PurchaseMethod.CARD: {
         const purchaseAmount = (price + (extraAmount ?? 0)) / 100.0
         switch (purchaseVendor) {
           case PurchaseVendor.COINFLOW:
@@ -531,6 +532,7 @@ function* doStartPurchaseContentFlow({
             break
         }
         break
+      }
     }
 
     // Mark the purchase as successful


### PR DESCRIPTION
### Description

The real issue was just that we never handled PurchaseMethod.CRYPTO here, but I refactored this code so that it uses a switch statement where the typecheck would have protected us.

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._

```
npm run android:stage
```