### PR TITLE
[PAY-2888] Fix dog ear positioning

### DIFF
--- a/packages/web/src/components/tile/Tile.tsx
+++ b/packages/web/src/components/tile/Tile.tsx
@@ -8,6 +8,7 @@ import {
 } from 'react'
 
 import { DogEarType } from '@audius/common/models'
+import { Box } from '@audius/harmony'
 import cn from 'classnames'
 
 import { DogEar } from 'components/dog-ear'
@@ -43,25 +44,23 @@ export const Tile = forwardRef(
     } = props
 
     return (
-      <RootComponent
-        className={cn(
-          styles.root,
-          size && styles[size],
-          styles[elevation],
-          className
-        )}
-        type={onClick ? 'button' : undefined}
-        onClick={onClick}
-        ref={ref}
-        {...other}
-      >
-        {dogEar ? (
-          <div className={styles.borderOffset}>
-            <DogEar type={dogEar} />
-          </div>
-        ) : null}
-        {children}
-      </RootComponent>
+      <Box>
+        {dogEar ? <DogEar type={dogEar} /> : null}
+        <RootComponent
+          className={cn(
+            styles.root,
+            size && styles[size],
+            styles[elevation],
+            className
+          )}
+          type={onClick ? 'button' : undefined}
+          onClick={onClick}
+          ref={ref}
+          {...other}
+        >
+          {children}
+        </RootComponent>
+      </Box>
     )
   }
 )


### PR DESCRIPTION
### Description

The dog ear was seemingly 1 px off of the correct position, but it was just the border of the parent covering it up. 
No amount of repositioning fixed because the real issue was there was an `overflow: hidden` in the parent not allowing it to show.

To fix I moved it to be alongside the parent container so it can properly lay over the top

### How Has This Been Tested?

web:stage

![image](https://github.com/AudiusProject/audius-protocol/assets/6711655/cc8d807c-6f2b-4956-a9c5-8924005ad373)
