### PR TITLE
[ONC-62] Fix pause on track screen

### DIFF
--- a/packages/mobile/src/screens/track-screen/TrackScreenDetailsTile.tsx
+++ b/packages/mobile/src/screens/track-screen/TrackScreenDetailsTile.tsx
@@ -326,7 +326,11 @@ export const TrackScreenDetailsTile = ({
     ({ isPreview = false } = {}) => {
       if (isLineupLoading) return
 
-      if (isPlaying && isPreviewing && isPreview) {
+      if (
+        isPlaying &&
+        currentQueueItem.uid === uid &&
+        isPreviewing === isPreview
+      ) {
         dispatch(tracksActions.pause())
         recordPlay(track_id, false, true)
       } else if (


### PR DESCRIPTION
### Description

This PR broke pause: https://github.com/AudiusProject/audius-protocol/pull/7888

```
isPreviewing === isPreview
```
is required because `isPreviewing` will only ever be true for previews. We needed to add a check for `currentQueueItem.uid === uid` to allow other tracks to play immediately without pausing

### How Has This Been Tested?

Pause and play works properly locally
