### PR TITLE
Allow querying for unlisted tracks by ID

### DIFF
--- a/packages/discovery-provider/src/api/v1/tracks.py
+++ b/packages/discovery-provider/src/api/v1/tracks.py
@@ -67,7 +67,7 @@ from src.queries.get_track_signature import (
     get_track_download_signature,
     get_track_stream_signature,
 )
-from src.queries.get_tracks import GetTrackArgs, RouteArgs, get_tracks
+from src.queries.get_tracks import RouteArgs, get_tracks
 from src.queries.get_trending import get_trending
 from src.queries.get_trending_ids import get_trending_ids
 from src.queries.get_unclaimed_id import get_unclaimed_id
@@ -113,9 +113,8 @@ full_tracks_response = make_full_response(
 
 
 def get_single_track(track_id, current_user_id, endpoint_ns, exclude_gated=True):
-    args: GetTrackArgs = {
+    args = {
         "id": [track_id],
-        "with_users": True,
         "filter_deleted": False,
         "exclude_gated": exclude_gated,
         "current_user_id": current_user_id,

--- a/packages/discovery-provider/src/api/v1/tracks.py
+++ b/packages/discovery-provider/src/api/v1/tracks.py
@@ -67,8 +67,7 @@ from src.queries.get_track_signature import (
     get_track_download_signature,
     get_track_stream_signature,
 )
-from src.queries.get_tracks import RouteArgs, get_tracks
-from src.queries.get_tracks_including_unlisted import get_tracks_including_unlisted
+from src.queries.get_tracks import GetTrackArgs, RouteArgs, get_tracks
 from src.queries.get_trending import get_trending
 from src.queries.get_trending_ids import get_trending_ids
 from src.queries.get_unclaimed_id import get_unclaimed_id
@@ -114,28 +113,15 @@ full_tracks_response = make_full_response(
 
 
 def get_single_track(track_id, current_user_id, endpoint_ns, exclude_gated=True):
-    args = {
+    args: GetTrackArgs = {
         "id": [track_id],
         "with_users": True,
         "filter_deleted": False,
         "exclude_gated": exclude_gated,
         "current_user_id": current_user_id,
+        "skip_unlisted_filter": True,
     }
     tracks = get_tracks(args)
-    if not tracks:
-        abort_not_found(track_id, endpoint_ns)
-    single_track = extend_track(tracks[0])
-    return success_response(single_track)
-
-
-def get_unlisted_track(track_id, url_title, handle, current_user_id, endpoint_ns):
-    args = {
-        "identifiers": [{"handle": handle, "url_title": url_title, "id": track_id}],
-        "filter_deleted": False,
-        "with_users": True,
-        "current_user_id": current_user_id,
-    }
-    tracks = get_tracks_including_unlisted(args)
     if not tracks:
         abort_not_found(track_id, endpoint_ns)
     single_track = extend_track(tracks[0])
@@ -168,20 +154,6 @@ class Track(Resource):
         return get_single_track(decoded_id, None, ns)
 
 
-full_track_parser = current_user_parser.copy()
-full_track_parser.add_argument(
-    "handle", description="The User handle of the track owner"
-)
-full_track_parser.add_argument(
-    "url_title", description="The URLized title of the track"
-)
-full_track_parser.add_argument(
-    "show_unlisted",
-    description="Whether or not to show unlisted tracks",
-    type=inputs.boolean,
-)
-
-
 @full_ns.route(TRACK_ROUTE)
 class FullTrack(Resource):
     @record_metrics
@@ -192,20 +164,13 @@ class FullTrack(Resource):
             "track_id": "A Track ID",
         },
     )
-    @full_ns.expect(full_track_parser)
+    @full_ns.expect(current_user_parser)
     @full_ns.marshal_with(full_track_response)
     @cache(ttl_sec=5)
     def get(self, track_id: str):
-        args = full_track_parser.parse_args()
+        args = current_user_parser.parse_args()
         decoded_id = decode_with_abort(track_id, full_ns)
         current_user_id = get_current_user_id(args)
-        if args.get("show_unlisted"):
-            url_title, handle = args.get("url_title"), args.get("handle")
-            if not (url_title and handle):
-                full_ns.abort(400, "Unlisted tracks require url_title and handle")
-            return get_unlisted_track(
-                decoded_id, url_title, handle, current_user_id, full_ns
-            )
 
         return get_single_track(
             track_id=decoded_id,
@@ -285,6 +250,7 @@ class BulkTracks(Resource):
                     "with_users": True,
                     "id": decode_ids_array(ids),
                     "exclude_gated": True,
+                    "skip_unlisted_filter": True,
                 }
             )
         else:
@@ -293,6 +259,7 @@ class BulkTracks(Resource):
                     "with_users": True,
                     "routes": routes_parsed,
                     "exclude_gated": True,
+                    "skip_unlisted_filter": True,
                 }
             )
         if not tracks:
