### PR TITLE
Bump mediorum play logging timeout to 60s

### DIFF
--- a/mediorum/server/serve_blob.go
+++ b/mediorum/server/serve_blob.go
@@ -332,7 +332,7 @@ func (ss *MediorumServer) logTrackListen(c echo.Context) {
 	}
 
 	httpClient := http.Client{
-		Timeout: 5 * time.Second, // identity svc slow
+		Timeout: 1 * time.Minute, // identity svc slow
 	}
 
 	sig, err := signature.ParseFromQueryString(c.QueryParam("signature"))


### PR DESCRIPTION
Bumps the logging of play counts in mediorum from 5 seconds to 1 minute because the endpoint it uses will sometimes take more than 5 seconds. This runs in a goroutine, so it doesn't block streaming.