### PR TITLE
[PAY-2704] Show content type icon in last cell of row in TracksTable

### DIFF
--- a/packages/web/src/components/collections-table/CollectionsTable.module.css
+++ b/packages/web/src/components/collections-table/CollectionsTable.module.css
@@ -36,3 +36,19 @@
 .tableRow.lockedRow {
   background-color: var(--harmony-white);
 }
+
+.typeIcon {
+  position: absolute;
+}
+
+.tableRow:hover .typeIcon {
+  opacity: 0;
+}
+
+.tableRow:hover .overflowMenu {
+  opacity: 1;
+}
+
+.tableRow .overflowMenu {
+  opacity: 0;
+}

--- a/packages/web/src/components/collections-table/CollectionsTable.tsx
+++ b/packages/web/src/components/collections-table/CollectionsTable.tsx
@@ -2,10 +2,11 @@ import { MouseEvent, useCallback, useMemo, useRef } from 'react'
 
 import {
   CollectionMetadata,
-  UserCollectionMetadata
+  UserCollectionMetadata,
+  isContentUSDCPurchaseGated
 } from '@audius/common/models'
 import { formatCount } from '@audius/common/utils'
-import { Flex } from '@audius/harmony'
+import { Flex, IconLock, IconVisibilityHidden } from '@audius/harmony'
 import cn from 'classnames'
 import moment from 'moment'
 import { Cell, Row } from 'react-table'
