### PR TITLE
[PAY-2817] Web collections show reposts, remove artist column

### DIFF
--- a/packages/web/src/pages/collection-page/components/desktop/CollectionPage.tsx
+++ b/packages/web/src/pages/collection-page/components/desktop/CollectionPage.tsx
@@ -274,18 +274,18 @@ const CollectionPage = ({
       return [
         'playButton',
         'trackName',
-        'artistName',
         isAlbum ? 'date' : 'addedDate',
         'length',
+        'reposts',
         'overflowActions'
       ]
     return [
       'playButton',
       'trackName',
-      'artistName',
       isAlbum ? 'date' : 'addedDate',
       'length',
       'plays',
+      'reposts',
       'overflowActions'
     ]
   }, [areAllTracksPremium, isAlbum, isNftPlaylist])


### PR DESCRIPTION
### Description
For collection page tracks tables:
- Remove artist column
- Show reposts column

### How Has This Been Tested?

Premium album
<img width="1920" alt="Screenshot 2024-04-29 at 9 05 59 PM" src="https://github.com/AudiusProject/audius-protocol/assets/3893871/e9ca78b6-e485-4eb9-9a82-ece5b585073b">


Normal album
<img width="1920" alt="Screenshot 2024-04-29 at 9 06 08 PM" src="https://github.com/AudiusProject/audius-protocol/assets/3893871/580320b0-f3f7-4a24-9b31-2371c10f7b07">
