### PR TITLE
Don't show pay extra in purchase/sale email v2

### DIFF
--- a/packages/discovery-provider/plugins/notifications/src/email/notifications/preRendered/purchase.ts
+++ b/packages/discovery-provider/plugins/notifications/src/email/notifications/preRendered/purchase.ts
@@ -315,7 +315,7 @@ export const email = ({
 										</table>
 									</div> 
 									${
-                    payExtra
+                    payExtra !== '0.00'
                       ? `<div>
 										<table border="0" cellspacing="0" cellpadding="0" width="100%">
 										<tr><td align="left" valign="middle" bgcolor="#ffffff" style="padding: 12px 24px; border-top: 1px solid #f2f2f4;">

--- a/packages/discovery-provider/plugins/notifications/src/email/notifications/preRendered/sale.ts
+++ b/packages/discovery-provider/plugins/notifications/src/email/notifications/preRendered/sale.ts
@@ -319,7 +319,7 @@ export const email = ({
 										</table>
 									</div> 
 									${
-                    payExtra
+                    payExtra !== '0.00'
                       ? `<div>
 										<table border="0" cellspacing="0" cellpadding="0" width="100%">
 										<tr><td align="left" valign="middle" bgcolor="#ffffff" style="padding: 12px 24px; border-top: 1px solid #f2f2f4;">


### PR DESCRIPTION
### Description
Realized that `payExtra` is `0.00` which is not null/undefined. Need to compare with the `0.00` string directly.

### How Has This Been Tested?

Not tested, test on stage.