### PR TITLE
[Web] Fix Send Tip modal header icon and Download Page cloud icons [C-3952]

### DIFF
--- a/packages/web/src/components/tipping/tip-audio/TipAudio.module.css
+++ b/packages/web/src/components/tipping/tip-audio/TipAudio.module.css
@@ -338,3 +338,7 @@
 .iconSuccess path:nth-child(2) {
   fill: var(--static-white);
 }
+
+.iconToken path {
+  fill: revert-layer;
+}

--- a/packages/web/src/components/tipping/tip-audio/TipAudioModal.tsx
+++ b/packages/web/src/components/tipping/tip-audio/TipAudioModal.tsx
@@ -42,7 +42,11 @@ const messages = {
 }
 
 const GoldBadgeIconImage = () => (
-  <IconTokenGold size='l' aria-label='Gold badge' />
+  <IconTokenGold
+    size='l'
+    aria-label='Gold badge'
+    className={styles.iconToken}
+  />
 )
 
 const titleMessagesMap: { [key in TippingSendStatus]?: string } = {

--- a/packages/web/src/public-site/pages/download-page/DownloadPage.module.css
+++ b/packages/web/src/public-site/pages/download-page/DownloadPage.module.css
@@ -240,6 +240,10 @@
   margin-right: 6px;
 }
 
+.platformIcon path {
+  fill: currentColor;
+}
+
 .isMobile .platformIcon {
   width: 22px;
   height: 22px;


### PR DESCRIPTION
### Description
<img width="548" alt="Screenshot 2024-03-12 at 10 34 21 AM" src="https://github.com/AudiusProject/audius-protocol/assets/36916764/a8b03b65-b2be-4663-b27e-f46509db5bc8">
<img width="1221" alt="Screenshot 2024-03-12 at 10 35 01 AM" src="https://github.com/AudiusProject/audius-protocol/assets/36916764/f4457a64-8f6f-492c-a97d-8bd6ba14cdc7">
(In screenshot, am hovering over Mac download button. ^)

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._
