### PR TITLE
Allow CI workflows to be manually triggered

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -426,6 +426,8 @@ workflows:
     when:
       and:
         - equal: ['main', << pipeline.parameters.workflow >>]
+        - not:
+            equal: [scheduled_pipeline, << pipeline.trigger_source >>]
     jobs:
       - generate-config
       - init:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -426,8 +426,6 @@ workflows:
     when:
       and:
         - equal: ['main', << pipeline.parameters.workflow >>]
-        - not:
-            equal: [scheduled_pipeline, << pipeline.trigger_source >>]
     jobs:
       - generate-config
       - init:
@@ -583,75 +581,9 @@ workflows:
             - init
           workspace_path: ../workspace
 
-  release-create-branch:
-    when:
-      condition:
-        or:
-          - and:
-              - equal: [scheduled_pipeline, << pipeline.trigger_source >>]
-              - equal: ['release-create-branch', << pipeline.schedule.name >>]
-          - equal: ['release-create-branch', << pipeline.parameters.workflow >>]
-    jobs:
-      - generate-release-branch
-
-  auto-approve-foundation-deploy:
-    when:
-      condition:
-        or:
-          - and:
-              - equal: [scheduled_pipeline, << pipeline.trigger_source >>]
-              - equal:
-                  [
-                    'auto-approve-foundation-deploy',
-                    << pipeline.schedule.name >>
-                  ]
-          - equal:
-              [
-                'auto-approve-foundation-deploy',
-                << pipeline.parameters.workflow >>
-              ]
-    jobs:
-      - approve-deployment-holds:
-          context: [slack-secrets, circle-daily-deploy-secrets]
-
-  notify-sp-release:
-    when:
-      condition:
-        or:
-          - and:
-              - equal: [scheduled_pipeline, << pipeline.trigger_source >>]
-              - equal: ['notify-sp-release', << pipeline.schedule.name >>]
-          - equal: ['notify-sp-release', << pipeline.parameters.workflow >>]
-    jobs:
-      - notify-sp-release-job:
-          context: [slack-secrets, circle-daily-deploy-secrets]
-
   release-client-create-branch:
     when:
-      condition:
-        or:
-          - and:
-              - equal: [scheduled_pipeline, << pipeline.trigger_source >>]
-              - equal:
-                  ['release-client-create-branch', << pipeline.schedule.name >>]
-          - equal:
-              [
-                'release-client-create-branch',
-                << pipeline.parameters.workflow >>
-              ]
+      equal:
+        ['release-client-create-branch', << pipeline.parameters.workflow >>]
     jobs:
       - generate-client-release
-
-  notify-stuck-stage-nodes:
-    when:
-      condition:
-        or:
-          - and:
-              - equal: [scheduled_pipeline, << pipeline.trigger_source >>]
-              - equal:
-                  ['notify-stuck-stage-nodes', << pipeline.schedule.name >>]
-          - equal:
-              ['notify-stuck-stage-nodes', << pipeline.parameters.workflow >>]
-    jobs:
-      - notify-stuck-stage-nodes-job:
-          context: [slack-secrets]

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -427,8 +427,7 @@ workflows:
       and:
         - not:
             equal: [scheduled_pipeline, << pipeline.trigger_source >>]
-        - not:
-            equal: ['', << pipeline.parameters.workflow >>]
+        - not: << pipeline.parameters.workflow >>
     jobs:
       - generate-config
       - init:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -427,8 +427,7 @@ workflows:
       and:
         - not:
             equal: [scheduled_pipeline, << pipeline.trigger_source >>]
-        - not:
-            equal: ['main', << pipeline.parameters.workflow >>]
+        - equal: ['main', << pipeline.parameters.workflow >>]
     jobs:
       - generate-config
       - init:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -425,9 +425,9 @@ workflows:
   setup:
     when:
       and:
