### PR TITLE
Upgrade sentry to fix iOS build errors

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23172,6 +23172,122 @@
         "node": "6.* || 8.* || >=10.*"
       }
     },
+    "node_modules/@sentry-internal/feedback": {
+      "version": "7.100.1",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/feedback/-/feedback-7.100.1.tgz",
+      "integrity": "sha512-yqcRVnjf+qS+tC4NxOKLJOaSJ+csHmh/dHUzvCTkf5rLsplwXYRnny2r0tqGTQ4tuXMxwgSMKPYwicg81P+xuw==",
+      "dependencies": {
+        "@sentry/core": "7.100.1",
+        "@sentry/types": "7.100.1",
+        "@sentry/utils": "7.100.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@sentry-internal/feedback/node_modules/@sentry/core": {
+      "version": "7.100.1",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-7.100.1.tgz",
+      "integrity": "sha512-f+ItUge/o9AjlveQq0ZUbQauKlPH1FIJbC1TRaYLJ4KNfOdrsh8yZ29RmWv0cFJ/e+FGTr603gWpRPObF5rM8Q==",
+      "dependencies": {
+        "@sentry/types": "7.100.1",
+        "@sentry/utils": "7.100.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@sentry-internal/feedback/node_modules/@sentry/types": {
+      "version": "7.100.1",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.100.1.tgz",
+      "integrity": "sha512-fLM+LedHuKzOd8IhXBqaQuym+AA519MGjeczBa5kGakes/BbAsUMwsNfjsKQedp7Kh44RgYF99jwoRPK2oDrXw==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@sentry-internal/feedback/node_modules/@sentry/utils": {
+      "version": "7.100.1",
+      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-7.100.1.tgz",
+      "integrity": "sha512-Ve6dXr1o6xiBe3VCoJgiutmBKrugryI65EZAbYto5XI+t+PjiLLf9wXtEMF24ZrwImo4Lv3E9Uqza+fWkEbw6A==",
+      "dependencies": {
+        "@sentry/types": "7.100.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@sentry-internal/replay-canvas": {
+      "version": "7.100.1",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/replay-canvas/-/replay-canvas-7.100.1.tgz",
+      "integrity": "sha512-TnqxqJGhbFhhYRhTG2WLFer+lVieV7mNGeIxFBiw1L4kuj8KGl+C0sknssKyZSRVJFSahhHIosHJGRMkkD//7g==",
+      "dependencies": {
+        "@sentry/core": "7.100.1",
+        "@sentry/replay": "7.100.1",
+        "@sentry/types": "7.100.1",
+        "@sentry/utils": "7.100.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@sentry-internal/replay-canvas/node_modules/@sentry-internal/tracing": {
+      "version": "7.100.1",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/tracing/-/tracing-7.100.1.tgz",
+      "integrity": "sha512-+u9RRf5eL3StiyiRyAHZmdkAR7GTSGx4Mt4Lmi5NEtCcWlTGZ1QgW2r8ZbhouVmTiJkjhQgYCyej3cojtazeJg==",
+      "dependencies": {
+        "@sentry/core": "7.100.1",
+        "@sentry/types": "7.100.1",
+        "@sentry/utils": "7.100.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@sentry-internal/replay-canvas/node_modules/@sentry/core": {
+      "version": "7.100.1",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-7.100.1.tgz",
+      "integrity": "sha512-f+ItUge/o9AjlveQq0ZUbQauKlPH1FIJbC1TRaYLJ4KNfOdrsh8yZ29RmWv0cFJ/e+FGTr603gWpRPObF5rM8Q==",
+      "dependencies": {
+        "@sentry/types": "7.100.1",
+        "@sentry/utils": "7.100.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@sentry-internal/replay-canvas/node_modules/@sentry/replay": {
+      "version": "7.100.1",
+      "resolved": "https://registry.npmjs.org/@sentry/replay/-/replay-7.100.1.tgz",
+      "integrity": "sha512-B1NFjzGEFaqejxBRdUyEzH8ChXc2kfiqlA/W/Lg0aoWIl2/7nuMk+l4ld9gW5F5bIAXDTVd5vYltb1lWEbpr7w==",
+      "dependencies": {
+        "@sentry-internal/tracing": "7.100.1",
+        "@sentry/core": "7.100.1",
+        "@sentry/types": "7.100.1",
+        "@sentry/utils": "7.100.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@sentry-internal/replay-canvas/node_modules/@sentry/types": {
+      "version": "7.100.1",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.100.1.tgz",
+      "integrity": "sha512-fLM+LedHuKzOd8IhXBqaQuym+AA519MGjeczBa5kGakes/BbAsUMwsNfjsKQedp7Kh44RgYF99jwoRPK2oDrXw==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@sentry-internal/replay-canvas/node_modules/@sentry/utils": {
+      "version": "7.100.1",
+      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-7.100.1.tgz",
+      "integrity": "sha512-Ve6dXr1o6xiBe3VCoJgiutmBKrugryI65EZAbYto5XI+t+PjiLLf9wXtEMF24ZrwImo4Lv3E9Uqza+fWkEbw6A==",
+      "dependencies": {
+        "@sentry/types": "7.100.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/@sentry-internal/tracing": {
       "version": "7.65.0",
       "license": "MIT",
@@ -23200,75 +23316,100 @@
         "node": ">=8"
       }
     },
-    "node_modules/@sentry/cli": {
-      "version": "2.23.0",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "https-proxy-agent": "^5.0.0",
-        "node-fetch": "^2.6.7",
-        "progress": "^2.0.3",
-        "proxy-from-env": "^1.1.0",
-        "which": "^2.0.2"
-      },
-      "bin": {
-        "sentry-cli": "bin/sentry-cli"
-      },
-      "engines": {
-        "node": ">= 10"
-      },
-      "optionalDependencies": {
-        "@sentry/cli-darwin": "2.23.0",
-        "@sentry/cli-linux-arm": "2.23.0",
-        "@sentry/cli-linux-arm64": "2.23.0",
-        "@sentry/cli-linux-i686": "2.23.0",
-        "@sentry/cli-linux-x64": "2.23.0",
-        "@sentry/cli-win32-i686": "2.23.0",
-        "@sentry/cli-win32-x64": "2.23.0"
-      }
-    },
-    "node_modules/@sentry/cli-darwin": {
-      "version": "2.23.0",
-      "license": "BSD-3-Clause",
+    "node_modules/@sentry/cli-linux-arm": {
+      "version": "2.30.0",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-linux-arm/-/cli-linux-arm-2.30.0.tgz",
+      "integrity": "sha512-MDB3iS31WKg4krCcLo520yxbUERPeA2DCtk9Qs9vSDbQl6Er64dteHllOdx1SDOyX/7GKcxrQEQ6SMmbnOo6wg==",
+      "cpu": [
+        "arm"
+      ],
       "optional": true,
       "os": [
-        "darwin"
+        "linux",
+        "freebsd"
       ],
       "engines": {
         "node": ">=10"
       }
     },
-    "node_modules/@sentry/cli/node_modules/node-fetch": {
-      "version": "2.7.0",
-      "license": "MIT",
-      "dependencies": {
-        "whatwg-url": "^5.0.0"
-      },
+    "node_modules/@sentry/cli-linux-arm64": {
+      "version": "2.30.0",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-linux-arm64/-/cli-linux-arm64-2.30.0.tgz",
+      "integrity": "sha512-JNXPkkMubKoZVlcFIoClSmTb9C/I6Bz08DuAZm2jnjRaaOMiCBxI/l50H3dmfVZ6apjEguG9JkjFdb0kqKB90w==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux",
+        "freebsd"
+      ],
       "engines": {
-        "node": "4.x || >=6.0.0"
-      },
-      "peerDependencies": {
-        "encoding": "^0.1.0"
-      },
-      "peerDependenciesMeta": {
-        "encoding": {
-          "optional": true
-        }
+        "node": ">=10"
       }
     },
-    "node_modules/@sentry/cli/node_modules/tr46": {
-      "version": "0.0.3",
-      "license": "MIT"
+    "node_modules/@sentry/cli-linux-i686": {
+      "version": "2.30.0",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-linux-i686/-/cli-linux-i686-2.30.0.tgz",
+      "integrity": "sha512-WhVVziFQw/fO0Cc53pY8goPAzJtIs6ORTR89fVbKwa3ZDNkX++mEOECbP7RkmD87kuRxyKzN543RPV971PcAHw==",
+      "cpu": [
+        "x86",
+        "ia32"
+      ],
+      "optional": true,
+      "os": [
+        "linux",
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
     },
-    "node_modules/@sentry/cli/node_modules/webidl-conversions": {
-      "version": "3.0.1",
-      "license": "BSD-2-Clause"
+    "node_modules/@sentry/cli-linux-x64": {
+      "version": "2.30.0",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-linux-x64/-/cli-linux-x64-2.30.0.tgz",
+      "integrity": "sha512-QkiVDeSfspotZ0Au5Yauv2DAm/BC1fL9BwPek/WwddM18I2HqnDp6l4TA4bQeEY++o0KEuNF53cPahpepltPjw==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux",
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
     },
-    "node_modules/@sentry/cli/node_modules/whatwg-url": {
-      "version": "5.0.0",
-      "license": "MIT",
-      "dependencies": {
-        "tr46": "~0.0.3",
-        "webidl-conversions": "^3.0.0"
+    "node_modules/@sentry/cli-win32-i686": {
+      "version": "2.30.0",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-win32-i686/-/cli-win32-i686-2.30.0.tgz",
+      "integrity": "sha512-xLY9B1EEGuNYPKpK6M9PMmcu2PzofdvRtbraTcU6Ck2zALS5oXB9kmWc4dDKucZ/uu9JB0m+Lo4ebaNlca45qQ==",
+      "cpu": [
+        "x86",
+        "ia32"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@sentry/cli-win32-x64": {
+      "version": "2.30.0",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-win32-x64/-/cli-win32-x64-2.30.0.tgz",
+      "integrity": "sha512-CiXuxnpJI0zho0XE5PVqIS9CwjDEYoMnHQRIr4Jj9OzlGTJ2iSSU6Zp3Ykd7lgo2iK4P6MfxIBm30gFQPnSvVA==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/@sentry/core": {
@@ -23393,199 +23534,6 @@
       },
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/@sentry/react": {
-      "version": "7.81.1",
-      "license": "MIT",
-      "dependencies": {
-        "@sentry/browser": "7.81.1",
-        "@sentry/types": "7.81.1",
-        "@sentry/utils": "7.81.1",
-        "hoist-non-react-statics": "^3.3.2"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "peerDependencies": {
-        "react": "15.x || 16.x || 17.x || 18.x"
-      }
-    },
-    "node_modules/@sentry/react-native": {
-      "version": "5.15.2",
-      "license": "MIT",
-      "dependencies": {
-        "@sentry/browser": "7.81.1",
-        "@sentry/cli": "2.23.0",
-        "@sentry/core": "7.81.1",
-        "@sentry/hub": "7.81.1",
-        "@sentry/integrations": "7.81.1",
-        "@sentry/react": "7.81.1",
-        "@sentry/types": "7.81.1",
-        "@sentry/utils": "7.81.1"
-      },
-      "peerDependencies": {
-        "react": ">=17.0.0",
-        "react-native": ">=0.65.0"
-      }
-    },
-    "node_modules/@sentry/react-native/node_modules/@sentry-internal/tracing": {
-      "version": "7.81.1",
-      "license": "MIT",
-      "dependencies": {
-        "@sentry/core": "7.81.1",
-        "@sentry/types": "7.81.1",
-        "@sentry/utils": "7.81.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@sentry/react-native/node_modules/@sentry/browser": {
-      "version": "7.81.1",
-      "license": "MIT",
-      "dependencies": {
-        "@sentry-internal/tracing": "7.81.1",
-        "@sentry/core": "7.81.1",
-        "@sentry/replay": "7.81.1",
-        "@sentry/types": "7.81.1",
-        "@sentry/utils": "7.81.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@sentry/react-native/node_modules/@sentry/core": {
-      "version": "7.81.1",
-      "license": "MIT",
-      "dependencies": {
-        "@sentry/types": "7.81.1",
-        "@sentry/utils": "7.81.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@sentry/react-native/node_modules/@sentry/hub": {
-      "version": "7.81.1",
-      "license": "MIT",
-      "dependencies": {
-        "@sentry/core": "7.81.1",
-        "@sentry/types": "7.81.1",
-        "@sentry/utils": "7.81.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@sentry/react-native/node_modules/@sentry/integrations": {
-      "version": "7.81.1",
-      "license": "MIT",
-      "dependencies": {
-        "@sentry/core": "7.81.1",
-        "@sentry/types": "7.81.1",
-        "@sentry/utils": "7.81.1",
-        "localforage": "^1.8.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@sentry/react-native/node_modules/@sentry/replay": {
-      "version": "7.81.1",
-      "license": "MIT",
-      "dependencies": {
-        "@sentry-internal/tracing": "7.81.1",
-        "@sentry/core": "7.81.1",
-        "@sentry/types": "7.81.1",
-        "@sentry/utils": "7.81.1"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@sentry/react-native/node_modules/@sentry/types": {
-      "version": "7.81.1",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@sentry/react-native/node_modules/@sentry/utils": {
-      "version": "7.81.1",
-      "license": "MIT",
-      "dependencies": {
-        "@sentry/types": "7.81.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@sentry/react/node_modules/@sentry-internal/tracing": {
-      "version": "7.81.1",
-      "license": "MIT",
-      "dependencies": {
-        "@sentry/core": "7.81.1",
-        "@sentry/types": "7.81.1",
-        "@sentry/utils": "7.81.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@sentry/react/node_modules/@sentry/browser": {
-      "version": "7.81.1",
-      "license": "MIT",
-      "dependencies": {
-        "@sentry-internal/tracing": "7.81.1",
-        "@sentry/core": "7.81.1",
-        "@sentry/replay": "7.81.1",
-        "@sentry/types": "7.81.1",
-        "@sentry/utils": "7.81.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@sentry/react/node_modules/@sentry/core": {
-      "version": "7.81.1",
-      "license": "MIT",
-      "dependencies": {
-        "@sentry/types": "7.81.1",
-        "@sentry/utils": "7.81.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@sentry/react/node_modules/@sentry/replay": {
-      "version": "7.81.1",
-      "license": "MIT",
-      "dependencies": {
-        "@sentry-internal/tracing": "7.81.1",
-        "@sentry/core": "7.81.1",
-        "@sentry/types": "7.81.1",
-        "@sentry/utils": "7.81.1"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@sentry/react/node_modules/@sentry/types": {
-      "version": "7.81.1",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@sentry/react/node_modules/@sentry/utils": {
-      "version": "7.81.1",
-      "license": "MIT",
-      "dependencies": {
-        "@sentry/types": "7.81.1"
-      },
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/@sentry/replay": {
@@ -137119,7 +137067,7 @@
         "@redux-devtools/remote": "0.8.0",
         "@reduxjs/toolkit": "1.6.1",
         "@sayem314/react-native-keep-awake": "1.2.2",
-        "@sentry/react-native": "5.15.2",
+        "@sentry/react-native": "5.19.3",
         "@snapchat/snap-kit-react-native": "0.4.0",
         "@solana-mobile/mobile-wallet-adapter-protocol": "0.9.9",
         "@solana-mobile/mobile-wallet-adapter-protocol-web3js": "0.9.9",
@@ -137865,6 +137813,194 @@
       "funding": {
         "type": "individual",
         "url": "https://github.com/sponsors/sayem314"
+      }
+    },
+    "packages/mobile/node_modules/@sentry-internal/tracing": {
+      "version": "7.100.1",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/tracing/-/tracing-7.100.1.tgz",
+      "integrity": "sha512-+u9RRf5eL3StiyiRyAHZmdkAR7GTSGx4Mt4Lmi5NEtCcWlTGZ1QgW2r8ZbhouVmTiJkjhQgYCyej3cojtazeJg==",
+      "dependencies": {
+        "@sentry/core": "7.100.1",
+        "@sentry/types": "7.100.1",
+        "@sentry/utils": "7.100.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "packages/mobile/node_modules/@sentry/browser": {
+      "version": "7.100.1",
+      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-7.100.1.tgz",
+      "integrity": "sha512-IxHQ08ixf0bmaWpe4yt1J4UUsOpg02fxax9z3tOQYXw5MSzz5pDXn8M8DFUVJB3wWuyXhHXTub9yD3VIP9fnoA==",
+      "dependencies": {
+        "@sentry-internal/feedback": "7.100.1",
+        "@sentry-internal/replay-canvas": "7.100.1",
+        "@sentry-internal/tracing": "7.100.1",
+        "@sentry/core": "7.100.1",
+        "@sentry/replay": "7.100.1",
+        "@sentry/types": "7.100.1",
+        "@sentry/utils": "7.100.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "packages/mobile/node_modules/@sentry/cli": {
+      "version": "2.30.0",
+      "resolved": "https://registry.npmjs.org/@sentry/cli/-/cli-2.30.0.tgz",
+      "integrity": "sha512-GTO5e98vy2QwEYQvhE/ZtGUiVrUu4XungLioJbazm+ZOen8cyac8YOapZfozN5mtxjWOWMOwhOqoTeCU3Q8YKQ==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "https-proxy-agent": "^5.0.0",
+        "node-fetch": "^2.6.7",
+        "progress": "^2.0.3",
+        "proxy-from-env": "^1.1.0",
+        "which": "^2.0.2"
+      },
+      "bin": {
+        "sentry-cli": "bin/sentry-cli"
+      },
+      "engines": {
+        "node": ">= 10"
+      },
+      "optionalDependencies": {
+        "@sentry/cli-darwin": "2.30.0",
+        "@sentry/cli-linux-arm": "2.30.0",
+        "@sentry/cli-linux-arm64": "2.30.0",
+        "@sentry/cli-linux-i686": "2.30.0",
+        "@sentry/cli-linux-x64": "2.30.0",
+        "@sentry/cli-win32-i686": "2.30.0",
+        "@sentry/cli-win32-x64": "2.30.0"
+      }
+    },
+    "packages/mobile/node_modules/@sentry/cli-darwin": {
+      "version": "2.30.0",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-darwin/-/cli-darwin-2.30.0.tgz",
+      "integrity": "sha512-JVesQ9PznbHBOOOwuej2X8/onfXdmAEjBH6fTyWxBl6K8mB4KmBX/aHunXWMBX+VR9X32XZghIqj7acwaFUMPA==",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "packages/mobile/node_modules/@sentry/core": {
+      "version": "7.100.1",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-7.100.1.tgz",
+      "integrity": "sha512-f+ItUge/o9AjlveQq0ZUbQauKlPH1FIJbC1TRaYLJ4KNfOdrsh8yZ29RmWv0cFJ/e+FGTr603gWpRPObF5rM8Q==",
+      "dependencies": {
+        "@sentry/types": "7.100.1",
+        "@sentry/utils": "7.100.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "packages/mobile/node_modules/@sentry/hub": {
+      "version": "7.100.1",
+      "resolved": "https://registry.npmjs.org/@sentry/hub/-/hub-7.100.1.tgz",
+      "integrity": "sha512-zdt7f1k+5JE5FAunzBZUEFbvK5YP/LekLMeogTonaRObB07J6fJ9FD4mtNk7pV0utrTDwR+n942qmp+LbWauWA==",
+      "dependencies": {
+        "@sentry/core": "7.100.1",
+        "@sentry/types": "7.100.1",
+        "@sentry/utils": "7.100.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "packages/mobile/node_modules/@sentry/integrations": {
+      "version": "7.100.1",
+      "resolved": "https://registry.npmjs.org/@sentry/integrations/-/integrations-7.100.1.tgz",
+      "integrity": "sha512-RUyZHcsN3Plc8G4hJN3BCMdbwS8ljUY3E3iLjzucA4HroBsGk5AMc6n7Pp/QqFIRgxrPjKEgA52Wgy5Nq6dSvw==",
+      "dependencies": {
+        "@sentry/core": "7.100.1",
+        "@sentry/types": "7.100.1",
+        "@sentry/utils": "7.100.1",
+        "localforage": "^1.8.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "packages/mobile/node_modules/@sentry/react": {
+      "version": "7.100.1",
+      "resolved": "https://registry.npmjs.org/@sentry/react/-/react-7.100.1.tgz",
+      "integrity": "sha512-EdrBtrXVLK2LSx4Rvz/nQP7HZUZQmr+t3GHV8436RAhF6vs5mntACVMBoQJRWiUvtZ1iRo3rIsIdah7DLiFPgQ==",
+      "dependencies": {
+        "@sentry/browser": "7.100.1",
+        "@sentry/core": "7.100.1",
+        "@sentry/types": "7.100.1",
+        "@sentry/utils": "7.100.1",
+        "hoist-non-react-statics": "^3.3.2"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "peerDependencies": {
+        "react": "15.x || 16.x || 17.x || 18.x"
+      }
+    },
+    "packages/mobile/node_modules/@sentry/react-native": {
+      "version": "5.19.3",
+      "resolved": "https://registry.npmjs.org/@sentry/react-native/-/react-native-5.19.3.tgz",
+      "integrity": "sha512-DBX+Bs293c1jj4JSC3aC4TFF2COt/5uO+saZQamUNsQlH5zBS7TaVhKnAhmdMd0/ByZ+UPCJFFtUyV6E1xV81w==",
+      "dependencies": {
+        "@sentry/browser": "7.100.1",
+        "@sentry/cli": "2.30.0",
+        "@sentry/core": "7.100.1",
+        "@sentry/hub": "7.100.1",
+        "@sentry/integrations": "7.100.1",
+        "@sentry/react": "7.100.1",
+        "@sentry/types": "7.100.1",
+        "@sentry/utils": "7.100.1"
+      },
+      "bin": {
+        "sentry-expo-upload-sourcemaps": "scripts/expo-upload-sourcemaps.js"
+      },
+      "peerDependencies": {
+        "expo": ">=49.0.0",
+        "react": ">=17.0.0",
+        "react-native": ">=0.65.0"
+      },
+      "peerDependenciesMeta": {
+        "expo": {
+          "optional": true
+        }
+      }
+    },
+    "packages/mobile/node_modules/@sentry/replay": {
+      "version": "7.100.1",
+      "resolved": "https://registry.npmjs.org/@sentry/replay/-/replay-7.100.1.tgz",
+      "integrity": "sha512-B1NFjzGEFaqejxBRdUyEzH8ChXc2kfiqlA/W/Lg0aoWIl2/7nuMk+l4ld9gW5F5bIAXDTVd5vYltb1lWEbpr7w==",
+      "dependencies": {
+        "@sentry-internal/tracing": "7.100.1",
+        "@sentry/core": "7.100.1",
+        "@sentry/types": "7.100.1",
+        "@sentry/utils": "7.100.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "packages/mobile/node_modules/@sentry/types": {
+      "version": "7.100.1",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.100.1.tgz",
+      "integrity": "sha512-fLM+LedHuKzOd8IhXBqaQuym+AA519MGjeczBa5kGakes/BbAsUMwsNfjsKQedp7Kh44RgYF99jwoRPK2oDrXw==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "packages/mobile/node_modules/@sentry/utils": {
+      "version": "7.100.1",
+      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-7.100.1.tgz",
+      "integrity": "sha512-Ve6dXr1o6xiBe3VCoJgiutmBKrugryI65EZAbYto5XI+t+PjiLLf9wXtEMF24ZrwImo4Lv3E9Uqza+fWkEbw6A==",
+      "dependencies": {
+        "@sentry/types": "7.100.1"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "packages/mobile/node_modules/@storybook/addon-actions": {
@@ -138818,6 +138954,25 @@
         "node": ">=10"
       }
     },
+    "packages/mobile/node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
     "packages/mobile/node_modules/path-key": {
       "version": "3.1.1",
       "dev": true,
@@ -139332,6 +139487,11 @@
         "node": ">=8.0"
       }
     },
+    "packages/mobile/node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
+    },
     "packages/mobile/node_modules/tslib": {
       "version": "2.6.2",
       "license": "0BSD"
@@ -139351,6 +139511,20 @@
       "license": "MIT",
       "engines": {
         "node": ">= 10.0.0"
+      }
+    },
+    "packages/mobile/node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
+    },
+    "packages/mobile/node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
       }
     },
     "packages/mobile/node_modules/write-file-atomic": {

--- a/packages/mobile/android/app/build.gradle
+++ b/packages/mobile/android/app/build.gradle
@@ -56,7 +56,7 @@ project.ext.envConfigFiles = [
     releasecandidaterelease: ".env.prod"
 ]
 
-apply from: "../../../../node_modules/@sentry/react-native/sentry.gradle"
+apply from: "../../node_modules/@sentry/react-native/sentry.gradle"
 apply from: project(':react-native-config').projectDir.getPath() + "/dotenv.gradle"
 
 /**

--- a/packages/mobile/ios/Podfile.lock
+++ b/packages/mobile/ios/Podfile.lock
@@ -1213,11 +1213,11 @@ PODS:
     - glog
     - RCT-Folly (= 2022.05.16.00)
     - React-Core
-  - RNSentry (5.15.2):
+  - RNSentry (5.19.3):
     - hermes-engine
     - React-Core
     - React-hermes
-    - Sentry/HybridSDK (= 8.17.1)
+    - Sentry/HybridSDK (= 8.21.0)
   - RNShare (10.0.2):
     - React-Core
   - RNSVG (13.14.0):
@@ -1235,9 +1235,9 @@ PODS:
   - SDWebImageWebPCoder (0.8.5):
     - libwebp (~> 1.0)
     - SDWebImage/Core (~> 5.10)
-  - Sentry/HybridSDK (8.17.1):
-    - SentryPrivate (= 8.17.1)
-  - SentryPrivate (8.17.1)
+  - Sentry/HybridSDK (8.21.0):
+    - SentryPrivate (= 8.21.0)
+  - SentryPrivate (8.21.0)
   - snap-kit-react-native (0.4.0):
     - React-Core
     - SnapSDK/SCSDKCreativeKit (~> 1.15.0)
@@ -1353,7 +1353,7 @@ DEPENDENCIES:
   - RNReactNativeHapticFeedback (from `../node_modules/react-native-haptic-feedback`)
   - RNReanimated (from `../../../node_modules/react-native-reanimated`)
   - RNScreens (from `../../../node_modules/react-native-screens`)
-  - "RNSentry (from `../../../node_modules/@sentry/react-native`)"
+  - "RNSentry (from `../node_modules/@sentry/react-native`)"
   - RNShare (from `../node_modules/react-native-share`)
   - RNSVG (from `../../../node_modules/react-native-svg`)
   - RNZipArchive (from `../../../node_modules/react-native-zip-archive`)
@@ -1575,7 +1575,7 @@ EXTERNAL SOURCES:
   RNScreens:
     :path: "../../../node_modules/react-native-screens"
   RNSentry:
-    :path: "../../../node_modules/@sentry/react-native"
+    :path: "../node_modules/@sentry/react-native"
   RNShare:
     :path: "../node_modules/react-native-share"
   RNSVG:
@@ -1696,14 +1696,14 @@ SPEC CHECKSUMS:
   RNReactNativeHapticFeedback: ec56a5f81c3941206fd85625fa669ffc7b4545f9
   RNReanimated: 18faeee6e1d8eb9a60f1a62488bb357354569051
   RNScreens: b582cb834dc4133307562e930e8fa914b8c04ef2
-  RNSentry: b7f4f53bb7076f119558f8898fca901b48213f12
+  RNSentry: 73baf47160d2f25b62e31a1850eb788f04c1706f
   RNShare: 859ff710211285676b0bcedd156c12437ea1d564
   RNSVG: d00c8f91c3cbf6d476451313a18f04d220d4f396
   RNZipArchive: ef9451b849c45a29509bf44e65b788829ab07801
   SDWebImage: a7f831e1a65eb5e285e3fb046a23fcfbf08e696d
   SDWebImageWebPCoder: 908b83b6adda48effe7667cd2b7f78c897e5111d
-  Sentry: d9f99f9cc13777c5d938650c1e1c85047bb4f0d1
-  SentryPrivate: 839b1e58addf58624087a80b2628e543193fa8ef
+  Sentry: ebc12276bd17613a114ab359074096b6b3725203
+  SentryPrivate: d651efb234cf385ec9a1cdd3eff94b5e78a0e0fe
   snap-kit-react-native: 751006199818fccb38c8a01196495167bc25e9fb
   SnapSDK: 1e68aad748e080f49e3802559b3b76026666ef62
   SocketRocket: f32cd54efbe0f095c4d7594881e52619cfe80b17

--- a/packages/mobile/package.json
+++ b/packages/mobile/package.json
@@ -87,7 +87,7 @@
     "@redux-devtools/remote": "0.8.0",
     "@reduxjs/toolkit": "1.6.1",
     "@sayem314/react-native-keep-awake": "1.2.2",
-    "@sentry/react-native": "5.15.2",
+    "@sentry/react-native": "5.19.3",
     "@snapchat/snap-kit-react-native": "0.4.0",
     "@solana-mobile/mobile-wallet-adapter-protocol": "0.9.9",
     "@solana-mobile/mobile-wallet-adapter-protocol-web3js": "0.9.9",


### PR DESCRIPTION
### Description
Now that we have our own `PrivacyInfo.xcprivacy` file, we're running into this bug: https://github.com/getsentry/sentry-react-native/issues/3599

So this upgrades us to the version of sentry which fixes the issue.

### How Has This Been Tested?
Tested locally on iOS emulator. Will need a test on staging before we send it out to make sure sentry logs are still propagating.
