### PR TITLE
Fix solana relay cache key

### DIFF
--- a/packages/discovery-provider/plugins/pedalboard/apps/solana-relay/src/redis.ts
+++ b/packages/discovery-provider/plugins/pedalboard/apps/solana-relay/src/redis.ts
@@ -43,7 +43,7 @@ type DiscoveryNode = {
 
 export const getCachedDiscoveryNodes = async () => {
   const redis = await getRedisConnection()
-  const key = 'all-discovery-nodes'
+  const key = 'all-discovery-nodes-with-wallets'
   const json = await redis.get(key)
   return parseArray(json).filter(
     (p): p is DiscoveryNode =>


### PR DESCRIPTION
Other nodes aren't caching the transactions because they don't recognize the discovery node that signed the request. This is because the Redis key moved since this code was written for where discovery nodes are cached.