### PR TITLE
[C-4293] Add cooldown days to challenge definitions in jsons for dev and stage envs

### DIFF
--- a/packages/discovery-provider/src/challenges/challenges.dev.json
+++ b/packages/discovery-provider/src/challenges/challenges.dev.json
@@ -9,7 +9,8 @@
     "id": "track-upload",
     "active": true,
     "starting_block": 0,
-    "amount": 1
+    "amount": 1,
+    "cooldown_days": 7
   },
   {
     "id": "referrals",
@@ -33,13 +34,15 @@
     "id": "connect-verified",
     "active": true,
     "starting_block": 0,
-    "amount": 5
+    "amount": 5,
+    "cooldown_days": 7
   },
   {
     "id": "mobile-install",
     "active": true,
     "starting_block": 0,
-    "amount": 1
+    "amount": 1,
+    "cooldown_days": 7
   },
   {
     "id": "tt",
@@ -64,14 +67,16 @@
     "type": "boolean",
     "amount": 2,
     "active": true,
-    "starting_block": 0
+    "starting_block": 0,
+    "cooldown_days": 7
   },
   {
     "id": "first-playlist",
     "type": "boolean",
     "amount": 2,
     "active": true,
-    "starting_block": 0
+    "starting_block": 0,
+    "cooldown_days": 7
   },
   {
     "id": "b",

--- a/packages/discovery-provider/src/challenges/challenges.dev.json
+++ b/packages/discovery-provider/src/challenges/challenges.dev.json
@@ -3,38 +3,47 @@
     "id": "listen-streak",
     "active": true,
     "starting_block": 0,
-    "amount": 1
+    "amount": 1,
+    "weekly_pool": 25000
   },
   {
     "id": "track-upload",
     "active": true,
     "starting_block": 0,
     "amount": 1,
+    "weekly_pool": 25000,
     "cooldown_days": 7
   },
   {
     "id": "referrals",
     "active": true,
     "starting_block": 0,
-    "amount": 1
+    "amount": 1,
+    "weekly_pool": 25000,
+    "cooldown_days": 7
   },
   {
     "id": "ref-v",
     "active": true,
     "starting_block": 0,
-    "amount": 1
+    "amount": 1,
+    "weekly_pool": 25000,
+    "cooldown_days": 7
   },
   {
     "id": "referred",
     "active": true,
     "starting_block": 0,
-    "amount": 1
+    "amount": 1,
+    "weekly_pool": 25000,
+    "cooldown_days": 7
   },
   {
     "id": "connect-verified",
     "active": true,
     "starting_block": 0,
     "amount": 5,
+    "weekly_pool": 25000,
     "cooldown_days": 7
   },
   {
@@ -42,25 +51,29 @@
     "active": true,
     "starting_block": 0,
     "amount": 1,
+    "weekly_pool": 25000,
     "cooldown_days": 7
   },
   {
     "id": "tt",
     "active": true,
     "starting_block": 0,
-    "amount": 100
+    "amount": 100,
+    "weekly_pool": 500
   },
   {
     "id": "tut",
     "active": true,
     "starting_block": 0,
-    "amount": 100
+    "amount": 100,
+    "weekly_pool": 500
   },
   {
     "id": "tp",
     "active": true,
     "starting_block": 0,
-    "amount": 100
+    "amount": 100,
+    "weekly_pool": 500
   },
   {
     "id": "send-first-tip",
@@ -68,6 +81,7 @@
     "amount": 2,
     "active": true,
     "starting_block": 0,
+    "weekly_pool": 25000,
     "cooldown_days": 7
   },
   {
@@ -76,6 +90,7 @@
     "amount": 2,
     "active": true,
     "starting_block": 0,
+    "weekly_pool": 25000,
     "cooldown_days": 7
   },
   {

--- a/packages/discovery-provider/src/challenges/challenges.stage.json
+++ b/packages/discovery-provider/src/challenges/challenges.stage.json
@@ -9,7 +9,8 @@
     "id": "track-upload",
     "active": true,
     "starting_block": 0,
-    "amount": 1
+    "amount": 1,
+    "cooldown_days": 7
   },
   {
     "id": "referrals",
@@ -33,13 +34,15 @@
     "id": "connect-verified",
     "active": true,
     "starting_block": 0,
-    "amount": 5
+    "amount": 5,
+    "cooldown_days": 7
   },
   {
     "id": "mobile-install",
     "active": true,
     "starting_block": 0,
-    "amount": 1
+    "amount": 1,
+    "cooldown_days": 7
   },
   {
     "id": "tt",
@@ -64,14 +67,16 @@
     "type": "boolean",
     "amount": 2,
     "active": true,
-    "starting_block": 0
+    "starting_block": 0,
+    "cooldown_days": 7
   },
   {
     "id": "first-playlist",
     "type": "boolean",
     "amount": 2,
     "active": true,
-    "starting_block": 0
+    "starting_block": 0,
+    "cooldown_days": 7
   },
   {
     "id": "b",

--- a/packages/discovery-provider/src/challenges/challenges.stage.json
+++ b/packages/discovery-provider/src/challenges/challenges.stage.json
@@ -3,38 +3,47 @@
     "id": "listen-streak",
     "active": true,
     "starting_block": 0,
-    "amount": 1
+    "amount": 1,
+    "weekly_pool": 25000
   },
   {
     "id": "track-upload",
     "active": true,
     "starting_block": 0,
     "amount": 1,
+    "weekly_pool": 25000,
     "cooldown_days": 7
   },
   {
     "id": "referrals",
     "active": true,
     "starting_block": 0,
-    "amount": 1
+    "amount": 1,
+    "weekly_pool": 25000,
+    "cooldown_days": 7
   },
   {
     "id": "ref-v",
     "active": true,
     "starting_block": 0,
-    "amount": 1
+    "amount": 1,
+    "weekly_pool": 25000,
+    "cooldown_days": 7
   },
   {
     "id": "referred",
     "active": true,
     "starting_block": 0,
-    "amount": 1
+    "amount": 1,
+    "weekly_pool": 25000,
+    "cooldown_days": 7
   },
   {
     "id": "connect-verified",
     "active": true,
     "starting_block": 0,
     "amount": 5,
+    "weekly_pool": 25000,
     "cooldown_days": 7
   },
   {
@@ -42,25 +51,29 @@
     "active": true,
     "starting_block": 0,
     "amount": 1,
+    "weekly_pool": 25000,
     "cooldown_days": 7
   },
   {
     "id": "tt",
     "active": true,
     "starting_block": 0,
-    "amount": 100
+    "amount": 100,
+    "weekly_pool": 500
   },
   {
     "id": "tut",
     "active": true,
     "starting_block": 0,
-    "amount": 100
+    "amount": 100,
+    "weekly_pool": 500
   },
   {
     "id": "tp",
     "active": true,
     "starting_block": 0,
-    "amount": 100
+    "amount": 100,
+    "weekly_pool": 500
   },
   {
     "id": "send-first-tip",
@@ -68,6 +81,7 @@
     "amount": 2,
     "active": true,
     "starting_block": 0,
+    "weekly_pool": 25000,
     "cooldown_days": 7
   },
   {
@@ -76,6 +90,7 @@
     "amount": 2,
     "active": true,
     "starting_block": 0,
+    "weekly_pool": 25000,
     "cooldown_days": 7
   },
   {

--- a/packages/discovery-provider/src/challenges/create_new_challenges.py
+++ b/packages/discovery-provider/src/challenges/create_new_challenges.py
@@ -105,7 +105,7 @@ def create_new_challenges(session, allowed_challenge_types=None):
         challenges.append(challenge)
     session.add_all(challenges)
 
-    # Update any challenges whose active state / amount / step count / starting block changed
+    # Update any challenges whose active state / amount / step count / starting block / weekly pool / cooldown days changed
     existing_challenge_map = {
         challenge.id: challenge for challenge in existing_challenges
     }


### PR DESCRIPTION
### Description

Update challenge jsons only for dev and stage envs, _not prod_.

Note: for some reason, `profile-completion` is only on the prod challenge json file. maybe they should be added to the other env json files to. _at any rate, cooldown days will need to be added to `profile-completion` whenever we do this update for the prod json file_

### How Has This Been Tested?

Need to test
