### PR TITLE
[QA-1241] Fix hidden track add to playlist allowing non hidden items

### DIFF
--- a/packages/web/src/components/track/GiantTrackTile.tsx
+++ b/packages/web/src/components/track/GiantTrackTile.tsx
@@ -518,6 +518,7 @@ export const GiantTrackTile = ({
       includeFavorite: false,
       includeTrackPage: false,
       isArtistPick,
+      isUnlisted,
       includeEmbed: !(isUnlisted || isStreamGated),
       includeArtistPick: !isUnlisted,
       includeAddToAlbum: isOwner,


### PR DESCRIPTION
### Description

Fix hidden tracks being allowed to add to on a public playlist

### How Has This Been Tested?

![2024-05-03 18 00 13](https://github.com/AudiusProject/audius-protocol/assets/6711655/7dfd9128-cd2b-44a6-9313-d3277ee60657)


web:stage
- [x] Add to album & add to playlist no longer shows public ones as enabled