### PR TITLE
Mobile playlist UI updates - icons, no dividers

### DIFF
--- a/packages/mobile/src/components/track-list/TrackListItem.tsx
+++ b/packages/mobile/src/components/track-list/TrackListItem.tsx
@@ -125,19 +125,6 @@ const useStyles = makeStyles(({ palette, spacing, typography }) => ({
   dragIcon: {
     marginRight: spacing(4)
   },
-  divider: {
-    borderBottomColor: palette.neutralLight7,
-    borderBottomWidth: 1,
-    marginVertical: 0,
-    marginHorizontal: spacing(6)
-  },
-  noMarginDivider: {
-    borderBottomColor: palette.neutralLight8,
-    marginHorizontal: 0
-  },
-  hideDivider: {
-    opacity: 0
-  },
   locked: {
     ...flexRowCentered(),
     paddingVertical: spacing(0.5),
@@ -175,11 +162,8 @@ export type TrackListItemProps = {
   index: number
   isReorderable?: boolean
   showViewAlbum?: boolean
-  noDividerMargin?: boolean
   onRemove?: (index: number) => void
   prevUid?: UID
-  showDivider?: boolean
-  showTopDivider?: boolean
   togglePlay?: (uid: string, trackId: ID) => void
   trackItemAction?: TrackItemAction
   uid?: UID
@@ -226,11 +210,8 @@ const TrackListItemComponent = (props: TrackListItemComponentProps) => {
     index,
     isReorderable = false,
     showViewAlbum = false,
-    noDividerMargin,
     onRemove,
     prevUid,
-    showDivider,
-    showTopDivider,
     togglePlay,
     track,
     trackItemAction,
@@ -386,9 +367,6 @@ const TrackListItemComponent = (props: TrackListItemComponentProps) => {
     onRemove?.(index)
   }
 
-  // The dividers above and belove the active track should be hidden
-  const hideDivider = isActive || isPrevItemActive
-
   const renderGatedIcons = useCallback(() => {
     const shouldShowIcon = isStreamGated || isUnlisted
     const Icon = isUnlisted
@@ -407,15 +385,6 @@ const TrackListItemComponent = (props: TrackListItemComponentProps) => {
 
   return (
     <View>
-      {showDivider && (showTopDivider || index > 0) ? (
-        <View
-          style={[
-            styles.divider,
-            hideDivider && styles.hideDivider,
-            noDividerMargin && styles.noMarginDivider
-          ]}
-        />
-      ) : null}
       <View
         style={[
           styles.trackContainer,

--- a/packages/mobile/src/components/track-list/TrackListItemSkeleton.tsx
+++ b/packages/mobile/src/components/track-list/TrackListItemSkeleton.tsx
@@ -3,8 +3,6 @@ import { View } from 'react-native'
 import Skeleton from 'app/components/skeleton'
 import { makeStyles } from 'app/styles'
 
-import type { TrackListItemProps } from './TrackListItem'
-
 const useStyles = makeStyles(({ palette, spacing }) => ({
   trackContainer: {
     width: '100%',
@@ -15,38 +13,14 @@ const useStyles = makeStyles(({ palette, spacing }) => ({
     justifyContent: 'center'
   },
   trackTitle: { height: spacing(4), marginBottom: 2 },
-  trackArtist: { height: spacing(4) },
-  divider: {
-    borderBottomColor: palette.neutralLight7,
-    borderBottomWidth: 1,
-    marginVertical: 0,
-    marginHorizontal: spacing(6)
-  },
-  noMarginDivider: {
-    borderBottomColor: palette.neutralLight8,
-    marginHorizontal: 0
-  },
-  hideDivider: {
-    opacity: 0
-  }
+  trackArtist: { height: spacing(4) }
 }))
 
-type TrackListItemSkeletonProps = { index: number } & Pick<
-  TrackListItemProps,
-  'noDividerMargin' | 'showDivider' | 'showTopDivider'
->
-
-export const TrackListItemSkeleton = (props: TrackListItemSkeletonProps) => {
-  const { index, showDivider, showTopDivider, noDividerMargin } = props
+export const TrackListItemSkeleton = () => {
   const styles = useStyles()
 
   return (
     <View>
-      {showDivider && (showTopDivider || index > 0) ? (
-        <View
-          style={[styles.divider, noDividerMargin && styles.noMarginDivider]}
-        />
-      ) : null}
       <View style={styles.trackContainer}>
         <Skeleton style={styles.trackTitle} width='54%' />
         <Skeleton style={styles.trackArtist} width='30%' />

--- a/packages/web/src/components/track/mobile/TrackList.tsx
+++ b/packages/web/src/components/track/mobile/TrackList.tsx
@@ -33,9 +33,6 @@ type TrackListProps = {
     streamConditions?: Nullable<AccessConditions>
     hasStreamAccess?: boolean
   }>
-  showTopDivider?: boolean
-  showDivider?: boolean
-  noDividerMargin?: boolean
   showBorder?: boolean
   onRemove?: (index: number) => void
   togglePlay?: (uid: string, trackId: ID) => void
@@ -49,9 +46,6 @@ const TrackList = ({
   itemClassName,
   tracks,
   onRemove,
-  showTopDivider,
-  showDivider,
-  noDividerMargin,
   showBorder,
   togglePlay,
   trackItemAction,
@@ -73,22 +67,9 @@ const TrackList = ({
     [onReorder]
   )
 
-  // The dividers above and belove the active track should be hidden
-  const activeIndex = tracks.findIndex((track) => track.isActive)
-  const hideDivider = (idx: number) =>
-    activeIndex >= 0 && (activeIndex === idx || activeIndex === idx - 1)
-
   const renderedTracks = tracks.map((track, idx) => {
     const listItem = (isDragging?: boolean) => (
       <div key={track.uid}>
-        {showDivider && (showTopDivider || idx > 0) ? (
-          <div
-            className={cn(styles.divider, {
-              [styles.hideDivider]: hideDivider(idx),
-              [styles.noMargin]: noDividerMargin
-            })}
-          ></div>
-        ) : null}
         <TrackListItem
           index={idx}
           trackId={track.trackId}
@@ -177,8 +158,6 @@ const TrackList = ({
 }
 
 TrackList.defaultProps = {
-  hasTopDivider: false,
-  showDivider: true,
   showBorder: false
 }
 

--- a/packages/web/src/pages/collection-page/components/mobile/CollectionPage.tsx
+++ b/packages/web/src/pages/collection-page/components/mobile/CollectionPage.tsx
@@ -320,7 +320,6 @@ const CollectionPage = ({
                   containerClassName={''}
                   itemClassName={''}
                   tracks={trackList}
-                  showDivider
                   togglePlay={togglePlay}
                 />
               )


### PR DESCRIPTION
### Description
For CollectionScreen tracklists on both native mobile and mobile web:
- Adds icons to right of row based on gated type (special access, premium, etc). Resizes them as well.
- Removes dividers

### How Has This Been Tested?

native mobile:
![Simulator Screenshot - iPhone 15 Pro - 2024-04-26 at 17 16 54](https://github.com/AudiusProject/audius-protocol/assets/3893871/6bbf1599-e0e2-462a-95bc-1645d6009380)

mobile web:
<img width="489" alt="Screenshot 2024-04-26 at 5 17 11 PM" src="https://github.com/AudiusProject/audius-protocol/assets/3893871/b5ad2930-e209-438e-a850-a9ab9492a3a2">
