### PR TITLE
Fix issues with manager mode user fetching

### DIFF
--- a/packages/common/src/api/account.ts
+++ b/packages/common/src/api/account.ts
@@ -51,13 +51,13 @@ const accountApi = createApi({
         // TODO: https://linear.app/audius/issue/PAY-2838/separate-walletentropy-user-and-current-user-in-state
         // What happens in the cache if something here is null?
 
-        // Note: This cast is mostly safe, but is missing info populated in AudiusBackend.getAccount()
-        // Okay for now as that info isn't generally available on non-account users and isn't used in manager mode.
         return libs.Account?.getWeb3User() as UserMetadata | null
       },
       options: {
-        type: 'query',
-        schemaKey: 'currentWeb3User'
+        type: 'query'
+        // TODO: Cannot cache the response from this unless we fully decorate it
+        // https://linear.app/audius/issue/PAY-3066/getcurrentweb3user-breaks-decorated-account-info
+        // schemaKey: 'currentWeb3User'
       }
     },
     resetPassword: {

--- a/packages/common/src/services/local-storage/LocalStorage.ts
+++ b/packages/common/src/services/local-storage/LocalStorage.ts
@@ -9,6 +9,7 @@ import { Nullable } from '../../utils'
 // discoveryProvider/constants is migrated to typescript.
 const AUDIUS_ACCOUNT_KEY = '@audius/account'
 const AUDIUS_ACCOUNT_USER_KEY = '@audius/audius-user'
+const AUDIUS_USER_WALLET_OVERRIDE_KEY = '@audius/user-wallet-override'
 
 type LocalStorageType = {
   getItem: (key: string) => Promise<string | null> | string | null
@@ -99,6 +100,13 @@ export class LocalStorage {
   setAudiusAccount = async (value: object) => {
     await this.setJSONValue(AUDIUS_ACCOUNT_KEY, value)
   }
+
+  clearAudiusUserWalletOverride = async () =>
+    this.removeItem(AUDIUS_USER_WALLET_OVERRIDE_KEY)
+  getAudiusUserWalletOverride = async () =>
+    this.getValue(AUDIUS_USER_WALLET_OVERRIDE_KEY)
+  setAudiusUserWalletOverride = async (value: string) =>
+    this.setValue(AUDIUS_USER_WALLET_OVERRIDE_KEY, value)
 
   clearAudiusAccount = async () => this.removeItem(AUDIUS_ACCOUNT_KEY)
 

--- a/packages/mobile/src/store/sign-out/sagas.ts
+++ b/packages/mobile/src/store/sign-out/sagas.ts
@@ -50,6 +50,7 @@ function* signOut() {
   yield* put(resetSignOn())
 
   yield* call(deregisterPushNotifications)
+  yield* call([localStorage, 'clearAudiusUserWalletOverride'])
   yield* call([localStorage, 'clearAudiusAccount'])
   yield* call([localStorage, 'clearAudiusAccountUser'])
   yield* call([audiusBackendInstance, 'signOut'])

--- a/packages/web/src/store/sign-out/signOut.ts
+++ b/packages/web/src/store/sign-out/signOut.ts
@@ -18,6 +18,7 @@ export const signOut = async (
   localStorage: LocalStorage
 ) => {
   await removeLocalStorageItems(localStorage)
+  await localStorage.clearAudiusUserWalletOverride()
   await localStorage.clearAudiusAccount()
   await localStorage.clearAudiusAccountUser()
   await localStorage.clearPlaybackRate()


### PR DESCRIPTION
### Description
Two issues here:
* When using manager mode, we aren't clearing the user wallet override, and we're setting it to the same wallet as the signed in user if a non-managed account is selected. This breaks sign-out.
* Fetching the current web3 user via `libs.Account` does not apply the decoration logic in AudiusBackend that adds social handles, `userBank` and user images. That means if we write this object to the cache, those values go missing and it breaks a few different views/modals in subtle ways. For now, I'm disabling the caching behavior in the audius-query endpoint until I can implement a proper fix (this is behind a feature flag anyway)

### How Has This Been Tested?
Tested locally against staging.
