### PR TITLE
[PAY-2508] Fix download lossless mp3 failure

### DIFF
--- a/packages/discovery-provider/src/api/v1/tracks.py
+++ b/packages/discovery-provider/src/api/v1/tracks.py
@@ -396,7 +396,7 @@ def get_stream_url_from_content_node(content_node: str, path: str):
 
     try:
         response = requests.get(stream_url, headers=headers, timeout=5)
-        if response.status_code == 206 or response.status_code == 204:
+        if response.status_code == 206 or response.status_code == 204 or response.status_code == 200:
             return parsed_url.geturl()
     except:
         pass
@@ -738,7 +738,7 @@ class TrackDownload(Resource):
         healthy_nodes = get_all_healthy_content_nodes_cached(redis)
         if not healthy_nodes:
             logger.error(
-                f"tracks.py | stream | No healthy Content Nodes found when streaming track ID {track_id}. Please investigate."
+                f"tracks.py | download | No healthy Content Nodes found when streaming track ID {track_id}. Please investigate."
             )
             abort_not_found(track_id, ns)
 


### PR DESCRIPTION
### Description

Weirdness is that this only happened for a few stems, it was not a global lossless mp3 issue. Fix is that the request to get the first byte from content node returned with a status code of 200, whereas we were expecting 204 or 206. Although, it's not clear to me from CN side why it would be 200 only some of the time. It would seem like this line is what returns the data:
`if isAudioFile {
	ss.recordMetric(StreamTrack)
	http.ServeContent(c.Response(), c.Request(), cid, blob.ModTime(), blob)
	return nil
}`
and not clear to me why the blob, gotten from `blob, err := ss.bucket.NewReader(ctx, key, nil)` would do that.

### How Has This Been Tested?

stage web dapp against stage dn2 which had my commit deployed onto it. downloading https://staging.audius.co/raylosslessqa/3-free-lossless-stems lossless mp3 worked; they used to fail.
