### PR TITLE
[C-4402] Use completed at for cooldown check

### DIFF
--- a/packages/common/src/hooks/purchaseContent/useChallengeCooldownSchedule.ts
+++ b/packages/common/src/hooks/purchaseContent/useChallengeCooldownSchedule.ts
@@ -22,10 +22,10 @@ const getCooldownChallengeInfo = (
   challenge: UndisbursedUserChallenge,
   now: Dayjs
 ) => {
-  const createdAt = utcToLocalTime(challenge.created_at)
+  const completedAt = utcToLocalTime(challenge.completed_at)
   const cooldownDays = challenge.cooldown_days ?? 0
-  const diff = now.diff(createdAt, 'day')
-  const claimableDate = createdAt.add(cooldownDays, 'day')
+  const diff = now.diff(completedAt, 'day')
+  const claimableDate = completedAt.add(cooldownDays, 'day')
   const isClose = cooldownDays - diff <= 1
   let label = claimableDate.format('dddd')
   if (diff === cooldownDays) {
@@ -47,8 +47,8 @@ export const formatCooldownChallenges = (
   const now = dayjs().endOf('day')
   const cooldownChallenges = new Array(challenges[0].cooldown_days)
   challenges.forEach((c) => {
-    const createdAt = utcToLocalTime(c.created_at)
-    const diff = now.diff(createdAt, 'day')
+    const completedAt = utcToLocalTime(c.completed_at)
+    const diff = now.diff(completedAt, 'day')
     cooldownChallenges[diff] = {
       ...cooldownChallenges[diff],
       id: c.specifier,
@@ -74,7 +74,6 @@ export const useChallengeCooldownSchedule = ({
   const challenges = useSelector(getUndisbursedUserChallenges)
     .filter((c) => multiple || c.challenge_id === challengeId)
     .filter((c) => !TRENDING_CHALLENGE_IDS.has(c.challenge_id))
-    .map((c) => ({ ...c, createdAtDate: dayjs.utc(c.created_at) }))
 
   const [claimableChallenges, cooldownChallenges] = partition(
     challenges,

--- a/packages/common/src/store/pages/audio-rewards/types.ts
+++ b/packages/common/src/store/pages/audio-rewards/types.ts
@@ -31,6 +31,7 @@ export type UndisbursedUserChallenge = Pick<
   handle: string
   wallet: string
   created_at: string
+  completed_at: string
   cooldown_days?: number
 }
 

--- a/packages/common/src/utils/challenges.ts
+++ b/packages/common/src/utils/challenges.ts
@@ -255,7 +255,7 @@ export const isCooldownChallengeClaimable = (
 ) => {
   return (
     challenge.cooldown_days === undefined ||
-    dayjs.utc().diff(dayjs.utc(challenge.created_at), 'day') >=
+    dayjs.utc().diff(dayjs.utc(challenge.completed_at), 'day') >=
       challenge.cooldown_days
   )
 }

--- a/packages/discovery-provider/integration_tests/queries/test_undisbursed_challenges.py
+++ b/packages/discovery-provider/integration_tests/queries/test_undisbursed_challenges.py
@@ -74,6 +74,7 @@ def setup_challenges(app):
                 current_step_count=1,
                 amount=5,
                 created_at="2023-10-16 17:51:31.105065+00",
+                completed_at="2023-10-16 17:51:31.105065+00",
             ),
             UserChallenge(
                 challenge_id="test_challenge_1",
@@ -84,6 +85,7 @@ def setup_challenges(app):
                 completed_blocknumber=100,
                 amount=5,
                 created_at="2023-10-16 17:51:31.105065+00",
+                completed_at="2023-10-16 17:51:31.105065+00",
             ),
             UserChallenge(
                 challenge_id="test_challenge_2",
@@ -92,6 +94,7 @@ def setup_challenges(app):
                 is_complete=False,
                 amount=5,
                 created_at="2023-10-16 17:51:31.105065+00",
+                completed_at="2023-10-16 17:51:31.105065+00",
             ),
             UserChallenge(
                 challenge_id="test_challenge_2",
@@ -101,6 +104,7 @@ def setup_challenges(app):
                 completed_blocknumber=102,
                 amount=5,
                 created_at="2023-10-16 17:51:31.105065+00",
+                completed_at="2023-10-16 17:51:31.105065+00",
             ),
             UserChallenge(
                 challenge_id="test_challenge_2",
@@ -110,6 +114,7 @@ def setup_challenges(app):
                 completed_blocknumber=102,
                 amount=5,
                 created_at="2023-10-16 17:51:31.105065+00",
+                completed_at="2023-10-16 17:51:31.105065+00",
             ),
             UserChallenge(
                 challenge_id="test_challenge_3",
@@ -119,6 +124,7 @@ def setup_challenges(app):
                 completed_blocknumber=100,
                 amount=5,
                 created_at="2023-10-16 17:51:31.105065+00",
+                completed_at="2023-10-16 17:51:31.105065+00",
             ),
         ]
 
@@ -153,6 +159,7 @@ def test_undisbursed_challenges(app):
                 "handle": "TestHandle6",
                 "wallet": "0x6",
                 "created_at": "2023-10-16 17:51:31.105065+00:00",
+                "completed_at": "2023-10-16 17:51:31.105065",
                 "cooldown_days": None,
             },
             {
@@ -164,6 +171,7 @@ def test_undisbursed_challenges(app):
                 "handle": "TestHandle4",
                 "wallet": "0x4",
                 "created_at": "2023-10-16 17:51:31.105065+00:00",
+                "completed_at": "2023-10-16 17:51:31.105065",
                 "cooldown_days": None,
             },
             {
@@ -175,6 +183,7 @@ def test_undisbursed_challenges(app):
                 "handle": "TestHandle5",
                 "wallet": "0x5",
                 "created_at": "2023-10-16 17:51:31.105065+00:00",
+                "completed_at": "2023-10-16 17:51:31.105065",
                 "cooldown_days": None,
             },
         ]
@@ -196,6 +205,7 @@ def test_undisbursed_challenges(app):
                 "handle": "TestHandle6",
                 "wallet": "0x6",
                 "created_at": "2023-10-16 17:51:31.105065+00:00",
+                "completed_at": "2023-10-16 17:51:31.105065",
                 "cooldown_days": None,
             },
         ]

--- a/packages/discovery-provider/src/queries/get_undisbursed_challenges.py
+++ b/packages/discovery-provider/src/queries/get_undisbursed_challenges.py
@@ -17,6 +17,7 @@ class UndisbursedChallengeResponse(TypedDict):
     handle: str
     wallet: str
     created_at: str
+    completed_at: str
     cooldown_days: Optional[int]
 
 
@@ -35,6 +36,7 @@ def to_challenge_response(
         "handle": handle,
         "wallet": wallet,
         "created_at": str(user_challenge.created_at),
+        "completed_at": str(user_challenge.completed_at),
         "cooldown_days": challenge.cooldown_days,
     }
 


### PR DESCRIPTION
### Description

Use the completed timestamp instead of the created timestamp to determine when a cooldown challenge reward is claimable.

Note that this change must first be deployed to the DNs before clients so that the `completed_at` field is returned to clients for use.

Fyi, The backend fix was in [this pr](https://github.com/AudiusProject/audius-protocol/pull/8419/files).

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._
