### PR TITLE
[C-4253] Fix stats test line-height

### DIFF
--- a/packages/web/src/components/track/desktop/stats/Stats.module.css
+++ b/packages/web/src/components/track/desktop/stats/Stats.module.css
@@ -53,4 +53,5 @@
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
+  line-height: normal;
 }

--- a/packages/web/src/components/track/desktop/stats/StatsText.module.css
+++ b/packages/web/src/components/track/desktop/stats/StatsText.module.css
@@ -4,7 +4,6 @@
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
-  line-height: normal;
 }
 
 .first {


### PR DESCRIPTION
### Description
Small fix to apply the same line-height to all of the stats text

(Shoutout AJ with the eagle eyes)

### How Has This Been Tested?

Manually tested
