### PR TITLE
[ONC-74] Fix social account association

### DIFF
--- a/packages/common/src/services/audius-backend/AudiusBackend.ts
+++ b/packages/common/src/services/audius-backend/AudiusBackend.ts
@@ -1719,11 +1719,17 @@ export const audiusBackend = ({
   async function associateTwitterAccount(
     twitterId: string,
     userId: ID,
-    handle: string
+    handle: string,
+    blockNumber: number
   ) {
     await waitForLibsInit()
     try {
-      await audiusLibs.Account.associateTwitterUser(twitterId, userId, handle)
+      await audiusLibs.Account.associateTwitterUser(
+        twitterId,
+        userId,
+        handle,
+        blockNumber
+      )
       return { success: true }
     } catch (error) {
       console.error(getErrorMessage(error))
@@ -1734,14 +1740,16 @@ export const audiusBackend = ({
   async function associateInstagramAccount(
     instagramId: string,
     userId: ID,
-    handle: string
+    handle: string,
+    blockNumber: number
   ) {
     await waitForLibsInit()
     try {
       await audiusLibs.Account.associateInstagramUser(
         instagramId,
         userId,
-        handle
+        handle,
+        blockNumber
       )
       return { success: true }
     } catch (error) {
@@ -1753,11 +1761,17 @@ export const audiusBackend = ({
   async function associateTikTokAccount(
     tikTokId: string,
     userId: ID,
-    handle: string
+    handle: string,
+    blockNumber: number
   ) {
     await waitForLibsInit()
     try {
-      await audiusLibs.Account.associateTikTokUser(tikTokId, userId, handle)
+      await audiusLibs.Account.associateTikTokUser(
+        tikTokId,
+        userId,
+        handle,
+        blockNumber
+      )
       return { success: true }
     } catch (error) {
       console.error(getErrorMessage(error))

--- a/packages/identity-service/src/routes/instagram.js
+++ b/packages/identity-service/src/routes/instagram.js
@@ -111,7 +111,7 @@ module.exports = function (app) {
     '/instagram/associate',
     handleResponse(async (req, res, next) => {
       const { uuid, userId, handle, blockNumber } = req.body
-      req.connection.setTimeout(10 * 1000)
+      req.connection.setTimeout(60 * 1000)
       const audiusLibsInstance = req.app.get('audiusLibs')
       try {
         const instagramObj = await models.InstagramUser.findOne({

--- a/packages/identity-service/src/routes/instagram.js
+++ b/packages/identity-service/src/routes/instagram.js
@@ -3,6 +3,7 @@ const retry = require('async-retry')
 const config = require('../config.js')
 const models = require('../models')
 const txRelay = require('../relay/txRelay')
+const { waitForUser } = require('../utils/waitForUser')
 
 const {
   handleResponse,
@@ -109,14 +110,19 @@ module.exports = function (app) {
   app.post(
     '/instagram/associate',
     handleResponse(async (req, res, next) => {
-      const { uuid, userId, handle } = req.body
+      const { uuid, userId, handle, blockNumber } = req.body
+      req.connection.setTimeout(10 * 1000)
       const audiusLibsInstance = req.app.get('audiusLibs')
       try {
         const instagramObj = await models.InstagramUser.findOne({
           where: { uuid }
         })
-        const user = await models.User.findOne({
-          where: { handle }
+        const user = await waitForUser({
+          userId,
+          handle,
+          blockNumber,
+          audiusLibsInstance,
+          logger: req.logger
         })
 
         const isUnassociated = instagramObj && !instagramObj.blockchainUserId
@@ -185,7 +191,7 @@ module.exports = function (app) {
           )
         }
       } catch (err) {
-        return errorResponseBadRequest(err)
+        return errorResponseBadRequest(err instanceof Error ? err.message : err)
       }
     })
   )

--- a/packages/identity-service/src/routes/tiktok.js
+++ b/packages/identity-service/src/routes/tiktok.js
@@ -149,7 +149,7 @@ module.exports = function (app) {
     '/tiktok/associate',
     handleResponse(async (req, res, next) => {
       const { uuid, userId, handle, blockNumber } = req.body
-      req.connection.setTimeout(10 * 1000)
+      req.connection.setTimeout(60 * 1000)
       const audiusLibsInstance = req.app.get('audiusLibs')
 
       try {

--- a/packages/identity-service/src/routes/tiktok.js
+++ b/packages/identity-service/src/routes/tiktok.js
@@ -4,6 +4,7 @@ const models = require('../models')
 const config = require('../config.js')
 const txRelay = require('../relay/txRelay')
 const querystring = require('querystring')
+const { waitForUser } = require('../utils/waitForUser')
 
 const {
   handleResponse,
@@ -147,16 +148,20 @@ module.exports = function (app) {
   app.post(
     '/tiktok/associate',
     handleResponse(async (req, res, next) => {
-      const { uuid, userId, handle } = req.body
+      const { uuid, userId, handle, blockNumber } = req.body
+      req.connection.setTimeout(10 * 1000)
       const audiusLibsInstance = req.app.get('audiusLibs')
 
       try {
         const tikTokObj = await models.TikTokUser.findOne({
           where: { uuid: uuid }
         })
-
-        const user = await models.User.findOne({
-          where: { handle }
+        const user = await waitForUser({
+          userId,
+          handle,
+          blockNumber,
+          audiusLibsInstance,
+          logger: req.logger
         })
 
         const isUnassociated = tikTokObj && !tikTokObj.blockchainUserId

--- a/packages/identity-service/src/routes/twitter.js
+++ b/packages/identity-service/src/routes/twitter.js
@@ -145,7 +145,7 @@ module.exports = function (app) {
     '/twitter/associate',
     handleResponse(async (req, res, next) => {
       const { uuid, userId, handle, blockNumber } = req.body
-      req.connection.setTimeout(10 * 1000)
+      req.connection.setTimeout(60 * 1000)
       const audiusLibsInstance = req.app.get('audiusLibs')
 
       try {

--- a/packages/identity-service/src/routes/twitter.js
+++ b/packages/identity-service/src/routes/twitter.js
@@ -4,6 +4,7 @@ const config = require('../config.js')
 const models = require('../models')
 const uuidv4 = require('uuid/v4')
 const txRelay = require('../relay/txRelay')
+const { waitForUser } = require('../utils/waitForUser')
 
 const {
   handleResponse,
@@ -143,15 +144,20 @@ module.exports = function (app) {
   app.post(
     '/twitter/associate',
     handleResponse(async (req, res, next) => {
-      const { uuid, userId, handle } = req.body
+      const { uuid, userId, handle, blockNumber } = req.body
+      req.connection.setTimeout(10 * 1000)
       const audiusLibsInstance = req.app.get('audiusLibs')
 
       try {
         const twitterObj = await models.TwitterUser.findOne({
           where: { uuid: uuid }
         })
-        const user = await models.User.findOne({
-          where: { handle }
+        const user = await waitForUser({
+          userId,
+          handle,
+          blockNumber,
+          audiusLibsInstance,
+          logger: req.logger
         })
 
         // only set blockchainUserId if not already set

--- a/packages/identity-service/src/utils/waitForUser.js
+++ b/packages/identity-service/src/utils/waitForUser.js
@@ -3,42 +3,47 @@ const RETRY_TIMEOUT_MS = 45 * 1000
 /** How long to wait between retries */
 const RETRY_DELAY_MS = 1000
 
-export const waitForUser = async ({
-  userId,
-  handle,
-  blockNumber: blocknumber,
-  audiusLibsInstance,
-  logger
-}) => {
-  let retryCount = 0
-  while (retryCount < RETRY_TIMEOUT_MS / RETRY_DELAY_MS) {
-    try {
-      logger.info({ userId, handle, blocknumber }, 'req')
-      const u = await audiusLibsInstance.discoveryProvider._makeRequest(
-        {
-          endpoint: 'users',
-          queryParams: { id: userId }
-        },
-        true,
-        0,
-        true,
-        blocknumber
-      )
-      if (!u || !u[0]) {
-        throw new Error('User not found')
-      }
-      return u[0]
-    } catch (e) {
-      if (e instanceof Error && e.message.startsWith('Requested blocknumber')) {
-        logger.warn(
-          { blocknumber, handle, userId, retryCount },
-          'Block number not passed... waiting...'
+module.exports = {
+  waitForUser: async ({
+    userId,
+    handle,
+    blockNumber: blocknumber,
+    audiusLibsInstance,
+    logger
+  }) => {
+    let retryCount = 0
+    while (retryCount < RETRY_TIMEOUT_MS / RETRY_DELAY_MS) {
+      try {
+        logger.info({ userId, handle, blocknumber }, 'req')
+        const u = await audiusLibsInstance.discoveryProvider._makeRequest(
+          {
+            endpoint: 'users',
+            queryParams: { id: userId }
+          },
+          true,
+          0,
+          true,
+          blocknumber
         )
-        await new Promise((resolve) => setTimeout(resolve, RETRY_DELAY_MS))
-        retryCount++
-        continue
+        if (!u || !u[0]) {
+          throw new Error('User not found')
+        }
+        return u[0]
+      } catch (e) {
+        if (
+          e instanceof Error &&
+          e.message.startsWith('Requested blocknumber')
+        ) {
+          logger.warn(
+            { blocknumber, handle, userId, retryCount },
+            'Block number not passed... waiting...'
+          )
+          await new Promise((resolve) => setTimeout(resolve, RETRY_DELAY_MS))
+          retryCount++
+          continue
+        }
+        throw e
       }
-      throw e
     }
   }
 }

--- a/packages/identity-service/src/utils/waitForUser.js
+++ b/packages/identity-service/src/utils/waitForUser.js
@@ -1,6 +1,3 @@
-import type { AudiusLibs } from '@audius/sdk'
-import type Logger from 'bunyan'
-
 /** How long to attempt to retry for (roughly) */
 const RETRY_TIMEOUT_MS = 45 * 1000
 /** How long to wait between retries */
@@ -12,22 +9,12 @@ export const waitForUser = async ({
   blockNumber: blocknumber,
   audiusLibsInstance,
   logger
-}: {
-  userId: number
-  handle: string
-  blockNumber: number
-  audiusLibsInstance: AudiusLibs
-  logger: Logger
 }) => {
   let retryCount = 0
   while (retryCount < RETRY_TIMEOUT_MS / RETRY_DELAY_MS) {
     try {
       logger.info({ userId, handle, blocknumber }, 'req')
-      const u = await audiusLibsInstance.discoveryProvider!._makeRequest<
-        {
-          handle: string
-        }[]
-      >(
+      const u = await audiusLibsInstance.discoveryProvider._makeRequest(
         {
           endpoint: 'users',
           queryParams: { id: userId }

--- a/packages/identity-service/src/utils/waitForUser.ts
+++ b/packages/identity-service/src/utils/waitForUser.ts
@@ -1,0 +1,52 @@
+import type { AudiusLibs } from '@audius/sdk'
+import type Logger from 'bunyan'
+
+export const waitForUser = async ({
+  userId,
+  handle,
+  blockNumber: blocknumber,
+  audiusLibsInstance,
+  logger
+}: {
+  userId: number
+  handle: string
+  blockNumber: number
+  audiusLibsInstance: AudiusLibs
+  logger: Logger
+}) => {
+  let retryCount = 0
+  while (retryCount < 10) {
+    try {
+      logger.info({ userId, handle, blocknumber }, 'req')
+      const u = await audiusLibsInstance.discoveryProvider!._makeRequest<
+        {
+          handle: string
+        }[]
+      >(
+        {
+          endpoint: 'users',
+          queryParams: { id: userId }
+        },
+        true,
+        0,
+        true,
+        blocknumber
+      )
+      if (!u || !u[0]) {
+        throw new Error('User not found')
+      }
+      return u[0]
+    } catch (e) {
+      if (e instanceof Error && e.message.startsWith('Requested blocknumber')) {
+        logger.warn(
+          { blocknumber, handle, userId, retryCount },
+          'Block number not passed... waiting...'
+        )
+        await new Promise((resolve) => setTimeout(resolve, 500))
+        retryCount++
+        continue
+      }
+      throw e
+    }
+  }
+}

--- a/packages/identity-service/src/utils/waitForUser.ts
+++ b/packages/identity-service/src/utils/waitForUser.ts
@@ -1,6 +1,11 @@
 import type { AudiusLibs } from '@audius/sdk'
 import type Logger from 'bunyan'
 
+/** How long to attempt to retry for (roughly) */
+const RETRY_TIMEOUT_MS = 45 * 1000
+/** How long to wait between retries */
+const RETRY_DELAY_MS = 1000
+
 export const waitForUser = async ({
   userId,
   handle,
@@ -15,7 +20,7 @@ export const waitForUser = async ({
   logger: Logger
 }) => {
   let retryCount = 0
-  while (retryCount < 10) {
+  while (retryCount < RETRY_TIMEOUT_MS / RETRY_DELAY_MS) {
     try {
       logger.info({ userId, handle, blocknumber }, 'req')
       const u = await audiusLibsInstance.discoveryProvider!._makeRequest<
@@ -42,7 +47,7 @@ export const waitForUser = async ({
           { blocknumber, handle, userId, retryCount },
           'Block number not passed... waiting...'
         )
-        await new Promise((resolve) => setTimeout(resolve, 500))
+        await new Promise((resolve) => setTimeout(resolve, RETRY_DELAY_MS))
         retryCount++
         continue
       }

--- a/packages/libs/src/api/Account.ts
+++ b/packages/libs/src/api/Account.ts
@@ -273,21 +273,37 @@ export class Account extends Base {
    * Associates a user with a twitter uuid.
    * @param uuid from the Twitter API
    */
-  async associateTwitterUser(uuid: string, userId: number, handle: string) {
+  async associateTwitterUser(
+    uuid: string,
+    userId: number,
+    handle: string,
+    blockNumber: number
+  ) {
     this.REQUIRES(Services.IDENTITY_SERVICE)
-    return await this.identityService.associateTwitterUser(uuid, userId, handle)
+    return await this.identityService.associateTwitterUser(
+      uuid,
+      userId,
+      handle,
+      blockNumber
+    )
   }
 
   /**
    * Associates a user with an instagram uuid.
    * @param uuid from the Instagram API
    */
-  async associateInstagramUser(uuid: string, userId: number, handle: string) {
+  async associateInstagramUser(
+    uuid: string,
+    userId: number,
+    handle: string,
+    blockNumber: number
+  ) {
     this.REQUIRES(Services.IDENTITY_SERVICE)
     return await this.identityService.associateInstagramUser(
       uuid,
       userId,
-      handle
+      handle,
+      blockNumber
     )
   }
 
@@ -295,9 +311,19 @@ export class Account extends Base {
    * Associates a user with an tiktok uuid
    * @param uuid from the TikTok API
    */
-  async associateTikTokUser(uuid: string, userId: number, handle: string) {
+  async associateTikTokUser(
+    uuid: string,
+    userId: number,
+    handle: string,
+    blockNumber: number
+  ) {
     this.REQUIRES(Services.IDENTITY_SERVICE)
-    return await this.identityService.associateTikTokUser(uuid, userId, handle)
+    return await this.identityService.associateTikTokUser(
+      uuid,
+      userId,
+      handle,
+      blockNumber
+    )
   }
 
   /**

--- a/packages/libs/src/services/identity/IdentityService.ts
+++ b/packages/libs/src/services/identity/IdentityService.ts
@@ -224,14 +224,20 @@ export class IdentityService {
    * @param userId
    * @param handle User handle
    */
-  async associateTwitterUser(uuid: string, userId: number, handle: string) {
+  async associateTwitterUser(
+    uuid: string,
+    userId: number,
+    handle: string,
+    blockNumber: number
+  ) {
     return await this._makeRequest({
       url: '/twitter/associate',
       method: 'post',
       data: {
         uuid,
         userId,
-        handle
+        handle,
+        blockNumber
       }
     })
   }
@@ -242,14 +248,20 @@ export class IdentityService {
    * @param userId
    * @param handle
    */
-  async associateInstagramUser(uuid: string, userId: number, handle: string) {
+  async associateInstagramUser(
+    uuid: string,
+    userId: number,
+    handle: string,
+    blockNumber: number
+  ) {
     return await this._makeRequest({
       url: '/instagram/associate',
       method: 'post',
       data: {
         uuid,
         userId,
-        handle
+        handle,
+        blockNumber
       }
     })
   }
@@ -260,14 +272,20 @@ export class IdentityService {
    * @param userId
    * @param handle
    */
-  async associateTikTokUser(uuid: string, userId: number, handle: string) {
+  async associateTikTokUser(
+    uuid: string,
+    userId: number,
+    handle: string,
+    blockNumber: number
+  ) {
     return await this._makeRequest({
       url: '/tiktok/associate',
       method: 'post',
       data: {
         uuid,
         userId,
-        handle
+        handle,
+        blockNumber
       }
     })
   }

--- a/packages/web/src/common/store/pages/signon/sagas.ts
+++ b/packages/web/src/common/store/pages/signon/sagas.ts
@@ -535,7 +535,8 @@ function* signUp() {
             audiusBackendInstance.associateTwitterAccount,
             signOn.twitterId,
             userId,
-            handle
+            handle,
+            blockNumber
           )
           if (error) {
             reportToSentry({
@@ -550,7 +551,8 @@ function* signUp() {
             audiusBackendInstance.associateInstagramAccount,
             signOn.instagramId,
             userId,
-            handle
+            handle,
+            blockNumber
           )
           if (error) {
             reportToSentry({
@@ -566,7 +568,8 @@ function* signUp() {
             audiusBackendInstance.associateTikTokAccount,
             signOn.tikTokId,
             userId,
-            handle
+            handle,
+            blockNumber
           )
           if (error) {
             reportToSentry({


### PR DESCRIPTION
### Description

Request users from DN instead of from the Identity db, since the Identity db won't have handles at the time of association request and these endpoints aren't hitting the auth middleware which would populate it. Continuously request until the blocknumber is hit.

### How Has This Been Tested?

Tested the instagram endpoint waits until blocknumber is passed. Didn't test the rest...