### PR TITLE
Discovery placement hosts

### DIFF
--- a/packages/discovery-provider/ddl/migrations/0056_tracks_placement_hosts.sql
+++ b/packages/discovery-provider/ddl/migrations/0056_tracks_placement_hosts.sql
@@ -1,0 +1,5 @@
+begin;
+
+alter table tracks add column if not exists placement_hosts text;
+
+commit;

--- a/packages/discovery-provider/integration_tests/tasks/entity_manager/test_track_entity_manager.py
+++ b/packages/discovery-provider/integration_tests/tasks/entity_manager/test_track_entity_manager.py
@@ -227,6 +227,7 @@ def test_index_valid_track(app, mocker):
             "orig_filename": "original-filename-4",
             "is_downloadable": False,
             "is_original_available": False,
+            "placement_hosts": "https://host1.com,https://host2.com,https://host3.com,https://host4.com",
         },
         "QmUpdateTrack1": {
             "title": "track 1 2",
@@ -444,6 +445,10 @@ def test_index_valid_track(app, mocker):
         )
         assert track_4.title == "track 4"
         assert track_4.is_delete == False
+        assert (
+            track_4.placement_hosts
+            == "https://host1.com,https://host2.com,https://host3.com,https://host4.com"
+        )
 
         # Check that track routes are updated appropriately
         track_routes = (

--- a/packages/discovery-provider/integration_tests/tasks/entity_manager/test_utils.py
+++ b/packages/discovery-provider/integration_tests/tasks/entity_manager/test_utils.py
@@ -187,6 +187,7 @@ def test_valid_parse_metadata(app):
                 "is_original_available": False,
                 "preview_start_seconds": None,
                 "audio_upload_id": None,
+                "placement_hosts": None,
             },
             "QmUpdatePlaylist1": {
                 "playlist_id": 1,

--- a/packages/discovery-provider/src/api/v1/tracks.py
+++ b/packages/discovery-provider/src/api/v1/tracks.py
@@ -396,7 +396,11 @@ def get_stream_url_from_content_node(content_node: str, path: str):
 
     try:
         response = requests.get(stream_url, headers=headers, timeout=5)
-        if response.status_code == 206 or response.status_code == 204 or response.status_code == 200:
+        if (
+            response.status_code == 206
+            or response.status_code == 204
+            or response.status_code == 200
+        ):
             return parsed_url.geturl()
     except:
         pass
@@ -625,6 +629,11 @@ class TrackStream(Resource):
         )
 
         content_nodes = rendezvous.get_n(9999999, cid)
+
+        # if track has placement_hosts, use that instead
+        if track.get("placement_hosts"):
+            content_nodes = track.get("placement_hosts").split(",")
+
         for content_node in content_nodes:
             stream_url = get_stream_url_from_content_node(content_node, path)
             if stream_url:

--- a/packages/discovery-provider/src/models/tracks/track.py
+++ b/packages/discovery-provider/src/models/tracks/track.py
@@ -87,6 +87,7 @@ class Track(Base, RepresentableMixin):
     download_conditions = Column(JSONB(True))
     is_playlist_upload = Column(Boolean, nullable=False, server_default=text("false"))
     ai_attribution_user_id = Column(Integer, nullable=True)
+    placement_hosts = Column(String, nullable=True)
 
     block1 = relationship(  # type: ignore
         "Block", primaryjoin="Track.blocknumber == Block.number"

--- a/packages/discovery-provider/src/tasks/metadata.py
+++ b/packages/discovery-provider/src/tasks/metadata.py
@@ -75,6 +75,7 @@ class TrackMetadata(TypedDict):
     download_conditions: Optional[Any]
     is_playlist_upload: Optional[bool]
     ai_attribution_user_id: Optional[int]
+    placement_hosts: Optional[str]
 
 
 track_metadata_format: TrackMetadata = {
@@ -120,6 +121,7 @@ track_metadata_format: TrackMetadata = {
     "download_conditions": None,
     "is_playlist_upload": False,
     "ai_attribution_user_id": None,
+    "placement_hosts": None,
 }
 
 # Required format for user metadata retrieved from the content system


### PR DESCRIPTION
### Description

Follow on to: https://github.com/AudiusProject/audius-protocol/pull/7668

Adds `placement_hosts` field to tracks table - a comma separated list of host names (e.g. `https://a1.host.com,https://a2.host.com,https://otherhost.com`)

Uses this field instead of rendezvous in the track stream endpoint.

### How Has This Been Tested?

Entity Manager tests that field gets from track metadata to db.  There are no existing tests for the api track stream endpoint, so that part is untested atm.