### PR TITLE
Content-Length header for images

### DIFF
--- a/mediorum/server/serve_image.go
+++ b/mediorum/server/serve_image.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io"
 	"mime"
+	"net/http"
 	"strings"
 	"time"
 
@@ -24,13 +25,9 @@ func (ss *MediorumServer) serveImage(c echo.Context) error {
 
 	// helper function... only sets cache-control header on success
 	serveSuccessWithReader := func(blob *blob.Reader) error {
-		blobData, err := io.ReadAll(blob)
-		if err != nil {
-			return err
-		}
-		blob.Close()
 		c.Response().Header().Set(echo.HeaderCacheControl, "public, max-age=2592000, immutable")
-		return c.Blob(200, blob.ContentType(), blobData)
+		http.ServeContent(c.Response(), c.Request(), jobID+variant, blob.ModTime(), blob)
+		return nil
 	}
 
 	serveSuccess := func(blobPath string) error {

--- a/mediorum/server/server.go
+++ b/mediorum/server/server.go
@@ -252,7 +252,6 @@ func New(config MediorumConfig) (*MediorumServer, error) {
 	echoServer.Use(middleware.Recover())
 	echoServer.Use(middleware.Logger())
 	echoServer.Use(middleware.CORS())
-	echoServer.Use(middleware.Gzip())
 
 	ss := &MediorumServer{
 		echo:             echoServer,


### PR DESCRIPTION
### Description

* use `http.ServeContent` for images, which will correctly set Content-Length header
* disable gzip middleware in mediorum server.  See [this](https://github.com/labstack/echo/issues/444) and [this](https://images.weserv.nl/faq/#are-images-compressed-in-any-way) for some reasoning.

### How Has This Been Tested?

Deployed to stage creator 6
