### PR TITLE
Fix Solana Relay Discovery Node cache parsing

### DIFF
--- a/packages/discovery-provider/plugins/pedalboard/apps/solana-relay/src/middleware/signerRecovery.ts
+++ b/packages/discovery-provider/plugins/pedalboard/apps/solana-relay/src/middleware/signerRecovery.ts
@@ -3,7 +3,7 @@ import { recoverPersonalSignature } from 'eth-sig-util'
 import { Table, Users } from '@pedalboard/storage'
 import { initializeDiscoveryDb } from '@pedalboard/basekit'
 import { config } from '../config'
-import { getCachedDiscoveryNodeWallets } from '../redis'
+import { getCachedDiscoveryNodes } from '../redis'
 
 const discoveryDb = initializeDiscoveryDb(config.discoveryDbConnectionString)
 
@@ -43,9 +43,9 @@ export const discoveryNodeSignerRecoveryMiddleware = async (
     return next()
   }
   const walletAddress = recoverPersonalSignature({ data, sig })
-  const discoveryWallets = await getCachedDiscoveryNodeWallets()
+  const discoveryWallets = await getCachedDiscoveryNodes()
   const isSignedByDiscovery = discoveryWallets
-    .map((wallet) => wallet.toLowerCase())
+    .map(({ delegateOwnerWallet }) => delegateOwnerWallet.toLowerCase())
     .includes(walletAddress)
   res.locals.isSignedByDiscovery = isSignedByDiscovery
   if (!isSignedByDiscovery) {

--- a/packages/discovery-provider/plugins/pedalboard/apps/solana-relay/src/routes/relay/relay.ts
+++ b/packages/discovery-provider/plugins/pedalboard/apps/solana-relay/src/routes/relay/relay.ts
@@ -11,7 +11,7 @@ import { Request, Response, NextFunction } from 'express'
 import { config } from '../../config'
 import { BadRequestError } from '../../errors'
 import { assertRelayAllowedInstructions } from './assertRelayAllowedInstructions'
-import { cacheTransaction, getCachedDiscoveryNodeEndpoints } from '../../redis'
+import { cacheTransaction, getCachedDiscoveryNodes } from '../../redis'
 import fetch from 'cross-fetch'
 import { Logger } from 'pino'
 import base58 from 'bs58'
@@ -59,13 +59,13 @@ const getFeePayerKeyPair = (feePayerPublicKey?: PublicKey) => {
  * nodes so that they can cache it to lighten the RPC load on indexing.
  */
 const forwardTransaction = async (logger: Logger, transaction: string) => {
-  const endpoints = await getCachedDiscoveryNodeEndpoints()
+  const endpoints = await getCachedDiscoveryNodes()
   logger.info(`Forwarding to ${endpoints.length} endpoints...`)
   const body = JSON.stringify({ transaction })
   await Promise.all(
     endpoints
-      .filter((endpoint) => endpoint !== config.endpoint)
-      .map((endpoint) =>
+      .filter((p) => p.endpoint !== config.endpoint)
+      .map(({ endpoint }) =>
         fetch(`${endpoint}/solana/cache`, {
           method: 'POST',
           body,


### PR DESCRIPTION
### Description

When this code was first written, the `all-discovery-nodes` cache key looked like `["endpoint1", "endpoint2"...]` etc. Now it's an array of objects that looks like `[{"delegateOwnerWallet": "0x123", "endpoint": "endpoint1"} ...]` etc

