### PR TITLE
[DOCS] - Audius Node Migration Guide Page

### DIFF
--- a/docs/docs/node-operator/migration-guide.mdx
+++ b/docs/docs/node-operator/migration-guide.mdx
@@ -2,7 +2,7 @@
 id: migration-guide
 title: Migration Guide
 pagination_label: Migration Guide
-sidebar_label: 📦 Migration Guide
+sidebar_label: Migration Guide
 description: Audius Protocol Documentation
 ---
 
@@ -14,6 +14,8 @@ This portion of the guide is only for Node Operators that setup Audius Nodes usi
 `audius-docker-compose`.
 
 :::
+
+## Overview
 
 Migrating Audius Nodes in just a few steps:
 

--- a/docs/docs/node-operator/migration-guide.mdx
+++ b/docs/docs/node-operator/migration-guide.mdx
@@ -1,0 +1,223 @@
+---
+id: migration-guide
+title: Migration Guide
+pagination_label: Migration Guide
+sidebar_label: 📦 Migration Guide
+description: Audius Protocol Documentation
+---
+
+import useBaseUrl from '@docusaurus/useBaseUrl'
+
+:::warning Read this first
+
+This portion of the guide is only for Node Operators that setup Audius Nodes using
+`audius-docker-compose`.
+
+:::
+
+Migrating Audius Nodes in just a few steps:
+
+1. Disable auto-upgrade on existing Audius Nodes
+2. Stop the Audius daemon on existing Audius Nodes
+3. Install `audius-ctl`
+4. Confirm your
+   [ssh access and port configuration](/node-operator/setup/hardware-requirements#system-configuration)
+5. Edit the configuration file
+6. Run your Audius Nodes
+
+---
+
+## 1. Disable Auto-Upgrade on Existing Nodes
+
+Disable Auto Upgrade by repeating these steps on each of you existing Audius Nodes
+
+1. ssh into Virtual Machine
+
+2. disable auto upgrade with the following command:
+
+```bash
+audius-cli auto-upgrade --remove
+```
+
+## 2. Stop the Audius daemon on Existing Nodes
+
+For each Node to be migrated, you will need to ssh into the Virtual Machine, disable auto upgrade,
+and `down` the Node. The workflow and required commands are as follows:
+
+1. ssh into Virtual Machine
+
+2. Down the Audius Node with the following command:
+
+```bash
+audius-cli down
+```
+
+---
+
+:::tip No New Nodes
+
+Existing Audius Nodes should be "upgraded in place", so unless you have a specific need, we strongly
+recommend following this guide and doing so.
+
+If you are starting up a new Audius Node, follow the
+[Installation Guide](/node-operator/setup/installation) to get started.
+
+:::
+
+---
+
+## 3. Install `audius-ctl`
+
+Get started by opening a terminal on a local machine, this can be any computer, such as a laptop or
+desktop.
+
+Run the following command to install the controller utility, `audius-ctl`
+
+```bash
+curl -sSL https://install.audius.org | sh
+```
+
+:::info Where to install audius-ctl
+
+While it is recommended to install the controller utility on a separate computer, such as your
+laptop, any machine can operate as a Controller. Check the
+[Advanced Usage page](/node-operator/setup/advanced#audius-control-utility) for more information.
+
+:::
+
+---
+
+## 4. Confirm ssh Access to Audius Nodes
+
+For `audius-ctl` to interact with your Audius Nodes, your local machine will need ssh access.
+
+Read more about configuring
+[ssh access and port configuration here.](/node-operator/setup/hardware-requirements#system-configuration)
+
+---
+
+## 5. Edit the Configuration File
+
+Next you will need to edit the configuration file. Run the following command to get started:
+
+```bash
+audius-ctl config edit
+```
+
+### 5.1 Configuration Details
+
+The configuration file will be pre-populated with the required fields. Enter your information into
+each field for each Audius Node you will be running.
+
+```bash showLineNumbers title="audius-ctl configuration file"
+network:
+  deployOn: mainnet
+nodes:
+  content-1.example.com:        # <--- THE URL OF YOUR CONTENT NODE
+    type: content
+    privateKey: abc123          # <--- UNIQUE PRIV KEY USED BY THIS NODE TO SIGN RESPONSES
+    wallet: 0xABC123            # <--- UNIQUE WALLET ADDRESS OF ABOVE PRIV KEY
+    rewardsWallet: 0xABC123     # <--- ADDRESS OF WALLET HOLDING STAKED TOKENS
+  discovery-1.example.com:      # <--- THE URL OF YOUR DISCOVERY NODE
+    type: discovery
+    privateKey: abc123          # <--- UNIQUE PRIV KEY USED BY THIS NODE TO SIGN RESPONSES
+    wallet: 0xABC123            # <--- UNIQUE WALLET ADDRESS OF ABOVE PRIV KEY
+    rewardsWallet: 0xABC123     # <--- ADDRESS OF WALLET HOLDING STAKED TOKENS
+```
+
+<details>
+<summary>More Info</summary>
+<div>
+
+| field           | description                                                                                                        |
+| --------------- | ------------------------------------------------------------------------------------------------------------------ |
+| `type`          | either `content` or `discovery`                                                                                    |
+| `privateKey`    | private key associated with the `wallet`                                                                           |
+| `wallet`        | Address of wallet that contains no tokens but that is registered on chain, used to sign JSON responses from server |
+| `rewardsWallet` | Wallet that registered (or will register) the Audius Node on chain                                                 |
+
+</div>
+</details>
+
+---
+
+## 6. Run Your Audius Nodes
+
+With the configuration file setup correctly, the final command to run is:
+
+```bash
+audius-ctl up
+```
+
+This command does a few things:
+
+1. Loops over every Audius Node specified
+2. Connects to each Virtual Machine via ssh
+   1. Checks that the required Audius Node software is installed
+   2. If not found, runs the installer
+   3. Starts the Audius Node
+
+---
+
+## Additional Information
+
+### Environment Variable Mapping
+
+Node Operators migrating existing Nodes will be familiar with the legacy variables for each Node
+type. See the mappings below to correctly use existing keys from a `override.env` file in a new
+configuration file.
+
+- Content Node Variables
+
+  - `delegateOwnerWallet` --> `wallet`
+  - `delegatePrivateKey` --> `privateKey`
+
+- Discovery Node Variables
+  - `audius_delegate_owner_wallet` --> `wallet`
+  - `audius_delegate_private_key` --> `privateKey`
+
+:::caution Looking for Old Docs?
+
+Please be aware that `audius-docker-compose` will soon no longer be supported.
+
+Read the [Migration Guide](/node-operator/migration-guide) for instructions.
+
+<details>
+<summary>Click here for legacy documentation.</summary>
+<div>
+
+This guide describes how to run Audius services on a single machine via Docker Compose. The
+repository of Docker Compose files can be found on
+[GitHub](https://github.com/AudiusProject/audius-docker-compose).
+
+On a VM that meets the minimum requirements from above run:
+
+```bash
+bash <(curl https://raw.githubusercontent.com/AudiusProject/audius-docker-compose/main/install.sh)
+```
+
+During installation there will be prompts for required environment variables. The variables are:
+
+---
+
+**Creator Node**
+
+- `creatorNodeEndpoint` - The DNS of your content node. If you haven't registered the service yet,
+  please enter the url you plan to register.
+- `delegateOwnerWallet` - Address of wallet that contains no tokens but that is registered on chain,
+  used to sign JSON responses from server
+- `delegatePrivateKey` - Private key associated with `delegateOwnerWallet`
+- `spOwnerWallet` - Wallet that registered (or will register) the content node on chain
+
+---
+
+**Discovery Node**
+
+- `audius_delegate_owner_wallet` - Address of wallet that contains no tokens but that is registered
+  on chain, used to sign JSON responses from server
+- `audius_delegate_private_key` - Private key associated with `audius_delegate_owner_wallet`
+
+</div>
+</details>
+
+:::

--- a/docs/docs/node-operator/setup/installation.mdx
+++ b/docs/docs/node-operator/setup/installation.mdx
@@ -8,56 +8,17 @@ description: Audius Protocol Documentation
 
 import useBaseUrl from '@docusaurus/useBaseUrl'
 
-:::caution Looking for Old Docs?
+:::caution Already a Node Operator?
 
-Please be aware that `audius-docker-compose` will soon no longer be supported.
-
-Read the [Migration Guide](/node-operator/setup/installation#migration-guide) at the bottom of this
-page to upgrade.
-
-<details>
-<summary>Click here for legacy documentation.</summary>
-<div>
-
-This guide describes how to run Audius services on a single machine via Docker Compose. The
-repository of Docker Compose files can be found on
-[GitHub](https://github.com/AudiusProject/audius-docker-compose).
-
-On a VM that meets the minimum requirements from above run:
-
-```bash
-bash <(curl https://raw.githubusercontent.com/AudiusProject/audius-docker-compose/main/install.sh)
-```
-
-During installation there will be prompts for required environment variables. The variables are:
-
----
-
-**Creator Node**
-
-- `creatorNodeEndpoint` - The DNS of your content node. If you haven't registered the service yet,
-  please enter the url you plan to register.
-- `delegateOwnerWallet` - Address of wallet that contains no tokens but that is registered on chain,
-  used to sign JSON responses from server
-- `delegatePrivateKey` - Private key associated with `delegateOwnerWallet`
-- `spOwnerWallet` - Wallet that registered (or will register) the content node on chain
-
----
-
-**Discovery Node**
-
-- `audius_delegate_owner_wallet` - Address of wallet that contains no tokens but that is registered
-  on chain, used to sign JSON responses from server
-- `audius_delegate_private_key` - Private key associated with `audius_delegate_owner_wallet`
-
-</div>
-</details>
+Do you currently run an Audius Node? Does `audius-docker-compose` sound familiar? If so, check out
+the [📦 Migration Guide](/node-operator/migration-guide) to migrate your existing Audius Nodes to
+the new architecture.
 
 :::
 
 ## Overview
 
-Installing and managing Audius Nodes is (in most cases) a 3 step process.
+Installing and managing Audius Nodes is (in most cases) a 4 step process.
 
 1. Install `audius-ctl`
 2. Confirm your
@@ -67,7 +28,7 @@ Installing and managing Audius Nodes is (in most cases) a 3 step process.
 
 ---
 
-## Install `audius-ctl`
+## 1. Install `audius-ctl`
 
 Get started by opening a terminal on a local machine, this can be any computer, such as a laptop or
 desktop.
@@ -78,7 +39,7 @@ Run the following command to install the controller utility, `audius-ctl`
 curl -sSL https://install.audius.org | sh
 ```
 
-:::tip Where to install audius-ctl
+:::info Where to install audius-ctl
 
 While it is recommended to install the controller utility on a separate computer, such as your
 laptop, any machine can operate as a Controller. Check the
@@ -88,7 +49,16 @@ laptop, any machine can operate as a Controller. Check the
 
 ---
 
-## Edit the Configuration File
+## 2. Confirm ssh Access to Audius Nodes
+
+For `audius-ctl` to interact with your Audius Nodes, your local machine will need ssh access.
+
+Read more about configuring
+[ssh access and port configuration here.](/node-operator/setup/hardware-requirements#system-configuration)
+
+---
+
+## 3. Edit the Configuration File
 
 Next you will need to edit the configuration file. Run the following command to get started:
 
@@ -96,7 +66,7 @@ Next you will need to edit the configuration file. Run the following command to 
 audius-ctl config edit
 ```
 
-### Configuration Details
+### 3.1 Configuration Details
 
 The configuration file will be pre-populated with the required fields. Enter your information into
 each field for each Audius Node you will be running.
@@ -133,7 +103,7 @@ nodes:
 
 ---
 
-## Run Your Audius Nodes
+## 4. Run Your Audius Nodes
 
 With the configuration file setup correctly, the final command to run is:
 
@@ -149,7 +119,9 @@ This command does a few things:
    2. If not found, runs the installer
    3. Starts the Audius Node
 
-### Additional Commands
+---
+
+## Additional Commands
 
 Get help, and view all of the available commands by running the following command:
 
@@ -188,64 +160,3 @@ Use "audius-ctl [command] --help" for more information about a command.
 ```
 
 > checkout the [code on GitHub](https://github.com/AudiusProject/audius-d)
-
----
-
-## Migration Guide
-
-:::warning Read this first
-
-This portion of the guide is only for Node Operators that setup Audius Nodes using
-`audius-docker-compose`.
-
-:::
-
-Migrating Audius Nodes in just a few steps:
-
-1. Disable auto-upgrade on existing Nodes
-2. Stop the Audius daemon on existing Nodes
-3. Follow the [steps outlined above](/node-operator/setup/installation#overview)
-
-### Stop Existing Nodes
-
-For each Node to be migrated, you will need to ssh into the Virtual Machine, disable auto upgrade,
-and down the Node. The workflow and required commands are as follows:
-
-1. ssh into Virtual Machine
-
-2. disable auto upgrade
-
-```bash
-audius-cli auto-upgrade --remove
-```
-
-3. Down the Audius Node
-
-```bash
-audius-cli down
-```
-
-4. log out
-
-5. Repeat with each Node.
-
-### Configure Nodes
-
-From here, the guide is the same as though you were creating new Nodes from scratch. Head back up to
-the [`audius-ctl` installation step](/node-operator/setup/installation#install-audius-ctl) to get
-started.
-
-#### Migration Variable Mapping
-
-Node Operators migrating existing Nodes will be familiar with the legacy variables for each Node
-type. See the mappings below to correctly use existing keys from a `override.env` file in a new
-configuration file.
-
-- Content Node Variables
-
-  - `delegateOwnerWallet` --> `wallet`
-  - `delegatePrivateKey` --> `privateKey`
-
-- Discovery Node Variables
-  - `audius_delegate_owner_wallet` --> `wallet`
-  - `audius_delegate_private_key` --> `privateKey`

--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -127,6 +127,7 @@ module.exports = {
         'node-operator/setup/installation',
         'node-operator/setup/advanced',
         'node-operator/sla',
+        'node-operator/migration-guide',
       ],
       collapsed: false,
     },


### PR DESCRIPTION
## Description

- Split `audius-d` migration guide to a separate page.
- added numbers to headings in guides for readibility
- added call out for "upgrade in place" structure

## Preview Pages

- [Installation Guide Preview](https://1ad16ba4.docs-eaf.pages.dev/node-operator/setup/installation)
- [Migration Guide Preview](https://1ad16ba4.docs-eaf.pages.dev/node-operator/migration-guide)