### PR TITLE
[ONC-65] Fix search auto suggest

### DIFF
--- a/packages/web/src/components/search/SearchBar.jsx
+++ b/packages/web/src/components/search/SearchBar.jsx
@@ -222,6 +222,9 @@ class SearchBar extends Component {
       !isEqual(nextProps.dataSource, this.props.dataSource) &&
       nextProps.resultsCount > 0
     ) {
+      if (!nextState.selected && !nextState.valueFromParent) {
+        this.setState({ open: true })
+      }
       if (nextProps.status === Status.SUCCESS) {
         return true
       }
@@ -233,6 +236,9 @@ class SearchBar extends Component {
       nextProps.resultsCount === 0 &&
       this.state.value !== ''
     ) {
+      if (!nextState.selected && !nextState.valueFromParent) {
+        this.setState({ open: true })
+      }
       return false
     }
     // Close the dropdown if we're searching for '' (deleted text in search).

--- a/packages/web/src/components/search/SearchBar.jsx
+++ b/packages/web/src/components/search/SearchBar.jsx
@@ -56,6 +56,7 @@ class SearchBar extends Component {
     super(props)
     this.state = {
       open: false,
+      focused: false,
       // State variable set to true when an item has been selected.
       selected: false,
       value: '',
@@ -129,7 +130,7 @@ class SearchBar extends Component {
   }
 
   onFocus = () => {
-    this.setState({ shouldDismissTagPopup: false })
+    this.setState({ shouldDismissTagPopup: false, focused: true })
     this.searchBarRef.current
       .getElementsByClassName('ant-select-selection-search')[0]
       .classList.add('expanded')
@@ -163,7 +164,7 @@ class SearchBar extends Component {
           .getElementsByClassName('ant-select-selection-search')[0]
           .classList.remove('expanded')
       }
-      this.setState({ open: false })
+      this.setState({ open: false, focused: false })
     }
   }
 
@@ -222,7 +223,12 @@ class SearchBar extends Component {
       !isEqual(nextProps.dataSource, this.props.dataSource) &&
       nextProps.resultsCount > 0
     ) {
-      if (!nextState.selected && !nextState.valueFromParent) {
+      if (
+        !nextState.selected &&
+        !nextState.valueFromParent &&
+        // Only open the suggestions if the search bar is focused
+        nextState.focused
+      ) {
         this.setState({ open: true })
       }
       if (nextProps.status === Status.SUCCESS) {
@@ -236,7 +242,12 @@ class SearchBar extends Component {
       nextProps.resultsCount === 0 &&
       this.state.value !== ''
     ) {
-      if (!nextState.selected && !nextState.valueFromParent) {
+      if (
+        !nextState.selected &&
+        !nextState.valueFromParent &&
+        // Only open the suggestions if the search bar is focused
+        nextState.focused
+      ) {
         this.setState({ open: true })
       }
       return false


### PR DESCRIPTION
### Description

Reverts https://github.com/AudiusProject/audius-protocol/pull/7913
Also closes https://linear.app/audius/issue/C-4089/[qa]-search-results-modal-stuck-on-screen

Add `focused` state to keep track of whether or not the search bar is focused. Only open the auto suggestions when the search bar is focused

### How Has This Been Tested?

Confirmed suggestions appear properly and don't get stuck on screen with fast searches
