### PR TITLE
⚠️ [C-4064] Fix empty feed/trending pages

### DIFF
--- a/packages/web/src/app/web-player/WebPlayer.jsx
+++ b/packages/web/src/app/web-player/WebPlayer.jsx
@@ -991,7 +991,9 @@ class WebPlayer extends Component {
           </div>
           <PlayBarProvider />
           <ClientOnly>
-            <Modals />
+            <Suspense fallback={null}>
+              <Modals />
+            </Suspense>
             <ConnectedMusicConfetti />
           </ClientOnly>
 

--- a/packages/web/src/components/client-only/ClientOnly.tsx
+++ b/packages/web/src/components/client-only/ClientOnly.tsx
@@ -1,4 +1,6 @@
-import { ReactNode, useEffect, useState } from 'react'
+import { ReactNode, useContext } from 'react'
+
+import { SsrContext } from 'ssr/SsrContext'
 
 type ClientOnlyProps = {
   children: ReactNode
@@ -14,12 +16,7 @@ type ClientOnlyProps = {
 export const ClientOnly = (props: ClientOnlyProps) => {
   const { children, fallback = null } = props
 
-  const [isClientSide, setIsClientSide] = useState(false)
+  const { isServerSide } = useContext(SsrContext)
 
-  // useEffect only runs on the client
-  useEffect(() => {
-    setIsClientSide(true)
-  }, [])
-
-  return <>{isClientSide ? children : fallback}</>
+  return <>{isServerSide ? fallback : children}</>
 }


### PR DESCRIPTION
### Description

Combination of 2 things were causing empty lineups on feed + trending pages
- Modals were being lazy-loaded, but not wrapped in a suspense causing the "pause" to be bubbled up to the root level Suspense (in App.tsx).
- ClientOnly component was using a useEffect + useState to determine whether it was client- or server-side, triggering a page reload.

This PR addresses both of those:
- Wrap `Modals` in its own `Suspense`.
- Change `ClientOnly` to use `SsrContext` instead of `useEffect` which avoids the re-render

### How Has This Been Tested?

Local web stage
