### PR TITLE
[Mobile] ⚠️ Install pending CodePush update upon foregrounding after 1hr [C-3791]

### DIFF
--- a/packages/mobile/src/screens/root-screen/useSyncCodePush.ts
+++ b/packages/mobile/src/screens/root-screen/useSyncCodePush.ts
@@ -42,7 +42,7 @@ export const useSyncCodePush = () => {
           ) {
             // If there's a pending update and it's not mandatory, and the user backgrounded the app for over an hour and came back, and the user is NOT playing music, restart the app to apply the new update
             const time = new Date().getTime() / 1000
-            if (time - timeLastBackgrounded.current > 2) {
+            if (time - timeLastBackgrounded.current > 3600) {
               codePush.restartApp(true)
             }
           }

--- a/packages/mobile/src/screens/root-screen/useSyncCodePush.ts
+++ b/packages/mobile/src/screens/root-screen/useSyncCodePush.ts
@@ -1,11 +1,11 @@
 import { useCallback, useRef, useState } from 'react'
-import { playerSelectors } from '@audius/common/store'
 
+import { playerSelectors } from '@audius/common/store'
 import codePush from 'react-native-code-push'
+import { useSelector } from 'react-redux'
 import { useEffectOnce } from 'react-use'
 
 import { useEnterBackground, useEnterForeground } from 'app/hooks/useAppState'
-import { useSelector } from 'react-redux'
 
 const { getPlaying } = playerSelectors
 
@@ -42,7 +42,7 @@ export const useSyncCodePush = () => {
           ) {
             // If there's a pending update and it's not mandatory, and the user backgrounded the app for over an hour and came back, and the user is NOT playing music, restart the app to apply the new update
             const time = new Date().getTime() / 1000
-            if (time - timeLastBackgrounded.current > 3600) {
+            if (time - timeLastBackgrounded.current > 2) {
               codePush.restartApp(true)
             }
           }
@@ -50,7 +50,7 @@ export const useSyncCodePush = () => {
         })
       }
     )
-  }, [])
+  }, [playing])
 
   useEffectOnce(() => {
     codePushSync()

--- a/packages/mobile/src/screens/root-screen/useSyncCodePush.ts
+++ b/packages/mobile/src/screens/root-screen/useSyncCodePush.ts
@@ -1,15 +1,22 @@
-import { useCallback, useState } from 'react'
+import { useCallback, useRef, useState } from 'react'
+import { playerSelectors } from '@audius/common/store'
 
 import codePush from 'react-native-code-push'
 import { useEffectOnce } from 'react-use'
 
-import { useEnterForeground } from 'app/hooks/useAppState'
+import { useEnterBackground, useEnterForeground } from 'app/hooks/useAppState'
+import { useSelector } from 'react-redux'
+
+const { getPlaying } = playerSelectors
 
 export const useSyncCodePush = () => {
   const [
     isPendingMandatoryCodePushUpdate,
     setIsPendingMandatoryCodePushUpdate
   ] = useState(false)
+
+  const playing = useSelector(getPlaying)
+  const timeLastBackgrounded = useRef<number | null>(null)
 
   const codePushSync = useCallback(() => {
     codePush.sync(
@@ -26,8 +33,20 @@ export const useSyncCodePush = () => {
         console.info('New CodePush Status: ', newStatus)
         codePush.getUpdateMetadata(codePush.UpdateState.PENDING).then((res) => {
           if (res != null && res.isMandatory) {
+            // If there's a pending (downloaded but not yet installed) update, and it's mandatory, show the mandatory update UI
             setIsPendingMandatoryCodePushUpdate(true)
+          } else if (
+            res !== null &&
+            !playing &&
+            timeLastBackgrounded.current != null
+          ) {
+            // If there's a pending update and it's not mandatory, and the user backgrounded the app for over an hour and came back, and the user is NOT playing music, restart the app to apply the new update
+            const time = new Date().getTime() / 1000
+            if (time - timeLastBackgrounded.current > 3600) {
+              codePush.restartApp(true)
+            }
           }
+          timeLastBackgrounded.current = null
         })
       }
     )
@@ -39,6 +58,10 @@ export const useSyncCodePush = () => {
 
   useEnterForeground(() => {
     codePushSync()
+  })
+
+  useEnterBackground(() => {
+    timeLastBackgrounded.current = new Date().getTime() / 1000
   })
 
   return { isPendingMandatoryCodePushUpdate }


### PR DESCRIPTION
### Description
Implement item #2 from [OTA improvements plan](https://www.notion.so/audiusproject/Improving-Latest-Mobile-App-Release-Adoption-w-focus-on-OTA-8abb2e0e67dc4a538724d11b214ca632?pvs=4)

- Install pending Codepush (OTA) updates upon foregrounding the app after 1 hr has passed since last foreground UNLESS user is playing music

### How Has This Been Tested?
On Android device in production mode. Will make sure to test thoroughly in "real" settings too once merged (with staging and RC apps).
Test cases:
- Background for >1 hr -> re open app -> app should restart and new update should be applied
- Play music (like a >1 hr playlist) -> background for >1hr -> re open app -> app should not restart -> stop music -> background for >1 hr -> re open app -> app should restart and new update should be applied
- Force close app (completelry) -> re open app -> app should restart and new update should be applied

