### PR TITLE
Fix first track in lineup playback issue

### DIFF
--- a/packages/mobile/src/components/audio/AudioPlayer.tsx
+++ b/packages/mobile/src/components/audio/AudioPlayer.tsx
@@ -20,7 +20,8 @@ import {
   playbackPositionActions,
   playbackPositionSelectors,
   gatedContentSelectors,
-  calculatePlayerBehavior
+  calculatePlayerBehavior,
+  PlayerBehavior
 } from '@audius/common/store'
 import type { Queueable, CommonState } from '@audius/common/store'
 import {
@@ -178,7 +179,8 @@ export const AudioPlayer = () => {
   const uid = useSelector(getUid)
   const playerBehavior = useSelector(getPlayerBehavior)
   const previousUid = usePrevious(uid)
-  const previousPlayerBehavior = usePrevious(playerBehavior)
+  const previousPlayerBehavior =
+    usePrevious(playerBehavior) || PlayerBehavior.FULL_OR_PREVIEW
   const trackPositions = useSelector((state: CommonState) =>
     getUserTrackPositions(state, { userId: currentUserId })
   )


### PR DESCRIPTION
### Description

previousPlayerBehavior was undefined when playerBehavior was null, which triggers excessive calls to the below useAsync hook.

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._

on device