### PR TITLE
[PAY-2745] Hide play count for premium tracks

### DIFF
--- a/packages/web/src/components/tracks-table/TracksTable.tsx
+++ b/packages/web/src/components/tracks-table/TracksTable.tsx
@@ -263,8 +263,15 @@ export const TracksTable = ({
   const renderPlaysCell = useCallback((cellInfo: TrackCell) => {
     const track = cellInfo.row.original
     const { plays } = track
+    const isOwner = track.owner_id === userId
     // negative plays indicates the track is hidden
     if (plays === -1) return '-'
+    if (
+      track.is_stream_gated &&
+      isContentUSDCPurchaseGated(track.stream_conditions) &&
+      !isOwner
+    )
+      return null
     return formatCount(track.plays)
   }, [])
 


### PR DESCRIPTION
### Description
* Fully remove plays column if all tracks in a collection are premium
* In the case where the collection has both premium and non-premium tracks, display blank space instead of the play count. (couldn't get screenshot for this bc we can't add premium tracks to playlists yet, but I confirmed it works manually).

### How Has This Been Tested?

Local web stage
<img width="943" alt="Screenshot 2024-04-23 at 10 20 48 PM" src="https://github.com/AudiusProject/audius-protocol/assets/3893871/66f5f62a-8ca2-4e48-a55c-82e883e5c7bf">

Artist dashboard still works
<img width="1126" alt="Screenshot 2024-04-23 at 9 58 05 PM" src="https://github.com/AudiusProject/audius-protocol/assets/3893871/039f8d31-8882-4f90-af15-9bd6875eeede">
