### PR TITLE
ddex: handle updates and deletes

### DIFF
--- a/packages/ddex/processor/PROD.md
+++ b/packages/ddex/processor/PROD.md
@@ -1,0 +1,39 @@
+```bash
+curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.3/install.sh | bash
+
+# source ~/.bashrc
+# clone audius repo
+
+cd audius-protocol
+nvm install
+
+sudo apt install -y python3 make g++ curl bash git
+
+CI=true npm i
+
+npm run sdk
+
+cd packages/ddex/procesor
+
+npx tsx cli server &
+
+# or
+# npx pm2 start 'npm start'
+
+```
+
+
+setup `/etc/caddy/Caddyfile` like:
+
+```
+ddex2.staging.audius.co
+
+reverse_proxy "localhost:8989"
+```
+
+
+setup .env with:
+
+```
+DDEX_URL='https://ddex2.staging.audius.co'
+```

--- a/packages/ddex/processor/PROD.md
+++ b/packages/ddex/processor/PROD.md
@@ -15,10 +15,13 @@ npm run sdk
 
 cd packages/ddex/procesor
 
-npx tsx cli server &
+npx tsx cli server
 
 # or
 # npx pm2 start 'npm start'
+
+# also setup pm2 to run on boot:
+# https://pm2.keymetrics.io/docs/usage/startup/
 
 ```
 
@@ -26,6 +29,12 @@ npx tsx cli server &
 setup `/etc/caddy/Caddyfile` like:
 
 ```
+{
+    servers :443 {
+        protocols h1
+    }
+}
+
 ddex2.staging.audius.co
 
 reverse_proxy "localhost:8989"

--- a/packages/ddex/processor/README.md
+++ b/packages/ddex/processor/README.md
@@ -39,11 +39,8 @@ npx tsx watch cli.ts server
 
 ## simulate rematch
 