+        - equal: ['main', << pipeline.parameters.workflow >>]
         - not:
             equal: [scheduled_pipeline, << pipeline.trigger_source >>]
-        - equal: ['main', << pipeline.parameters.workflow >>]
     jobs:
       - generate-config
       - init:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -424,10 +424,7 @@ jobs:
 workflows:
   setup:
     when:
-      and:
-        - equal: ['main', << pipeline.parameters.workflow >>]
-        - not:
-            equal: [scheduled_pipeline, << pipeline.trigger_source >>]
+      equal: ['main', << pipeline.parameters.workflow >>]
     jobs:
       - generate-config
       - init:
@@ -583,14 +580,30 @@ workflows:
             - init
           workspace_path: ../workspace
 
+  release-create-branch:
+    when:
+      equal: ['release-create-branch', << pipeline.parameters.workflow >>]
+    jobs:
+      - generate-release-branch
+
+  auto-approve-foundation-deploy:
+    when:
+      equal:
+        ['auto-approve-foundation-deploy', << pipeline.parameters.workflow >>]
+    jobs:
+      - approve-deployment-holds:
+          context: [slack-secrets, circle-daily-deploy-secrets]
+
+  notify-sp-release:
+    when:
+      equal: ['notify-sp-release', << pipeline.parameters.workflow >>]
+    jobs:
+      - notify-sp-release-job:
+          context: [slack-secrets, circle-daily-deploy-secrets]
+
   release-client-create-branch:
     when:
-      or:
-        - and:
-            - equal: [scheduled_pipeline, << pipeline.trigger_source >>]
-            - equal:
-                ['release-client-create-branch', << pipeline.schedule.name >>]
-        - equal:
-            ['release-client-create-branch', << pipeline.parameters.workflow >>]
+      equal:
+        ['release-client-create-branch', << pipeline.parameters.workflow >>]
     jobs:
       - generate-client-release

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -424,8 +424,11 @@ jobs:
 workflows:
   setup:
     when:
-      not:
-        equal: [scheduled_pipeline, << pipeline.trigger_source >>]
+      and:
+        - not:
+            equal: [scheduled_pipeline, << pipeline.trigger_source >>]
+        - not:
+            equal: ['', << pipeline.parameters.workflow >>]
     jobs:
       - generate-config
       - init:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -585,16 +585,12 @@ workflows:
 
   release-client-create-branch:
     when:
-      condition:
-        or:
-          - and:
-              - equal: [scheduled_pipeline, << pipeline.trigger_source >>]
-              - equal:
-                  ['release-client-create-branch', << pipeline.schedule.name >>]
-          - equal:
-              [
-                'release-client-create-branch',
-                << pipeline.parameters.workflow >>
-              ]
+      or:
+        - and:
+            - equal: [scheduled_pipeline, << pipeline.trigger_source >>]
+            - equal:
+                ['release-client-create-branch', << pipeline.schedule.name >>]
+        - equal:
+            ['release-client-create-branch', << pipeline.parameters.workflow >>]
     jobs:
       - generate-client-release

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -583,44 +583,73 @@ workflows:
 
   release-create-branch:
     when:
-      and:
-        - equal: [scheduled_pipeline, << pipeline.trigger_source >>]
-        - equal: ['release-create-branch', << pipeline.schedule.name >>]
+      condition:
+        or:
+          - and:
+              - equal: [scheduled_pipeline, << pipeline.trigger_source >>]
+              - equal: ['release-create-branch', << pipeline.schedule.name >>]
+          - equal: ['release-create-branch', << pipeline.parameters.workflow >>]
     jobs:
       - generate-release-branch
 
   auto-approve-foundation-deploy:
     when:
