### PR TITLE
Fix TrackPriceHistory access for broken tracks

### DIFF
--- a/packages/discovery-provider/ddl/migrations/0070_fix_track_price_access.sql
+++ b/packages/discovery-provider/ddl/migrations/0070_fix_track_price_access.sql
@@ -1,0 +1,10 @@
+UPDATE track_price_history
+SET access = 'download'
+WHERE track_id IN (
+    SELECT tp.track_id
+    FROM track_price_history tp
+    JOIN tracks t ON t.track_id = tp.track_id
+    WHERE tp.access = 'stream'
+    AND t.is_stream_gated = false
+    AND t.is_download_gated = true
+);


### PR DESCRIPTION
### Description
This track was initially uploaded as stream-gated, but then later changed to download-gated: https://audius.co/DJSKT/dj-skt-pure-cold-shaq-rayes-pelota

We weren't updating the `TrackPriceHistory` row in the case where only `access` changed. Fix in this PR: https://github.com/AudiusProject/audius-protocol/pull/8498

This migration updates the `access` to `download` for tracks affected by this.

### How Has This Been Tested?

Tested query on stage DN 4. Also ran this query to make sure everything was good:
```
SELECT tp.track_id, t.owner_id
    from track_price_history tp
    JOIN tracks t ON t.track_id = tp.track_id
    WHERE tp.access != 'stream' and tp.access != 'download';
```