### PR TITLE
Fix the same typo in another spot

### DIFF
--- a/dev-tools/audius-compose
+++ b/dev-tools/audius-compose
@@ -497,7 +497,7 @@ def up(
             "--profile=solana",
             "--profile=identity",
             "--profile=discovery",
-            "--profile=chains",
+            "--profile=chain",
             "--profile=healthz",
             *(["--file=" + str(AAO_DIR / 'audius-compose.yml')] if anti_abuse_oracle else []),
         )


### PR DESCRIPTION
Followup to fix the same typo as https://github.com/AudiusProject/audius-protocol/pull/7713. This would've been caught by CI, but Circle was having an incident. We'll make sure CI is green to merge this now that the incident is resolved.