### PR TITLE
[PAY-3005] Bring back aao error emojis

### DIFF
--- a/.changeset/breezy-avocados-sip.md
+++ b/.changeset/breezy-avocados-sip.md
@@ -1,0 +1,5 @@
+---
+'@audius/sdk': minor
+---
+
+Resurface aao error code when claiming audio rewards

--- a/.changeset/breezy-avocados-sip.md
+++ b/.changeset/breezy-avocados-sip.md
@@ -1,5 +1,5 @@
 ---
-'@audius/sdk': minor
+'@audius/sdk': major
 ---
 
 Resurface aao error code when claiming audio rewards

--- a/packages/libs/src/sdk/api/challenges/ChallengesApi.ts
+++ b/packages/libs/src/sdk/api/challenges/ChallengesApi.ts
@@ -85,7 +85,7 @@ export class ChallengesApi extends BaseAPI {
    */
   public async claimReward(
     request: ClaimRewardsRequest
-  ): Promise<{ txSignature: string } | { aaoErrorCode: number }> {
+  ): Promise<{ transactionSignature: string } | { aaoErrorCode: number }> {
     const args = await parseParams('claimRewards', ClaimRewardsSchema)(request)
     const { challengeId, specifier, amount: inputAmount } = args
     const logger = this.logger.createPrefixedLogger(
@@ -168,7 +168,7 @@ export class ChallengesApi extends BaseAPI {
     )
 
     logger.debug('Disbursing claim...')
-    const txSignature = await this.evaluateAttestations({
+    const transactionSignature = await this.evaluateAttestations({
       challengeId,
       specifier,
       recipientEthAddress,
@@ -177,7 +177,7 @@ export class ChallengesApi extends BaseAPI {
       amount
     })
 
-    return { txSignature }
+    return { transactionSignature }
   }
 
   private async submitAntiAbuseOracleAttestation({

--- a/packages/web/src/common/store/pages/audio-rewards/sagas.ts
+++ b/packages/web/src/common/store/pages/audio-rewards/sagas.ts
@@ -581,6 +581,7 @@ function* claimAllChallengeRewardsAsync(
 ) {
   const { claims } = action.payload
   let hasError = false
+  let aaoErrorCode: undefined | number
   yield* all(
     claims.map((claim) =>
       call(function* () {
@@ -590,9 +591,7 @@ function* claimAllChallengeRewardsAsync(
             payload: { claim, retryOnFailure: false }
           })
           if (result?.aaoErrorCode) {
-            yield* put(
-              claimChallengeRewardFailed({ aaoErrorCode: result.aaoErrorCode })
-            )
+            aaoErrorCode = result.aaoErrorCode
           }
         } catch (e) {
           console.error(e)
@@ -601,7 +600,9 @@ function* claimAllChallengeRewardsAsync(
       })
     )
   )
-  if (hasError) {
+  if (aaoErrorCode) {
+    yield* put(claimChallengeRewardFailed({ aaoErrorCode }))
+  } else if (hasError) {
     yield* put(claimChallengeRewardFailed())
   } else {
     yield* put(claimAllChallengeRewardsSucceeded())

--- a/packages/web/src/common/store/pages/audio-rewards/sagas.ts
+++ b/packages/web/src/common/store/pages/audio-rewards/sagas.ts
@@ -223,6 +223,9 @@ function* waitForOptimisticChallengeToComplete({
   }
 }
 
+type AAOErrorResult = SpecifierWithAmount & {
+  aaoErrorCode: number
+}
 type ErrorResult = SpecifierWithAmount & {
   error: unknown
 }
@@ -237,7 +240,7 @@ async function claimRewardsForChallenge({
   userId: string
   challengeId: ChallengeId
   specifiers: SpecifierWithAmount[]
-}): Promise<(SpecifierWithAmount | ErrorResult)[]> {
+}): Promise<(SpecifierWithAmount | AAOErrorResult | ErrorResult)[]> {
   return await Promise.all(
     specifiers.map(async (specifierWithAmount) =>
       sdk.challenges
@@ -247,8 +250,15 @@ async function claimRewardsForChallenge({
           amount: specifierWithAmount.amount,
           userId
         })
-        .then(() => {
-          return specifierWithAmount
+        .then((res) => {
+          if ('aaoErrorCode' in res) {
+            return {
+              ...specifierWithAmount,
+              aaoErrorCode: res.aaoErrorCode
+            }
+          } else {
+            return specifierWithAmount
+          }
         })
         // Handle the individual specifier failures here to let the other
         // ones continue to claim and not reject the all() call.
@@ -297,7 +307,9 @@ function* claimSingleChallengeRewardAsync(
       challengeId: challengeId as ChallengeId,
       specifiers
     })
-    const claimed = results.filter((r) => !('error' in r))
+    const claimed = results.filter(
+      (r) => !('error' in r || 'aaoErrorCode' in r)
+    )
     const claimedAmount = claimed.reduce((sum, { amount }) => {
       return sum + amount
     }, 0)
@@ -308,8 +320,24 @@ function* claimSingleChallengeRewardAsync(
     )
     yield* put(setUserChallengesDisbursed({ challengeId, specifiers: claimed }))
 
+    // Ignore other errors and return early if there are AAO errors.
+    const aaoErrors = results.filter(
+      (r): r is AAOErrorResult => 'aaoErrorCode' in r
+    )
+    if (aaoErrors.length > 0) {
+      for (const error of aaoErrors) {
+        console.error(
+          `AAO attestation failed for specifier: ${error.specifier} for amount: ${error.amount}`
+        )
+      }
+      // Only consider the first AAO error code; others are likely to be the same anyway for the same user.
+      const aaoErrorCode = aaoErrors.map((r) => r.aaoErrorCode)[0]
+      return { aaoErrorCode }
+    }
+
     const errors = results.filter((r): r is ErrorResult => 'error' in r)
     if (errors.length > 0) {
+      // Log and report errors for each specifier that failed to claim
       for (const res of errors) {
         const error =
           res.error instanceof Error ? res.error : new Error(String(res.error))
@@ -536,7 +564,12 @@ function* claimChallengeRewardAsync(
   action: ReturnType<typeof claimChallengeReward>
 ) {
   try {
-    yield* call(claimSingleChallengeRewardAsync, action)
+    const result = yield* call(claimSingleChallengeRewardAsync, action)
+    if (result?.aaoErrorCode) {
+      yield* put(
+        claimChallengeRewardFailed({ aaoErrorCode: result.aaoErrorCode })
+      )
+    }
     yield* put(claimChallengeRewardSucceeded())
   } catch (e) {
     yield* put(claimChallengeRewardFailed())
@@ -552,10 +585,15 @@ function* claimAllChallengeRewardsAsync(
     claims.map((claim) =>
       call(function* () {
         try {
-          yield* call(claimSingleChallengeRewardAsync, {
+          const result = yield* call(claimSingleChallengeRewardAsync, {
             type: claimChallengeReward.type,
             payload: { claim, retryOnFailure: false }
           })
+          if (result?.aaoErrorCode) {
+            yield* put(
+              claimChallengeRewardFailed({ aaoErrorCode: result.aaoErrorCode })
+            )
+          }
         } catch (e) {
           console.error(e)
           hasError = true


### PR DESCRIPTION
### Description

The claim reward sdk changes swallowed the aao error codes. This PR brings them back and resurfaces them to the client.

Design-wise. I tried to not re-introduce the { result } | { error } type but it seemed the most sensible here. Thought about throwing the error code itself, but we have TS rules for only throwing Error types. I think what is done here is fine, but lmk if strong opinions about the design if you have them.

### How Has This Been Tested?

Local v stage

tested the happy path. claiming still works.

https://github.com/AudiusProject/audius-protocol/assets/9600175/7d5e7e47-e34d-4768-af99-8dd4784b6713

