### PR TITLE
Lower default celery worker concurrency

### DIFF
--- a/packages/discovery-provider/scripts/start.sh
+++ b/packages/discovery-provider/scripts/start.sh
@@ -64,7 +64,7 @@ else
         audius_service=worker celery -A src.worker.celery worker -Q index_sol --loglevel "$audius_discprov_loglevel" --hostname=index_sol --concurrency 1 2>&1 | tee >(logger -t index_sol_worker) &
 
         # start other workers with remaining CPUs
-        audius_service=worker celery -A src.worker.celery worker --max-memory-per-child 300000 --loglevel "$audius_discprov_loglevel" --concurrency=$(($(nproc) - 5)) 2>&1 | tee >(logger -t worker) &
+        audius_service=worker celery -A src.worker.celery worker --max-memory-per-child 300000 --loglevel "$audius_discprov_loglevel" --concurrency 3 2>&1 | tee >(logger -t worker) &
 
         while [[ "$audius_discprov_env" == "stage" ]]; do
             # log active tasks and mem to find mem leaks


### PR DESCRIPTION
### Description
Discovery nodes are getting stuck, losing connection with redis. Started over the weekend without any code release or dependency changes. 

```
missed heartbeat from celery@index_nethermind
missed heartbeat from celery@db062c57dbd0	
missed heartbeat from celery@index_sol	

```

I noticed the nodes that missed heartbeats the most had higher CPUs so they have more concurrency in the default worker and the default worker missed more heartbeats than the others. I'm guessing lowering may be a mitigation for now. Nodes at min requirement will not be affected.


### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._

Tested on sandbox.