### PR TITLE
[C-4384][C-4383] Small web mobile UI fixes

### DIFF
--- a/packages/web/src/pages/audio-rewards-page/ChallengeRewardsTile.tsx
+++ b/packages/web/src/pages/audio-rewards-page/ChallengeRewardsTile.tsx
@@ -283,17 +283,18 @@ const ClaimAllPanel = () => {
         alignItems='center'
         alignSelf='stretch'
         justifyContent='space-between'
-        m='s'
         css={{ cursor: 'pointer' }}
         onClick={handleClick}
       >
         <Flex direction='column' alignItems='start' w='100%'>
           <Flex gap='s' alignItems='center'>
-            <IconTokenGold
-              height={24}
-              width={24}
-              aria-label={messages.goldAudioToken}
-            />
+            {claimableAmount > 0 ? (
+              <IconTokenGold
+                height={24}
+                width={24}
+                aria-label={messages.goldAudioToken}
+              />
+            ) : null}
             {isEmpty ? null : (
               <Text color='accent' variant='title' size='l'>
                 {claimableAmount > 0

--- a/packages/web/src/pages/audio-rewards-page/ChallengeRewardsTile.tsx
+++ b/packages/web/src/pages/audio-rewards-page/ChallengeRewardsTile.tsx
@@ -258,7 +258,7 @@ const ClaimAllPanel = () => {
   const wm = useWithMobileStyle(styles.mobile)
   const { cooldownChallenges, cooldownAmount, claimableAmount, isEmpty } =
     useChallengeCooldownSchedule({ multiple: true })
-
+  const claimable = claimableAmount > 0
   const [, setClaimAllRewardsVisibility] = useModalState('ClaimAllRewards')
   const onClickClaimAllRewards = useCallback(() => {
     setClaimAllRewardsVisibility(true)
@@ -267,7 +267,7 @@ const ClaimAllPanel = () => {
     setClaimAllRewardsVisibility(true)
   }, [setClaimAllRewardsVisibility])
   const handleClick = useCallback(() => {
-    if (claimableAmount > 0) {
+    if (claimable) {
       onClickClaimAllRewards()
     } else if (cooldownAmount > 0) {
       onClickMoreInfo()
@@ -288,7 +288,7 @@ const ClaimAllPanel = () => {
       >
         <Flex direction='column' alignItems='start' w='100%'>
           <Flex gap='s' alignItems='center'>
-            {claimableAmount > 0 ? (
+            {claimable ? (
               <IconTokenGold
                 height={24}
                 width={24}
@@ -297,7 +297,7 @@ const ClaimAllPanel = () => {
             ) : null}
             {isEmpty ? null : (
               <Text color='accent' variant='title' size='l'>
-                {claimableAmount > 0
+                {claimable
                   ? messages.totalReadyToClaim
                   : messages.totalUpcomingRewards}
               </Text>
@@ -318,14 +318,14 @@ const ClaimAllPanel = () => {
           ) : null}
           <Box mt='l' mb='xl'>
             <Text variant='body' textAlign='left' size='s'>
-              {claimableAmount > 0
+              {claimable
                 ? `${claimableAmount} ${messages.available} ${messages.now}`
                 : messages.availableMessage(
                     formatCooldownChallenges(cooldownChallenges)
                   )}
             </Text>
           </Box>
-          {claimableAmount > 0 ? (
+          {claimable ? (
             <Button
               onClick={onClickClaimAllRewards}
               iconRight={IconArrow}

--- a/packages/web/src/pages/audio-rewards-page/RewardsTile.module.css
+++ b/packages/web/src/pages/audio-rewards-page/RewardsTile.module.css
@@ -173,7 +173,7 @@
 }
 .rewardProgress.mobile {
   align-items: flex-start;
-  flex-direction: column;
+  flex-direction: row;
 }
 
 .rewardProgressLabel {


### PR DESCRIPTION
### Description
Small web mobile UI fixes:
* Remove margin so Claim All tile is the same size.
* Only show token gold when there's claimable tokens.
* Make ready to claim flex horizontally not vertically.

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._

Tested with local client against stage.
<img width="378" alt="Screenshot 2024-05-10 at 12 40 36 PM" src="https://github.com/AudiusProject/audius-protocol/assets/6413636/cbc642c4-dd3f-43f6-b200-61496162cb44">
