### PR TITLE
[PROTO-1824] Add country to csv download for sales

### DIFF
--- a/packages/discovery-provider/src/queries/download_csv.py
+++ b/packages/discovery-provider/src/queries/download_csv.py
@@ -61,6 +61,7 @@ def get_purchases_or_sales(user_id: int, is_purchases: bool):
                     USDCPurchase.created_at.label("created_at"),
                     USDCPurchase.amount.label("amount"),
                     USDCPurchase.extra_amount.label("extra_amount"),
+                    USDCPurchase.country.label("country"),
                     User.name.label("buyer_name"),
                 )
                 .join(User, User.user_id == USDCPurchase.buyer_user_id)
@@ -179,6 +180,7 @@ def download_sales(args: DownloadSalesArgs):
                 "date": result.created_at,
                 "value": get_dollar_amount(result.amount),
                 "pay extra": get_dollar_amount(result.extra_amount),
+                "country": result.country,
             },
             results,
         )


### PR DESCRIPTION
### Description

Country will exist after purchasing goes through sdk & payment router. Add support to CSV download so artists can see where their fans are buying from.

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._

Will wait to merge & test on stage after sdk purchases is turned on