### PR TITLE
Lint check should actually fail, not modify in place.

### DIFF
--- a/.circleci/src/jobs/@discovery-jobs.yml
+++ b/.circleci/src/jobs/@discovery-jobs.yml
@@ -35,9 +35,9 @@ lint-discovery-provider:
         name: Lint
         command: |
           cd packages/discovery-provider
-          isort .
+          isort --check --diff .
           flake8 .
-          black .
+          black --check --diff .
 
     - run:
         name: Typecheck


### PR DESCRIPTION
### Description

The lint job has been modifying files in place instead of enforcing formatting.

### How Has This Been Tested?

CI