### PR TITLE
Fix UserNameAndBadges line-height

### DIFF
--- a/packages/web/src/components/user-name-and-badges/UserNameAndBadges.module.css
+++ b/packages/web/src/components/user-name-and-badges/UserNameAndBadges.module.css
@@ -12,4 +12,5 @@
 .name {
   overflow: hidden;
   text-overflow: ellipsis;
+  line-height: 125%;
 }


### PR DESCRIPTION
### Description
Fixes bug that was clipping bottom of text in certain places like `SalesTable`.

### How Has This Been Tested?

Before:
<img width="103" alt="Screenshot 2024-04-26 at 3 20 47 PM" src="https://github.com/AudiusProject/audius-protocol/assets/3893871/3f836ea8-0336-4556-b531-63e393975161">

After:
<img width="81" alt="Screenshot 2024-04-26 at 3 21 20 PM" src="https://github.com/AudiusProject/audius-protocol/assets/3893871/c6f55779-e075-4dca-9228-9625e8440cc7">
