### PR TITLE
[ONC-82] Fix android notif permissions

### DIFF
--- a/packages/mobile/android/app/src/main/AndroidManifest.xml
+++ b/packages/mobile/android/app/src/main/AndroidManifest.xml
@@ -15,6 +15,7 @@
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
     <uses-permission android:name="android.permission.DOWNLOAD_WITHOUT_NOTIFICATION" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS"/>
 
     <uses-permission android:name="android.permission.CAMERA"/>
     <uses-permission android:name="android.permission.READ_MEDIA_IMAGES" />


### PR DESCRIPTION
### Description

While debugging android permission notifs, we found that settings were showing this for Audius:

![Screenshot_20240430-131605](https://github.com/AudiusProject/audius-protocol/assets/6711655/7a4f06ec-2c09-4050-a374-8cf5b5eea5a3)

Looking into the manifest revealed that we were missing a permission

### How Has This Been Tested?

on android:stage, after this change it now shows

![image](https://github.com/AudiusProject/audius-protocol/assets/6711655/bc9cd0b1-f7bb-49df-a849-064c3acb1981)