@@ -354,6 +321,7 @@ class FullBulkTracks(Resource):
                     "with_users": True,
                     "id": decode_ids_array(ids),
                     "current_user_id": current_user_id,
+                    "skip_unlisted_filter": True,
                 }
             )
         else:
@@ -362,6 +330,7 @@ class FullBulkTracks(Resource):
                     "with_users": True,
                     "routes": routes_parsed,
                     "current_user_id": current_user_id,
+                    "skip_unlisted_filter": True,
                 }
             )
         if not tracks:

--- a/packages/discovery-provider/src/gated_content/content_access_checker.py
+++ b/packages/discovery-provider/src/gated_content/content_access_checker.py
@@ -75,7 +75,6 @@ class ContentAccessChecker:
         content_type: GatedContentType,
         content_entity: Track,
     ) -> ContentAccessResponse:
-
         if content_type != "track" and content_type != "album":
             logger.warn(
                 f"gated_content_access_checker | check_access | gated content type {content_type} is not supported."

--- a/packages/discovery-provider/src/queries/get_tracks.py
+++ b/packages/discovery-provider/src/queries/get_tracks.py
@@ -36,7 +36,7 @@ class GetTrackArgs(TypedDict):
     limit: int
     offset: int
     handle: str
-    id: int
+    id: List[int]
     current_user_id: int
     authed_user_id: Optional[int]
     min_block_number: int
@@ -50,12 +50,15 @@ class GetTrackArgs(TypedDict):
     routes: List[RouteArgs]
     filter_tracks: str
 
+    # If true, skips the filtering of unlisted tracks
+    skip_unlisted_filter: Optional[bool]
+
     # Optional sort method for the returned results
     sort_method: Optional[SortMethod]
     sort_direction: Optional[SortDirection]
 
 
-def _get_tracks(session, args):
+def _get_tracks(session, args: GetTrackArgs):
     # Create initial query
     base_query = session.query(TrackWithAggregates)
     base_query = base_query.filter(TrackWithAggregates.is_current == True)

--- a/packages/discovery-provider/src/queries/get_tracks.py
+++ b/packages/discovery-provider/src/queries/get_tracks.py
@@ -58,7 +58,7 @@ class GetTrackArgs(TypedDict):
     sort_direction: Optional[SortDirection]
 
 
-def _get_tracks(session, args: GetTrackArgs):
+def _get_tracks(session, args):
     # Create initial query
     base_query = session.query(TrackWithAggregates)
     base_query = base_query.filter(TrackWithAggregates.is_current == True)

--- a/packages/discovery-provider/src/tasks/index_payment_router.py
+++ b/packages/discovery-provider/src/tasks/index_payment_router.py
@@ -989,5 +989,5 @@ def index_payment_router(self):
         if have_lock:
             update_lock.release()
         celery.send_task(
-                "index_payment_router", countdown=0.5, queue="index_nethermind"
-            )
+            "index_payment_router", countdown=0.5, queue="index_nethermind"
+        )

--- a/packages/discovery-provider/src/tasks/index_user_bank.py
+++ b/packages/discovery-provider/src/tasks/index_user_bank.py
@@ -1119,6 +1119,4 @@ def index_user_bank(self):
     finally:
         if have_lock:
             update_lock.release()
-        celery.send_task(
-                "index_user_bank", countdown=0.5, queue="index_nethermind"
-            )
+        celery.send_task("index_user_bank", countdown=0.5, queue="index_nethermind")


### PR DESCRIPTION
### Description

Prior to this PR,`v1/full/tracks/<id>`, `v1/tracks?id=<id1>&id=<id2>...`, `v1/full/tracks?id=<id1>&id=<id2>...` all filtered out unlisted tracks unless the user was logged in. The `v1/full/tracks/<id>` endpoint specifically had a check for two parameters that detail knowledge of the track's title and owner _even if the owner was the one requesting_, which was breaking my fetch for a freshly uploaded track at the end of the upload flow. 

With this PR we're deciding that filtering unlisted tracks from the API when requesting by ID alone is unnecessary, as we no longer use monotonically increasing IDs anyway so the ID is something that's obscure enough to know.

Did not adjust at the query level because getting tracks by user should still not reveal unlisted tracks, lest we show unlisted tracks on profiles.

### How Has This Been Tested?

TBD, putting up for PR while I get protocol up and running