### PR TITLE
Fix android playback by setting default maxBuffer

### DIFF
--- a/packages/mobile/src/app/App.tsx
+++ b/packages/mobile/src/app/App.tsx
@@ -66,6 +66,8 @@ const App = () => {
     subscribeToNetworkStatusUpdates()
     TrackPlayer.setupPlayer({
       minBuffer: 0.1,
+      // Default value (50), but required to be set on android (crashes otherwise)
+      maxBuffer: 50,
       playBuffer: 0.1,
       waitForBuffer: false,
       autoHandleInterruptions: true,


### PR DESCRIPTION
### Description

The docs say

```
/**
     * Maximum duration of media that the player will attempt to buffer in seconds.
     * Max buffer may not be lower than min buffer.
     *
     * Supported on Android only.
     *
     * @throws Will throw if max buffer is lower than min buffer.
     * @default 50
     */
    maxBuffer?: number;
```

But it turns out on android that if you set minBuffer and don't set maxBuffer, it looks like maxBuffer does not get set.

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._

Physical android device

```
npm run mobile
npm run android:prod -- --device "xxx"
```