### PR TITLE
Remove ComputeBudget from Withdrawals

### DIFF
--- a/packages/common/src/services/audius-backend/solana.ts
+++ b/packages/common/src/services/audius-backend/solana.ts
@@ -9,6 +9,7 @@ import {
 } from '@solana/spl-token'
 import {
   AddressLookupTableAccount,
+  ComputeBudgetProgram,
   Keypair,
   PublicKey,
   Transaction,
@@ -521,11 +522,18 @@ export const decorateCoinflowWithdrawalTransaction = async (
       'usdc'
     )
 
+  // Filter any compute budget instructions since the budget will
+  // definitely change
+  const instructions = transaction.instructions.filter(
+    (instruction) =>
+      !instruction.programId.equals(ComputeBudgetProgram.programId)
+  )
+
   // Find original transfer instruction and index
-  const transferInstructionIndex = transaction.instructions.findIndex(
+  const transferInstructionIndex = instructions.findIndex(
     isTransferCheckedInstruction
   )
-  const transferInstruction = transaction.instructions[transferInstructionIndex]
+  const transferInstruction = instructions[transferInstructionIndex]
   if (!transferInstruction) {
     throw new Error('No transfer instruction found')
   }
@@ -572,7 +580,6 @@ export const decorateCoinflowWithdrawalTransaction = async (
   })
 
   // Remove original transfer instruction and replace with our set of transfer steps
-  const instructions = [...transaction.instructions]
   instructions.splice(
     transferInstructionIndex,
     1,


### PR DESCRIPTION
### Description

Removes ComputeBudget instructions from the withdrawal transaction we get back from Coinflow, since the budget will change according to the new set of instructions.

### How Has This Been Tested?

Tested against prod. Successfully withdrew.