### PR TITLE
fix an optional Id parse that breaks when logged out

### DIFF
--- a/packages/web/src/common/store/cache/users/sagas.ts
+++ b/packages/web/src/common/store/cache/users/sagas.ts
@@ -1,7 +1,7 @@
 import {
   DefaultSizes,
-  Id,
   Kind,
+  OptionalId,
   User,
   UserMetadata,
   userMetadataListFromSDK
@@ -71,7 +71,7 @@ function* retrieveUserByHandle(handle: string, retry: boolean) {
     [sdk.full.users, sdk.full.users.getUserByHandle],
     {
       handle,
-      userId: Id.parse(userId)
+      userId: OptionalId.parse(userId)
     }
   )
   return userMetadataListFromSDK(users)


### PR DESCRIPTION
### Description
Accidentally used a non-optional Id parse when converting this to SDK, which results in an error while attempting to fetch the profile while logged out.

### How Has This Been Tested?
Ran locally against staging
