### PR TITLE
Slow down solana tx retries

### DIFF
--- a/packages/identity-service/src/solana-client.js
+++ b/packages/identity-service/src/solana-client.js
@@ -231,12 +231,8 @@ async function createTrackListenInstructions({
     programId: TRACK_LISTEN_PROGRAM,
     data: serializedInstructionArgs
   })
-  const priorityFeeInstruction =
-    solanaWeb3.ComputeBudgetProgram.setComputeUnitPrice({
-      microLamports: 1
-    })
 
-  return [secpInstruction, listenInstruction, priorityFeeInstruction]
+  return [secpInstruction, listenInstruction]
 }
 
 module.exports = {

--- a/packages/libs/src/services/solana/transactionHandler.ts
+++ b/packages/libs/src/services/solana/transactionHandler.ts
@@ -52,8 +52,8 @@ export class TransactionHandler {
     feePayerKeypairs = null,
     skipPreflight = true,
     retryTimeoutMs = 60000,
-    pollingFrequencyMs = 300,
-    sendingFrequencyMs = 300
+    pollingFrequencyMs = 2000,
+    sendingFrequencyMs = 2000
   }: {
     connection: Connection
     useRelay: boolean

--- a/packages/libs/src/services/solana/transactionHandler.ts
+++ b/packages/libs/src/services/solana/transactionHandler.ts
@@ -178,6 +178,7 @@ export class TransactionHandler {
     lookupTableAddresses: string[],
     retry = true
   ) {
+    const txStartTime = Date.now()
     const feePayerKeypairOverride = (() => {
       if (feePayerOverride && this.feePayerKeypairs) {
         const stringFeePayer = feePayerOverride.toString()
@@ -277,10 +278,9 @@ export class TransactionHandler {
     // Send the txn
     const sendRawTransaction = async () => {
       return await this.connection.sendRawTransaction(rawTransaction, {
-        skipPreflight:
-          skipPreflight === null ? this.skipPreflight : skipPreflight,
+        skipPreflight: true,
         preflightCommitment: 'processed',
-        maxRetries: retry ? 0 : undefined
+        maxRetries: 0
       })
     }
 
@@ -323,7 +323,9 @@ export class TransactionHandler {
       await this._awaitTransactionSignatureConfirmation(txid, logger)
       done = true
       logger.info(
-        `transactionHandler: finished for txid ${txid} with ${sendCount} retries`
+        `transactionHandler: finished for txid ${txid} with ${sendCount} retries ${
+          Date.now() - txStartTime
+        }`
       )
       return {
         res: txid,


### PR DESCRIPTION
### Description

Slow down retries for solana transactions and revert priority listens as it's not necessary at the moment.

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._

Running in prod identity confirmed tansactions.