### PR TITLE
[PAY-2784] Fix premium album upload with download toggle disabled

### DIFF
--- a/packages/web/src/common/store/upload/sagas.ts
+++ b/packages/web/src/common/store/upload/sagas.ts
@@ -123,7 +123,7 @@ function* combineMetadata(
   const albumTrackPrice =
     collectionMetadata.stream_conditions?.usdc_purchase?.albumTrackPrice
   if (albumTrackPrice !== undefined && albumTrackPrice > 0) {
-    metadata.is_download_gated = !!collectionMetadata.is_downloadable
+    metadata.is_download_gated = true
     metadata.download_conditions = {
       usdc_purchase: {
         price: albumTrackPrice,
@@ -760,7 +760,6 @@ export function* uploadCollection(
 
   // Propagate the collection metadata to the tracks
   for (const track of tracks) {
-    combineMetadata(track.metadata, collectionMetadata)
     track.metadata = yield* call(
       combineMetadata,
       track.metadata,

--- a/packages/web/src/common/store/upload/sagas.ts
+++ b/packages/web/src/common/store/upload/sagas.ts
@@ -123,6 +123,7 @@ function* combineMetadata(
   const albumTrackPrice =
     collectionMetadata.stream_conditions?.usdc_purchase?.albumTrackPrice
   if (albumTrackPrice !== undefined && albumTrackPrice > 0) {
+    // is_download_gated must always be set to true for all premium tracks
     metadata.is_download_gated = true
     metadata.download_conditions = {
       usdc_purchase: {


### PR DESCRIPTION
### Description

Currently a premium album upload with the download toggle off results in no tracks getting uploaded. 

This is because `is_download_gated` must always be set to true for premium tracks

### How Has This Been Tested?

web:stage
- [x] Successful uploads with & without download enabled 👍  staging.audius.co/dejayjdstaging/album/no-download-1