### PR TITLE
Filter yourself and current managers out of search results list in Accounts Managing You search [PAY-2833]

### DIFF
--- a/packages/web/src/components/search-users-modal/SearchUsersModal.tsx
+++ b/packages/web/src/components/search-users-modal/SearchUsersModal.tsx
@@ -92,12 +92,11 @@ export const UsersSearch = (props: UsersSearchProps) => {
 
   const { userIds, hasMore, status } = useSelector(getUserList)
   const lastSearchQuery = useSelector(getLastSearchQuery)
-  const excludedUserIdsSet = useMemo(() => {
-    return new Set(excludedUserIds ?? [])
-  }, [excludedUserIds])
+
   const users = useProxySelector(
     (state) => {
       const unfilteredIds = hasQuery ? userIds : defaultUserList.userIds
+      const excludedUserIdsSet = new Set(excludedUserIds ?? [])
       const ids = unfilteredIds.filter((id) => !excludedUserIdsSet.has(id))
       const users = getUsers(state, { ids })
       return ids.map((id) => users[id])

--- a/packages/web/src/components/search-users-modal/SearchUsersModal.tsx
+++ b/packages/web/src/components/search-users-modal/SearchUsersModal.tsx
@@ -3,7 +3,6 @@ import {
   ReactNode,
   useCallback,
   useEffect,
-  useMemo,
   useRef,
   useState
 } from 'react'

--- a/packages/web/src/pages/settings-page/components/desktop/ManagerMode/FindAccountManagerPage.tsx
+++ b/packages/web/src/pages/settings-page/components/desktop/ManagerMode/FindAccountManagerPage.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useMemo, useState } from 'react'
 
 import { useGetManagers } from '@audius/common/api'
-import { ID, User } from '@audius/common/models'
+import { User } from '@audius/common/models'
 import { accountSelectors } from '@audius/common/store'
 import { Box, Flex, IconShieldUser, Text, TextLink } from '@audius/harmony'
 

--- a/packages/web/src/pages/settings-page/components/desktop/ManagerMode/FindAccountManagerPage.tsx
+++ b/packages/web/src/pages/settings-page/components/desktop/ManagerMode/FindAccountManagerPage.tsx
@@ -26,7 +26,7 @@ export const FindAccountManagerPage = (props: FindAccountManagerPageProps) => {
   const [query, setQuery] = useState(params?.query ?? '')
   const userId = useSelector(getUserId)
   const { data: managers } = useGetManagers(
-    { userId: userId as ID },
+    { userId: userId! },
     { disabled: userId == null }
   )
   const excludedUserIds = useMemo(() => {

--- a/packages/web/src/pages/settings-page/components/desktop/ManagerMode/FindAccountManagerPage.tsx
+++ b/packages/web/src/pages/settings-page/components/desktop/ManagerMode/FindAccountManagerPage.tsx
@@ -1,13 +1,18 @@
-import { useCallback, useState } from 'react'
+import { useCallback, useMemo, useState } from 'react'
 
-import { User } from '@audius/common/models'
+import { useGetManagers } from '@audius/common/api'
+import { ID, User } from '@audius/common/models'
+import { accountSelectors } from '@audius/common/store'
 import { Box, Flex, IconShieldUser, Text, TextLink } from '@audius/harmony'
 
 import ArtistChip from 'components/artist/ArtistChip'
 import { UsersSearch } from 'components/search-users-modal/SearchUsersModal'
+import { useSelector } from 'utils/reducer'
 
 import { sharedMessages } from './sharedMessages'
 import { AccountsManagingYouPages, FindAccountManagerPageProps } from './types'
+
+const { getUserId } = accountSelectors
 
 const messages = {
   description: 'Invite a manager to join your account.',
@@ -19,6 +24,18 @@ const messages = {
 export const FindAccountManagerPage = (props: FindAccountManagerPageProps) => {
   const { setPage, params } = props
   const [query, setQuery] = useState(params?.query ?? '')
+  const userId = useSelector(getUserId)
+  const { data: managers } = useGetManagers(
+    { userId: userId as ID },
+    { disabled: userId == null }
+  )
+  const excludedUserIds = useMemo(() => {
+    const res: number[] = managers.map((m) => m.manager.user_id)
+    if (userId) {
+      res.push(userId)
+    }
+    return res
+  }, [managers, userId])
 
   const renderEmpty = useCallback(() => {
     return (
@@ -76,6 +93,7 @@ export const FindAccountManagerPage = (props: FindAccountManagerPageProps) => {
         </Text>
       </Box>
       <UsersSearch
+        excludedUserIds={excludedUserIds}
         query={query}
         onChange={setQuery}
         disableAutofocus


### PR DESCRIPTION
### Description
See title!

### How Has This Been Tested?
Locally against stage - tested both the managers search and the chat search (which doesn't use an exclusion list)

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._
