### PR TITLE
[PAY-2509] Bring lossless downloads mobile web up to spec

### DIFF
--- a/packages/web/src/components/track/DownloadRow.tsx
+++ b/packages/web/src/components/track/DownloadRow.tsx
@@ -1,5 +1,4 @@
 import { useDownloadableContentAccess } from '@audius/common/hooks'
-import { useIsMobile } from 'hooks/useIsMobile'
 import {
   ID,
   StemCategory,
@@ -13,6 +12,7 @@ import { shallowEqual, useSelector } from 'react-redux'
 import { Icon } from 'components/Icon'
 import LoadingSpinner from 'components/loading-spinner/LoadingSpinner'
 import Tooltip from 'components/tooltip/Tooltip'
+import { useIsMobile } from 'hooks/useIsMobile'
 
 import styles from './DownloadRow.module.css'
 
@@ -80,24 +80,14 @@ export const DownloadRow = ({
       direction='row'
       alignItems='center'
       justifyContent='space-between'
-      width='100%'
+      w='100%'
       gap='xs'
     >
-      <Flex
-        gap='xl'
-        alignItems='center'
-        width='100%'
-        css={{ overflow: 'hidden' }}
-      >
+      <Flex gap='xl' alignItems='center' w='100%' css={{ overflow: 'hidden' }}>
         <Text variant='body' color='subdued'>
           {index}
         </Text>
-        <Flex
-          direction='column'
-          gap='xs'
-          css={{ overflow: 'hidden' }}
-          width='100%'
-        >
+        <Flex direction='column' gap='xs' css={{ overflow: 'hidden' }} w='100%'>
           <Text variant='body' strength='default'>
             {category
               ? stemCategoryFriendlyNames[category]

--- a/packages/web/src/components/track/DownloadRow.tsx
+++ b/packages/web/src/components/track/DownloadRow.tsx
@@ -1,4 +1,5 @@
 import { useDownloadableContentAccess } from '@audius/common/hooks'
+import { useIsMobile } from 'hooks/useIsMobile'
 import {
   ID,
   StemCategory,
@@ -47,6 +48,7 @@ export const DownloadRow = ({
   filename,
   isLoading
 }: DownloadRowProps) => {
+  const isMobile = useIsMobile()
   const track = useSelector(
     (state: CommonState) => getTrack(state, { id: trackId }),
     shallowEqual
@@ -78,12 +80,24 @@ export const DownloadRow = ({
       direction='row'
       alignItems='center'
       justifyContent='space-between'
+      width='100%'
+      gap='xs'
     >
-      <Flex gap='xl' alignItems='center'>
+      <Flex
+        gap='xl'
+        alignItems='center'
+        width='100%'
+        css={{ overflow: 'hidden' }}
+      >
         <Text variant='body' color='subdued'>
           {index}
         </Text>
-        <Flex direction='column' gap='xs'>
+        <Flex
+          direction='column'
+          gap='xs'
+          css={{ overflow: 'hidden' }}
+          width='100%'
+        >
           <Text variant='body' strength='default'>
             {category
               ? stemCategoryFriendlyNames[category]
@@ -91,7 +105,15 @@ export const DownloadRow = ({
               ? stemCategoryFriendlyNames[track?.stem_of?.category]
               : messages.fullTrack}
           </Text>
-          <Text variant='body' color='subdued'>
+          <Text
+            variant='body'
+            color='subdued'
+            css={{
+              overflow: 'hidden',
+              textOverflow: 'ellipsis',
+              'white-space': 'nowrap'
+            }}
+          >
             {getDownloadFilename({
               filename: filename ?? track?.orig_filename,
               isOriginal
@@ -100,7 +122,7 @@ export const DownloadRow = ({
         </Flex>
       </Flex>
       <Flex gap='2xl'>
-        {size ? (
+        {size && !isMobile ? (
           <Text variant='body' size='s' color='subdued'>
             {formatBytes(size)}
           </Text>

--- a/packages/web/src/components/track/DownloadSection.tsx
+++ b/packages/web/src/components/track/DownloadSection.tsx
@@ -274,7 +274,11 @@ export const DownloadSection = ({ trackId }: DownloadSectionProps) => {
                 alignItems='center'
                 borderTop='default'
               >
-                <Flex direction='row' alignItems='center' gap='l'>
+                <Flex
+                  direction={isMobile ? 'column' : 'row'}
+                  alignItems='center'
+                  gap='l'
+                >
                   <Text variant='title'>{messages.choose}</Text>
                   <SegmentedControl
                     options={options}
@@ -285,7 +289,9 @@ export const DownloadSection = ({ trackId }: DownloadSectionProps) => {
                     equalWidth
                   />
                 </Flex>
-                {shouldDisplayDownloadAll ? downloadAllButton() : null}
+                {shouldDisplayDownloadAll && !isMobile
+                  ? downloadAllButton()
+                  : null}
               </Flex>
             ) : null}
             {track?.is_downloadable ? (
@@ -337,7 +343,8 @@ export const DownloadSection = ({ trackId }: DownloadSectionProps) => {
             ))}
             {/* Only display this row if original quality is not available,
             because the download all button will not be displayed at the top right. */}
-            {!track?.is_original_available && shouldDisplayDownloadAll ? (
+            {(!track?.is_original_available && shouldDisplayDownloadAll) ||
+            isMobile ? (
               <Flex borderTop='default' p='l' justifyContent='center'>
                 {downloadAllButton()}
               </Flex>


### PR DESCRIPTION
### Description
Noticed mobile web was bonked.

### How Has This Been Tested?

Before:
<img width="1920" alt="Screenshot 2024-02-16 at 4 56 27 PM" src="https://github.com/AudiusProject/audius-protocol/assets/3893871/abafc615-8a6b-4654-ba90-a78b8841babe">

After:
<img width="1920" alt="Screenshot 2024-02-16 at 4 51 50 PM" src="https://github.com/AudiusProject/audius-protocol/assets/3893871/cc78755c-653a-48a9-9741-7df0ebedf8ca">
<img width="1920" alt="Screenshot 2024-02-16 at 4 51 23 PM" src="https://github.com/AudiusProject/audius-protocol/assets/3893871/0e49e961-6ca0-4f32-ab4f-82a2fc73054b">
<img width="1920" alt="Screenshot 2024-02-16 at 4 51 43 PM" src="https://github.com/AudiusProject/audius-protocol/assets/3893871/2b815f67-65c7-4aea-955d-7c3e24f1e841">

Normal web still ok:
<img width="1920" alt="Screenshot 2024-02-16 at 4 51 32 PM" src="https://github.com/AudiusProject/audius-protocol/assets/3893871/f3fefc25-6c0c-4bb2-9cca-da0326758c30">
