### PR TITLE
[C-3881] Add apiKey to the jwt payload

### DIFF
--- a/docs/docs/developers/log-in-with-audius.mdx
+++ b/docs/docs/developers/log-in-with-audius.mdx
@@ -101,6 +101,7 @@ audiusSdk.oauth.init({
         handle: string;
         verified: boolean; // whether the user has the Audius "verified" checkmark
         profilePicture: {"150x150": string, "480x480": string, "1000x1000": string } | null // URLs for the user's profile picture
+        apiKey: string | null // the API key for your application if specified
         sub: number; // alias for userId
         iat: string; // timestamp for when auth was performed
       }
@@ -408,6 +409,7 @@ We recommend selecting a host each time your application starts up as availabili
   handle: string,
   verified: boolean, // whether the user has the Audius "verified" checkmark
   profilePicture: {"150x150": string, "480x480": string, "1000x1000": string } | null // URLs for the user's profile picture
+  apiKey: string | null // the API key for your application if specified
   sub: number, // alias for userId
   iat: string, // timestamp for when auth was performed
 }

--- a/docs/docs/developers/sdk-oauth-methods.mdx
+++ b/docs/docs/developers/sdk-oauth-methods.mdx
@@ -37,6 +37,7 @@ Enables the Audius OAuth functionality. Call this before using any other `oauth`
     * If the user has no profile picture, this field will be empty.
     */
     profilePicture: {"150x150": string, "480x480": string, "1000x1000": string } | { misc: string } | undefined | null
+    apiKey: string | null // the API key for your application if specified
     sub: number; // alias for userId
     iat: string; // timestamp for when auth was performed
   }

--- a/packages/web/src/pages/oauth-login-page/hooks.ts
+++ b/packages/web/src/pages/oauth-login-page/hooks.ts
@@ -315,6 +315,7 @@ export const useOAuthSetup = ({
       const jwt = await formOAuthResponse({
         account,
         userEmail,
+        apiKey,
         onError: () => {
           dispatch(
             errorActions.handleError({

--- a/packages/web/src/pages/oauth-login-page/utils.ts
+++ b/packages/web/src/pages/oauth-login-page/utils.ts
@@ -104,11 +104,13 @@ export const getFormattedAppAddress = ({
 export const formOAuthResponse = async ({
   account,
   userEmail,
+  apiKey,
+  onError,
   txSignature, // Only applicable to scope = write_once
-  onError
 }: {
   account: User
   userEmail?: string | null
+  apiKey: string | string[] | null
   onError: () => void
   txSignature?: { message: string; signature: string }
 }) => {
@@ -173,6 +175,7 @@ export const formOAuthResponse = async ({
     handle: account?.handle,
     verified: account?.is_verified,
     profilePicture,
+    apiKey,
     ...(txSignature ? { txSignature } : {}),
     sub: userId,
     iat: timestamp


### PR DESCRIPTION
### Description

Allows apps to validate that the jwt generated used was from their app (and not forged).

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._

Will test auth flows on stage, but change should be safe. Discovery node verify endpoint simply returns the entire payload.

