### PR TITLE
[PAY-2737] Fix mobile collection tile formatting

### DIFF
--- a/packages/common/src/utils/timeUtil.ts
+++ b/packages/common/src/utils/timeUtil.ts
@@ -28,8 +28,12 @@ export const formatSecondsAsText = (seconds: number): string => {
 
 export const formatLineupTileDuration = (
   seconds: number,
-  isLongFormContent = false
+  isLongFormContent = false,
+  isCollection = false
 ): string => {
+  if (isCollection) {
+    return formatSecondsAsText(seconds)
+  }
   if (!isLongFormContent && seconds < SECONDS_PER_HOUR) {
     return formatSeconds(seconds)
   }

--- a/packages/mobile/src/components/lineup-tile/LineupTile.tsx
+++ b/packages/mobile/src/components/lineup-tile/LineupTile.tsx
@@ -114,6 +114,7 @@ export const LineupTile = ({
           duration={duration}
           trackId={id}
           isLongFormContent={isLongFormContent}
+          isCollection={isCollection}
         />
         <LineupTileMetadata
           artistName={name}

--- a/packages/mobile/src/components/lineup-tile/LineupTileActionButtons.tsx
+++ b/packages/mobile/src/components/lineup-tile/LineupTileActionButtons.tsx
@@ -49,6 +49,7 @@ const useStyles = makeStyles(({ spacing, palette }) => ({
     ...flexRowCentered(),
     justifyContent: 'space-between',
     marginHorizontal: spacing(3),
+    marginBottom: spacing(1),
     borderTopWidth: 1,
     borderTopColor: palette.neutralLight8,
     minHeight: spacing(8)

--- a/packages/mobile/src/components/lineup-tile/LineupTileTopRight.tsx
+++ b/packages/mobile/src/components/lineup-tile/LineupTileTopRight.tsx
@@ -51,7 +51,7 @@ type Props = {
    */
   trackId?: number
   /**
-   * Whether or not the track is a collection
+   * Whether or not the tile is for a collection
    */
   isCollection?: boolean
   /**

--- a/packages/mobile/src/components/lineup-tile/LineupTileTopRight.tsx
+++ b/packages/mobile/src/components/lineup-tile/LineupTileTopRight.tsx
@@ -51,6 +51,10 @@ type Props = {
    */
   trackId?: number
   /**
+   * Whether or not the track is a collection
+   */
+  isCollection?: boolean
+  /**
    * Whether or not the track is long-form content (podcast/audiobook/etc)
    */
   isLongFormContent?: boolean
@@ -59,6 +63,7 @@ type Props = {
 export const LineupTileTopRight = ({
   duration,
   trackId,
+  isCollection,
   isLongFormContent
 }: Props) => {
   const { isEnabled: isNewPodcastControlsEnabled } = useFeatureFlag(
@@ -82,9 +87,10 @@ export const LineupTileTopRight = ({
     ? isInProgress
       ? `${formatLineupTileDuration(
           duration - playbackPositionInfo.playbackPosition,
-          isLongFormContent
+          isLongFormContent,
+          isCollection
         )} ${messages.timeLeft}`
-      : formatLineupTileDuration(duration, isLongFormContent)
+      : formatLineupTileDuration(duration, isLongFormContent, isCollection)
     : null
 
   return (

--- a/packages/web/src/components/track/desktop/TrackTile.tsx
+++ b/packages/web/src/components/track/desktop/TrackTile.tsx
@@ -214,7 +214,7 @@ const TrackTile = ({
         return (
           <div className={styles.progressTextContainer}>
             <p className={styles.progressText}>
-              {`${formatLineupTileDuration(remainingTime, true)} ${
+              {`${formatLineupTileDuration(remainingTime, true, !isTrack)} ${
                 messages.timeLeft
               }`}
             </p>
@@ -233,7 +233,7 @@ const TrackTile = ({
         )
       }
     } else {
-      return formatLineupTileDuration(duration, isLongFormContent)
+      return formatLineupTileDuration(duration, isLongFormContent, !isTrack)
     }
   }
 

--- a/packages/web/src/components/track/mobile/BottomButtons.tsx
+++ b/packages/web/src/components/track/mobile/BottomButtons.tsx
@@ -63,10 +63,10 @@ const BottomButtons = (props: BottomButtonsProps) => {
   if (!props.isLoading && props.streamConditions && !props.hasStreamAccess) {
     return (
       <Flex
-        ph='s'
-        p='xs'
+        ph={props.isTrack ? undefined : 's'}
+        pb={props.isTrack ? undefined : 'xs'}
         direction='row'
-        alignItems='center'
+        alignItems='flex-end'
         justifyContent='space-between'
         borderTop='default'
       >

--- a/packages/web/src/components/track/mobile/BottomButtons.tsx
+++ b/packages/web/src/components/track/mobile/BottomButtons.tsx
@@ -64,7 +64,7 @@ const BottomButtons = (props: BottomButtonsProps) => {
     return (
       <Flex
         ph={props.isTrack ? undefined : 's'}
-        pb={props.isTrack ? undefined : 'xs'}
+        pb={props.isTrack ? undefined : 's'}
         direction='row'
         alignItems='flex-end'
         justifyContent='space-between'
@@ -97,7 +97,7 @@ const BottomButtons = (props: BottomButtonsProps) => {
     return (
       <Flex
         ph='s'
-        pv='xs'
+        pv='s'
         direction='row'
         alignItems='center'
         justifyContent='flex-end'
@@ -111,7 +111,7 @@ const BottomButtons = (props: BottomButtonsProps) => {
   return (
     <Flex
       ph={props.isTrack ? undefined : 's'}
-      pb={props.isTrack ? undefined : 'xs'}
+      pb={props.isTrack ? undefined : 's'}
       direction='row'
       alignItems='center'
       justifyContent='space-between'

--- a/packages/web/src/components/track/mobile/PlaylistTile.tsx
+++ b/packages/web/src/components/track/mobile/PlaylistTile.tsx
@@ -390,7 +390,11 @@ const PlaylistTile = (props: PlaylistTileProps & ExtraProps) => {
                 isVisible={isTrending && shouldShow}
                 showCrown={showRankIcon}
               />
-              {isReadonly ? specialContentLabel : null}
+              {isReadonly ? (
+                <Text variant='body' size='xs' strength='default'>
+                  {specialContentLabel}
+                </Text>
+              ) : null}
               {!!(props.repostCount || props.saveCount) && (
                 <>
                   <Flex

--- a/packages/web/src/components/track/mobile/PlaylistTile.tsx
+++ b/packages/web/src/components/track/mobile/PlaylistTile.tsx
@@ -36,10 +36,7 @@ import FavoriteButton from 'components/alt-button/FavoriteButton'
 import RepostButton from 'components/alt-button/RepostButton'
 import { DogEar } from 'components/dog-ear'
 import { TextLink, UserLink } from 'components/link'
-import {
-  LockedStatusPill,
-  LockedStatusPillProps
-} from 'components/locked-status-pill'
+import { LockedStatusPill } from 'components/locked-status-pill'
 import Skeleton from 'components/skeleton/Skeleton'
 import { PlaylistTileProps } from 'components/track/types'
 import { useAuthenticatedClickCallback } from 'hooks/useAuthenticatedCallback'

--- a/packages/web/src/components/track/mobile/PlaylistTile.tsx
+++ b/packages/web/src/components/track/mobile/PlaylistTile.tsx
@@ -182,12 +182,16 @@ type CombinedProps = PlaylistTileProps & ExtraProps
 
 type LockedOrPlaysContentProps = Pick<
   CombinedProps,
-  'hasStreamAccess' | 'isOwner' | 'isStreamGated' | 'streamConditions'
-> &
-  Pick<LockedStatusPillProps, 'variant'> & {
-    gatedTrackStatus?: GatedContentStatus
-    onClickGatedUnlockPill: (e: MouseEvent) => void
-  }
+  | 'hasStreamAccess'
+  | 'isOwner'
+  | 'isStreamGated'
+  | 'streamConditions'
+  | 'variant'
+> & {
+  lockedContentType: 'premium' | 'gated'
+  gatedTrackStatus?: GatedContentStatus
+  onClickGatedUnlockPill: (e: MouseEvent) => void
+}
 
 const renderLockedContent = ({
   hasStreamAccess,
@@ -196,10 +200,11 @@ const renderLockedContent = ({
   streamConditions,
   gatedTrackStatus,
   onClickGatedUnlockPill,
+  lockedContentType,
   variant
 }: LockedOrPlaysContentProps) => {
   if (isStreamGated && streamConditions && !isOwner) {
-    if (variant === 'premium') {
+    if (lockedContentType === 'premium' && variant === 'readonly') {
       return (
         <GatedConditionsPill
           streamConditions={streamConditions}
@@ -209,7 +214,9 @@ const renderLockedContent = ({
         />
       )
     }
-    return <LockedStatusPill locked={!hasStreamAccess} variant={variant} />
+    return (
+      <LockedStatusPill locked={!hasStreamAccess} variant={lockedContentType} />
+    )
   }
 }
 
@@ -321,9 +328,19 @@ const PlaylistTile = (props: PlaylistTileProps & ExtraProps) => {
         className={styles.mainContent}
         onClick={props.togglePlay}
       >
-        <div className={cn(styles.duration, styles.statText, fadeIn)}>
-          {formatLineupTileDuration(props.duration)}
-        </div>
+        <Text
+          className={cn(styles.duration, fadeIn)}
+          variant='body'
+          size='xs'
+          strength='default'
+          color='subdued'
+        >
+          {formatLineupTileDuration(
+            props.duration,
+            false,
+            /* isCollection */ true
+          )}
+        </Text>
 
         <div className={styles.metadata}>
           <TrackTileArt
@@ -424,24 +441,23 @@ const PlaylistTile = (props: PlaylistTileProps & ExtraProps) => {
                 </>
               )}
             </Flex>
-            {isReadonly ? (
-              <Text
-                variant='body'
-                size='xs'
-                color='staticWhite'
-                className={cn(styles.bottomRight, fadeIn)}
-              >
-                {renderLockedContent({
-                  hasStreamAccess,
-                  isOwner,
-                  isStreamGated,
-                  streamConditions,
-                  gatedTrackStatus: gatedContentStatus,
-                  variant: isPurchase ? 'premium' : 'gated',
-                  onClickGatedUnlockPill
-                })}
-              </Text>
-            ) : null}
+            <Text
+              variant='body'
+              size='xs'
+              color='staticWhite'
+              className={cn(styles.bottomRight, fadeIn)}
+            >
+              {renderLockedContent({
+                hasStreamAccess,
+                isOwner,
+                isStreamGated,
+                streamConditions,
+                gatedTrackStatus: gatedContentStatus,
+                lockedContentType: isPurchase ? 'premium' : 'gated',
+                variant,
+                onClickGatedUnlockPill
+              })}
+            </Text>
           </Flex>
         </Text>
         <TrackList

--- a/packages/web/src/components/track/mobile/TrackTile.tsx
+++ b/packages/web/src/components/track/mobile/TrackTile.tsx
@@ -37,10 +37,7 @@ import FavoriteButton from 'components/alt-button/FavoriteButton'
 import RepostButton from 'components/alt-button/RepostButton'
 import { DogEar } from 'components/dog-ear'
 import { TextLink, UserLink } from 'components/link'
-import {
-  LockedStatusPill,
-  LockedStatusPillProps
-} from 'components/locked-status-pill'
+import { LockedStatusPill } from 'components/locked-status-pill'
 import Skeleton from 'components/skeleton/Skeleton'
 import { GatedContentLabel } from 'components/track/GatedContentLabel'
 import { TrackTileProps } from 'components/track/types'
@@ -53,7 +50,6 @@ import { messages } from '../trackTileMessages'
 import BottomButtons from './BottomButtons'
 import styles from './TrackTile.module.css'
 import TrackTileArt from './TrackTileArt'
-import { render } from '@testing-library/react'
 
 const { setLockedContentId } = gatedContentActions
 const { getGatedContentStatusMap } = gatedContentSelectors

--- a/packages/web/src/components/track/mobile/TrackTile.tsx
+++ b/packages/web/src/components/track/mobile/TrackTile.tsx
@@ -53,6 +53,7 @@ import { messages } from '../trackTileMessages'
 import BottomButtons from './BottomButtons'
 import styles from './TrackTile.module.css'
 import TrackTileArt from './TrackTileArt'
+import { render } from '@testing-library/react'
 
 const { setLockedContentId } = gatedContentActions
 const { getGatedContentStatusMap } = gatedContentSelectors
@@ -83,11 +84,12 @@ type LockedOrPlaysContentProps = Pick<
   | 'isStreamGated'
   | 'streamConditions'
   | 'listenCount'
-> &
-  Pick<LockedStatusPillProps, 'variant'> & {
-    gatedTrackStatus?: GatedContentStatus
-    onClickGatedUnlockPill: (e: MouseEvent) => void
-  }
+  | 'variant'
+> & {
+  lockedContentType: 'gated' | 'premium'
+  gatedTrackStatus?: GatedContentStatus
+  onClickGatedUnlockPill: (e: MouseEvent) => void
+}
 
 const renderLockedContentOrPlayCount = ({
   hasStreamAccess,
@@ -98,10 +100,11 @@ const renderLockedContentOrPlayCount = ({
   gatedTrackStatus,
   listenCount,
   onClickGatedUnlockPill,
-  variant
+  variant,
+  lockedContentType
 }: LockedOrPlaysContentProps) => {
   if (isStreamGated && streamConditions && !isOwner) {
-    if (variant === 'premium') {
+    if (lockedContentType === 'premium' && variant === 'readonly') {
       return (
         <GatedConditionsPill
           streamConditions={streamConditions}
@@ -111,7 +114,9 @@ const renderLockedContentOrPlayCount = ({
         />
       )
     }
-    return <LockedStatusPill locked={!hasStreamAccess} variant={variant} />
+    return (
+      <LockedStatusPill locked={!hasStreamAccess} variant={lockedContentType} />
+    )
   }
 
   const hidePlays = fieldVisibility
@@ -488,7 +493,8 @@ const TrackTile = (props: CombinedProps) => {
                   streamConditions,
                   listenCount,
                   gatedTrackStatus,
-                  variant: isPurchase ? 'premium' : 'gated',
+                  variant,
+                  lockedContentType: isPurchase ? 'premium' : 'gated',
                   onClickGatedUnlockPill: onClickPill
                 })
               : null}


### PR DESCRIPTION
### Description

⚠️ To be cherry-picked onto release ⚠️

- Remove duplicate purchase button and replace with locked content icon
- Use `3h 5m` formatting for duration
- Fix padding on bottom buttons

#### Screenshots

<img width="49%" src="https://github.com/AudiusProject/audius-protocol/assets/2358254/c3c7adf0-d138-4a0f-b4c7-fb713a6c044e" />
<img width="49%" src="https://github.com/AudiusProject/audius-protocol/assets/2358254/47c71c17-bd01-4cbd-bffe-8ca0b38db4da" />
<img src="https://github.com/AudiusProject/audius-protocol/assets/2358254/3ec6b2ae-71d4-4cdf-8fbf-7aa71c24dfc5" />


### How Has This Been Tested?

local mobile web