### PR TITLE
Fix dog ear pt 3

### DIFF
--- a/packages/web/src/components/tile/Tile.tsx
+++ b/packages/web/src/components/tile/Tile.tsx
@@ -45,7 +45,6 @@ export const Tile = forwardRef(
 
     return (
       <Box>
-        {dogEar ? <DogEar type={dogEar} /> : null}
         <RootComponent
           className={cn(
             styles.root,
@@ -58,7 +57,12 @@ export const Tile = forwardRef(
           ref={ref}
           {...other}
         >
-          {children}
+          {dogEar ? (
+            <DogEar type={dogEar} className={styles.borderOffset} />
+          ) : null}
+          <Box css={{ overflow: 'hidden', borderRadius: 'inherit' }}>
+            {children}
+          </Box>
         </RootComponent>
       </Box>
     )

--- a/packages/web/src/components/tile/Tile.tsx
+++ b/packages/web/src/components/tile/Tile.tsx
@@ -44,27 +44,23 @@ export const Tile = forwardRef(
     } = props
 
     return (
-      <Box>
-        <RootComponent
-          className={cn(
-            styles.root,
-            size && styles[size],
-            styles[elevation],
-            className
-          )}
-          type={onClick ? 'button' : undefined}
-          onClick={onClick}
-          ref={ref}
-          {...other}
-        >
-          {dogEar ? (
-            <DogEar type={dogEar} className={styles.borderOffset} />
-          ) : null}
-          <Box css={{ overflow: 'hidden', borderRadius: 'inherit' }}>
-            {children}
-          </Box>
-        </RootComponent>
-      </Box>
+      <RootComponent
+        className={cn(
+          styles.root,
+          size && styles[size],
+          styles[elevation],
+          className
+        )}
+        type={onClick ? 'button' : undefined}
+        onClick={onClick}
+        ref={ref}
+        {...other}
+      >
+        {dogEar ? (
+          <DogEar type={dogEar} className={styles.borderOffset} />
+        ) : null}
+        {children}
+      </RootComponent>
     )
   }
 )

--- a/packages/web/src/components/tile/Tile.tsx
+++ b/packages/web/src/components/tile/Tile.tsx
@@ -8,7 +8,6 @@ import {
 } from 'react'
 
 import { DogEarType } from '@audius/common/models'
-import { Box } from '@audius/harmony'
 import cn from 'classnames'
 
 import { DogEar } from 'components/dog-ear'

--- a/packages/web/src/pages/collection-page/components/desktop/CollectionPage.module.css
+++ b/packages/web/src/pages/collection-page/components/desktop/CollectionPage.module.css
@@ -10,7 +10,6 @@
 .bodyWrapper {
   min-width: 774px;
   margin-bottom: var(--harmony-unit-10);
-  overflow: hidden;
 }
 
 /* Empty Page Section Wrapper */

--- a/packages/web/src/pages/collection-page/components/desktop/CollectionPage.module.css
+++ b/packages/web/src/pages/collection-page/components/desktop/CollectionPage.module.css
@@ -35,6 +35,7 @@
   background-color: var(--harmony-n-25);
   border-top-left-radius: 8px;
   border-top-right-radius: 8px;
+  overflow: hidden;
 }
 
 /* Track Table */


### PR DESCRIPTION
### Description

Redoing changes from #8406 (which were reverted in #8416)

Redone with much less impactful changes; puts the dog ear back inside the container (the way it was before I messed with it), removed any added wrappers, and just moved the `overflow:hidden` one layer deeper

### How Has This Been Tested?

web:stage 
 Since these changes touch less, the testing needs are lower than the previous iterations
- [x] I checked the album page, track page, and tiles used in upload flow