### PR TITLE
Make another ddex delivery work (different URL)

### DIFF
--- a/packages/common/src/schemas/upload/uploadFormSchema.ts
+++ b/packages/common/src/schemas/upload/uploadFormSchema.ts
@@ -73,7 +73,7 @@ const DDEXResourceContributor = z
   .object({
     name: z.string(),
     roles: z.array(z.string()),
-    sequence_number: z.number().positive()
+    sequence_number: z.optional(z.number())
   })
   .strict()
 

--- a/packages/ddex/ingester/parser/ern38x.go
+++ b/packages/ddex/ingester/parser/ern38x.go
@@ -319,6 +319,13 @@ func buildAlbumMetadata(release *common.Release, mainRelease *common.ParsedRelea
 		return
 	}
 
+	// Use mainRelease's genre for all tracks if a track is missing a genre
+	for i := range tracks {
+		if tracks[i].Genre == "" {
+			tracks[i].Genre = mainRelease.Genre
+		}
+	}
+
 	// Album is required to have a cover art image
 	if mainRelease.Resources.Images == nil || len(mainRelease.Resources.Images) == 0 || mainRelease.Resources.Images[0].URL == "" {
 		*errs = append(*errs, fmt.Errorf("missing cover art image for release %s", mainRelease.ReleaseRef))

--- a/packages/ddex/ingester/parser/parser.go
+++ b/packages/ddex/ingester/parser/parser.go
@@ -354,6 +354,13 @@ func (p *Parser) parseBatch(batch *common.UnprocessedBatch, deliveryRemotePath s
 
 		// Validate the URL without the prefix "/"
 		releaseURL := strings.TrimPrefix(safeInnerText(messageInBatch.SelectElement("URL")), "/")
+
+		// Special case for Fuga deliveries with a different URL format
+		if strings.Contains(releaseURL, "ddex-prod-fuga-raw") {
+			releaseURL = strings.SplitAfter(releaseURL, "ddex-prod-fuga-raw//")[1]
+			releaseURL = fmt.Sprintf("%s/%s", strings.Split(targetRelease.XmlFilePath, "/")[0], releaseURL)
+		}
+
 		if releaseURL != targetRelease.XmlFilePath {
 			err := fmt.Errorf("URL '%s' does not match expected value: '%s'", releaseURL, targetRelease.XmlFilePath)
 			batch.ValidationErrors = append(batch.ValidationErrors, err.Error())

--- a/packages/ddex/publisher/src/models/publishedReleases.ts
+++ b/packages/ddex/publisher/src/models/publishedReleases.ts
@@ -1,5 +1,4 @@
 import mongoose from 'mongoose'
-import { releaseSchema } from './pendingReleases'
 
 // DDEX releases that have been published
 const publishedReleasesSchema = new mongoose.Schema({
@@ -8,7 +7,7 @@ const publishedReleasesSchema = new mongoose.Schema({
   entity_id: String,
   blockhash: String,
   blocknumber: Number,
-  release: releaseSchema,
+  release: { type: mongoose.Schema.Types.Mixed, default: null },
   created_at: Date,
 })
 

--- a/packages/libs/src/sdk/types/DDEX.ts
+++ b/packages/libs/src/sdk/types/DDEX.ts
@@ -4,7 +4,7 @@ export const DDEXResourceContributor = z
   .object({
     name: z.string(),
     roles: z.array(z.string()),
-    sequence_number: z.number().positive()
+    sequence_number: z.optional(z.number())
   })
   .strict()
 


### PR DESCRIPTION
### Description
Supports another DDEX example's quirks:
- Different URL format in the batch XML file
- Missing sequence numbers for resource contributor XML elements
- Missing genre on tracks in album

### How Has This Been Tested?
I ran DDEX locally to get a delivery uploaded to staging.