### PR TITLE
[C-4026, C-4059] Update profile page to render basic info and pictures on the server side

### DIFF
--- a/packages/web/src/components/cover-photo/CoverPhoto.module.css
+++ b/packages/web/src/components/cover-photo/CoverPhoto.module.css
@@ -1,19 +1,21 @@
 .coverPhoto {
   width: 100%;
-  height: 100%;
-  min-height: 376px;
+  height: 376px;
   position: relative;
   display: flex;
   justify-content: center;
+  overflow: hidden;
 }
 
 .placeholder,
 .photo {
   position: absolute;
   width: 100%;
+  height: 100%;
   min-height: 376px;
   display: flex;
   background-position: center;
+  z-index: 0;
 }
 
 .photo {
@@ -47,6 +49,7 @@
 .hide {
   opacity: 0;
 }
+
 .show {
   opacity: 1;
 }

--- a/packages/web/src/components/cover-photo/CoverPhoto.tsx
+++ b/packages/web/src/components/cover-photo/CoverPhoto.tsx
@@ -104,25 +104,27 @@ const CoverPhoto = ({
         isUrl={false}
         wrapperClassName={styles.photo}
         imageStyle={backgroundStyle}
+        useBlur={shouldBlur}
         usePlaceholder={false}
         immediate={immediate}
-        useBlur={shouldBlur}
       >
         <div className={styles.spinner}>
           {processing ? loadingElement : null}
         </div>
       </DynamicImage>
-      <div className={styles.button}>
-        {edit ? (
-          <ImageSelectionButton
-            imageName={messages.imageName}
-            hasImage={Boolean(image || updatedCoverPhoto)}
-            error={!!error}
-            onSelect={handleDrop}
-            source='CoverPhoto'
-          />
-        ) : null}
-      </div>
+      <ClientOnly>
+        <div className={styles.button}>
+          {edit ? (
+            <ImageSelectionButton
+              imageName={messages.imageName}
+              hasImage={Boolean(image || updatedCoverPhoto)}
+              error={!!error}
+              onSelect={handleDrop}
+              source='CoverPhoto'
+            />
+          ) : null}
+        </div>
+      </ClientOnly>
     </div>
   )
 }

--- a/packages/web/src/components/nav-banner/NavBanner.module.css
+++ b/packages/web/src/components/nav-banner/NavBanner.module.css
@@ -1,10 +1,3 @@
-.wrapper {
-  position: relative;
-  width: 100%;
-  display: flex;
-  justify-content: center;
-}
-
 .background {
   position: absolute;
   top: 0;

--- a/packages/web/src/components/nav-banner/NavBanner.tsx
+++ b/packages/web/src/components/nav-banner/NavBanner.tsx
@@ -1,8 +1,10 @@
 import { ReactElement } from 'react'
 
 import { removeNullable } from '@audius/common/utils'
-import { Button, PopupMenu, IconSort as SortIcon } from '@audius/harmony'
+import { Flex, Button, PopupMenu, IconSort as SortIcon } from '@audius/harmony'
 import cn from 'classnames'
+
+import { ClientOnly } from 'components/client-only/ClientOnly'
 
 import styles from './NavBanner.module.css'
 
@@ -51,7 +53,7 @@ const NavBanner = (props: NavBannerProps) => {
   ].filter(removeNullable)
 
   return (
-    <div className={styles.wrapper}>
+    <Flex h={48} w='100%' justifyContent='center'>
       <div className={styles.background} />
       {!empty ? (
         <div
@@ -63,27 +65,29 @@ const NavBanner = (props: NavBannerProps) => {
 
           {isArtist && (
             <div className={styles.dropdown}>
-              {!dropdownDisabled ? (
-                <PopupMenu
-                  items={menuItems}
-                  anchorOrigin={{ vertical: 'bottom', horizontal: 'left' }}
-                  renderTrigger={(ref, triggerPopup) => (
-                    <Button
-                      ref={ref}
-                      size='small'
-                      variant='secondary'
-                      iconLeft={SortIcon}
-                      aria-label={messages.openSortButton}
-                      onClick={() => triggerPopup()}
-                    />
-                  )}
-                />
-              ) : null}
+              <ClientOnly>
+                {!dropdownDisabled ? (
+                  <PopupMenu
+                    items={menuItems}
+                    anchorOrigin={{ vertical: 'bottom', horizontal: 'left' }}
+                    renderTrigger={(ref, triggerPopup) => (
+                      <Button
+                        ref={ref}
+                        size='small'
+                        variant='secondary'
+                        iconLeft={SortIcon}
+                        aria-label={messages.openSortButton}
+                        onClick={() => triggerPopup()}
+                      />
+                    )}
+                  />
+                ) : null}
+              </ClientOnly>
             </div>
           )}
         </div>
       ) : null}
-    </div>
+    </Flex>
   )
 }
 

--- a/packages/web/src/components/profile-picture/ProfilePicture.jsx
+++ b/packages/web/src/components/profile-picture/ProfilePicture.jsx
@@ -1,16 +1,23 @@
 import { memo, useState, useEffect } from 'react'
 
+import { imageProfilePicEmpty } from '@audius/common/assets'
 import { SquareSizes } from '@audius/common/models'
+import { cacheUsersSelectors } from '@audius/common/store'
 import cn from 'classnames'
 import PropTypes from 'prop-types'
 import Lottie from 'react-lottie'
+import { useSelector } from 'react-redux'
 
 import loadingSpinner from 'assets/animations/loadingSpinner.json'
 import DynamicImage from 'components/dynamic-image/DynamicImage'
 import ImageSelectionButton from 'components/image-selection/ImageSelectionButton'
+import { StaticImage } from 'components/static-image/StaticImage'
 import { useUserProfilePicture } from 'hooks/useUserProfilePicture'
+import { useSsrContext } from 'ssr/SsrContext'
 
 import styles from './ProfilePicture.module.css'
+
+const { getUser } = cacheUsersSelectors
 
 const ProfilePicture = ({
   editMode,
@@ -34,6 +41,8 @@ const ProfilePicture = ({
   const [hasChanged, setHasChanged] = useState(false)
   const [processing, setProcessing] = useState(false)
   const [modalOpen, setModalOpen] = useState(false)
+  const user = useSelector((state) => getUser(state, { id: userId }))
+  const { isSsrEnabled } = useSsrContext()
 
   useEffect(() => {
     if (editMode) {
@@ -57,6 +66,8 @@ const ProfilePicture = ({
     setModalOpen(false)
   }
 
+  const ImageElement = isSsrEnabled ? StaticImage : DynamicImage
+
   return (
     <div
       className={cn(styles.profilePictureWrapper, {
@@ -67,7 +78,13 @@ const ProfilePicture = ({
       })}
     >
       <div className={styles.profilePictureBackground}>
-        <DynamicImage
+        <ImageElement
+          cid={user?.profile_picture_sizes}
+          size={SquareSizes.SIZE_480_BY_480}
+          imageUrl={
+            updatedProfilePicture ||
+            (!user?.profile_picture_sizes ? imageProfilePicEmpty : undefined)
+          }
           usePlaceholder={false}
           image={updatedProfilePicture || image}
           skeletonClassName={styles.profilePictureSkeleton}
@@ -88,7 +105,7 @@ const ProfilePicture = ({
               />
             </div>
           )}
-        </DynamicImage>
+        </ImageElement>
         {(editMode || showEdit) && (
           <ImageSelectionButton
             wrapperClassName={styles.imageSelectionButtonWrapper}

--- a/packages/web/src/components/profile-picture/ProfilePicture.module.css
+++ b/packages/web/src/components/profile-picture/ProfilePicture.module.css
@@ -20,11 +20,14 @@
   background-repeat: no-repeat;
   background-color: var(--default-profile-picture-background);
   overflow: hidden;
+  width: 100%;
+  height: 100%;
 
   display: flex;
   align-items: center;
   justify-content: center;
 }
+
 .profilePictureSkeleton {
   border-radius: 50%;
 }
@@ -85,9 +88,7 @@
 }
 
 .editMode.hasChanged:not(.modalOpen) .profilePictureBackground:hover .overlay,
-.editMode.hasChanged:not(.modalOpen)
-  .profilePictureBackground:hover
-  .imageSelectionButton {
+.editMode.hasChanged:not(.modalOpen) .profilePictureBackground:hover .imageSelectionButton {
   opacity: 1;
   pointer-events: all;
 }
@@ -98,6 +99,7 @@
 .loadingSkeleton :global(.ant-skeleton-header) {
   padding: 0 !important;
 }
+
 .profilePictureWrapper .loadingSkeleton :global(.ant-skeleton-avatar) {
   position: absolute;
   top: 0;

--- a/packages/web/src/components/stat-banner/StatBanner.tsx
+++ b/packages/web/src/components/stat-banner/StatBanner.tsx
@@ -18,6 +18,7 @@ import {
 import cn from 'classnames'
 
 import { ArtistRecommendationsPopup } from 'components/artist-recommendations/ArtistRecommendationsPopup'
+import { ClientOnly } from 'components/client-only/ClientOnly'
 import Stats, { StatProps } from 'components/stats/Stats'
 import SubscribeButton from 'components/subscribe-button/SubscribeButton'
 import { useFlag } from 'hooks/useRemoteConfig'
@@ -244,12 +245,14 @@ export const StatBanner = (props: StatsBannerProps) => {
               onFollow={onFollow}
               onUnfollow={onUnfollow}
             />
-            <ArtistRecommendationsPopup
-              anchorRef={followButtonRef}
-              artistId={profileId!}
-              isVisible={areArtistRecommendationsVisible}
-              onClose={onCloseArtistRecommendations!}
-            />
+            <ClientOnly>
+              <ArtistRecommendationsPopup
+                anchorRef={followButtonRef}
+                artistId={profileId!}
+                isVisible={areArtistRecommendationsVisible}
+                onClose={onCloseArtistRecommendations!}
+              />
+            </ClientOnly>
           </>
         </>
       )

--- a/packages/web/src/components/static-image/StaticImage.tsx
+++ b/packages/web/src/components/static-image/StaticImage.tsx
@@ -1,6 +1,6 @@
 import { ComponentPropsWithoutRef } from 'react'
 
-import { SquareSizes } from '@audius/common/models'
+import { WidthSizes, SquareSizes } from '@audius/common/models'
 import { Box, Flex } from '@audius/harmony'
 import {
   DiscoveryNodeSelector,
@@ -17,11 +17,15 @@ export type StaticImageProps = {
   // Image CID
   cid?: string | null
   // Size of image to select
-  size?: SquareSizes
+  size?: SquareSizes | WidthSizes
+  // Override image url. Used for updated profile picture and things
+  imageUrl?: string
   // Set height and width of wrapper container to 100%
   fullWidth?: boolean
   // Classes to apply to the wrapper
   wrapperClassName?: string
+  // Whether or not to blur the background image
+  useBlur?: boolean
 } & ComponentPropsWithoutRef<'img'>
 
 const sdkConfigs = {
@@ -50,9 +54,11 @@ export const StaticImage = (props: StaticImageProps) => {
   const {
     cid,
     size = SquareSizes.SIZE_1000_BY_1000,
+    imageUrl,
     fullWidth = false,
     wrapperClassName,
     children,
+    useBlur,
     ...other
   } = props
 
@@ -70,14 +76,35 @@ export const StaticImage = (props: StaticImageProps) => {
       className={wrapperClassName}
       css={{ overflow: 'hidden' }}
     >
-      <img height='100%' width='100%' src={url} {...other} />
+      <img
+        css={{
+          height: '100%',
+          width: '100%',
+          maxWidth: '100%',
+          objectFit: 'cover'
+        }}
+        src={imageUrl ?? url}
+        {...other}
+      />
+
+      {useBlur ? (
+        <Box
+          css={{
+            position: 'absolute',
+            height: '100%',
+            width: '100%',
+            backdropFilter: 'blur(25px)',
+            zIndex: 3
+          }}
+        />
+      ) : null}
       {children ? (
         <Flex
           h='100%'
           w='100%'
           alignItems='center'
           justifyContent='center'
-          css={{ zIndex: 3 }}
+          css={{ position: 'absolute', top: 0, left: 0, zIndex: 3 }}
         >
           {children}
         </Flex>

--- a/packages/web/src/pages/profile-page/components/desktop/ProfileLeftNav.tsx
+++ b/packages/web/src/pages/profile-page/components/desktop/ProfileLeftNav.tsx
@@ -6,6 +6,7 @@ import { animated } from 'react-spring'
 
 import { useSelector } from 'common/hooks/useSelector'
 import { AiGeneratedCallout } from 'components/ai-generated-button/AiGeneratedCallout'
+import { ClientOnly } from 'components/client-only/ClientOnly'
 import Input from 'components/data-entry/Input'
 import TextArea from 'components/data-entry/TextArea'
 import { RelatedArtists } from 'components/related-artists/RelatedArtists'
@@ -18,6 +19,7 @@ import ProfilePageBadge from 'components/user-badges/ProfilePageBadge'
 import { Type } from 'pages/profile-page/components/SocialLink'
 import SocialLinkInput from 'pages/profile-page/components/SocialLinkInput'
 import { ProfileTopTags } from 'pages/profile-page/components/desktop/ProfileTopTags'
+import { useSsrContext } from 'ssr/SsrContext'
 
 import { ProfileBio } from './ProfileBio'
 import { ProfileMutuals } from './ProfileMutuals'
@@ -93,6 +95,7 @@ export const ProfileLeftNav = (props: ProfileLeftNavProps) => {
   } = props
 
   const accountUser = useSelector(getAccountUser)
+  const { isSsrEnabled } = useSsrContext()
 
   const renderTipAudioButton = (_: any, style: object) => (
     <animated.div className={styles.tipAudioButtonContainer} style={style}>
@@ -179,40 +182,42 @@ export const ProfileLeftNav = (props: ProfileLeftNavProps) => {
         </div>
       </div>
     )
-  } else if (!loading && !isDeactivated) {
+  } else if ((!loading || isSsrEnabled) && !isDeactivated) {
     const showUploadChip = isOwner && !isArtist
     return (
       <div className={styles.about}>
         <ProfilePageBadge userId={userId} className={styles.badge} />
-        <ProfileBio
-          handle={handle}
-          bio={bio}
-          location={location}
-          website={website}
-          donation={donation}
-          created={created}
-          twitterHandle={twitterHandle}
-          instagramHandle={instagramHandle}
-          tikTokHandle={tikTokHandle}
-        />
-        {!accountUser || accountUser.user_id !== userId ? (
-          <OpacityTransition render={renderTipAudioButton} />
-        ) : null}
-        {allowAiAttribution ? (
-          <div className={styles.aiGeneratedCalloutContainer}>
-            <AiGeneratedCallout handle={handle} />
-          </div>
-        ) : null}
-        <SupportingList />
-        <div className={styles.profileBottomSection}>
-          <TopSupporters />
-          <ProfileMutuals />
-          <RelatedArtists />
-          {isArtist ? <ProfileTopTags /> : null}
-          {showUploadChip ? (
-            <UploadChip type='track' variant='nav' source='nav' />
+        <ClientOnly>
+          <ProfileBio
+            handle={handle}
+            bio={bio}
+            location={location}
+            website={website}
+            donation={donation}
+            created={created}
+            twitterHandle={twitterHandle}
+            instagramHandle={instagramHandle}
+            tikTokHandle={tikTokHandle}
+          />
+          {!accountUser || accountUser.user_id !== userId ? (
+            <OpacityTransition render={renderTipAudioButton} />
           ) : null}
-        </div>
+          {allowAiAttribution ? (
+            <div className={styles.aiGeneratedCalloutContainer}>
+              <AiGeneratedCallout handle={handle} />
+            </div>
+          ) : null}
+          <SupportingList />
+          <div className={styles.profileBottomSection}>
+            <TopSupporters />
+            <ProfileMutuals />
+            <RelatedArtists />
+            {isArtist ? <ProfileTopTags /> : null}
+            {showUploadChip ? (
+              <UploadChip type='track' variant='nav' source='nav' />
+            ) : null}
+          </div>
+        </ClientOnly>
       </div>
     )
   } else {

--- a/packages/web/src/pages/profile-page/components/desktop/ProfilePage.module.css
+++ b/packages/web/src/pages/profile-page/components/desktop/ProfilePage.module.css
@@ -4,11 +4,6 @@
   min-width: 788px;
 }
 
-.headerWrapper {
-  position: relative;
-  width: 100%;
-}
-
 /* Style for static profile wrapper content */
 
 .mask {
@@ -203,12 +198,6 @@
 }
 
 /* Style for content section */
-
-.inset {
-  display: flex;
-  flex-direction: column;
-}
-
 .content {
   max-width: 753px;
   padding-left: 229px;

--- a/packages/web/src/pages/profile-page/components/desktop/ProfilePage.tsx
+++ b/packages/web/src/pages/profile-page/components/desktop/ProfilePage.tsx
@@ -20,6 +20,8 @@ import {
   ProfileUser
 } from '@audius/common/store'
 import {
+  Box,
+  Flex,
   IconAlbum,
   IconCollectible as IconCollectibles,
   IconNote,
@@ -28,6 +30,7 @@ import {
 } from '@audius/harmony'
 
 import Card from 'components/card/desktop/Card'
+import { ClientOnly } from 'components/client-only/ClientOnly'
 import CollectiblesPage from 'components/collectibles/components/CollectiblesPage'
 import CoverPhoto from 'components/cover-photo/CoverPhoto'
 import CardLineup from 'components/lineup/CardLineup'
@@ -684,12 +687,14 @@ const ProfilePage = ({
     elements,
     pathname: profilePage(handle)
   })
+
   const {
     title = '',
     description = '',
     canonicalUrl = '',
     structuredData
   } = getUserPageSEOFields({ handle, userName: name, bio })
+
   return (
     <Page
       title={title}
@@ -699,8 +704,9 @@ const ProfilePage = ({
       variant='flush'
       contentClassName={styles.profilePageWrapper}
       scrollableSearch
+      fromOpacity={1}
     >
-      <div className={styles.headerWrapper}>
+      <Box w='100%'>
         <ProfileWrapping
           userId={userId}
           isDeactivated={!!profile?.is_deactivated}
@@ -769,7 +775,7 @@ const ProfilePage = ({
             onBlock={onBlock}
             onUnblock={onUnblock}
           />
-          <div className={styles.inset}>
+          <Flex direction='column'>
             <NavBanner
               empty={!profile || profile.is_deactivated}
               tabs={tabs}
@@ -781,30 +787,35 @@ const ProfilePage = ({
               onSortByPopular={onSortByPopular}
               shouldMaskContent={shouldMaskContent}
             />
-            <div className={styles.content}>
-              {profile && profile.is_deactivated ? (
-                <DeactivatedProfileTombstone />
-              ) : (
-                body
-              )}
-            </div>
-          </div>
+            <ClientOnly>
+              <div className={styles.content}>
+                {profile && profile.is_deactivated ? (
+                  <DeactivatedProfileTombstone />
+                ) : (
+                  body
+                )}
+              </div>
+            </ClientOnly>
+          </Flex>
         </Mask>
-      </div>
-      {profile ? (
-        <>
-          <BlockUserConfirmationModal
-            user={profile}
-            isVisible={showBlockUserConfirmationModal}
-            onClose={onCloseBlockUserConfirmationModal}
-          />
-          <UnblockUserConfirmationModal
-            user={profile}
-            isVisible={showUnblockUserConfirmationModal}
-            onClose={onCloseUnblockUserConfirmationModal}
-          />
-        </>
-      ) : null}
+      </Box>
+      {/* NOTE: KJ - This ClientOnly might not be necessary, but helps keep server computation down */}
+      <ClientOnly>
+        {profile ? (
+          <>
+            <BlockUserConfirmationModal
+              user={profile}
+              isVisible={showBlockUserConfirmationModal}
+              onClose={onCloseBlockUserConfirmationModal}
+            />
+            <UnblockUserConfirmationModal
+              user={profile}
+              isVisible={showUnblockUserConfirmationModal}
+              onClose={onCloseUnblockUserConfirmationModal}
+            />
+          </>
+        ) : null}
+      </ClientOnly>
     </Page>
   )
 }

--- a/packages/web/src/pages/profile-page/components/mobile/GrowingCoverPhoto.tsx
+++ b/packages/web/src/pages/profile-page/components/mobile/GrowingCoverPhoto.tsx
@@ -1,12 +1,18 @@
 import { useEffect, useCallback } from 'react'
 
 import { useInstanceVar } from '@audius/common/hooks'
+import { WidthSizes } from '@audius/common/models'
 // eslint-disable-next-line no-restricted-imports -- TODO: migrate to @react-spring/web
 import { useSpring, animated } from 'react-spring'
 
 import DynamicImage, {
   DynamicImageProps
 } from 'components/dynamic-image/DynamicImage'
+import {
+  StaticImage,
+  StaticImageProps
+} from 'components/static-image/StaticImage'
+import { useSsrContext } from 'ssr/SsrContext'
 
 // Scale the image by making it larger relative to y-pos and translate it up slightly (capping at -15px) so it
 // covers the gap made by overscroll.
@@ -33,12 +39,10 @@ const springConfig = {
  * Same props as DynamicImage.
  */
 const GrowingCoverPhoto = ({
-  image,
-  imageStyle,
-  wrapperClassName,
   children,
   ...rest
-}: DynamicImageProps) => {
+}: DynamicImageProps | StaticImageProps) => {
+  const { isSsrEnabled } = useSsrContext()
   const [getShouldTrackScroll, setShouldTrackScroll] = useInstanceVar(false)
   const [springProps, setSpringProps] = useSpring(() => ({
     to: {
@@ -105,6 +109,8 @@ const GrowingCoverPhoto = ({
     }
   }, [handleScrollEvent, handleReset, handleTouch])
 
+  const ImageElement = isSsrEnabled ? StaticImage : DynamicImage
+
   return (
     <animated.div
       style={{
@@ -117,14 +123,9 @@ const GrowingCoverPhoto = ({
         transform: springProps.y.interpolate(interpTransform)
       }}
     >
-      <DynamicImage
-        image={image}
-        imageStyle={imageStyle}
-        wrapperClassName={wrapperClassName}
-        {...rest}
-      >
+      <ImageElement size={WidthSizes.SIZE_640} {...rest}>
         {children}
-      </DynamicImage>
+      </ImageElement>
     </animated.div>
   )
 }

--- a/packages/web/src/pages/profile-page/components/mobile/ProfileHeader.module.css
+++ b/packages/web/src/pages/profile-page/components/mobile/ProfileHeader.module.css
@@ -20,7 +20,7 @@
 }
 
 .profilePictureWrapper {
-  position: absolute;
+  position: absolute !important;
   top: 37px;
   left: 11px;
   height: 82px;

--- a/packages/web/src/pages/profile-page/components/mobile/ProfileHeader.tsx
+++ b/packages/web/src/pages/profile-page/components/mobile/ProfileHeader.tsx
@@ -12,6 +12,7 @@ import {
   ProfilePictureSizes,
   CoverPhotoSizes
 } from '@audius/common/models'
+import { ProfileUser } from '@audius/common/store'
 import { formatCount } from '@audius/common/utils'
 import {
   IconArtistBadge as BadgeArtist,
@@ -29,8 +30,10 @@ import cn from 'classnames'
 
 import { make, useRecord } from 'common/store/analytics/actions'
 import { ArtistRecommendationsDropdown } from 'components/artist-recommendations/ArtistRecommendationsDropdown'
+import { ClientOnly } from 'components/client-only/ClientOnly'
 import DynamicImage from 'components/dynamic-image/DynamicImage'
 import Skeleton from 'components/skeleton/Skeleton'
+import { StaticImage } from 'components/static-image/StaticImage'
 import SubscribeButton from 'components/subscribe-button/SubscribeButton'
 import FollowsYouBadge from 'components/user-badges/FollowsYouBadge'
 import ProfilePageBadge from 'components/user-badges/ProfilePageBadge'
@@ -38,6 +41,7 @@ import UserBadges from 'components/user-badges/UserBadges'
 import { UserGeneratedText } from 'components/user-generated-text'
 import { useCoverPhoto } from 'hooks/useCoverPhoto'
 import { useUserProfilePicture } from 'hooks/useUserProfilePicture'
+import { useSsrContext } from 'ssr/SsrContext'
 import { FOLLOWING_USERS_ROUTE, FOLLOWERS_USERS_ROUTE } from 'utils/route'
 
 import GrowingCoverPhoto from './GrowingCoverPhoto'
@@ -81,6 +85,7 @@ const LoadingProfileHeader = () => {
 
 type ProfileHeaderProps = {
   isDeactivated: boolean
+  profile: ProfileUser
   name: string
   handle: string
   isArtist: boolean
@@ -131,6 +136,7 @@ function isEllipsisActive(e: HTMLElement) {
 
 const ProfileHeader = ({
   isDeactivated,
+  profile,
   name,
   handle,
   isArtist,
@@ -167,6 +173,7 @@ const ProfileHeader = ({
 }: ProfileHeaderProps) => {
   const [hasEllipsis, setHasEllipsis] = useState(false)
   const [isDescriptionMinimized, setIsDescriptionMinimized] = useState(true)
+  const { isSsrEnabled } = useSsrContext()
   const bioRef = useRef<HTMLElement | null>(null)
   const isEditing = mode === 'editing'
 
@@ -198,10 +205,7 @@ const ProfileHeader = ({
     }
   }, [website, donation, hasEllipsis, setHasEllipsis])
 
-  let { source: coverPhoto, shouldBlur } = useCoverPhoto(
-    userId,
-    WidthSizes.SIZE_2000
-  )
+  let { source: coverPhoto } = useCoverPhoto(userId, WidthSizes.SIZE_2000)
   coverPhoto = isDeactivated ? imageProfilePicEmpty : coverPhoto
   let coverPhotoStyle = {}
   if (coverPhoto === imageCoverPhotoBlank) {
@@ -288,34 +292,58 @@ const ProfileHeader = ({
 
   // If we're not loading, we know that
   // nullable fields such as userId are valid.
-  if (loading) {
+  if (loading && !isSsrEnabled) {
     return <LoadingProfileHeader />
   }
+
+  const ImageElement = isSsrEnabled ? StaticImage : DynamicImage
+
+  const isUserMissingImage =
+    !profile?.cover_photo_sizes && !profile?.profile_picture_sizes
 
   return (
     <div className={styles.headerContainer}>
       <GrowingCoverPhoto
+        cid={
+          profile?.cover_photo_sizes ?? profile?.profile_picture_sizes ?? null
+        }
+        imageUrl={
+          updatedCoverPhoto ??
+          (isUserMissingImage || isDeactivated
+            ? imageCoverPhotoBlank
+            : undefined)
+        }
         image={updatedCoverPhoto || coverPhoto}
         imageStyle={coverPhotoStyle}
         wrapperClassName={cn(styles.coverPhoto, {
           [styles.isEditing]: isEditing
         })}
-        useBlur={shouldBlur}
+        useBlur={Boolean(
+          !profile?.cover_photo_sizes && profile?.profile_picture_sizes
+        )}
       >
         {isArtist && !isEditing && !isDeactivated ? (
           <BadgeArtist className={styles.badgeArtist} />
         ) : null}
         {isEditing && <UploadStub onChange={onUpdateCoverPhoto} />}
       </GrowingCoverPhoto>
-      <DynamicImage
+      <ImageElement
         image={updatedProfilePicture || profilePicture}
+        cid={profile?.profile_picture_sizes}
+        size={SquareSizes.SIZE_150_BY_150}
+        imageUrl={
+          updatedProfilePicture ||
+          (isUserMissingImage || isDeactivated
+            ? imageProfilePicEmpty
+            : undefined)
+        }
         className={styles.profilePicture}
         wrapperClassName={cn(styles.profilePictureWrapper, {
           [styles.isEditing]: isEditing
         })}
       >
         {isEditing && <UploadStub onChange={onUpdateProfilePicture} />}
-      </DynamicImage>
+      </ImageElement>
       {!isEditing && !isDeactivated && (
         <div className={styles.artistInfo}>
           <div className={styles.titleContainer}>
@@ -337,32 +365,34 @@ const ProfileHeader = ({
                 <FollowsYouBadge userId={userId} />
               </div>
             </div>
-            <Flex gap='s' justifyContent='flex-end' flex={1}>
-              {following ? (
-                <SubscribeButton
-                  isSubscribed={isSubscribed}
-                  isFollowing={following}
-                  onToggleSubscribe={toggleNotificationSubscription}
-                />
-              ) : null}
-              {mode === 'owner' ? (
-                <Button
-                  variant='secondary'
-                  size='small'
-                  onClick={switchToEditMode}
-                  iconLeft={IconPencil}
-                >
-                  {messages.editProfile}
-                </Button>
-              ) : (
-                <FollowButton
-                  isFollowing={following}
-                  onFollow={() => onFollow(userId)}
-                  onUnfollow={() => onUnfollow(userId)}
-                  fullWidth={false}
-                />
-              )}
-            </Flex>
+            <ClientOnly>
+              <Flex gap='s' justifyContent='flex-end' flex={1}>
+                {following ? (
+                  <SubscribeButton
+                    isSubscribed={isSubscribed}
+                    isFollowing={following}
+                    onToggleSubscribe={toggleNotificationSubscription}
+                  />
+                ) : null}
+                {mode === 'owner' ? (
+                  <Button
+                    variant='secondary'
+                    size='small'
+                    onClick={switchToEditMode}
+                    iconLeft={IconPencil}
+                  >
+                    {messages.editProfile}
+                  </Button>
+                ) : (
+                  <FollowButton
+                    isFollowing={following}
+                    onFollow={() => onFollow(userId)}
+                    onUnfollow={() => onUnfollow(userId)}
+                    fullWidth={false}
+                  />
+                )}
+              </Flex>
+            </ClientOnly>
           </div>
           <div className={styles.artistMetrics}>
             <div className={styles.artistMetric}>

--- a/packages/web/src/pages/profile-page/components/mobile/ProfilePage.tsx
+++ b/packages/web/src/pages/profile-page/components/mobile/ProfilePage.tsx
@@ -29,6 +29,7 @@ import {
 import cn from 'classnames'
 
 import Card from 'components/card/mobile/Card'
+import { ClientOnly } from 'components/client-only/ClientOnly'
 import CollectiblesPage from 'components/collectibles/components/CollectiblesPage'
 import { HeaderContext } from 'components/header/mobile/HeaderContextProvider'
 import CardLineup from 'components/lineup/CardLineup'
@@ -42,6 +43,7 @@ import NavContext, {
 import TierExplainerDrawer from 'components/user-badges/TierExplainerDrawer'
 import useTabs, { TabHeader } from 'hooks/useTabs/useTabs'
 import { MIN_COLLECTIBLES_TIER } from 'pages/profile-page/ProfilePageProvider'
+import { useSsrContext } from 'ssr/SsrContext'
 import { collectionPage, profilePage } from 'utils/route'
 import { getUserPageSEOFields } from 'utils/seo'
 import { withNullGuard } from 'utils/withNullGuard'
@@ -300,6 +302,7 @@ const ProfilePage = g(
     onCloseArtistRecommendations
   }) => {
     const { setHeader } = useContext(HeaderContext)
+    const { isSsrEnabled } = useSsrContext()
     useEffect(() => {
       setHeader(null)
     }, [setHeader])
@@ -308,7 +311,7 @@ const ProfilePage = g(
     let content
     let profileTabs
     let profileElements
-    const isLoading = status === Status.LOADING
+    const isLoading = status === Status.LOADING && !isSsrEnabled
     const isEditing = mode === 'editing'
 
     // Set Nav-Bar Menu
@@ -643,7 +646,7 @@ const ProfilePage = g(
       content = (
         <div className={styles.contentContainer}>
           <div className={styles.tabs}>{tabs}</div>
-          {body}
+          <ClientOnly>{body}</ClientOnly>
         </div>
       )
     }
@@ -666,6 +669,7 @@ const ProfilePage = g(
         >
           <ProfileHeader
             isDeactivated={profile?.is_deactivated}
+            profile={profile}
             name={name}
             handle={handle}
             isArtist={isArtist}
@@ -707,7 +711,9 @@ const ProfilePage = g(
           />
           {content}
         </MobilePageContainer>
-        <TierExplainerDrawer />
+        <ClientOnly>
+          <TierExplainerDrawer />
+        </ClientOnly>
       </>
     )
   }

--- a/packages/web/src/ssr/profile/+route.tsx
+++ b/packages/web/src/ssr/profile/+route.tsx
@@ -1,4 +1,3 @@
-// NOTE: This ssr route is off until the profile page is rendered server-side
 import { makePageRoute } from 'ssr/util'
 
 export default makePageRoute('/@handle', 'Profile Page')


### PR DESCRIPTION
### Description
Add back the route for profile pages
Render profile pages on web with basic user info (user name, handle, profile pic, etc.)
Render profile page header on web mobile with cover photo as well

### How Has This Been Tested?
Lots of manual testing, but there is a timeout issue happening on main that I need to look into to get a full test and lighthouse score for these changes
