### PR TITLE
Perma-dismiss purple select artists banner on mobile

### DIFF
--- a/packages/mobile/src/screens/sign-on-screen/screens/SelectArtistScreen/PreviewArtistHint.tsx
+++ b/packages/mobile/src/screens/sign-on-screen/screens/SelectArtistScreen/PreviewArtistHint.tsx
@@ -1,4 +1,6 @@
-import { useState } from 'react'
+import { setHidePreviewHint } from 'audius-client/src/common/store/pages/signon/actions'
+import { getHidePreviewHint } from 'audius-client/src/common/store/pages/signon/selectors'
+import { useDispatch, useSelector } from 'react-redux'
 
 import {
   IconButton,
@@ -14,10 +16,11 @@ const messages = {
 }
 
 export const PreviewArtistHint = () => {
-  const [isOpen, setIsOpen] = useState(true)
   const { spacing } = useTheme()
+  const hidePreviewHint = useSelector(getHidePreviewHint)
+  const dispatch = useDispatch()
 
-  if (!isOpen) return null
+  if (hidePreviewHint) return null
 
   return (
     <Paper
@@ -41,7 +44,7 @@ export const PreviewArtistHint = () => {
         hitSlop={spacing.l}
         color='staticWhite'
         size='m'
-        onPress={() => setIsOpen(false)}
+        onPress={() => dispatch(setHidePreviewHint())}
       />
     </Paper>
   )

--- a/packages/web/src/pages/sign-up-page/components/PreviewArtistHint.tsx
+++ b/packages/web/src/pages/sign-up-page/components/PreviewArtistHint.tsx
@@ -1,10 +1,14 @@
-import { useState } from 'react'
-
 import { IconCloseAlt, IconPlay, Paper, Text } from '@audius/harmony'
 import { useDispatch } from 'react-redux'
 
-import { setHidePreviewHint } from 'common/store/pages/signon/actions'
-import { getHidePreviewHint } from 'common/store/pages/signon/selectors'
+import {
+  dismissArtistPreviewBanner,
+  setHidePreviewHint
+} from 'common/store/pages/signon/actions'
+import {
+  getHasDismissedArtistPreviewBanner,
+  getHidePreviewHint
+} from 'common/store/pages/signon/selectors'
 import { useSelector } from 'utils/reducer'
 
 const messages = {
@@ -12,11 +16,10 @@ const messages = {
 }
 
 export const PreviewArtistHint = () => {
-  const [isOpen, setIsOpen] = useState(true)
   const hidePreviewHint = useSelector(getHidePreviewHint)
   const dispatch = useDispatch()
 
-  if (!isOpen || hidePreviewHint) return null
+  if (hidePreviewHint) return null
 
   return (
     <Paper
@@ -37,7 +40,6 @@ export const PreviewArtistHint = () => {
         color='staticWhite'
         size='m'
         onClick={() => {
-          setIsOpen(false)
           dispatch(setHidePreviewHint())
         }}
       />


### PR DESCRIPTION
### Description

Make this banner go away for good on mobile
![image](https://github.com/AudiusProject/audius-protocol/assets/6711655/d5a24e5d-5fcf-482e-8956-6def37fcd4a1)

also, just removed the unnecessary state management in the hint itself

### How Has This Been Tested?

web:stage & ios:stage