### PR TITLE
[QA-1259] Restrict OTP spam

### DIFF
--- a/dev-tools/compose/docker-compose.test.yml
+++ b/dev-tools/compose/docker-compose.test.yml
@@ -409,7 +409,7 @@ services:
 
   test-identity-service-migrations:
     extends:
-      file: docker-compose.identity.prod.yml
+      file: docker-compose.identity.dev.yml
       service: identity-service
     command: sh -c "npm run db:migrate"
     environment:
@@ -426,11 +426,11 @@ services:
 
   test-identity-service:
     extends:
-      file: docker-compose.identity.prod.yml
+      file: docker-compose.identity.dev.yml
       service: identity-service
     build:
       context: ${PROJECT_ROOT}
-      dockerfile: ${PROJECT_ROOT}/packages/identity-service/Dockerfile.prod
+      dockerfile: ${PROJECT_ROOT}/packages/identity-service/Dockerfile.dev
     entrypoint: sh -c '[ ! "$$1" = "test" ] && echo $$(ls) && sleep inf || (shift; npx mocha "$$@")' -
     command: ''
     environment:

--- a/packages/identity-service/src/routes/authentication.js
+++ b/packages/identity-service/src/routes/authentication.js
@@ -6,7 +6,12 @@ const {
   errorResponseForbidden,
   errorResponseUnauthorized
 } = require('../apiHelpers')
