### PR TITLE
Fix failing E2E upload tests

### DIFF
--- a/packages/web/e2e/test.ts
+++ b/packages/web/e2e/test.ts
@@ -1,6 +1,6 @@
 import { Page, expect, test as base } from '@playwright/test'
 
-export const SSR_HYDRATE_TIMEOUT = 60 * 1000
+const SSR_HYDRATE_TIMEOUT = 60 * 1000
 
 /**
  * The initial page load is slow because we need to wait for the

--- a/packages/web/e2e/test.ts
+++ b/packages/web/e2e/test.ts
@@ -33,3 +33,10 @@ export const test = base.extend<{}>({
     await use(page)
   }
 })
+
+// TODO: Remove this and fix bug in upload that doesn't wait for user
+export const waitForUser = async (page: Page) => {
+  await expect(page.getByRole('link', { name: /probertest/i })).toBeVisible({
+    timeout: 15 * 1000
+  })
+}

--- a/packages/web/e2e/uploadCollection.test.ts
+++ b/packages/web/e2e/uploadCollection.test.ts
@@ -6,7 +6,7 @@ import {
   UploadFinishPage,
   UploadSelectPage
 } from './page-object-models/upload'
-import { SSR_HYDRATE_TIMEOUT, test } from './test'
+import { test, waitForUser } from './test'
 import { openCleanBrowser } from './utils'
 
 test('should upload a playlist', async ({ page }) => {
@@ -23,6 +23,7 @@ test('should upload a playlist', async ({ page }) => {
   const tags = ['TAG1', 'TAG2']
 
   await page.goto('upload')
+  await waitForUser(page)
 
   const selectPage = new UploadSelectPage(page)
   await selectPage.setTracks('track.mp3', 'track-2.mp3')
@@ -114,6 +115,7 @@ test('should upload an album', async ({ page }) => {
   const tags = ['TAG1', 'TAG2']
 
   await page.goto('upload')
+  await waitForUser(page)
 
   const selectPage = new UploadSelectPage(page)
   await selectPage.setTracks('track.mp3', 'track-2.mp3')
@@ -204,6 +206,7 @@ test.fixme('should upload a premium album', async ({ browser, page }) => {
   const albumTrackPrice = 2
 
   await page.goto('upload')
+  await waitForUser(page)
 
   const selectPage = new UploadSelectPage(page)
   await selectPage.setTracks('track.mp3', 'track-2.mp3')
@@ -309,22 +312,13 @@ test.fixme('should upload a premium album', async ({ browser, page }) => {
   const newPageTrackPriceText = newPage.getByText(`$${albumTrackPrice}.00`)
 
   newPage.goto(albumUrl)
-  await expect(newPage.getByTestId('app-hydrated')).toBeAttached({
-    timeout: SSR_HYDRATE_TIMEOUT
-  })
   await expect(buyButton).toBeVisible({ timeout: 20000 }) // The first track page load can take extra long sometimes (mainly in CI)
   await expect(newPageAlbumPriceText).toBeVisible()
 
   newPage.goto(track1url)
-  await expect(newPage.getByTestId('app-hydrated')).toBeAttached({
-    timeout: SSR_HYDRATE_TIMEOUT
-  })
   await expect(buyButton).toBeVisible()
   await expect(newPageTrackPriceText).toBeVisible()
   newPage.goto(track2url)
-  await expect(newPage.getByTestId('app-hydrated')).toBeAttached({
-    timeout: SSR_HYDRATE_TIMEOUT
-  })
   await expect(buyButton).toBeVisible()
   await expect(newPageTrackPriceText).toBeVisible()
 })

--- a/packages/web/e2e/uploadTrack.test.ts
+++ b/packages/web/e2e/uploadTrack.test.ts
@@ -11,7 +11,7 @@ import {
   UploadFinishPage,
   UploadSelectPage
 } from './page-object-models/upload'
-import { SSR_HYDRATE_TIMEOUT, test } from './test'
+import { SSR_HYDRATE_TIMEOUT, test, waitForUser } from './test'
 import { openCleanBrowser } from './utils'
 
 test('should upload a remix, hidden, AI-attributed track', async ({ page }) => {
@@ -27,6 +27,7 @@ test('should upload a remix, hidden, AI-attributed track', async ({ page }) => {
   const iswc = 'T-123456789-0'
 
   await page.goto('upload')
+  await waitForUser(page)
 
   const selectPage = new UploadSelectPage(page)
   await selectPage.setTracks('track.mp3')
@@ -136,6 +137,7 @@ test('should upload a premium track', async ({ page, browser }) => {
   const previewSeconds = '15'
 
   await page.goto('upload')
+  await waitForUser(page)
 
   const selectPage = new UploadSelectPage(page)
   await selectPage.setTracks('track.mp3')
@@ -194,6 +196,7 @@ test('should upload a track with free stems', async ({ page }) => {
   const genre = 'Alternative'
 
   await page.goto('upload')
+  await waitForUser(page)
 
   const selectPage = new UploadSelectPage(page)
   await selectPage.setTracks('track.mp3')

--- a/packages/web/e2e/uploadTrack.test.ts
+++ b/packages/web/e2e/uploadTrack.test.ts
@@ -11,7 +11,7 @@ import {
   UploadFinishPage,
   UploadSelectPage
 } from './page-object-models/upload'
-import { SSR_HYDRATE_TIMEOUT, test, waitForUser } from './test'
+import { test, waitForUser } from './test'
 import { openCleanBrowser } from './utils'
 
 test('should upload a remix, hidden, AI-attributed track', async ({ page }) => {
@@ -184,9 +184,6 @@ test('should upload a premium track', async ({ page, browser }) => {
   const newPage = await openCleanBrowser({ browser })
   const buyButton = newPage.getByRole('button', { name: /buy/i })
   newPage.goto(trackUrl)
-  await expect(newPage.getByTestId('app-hydrated')).toBeAttached({
-    timeout: SSR_HYDRATE_TIMEOUT
-  })
   await expect(buyButton).toBeVisible()
   await expect(newPage.getByText('$' + price)).toBeVisible()
 })


### PR DESCRIPTION
Upload tests were failing due to the user not being loaded by the time the test clicks continue.

Also removes redundant hydration checks.