### PR TITLE
Fix download buttons erroneously displaying

### DIFF
--- a/packages/web/src/components/track/DownloadRow.tsx
+++ b/packages/web/src/components/track/DownloadRow.tsx
@@ -126,7 +126,7 @@ export const DownloadRow = ({
             {formatBytes(size)}
           </Text>
         ) : null}
-        {!hideDownload ? null : (
+        {hideDownload ? null : (
           <>
             {shouldDisplayDownloadFollowGated ? (
               <Tooltip


### PR DESCRIPTION
### Description
Fixes bug where `!` was accidentally added while doing an icon migration, causing download buttons to show before purchase, and vice versa.

### How Has This Been Tested?

Local web stage
