### PR TITLE
Don't allow creating developer app with user wallet as address [C-4041

### DIFF
--- a/packages/discovery-provider/integration_tests/tasks/entity_manager/test_developer_app_entity_manager.py
+++ b/packages/discovery-provider/integration_tests/tasks/entity_manager/test_developer_app_entity_manager.py
@@ -166,7 +166,9 @@ def test_index_app(app, mocker):
         "users": [
             {"user_id": user_id, "wallet": f"user{user_id}wallet"}
             for user_id in range(1, 6)
-        ],
+            # Private key: fcacb6c31a5b6bfd506a277ea34efcc44465476457385220fc252d7e58d6f2e7
+        ]
+        + [{"user_id": 99, "wallet": "0xE2975eF7594353238Cc68ECCf5d444c47BC17058"}],
         "developer_apps": [
             {
                 "user_id": 5,
@@ -371,6 +373,21 @@ def test_index_app(app, mocker):
                         "_userId": 2,
                         "_action": Action.CREATE,
                         "_metadata": '{"app_signature": {"signature": "949b7bad5ba5a1bc1e28212673e2d2786d7b85561eca8f0b9d962ffd42393dd041cf2c6b11418a97fd4f2b9a7fbaab26308795bb872ab9a39d1b4cb94935931e1c", "message": "Creating Audius developer app at 1686252026"}, "name": "My really long app name this is really long we will rock you"}',
+                        "_signer": "user2wallet",
+                    }
+                )
+            },
+        ],
+        "CreateAppInvalidTx12": [
+            {
+                # Address is a user's wallet
+                "args": AttributeDict(
+                    {
+                        "_entityId": 0,
+                        "_entityType": EntityType.DEVELOPER_APP,
+                        "_userId": 2,
+                        "_action": Action.CREATE,
+                        "_metadata": '{"app_signature": {"signature": "20e5b1d95cc5d942571a097b5d7cb30cfcf355bbb5a51df498914dc42f4472d53c0d5ee9d2d89a00b56d19c912fade6760daa7f4c62437c5251776bd34cc4f3c1c", "message": "Creating Audius developer app at 1686252026"}, "name": "My app name"}',
                         "_signer": "user2wallet",
                     }
                 )

--- a/packages/discovery-provider/src/tasks/entity_manager/entities/developer_app.py
+++ b/packages/discovery-provider/src/tasks/entity_manager/entities/developer_app.py
@@ -118,7 +118,6 @@ def validate_developer_app_tx(params: ManageEntityParameters, metadata):
             f"Programming error while indexing {params.action} Developer App Transaction, user wallet missing"
         )
     validate_signer(params)
-    # TODO (C-4041) - Make sure address is not already a user
     if params.action == Action.DELETE:
         if not address:
             raise IndexingValidationError(
@@ -172,6 +171,10 @@ def validate_developer_app_tx(params: ManageEntityParameters, metadata):
         if address in params.existing_records["DeveloperApp"]:
             raise IndexingValidationError(
                 f"Invalid Create Developer App Transaction, address {address} already exists"
+            )
+        if address in params.existing_records["UserWallet"]:
+            raise IndexingValidationError(
+                "Invalid Create Developer App Transaction, address cannot be a user's wallet"
             )
         if metadata["is_personal_access"] != None and not isinstance(
             metadata["is_personal_access"], bool

--- a/packages/discovery-provider/src/tasks/entity_manager/entity_manager.py
+++ b/packages/discovery-provider/src/tasks/entity_manager/entity_manager.py
@@ -520,11 +520,16 @@ def collect_entities_to_fetch(update_task, entity_manager_txs):
                     entities_to_fetch[EntityType.DEVELOPER_APP].add(raw_address.lower())
                 else:
                     try:
-                        entities_to_fetch[EntityType.DEVELOPER_APP].add(
-                            get_address_from_signature(
-                                json_metadata.get("app_signature", {})
-                            )
+                        address_from_signature = get_address_from_signature(
+                            json_metadata.get("app_signature", {})
                         )
+                        entities_to_fetch[EntityType.DEVELOPER_APP].add(
+                            address_from_signature
+                        )
+                        if action == Action.CREATE:
+                            entities_to_fetch[EntityType.USER_WALLET].add(
+                                address_from_signature
+                            )
                     except:
                         logger.error(
                             "tasks | entity_manager.py | Missing address or valid app signature in metadata required for add developer app tx"


### PR DESCRIPTION
### Description
Avoid unwanted behaviors by disallowing creating a developer app if the address belongs to a user (i.e. matches a user's erc wallet)

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._
