### PR TITLE
[C-3858] Social sign on loading screen adjustments

### DIFF
--- a/packages/mobile/src/app/navigation/useScreenOptions.tsx
+++ b/packages/mobile/src/app/navigation/useScreenOptions.tsx
@@ -1,28 +1,32 @@
-import { useCallback } from 'react'
+import { createContext, useContext } from 'react'
 
 import type { NativeStackNavigationOptions } from '@react-navigation/native-stack'
 
 import { AudiusHomeLink } from './AudiusHomeLink'
 import { BackButton } from './BackButton'
 
-export const useScreenOptions = (
-  options?: Partial<NativeStackNavigationOptions>
-) => {
-  return useCallback((): NativeStackNavigationOptions => {
-    return {
-      animation: 'default',
-      fullScreenGestureEnabled: true,
-      headerShadowVisible: false,
-      headerTitleAlign: 'center',
-      headerBackVisible: false,
-      headerLeft: (props) => {
-        const { canGoBack } = props
-        if (canGoBack) return <BackButton />
-        return null
-      },
-      title: '',
-      headerTitle: () => <AudiusHomeLink />,
-      ...options
-    }
-  }, [options])
+export const defaultScreenOptions: NativeStackNavigationOptions = {
+  animation: 'default',
+  fullScreenGestureEnabled: true,
+  headerShadowVisible: false,
+  headerTitleAlign: 'center',
+  headerBackVisible: false,
+  headerLeft: (props) => {
+    const { canGoBack } = props
+    if (canGoBack) return <BackButton />
+    return null
+  },
+  title: '',
+  headerTitle: () => <AudiusHomeLink />
+}
+
+export const ScreenOptionsContext = createContext<{
+  options: NativeStackNavigationOptions
+  updateOptions: (options?: NativeStackNavigationOptions) => void
+}>({ options: defaultScreenOptions, updateOptions: () => {} })
+
+export const useScreenOptions = () => {
+  // These are managed via useState in SignOnStack
+  const { options, updateOptions } = useContext(ScreenOptionsContext) ?? {}
+  return { options, updateOptions }
 }

--- a/packages/mobile/src/screens/sign-on-screen/SignOnStack.tsx
+++ b/packages/mobile/src/screens/sign-on-screen/SignOnStack.tsx
@@ -1,6 +1,9 @@
+import { useCallback, useState } from 'react'
+
+import type { NativeStackNavigationOptions } from '@react-navigation/native-stack'
 import { createNativeStackNavigator } from '@react-navigation/native-stack'
 
-import { useScreenOptions } from 'app/app/navigation'
+import { ScreenOptionsContext, defaultScreenOptions } from 'app/app/navigation'
 
 import { AccountLoadingScreen } from './screens/AccountLoadingScreen'
 import { ConfirmEmailScreen } from './screens/ConfirmEmailScreen'
@@ -22,40 +25,62 @@ type SignOnStackProps = {
 
 export const SignOnStack = (props: SignOnStackProps) => {
   const { isSplashScreenDismissed } = props
-  const screenOptions = useScreenOptions(screenOptionsOverrides)
+  const [screenOptions, setScreenOptions] =
+    useState<NativeStackNavigationOptions>({
+      ...defaultScreenOptions,
+      ...screenOptionsOverrides
+    })
+
+  const updateOptions = useCallback(
+    (newOptions: NativeStackNavigationOptions) => {
+      setScreenOptions({
+        ...defaultScreenOptions,
+        ...screenOptionsOverrides,
+        ...newOptions
+      })
+    },
+    []
+  )
 
   return (
-    <Stack.Navigator initialRouteName='SignOn' screenOptions={screenOptions}>
-      <Stack.Group>
-        <Stack.Screen name='SignOn' options={{ headerShown: false }}>
-          {() => (
-            <SignOnScreen isSplashScreenDismissed={isSplashScreenDismissed} />
-          )}
-        </Stack.Screen>
-        <Stack.Screen name='ConfirmEmail' component={ConfirmEmailScreen} />
-      </Stack.Group>
-      <Stack.Group>
-        <Stack.Screen name='CreatePassword' component={CreatePasswordScreen} />
-        <Stack.Screen name='PickHandle' component={PickHandleScreen} />
-        <Stack.Screen name='ReviewHandle' component={ReviewHandleScreen} />
-        <Stack.Screen
-          name='CreateLoginDetails'
-          component={CreateLoginDetailsScreen}
-        />
-        <Stack.Screen name='FinishProfile' component={FinishProfileScreen} />
-        <Stack.Screen
-          name='SelectGenre'
-          component={SelectGenresScreen}
-          options={{ headerLeft: () => null, gestureEnabled: false }}
-        />
-        <Stack.Screen name='SelectArtists' component={SelectArtistsScreen} />
-        <Stack.Screen
-          name='AccountLoading'
-          component={AccountLoadingScreen}
-          // animation: none here is a workaround to prevent "white screen of death" on Android
-          options={{ headerShown: false, animation: 'none' }}
-        />
-      </Stack.Group>
-    </Stack.Navigator>
+    <ScreenOptionsContext.Provider
+      value={{ options: screenOptions, updateOptions }}
+    >
+      <Stack.Navigator initialRouteName='SignOn' screenOptions={screenOptions}>
+        <Stack.Group>
+          <Stack.Screen name='SignOn' options={{ headerShown: false }}>
+            {() => (
+              <SignOnScreen isSplashScreenDismissed={isSplashScreenDismissed} />
+            )}
+          </Stack.Screen>
+          <Stack.Screen name='ConfirmEmail' component={ConfirmEmailScreen} />
+        </Stack.Group>
+        <Stack.Group>
+          <Stack.Screen
+            name='CreatePassword'
+            component={CreatePasswordScreen}
+          />
+          <Stack.Screen name='PickHandle' component={PickHandleScreen} />
+          <Stack.Screen name='ReviewHandle' component={ReviewHandleScreen} />
+          <Stack.Screen
+            name='CreateLoginDetails'
+            component={CreateLoginDetailsScreen}
+          />
+          <Stack.Screen name='FinishProfile' component={FinishProfileScreen} />
+          <Stack.Screen
+            name='SelectGenre'
+            component={SelectGenresScreen}
+            options={{ headerLeft: () => null, gestureEnabled: false }}
+          />
+          <Stack.Screen name='SelectArtists' component={SelectArtistsScreen} />
+          <Stack.Screen
+            name='AccountLoading'
+            component={AccountLoadingScreen}
+            // animation: none here is a workaround to prevent "white screen of death" on Android
+            options={{ headerShown: false, animation: 'none' }}
+          />
+        </Stack.Group>
+      </Stack.Navigator>
+    </ScreenOptionsContext.Provider>
   )
 }

--- a/packages/mobile/src/screens/sign-on-screen/components/SocialMediaLoading.tsx
+++ b/packages/mobile/src/screens/sign-on-screen/components/SocialMediaLoading.tsx
@@ -15,7 +15,13 @@ const messages = {
   connectingSocialMedia: 'We’re connecting your social account'
 }
 
-export const SocialMediaLoading = ({ onClose }: { onClose: () => void }) => {
+export const SocialMediaLoading = ({
+  onClose,
+  hideIcon
+}: {
+  onClose: () => void
+  hideIcon?: boolean
+}) => {
   const { color, spacing } = useTheme()
   return (
     <Flex
@@ -27,26 +33,28 @@ export const SocialMediaLoading = ({ onClose }: { onClose: () => void }) => {
       style={css({
         textAlign: 'center',
         position: 'absolute',
-        top: 0,
+        top: -20,
         right: 0,
         bottom: 0,
         left: 0,
-        zIndex: 6,
+        zIndex: 1000,
         borderRadius: 0,
         backgroundColor: color.background.white
       })}
     >
-      <IconButton
-        color='subdued'
-        icon={IconClose}
-        aria-label='Return to email screen'
-        style={css({
-          position: 'absolute',
-          top: spacing.xl,
-          left: spacing.xl
-        })}
-        onPress={onClose}
-      />
+      {hideIcon ? undefined : (
+        <IconButton
+          color='subdued'
+          icon={IconClose}
+          aria-label='Return to email screen'
+          style={css({
+            position: 'absolute',
+            top: spacing.xl,
+            left: spacing.xl
+          })}
+          onPress={() => onClose()}
+        />
+      )}
       <Text variant='heading' size='m' color='accent' textAlign='center'>
         {messages.hangTight}
         {'\n'}

--- a/packages/mobile/src/screens/sign-on-screen/components/useSocialMediaLoader.tsx
+++ b/packages/mobile/src/screens/sign-on-screen/components/useSocialMediaLoader.tsx
@@ -3,6 +3,9 @@ import { useCallback, useEffect, useState } from 'react'
 import { useDispatch } from 'react-redux'
 import type { AnyAction } from 'redux'
 
+import { IconClose } from '@audius/harmony-native'
+import { useScreenOptions } from 'app/app/navigation'
+
 export const useSocialMediaLoader = ({
   linkedSocialOnThisPagePreviously,
   resetAction
@@ -12,6 +15,11 @@ export const useSocialMediaLoader = ({
 }) => {
   const dispatch = useDispatch()
   const [isWaitingForSocialLogin, setIsWaitingForSocialLogin] = useState(false)
+  const [openTimeout, setOpenTimeout] = useState<
+    ReturnType<typeof setTimeout> | undefined
+  >(undefined)
+
+  const { updateOptions: updateScreenOptions } = useScreenOptions()
 
   useEffect(() => {
     // If the user goes back to this page in the middle of the flow after they linked
@@ -24,15 +32,43 @@ export const useSocialMediaLoader = ({
 
   const handleCloseSocialMediaLogin = useCallback(() => {
     setIsWaitingForSocialLogin(false)
-  }, [])
+    // Without this setTimeout, the header just "disappears"
+    // My suspicion is this is something related to animations
+    setTimeout(() => updateScreenOptions(undefined), 0)
+    if (openTimeout) {
+      clearTimeout(openTimeout)
+    }
+  }, [openTimeout, updateScreenOptions])
 
   const handleStartSocialMediaLogin = useCallback(() => {
-    setIsWaitingForSocialLogin(true)
-  }, [])
+    // NOTE: this cannot go inside the timeout or it will cause the header to just disappear
+    updateScreenOptions({
+      headerLeft: () => (
+        <IconClose
+          color='subdued'
+          onPress={() => {
+            setIsWaitingForSocialLogin(false)
+          }}
+        />
+      )
+    })
+    // Set a delay for showing the social media loading screen
+    // so we avoid it "flashing" right as the webview is popping up
+    const timeoutId = setTimeout(() => {
+      setIsWaitingForSocialLogin(true)
+    }, 1500)
+    setOpenTimeout(timeoutId)
+  }, [updateScreenOptions])
 
   const handleErrorSocialMediaLogin = useCallback(() => {
     setIsWaitingForSocialLogin(false)
-  }, [])
+    // Without this setTimeout, the header just "disappears"
+    // My suspicion is this is something related to animations
+    setTimeout(() => updateScreenOptions(undefined), 0)
+    if (openTimeout) {
+      clearTimeout(openTimeout)
+    }
+  }, [openTimeout, updateScreenOptions])
 
   return {
     isWaitingForSocialLogin,

--- a/packages/mobile/src/screens/sign-on-screen/screens/PickHandleScreen.tsx
+++ b/packages/mobile/src/screens/sign-on-screen/screens/PickHandleScreen.tsx
@@ -104,7 +104,6 @@ export const PickHandleScreen = () => {
     resetAction: unsetSocialProfile,
     linkedSocialOnThisPagePreviously: alreadyLinkedSocial
   })
-
   useTrackScreen('PickHandle')
 
   const audiusQueryContext = useAudiusQueryContext()
@@ -154,7 +153,7 @@ export const PickHandleScreen = () => {
     >
       <Page>
         {isWaitingForSocialLogin ? (
-          <SocialMediaLoading onClose={handleCloseSocialMediaLogin} />
+          <SocialMediaLoading onClose={handleCloseSocialMediaLogin} hideIcon />
         ) : null}
         <Heading
           heading={pickHandlePageMessages.title}


### PR DESCRIPTION
### Description

Adjustments to the "social loading" screen 
- Add a short timer so that it doesn't appear right as the user is going away
- Remove the X on the pick handle page so that there isn't an X and a < button next to each other.
  - Instead I modified it so that the "back" button becomes an X while the social loader is up
![2024-02-26 10 39 01](https://github.com/AudiusProject/audius-protocol/assets/6711655/e5380240-083d-4695-abf3-c5854c6d9b56)




### How Has This Been Tested?

ios:stage and android:stage
