### PR TITLE
[PAY-2725] Add purchase button to mobile web albums

### DIFF
--- a/packages/web/src/components/collection/mobile/CollectionHeader.tsx
+++ b/packages/web/src/components/collection/mobile/CollectionHeader.tsx
@@ -6,10 +6,12 @@ import { FeatureFlags } from '@audius/common/services'
 import {
   CommonState,
   OverflowAction,
+  PurchaseableContentType,
   cacheCollectionsSelectors,
   useEditPlaylistModal
 } from '@audius/common/store'
 import {
+  Box,
   Button,
   ButtonProps,
   Flex,
@@ -24,6 +26,7 @@ import DynamicImage from 'components/dynamic-image/DynamicImage'
 import { UserLink } from 'components/link'
 import Skeleton from 'components/skeleton/Skeleton'
 import { StaticImage } from 'components/static-image/StaticImage'
+import { GatedContentSection } from 'components/track/GatedContentSection'
 import { UserGeneratedText } from 'components/user-generated-text'
 import { useCollectionCoverArt } from 'hooks/useCollectionCoverArt'
 import { useFlag } from 'hooks/useRemoteConfig'
@@ -119,6 +122,9 @@ const CollectionHeader = ({
 }: MobileCollectionHeaderProps) => {
   const { isSsrEnabled } = useSsrContext()
   const { isEnabled: isEditAlbumsEnabled } = useFlag(FeatureFlags.EDIT_ALBUMS)
+  const { isEnabled: isPremiumAlbumsEnabled } = useFlag(
+    FeatureFlags.PREMIUM_ALBUMS_ENABLED
+  )
   const collection = useSelector((state: CommonState) =>
     getCollection(state, { id: collectionId })
   ) as Collection
@@ -236,6 +242,26 @@ const CollectionHeader = ({
         {isPlayable ? (
           <PlayButton playing={playing} onPlay={onPlay} fullWidth />
         ) : null}
+        {isPremiumAlbumsEnabled &&
+        isAlbum &&
+        isPurchaseableAlbum &&
+        collectionId ? (
+          <Box mb='xl' w='100%'>
+            <GatedContentSection
+              isLoading={isLoading}
+              contentId={collectionId}
+              contentType={PurchaseableContentType.ALBUM}
+              streamConditions={streamConditions}
+              hasStreamAccess={hasStreamAccess}
+              isOwner={isOwner}
+              wrapperClassName={styles.gatedContentSectionWrapper}
+              className={styles.gatedContentSection}
+              buttonClassName={styles.gatedContentSectionButton}
+              ownerId={userId}
+            />
+          </Box>
+        ) : null}
+
         <ActionButtonRow
           isOwner={isOwner}
           isSaved={isSaved}

--- a/packages/web/src/components/collection/mobile/CollectionHeader.tsx
+++ b/packages/web/src/components/collection/mobile/CollectionHeader.tsx
@@ -100,6 +100,9 @@ const CollectionHeader = ({
   lastModifiedDate,
   numTracks,
   isPlayable,
+  isStreamGated,
+  streamConditions,
+  access,
   duration,
   isPublished = false,
   isPublishing = false,
@@ -244,7 +247,7 @@ const CollectionHeader = ({
         ) : null}
         {isPremiumAlbumsEnabled &&
         isAlbum &&
-        isPurchaseableAlbum &&
+        streamConditions &&
         collectionId ? (
           <Box mb='xl' w='100%'>
             <GatedContentSection
@@ -252,7 +255,7 @@ const CollectionHeader = ({
               contentId={collectionId}
               contentType={PurchaseableContentType.ALBUM}
               streamConditions={streamConditions}
-              hasStreamAccess={hasStreamAccess}
+              hasStreamAccess={!!access?.stream}
               isOwner={isOwner}
               wrapperClassName={styles.gatedContentSectionWrapper}
               className={styles.gatedContentSection}

--- a/packages/web/src/components/track/GatedContentSection.tsx
+++ b/packages/web/src/components/track/GatedContentSection.tsx
@@ -478,7 +478,7 @@ const UnlockedGatedContentSection = ({
           </span>
         </div>
       ) : (
-        <Flex direction='row'>
+        <Flex direction='row' wrap='wrap'>
           <span>{messages.purchased}&nbsp;</span>
           {trackOwner ? (
             <>


### PR DESCRIPTION
### Description

- Added purchase button to mobile web
- Fixed wrapping inside the gated content section for narrow windows

<img width="49%" src="https://github.com/AudiusProject/audius-protocol/assets/2358254/7b13507e-49c3-48a4-b34b-c3dd06f0b545" />
<img width="49%" src="https://github.com/AudiusProject/audius-protocol/assets/2358254/165f3a48-55f6-4646-a3b1-11f3954768fd" />

### How Has This Been Tested?

local web