### PR TITLE
[DOCS] - Reference Docs for Ethereum and Solana Contracts

### DIFF
--- a/docs/.vscode/spellright.dict
+++ b/docs/.vscode/spellright.dict
@@ -32,6 +32,7 @@ mainnet
 markdownlint
 metadatas
 metamask
+mintable
 multisig
 nethermind
 nft
@@ -44,6 +45,7 @@ oauthed
 off-chain
 on-chain
 onclick
+pausable
 pauser
 permissionless
 polyfill
@@ -53,9 +55,11 @@ py
 redis
 screensnippet
 sdk
+sepolia
 sequelize
 skrillex
 sla
+solana
 sp
 spl
 staker
@@ -71,3 +75,4 @@ upc
 userbase
 wei
 whitepaper
+wormholeclient

--- a/docs/docs/learn/introduction/getting-started.mdx
+++ b/docs/docs/learn/introduction/getting-started.mdx
@@ -48,12 +48,14 @@ and account and exploring new music.
 
 <!-- TODO: - [Audius 101]() - a walkthrough of the Audius protocol. -->
 
-- [Core Concepts](/learn/concepts/protocol) - learn about the building blocks of Audius, starting
+- [Core Concepts](/learn/concepts/protocol) - Learn about the building blocks of Audius, starting
   with nodes.
-- [Architecture](/learn/architecture/content-node) - breakdown of Audius' on-chain and off-chain
+- [Architecture](/learn/architecture/content-node) - Breakdown of Audius' on-chain and off-chain
   systems.
 - [Deploy a Node](/node-operator/setup/overview) - Deploy Content and Discovery nodes to power the
   Audius protocol.
+- [Contracts & Programs](/reference/eth-contracts) - Ethereum Contracts and Solana Programs that
+  power the Audius protocol.
 
 ---
 

