### PR TITLE
Re-add download to track api response for old clients

### DIFF
--- a/packages/discovery-provider/src/api/v1/helpers.py
+++ b/packages/discovery-provider/src/api/v1/helpers.py
@@ -383,6 +383,14 @@ def extend_track(track):
         "is_deactivated"
     )
 
+    # todo: remove once clients catch up i.e. no longer use this field
+    track["download"] = {
+        "cid": track.get("track_cid"),
+        "is_downloadable": bool(track.get("is_downloadable")),
+        "requires_follow": track.get("download_conditions") is not None
+        and "follow_user_id" in track.get("download_conditions"),
+    }
+
     # TODO: This block is only for legacy tracks that have track_segments instead of duration
     duration = track.get("duration")
     if not duration:


### PR DESCRIPTION
### Description

Re-adds `download` field in track api response for clients on old versions. This will be removed later once we force upgrade on mobile.

Related to
https://github.com/AudiusProject/audius-protocol/pull/7784
https://github.com/AudiusProject/audius-protocol/pull/7896

### How Has This Been Tested?

Passes integration tests.
Ran web client against local stack, confirmed all-time trending works and `download` field is present in track response.