### PR TITLE
[C-3996] Add Privacy manifest with privacy api reasons

### DIFF
--- a/packages/mobile/ios/AudiusReactNative.xcodeproj/project.pbxproj
+++ b/packages/mobile/ios/AudiusReactNative.xcodeproj/project.pbxproj
@@ -95,6 +95,7 @@
 		83F735A423C64C950040A4C5 /* AirplayEvent.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = AirplayEvent.m; sourceTree = "<group>"; };
 		871B6984E1993EF6CFB9B5A5 /* Pods-AudiusReactNative.staging.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AudiusReactNative.staging.release.xcconfig"; path = "Target Support Files/Pods-AudiusReactNative/Pods-AudiusReactNative.staging.release.xcconfig"; sourceTree = "<group>"; };
 		8FFE615B56774422849C5A08 /* AvenirNextLTPro-Light.otf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = "AvenirNextLTPro-Light.otf"; path = "../src/assets/fonts/AvenirNextLTPro-Light.otf"; sourceTree = "<group>"; };
+		9E5B39082BB49198009C765B /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
 		A20D1DBF23ABDA2B003D6530 /* Audius Music.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; name = "Audius Music.entitlements"; path = "AudiusReactNative/Audius Music.entitlements"; sourceTree = "<group>"; };
 		AA7D27FE2A68C20F008DF4D3 /* library_dark.riv */ = {isa = PBXFileReference; lastKnownFileType = file; name = library_dark.riv; path = Assets/library_dark.riv; sourceTree = "<group>"; };
 		AA7D27FF2A68C20F008DF4D3 /* library_matrix.riv */ = {isa = PBXFileReference; lastKnownFileType = file; name = library_matrix.riv; path = Assets/library_matrix.riv; sourceTree = "<group>"; };
@@ -208,6 +209,7 @@
 		83CBB9F61A601CBA00E9B192 = {
 			isa = PBXGroup;
 			children = (
+				9E5B39082BB49198009C765B /* PrivacyInfo.xcprivacy */,
 				13B32CE623D2782B002F0526 /* SampleSwiftFile.swift */,
 				13B07FAE1A68108700A75B9A /* AudiusReactNative */,
 				832341AE1AAA6A7D00B99B32 /* Libraries */,

--- a/packages/mobile/ios/PrivacyInfo.xcprivacy
+++ b/packages/mobile/ios/PrivacyInfo.xcprivacy
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+ <key>NSPrivacyAccessedAPITypes</key>
+ <array>
+  <dict>
+   <key>NSPrivacyAccessedAPIType</key>
+   <string>NSPrivacyAccessedAPICategoryFileTimestamp</string>
+   <key>NSPrivacyAccessedAPITypeReasons</key>
+   <array>
+    <string>C617.1</string>
+   </array>
+  </dict>
+  <dict>
+   <key>NSPrivacyAccessedAPIType</key>
+   <string>NSPrivacyAccessedAPICategoryDiskSpace</string>
+   <key>NSPrivacyAccessedAPITypeReasons</key>
+   <array>
+    <string>E174.1</string>
+   </array>
+  </dict>
+ </array>
+</dict>
+</plist>


### PR DESCRIPTION
### Description

* Add `PrivacyInfo.xcprivacy` following steps outlined [here](https://jochen-holzer.medium.com/embrace-the-evolution-preparing-your-ios-app-for-the-required-reason-api-38f2d12bbce5) and [here](https://developer.apple.com/documentation/bundleresources/privacy_manifest_files/describing_use_of_required_reason_api)
* For `NSPrivacyAccessedAPICategoryFileTimestamp` added the `C617.1` reason which reads as:
    > Declare this reason to access the timestamps, size, or other metadata of files inside the app container, app group container, or the app’s CloudKit container.
* For `NSPrivacyAccessedAPICategoryDiskSpace` added the `E174.1` reason which reads as:
    > Declare this reason to check whether there is sufficient disk space to write files, or to check whether the disk space is low so that the app can delete files when the disk space is low. The app must behave differently based on disk space in a way that is observable to users. Information accessed for this reason, or any derived information, may not be sent off-device. There is an exception that allows the app to avoid downloading files from a server when disk space is insufficient.
    
Please let me know if these are not the correct reasons.

### How Has This Been Tested?

Confirmed privacy manifest is correct in xcode and the app builds
