### PR TITLE
[ONC-83] Add stage-only migration to fix indexing the sepolia chain

### DIFF
--- a/packages/discovery-provider/ddl/migrations/0068_refresh_sepolia_indexing.sql
+++ b/packages/discovery-provider/ddl/migrations/0068_refresh_sepolia_indexing.sql
@@ -1,0 +1,8 @@
+BEGIN;
+DO $$ BEGIN
+-- Non-prod gate so migration doesn't run on prod
+IF NOT EXISTS (SELECT * FROM "blocks" WHERE "blockhash" = '0x8d5e6984014505e1e11bcbb1ca1a13bcc6ae85ac74014710a73271d82ca49f01') THEN
+    UPDATE eth_blocks SET last_scanned_block = 5117133;
+END IF;
+END $$;
+COMMIT;


### PR DESCRIPTION
### Description

For stage only, update the last scanned eth block to the block at which we migrated to Sepolia.

Previously were attempting to scan recent Goerli block numbers, which were beyond the Sepolia max block number.

### How Has This Been Tested?

Tested on stage DN5 and it worked. See logs showing the scanning of the blocks.

```
{"level": "INFO", "msg": "index_eth.py | Scanning events from blocks 5791842 - 5791859", "timestamp": "2024-04-27 23:50:28,626", "service": "worker", "otelSpanID": "0", "otelTraceID": "0", "otelServiceName": "discovery-provider", "cpu": 0.0, "memory": 407.375}
{"level": "INFO", "msg": "event_scanner.py | Saving last scanned block (5791859) to redis", "timestamp": "2024-04-27 23:50:28,692", "service": "worker", "otelSpanID": "0", "otelTraceID": "0", "otelServiceName": "discovery-provider", "cpu": 17.0, "memory": 407.7109375}
```

```
 last_scanned_block |         created_at         |         updated_at
--------------------+----------------------------+----------------------------
            5791866 | 2021-09-25 09:49:14.065805 | 2022-07-24 16:57:05.862958
(1 row)
```

```
 last_scanned_block |         created_at         |         updated_at
--------------------+----------------------------+----------------------------
            5791983 | 2021-09-25 09:49:14.065805 | 2022-07-24 16:57:05.862958
(1 row)
```
