### PR TITLE
[INF-668] Remove peerDeps from @audius/harmony

### DIFF
--- a/packages/harmony/README.md
+++ b/packages/harmony/README.md
@@ -22,13 +22,7 @@ Full documentation can be found here: [Harmony Docs](https://harmony.audius.co)
 
 ## Installation
 
-Install `@audius/harmony` required peer dependencies:
-
-```bash
-npm install --save @emotion/react @emotion/styled @radix-ui/react-slot @react-spring/web classnames lodash react-lottie react-merge-refs react-perfect-scrollbar react-use react-use-measure
-```
-
-Then install `@audius/harmony`
+Install `@audius/harmony`:
 
 ```bash
 npm install --save @audius/harmony
@@ -48,12 +42,7 @@ Setup the ThemeProvider exported by Harmony
 import { ThemeProvider as HarmonyThemeProvider } from '@audius/harmony'
 
 const App = () => {
-
-  return (
-    <HarmonyThemeProvider theme='day'>
-        ...
-    </HarmonyThemeProvider>
-  )
+  return <HarmonyThemeProvider theme='day'>...</HarmonyThemeProvider>
 }
 ```
 

--- a/packages/harmony/package.json
+++ b/packages/harmony/package.json
@@ -31,11 +31,6 @@
     "@babel/preset-typescript": "7.22.15",
     "@emotion/babel-plugin": "11.11.0",
     "@emotion/babel-preset-css-prop": "11.11.0",
-    "@emotion/css": "11.11.2",
-    "@emotion/react": "11.11.1",
-    "@emotion/styled": "11.11.0",
-    "@radix-ui/react-slot": "1.0.2",
-    "@react-spring/web": "9.7.2",
     "@rollup/plugin-alias": "5.0.1",
     "@storybook/addon-a11y": "7.4.0",
     "@storybook/addon-actions": "7.4.2",
@@ -61,23 +56,15 @@
     "babel-loader": "8.3.0",
     "babel-runtime": "6.26.0",
     "chromatic": "7.4.0",
-    "classnames": "2.5.1",
     "cross-env": "5.2.1",
     "css-loader": "6.8.1",
     "eslint": "8.56.0",
     "eslint-plugin-storybook": "0.6.13",
     "file-loader": "6.2.0",
-    "lodash": "4.17.21",
     "prettier": "2.8.8",
     "react": "18.2.0",
     "react-docgen-typescript-loader": "3.7.2",
     "react-dom": "18.2.0",
-    "react-lottie": "1.2.3",
-    "react-merge-refs": "2.0.1",
-    "react-perfect-scrollbar": "1.5.8",
-    "react-spring": "8.0.27",
-    "react-use": "15.3.8",
-    "react-use-measure": "2.1.1",
     "remark-gfm": "3.0.1",
     "rollup": "4.3.0",
     "rollup-plugin-json": "4.0.0",
@@ -92,10 +79,11 @@
     "typescript-transform-paths": "3.4.6",
     "webpack": "4.46.0"
   },
-  "peerDependencies": {
+  "dependencies": {
     "@emotion/css": "^11.11.2",
     "@emotion/react": "^11.11.1",
     "@emotion/styled": "^11.11.0",
+    "@juggle/resize-observer": "3.4.0",
     "@radix-ui/react-slot": "^1.0.2",
     "@react-spring/web": "^9.7.2",
     "classnames": "^2.5.1",
@@ -104,10 +92,7 @@
     "react-merge-refs": "^2.0.1",
     "react-perfect-scrollbar": "^1.5.8",
     "react-spring": "^8.0.27",
-    "react-use": "^15.3.8",
-    "react-use-measure": "^2.1.1"
-  },
-  "dependencies": {
-    "@juggle/resize-observer": "3.4.0"
+    "react-use-measure": "^2.1.1",
+    "react-use": "^17.5.0"
   }
 }

--- a/packages/harmony/rollup.config.mjs
+++ b/packages/harmony/rollup.config.mjs
@@ -12,8 +12,8 @@ const cjsRequire = createRequire(import.meta.url)
 const tspCompiler = cjsRequire('ts-patch/compiler')
 
 const external = [
-  ...Object.keys(pkg.devDependencies),
-  ...Object.keys(pkg.peerDependencies),
+  ...Object.keys(pkg.devDependencies ?? {}),
+  ...Object.keys(pkg.peerDependencies ?? {}),
   '@emotion/react/jsx-runtime',
   '@emotion/cache',
   '@emotion/is-prop-valid',


### PR DESCRIPTION
### Description

Keeping peerDeps up to date for this many packages is going to be very painful. It also adds extra friction to the harmony install process.

I was attempting to use harmony in a brand new react 18 app and peerDeps were failing to resolve because of an outdated `react-use` version. This problem is exacerbated by the fact the we use `legacy-peer-deps` in the monorepo but external users may not want to do that

Material UI only has 2 peer deps, `react` and `react-use` which I think is more reasonable. But in our case I think it makes sense to remove all peerDeps and then use overrides in our client if we want/need to reduce bundle size due to multiple versions of packages being installed

I will publish a new version of harmony once this is merged!

### How Has This Been Tested?

Confirmed things build
