### PR TITLE
[C-3861] Remove default padding on text inputs for andoird

### DIFF
--- a/packages/mobile/src/harmony-native/components/input/TextInput/TextInput.tsx
+++ b/packages/mobile/src/harmony-native/components/input/TextInput/TextInput.tsx
@@ -333,7 +333,7 @@ export const TextInput = forwardRef(
                         // Need absolute height to ensure consistency across platforms
                         height: !isSmall ? 23 : undefined,
                         // Android has a default padding that needs to be removed
-                        paddingVertical: 0,
+                        padding: 0,
                         fontSize: typography.size[isSmall ? 's' : 'l'],
                         fontFamily: typography.fontByWeight.medium,
                         color: color.text[disabled ? 'subdued' : 'default']


### PR DESCRIPTION
### Description
Remove all default padding on text inputs so that it doesn't show up on android

### How Has This Been Tested?

Manually tested
