### PR TITLE
Bump mobile version to 1.1.93 for release

### DIFF
--- a/packages/mobile/android/app/build.gradle
+++ b/packages/mobile/android/app/build.gradle
@@ -113,7 +113,7 @@ android {
         // versionCode is automatically incremented in CI
         versionCode 1
         // Make sure this is above the currently released Android version in the play store if your changes touch native code:
-        versionName "1.1.418"
+        versionName "1.1.419"
         resValue "string", "build_config_package", "co.audius.app"
         resValue 'string', "CODE_PUSH_APK_BUILD_TIME", String.format("\"%d\"", System.currentTimeMillis())
         resConfigs "en"

--- a/packages/mobile/ios/AudiusReactNative/Info.plist
+++ b/packages/mobile/ios/AudiusReactNative/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.1.92</string>
+	<string>1.1.93</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleURLTypes</key>


### PR DESCRIPTION
### Description

Bumps mobile version for full app release. Needed due to changes to pods for collectibles
