### PR TITLE
[PROTO-1835] Enforce allowed api keys for stream

### DIFF
--- a/packages/discovery-provider/src/api/v1/tracks.py
+++ b/packages/discovery-provider/src/api/v1/tracks.py
@@ -539,7 +539,9 @@ class TrackStream(Resource):
             )
             abort_not_found(track_id, ns)
         elif (track["allowed_api_keys"] and not api_key) or (
-            api_key.lower() not in track["allowed_api_keys"]
+            api_key
+            and track["allowed_api_keys"]
+            and api_key.lower() not in track["allowed_api_keys"]
         ):
             logger.error(
                 f"tracks.py | stream | Streaming track {track_id} does not allow streaming from api key {api_key}."


### PR DESCRIPTION
### Description
Track rows with `allowed_api_keys` require a matching api_key in the stream request. If no api_key is passed in, only tracks without `allowed_api_keys` will be streamable which is the default. 

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._

Tested against sandbox. Confirmed no api_key, wrong api_key will not stream on a track with `allowed_api_keys`.