### PR TITLE
[PROTO-1787] Add full screen oauth variant

### DIFF
--- a/docs/docs/developers/guides/log-in-with-audius.mdx
+++ b/docs/docs/developers/guides/log-in-with-audius.mdx
@@ -348,6 +348,8 @@ You must open this page with the required URL parameters, described below.
   whether the auth flow response parameters will be encoded in the query string or the fragment
   component of the redirect_uri when redirecting back to your app. Default behavior is equivalent to
   "fragment". We recommend NOT changing this if possible.
+- `display` _optional_ `"popup" | "fullScreen"` - determines whether the auth flow expects to be
+  rendered in a popup or a full screen view. Defaulted to `"popup"` if unspecified.
 
 **Example**
 

--- a/packages/ddex/webapp/client/src/pages/Login/Login.tsx
+++ b/packages/ddex/webapp/client/src/pages/Login/Login.tsx
@@ -1,9 +1,10 @@
 import { useCallback, useEffect } from 'react'
 
 import { Button, Flex } from '@audius/harmony'
+import { useSearchParams } from 'react-router-dom'
+
 import { useAudiusSdk } from 'providers/AudiusSdkProvider'
 import { useAuth } from 'providers/AuthProvider'
-import { useSearchParams } from 'react-router-dom'
 
 import styles from './Login.module.css'
 

--- a/packages/ddex/webapp/client/src/pages/Login/Login.tsx
+++ b/packages/ddex/webapp/client/src/pages/Login/Login.tsx
@@ -1,10 +1,9 @@
 import { useCallback, useEffect } from 'react'
 
 import { Button, Flex } from '@audius/harmony'
-import { useSearchParams } from 'react-router-dom'
-
 import { useAudiusSdk } from 'providers/AudiusSdkProvider'
 import { useAuth } from 'providers/AuthProvider'
+import { useSearchParams } from 'react-router-dom'
 
 import styles from './Login.module.css'
 
@@ -20,7 +19,8 @@ const Login = () => {
     if (audiusSdk && auto) {
       audiusSdk.oauth!.login({
         scope: 'write',
-        redirectUri: new URL(window.location.href).origin
+        redirectUri: new URL(window.location.href).origin,
+        display: 'fullScreen'
       })
     }
   }, [audiusSdk, auto])

