### PR TITLE
[ONC-35] Fix crash on android due to react native importing images as numbers

### DIFF
--- a/packages/common/src/hooks/useImageSize.ts
+++ b/packages/common/src/hooks/useImageSize.ts
@@ -109,7 +109,7 @@ export function useImageSize<
   sizes
 }: BaseUserImageSizeProps<ImageSize, ImageSizes> & {
   onDemand?: boolean
-}): string | undefined | (() => Maybe<string>) {
+}): string | number | undefined | (() => Maybe<string | number>) {
   const [getPreviousId, setPreviousId] = useInstanceVar<number | null>(null)
 
   const getSmallerImage = useMemo(
@@ -122,14 +122,14 @@ export function useImageSize<
   )
 
   const getImageSize = useCallback((): {
-    url: Maybe<URL>
+    url: Maybe<URL | number>
     type: ImageType
   } => {
     if (id === null || id === undefined || typeof id === 'string') {
       return { url: '', type: 'empty' }
     }
 
-    const fallbackImage = (url: URL) => {
+    const fallbackImage = (url: URL | number) => {
       setPreviousId(null)
       return url
     }
@@ -141,7 +141,7 @@ export function useImageSize<
 
     // An override exists
     if (DefaultSizes.OVERRIDE in sizes) {
-      const override: Maybe<URL> = sizes[DefaultSizes.OVERRIDE]
+      const override: Maybe<URL | number> = sizes[DefaultSizes.OVERRIDE]
       if (override) {
         return { url: fallbackImage(override), type: 'override' }
       }
@@ -182,7 +182,7 @@ export function useImageSize<
     setPreviousId
   ])
 
-  let imageUrl: Maybe<URL>
+  let imageUrl: Maybe<URL | number>
   let imageType: Maybe<ImageType>
 
   if (!onDemand) {

--- a/packages/common/src/models/Collection.ts
+++ b/packages/common/src/models/Collection.ts
@@ -1,5 +1,5 @@
 import { CID, ID, UID } from '../models/Identifiers'
-import { CoverArtSizes } from '../models/ImageSizes'
+import { CoverArtSizes, CoverArtSizesCids } from '../models/ImageSizes'
 import { Repost } from '../models/Repost'
 import { Nullable } from '../utils/typeUtils'
 
@@ -43,7 +43,7 @@ export type CollectionMetadata = {
   playlist_id: ID
   cover_art: CID | null
   cover_art_sizes: Nullable<CID>
-  cover_art_cids?: Nullable<CoverArtSizes>
+  cover_art_cids?: Nullable<CoverArtSizesCids>
   permalink?: string
   playlist_name: string
   playlist_owner_id: ID
@@ -106,5 +106,5 @@ export type SmartCollection = {
 export type CollectionImage = {
   cover_art: Nullable<CID>
   cover_art_sizes: Nullable<CID>
-  cover_art_cids?: Nullable<CoverArtSizes>
+  cover_art_cids?: Nullable<CoverArtSizesCids>
 }

--- a/packages/common/src/models/ImageSizes.ts
+++ b/packages/common/src/models/ImageSizes.ts
@@ -16,9 +16,18 @@ export enum WidthSizes {
 
 export type URL = string
 
-export type ImageSizesObject<ImageSizeEnum extends SquareSizes | WidthSizes> =
-  Partial<Record<ImageSizeEnum | DefaultSizes, URL>>
+export type ImageSizesObjectWithoutOverride<
+  ImageSizeEnum extends SquareSizes | WidthSizes
+> = Partial<Record<ImageSizeEnum, URL>>
 
+export type ImageSizesObject<ImageSizeEnum extends SquareSizes | WidthSizes> =
+  ImageSizesObjectWithoutOverride<ImageSizeEnum> &
+    Partial<Record<DefaultSizes, URL | number>>
+
+export type CoverArtSizesCids = ImageSizesObjectWithoutOverride<SquareSizes>
 export type CoverArtSizes = ImageSizesObject<SquareSizes>
+export type ProfilePictureSizesCids =
+  ImageSizesObjectWithoutOverride<SquareSizes>
 export type ProfilePictureSizes = ImageSizesObject<SquareSizes>
+export type CoverPhotoSizesCids = ImageSizesObjectWithoutOverride<WidthSizes>
 export type CoverPhotoSizes = ImageSizesObject<WidthSizes>

--- a/packages/common/src/models/Track.ts
+++ b/packages/common/src/models/Track.ts
@@ -5,7 +5,7 @@ import { Nullable } from '../utils/typeUtils'
 import { Chain } from './Chain'
 import { Favorite } from './Favorite'
 import { CID, ID, UID } from './Identifiers'
-import { CoverArtSizes } from './ImageSizes'
+import { CoverArtSizes, CoverArtSizesCids } from './ImageSizes'
 import { Repost } from './Repost'
 import { StemCategory } from './Stems'
 import { Timestamped } from './Timestamped'
@@ -203,7 +203,7 @@ export type TrackMetadata = {
   track_segments: TrackSegment[]
   cover_art: Nullable<CID>
   cover_art_sizes: Nullable<CID>
-  cover_art_cids?: Nullable<CoverArtSizes>
+  cover_art_cids?: Nullable<CoverArtSizesCids>
   is_scheduled_release: boolean
   is_unlisted: boolean
   is_available: boolean

--- a/packages/common/src/models/User.ts
+++ b/packages/common/src/models/User.ts
@@ -1,7 +1,12 @@
 import { Collectible, CollectiblesMetadata } from '~/models/Collectible'
 import { Color } from '~/models/Color'
 import { CID, ID } from '~/models/Identifiers'
-import { CoverPhotoSizes, ProfilePictureSizes } from '~/models/ImageSizes'
+import {
+  CoverPhotoSizes,
+  CoverPhotoSizesCids,
+  ProfilePictureSizes,
+  ProfilePictureSizesCids
+} from '~/models/ImageSizes'
 import { PlaylistLibrary } from '~/models/PlaylistLibrary'
 import { SolanaWalletAddress, StringWei, WalletAddress } from '~/models/Wallet'
 import { Nullable } from '~/utils/typeUtils'
@@ -35,9 +40,9 @@ export type UserMetadata = {
   repost_count: number
   track_count: number
   cover_photo_sizes: Nullable<CID>
-  cover_photo_cids?: Nullable<CoverPhotoSizes>
+  cover_photo_cids?: Nullable<CoverPhotoSizesCids>
   profile_picture_sizes: Nullable<CID>
-  profile_picture_cids?: Nullable<ProfilePictureSizes>
+  profile_picture_cids?: Nullable<ProfilePictureSizesCids>
   metadata_multihash: Nullable<CID>
   erc_wallet: WalletAddress
   spl_wallet: Nullable<SolanaWalletAddress>

--- a/packages/common/src/services/audius-backend/AudiusBackend.ts
+++ b/packages/common/src/services/audius-backend/AudiusBackend.ts
@@ -552,7 +552,9 @@ export const audiusBackend = ({
     }
 
     if (!collection.cover_art_sizes && !collection.cover_art) {
-      coverArtSizes[DefaultSizes.OVERRIDE] = placeholderCoverArt as string
+      coverArtSizes[DefaultSizes.OVERRIDE] = placeholderCoverArt as
+        | string
+        | number // ReactNative require() is a number for images!
     }
 
     return {

--- a/packages/mobile/src/components/image/CollectionImage.tsx
+++ b/packages/mobile/src/components/image/CollectionImage.tsx
@@ -17,6 +17,8 @@ import { getCollectionDownloadStatus } from 'app/store/offline-downloads/selecto
 import { OfflineDownloadStatus } from 'app/store/offline-downloads/slice'
 import { useThemeColors } from 'app/utils/theme'
 
+import { primitiveToImageSource } from './primitiveToImageSource'
+
 const { getIsReachable } = reachabilitySelectors
 
 type UseCollectionImageOptions = {
@@ -58,22 +60,27 @@ const useLocalCollectionImageUri = (collectionId: Maybe<ID>) => {
 
 export const useCollectionImage = (options: UseCollectionImageOptions) => {
   const { collection, size } = options
-  const optimisticCoverArt = collection?._cover_art_sizes?.OVERRIDE
+
   const cid = collection
-    ? collection.cover_art_sizes || collection.cover_art
+    ? collection.cover_art_sizes ?? collection.cover_art
     : null
 
+  const optimisticCoverArt = primitiveToImageSource(
+    collection?._cover_art_sizes?.OVERRIDE
+  )
   const localCollectionImageUri = useLocalCollectionImageUri(
     collection?.playlist_id
   )
-
-  const localSourceUri = optimisticCoverArt || localCollectionImageUri
+  const localCollectionImageSource = primitiveToImageSource(
+    localCollectionImageUri
+  )
+  const localSource = optimisticCoverArt ?? localCollectionImageSource
 
   const contentNodeSource = useContentNodeImage({
     cid,
     size,
     fallbackImageSource: imageEmpty,
-    localSource: localSourceUri ? { uri: localSourceUri } : null,
+    localSource,
     cidMap: collection?.cover_art_cids
   })
 

--- a/packages/mobile/src/components/image/TrackImage.tsx
+++ b/packages/mobile/src/components/image/TrackImage.tsx
@@ -12,6 +12,8 @@ import { getTrackDownloadStatus } from 'app/store/offline-downloads/selectors'
 import { OfflineDownloadStatus } from 'app/store/offline-downloads/slice'
 import { useThemeColors } from 'app/utils/theme'
 
+import { primitiveToImageSource } from './primitiveToImageSource'
+
 export const DEFAULT_IMAGE_URL =
   'https://download.audius.co/static-resources/preview-image.jpg'
 
@@ -51,16 +53,18 @@ const useLocalTrackImageUri = (trackId: Maybe<ID>) => {
 export const useTrackImage = ({ track, size }: UseTrackImageOptions) => {
   const cid = track ? track.cover_art_sizes || track.cover_art : null
 
-  const optimisticCoverArt = track?._cover_art_sizes?.OVERRIDE
-
+  const optimisticCoverArt = primitiveToImageSource(
+    track?._cover_art_sizes?.OVERRIDE
+  )
   const localTrackImageUri = useLocalTrackImageUri(track?.track_id)
-  const localSourceUri = optimisticCoverArt || localTrackImageUri
+  const localTrackImageSource = primitiveToImageSource(localTrackImageUri)
+  const localSource = optimisticCoverArt ?? localTrackImageSource
 
   const contentNodeSource = useContentNodeImage({
     cid,
     size,
     fallbackImageSource: imageEmpty,
-    localSource: localSourceUri ? { uri: localSourceUri } : null,
+    localSource,
     cidMap: track?.cover_art_cids
   })
 

--- a/packages/mobile/src/components/image/primitiveToImageSource.ts
+++ b/packages/mobile/src/components/image/primitiveToImageSource.ts
@@ -1,0 +1,15 @@
+import type { ImageSourcePropType } from 'react-native'
+
+/**
+ * Converts our primitive URL strings or imports into ImageSourcePropType.
+ *
+ * In many places, we expect a URL string, but fallback to an imported image.
+ * Those imported images in React Native are _numbers_ and are meant to be
+ * used directly as an ImageSource, but the strings need to be wrapped in an
+ * object under the `uri` key. Also, ImageSourcePropType can't be null, so this
+ * handles that too.
+ */
+export const primitiveToImageSource = (
+  src: string | number | undefined | null
+): ImageSourcePropType | undefined =>
+  typeof src === 'string' ? { uri: src } : src ?? undefined

--- a/packages/mobile/src/hooks/useContentNodeImage.ts
+++ b/packages/mobile/src/hooks/useContentNodeImage.ts
@@ -44,7 +44,7 @@ const createImageSourcesForEndpoints = ({
  * Create all the sources for an image.
  * Includes legacy endpoints and optionally lokj cal sources
  */
-export const createAllImageSources = ({
+export const createAllImageSources = <T extends ImageSourcePropType>({
   cid,
   endpoints,
   size,
@@ -54,7 +54,7 @@ export const createAllImageSources = ({
   cid: Nullable<CID>
   endpoints: string[]
   size: SquareSizes | WidthSizes
-  localSource?: ImageURISource | null
+  localSource?: T
   cidMap?: Nullable<{ [key: string]: string }>
 }) => {
   if (!cid || !endpoints) {
@@ -95,8 +95,10 @@ export const createAllImageSources = ({
  * or a local source. This is useful for cases where there is no error
  * callback if the image fails to load - like the MusicControls on the lockscreen
  */
-export const getImageSourceOptimistic = (
-  options: Parameters<typeof createAllImageSources>[0]
+export const getImageSourceOptimistic = <
+  T extends ImageSourcePropType = ImageURISource
+>(
+  options: Parameters<typeof createAllImageSources<T>>[0]
 ) => {
   const allImageSources = createAllImageSources(options)
   return allImageSources[0]
@@ -107,7 +109,7 @@ type UseContentNodeImageOptions = {
   // The size of the image to fetch
   size: SquareSizes | WidthSizes
   fallbackImageSource: ImageSourcePropType
-  localSource?: ImageURISource | null
+  localSource?: ImageSourcePropType
   cidMap?: Nullable<{ [key: string]: string }>
 }
 

--- a/packages/mobile/src/store/offline-downloads/sagas/offlineQueueSagas/workers/downloadCollectionWorker.ts
+++ b/packages/mobile/src/store/offline-downloads/sagas/offlineQueueSagas/workers/downloadCollectionWorker.ts
@@ -160,7 +160,9 @@ function* downloadCollectionCoverArt(collection: CollectionMetadata) {
     cidMap: cover_art_cids
   })
 
-  const coverArtUris = imageSources.map(({ uri }) => uri).filter(removeNullable)
+  const coverArtUris = imageSources
+    .map((src) => (typeof src === 'object' && 'uri' in src ? src.uri : null))
+    .filter(removeNullable)
   const covertArtFilePath = getCollectionCoverArtPath(playlist_id)
 
   for (const coverArtUri of coverArtUris) {

--- a/packages/mobile/src/store/offline-downloads/sagas/offlineQueueSagas/workers/downloadTrackWorker.ts
+++ b/packages/mobile/src/store/offline-downloads/sagas/offlineQueueSagas/workers/downloadTrackWorker.ts
@@ -205,7 +205,9 @@ function* downloadTrackCoverArt(track: TrackMetadata) {
     cidMap: cover_art_cids
   })
 
-  const coverArtUris = imageSources.map(({ uri }) => uri).filter(removeNullable)
+  const coverArtUris = imageSources
+    .map((src) => (typeof src === 'object' && 'uri' in src ? src.uri : null))
+    .filter(removeNullable)
   const covertArtFilePath = getLocalTrackCoverArtDestination(track_id)
 
   for (const coverArtUri of coverArtUris) {


### PR DESCRIPTION
### Description

React native imports images as numbers, but we weren't handling that for our override image sources. This led to Android crashing.

ONC-35 for details