### PR TITLE
[PAY-2896][PAY-2908][PAY-2907] Update claim all button text logic

### DIFF
--- a/packages/mobile/src/components/challenge-rewards-drawer/ClaimAllRewardsDrawer.tsx
+++ b/packages/mobile/src/components/challenge-rewards-drawer/ClaimAllRewardsDrawer.tsx
@@ -27,8 +27,8 @@ const { getClaimStatus } = audioRewardsPageSelectors
 const messages = {
   // Claim success toast
   claimSuccessMessage: 'All rewards successfully claimed!',
-  pending: (amount) => `${amount} Pending`,
-  claimAudio: (amount) => `Claim ${amount} $AUDIO`,
+  pending: (amount: number) => `${amount} Pending`,
+  claimAudio: (amount: number) => `Claim ${amount} $AUDIO`,
   done: 'Done'
 }
 
@@ -60,17 +60,18 @@ export const ClaimAllRewardsDrawer = () => {
   const { toast } = useToast()
   const claimStatus = useSelector(getClaimStatus)
   const { onClose } = useDrawerState(MODAL_NAME)
-  const { claimableChallenges, cooldownChallenges, summary } =
+  const { claimableAmount, claimableChallenges, cooldownChallenges, summary } =
     useChallengeCooldownSchedule({
       multiple: true
     })
   const claimInProgress = claimStatus === ClaimStatus.CUMULATIVE_CLAIMING
+  const hasClaimed = claimStatus === ClaimStatus.CUMULATIVE_SUCCESS
 
   useEffect(() => {
-    if (claimStatus === ClaimStatus.CUMULATIVE_SUCCESS) {
+    if (hasClaimed) {
       toast({ content: messages.claimSuccessMessage, type: 'info' })
     }
-  }, [claimStatus, toast])
+  }, [hasClaimed, toast])
 
   const handleClose = useCallback(() => {
     dispatch(resetAndCancelClaimReward())
@@ -114,7 +115,7 @@ export const ClaimAllRewardsDrawer = () => {
         </Flex>
       </ScrollView>
       <View style={styles.stickyClaimRewardsContainer}>
-        {summary && summary?.value > 0 ? (
+        {claimableAmount > 0 && !hasClaimed ? (
           <Button
             isLoading={claimInProgress}
             variant='primary'
@@ -122,7 +123,7 @@ export const ClaimAllRewardsDrawer = () => {
             iconRight={IconArrowRight}
             fullWidth
           >
-            {messages.claimAudio(summary?.value)}
+            {messages.claimAudio(claimableAmount)}
           </Button>
         ) : (
           <Button variant='primary' onPress={handleClose} fullWidth>

--- a/packages/mobile/src/components/challenge-rewards-drawer/ClaimAllRewardsDrawer.tsx
+++ b/packages/mobile/src/components/challenge-rewards-drawer/ClaimAllRewardsDrawer.tsx
@@ -117,6 +117,7 @@ export const ClaimAllRewardsDrawer = () => {
       <View style={styles.stickyClaimRewardsContainer}>
         {claimableAmount > 0 && !hasClaimed ? (
           <Button
+            disabled={claimInProgress}
             isLoading={claimInProgress}
             variant='primary'
             onPress={onClaim}

--- a/packages/web/src/pages/audio-rewards-page/components/modals/ChallengeRewardsModal/ClaimAllRewardsModal.tsx
+++ b/packages/web/src/pages/audio-rewards-page/components/modals/ChallengeRewardsModal/ClaimAllRewardsModal.tsx
@@ -50,7 +50,6 @@ export const ClaimAllRewardsModal = () => {
   const { toast } = useContext(ToastContext)
   const wm = useWithMobileStyle(styles.mobile)
   const [isOpen, setOpen] = useModalState('ClaimAllRewards')
-  const [isHCaptchaModalOpen] = useModalState('HCaptcha')
   const claimStatus = useSelector(getClaimStatus)
   const { claimableAmount, claimableChallenges, cooldownChallenges, summary } =
     useChallengeCooldownSchedule({
@@ -103,8 +102,6 @@ export const ClaimAllRewardsModal = () => {
       useGradientTitle={false}
       titleClassName={wm(styles.title)}
       headerContainerClassName={styles.header}
-      showDismissButton={!isHCaptchaModalOpen}
-      dismissOnClickOutside={!isHCaptchaModalOpen}
     >
       <ModalContent>
         <Flex direction='column' gap='2xl' mt='s'>

--- a/packages/web/src/pages/audio-rewards-page/components/modals/ChallengeRewardsModal/ClaimAllRewardsModal.tsx
+++ b/packages/web/src/pages/audio-rewards-page/components/modals/ChallengeRewardsModal/ClaimAllRewardsModal.tsx
@@ -81,7 +81,7 @@ export const ClaimAllRewardsModal = () => {
   const handleClose = useCallback(() => {
     dispatch(resetAndCancelClaimReward())
     setOpen(false)
-  }, [dispatch])
+  }, [dispatch, setOpen])
 
   const formatLabel = useCallback((item: any) => {
     const { label, claimableDate, isClose } = item

--- a/packages/web/src/pages/audio-rewards-page/components/modals/ChallengeRewardsModal/ClaimAllRewardsModal.tsx
+++ b/packages/web/src/pages/audio-rewards-page/components/modals/ChallengeRewardsModal/ClaimAllRewardsModal.tsx
@@ -57,13 +57,14 @@ export const ClaimAllRewardsModal = () => {
       multiple: true
     })
   const claimInProgress = claimStatus === ClaimStatus.CUMULATIVE_CLAIMING
+  const hasClaimed = claimStatus === ClaimStatus.CUMULATIVE_SUCCESS
 
   useEffect(() => {
-    if (claimStatus === ClaimStatus.CUMULATIVE_SUCCESS) {
+    if (hasClaimed) {
       toast(messages.rewardsClaimed, CLAIM_REWARD_TOAST_TIMEOUT_MILLIS)
       dispatch(showConfetti())
     }
-  }, [claimStatus, toast, dispatch])
+  }, [toast, dispatch, hasClaimed])
 
   const onClaimRewardClicked = useCallback(() => {
     const claims = claimableChallenges.map((challenge) => ({
@@ -120,7 +121,7 @@ export const ClaimAllRewardsModal = () => {
             summaryLabelColor='accent'
             summaryValueColor='default'
           />
-          {claimableAmount > 0 ? (
+          {claimableAmount > 0 && !hasClaimed ? (
             <Button
               isLoading={claimInProgress}
               onClick={onClaimRewardClicked}

--- a/packages/web/src/pages/audio-rewards-page/components/modals/ChallengeRewardsModal/ClaimAllRewardsModal.tsx
+++ b/packages/web/src/pages/audio-rewards-page/components/modals/ChallengeRewardsModal/ClaimAllRewardsModal.tsx
@@ -78,6 +78,11 @@ export const ClaimAllRewardsModal = () => {
     dispatch(claimAllChallengeRewards({ claims }))
   }, [dispatch, claimableChallenges])
 
+  const handleClose = useCallback(() => {
+    dispatch(resetAndCancelClaimReward())
+    setOpen(false)
+  }, [dispatch])
+
   const formatLabel = useCallback((item: any) => {
     const { label, claimableDate, isClose } = item
     const formattedLabel = isClose ? (
@@ -99,7 +104,7 @@ export const ClaimAllRewardsModal = () => {
       title={messages.rewards}
       showTitleHeader
       isOpen={isOpen}
-      onClose={() => setOpen(false)}
+      onClose={handleClose}
       isFullscreen={true}
       useGradientTitle={false}
       titleClassName={wm(styles.title)}

--- a/packages/web/src/pages/audio-rewards-page/components/modals/ChallengeRewardsModal/ClaimAllRewardsModal.tsx
+++ b/packages/web/src/pages/audio-rewards-page/components/modals/ChallengeRewardsModal/ClaimAllRewardsModal.tsx
@@ -63,7 +63,6 @@ export const ClaimAllRewardsModal = () => {
     if (hasClaimed) {
       toast(messages.rewardsClaimed, CLAIM_REWARD_TOAST_TIMEOUT_MILLIS)
       dispatch(showConfetti())
-      dispatch(resetAndCancelClaimReward())
     }
   }, [toast, dispatch, hasClaimed])
 

--- a/packages/web/src/pages/audio-rewards-page/components/modals/ChallengeRewardsModal/ClaimAllRewardsModal.tsx
+++ b/packages/web/src/pages/audio-rewards-page/components/modals/ChallengeRewardsModal/ClaimAllRewardsModal.tsx
@@ -122,6 +122,7 @@ export const ClaimAllRewardsModal = () => {
           />
           {claimableAmount > 0 && !hasClaimed ? (
             <Button
+              disabled={claimInProgress}
               isLoading={claimInProgress}
               onClick={onClaimRewardClicked}
               iconRight={IconArrowRight}

--- a/packages/web/src/pages/audio-rewards-page/components/modals/ChallengeRewardsModal/ClaimAllRewardsModal.tsx
+++ b/packages/web/src/pages/audio-rewards-page/components/modals/ChallengeRewardsModal/ClaimAllRewardsModal.tsx
@@ -42,7 +42,8 @@ const messages = {
 }
 
 const { show: showConfetti } = musicConfettiActions
-const { claimAllChallengeRewards } = audioRewardsPageActions
+const { claimAllChallengeRewards, resetAndCancelClaimReward } =
+  audioRewardsPageActions
 const { getClaimStatus } = audioRewardsPageSelectors
 
 export const ClaimAllRewardsModal = () => {
@@ -62,6 +63,7 @@ export const ClaimAllRewardsModal = () => {
     if (hasClaimed) {
       toast(messages.rewardsClaimed, CLAIM_REWARD_TOAST_TIMEOUT_MILLIS)
       dispatch(showConfetti())
+      dispatch(resetAndCancelClaimReward())
     }
   }, [toast, dispatch, hasClaimed])
 


### PR DESCRIPTION
### Description

Noticed that the Claim All button did not immediately update to Done after successfully claiming all rewards. It updated later after the state was refreshed. This makes is so it updated automatically.
Web and mobile.

Also, reset success status on closing modal so that re-opening does not re-trigger confetti.

Also, make sure there is no state where claim all button is loading yet not disabled.

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._
