### PR TITLE
[C-4087] Fix library not loading

### DIFF
--- a/packages/libs/src/sdk/middleware/addRequestSignatureMiddleware.ts
+++ b/packages/libs/src/sdk/middleware/addRequestSignatureMiddleware.ts
@@ -32,10 +32,10 @@ export const addRequestSignatureMiddleware = ({
           !timestamp || timestamp + SIGNATURE_EXPIRY_MS < currentTimestamp
 
         if (!message || !signature || isExpired) {
-          message = `signature:${currentTimestamp}`
+          const m = `signature:${currentTimestamp}`
           // Add Ethereum-specific prefixes
-          const prefix = `\x19Ethereum Signed Message:\n${message.length}`
-          const prefixedMessage = prefix + message
+          const prefix = `\x19Ethereum Signed Message:\n${m.length}`
+          const prefixedMessage = prefix + m
 
           const [sig, recid] = await auth.sign(
             Buffer.from(prefixedMessage, 'utf-8')
@@ -45,6 +45,7 @@ export const addRequestSignatureMiddleware = ({
           // Add Ethereum Recovery ID offset
           const v = (recid + 27).toString(16)
 
+          message = m
           signature = `0x${r}${s}${v}`
           timestamp = currentTimestamp
         }


### PR DESCRIPTION
### Description

This fixes an issue where going directly to https://audius.co/library would not load your library.

Interesting bug with the auth middleware added to sdk in https://github.com/AudiusProject/audius-protocol/pull/7724

Multiple requests were running in parallel and `message` got set before an `await `call, while `signature` got set after. This caused some requests to have mismatched `message` and `signature` resulting in a 403

### How Has This Been Tested?

Confirmed that library, history, and other requests that require auth work properly.
