### PR TITLE
re-do placement_hosts field

### DIFF
--- a/packages/libs/src/services/creatorNode/CreatorNode.ts
+++ b/packages/libs/src/services/creatorNode/CreatorNode.ts
@@ -206,6 +206,10 @@ export class CreatorNode {
         updatedMetadata.preview_start_seconds.toString()
     }
 
+    if (metadata.placement_hosts) {
+      audioUploadOpts.placement_hosts = metadata.placement_hosts
+    }
+
     // Upload audio and cover art
     const promises = [
       this._retry3(

--- a/packages/libs/src/utils/types.ts
+++ b/packages/libs/src/utils/types.ts
@@ -178,6 +178,7 @@ export type TrackMetadata = {
   permalink: string
   audio_upload_id: Nullable<string>
   preview_start_seconds: Nullable<number>
+  placement_hosts?: Nullable<string>
   ddex_app?: Nullable<string>
   ddex_release_ids?: Nullable<DDEXReleaseIDs>
   artists?: Nullable<[ResourceContributor]>


### PR DESCRIPTION
### Description


SDK allows optional `placement_hosts` field, passes thru to mediorum.

Replaces: https://github.com/AudiusProject/audius-protocol/pull/7726