### PR TITLE
[PAY-2879] Add purchased pill to mobile albums library

### DIFF
--- a/packages/mobile/src/screens/favorites-screen/LibraryCategorySelectionMenu.tsx
+++ b/packages/mobile/src/screens/favorites-screen/LibraryCategorySelectionMenu.tsx
@@ -103,7 +103,8 @@ export const LibraryCategorySelectionMenu = () => {
 
   const isUSDCPurchasesEnabled = useIsUSDCEnabled()
   const categories =
-    currentTab === SavedPageTabs.TRACKS && isUSDCPurchasesEnabled
+    isUSDCPurchasesEnabled &&
+    (currentTab === SavedPageTabs.TRACKS || currentTab === SavedPageTabs.ALBUMS)
       ? ALL_CATEGORIES
       : CATEGORIES_WITHOUT_PURCHASED
 


### PR DESCRIPTION
### Description

It just worked. Incredible! Shoutout @nicoback2 for making it forwards compatible

![Screenshot 2024-05-06 at 4 47 17 PM](https://github.com/AudiusProject/audius-protocol/assets/2358254/c650416d-cebe-4201-bab5-53f294133fcb)

### How Has This Been Tested?

working on sim. Shows my purchased albums and not others