### PR TITLE
[PAY-3018] Rework tile (pt 4) to fix collection page curved border

### DIFF
--- a/packages/web/src/components/tile/Tile.tsx
+++ b/packages/web/src/components/tile/Tile.tsx
@@ -43,23 +43,25 @@ export const Tile = forwardRef(
     } = props
 
     return (
-      <RootComponent
-        className={cn(
-          styles.root,
-          size && styles[size],
-          styles[elevation],
-          className
-        )}
-        type={onClick ? 'button' : undefined}
-        onClick={onClick}
-        ref={ref}
-        {...other}
-      >
+      <>
         {dogEar ? (
           <DogEar type={dogEar} className={styles.borderOffset} />
         ) : null}
-        {children}
-      </RootComponent>
+        <RootComponent
+          className={cn(
+            styles.root,
+            size && styles[size],
+            styles[elevation],
+            className
+          )}
+          type={onClick ? 'button' : undefined}
+          onClick={onClick}
+          ref={ref}
+          {...other}
+        >
+          {children}
+        </RootComponent>
+      </>
     )
   }
 )

--- a/packages/web/src/pages/collection-page/components/desktop/CollectionPage.module.css
+++ b/packages/web/src/pages/collection-page/components/desktop/CollectionPage.module.css
@@ -10,6 +10,7 @@
 .bodyWrapper {
   min-width: 774px;
   margin-bottom: var(--harmony-unit-10);
+  overflow: hidden;
 }
 
 /* Empty Page Section Wrapper */


### PR DESCRIPTION
### Description

More tile changes put the dog ear above the tile container. Same concept as I tried to do before, but no longer with an empty parent container. This works fine since the dog ear is absolutely positioned. This also allows `overflow: hidden` to be set without any issues

### How Has This Been Tested?

Made sure to go through every instance of Tile

- [x] ContextualMenu
![image](https://github.com/AudiusProject/audius-protocol/assets/6711655/3d9e18f8-9119-422d-b16d-4b7bfa3c79b3)

- [x] SuggestedTracks
![image](https://github.com/AudiusProject/audius-protocol/assets/6711655/04f88b89-33f1-44d5-931f-4bb745852b62)

- [x] GiantTrackTile
![image](https://github.com/AudiusProject/audius-protocol/assets/6711655/3c5755d1-b149-43b1-88b6-66c8728c77d3)

- [x] ServerGiantTrackTile
![image](https://github.com/AudiusProject/audius-protocol/assets/6711655/7403e0bd-26d5-43f8-91e7-1b4e3e78b82b)

- [x] UploadChip
![image](https://github.com/AudiusProject/audius-protocol/assets/6711655/ebf97d69-d799-4ea6-898e-d917c431df28)

- [x] CollectionPage
![image](https://github.com/AudiusProject/audius-protocol/assets/6711655/eea2cdef-0800-44f9-9dd2-aabee06cf551)

- [x] CollectionTrackField
![image](https://github.com/AudiusProject/audius-protocol/assets/6711655/1aa2f703-bc6f-47e1-97c9-5d0bf1b267fb)

- [x] ModalField 
This is unused at the moment; I believe this came from the previous "track override" feature. Probably can delete

- [x] StemsAndDownloadCollectionsField
This is unused at the moment; this came from the previous "track override" feature. Probably can delete 

- [x] EditCollectionForm
![image](https://github.com/AudiusProject/audius-protocol/assets/6711655/ac86bd5e-bb7d-41a3-a17b-58e38b67ffd7)

- [x] FinishPage
![image](https://github.com/AudiusProject/audius-protocol/assets/6711655/ec6ac9f5-5e37-4560-8da9-10886aa3d76b)

