### PR TITLE
[PAY-2731] Web FilterButton transparent when disabled

### DIFF
--- a/packages/harmony/src/components/button/FilterButton/FilterButton.tsx
+++ b/packages/harmony/src/components/button/FilterButton/FilterButton.tsx
@@ -16,7 +16,7 @@ export const FilterButton = forwardRef<HTMLButtonElement, FilterButtonProps>(
       label,
       options,
       onSelect,
-      isDisabled,
+      disabled,
       variant = 'fillContainer',
       size = 'default',
       iconRight = IconCaretDown,
@@ -90,6 +90,7 @@ export const FilterButton = forwardRef<HTMLButtonElement, FilterButtonProps>(
       fontSize: typography.size.s,
       fontWeight: typography.weight.demiBold,
       lineHeight: typography.lineHeight.s,
+      opacity: disabled ? 0.6 : 1,
 
       '&:hover': {
         border: `1px solid ${color.neutral.n800}`,
@@ -173,7 +174,7 @@ export const FilterButton = forwardRef<HTMLButtonElement, FilterButtonProps>(
             ? IconCloseAlt
             : iconRight
         }
-        disabled={isDisabled}
+        disabled={disabled}
         aria-haspopup='listbox'
         aria-expanded={isOpen}
       >

--- a/packages/harmony/src/components/button/FilterButton/types.ts
+++ b/packages/harmony/src/components/button/FilterButton/types.ts
@@ -68,7 +68,7 @@ export type FilterButtonProps = {
   /**
    * Whether interaction is disabled
    */
-  isDisabled?: boolean
+  disabled?: boolean
 
   /**
    * Popup anchor origin

--- a/packages/web/src/components/upload/TrackPreview.tsx
+++ b/packages/web/src/components/upload/TrackPreview.tsx
@@ -161,7 +161,7 @@ export const TrackPreview = (props: TrackPreviewProps) => {
               onSelect={(label) => onEditStemCategory(label as StemCategory)}
               selection={stemCategory?.toString() ?? null}
               popupZIndex={zIndex.STEMS_AND_DOWNLOADS_FILTER_BUTTON_POPUP}
-              isDisabled={!allowCategorySwitch}
+              disabled={!allowCategorySwitch}
             />
           </Box>
         ) : null}

--- a/packages/web/src/pages/dashboard-page/components/ArtistContentSection.tsx
+++ b/packages/web/src/pages/dashboard-page/components/ArtistContentSection.tsx
@@ -116,7 +116,7 @@ export const ArtistContentSection = () => {
             options={filterButtonOptions}
             popupAnchorOrigin={{ vertical: 'bottom', horizontal: 'left' }}
             popupTransformOrigin={{ vertical: 'top', horizontal: 'left' }}
-            isDisabled={isFilterButtonDisabled}
+            disabled={isFilterButtonDisabled}
           />
         </Flex>
         <Flex>


### PR DESCRIPTION
### Description
Sets FilterButton opacity to 0.6 when `disabled` is true.

Also changes the prop name to `disabled` from `isDisabled` to match our other components.

### How Has This Been Tested?

Local web stage
<img width="1126" alt="Screenshot 2024-04-23 at 9 58 05 PM" src="https://github.com/AudiusProject/audius-protocol/assets/3893871/ba7db128-1330-403a-8073-849a7cd6756b">
