### PR TITLE
Fix challenge info decimal

### DIFF
--- a/packages/discovery-provider/src/api/v1/challenges.py
+++ b/packages/discovery-provider/src/api/v1/challenges.py
@@ -256,7 +256,7 @@ class ChallengeInfo(Resource):
                     "step_count": challenge.step_count,
                     "starting_block": challenge.starting_block,
                     "weekly_pool": challenge.weekly_pool,
-                    "weekly_pool_remaining": weekly_pool_remaining,
+                    "weekly_pool_remaining": float(weekly_pool_remaining),
                     "cooldown_days": challenge.cooldown_days,
                 }
                 if (


### PR DESCRIPTION
### Description

fixes json error
```
{
"message": "Object of type Decimal is not JSON serializable"
}
```

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._

tested against prod sandbox


```
{
"data": {
"challenge_id": "b",
"type": "aggregate",
"amount": "1",
"active": true,
"step_count": 2147483647,
"starting_block": 220157041,
"weekly_pool": "25000",
"weekly_pool_remaining": "52.0",
"cooldown_days": 7
}
}
```