### PR TITLE
Drop dashboard wallet users blockhash fkey

### DIFF
--- a/packages/discovery-provider/ddl/migrations/0052_remove_dashboard_wallet_users_fkey.sql
+++ b/packages/discovery-provider/ddl/migrations/0052_remove_dashboard_wallet_users_fkey.sql
@@ -1,2 +1,2 @@
 ALTER TABLE dashboard_wallet_users
-DROP CONSTRAINT dashboard_wallet_users_blockhash_fkey;
+DROP CONSTRAINT IF EXISTS dashboard_wallet_users_blockhash_fkey;

--- a/packages/discovery-provider/ddl/migrations/0052_remove_dashboard_wallet_users_fkey.sql
+++ b/packages/discovery-provider/ddl/migrations/0052_remove_dashboard_wallet_users_fkey.sql
@@ -1,0 +1,2 @@
+ALTER TABLE dashboard_wallet_users
+DROP CONSTRAINT dashboard_wallet_users_blockhash_fkey;

--- a/packages/discovery-provider/src/models/grants/developer_app.py
+++ b/packages/discovery-provider/src/models/grants/developer_app.py
@@ -16,7 +16,7 @@ from src.models.model_utils import RepresentableMixin
 class DeveloperApp(Base, RepresentableMixin):
     __tablename__ = "developer_apps"
 
-    blockhash = Column(Text, ForeignKey("blocks.blockhash"), nullable=False)
+    blockhash = Column(Text, nullable=False)
     blocknumber = Column(Integer, ForeignKey("blocks.number"), nullable=False)
     address = Column(String, primary_key=True, nullable=False, index=True)
     user_id = Column(Integer, nullable=True)

--- a/packages/discovery-provider/src/models/grants/grant.py
+++ b/packages/discovery-provider/src/models/grants/grant.py
@@ -16,7 +16,7 @@ from src.models.model_utils import RepresentableMixin
 class Grant(Base, RepresentableMixin):
     __tablename__ = "grants"
 
-    blockhash = Column(Text, ForeignKey("blocks.blockhash"), nullable=False)
+    blockhash = Column(Text, nullable=False)
     blocknumber = Column(Integer, ForeignKey("blocks.number"), nullable=False)
     grantee_address = Column(String, primary_key=True, nullable=False)
     user_id = Column(Integer, primary_key=True, nullable=False)

--- a/packages/discovery-provider/src/models/playlists/playlist.py
+++ b/packages/discovery-provider/src/models/playlists/playlist.py
@@ -21,7 +21,7 @@ from src.models.users.user import User
 class Playlist(Base, RepresentableMixin):
     __tablename__ = "playlists"
 
-    blockhash = Column(Text, ForeignKey("blocks.blockhash"), nullable=False)
+    blockhash = Column(Text, nullable=False)
     blocknumber = Column(
         Integer, ForeignKey("blocks.number"), index=True, nullable=False
     )

--- a/packages/discovery-provider/src/models/playlists/playlist.py
+++ b/packages/discovery-provider/src/models/playlists/playlist.py
@@ -52,9 +52,6 @@ class Playlist(Base, RepresentableMixin):
     slot = Column(Integer)
     metadata_multihash = Column(String)
 
-    block = relationship(  # type: ignore
-        "Block", primaryjoin="Playlist.blockhash == Block.blockhash"
-    )
     block1 = relationship(  # type: ignore
         "Block", primaryjoin="Playlist.blocknumber == Block.number"
     )

--- a/packages/discovery-provider/src/models/social/follow.py
+++ b/packages/discovery-provider/src/models/social/follow.py
@@ -27,7 +27,7 @@ class Follow(Base, RepresentableMixin):
         ),
     )
 
-    blockhash = Column(Text, ForeignKey("blocks.blockhash"), nullable=False)
+    blockhash = Column(Text, nullable=False)
     blocknumber = Column(
         Integer, ForeignKey("blocks.number"), index=True, nullable=False
     )

--- a/packages/discovery-provider/src/models/social/follow.py
+++ b/packages/discovery-provider/src/models/social/follow.py
@@ -44,9 +44,6 @@ class Follow(Base, RepresentableMixin):
     )
     slot = Column(Integer)
 
-    block = relationship(  # type: ignore
-        "Block", primaryjoin="Follow.blockhash == Block.blockhash"
-    )
     block1 = relationship(  # type: ignore
         "Block", primaryjoin="Follow.blocknumber == Block.number"
     )

--- a/packages/discovery-provider/src/models/social/repost.py
+++ b/packages/discovery-provider/src/models/social/repost.py
@@ -58,9 +58,6 @@ class Repost(Base, RepresentableMixin):
     )
     slot = Column(Integer)
 
-    block = relationship(  # type: ignore
-        "Block", primaryjoin="Repost.blockhash == Block.blockhash"
-    )
     block1 = relationship(  # type: ignore
         "Block", primaryjoin="Repost.blocknumber == Block.number"
     )

--- a/packages/discovery-provider/src/models/social/repost.py
+++ b/packages/discovery-provider/src/models/social/repost.py
@@ -31,7 +31,7 @@ class Repost(Base, RepresentableMixin):
         Index("repost_user_id_idx", "user_id", "repost_type"),
     )
 
-    blockhash = Column(Text, ForeignKey("blocks.blockhash"), nullable=False)
+    blockhash = Column(Text, nullable=False)
     blocknumber = Column(
         Integer, ForeignKey("blocks.number"), index=True, nullable=False
     )

