### PR TITLE
[PAY-3049, QA-1307] filter premium albums from feed if flag off; fix feed spacing

### DIFF
--- a/packages/mobile/src/components/details-tile/DetailsTileNoAccess.tsx
+++ b/packages/mobile/src/components/details-tile/DetailsTileNoAccess.tsx
@@ -209,6 +209,9 @@ export const DetailsTileNoAccess = ({
   const { isEnabled: isIosGatedContentEnabled } = useFeatureFlag(
     FeatureFlags.IOS_GATED_CONTENT_ENABLED
   )
+  const { isEnabled: isUsdcPurchasesEnabled } = useFeatureFlag(
+    FeatureFlags.USDC_PURCHASES
+  )
 
   const { onPress: handlePressCollection } = useLink(collectionLink)
 
@@ -479,6 +482,10 @@ export const DetailsTileNoAccess = ({
   ])
 
   const isUnlocking = gatedTrackStatus === 'UNLOCKING'
+
+  if (!isUsdcPurchasesEnabled && isContentUSDCPurchaseGated(streamConditions)) {
+    return null
+  }
 
   return (
     <DetailsTileNoAccessSection

--- a/packages/mobile/src/components/lineup/Lineup.tsx
+++ b/packages/mobile/src/components/lineup/Lineup.tsx
@@ -99,9 +99,6 @@ const styles = StyleSheet.create({
   root: {
     flex: 1
   },
-  list: {
-    paddingBottom: 12
-  },
   item: {
     padding: 12,
     paddingBottom: 0
@@ -534,7 +531,6 @@ export const Lineup = ({
       <SectionList
         {...listProps}
         {...pullToRefreshProps}
-        style={styles.list}
         ref={ref}
         onScroll={handleScroll}
         ListHeaderComponent={

--- a/packages/mobile/src/components/lineup/Lineup.tsx
+++ b/packages/mobile/src/components/lineup/Lineup.tsx
@@ -99,8 +99,12 @@ const styles = StyleSheet.create({
   root: {
     flex: 1
   },
+  list: {
+    paddingBottom: 12
+  },
   item: {
-    padding: 12
+    padding: 12,
+    paddingBottom: 0
   }
 })
 
@@ -530,6 +534,7 @@ export const Lineup = ({
       <SectionList
         {...listProps}
         {...pullToRefreshProps}
+        style={styles.list}
         ref={ref}
         onScroll={handleScroll}
         ListHeaderComponent={

--- a/packages/web/src/common/store/lineup/sagas.ts
+++ b/packages/web/src/common/store/lineup/sagas.ts
@@ -72,10 +72,12 @@ function* filterDeletes<T extends Track | Collection>(
   const getFeatureEnabled = yield* getContext('getFeatureEnabled')
   yield* call(remoteConfig.waitForRemoteConfig)
 
-  const isUSDCGatedContentEnabled = getFeatureEnabled(
+  const isUSDCGatedContentEnabled = yield* call(
+    getFeatureEnabled,
     FeatureFlags.USDC_PURCHASES
   )
-  const isPremiumAlbumsEnabled = getFeatureEnabled(
+  const isPremiumAlbumsEnabled = yield* call(
+    getFeatureEnabled,
     FeatureFlags.PREMIUM_ALBUMS_ENABLED
   )
 


### PR DESCRIPTION
### Description

- Respect feature flags and don't show purchase buttons
- Resolve promise on `getFeatureEnabled` in feed sagas
	- Correctly filters out premium content from feed instead of allowing it through

Extraneous:
- Fixes gap between feed tiles
	- Note that this effectively reverts https://github.com/AudiusProject/audius-protocol/pull/8511 so we'll need another solution for the scroll padding issues there

### How Has This Been Tested?

working locally with flags off and on