### PR TITLE
Update welcome drawer close functionality to always open the notifications drawer

### DIFF
--- a/packages/mobile/src/screens/sign-on-screen/components/WelcomeDrawer.tsx
+++ b/packages/mobile/src/screens/sign-on-screen/components/WelcomeDrawer.tsx
@@ -31,13 +31,17 @@ export const WelcomeDrawer = () => {
   const { onClose: closeDrawer } = useDrawer('Welcome')
   const dispatch = useDispatch()
 
+  const openNotificationsDrawer = useCallback(() => {
+    dispatch(requestPushNotificationPermissions())
+  }, [dispatch])
+
   const handleClose = useCallback(() => {
     closeDrawer()
-    dispatch(requestPushNotificationPermissions())
-  }, [closeDrawer, dispatch])
+    openNotificationsDrawer()
+  }, [closeDrawer, openNotificationsDrawer])
 
   return (
-    <NativeDrawer drawerName='Welcome'>
+    <NativeDrawer drawerName='Welcome' onClose={openNotificationsDrawer}>
       <Flex w='100%' h={96} style={css({ zIndex: 1 })}>
         <ReadOnlyCoverPhotoBanner />
         <Flex


### PR DESCRIPTION
### Description
Was originally looking into the overlap issue, but noticed this bug.
Just added the open notif drawer call to the onClose of the drawer

### How Has This Been Tested?

Manually tested
