### PR TITLE
increase solana RPC reselect freq

### DIFF
--- a/packages/libs/src/services/solana/transactionHandler.ts
+++ b/packages/libs/src/services/solana/transactionHandler.ts
@@ -53,7 +53,7 @@ export class TransactionHandler {
     identityService = null,
     feePayerKeypairs = null,
     skipPreflight = true,
-    retryTimeoutMs = 60000,
+    retryTimeoutMs = 10000,
     pollingFrequencyMs = 2000,
     sendingFrequencyMs = 2000,
     fallbackConnections = null

--- a/packages/libs/src/services/solana/transactionHandler.ts
+++ b/packages/libs/src/services/solana/transactionHandler.ts
@@ -312,11 +312,10 @@ export class TransactionHandler {
     const startTime = Date.now()
     if (retry) {
       ;(async () => {
-        const connections =
-          this.fallbackConnections?.filter(
-            (conn) => conn.rpcEndpoint !== this.connection.rpcEndpoint
-          ) ?? []
-        connections.push(this.connection)
+        const connections = this.fallbackConnections ?? []
+        if (connections.length === 0) {
+          connections.push(this.connection)
+        }
         let elapsed = Date.now() - startTime
         // eslint-disable-next-line no-unmodified-loop-condition
         while (!done && elapsed < this.retryTimeoutMs) {

--- a/packages/libs/src/services/solana/transactionHandler.ts
+++ b/packages/libs/src/services/solana/transactionHandler.ts
@@ -318,10 +318,9 @@ export class TransactionHandler {
           ) ?? []
         connections.push(this.connection)
         let elapsed = Date.now() - startTime
-        let currConnIdx = 0
         // eslint-disable-next-line no-unmodified-loop-condition
         while (!done && elapsed < this.retryTimeoutMs) {
-          const conn = connections[currConnIdx % connections.length]
+          const conn = connections[sendCount % connections.length]
           try {
             sendRawTransactionToConn(conn!)
           } catch (e) {
@@ -332,7 +331,6 @@ export class TransactionHandler {
             )
           }
           sendCount++
-          currConnIdx++
           await delay(this.sendingFrequencyMs)
           elapsed = Date.now() - startTime
         }


### PR DESCRIPTION
### Description
send solana txs to an RPC every 2 seconds, going down the list of known RPCs, rather than trying 1 RPC for 60s then falling back to the others one at a time

### How Has This Been Tested?
