### PR TITLE
[QA-1242] Fix play correct track

### DIFF
--- a/packages/mobile/src/components/audio/AudioPlayer.tsx
+++ b/packages/mobile/src/components/audio/AudioPlayer.tsx
@@ -621,7 +621,7 @@ export const AudioPlayer = () => {
     // Enqueue tracks using 'middle-out' to ensure user can ready skip forward or backwards
     const enqueueTracks = async (
       queuableTracks: QueueableTrack[],
-      queueIndex = 0
+      queueIndex = -1
     ) => {
       let currentPivot = 1
       while (


### PR DESCRIPTION
### Description

Fixes issue where after a lineup append, track playback is off-by-one. This is because the track-append index + pivot started at 1, when it should start at 0. To fix this, we default the index to -1