### PR TITLE
Add log for ws check

### DIFF
--- a/comms/discovery/server/server.go
+++ b/comms/discovery/server/server.go
@@ -741,10 +741,12 @@ func (ss *ChatServer) doWebsocketTest() error {
 	}
 
 	wsUrl = wsUrl.JoinPath("/comms/debug/ws")
+	slog.Info("testing ws connection", wsUrl)
 
 	ctx := context.Background()
 	con, _, _, err := ws.Dial(ctx, wsUrl.String())
 	if err != nil {
+		slog.Info("ws connection error "+err.Error(), wsUrl)
 		return err
 	}
 	return con.Close()


### PR DESCRIPTION
### Description

WS check is doing really strange things.

I am able to run this flavor of the check and properly connect to the host https://dn2.monophonic.digital, but it fails on the node itself
```
package main

import (
	"context"
	"fmt"
	"net/url"
	"os"
	"strings"

	"github.com/gobwas/ws"
)

type ChatServer struct {
	config ServerConfig
}

type ServerConfig struct {
	MyHost string
}

func (ss *ChatServer) doWebsocketTest() error {
	wsUrl, err := url.Parse(strings.Replace(ss.config.MyHost, "http", "ws", 1))
	if err != nil {
		return err
	}

	wsUrl = wsUrl.JoinPath("/comms/debug/ws")

	ctx := context.Background()
	con, _, _, err := ws.Dial(ctx, wsUrl.String())
	fmt.Println(err)
	if err != nil {
		return err
	}
	return con.Close()
}

func main() {
	// Replace with your server configuration
	serverConfig := ServerConfig{
		MyHost: "https://dn2.monophonic.digital",
	}

	chatServer := ChatServer{
		config: serverConfig,
	}

	// Perform the WebSocket test
	err := chatServer.doWebsocketTest()
	if err != nil {
		fmt.Fprintf(os.Stderr, "WebSocket Test Error: %v\n", err)
		os.Exit(1)
	}

	fmt.Println("WebSocket Test Successful")
}

```

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._

