### PR TITLE
Add fixed-decimal to web deps and update version in libs

### DIFF
--- a/packages/libs/package.json
+++ b/packages/libs/package.json
@@ -63,7 +63,7 @@
     "prepack": "turbo run build"
   },
   "dependencies": {
-    "@audius/fixed-decimal": "^0.0.20",
+    "@audius/fixed-decimal": "^0.0.21",
     "@audius/hedgehog": "3.0.0-alpha.0",
     "@audius/spl": "^0.0.27",
     "@babel/core": "^7.23.7",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -66,6 +66,7 @@
     "@audius/harmony": "*",
     "@audius/sdk": "*",
     "@audius/stems": "*",
+    "@audius/fixed-decimal": "*",
     "@audius/trpc-server": "*",
     "@cloudflare/kv-asset-handler": "0.2.0",
     "@coinbase/cbpay-js": "1.2.0",


### PR DESCRIPTION
### Description
* Adds `@audius/fixed-decimal` as a dependency in `packages/web`
* Update version of `@audius/fixed-decimal` in `packages/libs`

### How Has This Been Tested?

In a clean working dir, `npm i` followed by `npm run web:stage` works without building `@audius/fixed-decimal` manually.