### PR TITLE
[C-3958] Add StaticImage component and update track artwork rendering on web and mobile-web track pages for ssr

### DIFF
--- a/packages/web/src/components/static-image/StaticImage.tsx
+++ b/packages/web/src/components/static-image/StaticImage.tsx
@@ -1,0 +1,87 @@
+import { ComponentPropsWithoutRef } from 'react'
+
+import { SquareSizes } from '@audius/common/models'
+import { Box, Flex } from '@audius/harmony'
+import {
+  DiscoveryNodeSelector,
+  productionConfig,
+  stagingConfig,
+  developmentConfig,
+  StorageNodeSelector,
+  AppAuth
+} from '@audius/sdk'
+
+import { env } from 'services/env'
+
+export type StaticImageProps = {
+  // Image CID
+  cid?: string | null
+  // Size of image to select
+  size?: SquareSizes
+  // Set height and width of wrapper container to 100%
+  fullWidth?: boolean
+  // Classes to apply to the wrapper
+  wrapperClassName?: string
+} & ComponentPropsWithoutRef<'img'>
+
+const sdkConfigs = {
+  production: productionConfig,
+  staging: stagingConfig,
+  development: developmentConfig
+}
+
+const discoveryNodeSelector = new DiscoveryNodeSelector({
+  bootstrapServices: (
+    sdkConfigs[env.ENVIRONMENT as keyof typeof sdkConfigs] ?? productionConfig
+  ).discoveryNodes
+})
+
+const auth = new AppAuth('', '')
+
+const storageNodeSelector = new StorageNodeSelector({
+  auth,
+  discoveryNodeSelector,
+  bootstrapNodes: (
+    sdkConfigs[env.ENVIRONMENT as keyof typeof sdkConfigs] ?? productionConfig
+  ).storageNodes
+})
+
+export const StaticImage = (props: StaticImageProps) => {
+  const {
+    cid,
+    size = SquareSizes.SIZE_1000_BY_1000,
+    fullWidth = false,
+    wrapperClassName,
+    children,
+    ...other
+  } = props
+
+  let url = ''
+  if (cid) {
+    const cidFileName = `${cid}/${size}.jpg`
+    const storageNodes = storageNodeSelector.getNodes(cidFileName)
+    url = `${storageNodes[0]}/content/${cidFileName}`
+  }
+
+  return (
+    <Box
+      h={fullWidth ? '100%' : undefined}
+      w={fullWidth ? '100%' : undefined}
+      className={wrapperClassName}
+      css={{ overflow: 'hidden' }}
+    >
+      <img height='100%' width='100%' src={url} {...other} />
+      {children ? (
+        <Flex
+          h='100%'
+          w='100%'
+          alignItems='center'
+          justifyContent='center'
+          css={{ zIndex: 3 }}
+        >
+          {children}
+        </Flex>
+      ) : null}
+    </Box>
+  )
+}

--- a/packages/web/src/components/track/GiantArtwork.tsx
+++ b/packages/web/src/components/track/GiantArtwork.tsx
@@ -6,7 +6,9 @@ import { Nullable } from '@audius/common/utils'
 import CoSign from 'components/co-sign/CoSign'
 import { Size } from 'components/co-sign/types'
 import DynamicImage from 'components/dynamic-image/DynamicImage'
+import { StaticImage } from 'components/static-image/StaticImage'
 import { useTrackCoverArt } from 'hooks/useTrackCoverArt'
+import { useSsrContext } from 'ssr/SsrContext'
 
 import styles from './GiantArtwork.module.css'
 
