### PR TITLE
Allow empty adc auto-deploy commits

### DIFF
--- a/.circleci/src/jobs/commit-audius-docker-compose-and-notify.yml
+++ b/.circleci/src/jobs/commit-audius-docker-compose-and-notify.yml
@@ -119,7 +119,7 @@ steps:
           sed -i "s/\({TAG:-\)[^}]*\}/\1$CIRCLE_SHA1}/" identity-service/docker-compose*.yml
           sed -i "s/\({TAG:-\)[^}]*\}/\1$CIRCLE_SHA1}/" ddex/docker-compose*.yml
           git add */docker-compose*.yml
-          git commit -m "$CIRCLE_BRANCH auto-deploy"
+          git commit --allow-empty -m "$CIRCLE_BRANCH auto-deploy"
           git push origin stage
 
           # Generate git diff for audius-docker-compose commits from last "release-vX.Y.Z auto-deploy" commit to HEAD


### PR DESCRIPTION
### Description
In case ci has updated the git hashes before the release job does - allow an empty `release-v0... auto-deploy` commit so the day's release can proceed.

### How Has This Been Tested?
