### PR TITLE
[PAY-3014] Fix feed not returning access for collections

### DIFF
--- a/packages/discovery-provider/src/queries/get_feed_es.py
+++ b/packages/discovery-provider/src/queries/get_feed_es.py
@@ -250,11 +250,10 @@ def get_feed_es(args, limit=10, offset=0):
         )
     )
 
-    # batch populate gated track metadata
+    # batch populate gated track and collection metadata
     db = get_db_read_replica()
     with db.scoped_session() as session:
-        track_items = list(filter(lambda item: "track_id" in item, sorted_feed))
-        _populate_gated_content_metadata(session, track_items, current_user["user_id"])
+        _populate_gated_content_metadata(session, sorted_feed, current_user["user_id"])
 
     # populate metadata + remove extra fields from items
     sorted_feed = [

--- a/packages/discovery-provider/src/queries/query_helpers.py
+++ b/packages/discovery-provider/src/queries/query_helpers.py
@@ -556,9 +556,7 @@ def populate_track_metadata(
     return tracks
 
 
-def _populate_gated_content_metadata(
-    session, entities, current_user_id
-):
+def _populate_gated_content_metadata(session, entities, current_user_id):
     if not entities:
         return
     if not current_user_id:
@@ -595,7 +593,7 @@ def _populate_gated_content_metadata(
             f"query_helpers.py | _populate_gated_content_metadata | no wallet for current_user_id {current_user_id}"
         )
         return
-    
+
     def getContentId(metadata):
         return (
             metadata.get("track_id")
@@ -926,9 +924,7 @@ def populate_playlist_metadata(
     # has current user unlocked gated tracks?
     # if so, also populate corresponding signatures.
     # if no current user (guest), populate access based on track stream/download conditions
-    _populate_gated_content_metadata(
-        session, playlists, current_user_id
-    )
+    _populate_gated_content_metadata(session, playlists, current_user_id)
 
     track_ids = []
     for playlist in playlists:

--- a/packages/discovery-provider/src/queries/query_helpers.py
+++ b/packages/discovery-provider/src/queries/query_helpers.py
@@ -557,7 +557,7 @@ def populate_track_metadata(
 
 
 def _populate_gated_content_metadata(
-    session, entities, current_user_id, content_type="track"
+    session, entities, current_user_id
 ):
     if not entities:
         return
@@ -595,11 +595,11 @@ def _populate_gated_content_metadata(
             f"query_helpers.py | _populate_gated_content_metadata | no wallet for current_user_id {current_user_id}"
         )
         return
-
+    
     def getContentId(metadata):
         return (
             metadata.get("track_id")
-            if content_type == "track"
+            if "track_id" in metadata
             else metadata.get("playlist_id")
         )
 
@@ -616,6 +616,7 @@ def _populate_gated_content_metadata(
     gated_content_ids = set([getContentId(metadata) for metadata in gated_entities])
     gated_content_access_args = []
     for entity in gated_entities:
+        content_type = "track" if entity.get("track_id") else "album"
         gated_content_access_args.append(
             {
                 "user_id": current_user_id,
@@ -926,7 +927,7 @@ def populate_playlist_metadata(
     # if so, also populate corresponding signatures.
     # if no current user (guest), populate access based on track stream/download conditions
     _populate_gated_content_metadata(
-        session, playlists, current_user_id, content_type="album"
+        session, playlists, current_user_id
     )
 
     track_ids = []

--- a/packages/discovery-provider/src/queries/search_es.py
+++ b/packages/discovery-provider/src/queries/search_es.py
@@ -261,7 +261,7 @@ def finalize_response(
             hydrate_saves_reposts(playlists, follow_saves, follow_reposts)
         hydrate_user(playlists, users_by_id)
         response[k] = [map_playlist(playlist, current_user) for playlist in playlists]
-        
+
         # batch populate gated playlist metadata
         db = get_db_read_replica()
         with db.scoped_session() as session:

--- a/packages/discovery-provider/src/queries/search_es.py
+++ b/packages/discovery-provider/src/queries/search_es.py
@@ -261,6 +261,11 @@ def finalize_response(
             hydrate_saves_reposts(playlists, follow_saves, follow_reposts)
         hydrate_user(playlists, users_by_id)
         response[k] = [map_playlist(playlist, current_user) for playlist in playlists]
+        
+        # batch populate gated playlist metadata
+        db = get_db_read_replica()
+        with db.scoped_session() as session:
+            _populate_gated_content_metadata(session, response[k], current_user_id)
 
     return response
 


### PR DESCRIPTION
### Description

We weren't processing gated access for albums before returning from feed. This led to client having no access data and failing to render the albums.

Removed the `content_type` flag from `_populate_gated_content_metadata` since it can be easily inferred from the structure of the entity.

### How Has This Been Tested?

Works on local stack. Feed returns access for albums where it didn't before