### PR TITLE
[PAY-2873] Add forceRefetch flag to collection fetching on web

### DIFF
--- a/packages/common/src/store/pages/collection/actions.ts
+++ b/packages/common/src/store/pages/collection/actions.ts
@@ -20,6 +20,7 @@ export type FetchCollectionAction = {
   id: ID | null
   permalink?: string
   fetchLineup?: boolean
+  forceFetch?: boolean
 }
 
 export type FetchCollectionSucceededAction = {
@@ -57,12 +58,14 @@ export type CollectionPageAction =
 export const fetchCollection = (
   id: number | null,
   permalink?: string,
-  fetchLineup?: boolean
+  fetchLineup?: boolean,
+  forceFetch?: boolean
 ): FetchCollectionAction => ({
   type: FETCH_COLLECTION,
   id,
   permalink,
-  fetchLineup
+  fetchLineup,
+  forceFetch
 })
 
 export const fetchCollectionSucceeded = (

--- a/packages/web/src/common/store/pages/collection/sagas.js
+++ b/packages/web/src/common/store/pages/collection/sagas.js
@@ -32,14 +32,14 @@ function* watchFetchCollection() {
         {
           requiresAllTracks: true,
           deleteExistingEntry: true,
-          forceRetrieveFromSource: forceFetch ?? false
+          forceRetrieveFromSource: forceFetch
         }
       )
     } else {
       retrievedCollections = yield call(retrieveCollections, [collectionId], {
         requiresAllTracks: true,
         deleteExistingEntry: true,
-        forceRetrieveFromSource: forceFetch ?? false
+        forceRetrieveFromSource: forceFetch
       })
     }
 

--- a/packages/web/src/common/store/pages/collection/sagas.js
+++ b/packages/web/src/common/store/pages/collection/sagas.js
@@ -23,7 +23,7 @@ const { getIsReachable } = reachabilitySelectors
 
 function* watchFetchCollection() {
   yield takeLatest(collectionActions.FETCH_COLLECTION, function* (action) {
-    const { id: collectionId, permalink, fetchLineup } = action
+    const { id: collectionId, permalink, fetchLineup, forceFetch } = action
     let retrievedCollections
     if (permalink) {
       retrievedCollections = yield call(
@@ -31,13 +31,15 @@ function* watchFetchCollection() {
         permalink,
         {
           requiresAllTracks: true,
-          deleteExistingEntry: true
+          deleteExistingEntry: true,
+          forceRetrieveFromSource: forceFetch ?? false
         }
       )
     } else {
       retrievedCollections = yield call(retrieveCollections, [collectionId], {
         requiresAllTracks: true,
-        deleteExistingEntry: true
+        deleteExistingEntry: true,
+        forceRetrieveFromSource: forceFetch ?? false
       })
     }
 

--- a/packages/web/src/components/notification/Notification/TrackAddedToPurchasedAlbumNotification.tsx
+++ b/packages/web/src/components/notification/Notification/TrackAddedToPurchasedAlbumNotification.tsx
@@ -45,7 +45,7 @@ export const TrackAddedToPurchasedAlbumNotification = (
   const dispatch = useDispatch()
 
   const handleClick = useCallback(() => {
-    dispatch(push(getEntityLink(playlist)))
+    dispatch(push(getEntityLink(playlist), { forceFetch: true }))
   }, [playlist, dispatch])
 
   if (!playlistOwner || !track) return null

--- a/packages/web/src/pages/collection-page/CollectionPageProvider.tsx
+++ b/packages/web/src/pages/collection-page/CollectionPageProvider.tsx
@@ -884,8 +884,7 @@ function mapDispatchToProps(dispatch: Dispatch) {
       permalink?: string
       fetchLineup?: boolean
       forceFetch?: boolean
-    }) => {
-      console.log('REED got action')
+    }) =>
       dispatch(
         collectionActions.fetchCollection(
           id,
@@ -893,8 +892,7 @@ function mapDispatchToProps(dispatch: Dispatch) {
           fetchLineup,
           forceFetch
         )
-      )
-    },
+      ),
     fetchTracks: () =>
       dispatch(tracksActions.fetchLineupMetadatas(0, 200, false, undefined)),
     resetCollection: (collectionUid: string, userUid: string) =>

--- a/packages/web/src/pages/collection-page/CollectionPageProvider.tsx
+++ b/packages/web/src/pages/collection-page/CollectionPageProvider.tsx
@@ -371,16 +371,29 @@ class CollectionPage extends Component<
     return s
   }
 
-  fetchCollection = (pathname: string, forceFetch = false) => {
+  fetchCollection = (
+    pathname: string,
+    fetchLineup = false,
+    forceFetchArg = false
+  ) => {
     const { fetchCollection } = this.props
     const params = parseCollectionRoute(pathname)
     if (!params) return
 
     const { permalink, collectionId } = params
 
+    // Need typecast as can't set type via connected-react-router, see https://github.com/reach/router/issues/414
+    const locationState = this.props.location.state as { forceFetch?: boolean }
+    const forceFetch = locationState?.forceFetch ?? forceFetchArg
+
     if (forceFetch || permalink || collectionId !== this.state.playlistId) {
       this.setState({ playlistId: collectionId as number })
-      fetchCollection(collectionId, permalink, forceFetch)
+      fetchCollection({
+        id: collectionId,
+        permalink,
+        fetchLineup,
+        forceFetch
+      })
     }
   }
 
@@ -865,12 +878,27 @@ function makeMapStateToProps() {
 
 function mapDispatchToProps(dispatch: Dispatch) {
   return {
-    fetchCollection: (
-      id: Nullable<number>,
-      permalink?: string,
+    fetchCollection: ({
+      id,
+      permalink,
+      fetchLineup,
+      forceFetch
+    }: {
+      id: Nullable<number>
+      permalink?: string
       fetchLineup?: boolean
-    ) =>
-      dispatch(collectionActions.fetchCollection(id, permalink, fetchLineup)),
+      forceFetch?: boolean
+    }) => {
+      console.log('REED got action')
+      dispatch(
+        collectionActions.fetchCollection(
+          id,
+          permalink,
+          fetchLineup,
+          forceFetch
+        )
+      )
+    },
     fetchTracks: () =>
       dispatch(tracksActions.fetchLineupMetadatas(0, 200, false, undefined)),
     resetCollection: (collectionUid: string, userUid: string) =>

--- a/packages/web/src/pages/collection-page/CollectionPageProvider.tsx
+++ b/packages/web/src/pages/collection-page/CollectionPageProvider.tsx
@@ -371,11 +371,7 @@ class CollectionPage extends Component<
     return s
   }
 
-  fetchCollection = (
-    pathname: string,
-    fetchLineup = false,
-    forceFetchArg = false
-  ) => {
+  fetchCollection = (pathname: string, fetchLineup = false) => {
     const { fetchCollection } = this.props
     const params = parseCollectionRoute(pathname)
     if (!params) return
@@ -384,7 +380,7 @@ class CollectionPage extends Component<
 
     // Need typecast as can't set type via connected-react-router, see https://github.com/reach/router/issues/414
     const locationState = this.props.location.state as { forceFetch?: boolean }
-    const forceFetch = locationState?.forceFetch ?? forceFetchArg
+    const forceFetch = locationState?.forceFetch
 
     if (forceFetch || permalink || collectionId !== this.state.playlistId) {
       this.setState({ playlistId: collectionId as number })


### PR DESCRIPTION
### Description
Add a `forceRefetch` flag and use it from the `TrackAddedToPurchasedAlbum` notification to make sure we've fetched the latest lineup after clicking on the notification tile.

Mobile doesn't have this bug.

### How Has This Been Tested?

Ran on local - had 2 sessions open -> added a track to an album that the other user had bought, confirmed they had latest tracklist. Also tried after loading in purchaser account from feed so the album was already loaded from that endpoint.