### PR TITLE
[PROTO-1753] Make ddex publisher+web work with refactored parser

### DIFF
--- a/packages/ddex/ingester/common/sdk_types.go
+++ b/packages/ddex/ingester/common/sdk_types.go
@@ -218,10 +218,15 @@ type TrackMetadata struct {
 
 // SDKUploadMetadata represents the metadata required to upload a track or album to Audius
 type SDKUploadMetadata struct {
-	// Used by both tracks and albums
-	ReleaseDate           time.Time             `bson:"release_date"`
-	Genre                 Genre                 `bson:"genre"`
-	Artists               []ResourceContributor `bson:"artists"`
+	// Required for both tracks and albums
+	ReleaseDate time.Time `bson:"release_date"`
+	Genre       Genre     `bson:"genre"`
+	CoverArtURL string    `bson:"cover_art_url"`
+
+	// Optional for both tracks and albums
+	CoverArtURLHash       NullableString        `bson:"cover_art_url_hash,omitempty"`
+	CoverArtURLHashAlgo   NullableString        `bson:"cover_art_url_hash_algo,omitempty"`
+	Artists               []ResourceContributor `bson:"artists,omitempty"`
 	Description           NullableString        `bson:"description,omitempty"` // Apparently there's supposed to be a <MarketingComment> that we use for this, but I haven't seen it in any example files
 	DDEXReleaseIDs        *ReleaseIDs           `bson:"ddex_release_ids,omitempty"`
 	Mood                  *Mood                 `bson:"mood,omitempty"` // DDEX doesn't provide this, but the Audius SDK requires it
@@ -230,9 +235,6 @@ type SDKUploadMetadata struct {
 	ProducerCopyrightLine *Copyright            `bson:"producer_copyright_line,omitempty"`
 	ParentalWarningType   NullableString        `bson:"parental_warning_type,omitempty"`
 	License               NullableString        `bson:"license,omitempty"`
-	CoverArtURL           string                `bson:"cover_art_url"`
-	CoverArtURLHash       NullableString        `bson:"cover_art_url_hash,omitempty"`
-	CoverArtURLHashAlgo   NullableString        `bson:"cover_art_url_hash_algo,omitempty"`
 
 	// Only for tracks
 	Title                        NullableString        `bson:"title,omitempty"`

--- a/packages/ddex/ingester/common/types.go
+++ b/packages/ddex/ingester/common/types.go
@@ -66,7 +66,6 @@ type PublishedRelease struct {
 
 type Release struct {
 	ReleaseProfile     ReleaseProfile         `bson:"release_profile"`      // "ReleaseProfileVersionId" from the DDEX XML
-	PublishDate        time.Time              `bson:"publish_date"`         // Alias to the main ParsedReleaseElems's ReleaseDate for faster lookups
 	ParsedReleaseElems []ParsedReleaseElement `bson:"parsed_release_elems"` // Releases parsed from XML
 	SDKUploadMetadata  SDKUploadMetadata      `bson:"sdk_upload_metadata"`  // Metadata for the publisher to upload to Audius via SDK
 }

--- a/packages/ddex/ingester/e2e_test/e2e_test.go
+++ b/packages/ddex/ingester/e2e_test/e2e_test.go
@@ -127,7 +127,6 @@ func TestRunE2E(t *testing.T) {
 				PublishErrors:      []string{},
 				Release: common.Release{
 					ReleaseProfile: common.UnspecifiedReleaseProfile,
-					PublishDate:    time.Date(2023, time.September, 1, 0, 0, 0, 0, time.UTC),
 					SDKUploadMetadata: common.SDKUploadMetadata{
 						ReleaseDate: time.Date(2023, time.September, 1, 0, 0, 0, 0, time.UTC),
 						Genre:       "Hip-Hop/Rap",
@@ -283,7 +282,6 @@ func TestRunE2E(t *testing.T) {
 				PublishErrors:      []string{},
 				Release: common.Release{
 					ReleaseProfile: common.Common14AudioAlbumMusicOnly,
-					PublishDate:    time.Date(2010, time.January, 1, 0, 0, 0, 0, time.UTC),
 					SDKUploadMetadata: common.SDKUploadMetadata{
 						ReleaseDate:       time.Date(2010, time.January, 1, 0, 0, 0, 0, time.UTC),
 						PlaylistName:      stringPtr("A Monkey Claw in a Velvet Glove"),
@@ -432,7 +430,6 @@ func TestRunE2E(t *testing.T) {
 				PublishErrors:      []string{},
 				Release: common.Release{
 					ReleaseProfile: common.Common13AudioSingle,
-					PublishDate:    time.Date(2023, time.October, 1, 0, 0, 0, 0, time.UTC),
 					SDKUploadMetadata: common.SDKUploadMetadata{
 						ReleaseDate: time.Date(2023, time.October, 1, 0, 0, 0, 0, time.UTC),
 						Genre:       "Blues",
@@ -523,7 +520,6 @@ func TestRunE2E(t *testing.T) {
 		assert.Equal(t, st.expectedPR.PublishErrors, pendingRelease.PublishErrors)
 		assert.Equal(t, st.expectedPR.FailedAfterUpload, pendingRelease.FailedAfterUpload)
 		assert.Equal(t, st.expectedPR.Release.ReleaseProfile, pendingRelease.Release.ReleaseProfile)
-		assert.Equal(t, st.expectedPR.Release.PublishDate, pendingRelease.Release.PublishDate)
 
 		// Compare SDKUploadMetadata without tracks (for cleaner diffing), and then compare tracks after
 		expectedTracks, actualTracks := st.expectedPR.Release.SDKUploadMetadata.Tracks, pendingRelease.Release.SDKUploadMetadata.Tracks

--- a/packages/ddex/publisher/src/models/pendingReleases.ts
+++ b/packages/ddex/publisher/src/models/pendingReleases.ts
@@ -52,6 +52,7 @@ const genres = [
   'Jersey Club',
   'Vaporwave',
   'Moombahton',
+  'Dancehall',
 ]
 const moods = [
   'Peaceful',
@@ -116,8 +117,8 @@ const trackMetadataSchema = new mongoose.Schema({
   title: { type: String, required: true },
   release_date: { type: Date, required: true },
   ddex_release_ids: mongoose.Schema.Types.Mixed,
-  genre: { type: String, enum: genres, required: true },
-  duration: { type: Number, required: true },
+  genre: { type: String, enum: genres },
+  duration: Number,
   preview_start_seconds: Number,
   isrc: String,
   license: String,
@@ -127,13 +128,13 @@ const trackMetadataSchema = new mongoose.Schema({
   preview_audio_file_url: String,
   preview_audio_file_url_hash: String,
   preview_audio_file_url_hash_algo: String,
-  audio_file_url: { type: String, required: true },
-  audio_file_url_hash: { type: String, required: true },
-  audio_file_url_hash_algo: { type: String, required: true },
+  audio_file_url: String,
+  audio_file_url_hash: String,
+  audio_file_url_hash_algo: String,
 
   // Required if it's a standalone track. Uses playlist_owner_id and playlist's cover_art_url if it's part of an album
-  artist_id: { type: String, required: true },
-  artist_name: { type: String, required: true },
+  artist_id: String,
+  artist_name: String,
   artists: { type: [resourceContributorSchema], default: null },
   resource_contributors: { type: [resourceContributorSchema], default: null },
   indirect_resource_contributors: {
@@ -144,69 +145,166 @@ const trackMetadataSchema = new mongoose.Schema({
   copyright_line: { type: copyrightSchema, default: null },
   producer_copyright_line: { type: copyrightSchema, default: null },
   parental_warning_type: { type: String, default: null },
-  cover_art_url: { type: String, required: true },
-  cover_art_url_hash: { type: String, required: true },
-  cover_art_url_hash_algo: { type: String, required: true },
+  cover_art_url: String,
+  cover_art_url_hash: String,
+  cover_art_url_hash_algo: String,
 })
 
 export type TrackMetadata = mongoose.InferSchemaType<typeof trackMetadataSchema>
 
-const collectionMetadataSchema = new mongoose.Schema({
-  playlist_name: { type: String, required: true },
-  playlist_owner_name: { type: String, required: true },
-  playlist_owner_id: { type: String, required: true },
-  artists: { type: [resourceContributorSchema], default: null },
-  genre: { type: String, enum: genres, required: true },
-  release_date: { type: Date, required: true },
-  ddex_release_ids: mongoose.Schema.Types.Mixed,
-  description: String,
-  is_album: Boolean,
-  is_private: Boolean,
-  tags: String,
-  mood: { type: String, enum: moods },
-  license: String,
-  upc: String,
-  cover_art_url: { type: String, required: true },
-  cover_art_url_hash: { type: String, required: true },
-  cover_art_url_hash_algo: { type: String, required: true },
-  copyright_line: { type: copyrightSchema, default: null },
-  producer_copyright_line: { type: copyrightSchema, default: null },
-  parental_warning_type: { type: String, default: null },
+const imageMetadataSchema = new mongoose.Schema({
+  url: String,
+  url_hash: String,
+  url_hash_algo: String,
 })
 
-export type CollectionMetadata = mongoose.InferSchemaType<
-  typeof collectionMetadataSchema
->
+const nullableString = {
+  type: String,
+  default: null,
+}
 
-export const createTrackReleaseSchema = new mongoose.Schema({
-  ddex_release_ref: { type: String, required: true },
-  metadata: { type: trackMetadataSchema, required: true },
+const nullableBool = {
+  type: Boolean,
+  default: null,
+}
+
+const nullableInt = {
+  type: Number,
+  default: null,
+}
+
+const releaseIDsSchema = new mongoose.Schema({
+  party_id: { type: String, default: '' },
+  catalog_number: { type: String, default: '' },
+  icpn: { type: String, default: '' },
+  grid: { type: String, default: '' },
+  isan: { type: String, default: '' },
+  isbn: { type: String, default: '' },
+  ismn: { type: String, default: '' },
+  isrc: { type: String, default: '' },
+  issn: { type: String, default: '' },
+  istc: { type: String, default: '' },
+  iswc: { type: String, default: '' },
+  mwli: { type: String, default: '' },
+  sici: { type: String, default: '' },
+  proprietary_id: { type: String, default: '' },
 })
 
-export type CreateTrackRelease = mongoose.InferSchemaType<
-  typeof createTrackReleaseSchema
+export const sdkUploadMetadataSchema = new mongoose.Schema(
+  {
+    // Used by both tracks and albums
+    release_date: { type: Date, required: true },
+    genre: { type: String, required: true, enum: genres },
+    artists: { type: [resourceContributorSchema], default: null },
+    description: nullableString,
+    ddex_release_ids: releaseIDsSchema,
+    mood: { type: String, enum: moods, default: null },
+    tags: nullableString,
+    copyright_line: copyrightSchema,
+    producer_copyright_line: copyrightSchema,
+    parental_warning_type: nullableString,
+    license: nullableString,
+    cover_art_url: { type: String, required: true },
+    cover_art_url_hash: nullableString,
+    cover_art_url_hash_algo: nullableString,
+
+    // Only for tracks
+    title: nullableString,
+    artist_id: nullableString,
+    duration: Number,
+    preview_start_seconds: nullableInt,
+    isrc: nullableString,
+    resource_contributors: [resourceContributorSchema],
+    indirect_resource_contributors: [resourceContributorSchema],
+    rights_controller: rightsControllerSchema,
+    preview_audio_file_url: nullableString,
+    preview_audio_file_url_hash: nullableString,
+    preview_audio_file_url_hash_algo: nullableString,
+    audio_file_url: nullableString,
+    audio_file_url_hash: nullableString,
+    audio_file_url_hash_algo: nullableString,
+
+    // Only for albums
+    tracks: [trackMetadataSchema],
+    playlist_name: nullableString,
+    playlist_owner_id: nullableString,
+    playlist_owner_name: nullableString,
+    is_album: nullableBool,
+    is_private: nullableBool,
+    upc: nullableString,
+  },
+  { _id: false }
+) // _id is set to false because this schema is used as a sub-document
+
+export type SDKUploadMetadataSchema = mongoose.InferSchemaType<
+  typeof sdkUploadMetadataSchema
 >
 
-export const createAlbumReleaseSchema = new mongoose.Schema({
-  ddex_release_ref: { type: String, required: true },
+const releaseResourcesSchema = new mongoose.Schema({
   tracks: [trackMetadataSchema],
-  metadata: { type: collectionMetadataSchema, required: true },
+  images: [imageMetadataSchema],
 })
 
-export type CreateAlbumRelease = mongoose.InferSchemaType<
-  typeof createAlbumReleaseSchema
->
+const parsedReleaseElementSchema = new mongoose.Schema(
+  {
+    release_ref: { type: String, required: true },
+    is_main_release: { type: Boolean, required: true },
+    release_type: {
+      type: String,
+      required: true,
+      enum: ['Album', 'EP', 'TrackRelease', 'Single'],
+    },
+    release_ids: releaseIDsSchema,
+    release_date: { type: Date, required: true },
+    resources: releaseResourcesSchema,
+    artist_id: { type: String, required: true },
+    artist_name: { type: String, required: true },
+    display_title: { type: String, required: true },
+    display_subtitle: nullableString,
+    reference_title: nullableString,
+    reference_subtitle: nullableString,
+    formal_title: nullableString,
+    formal_subtitle: nullableString,
+    genre: { type: String, enum: genres, required: true },
+    duration: { type: Number, required: true },
+    preview_start_seconds: nullableInt,
+    isrc: nullableString,
+    artists: { type: [resourceContributorSchema], default: null },
+    resource_contributors: { type: [resourceContributorSchema], default: null },
+    indirect_resource_contributors: {
+      type: [resourceContributorSchema],
+      default: null,
+    },
+    rights_controller: { type: rightsControllerSchema, default: null },
+    copyright_line: { type: copyrightSchema, default: null },
+    producer_copyright_line: { type: copyrightSchema, default: null },
+    parental_warning_type: nullableString,
+  },
+  { _id: false }
+) // _id is set to false because this schema is used as a sub-document
 
-export const pendingReleasesSchema = new mongoose.Schema({
+export const releaseSchema = new mongoose.Schema({
+  release_profile: {
+    type: String,
+    required: true,
+    enum: [
+      'CommonReleaseTypes/13/AudioSingle',
+      'CommonReleaseTypesTypes/14/AudioAlbumMusicOnly',
+      'Unspecified',
+    ],
+  },
+  parsed_release_elems: [parsedReleaseElementSchema],
+  sdk_upload_metadata: sdkUploadMetadataSchema,
+})
+
+const pendingReleasesSchema = new mongoose.Schema({
   _id: { type: String, required: true },
   delivery_remote_path: { type: String, required: true },
-  publish_date: { type: Date, required: true },
+  release: releaseSchema,
   created_at: { type: Date, required: true },
-  create_track_release: createTrackReleaseSchema,
-  create_album_release: createAlbumReleaseSchema,
   publish_errors: [String],
-  failure_count: Number,
-  failed_after_upload: Boolean,
+  failure_count: { type: Number, default: 0 },
+  failed_after_upload: { type: Boolean, default: false },
 })
 
 // Releases awaiting publishing. Releases are parsed from DDEX deliveries

--- a/packages/ddex/publisher/src/models/publishedReleases.ts
+++ b/packages/ddex/publisher/src/models/publishedReleases.ts
@@ -1,19 +1,14 @@
 import mongoose from 'mongoose'
-import {
-  createTrackReleaseSchema,
-  createAlbumReleaseSchema,
-} from './pendingReleases'
+import { releaseSchema } from './pendingReleases'
 
 // DDEX releases that have been published
 const publishedReleasesSchema = new mongoose.Schema({
   _id: { type: String, required: true },
   delivery_remote_path: { type: String, required: true },
-  publish_date: Date,
   entity_id: String,
   blockhash: String,
   blocknumber: Number,
-  track: createTrackReleaseSchema,
-  album: createAlbumReleaseSchema,
+  release: releaseSchema,
   created_at: Date,
 })
 

--- a/packages/ddex/publisher/src/services/publisherService.ts
+++ b/packages/ddex/publisher/src/services/publisherService.ts
@@ -3,9 +3,7 @@ import PendingReleases from '../models/pendingReleases'
 import PublishedReleases from '../models/publishedReleases'
 import type {
   TrackMetadata,
-  CollectionMetadata,
-  CreateTrackRelease,
-  CreateAlbumRelease,
+  SDKUploadMetadataSchema,
   PendingRelease,
 } from '../models/pendingReleases'
 import type {
@@ -18,7 +16,7 @@ import type {
 import createS3 from './s3Service'
 
 const formatTrackMetadata = (
-  metadata: TrackMetadata
+  metadata: SDKUploadMetadataSchema | TrackMetadata
 ): UploadTrackRequest['metadata'] => {
   return {
     title: metadata.title,
@@ -57,7 +55,7 @@ const formatTrackMetadata = (
 }
 
 const formatAlbumMetadata = (
-  metadata: CollectionMetadata
+  metadata: SDKUploadMetadataSchema
 ): UploadAlbumRequest['metadata'] => {
   return {
     genre: metadata.genre as Genre,
@@ -78,26 +76,26 @@ const formatAlbumMetadata = (
 
 const uploadTrack = async (
   audiusSdk: AudiusSdkType,
-  pendingTrack: CreateTrackRelease,
+  pendingTrack: SDKUploadMetadataSchema,
   s3Service: ReturnType<typeof createS3>
 ) => {
-  const userId = pendingTrack.metadata.artist_id
-  const metadata = formatTrackMetadata(pendingTrack.metadata)
+  const userId = pendingTrack.artist_id
+  const metadata = formatTrackMetadata(pendingTrack)
 
   const coverArtDownload = await s3Service.downloadFromS3Crawled(
-    pendingTrack.metadata.cover_art_url
+    pendingTrack.cover_art_url
   )
   // TODO: We can hash and verify against the metadata here
   const coverArtFile = {
     buffer: coverArtDownload!,
-    originalname: pendingTrack.metadata.cover_art_url.split('/').pop(),
+    originalname: pendingTrack.cover_art_url.split('/').pop(),
   }
   const trackDownload = await s3Service.downloadFromS3Crawled(
-    pendingTrack.metadata.audio_file_url
+    pendingTrack.audio_file_url
   )
   const trackFile = {
     buffer: trackDownload!,
-    originalname: pendingTrack.metadata.audio_file_url.split('/').pop(),
+    originalname: pendingTrack.audio_file_url.split('/').pop(),
   }
 
   const uploadTrackRequest: UploadTrackRequest = {
@@ -108,7 +106,7 @@ const uploadTrack = async (
     trackFile,
   }
   console.log(
-    `Uploading ${pendingTrack.metadata.title} by ${pendingTrack.metadata.artist_name} to Audius...`
+    `Uploading ${pendingTrack.title} by ${pendingTrack.artist_id} to Audius...`
   )
   const result = await audiusSdk.tracks.uploadTrack(uploadTrackRequest)
   console.log(result)
@@ -117,28 +115,28 @@ const uploadTrack = async (
 
 const uploadAlbum = async (
   audiusSdk: AudiusSdkType,
-  pendingAlbum: CreateAlbumRelease,
+  pendingAlbum: SDKUploadMetadataSchema,
   s3Service: ReturnType<typeof createS3>
 ) => {
   // Fetch cover art from S3
   const coverArtDownload = await s3Service.downloadFromS3Crawled(
-    pendingAlbum.metadata.cover_art_url
+    pendingAlbum.cover_art_url
   )
   // TODO: We can hash and verify against the metadata here
   const coverArtFile = {
     buffer: coverArtDownload!,
-    originalname: pendingAlbum.metadata.cover_art_url.split('/').pop(),
+    originalname: pendingAlbum.cover_art_url.split('/').pop(),
   }
 
   // Fetch track audio files from S3
   const trackFilesPromises = pendingAlbum.tracks.map(async (track) => {
     const trackDownload = await s3Service.downloadFromS3Crawled(
-      track.audio_file_url
+      track.audio_file_url!
     )
     // TODO: We can hash and verify against the metadata here
     return {
       buffer: trackDownload!,
-      originalname: track.audio_file_url.split('/').pop(),
+      originalname: track.audio_file_url!.split('/').pop(),
     }
   })
   const trackFiles = await Promise.all(trackFilesPromises)
@@ -149,14 +147,14 @@ const uploadAlbum = async (
 
   const uploadAlbumRequest: UploadAlbumRequest = {
     coverArtFile,
-    metadata: formatAlbumMetadata(pendingAlbum.metadata),
+    metadata: formatAlbumMetadata(pendingAlbum),
     onProgress: (progress: any) => console.log('Progress:', progress),
     trackFiles,
     trackMetadatas,
-    userId: pendingAlbum.metadata.playlist_owner_id,
+    userId: pendingAlbum.playlist_owner_id,
   }
   console.log(
-    `Uploading ${pendingAlbum.metadata.playlist_name} by ${pendingAlbum.metadata.playlist_owner_id} to Audius...`
+    `Uploading ${pendingAlbum.playlist_name} by ${pendingAlbum.playlist_owner_id} to Audius...`
   )
   const result = await audiusSdk.albums.uploadAlbum(uploadAlbumRequest)
   console.log(result)
@@ -205,7 +203,7 @@ export const publishReleases = async (
     try {
       const currentDate = new Date()
       documents = await PendingReleases.find({
-        publish_date: { $lte: currentDate },
+        'release.sdk_upload_metadata.release_date': { $lte: currentDate },
       }).lean<PendingRelease[]>()
     } catch (error) {
       console.error('Failed to fetch pending releases:', error)
@@ -230,16 +228,16 @@ export const publishReleases = async (
         blockNumber: number
       }
       try {
-        if (doc.create_track_release?.ddex_release_ref) {
+        if (doc.release?.sdk_upload_metadata?.title) {
           uploadResult = await uploadTrack(
             audiusSdk,
-            doc.create_track_release,
+            doc.release.sdk_upload_metadata,
             s3
           )
-        } else if (doc.create_album_release?.ddex_release_ref) {
+        } else if (doc.release?.sdk_upload_metadata?.playlist_name) {
           uploadResult = await uploadAlbum(
             audiusSdk,
-            doc.create_album_release,
+            doc.release.sdk_upload_metadata,
             s3
           )
         } else {
@@ -256,14 +254,12 @@ export const publishReleases = async (
 
       const publishedData = {
         _id: releaseId,
-        track: doc.create_track_release,
-        album: doc.create_album_release,
-        entity_id: doc.create_track_release
+        release: doc.release,
+        entity_id: doc.release.sdk_upload_metadata.title
           ? uploadResult.trackId
           : uploadResult.albumId,
         blockhash: uploadResult.blockHash,
         blocknumber: uploadResult.blockNumber,
-        publish_date: doc.publish_date,
         delivery_remote_path: doc.delivery_remote_path,
         created_at: new Date(),
       }

--- a/packages/ddex/webapp/client/src/components/Collection/Collection.tsx
+++ b/packages/ddex/webapp/client/src/components/Collection/Collection.tsx
@@ -166,13 +166,13 @@ const Table = ({
               <tr key={item._id}>
                 <td>{item._id}</td>
                 <td>
-                  {item.create_album_release?.ddex_release_ref
-                    ? 'album'
-                    : item.create_track_release?.ddex_release_ref
-                      ? 'track'
+                  {item.release?.sdk_upload_metadata?.title
+                    ? 'track'
+                    : item.release?.sdk_upload_metadata?.playlist_name
+                      ? 'album'
                       : 'unknown'}
                 </td>
-                <td>{item.publish_date}</td>
+                <td>{item.release?.sdk_upload_metadata?.release_date}</td>
                 <td>{item.created_at}</td>
                 <td className={item.failure_count ? styles.statusFailed : ''}>
                   {item.failure_count
@@ -197,7 +197,6 @@ const Table = ({
               <th>Entity ID</th>
               <th>Blockhash</th>
               <th>Blocknumber</th>
-              <th>Publish Date</th>
               <th>Created At</th>
             </tr>
           </thead>
@@ -206,12 +205,15 @@ const Table = ({
               <tr key={item.id}>
                 <td>{item._id}</td>
                 <td>
-                  {item.track ? 'track' : item.album ? 'album' : 'unknown'}
+                  {item.release?.sdk_upload_metadata?.title
+                    ? 'track'
+                    : item.release?.sdk_upload_metadata?.playlist_name
+                      ? 'album'
+                      : 'unknown'}
                 </td>
                 <td>{item.entity_id}</td>
                 <td>{item.blockhash}</td>
                 <td>{item.blocknumber}</td>
-                <td>{item.publish_date}</td>
                 <td>{item.created_at}</td>
               </tr>
             ))}


### PR DESCRIPTION
### Description
Adds all the types and logic updates to the DDEX publisher and web app to get back to a working state after the latest refactor.

### How Has This Been Tested?
The OAuth + upload flow resulted in a successful stage upload:
1. `audius-compose up --ddex-release-by-release`, go to localhost:9000, and login with Audius
2. `aws --endpoint=http://ingress:4566 s3 mb s3://audius-test-raw && aws --endpoint=http://ingress:4566 s3 mb s3://audius-test-crawled`
3. `aws --endpoint=http://ingress:4566 s3 cp ./ingester/e2e_test/fixtures/release_by_release/ern381/sony1.zip s3://audius-test-raw`
