### PR TITLE
skip relay rate limit on dev

### DIFF
--- a/packages/discovery-provider/plugins/pedalboard/apps/relay/src/middleware/rateLimiter.ts
+++ b/packages/discovery-provider/plugins/pedalboard/apps/relay/src/middleware/rateLimiter.ts
@@ -16,6 +16,12 @@ export const rateLimiterMiddleware = async (
   const { validatedRelayRequest, recoveredSigner, signerIsUser, createOrDeactivate, isSenderVerifier, logger } = res.locals.ctx
   const { encodedABI } = validatedRelayRequest
 
+  // don't rate limit on local dev, this can block audius-cmd
+  if (config.environment === 'dev') {
+    next()
+    return
+  }
+
   let signer: string | null
   if (signerIsUser) {
     signer = (recoveredSigner as Users).wallet!


### PR DESCRIPTION
### Description
Removes rate limit locally for relay. This can block audius-cmd if you use it a lot for the same command.

### How Has This Been Tested?
audius-cmd create-user a bunch of times
