### PR TITLE
[C-4453] Fix notification email image and layout

### DIFF
--- a/packages/discovery-provider/plugins/notifications/src/__tests__/__snapshots__/emailRender.test.ts.snap
+++ b/packages/discovery-provider/plugins/notifications/src/__tests__/__snapshots__/emailRender.test.ts.snap
@@ -520,12 +520,6 @@ exports[`Render email Render a live email 1`] = `
     }
 
     @media (max-width: 720px) {
-      #bodyCell {
-        text-align: center;
-      }
-    }
-
-    @media (max-width: 720px) {
       .templateContainer {
         display: table !important;
         max-width: 384px !important;
@@ -1114,12 +1108,6 @@ exports[`Render email Render a multiple Message Reactions email 1`] = `
       #templateHeader p {
         font-size: 16px !important;
         line-height: 150% !important;
-      }
-    }
-
-    @media (max-width: 720px) {
-      #bodyCell {
-        text-align: center;
       }
     }
 
@@ -1716,12 +1704,6 @@ exports[`Render email Render a multiple Messages email 1`] = `
     }
 
     @media (max-width: 720px) {
-      #bodyCell {
-        text-align: center;
-      }
-    }
-
-    @media (max-width: 720px) {
       .templateContainer {
         display: table !important;
         max-width: 384px !important;
@@ -2310,12 +2292,6 @@ exports[`Render email Render a single Message Reaction email 1`] = `
       #templateHeader p {
         font-size: 16px !important;
         line-height: 150% !important;
-      }
-    }
-
-    @media (max-width: 720px) {
-      #bodyCell {
-        text-align: center;
       }
     }
 
@@ -2912,12 +2888,6 @@ exports[`Render email Render a single Message email 1`] = `
     }
 
     @media (max-width: 720px) {
-      #bodyCell {
-        text-align: center;
-      }
-    }
-
-    @media (max-width: 720px) {
       .templateContainer {
         display: table !important;
         max-width: 384px !important;
@@ -3506,12 +3476,6 @@ exports[`Render email Render a weekly email 1`] = `
       #templateHeader p {
         font-size: 16px !important;
         line-height: 150% !important;
-      }
-    }
-
-    @media (max-width: 720px) {
-      #bodyCell {
-        text-align: center;
       }
     }
 

