### PR TITLE
[INF-670] Add check for wildcard deps in public packages

### DIFF
--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -37,6 +37,9 @@ jobs:
       - name: Checkout Repo
         uses: actions/checkout@v3
 
+      - name: Check wildcard dependencies
+        run: bash ./scripts/check-wildcard-deps.sh
+
       - uses: actions/setup-node@v4
         with:
           node-version: 18

--- a/packages/libs/src/sdk/examples/signed-request/package.json
+++ b/packages/libs/src/sdk/examples/signed-request/package.json
@@ -5,7 +5,7 @@
     "start": "ts-node index.ts"
   },
   "dependencies": {
-    "@audius/sdk": "*",
+    "@audius/sdk": "latest",
     "prompt-sync": "4.2.0",
     "ts-node-dev": "2.0.0",
     "typescript": "5.0.2",

--- a/scripts/check-wildcard-deps.sh
+++ b/scripts/check-wildcard-deps.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+
+should_error=false
+
+echo "Checking public packages for dependencies with '*' version..."
+
+# Find all package.json files in the current directory and its subdirectories
+find . -name 'package.json' -not \( -path "./node_modules/*" -o -path "./**/node_modules/*" \) | while read -r file; do
+    # Check if "private" is not set to true in the package.json file
+    if ! grep -q '"private":\s*true' "$file"; then
+        echo "Checking $file"
+        
+        # Check if any dependencies have a '*' version
+        dependencies_with_star=$(jq -r '.dependencies // {} | to_entries[] | select(.value | endswith("*")) | .key' "$file")
+        dev_dependencies_with_star=$(jq -r '.devDependencies // {} | to_entries[] | select(.value | endswith("*")) | .key' "$file")
+        
+        if [ -n "$dependencies_with_star" ] || [ -n "$dev_dependencies_with_star" ]; then
+            echo "Found dependencies with '*' version in $file"
+            echo "Dependencies with '*' version: $dependencies_with_star"
+            echo "Dev dependencies with '*' version: $dev_dependencies_with_star"
+            echo ""
+            should_error=true
+        fi
+    fi
+done
+
+if [[ $should_error = true ]]; then
+  exit 1
+fi
+
+echo "No '*' version dependencies found in public packages!"

--- a/scripts/check-wildcard-deps.sh
+++ b/scripts/check-wildcard-deps.sh
@@ -6,7 +6,7 @@ should_error=false
 echo "Checking public packages for dependencies with '*' version..."
 
 # Find all package.json files in the current directory and its subdirectories
-find . -name 'package.json' -not \( -path "./node_modules/*" -o -path "./**/node_modules/*" \) | while read -r file; do
+while IFS= read -r file; do
     # Check if "private" is not set to true in the package.json file
     if ! grep -q '"private":\s*true' "$file"; then
         echo "Checking $file"
@@ -23,10 +23,13 @@ find . -name 'package.json' -not \( -path "./node_modules/*" -o -path "./**/node
             should_error=true
         fi
     fi
-done
+done <<< "$(find . -name 'package.json' -not \( -path "./node_modules/*" -o -path "./**/node_modules/*" \))"
 
 if [[ $should_error = true ]]; then
-  exit 1
+    echo "Public packages should not contain dependencies with '*' version!"
+    echo "If you are trying to use an internal package from the monorepo, please specify the exact version. It will get updated automatically via changesets."
+    echo "If you are trying to use the latest version of an external package, please use 'latest'"
+    exit 1
 fi
 
 echo "No '*' version dependencies found in public packages!"


### PR DESCRIPTION
### Description

Add a step to `publish-packages.yml` that prevents us from publishing packages containing a wildcard `*` dependency. This is to prevent consumers from getting the wrong version of a dependency when using an older version of one of our packages

### How Has This Been Tested?

Confirmed script accurately checks for wildcard deps in public package.jsons
