### PR TITLE
[PAY-2513] Fix file size text wrap on web DownloadRow

### DIFF
--- a/packages/web/src/components/track/DownloadRow.tsx
+++ b/packages/web/src/components/track/DownloadRow.tsx
@@ -113,7 +113,14 @@ export const DownloadRow = ({
       </Flex>
       <Flex gap='2xl'>
         {size && !isMobile ? (
-          <Text variant='body' size='s' color='subdued'>
+          <Text
+            variant='body'
+            size='s'
+            color='subdued'
+            css={{
+              'white-space': 'nowrap'
+            }}
+          >
             {formatBytes(size)}
           </Text>
         ) : null}


### PR DESCRIPTION
### Description
Needed `white-space: nowrap`.

### How Has This Been Tested?

<img width="1920" alt="Screenshot 2024-02-22 at 2 06 52 PM" src="https://github.com/AudiusProject/audius-protocol/assets/3893871/0e2f392e-e4ad-4893-a9dd-9a2bbf9ec49d">