--- a/packages/discovery-provider/plugins/notifications/src/__tests__/mappings/__snapshots__/addTrackToPlaylist.test.ts.snap
+++ b/packages/discovery-provider/plugins/notifications/src/__tests__/mappings/__snapshots__/addTrackToPlaylist.test.ts.snap
@@ -520,12 +520,6 @@ exports[`Add track to playlist notification Render a single Add Track To Playlis
     }
 
     @media (max-width: 720px) {
-      #bodyCell {
-        text-align: center;
-      }
-    }
-
-    @media (max-width: 720px) {
       .templateContainer {
         display: table !important;
         max-width: 384px !important;

--- a/packages/discovery-provider/plugins/notifications/src/__tests__/mappings/__snapshots__/announcement.test.ts.snap
+++ b/packages/discovery-provider/plugins/notifications/src/__tests__/mappings/__snapshots__/announcement.test.ts.snap
@@ -520,12 +520,6 @@ exports[`Announcement Notification Render a single announcement email 1`] = `
     }
 
     @media (max-width: 720px) {
-      #bodyCell {
-        text-align: center;
-      }
-    }
-
-    @media (max-width: 720px) {
       .templateContainer {
         display: table !important;
         max-width: 384px !important;

--- a/packages/discovery-provider/plugins/notifications/src/__tests__/mappings/__snapshots__/challengeReward.test.ts.snap
+++ b/packages/discovery-provider/plugins/notifications/src/__tests__/mappings/__snapshots__/challengeReward.test.ts.snap
@@ -520,12 +520,6 @@ exports[`Challenge Reward Notification Render a single challenge reward email 1`
     }
 
     @media (max-width: 720px) {
-      #bodyCell {
-        text-align: center;
-      }
-    }
-
-    @media (max-width: 720px) {
       .templateContainer {
         display: table !important;
         max-width: 384px !important;

--- a/packages/discovery-provider/plugins/notifications/src/__tests__/mappings/__snapshots__/cosign.test.ts.snap
+++ b/packages/discovery-provider/plugins/notifications/src/__tests__/mappings/__snapshots__/cosign.test.ts.snap
@@ -520,12 +520,6 @@ exports[`Cosign Notification Render a single cosign email 1`] = `
     }
 
     @media (max-width: 720px) {
-      #bodyCell {
-        text-align: center;
-      }
-    }
-
-    @media (max-width: 720px) {
       .templateContainer {
         display: table !important;
         max-width: 384px !important;

--- a/packages/discovery-provider/plugins/notifications/src/__tests__/mappings/__snapshots__/create.test.ts.snap
+++ b/packages/discovery-provider/plugins/notifications/src/__tests__/mappings/__snapshots__/create.test.ts.snap
@@ -520,12 +520,6 @@ exports[`Create Notification Process email notification for create album 1`] = `
     }
 
     @media (max-width: 720px) {
-      #bodyCell {
-        text-align: center;
-      }
-    }
-
-    @media (max-width: 720px) {
       .templateContainer {
         display: table !important;
         max-width: 384px !important;
@@ -1118,12 +1112,6 @@ exports[`Create Notification Process email notification for create playlist 1`] 
     }
 
     @media (max-width: 720px) {
-      #bodyCell {
-        text-align: center;
-      }
-    }
-
-    @media (max-width: 720px) {
       .templateContainer {
         display: table !important;
         max-width: 384px !important;
@@ -1712,12 +1700,6 @@ exports[`Create Notification Process email notification for create tracks 1`] = 
       #templateHeader p {
         font-size: 16px !important;
         line-height: 150% !important;
-      }
-    }
-
-    @media (max-width: 720px) {
-      #bodyCell {
-        text-align: center;
       }
     }
 

--- a/packages/discovery-provider/plugins/notifications/src/__tests__/mappings/__snapshots__/follow.test.ts.snap
+++ b/packages/discovery-provider/plugins/notifications/src/__tests__/mappings/__snapshots__/follow.test.ts.snap
@@ -520,12 +520,6 @@ exports[`Follow Notification Render a multi Follow email 1`] = `
     }
 
     @media (max-width: 720px) {
-      #bodyCell {
-        text-align: center;
-      }
-    }
-
-    @media (max-width: 720px) {
       .templateContainer {
         display: table !important;
         max-width: 384px !important;
@@ -1114,12 +1108,6 @@ exports[`Follow Notification Render a single Follow email 1`] = `
       #templateHeader p {
         font-size: 16px !important;
         line-height: 150% !important;
-      }
-    }
-
-    @media (max-width: 720px) {
-      #bodyCell {
-        text-align: center;
       }
     }
 

--- a/packages/discovery-provider/plugins/notifications/src/__tests__/mappings/__snapshots__/milestone.test.ts.snap
+++ b/packages/discovery-provider/plugins/notifications/src/__tests__/mappings/__snapshots__/milestone.test.ts.snap
@@ -520,12 +520,6 @@ exports[`Milestone Notification Process email notification for follow count mile
     }
 
     @media (max-width: 720px) {
-      #bodyCell {
-        text-align: center;
-      }
-    }
-
-    @media (max-width: 720px) {
       .templateContainer {
         display: table !important;
         max-width: 384px !important;
@@ -1114,12 +1108,6 @@ exports[`Milestone Notification Process email notification for playlist repost m
       #templateHeader p {
         font-size: 16px !important;
         line-height: 150% !important;
-      }
-    }
-
-    @media (max-width: 720px) {
-      #bodyCell {
-        text-align: center;
       }
     }
 
