### PR TITLE
[PAY-2814] Omit favorite and repost buttons for unowned albums

### DIFF
--- a/packages/mobile/src/screens/collection-screen/CollectionScreenDetailsTile.tsx
+++ b/packages/mobile/src/screens/collection-screen/CollectionScreenDetailsTile.tsx
@@ -163,6 +163,7 @@ export const CollectionScreenDetailsTile = ({
   isOwner,
   hideOverflow,
   hideRepost,
+  hideFavorite,
   hasStreamAccess,
   streamConditions,
   ddexApp,
@@ -291,7 +292,8 @@ export const CollectionScreenDetailsTile = ({
       hideListenCount={true}
       hasStreamAccess={hasStreamAccess}
       streamConditions={streamConditions}
-      hideRepost={hideRepost || !isReachable}
+      hideFavorite={hideFavorite || !hasStreamAccess}
+      hideRepost={hideRepost || !isReachable || !hasStreamAccess}
       isPlaying={isPlaying && isQueued}
       isPreviewing={isPreviewing && isQueued}
       isPublished={!isPrivate || isPublishing}

--- a/packages/web/src/components/card-legacy/desktop/CollectionArtCard.tsx
+++ b/packages/web/src/components/card-legacy/desktop/CollectionArtCard.tsx
@@ -85,9 +85,11 @@ const CollectionArtCard = g(
       has_current_user_saved,
       repost_count,
       save_count,
-      permalink
+      permalink,
+      access
     } = collection
     const { user_id, name, handle } = user
+    const hasStreamAccess = access?.stream
 
     const [isPerspectiveDisabled, setIsPerspectiveDisabled] = useState(false)
 
@@ -144,8 +146,8 @@ const CollectionArtCard = g(
       playlistName: playlist_name,
       isOwner: currentUserId === user_id,
       includeShare: true,
-      includeRepost: true,
-      includeSave: true,
+      includeRepost: hasStreamAccess,
+      includeFavorite: hasStreamAccess,
       includeVisitPage: true,
       isFavorited: has_current_user_saved,
       isReposted: has_current_user_reposted,

--- a/packages/web/src/components/collection/desktop/OverflowMenuButton.tsx
+++ b/packages/web/src/components/collection/desktop/OverflowMenuButton.tsx
@@ -35,7 +35,8 @@ export const OverflowMenuButton = (props: OverflowMenuButtonProps) => {
     is_private,
     playlist_owner_id,
     has_current_user_saved,
-    permalink
+    permalink,
+    access
   } =
     (useSelector((state: CommonState) =>
       getCollection(state, { id: collectionId })
@@ -43,6 +44,7 @@ export const OverflowMenuButton = (props: OverflowMenuButtonProps) => {
 
   const owner = useSelector(getUser) as User
   const isFollowing = owner?.does_current_user_follow
+  const hasStreamAccess = access?.stream
 
   const handleFollow = useCallback(() => {
     if (isFollowing) {
@@ -70,7 +72,7 @@ export const OverflowMenuButton = (props: OverflowMenuButtonProps) => {
     mount: 'page',
     isOwner,
     includeEmbed: true,
-    includeSave: false,
+    includeFavorite: hasStreamAccess,
     includeVisitPage: false,
     isPublic: !is_private,
     extraMenuItems,

--- a/packages/web/src/components/collection/desktop/ViewerActionButtons.tsx
+++ b/packages/web/src/components/collection/desktop/ViewerActionButtons.tsx
@@ -20,13 +20,18 @@ export const ViewerActionButtons = (props: ViewerActionButtonsProps) => {
     getCollection(state, { id: collectionId })
   ) as Collection | null
 
-  const { track_count, is_private } = collection ?? {}
+  const { track_count, is_private, access } = collection ?? {}
   const isDisabled = !collection || track_count === 0 || is_private
+  const hasStreamAccess = access?.stream
 
   return (
     <>
-      <RepostButton disabled={isDisabled} collectionId={collectionId} />
-      <FavoriteButton disabled={isDisabled} collectionId={collectionId} />
+      {hasStreamAccess ? (
+        <>
+          <RepostButton disabled={isDisabled} collectionId={collectionId} />
+          <FavoriteButton disabled={isDisabled} collectionId={collectionId} />
+        </>
+      ) : null}
 
       <ShareButton disabled={isDisabled} collectionId={collectionId} />
       <ClientOnly>

--- a/packages/web/src/components/collection/mobile/CollectionHeader.tsx
+++ b/packages/web/src/components/collection/mobile/CollectionHeader.tsx
@@ -126,12 +126,12 @@ const CollectionHeader = ({
 
   const onClickOverflow = () => {
     const overflowActions = [
-      isOwner || !isPublished
+      isOwner || !isPublished || !hasStreamAccess
         ? null
         : isReposted
         ? OverflowAction.UNREPOST
         : OverflowAction.REPOST,
-      isOwner || !isPublished
+      isOwner || !isPublished || !hasStreamAccess
         ? null
         : isSaved
         ? OverflowAction.UNFAVORITE
@@ -277,8 +277,8 @@ const CollectionHeader = ({
           onRepost={onRepost}
           onClickOverflow={onClickOverflow}
           onClickEdit={handleClickEdit}
-          showFavorite={!!onSave && !isOwner}
-          showRepost={variant !== Variant.SMART && !isOwner}
+          showFavorite={!!onSave && !isOwner && hasStreamAccess}
+          showRepost={variant !== Variant.SMART && !isOwner && hasStreamAccess}
           showShare={variant !== Variant.SMART || type === 'Audio NFT Playlist'}
           showOverflow={variant !== Variant.SMART}
           darkMode={isDarkMode()}

--- a/packages/web/src/components/collections-table/CollectionsTableOverflowMenuButton.tsx
+++ b/packages/web/src/components/collections-table/CollectionsTableOverflowMenuButton.tsx
@@ -34,7 +34,7 @@ export const CollectionsTableOverflowMenuButton = (
     includeVisitArtistPage: false,
     includeShare: true,
     includeEdit: true,
-    includeSave: false,
+    includeFavorite: false,
     isPublic: !isPrivate,
     isOwner: currentUserId === playlistOwnerId,
     permalink


### PR DESCRIPTION
### Description

Don't show favorite and repost action buttons or menu options for purchaseable albums you don't own

![Screenshot 2024-05-06 at 1 06 36 PM](https://github.com/AudiusProject/audius-protocol/assets/2358254/01a6b1ac-bbcd-488c-9751-660c8715cf14)
![Screenshot 2024-05-06 at 1 20 52 PM](https://github.com/AudiusProject/audius-protocol/assets/2358254/0f3d2878-fdf3-44d1-99a6-871240df6a75)


### How Has This Been Tested?

buttons showing when they should and not when they shouldn't