### PR TITLE
[C-4277] Prevent empty albums in feed

### DIFF
--- a/dev-tools/compose/docker-compose.test.yml
+++ b/dev-tools/compose/docker-compose.test.yml
@@ -241,6 +241,9 @@ services:
       audius_elasticsearch_url: 'http://discovery-provider-elasticsearch:9200'
     volumes:
       - ${PROJECT_ROOT}/packages/discovery-provider:/audius-discovery-provider
+      - ${PROJECT_ROOT}/packages/es-indexer:/app/packages/discovery-provider/es-indexer
+      - ${PROJECT_ROOT}/node_modules:/app/node_modules
+
     depends_on:
       discovery-provider-elasticsearch:
         condition: service_healthy
@@ -472,7 +475,7 @@ services:
         condition: service_completed_successfully
       ddex-s3:
         condition: service_healthy
-  
+
   ddex-s3:
     container_name: ddex-s3
     image: localstack/localstack:s3-latest

--- a/packages/discovery-provider/integration_tests/tasks/test_get_feed_es.py
+++ b/packages/discovery-provider/integration_tests/tasks/test_get_feed_es.py
@@ -208,9 +208,6 @@ def test_access_controls(app):
     search_res = esclient.search(index="*", query={"match_all": {}})["hits"]["hits"]
     assert len(search_res) == 7
 
-    # test feed
     with app.app_context():
-        assert 1 == 1
         feed_results = get_feed_es({"user_id": "2"})
-
         assert len(feed_results) == 0

--- a/packages/discovery-provider/integration_tests/tasks/test_get_feed_es.py
+++ b/packages/discovery-provider/integration_tests/tasks/test_get_feed_es.py
@@ -137,7 +137,6 @@ access_control_entities = {
         {"user_id": 1, "handle": "user1"},
         {"user_id": 2, "handle": "user2"},
     ],
-
     "tracks": [
         {"track_id": 1, "owner_id": 1, "is_unlisted": True},
         {"track_id": 2, "owner_id": 1, "is_delete": True},
@@ -147,9 +146,7 @@ access_control_entities = {
             "playlist_id": 1,
             "playlist_name": "Empty",
             "playlist_owner_id": 1,
-            "playlist_contents": {
-                "track_ids": []
-            },
+            "playlist_contents": {"track_ids": []},
         },
         {
             "playlist_id": 2,
@@ -178,7 +175,7 @@ access_control_entities = {
             "follower_user_id": 2,
             "followee_user_id": 1,
         },
-    ]
+    ],
 }
 
 

--- a/packages/discovery-provider/integration_tests/tasks/test_get_feed_es.py
+++ b/packages/discovery-provider/integration_tests/tasks/test_get_feed_es.py
@@ -1,5 +1,6 @@
 import logging
 import os
+import subprocess
 import time
 
 from elasticsearch import Elasticsearch
