### PR TITLE
Disable hidden album upload feature

### DIFF
--- a/packages/common/src/hooks/useAccessAndRemixSettings.test.ts
+++ b/packages/common/src/hooks/useAccessAndRemixSettings.test.ts
@@ -328,7 +328,7 @@ describe('useAccessAndRemixSettings', () => {
         disableSpecialAccessGateFields: true,
         disableCollectibleGate: true,
         disableCollectibleGateFields: true,
-        disableHidden: false
+        disableHidden: true
       }
       expect(actual).toEqual(expected)
     })
@@ -393,7 +393,7 @@ describe('useAccessAndRemixSettings', () => {
         disableSpecialAccessGateFields: true,
         disableCollectibleGate: true,
         disableCollectibleGateFields: true,
-        disableHidden: false
+        disableHidden: true
       }
       expect(actual).toEqual(expected)
     })

--- a/packages/common/src/hooks/useAccessAndRemixSettings.ts
+++ b/packages/common/src/hooks/useAccessAndRemixSettings.ts
@@ -107,7 +107,7 @@ export const useAccessAndRemixSettings = ({
     disableCollectibleGate || (!isUpload && !isInitiallyHidden)
 
   const disableHidden =
-    isScheduledRelease || (!isUpload && !isInitiallyUnlisted)
+    isAlbum || isScheduledRelease || (!isUpload && !isInitiallyUnlisted)
 
   return {
     disableUsdcGate,


### PR DESCRIPTION
### Description

Per some recent scope changes we have decided to halt some ongoing work around hidden albums. 
This PR disables the changes from this PR https://github.com/AudiusProject/audius-protocol/pull/8191 but since its so simple to disable the feature I decided it was better to leave the supporting logic in and just disable it for now.

### How Has This Been Tested?

web:stage 
- [x] Hidden is no longer selectable at edit upload (with prem flag on)
- [x] Hidden is no longer selectable at album edit (even on an already hidden album)
![image](https://github.com/AudiusProject/audius-protocol/assets/6711655/457bef63-ffb0-482c-9e0c-fa9ea796e0fc)

![image](https://github.com/AudiusProject/audius-protocol/assets/6711655/5fd995c4-9acf-428e-9cfe-a45cc35267df)
