### PR TITLE
[ONC-52] Self-re-enqueue user_bank and payment_router indexing tasks

### DIFF
--- a/packages/discovery-provider/src/app.py
+++ b/packages/discovery-provider/src/app.py
@@ -367,14 +367,6 @@ def configure_celery(celery, test_config=None):
                 "task": "index_solana_plays",
                 "schedule": timedelta(seconds=5),
             },
-            "index_user_bank": {
-                "task": "index_user_bank",
-                "schedule": timedelta(seconds=1),
-            },
-            "index_payment_router": {
-                "task": "index_payment_router",
-                "schedule": timedelta(seconds=1),
-            },
             "index_challenges": {
                 "task": "index_challenges",
                 "schedule": timedelta(seconds=5),
@@ -543,3 +535,5 @@ def configure_celery(celery, test_config=None):
     # Start tasks that should fire upon startup
     celery.send_task("cache_entity_counts")
     celery.send_task("index_nethermind", queue="index_nethermind")
+    celery.send_task("index_user_bank", queue="index_nethermind")
+    celery.send_task("index_payment_router", queue="index_nethermind")

--- a/packages/discovery-provider/src/tasks/index_payment_router.py
+++ b/packages/discovery-provider/src/tasks/index_payment_router.py
@@ -988,3 +988,6 @@ def index_payment_router(self):
     finally:
         if have_lock:
             update_lock.release()
+        celery.send_task(
+                "index_payment_router", countdown=0.5, queue="index_nethermind"
+            )

--- a/packages/discovery-provider/src/tasks/index_user_bank.py
+++ b/packages/discovery-provider/src/tasks/index_user_bank.py
@@ -1119,3 +1119,6 @@ def index_user_bank(self):
     finally:
         if have_lock:
             update_lock.release()
+        celery.send_task(
+                "index_user_bank", countdown=0.5, queue="index_nethermind"
+            )


### PR DESCRIPTION
### Description
* Makes the index_user_bank and index_payment_router celery tasks re-enqueue themselves when finished instead of enqueuing every second regardless of if the previous job hadn't run yet
* Moves index_user_bank and index_payment_router to the dedicated ACDC queue instead of being in a shared queue with all tasks

The aim of this is to reduce the buildup of tasks in the shared queue, which was too much to keep up with when enqueuing these tasks every second.

### How Has This Been Tested?
Indexing works locally and with test-audius-cmd on CI. User bank and payment router need to also be more explicitly tested.