### PR TITLE
[PAY-3042] Enable mobile feed tap to preview for collections

### DIFF
--- a/packages/mobile/src/components/lineup-tile/CollectionTile.tsx
+++ b/packages/mobile/src/components/lineup-tile/CollectionTile.tsx
@@ -7,7 +7,8 @@ import {
   FavoriteSource,
   PlaybackSource,
   FavoriteType,
-  SquareSizes
+  SquareSizes,
+  isContentUSDCPurchaseGated
 } from '@audius/common/models'
 import type { Collection, Track, User } from '@audius/common/models'
 import {
@@ -28,6 +29,7 @@ import { useDispatch, useSelector } from 'react-redux'
 
 import type { ImageProps } from '@audius/harmony-native'
 import { CollectionImage } from 'app/components/image/CollectionImage'
+import { useIsUSDCEnabled } from 'app/hooks/useIsUSDCEnabled'
 import { useNavigation } from 'app/hooks/useNavigation'
 import { setVisibility } from 'app/store/drawers/slice'
 import { getIsCollectionMarkedForDownload } from 'app/store/offline-downloads/selectors'
@@ -105,6 +107,7 @@ const CollectionTileComponent = ({
   variant,
   ...lineupTileProps
 }: CollectionTileProps) => {
+  const isUSDCEnabled = useIsUSDCEnabled()
   const dispatch = useDispatch()
   const navigation = useNavigation()
   const currentUserId = useSelector(getUserId)
@@ -123,8 +126,12 @@ const CollectionTileComponent = ({
     is_album,
     playlist_id,
     playlist_name,
-    playlist_owner_id
+    playlist_owner_id,
+    stream_conditions
   } = collection
+
+  const hasPreview =
+    isUSDCEnabled && isContentUSDCPurchaseGated(stream_conditions)
 
   const isOwner = playlist_owner_id === currentUserId
 
@@ -255,6 +262,7 @@ const CollectionTileComponent = ({
       onPressSave={handlePressSave}
       onPressShare={handlePressShare}
       onPressTitle={handlePressTitle}
+      hasPreview={hasPreview}
       title={playlist_name}
       item={collection}
       user={user}


### PR DESCRIPTION
### Description

The tile thought there was no preview so it fails

### How Has This Been Tested?

working on local sim