### PR TITLE
fix self album share button

### DIFF
--- a/packages/web/src/components/collection/desktop/OwnerActionButtons.tsx
+++ b/packages/web/src/components/collection/desktop/OwnerActionButtons.tsx
@@ -18,7 +18,6 @@ export const OwnerActionButtons = (props: OwnerActionButtonProps) => {
   const collection = useSelector((state: CommonState) =>
     getCollection(state, { id: collectionId })
   ) as Collection
-  console.info({ COLLECTION: collection })
   const { is_private, is_album, playlist_contents } = collection ?? {}
   const track_count = playlist_contents.track_ids.length
 

--- a/packages/web/src/components/collection/desktop/OwnerActionButtons.tsx
+++ b/packages/web/src/components/collection/desktop/OwnerActionButtons.tsx
@@ -18,7 +18,9 @@ export const OwnerActionButtons = (props: OwnerActionButtonProps) => {
   const collection = useSelector((state: CommonState) =>
     getCollection(state, { id: collectionId })
   ) as Collection
-  const { track_count, is_private, is_album } = collection ?? {}
+  console.info({ COLLECTION: collection })
+  const { is_private, is_album, playlist_contents } = collection ?? {}
+  const track_count = playlist_contents.track_ids.length
 
   const isDisabled = !track_count || track_count === 0
 


### PR DESCRIPTION
### Description
Previously the code was referencing a `track_count` that seems to no longer be returned from the API. You can derive this from playlist_contents though. This was causing the Share button on someones personal album page to be disabled.
![Screenshot 2024-02-17 at 3 41 54 PM](https://github.com/AudiusProject/audius-protocol/assets/16739903/33ce21e7-c619-42a0-ac0f-cab7bc16fadc)
![Screenshot 2024-02-17 at 3 41 24 PM](https://github.com/AudiusProject/audius-protocol/assets/16739903/2e0aee7d-c43c-43c1-a190-b8bc2a8461e7)


### How Has This Been Tested?
Run `npm run web:prod` and navigate to an uploaded album you have. The share button should be functional now.
![Screenshot 2024-02-17 at 3 55 22 PM](https://github.com/AudiusProject/audius-protocol/assets/16739903/7c034557-9166-4b30-9366-43c9f0711a5b)

