### PR TITLE
[QA-1281] Fix twitter reserved handle check

### DIFF
--- a/packages/identity-service/src/config.js
+++ b/packages/identity-service/src/config.js
@@ -105,6 +105,12 @@ const config = convict({
     env: 'twitterAPISecret',
     default: null
   },
+  twitterBearerToken: {
+    doc: 'Twitter Bearer Token',
+    format: String,
+    env: 'twitterBearerToken',
+    default: null
+  },
   instagramAPIKey: {
     doc: 'Instagram API Key',
     format: String,


### PR DESCRIPTION
### Description

- Fixes issue where twitter handle checks were failing since we were on the old 1.1 api. Migrated to 2.0.
- Switches between two endpoints to double our rate-limit capacity

I think there is a chance that doRequest doesnt reject on 429, so may need to think more about that