@@ -71,7 +72,6 @@ basic_entities = {
 
 
 def test_get_feed_es(app):
-    return
     """
     Tests es-indexer catchup + get_feed_es
     """
@@ -83,15 +83,15 @@ def test_get_feed_es(app):
 
     # run indexer catchup
     time.sleep(1)
-    # logs = subprocess.run(
-    #     ["npm", "run", "catchup:ci"],
-    #     env=os.environ,
-    #     capture_output=True,
-    #     text=True,
-    #     cwd="es-indexer",
-    #     timeout=30,
-    # )
-    # logging.info(logs)
+    logs = subprocess.run(
+        ["npm", "run", "catchup:ci"],
+        env=os.environ,
+        capture_output=True,
+        text=True,
+        cwd="es-indexer",
+        timeout=30,
+    )
+    logging.info(logs)
     esclient.indices.refresh(index="*")
     search_res = esclient.search(index="*", query={"match_all": {}})["hits"]["hits"]
     # actually would be more than 10, but 10 is the default `size`...
@@ -130,3 +130,87 @@ def test_get_feed_es(app):
         # user 3 with explicit IDs
         feed_results = get_feed_es({"user_id": "3", "followee_user_ids": [2]})
         assert len(feed_results) == 2
+
+
+access_control_entities = {
+    "users": [
+        {"user_id": 1, "handle": "user1"},
+        {"user_id": 2, "handle": "user2"},
+    ],
+
+    "tracks": [
+        {"track_id": 1, "owner_id": 1, "is_unlisted": True},
+        {"track_id": 2, "owner_id": 1, "is_delete": True},
+    ],
+    "playlists": [
+        {
+            "playlist_id": 1,
+            "playlist_name": "Empty",
+            "playlist_owner_id": 1,
+            "playlist_contents": {
+                "track_ids": []
+            },
+        },
+        {
+            "playlist_id": 2,
+            "playlist_name": "Hidden Tracks",
+            "playlist_owner_id": 1,
+            "playlist_contents": {
+                "track_ids": [
+                    {"track": 1, "time": 1},
+                ]
+            },
+        },
+        {
+            "playlist_id": 3,
+            "playlist_name": "Deleted Tracks",
+            "playlist_owner_id": 1,
+            "playlist_contents": {
+                "track_ids": [
+                    {"track": 2, "time": 2},
+                ]
+            },
+        },
+    ],
+    "follows": [
+        # user 2 follows user 1
+        {
+            "follower_user_id": 2,
+            "followee_user_id": 1,
+        },
+    ]
+}
+
+
+def test_access_controls(app):
+    """
+    Ensurses empty albums, albums with only deleted tracks, and hidden albums
+    are not returned
+    """
+
+    with app.app_context():
+        db = get_db()
+
+    populate_mock_db(db, access_control_entities)
+
+    # run indexer catchup
+    time.sleep(1)
+    logs = subprocess.run(
+        ["npm", "run", "catchup:ci"],
+        env=os.environ,
+        capture_output=True,
+        text=True,
+        cwd="es-indexer",
+        timeout=30,
+    )
+    logging.info(logs)
+    esclient.indices.refresh(index="*")
+    search_res = esclient.search(index="*", query={"match_all": {}})["hits"]["hits"]
+    assert len(search_res) == 7
+
+    # test feed
+    with app.app_context():
+        assert 1 == 1
+        feed_results = get_feed_es({"user_id": "2"})
+
+        assert len(feed_results) == 0

--- a/packages/discovery-provider/src/queries/get_feed_es.py
+++ b/packages/discovery-provider/src/queries/get_feed_es.py
@@ -83,13 +83,8 @@ def get_feed_es(args, limit=10, offset=0):
                                     current_user_id, "playlist_owner_id", explicit_ids
                                 ),
                                 {"term": {"is_private": False}},
-                                {"term": {"track_ids": False}},
-                                {"script": {
-                                    "script": {
-                                        "source": "doc[''].size() > 0"
-                                    }
-                                }
-                                }
+                                {"term": {"is_delete": False}},
+                                {"exists": {"field": "tracks.genre"}},
                             ]
                         }
                     },

--- a/packages/discovery-provider/src/queries/get_feed_es.py
+++ b/packages/discovery-provider/src/queries/get_feed_es.py
@@ -83,7 +83,13 @@ def get_feed_es(args, limit=10, offset=0):
                                     current_user_id, "playlist_owner_id", explicit_ids
                                 ),
                                 {"term": {"is_private": False}},
-                                {"term": {"is_delete": False}},
+                                {"term": {"track_ids": False}},
+                                {"script": {
+                                    "script": {
+                                        "source": "doc[''].size() > 0"
+                                    }
+                                }
+                                }
                             ]
                         }
                     },


### PR DESCRIPTION
### Description

Fixes issue where albums with no tracks and albums with all hidden/deleted tracks appear on the feed.

### How Has This Been Tested?

Reintroduced and added new feed_es tests