### PR TITLE
[PAY-2966] Add purchase track to mobile collection tracklist overflow

### DIFF
--- a/packages/common/src/store/ui/mobile-overflow-menu/types.ts
+++ b/packages/common/src/store/ui/mobile-overflow-menu/types.ts
@@ -29,7 +29,8 @@ export enum OverflowAction {
   UNFOLLOW = 'UNFOLLOW',
   MARK_AS_PLAYED = 'MARK_AS_PLAYED',
   MARK_AS_UNPLAYED = 'MARK_AS_UNPLAYED',
-  RELEASE_NOW = 'RELEASE_NOW'
+  RELEASE_NOW = 'RELEASE_NOW',
+  PURCHASE_TRACK = 'PURCHASE_TRACK'
 }
 
 export enum OverflowSource {

--- a/packages/mobile/src/components/overflow-menu-drawer/OverflowMenuDrawer.tsx
+++ b/packages/mobile/src/components/overflow-menu-drawer/OverflowMenuDrawer.tsx
@@ -51,7 +51,8 @@ const overflowRowConfig: Record<OverflowAction, ActionDrawerRow> = {
   [OverflowAction.VIEW_COLLECTIBLE_PAGE]: { text: 'View Collectible Page' },
   [OverflowAction.VIEW_EPISODE_PAGE]: { text: 'View Episode Page' },
   [OverflowAction.MARK_AS_PLAYED]: { text: 'Mark as Played' },
-  [OverflowAction.MARK_AS_UNPLAYED]: { text: 'Mark as Unplayed' }
+  [OverflowAction.MARK_AS_UNPLAYED]: { text: 'Mark as Unplayed' },
+  [OverflowAction.PURCHASE_TRACK]: { text: 'Purchase Track' }
 }
 
 export const OverflowMenuDrawer = () => {

--- a/packages/mobile/src/components/overflow-menu-drawer/TrackOverflowMenuDrawer.tsx
+++ b/packages/mobile/src/components/overflow-menu-drawer/TrackOverflowMenuDrawer.tsx
@@ -93,7 +93,7 @@ const TrackOverflowMenuDrawer = ({ render }: Props) => {
           contentId: track?.track_id,
           contentType: PurchaseableContentType.TRACK
         },
-        { source: ModalSource.LineUpCollectionTile }
+        { source: ModalSource.TrackListItem }
       )
     }
   }, [track, openPremiumContentPurchaseModal])

--- a/packages/mobile/src/components/track-list/TrackListItem.tsx
+++ b/packages/mobile/src/components/track-list/TrackListItem.tsx
@@ -297,16 +297,17 @@ const TrackListItemComponent = (props: TrackListItemComponentProps) => {
   const handleOpenOverflowMenu = useCallback(() => {
     const overflowActions = [
       OverflowAction.SHARE,
-      !isTrackOwner
+      !isTrackOwner && !isLocked
         ? has_current_user_saved
           ? OverflowAction.UNFAVORITE
           : OverflowAction.FAVORITE
         : null,
-      !isTrackOwner
+      !isTrackOwner && !isLocked
         ? has_current_user_reposted
           ? OverflowAction.UNREPOST
           : OverflowAction.REPOST
         : null,
+      !isTrackOwner && isLocked ? OverflowAction.PURCHASE_TRACK : null,
       isEditAlbumsEnabled && isTrackOwner && !ddexApp
         ? OverflowAction.ADD_TO_ALBUM
         : null,


### PR DESCRIPTION
### Description
Adds "Purchase Track" option to overflow menu for track list items in a collection screen

### How Has This Been Tested?

before purchase:
https://github.com/AudiusProject/audius-protocol/assets/3893871/1c36914a-e3f8-404b-a9ca-7afda56f993c

purchased:
![Simulator Screenshot - iPhone 15 Pro - 2024-05-09 at 20 22 22](https://github.com/AudiusProject/audius-protocol/assets/3893871/c6f42652-a714-47d0-a337-9308aefad50d)
