### PR TITLE
Fix collection search ranking in common

### DIFF
--- a/packages/common/src/store/pages/search-results/selectors.ts
+++ b/packages/common/src/store/pages/search-results/selectors.ts
@@ -36,8 +36,9 @@ export const makeGetSearchArtists = () => {
 const getSearchAlbums = (state: CommonState) =>{
   const albumIds = getBaseState(state).albumIds
   const collections = getCollections(state, { ids: albumIds || [] })
-  return albumIds?.map(id => collections[id])
+  return albumIds?.map(id => collections[id]) ?? []
 }
+
 export const makeGetSearchAlbums = () => {
   return createShallowSelector([getSearchAlbums, getUsers], (albums, users) =>
     Object.values(albums)
@@ -51,8 +52,12 @@ export const makeGetSearchAlbums = () => {
   )
 }
 
-const getSearchPlaylists = (state: CommonState) =>
-  getCollections(state, { ids: getBaseState(state).playlistIds || [] })
+const getSearchPlaylists = (state: CommonState) => {
+  const playlistIds = getBaseState(state).playlistIds
+  const collections = getCollections(state, { ids: playlistIds || [] })
+  return playlistIds?.map(id => collections[id]) ?? []
+}
+
 export const makeGetSearchPlaylists = () => {
   return createShallowSelector(
     [getSearchPlaylists, getUsers],

--- a/packages/common/src/store/pages/search-results/selectors.ts
+++ b/packages/common/src/store/pages/search-results/selectors.ts
@@ -33,8 +33,11 @@ export const makeGetSearchArtists = () => {
   )
 }
 
-const getSearchAlbums = (state: CommonState) =>
-  getCollections(state, { ids: getBaseState(state).albumIds || [] })
+const getSearchAlbums = (state: CommonState) =>{
+  const albumIds = getBaseState(state).albumIds
+  const collections = getCollections(state, { ids: albumIds || [] })
+  return albumIds?.map(id => collections[id])
+}
 export const makeGetSearchAlbums = () => {
   return createShallowSelector([getSearchAlbums, getUsers], (albums, users) =>
     Object.values(albums)


### PR DESCRIPTION
### Description

Collection search results are ranked by playlist ID instead of maintaining the relevancy order. 

Autocomplete results differ from search results page because of this.
<img width="865" alt="Screenshot 2024-03-15 at 3 44 23 PM" src="https://github.com/AudiusProject/audius-protocol/assets/6413636/62ffa45d-4177-4257-a741-b26a82d27907">

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._

Tested locally against prod
<img width="866" alt="Screenshot 2024-03-15 at 3 45 09 PM" src="https://github.com/AudiusProject/audius-protocol/assets/6413636/0d4fef5a-1832-4f5f-a00f-2ae8557385b7">
