### PR TITLE
[PAY-2991] Fix optimistic cumulative claiming

### DIFF
--- a/packages/common/src/store/pages/audio-rewards/slice.ts
+++ b/packages/common/src/store/pages/audio-rewards/slice.ts
@@ -106,12 +106,14 @@ const slice = createSlice({
 
       if (!userChallenge) return
 
+      // Update disbursed specifiers
+      state.disbursedChallenges[challengeId] = ([] as string[]).concat(
+        state.disbursedChallenges[challengeId] ?? [],
+        specifiers.map((s) => s.specifier)
+      )
+
       // Keep track of individual challenges for rolled up aggregates
       if (userChallenge.challenge_type === 'aggregate') {
-        state.disbursedChallenges[challengeId] = ([] as string[]).concat(
-          state.disbursedChallenges[challengeId] ?? [],
-          specifiers.map((s) => s.specifier)
-        )
         // All completed challenges that are disbursed are fully disbursed
         if (userChallenge?.is_complete) {
           state.userChallengesOverrides[challengeId] = {

--- a/packages/mobile/src/components/track-list/TrackListItem.tsx
+++ b/packages/mobile/src/components/track-list/TrackListItem.tsx
@@ -338,6 +338,7 @@ const TrackListItemComponent = (props: TrackListItemComponentProps) => {
     )
   }, [
     isTrackOwner,
+    isLocked,
     has_current_user_saved,
     has_current_user_reposted,
     isEditAlbumsEnabled,

--- a/packages/mobile/src/screens/audio-screen/AudioScreen.tsx
+++ b/packages/mobile/src/screens/audio-screen/AudioScreen.tsx
@@ -78,8 +78,7 @@ const messages = {
   what: 'What is $AUDIO',
   whatBody1:
     'Audius is owned by people like you, not major corporations. Holding $AUDIO grants you partial ownership of the Audius platform and gives you access to special features as they are released.',
-  learnMore: 'Learn More',
-  whatBody2: `Still confused? Don't worry, more details coming soon!`
+  learnMore: 'Learn More'
 }
 
 const useStyles = makeStyles(({ spacing, palette, typography }) => ({
@@ -479,7 +478,6 @@ export const AudioScreen = () => {
         >
           <Text style={styles.tileLink}>{messages.learnMore}</Text>
         </TouchableOpacity>
-        <Text style={styles.tileSubheader}>{messages.whatBody2}</Text>
       </Tile>
     )
   }

--- a/packages/web/src/components/track/mobile/ConnectedPlaylistTile.tsx
+++ b/packages/web/src/components/track/mobile/ConnectedPlaylistTile.tsx
@@ -209,7 +209,7 @@ const ConnectedPlaylistTile = ({
       // @ts-ignore
       overflowActions
     )
-  }, [collection, isOwner, clickOverflow, isEditAlbumsEnabled])
+  }, [hasStreamAccess, collection, isOwner, clickOverflow, isEditAlbumsEnabled])
 
   const togglePlay = useCallback(() => {
     if (uploading) return

--- a/packages/web/src/pages/audio-rewards-page/ChallengeRewardsTile.tsx
+++ b/packages/web/src/pages/audio-rewards-page/ChallengeRewardsTile.tsx
@@ -272,7 +272,7 @@ const ClaimAllPanel = () => {
     } else if (cooldownAmount > 0) {
       onClickMoreInfo()
     }
-  }, [claimableAmount, cooldownAmount, onClickClaimAllRewards, onClickMoreInfo])
+  }, [claimable, cooldownAmount, onClickClaimAllRewards, onClickMoreInfo])
 
   if (isMobile) {
     return (

--- a/packages/web/src/pages/audio-rewards-page/components/ExplainerTile.tsx
+++ b/packages/web/src/pages/audio-rewards-page/components/ExplainerTile.tsx
@@ -16,7 +16,6 @@ const TOKEN_ANIMATION_URL =
 const messages = {
   whatIsAudio: 'WHAT IS $AUDIO',
   audioDescription: `Audius is owned by people like you, not major corporations. Holding $AUDIO grants you partial ownership of the Audius platform and gives you access to special features as they are released.`,
-  confused: 'Still confused? Don’t worry, more details coming soon!',
   learnMore: 'Learn More'
 }
 
@@ -89,7 +88,6 @@ export const ExplainerTile = ({ className }: { className?: string }) => {
           <div className={styles.learnMore} onClick={onClickLearnMore}>
             {messages.learnMore}
           </div>
-          <div className={styles.description}>{messages.confused}</div>
         </div>
       </>
     </Tile>

--- a/packages/web/src/pages/audio-rewards-page/components/modals/ChallengeRewardsModal/ClaimAllRewardsModal.tsx
+++ b/packages/web/src/pages/audio-rewards-page/components/modals/ChallengeRewardsModal/ClaimAllRewardsModal.tsx
@@ -33,7 +33,6 @@ import styles from './styles.module.css'
 const messages = {
   upcomingRewards: 'Upcoming Rewards',
   claimAudio: (amount: string) => `Claim ${amount} $AUDIO`,
-  readyToClaim: 'Ready to claim!',
   rewardsClaimed: 'All rewards claimed successfully!',
   rewards: 'Rewards',
   audio: '$AUDIO',


### PR DESCRIPTION
### Description

Previously, the cumulative claiming would be in a failure state as soon as one of the calls failed, while the other calls would still be in progress, making it seem to the user that everything failed.
Now, we save the failure state temporarily and wait until all claim attempts are resolved to finally show the failure state. This way, partial failures would only show in the UI after all claim attempts, the successful claims would update accordingly, and the user can rightfully click the claim all button again as no reward claiming is in progress.

Also, previously, we only updated disbursedChallenges for aggregate challenges. This PR updates it for all types of challenges as long as they are disbursed. This should fix the issue where the Claim All rewards modal still showed the "Ready to Claim" summary item because it thought that there were rewards still to be claimed.

Also removed old and unused messages and fixed unrelated lint errors.

### How Has This Been Tested?

Need to test optimistic cumulative claiming fix.

Tested other changes on local dapp vs stage.
