### PR TITLE
Retrigger logic for android notification permissions post-manifest fix

### DIFF
--- a/packages/mobile/src/components/notification-reminder/NotificationReminder.tsx
+++ b/packages/mobile/src/components/notification-reminder/NotificationReminder.tsx
@@ -1,8 +1,10 @@
 import { useCallback } from 'react'
 
+import AsyncStorage from '@react-native-async-storage/async-storage'
 import { getHasCompletedAccount } from 'common/store/pages/signon/selectors'
 import { checkNotifications, RESULTS } from 'react-native-permissions'
 import { useDispatch, useSelector } from 'react-redux'
+import { useAsync } from 'react-use'
 
 import useSessionCount from 'app/hooks/useSessionCount'
 import { setVisibility } from 'app/store/drawers/slice'
@@ -12,6 +14,7 @@ const REMINDER_FREQUENCY = 10
 
 export const NotificationReminder = () => {
   const hasCompletedAccount = useSelector(getHasCompletedAccount)
+
   if (hasCompletedAccount) {
     return <NotificationReminderInternal />
   }
@@ -21,40 +24,63 @@ export const NotificationReminder = () => {
 const NotificationReminderInternal = () => {
   const dispatch = useDispatch()
 
-  // Sets up reminders to turn on push notifications
   const remindUserToTurnOnNotifications = useCallback(async () => {
+    console.log('Reminding user')
     try {
       const { status } = await checkNotifications()
-      switch (status) {
-        case RESULTS.UNAVAILABLE:
-          // Notifications are not available (on this device / in this context).
-          // Do nothing.
-          return
-        case RESULTS.LIMITED:
-          // Some subset of notification features are enabled, let the user be.
-          // Do nothing.
-          return
-        case RESULTS.GRANTED:
-          // The user already has given notifications permissions!
-          // Do nothing.
-          return
-        case RESULTS.BLOCKED:
-          // The user has explicitly blocked notifications.
-          // Don't be a jerk.
-          // Do nothing.
-          return
-        case RESULTS.DENIED:
-          // The permission has not been requested or has been denied but it still requestable
-          // Appeal to the user to enable notifications
-          dispatch(
-            setVisibility({ drawer: 'EnablePushNotifications', visible: true })
-          )
-      }
+      console.log('STATUS', { status })
+      dispatch(
+        setVisibility({ drawer: 'EnablePushNotifications', visible: true })
+      )
+      // switch (status) {
+      //   case RESULTS.UNAVAILABLE:
+      //     // Notifications are not available (on this device / in this context).
+      //     // Do nothing.
+      //     return
+      //   case RESULTS.LIMITED:
+      //     // Some subset of notification features are enabled, let the user be.
+      //     // Do nothing.
+      //     return
+      //   case RESULTS.GRANTED:
+      //     // The user already has given notifications permissions!
+      //     // Do nothing.
+      //     return
+      //   case RESULTS.BLOCKED:
+      //     // The user has explicitly blocked notifications.
+      //     // Don't be a jerk.
+      //     // Do nothing.
+      //     return
+      //   case RESULTS.DENIED:
+      //     // The permission has not been requested or has been denied but it still requestable
+      //     // Appeal to the user to enable notifications
+      //     dispatch(
+      //       setVisibility({ drawer: 'EnablePushNotifications', visible: true })
+      //     )
+      //     return
+      // }
     } catch (error) {
+      console.log('EROOOROR')
       // Not sure what happened, but swallow the error. Not worth blocking on.
       console.error(error)
     }
   }, [dispatch])
+
+  useAsync(async () => {
+    const hasRetriggeredNotifs = await AsyncStorage.getItem('RETRIGGER_NOTIFS')
+    if (hasRetriggeredNotifs === null) {
+      // Not set at all yet - new patch
+      await AsyncStorage.setItem('RETRIGGER_NOTIFS', 'false')
+    } else {
+      // if (hasRetriggeredNotifs === 'true') {
+      if (hasRetriggeredNotifs !== 'true') {
+        console.log('Needs retriggering')
+        remindUserToTurnOnNotifications()
+        await AsyncStorage.setItem('RETRIGGER_NOTIFS', 'true')
+      }
+    }
+  })
+
+  // Sets up reminders to turn on push notifications
 
   useSessionCount(
     remindUserToTurnOnNotifications,

--- a/packages/mobile/src/components/notification-reminder/NotificationReminder.tsx
+++ b/packages/mobile/src/components/notification-reminder/NotificationReminder.tsx
@@ -28,38 +28,33 @@ const NotificationReminderInternal = () => {
     console.log('Reminding user')
     try {
       const { status } = await checkNotifications()
-      console.log('STATUS', { status })
-      dispatch(
-        setVisibility({ drawer: 'EnablePushNotifications', visible: true })
-      )
-      // switch (status) {
-      //   case RESULTS.UNAVAILABLE:
-      //     // Notifications are not available (on this device / in this context).
-      //     // Do nothing.
-      //     return
-      //   case RESULTS.LIMITED:
-      //     // Some subset of notification features are enabled, let the user be.
-      //     // Do nothing.
-      //     return
-      //   case RESULTS.GRANTED:
-      //     // The user already has given notifications permissions!
-      //     // Do nothing.
-      //     return
-      //   case RESULTS.BLOCKED:
-      //     // The user has explicitly blocked notifications.
-      //     // Don't be a jerk.
-      //     // Do nothing.
-      //     return
-      //   case RESULTS.DENIED:
-      //     // The permission has not been requested or has been denied but it still requestable
-      //     // Appeal to the user to enable notifications
-      //     dispatch(
-      //       setVisibility({ drawer: 'EnablePushNotifications', visible: true })
-      //     )
-      //     return
-      // }
+      switch (status) {
+        case RESULTS.UNAVAILABLE:
+          // Notifications are not available (on this device / in this context).
+          // Do nothing.
+          return
+        case RESULTS.LIMITED:
+          // Some subset of notification features are enabled, let the user be.
+          // Do nothing.
+          return
+        case RESULTS.GRANTED:
+          // The user already has given notifications permissions!
+          // Do nothing.
+          return
+        case RESULTS.BLOCKED:
+          // The user has explicitly blocked notifications.
+          // Don't be a jerk.
+          // Do nothing.
+          return
+        case RESULTS.DENIED:
+          // The permission has not been requested or has been denied but it still requestable
+          // Appeal to the user to enable notifications
+          dispatch(
+            setVisibility({ drawer: 'EnablePushNotifications', visible: true })
+          )
+          return
+      }
     } catch (error) {
-      console.log('EROOOROR')
       // Not sure what happened, but swallow the error. Not worth blocking on.
       console.error(error)
     }
@@ -73,9 +68,11 @@ const NotificationReminderInternal = () => {
     } else {
       // if (hasRetriggeredNotifs === 'true') {
       if (hasRetriggeredNotifs !== 'true') {
-        console.log('Needs retriggering')
+        console.log('Needs retriggering', { hasRetriggeredNotifs })
         remindUserToTurnOnNotifications()
         await AsyncStorage.setItem('RETRIGGER_NOTIFS', 'true')
+      } else {
+        console.log('Doesnt need retriggering', { hasRetriggeredNotifs })
       }
     }
   })

--- a/packages/mobile/src/components/notification-reminder/NotificationReminder.tsx
+++ b/packages/mobile/src/components/notification-reminder/NotificationReminder.tsx
@@ -1,7 +1,9 @@
 import { useCallback } from 'react'
 
+import { MobileOS } from '@audius/common/models'
 import AsyncStorage from '@react-native-async-storage/async-storage'
 import { getHasCompletedAccount } from 'common/store/pages/signon/selectors'
+import { Platform } from 'react-native'
 import { checkNotifications, RESULTS } from 'react-native-permissions'
 import { useDispatch, useSelector } from 'react-redux'
 import { useAsync } from 'react-use'
@@ -68,8 +70,9 @@ const NotificationReminderInternal = () => {
      * This value should be one-time-use (created & set to true in the same session)
      */
     const hasRetriggeredNotifs = await AsyncStorage.getItem('RETRIGGER_NOTIFS')
+    const isAndroid = Platform.OS === MobileOS.ANDROID
 
-    if (hasRetriggeredNotifs === null) {
+    if (hasRetriggeredNotifs === null && isAndroid) {
       // Not set at all yet - this was introduced in 1.5.78 for a
       await AsyncStorage.setItem('RETRIGGER_NOTIFS', 'false')
     } else {

--- a/packages/mobile/src/notifications.ts
+++ b/packages/mobile/src/notifications.ts
@@ -1,7 +1,9 @@
+import { MobileOS } from '@audius/common/models'
 import AsyncStorage from '@react-native-async-storage/async-storage'
 import { Platform } from 'react-native'
 import { Notifications } from 'react-native-notifications'
 import type { Registered, Notification } from 'react-native-notifications'
+import { PERMISSIONS, request } from 'react-native-permissions'
 
 import { track, make } from 'app/services/analytics'
 import { EventNames } from 'app/types/analytics'
@@ -91,9 +93,18 @@ class PushNotifications {
     return await Notifications.isRegisteredForRemoteNotifications()
   }
 
-  requestPermission() {
+  async requestPermission() {
+    const isAndroid = Platform.OS === MobileOS.ANDROID
     isRegistering = true
-    Notifications.registerRemoteNotifications()
+
+    if (isAndroid) {
+      console.log('is android')
+      // await request(PERMISSIONS.ANDROID.POST_NOTIFICATIONS)
+      Notifications.registerRemoteNotifications()
+    } else {
+      // iOS
+      Notifications.registerRemoteNotifications()
+    }
   }
 
   cancelNotif() {

--- a/packages/mobile/src/notifications.ts
+++ b/packages/mobile/src/notifications.ts
@@ -97,6 +97,9 @@ class PushNotifications {
     const isAndroid = Platform.OS === MobileOS.ANDROID
     isRegistering = true
 
+    const alreadyHasPerms = await this.hasPermission()
+
+    console.log({ alreadyHasPerms })
     if (isAndroid) {
       console.log('is android')
       // await request(PERMISSIONS.ANDROID.POST_NOTIFICATIONS)

--- a/packages/mobile/src/notifications.ts
+++ b/packages/mobile/src/notifications.ts
@@ -97,13 +97,9 @@ class PushNotifications {
     const isAndroid = Platform.OS === MobileOS.ANDROID
     isRegistering = true
 
-    const alreadyHasPerms = await this.hasPermission()
-
-    console.log({ alreadyHasPerms })
     if (isAndroid) {
-      console.log('is android')
-      // await request(PERMISSIONS.ANDROID.POST_NOTIFICATIONS)
-      Notifications.registerRemoteNotifications()
+      // For android, Notifications.registerRemoteNotifications is supposed to prompt user for permission but its currently not
+      await request(PERMISSIONS.ANDROID.POST_NOTIFICATIONS)
     } else {
       // iOS
       Notifications.registerRemoteNotifications()

--- a/packages/mobile/src/store/settings/sagas.ts
+++ b/packages/mobile/src/store/settings/sagas.ts
@@ -44,12 +44,8 @@ export function* deregisterPushNotifications() {
 }
 
 function* registerDeviceToken() {
-  let { token, os } = yield* call([PushNotifications, 'getToken'])
-
-  if (!token) {
-    yield* call([PushNotifications, 'requestPermission'])
-    ;({ token, os } = yield* call([PushNotifications, 'getToken']))
-  }
+  yield* call([PushNotifications, 'requestPermission'])
+  const { token, os } = yield* call([PushNotifications, 'getToken'])
 
   const audiusBackend = yield* getContext('audiusBackendInstance')
   yield* call(audiusBackend.registerDeviceToken, token, os)
@@ -72,6 +68,7 @@ function* reregisterDeviceTokenOnStartup() {
 }
 
 function* enablePushNotifications() {
+  console.log('ENABLING PUSH NOTIS')
   yield* call(registerDeviceToken)
 
   const audiusBackendInstance = yield* getContext('audiusBackendInstance')
@@ -156,10 +153,12 @@ function* watchUpdatePushNotificationSettings() {
     settingsPageActions.TOGGLE_PUSH_NOTIFICATION_SETTING,
     function* (action: settingsPageActions.TogglePushNotificationSetting) {
       let isOn = action.isOn
+      console.log({ isOn })
 
       try {
         if (action.notificationType === PushNotificationSetting.MobilePush) {
           if (isOn) {
+            console.log('calling enable push')
             yield* call(enablePushNotifications)
           } else {
             yield* call(disablePushNotifications)

--- a/packages/mobile/src/store/settings/sagas.ts
+++ b/packages/mobile/src/store/settings/sagas.ts
@@ -68,7 +68,6 @@ function* reregisterDeviceTokenOnStartup() {
 }
 
 function* enablePushNotifications() {
-  console.log('ENABLING PUSH NOTIS')
   yield* call(registerDeviceToken)
 
   const audiusBackendInstance = yield* getContext('audiusBackendInstance')
@@ -153,12 +152,10 @@ function* watchUpdatePushNotificationSettings() {
     settingsPageActions.TOGGLE_PUSH_NOTIFICATION_SETTING,
     function* (action: settingsPageActions.TogglePushNotificationSetting) {
       let isOn = action.isOn
-      console.log({ isOn })
 
       try {
         if (action.notificationType === PushNotificationSetting.MobilePush) {
           if (isOn) {
-            console.log('calling enable push')
             yield* call(enablePushNotifications)
           } else {
             yield* call(disablePushNotifications)


### PR DESCRIPTION
### Description

After #8279 I realized that permissions are still disabled even after the manifest change; so we needed a way to one-off trigger our notif permission modal and ask for them again
In the process I realized the existing setup wasn't working because it wasn't popping up the native Android window for some reason.
This PR fixes both.

### How Has This Been Tested?
on android:stage
1. Deleted app 
2. Built old version of code (used commit on main 1 before my previous change)
3. Verified that notifications setting is grayed out + off 
4. Signed into the app & clicked on the "enable notifs" modal
5. Rebuilt app with the manifest changes (used latest release-1.5.78 changes)
6. Verified notifications setting is no longer grayed out but still off
7. Swapped to this branch
8. Open the app again
9. Notifications modal popped up
10. Verified notifications setting is now turned on
11. Closed app and started a new session then verified that the notif permission drawer up didn't show again
12. Reinstalled app and verified that a new user gets notifications set up as expected 

TODO:

- [ ] Test with some staging guinea pigs (aka any of our peeps that have android on staging; Reed/Marcus/whoever)
- [ ] Test some actual notifications; my understanding is that we have no way to do this until prod though 😞

