### PR TITLE
[PAY-2796] Fix extra notifications on track removal from purchased album

### DIFF
--- a/packages/discovery-provider/ddl/functions/handle_playlist.sql
+++ b/packages/discovery-provider/ddl/functions/handle_playlist.sql
@@ -5,7 +5,6 @@ declare
   subscriber_user_ids integer[];
   old_row RECORD;
   delta int := 0;
-  purchase_record RECORD;
 begin
 
   insert into aggregate_user (user_id) values (new.playlist_owner_id) on conflict do nothing;
@@ -89,27 +88,6 @@ begin
     if new.is_delete IS FALSE and new.is_private IS FALSE then
       for track_item IN select jsonb_array_elements from jsonb_array_elements(new.playlist_contents->'track_ids')
       loop
-        -- Add notification for each purchaser
-        if new.is_album and new.is_stream_gated then
-          with album_purchasers as (
-            select distinct buyer_user_id
-              from usdc_purchases
-              where content_id = new.playlist_id
-              and content_type = 'album'
-          )
-            insert into notification
-              (blocknumber, user_ids, timestamp, type, specifier, group_id, data)
-              select
-                new.blocknumber,
-                array [album_purchaser.buyer_user_id],
-                new.updated_at,
-                'track_added_to_purchased_album',
-                album_purchaser.buyer_user_id,
-                'track_added_to_purchased_album:playlist_id:' || new.playlist_id || ':track_id:' || (track_item->>'track')::int,
-                json_build_object('track_id', (track_item->>'track')::int, 'playlist_id', new.playlist_id, 'playlist_owner_id', new.playlist_owner_id)
-              from album_purchasers as album_purchaser;
-        end if;
-
         -- Add notification for each track owner
         if (track_item->>'time')::double precision::int >= extract(epoch from new.updated_at)::int then
           select owner_id into track_owner_id from tracks where is_current and track_id=(track_item->>'track')::int;

--- a/packages/discovery-provider/ddl/functions/handle_playlist_track.sql
+++ b/packages/discovery-provider/ddl/functions/handle_playlist_track.sql
@@ -1,5 +1,3 @@
--- drop trigger on_playlist_track; -- DO NOT MERGE!!!!
-
 create or replace function handle_playlist_track() returns trigger as $$
 declare
   playlist_record RECORD;

--- a/packages/discovery-provider/ddl/functions/handle_playlist_track.sql
+++ b/packages/discovery-provider/ddl/functions/handle_playlist_track.sql
@@ -1,0 +1,49 @@
+-- drop trigger on_playlist_track; -- DO NOT MERGE!!!!
+
+create or replace function handle_playlist_track() returns trigger as $$
+declare
+  playlist_record RECORD;
+begin
+  select * into playlist_record from playlists where playlist_id = new.playlist_id limit 1;
+
+  -- Add notification for each purchaser
+  if playlist_record.is_stream_gated = true and jsonb_exists(playlist_record.stream_conditions, 'usdc_purchase') then
+    with album_purchasers as (
+      select distinct buyer_user_id
+        from usdc_purchases
+        where content_id = new.playlist_id
+        and content_type = 'album'
+    )
+      insert into notification
+        (blocknumber, user_ids, timestamp, type, specifier, group_id, data)
+        select
+          playlist_record.blocknumber,
+          array [album_purchaser.buyer_user_id],
+          new.updated_at,
+          'track_added_to_purchased_album',
+          album_purchaser.buyer_user_id,
+          'track_added_to_purchased_album:playlist_id:' || new.playlist_id || ':track_id:' || new.track_id,
+          json_build_object('track_id', new.track_id, 'playlist_id', new.playlist_id, 'playlist_owner_id', playlist_record.playlist_owner_id)
+        from album_purchasers as album_purchaser;
+  end if;
+  
+  return null;
+
+exception
+  when others then
+    raise warning 'An error occurred in %: %', tg_name, sqlerrm;
+    raise;
+
+end;
+$$ language plpgsql;
+
+
+do $$ begin
+  create trigger on_playlist_track
+  after insert on playlist_tracks
+  for each row execute procedure handle_playlist_track();
+exception
+  when others then null;
+end $$;
+
+


### PR DESCRIPTION
### Description
The desired behavior:
New notification for when a user purchases an album from an artist, then the artist adds a new track to that purchased album. Think "T Swift just released a new track to the album you already own so you can listen to it for no extra cost."

The bug:
When the artist removes a track from the album, purchasers were getting notifications for each remaining track that existed in the album. This is because we were looping over every existing track in the playlist contents, and inserting a notification row for each.

Solution:
Replace with a new sql function that runs on every new row added to `playlist_tracks` table (which contains 1 row per track-playlist relationship). These rows are unique and never get deleted, which avoids duplicates.

### How Has This Been Tested?

Tested with local stack:
- Confirmed new track added to purchased album notification works
- Confirmed no notification spam when artist removes a track from the purchased album
- Confirmed no extra notifications if artist deletes and re-adds same track to purchased album
- Confirmed no extra notifications if artist adds the same track multiple times to an album