### PR TITLE
[Discovery] Fix flaky test

### DIFF
--- a/packages/discovery-provider/integration_tests/notifications/test_manager_mode_notifs.py
+++ b/packages/discovery-provider/integration_tests/notifications/test_manager_mode_notifs.py
@@ -2,6 +2,8 @@ import logging
 from datetime import datetime, timedelta
 from typing import List
 
+from freezegun import freeze_time
+
 from integration_tests.utils import populate_mock_db
 from src.models.notifications.notification import Notification
 from src.utils.db_session import get_db
@@ -9,6 +11,7 @@ from src.utils.db_session import get_db
 logger = logging.getLogger(__name__)
 
 
+@freeze_time("2024-05-23 00:12:51.695089")
 def test_manager_mode_notifications(app):
     with app.app_context():
         db = get_db()


### PR DESCRIPTION
### Description
Fix test that would flake if the current timestamp ended in 0 due to [Postgres truncating trailing 0s when converting timestamp to string](https://stackoverflow.com/questions/56792490/postgres-truncates-trailing-zeros-for-timestamps)

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._
