### PR TITLE
[PROTO-1686] Setup DDEX choreography infra and related improvements

### DIFF
--- a/.circleci/src/workflows/ddex-stage.yml
+++ b/.circleci/src/workflows/ddex-stage.yml
@@ -1,9 +1,13 @@
 when: << pipeline.parameters.run-ddex-stage-workflow >>
 jobs:
   - test:
-      name: test-ddex-e2e
+      name: test-ddex-e2e-release-by-release
       context: Vercel
-      service: ddex-e2e
+      service: ddex-e2e-release-by-release
+  - test:
+      name: test-ddex-e2e-batched
+      context: Vercel
+      service: ddex-e2e-batched
   - test:
       name: test-ddex-unittests
       context: Vercel
@@ -32,7 +36,8 @@ jobs:
   - deploy-stage-nodes:
       name: deploy-stage-ddex
       requires:
-        - test-ddex-e2e
+        - test-ddex-e2e-release-by-release
+        - test-ddex-e2e-batched
         - test-ddex-unittests
         - push-ddex-web
         - push-ddex-ingester

--- a/.circleci/src/workflows/ddex-webapp.yml
+++ b/.circleci/src/workflows/ddex-webapp.yml
@@ -2,9 +2,13 @@ when: << pipeline.parameters.run-ddex-webapp-workflow >>
 jobs:
   - ddex-webapp-init
   - test:
-      name: test-ddex-e2e
+      name: test-ddex-e2e-release-by-release
       context: Vercel
-      service: ddex-e2e
+      service: ddex-e2e-release-by-release
+  - test:
+      name: test-ddex-e2e-batched
+      context: Vercel
+      service: ddex-e2e-batched
   - test:
       name: test-ddex-unittests
       context: Vercel

--- a/dev-tools/compose/docker-compose.test.yml
+++ b/dev-tools/compose/docker-compose.test.yml
@@ -442,57 +442,193 @@ services:
 
   # ddex
 
-  ddex-crawler:
+  ddex-crawler-release-by-release:
     extends:
       file: docker-compose.yml
       service: ddex-crawler
+    container_name: ddex-crawler-release-by-release
     logging: *default-logging
     environment:
-      AWS_ENDPOINT: 'http://ddex-s3:4566'
+      AWS_ENDPOINT: 'http://ddex-s3-release-by-release:4566'
       TEST_MODE: 'true'
+      DDEX_CHOREOGRAPHY: 'ERNReleaseByRelease'
     depends_on:
       ddex-mongo-init:
         condition: service_completed_successfully
-      ddex-s3:
+      ddex-s3-release-by-release:
         condition: service_healthy
 
-  ddex-indexer:
+  ddex-indexer-release-by-release:
     extends:
       file: docker-compose.yml
       service: ddex-indexer
+    container_name: ddex-indexer-release-by-release
     logging: *default-logging
     environment:
-      AWS_ENDPOINT: 'http://ddex-s3:4566'
+      AWS_ENDPOINT: 'http://ddex-s3-release-by-release:4566'
+      DDEX_CHOREOGRAPHY: 'ERNReleaseByRelease'
     depends_on:
       ddex-mongo-init:
         condition: service_completed_successfully
-      ddex-s3:
+      ddex-s3-release-by-release:
         condition: service_healthy
 
-  ddex-parser:
+  ddex-parser-release-by-release:
     extends:
       file: docker-compose.yml
       service: ddex-parser
+    container_name: ddex-parser-release-by-release
     logging: *default-logging
     environment:
-      AWS_ENDPOINT: 'http://ddex-s3:4566'
+      AWS_ENDPOINT: 'http://ddex-s3-release-by-release:4566'
+      DDEX_CHOREOGRAPHY: 'ERNReleaseByRelease'
     depends_on:
       ddex-mongo-init:
         condition: service_completed_successfully
-      ddex-s3:
+      ddex-s3-release-by-release:
         condition: service_healthy
 
