### PR TITLE
[PROTO-1754] Fix DDEX albums being editable, fields not persisting

### DIFF
--- a/packages/discovery-provider/src/schemas/playlist_schema.json
+++ b/packages/discovery-provider/src/schemas/playlist_schema.json
@@ -25,10 +25,116 @@
         "upc": {
           "type": ["string", "null"],
           "default": null
+        },
+        "ddex_release_ids": {
+          "type": [
+            "object",
+            "null"
+          ],
+          "default": null
+        },
+        "artists": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "$ref": "#/definitions/ResourceContributor"
+          },
+          "default": null
+        },
+        "resource_contributors": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "$ref": "#/definitions/ResourceContributor"
+          },
+          "default": null
+        },
+        "indirect_resource_contributors": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "$ref": "#/definitions/ResourceContributor"
+          },
+          "default": null
+        },
+        "copyright_line": {
+          "type": [
+            "object",
+            "null"
+          ],
+          "items": {
+            "$ref": "#/definitions/Copyright"
+          },
+          "default": null
+        },
+        "producer_copyright_line": {
+          "type": [
+            "object",
+            "null"
+          ],
+          "items": {
+            "$ref": "#/definitions/Copyright"
+          },
+          "default": null
+        },
+        "parental_warning_type": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "default": null
         }
       },
       "required": [],
       "title": "Playlist"
+    },
+    "Role": {
+      "type": "string"
+    },
+    "ResourceContributor": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "roles": {
+          "type": "array",
+          "$ref": "#/definitions/Role"
+        },
+        "sequence_number": {
+          "type": "integer"
+        }
+      },
+      "required": [
+        "name",
+        "roles",
+        "sequence_number"
+      ],
+      "title": "ResourceContributor"
+    },
+    "Copyright": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "year": {
+          "type": "string"
+        },
+        "text": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "year",
+        "text"
+      ],
+      "title": "Copyright"
     }
   }
 }

--- a/packages/discovery-provider/src/tasks/entity_manager/utils.py
+++ b/packages/discovery-provider/src/tasks/entity_manager/utils.py
@@ -504,5 +504,5 @@ def is_ddex_signer(signer):
     # TODO read from a table in the db after implementing UI to register a DDEX node
     ddex_apps = os.getenv("audius_ddex_apps")
     if ddex_apps:
-        return signer.removeprefix("0x") in ddex_apps.split(",")
+        return signer.removeprefix("0x").lower() in (address.lower() for address in ddex_apps.split(","))
     return False

--- a/packages/discovery-provider/src/tasks/metadata.py
+++ b/packages/discovery-provider/src/tasks/metadata.py
@@ -184,6 +184,11 @@ class PlaylistMetadata(TypedDict):
     stream_conditions: Optional[Any]
     ddex_app: Optional[str]
     upc: Optional[str]
+    ddex_release_ids: Optional[Any]
+    artists: Optional[List[ResourceContributor]]
+    copyright_line: Optional[Copyright]
+    producer_copyright_line: Optional[Copyright]
+    parental_warning_type: Optional[str]
 
 
 playlist_metadata_format: PlaylistMetadata = {
@@ -199,6 +204,11 @@ playlist_metadata_format: PlaylistMetadata = {
     "stream_conditions": None,
     "ddex_app": None,
     "upc": None,
+    "ddex_release_ids": None,
+    "artists": None,
+    "copyright_line": None,
+    "producer_copyright_line": None,
+    "parental_warning_type": None,
 }
 
 # Updates cannot directly modify these fields via metadata


### PR DESCRIPTION
### Description
- Fixes DDEX albums being editable by the artist (I think this was due to case-sensitivity)
- Fixes other DDEX fields not being persisted for albums due to metadata filtering in Discovery

### How Has This Been Tested?
I tested on stage DN3 and verified that the fields now persist in Postgres.