### PR TITLE
[C-4260] Improve icon a11y

### DIFF
--- a/packages/harmony/.svgrrc.js
+++ b/packages/harmony/.svgrrc.js
@@ -1,5 +1,7 @@
 module.exports = {
   template: require('../../svgr-template'),
+  titleProp: true,
+  descProp: true,
   replaceAttrValues: {
     red: '{props.fillColor}',
     '#FF0000': '{props.fillColor}'

--- a/packages/harmony/src/icons/UtilityIcons.stories.mdx
+++ b/packages/harmony/src/icons/UtilityIcons.stories.mdx
@@ -57,7 +57,7 @@ Utility icons are simple, single-color glyphs that identify labels and actions a
 
 |                                     | Existing Name         | Primary Object | Modifier      | Modifier 2 | Modifier 3 |
 | ----------------------------------- | --------------------- | -------------- | ------------- | ---------- | ---------- |
-| <Icons.IconAlbum />                 | Album                 | Album          | -             | -          | -          |
+| <Icons.IconAlbum title='blah'/>     | Album                 | Album          | -             | -          | -          |
 | <Icons.IconAllTime />               | AllTime               | Infinity       | -             | -          | -          |
 | <Icons.IconAppearance />            | Appearance            | Circle         | Half          | -          | -          |
 | <Icons.IconArrowLeft />             | ArrowLeft             | Arrow          | Left          | -          | -          |

--- a/packages/mobile/.svgrrc.js
+++ b/packages/mobile/.svgrrc.js
@@ -1,5 +1,7 @@
 module.exports = {
   template: require('../../svgr-template'),
+  titleProp: true,
+  descProp: true,
   replaceAttrValues: {
     '#FF0000': '{props.fillColor}',
     '#000': '{props.fill}',

--- a/packages/web/.svgrrc.js
+++ b/packages/web/.svgrrc.js
@@ -1,5 +1,7 @@
 module.exports = {
   template: require('../../svgr-template'),
+  titleProp: true,
+  descProp: true,
   replaceAttrValues: {
     '#FF0000': '{props.fillColor}',
     '#000': '{props.fill}',

--- a/svgr-template.js
+++ b/svgr-template.js
@@ -59,6 +59,9 @@ const ${variables.componentName} = forwardRef((${variables.props}, ref) => {
 
   ${native ? nativeStyles : webStyles}
 
+  other.role = title ? 'img' : undefined
+  other['aria-hidden'] = title ? undefined : true
+
   props = {...other, ref, fillColor}
 
   return (${variables.jsx})


### PR DESCRIPTION
### Description

Improves icon a11y in some important ways.

1. By default svgs are decorative, which now have aria-hidden following guidelines
2. When svgs are semantic, we now can add a "title" prop, which updates role to img and adds title tag inside svg, following guidelines

https://www.tpgi.com/using-aria-enhance-svg-accessibility/
