### PR TITLE
SDK will pass thru placement_hosts.

### DIFF
--- a/packages/libs/src/services/creatorNode/CreatorNode.ts
+++ b/packages/libs/src/services/creatorNode/CreatorNode.ts
@@ -188,6 +188,10 @@ export class CreatorNode {
         updatedMetadata.preview_start_seconds.toString()
     }
 
+    if (metadata.placement_hosts) {
+      audioUploadOpts.placement_hosts = metadata.placement_hosts
+    }
+
     // Upload audio and cover art
     const promises = [
       this._retry3(

--- a/packages/libs/src/utils/types.ts
+++ b/packages/libs/src/utils/types.ts
@@ -162,6 +162,7 @@ export type TrackMetadata = {
   permalink: string
   audio_upload_id: Nullable<string>
   preview_start_seconds: Nullable<number>
+  placement_hosts: Nullable<string>
 
   // Optional Fields
   is_invalid?: boolean


### PR DESCRIPTION
### Description

SDK: Specifying `placement_hosts` in track metadata for an upload to "place" a file.
