### PR TITLE
Pin docker to older version to fix regression

### DIFF
--- a/dev-tools/setup.sh
+++ b/dev-tools/setup.sh
@@ -35,8 +35,8 @@ debian | ubuntu)
         git \
         python3 \
         python3-pip \
-        docker-ce \
-        docker-ce-cli \
+        docker-ce='5:24.0.5-1~ubuntu.22.04~jammy' \
+        docker-ce-cli='5:24.0.5-1~ubuntu.22.04~jammy' \
         containerd.io \
         docker-buildx-plugin \
         docker-compose-plugin='2.21.0-1~ubuntu.22.04~jammy'


### PR DESCRIPTION
### Description

[Docker released a patch to fix a vulnerability](https://github.com/moby/moby/security/advisories/GHSA-mq39-4gv4-mvpx), but this creates a regression in the build process by not allowing connections to local services. This broke the build for eth-contracts and in turn broke the test-audius-cmd integration workflow.

This will pin docker to an earlier version not impacted by the vulnerability or the regression.

### How Has This Been Tested?

CI