--- a/docs/docs/reference/eth-contracts.mdx
+++ b/docs/docs/reference/eth-contracts.mdx
@@ -1,0 +1,256 @@
+---
+id: eth-contracts
+title: Ethereum Contracts
+pagination_label: Ethereum Contracts
+sidebar_label: Ethereum Contracts
+description: Audius Protocol Documentation
+---
+
+import useBaseUrl from '@docusaurus/useBaseUrl'
+
+## Overview
+
+The Audius Ethereum contracts are meant to accomplish the following goals for the Audius protocol:
+
+- Create the Audius token through an ERC-20
+- Keep track of different service versions
+- Allow service providers to stake and register services to run
+- Allow delegation from users holding Audius token to service providers running services on the
+  network
+- Allow network to mint new tokens for stakers and delegators to earn staking rewards
+- Enable protocol governance to carry out protocol actions such as slash, and static value updates
+
+:::info
+
+All contracts are built on top of
+[OpenZeppelin's Proxy pattern](https://docs.openzeppelin.com/upgrades-plugins/1.x/proxies) through
+`AudiusAdminUpgradeabilityProxy` which extends `AdminUpgradeabilityProxy`, enabling logic upgrades
+to be performed through the [Governance contract](#governance).
+
+:::
+
+---
+
+## Contracts
+
+> [Github Code available here](https://github.com/AudiusProject/audius-protocol/tree/main/eth-contracts/contracts)
+
+### AudiusToken
+
+> This contract defines the Audius Protocol token, `$AUDIO`
+
+The `$AUDIO` token is a ERC-20 token contract with initial supply of 1 billion tokens, each
+divisible up to 18 decimal places, and is `Mintable`, `Pausable`, and `Burnable`.
+
+| Mainnet Contract                                            | Sepolia Testnet Contract                                         |
+| ----------------------------------------------------------- | ---------------------------------------------------------------- |
+| [`0x18aAA7115705e8be94bfFEBDE57Af9BFc265B998`][AudiusToken] | [`0x1376180Ee935AA64A27780F4BE97726Df7B0e2B2`][AudiusToken_test] |
+
+[AudiusToken]: https://etherscan.io/address/0x18aAA7115705e8be94bfFEBDE57Af9BFc265B998#code
+[AudiusToken_test]: https://sepolia.etherscan.io/address/0x1376180Ee935AA64A27780F4BE97726Df7B0e2B2
+
+### ClaimsManager
+
+> This contract is responsible for allocating and minting new tokens as well as managing claim
+> rounds.
+
+A claim round is a period of time during which service providers with valid stakes can retrieve the
+reward apportioned to them in the network. Claims are processed here and new value transferred to
+[Staking](#staking) for the claimer, but the values in both
+[ServiceProviderFactory](#serviceproviderfactory) and [DelegateManager](#delegatemanager) are
+updated through calls to [DelegateManager](#delegatemanager).
+
+| Mainnet Contract                                              | Sepolia Testnet Contract                                           |
+| ------------------------------------------------------------- | ------------------------------------------------------------------ |
+| [`0x44617F9dCEd9787C3B06a05B35B4C779a2AA1334`][ClaimsManager] | [`0xcdFFAE230aeDC376478b16f369489A3b450fc2c8`][ClaimsManager_test] |
+
+[ClaimsManager]: https://etherscan.io/address/0x44617F9dCEd9787C3B06a05B35B4C779a2AA1334#code
+[ClaimsManager_test]:
+  https://sepolia.etherscan.io/address/0xcdFFAE230aeDC376478b16f369489A3b450fc2c8
+
+### DelegateManager
+
+> This contract is responsible for tracking delegation state, making claims, and handling slash
+> operations.
+
+This contract allows any Audio Token holder to delegate to an existing Node Operator, earning
+rewards by providing additional stake the Node Operator while allocating a known percentage of their
+rewards to the Node Operator.
+
+This contract manages the proportional distribution of stake between the Node Operator and
+delegators.
+
+All claim and slash operations flow through this contract in order to update values tracked outside
+of the [Staking contract](#staking) appropriately and maintain consistency between total value
+within the [Staking contract](#staking) and value tracked by the
+[DelegateManager contract](#delegatemanager) and the
+[ServiceProviderFactory contract](#serviceproviderfactory).
+
+| Mainnet Contract                                                | Sepolia Testnet Contract                                             |
+| --------------------------------------------------------------- | -------------------------------------------------------------------- |
+| [`0x4d7968ebfD390D5E7926Cb3587C39eFf2F9FB225`][DelegateManager] | [`0xDA74d6FfbF268Ac441404f5a61f01103451E8697`][DelegateManager_test] |
+
+[DelegateManager]: https://etherscan.io/address/0x4d7968ebfD390D5E7926Cb3587C39eFf2F9FB225#code
+[DelegateManager_test]:
+  https://sepolia.etherscan.io/address/0xDA74d6FfbF268Ac441404f5a61f01103451E8697
+
+### EthRewardsManager
+
+| Mainnet Contract                                                  | Sepolia Testnet Contract                                               |
+| ----------------------------------------------------------------- | ---------------------------------------------------------------------- |
+| [`0x5aa6B99A2B461bA8E97207740f0A689C5C39C3b0`][EthRewardsManager] | [`0x563483ccD66a49Ca730275F8cf37Dd3E6Da864f1`][EthRewardsManager_test] |
+
+[EthRewardsManager]: https://etherscan.io/address/0x5aa6B99A2B461bA8E97207740f0A689C5C39C3b0#code
+[EthRewardsManager_test]:
+  https://sepolia.etherscan.io/address/0x563483ccD66a49Ca730275F8cf37Dd3E6Da864f1
+
+### Governance
+
+> This contract allows protocol participants to change protocol direction by submitting and voting
+> on proposals.
+
+Each proposal represents an executable function call on a contract in the [Registry](#registry).
+Once submitted, there is a period of time during which other participants can submit their votes -
+`Yes` or `No` - on the proposal.
+
+After the voting period has concluded, the proposal outcome is calculated as a the sum of the stakes
+of the `Yes` voters minus the sum of the stakes of the `No` voters.
+
+Any non-negative value results in a successful proposal, at which point the specified function call
+is executed, and the proposal is closed.
+
+Only addresses that have staked in [Staking.sol](#staking) and are represented through the
+[Registry](#registry) can submit and vote on proposals.
+
+| Mainnet Contract                                           | Sepolia Testnet Contract                                        |
+| ---------------------------------------------------------- | --------------------------------------------------------------- |
+| [`0x4DEcA517D6817B6510798b7328F2314d3003AbAC`][Governance] | [`0x04973b4416f7e3D62374Ef8b5ABD4a98e4dD401C`][Governance_test] |
+
+[Governance]: https://etherscan.io/address/0x4DEcA517D6817B6510798b7328F2314d3003AbAC#code
+[Governance_test]: https://sepolia.etherscan.io/address/0x04973b4416f7e3D62374Ef8b5ABD4a98e4dD401C
+
+### Registry
+
+Contract through which external clients and Governance interact with the remaining contracts within
+the protocol. Each contract is registered using a key with which its address can be queried.
+
+| Mainnet Contract                                         | Sepolia Testnet Contract                                      |
+| -------------------------------------------------------- | ------------------------------------------------------------- |
+| [`0xd976d3b4f4e22a238c1A736b6612D22f17b6f64C`][Registry] | [`0xc682C2166E11690B64338e11633Cb8Bb60B0D9c0`][Registry_test] |
+
+[Registry]: https://etherscan.io/address/0xd976d3b4f4e22a238c1A736b6612D22f17b6f64C#code
+[Registry_test]: https://sepolia.etherscan.io/address/0xc682C2166E11690B64338e11633Cb8Bb60B0D9c0
+
+### ServiceProviderFactory
+
+> This contract is responsible for tracking Service Provider state within the Audius network.
+
+A service provider is the account associated with a given service endpoint.
+
+Each service provider can increase/decrease stake within dynamic bounds determined by the
+combination of endpoints they have registered, accept delegation from other token holders, define a
+reward cut for delegation, and continue registering endpoints as necessary.
+
+This contract forwards staking requests to the actual [Staking](#staking) contract but tracks the
+amount of stake for the deployer - [Staking](#staking) tracks the sum of delegate stake + deployer
+stake.
+
+| Contract                                                               | Sepolia Testnet Contract Mainnet                                            |
+| ---------------------------------------------------------------------- | --------------------------------------------------------------------------- |
+| [`0xD17A9bc90c582249e211a4f4b16721e7f65156c8`][ServiceProviderFactory] | [`0x377BE01aD31360d0DFB16035A4515954395A8185`][ServiceProviderFactory_test] |
+
+[ServiceProviderFactory]:
+  https://etherscan.io/address/0xD17A9bc90c582249e211a4f4b16721e7f65156c8#code
+[ServiceProviderFactory_test]:
+  https://sepolia.etherscan.io/address/0x377BE01aD31360d0DFB16035A4515954395A8185
+
+<details>
+<summary>A Note on Terminology</summary>
+
+Through out the Smart Contracts that define the Audius protocol, the term "service provider" is used
+along with the "service endpoint(s)" that they operate.
+
+More current terminology is "Node Operator" and "Audius Node" respectively.
+
+- **Old**: `Service Providers` operate `service endpoints`
+- **New**: `Node Operators` operate `Audius Nodes`
+
+</details>
+
+### ServiceTypeManager
+
+> This contract is responsible for maintaining known `service types`, associated versioning
+> information and service type stake requirements within the Audius Protocol.
+
+Service types are used to identify services being registered within the protocol, for example
+`creator-node` or `discovery-provider`.
+
+Service type stake requirements enforce a minimum and maximum stake amount for each endpoint of a
+given type that service providers register.
+
+| Mainnet Contract                                                   | Sepolia Testnet Contract                                                |
+| ------------------------------------------------------------------ | ----------------------------------------------------------------------- |
+| [`0x9EfB0f4F38aFbb4b0984D00C126E97E21b8417C5`][ServiceTypeManager] | [`0x9fd76d2cD48022526F3a164541E6552291F4a862`][ServiceTypeManager_test] |
+
+[ServiceTypeManager]: https://etherscan.io/address/0x9EfB0f4F38aFbb4b0984D00C126E97E21b8417C5#code
+[ServiceTypeManager_test]:
+  https://sepolia.etherscan.io/address/0x9fd76d2cD48022526F3a164541E6552291F4a862
+
+<details>
+<summary>A Note on Terminology</summary>
+
+Through out the Smart Contracts that define the Audius protocol, the terms `creator-node` and
+`discovery-provider` are used to define `service types`.
+
+More current terminology is `content-node` and `discovery-node` are `Audius Node` types
+respectively.
+
+- **Old**: `creator-node` and `discovery-provider` are `service types`
+- **New**: `content-node` and `discovery-node` are `Audius Node` types.
+
+</details>
+
+### Staking
+
+> This contract manages token staking functions and state across the Audius Protocol
+
+For every service provider address in Audius Protocol, this contract:
+
+- Stores tokens and manages account balances
+- Tracks total stake history
+- The total stake (represented as the sun of the deployer stake plus the delegate stake)
+- Tracks last claim block
+
+| Mainnet Contract                                        | Sepolia Testnet Contract                                     |
+| ------------------------------------------------------- | ------------------------------------------------------------ |
+| [`0xe6D97B2099F142513be7A2a068bE040656Ae4591`][Staking] | [`0x5bcF21A4D5Bab9B0869B9c55D233f80135C814C6`][Staking_test] |
+
+[Staking]: https://etherscan.io/address/0xe6D97B2099F142513be7A2a068bE040656Ae4591#code
+[Staking_test]: https://sepolia.etherscan.io/address/0x5bcF21A4D5Bab9B0869B9c55D233f80135C814C6
+
+### TrustedNotifierManager
+
+This contract serves as the on chain registry of trusted notifier services. Other services may look
+up and adjust their selected trusted notifier accordingly.
+
+| Contract                                                               | Sepolia Testnet Contract Mainnet                                            |
+| ---------------------------------------------------------------------- | --------------------------------------------------------------------------- |
+| [`0x6f08105c8CEef2BC5653640fcdbBE1e7bb519D39`][TrustedNotifierManager] | [`0x71f8D2aC2f63A481d597d2A6cc160787A048525C`][TrustedNotifierManager_test] |
+
+[TrustedNotifierManager]:
+  https://etherscan.io/address/0x6f08105c8CEef2BC5653640fcdbBE1e7bb519D39#code
+[TrustedNotifierManager_test]:
+  https://sepolia.etherscan.io/address/0x71f8D2aC2f63A481d597d2A6cc160787A048525C
+
+### WormholeClient
+
+This contract serves as the interface between the Audius Protocol and
+[Wormhole](https://solana.com/ecosystem/wormhole).
+
+| Mainnet Contract                                               | Sepolia Testnet Contract                                            |
+| -------------------------------------------------------------- | ------------------------------------------------------------------- |
+| [`0x6E7a1F7339bbB62b23D44797b63e4258d283E095`][wormholeclient] | [`0x2Eb3BF862e7a724A151e78CEB1173FB332E174a0`][wormholeclient_test] |
+
+[wormholeclient]: https://etherscan.io/address/0x6E7a1F7339bbB62b23D44797b63e4258d283E095#code
+[wormholeclient_test]:
+  https://sepolia.etherscan.io/address/0x2Eb3BF862e7a724A151e78CEB1173FB332E174a0

--- a/docs/docs/reference/solana-programs.mdx
+++ b/docs/docs/reference/solana-programs.mdx
@@ -1,0 +1,104 @@
+---
+id: solana-programs
+title: Solana Programs
+pagination_label: Solana Programs
+sidebar_label: Solana Programs
+description: Audius Protocol Documentation
+---
+
+import useBaseUrl from '@docusaurus/useBaseUrl'
+
+## Programs
+
+:::info Testnet on Mainnet?
+
+Please note that all Audius Protocol Testnet Programs are deployed to Solana Mainnet.
+
+:::
+
+> [Github Code available here](https://github.com/AudiusProject/audius-protocol/tree/main/solana-programs)
+
+### Audius Plays
+
+This program handles recording track play counts on chain. Every time a user listens to a track on
+Audius, it is recorded on the Solana blockchain.
+
+| Mainnet Program                                               | Testnet Program                                                    |
+| ------------------------------------------------------------- | ------------------------------------------------------------------ |
+| [`7K3UpbZViPnQDLn2DAM853B9J5GBxd1L1rLHy4KqSmWG`][AudiusPlays] | [`ApR7QbouRviwoE6nLL83omE6GdtM6yUJAsuXw5sPDCQV`][AudiusPlays_test] |
+
+[AudiusPlays]: https://solscan.io/account/7K3UpbZViPnQDLn2DAM853B9J5GBxd1L1rLHy4KqSmWG
+[AudiusPlays_test]: https://solscan.io/account/ApR7QbouRviwoE6nLL83omE6GdtM6yUJAsuXw5sPDCQV
+
+- [Code on GitHub](https://github.com/AudiusProject/audius-protocol/tree/main/solana-programs/track_listen_count)
+
+### Claimable Tokens
+
+This program powers the Audis reward system, and allows Solana non-custodial token accounts to be
+created for Audius users that are represented by an Ethereum wallet. This program is also referred
+to as the "User Bank".
+
+| Mainnet Program                                                   | Testnet Program                                                        |
+| ----------------------------------------------------------------- | ---------------------------------------------------------------------- |
+| [`Ewkv3JahEFRKkcJmpoKB7pXbnUHwjAyXiwEo4ZY2rezQ`][ClaimableTokens] | [`2sjQNmUfkV6yKKi4dPR8gWRgtyma5aiymE3aXL2RAZww`][ClaimableTokens_test] |
+
+[ClaimableTokens]: https://solscan.io/account/Ewkv3JahEFRKkcJmpoKB7pXbnUHwjAyXiwEo4ZY2rezQ
+[ClaimableTokens_test]: https://solscan.io/account/2sjQNmUfkV6yKKi4dPR8gWRgtyma5aiymE3aXL2RAZww
+
+- [Code on GitHub](https://github.com/AudiusProject/audius-protocol/tree/main/solana-programs/claimable-tokens)
+
+### Payment Router
+
+This program is responsible for distributing any SPL Token across different provided Solana
+associated token accounts, with amounts determined by a given percent split.
+
+It is intended to be used with `SPL-AUDIO` and `SPL-USDC`. While payments can be made independently
+of the `Payment Router` program, it is designed to improve space-efficiency and usability off-chain.
+
+| Mainnet Program                                                | Testnet Program                                                     |
+| -------------------------------------------------------------- | ------------------------------------------------------------------- |
+| [`paytYpX3LPN98TAeen6bFFeraGSuWnomZmCXjAsoqPa`][PaymentRouter] | [`sp38CXGL9FoWPp9Avo4fevewEX4UqNkTSTFUPpQFRry`][PaymentRouter_test] |
+
+[PaymentRouter]: https://solscan.io/account/paytYpX3LPN98TAeen6bFFeraGSuWnomZmCXjAsoqPa
+[PaymentRouter_test]: https://solscan.io/account/sp38CXGL9FoWPp9Avo4fevewEX4UqNkTSTFUPpQFRry
+
+- [Code on GitHub](https://github.com/AudiusProject/audius-protocol/tree/main/solana-programs/payment-router)
+
+### Reward Manager
+
+This program allows for Audius users to claim rewards given attestations from Node Operators that
+they have successfully completed a challenge.
+
+For example, to claim the “I’ve completed my profile reward,” a user may ask for a set of Discovery
+Node Operators to provide a cryptographic proof that they have completed the challenge and submit
+that to chain. If the signatures are valid, tokens are dispensed
+
+| Mainnet Program                                                 | Testnet Program                                                      |
+| --------------------------------------------------------------- | -------------------------------------------------------------------- |
+| [`DDZDcYdQFEMwcu2Mwo75yGFjJ1mUQyyXLWzhZLEVFcei`][RewardManager] | [`CDpzvz7DfgbF95jSSCHLX3ERkugyfgn9Fw8ypNZ1hfXp`][RewardManager_test] |
+
+[RewardManager]: https://solscan.io/account/DDZDcYdQFEMwcu2Mwo75yGFjJ1mUQyyXLWzhZLEVFcei
+[RewardManager_test]: https://solscan.io/account/CDpzvz7DfgbF95jSSCHLX3ERkugyfgn9Fw8ypNZ1hfXp
+
+- [Code on GitHub](https://github.com/AudiusProject/audius-protocol/tree/main/solana-programs/reward-manager)
+
+### Staking Bridge
+
+This program has 2 main functions:
+
+1. Swap `SPL-USDC` tokens to `SPL-AUDIO` tokens via the [Raydium AMM Program](https://raydium.io/).
+2. Convert `SPL-AUDIO` tokens to `ERC20-AUDIO` tokens via the Wormhole Token Bridge.
+
+The methods in this program are intentionally permissionless, allowing any user willing to pay
+transaction fees to interact.
+
+The methods of the Staking Bridge are independent to reduce price impact of swaps and fees
+associated with bridging tokens.
+
+| Mainnet Program                                                 | Testnet Program |
+| --------------------------------------------------------------- | --------------- |
+| [`Ewkv3JahEFRKkcJmpoKB7pXbnUHwjAyXiwEo4ZY2rezQ`][StakingBridge] |                 |
+
+[StakingBridge]: https://solscan.io/account/Ewkv3JahEFRKkcJmpoKB7pXbnUHwjAyXiwEo4ZY2rezQ
+
+- [Code on GitHub](https://github.com/AudiusProject/audius-protocol/tree/main/solana-programs/staking-bridge)

--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -154,5 +154,11 @@ module.exports = {
       items: ['reference/protocol-dashboard/link-profile'],
       collapsed: false,
     },
+    {
+      type: 'category',
+      label: 'Contracts and Programs',
+      items: ['reference/eth-contracts', 'reference/solana-programs'],
+      collapsed: false,
+    },
   ],
 }


### PR DESCRIPTION
### Description

adding reference Ethereum Contracts and Solana Programs

- [Ethereum Contracts](https://57f16b01.docs-eaf.pages.dev/reference/eth-contracts)
- [Solana Programs](https://57f16b01.docs-eaf.pages.dev/reference/solana-programs)

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._
