### PR TITLE
fix ddex playlist release_date parsing

### DIFF
--- a/packages/discovery-provider/src/tasks/entity_manager/entities/playlist.py
+++ b/packages/discovery-provider/src/tasks/entity_manager/entities/playlist.py
@@ -314,7 +314,7 @@ def validate_playlist_tx(params: ManageEntityParameters):
                 f"Cannot create playlist {playlist_id} below the offset"
             )
         if is_ddex_signer(params.signer):
-            parsed_release_date = parse_release_date(params.metadata["release_date"])
+            parsed_release_date = parse_release_date(params.metadata.get("release_date"))
             if parsed_release_date and parsed_release_date > datetime.now().astimezone(timezone.utc):
                 raise IndexingValidationError(
                     f"Cannot create playlist {playlist_id} with a future relaese date"
@@ -448,7 +448,7 @@ def create_playlist(params: ManageEntityParameters):
     if is_ddex_signer(params.signer):
         ddex_app = params.signer
         if params.action == Action.CREATE:
-            parsed_release_date = parse_release_date(params.metadata["release_date"])
+            parsed_release_date = parse_release_date(params.metadata.get("release_date"))
             if parsed_release_date:
                 created_at = str(parsed_release_date)  # type: ignore
 


### PR DESCRIPTION
### Description
Fix so indexing doesn't skip this tx. Still need to debug why this field is missing in the metadata (I can see it in the _metadata in the healthz tx explorer) but this makes testing a fix easier.

### How Has This Been Tested?
deployed to a stage node, verified tx succeeded