### PR TITLE
[PAY-2675] New Purchase/Sale details modal UI

### DIFF
--- a/packages/web/src/components/link/ExternalLink.tsx
+++ b/packages/web/src/components/link/ExternalLink.tsx
@@ -1,19 +1,28 @@
-import { MouseEvent, useCallback } from 'react'
+import { MouseEvent, ReactNode, useCallback } from 'react'
 
 import { Name } from '@audius/common/models'
 import { useLeavingAudiusModal } from '@audius/common/store'
 import { isAllowedExternalLink } from '@audius/common/utils'
-import { TextLink, TextLinkProps } from '@audius/harmony'
 
 import { make, useRecord } from 'common/store/analytics/actions'
 
-type ExternalLinkProps = Omit<TextLinkProps, 'href'> & {
+export type ExternalLinkProps = {
+  to: string
+  onClick?: (event: MouseEvent<HTMLAnchorElement>) => void
   source?: 'profile page' | 'track page' | 'collection page'
   ignoreWarning?: boolean
+  children: ReactNode
 }
 
 export const ExternalLink = (props: ExternalLinkProps) => {
-  const { to, onClick, source, ignoreWarning = false, ...other } = props
+  const {
+    to,
+    onClick,
+    source,
+    ignoreWarning = false,
+    children,
+    ...other
+  } = props
 
   const record = useRecord()
   const { onOpen: openLeavingAudiusModal } = useLeavingAudiusModal()
@@ -38,5 +47,15 @@ export const ExternalLink = (props: ExternalLinkProps) => {
     [onClick, record, source, openLeavingAudiusModal, to, ignoreWarning]
   )
 
-  return <TextLink isExternal href={to} onClick={handleClick} {...other} />
+  return (
+    <a
+      target='_blank'
+      rel='noreferrer'
+      href={to}
+      onClick={handleClick}
+      {...other}
+    >
+      {children}
+    </a>
+  )
 }

--- a/packages/web/src/components/link/ExternalTextLink.tsx
+++ b/packages/web/src/components/link/ExternalTextLink.tsx
@@ -1,0 +1,21 @@
+import { TextLink, TextLinkProps } from '@audius/harmony'
+
+import { ExternalLink, ExternalLinkProps } from './ExternalLink'
+
+type ExternalTextLinkProps = Omit<TextLinkProps, 'href'> & ExternalLinkProps
+
+export const ExternalTextLink = (props: ExternalTextLinkProps) => {
+  const { to, onClick, source, ignoreWarning, children, ...other } = props
+  return (
+    <TextLink asChild {...other}>
+      <ExternalLink
+        to={to}
+        onClick={onClick}
+        source={source}
+        ignoreWarning={ignoreWarning}
+      >
+        {children}
+      </ExternalLink>
+    </TextLink>
+  )
+}

--- a/packages/web/src/components/link/index.ts
+++ b/packages/web/src/components/link/index.ts
@@ -1,4 +1,5 @@
 export * from './SeoLink'
 export * from './ExternalLink'
+export * from './ExternalTextLink'
 export * from './UserLink'
 export * from './TextLink'

--- a/packages/web/src/components/track/DynamicTrackArtwork.module.css
+++ b/packages/web/src/components/track/DynamicTrackArtwork.module.css
@@ -16,3 +16,7 @@
 .default {
   --size: var(--harmony-unit-16);
 }
+
+.default {
+  --size: var(--harmony-unit-24);
+}

--- a/packages/web/src/components/track/DynamicTrackArtwork.module.css
+++ b/packages/web/src/components/track/DynamicTrackArtwork.module.css
@@ -17,6 +17,6 @@
   --size: var(--harmony-unit-16);
 }
 
