### PR TITLE
[PAY-2781] Poll for track access on album purchase

### DIFF
--- a/packages/common/src/store/gated-content/sagas.ts
+++ b/packages/common/src/store/gated-content/sagas.ts
@@ -441,11 +441,6 @@ export function* pollGatedContent({
   const initiallyHadNoStreamAccess = !cachedEntity?.access.stream
   const initiallyHadNoDownloadAccess = !cachedEntity?.access.download
 
-  // If already had acccess, no need to poll
-  if (!initiallyHadNoStreamAccess && !initiallyHadNoDownloadAccess) {
-    return
-  }
-
   // poll for access until it is granted
   while (true) {
     const apiEntity = isAlbum

--- a/packages/common/src/store/gated-content/sagas.ts
+++ b/packages/common/src/store/gated-content/sagas.ts
@@ -441,6 +441,11 @@ export function* pollGatedContent({
   const initiallyHadNoStreamAccess = !cachedEntity?.access.stream
   const initiallyHadNoDownloadAccess = !cachedEntity?.access.download
 
+  // If already had acccess, no need to poll
+  if (!initiallyHadNoStreamAccess && !initiallyHadNoDownloadAccess) {
+    return
+  }
+
   // poll for access until it is granted
   while (true) {
     const apiEntity = isAlbum

--- a/packages/common/src/store/purchase-content/sagas.ts
+++ b/packages/common/src/store/purchase-content/sagas.ts
@@ -313,15 +313,11 @@ function* pollForPurchaseConfirmation({
       metadata.playlist_contents.track_ids
     ) {
       const apiClient = yield* getContext('apiClient')
-      const tracks = yield* all(
-        Array.from(metadata.playlist_contents.track_ids).map((trackId) => {
-          return call([apiClient, 'getTrack'], {
-            id: trackId.track,
-            currentUserId
-          })
+      for (const trackId of metadata.playlist_contents.track_ids) {
+        const track = yield* call([apiClient, 'getTrack'], {
+          id: trackId.track,
+          currentUserId
         })
-      )
-      for (const track of tracks) {
         if (track) {
           yield* put(
             cacheActions.update(Kind.TRACKS, [

--- a/packages/common/src/store/purchase-content/sagas.ts
+++ b/packages/common/src/store/purchase-content/sagas.ts
@@ -4,6 +4,7 @@ import { takeLatest } from 'redux-saga/effects'
 import { call, put, race, select, take } from 'typed-redux-saga'
 
 import { PurchaseableContentMetadata, isPurchaseableAlbum } from '~/hooks'
+import { Kind } from '~/models'
 import { FavoriteSource, Name } from '~/models/Analytics'
 import { ErrorLevel } from '~/models/ErrorReporting'
 import { ID } from '~/models/Identifiers'
@@ -59,6 +60,7 @@ import {
 } from '~/store/ui/modals/coinflow-onramp-modal'
 import { BN_USDC_CENT_WEI } from '~/utils/wallet'
 
+import { cacheActions } from '../cache'
 import { pollGatedContent } from '../gated-content/sagas'
 import { updateGatedContentStatus } from '../gated-content/slice'
 import { saveCollection } from '../social/collections/actions'
@@ -78,8 +80,6 @@ import {
   PurchaseErrorCode
 } from './types'
 import { getBalanceNeeded } from './utils'
-import { cacheActions } from '../cache'
-import { Kind } from '~/models'
 
 const { getUserId, getAccountUser } = accountSelectors
 

--- a/packages/common/src/store/purchase-content/sagas.ts
+++ b/packages/common/src/store/purchase-content/sagas.ts
@@ -1,7 +1,7 @@
 import BN from 'bn.js'
 import { sumBy } from 'lodash'
 import { takeLatest } from 'redux-saga/effects'
-import { all, call, put, race, select, take } from 'typed-redux-saga'
+import { call, put, race, select, take } from 'typed-redux-saga'
 
 import { PurchaseableContentMetadata, isPurchaseableAlbum } from '~/hooks'
 import { FavoriteSource, Name } from '~/models/Analytics'


### PR DESCRIPTION
### Description
After purchasing an album, re-fetch the tracks inside of the album to update access.

### How Has This Been Tested?

Local web stage - confirmed all tracks in purchased album now show unlocked UI.
