### PR TITLE
Change internal sdk deps back to wildcard version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -132288,9 +132288,9 @@
       "version": "3.0.40",
       "license": "Apache-2.0",
       "dependencies": {
-        "@audius/fixed-decimal": "^0.0.21",
+        "@audius/fixed-decimal": "*",
         "@audius/hedgehog": "3.0.0-alpha.0",
-        "@audius/spl": "^0.0.27",
+        "@audius/spl": "*",
         "@babel/core": "^7.23.7",
         "@babel/plugin-proposal-class-static-block": "7.21.0",
         "@babel/runtime": "7.18.3",

--- a/packages/libs/package.json
+++ b/packages/libs/package.json
@@ -63,9 +63,9 @@
     "prepack": "turbo run build"
   },
   "dependencies": {
-    "@audius/fixed-decimal": "^0.0.21",
+    "@audius/fixed-decimal": "*",
     "@audius/hedgehog": "3.0.0-alpha.0",
-    "@audius/spl": "^0.0.27",
+    "@audius/spl": "*",
     "@babel/core": "^7.23.7",
     "@babel/plugin-proposal-class-static-block": "7.21.0",
     "@babel/runtime": "7.18.3",


### PR DESCRIPTION
### Description

The client release branch failed to cut because of some strange npm behavior. We had `"@audius/fixed-decimal": ^0.0.21` in the sdk package.json, which I presumed would pull the local version as long as the semver range was satisfied. However when CI bumped the version in `@audius/fixed-decimal` to 0.0.22, sdk attempted to pull this from the npm registry instead of from local.

Temporary fix is to go back to wildcard versions. We will need to change this if we want to publish sdk! Coming changes in the Better Releases & Changelogs project will address this with a more permanent process change + fix

### How Has This Been Tested?

Confirmed bumping versions and doing npm i works locally
