### PR TITLE
[DRAFT] Separate cypress tests into "essential" tests that run on PRs vs "comprehensive" tests that run on main

### DIFF
--- a/.circleci/src/jobs/@web-jobs.yml
+++ b/.circleci/src/jobs/@web-jobs.yml
@@ -114,6 +114,27 @@ web-test-staging:
     - store_artifacts:
         path: /home/circleci/audius-protocol/packages/probers/cypress/screenshots
 
+web-test-staging-essential:
+  working_directory: ~/audius-protocol
+  resource_class: large
+  executor: cypress/default
+  steps:
+    - checkout
+    - attach_workspace:
+        at: ./
+    - browser-tools/install-browser-tools:
+        chrome-version: 116.0.5845.96 # TODO: remove when chromedriver downloads are fixed
+    - cypress/install:
+        install-command: 'cd packages/probers && npx cypress install'
+        install-browsers: false
+    - cypress/run-tests:
+        cypress-command: 'cd packages/probers && npx cypress run --browser chrome --env grep="@essential"'
+        start-command: 'npx serve -l 3001 -s packages/web/build-staging'
+    - store_artifacts:
+        path: /home/circleci/audius-protocol/packages/probers/cypress/videos
+    - store_artifacts:
+        path: /home/circleci/audius-protocol/packages/probers/cypress/screenshots
+
 web-test:
   working_directory: ~/audius-protocol
   docker:

--- a/.circleci/src/workflows/web.yml
+++ b/.circleci/src/workflows/web.yml
@@ -52,10 +52,21 @@ jobs:
         branches:
           only: /(^release.*)$/
 
+  - web-test-staging-essential:
+      context: Audius Client
+      requires:
+        - web-build-staging
+      filters:
+        branches:
+          ignore: /^main$/
+
   - web-test-staging:
       context: Audius Client
       requires:
         - web-build-staging
+      filters:
+        branches:
+          only: /^main$/
 
   - web-test:
       context: Audius Client

--- a/packages/probers/cypress/e2e/flaky-test-jail.md
+++ b/packages/probers/cypress/e2e/flaky-test-jail.md
@@ -4,17 +4,20 @@
 
 A list of flaky/misbehaving tests that we are currently skipping in order to keep a green baseline
 
-## Current Inmates - [C-3508]
+## Current Inmates 
 
-#### [Upload Track](./uploadTrack.cy.ts)
+#### [Upload Track](./uploadTrack.cy.ts) - [C-3508]
 
 This entire suite is in jail.
 
 The upload flow seems to generally take too long in CI and results in timeouts and consistent failures.
 
-#### [Sign Up](./signUp.cy.ts) - [C-3593]
 
-"should create an account" tests are skipped until they can be updated
+#### [Sign In](./signIn.cy.ts) - [C-4005]
+
+The 'can sign in' test is in jail until we can hard-code an OTP code
+
+
 
 <!-- Template
 

