### PR TITLE
[QA-1276] Fix user-links

### DIFF
--- a/packages/harmony/src/components/text-link/TextLink.tsx
+++ b/packages/harmony/src/components/text-link/TextLink.tsx
@@ -60,7 +60,6 @@ export const TextLink = forwardRef((props: TextLinkProps, ref: Ref<'a'>) => {
       ref={ref}
       asChild
       onClick={onClick}
-      tag='a'
       css={{
         display: 'inline-flex',
         gap: spacing.s,

--- a/packages/web/src/components/collection/mobile/CollectionHeader.tsx
+++ b/packages/web/src/components/collection/mobile/CollectionHeader.tsx
@@ -242,7 +242,12 @@ const CollectionHeader = ({
             {title}
           </Text>
           {userId ? (
-            <UserLink userId={userId} size='l' variant='visible' />
+            <UserLink
+              userId={userId}
+              textVariant='body'
+              size='l'
+              variant='visible'
+            />
           ) : null}
         </Flex>
         {shouldShowPlay ? (

--- a/packages/web/src/components/link/UserLink.tsx
+++ b/packages/web/src/components/link/UserLink.tsx
@@ -42,9 +42,7 @@ export const UserLink = (props: UserLinkProps) => {
       ellipses={popover}
       {...other}
     >
-      <Text ellipses variant='body'>
-        {userName}
-      </Text>
+      <Text ellipses>{userName}</Text>
       <UserBadges
         badgeSize={iconSizes[badgeSize]}
         userId={userId}

--- a/packages/web/src/components/user-card/UserCard.tsx
+++ b/packages/web/src/components/user-card/UserCard.tsx
@@ -63,7 +63,8 @@ export const UserCard = (props: UserCardProps) => {
         <UserLink
           userId={id}
           textVariant='title'
-          css={{ justifyContent: 'center', pointerEvents: 'none' }}
+          size='l'
+          css={{ justifyContent: 'center' }}
         />
         <Text variant='body' ellipses>
           @{handle}


### PR DESCRIPTION
### Description

Fixes issue where user-links textVariants are overridden by inner text variant='body' which was added to fix a specific use case. The fix is to roll that back and update the specfic use-case to have textVariant='body'

Also went ahead and updated harmony's text-link to not set tag='a' since that happens in the child component by default.