### PR TITLE
Fix reset password

### DIFF
--- a/packages/common/src/services/audius-backend/AudiusBackend.ts
+++ b/packages/common/src/services/audius-backend/AudiusBackend.ts
@@ -1678,9 +1678,9 @@ export const audiusBackend = ({
     )
   }
 
-  async function resetPassword(email: string, password: string) {
-    await waitForLibsInit()
-    return audiusLibs.Account.resetPassword(email, password)
+  async function resetPassword(username: string, password: string) {
+    const libs = await getAudiusLibsTyped()
+    return libs.Account!.resetPassword({ username, password })
   }
 
   async function sendRecoveryEmail() {


### PR DESCRIPTION
The parameters changed to an object arg, but since `audiusLibs` is untyped, we didn't catch it.

Created ONC-41 to track better types for that file