### PR TITLE
Ddex placement hosts

### DIFF
--- a/packages/ddex/processor/src/sources.ts
+++ b/packages/ddex/processor/src/sources.ts
@@ -9,6 +9,7 @@ export type SourceConfig = {
   awsSecret: string
   awsRegion: string
   awsBucket: string
+  placementHosts?: string
 }
 
 let sourceList: SourceConfig[] = []

--- a/packages/libs/src/sdk/api/tracks/TracksApi.ts
+++ b/packages/libs/src/sdk/api/tracks/TracksApi.ts
@@ -114,6 +114,10 @@ export class TracksApi extends GeneratedTracksApi {
         metadata.previewStartSeconds.toString()
     }
 
+    if (metadata.placementHosts) {
+      uploadOptions.placement_hosts = metadata.placementHosts
+    }
+
     // Upload track audio and cover art to storage node
     this.logger.info('Uploading track audio and cover art')
     const [coverArtResponse, audioResponse] = await Promise.all([

--- a/packages/libs/src/sdk/api/tracks/types.ts
+++ b/packages/libs/src/sdk/api/tracks/types.ts
@@ -139,6 +139,7 @@ export const createUploadTrackMetadataSchema = () =>
       required_error: messages.titleRequiredError
     }),
     previewStartSeconds: z.optional(z.number()),
+    placementHosts: z.optional(z.string()),
     audioUploadId: z.optional(z.string()),
     previewCid: z.optional(z.string()),
     origFileCid: z.optional(z.string()),


### PR DESCRIPTION
### Description

A follow up to https://github.com/AudiusProject/audius-protocol/commit/0371ee2573e74f565d337babb2d9d0fd2f6d70b4.

Former PR passed thru `placement_hosts` at a lower level, this PR does the same at the higher level tracks API.

Tested on staging and confirmed it correctly sets `placement_hosts` on the resulting mediorum upload.

It is still the case that the initial upload won't respect the `placement_hosts` preference and use the currently selected CN.  For that I think we'll have to change [_makeRequestV2](https://github.com/AudiusProject/audius-protocol/blob/main/packages/libs/src/services/creatorNode/CreatorNode.ts#L419) to use specified host list and fallback to a randomized host list if not specified.

