### PR TITLE
Only bump web and mobile versions on release branch

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -324,7 +324,7 @@ jobs:
             PREV_VERSION=$(jq -r .version ./package.json)
             CHANGELOG=$(git log --pretty=format:"[%h] %s %an" --date=short client-v${PREV_VERSION}..HEAD)
             npm i --ignore-scripts
-            npm version patch -ws --include-workspace-root --no-git-tag-version
+            npm version patch -w audius-client -w audius-mobile-client --include-workspace-root --no-git-tag-version
             git add .
             VERSION=$(jq -r .version ./package.json)
             MESSAGE="v${VERSION}


### PR DESCRIPTION
### Description

Update `generate-client-release` command to only bump web and mobile versions instead of every package. Changesets will handle bumping everything else for us

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._
