### PR TITLE
[PAY-2806] Fix offline downloads legacy content node selection

### DIFF
--- a/packages/mobile/src/store/offline-downloads/sagas/offlineQueueSagas/workers/downloadTrackWorker.ts
+++ b/packages/mobile/src/store/offline-downloads/sagas/offlineQueueSagas/workers/downloadTrackWorker.ts
@@ -160,11 +160,7 @@ function* downloadTrackAsync(
 }
 
 function* downloadTrackAudio(track: UserTrackMetadata) {
-  const { track_id, title, user } = track
-
-  const { creator_node_endpoint } = user
-  const creatorNodeEndpoints = creator_node_endpoint?.split(',')
-  if (!creatorNodeEndpoints) throw new Error('No creator node endpoints')
+  const { track_id, title } = track
 
   const trackFilePath = getLocalAudioPath(track_id)
   const encodedTrackId = encodeHashId(track_id)


### PR DESCRIPTION
### Description

Offline mode was migrated away from the legacy `creator_node_endpoint` but we were still checking for it and throwing when it's missing. Removed the check and now it's working 🤦

### How Has This Been Tested?

working on mobile sim
can download tracks by newly created users