### PR TITLE
[PAY-2566] Check playlists_previously_containing_track in access checker

### DIFF
--- a/packages/discovery-provider/integration_tests/utils.py
+++ b/packages/discovery-provider/integration_tests/utils.py
@@ -236,6 +236,9 @@ def populate_mock_db(db, entities, block_offset=None):
                 playlists_containing_track=track_meta.get(
                     "playlists_containing_track", []
                 ),
+                playlists_previously_containing_track=track_meta.get(
+                    "playlists_previously_containing_track", {}
+                ),
             )
             session.add(track)
         for i, track_price_history_meta in enumerate(track_price_history):


### PR DESCRIPTION
### Description
* Access checker now grants access if the user purchased an album that previously contained the track, and the purchase occurred before the track was removed from the album
* Cleaned up `test_batch_access` so that the test cases match `test_access` 1-to-1.

### How Has This Been Tested?

Added integration test cases
