### PR TITLE
Make secondary buy $AUDIO button full-width

### DIFF
--- a/packages/web/src/pages/audio-rewards-page/components/WalletManagementTile.module.css
+++ b/packages/web/src/pages/audio-rewards-page/components/WalletManagementTile.module.css
@@ -149,4 +149,5 @@
   padding: 12px 24px;
   font-size: var(--harmony-font-m);
   font-weight: var(--harmony-font-demi-bold);
+  width: 100%;
 }


### PR DESCRIPTION
### Description
Noticed this small UI bug.

### How Has This Been Tested?
Before:
<img width="1245" alt="Screenshot 2024-03-28 at 4 23 01 PM" src="https://github.com/AudiusProject/audius-protocol/assets/3893871/25611064-0f1e-4285-9b51-b8de08233d8d">

After:
<img width="742" alt="Screenshot 2024-03-28 at 6 14 18 PM" src="https://github.com/AudiusProject/audius-protocol/assets/3893871/859f8f9d-2a49-42a7-b4b1-d039c67d3a6b">
