### PR TITLE
[PAY-3024] Skip onFavorite notifications for purchased content

### DIFF
--- a/packages/discovery-provider/ddl/functions/handle_save.sql
+++ b/packages/discovery-provider/ddl/functions/handle_save.sql
@@ -10,8 +10,8 @@ declare
   is_album boolean;
   delta int;
   entity_type text;
-  is_purchased boolean;
-  is_containing_album_purchased boolean;
+  is_purchased boolean default false;
+  is_containing_album_purchased boolean default false;
 begin
 
   insert into aggregate_user (user_id) values (new.user_id) on conflict do nothing;

--- a/packages/discovery-provider/ddl/functions/handle_save.sql
+++ b/packages/discovery-provider/ddl/functions/handle_save.sql
@@ -10,6 +10,8 @@ declare
   is_album boolean;
   delta int;
   entity_type text;
+  is_purchased boolean;
+  is_containing_album_purchased boolean;
 begin
 
   insert into aggregate_user (user_id) values (new.user_id) on conflict do nothing;
@@ -17,6 +19,28 @@ begin
     insert into aggregate_track (track_id) values (new.save_item_id) on conflict do nothing;
 
     entity_type := 'track';
+
+    -- check if the track has been purchased
+    select exists (
+        select 1
+        from usdc_purchases
+        where content_type = 'track'
+        and content_id = new.save_item_id
+        and buyer_user_id = new.user_id
+    ) into is_purchased;
+
+    -- check if the track is part of an album that has been purchased
+    select exists (
+      select 1
+      from
+        usdc_purchases
+        join playlist_tracks as pt
+        on content_id = pt.playlist_id
+      where track_id = new.save_item_id
+      and buyer_user_id = new.user_id
+    ) into is_containing_album_purchased;
+
+    is_purchased := is_purchased or is_containing_album_purchased;
   else
     insert into aggregate_playlist (playlist_id, is_album)
     select p.playlist_id, p.is_album
@@ -28,6 +52,14 @@ begin
     select ap.is_album into is_album
     from aggregate_playlist ap
     where ap.playlist_id = new.save_item_id;
+
+    select exists (
+      select 1
+      from usdc_purchases
+      where content_type = 'album'
+      and content_id = new.save_item_id
+      and buyer_user_id = new.user_id
+    ) into is_purchased;
   end if;
 
   -- increment or decrement?
@@ -133,7 +165,8 @@ begin
 
   begin
     -- create a notification for the saved content's owner
-    if new.is_delete is false then
+    -- skip notification for purchased content as the purchase triggers its own notification
+    if new.is_delete is false and is_purchased is false then
       insert into notification
         (blocknumber, user_ids, timestamp, type, specifier, group_id, data)
         values
@@ -152,7 +185,10 @@ begin
     -- notify followees of the favoriter who have reposted the same content
     -- within the last month
     if new.is_delete is false
-    and new.is_save_of_repost is true then
+    and new.is_save_of_repost is true
+    -- skip notification for tracks contained within a purchased album
+    -- the favorite of the album itself will still trigger this notification
+    and is_containing_album_purchased is false then
     with
         followee_save_repost_ids as (
             select user_id


### PR DESCRIPTION
### Description

Purchasing an album automatically favorites the album itself and every track within it. This causes a cascade of favorite notifications for the artist. In each of the below cases, the artist or reposter will receive only one notification per purchased item, whether it's a track or an album.

#### Skip `save` notification if:
- Track has been purchased by the `favorited_by_user`
- An album containing the track has been purchased by the `favorited_by_user`

#### Skip `save_of_repost` repost notification if:
- An album containing the track has been purchased
	- This means that the reposter will still receive a notification for the album or track that was favorited, but in the case where an album was purchased, we won't send one for every track therein


### How Has This Been Tested?

tested several cases on local stack:
- purchased album containing tracks
- purchased tracks separately
- saved public album
- saved individual track
- etc.

each results in exactly one notification (either purchase or save)