### PR TITLE
fix ddex playlists UI

### DIFF
--- a/packages/discovery-provider/src/tasks/metadata.py
+++ b/packages/discovery-provider/src/tasks/metadata.py
@@ -189,6 +189,7 @@ class PlaylistMetadata(TypedDict):
     copyright_line: Optional[Copyright]
     producer_copyright_line: Optional[Copyright]
     parental_warning_type: Optional[str]
+    release_date: None
 
 
 playlist_metadata_format: PlaylistMetadata = {
@@ -209,6 +210,7 @@ playlist_metadata_format: PlaylistMetadata = {
     "copyright_line": None,
     "producer_copyright_line": None,
     "parental_warning_type": None,
+    "release_date": None,
 }
 
 # Updates cannot directly modify these fields via metadata

--- a/packages/web/src/components/tracks-table/TracksTable.tsx
+++ b/packages/web/src/components/tracks-table/TracksTable.tsx
@@ -441,6 +441,7 @@ export const TracksTable = ({
                 includeEdit={false}
                 includeAlbumPage={!isAlbumPage}
                 includeAddToPlaylist={false}
+                includeAddToAlbum={false}
                 includeFavorite={!isLocked}
                 handle={track.handle}
                 trackId={track.track_id}

--- a/packages/web/src/components/tracks-table/TracksTable.tsx
+++ b/packages/web/src/components/tracks-table/TracksTable.tsx
@@ -425,6 +425,35 @@ export const TracksTable = ({
           ? IconVisibilityHidden
           : null
       }
+      const overflowProps = {
+        className: styles.tableActionButton,
+        isDeleted: deleted,
+        includeAlbumPage: !isAlbumPage,
+        includeFavorite: !isLocked,
+        handle: track.handle,
+        trackId: track.track_id,
+        uid: track.uid,
+        date: track.date,
+        isFavorited: track.has_current_user_saved,
+        isOwner: track.owner_id === userId,
+        isOwnerDeactivated: !!track.user?.is_deactivated,
+        isArtistPick: track.user?.artist_pick_track_id === track.track_id,
+        index: cellInfo.row.index,
+        trackTitle: track.name,
+        trackPermalink: track.permalink
+      }
+      const conditionalOverflowProps = isDdex
+        ? {
+            includeEdit: false,
+            includeAddToPlaylist: false,
+            includeAddToAlbum: false
+          }
+        : {
+            includeEdit: !disabledTrackEdit,
+            includeAddToPlaylist: !isLocked && !track.is_stream_gated,
+            onRemove: onClickRemove,
+            removeText
+          }
 
       return (
         <>
@@ -433,54 +462,12 @@ export const TracksTable = ({
               <Icon color='subdued' size='m' />
             </Flex>
           ) : null}
-          {isDdex ? (
-            <div ref={overflowMenuRef} className={styles.overflowMenu}>
-              <OverflowMenuButton
-                className={styles.tableActionButton}
-                isDeleted={deleted}
-                includeEdit={false}
-                includeAlbumPage={!isAlbumPage}
-                includeAddToPlaylist={false}
-                includeAddToAlbum={false}
-                includeFavorite={!isLocked}
-                handle={track.handle}
-                trackId={track.track_id}
-                uid={track.uid}
-                date={track.date}
-                isFavorited={track.has_current_user_saved}
-                isOwner={track.owner_id === userId}
-                isOwnerDeactivated={!!track.user?.is_deactivated}
-                isArtistPick={track.user?.artist_pick_track_id === track.track_id}
-                index={cellInfo.row.index}
-                trackTitle={track.name}
-                trackPermalink={track.permalink}
-              />
-            </div>
-          ) : (
-            <div ref={overflowMenuRef} className={styles.overflowMenu}>
-              <OverflowMenuButton
-                className={styles.tableActionButton}
-                isDeleted={deleted}
-                includeEdit={!disabledTrackEdit}
-                includeAlbumPage={!isAlbumPage}
-                includeAddToPlaylist={!isLocked && !track.is_stream_gated}
-                includeFavorite={!isLocked}
-                onRemove={onClickRemove}
-                removeText={removeText}
-                handle={track.handle}
-                trackId={track.track_id}
-                uid={track.uid}
-                date={track.date}
-                isFavorited={track.has_current_user_saved}
-                isOwner={track.owner_id === userId}
-                isOwnerDeactivated={!!track.user?.is_deactivated}
-                isArtistPick={track.user?.artist_pick_track_id === track.track_id}
-                index={cellInfo.row.index}
-                trackTitle={track.name}
-                trackPermalink={track.permalink}
-              />
-            </div>
-          )}
+          <div ref={overflowMenuRef} className={styles.overflowMenu}>
+            <OverflowMenuButton
+              {...overflowProps}
+              {...conditionalOverflowProps}
+            />
+          </div>
         </>
       )
     },

--- a/packages/web/src/components/tracks-table/TracksTable.tsx
+++ b/packages/web/src/components/tracks-table/TracksTable.tsx
@@ -402,6 +402,7 @@ export const TracksTable = ({
         track.track_id
       ] ?? { isFetchingNFTAccess: false, hasStreamAccess: true }
       const isLocked = !isFetchingNFTAccess && !hasStreamAccess
+      const isDdex = !!track.ddex_app
       const deleted =
         track.is_delete || track._marked_deleted || !!track.user?.is_deactivated
       // For owners, we want to show the type of gating on the track. For fans,
@@ -432,29 +433,53 @@ export const TracksTable = ({
               <Icon color='subdued' size='m' />
             </Flex>
           ) : null}
-          <div ref={overflowMenuRef} className={styles.overflowMenu}>
-            <OverflowMenuButton
-              className={styles.tableActionButton}
-              isDeleted={deleted}
-              includeEdit={!disabledTrackEdit}
-              includeAlbumPage={!isAlbumPage}
-              includeAddToPlaylist={!isLocked && !track.is_stream_gated}
-              includeFavorite={!isLocked}
-              onRemove={onClickRemove}
-              removeText={removeText}
-              handle={track.handle}
-              trackId={track.track_id}
-              uid={track.uid}
-              date={track.date}
-              isFavorited={track.has_current_user_saved}
-              isOwner={track.owner_id === userId}
-              isOwnerDeactivated={!!track.user?.is_deactivated}
-              isArtistPick={track.user?.artist_pick_track_id === track.track_id}
-              index={cellInfo.row.index}
-              trackTitle={track.name}
-              trackPermalink={track.permalink}
-            />
-          </div>
+          {isDdex ? (
+            <div ref={overflowMenuRef} className={styles.overflowMenu}>
+              <OverflowMenuButton
+                className={styles.tableActionButton}
+                isDeleted={deleted}
+                includeEdit={false}
+                includeAlbumPage={!isAlbumPage}
+                includeAddToPlaylist={false}
+                includeFavorite={!isLocked}
+                handle={track.handle}
+                trackId={track.track_id}
+                uid={track.uid}
+                date={track.date}
+                isFavorited={track.has_current_user_saved}
+                isOwner={track.owner_id === userId}
+                isOwnerDeactivated={!!track.user?.is_deactivated}
+                isArtistPick={track.user?.artist_pick_track_id === track.track_id}
+                index={cellInfo.row.index}
+                trackTitle={track.name}
+                trackPermalink={track.permalink}
+              />
+            </div>
+          ) : (
+            <div ref={overflowMenuRef} className={styles.overflowMenu}>
+              <OverflowMenuButton
+                className={styles.tableActionButton}
+                isDeleted={deleted}
+                includeEdit={!disabledTrackEdit}
+                includeAlbumPage={!isAlbumPage}
+                includeAddToPlaylist={!isLocked && !track.is_stream_gated}
+                includeFavorite={!isLocked}
+                onRemove={onClickRemove}
+                removeText={removeText}
+                handle={track.handle}
+                trackId={track.track_id}
+                uid={track.uid}
+                date={track.date}
+                isFavorited={track.has_current_user_saved}
+                isOwner={track.owner_id === userId}
+                isOwnerDeactivated={!!track.user?.is_deactivated}
+                isArtistPick={track.user?.artist_pick_track_id === track.track_id}
+                index={cellInfo.row.index}
+                trackTitle={track.name}
+                trackPermalink={track.permalink}
+              />
+            </div>
+          )}
         </>
       )
     },


### PR DESCRIPTION
### Description
- read `release_date` from playlist metadata (sent by ddex). EM changes done in https://github.com/AudiusProject/audius-protocol/pull/8368. after this is merged, ddex albums should display as created at the parsed release date.
- fix UI for tracks in a playlist/album. EM was parsing the `ddex_app` correctly but the UI was not checking the `ddex_app` field in this particular component.

### How Has This Been Tested?
- will test the release date after this is merged
- tested UI locally. verified there are no edit buttons displayed for tracks in a ddex playlist/album. verified all edit buttons displayed for non-ddex playlist/albums
ddex album:
![image](https://github.com/AudiusProject/audius-protocol/assets/25782182/8a9c81f1-12b9-47f2-8de2-a69cca5b62c8)