### PR TITLE
[QA-1253] Improve details tile layout

### DIFF
--- a/packages/mobile/src/components/core/Tag.tsx
+++ b/packages/mobile/src/components/core/Tag.tsx
@@ -10,7 +10,6 @@ import { Text } from './Text'
 
 const useStyles = makeStyles(({ spacing, palette }) => ({
   root: {
-    margin: spacing(1),
     borderRadius: 2,
     backgroundColor: palette.neutralLight4,
     paddingVertical: spacing(1),

--- a/packages/mobile/src/components/details-tile/DetailsStat.tsx
+++ b/packages/mobile/src/components/details-tile/DetailsStat.tsx
@@ -1,9 +1,7 @@
 import React from 'react'
 
-import { Pressable } from 'react-native'
-
 import type { IconComponent } from '@audius/harmony-native'
-import { Flex, Text } from '@audius/harmony-native'
+import { PlainButton } from '@audius/harmony-native'
 import { formatCount } from 'app/utils/format'
 
 type DetailsTileStatProps = {
@@ -21,18 +19,8 @@ export const DetailsTileStat = ({
   label
 }: DetailsTileStatProps) => {
   return (
-    <Pressable onPress={onPress}>
-      <Text>
-        <Flex direction='row' gap='xs' alignItems='center'>
-          <Icon color='default' size='s' />
-          <Text variant='label' size='m' textTransform='capitalize'>
-            {formatCount(count)}
-          </Text>
-          <Text variant='label' size='m' textTransform='capitalize'>
-            {label}
-          </Text>
-        </Flex>
-      </Text>
-    </Pressable>
+    <PlainButton onPress={onPress} iconLeft={Icon}>{`${formatCount(
+      count
+    )} ${label}`}</PlainButton>
   )
 }

--- a/packages/mobile/src/components/details-tile/DetailsTile.tsx
+++ b/packages/mobile/src/components/details-tile/DetailsTile.tsx
@@ -10,7 +10,7 @@ import {
 import type { CommonState } from '@audius/common/store'
 import { dayjs, getDogEarType, Genre } from '@audius/common/utils'
 import moment from 'moment'
-import { TouchableOpacity, Image } from 'react-native'
+import { TouchableOpacity } from 'react-native'
 import { useSelector } from 'react-redux'
 
 import {
@@ -34,7 +34,6 @@ import { light } from 'app/haptics'
 import { useNavigation } from 'app/hooks/useNavigation'
 import { useFeatureFlag } from 'app/hooks/useRemoteConfig'
 import { makeStyles } from 'app/styles'
-import { moodMap } from 'app/utils/moods'
 
 import { OfflineStatusRow } from '../offline-downloads'
 
@@ -43,6 +42,7 @@ import { DetailsProgressInfo } from './DetailsProgressInfo'
 import { DetailsTileActionButtons } from './DetailsTileActionButtons'
 import { DetailsTileAiAttribution } from './DetailsTileAiAttribution'
 import { DetailsTileHasAccess } from './DetailsTileHasAccess'
+import { DetailsTileMetadata } from './DetailsTileMetadata'
 import { DetailsTileNoAccess } from './DetailsTileNoAccess'
 import { DetailsTileStats } from './DetailsTileStats'
 import { SecondaryStats } from './SecondaryStats'
@@ -56,16 +56,10 @@ const messages = {
   pause: 'Pause',
   resume: 'Resume',
   replay: 'Replay',
-  preview: 'Preview',
-  trackCount: 'track',
-  playCount: 'play',
-  released: 'Released',
-  updated: 'Updated',
-  genre: 'Genre',
-  mood: 'Mood'
+  preview: 'Preview'
 }
 
-const useStyles = makeStyles(({ palette, spacing, typography }) => ({
+const useStyles = makeStyles(({ palette, spacing }) => ({
   coverArt: {
     borderWidth: 1,
     borderColor: palette.neutralLight8,
@@ -73,10 +67,6 @@ const useStyles = makeStyles(({ palette, spacing, typography }) => ({
     height: 224,
     width: 224,
     alignSelf: 'center'
-  },
-  emoji: {
-    height: spacing(4),
-    width: spacing(4)
   }
 }))
 
@@ -250,9 +240,9 @@ export const DetailsTile = ({
       <Flex
         direction='row'
         wrap='wrap'
+        w='100%'
         justifyContent='flex-start'
-        // Accounts for the margin on the Tag component
-        m='negativeUnit'
+        gap='s'
       >
         {filteredTags.map((tag) => (
           <Tag key={tag} onPress={() => handlePressTag(tag)}>
@@ -276,7 +266,7 @@ export const DetailsTile = ({
   }
 
   return (
-    <Paper mb='xl'>
+    <Paper>
       {renderDogEar()}
       <Flex p='l' gap='l' alignItems='center' w='100%'>
         <Text
@@ -397,31 +387,7 @@ export const DetailsTile = ({
             trackArtist={user}
           />
         ) : null}
-        {track?.genre || track?.mood ? (
-          <Flex w='100%' direction='row' gap='l'>
-            {track?.genre ? (
-              <Flex direction='row' gap='xs' alignItems='center'>
-                <Text variant='label' textTransform='uppercase' color='subdued'>
-                  {messages.genre}
-                </Text>
-                <Text variant='body' size='s' strength='strong'>
-                  {track.genre}
-                </Text>
-              </Flex>
-            ) : null}
-            {track?.mood ? (
-              <Flex direction='row' gap='xs' alignItems='center'>
-                <Text variant='label' textTransform='uppercase' color='subdued'>
-                  {messages.mood}
-                </Text>
-                <Text variant='body' size='s' strength='strong'>
-                  {track.mood}
-                </Text>
-                <Image source={moodMap[track.mood]} style={styles.emoji} />
-              </Flex>
-            ) : null}
-          </Flex>
-        ) : null}
+        <DetailsTileMetadata genre={track?.genre} mood={track?.mood} />
         <SecondaryStats
           playCount={playCount}
           duration={duration}

--- a/packages/mobile/src/components/details-tile/DetailsTile.tsx
+++ b/packages/mobile/src/components/details-tile/DetailsTile.tsx
@@ -351,6 +351,8 @@ export const DetailsTile = ({
         alignItems='center'
         borderTop='default'
         backgroundColor='surface1'
+        borderBottomLeftRadius='m'
+        borderBottomRightRadius='m'
       >
         {!isPublished ? null : (
           <DetailsTileStats

--- a/packages/mobile/src/components/details-tile/DetailsTileMetadata.tsx
+++ b/packages/mobile/src/components/details-tile/DetailsTileMetadata.tsx
@@ -1,0 +1,62 @@
+import type { Nullable } from '@audius/common/utils'
+import { Image } from 'react-native'
+
+import { Flex, Text, useTheme } from '@audius/harmony-native'
+import { moodMap } from 'app/utils/moods'
+
+const messages = {
+  genre: 'Genre',
+  mood: 'Mood'
+}
+
+type MetadataProps = {
+  label: string
+  value: string
+}
+
+const Metadata = (props: MetadataProps) => {
+  const { label, value } = props
+
+  return (
+    <Text>
+      <Text
+        variant='label'
+        color='subdued'
+        // Adjusting line-height to match body
+        style={{ lineHeight: 20 }}
+      >
+        {label}
+      </Text>{' '}
+      <Text variant='body' size='s' strength='strong'>
+        {value}
+      </Text>
+    </Text>
+  )
+}
+
+type DetailsTileMetadataProps = {
+  genre?: string
+  mood?: Nullable<string>
+}
+
+export const DetailsTileMetadata = (props: DetailsTileMetadataProps) => {
+  const { genre, mood } = props
+  const { spacing } = useTheme()
+
+  if (!genre && !mood) return null
+
+  return (
+    <Flex w='100%' direction='row' gap='l'>
+      {genre ? <Metadata label={messages.genre} value={genre} /> : null}
+      {mood ? (
+        <Flex direction='row' gap='xs'>
+          <Metadata label={messages.mood} value={mood} />
+          <Image
+            source={moodMap[mood]}
+            style={{ height: spacing.l, width: spacing.l }}
+          />
+        </Flex>
+      ) : null}
+    </Flex>
+  )
+}

--- a/packages/mobile/src/components/details-tile/SecondaryStats.tsx
+++ b/packages/mobile/src/components/details-tile/SecondaryStats.tsx
@@ -2,7 +2,8 @@ import {
   formatSecondsAsText,
   formatDate,
   removeNullable,
-  pluralize
+  pluralize,
+  formatCount
 } from '@audius/common/utils'
 
 import { Flex, Text } from '@audius/harmony-native'
@@ -17,17 +18,17 @@ const messages = {
 const SecondaryStatRow = (props: { stats: (string | null)[] }) => {
   const { stats } = props
   const nonNullStats = stats.filter(removeNullable)
+  if (nonNullStats.length === 0) return null
+
   return (
-    <Flex direction='row' gap='xs'>
-      {nonNullStats.map((stat, i) => {
-        return (
-          <Text variant='body' size='s' strength='strong' key={i}>
-            {stat}
-            {i < nonNullStats.length - 1 ? ', ' : ''}
-          </Text>
-        )
-      })}
-    </Flex>
+    <Text variant='body' size='s' strength='strong'>
+      {nonNullStats.map((stat, i) => (
+        <>
+          {stat}
+          {i < nonNullStats.length - 1 ? ', ' : ''}
+        </>
+      ))}
+    </Text>
   )
 }
 
@@ -68,7 +69,10 @@ export const SecondaryStats = ({
             : null,
           formatSecondsAsText(duration ?? 0),
           playCount && !hidePlayCount
-            ? `${playCount} ${pluralize(messages.playCount, playCount)}`
+            ? `${formatCount(playCount)} ${pluralize(
+                messages.playCount,
+                playCount
+              )}`
             : null
         ]}
       />

--- a/packages/mobile/src/components/offline-downloads/DownloadStatusIndicator.tsx
+++ b/packages/mobile/src/components/offline-downloads/DownloadStatusIndicator.tsx
@@ -105,5 +105,8 @@ export const DownloadStatusIndicator = (
         return null
     }
   }
-  return <View style={style}>{renderIndicator()}</View>
+
+  const indicator = renderIndicator()
+  if (!indicator) return null
+  return <View style={style}>{indicator}</View>
 }

--- a/packages/mobile/src/harmony-native/components/Button/PlainButton/PlainButton.tsx
+++ b/packages/mobile/src/harmony-native/components/Button/PlainButton/PlainButton.tsx
@@ -40,7 +40,6 @@ export const PlainButton = (props: PlainButtonProps) => {
   const defaultTextStyles: TextStyle = {
     fontFamily: typography.fontByWeight.bold,
     fontSize: typography.size.s,
-    fontWeight: `${typography.weight.bold}` as TextStyle['fontWeight'],
     lineHeight: typography.lineHeight.s,
     textTransform: 'capitalize'
   }
@@ -52,7 +51,6 @@ export const PlainButton = (props: PlainButtonProps) => {
   const largeTextStyles: TextStyle = {
     fontFamily: typography.fontByWeight.bold,
     fontSize: typography.size.l,
-    fontWeight: `${typography.weight.bold}` as TextStyle['fontWeight'],
     lineHeight: typography.lineHeight.m,
     textTransform: 'capitalize'
   }


### PR DESCRIPTION
### Description

Fixes various aspects of details tile:
- Improves alignment of metadata
- Refactors metadata into it's own component
- Fixes line-height for metadata when mixing label + body variants
- Fixes square block at bottom of details tile
- Fixes margin below tile
- Fixes tag alignment and spacing
- Fixes play-count formatting
- Uses full text component rather than flex for stats
- Refactors reposts + favorites to use plain-button
- Fixes plain-button text-weight
<img width="414" alt="image" src="https://github.com/AudiusProject/audius-protocol/assets/8230000/612abee3-c47f-46ef-b8e4-0246de05a3bb">


