### PR TITLE
[C-3880] Add bottom padding to the safe area on the sign in screen

### DIFF
--- a/packages/mobile/src/screens/sign-on-screen/screens/SignOnScreen.tsx
+++ b/packages/mobile/src/screens/sign-on-screen/screens/SignOnScreen.tsx
@@ -41,6 +41,8 @@ const AnimatedFlex = Animated.createAnimatedComponent(Flex)
 
 const CreateAccountLink = (props: TextProps) => {
   const { onPress } = props
+  const { spacing } = useTheme()
+
   return (
     <AnimatedFlex
       alignItems='center'
@@ -49,7 +51,7 @@ const CreateAccountLink = (props: TextProps) => {
       entering={FadeIn}
       exiting={FadeOut}
     >
-      <SafeAreaView>
+      <SafeAreaView style={{ paddingBottom: spacing['3xl'] }}>
         <Text
           variant='title'
           strength='weak'


### PR DESCRIPTION
### Description
Add bottom padding to avoid the link being covered by android os buttons

### How Has This Been Tested?
Manually Tested

Padding looked good on ios simulator and Android device
