### PR TITLE
Fix reward in cooldown button

### DIFF
--- a/packages/common/src/store/pages/audio-rewards/types.ts
+++ b/packages/common/src/store/pages/audio-rewards/types.ts
@@ -31,7 +31,7 @@ export type UndisbursedUserChallenge = Pick<
   handle: string
   wallet: string
   created_at: string
-  cooldown_days?: number
+    cooldown_days?: number
 }
 
 export enum HCaptchaStatus {

--- a/packages/common/src/store/pages/audio-rewards/types.ts
+++ b/packages/common/src/store/pages/audio-rewards/types.ts
@@ -31,7 +31,7 @@ export type UndisbursedUserChallenge = Pick<
   handle: string
   wallet: string
   created_at: string
-    cooldown_days?: number
+  cooldown_days?: number
 }
 
 export enum HCaptchaStatus {

--- a/packages/mobile/src/components/challenge-rewards-drawer/ChallengeRewardsDrawerContent.tsx
+++ b/packages/mobile/src/components/challenge-rewards-drawer/ChallengeRewardsDrawerContent.tsx
@@ -104,6 +104,7 @@ export const ChallengeRewardsDrawerContent = ({
   const palette = useThemePalette()
   const isInProgress = challengeState === 'in_progress'
   const isClaimable = claimableAmount > 0
+  console.log('asdf isClaimable: ', isClaimable)
   const {
     cooldownChallenges,
     summary,
@@ -213,7 +214,6 @@ export const ChallengeRewardsDrawerContent = ({
             </Text>
           </View>
         </View>
-        {children}
         <View style={styles.claimRewardsContainer}>
           {isCooldownChallenge && isRewardsCooldownEnabled ? (
             renderCooldownSummaryTable()
@@ -251,6 +251,7 @@ export const ChallengeRewardsDrawerContent = ({
           ) : null}
           {claimError ? <ClaimError aaoErrorCode={aaoErrorCode} /> : null}
         </View>
+        {children}
       </ScrollView>
       {isClaimable &&
       onClaim &&

--- a/packages/mobile/src/components/challenge-rewards-drawer/ChallengeRewardsDrawerContent.tsx
+++ b/packages/mobile/src/components/challenge-rewards-drawer/ChallengeRewardsDrawerContent.tsx
@@ -215,32 +215,30 @@ export const ChallengeRewardsDrawerContent = ({
         </View>
         {children}
         <View style={styles.claimRewardsContainer}>
-          {isClaimable && onClaim ? (
-            isCooldownChallenge && isRewardsCooldownEnabled ? (
-              renderCooldownSummaryTable()
-            ) : (
-              <>
-                <Text
-                  key='claimableAmount'
-                  style={styles.claimableAmount}
-                  variant='label'
-                  strength='strong'
-                  textTransform='uppercase'
-                >
-                  {claimableAmountText}
-                </Text>
-                <Button
-                  style={styles.claimButton}
-                  variant={claimInProgress ? 'secondary' : 'primary'}
-                  isLoading={claimInProgress}
-                  onPress={onClaim}
-                  iconLeft={IconCheck}
-                >
-                  {messages.claim}
-                </Button>
-              </>
-            )
-          ) : null}
+          {isCooldownChallenge && isRewardsCooldownEnabled ? (
+            renderCooldownSummaryTable()
+          ) : (
+            <>
+              <Text
+                key='claimableAmount'
+                style={styles.claimableAmount}
+                variant='label'
+                strength='strong'
+                textTransform='uppercase'
+              >
+                {claimableAmountText}
+              </Text>
+              <Button
+                style={styles.claimButton}
+                variant={claimInProgress ? 'secondary' : 'primary'}
+                isLoading={claimInProgress}
+                onPress={onClaim}
+                iconLeft={IconCheck}
+              >
+                {messages.claim}
+              </Button>
+            </>
+          )}
           {claimedAmount > 0 && challengeState !== 'disbursed' ? (
             <Text
               variant='label'

--- a/packages/mobile/src/components/challenge-rewards-drawer/ChallengeRewardsDrawerProvider.tsx
+++ b/packages/mobile/src/components/challenge-rewards-drawer/ChallengeRewardsDrawerProvider.tsx
@@ -84,7 +84,7 @@ export const ChallengeRewardsDrawerProvider = () => {
     audioToClaim = challenge.claimableAmount
     audioClaimedSoFar = challenge.disbursed_amount
   } else if (challenge?.state === 'completed') {
-    audioToClaim = challenge.totalAmount
+    audioToClaim = challenge.claimableAmount
     audioClaimedSoFar = 0
   } else if (challenge?.state === 'disbursed') {
     audioToClaim = 0
@@ -143,7 +143,7 @@ export const ChallengeRewardsDrawerProvider = () => {
 
   // Challenge drawer contents
   let contents: Maybe<React.ReactElement>
-  if (challenge?.state && challenge?.state !== 'completed') {
+  if (!audioToClaim) {
     switch (modalType) {
       case 'referrals':
       case 'ref-v':

--- a/packages/mobile/src/components/challenge-rewards-drawer/styles.ts
+++ b/packages/mobile/src/components/challenge-rewards-drawer/styles.ts
@@ -87,7 +87,7 @@ export const useStyles = makeStyles(({ palette, spacing, typography }) => ({
     width: '100%'
   },
   claimRewardsContainer: {
-    marginTop: spacing(4),
+    marginVertical: spacing(4),
     width: '100%'
   },
   claimRewardsError: {

--- a/packages/web/src/pages/audio-rewards-page/components/modals/ChallengeRewardsModal/ChallengeRewardsModal.tsx
+++ b/packages/web/src/pages/audio-rewards-page/components/modals/ChallengeRewardsModal/ChallengeRewardsModal.tsx
@@ -275,12 +275,13 @@ const ChallengeRewardsBody = ({ dismissModal }: BodyProps) => {
     audioToClaim = challenge.claimableAmount
     audioClaimedSoFar = challenge.disbursed_amount
   } else if (challenge?.state === 'completed') {
-    audioToClaim = challenge.totalAmount
+    audioToClaim = challenge.claimableAmount
     audioClaimedSoFar = 0
   } else if (challenge?.state === 'disbursed') {
     audioToClaim = 0
     audioClaimedSoFar = challenge.totalAmount
   }
+  console.log('asdf challenge:', challenge, audioToClaim, audioClaimedSoFar)
 
   let linkType: 'complete' | 'inProgress' | 'incomplete'
   if (challenge?.state === 'completed') {
@@ -563,7 +564,7 @@ const ChallengeRewardsBody = ({ dismissModal }: BodyProps) => {
         )}
         {renderReferralContent()}
         {renderMobileInstallContent()}
-        {buttonLink && challenge?.state !== 'completed' ? (
+        {buttonLink && !audioToClaim ? (
           <Button
             variant='primary'
             fullWidth={isMobile}

--- a/packages/web/src/pages/audio-rewards-page/components/modals/ChallengeRewardsModal/ChallengeRewardsModal.tsx
+++ b/packages/web/src/pages/audio-rewards-page/components/modals/ChallengeRewardsModal/ChallengeRewardsModal.tsx
@@ -281,7 +281,6 @@ const ChallengeRewardsBody = ({ dismissModal }: BodyProps) => {
     audioToClaim = 0
     audioClaimedSoFar = challenge.totalAmount
   }
-  console.log('asdf challenge:', challenge, audioToClaim, audioClaimedSoFar)
 
   let linkType: 'complete' | 'inProgress' | 'incomplete'
   if (challenge?.state === 'completed') {


### PR DESCRIPTION
### Description
Cooldown state shows $AUDIO is claimable in web and mobile on individual reward (claim all is OK).
<img width="709" alt="Screenshot 2024-05-17 at 8 45 43 AM" src="https://github.com/AudiusProject/audius-protocol/assets/6413636/92b9814e-292e-4ddf-8a7b-2ae7af81fae7">



### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._

Cooldown state is not claimable. 

<img width="1520" alt="Screenshot 2024-05-17 at 8 44 42 AM" src="https://github.com/AudiusProject/audius-protocol/assets/6413636/d859e91e-4a70-452f-92a2-b029bd6e4f1f">
