### PR TITLE
Parse more ddex fields

### DIFF
--- a/packages/ddex/ingester/artistutils/artistutils.go
+++ b/packages/ddex/ingester/artistutils/artistutils.go
@@ -5,8 +5,10 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"ingester/common"
 	"io"
 	"net/http"
+	"sort"
 	"strings"
 
 	"go.mongodb.org/mongo-driver/bson"
@@ -24,42 +26,76 @@ func CreateArtistNameIndex(usersColl *mongo.Collection, ctx context.Context) err
 	return nil
 }
 
-// GetArtistID searches Mongo OAuthed artists for an exact match on artistName (display name) and returns the artist's ID
-func GetArtistID(artistName string, usersColl *mongo.Collection, ctx context.Context) (string, error) {
-	filter := bson.M{"name": artistName}
-	cursor, err := usersColl.Find(ctx, filter)
-	if err != nil {
-		return "", err
-	}
-	defer cursor.Close(ctx)
+// GetFirstArtistID searches Mongo OAuthed artists for the first match on the track's display artists' names
+// and returns that artist's ID
+func GetFirstArtistID(artists []common.Artist, usersColl *mongo.Collection, ctx context.Context) (string, string, []string, error) {
+	// Sort artists by SequenceNumber (asc)
+	sort.Slice(artists, func(i, j int) bool {
+		return artists[i].SequenceNumber < artists[j].SequenceNumber
+	})
 
-	var results []bson.M
-	if err = cursor.All(ctx, &results); err != nil {
-		return "", err
-	}
-
-	// Fail if multiple artists have their display name set to the same string
-	if len(results) > 1 {
-		var handles []string
-		for _, result := range results {
-			if handle, ok := result["handle"].(string); ok {
-				handles = append(handles, "@"+handle)
-			}
+	artistID := ""
+	artistName := ""
+	var err error
+	var warnings []string
+	for _, artist := range artists {
+		filter := bson.M{"name": artist.Name}
+		cursor, err := usersColl.Find(ctx, filter)
+		if err != nil {
+			return "", "", warnings, err
 		}
-		idsStr := strings.Join(handles, ", ")
-		return "", fmt.Errorf("error: more than one artist found with the same display name: %s", idsStr)
+		defer cursor.Close(ctx)
+
+		var results []bson.M
+		if err = cursor.All(ctx, &results); err != nil {
+			return "", "", warnings, err
+		}
+
+		// Continue to the next display artist if multiple artists have their display name set to this artist.Name
+		if len(results) > 1 {
+			var handles []string
+			for _, result := range results {
+				if handle, ok := result["handle"].(string); ok {
+					handles = append(handles, "@"+handle)
+				}
+			}
+			idsStr := strings.Join(handles, ", ")
+			warnings = append(warnings, fmt.Sprintf("error: more than one artist found with the same display name %s: %s", artist.Name, idsStr))
+			continue
+		}
+
+		// Continue to the next display artist if no artist is found, and use /v1/users/search to display potential
+		// matches in the warnings
+		if len(results) == 0 {
+			id, err := searchArtistOnAudius(artist.Name)
+			if err != nil {
+				warnings = append(warnings, err.Error())
+				continue
+			}
+			// Unreachable for now
+			artistID = id
+			artistName = artist.Name
+			err = nil
+			break
+		}
+
+		id, ok := results[0]["_id"].(string)
+		if !ok {
+			warnings = append(warnings, "error: unable to parse _id from the users collection")
+			continue
+		}
+
+		// Found first OAuthed artist ID
+		artistID = id
+		artistName = artist.Name
+		err = nil
+		break
 	}
 
-	// Fail if no artist is found, and use /v1/users/search to display potential matches in the error message
-	if len(results) == 0 {
-		return searchArtistOnAudius(artistName)
+	if artistID != "" {
+		return artistID, artistName, warnings, nil
 	}
-
-	artistID, ok := results[0]["_id"].(string)
-	if !ok {
-		return "", errors.New("error: unable to parse artist ID")
-	}
-	return artistID, nil
+	return "", "", warnings, err
 }
 
 // searchArtistOnAudius searches Audius (public /v1/users/search endpoint) for an artist by name and returns potential matches.

--- a/packages/ddex/ingester/common/sdk_types.go
+++ b/packages/ddex/ingester/common/sdk_types.go
@@ -200,12 +200,12 @@ type TrackMetadata struct {
 	ArtistName string `bson:"artist_name"`
 
 	// michelle add to sdk ==
-	ResourceContributors         []ResourceContributor `bson:"resource_contributor"`
-	IndirectResourceContributors []ResourceContributor `bson:"indirect_resource_contributor"`
-	RightsController             RightsController      `bson:"rights_controller"`
-	CopyrightLine                Copyright             `bson:"copyright_line"`
-	ProducerCopyrightLine        Copyright             `bson:"producer_copyright_line"`
-	ParentalWarningType          string                `bson:"parental_warning_type"`
+	ResourceContributors         []ResourceContributor `bson:"resource_contributor,omitempty"`
+	IndirectResourceContributors []ResourceContributor `bson:"indirect_resource_contributor,omitempty"`
+	RightsController             RightsController      `bson:"rights_controller,omitempty"`
+	CopyrightLine                Copyright             `bson:"copyright_line,omitempty"`
+	ProducerCopyrightLine        Copyright             `bson:"producer_copyright_line,omitempty"`
+	ParentalWarningType          string                `bson:"parental_warning_type,omitempty"`
 	// michelle add to sdk ==
 
 	PreviewAudioFileURL         string `bson:"preview_audio_file_url"`
@@ -265,9 +265,9 @@ type CollectionMetadata struct {
 
 	// michelle add to sdk ==
 	Artists               []Artist  `bson:"artists"`
-	CopyrightLine         Copyright `bson:"copyright_line"`
-	ProducerCopyrightLine Copyright `bson:"producer_copyright_line"`
-	ParentalWarningType   string    `bson:"parental_warning_type"`
+	CopyrightLine         Copyright `bson:"copyright_line,omitempty"`
+	ProducerCopyrightLine Copyright `bson:"producer_copyright_line,omitempty"`
+	ParentalWarningType   string    `bson:"parental_warning_type,omitempty"`
 	// michelle add to sdk ==
 
 	CoverArtURL         string `bson:"cover_art_url"`

--- a/packages/ddex/ingester/common/sdk_types.go
+++ b/packages/ddex/ingester/common/sdk_types.go
@@ -191,25 +191,57 @@ type TrackMetadata struct {
 	Tags        NullableString `bson:"tags,omitempty"`
 
 	// Extra fields (not in SDK)
-	Artists                     []Artist `bson:"artists"`
-	ArtistID                    string   `bson:"artist_id"`
-	ArtistName                  string   `bson:"artist_name"`
-	Copyright                   string   `bson:"copyright"`
-	PreviewAudioFileURL         string   `bson:"preview_audio_file_url"`
-	PreviewAudioFileURLHash     string   `bson:"preview_audio_file_url_hash"`
-	PreviewAudioFileURLHashAlgo string   `bson:"preview_audio_file_url_hash_algo"`
-	AudioFileURL                string   `bson:"audio_file_url"`
-	AudioFileURLHash            string   `bson:"audio_file_url_hash"`
-	AudioFileURLHashAlgo        string   `bson:"audio_file_url_hash_algo"`
-	CoverArtURL                 string   `bson:"cover_art_url"`
-	CoverArtURLHash             string   `bson:"cover_art_url_hash"`
-	CoverArtURLHashAlgo         string   `bson:"cover_art_url_hash_algo"`
+
+	// michelle add to sdk ==
+	Artists []Artist `bson:"artists"`
+	// michelle add to sdk ==
+
+	ArtistID   string `bson:"artist_id"`
+	ArtistName string `bson:"artist_name"`
+
+	// michelle add to sdk ==
+	ResourceContributors         []ResourceContributor `bson:"resource_contributor"`
+	IndirectResourceContributors []ResourceContributor `bson:"indirect_resource_contributor"`
+	RightsController             RightsController      `bson:"rights_controller"`
+	CopyrightLine                Copyright             `bson:"copyright_line"`
+	ProducerCopyrightLine        Copyright             `bson:"producer_copyright_line"`
+	ParentalWarningType          string                `bson:"parental_warning_type"`
+	// michelle add to sdk ==
+
+	PreviewAudioFileURL         string `bson:"preview_audio_file_url"`
+	PreviewAudioFileURLHash     string `bson:"preview_audio_file_url_hash"`
+	PreviewAudioFileURLHashAlgo string `bson:"preview_audio_file_url_hash_algo"`
+	AudioFileURL                string `bson:"audio_file_url"`
+	AudioFileURLHash            string `bson:"audio_file_url_hash"`
+	AudioFileURLHashAlgo        string `bson:"audio_file_url_hash_algo"`
+	CoverArtURL                 string `bson:"cover_art_url"`
+	CoverArtURLHash             string `bson:"cover_art_url_hash"`
+	CoverArtURLHashAlgo         string `bson:"cover_art_url_hash_algo"`
 }
 
 // Not part of SDK
 type Artist struct {
-	Name  string   `bson:"name"`
-	Roles []string `bson:"roles"`
+	Name           string   `bson:"name"`
+	Roles          []string `bson:"roles"`
+	SequenceNumber int      `bson:"sequence_number"`
+}
+
+type Copyright struct {
+	Year string
+	Text string
+}
+
+// ResourceContributor represents a contributor to the sound recording
+type ResourceContributor struct {
+	Name           string
+	Roles          []string
+	SequenceNumber int `bson:"sequence_number"`
+}
+
+type RightsController struct {
+	Name               string
+	Roles              []string
+	RightsShareUnknown string
 }
 
 type CollectionMetadata struct {
@@ -230,6 +262,14 @@ type CollectionMetadata struct {
 	UPC     NullableString `bson:"upc,omitempty"`
 
 	// Extra fields (not in SDK)
+
+	// michelle add to sdk ==
+	Artists               []Artist  `bson:"artists"`
+	CopyrightLine         Copyright `bson:"copyright_line"`
+	ProducerCopyrightLine Copyright `bson:"producer_copyright_line"`
+	ParentalWarningType   string    `bson:"parental_warning_type"`
+	// michelle add to sdk ==
+
 	CoverArtURL         string `bson:"cover_art_url"`
 	CoverArtURLHash     string `bson:"cover_art_url_hash"`
 	CoverArtURLHashAlgo string `bson:"cover_art_url_hash_algo"`

--- a/packages/ddex/ingester/e2e_test/e2e_test.go
+++ b/packages/ddex/ingester/e2e_test/e2e_test.go
@@ -145,6 +145,20 @@ func (e *e2eTest) runERN382Batched(t *testing.T) {
 				ICPN: "721620118165",
 			},
 			CoverArtURL: "s3://audius-test-crawled/721620118165/resources/721620118165_T7_007.jpg",
+			Artists: []common.Artist{{
+				Name:           "Monkey Claw",
+				Roles:          []string{"MainArtist"},
+				SequenceNumber: 1,
+			}},
+			CopyrightLine: common.Copyright{
+				Year: "2010",
+				Text: "(C) 2010 Iron Crown Music",
+			},
+			ProducerCopyrightLine: common.Copyright{
+				Year: "2010",
+				Text: "(C) 2010 Iron Crown Music",
+			},
+			ParentalWarningType: "NotExplicit",
 		},
 		DDEXReleaseRef: "R0",
 		Tracks: []common.TrackMetadata{
@@ -164,7 +178,26 @@ func (e *e2eTest) runERN382Batched(t *testing.T) {
 						Roles: []string{"MainArtist"},
 					},
 				},
+				ResourceContributors: []common.ResourceContributor{{
+					Name:           "Steve Albino",
+					Roles:          []string{"Producer"},
+					SequenceNumber: 1,
+				}},
+				IndirectResourceContributors: []common.ResourceContributor{{
+					Name:           "Bob Black",
+					Roles:          []string{"Composer"},
+					SequenceNumber: 1,
+				}},
 				AudioFileURL: "s3://audius-test-crawled/721620118165/resources/721620118165_T1_001.wav",
+				CopyrightLine: common.Copyright{
+					Year: "2010",
+					Text: "(C) 2010 Iron Crown Music",
+				},
+				ProducerCopyrightLine: common.Copyright{
+					Year: "2010",
+					Text: "(C) 2010 Iron Crown Music",
+				},
+				ParentalWarningType: "NotExplicit",
 			},
 			{
 				Title:       "Red top mountain, blown sky high",
@@ -182,7 +215,26 @@ func (e *e2eTest) runERN382Batched(t *testing.T) {
 						Roles: []string{"MainArtist"},
 					},
 				},
+				ResourceContributors: []common.ResourceContributor{{
+					Name:           "Steve Albino",
+					Roles:          []string{"Producer"},
+					SequenceNumber: 1,
+				}},
+				IndirectResourceContributors: []common.ResourceContributor{{
+					Name:           "Bob Black",
+					Roles:          []string{"Composer"},
+					SequenceNumber: 1,
+				}},
 				AudioFileURL: "s3://audius-test-crawled/721620118165/resources/721620118165_T2_002.wav",
+				CopyrightLine: common.Copyright{
+					Year: "2010",
+					Text: "(C) 2010 Iron Crown Music",
+				},
+				ProducerCopyrightLine: common.Copyright{
+					Year: "2010",
+					Text: "(C) 2010 Iron Crown Music",
+				},
+				ParentalWarningType: "NotExplicit",
 			},
 			{
 				Title:       "Seige of Antioch",
@@ -200,7 +252,26 @@ func (e *e2eTest) runERN382Batched(t *testing.T) {
 						Roles: []string{"MainArtist"},
 					},
 				},
+				ResourceContributors: []common.ResourceContributor{{
+					Name:           "Steve Albino",
+					Roles:          []string{"Producer"},
+					SequenceNumber: 1,
+				}},
+				IndirectResourceContributors: []common.ResourceContributor{{
+					Name:           "Bob Black",
+					Roles:          []string{"Composer"},
+					SequenceNumber: 1,
+				}},
 				AudioFileURL: "s3://audius-test-crawled/721620118165/resources/721620118165_T3_003.wav",
+				CopyrightLine: common.Copyright{
+					Year: "2010",
+					Text: "(C) 2010 Iron Crown Music",
+				},
+				ProducerCopyrightLine: common.Copyright{
+					Year: "2010",
+					Text: "(C) 2010 Iron Crown Music",
+				},
+				ParentalWarningType: "NotExplicit",
 			},
 			{
 				Title:       "Warhammer",
@@ -218,7 +289,26 @@ func (e *e2eTest) runERN382Batched(t *testing.T) {
 						Roles: []string{"MainArtist"},
 					},
 				},
+				ResourceContributors: []common.ResourceContributor{{
+					Name:           "Steve Albino",
+					Roles:          []string{"Producer"},
+					SequenceNumber: 1,
+				}},
+				IndirectResourceContributors: []common.ResourceContributor{{
+					Name:           "Bob Black",
+					Roles:          []string{"Composer"},
+					SequenceNumber: 1,
+				}},
 				AudioFileURL: "s3://audius-test-crawled/721620118165/resources/721620118165_T4_004.wav",
+				CopyrightLine: common.Copyright{
+					Year: "2010",
+					Text: "(C) 2010 Iron Crown Music",
+				},
+				ProducerCopyrightLine: common.Copyright{
+					Year: "2010",
+					Text: "(C) 2010 Iron Crown Music",
+				},
+				ParentalWarningType: "NotExplicit",
 			},
 			{
 				Title:       "Iron Horse",
@@ -236,7 +326,26 @@ func (e *e2eTest) runERN382Batched(t *testing.T) {
 						Roles: []string{"MainArtist"},
 					},
 				},
+				ResourceContributors: []common.ResourceContributor{{
+					Name:           "Steve Albino",
+					Roles:          []string{"Producer"},
+					SequenceNumber: 1,
+				}},
+				IndirectResourceContributors: []common.ResourceContributor{{
+					Name:           "Bob Black",
+					Roles:          []string{"Composer"},
+					SequenceNumber: 1,
+				}},
 				AudioFileURL: "s3://audius-test-crawled/721620118165/resources/721620118165_T5_005.wav",
+				CopyrightLine: common.Copyright{
+					Year: "2010",
+					Text: "(C) 2010 Iron Crown Music",
+				},
+				ProducerCopyrightLine: common.Copyright{
+					Year: "2010",
+					Text: "(C) 2010 Iron Crown Music",
+				},
+				ParentalWarningType: "NotExplicit",
 			},
 			{
 				Title:       "Yes... I can feel the Monkey Claw!",
@@ -254,7 +363,26 @@ func (e *e2eTest) runERN382Batched(t *testing.T) {
 						Roles: []string{"MainArtist"},
 					},
 				},
+				ResourceContributors: []common.ResourceContributor{{
+					Name:           "Steve Albino",
+					Roles:          []string{"Producer"},
+					SequenceNumber: 1,
+				}},
+				IndirectResourceContributors: []common.ResourceContributor{{
+					Name:           "Bob Black",
+					Roles:          []string{"Composer"},
+					SequenceNumber: 1,
+				}},
 				AudioFileURL: "s3://audius-test-crawled/721620118165/resources/721620118165_T6_006.wav",
+				CopyrightLine: common.Copyright{
+					Year: "2010",
+					Text: "(C) 2010 Iron Crown Music",
+				},
+				ProducerCopyrightLine: common.Copyright{
+					Year: "2010",
+					Text: "(C) 2010 Iron Crown Music",
+				},
+				ParentalWarningType: "NotExplicit",
 			},
 		},
 	}, pendingRelease.CreateAlbumRelease, "Album release doesn't match expected")
