### PR TITLE
Index all memos (v1 and v2) and use cache in index_payment_router

### DIFF
--- a/packages/discovery-provider/src/solana/solana_helpers.py
+++ b/packages/discovery-provider/src/solana/solana_helpers.py
@@ -39,5 +39,8 @@ METADATA_PROGRAM_ID_PK = Pubkey.from_string(METADATA_PROGRAM_ID)
 # Static Memo Program ID
 MEMO_PROGRAM_ID = "Memo1UhkJRfHyvLMcVucJwxXeuD728EqVDDwQDxFMNo"
 
+# Static Memo Program ID
+MEMO_V2_PROGRAM_ID = "MemoSq4gqABAXKb96qnH8TysNcWxMyWCqXgDLGmfcHr"
+
 # Static Jupiter Swap Program ID
 JUPITER_PROGRAM_ID = "JUP6LkbZbjS1jKKwapdHNy74zcZ3tLUZoi5QNyVTaV4"


### PR DESCRIPTION
### Description

Previously we ignored the Memo V2 Program. This allows us to parse those memos as well. Also adds support for loading from the cache for indexing payment router.

### How Has This Been Tested?

Tested locally, purchased a track.
