### PR TITLE
[INF-663] Fix external package versioning in monorepo

### DIFF
--- a/packages/libs/package.json
+++ b/packages/libs/package.json
@@ -63,9 +63,9 @@
     "prepack": "turbo run build"
   },
   "dependencies": {
-    "@audius/fixed-decimal": "*",
+    "@audius/fixed-decimal": "^0.0.20",
     "@audius/hedgehog": "3.0.0-alpha.0",
-    "@audius/spl": "*",
+    "@audius/spl": "^0.0.27",
     "@babel/core": "^7.23.7",
     "@babel/plugin-proposal-class-static-block": "7.21.0",
     "@babel/runtime": "7.18.3",


### PR DESCRIPTION
### Description

After publishing a new version of @audius/sdk it throws an error when consumed:
```
✘ [ERROR] No matching export in "node_modules/@audius/spl/dist/esm/index.js" for import "ClaimableTokensProgram"

    node_modules/@audius/sdk/dist/index-b7c375d7.js:27:9:
      27 │ import { ClaimableTokensProgram, RewardManagerProgram } from '@audius/spl';
         ╵          ~~~~~~~~~~~~~~~~~~~~~~

✘ [ERROR] No matching export in "node_modules/@audius/spl/dist/esm/index.js" for import "RewardManagerProgram"

    node_modules/@audius/sdk/dist/index-b7c375d7.js:27:33:
      27 │ import { ClaimableTokensProgram, RewardManagerProgram } from '@audius/spl';
```
This is because changes in `@audius/spl` had not been published and `@audius/sdk` had wildcard dependencies on `@audius/spl` and `@audius/fixed-decimal`

Resolved by setting these versions to `^` ranges, which will match our local version. But for consumers of sdk it will match the published version. Going to publish sdk again after this gets merged

Let's make sure we adhere to semver with all of our public packages! There will hopefully be better tooling around this in the future

### How Has This Been Tested?

Confirmed that local versions of packages are still used
