### PR TITLE
[ONC-76] Exclude backgroundColor from forwardedProps for Box

### DIFF
--- a/packages/mobile/src/harmony-native/components/layout/Box/Box.tsx
+++ b/packages/mobile/src/harmony-native/components/layout/Box/Box.tsx
@@ -20,6 +20,7 @@ const invalidProps = [
   'ml',
   'mr',
   'mb',
+  'backgroundColor',
   'border',
   'borderTop',
   'borderRight',


### PR DESCRIPTION
### Description
This fixes an issue where components using `Paper` on mobile don't correctly apply background colors on iOS. I think the underlying issue here might be a bug with RN, but I couldn't find any in their repo.
The way this works is:
* `Paper` renders a styled `Flex`, passing `white` as the `backgroundColor`
* `Flex` renders a styled `Box`, passing the `backgroundColor` prop through
* `Box` checks the passed value against `theme.colors.background` to see if it's a valid background color and maps it accordingly.
* `Box` renders a `View` and passes all "valid" props through, based on a filter list.

Since `backgroundColor` is not in the filter list for `Box`, it ends up being passed down to `View`. We then pass a `style` object which _should_ override the `backgroundColor` value. For some reason, on iOS that override is not being applied.

Solution for now is to also add the `backgroundColor` prop to the exclusion list and let the underlying View component rely on the value passed through `style`. It's meant to be an index into a short list of allowed values anyway. So it's not a valid "generic" attribute.

fixes ONC-76
 
### How Has This Been Tested?
Tested on iOS and Android Simulator
