### PR TITLE
Fix mobile collectible svg+xml and video display

### DIFF
--- a/packages/mobile/src/screens/profile-screen/CollectiblesCard.tsx
+++ b/packages/mobile/src/screens/profile-screen/CollectiblesCard.tsx
@@ -1,7 +1,11 @@
 import type { ReactNode } from 'react'
 import { useState, useCallback } from 'react'
 
-import type { Collectible, ID } from '@audius/common/models'
+import {
+  CollectibleMediaType,
+  type Collectible,
+  type ID
+} from '@audius/common/models'
 import {
   accountSelectors,
   collectibleDetailsUIActions,
@@ -65,29 +69,30 @@ type CollectiblesCardProps = {
 type CollectibleImageProps = {
   uri: string
   style: StyleProp<ImageStyle>
+  mediaType: CollectibleMediaType
   children?: ReactNode
 }
 
 const CollectibleImage = (props: CollectibleImageProps) => {
-  const { children, style, uri } = props
+  const { children, style, uri, mediaType } = props
 
   const isUriNumber = typeof uri === 'number'
   const isSvg = isUriNumber ? false : !!uri.match(/.*\.svg$/)
-  const isMp4 = isUriNumber ? false : !!uri.match(/.*\.mp4$/)
   const isSvgXml = isUriNumber ? false : !!uri.match(/data:image\/svg\+xml.*/)
+  const isVideo = isUriNumber ? false : mediaType === CollectibleMediaType.VIDEO
 
   const [size, setSize] = useState(0)
   const [hasLoaded, setHasLoaded] = useState(false)
 
-  const { value: mp4ThumbnailUrl } = useAsync(async () => {
-    if (isMp4) {
+  const { value: videoThumbnailUrl } = useAsync(async () => {
+    if (isVideo) {
       const response = await createThumbnail({
         url: uri,
         timeStamp: 10000
       })
       return response.path
     }
-  }, [isMp4])
+  }, [mediaType])
 
   if (isSvg) {
     return (
@@ -161,7 +166,7 @@ const CollectibleImage = (props: CollectibleImageProps) => {
         isUriNumber
           ? uri
           : {
-              uri: isMp4 ? mp4ThumbnailUrl : uri
+              uri: isVideo ? videoThumbnailUrl : uri
             }
       }
     >
@@ -214,7 +219,11 @@ export const CollectiblesCard = (props: CollectiblesCardProps) => {
         onPress={handlePress}
       >
         {url ? (
-          <CollectibleImage style={styles.image} uri={url}>
+          <CollectibleImage
+            style={styles.image}
+            uri={url}
+            mediaType={mediaType}
+          >
             {mediaType === 'VIDEO' ? (
               <View style={styles.iconPlay}>
                 <IconPlay

--- a/packages/mobile/src/screens/profile-screen/CollectiblesCard.tsx
+++ b/packages/mobile/src/screens/profile-screen/CollectiblesCard.tsx
@@ -126,36 +126,41 @@ const CollectibleImage = (props: CollectibleImageProps) => {
       </View>
     )
   } else if (isSvgXml) {
-    return (
-      <View
-        onLayout={(e) => {
-          setSize(e.nativeEvent.layout.width)
-        }}
-      >
-        <SvgXml
-          height={size}
-          width={size}
-          xml={atob(uri)}
-          style={{ borderRadius: 8, overflow: 'hidden' }}
-          onLoad={() => setHasLoaded(true)}
+    try {
+      const xml = atob(uri)
+      return (
+        <View
+          onLayout={(e) => {
+            setSize(e.nativeEvent.layout.width)
+          }}
         >
-          {hasLoaded ? (
-            children
-          ) : (
-            <Skeleton
-              width={'100%'}
-              style={{
-                position: 'absolute',
-                top: 0,
-                left: 0,
-                right: 0,
-                bottom: 0
-              }}
-            />
-          )}
-        </SvgXml>
-      </View>
-    )
+          <SvgXml
+            height={size}
+            width={size}
+            xml={xml}
+            style={{ borderRadius: 8, overflow: 'hidden' }}
+            onLoad={() => setHasLoaded(true)}
+          >
+            {hasLoaded ? (
+              children
+            ) : (
+              <Skeleton
+                width={'100%'}
+                style={{
+                  position: 'absolute',
+                  top: 0,
+                  left: 0,
+                  right: 0,
+                  bottom: 0
+                }}
+              />
+            )}
+          </SvgXml>
+        </View>
+      )
+    } catch (e) {
+      return null
+    }
   }
 
   return (


### PR DESCRIPTION
### Description

A version has been cherry picked to 1.5.73 -- we will want this one on 1.5.74 as well once it goes in

1. Never had support for svg+xml on mobile since it does not work when put into an `<Image>` as is
2. Support more than mp4 for video types. We can't trust that it will have an extension

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._

```
npm run mobile:prod
```
* sceretpanda007
* rayjacobson
* forrest
* eeeeqanft