--- a/packages/libs/src/sdk/oauth/OAuth.ts
+++ b/packages/libs/src/sdk/oauth/OAuth.ts
@@ -191,11 +191,13 @@ export class OAuth {
   login({
     scope = 'read',
     params,
-    redirectUri = 'postMessage'
+    redirectUri = 'postMessage',
+    display = 'popup'
   }: {
     scope?: OAuthScope
     params?: WriteOnceParams
     redirectUri?: string
+    display?: 'popup' | 'fullScreen'
   }) {
     const scopeFormatted = typeof scope === 'string' ? [scope] : scope
     if (!this.config.appName && !this.apiKey) {
@@ -249,7 +251,8 @@ export class OAuth {
 
     const fullOauthUrl = `${
       OAUTH_URL[this.env]
-    }?scope=${effectiveScope}&state=${csrfToken}&redirect_uri=${redirectUri}&origin=${originURISafe}&${appIdURIParam}${writeOnceParams}`
+    }?scope=${effectiveScope}&state=${csrfToken}&redirect_uri=${redirectUri}&origin=${originURISafe}&${appIdURIParam}${writeOnceParams}&display=${display}`
+
     if (redirectUri === 'postMessage') {
       this.activePopupWindow = window.open(fullOauthUrl, '', windowOptions)
       this._clearPopupCheckInterval()

--- a/packages/web/src/pages/oauth-login-page/OAuthLoginPage.module.css
+++ b/packages/web/src/pages/oauth-login-page/OAuthLoginPage.module.css
@@ -6,6 +6,7 @@
   bottom: 0;
   justify-content: center;
   display: flex;
+  overflow: scroll;
 }
 
 .popup {

--- a/packages/web/src/pages/oauth-login-page/OAuthLoginPage.module.css
+++ b/packages/web/src/pages/oauth-login-page/OAuthLoginPage.module.css
@@ -1,12 +1,15 @@
-.bgWhite {
-  background-color: var(--harmony-static-white);
+.wrapper {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  justify-content: center;
+  display: flex;
 }
 
-.wrapper {
-  margin: 0 auto;
-  justify-content: center;
-  width: 375px;
-  display: flex;
+.popup {
+  background-color: var(--harmony-static-white);
 }
 
 .centeredContent {
@@ -29,7 +32,7 @@
   text-overflow: ellipsis;
 }
 
-.loadingStateContainer {
+.popup .loadingStateContainer {
   margin-top: 200px;
 }
 

--- a/packages/web/src/pages/oauth-login-page/OAuthLoginPage.tsx
+++ b/packages/web/src/pages/oauth-login-page/OAuthLoginPage.tsx
@@ -1,4 +1,4 @@
-import { FormEvent, useLayoutEffect, useState } from 'react'
+import { FormEvent, useState } from 'react'
 
 import { Name, ErrorLevel } from '@audius/common/models'
 import { accountSelectors, signOutActions } from '@audius/common/store'
@@ -35,12 +35,6 @@ const { signOut } = signOutActions
 const { getAccountUser } = accountSelectors
 
 export const OAuthLoginPage = () => {
-  useLayoutEffect(() => {
-    document.body.classList.add(styles.bgWhite)
-    return () => {
-      document.body.classList.remove(styles.bgWhite)
-    }
-  }, [])
   const record = useRecord()
   const account = useSelector(getAccountUser)
   const isLoggedIn = Boolean(account)
@@ -156,7 +150,8 @@ export const OAuthLoginPage = () => {
     appImage,
     userEmail,
     authorize,
-    txParams
+    txParams,
+    display
   } = useOAuthSetup({
     onError: handleAuthError,
     onPendingTransactionApproval: handlePendingTransactionApproval,
@@ -247,7 +242,7 @@ export const OAuthLoginPage = () => {
 
   if (queryParamsError) {
     return (
-      <ContentWrapper>
+      <ContentWrapper display={display}>
         <div className={cn(styles.centeredContent, styles.titleContainer)}>
           <span className={styles.errorText}>{queryParamsError}</span>
         </div>
@@ -256,7 +251,7 @@ export const OAuthLoginPage = () => {
   }
   if (loading) {
     return (
-      <ContentWrapper>
+      <ContentWrapper display={display}>
         <div
           className={cn(styles.centeredContent, styles.loadingStateContainer)}
         >
@@ -271,7 +266,7 @@ export const OAuthLoginPage = () => {
   }
 
   return (
-    <ContentWrapper>
+    <ContentWrapper display={display}>
       <Flex alignItems='center' direction='column'>
         <Flex gap='l' alignItems='center' mb='l'>
           <Flex h='88px' w='88px'>

--- a/packages/web/src/pages/oauth-login-page/components/ContentWrapper.tsx
+++ b/packages/web/src/pages/oauth-login-page/components/ContentWrapper.tsx
@@ -1,9 +1,34 @@
 import { ReactNode } from 'react'
 
-import styles from '../OAuthLoginPage.module.css'
+import { Paper } from '@audius/harmony'
+import cn from 'classnames'
 
-export const ContentWrapper = ({ children }: { children: ReactNode }) => (
-  <div className={styles.wrapper}>
-    <div className={styles.container}>{children}</div>
+import styles from '../OAuthLoginPage.module.css'
+import { Display } from '../types'
+
+export const ContentWrapper = ({
+  display,
+  children
+}: {
+  display: Display
+  children: ReactNode
+}) => (
+  <div className={cn(styles.wrapper, { [styles.popup]: display === 'popup' })}>
+    {display === 'popup' ? (
+      <div className={styles.container}>{children}</div>
+    ) : (
+      <Paper
+        shadow='mid'
+        w='375px'
+        direction='column'
+        pv='3xl'
+        ph='xl'
+        mt='3xl'
+        alignSelf='flex-start'
+        borderRadius='xl'
+      >
+        {children}
+      </Paper>
+    )}
   </div>
 )

--- a/packages/web/src/pages/oauth-login-page/components/ContentWrapper.tsx
+++ b/packages/web/src/pages/oauth-login-page/components/ContentWrapper.tsx
@@ -23,7 +23,7 @@ export const ContentWrapper = ({
         direction='column'
         pv='3xl'
         ph='xl'
-        mt='3xl'
+        mv='3xl'
         alignSelf='flex-start'
         borderRadius='xl'
       >

--- a/packages/web/src/pages/oauth-login-page/hooks.ts
+++ b/packages/web/src/pages/oauth-login-page/hooks.ts
@@ -17,9 +17,9 @@ import { audiusBackendInstance } from 'services/audius-backend/audius-backend-in
 import { audiusSdk } from 'services/audius-sdk'
 import * as errorActions from 'store/errors/actions'
 import { reportToSentry } from 'store/errors/reportToSentry'
-import { Display } from './types'
 
 import { messages } from './messages'
+import { Display } from './types'
 import {
   authWrite,
   formOAuthResponse,
@@ -132,7 +132,8 @@ export const useParsedQueryParams = () => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isRedirectValid, parsedOrigin, parsedRedirectUri, search])
 
-  const display: Display = displayQueryParam === 'fullScreen' ? 'fullScreen' : 'popup'
+  const display: Display =
+    displayQueryParam === 'fullScreen' ? 'fullScreen' : 'popup'
 
   return {
     apiKey,

--- a/packages/web/src/pages/oauth-login-page/hooks.ts
+++ b/packages/web/src/pages/oauth-login-page/hooks.ts
@@ -17,6 +17,7 @@ import { audiusBackendInstance } from 'services/audius-backend/audius-backend-in
 import { audiusSdk } from 'services/audius-sdk'
 import * as errorActions from 'store/errors/actions'
 import { reportToSentry } from 'store/errors/reportToSentry'
+import { Display } from './types'
 
 import { messages } from './messages'
 import {
@@ -47,6 +48,7 @@ export const useParsedQueryParams = () => {
     api_key: apiKey,
     origin,
     tx,
+    display: displayQueryParam,
     ...rest
   } = queryString.parse(search)
 
@@ -130,6 +132,8 @@ export const useParsedQueryParams = () => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isRedirectValid, parsedOrigin, parsedRedirectUri, search])
 
+  const display: Display = displayQueryParam === 'fullScreen' ? 'fullScreen' : 'popup'
+
   return {
     apiKey,
     appName,
@@ -143,7 +147,8 @@ export const useParsedQueryParams = () => {
     parsedOrigin,
     error,
     tx,
-    txParams
+    txParams,
+    display
   }
 }
 
@@ -181,6 +186,7 @@ export const useOAuthSetup = ({
     parsedOrigin,
     txParams,
     tx,
+    display,
     error: initError
   } = useParsedQueryParams()
   const accountIsLoading = useSelector((state: CommonState) => {
@@ -518,6 +524,7 @@ export const useOAuthSetup = ({
     userEmail,
     authorize,
     tx,
-    txParams: txParams as WriteOnceParams
+    txParams: txParams as WriteOnceParams,
+    display
   }
 }

--- a/packages/web/src/pages/oauth-login-page/types.ts
+++ b/packages/web/src/pages/oauth-login-page/types.ts
@@ -1,0 +1,1 @@
+export type Display = 'popup' | 'fullScreen'


### PR DESCRIPTION
### Description

Allow DDEX to pass a flag and use a full page oauth variant

<img width="1440" alt="image" src="https://github.com/AudiusProject/audius-protocol/assets/2731362/f289bbf1-02f5-42cc-912f-da6f742717d3">

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._

```
npm run web:stage
```
Test url:
http://localhost:3001/oauth/auth?scope=write&api_key=92ae5d1be6a54327db811c949a3f520cf3e0aa51&redirect_uri=http://127.0.0.1:3000/connect/callback&response_mode=query&display=fullScreen

Also confirmed display=popup works correctly still!