### PR TITLE
[C-4083] Fix native password perf

### DIFF
--- a/packages/mobile/src/components/fields/HarmonyTextField.tsx
+++ b/packages/mobile/src/components/fields/HarmonyTextField.tsx
@@ -27,7 +27,7 @@ export const HarmonyTextField = (props: HarmonyTextFieldProps) => {
     transformValueOnBlur,
     debouncedValidationMs = 0,
     helperText,
-    onChange: propsOnChange,
+    onChange: onChangeProp,
     error: errorProp,
     ...other
   } = props
@@ -56,7 +56,7 @@ export const HarmonyTextField = (props: HarmonyTextFieldProps) => {
       error={hasError}
       helperText={helperText ?? (hasError ? error : undefined)}
       onChange={(e) => {
-        propsOnChange?.(e)
+        onChangeProp?.(e)
         if (clearErrorOnChange) {
           setError(undefined)
         }

--- a/packages/mobile/src/components/fields/PasswordField.tsx
+++ b/packages/mobile/src/components/fields/PasswordField.tsx
@@ -22,11 +22,11 @@ export const PasswordField = (props: PasswordFieldProps) => {
     <PasswordInput
       {...field}
       error={hasError}
-      onChangeText={(e) => {
+      onChange={(e) => {
         if (clearErrorOnChange) {
           setError(undefined)
         }
-        field.onChange(name)(e)
+        field.onChange(name)(e.nativeEvent.text)
       }}
       onBlur={field.onBlur(name)}
       {...other}


### PR DESCRIPTION
### Description

Fixes issue where we used onChangeText instead of onChange, meaning field.onChange was silently passed to password-fields onChange, resulting in a bunch of warnings