### PR TITLE
Reduce border on playlist tile track list

### DIFF
--- a/packages/web/src/components/track/desktop/PlaylistTile.tsx
+++ b/packages/web/src/components/track/desktop/PlaylistTile.tsx
@@ -125,7 +125,11 @@ const PlaylistTile = ({
           hasStreamAccess={hasStreamAccess}
         />
       </TileTrackContainer>
-      <Box backgroundColor='surface1' borderTop='strong' borderBottom='strong'>
+      <Box
+        backgroundColor='surface1'
+        borderTop='default'
+        borderBottom='default'
+      >
         {renderTracks()}
         {renderMoreTracks()}
       </Box>


### PR DESCRIPTION
### Description

The border was too strong here. Bumping it down to keep things visually balanced.
The change is subtle, but the strong border stands out when viewed in context of the feed.

#### Before
![Screenshot 2024-04-10 at 11 28 31 AM](https://github.com/AudiusProject/audius-protocol/assets/2358254/6a85aa0f-0b38-4208-bbd7-8d03db001b9c)
#### After
![Screenshot 2024-04-10 at 11 28 20 AM](https://github.com/AudiusProject/audius-protocol/assets/2358254/9c41216d-eaad-42ab-b5dd-5ae9ae112090)


### How Has This Been Tested?

local web