### PR TITLE
[C-4040, C-4032] Fix play cls, Fix pause on track screen

### DIFF
--- a/packages/mobile/src/components/lineup-tile/LineupTileMetadata.tsx
+++ b/packages/mobile/src/components/lineup-tile/LineupTileMetadata.tsx
@@ -91,21 +91,20 @@ export const LineupTileMetadata = ({
         duration={500}
       >
         <TouchableOpacity style={trackTileStyles.title} onPress={onPressTitle}>
-          <>
-            <Text
-              color={isActive ? 'primary' : 'neutral'}
-              weight='bold'
-              numberOfLines={1}
-            >
-              {title}
-            </Text>
-            {isPlaying ? (
-              <IconVolumeLevel2
-                fill={primary}
-                style={styles.playingIndicator}
-              />
-            ) : null}
-          </>
+          <Text
+            color={isActive ? 'primary' : 'neutral'}
+            weight='bold'
+            numberOfLines={1}
+          >
+            {title}
+          </Text>
+          {isPlaying ? (
+            <IconVolumeLevel2
+              fill={primary}
+              style={styles.playingIndicator}
+              size='m'
+            />
+          ) : null}
         </TouchableOpacity>
         <TouchableOpacity
           style={trackTileStyles.artist}

--- a/packages/mobile/src/screens/track-screen/TrackScreenDetailsTile.tsx
+++ b/packages/mobile/src/screens/track-screen/TrackScreenDetailsTile.tsx
@@ -326,7 +326,7 @@ export const TrackScreenDetailsTile = ({
     ({ isPreview = false } = {}) => {
       if (isLineupLoading) return
 
-      if (isPlaying && isPreviewing === isPreview) {
+      if (isPlaying && isPreviewing && isPreview) {
         dispatch(tracksActions.pause())
         recordPlay(track_id, false, true)
       } else if (


### PR DESCRIPTION
### Description

Fixes issue where pressing play causes layout shift of track title due to icon being too large.
Fixes issue where pressing play on track screen when another track is already playing triggered a pause when`isPreview` and `isPreviewing` are false.
