### PR TITLE
Fix audius-cmd health check

### DIFF
--- a/dev-tools/compose/docker-compose.discovery.prod.yml
+++ b/dev-tools/compose/docker-compose.discovery.prod.yml
@@ -153,7 +153,7 @@ services:
     healthcheck:
       test: [
           "CMD-SHELL",
-          "pgrep pg_migrate || curl -f http://localhost:5000/health_check?bypass_errors=true || exit 1"
+          "pgrep pg_migrate || curl -f http://localhost:5000/health_check || exit 1"
         ]
     depends_on:
       db:

--- a/dev-tools/compose/docker-compose.discovery.prod.yml
+++ b/dev-tools/compose/docker-compose.discovery.prod.yml
@@ -150,6 +150,11 @@ services:
       - eth-contracts-abis:/audius-discovery-provider/build/eth-contracts
       - solana-programs-idl:/audius-discovery-provider/idl
       - ${PROJECT_ROOT}/dev-tools:/tmp/dev-tools
+    healthcheck:
+      test: [
+          "CMD-SHELL",
+          "pgrep pg_migrate || curl -f http://localhost:5000/health_check?bypass_errors=true || exit 1"
+        ]
     depends_on:
       db:
         condition: service_healthy


### PR DESCRIPTION
### Description

This PR: https://github.com/AudiusProject/audius-protocol/pull/7582
Most likely broke audius-cmd because there is no health check protecting audius-compose from coming up and resolving before discovery is healthy.

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._

Wait for CI