### PR TITLE
[PAY-2800] Fix mobile navigate to album on purchase success

### DIFF
--- a/packages/common/src/hooks/purchaseContent/types.ts
+++ b/packages/common/src/hooks/purchaseContent/types.ts
@@ -40,6 +40,11 @@ export type PurchaseableContentMetadata =
   | PurchaseableTrackDownloadMetadata
   | PurchaseableAlbumStreamMetadata
 
+export const isContentDownloadGated = (
+  metadata?: PurchaseableContentMetadata
+): metadata is PurchaseableTrackDownloadMetadata =>
+  !!metadata && 'is_download_gated' in metadata
+
 export type USDCPurchaseConfig = {
   minContentPriceCents: number
   maxContentPriceCents: number

--- a/packages/mobile/src/components/premium-content-purchase-drawer/PremiumContentPurchaseDrawer.tsx
+++ b/packages/mobile/src/components/premium-content-purchase-drawer/PremiumContentPurchaseDrawer.tsx
@@ -6,11 +6,7 @@ import {
   useGetTrackById,
   useGetUserById
 } from '@audius/common/api'
-import type {
-  PurchaseableTrackStreamMetadata,
-  PurchaseableTrackDownloadMetadata,
-  PurchaseableContentMetadata
-} from '@audius/common/hooks'
+import type { PurchaseableContentMetadata } from '@audius/common/hooks'
 import {
   useRemoteVar,
   useUSDCBalance,

--- a/packages/mobile/src/components/premium-content-purchase-drawer/PurchaseSuccess.tsx
+++ b/packages/mobile/src/components/premium-content-purchase-drawer/PurchaseSuccess.tsx
@@ -1,6 +1,5 @@
 import { useCallback } from 'react'
 
-import { capitalize } from '@audius/common/audius-query/utils'
 import {
   isPurchaseableAlbum,
   type PurchaseableContentMetadata
@@ -9,6 +8,7 @@ import {
   collectionsSocialActions,
   tracksSocialActions
 } from '@audius/common/store'
+import { capitalize } from 'lodash'
 import { useDispatch } from 'react-redux'
 
 import {

--- a/packages/mobile/src/components/premium-content-purchase-drawer/PurchaseSuccess.tsx
+++ b/packages/mobile/src/components/premium-content-purchase-drawer/PurchaseSuccess.tsx
@@ -1,5 +1,6 @@
 import { useCallback } from 'react'
 
+import { capitalize } from '@audius/common/audius-query/utils'
 import {
   isPurchaseableAlbum,
   type PurchaseableContentMetadata
@@ -29,7 +30,7 @@ const messages = {
   success: 'Your Purchase Was Successful!',
   shareTwitterText: (contentType: string, trackTitle: string, handle: string) =>
     `I bought the ${contentType} ${trackTitle} by ${handle} on @Audius! #AudiusPremium`,
-  viewTrack: 'View Track',
+  view: (contentType: string) => `View ${capitalize(contentType)}`,
   repost: 'Repost',
   reposted: 'Reposted'
 }
@@ -46,10 +47,12 @@ export const PurchaseSuccess = ({
   const isAlbum = isPurchaseableAlbum(metadata)
   const title = isAlbum ? metadata.playlist_name : metadata.title
   const contentId = isAlbum ? metadata.playlist_id : metadata.track_id
+  const contentType = isAlbum ? 'album' : 'track'
 
   const link = isAlbum
     ? getCollectionRoute(metadata)
     : getTrackRoute(metadata, true)
+  console.log('REED', { link })
 
   const dispatch = useDispatch()
 
@@ -122,7 +125,7 @@ export const PurchaseSuccess = ({
         onPress={onPressViewTrack}
         iconRight={IconCaretRight}
       >
-        {messages.viewTrack}
+        {messages.view(contentType)}
       </PlainButton>
     </Flex>
   )

--- a/packages/mobile/src/components/premium-content-purchase-drawer/PurchaseSuccess.tsx
+++ b/packages/mobile/src/components/premium-content-purchase-drawer/PurchaseSuccess.tsx
@@ -52,7 +52,6 @@ export const PurchaseSuccess = ({
   const link = isAlbum
     ? getCollectionRoute(metadata)
     : getTrackRoute(metadata, true)
-  console.log('REED', { link })
 
   const dispatch = useDispatch()
 


### PR DESCRIPTION
### Description
- Change copy to say "view album"
- Navigate to album in background on purchase success
- Add helper typeguard to split between the different `PurchasableContentMetadata` types.

### How Has This Been Tested?



https://github.com/AudiusProject/audius-protocol/assets/3893871/733c3fd3-2d10-4e6b-80f7-ddd8985b262a

