### PR TITLE
[INF-659] Remove flipper and enable experimental debugger

### DIFF
--- a/packages/mobile/ios/AudiusReactNative.xcodeproj/xcshareddata/xcschemes/Staging.xcscheme
+++ b/packages/mobile/ios/AudiusReactNative.xcodeproj/xcshareddata/xcschemes/Staging.xcscheme
@@ -59,15 +59,6 @@
       debugDocumentVersioning = "YES"
       debugServiceExtension = "internal"
       allowLocationSimulation = "YES">
-      <PreActions>
-         <ExecutionAction
-            ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">
-            <ActionContent
-               title = "Run Script"
-               scriptText = "# Type a script or drag a script file from your workspace to insert its path.&#10;">
-            </ActionContent>
-         </ExecutionAction>
-      </PreActions>
       <BuildableProductRunnable
          runnableDebuggingMode = "0">
          <BuildableReference

--- a/packages/mobile/ios/Podfile
+++ b/packages/mobile/ios/Podfile
@@ -18,8 +18,6 @@ setup_permissions([
   'PhotoLibraryAddOnly',
 ])
 
-flipper_config = ENV['NO_FLIPPER'] == "1" ? FlipperConfiguration.disabled : FlipperConfiguration.enabled(["Debug", "Staging.Debug"], { 'Flipper' => '0.175.0' })
-
 linkage = ENV['USE_FRAMEWORKS']
 if linkage != nil
   Pod::UI.puts "Configuring Pod with #{linkage}ally linked Frameworks".green
@@ -41,11 +39,6 @@ target 'AudiusReactNative' do
 
   use_react_native!(
     :path => config[:reactNativePath],
-    # Enables Flipper.
-    #
-    # Note that if you have use_frameworks! enabled, Flipper will not work and
-    # you should disable the next line.
-    :flipper_configuration => flipper_config,
     # An absolute path to your application root.
     :app_path => "#{Pod::Config.instance.installation_root}/.."
   )

--- a/packages/mobile/ios/Podfile.lock
+++ b/packages/mobile/ios/Podfile.lock
@@ -9,7 +9,6 @@ PODS:
   - boost (1.83.0)
   - BVLinearGradient (2.8.3):
     - React-Core
-  - CocoaAsyncSocket (7.6.5)
   - CodePush (8.1.1):
     - Base64 (~> 1.1)
     - JWT (~> 3.0.0-beta.12)
@@ -29,64 +28,6 @@ PODS:
     - ffmpeg-kit-ios-https-gpl (= 6.0.LTS)
     - React-Core
   - FingerprintPro (2.3.2)
