### PR TITLE
[PAY-2399] Update header and cell contents for withdrawals table

### DIFF
--- a/packages/web/src/pages/pay-and-earn-page/components/WithdrawalsTable.tsx
+++ b/packages/web/src/pages/pay-and-earn-page/components/WithdrawalsTable.tsx
@@ -15,7 +15,8 @@ import { isEmptyTransactionRow } from '../utils'
 import styles from './WithdrawalsTable.module.css'
 
 const messages = {
-  cash: 'Cash'
+  cash: 'Cash',
+  crypto: 'Crypto'
 }
 
 export type WithdrawalsTableColumn =
@@ -55,15 +56,22 @@ const defaultColumns: WithdrawalsTableColumn[] = [
 // Cell Render Functions
 const renderDestinationCell = (cellInfo: TransactionCell) => {
   const { metadata, transactionType } = cellInfo.row.original
-  const destination =
-    transactionType === USDCTransactionType.WITHDRAWAL
-      ? messages.cash
-      : metadata
-  return typeof destination === 'string' ? (
-    <span className={styles.text}>{destination}</span>
-  ) : (
-    ''
-  )
+  let destination = ''
+  switch (transactionType) {
+    case USDCTransactionType.WITHDRAWAL:
+      destination = messages.cash
+      break
+    case USDCTransactionType.TRANSFER:
+      destination = messages.crypto
+      break
+    default:
+      console.error(
+        `Unexpected transaction type for withdrawal: ${transactionType}`
+      )
+      break
+  }
+
+  return <span className={styles.text}>{destination}</span>
 }
 
 const renderDateCell = (cellInfo: TransactionCell) => {
@@ -80,7 +88,7 @@ const renderAmountCell = (cellInfo: TransactionCell) => {
 const tableColumnMap = {
   destination: {
     id: 'destination',
-    Header: 'Wallet',
+    Header: 'Method',
     accessor: 'metadata',
     Cell: renderDestinationCell,
     width: 480,

--- a/packages/web/src/pages/pay-and-earn-page/components/WithdrawalsTable.tsx
+++ b/packages/web/src/pages/pay-and-earn-page/components/WithdrawalsTable.tsx
@@ -55,7 +55,7 @@ const defaultColumns: WithdrawalsTableColumn[] = [
 
 // Cell Render Functions
 const renderDestinationCell = (cellInfo: TransactionCell) => {
-  const { metadata, transactionType } = cellInfo.row.original
+  const { transactionType } = cellInfo.row.original
   let destination = ''
   switch (transactionType) {
     case USDCTransactionType.WITHDRAWAL:


### PR DESCRIPTION
### Description
* Updates header from 'Destination' to 'Method'
* Updates the contents of the cell to be 'Cash' or 'Crypto', with the destination address being found in the details modal

fixes PAY-2399
### How Has This Been Tested?
Tested locally against staging

![image](https://github.com/AudiusProject/audius-protocol/assets/1815175/8723f3a3-efbb-4175-9204-dd8f05838c69)
---

![Screenshot 2024-04-22 at 4 35 58 PM](https://github.com/AudiusProject/audius-protocol/assets/1815175/d1bd7a06-df84-4e1f-ac8e-c5a3c702acd4)