-  ddex-publisher:
+  ddex-publisher-release-by-release:
     extends:
       file: docker-compose.yml
       service: ddex-publisher
+    container_name: ddex-publisher-release-by-release
     logging: *default-logging
     environment:
-      AWS_ENDPOINT: 'http://ddex-s3:4566'
+      AWS_ENDPOINT: 'http://ddex-s3-release-by-release:4566'
+      DDEX_CHOREOGRAPHY: 'ERNReleaseByRelease'
     depends_on:
       ddex-mongo-init:
         condition: service_completed_successfully
-      ddex-s3:
+      ddex-s3-release-by-release:
+        condition: service_healthy
+  
+  # It also wouldn't be a bad idea to set CORS and use localstack in the local dev setup (ie audius-compose up --ddex-only)
+  ddex-s3-release-by-release:
+    container_name: ddex-s3-release-by-release
+    image: localstack/localstack:s3-latest
+    ports:
+      - "127.0.0.1:4566:4566"
+    networks:
+      - ddex-network
+    volumes:
+      - "ddex-s3:/var/lib/localstack"
+      - "/var/run/docker.sock:/var/run/docker.sock"
+
+  test-ddex-e2e-release-by-release:
+    container_name: test-ddex-e2e-release-by-release
+    extends:
+      file: docker-compose.ddex.yml
+      service: ddex-test
+    entrypoint: sh -c '[ ! "$$1" = "test" ] && sleep inf || (shift;  go test ./e2e_test/... -count 1 -timeout 3m "$$@")' -
+    logging: *default-logging
+    environment:
+      AWS_ENDPOINT: 'http://ddex-s3-release-by-release:4566'
+      DDEX_CHOREOGRAPHY: 'ERNReleaseByRelease'
+    networks:
+      - ddex-network
+    depends_on:
+      ddex-crawler-release-by-release:
+        condition: service_healthy
+      ddex-indexer-release-by-release:
+        condition: service_healthy
+      ddex-parser-release-by-release:
+        condition: service_healthy
+      # ddex-publisher:
+      #   condition: service_healthy
+      # Leaving out publisher for now because it takes a long time to build.
+      # We don't actually upload anything to Audius in the e2e test, but having a "dry run" publisher mode could be useful
+  
+  ddex-crawler-batched:
+    extends:
+      file: docker-compose.yml
+      service: ddex-crawler
+    container_name: ddex-crawler-batched
+    logging: *default-logging
+    environment:
+      AWS_ENDPOINT: 'http://ddex-s3-batched:4566'
+      TEST_MODE: 'true'
+      DDEX_CHOREOGRAPHY: 'ERNBatched'
+    depends_on:
+      ddex-mongo-init:
+        condition: service_completed_successfully
+      ddex-s3-batched:
+        condition: service_healthy
+
+  ddex-indexer-batched:
+    extends:
+      file: docker-compose.yml
+      service: ddex-indexer
+    container_name: ddex-indexer-batched
+    logging: *default-logging
+    environment:
+      AWS_ENDPOINT: 'http://ddex-s3-batched:4566'
+      DDEX_CHOREOGRAPHY: 'ERNBatched'
+    depends_on:
+      ddex-mongo-init:
+        condition: service_completed_successfully
+      ddex-s3-batched:
+        condition: service_healthy
+
+  ddex-parser-batched:
+    extends:
+      file: docker-compose.yml
+      service: ddex-parser
+    container_name: ddex-parser-batched
+    logging: *default-logging
+    environment:
+      AWS_ENDPOINT: 'http://ddex-s3-batched:4566'
+      DDEX_CHOREOGRAPHY: 'ERNBatched'
+    depends_on:
+      ddex-mongo-init:
+        condition: service_completed_successfully
+      ddex-s3-batched:
+        condition: service_healthy
+
+  ddex-publisher-batched:
+    extends:
+      file: docker-compose.yml
+      service: ddex-publisher
+    container_name: ddex-publisher-batched
+    logging: *default-logging
+    environment:
+      AWS_ENDPOINT: 'http://ddex-s3-batched:4566'
+      DDEX_CHOREOGRAPHY: 'ERNBatched'
+    depends_on:
+      ddex-mongo-init:
+        condition: service_completed_successfully
+      ddex-s3-batched:
+        condition: service_healthy
+  
+  ddex-s3-batched:
+    container_name: ddex-s3-batched
+    image: localstack/localstack:s3-latest
+    ports:
+      - "127.0.0.1:4566:4566"
+    networks:
+      - ddex-network
+    volumes:
+      - "ddex-s3:/var/lib/localstack"
+      - "/var/run/docker.sock:/var/run/docker.sock"
+
+  test-ddex-e2e-batched:
+    container_name: test-ddex-e2e-batched
+    extends:
+      file: docker-compose.ddex.yml
+      service: ddex-test
+    entrypoint: sh -c '[ ! "$$1" = "test" ] && sleep inf || (shift;  go test ./e2e_test/... -count 1 -timeout 3m "$$@")' -
+    logging: *default-logging
+    environment:
+      AWS_ENDPOINT: 'http://ddex-s3-batched:4566'
+      DDEX_CHOREOGRAPHY: 'ERNBatched'
+    networks:
+      - ddex-network
+    depends_on:
+      ddex-crawler-batched:
+        condition: service_healthy
+      ddex-indexer-batched:
+        condition: service_healthy
+      ddex-parser-batched:
         condition: service_healthy
 
   ddex-mongo:
