### PR TITLE
[PROTO-1669] Find Mongo changes when offline and clean up DDEX

### DIFF
--- a/packages/ddex/ingester/common/common.go
+++ b/packages/ddex/ingester/common/common.go
@@ -11,9 +11,115 @@ import (
 	"github.com/aws/aws-sdk-go/aws/credentials"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/s3"
+	"github.com/aws/aws-sdk-go/service/s3/s3manager"
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/bson/primitive"
 	"go.mongodb.org/mongo-driver/mongo"
 	"go.mongodb.org/mongo-driver/mongo/options"
 )
+
+type Cursor struct {
+	CollectionName string    `bson:"collection_name"`
+	ResumeToken    bson.Raw  `bson:"resume_token"`
+	LastUpdated    time.Time `bson:"last_updated"`
+}
+
+type Ingester interface {
+	GetResumeToken(ctx context.Context, collectionName string) (bson.Raw, error)
+	UpdateResumeToken(ctx context.Context, collectionName string, resumeToken bson.Raw) error
+}
+
+type BaseIngester struct {
+	Ctx                 context.Context
+	MongoClient         *mongo.Client
+	S3Client            *s3.S3
+	S3Downloader        *s3manager.Downloader
+	S3Uploader          *s3manager.Uploader
+	RawBucket           string
+	IndexedBucket       string
+	CursorsColl         *mongo.Collection
+	UploadsColl         *mongo.Collection
+	DeliveriesColl      *mongo.Collection
+	PendingReleasesColl *mongo.Collection
+	UsersColl           *mongo.Collection
+	Logger              *slog.Logger
+}
+
+func NewBaseIngester(ctx context.Context, service string) *BaseIngester {
+	logger := slog.With("service", service)
+	s3, s3Session := InitS3Client(logger)
+	mongoClient := InitMongoClient(ctx, logger)
+
+	return &BaseIngester{
+		S3Client:            s3,
+		S3Downloader:        s3manager.NewDownloader(s3Session),
+		S3Uploader:          s3manager.NewUploader(s3Session),
+		MongoClient:         mongoClient,
+		RawBucket:           MustGetenv("AWS_BUCKET_RAW"),
+		IndexedBucket:       MustGetenv("AWS_BUCKET_INDEXED"),
+		CursorsColl:         mongoClient.Database("ddex").Collection("cursors"),
+		UploadsColl:         mongoClient.Database("ddex").Collection("uploads"),
+		DeliveriesColl:      mongoClient.Database("ddex").Collection("deliveries"),
+		PendingReleasesColl: mongoClient.Database("ddex").Collection("pending_releases"),
+		UsersColl:           mongoClient.Database("ddex").Collection("users"),
+		Ctx:                 ctx,
+		Logger:              logger,
+	}
+}
+
+// ProcessChangeStream watches a collection for new insert operations and processes them with the provided function.
+func (bi *BaseIngester) ProcessChangeStream(c *mongo.Collection, exec func(*mongo.ChangeStream)) {
+	p := mongo.Pipeline{bson.D{{Key: "$match", Value: bson.D{{Key: "operationType", Value: "insert"}}}}}
+	rt, _ := bi.GetResumeToken(c.Name())
+	var opts *options.ChangeStreamOptions
+	if rt == nil {
+		// Start at the beginning (oldest timestamp in oplog because the time has to be in the oplog for the resume token to work)
+		oldestOplogTimestamp, err := getOldestOplogTimestamp(bi.MongoClient)
+		if err != nil {
+			log.Fatal(err)
+		}
+		bi.Logger.Info("Starting at oldest oplog timestamp", "timestamp", oldestOplogTimestamp)
+		opts = options.ChangeStream().SetStartAtOperationTime(&oldestOplogTimestamp)
+	} else {
+		// Note: if the collection is dropped and recreated, inserts will still be replayed from this resume token
+		bi.Logger.Info("Resuming from resume token", "resume_token", rt)
+		opts = options.ChangeStream().SetStartAfter(rt)
+	}
+
+	cs, err := c.Watch(bi.Ctx, p, opts)
+	if err != nil {
+		panic(err)
+	}
+	bi.Logger.Info("Watching collection", "collection", c.Name())
+	defer cs.Close(bi.Ctx)
+
+	for cs.Next(bi.Ctx) {
+		exec(cs)
+		rt := cs.ResumeToken()
+		if err := bi.UpdateResumeToken(c.Name(), rt); err != nil {
+			log.Fatalf("Failed to update resume token for '%s': %v", c.Name(), err)
+		}
+	}
+
+	if err := cs.Err(); err != nil {
+		log.Fatal(err)
+	}
+}
+
+func (bi *BaseIngester) GetResumeToken(collectionName string) (bson.Raw, error) {
+	var cursorDoc Cursor
+	if err := bi.CursorsColl.FindOne(bi.Ctx, bson.M{"collection_name": collectionName}).Decode(&cursorDoc); err != nil {
+		return nil, err
+	}
+	return cursorDoc.ResumeToken, nil
+}
+
+func (bi *BaseIngester) UpdateResumeToken(collectionName string, resumeToken bson.Raw) error {
+	filter := bson.M{"collection_name": collectionName}
+	update := bson.M{"$set": Cursor{CollectionName: collectionName, ResumeToken: resumeToken, LastUpdated: time.Now()}}
+	_, err := bi.CursorsColl.UpdateOne(bi.Ctx, filter, update, options.Update().SetUpsert(true))
+	return err
+}
 
 func InitMongoClient(ctx context.Context, logger *slog.Logger) *mongo.Client {
 	mongoUrl := os.Getenv("DDEX_MONGODB_URL")
@@ -52,4 +158,19 @@ func MustGetenv(key string) string {
 		log.Fatal("Missing required env variable: ", key)
 	}
 	return val
+}
+
+func getOldestOplogTimestamp(client *mongo.Client) (primitive.Timestamp, error) {
+	var result struct {
+		TS primitive.Timestamp `bson:"ts"`
+	}
+
+	oplogCollection := client.Database("local").Collection("oplog.rs")
+	opts := options.FindOne().SetSort(bson.D{{Key: "ts", Value: 1}})
+	err := oplogCollection.FindOne(context.TODO(), bson.D{}, opts).Decode(&result)
+	if err != nil {
+		return primitive.Timestamp{}, err
+	}
+
+	return result.TS, nil
 }

