### PR TITLE
Fix spacing in AccountDetails

### DIFF
--- a/packages/web/src/components/nav/desktop/AccountDetails.tsx
+++ b/packages/web/src/components/nav/desktop/AccountDetails.tsx
@@ -56,7 +56,7 @@ export const AccountDetails = () => {
             }
           : undefined)}
       >
-        <Flex alignItems='center' w='100%' justifyContent='flex-start' gap='l'>
+        <Flex alignItems='center' w='100%' justifyContent='flex-start' gap='s'>
           <AvatarLegacy userId={account?.user_id} />
           <Flex
             direction='column'
@@ -74,7 +74,7 @@ export const AccountDetails = () => {
                 <Flex
                   alignItems='center'
                   justifyContent='space-between'
-                  gap='l'
+                  gap='s'
                 >
                   <UserLink
                     textVariant='title'


### PR DESCRIPTION
### Description
Mock uses small spacing (8px) for the gap. I had set them to large!

### How Has This Been Tested?
N/A
