### PR TITLE
Disable add to playlist for prem tracks if not purchased

### DIFF
--- a/packages/common/src/hooks/purchaseContent/utils.ts
+++ b/packages/common/src/hooks/purchaseContent/utils.ts
@@ -61,12 +61,13 @@ export const isTrackDownloadPurchaseable = (
   isContentUSDCPurchaseGated(metadata.download_conditions)
 
 export const useIsGatedContentPlaylistAddable = (
-  content: Nullable<Partial<Track | UserTrackMetadata | Collection>>
+  contentArg?: Nullable<Partial<Track | UserTrackMetadata | Collection>>
 ) => {
+  const content = contentArg ?? {}
   const {
     stream_conditions: streamConditions,
     is_stream_gated: isStreamGated
-  } = content ?? {}
+  } = content
   const { hasStreamAccess } = useGatedContentAccess(content)
   return (
     !isStreamGated ||

--- a/packages/common/src/hooks/purchaseContent/utils.ts
+++ b/packages/common/src/hooks/purchaseContent/utils.ts
@@ -1,4 +1,8 @@
-import { isContentUSDCPurchaseGated } from '~/models/Track'
+import { Collection, Track } from '~/models'
+import { UserTrackMetadata, isContentUSDCPurchaseGated } from '~/models/Track'
+import { Nullable } from '~/utils'
+
+import { useGatedContentAccess } from '../useGatedContent'
 
 import {
   PayExtraAmountPresetValues,
@@ -55,3 +59,17 @@ export const isTrackDownloadPurchaseable = (
 ): metadata is PurchaseableTrackDownloadMetadata =>
   'download_conditions' in metadata &&
   isContentUSDCPurchaseGated(metadata.download_conditions)
+
+export const useIsGatedContentPlaylistAddable = (
+  content: Nullable<Partial<Track | UserTrackMetadata | Collection>>
+) => {
+  const {
+    stream_conditions: streamConditions,
+    is_stream_gated: isStreamGated
+  } = content ?? {}
+  const { hasStreamAccess } = useGatedContentAccess(content)
+  return (
+    !isStreamGated ||
+    (isContentUSDCPurchaseGated(streamConditions) && hasStreamAccess)
+  )
+}

--- a/packages/common/src/hooks/purchaseContent/utils.ts
+++ b/packages/common/src/hooks/purchaseContent/utils.ts
@@ -61,16 +61,18 @@ export const isTrackDownloadPurchaseable = (
   isContentUSDCPurchaseGated(metadata.download_conditions)
 
 export const useIsGatedContentPlaylistAddable = (
-  contentArg?: Nullable<Partial<Track | UserTrackMetadata | Collection>>
+  contentArg: Nullable<Partial<Track | UserTrackMetadata | Collection>>
 ) => {
   const content = contentArg ?? {}
   const {
     stream_conditions: streamConditions,
-    is_stream_gated: isStreamGated
+    is_stream_gated: isStreamGated,
+    ddex_app: ddexApp
   } = content
   const { hasStreamAccess } = useGatedContentAccess(content)
   return (
-    !isStreamGated ||
-    (isContentUSDCPurchaseGated(streamConditions) && hasStreamAccess)
+    !ddexApp &&
+    (!isStreamGated ||
+      (isContentUSDCPurchaseGated(streamConditions) && hasStreamAccess))
   )
 }

--- a/packages/common/src/hooks/purchaseContent/utils.ts
+++ b/packages/common/src/hooks/purchaseContent/utils.ts
@@ -61,7 +61,7 @@ export const isTrackDownloadPurchaseable = (
   isContentUSDCPurchaseGated(metadata.download_conditions)
 
 export const useIsGatedContentPlaylistAddable = (
-  contentArg: Nullable<Partial<Track | UserTrackMetadata | Collection>>
+  contentArg?: Nullable<Partial<Track | UserTrackMetadata | Collection>>
 ) => {
   const content = contentArg ?? {}
   const {

--- a/packages/mobile/src/components/lineup-tile/TrackTile.tsx
+++ b/packages/mobile/src/components/lineup-tile/TrackTile.tsx
@@ -1,5 +1,6 @@
 import { useCallback } from 'react'
 
+import { useIsGatedContentPlaylistAddable } from '@audius/common/hooks'
 import {
   ShareSource,
   RepostSource,
@@ -126,6 +127,7 @@ export const TrackTileComponent = ({
     isUSDCEnabled &&
     isContentUSDCPurchaseGated(streamConditions) &&
     !!preview_cid
+  const isPlaylistAddable = useIsGatedContentPlaylistAddable(track)
 
   const renderImage = useCallback(
     (props: ImageProps) => (
@@ -167,7 +169,7 @@ export const TrackTileComponent = ({
       isEditAlbumsEnabled && isOwner && !ddexApp
         ? OverflowAction.ADD_TO_ALBUM
         : null,
-      OverflowAction.ADD_TO_PLAYLIST,
+      isPlaylistAddable ? OverflowAction.ADD_TO_PLAYLIST : null,
       isNewPodcastControlsEnabled && isLongFormContent
         ? OverflowAction.VIEW_EPISODE_PAGE
         : OverflowAction.VIEW_TRACK_PAGE,
@@ -198,6 +200,7 @@ export const TrackTileComponent = ({
     isEditAlbumsEnabled,
     isOwner,
     ddexApp,
+    isPlaylistAddable,
     isNewPodcastControlsEnabled,
     albumInfo,
     playbackPositionInfo?.status,

--- a/packages/mobile/src/components/now-playing-drawer/ActionsBar.tsx
+++ b/packages/mobile/src/components/now-playing-drawer/ActionsBar.tsx
@@ -1,6 +1,9 @@
 import { useCallback, useLayoutEffect } from 'react'
 
-import { useGatedContentAccess } from '@audius/common/hooks'
+import {
+  useGatedContentAccess,
+  useIsGatedContentPlaylistAddable
+} from '@audius/common/hooks'
 import {
   ShareSource,
   RepostSource,
@@ -120,6 +123,7 @@ export const ActionsBar = ({ track }: ActionsBarProps) => {
   const { isEnabled: isEditAlbumsEnabled } = useFeatureFlag(
     FeatureFlags.EDIT_ALBUMS
   )
+  const isPlaylistAddable = useIsGatedContentPlaylistAddable(track)
 
   const isOwner = track?.owner_id === accountUser?.user_id
   const { onOpen: openPremiumContentPurchaseModal } =
@@ -201,7 +205,7 @@ export const ActionsBar = ({ track }: ActionsBarProps) => {
         track.genre === Genre.PODCASTS || track.genre === Genre.AUDIOBOOKS
       const overflowActions = [
         isEditAlbumsEnabled && isOwner ? OverflowAction.ADD_TO_ALBUM : null,
-        OverflowAction.ADD_TO_PLAYLIST,
+        isPlaylistAddable ? OverflowAction.ADD_TO_PLAYLIST : null,
         isNewPodcastControlsEnabled && isLongFormContent
           ? OverflowAction.VIEW_EPISODE_PAGE
           : OverflowAction.VIEW_TRACK_PAGE,
@@ -228,6 +232,7 @@ export const ActionsBar = ({ track }: ActionsBarProps) => {
     track,
     isEditAlbumsEnabled,
     isOwner,
+    isPlaylistAddable,
     isNewPodcastControlsEnabled,
     albumInfo,
     playbackPositionInfo?.status,

--- a/packages/mobile/src/components/track-list/TrackListItem.tsx
+++ b/packages/mobile/src/components/track-list/TrackListItem.tsx
@@ -238,7 +238,6 @@ const TrackListItemComponent = (props: TrackListItemComponentProps) => {
     title,
     track_id,
     owner_id,
-    is_stream_gated: isStreamGated,
     ddex_app: ddexApp
   } = track
   const { isEnabled: isEditAlbumsEnabled } = useFeatureFlag(

--- a/packages/mobile/src/components/track-list/TrackListItem.tsx
+++ b/packages/mobile/src/components/track-list/TrackListItem.tsx
@@ -1,7 +1,10 @@
 import type { ComponentType } from 'react'
 import { memo, useCallback, useMemo, useState } from 'react'
 
-import { useGatedContentAccess } from '@audius/common/hooks'
+import {
+  useGatedContentAccess,
+  useIsGatedContentPlaylistAddable
+} from '@audius/common/hooks'
 import type { Collection, ID, UID, Track, User } from '@audius/common/models'
 import { FeatureFlags } from '@audius/common/services'
 import {
@@ -235,6 +238,7 @@ const TrackListItemComponent = (props: TrackListItemComponentProps) => {
     title,
     track_id,
     owner_id,
+    is_stream_gated: isStreamGated,
     ddex_app: ddexApp
   } = track
   const { isEnabled: isEditAlbumsEnabled } = useFeatureFlag(
@@ -262,6 +266,7 @@ const TrackListItemComponent = (props: TrackListItemComponentProps) => {
   const isPlaying = useSelector((state) => {
     return isActive && getPlaying(state)
   })
+  const isPlaylistAddable = useIsGatedContentPlaylistAddable(track)
 
   const messages = getMessages({ isDeleted })
   const styles = useStyles()
@@ -323,7 +328,7 @@ const TrackListItemComponent = (props: TrackListItemComponentProps) => {
       isEditAlbumsEnabled && isTrackOwner && !ddexApp
         ? OverflowAction.ADD_TO_ALBUM
         : null,
-      OverflowAction.ADD_TO_PLAYLIST,
+      isPlaylistAddable ? OverflowAction.ADD_TO_PLAYLIST : null,
       isNewPodcastControlsEnabled && isLongFormContent
         ? OverflowAction.VIEW_EPISODE_PAGE
         : OverflowAction.VIEW_TRACK_PAGE,
@@ -354,6 +359,7 @@ const TrackListItemComponent = (props: TrackListItemComponentProps) => {
     has_current_user_reposted,
     isEditAlbumsEnabled,
     ddexApp,
+    isPlaylistAddable,
     isNewPodcastControlsEnabled,
     isLongFormContent,
     showViewAlbum,

--- a/packages/mobile/src/screens/track-screen/TrackScreenDetailsTile.tsx
+++ b/packages/mobile/src/screens/track-screen/TrackScreenDetailsTile.tsx
@@ -1,6 +1,9 @@
 import { useCallback } from 'react'
 
-import { useGatedContentAccess } from '@audius/common/hooks'
+import {
+  useGatedContentAccess,
+  useIsGatedContentPlaylistAddable
+} from '@audius/common/hooks'
 import {
   Name,
   ShareSource,
@@ -144,6 +147,7 @@ export const TrackScreenDetailsTile = ({
   const hasDownloadableAssets =
     (track as Track)?.is_downloadable ||
     ((track as Track)?._stems?.length ?? 0) > 0
+  const isPlaylistAddable = useIsGatedContentPlaylistAddable(track as Track)
 
   const { data: albumInfo } = trpc.tracks.getAlbumBacklink.useQuery(
     { trackId },
@@ -248,9 +252,12 @@ export const TrackScreenDetailsTile = ({
       isEditAlbumsEnabled && isOwner && !ddexApp
         ? OverflowAction.ADD_TO_ALBUM
         : null
+    const addToPlaylistAction = isPlaylistAddable
+      ? OverflowAction.ADD_TO_PLAYLIST
+      : null
     const overflowActions = [
       addToAlbumAction,
-      OverflowAction.ADD_TO_PLAYLIST,
+      addToPlaylistAction,
       isOwner
         ? null
         : user.does_current_user_follow

--- a/packages/mobile/src/screens/track-screen/TrackScreenDetailsTile.tsx
+++ b/packages/mobile/src/screens/track-screen/TrackScreenDetailsTile.tsx
@@ -252,9 +252,8 @@ export const TrackScreenDetailsTile = ({
       isEditAlbumsEnabled && isOwner && !ddexApp
         ? OverflowAction.ADD_TO_ALBUM
         : null
-    const addToPlaylistAction = isPlaylistAddable
-      ? OverflowAction.ADD_TO_PLAYLIST
-      : null
+    const addToPlaylistAction =
+      isPlaylistAddable && !ddexApp ? OverflowAction.ADD_TO_PLAYLIST : null
     const overflowActions = [
       addToAlbumAction,
       addToPlaylistAction,

--- a/packages/mobile/src/screens/track-screen/TrackScreenDetailsTile.tsx
+++ b/packages/mobile/src/screens/track-screen/TrackScreenDetailsTile.tsx
@@ -134,8 +134,7 @@ export const TrackScreenDetailsTile = ({
     save_count,
     title,
     track_id: trackId,
-    stream_conditions: streamConditions,
-    ddex_app: ddexApp
+    stream_conditions: streamConditions
   } = track
 
   const isOwner = owner_id === currentUserId
@@ -252,8 +251,9 @@ export const TrackScreenDetailsTile = ({
       isEditAlbumsEnabled && isOwner && !ddexApp
         ? OverflowAction.ADD_TO_ALBUM
         : null
-    const addToPlaylistAction =
-      isPlaylistAddable && !ddexApp ? OverflowAction.ADD_TO_PLAYLIST : null
+    const addToPlaylistAction = isPlaylistAddable
+      ? OverflowAction.ADD_TO_PLAYLIST
+      : null
     const overflowActions = [
       addToAlbumAction,
       addToPlaylistAction,

--- a/packages/web/src/components/track/GiantTrackTile.tsx
+++ b/packages/web/src/components/track/GiantTrackTile.tsx
@@ -1,5 +1,6 @@
 import { Suspense, lazy, useCallback, useState } from 'react'
 
+import { useIsGatedContentPlaylistAddable } from '@audius/common/hooks'
 import {
   isContentUSDCPurchaseGated,
   ID,
@@ -223,6 +224,7 @@ export const GiantTrackTile = ({
   const showPreview = isUSDCPurchaseGated && (isOwner || !hasStreamAccess)
   // Play button is conditionally hidden for USDC-gated tracks when the user does not have access
   const showPlay = isUSDCPurchaseGated ? hasStreamAccess : true
+  const isPlaylistAddable = useIsGatedContentPlaylistAddable(track)
   const { data: albumInfo } = trpc.tracks.getAlbumBacklink.useQuery(
     { trackId },
     { enabled: !!trackId }
@@ -520,7 +522,8 @@ export const GiantTrackTile = ({
       isArtistPick,
       includeEmbed: !(isUnlisted || isStreamGated),
       includeArtistPick: !isUnlisted,
-      includeAddToAlbum: isOwner,
+      includeAddToPlaylist: isPlaylistAddable,
+      includeAddToAlbum: isPlaylistAddable,
       extraMenuItems: overflowMenuExtraItems
     }
   }

--- a/packages/web/src/components/track/desktop/ConnectedTrackTile.tsx
+++ b/packages/web/src/components/track/desktop/ConnectedTrackTile.tsx
@@ -7,7 +7,10 @@ import {
   useRef
 } from 'react'
 
-import { useGatedContentAccess } from '@audius/common/hooks'
+import {
+  useGatedContentAccess,
+  useIsGatedContentPlaylistAddable
+} from '@audius/common/hooks'
 import {
   ShareSource,
   RepostSource,
@@ -158,6 +161,7 @@ const ConnectedTrackTile = ({
   const { isFetchingNFTAccess, hasStreamAccess } =
     useGatedContentAccess(trackWithFallback)
   const loading = isLoading || isFetchingNFTAccess
+  const isPlaylistAddable = useIsGatedContentPlaylistAddable(trackWithFallback)
 
   const dispatch = useDispatch()
   const [, setLockedContentVisibility] = useModalState('LockedContent')
@@ -202,8 +206,8 @@ const ConnectedTrackTile = ({
     const menu: Omit<TrackMenuProps, 'children'> = {
       extraMenuItems: [],
       handle,
-      includeAddToPlaylist: true,
-      includeAddToAlbum: true,
+      includeAddToPlaylist: isPlaylistAddable,
+      includeAddToAlbum: isPlaylistAddable,
       includeArtistPick: handle === userHandle && !isUnlisted,
       includeEdit: handle === userHandle,
       ddexApp: track?.ddex_app,

--- a/packages/web/src/components/track/desktop/ConnectedTrackTile.tsx
+++ b/packages/web/src/components/track/desktop/ConnectedTrackTile.tsx
@@ -8,6 +8,7 @@ import {
 } from 'react'
 
 import {
+  useFeatureFlag,
   useGatedContentAccess,
   useIsGatedContentPlaylistAddable
 } from '@audius/common/hooks'
@@ -18,6 +19,7 @@ import {
   ID,
   UID
 } from '@audius/common/models'
+import { FeatureFlags } from '@audius/common/services'
 import {
   accountSelectors,
   cacheTracksSelectors,
@@ -157,11 +159,15 @@ const ConnectedTrackTile = ({
   const isOwner = handle === userHandle
   const isArtistPick = showArtistPick && artist_pick_track_id === trackId
   const hasPreview = !!track?.preview_cid
+  const { isEnabled: isEditAlbumsEnabled } = useFeatureFlag(
+    FeatureFlags.EDIT_ALBUMS
+  )
 
   const { isFetchingNFTAccess, hasStreamAccess } =
     useGatedContentAccess(trackWithFallback)
   const loading = isLoading || isFetchingNFTAccess
   const isPlaylistAddable = useIsGatedContentPlaylistAddable(trackWithFallback)
+  const isAlbumAddable = isEditAlbumsEnabled && isOwner
 
   const dispatch = useDispatch()
   const [, setLockedContentVisibility] = useModalState('LockedContent')
@@ -207,7 +213,7 @@ const ConnectedTrackTile = ({
       extraMenuItems: [],
       handle,
       includeAddToPlaylist: isPlaylistAddable,
-      includeAddToAlbum: isPlaylistAddable,
+      includeAddToAlbum: isAlbumAddable,
       includeArtistPick: handle === userHandle && !isUnlisted,
       includeEdit: handle === userHandle,
       ddexApp: track?.ddex_app,

--- a/packages/web/src/components/track/desktop/TrackListItem.tsx
+++ b/packages/web/src/components/track/desktop/TrackListItem.tsx
@@ -1,5 +1,6 @@
 import { memo, MouseEvent, useRef } from 'react'
 
+import { useGetCurrentUserId } from '@audius/common/api'
 import { useIsGatedContentPlaylistAddable } from '@audius/common/hooks'
 import { ID, Track, UID } from '@audius/common/models'
 import { EnhancedCollectionTrack } from '@audius/common/store'
@@ -55,6 +56,8 @@ const TrackListItem = ({
   forceSkeleton = false
 }: TrackListItemProps) => {
   const menuRef = useRef<HTMLDivElement>(null)
+  const { data: currentUserId } = useGetCurrentUserId({})
+  const isOwner = track?.owner_id === currentUserId
   const isPlaylistAddable = useIsGatedContentPlaylistAddable(track as Track)
 
   if (forceSkeleton) {
@@ -114,6 +117,7 @@ const TrackListItem = ({
   const menu: Omit<TrackMenuProps, 'children'> = {
     handle: track.user.handle,
     includeAddToPlaylist: isPlaylistAddable,
+    includeAddToAlbum: isOwner,
     includeArtistPick: false,
     includeEdit: false,
     includeFavorite: true,

--- a/packages/web/src/components/track/desktop/TrackListItem.tsx
+++ b/packages/web/src/components/track/desktop/TrackListItem.tsx
@@ -1,7 +1,7 @@
 import { memo, MouseEvent, useRef } from 'react'
 
-import { useGetCurrentUserId } from '@audius/common/api'
-import { ID, UID } from '@audius/common/models'
+import { useIsGatedContentPlaylistAddable } from '@audius/common/hooks'
+import { ID, Track, UID } from '@audius/common/models'
 import { EnhancedCollectionTrack } from '@audius/common/store'
 import { Genre, formatSeconds } from '@audius/common/utils'
 import { IconKebabHorizontal } from '@audius/harmony'
@@ -55,8 +55,7 @@ const TrackListItem = ({
   forceSkeleton = false
 }: TrackListItemProps) => {
   const menuRef = useRef<HTMLDivElement>(null)
-  const { data: currentUserId } = useGetCurrentUserId({})
-  const isOwner = track?.owner_id === currentUserId
+  const isPlaylistAddable = useIsGatedContentPlaylistAddable(track as Track)
 
   if (forceSkeleton) {
     return (
@@ -114,8 +113,7 @@ const TrackListItem = ({
 
   const menu: Omit<TrackMenuProps, 'children'> = {
     handle: track.user.handle,
-    includeAddToPlaylist: true,
-    includeAddToAlbum: isOwner,
+    includeAddToPlaylist: isPlaylistAddable,
     includeArtistPick: false,
     includeEdit: false,
     includeFavorite: true,

--- a/packages/web/src/components/track/mobile/ConnectedTrackListItem.tsx
+++ b/packages/web/src/components/track/mobile/ConnectedTrackListItem.tsx
@@ -1,11 +1,14 @@
 import { memo, useCallback } from 'react'
 
+import { useGetTrackById } from '@audius/common/api'
+import { useIsGatedContentPlaylistAddable } from '@audius/common/hooks'
 import {
   RepostSource,
   FavoriteSource,
   ID,
   isContentUSDCPurchaseGated,
-  ModalSource
+  ModalSource,
+  Track
 } from '@audius/common/models'
 import { FeatureFlags } from '@audius/common/services'
 import {
@@ -65,6 +68,7 @@ const ConnectedTrackListItem = (props: ConnectedTrackListItemProps) => {
     { trackId },
     { enabled: !!trackId }
   )
+  const { data: track } = useGetTrackById({ id: trackId })
   const dispatch = useDispatch()
   const { onOpen: openPremiumContentPurchaseModal } =
     usePremiumContentPurchaseModal()
@@ -73,6 +77,7 @@ const ConnectedTrackListItem = (props: ConnectedTrackListItemProps) => {
     dispatch(setLockedContentId({ id: trackId }))
     setLockedContentVisibility(true)
   }, [dispatch, trackId, setLockedContentVisibility])
+  const isPlaylistAddable = useIsGatedContentPlaylistAddable(track)
 
   const onClickOverflow = () => {
     const overflowActions = [
@@ -89,7 +94,7 @@ const ConnectedTrackListItem = (props: ConnectedTrackListItemProps) => {
       isEditAlbumsEnabled && user?.user_id === currentUserId && !ddexApp
         ? OverflowAction.ADD_TO_ALBUM
         : null,
-      OverflowAction.ADD_TO_PLAYLIST,
+      isPlaylistAddable ? OverflowAction.ADD_TO_PLAYLIST : null,
       OverflowAction.VIEW_TRACK_PAGE,
       isEditAlbumsEnabled && albumInfo ? OverflowAction.VIEW_ALBUM_PAGE : null,
       OverflowAction.VIEW_ARTIST_PAGE

--- a/packages/web/src/components/track/mobile/ConnectedTrackListItem.tsx
+++ b/packages/web/src/components/track/mobile/ConnectedTrackListItem.tsx
@@ -7,8 +7,7 @@ import {
   FavoriteSource,
   ID,
   isContentUSDCPurchaseGated,
-  ModalSource,
-  Track
+  ModalSource
 } from '@audius/common/models'
 import { FeatureFlags } from '@audius/common/services'
 import {

--- a/packages/web/src/components/track/mobile/ConnectedTrackTile.tsx
+++ b/packages/web/src/components/track/mobile/ConnectedTrackTile.tsx
@@ -1,6 +1,9 @@
 import { memo, MouseEvent } from 'react'
 
-import { useGatedContentAccess } from '@audius/common/hooks'
+import {
+  useGatedContentAccess,
+  useIsGatedContentPlaylistAddable
+} from '@audius/common/hooks'
 import {
   ShareSource,
   RepostSource,
@@ -152,6 +155,7 @@ const ConnectedTrackTile = ({
   )
   const { isFetchingNFTAccess, hasStreamAccess } =
     useGatedContentAccess(trackWithFallback)
+  const isPlaylistAddable = useIsGatedContentPlaylistAddable(track)
   const loading = isLoading || isFetchingNFTAccess
 
   const toggleSave = (trackId: ID) => {
@@ -205,11 +209,14 @@ const ConnectedTrackTile = ({
         : null
     const addToAlbumAction =
       isEditAlbumsEnabled && isOwner ? OverflowAction.ADD_TO_ALBUM : null
+    const addToPlaylistAction = isPlaylistAddable
+      ? OverflowAction.ADD_TO_PLAYLIST
+      : null
     const overflowActions = [
       repostAction,
       favoriteAction,
       addToAlbumAction,
-      OverflowAction.ADD_TO_PLAYLIST,
+      addToPlaylistAction,
       isNewPodcastControlsEnabled && isLongFormContent
         ? OverflowAction.VIEW_EPISODE_PAGE
         : OverflowAction.VIEW_TRACK_PAGE,

--- a/packages/web/src/pages/track-page/components/mobile/TrackHeader.tsx
+++ b/packages/web/src/pages/track-page/components/mobile/TrackHeader.tsx
@@ -1,6 +1,7 @@
 import { Suspense, useCallback } from 'react'
 
 import { imageBlank as placeholderArt } from '@audius/common/assets'
+import { useIsGatedContentPlaylistAddable } from '@audius/common/hooks'
 import {
   SquareSizes,
   isContentCollectibleGated,
@@ -218,6 +219,7 @@ const TrackHeader = ({
     { trackId },
     { enabled: !!trackId }
   )
+  const isPlaylistAddable = useIsGatedContentPlaylistAddable(track)
 
   const image = useTrackCoverArt(
     trackId,
@@ -263,7 +265,7 @@ const TrackHeader = ({
         ? OverflowAction.UNFAVORITE
         : OverflowAction.FAVORITE,
       isEditAlbumsEnabled && isOwner ? OverflowAction.ADD_TO_ALBUM : null,
-      OverflowAction.ADD_TO_PLAYLIST,
+      isPlaylistAddable ? OverflowAction.ADD_TO_PLAYLIST : null,
       isEditAlbumsEnabled && albumInfo ? OverflowAction.VIEW_ALBUM_PAGE : null,
       isFollowing
         ? OverflowAction.UNFOLLOW_ARTIST


### PR DESCRIPTION
### Description
Compare with: https://github.com/AudiusProject/audius-protocol/pull/8227

Only allow "add to playlist" + "add to album" options if user has purchased track.

### How Has This Been Tested?

Local web + ios stage
![Simulator Screenshot - iPhone 15 Pro - 2024-05-03 at 17 56 37](https://github.com/AudiusProject/audius-protocol/assets/3893871/6dd5da66-3de2-4697-9bf0-7f0a33f0db18)
<img width="1920" alt="Screenshot 2024-05-03 at 5 56 44 PM" src="https://github.com/AudiusProject/audius-protocol/assets/3893871/28d762e5-8ecf-4a12-96ad-a9186d1619a8">