@@ -1716,12 +1704,6 @@ exports[`Milestone Notification Process email notification for playlist save mil
     }
 
     @media (max-width: 720px) {
-      #bodyCell {
-        text-align: center;
-      }
-    }
-
-    @media (max-width: 720px) {
       .templateContainer {
         display: table !important;
         max-width: 384px !important;
@@ -2314,12 +2296,6 @@ exports[`Milestone Notification Process email notification for track repost mile
     }
 
     @media (max-width: 720px) {
-      #bodyCell {
-        text-align: center;
-      }
-    }
-
-    @media (max-width: 720px) {
       .templateContainer {
         display: table !important;
         max-width: 384px !important;
@@ -2908,12 +2884,6 @@ exports[`Milestone Notification Process email notification for track save milest
       #templateHeader p {
         font-size: 16px !important;
         line-height: 150% !important;
-      }
-    }
-
-    @media (max-width: 720px) {
-      #bodyCell {
-        text-align: center;
       }
     }
 

--- a/packages/discovery-provider/plugins/notifications/src/__tests__/mappings/__snapshots__/multipleMappings.test.ts.snap
+++ b/packages/discovery-provider/plugins/notifications/src/__tests__/mappings/__snapshots__/multipleMappings.test.ts.snap
@@ -520,12 +520,6 @@ exports[`Multiple Mappings Notification Render multiple notifications in email 1
     }
 
     @media (max-width: 720px) {
-      #bodyCell {
-        text-align: center;
-      }
-    }
-
-    @media (max-width: 720px) {
       .templateContainer {
         display: table !important;
         max-width: 384px !important;

--- a/packages/discovery-provider/plugins/notifications/src/__tests__/mappings/__snapshots__/reaction.test.ts.snap
+++ b/packages/discovery-provider/plugins/notifications/src/__tests__/mappings/__snapshots__/reaction.test.ts.snap
@@ -520,12 +520,6 @@ exports[`Reaction Notification Process email notification for reaction 1`] = `
     }
 
     @media (max-width: 720px) {
-      #bodyCell {
-        text-align: center;
-      }
-    }
-
-    @media (max-width: 720px) {
       .templateContainer {
         display: table !important;
         max-width: 384px !important;

--- a/packages/discovery-provider/plugins/notifications/src/__tests__/mappings/__snapshots__/remix.test.ts.snap
+++ b/packages/discovery-provider/plugins/notifications/src/__tests__/mappings/__snapshots__/remix.test.ts.snap
@@ -520,12 +520,6 @@ exports[`Remix Notification Render a single Remix email 1`] = `
     }
 
     @media (max-width: 720px) {
-      #bodyCell {
-        text-align: center;
-      }
-    }
-
-    @media (max-width: 720px) {
       .templateContainer {
         display: table !important;
         max-width: 384px !important;

--- a/packages/discovery-provider/plugins/notifications/src/__tests__/mappings/__snapshots__/repost.test.ts.snap
+++ b/packages/discovery-provider/plugins/notifications/src/__tests__/mappings/__snapshots__/repost.test.ts.snap
@@ -520,12 +520,6 @@ exports[`Repost Notification Render a multi repost email 1`] = `
     }
 
     @media (max-width: 720px) {
-      #bodyCell {
-        text-align: center;
-      }
-    }
-
-    @media (max-width: 720px) {
       .templateContainer {
         display: table !important;
         max-width: 384px !important;
@@ -1114,12 +1108,6 @@ exports[`Repost Notification Render a single email 1`] = `
       #templateHeader p {
         font-size: 16px !important;
         line-height: 150% !important;
-      }
-    }
-
-    @media (max-width: 720px) {
-      #bodyCell {
-        text-align: center;
       }
     }
 

