### PR TITLE
[PAY-2343] Only dispatch audio matching challenges for valid purchases

### DIFF
--- a/packages/discovery-provider/integration_tests/challenges/test_audio_matching_challenges.py
+++ b/packages/discovery-provider/integration_tests/challenges/test_audio_matching_challenges.py
@@ -21,7 +21,7 @@ AMOUNT_FIVE = 5
 TRACK_ID = 1234
 
 
-def test_referral_challenge(app):
+def test_audio_matching_challenge(app):
     redis_conn = get_redis()
 
     with app.app_context():


### PR DESCRIPTION
### Description
Move $AUDIO matching challenge event dispatch to inside the valid purchase branch - so that we only ever dispatch these events on valid purchases.

Bonus - a test was misnamed.

### How Has This Been Tested?

Untested - will test on local stack tmr