### PR TITLE
[PAY-2791] Show only own albums in artist dashboard

### DIFF
--- a/packages/common/src/store/account/selectors.ts
+++ b/packages/common/src/store/account/selectors.ts
@@ -177,11 +177,13 @@ export const getAccountWithAlbums = createSelector(
   }
 )
 
-export const getAccountAlbums = createSelector(
+export const getAccountsOwnAlbums = createSelector(
   [getAccountWithCollections],
   (account) => {
     if (!account) return undefined
-    return account.collections.filter((c) => c.is_album)
+    return account.collections.filter(
+      (c) => c.is_album && account.user_id === c.playlist_owner_id
+    )
   }
 )
 

--- a/packages/common/src/store/account/selectors.ts
+++ b/packages/common/src/store/account/selectors.ts
@@ -177,7 +177,15 @@ export const getAccountWithAlbums = createSelector(
   }
 )
 
-export const getAccountsOwnAlbums = createSelector(
+export const getAccountAlbums = createSelector(
+  [getAccountWithCollections],
+  (account) => {
+    if (!account) return undefined
+    return account.collections.filter((c) => c.is_album)
+  }
+)
+
+export const getAccountOwnAlbums = createSelector(
   [getAccountWithCollections],
   (account) => {
     if (!account) return undefined

--- a/packages/common/src/store/account/selectors.ts
+++ b/packages/common/src/store/account/selectors.ts
@@ -177,14 +177,6 @@ export const getAccountWithAlbums = createSelector(
   }
 )
 
-export const getAccountAlbums = createSelector(
-  [getAccountWithCollections],
-  (account) => {
-    if (!account) return undefined
-    return account.collections.filter((c) => c.is_album)
-  }
-)
-
 export const getAccountOwnAlbums = createSelector(
   [getAccountWithCollections],
   (account) => {

--- a/packages/web/src/pages/dashboard-page/components/hooks.ts
+++ b/packages/web/src/pages/dashboard-page/components/hooks.ts
@@ -28,7 +28,7 @@ import {
   TrackFilters
 } from './types'
 
-const { getAccountsOwnAlbums } = accountSelectors
+const { getAccountOwnAlbums } = accountSelectors
 
 const messages = {
   public: 'Public',
@@ -268,7 +268,7 @@ const formatAlbumMetadata = (album: Collection): DataSourceAlbum => {
 
 /** Returns the logged-in user's albums, formatted for Artist Dashboard albums table */
 export const useFormattedAlbumData = () => {
-  const albums = useSelector(getAccountsOwnAlbums)
+  const albums = useSelector(getAccountOwnAlbums)
   const albumsFormatted = useMemo(() => {
     return albums?.map((album) => formatAlbumMetadata(album))
   }, [albums])

--- a/packages/web/src/pages/dashboard-page/components/hooks.ts
+++ b/packages/web/src/pages/dashboard-page/components/hooks.ts
@@ -28,7 +28,7 @@ import {
   TrackFilters
 } from './types'
 
-const { getAccountAlbums } = accountSelectors
+const { getAccountsOwnAlbums } = accountSelectors
 
 const messages = {
   public: 'Public',
@@ -268,7 +268,7 @@ const formatAlbumMetadata = (album: Collection): DataSourceAlbum => {
 
 /** Returns the logged-in user's albums, formatted for Artist Dashboard albums table */
 export const useFormattedAlbumData = () => {
-  const albums = useSelector(getAccountAlbums)
+  const albums = useSelector(getAccountsOwnAlbums)
   const albumsFormatted = useMemo(() => {
     return albums?.map((album) => formatAlbumMetadata(album))
   }, [albums])


### PR DESCRIPTION
### Description
In the artist dashboard, filter for only albums owned by the current user.

### How Has This Been Tested?

Local web stage