### PR TITLE
[PAY-2794] Fix several album track price issues

### DIFF
--- a/packages/common/src/schemas/upload/uploadFormSchema.ts
+++ b/packages/common/src/schemas/upload/uploadFormSchema.ts
@@ -284,7 +284,9 @@ export const createCollectionSchema = (collectionType: 'playlist' | 'album') =>
             USDCPurchaseConditionsSchema,
             z.object({
               usdc_purchase: z.object({
-                albumTrackPrice: z.number().optional() // Album uploads can set a price for all tracks
+                // Album uploads set a price for all tracks.
+                // Note: this is required, but it is also prefilled in the form component (USDCPurchaseFields)
+                albumTrackPrice: z.number()
               })
             })
           )

--- a/packages/common/src/schemas/upload/uploadFormSchema.ts
+++ b/packages/common/src/schemas/upload/uploadFormSchema.ts
@@ -286,7 +286,7 @@ export const createCollectionSchema = (collectionType: 'playlist' | 'album') =>
               usdc_purchase: z.object({
                 // Album uploads set a price for all tracks.
                 // Note: this is required, but it is also prefilled in the form component (USDCPurchaseFields)
-                albumTrackPrice: z.number()
+                albumTrackPrice: z.number().optional()
               })
             })
           )

--- a/packages/common/src/schemas/upload/uploadFormSchema.ts
+++ b/packages/common/src/schemas/upload/uploadFormSchema.ts
@@ -285,7 +285,7 @@ export const createCollectionSchema = (collectionType: 'playlist' | 'album') =>
             z.object({
               usdc_purchase: z.object({
                 // Album uploads set a price for all tracks.
-                // Note: this is made "required" via validation logic, set to optional here for TS
+                // Note: this is made "required" via validation logic, set to optional here to avoid TS conflicts
                 // but is also prefilled in the form component (USDCPurchaseFields)
                 albumTrackPrice: z.number().optional()
               })

--- a/packages/common/src/schemas/upload/uploadFormSchema.ts
+++ b/packages/common/src/schemas/upload/uploadFormSchema.ts
@@ -285,7 +285,8 @@ export const createCollectionSchema = (collectionType: 'playlist' | 'album') =>
             z.object({
               usdc_purchase: z.object({
                 // Album uploads set a price for all tracks.
-                // Note: this is required, but it is also prefilled in the form component (USDCPurchaseFields)
+                // Note: this is made "required" via validation logic, set to optional here for TS
+                // but is also prefilled in the form component (USDCPurchaseFields)
                 albumTrackPrice: z.number().optional()
               })
             })

--- a/packages/web/src/pages/upload-page/fields/AccessAndSaleField.tsx
+++ b/packages/web/src/pages/upload-page/fields/AccessAndSaleField.tsx
@@ -172,9 +172,7 @@ export const AccessAndSaleFormSchema = (
     // Check for albumTrackPrice price >= min price (if applicable)
     .refine(
       (values) =>
-        isAlbum &&
-        isUpload &&
-        values[STREAM_CONDITIONS]?.usdc_purchase?.albumTrackPrice
+        isAlbum && isUpload
           ? refineMinPrice('albumTrackPrice', minContentPriceCents)(values)
           : true,
       {
@@ -189,9 +187,7 @@ export const AccessAndSaleFormSchema = (
     })
     .refine(
       (values) =>
-        isAlbum &&
-        isUpload &&
-        values[STREAM_CONDITIONS]?.usdc_purchase?.albumTrackPrice
+        isAlbum && isUpload
           ? refineMaxPrice('albumTrackPrice', maxContentPriceCents)(values)
           : true,
       {

--- a/packages/web/src/pages/upload-page/fields/AccessAndSaleMenuFields.tsx
+++ b/packages/web/src/pages/upload-page/fields/AccessAndSaleMenuFields.tsx
@@ -1,3 +1,5 @@
+import { useEffect } from 'react'
+
 import { useFeatureFlag, useAccessAndRemixSettings } from '@audius/common/hooks'
 import {
   AccessConditions,
@@ -27,7 +29,11 @@ import { HiddenAvailabilityFields } from './stream-availability/HiddenAvailabili
 import { SpecialAccessFields } from './stream-availability/SpecialAccessFields'
 import { CollectibleGatedRadioField } from './stream-availability/collectible-gated/CollectibleGatedRadioField'
 import { UsdcPurchaseGatedRadioField } from './stream-availability/usdc-purchase-gated/UsdcPurchaseGatedRadioField'
-import { STREAM_AVAILABILITY_TYPE, STREAM_CONDITIONS } from './types'
+import {
+  ALBUM_TRACK_PRICE,
+  STREAM_AVAILABILITY_TYPE,
+  STREAM_CONDITIONS
+} from './types'
 
 const messages = {
   title: 'Access & Sale',

--- a/packages/web/src/pages/upload-page/fields/AccessAndSaleMenuFields.tsx
+++ b/packages/web/src/pages/upload-page/fields/AccessAndSaleMenuFields.tsx
@@ -1,5 +1,3 @@
-import { useEffect } from 'react'
-
 import { useFeatureFlag, useAccessAndRemixSettings } from '@audius/common/hooks'
 import {
   AccessConditions,
@@ -29,11 +27,7 @@ import { HiddenAvailabilityFields } from './stream-availability/HiddenAvailabili
 import { SpecialAccessFields } from './stream-availability/SpecialAccessFields'
 import { CollectibleGatedRadioField } from './stream-availability/collectible-gated/CollectibleGatedRadioField'
 import { UsdcPurchaseGatedRadioField } from './stream-availability/usdc-purchase-gated/UsdcPurchaseGatedRadioField'
-import {
-  ALBUM_TRACK_PRICE,
-  STREAM_AVAILABILITY_TYPE,
-  STREAM_CONDITIONS
-} from './types'
+import { STREAM_AVAILABILITY_TYPE, STREAM_CONDITIONS } from './types'
 
 const messages = {
   title: 'Access & Sale',

--- a/packages/web/src/pages/upload-page/fields/helpers.ts
+++ b/packages/web/src/pages/upload-page/fields/helpers.ts
@@ -10,7 +10,7 @@ import { Nullable } from '@audius/common/utils'
 export const getCombinedDefaultGatedConditionValues = (
   userId: Nullable<ID>
 ) => ({
-  usdc_purchase: { price: null },
+  usdc_purchase: { price: null, albumTrackPrice: null },
   follow_user_id: userId,
   tip_user_id: userId,
   nft_collection: undefined

--- a/packages/web/src/pages/upload-page/fields/stream-availability/usdc-purchase-gated/UsdcPurchaseFields.tsx
+++ b/packages/web/src/pages/upload-page/fields/stream-availability/usdc-purchase-gated/UsdcPurchaseFields.tsx
@@ -2,6 +2,7 @@ import {
   ChangeEventHandler,
   FocusEventHandler,
   useCallback,
+  useEffect,
   useState
 } from 'react'
 
@@ -87,6 +88,18 @@ export const UsdcPurchaseFields = (props: TrackAvailabilityFieldsProps) => {
   const { disabled, isAlbum, isUpload } = props
   const [{ value: downloadConditions }] =
     useField<Nullable<AccessConditions>>(DOWNLOAD_CONDITIONS)
+
+  const [, , { setValue: setAlbumTrackPrice }] =
+    useField<Nullable<number>>(ALBUM_TRACK_PRICE)
+
+  useEffect(() => {
+    if (isAlbum) {
+      // Prefill the initial value of the album track price to $1 (for albums)
+      // Note: this can't go into any formik initialValues because the parent form may not have started with USDC purchase
+      // (aka might have null stream_conditions)
+      setAlbumTrackPrice(100)
+    }
+  }, [isAlbum, setAlbumTrackPrice])
 
   return (
     <div className={cn(layoutStyles.col, layoutStyles.gap4)}>

--- a/packages/web/src/pages/upload-page/fields/stream-availability/usdc-purchase-gated/UsdcPurchaseFields.tsx
+++ b/packages/web/src/pages/upload-page/fields/stream-availability/usdc-purchase-gated/UsdcPurchaseFields.tsx
@@ -174,7 +174,7 @@ const PriceField = (props: PriceFieldProps) => {
       : null
   )
 
-  // This logic is a bit of a hack to update the Formik field whenever the prefilled value was set
+  // This logic is a bit of a hack to set an initial value once in the Formik field (when a prefilled value is desired)
   // This could have lived elsewhere (i.e. initialValues or onChange higher up),
   // but it made sense to colocate here since we also had to set up workaround logic to work with the "setHumanizedValue" state
   const [hasSetInitialValue, setHasSetInitialValue] = useState(false)


### PR DESCRIPTION
### Description

Addresses 
- [PAY-2970] - this state is no longer possible to reach (since you now cant leave the premium modal with an invalid form)
- [PAY-2967] - it's required now, but prefilled to $1
- [PAY-2794] - My recent changes to parse out `albumTrackPrice` getting sent to the backend clobbered the value too early. I refactored to hold onto it before it gets removed

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._
