### PR TITLE
[C-4065, C-4067] Update sdk instances in ssr files to avoid http provider errors

### DIFF
--- a/packages/web/src/ssr/profile/+onBeforeRender.tsx
+++ b/packages/web/src/ssr/profile/+onBeforeRender.tsx
@@ -1,8 +1,33 @@
 import { Maybe } from '@audius/common/utils'
-import { full as FullSdk } from '@audius/sdk'
+import {
+  sdk,
+  full as FullSdk,
+  DiscoveryNodeSelector,
+  productionConfig,
+  stagingConfig,
+  developmentConfig
+} from '@audius/sdk'
 import type { PageContextServer } from 'vike/types'
 
-import { audiusSdk } from 'ssr/util'
+const sdkConfigs = {
+  production: productionConfig,
+  staging: stagingConfig,
+  development: developmentConfig
+}
+
+const discoveryNodeSelector = new DiscoveryNodeSelector({
+  bootstrapServices: (
+    sdkConfigs[process.env.VITE_ENVIRONMENT as keyof typeof sdkConfigs] ??
+    productionConfig
+  ).discoveryNodes
+})
+
+export const audiusSdk = sdk({
+  appName: process.env.VITE_PUBLIC_HOSTNAME ?? 'audius.co',
+  services: {
+    discoveryNodeSelector
+  }
+})
 
 export type ProfilePageProps = {
   user: Maybe<FullSdk.UserFull>

--- a/packages/web/src/ssr/profile/+onBeforeRender.tsx
+++ b/packages/web/src/ssr/profile/+onBeforeRender.tsx
@@ -1,33 +1,8 @@
 import { Maybe } from '@audius/common/utils'
-import {
-  sdk,
-  full as FullSdk,
-  DiscoveryNodeSelector,
-  productionConfig,
-  stagingConfig,
-  developmentConfig
-} from '@audius/sdk'
+import { full as FullSdk } from '@audius/sdk'
 import type { PageContextServer } from 'vike/types'
 
-const sdkConfigs = {
-  production: productionConfig,
-  staging: stagingConfig,
-  development: developmentConfig
-}
-
-const discoveryNodeSelector = new DiscoveryNodeSelector({
-  bootstrapServices: (
-    sdkConfigs[process.env.VITE_ENVIRONMENT as keyof typeof sdkConfigs] ??
-    productionConfig
-  ).discoveryNodes
-})
-
-export const audiusSdk = sdk({
-  appName: process.env.VITE_PUBLIC_HOSTNAME ?? 'audius.co',
-  services: {
-    discoveryNodeSelector
-  }
-})
+import { audiusSdk } from '../sdk'
 
 export type ProfilePageProps = {
   user: Maybe<FullSdk.UserFull>

--- a/packages/web/src/ssr/sdk.ts
+++ b/packages/web/src/ssr/sdk.ts
@@ -1,0 +1,27 @@
+import {
+  sdk,
+  DiscoveryNodeSelector,
+  productionConfig,
+  stagingConfig,
+  developmentConfig
+} from '@audius/sdk'
+
+const sdkConfigs = {
+  production: productionConfig,
+  staging: stagingConfig,
+  development: developmentConfig
+}
+
+const discoveryNodeSelector = new DiscoveryNodeSelector({
+  bootstrapServices: (
+    sdkConfigs[process.env.VITE_ENVIRONMENT as keyof typeof sdkConfigs] ??
+    productionConfig
+  ).discoveryNodes
+})
+
+export const audiusSdk = sdk({
+  appName: process.env.VITE_PUBLIC_HOSTNAME ?? 'audius.co',
+  services: {
+    discoveryNodeSelector
+  }
+})

--- a/packages/web/src/ssr/track/+onBeforeRender.tsx
+++ b/packages/web/src/ssr/track/+onBeforeRender.tsx
@@ -1,8 +1,33 @@
 import { Maybe } from '@audius/common/utils'
-import { full as FullSdk } from '@audius/sdk'
+import {
+  sdk,
+  full as FullSdk,
+  DiscoveryNodeSelector,
+  productionConfig,
+  stagingConfig,
+  developmentConfig
+} from '@audius/sdk'
 import type { PageContextServer } from 'vike/types'
 
-import { audiusSdk } from 'ssr/util'
+const sdkConfigs = {
+  production: productionConfig,
+  staging: stagingConfig,
+  development: developmentConfig
+}
+
+const discoveryNodeSelector = new DiscoveryNodeSelector({
+  bootstrapServices: (
+    sdkConfigs[process.env.VITE_ENVIRONMENT as keyof typeof sdkConfigs] ??
+    productionConfig
+  ).discoveryNodes
+})
+
+export const audiusSdk = sdk({
+  appName: process.env.VITE_PUBLIC_HOSTNAME ?? 'audius.co',
+  services: {
+    discoveryNodeSelector
+  }
+})
 
 export type TrackPageProps = {
   track: Maybe<FullSdk.TrackFull>

--- a/packages/web/src/ssr/track/+onBeforeRender.tsx
+++ b/packages/web/src/ssr/track/+onBeforeRender.tsx
@@ -1,33 +1,8 @@
 import { Maybe } from '@audius/common/utils'
-import {
-  sdk,
-  full as FullSdk,
-  DiscoveryNodeSelector,
-  productionConfig,
-  stagingConfig,
-  developmentConfig
-} from '@audius/sdk'
+import { full as FullSdk } from '@audius/sdk'
 import type { PageContextServer } from 'vike/types'
 
-const sdkConfigs = {
-  production: productionConfig,
-  staging: stagingConfig,
-  development: developmentConfig
-}
-
-const discoveryNodeSelector = new DiscoveryNodeSelector({
-  bootstrapServices: (
-    sdkConfigs[process.env.VITE_ENVIRONMENT as keyof typeof sdkConfigs] ??
-    productionConfig
-  ).discoveryNodes
-})
-
-export const audiusSdk = sdk({
-  appName: process.env.VITE_PUBLIC_HOSTNAME ?? 'audius.co',
-  services: {
-    discoveryNodeSelector
-  }
-})
+import { audiusSdk } from '../sdk'
 
 export type TrackPageProps = {
   track: Maybe<FullSdk.TrackFull>

--- a/packages/web/src/ssr/util.ts
+++ b/packages/web/src/ssr/util.ts
@@ -1,34 +1,7 @@
-import {
-  sdk,
-  DiscoveryNodeSelector,
-  productionConfig,
-  stagingConfig,
-  developmentConfig
-} from '@audius/sdk'
 import { resolveRoute } from 'vike/routing'
 import type { PageContextServer } from 'vike/types'
 
 import { staticRoutes } from 'utils/route'
-
-const sdkConfigs = {
-  production: productionConfig,
-  staging: stagingConfig,
-  development: developmentConfig
-}
-
-const discoveryNodeSelector = new DiscoveryNodeSelector({
-  bootstrapServices: (
-    sdkConfigs[process.env.VITE_ENVIRONMENT as keyof typeof sdkConfigs] ??
-    productionConfig
-  ).discoveryNodes
-})
-
-export const audiusSdk = sdk({
-  appName: process.env.VITE_PUBLIC_HOSTNAME ?? 'audius.co',
-  services: {
-    discoveryNodeSelector
-  }
-})
 
 const assetPaths = new Set(['src', 'assets', 'scripts', 'fonts', 'favicons'])
 


### PR DESCRIPTION
### Description
Small fix to create separate instances in the files where they are needed
This fix also got rid of the timeout issue which makes sense if the sdk instance was not being set up properly

### How Has This Been Tested?
Manually tested and tested on kj.audius.co
