### PR TITLE
Disable play button if all collection tracks deleted on web

### DIFF
--- a/packages/web/src/components/collection/desktop/CollectionActionButtons.tsx
+++ b/packages/web/src/components/collection/desktop/CollectionActionButtons.tsx
@@ -18,7 +18,7 @@ type CollectionActionButtonProps = {
   isOwner?: boolean
   onPlay: () => void
   playing: boolean
-  isEmptyPlaylist: boolean
+  isPlayable: boolean
   userId: ID
   tracksLoading: boolean
 }
@@ -30,7 +30,7 @@ export const CollectionActionButtons = (props: CollectionActionButtonProps) => {
     collectionId,
     onPlay,
     playing,
-    isEmptyPlaylist,
+    isPlayable,
     userId,
     tracksLoading
   } = props
@@ -61,9 +61,7 @@ export const CollectionActionButtons = (props: CollectionActionButtonProps) => {
       role='group'
       aria-label={messages.actionGroupLabel}
     >
-      {isEmptyPlaylist ? null : (
-        <PlayButton onPlay={onPlay} playing={playing} />
-      )}
+      {!isPlayable ? null : <PlayButton onPlay={onPlay} playing={playing} />}
       {actionButtons}
     </div>
   )

--- a/packages/web/src/components/collection/desktop/CollectionHeader.tsx
+++ b/packages/web/src/components/collection/desktop/CollectionHeader.tsx
@@ -34,6 +34,7 @@ export const CollectionHeader = (props: CollectionHeaderProps) => {
     isOwner,
     modified,
     numTracks,
+    isPlayable,
     duration,
     isPublished,
     tracksLoading,
@@ -180,7 +181,7 @@ export const CollectionHeader = (props: CollectionHeaderProps) => {
             userId={userId}
             collectionId={collectionId}
             onPlay={onPlay}
-            isEmptyPlaylist={numTracks === 0}
+            isPlayable={isPlayable}
             tracksLoading={tracksLoading}
           />
         </div>

--- a/packages/web/src/components/collection/mobile/CollectionHeader.jsx
+++ b/packages/web/src/components/collection/mobile/CollectionHeader.jsx
@@ -85,6 +85,7 @@ const CollectionHeader = ({
   isSaved,
   modified,
   numTracks,
+  isPlayable,
   duration,
   isPublished,
   isPublishing,
@@ -230,7 +231,9 @@ const CollectionHeader = ({
             className={styles.artist}
           />
           <div className={styles.buttonSection}>
-            <PlayButton playing={playing} onPlay={onPlay} />
+            {isPlayable ? (
+              <PlayButton playing={playing} onPlay={onPlay} />
+            ) : null}
             <ActionButtonRow
               isOwner={isOwner}
               isSaved={isSaved}
@@ -306,6 +309,8 @@ CollectionHeader.propTypes = {
   isSaved: PropTypes.bool,
   saves: PropTypes.number,
   repostCount: PropTypes.number,
+  numTracks: PropTypes.number,
+  isPlayable: PropTypes.bool,
 
   // Actions
   onRepost: PropTypes.func,

--- a/packages/web/src/pages/collection-page/components/desktop/CollectionPage.tsx
+++ b/packages/web/src/pages/collection-page/components/desktop/CollectionPage.tsx
@@ -180,6 +180,9 @@ const CollectionPage = ({
     playlistSaveCount,
     playlistRepostCount
   } = computeCollectionMetadataProps(metadata)
+  const numTracks = tracks.entries.length
+  const areAllTracksDeleted = tracks.entries.every((track) => track.is_delete)
+  const isPlayable = !areAllTracksDeleted && numTracks > 0
 
   const topSection = (
     <CollectionHeader
@@ -195,7 +198,8 @@ const CollectionPage = ({
       description={description}
       isOwner={isOwner}
       isAlbum={isAlbum}
-      numTracks={tracks.entries.length}
+      numTracks={numTracks}
+      isPlayable={isPlayable}
       modified={lastModified}
       duration={duration}
       isPublished={!isPrivate}

--- a/packages/web/src/pages/collection-page/components/mobile/CollectionPage.tsx
+++ b/packages/web/src/pages/collection-page/components/mobile/CollectionPage.tsx
@@ -227,6 +227,9 @@ const CollectionPage = ({
       isLocked
     }
   })
+  const numTracks = trackList.length
+  const areAllTracksDeleted = trackList.every((track) => track.isDeleted)
+  const isPlayable = !areAllTracksDeleted && numTracks > 0
 
   return (
     <MobilePageContainer
@@ -254,7 +257,8 @@ const CollectionPage = ({
             description={description}
             isOwner={isOwner}
             isAlbum={isAlbum}
-            numTracks={trackList.length}
+            numTracks={numTracks}
+            isPlayable={isPlayable}
             modified={lastModified || Date.now()}
             duration={duration}
             isPublished={!isPrivate}

--- a/packages/web/src/pages/track-page/components/mobile/ActionButtonRow.tsx
+++ b/packages/web/src/pages/track-page/components/mobile/ActionButtonRow.tsx
@@ -125,7 +125,13 @@ const ActionButtonRow = ({
   }
 
   return (
-    <Flex direction='row' alignItems='center' gap='xl' mt='m'>
+    <Flex
+      direction='row'
+      alignItems='center'
+      justifyContent='center'
+      gap='xl'
+      mt='m'
+    >
       <ClientOnly>
         {showRepost && renderRepostButton()}
         {showFavorite && renderFavoriteButton()}


### PR DESCRIPTION
### Description

Handled for mobile. Forgot about web (and mobile web).

Instead of disabling the button, web has logic to remove the play button if playlist empty, so im also removing the button if all playlist tracks deleted.

### How Has This Been Tested?

local web v stage

<img width="870" alt="Screenshot 2024-02-29 at 4 37 09 PM" src="https://github.com/AudiusProject/audius-protocol/assets/9600175/6f2d723c-177e-4b82-85fe-d59a7c73d436">

<img width="547" alt="Screenshot 2024-02-29 at 4 57 12 PM" src="https://github.com/AudiusProject/audius-protocol/assets/9600175/dc15595c-27f0-4f5f-b1f0-78a4097a7eda">
