### PR TITLE
[PAY-2685] Render TrackAddedToPurchasedAlbumNotification on mobile

### DIFF
--- a/packages/mobile/src/screens/notifications-screen/NotificationListItem.tsx
+++ b/packages/mobile/src/screens/notifications-screen/NotificationListItem.tsx
@@ -29,6 +29,7 @@ import {
   USDCPurchaseSellerNotification,
   USDCPurchaseBuyerNotification
 } from './Notifications'
+import { TrackAddedToPurchasedAlbumNotification } from './Notifications/TrackAddedToPurchasedAlbumNotification'
 
 type NotificationListItemProps = {
   notification: Notification
@@ -93,6 +94,10 @@ export const NotificationListItem = (props: NotificationListItemProps) => {
         return <UserSubscriptionNotification notification={notification} />
       case NotificationType.AddTrackToPlaylist:
         return <AddTrackToPlaylistNotification notification={notification} />
+      case NotificationType.TrackAddedToPurchasedAlbum:
+        return (
+          <TrackAddedToPurchasedAlbumNotification notification={notification} />
+        )
       case NotificationType.SupporterDethroned:
         return <SupporterDethronedNotification notification={notification} />
       case NotificationType.USDCPurchaseSeller:

--- a/packages/mobile/src/screens/notifications-screen/Notifications/TrackAddedToPurchasedAlbumNotification.tsx
+++ b/packages/mobile/src/screens/notifications-screen/Notifications/TrackAddedToPurchasedAlbumNotification.tsx
@@ -1,0 +1,70 @@
+import { useCallback } from 'react'
+
+import { useProxySelector } from '@audius/common/hooks'
+import type { TrackAddedToPurchasedAlbumNotification as TrackAddedToPurchasedAlbumNotificationType } from '@audius/common/store'
+import { notificationsSelectors } from '@audius/common/store'
+import { View } from 'react-native'
+
+import { IconStars } from '@audius/harmony-native'
+import { useNotificationNavigation } from 'app/hooks/useNotificationNavigation'
+
+import {
+  NotificationHeader,
+  NotificationText,
+  NotificationTile,
+  NotificationTitle,
+  EntityLink,
+  UserNameLink,
+  NotificationProfilePicture
+} from '../Notification'
+const { getNotificationEntities } = notificationsSelectors
+
+const messages = {
+  title: 'New Release',
+  released: ' released a new track ',
+  onAlbum: ' on the album you purchased, '
+}
+type TrackAddedToPurchasedAlbumNotificationProps = {
+  notification: TrackAddedToPurchasedAlbumNotificationType
+}
+
+export const TrackAddedToPurchasedAlbumNotification = (
+  props: TrackAddedToPurchasedAlbumNotificationProps
+) => {
+  const { notification } = props
+  const navigation = useNotificationNavigation()
+  const entities = useProxySelector(
+    (state) => getNotificationEntities(state, notification),
+    [notification]
+  )
+  const { track, playlist } = entities
+  const playlistOwner = playlist.user
+
+  const handlePress = useCallback(() => {
+    if (playlist) {
+      navigation.navigate(notification)
+    }
+  }, [playlist, navigation, notification])
+
+  if (!playlistOwner) return null
+
+  return (
+    <NotificationTile notification={notification} onPress={handlePress}>
+      <NotificationHeader icon={IconStars}>
+        <NotificationTitle>{messages.title}</NotificationTitle>
+      </NotificationHeader>
+      <View style={{ flexDirection: 'row', alignItems: 'center' }}>
+        <NotificationProfilePicture profile={playlistOwner} />
+        <View style={{ flex: 1 }}>
+          <NotificationText>
+            <UserNameLink user={playlistOwner} />
+            {messages.released}
+            <EntityLink entity={track} />
+            {messages.onAlbum}
+            <EntityLink entity={playlist} />
+          </NotificationText>
+        </View>
+      </View>
+    </NotificationTile>
+  )
+}

--- a/packages/mobile/src/screens/notifications-screen/Notifications/TrackAddedToPurchasedAlbumNotification.tsx
+++ b/packages/mobile/src/screens/notifications-screen/Notifications/TrackAddedToPurchasedAlbumNotification.tsx
@@ -46,7 +46,7 @@ export const TrackAddedToPurchasedAlbumNotification = (
     }
   }, [playlist, navigation, notification])
 
-  if (!playlistOwner) return null
+  if (!playlistOwner || !track || !playlist) return null
 
   return (
     <NotificationTile notification={notification} onPress={handlePress}>


### PR DESCRIPTION
### Description

This concludes all work on PAY-2657

- Add support for new `TrackAddedToPurchasedAlbum` notification type in mobile

![Screenshot 2024-04-10 at 3 12 40 PM](https://github.com/AudiusProject/audius-protocol/assets/2358254/d72d8f87-a75f-4b0c-8753-ec08aebac30e)

### How Has This Been Tested?

working on ios against local stack
