### PR TITLE
[C-4338] Fix $AUDIO available to claim

### DIFF
--- a/packages/web/src/pages/audio-rewards-page/components/modals/ChallengeRewardsModal/ChallengeRewardsModal.tsx
+++ b/packages/web/src/pages/audio-rewards-page/components/modals/ChallengeRewardsModal/ChallengeRewardsModal.tsx
@@ -107,7 +107,7 @@ const messages = {
     'Something has gone wrong, not all your rewards were claimed. Please try again or contact support@audius.co.',
   claimErrorAAO:
     'Your account is unable to claim rewards at this time. Please try again later or contact support@audius.co. ',
-  claimYourReward: 'Claim This Reward',
+  claimableAmountLabel: (amount: number) => `Claim $${amount} AUDIO`,
   twitterShare: (modalType: 'referrals' | 'ref-v') =>
     `Share Invite With Your ${modalType === 'referrals' ? 'Friends' : 'Fans'}`,
   twitterCopy: `Come support me on @audius! Use my link and we both earn $AUDIO when you sign up.\n\n #audius #audiorewards\n\n`,
@@ -491,7 +491,7 @@ const ChallengeRewardsBody = ({ dismissModal }: BodyProps) => {
           iconRight={IconCheck}
           onClick={onClaimRewardClicked}
         >
-          {messages.claimYourReward}
+          {messages.claimableAmountLabel(audioToClaim)}
         </Button>
       )
     }

--- a/packages/web/src/pages/audio-rewards-page/components/modals/ChallengeRewardsModal/ChallengeRewardsModal.tsx
+++ b/packages/web/src/pages/audio-rewards-page/components/modals/ChallengeRewardsModal/ChallengeRewardsModal.tsx
@@ -485,19 +485,14 @@ const ChallengeRewardsBody = ({ dismissModal }: BodyProps) => {
   const renderClaimButton = () => {
     if (audioToClaim > 0) {
       return (
-        <>
-          <div className={styles.claimRewardAmountLabel}>
-            {`${audioToClaim} ${messages.claimAmountLabel}`}
-          </div>
-          <Button
-            variant='primary'
-            isLoading={claimInProgress}
-            iconRight={IconCheck}
-            onClick={onClaimRewardClicked}
-          >
-            {messages.claimYourReward}
-          </Button>
-        </>
+        <Button
+          variant='primary'
+          isLoading={claimInProgress}
+          iconRight={IconCheck}
+          onClick={onClaimRewardClicked}
+        >
+          {messages.claimYourReward}
+        </Button>
       )
     }
     return null
@@ -582,6 +577,11 @@ const ChallengeRewardsBody = ({ dismissModal }: BodyProps) => {
         {audioToClaim > 0 ||
         (audioClaimedSoFar > 0 && challenge?.state !== 'disbursed') ? (
           <div className={wm(styles.claimRewardWrapper)}>
+            {!isRewardsCooldownEnabled ? (
+              <div className={styles.claimRewardAmountLabel}>
+                {`${audioToClaim} ${messages.claimAmountLabel}`}
+              </div>
+            ) : null}
             {renderClaimButton()}
             {renderClaimedSoFarContent()}
           </div>


### PR DESCRIPTION
### Description
New designs show this `available to claim` label is removed and the button should show the claimable amount. Mobile appears to match design.

<img width="713" alt="Screenshot 2024-05-06 at 11 25 49 AM" src="https://github.com/AudiusProject/audius-protocol/assets/6413636/b27d4067-5ee0-493a-9852-56a48b7c4acf">

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._

Ran local client against stage and confirmed labels look correct.

<img width="694" alt="Screenshot 2024-05-06 at 11 25 09 AM" src="https://github.com/AudiusProject/audius-protocol/assets/6413636/dfd99797-9118-4259-b3ed-39433e533e96">
