### PR TITLE
Fix amplitude key injection on mobile

### DIFF
--- a/.circleci/src/jobs/@mobile-jobs.yml
+++ b/.circleci/src/jobs/@mobile-jobs.yml
@@ -8,12 +8,12 @@ mobile-init:
         name: copy staging env
         command: |
           cd packages/mobile
-          echo "AMPLITUDE_WRITE_KEY=$AMPLITUDE_WRITE_KEY_STAGE" >> .env.stage
+          echo -e "\nAMPLITUDE_WRITE_KEY=$AMPLITUDE_WRITE_KEY_STAGE" >> .env.stage
     - run:
         name: copy production env
         command: |
           cd packages/mobile
-          echo "AMPLITUDE_WRITE_KEY=$AMPLITUDE_WRITE_KEY_PROD" >> .env.prod
+          echo -e "\nAMPLITUDE_WRITE_KEY=$AMPLITUDE_WRITE_KEY_PROD" >> .env.prod
 
     - create_concatenated_patch_file:
         filename: combined-patch-file.txt


### PR DESCRIPTION
Co-authored-by: Saliou saliou@audius.co
Co-authored-by: Reed reed@audius.co
Co-authored-by: Ray ray@audius.co

### Description

Fixes issue where env key injection fails because some config files don't have a new line. This updates the injection script to ensure we always add a new line before adding env key