@@ -15,14 +17,17 @@ type GiantArtworkProps = {
   coverArtSizes: Nullable<CoverArtSizes>
   coSign: Nullable<Remix>
   callback: () => void
+  cid: Nullable<string>
 }
 
 const GiantArtwork = ({
+  cid,
   trackId,
   coverArtSizes,
   coSign,
   callback
 }: GiantArtworkProps) => {
+  const { isSsrEnabled } = useSsrContext()
   const image = useTrackCoverArt(
     trackId,
     coverArtSizes,
@@ -32,6 +37,18 @@ const GiantArtwork = ({
   useEffect(() => {
     if (image) callback()
   }, [image, callback])
+
+  const imageElement = isSsrEnabled ? (
+    <StaticImage
+      fullWidth
+      wrapperClassName={styles.imageWrapper}
+      cid={cid}
+      alt='Track Artwork'
+    />
+  ) : (
+    <DynamicImage wrapperClassName={styles.imageWrapper} image={image} />
+  )
+
   return coSign ? (
     <CoSign
       size={Size.XLARGE}
@@ -41,12 +58,10 @@ const GiantArtwork = ({
       className={styles.giantArtwork}
       userId={coSign.user?.user_id}
     >
-      <DynamicImage wrapperClassName={styles.imageWrapper} image={image} />
+      {imageElement}
     </CoSign>
   ) : (
-    <div className={styles.giantArtwork}>
-      <DynamicImage wrapperClassName={styles.imageWrapper} image={image} />
-    </div>
+    <div className={styles.giantArtwork}>{imageElement}</div>
   )
 }
 

--- a/packages/web/src/components/track/GiantTrackTile.tsx
+++ b/packages/web/src/components/track/GiantTrackTile.tsx
@@ -552,6 +552,7 @@ export const GiantTrackTile = ({
           trackId={trackId}
           coverArtSizes={coverArtSizes}
           coSign={coSign}
+          cid={track?.cover_art_sizes ?? null}
           callback={onArtworkLoad}
         />
         <div className={styles.infoSection}>

--- a/packages/web/src/pages/track-page/components/mobile/TrackHeader.module.css
+++ b/packages/web/src/pages/track-page/components/mobile/TrackHeader.module.css
@@ -44,6 +44,10 @@
   overflow: hidden;
 }
 
+.cosignImageWrapper {
+  height: 100%
+}
+
 .title {
   color: var(--neutral);
   font-family: var(--font-family);

--- a/packages/web/src/pages/track-page/components/mobile/TrackHeader.tsx
+++ b/packages/web/src/pages/track-page/components/mobile/TrackHeader.tsx
@@ -45,6 +45,7 @@ import { DogEar } from 'components/dog-ear'
 import DynamicImage from 'components/dynamic-image/DynamicImage'
 import { UserLink } from 'components/link'
 import { SearchTag } from 'components/search/SearchTag'
+import { StaticImage } from 'components/static-image/StaticImage'
 import { AiTrackSection } from 'components/track/AiTrackSection'
 import Badge from 'components/track/Badge'
 import { DownloadSection } from 'components/track/DownloadSection'
@@ -52,6 +53,7 @@ import { GatedTrackSection } from 'components/track/GatedTrackSection'
 import { UserGeneratedText } from 'components/user-generated-text'
 import { useFlag } from 'hooks/useRemoteConfig'
 import { useTrackCoverArt } from 'hooks/useTrackCoverArt'
+import { useSsrContext } from 'ssr/SsrContext'
 import { moodMap } from 'utils/Moods'
 import { isDarkMode } from 'utils/theme/theme'
 import { trpc } from 'utils/trpcClientWeb'
@@ -203,6 +205,7 @@ const TrackHeader = ({
 }: TrackHeaderProps) => {
   const { isEnabled: isEditAlbumsEnabled } = useFlag(FeatureFlags.EDIT_ALBUMS)
   const { getTrack } = cacheTracksSelectors
+  const { isSsrEnabled } = useSsrContext()
   const track = useSelector(
     (state: CommonState) => getTrack(state, { id: trackId }),
     shallowEqual
@@ -229,6 +232,7 @@ const TrackHeader = ({
     coverArtSizes,
     SquareSizes.SIZE_480_BY_480
   )
+
   const onSaveHeroTrack = () => {
     if (!isOwner) onSave()
   }
@@ -318,6 +322,9 @@ const TrackHeader = ({
     goToRepostsPage(trackId)
   }, [goToRepostsPage, trackId])
 
+  const InnerImageElement = isSsrEnabled ? StaticImage : DynamicImage
+  const imageSrc = isSsrEnabled ? track?.cover_art_sizes : image
+
   const imageElement = coSign ? (
     <CoSign
       size={Size.LARGE}
@@ -327,11 +334,18 @@ const TrackHeader = ({
       className={styles.coverArt}
       userId={coSign.user.user_id}
     >
-      <DynamicImage image={image} wrapperClassName={styles.imageWrapper} />
+      <InnerImageElement
+        cid={imageSrc}
+        image={imageSrc ?? undefined}
+        alt='Track Artwork'
+        wrapperClassName={cn(styles.imageWrapper, styles.cosignImageWrapper)}
+      />
     </CoSign>
   ) : (
-    <DynamicImage
-      image={image}
+    <InnerImageElement
+      cid={imageSrc}
+      image={imageSrc ?? undefined}
+      alt='Track Artwork'
       wrapperClassName={cn(styles.coverArt, styles.imageWrapper)}
     />
   )

--- a/packages/web/src/ssr/track/+route.tsx
+++ b/packages/web/src/ssr/track/+route.tsx
@@ -1,5 +1,4 @@
 import { resolveRoute } from 'vike/routing'
-// eslint-disable-next-line import/no-unresolved
 import { PageContextServer } from 'vike/types'
 
 import { staticRoutes } from 'utils/route'


### PR DESCRIPTION
### Description
Added very minimal StaticImage component to handle rendering an img tag based on a provided src to kick off the img fetch sooner in the start up, and then split the image logic on web and mobile-web track pages to conditionally render the static image based on if SSR is enabled

Drops LCP time drop from 26 - 29 sec to 6 - 8 sec which is pretty neat

### How Has This Been Tested?

Lots of manual testing on kj.audius.co
