### PR TITLE
[PAY-2995] Fix stream_conditions in saved and library fetch

### DIFF
--- a/packages/common/src/services/audius-api-client/makeActivity.ts
+++ b/packages/common/src/services/audius-api-client/makeActivity.ts
@@ -4,6 +4,7 @@ import { UserTrackMetadata, UserCollectionMetadata } from '~/models'
 
 import { makePlaylist, makeTrack } from './ResponseAdapter'
 import { APIActivity, APIActivityV2, isApiActivityV2 } from './types'
+import { pickBy } from 'lodash'
 
 export const makeActivity = (
   activity: APIActivity | APIActivityV2
@@ -13,7 +14,16 @@ export const makeActivity = (
       return undefined
     }
     if (activity.itemType === 'track') {
-      return makeTrack(full.TrackFullToJSON(activity.item as full.TrackFull))
+      // HACK to cover for sdk
+      // https://linear.app/audius/issue/PAY-2994/oneofmodel-breaking-premium-conditions-in-client
+      const picked = pickBy(activity.item.streamConditions, (value) => !!value)
+      const trackFull: full.TrackFull = {
+        ...activity.item,
+        // @ts-ignore
+        streamConditions: picked
+      }
+
+      return makeTrack(full.TrackFullToJSON(trackFull as full.TrackFull))
     } else if (activity.itemType === 'playlist') {
       return makePlaylist(
         full.PlaylistFullWithoutTracksToJSON(

--- a/packages/common/src/services/audius-api-client/makeActivity.ts
+++ b/packages/common/src/services/audius-api-client/makeActivity.ts
@@ -1,10 +1,10 @@
 import { full } from '@audius/sdk'
+import { pickBy } from 'lodash'
 
 import { UserTrackMetadata, UserCollectionMetadata } from '~/models'
 
 import { makePlaylist, makeTrack } from './ResponseAdapter'
 import { APIActivity, APIActivityV2, isApiActivityV2 } from './types'
-import { pickBy } from 'lodash'
 
 export const makeActivity = (
   activity: APIActivity | APIActivityV2


### PR DESCRIPTION
### Description

Fixes an issue where tracks initially loaded in library or history would result in bad `stream_conditions` values and show the wrong gated content type.

This is a temporary hack fix until @rickyrombo returns to tackle PAY-2994

### How Has This Been Tested?

working on local web