### PR TITLE
Add undefined check to sentry navigator and remove profile page route

### DIFF
--- a/packages/web/src/pages/profile-page/ProfilePage.tsx
+++ b/packages/web/src/pages/profile-page/ProfilePage.tsx
@@ -1,6 +1,6 @@
 import { RefObject, memo } from 'react'
 
-import { useIsMobile } from 'hooks/useIsMobile'
+import { useSsrContext } from 'ssr/SsrContext'
 
 import ProfilePageProvider from './ProfilePageProvider'
 import DesktopProfilePage from './components/desktop/ProfilePage'
@@ -11,7 +11,7 @@ type ProfilePageProps = {
 }
 
 const ProfilePage = ({ containerRef }: ProfilePageProps) => {
-  const isMobile = useIsMobile()
+  const { isMobile } = useSsrContext()
   const content = isMobile ? MobileProfilePage : DesktopProfilePage
 
   return (

--- a/packages/web/src/services/sentry.ts
+++ b/packages/web/src/services/sentry.ts
@@ -17,7 +17,12 @@ const MAX_BREADCRUMBS = 300
 export const initializeSentry = () => {
   init({
     dsn: env.SENTRY_DSN,
-    ignoreErrors: navigator.userAgent === 'probers' ? [/.*/] : undefined,
+    ignoreErrors:
+      typeof navigator !== 'undefined'
+        ? navigator?.userAgent === 'probers'
+          ? [/.*/]
+          : undefined
+        : undefined,
 
     // Need to give Sentry a version so it can
     // associate stacktraces with sourcemaps

--- a/packages/web/src/ssr/profile/route.tsx
+++ b/packages/web/src/ssr/profile/route.tsx
@@ -1,3 +1,4 @@
+// NOTE: This ssr route is off until the profile page is rendered server-side
 import { makePageRoute } from 'ssr/util'
 
 export default makePageRoute('/@handle', 'Profile Page')


### PR DESCRIPTION
### Description
* Update +route to route for profile page to not render profile page on the server until more work is done there
* Add an undefined check on navigator in sentry.ts to not break server-side rendering

### How Has This Been Tested?

Tested locally
