### PR TITLE
PROTO-1755: purge celery messages on startup

### DIFF
--- a/packages/discovery-provider/src/app.py
+++ b/packages/discovery-provider/src/app.py
@@ -291,10 +291,6 @@ def configure_celery(celery, test_config=None):
             if "url_read_replica" in test_config["db"]:
                 database_url_read_replica = test_config["db"]["url_read_replica"]
 
-    # Clear out old celery tasks on app startup
-    # Initialize with beat or initial message
-    celery.control.purge()
-
     # Update celery configuration
     celery.conf.update(
         imports=[
@@ -523,6 +519,10 @@ def configure_celery(celery, test_config=None):
     celery.Task = WrappedDatabaseTask
 
     celery.finalize()
+
+    # Clear out old celery tasks on app startup
+    # Initialize with beat or initial message
+    celery.control.purge()
 
     # Start tasks that should fire upon startup
     celery.send_task("cache_current_nodes")

--- a/packages/discovery-provider/src/app.py
+++ b/packages/discovery-provider/src/app.py
@@ -291,6 +291,10 @@ def configure_celery(celery, test_config=None):
             if "url_read_replica" in test_config["db"]:
                 database_url_read_replica = test_config["db"]["url_read_replica"]
 
+    # Clear out old celery tasks on app startup
+    # Initialize with beat or initial message
+    celery.control.purge()
+
     # Update celery configuration
     celery.conf.update(
         imports=[


### PR DESCRIPTION
### Description
We are still seeing a backlog of celery messages on some nodes. Since we're not distributing celery in the way it normally would be used purging the queue and letting beats + self queued tasks startup cleanly is probably all we need to keep these under control for now. With at least daily releases this will make sure tasks don't build up longer than 24 hours and then on a new deploy they'll start up as normal.

### How Has This Been Tested?
This ran with the initial celery concurrency change so all tasks do correctly start back up.
