### PR TITLE
[PAY-2889] Fix edit collection unlisted value

### DIFF
--- a/packages/common/src/schemas/upload/uploadFormSchema.ts
+++ b/packages/common/src/schemas/upload/uploadFormSchema.ts
@@ -267,7 +267,7 @@ export const createCollectionSchema = (collectionType: 'playlist' | 'album') =>
         mood: MoodSchema,
         tags: z.optional(z.string())
       }),
-      is_unlisted: z.optional(z.boolean()),
+      is_private: z.optional(z.boolean()),
       is_album: z.literal(collectionType === 'album'),
       tracks: z.array(z.object({ metadata: CollectionTrackMetadataSchema })),
       ddex_release_ids: z.optional(z.record(z.string()).nullable()),

--- a/packages/web/src/common/store/upload/sagas.ts
+++ b/packages/web/src/common/store/upload/sagas.ts
@@ -109,8 +109,8 @@ function* combineMetadata(
   // Set download & hidden status
   metadata.is_downloadable = !!collectionMetadata.is_downloadable
 
-  metadata.is_unlisted = !!collectionMetadata.is_unlisted
-  if (collectionMetadata.is_unlisted && collectionMetadata.field_visibility) {
+  metadata.is_unlisted = !!collectionMetadata.is_private
+  if (collectionMetadata.is_private && collectionMetadata.field_visibility) {
     // Convert any undefined values to booleans
     const booleanFieldVisibility = mapValues(
       collectionMetadata.field_visibility,
@@ -796,7 +796,7 @@ export function* uploadCollection(
           collectionMetadata as unknown as CollectionMetadata,
           isAlbum,
           trackIds,
-          !!collectionMetadata.is_unlisted
+          !!collectionMetadata.is_private
         )
 
         if (error) {

--- a/packages/web/src/pages/upload-page/fields/AccessAndSaleField.tsx
+++ b/packages/web/src/pages/upload-page/fields/AccessAndSaleField.tsx
@@ -402,13 +402,12 @@ export const AccessAndSaleField = (props: AccessAndSaleFieldProps) => {
       const fieldVisibility = get(values, FIELD_VISIBILITY)
       const streamConditions = get(values, STREAM_CONDITIONS)
       const lastGateKeeper = get(values, LAST_GATE_KEEPER)
-      const isUnlisted = get(values, IS_UNLISTED)
 
       setFieldVisibilityValue({
         ...defaultFieldVisibility,
         remixes: fieldVisibility?.remixes ?? defaultFieldVisibility.remixes
       })
-      setIsUnlistedValue(isUnlisted)
+      setIsUnlistedValue(false)
       setIsStreamGated(false)
       setStreamConditionsValue(null)
       setPreviewValue(undefined)

--- a/packages/web/src/pages/upload-page/fields/AccessAndSaleField.tsx
+++ b/packages/web/src/pages/upload-page/fields/AccessAndSaleField.tsx
@@ -343,7 +343,7 @@ export const AccessAndSaleField = (props: AccessAndSaleFieldProps) => {
     const isCollectibleGated = isContentCollectibleGated(savedStreamConditions)
 
     const initialValues = {}
-    set(initialValues, IS_UNLISTED, isUnlisted)
+    set(initialValues, isHiddenFieldName, isUnlisted)
     set(initialValues, IS_STREAM_GATED, isStreamGated)
     set(initialValues, STREAM_CONDITIONS, tempStreamConditions)
     set(initialValues, IS_DOWNLOAD_GATED, isDownloadGated)
@@ -382,16 +382,17 @@ export const AccessAndSaleField = (props: AccessAndSaleFieldProps) => {
     return initialValues as AccessAndSaleFormValues
   }, [
     savedStreamConditions,
+    isHiddenFieldName,
     isUnlisted,
     isStreamGated,
     tempStreamConditions,
     isDownloadGated,
     downloadConditions,
     isDownloadable,
-    fieldVisibility,
-    preview,
+    lastGateKeeper,
     isScheduledRelease,
-    lastGateKeeper
+    fieldVisibility,
+    preview
   ])
 
   const handleSubmit = useCallback(
@@ -407,10 +408,15 @@ export const AccessAndSaleField = (props: AccessAndSaleFieldProps) => {
         ...defaultFieldVisibility,
         remixes: fieldVisibility?.remixes ?? defaultFieldVisibility.remixes
       })
-      setIsUnlistedValue(false)
       setIsStreamGated(false)
       setStreamConditionsValue(null)
       setPreviewValue(undefined)
+
+      if (availabilityType === StreamTrackAvailabilityType.HIDDEN) {
+        setIsUnlistedValue(true)
+      } else {
+        setIsUnlistedValue(false)
+      }
 
       // For gated options, extract the correct stream conditions based on the selected availability type
       switch (availabilityType) {
@@ -593,11 +599,12 @@ export const AccessAndSaleField = (props: AccessAndSaleFieldProps) => {
         messages.fieldVisibility
       ) as Array<keyof FieldVisibility>
 
-      const fieldVisibilityLabels = fieldVisibility
-        ? fieldVisibilityKeys
-            .filter((visibilityKey) => fieldVisibility[visibilityKey])
-            .map((visibilityKey) => messages.fieldVisibility[visibilityKey])
-        : []
+      const fieldVisibilityLabels =
+        fieldVisibility && !isAlbum
+          ? fieldVisibilityKeys
+              .filter((visibilityKey) => fieldVisibility[visibilityKey])
+              .map((visibilityKey) => messages.fieldVisibility[visibilityKey])
+          : []
       selectedValues = [
         { label: messages.hidden, icon: IconHidden },
         ...fieldVisibilityLabels
@@ -630,7 +637,8 @@ export const AccessAndSaleField = (props: AccessAndSaleFieldProps) => {
     isScheduledRelease,
     preview,
     isUpload,
-    fieldVisibility
+    fieldVisibility,
+    isAlbum
   ])
 
   return (

--- a/packages/web/src/pages/upload-page/forms/EditCollectionForm.tsx
+++ b/packages/web/src/pages/upload-page/forms/EditCollectionForm.tsx
@@ -68,6 +68,7 @@ export const EditCollectionForm = (props: EditCollectionFormProps) => {
     playlist_name: '',
     description: '',
     release_date: moment().toString(),
+    is_private: false,
     trackDetails: {
       genre: null,
       mood: null,


### PR DESCRIPTION
### Description

#### Before:
setting album from hidden to premium would not clear the `is_private: true` value on the collection. We see both icons showing since it's `is_stream_gated: true` and `is_private: true`

![image](https://github.com/AudiusProject/audius-protocol/assets/2358254/f80b6308-bfc0-4fdb-9717-95265dd88cc5)

#### After:
we update the unlisted value to true whenever we change the access to anything besides hidden.

![image](https://github.com/AudiusProject/audius-protocol/assets/2358254/ac8b2cbe-ad60-4d9c-9cf7-45ff1f14c8ce)


### How Has This Been Tested?

local web