### PR TITLE
Fix social sign ups redirecting unintentionally

### DIFF
--- a/packages/mobile/src/screens/sign-on-screen/screens/CreateEmailScreen.tsx
+++ b/packages/mobile/src/screens/sign-on-screen/screens/CreateEmailScreen.tsx
@@ -81,6 +81,7 @@ export const CreateEmailScreen = (props: SignOnScreenProps) => {
   const handleSocialMediaLoginSuccess = useCallback(
     (result: { requiresReview: boolean; handle: string }) => {
       const { handle, requiresReview } = result
+      dispatch(startSignUp())
       handleCompleteSocialMediaLogin()
       dispatch(setLinkedSocialOnFirstPage(true))
       dispatch(setValueField('handle', handle))


### PR DESCRIPTION
### Description

Found a small but serious bug where twitter sign up was forcefully redirecting to the feed during the last two steps, realized its because we weren't "starting" the sign up with the social flow.
Only noticeable on a fresh session

### How Has This Been Tested?

ios sim with twitter sign up
