### PR TITLE
Remove custom Sentry fingerprint

### DIFF
--- a/packages/web/src/services/sentry.ts
+++ b/packages/web/src/services/sentry.ts
@@ -50,19 +50,6 @@ export const initializeSentry = () => {
         }
       }
       return breadCrumb
-    },
-    beforeSend: (event, hint) => {
-      // This code manually adds the exceptionName to the event Fingerprint,
-      // which controls how Sentry groups events into issues.
-      // More background:
-      // https://docs.sentry.io/data-management/event-grouping/sdk-fingerprinting/?platform=javascript
-      const exception = hint ? hint.originalException : undefined
-      if (!exception) return event
-
-      const exceptionName = exception.toString()
-      event.fingerprint = [exceptionName]
-
-      return event
     }
   })
 }


### PR DESCRIPTION
### Description

By default, Sentry will use the stack trace when available to group issues together. This seems like it might work better than what we have today, which is a `toString()` on the error object.

https://docs.sentry.io/product/data-management-settings/event-grouping/#grouping-by-stack-trace

The goal is hopefully sentry is smart enough to group the myriad of similar issues with different messages but same stack trace/cause into the same issues, reducing issue noise on sentry.

Will test on staging