### PR TITLE
[C-3961] Fix sign up modal toast triggers

### DIFF
--- a/packages/web/src/common/store/pages/signon/actions.ts
+++ b/packages/web/src/common/store/pages/signon/actions.ts
@@ -3,7 +3,8 @@ import {
   InstagramProfile,
   TwitterProfile,
   TikTokProfile,
-  Image
+  Image,
+  toastActions
 } from '@audius/common/store'
 import { createCustomAction } from 'typesafe-actions'
 
@@ -437,10 +438,11 @@ export const clearToast = () => ({
   text: null
 })
 
-export const showRequiresAccountModal = () => ({
-  type: SET_TOAST,
-  text: 'Oops, it looks like you need an account to do that!'
-})
+export const showRequiresAccountModal = () =>
+  toastActions.toast({
+    content: 'Oops, it looks like you need an account to do that!',
+    timeout: 300000
+  })
 
 /**
  * Opens the signin/up modal in mobile and routes to the page on desktop

--- a/packages/web/src/common/store/pages/signon/actions.ts
+++ b/packages/web/src/common/store/pages/signon/actions.ts
@@ -66,7 +66,6 @@ export const NEXT_PAGE = 'SIGN_ON/NEXT_PAGE'
 export const PREVIOUS_PAGE = 'SIGN_ON/PREVIOUS_PAGE'
 export const GO_TO_PAGE = 'SIGN_ON/GO_TO_PAGE'
 
-export const SET_TOAST = 'SIGN_ON/SET_TOAST'
 export const UPDATE_ROUTE_ON_COMPLETION = 'SIGN_ON/UPDATE_ROUTE_ON_COMPLETION'
 export const UPDATE_ROUTE_ON_EXIT = 'SIGN_ON/UPDATE_ROUTE_ON_EXIT'
 
@@ -421,22 +420,6 @@ export function addFollowArtists(userIds: ID[]) {
 export function removeFollowArtists(userIds: ID[]) {
   return { type: REMOVE_FOLLOW_ARTISTS, userIds }
 }
-
-/**
- * Sets a toast appearing over signon
- */
-export const showToast = (text: string) => ({
-  type: SET_TOAST,
-  text
-})
-
-/**
- * Clears a toast appearing over signon
- */
-export const clearToast = () => ({
-  type: SET_TOAST,
-  text: null
-})
 
 export const showRequiresAccountModal = () =>
   toastActions.toast({

--- a/packages/web/src/common/store/pages/signon/reducer.js
+++ b/packages/web/src/common/store/pages/signon/reducer.js
@@ -31,7 +31,6 @@ import {
   SIGN_IN_FAILED,
   SIGN_IN_SUCCEEDED,
   CONFIGURE_META_MASK,
-  SET_TOAST,
   UPDATE_ROUTE_ON_COMPLETION,
   UPDATE_ROUTE_ON_EXIT,
   ADD_FOLLOW_ARTISTS,
@@ -74,7 +73,6 @@ const initialState = {
   profileImage: null, // Object with file blob & url
   coverPhoto: null, // Object with file blob & url
   status: 'editing', // 'editing', 'loading', 'success', or 'failure'
-  toastText: null,
   page: Pages.EMAIL,
   startedSignUpProcess: false,
   /** @deprecated */
@@ -407,12 +405,6 @@ const actionsMap = {
         error: action.error
       },
       otp: createTextField()
-    }
-  },
-  [SET_TOAST](state, action) {
-    return {
-      ...state,
-      toastText: action.text
     }
   },
   [UPDATE_ROUTE_ON_COMPLETION](state, action) {

--- a/packages/web/src/common/store/pages/signon/sagas.ts
+++ b/packages/web/src/common/store/pages/signon/sagas.ts
@@ -826,7 +826,7 @@ function* signIn(action: ReturnType<typeof signOnActions.signIn>) {
           accountAlreadyExisted: true
         })
       )
-      yield* put(signOnActions.showToast(messages.incompleteAccount))
+      yield* put(toastActions.toast({ content: messages.incompleteAccount }))
     } else {
       yield* put(
         signOnActions.signInFailed(

--- a/packages/web/src/common/store/pages/signon/sagas.ts
+++ b/packages/web/src/common/store/pages/signon/sagas.ts
@@ -813,7 +813,7 @@ function* signIn(action: ReturnType<typeof signOnActions.signIn>) {
           }
         })
       )