-const { validateOtp, sendOtp, bypassOtp } = require('../utils/otp')
+const {
+  validateOtp,
+  shouldSendOtp,
+  sendOtp,
+  bypassOtp
+} = require('../utils/otp')
 const authMiddleware = require('../authMiddleware')
 
 module.exports = function (app) {
@@ -129,7 +134,9 @@ module.exports = function (app) {
       }
 
       if (!otp) {
-        await sendOtp({ email, redis, sendgrid })
+        if (await shouldSendOtp({ email, redis })) {
+          await sendOtp({ email, redis, sendgrid })
+        }
         return errorResponseForbidden('Missing otp')
       }
 

--- a/packages/identity-service/src/utils/otp.js
+++ b/packages/identity-service/src/utils/otp.js
@@ -38,18 +38,22 @@ const validateOtp = async ({ email, otp, redis }) => {
 
 const shouldSendOtp = async ({ email, redis }) => {
   const storedOtp = await redis.get(`${OTP_REDIS_PREFIX}:${email}`)
-  const resendCount = await redis.get(
+  const otpCount = await redis.get(
     `${OTP_REDIS_PREFIX}:${email}:${OTP_COUNT_REDIS_POSTFIX}`
   )
-  return !storedOtp || resendCount < OTP_COUNT_LIMIT
+  return !storedOtp || Number(otpCount) < OTP_COUNT_LIMIT
 }
 
 const updateOtpCount = async ({ email, redis }) => {
   const otpCountKey = `${OTP_REDIS_PREFIX}:${email}:${OTP_COUNT_REDIS_POSTFIX}`
-  const otpCountValue = await redis.get(otpCountKey)
-  const otpCountNumber = otpCountValue ? parseInt(otpCountValue) : 0
+  const otpCount = await redis.get(otpCountKey)
 
-  await redis.set(otpCountKey, otpCountNumber + 1, 'EX', OTP_EXPIRATION_SECONDS)
+  await redis.set(
+    otpCountKey,
+    Number(otpCount) + 1,
+    'EX',
+    OTP_EXPIRATION_SECONDS
+  )
 }
 
 const sendOtp = async ({ email, redis, sendgrid }) => {

--- a/packages/identity-service/src/utils/otp.js
+++ b/packages/identity-service/src/utils/otp.js
@@ -3,6 +3,8 @@ const { getOtpEmail } = require('../notifications/emails/otp')
 const OTP_CHARS = '0123456789'
 const OTP_REDIS_PREFIX = 'otp'
 const OTP_EXPIRATION_SECONDS = 600
+const OTP_COUNT_REDIS_POSTFIX = 'count'
+const OTP_COUNT_LIMIT = 2
 const OTP_BYPASS_EMAILS = new Set([
   'testflight@audius.co',
   'playstore@audius.co',
@@ -34,6 +36,22 @@ const validateOtp = async ({ email, otp, redis }) => {
   return otp === storedOtp
 }
 
+const shouldSendOtp = async ({ email, redis }) => {
+  const storedOtp = await redis.get(`${OTP_REDIS_PREFIX}:${email}`)
+  const resendCount = await redis.get(
+    `${OTP_REDIS_PREFIX}:${email}:${OTP_COUNT_REDIS_POSTFIX}`
+  )
+  return !storedOtp || resendCount < OTP_COUNT_LIMIT
+}
+
+const updateOtpCount = async ({ email, redis }) => {
+  const otpCountKey = `${OTP_REDIS_PREFIX}:${email}:${OTP_COUNT_REDIS_POSTFIX}`
+  const otpCountValue = await redis.get(otpCountKey)
+  const otpCountNumber = otpCountValue ? parseInt(otpCountValue) : 0
+
+  await redis.set(otpCountKey, otpCountNumber + 1, 'EX', OTP_EXPIRATION_SECONDS)
+}
+
 const sendOtp = async ({ email, redis, sendgrid }) => {
   const otp = generateOtp()
   const html = getEmail({
@@ -49,12 +67,16 @@ const sendOtp = async ({ email, redis, sendgrid }) => {
       groupId: 26666 // id of unsubscribe group at https://mc.sendgrid.com/unsubscribe-groups
     }
   }
+
   await redis.set(
     `${OTP_REDIS_PREFIX}:${email}`,
     otp,
     'EX',
     OTP_EXPIRATION_SECONDS
   )
+
+  await updateOtpCount({ email, redis })
+
   if (sendgrid) {
     await sendgrid.send(emailParams)
   }
@@ -63,5 +85,6 @@ const sendOtp = async ({ email, redis, sendgrid }) => {
 module.exports = {
   bypassOtp,
   validateOtp,
+  shouldSendOtp,
   sendOtp
 }

--- a/packages/identity-service/test/authenticationTest.js
+++ b/packages/identity-service/test/authenticationTest.js
@@ -178,7 +178,7 @@ describe('test authentication routes', function () {
     assert.ok(otp)
   })
 
-  it('sends 2 otp codes every 10 minutes', async function () {
+  it('sends up to 2 otp codes every 10 minutes', async function () {
     const redis = app.get('redis')
     await signUpUser()
 

--- a/packages/identity-service/test/authenticationTest.js
+++ b/packages/identity-service/test/authenticationTest.js
@@ -160,7 +160,7 @@ describe('test authentication routes', function () {
     assert.deepStrictEqual(response.statusCode, 200)
   })
 
-  it.only('sends otp code to authenticating users', async function () {
+  it('sends otp code to authenticating users', async function () {
     await signUpUser()
 
     await request(app)
@@ -178,7 +178,7 @@ describe('test authentication routes', function () {
     assert.ok(otp)
   })
 
-  it.only('sends 2 otp codes every 10 minutes', async function () {
+  it('sends 2 otp codes every 10 minutes', async function () {
     const redis = app.get('redis')
     await signUpUser()
 

--- a/packages/identity-service/test/authenticationTest.js
+++ b/packages/identity-service/test/authenticationTest.js
@@ -9,10 +9,26 @@ describe('test authentication routes', function () {
     const appInfo = await getApp()
     app = appInfo.app
     server = appInfo.server
+    await app.get('redis').flushdb()
   })
   afterEach(async () => {
     await server.close()
   })
+
+  async function signUpUser() {
+    await request(app).post('/authentication').send({
+      iv: 'a7407b91ccb1a09a270e79296c88a990',
+      cipherText:
+        '00b1684fe58f95ef7bca1442681a61b8aa817a136d3c932dcee2bdcb59454205b73174e71b39fa1d532ee915b6d4ba24e8487603fa63e738de35d3505085a142',
+      lookupKey:
+        '9bdc91e1bb7ef60177131690b18349625778c14656dc17814945b52a3f07ac77'
+    })
+
+    await request(app).post('/user').send({
+      username: 'dheeraj@audius.co',
+      walletAddress: '0xaaaaaaaaaaaaaaaaaaaaaaaaa'
+    })
+  }
 
   it('responds 400 for sign up with incorrect body', function (done) {
     request(app)
@@ -39,16 +55,7 @@ describe('test authentication routes', function () {
   })
 
   it('changes passwords for the user', async function () {
-    await request(app)
-      .post('/authentication')
-      .send({
-        iv: 'a7407b91ccb1a09a270e79296c88a990',
-        cipherText:
-          '00b1684fe58f95ef7bca1442681a61b8aa817a136d3c932dcee2bdcb59454205b73174e71b39fa1d532ee915b6d4ba24e8487603fa63e738de35d3505085a142',
-        lookupKey:
-          '9bdc91e1bb7ef60177131690b18349625778c14656dc17814945b52a3f07ac77'
-      })
-      .expect(200)
+    await signUpUser()
 
     await request(app)
       .post('/authentication')
@@ -124,9 +131,9 @@ describe('test authentication routes', function () {
       .expect(200)
   })
 
-  it('responds 400 for lookup authentication with invalid lookupKey', function (done) {
+  it('responds 400 for lookup authentication with invalid lookupKey', async function () {
     // Try getting data without the correct query params, should fail
-    request(app)
+    await request(app)
       .get('/authentication')
       .query({
         lookupKey:
@@ -134,23 +141,11 @@ describe('test authentication routes', function () {
         username: 'dheeraj@audius.co',
         otp: '123456'
       })
-      .expect(400, done)
+      .expect(400, { error: 'Invalid credentials' })
   })
 
   it('responds 200 for lookup authentication with correct params', async function () {
-    // First, create some data in the db
-    await request(app).post('/authentication').send({
-      iv: 'a7407b91ccb1a09a270e79296c88a990',
-      cipherText:
-        '00b1684fe58f95ef7bca1442681a61b8aa817a136d3c932dcee2bdcb59454205b73174e71b39fa1d532ee915b6d4ba24e8487603fa63e738de35d3505085a142',
-      lookupKey:
-        '9bdc91e1bb7ef60177131690b18349625778c14656dc17814945b52a3f07ac77'
-    })
-
-    await request(app).post('/user').send({
-      username: 'dheeraj@audius.co',
-      walletAddress: '0xaaaaaaaaaaaaaaaaaaaaaaaaa'
-    })
+    await signUpUser()
 
     const redis = app.get('redis')
     await redis.set('otp:dheeraj@audius.co', '123456')
@@ -163,5 +158,48 @@ describe('test authentication routes', function () {
     })
 
     assert.deepStrictEqual(response.statusCode, 200)
+  })
+
+  it.only('sends otp code to authenticating users', async function () {
+    await signUpUser()
+
+    await request(app)
+      .get('/authentication')
+      .query({
+        lookupKey:
+          '9bdc91e1bb7ef60177131690b18349625778c14656dc17814945b52a3f07ac77',
+        username: 'dheeraj@audius.co'
+      })
+      .expect(403, { error: 'Missing otp' })
+
+    const redis = app.get('redis')
+    const otp = await redis.get('otp:dheeraj@audius.co')
+
+    assert.ok(otp)
+  })
+
+  it.only('sends 2 otp codes every 10 minutes', async function () {
+    const redis = app.get('redis')
+    await signUpUser()
+
+    async function requestSignUp() {
+      await request(app).get('/authentication').query({
+        lookupKey:
+          '9bdc91e1bb7ef60177131690b18349625778c14656dc17814945b52a3f07ac77',
+        username: 'dheeraj@audius.co'
+      })
+    }
+
+    await requestSignUp()
+    const otp1 = await redis.get('otp:dheeraj@audius.co')
+
+    await requestSignUp()
+    const otp2 = await redis.get('otp:dheeraj@audius.co')
+    assert.notStrictEqual(otp1, otp2)
+
+    // After the second request, we don't send any more new otp emails
+    await requestSignUp()
+    const otp3 = await redis.get('otp:dheeraj@audius.co')
+    assert.strictEqual(otp2, otp3)
   })
 })

--- a/packages/mobile/src/screens/sign-on-screen/screens/ConfirmEmailScreen.tsx
+++ b/packages/mobile/src/screens/sign-on-screen/screens/ConfirmEmailScreen.tsx
@@ -116,7 +116,11 @@ const ResendCodeLink = () => {
   }, [dispatch, email, password, toast])
 
   return (
-    <TextLink variant='visible' onPress={handleClick} disabled={hasResentCode}>
+    <TextLink
+      variant={hasResentCode ? 'subdued' : 'visible'}
+      onPress={handleClick}
+      disabled={hasResentCode}
+    >
       {confirmEmailMessages.resendCode}
     </TextLink>
   )

--- a/packages/web/src/pages/sign-in-page/ConfirmEmailPage.tsx
+++ b/packages/web/src/pages/sign-in-page/ConfirmEmailPage.tsx
@@ -110,7 +110,11 @@ const ResendCodeLink = () => {
   }, [dispatch, email, password, toast])
 
   return (
-    <TextLink variant='visible' onClick={handleClick} disabled={hasResentCode}>
+    <TextLink
+      variant={hasResentCode ? 'subdued' : 'visible'}
+      onClick={handleClick}
+      disabled={hasResentCode}
+    >
       {confirmEmailMessages.resendCode}
     </TextLink>
   )


### PR DESCRIPTION
### Description

- Helps prevent OTP spam by ensuring no more than two otp emails can be send out every 10 minutes.
- Improves UI by visually disabling resend-link
- Fixes local dev for identity-service by updating docker envs for test config.

### How Has This Been Tested?

Added new test for this feature, and fleshed out a few other related to otp