-```sql
-sqlite3 data/dev.db
-
-insert into users (id, handle, name) values ('2fuga', '2FUGA', '2FUGA') on conflict do nothing;
-insert into users (id, handle, name) values ('FUGARIAN', 'FUGARIAN', 'FUGARIAN') on conflict do nothing;
+```bash
+sqlite3 data/dev.db "insert into users (id, handle, name) values ('2fuga', '2FUGA', '2FUGA') on conflict do nothing; insert into users (id, handle, name) values ('FUGARIAN', 'FUGARIAN', 'FUGARIAN') on conflict do nothing;"
 ```
 
 * visit http://localhost:8989/releases

--- a/packages/ddex/processor/fixtures/01_delivery.xml
+++ b/packages/ddex/processor/fixtures/01_delivery.xml
@@ -20,7 +20,7 @@
         <FullName>Tiki Labs, Inc.</FullName>
       </PartyName>
     </MessageRecipient>
-    <MessageCreatedDateTime>2024-04-01T12:00:00Z</MessageCreatedDateTime>
+    <MessageCreatedDateTime>2024-04-01T05:00:00Z</MessageCreatedDateTime>
   </MessageHeader>
   <ResourceList>
     <SoundRecording>

--- a/packages/ddex/processor/fixtures/01_delivery.xml
+++ b/packages/ddex/processor/fixtures/01_delivery.xml
@@ -109,6 +109,7 @@
       </ReferenceTitle>
       <ReleaseResourceReferenceList>
         <ReleaseResourceReference>A1</ReleaseResourceReference>
+        <ReleaseResourceReference>A2</ReleaseResourceReference>
       </ReleaseResourceReferenceList>
       <ReleaseDetailsByTerritory>
         <TerritoryCode>Worldwide</TerritoryCode>
@@ -119,6 +120,18 @@
           <Year>2024</Year>
           <CLineText>© 2024 Label Name</CLineText>
         </CLine>
+
+        <Genre>
+          <GenreText>Folk</GenreText>
+          <SubGenre>Indie Folk</SubGenre>
+        </Genre>
+        <DisplayArtist SequenceNumber="1">
+          <PartyName>
+            <FullName>DJ Theo</FullName>
+          </PartyName>
+          <ArtistRole>MainArtist</ArtistRole>
+        </DisplayArtist>
+
       </ReleaseDetailsByTerritory>
     </Release>
   </ReleaseList>

--- a/packages/ddex/processor/fixtures/02_update.xml
+++ b/packages/ddex/processor/fixtures/02_update.xml
@@ -110,6 +110,7 @@
 
       <ReleaseResourceReferenceList>
         <ReleaseResourceReference>A1</ReleaseResourceReference>
+        <ReleaseResourceReference>A2</ReleaseResourceReference>
       </ReleaseResourceReferenceList>
 
       <ReleaseDetailsByTerritory>
@@ -121,6 +122,18 @@
           <Year>2024</Year>
           <CLineText>© 2024 Label Name</CLineText>
         </CLine>
+
+        <Genre>
+          <GenreText>Folk</GenreText>
+          <SubGenre>Indie Folk</SubGenre>
+        </Genre>
+        <DisplayArtist SequenceNumber="1">
+          <PartyName>
+            <FullName>DJ Theo</FullName>
+          </PartyName>
+          <ArtistRole>MainArtist</ArtistRole>
+        </DisplayArtist>
+
       </ReleaseDetailsByTerritory>
     </Release>
   </ReleaseList>

--- a/packages/ddex/processor/fixtures/02_update.xml
+++ b/packages/ddex/processor/fixtures/02_update.xml
@@ -20,7 +20,7 @@
         <FullName>Tiki Labs, Inc.</FullName>
       </PartyName>
     </MessageRecipient>
-    <MessageCreatedDateTime>2024-04-01T12:00:00Z</MessageCreatedDateTime>
+    <MessageCreatedDateTime>2024-04-01T06:00:00Z</MessageCreatedDateTime>
   </MessageHeader>
   <ResourceList>
     <SoundRecording>

--- a/packages/ddex/processor/fixtures/03_delete.xml
+++ b/packages/ddex/processor/fixtures/03_delete.xml
@@ -18,7 +18,7 @@
         <FullName>Tiki Labs, Inc.</FullName>
       </PartyName>
     </MessageRecipient>
-    <MessageCreatedDateTime>2024-04-02T12:00:00Z</MessageCreatedDateTime>
+    <MessageCreatedDateTime>2024-04-02T07:00:00Z</MessageCreatedDateTime>
   </MessageHeader>
   <PurgedRelease>
     <ReleaseId>

--- a/packages/ddex/processor/src/parseDelivery.test.ts
+++ b/packages/ddex/processor/src/parseDelivery.test.ts
@@ -1,14 +1,18 @@
 import { expect, test } from 'vitest'
 import {
+  DDEXRelease,
   DealEthGated,
   DealFollowGated,
   DealPayGated,
   DealSolGated,
   parseDdexXmlFile,
 } from './parseDelivery'
+import { readFileSync } from 'node:fs'
 
 test('deal types', async () => {
-  const releases = await parseDdexXmlFile('fixtures/dealTypes.xml')
+  const releases = (await parseDdexXmlFile(
+    'fixtures/dealTypes.xml'
+  )) as DDEXRelease[]
 
   expect(releases[1].deal).toMatchObject<Partial<DealPayGated>>({
     audiusDealType: 'PayGated',

--- a/packages/ddex/processor/src/parseDelivery.ts
+++ b/packages/ddex/processor/src/parseDelivery.ts
@@ -203,7 +203,7 @@ export function parseDdexXml(xmlUrl: string, xmlText: string) {
   if (tagName == 'ManifestMessage') {
     console.log('todo: batch')
   } else if (tagName == 'PurgeReleaseMessage') {
-    const purge = parsePurge($)
+    const purge = parsePurgeXml($)
     const key = releaseRepo.chooseReleaseId(purge.releaseIds)
     const prior = releaseRepo.get(key)
     if (!prior) {
@@ -231,7 +231,7 @@ export function parseDdexXml(xmlUrl: string, xmlText: string) {
 //
 // parseRelease
 //
-export function parseReleaseXml($: cheerio.CheerioAPI) {
+function parseReleaseXml($: cheerio.CheerioAPI) {
   function toTexts($doc: CH) {
     return $doc.map((_, el) => $(el).text()).get()
   }
@@ -527,7 +527,8 @@ export function parseReleaseXml($: cheerio.CheerioAPI) {
 // parse purge
 //
 
-function parsePurge($: cheerio.CheerioAPI): DDEXPurgeRelease {
+function parsePurgeXml($: cheerio.CheerioAPI): DDEXPurgeRelease {
+  // todo: is it possible multiple releases purged in one message?
   const releaseIds = parseReleaseIds($('PurgedRelease').first())
   return { releaseIds }
 }

--- a/packages/ddex/processor/src/parseDelivery.ts
+++ b/packages/ddex/processor/src/parseDelivery.ts
@@ -203,19 +203,9 @@ export function parseDdexXml(xmlUrl: string, xmlText: string) {
   if (tagName == 'ManifestMessage') {
     console.log('todo: batch')
   } else if (tagName == 'PurgeReleaseMessage') {
-    const purge = parsePurgeXml($)
-    const key = releaseRepo.chooseReleaseId(purge.releaseIds)
-    const prior = releaseRepo.get(key)
-    if (!prior) {
-      console.log(`got purge release but no prior ${key}`)
-    } else {
-      releaseRepo.update({
-        key,
-        status: ReleaseProcessingStatus.DeletePending,
-        xmlUrl,
-      })
-    }
-    return purge
+    // mark release rows as DeletePending
+    const { releaseIds } = parsePurgeXml($)
+    releaseRepo.markForDelete(xmlUrl, messageTimestamp, releaseIds)
   } else if (tagName == 'NewReleaseMessage') {
     // create or replace this release in db
     const releases = parseReleaseXml($)

--- a/packages/ddex/processor/src/parseDelivery.ts
+++ b/packages/ddex/processor/src/parseDelivery.ts
@@ -220,7 +220,7 @@ export function parseDdexXml(xmlUrl: string, xmlText: string) {
     // create or replace this release in db
     const releases = parseReleaseXml($)
     for (const release of releases) {
-      releaseRepo.upsert(xmlUrl, release)
+      releaseRepo.upsert(xmlUrl, messageTimestamp, release)
     }
     return releases
   } else {

--- a/packages/ddex/processor/src/parseTakedown.test.ts
+++ b/packages/ddex/processor/src/parseTakedown.test.ts
@@ -24,7 +24,7 @@ test('crud', async () => {
     await parseDdexXmlFile('fixtures/01_delivery.xml')
     const rr = releaseRepo.get(grid)!
     expect(rr._parsed?.soundRecordings[0].title).toBe('Example Song')
-    expect(rr.status).toBe(ReleaseProcessingStatus.Parsed)
+    expect(rr.status).toBe(ReleaseProcessingStatus.PublishPending)
   }
 
   // simulate publish
@@ -35,7 +35,7 @@ test('crud', async () => {
     await parseDdexXmlFile('fixtures/02_update.xml')
     const rr = releaseRepo.get(grid)!
     expect(rr._parsed?.soundRecordings[0].title).toBe('Updated Example Song')
-    expect(rr.status).toBe(ReleaseProcessingStatus.Parsed)
+    expect(rr.status).toBe(ReleaseProcessingStatus.PublishPending)
   }
 
   // simulate publish

--- a/packages/ddex/processor/src/parseTakedown.test.ts
+++ b/packages/ddex/processor/src/parseTakedown.test.ts
@@ -2,36 +2,57 @@ import { readFileSync } from 'fs'
 import { expect, test } from 'vitest'
 
 import * as cheerio from 'cheerio'
-import { parseDdexXmlFile, parseReleaseIds } from './parseDelivery'
-import { releaseRepo } from './db'
+import {
+  DDEXPurgeRelease,
+  parseDdexXmlFile,
+  parseReleaseIds,
+} from './parseDelivery'
+import { ReleaseProcessingStatus, releaseRepo, userRepo } from './db'
 
 test('crud', async () => {
+  const grid = 'A1B2C3D4E5F6G7H8I9J0K1L2M3N4O5P6Q7R8S9T0'
+
+  // create user for artist matching
+  userRepo.upsert({
+    id: 'djtheo',
+    handle: 'djtheo',
+    name: 'DJ Theo',
+  })
+
   // load 01
   {
     await parseDdexXmlFile('fixtures/01_delivery.xml')
-    const rr = releaseRepo.get('A1B2C3D4E5F6G7H8I9J0K1L2M3N4O5P6Q7R8S9T0')
-    expect(rr?._parsed?.soundRecordings[0].title).toBe('Example Song')
+    const rr = releaseRepo.get(grid)!
+    expect(rr._parsed?.soundRecordings[0].title).toBe('Example Song')
+    expect(rr.status).toBe(ReleaseProcessingStatus.Parsed)
   }
+
+  // simulate publish
+  releaseRepo.update({ key: grid, status: ReleaseProcessingStatus.Published })
 
   // load 02 update
   {
     await parseDdexXmlFile('fixtures/02_update.xml')
-    const rr = releaseRepo.get('A1B2C3D4E5F6G7H8I9J0K1L2M3N4O5P6Q7R8S9T0')
-    expect(rr?._parsed?.soundRecordings[0].title).toBe('Updated Example Song')
+    const rr = releaseRepo.get(grid)!
+    expect(rr._parsed?.soundRecordings[0].title).toBe('Updated Example Song')
+    expect(rr.status).toBe(ReleaseProcessingStatus.Parsed)
+  }
+
+  // simulate publish
+  releaseRepo.update({ key: grid, status: ReleaseProcessingStatus.Published })
+
+  // reprocess older 01 .. should be a noop
+  {
+    await parseDdexXmlFile('fixtures/01_delivery.xml')
+    const rr = releaseRepo.get(grid)!
+    expect(rr._parsed?.soundRecordings[0].title).toBe('Updated Example Song')
+    expect(rr.status).toBe(ReleaseProcessingStatus.Published)
   }
 
   // load 03 delete
   {
-    const rawXml = readFileSync('fixtures/03_delete.xml', 'utf8')
-    const $ = cheerio.load(rawXml, { xmlMode: true })
-
-    const messageTs = $('MessageCreatedDateTime').first().text()
-    expect(messageTs).toEqual('2024-04-02T12:00:00Z')
-
-    const releaseIds = parseReleaseIds($('PurgedRelease').first())
-    expect(releaseIds).toMatchObject({
-      grid: 'A1B2C3D4E5F6G7H8I9J0K1L2M3N4O5P6Q7R8S9T0',
-    })
-    console.log(releaseIds)
+    await parseDdexXmlFile('fixtures/03_delete.xml')
+    const rr = releaseRepo.get(grid)!
+    expect(rr.status).toBe(ReleaseProcessingStatus.DeletePending)
   }
 })

--- a/packages/ddex/processor/src/parseTakedown.test.ts
+++ b/packages/ddex/processor/src/parseTakedown.test.ts
@@ -55,4 +55,14 @@ test('crud', async () => {
     const rr = releaseRepo.get(grid)!
     expect(rr.status).toBe(ReleaseProcessingStatus.DeletePending)
   }
+
+  // simulate delete
+  releaseRepo.update({ key: grid, status: ReleaseProcessingStatus.Deleted })
+
+  // re-load 03 delete... should be noop
+  {
+    await parseDdexXmlFile('fixtures/03_delete.xml')
+    const rr = releaseRepo.get(grid)!
+    expect(rr.status).toBe(ReleaseProcessingStatus.Deleted)
+  }
 })

--- a/packages/ddex/processor/src/publishRelease.ts
+++ b/packages/ddex/processor/src/publishRelease.ts
@@ -31,32 +31,20 @@ export async function publishValidPendingReleases(opts?: {
     // todo: remove
     parsed.audiusUser = 'KKa311z'
 
-    if (row.entityId) {
-      // todo: need better state tracking for updates
-      // simplest way... if parsedJson != publishedJson issue update
-      //    the risk being that this might incite a ton of needless updates if not careful
-      // could do... if xmlUrl != publishedXmlUrl
-      //    but that wouldn't handle code change type of thing
-
-      // for now, update all published releases when `republish` flag is set vai:
-      //   npx tsx cli publish --republish
-
-      if (opts?.republish) {
-        if (row.entityType == 'track') {
-          await updateTrack(sdk, row, parsed)
-        } else if (row.entityType == 'album') {
-          await updateAlbum(sdk, row, parsed)
-        } else {
-          console.log('unknown entity type', row.entityType)
-        }
+    if (row.status == ReleaseProcessingStatus.DeletePending) {
+      // delete
+      deleteRelease(sdk, row)
+    } else if (row.entityId) {
+      // update
+      if (row.entityType == 'track') {
+        await updateTrack(sdk, row, parsed)
+      } else if (row.entityType == 'album') {
+        await updateAlbum(sdk, row, parsed)
+      } else {
+        console.log('unknown entity type', row.entityType)
       }
-
-      releaseRepo.update({
-        key: row.key,
-        status: ReleaseProcessingStatus.Published,
-      })
     } else {
-      // publish new release
+      // create
       try {
         await publishRelease(sdk, row, parsed)
       } catch (e: any) {
@@ -117,11 +105,11 @@ export async function publishRelease(
     console.log(result)
 
     // on success set publishedAt, entityId, blockhash
-    dbUpdate('releases', 'key', {
+    releaseRepo.update({
       key: releaseRow.key,
-      status: 'Published',
+      status: ReleaseProcessingStatus.Published,
       entityType: 'album',
-      entityId: result.albumId,
+      entityId: result.albumId!,
       blockNumber: result.blockNumber,
       blockHash: result.blockHash,
       publishedAt: new Date().toISOString(),
@@ -177,8 +165,13 @@ async function updateTrack(
     metadata: metas[0],
   })
 
-  console.log('update track', result)
-  // todo: record update to db
+  releaseRepo.update({
+    key: row.key,
+    status: ReleaseProcessingStatus.Published,
+    ...result,
+  })
+
+  return result
 }
 
 export function prepareTrackMetadatas(release: DDEXRelease) {
@@ -201,7 +194,7 @@ export function prepareTrackMetadatas(release: DDEXRelease) {
       const meta: UploadTrackRequest['metadata'] = {
         genre: audiusGenre,
         title: sound.title,
-        isrc: release.isrc,
+        isrc: release.releaseIds.isrc,
         releaseDate,
         copyrightLine,
         producerCopyrightLine,
@@ -236,13 +229,17 @@ async function updateAlbum(
     metadata: meta,
   })
 
-  console.log('UPDATE ALBUM', result)
-  // todo: record update to db blocknumber / blockhash
+  releaseRepo.update({
+    key: row.key,
+    status: ReleaseProcessingStatus.Published,
+    ...result,
+  })
+
+  return result
 }
 
 export async function deleteRelease(sdk: AudiusSdk, r: ReleaseRow) {
   const userId = r._parsed!.audiusUser!
-  // const userId = 'KKa311z'
   const entityId = r.entityId
 
   if (!userId || !entityId) {
@@ -255,26 +252,21 @@ export async function deleteRelease(sdk: AudiusSdk, r: ReleaseRow) {
       trackId: entityId,
       userId,
     })
-
-    releaseRepo.update({
-      key: r.key,
-      status: ReleaseProcessingStatus.Deleted,
-      // update blockhash / blockno?
-    })
-    console.log('deleted track', result)
-    return result
+    return onDeleted(result)
   } else if (r.entityType == 'album') {
     const result = await sdk.albums.deleteAlbum({
       albumId: entityId,
       userId,
     })
+    return onDeleted(result)
+  }
 
+  function onDeleted(result: any) {
     releaseRepo.update({
       key: r.key,
       status: ReleaseProcessingStatus.Deleted,
-      // update blockhash / blockno?
+      ...result,
     })
-    console.log('deleted album', result)
     return result
   }
 }

--- a/packages/ddex/processor/src/publishRelease.ts
+++ b/packages/ddex/processor/src/publishRelease.ts
@@ -168,6 +168,7 @@ async function updateTrack(
   releaseRepo.update({
     key: row.key,
     status: ReleaseProcessingStatus.Published,
+    publishedAt: new Date().toISOString(),
     ...result,
   })
 
@@ -232,6 +233,7 @@ async function updateAlbum(
   releaseRepo.update({
     key: row.key,
     status: ReleaseProcessingStatus.Published,
+    publishedAt: new Date().toISOString(),
     ...result,
   })
 
@@ -242,7 +244,7 @@ export async function deleteRelease(sdk: AudiusSdk, r: ReleaseRow) {
   const userId = r._parsed!.audiusUser!
   const entityId = r.entityId
 
-  // if not published to audius, mark internal releases row as deleted
+  // if not yet published to audius, mark internal releases row as deleted
   if (!userId || !entityId) {
     releaseRepo.update({
       key: r.key,
@@ -269,6 +271,7 @@ export async function deleteRelease(sdk: AudiusSdk, r: ReleaseRow) {
     releaseRepo.update({
       key: r.key,
       status: ReleaseProcessingStatus.Deleted,
+      publishedAt: new Date().toISOString(),
       ...result,
     })
     return result

--- a/packages/ddex/processor/src/publishRelease.ts
+++ b/packages/ddex/processor/src/publishRelease.ts
@@ -242,8 +242,12 @@ export async function deleteRelease(sdk: AudiusSdk, r: ReleaseRow) {
   const userId = r._parsed!.audiusUser!
   const entityId = r.entityId
 
+  // if not published to audius, mark internal releases row as deleted
   if (!userId || !entityId) {
-    console.log('no entityType for release ${r.key}')
+    releaseRepo.update({
+      key: r.key,
+      status: ReleaseProcessingStatus.Deleted,
+    })
     return
   }
 

--- a/packages/ddex/processor/src/server.ts
+++ b/packages/ddex/processor/src/server.ts
@@ -8,17 +8,16 @@ import { html } from 'hono/html'
 import { decode } from 'hono/jwt'
 import { prettyJSON } from 'hono/pretty-json'
 import { HtmlEscapedString } from 'hono/utils/html'
+import { ReleaseProcessingStatus, releaseRepo, userRepo, xmlRepo } from './db'
 import {
-  ReleaseProcessingStatus,
-  dbUpsert,
-  releaseRepo,
-  userRepo,
-  xmlRepo,
-} from './db'
-import { DDEXContributor, parseDdexXml, reParsePastXml } from './parseDelivery'
+  DDEXContributor,
+  DDEXRelease,
+  parseDdexXml,
+  reParsePastXml,
+} from './parseDelivery'
 import { prepareAlbumMetadata, prepareTrackMetadatas } from './publishRelease'
-import { parseBool } from './util'
 import { readAssetWithCaching } from './s3poller'
+import { parseBool } from './util'
 
 const { NODE_ENV, DDEX_KEY, DDEX_URL, COOKIE_SECRET } = process.env
 const COOKIE_NAME = 'audiusUser'
@@ -85,7 +84,7 @@ app.get('/auth/redirect', async (c) => {
     }
 
     // upsert user record
-    dbUpsert('users', {
+    userRepo.upsert({
       id: payload.userId,
       handle: payload.handle,
       name: payload.name,
@@ -112,7 +111,7 @@ app.get('/auth/success', async (c) => {
     }
 
     // upsert user record
-    dbUpsert('users', {
+    userRepo.upsert({
       id: payload.userId,
       handle: payload.handle,
       name: payload.name,
@@ -406,7 +405,7 @@ app.get('/xmls/:xmlUrl', (c) => {
 
   // parse=true will parse the xml to internal representation
   if (parseBool(c.req.query('parse'))) {
-    const parsed = parseDdexXml(xmlUrl, row.xmlText)
+    const parsed = parseDdexXml(xmlUrl, row.xmlText) as DDEXRelease[]
 
     // parse=sdk will convert internal representation to SDK friendly format
     if (c.req.query('parse') == 'sdk') {


### PR DESCRIPTION
### Description

* parse xml switches on root xml node name to call either `parsePurgeXml` or `parseReleaseXml`
* adds a status for `DeletePending` and publisher will use that to perform deletes
* adds `messageTimestamp` to `releases` table... upsert will only update `releases` row to `PublishPending` if timestamp is newer (or timestamp is same and json changed)
* tests simulate state transitions

inspired by: https://github.com/AudiusProject/audius-protocol/pull/8251