### PR TITLE
Option 1 for dealing with remove/approve manager errors: undo optimistic changes upon error [C-4331]

### DIFF
--- a/packages/common/src/audius-query/createApi.ts
+++ b/packages/common/src/audius-query/createApi.ts
@@ -388,6 +388,7 @@ const fetchData = async <Args, Data>(
         errorMessage: getErrorMessage(e)
       }) as FetchErrorAction
     )
+    endpoint.onQueryError?.(e, fetchArgs, context)
     return undefined
   }
 }

--- a/packages/common/src/audius-query/types.ts
+++ b/packages/common/src/audius-query/types.ts
@@ -90,6 +90,11 @@ export type EndpointConfig<Args, Data> = {
     fetchArgs: Args,
     context: { dispatch: ThunkDispatch<any, any, any> }
   ) => void
+  onQueryError?: (
+    error: unknown,
+    fetchArgs: Args,
+    context: AudiusQueryContextType & { dispatch: ThunkDispatch<any, any, any> }
+  ) => void
 }
 
 export type EntityMap = {

--- a/packages/common/src/audius-query/types.ts
+++ b/packages/common/src/audius-query/types.ts
@@ -9,7 +9,6 @@ import {
   ThunkDispatch
 } from '@reduxjs/toolkit'
 import AsyncRetry from 'async-retry'
-import { Dispatch } from 'redux'
 
 import { Kind, Status } from '~/models'
 
@@ -82,7 +81,10 @@ type EndpointOptions = {
 export type EndpointConfig<Args, Data> = {
   fetch: (fetchArgs: Args, context: AudiusQueryContextType) => Promise<Data>
   options: EndpointOptions
-  onQueryStarted?: (fetchArgs: Args, context: { dispatch: Dispatch }) => void
+  onQueryStarted?: (
+    fetchArgs: Args,
+    context: { dispatch: ThunkDispatch<any, any, any> }
+  ) => void
   onQuerySuccess?: (
     data: Data,
     fetchArgs: Args,

--- a/packages/web/src/pages/settings-page/components/desktop/ManagerMode/AccountListItem.tsx
+++ b/packages/web/src/pages/settings-page/components/desktop/ManagerMode/AccountListItem.tsx
@@ -23,6 +23,7 @@ import { useComposeChat } from 'pages/chat-page/components/useComposeChat'
 import { useSelector } from 'utils/reducer'
 import { profilePage } from 'utils/route'
 import zIndex from 'utils/zIndex'
+import { useAccountSwitcher } from '@audius/common/hooks'
 
 const { getUserId } = accountSelectors
 const { getCanCreateChat } = chatSelectors
@@ -70,6 +71,8 @@ export const AccountListItem = ({
     if (!user) return
     goToRoute(profilePage(user.handle))
   }, [goToRoute, user])
+
+  const { switchAccount } = useAccountSwitcher()
 
   const { canCreateChat } = useSelector((state) =>
     getCanCreateChat(state, { userId: user?.user_id })
@@ -131,13 +134,14 @@ export const AccountListItem = ({
       items.push({
         icon: <IconUserArrowRotate />,
         text: messages.switchToUser,
-        // TODO(nkang - PAY-2831) - Implement this
-        onClick: () => {}
+        onClick: () => switchAccount(user)
       })
     }
 
     return items
   }, [
+    user,
+    switchAccount,
     isManagedAccount,
     isPending,
     handleCancelInvite,

--- a/packages/web/src/pages/settings-page/components/desktop/ManagerMode/AccountsManagingYouHomePage.tsx
+++ b/packages/web/src/pages/settings-page/components/desktop/ManagerMode/AccountsManagingYouHomePage.tsx
@@ -1,4 +1,4 @@
-import { useCallback } from 'react'
+import { useCallback, useContext, useEffect } from 'react'
 
 import { useGetManagers, useRemoveManager } from '@audius/common/api'
 import { Status } from '@audius/common/models'
@@ -19,6 +19,7 @@ import { useSelector } from 'utils/reducer'
 import { AccountListItem } from './AccountListItem'
 import { sharedMessages } from './sharedMessages'
 import { AccountsManagingYouPageProps, AccountsManagingYouPages } from './types'
+import { ToastContext } from 'components/toast/ToastContext'
 
 const { getUserId } = accountSelectors
 
@@ -35,8 +36,9 @@ export const AccountsManagingYouHomePage = (
 ) => {
   const { setPage } = props
   const userId = useSelector(getUserId) as number
+  const { toast } = useContext(ToastContext)
 
-  const [removeManager] = useRemoveManager()
+  const [removeManager, removeResult] = useRemoveManager()
   const { data: managers, status: managersStatus } = useGetManagers({ userId })
 
   const handleRemoveManager = useCallback(
@@ -52,6 +54,12 @@ export const AccountsManagingYouHomePage = (
     },
     [removeManager]
   )
+
+  useEffect(() => {
+    if (removeResult.status === Status.ERROR) {
+      toast(sharedMessages.somethingWentWrong)
+    }
+  }, [toast, removeResult.status])
 
   return (
     <Flex direction='column' gap='xl' ph='xl'>

--- a/packages/web/src/pages/settings-page/components/desktop/ManagerMode/AccountsYouManageHomePage.tsx
+++ b/packages/web/src/pages/settings-page/components/desktop/ManagerMode/AccountsYouManageHomePage.tsx
@@ -5,7 +5,11 @@ import {
   useGetManagedAccounts,
   useRemoveManager
 } from '@audius/common/api'
-import { ID, Status, UserMetadata } from '@audius/common/models'
+import {
+  ManagedUserMetadata,
+  Status,
+  UserMetadata
+} from '@audius/common/models'
 import { accountSelectors } from '@audius/common/store'
 import { Box, Divider, Flex, Text, TextLink } from '@audius/harmony'
 
@@ -21,8 +25,7 @@ const { getUserId } = accountSelectors
 const messages = {
   takeControl:
     'Take control of your managed accounts by making changes to their profiles, preferences, and content.',
-  noAccounts: 'You don’t manage any accounts.',
-  somethingWentWrong: 'Something went wrong. Please try again later.'
+  noAccounts: 'You don’t manage any accounts.'
 }
 
 export const AccountsYouManageHomePage = ({
@@ -30,7 +33,7 @@ export const AccountsYouManageHomePage = ({
 }: AccountsYouManagePageProps) => {
   const userId = useSelector(getUserId)
   const { data: managedAccounts, status } = useGetManagedAccounts(
-    { userId: userId as ID },
+    { userId: userId! },
     { disabled: userId == null }
   )
   const [approveManagedAccount, approveResult] = useApproveManagedAccount()
@@ -74,13 +77,16 @@ export const AccountsYouManageHomePage = ({
   )
 
   useEffect(() => {
-    if (
-      approveResult.status === Status.ERROR ||
-      rejectResult.status === Status.ERROR
-    ) {
-      toast(messages.somethingWentWrong)
+    if (approveResult.status === Status.ERROR) {
+      toast(sharedMessages.somethingWentWrong)
     }
-  }, [toast, approveResult.status, rejectResult.status])
+  }, [toast, approveResult.status])
+
+  useEffect(() => {
+    if (rejectResult.status === Status.ERROR) {
+      toast(sharedMessages.somethingWentWrong)
+    }
+  }, [toast, rejectResult.status])
 
   return (
     <Flex direction='column' gap='xl'>

--- a/packages/web/src/pages/settings-page/components/desktop/ManagerMode/AccountsYouManageHomePage.tsx
+++ b/packages/web/src/pages/settings-page/components/desktop/ManagerMode/AccountsYouManageHomePage.tsx
@@ -48,16 +48,13 @@ export const AccountsYouManageHomePage = ({
   )
 
   const handleApprove = useCallback(
-    ({
-      currentUserId,
-      grantorUser
-    }: {
-      currentUserId: number
-      grantorUser: UserMetadata
-    }) => {
-      approveManagedAccount({ userId: currentUserId, grantorUser })
+    (managedAccount: ManagedUserMetadata) => {
+      approveManagedAccount(
+        { userId: userId!, managedAccount },
+        { disabled: userId == null }
+      )
     },
-    [approveManagedAccount]
+    [approveManagedAccount, userId]
   )
 
   const handleReject = useCallback(
@@ -121,7 +118,7 @@ export const AccountsYouManageHomePage = ({
             key={m.user.user_id}
             user={m.user}
             onRemoveManager={handleStopManaging}
-            onApprove={handleApprove}
+            onApprove={() => handleApprove(m)}
             onReject={handleReject}
             isManagedAccount
             isPending={m.grant.is_approved == null}

--- a/packages/web/src/pages/settings-page/components/desktop/ManagerMode/RemoveManagerConfirmationContent.tsx
+++ b/packages/web/src/pages/settings-page/components/desktop/ManagerMode/RemoveManagerConfirmationContent.tsx
@@ -48,7 +48,6 @@ export const RemoveManagerConfirmationContent = ({
       <Text variant='body' size='l'>
         {confirmationMessage}
       </Text>
-
       <Flex gap='s'>
         <Button
           variant='secondary'
@@ -67,7 +66,7 @@ export const RemoveManagerConfirmationContent = ({
           {messages.remove}
         </Button>
       </Flex>
-      {status === Status.ERROR ? null : (
+      {status !== Status.ERROR ? null : (
         <Text textAlign='center' color='danger' variant='body'>
           {messages.errorGeneral}
         </Text>

--- a/packages/web/src/pages/settings-page/components/desktop/ManagerMode/sharedMessages.ts
+++ b/packages/web/src/pages/settings-page/components/desktop/ManagerMode/sharedMessages.ts
@@ -1,5 +1,6 @@
 export const sharedMessages = {
   accountManagersExplanation:
     'Account managers can modify your profile, change account preferences, and upload, edit, and delete content on your behalf.',
-  learnMore: 'Learn More'
+  learnMore: 'Learn More',
+  somethingWentWrong: 'Something went wrong. Please try again later.'
 }


### PR DESCRIPTION
### Description
Adds `onQueryError` to Audius-query and uses it to undo optimistic changes that were performed when certain queries were started (specifically, approving a manager and removing a manager).

I'm presenting this as "option 1" for dealing with errors in this situation (where we reflect changes in UI immediately instead of upon confirmation) because in many ways audius-query is not "ready" for being used to reverse optimistic changes. There are a lot of challenges like: a) not being able to get the fully hydrated state from inside the `updateQueryData` recipe, and b) the cache not normalizing or formatting entities after manual state changes we perform in `onQueryStarted/onQuerySuccess/onQueryError` (this is also complicated by the fact that these manual state changes might deal with multiple schemas).

For these reasons the code here is potentially a liability and I had to do some weird stuff to get things to work. I'm opening another PR, "option 2", which proposes that we do not try to reverse the optimistic update at all to save us from these complexities and instead suggests for the user to refresh. 

### How Has This Been Tested?
[screen-capture.webm](https://github.com/AudiusProject/audius-protocol/assets/36916764/aef6badc-4333-4da7-bfee-3bdc7dd2af8c)

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._
