### PR TITLE
Fix signature in SDK rewards

### DIFF
--- a/.changeset/new-taxis-trade.md
+++ b/.changeset/new-taxis-trade.md
@@ -1,0 +1,5 @@
+---
+'@audius/spl': patch
+---
+
+Fixes RewardManagerProgram getSubmittedAttestations to account for the program padding the verified messages to 128 bytes

--- a/.changeset/plenty-toes-report.md
+++ b/.changeset/plenty-toes-report.md
@@ -1,0 +1,6 @@
+---
+'@audius/spl': patch
+'@audius/sdk': patch
+---
+
+Fix RewardManagerClient attestation signatures when signature is less than 64 bytes

--- a/.changeset/plenty-toes-report.md
+++ b/.changeset/plenty-toes-report.md
@@ -1,6 +1,5 @@
 ---
 '@audius/spl': patch
-'@audius/sdk': patch
 ---
 
-Fix RewardManagerClient attestation signatures when signature is less than 64 bytes
+Fixes RewardManagerProgram signature parsing when service attestation signature is less than 64 bytes

--- a/packages/spl/src/reward-manager/RewardManagerProgram.ts
+++ b/packages/spl/src/reward-manager/RewardManagerProgram.ts
@@ -593,9 +593,9 @@ export class RewardManagerProgram {
     const strippedSignature = signature
       .substring(0, signature.length - 2)
       .replace('0x', '')
+      .padStart(128, '0')
+      .substring(0, 128)
     const signatureBuffer = Buffer.from(strippedSignature, 'hex')
-    const fixedBuf = Buffer.alloc(64, 0)
-    signatureBuffer.copy(fixedBuf, 64 - signatureBuffer.length)
     return {
       signature: signatureBuffer,
       recoveryId: recoveryIdBuffer.readInt8()

--- a/packages/spl/src/reward-manager/RewardManagerProgram.ts
+++ b/packages/spl/src/reward-manager/RewardManagerProgram.ts
@@ -1,4 +1,4 @@
-import { seq, struct, u8 } from '@solana/buffer-layout'
+import { blob, seq, struct, u8 } from '@solana/buffer-layout'
 import { publicKey, u64 } from '@solana/buffer-layout-utils'
 import { TOKEN_PROGRAM_ID } from '@solana/spl-token'
 import {
@@ -80,11 +80,16 @@ export class RewardManagerProgram {
     attestationsAccountData: struct<AttestationsAccountData>([
       u8('version'),
       publicKey('rewardManagerState'),
+      u8('count'),
       seq(
         struct<VerifiedMessage>([
-          u8('index'),
           ethAddress('senderEthAddress'),
-          attestationLayout('attestation'),
+          attestationLayout('message'),
+          // Though the actual attestation message is only 83 bytes, we allocate
+          // 128 bytes for each element of this array on the program side.
+          // Thus we add 45 bytes of padding here to be consistent.
+          // See: https://github.com/AudiusProject/audius-protocol/blob/dde78ad7e26d9f6fb358fef5d240c5c7e2d25c66/solana-programs/reward-manager/program/src/state/verified_messages.rs#L99
+          blob(45),
           ethAddress('operator')
         ]),
         3,

--- a/packages/spl/src/reward-manager/types.ts
+++ b/packages/spl/src/reward-manager/types.ts
@@ -284,14 +284,17 @@ export type Attestation = {
 }
 
 export type VerifiedMessage = {
-  index: number
   senderEthAddress: string
   attestation: Attestation
+  // Hint to make types not complain when adding empty padding for
+  // the array of verified messages in the account data.
+  _: Uint8Array
   operator: string
 }
 
 export type AttestationsAccountData = {
   version: number
   rewardManagerState: PublicKey
+  count: number
   messages: VerifiedMessage[]
 }

--- a/packages/web/src/common/store/pages/audio-rewards/sagas.ts
+++ b/packages/web/src/common/store/pages/audio-rewards/sagas.ts
@@ -32,7 +32,7 @@ import {
   waitForValue
 } from '@audius/common/utils'
 import { AUDIO } from '@audius/fixed-decimal'
-import { ChallengeId } from '@audius/sdk'
+import { ChallengeId, ResponseError } from '@audius/sdk'
 import {
   call,
   fork,
@@ -270,7 +270,7 @@ function* claimChallengeRewardAsync(
             })
             // Handle the individual specifier failures here to let the other
             // ones continue to claim and not reject the all() call.
-            .catch((error) => {
+            .catch((error: unknown) => {
               return {
                 ...specifierWithAmount,
                 error
@@ -290,14 +290,21 @@ function* claimChallengeRewardAsync(
     )
     yield* put(setUserChallengesDisbursed({ challengeId, specifiers: claimed }))
 
+    const isResponseError = (error: Error): error is ResponseError =>
+      'response' in error
     const errors = results.filter((r): r is ErrorResult => 'error' in r)
     if (errors.length > 0) {
       for (const res of errors) {
         const error =
           res.error instanceof Error ? res.error : new Error(String(res.error))
+        let response, responseBody
+        if (isResponseError(error)) {
+          response = error.response
+          responseBody = yield* call(async () => await error.response.json())
+        }
         console.error(
-          `Failed to claim specifier: ${res.specifier} for amount: ${res.amount} with error:`,
-          error
+          `Failed to claim challenge: ${challengeId} specifier: ${res.specifier} for amount: ${res.amount} with error:`,
+          response ?? error
         )
         yield* call(reportToSentry, {
           error,
@@ -305,7 +312,9 @@ function* claimChallengeRewardAsync(
           additionalInfo: {
             challengeId,
             specifier: res.specifier,
-            amount: res.amount
+            amount: res.amount,
+            responseBody,
+            response
           }
         })
       }


### PR DESCRIPTION
### Description

Occasionally an attestation signature returned by our services will have less than 64 bytes. When recreating this signature logic, I didn't realize that meant it could have 63 1/2 bytes 😝 

Using `Buffer.alloc()` to ensure 64 bytes was stripping the last half-byte off and pushing everything a half byte. Eg.

`d405b277dc948f97d7b7db8648cb16590d66084ba49642fedb08380ce5027a95d0a895287a3331332e7ad13daba87eed5c70820a19ca2eb6cc0ea1eb4695ba4`

would become
`00d405b277dc948f97d7b7db8648cb16590d66084ba49642fedb08380ce5027a95d0a895287a3331332e7ad13daba87eed5c70820a19ca2eb6cc0ea1eb4695ba` (note the two prepended 0s)

instead of
`0d405b277dc948f97d7b7db8648cb16590d66084ba49642fedb08380ce5027a95d0a895287a3331332e7ad13daba87eed5c70820a19ca2eb6cc0ea1eb4695ba4` (note the 4)

That was fun.

While I was at it, I noticed the new cooldown errors from @sddioulde 's changes, and decided the error handling in reportToSentry should add the responses if it can.

And then what's _more_:

The attestation account data looks different than the data that we submit in the `submitAttestation` instruction. The actual attestation message is padded to be 128 bytes in the program logic rather than being the actual 83 bytes it actually uses. So that was breaking the code that checks to see what existing senders have already submitted. I added padding for the parsing of the account data to get this to work as well. Fun stuff! Hex editor for the win.