### PR TITLE
Make user bank indexer run ever 1s instead of 5

### DIFF
--- a/packages/discovery-provider/src/app.py
+++ b/packages/discovery-provider/src/app.py
@@ -369,7 +369,7 @@ def configure_celery(celery, test_config=None):
             },
             "index_user_bank": {
                 "task": "index_user_bank",
-                "schedule": timedelta(seconds=5),
+                "schedule": timedelta(seconds=1),
             },
             "index_payment_router": {
                 "task": "index_payment_router",


### PR DESCRIPTION
### Description

Match parity with payment router. Most of the runs are no-ops anyways.

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._