-.default {
+.large {
   --size: var(--harmony-unit-24);
 }

--- a/packages/web/src/components/track/DynamicTrackArtwork.tsx
+++ b/packages/web/src/components/track/DynamicTrackArtwork.tsx
@@ -13,7 +13,7 @@ export enum DynamicTrackArtworkSize {
   /** 64x64 */
   DEFAULT = 'default',
   /** 96x96 */
-  LARGE = 'default'
+  LARGE = 'large'
 }
 
 type DynamicTrackArtworkProps = {

--- a/packages/web/src/components/track/DynamicTrackArtwork.tsx
+++ b/packages/web/src/components/track/DynamicTrackArtwork.tsx
@@ -11,7 +11,9 @@ export enum DynamicTrackArtworkSize {
   /** 40x40 */
   SMALL = 'small',
   /** 64x64 */
-  DEFAULT = 'default'
+  DEFAULT = 'default',
+  /** 96x96 */
+  LARGE = 'default'
 }
 
 type DynamicTrackArtworkProps = {

--- a/packages/web/src/components/usdc-purchase-details-modal/components/DetailSection.tsx
+++ b/packages/web/src/components/usdc-purchase-details-modal/components/DetailSection.tsx
@@ -1,6 +1,6 @@
-import { Flex, Text } from '@audius/harmony'
-
 import React from 'react'
+
+import { Flex, Text } from '@audius/harmony'
 
 export const DetailSection = ({
   children,

--- a/packages/web/src/components/usdc-purchase-details-modal/components/DetailSection.tsx
+++ b/packages/web/src/components/usdc-purchase-details-modal/components/DetailSection.tsx
@@ -5,15 +5,15 @@ import React from 'react'
 export const DetailSection = ({
   children,
   label,
-  button
+  actionButton
 }: {
   children?: React.ReactNode
   label: string | React.ReactNode
-  button?: React.ReactNode
+  actionButton?: React.ReactNode
 }) => (
   <Flex
     w='100%'
-    alignItems={button ? undefined : 'center'}
+    alignItems={actionButton ? undefined : 'center'}
     css={{ overflow: 'hidden' }}
   >
     <Flex gap='s' direction='column' w='100%'>
@@ -22,6 +22,6 @@ export const DetailSection = ({
       </Text>
       {children}
     </Flex>
-    {button}
+    {actionButton}
   </Flex>
 )

--- a/packages/web/src/components/usdc-purchase-details-modal/components/DetailSection.tsx
+++ b/packages/web/src/components/usdc-purchase-details-modal/components/DetailSection.tsx
@@ -1,18 +1,27 @@
-import { Text } from '@audius/harmony'
+import { Flex, Text } from '@audius/harmony'
 
-import styles from './styles.module.css'
+import React from 'react'
 
 export const DetailSection = ({
   children,
-  label
+  label,
+  button
 }: {
   children?: React.ReactNode
   label: string | React.ReactNode
+  button?: React.ReactNode
 }) => (
-  <div className={styles.detailSection}>
-    <Text variant='label' size='l' color='subdued'>
-      {label}
-    </Text>
-    {children}
-  </div>
+  <Flex
+    justifyContent='space-between'
+    w='100%'
+    alignItems={button ? undefined : 'center'}
+  >
+    <Flex gap='s' direction='column'>
+      <Text variant='label' size='l' color='subdued'>
+        {label}
+      </Text>
+      {children}
+    </Flex>
+    {button}
+  </Flex>
 )

--- a/packages/web/src/components/usdc-purchase-details-modal/components/DetailSection.tsx
+++ b/packages/web/src/components/usdc-purchase-details-modal/components/DetailSection.tsx
@@ -12,11 +12,11 @@ export const DetailSection = ({
   button?: React.ReactNode
 }) => (
   <Flex
-    justifyContent='space-between'
     w='100%'
     alignItems={button ? undefined : 'center'}
+    css={{ overflow: 'hidden' }}
   >
-    <Flex gap='s' direction='column'>
+    <Flex gap='s' direction='column' w='100%'>
       <Text variant='label' size='l' color='subdued'>
         {label}
       </Text>

--- a/packages/web/src/components/usdc-purchase-details-modal/components/PurchaseModalContent.tsx
+++ b/packages/web/src/components/usdc-purchase-details-modal/components/PurchaseModalContent.tsx
@@ -88,7 +88,7 @@ export const PurchaseModalContent = ({
         </Flex>
         <DetailSection
           label={messages.transactionDate}
-          button={
+          actionButton={
             <Button
               iconLeft={IconExternalLink}
               variant='secondary'

--- a/packages/web/src/components/usdc-purchase-details-modal/components/PurchaseModalContent.tsx
+++ b/packages/web/src/components/usdc-purchase-details-modal/components/PurchaseModalContent.tsx
@@ -33,7 +33,7 @@ import { useFlag } from 'hooks/useRemoteConfig'
 import { FeatureFlags } from '@audius/common/services'
 
 const messages = {
-  by: 'By',
+  by: 'by',
   date: 'Date',
   transactionDate: 'Transaction Date',
   done: 'Done',
@@ -59,46 +59,42 @@ export const PurchaseModalContent = ({
     }
   }, [track, onClose, goToRoute])
 
-  return isPremiumAlbumsEnabled ? (
+  return !isPremiumAlbumsEnabled ? (
     <>
       <ModalHeader>
         <ModalTitle title={messages.purchaseDetails} />
       </ModalHeader>
       <ModalContent className={styles.content}>
-        <Flex gap='xl' direction='column' w='100%'>
-          <Flex
-            borderBottom='default'
-            gap='l'
-            justifyContent='spaceBetween'
-            w='100%'
-            pb='xl'
-          >
-            <DynamicTrackArtwork
-              id={purchaseDetails.contentId}
-              size={DynamicTrackArtworkSize.LARGE}
-            />
-            <DetailSection label={messages.track}>
-              <TrackLink onClick={onClose} id={purchaseDetails.contentId} />
-              <Flex gap='xs'>
-                <Text variant='body' size='l' textTransform='lowercase'>
-                  {messages.by}
-                </Text>
-                <Text variant='body' size='l' color='accent'>
-                  <UserNameAndBadges
-                    onNavigateAway={onClose}
-                    userId={purchaseDetails.sellerUserId}
-                  />
-                </Text>
-              </Flex>
-            </DetailSection>
-          </Flex>
-          <Flex justifyContent='space-between' w='100%'>
-            <Flex gap='s' direction='column'>
-              <Text variant='label'>{messages.transactionDate}</Text>
+        <Flex
+          borderBottom='default'
+          gap='l'
+          justifyContent='spaceBetween'
+          w='100%'
+          pb='xl'
+          alignItems='center'
+        >
+          <DynamicTrackArtwork
+            id={purchaseDetails.contentId}
+            size={DynamicTrackArtworkSize.LARGE}
+          />
+          <DetailSection label={messages.track}>
+            <TrackLink onClick={onClose} id={purchaseDetails.contentId} />
+            <Flex gap='xs'>
               <Text variant='body' size='l'>
-                {moment(purchaseDetails.createdAt).format('MMM DD, YYYY')}
+                {messages.by}
+              </Text>
+              <Text variant='body' size='l' color='accent'>
+                <UserNameAndBadges
+                  onNavigateAway={onClose}
+                  userId={purchaseDetails.sellerUserId}
+                />
               </Text>
             </Flex>
+          </DetailSection>
+        </Flex>
+        <DetailSection
+          label={messages.transactionDate}
+          button={
             <Button
               iconLeft={IconExternalLink}
               variant='secondary'
@@ -109,12 +105,16 @@ export const PurchaseModalContent = ({
                 {messages.transaction}
               </a>
             </Button>
-          </Flex>
-          <TransactionSummary transaction={purchaseDetails} />
-        </Flex>
+          }
+        >
+          <Text variant='body' size='l'>
+            {moment(purchaseDetails.createdAt).format('MMM DD, YYYY')}
+          </Text>
+        </DetailSection>
+        <TransactionSummary transaction={purchaseDetails} />
       </ModalContent>
-      <ModalFooter className={styles.footer}>
-        <Button className={styles.button} onClick={onClose}>
+      <ModalFooter style={{ paddingTop: 0 }}>
+        <Button onClick={onClose} fullWidth>
           {messages.done}
         </Button>
       </ModalFooter>
@@ -132,7 +132,10 @@ export const PurchaseModalContent = ({
           <DetailSection label={messages.track}>
             <TrackLink onClick={onClose} id={purchaseDetails.contentId} />
           </DetailSection>
-          <DynamicTrackArtwork id={purchaseDetails.contentId} />
+          <DynamicTrackArtwork
+            id={purchaseDetails.contentId}
+            size={DynamicTrackArtworkSize.DEFAULT}
+          />
         </div>
         <DetailSection label={messages.by}>
           <Text variant='body' size='l' color='accent'>

--- a/packages/web/src/components/usdc-purchase-details-modal/components/PurchaseModalContent.tsx
+++ b/packages/web/src/components/usdc-purchase-details-modal/components/PurchaseModalContent.tsx
@@ -31,8 +31,6 @@ import styles from './styles.module.css'
 import { ContentProps } from './types'
 import { useFlag } from 'hooks/useRemoteConfig'
 import { FeatureFlags } from '@audius/common/services'
-import { Link } from 'react-router-dom'
-import { ExternalLink } from 'components/link'
 
 const messages = {
   by: 'By',

--- a/packages/web/src/components/usdc-purchase-details-modal/components/PurchaseModalContent.tsx
+++ b/packages/web/src/components/usdc-purchase-details-modal/components/PurchaseModalContent.tsx
@@ -17,7 +17,10 @@ import {
 } from '@audius/harmony'
 import moment from 'moment'
 
-import { DynamicTrackArtwork } from 'components/track/DynamicTrackArtwork'
+import {
+  DynamicTrackArtwork,
+  DynamicTrackArtworkSize
+} from 'components/track/DynamicTrackArtwork'
 import { UserNameAndBadges } from 'components/user-name-and-badges/UserNameAndBadges'
 import { useGoToRoute } from 'hooks/useGoToRoute'
 
@@ -26,10 +29,15 @@ import { TrackLink } from './TrackLink'
 import { TransactionSummary } from './TransactionSummary'
 import styles from './styles.module.css'
 import { ContentProps } from './types'
+import { useFlag } from 'hooks/useRemoteConfig'
+import { FeatureFlags } from '@audius/common/services'
+import { Link } from 'react-router-dom'
+import { ExternalLink } from 'components/link'
 
 const messages = {
   by: 'By',
   date: 'Date',
+  transactionDate: 'Transaction Date',
   done: 'Done',
   purchaseDetails: 'Purchase Details',
   track: 'Track',
@@ -41,6 +49,9 @@ export const PurchaseModalContent = ({
   purchaseDetails,
   onClose
 }: ContentProps) => {
+  const { isEnabled: isPremiumAlbumsEnabled } = useFlag(
+    FeatureFlags.PREMIUM_ALBUMS_ENABLED
+  )
   const goToRoute = useGoToRoute()
   const { data: track } = useGetTrackById({ id: purchaseDetails.contentId })
   const handleClickVisitTrack = useCallback(() => {
@@ -50,7 +61,67 @@ export const PurchaseModalContent = ({
     }
   }, [track, onClose, goToRoute])
 
-  return (
+  return isPremiumAlbumsEnabled ? (
+    <>
+      <ModalHeader>
+        <ModalTitle title={messages.purchaseDetails} />
+      </ModalHeader>
+      <ModalContent className={styles.content}>
+        <Flex gap='xl' direction='column' w='100%'>
+          <Flex
+            borderBottom='default'
+            gap='l'
+            justifyContent='spaceBetween'
+            w='100%'
+            pb='xl'
+          >
+            <DynamicTrackArtwork
+              id={purchaseDetails.contentId}
+              size={DynamicTrackArtworkSize.LARGE}
+            />
+            <DetailSection label={messages.track}>
+              <TrackLink onClick={onClose} id={purchaseDetails.contentId} />
+              <Flex gap='xs'>
+                <Text variant='body' size='l' textTransform='lowercase'>
+                  {messages.by}
+                </Text>
+                <Text variant='body' size='l' color='accent'>
+                  <UserNameAndBadges
+                    onNavigateAway={onClose}
+                    userId={purchaseDetails.sellerUserId}
+                  />
+                </Text>
+              </Flex>
+            </DetailSection>
+          </Flex>
+          <Flex justifyContent='space-between' w='100%'>
+            <Flex gap='s' direction='column'>
+              <Text variant='label'>{messages.transactionDate}</Text>
+              <Text variant='body' size='l'>
+                {moment(purchaseDetails.createdAt).format('MMM DD, YYYY')}
+              </Text>
+            </Flex>
+            <Button
+              iconLeft={IconExternalLink}
+              variant='secondary'
+              size='small'
+              asChild
+            >
+              <a href={makeSolanaTransactionLink(purchaseDetails.signature)}>
+                {messages.transaction}
+              </a>
+            </Button>
+          </Flex>
+          <TransactionSummary transaction={purchaseDetails} />
+        </Flex>
+      </ModalContent>
+      <ModalFooter className={styles.footer}>
+        <Button className={styles.button} onClick={onClose}>
+          {messages.done}
+        </Button>
+      </ModalFooter>
+    </>
+  ) : (
     <>
       <ModalHeader>
         <ModalTitle

--- a/packages/web/src/components/usdc-purchase-details-modal/components/PurchaseModalContent.tsx
+++ b/packages/web/src/components/usdc-purchase-details-modal/components/PurchaseModalContent.tsx
@@ -1,5 +1,5 @@
 import { useCallback } from 'react'
-import { UserLink } from 'components/link'
+import { ExternalLink, UserLink } from 'components/link'
 
 import { useGetTrackById } from '@audius/common/api'
 import { makeSolanaTransactionLink } from '@audius/common/utils'
@@ -95,9 +95,11 @@ export const PurchaseModalContent = ({
               size='small'
               asChild
             >
-              <a href={makeSolanaTransactionLink(purchaseDetails.signature)}>
+              <ExternalLink
+                to={makeSolanaTransactionLink(purchaseDetails.signature)}
+              >
                 {messages.transaction}
-              </a>
+              </ExternalLink>
             </Button>
           }
         >

--- a/packages/web/src/components/usdc-purchase-details-modal/components/PurchaseModalContent.tsx
+++ b/packages/web/src/components/usdc-purchase-details-modal/components/PurchaseModalContent.tsx
@@ -1,7 +1,7 @@
 import { useCallback } from 'react'
-import { ExternalLink, UserLink } from 'components/link'
 
 import { useGetTrackById } from '@audius/common/api'
+import { FeatureFlags } from '@audius/common/services'
 import { makeSolanaTransactionLink } from '@audius/common/utils'
 import {
   ModalContent,
@@ -18,20 +18,20 @@ import {
 } from '@audius/harmony'
 import moment from 'moment'
 
+import { ExternalLink, UserLink } from 'components/link'
 import {
   DynamicTrackArtwork,
   DynamicTrackArtworkSize
 } from 'components/track/DynamicTrackArtwork'
 import { UserNameAndBadges } from 'components/user-name-and-badges/UserNameAndBadges'
 import { useGoToRoute } from 'hooks/useGoToRoute'
+import { useFlag } from 'hooks/useRemoteConfig'
 
 import { DetailSection } from './DetailSection'
 import { TrackLink } from './TrackLink'
 import { TransactionSummary } from './TransactionSummary'
 import styles from './styles.module.css'
 import { ContentProps } from './types'
-import { useFlag } from 'hooks/useRemoteConfig'
-import { FeatureFlags } from '@audius/common/services'
 
 const messages = {
   by: 'by',

--- a/packages/web/src/components/usdc-purchase-details-modal/components/PurchaseModalContent.tsx
+++ b/packages/web/src/components/usdc-purchase-details-modal/components/PurchaseModalContent.tsx
@@ -59,20 +59,13 @@ export const PurchaseModalContent = ({
     }
   }, [track, onClose, goToRoute])
 
-  return !isPremiumAlbumsEnabled ? (
+  return isPremiumAlbumsEnabled ? (
     <>
       <ModalHeader>
         <ModalTitle title={messages.purchaseDetails} />
       </ModalHeader>
       <ModalContent className={styles.content}>
-        <Flex
-          borderBottom='default'
-          gap='l'
-          justifyContent='spaceBetween'
-          w='100%'
-          pb='xl'
-          alignItems='center'
-        >
+        <Flex borderBottom='default' gap='l' w='100%' pb='xl'>
           <DynamicTrackArtwork
             id={purchaseDetails.contentId}
             size={DynamicTrackArtworkSize.LARGE}

--- a/packages/web/src/components/usdc-purchase-details-modal/components/PurchaseModalContent.tsx
+++ b/packages/web/src/components/usdc-purchase-details-modal/components/PurchaseModalContent.tsx
@@ -1,4 +1,5 @@
 import { useCallback } from 'react'
+import { UserLink } from 'components/link'
 
 import { useGetTrackById } from '@audius/common/api'
 import { makeSolanaTransactionLink } from '@audius/common/utils'
@@ -76,12 +77,12 @@ export const PurchaseModalContent = ({
               <Text variant='body' size='l'>
                 {messages.by}
               </Text>
-              <Text variant='body' size='l' color='accent'>
-                <UserNameAndBadges
-                  onNavigateAway={onClose}
-                  userId={purchaseDetails.sellerUserId}
-                />
-              </Text>
+              <UserLink
+                userId={purchaseDetails.sellerUserId}
+                popover
+                textVariant='body'
+                size='l'
+              />
             </Flex>
           </DetailSection>
         </Flex>

--- a/packages/web/src/components/usdc-purchase-details-modal/components/SaleModalContent.tsx
+++ b/packages/web/src/components/usdc-purchase-details-modal/components/SaleModalContent.tsx
@@ -113,7 +113,7 @@ export const SaleModalContent = ({
         <Flex borderBottom='default' w='100%' pb='xl'>
           <DetailSection
             label={messages.purchasedBy}
-            button={
+            actionButton={
               <Button
                 iconLeft={IconMessage}
                 variant='secondary'

--- a/packages/web/src/components/usdc-purchase-details-modal/components/SaleModalContent.tsx
+++ b/packages/web/src/components/usdc-purchase-details-modal/components/SaleModalContent.tsx
@@ -1,5 +1,6 @@
 import { useCallback } from 'react'
 
+import { FeatureFlags } from '@audius/common/services'
 import {
   chatActions,
   chatSelectors,
@@ -23,20 +24,19 @@ import {
 import moment from 'moment'
 import { useDispatch, useSelector } from 'react-redux'
 
+import { ExternalTextLink, UserLink } from 'components/link'
 import {
   DynamicTrackArtwork,
   DynamicTrackArtworkSize
 } from 'components/track/DynamicTrackArtwork'
 import { UserNameAndBadges } from 'components/user-name-and-badges/UserNameAndBadges'
+import { useFlag } from 'hooks/useRemoteConfig'
 
 import { DetailSection } from './DetailSection'
 import { TrackLink } from './TrackLink'
 import { TransactionSummary } from './TransactionSummary'
 import styles from './styles.module.css'
 import { ContentProps } from './types'
-import { useFlag } from 'hooks/useRemoteConfig'
-import { FeatureFlags } from '@audius/common/services'
-import { ExternalLink, UserLink } from 'components/link'
 
 const { getCanCreateChat } = chatSelectors
 const { createChat } = chatActions
@@ -141,11 +141,11 @@ export const SaleModalContent = ({
               size='small'
               asChild
             >
-              <ExternalLink
+              <ExternalTextLink
                 to={makeSolanaTransactionLink(purchaseDetails.signature)}
               >
                 {messages.transaction}
-              </ExternalLink>
+              </ExternalTextLink>
             </Button>
           }
         >

--- a/packages/web/src/components/usdc-purchase-details-modal/components/SaleModalContent.tsx
+++ b/packages/web/src/components/usdc-purchase-details-modal/components/SaleModalContent.tsx
@@ -36,13 +36,12 @@ import styles from './styles.module.css'
 import { ContentProps } from './types'
 import { useFlag } from 'hooks/useRemoteConfig'
 import { FeatureFlags } from '@audius/common/services'
-import { Link } from 'react-router-dom'
 
 const { getCanCreateChat } = chatSelectors
 const { createChat } = chatActions
 
 const messages = {
-  by: 'By',
+  by: 'by',
   date: 'Date',
   done: 'Done',
   messageBuyer: 'Message Buyer',
@@ -84,86 +83,84 @@ export const SaleModalContent = ({
     dispatch
   ])
 
-  return isPremiumAlbumsEnabled ? (
+  return !isPremiumAlbumsEnabled ? (
     <>
       <ModalHeader>
         <ModalTitle title={messages.saleDetails} />
       </ModalHeader>
       <ModalContent className={styles.content}>
-        <Flex gap='xl' direction='column' w='100%'>
-          <Flex
-            borderBottom='default'
-            gap='l'
-            justifyContent='spaceBetween'
-            w='100%'
-            pb='xl'
-          >
-            <DynamicTrackArtwork
-              id={purchaseDetails.contentId}
-              size={DynamicTrackArtworkSize.LARGE}
-            />
-            <DetailSection label={messages.track}>
-              <TrackLink onClick={onClose} id={purchaseDetails.contentId} />
-              <Flex gap='xs'>
-                <Text variant='body' size='l' textTransform='lowercase'>
-                  {messages.by}
-                </Text>
-                <Text variant='body' size='l' color='accent'>
-                  <UserNameAndBadges
-                    onNavigateAway={onClose}
-                    userId={purchaseDetails.sellerUserId}
-                  />
-                </Text>
-              </Flex>
-            </DetailSection>
-          </Flex>
-          <Flex
-            justifyContent='space-between'
-            w='100%'
-            borderBottom='default'
-            pb='xl'
-          >
-            <Flex gap='s' direction='column'>
-              <Text variant='label'> {messages.purchasedBy}</Text>
+        <Flex
+          borderBottom='default'
+          gap='l'
+          justifyContent='spaceBetween'
+          w='100%'
+          pb='xl'
+        >
+          <DynamicTrackArtwork
+            id={purchaseDetails.contentId}
+            size={DynamicTrackArtworkSize.LARGE}
+          />
+          <DetailSection label={messages.track}>
+            <TrackLink onClick={onClose} id={purchaseDetails.contentId} />
+            <Flex gap='xs'>
+              <Text variant='body' size='l'>
+                {messages.by}
+              </Text>
               <Text variant='body' size='l' color='accent'>
                 <UserNameAndBadges
                   onNavigateAway={onClose}
-                  userId={purchaseDetails.buyerUserId}
+                  userId={purchaseDetails.sellerUserId}
                 />
               </Text>
             </Flex>
-            <Button
-              iconLeft={IconMessage}
-              variant='secondary'
-              size='small'
-              onClick={handleClickMessageBuyer}
-            >
-              {messages.sayThanks}
-            </Button>
-          </Flex>
-          <Flex justifyContent='space-between' w='100%'>
-            <Flex gap='s' direction='column'>
-              <Text variant='label'>{messages.transactionDate}</Text>
-              <Text variant='body' size='l'>
-                {moment(purchaseDetails.createdAt).format('MMM DD, YYYY')}
-              </Text>
-            </Flex>
-            <Button
-              iconLeft={IconExternalLink}
-              variant='secondary'
-              size='small'
-              asChild
-            >
-              <a href={makeSolanaTransactionLink(purchaseDetails.signature)}>
-                {messages.transaction}
-              </a>
-            </Button>
-          </Flex>
-          <TransactionSummary transaction={purchaseDetails} />
+          </DetailSection>
         </Flex>
+        <Flex
+          justifyContent='space-between'
+          w='100%'
+          borderBottom='default'
+          pb='xl'
+        >
+          <Flex gap='s' direction='column'>
+            <Text variant='label'>{messages.purchasedBy}</Text>
+            <Text variant='body' size='l' color='accent'>
+              <UserNameAndBadges
+                onNavigateAway={onClose}
+                userId={purchaseDetails.buyerUserId}
+              />
+            </Text>
+          </Flex>
+          <Button
+            iconLeft={IconMessage}
+            variant='secondary'
+            size='small'
+            onClick={handleClickMessageBuyer}
+          >
+            {messages.sayThanks}
+          </Button>
+        </Flex>
+        <Flex justifyContent='space-between' w='100%'>
+          <Flex gap='s' direction='column'>
+            <Text variant='label'>{messages.transactionDate}</Text>
+            <Text variant='body' size='l'>
+              {moment(purchaseDetails.createdAt).format('MMM DD, YYYY')}
+            </Text>
+          </Flex>
+          <Button
+            iconLeft={IconExternalLink}
+            variant='secondary'
+            size='small'
+            asChild
+          >
+            <a href={makeSolanaTransactionLink(purchaseDetails.signature)}>
+              {messages.transaction}
+            </a>
+          </Button>
+        </Flex>
+        <TransactionSummary transaction={purchaseDetails} />
       </ModalContent>
-      <ModalFooter className={styles.footer}>
-        <Button className={styles.button} onClick={onClose}>
+      <ModalFooter style={{ paddingTop: 0 }}>
+        <Button onClick={onClose} fullWidth>
           {messages.done}
         </Button>
       </ModalFooter>

--- a/packages/web/src/components/usdc-purchase-details-modal/components/SaleModalContent.tsx
+++ b/packages/web/src/components/usdc-purchase-details-modal/components/SaleModalContent.tsx
@@ -36,6 +36,7 @@ import styles from './styles.module.css'
 import { ContentProps } from './types'
 import { useFlag } from 'hooks/useRemoteConfig'
 import { FeatureFlags } from '@audius/common/services'
+import { UserLink } from 'components/link'
 
 const { getCanCreateChat } = chatSelectors
 const { createChat } = chatActions
@@ -100,12 +101,12 @@ export const SaleModalContent = ({
               <Text variant='body' size='l'>
                 {messages.by}
               </Text>
-              <Text variant='body' size='l' color='accent'>
-                <UserNameAndBadges
-                  onNavigateAway={onClose}
-                  userId={purchaseDetails.sellerUserId}
-                />
-              </Text>
+              <UserLink
+                userId={purchaseDetails.sellerUserId}
+                popover
+                textVariant='body'
+                size='l'
+              />
             </Flex>
           </DetailSection>
         </Flex>
@@ -123,12 +124,12 @@ export const SaleModalContent = ({
               </Button>
             }
           >
-            <Text variant='body' size='l' color='accent'>
-              <UserNameAndBadges
-                onNavigateAway={onClose}
-                userId={purchaseDetails.buyerUserId}
-              />
-            </Text>
+            <UserLink
+              userId={purchaseDetails.buyerUserId}
+              popover
+              textVariant='body'
+              size='l'
+            />
           </DetailSection>
         </Flex>
         <DetailSection

--- a/packages/web/src/components/usdc-purchase-details-modal/components/SaleModalContent.tsx
+++ b/packages/web/src/components/usdc-purchase-details-modal/components/SaleModalContent.tsx
@@ -83,19 +83,13 @@ export const SaleModalContent = ({
     dispatch
   ])
 
-  return !isPremiumAlbumsEnabled ? (
+  return isPremiumAlbumsEnabled ? (
     <>
       <ModalHeader>
         <ModalTitle title={messages.saleDetails} />
       </ModalHeader>
       <ModalContent className={styles.content}>
-        <Flex
-          borderBottom='default'
-          gap='l'
-          justifyContent='spaceBetween'
-          w='100%'
-          pb='xl'
-        >
+        <Flex borderBottom='default' gap='l' w='100%' pb='xl'>
           <DynamicTrackArtwork
             id={purchaseDetails.contentId}
             size={DynamicTrackArtworkSize.LARGE}
@@ -115,48 +109,47 @@ export const SaleModalContent = ({
             </Flex>
           </DetailSection>
         </Flex>
-        <Flex
-          justifyContent='space-between'
-          w='100%'
-          borderBottom='default'
-          pb='xl'
-        >
-          <Flex gap='s' direction='column'>
-            <Text variant='label'>{messages.purchasedBy}</Text>
+        <Flex borderBottom='default' w='100%' pb='xl'>
+          <DetailSection
+            label={messages.purchasedBy}
+            button={
+              <Button
+                iconLeft={IconMessage}
+                variant='secondary'
+                size='small'
+                onClick={handleClickMessageBuyer}
+              >
+                {messages.sayThanks}
+              </Button>
+            }
+          >
             <Text variant='body' size='l' color='accent'>
               <UserNameAndBadges
                 onNavigateAway={onClose}
                 userId={purchaseDetails.buyerUserId}
               />
             </Text>
-          </Flex>
-          <Button
-            iconLeft={IconMessage}
-            variant='secondary'
-            size='small'
-            onClick={handleClickMessageBuyer}
-          >
-            {messages.sayThanks}
-          </Button>
+          </DetailSection>
         </Flex>
-        <Flex justifyContent='space-between' w='100%'>
-          <Flex gap='s' direction='column'>
-            <Text variant='label'>{messages.transactionDate}</Text>
-            <Text variant='body' size='l'>
-              {moment(purchaseDetails.createdAt).format('MMM DD, YYYY')}
-            </Text>
-          </Flex>
-          <Button
-            iconLeft={IconExternalLink}
-            variant='secondary'
-            size='small'
-            asChild
-          >
-            <a href={makeSolanaTransactionLink(purchaseDetails.signature)}>
-              {messages.transaction}
-            </a>
-          </Button>
-        </Flex>
+        <DetailSection
+          label={messages.transactionDate}
+          button={
+            <Button
+              iconLeft={IconExternalLink}
+              variant='secondary'
+              size='small'
+              asChild
+            >
+              <a href={makeSolanaTransactionLink(purchaseDetails.signature)}>
+                {messages.transaction}
+              </a>
+            </Button>
+          }
+        >
+          <Text variant='body' size='l'>
+            {moment(purchaseDetails.createdAt).format('MMM DD, YYYY')}
+          </Text>
+        </DetailSection>
         <TransactionSummary transaction={purchaseDetails} />
       </ModalContent>
       <ModalFooter style={{ paddingTop: 0 }}>

--- a/packages/web/src/components/usdc-purchase-details-modal/components/SaleModalContent.tsx
+++ b/packages/web/src/components/usdc-purchase-details-modal/components/SaleModalContent.tsx
@@ -36,7 +36,7 @@ import styles from './styles.module.css'
 import { ContentProps } from './types'
 import { useFlag } from 'hooks/useRemoteConfig'
 import { FeatureFlags } from '@audius/common/services'
-import { UserLink } from 'components/link'
+import { ExternalLink, UserLink } from 'components/link'
 
 const { getCanCreateChat } = chatSelectors
 const { createChat } = chatActions
@@ -134,16 +134,18 @@ export const SaleModalContent = ({
         </Flex>
         <DetailSection
           label={messages.transactionDate}
-          button={
+          actionButton={
             <Button
               iconLeft={IconExternalLink}
               variant='secondary'
               size='small'
               asChild
             >
-              <a href={makeSolanaTransactionLink(purchaseDetails.signature)}>
+              <ExternalLink
+                to={makeSolanaTransactionLink(purchaseDetails.signature)}
+              >
                 {messages.transaction}
-              </a>
+              </ExternalLink>
             </Button>
           }
         >

--- a/packages/web/src/components/usdc-purchase-details-modal/components/TrackLink.tsx
+++ b/packages/web/src/components/usdc-purchase-details-modal/components/TrackLink.tsx
@@ -3,7 +3,7 @@ import { Text } from '@audius/harmony'
 import { TextLink } from 'components/link'
 
 export const TrackLink = (props: { id: number; onClick: () => void }) => {
-  const { id, onClick, ...other } = props
+  const { id, ...other } = props
   const { data: track } = useGetTrackById({ id })
   if (!track) return null
   return (

--- a/packages/web/src/components/usdc-purchase-details-modal/components/TrackLink.tsx
+++ b/packages/web/src/components/usdc-purchase-details-modal/components/TrackLink.tsx
@@ -1,23 +1,14 @@
 import { useGetTrackById } from '@audius/common/api'
 import { Text } from '@audius/harmony'
-import { Link } from 'react-router-dom'
+import { TextLink } from 'components/link'
 
-import styles from './styles.module.css'
-
-export const TrackLink = ({
-  id,
-  onClick
-}: {
-  id: number
-  onClick: () => void
-}) => {
+export const TrackLink = (props: { id: number; onClick: () => void }) => {
+  const { id, onClick, ...other } = props
   const { data: track } = useGetTrackById({ id })
   if (!track) return null
   return (
-    <Link onClick={onClick} className={styles.link} to={track.permalink}>
-      <Text variant='body' size='l' color='accent'>
-        {track.title}
-      </Text>
-    </Link>
+    <TextLink to={track.permalink} textVariant='body' size='l' {...other}>
+      <Text ellipses>{track.title}</Text>
+    </TextLink>
   )
 }

--- a/packages/web/src/components/usdc-purchase-details-modal/components/TrackLink.tsx
+++ b/packages/web/src/components/usdc-purchase-details-modal/components/TrackLink.tsx
@@ -1,5 +1,6 @@
 import { useGetTrackById } from '@audius/common/api'
 import { Text } from '@audius/harmony'
+
 import { TextLink } from 'components/link'
 
 export const TrackLink = (props: { id: number; onClick: () => void }) => {

--- a/packages/web/src/components/usdc-purchase-details-modal/components/styles.module.css
+++ b/packages/web/src/components/usdc-purchase-details-modal/components/styles.module.css
@@ -2,7 +2,7 @@
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: var(--harmony-unit-4);
+  gap: var(--harmony-unit-6);
 }
 
 .trackRow {

--- a/packages/web/src/components/usdc-transaction-details-modal/USDCTransactionDetailsModal.tsx
+++ b/packages/web/src/components/usdc-transaction-details-modal/USDCTransactionDetailsModal.tsx
@@ -16,7 +16,7 @@ import {
 } from '@audius/harmony'
 import moment from 'moment'
 
-import { ExternalLink } from 'components/link'
+import { ExternalTextLink } from 'components/link'
 
 import styles from './USDCTransactionDetailsModal.module.css'
 
@@ -82,14 +82,14 @@ export const USDCTransactionDetailsModal = () => {
         USDCTransactionType.WITHDRAWAL ? (
           <DetailSection
             label={
-              <ExternalLink
+              <ExternalTextLink
                 to={makeSolanaTransactionLink(transactionDetails.signature)}
               >
                 <span className={styles.transactionLink}>
                   {messages.destinationWallet}
                   <IconExternalLink size='s' color='default' />
                 </span>
-              </ExternalLink>
+              </ExternalTextLink>
             }
             value={`${transactionDetails.metadata ?? '-'}`}
           />

--- a/packages/web/src/components/user-generated-text/UserGeneratedText.tsx
+++ b/packages/web/src/components/user-generated-text/UserGeneratedText.tsx
@@ -16,7 +16,7 @@ import { Text, TextProps } from '@audius/harmony'
 import Linkify from 'linkify-react'
 import { IntermediateRepresentation, Opts } from 'linkifyjs'
 
-import { ExternalLink, TextLink } from 'components/link'
+import { ExternalTextLink, TextLink } from 'components/link'
 
 type LinkifyTextProps = TextProps<any> & {
   innerRef?: Ref<any>
@@ -47,7 +47,7 @@ const renderLink = ({ attributes, content }: IntermediateRepresentation) => {
   const isExternalLink = !isAudiusUrl(href)
   const to = isExternalLink ? formatExternalLink(href) : formatAudiusUrl(href)
 
-  const LinkComponent = isExternalLink ? ExternalLink : TextLink
+  const LinkComponent = isExternalLink ? ExternalTextLink : TextLink
 
   return (
     <LinkComponent to={to} variant='visible' {...props}>

--- a/packages/web/src/pages/profile-page/components/SocialLink.tsx
+++ b/packages/web/src/pages/profile-page/components/SocialLink.tsx
@@ -10,7 +10,7 @@ import {
   Flex
 } from '@audius/harmony'
 
-import { ExternalLink } from 'components/link'
+import { ExternalTextLink } from 'components/link'
 import Tooltip from 'components/tooltip/Tooltip'
 import { UserGeneratedText } from 'components/user-generated-text'
 
@@ -92,9 +92,9 @@ const SocialLink = (props: SocialLinkProps) => {
 
   if (href) {
     return (
-      <ExternalLink to={href} onClick={onClick} textVariant='body'>
+      <ExternalTextLink to={href} onClick={onClick} textVariant='body'>
         {icon} <Text ellipses>{iconOnly ? null : text}</Text>
-      </ExternalLink>
+      </ExternalTextLink>
     )
   }
 

--- a/packages/web/src/pages/profile-page/components/mobile/SocialLink.tsx
+++ b/packages/web/src/pages/profile-page/components/mobile/SocialLink.tsx
@@ -1,6 +1,6 @@
 import { ReactElement } from 'react'
 
-import { ExternalLink } from 'components/link'
+import { ExternalTextLink } from 'components/link'
 
 import styles from './ProfileHeader.module.css'
 
@@ -13,8 +13,8 @@ type SocialLinkProps = {
 export const SocialLink = (props: SocialLinkProps) => {
   const { icon, ...other } = props
   return (
-    <ExternalLink {...other} className={styles.socialIcon}>
+    <ExternalTextLink {...other} className={styles.socialIcon}>
       {icon}
-    </ExternalLink>
+    </ExternalTextLink>
   )
 }

--- a/packages/web/src/pages/settings-page/components/desktop/DeveloperApps/AppDetailsPage.tsx
+++ b/packages/web/src/pages/settings-page/components/desktop/DeveloperApps/AppDetailsPage.tsx
@@ -9,7 +9,7 @@ import {
 } from '@audius/harmony'
 
 import { Divider } from 'components/divider'
-import { ExternalLink } from 'components/link'
+import { ExternalTextLink } from 'components/link'
 import Toast from 'components/toast/Toast'
 import { MountPlacement } from 'components/types'
 import { copyToClipboard } from 'utils/clipboardUtil'
@@ -61,9 +61,12 @@ export const AppDetailsPage = (props: AppDetailsPageProps) => {
           icon={IconError}
           actions={
             // TODO: use variant='visible' when migrated to harmony
-            <ExternalLink to={AUDIUS_SDK_LINK} className={styles.readTheDocs}>
+            <ExternalTextLink
+              to={AUDIUS_SDK_LINK}
+              className={styles.readTheDocs}
+            >
               {messages.readTheDocs}
-            </ExternalLink>
+            </ExternalTextLink>
           }
         >
           {messages.secretReminder}

--- a/packages/web/src/pages/upload-page/fields/stream-availability/collectible-gated/CollectibleGatedDescription.tsx
+++ b/packages/web/src/pages/upload-page/fields/stream-availability/collectible-gated/CollectibleGatedDescription.tsx
@@ -1,7 +1,7 @@
 import { Flex, IconExternalLink, Text } from '@audius/harmony'
 
 import { HelpCallout } from 'components/help-callout/HelpCallout'
-import { ExternalLink } from 'components/link'
+import { ExternalTextLink } from 'components/link'
 import { AUDIUS_GATED_CONTENT_BLOG_LINK } from 'utils/route'
 
 const messages = {
@@ -30,9 +30,9 @@ export const CollectibleGatedDescription = (
       {!hasCollectibles && isUpload ? (
         <HelpCallout content={helpContent} />
       ) : null}
-      <ExternalLink to={AUDIUS_GATED_CONTENT_BLOG_LINK} textVariant='body'>
+      <ExternalTextLink to={AUDIUS_GATED_CONTENT_BLOG_LINK} textVariant='body'>
         {messages.learnMore} <IconExternalLink size='s' color='default' />
-      </ExternalLink>
+      </ExternalTextLink>
     </Flex>
   )
 }

--- a/packages/web/src/pages/upload-page/fields/stream-availability/usdc-purchase-gated/UsdcPurchaseGatedRadioField.tsx
+++ b/packages/web/src/pages/upload-page/fields/stream-availability/usdc-purchase-gated/UsdcPurchaseGatedRadioField.tsx
@@ -9,7 +9,7 @@ import {
 import { FeatureFlags } from '@audius/common/services'
 import { IconCart, IconStars } from '@audius/harmony'
 
-import { ExternalLink } from 'components/link'
+import { ExternalTextLink } from 'components/link'
 import { ModalRadioItem } from 'components/modal-radio/ModalRadioItem'
 import { make, track } from 'services/analytics'
 
@@ -60,7 +60,7 @@ export const UsdcPurchaseGatedRadioField = (
   const helpContent = (
     <div className={styles.helpContent}>
       <div>{messages.waitlist}</div>
-      <ExternalLink
+      <ExternalTextLink
         onClick={handleClickWaitListLink}
         className={styles.link}
         to={WAITLIST_TYPEFORM}
@@ -68,7 +68,7 @@ export const UsdcPurchaseGatedRadioField = (
         ignoreWarning
       >
         {messages.join}
-      </ExternalLink>
+      </ExternalTextLink>
     </div>
   )
 


### PR DESCRIPTION
### Description
UI updates gated on premium album feature flag.

Will follow up with support for album purchases/sales, and that `ExternalLink` change you requested @dylanjeffers .

### How Has This Been Tested?

Local web stage


<img width="1728" alt="Screenshot 2024-04-04 at 10 55 30 PM" src="https://github.com/AudiusProject/audius-protocol/assets/3893871/b9f943c7-9693-4b8c-8196-c90013788f72">
<img width="1728" alt="Screenshot 2024-04-04 at 10 55 34 PM" src="https://github.com/AudiusProject/audius-protocol/assets/3893871/204e127b-e692-4aad-96e1-22c8853843a9">

With ellipses:
<img width="1728" alt="Screenshot 2024-04-05 at 2 42 39 PM" src="https://github.com/AudiusProject/audius-protocol/assets/3893871/fdbc4eb0-02b3-4d5d-937b-42a6699ab405">

