### PR TITLE
QA-1260: change content title to not say track

### DIFF
--- a/packages/web/src/components/track/desktop/ConnectedPlaylistTile.tsx
+++ b/packages/web/src/components/track/desktop/ConnectedPlaylistTile.tsx
@@ -345,7 +345,7 @@ const ConnectedPlaylistTile = ({
   }, [setRepostUsers, id, setModalVisibility])
 
   const renderStats = () => {
-    const contentTitle = 'track' // undefined,  playlist or album -  undefined is track
+    const contentTitle = isAlbum ? 'album' : 'playlist'
     const sz = 'large'
     return (
       <div className={cn(styles.socialInfo)}>


### PR DESCRIPTION
### Description
instead of just saying track, determine if playlist is a playlist or album and set that as the content tile

### How Has This Been Tested?
npm run web:stage and look for new tracks, playlists, and albums in your feed. Each of these now have the right text.