### PR TITLE
[PAY-2739] show purchase button on tracks table mobile web

### DIFF
--- a/packages/web/src/components/track/mobile/TrackList.tsx
+++ b/packages/web/src/components/track/mobile/TrackList.tsx
@@ -1,8 +1,9 @@
 import { memo, useCallback } from 'react'
 
-import { ID, CoverArtSizes } from '@audius/common/models'
+import { ID, CoverArtSizes, AccessConditions } from '@audius/common/models'
 import cn from 'classnames'
 import { DragDropContext, Droppable, Draggable } from 'react-beautiful-dnd'
+import { Nullable } from 'vitest'
 
 import TrackListItem from './ConnectedTrackListItem'
 import styles from './TrackList.module.css'
@@ -29,6 +30,8 @@ type TrackListProps = {
     coverArtSizes?: CoverArtSizes
     isDeleted: boolean
     isLocked: boolean
+    streamConditions?: Nullable<AccessConditions>
+    hasStreamAccess?: boolean
   }>
   showTopDivider?: boolean
   showDivider?: boolean
@@ -96,6 +99,8 @@ const TrackList = ({
           isActive={track.isActive}
           isPlaying={track.isPlaying}
           isStreamGated={track.isStreamGated}
+          hasStreamAccess={track.hasStreamAccess}
+          streamConditions={track.streamConditions}
           artistHandle={track.artistHandle}
           artistName={track.artistName}
           permalink={track.permalink}

--- a/packages/web/src/components/track/mobile/TrackListItem.tsx
+++ b/packages/web/src/components/track/mobile/TrackListItem.tsx
@@ -1,6 +1,14 @@
 import { memo, MouseEvent } from 'react'
 
-import { SquareSizes, ID, CoverArtSizes } from '@audius/common/models'
+import {
+  SquareSizes,
+  ID,
+  CoverArtSizes,
+  AccessConditions,
+  isContentUSDCPurchaseGated,
+  GatedContentStatus
+} from '@audius/common/models'
+import { Nullable } from '@audius/common/utils'
 import {
   IconRemove,
   IconPlaybackPause,
@@ -19,6 +27,8 @@ import { TablePlayButton } from 'components/table/components/TablePlayButton'
 import UserBadges from 'components/user-badges/UserBadges'
 import { useTrackCoverArt } from 'hooks/useTrackCoverArt'
 import { profilePage } from 'utils/route'
+
+import { GatedConditionsPill } from '../GatedConditionsPill'
 
 import styles from './TrackListItem.module.css'
 
@@ -125,7 +135,11 @@ export type TrackListItemProps = {
   onRemove?: (trackId: ID) => void
   togglePlay?: (uid: string, trackId: ID) => void
   onClickOverflow?: () => void
+  onClickGatedUnlockPill?: (e: MouseEvent) => void
+  hasStreamAccess?: boolean
   trackItemAction?: TrackItemAction
+  gatedUnlockStatus?: GatedContentStatus
+  streamConditions?: Nullable<AccessConditions>
 }
 
 const TrackListItem = ({
@@ -149,10 +163,14 @@ const TrackListItem = ({
   togglePlay,
   trackItemAction,
   onClickOverflow,
+  onClickGatedUnlockPill,
+  streamConditions,
+  gatedUnlockStatus,
   isReorderable = false,
   isDragging = false
 }: TrackListItemProps) => {
   const messages = getMessages({ isDeleted })
+  const isUsdcPurchaseGated = isContentUSDCPurchaseGated(streamConditions)
 
   const onClickTrack = () => {
     if (uid && !isLocked && !isDeleted && togglePlay) togglePlay(uid, trackId)
@@ -216,10 +234,19 @@ const TrackListItem = ({
         </SeoLink>
       </div>
       {!isDeleted && isLocked ? (
-        <div className={styles.locked}>
-          <IconLock />
-          <span>{messages.locked}</span>
-        </div>
+        isUsdcPurchaseGated ? (
+          <GatedConditionsPill
+            streamConditions={streamConditions}
+            unlocking={gatedUnlockStatus === 'UNLOCKING'}
+            onClick={onClickGatedUnlockPill}
+            buttonSize='small'
+          />
+        ) : (
+          <div className={styles.locked}>
+            <IconLock />
+            <span>{messages.locked}</span>
+          </div>
+        )
       ) : null}
       {onClickOverflow && trackItemAction === TrackItemAction.Overflow && (
         <div className={styles.iconContainer}>

--- a/packages/web/src/pages/collection-page/components/mobile/CollectionPage.tsx
+++ b/packages/web/src/pages/collection-page/components/mobile/CollectionPage.tsx
@@ -229,7 +229,9 @@ const CollectionPage = ({
       uid: entry.uid,
       isStreamGated: entry.is_stream_gated,
       isDeleted: entry.is_delete || !!entry?.user?.is_deactivated,
-      isLocked
+      isLocked,
+      hasStreamAccess,
+      streamConditions: entry.stream_conditions
     }
   })
   const numTracks = trackList.length


### PR DESCRIPTION
### Description

Show purchase button instead of the locked badge on mobile web track list tracks

#### Before & After
<img width="49%" src="https://github.com/AudiusProject/audius-protocol/assets/2358254/083975b8-5975-4a97-a9d5-bb178374677c" />
<img width="49%" src="https://github.com/AudiusProject/audius-protocol/assets/2358254/5a12ebc8-43e9-49e4-ad91-0ad9b690c069" />


### How Has This Been Tested?

mobile web