### PR TITLE
[ONC-28] Fix track tile icon size

### DIFF
--- a/packages/web/src/components/track/desktop/TrackTile.module.css
+++ b/packages/web/src/components/track/desktop/TrackTile.module.css
@@ -22,6 +22,7 @@
     0 1px 0 0 var(--tile-shadow-2), 0 2px 10px -2px var(--tile-shadow-3);
   transform: scale3d(1.005, 1.005, 1.005);
 }
+
 .container.standalone:not(.loading):not(.isDisabled):active {
   box-shadow: 0 0 1px 0 var(--tile-shadow-1),
     0 2px 3px -2px var(--tile-shadow-3);
@@ -279,6 +280,7 @@
   height: var(--unit-4);
   width: var(--unit-4);
 }
+
 .artistPickIcon path {
   fill: var(--neutral-light-4);
 }
@@ -318,6 +320,7 @@
 
   color: var(--neutral-light-4);
 }
+
 .large .topRight {
   /* Matches header row height for large tile variant */
   line-height: var(--unit-3);
@@ -349,6 +352,7 @@
   height: var(--unit-3);
   width: var(--unit-3);
 }
+
 .completeIcon path {
   fill: var(--secondary);
 }

--- a/packages/web/src/components/track/desktop/TrackTile.tsx
+++ b/packages/web/src/components/track/desktop/TrackTile.tsx
@@ -339,7 +339,7 @@ const TrackTile = ({
                   {title}
                 </Text>
                 {isPlaying ? (
-                  <IconVolume className={styles.volumeIcon} />
+                  <IconVolume size='m' className={styles.volumeIcon} />
                 ) : null}
               </Link>
             )}


### PR DESCRIPTION
### Description
Small update to the playing volumeIcon on track tile to prevent them from shifting content

### How Has This Been Tested?
Manually tested
