### PR TITLE
Fix pause button pt 2

### DIFF
--- a/packages/mobile/src/screens/track-screen/TrackScreenDetailsTile.tsx
+++ b/packages/mobile/src/screens/track-screen/TrackScreenDetailsTile.tsx
@@ -326,11 +326,7 @@ export const TrackScreenDetailsTile = ({
     ({ isPreview = false } = {}) => {
       if (isLineupLoading) return
 
-      if (
-        isPlaying &&
-        currentQueueItem.uid === uid &&
-        isPreviewing === isPreview
-      ) {
+      if (isPlaying && isPlayingId && isPreviewing === isPreview) {
         dispatch(tracksActions.pause())
         recordPlay(track_id, false, true)
       } else if (
@@ -351,6 +347,7 @@ export const TrackScreenDetailsTile = ({
       uid,
       dispatch,
       isPlaying,
+      isPlayingId,
       isPreviewing,
       isLineupLoading
     ]


### PR DESCRIPTION
### Description

Use playingId instead of uid to determine if the track is playing. This is the same way the state of the button is determined

### How Has This Been Tested?

Tested:
* Playing from feed and pausing from track screen
* Playing from track screen and pausing from track screen
* Playing one track and pressing play on another track screen
