### PR TITLE
Hotfix tracks not getting artwork

### DIFF
--- a/packages/web/src/common/store/upload/sagas.ts
+++ b/packages/web/src/common/store/upload/sagas.ts
@@ -90,7 +90,8 @@ const combineMetadata = (
   collectionMetadata: CollectionValues
 ) => {
   const metadata = trackMetadata
-  metadata.artwork = trackMetadata.artwork ?? collectionMetadata.artwork
+
+  metadata.artwork = collectionMetadata.artwork
 
   if (!metadata.genre)
     metadata.genre = collectionMetadata.trackDetails.genre ?? ''


### PR DESCRIPTION
### Description

Found a very easy-to-miss issue here since The `collectionMetadata.artwork` is an object like `{url: '', file: null}`.

This is just reverting back to the way it way before this PR:
https://github.com/AudiusProject/audius-protocol/pull/7723/files#diff-cd2a776f8ad4b4f879367d7b620db02fdf59a71b27f5e0289b557c8e60d47e65L75



### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._
