### PR TITLE
Allow audio/x-flac mime type

### DIFF
--- a/packages/libs/src/sdk/types/File.ts
+++ b/packages/libs/src/sdk/types/File.ts
@@ -43,6 +43,7 @@ export const ALLOWED_AUDIO_MIME_TYPES = [
   'audio/mp3',
   'audio/aiff',
   'audio/flac',
+  'audio/x-flac',
   'audio/ogg',
   'audio/wav',
   'audio/vnd.wave'


### PR DESCRIPTION
When calling `uploadTrack` with a flac file in node you get:

```
{ "code": "custom", "message": "Audio file has invalid file type. Supported file types are: audio/mpeg, audio/mp3, audio/aiff, audio/flac, audio/ogg, audio/wav, audio/vnd.wave", "path": [ "trackFiles", 0 ] }, { "code": "custom", "message": "Audio file has invalid file type. Supported file types are: audio/mpeg, audio/mp3, audio/aiff, audio/flac, audio/ogg, audio/wav, audio/vnd.wave", "path": [ "trackFiles", 1 ] },
```

because `file-type` package gives audio/x-flac for flac