### PR TITLE
[ONC-17] Remove hotkeys on unmount of playbar to prevent double-triggers

### DIFF
--- a/packages/web/src/components/play-bar/desktop/PlayBar.jsx
+++ b/packages/web/src/components/play-bar/desktop/PlayBar.jsx
@@ -22,7 +22,7 @@ import {
   playbackRateValueMap
 } from '@audius/common/store'
 import { Genre } from '@audius/common/utils'
-import { setupHotkeys } from '@audius/harmony'
+import { removeHotkeys, setupHotkeys } from '@audius/harmony'
 import { Scrubber } from '@audius/stems'
 import { push as pushRoute } from 'connected-react-router'
 import { connect } from 'react-redux'
@@ -85,11 +85,12 @@ class PlayBar extends Component {
       initialVolume: null,
       mediaKey: 0
     }
+    this.hotkeysHook = null
     this.seekInterval = null
   }
 
   componentDidMount() {
-    setupHotkeys(
+    this.hotkeysHook = setupHotkeys(
       {
         32 /* space */: this.togglePlay,
         37 /* left arrow */: this.onPrevious,
@@ -134,6 +135,7 @@ class PlayBar extends Component {
 
   componentWillUnmount() {
     clearInterval(this.seekInterval)
+    removeHotkeys(this.hotkeysHook)
   }
 
   goToTrackPage = () => {


### PR DESCRIPTION
### Description
There are intermittent cases where the playbar gets unmounted/remounted on initial page load (error boundaries? SSR?). We don't unregister our hotkeys in the playbar component. And the way it's wired up results in a `dispatch()` call in each case. This fixes the bug for now. Longer term fix is to migrate this component to hooks and use `useHotkeys()` which has the correct behavior built in.

fixes ONC-17

### How Has This Been Tested?
Tested locally against prod. Used logpoints to make sure the reproduction case was triggered.