-  - Flipper (0.175.0):
-    - Flipper-Folly (~> 2.6)
-  - Flipper-Boost-iOSX (1.76.0.1.11)
-  - Flipper-DoubleConversion (3.2.0.1)
-  - Flipper-Fmt (7.1.7)
-  - Flipper-Folly (2.6.10):
-    - Flipper-Boost-iOSX
-    - Flipper-DoubleConversion
-    - Flipper-Fmt (= 7.1.7)
-    - Flipper-Glog
-    - libevent (~> 2.1.12)
-    - OpenSSL-Universal (= 1.1.1100)
-  - Flipper-Glog (0.5.0.5)
-  - Flipper-PeerTalk (0.0.4)
-  - FlipperKit (0.175.0):
-    - FlipperKit/Core (= 0.175.0)
-  - FlipperKit/Core (0.175.0):
-    - Flipper (~> 0.175.0)
-    - FlipperKit/CppBridge
-    - FlipperKit/FBCxxFollyDynamicConvert
-    - FlipperKit/FBDefines
-    - FlipperKit/FKPortForwarding
-    - SocketRocket (~> 0.6.0)
-  - FlipperKit/CppBridge (0.175.0):
-    - Flipper (~> 0.175.0)
-  - FlipperKit/FBCxxFollyDynamicConvert (0.175.0):
-    - Flipper-Folly (~> 2.6)
-  - FlipperKit/FBDefines (0.175.0)
-  - FlipperKit/FKPortForwarding (0.175.0):
-    - CocoaAsyncSocket (~> 7.6)
-    - Flipper-PeerTalk (~> 0.0.4)
-  - FlipperKit/FlipperKitHighlightOverlay (0.175.0)
-  - FlipperKit/FlipperKitLayoutHelpers (0.175.0):
-    - FlipperKit/Core
-    - FlipperKit/FlipperKitHighlightOverlay
-    - FlipperKit/FlipperKitLayoutTextSearchable
-  - FlipperKit/FlipperKitLayoutIOSDescriptors (0.175.0):
-    - FlipperKit/Core
-    - FlipperKit/FlipperKitHighlightOverlay
-    - FlipperKit/FlipperKitLayoutHelpers
-    - YogaKit (~> 1.18)
-  - FlipperKit/FlipperKitLayoutPlugin (0.175.0):
-    - FlipperKit/Core
-    - FlipperKit/FlipperKitHighlightOverlay
-    - FlipperKit/FlipperKitLayoutHelpers
-    - FlipperKit/FlipperKitLayoutIOSDescriptors
-    - FlipperKit/FlipperKitLayoutTextSearchable
-    - YogaKit (~> 1.18)
-  - FlipperKit/FlipperKitLayoutTextSearchable (0.175.0)
-  - FlipperKit/FlipperKitNetworkPlugin (0.175.0):
-    - FlipperKit/Core
-  - FlipperKit/FlipperKitReactPlugin (0.175.0):
-    - FlipperKit/Core
-  - FlipperKit/FlipperKitUserDefaultsPlugin (0.175.0):
-    - FlipperKit/Core
-  - FlipperKit/SKIOSNetworkPlugin (0.175.0):
-    - FlipperKit/Core
-    - FlipperKit/FlipperKitNetworkPlugin
   - fmt (6.2.1)
   - glog (0.3.5)
   - google-cast-sdk-dynamic-xcframework-no-bluetooth (4.8.0)
@@ -113,7 +54,6 @@ PODS:
     - lottie-ios (~> 4.3.3)
     - React-Core
   - nSure (1.3.1)
-  - OpenSSL-Universal (1.1.1100)
   - PromisesObjC (2.3.1)
   - RCT-Folly (2022.05.16.00):
     - boost
@@ -1313,8 +1253,6 @@ PODS:
   - TikTokOpenSDK (5.0.0)
   - TOCropViewController (2.6.1)
   - Yoga (1.14.0)
-  - YogaKit (1.18.1):
-    - Yoga (~> 1.14)
 
 DEPENDENCIES:
   - "amplitude-react-native (from `../../../node_modules/@amplitude/react-native`)"
@@ -1325,32 +1263,11 @@ DEPENDENCIES:
   - FBLazyVector (from `../node_modules/react-native/Libraries/FBLazyVector`)
   - FBReactNativeSpec (from `../node_modules/react-native/React/FBReactNativeSpec`)
   - ffmpeg-kit-react-native/https-gpl-lts (from `../node_modules/ffmpeg-kit-react-native/ffmpeg-kit-react-native.podspec`)
