### PR TITLE
[QA-1251] Fix short lineup playback issues.

### DIFF
--- a/packages/mobile/src/components/audio/AudioPlayer.tsx
+++ b/packages/mobile/src/components/audio/AudioPlayer.tsx
@@ -332,7 +332,7 @@ export const AudioPlayer = () => {
       if (playerIndex === undefined) return
 
       // Update queue and player state if the track player auto plays next track
-      if (playerIndex !== queueIndex) {
+      if (playerIndex > queueIndex) {
         if (queueShuffle) {
           // TODO: There will be a very short period where the next track in the queue is played instead of the next shuffle track.
           // Figure out how to call next earlier

--- a/packages/web/src/common/store/pages/ai/lineups/tracks/sagas.ts
+++ b/packages/web/src/common/store/pages/ai/lineups/tracks/sagas.ts
@@ -12,7 +12,7 @@ import { call, put, select } from 'typed-redux-saga'
 import { processAndCacheTracks } from 'common/store/cache/tracks/utils'
 import { LineupSagas } from 'common/store/lineup/sagas'
 import { waitForRead } from 'utils/sagaHelpers'
-const { getAiUserHandle, getLineup } = aiPageSelectors
+const { getAiUserId, getLineup } = aiPageSelectors
 const { setCount } = aiPageActions
 const getUserId = accountSelectors.getUserId
 
@@ -49,7 +49,7 @@ function* getTracks({
 }
 
 const sourceSelector = (state: CommonState) =>
-  `${tracksActions.prefix}:${getAiUserHandle(state)}`
+  `${tracksActions.prefix}:${getAiUserId(state)}`
 
 class TracksSagas extends LineupSagas<Track> {
   constructor() {


### PR DESCRIPTION
### Description

Fixes issue where short lineups load too quickly leading to situation where player index is lower than queue index, leading to a weird skip back to the first track. The change here is to ensure playerIndex is always greater than queueIndex before we skip. This makes sense because playerIndex should naturally always be equal to or one index ahead of queueIndex.
