### PR TITLE
Fix wallet connect icons [C-3871]

### DIFF
--- a/packages/web/src/assets/img/phantom-icon-purple.svg
+++ b/packages/web/src/assets/img/phantom-icon-purple.svg
@@ -1,0 +1,14 @@
+<svg width="128" height="128" viewBox="0 0 128 128" fill="none" xmlns="http://www.w3.org/2000/svg">
+<circle cx="64" cy="64" r="64" fill="url(#paint0_linear)"/>
+<path d="M110.584 64.9142H99.142C99.142 41.7651 80.173 23 56.7724 23C33.6612 23 14.8716 41.3057 14.4118 64.0583C13.936 87.577 36.241 108 60.0186 108H63.0094C83.9723 108 112.069 91.7667 116.459 71.9874C117.27 68.3413 114.358 64.9142 110.584 64.9142ZM39.7689 65.9454C39.7689 69.0411 37.2095 71.5729 34.0802 71.5729C30.9509 71.5729 28.3916 69.0399 28.3916 65.9454V56.8414C28.3916 53.7457 30.9509 51.2139 34.0802 51.2139C37.2095 51.2139 39.7689 53.7457 39.7689 56.8414V65.9454ZM59.5224 65.9454C59.5224 69.0411 56.9631 71.5729 53.8338 71.5729C50.7045 71.5729 48.1451 69.0399 48.1451 65.9454V56.8414C48.1451 53.7457 50.7056 51.2139 53.8338 51.2139C56.9631 51.2139 59.5224 53.7457 59.5224 56.8414V65.9454Z" fill="url(#paint1_linear)"/>
+<defs>
+<linearGradient id="paint0_linear" x1="64" y1="0" x2="64" y2="128" gradientUnits="userSpaceOnUse">
+<stop stop-color="#534BB1"/>
+<stop offset="1" stop-color="#551BF9"/>
+</linearGradient>
+<linearGradient id="paint1_linear" x1="65.4998" y1="23" x2="65.4998" y2="108" gradientUnits="userSpaceOnUse">
+<stop stop-color="white"/>
+<stop offset="1" stop-color="white" stop-opacity="0.82"/>
+</linearGradient>
+</defs>
+</svg>

--- a/packages/web/src/services/web3-modal/index.ts
+++ b/packages/web/src/services/web3-modal/index.ts
@@ -1,7 +1,7 @@
 import { getErrorMessage } from '@audius/common/utils'
-import { IconPhantom as phantomIconPurpleSvg } from '@audius/harmony'
 import type { IProviderOptions } from 'web3modal'
 
+import phantomIconPurpleSvg from 'assets/img/phantom-icon-purple.svg'
 import walletLinkSvg from 'assets/img/wallet-link.svg'
 import { env } from 'services/env'
 
@@ -93,10 +93,11 @@ export const createSession = async (config: Config): Promise<any> => {
         }
       }
     }
+    console.log('phanton', phantomIconPurpleSvg)
     if (config.isPhantomEnabled && window?.solana?.isPhantom) {
       providerOptions['custom-phantom'] = {
         display: {
-          logo: phantomIconPurpleSvg as any,
+          logo: phantomIconPurpleSvg,
           name: 'Phantom',
           description: 'Connect Solana account'
         },

--- a/packages/web/src/services/web3-modal/index.ts
+++ b/packages/web/src/services/web3-modal/index.ts
@@ -93,7 +93,6 @@ export const createSession = async (config: Config): Promise<any> => {
         }
       }
     }
-    console.log('phanton', phantomIconPurpleSvg)
     if (config.isPhantomEnabled && window?.solana?.isPhantom) {
       providerOptions['custom-phantom'] = {
         display: {

--- a/packages/web/vite.config.ts
+++ b/packages/web/vite.config.ts
@@ -72,7 +72,11 @@ export default defineConfig(({ mode }) => {
     plugins: [
       glslify(),
       svgr({
-        include: '**/*.svg'
+        include: '**/*.svg',
+        exclude: [
+          'src/assets/img/wallet-link.svg',
+          'src/assets/img/phantom-icon-purple.svg'
+        ]
       }),
       // Import workerscript as raw string
       // Could use ?raw suffix but it breaks on mobile


### PR DESCRIPTION
### Description
Problem: 
Custom web3 provider logos weren't loading in the wallet connect modal because web3modal (external package) expects a raw image, but we were passing in SVGR SVG components due to adding SVGR to our Vite config a few months ago.

Solution:
Exclude the two logo files in question from SVGR scope so that they are just imported as raw image data.

Before:
![image](https://github.com/AudiusProject/audius-protocol/assets/36916764/89bb7e92-f214-44d8-bfca-597bfcc7be16)

After:
<img width="848" alt="Screenshot 2024-02-16 at 1 04 56 PM" src="https://github.com/AudiusProject/audius-protocol/assets/36916764/c02b5c3a-e8d8-495f-93c8-2b6ee9594d39">


### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._
