### PR TITLE
Fix issues with text-link variant

### DIFF
--- a/packages/harmony/src/components/text-link/types.ts
+++ b/packages/harmony/src/components/text-link/types.ts
@@ -2,9 +2,7 @@ import type { HTMLProps } from 'react'
 
 import type { TextProps } from 'components/text/Text'
 
-type TextLinkTextProps = Omit<TextProps<any>, 'variant' | 'color' | 'onClick'>
-
-export type TextLinkProps = TextLinkTextProps &
+export type TextLinkProps = Omit<TextProps, 'variant' | 'onClick' | 'color'> &
   Omit<
     HTMLProps<HTMLAnchorElement>,
     // Props from Text that don't match anchor props

--- a/packages/web/src/components/collection/mobile/CollectionHeader.tsx
+++ b/packages/web/src/components/collection/mobile/CollectionHeader.tsx
@@ -221,13 +221,7 @@ const CollectionHeader = ({
             {title}
           </Text>
           {userId ? (
-            <UserLink
-              userId={userId}
-              color='accent'
-              size='l'
-              textAs='h2'
-              variant='visible'
-            />
+            <UserLink userId={userId} size='l' variant='visible' />
           ) : null}
         </Flex>
         {shouldShowPlay ? (

--- a/packages/web/src/components/collections-table/CollectionsTable.tsx
+++ b/packages/web/src/components/collections-table/CollectionsTable.tsx
@@ -94,7 +94,6 @@ export const CollectionsTable = ({
         }}
       >
         <TextLink
-          tag={deleted ? 'span' : undefined}
           to={deleted ? '' : collection.permalink ?? ''}
           textVariant='title'
           size='s'

--- a/packages/web/src/components/link/TextLink.tsx
+++ b/packages/web/src/components/link/TextLink.tsx
@@ -7,7 +7,7 @@ import {
 import { Link, LinkProps } from 'react-router-dom'
 
 export type TextLinkProps = HarmonyTextLinkProps &
-  LinkProps & {
+  Omit<LinkProps, 'color'> & {
     stopPropagation?: boolean
   }
 

--- a/packages/web/src/components/link/UserLink.tsx
+++ b/packages/web/src/components/link/UserLink.tsx
@@ -21,14 +21,7 @@ type UserLinkProps = Omit<TextLinkProps, 'to'> & {
 
 export const UserLink = (props: UserLinkProps) => {
   const { isServerSide } = useSsrContext()
-  const {
-    userId,
-    badgeSize = 's',
-    popover,
-    children,
-    textVariant = 'body',
-    ...other
-  } = props
+  const { userId, badgeSize = 's', popover, children, ...other } = props
   const { iconSizes, spacing } = useTheme()
 
   const url = useSelector((state) => {
@@ -50,9 +43,7 @@ export const UserLink = (props: UserLinkProps) => {
       ellipses={popover}
       {...other}
     >
-      <Text ellipses variant={textVariant}>
-        {userName}
-      </Text>
+      <Text ellipses>{userName}</Text>
       <UserBadges
         badgeSize={iconSizes[badgeSize]}
         userId={userId}

--- a/packages/web/src/components/track/LockedContentDetailsTile.tsx
+++ b/packages/web/src/components/track/LockedContentDetailsTile.tsx
@@ -140,6 +140,14 @@ export const LockedContentDetailsTile = ({
         ) : null}
         <Flex direction='column' gap='s'>
           <Text variant='heading'>{title}</Text>
+          <Text variant='title'>
+            <Text color='subdued'>{messages.by}</Text>{' '}
+            <UserLink
+              textVariant='title'
+              strength='weak'
+              userId={owner.user_id}
+            />
+          </Text>
           <Flex gap='xs'>
             <Text variant='title'>{messages.by}</Text>
             <UserLink userId={owner.user_id} />

--- a/packages/web/src/components/track/LockedContentDetailsTile.tsx
+++ b/packages/web/src/components/track/LockedContentDetailsTile.tsx
@@ -148,10 +148,6 @@ export const LockedContentDetailsTile = ({
               userId={owner.user_id}
             />
           </Text>
-          <Flex gap='xs'>
-            <Text variant='title'>{messages.by}</Text>
-            <UserLink userId={owner.user_id} />
-          </Flex>
         </Flex>
       </Flex>
     </Flex>

--- a/packages/web/src/components/tracks-table/TracksTable.tsx
+++ b/packages/web/src/components/tracks-table/TracksTable.tsx
@@ -212,7 +212,6 @@ export const TracksTable = ({
       return (
         <div className={styles.textContainer} css={{ overflow: 'hidden' }}>
           <TextLink
-            tag={isLocked || deleted ? 'span' : undefined}
             to={isLocked || deleted ? '' : track.permalink}
             isActive={active}
             textVariant='title'

--- a/packages/web/src/pages/server-track-page/mobile/ServerTrackPageHeader.tsx
+++ b/packages/web/src/pages/server-track-page/mobile/ServerTrackPageHeader.tsx
@@ -272,10 +272,9 @@ export const ServerTrackPageHeader = ({
         <h1 className={styles.title}>{title}</h1>
         <ServerUserLink
           userId={userId}
-          color='accent'
+          variant='visible'
           textVariant='body'
           size='l'
-          tag='h2'
         />
       </div>
       <PlayButton

--- a/packages/web/src/pages/track-page/components/mobile/TrackHeader.tsx
+++ b/packages/web/src/pages/track-page/components/mobile/TrackHeader.tsx
@@ -406,10 +406,9 @@ const TrackHeader = ({
         <h1 className={styles.title}>{title}</h1>
         <UserLink
           userId={userId}
-          color='accent'
+          variant='visible'
           textVariant='body'
           size='l'
-          tag='h2'
         />
       </div>
       {showPlay ? (


### PR DESCRIPTION
### Description

TextLink had textVariant = 'body' default introduced, which broke a few cases that implicitly received styles from it's parent: 
<img width="260" alt="image" src="https://github.com/AudiusProject/audius-protocol/assets/8230000/ed336e7c-8d4f-4691-af37-ba305cb72898">
(the user name is too big)

Fixes issue introduced by setting default textVariant on text-link by removing default and updating usages.
Also improves the typing around text-link, fixing a few instances that were malformed.