### PR TITLE
Fix web TextInput small variant icon left padding

### DIFF
--- a/packages/harmony/src/components/input/TextInput/TextInput.module.css
+++ b/packages/harmony/src/components/input/TextInput/TextInput.module.css
@@ -10,7 +10,7 @@
   width: 100%;
   align-items: center;
   /* Dont need Y padding since the flex centering takes care of it */
-  padding: 0 var(--harmony-spacing-l);
+  padding: 0 var(--harmony-spacing-l) 0 0;
   border: 1px solid var(--harmony-border-default);
   border-radius: var(--harmony-border-radius-s);
   background-color: var(--harmony-bg-surface-1);

--- a/packages/harmony/src/components/input/TextInput/TextInput.tsx
+++ b/packages/harmony/src/components/input/TextInput/TextInput.tsx
@@ -172,13 +172,15 @@ export const TextInput = forwardRef<HTMLInputElement, TextInputProps>(
             inputRootStyle
           )}
         >
-          {StartIcon ? (
-            <StartIcon
-              size={size === TextInputSize.SMALL ? 's' : 'm'}
-              color='subdued'
-              {...IconProps}
-            />
-          ) : null}
+          <Flex pl={size === TextInputSize.SMALL ? 's' : 'l'}>
+            {StartIcon ? (
+              <StartIcon
+                size={size === TextInputSize.SMALL ? 's' : 'm'}
+                color='subdued'
+                {...IconProps}
+              />
+            ) : null}
+          </Flex>
           <Flex direction='column' gap='xs' justifyContent='center' w='100%'>
             {shouldShowLabel ? (
               <Flex


### PR DESCRIPTION
### Description
Padding to left of start icon in harmony `TextInput` was too large.

### How Has This Been Tested?

Small before:
<img width="230" alt="Screenshot 2024-04-20 at 5 11 40 AM" src="https://github.com/AudiusProject/audius-protocol/assets/3893871/6b1977da-f77f-4633-ab6a-61c35aef13a6">

Small after:
<img width="218" alt="Screenshot 2024-04-20 at 5 12 29 AM" src="https://github.com/AudiusProject/audius-protocol/assets/3893871/586ff825-9a2f-4f19-b1ae-11dd9ab14a7b">

Large after:
<img width="290" alt="Screenshot 2024-04-20 at 5 17 04 AM" src="https://github.com/AudiusProject/audius-protocol/assets/3893871/0ff04294-c1af-401a-a204-41c718746ca2">
