### PR TITLE
Remove download field in client

### DIFF
--- a/packages/common/src/schemas/metadata.ts
+++ b/packages/common/src/schemas/metadata.ts
@@ -51,7 +51,6 @@ const trackMetadataSchema = {
   license: null,
   isrc: null,
   iswc: null,
-  download: null,
   is_playlist_upload: false,
   ai_attribution_user_id: null,
   ddex_release_ids: null,


### PR DESCRIPTION
### Description

This is so download field is no longer sent.
Will merge later, once libs is sure to be pushed with validation fixed.

### How Has This Been Tested?

Works locally, as long as libs change is there.
