### PR TITLE
Add documents path to asset url check

### DIFF
--- a/packages/web/scripts/workers-site/index.js
+++ b/packages/web/scripts/workers-site/index.js
@@ -342,7 +342,8 @@ function isAssetUrl(url) {
     pathname.startsWith('/fonts') ||
     pathname.startsWith('/favicons') ||
     pathname.startsWith('/manifest.json') ||
-    pathname.startsWith('/.well-known')
+    pathname.startsWith('/.well-known') ||
+    pathname.startsWith('/documents')
   )
 }
 

--- a/packages/web/src/ssr/worker.js
+++ b/packages/web/src/ssr/worker.js
@@ -79,6 +79,7 @@ function isAssetUrl(url) {
     pathname.startsWith('/fonts') ||
     pathname.startsWith('/favicons') ||
     pathname.startsWith('/manifest.json') ||
-    pathname.startsWith('/.well-known')
+    pathname.startsWith('/.well-known') ||
+    pathname.startsWith('/documents')
   )
 }


### PR DESCRIPTION
### Description
Fixes errors with pages that show assets from the `documents` folder (such as privacy policy and TOS)

### How Has This Been Tested?
This is porting a change already live on CF, so tested in prod! 😅 
