### PR TITLE
RPC fallback on error

### DIFF
--- a/packages/discovery-provider/ddl/pg_migrate.sh
+++ b/packages/discovery-provider/ddl/pg_migrate.sh
@@ -39,9 +39,12 @@ migrate_dir() {
     migration_files=$(ls "$1"/*.sql | sort -V)
 
     md5s=$(psql -c "select md5 from $MIGRATIONS_TABLE")
+    echo $migration_files
+    echo $md5s
 
     for file in $migration_files; do
         md5=$(cat "$file" | tr -d "[:space:]" | md5sum | awk '{print $1}')
+        echo $md5
 
         if [[ $md5s =~ $md5 ]]; then
           # echo "... skipping $file $md5"
@@ -49,7 +52,7 @@ migrate_dir() {
         fi
 
         if [[ $file =~ "failable" ]]; then
-            # echo "Applying failable $file"
+            echo "Applying failable $file"
             set +e
             psql < "$file"
             retval=$?

--- a/packages/discovery-provider/ddl/pg_migrate.sh
+++ b/packages/discovery-provider/ddl/pg_migrate.sh
@@ -39,12 +39,9 @@ migrate_dir() {
     migration_files=$(ls "$1"/*.sql | sort -V)
 
     md5s=$(psql -c "select md5 from $MIGRATIONS_TABLE")
-    echo $migration_files
-    echo $md5s
 
     for file in $migration_files; do
         md5=$(cat "$file" | tr -d "[:space:]" | md5sum | awk '{print $1}')
-        echo $md5
 
         if [[ $md5s =~ $md5 ]]; then
           # echo "... skipping $file $md5"
@@ -52,7 +49,7 @@ migrate_dir() {
         fi
 
         if [[ $file =~ "failable" ]]; then
-            echo "Applying failable $file"
+            # echo "Applying failable $file"
             set +e
             psql < "$file"
             retval=$?

--- a/packages/libs/src/services/solana/SolanaWeb3Manager.ts
+++ b/packages/libs/src/services/solana/SolanaWeb3Manager.ts
@@ -186,8 +186,9 @@ export class SolanaWeb3Manager {
     } = this.solanaWeb3Config
 
     this.solanaClusterEndpoint = solanaClusterEndpoint
+
+    this.connections = []
     for (const endpoint of this.solanaClusterEndpoint.split(',')) {
-      this.connections = []
       this.connections.push(
         new Connection(endpoint, {
           confirmTransactionInitialTimeout:
@@ -200,7 +201,8 @@ export class SolanaWeb3Manager {
       connection: this.getConnection(),
       useRelay,
       identityService: this.identityService,
-      feePayerKeypairs
+      feePayerKeypairs,
+      fallbackConnections: this.connections
     })
 
     this.mints = {

--- a/packages/libs/src/services/solana/transactionHandler.ts
+++ b/packages/libs/src/services/solana/transactionHandler.ts
@@ -336,17 +336,20 @@ export class TransactionHandler {
         errorCode: null
       }
     } catch (e) {
+      const fallbackConnection =
+        sample(
+          this.fallbackConnections?.filter(
+            (conn) => conn.rpcEndpoint !== this.connection.rpcEndpoint
+          )
+        ) ?? this.connection
       logger.error(
         `transactionHandler: error in awaitTransactionSignature: ${JSON.stringify(
           e
         )}, ${txid}, with ${sendCount} retries to ${
           this.connection.rpcEndpoint
-        }`
+        } falling back to ${fallbackConnection.rpcEndpoint}`
       )
-      this.connection =
-        sample(
-          this.fallbackConnections?.filter((conn) => conn !== this.connection)
-        ) ?? this.connection
+      this.connection = fallbackConnection
       done = true
       let errorCode = null
       let error = null

--- a/packages/libs/src/services/solana/transactionHandler.ts
+++ b/packages/libs/src/services/solana/transactionHandler.ts
@@ -322,7 +322,7 @@ export class TransactionHandler {
       done = true
       logger.info(
         `transactionHandler: finished sending txid ${txid} with ${sendCount} retries to ${
-          this.connection
+          this.connection.rpcEndpoint
         } in ${Date.now() - txStartTime} ms`
       )
       return {
@@ -334,7 +334,9 @@ export class TransactionHandler {
       logger.error(
         `transactionHandler: error in awaitTransactionSignature: ${JSON.stringify(
           e
-        )}, ${txid}, with ${sendCount} retries to ${this.connection}`
+        )}, ${txid}, with ${sendCount} retries to ${
+          this.connection.rpcEndpoint
+        }`
       )
       done = true
       let errorCode = null

--- a/packages/libs/src/services/solana/transactionHandler.ts
+++ b/packages/libs/src/services/solana/transactionHandler.ts
@@ -9,6 +9,7 @@ import {
   VersionedTransaction
 } from '@solana/web3.js'
 import bs58 from 'bs58'
+import { sample } from 'lodash'
 
 import type { Logger, Nullable } from '../../utils'
 import type { IdentityService, RelayTransactionData } from '../identity'
@@ -33,7 +34,7 @@ type HandleTransactionParams = {
  * or via IdentityService's relay.
  */
 export class TransactionHandler {
-  private readonly connection: Connection
+  private connection: Connection
   private readonly useRelay: boolean
   private readonly identityService: IdentityService | null
   private readonly feePayerKeypairs: Keypair[] | null
@@ -41,6 +42,7 @@ export class TransactionHandler {
   private readonly retryTimeoutMs: number
   private readonly pollingFrequencyMs: number
   private readonly sendingFrequencyMs: number
+  private readonly fallbackConnections: Connection[] | null
 
   /**
    * Creates an instance of TransactionHandler.
@@ -53,7 +55,8 @@ export class TransactionHandler {
     skipPreflight = true,
     retryTimeoutMs = 60000,
     pollingFrequencyMs = 2000,
-    sendingFrequencyMs = 2000
+    sendingFrequencyMs = 2000,
+    fallbackConnections = null
   }: {
     connection: Connection
     useRelay: boolean
@@ -63,6 +66,7 @@ export class TransactionHandler {
     retryTimeoutMs?: number
     pollingFrequencyMs?: number
     sendingFrequencyMs?: number
+    fallbackConnections?: Connection[] | null
   }) {
     this.connection = connection
     this.useRelay = useRelay
@@ -72,6 +76,7 @@ export class TransactionHandler {
     this.retryTimeoutMs = retryTimeoutMs
     this.pollingFrequencyMs = pollingFrequencyMs
     this.sendingFrequencyMs = sendingFrequencyMs
+    this.fallbackConnections = fallbackConnections
   }
 
   /**
@@ -338,6 +343,10 @@ export class TransactionHandler {
           this.connection.rpcEndpoint
         }`
       )
+      this.connection =
+        sample(
+          this.fallbackConnections?.filter((conn) => conn !== this.connection)
+        ) ?? this.connection
       done = true
       let errorCode = null
       let error = null


### PR DESCRIPTION
### Description

https://github.com/AudiusProject/audius-protocol/pull/8024 instantiates libs w a random RPC endpoint on startup, but doesn't rotate after that. This change allows RPCs to fallback on error.

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._

Tested on stage, confirmed errors cause RPCs to rotate.
```
transactionHandler: finished sending txid 5cEkdyHhpCwYYG2MBH2cUhBF8gsDJ7ps1nuhNwWsyobg8BU2xsKuLfgpb4JpQwCAsP88oac5tKmHcmVUSk71EAyH with 17 retries to https://audius.rpcpool.com/a9a724f9717b3395117350265c4e in 33218 ms
transactionHandler: Timed out in await, HqKrbfXGJ2Y5Bk5u18XziMHJmsyVsZVz9zM92Pj8GMWs51XMQtpTvs3EAmXYF7fbujdvoyojrHdHcJHFdt7QuT2
transactionHandler: error in awaitTransactionSignature: {}, HqKrbfXGJ2Y5Bk5u18XziMHJmsyVsZVz9zM92Pj8GMWs51XMQtpTvs3EAmXYF7fbujdvoyojrHdHcJHFdt7QuT2, with 30 retries to https://audius.rpcpool.com/a9a724f9717b3395117350265c4e falling back to https://audius.rpcpool.com/a9a724f9717b3395117350265c4e out of null
transactionHandler: finished sending txid 59QjAoa5vVL6NViuHWh4j1XwHM5VUas3oEwqhmJfviNy3UGD9G4YAfbiofSr979fYpPB3cukhNwBLDf4cuSGXxM2 with 13 retries to https://virulent-magical-arm.solana-mainnet.quiknode.pro/321f97700d8f61a4f1de9c14fb070c29db8d8cb0 in 24344 ms
```