### PR TITLE
[C-3898] Fix faded gray screen android on sign up

### DIFF
--- a/packages/mobile/src/screens/root-screen/RootScreen.tsx
+++ b/packages/mobile/src/screens/root-screen/RootScreen.tsx
@@ -13,6 +13,7 @@ import {
   getStartedSignUpProcess,
   getWelcomeModalShown
 } from 'common/store/pages/signon/selectors'
+import { Platform } from 'react-native'
 import { useDispatch, useSelector } from 'react-redux'
 
 import useAppState from 'app/hooks/useAppState'
@@ -34,7 +35,6 @@ import { ResetPasswordModalScreen } from '../reset-password-screen'
 import { SignOnStack } from '../sign-on-screen'
 
 import { StatusBar } from './StatusBar'
-import { Platform } from 'react-native'
 
 const { getAccountStatus } = accountSelectors
 const { fetchMoreChats, fetchUnreadMessagesCount, connect, disconnect } =

--- a/packages/mobile/src/screens/root-screen/RootScreen.tsx
+++ b/packages/mobile/src/screens/root-screen/RootScreen.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useState } from 'react'
 
-import { Status } from '@audius/common/models'
+import { MobileOS, Status } from '@audius/common/models'
 import { FeatureFlags } from '@audius/common/services'
 import {
   accountSelectors,
@@ -34,6 +34,7 @@ import { ResetPasswordModalScreen } from '../reset-password-screen'
 import { SignOnStack } from '../sign-on-screen'
 
 import { StatusBar } from './StatusBar'
+import { Platform } from 'react-native'
 
 const { getAccountStatus } = accountSelectors
 const { fetchMoreChats, fetchUnreadMessagesCount, connect, disconnect } =
@@ -63,6 +64,7 @@ export const RootScreen = () => {
   const showHomeStack = useSelector(getHasCompletedAccount)
   const startedSignUp = useSelector(getStartedSignUpProcess)
   const welcomeModalShown = useSelector(getWelcomeModalShown)
+  const isAndroid = Platform.OS === MobileOS.ANDROID
 
   const [isLoaded, setIsLoaded] = useState(false)
   const [isSplashScreenDismissed, setIsSplashScreenDismissed] = useState(false)
@@ -154,7 +156,7 @@ export const RootScreen = () => {
               name='HomeStack'
               component={AppDrawerScreen}
               // animation: none here is a workaround to prevent "white screen of death" on Android
-              options={{ animation: 'none' }}
+              options={isAndroid ? { animation: 'none' } : undefined}
             />
           ) : isSignUpRedesignEnabled ? (
             <Stack.Screen name='SignOnStackNew'>

--- a/packages/mobile/src/screens/sign-on-screen/SignOnStack.tsx
+++ b/packages/mobile/src/screens/sign-on-screen/SignOnStack.tsx
@@ -1,7 +1,9 @@
 import { useCallback, useState } from 'react'
 
+import { MobileOS } from '@audius/common/models'
 import type { NativeStackNavigationOptions } from '@react-navigation/native-stack'
 import { createNativeStackNavigator } from '@react-navigation/native-stack'
+import { getMobileOS } from 'audius-client/src/utils/clientUtil'
 
 import { ScreenOptionsContext, defaultScreenOptions } from 'app/app/navigation'
 
@@ -30,6 +32,8 @@ export const SignOnStack = (props: SignOnStackProps) => {
       ...defaultScreenOptions,
       ...screenOptionsOverrides
     })
+
+  const isAndroid = getMobileOS() === MobileOS.ANDROID
 
   const updateOptions = useCallback(
     (newOptions: NativeStackNavigationOptions) => {
@@ -70,14 +74,21 @@ export const SignOnStack = (props: SignOnStackProps) => {
           <Stack.Screen
             name='SelectGenre'
             component={SelectGenresScreen}
-            options={{ headerLeft: () => null, gestureEnabled: false }}
+            options={{
+              headerLeft: () => null,
+              gestureEnabled: false,
+              ...(isAndroid ? { animation: 'none' } : undefined)
+            }}
           />
           <Stack.Screen name='SelectArtists' component={SelectArtistsScreen} />
           <Stack.Screen
             name='AccountLoading'
             component={AccountLoadingScreen}
             // animation: none here is a workaround to prevent "white screen of death" on Android
-            options={{ headerShown: false, animation: 'none' }}
+            options={{
+              headerShown: false,
+              ...(isAndroid ? { animation: 'none' } : undefined)
+            }}
           />
         </Stack.Group>
       </Stack.Navigator>

--- a/packages/mobile/src/screens/sign-on-screen/SignOnStack.tsx
+++ b/packages/mobile/src/screens/sign-on-screen/SignOnStack.tsx
@@ -3,7 +3,7 @@ import { useCallback, useState } from 'react'
 import { MobileOS } from '@audius/common/models'
 import type { NativeStackNavigationOptions } from '@react-navigation/native-stack'
 import { createNativeStackNavigator } from '@react-navigation/native-stack'
-import { getMobileOS } from 'audius-client/src/utils/clientUtil'
+import { Platform } from 'react-native'
 
 import { ScreenOptionsContext, defaultScreenOptions } from 'app/app/navigation'
 
@@ -17,7 +17,6 @@ import { ReviewHandleScreen } from './screens/ReviewHandleScreen'
 import { SelectArtistsScreen } from './screens/SelectArtistScreen'
 import { SelectGenresScreen } from './screens/SelectGenresScreen'
 import { SignOnScreen } from './screens/SignOnScreen'
-import { Platform } from 'react-native'
 
 const Stack = createNativeStackNavigator()
 const screenOptionsOverrides = { animationTypeForReplace: 'pop' as const }

--- a/packages/mobile/src/screens/sign-on-screen/SignOnStack.tsx
+++ b/packages/mobile/src/screens/sign-on-screen/SignOnStack.tsx
@@ -17,6 +17,7 @@ import { ReviewHandleScreen } from './screens/ReviewHandleScreen'
 import { SelectArtistsScreen } from './screens/SelectArtistScreen'
 import { SelectGenresScreen } from './screens/SelectGenresScreen'
 import { SignOnScreen } from './screens/SignOnScreen'
+import { Platform } from 'react-native'
 
 const Stack = createNativeStackNavigator()
 const screenOptionsOverrides = { animationTypeForReplace: 'pop' as const }
@@ -33,7 +34,7 @@ export const SignOnStack = (props: SignOnStackProps) => {
       ...screenOptionsOverrides
     })
 
-  const isAndroid = getMobileOS() === MobileOS.ANDROID
+  const isAndroid = Platform.OS === MobileOS.ANDROID
 
   const updateOptions = useCallback(
     (newOptions: NativeStackNavigationOptions) => {


### PR DESCRIPTION
### Description

Disables animations for android on the genres page.

Also added logic to set animation none only on android

If I'm understanding the "gray screen" problem correctly this should fix it?

### How Has This Been Tested?

Don't have a way to test 😢, need to have Julian or someone try to see if they can still get it after this
