### PR TITLE
Make audius-compose use plain progress for CI

### DIFF
--- a/dev-tools/audius-compose
+++ b/dev-tools/audius-compose
@@ -223,6 +223,7 @@ def build(
                 [
                     "docker",
                     "compose",
+                    "--progress=plain",
                     f"--project-directory={protocol_dir / 'dev-tools/compose'}",
                     f"--file={protocol_dir / 'dev-tools/compose/docker-compose.yml'}",
                     f"--project-name={protocol_dir.name}",
@@ -240,6 +241,7 @@ def build(
         [
             "docker",
             "compose",
+            "--progress=plain",
             f"--project-directory={protocol_dir / 'dev-tools/compose'}",
             f"--file={protocol_dir / 'dev-tools/compose/docker-compose.yml'}",
             f"--project-name={protocol_dir.name}",
@@ -428,6 +430,7 @@ def pull(ctx):
         [
             "docker",
             "compose",
+            "--progress=plain",
             f"--file={protocol_dir / 'dev-tools/compose/docker-compose.yml'}",
             f"--project-name={protocol_dir.name}",
             f"--project-directory={protocol_dir / 'dev-tools/compose'}",
@@ -559,6 +562,7 @@ def up(
             [
                 "docker",
                 "compose",
+                "--progress=plain",
                 f"--project-directory={protocol_dir / 'dev-tools/compose'}",
                 f"--project-name={protocol_dir.name}",
                 f"--file={protocol_dir / 'dev-tools/compose/docker-compose.yml'}",
@@ -581,6 +585,7 @@ def down(protocol_dir):
         [
             "docker",
             "compose",
+            "--progress=plain",
             f"--project-directory={protocol_dir / 'dev-tools/compose'}",
             f"--project-name={protocol_dir.name}",
             f"--file={protocol_dir / 'dev-tools/compose/docker-compose.yml'}",
@@ -622,6 +627,7 @@ def test_build(protocol_dir):
         [
             "docker",
             "compose",
+            "--progress=plain",
             f"--file={protocol_dir / 'dev-tools/compose/docker-compose.test.yml'}",
             f"--project-name={protocol_dir.name}-test",
             f"--project-directory={protocol_dir / 'dev-tools/compose'}",
@@ -633,6 +639,7 @@ def test_build(protocol_dir):
         [
             "docker",
             "compose",
+            "--progress=plain",
             f"--file={protocol_dir / 'dev-tools/compose/docker-compose.test.yml'}",
             f"--project-name={protocol_dir.name}-test",
             f"--project-directory={protocol_dir / 'dev-tools/compose'}",
@@ -677,6 +684,7 @@ def test_run(protocol_dir, service, args):
         [
             "docker",
             "compose",
+            "--progress=plain",
             f"--file={protocol_dir / 'dev-tools/compose/docker-compose.test.yml'}",
             f"--project-name={protocol_dir.name}-test",
             f"--project-directory={protocol_dir / 'dev-tools/compose'}",
@@ -721,6 +729,7 @@ def test_up(protocol_dir, service):
             [
                 "docker",
                 "compose",
+                "--progress=plain",
                 f"--file={protocol_dir / 'dev-tools/compose/docker-compose.test.yml'}",
                 f"--project-name={protocol_dir.name}-test",
                 f"--project-directory={protocol_dir / 'dev-tools/compose'}",
@@ -742,6 +751,7 @@ def test_down(protocol_dir):
         [
             "docker",
             "compose",
+            "--progress=plain",
             f"--file={protocol_dir / 'dev-tools/compose/docker-compose.test.yml'}",
             f"--project-name={protocol_dir.name}-test",
             f"--project-directory={protocol_dir / 'dev-tools/compose'}",


### PR DESCRIPTION
### Description

CircleCI jobs show long and poorly formatted logs for CI jobs due to the way docker compose output is handled.

### How Has This Been Tested?

CI