### PR TITLE
[PAY-2965, PAY-2968, PAY-2963] Album upload copy fixes; remove 'hidden' option

### DIFF
--- a/packages/web/src/pages/upload-page/fields/AccessAndSaleMenuFields.tsx
+++ b/packages/web/src/pages/upload-page/fields/AccessAndSaleMenuFields.tsx
@@ -19,6 +19,7 @@ import { useField } from 'formik'
 import layoutStyles from 'components/layout/layout.module.css'
 import { ModalRadioItem } from 'components/modal-radio/ModalRadioItem'
 import { useFlag } from 'hooks/useRemoteConfig'
+import { pluralize } from 'utils/stringUtils'
 
 import { SingleTrackEditValues } from '../types'
 
@@ -37,8 +38,11 @@ const messages = {
     'This track is marked as a remix. To enable additional availability options, unmark within Remix Settings.',
   done: 'Done',
   public: 'Public (Free to Stream)',
-  publicSubtitle:
-    'Public tracks are visible to all users and appear throughout Audius.',
+  publicSubtitle: (contentType: 'album' | 'track') =>
+    `Public ${pluralize(
+      contentType,
+      2
+    )} are visible to all users and appear throughout Audius.`,
   specialAccess: 'Special Access',
   specialAccessSubtitle:
     'Special Access tracks are only available to users who meet certain criteria, such as following the artist.',
@@ -122,7 +126,7 @@ export const AccessAndSaleMenuFields = (props: AccesAndSaleMenuFieldsProps) => {
         <ModalRadioItem
           icon={<IconVisibilityPublic className={styles.icon} />}
           label={messages.public}
-          description={messages.publicSubtitle}
+          description={messages.publicSubtitle(isAlbum ? 'album' : 'track')}
           value={StreamTrackAvailabilityType.PUBLIC}
           disabled={isPublishDisabled}
         />
@@ -157,25 +161,27 @@ export const AccessAndSaleMenuFields = (props: AccesAndSaleMenuFieldsProps) => {
             isInitiallyUnlisted={isInitiallyUnlisted}
           />
         ) : null}
-        <ModalRadioItem
-          icon={<IconVisibilityHidden />}
-          label={messages.hidden}
-          value={StreamTrackAvailabilityType.HIDDEN}
-          description={
-            isAlbum
-              ? messages.hiddenSubtitleAlbums
-              : messages.hiddenSubtitleTracks
-          }
-          disabled={disableHidden}
-          // isInitiallyUnlisted is undefined on create
-          // show hint on scheduled releases that are in create or already unlisted
-          hintContent={
-            isScheduledRelease && isInitiallyUnlisted !== false
-              ? messages.hiddenHint
-              : ''
-          }
-          checkedContent={isAlbum ? null : <HiddenAvailabilityFields />}
-        />
+        {!isAlbum ? (
+          <ModalRadioItem
+            icon={<IconVisibilityHidden />}
+            label={messages.hidden}
+            value={StreamTrackAvailabilityType.HIDDEN}
+            description={
+              isAlbum
+                ? messages.hiddenSubtitleAlbums
+                : messages.hiddenSubtitleTracks
+            }
+            disabled={disableHidden}
+            // isInitiallyUnlisted is undefined on create
+            // show hint on scheduled releases that are in create or already unlisted
+            hintContent={
+              isScheduledRelease && isInitiallyUnlisted !== false
+                ? messages.hiddenHint
+                : ''
+            }
+            checkedContent={isAlbum ? null : <HiddenAvailabilityFields />}
+          />
+        ) : null}
       </RadioGroup>
     </div>
   )

--- a/packages/web/src/pages/upload-page/fields/stream-availability/usdc-purchase-gated/UsdcPurchaseGatedRadioField.tsx
+++ b/packages/web/src/pages/upload-page/fields/stream-availability/usdc-purchase-gated/UsdcPurchaseGatedRadioField.tsx
@@ -7,6 +7,7 @@ import {
   AccessConditions
 } from '@audius/common/models'
 import { FeatureFlags } from '@audius/common/services'
+import { pluralize } from '@audius/common/utils'
 import { IconCart, IconStars } from '@audius/harmony'
 
 import { ExternalTextLink } from 'components/link'
@@ -20,8 +21,11 @@ const WAITLIST_TYPEFORM = 'https://link.audius.co/waitlist'
 
 const messages = {
   usdcPurchase: 'Premium (Pay-to-Unlock)',
-  usdcPurchaseSubtitle:
-    'Unlockable by purchase, these tracks are visible to everyone but only playable by users who have paid for access.',
+  usdcPurchaseSubtitle: (contentType: 'album' | 'track') =>
+    `Unlockable by purchase, these ${pluralize(
+      contentType,
+      2
+    )} are visible to everyone but only playable by users who have paid for access.`,
   waitlist:
     'Start selling your music on Audius today! Limited access beta now available.',
   join: 'Join the Waitlist',
@@ -86,7 +90,7 @@ export const UsdcPurchaseGatedRadioField = (
     <ModalRadioItem
       icon={<IconCart />}
       label={messages.usdcPurchase}
-      description={messages.usdcPurchaseSubtitle}
+      description={messages.usdcPurchaseSubtitle(isAlbum ? 'album' : 'track')}
       value={StreamTrackAvailabilityType.USDC_PURCHASE}
       disabled={disabled}
       hintIcon={IconStars}


### PR DESCRIPTION
### Description

- Update copy to say 'albums' instead of 'tracks' where appropriate
- Remove Hidden option for album uploads

### How Has This Been Tested?

looks good on local web