### PR TITLE
[PAY-2872] Mobile purchase notifications navigate to content

### DIFF
--- a/packages/mobile/src/hooks/useNotificationNavigation.ts
+++ b/packages/mobile/src/hooks/useNotificationNavigation.ts
@@ -38,7 +38,9 @@ import type {
   AddTrackToPlaylistNotification,
   AddTrackToPlaylistPushNotification,
   MessagePushNotification,
-  MessageReactionPushNotification
+  MessageReactionPushNotification,
+  USDCPurchaseBuyerNotification,
+  USDCPurchaseSellerNotification
 } from '@audius/common/store'
 import {
   NotificationType,
@@ -103,7 +105,11 @@ export const useNotificationNavigation = () => {
 
   const entityHandler = useCallback(
     (
-      notification: RepostOfRepostNotification | FavoriteOfRepostNotification
+      notification:
+        | RepostOfRepostNotification
+        | FavoriteOfRepostNotification
+        | USDCPurchaseBuyerNotification
+        | USDCPurchaseSellerNotification
     ) => {
       const { entityType, entityId } = notification
       if (entityType === Entity.Track) {
@@ -294,6 +300,8 @@ export const useNotificationNavigation = () => {
         }
       },
       [NotificationType.Tastemaker]: entityHandler,
+      [NotificationType.USDCPurchaseBuyer]: entityHandler,
+      [NotificationType.USDCPurchaseSeller]: entityHandler,
       [PushNotificationType.Message]: messagesHandler,
       [PushNotificationType.MessageReaction]: messagesHandler
     }),

--- a/packages/mobile/src/screens/notifications-screen/Notifications/TrackAddedToPurchasedAlbumNotification.tsx
+++ b/packages/mobile/src/screens/notifications-screen/Notifications/TrackAddedToPurchasedAlbumNotification.tsx
@@ -6,7 +6,7 @@ import { notificationsSelectors } from '@audius/common/store'
 import { View } from 'react-native'
 
 import { IconStars } from '@audius/harmony-native'
-import { useNotificationNavigation } from 'app/hooks/useNotificationNavigation'
+import { useNavigation } from 'app/hooks/useNavigation'
 
 import {
   NotificationHeader,
@@ -32,7 +32,7 @@ export const TrackAddedToPurchasedAlbumNotification = (
   props: TrackAddedToPurchasedAlbumNotificationProps
 ) => {
   const { notification } = props
-  const navigation = useNotificationNavigation()
+  const navigation = useNavigation()
   const entities = useProxySelector(
     (state) => getNotificationEntities(state, notification),
     [notification]
@@ -41,10 +41,11 @@ export const TrackAddedToPurchasedAlbumNotification = (
   const playlistOwner = playlist.user
 
   const handlePress = useCallback(() => {
-    if (playlist) {
-      navigation.navigate(notification)
-    }
-  }, [playlist, navigation, notification])
+    navigation.navigate('Collection', {
+      id: playlist.playlist_id,
+      canBeUnlisted: false
+    })
+  }, [navigation, playlist.playlist_id])
 
   if (!playlistOwner || !track || !playlist) return null
 

--- a/packages/mobile/src/screens/notifications-screen/Notifications/USDCPurchaseBuyerNotification.tsx
+++ b/packages/mobile/src/screens/notifications-screen/Notifications/USDCPurchaseBuyerNotification.tsx
@@ -78,10 +78,8 @@ export const USDCPurchaseBuyerNotification = ({
   )
 
   const handlePress = useCallback(() => {
-    if (content) {
-      navigation.navigate(notification)
-    }
-  }, [content, navigation, notification])
+    navigation.navigate(notification)
+  }, [navigation, notification])
 
   if (!content || !sellerUser) return null
   return (

--- a/packages/mobile/src/screens/notifications-screen/Notifications/USDCPurchaseSellerNotification.tsx
+++ b/packages/mobile/src/screens/notifications-screen/Notifications/USDCPurchaseSellerNotification.tsx
@@ -57,10 +57,8 @@ export const USDCPurchaseSellerNotification = (
   const { amount, extraAmount } = notification
 
   const handlePress = useCallback(() => {
-    if (content) {
-      navigation.navigate(notification)
-    }
-  }, [content, navigation, notification])
+    navigation.navigate(notification)
+  }, [navigation, notification])
 
   if (!content || !buyerUser) return null
   return (


### PR DESCRIPTION
### Description
Navigate to purchased content when pressing on USDC purchase notification.

### How Has This Been Tested?

Local ios stage

https://github.com/AudiusProject/audius-protocol/assets/3893871/743a7978-bb1e-4a54-8567-7e5fb7a54e16

