### PR TITLE
[C-4033] Prevent useTabs from redirecting on page load

### DIFF
--- a/packages/web/src/hooks/useTabs/useTabs.tsx
+++ b/packages/web/src/hooks/useTabs/useTabs.tsx
@@ -474,6 +474,7 @@ const GestureSupportingBodyContainer = memo(
     const onRest = useCallback(() => {
       if (getGestureInProgress()) return
       const { from, to } = getTransitionInfo()
+      if (from === to) return
       onChangeComplete(from, to)
       setInternalIndex((i) => i + getIndexDelta())
       setIndexDelta(0)


### PR DESCRIPTION
### Description

Google search console notified us of redirects happening on mobile web profile pages. There was an issue with useTabs triggering a tab change immediately. Was able to fix this by preventing the transition when `from` index is equal to `to` index

### How Has This Been Tested?

Confirmed mobile web tabs work properly and don't redirect
