### PR TITLE
[PROTO-1760] Ensure UPC and ISWC are persisted top-level

### DIFF
--- a/packages/ddex/ingester/e2e_test/e2e_test.go
+++ b/packages/ddex/ingester/e2e_test/e2e_test.go
@@ -174,7 +174,7 @@ func TestRunE2E(t *testing.T) {
 						PlaylistOwnerName: stringPtr("Theo Random"),
 						IsAlbum:           boolPtr(true),
 						IsPrivate:         nil,
-						UPC:               nil,
+						UPC:               stringPtr("196871335584"),
 						Tracks: []common.TrackMetadata{
 							{
 								Title:       "Playing With Fire.",
@@ -292,6 +292,7 @@ func TestRunE2E(t *testing.T) {
 						DDEXReleaseIDs: &common.ReleaseIDs{
 							ICPN: "721620118165",
 						},
+						UPC: stringPtr("721620118165"),
 						CopyrightLine: &common.Copyright{
 							Year: "2010",
 							Text: "(C) 2010 Iron Crown Music",

--- a/packages/ddex/ingester/parser/ern38x.go
+++ b/packages/ddex/ingester/parser/ern38x.go
@@ -324,13 +324,13 @@ func buildAlbumMetadata(release *common.Release, mainRelease *common.ParsedRelea
 		PlaylistOwnerID:   &mainRelease.ArtistID,
 		PlaylistOwnerName: &mainRelease.ArtistName,
 		IsAlbum:           &isAlbum,
+		UPC:               stringPtr(mainRelease.ReleaseIDs.ICPN), // ICPN is either UPC (USA/Canada) or EAN (rest of world), but we call them both UPC
 
 		// Fields we don't know the value for (except IsPrivate should come from parsing DealList)
 		// Description:           "",
 		// Mood:                  nil,
 		// License:               nil,
 		// IsPrivate:         nil,
-		// UPC:               nil,
 	}
 }
 

--- a/packages/ddex/publisher/src/services/publisherService.ts
+++ b/packages/ddex/publisher/src/services/publisherService.ts
@@ -25,6 +25,7 @@ const formatTrackMetadata = (
     ...(metadata.mood && { mood: metadata.mood as Mood }),
     tags: metadata.tags || '',
     isrc: metadata.isrc,
+    iswc: metadata.ddex_release_ids?.iswc,
     license: metadata.license,
     releaseDate: new Date(metadata.release_date),
     ddexReleaseIds: metadata.ddex_release_ids,
@@ -42,7 +43,6 @@ const formatTrackMetadata = (
     producerCopyrightLine: metadata.producer_copyright_line,
     parentalWarningType: metadata.parental_warning_type,
     // isUnlisted: // TODO: set visibility
-    // iswc:
     // origFilename:
     // isOriginalAvailable:
     // isStreamGated:

--- a/packages/discovery-provider/src/api/v1/models/playlists.py
+++ b/packages/discovery-provider/src/api/v1/models/playlists.py
@@ -46,6 +46,7 @@ playlist_model = ns.model(
         "user": fields.Nested(user_model, required=True),
         "ddex_app": fields.String(allow_null=True),
         "access": fields.Nested(access),
+        "upc": fields.String(allow_null=True),
     },
 )
 

--- a/packages/discovery-provider/src/schemas/playlist_schema.json
+++ b/packages/discovery-provider/src/schemas/playlist_schema.json
@@ -21,6 +21,10 @@
         "ddex_app": {
           "type": ["string", "null"],
           "default": null
+        },
+        "upc": {
+          "type": ["string", "null"],
+          "default": null
         }
       },
       "required": [],

--- a/packages/discovery-provider/src/tasks/entity_manager/entities/playlist.py
+++ b/packages/discovery-provider/src/tasks/entity_manager/entities/playlist.py
@@ -490,6 +490,7 @@ def create_playlist(params: ManageEntityParameters):
         copyright_line=params.metadata.get("copyright_line", None),
         producer_copyright_line=params.metadata.get("producer_copyright_line", None),
         parental_warning_type=params.metadata.get("parental_warning_type", None),
+        upc=params.metadata.get("upc", None),
     )
 
     update_playlist_routes_table(params, playlist_record, True)

--- a/packages/discovery-provider/src/tasks/metadata.py
+++ b/packages/discovery-provider/src/tasks/metadata.py
@@ -183,6 +183,7 @@ class PlaylistMetadata(TypedDict):
     is_stream_gated: Optional[bool]
     stream_conditions: Optional[Any]
     ddex_app: Optional[str]
+    upc: Optional[str]
 
 
 playlist_metadata_format: PlaylistMetadata = {
@@ -197,6 +198,7 @@ playlist_metadata_format: PlaylistMetadata = {
     "is_stream_gated": False,
     "stream_conditions": None,
     "ddex_app": None,
+    "upc": None,
 }
 
 # Updates cannot directly modify these fields via metadata


### PR DESCRIPTION
### Description
- Persists UPC and ISWC as top-level identifiers in addition to where they were currently stored (within metadata under `ddex_release_ids`).
- Fixes Discovery bug which was ignoring UPC. Now Discovery persists UPC when passed during album creation.

### How Has This Been Tested?
- UPC is top-level in DDEX and passed through to Discovery when tested locally
- Tested on a stage node, including updating the album after to ensure this didn't overwrite the UPC field to be null