### PR TITLE
[PAY-2766] Analytics events for premium albums

### DIFF
--- a/packages/common/src/models/Analytics.ts
+++ b/packages/common/src/models/Analytics.ts
@@ -219,11 +219,16 @@ export enum Name {
   // Track Edits
   TRACK_EDIT_ACCESS_CHANGED = 'Track Edit: Access Changed',
 
+  // Collection Edits
+  COLLECTION_EDIT_ACCESS_CHANGED = 'Collection Edit: Access Changed',
+  COLLECTION_EDIT = 'Collection Edit: Edits',
+
   // Gated Track Listen
   LISTEN_GATED = 'Listen: Gated',
 
   // Unlocked Gated Tracks
   USDC_PURCHASE_GATED_TRACK_UNLOCKED = 'USDC Gated: Track Unlocked',
+  USDC_PURCHASE_GATED_COLLECTION_UNLOCKED = 'USDC Gated: Collection Unlocked',
   COLLECTIBLE_GATED_TRACK_UNLOCKED = 'Collectible Gated: Track Unlocked',
   FOLLOW_GATED_TRACK_UNLOCKED = 'Follow Gated: Track Unlocked',
   TIP_GATED_TRACK_UNLOCKED = 'Tip Gated: Track Unlocked',
@@ -1146,6 +1151,21 @@ type TrackEditAccessChanged = {
   to: TrackAccessType
 }
 
+// Collection Edits
+type CollectionEditAccessChanged = {
+  eventName: Name.TRACK_EDIT_ACCESS_CHANGED
+  id: number
+  from: TrackAccessType
+  to: TrackAccessType
+}
+
+type CollectionEdit = {
+  eventName: Name.TRACK_EDIT_ACCESS_CHANGED
+  id: number
+  from: TrackAccessType
+  to: TrackAccessType
+}
+
 // Unlocked Gated Tracks
 type USDCGatedTrackUnlocked = {
   eventName: Name.USDC_PURCHASE_GATED_TRACK_UNLOCKED
@@ -1334,8 +1354,10 @@ export enum PlaybackSource {
   PLAYLIST_PAGE = 'playlist page',
   TRACK_PAGE = 'track page',
   TRACK_TILE = 'track tile',
+  TRACK_TILE_LINEUP = 'track tile lineup',
   PLAYLIST_TRACK = 'playlist page track list',
   PLAYLIST_TILE_TRACK = 'playlist track tile',
+  PLAYLIST_TILE_TRACK_LINEUP = 'playlist track tile lineup',
   HISTORY_PAGE = 'history page',
   LIBRARY_PAGE = 'library page',
   PASSIVE = 'passive',
@@ -1370,9 +1392,16 @@ type TagClicking = {
 
 export enum ModalSource {
   TrackTile = 'track tile',
+  CollectionTile = 'collection tile',
   TrackDetails = 'track details',
+  CollectionDetails = 'collection details',
   NowPlaying = 'now playing',
   PlayBar = 'play bar',
+  DirectMessageTrackTile = 'track tile - direct message',
+  DirectMessageCollectionTile = 'collection tile - direct message',
+  LineUpTrackTile = 'track tile - lineup',
+  LineUpCollectionTile = 'collection tile - lineup',
+  TrackListItem = 'track list item',
   // Should never be used, but helps with type-checking
   Unknown = 'unknown'
 }
@@ -2424,6 +2453,8 @@ export type AllTrackingEvents =
   | TrackDownloadSuccessfulDownloadSingle
   | TrackDownloadFailedDownloadSingle
   | TrackEditAccessChanged
+  | CollectionEditAccessChanged
+  | CollectionEdit
   | TrackUploadSuccess
   | TrackUploadFailure
   | TrackUploadRejected

--- a/packages/common/src/models/Analytics.ts
+++ b/packages/common/src/models/Analytics.ts
@@ -10,12 +10,12 @@ import {
   WalletAddress
 } from '~/models/Wallet'
 import { MintName } from '~/services/index'
-import { Prettify } from '~/utils/typeUtils'
+import { Nullable, Prettify } from '~/utils/typeUtils'
 
 import { Chain } from './Chain'
 import { PlaylistLibraryKind } from './PlaylistLibrary'
 import { PurchaseMethod } from './PurchaseContent'
-import { TrackAccessType } from './Track'
+import { AccessConditions, TrackAccessType } from './Track'
 
 const ANALYTICS_TRACK_EVENT = 'ANALYTICS/TRACK_EVENT'
 
@@ -221,7 +221,7 @@ export enum Name {
 
   // Collection Edits
   COLLECTION_EDIT_ACCESS_CHANGED = 'Collection Edit: Access Changed',
-  COLLECTION_EDIT = 'Collection Edit: Edits',
+  COLLECTION_EDIT = 'Collection Edit: General Edits',
 
   // Gated Track Listen
   LISTEN_GATED = 'Listen: Gated',
@@ -1153,14 +1153,14 @@ type TrackEditAccessChanged = {
 
 // Collection Edits
 type CollectionEditAccessChanged = {
-  eventName: Name.TRACK_EDIT_ACCESS_CHANGED
+  eventName: Name.COLLECTION_EDIT_ACCESS_CHANGED
   id: number
-  from: TrackAccessType
-  to: TrackAccessType
+  from: Nullable<AccessConditions>
+  to: Nullable<AccessConditions>
 }
 
 type CollectionEdit = {
-  eventName: Name.TRACK_EDIT_ACCESS_CHANGED
+  eventName: Name.COLLECTION_EDIT
   id: number
   from: TrackAccessType
   to: TrackAccessType

--- a/packages/common/src/store/gated-content/sagas.ts
+++ b/packages/common/src/store/gated-content/sagas.ts
@@ -492,16 +492,21 @@ export function* pollGatedContent({
         return
       }
 
-      // TODO: Add separate analytics names for gated albums
-      const eventName =
-        !isAlbum &&
-        (isContentUSDCPurchaseGated(apiEntity.stream_conditions)
-          ? Name.USDC_PURCHASE_GATED_TRACK_UNLOCKED
-          : isContentFollowGated(apiEntity.stream_conditions)
-          ? Name.FOLLOW_GATED_TRACK_UNLOCKED
-          : isContentTipGated(apiEntity.stream_conditions)
-          ? Name.TIP_GATED_TRACK_UNLOCKED
-          : null)
+      const getEventName = () => {
+        if (isContentUSDCPurchaseGated(apiEntity.stream_conditions)) {
+          return isAlbum
+            ? Name.USDC_PURCHASE_GATED_COLLECTION_UNLOCKED
+            : Name.USDC_PURCHASE_GATED_TRACK_UNLOCKED
+        }
+        if (isContentFollowGated(apiEntity.stream_conditions)) {
+          return Name.FOLLOW_GATED_TRACK_UNLOCKED
+        }
+        if (isContentTipGated(apiEntity.stream_conditions)) {
+          return Name.TIP_GATED_TRACK_UNLOCKED
+        }
+        return null
+      }
+      const eventName = getEventName()
       if (eventName) {
         analytics.track({
           eventName,

--- a/packages/web/src/components/collection/desktop/CollectionHeader.tsx
+++ b/packages/web/src/components/collection/desktop/CollectionHeader.tsx
@@ -6,6 +6,7 @@ import {
   AccessPermissions,
   CoverArtSizes,
   ID,
+  ModalSource,
   Variant,
   isContentUSDCPurchaseGated
 } from '@audius/common/models'
@@ -315,6 +316,7 @@ export const CollectionHeader = (props: CollectionHeaderProps) => {
           hasStreamAccess={hasStreamAccess}
           isOwner={ownerId === currentUserId}
           ownerId={ownerId}
+          source={ModalSource.CollectionDetails}
         />
       ) : null}
 

--- a/packages/web/src/components/collection/mobile/CollectionHeader.tsx
+++ b/packages/web/src/components/collection/mobile/CollectionHeader.tsx
@@ -1,7 +1,13 @@
 import { MouseEventHandler, memo, useCallback } from 'react'
 
 import { imageBlank } from '@audius/common/assets'
-import { Variant, SquareSizes, Collection, ID } from '@audius/common/models'
+import {
+  Variant,
+  SquareSizes,
+  Collection,
+  ID,
+  ModalSource
+} from '@audius/common/models'
 import { FeatureFlags } from '@audius/common/services'
 import {
   CommonState,
@@ -261,6 +267,7 @@ const CollectionHeader = ({
               className={styles.gatedContentSection}
               buttonClassName={styles.gatedContentSectionButton}
               ownerId={userId}
+              source={ModalSource.CollectionDetails}
             />
           </Box>
         ) : null}

--- a/packages/web/src/components/create-playlist/PlaylistForm.tsx
+++ b/packages/web/src/components/create-playlist/PlaylistForm.tsx
@@ -1,8 +1,4 @@
-import {
-  SquareSizes,
-  CollectionMetadata,
-  Collection
-} from '@audius/common/models'
+import { SquareSizes, Collection } from '@audius/common/models'
 import { createCollectionSchema } from '@audius/common/schemas'
 import { Nullable } from '@audius/common/utils'
 import { Flex } from '@audius/harmony'
@@ -48,8 +44,8 @@ type PlaylistFormProps = {
   /** Only applies to edit mode */
   onCancel?: () => void
   onSave: (
-    formFields: CollectionMetadata,
-    initialValues: CollectionMetadata
+    formFields: EditPlaylistValues,
+    initialValues: EditPlaylistValues
   ) => void
 }
 

--- a/packages/web/src/components/create-playlist/PlaylistForm.tsx
+++ b/packages/web/src/components/create-playlist/PlaylistForm.tsx
@@ -47,7 +47,10 @@ type PlaylistFormProps = {
   onDelete?: () => void
   /** Only applies to edit mode */
   onCancel?: () => void
-  onSave: (formFields: CollectionMetadata) => void
+  onSave: (
+    formFields: CollectionMetadata,
+    initialValues: CollectionMetadata
+  ) => void
 }
 
 const createCollectionFormSchema = (collectionType: 'album' | 'playlist') => {
@@ -72,14 +75,16 @@ const PlaylistForm = ({
     SquareSizes.SIZE_1000_BY_1000
   )
 
+  const initialValues = {
+    ...metadata,
+    artwork: coverArtUrl ? { url: coverArtUrl } : null,
+    description: metadata.description ?? ''
+  }
+
   return (
     <Formik<EditPlaylistValues>
-      initialValues={{
-        ...metadata,
-        artwork: coverArtUrl ? { url: coverArtUrl } : null,
-        description: metadata.description ?? ''
-      }}
-      onSubmit={onSave}
+      initialValues={initialValues}
+      onSubmit={(values) => onSave(values, initialValues)}
       validationSchema={toFormikValidationSchema(
         createCollectionFormSchema(isAlbum ? 'album' : 'playlist')
       )}

--- a/packages/web/src/components/edit-playlist/desktop/EditPlaylistModal.tsx
+++ b/packages/web/src/components/edit-playlist/desktop/EditPlaylistModal.tsx
@@ -70,19 +70,19 @@ const EditPlaylistModal = () => {
   const handleSubmit = useCallback(
     (formFields: PlaylistFormValues, initialValues: PlaylistFormValues) => {
       if (playlistId) {
-        // Track what things changed
-        const edits = omitBy(formFields, (value, key) =>
+        // Make what things changed
+        const metadataChanges = omitBy(formFields, (value, key) =>
           isEqual(value, initialValues[key])
-        )
+        ) as Partial<PlaylistFormValues>
         track({
           eventName: Name.COLLECTION_EDIT,
           properties: {
             id: playlistId,
-            edits
+            edits: metadataChanges
           }
         })
         // We want to pay special attention to access condition changes
-        if (initialValues.stream_conditions !== formFields.stream_conditions) {
+        if (metadataChanges.stream_conditions) {
           track({
             eventName: Name.COLLECTION_EDIT_ACCESS_CHANGED,
             properties: {
@@ -99,9 +99,8 @@ const EditPlaylistModal = () => {
     [playlistId, dispatch, onClose]
   )
 
-  const editPlaylistModalTitle = `${messages.edit} ${
-    isAlbum ? messages.title.album : messages.title.playlist
-  }`
+  const editPlaylistModalTitle = `${messages.edit} ${isAlbum ? messages.title.album : messages.title.playlist
+    }`
 
   const handleDelete = useCallback(() => {
     setShowDeleteConfirmation(false)

--- a/packages/web/src/components/edit-playlist/desktop/EditPlaylistModal.tsx
+++ b/packages/web/src/components/edit-playlist/desktop/EditPlaylistModal.tsx
@@ -16,7 +16,6 @@ import {
   IconPlaylists
 } from '@audius/harmony'
 import { push as pushRoute } from 'connected-react-router'
-import { isEqual, omitBy } from 'lodash'
 import { useDispatch } from 'react-redux'
 
 import PlaylistForm, {
@@ -70,19 +69,8 @@ const EditPlaylistModal = () => {
   const handleSubmit = useCallback(
     (formFields: PlaylistFormValues, initialValues: PlaylistFormValues) => {
       if (playlistId) {
-        // Make what things changed
-        const metadataChanges = omitBy(formFields, (value, key) =>
-          isEqual(value, initialValues[key])
-        ) as Partial<PlaylistFormValues>
-        track({
-          eventName: Name.COLLECTION_EDIT,
-          properties: {
-            id: playlistId,
-            edits: metadataChanges
-          }
-        })
         // We want to pay special attention to access condition changes
-        if (metadataChanges.stream_conditions) {
+        if (formFields.stream_conditions !== initialValues.stream_conditions) {
           track({
             eventName: Name.COLLECTION_EDIT_ACCESS_CHANGED,
             properties: {
@@ -99,9 +87,8 @@ const EditPlaylistModal = () => {
     [playlistId, dispatch, onClose]
   )
 
-  const editPlaylistModalTitle = `${messages.edit} ${
-    isAlbum ? messages.title.album : messages.title.playlist
-  }`
+  const editPlaylistModalTitle = `${messages.edit} ${isAlbum ? messages.title.album : messages.title.playlist
+    }`
 
   const handleDelete = useCallback(() => {
     setShowDeleteConfirmation(false)

--- a/packages/web/src/components/edit-playlist/desktop/EditPlaylistModal.tsx
+++ b/packages/web/src/components/edit-playlist/desktop/EditPlaylistModal.tsx
@@ -69,6 +69,12 @@ const EditPlaylistModal = () => {
   const handleSubmit = useCallback(
     (formFields: PlaylistFormValues, initialValues: PlaylistFormValues) => {
       if (playlistId) {
+        track({
+          eventName: Name.COLLECTION_EDIT,
+          properties: {
+            id: playlistId
+          }
+        })
         // We want to pay special attention to access condition changes
         if (formFields.stream_conditions !== initialValues.stream_conditions) {
           track({
@@ -87,8 +93,9 @@ const EditPlaylistModal = () => {
     [playlistId, dispatch, onClose]
   )
 
-  const editPlaylistModalTitle = `${messages.edit} ${isAlbum ? messages.title.album : messages.title.playlist
-    }`
+  const editPlaylistModalTitle = `${messages.edit} ${
+    isAlbum ? messages.title.album : messages.title.playlist
+  }`
 
   const handleDelete = useCallback(() => {
     setShowDeleteConfirmation(false)

--- a/packages/web/src/components/edit-playlist/desktop/EditPlaylistModal.tsx
+++ b/packages/web/src/components/edit-playlist/desktop/EditPlaylistModal.tsx
@@ -99,8 +99,9 @@ const EditPlaylistModal = () => {
     [playlistId, dispatch, onClose]
   )
 
-  const editPlaylistModalTitle = `${messages.edit} ${isAlbum ? messages.title.album : messages.title.playlist
-    }`
+  const editPlaylistModalTitle = `${messages.edit} ${
+    isAlbum ? messages.title.album : messages.title.playlist
+  }`
 
   const handleDelete = useCallback(() => {
     setShowDeleteConfirmation(false)

--- a/packages/web/src/components/edit-playlist/desktop/EditPlaylistModal.tsx
+++ b/packages/web/src/components/edit-playlist/desktop/EditPlaylistModal.tsx
@@ -2,7 +2,6 @@ import { useCallback, useEffect, useState } from 'react'
 
 import { Name } from '@audius/common/models'
 import {
-  EditPlaylistValues,
   accountActions,
   cacheCollectionsActions,
   cacheCollectionsSelectors,
@@ -18,7 +17,9 @@ import {
 import { push as pushRoute } from 'connected-react-router'
 import { useDispatch } from 'react-redux'
 
-import PlaylistForm from 'components/create-playlist/PlaylistForm'
+import PlaylistForm, {
+  EditPlaylistValues
+} from 'components/create-playlist/PlaylistForm'
 import LoadingSpinner from 'components/loading-spinner/LoadingSpinner'
 import { DeleteCollectionConfirmationModal } from 'components/nav/desktop/PlaylistLibrary/DeleteCollectionConfirmationModal'
 import { track } from 'services/analytics'
@@ -94,9 +95,8 @@ const EditPlaylistModal = () => {
     [playlistId, dispatch, onClose]
   )
 
-  const editPlaylistModalTitle = `${messages.edit} ${
-    isAlbum ? messages.title.album : messages.title.playlist
-  }`
+  const editPlaylistModalTitle = `${messages.edit} ${isAlbum ? messages.title.album : messages.title.playlist
+    }`
 
   const handleDelete = useCallback(() => {
     setShowDeleteConfirmation(false)

--- a/packages/web/src/components/edit-playlist/mobile/EditPlaylistPage.tsx
+++ b/packages/web/src/components/edit-playlist/mobile/EditPlaylistPage.tsx
@@ -242,8 +242,7 @@ const EditPlaylistPage = g(
         track({
           eventName: Name.COLLECTION_EDIT,
           properties: {
-            id: metadata.playlist_id,
-            to: formFields
+            id: metadata.playlist_id
           }
         })
 

--- a/packages/web/src/components/edit-playlist/mobile/EditPlaylistPage.tsx
+++ b/packages/web/src/components/edit-playlist/mobile/EditPlaylistPage.tsx
@@ -2,7 +2,7 @@ import { useEffect, useState, useCallback } from 'react'
 
 import { imageBlank as placeholderCoverArt } from '@audius/common/assets'
 import { useGatedContentAccessMap } from '@audius/common/hooks'
-import { SquareSizes, Collection, ID } from '@audius/common/models'
+import { SquareSizes, Collection, ID, Name } from '@audius/common/models'
 import { newCollectionMetadata } from '@audius/common/schemas'
 import { RandomImage } from '@audius/common/services'
 import {
@@ -29,6 +29,7 @@ import TrackList from 'components/track/mobile/TrackList'
 import { useCollectionCoverArt } from 'hooks/useCollectionCoverArt'
 import useHasChangedRoute from 'hooks/useHasChangedRoute'
 import UploadStub from 'pages/profile-page/components/mobile/UploadStub'
+import { track } from 'services/analytics'
 import { AppState } from 'store/types'
 import { resizeImage } from 'utils/imageProcessingUtil'
 import { useSelector } from 'utils/reducer'
@@ -237,6 +238,14 @@ const EditPlaylistPage = g(
         }
 
         editPlaylist(metadata.playlist_id, editPlaylistData)
+
+        track({
+          eventName: Name.COLLECTION_EDIT,
+          properties: {
+            id: metadata.playlist_id,
+            to: formFields
+          }
+        })
 
         onClose()
       }

--- a/packages/web/src/components/lineup/LineupProvider.tsx
+++ b/packages/web/src/components/lineup/LineupProvider.tsx
@@ -7,7 +7,8 @@ import {
   Status,
   ID,
   UID,
-  Lineup
+  Lineup,
+  ModalSource
 } from '@audius/common/models'
 import {
   LineupBaseActions,
@@ -527,7 +528,7 @@ class LineupProvider extends PureComponent<CombinedProps, LineupProviderState> {
           // Render a track tile if the kind tracks or there's a track id present
 
           if (entry._marked_deleted) return null
-          let trackProps = {
+          let trackProps: TrackTileProps = {
             ...entry,
             key: index,
             index,
@@ -542,7 +543,8 @@ class LineupProvider extends PureComponent<CombinedProps, LineupProviderState> {
             isTrending,
             showRankIcon: index < rankIconCount,
             showFeedTipTile,
-            onClick: onClickTile
+            onClick: onClickTile,
+            source: ModalSource.LineUpTrackTile
           }
           if (entry.id === leadingElementId) {
             trackProps = { ...trackProps, ...leadingElementTileProps }
@@ -551,7 +553,7 @@ class LineupProvider extends PureComponent<CombinedProps, LineupProviderState> {
         } else if (entry.kind === Kind.COLLECTIONS || entry.playlist_id) {
           // Render a track tile if the kind tracks or there's a track id present
 
-          const playlistProps = {
+          const playlistProps: PlaylistTileProps = {
             ...entry,
             key: index,
             index,
@@ -567,7 +569,8 @@ class LineupProvider extends PureComponent<CombinedProps, LineupProviderState> {
             numLoadingSkeletonRows: numPlaylistSkeletonRows,
             isTrending,
             showRankIcon: index < rankIconCount,
-            showFeedTipTile
+            showFeedTipTile,
+            source: ModalSource.LineUpCollectionTile
           }
 
           return <this.props.playlistTile key={index} {...playlistProps} />

--- a/packages/web/src/components/track/GatedContentSection.tsx
+++ b/packages/web/src/components/track/GatedContentSection.tsx
@@ -105,6 +105,7 @@ type GatedContentAccessSectionProps = {
   isOwner: boolean
   className?: string
   buttonClassName?: string
+  source?: ModalSource
 }
 
 const LockedGatedContentSection = ({
@@ -116,7 +117,9 @@ const LockedGatedContentSection = ({
   goToCollection,
   renderArtist,
   className,
-  buttonClassName
+  buttonClassName,
+  source: premiumModalSource,
+  ...other
 }: GatedContentAccessSectionProps) => {
   const messages = getMessages(contentType)
   const dispatch = useDispatch()
@@ -124,7 +127,7 @@ const LockedGatedContentSection = ({
     useModalState('LockedContent')
   const { onOpen: openPremiumContentPurchaseModal } =
     usePremiumContentPurchaseModal()
-  const source = lockedContentModalVisibility
+  const tipSource = lockedContentModalVisibility
     ? 'howToUnlockModal'
     : 'howToUnlockTrackPage'
   const followSource = lockedContentModalVisibility
@@ -139,18 +142,21 @@ const LockedGatedContentSection = ({
     }
     openPremiumContentPurchaseModal(
       { contentId, contentType },
-      { source: ModalSource.TrackDetails }
+      { source: premiumModalSource ?? ModalSource.TrackDetails }
     )
   }, [
     contentId,
     contentType,
     lockedContentModalVisibility,
     openPremiumContentPurchaseModal,
-    setLockedContentModalVisibility
+    setLockedContentModalVisibility,
+    premiumModalSource
   ])
 
   const handleSendTip = useAuthenticatedCallback(() => {
-    dispatch(beginTip({ user: tippedUser, source, trackId: contentId }))
+    dispatch(
+      beginTip({ user: tippedUser, source: tipSource, trackId: contentId })
+    )
 
     if (lockedContentModalVisibility) {
       setLockedContentModalVisibility(false)
@@ -158,7 +164,7 @@ const LockedGatedContentSection = ({
   }, [
     dispatch,
     tippedUser,
-    source,
+    tipSource,
     contentId,
     lockedContentModalVisibility,
     setLockedContentModalVisibility
@@ -554,6 +560,8 @@ type GatedContentSectionProps = {
   className?: string
   buttonClassName?: string
   ownerId: ID | null
+  /** More context for analytics to know about where purchases are being triggered from */
+  source?: ModalSource
 }
 
 export const GatedContentSection = ({
@@ -566,7 +574,8 @@ export const GatedContentSection = ({
   wrapperClassName,
   className,
   buttonClassName,
-  ownerId
+  ownerId,
+  source
 }: GatedContentSectionProps) => {
   const dispatch = useDispatch()
   const gatedContentStatusMap = useSelector(getGatedContentStatusMap)
@@ -699,6 +708,7 @@ export const GatedContentSection = ({
         isOwner={isOwner}
         className={cn(styles.gatedContentSectionLocked, className)}
         buttonClassName={buttonClassName}
+        source={source}
       />
     </div>
   )

--- a/packages/web/src/components/track/GatedContentSection.tsx
+++ b/packages/web/src/components/track/GatedContentSection.tsx
@@ -118,8 +118,7 @@ const LockedGatedContentSection = ({
   renderArtist,
   className,
   buttonClassName,
-  source: premiumModalSource,
-  ...other
+  source: premiumModalSource
 }: GatedContentAccessSectionProps) => {
   const messages = getMessages(contentType)
   const dispatch = useDispatch()

--- a/packages/web/src/components/track/desktop/ConnectedPlaylistTile.tsx
+++ b/packages/web/src/components/track/desktop/ConnectedPlaylistTile.tsx
@@ -95,6 +95,7 @@ type OwnProps = {
   isTrending: boolean
   showRankIcon: boolean
   isFeed: boolean
+  source?: ModalSource
 }
 
 type ConnectedPlaylistTileProps = OwnProps &
@@ -133,7 +134,8 @@ const ConnectedPlaylistTile = ({
   unsaveCollection,
   isTrending,
   showRankIcon,
-  isFeed = false
+  isFeed = false,
+  source
 }: ConnectedPlaylistTileProps) => {
   const {
     is_album: isAlbum,
@@ -395,7 +397,7 @@ const ConnectedPlaylistTile = ({
     if (isPurchase && id) {
       openPremiumContentPurchaseModal(
         { contentId: id, contentType: PurchaseableContentType.ALBUM },
-        { source: ModalSource.TrackTile }
+        { source: source ?? ModalSource.TrackTile }
       )
     }
   }, [id, openPremiumContentPurchaseModal, hasStreamAccess])
@@ -546,6 +548,7 @@ const ConnectedPlaylistTile = ({
       href={href}
       hasStreamAccess={hasStreamAccess}
       streamConditions={isStreamGated ? streamConditions : null}
+      source={source}
     />
   )
 }

--- a/packages/web/src/components/track/desktop/PlaylistTile.tsx
+++ b/packages/web/src/components/track/desktop/PlaylistTile.tsx
@@ -54,7 +54,8 @@ const PlaylistTile = ({
   href,
   hasStreamAccess,
   streamConditions,
-  TileTrackContainer = DefaultTileContainer
+  TileTrackContainer = DefaultTileContainer,
+  source
 }: PlaylistTileProps) => {
   const renderTracks = useCallback(
     () => (
@@ -124,6 +125,7 @@ const PlaylistTile = ({
           isStreamGated={!!streamConditions}
           streamConditions={streamConditions}
           hasStreamAccess={hasStreamAccess}
+          source={source}
         />
       </TileTrackContainer>
       <Box backgroundColor='surface1' borderTop='strong' borderBottom='strong'>

--- a/packages/web/src/components/track/desktop/TrackTile.tsx
+++ b/packages/web/src/components/track/desktop/TrackTile.tsx
@@ -161,7 +161,8 @@ const TrackTile = ({
   permalink,
   isTrack,
   trackId,
-  releaseDate
+  releaseDate,
+  source
 }: TrackTileProps) => {
   const { isEnabled: isNewPodcastControlsEnabled } = useFlag(
     FeatureFlags.PODCAST_CONTROL_UPDATES_ENABLED,
@@ -188,7 +189,7 @@ const TrackTile = ({
     if (isPurchase && trackId) {
       openPremiumContentPurchaseModal(
         { contentId: trackId, contentType: PurchaseableContentType.TRACK },
-        { source: ModalSource.TrackTile }
+        { source: source ?? ModalSource.TrackTile }
       )
     } else if (trackId && !hasStreamAccess && onClickLocked) {
       onClickLocked()

--- a/packages/web/src/components/track/mobile/ConnectedPlaylistTile.tsx
+++ b/packages/web/src/components/track/mobile/ConnectedPlaylistTile.tsx
@@ -124,7 +124,8 @@ const ConnectedPlaylistTile = ({
   isTrending,
   variant,
   containerClassName,
-  isFeed = false
+  isFeed = false,
+  source
 }: ConnectedPlaylistTileProps) => {
   const collection = getCollectionWithFallback(nullableCollection)
   const user = getUserWithFallback(nullableUser)
@@ -331,6 +332,7 @@ const ConnectedPlaylistTile = ({
       isStreamGated={collection.is_stream_gated}
       hasStreamAccess={!!collection.access?.stream}
       streamConditions={collection.stream_conditions}
+      source={source}
     />
   )
 }

--- a/packages/web/src/components/track/mobile/ConnectedTrackListItem.tsx
+++ b/packages/web/src/components/track/mobile/ConnectedTrackListItem.tsx
@@ -106,7 +106,7 @@ const ConnectedTrackListItem = (props: ConnectedTrackListItemProps) => {
           contentId: trackId,
           contentType: PurchaseableContentType.TRACK
         },
-        { source: ModalSource.TrackTile }
+        { source: ModalSource.TrackListItem }
       )
     } else if (trackId && !hasStreamAccess) {
       openLockedContentModal()

--- a/packages/web/src/components/track/mobile/ConnectedTrackTile.tsx
+++ b/packages/web/src/components/track/mobile/ConnectedTrackTile.tsx
@@ -108,7 +108,8 @@ const ConnectedTrackTile = ({
   variant,
   containerClassName,
   releaseDate,
-  isFeed = false
+  isFeed = false,
+  source
 }: ConnectedTrackTileProps) => {
   const trackWithFallback = getTrackWithFallback(track)
   const {
@@ -283,6 +284,7 @@ const ConnectedTrackTile = ({
       showRankIcon={showRankIcon}
       variant={variant}
       releaseDate={releaseDate}
+      source={source}
     />
   )
 }

--- a/packages/web/src/components/track/mobile/PlaylistTile.tsx
+++ b/packages/web/src/components/track/mobile/PlaylistTile.tsx
@@ -239,7 +239,8 @@ const PlaylistTile = (props: PlaylistTileProps & ExtraProps) => {
     ownerId,
     isStreamGated,
     hasStreamAccess,
-    streamConditions
+    streamConditions,
+    source
   } = props
   const [artworkLoaded, setArtworkLoaded] = useState(false)
   useEffect(() => {
@@ -274,7 +275,7 @@ const PlaylistTile = (props: PlaylistTileProps & ExtraProps) => {
     if (isPurchase && id) {
       openPremiumContentPurchaseModal(
         { contentId: id, contentType: PurchaseableContentType.ALBUM },
-        { source: ModalSource.TrackTile }
+        { source: source ?? ModalSource.TrackTile }
       )
     } else if (id && !hasStreamAccess) {
       openLockedContentModal()

--- a/packages/web/src/components/track/mobile/TrackTile.tsx
+++ b/packages/web/src/components/track/mobile/TrackTile.tsx
@@ -208,7 +208,8 @@ const TrackTile = (props: CombinedProps) => {
     variant,
     containerClassName,
     hasPreview = false,
-    title
+    title,
+    source
   } = props
 
   const hideShare: boolean = props.fieldVisibility
@@ -256,7 +257,7 @@ const TrackTile = (props: CombinedProps) => {
     if (isPurchase && trackId) {
       openPremiumContentPurchaseModal(
         { contentId: trackId, contentType: PurchaseableContentType.TRACK },
-        { source: ModalSource.TrackTile }
+        { source: source ?? ModalSource.TrackTile }
       )
     } else if (trackId && !hasStreamAccess) {
       openLockedContentModal()

--- a/packages/web/src/components/track/types.ts
+++ b/packages/web/src/components/track/types.ts
@@ -11,7 +11,8 @@ import {
   FieldVisibility,
   Remix,
   AccessConditions,
-  LineupTrack
+  LineupTrack,
+  ModalSource
 } from '@audius/common/models'
 import { Genre, Nullable } from '@audius/common/utils'
 
@@ -75,6 +76,8 @@ export type TrackTileProps = TileProps & {
   coSign?: Remix | null
   releaseDate?: string | null
   onClickOverflow?: (trackId: ID) => void
+  /** Provides more context to analytics about where the tile is being used */
+  source?: ModalSource
 }
 
 export type PlaylistTileProps = TileProps & {
@@ -107,6 +110,8 @@ export type PlaylistTileProps = TileProps & {
   record?: (event: any) => void
   /** Number of rows to show when in loading state, if any */
   numLoadingSkeletonRows?: number
+  /** Provides more context to analytics about where the tile is being used */
+  source?: ModalSource
 }
 
 export type DesktopTrackTileProps = {
@@ -241,6 +246,9 @@ export type DesktopTrackTileProps = {
 
   /** Track id if track tile */
   trackId?: ID
+
+  /** Additional context for analytics to know which area of the app the track tile is being used */
+  source?: ModalSource
 }
 
 export type DesktopPlaylistTileProps = {
@@ -363,6 +371,9 @@ export type DesktopPlaylistTileProps = {
 
   /** Stream gated conditions for the collection */
   streamConditions?: Nullable<AccessConditions>
+
+  /** Additional context for analytics to know which area of the app the track tile is being used */
+  source?: ModalSource
 }
 
 export type SkeletonTileProps = {

--- a/packages/web/src/pages/chat-page/components/ChatMessagePlaylist.tsx
+++ b/packages/web/src/pages/chat-page/components/ChatMessagePlaylist.tsx
@@ -5,7 +5,14 @@ import {
   useGetPlaylistByPermalink
 } from '@audius/common/api'
 import { usePlayTrack, usePauseTrack } from '@audius/common/hooks'
-import { Name, SquareSizes, Kind, Status, ID } from '@audius/common/models'
+import {
+  Name,
+  SquareSizes,
+  Kind,
+  Status,
+  ID,
+  ModalSource
+} from '@audius/common/models'
 import {
   accountSelectors,
   cacheCollectionsActions,
@@ -143,6 +150,7 @@ export const ChatMessagePlaylist = ({
       togglePlay={() => {}}
       playingTrackId={playingTrackId}
       variant='readonly'
+      source={ModalSource.DirectMessageCollectionTile}
     />
   ) : null
 }

--- a/packages/web/src/pages/chat-page/components/ChatMessageTrack.tsx
+++ b/packages/web/src/pages/chat-page/components/ChatMessageTrack.tsx
@@ -12,7 +12,8 @@ import {
   SquareSizes,
   Kind,
   Status,
-  ID
+  ID,
+  ModalSource
 } from '@audius/common/models'
 import {
   accountSelectors,
@@ -108,6 +109,7 @@ export const ChatMessageTrack = ({
       showArtistPick={false}
       isActive={isTrackPlaying}
       variant='readonly'
+      source={ModalSource.DirectMessageTrackTile}
     />
   ) : null
 }

--- a/packages/web/src/pages/collection-page/CollectionPageProvider.tsx
+++ b/packages/web/src/pages/collection-page/CollectionPageProvider.tsx
@@ -15,7 +15,8 @@ import {
   SmartCollection,
   ID,
   UID,
-  isContentUSDCPurchaseGated
+  isContentUSDCPurchaseGated,
+  ModalSource
 } from '@audius/common/models'
 import {
   accountSelectors,
@@ -29,6 +30,7 @@ import {
   tracksSocialActions as socialTracksActions,
   usersSocialActions as socialUsersActions,
   mobileOverflowMenuUIActions,
+  modalsActions,
   shareModalUIActions,
   OverflowAction,
   OverflowSource,
@@ -81,6 +83,7 @@ import { getCollectionPageSEOFields } from 'utils/seo'
 import { CollectionPageProps as DesktopCollectionPageProps } from './components/desktop/CollectionPage'
 import { CollectionPageProps as MobileCollectionPageProps } from './components/mobile/CollectionPage'
 
+const { trackModalOpened } = modalsActions
 const { selectAllPlaylistUpdateIds } = playlistUpdatesSelectors
 const { makeGetCurrent } = queueSelectors
 const { getPlaying, getBuffering } = playerSelectors
@@ -498,7 +501,8 @@ class CollectionPage extends Component<
   onClickPurchaseTrack = (record: CollectionPageTrackRecord) => {
     this.props.openPremiumContentPurchaseModal({
       contentId: record.track_id,
-      contentType: PurchaseableContentType.TRACK
+      contentType: PurchaseableContentType.TRACK,
+      source: ModalSource.TrackListItem
     })
   }
 
@@ -1012,8 +1016,19 @@ function mapDispatchToProps(dispatch: Dispatch) {
       ),
     updatePlaylistLastViewedAt: (playlistId: ID) =>
       dispatch(updatedPlaylistViewed({ playlistId })),
-    openPremiumContentPurchaseModal: (args: PremiumContentPurchaseModalState) =>
+    openPremiumContentPurchaseModal: (
+      args: PremiumContentPurchaseModalState & { source: ModalSource }
+    ) => {
+      // Since we cant use the premium modal hook we have to manually trigger the modal action & the analytics tracking call
       dispatch(usePremiumContentPurchaseModalActions.open(args))
+      dispatch(
+        trackModalOpened({
+          name: 'PremiumContentPurchaseModal',
+          trackingData: args,
+          source: args.source
+        })
+      )
+    }
   }
 }
 


### PR DESCRIPTION
### Description

My aim was to provide details supporting these dashboards:
- Premium album upload count
  - No added metrics, in metabase we can query using existing upload success event & collection ID
- Premium album edits
  - New metrics added
- Premium modal opens & where they are coming from
  - Expanded metrics
- Premium album purchases
  - No added metrics, in metabase we can query using existing purchase event & collection ID
- Track added to premium album
  - No added metrics, in metabase we can query using existing 'added to collection' event & collection ID

Various analytics changes events related to premium albums

- Added events for collection edit & one specifically for tracking access changes
- Greatly expanded the premium modal source type, previously was using `track tile` for a ton of stuff
  - DMs now have a separate event for tracks & collections
  - Lineup now has a separate event for tracks & collections
  - Tracks in a list item view has it's own source (i.e. for the tables in collectinos)
- Added logic for unlocking 

### How Has This Been Tested?

web:stage
- [x] Verified that all the new events are triggered as expected
