### PR TITLE
[PROTO-1693] Fix tag search triggering autocomplete

### DIFF
--- a/packages/mobile/src/screens/search-screen/SearchScreen.tsx
+++ b/packages/mobile/src/screens/search-screen/SearchScreen.tsx
@@ -40,7 +40,7 @@ export const SearchScreen = () => {
   )
 
   const renderSearchContent = () => {
-    if (hasResults) {
+    if (hasResults && !searchBarText.startsWith('#')) {
       return <SearchResults />
     }
     if (searchBarText && !hasResults) {


### PR DESCRIPTION
### Description
On mobile, performing tag search, then going back to the previous page shows autocomplete results. This change prevents those autocomplete results so recent searches can show instead, in line with web behavior. 

https://github.com/AudiusProject/audius-protocol/assets/6413636/7ebb5288-5c4e-4abb-8837-2aba0e57995d


### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._

Tested locally against prod

![simulator_screenshot_6FC888F0-7662-4B75-9D97-B74D7615C089](https://github.com/AudiusProject/audius-protocol/assets/6413636/85c1b1a8-3f9d-4b70-8642-5aa54ed5d9c3)
