### PR TITLE
[QA-1294] Refetch tracks on reorder

### DIFF
--- a/packages/mobile/src/components/add-to-collection-drawer/AddToCollectionDrawer.tsx
+++ b/packages/mobile/src/components/add-to-collection-drawer/AddToCollectionDrawer.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useMemo, useState } from 'react'
 
 import type { Collection } from '@audius/common/models'
-import { CreatePlaylistSource, SquareSizes } from '@audius/common/models'
+import { CreatePlaylistSource } from '@audius/common/models'
 import type { CommonState } from '@audius/common/store'
 import {
   accountSelectors,
@@ -15,16 +15,14 @@ import { View } from 'react-native'
 import { useDispatch, useSelector } from 'react-redux'
 import { useEffectOnce } from 'react-use'
 
-import type { ImageProps } from '@audius/harmony-native'
-import { Card } from 'app/components/card'
 import { AppDrawer, useDrawerState } from 'app/components/drawer'
-import { CollectionImage } from 'app/components/image/CollectionImage'
 import { useToast } from 'app/hooks/useToast'
-import { makeStyles, shadow } from 'app/styles'
+import { makeStyles } from 'app/styles'
 import { fuzzySearch } from 'app/utils/fuzzySearch'
 
 import { CollectionList } from '../collection-list'
 import { AddCollectionCard } from '../collection-list/AddCollectionCard'
+import { CollectionCard } from '../collection-list/CollectionCard'
 import { FilterInput } from '../filter-input'
 
 const { addTrackToPlaylist, createAlbum, createPlaylist } =
@@ -57,15 +55,6 @@ const getMessages = (collectionType: 'album' | 'playlist') => ({
 })
 
 const useStyles = makeStyles(() => ({
-  buttonContainer: {
-    alignSelf: 'center',
-    borderRadius: 4,
-    marginBottom: 16,
-    ...shadow()
-  },
-  button: {
-    width: 256
-  },
   cardList: {
     paddingBottom: 240
   }
@@ -134,15 +123,10 @@ export const AddToCollectionDrawer = () => {
           collectionType={collectionType}
         />
       ) : (
-        <Card
-          style={{ opacity: isTrackUnlisted && !item.is_private ? 0.5 : 1 }}
+        <CollectionCard
           key={item.playlist_id}
-          type='collection'
           id={item.playlist_id}
-          primaryText={item.playlist_name}
-          secondaryText={messages.tracks(
-            item.playlist_contents.track_ids.length
-          )}
+          noNavigation
           onPress={() => {
             if (!trackId) return
 
@@ -170,13 +154,6 @@ export const AddToCollectionDrawer = () => {
             }
             onClose()
           }}
-          renderImage={(props?: ImageProps) => (
-            <CollectionImage
-              collection={item}
-              size={SquareSizes.SIZE_480_BY_480}
-              {...props}
-            />
-          )}
         />
       ),
     [

--- a/packages/mobile/src/components/collection-list/CollectionCard.tsx
+++ b/packages/mobile/src/components/collection-list/CollectionCard.tsx
@@ -40,10 +40,11 @@ const messages = {
 type CollectionCardProps = {
   id: ID
   onPress?: (e: GestureResponderEvent) => void
+  noNavigation?: boolean
 }
 
 export const CollectionCard = (props: CollectionCardProps) => {
-  const { id, onPress } = props
+  const { id, onPress, noNavigation } = props
 
   const collection = useSelector((state) => getCollection(state, { id }))
   const accountId = useSelector(getUserId)
@@ -53,9 +54,10 @@ export const CollectionCard = (props: CollectionCardProps) => {
   const handlePress = useCallback(
     (e: GestureResponderEvent) => {
       onPress?.(e)
+      if (noNavigation) return
       navigation.navigate('Collection', { id })
     },
-    [onPress, navigation, id]
+    [onPress, noNavigation, navigation, id]
   )
 
   if (!collection) {

--- a/packages/mobile/src/screens/collection-screen/useFetchCollectionLineup.ts
+++ b/packages/mobile/src/screens/collection-screen/useFetchCollectionLineup.ts
@@ -1,4 +1,4 @@
-import { useCallback } from 'react'
+import { useCallback, useEffect } from 'react'
 
 import type { SmartCollectionVariant } from '@audius/common/models'
 import { Kind } from '@audius/common/models'
@@ -16,6 +16,8 @@ import { useDispatch, useSelector } from 'react-redux'
 import { useIsOfflineModeEnabled } from 'app/hooks/useIsOfflineModeEnabled'
 import { useReachabilityEffect } from 'app/hooks/useReachabilityEffect'
 import { getOfflineTrackIds } from 'app/store/offline-downloads/selectors'
+
+import { useHasCollectionChanged } from './useHasCollectionChanged'
 
 const { getCollection } = cacheCollectionsSelectors
 const { getCollectionTracksLineup } = collectionPageSelectors
@@ -129,4 +131,5 @@ export const useFetchCollectionLineup = (
 
   // Fetch the lineup based on reachability
   useReachabilityEffect(fetchLineup, fetchLineupOffline)
+  useHasCollectionChanged(collectionId as number, fetchLineup)
 }

--- a/packages/mobile/src/screens/collection-screen/useHasCollectionChanged.tsx
+++ b/packages/mobile/src/screens/collection-screen/useHasCollectionChanged.tsx
@@ -1,0 +1,32 @@
+import { useEffect } from 'react'
+
+import type { ID } from '@audius/common/models'
+import { cacheCollectionsSelectors } from '@audius/common/store'
+import { isEqual } from 'lodash'
+import { useSelector } from 'react-redux'
+import { usePrevious } from 'react-use'
+
+const { getCollection } = cacheCollectionsSelectors
+
+export const useHasCollectionChanged = (
+  collectionId: ID,
+  callback: () => void
+) => {
+  const trackIds = useSelector((state) =>
+    getCollection(state, { id: collectionId })?.playlist_contents.track_ids.map(
+      (track: any) => track.track
+    )
+  )
+
+  const previousTrackIds = usePrevious(trackIds)
+
+  const hasCollectionChanged =
+    trackIds && previousTrackIds && !isEqual(trackIds, previousTrackIds)
+
+  useEffect(() => {
+    if (hasCollectionChanged) {
+      console.log('refetching')
+      callback()
+    }
+  }, [hasCollectionChanged, callback])
+}


### PR DESCRIPTION
### Description

Fixes issue where collection lineup does not refetch when tracks are added/removed/reordered
Also fixes issue with add-to-collection drawer rendering old cards.