### PR TITLE
Move some tasks to new standalone index_sol worker

### DIFF
--- a/packages/discovery-provider/scripts/start.sh
+++ b/packages/discovery-provider/scripts/start.sh
@@ -61,7 +61,7 @@ else
         audius_service=worker celery -A src.worker.celery worker -Q index_nethermind --loglevel "$audius_discprov_loglevel" --hostname=index_nethermind --concurrency 1 2>&1 | tee >(logger -t index_nethermind_worker) &
 
         # start worker dedicated to indexing user bank and payment router
-        audius_service=worker celery -A src.worker.celery worker -Q index_sol --loglevel "$audius_discprov_loglevel" --hostname=index_sol --concurrency 1 2>&1 | tee >(logger -t index_nethermind_worker) &
+        audius_service=worker celery -A src.worker.celery worker -Q index_sol --loglevel "$audius_discprov_loglevel" --hostname=index_sol --concurrency 1 2>&1 | tee >(logger -t index_sol_worker) &
 
         # start other workers with remaining CPUs
         audius_service=worker celery -A src.worker.celery worker --max-memory-per-child 300000 --loglevel "$audius_discprov_loglevel" --concurrency=$(($(nproc) - 5)) 2>&1 | tee >(logger -t worker) &

--- a/packages/discovery-provider/scripts/start.sh
+++ b/packages/discovery-provider/scripts/start.sh
@@ -60,6 +60,9 @@ else
         # start worker dedicated to indexing ACDC
         audius_service=worker celery -A src.worker.celery worker -Q index_nethermind --loglevel "$audius_discprov_loglevel" --hostname=index_nethermind --concurrency 1 2>&1 | tee >(logger -t index_nethermind_worker) &
 
+        # start worker dedicated to indexing user bank and payment router
+        audius_service=worker celery -A src.worker.celery worker -Q index_sol --loglevel "$audius_discprov_loglevel" --hostname=index_sol --concurrency 1 2>&1 | tee >(logger -t index_nethermind_worker) &
+
         # start other workers with remaining CPUs
         audius_service=worker celery -A src.worker.celery worker --max-memory-per-child 300000 --loglevel "$audius_discprov_loglevel" --concurrency=$(($(nproc) - 5)) 2>&1 | tee >(logger -t worker) &
 

--- a/packages/discovery-provider/src/app.py
+++ b/packages/discovery-provider/src/app.py
@@ -535,5 +535,5 @@ def configure_celery(celery, test_config=None):
     # Start tasks that should fire upon startup
     celery.send_task("cache_entity_counts")
     celery.send_task("index_nethermind", queue="index_nethermind")
-    celery.send_task("index_user_bank", queue="index_nethermind")
-    celery.send_task("index_payment_router", queue="index_nethermind")
+    celery.send_task("index_user_bank", queue="index_sol")
+    celery.send_task("index_payment_router", queue="index_sol")

--- a/packages/discovery-provider/src/tasks/index_payment_router.py
+++ b/packages/discovery-provider/src/tasks/index_payment_router.py
@@ -989,5 +989,5 @@ def index_payment_router(self):
         if have_lock:
             update_lock.release()
         celery.send_task(
-                "index_payment_router", countdown=0.5, queue="index_nethermind"
+                "index_payment_router", countdown=0.5, queue="index_sol"
             )

--- a/packages/discovery-provider/src/tasks/index_user_bank.py
+++ b/packages/discovery-provider/src/tasks/index_user_bank.py
@@ -1120,5 +1120,5 @@ def index_user_bank(self):
         if have_lock:
             update_lock.release()
         celery.send_task(
-                "index_user_bank", countdown=0.5, queue="index_nethermind"
+                "index_user_bank", countdown=0.5, queue="index_sol"
             )


### PR DESCRIPTION
### Description
Moves user bank and payment router indexing off of the acdc worker and into their own (new) worker. Let me know if this seems like too many workers, but having them share with the acdc worker is causing staging to fall behind.

### Testing
This is running on stage DN2 and able to index ACDC quickly enough now.