### PR TITLE
[ONC-60] Don't delete tracks when deleting album

### DIFF
--- a/packages/common/src/services/audius-backend/AudiusBackend.ts
+++ b/packages/common/src/services/audius-backend/AudiusBackend.ts
@@ -1484,34 +1484,6 @@ export const audiusBackend = ({
     }
   }
 
-  async function deleteAlbum(playlistId: ID, trackIds: PlaylistTrackId[]) {
-    try {
-      console.debug(
-        `Deleting Album ${playlistId}, tracks: ${JSON.stringify(
-          trackIds.map((t) => t.track)
-        )}`
-      )
-
-      const trackDeletionPromises = trackIds.map((t) =>
-        audiusLibs.Track.deleteTrack(t.track)
-      )
-      const playlistDeletionPromise =
-        audiusLibs.EntityManager.deletePlaylist(playlistId)
-      const results = await Promise.all(
-        trackDeletionPromises.concat(playlistDeletionPromise)
-      )
-      const deleteTrackReceipts = results.slice(0, -1).map((r) => r.txReceipt)
-      const deletePlaylistReceipt = results.slice(-1)[0].txReceipt
-
-      return getLatestTxReceipt(
-        deleteTrackReceipts.concat(deletePlaylistReceipt)
-      )
-    } catch (error) {
-      console.error(getErrorMessage(error))
-      return { error }
-    }
-  }
-
   // TODO(C-2719)
   async function getSavedTracks(limit = 100, offset = 0) {
     try {
@@ -3265,7 +3237,6 @@ export const audiusBackend = ({
     createPlaylist,
     currentDiscoveryProvider,
     dangerouslySetPlaylistOrder,
-    deleteAlbum,
     deletePlaylist,
     deletePlaylistTrack,
     deleteTrack,

--- a/packages/common/src/services/audius-backend/AudiusBackend.ts
+++ b/packages/common/src/services/audius-backend/AudiusBackend.ts
@@ -36,7 +36,6 @@ import {
   FailureReason,
   ID,
   Name,
-  PlaylistTrackId,
   ProfilePictureSizes,
   SquareSizes,
   StringUSDC,

--- a/packages/common/src/store/pages/search-results/selectors.ts
+++ b/packages/common/src/store/pages/search-results/selectors.ts
@@ -33,10 +33,10 @@ export const makeGetSearchArtists = () => {
   )
 }
 
-const getSearchAlbums = (state: CommonState) =>{
+const getSearchAlbums = (state: CommonState) => {
   const albumIds = getBaseState(state).albumIds
   const collections = getCollections(state, { ids: albumIds || [] })
-  return albumIds?.map(id => collections[id]) ?? []
+  return albumIds?.map((id) => collections[id]) ?? []
 }
 
 export const makeGetSearchAlbums = () => {
@@ -55,7 +55,7 @@ export const makeGetSearchAlbums = () => {
 const getSearchPlaylists = (state: CommonState) => {
   const playlistIds = getBaseState(state).playlistIds
   const collections = getCollections(state, { ids: playlistIds || [] })
-  return playlistIds?.map(id => collections[id]) ?? []
+  return playlistIds?.map((id) => collections[id]) ?? []
 }
 
 export const makeGetSearchPlaylists = () => {

--- a/packages/web/src/common/store/cache/collections/commonSagas.ts
+++ b/packages/web/src/common/store/cache/collections/commonSagas.ts
@@ -5,7 +5,6 @@ import {
   PlaylistContents,
   ID,
   Collection,
-  PlaylistTrackId,
   UserCollectionMetadata,
   User,
   UserFollowees,


### PR DESCRIPTION
### Description

Historically the intended behavior when deleting an album was to delete the tracks. However, now that we have editable albums that allow users to add existing tracks, deleting the album can unintentionally delete tracks.

This PR makes albums behave similarly to playlists in the deleting the collection does not delete the tracks.

Was able to remove `deleteAlbum` codepath in AudiusBackend, but needed to keep `confirmDeleteAlbum` because it's slightly different from `confirmDeletePlaylist`

### How Has This Been Tested?

Tested that deleting album does not delete tracks