### PR TITLE
[PAY-2815] Show unlocked icon if dm content is purchased

### DIFF
--- a/packages/web/src/components/track/mobile/PlaylistTile.tsx
+++ b/packages/web/src/components/track/mobile/PlaylistTile.tsx
@@ -201,7 +201,11 @@ const renderLockedContent = ({
   variant
 }: LockedOrPlaysContentProps) => {
   if (isStreamGated && streamConditions && !isOwner) {
-    if (lockedContentType === 'premium' && variant === 'readonly') {
+    if (
+      !hasStreamAccess &&
+      lockedContentType === 'premium' &&
+      variant === 'readonly'
+    ) {
       return (
         <GatedConditionsPill
           streamConditions={streamConditions}

--- a/packages/web/src/components/track/mobile/TrackTile.tsx
+++ b/packages/web/src/components/track/mobile/TrackTile.tsx
@@ -100,7 +100,11 @@ const renderLockedContentOrPlayCount = ({
   lockedContentType
 }: LockedOrPlaysContentProps) => {
   if (isStreamGated && streamConditions && !isOwner) {
-    if (lockedContentType === 'premium' && variant === 'readonly') {
+    if (
+      !hasStreamAccess &&
+      lockedContentType === 'premium' &&
+      variant === 'readonly'
+    ) {
       return (
         <GatedConditionsPill
           streamConditions={streamConditions}


### PR DESCRIPTION
### Description

DM unfurls were showing the buy button for already purchased content. Fixed to show the unlocked icon if you own it already

![Screenshot 2024-05-01 at 4 54 32 PM](https://github.com/AudiusProject/audius-protocol/assets/2358254/77896978-e859-4847-916c-c60879e7511f)


### How Has This Been Tested?

local web