### PR TITLE
Add '--maxsockets 1' flag to make ddex build more reliable

### DIFF
--- a/packages/ddex/publisher/Dockerfile
+++ b/packages/ddex/publisher/Dockerfile
@@ -31,7 +31,7 @@ COPY --from=turbo-builder /app/out/json/ .
 COPY --from=turbo-builder /app/out/package-lock.json ./package-lock.json
 COPY --from=turbo-builder /app/scripts ./scripts
 
-RUN CI=true npm i
+RUN CI=true npm i --maxsockets 1
 
 # Build the app and its dependencies
 COPY --from=turbo-builder /app/out/full/ .

--- a/packages/ddex/webapp/Dockerfile
+++ b/packages/ddex/webapp/Dockerfile
@@ -31,7 +31,7 @@ COPY --from=turbo-builder /app/out/json/ .
 COPY --from=turbo-builder /app/out/package-lock.json ./package-lock.json
 COPY --from=turbo-builder /app/scripts ./scripts
 
-RUN CI=true npm i
+RUN CI=true npm i --maxsockets 1
 
 # Build the app and its dependencies
 COPY --from=turbo-builder /app/out/full/ .


### PR DESCRIPTION
### Description

We've seen [this issue](https://app.circleci.com/pipelines/github/AudiusProject/audius-protocol/54178/workflows/d3cc1bb7-47e8-4415-90f8-eae5ec76bd99/jobs/749621) in the past where npm i randomly fails due to `ECONNRESET`. For some reason, this flag helps make the build more reliable. We're already doing this for other Dockerfiles, see #7397 

### How Has This Been Tested?

CI