### PR TITLE
[PAY-2866] Fix duration showing 0m 0s

### DIFF
--- a/packages/mobile/src/screens/track-screen/TrackScreenDetailsTile.tsx
+++ b/packages/mobile/src/screens/track-screen/TrackScreenDetailsTile.tsx
@@ -136,7 +136,8 @@ export const TrackScreenDetailsTile = ({
     track_id: trackId,
     stream_conditions: streamConditions,
     ddex_app: ddexApp,
-    is_delete
+    is_delete,
+    duration
   } = track
 
   const isOwner = owner_id === currentUserId
@@ -334,6 +335,7 @@ export const TrackScreenDetailsTile = ({
       contentId={trackId}
       contentType={PurchaseableContentType.TRACK}
       ddexApp={ddexApp}
+      duration={duration}
     />
   )
 }


### PR DESCRIPTION
### Description

Fix duration showing 0m 0s on native mobile track page


### How Has This Been Tested?

![image](https://github.com/AudiusProject/audius-protocol/assets/6711655/1e9579e9-3aa5-4a2a-8ed1-2e7558857de8)


ios:stage
