### PR TITLE
[C-4079] Add rewards cooldown to web

### DIFF
--- a/packages/common/src/models/AudioRewards.ts
+++ b/packages/common/src/models/AudioRewards.ts
@@ -12,6 +12,7 @@ export type UserChallenge = {
   user_id: string
   amount: number
   disbursed_amount: number
+  cooldown_days: number
 }
 
 export type Specifier = string

--- a/packages/common/src/services/remote-config/feature-flags.ts
+++ b/packages/common/src/services/remote-config/feature-flags.ts
@@ -57,7 +57,8 @@ export enum FeatureFlags {
   EDIT_ALBUMS = 'edit_albums',
   COINFLOW_OFFRAMP_ENABLED = 'coinflow_offramp_enabled',
   TIKTOK_NATIVE_AUTH = 'tiktok_native_auth',
-  PREMIUM_ALBUMS_ENABLED = 'premium_albums_enabled'
+  PREMIUM_ALBUMS_ENABLED = 'premium_albums_enabled',
+  REWARDS_COOLDOWN = 'rewards_cooldown'
 }
 
 type FlagDefaults = Record<FeatureFlags, boolean>
@@ -130,5 +131,6 @@ export const flagDefaults: FlagDefaults = {
   [FeatureFlags.EDIT_ALBUMS]: false,
   [FeatureFlags.COINFLOW_OFFRAMP_ENABLED]: false,
   [FeatureFlags.TIKTOK_NATIVE_AUTH]: true,
-  [FeatureFlags.PREMIUM_ALBUMS_ENABLED]: false
+  [FeatureFlags.PREMIUM_ALBUMS_ENABLED]: false,
+  [FeatureFlags.REWARDS_COOLDOWN]: false
 }

