### PR TITLE
Ignore sentry errors for probers

### DIFF
--- a/packages/web/src/services/sentry.ts
+++ b/packages/web/src/services/sentry.ts
@@ -17,6 +17,7 @@ const MAX_BREADCRUMBS = 300
 export const initializeSentry = () => {
   init({
     dsn: env.SENTRY_DSN,
+    ignoreErrors: navigator.userAgent === 'probers' ? [/.*/] : undefined,
 
     // Need to give Sentry a version so it can
     // associate stacktraces with sourcemaps


### PR DESCRIPTION
### Description

Sentry Errors are ignored from probers user agent
