### PR TITLE
Fix ddex indexing

### DIFF
--- a/packages/discovery-provider/ddl/migrations/0063_ddex_jsonb_columns.sql
+++ b/packages/discovery-provider/ddl/migrations/0063_ddex_jsonb_columns.sql
@@ -1,0 +1,39 @@
+DO $$
+BEGIN
+    -- For the 'artists' column in the 'tracks' table
+    IF EXISTS (
+        SELECT FROM information_schema.columns 
+        WHERE table_name = 'tracks' AND column_name = 'artists' 
+        AND udt_name != 'jsonb'
+    ) THEN
+        EXECUTE 'ALTER TABLE tracks ALTER COLUMN artists TYPE jsonb USING artists::text::jsonb;';
+    END IF;
+    
+    -- For the 'resource_contributors' column in the 'tracks' table
+    IF EXISTS (
+        SELECT FROM information_schema.columns 
+        WHERE table_name = 'tracks' AND column_name = 'resource_contributors' 
+        AND udt_name != 'jsonb'
+    ) THEN
+        EXECUTE 'ALTER TABLE tracks ALTER COLUMN resource_contributors TYPE jsonb USING resource_contributors::text::jsonb;';
+    END IF;
+
+    -- For the 'indirect_resource_contributors' column in the 'tracks' table
+    IF EXISTS (
+        SELECT FROM information_schema.columns 
+        WHERE table_name = 'tracks' AND column_name = 'indirect_resource_contributors' 
+        AND udt_name != 'jsonb'
+    ) THEN
+        EXECUTE 'ALTER TABLE tracks ALTER COLUMN indirect_resource_contributors TYPE jsonb USING indirect_resource_contributors::text::jsonb;';
+    END IF;
+
+    -- For the 'artists' column in the 'playlists' table
+    IF EXISTS (
+        SELECT FROM information_schema.columns 
+        WHERE table_name = 'playlists' AND column_name = 'artists' 
+        AND udt_name != 'jsonb'
+    ) THEN
+        EXECUTE 'ALTER TABLE playlists ALTER COLUMN artists TYPE jsonb USING artists::text::jsonb;';
+    END IF;
+    
+END $$;

--- a/packages/discovery-provider/src/models/playlists/playlist.py
+++ b/packages/discovery-provider/src/models/playlists/playlist.py
@@ -1,5 +1,4 @@
 from sqlalchemy import (
-    ARRAY,
     Boolean,
     Column,
     DateTime,
@@ -58,7 +57,7 @@ class Playlist(Base, RepresentableMixin):
     # From DDEX
     ddex_app = Column(String)
     ddex_release_ids = Column(JSONB())
-    artists = Column(ARRAY(JSONB()))
+    artists = Column(JSONB())
     copyright_line = Column(JSONB())
     producer_copyright_line = Column(JSONB())
     parental_warning_type = Column(String)

--- a/packages/discovery-provider/src/models/tracks/track.py
+++ b/packages/discovery-provider/src/models/tracks/track.py
@@ -95,9 +95,9 @@ class Track(Base, RepresentableMixin):
     # From DDEX
     ddex_release_ids = Column(JSONB())
     ddex_app = Column(String)
-    artists = Column(ARRAY(JSONB()))
-    resource_contributors = Column(ARRAY(JSONB()))
-    indirect_resource_contributors = Column(ARRAY(JSONB()))
+    artists = Column(JSONB())
+    resource_contributors = Column(JSONB())
+    indirect_resource_contributors = Column(JSONB())
     rights_controller = Column(JSONB())
     copyright_line = Column(JSONB())
     producer_copyright_line = Column(JSONB())

--- a/packages/discovery-provider/src/tasks/entity_manager/entities/playlist.py
+++ b/packages/discovery-provider/src/tasks/entity_manager/entities/playlist.py
@@ -466,6 +466,10 @@ def create_playlist(params: ManageEntityParameters):
         is_current=False,
         is_delete=False,
         ddex_app=ddex_app,
+        ddex_release_ids=params.metadata.get("ddex_release_ids", None),
+        artists=params.metadata.get("artists", None),
+        copyright_line=params.metadata.get("copyright_line", None),
+        producer_copyright_line=params.metadata.get("producer_copyright_line", None),
         parental_warning_type=params.metadata.get("parental_warning_type", None),
     )
 

