### PR TITLE
fix audius-compose ps

### DIFF
--- a/dev-tools/audius-compose
+++ b/dev-tools/audius-compose
@@ -787,28 +787,23 @@ def exec(protocol_dir, service, command, args):
 @cli.command()
 @click.pass_obj
 def ps(protocol_dir):
-    AAO_DIR = pathlib.Path(os.getenv("AAO_DIR", protocol_dir / "../anti-abuse-oracle"))
-
     proc = subprocess.run(
         [
             "docker",
-            "compose",
-            f"--project-directory={protocol_dir / 'dev-tools/compose'}",
-            f"--file={protocol_dir / 'dev-tools/compose/docker-compose.yml'}",
-            f"--project-name={protocol_dir.name}",
-            *([f"--file={AAO_DIR / 'audius-compose.yml'}"] if AAO_DIR.exists() else []),
-            "--profile=*",
             "ps",
-            "--format=json",
+            "--format",
+            "{{json .}}",
         ],
         capture_output=True,
+        text=True
     )
 
     if proc.returncode != 0:
         raise click.ClickException(proc.stderr.decode())
 
-    services = json.loads(proc.stdout.decode())
-    services.sort(key=lambda x: x["Name"])
+    output = proc.stdout.strip()
+    services = [json.loads(line) for line in output.splitlines()]
+    services.sort(key=lambda x: x["Names"])
 
     print(
         "CONTAINER ID".ljust(13),
@@ -818,31 +813,23 @@ def ps(protocol_dir):
     )
 
     for service in services:
-        if service["Service"] == "port-forwarder":
-            continue
+        name = service["Names"]
+        status = service["Status"] or service["State"]
 
-        name = service["Service"]
-        status = service["Health"] or service["State"]
+        ports = service["Ports"]
 
-        ports = {}
-        if service["Publishers"]:
-            for publisher in service["Publishers"]:
-                if publisher["PublishedPort"]:
-                    ports[publisher["PublishedPort"]] = publisher["TargetPort"]
-
-        if service["Service"] in [
+        if service["Names"] in [
             "discovery-provider",
             "discovery-provider-elasticsearch",
         ]:
             replica = int(service["Name"].split("-")[-1])
-        if service["Service"] == "discovery-provider":
-            name = f"{service['Service']}-{replica}"
+        if service["Names"] == "discovery-provider":
+            name = f"{service['Names']}-{replica}"
             ports[5000 + replica - 1] = 5000
-        if service["Service"] == "discovery-provider-elasticsearch":
-            name = f"{service['Service']}-{replica}"
+        if service["Names"] == "discovery-provider-elasticsearch":
+            name = f"{service['Names']}-{replica}"
 
-        ports = sorted(ports.items())
-        ports = ", ".join(f"{target}->{published}" for target, published in ports)
+        name = name.removeprefix("audius-protocol-")
 
         print(
             service["ID"][:12].ljust(13),
@@ -850,6 +837,8 @@ def ps(protocol_dir):
             status.ljust(10),
             ports,
         )
+
+    print("** most containers prefixed with 'audius-protocol-' **")
 
 
 @cli.command()


### PR DESCRIPTION
### Description
I'm not sure if this ever worked for me but a couple people asked why it's broken. 

### How Has This Been Tested?
`audius-compose ps` yields
```
CONTAINER ID  NAME                                STATUS     PORTS
070ab8e8ada0  audius-cmd-1                        Up 34 minutes
2c83a7315618  comms-1                             Up 34 minutes 4222/tcp
52566e2526a4  db-1                                Up 34 minutes (healthy) 0.0.0.0:5432->5432/tcp, 0.0.0.0:5454->5432/tcp
099592a5d0c7  discovery-provider-1                Up 33 minutes (healthy) 5000/tcp
c5e30f2f5677  discovery-provider-elasticsearch-1  Up 34 minutes (healthy) 9200/tcp, 9300/tcp
038c8369e914  discovery-provider-openresty-1      Up 34 minutes 5000/tcp
2a264cb39653  discovery-provider-redis-1          Up 34 minutes (healthy) 6379/tcp
a32742194dea  es-indexer-1                        Up 34 minutes
cc73bce6fa44  eth-ganache-1                       Up 34 minutes (healthy) 0.0.0.0:8546->8545/tcp
3ae28dc5b6f0  identity-service-1                  Up 34 minutes (healthy) 0.0.0.0:7000->7000/tcp, 0.0.0.0:9229->9229/tcp
d5b9b0ccdb38  identity-service-redis-1            Up 34 minutes (healthy) 6379/tcp
18d64deb10e6  mediorum                            Up 34 minutes (healthy) 0.0.0.0:1991-1995->1991-1995/tcp
298be8774e73  poa-ganache-1                       Up 34 minutes (healthy) 0.0.0.0:8545->8545/tcp
aaf1117dc541  relay-1                             Up 34 minutes (healthy)
4b4f0ea1df3b  solana-relay-1                      Up 34 minutes (healthy)
13f50ddd9830  solana-test-validator-1             Up 34 minutes (healthy) 0.0.0.0:8899-8900->8899-8900/tcp
df5ec6e1ced4  trpc-1                              Up 34 minutes
5c7546909e32  buildx_buildkit_relaxed_hamilton0   Up 4 days
9e3dac54f8dc  healthz                             Up 34 minutes
1a272ae60530  ingress                             Up 34 minutes 0.0.0.0:80->80/tcp
** most containers prefixed with 'audius-protocol-' **
```
