### PR TITLE
Filter out all premium content on USDC_PURCHASES flag

### DIFF
--- a/packages/web/src/common/store/lineup/sagas.ts
+++ b/packages/web/src/common/store/lineup/sagas.ts
@@ -97,7 +97,6 @@ function* filterDeletes<T extends Track | Collection>(
       // Remove this when removing the feature flags
       if (
         !isUSDCGatedContentEnabled &&
-        'track_id' in metadata &&
         metadata.is_stream_gated &&
         isContentUSDCPurchaseGated(metadata.stream_conditions)
       ) {


### PR DESCRIPTION
### Description
Filter out *ALL* premium content when `USDC_PURCHASES` flag is disabled, not just tracks.

Currently we have another filter below this one that filters out specifically albums, but on the `PREMIUM_ALBUMS_ENABLED` flag.

### How Has This Been Tested?

Not tested..

