### PR TITLE
[PAY-2671] Add purchase button to native mobile playlist feed tiles

### DIFF
--- a/packages/mobile/src/components/details-tile/DetailsTile.tsx
+++ b/packages/mobile/src/components/details-tile/DetailsTile.tsx
@@ -14,6 +14,7 @@ import {
   Genre,
   getDogEarType
 } from '@audius/common/utils'
+import { css } from '@emotion/native'
 import moment from 'moment'
 import { TouchableOpacity } from 'react-native'
 import { useSelector } from 'react-redux'
@@ -45,7 +46,6 @@ import { DetailsTileHasAccess } from './DetailsTileHasAccess'
 import { DetailsTileNoAccess } from './DetailsTileNoAccess'
 import { DetailsTileStats } from './DetailsTileStats'
 import type { DetailsTileProps } from './types'
-import { css } from '@emotion/native'
 
 const { getTrackId } = playerSelectors
 const { getTrackPosition } = playbackPositionSelectors

--- a/packages/mobile/src/components/lineup-tile/LineupTile.tsx
+++ b/packages/mobile/src/components/lineup-tile/LineupTile.tsx
@@ -1,7 +1,11 @@
 import { useCallback } from 'react'
 
 import { useGatedContentAccess } from '@audius/common/hooks'
-import { accountSelectors, gatedContentActions } from '@audius/common/store'
+import {
+  PurchaseableContentType,
+  accountSelectors,
+  gatedContentActions
+} from '@audius/common/store'
 import { Genre, getDogEarType } from '@audius/common/utils'
 import moment from 'moment'
 import { View } from 'react-native'
