### PR TITLE
[PAY-2878] Fix tracks tables right icons

### DIFF
--- a/packages/web/src/components/collections-table/CollectionsTable.tsx
+++ b/packages/web/src/components/collections-table/CollectionsTable.tsx
@@ -5,7 +5,7 @@ import {
   UserCollectionMetadata
 } from '@audius/common/models'
 import { formatCount } from '@audius/common/utils'
-import { Flex, IconLock, IconVisibilityHidden } from '@audius/harmony'
+import { Flex, IconCart, IconVisibilityHidden } from '@audius/harmony'
 import cn from 'classnames'
 import moment from 'moment'
 import { Cell, Row } from 'react-table'
@@ -137,7 +137,7 @@ export const CollectionsTable = ({
   const overflowMenuRef = useRef<HTMLDivElement>(null)
   const renderOverflowMenuCell = useCallback((cellInfo: CollectionCell) => {
     const collection = cellInfo.row.original
-    const Icon = collection.is_private ? IconVisibilityHidden : IconLock
+    const Icon = collection.is_private ? IconVisibilityHidden : IconCart
     const shouldShowIcon = collection.is_stream_gated || collection.is_private
     return (
       <>

--- a/packages/web/src/components/collections-table/CollectionsTable.tsx
+++ b/packages/web/src/components/collections-table/CollectionsTable.tsx
@@ -137,11 +137,14 @@ export const CollectionsTable = ({
   const overflowMenuRef = useRef<HTMLDivElement>(null)
   const renderOverflowMenuCell = useCallback((cellInfo: CollectionCell) => {
     const collection = cellInfo.row.original
-    const Icon = collection.is_private ? IconVisibilityHidden : IconCart
-    const shouldShowIcon = collection.is_stream_gated || collection.is_private
+    const Icon = collection.is_private
+      ? IconVisibilityHidden
+      : collection.is_stream_gated
+      ? IconCart
+      : null
     return (
       <>
-        {shouldShowIcon ? (
+        {Icon ? (
           <Flex className={styles.typeIcon}>
             <Icon color='subdued' size='m' />
           </Flex>

--- a/packages/web/src/components/tracks-table/TracksTable.tsx
+++ b/packages/web/src/components/tracks-table/TracksTable.tsx
@@ -14,7 +14,8 @@ import {
   Button,
   Flex,
   IconSpecialAccess,
-  IconCollectible
+  IconCollectible,
+  IconCart
 } from '@audius/harmony'
 import cn from 'classnames'
 import moment from 'moment'
@@ -84,6 +85,7 @@ type TracksTableProps = {
   isAlbumPage?: boolean
   isAlbumPremium?: boolean
   isPremiumEnabled?: boolean
+  shouldShowGatedType?: boolean
   loading?: boolean
   onClickFavorite?: (track: any) => void
   onClickPurchase?: (track: any) => void
@@ -139,6 +141,7 @@ export const TracksTable = ({
   fetchThreshold,
   isVirtualized = false,
   isPremiumEnabled = false,
+  shouldShowGatedType = false,
   loading = false,
   onClickFavorite,
   onClickRemove,
@@ -400,17 +403,29 @@ export const TracksTable = ({
       const isLocked = !isFetchingNFTAccess && !hasStreamAccess
       const deleted =
         track.is_delete || track._marked_deleted || !!track.user?.is_deactivated
+      // For owners, we want to show the type of gating on the track. For fans,
+      // we want to show whether or not they have access.
       const shouldShowIcon = track.is_stream_gated || track.is_unlisted
-      const Icon = track.is_unlisted
-        ? IconVisibilityHidden
-        : isContentUSDCPurchaseGated(track.stream_conditions)
-        ? IconLock
-        : isContentCollectibleGated(track.stream_conditions)
-        ? IconCollectible
-        : IconSpecialAccess
+      let Icon
+      if (shouldShowGatedType) {
+        Icon = track.is_unlisted
+          ? IconVisibilityHidden
+          : isContentUSDCPurchaseGated(track.stream_conditions)
+          ? IconCart
+          : isContentCollectibleGated(track.stream_conditions)
+          ? IconCollectible
+          : IconSpecialAccess
+      } else {
+        Icon = !hasStreamAccess
+          ? IconLock
+          : track.is_unlisted
+          ? IconVisibilityHidden
+          : null
+      }
+
       return (
         <>
-          {shouldShowIcon ? (
+          {shouldShowIcon && Icon ? (
             <Flex className={styles.typeIcon}>
               <Icon color='subdued' size='m' />
             </Flex>

--- a/packages/web/src/components/tracks-table/TracksTable.tsx
+++ b/packages/web/src/components/tracks-table/TracksTable.tsx
@@ -5,6 +5,7 @@ import {
   UID,
   UserTrack,
   isContentCollectibleGated,
+  isContentFollowGated,
   isContentUSDCPurchaseGated
 } from '@audius/common/models'
 import { formatCount, formatSeconds } from '@audius/common/utils'
@@ -405,7 +406,6 @@ export const TracksTable = ({
         track.is_delete || track._marked_deleted || !!track.user?.is_deactivated
       // For owners, we want to show the type of gating on the track. For fans,
       // we want to show whether or not they have access.
-      const shouldShowIcon = track.is_stream_gated || track.is_unlisted
       let Icon
       if (shouldShowGatedType) {
         Icon = track.is_unlisted
@@ -414,7 +414,9 @@ export const TracksTable = ({
           ? IconCart
           : isContentCollectibleGated(track.stream_conditions)
           ? IconCollectible
-          : IconSpecialAccess
+          : isContentFollowGated(track.stream_conditions)
+          ? IconSpecialAccess
+          : null
       } else {
         Icon = !hasStreamAccess
           ? IconLock
@@ -425,7 +427,7 @@ export const TracksTable = ({
 
       return (
         <>
-          {shouldShowIcon && Icon ? (
+          {Icon ? (
             <Flex className={styles.typeIcon}>
               <Icon color='subdued' size='m' />
             </Flex>

--- a/packages/web/src/pages/dashboard-page/components/ArtistDashboardTracksTab.tsx
+++ b/packages/web/src/pages/dashboard-page/components/ArtistDashboardTracksTab.tsx
@@ -85,6 +85,7 @@ export const ArtistDashboardTracksTab = ({
         loading={tracksStatus === Status.LOADING}
         isPaginated
         tableHeaderClassName={styles.tableHeader}
+        shouldShowGatedType
       />
     </Flex>
   )


### PR DESCRIPTION
### Description
Per design - For owners, we want to show the type of gating on the track. For fans, we want to show whether or not they have access.

### How Has This Been Tested?
unlocked album: no icons
<img width="1920" alt="Screenshot 2024-05-08 at 9 43 12 PM" src="https://github.com/AudiusProject/audius-protocol/assets/3893871/aaf65839-009c-443d-a81d-2436f65ca329">

locked album shows lock icon:
<img width="1920" alt="Screenshot 2024-05-08 at 9 44 01 PM" src="https://github.com/AudiusProject/audius-protocol/assets/3893871/f1aa579d-a5d7-47f2-8260-c2799731ba1e">

owner on artist dashboard sees gated type icons:
<img width="1920" alt="Screenshot 2024-05-08 at 9 42 02 PM" src="https://github.com/AudiusProject/audius-protocol/assets/3893871/6f60ee56-0c69-4bd4-a868-ef91fe79a6c4">

ditto for albums tab:
<img width="1920" alt="Screenshot 2024-05-08 at 9 42 59 PM" src="https://github.com/AudiusProject/audius-protocol/assets/3893871/708b787a-a12d-44ee-aae2-922bf743a01d">

