### PR TITLE
[C-4017] Small fixes for ssr profile page rendering

### DIFF
--- a/packages/web/src/hooks/useTabs/useTabs.tsx
+++ b/packages/web/src/hooks/useTabs/useTabs.tsx
@@ -21,6 +21,7 @@ import { throttle } from 'lodash'
 import { animated, useTransition, useSpring } from 'react-spring'
 import { useDrag } from 'react-use-gesture'
 
+import { ClientOnly } from 'components/client-only/ClientOnly'
 import { SeoLink } from 'components/link'
 import Tooltip from 'components/tooltip/Tooltip'
 
@@ -268,20 +269,21 @@ const TabBar = memo(
           }
 
           return (
-            <Tooltip
-              text={tab.disabledTooltipText || disabledTabTooltipText}
-              placement='bottom'
-              disabled={!tooltipActive}
-              key={i}
-            >
-              {to && pathname ? (
-                <SeoLink {...rootProps} to={`${pathname}/${to}`}>
-                  {tabElement}
-                </SeoLink>
-              ) : (
-                <div {...rootProps}>{tabElement}</div>
-              )}
-            </Tooltip>
+            <ClientOnly key={i}>
+              <Tooltip
+                text={tab.disabledTooltipText || disabledTabTooltipText}
+                placement='bottom'
+                disabled={!tooltipActive}
+              >
+                {to && pathname ? (
+                  <SeoLink {...rootProps} to={`${pathname}/${to}`}>
+                    {tabElement}
+                  </SeoLink>
+                ) : (
+                  <div {...rootProps}>{tabElement}</div>
+                )}
+              </Tooltip>
+            </ClientOnly>
           )
         })}
       </div>

--- a/packages/web/src/pages/profile-page/components/mobile/ProfileHeader.tsx
+++ b/packages/web/src/pages/profile-page/components/mobile/ProfileHeader.tsx
@@ -495,14 +495,16 @@ const ProfileHeader = ({
               {isDescriptionMinimized ? messages.showMore : messages.showLess}
             </div>
           ) : null}
-          <ArtistRecommendationsDropdown
-            isVisible={areArtistRecommendationsVisible}
-            renderHeader={() => (
-              <p>Here are some accounts that vibe well with {name}</p>
-            )}
-            artistId={userId}
-            onClose={onCloseArtistRecommendations}
-          />
+          <ClientOnly>
+            <ArtistRecommendationsDropdown
+              isVisible={areArtistRecommendationsVisible}
+              renderHeader={() => (
+                <p>Here are some accounts that vibe well with {name}</p>
+              )}
+              artistId={userId}
+              onClose={onCloseArtistRecommendations}
+            />
+          </ClientOnly>
         </div>
       )}
       {mode === 'owner' && !isEditing && <UploadButton />}

--- a/packages/web/src/pages/profile-page/components/mobile/ProfilePage.tsx
+++ b/packages/web/src/pages/profile-page/components/mobile/ProfilePage.tsx
@@ -709,7 +709,7 @@ const ProfilePage = g(
             areArtistRecommendationsVisible={areArtistRecommendationsVisible}
             onCloseArtistRecommendations={onCloseArtistRecommendations}
           />
-          {content}
+          <ClientOnly>{content}</ClientOnly>
         </MobilePageContainer>
         <ClientOnly>
           <TierExplainerDrawer />


### PR DESCRIPTION
### Description
Small fixes to render the profile page properly on the server side

Scores before and after (ignore the blocking time)

Before:
<img width="955" alt="Screenshot 2024-03-19 at 6 23 45 PM" src="https://github.com/AudiusProject/audius-protocol/assets/23732287/27fc89cb-3b95-42a3-bab0-568caa5cbf83">

After:
<img width="890" alt="Screenshot 2024-03-25 at 5 28 00 PM" src="https://github.com/AudiusProject/audius-protocol/assets/23732287/5b6d0c92-32a0-4c6d-9cc6-e6b61bba028e">

### How Has This Been Tested?

Manual testing and testing on kj.audius.co