--- a/packages/common/src/store/challenges/selectors/optimistic-challenges.ts
+++ b/packages/common/src/store/challenges/selectors/optimistic-challenges.ts
@@ -96,7 +96,7 @@ const toOptimisticChallenge = (
   if (challenge.challenge_id === 'mobile-install' && isNativeMobile) {
     challengeOverridden.is_complete = true
   }
-
+  const isCooldownChallenge = challenge.cooldown_days > 0
   const state = getUserChallengeState(challengeOverridden)
   // For aggregate challenges, we show the total amount
   // you'd get when completing every step of the challenge
@@ -105,16 +105,15 @@ const toOptimisticChallenge = (
     challenge.challenge_type === 'aggregate'
       ? challenge.amount * challenge.max_steps
       : challenge.amount
-  const claimableAmount =
-    challengeOverridden.challenge_type !== 'aggregate'
-      ? state === 'completed'
-        ? totalAmount
-        : 0
-      : undisbursed.reduce<number>(
-          (acc, val) =>
-            isCooldownChallengeClaimable(val) ? acc + val.amount : acc + 0,
-          0
-        )
+  const claimableAmount = isCooldownChallenge
+    ? undisbursed.reduce<number>(
+        (acc, val) =>
+          isCooldownChallengeClaimable(val) ? acc + val.amount : acc + 0,
+        0
+      )
+    : state === 'completed'
+    ? totalAmount
+    : 0
 
   const undisbursedSpecifiers = undisbursed.reduce(
     (acc, c) => [...acc, { specifier: c.specifier, amount: c.amount }],
@@ -127,7 +126,8 @@ const toOptimisticChallenge = (
     state,
     totalAmount,
     claimableAmount,
-    undisbursedSpecifiers
+    undisbursedSpecifiers,
+    cooldown_days: challenge.cooldown_days
   }
 }
 

--- a/packages/common/src/store/challenges/selectors/optimistic-challenges.ts
+++ b/packages/common/src/store/challenges/selectors/optimistic-challenges.ts
@@ -96,7 +96,7 @@ const toOptimisticChallenge = (
   if (challenge.challenge_id === 'mobile-install' && isNativeMobile) {
     challengeOverridden.is_complete = true
   }
-  const isCooldownChallenge = challenge.cooldown_days > 0
+
   const state = getUserChallengeState(challengeOverridden)
   // For aggregate challenges, we show the total amount
   // you'd get when completing every step of the challenge
@@ -105,15 +105,16 @@ const toOptimisticChallenge = (
     challenge.challenge_type === 'aggregate'
       ? challenge.amount * challenge.max_steps
       : challenge.amount
-  const claimableAmount = isCooldownChallenge
-    ? undisbursed.reduce<number>(
-        (acc, val) =>
-          isCooldownChallengeClaimable(val) ? acc + val.amount : acc + 0,
-        0
-      )
-    : state === 'completed'
-    ? totalAmount
-    : 0
+  const claimableAmount =
+    challengeOverridden.challenge_type !== 'aggregate'
+      ? state === 'completed'
+        ? totalAmount
+        : 0
+      : undisbursed.reduce<number>(
+          (acc, val) =>
+            isCooldownChallengeClaimable(val) ? acc + val.amount : acc + 0,
+          0
+        )
 
   const undisbursedSpecifiers = undisbursed.reduce(
     (acc, c) => [...acc, { specifier: c.specifier, amount: c.amount }],
@@ -126,8 +127,7 @@ const toOptimisticChallenge = (
     state,
     totalAmount,
     claimableAmount,
-    undisbursedSpecifiers,
-    cooldown_days: challenge.cooldown_days
+    undisbursedSpecifiers
   }
 }
 

--- a/packages/web/src/common/store/pages/audio-rewards/store.test.ts
+++ b/packages/web/src/common/store/pages/audio-rewards/store.test.ts
@@ -479,7 +479,8 @@ describe.skip('Rewards Page Sagas', () => {
         challenge_type: 'numeric',
         specifier: '1',
         user_id: '1',
-        disbursed_amount: 7
+        disbursed_amount: 7,
+        cooldown_days: 0
       },
       {
         challenge_id: 'referrals',
@@ -492,7 +493,8 @@ describe.skip('Rewards Page Sagas', () => {
         challenge_type: 'numeric',
         specifier: '1',
         user_id: '1',
-        disbursed_amount: 5
+        disbursed_amount: 5,
+        cooldown_days: 0
       },
       {
         challenge_id: 'track-upload',
@@ -505,7 +507,8 @@ describe.skip('Rewards Page Sagas', () => {
         challenge_type: 'numeric',
         specifier: '1',
         user_id: '1',
-        disbursed_amount: 3
+        disbursed_amount: 3,
+        cooldown_days: 0
       }
     ]
     const fetchUserChallengesProvisions: StaticProvider[] = [
@@ -614,7 +617,8 @@ describe.skip('Rewards Page Sagas', () => {
         challenge_type: 'numeric',
         specifier: '1',
         user_id: '1',
-        disbursed_amount: 7
+        disbursed_amount: 7,
+        cooldown_days: 0
       }
     ]
 
@@ -667,7 +671,8 @@ describe.skip('Rewards Page Sagas', () => {
         challenge_type: 'numeric',
         specifier: '1',
         user_id: '1',
-        disbursed_amount: 2
+        disbursed_amount: 2,
+        cooldown_days: 0
       }
     ]
 

--- a/packages/web/src/pages/audio-rewards-page/components/modals/ChallengeRewardsModal/ChallengeRewardsModal.tsx
+++ b/packages/web/src/pages/audio-rewards-page/components/modals/ChallengeRewardsModal/ChallengeRewardsModal.tsx
@@ -386,7 +386,7 @@ const ChallengeRewardsBody = ({ dismissModal }: BodyProps) => {
   const { isEnabled: isRewardsCooldownEnabled } = useFeatureFlag(
     FeatureFlags.REWARDS_COOLDOWN
   )
-  if (isRewardsCooldownEnabled && challenge?.cooldown_days) {
+  if (isRewardsCooldownEnabled && challenge && challenge.cooldown_days > 0) {
     return (
       <CooldownRewardsModalContent
         errorContent={errorContent}

--- a/packages/web/src/pages/audio-rewards-page/components/modals/ChallengeRewardsModal/ChallengeRewardsModal.tsx
+++ b/packages/web/src/pages/audio-rewards-page/components/modals/ChallengeRewardsModal/ChallengeRewardsModal.tsx
@@ -386,11 +386,6 @@ const ChallengeRewardsBody = ({ dismissModal }: BodyProps) => {
   const { isEnabled: isRewardsCooldownEnabled } = useFeatureFlag(
     FeatureFlags.REWARDS_COOLDOWN
   )
-  console.log(
-    'asdf isRewardsCooldownEnabled: ',
-    isRewardsCooldownEnabled,
-    challenge
-  )
   if (isRewardsCooldownEnabled && challenge?.cooldown_days) {
     return (
       <CooldownRewardsModalContent

--- a/packages/web/src/pages/audio-rewards-page/components/modals/ChallengeRewardsModal/ChallengeRewardsModal.tsx
+++ b/packages/web/src/pages/audio-rewards-page/components/modals/ChallengeRewardsModal/ChallengeRewardsModal.tsx
@@ -294,14 +294,13 @@ const ChallengeRewardsBody = ({ dismissModal }: BodyProps) => {
           challenge?.state === 'completed' || challenge?.state === 'disbursed'
       })}
     >
-      {challenge?.state === 'incomplete' && (
+      {challenge?.state === 'incomplete' ? (
         <h3 className={styles.incomplete}>Incomplete</h3>
-      )}
-      {(challenge?.state === 'completed' ||
-        challenge?.state === 'disbursed') && (
+      ) : null}
+      {challenge?.state === 'completed' || challenge?.state === 'disbursed' ? (
         <h3 className={styles.complete}>Complete</h3>
-      )}
-      {challenge?.state === 'in_progress' && progressLabel && (
+      ) : null}
+      {challenge?.state === 'in_progress' && progressLabel ? (
         <h3 className={styles.inProgress}>
           {fillString(
             progressLabel,
@@ -309,7 +308,7 @@ const ChallengeRewardsBody = ({ dismissModal }: BodyProps) => {
             formatNumberCommas(challenge?.max_steps?.toString() ?? '')
           )}
         </h3>
-      )}
+      ) : null}
     </div>
   )
 
@@ -433,7 +432,7 @@ const ChallengeRewardsBody = ({ dismissModal }: BodyProps) => {
               </div>
               {progressStatusLabel}
             </div>
-            {modalType === 'profile-completion' && <ProfileChecks />}
+            {modalType === 'profile-completion' ? <ProfileChecks /> : null}
           </>
         ) : (
           <div className={styles.progressCard}>
@@ -441,28 +440,28 @@ const ChallengeRewardsBody = ({ dismissModal }: BodyProps) => {
               {progressDescription}
               {progressReward}
             </div>
-            {showProgressBar && (
+            {showProgressBar ? (
               <div className={wm(styles.progressBarSection)}>
-                {modalType === 'profile-completion' && <ProfileChecks />}
+                {modalType === 'profile-completion' ? <ProfileChecks /> : null}
                 <ProgressBar
                   className={wm(styles.progressBar)}
                   value={currentStepCount}
                   max={challenge?.max_steps}
                 />
               </div>
-            )}
+            ) : null}
             {progressStatusLabel}
           </div>
         )}
 
-        {userHandle && (modalType === 'referrals' || modalType === 'ref-v') && (
+        {userHandle && (modalType === 'referrals' || modalType === 'ref-v') ? (
           <div className={wm(styles.buttonContainer)}>
             <TwitterShareButton modalType={modalType} inviteLink={inviteLink} />
             <div className={styles.buttonSpacer} />
             <InviteLink inviteLink={inviteLink} />
           </div>
-        )}
-        {modalType === 'mobile-install' && (
+        ) : null}
+        {modalType === 'mobile-install' ? (
           <div className={wm(styles.qrContainer)}>
             <img className={styles.qr} src={QRCode} alt='QR Code' />
             <div className={styles.qrTextContainer}>
@@ -470,8 +469,8 @@ const ChallengeRewardsBody = ({ dismissModal }: BodyProps) => {
               <h3 className={styles.qrSubtext}>{messages.qrSubtext}</h3>
             </div>
           </div>
-        )}
-        {buttonLink && challenge?.state !== 'completed' && (
+        ) : null}
+        {buttonLink && challenge?.state !== 'completed' ? (
           <Button
             variant='primary'
             fullWidth={isMobile}
@@ -481,7 +480,7 @@ const ChallengeRewardsBody = ({ dismissModal }: BodyProps) => {
           >
             {buttonInfo?.label}
           </Button>
-        )}
+        ) : null}
         <div className={wm(styles.claimRewardWrapper)}>
           {audioToClaim > 0 ? (
             <>

--- a/packages/web/src/pages/audio-rewards-page/components/modals/ChallengeRewardsModal/ChallengeRewardsModal.tsx
+++ b/packages/web/src/pages/audio-rewards-page/components/modals/ChallengeRewardsModal/ChallengeRewardsModal.tsx
@@ -1,5 +1,7 @@
 import { useCallback, useEffect, useContext, useMemo } from 'react'
 
+import { useFeatureFlag } from '@audius/common/hooks'
+import { FeatureFlags } from '@audius/common/services'
 import {
   accountSelectors,
   challengesSelectors,
@@ -49,6 +51,7 @@ import PurpleBox from '../../PurpleBox'
 import ModalDrawer from '../ModalDrawer'
 
 import { AudioMatchingRewardsModalContent } from './AudioMatchingRewardsModalContent'
+import { CooldownRewardsModalContent } from './CooldownRewardsModalContent'
 import { ProgressDescription } from './ProgressDescription'
 import { ProgressReward } from './ProgressReward'
 import styles from './styles.module.css'
@@ -380,113 +383,138 @@ const ChallengeRewardsBody = ({ dismissModal }: BodyProps) => {
     claimStatus === ClaimStatus.ERROR ? (
       <div className={styles.claimError}>{getErrorMessage(aaoErrorCode)}</div>
     ) : null
-
-  return isAudioMatchingChallenge(modalType) ? (
-    <AudioMatchingRewardsModalContent
-      errorContent={errorContent}
-      onNavigateAway={dismissModal}
-      onClaimRewardClicked={onClaimRewardClicked}
-      claimInProgress={claimInProgress}
-      challenge={challenge}
-      challengeName={modalType}
-    />
-  ) : (
-    <div className={wm(styles.container)}>
-      {isMobile ? (
-        <>
-          {progressDescription}
-          <div className={wm(styles.progressCard)}>
-            <div className={wm(styles.progressInfo)}>
-              {progressReward}
-              {showProgressBar ? (
-                <div className={wm(styles.progressBarSection)}>
-                  <h3>Progress</h3>
-                  <ProgressBar
-                    className={wm(styles.progressBar)}
-                    value={currentStepCount}
-                    max={challenge?.max_steps}
-                  />
-                </div>
-              ) : null}
+  const { isEnabled: isRewardsCooldownEnabled } = useFeatureFlag(
+    FeatureFlags.REWARDS_COOLDOWN
+  )
+  console.log(
+    'asdf isRewardsCooldownEnabled: ',
+    isRewardsCooldownEnabled,
+    challenge
+  )
+  if (isRewardsCooldownEnabled && challenge?.cooldown_days) {
+    return (
+      <CooldownRewardsModalContent
+        errorContent={errorContent}
+        onNavigateAway={dismissModal}
+        onClaimRewardClicked={onClaimRewardClicked}
+        claimInProgress={claimInProgress}
+        challenge={challenge}
+        challengeName={modalType}
+        onClickProgress={goToRoute}
+        progressIcon={buttonInfo?.rightIcon}
+        progressLabel={buttonInfo?.label}
+      />
+    )
+  } else if (!isRewardsCooldownEnabled && isAudioMatchingChallenge(modalType)) {
+    return (
+      <AudioMatchingRewardsModalContent
+        errorContent={errorContent}
+        onNavigateAway={dismissModal}
+        onClaimRewardClicked={onClaimRewardClicked}
+        claimInProgress={claimInProgress}
+        challenge={challenge}
+        challengeName={modalType}
+      />
+    )
+  } else {
+    return (
+      <div className={wm(styles.container)}>
+        {isMobile ? (
+          <>
+            {progressDescription}
+            <div className={wm(styles.progressCard)}>
+              <div className={wm(styles.progressInfo)}>
+                {progressReward}
+                {showProgressBar ? (
+                  <div className={wm(styles.progressBarSection)}>
+                    <h3>Progress</h3>
+                    <ProgressBar
+                      className={wm(styles.progressBar)}
+                      value={currentStepCount}
+                      max={challenge?.max_steps}
+                    />
+                  </div>
+                ) : null}
+              </div>
+              {progressStatusLabel}
             </div>
+            {modalType === 'profile-completion' && <ProfileChecks />}
+          </>
+        ) : (
+          <div className={styles.progressCard}>
+            <div className={styles.progressInfo}>
+              {progressDescription}
+              {progressReward}
+            </div>
+            {showProgressBar && (
+              <div className={wm(styles.progressBarSection)}>
+                {modalType === 'profile-completion' && <ProfileChecks />}
+                <ProgressBar
+                  className={wm(styles.progressBar)}
+                  value={currentStepCount}
+                  max={challenge?.max_steps}
+                />
+              </div>
+            )}
             {progressStatusLabel}
           </div>
-          {modalType === 'profile-completion' && <ProfileChecks />}
-        </>
-      ) : (
-        <div className={styles.progressCard}>
-          <div className={styles.progressInfo}>
-            {progressDescription}
-            {progressReward}
-          </div>
-          {showProgressBar && (
-            <div className={wm(styles.progressBarSection)}>
-              {modalType === 'profile-completion' && <ProfileChecks />}
-              <ProgressBar
-                className={wm(styles.progressBar)}
-                value={currentStepCount}
-                max={challenge?.max_steps}
-              />
-            </div>
-          )}
-          {progressStatusLabel}
-        </div>
-      )}
+        )}
 
-      {userHandle && (modalType === 'referrals' || modalType === 'ref-v') && (
-        <div className={wm(styles.buttonContainer)}>
-          <TwitterShareButton modalType={modalType} inviteLink={inviteLink} />
-          <div className={styles.buttonSpacer} />
-          <InviteLink inviteLink={inviteLink} />
-        </div>
-      )}
-      {modalType === 'mobile-install' && (
-        <div className={wm(styles.qrContainer)}>
-          <img className={styles.qr} src={QRCode} alt='QR Code' />
-          <div className={styles.qrTextContainer}>
-            <h2 className={styles.qrText}>{messages.qrText}</h2>
-            <h3 className={styles.qrSubtext}>{messages.qrSubtext}</h3>
+        {userHandle && (modalType === 'referrals' || modalType === 'ref-v') && (
+          <div className={wm(styles.buttonContainer)}>
+            <TwitterShareButton modalType={modalType} inviteLink={inviteLink} />
+            <div className={styles.buttonSpacer} />
+            <InviteLink inviteLink={inviteLink} />
           </div>
-        </div>
-      )}
-      {buttonLink && challenge?.state !== 'completed' && (
-        <Button
-          variant='primary'
-          fullWidth={isMobile}
-          onClick={goToRoute}
-          iconLeft={buttonInfo?.leftIcon}
-          iconRight={buttonInfo?.rightIcon}
-        >
-          {buttonInfo?.label}
-        </Button>
-      )}
-      <div className={wm(styles.claimRewardWrapper)}>
-        {audioToClaim > 0 ? (
-          <>
-            <div className={styles.claimRewardAmountLabel}>
-              {`${audioToClaim} ${messages.claimAmountLabel}`}
+        )}
+        {modalType === 'mobile-install' && (
+          <div className={wm(styles.qrContainer)}>
+            <img className={styles.qr} src={QRCode} alt='QR Code' />
+            <div className={styles.qrTextContainer}>
+              <h2 className={styles.qrText}>{messages.qrText}</h2>
+              <h3 className={styles.qrSubtext}>{messages.qrSubtext}</h3>
             </div>
-            <Button
-              variant='primary'
-              isLoading={claimInProgress}
-              iconRight={IconCheck}
-              onClick={onClaimRewardClicked}
-            >
-              {messages.claimYourReward}
-            </Button>
-          </>
-        ) : null}
-        {audioClaimedSoFar > 0 && challenge?.state !== 'disbursed' ? (
-          <div className={styles.claimRewardClaimedAmountLabel}>
-            {`(${formatNumberCommas(audioClaimedSoFar)} ${
-              messages.claimedSoFar
-            })`}
           </div>
-        ) : null}
+        )}
+        {buttonLink && challenge?.state !== 'completed' && (
+          <Button
+            variant='primary'
+            fullWidth={isMobile}
+            onClick={goToRoute}
+            iconLeft={buttonInfo?.leftIcon}
+            iconRight={buttonInfo?.rightIcon}
+          >
+            {buttonInfo?.label}
+          </Button>
+        )}
+        <div className={wm(styles.claimRewardWrapper)}>
+          {audioToClaim > 0 ? (
+            <>
+              <div className={styles.claimRewardAmountLabel}>
+                {`${audioToClaim} ${messages.claimAmountLabel}`}
+              </div>
+              <Button
+                variant='primary'
+                isLoading={claimInProgress}
+                iconRight={IconCheck}
+                onClick={onClaimRewardClicked}
+              >
+                {messages.claimYourReward}
+              </Button>
+            </>
+          ) : null}
+          {audioClaimedSoFar > 0 && challenge?.state !== 'disbursed' ? (
+            <div className={styles.claimRewardClaimedAmountLabel}>
+              {`(${formatNumberCommas(audioClaimedSoFar)} ${
+                messages.claimedSoFar
+              })`}
+            </div>
+          ) : null}
+        </div>
+        {errorContent}
       </div>
-      {errorContent}
-    </div>
-  )
+    )
+  }
 }
 
 export const ChallengeRewardsModal = () => {

--- a/packages/web/src/pages/audio-rewards-page/components/modals/ChallengeRewardsModal/CooldownRewardsModalContent.tsx
+++ b/packages/web/src/pages/audio-rewards-page/components/modals/ChallengeRewardsModal/CooldownRewardsModalContent.tsx
@@ -60,7 +60,7 @@ const ClaimInProgressSpinner = () => (
   <LoadingSpinner className={styles.spinner} />
 )
 
-/** Implements custom ChallengeRewardsContent for the $AUDIO matching challenges */
+/** Implements custom ChallengeRewardsContent for the cooldown challenges */
 export const CooldownRewardsModalContent = ({
   challenge,
   challengeName,

--- a/packages/web/src/pages/audio-rewards-page/components/modals/ChallengeRewardsModal/CooldownRewardsModalContent.tsx
+++ b/packages/web/src/pages/audio-rewards-page/components/modals/ChallengeRewardsModal/CooldownRewardsModalContent.tsx
@@ -1,7 +1,11 @@
 import { ReactNode, useCallback } from 'react'
 
 import { useAudioMatchingChallengeCooldownSchedule } from '@audius/common/hooks'
-import { ChallengeName, OptimisticUserChallenge } from '@audius/common/models'
+import {
+  ChallengeName,
+  ChallengeRewardID,
+  OptimisticUserChallenge
+} from '@audius/common/models'
 import { challengesSelectors } from '@audius/common/store'
 import {
   formatNumberCommas,
@@ -14,9 +18,7 @@ import { useSelector } from 'react-redux'
 import LoadingSpinner from 'components/loading-spinner/LoadingSpinner'
 import { SummaryTable } from 'components/summary-table'
 import { useIsMobile } from 'hooks/useIsMobile'
-import { useNavigateToPage } from 'hooks/useNavigateToPage'
 import { useWithMobileStyle } from 'hooks/useWithMobileStyle'
-import { EXPLORE_PREMIUM_TRACKS_PAGE, UPLOAD_PAGE } from 'utils/route'
 
 import { ProgressDescription } from './ProgressDescription'
 import { ProgressReward } from './ProgressReward'
@@ -24,19 +26,17 @@ import styles from './styles.module.css'
 
 const { getOptimisticUserChallenges } = challengesSelectors
 
+type AudioMatchingChallengeName =
+  | ChallengeName.AudioMatchingBuy
+  | ChallengeName.AudioMatchingSell
+
 const messages = {
   rewardMapping: {
     [ChallengeName.AudioMatchingBuy]: '$AUDIO Every Dollar Spent',
     [ChallengeName.AudioMatchingSell]: '$AUDIO Every Dollar Earned'
   },
-  descriptionSubtext: {
-    [ChallengeName.AudioMatchingBuy]:
-      'Note: There is a 7 day waiting period between when you purchase and when you can claim your reward.',
-    [ChallengeName.AudioMatchingSell]:
-      'Note: There is a 7 day waiting period between when your track is purchased and when you can claim your reward.'
-  },
-  viewPremiumTracks: 'View Premium Tracks',
-  uploadTrack: 'Upload Track',
+  descriptionSubtext:
+    'Note: There is a 7 day waiting period from completion until you can claim your reward.',
   totalClaimed: (amount: string) => `Total $AUDIO Claimed: ${amount}`,
   claimAudio: (amount: string) => `Claim ${amount} $AUDIO`,
   upcomingRewards: 'Upcoming Rewards',
@@ -45,7 +45,7 @@ const messages = {
 
 type CooldownRewardsModalContentProps = {
   challenge?: OptimisticUserChallenge
-  challengeName: AudioMatchingChallengeName
+  challengeName: ChallengeRewardID
   onClaimRewardClicked: () => void
   claimInProgress?: boolean
   onNavigateAway: () => void
@@ -74,7 +74,6 @@ export const CooldownRewardsModalContent = ({
 }: CooldownRewardsModalContentProps) => {
   const wm = useWithMobileStyle(styles.mobile)
   const isMobile = useIsMobile()
-  const navigateToPage = useNavigateToPage()
   const { fullDescription } = challengeRewardsConfig[challengeName]
   const {
     cooldownChallenges,
@@ -90,7 +89,7 @@ export const CooldownRewardsModalContent = ({
         <div className={styles.audioMatchingDescription}>
           <Text variant='body'>{fullDescription?.(challenge)}</Text>
           <Text variant='body' color='subdued'>
-            {messages.descriptionSubtext[challengeName]}
+            {messages.descriptionSubtext}
           </Text>
         </div>
       }
@@ -99,7 +98,11 @@ export const CooldownRewardsModalContent = ({
   const progressReward = (
     <ProgressReward
       amount={formatNumberCommas(challenge?.amount ?? '')}
-      subtext={messages.rewardMapping[challengeName]}
+      subtext={
+        challengeName in messages.rewardMapping
+          ? messages.rewardMapping[challengeName as AudioMatchingChallengeName]
+          : messages.audio
+      }
     />
   )
 
@@ -115,15 +118,9 @@ export const CooldownRewardsModalContent = ({
     ) : null
 
   const handleClickCTA = useCallback(() => {
-    if (challengeName === ChallengeName.AudioMatchingBuy) {
-      navigateToPage(EXPLORE_PREMIUM_TRACKS_PAGE)
-    } else if (challengeName === ChallengeName.AudioMatchingSell) {
-      navigateToPage(UPLOAD_PAGE)
-    } else {
-      onClickProgress()
-    }
+    onClickProgress()
     onNavigateAway()
-  }, [challengeName, onNavigateAway, navigateToPage])
+  }, [onNavigateAway, onClickProgress])
   return (
     <div className={wm(cn(styles.container, styles.audioMatchingContainer))}>
       {isMobile ? (
@@ -169,9 +166,10 @@ export const CooldownRewardsModalContent = ({
           variant='secondary'
           fullWidth
           iconRight={progressIcon}
-          children={progressLabel}
           onClick={handleClickCTA}
-        />
+        >
+          {progressLabel}
+        </Button>
       )}
       {errorContent}
     </div>

--- a/packages/web/src/pages/audio-rewards-page/components/modals/ChallengeRewardsModal/CooldownRewardsModalContent.tsx
+++ b/packages/web/src/pages/audio-rewards-page/components/modals/ChallengeRewardsModal/CooldownRewardsModalContent.tsx
@@ -11,11 +11,10 @@ import {
   formatNumberCommas,
   challengeRewardsConfig
 } from '@audius/common/utils'
-import { Button, IconArrowRight, IconComponent, Text } from '@audius/harmony'
+import { Button, IconComponent, Text } from '@audius/harmony'
 import cn from 'classnames'
 import { useSelector } from 'react-redux'
 
-import LoadingSpinner from 'components/loading-spinner/LoadingSpinner'
 import { SummaryTable } from 'components/summary-table'
 import { useIsMobile } from 'hooks/useIsMobile'
 import { useWithMobileStyle } from 'hooks/useWithMobileStyle'
@@ -54,11 +53,6 @@ type CooldownRewardsModalContentProps = {
   progressLabel?: string
   errorContent?: ReactNode
 }
-
-// TODO: Migrate to @audius/harmony Button and pass `isLoading`
-const ClaimInProgressSpinner = () => (
-  <LoadingSpinner className={styles.spinner} />
-)
 
 /** Implements custom ChallengeRewardsContent for the cooldown challenges */
 export const CooldownRewardsModalContent = ({
@@ -155,8 +149,7 @@ export const CooldownRewardsModalContent = ({
       {challenge?.claimableAmount && challenge.claimableAmount > 0 ? (
         <Button
           fullWidth
-          iconRight={claimInProgress ? ClaimInProgressSpinner : IconArrowRight}
-          disabled={claimInProgress}
+          isLoading={claimInProgress}
           onClick={onClaimRewardClicked}
         >
           {messages.claimAudio(formatNumberCommas(claimableAmount))}

--- a/packages/web/src/pages/audio-rewards-page/components/modals/ChallengeRewardsModal/CooldownRewardsModalContent.tsx
+++ b/packages/web/src/pages/audio-rewards-page/components/modals/ChallengeRewardsModal/CooldownRewardsModalContent.tsx
@@ -11,7 +11,7 @@ import {
   formatNumberCommas,
   challengeRewardsConfig
 } from '@audius/common/utils'
-import { Button, IconArrowRight, Text } from '@audius/harmony'
+import { Button, IconArrowRight, IconComponent, Text } from '@audius/harmony'
 import cn from 'classnames'
 import { useSelector } from 'react-redux'
 
@@ -49,9 +49,9 @@ type CooldownRewardsModalContentProps = {
   onClaimRewardClicked: () => void
   claimInProgress?: boolean
   onNavigateAway: () => void
-  onClickProgress: any
-  progressIcon: any
-  progressLabel: any
+  onClickProgress: () => void
+  progressIcon?: IconComponent | null
+  progressLabel?: string
   errorContent?: ReactNode
 }
 

--- a/packages/web/src/pages/audio-rewards-page/components/modals/ChallengeRewardsModal/CooldownRewardsModalContent.tsx
+++ b/packages/web/src/pages/audio-rewards-page/components/modals/ChallengeRewardsModal/CooldownRewardsModalContent.tsx
@@ -1,0 +1,179 @@
+import { ReactNode, useCallback } from 'react'
+
+import { useAudioMatchingChallengeCooldownSchedule } from '@audius/common/hooks'
+import { ChallengeName, OptimisticUserChallenge } from '@audius/common/models'
+import { challengesSelectors } from '@audius/common/store'
+import {
+  formatNumberCommas,
+  challengeRewardsConfig
+} from '@audius/common/utils'
+import { Button, IconArrowRight, Text } from '@audius/harmony'
+import cn from 'classnames'
+import { useSelector } from 'react-redux'
+
+import LoadingSpinner from 'components/loading-spinner/LoadingSpinner'
+import { SummaryTable } from 'components/summary-table'
+import { useIsMobile } from 'hooks/useIsMobile'
+import { useNavigateToPage } from 'hooks/useNavigateToPage'
+import { useWithMobileStyle } from 'hooks/useWithMobileStyle'
+import { EXPLORE_PREMIUM_TRACKS_PAGE, UPLOAD_PAGE } from 'utils/route'
+
+import { ProgressDescription } from './ProgressDescription'
+import { ProgressReward } from './ProgressReward'
+import styles from './styles.module.css'
+
+const { getOptimisticUserChallenges } = challengesSelectors
+
+const messages = {
+  rewardMapping: {
+    [ChallengeName.AudioMatchingBuy]: '$AUDIO Every Dollar Spent',
+    [ChallengeName.AudioMatchingSell]: '$AUDIO Every Dollar Earned'
+  },
+  descriptionSubtext: {
+    [ChallengeName.AudioMatchingBuy]:
+      'Note: There is a 7 day waiting period between when you purchase and when you can claim your reward.',
+    [ChallengeName.AudioMatchingSell]:
+      'Note: There is a 7 day waiting period between when your track is purchased and when you can claim your reward.'
+  },
+  viewPremiumTracks: 'View Premium Tracks',
+  uploadTrack: 'Upload Track',
+  totalClaimed: (amount: string) => `Total $AUDIO Claimed: ${amount}`,
+  claimAudio: (amount: string) => `Claim ${amount} $AUDIO`,
+  upcomingRewards: 'Upcoming Rewards',
+  audio: '$AUDIO'
+}
+
+type CooldownRewardsModalContentProps = {
+  challenge?: OptimisticUserChallenge
+  challengeName: AudioMatchingChallengeName
+  onClaimRewardClicked: () => void
+  claimInProgress?: boolean
+  onNavigateAway: () => void
+  onClickProgress: any
+  progressIcon: any
+  progressLabel: any
+  errorContent?: ReactNode
+}
+
+// TODO: Migrate to @audius/harmony Button and pass `isLoading`
+const ClaimInProgressSpinner = () => (
+  <LoadingSpinner className={styles.spinner} />
+)
+
+/** Implements custom ChallengeRewardsContent for the $AUDIO matching challenges */
+export const CooldownRewardsModalContent = ({
+  challenge,
+  challengeName,
+  onClaimRewardClicked,
+  claimInProgress = false,
+  onNavigateAway,
+  onClickProgress,
+  progressIcon,
+  progressLabel,
+  errorContent
+}: CooldownRewardsModalContentProps) => {
+  const wm = useWithMobileStyle(styles.mobile)
+  const isMobile = useIsMobile()
+  const navigateToPage = useNavigateToPage()
+  const { fullDescription } = challengeRewardsConfig[challengeName]
+  const {
+    cooldownChallenges,
+    claimableAmount,
+    cooldownChallengesSummary,
+    isEmpty: isCooldownChallengesEmpty
+  } = useAudioMatchingChallengeCooldownSchedule(challenge?.challenge_id)
+  const userChallenge = useSelector(getOptimisticUserChallenges)[challengeName]
+
+  const progressDescription = (
+    <ProgressDescription
+      description={
+        <div className={styles.audioMatchingDescription}>
+          <Text variant='body'>{fullDescription?.(challenge)}</Text>
+          <Text variant='body' color='subdued'>
+            {messages.descriptionSubtext[challengeName]}
+          </Text>
+        </div>
+      }
+    />
+  )
+  const progressReward = (
+    <ProgressReward
+      amount={formatNumberCommas(challenge?.amount ?? '')}
+      subtext={messages.rewardMapping[challengeName]}
+    />
+  )
+
+  const progressStatusLabel =
+    userChallenge && userChallenge?.disbursed_amount > 0 ? (
+      <div className={styles.audioMatchingTotalContainer}>
+        <Text variant='label' size='l' strength='strong'>
+          {messages.totalClaimed(
+            formatNumberCommas(userChallenge.disbursed_amount.toString())
+          )}
+        </Text>
+      </div>
+    ) : null
+
+  const handleClickCTA = useCallback(() => {
+    if (challengeName === ChallengeName.AudioMatchingBuy) {
+      navigateToPage(EXPLORE_PREMIUM_TRACKS_PAGE)
+    } else if (challengeName === ChallengeName.AudioMatchingSell) {
+      navigateToPage(UPLOAD_PAGE)
+    } else {
+      onClickProgress()
+    }
+    onNavigateAway()
+  }, [challengeName, onNavigateAway, navigateToPage])
+  return (
+    <div className={wm(cn(styles.container, styles.audioMatchingContainer))}>
+      {isMobile ? (
+        <>
+          {progressDescription}
+          <div className={wm(styles.progressCard)}>
+            <div className={wm(styles.progressInfo)}>{progressReward}</div>
+            {progressStatusLabel}
+          </div>
+        </>
+      ) : (
+        <>
+          <div className={styles.progressCard}>
+            <div className={styles.progressInfo}>
+              {progressDescription}
+              {progressReward}
+            </div>
+            {progressStatusLabel}
+          </div>
+          {!isCooldownChallengesEmpty ? (
+            <SummaryTable
+              title={messages.upcomingRewards}
+              items={cooldownChallenges}
+              summaryItem={cooldownChallengesSummary}
+              secondaryTitle={messages.audio}
+              summaryLabelColor='accent'
+              summaryValueColor='default'
+            />
+          ) : null}
+        </>
+      )}
+      {challenge?.claimableAmount && challenge.claimableAmount > 0 ? (
+        <Button
+          fullWidth
+          iconRight={claimInProgress ? ClaimInProgressSpinner : IconArrowRight}
+          disabled={claimInProgress}
+          onClick={onClaimRewardClicked}
+        >
+          {messages.claimAudio(formatNumberCommas(claimableAmount))}
+        </Button>
+      ) : (
+        <Button
+          variant='secondary'
+          fullWidth
+          iconRight={progressIcon}
+          children={progressLabel}
+          onClick={handleClickCTA}
+        />
+      )}
+      {errorContent}
+    </div>
+  )
+}


### PR DESCRIPTION
### Description

Adding a generic cooldown rewards modal based off the existing audio match one. This is a first pass hidden behind a feature flag. Previously, a separate cooldown modal is shown based on the specific challenge. Now, it relies on the cooldown value which need to be added to the user challenges response.

Discovery changes are WIP on https://github.com/AudiusProject/audius-protocol/tree/is-more-cooldown. 

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._

Confirmed rewards are working the same when feature flag disabled.
When feature flag is enabled and pointed to a sandbox, it will show cooldowns for any rewards. 