### PR TITLE
Fix git secrets

### DIFF
--- a/scripts/install-git-secrets.sh
+++ b/scripts/install-git-secrets.sh
@@ -6,6 +6,8 @@ if ! git secrets > /dev/null 2>&1; then
   exit 1
 fi
 
+git config --remove-section secrets
+
 git secrets --add --allowed 'dev-tools/config.json'
 git secrets --add --allowed 'scripts/install-git-secrets.sh'
 git secrets --add --allowed 'package.json'


### PR DESCRIPTION
### Description

Installing git-secrets fails for some reason. _Could be that re-running the secrets and not changing the config returns a non-zero code and that made it fail ...  unsure_.
The fix removes the `[secrets]` section from the ./git/config file so that postinstall could freshly re-add it.

### How Has This Been Tested?

locally
