### PR TITLE
Fix lossless validation

### DIFF
--- a/packages/web/src/pages/upload-page/fields/StemsAndDownloadsMenuFields.tsx
+++ b/packages/web/src/pages/upload-page/fields/StemsAndDownloadsMenuFields.tsx
@@ -46,8 +46,6 @@ const messages = {
     `Price must be at least $${formatPrice(minPrice)}.`,
   priceTooHigh: (maxPrice: number) =>
     `Price must be less than $${formatPrice(maxPrice)}.`,
-  losslessNoDownloadableAssets:
-    'You must enable full track download or upload a stem file to provide lossless files.',
   gatedNoDownloadableAssets:
     'You must enable full track download or upload a stem file before setting download availability.',
   noUsdcUploadAccess:
@@ -106,22 +104,6 @@ export const stemsAndDownloadsSchema = ({
       {
         message: messages.priceTooHigh(maxContentPriceCents),
         path: [DOWNLOAD_PRICE]
-      }
-    )
-    .refine(
-      // cannot provide lossless files if no downloadable assets
-      (values) => {
-        const formValues = values as StemsAndDownloadsFormValues
-        const isOriginalAvailable = formValues[IS_ORIGINAL_AVAILABLE]
-        const isDownloadable = formValues[IS_DOWNLOADABLE]
-        const stems = formValues[STEMS]
-        const hasStems = stems.length > 0
-        const hasDownloadableAssets = isDownloadable || hasStems
-        return !isOriginalAvailable || hasDownloadableAssets
-      },
-      {
-        message: messages.losslessNoDownloadableAssets,
-        path: [IS_DOWNLOAD_GATED]
       }
     )
     .refine(


### PR DESCRIPTION
### Description

Caused a bug where user could not untoggle full track download. No longer relevant since we provide lossless always.

### How Has This Been Tested?

local web dapp v stage
