### PR TITLE
[PROTO-1764] Pipe vector logs for ddex containers

### DIFF
--- a/monitoring/vector/start.sh
+++ b/monitoring/vector/start.sh
@@ -15,6 +15,8 @@ elif [ "${audius_delegate_owner_wallet}" ]; then
   node=${audius_delegate_owner_wallet}
 elif [ "${delegateOwnerWallet}" ]; then
   node=${delegateOwnerWallet}
+elif [ "${DDEX_URL}" ]; then
+  node=${DDEX_URL}
 fi
 
 # use regex to extract domain in url (source: https://stackoverflow.com/a/2506635/8674706)

--- a/monitoring/vector/vector.toml
+++ b/monitoring/vector/vector.toml
@@ -13,7 +13,11 @@
     "notifications",
     "chain",
     "mediorum",
-    "relay"
+    "relay",
+    "ddex-publisher",
+    "ddex-web",
+    "ddex-parser",
+    "ddex-crawler"
   ]
   exclude_containers = [
     # System containers


### PR DESCRIPTION
### Description
- Sends logs to Axiom for DDEX containers except for mongo and mongo-init (up for debate, but I don't see them being very useful compared to their spam)
- Uses `DDEX_URL` as the `node` field because otherwise it was empty, and we want a way to differentiate prod DDEX instances
- I already added the Vector container to the DDEX audius-docker-compose yaml separately

### How Has This Been Tested?
I pushed a Docker image with these changes and confirmed that the logs show up in Axiom with the correct `node` field.