### PR TITLE
[PAY-2747] Fix attestation decoding and add Secp256k1Program utils

### DIFF
--- a/.changeset/six-pens-flash.md
+++ b/.changeset/six-pens-flash.md
@@ -1,0 +1,5 @@
+---
+'@audius/spl': patch
+---
+
+Add Secp256k1Program extensions to @audius/spl to aid in decoding and debugging secp256k1 instructions

--- a/package-lock.json
+++ b/package-lock.json
@@ -139582,6 +139582,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@coral-xyz/anchor": "0.29.0",
+        "@noble/hashes": "1.4.0",
         "@solana/buffer-layout": "4.0.1",
         "@solana/buffer-layout-utils": "0.2.0",
         "@solana/spl-token": "0.3.8",
@@ -139589,6 +139590,17 @@
       },
       "devDependencies": {
         "vitest": "0.34.6"
+      }
+    },
+    "packages/spl/node_modules/@noble/hashes": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.4.0.tgz",
+      "integrity": "sha512-V1JJ1WTRUqHHrOSh597hURcMqVKVGL/ea3kv0gSnEdsEZ0/+VyPghM1lMNGc00z7CIQorSvbKpuJkxvuHbvdbg==",
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
       }
     },
     "packages/sql-ts": {

--- a/packages/discovery-provider/plugins/pedalboard/apps/solana-relay/src/routes/health/health.ts
+++ b/packages/discovery-provider/plugins/pedalboard/apps/solana-relay/src/routes/health/health.ts
@@ -1,8 +1,7 @@
-  import { Request, Response, NextFunction } from 'express'
-  import type { RelayRequestBody } from '@audius/sdk'
+import { Request, Response } from 'express'
 
-export const health = async (req: Request, res: Response) => {
-    res.status(200).json({
-        isHealthy: true
-    })
+export const health = async (_req: Request, res: Response) => {
+  res.status(200).json({
+    isHealthy: true
+  })
 }

--- a/packages/spl/package.json
+++ b/packages/spl/package.json
@@ -23,6 +23,7 @@
   "homepage": "https://github.com/AudiusProject/audius-protocol/tree/main/packages/spl",
   "dependencies": {
     "@coral-xyz/anchor": "0.29.0",
+    "@noble/hashes": "1.4.0",
     "@solana/buffer-layout": "4.0.1",
     "@solana/buffer-layout-utils": "0.2.0",
     "@solana/spl-token": "0.3.8",

--- a/packages/spl/src/index.ts
+++ b/packages/spl/src/index.ts
@@ -1,6 +1,7 @@
 export { ClaimableTokensProgram } from './claimable-tokens/ClaimableTokensProgram'
 export { RewardManagerInstruction } from './reward-manager/constants'
 export { RewardManagerProgram } from './reward-manager/RewardManagerProgram'
+export { Secp256k1Program } from './secp256k1/Secp256k1Program'
 export { ethAddress } from './layout-utils'
 export * from './associated-token'
 export * from './payment-router'

--- a/packages/spl/src/reward-manager/RewardManagerProgram.test.ts
+++ b/packages/spl/src/reward-manager/RewardManagerProgram.test.ts
@@ -85,7 +85,7 @@ describe('RewardManagerProgram', () => {
     expect(attestation.antiAbuseOracleEthAddress).toBe(null)
   })
 
-  it('decodes the account data', () => {
+  it('decodes the account data of a single attestation', () => {
     const data = Buffer.from([
       1, 182, 193, 28, 253, 102, 169, 6, 208, 160, 135, 219, 13, 183, 183, 115,
       130, 16, 205, 49, 82, 187, 88, 76, 117, 96, 175, 210, 205, 23, 16, 17, 91,
@@ -136,6 +136,106 @@ describe('RewardManagerProgram', () => {
     )
     expect(decoded.messages[0].attestation.antiAbuseOracleEthAddress).toBe(null)
     expect(decoded.messages.length === 1)
+  })
+
+  it('decodes the account data of three attestations', () => {
+    const data = Buffer.from([
+      1, 89, 83, 235, 128, 55, 250, 76, 101, 233, 208, 198, 87, 196, 72, 83,
+      209, 60, 0, 168, 125, 185, 129, 114, 121, 85, 236, 215, 187, 200, 142,
+      245, 203, 3, 242, 137, 121, 147, 149, 29, 83, 167, 227, 235, 34, 66, 214,
+      161, 77, 32, 40, 20, 13, 200, 38, 3, 48, 178, 184, 224, 69, 105, 57, 71,
+      185, 90, 101, 197, 87, 24, 61, 0, 57, 125, 95, 0, 225, 245, 5, 0, 0, 0, 0,
+      95, 98, 58, 49, 48, 54, 56, 55, 57, 61, 62, 49, 48, 48, 52, 54, 53, 48,
+      52, 49, 55, 95, 152, 17, 186, 62, 171, 31, 44, 217, 162, 223, 237, 177,
+      158, 140, 42, 105, 114, 157, 200, 182, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+      0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+      0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 229, 178, 86,
+      211, 2, 234, 47, 78, 4, 184, 243, 191, 216, 105, 90, 222, 20, 122, 182,
+      141, 152, 17, 186, 62, 171, 31, 44, 217, 162, 223, 237, 177, 158, 140, 42,
+      105, 114, 157, 200, 182, 38, 3, 48, 178, 184, 224, 69, 105, 57, 71, 185,
+      90, 101, 197, 87, 24, 61, 0, 57, 125, 95, 0, 225, 245, 5, 0, 0, 0, 0, 95,
+      98, 58, 49, 48, 54, 56, 55, 57, 61, 62, 49, 48, 48, 52, 54, 53, 48, 52,
+      49, 55, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+      0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+      0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+      0, 0, 0, 0, 0, 0, 152, 17, 186, 62, 171, 31, 44, 217, 162, 223, 237, 177,
+      158, 140, 42, 105, 114, 157, 200, 182, 44, 214, 106, 57, 49, 195, 101,
+      150, 239, 176, 55, 176, 103, 83, 71, 109, 206, 107, 78, 134, 38, 3, 48,
+      178, 184, 224, 69, 105, 57, 71, 185, 90, 101, 197, 87, 24, 61, 0, 57, 125,
+      95, 0, 225, 245, 5, 0, 0, 0, 0, 95, 98, 58, 49, 48, 54, 56, 55, 57, 61,
+      62, 49, 48, 48, 52, 54, 53, 48, 52, 49, 55, 95, 152, 17, 186, 62, 171, 31,
+      44, 217, 162, 223, 237, 177, 158, 140, 42, 105, 114, 157, 200, 182, 0, 0,
+      0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+      0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+      0, 0, 0, 0, 0, 100, 112, 218, 243, 189, 50, 245, 1, 69, 18, 188, 223, 13,
+      2, 35, 47, 86, 64, 165, 189, 152, 17, 186, 62, 171, 31, 44, 217, 162, 223,
+      237, 177, 158, 140, 42, 105, 114, 157, 200, 182, 38, 3, 48, 178, 184, 224,
+      69, 105, 57, 71, 185, 90, 101, 197, 87, 24, 61, 0, 57, 125, 95, 0, 225,
+      245, 5, 0, 0, 0, 0, 95, 98, 58, 49, 48, 54, 56, 55, 57, 61, 62, 49, 48,
+      48, 52, 54, 53, 48, 52, 49, 55, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+      0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+      0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+      0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 152, 17, 186, 62, 171, 31, 44,
+      217, 162, 223, 237, 177, 158, 140, 42, 105, 114, 157, 200, 182
+    ])
+    const decoded = RewardManagerProgram.decodeAttestationsAccountData(data)
+    expect(decoded.version).toBe(1)
+    expect(decoded.rewardManagerState.toBase58()).toBe(
+      '71hWFVYokLaN1PNYzTAWi13EfJ7Xt9VbSWUKsXUT8mxE'
+    )
+    expect(decoded.count).toBe(3)
+
+    // Check message 0: DN Attestation
+    expect(decoded.messages[0].senderEthAddress).toBe(
+      '0xf2897993951d53a7e3eb2242d6a14d2028140dc8'
+    )
+    expect(decoded.messages[0].attestation.recipientEthAddress).toBe(
+      '0x260330b2b8e045693947b95a65c557183d00397d'
+    )
+    expect(decoded.messages[0].attestation.amount).toBe(BigInt(100000000))
+    expect(decoded.messages[0].attestation.disbursementId).toBe(
+      'b:106879=>1004650417'
+    )
+    expect(decoded.messages[0].attestation.antiAbuseOracleEthAddress).toBe(
+      '0x9811ba3eab1f2cd9a2dfedb19e8c2a69729dc8b6'
+    )
+    expect(decoded.messages[0].operator).toBe(
+      '0xe5b256d302ea2f4e04b8f3bfd8695ade147ab68d'
+    )
+
+    // Check message 1: Oracle Attestation
+    expect(decoded.messages[1].senderEthAddress).toBe(
+      '0x9811ba3eab1f2cd9a2dfedb19e8c2a69729dc8b6'
+    )
+    expect(decoded.messages[1].attestation.recipientEthAddress).toBe(
+      '0x260330b2b8e045693947b95a65c557183d00397d'
+    )
+    expect(decoded.messages[1].attestation.amount).toBe(BigInt(100000000))
+    expect(decoded.messages[1].attestation.disbursementId).toBe(
+      'b:106879=>1004650417'
+    )
+    expect(decoded.messages[1].attestation.antiAbuseOracleEthAddress).toBe(null)
+    expect(decoded.messages[1].operator).toBe(
+      '0x9811ba3eab1f2cd9a2dfedb19e8c2a69729dc8b6'
+    )
+
+    // Check message 2: DN Attestation
+    expect(decoded.messages[2].senderEthAddress).toBe(
+      '0x2cd66a3931c36596efb037b06753476dce6b4e86'
+    )
+    expect(decoded.messages[2].attestation.recipientEthAddress).toBe(
+      '0x260330b2b8e045693947b95a65c557183d00397d'
+    )
+    expect(decoded.messages[2].attestation.amount).toBe(BigInt(100000000))
+    expect(decoded.messages[2].attestation.disbursementId).toBe(
+      'b:106879=>1004650417'
+    )
+    expect(decoded.messages[2].attestation.antiAbuseOracleEthAddress).toBe(
+      '0x9811ba3eab1f2cd9a2dfedb19e8c2a69729dc8b6'
+    )
+    expect(decoded.messages[2].operator).toBe(
+      '0x6470daf3bd32f5014512bcdf0d02232f5640a5bd'
+    )
   })
 
   it('encodes the evaluate attestation instruction data', () => {

--- a/packages/spl/src/reward-manager/RewardManagerProgram.ts
+++ b/packages/spl/src/reward-manager/RewardManagerProgram.ts
@@ -84,7 +84,7 @@ export class RewardManagerProgram {
       seq(
         struct<VerifiedMessage>([
           ethAddress('senderEthAddress'),
-          attestationLayout('message'),
+          attestationLayout('attestation'),
           // Though the actual attestation message is only 83 bytes, we allocate
           // 128 bytes for each element of this array on the program side.
           // Thus we add 45 bytes of padding here to be consistent.
@@ -508,8 +508,7 @@ export class RewardManagerProgram {
 
   public static decodeAttestationsAccountData(data: Buffer | Uint8Array) {
     const decoded = this.layouts.attestationsAccountData.decode(data)
-    // decoded.messages = decoded.messages.filter((m) => m.index !== 0)
-    for (let i = 0; i < decoded.messages.length; i++) {
+    for (let i = 0; i < decoded.count; i++) {
       if (
         decoded.messages[i].attestation.antiAbuseOracleEthAddress ===
         '0x0000000000000000000000000000000000000000'

--- a/packages/spl/src/reward-manager/RewardManagerProgram.ts
+++ b/packages/spl/src/reward-manager/RewardManagerProgram.ts
@@ -508,7 +508,8 @@ export class RewardManagerProgram {
 
   public static decodeAttestationsAccountData(data: Buffer | Uint8Array) {
     const decoded = this.layouts.attestationsAccountData.decode(data)
-    for (let i = 0; i < decoded.count; i++) {
+    decoded.messages = decoded.messages.slice(0, decoded.count)
+    for (let i = 0; i < decoded.messages.length; i++) {
       if (
         decoded.messages[i].attestation.antiAbuseOracleEthAddress ===
         '0x0000000000000000000000000000000000000000'

--- a/packages/spl/src/secp256k1/Secp256k1Program.test.ts
+++ b/packages/spl/src/secp256k1/Secp256k1Program.test.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect } from 'vitest'
+
+import { Secp256k1Program } from './Secp256k1Program'
+
+describe('Secp256k1Program', () => {
+  it('returns true when signature is valid and matches instruction', () => {
+    // Data from a valid submitAttestation SECP instruction
+    const validSignature =
+      '012000000c000061004500008fcfa10bd3808570987dbb5b1ef4ab74400fbfdaf89b2e6f97f95f1306b468b10b1a18df9569b07d9d7b81b241d6fc99d9ec782e4e449f5c3c63836ed52c9344d3de5c3133fead711e421af545822f09bd78cb390068d5397bb16195ea47091010f3abb8fc6b5cdfa65f00e1f505000000005f623a33383639383d3e3530373431303135335f00b6462e955da5841b6d9e1e2529b830f00f31bf'
+    expect(
+      Secp256k1Program.verifySignature(
+        Secp256k1Program.decode(Buffer.from(validSignature, 'hex'))
+      )
+    )
+  })
+
+  it('throws when the signature recovery is off the curve', () => {
+    // Data from an invalid submitAttestation SECP instruction (malformed signature)
+    const invalidSignature =
+      '012000000c0000610030000000b6462e955da5841b6d9e1e2529b830f00f31bf00d405b277dc948f97d7b7db8648cb16590d66084ba49642fedb08380ce5027a95d0a895287a3331332e7ad13daba87eed5c70820a19ca2eb6cc0ea1eb4695ba0081729dc83c157f41de7df4b72fc7e90d8d64d5aa5f00e1f505000000005f72656665727265643a353339343735333137'
+    expect(() =>
+      Secp256k1Program.verifySignature(
+        Secp256k1Program.decode(Buffer.from(invalidSignature, 'hex'))
+      )
+    ).toThrow()
+  })
+})

--- a/packages/spl/src/secp256k1/Secp256k1Program.ts
+++ b/packages/spl/src/secp256k1/Secp256k1Program.ts
@@ -1,0 +1,106 @@
+import { keccak_256 } from '@noble/hashes/sha3'
+import * as secp from '@noble/secp256k1'
+import { struct, u8, u16, blob } from '@solana/buffer-layout'
+import {
+  Secp256k1Program as BaseSecp256k1Program,
+  TransactionInstruction
+} from '@solana/web3.js'
+
+/**
+ * The layout of Secp256k1 instruction data. Copied from @solana/web3.js because
+ * it isn't exported there.
+ *
+ * @see {@link https://github.com/solana-labs/solana-web3.js/blob/d0d4d3e4d96f4fc7a4a9adf24e189be60183f460/packages/library-legacy/src/programs/secp256k1.ts#L47 SECP256K1_INSTRUCTION_LAYOUT}
+ */
+const SECP256K1_INSTRUCTION_LAYOUT = struct<
+  Readonly<{
+    ethAddress: Uint8Array
+    ethAddressInstructionIndex: number
+    ethAddressOffset: number
+    messageDataOffset: number
+    messageDataSize: number
+    messageInstructionIndex: number
+    numSignatures: number
+    recoveryId: number
+    signature: Uint8Array
+    signatureInstructionIndex: number
+    signatureOffset: number
+  }>
+>([
+  u8('numSignatures'),
+  u16('signatureOffset'),
+  u8('signatureInstructionIndex'),
+  u16('ethAddressOffset'),
+  u8('ethAddressInstructionIndex'),
+  u16('messageDataOffset'),
+  u16('messageDataSize'),
+  u8('messageInstructionIndex'),
+  blob(20, 'ethAddress'),
+  blob(64, 'signature'),
+  u8('recoveryId')
+])
+
+type DecodedSecp256k1Instruction = ReturnType<typeof Secp256k1Program.decode>
+
+/**
+ * Extends the @solana/web3.js Secp256k1Program API with a decode method
+ * and other useful utilities.
+ */
+export class Secp256k1Program extends BaseSecp256k1Program {
+  /**
+   * Decodes an Secp256k1 instruction data into a Typescript object.
+   * Useful for debugging.
+   */
+  static decode(instructionOrData: TransactionInstruction | Uint8Array) {
+    const data =
+      instructionOrData instanceof TransactionInstruction
+        ? instructionOrData.data
+        : instructionOrData
+    const decoded = SECP256K1_INSTRUCTION_LAYOUT.decode(data)
+    const message = data.subarray(
+      decoded.messageDataOffset,
+      decoded.messageDataOffset + decoded.messageDataSize
+    )
+    return {
+      ...decoded,
+      message
+    }
+  }
+
+  /**
+   * Creates an Ethereum address from a secp256k1 public key.
+   *
+   * Port of the secp256k1 program's Rust code.
+   * @see {@link https://github.com/solana-labs/solana/blob/27eff8408b7223bb3c4ab70523f8a8dca3ca6645/sdk/src/secp256k1_instruction.rs#L906C1-L914C2 construct_eth_pubkey}
+   */
+  static constructEthPubkey(pubkey: Uint8Array) {
+    return keccak_256(Buffer.from(pubkey.subarray(1))).subarray(12)
+  }
+
+  /**
+   * Recovers the true signer for a decoded instruction.
+   */
+  static recoverSigner(decoded: DecodedSecp256k1Instruction) {
+    const messageHash = keccak_256(decoded.message)
+    return secp.recoverPublicKey(
+      messageHash,
+      decoded.signature,
+      decoded.recoveryId
+    )
+  }
+
+  /**
+   * Verifies the true signer for a decoded instruction matches the one
+   * in the instruction data.
+   */
+  static verifySignature(decoded: DecodedSecp256k1Instruction) {
+    const signer = Secp256k1Program.recoverSigner(decoded)
+    const address = Secp256k1Program.constructEthPubkey(signer)
+    for (let i = 0; i < address.length; i++) {
+      if (address.at(i) !== decoded.ethAddress.at(i)) {
+        return false
+      }
+    }
+    return address.byteLength === decoded.ethAddress.byteLength
+  }
+}


### PR DESCRIPTION
### Description

Adds helpful methods to the Secp256k1Program from @solana/web3.js for decoding and recovering signers. Useful for us if we want to check why transactions are failing.

Stopped short of adding an override to the program to validate on creating instructions, but could see that being useful... instead, added the check to the relay itself so it'll error quickly if the instruction signature doesn't match the signer.

Also fixes some minor things when decoding the existing attestations in the verified messages account and added more tests.
