### PR TITLE
[PAY-2985] Fix squished art in purchase modal

### DIFF
--- a/packages/web/src/components/track/LockedContentDetailsTile.module.css
+++ b/packages/web/src/components/track/LockedContentDetailsTile.module.css
@@ -15,6 +15,7 @@
 }
 
 .imageWrapper {
+  min-width: 124px;
   width: 124px;
   height: 124px;
 }

--- a/packages/web/src/components/track/LockedContentDetailsTile.tsx
+++ b/packages/web/src/components/track/LockedContentDetailsTile.tsx
@@ -122,7 +122,7 @@ export const LockedContentDetailsTile = ({
           <DogEar type={dogEarType} />
         </Flex>
       ) : null}
-      <Flex>
+      <Flex css={{ overflow: 'hidden' }}>
         {showLabel && IconComponent && message ? (
           <Flex
             className={cn(styles.gatedContentLabel, {
@@ -140,8 +140,10 @@ export const LockedContentDetailsTile = ({
             <Text>{message}</Text>
           </Flex>
         ) : null}
-        <Flex direction='column' gap='s'>
-          <Text variant='heading'>{title}</Text>
+        <Flex w='100%' direction='column' gap='s'>
+          <Text ellipses variant='heading'>
+            {title}
+          </Text>
           <Text variant='title'>
             <Text color='subdued'>{messages.by}</Text>{' '}
             <UserLink


### PR DESCRIPTION
### Description
Needed to set a min-width for image, width on parent container, and `overflow: hidden` on grandparent container

### How Has This Been Tested?

Before:
<img width="697" alt="Screenshot 2024-05-09 at 6 50 50 PM" src="https://github.com/AudiusProject/audius-protocol/assets/3893871/3b79dbb2-e149-4551-b521-d01693ddaba8">

After:
<img width="711" alt="Screenshot 2024-05-09 at 6 51 03 PM" src="https://github.com/AudiusProject/audius-protocol/assets/3893871/dd157337-a58f-4f43-81f9-99e8279c8e23">