--- a/packages/ddex/ingester/indexer/indexer.go
+++ b/packages/ddex/ingester/indexer/indexer.go
@@ -9,7 +9,6 @@ import (
 	"ingester/constants"
 	"io"
 	"log"
-	"log/slog"
 	"os"
 	"path/filepath"
 	"strings"
@@ -24,51 +23,16 @@ import (
 )
 
 type Indexer struct {
-	s3Downloader   *s3manager.Downloader
-	s3Uploader     *s3manager.Uploader
-	mongoClient    *mongo.Client
-	rawBucket      string
-	indexedBucket  string
-	deliveriesColl *mongo.Collection
-	ctx            context.Context
-	logger         *slog.Logger
+	*common.BaseIngester
 }
 
 // RunNewIndexer starts the indexer service, which listens for new uploads in the Mongo "uploads" collection and processes them.
 func RunNewIndexer(ctx context.Context) {
-	logger := slog.With("service", "indexer")
-	_, s3Session := common.InitS3Client(logger)
-	mongoClient := common.InitMongoClient(ctx, logger)
-	defer mongoClient.Disconnect(ctx)
-	deliveriesColl := mongoClient.Database("ddex").Collection("deliveries")
-
 	i := &Indexer{
-		s3Downloader:   s3manager.NewDownloader(s3Session),
-		s3Uploader:     s3manager.NewUploader(s3Session),
-		mongoClient:    mongoClient,
-		rawBucket:      common.MustGetenv("AWS_BUCKET_RAW"),
-		indexedBucket:  common.MustGetenv("AWS_BUCKET_INDEXED"),
-		deliveriesColl: deliveriesColl,
-		ctx:            ctx,
-		logger:         logger,
+		BaseIngester: common.NewBaseIngester(ctx, "indexer"),
 	}
-
-	uploadsColl := mongoClient.Database("ddex").Collection("uploads")
-	pipeline := mongo.Pipeline{bson.D{{Key: "$match", Value: bson.D{{Key: "operationType", Value: "insert"}}}}}
-	changeStream, err := uploadsColl.Watch(ctx, pipeline)
-	if err != nil {
-		panic(err)
-	}
-	i.logger.Info("Watching collection 'uploads'")
-	defer changeStream.Close(ctx)
-
-	for changeStream.Next(ctx) {
-		i.processZIP(changeStream)
-	}
-
-	if err := changeStream.Err(); err != nil {
-		log.Fatal(err)
-	}
+	defer i.MongoClient.Disconnect(ctx)
+	i.ProcessChangeStream(i.UploadsColl, i.processZIP)
 }
 
 // processZIP unzips an "upload" into a "delivery" (or multiple deliveries if the ZIP file contains multiple folders with XML files).
@@ -81,7 +45,7 @@ func (i *Indexer) processZIP(changeStream *mongo.ChangeStream) {
 		log.Fatal(err)
 	}
 	upload := changeDoc.FullDocument
-	i.logger.Info("Processing new upload", "_id", upload.ID)
+	i.Logger.Info("Processing new upload", "_id", upload.ID)
 
 	// Download ZIP file from S3
 	uploadETag := upload.UploadETag
@@ -89,20 +53,20 @@ func (i *Indexer) processZIP(changeStream *mongo.ChangeStream) {
 	zipFilePath, cleanup := i.downloadFromS3Raw(remotePath)
 	defer cleanup()
 	if zipFilePath == "" {
-		i.logger.Error("Failed to download ZIP file from S3 bucket", "path", remotePath)
+		i.Logger.Error("Failed to download ZIP file from S3 bucket", "path", remotePath)
 		return
 	}
 
 	// Unzip the file and process its contents
 	extractDir, err := os.MkdirTemp("", "extracted")
 	if err != nil {
-		i.logger.Error("Error creating temp directory", "error", err)
+		i.Logger.Error("Error creating temp directory", "error", err)
 		return
 	}
 	defer os.RemoveAll(extractDir)
 
 	if err := unzip(zipFilePath, extractDir); err != nil {
-		i.logger.Error("Error unzipping file", "error", err)
+		i.Logger.Error("Error unzipping file", "error", err)
 		return
 	}
 
@@ -162,7 +126,7 @@ func (i *Indexer) processDelivery(rootDir, dir, uploadETag string) error {
 	}
 
 	if deliveryID == primitive.NilObjectID {
-		i.logger.Info("No XML file found in directory. Skipping", "dir", dir)
+		i.Logger.Info("No XML file found in directory. Skipping", "dir", dir)
 		return errors.New("no XML file found in directory")
 	}
 
@@ -191,7 +155,7 @@ func (i *Indexer) processDelivery(rootDir, dir, uploadETag string) error {
 		"xml_content":     primitive.Binary{Data: xmlBytes, Subtype: 0x00}, // Store directly as generic binary for high data integrity
 		"created_at":      time.Now(),
 	}
-	if _, err := i.deliveriesColl.InsertOne(i.ctx, deliveryDoc); err != nil {
+	if _, err := i.DeliveriesColl.InsertOne(i.Ctx, deliveryDoc); err != nil {
 		return fmt.Errorf("failed to insert XML data into Mongo: %w", err)
 	}
 
@@ -200,23 +164,23 @@ func (i *Indexer) processDelivery(rootDir, dir, uploadETag string) error {
 
 // downloadFromRaw downloads a file from the S3 "raw" bucket to a temporary file.
 func (i *Indexer) downloadFromS3Raw(remotePath string) (string, func()) {
-	if !strings.HasPrefix(remotePath, "s3://"+i.rawBucket+"/") {
-		i.logger.Error("Invalid S3 path", "path", remotePath)
+	if !strings.HasPrefix(remotePath, "s3://"+i.RawBucket+"/") {
+		i.Logger.Error("Invalid S3 path", "path", remotePath)
 		return "", func() {}
 	}
-	s3Key := strings.TrimPrefix(remotePath, "s3://"+i.rawBucket+"/")
+	s3Key := strings.TrimPrefix(remotePath, "s3://"+i.RawBucket+"/")
 	file, err := os.CreateTemp("", "*.zip")
 	if err != nil {
-		i.logger.Error("Error creating temp file", "error", err)
+		i.Logger.Error("Error creating temp file", "error", err)
 		return "", func() {}
 	}
 
-	_, err = i.s3Downloader.Download(file, &s3.GetObjectInput{
-		Bucket: aws.String(i.rawBucket),
+	_, err = i.S3Downloader.Download(file, &s3.GetObjectInput{
+		Bucket: aws.String(i.RawBucket),
 		Key:    aws.String(s3Key),
 	})
 	if err != nil {
-		i.logger.Error("Error downloading file from S3", "error", err)
+		i.Logger.Error("Error downloading file from S3", "error", err)
 		file.Close()
 		os.Remove(file.Name())
 		return "", func() {}
@@ -243,7 +207,7 @@ func (i *Indexer) uploadDirToS3Indexed(dirPath, keyPrefix string) {
 	})
 
 	if err != nil {
-		i.logger.Warn("Error walking through the directory", "err", err)
+		i.Logger.Warn("Error walking through the directory", "err", err)
 	}
 }
 
@@ -251,20 +215,20 @@ func (i *Indexer) uploadDirToS3Indexed(dirPath, keyPrefix string) {
 func (i *Indexer) uploadFileToS3Indexed(filePath, fileKey string) {
 	file, err := os.Open(filePath)
 	if err != nil {
-		i.logger.Error("Error opening file", "error", err)
+		i.Logger.Error("Error opening file", "error", err)
 		return
 	}
 	defer file.Close()
 
-	_, err = i.s3Uploader.Upload(&s3manager.UploadInput{
-		Bucket: aws.String(i.indexedBucket),
+	_, err = i.S3Uploader.Upload(&s3manager.UploadInput{
+		Bucket: aws.String(i.IndexedBucket),
 		Key:    aws.String(fileKey),
 		Body:   file,
 	})
 	if err != nil {
-		i.logger.Error("Error uploading file to S3", "error", err)
+		i.Logger.Error("Error uploading file to S3", "error", err)
 	} else {
-		i.logger.Info("Uploaded file to S3", "file", filePath, "key", fileKey)
+		i.Logger.Info("Uploaded file to S3", "file", filePath, "key", fileKey)
 	}
 }
 

--- a/packages/ddex/ingester/parser/parser.go
+++ b/packages/ddex/ingester/parser/parser.go
@@ -9,72 +9,37 @@ import (
 	"ingester/constants"
 	"io"
 	"log"
-	"log/slog"
 	"net/http"
 	"strings"
 	"time"
 
-	"github.com/aws/aws-sdk-go/service/s3/s3manager"
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/bson/primitive"
 	"go.mongodb.org/mongo-driver/mongo"
 )
 
 type Parser struct {
-	s3Downloader        *s3manager.Downloader
-	mongoClient         *mongo.Client
-	rawBucket           string
-	indexedBucket       string
-	deliveriesColl      *mongo.Collection
-	pendingReleasesColl *mongo.Collection
-	usersColl           *mongo.Collection
-	ctx                 context.Context
-	logger              *slog.Logger
+	*common.BaseIngester
 }
 
 // RunNewParser starts the parser service, which listens for new delivery documents in the Mongo "deliveries" collection and turns them into Audius format track format.
 func RunNewParser(ctx context.Context) {
-	logger := slog.With("service", "parser")
-	_, s3Session := common.InitS3Client(logger)
-	mongoClient := common.InitMongoClient(ctx, logger)
-	defer mongoClient.Disconnect(ctx)
-
 	p := &Parser{
-		s3Downloader:        s3manager.NewDownloader(s3Session),
-		mongoClient:         mongoClient,
-		rawBucket:           common.MustGetenv("AWS_BUCKET_RAW"),
-		indexedBucket:       common.MustGetenv("AWS_BUCKET_INDEXED"),
-		deliveriesColl:      mongoClient.Database("ddex").Collection("deliveries"),
-		pendingReleasesColl: mongoClient.Database("ddex").Collection("pending_releases"),
-		usersColl:           mongoClient.Database("ddex").Collection("users"),
-		ctx:                 ctx,
-		logger:              logger,
+		BaseIngester: common.NewBaseIngester(ctx, "parser"),
 	}
+	defer p.MongoClient.Disconnect(ctx)
 
+	// Run migration to create artist name index
 	if err := p.createArtistNameIndex(); err != nil {
 		log.Fatal(err)
 	}
 
-	pipeline := mongo.Pipeline{bson.D{{Key: "$match", Value: bson.D{{Key: "operationType", Value: "insert"}}}}}
-	changeStream, err := p.deliveriesColl.Watch(ctx, pipeline)
-	if err != nil {
-		panic(err)
-	}
-	p.logger.Info("Watching collection 'deliveries'")
-	defer changeStream.Close(ctx)
-
-	for changeStream.Next(ctx) {
-		p.processDelivery(changeStream)
-	}
-
-	if err := changeStream.Err(); err != nil {
-		log.Fatal(err)
-	}
+	p.ProcessChangeStream(p.DeliveriesColl, p.processDelivery)
 }
 
 // createArtistNameIndex creates an index on the name (display name) field in the 'users' collection
 func (p *Parser) createArtistNameIndex() error {
-	_, err := p.usersColl.Indexes().CreateOne(p.ctx, mongo.IndexModel{
+	_, err := p.UsersColl.Indexes().CreateOne(p.Ctx, mongo.IndexModel{
 		Keys: bson.M{"name": 1},
 	})
 	if err != nil {
@@ -86,30 +51,27 @@ func (p *Parser) createArtistNameIndex() error {
 func (p *Parser) getArtistID(artistName string) (string, error) {
 	// Search Mongo for an exact match on artist name
 	filter := bson.M{"name": artistName}
-	cursor, err := p.usersColl.Find(p.ctx, filter)
+	cursor, err := p.UsersColl.Find(p.Ctx, filter)
 	if err != nil {
 		return "", err
 	}
-	defer cursor.Close(p.ctx)
+	defer cursor.Close(p.Ctx)
 
 	var results []bson.M
-	if err = cursor.All(p.ctx, &results); err != nil {
+	if err = cursor.All(p.Ctx, &results); err != nil {
 		return "", err
 	}
 
-	// Fail if multiple artists have their display name set to the same thing
+	// Fail if multiple artists have their display name set to the same string
 	if len(results) > 1 {
-		var matchingHandles []string
+		var handles []string
 		for _, result := range results {
 			if handle, ok := result["handle"].(string); ok {
-				matchingHandles = append(matchingHandles, "@"+handle)
+				handles = append(handles, "@"+handle)
 			}
 		}
-
-		// Join the artist IDs with commas
-		idsStr := strings.Join(matchingHandles, ", ")
-
-		return "", fmt.Errorf("error: more than one artist found with the same display name: : %s", idsStr)
+		idsStr := strings.Join(handles, ", ")
+		return "", fmt.Errorf("error: more than one artist found with the same display name: %s", idsStr)
 	}
 
 	// Fail if no artist is found, and use /v1/users/search to display potential matches in the error message
@@ -168,18 +130,19 @@ func (p *Parser) processDelivery(changeStream *mongo.ChangeStream) {
 		log.Fatal(err)
 	}
 	delivery := changeDoc.FullDocument
-	p.logger.Info("Processing new delivery", "_id", delivery.ID)
+	p.Logger.Info("Processing new delivery", "_id", delivery.ID)
 
 	xmlData := delivery.XmlContent.Data
-	createTrackRelease, createAlbumRelease, errs := parseSonyXML(xmlData, p.indexedBucket, delivery.ID.Hex())
+	createTrackRelease, createAlbumRelease, errs := parseSonyXML(xmlData, p.IndexedBucket, delivery.ID.Hex())
 	if len(errs) != 0 {
-		p.logger.Error("Failed to parse delivery. Printing errors...")
+		p.Logger.Error("Failed to parse delivery. Printing errors...")
 		for _, err := range errs {
-			p.logger.Error(err.Error())
+			p.Logger.Error(err.Error())
 		}
 		p.failAndUpdateStatus(delivery.ID, fmt.Errorf("failed to parse delivery: %v", errs))
+		return
 	}
-	p.logger.Info("Parsed delivery", "createTrackRelease", fmt.Sprintf("%+v", createTrackRelease), "createAlbumRelease", fmt.Sprintf("%+v", createAlbumRelease))
+	p.Logger.Info("Parsed delivery", "createTrackRelease", fmt.Sprintf("%+v", createTrackRelease), "createAlbumRelease", fmt.Sprintf("%+v", createAlbumRelease))
 
 	// If there's an album release, the tracks we parsed out are actually part of the album release
 	if len(createAlbumRelease) > 0 {
@@ -192,6 +155,7 @@ func (p *Parser) processDelivery(changeStream *mongo.ChangeStream) {
 		artistID, err := p.getArtistID(track.Metadata.ArtistName)
 		if err != nil {
 			p.failAndUpdateStatus(delivery.ID, fmt.Errorf("track '%s' failed to find artist ID for '%s': %v", track.Metadata.Title, track.Metadata.ArtistName, err))
+			return
 		}
 		track.Metadata.ArtistID = artistID
 	}
@@ -200,18 +164,21 @@ func (p *Parser) processDelivery(changeStream *mongo.ChangeStream) {
 		artistID, err := p.getArtistID(album.Metadata.PlaylistOwnerName)
 		if err != nil {
 			p.failAndUpdateStatus(delivery.ID, fmt.Errorf("album '%s' failed to find artist ID for '%s': %v", album.Metadata.PlaylistName, album.Metadata.PlaylistOwnerName, err))
+			return
 		}
 		album.Metadata.PlaylistOwnerID = artistID
 	}
 
-	session, err := p.mongoClient.StartSession()
+	session, err := p.MongoClient.StartSession()
 	if err != nil {
 		p.failAndUpdateStatus(delivery.ID, err)
+		return
 	}
-	err = mongo.WithSession(p.ctx, session, func(sessionCtx mongo.SessionContext) error {
+	err = mongo.WithSession(p.Ctx, session, func(sessionCtx mongo.SessionContext) error {
 		if err := session.StartTransaction(); err != nil {
 			return err
 		}
+		defer session.EndSession(p.Ctx)
 
 		// 2. Write each release in "delivery_xml" in the delivery as a bson doc in the 'pending_releases' collection
 		for _, track := range createTrackRelease {
@@ -222,12 +189,12 @@ func (p *Parser) processDelivery(changeStream *mongo.ChangeStream) {
 				"publish_date":         track.Metadata.ReleaseDate,
 				"created_at":           time.Now(),
 			}
-			result, err := p.pendingReleasesColl.InsertOne(p.ctx, pendingRelease)
+			result, err := p.PendingReleasesColl.InsertOne(p.Ctx, pendingRelease)
 			if err != nil {
 				session.AbortTransaction(sessionCtx)
 				return err
 			}
-			p.logger.Info("Inserted pending track release", "_id", result.InsertedID)
+			p.Logger.Info("Inserted pending track release", "_id", result.InsertedID)
 		}
 		for _, album := range createAlbumRelease {
 			pendingRelease := bson.M{
@@ -237,12 +204,12 @@ func (p *Parser) processDelivery(changeStream *mongo.ChangeStream) {
 				"publish_date":         album.Metadata.ReleaseDate,
 				"created_at":           time.Now(),
 			}
-			result, err := p.pendingReleasesColl.InsertOne(p.ctx, pendingRelease)
+			result, err := p.PendingReleasesColl.InsertOne(p.Ctx, pendingRelease)
 			if err != nil {
 				session.AbortTransaction(sessionCtx)
 				return err
 			}
-			p.logger.Info("Inserted pending album release", "_id", result.InsertedID)
+			p.Logger.Info("Inserted pending album release", "_id", result.InsertedID)
 		}
 
 		// 3. Set delivery status for delivery in 'deliveries' collection
@@ -258,8 +225,6 @@ func (p *Parser) processDelivery(changeStream *mongo.ChangeStream) {
 	if err != nil {
 		p.failAndUpdateStatus(delivery.ID, err)
 	}
-
-	session.EndSession(p.ctx)
 }
 
 func (p *Parser) setDeliveryStatus(documentId primitive.ObjectID, status string, err error, ctx context.Context) error {
@@ -273,15 +238,15 @@ func (p *Parser) setDeliveryStatus(documentId primitive.ObjectID, status string,
 		update = bson.M{"$set": bson.M{"delivery_status": status}}
 	}
 
-	_, updateErr := p.deliveriesColl.UpdateByID(ctx, documentId, update)
+	_, updateErr := p.DeliveriesColl.UpdateByID(ctx, documentId, update)
 	return updateErr
 }
 
-func (p *Parser) failAndUpdateStatus(documentId primitive.ObjectID, err error) {
-	updateErr := p.setDeliveryStatus(documentId, constants.DeliveryStatusError, err, p.ctx)
+func (p *Parser) failAndUpdateStatus(documentID primitive.ObjectID, err error) {
+	updateErr := p.setDeliveryStatus(documentID, constants.DeliveryStatusError, err, p.Ctx)
 	if updateErr != nil {
-		log.Fatal(fmt.Errorf("failed to set error on delivery status: %v. original err: %v", updateErr, err))
+		p.Logger.Error("Failed to set error on delivery status", "documentID", documentID, "updateErr", updateErr, "originalErr", err)
 	} else {
-		log.Fatal(err)
+		p.Logger.Error("Set delivery status to error", "documentID", documentID, "error", err)
 	}
 }


### PR DESCRIPTION
- Makes Mongo change streams catch up where they left off between restarts / offline time
- Cleans up shared code between the DDEX services
- Makes some expected parsing errors recoverable instead of using log.Fatal