### PR TITLE
[C-3863] Increase touch target of close button of artist preview banner

### DIFF
--- a/packages/mobile/src/screens/sign-on-screen/screens/SelectArtistScreen/PreviewArtistHint.tsx
+++ b/packages/mobile/src/screens/sign-on-screen/screens/SelectArtistScreen/PreviewArtistHint.tsx
@@ -1,6 +1,13 @@
 import { useState } from 'react'
 
-import { IconCloseAlt, IconPlay, Paper, Text } from '@audius/harmony-native'
+import {
+  IconButton,
+  IconCloseAlt,
+  IconPlay,
+  Paper,
+  Text,
+  useTheme
+} from '@audius/harmony-native'
 
 const messages = {
   previewNotice: "Press the artist's photo to preview their music."
@@ -8,6 +15,7 @@ const messages = {
 
 export const PreviewArtistHint = () => {
   const [isOpen, setIsOpen] = useState(true)
+  const { spacing } = useTheme()
 
   if (!isOpen) return null
 
@@ -27,8 +35,10 @@ export const PreviewArtistHint = () => {
       <Text variant='body' color='staticWhite' style={{ flex: 1 }}>
         {messages.previewNotice}
       </Text>
-      <IconCloseAlt
+      <IconButton
         role='button'
+        icon={IconCloseAlt}
+        hitSlop={spacing.l}
         color='staticWhite'
         size='m'
         onPress={() => setIsOpen(false)}


### PR DESCRIPTION
### Description
Increase the touch target of the close a bit
 
### How Has This Been Tested?
Manually tested

Before: 
<img width="459" alt="Screenshot 2024-02-21 at 12 41 31 PM" src="https://github.com/AudiusProject/audius-protocol/assets/23732287/e35ae00d-47d0-4002-970e-569b789e3519">

After:
<img width="478" alt="Screenshot 2024-02-21 at 12 43 46 PM" src="https://github.com/AudiusProject/audius-protocol/assets/23732287/5eba465c-a24d-42c0-8087-7ee0e1ad69cb">
