### PR TITLE
[PAY-2720] Fixes issues with checking for recovery on load

### DIFF
--- a/packages/common/src/store/buy-usdc/sagas.ts
+++ b/packages/common/src/store/buy-usdc/sagas.ts
@@ -33,7 +33,7 @@ import { coinflowOnrampModalActions } from '~/store/ui/modals/coinflow-onramp-mo
 import { setVisibility } from '~/store/ui/modals/parentSlice'
 import { initializeStripeModal } from '~/store/ui/stripe-modal/slice'
 import { setUSDCBalance } from '~/store/wallet/slice'
-import { waitForValue } from '~/utils'
+import { waitForRead, waitForValue } from '~/utils'
 
 import {
   buyUSDCFlowFailed,
@@ -395,6 +395,7 @@ function* doBuyUSDC({
 }
 
 function* recoverPurchaseIfNecessary() {
+  yield* waitForRead()
   const user = yield* select(getAccountUser)
   if (!user) return
 
@@ -549,7 +550,7 @@ function* watchRecovery() {
  * Gate on local storage existing for the previous purchase attempt to reduce RPC load.
  */
 function* recoverOnPageLoad() {
-  yield* call(recoverPurchaseIfNecessary)
+  yield* put(startRecoveryIfNecessary())
 }
 
 export default function sagas() {


### PR DESCRIPTION
### Description
Two small issues fixed here:
1. The saga we use to check for a recoverable balance attempts to read the user immediately without using `waitForRead()`. So if this is triggered early in the app lifecycle, the `user` will almost always be empty and cause it to exit early
2. We have a separate saga that runs on page load to check for recovery, but it can run in parallel. I updated this to `put` the same action we use for other flows, so that the `takeLeading` will keep us from running it concurrently if you happen to navigate directly to any page that checks for recovery on mount.

Fixes PAY-2720

### How Has This Been Tested?
Tested locally against staging
