### PR TITLE
Add an isNativeMobile prop to amplitude

### DIFF
--- a/packages/mobile/src/services/analytics.ts
+++ b/packages/mobile/src/services/analytics.ts
@@ -81,6 +81,7 @@ export const track = async ({ eventName, properties }: Track) => {
   const propertiesWithContext = {
     ...properties,
     clientVersion,
+    isNativeMobile: true,
     mobileClientVersion: version,
     mobileClientVersionInclOTA: versionInfo ?? 'unknown'
   }


### PR DESCRIPTION
### Description

Make it so that we can filter all amplitude events by `isNativeMobile`

### How Has This Been Tested?

atm cant test locally due to "missing amplitude key" error (need to dig into, I thought we fixed that?), but not worried about it not working out in the wild