### PR TITLE
Bump web3 package

### DIFF
--- a/dev-tools/compose/docker-compose.test.yml
+++ b/dev-tools/compose/docker-compose.test.yml
@@ -1,6 +1,5 @@
 # Do not expose any ports in this file to allow running multiple tests and e2e dev at the same time
 
-version: '3.9'
 
 x-logging: &default-logging
   options:
@@ -513,55 +512,6 @@ services:
     depends_on:
       ddex-mongo:
         condition: service_healthy
-
-  test-ddex-e2e-release-by-release:
-    container_name: test-ddex-e2e-release-by-release
-    extends:
-      file: docker-compose.ddex.yml
-      service: ddex-test
-    entrypoint: sh -c '[ ! "$$1" = "test" ] && sleep inf || (shift;  go test ./e2e_test/... -count 1 -timeout 3m "$$@")' -
-    logging: *default-logging
-    environment:
-      AWS_ENDPOINT: 'http://ddex-s3:4566'
-      DDEX_CHOREOGRAPHY: "ERNReleaseByRelease"
-    networks:
-      - ddex-network
-    depends_on:
-      ddex-crawler:
-        condition: service_healthy
-      ddex-parser:
-        condition: service_healthy
-      # ddex-publisher:
-      #   condition: service_healthy
-      # Leaving out publisher for now because it takes a long time to build.
-      # We don't actually upload anything to Audius in the e2e test, but having a "dry run" publisher mode could be useful
-
-  test-ddex-e2e-batched:
-    container_name: test-ddex-e2e-batched
-    extends:
-      file: docker-compose.ddex.yml
-      service: ddex-test
-    entrypoint: sh -c '[ ! "$$1" = "test" ] && sleep inf || (shift;  go test ./e2e_test/... -count 1 -timeout 3m "$$@")' -
-    logging: *default-logging
-    environment:
-      AWS_ENDPOINT: 'http://ddex-s3:4566'
-      DDEX_CHOREOGRAPHY: "ERNBatched"
-    networks:
-      - ddex-network
-    depends_on:
-      ddex-crawler:
-        condition: service_healthy
-      ddex-parser:
-        condition: service_healthy
-  
-  test-ddex-unittests:
-    container_name: test-ddex-unittests
-    extends:
-      file: docker-compose.ddex.yml
-      service: ddex-test
-    entrypoint: sh -c '[ ! "$$1" = "test" ] && sleep inf || (shift;  go test $(go list ./... | grep -v /e2e_test) -count 1 -timeout 60s "$$@")' -
-    logging: *default-logging
-    # Will need a depends_on for S3 and Mongo if any future unit tests use them
 
 networks:
   ddex-network:

--- a/packages/discovery-provider/requirements.txt
+++ b/packages/discovery-provider/requirements.txt
@@ -13,6 +13,7 @@ types-freezegun==1.1.10
 types-Flask==1.1.6
 
 web3==6.6.1
+eth-typing==4.2.1
 hexbytes==0.3.1
 Flask==1.0.4
 # pin itsdangerous and markupsafe https://github.com/pallets/flask/issues/4455


### PR DESCRIPTION
### Description

Seeing an error `ImportError: cannot import name 'ContractName' from 'eth_typing' (/usr/lib/python3.11/site-packages/eth_typing/__init__.py)` on discovery tests, this may be a fix.

### How Has This Been Tested?

CI