### PR TITLE
[PAY-2527] Return `playlists_containing_track` from track apis

### DIFF
--- a/packages/discovery-provider/integration_tests/tasks/entity_manager/test_utils.py
+++ b/packages/discovery-provider/integration_tests/tasks/entity_manager/test_utils.py
@@ -189,6 +189,7 @@ def test_valid_parse_metadata(app):
                 "audio_upload_id": None,
                 "placement_hosts": None,
                 "ddex_app": None,
+                "playlists_containing_track": None,
             },
             "QmUpdatePlaylist1": {
                 "playlist_id": 1,

--- a/packages/discovery-provider/plugins/pedalboard/packages/storage/src/index.ts
+++ b/packages/discovery-provider/plugins/pedalboard/packages/storage/src/index.ts
@@ -987,6 +987,7 @@ export type Tracks = {
   is_download_gated: boolean;
   download_conditions: unknown | null;
   is_original_available: boolean;
+  playlists_containing_track: number[] | null;
   orig_file_cid: string | null;
   orig_filename: string | null;
   ddex_app: string | null;

--- a/packages/discovery-provider/src/api/v1/models/tracks.py
+++ b/packages/discovery-provider/src/api/v1/models/tracks.py
@@ -117,6 +117,7 @@ track = ns.model(
         "permalink": fields.String,
         "is_streamable": fields.Boolean,
         "ddex_app": fields.String(allow_null=True),
+        "playlists_containing_track": fields.List(fields.Integer),
     },
 )
 

--- a/packages/discovery-provider/src/schemas/track_schema.json
+++ b/packages/discovery-provider/src/schemas/track_schema.json
@@ -58,6 +58,13 @@
           "type": "integer",
           "default": 0
         },
+        "playlists_containing_track": {
+          "type": "array",
+          "default": [],
+          "items": {
+            "type": "integer"
+          }
+        },
         "preview_start_seconds": {
           "type": [
             "float",

--- a/packages/discovery-provider/src/tasks/metadata.py
+++ b/packages/discovery-provider/src/tasks/metadata.py
@@ -74,6 +74,7 @@ class TrackMetadata(TypedDict):
     is_download_gated: Optional[bool]
     download_conditions: Optional[Any]
     is_playlist_upload: Optional[bool]
+    playlists_containing_track: Optional[List[int]]
     ai_attribution_user_id: Optional[int]
     placement_hosts: Optional[str]
     ddex_app: Optional[str]
@@ -121,6 +122,7 @@ track_metadata_format: TrackMetadata = {
     "is_download_gated": False,
     "download_conditions": None,
     "is_playlist_upload": False,
+    "playlists_containing_track": None,
     "ai_attribution_user_id": None,
     "placement_hosts": None,
     "ddex_app": None,


### PR DESCRIPTION
### Description

Add `playlists_containing_track` field to all track api returns

### How Has This Been Tested?

local discovery provider returns the field with api results