### PR TITLE
Fix password & genre spacing, fix profile-genre swipe animation

### DIFF
--- a/packages/mobile/src/screens/sign-on-screen/screens/CreatePasswordScreen.tsx
+++ b/packages/mobile/src/screens/sign-on-screen/screens/CreatePasswordScreen.tsx
@@ -60,11 +60,11 @@ export const CreatePasswordScreen = () => {
     >
       <Page>
         <KeyboardAvoidingView keyboardShowingOffset={220}>
-          <Heading
-            heading={createPasswordPageMessages.createYourPassword}
-            description={createPasswordPageMessages.description}
-          />
           <Flex direction='column' h='100%' gap='l'>
+            <Heading
+              heading={createPasswordPageMessages.createYourPassword}
+              description={createPasswordPageMessages.description}
+            />
             <ReadOnlyField
               label={createPasswordPageMessages.yourEmail}
               value={email}

--- a/packages/mobile/src/screens/sign-on-screen/screens/FinishProfileScreen.tsx
+++ b/packages/mobile/src/screens/sign-on-screen/screens/FinishProfileScreen.tsx
@@ -65,7 +65,6 @@ export const FinishProfileScreen = () => {
       const { displayName } = values
       dispatch(setValueField('name', displayName))
       dispatch(signUp())
-      dispatch(setFinishedPhase1(true))
       navigation.navigate('SelectGenre')
     },
     [dispatch, navigation]

--- a/packages/mobile/src/screens/sign-on-screen/screens/SelectGenresScreen.tsx
+++ b/packages/mobile/src/screens/sign-on-screen/screens/SelectGenresScreen.tsx
@@ -4,10 +4,11 @@ import { selectGenresPageMessages } from '@audius/common/messages'
 import { selectableGenres, selectGenresSchema } from '@audius/common/schemas'
 import type { GENRES } from '@audius/common/utils'
 import type { Genre as SDKGenre } from '@audius/sdk'
-import { setField } from 'common/store/pages/signon/actions'
+import { setField, setFinishedPhase1 } from 'common/store/pages/signon/actions'
 import { Formik, useField } from 'formik'
 import { ScrollView, View } from 'react-native'
 import { useDispatch } from 'react-redux'
+import { useEffectOnce } from 'react-use'
 import { toFormikValidationSchema } from 'zod-formik-adapter'
 
 import { Box, Flex, Paper, SelectablePill } from '@audius/harmony-native'
@@ -90,6 +91,10 @@ export const SelectGenresScreen = () => {
   const dispatch = useDispatch()
   const navigation = useNavigation<SignUpScreenParamList>()
 
+  useEffectOnce(() => {
+    dispatch(setFinishedPhase1(true))
+  })
+
   const handleSubmit = useCallback(
     (values: SelectGenresValue) => {
       const genres = values.genres
@@ -109,7 +114,7 @@ export const SelectGenresScreen = () => {
     >
       <View>
         <ScrollView testID='genreScrollView'>
-          <Paper flex={1} gap='2xl'>
+          <Paper flex={1} gap='2xl' pb='2xl'>
             <ReadOnlyAccountHeader />
             <Flex ph={gutterSize} gap='2xl' flex={1}>
               <Heading


### PR DESCRIPTION
### Description

Handful of last QA finds, fixes some spacing on password page & genre page. 
Fix the profile->genre swipe animation by moving the state change to unrender stuff from submit of profile page to render of genre page

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._
