### PR TITLE
[C-3708] Fix wallet text clipping issue in withdrawals table

### DIFF
--- a/packages/web/src/pages/pay-and-earn-page/components/WithdrawalsTable.module.css
+++ b/packages/web/src/pages/pay-and-earn-page/components/WithdrawalsTable.module.css
@@ -1,4 +1,5 @@
 .text {
+  line-height: 16px;
   overflow: hidden;
   text-overflow: ellipsis;
 }


### PR DESCRIPTION
### Description
Slight increase to line height to make sure that the text doesn't clip vertically

### How Has This Been Tested?
I can't test bc i don't have withdrawals, but this fix should work based on testing with Dylan