--- a/packages/discovery-provider/src/tasks/entity_manager/entities/track.py
+++ b/packages/discovery-provider/src/tasks/entity_manager/entities/track.py
@@ -329,32 +329,74 @@ def populate_track_record_metadata(track_record: Track, track_metadata, handle, 
                 )
 
         elif key == "ddex_release_ids":
-            if "ddex_release_ids" in track_metadata and track_metadata["ddex_release_ids"]:
-                continue
+            if "ddex_release_ids" in track_metadata and (
+                is_valid_json_field(track_metadata, "ddex_release_ids")
+                or track_metadata["ddex_release_ids"] is None
+            ):
+                track_record.ddex_release_ids = track_metadata["ddex_release_ids"]
 
         elif key == "artists":
-            if "artists" in track_metadata and track_metadata["artists"]:
-                continue
+            if "artists" in track_metadata:
+                artists = track_metadata["artists"]
+                if artists and isinstance(artists, list):
+                    valid = True
+                    for artist in artists:
+                        if not isinstance(artist, dict):
+                            valid = False
+                            break
+                    if valid:
+                        track_record.artists = artists
+                elif artists is None:
+                    track_record.artists = artists
 
         elif key == "resource_contributors":
-            if "resource_contributors" in track_metadata and track_metadata["resource_contributors"]:
-                continue
+            if "resource_contributors" in track_metadata:
+                resource_contributors = track_metadata["resource_contributors"]
+                if resource_contributors and isinstance(resource_contributors, list):
+                    valid = True
+                    for contributor in resource_contributors:
+                        if not isinstance(contributor, dict):
+                            valid = False
+                            break
+                    if valid:
+                        track_record.resource_contributors = resource_contributors
+                elif resource_contributors is None:
+                    track_record.resource_contributors = resource_contributors
 
         elif key == "indirect_resource_contributors":
-            if "indirect_resource_contributors" in track_metadata and track_metadata["indirect_resource_contributors"]:
-                continue
+            if "indirect_resource_contributors" in track_metadata:
+                indirect_resource_contributors = track_metadata["indirect_resource_contributors"]
+                if indirect_resource_contributors and isinstance(indirect_resource_contributors, list):
+                    valid = True
+                    for contributor in indirect_resource_contributors:
+                        if not isinstance(contributor, dict):
+                            valid = False
+                            break
+                    if valid:
+                        track_record.indirect_resource_contributors = indirect_resource_contributors
+                elif indirect_resource_contributors is None:
+                    track_record.indirect_resource_contributors = indirect_resource_contributors
 
         elif key == "rights_controller":
-            if "rights_controller" in track_metadata and track_metadata["rights_controller"]:
-                continue
+            if "rights_controller" in track_metadata and (
+                is_valid_json_field(track_metadata, "rights_controller")
+                or track_metadata["rights_controller"] is None
+            ):
+                track_record.rights_controller = track_metadata["rights_controller"]
 
         elif key == "copyright_line":
-            if "copyright_line" in track_metadata and track_metadata["copyright_line"]:
-                continue
+            if "copyright_line" in track_metadata and (
+                is_valid_json_field(track_metadata, "copyright_line")
+                or track_metadata["copyright_line"] is None
+            ):
+                track_record.copyright_line = track_metadata["copyright_line"]
 
         elif key == "producer_copyright_line":
-            if "producer_copyright_line" in track_metadata and track_metadata["producer_copyright_line"]:
-                continue
+            if "producer_copyright_line" in track_metadata and (
+                is_valid_json_field(track_metadata, "producer_copyright_line")
+                or track_metadata["producer_copyright_line"] is None
+            ):
+                track_record.producer_copyright_line = track_metadata["producer_copyright_line"]
 
         else:
             # For most fields, update the track_record when the corresponding field exists


### PR DESCRIPTION
### Description
Indexing stalled because sqlalchemy could not out of the box handle inserting an array of dicts into a jsonb[] type postgresql column. However these columns should actually just be jsonb cols, which can handle arrays of jsonb blobs and also keeps all the postgres jsonb functionality.

Change these cols from jsonb[] -> jsonb. Add validation to the tracks entity manager to match the other jsonb columns' validation. Playlists do not seem to have this. 

It appears to be a larger problem that the entity manager in general doesn't validate types before inserting into the db, and if the db insert errors, indexing stalls.

### How Has This Been Tested?
Verified this unblocked stage DN3 which was stuck trying to index a DDEX track