### PR TITLE
Restore common deps in CI

### DIFF
--- a/.circleci/src/jobs/@common-jobs.yml
+++ b/.circleci/src/jobs/@common-jobs.yml
@@ -23,6 +23,8 @@ common-init:
         paths:
           - node_modules
           - packages/common/node_modules
+          - packages/libs/node_modules
+          - packages/libs/dist
 
 common-test:
   working_directory: ~/audius-protocol


### PR DESCRIPTION
### Description

Seeing common test failures: https://app.circleci.com/pipelines/gh/AudiusProject/audius-protocol/54838/workflows/5544563e-a493-47c6-aadf-318c2b3f937d/jobs/767847 seemingly because we do not persist the libs node_modules in common ci

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._