@@ -509,41 +645,6 @@ services:
     depends_on:
       ddex-mongo:
         condition: service_healthy
-  
-  # It also wouldn't be a bad idea to set CORS and use localstack in the local dev setup (ie audius-compose up --ddex-only)
-  ddex-s3:
-    container_name: ddex-s3
-    image: localstack/localstack:s3-latest
-    ports:
-      - "127.0.0.1:4566:4566"
-    networks:
-      - ddex-network
-    volumes:
-      - "ddex-s3:/var/lib/localstack"
-      - "/var/run/docker.sock:/var/run/docker.sock"
-
-  test-ddex-e2e:
-    container_name: test-ddex-e2e
-    extends:
-      file: docker-compose.ddex.yml
-      service: ddex-test
-    entrypoint: sh -c '[ ! "$$1" = "test" ] && sleep inf || (shift;  go test ./e2e_test/... -count 1 -timeout 3m "$$@")' -
-    logging: *default-logging
-    environment:
-      AWS_ENDPOINT: 'http://ddex-s3:4566'
-    networks:
-      - ddex-network
-    depends_on:
-      ddex-crawler:
-        condition: service_healthy
-      ddex-indexer:
-        condition: service_healthy
-      ddex-parser:
-        condition: service_healthy
-      # ddex-publisher:
-      #   condition: service_healthy
-      # Leaving out publisher for now because it takes a long time to build.
-      # We don't actually upload anything to Audius in the e2e test, but having a "dry run" publisher mode could be useful
   
   test-ddex-unittests:
     container_name: test-ddex-unittests

--- a/dev-tools/compose/docker-compose.yml
+++ b/dev-tools/compose/docker-compose.yml
@@ -194,24 +194,32 @@ services:
     extends:
       file: docker-compose.ddex.yml
       service: ddex-crawler
+    environment:
+      DDEX_CHOREOGRAPHY: 'ERNReleaseByRelease'
     <<: *common
 
   ddex-indexer:
     extends:
       file: docker-compose.ddex.yml
       service: ddex-indexer
+    environment:
+      DDEX_CHOREOGRAPHY: 'ERNReleaseByRelease'
     <<: *common
 
   ddex-parser:
     extends:
       file: docker-compose.ddex.yml
       service: ddex-parser
+    environment:
+      DDEX_CHOREOGRAPHY: 'ERNReleaseByRelease'
     <<: *common
 
   ddex-publisher:
     extends:
       file: docker-compose.ddex.yml
       service: ddex-publisher
