### PR TITLE
[PROTO-1833] Index allowed api keys

### DIFF
--- a/packages/discovery-provider/ddl/migrations/0071_add_allowed_api_keys.sql
+++ b/packages/discovery-provider/ddl/migrations/0071_add_allowed_api_keys.sql
@@ -1,0 +1,3 @@
+begin;
+alter table tracks add column if not exists allowed_api_keys text[];
+commit;

--- a/packages/discovery-provider/integration_tests/tasks/entity_manager/test_track_entity_manager.py
+++ b/packages/discovery-provider/integration_tests/tasks/entity_manager/test_track_entity_manager.py
@@ -468,7 +468,7 @@ def test_index_valid_track(app, mocker):
         assert track_1.is_unlisted
         assert track_1.is_delete == True
         assert track_1.duration == 100
-        assert track_1.allowed_api_keys == ["0xApiKey"]
+        assert track_1.allowed_api_keys == ["0xapikey"]
 
         track_2: Track = (
             session.query(Track)

--- a/packages/discovery-provider/integration_tests/tasks/entity_manager/test_track_entity_manager.py
+++ b/packages/discovery-provider/integration_tests/tasks/entity_manager/test_track_entity_manager.py
@@ -88,6 +88,7 @@ def test_index_valid_track(app, mocker):
             "orig_filename": "original-filename",
             "is_downloadable": False,
             "is_original_available": False,
+            "allowed_api_keys": ["0xApiKey"],
         },
         "QmCreateTrack2": {
             "owner_id": 1,
@@ -467,6 +468,7 @@ def test_index_valid_track(app, mocker):
         assert track_1.is_unlisted
         assert track_1.is_delete == True
         assert track_1.duration == 100
+        assert track_1.allowed_api_keys == ["0xApiKey"]
 
         track_2: Track = (
             session.query(Track)

--- a/packages/discovery-provider/src/models/tracks/track.py
+++ b/packages/discovery-provider/src/models/tracks/track.py
@@ -81,6 +81,7 @@ class Track(Base, RepresentableMixin):
     )
     slot = Column(Integer)
     is_available = Column(Boolean, nullable=False, server_default=text("true"))
+    allowed_api_keys = Column(ARRAY(String))
     is_stream_gated = Column(Boolean, nullable=False, server_default=text("false"))
     stream_conditions = Column(JSONB(True))
     is_download_gated = Column(Boolean, nullable=False, server_default=text("false"))

--- a/packages/discovery-provider/src/tasks/entity_manager/entities/track.py
+++ b/packages/discovery-provider/src/tasks/entity_manager/entities/track.py
@@ -248,7 +248,11 @@ def populate_track_record_metadata(track_record: Track, track_metadata, handle, 
                 or track_metadata["download_conditions"] is None
             ):
                 track_record.download_conditions = track_metadata["download_conditions"]
-
+        elif key == "allowed_api_keys":
+            if key in track_metadata and track_metadata[key]:
+                track_record.allowed_api_keys = [
+                    api_key.lower() for api_key in track_metadata["allowed_api_keys"]
+                ]
         elif key == "stem_of":
             if "stem_of" in track_metadata and is_valid_json_field(
                 track_metadata, "stem_of"

--- a/packages/discovery-provider/src/tasks/metadata.py
+++ b/packages/discovery-provider/src/tasks/metadata.py
@@ -96,6 +96,7 @@ class TrackMetadata(TypedDict):
     copyright_line: Optional[Copyright]
     producer_copyright_line: Optional[Copyright]
     parental_warning_type: Optional[str]
+    allowed_api_keys: Optional[str]
 
 
 track_metadata_format: TrackMetadata = {
@@ -147,6 +148,7 @@ track_metadata_format: TrackMetadata = {
     "copyright_line": None,
     "producer_copyright_line": None,
     "parental_warning_type": None,
+    "allowed_api_keys": None,
 }
 
 # Required format for user metadata retrieved from the content system


### PR DESCRIPTION
### Description
DB migration to add allowed_api_keys column and enable EntityManager to index allowed api keys. Null means all API keys are allowed.

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._

Updated integration test.