### PR TITLE
Fix mobile @audius/common auto imports

### DIFF
--- a/packages/mobile/tsconfig.json
+++ b/packages/mobile/tsconfig.json
@@ -21,6 +21,7 @@
     "module": "esnext",
     "paths": {
       "@audius/harmony-native": ["./src/harmony-native/index.ts"],
+      "@audius/common/*": ["../common/src/*"],
       "~/*": ["../common/src/*"],
       "app/*": ["./src/*"],
       // Remove these when no longer dependent on audius-client
@@ -42,5 +43,5 @@
     // Issue is due to absolute paths into audius-client
     "strict": false
   },
-    "exclude": ["node_modules", "harmony"],
+  "exclude": ["node_modules", "harmony"]
 }


### PR DESCRIPTION
### Description

Auto imports of common in mobile were going to `~/`. Adding this path fixes it

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._