+    environment:
+      DDEX_CHOREOGRAPHY: 'ERNReleaseByRelease'
     <<: *common
 
   ddex-mongo:

--- a/packages/ddex/README.md
+++ b/packages/ddex/README.md
@@ -2,7 +2,28 @@
 
 Processes and uploads DDEX releases to Audius.
 
-## Local Dev
+## Production setup
+Use audius-docker-compose to run a production DDEX instance. After you've installed audius-docker-compose, set the following required environment variables in override.env (in the audius-docker-compose repository, not here).
+
+### AWS environment variables:
+Set up your buckets by following the "Creating a bucket in S3" section below. Then, set these environment variables:
+- `AWS_ACCESS_KEY_ID`: the access key for the IAM user you created
+- `AWS_SECRET_ACCESS_KEY`: the secret access key for the IAM user you created
+- `AWS_REGION`: the region where your buckets were created (e.g., 'us-west-2' or 'us-east-1')
+- `AWS_BUCKET_RAW`: the name of the bucket you created (likely the format of `ddex-[dev|staging]-<label/distributor>-raw`)
+- `AWS_BUCKET_INDEXED`: the name of the bucket you created (likely the format of `ddex-[dev|staging]-<label/distributor>-indexed`)
+
+### App environment variables:
+Create an app by following the 2 steps [here](https://docs.audius.org/developers/sdk/#set-up-your-developer-app), and then set these environment variables:
+- `DDEX_KEY`: the key created for your Audius app
+- `DDEX_SECRET`: the secret created for your Audius app
+- `DDEX_CHOREOGRAPHY`: the type of choreography you're using: "[ERNReleaseByRelease](https://ernccloud.ddex.net/electronic-release-notification-message-suite-part-3%253A-choreographies-for-cloud-based-storage/5-release-by-release-profile/5.1-choreography/)" or "[ERNBatched](https://ernccloud.ddex.net/electronic-release-notification-message-suite-part-3%253A-choreographies-for-cloud-based-storage/6-batch-profile/6.1-choreography/)." If you want another option, you'll have to implement the code for it
+
+### Auth-related environment variables:
+- `DDEX_ADMIN_ALLOWLIST`: a comma-separated list of **decoded** user IDs that are allowed to act as admins on your DDEX website. You can decode your user ID by going to `https://discoveryprovider.audius.co/v1/full/users/handle/<your audius handle>`, looking at the `id` field, and then decoding it by pasting it into the "Encoded" textbox [here](https://healthz.audius.co/#/utils/id) and copying the "Integer" value
+- `SESSION_SECRET`: enter something random and unique. This is important for the security of user sessions
+
+## Local dev
 DDEX requires these services: `ddex-webapp`, `ddex-crawler`, `ddex-indexer`, `ddex-parser`, `ddex-publisher`, `ddex-mongo`.
 
 ### Env configuration
@@ -62,5 +83,5 @@ Each service can be run independently as long as `ddex-mongo` is up (from `audiu
 ```
 
 ### Running / debugging the e2e test
-* Run `audius-compose test down && audius-compose test run ddex-e2e` to start the ddex stack and run the e2e test
+* Run `audius-compose test down && audius-compose test run ddex-e2e-release-by-release` to start the ddex stack and run the e2e test for the Release-By-Release choreography. You can replace `ddex-e2e-release-by-release` with `ddex-e2e-batched` to run the e2e test for the Batched choreography.
 * To debug S3, exec into `ddex-s3`, run `pip install awscli`, and then you can run `aws --endpoint=http://localhost:4566 s3 ls` and other commands to debug the S3 state

--- a/packages/ddex/ingester/e2e_test/e2e_test.go
+++ b/packages/ddex/ingester/e2e_test/e2e_test.go
@@ -29,7 +29,14 @@ func TestRunE2E(t *testing.T) {
 		t.Fatalf("Failed to set up test environment: %v", err)
 	}
 
-	e.runERN381ReleaseByRelease(t)
+	choreography := common.MustGetChoreography()
+	if choreography == common.ERNReleaseByRelease {
+		e.runERN381ReleaseByRelease(t)
+	} else if choreography == common.ERNBatched {
+		t.Skip("Batched choreography not yet implemented")
+	} else {
+		t.Fatalf("Unexpected choreography: %s", choreography)
+	}
 }
 
 type e2eTest struct {

--- a/packages/ddex/ingester/parser/parser.go
+++ b/packages/ddex/ingester/parser/parser.go
@@ -1,6 +1,7 @@
 package parser
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -13,6 +14,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/antchfx/xmlquery"
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/bson/primitive"
 	"go.mongodb.org/mongo-driver/mongo"
@@ -137,7 +139,41 @@ func (p *Parser) processDelivery(changeStream *mongo.ChangeStream) {
 	p.Logger.Info("Processing new delivery", "_id", delivery.ID)
 
 	xmlData := delivery.XmlContent.Data
-	createTrackRelease, createAlbumRelease, errs := parseSonyXML(xmlData, p.IndexedBucket, delivery.ID.Hex())
+	doc, err := xmlquery.Parse(bytes.NewReader(xmlData))
+	if err != nil {
+		p.Logger.Error("Failed to read XML bytes", "error", err)
+		p.failAndUpdateStatus(delivery.ID, fmt.Errorf("failed to read XML bytes: %v", err))
+		return
+	}
+
+	// Use local-name() to ignore namespace because sometimes it's ern and sometimes it's ernm
+	msgVersionElem := xmlquery.FindOne(doc, "//*[local-name()='NewReleaseMessage']")
+	if msgVersionElem == nil {
+		p.Logger.Error("Missing <NewReleaseMessage> element")
+		p.failAndUpdateStatus(delivery.ID, errors.New("missing <NewReleaseMessage> element"))
+		return
+	}
+
+	// Extract the ERN Version in the form of 'ern/xxx' or '/ern/xxx'
+	msgSchemaVersionId := msgVersionElem.SelectAttr("MessageSchemaVersionId")
+	ernVersion := strings.TrimPrefix(msgSchemaVersionId, "/")
+	ernVersion = strings.TrimPrefix(ernVersion, "ern/")
+
+	var createTrackRelease []common.CreateTrackRelease
+	var createAlbumRelease []common.CreateAlbumRelease
+	var errs []error
+	switch ernVersion {
+	// Not sure what the difference is between 3.81 and 3.82
+	case "381":
+		createTrackRelease, createAlbumRelease, errs = parseERN381(doc, p.IndexedBucket, delivery.ID.Hex())
+	case "382":
+		createTrackRelease, createAlbumRelease, errs = parseERN381(doc, p.IndexedBucket, delivery.ID.Hex())
+	default:
+		p.Logger.Error("Unsupported schema. Expected ern/381 or ern/382", "schema", msgSchemaVersionId)
+		p.failAndUpdateStatus(delivery.ID, fmt.Errorf("unsupported schema '%s'. Expected ern/381 or ern/382", msgSchemaVersionId))
+		return
+	}
+
 	if len(errs) != 0 {
 		p.Logger.Error("Failed to parse delivery. Printing errors...")
 		for _, err := range errs {


### PR DESCRIPTION
### Description
DDEX choreography affects how files are indexed. This PR doesn't change the indexer but sets up DDEX to run for one choreography at a time with related infra changes:

- Adds `DDEX_CHOREOGRAPHY` env var and pipes it to each service
- Makes integration tests run separately for the 2 choreography types (release-by-release vs batched)
- Enables support for parsing multiple ERN versions by reading the ERN version from XML
- Documents the env vars needed in prod

### How Has This Been Tested?
Running e2e tests for batched and release-by-release choreographies behave as expected locally. CI should also be green before merging.