### PR TITLE
[PAY-2809] Mobile premium album tracklist UI updates

### DIFF
--- a/packages/mobile/src/components/track-list/TrackListItem.tsx
+++ b/packages/mobile/src/components/track-list/TrackListItem.tsx
@@ -273,9 +273,9 @@ const TrackListItemComponent = (props: TrackListItemComponentProps) => {
     return isActive && getPlaying(state)
   })
   const isPlaylistAddable = useIsGatedContentPlaylistAddable(track)
-  // Unlike other types of gated tracks, USDC-gated tracks have previews so we
-  // should show the play button for them.
-  const isPlayable = !isLocked || isContentUSDCPurchaseGated(streamConditions)
+  // Unlike other gated tracks, USDC purchase gated tracks are playable because they have previews
+  const isPlayable =
+    !isDeleted && (!isLocked || isContentUSDCPurchaseGated(streamConditions))
 
   const messages = getMessages({ isDeleted })
   const styles = useStyles()
@@ -294,7 +294,7 @@ const TrackListItemComponent = (props: TrackListItemComponentProps) => {
   )
 
   const onPressTrack = () => {
-    if (uid && isPlayable && !isDeleted && togglePlay) {
+    if (uid && isPlayable && togglePlay) {
       togglePlay(uid, track_id)
     }
   }
@@ -416,7 +416,7 @@ const TrackListItemComponent = (props: TrackListItemComponentProps) => {
         <ListItemView
           style={styles.trackInnerContainer}
           onPress={isReorderable ? undefined : onPressTrack}
-          disabled={isDeleted || !isPlayable}
+          disabled={!isPlayable}
         >
           {!hideArt ? (
             <TrackArtwork
@@ -425,7 +425,7 @@ const TrackListItemComponent = (props: TrackListItemComponentProps) => {
               isPlaying={isPlaying}
               isUnlisted={isUnlisted}
             />
-          ) : isActive && !isDeleted && isPlayable ? (
+          ) : isActive && isPlayable ? (
             <IconButton
               icon={isPlaying ? IconPlaybackPause : IconPlaybackPlay}
               onPress={onPressTrack}
@@ -447,7 +447,7 @@ const TrackListItemComponent = (props: TrackListItemComponentProps) => {
           <View
             style={[
               styles.nameArtistContainer,
-              !isDeleted && !isPlayable ? styles.halfTransparent : null
+              isPlayable ? null : styles.halfTransparent
             ]}
           >
             <View

--- a/packages/mobile/src/components/track-list/TrackListItem.tsx
+++ b/packages/mobile/src/components/track-list/TrackListItem.tsx
@@ -273,6 +273,8 @@ const TrackListItemComponent = (props: TrackListItemComponentProps) => {
     return isActive && getPlaying(state)
   })
   const isPlaylistAddable = useIsGatedContentPlaylistAddable(track)
+  // Unlike other types of gated tracks, USDC-gated tracks have previews so we
+  // should show the play button for them.
   const isPlayable = !isLocked || isContentUSDCPurchaseGated(streamConditions)
 
   const messages = getMessages({ isDeleted })
@@ -292,12 +294,7 @@ const TrackListItemComponent = (props: TrackListItemComponentProps) => {
   )
 
   const onPressTrack = () => {
-    if (
-      uid &&
-      (!isLocked || isContentUSDCPurchaseGated(streamConditions)) &&
-      !isDeleted &&
-      togglePlay
-    ) {
+    if (uid && isPlayable && !isDeleted && togglePlay) {
       togglePlay(uid, track_id)
     }
   }


### PR DESCRIPTION
### Description
* USDC-gated tracks can now be pressed to play preview + show locked icon at right of row
* Locked icon goes away when track is unlocked
* Locked icon also appears for other gated types (for future)
* Other gated types are still grayed out + unclickable (for future)

### How Has This Been Tested?
Locked tracks
![Simulator Screenshot - iPhone 15 Pro - 2024-05-06 at 14 50 25](https://github.com/AudiusProject/audius-protocol/assets/3893871/fd8ab04f-227e-4b35-aa97-e16a29829423)

Other types of locked gated tracks
![Simulator Screenshot - iPhone 15 Pro - 2024-05-06 at 14 50 12](https://github.com/AudiusProject/audius-protocol/assets/3893871/ac0fbdbb-3748-4a2c-84aa-3caae16f7501)

unlocked
![Simulator Screenshot - iPhone 15 Pro - 2024-05-06 at 14 50 02](https://github.com/AudiusProject/audius-protocol/assets/3893871/e1956059-0b6a-475b-9b9d-4717ae8d705d)

deleted tracks
![Simulator Screenshot - iPhone 15 Pro - 2024-05-06 at 18 46 30](https://github.com/AudiusProject/audius-protocol/assets/3893871/614e2d4a-4e9c-40b4-a847-47841dd6a618)
