### PR TITLE
[PAY-2789] Bug fix for retaining access on track removal from prem album

### DIFF
--- a/packages/discovery-provider/integration_tests/gated_content/test_access.py
+++ b/packages/discovery-provider/integration_tests/gated_content/test_access.py
@@ -112,7 +112,6 @@ usdc_stream_gated_track_previously_purchased_album = {
     "stream_conditions": usdc_gate_1,
     "is_download_gated": True,
     "download_conditions": usdc_gate_1,
-    "playlists_containing_track": [1],
     "playlists_previously_containing_track": {"2": {"time": 1711485199}},
 }
 tracks: List[Dict[str, Any]] = [


### PR DESCRIPTION
### Description
Main bug was that we were returning `False` early if `track_record.playlists_containing_track` didn't exist on line 92. After that, it seems reasonable to perform the following checks conditionally.

### How Has This Been Tested?

Local web against local stack - confirmed purchaser retains access to prem track that was removed from a prem album that the user previously purchased.