### PR TITLE
Fix search autocomplete race condition

### DIFF
--- a/packages/web/src/components/search/SearchBar.jsx
+++ b/packages/web/src/components/search/SearchBar.jsx
@@ -222,9 +222,6 @@ class SearchBar extends Component {
       !isEqual(nextProps.dataSource, this.props.dataSource) &&
       nextProps.resultsCount > 0
     ) {
-      if (!nextState.selected && !nextState.valueFromParent) {
-        this.setState({ open: true })
-      }
       if (nextProps.status === Status.SUCCESS) {
         return true
       }
@@ -236,9 +233,6 @@ class SearchBar extends Component {
       nextProps.resultsCount === 0 &&
       this.state.value !== ''
     ) {
-      if (!nextState.selected && !nextState.valueFromParent) {
-        this.setState({ open: true })
-      }
       return false
     }
     // Close the dropdown if we're searching for '' (deleted text in search).


### PR DESCRIPTION
### Description

Fixes PROTO-1721
Fixes PROTO-1725

This fixes a race condition in the autocomplete search. When typing quickly, the shouldComponentUpdate forces the dropdown to stay open even if the users hits `Enter`. The component is rendering new results after the search is already submitted so the autocomplete pops up in a broken state where it's open half-rendered but not in focus so unable to be blurred/dismissed.

Not entirely sure why this was necessary in the first place, considering autocomplete should probably only open onFocus. 

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._

Search seems pretty smooth now even when typing fast.



https://github.com/AudiusProject/audius-protocol/assets/6413636/b35b3a64-ec2c-4c50-8da4-17a151b158eb



