### PR TITLE
Remove idempotent check in pg migrate test

### DIFF
--- a/packages/discovery-provider/ddl/pg_migrate.sh
+++ b/packages/discovery-provider/ddl/pg_migrate.sh
@@ -60,12 +60,6 @@ migrate_dir() {
         else
             echo "Applying $file"
             psql < "$file"
-
-            # if test mode, run migration again to ensure idempotent
-            if [[ $is_test == "test" ]]; then
-              echo "RE-Applying $file"
-              psql < "$file"
-            fi
         fi
 
         psql -c "INSERT INTO $MIGRATIONS_TABLE (file_name, md5) VALUES ('$file', '$md5') on conflict(file_name) do update set md5='$md5', applied_at=now();"


### PR DESCRIPTION
### Description
No need for idempotent check in test mode when we're already checking md5 to avoid applying the same migration twice. Took a while to figure out but I made a migration that was not idempotent which broke a few notification tests because it made the migrations fail early, missing the trigger functions.

https://github.com/AudiusProject/audius-protocol/pull/8419/files#diff-1f036baf6a9ac4383d09184a9df22e8dc04bb02b88ad623e65bfc4599eb27b31



### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._

Ran `audius-compose test run "discovery-provider-notifications"` locally 
