### PR TITLE
Fix chromecast support, again

### DIFF
--- a/packages/mobile/src/components/audio/GoogleCast.tsx
+++ b/packages/mobile/src/components/audio/GoogleCast.tsx
@@ -48,33 +48,29 @@ export const useChromecast = () => {
 
   const loadCast = useCallback(
     async (track, startTime, contentUrl) => {
-      if (client && track && owner) {
+      if (client && track && owner && contentUrl) {
         const imageUrl = await audiusBackendInstance.getImageUrl(
           track.cover_art_sizes,
           SquareSizes.SIZE_1000_BY_1000,
           track.cover_art_cids
         )
 
-        try {
-          client.loadMedia({
-            mediaInfo: {
-              contentUrl,
-              metadata: {
-                type: 'musicTrack',
-                images: [
-                  {
-                    url: imageUrl
-                  }
-                ],
-                title: track.title,
-                artist: owner.name
-              }
-            },
-            startTime
-          })
-        } catch (e) {
-          console.error('failed to load', e)
-        }
+        client.loadMedia({
+          mediaInfo: {
+            contentUrl,
+            metadata: {
+              type: 'musicTrack',
+              images: [
+                {
+                  url: imageUrl
+                }
+              ],
+              title: track.title,
+              artist: owner.name
+            }
+          },
+          startTime
+        })
       }
     },
     [client, owner]
@@ -113,9 +109,7 @@ export const useChromecast = () => {
     if (castState === CastState.CONNECTED) {
       const currentPosition = await TrackPlayer.getPosition()
       const currentPlaying = await TrackPlayer.getActiveTrack()
-      if (track && currentPlaying) {
-        loadCast(track, currentPosition, currentPlaying.url)
-      }
+      loadCast(track, currentPosition, currentPlaying?.url)
     }
   }, [loadCast, track, castState])
 

--- a/packages/mobile/src/components/now-playing-drawer/ActionsBar.tsx
+++ b/packages/mobile/src/components/now-playing-drawer/ActionsBar.tsx
@@ -29,7 +29,7 @@ import {
 import { formatPrice, Genre, removeNullable } from '@audius/common/utils'
 import type { Nullable } from '@audius/common/utils'
 import { View, Platform } from 'react-native'
-import { CastButton } from 'react-native-google-cast'
+import { CastButton, useDevices } from 'react-native-google-cast'
 import { useDispatch, useSelector } from 'react-redux'
 import { trpc } from 'utils/trpcClientWeb'
 
@@ -234,6 +234,7 @@ export const ActionsBar = ({ track }: ActionsBarProps) => {
   ])
 
   const { openAirplayDialog } = useAirplay()
+  const castDevices = useDevices()
 
   const renderPurchaseButton = () => {
     if (
@@ -266,7 +267,7 @@ export const ActionsBar = ({ track }: ActionsBarProps) => {
         />
       )
     }
-    return isReachable ? (
+    return isReachable && castDevices.length > 0 ? (
       <CastButton
         style={{
           ...styles.button,

--- a/packages/mobile/src/components/now-playing-drawer/ActionsBar.tsx
+++ b/packages/mobile/src/components/now-playing-drawer/ActionsBar.tsx
@@ -277,12 +277,7 @@ export const ActionsBar = ({ track }: ActionsBarProps) => {
       />
     ) : (
       <View style={{ ...styles.button, width: 24 }}>
-        <IconCastChromecast
-          fill={neutralLight6}
-          height={30}
-          width={30}
-          style={{ transform: [{ scaleX: -1 }] }}
-        />
+        <IconCastChromecast fill={neutralLight6} height={24} width={24} />
       </View>
     )
   }


### PR DESCRIPTION
### Description

Chromecast support was broken yet again due to changes to the way urls are constructed (api block track related?).
In any event, the current approach is super error prone, so utilize the content url directly from RNTP.

Fix a few other UX issues:
- Add buffering state for chromecast
- Don't move progress bar when cast is loading
- Render button when no devices found
- Handle stopping cast elegantly

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._

local device vs. google home