-  - Flipper (= 0.175.0)
-  - Flipper-Boost-iOSX (= 1.76.0.1.11)
-  - Flipper-DoubleConversion (= 3.2.0.1)
-  - Flipper-Fmt (= 7.1.7)
-  - Flipper-Folly (= 2.6.10)
-  - Flipper-Glog (= 0.5.0.5)
-  - Flipper-PeerTalk (= 0.0.4)
-  - FlipperKit (= 0.175.0)
-  - FlipperKit/Core (= 0.175.0)
-  - FlipperKit/CppBridge (= 0.175.0)
-  - FlipperKit/FBCxxFollyDynamicConvert (= 0.175.0)
-  - FlipperKit/FBDefines (= 0.175.0)
-  - FlipperKit/FKPortForwarding (= 0.175.0)
-  - FlipperKit/FlipperKitHighlightOverlay (= 0.175.0)
-  - FlipperKit/FlipperKitLayoutPlugin (= 0.175.0)
-  - FlipperKit/FlipperKitLayoutTextSearchable (= 0.175.0)
-  - FlipperKit/FlipperKitNetworkPlugin (= 0.175.0)
-  - FlipperKit/FlipperKitReactPlugin (= 0.175.0)
-  - FlipperKit/FlipperKitUserDefaultsPlugin (= 0.175.0)
-  - FlipperKit/SKIOSNetworkPlugin (= 0.175.0)
   - glog (from `../node_modules/react-native/third-party-podspecs/glog.podspec`)
   - hermes-engine (from `../node_modules/react-native/sdks/hermes-engine/hermes-engine.podspec`)
   - libevent (~> 2.1.12)
   - lottie-react-native (from `../node_modules/lottie-react-native`)
   - nSure
-  - OpenSSL-Universal (= 1.1.1100)
   - RCT-Folly (from `../node_modules/react-native/third-party-podspecs/RCT-Folly.podspec`)
   - RCT-Folly/Fabric (from `../node_modules/react-native/third-party-podspecs/RCT-Folly.podspec`)
   - RCTRequired (from `../node_modules/react-native/Libraries/RCTRequired`)
@@ -1359,7 +1276,6 @@ DEPENDENCIES:
   - React-callinvoker (from `../node_modules/react-native/ReactCommon/callinvoker`)
   - React-Codegen (from `build/generated/ios`)
   - React-Core (from `../node_modules/react-native/`)
-  - React-Core/DevSupport (from `../node_modules/react-native/`)
   - React-Core/RCTWebSocket (from `../node_modules/react-native/`)
   - React-CoreModules (from `../node_modules/react-native/React/CoreModules`)
   - React-cxxreact (from `../node_modules/react-native/ReactCommon/cxxreact`)
@@ -1447,17 +1363,8 @@ SPEC REPOS:
     - Amplitude
     - AnalyticsConnector
     - Base64
-    - CocoaAsyncSocket
     - ffmpeg-kit-ios-https-gpl
     - FingerprintPro
-    - Flipper
-    - Flipper-Boost-iOSX
-    - Flipper-DoubleConversion
-    - Flipper-Fmt
-    - Flipper-Folly
-    - Flipper-Glog
-    - Flipper-PeerTalk
-    - FlipperKit
     - fmt
     - google-cast-sdk-dynamic-xcframework-no-bluetooth
     - JWT
@@ -1465,7 +1372,6 @@ SPEC REPOS:
     - libwebp
     - lottie-ios
     - nSure
-    - OpenSSL-Universal
     - PromisesObjC
     - RiveRuntime
     - SDWebImage
@@ -1478,7 +1384,6 @@ SPEC REPOS:
     - SwiftAudioEx
     - TikTokOpenSDK
     - TOCropViewController
-    - YogaKit
 
 EXTERNAL SOURCES:
   amplitude-react-native:
@@ -1686,7 +1591,6 @@ SPEC CHECKSUMS:
   Base64: cecfb41a004124895a7bcee567a89bae5a89d49b
   boost: 69c3d61aee7f5f7facabe24312f0302003b5af29
   BVLinearGradient: 880f91a7854faff2df62518f0281afb1c60d49a3
-  CocoaAsyncSocket: 065fd1e645c7abab64f7a6a2007a48038fdc6a99
   CodePush: c3fdecab0dba1f760a1c6d1a562b9b88ce311fe1
   DoubleConversion: fea03f2699887d960129cc54bba7e52542b6f953
   FBLazyVector: 2296bacb2fa157a43991048b0a9d71c1c8b65083
