### PR TITLE
Add user.info.profile scope to tiktok redirect

### DIFF
--- a/packages/identity-service/src/routes/tiktok.js
+++ b/packages/identity-service/src/routes/tiktok.js
@@ -48,10 +48,6 @@ module.exports = function (app) {
       const { code, state } = req.body
       const { csrfState } = req.cookies
 
-      if (!state || !csrfState || state !== csrfState) {
-        return errorResponseBadRequest('Invalid state')
-      }
-
       try {
         // Fetch user's accessToken
         const accessTokenResponse = await axios.post(
@@ -134,6 +130,7 @@ module.exports = function (app) {
 
         return successResponse({ data: accessTokenResponse.data })
       } catch (err) {
+        req.logger.error(`TikTok access_token error`, err)
         return errorResponseBadRequest(err)
       }
     })

--- a/packages/identity-service/src/routes/tiktok.js
+++ b/packages/identity-service/src/routes/tiktok.js
@@ -48,6 +48,10 @@ module.exports = function (app) {
       const { code, state } = req.body
       const { csrfState } = req.cookies
 
+      if (!state || !csrfState || state !== csrfState) {
+        return errorResponseBadRequest('Invalid state')
+      }
+
       try {
         // Fetch user's accessToken
         const accessTokenResponse = await axios.post(

--- a/packages/identity-service/src/routes/tiktok.js
+++ b/packages/identity-service/src/routes/tiktok.js
@@ -26,7 +26,7 @@ module.exports = function (app) {
       let url = 'https://www.tiktok.com/v2/auth/authorize/'
 
       url += `?client_key=${config.get('tikTokAPIKey')}`
-      url += '&scope=user.info.basic'
+      url += '&scope=user.info.basic,user.info.profile'
       url += '&response_type=code'
       url += `&redirect_uri=${config.get('tikTokAuthOrigin')}`
       url += '&state=' + csrfState


### PR DESCRIPTION
### Description

TikTok auth was broken because our redirect was missing `user.info.profile` scope. Adding the scope fixes it

### How Has This Been Tested?

Confirmed tiktok auth on staging
