### PR TITLE
Productionize DDEX webserver

### DIFF
--- a/packages/ddex/webapp/Dockerfile
+++ b/packages/ddex/webapp/Dockerfile
@@ -59,4 +59,4 @@ COPY --from=app-builder --chown=nodejs:nodejs /app .
 WORKDIR /app/packages/ddex/webapp/server
 
 EXPOSE 9000
-CMD ["node", "dist/index.js"]
+CMD ["npm", "run", "start:prod"]

--- a/packages/ddex/webapp/Dockerfile.fast
+++ b/packages/ddex/webapp/Dockerfile.fast
@@ -52,4 +52,4 @@ COPY packages/ddex/webapp/server/dist /app/packages/ddex/webapp/server/public
 WORKDIR /app/packages/ddex/webapp/server
 
 EXPOSE 9000
-CMD [ "node", "dist/index.js" ]
+CMD ["npm", "run", "start:prod"]

--- a/packages/ddex/webapp/server/package.json
+++ b/packages/ddex/webapp/server/package.json
@@ -29,7 +29,6 @@
     "fast-xml-parser": "4.3.2",
     "fastq": "1.16.0",
     "hashids": "2.3.0",
-    "helmet": "7.1.0",
     "mongodb": "6.3.0",
     "mongoose": "8.1.0",
     "multer": "1.4.5-lts.1",

--- a/packages/ddex/webapp/server/package.json
+++ b/packages/ddex/webapp/server/package.json
@@ -29,6 +29,7 @@
     "fast-xml-parser": "4.3.2",
     "fastq": "1.16.0",
     "hashids": "2.3.0",
+    "helmet": "7.1.0",
     "mongodb": "6.3.0",
     "mongoose": "8.1.0",
     "multer": "1.4.5-lts.1",

--- a/packages/ddex/webapp/server/src/app.ts
+++ b/packages/ddex/webapp/server/src/app.ts
@@ -1,6 +1,5 @@
 import express, { Express, NextFunction, Request, Response } from 'express'
 import path from 'path'
-import helmet from 'helmet'
 import session from 'express-session'
 import connectMongoDBSession from 'connect-mongodb-session'
 import User from './userSchema'
@@ -36,7 +35,6 @@ export default function createApp(
 
   app.disable('x-powered-by')
   app.use(express.json())
-  app.use(helmet())
 
   const MongoDBStore = connectMongoDBSession(session)
   const store = new MongoDBStore({

--- a/packages/ddex/webapp/server/src/app.ts
+++ b/packages/ddex/webapp/server/src/app.ts
@@ -1,5 +1,6 @@
 import express, { Express, NextFunction, Request, Response } from 'express'
 import path from 'path'
+import helmet from 'helmet'
 import session from 'express-session'
 import connectMongoDBSession from 'connect-mongodb-session'
 import User from './userSchema'
@@ -33,7 +34,9 @@ export default function createApp(
    */
   const app: Express = express()
 
+  app.disable('x-powered-by')
   app.use(express.json())
+  app.use(helmet())
 
   const MongoDBStore = connectMongoDBSession(session)
   const store = new MongoDBStore({
@@ -173,9 +176,6 @@ export default function createApp(
     const envData = {
       data: {
         env: process.env.NODE_ENV,
-        awsAccessKeyId: process.env.AWS_ACCESS_KEY_ID,
-        awsBucketRaw: process.env.AWS_BUCKET_RAW,
-        awsBucketCrawled: process.env.AWS_BUCKET_CRAWLED,
         ddexKey: process.env.DDEX_KEY,
         ddexChoreography: process.env.DDEX_CHOREOGRAPHY,
       },


### PR DESCRIPTION
### Description
Adds the following standard production aspects to the DDEX Express server:
- [Helmet](https://www.npmjs.com/package/helmet) for security-related HTTP headers
- Removing exposing of config that isn't necessary anymore
- Ensuring running in prod uses NODE_ENV=production (the npm script had this, but the Dockerfile wasn't using it)

### How Has This Been Tested?
I'm ensuring requests still work on a stage node and locally before merging.