### PR TITLE
Fix app site association

### DIFF
--- a/packages/web/scripts/workers-site/index.js
+++ b/packages/web/scripts/workers-site/index.js
@@ -341,7 +341,8 @@ function isAssetUrl(url) {
     pathname.startsWith('/scripts') ||
     pathname.startsWith('/fonts') ||
     pathname.startsWith('/favicons') ||
-    pathname.startsWith('/manifest.json')
+    pathname.startsWith('/manifest.json') ||
+    pathname.startsWith('/.well-known')
   )
 }
 

--- a/packages/web/src/ssr/worker.js
+++ b/packages/web/src/ssr/worker.js
@@ -78,6 +78,7 @@ function isAssetUrl(url) {
     pathname.startsWith('/scripts') ||
     pathname.startsWith('/fonts') ||
     pathname.startsWith('/favicons') ||
-    pathname.startsWith('/manifest.json')
+    pathname.startsWith('/manifest.json') ||
+    pathname.startsWith('/.well-known')
   )
 }


### PR DESCRIPTION
### Description

Changes in the worker caused `/.well-known/apple-app-site-association` to no longer serve the correct file. Fixed this by including `/.well-known` in the list of asset paths

### How Has This Been Tested?

Edited prod worker to confirm file is served correctly
