### PR TITLE
[PAY-3041] Fix green play button in TracksTable

### DIFF
--- a/packages/web/src/components/table/components/TablePlayButton.tsx
+++ b/packages/web/src/components/table/components/TablePlayButton.tsx
@@ -23,6 +23,7 @@ export const TablePlayButton = ({
   onClick,
   paused,
   playing = false,
+  isTrackPremium = false,
   isLocked = false
 }: TablePlayButtonProps) => {
   const {
@@ -31,19 +32,20 @@ export const TablePlayButton = ({
       primary: { p300 }
     }
   } = useTheme()
+  const shouldShowPremiumColor = isLocked && isTrackPremium
   return (
     <div onClick={onClick} className={cn(styles.tablePlayButton, className)}>
       {playing && !paused ? (
         <IconPause
           className={styles.icon}
-          fill={isLocked ? lightGreen : p300}
+          fill={shouldShowPremiumColor ? lightGreen : p300}
         />
       ) : (
         <IconPlay
           className={cn(styles.icon, {
             [styles.hideDefault]: hideDefault && !playing
           })}
-          fill={isLocked ? lightGreen : p300}
+          fill={shouldShowPremiumColor ? lightGreen : p300}
         />
       )}
     </div>

--- a/packages/web/src/components/table/components/TablePlayButton.tsx
+++ b/packages/web/src/components/table/components/TablePlayButton.tsx
@@ -14,7 +14,7 @@ type TablePlayButtonProps = {
   paused?: boolean
   playing?: boolean
   isTrackPremium?: boolean
-  isOwned?: boolean
+  isLocked?: boolean
 }
 
 export const TablePlayButton = ({
@@ -23,29 +23,27 @@ export const TablePlayButton = ({
   onClick,
   paused,
   playing = false,
-  isTrackPremium = false,
-  isOwned = false
+  isLocked = false
 }: TablePlayButtonProps) => {
   const {
     color: {
-      special,
+      special: { lightGreen },
       primary: { p300 }
     }
   } = useTheme()
-  const showPremiumColor = isOwned && isTrackPremium
   return (
     <div onClick={onClick} className={cn(styles.tablePlayButton, className)}>
       {playing && !paused ? (
         <IconPause
           className={styles.icon}
-          fill={showPremiumColor ? special.lightGreen : p300}
+          fill={isLocked ? lightGreen : p300}
         />
       ) : (
         <IconPlay
           className={cn(styles.icon, {
             [styles.hideDefault]: hideDefault && !playing
           })}
-          fill={showPremiumColor ? special.lightGreen : p300}
+          fill={isLocked ? lightGreen : p300}
         />
       )}
     </div>

--- a/packages/web/src/components/track/desktop/TrackListItem.tsx
+++ b/packages/web/src/components/track/desktop/TrackListItem.tsx
@@ -1,7 +1,10 @@
 import { memo, MouseEvent, useRef } from 'react'
 
 import { useGetCurrentUserId } from '@audius/common/api'
-import { useIsGatedContentPlaylistAddable } from '@audius/common/hooks'
+import {
+  useGatedContentAccess,
+  useIsGatedContentPlaylistAddable
+} from '@audius/common/hooks'
 import {
   ID,
   isContentUSDCPurchaseGated,
@@ -65,6 +68,7 @@ const TrackListItem = ({
   const isOwner = track?.owner_id === currentUserId
   const isPlaylistAddable = useIsGatedContentPlaylistAddable(track as Track)
   const isPremium = isContentUSDCPurchaseGated(track?.stream_conditions)
+  const { hasStreamAccess } = useGatedContentAccess(track as Track)
 
   if (forceSkeleton) {
     return (
@@ -170,7 +174,7 @@ const TrackListItem = ({
               paused={!playing}
               hideDefault={false}
               isTrackPremium={isPremium}
-              isOwned={isOwner}
+              isLocked={!hasStreamAccess}
             />
           </div>
         ) : null}

--- a/packages/web/src/components/track/mobile/TrackListItem.tsx
+++ b/packages/web/src/components/track/mobile/TrackListItem.tsx
@@ -198,7 +198,7 @@ const TrackListItem = ({
             paused={!isPlaying}
             hideDefault={false}
             isTrackPremium={isPremium}
-            isOwned={!isLocked}
+            isLocked={isLocked}
           />
         </div>
       ) : null}

--- a/packages/web/src/components/tracks-table/TracksTable.tsx
+++ b/packages/web/src/components/tracks-table/TracksTable.tsx
@@ -188,7 +188,7 @@ export const TracksTable = ({
             playing={active}
             hideDefault={false}
             isTrackPremium={isTrackPremium && isPremiumEnabled}
-            isOwned={!isLocked}
+            isLocked={isLocked}
           />
           {isTrackUnlisted ? (
             <IconVisibilityHidden


### PR DESCRIPTION
### Description
Small logic fix to not show green play buttons for owner case.

### How Has This Been Tested?
owner:
<img width="1187" alt="Screenshot 2024-05-16 at 7 23 03 PM" src="https://github.com/AudiusProject/audius-protocol/assets/3893871/81b30f06-2e87-4a0e-9b78-a87df28581c7">

locked:
<img width="1165" alt="Screenshot 2024-05-16 at 7 23 58 PM" src="https://github.com/AudiusProject/audius-protocol/assets/3893871/806f087a-a03d-4b15-a293-ad96d220db3f">

unlocked:
<img width="1129" alt="Screenshot 2024-05-16 at 7 26 26 PM" src="https://github.com/AudiusProject/audius-protocol/assets/3893871/a822f7a1-f133-4e27-8fa4-dcc571c05c0e">

TrackListItem locked:
<img width="993" alt="Screenshot 2024-05-16 at 9 09 47 PM" src="https://github.com/AudiusProject/audius-protocol/assets/3893871/222903c7-6e2d-4f1f-a144-ec079b59249d">

TrackListItem public:
<img width="1005" alt="Screenshot 2024-05-16 at 9 09 43 PM" src="https://github.com/AudiusProject/audius-protocol/assets/3893871/8945df51-8952-4c70-b907-559039a6ac1d">
