### PR TITLE
[QA-1267] Fix blank android tip screen

### DIFF
--- a/packages/mobile/src/screens/app-screen/AppScreen.tsx
+++ b/packages/mobile/src/screens/app-screen/AppScreen.tsx
@@ -1,4 +1,6 @@
+import { MobileOS } from '@audius/common/models'
 import { createNativeStackNavigator } from '@react-navigation/native-stack'
+import { Platform } from 'react-native'
 
 import { ChangeEmailModalScreen } from '../change-email-screen/ChangeEmailScreen'
 import { ChangePasswordModalScreen } from '../change-password-screen'
@@ -10,8 +12,6 @@ import { UploadModalScreen } from '../upload-screen'
 import { WalletConnectModalScreen } from '../wallet-connect'
 
 import { AppTabsScreen } from './AppTabsScreen'
-import { Platform } from 'react-native'
-import { MobileOS } from '@audius/common/models'
 
 const Stack = createNativeStackNavigator()
 

--- a/packages/mobile/src/screens/app-screen/AppScreen.tsx
+++ b/packages/mobile/src/screens/app-screen/AppScreen.tsx
@@ -10,6 +10,8 @@ import { UploadModalScreen } from '../upload-screen'
 import { WalletConnectModalScreen } from '../wallet-connect'
 
 import { AppTabsScreen } from './AppTabsScreen'
+import { Platform } from 'react-native'
+import { MobileOS } from '@audius/common/models'
 
 const Stack = createNativeStackNavigator()
 
@@ -18,7 +20,14 @@ export const AppScreen = () => {
     <Stack.Navigator screenOptions={{ headerShown: false }}>
       <Stack.Screen name='AppTabs' component={AppTabsScreen} />
       <Stack.Group screenOptions={{ presentation: 'fullScreenModal' }}>
-        <Stack.Screen name='TipArtist' component={TipArtistModalScreen} />
+        <Stack.Screen
+          name='TipArtist'
+          component={TipArtistModalScreen}
+          // Drop animation on android to fix blank tip screen
+          options={
+            Platform.OS === MobileOS.ANDROID ? { animation: 'none' } : undefined
+          }
+        />
         <Stack.Screen name='Upload' component={UploadModalScreen} />
         <Stack.Screen name='EditTrack' component={EditTrackModalScreen} />
         <Stack.Screen name='EditPlaylist' component={EditPlaylistModalScreen} />


### PR DESCRIPTION
### Description

Fixes issue weve seen in the past where screen transition animations sometimes don't work properly on android causing some pages, in this case the tip screen, to look blank.