-      yield* put(signOnActions.showToast(messages.incompleteAccount))
+      yield* put(toastActions.toast({ content: messages.incompleteAccount }))
 
       const trackEvent = make(Name.SIGN_IN_WITH_INCOMPLETE_ACCOUNT, {
         handle: signInResponse.handle
@@ -1038,18 +1038,6 @@ function* watchFollowArtists() {
   yield* takeLatest(signOnActions.FOLLOW_ARTISTS, followArtists)
 }
 
-function* watchShowToast() {
-  yield* takeLatest(
-    signOnActions.SET_TOAST,
-    function* (action: ReturnType<typeof signOnActions.showToast>) {
-      if (action.text) {
-        yield* delay(5000)
-        yield* put(signOnActions.clearToast())
-      }
-    }
-  )
-}
-
 function* watchOpenSignOn() {
   yield* takeLatest(
     signOnActions.OPEN_SIGN_ON,
@@ -1085,7 +1073,6 @@ export default function sagas() {
     watchFollowArtists,
     watchGetArtistsToFollow,
     watchConfigureMetaMask,
-    watchShowToast,
     watchOpenSignOn,
     watchSignOnError,
     watchSendWelcomeEmail,

--- a/packages/web/src/common/store/pages/signon/selectors.ts
+++ b/packages/web/src/common/store/pages/signon/selectors.ts
@@ -31,7 +31,6 @@ export const getIsMobileSignOnVisible = (state: AppState) =>
   state.signOn.isMobileSignOnVisible
 export const getStatus = (state: AppState) => state.signOn.status
 export const getPage = (state: AppState) => state.signOn.page
-export const getToastText = (state: AppState) => state.signOn.toastText
 export const getRouteOnCompletion = (state: AppState) =>
   state.signOn.routeOnCompletion
 export const getRouteOnExit = (state: AppState) => state.signOn.routeOnExit

--- a/packages/web/src/common/store/pages/signon/types.ts
+++ b/packages/web/src/common/store/pages/signon/types.ts
@@ -64,7 +64,6 @@ export default interface SignOnPageState {
   suggestedFollowEntries: User[]
   followIds: ID[]
   status: EditingStatus
-  toastText: string | null
   hidePreviewHint: boolean
   followArtists: FollowArtists
   isMobileSignOnVisible: boolean

--- a/packages/web/src/components/toast/ToastContext.module.css
+++ b/packages/web/src/components/toast/ToastContext.module.css
@@ -3,6 +3,8 @@
   align-items: center;
   position: fixed;
   top: 0;
-  width: 100%;
   height: auto !important;
+  width: max-content;
+  max-width: 80%;
+  left: 50%;
 }

--- a/packages/web/src/components/toast/ToastContext.tsx
+++ b/packages/web/src/components/toast/ToastContext.tsx
@@ -28,8 +28,8 @@ const TOAST_SPACING = 40
 // toasts to a valid Y index into [FROM_POSITION, index * toast spacing + ENTER_POSITION]
 const interp = (i: number) => (y: number) =>
   y === FROM_POSITION
-    ? `translate3d(0,${y}px,0)`
-    : `translate3d(0, ${y + i * TOAST_SPACING}px, 0)`
+    ? `translate3d(-50%,${y}px,0)`
+    : `translate3d(-50%, ${y + i * TOAST_SPACING}px, 0)`
 
 type ToastContextProps = {
   toast: (content: string | JSX.Element, timeout?: number) => void

--- a/packages/web/src/components/toast/mobile/Toast.module.css
+++ b/packages/web/src/components/toast/mobile/Toast.module.css
@@ -5,7 +5,7 @@
   background-color: var(--harmony-secondary);
   padding: 12px 16px;
   margin: auto;
-  max-width: 80%;
+  max-width: 100%;
 
   color: var(--harmony-static-white);
   font-family: var(--harmony-font-family);


### PR DESCRIPTION
### Description

Fixes the "you need an account" toast trigger logic.
Also fixes a bug where the toast takes up 100% width and as a result covers stuff like the modal X button

### Changes
- Remove the one-off and now unused toast logic in sign on and replace with the standard toast logic
- Modify the toast css to use left:50% + translate(-50%) to position rather than width: 100% 
  - Position and size should be unchanged, its just now absolute

### How Has This Been Tested?

web:stage on desktop and mobile sizes (chrome)