@@ -138,12 +139,22 @@ export const CollectionsTable = ({
   const overflowMenuRef = useRef<HTMLDivElement>(null)
   const renderOverflowMenuCell = useCallback((cellInfo: CollectionCell) => {
     const collection = cellInfo.row.original
+    const icon = collection.is_private ? (
+      <IconVisibilityHidden color='subdued' size='m' />
+    ) : (
+      <IconLock color='subdued' size='m' />
+    )
     return (
-      <div ref={overflowMenuRef}>
-        <CollectionsTableOverflowMenuButton
-          collectionId={collection.playlist_id}
-        />
-      </div>
+      <>
+        {collection.is_stream_gated || collection.is_private ? (
+          <Flex className={styles.typeIcon}>{icon}</Flex>
+        ) : null}
+        <div ref={overflowMenuRef} className={styles.overflowMenu}>
+          <CollectionsTableOverflowMenuButton
+            collectionId={collection.playlist_id}
+          />
+        </div>
+      </>
     )
   }, [])
 

--- a/packages/web/src/components/collections-table/CollectionsTable.tsx
+++ b/packages/web/src/components/collections-table/CollectionsTable.tsx
@@ -2,8 +2,7 @@ import { MouseEvent, useCallback, useMemo, useRef } from 'react'
 
 import {
   CollectionMetadata,
-  UserCollectionMetadata,
-  isContentUSDCPurchaseGated
+  UserCollectionMetadata
 } from '@audius/common/models'
 import { formatCount } from '@audius/common/utils'
 import { Flex, IconLock, IconVisibilityHidden } from '@audius/harmony'
@@ -139,15 +138,14 @@ export const CollectionsTable = ({
   const overflowMenuRef = useRef<HTMLDivElement>(null)
   const renderOverflowMenuCell = useCallback((cellInfo: CollectionCell) => {
     const collection = cellInfo.row.original
-    const icon = collection.is_private ? (
-      <IconVisibilityHidden color='subdued' size='m' />
-    ) : (
-      <IconLock color='subdued' size='m' />
-    )
+    const Icon = collection.is_private ? IconVisibilityHidden : IconLock
+    const shouldShowIcon = collection.is_stream_gated || collection.is_private
     return (
       <>
-        {collection.is_stream_gated || collection.is_private ? (
-          <Flex className={styles.typeIcon}>{icon}</Flex>
+        {shouldShowIcon ? (
+          <Flex className={styles.typeIcon}>
+            <Icon color='subdued' size='m' />
+          </Flex>
         ) : null}
         <div ref={overflowMenuRef} className={styles.overflowMenu}>
           <CollectionsTableOverflowMenuButton

--- a/packages/web/src/components/collections-table/CollectionsTableOverflowMenuButton.tsx
+++ b/packages/web/src/components/collections-table/CollectionsTableOverflowMenuButton.tsx
@@ -54,7 +54,7 @@ export const CollectionsTableOverflowMenuButton = (
             }}
           >
             <Flex ref={ref}>
-              <IconKebabHorizontal color='subdued' size='xs' />
+              <IconKebabHorizontal color='subdued' size='m' />
             </Flex>
           </Flex>
         )}

--- a/packages/web/src/components/table/components/OverflowMenuButton.module.css
+++ b/packages/web/src/components/table/components/OverflowMenuButton.module.css
@@ -9,8 +9,8 @@
   align-items: center;
 }
 .icon {
-  width: 14px;
-  height: 14px;
+  width: 20px;
+  height: 20px;
   position: relative;
   transition: all 0.07s ease-in-out !important;
 }

--- a/packages/web/src/components/table/components/TableFavoriteButton.module.css
+++ b/packages/web/src/components/table/components/TableFavoriteButton.module.css
@@ -9,7 +9,7 @@
 }
 
 .icon {
-  width: 16px;
-  height: 16px;
+  width: 18px;
+  height: 18px;
   position: relative;
 }

--- a/packages/web/src/components/table/components/TableRepostButton.module.css
+++ b/packages/web/src/components/table/components/TableRepostButton.module.css
@@ -6,8 +6,8 @@
 }
 
 .icon {
-  width: 18px;
-  height: 18px;
+  width: 20px;
+  height: 20px;
 }
 
 .iconContainer {

--- a/packages/web/src/components/tracks-table/TracksTable.module.css
+++ b/packages/web/src/components/tracks-table/TracksTable.module.css
@@ -43,6 +43,10 @@
   opacity: 0;
 }
 
+.trackActionsContainer {
+  margin-left: 0px;
+}
+
 .trackActionsContainer .placeholderButton {
   width: 14px;
 }
@@ -152,4 +156,12 @@
   overflow: hidden;
   white-space: nowrap;
   text-overflow: ellipsis;
+}
+
+.typeIcon {
+  position: absolute;
+}
+
+.tableRow:hover .typeIcon {
+  opacity: 0;
 }

--- a/packages/web/src/components/tracks-table/TracksTable.module.css
+++ b/packages/web/src/components/tracks-table/TracksTable.module.css
@@ -165,3 +165,11 @@
 .tableRow:hover .typeIcon {
   opacity: 0;
 }
+
+.tableRow:hover .overflowMenu {
+  opacity: 1;
+}
+
+.tableRow .overflowMenu {
+  opacity: 0;
+}

--- a/packages/web/src/components/tracks-table/TracksTable.tsx
+++ b/packages/web/src/components/tracks-table/TracksTable.tsx
@@ -4,10 +4,19 @@ import { useGatedContentAccessMap } from '@audius/common/hooks'
 import {
   UID,
   UserTrack,
+  isContentCollectibleGated,
+  isContentFollowGated,
   isContentUSDCPurchaseGated
 } from '@audius/common/models'
 import { formatCount, formatSeconds } from '@audius/common/utils'
-import { IconVisibilityHidden, IconLock, Button, Flex } from '@audius/harmony'
+import {
+  IconVisibilityHidden,
+  IconLock,
+  Button,
+  Flex,
+  IconSpecialAccess,
+  IconCollectible
+} from '@audius/harmony'
 import cn from 'classnames'
 import moment from 'moment'
 import { Cell, Row } from 'react-table'
@@ -410,30 +419,44 @@ export const TracksTable = ({
       const isLocked = !isFetchingNFTAccess && !hasStreamAccess
       const deleted =
         track.is_delete || track._marked_deleted || !!track.user?.is_deactivated
+      const icon = track.is_unlisted ? (
+        <IconVisibilityHidden color='subdued' size='m' />
+      ) : isContentUSDCPurchaseGated(track.stream_conditions) ? (
+        <IconLock color='subdued' size='m' />
+      ) : isContentCollectibleGated(track.stream_conditions) ? (
+        <IconCollectible color='subdued' size='m' />
+      ) : (
+        <IconSpecialAccess color='subdued' size='m' />
+      )
       return (
-        <div ref={overflowMenuRef}>
-          <OverflowMenuButton
-            className={styles.tableActionButton}
-            isDeleted={deleted}
-            includeEdit={!disabledTrackEdit}
-            includeAlbumPage={!isAlbumPage}
-            includeAddToPlaylist={!isLocked && !track.is_stream_gated}
-            includeFavorite={!isLocked}
-            onRemove={onClickRemove}
-            removeText={removeText}
-            handle={track.handle}
-            trackId={track.track_id}
-            uid={track.uid}
-            date={track.date}
-            isFavorited={track.has_current_user_saved}
-            isOwner={track.owner_id === userId}
-            isOwnerDeactivated={!!track.user?.is_deactivated}
-            isArtistPick={track.user?.artist_pick_track_id === track.track_id}
-            index={cellInfo.row.index}
-            trackTitle={track.name}
-            trackPermalink={track.permalink}
-          />
-        </div>
+        <>
+          {track.is_stream_gated || track.is_unlisted ? (
+            <Flex className={styles.typeIcon}>{icon}</Flex>
+          ) : null}
+          <div ref={overflowMenuRef} className={styles.overflowMenu}>
+            <OverflowMenuButton
+              className={styles.tableActionButton}
+              isDeleted={deleted}
+              includeEdit={!disabledTrackEdit}
+              includeAlbumPage={!isAlbumPage}
+              includeAddToPlaylist={!isLocked && !track.is_stream_gated}
+              includeFavorite={!isLocked}
+              onRemove={onClickRemove}
+              removeText={removeText}
+              handle={track.handle}
+              trackId={track.track_id}
+              uid={track.uid}
+              date={track.date}
+              isFavorited={track.has_current_user_saved}
+              isOwner={track.owner_id === userId}
+              isOwnerDeactivated={!!track.user?.is_deactivated}
+              isArtistPick={track.user?.artist_pick_track_id === track.track_id}
+              index={cellInfo.row.index}
+              trackTitle={track.name}
+              trackPermalink={track.permalink}
+            />
+          </div>
+        </>
       )
     },
     [
@@ -603,9 +626,9 @@ export const TracksTable = ({
       overflowActions: {
         id: 'trackActions',
         Cell: renderTrackActions,
-        minWidth: 144,
-        maxWidth: 144,
-        width: 144,
+        minWidth: 140,
+        maxWidth: 140,
+        width: 140,
         disableResizing: true,
         disableSortBy: true
       },

--- a/packages/web/src/components/tracks-table/TracksTable.tsx
+++ b/packages/web/src/components/tracks-table/TracksTable.tsx
@@ -5,7 +5,6 @@ import {
   UID,
   UserTrack,
   isContentCollectibleGated,
-  isContentFollowGated,
   isContentUSDCPurchaseGated
 } from '@audius/common/models'
 import { formatCount, formatSeconds } from '@audius/common/utils'
@@ -419,19 +418,20 @@ export const TracksTable = ({
       const isLocked = !isFetchingNFTAccess && !hasStreamAccess
       const deleted =
         track.is_delete || track._marked_deleted || !!track.user?.is_deactivated
-      const icon = track.is_unlisted ? (
-        <IconVisibilityHidden color='subdued' size='m' />
-      ) : isContentUSDCPurchaseGated(track.stream_conditions) ? (
-        <IconLock color='subdued' size='m' />
-      ) : isContentCollectibleGated(track.stream_conditions) ? (
-        <IconCollectible color='subdued' size='m' />
-      ) : (
-        <IconSpecialAccess color='subdued' size='m' />
-      )
+      const shouldShowIcon = track.is_stream_gated || track.is_unlisted
+      const Icon = track.is_unlisted
+        ? IconVisibilityHidden
+        : isContentUSDCPurchaseGated(track.stream_conditions)
+        ? IconLock
+        : isContentCollectibleGated(track.stream_conditions)
+        ? IconCollectible
+        : IconSpecialAccess
       return (
         <>
-          {track.is_stream_gated || track.is_unlisted ? (
-            <Flex className={styles.typeIcon}>{icon}</Flex>
+          {shouldShowIcon ? (
+            <Flex className={styles.typeIcon}>
+              <Icon color='subdued' size='m' />
+            </Flex>
           ) : null}
           <div ref={overflowMenuRef} className={styles.overflowMenu}>
             <OverflowMenuButton


### PR DESCRIPTION
### Description
Show content type (follow-gated, premium, hidden etc) to the far right of each row in a `TracksTable`. Disappears on hover to show the overflow menu instead.
Also updated cell width + icon sizes to more closely match mocks.

Bit of css finnagling to get the icons to all line up. Would have preferred to do it with a state var, but couldn't figure out a way without breaking the rule of hooks.

Plz ignore the wrong gray color for the icons, not sure what's going on there. I didn't change the colors so I think it's some local env thing, should be fine once it gets to stage.

### How Has This Been Tested?


https://github.com/AudiusProject/audius-protocol/assets/3893871/1b8b1925-e8ed-4298-9e2d-2331d022f5be

