### PR TITLE
DDEX users poller

### DIFF
--- a/packages/ddex/processor/cli.ts
+++ b/packages/ddex/processor/cli.ts
@@ -7,12 +7,12 @@ import { pollS3 } from './src/s3poller'
 import {
   deleteRelease,
   publishValidPendingReleases,
-  sdkService,
 } from './src/publishRelease'
 import { sync } from './src/s3sync'
 import { startServer } from './src/server'
 import { sleep } from './src/util'
 import { releaseRepo } from './src/db'
+import { createSdkService } from './src/sdk'
 
 program
   .name('ddexer')
@@ -45,7 +45,7 @@ program
   .action(async (id) => {
     // find release and delete it
     const release = releaseRepo.get(id)
-    const sdk = (await sdkService).getSdk()
+    const sdk = (await createSdkService()).getSdk()
     await deleteRelease(sdk, release!)
   })
 

--- a/packages/ddex/processor/src/db.ts
+++ b/packages/ddex/processor/src/db.ts
@@ -130,6 +130,14 @@ export const userRepo = {
     dbUpsert('users', user)
   },
 
+  updateField(id: string, field: keyof UserRow, value: string | Date) {
+    return db.run(sql`
+      update users
+      set ${field} = ${value}
+      where id = ${id}
+    `)
+  },
+
   match(artistNames: string[]) {
     const artistSet = new Set(artistNames.map(lowerAscii))
     const users = db.all<UserRow>(sql`select * from users`)

--- a/packages/ddex/processor/src/db.ts
+++ b/packages/ddex/processor/src/db.ts
@@ -130,14 +130,6 @@ export const userRepo = {
     dbUpsert('users', user)
   },
 
-  updateField(id: string, field: keyof UserRow, value: string | Date) {
-    return db.run(sql`
-      update users
-      set ${field} = ${value}
-      where id = ${id}
-    `)
-  },
-
   match(artistNames: string[]) {
     const artistSet = new Set(artistNames.map(lowerAscii))
     const users = db.all<UserRow>(sql`select * from users`)

--- a/packages/ddex/processor/src/publishRelease.ts
+++ b/packages/ddex/processor/src/publishRelease.ts
@@ -14,15 +14,13 @@ import { DDEXContributor, DDEXRelease, DDEXResource } from './parseDelivery'
 import { readAssetWithCaching } from './s3poller'
 import { createSdkService } from './sdk'
 
-export const sdkService = createSdkService()
-
 export async function publishValidPendingReleases(opts?: {
   republish: boolean
 }) {
   const rows = releaseRepo.all({ pendingPublish: true })
   if (!rows.length) return
 
-  const sdk = (await sdkService).getSdk()
+  const sdk = (await createSdkService()).getSdk()
 
   for (const row of rows) {
     const parsed = row._parsed!

--- a/packages/ddex/processor/src/server.ts
+++ b/packages/ddex/processor/src/server.ts
@@ -44,7 +44,7 @@ app.get('/', async (c) => {
           : ''}
         ${me
           ? html`
-              <h4>Welcome back ${me.name}</h4>
+              <h4>Welcome back @${me.handle}</h4>
               <a href="/auth/logout" role="button">log out</a>
             `
           : html` <a role="button" href="/auth">login</a> `}

--- a/packages/ddex/processor/src/server.ts
+++ b/packages/ddex/processor/src/server.ts
@@ -21,7 +21,7 @@ import { parseBool } from './util'
 import { startUsersPoller } from './usersPoller'
 
 const { NODE_ENV, DDEX_KEY, DDEX_URL, COOKIE_SECRET } = process.env
-export const COOKIE_NAME = 'audiusUser'
+const COOKIE_NAME = 'audiusUser'
 
 const IS_PROD = NODE_ENV == 'production'
 const API_HOST = IS_PROD
@@ -476,7 +476,7 @@ app.get('/users', (c) => {
   )
 })
 
-export type JwtUser = {
+type JwtUser = {
   userId: string
   email: string
   name: string
@@ -489,7 +489,7 @@ export type JwtUser = {
   }
 }
 
-export async function getAudiusUser(c: Context) {
+async function getAudiusUser(c: Context) {
   const j = await getSignedCookie(c, COOKIE_SECRET!, COOKIE_NAME)
   if (!j) return
   return JSON.parse(j) as JwtUser

--- a/packages/ddex/processor/src/server.ts
+++ b/packages/ddex/processor/src/server.ts
@@ -18,9 +18,10 @@ import {
 import { prepareAlbumMetadata, prepareTrackMetadatas } from './publishRelease'
 import { readAssetWithCaching } from './s3poller'
 import { parseBool } from './util'
+import { startUsersPoller } from './usersPoller'
 
 const { NODE_ENV, DDEX_KEY, DDEX_URL, COOKIE_SECRET } = process.env
-const COOKIE_NAME = 'audiusUser'
+export const COOKIE_NAME = 'audiusUser'
 
 const IS_PROD = NODE_ENV == 'production'
 const API_HOST = IS_PROD
@@ -475,7 +476,7 @@ app.get('/users', (c) => {
   )
 })
 
-type JwtUser = {
+export type JwtUser = {
   userId: string
   email: string
   name: string
@@ -488,7 +489,7 @@ type JwtUser = {
   }
 }
 
-async function getAudiusUser(c: Context) {
+export async function getAudiusUser(c: Context) {
   const j = await getSignedCookie(c, COOKIE_SECRET!, COOKIE_NAME)
   if (!j) return
   return JSON.parse(j) as JwtUser
@@ -547,4 +548,6 @@ export function startServer() {
     fetch: app.fetch,
     port,
   })
+
+  startUsersPoller().catch(console.error)
 }

--- a/packages/ddex/processor/src/usersPoller.ts
+++ b/packages/ddex/processor/src/usersPoller.ts
@@ -4,7 +4,7 @@ import { createSdkService } from './sdk'
 export async function startUsersPoller() {
   const sdk = (await createSdkService()).getSdk()
 
-  // Periodic task to fetch user data and update handles
+  // Periodic task to fetch user data and update names
   setInterval(async () => {
     try {
       const users = userRepo.all()
@@ -14,13 +14,16 @@ export async function startUsersPoller() {
         if (!userResponse) {
           throw new Error(`Error fetching user ${user.id} from sdk`)
         }
-        if (userResponse.handle !== user.handle) {
-          userRepo.updateField(user.id, 'handle', userResponse.handle)
-          console.log(`Updated user ${user.id}'s handle'`)
+        if (userResponse.name !== user.name) {
+          userRepo.upsert({
+            id: user.id,
+            name: userResponse.name,
+          })
+          console.log(`Updated user ${user.id}'s name`)
         }
       }
     } catch (error) {
-      console.error('Failed to update user handles:', error)
+      console.error('Failed to update user names:', error)
     }
   }, 300000) // Runs every 5 min
 }

--- a/packages/ddex/processor/src/usersPoller.ts
+++ b/packages/ddex/processor/src/usersPoller.ts
@@ -1,0 +1,26 @@
+import { userRepo } from './db'
+import { sdkService } from './publishRelease' // todo move this
+
+export async function startUsersPoller() {
+  const sdk = (await sdkService).getSdk()
+
+  // Periodic task to fetch user data and update handles
+  setInterval(async () => {
+    try {
+      const users = userRepo.all()
+
+      for (const user of users) {
+        const { data: userResponse } = await sdk.users.getUser({ id: user.id })
+        if (!userResponse) {
+          throw new Error(`Error fetching user ${user.id} from sdk`)
+        }
+        if (userResponse.handle !== user.handle) {
+          userRepo.updateField(user.id, 'handle', userResponse.handle)
+          console.log(`Updated user ${user.id}'s handle'`)
+        }
+      }
+    } catch (error) {
+      console.error('Failed to update user handles:', error)
+    }
+  }, 300000) // Runs every 5 min
+}

--- a/packages/ddex/processor/src/usersPoller.ts
+++ b/packages/ddex/processor/src/usersPoller.ts
@@ -1,8 +1,8 @@
 import { userRepo } from './db'
-import { sdkService } from './publishRelease' // todo move this
+import { createSdkService } from './sdk'
 
 export async function startUsersPoller() {
-  const sdk = (await sdkService).getSdk()
+  const sdk = (await createSdkService()).getSdk()
 
   // Periodic task to fetch user data and update handles
   setInterval(async () => {

--- a/packages/ddex/processor/src/usersPoller.ts
+++ b/packages/ddex/processor/src/usersPoller.ts
@@ -16,8 +16,8 @@ export async function startUsersPoller() {
         }
         if (userResponse.name !== user.name) {
           userRepo.upsert({
-            id: user.id,
-            name: userResponse.name,
+            ...user,
+            name: userResponse.name
           })
           console.log(`Updated user ${user.id}'s name`)
         }


### PR DESCRIPTION
### Description
Poll sdk every 5 mins to keep user names in the DDEX db from becoming stale. Thoughts on this frequency?

Note: this doesn't update the JWT user's name in the cookie, which I figured is not worth updating. Unless you think otherwise @stereosteve. /whoami will potentially show a stale name until they logout and login again.

Note 2: this will also console log an error if the sdk can't find a user id in discovery, which will create some noise when using fake user data for local testing.

### How Has This Been Tested?
Ran server locally, ensured server polls, changed my user's name, ensured ddex persisted new name