### PR TITLE
[C-3852] Fix android bottom bar button colors

### DIFF
--- a/packages/mobile/src/components/bottom-tab-bar/bottom-tab-bar-buttons/BottomTabBarButton.tsx
+++ b/packages/mobile/src/components/bottom-tab-bar/bottom-tab-bar-buttons/BottomTabBarButton.tsx
@@ -74,7 +74,7 @@ const BottomTabBarRiveButton = (props: BottomTabBarRiveButtonProps) => {
 
   useEffect(() => {
     if (previousActive && !isActive) {
-      riveRef.current?.stop()
+      riveRef.current?.reset()
     }
   }, [isActive, previousActive])
 


### PR DESCRIPTION
### Description

Fixes issue where android bottom bar buttons don't unset when inactive. It appears there is a big with rive .stop on android. .reset() works for both platforms and looks the same.
