### PR TITLE
Add country column to aggregate_monthly_plays

### DIFF
--- a/packages/discovery-provider/ddl/migrations/0060_aggregate_monthly_plays_country.sql
+++ b/packages/discovery-provider/ddl/migrations/0060_aggregate_monthly_plays_country.sql
@@ -1,0 +1,9 @@
+begin;
+
+alter table aggregate_monthly_plays add column if not exists country text not null default '';
+
+ALTER TABLE aggregate_monthly_plays DROP CONSTRAINT aggregate_monthly_plays_pkey;
+
+ALTER TABLE aggregate_monthly_plays ADD PRIMARY KEY (play_item_id, "timestamp", country);
+
+commit;

--- a/packages/discovery-provider/src/models/social/aggregate_monthly_plays.py
+++ b/packages/discovery-provider/src/models/social/aggregate_monthly_plays.py
@@ -1,4 +1,4 @@
-from sqlalchemy import Column, Date, Integer, text
+from sqlalchemy import Column, Date, Integer, String, text
 
 from src.models.base import Base
 from src.models.model_utils import RepresentableMixin
@@ -13,4 +13,5 @@ class AggregateMonthlyPlay(Base, RepresentableMixin):
     timestamp = Column(
         Date, primary_key=True, nullable=False, server_default=text("CURRENT_TIMESTAMP")
     )
+    country = Column(String, primary_key=True, nullable=False, server_default="")
     count = Column(Integer, nullable=False)

--- a/packages/discovery-provider/src/queries/get_user_listen_counts_monthly.py
+++ b/packages/discovery-provider/src/queries/get_user_listen_counts_monthly.py
@@ -1,5 +1,6 @@
 from typing import TypedDict
 
+from sqlalchemy import func
 from sqlalchemy.orm.session import Session
 
 from src.models.social.aggregate_monthly_plays import AggregateMonthlyPlay
@@ -45,11 +46,16 @@ def _get_user_listen_counts_monthly(
     end_time = args["end_time"]
 
     query = (
-        session.query(AggregateMonthlyPlay)
+        session.query(
+            AggregateMonthlyPlay.play_item_id,
+            AggregateMonthlyPlay.timestamp,
+            func.sum(AggregateMonthlyPlay.count),
+        )
         .join(Track, Track.track_id == AggregateMonthlyPlay.play_item_id)
         .filter(Track.owner_id == user_id)
         .filter(Track.is_current == True)
         .filter(AggregateMonthlyPlay.timestamp >= start_time)
         .filter(AggregateMonthlyPlay.timestamp < end_time)
+        .group_by(AggregateMonthlyPlay.play_item_id, AggregateMonthlyPlay.timestamp)
     )
     return query.all()

--- a/packages/discovery-provider/src/tasks/index_aggregate_monthly_plays.py
+++ b/packages/discovery-provider/src/tasks/index_aggregate_monthly_plays.py
@@ -25,6 +25,7 @@ UPSERT_AGGREGATE_MONTHLY_PLAYS_QUERY = """
         select
             play_item_id,
             date_trunc('month', created_at) as timestamp,
+            coalesce(country, '') as country,
             count(play_item_id) as count
         from
             plays p
@@ -32,16 +33,17 @@ UPSERT_AGGREGATE_MONTHLY_PLAYS_QUERY = """
             p.id > :prev_id_checkpoint
             and p.id <= :new_id_checkpoint
         group by
-            play_item_id, date_trunc('month', created_at)
+            play_item_id, date_trunc('month', created_at), coalesce(country, '')
     )
     insert into
-        aggregate_monthly_plays (play_item_id, timestamp, count)
+        aggregate_monthly_plays (play_item_id, timestamp, country, count)
     select
         new_plays.play_item_id,
         new_plays.timestamp,
+        new_plays.country,
         new_plays.count
     from
-        new_plays on conflict (play_item_id, timestamp) do
+        new_plays on conflict (play_item_id, timestamp, country) do
     update
     set
         count = aggregate_monthly_plays.count + excluded.count


### PR DESCRIPTION
### Description

* Adds country column (`default ''`) to `aggregate_monthly_plays`.
* Updates primary key to be `(play_item_id, timestamp, country)`
* Updates `index_aggregate_monthly_plays` to include the `country` column.
* Updates existing endpoint to ignore `country` by doing a `sum(count)` with a `group by play_item_id, timestamp`