--- a/packages/discovery-provider/plugins/notifications/src/__tests__/mappings/__snapshots__/repostOfRepost.test.ts.snap
+++ b/packages/discovery-provider/plugins/notifications/src/__tests__/mappings/__snapshots__/repostOfRepost.test.ts.snap
@@ -520,12 +520,6 @@ exports[`Repost Of Repost Notification Render a single email 1`] = `
     }
 
     @media (max-width: 720px) {
-      #bodyCell {
-        text-align: center;
-      }
-    }
-
-    @media (max-width: 720px) {
       .templateContainer {
         display: table !important;
         max-width: 384px !important;

--- a/packages/discovery-provider/plugins/notifications/src/__tests__/mappings/__snapshots__/save.test.ts.snap
+++ b/packages/discovery-provider/plugins/notifications/src/__tests__/mappings/__snapshots__/save.test.ts.snap
@@ -520,12 +520,6 @@ exports[`Save Notification Render a multi save email 1`] = `
     }
 
     @media (max-width: 720px) {
-      #bodyCell {
-        text-align: center;
-      }
-    }
-
-    @media (max-width: 720px) {
       .templateContainer {
         display: table !important;
         max-width: 384px !important;
@@ -1114,12 +1108,6 @@ exports[`Save Notification Render a single email 1`] = `
       #templateHeader p {
         font-size: 16px !important;
         line-height: 150% !important;
-      }
-    }
-
-    @media (max-width: 720px) {
-      #bodyCell {
-        text-align: center;
       }
     }
 

--- a/packages/discovery-provider/plugins/notifications/src/__tests__/mappings/__snapshots__/saveOfRepost.test.ts.snap
+++ b/packages/discovery-provider/plugins/notifications/src/__tests__/mappings/__snapshots__/saveOfRepost.test.ts.snap
@@ -520,12 +520,6 @@ exports[`Save Of Repost Notification Render a single email 1`] = `
     }
 
     @media (max-width: 720px) {
-      #bodyCell {
-        text-align: center;
-      }
-    }
-
-    @media (max-width: 720px) {
       .templateContainer {
         display: table !important;
         max-width: 384px !important;

--- a/packages/discovery-provider/plugins/notifications/src/__tests__/mappings/__snapshots__/supporterRankUp.test.ts.snap
+++ b/packages/discovery-provider/plugins/notifications/src/__tests__/mappings/__snapshots__/supporterRankUp.test.ts.snap
@@ -520,12 +520,6 @@ exports[`Supporter Rank Up Notification Process email notification for supporter
     }
 
     @media (max-width: 720px) {
-      #bodyCell {
-        text-align: center;
-      }
-    }
-
-    @media (max-width: 720px) {
       .templateContainer {
         display: table !important;
         max-width: 384px !important;

--- a/packages/discovery-provider/plugins/notifications/src/__tests__/mappings/__snapshots__/supportingRankUp.test.ts.snap
+++ b/packages/discovery-provider/plugins/notifications/src/__tests__/mappings/__snapshots__/supportingRankUp.test.ts.snap
@@ -520,12 +520,6 @@ exports[`Supporting Rank Up Notification Process email notification for supporti
     }
 
     @media (max-width: 720px) {
-      #bodyCell {
-        text-align: center;
-      }
-    }
-
-    @media (max-width: 720px) {
       .templateContainer {
         display: table !important;
         max-width: 384px !important;

--- a/packages/discovery-provider/plugins/notifications/src/__tests__/mappings/__snapshots__/tastemaker.test.ts.snap
+++ b/packages/discovery-provider/plugins/notifications/src/__tests__/mappings/__snapshots__/tastemaker.test.ts.snap
@@ -520,12 +520,6 @@ exports[`Tastemaker Notification Render a single email 1`] = `
     }
 
     @media (max-width: 720px) {
-      #bodyCell {
-        text-align: center;
-      }
-    }
-
-    @media (max-width: 720px) {
       .templateContainer {
         display: table !important;
         max-width: 384px !important;

--- a/packages/discovery-provider/plugins/notifications/src/__tests__/mappings/__snapshots__/tip.test.ts.snap
+++ b/packages/discovery-provider/plugins/notifications/src/__tests__/mappings/__snapshots__/tip.test.ts.snap
@@ -520,12 +520,6 @@ exports[`Tip Notification Process email notification for tip receive 1`] = `
     }
 
     @media (max-width: 720px) {
-      #bodyCell {
-        text-align: center;
-      }
-    }
-
-    @media (max-width: 720px) {
       .templateContainer {
         display: table !important;
         max-width: 384px !important;

--- a/packages/discovery-provider/plugins/notifications/src/__tests__/mappings/__snapshots__/trendingPlaylist.test.ts.snap
+++ b/packages/discovery-provider/plugins/notifications/src/__tests__/mappings/__snapshots__/trendingPlaylist.test.ts.snap
@@ -520,12 +520,6 @@ exports[`Trending Playlist Notification Render a single email 1`] = `
     }
 
     @media (max-width: 720px) {
-      #bodyCell {
-        text-align: center;
-      }
-    }
-
-    @media (max-width: 720px) {
       .templateContainer {
         display: table !important;
         max-width: 384px !important;

--- a/packages/discovery-provider/plugins/notifications/src/__tests__/mappings/__snapshots__/trendingTrack.test.ts.snap
+++ b/packages/discovery-provider/plugins/notifications/src/__tests__/mappings/__snapshots__/trendingTrack.test.ts.snap
@@ -520,12 +520,6 @@ exports[`Trending Track Notification Render a single email 1`] = `
     }
 
     @media (max-width: 720px) {
-      #bodyCell {
-        text-align: center;
-      }
-    }
-
-    @media (max-width: 720px) {
       .templateContainer {
         display: table !important;
         max-width: 384px !important;

--- a/packages/discovery-provider/plugins/notifications/src/__tests__/mappings/__snapshots__/trendingUnderground.test.ts.snap
+++ b/packages/discovery-provider/plugins/notifications/src/__tests__/mappings/__snapshots__/trendingUnderground.test.ts.snap
@@ -520,12 +520,6 @@ exports[`Trending Underground Notification Render a single email 1`] = `
     }
 
     @media (max-width: 720px) {
-      #bodyCell {
-        text-align: center;
-      }
-    }
-
-    @media (max-width: 720px) {
       .templateContainer {
         display: table !important;
         max-width: 384px !important;

--- a/packages/discovery-provider/plugins/notifications/src/__tests__/mappings/__snapshots__/usdcPurchaseBuyer.test.ts.snap
+++ b/packages/discovery-provider/plugins/notifications/src/__tests__/mappings/__snapshots__/usdcPurchaseBuyer.test.ts.snap
@@ -520,12 +520,6 @@ exports[`USDC Purchase Buyer Render emails 1`] = `
     }
 
     @media (max-width: 720px) {
-      #bodyCell {
-        text-align: center;
-      }
-    }
-
-    @media (max-width: 720px) {
       .templateContainer {
         display: table !important;
         max-width: 384px !important;
@@ -1114,12 +1108,6 @@ exports[`USDC Purchase Buyer Render emails 2`] = `
       #templateHeader p {
         font-size: 16px !important;
         line-height: 150% !important;
-      }
-    }
-
-    @media (max-width: 720px) {
-      #bodyCell {
-        text-align: center;
       }
     }
 

--- a/packages/discovery-provider/plugins/notifications/src/__tests__/mappings/__snapshots__/usdcPurchaseSeller.test.ts.snap
+++ b/packages/discovery-provider/plugins/notifications/src/__tests__/mappings/__snapshots__/usdcPurchaseSeller.test.ts.snap
@@ -520,12 +520,6 @@ exports[`USDC Purchase Seller Render emails 1`] = `
     }
 
     @media (max-width: 720px) {
-      #bodyCell {
-        text-align: center;
-      }
-    }
-
-    @media (max-width: 720px) {
       .templateContainer {
         display: table !important;
         max-width: 384px !important;
@@ -1114,12 +1108,6 @@ exports[`USDC Purchase Seller Render emails 2`] = `
       #templateHeader p {
         font-size: 16px !important;
         line-height: 150% !important;
-      }
-    }
-
-    @media (max-width: 720px) {
-      #bodyCell {
-        text-align: center;
       }
     }
 

--- a/packages/discovery-provider/plugins/notifications/src/email/notifications/components/BodyStyles.tsx
+++ b/packages/discovery-provider/plugins/notifications/src/email/notifications/components/BodyStyles.tsx
@@ -395,12 +395,6 @@ export const BodyStyles = () => {
     }
 
     @media (max-width: 720px) {
-      #bodyCell {
-        text-align: center;
-      }
-    }
-
-    @media (max-width: 720px) {
       .templateContainer {
         display: table !important;
         max-width: 384px !important;

--- a/packages/discovery-provider/plugins/notifications/src/email/notifications/renderEmail.ts
+++ b/packages/discovery-provider/plugins/notifications/src/email/notifications/renderEmail.ts
@@ -11,6 +11,7 @@ import { Knex } from 'knex'
 import { mapNotifications } from '../../processNotifications/mappers/mapNotifications'
 import { BaseNotification } from '../../processNotifications/mappers/base'
 import { EmailFrequency } from '../../processNotifications/mappers/userNotificationSettings'
+import { getContentNode } from '../../utils/env'
 
 type RenderEmailProps = {
   userId: number
@@ -86,16 +87,12 @@ const DEFAULT_TRACK_COVER_ART_URL = ''
 const DEFAULT_PLAYLIST_IMAGE_IRL = ''
 
 const getUserProfileUrl = (user: UserResource) => {
-  if (!user.creator_node_endpoint) {
-    return null
-  }
-  const contentNodes = user.creator_node_endpoint.split(',')
-  const primaryEndpoint = contentNodes[0]
   let profilePictureUrl = DEFAULT_PROFILE_IMG
+  const contentNode = getContentNode()
   if (user.profile_picture_sizes) {
-    profilePictureUrl = `${primaryEndpoint}/ipfs/${user.profile_picture_sizes}/1000x1000.jpg`
+    profilePictureUrl = `${contentNode}/content/${user.profile_picture_sizes}/1000x1000.jpg`
   } else if (user.profile_picture) {
-    profilePictureUrl = `${primaryEndpoint}/ipfs/${user.profile_picture}`
+    profilePictureUrl = `${contentNode}/content/${user.profile_picture}`
   }
   return profilePictureUrl
 }
@@ -252,7 +249,7 @@ const getNotificationProps = async (
   for (const notification of mappedNotifications) {
     const resourcesToFetch = notification.getResourcesForEmail()
     Object.entries(resourcesToFetch).forEach(([key, value]) => {
-      ; (value as Set<number>).forEach(
+      ;(value as Set<number>).forEach(
         idsToFetch[key as keyof ResourceIds].add,
         idsToFetch[key as keyof ResourceIds]
       )
@@ -266,7 +263,7 @@ const getNotificationProps = async (
       for (const notification of acc[n]) {
         const resourcesToFetch = notification.getResourcesForEmail()
         Object.entries(resourcesToFetch).forEach(([key, value]) => {
-          ; (value as Set<number>).forEach(
+          ;(value as Set<number>).forEach(
             idsToFetch[key as keyof ResourceIds].add,
             idsToFetch[key as keyof ResourceIds]
           )
@@ -310,12 +307,15 @@ const getEmailSubject = (
   // they receive the email.
   const formattedDayAgo = now.format('MMMM Do YYYY')
   const shortWeekAgoFormat = weekAgo.format('MMMM Do')
-  const liveSubjectFormat = `${notificationCount} unread notification${notificationCount > 1 ? 's' : ''
-    }`
-  const weeklySubjectFormat = `${notificationCount} unread notification${notificationCount > 1 ? 's' : ''
-    } from ${shortWeekAgoFormat} - ${formattedDayAgo}`
-  const dailySubjectFormat = `${notificationCount} unread notification${notificationCount > 1 ? 's' : ''
-    } from ${formattedDayAgo}`
+  const liveSubjectFormat = `${notificationCount} unread notification${
+    notificationCount > 1 ? 's' : ''
+  }`
+  const weeklySubjectFormat = `${notificationCount} unread notification${
+    notificationCount > 1 ? 's' : ''
+  } from ${shortWeekAgoFormat} - ${formattedDayAgo}`
+  const dailySubjectFormat = `${notificationCount} unread notification${
+    notificationCount > 1 ? 's' : ''
+  } from ${formattedDayAgo}`
 
   let subject
   if (frequency === 'live') {

--- a/packages/discovery-provider/plugins/notifications/src/email/notifications/sendEmail.ts
+++ b/packages/discovery-provider/plugins/notifications/src/email/notifications/sendEmail.ts
@@ -5,9 +5,7 @@ import { logger } from '../../logger'
 import { getSendgrid } from '../../sendgrid'
 import { MailDataRequired } from '@sendgrid/mail'
 import { Knex } from 'knex'
-import {
-  EmailFrequency,
-} from '../../processNotifications/mappers/userNotificationSettings'
+import { EmailFrequency } from '../../processNotifications/mappers/userNotificationSettings'
 
 // id of unsubscribe group at https://mc.sendgrid.com/unsubscribe-groups
 const NOTIFICATION_EMAIL_UNSUBSCRIBE_GROUP_ID = 19141
@@ -81,7 +79,7 @@ export const sendNotificationEmail = async ({
       html: notifHtml,
       subject: emailSubject,
       asm: {
-        groupId: NOTIFICATION_EMAIL_UNSUBSCRIBE_GROUP_ID 
+        groupId: NOTIFICATION_EMAIL_UNSUBSCRIBE_GROUP_ID
       }
     }
 

--- a/packages/discovery-provider/plugins/notifications/src/processNotifications/mappers/create.ts
+++ b/packages/discovery-provider/plugins/notifications/src/processNotifications/mappers/create.ts
@@ -118,17 +118,18 @@ export class Create extends BaseNotification<CreateNotificationRow> {
     if (this.trackId) {
       description = `${userName} released a new track`
     } else {
-      description = `${userName} released a new ${this.isAlbum ? 'album' : 'playlist'
-        } ${playlist.playlist_name}`
+      description = `${userName} released a new ${
+        this.isAlbum ? 'album' : 'playlist'
+      } ${playlist.playlist_name}`
     }
 
     const entityType = this.trackId
       ? 'Track'
       : this.playlistId && this.isAlbum
-        ? 'Album'
-        : this.playlistId && !this.isAlbum
-          ? 'Playlist'
-          : null
+      ? 'Album'
+      : this.playlistId && !this.isAlbum
+      ? 'Playlist'
+      : null
 
     const entityId = this.trackId ?? this.playlistId
 
@@ -191,8 +192,9 @@ export class Create extends BaseNotification<CreateNotificationRow> {
                 body: description,
                 data: {
                   type: 'UserSubscription',
-                  id: `timestamp:${this.getNotificationTimestamp()}:group_id:${this.notification.group_id
-                    }`,
+                  id: `timestamp:${this.getNotificationTimestamp()}:group_id:${
+                    this.notification.group_id
+                  }`,
                   entityType: capitalize(entityType),
                   entityIds: [entityId],
                   userId: ownerId


### PR DESCRIPTION
### Description
Notification emails look wonky because:
* Storage V2 stores images in a different URL. We can let the selected content node handle rendezvous.
* Responsive mobile Safari / Apple Mail changes the layout. Removing this `text-align` fixes. 

![IMG_3770](https://github.com/AudiusProject/audius-protocol/assets/6413636/a6f77fd7-15e4-4ec8-b5f7-b0f6f05e772e)


### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._

Ran with stage DN1. Confirmed layout looks good on web and mobile Chrome / Safari.

![IMG_3769](https://github.com/AudiusProject/audius-protocol/assets/6413636/61781f84-6ba6-45a4-824d-fd63ee1a81fa)
