### PR TITLE
[ONC-67] Update aggregates counts with more straightforward logic

### DIFF
--- a/packages/discovery-provider/ddl/functions/handle_track.sql
+++ b/packages/discovery-provider/ddl/functions/handle_track.sql
@@ -7,13 +7,13 @@ begin
 end
 $$ LANGUAGE plpgsql;
 
-create or replace function track_should_notify(old_track record, new_track record, tg_op varchar) returns boolean as $$
+create or replace function track_should_notify(old_track tracks, new_track record, tg_op varchar) returns boolean as $$
 begin
-  if tg_op = 'UPDATE' and old_track is not null then
+  if tg_op = 'UPDATE' and old_track.track_id is not null then
     return not track_is_public(old_track) and track_is_public(new_track);
   else
-    return new_track.created_at = new_track.updated_at 
-      and tg_op = 'INSERT' 
+    return new_track.created_at = new_track.updated_at
+      and tg_op = 'INSERT'
       and track_is_public(new_track)
     ;
   end if;

--- a/packages/discovery-provider/integration_tests/utils.py
+++ b/packages/discovery-provider/integration_tests/utils.py
@@ -226,6 +226,7 @@ def populate_mock_db(db, entities, block_offset=None):
                     else None
                 ),
                 is_unlisted=track_meta.get("is_unlisted", False),
+                is_scheduled_release=track_meta.get("is_scheduled_release", False),
                 is_stream_gated=track_meta.get("is_stream_gated", False),
                 stream_conditions=track_meta.get("stream_conditions", None),
                 is_download_gated=track_meta.get("is_download_gated", False),

--- a/packages/discovery-provider/integration_tests/utils.py
+++ b/packages/discovery-provider/integration_tests/utils.py
@@ -191,10 +191,10 @@ def populate_mock_db(db, entities, block_offset=None):
         for i, track_meta in enumerate(tracks):
             track_id = track_meta.get("track_id", i)
 
-            # mark previous tracks as is_current = False
+            # delete previous tracks
             session.query(Track).filter(Track.is_current == True).filter(
                 Track.track_id == track_id
-            ).update({"is_current": False})
+            ).delete()
             track_created_at = datetime.now()
             track = Track(
                 blockhash=hex(i + block_offset),


### PR DESCRIPTION
### Description

Due to a bug in how track counts were being reported,  we can opt to update aggregate counts for user tracks in the handle_track psql trigger to have more timely and accurate track counts.

### How Has This Been Tested?

Unit tests in CI with some additions.