### PR TITLE
Cache content nodes immediately at startup

### DIFF
--- a/packages/discovery-provider/src/app.py
+++ b/packages/discovery-provider/src/app.py
@@ -40,6 +40,7 @@ from src.solana.solana_client_manager import SolanaClientManager
 from src.tasks import celery_app
 from src.tasks.index_reactions import INDEX_REACTIONS_LOCK
 from src.tasks.update_delist_statuses import UPDATE_DELIST_STATUSES_LOCK
+from src.tasks.cache_current_nodes import do_cache_current_nodes
 from src.utils import helpers, web3_provider
 from src.utils.config import ConfigIni, config_files, shared_config
 from src.utils.constants import CONTRACT_NAMES_ON_CHAIN, CONTRACT_TYPES
@@ -527,8 +528,10 @@ def configure_celery(celery, test_config=None):
 
     celery.finalize()
 
+    # Cache current nodes at startup
+    do_cache_current_nodes(redis_inst)
+
     # Start tasks that should fire upon startup
-    celery.send_task("cache_current_nodes")
     celery.send_task("cache_entity_counts")
     celery.send_task("index_nethermind", queue="index_nethermind")
     celery.send_task("index_user_bank", queue="index_sol")

--- a/packages/discovery-provider/src/app.py
+++ b/packages/discovery-provider/src/app.py
@@ -528,6 +528,7 @@ def configure_celery(celery, test_config=None):
     celery.finalize()
 
     # Start tasks that should fire upon startup
+    celery.send_task("cache_current_nodes")
     celery.send_task("cache_entity_counts")
     celery.send_task("index_nethermind", queue="index_nethermind")
     celery.send_task("index_user_bank", queue="index_sol")

--- a/packages/discovery-provider/src/app.py
+++ b/packages/discovery-provider/src/app.py
@@ -38,9 +38,9 @@ from src.queries import (
 )
 from src.solana.solana_client_manager import SolanaClientManager
 from src.tasks import celery_app
+from src.tasks.cache_current_nodes import do_cache_current_nodes
 from src.tasks.index_reactions import INDEX_REACTIONS_LOCK
 from src.tasks.update_delist_statuses import UPDATE_DELIST_STATUSES_LOCK
-from src.tasks.cache_current_nodes import do_cache_current_nodes
 from src.utils import helpers, web3_provider
 from src.utils.config import ConfigIni, config_files, shared_config
 from src.utils.constants import CONTRACT_NAMES_ON_CHAIN, CONTRACT_TYPES

--- a/packages/discovery-provider/src/tasks/cache_current_nodes.py
+++ b/packages/discovery-provider/src/tasks/cache_current_nodes.py
@@ -23,7 +23,7 @@ def cache_current_nodes_task(self):
     do_cache_current_nodes(redis)
 
 
-def do_cache_current_nodes(redis)
+def do_cache_current_nodes(redis):
     # Define lock acquired boolean
     have_lock = False
     # Define redis lock object

--- a/packages/discovery-provider/src/tasks/cache_current_nodes.py
+++ b/packages/discovery-provider/src/tasks/cache_current_nodes.py
@@ -20,6 +20,10 @@ logger = logging.getLogger(__name__)
 @save_duration_metric(metric_group="celery_task")
 def cache_current_nodes_task(self):
     redis = cache_current_nodes_task.redis
+    do_cache_current_nodes(redis)
+
+
+def do_cache_current_nodes(redis)
     # Define lock acquired boolean
     have_lock = False
     # Define redis lock object

--- a/packages/discovery-provider/src/tasks/index_rewards_manager.py
+++ b/packages/discovery-provider/src/tasks/index_rewards_manager.py
@@ -132,9 +132,11 @@ def get_challenge_type_map(
             .all()
         )
         challenge_type_map_global = {
-            challenge[0]: TransactionType.trending_reward
-            if challenge[1] == ChallengeType.trending
-            else TransactionType.user_reward
+            challenge[0]: (
+                TransactionType.trending_reward
+                if challenge[1] == ChallengeType.trending
+                else TransactionType.user_reward
+            )
             for challenge in challenges
         }
 

--- a/packages/discovery-provider/src/tasks/user_listening_history/index_user_listening_history.py
+++ b/packages/discovery-provider/src/tasks/user_listening_history/index_user_listening_history.py
@@ -111,10 +111,10 @@ def update_existing_user_listening_histories(
             )
             track_to_play_count[new_play["track_id"]] += 1
 
-        existing_user_listening_history[
-            i
-        ].listening_history = sort_listening_history_desc_by_timestamp(
-            track_to_latest_timestamp, track_to_play_count
+        existing_user_listening_history[i].listening_history = (
+            sort_listening_history_desc_by_timestamp(
+                track_to_latest_timestamp, track_to_play_count
+            )
         )
 
 


### PR DESCRIPTION
### Description

Avoids a 20-30min downtime on fresh startup while we wait for content nodes cache to populate on the discovery node. This is because no celery tasks on the main queue are processed during the first 20-30 minutes for reasons not yet clear.

### How Has This Been Tested?

Successfully tested on stage dn5