### PR TITLE
Pin dnspython to version 2.5.0

### DIFF
--- a/packages/discovery-provider/requirements.txt
+++ b/packages/discovery-provider/requirements.txt
@@ -36,6 +36,7 @@ fakeredis==2.17.0
 jsonformatter==0.3.0
 pytest-postgresql==2.4.1
 eventlet==0.33.3
+dnspython==2.5.0
 psutil==5.8.0
 pytz==2021.1
 prometheus-client==0.13.1


### PR DESCRIPTION
### Description
dnspython upgraded to 2.6.0 which causes server container to get stuck in a restart loop.

```
[2024-02-21 21:07:26 +0000] [20] [ERROR] Exception in worker process
Traceback (most recent call last):
  File "/usr/lib/python3.11/site-packages/eventlet/support/greendns.py", line 456, in resolve
    return _proxy.query(name, rdtype, raise_on_no_answer=raises,
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/site-packages/eventlet/support/greendns.py", line 412, in query
    return end()
           ^^^^^
  File "/usr/lib/python3.11/site-packages/eventlet/support/greendns.py", line 391, in end
    raise result[1]
  File "/usr/lib/python3.11/site-packages/eventlet/support/greendns.py", line 372, in step
    a = fun(*args, **kwargs)
        ^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/site-packages/dns/resolver.py", line 1364, in query
    return self.resolve(
           ^^^^^^^^^^^^^
  File "/usr/lib/python3.11/site-packages/dns/resolver.py", line 1321, in resolve
    timeout = self._compute_timeout(start, lifetime, resolution.errors)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/site-packages/dns/resolver.py", line 1075, in _compute_timeout
    raise LifetimeTimeout(timeout=duration, errors=errors)

```

piplist shows that dnspython version changed. 

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._

Tested on stage. Took a commit w dns 2.6.0 and forced pip install to 2.5.0 which stopped the error.