### PR TITLE
[PAY-2978] Fix mobile tile spacing

### DIFF
--- a/packages/mobile/src/components/details-tile/DetailsTile.tsx
+++ b/packages/mobile/src/components/details-tile/DetailsTile.tsx
@@ -266,7 +266,7 @@ export const DetailsTile = ({
   }
 
   return (
-    <Paper>
+    <Paper mb='2xl' style={{overflow:'hidden'}}>
       {renderDogEar()}
       <Flex p='l' gap='l' alignItems='center' w='100%'>
         <Text

--- a/packages/mobile/src/components/details-tile/DetailsTile.tsx
+++ b/packages/mobile/src/components/details-tile/DetailsTile.tsx
@@ -266,7 +266,7 @@ export const DetailsTile = ({
   }
 
   return (
-    <Paper mb='2xl' style={{overflow:'hidden'}}>
+    <Paper mb='2xl' style={{ overflow: 'hidden' }}>
       {renderDogEar()}
       <Flex p='l' gap='l' alignItems='center' w='100%'>
         <Text

--- a/packages/mobile/src/components/lineup/Lineup.tsx
+++ b/packages/mobile/src/components/lineup/Lineup.tsx
@@ -100,8 +100,7 @@ const styles = StyleSheet.create({
     flex: 1
   },
   item: {
-    padding: 12,
-    paddingBottom: 0
+    padding: 12
   }
 })
 


### PR DESCRIPTION
### Description

Fixed:
- CollectionScreen now has plenty of bottom spacing
![2024-05-16 11 35 56](https://github.com/AudiusProject/audius-protocol/assets/6711655/26e31f03-73e8-4af1-95bc-f230f88a2300)
- CollectionScreen tile bottom has rounded borders now
- TrackScreen now has plenty of bottom spacing
![image](https://github.com/AudiusProject/audius-protocol/assets/6711655/82e0e4bf-6733-4b21-ab03-a8f5edd46109)


### How Has This Been Tested?

ios:stage