### PR TITLE
Fix web-test by resolving circular import

### DIFF
--- a/packages/common/src/store/effects.ts
+++ b/packages/common/src/store/effects.ts
@@ -7,7 +7,7 @@ import {
 } from 'typed-redux-saga'
 
 import { ErrorLevel } from '~/models/ErrorReporting'
-import { FeatureFlags } from '~/services'
+import { FeatureFlags } from '~/services/remote-config/feature-flags'
 import {
   compareSDKResponse,
   SDKMigrationFailedError


### PR DESCRIPTION
### Description

Reward sagas tests were failing because `getContext` was undefined. This was because `common/src/store/effects.ts` was importing `~/services` which was causing a circular dependency. Using a more narrow import solved the issue

### How Has This Been Tested?

web-test passes
