### PR TITLE
Change 'creator' to 'content' where applicable for audius-ctl docs

### DIFF
--- a/docs/docs/node-operator/setup/advanced.mdx
+++ b/docs/docs/node-operator/setup/advanced.mdx
@@ -155,7 +155,7 @@ This command will down **ALL** of the Audius Nodes specified in the configuratio
 node, pass the URL as an additional argument, like this:
 
 ```bash
-audius-ctl down creator-1.example.com
+audius-ctl down content-1.example.com
 ```
 
 The same can be done with the `up` command when you are ready to start the Audius Node again.

--- a/docs/docs/node-operator/setup/architecture.mdx
+++ b/docs/docs/node-operator/setup/architecture.mdx
@@ -241,7 +241,7 @@ example below to identify the information needed for each node.
 
 | field           | description                                                                                                        |
 | --------------- | ------------------------------------------------------------------------------------------------------------------ |
-| `type`          | either `creator` or `discovery`                                                                                    |
+| `type`          | either `content` or `discovery`                                                                                    |
 | `privateKey`    | private key associated with                                                                                        |
 | `wallet`        | Address of wallet that contains no tokens but that is registered on chain, used to sign JSON responses from server |
 | `rewardsWallet` | Wallet that registered (or will register) the content node on chain                                                |
@@ -252,7 +252,7 @@ Node Operators migrating existing Nodes will be familiar with the legacy variabl
 type. See the mappings below to correctly use existing keys from a `override.env` file in a new
 config file.
 
-- Creator Node Variables
+- Content Node Variables
 
   - `delegateOwnerWallet` --> `wallet`
   - `delegatePrivateKey` --> `privateKey`
@@ -267,8 +267,8 @@ config file.
 network:
   deployOn: mainnet
 nodes:
-  creator-1.example.com:        # the url of the node
-    type: creator               # creator or discovery, depending on the node type
+  content-1.example.com:        # the url of the node
+    type: content               # content or discovery, depending on the node type
     privateKey: abc123          # <--- UNIQUE PRIV KEY USED BY THIS NODE TO SIGN RESPONSES
     wallet: 0xABC123            # <--- UNIQUE WALLET ADDRESS OF ABOVE PRIV KEY
     rewardsWallet: 0xABC123     # <--- ADDRESS OF WALLET HOLDING STAKED TOKENS
@@ -319,7 +319,7 @@ This command will down **ALL** of the Audius Nodes specified in the configuratio
 node, pass the URL as an additional argument, like this:
 
 ```bash
-audius-ctl down creator-1.example.com
+audius-ctl down content-1.example.com
 ```
 
 The same can be done with the `up` command when you are ready to start the Audius Node again.

--- a/docs/docs/node-operator/setup/installation.mdx
+++ b/docs/docs/node-operator/setup/installation.mdx
@@ -97,8 +97,8 @@ each field for each Audius Node you will be running.
 network:
   deployOn: mainnet
 nodes:
-  creator-1.example.com:        # <--- THE URL OF YOUR CONTENT NODE
-    type: creator
+  content-1.example.com:        # <--- THE URL OF YOUR CONTENT NODE
+    type: content
     privateKey: abc123          # <--- UNIQUE PRIV KEY USED BY THIS NODE TO SIGN RESPONSES
     wallet: 0xABC123            # <--- UNIQUE WALLET ADDRESS OF ABOVE PRIV KEY
     rewardsWallet: 0xABC123     # <--- ADDRESS OF WALLET HOLDING STAKED TOKENS
@@ -115,7 +115,7 @@ nodes:
 
 | field           | description                                                                                                        |
 | --------------- | ------------------------------------------------------------------------------------------------------------------ |
-| `type`          | either `creator` or `discovery`                                                                                    |
+| `type`          | either `content` or `discovery`                                                                                    |
 | `privateKey`    | private key associated with the `wallet`                                                                           |
 | `wallet`        | Address of wallet that contains no tokens but that is registered on chain, used to sign JSON responses from server |
 | `rewardsWallet` | Wallet that registered (or will register) the Audius Node on chain                                                 |
@@ -222,7 +222,7 @@ audius-cli down
 ### Configure Nodes
 
 From here, the guide is the same as though you were creating new Nodes from scratch. Head back up to
-the [`audius-cli` installation step](/node-operator/setup/installation#install-audius-ctl) to get
+the [`audius-ctl` installation step](/node-operator/setup/installation#install-audius-ctl) to get
 started.
 
 #### Migration Variable Mapping


### PR DESCRIPTION
### Description

"Creator" is the deprecated term for "content" nodes and audius-d configuration has been updated accordingly.

### How Has This Been Tested?

N/A