### PR TITLE
Play with RNTP buffer settings

### DIFF
--- a/packages/mobile/src/app/App.tsx
+++ b/packages/mobile/src/app/App.tsx
@@ -6,7 +6,7 @@ import {
   SafeAreaProvider,
   initialWindowMetrics
 } from 'react-native-safe-area-context'
-import TrackPlayer from 'react-native-track-player'
+import TrackPlayer, { IOSCategory } from 'react-native-track-player'
 import { Provider } from 'react-redux'
 import { useEffectOnce } from 'react-use'
 import { PersistGate } from 'redux-persist/integration/react'
@@ -64,7 +64,13 @@ const App = () => {
   useEffectOnce(() => {
     setLibs(null)
     subscribeToNetworkStatusUpdates()
-    TrackPlayer.setupPlayer({ autoHandleInterruptions: true })
+    TrackPlayer.setupPlayer({
+      minBuffer: 0.1,
+      playBuffer: 0.1,
+      waitForBuffer: false,
+      autoHandleInterruptions: true,
+      iosCategory: IOSCategory.Playback
+    })
   })
 
   useEnterForeground(() => {

--- a/packages/mobile/src/components/audio/AudioPlayer.tsx
+++ b/packages/mobile/src/components/audio/AudioPlayer.tsx
@@ -37,7 +37,6 @@ import TrackPlayer, {
   Capability,
   Event,
   State,
-  usePlaybackState,
   useTrackPlayerEvents,
   RepeatMode as TrackPlayerRepeatMode,
   TrackType,
@@ -167,7 +166,6 @@ export const AudioPlayer = () => {
     FeatureFlags.PODCAST_CONTROL_UPDATES_ENABLED,
     FeatureFlags.PODCAST_CONTROL_UPDATES_ENABLED_FALLBACK
   )
-  const playbackState = usePlaybackState()
   const track = useSelector(getCurrentTrack)
   const playing = useSelector(getPlaying)
   const seek = useSelector(getSeek)

--- a/packages/mobile/src/components/audio/AudioPlayer.tsx
+++ b/packages/mobile/src/components/audio/AudioPlayer.tsx
@@ -40,7 +40,8 @@ import TrackPlayer, {
   usePlaybackState,
   useTrackPlayerEvents,
   RepeatMode as TrackPlayerRepeatMode,
-  TrackType
+  TrackType,
+  PitchAlgorithm
 } from 'react-native-track-player'
 import { useDispatch, useSelector } from 'react-redux'
 import { useAsync, usePrevious } from 'react-use'
@@ -609,6 +610,8 @@ export const AudioPlayer = () => {
       return {
         url,
         type: TrackType.Default,
+        contentType: 'audio/mpeg',
+        pitchAlgorithm: PitchAlgorithm.Music,
         title: track.title,
         artist: trackOwner.name,
         genre: track.genre,
@@ -652,13 +655,12 @@ export const AudioPlayer = () => {
     } else {
       await TrackPlayer.reset()
 
+      await TrackPlayer.play()
+
       const firstTrack = newQueueTracks[queueIndex]
       if (!firstTrack) return
-      await TrackPlayer.add(await makeTrackData(firstTrack))
 
-      if (playing) {
-        await TrackPlayer.play()
-      }
+      await TrackPlayer.add(await makeTrackData(firstTrack))
 
       enqueueTracksJobRef.current = enqueueTracks(newQueueTracks, queueIndex)
       await enqueueTracksJobRef.current
@@ -675,8 +677,7 @@ export const AudioPlayer = () => {
     isCollectionMarkedForDownload,
     isNotReachable,
     storageNodeSelector,
-    nftAccessSignatureMap,
-    playing
+    nftAccessSignatureMap
   ])
 
   const handleQueueIdxChange = useCallback(async () => {
@@ -694,17 +695,12 @@ export const AudioPlayer = () => {
   }, [queueIndex])
 
   const handleTogglePlay = useCallback(async () => {
-    if (playbackState.state === State.Playing && !playing) {
-      await TrackPlayer.pause()
-    } else if (
-      (playbackState.state === State.Paused ||
-        playbackState.state === State.Ready ||
-        playbackState.state === State.Stopped) &&
-      playing
-    ) {
+    if (playing) {
       await TrackPlayer.play()
+    } else {
+      await TrackPlayer.pause()
     }
-  }, [playbackState, playing])
+  }, [playing])
 
   const handleStop = useCallback(async () => {
     TrackPlayer.reset()


### PR DESCRIPTION
### Description

    minBuffer: 0.1
    playBuffer: 0.1,
    waitForBuffer: false,
=> all should help try to make RNTP buffer less and start playing back sooner


    iosCategory: IOSCategory.Playback
    contentType: 'audio/mpeg',
    pitchAlgorithm: PitchAlgorithm.Music,
=> no real change I think, but are all "correct" based on what we're trying to do and maybe the thought is it would help the OS decide how to handle our content

I want to try to merge this PR and see how it fares on staging for a little, and then revert if we see anything weird

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._

Local device running against prod
