### PR TITLE
Fix half-load of spring animation on all <Page> components

### DIFF
--- a/packages/web/src/components/page/Page.tsx
+++ b/packages/web/src/components/page/Page.tsx
@@ -10,7 +10,8 @@ import {
 
 import { Nullable } from '@audius/common/utils'
 import cn from 'classnames'
-import { animated, useSpring } from 'react-spring/web'
+// eslint-disable-next-line no-restricted-imports -- TODO: migrate to @react-spring/web
+import { animated, useSpring } from 'react-spring'
 // @ts-ignore
 import calcScrollbarWidth from 'scrollbar-width'
 

--- a/packages/web/src/components/page/Page.tsx
+++ b/packages/web/src/components/page/Page.tsx
@@ -10,8 +10,7 @@ import {
 
 import { Nullable } from '@audius/common/utils'
 import cn from 'classnames'
-// eslint-disable-next-line no-restricted-imports -- TODO: migrate to @react-spring/web
-import { Spring } from 'react-spring/renderprops.cjs'
+import { animated, useSpring } from 'react-spring'
 // @ts-ignore
 import calcScrollbarWidth from 'scrollbar-width'
 
@@ -156,66 +155,63 @@ export const Page = (props: PageProps) => {
     structuredData,
     noIndex
   }
+  const springProps = useSpring({
+    from: { opacity: fromOpacity },
+    opacity: 1,
+    config: { duration: fadeDuration }
+  })
 
   return (
     <>
       <MetaTags {...metaTagsProps} />
-      <Spring
-        from={{ opacity: fromOpacity }}
-        to={{ opacity: 1 }}
-        config={{ duration: fadeDuration }}
-      >
-        {(animProps) => (
-          <div
-            ref={containerRef}
-            style={animProps}
-            className={cn(
-              styles.pageContainer,
-              props.containerClassName,
-              props.className
-            )}
-          >
-            {header && (
-              <HeaderContainer
-                header={header}
-                showSearch={showSearch}
-                containerRef={calculateHeaderHeight}
-              />
-            )}
-            <div
-              className={cn({
-                [styles.inset]: variant === 'inset',
-                [styles.flush]: variant === 'flush',
-                [styles.medium]: size === 'medium',
-                [styles.large]: size === 'large',
-                [containerClassName ?? '']: !!containerClassName
-              })}
-              style={
-                variant === 'inset'
-                  ? { paddingTop: `${headerHeight + HEADER_MARGIN_PX}px` }
-                  : undefined
-              }
-            >
-              {/* Set an id so that nested components can mount in relation to page if needed, e.g. fixed menu popups. */}
-              <div
-                id='page'
-                className={cn(styles.pageContent, {
-                  [contentClassName ?? '']: !!contentClassName
-                })}
-              >
-                {children}
-              </div>
-            </div>
-            <ClientOnly>
-              {scrollableSearch && (
-                <div className={styles.searchWrapper}>
-                  <SearchBar />
-                </div>
-              )}
-            </ClientOnly>
-          </div>
+      <animated.div
+        ref={containerRef}
+        style={springProps}
+        className={cn(
+          styles.pageContainer,
+          props.containerClassName,
+          props.className
         )}
-      </Spring>
+      >
+        {header && (
+          <HeaderContainer
+            header={header}
+            showSearch={showSearch}
+            containerRef={calculateHeaderHeight}
+          />
+        )}
+        <div
+          className={cn({
+            [styles.inset]: variant === 'inset',
+            [styles.flush]: variant === 'flush',
+            [styles.medium]: size === 'medium',
+            [styles.large]: size === 'large',
+            [containerClassName ?? '']: !!containerClassName
+          })}
+          style={
+            variant === 'inset'
+              ? { paddingTop: `${headerHeight + HEADER_MARGIN_PX}px` }
+              : undefined
+          }
+        >
+          {/* Set an id so that nested components can mount in relation to page if needed, e.g. fixed menu popups. */}
+          <div
+            id='page'
+            className={cn(styles.pageContent, {
+              [contentClassName ?? '']: !!contentClassName
+            })}
+          >
+            {children}
+          </div>
+        </div>
+        <ClientOnly>
+          {scrollableSearch && (
+            <div className={styles.searchWrapper}>
+              <SearchBar />
+            </div>
+          )}
+        </ClientOnly>
+      </animated.div>
     </>
   )
 }

--- a/packages/web/src/components/page/Page.tsx
+++ b/packages/web/src/components/page/Page.tsx
@@ -10,7 +10,7 @@ import {
 
 import { Nullable } from '@audius/common/utils'
 import cn from 'classnames'
-import { animated, useSpring } from 'react-spring'
+import { animated, useSpring } from 'react-spring/web'
 // @ts-ignore
 import calcScrollbarWidth from 'scrollbar-width'
 


### PR DESCRIPTION
### Description

Not quite sure what changed and how this actually triggers, but recently on dev, stage, and prod, I've been seeing a partial load of all pages where the opacity never moves from 0.2. It seems like moving to the useSpring hook model instead of the cjs component works.

![image](https://github.com/AudiusProject/audius-protocol/assets/2731362/f5d61cc0-4f1b-4993-b752-7a011843d369)


### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._

Can't repro any more, but maybe not a for-sure fix.
