### PR TITLE
Close purchase/sale details modal on user click

### DIFF
--- a/packages/web/src/components/usdc-purchase-details-modal/components/PurchaseModalContent.tsx
+++ b/packages/web/src/components/usdc-purchase-details-modal/components/PurchaseModalContent.tsx
@@ -89,6 +89,7 @@ export const PurchaseModalContent = ({
                 popover
                 textVariant='body'
                 size='l'
+                onClick={onClose}
               />
             </Flex>
           </DetailSection>

--- a/packages/web/src/components/usdc-purchase-details-modal/components/SaleModalContent.tsx
+++ b/packages/web/src/components/usdc-purchase-details-modal/components/SaleModalContent.tsx
@@ -116,6 +116,7 @@ export const SaleModalContent = ({
                 popover
                 textVariant='body'
                 size='l'
+                onClick={onClose}
               />
             </Flex>
           </DetailSection>


### PR DESCRIPTION
### Description
Need to close the details modal when the `UserLink` is clicked on web.

### How Has This Been Tested?

Local web stage