### PR TITLE
[C-4285] Add claim all rewards button functionality

### DIFF
--- a/packages/common/src/store/pages/audio-rewards/slice.ts
+++ b/packages/common/src/store/pages/audio-rewards/slice.ts
@@ -200,6 +200,12 @@ const slice = createSlice({
     resetAndCancelClaimReward: (state) => {
       state.claimState = { status: ClaimStatus.NONE }
     },
+    claimAllChallengeRewards: (
+      state,
+      _action: PayloadAction<{ claims: AudioRewardsClaim[] }>
+    ) => {
+      state.claimState = { status: ClaimStatus.CLAIMING }
+    },
     claimChallengeReward: (
       state,
       _action: PayloadAction<{
@@ -235,6 +241,9 @@ const slice = createSlice({
     claimChallengeRewardSucceeded: (state) => {
       state.claimState = { status: ClaimStatus.SUCCESS }
     },
+    claimAllChallengeRewardsSucceeded: (state) => {
+      state.claimState = { status: ClaimStatus.CUMULATIVE_SUCCESS }
+    },
     showRewardClaimedToast: (state) => {
       state.showRewardClaimedToast = true
     },
@@ -257,10 +266,12 @@ export const {
   resetHCaptchaStatus,
   updateHCaptchaScore,
   claimChallengeReward,
+  claimAllChallengeRewards,
   claimChallengeRewardWaitForRetry,
   claimChallengeRewardAlreadyClaimed,
   claimChallengeRewardFailed,
   claimChallengeRewardSucceeded,
+  claimAllChallengeRewardsSucceeded,
   showRewardClaimedToast,
   resetRewardClaimedToast,
   updateOptimisticListenStreak,

--- a/packages/common/src/store/pages/audio-rewards/slice.ts
+++ b/packages/common/src/store/pages/audio-rewards/slice.ts
@@ -204,7 +204,7 @@ const slice = createSlice({
       state,
       _action: PayloadAction<{ claims: AudioRewardsClaim[] }>
     ) => {
-      state.claimState = { status: ClaimStatus.CLAIMING }
+      state.claimState = { status: ClaimStatus.CUMULATIVE_CLAIMING }
     },
     claimChallengeReward: (
       state,

--- a/packages/common/src/store/pages/audio-rewards/types.ts
+++ b/packages/common/src/store/pages/audio-rewards/types.ts
@@ -13,6 +13,7 @@ export type ClaimState =
   | { status: ClaimStatus.WAITING_FOR_RETRY }
   | { status: ClaimStatus.ALREADY_CLAIMED }
   | { status: ClaimStatus.SUCCESS }
+  | { status: ClaimStatus.CUMULATIVE_SUCCESS }
   | { status: ClaimStatus.ERROR; aaoErrorCode: number | undefined }
 
 export type AudioRewardsClaim = {
@@ -45,5 +46,6 @@ export enum ClaimStatus {
   WAITING_FOR_RETRY = 'waiting for retry',
   ALREADY_CLAIMED = 'already claimed',
   SUCCESS = 'success',
+  CUMULATIVE_SUCCESS = 'cumulative success',
   ERROR = 'error'
 }

--- a/packages/common/src/store/pages/audio-rewards/types.ts
+++ b/packages/common/src/store/pages/audio-rewards/types.ts
@@ -10,6 +10,7 @@ export type ChallengeRewardsModalType = ChallengeRewardID
 export type ClaimState =
   | { status: ClaimStatus.NONE }
   | { status: ClaimStatus.CLAIMING }
+  | { status: ClaimStatus.CUMULATIVE_CLAIMING }
   | { status: ClaimStatus.WAITING_FOR_RETRY }
   | { status: ClaimStatus.ALREADY_CLAIMED }
   | { status: ClaimStatus.SUCCESS }
@@ -43,6 +44,7 @@ export enum HCaptchaStatus {
 export enum ClaimStatus {
   NONE = 'none',
   CLAIMING = 'claiming',
+  CUMULATIVE_CLAIMING = 'cumulative claiming',
   WAITING_FOR_RETRY = 'waiting for retry',
   ALREADY_CLAIMED = 'already claimed',
   SUCCESS = 'success',

--- a/packages/mobile/src/components/challenge-rewards-drawer/ChallengeRewardsDrawerProvider.tsx
+++ b/packages/mobile/src/components/challenge-rewards-drawer/ChallengeRewardsDrawerProvider.tsx
@@ -118,15 +118,10 @@ export const ChallengeRewardsDrawerProvider = () => {
         claimChallengeReward({
           claim: {
             challengeId: modalType,
-            specifiers:
-              challenge.challenge_type === 'aggregate'
-                ? getClaimableChallengeSpecifiers(
-                    challenge.undisbursedSpecifiers,
-                    undisbursedUserChallenges
-                  )
-                : [
-                    { specifier: challenge.specifier, amount: challenge.amount }
-                  ],
+            specifiers: getClaimableChallengeSpecifiers(
+              challenge.undisbursedSpecifiers,
+              undisbursedUserChallenges
+            ),
             amount: challenge?.claimableAmount ?? 0
           },
           retryOnFailure: true

--- a/packages/web/src/common/store/pages/audio-rewards/sagas.ts
+++ b/packages/web/src/common/store/pages/audio-rewards/sagas.ts
@@ -329,11 +329,9 @@ function* claimSingleChallengeRewardAsync(
       }
       throw new Error('Some specifiers failed to claim')
     }
-
-    return { res: results, error: null }
   } catch (e) {
     console.error(e)
-    return { res: null, error: e }
+    throw new Error('Failed to claim for challenge')
   }
 }
 
@@ -538,12 +536,8 @@ function* claimChallengeRewardAsync(
   action: ReturnType<typeof claimChallengeReward>
 ) {
   try {
-    const { error } = yield* call(claimSingleChallengeRewardAsync, action)
-    if (error) {
-      yield* put(claimChallengeRewardFailed())
-    } else {
-      yield* put(claimChallengeRewardSucceeded())
-    }
+    yield* call(claimSingleChallengeRewardAsync, action)
+    yield* put(claimChallengeRewardSucceeded())
   } catch (e) {
     yield* put(claimChallengeRewardFailed())
   }
@@ -554,7 +548,7 @@ function* claimAllChallengeRewardsAsync(
 ) {
   const { claims } = action.payload
   try {
-    const results = yield* all(
+    yield* all(
       claims.map((claim) =>
         call(claimSingleChallengeRewardAsync, {
           type: claimChallengeReward.type,
@@ -562,12 +556,7 @@ function* claimAllChallengeRewardsAsync(
         })
       )
     )
-    const resultsWithError = results.filter((r) => r.error)
-    if (resultsWithError.length > 0) {
-      yield* put(claimChallengeRewardFailed())
-    } else {
-      yield* put(claimAllChallengeRewardsSucceeded())
-    }
+    yield* put(claimAllChallengeRewardsSucceeded())
   } catch (e) {
     console.error(e)
     yield* put(claimChallengeRewardFailed())

--- a/packages/web/src/pages/audio-rewards-page/components/modals/ChallengeRewardsModal/ChallengeRewardsModal.tsx
+++ b/packages/web/src/pages/audio-rewards-page/components/modals/ChallengeRewardsModal/ChallengeRewardsModal.tsx
@@ -375,15 +375,10 @@ const ChallengeRewardsBody = ({ dismissModal }: BodyProps) => {
         claimChallengeReward({
           claim: {
             challengeId: challenge.challenge_id,
-            specifiers:
-              challenge.challenge_type === 'aggregate'
-                ? getClaimableChallengeSpecifiers(
-                    challenge.undisbursedSpecifiers,
-                    undisbursedUserChallenges
-                  )
-                : [
-                    { specifier: challenge.specifier, amount: challenge.amount }
-                  ],
+            specifiers: getClaimableChallengeSpecifiers(
+              challenge.undisbursedSpecifiers,
+              undisbursedUserChallenges
+            ),
             amount: challenge.claimableAmount
           },
           retryOnFailure: true

--- a/packages/web/src/pages/audio-rewards-page/components/modals/ChallengeRewardsModal/ClaimAllRewardsModal.tsx
+++ b/packages/web/src/pages/audio-rewards-page/components/modals/ChallengeRewardsModal/ClaimAllRewardsModal.tsx
@@ -1,10 +1,21 @@
-import { useCallback } from 'react'
+import { useCallback, useContext, useEffect } from 'react'
 
 import {
   formatCooldownChallenges,
   useChallengeCooldownSchedule
 } from '@audius/common/hooks'
-import { formatNumberCommas } from '@audius/common/utils'
+import { ChallengeRewardID, SpecifierWithAmount } from '@audius/common/models'
+import {
+  ClaimStatus,
+  UndisbursedUserChallenge,
+  audioRewardsPageActions,
+  audioRewardsPageSelectors,
+  musicConfettiActions
+} from '@audius/common/store'
+import {
+  formatNumberCommas,
+  getClaimableChallengeSpecifiers
+} from '@audius/common/utils'
 import {
   Button,
   Flex,
@@ -12,10 +23,13 @@ import {
   ModalContent,
   Text
 } from '@audius/harmony'
+import { useDispatch, useSelector } from 'react-redux'
 
 import { useModalState } from 'common/hooks/useModalState'
 import { SummaryTable } from 'components/summary-table'
+import { ToastContext } from 'components/toast/ToastContext'
 import { useWithMobileStyle } from 'hooks/useWithMobileStyle'
+import { CLAIM_REWARD_TOAST_TIMEOUT_MILLIS } from 'utils/constants'
 
 import ModalDrawer from '../ModalDrawer'
 
@@ -25,23 +39,70 @@ const messages = {
   upcomingRewards: 'Upcoming Rewards',
   claimAudio: (amount: string) => `Claim ${amount} $AUDIO`,
   readyToClaim: 'Ready to claim!',
+  rewardsClaimed: 'All rewards claimed successfully!',
   rewards: 'Rewards',
   audio: '$AUDIO',
   description: 'You can check and claim all your upcoming rewards here.',
   done: 'Done'
 }
 
+const { show: showConfetti } = musicConfettiActions
+const { claimAllChallengeRewards } = audioRewardsPageActions
+const { getClaimStatus, getUndisbursedUserChallenges } =
+  audioRewardsPageSelectors
+
 export const ClaimAllRewardsModal = () => {
+  const dispatch = useDispatch()
+  const { toast } = useContext(ToastContext)
+  const wm = useWithMobileStyle(styles.mobile)
   const [isOpen, setOpen] = useModalState('ClaimAllRewards')
   const [isHCaptchaModalOpen] = useModalState('HCaptcha')
-  const wm = useWithMobileStyle(styles.mobile)
-
-  const { claimableAmount, cooldownChallenges, summary } =
+  const claimStatus = useSelector(getClaimStatus)
+  const undisbursedUserChallenges = useSelector(getUndisbursedUserChallenges)
+  const undisbursedUserChallengesMap = undisbursedUserChallenges.reduce<
+    Partial<Record<ChallengeRewardID, UndisbursedUserChallenge[]>>
+  >((acc, val) => {
+    acc[val.challenge_id] = [...(acc[val.challenge_id] || []), val]
+    return acc
+  }, {})
+  const { claimableAmount, claimableChallenges, cooldownChallenges, summary } =
     useChallengeCooldownSchedule({
       multiple: true
     })
-  const claimInProgress = false
-  const onClaimRewardClicked = useCallback(() => {}, [])
+  const claimInProgress = claimStatus === ClaimStatus.CUMULATIVE_CLAIMING
+
+  useEffect(() => {
+    if (claimStatus === ClaimStatus.CUMULATIVE_SUCCESS) {
+      toast(messages.rewardsClaimed, CLAIM_REWARD_TOAST_TIMEOUT_MILLIS)
+      dispatch(showConfetti())
+    }
+  }, [claimStatus, toast, dispatch])
+
+  const onClaimRewardClicked = useCallback(() => {
+    const claims = claimableChallenges.map((challenge) => {
+      const undisbursed =
+        undisbursedUserChallengesMap[challenge.challenge_id] || []
+      const undisbursedSpecifiers = undisbursed.reduce(
+        (acc, c) => [...acc, { specifier: c.specifier, amount: c.amount }],
+        [] as SpecifierWithAmount[]
+      )
+      return {
+        challengeId: challenge.challenge_id,
+        specifiers: getClaimableChallengeSpecifiers(
+          undisbursedSpecifiers,
+          undisbursedUserChallenges
+        ),
+        amount: challenge.amount
+      }
+    })
+    dispatch(claimAllChallengeRewards({ claims }))
+  }, [
+    dispatch,
+    claimableChallenges,
+    undisbursedUserChallengesMap,
+    undisbursedUserChallenges
+  ])
+
   const formatLabel = useCallback((item: any) => {
     const { label, claimableDate, isClose } = item
     const formattedLabel = isClose ? (
@@ -57,6 +118,7 @@ export const ClaimAllRewardsModal = () => {
       label: formattedLabel
     }
   }, [])
+
   return (
     <ModalDrawer
       title={messages.rewards}


### PR DESCRIPTION
### Description

Add an action and corresponding saga to handle claiming all rewards that are claimable.
Update component to show loading state while claiming, and display confetti on success.

Also fix functionality on native mobile + add claim all button loading state on native mobile and toast on successful claim.

### How Has This Been Tested?

local web dapp vs stage
