### PR TITLE
[QA-1289] Fix broken android notifications

### DIFF
--- a/packages/mobile/src/notifications.ts
+++ b/packages/mobile/src/notifications.ts
@@ -94,16 +94,14 @@ class PushNotifications {
   }
 
   async requestPermission() {
-    const isAndroid = Platform.OS === MobileOS.ANDROID
     isRegistering = true
 
-    if (isAndroid) {
+    if (Platform.OS === MobileOS.ANDROID) {
       // For android, Notifications.registerRemoteNotifications is supposed to prompt user for permission but its currently not
       await request(PERMISSIONS.ANDROID.POST_NOTIFICATIONS)
-    } else {
-      // iOS
-      Notifications.registerRemoteNotifications()
     }
+
+    Notifications.registerRemoteNotifications()
   }
 
   cancelNotif() {


### PR DESCRIPTION
### Description

Fixes issue where new android installs/sign-ins do not receive remote notifications, since we were only calling `registerRemoteNotifications` for ios.