### PR TITLE
Fixes close icon color on artist dashboard

### DIFF
--- a/packages/web/src/pages/dashboard-page/components/TracksTableContainer.tsx
+++ b/packages/web/src/pages/dashboard-page/components/TracksTableContainer.tsx
@@ -249,6 +249,7 @@ export const TracksTableContainer = ({
             suffix={
               filterText ? (
                 <IconClose
+                  color='subdued'
                   className={styles.close}
                   onClick={() => setFilterText('')}
                 />


### PR DESCRIPTION
### Description
Fixes an icon missing a color setting.

Before
<img width="202" alt="image" src="https://github.com/AudiusProject/audius-protocol/assets/1815175/294bdc50-ae73-477b-98f1-dd0488ec281d">


After
<img width="224" alt="image" src="https://github.com/AudiusProject/audius-protocol/assets/1815175/96011e70-c10b-4c75-97f7-5f821817fdd1">

