### PR TITLE
[QA-1226] Add missing tier info

### DIFF
--- a/packages/mobile/src/screens/audio-screen/AudioScreen.tsx
+++ b/packages/mobile/src/screens/audio-screen/AudioScreen.tsx
@@ -402,34 +402,36 @@ export const AudioScreen = () => {
         <Tier
           tierNumber={1}
           title='bronze'
-          colors={['rgba(141, 48, 8, 0.5)', 'rgb(182, 97, 11)']}
+          gradientColors={['rgba(141, 48, 8, 0.5)', 'rgb(182, 97, 11)']}
           minAmount={10}
-          image={<Image source={Bronze} />}
+          imageSource={Bronze}
           isCurrentTier={tierNumber === 1}
         />
         <Tier
           tierNumber={2}
           title='silver'
-          colors={['rgba(179, 182, 185, 0.5)', 'rgb(189, 189, 189)']}
+          gradientColors={['rgba(179, 182, 185, 0.5)', 'rgb(189, 189, 189)']}
           minAmount={100}
-          image={<Image source={Silver} />}
+          imageSource={Silver}
           isCurrentTier={tierNumber === 2}
         />
         <Tier
           tierNumber={3}
           title='gold'
-          colors={['rgb(236, 173, 11)', 'rgb(236, 173, 11)']}
+          gradientColors={['rgb(236, 173, 11)', 'rgb(236, 173, 11)']}
           minAmount={1000}
-          image={<Image source={Gold} />}
+          imageSource={Gold}
           isCurrentTier={tierNumber === 3}
+          unlocks={['matrix']}
         />
         <Tier
           tierNumber={4}
           title='platinum'
-          colors={['rgb(179, 236, 249)', 'rgb(87, 194, 215)']}
+          gradientColors={['rgb(179, 236, 249)', 'rgb(87, 194, 215)']}
           minAmount={10000}
-          image={<Image source={Platinum} />}
+          imageSource={Platinum}
           isCurrentTier={tierNumber === 4}
+          unlocks={['matrix']}
         />
         <Button
           title={messages.learnMore}

--- a/packages/mobile/src/screens/audio-screen/Tier.tsx
+++ b/packages/mobile/src/screens/audio-screen/Tier.tsx
@@ -1,23 +1,24 @@
-import { View, Image, ImageSourcePropType } from 'react-native'
+import { vipDiscordModalActions } from '@audius/common/store'
+import type { ImageSourcePropType } from 'react-native'
+import { View, Image } from 'react-native'
+import { useDispatch } from 'react-redux'
 
 import {
   Button,
   Flex,
   IconArrowRight,
   IconDiscord,
-  useTheme
+  useTheme,
+  Text
 } from '@audius/harmony-native'
+import Hole from 'app/assets/images/emojis/hole.png'
+import Rabbit from 'app/assets/images/emojis/rabbit.png'
+import Sparkles from 'app/assets/images/emojis/sparkles.png'
+import Checkmark from 'app/assets/images/emojis/white-heavy-check-mark.png'
 import { GradientText, Shadow } from 'app/components/core'
-import { Text } from '@audius/harmony-native'
 import { makeStyles } from 'app/styles'
 import { spacing } from 'app/styles/spacing'
 import { useThemeColors } from 'app/utils/theme'
-import Checkmark from 'app/assets/images/emojis/white-heavy-check-mark.png'
-import Sparkles from 'app/assets/images/emojis/sparkles.png'
-import Rabbit from 'app/assets/images/emojis/rabbit.png'
-import Hole from 'app/assets/images/emojis/hole.png'
-import { useDispatch } from 'react-redux'
-import { vipDiscordModalActions } from '@audius/common/store'
 const { pressDiscord } = vipDiscordModalActions
 
 const messages = {

--- a/packages/mobile/src/screens/audio-screen/Tier.tsx
+++ b/packages/mobile/src/screens/audio-screen/Tier.tsx
@@ -1,17 +1,31 @@
-import type { ReactNode } from 'react'
+import { View, Image, ImageSourcePropType } from 'react-native'
 
-import { View } from 'react-native'
-
-import { IconArrowRight } from '@audius/harmony-native'
-import { GradientText, Shadow, Text } from 'app/components/core'
+import {
+  Button,
+  Flex,
+  IconArrowRight,
+  IconDiscord,
+  useTheme
+} from '@audius/harmony-native'
+import { GradientText, Shadow } from 'app/components/core'
+import { Text } from '@audius/harmony-native'
 import { makeStyles } from 'app/styles'
 import { spacing } from 'app/styles/spacing'
 import { useThemeColors } from 'app/utils/theme'
+import Checkmark from 'app/assets/images/emojis/white-heavy-check-mark.png'
+import Sparkles from 'app/assets/images/emojis/sparkles.png'
+import Rabbit from 'app/assets/images/emojis/rabbit.png'
+import Hole from 'app/assets/images/emojis/hole.png'
+import { useDispatch } from 'react-redux'
+import { vipDiscordModalActions } from '@audius/common/store'
+const { pressDiscord } = vipDiscordModalActions
 
 const messages = {
   tier: 'Tier',
   minAmount: '$AUDIO',
-  current: 'Current Tier'
+  current: 'Current Tier',
+  unlocks: 'Unlocks',
+  updateRole: 'Update Role'
 }
 
 const useStyles = makeStyles(({ spacing, palette, typography }) => ({
@@ -49,23 +63,11 @@ const useStyles = makeStyles(({ spacing, palette, typography }) => ({
     transform: [{ rotate: '90deg' }],
     marginBottom: spacing(2)
   },
-  tier: {
-    color: palette.neutralLight6,
-    fontFamily: typography.fontByWeight.bold,
-    fontSize: typography.fontSize.medium,
-    textTransform: 'uppercase'
-  },
   title: {
     margin: 8,
     fontFamily: typography.fontByWeight.heavy,
     fontSize: 28,
     textTransform: 'uppercase'
-  },
-  minAmount: {
-    color: palette.secondary,
-    fontFamily: typography.fontByWeight.bold,
-    fontSize: typography.fontSize.small,
-    lineHeight: spacing(4)
   },
   separator: {
     height: 1,
@@ -75,39 +77,96 @@ const useStyles = makeStyles(({ spacing, palette, typography }) => ({
   }
 }))
 
+const Unlock = ({ images, children }) => {
+  const { spacing } = useTheme()
+  return (
+    <Text variant='body' size='l' strength='strong' textTransform='capitalize'>
+      {images.map((image, i) => (
+        <>
+          <Image
+            key={i}
+            source={image}
+            style={{ height: spacing.l, width: spacing.l }}
+          />{' '}
+        </>
+      ))}
+      {children}
+    </Text>
+  )
+}
+
 type TierProps = {
   tierNumber: number
   title: string
-  colors: string[]
+  gradientColors: string[]
   minAmount: number
-  image: ReactNode
+  imageSource: ImageSourcePropType
   isCurrentTier: boolean
+  unlocks?: 'matrix'[]
 }
 
-export const Tier = ({
-  tierNumber,
-  title,
-  colors,
-  minAmount,
-  image,
-  isCurrentTier
-}: TierProps) => {
+export const Tier = (props: TierProps) => {
+  const {
+    tierNumber,
+    title,
+    gradientColors,
+    minAmount,
+    imageSource,
+    isCurrentTier,
+    unlocks = []
+  } = props
   const styles = useStyles()
   const { secondary } = useThemeColors()
+  const dispatch = useDispatch()
 
   const renderTierBody = () => {
     return (
       <>
         <View style={[styles.container, isCurrentTier && styles.current]}>
-          <Text style={styles.tier}>{`${messages.tier} ${tierNumber}`}</Text>
-          <GradientText style={styles.title} colors={colors}>
+          <Text
+            variant='label'
+            size='l'
+            color='subdued'
+          >{`${messages.tier} ${tierNumber}`}</Text>
+          <GradientText style={styles.title} colors={gradientColors}>
             {title}
           </GradientText>
           <Text
-            style={styles.minAmount}
+            variant='title'
+            size='s'
+            color='accent'
           >{`${minAmount}+ ${messages.minAmount}`}</Text>
           <View style={styles.separator} />
-          {image}
+          <Image source={imageSource} style={{ height: 108, width: 108 }} />
+          <Flex mt='xl' gap='l' alignItems='center'>
+            <Text variant='label' size='l' color='subdued'>
+              {messages.unlocks}
+            </Text>
+            <Unlock images={[Checkmark]}>{title} Badge</Unlock>
+            <Unlock images={[Checkmark]}>{title} Discord Role</Unlock>
+            {isCurrentTier ? (
+              <Button
+                variant='secondary'
+                onPress={() => dispatch(pressDiscord())}
+                iconLeft={IconDiscord}
+              >
+                {messages.updateRole}
+              </Button>
+            ) : null}
+            {unlocks.map((unlock) => {
+              switch (unlock) {
+                case 'matrix':
+                  return (
+                    <Unlock key={unlock} images={[Rabbit, Hole]}>
+                      Matrix Mode
+                    </Unlock>
+                  )
+                default:
+                  return null
+              }
+            })}
+            <Unlock images={[Sparkles]}>More Coming Soon</Unlock>
+          </Flex>
         </View>
       </>
     )


### PR DESCRIPTION
### Description

Adds missing tier info to mobile rewards page

<img width="450" alt="image" src="https://github.com/AudiusProject/audius-protocol/assets/8230000/98f1729e-4c33-4b6a-b71a-7c45e10e4738">
