### PR TITLE
PAY-2563: add solana relay health check

### DIFF
--- a/dev-tools/compose/docker-compose.pedalboard.prod.yml
+++ b/dev-tools/compose/docker-compose.pedalboard.prod.yml
@@ -47,7 +47,10 @@ services:
       - discovery
     healthcheck:
       test:
-        ['CMD-SHELL', 'curl -f http://localhost:6001/relay/health || exit 1']
+        [
+          'CMD-SHELL',
+          'curl -f http://localhost:6001/relay/health || exit 1'
+        ]
       interval: 3s
       timeout: 30s
       retries: 3
@@ -74,6 +77,16 @@ services:
     deploy:
       mode: replicated
       replicas: '${DISCOVERY_PROVIDER_REPLICAS}'
+    healthcheck:
+      test:
+        [
+          'CMD-SHELL',
+          'curl -f http://localhost:6002/solana/health_check || exit 1'
+        ]
+      interval: 3s
+      timeout: 30s
+      retries: 3
+      start_period: 5s
 
   sla-auditor:
     container_name: sla-auditor

--- a/packages/discovery-provider/plugins/pedalboard/apps/solana-relay/src/index.ts
+++ b/packages/discovery-provider/plugins/pedalboard/apps/solana-relay/src/index.ts
@@ -15,6 +15,7 @@ import {
 } from './middleware/signerRecovery'
 import { cache } from './routes/cache'
 import { feePayer } from './routes/feePayer'
+import { health } from './routes/health/health'
 
 const main = async () => {
   const { serverHost, serverPort } = config
@@ -22,6 +23,7 @@ const main = async () => {
   app.use(json())
   app.use(cors())
   app.use(incomingRequestLogger)
+  app.get('/solana/health_check', health)
   app.use(userSignerRecoveryMiddleware)
   app.use(discoveryNodeSignerRecoveryMiddleware)
   app.post('/solana/relay', relay)

--- a/packages/discovery-provider/plugins/pedalboard/apps/solana-relay/src/routes/health/health.ts
+++ b/packages/discovery-provider/plugins/pedalboard/apps/solana-relay/src/routes/health/health.ts
@@ -1,0 +1,8 @@
+  import { Request, Response, NextFunction } from 'express'
+  import type { RelayRequestBody } from '@audius/sdk'
+
+export const health = async (req: Request, res: Response) => {
+    res.status(200).json({
+        isHealthy: true
+    })
+}


### PR DESCRIPTION
### Description
Adds a /health_check route to solana relay and uses this to gauge health in the docker container. More data can be added to this in the future as we build out solana relay for plays and such.

### How Has This Been Tested?

Docker container won't come up as healthy if this is down. `audius-compose up`
```
docker ps
CONTAINER ID   IMAGE                                                 COMMAND                  CREATED         STATUS                   PORTS                                            NAMES
39717cc92f50   audius-protocol-discovery-provider                    "sh -c '. /tmp/dev-t…"   5 minutes ago   Up 5 minutes (healthy)   5000/tcp                                         audius-protocol-discovery-provider-1
d637f609a1b7   audius-protocol-solana-relay                          "docker-entrypoint.s…"   5 minutes ago   Up 5 minutes (healthy)                                                    audius-protocol-solana-relay-1
```