-      and:
-        - equal: [scheduled_pipeline, << pipeline.trigger_source >>]
-        - equal:
-            ['auto-approve-foundation-deploy', << pipeline.schedule.name >>]
+      condition:
+        or:
+          - and:
+              - equal: [scheduled_pipeline, << pipeline.trigger_source >>]
+              - equal:
+                  [
+                    'auto-approve-foundation-deploy',
+                    << pipeline.schedule.name >>
+                  ]
+          - equal:
+              [
+                'auto-approve-foundation-deploy',
+                << pipeline.parameters.workflow >>
+              ]
     jobs:
       - approve-deployment-holds:
           context: [slack-secrets, circle-daily-deploy-secrets]
 
   notify-sp-release:
     when:
-      and:
-        - equal: [scheduled_pipeline, << pipeline.trigger_source >>]
-        - equal: ['notify-sp-release', << pipeline.schedule.name >>]
+      condition:
+        or:
+          - and:
+              - equal: [scheduled_pipeline, << pipeline.trigger_source >>]
+              - equal: ['notify-sp-release', << pipeline.schedule.name >>]
+          - equal: ['notify-sp-release', << pipeline.parameters.workflow >>]
     jobs:
       - notify-sp-release-job:
           context: [slack-secrets, circle-daily-deploy-secrets]
 
   release-client-create-branch:
     when:
-      and:
-        - equal: [scheduled_pipeline, << pipeline.trigger_source >>]
-        - equal: ['release-client-create-branch', << pipeline.schedule.name >>]
+      condition:
+        or:
+          - and:
+              - equal: [scheduled_pipeline, << pipeline.trigger_source >>]
+              - equal:
+                  ['release-client-create-branch', << pipeline.schedule.name >>]
+          - equal:
+              [
+                'release-client-create-branch',
+                << pipeline.parameters.workflow >>
+              ]
     jobs:
       - generate-client-release
 
   notify-stuck-stage-nodes:
     when:
-      and:
-        - equal: [scheduled_pipeline, << pipeline.trigger_source >>]
-        - equal: ['notify-stuck-stage-nodes', << pipeline.schedule.name >>]
+      condition:
+        or:
+          - and:
+              - equal: [scheduled_pipeline, << pipeline.trigger_source >>]
+              - equal:
+                  ['notify-stuck-stage-nodes', << pipeline.schedule.name >>]
+          - equal:
+              ['notify-stuck-stage-nodes', << pipeline.parameters.workflow >>]
     jobs:
       - notify-stuck-stage-nodes-job:
           context: [slack-secrets]

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -427,7 +427,8 @@ workflows:
       and:
         - not:
             equal: [scheduled_pipeline, << pipeline.trigger_source >>]
-        - not: << pipeline.parameters.workflow >>
+        - not:
+            equal: ['main', << pipeline.parameters.workflow >>]
     jobs:
       - generate-config
       - init:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -585,7 +585,16 @@ workflows:
 
   release-client-create-branch:
     when:
-      equal:
-        ['release-client-create-branch', << pipeline.parameters.workflow >>]
+      condition:
+        or:
+          - and:
+              - equal: [scheduled_pipeline, << pipeline.trigger_source >>]
+              - equal:
+                  ['release-client-create-branch', << pipeline.schedule.name >>]
+          - equal:
+              [
+                'release-client-create-branch',
+                << pipeline.parameters.workflow >>
+              ]
     jobs:
       - generate-client-release

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -607,3 +607,12 @@ workflows:
         ['release-client-create-branch', << pipeline.parameters.workflow >>]
     jobs:
       - generate-client-release
+
+  notify-stuck-stage-nodes:
+    when:
+      and:
+        - equal:
+            ['notify-stuck-stage-nodes', << pipeline.parameters.workflow >>]
+    jobs:
+      - notify-stuck-stage-nodes-job:
+          context: [slack-secrets]


### PR DESCRIPTION
### Description

Updates our CI triggers to use workflow name instead of the trigger name. This is more versatile and lets us trigger workflows manually if something doesn't go right in the scheduled trigger.

I have updated all scheduled triggers to include the correct `workflow` param

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._

CI Runs on main, will confirm after merge it works via triggered release