### PR TITLE
Fix profile page artist vs user

### DIFF
--- a/packages/web/src/pages/profile-page/components/desktop/ProfilePage.tsx
+++ b/packages/web/src/pages/profile-page/components/desktop/ProfilePage.tsx
@@ -550,7 +550,7 @@ const ProfilePage = ({
   }
 
   const { headers, elements } = profile
-    ? !isArtist
+    ? isArtist
       ? getArtistProfileContent()
       : getUserProfileContent()
     : { headers: [], elements: [] }


### PR DESCRIPTION
### Description

Bug introduced in collection card migration that renders artist content when it should render user content, and vis-versa
