### PR TITLE
stabilize relay startup

### DIFF
--- a/dev-tools/compose/docker-compose.pedalboard.prod.yml
+++ b/dev-tools/compose/docker-compose.pedalboard.prod.yml
@@ -51,10 +51,17 @@ services:
           'CMD-SHELL',
           'curl -f http://localhost:6001/relay/health || exit 1'
         ]
-      interval: 3s
+      interval: 5s
       timeout: 30s
-      retries: 3
+      retries: 5
       start_period: 5s
+    depends_on:
+      db:
+        condition: service_healthy
+      discovery-provider-redis:
+        condition: service_healthy
+      poa-ganache:
+        condition: service_healthy
 
   solana-relay:
     build:
@@ -83,10 +90,17 @@ services:
           'CMD-SHELL',
           'curl -f http://localhost:6002/solana/health_check || exit 1'
         ]
-      interval: 3s
+      interval: 5s
       timeout: 30s
-      retries: 3
+      retries: 5
       start_period: 5s
+    depends_on:
+      db:
+        condition: service_healthy
+      discovery-provider-redis:
+        condition: service_healthy
+      solana-test-validator:
+        condition: service_healthy
 
   sla-auditor:
     container_name: sla-auditor


### PR DESCRIPTION
### Description
During audius-compose up solana and acdc relay both have a high chance of a flaky startup. This PR adds the correct dependencies to their docker compose entries as well as increases the timeout of their health checks so they're more stable when brought up.

### How Has This Been Tested?
`audius-compose down && audius-compose up`
