### PR TITLE
DDEX separate release date and validity start date

### DIFF
--- a/packages/ddex/ingester/common/sdk_types.go
+++ b/packages/ddex/ingester/common/sdk_types.go
@@ -181,6 +181,7 @@ type ReleaseIDs struct {
 type TrackMetadata struct {
 	Title                        string                `bson:"title"`
 	ReleaseDate                  time.Time             `bson:"release_date"`
+	ValidityStartDate            time.Time             `bson:"validity_start_date"`
 	Genre                        Genre                 `bson:"genre"`
 	Duration                     int                   `bson:"duration"`
 	PreviewStartSeconds          NullableInt           `bson:"preview_start_seconds,omitempty"`
@@ -227,9 +228,10 @@ type TrackMetadata struct {
 // SDKUploadMetadata represents the metadata required to upload a track or album to Audius
 type SDKUploadMetadata struct {
 	// Required for both tracks and albums
-	ReleaseDate time.Time `bson:"release_date"`
-	Genre       Genre     `bson:"genre"`
-	CoverArtURL string    `bson:"cover_art_url"`
+	ReleaseDate       time.Time `bson:"release_date"`
+	ValidityStartDate time.Time `bson:"validity_start_date"`
+	Genre             Genre     `bson:"genre"`
+	CoverArtURL       string    `bson:"cover_art_url"`
 
 	// Optional for both tracks and albums
 	CoverArtURLHash       NullableString        `bson:"cover_art_url_hash,omitempty"`

--- a/packages/ddex/ingester/common/types.go
+++ b/packages/ddex/ingester/common/types.go
@@ -72,14 +72,15 @@ type Release struct {
 
 // ParsedReleaseElement contains parsed details of a <Release> element
 type ParsedReleaseElement struct {
-	ReleaseRef    string           `bson:"release_ref"`
-	IsMainRelease bool             `bson:"is_main_release"`
-	ReleaseType   ReleaseType      `bson:"release_type"`
-	ReleaseIDs    ReleaseIDs       `bson:"release_ids"`
-	ReleaseDate   time.Time        `bson:"release_date"`
-	Resources     ReleaseResources `bson:"resources"`
-	ArtistID      string           `bson:"artist_id"`
-	ArtistName    string           `bson:"artist_name"`
+	ReleaseRef        string           `bson:"release_ref"`
+	IsMainRelease     bool             `bson:"is_main_release"`
+	ReleaseType       ReleaseType      `bson:"release_type"`
+	ReleaseIDs        ReleaseIDs       `bson:"release_ids"`
+	ReleaseDate       time.Time        `bson:"release_date"`
+	ValidityStartDate time.Time        `bson:"validity_start_date"`
+	Resources         ReleaseResources `bson:"resources"`
+	ArtistID          string           `bson:"artist_id"`
+	ArtistName        string           `bson:"artist_name"`
 
 	DisplayTitle                 string                `bson:"display_title"` // For displaying on the frontend
 	DisplaySubtitle              NullableString        `bson:"display_subtitle,omitempty"`

--- a/packages/ddex/ingester/e2e_test/e2e_test.go
+++ b/packages/ddex/ingester/e2e_test/e2e_test.go
@@ -128,8 +128,9 @@ func TestRunE2E(t *testing.T) {
 				Release: common.Release{
 					ReleaseProfile: common.UnspecifiedReleaseProfile,
 					SDKUploadMetadata: common.SDKUploadMetadata{
-						ReleaseDate: time.Date(2023, time.September, 2, 0, 0, 0, 0, time.UTC),
-						Genre:       "Hip-Hop/Rap",
+						ReleaseDate:       time.Date(2023, time.September, 1, 0, 0, 0, 0, time.UTC),
+						ValidityStartDate: time.Date(2023, time.September, 2, 0, 0, 0, 0, time.UTC),
+						Genre:             "Hip-Hop/Rap",
 						Artists: []common.ResourceContributor{
 							{
 								Name:           "Theo Random",
@@ -178,14 +179,16 @@ func TestRunE2E(t *testing.T) {
 						HasDeal:           true,
 						Tracks: []common.TrackMetadata{
 							{
-								Title:       "Playing With Fire.",
-								ReleaseDate: time.Date(2023, time.September, 2, 0, 0, 0, 0, time.UTC),
-								Genre:       "Hip-Hop/Rap",
-								Duration:    279,
-								ISRC:        stringPtr("ZAA012300131"),
+								Title:             "Playing With Fire.",
+								ReleaseDate:       time.Date(2023, time.September, 1, 0, 0, 0, 0, time.UTC),
+								ValidityStartDate: time.Date(2023, time.September, 2, 0, 0, 0, 0, time.UTC),
+								Genre:             "Hip-Hop/Rap",
+								Duration:          279,
+								ISRC:              stringPtr("ZAA012300131"),
 								DDEXReleaseIDs: common.ReleaseIDs{
 									ISRC: "ZAA012300131",
 								},
+								ArtistID: "Bmv3bJ",
 								Artists: []common.ResourceContributor{
 									{
 										Name:           "Theo Random",
@@ -217,14 +220,16 @@ func TestRunE2E(t *testing.T) {
 								HasDeal:              true,
 							},
 							{
-								Title:       "No Comment.",
-								ReleaseDate: time.Date(2023, time.September, 2, 0, 0, 0, 0, time.UTC),
-								Genre:       "Hip-Hop/Rap",
-								Duration:    142,
-								ISRC:        stringPtr("ZAA012300128"),
+								Title:             "No Comment.",
+								ReleaseDate:       time.Date(2023, time.July, 27, 0, 0, 0, 0, time.UTC),
+								ValidityStartDate: time.Date(2023, time.September, 2, 0, 0, 0, 0, time.UTC),
+								Genre:             "Hip-Hop/Rap",
+								Duration:          142,
+								ISRC:              stringPtr("ZAA012300128"),
 								DDEXReleaseIDs: common.ReleaseIDs{
 									ISRC: "ZAA012300128",
 								},
+								ArtistID: "Bmv3bJ",
 								Artists: []common.ResourceContributor{
 									{Name: "Theo Random", Roles: []string{"AssociatedPerformer", "MainArtist"}, SequenceNumber: 1},
 									{Name: "Thato Saul", Roles: []string{"AssociatedPerformer", "MainArtist"}, SequenceNumber: 2},
@@ -291,6 +296,7 @@ func TestRunE2E(t *testing.T) {
 					ReleaseProfile: common.Common14AudioAlbumMusicOnly,
 					SDKUploadMetadata: common.SDKUploadMetadata{
 						ReleaseDate:       time.Date(2010, time.January, 1, 0, 0, 0, 0, time.UTC),
+						ValidityStartDate: time.Date(2018, time.January, 10, 0, 0, 0, 0, time.UTC),
 						PlaylistName:      stringPtr("A Monkey Claw in a Velvet Glove"),
 						PlaylistOwnerID:   stringPtr("abcdef"),
 						PlaylistOwnerName: stringPtr("Monkey Claw"),
@@ -319,12 +325,13 @@ func TestRunE2E(t *testing.T) {
 						CoverArtURL: "s3://audius-test-crawled/721620118165/resources/721620118165_T7_007.jpg",
 						Tracks: []common.TrackMetadata{
 							{
-								Title:       "Can you feel ...the Monkey Claw!",
-								ArtistName:  "Monkey Claw",
-								ReleaseDate: time.Date(2018, time.January, 10, 0, 0, 0, 0, time.UTC),
-								Genre:       "Metal",
-								Duration:    811,
-								ISRC:        stringPtr("CASE00000001"),
+								Title:             "Can you feel ...the Monkey Claw!",
+								ArtistName:        "Monkey Claw",
+								ReleaseDate:       time.Date(2010, time.January, 1, 0, 0, 0, 0, time.UTC),
+								ValidityStartDate: time.Date(2018, time.January, 10, 0, 0, 0, 0, time.UTC),
+								Genre:             "Metal",
+								Duration:          811,
+								ISRC:              stringPtr("CASE00000001"),
 								DDEXReleaseIDs: common.ReleaseIDs{
 									ISRC: "CASE00000001",
 								},
@@ -351,6 +358,7 @@ func TestRunE2E(t *testing.T) {
 										SequenceNumber: 1,
 									},
 								},
+								ArtistID: "abcdef",
 								Artists: []common.ResourceContributor{
 									{
 										Name:           "Monkey Claw",
@@ -364,12 +372,13 @@ func TestRunE2E(t *testing.T) {
 								HasDeal:         true,
 							},
 							{
-								Title:       "Red top mountain, blown sky high",
-								ArtistName:  "Monkey Claw",
-								ReleaseDate: time.Date(2018, time.January, 10, 0, 0, 0, 0, time.UTC),
-								Genre:       "Metal",
-								Duration:    366,
-								ISRC:        stringPtr("CASE00000002"),
+								Title:             "Red top mountain, blown sky high",
+								ArtistName:        "Monkey Claw",
+								ReleaseDate:       time.Date(2010, time.January, 1, 0, 0, 0, 0, time.UTC),
+								ValidityStartDate: time.Date(2018, time.January, 10, 0, 0, 0, 0, time.UTC),
+								Genre:             "Metal",
+								Duration:          366,
+								ISRC:              stringPtr("CASE00000002"),
 								DDEXReleaseIDs: common.ReleaseIDs{
 									ISRC: "CASE00000002",
 								},
@@ -396,6 +405,7 @@ func TestRunE2E(t *testing.T) {
 										SequenceNumber: 1,
 									},
 								},
+								ArtistID: "abcdef",
 								Artists: []common.ResourceContributor{
 									{
 										Name:           "Monkey Claw",
@@ -445,11 +455,13 @@ func TestRunE2E(t *testing.T) {
 				Release: common.Release{
 					ReleaseProfile: common.Common13AudioSingle,
 					SDKUploadMetadata: common.SDKUploadMetadata{
-						ReleaseDate: time.Date(2023, time.October, 1, 0, 0, 0, 0, time.UTC),
-						Genre:       "Blues",
+						ReleaseDate:       time.Date(2023, time.October, 1, 0, 0, 0, 0, time.UTC),
+						ValidityStartDate: time.Date(2023, time.October, 1, 0, 0, 0, 0, time.UTC),
+						Genre:             "Blues",
 						DDEXReleaseIDs: &common.ReleaseIDs{
 							ISRC: "NLRD51952976",
 						},
+						ArtistID: stringPtr("fugarian"),
 						Artists: []common.ResourceContributor{
 							{
 								Name:           "FUGARIAN",
@@ -470,7 +482,6 @@ func TestRunE2E(t *testing.T) {
 						CoverArtURLHash:     stringPtr("03a3372963d1567ef98f7229c49538e0"),
 						CoverArtURLHashAlgo: stringPtr("MD5"),
 						Title:               stringPtr("All My Single"),
-						ArtistID:            stringPtr(""), // TODO: Shouldn't be empty
 						Duration:            75,
 						ISRC:                stringPtr("NLRD51952976"),
 						ResourceContributors: []common.ResourceContributor{

--- a/packages/ddex/ingester/parser/ern38x.go
+++ b/packages/ddex/ingester/parser/ern38x.go
@@ -159,24 +159,14 @@ func parseERN38x(doc *xmlquery.Node, crawledBucket, releaseID string, release *c
 		}
 	}
 
-	// Find the release that's marked as the main release
+	// Validate existence of a single main release
 	if len(release.ParsedReleaseElems) == 0 {
 		errs = append(errs, fmt.Errorf("no <Release> elements could be parsed from <ReleaseList>"))
 		return
 	}
-	var mainRelease *common.ParsedReleaseElement
-	for i := range release.ParsedReleaseElems {
-		parsedRelease := &release.ParsedReleaseElems[i]
-		if parsedRelease.IsMainRelease {
-			if mainRelease != nil {
-				errs = append(errs, fmt.Errorf("multiple main releases found: %s and %s", mainRelease.ReleaseRef, parsedRelease.ReleaseRef))
-				return
-			}
-			mainRelease = parsedRelease
-		}
-	}
-	if mainRelease == nil {
-		errs = append(errs, fmt.Errorf("no main release found in releases: %#v", release.ParsedReleaseElems))
+	_, err := getMainRelease(release)
+	if err != nil {
+		errs = append(errs, err)
 		return
 	}
 
@@ -194,6 +184,15 @@ func parseERN38x(doc *xmlquery.Node, crawledBucket, releaseID string, release *c
 		}
 	}
 
+	return
+}
+
+func buildSDKMetadataERN38x(release *common.Release) (errs []error) {
+	mainRelease, err := getMainRelease(release)
+	if err != nil {
+		errs = append(errs, err)
+		return
+	}
 	// Create metadata to use in the Audius SDK's upload based on release type
 	switch release.ReleaseProfile {
 	case common.Common13AudioSingle:
@@ -213,6 +212,24 @@ func parseERN38x(doc *xmlquery.Node, crawledBucket, releaseID string, release *c
 	}
 
 	return
+}
+
+func getMainRelease(release *common.Release) (*common.ParsedReleaseElement, error) {
+	var mainRelease *common.ParsedReleaseElement
+	for i := range release.ParsedReleaseElems {
+		parsedRelease := &release.ParsedReleaseElems[i]
+		if parsedRelease.IsMainRelease {
+			if mainRelease != nil {
+				return nil, fmt.Errorf("multiple main releases found: %s and %s", mainRelease.ReleaseRef, parsedRelease.ReleaseRef)
+			}
+			mainRelease = parsedRelease
+		}
+	}
+	if mainRelease == nil {
+		return nil, fmt.Errorf("no main release found in releases: %#v", release.ParsedReleaseElems)
+	}
+
+	return mainRelease, nil
 }
 
 func buildSingleMetadata(release *common.Release, mainRelease *common.ParsedReleaseElement, errs *[]error) {
@@ -405,9 +422,7 @@ func buildSupportingTracks(release *common.Release) (tracks []common.TrackMetada
 		track.IsStreamFollowGated = parsedReleaseElem.IsStreamFollowGated
 		track.IsStreamTipGated = parsedReleaseElem.IsStreamTipGated
 		track.IsDownloadFollowGated = parsedReleaseElem.IsDownloadFollowGated
-		if !parsedReleaseElem.ReleaseDate.IsZero() {
-			track.ReleaseDate = parsedReleaseElem.ReleaseDate
-		}
+		track.ReleaseDate = parsedReleaseElem.ReleaseDate
 
 		tracks = append(tracks, track)
 	}
@@ -770,7 +785,7 @@ func processDealNode(dNode *xmlquery.Node, release *common.Release) (err error) 
 				}
 
 				if validityStartStr != "" {
-					elem.ReleaseDate = validityStart
+					elem.ValidityStartDate = validityStart
 				}
 				elem.HasDeal = true
 			}

--- a/packages/ddex/ingester/parser/ern38x.go
+++ b/packages/ddex/ingester/parser/ern38x.go
@@ -271,6 +271,7 @@ func buildSingleMetadata(release *common.Release, mainRelease *common.ParsedRele
 	releaseIDs := tracks[0].DDEXReleaseIDs
 	release.SDKUploadMetadata = common.SDKUploadMetadata{
 		ReleaseDate:           tracks[0].ReleaseDate,
+		ValidityStartDate:     tracks[0].ValidityStartDate,
 		Genre:                 tracks[0].Genre,
 		Artists:               tracks[0].Artists,
 		Tags:                  nil,
@@ -347,6 +348,7 @@ func buildAlbumMetadata(release *common.Release, mainRelease *common.ParsedRelea
 	releaseIDs := mainRelease.ReleaseIDs
 	release.SDKUploadMetadata = common.SDKUploadMetadata{
 		ReleaseDate:           mainRelease.ReleaseDate,
+		ValidityStartDate:     mainRelease.ValidityStartDate,
 		Genre:                 mainRelease.Genre,
 		Artists:               mainRelease.Artists,
 		Tags:                  nil,
@@ -423,6 +425,7 @@ func buildSupportingTracks(release *common.Release) (tracks []common.TrackMetada
 		track.IsStreamTipGated = parsedReleaseElem.IsStreamTipGated
 		track.IsDownloadFollowGated = parsedReleaseElem.IsDownloadFollowGated
 		track.ReleaseDate = parsedReleaseElem.ReleaseDate
+		track.ValidityStartDate = parsedReleaseElem.ValidityStartDate
 
 		tracks = append(tracks, track)
 	}

--- a/packages/ddex/ingester/parser/parser.go
+++ b/packages/ddex/ingester/parser/parser.go
@@ -219,7 +219,41 @@ func (p *Parser) parseRelease(unprocessedRelease *common.UnprocessedRelease, del
 				return nil, err
 			}
 		}
+		// For albums/EPs without a ValidityStartDate: use the latest ValidityStartDate from the tracks on the album
+		if parsedRelease.IsMainRelease && parsedRelease.ReleaseType != common.TrackReleaseType && parsedRelease.ValidityStartDate.IsZero() {
+			var maxTrackValidityStartDate time.Time
+			for _, elem := range release.ParsedReleaseElems {
+				if elem.IsMainRelease {
+					continue
+				}
+				if elem.ValidityStartDate.After(maxTrackValidityStartDate) {
+					maxTrackValidityStartDate = elem.ValidityStartDate
+				}
+			}
+			parsedRelease.ValidityStartDate = maxTrackValidityStartDate
+		}
+
+		// Verify release has a nonzero ValidityStartDate
+		if parsedRelease.ValidityStartDate.IsZero() {
+			err = fmt.Errorf("release '%s' (ref %s) does not have valid validity start date", parsedRelease.DisplayTitle, parsedRelease.ReleaseRef)
+			unprocessedRelease.ValidationErrors = append(unprocessedRelease.ValidationErrors, err.Error())
+			return nil, err
+		}
+
+		// Use ValidityStartDate as ReleaseDate if a ReleaseDate is not provided
+		if parsedRelease.ReleaseDate.IsZero() {
+			parsedRelease.ReleaseDate = parsedRelease.ValidityStartDate
+		}
+
 		release.ParsedReleaseElems[i] = parsedRelease
+	}
+
+	sdkErrs := buildSDKMetadataERN38x(release)
+	if len(sdkErrs) != 0 {
+		for _, err := range sdkErrs {
+			unprocessedRelease.ValidationErrors = append(unprocessedRelease.ValidationErrors, err.Error())
+		}
+		return nil, fmt.Errorf("failed to build SDK metadata for release: %v", errs)
 	}
 
 	// Create (but don't yet insert into Mongo) a PendingRelease for each track and album release

--- a/packages/ddex/ingester/parser/parser.go
+++ b/packages/ddex/ingester/parser/parser.go
@@ -219,7 +219,8 @@ func (p *Parser) parseRelease(unprocessedRelease *common.UnprocessedRelease, del
 				return nil, err
 			}
 		}
-		// For albums/EPs without a ValidityStartDate: use the latest ValidityStartDate from the tracks on the album
+		// For albums/EPs without a ValidityStartDate: use the latest ValidityStartDate from the tracks on the album.
+		// This case is possible because deals for tracks are required but a deal for the album release is not required.
 		if parsedRelease.IsMainRelease && parsedRelease.ReleaseType != common.TrackReleaseType && parsedRelease.ValidityStartDate.IsZero() {
 			var maxTrackValidityStartDate time.Time
 			for _, elem := range release.ParsedReleaseElems {

--- a/packages/ddex/publisher/src/models/pendingReleases.ts
+++ b/packages/ddex/publisher/src/models/pendingReleases.ts
@@ -214,7 +214,7 @@ export const sdkUploadMetadataSchema = new mongoose.Schema(
     cover_art_url: { type: String, required: true },
     cover_art_url_hash: nullableString,
     cover_art_url_hash_algo: nullableString,
-    has_deal: Boolean,
+    has_deal: { type: Boolean, default: false },
 
     // Only for tracks
     title: nullableString,
@@ -231,13 +231,13 @@ export const sdkUploadMetadataSchema = new mongoose.Schema(
     audio_file_url: nullableString,
     audio_file_url_hash: nullableString,
     audio_file_url_hash_algo: nullableString,
-    is_stream_gated: { type: Boolean, required: true },
+    is_stream_gated: { type: Boolean, default: false },
     stream_conditions: { type: mongoose.Schema.Types.Mixed, default: null },
-    is_download_gated: { type: Boolean, required: true },
+    is_download_gated: { type: Boolean, default: false },
     download_conditions: { type: mongoose.Schema.Types.Mixed, default: null },
-    is_stream_follow_gated: Boolean,
-    is_stream_tip_gated: Boolean,
-    is_download_follow_gated: Boolean,
+    is_stream_follow_gated: { type: Boolean, default: false },
+    is_stream_tip_gated: { type: Boolean, default: false },
+    is_download_follow_gated: { type: Boolean, default: false },
 
     // Only for albums
     tracks: [trackMetadataSchema],
@@ -295,6 +295,14 @@ const parsedReleaseElementSchema = new mongoose.Schema(
     copyright_line: { type: copyrightSchema, default: null },
     producer_copyright_line: { type: copyrightSchema, default: null },
     parental_warning_type: nullableString,
+    is_stream_gated: { type: Boolean, default: false },
+    stream_conditions: { type: mongoose.Schema.Types.Mixed, default: null },
+    is_download_gated: { type: Boolean, default: false },
+    download_conditions: { type: mongoose.Schema.Types.Mixed, default: null },
+    is_stream_follow_gated: { type: Boolean, default: false },
+    is_stream_tip_gated: { type: Boolean, default: false },
+    is_download_follow_gated: { type: Boolean, default: false },
+    has_deal: { type: Boolean, default: false },
   },
   { _id: false }
 ) // _id is set to false because this schema is used as a sub-document

--- a/packages/ddex/publisher/src/models/pendingReleases.ts
+++ b/packages/ddex/publisher/src/models/pendingReleases.ts
@@ -148,13 +148,13 @@ const trackMetadataSchema = new mongoose.Schema({
   cover_art_url: String,
   cover_art_url_hash: String,
   cover_art_url_hash_algo: String,
-  is_stream_gated: { type: Boolean, required: true },
+  is_stream_gated: { type: Boolean, default: false },
   stream_conditions: { type: mongoose.Schema.Types.Mixed, default: null },
-  is_download_gated: { type: Boolean, required: true },
+  is_download_gated: { type: Boolean, default: false },
   download_conditions: { type: mongoose.Schema.Types.Mixed, default: null },
-  is_stream_follow_gated: Boolean,
-  is_stream_tip_gated: Boolean,
-  is_download_follow_gated: Boolean,
+  is_stream_follow_gated: { type: Boolean, default: false },
+  is_stream_tip_gated: { type: Boolean, default: false },
+  is_download_follow_gated: { type: Boolean, default: false },
 })
 
 export type TrackMetadata = mongoose.InferSchemaType<typeof trackMetadataSchema>
@@ -271,6 +271,7 @@ const parsedReleaseElementSchema = new mongoose.Schema(
     },
     release_ids: releaseIDsSchema,
     release_date: { type: Date, required: true },
+    validity_start_date: { type: Date, required: true },
     resources: releaseResourcesSchema,
     artist_id: { type: String, required: true },
     artist_name: { type: String, required: true },

--- a/packages/ddex/publisher/src/services/publisherService.ts
+++ b/packages/ddex/publisher/src/services/publisherService.ts
@@ -217,7 +217,7 @@ export const publishReleases = async (
             },
           },
         },
-      ]).toArray()
+      ])
     } catch (error) {
       console.error('Failed to fetch pending releases:', error)
       await new Promise((resolve) => setTimeout(resolve, 10_000))


### PR DESCRIPTION
### Description
Parse and persist release date (from the release details) and validity start date (from the corr. deal) separately. Poll for `max(release_date, validity_start_date) >= current_date` in the publisher. If no `<ReleaseDate>` or `<GlobalOriginalReleaseDate>` is provided, `release_date` gets set to the validity start date, which is required. The `release_date` is what gets displayed in the UI.

### How Has This Been Tested?
e2e tests, upload an xml locally