### PR TITLE
PROTO-1768: add trending challenges to index_nethermind queue for priority

### DIFF
--- a/packages/discovery-provider/src/tasks/index_nethermind.py
+++ b/packages/discovery-provider/src/tasks/index_nethermind.py
@@ -354,7 +354,7 @@ def index_next_block(
                 )
                 if should_update:
                     celery.send_task(
-                        "calculate_trending_challenges", kwargs={"date": date}
+                        "calculate_trending_challenges", queue="index_nethermind", kwargs={"date": date}
                     )
         except Exception as e:
             # Do not throw error, as this should not stop indexing


### PR DESCRIPTION
### Description
As shown in the linked axiom chart (see ticket), trending rewards sometimes get missed when backed up in the queue and the rewards bot can't calculate. Since this is normally a part of the index_nethermind indexing process anyways I added it to that queue for priority so rewards are calculated in a timely manner.

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._
