### PR TITLE
[PAY-2946] Mobile progress bar for multiple claimed

### DIFF
--- a/packages/mobile/src/components/challenge-rewards-drawer/ClaimAllRewardsDrawer.tsx
+++ b/packages/mobile/src/components/challenge-rewards-drawer/ClaimAllRewardsDrawer.tsx
@@ -12,15 +12,15 @@ import {
 import { ScrollView, View } from 'react-native'
 import { useDispatch, useSelector } from 'react-redux'
 
-import { Flex, Text, Button, IconArrowRight, Box } from '@audius/harmony-native'
+import { Flex, Text, Button, IconArrowRight } from '@audius/harmony-native'
 import { useToast } from 'app/hooks/useToast'
 import { makeStyles } from 'app/styles'
 import { formatLabel } from 'app/utils/challenges'
 
 import { AppDrawer, useDrawerState } from '../drawer/AppDrawer'
-import { SummaryTable } from '../summary-table'
-import { ProgressBar } from '../progress-bar'
 import LoadingSpinner from '../loading-spinner'
+import { ProgressBar } from '../progress-bar'
+import { SummaryTable } from '../summary-table'
 
 const { claimAllChallengeRewards, resetAndCancelClaimReward } =
   audioRewardsPageActions

--- a/packages/mobile/src/components/challenge-rewards-drawer/ClaimAllRewardsDrawer.tsx
+++ b/packages/mobile/src/components/challenge-rewards-drawer/ClaimAllRewardsDrawer.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect } from 'react'
+import { useCallback, useEffect, useState } from 'react'
 
 import {
   formatCooldownChallenges,
@@ -12,13 +12,15 @@ import {
 import { ScrollView, View } from 'react-native'
 import { useDispatch, useSelector } from 'react-redux'
 
-import { Flex, Text, Button, IconArrowRight } from '@audius/harmony-native'
+import { Flex, Text, Button, IconArrowRight, Box } from '@audius/harmony-native'
 import { useToast } from 'app/hooks/useToast'
 import { makeStyles } from 'app/styles'
 import { formatLabel } from 'app/utils/challenges'
 
 import { AppDrawer, useDrawerState } from '../drawer/AppDrawer'
 import { SummaryTable } from '../summary-table'
+import { ProgressBar } from '../progress-bar'
+import LoadingSpinner from '../loading-spinner'
 
 const { claimAllChallengeRewards, resetAndCancelClaimReward } =
   audioRewardsPageActions
@@ -29,6 +31,7 @@ const messages = {
   claimSuccessMessage: 'All rewards successfully claimed!',
   pending: (amount: number) => `${amount} Pending`,
   claimAudio: (amount: number) => `Claim ${amount} $AUDIO`,
+  claiming: 'Claiming $AUDIO',
   done: 'Done'
 }
 
@@ -45,6 +48,15 @@ const useStyles = makeStyles(({ spacing, palette, typography }) => ({
     paddingHorizontal: spacing(4),
     paddingTop: spacing(4),
     width: '100%'
+  },
+  progressBar: {
+    height: spacing(1),
+    marginVertical: 0,
+    paddingVertical: 0
+  },
+  spinner: {
+    width: spacing(4),
+    height: spacing(4)
   }
 }))
 const config = {
@@ -66,6 +78,15 @@ export const ClaimAllRewardsDrawer = () => {
     })
   const claimInProgress = claimStatus === ClaimStatus.CUMULATIVE_CLAIMING
   const hasClaimed = claimStatus === ClaimStatus.CUMULATIVE_SUCCESS
+
+  const [totalClaimable, setTotalClaimable] = useState(claimableAmount)
+  useEffect(
+    () =>
+      setTotalClaimable((totalClaimable) =>
+        Math.max(totalClaimable, claimableAmount)
+      ),
+    [claimableAmount, setTotalClaimable]
+  )
 
   useEffect(() => {
     if (hasClaimed) {
@@ -112,6 +133,34 @@ export const ClaimAllRewardsDrawer = () => {
             )}
             summaryItem={summary}
           />
+          {claimInProgress && claimableAmount > 1 ? (
+            <Flex
+              backgroundColor='surface1'
+              gap='l'
+              borderRadius='s'
+              border='strong'
+              p='l'
+            >
+              <Flex direction='row' justifyContent='space-between'>
+                <Text variant='label' size='s' color='default'>
+                  {messages.claiming}
+                </Text>
+                <Flex direction='row' gap='l'>
+                  <Text variant='label' size='s' color='default'>
+                    {`${totalClaimable - claimableAmount}/${totalClaimable}`}
+                  </Text>
+                  <LoadingSpinner style={styles.spinner} />
+                </Flex>
+              </Flex>
+              <ProgressBar
+                style={{
+                  root: styles.progressBar
+                }}
+                max={totalClaimable}
+                progress={totalClaimable - claimableAmount}
+              />
+            </Flex>
+          ) : null}
         </Flex>
       </ScrollView>
       <View style={styles.stickyClaimRewardsContainer}>

--- a/packages/web/src/pages/audio-rewards-page/components/modals/ChallengeRewardsModal/ClaimAllRewardsModal.tsx
+++ b/packages/web/src/pages/audio-rewards-page/components/modals/ChallengeRewardsModal/ClaimAllRewardsModal.tsx
@@ -12,6 +12,7 @@ import {
 } from '@audius/common/store'
 import { formatNumberCommas } from '@audius/common/utils'
 import {
+  Box,
   Button,
   Flex,
   IconArrowRight,
@@ -136,51 +137,47 @@ export const ClaimAllRewardsModal = () => {
             summaryLabelColor='accent'
             summaryValueColor='default'
           />
-          {claimableAmount > 0 && !hasClaimed ? (
-            <>
-              {claimInProgress && claimableAmount > 1 ? (
-                <Flex
-                  direction='column'
-                  backgroundColor='surface1'
-                  gap='l'
-                  borderRadius='s'
-                  border='strong'
-                  p='l'
-                >
-                  <Flex justifyContent='space-between'>
-                    <Text variant='label' size='s' color='default'>
-                      {messages.claiming}
-                    </Text>
-                    <Flex gap='l'>
-                      <Text variant='label' size='s' color='default'>
-                        {`${
-                          totalClaimable - claimableAmount
-                        }/${totalClaimable}`}
-                      </Text>
-                      <Flex h='unit4' w='unit4'>
-                        <LoadingSpinner />
-                      </Flex>
-                    </Flex>
-                  </Flex>
-                  <ProgressBar
-                    min={0}
-                    max={totalClaimable}
-                    value={totalClaimable - claimableAmount}
-                  />
+          {claimInProgress && claimableAmount > 1 ? (
+            <Flex
+              direction='column'
+              backgroundColor='surface1'
+              gap='l'
+              borderRadius='s'
+              border='strong'
+              p='l'
+            >
+              <Flex justifyContent='space-between'>
+                <Text variant='label' size='s' color='default'>
+                  {messages.claiming}
+                </Text>
+                <Flex gap='l'>
+                  <Text variant='label' size='s' color='default'>
+                    {`${totalClaimable - claimableAmount}/${totalClaimable}`}
+                  </Text>
+                  <Box h='unit4' w='unit4'>
+                    <LoadingSpinner />
+                  </Box>
                 </Flex>
-              ) : null}
-              <Button
-                disabled={claimInProgress}
-                isLoading={claimInProgress}
-                onClick={onClaimRewardClicked}
-                iconRight={IconArrowRight}
-                fullWidth
-              >
-                {claimInProgress
-                  ? messages.claiming
-                  : messages.claimAudio(formatNumberCommas(claimableAmount))}
-              </Button>
-            </>
+              </Flex>
+              <ProgressBar
+                min={0}
+                max={totalClaimable}
+                value={totalClaimable - claimableAmount}
+              />
+            </Flex>
+          ) : null}
+          {claimableAmount > 0 && !hasClaimed ? (
+            <Button
+              disabled={claimInProgress}
+              isLoading={claimInProgress}
+              onClick={onClaimRewardClicked}
+              iconRight={IconArrowRight}
+              fullWidth
+            >
+              {claimInProgress
+                ? messages.claiming
+                : messages.claimAudio(formatNumberCommas(claimableAmount))}
+            </Button>
           ) : (
             <Button variant='primary' fullWidth onClick={() => setOpen(false)}>
               {messages.done}


### PR DESCRIPTION
### Description

Screenshot with dummy data:
<img src='https://github.com/AudiusProject/audius-protocol/assets/2731362/4855a75e-7d09-49e0-8d4f-165614d4910a' width='200' />

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._

I didn't get a screen grab, but used this to claim 2 challenges worth 4 $AUDIO today. Only nit observation is that it went to 1/4 and then zoomed to 4/4 and finished. Fine for now.