@@ -322,6 +450,16 @@ func (e *e2eTest) runERN381ReleaseByRelease(t *testing.T) {
 			CoverArtURL:         fmt.Sprintf("s3://audius-test-crawled/%s/resources/A10301A0005108088N_T-1027024165547_Image.jpg", pendingRelease.ReleaseID),
 			CoverArtURLHash:     "582fb410615167205e8741580cf77e71",
 			CoverArtURLHashAlgo: "MD5",
+			Artists: []common.Artist{{
+				Name:           "Theo Random",
+				Roles:          []string{"MainArtist"},
+				SequenceNumber: 1,
+			}},
+			ProducerCopyrightLine: common.Copyright{
+				Year: "2023",
+				Text: "(P) 2023 South Africa - Sony Music Entertainment Africa (Pty) Ltd, under Sound African Recordings a division of Sony Music Entertainment Africa (Pty) Ltd",
+			},
+			ParentalWarningType: "Explicit",
 		},
 		Tracks: []common.TrackMetadata{
 			{
@@ -329,10 +467,46 @@ func (e *e2eTest) runERN381ReleaseByRelease(t *testing.T) {
 				ReleaseDate: time.Time{},
 				Genre:       common.HipHopRap,
 				Duration:    279,
-				Artists:     []common.Artist{{Name: "Theo Random", Roles: []string{"AssociatedPerformer", "MainArtist"}}},
-				ArtistID:    "",
-				ArtistName:  "",
-				ISRC:        stringPtr("ZAA012300131"),
+				Artists: []common.Artist{{
+					Name:           "Theo Random",
+					Roles:          []string{"AssociatedPerformer", "MainArtist"},
+					SequenceNumber: 1,
+				}},
+				ResourceContributors: []common.ResourceContributor{
+					{
+						Name:           "Thabiso Moya",
+						Roles:          []string{"Composer", "Lyricist"},
+						SequenceNumber: 1,
+					},
+					{
+						Name:           "Melange",
+						Roles:          []string{"Producer"},
+						SequenceNumber: 2,
+					},
+					{
+						Name:           "Neo Ndungane",
+						Roles:          []string{"Composer", "Lyricist"},
+						SequenceNumber: 3,
+					},
+					{
+						Name:           "Feziekk",
+						Roles:          []string{"Producer"},
+						SequenceNumber: 4,
+					},
+					{
+						Name:           "Regaugetsue Refenyeditswe Leshabane",
+						Roles:          []string{"Composer", "Lyricist"},
+						SequenceNumber: 5,
+					},
+					{
+						Name:           "Gabe Archibald Horowitz",
+						Roles:          []string{"Composer", "Lyricist"},
+						SequenceNumber: 6,
+					},
+				},
+				ArtistID:   "",
+				ArtistName: "",
+				ISRC:       stringPtr("ZAA012300131"),
 				DDEXReleaseIDs: common.ReleaseIDs{
 					GRid: "A10328E0010879163O",
 					ISRC: "ZAA012300131",
@@ -342,6 +516,11 @@ func (e *e2eTest) runERN381ReleaseByRelease(t *testing.T) {
 				AudioFileURL:         fmt.Sprintf("s3://audius-test-crawled/%s/resources/A10301A0005108088N_T-1096524256352_SoundRecording_001-001.m4a", pendingRelease.ReleaseID),
 				AudioFileURLHash:     "8bb2ce119257314a8fcb215a49f14b33",
 				AudioFileURLHashAlgo: "MD5",
+				ProducerCopyrightLine: common.Copyright{
+					Year: "2023",
+					Text: "(P) 2023 South Africa - Sony Music Entertainment Africa (Pty) Ltd, under Sound African Recordings a division of Sony Music Entertainment Africa (Pty) Ltd",
+				},
+				ParentalWarningType: "Explicit",
 			},
 			{
 				Title:       "No Comment.",
@@ -350,8 +529,46 @@ func (e *e2eTest) runERN381ReleaseByRelease(t *testing.T) {
 				Duration:    142,
 				ArtistID:    "",
 				ArtistName:  "",
-				Artists:     []common.Artist{{Name: "Theo Random", Roles: []string{"AssociatedPerformer", "MainArtist"}}, {Name: "Thato Saul", Roles: []string{"AssociatedPerformer", "MainArtist"}}},
-				ISRC:        stringPtr("ZAA012300128"),
+				Artists: []common.Artist{
+					{
+						Name:           "Theo Random",
+						Roles:          []string{"AssociatedPerformer", "MainArtist"},
+						SequenceNumber: 1,
+					},
+					{
+						Name:           "Thato Saul",
+						Roles:          []string{"AssociatedPerformer", "MainArtist"},
+						SequenceNumber: 2,
+					},
+				},
+				ResourceContributors: []common.ResourceContributor{
+					{
+						Name:           "Theo Random &amp; Thato Saul",
+						Roles:          []string{"AssociatedPerformer"},
+						SequenceNumber: 1,
+					},
+					{
+						Name:           "Thabiso Moya",
+						Roles:          []string{"Composer", "Lyricist"},
+						SequenceNumber: 2,
+					},
+					{
+						Name:           "Melange",
+						Roles:          []string{"Producer"},
+						SequenceNumber: 3,
+					},
+					{
+						Name:           "Thato Matlebyane",
+						Roles:          []string{"Composer", "Lyricist"},
+						SequenceNumber: 4,
+					},
+					{
+						Name:           "Neo Ndungane",
+						Roles:          []string{"Composer", "Lyricist"},
+						SequenceNumber: 5,
+					},
+				},
+				ISRC: stringPtr("ZAA012300128"),
 				DDEXReleaseIDs: common.ReleaseIDs{
 					GRid: "A10328E0010879164M",
 					ISRC: "ZAA012300128",
@@ -361,6 +578,11 @@ func (e *e2eTest) runERN381ReleaseByRelease(t *testing.T) {
 				AudioFileURL:         fmt.Sprintf("s3://audius-test-crawled/%s/resources/A10301A0005108088N_T-1096524142976_SoundRecording_001-002.m4a", pendingRelease.ReleaseID),
 				AudioFileURLHash:     "1e9183898a4f6b45f895e45cd18ba162",
 				AudioFileURLHashAlgo: "MD5",
+				ProducerCopyrightLine: common.Copyright{
+					Year: "2023",
+					Text: "(P) 2023 South Africa - Sony Music Entertainment Africa (Pty) Ltd, under Sound African Recordings a division of Sony Music Entertainment Africa (Pty) Ltd",
+				},
+				ParentalWarningType: "Explicit",
 			},
 		},
 	}, pendingRelease.CreateAlbumRelease, "Album release doesn't match expected")

--- a/packages/ddex/ingester/parser/ern38x.go
+++ b/packages/ddex/ingester/parser/ern38x.go
@@ -171,6 +171,14 @@ func processReleaseNode(rNode *xmlquery.Node, soundRecordings *[]SoundRecording,
 	durationISOStr := safeInnerText(rNode.SelectElement("Duration"))
 	isrc := safeInnerText(rNode.SelectElement("ReleaseId/ISRC"))
 	releaseType := safeInnerText(rNode.SelectElement("ReleaseType"))
+	copyright := common.Copyright{
+		Year: safeInnerText(rNode.SelectElement("CLine/Year")),
+		Text: safeInnerText(rNode.SelectElement("CLine/CLineText")),
+	}
+	producerCopyright := common.Copyright{
+		Year: safeInnerText(rNode.SelectElement("PLine/Year")),
+		Text: safeInnerText(rNode.SelectElement("PLine/PLineText")),
+	}
 
 	// Release IDs
 	ddexReleaseIDs := &common.ReleaseIDs{
@@ -220,14 +228,6 @@ func processReleaseNode(rNode *xmlquery.Node, soundRecordings *[]SoundRecording,
 	artistName := safeInnerText(releaseDetails.SelectElement("DisplayArtistName"))
 	genreStr := safeInnerText(releaseDetails.SelectElement("Genre/GenreText"))
 	parentalWarning := safeInnerText(releaseDetails.SelectElement("ParentalWarningType"))
-	copyright := common.Copyright{
-		Year: safeInnerText(releaseDetails.SelectElement("CLine/Year")),
-		Text: safeInnerText(releaseDetails.SelectElement("CLine/PLineText")),
-	}
-	producerCopyright := common.Copyright{
-		Year: safeInnerText(releaseDetails.SelectElement("PLine/Year")),
-		Text: safeInnerText(releaseDetails.SelectElement("PLine/PLineText")),
-	}
 
 	// Parse DisplayArtist nodes
 	var displayArtists []common.Artist

--- a/packages/ddex/ingester/parser/ern38x.go
+++ b/packages/ddex/ingester/parser/ern38x.go
@@ -14,25 +14,21 @@ import (
 
 // SoundRecording represents the parsed details of a sound recording.
 type SoundRecording struct {
-	Type                  string
-	ISRC                  string
-	ResourceReference     string
-	TerritoryCode         string
-	Title                 string
-	LanguageOfPerformance string
-	Duration              string
-	Artists               []common.Artist
-	ResourceContributors  []ResourceContributor
-	LabelName             string
-	Genre                 string
-	ParentalWarningType   string
-	TechnicalDetails      []TechnicalSoundRecordingDetails
-}
-
-// ResourceContributor represents a contributor to the sound recording.
-type ResourceContributor struct {
-	Name  string
-	Roles []string
+	Type                         string
+	ISRC                         string
+	ResourceReference            string
+	TerritoryCode                string
+	Title                        string
+	LanguageOfPerformance        string
+	Duration                     string
+	Artists                      []common.Artist
+	ResourceContributors         []common.ResourceContributor
+	IndirectResourceContributors []common.ResourceContributor
+	LabelName                    string
+	Genre                        string
+	ParentalWarningType          string
+	TechnicalDetails             []TechnicalSoundRecordingDetails
+	RightsController             common.RightsController
 }
 
 // TechnicalSoundRecordingDetails represents technical details about the sound recording.
@@ -223,7 +219,34 @@ func processReleaseNode(rNode *xmlquery.Node, soundRecordings *[]SoundRecording,
 	title := safeInnerText(releaseDetails.SelectElement("Title[@TitleType='DisplayTitle']/TitleText")) // TODO: This assumes there aren't multiple titles in different languages (ie, different `LanguageAndScriptCode` attributes)
 	artistName := safeInnerText(releaseDetails.SelectElement("DisplayArtistName"))
 	genreStr := safeInnerText(releaseDetails.SelectElement("Genre/GenreText"))
-	copyright := safeInnerText(releaseDetails.SelectElement("PLine/PLineText"))
+	parentalWarning := safeInnerText(releaseDetails.SelectElement("ParentalWarningType"))
+	copyright := common.Copyright{
+		Year: safeInnerText(releaseDetails.SelectElement("CLine/Year")),
+		Text: safeInnerText(releaseDetails.SelectElement("CLine/PLineText")),
+	}
+	producerCopyright := common.Copyright{
+		Year: safeInnerText(releaseDetails.SelectElement("PLine/Year")),
+		Text: safeInnerText(releaseDetails.SelectElement("PLine/PLineText")),
+	}
+
+	// Parse DisplayArtist nodes
+	var displayArtists []common.Artist
+	for _, artistNode := range xmlquery.Find(releaseDetails, "DisplayArtist") {
+		name := safeInnerText(artistNode.SelectElement("PartyName/FullName"))
+		seqNo, seqNoErr := strconv.Atoi(artistNode.SelectAttr("SequenceNumber"))
+		if seqNoErr != nil {
+			err = fmt.Errorf("Error parsing DisplayArtist %s's SequenceNumber", name)
+			return
+		}
+		artist := common.Artist{
+			Name:           name,
+			SequenceNumber: seqNo,
+		}
+		for _, roleNode := range xmlquery.Find(artistNode, "ArtistRole") {
+			artist.Roles = append(artist.Roles, safeInnerText(roleNode))
+		}
+		displayArtists = append(displayArtists, artist)
+	}
 
 	// Use <ResourceGroup> to determine the order of tracks, as per the XML schema.
 	// There can be multiple <ResourceGroup>s for each "disk" in the album, but we count them all as one album with no "disk" concept.
@@ -301,16 +324,20 @@ func processReleaseNode(rNode *xmlquery.Node, soundRecordings *[]SoundRecording,
 			DDEXReleaseRef: releaseRef,
 			Tracks:         tracks,
 			Metadata: common.CollectionMetadata{
-				PlaylistName:        title,
-				PlaylistOwnerName:   artistName,
-				ReleaseDate:         releaseDate,
-				DDEXReleaseIDs:      *ddexReleaseIDs,
-				Genre:               genre,
-				IsAlbum:             true,
-				IsPrivate:           false, // TODO: Use DealList to determine this. Same with releaseDate because I think the XML element it's reading is deprecated
-				CoverArtURL:         coverArtURL,
-				CoverArtURLHash:     coverArtURLHash,
-				CoverArtURLHashAlgo: coverArtURLHashAlgo,
+				PlaylistName:          title,
+				PlaylistOwnerName:     artistName,
+				ReleaseDate:           releaseDate,
+				DDEXReleaseIDs:        *ddexReleaseIDs,
+				Genre:                 genre,
+				IsAlbum:               true,
+				IsPrivate:             false, // TODO: Use DealList to determine this. Same with releaseDate because I think the XML element it's reading is deprecated
+				CoverArtURL:           coverArtURL,
+				CoverArtURLHash:       coverArtURLHash,
+				CoverArtURLHashAlgo:   coverArtURLHashAlgo,
+				CopyrightLine:         copyright,
+				ProducerCopyrightLine: producerCopyright,
+				Artists:               displayArtists,
+				ParentalWarningType:   parentalWarning,
 			},
 		}
 		return
@@ -393,7 +420,9 @@ func processReleaseNode(rNode *xmlquery.Node, soundRecordings *[]SoundRecording,
 		trackMetadata.ArtistName = artistName
 		trackMetadata.ReleaseDate = releaseDate
 		trackMetadata.DDEXReleaseIDs = *ddexReleaseIDs
-		trackMetadata.Copyright = copyright
+		trackMetadata.CopyrightLine = copyright
+		trackMetadata.ProducerCopyrightLine = producerCopyright
+		trackMetadata.ParentalWarningType = parentalWarning
 		trackMetadata.CoverArtURL = coverArtURL
 		trackMetadata.CoverArtURLHash = coverArtURLHash
 		trackMetadata.CoverArtURLHashAlgo = coverArtURLHashAlgo
@@ -445,17 +474,20 @@ func parseTrackMetadata(ci ResourceGroupContentItem, crawledBucket, releaseID st
 
 	duration, _ := parseISODuration(ci.SoundRecording.Duration)
 	metadata = &common.TrackMetadata{
-		Title:                       ci.SoundRecording.Title,
-		Duration:                    int(duration.Seconds()),
-		PreviewStartSeconds:         &previewStartSec,
-		ISRC:                        &ci.SoundRecording.ISRC,
-		Artists:                     ci.SoundRecording.Artists,
-		PreviewAudioFileURL:         previewAudioFileURL,
-		PreviewAudioFileURLHash:     previewAudioFileURLHash,
-		PreviewAudioFileURLHashAlgo: previewAudioFileURLHashAlgo,
-		AudioFileURL:                audioFileURL,
-		AudioFileURLHash:            audioFileURLHash,
-		AudioFileURLHashAlgo:        audioFileURLHashAlgo,
+		Title:                        ci.SoundRecording.Title,
+		Duration:                     int(duration.Seconds()),
+		PreviewStartSeconds:          &previewStartSec,
+		ISRC:                         &ci.SoundRecording.ISRC,
+		Artists:                      ci.SoundRecording.Artists,
+		ResourceContributors:         ci.SoundRecording.ResourceContributors,
+		IndirectResourceContributors: ci.SoundRecording.IndirectResourceContributors,
+		RightsController:             ci.SoundRecording.RightsController,
+		PreviewAudioFileURL:          previewAudioFileURL,
+		PreviewAudioFileURLHash:      previewAudioFileURLHash,
+		PreviewAudioFileURLHashAlgo:  previewAudioFileURLHashAlgo,
+		AudioFileURL:                 audioFileURL,
+		AudioFileURLHash:             audioFileURLHash,
+		AudioFileURLHashAlgo:         audioFileURLHashAlgo,
 	}
 	if genre, ok := common.ToGenre(ci.SoundRecording.Genre); ok {
 		metadata.Genre = genre
@@ -535,8 +567,15 @@ func processSoundRecordingNode(sNode *xmlquery.Node) (recording *SoundRecording,
 
 	// Parse DisplayArtist nodes
 	for _, artistNode := range xmlquery.Find(details, "DisplayArtist") {
+		name := safeInnerText(artistNode.SelectElement("PartyName/FullName"))
+		seqNo, seqNoErr := strconv.Atoi(artistNode.SelectAttr("SequenceNumber"))
+		if seqNoErr != nil {
+			err = fmt.Errorf("Error parsing DisplayArtist %s's SequenceNumber", name)
+			return
+		}
 		artist := common.Artist{
-			Name: safeInnerText(artistNode.SelectElement("PartyName/FullName")),
+			Name:           name,
+			SequenceNumber: seqNo,
 		}
 		for _, roleNode := range xmlquery.Find(artistNode, "ArtistRole") {
 			artist.Roles = append(artist.Roles, safeInnerText(roleNode))
@@ -545,14 +584,64 @@ func processSoundRecordingNode(sNode *xmlquery.Node) (recording *SoundRecording,
 	}
 
 	// Parse ResourceContributor nodes
+	err = nil
 	for _, contributorNode := range xmlquery.Find(details, "ResourceContributor") {
-		contributor := ResourceContributor{
-			Name: safeInnerText(contributorNode.SelectElement("PartyName/FullName")),
+		name := safeInnerText(contributorNode.SelectElement("PartyName/FullName"))
+		seqNo, seqNoErr := strconv.Atoi(contributorNode.SelectAttr("SequenceNumber"))
+		if seqNoErr != nil {
+			err = fmt.Errorf("Error parsing ResourceContributor %s's SequenceNumber", name)
+			return
+		}
+		contributor := common.ResourceContributor{
+			Name:           name,
+			SequenceNumber: seqNo,
 		}
 		for _, roleNode := range xmlquery.Find(contributorNode, "ResourceContributorRole") {
-			contributor.Roles = append(contributor.Roles, safeInnerText(roleNode))
+			role := safeInnerText(roleNode)
+			if role == "UserDefined" {
+				role = roleNode.SelectAttr("UserDefinedValue")
+			}
+			if role != "" {
+				contributor.Roles = append(contributor.Roles, role)
+			}
 		}
 		recording.ResourceContributors = append(recording.ResourceContributors, contributor)
+	}
+
+	// Parse IndirectResourceContributor nodes
+	for _, indirectContributorNode := range xmlquery.Find(details, "IndirectResourceContributor") {
+		name := safeInnerText(indirectContributorNode.SelectElement("PartyName/FullName"))
+		seqNo, seqNoErr := strconv.Atoi(indirectContributorNode.SelectAttr("SequenceNumber"))
+		if seqNoErr != nil {
+			err = fmt.Errorf("Error parsing IndirectResourceContributor %s's SequenceNumber", name)
+			return
+		}
+		contributor := common.ResourceContributor{
+			Name:           name,
+			SequenceNumber: seqNo,
+		}
+		for _, roleNode := range xmlquery.Find(indirectContributorNode, "IndirectResourceContributorRole") {
+			role := safeInnerText(roleNode)
+			if role == "UserDefined" {
+				role = roleNode.SelectAttr("UserDefinedValue")
+			}
+			if role != "" {
+				contributor.Roles = append(contributor.Roles, role)
+			}
+		}
+		recording.IndirectResourceContributors = append(recording.IndirectResourceContributors, contributor)
+	}
+
+	// Parse RightsController
+	if rightsControllerNode := xmlquery.FindOne(details, "RightsController"); rightsControllerNode != nil {
+		controller := common.RightsController{
+			Name:               safeInnerText(rightsControllerNode.SelectElement("PartyName/FullName")),
+			RightsShareUnknown: safeInnerText(rightsControllerNode.SelectElement("RightsShareUnknown")),
+		}
+		for _, roleNode := range xmlquery.Find(rightsControllerNode, "RightsControllerRole") {
+			controller.Roles = append(controller.Roles, safeInnerText(roleNode))
+		}
+		recording.RightsController = controller
 	}
 
 	// Parse TechnicalSoundRecordingDetails nodes


### PR DESCRIPTION
### Description
- `ResourceContributor` + SeqNos
- `IndirectResourceContributor` + SeqNos
- All `DisplayArtist`s + SeqNos
- Find and use 1st `DisplayArtist` that is oauthed for sdk upload
- `RightsController`
- CLine/Year, CLine/CLineText
- CLine/Year, CLine/CLineText
- `ParentalWarningType`

Left out  `IsInstrumental` for now. Doesn't seem very important.

Will follow up with the sdk / discovery changes to persist these new fields.

### How Has This Been Tested?
e2e test