### PR TITLE
Fix clipped text in TracksTable name column

### DIFF
--- a/packages/web/src/components/tracks-table/TracksTable.tsx
+++ b/packages/web/src/components/tracks-table/TracksTable.tsx
@@ -216,7 +216,7 @@ export const TracksTable = ({
             textVariant='title'
             size='s'
             strength='weak'
-            css={{ display: 'block' }}
+            css={{ display: 'block', 'line-height': '125%' }}
             ellipses
           >
             {track.name}


### PR DESCRIPTION
### Description
Small UI bug

### How Has This Been Tested?

before:
<img width="106" alt="Screenshot 2024-04-29 at 3 24 44 PM" src="https://github.com/AudiusProject/audius-protocol/assets/3893871/44f2e651-b5ca-4945-92db-117d0cdf45c8">

after:
<img width="123" alt="Screenshot 2024-04-29 at 3 24 35 PM" src="https://github.com/AudiusProject/audius-protocol/assets/3893871/06660b40-2dd7-4a9e-9e56-abf4804d7677">
