### PR TITLE
[PAY-2881] Fix access & sale showing hidden by default

### DIFF
--- a/packages/common/src/hooks/useAccessAndRemixSettings.test.ts
+++ b/packages/common/src/hooks/useAccessAndRemixSettings.test.ts
@@ -328,7 +328,7 @@ describe('useAccessAndRemixSettings', () => {
         disableSpecialAccessGateFields: true,
         disableCollectibleGate: true,
         disableCollectibleGateFields: true,
-        disableHidden: false
+        disableHidden: true
       }
       expect(actual).toEqual(expected)
     })
@@ -393,7 +393,7 @@ describe('useAccessAndRemixSettings', () => {
         disableSpecialAccessGateFields: true,
         disableCollectibleGate: true,
         disableCollectibleGateFields: true,
-        disableHidden: false
+        disableHidden: true
       }
       expect(actual).toEqual(expected)
     })

--- a/packages/common/src/hooks/useAccessAndRemixSettings.ts
+++ b/packages/common/src/hooks/useAccessAndRemixSettings.ts
@@ -113,7 +113,7 @@ export const useAccessAndRemixSettings = ({
     disableCollectibleGate || (!isUpload && !isInitiallyHidden)
 
   const disableHidden =
-    isScheduledRelease || (!isUpload && !isInitiallyUnlisted)
+    isAlbum || isScheduledRelease || (!isUpload && !isInitiallyUnlisted)
 
   return {
     disableUsdcGate,

--- a/packages/common/src/schemas/metadata.ts
+++ b/packages/common/src/schemas/metadata.ts
@@ -87,7 +87,7 @@ export const newTrackMetadata = (fields, validate = false): TrackMetadata => {
 const collectionMetadataSchema = {
   is_album: false,
   is_current: true,
-  is_private: true,
+  is_private: false,
   tags: null,
   genre: null,
   mood: null,

--- a/packages/common/src/schemas/upload/uploadFormSchema.ts
+++ b/packages/common/src/schemas/upload/uploadFormSchema.ts
@@ -269,6 +269,7 @@ export const createCollectionSchema = (collectionType: 'playlist' | 'album') =>
       }),
       is_unlisted: z.optional(z.boolean()),
       is_album: z.literal(collectionType === 'album'),
+      is_private: z.optional(z.boolean()),
       tracks: z.array(z.object({ metadata: CollectionTrackMetadataSchema })),
       ddex_release_ids: z.optional(z.record(z.string()).nullable()),
       artists: z.optional(z.array(DDEXResourceContributor).nullable()),


### PR DESCRIPTION
### Description

Disable hidden option on access & sale, set `is_private` to false by default

### How Has This Been Tested?

web:stage

![2024-05-06 14 04 10](https://github.com/AudiusProject/audius-protocol/assets/6711655/10ffad98-ea1a-4bcd-99ec-6c7a14d7a719)

- [x] Create playlist via upload creates as public on web
- [x] Create album via upload creates as public on web
- [x] Create playlist via profile page creates hidden playlist on web
- [x] Create playlist via left nav creates hidden playlist on web
- [x] Create album via profile page creates hidden playlist on web
- [x] Create playlist via profile page creates hidden playlist on native
- [x] Create playlist via library page creates hidden playlist on native
