### PR TITLE
Fail check-generated-types.sh faster with git --no-pager

### DIFF
--- a/packages/libs/scripts/check-generated-types.sh
+++ b/packages/libs/scripts/check-generated-types.sh
@@ -8,6 +8,6 @@ if [ -z "$(git status . --porcelain)" ]; then
     printf '%s\n' "No diff found between generated types and checked in types"
 else
     printf '%s\n' "Found diff between generated types and checked in types, please 'npm run gen:dev' in libs" >&2
-    git diff .
+    git --no-pager diff .
     exit 1    
 fi


### PR DESCRIPTION
### Description

Jobs that fail `verify sdk types` would take 10 additional minutes to complete because they wait for input on `git diff .` and timeout, e.g. https://app.circleci.com/pipelines/github/AudiusProject/audius-protocol/56881/workflows/3459d239-89b5-480e-a575-f79ec94dce63/jobs/815260

### How has this been tested?

[Integration test is failing](https://app.circleci.com/pipelines/github/AudiusProject/audius-protocol/56894/workflows/43278911-0261-4d65-bb25-369c53faeca3/jobs/815461/parallel-runs/0/steps/0-106) due to unrelated regression, confirmed that it only takes 30s to complete instead of 10m