### PR TITLE
Add cascade delete on album price history

### DIFF
--- a/packages/discovery-provider/ddl/migrations/0071_album_price_history_cascade_delete.sql
+++ b/packages/discovery-provider/ddl/migrations/0071_album_price_history_cascade_delete.sql
@@ -1,0 +1,12 @@
+begin;
+
+-- drop the existing foreign key constraint
+alter table album_price_history drop constraint if exists blocknumber_fkey;
+alter table album_price_history drop constraint if exists album_price_history_blocknumber_fkey;
+
+-- add the foreign key constraint with on delete cascade
+alter table album_price_history
+add constraint album_price_history_blocknumber_fkey foreign key (blocknumber)
+references blocks(number) on delete cascade;
+
+commit;


### PR DESCRIPTION
### Description
```
Error in indexing blocks (psycopg2.errors.ForeignKeyViolation) update or delete on table "blocks" violates foreign key constraint "blocknumber_fkey" on table "album_price_history"
DETAIL:  Key (number)=(68871272) is still referenced from table "album_price_history".
```

This error is because reverting a block will delete a row from the blocks table but there's a foreign key reference in album_price_history. Without cascade delete, deleting the row will fail. `on delete cascade` will make sure it removes any row that references the row in the blocks table. It'll be re-applied as it moves forward. 

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._

Ran migration on sandbox.
