### PR TITLE
[C-3926] Add error helper text to new sign in password field

### DIFF
--- a/packages/mobile/src/screens/sign-on-screen/screens/SignInScreen.tsx
+++ b/packages/mobile/src/screens/sign-on-screen/screens/SignInScreen.tsx
@@ -107,7 +107,7 @@ const SignInPasswordField = () => {
   const signInError = useSelector((state: any) =>
     getPasswordField(state)?.error.includes('400')
   )
-  const [, , { setError }] = useField('password')
+  const [, { error }, { setError }] = useField('password')
 
   useEffect(() => {
     if (signInError) {
@@ -120,6 +120,7 @@ const SignInPasswordField = () => {
       name='password'
       label={signInPageMessages.passwordLabel}
       autoComplete='current-password'
+      helperText={error}
     />
   )
 }


### PR DESCRIPTION
### Description
Add the error message as helper text to the password field
Error from the field automatically is cleared when the field is changed

### How Has This Been Tested?

Manually tested
