### PR TITLE
[C-4329] Fix ai-attribution-details styles

### DIFF
--- a/packages/harmony/src/components/text/Text/Text.tsx
+++ b/packages/harmony/src/components/text/Text/Text.tsx
@@ -59,7 +59,7 @@ export const Text = forwardRef(
         textShadow: typography.shadow[shadow]
       }),
       textAlign,
-      textTransform,
+      ...(textTransform && { textTransform }),
       ...(ellipses && {
         overflow: 'hidden',
         textOverflow: 'ellipsis',

--- a/packages/mobile/src/components/details-tile/DetailsTileAiAttribution.tsx
+++ b/packages/mobile/src/components/details-tile/DetailsTileAiAttribution.tsx
@@ -16,7 +16,6 @@ import {
 import UserBadges from 'app/components/user-badges'
 import { useNavigation } from 'app/hooks/useNavigation'
 import { makeStyles } from 'app/styles'
-import { useThemeColors } from 'app/utils/theme'
 
 const { fetchAiUser, reset } = aiPageActions
 const { getAiUser } = aiPageSelectors
@@ -42,7 +41,6 @@ const useStyles = makeStyles(({ spacing, palette }) => ({
 
 export const DetailsTileAiAttribution = ({ userId }: { userId: ID }) => {
   const styles = useStyles()
-  const { neutral } = useThemeColors()
   const navigation = useNavigation()
 
   const dispatch = useDispatch()
@@ -69,7 +67,12 @@ export const DetailsTileAiAttribution = ({ userId }: { userId: ID }) => {
       </Flex>
       <Text variant='body' size='s'>
         {messages.description}
-        <TextLink variant='visible'>{user.name}</TextLink>
+        <TextLink
+          variant='visible'
+          to={{ screen: 'Profile', params: { id: user.user_id } }}
+        >
+          {user.name}
+        </TextLink>
         <UserBadges user={user} hideName style={styles.badges} badgeSize={12} />
       </Text>
       <PlainButton

--- a/packages/mobile/src/components/details-tile/DetailsTileAiAttribution.tsx
+++ b/packages/mobile/src/components/details-tile/DetailsTileAiAttribution.tsx
@@ -3,11 +3,16 @@ import { useEffect } from 'react'
 import type { ID } from '@audius/common/models'
 import { aiPageActions, aiPageSelectors } from '@audius/common/store'
 import { View } from 'react-native'
-import { TouchableWithoutFeedback } from 'react-native-gesture-handler'
 import { useDispatch, useSelector } from 'react-redux'
 
-import { IconRobot } from '@audius/harmony-native'
-import { Text } from 'app/components/core'
+import {
+  IconArrowRight,
+  IconRobot,
+  PlainButton,
+  Text,
+  Flex,
+  TextLink
+} from '@audius/harmony-native'
 import UserBadges from 'app/components/user-badges'
 import { useNavigation } from 'app/hooks/useNavigation'
 import { makeStyles } from 'app/styles'
@@ -22,7 +27,7 @@ const messages = {
   viewMore: 'View More'
 }
 
-const useStyles = makeStyles(({ spacing, palette, typography }) => ({
+const useStyles = makeStyles(({ spacing, palette }) => ({
   root: {
     gap: spacing(2),
     borderBottomWidth: 1,
@@ -30,34 +35,8 @@ const useStyles = makeStyles(({ spacing, palette, typography }) => ({
     paddingBottom: spacing(4),
     marginBottom: spacing(4)
   },
-  title: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    gap: spacing(2)
-  },
-  titleText: {
-    textTransform: 'uppercase',
-    fontSize: typography.fontSize.small,
-    fontFamily: typography.fontByWeight.bold,
-    lineHeight: typography.fontSize.small * 1.3
-  },
-  description: {
-    fontSize: typography.fontSize.small,
-    lineHeight: typography.fontSize.small * 1.3
-  },
-  userBadgeTitle: {
-    fontSize: typography.fontSize.small,
-    lineHeight: typography.fontSize.small * 1.3,
-    fontFamily: typography.fontByWeight.medium,
-    color: palette.secondary
-  },
   badges: {
     paddingTop: spacing(4)
-  },
-  viewMore: {
-    fontSize: typography.fontSize.small,
-    lineHeight: typography.fontSize.small * 1.2,
-    color: palette.secondary
   }
 }))
 
@@ -82,18 +61,25 @@ export const DetailsTileAiAttribution = ({ userId }: { userId: ID }) => {
 
   return user ? (
     <View style={styles.root}>
-      <View style={styles.title}>
-        <IconRobot fill={neutral} />
-        <Text style={styles.titleText}>{messages.title}</Text>
-      </View>
-      <Text style={styles.description}>
+      <Flex inline direction='row' alignItems='center' gap='s'>
+        <IconRobot color='default' />
+        <Text variant='label' style={{ marginTop: 2 }}>
+          {messages.title}
+        </Text>
+      </Flex>
+      <Text variant='body' size='s'>
         {messages.description}
-        <Text style={styles.userBadgeTitle}>{user.name}</Text>
+        <TextLink variant='visible'>{user.name}</TextLink>
         <UserBadges user={user} hideName style={styles.badges} badgeSize={12} />
       </Text>
-      <TouchableWithoutFeedback onPress={handleViewMorePress}>
-        <Text style={styles.viewMore}>{messages.viewMore}</Text>
-      </TouchableWithoutFeedback>
+      <PlainButton
+        style={{ alignSelf: 'flex-start' }}
+        variant='subdued'
+        iconRight={IconArrowRight}
+        onPress={handleViewMorePress}
+      >
+        {messages.viewMore}
+      </PlainButton>
     </View>
   ) : null
 }

--- a/packages/mobile/src/components/details-tile/DetailsTileAiAttribution.tsx
+++ b/packages/mobile/src/components/details-tile/DetailsTileAiAttribution.tsx
@@ -61,6 +61,7 @@ export const DetailsTileAiAttribution = ({ userId }: { userId: ID }) => {
     <View style={styles.root}>
       <Flex inline direction='row' alignItems='center' gap='s'>
         <IconRobot color='default' />
+        {/* IconRobot is bottom-heavy, adding marginTop makes text look more aligned */}
         <Text variant='label' style={{ marginTop: 2 }}>
           {messages.title}
         </Text>

--- a/packages/mobile/src/components/details-tile/DetailsTileAiAttribution.tsx
+++ b/packages/mobile/src/components/details-tile/DetailsTileAiAttribution.tsx
@@ -2,7 +2,6 @@ import { useEffect } from 'react'
 
 import type { ID } from '@audius/common/models'
 import { aiPageActions, aiPageSelectors } from '@audius/common/store'
-import { View } from 'react-native'
 import { useDispatch, useSelector } from 'react-redux'
 
 import {
@@ -28,11 +27,8 @@ const messages = {
 
 const useStyles = makeStyles(({ spacing, palette }) => ({
   root: {
-    gap: spacing(2),
     borderBottomWidth: 1,
-    borderBottomColor: palette.neutralLight7,
-    paddingBottom: spacing(4),
-    marginBottom: spacing(4)
+    borderBottomColor: palette.neutralLight7
   },
   badges: {
     paddingTop: spacing(4)
@@ -58,7 +54,7 @@ export const DetailsTileAiAttribution = ({ userId }: { userId: ID }) => {
   }
 
   return user ? (
-    <View style={styles.root}>
+    <Flex gap='s' pb='l' mb='l' style={styles.root}>
       <Flex inline direction='row' alignItems='center' gap='s'>
         <IconRobot color='default' />
         {/* IconRobot is bottom-heavy, adding marginTop makes text look more aligned */}
@@ -84,6 +80,6 @@ export const DetailsTileAiAttribution = ({ userId }: { userId: ID }) => {
       >
         {messages.viewMore}
       </PlainButton>
-    </View>
+    </Flex>
   ) : null
 }

--- a/packages/mobile/src/harmony-native/components/Text/Text.tsx
+++ b/packages/mobile/src/harmony-native/components/Text/Text.tsx
@@ -48,7 +48,7 @@ export const Text = forwardRef<TextBase, TextProps>((props, ref) => {
     ...(color && { color }),
     ...(shadow && t.shadow[shadow]),
     textAlign,
-    textTransform,
+    ...(textTransform && { textTransform }),
     // Fixes demiBold text misalignment on iOS
     ...(fontWeight === 'demiBold' && Platform.OS === 'ios'
       ? { marginTop: 2 }


### PR DESCRIPTION
### Description

Fixes issue where ai-attribution details title looked misaligned. Migrated most things to harmony and added a paddingTop: 2px to make it nicer visually.

Also fixes harmony text issue where `textTransform` prop was always setting textTransform to undefined, which negated the textTransform: uppercase applied to the label variant.