### PR TITLE
[C-3949] Fix infinite library bug

### DIFF
--- a/packages/common/src/store/lineup/actions.ts
+++ b/packages/common/src/store/lineup/actions.ts
@@ -29,6 +29,8 @@ export const TOGGLE_PLAY = 'TOGGLE_PLAY'
 export const RESET = 'RESET'
 export const RESET_SUCCEEDED = 'RESET_SUCCEEDED'
 
+export const SET_MAX_ENTRIES = 'SET_MAX_ENTRIES'
+
 export const SET_IN_VIEW = 'SET_IN_VIEW'
 export const REFRESH_IN_VIEW = 'REFRESH_IN_VIEW'
 
@@ -238,6 +240,13 @@ export class LineupActions {
       kind,
       uid,
       handle
+    }
+  }
+
+  setMaxEntries(maxEntries: number | null) {
+    return {
+      type: addPrefix(this.prefix, SET_MAX_ENTRIES),
+      maxEntries
     }
   }
 

--- a/packages/web/src/common/store/pages/saved/lineups/sagas.ts
+++ b/packages/web/src/common/store/pages/saved/lineups/sagas.ts
@@ -1,4 +1,4 @@
-import { Collection, Kind, LineupEntry, UID } from '@audius/common/models'
+import { Collection, Kind, LineupEntry, UID, User } from '@audius/common/models'
 import {
   cacheTracksSelectors,
   savedPageTracksLineupActions as savedTracksActions,
@@ -14,9 +14,10 @@ import {
   playerSelectors,
   purchaseContentActions,
   PurchaseableContentType,
-  SavedPageTrack
+  SavedPageTrack,
+  accountSelectors
 } from '@audius/common/store'
-import { makeUid } from '@audius/common/utils'
+import { makeUid, waitForAccount } from '@audius/common/utils'
 import { uniq } from 'lodash'
 import moment from 'moment'
 import { call, select, put, takeEvery } from 'typed-redux-saga'
@@ -27,6 +28,7 @@ import { AppState } from 'store/types'
 
 const { getUid: getPlayerUid } = playerSelectors
 const { getSource } = queueSelectors
+const { FETCH_SAVES, FETCH_MORE_SAVES } = saveActions
 const { SAVE_TRACK, UNSAVE_TRACK, REPOST_TRACK, UNDO_REPOST_TRACK } =
   tracksSocialActions
 const {
@@ -132,6 +134,22 @@ class SavedTracksSagas extends LineupSagas<SavedPageTrack> {
       sourceSelector
     )
   }
+}
+
+function* watchFetchSaves() {
+  yield* takeEvery(
+    [FETCH_SAVES, FETCH_MORE_SAVES],
+    function* (_action: ReturnType<typeof saveActions.fetchSaves>) {
+      yield waitForAccount()
+      const account: User | null = yield* select(
+        accountSelectors.getAccountUser
+      )
+
+      if (account?.track_save_count) {
+        yield* put(savedTracksActions.setMaxEntries(account.track_save_count))
+      }
+    }
+  )
 }
 
 // If a local save is being done and the user is on the saved page route, make sure to update the lineup.
@@ -287,5 +305,5 @@ function* watchRemoveFromLibrary() {
 export default function sagas() {
   return new SavedTracksSagas()
     .getSagas()
-    .concat(watchAddToLibrary, watchRemoveFromLibrary)
+    .concat(watchAddToLibrary, watchRemoveFromLibrary, watchFetchSaves)
 }


### PR DESCRIPTION
### Description
Update lineup sagas for saved page to set maxEntries based on user save count so that the infinite library bug doesn't happen

### How Has This Been Tested?

Manually tested
