### PR TITLE
[PAY-3045] Show play button if user has access to any of collection's contents

### DIFF
--- a/packages/mobile/src/components/details-tile/DetailsTile.tsx
+++ b/packages/mobile/src/components/details-tile/DetailsTile.tsx
@@ -160,12 +160,14 @@ export const DetailsTile = ({
   const isUnpublishedScheduledRelease =
     track?.is_scheduled_release && track?.is_unlisted
 
-  // Show play if user has access to the collection or any of its contents,
-  // otherwise show preview
+  // Show play if user has access to the collection or any of its contents.
+  // Show preview only if the user is the owner on a track screen.
   const shouldShowPlay =
     (isPlayable && hasStreamAccess) || doesUserHaveAccessToAnyTrack
   const shouldShowPreview =
-    isUSDCPurchaseGated && !hasStreamAccess && !shouldShowPlay && onPressPreview
+    isUSDCPurchaseGated &&
+    ((isOwner && !isCollection) || !hasStreamAccess) &&
+    onPressPreview
 
   const handlePressArtistName = useCallback(() => {
     if (!user) {

--- a/packages/web/src/components/collection/mobile/CollectionHeader.tsx
+++ b/packages/web/src/components/collection/mobile/CollectionHeader.tsx
@@ -2,10 +2,15 @@ import { memo, useCallback } from 'react'
 
 import { useGetCurrentUserId, useGetPlaylistById } from '@audius/common/api'
 import { imageBlank } from '@audius/common/assets'
-import { useGatedContentAccess } from '@audius/common/hooks'
+import {
+  useGatedContentAccessMap,
+  useGatedContentAccess
+} from '@audius/common/hooks'
 import { Variant, SquareSizes, ID, ModalSource } from '@audius/common/models'
 import { FeatureFlags } from '@audius/common/services'
 import {
+  CommonState,
+  cacheCollectionsSelectors,
   OverflowAction,
   PurchaseableContentType,
   useEditPlaylistModal
@@ -13,6 +18,7 @@ import {
 import { getDogEarType } from '@audius/common/utils'
 import { Box, Button, Flex, IconPause, IconPlay, Text } from '@audius/harmony'
 import cn from 'classnames'
+import { useSelector } from 'react-redux'
 
 import { DogEar } from 'components/dog-ear'
 import DynamicImage from 'components/dynamic-image/DynamicImage'
@@ -33,6 +39,8 @@ import { RepostsFavoritesStats } from '../components/RepostsFavoritesStats'
 import { CollectionHeaderProps } from '../types'
 
 import styles from './CollectionHeader.module.css'
+
+const { getCollectionTracks } = cacheCollectionsSelectors
 
 const messages = {
   hiddenPlaylist: 'Hidden Playlist',
@@ -73,7 +81,6 @@ const CollectionHeader = ({
   lastModifiedDate,
   numTracks,
   isPlayable,
-  isStreamGated,
   streamConditions,
   access,
   duration,
@@ -104,20 +111,27 @@ const CollectionHeader = ({
   )
 
   const { data: currentUserId } = useGetCurrentUserId({})
-  const { data: collection } = useGetPlaylistById(
-    {
-      playlistId: typeof collectionId === 'number' ? collectionId : null,
-      currentUserId
-    },
-    { disabled: typeof collectionId !== 'number' }
-  )
+  const { data: collection } = useGetPlaylistById({
+    playlistId: collectionId,
+    currentUserId
+  })
   const { hasStreamAccess } = useGatedContentAccess(collection)
   const isPremium = collection?.is_stream_gated
   const isUnlisted = collection?.is_private
 
-  // If user doesn't have access, show preview only. If user has access, show play only.
-  const shouldShowPlay = isPlayable && hasStreamAccess
-  const shouldShowPreview = isPremium && !hasStreamAccess
+  const tracks = useSelector((state: CommonState) =>
+    getCollectionTracks(state, { id: collectionId })
+  )
+  const trackAccessMap = useGatedContentAccessMap(tracks ?? [])
+  const doesUserHaveAccessToAnyTrack = Object.values(trackAccessMap).some(
+    ({ hasStreamAccess }) => hasStreamAccess
+  )
+
+  // Show play if user has access to the collection or any of its contents,
+  // otherwise show preview
+  const shouldShowPlay =
+    (isPlayable && hasStreamAccess) || doesUserHaveAccessToAnyTrack
+  const shouldShowPreview = isPremium && !hasStreamAccess && !shouldShowPlay
 
   const showPremiumSection =
     isPremiumAlbumsEnabled && isAlbum && streamConditions && collectionId


### PR DESCRIPTION
### Description
Show only the play button for collections if the user has access to _any_ of the collection contents.

### How Has This Been Tested?

Local web + ios stage
Confirmed smart collection still works on web
Confirmed play/preview behavior is correct.

<img width="1920" alt="Screenshot 2024-05-21 at 3 18 29 PM" src="https://github.com/AudiusProject/audius-protocol/assets/3893871/c7d2ccf2-8e3b-41d7-852d-d2b31b9b67eb">

owner on track:
![Simulator Screenshot - iPhone 15 Pro - 2024-05-21 at 18 35 54](https://github.com/AudiusProject/audius-protocol/assets/3893871/bd155a6c-92fd-4a22-8c30-87d144402014)

owner on album:
![Simulator Screenshot - iPhone 15 Pro - 2024-05-21 at 18 37 17](https://github.com/AudiusProject/audius-protocol/assets/3893871/ea2e1bc6-c7a2-4d7c-9bb7-67f46187aa12)


non-owner on album
![Simulator Screenshot - iPhone 15 Pro - 2024-05-21 at 18 35 39](https://github.com/AudiusProject/audius-protocol/assets/3893871/3b847f6d-da10-44b1-be54-c87164bbad78)
