### PR TITLE
Parse DDEX deals

### DIFF
--- a/packages/ddex/ingester/common/sdk_types.go
+++ b/packages/ddex/ingester/common/sdk_types.go
@@ -180,16 +180,21 @@ type USDCPurchaseConditions struct {
 	Splits map[string]int `bson:"splits,omitempty"`
 }
 
+type CollectibleGatedConditions struct {
+	Chain        string `bson:"chain,omitempty"`
+	Address      string `bson:"address,omitempty"`
+	Standard     string `bson:"standard,omitempty"`
+	Name         string `bson:"name,omitempty"`
+	Slug         string `bson:"slug,omitempty"`
+	ImageURL     string `bson:"image_url,omitempty"`
+	ExternalLink string `bson:"external_link,omitempty"`
+}
+
 type AccessConditions struct {
-	USDCPurchase *USDCPurchaseConditions `bson:"usdc_purchase,omitempty"`
-	TipUserID    string                  `bson:"tip_user_id,omitempty"`
-	FollowUserID string                  `bson:"follow_user_id,omitempty"`
-	Chain        string                  `bson:"chain,omitempty"`
-	Address      string                  `bson:"address,omitempty"`
-	Standard     string                  `bson:"standard,omitempty"`
-	Name         string                  `bson:"name,omitempty"`
-	ImageURL     string                  `bson:"image_url,omitempty"`
-	ExternalLink string                  `bson:"external_link,omitempty"`
+	USDCPurchase  *USDCPurchaseConditions     `bson:"usdc_purchase,omitempty"`
+	TipUserID     string                      `bson:"tip_user_id,omitempty"`
+	FollowUserID  string                      `bson:"follow_user_id,omitempty"`
+	NFTCollection *CollectibleGatedConditions `bson:"nft_collection,omitempty"`
 }
 
 type TrackMetadata struct {

--- a/packages/ddex/ingester/common/sdk_types.go
+++ b/packages/ddex/ingester/common/sdk_types.go
@@ -175,6 +175,23 @@ type ReleaseIDs struct {
 	ProprietaryID string `bson:"proprietary_id,omitempty"`
 }
 
+type USDCPurchaseConditions struct {
+	Price  int            `bson:"price,omitempty"`
+	Splits map[string]int `bson:"splits,omitempty"`
+}
+
+type AccessConditions struct {
+	USDCPurchase *USDCPurchaseConditions `bson:"usdc_purchase,omitempty"`
+	TipUserID    string                  `bson:"tip_user_id,omitempty"`
+	FollowUserID string                  `bson:"follow_user_id,omitempty"`
+	Chain        string                  `bson:"chain,omitempty"`
+	Address      string                  `bson:"address,omitempty"`
+	Standard     string                  `bson:"standard,omitempty"`
+	Name         string                  `bson:"name,omitempty"`
+	ImageURL     string                  `bson:"image_url,omitempty"`
+	ExternalLink string                  `bson:"external_link,omitempty"`
+}
+
 type TrackMetadata struct {
 	Title                        string                `bson:"title"`
 	ReleaseDate                  time.Time             `bson:"release_date"`
@@ -190,6 +207,10 @@ type TrackMetadata struct {
 	CopyrightLine                *Copyright            `bson:"copyright_line,omitempty"`
 	ProducerCopyrightLine        *Copyright            `bson:"producer_copyright_line,omitempty"`
 	ParentalWarningType          NullableString        `bson:"parental_warning_type,omitempty"`
+	IsStreamGated                bool                  `bson:"is_stream_gated,omitempty"`
+	StreamConditions             *AccessConditions     `bson:"stream_conditions,omitempty"`
+	IsDownloadGated              bool                  `bson:"is_download_gated,omitempty"`
+	DownloadConditions           *AccessConditions     `bson:"download_conditions,omitempty"`
 
 	// TODO: Handle License from PLineText?
 	License NullableString `bson:"license,omitempty"`
@@ -202,6 +223,9 @@ type TrackMetadata struct {
 	// Extra fields (not in SDK)
 	ArtistID                    string `bson:"artist_id"`
 	ArtistName                  string `bson:"artist_name"`
+	IsStreamFollowGated         bool   `bson:"is_stream_follow_gated"`
+	IsStreamTipGated            bool   `bson:"is_stream_tip_gated"`
+	IsDownloadFollowGated       bool   `bson:"is_download_follow_gated"`
 	PreviewAudioFileURL         string `bson:"preview_audio_file_url"`
 	PreviewAudioFileURLHash     string `bson:"preview_audio_file_url_hash"`
 	PreviewAudioFileURLHashAlgo string `bson:"preview_audio_file_url_hash_algo"`
@@ -211,6 +235,7 @@ type TrackMetadata struct {
 	CoverArtURL                 string `bson:"cover_art_url"`
 	CoverArtURLHash             string `bson:"cover_art_url_hash"`
 	CoverArtURLHashAlgo         string `bson:"cover_art_url_hash_algo"`
+	HasDeal                     bool   `bson:"has_deal"`
 }
 
 // Not part of SDK

--- a/packages/ddex/ingester/e2e_test/e2e_test.go
+++ b/packages/ddex/ingester/e2e_test/e2e_test.go
@@ -324,7 +324,7 @@ func TestRunE2E(t *testing.T) {
 					Tracks: []common.TrackMetadata{
 						{
 							Title:       "Can you feel ...the Monkey Claw!",
-							ReleaseDate: time.Date(1, time.January, 1, 0, 0, 0, 0, time.UTC),
+							ReleaseDate: time.Date(2018, time.January, 10, 0, 0, 0, 0, time.UTC),
 							DDEXReleaseIDs: common.ReleaseIDs{
 								ISRC: "CASE00000001",
 							},
@@ -358,10 +358,13 @@ func TestRunE2E(t *testing.T) {
 								Text: "(P) 2010 Iron Crown Music",
 							},
 							ParentalWarningType: stringPtr("NotExplicit"),
+							IsStreamGated:       false,
+							IsDownloadGated:     false,
+							HasDeal:             true,
 						},
 						{
 							Title:       "Red top mountain, blown sky high",
-							ReleaseDate: time.Date(1, time.January, 1, 0, 0, 0, 0, time.UTC),
+							ReleaseDate: time.Date(2018, time.January, 10, 0, 0, 0, 0, time.UTC),
 							DDEXReleaseIDs: common.ReleaseIDs{
 								ISRC: "CASE00000002",
 							},
@@ -395,10 +398,13 @@ func TestRunE2E(t *testing.T) {
 								Text: "(P) 2010 Iron Crown Music",
 							},
 							ParentalWarningType: stringPtr("NotExplicit"),
+							IsStreamGated:       false,
+							IsDownloadGated:     false,
+							HasDeal:             true,
 						},
 						{
 							Title:       "Seige of Antioch",
-							ReleaseDate: time.Date(1, time.January, 1, 0, 0, 0, 0, time.UTC),
+							ReleaseDate: time.Date(2018, time.January, 10, 0, 0, 0, 0, time.UTC),
 							DDEXReleaseIDs: common.ReleaseIDs{
 								ISRC: "CASE00000003",
 							},
@@ -432,10 +438,13 @@ func TestRunE2E(t *testing.T) {
 								Text: "(P) 2010 Iron Crown Music",
 							},
 							ParentalWarningType: stringPtr("NotExplicit"),
+							IsStreamGated:       false,
+							IsDownloadGated:     false,
+							HasDeal:             true,
 						},
 						{
 							Title:       "Warhammer",
-							ReleaseDate: time.Date(1, time.January, 1, 0, 0, 0, 0, time.UTC),
+							ReleaseDate: time.Date(2018, time.January, 10, 0, 0, 0, 0, time.UTC),
 							DDEXReleaseIDs: common.ReleaseIDs{
 								ISRC: "CASE00000004",
 							},
@@ -469,10 +478,13 @@ func TestRunE2E(t *testing.T) {
 								Text: "(P) 2010 Iron Crown Music",
 							},
 							ParentalWarningType: stringPtr("NotExplicit"),
+							IsStreamGated:       false,
+							IsDownloadGated:     false,
+							HasDeal:             true,
 						},
 						{
 							Title:       "Iron Horse",
-							ReleaseDate: time.Date(1, time.January, 1, 0, 0, 0, 0, time.UTC),
+							ReleaseDate: time.Date(2018, time.January, 10, 0, 0, 0, 0, time.UTC),
 							DDEXReleaseIDs: common.ReleaseIDs{
 								ISRC: "CASE00000005",
 							},
@@ -506,10 +518,13 @@ func TestRunE2E(t *testing.T) {
 								Text: "(P) 2010 Iron Crown Music",
 							},
 							ParentalWarningType: stringPtr("NotExplicit"),
+							IsStreamGated:       false,
+							IsDownloadGated:     false,
+							HasDeal:             true,
 						},
 						{
 							Title:       "Yes... I can feel the Monkey Claw!",
-							ReleaseDate: time.Date(1, time.January, 1, 0, 0, 0, 0, time.UTC),
+							ReleaseDate: time.Date(2018, time.January, 10, 0, 0, 0, 0, time.UTC),
 							DDEXReleaseIDs: common.ReleaseIDs{
 								ISRC: "CASE00000006",
 							},
@@ -543,6 +558,9 @@ func TestRunE2E(t *testing.T) {
 								Text: "(P) 2010 Iron Crown Music",
 							},
 							ParentalWarningType: stringPtr("NotExplicit"),
+							IsStreamGated:       false,
+							IsDownloadGated:     false,
+							HasDeal:             true,
 						},
 					},
 				},

--- a/packages/ddex/ingester/e2e_test/e2e_test.go
+++ b/packages/ddex/ingester/e2e_test/e2e_test.go
@@ -96,7 +96,7 @@ func TestRunE2E(t *testing.T) {
 			expectedPR: common.PendingRelease{
 				ReleaseID:          "A10301A0005108088N",
 				DeliveryRemotePath: "s3://audius-test-raw/sony1.zip",
-				PublishDate:        time.Date(2023, time.September, 1, 0, 0, 0, 0, time.UTC),
+				PublishDate:        time.Date(2023, time.September, 2, 0, 0, 0, 0, time.UTC),
 				PublishErrors:      []string{},
 				CreateTrackRelease: common.CreateTrackRelease{},
 				CreateAlbumRelease: common.CreateAlbumRelease{
@@ -105,7 +105,7 @@ func TestRunE2E(t *testing.T) {
 						PlaylistName:      "Present.",
 						PlaylistOwnerID:   "Bmv3bJ",
 						PlaylistOwnerName: "Theo Random",
-						ReleaseDate:       time.Date(2023, time.September, 1, 0, 0, 0, 0, time.UTC),
+						ReleaseDate:       time.Date(2023, time.September, 2, 0, 0, 0, 0, time.UTC),
 						DDEXReleaseIDs: common.ReleaseIDs{
 							CatalogNumber: "G010005108088N",
 							GRid:          "A10301A0005108088N",
@@ -131,7 +131,7 @@ func TestRunE2E(t *testing.T) {
 					Tracks: []common.TrackMetadata{
 						{
 							Title:       "Playing With Fire.",
-							ReleaseDate: time.Time{},
+							ReleaseDate: time.Date(2023, time.September, 2, 0, 0, 0, 0, time.UTC),
 							Genre:       common.HipHopRap,
 							Duration:    279,
 							Artists: []common.ResourceContributor{{
@@ -188,10 +188,13 @@ func TestRunE2E(t *testing.T) {
 								Text: "(P) 2023 South Africa - Sony Music Entertainment Africa (Pty) Ltd, under Sound African Recordings a division of Sony Music Entertainment Africa (Pty) Ltd",
 							},
 							ParentalWarningType: stringPtr("Explicit"),
+							IsStreamGated:       false,
+							IsDownloadGated:     false,
+							HasDeal:             true,
 						},
 						{
 							Title:       "No Comment.",
-							ReleaseDate: time.Time{},
+							ReleaseDate: time.Date(2023, time.September, 2, 0, 0, 0, 0, time.UTC),
 							Genre:       common.HipHopRap,
 							Duration:    142,
 							ArtistID:    "",
@@ -250,6 +253,9 @@ func TestRunE2E(t *testing.T) {
 								Text: "(P) 2023 South Africa - Sony Music Entertainment Africa (Pty) Ltd, under Sound African Recordings a division of Sony Music Entertainment Africa (Pty) Ltd",
 							},
 							ParentalWarningType: stringPtr("Explicit"),
+							IsStreamGated:       false,
+							IsDownloadGated:     false,
+							HasDeal:             true,
 						},
 					},
 				},

--- a/packages/ddex/ingester/parser/ern38x.go
+++ b/packages/ddex/ingester/parser/ern38x.go
@@ -543,16 +543,13 @@ func processDealNode(dNode *xmlquery.Node, refToTrackReleaseMap map[string]*comm
 
 		// Parse validity start date
 		validityStartStr := safeInnerText(dealTerms.SelectElement("ValidityPeriod/StartDate"))
-		var validityStart time.Time
-		if validityStartStr != "" {
-			var validityStartErr error
-			validityStart, validityStartErr = time.Parse("2006-01-02", validityStartStr)
-			if validityStartErr != nil {
-				err = fmt.Errorf("error parsing ValidityPeriod/StartDate for <DealReleaseReference>s%v: %s", releaseRefs, validityStartErr)
-				break
-			}
-		} else {
+		if validityStartStr == "" {
 			err = fmt.Errorf("missing required ValidityPeriod/StartDatea for <DealReleaseReference>s%v", releaseRefs)
+			break
+		}
+		validityStart, validityStartErr := time.Parse("2006-01-02", validityStartStr)
+		if validityStartErr != nil {
+			err = fmt.Errorf("error parsing ValidityPeriod/StartDate for <DealReleaseReference>s%v: %s", releaseRefs, validityStartErr)
 			break
 		}
 

--- a/packages/ddex/ingester/parser/ern38x.go
+++ b/packages/ddex/ingester/parser/ern38x.go
@@ -639,12 +639,14 @@ func addStreamingConditionsToTrackRelease(dealTerms *xmlquery.Node, commercialMo
 
 		(*trackPtr).Metadata.IsStreamGated = true
 		(*trackPtr).Metadata.StreamConditions = &common.AccessConditions{
-			Chain:        chain,
-			Address:      address,
-			Standard:     standard,
-			Name:         name,
-			ImageURL:     imageUrl,
-			ExternalLink: externalLink,
+			NFTCollection: &common.CollectibleGatedConditions{
+				Chain:        chain,
+				Address:      address,
+				Standard:     standard,
+				Name:         name,
+				ImageURL:     imageUrl,
+				ExternalLink: externalLink,
+			},
 		}
 	} else if commercialModelType == "FollowGated" {
 		(*trackPtr).Metadata.IsStreamGated = true

--- a/packages/ddex/ingester/parser/parser.go
+++ b/packages/ddex/ingester/parser/parser.go
@@ -267,8 +267,7 @@ func (p *Parser) parseRelease(release *common.UnprocessedRelease, deliveryRemote
 }
 
 func copyTrackReleaseInfoToAlbum(createAlbumRelease []common.CreateAlbumRelease, createTrackRelease []common.CreateTrackRelease) {
-	// Copy missing fields from individual track releases to the album's tracks,
-	// which currently only have data from the SoundRecordings
+	// Copy missing fields from individual track releases to the album's tracks, which currently only have data from the SoundRecordings
 	isrcToMetadataMap := make(map[string]common.TrackMetadata)
 	for _, trackRelease := range createTrackRelease {
 		if trackRelease.Metadata.ISRC != nil {

--- a/packages/ddex/ingester/parser/parser.go
+++ b/packages/ddex/ingester/parser/parser.go
@@ -188,6 +188,7 @@ func (p *Parser) parseRelease(release *common.UnprocessedRelease, deliveryRemote
 						createAlbumRelease[i].Tracks[j].IsStreamFollowGated = trackReleaseMetadata.IsStreamFollowGated
 						createAlbumRelease[i].Tracks[j].IsStreamTipGated = trackReleaseMetadata.IsStreamTipGated
 						createAlbumRelease[i].Tracks[j].IsDownloadFollowGated = trackReleaseMetadata.IsDownloadFollowGated
+						createAlbumRelease[i].Tracks[j].ReleaseDate = trackReleaseMetadata.ReleaseDate
 						createAlbumRelease[i].Tracks[j].DDEXReleaseIDs = trackReleaseMetadata.DDEXReleaseIDs
 						if trackReleaseMetadata.ProducerCopyrightLine != nil {
 							createAlbumRelease[i].Tracks[j].ProducerCopyrightLine = trackReleaseMetadata.ProducerCopyrightLine
@@ -254,7 +255,7 @@ func (p *Parser) parseRelease(release *common.UnprocessedRelease, deliveryRemote
 	pendingReleases := []*common.PendingRelease{}
 	for _, track := range createTrackRelease {
 		if !track.Metadata.HasDeal {
-			p.Logger.Info("track '%s' does not have a corresponding deal. skipping track upload", track.Metadata.Title)
+			p.Logger.Info("track does not have a corresponding deal. skipping track upload", "release reference", track.DDEXReleaseRef, "track title", track.Metadata.Title)
 			continue
 		}
 		pendingRelease := &common.PendingRelease{
@@ -272,9 +273,9 @@ func (p *Parser) parseRelease(release *common.UnprocessedRelease, deliveryRemote
 	for _, album := range createAlbumRelease {
 		allTracksHaveDeals := true
 		for _, track := range album.Tracks {
-			if !track.Metadata.HasDeal {
+			if !track.HasDeal {
 				allTracksHaveDeals = false
-				p.Logger.Info("track '%s' on album '%s' does not have a corresponding deal. skipping album upload", track.Metadata.Title, album.Metadata.PlaylistName)
+				p.Logger.Info("album track does not have a corresponding deal. skipping album upload", "release reference", album.DDEXReleaseRef, "track title", track.Title, "album title", album.Metadata.PlaylistName)
 			}
 		}
 		if !allTracksHaveDeals {

--- a/packages/ddex/ingester/parser/parser.go
+++ b/packages/ddex/ingester/parser/parser.go
@@ -254,7 +254,7 @@ func (p *Parser) parseRelease(release *common.UnprocessedRelease, deliveryRemote
 	pendingReleases := []*common.PendingRelease{}
 	for _, track := range createTrackRelease {
 		if !track.Metadata.HasDeal {
-			p.Logger.Info("track '%s' does not have a corresponding deal. skipping queuing for upload", track.Metadata.Title)
+			p.Logger.Info("track '%s' does not have a corresponding deal. skipping track upload", track.Metadata.Title)
 			continue
 		}
 		pendingRelease := &common.PendingRelease{
@@ -274,7 +274,7 @@ func (p *Parser) parseRelease(release *common.UnprocessedRelease, deliveryRemote
 		for _, track := range album.Tracks {
 			if !track.Metadata.HasDeal {
 				allTracksHaveDeals = false
-				p.Logger.Info("track '%s' on album '%s' does not have a corresponding deal. skipping queuing album for upload", track.Metadata.Title, album.Metadata.PlaylistName)
+				p.Logger.Info("track '%s' on album '%s' does not have a corresponding deal. skipping album upload", track.Metadata.Title, album.Metadata.PlaylistName)
 			}
 		}
 		if !allTracksHaveDeals {

--- a/packages/ddex/publisher/src/models/pendingReleases.ts
+++ b/packages/ddex/publisher/src/models/pendingReleases.ts
@@ -112,41 +112,6 @@ const copyrightSchema = new mongoose.Schema<Copyright>({
   text: String,
 })
 
-interface USDCPurchaseConditions {
-  price: number
-  splits?: { [key: string]: number }
-}
-
-const usdcPurchaseConditionsSchema =
-  new mongoose.Schema<USDCPurchaseConditions>({
-    price: String,
-    splits: mongoose.Schema.Types.Mixed,
-  })
-
-interface AccessConditions {
-  usdc_purchase?: USDCPurchaseConditions
-  tip_user_id?: string
-  follow_user_id?: string
-  chain?: string
-  address?: string
-  standard?: string
-  name?: string
-  image_url?: string
-  external_link?: string
-}
-
-const accessConditionsSchema = new mongoose.Schema<AccessConditions>({
-  usdc_purchase: { type: usdcPurchaseConditionsSchema },
-  tip_user_id: String,
-  follow_user_id: String,
-  chain: String,
-  address: String,
-  standard: String,
-  name: String,
-  image_url: String,
-  external_link: String,
-})
-
 const trackMetadataSchema = new mongoose.Schema({
   title: { type: String, required: true },
   release_date: { type: Date, required: true },
@@ -179,10 +144,10 @@ const trackMetadataSchema = new mongoose.Schema({
   copyright_line: { type: copyrightSchema, default: null },
   producer_copyright_line: { type: copyrightSchema, default: null },
   parental_warning_type: { type: String, default: null },
-  is_stream_gated: { type: Boolean },
-  stream_conditions: { type: accessConditionsSchema },
-  is_download_gated: { type: Boolean },
-  download_conditions: { type: accessConditionsSchema },
+  is_stream_gated: { type: Boolean, required: true },
+  stream_conditions: { type: mongoose.Schema.Types.Mixed, default: null },
+  is_download_gated: { type: Boolean, required: true },
+  download_conditions: { type: mongoose.Schema.Types.Mixed, default: null },
   cover_art_url: { type: String, required: true },
   cover_art_url_hash: { type: String, required: true },
   cover_art_url_hash_algo: { type: String, required: true },

--- a/packages/ddex/publisher/src/models/pendingReleases.ts
+++ b/packages/ddex/publisher/src/models/pendingReleases.ts
@@ -112,6 +112,41 @@ const copyrightSchema = new mongoose.Schema<Copyright>({
   text: String,
 })
 
+interface USDCPurchaseConditions {
+  price: number
+  splits?: { [key: string]: number }
+}
+
+const usdcPurchaseConditionsSchema =
+  new mongoose.Schema<USDCPurchaseConditions>({
+    price: String,
+    splits: mongoose.Schema.Types.Mixed,
+  })
+
+interface AccessConditions {
+  usdc_purchase?: USDCPurchaseConditions
+  tip_user_id?: string
+  follow_user_id?: string
+  chain?: string
+  address?: string
+  standard?: string
+  name?: string
+  image_url?: string
+  external_link?: string
+}
+
+const accessConditionsSchema = new mongoose.Schema<AccessConditions>({
+  usdc_purchase: { type: usdcPurchaseConditionsSchema },
+  tip_user_id: String,
+  follow_user_id: String,
+  chain: String,
+  address: String,
+  standard: String,
+  name: String,
+  image_url: String,
+  external_link: String,
+})
+
 const trackMetadataSchema = new mongoose.Schema({
   title: { type: String, required: true },
   release_date: { type: Date, required: true },
@@ -144,6 +179,10 @@ const trackMetadataSchema = new mongoose.Schema({
   copyright_line: { type: copyrightSchema, default: null },
   producer_copyright_line: { type: copyrightSchema, default: null },
   parental_warning_type: { type: String, default: null },
+  is_stream_gated: { type: Boolean },
+  stream_conditions: { type: accessConditionsSchema },
+  is_download_gated: { type: Boolean },
+  download_conditions: { type: accessConditionsSchema },
   cover_art_url: { type: String, required: true },
   cover_art_url_hash: { type: String, required: true },
   cover_art_url_hash_algo: { type: String, required: true },

--- a/packages/ddex/publisher/src/models/pendingReleases.ts
+++ b/packages/ddex/publisher/src/models/pendingReleases.ts
@@ -148,9 +148,13 @@ const trackMetadataSchema = new mongoose.Schema({
   stream_conditions: { type: mongoose.Schema.Types.Mixed, default: null },
   is_download_gated: { type: Boolean, required: true },
   download_conditions: { type: mongoose.Schema.Types.Mixed, default: null },
+  is_stream_follow_gated: Boolean,
+  is_stream_tip_gated: Boolean,
+  is_download_follow_gated: Boolean,
   cover_art_url: { type: String, required: true },
   cover_art_url_hash: { type: String, required: true },
   cover_art_url_hash_algo: { type: String, required: true },
+  has_deal: Boolean,
 })
 
 export type TrackMetadata = mongoose.InferSchemaType<typeof trackMetadataSchema>

--- a/packages/ddex/publisher/src/services/publisherService.ts
+++ b/packages/ddex/publisher/src/services/publisherService.ts
@@ -43,6 +43,7 @@ const formatTrackMetadata = (
     copyrightLine: metadata.copyright_line,
     producerCopyrightLine: metadata.producer_copyright_line,
     parentalWarningType: metadata.parental_warning_type,
+    isStreamGated: metadata.is_stream_gated,
     // isUnlisted: // TODO: set visibility
     // iswc:
     // origFilename:

--- a/packages/ddex/publisher/src/services/publisherService.ts
+++ b/packages/ddex/publisher/src/services/publisherService.ts
@@ -44,15 +44,13 @@ const formatTrackMetadata = (
     producerCopyrightLine: metadata.producer_copyright_line,
     parentalWarningType: metadata.parental_warning_type,
     isStreamGated: metadata.is_stream_gated,
+    streamConditions: metadata.stream_conditions,
+    isDownloadGated: metadata.is_download_gated,
+    downloadConditions: metadata.download_conditions
     // isUnlisted: // TODO: set visibility
     // iswc:
     // origFilename:
     // isOriginalAvailable:
-    // isStreamGated:
-    // streamConditions:
-    // isDownloadable:
-    // isDownloadGated:
-    // downloadConditions:
     // remixOf:
   }
 }

--- a/packages/ddex/publisher/src/services/publisherService.ts
+++ b/packages/ddex/publisher/src/services/publisherService.ts
@@ -46,7 +46,7 @@ const formatTrackMetadata = (
     isStreamGated: metadata.is_stream_gated,
     streamConditions: metadata.stream_conditions,
     isDownloadGated: metadata.is_download_gated,
-    downloadConditions: metadata.download_conditions
+    downloadConditions: metadata.download_conditions,
     // isUnlisted: // TODO: set visibility
     // iswc:
     // origFilename:


### PR DESCRIPTION
### Description
Adds Audius deal parsing according to these specifications https://www.notion.so/audiusproject/Audius-DDEX-Deals-Guidance-6c21881d68934c2eada508f90fa11c7e?pvs=4.

Will follow up with album parsing in anticipation of premium albums.

Note: 
- For now, according to what I've seen in CPD/Sony examples, only track deals are required. Album deals can be omitted.
- The system uses the `ValidityPeriod/StartDate` (a required field according to our Audius docs) in the deal as the release date aka "street date", but if an album deal is omitted, it falls back to the deprecated `GlobalOriginalReleaseDate` for the album release date

### How Has This Been Tested?
e2e tests