--- a/packages/discovery-provider/src/models/social/save.py
+++ b/packages/discovery-provider/src/models/social/save.py
@@ -56,9 +56,6 @@ class Save(Base, RepresentableMixin):
     )
     slot = Column(Integer)
 
-    block = relationship(  # type: ignore
-        "Block", primaryjoin="Save.blockhash == Block.blockhash"
-    )
     block1 = relationship(  # type: ignore
         "Block", primaryjoin="Save.blocknumber == Block.number"
     )

--- a/packages/discovery-provider/src/models/social/save.py
+++ b/packages/discovery-provider/src/models/social/save.py
@@ -31,7 +31,7 @@ class Save(Base, RepresentableMixin):
         Index("save_user_id_idx", "user_id", "save_type"),
     )
 
-    blockhash = Column(Text, ForeignKey("blocks.blockhash"), nullable=False)
+    blockhash = Column(Text, nullable=False)
     blocknumber = Column(
         Integer, ForeignKey("blocks.number"), index=True, nullable=False
     )

--- a/packages/discovery-provider/src/models/tracks/track.py
+++ b/packages/discovery-provider/src/models/tracks/track.py
@@ -27,7 +27,7 @@ from src.models.users.user import User
 class Track(Base, RepresentableMixin):
     __tablename__ = "tracks"
 
-    blockhash = Column(Text, ForeignKey("blocks.blockhash"), nullable=False)
+    blockhash = Column(Text, nullable=False)
     blocknumber = Column(
         Integer, ForeignKey("blocks.number"), index=True, nullable=False
     )

--- a/packages/discovery-provider/src/models/tracks/track.py
+++ b/packages/discovery-provider/src/models/tracks/track.py
@@ -88,9 +88,6 @@ class Track(Base, RepresentableMixin):
     is_playlist_upload = Column(Boolean, nullable=False, server_default=text("false"))
     ai_attribution_user_id = Column(Integer, nullable=True)
 
-    block = relationship(  # type: ignore
-        "Block", primaryjoin="Track.blockhash == Block.blockhash"
-    )
     block1 = relationship(  # type: ignore
         "Block", primaryjoin="Track.blocknumber == Block.number"
     )

--- a/packages/discovery-provider/src/models/users/user.py
+++ b/packages/discovery-provider/src/models/users/user.py
@@ -24,7 +24,7 @@ from src.models.model_utils import (
 class User(Base, RepresentableMixin):
     __tablename__ = "users"
 
-    blockhash = Column(Text, ForeignKey("blocks.blockhash"), nullable=False)
+    blockhash = Column(Text, nullable=False)
     blocknumber = Column(
         Integer, ForeignKey("blocks.number"), index=True, nullable=False
     )

--- a/packages/discovery-provider/src/models/users/user.py
+++ b/packages/discovery-provider/src/models/users/user.py
@@ -71,9 +71,6 @@ class User(Base, RepresentableMixin):
     user_authority_account = Column(String)
     allow_ai_attribution = Column(Boolean, nullable=False, server_default=text("false"))
 
-    block = relationship(  # type: ignore
-        "Block", primaryjoin="User.blockhash == Block.blockhash"
-    )
     block1 = relationship(  # type: ignore
         "Block", primaryjoin="User.blocknumber == Block.number"
     )


### PR DESCRIPTION
### Description

```
Error in indexing blocks (psycopg2.errors.ForeignKeyViolation) update or delete on table "blocks" violates foreign key constraint "dashboard_wallet_users_blockhash_fkey" on table "dashboard_wallet_users"
DETAIL:  Key (blockhash)=(0x926644ae257bfdd060f45eff0023d2f124910bc8eb70f7471149a18fcdfca957) is still referenced from table "dashboard_wallet_users".

[SQL: DELETE FROM blocks WHERE blocks.blockhash = %(blockhash_1)s]
[parameters: {'blockhash_1': '0x926644ae257bfdd060f45eff0023d2f124910bc8eb70f7471149a18fcdfca957'}]
(Background on this error at: http://sqlalche.me/e/gkpj)
Traceback (most recent call last):
  File "/usr/lib/python3.11/site-packages/sqlalchemy/engine/base.py", line 1243, in _execute_context
    self.dialect.do_execute(
  File "/usr/lib/python3.11/site-packages/sqlalchemy/engine/default.py", line 552, in do_execute
    cursor.execute(statement, parameters)
psycopg2.errors.ForeignKeyViolation: update or delete on table "blocks" violates foreign key constraint "dashboard_wallet_users_blockhash_fkey" on table "dashboard_wallet_users"
DETAIL:  Key (blockhash)=(0x926644ae257bfdd060f45eff0023d2f124910bc8eb70f7471149a18fcdfca957) is still referenced from table "dashboard_wallet_users".

``` 
This blockhash fkey is preventing a node from reverting a block. When a new record is added to a table, it's previous state is saved in revert_blocks. When a revert happens, the block w the reverted blockhash will be deleted from blocks table and cascaded to all tables that reference that block's number. 

https://github.com/AudiusProject/audius-protocol/blob/ff65794f9c9d4320283daca4ccc0d87a631a5cb0/packages/discovery-provider/src/tasks/index_nethermind.py#L491-L493

I think the cascade delete is failing because sqlalchemy isn't expecting the cascade delete first. We could probably set up the relationships in a way that could work but deleting this duplicate constraint should work too. Confirmed that all other tables only have fkey on blocknumber.

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._

Tested on sandbox. Will monitor the stuck node to see if it fixes.
