### PR TITLE
[ONC-81] Fix giant track tile visual bug

### DIFF
--- a/packages/web/src/components/track/GiantTrackTile.tsx
+++ b/packages/web/src/components/track/GiantTrackTile.tsx
@@ -650,7 +650,7 @@ export const GiantTrackTile = ({
 
       <ClientOnly>
         {isStreamGated && streamConditions ? (
-          <Box mb='xl' mh='xl' w='100%'>
+          <Box mb='xl' ph='xl' w='100%'>
             <GatedContentSection
               isLoading={isLoading}
               contentId={trackId}


### PR DESCRIPTION
### Description

Fixes this bug
![Screenshot 2024-04-25 at 2 15 53 PM](https://github.com/AudiusProject/audius-protocol/assets/6711655/4c7b691f-d0f7-4e42-8327-4ad65d39467b)

### How Has This Been Tested?

Also double checked other spots to make sure it looks good
- [x] Verified desktop & mobile track page with different gated content (NFT, follow, USDC)
- [x] Verified desktop & mobile collection page
- [x] Verified the "unlock gate" modal (nft)