### PR TITLE
[C-4038] Fix missing playlist image

### DIFF
--- a/packages/mobile/src/components/details-tile/DetailsTile.tsx
+++ b/packages/mobile/src/components/details-tile/DetailsTile.tsx
@@ -14,6 +14,7 @@ import {
   Genre,
   getDogEarType
 } from '@audius/common/utils'
+import { css } from '@emotion/native'
 import moment from 'moment'
 import { TouchableOpacity } from 'react-native'
 import { useSelector } from 'react-redux'
@@ -45,7 +46,6 @@ import { DetailsTileHasAccess } from './DetailsTileHasAccess'
 import { DetailsTileNoAccess } from './DetailsTileNoAccess'
 import { DetailsTileStats } from './DetailsTileStats'
 import type { DetailsTileProps } from './types'
-import { css } from '@emotion/native'
 
 const { getTrackId } = playerSelectors
 const { getTrackPosition } = playbackPositionSelectors

--- a/packages/mobile/src/components/image/CollectionImage.tsx
+++ b/packages/mobile/src/components/image/CollectionImage.tsx
@@ -68,6 +68,7 @@ export const useCollectionImage = (options: UseCollectionImageOptions) => {
   const optimisticCoverArt = primitiveToImageSource(
     collection?._cover_art_sizes?.OVERRIDE
   )
+
   const localCollectionImageUri = useLocalCollectionImageUri(
     collection?.playlist_id
   )
@@ -99,18 +100,12 @@ export const CollectionImage = (props: CollectionImageProps) => {
 
   const { source, handleError, isFallbackImage } = collectionImageSource
 
-  if (isFallbackImage) {
-    return (
-      <FastImage
-        {...other}
-        style={[style, { backgroundColor: neutralLight6 }]}
-        source={source}
-        onError={handleError}
-      />
-    )
-  }
-
   return (
-    <FastImage {...other} style={style} source={source} onError={handleError} />
+    <FastImage
+      {...other}
+      style={[style, isFallbackImage && { backgroundColor: neutralLight6 }]}
+      source={source}
+      onError={handleError}
+    />
   )
 }

--- a/packages/mobile/src/components/image/TrackImage.tsx
+++ b/packages/mobile/src/components/image/TrackImage.tsx
@@ -83,18 +83,12 @@ export const TrackImage = (props: TrackImageProps) => {
 
   const { source, handleError, isFallbackImage } = trackImageSource
 
-  if (isFallbackImage) {
-    return (
-      <FastImage
-        {...other}
-        style={[style, { backgroundColor: neutralLight8 }]}
-        source={source}
-        onError={handleError}
-      />
-    )
-  }
-
   return (
-    <FastImage {...other} style={style} source={source} onError={handleError} />
+    <FastImage
+      {...other}
+      style={[style, isFallbackImage && { backgroundColor: neutralLight8 }]}
+      source={source}
+      onError={handleError}
+    />
   )
 }

--- a/packages/mobile/src/hooks/useContentNodeImage.ts
+++ b/packages/mobile/src/hooks/useContentNodeImage.ts
@@ -160,9 +160,9 @@ export const useContentNodeImage = (
     }
   }, [imageSourceIndex, imageSources])
 
-  const showFallbackImage = useMemo(() => {
-    return (!cid && !localSource) || failedToLoad
-  }, [failedToLoad, localSource, cid])
+  // when localSource is a number, it's a placeholder image, so we should show fallback image
+  const showFallbackImage =
+    (!cid && (!localSource || typeof localSource === 'number')) || failedToLoad
 
   const source = useMemo(() => {
     if (showFallbackImage) {


### PR DESCRIPTION
### Description

Fixes issue where some playlists images looked missing due to a weird issue where OVERRIDE image is the fallback image, but our hook doesn't recognize it should render the fallback image:

<img width="407" alt="image" src="https://github.com/AudiusProject/audius-protocol/assets/8230000/f6a55dae-95b3-4684-bc30-d8c75654d5c7">


Also cleans up Collection and Track image render