### PR TITLE
[ONC-68] Fix stream hex signature and delisting by downgrading hexbytes

### DIFF
--- a/packages/discovery-provider/requirements.txt
+++ b/packages/discovery-provider/requirements.txt
@@ -13,6 +13,7 @@ types-freezegun==1.1.10
 types-Flask==1.1.6
 
 web3==6.6.1
+hexbytes==0.3.1
 Flask==1.0.4
 # pin itsdangerous and markupsafe https://github.com/pallets/flask/issues/4455
 itsdangerous==1.1.0

--- a/packages/discovery-provider/src/api_helpers.py
+++ b/packages/discovery-provider/src/api_helpers.py
@@ -112,7 +112,11 @@ def generate_signature(data):
     signed_message = w3.eth.account.sign_message(
         encoded_to_sign, private_key=shared_config["delegate"]["private_key"]
     )
-    return signed_message.signature.hex()
+
+    signature_hex = signed_message.signature.hex()
+    if not signature_hex.startswith("0x"):
+        signature_hex = "0x" + signature_hex
+    return signature_hex
 
 
 # Accepts raw data with timestamp key and relevant fields, converts data to hash, and recovers the wallet

--- a/packages/discovery-provider/src/api_helpers.py
+++ b/packages/discovery-provider/src/api_helpers.py
@@ -112,11 +112,7 @@ def generate_signature(data):
     signed_message = w3.eth.account.sign_message(
         encoded_to_sign, private_key=shared_config["delegate"]["private_key"]
     )
-
-    signature_hex = signed_message.signature.hex()
-    if not signature_hex.startswith("0x"):
-        signature_hex = "0x" + signature_hex
-    return signature_hex
+    return signed_message.signature.hex()
 
 
 # Accepts raw data with timestamp key and relevant fields, converts data to hash, and recovers the wallet


### PR DESCRIPTION
### Description

Hexbytes upgraded from 0.3.1 to 1.2.0 in the image built with commit ffc165c7656d5ea3f90dfc69d199d9d231b151cc. Stream signatures used to start with 0x which content nodes expect, but the new version doesn't have this prrefix.


### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._

Fixed streaming on stage and confirmed delisting indexing works.