@@ -64,10 +68,10 @@ export const LineupTile = ({
   const isOwner = user_id === currentUserId
   const isCollection = 'playlist_id' in item
   const isTrack = 'track_id' in item
-  const trackId = isTrack ? item.track_id : undefined
-  const streamConditions = isTrack ? item.stream_conditions : null
+  const contentId = isTrack ? item.track_id : item.playlist_id
+  const streamConditions = item.stream_conditions ?? null
   const isArtistPick = artist_pick_track_id === id
-  const { hasStreamAccess } = useGatedContentAccess(isTrack ? item : null)
+  const { hasStreamAccess } = useGatedContentAccess(item)
   const isScheduledRelease = item.release_date
     ? moment(item.release_date).isAfter(moment())
     : false
@@ -81,13 +85,13 @@ export const LineupTile = ({
   })
 
   const handlePress = useCallback(() => {
-    if (trackId && !hasStreamAccess && !hasPreview) {
-      dispatch(setLockedContentId({ id: trackId }))
+    if (contentId && !hasStreamAccess && !hasPreview) {
+      dispatch(setLockedContentId({ id: contentId }))
       dispatch(setVisibility({ drawer: 'LockedContent', visible: true }))
     } else {
       onPress?.()
     }
-  }, [trackId, hasStreamAccess, hasPreview, dispatch, onPress])
+  }, [contentId, hasStreamAccess, hasPreview, dispatch, onPress])
 
   const isLongFormContent =
     isTrack &&
@@ -151,7 +155,12 @@ export const LineupTile = ({
         isShareHidden={hideShare}
         isUnlisted={isUnlisted}
         readonly={isReadonly}
-        trackId={trackId}
+        contentId={contentId}
+        contentType={
+          isTrack
+            ? PurchaseableContentType.TRACK
+            : PurchaseableContentType.ALBUM
+        }
         streamConditions={streamConditions}
         hasStreamAccess={hasStreamAccess}
         onPressOverflow={onPressOverflow}

--- a/packages/mobile/src/components/lineup-tile/LineupTileAccessStatus.tsx
+++ b/packages/mobile/src/components/lineup-tile/LineupTileAccessStatus.tsx
@@ -2,11 +2,11 @@ import { useCallback } from 'react'
 
 import type { ID, AccessConditions } from '@audius/common/models'
 import { ModalSource, isContentUSDCPurchaseGated } from '@audius/common/models'
+import type { PurchaseableContentType } from '@audius/common/store'
 import {
   usePremiumContentPurchaseModal,
   gatedContentActions,
-  gatedContentSelectors,
-  PurchaseableContentType
+  gatedContentSelectors
 } from '@audius/common/store'
 import { formatPrice } from '@audius/common/utils'
 import { TouchableOpacity, View } from 'react-native'
@@ -54,10 +54,12 @@ const useStyles = makeStyles(({ palette, spacing, typography }) => ({
 }))
 
 export const LineupTileAccessStatus = ({
-  trackId,
+  contentId,
+  contentType,
   streamConditions
 }: {
-  trackId: ID
+  contentId: ID
+  contentType: PurchaseableContentType
   streamConditions: AccessConditions
 }) => {
   const styles = useStyles()
@@ -66,7 +68,7 @@ export const LineupTileAccessStatus = ({
   const { onOpen: openPremiumContentPurchaseModal } =
     usePremiumContentPurchaseModal()
   const gatedTrackStatusMap = useSelector(getGatedContentStatusMap)
-  const gatedTrackStatus = gatedTrackStatusMap[trackId]
+  const gatedTrackStatus = gatedTrackStatusMap[contentId]
   const staticWhite = useColor('staticWhite')
   const isUSDCPurchase =
     isUSDCEnabled && isContentUSDCPurchaseGated(streamConditions)
@@ -74,14 +76,20 @@ export const LineupTileAccessStatus = ({
   const handlePress = useCallback(() => {
     if (isUSDCPurchase) {
       openPremiumContentPurchaseModal(
-        { contentId: trackId, contentType: PurchaseableContentType.TRACK },
+        { contentId, contentType },
         { source: ModalSource.TrackTile }
       )
-    } else if (trackId) {
-      dispatch(setLockedContentId({ id: trackId }))
+    } else if (contentId) {
+      dispatch(setLockedContentId({ id: contentId }))
       dispatch(setVisibility({ drawer: 'LockedContent', visible: true }))
     }
-  }, [trackId, isUSDCPurchase, openPremiumContentPurchaseModal, dispatch])
+  }, [
+    isUSDCPurchase,
+    contentId,
+    openPremiumContentPurchaseModal,
+    contentType,
+    dispatch
+  ])
 
   return (
     <TouchableOpacity onPress={handlePress}>

--- a/packages/mobile/src/components/lineup-tile/LineupTileActionButtons.tsx
+++ b/packages/mobile/src/components/lineup-tile/LineupTileActionButtons.tsx
@@ -34,8 +34,8 @@ type Props = {
   isOwner?: boolean
   isShareHidden?: boolean
   isUnlisted?: boolean
-  contentId: ID
-  contentType: PurchaseableContentType
+  contentId?: ID
+  contentType?: PurchaseableContentType
   streamConditions?: Nullable<AccessConditions>
   hasStreamAccess?: boolean
   onPressOverflow?: GestureResponderHandler
@@ -137,7 +137,7 @@ export const LineupTileActionButtons = ({
 
   let content: ReactElement | null = null
   if (readonly) {
-    if (isUSDCPurchase && showGatedAccessStatus) {
+    if (isUSDCPurchase && showGatedAccessStatus && contentType) {
       content = (
         <View style={styles.leftButtons}>
           <LineupTileAccessStatus
@@ -152,7 +152,7 @@ export const LineupTileActionButtons = ({
     content = (
       <>
         <View style={styles.leftButtons}>
-          {showGatedAccessStatus && streamConditions != null ? (
+          {showGatedAccessStatus && contentType && streamConditions != null ? (
             <LineupTileAccessStatus
               contentId={contentId}
               contentType={contentType}

--- a/packages/mobile/src/components/lineup-tile/LineupTileActionButtons.tsx
+++ b/packages/mobile/src/components/lineup-tile/LineupTileActionButtons.tsx
@@ -2,6 +2,7 @@ import type { ReactElement } from 'react'
 
 import type { ID, AccessConditions } from '@audius/common/models'
 import { isContentUSDCPurchaseGated } from '@audius/common/models'
+import type { PurchaseableContentType } from '@audius/common/store'
 import type { Nullable } from '@audius/common/utils'
 import { View } from 'react-native'
 
@@ -33,7 +34,8 @@ type Props = {
   isOwner?: boolean
   isShareHidden?: boolean
   isUnlisted?: boolean
-  trackId?: ID
+  contentId: ID
+  contentType: PurchaseableContentType
   streamConditions?: Nullable<AccessConditions>
   hasStreamAccess?: boolean
   onPressOverflow?: GestureResponderHandler
@@ -73,7 +75,8 @@ export const LineupTileActionButtons = ({
   isOwner,
   isShareHidden,
   isUnlisted,
-  trackId,
+  contentId,
+  contentType,
   hasStreamAccess = false,
   readonly = false,
   streamConditions,
@@ -129,7 +132,7 @@ export const LineupTileActionButtons = ({
     />
   )
 
-  const showGatedAccessStatus = trackId && !hasStreamAccess
+  const showGatedAccessStatus = contentId && !hasStreamAccess
   const showLeftButtons = !showGatedAccessStatus && !isUnlisted
 
   let content: ReactElement | null = null
@@ -138,7 +141,8 @@ export const LineupTileActionButtons = ({
       content = (
         <View style={styles.leftButtons}>
           <LineupTileAccessStatus
-            trackId={trackId}
+            contentId={contentId}
+            contentType={contentType}
             streamConditions={streamConditions}
           />
         </View>
@@ -150,7 +154,8 @@ export const LineupTileActionButtons = ({
         <View style={styles.leftButtons}>
           {showGatedAccessStatus && streamConditions != null ? (
             <LineupTileAccessStatus
-              trackId={trackId}
+              contentId={contentId}
+              contentType={contentType}
               streamConditions={streamConditions}
             />
           ) : null}


### PR DESCRIPTION
### Description

Sibling of https://github.com/AudiusProject/audius-protocol/pull/8029

- Show purchase button on playlist feed tiles
	- Open purchase modal on click
- Add dog ear to playlist feed tiles
<img width="457" alt="Screenshot 2024-04-04 at 4 18 46 PM" src="https://github.com/AudiusProject/audius-protocol/assets/2358254/cd464a80-492e-49d4-9e67-89b9a4991f32">
<img width="469" alt="Screenshot 2024-04-04 at 4 22 52 PM" src="https://github.com/AudiusProject/audius-protocol/assets/2358254/cab6578b-655a-48a2-97eb-95ccf92948c2">

### How Has This Been Tested?

working on ios sim