### PR TITLE
[PAY-2577] Fix nft issues

### DIFF
--- a/packages/common/src/models/OpenSea.ts
+++ b/packages/common/src/models/OpenSea.ts
@@ -12,26 +12,15 @@ type AssetContract = {
   owner: Nullable<number>
   schema_name: TokenStandard
   symbol: string
-  total_supply: number
   description: Nullable<string>
   external_link: Nullable<string>
   image_url: Nullable<string>
-  default_to_fiat: boolean
-  dev_buyer_fee_basis_points: number
-  dev_seller_fee_basis_points: number
-  only_proxied_transfers: boolean
-  opensea_buyer_fee_basis_points: number
-  opensea_seller_fee_basis_points: number
-  buyer_fee_basis_points: number
-  seller_fee_basis_points: number
-  payout_address: Nullable<string>
 }
 
 export type OpenSeaCollection = {
   collection: string
   name: string
   description: string
-  project_url: string
   image_url: string
 }
 
@@ -71,7 +60,7 @@ export type OpenSeaNft = {
   identifier: string
   collection: string
   contract: string
-  token_standard: string
+  token_standard: TokenStandard
   name: string
   description: string
   image_url: string

--- a/packages/common/src/services/opensea-client/ethCollectibleHelpers.ts
+++ b/packages/common/src/services/opensea-client/ethCollectibleHelpers.ts
@@ -6,7 +6,8 @@ import {
   CollectibleMediaType,
   OpenSeaNftExtended,
   OpenSeaEvent,
-  OpenSeaEventExtended
+  OpenSeaEventExtended,
+  TokenStandard
 } from '../../models'
 
 const fetchWithTimeout = async (
@@ -287,9 +288,7 @@ export const assetToCollectible = async (
         }
       } catch (e) {
         console.error(
-          `Could not fetch url metadata at ${ipfsProtocolUrl} for asset contract address ${
-            asset.asset_contract?.address ?? '(n/a)'
-          } and asset token id ${asset.token_id}`
+          `Could not fetch url metadata at ${ipfsProtocolUrl} for asset contract address ${asset.contract} and asset token id ${asset.token_id}`
         )
         mediaType = CollectibleMediaType.IMAGE
         frameUrl = imageUrls.find((url) => !!url)!
@@ -324,9 +323,7 @@ export const assetToCollectible = async (
         }
       } catch (e) {
         console.error(
-          `Could not fetch url metadata at ${arweaveProtocolUrl} for asset contract address ${
-            asset.asset_contract?.address ?? '(n/a)'
-          } and asset token id ${asset.token_id}`
+          `Could not fetch url metadata at ${arweaveProtocolUrl} for asset contract address ${asset.contract} and asset token id ${asset.token_id}`
         )
         mediaType = CollectibleMediaType.IMAGE
         frameUrl = imageUrls.find((url) => !!url)!
@@ -376,8 +373,8 @@ export const assetToCollectible = async (
     dateLastTransferred: null,
     externalLink: asset.external_url ?? null,
     permaLink: asset.opensea_url,
-    assetContractAddress: asset.asset_contract?.address ?? null,
-    standard: asset.asset_contract?.schema_name ?? null,
+    assetContractAddress: asset.contract,
+    standard: (asset.token_standard?.toUpperCase() as TokenStandard) ?? null,
     collectionSlug: asset.collection ?? null,
     collectionName: asset.collectionMetadata?.name ?? null,
     collectionImageUrl: asset.collectionMetadata?.image_url ?? null,

--- a/packages/common/src/services/solana-client/solCollectibleHelpers.ts
+++ b/packages/common/src/services/solana-client/solCollectibleHelpers.ts
@@ -68,7 +68,7 @@ const nftThreeDWithFrame = async (
 ): Promise<Nullable<SolanaNFTMedia>> => {
   const files = nft.properties?.files ?? []
   const objFile = files.find(
-    (file: any) => typeof file === 'object' && file.type.includes('glb')
+    (file: any) => typeof file === 'object' && file.type?.includes('glb')
   ) as MetaplexNFTPropertiesFile
   const objUrl = files.find(
     (file: any) => typeof file === 'string' && file.endsWith('glb')
@@ -84,7 +84,7 @@ const nftThreeDWithFrame = async (
       frameUrl = nft.image
     } else {
       const imageFile = files?.find(
-        (file: any) => typeof file === 'object' && file.type.includes('image')
+        (file: any) => typeof file === 'object' && file.type?.includes('image')
       ) as MetaplexNFTPropertiesFile
       if (imageFile) {
         frameUrl = imageFile.uri
@@ -130,8 +130,8 @@ const nftVideo = async (
   const videoFile = files.find(
     (file: any) =>
       typeof file === 'object' &&
-      file.type.includes('video') &&
-      !file.type.endsWith('glb')
+      file.type?.includes('video') &&
+      !file.type?.endsWith('glb')
   ) as MetaplexNFTPropertiesFile
   const videoUrl = files.find(
     (file: any) =>
@@ -186,7 +186,7 @@ const nftImage = async (
   // In case we want to restrict to specific file extensions, see below link
   // https://github.com/metaplex-foundation/metaplex/blob/81023eb3e52c31b605e1dcf2eb1e7425153600cd/js/packages/web/src/views/artCreate/index.tsx#L316
   const imageFile = files.find(
-    (file: any) => typeof file === 'object' && file.type.includes('image')
+    (file: any) => typeof file === 'object' && file.type?.includes('image')
   ) as MetaplexNFTPropertiesFile
   const isImage =
     nft.properties?.category === 'image' || nft.image.length || imageFile

--- a/packages/libs/src/sdk/api/tracks/types.ts
+++ b/packages/libs/src/sdk/api/tracks/types.ts
@@ -20,7 +20,7 @@ export const EthCollectibleGatedConditions = z
     name: z.string(),
     slug: z.string(),
     imageUrl: z.optional(z.string()),
-    externalLink: z.optional(z.string())
+    externalLink: z.optional(z.string()).nullable()
   })
   .strict()
 
@@ -30,7 +30,7 @@ export const SolCollectibleGatedConditions = z
     address: z.string(),
     name: z.string(),
     imageUrl: z.optional(z.string()),
-    externalLink: z.optional(z.string())
+    externalLink: z.optional(z.string()).nullable()
   })
   .strict()
 


### PR DESCRIPTION
### Description

Eth side:
- opensea v2 contract address lives in different field

Sol side:
- nft properties file is sometimes `{}`, causing `file.type` to be undefined, causing any chained function calls from it to break

General:
- make external links nullable
- remove unused fields

Note:
nfts very slow to load. should look more into that

### How Has This Been Tested?

local vs prod
upload flow collectibles didn't load nft collections, because of issues on both eth and sol sides.
collectibles page sol nfts also would not load.
with these fixes, they load properly now. collectibles page

<img width="759" alt="Screenshot 2024-03-19 at 8 56 26 PM" src="https://github.com/AudiusProject/audius-protocol/assets/9600175/f9794ae2-a3a2-4a3b-a7b2-b709d0ed51ef">
