### PR TITLE
[QA-1016] Fix date added

### DIFF
--- a/packages/web/src/common/store/pages/collection/lineups/sagas.js
+++ b/packages/web/src/common/store/pages/collection/lineups/sagas.js
@@ -36,7 +36,8 @@ function* getCollectionTracks() {
 
   const trackIds = tracks.map((t) => t.track)
   // TODO: Conform all timestamps to be of the same format so we don't have to do any special work here.
-  const times = tracks.map((t) => t.time || t.metadata_time)
+  const now = Math.floor(Date.now() / 1000)
+  const times = tracks.map((t) => t.metadata_time || now)
 
   // Reconcile fetching this playlist with the queue.
   // Search the queue for its currently playing uids. If any are sourced


### PR DESCRIPTION
### Description

The bug occurred because because, on collection creation (not after refreshing the page, which was fine) `time` was referring to the track duration and then would take that number as the timestamp for the date added to collection.

### How Has This Been Tested?

local web dapp v stage

https://github.com/AudiusProject/audius-protocol/assets/9600175/cd593fab-5d54-4510-88ab-e737fe651ebd


