### PR TITLE
[PAY-2945] Add claimable progress bar

### DIFF
--- a/packages/web/src/pages/audio-rewards-page/components/modals/ChallengeRewardsModal/ClaimAllRewardsModal.tsx
+++ b/packages/web/src/pages/audio-rewards-page/components/modals/ChallengeRewardsModal/ClaimAllRewardsModal.tsx
@@ -138,7 +138,7 @@ export const ClaimAllRewardsModal = () => {
           />
           {claimableAmount > 0 && !hasClaimed ? (
             <>
-              {claimInProgress ? (
+              {claimInProgress && claimableAmount > 1 ? (
                 <Flex
                   direction='column'
                   backgroundColor='surface1'


### PR DESCRIPTION
### Description

Web + mobile web (woo harmony!)

<img width="427" alt="image" src="https://github.com/AudiusProject/audius-protocol/assets/2731362/649a6932-30f4-470a-9dea-ad79365c4d89">


### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._

Tested by mocking some local data. Will want to confirm this strategy on stage with a cooldown unlock.