--- a/packages/probers/cypress/e2e/playTrack.cy.ts
+++ b/packages/probers/cypress/e2e/playTrack.cy.ts
@@ -1,4 +1,4 @@
-describe('Play Track', () => {
+describe('Play Track @essential', () => {
   it('should play a trending track', () => {
     cy.visit('trending')
     cy.findByRole('list', { name: /weekly trending tracks/i }).within(() => {

--- a/packages/probers/cypress/e2e/signIn.cy.ts
+++ b/packages/probers/cypress/e2e/signIn.cy.ts
@@ -6,7 +6,7 @@ function assertOnSignInPage() {
   )
 }
 
-describe('Sign In', () => {
+describe('Sign In @essential', () => {
   beforeEach(() => {
     localStorage.setItem('FeatureFlagOverride:sign_up_redesign', 'enabled')
   })
@@ -40,7 +40,8 @@ describe('Sign In', () => {
     assertOnSignInPage()
   })
 
-  // We need to integrate a hard-coded otp for this user
+  // [TEST JAIL] - C-4005
+  // TODO: We need to integrate a hard-coded otp for this user
   it.skip('can sign in', () => {
     cy.visit('signin')
     assertOnSignInPage()

--- a/packages/probers/cypress/e2e/signOut.cy.ts
+++ b/packages/probers/cypress/e2e/signOut.cy.ts
@@ -1,6 +1,6 @@
 import user from '../fixtures/user.json'
 
-describe('Sign Out', () => {
+describe('Sign Out @essential', () => {
   beforeEach(() => {
     localStorage.setItem('HAS_REQUESTED_BROWSER_PUSH_PERMISSION', 'true')
   })

--- a/packages/probers/cypress/e2e/signUp.cy.ts
+++ b/packages/probers/cypress/e2e/signUp.cy.ts
@@ -132,7 +132,7 @@ function testSignUp({ isMobile = false }) {
   })
 }
 
-describe('Sign Up', () => {
+describe('Sign Up @essential', () => {
   beforeEach(() => {
     localStorage.setItem('FeatureFlagOverride:sign_up_redesign', 'enabled')
   })

--- a/packages/probers/cypress/e2e/smoke/album.cy.ts
+++ b/packages/probers/cypress/e2e/smoke/album.cy.ts
@@ -1,6 +1,6 @@
 import { route, name } from '../../fixtures/album.json'
 
-describe('Smoke test -- album page', () => {
+describe('Smoke test -- album page @essential', () => {
   it('Should load an album page when visited!', () => {
     cy.visit(route)
     cy.findByRole('heading', { name, level: 1, timeout: 10000 }).should('exist')

--- a/packages/probers/cypress/e2e/smoke/feed.cy.ts
+++ b/packages/probers/cypress/e2e/smoke/feed.cy.ts
@@ -1,6 +1,6 @@
 import user from '../../fixtures/user.json'
 
-describe('Smoke test -- feed page', () => {
+describe('Smoke test -- feed page @essential', () => {
   beforeEach(() => {
     localStorage.setItem('HAS_REQUESTED_BROWSER_PUSH_PERMISSION', 'true')
   })

--- a/packages/probers/cypress/e2e/smoke/playlist.cy.ts
+++ b/packages/probers/cypress/e2e/smoke/playlist.cy.ts
@@ -1,6 +1,6 @@
 import { route, name } from '../../fixtures/playlist.json'
 
-describe('Smoke test -- playlist page', () => {
+describe('Smoke test -- playlist page @essential', () => {
   it('should load a playlist page when visited', () => {
     cy.visit(route)
     cy.findByRole('heading', { name, level: 1, timeout: 20000 }).should('exist')

--- a/packages/probers/cypress/e2e/smoke/remix.cy.ts
+++ b/packages/probers/cypress/e2e/smoke/remix.cy.ts
@@ -1,6 +1,6 @@
 import { route, name } from '../../fixtures/remix.json'
 
-describe('Smoke test -- remix page', () => {
+describe('Smoke test -- remix page @essential', () => {
   it('should load a remix page when visited', () => {
     cy.visit(route)
     cy.findByRole('heading', { name, level: 1 }).should('exist')

--- a/packages/probers/cypress/e2e/smoke/remixes.cy.ts
+++ b/packages/probers/cypress/e2e/smoke/remixes.cy.ts
@@ -1,6 +1,6 @@
 import { route } from '../../fixtures/remixes.json'
 
-describe('Smoke test -- remixes page', () => {
+describe('Smoke test -- remixes page @essential', () => {
   it('should load a remixes page when visited', () => {
     cy.visit(route)
     cy.findByRole('heading', {

--- a/packages/probers/cypress/e2e/smoke/track.cy.ts
+++ b/packages/probers/cypress/e2e/smoke/track.cy.ts
@@ -1,6 +1,6 @@
 import { route, name } from '../../fixtures/track.json'
 
-describe('Smoke test -- track page', () => {
+describe('Smoke test -- track page @essential', () => {
   it('should load a track page when visited', () => {
     cy.visit(route)
     cy.findByRole('heading', { name, level: 1 }).should('exist')

--- a/packages/probers/cypress/e2e/smoke/trending.cy.ts
+++ b/packages/probers/cypress/e2e/smoke/trending.cy.ts
@@ -1,4 +1,4 @@
-describe('Smoke test -- trending page', () => {
+describe('Smoke test -- trending page @essential', () => {
   it('should load trending page when visited', () => {
     cy.visit('trending')
     cy.findByRole('heading', { name: /trending/i, level: 1 }).should('exist')

--- a/packages/probers/cypress/e2e/smoke/upload.cy.ts
+++ b/packages/probers/cypress/e2e/smoke/upload.cy.ts
@@ -1,5 +1,5 @@
 import user from '../../fixtures/user.json'
-describe('Smoke test -- upload page', () => {
+describe('Smoke test -- upload page @essential', () => {
   beforeEach(() => {
     localStorage.setItem('HAS_REQUESTED_BROWSER_PUSH_PERMISSION', 'true')
   })

--- a/packages/probers/cypress/support/commands.ts
+++ b/packages/probers/cypress/support/commands.ts
@@ -2,8 +2,13 @@ import '@testing-library/cypress/add-commands'
 import 'cypress-file-upload'
 import 'cypress-wait-until'
 import 'cypress-plugin-tab'
+import registerCypressGrep from '@cypress/grep/src/support'
 
 import user from '../fixtures/user.json'
+
+// Enable the CLI grep tool
+registerCypressGrep()
+
 const base64Entropy = Buffer.from(user.entropy).toString('base64')
 
 declare global {

--- a/packages/probers/package.json
+++ b/packages/probers/package.json
@@ -8,6 +8,7 @@
     "cypress:open-stage": "cypress open --env configFile=stage",
     "cypress:open-rc-stage": "cypress open --env configFile=rc-stage",
     "cypress:run": "cypress run",
+    "cypress:run:essential": "cypress run --env grep='@essential'",
     "cypress:run-stage": "cypress run --env configFile=stage",
     "cypress:run-rc-stage": "cypress run --env configFile=rc-stage",
     "test:target": "env-cmd -f .env jest --runInBand",
@@ -21,6 +22,7 @@
   "dependencies": {
     "@testing-library/cypress": "^9.0.0",
     "cypress": "^12.17.2",
+    "@cypress/grep": "4.0.1",
     "cypress-file-upload": "^5.0.8",
     "cypress-wait-until": "^1.7.2",
     "dayjs": "^1.11.6",


### PR DESCRIPTION
### Description

(This would be a draft PR but I want to see the CCI workflows changed here)

### Context/Motivation

We've been discussing in our FE syncs how we want to increase cypress test coverage overall, but also want to avoid constantly spinning our wheels in PRs either waiting for long running test suites or spending time debugging flaky tests. 

The solution proposed here is to migrate a portion of our suite to not run on PRs and instead run on every main commit. This way we are able to quickly ship PRs but still have test coverage on each change identifying which commit caused issues.

We also discussed putting stuff further away from PRs, in frequencies like scheduled builds (morning/nightly/etc), on release branchs only, and some other potential options. If we decide to do any of those it will be pretty easy to adjust; we just change what triggers the "comprehensive" suite flow

### Changes in this PR 
Using [cypress-grep](https://www.npmjs.com/package/@cypress/grep), this PR enables adding an `@essential` tag to a cypress test block to dictate whether a test runs on PRs or not (all tests run on main no matter what)

I took a stab at picking which of our existing tests should be "essential" or not (spoiler; mostly essential)
Please do give feedback on these and whether some belong in/out of the "essential" list.

**Essential** (runs on every PR commit; aka existing flow)
- `signIn.cy.ts`
- `signOut.cy.ts`
- `signUp.cy.ts`
- `uploadTrack.cy.ts`
- `playTrack.cy.ts`
- smoke suite (I honestly think these are lower priority but they're so simple that it feels easy to include with the essential suite)

**Non-Essential** (runs on main commits only; aka the new flow)
- `favoriteTrack.cy.ts`
- `repostTrack.cy.ts`
(I was on the fence about even putting these in non-essential, so please do give feedback)

### Future TODOs
- [ ] Make an alerting system for tests failing on main
- [ ] More tests (right now there's not much difference in the "essential" test suite) 💯 
- [ ] Decide if running on main is the best place 
- [ ] Keep accountable on breaking main tests / addressing test flakes

### How Has This Been Tested?

TODO: watch CCI and make sure it works, also will verify suite runs once it goes to main (a little bit of 🚢 and 🙏)

