### PR TITLE
[C-4344][C-4352] Fix empty rewards mobile crashing

### DIFF
--- a/packages/mobile/src/screens/audio-screen/ChallengeRewards.tsx
+++ b/packages/mobile/src/screens/audio-screen/ChallengeRewards.tsx
@@ -144,7 +144,7 @@ export const ChallengeRewards = () => {
   const { isEnabled: isAudioMatchingChallengesEnabled } = useFeatureFlag(
     FeatureFlags.AUDIO_MATCHING_CHALLENGES
   )
-  const { cooldownChallenges, cooldownAmount, claimableAmount } =
+  const { cooldownChallenges, cooldownAmount, claimableAmount, isEmpty } =
     useChallengeCooldownSchedule({ multiple: true })
   const { isEnabled: isRewardsCooldownEnabled } = useFeatureFlag(
     FeatureFlags.REWARDS_COOLDOWN
@@ -220,7 +220,7 @@ export const ChallengeRewards = () => {
         <LoadingSpinner style={styles.loading} />
       ) : (
         <Flex gap='2xl'>
-          {isRewardsCooldownEnabled ? (
+          {isRewardsCooldownEnabled && !isEmpty ? (
             <Paper shadow='flat' border='strong' p='l' gap='m'>
               <Flex direction='row' justifyContent='flex-start' gap='s'>
                 {claimableAmount > 0 ? (
@@ -230,11 +230,13 @@ export const ChallengeRewards = () => {
                   {messages.totalReadyToClaim}
                 </Text>
               </Flex>
-              <View style={styles.pillContainer}>
-                <Text style={[styles.pillMessage, styles.readyToClaimPill]}>
-                  {cooldownAmount} {messages.pending}
-                </Text>
-              </View>
+              {cooldownAmount > 0 ? (
+                <View style={styles.pillContainer}>
+                  <Text style={[styles.pillMessage, styles.readyToClaimPill]}>
+                    {cooldownAmount} {messages.pending}
+                  </Text>
+                </View>
+              ) : null}
               <Text size='s' variant='body'>
                 {claimableAmount > 0
                   ? `${claimableAmount} ${messages.available} ${messages.now}`

--- a/packages/web/src/pages/audio-rewards-page/ChallengeRewardsTile.tsx
+++ b/packages/web/src/pages/audio-rewards-page/ChallengeRewardsTile.tsx
@@ -347,11 +347,13 @@ const ClaimAllPanel = () => {
       m='s'
     >
       <Flex gap='l' alignItems='center'>
-        <IconTokenGold
-          height={48}
-          width={48}
-          aria-label={messages.goldAudioToken}
-        />
+        {claimableAmount > 0 ? (
+          <IconTokenGold
+            height={48}
+            width={48}
+            aria-label={messages.goldAudioToken}
+          />
+        ) : null}
         <Flex direction='column'>
           <Flex>
             {isEmpty ? null : (


### PR DESCRIPTION
### Description
Mobile crashes on rewards page for new users. This is because it's trying to format empty challenges. This just adds a check to handle empty cases.
<img width="400" alt="Screenshot 2024-05-08 at 11 36 57 AM" src="https://github.com/AudiusProject/audius-protocol/assets/6413636/3bc62aba-84bc-43c9-9360-c3ec8b70547a">

Also, adding logic to remove token when a user only has pending challenges in cooldown. That should only show when rewards are claimable.


### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._

Tested on local clients against staging. 
