### PR TITLE
Increase replication cleanup in mediorum

### DIFF
--- a/mediorum/server/repair.go
+++ b/mediorum/server/repair.go
@@ -54,8 +54,8 @@ func (ss *MediorumServer) startRepairer() {
 				// run the next job
 				tracker.CursorI = lastRun.CursorI + 1
 
-				// 10% percent of time... clean up over-replicated and pull under-replicated
-				if tracker.CursorI >= 10 {
+				// 50% percent of time... clean up over-replicated and pull under-replicated
+				if tracker.CursorI > 2 {
 					tracker.CursorI = 1
 				}
 				tracker.CleanupMode = tracker.CursorI == 1
@@ -233,7 +233,7 @@ func (ss *MediorumServer) repairCid(cid string, placementHosts []string, tracker
 
 	tracker.Counters["total_checked"]++
 
-	// use preferredHealthyHosts when determining my rank because we want to check if we're in the top N*2 healthy nodes not the top N*2 unhealthy nodes
+	// use preferredHealthyHosts when determining my rank because we want to check if we're in the top healthy nodes not top of all nodes
 	myRank := slices.Index(preferredHealthyHosts, ss.Config.Self.Host)
 
 	key := cidutil.ShardCID(cid)
@@ -322,7 +322,7 @@ func (ss *MediorumServer) repairCid(cid string, placementHosts []string, tracker
 	// wasReplicatedToday := attrs.CreateTime.After(time.Now().Add(-24 * time.Hour))
 	wasReplicatedThisWeek := attrs.CreateTime.After(time.Now().Add(-24 * 7 * time.Hour))
 
-	if !isPlaced && !ss.Config.StoreAll && tracker.CleanupMode && alreadyHave && myRank > ss.Config.ReplicationFactor+2 && !wasReplicatedThisWeek {
+	if !isPlaced && !ss.Config.StoreAll && tracker.CleanupMode && alreadyHave && myRank > ss.Config.ReplicationFactor+1 && !wasReplicatedThisWeek {
 		// depth := 0
 		// // loop preferredHealthyHosts (not preferredHosts) because we don't mind storing a blob a little while longer if it's not on enough healthy nodes
 		// for _, host := range preferredHealthyHosts {

--- a/mediorum/server/replicate.go
+++ b/mediorum/server/replicate.go
@@ -233,5 +233,5 @@ func (ss *MediorumServer) diskHasSpace() bool {
 		return true
 	}
 
-	return !strings.HasPrefix(ss.Config.BlobStoreDSN, "file://") || ss.mediorumPathFree/uint64(1e9) > 100
+	return !strings.HasPrefix(ss.Config.BlobStoreDSN, "file://") || ss.mediorumPathFree/uint64(1e9) > 200
 }


### PR DESCRIPTION
### Description

- Clean up in 50% of the tasks so we can settle the network down a bit.
- Increase boundary back up to 200GB from 100GB because some nodes seem to be falsely reporting
- Decrease over-replication factor to R+1 instead of R+2 to clean up more

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._

Config changes...
