### PR TITLE
Field parity with ddex/publisher

### DIFF
--- a/packages/ddex/processor/src/parseDelivery.test.ts
+++ b/packages/ddex/processor/src/parseDelivery.test.ts
@@ -7,6 +7,7 @@ import {
   DealSolGated,
   DealTipGated,
   parseDdexXmlFile,
+  parseDuration,
 } from './parseDelivery'
 import { sources } from './sources'
 
@@ -69,4 +70,11 @@ test('separate stream / download deal conditions', async () => {
     forStream: false,
     forDownload: true,
   })
+})
+
+test('parse duration', () => {
+  expect(parseDuration('')).toEqual(undefined)
+  expect(parseDuration('PT2M5S')).toEqual(125)
+  expect(parseDuration('PT20M5S')).toEqual(1205)
+  expect(parseDuration('PT2H20M5S')).toEqual(8405)
 })

--- a/packages/ddex/processor/src/parseDelivery.ts
+++ b/packages/ddex/processor/src/parseDelivery.ts
@@ -58,6 +58,7 @@ type ReleaseAndSoundRecordingSharedFields = {
   artists: DDEXContributor[]
   contributors: DDEXContributor[]
   indirectContributors: DDEXContributor[]
+  labelName: string
 }
 
 type CopyrightPair = {
@@ -87,6 +88,7 @@ export type DDEXSoundRecording = {
     roles: string[]
     // rightShareUnknown: string
   }
+  duration?: number
 
   audiusGenre?: Genre
 } & DDEXResource &
@@ -403,6 +405,8 @@ function parseReleaseXml(source: string, $: cheerio.CheerioAPI) {
         'IndirectResourceContributor',
         $el
       ),
+      labelName: $el.find('LabelName').text(),
+      duration: parseDuration($el.find('Duration').text()),
       genre: $el.find('GenreText').text(),
       subGenre: $el.find('SubGenre').text(),
       releaseDate: $el
@@ -478,6 +482,7 @@ function parseReleaseXml(source: string, $: cheerio.CheerioAPI) {
           'IndirectResourceContributor',
           $el
         ),
+        labelName: $el.find('LabelName').text(),
         genre: $el.find('GenreText').text(),
         subGenre: $el.find('SubGenre').text(),
         releaseIds: parseReleaseIds($el),
@@ -633,4 +638,14 @@ function resolveAudiusGenre(
   // maybe try some edit distance magic?
   // for now just log
   console.warn(`failed to resolve genre: subgenre=${subgenre} genre=${genre}`)
+}
+
+export function parseDuration(dur: string) {
+  const m = dur.match(/PT(\d+H)?(\d+M)?(\d+S)?/)
+  if (!m) return
+  const hours = parseInt(m[1]) || 0
+  const minutes = parseInt(m[2]) || 0
+  const seconds = parseInt(m[3]) || 0
+  const totalSeconds = hours * 3600 + minutes * 60 + seconds
+  return totalSeconds
 }

--- a/packages/ddex/processor/src/parseTakedown.test.ts
+++ b/packages/ddex/processor/src/parseTakedown.test.ts
@@ -39,7 +39,10 @@ test('crud', async () => {
   {
     await parseDdexXmlFile(source, 'fixtures/01_delivery.xml')
     const rr = releaseRepo.get(grid)!
+    expect(rr._parsed?.labelName).toBe('Iron Crown Music')
     expect(rr._parsed?.soundRecordings[0].title).toBe('Example Song')
+    expect(rr._parsed?.soundRecordings[0].labelName).toBe('Label Name, Inc.')
+    expect(rr._parsed?.soundRecordings[0].duration).toBe(225)
     expect(rr.status).toBe(ReleaseProcessingStatus.PublishPending)
     expect(rr.source).toBe('crudTest')
   }

--- a/packages/ddex/processor/src/publishRelease.ts
+++ b/packages/ddex/processor/src/publishRelease.ts
@@ -191,6 +191,8 @@ export function prepareTrackMetadatas(release: DDEXRelease) {
         genre: audiusGenre,
         title: sound.title,
         isrc: release.releaseIds.isrc,
+        iswc: release.releaseIds.iswc,
+        ddexReleaseIds: release.releaseIds,
         releaseDate,
         copyrightLine,
         producerCopyrightLine,
@@ -206,9 +208,11 @@ export function prepareTrackMetadatas(release: DDEXRelease) {
         if (deal.audiusDealType == 'FollowGated') {
           const cond = { followUserId: release.audiusUser! }
           if (deal.forStream) {
+            meta.isStreamGated = true
             meta.streamConditions = cond
           }
           if (deal.forDownload) {
+            meta.isDownloadGated = true
             meta.downloadConditions = cond
           }
         }
@@ -216,9 +220,11 @@ export function prepareTrackMetadatas(release: DDEXRelease) {
         if (deal.audiusDealType == 'TipGated') {
           const cond = { tipUserId: release.audiusUser! }
           if (deal.forStream) {
+            meta.isStreamGated = true
             meta.streamConditions = cond
           }
           if (deal.forDownload) {
+            meta.isDownloadGated = true
             meta.downloadConditions = cond
           }
         }
@@ -230,9 +236,11 @@ export function prepareTrackMetadatas(release: DDEXRelease) {
             },
           }
           if (deal.forStream) {
+            meta.isStreamGated = true
             meta.streamConditions = cond
           }
           if (deal.forDownload) {
+            meta.isDownloadGated = true
             meta.downloadConditions = cond
           }
         }
@@ -322,6 +330,10 @@ export function prepareAlbumMetadata(release: DDEXRelease) {
     releaseDate,
     ddexReleaseIds: release.releaseIds,
     artists: release.artists.map(mapContributor),
+    upc: release.releaseIds.icpn, // ICPN is either UPC (USA/Canada) or EAN (rest of world), but we call them both UPC
+    parentalWarningType: release.parentalWarningType,
+    copyrightLine: release.copyrightLine,
+    producerCopyrightLine: release.producerCopyrightLine,
   }
 
   // todo: album stream + download conditions

--- a/packages/ddex/processor/src/server.ts
+++ b/packages/ddex/processor/src/server.ts
@@ -30,6 +30,10 @@ import { parseBool, simulateDeliveryForUserName } from './util'
 const { NODE_ENV, DDEX_URL, COOKIE_SECRET } = process.env
 const COOKIE_NAME = 'audiusUser'
 
+// validate ENV
+if (!DDEX_URL) console.warn('DDEX_URL not defined')
+if (!COOKIE_SECRET) console.warn('COOKIE_SECRET not defined')
+
 const IS_PROD = NODE_ENV == 'production'
 const API_HOST = IS_PROD
   ? 'https://discoveryprovider2.audius.co'


### PR DESCRIPTION
### Description

Match the track / album metadata fields in `ddex/publisher`

https://linear.app/audius/issue/PROTO-1792/parity-on-fields-busy-work
