### PR TITLE
Create Apps Dev Docs link updated

### DIFF
--- a/docs/i18n-disabled/en/docusaurus-plugin-content-docs/current/developers/sdk/index.md
+++ b/docs/i18n-disabled/en/docusaurus-plugin-content-docs/current/developers/sdk/index.md
@@ -189,6 +189,6 @@ If your bundler doesn't automatically polyfill node libraries (like when using c
 
 ## What's next?
 
-- [Get authorization](https://docs.audius.org/developers/log-in-with-audius) to access your app's users' Audius accounts
+- [Get authorization](https://docs.audius.org/developers/guides/log-in-with-audius) to access your app's users' Audius accounts
 
-- [Explore the API docs](https://docs.audius.org/developers/sdk/classes/TracksApi) to see what else you can do with the Audius SDK
+- [Explore the API docs](https://docs.audius.org/developers/sdk/tracks) to see what else you can do with the Audius SDK

--- a/packages/libs/README.md
+++ b/packages/libs/README.md
@@ -76,7 +76,7 @@ Do NOT include your API secret if you are running the SDK on the frontend, as th
 
 :::
 
-## Make your first API call using the SDK!
+## Make your first API call using the SDK
 
 Once you have the initialized SDK instance, it's smooth sailing to making your first API calls.
 
@@ -181,6 +181,6 @@ If your bundler doesn't automatically polyfill node libraries (like when using c
 
 ## What's next?
 
-- [Get authorization](https://docs.audius.org/developers/log-in-with-audius) to access your app's users' Audius accounts
+- [Get authorization](https://docs.audius.org/developers/guides/log-in-with-audius) to access your app's users' Audius accounts
 
-- [Explore the API docs](https://docs.audius.org/developers/sdk/classes/TracksApi) to see what else you can do with the Audius SDK
+- [Explore the API docs](https://docs.audius.org/developers/sdk/tracks) to see what else you can do with the Audius SDK

--- a/packages/web/src/pages/settings-page/components/desktop/DeveloperApps/AppDetailsPage.tsx
+++ b/packages/web/src/pages/settings-page/components/desktop/DeveloperApps/AppDetailsPage.tsx
@@ -13,7 +13,7 @@ import { CreateAppPageProps, CreateAppsPages } from './types'
 
 type AppDetailsPageProps = CreateAppPageProps
 
-const AUDIUS_SDK_LINK = 'https://docs.audius.org/developers/sdk/'
+const AUDIUS_SDK_LINK = 'https://docs.audius.org/developers'
 
 const messages = {
   secretReminder:


### PR DESCRIPTION
### Description

This "Read the Developer Docs" link points to a page that no longer exists at `https://docs.audius.org/developers/sdk/` this change updates that link and two other related SDK docs links 

![image](https://github.com/AudiusProject/audius-protocol/assets/1404219/725878fc-85b0-4bb2-9d13-52d4aee85db2)

> Covering Bases
A redirect to `https://docs.audius.org/developers` has been setup as a backup