### PR TITLE
[PAY-2576] Solana relay retries if initial send fails

### DIFF
--- a/.circleci/src/workflows/identity.yml
+++ b/.circleci/src/workflows/identity.yml
@@ -11,7 +11,7 @@ jobs:
         - identity-init
       filters:
         branches:
-          only: main
+          only: rt-relay2
 
   - test:
       name: test-identity-service
@@ -29,7 +29,6 @@ jobs:
           only: main
       requires:
         - push-identity-service
-
 
   # Deploy audius-protocol `main` branch (stage)
   - deploy-stage-nodes:

--- a/.circleci/src/workflows/identity.yml
+++ b/.circleci/src/workflows/identity.yml
@@ -11,7 +11,7 @@ jobs:
         - identity-init
       filters:
         branches:
-          only: rt-relay2
+          only: main
 
   - test:
       name: test-identity-service

--- a/packages/libs/src/services/solana/transactionHandler.ts
+++ b/packages/libs/src/services/solana/transactionHandler.ts
@@ -310,6 +310,9 @@ export class TransactionHandler {
         while (!done && elapsed < this.retryTimeoutMs) {
           try {
             sendRawTransaction()
+            logger.info(
+              `transactionHandler: retrying txId ${txid}, sendCount ${sendCount}`
+            )
           } catch (e) {
             logger.error(
               `transactionHandler: error in send loop: ${e} for txId ${txid}`

--- a/packages/libs/src/services/solana/transactionHandler.ts
+++ b/packages/libs/src/services/solana/transactionHandler.ts
@@ -312,7 +312,7 @@ export class TransactionHandler {
         // eslint-disable-next-line no-unmodified-loop-condition
         while (!done && elapsed < this.retryTimeoutMs) {
           try {
-            retryTxId = sendRawTransaction()
+            retryTxId = await sendRawTransaction()
             logger.info(
               `transactionHandler: retrying txId ${txid} with retryTxId ${retryTxId}, sendCount ${sendCount}`
             )

--- a/packages/libs/src/services/solana/transactionHandler.ts
+++ b/packages/libs/src/services/solana/transactionHandler.ts
@@ -254,8 +254,7 @@ export class TransactionHandler {
           tx.addSignature(new PublicKey(publicKey), signature)
         })
       }
-      txid = tx.signatures[0]!.toString()
-      logger.info('REED txid in v0 tx', txid)
+      txid = bs58.encode(tx.signatures[0]!)
       rawTransaction = tx.serialize()
     } else {
       // Otherwise send a legacy transaction
@@ -272,7 +271,6 @@ export class TransactionHandler {
         })
       }
       txid = bs58.encode(tx.signatures[0]!.signature!)
-      logger.info(`REED txid in legacy tx ${txid}`)
       rawTransaction = tx.serialize()
     }
 


### PR DESCRIPTION
### Description
If the initial send for a relayed transaction fails, currently we will just return an error response. It would be better if we would continue to retry even if the first send fails.

### How Has This Been Tested?

Tested by logging value of `txid` on prod and stage identity to confirm the value was correct for both v0 and legacy transactions.