### PR TITLE
[C-4256] Fix misaligned artist badge in premium content unlock section

### DIFF
--- a/packages/web/src/components/track/GiantTrackTile.module.css
+++ b/packages/web/src/components/track/GiantTrackTile.module.css
@@ -60,6 +60,11 @@
   fill: var(--harmony-text-subdued);
 }
 
+.gatedContentOwner {
+  display: flex;
+  align-items: center;
+}
+
 .title {
   margin-bottom: var(--harmony-unit-3);
   width: 100%;
@@ -133,6 +138,7 @@
   height: 18px;
   width: 18px;
 }
+
 .completeTextIcon path {
   fill: var(--harmony-n-400);
 }


### PR DESCRIPTION
### Description
Small update to fix the alignment of the badge and the text

### How Has This Been Tested?

Manually tested
