### PR TITLE
fix integration tests

### DIFF
--- a/packages/identity-service/default-config.json
+++ b/packages/identity-service/default-config.json
@@ -7,6 +7,7 @@
   "ipdataAPIKey": "",
   "twitterAPIKey": "",
   "twitterAPISecret": "",
+  "twitterBearerToken": "",
   "tikTokAPIKey": "",
   "tikTokAPISecret": "",
   "tikTokAuthOrigin": "",


### PR DESCRIPTION
### Description

twitterBearerToken (introduced here https://github.com/AudiusProject/audius-protocol/pull/8509) does not have the correct value for a default and the config rightfully throws an error. This adds the correct default per the default_config.json (which we should remove anyways later) like all the other default values.

### How Has This Been Tested?
anything that uses `audius-compose test ...`
