### PR TITLE
[PAY-2546] Fix stems and downloads text variant

### DIFF
--- a/packages/web/src/components/stem-files-modal/StemFilesModal.tsx
+++ b/packages/web/src/components/stem-files-modal/StemFilesModal.tsx
@@ -30,16 +30,12 @@ const MAX_ROWS = 20
 const messages = {
   title: 'STEMS & DOWNLOADS',
   additionalFiles: 'UPLOAD ADDITIONAL FILES',
-  description:
-    'Upload your stems and source files to allow fans to remix your track. This does not affect users ability to listen offline.',
   allowDownloads: 'Allow Full Track Download',
   allowDownloadsDescription:
     'Allow your fans to download a copy of your full track.',
   requireFollowToDownload: 'Require Follow to Download',
   done: 'DONE',
-  maxCapacity: 'Reached upload limit of 20 files.',
-  stemTypeHeader: 'Select Stem Type',
-  stemTypeDescription: 'Please select a stem type for each of your files.'
+  maxCapacity: 'Reached upload limit of 20 files.'
 }
 
 const defaultDownloadSettings: Download = {

--- a/packages/web/src/pages/upload-page/fields/StemsAndDownloadsMenuFields.tsx
+++ b/packages/web/src/pages/upload-page/fields/StemsAndDownloadsMenuFields.tsx
@@ -354,7 +354,7 @@ export const StemsAndDownloadsMenuFields = (
 
   return (
     <div className={styles.fields}>
-      <Text>{messages.description}</Text>
+      <Text variant='body'>{messages.description}</Text>
       <Divider />
       {isLosslessDownloadsEnabled ? (
         <DownloadAvailability

--- a/packages/web/src/pages/upload-page/fields/SwitchRowField.tsx
+++ b/packages/web/src/pages/upload-page/fields/SwitchRowField.tsx
@@ -37,7 +37,9 @@ export const SwitchRowField = (props: ToggleFieldProps) => {
         <Text tag='label' htmlFor={inputId} variant='title' size='l'>
           {header}
         </Text>
-        <Text id={descriptionId}>{description}</Text>
+        <Text id={descriptionId} variant='body'>
+          {description}
+        </Text>
         {(inverted ? !field.checked : field.checked) ? children : null}
       </div>
       <Switch


### PR DESCRIPTION
### Description

Text descriptions style was wrong, probably due to switching from old Text component to Harmony one.

### How Has This Been Tested?

local web dapp vs stage

now 
<img width="736" alt="Screenshot 2024-03-12 at 8 30 46 PM" src="https://github.com/AudiusProject/audius-protocol/assets/9600175/7ff0b186-bf53-4280-ba60-cd8bc8446e93">

before
<img width="736" alt="Screenshot 2024-03-12 at 8 31 04 PM" src="https://github.com/AudiusProject/audius-protocol/assets/9600175/d6a8936f-275d-4a21-bb49-a32f84e41626">
