### PR TITLE
[PAY-2651] Fix nft video thumbnail

### DIFF
--- a/packages/web/src/components/collectibles/components/CollectibleDetails.tsx
+++ b/packages/web/src/components/collectibles/components/CollectibleDetails.tsx
@@ -120,7 +120,6 @@ const CollectibleDetails = (props: CollectibleDetailsProps) => {
                 (mediaType === CollectibleMediaType.VIDEO && frame)) && (
                 <div className={styles.imageWrapper}>
                   <PreloadImage
-                    asBackground
                     src={frame!}
                     preloaded={true}
                     className={styles.media}
@@ -145,7 +144,6 @@ const CollectibleDetails = (props: CollectibleDetailsProps) => {
                 mediaType === CollectibleMediaType.THREE_D) && (
                 <div className={styles.imageWrapper}>
                   <PreloadImage
-                    asBackground
                     src={frame!}
                     preloaded={true}
                     className={styles.media}

--- a/packages/web/src/components/collectibles/components/CollectibleDetailsModal.tsx
+++ b/packages/web/src/components/collectibles/components/CollectibleDetailsModal.tsx
@@ -66,7 +66,8 @@ type CollectibleMediaProps = {
 const CollectibleMedia = (props: CollectibleMediaProps) => {
   const { collectible, isMuted, toggleMute, isMobile } = props
 
-  const { mediaType, imageUrl, videoUrl, gifUrl, threeDUrl } = collectible
+  const { mediaType, frameUrl, imageUrl, videoUrl, gifUrl, threeDUrl } =
+    collectible
 
   const [isSvg, setIsSvg] = useState(false)
 
@@ -99,7 +100,14 @@ const CollectibleMedia = (props: CollectibleMediaProps) => {
     </div>
   ) : mediaType === CollectibleMediaType.VIDEO ? (
     <div className={styles.detailsMediaWrapper} onClick={toggleMute}>
-      <video muted={isMuted} autoPlay loop playsInline src={videoUrl!}>
+      <video
+        src={videoUrl!}
+        poster={frameUrl ?? undefined}
+        muted={isMuted}
+        autoPlay
+        loop
+        playsInline
+      >
         {collectibleMessages.videoNotSupported}
       </video>
       {isMuted ? (


### PR DESCRIPTION
### Description

Sometimes an audio url is returned for what we think is a video. In this case, the audio nft should display the nft image (if it's there) as the thumbnail. This PR does that.

### How Has This Been Tested?

local web dapp with nfts on eth and sol prod
