### PR TITLE
[PAY-3035] Fix mobile track owner actions not correct

### DIFF
--- a/packages/mobile/src/components/details-tile/DetailsTileActionButtons.tsx
+++ b/packages/mobile/src/components/details-tile/DetailsTileActionButtons.tsx
@@ -173,20 +173,19 @@ export const DetailsTileActionButtons = ({
   )
 
   const isAlbum = isCollection && collection?.is_album
-  const isCollectionOwner = isCollection && isOwner
 
   return (
     <Flex direction='row' justifyContent='center' gap='xl'>
       {hideShare ? null : shareButton}
-      {isCollectionOwner && !ddexApp
+      {isOwner && !ddexApp
         ? !isAlbum || isEditAlbumsEnabled
           ? editButton
           : null
         : hideRepost
         ? null
         : repostButton}
-      {isCollectionOwner || hideFavorite ? null : favoriteButton}
-      {isCollectionOwner && !isPublished && (!isAlbum || isEditAlbumsEnabled)
+      {isOwner || hideFavorite ? null : favoriteButton}
+      {isOwner && !isPublished && (!isAlbum || isEditAlbumsEnabled)
         ? publishButton
         : null}
       {hideOverflow ? null : overflowMenu}


### PR DESCRIPTION
### Description

Mobile track owner actions now match the redesign and have share/edit as the primary

![image](https://github.com/AudiusProject/audius-protocol/assets/6711655/9e5be5af-6ace-4a5c-a682-87f7667dd4ca)


### How Has This Been Tested?

ios:stage
- [x] Looks as expected for an owner
- [x] Looks as expected for non-owner on a public track 
- [x] Looks as expected for non-owner on an unowned premium track 