### PR TITLE
[PAY-2873] Force re-fetch collection when fetchLineup is true

### DIFF
--- a/packages/web/src/common/store/pages/collection/sagas.js
+++ b/packages/web/src/common/store/pages/collection/sagas.js
@@ -31,13 +31,15 @@ function* watchFetchCollection() {
         permalink,
         {
           requiresAllTracks: true,
-          deleteExistingEntry: true
+          deleteExistingEntry: true,
+          forceRetrieveFromSource: fetchLineup
         }
       )
     } else {
       retrievedCollections = yield call(retrieveCollections, [collectionId], {
         requiresAllTracks: true,
-        deleteExistingEntry: true
+        deleteExistingEntry: true,
+        forceRetrieveFromSource: fetchLineup
       })
     }
 


### PR DESCRIPTION
### Description
Not 100% confident in this PR. It seems like `fetchLineup` is a proxy for "force refetch"? Not sure though. But if not we could add a separate flag.

### How Has This Been Tested?

Tried the repro case outlined in the linear - works.

- Make premium album with account a
- Buy premium album with account b
- Have account a add new track to premium album
- In-app notif shows up, but going to album (without page refresh) does not include newly added track to premium album
