### PR TITLE
Fix typo breaking audius-compose push

### DIFF
--- a/dev-tools/compose/docker-compose.blockchain.yml
+++ b/dev-tools/compose/docker-compose.blockchain.yml
@@ -18,7 +18,7 @@ services:
     deploy:
       mode: global
     profiles:
-      - chains
+      - chain
 
   poa-blockscout-db:
     image: postgres:13.6
@@ -74,7 +74,7 @@ services:
     deploy:
       mode: global
     profiles:
-      - chains
+      - chain
 
   eth-blockscout-db:
     image: postgres:13.6


### PR DESCRIPTION
Fixes I typo I added which was breaking `audius-compose push`. Tested by confirming that `audius-compose push --prod "mediorum"` no longer errors with `no such service: eth-ganache`.