### PR TITLE
PROTO-1844: fix poa block for trending rewards

### DIFF
--- a/packages/discovery-provider/src/tasks/calculate_trending_challenges.py
+++ b/packages/discovery-provider/src/tasks/calculate_trending_challenges.py
@@ -20,9 +20,10 @@ from src.queries.get_underground_trending import (
 )
 from src.tasks.aggregates import get_latest_blocknumber
 from src.tasks.celery_app import celery
+from src.tasks.entity_manager.utils import hex_to_blocknumber
 from src.trending_strategies.trending_strategy_factory import TrendingStrategyFactory
 from src.trending_strategies.trending_type_and_version import TrendingType
-from src.utils import web3_provider
+from src.utils import helpers, web3_provider
 from src.utils.prometheus_metric import save_duration_metric
 from src.utils.redis_constants import most_recent_indexed_block_redis_key
 from src.utils.session_manager import SessionManager
@@ -94,6 +95,12 @@ def enqueue_trending_challenges(
                 "calculate_trending_challenges.py | Unable to get latest block number"
             )
             return
+
+        # convert possibly from hex to int
+        latest_blocknumber = hex_to_blocknumber(latest_blocknumber)
+        # subtract final poa block because db is final_poa_block + latest_acdc_block
+        latest_blocknumber = latest_blocknumber - helpers.get_final_poa_block()
+
         latest_block_datetime = datetime.fromtimestamp(
             web3.eth.get_block(latest_blocknumber)["timestamp"]
         )

--- a/packages/discovery-provider/src/tasks/calculate_trending_challenges.py
+++ b/packages/discovery-provider/src/tasks/calculate_trending_challenges.py
@@ -20,7 +20,6 @@ from src.queries.get_underground_trending import (
 )
 from src.tasks.aggregates import get_latest_blocknumber
 from src.tasks.celery_app import celery
-from src.tasks.entity_manager.utils import hex_to_blocknumber
 from src.trending_strategies.trending_strategy_factory import TrendingStrategyFactory
 from src.trending_strategies.trending_type_and_version import TrendingType
 from src.utils import helpers, web3_provider
@@ -96,8 +95,6 @@ def enqueue_trending_challenges(
             )
             return
 
-        # convert possibly from hex to int
-        latest_blocknumber = hex_to_blocknumber(latest_blocknumber)
         # subtract final poa block because db is final_poa_block + latest_acdc_block
         latest_blocknumber = latest_blocknumber - helpers.get_final_poa_block()
 

--- a/packages/discovery-provider/src/tasks/entity_manager/utils.py
+++ b/packages/discovery-provider/src/tasks/entity_manager/utils.py
@@ -542,13 +542,3 @@ def parse_release_date(release_date_str):
         pass
 
     return None
-
-
-def hex_to_blocknumber(bl: str | int) -> int:
-    if isinstance(bl, str) and bl.startswith("0x"):
-        return int(bl, 16)
-    if isinstance(bl, int):
-        return bl
-    err_msg = f"not valid block hex str or int {bl}"
-    utils_logger.error(f"utils.py | {err_msg}")
-    raise TypeError(err_msg)

--- a/packages/discovery-provider/src/tasks/entity_manager/utils.py
+++ b/packages/discovery-provider/src/tasks/entity_manager/utils.py
@@ -542,3 +542,13 @@ def parse_release_date(release_date_str):
         pass
 
     return None
+
+
+def hex_to_blocknumber(bl: str | int) -> int:
+    if isinstance(bl, str) and bl.startswith("0x"):
+        return int(bl, 16)
+    if isinstance(bl, int):
+        return bl
+    err_msg = f"not valid block hex str or int {bl}"
+    utils_logger.error(f"utils.py | {err_msg}")
+    raise TypeError(err_msg)


### PR DESCRIPTION
### Description
Trending rewards has been trying to get the block timestamp of the last indexed block however the block it gets from redis does not subtract the final poa block. This results in a block not found when attempting to index the latest trending rewards.

```
web3.exceptions.BlockNotFound: Block with id: '0x41daca0' not found.
```

This is block 68885728 which is way too far for acdc. ACDC at this time is at roughly 39871415. Subtracting the final poa block (32269859) yields a more realistic result 36615869.

This logic here is why we need to do this
```
    # Get next block to index
    next_block_number = latest_database_block.number - (final_poa_block or 0) + 1
    try:
        next_block_immutable = web3.eth.get_block(next_block_number)
        # Copy the immutable attribute dict to a mutable dict
        next_block: BlockData = cast(BlockData, dict(next_block_immutable))
        next_block["number"] = next_block["number"] + final_poa_block
        return next_block
```

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._