@@ -1694,14 +1598,6 @@ SPEC CHECKSUMS:
   ffmpeg-kit-ios-https-gpl: 4f25b11cc9d0f20ed0d938061d242541a8ae531a
   ffmpeg-kit-react-native: 3cea88c9c5cfad62e1465279ea7d800dfbba3b00
   FingerprintPro: c6444f5a00d1126446da664124529e754475f198
-  Flipper: d9d1aa67916620c9a6af11cb8275f06cd522943e
-  Flipper-Boost-iOSX: fd1e2b8cbef7e662a122412d7ac5f5bea715403c
-  Flipper-DoubleConversion: 2dc99b02f658daf147069aad9dbd29d8feb06d30
-  Flipper-Fmt: 60cbdd92fc254826e61d669a5d87ef7015396a9b
-  Flipper-Folly: 584845625005ff068a6ebf41f857f468decd26b3
-  Flipper-Glog: 70c50ce58ddaf67dc35180db05f191692570f446
-  Flipper-PeerTalk: 116d8f857dc6ef55c7a5a75ea3ceaafe878aadc9
-  FlipperKit: 9f6df8cb028c2acd537ce24c1993aba142eceaf0
   fmt: ff9d55029c625d3757ed641535fd4a75fedc7ce9
   glog: c5d68082e772fa1c511173d6b30a9de2c05a69a2
   google-cast-sdk-dynamic-xcframework-no-bluetooth: 09d47191ef8821d82e813e754bcf98bc61a3dbc9
@@ -1712,7 +1608,6 @@ SPEC CHECKSUMS:
   lottie-ios: 3d98679b41fa6fd6aff2352b3953dbd3df8a397e
   lottie-react-native: a2ae9c27c273b060b2affff2957bc0ff7fdca353
   nSure: b2d7022f54c180c5afd88f9f79073841e1cfa844
-  OpenSSL-Universal: ebc357f1e6bc71fa463ccb2fe676756aff50e88c
   PromisesObjC: c50d2056b5253dadbd6c2bea79b0674bd5a52fa4
   RCT-Folly: 7169b2b1c44399c76a47b5deaaba715eeeb476c0
   RCTRequired: 6dda55e483f75d2b43781d8ad5bd7df276a50981
@@ -1812,8 +1707,7 @@ SPEC CHECKSUMS:
   TikTokOpenSDK: a63564ea4dc1fabc56352bf7aa9ddc386cdb63b6
   TOCropViewController: edfd4f25713d56905ad1e0b9f5be3fbe0f59c863
   Yoga: 4f53dc50008d626fa679c7a1cb4bed898f8c0bde
-  YogaKit: f782866e155069a2cca2517aafea43200b01fd5a
 
-PODFILE CHECKSUM: ab62f00b76ec92f97506cd7b0a75c5c470923f11
+PODFILE CHECKSUM: 82012892a9211b68a6524992c2822b7e06765cbd
 
 COCOAPODS: 1.13.0

--- a/packages/mobile/package.json
+++ b/packages/mobile/package.json
@@ -30,7 +30,7 @@
     "codepush-android-history:prod": "appcenter codepush deployment history -a Audius-Music/Audius-Android Production",
     "codepush-android-history:rc": "appcenter codepush deployment history -a Audius-Music/Audius-Android ReleaseCandidate",
     "codepush-android-history:staging": "appcenter codepush deployment history -a Audius-Music/Audius-Android Staging",
-    "start": "react-native start",
+    "start": "react-native start --experimental-debugger",
     "start:e2e": "RN_E2E=true react-native start",
     "start:storybook": "RN_STORYBOOK=true react-native start",
     "test": "jest src",


### PR DESCRIPTION
### Description

* Remove Flipper (deprecated)
* Set `--experimental-debugger` flag
* Working on doc with debugging instructions: https://www.notion.so/audiusproject/React-Native-Debugging-863813850b7a43c098b48d41acefd825

Next up -> redux dev tools

### How Has This Been Tested?

Confirmed debugger working on ios simulator and android emulator. Going to test on device still
