### PR TITLE
[ONC-27] Update collection cache reducer to add track uids to tracks in playlist_contents if not present

### DIFF
--- a/packages/common/src/store/cache/collections/reducer.ts
+++ b/packages/common/src/store/cache/collections/reducer.ts
@@ -1,6 +1,7 @@
 import { initialCacheState } from '~/store/cache/reducer'
+import { makeUid } from '~/utils'
 
-import { Collection, ID, Kind } from '../../../models'
+import { Collection, ID, Kind, PlaylistTrackId } from '../../../models'
 import {
   AddEntriesAction,
   AddSuccededAction,
@@ -18,6 +19,22 @@ const initialState = {
 
 const addEntries = (state: CollectionsCacheState, entries: any[]) => {
   const newPermalinks: Record<string, ID> = {}
+
+  // Add uids to track info in playlist_contents
+  // This allows collection tiles to be played when uid would not normally be present
+  entries.forEach((entry) => {
+    entry.metadata.playlist_contents.track_ids.forEach(
+      (track: PlaylistTrackId) => {
+        if (!track.uid) {
+          track.uid = makeUid(
+            Kind.TRACKS,
+            track.track,
+            `collection:${entry.metadata.playlist_id}`
+          )
+        }
+      }
+    )
+  })
 
   for (const entry of entries) {
     const { playlist_id, permalink } = entry.metadata


### PR DESCRIPTION
### Description
uids were not present in the playlist_contents of certain collections in the cache so they were not playable bc lineups use the uids to queue and play and stuff. This just adds uids if they are not present when the collections are being added to the store

### How Has This Been Tested?
Manually tested
