### PR TITLE
[QA-1313] Fix purchase/sale email random null

### DIFF
--- a/packages/discovery-provider/plugins/notifications/src/email/notifications/preRendered/purchase.ts
+++ b/packages/discovery-provider/plugins/notifications/src/email/notifications/preRendered/purchase.ts
@@ -368,7 +368,7 @@ export const email = ({
 										</td></tr>
 										</table>
 									</div>`
-                      : null
+                      : ''
                   } 
 									<div>
 										<table border="0" cellspacing="0" cellpadding="0" width="100%">

--- a/packages/discovery-provider/plugins/notifications/src/email/notifications/preRendered/sale.ts
+++ b/packages/discovery-provider/plugins/notifications/src/email/notifications/preRendered/sale.ts
@@ -372,7 +372,7 @@ export const email = ({
 										</td></tr>
 										</table>
 									</div>`
-                      : null
+                      : ''
                   }
 									<div>
 										<table border="0" cellspacing="0" cellpadding="0" width="100%">


### PR DESCRIPTION
### Description
Fixes a random `null` showing up in these emails.

### How Has This Been Tested?

Not tested - hard to test locally
