### PR TITLE
[C-4339] Fix rewards progress label formatting

### DIFF
--- a/packages/web/src/pages/audio-rewards-page/ChallengeRewardsTile.tsx
+++ b/packages/web/src/pages/audio-rewards-page/ChallengeRewardsTile.tsx
@@ -99,6 +99,18 @@ const messages = {
   }
 }
 
+const formatProgressLabel = (
+  label?: string,
+  current?: number,
+  max?: number
+) => {
+  return fillString(
+    label ?? '',
+    formatNumberCommas(current?.toString() ?? ''),
+    formatNumberCommas(max?.toString() ?? '')
+  )
+}
+
 type RewardPanelProps = {
   title: string
   icon: ReactNode
@@ -147,45 +159,32 @@ const RewardPanel = ({
     isAudioMatchingChallenge(id) && !needsDisbursement
 
   let progressLabelFilled: string
+  if (challenge?.challenge_id === 'track-upload') {
+    console.log('asdf challenge: ', challenge)
+  }
   if (shouldShowCompleted) {
     progressLabelFilled = messages.completeLabel
-  } else if (challenge && challenge?.cooldown_days > 0) {
-    if (needsDisbursement) {
-      progressLabelFilled = messages.readyToClaim
-    } else if (pending) {
-      progressLabelFilled = messages.pendingRewards
-    } else if (challenge?.challenge_type === 'aggregate') {
-      // Count down
-      progressLabelFilled = fillString(
-        remainingLabel ?? '',
-        formatNumberCommas(
-          (challenge?.max_steps - challenge?.current_step_count)?.toString() ??
-            ''
-        ),
-        formatNumberCommas(challenge?.max_steps?.toString() ?? '')
-      )
-    } else {
-      progressLabelFilled = progressLabel ?? ''
-    }
+  } else if (needsDisbursement) {
+    progressLabelFilled = messages.readyToClaim
+  } else if (pending) {
+    progressLabelFilled = messages.pendingRewards
   } else if (challenge?.challenge_type === 'aggregate') {
     // Count down
-    progressLabelFilled = fillString(
+    progressLabelFilled = formatProgressLabel(
       remainingLabel ?? '',
-      formatNumberCommas(
-        (challenge?.max_steps - challenge?.current_step_count)?.toString() ?? ''
-      ),
-      formatNumberCommas(challenge?.max_steps?.toString() ?? '')
+      challenge?.max_steps - challenge?.current_step_count,
+      challenge.max_steps
+    )
+  } else if (progressLabel?.includes('%')) {
+    progressLabelFilled = formatProgressLabel(
+      progressLabel,
+      challenge?.current_step_count,
+      challenge?.max_steps
     )
   } else {
-    // Count up
-    progressLabelFilled = progressLabel
-      ? fillString(
-          progressLabel,
-          formatNumberCommas(challenge?.current_step_count?.toString() ?? ''),
-          formatNumberCommas(challenge?.max_steps?.toString() ?? '')
-        )
-      : ''
+    progressLabelFilled = progressLabel ?? ''
   }
+
   const buttonMessage = needsDisbursement
     ? messages.claimReward
     : hasDisbursed

--- a/packages/web/src/pages/audio-rewards-page/ChallengeRewardsTile.tsx
+++ b/packages/web/src/pages/audio-rewards-page/ChallengeRewardsTile.tsx
@@ -159,9 +159,6 @@ const RewardPanel = ({
     isAudioMatchingChallenge(id) && !needsDisbursement
 
   let progressLabelFilled: string
-  if (challenge?.challenge_id === 'track-upload') {
-    console.log('asdf challenge: ', challenge)
-  }
   if (shouldShowCompleted) {
     progressLabelFilled = messages.completeLabel
   } else if (needsDisbursement) {

--- a/packages/web/src/pages/audio-rewards-page/ChallengeRewardsTile.tsx
+++ b/packages/web/src/pages/audio-rewards-page/ChallengeRewardsTile.tsx
@@ -99,18 +99,6 @@ const messages = {
   }
 }
 
-const formatProgressLabel = (
-  label?: string,
-  current?: number,
-  max?: number
-) => {
-  return fillString(
-    label ?? '',
-    formatNumberCommas(current?.toString() ?? ''),
-    formatNumberCommas(max?.toString() ?? '')
-  )
-}
-
 type RewardPanelProps = {
   title: string
   icon: ReactNode
@@ -161,27 +149,45 @@ const RewardPanel = ({
   let progressLabelFilled: string
   if (shouldShowCompleted) {
     progressLabelFilled = messages.completeLabel
-  } else if (needsDisbursement) {
-    progressLabelFilled = messages.readyToClaim
-  } else if (pending) {
-    progressLabelFilled = messages.pendingRewards
+  } else if (challenge && challenge?.cooldown_days > 0) {
+    if (needsDisbursement) {
+      progressLabelFilled = messages.readyToClaim
+    } else if (pending) {
+      progressLabelFilled = messages.pendingRewards
+    } else if (challenge?.challenge_type === 'aggregate') {
+      // Count down
+      progressLabelFilled = fillString(
+        remainingLabel ?? '',
+        formatNumberCommas(
+          (challenge?.max_steps - challenge?.current_step_count)?.toString() ??
+            ''
+        ),
+        formatNumberCommas(challenge?.max_steps?.toString() ?? '')
+      )
+    } else {
+      progressLabelFilled = fillString(
+        progressLabel ?? '',
+        formatNumberCommas(challenge?.current_step_count?.toString() ?? ''),
+        formatNumberCommas(challenge?.max_steps?.toString() ?? '')
+      )
+    }
   } else if (challenge?.challenge_type === 'aggregate') {
     // Count down
-    progressLabelFilled = formatProgressLabel(
+    progressLabelFilled = fillString(
       remainingLabel ?? '',
-      challenge?.max_steps - challenge?.current_step_count,
-      challenge.max_steps
-    )
-  } else if (progressLabel?.includes('%')) {
-    progressLabelFilled = formatProgressLabel(
-      progressLabel,
-      challenge?.current_step_count,
-      challenge?.max_steps
+      formatNumberCommas(
+        (challenge?.max_steps - challenge?.current_step_count)?.toString() ?? ''
+      ),
+      formatNumberCommas(challenge?.max_steps?.toString() ?? '')
     )
   } else {
-    progressLabelFilled = progressLabel ?? ''
+    // Count up
+    progressLabelFilled = fillString(
+      progressLabel ?? '',
+      formatNumberCommas(challenge?.current_step_count?.toString() ?? ''),
+      formatNumberCommas(challenge?.max_steps?.toString() ?? '')
+    )
   }
-
   const buttonMessage = needsDisbursement
     ? messages.claimReward
     : hasDisbursed


### PR DESCRIPTION
### Description
Progress labels are not being formatted because of complex logic in determining when to format. 

<img width="504" alt="Screenshot 2024-05-06 at 12 21 59 PM" src="https://github.com/AudiusProject/audius-protocol/assets/6413636/78e98d59-d49c-458c-8384-2867bc965309">

Tried simplifying it to match what happens in mobile. Special logic for cooldown_rewards is not necessary. 

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._

Tested locally against staging env.

<img width="569" alt="Screenshot 2024-05-06 at 12 23 41 PM" src="https://github.com/AudiusProject/audius-protocol/assets/6413636/60d718ea-ddb4-46be-8f14-f4217d25e480">
