### PR TITLE
[PROTO-1780] Import rewards claim utility from audius-docker-compose

### DIFF
--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -26,6 +26,7 @@ jobs:
               - 'packages/fixed-decimal/**'
               - 'packages/harmony/**'
               - 'packages/libs/**'
+              - 'packages/sp-actions/**'
               - 'packages/spl/**'
 
   publish-packages:

--- a/packages/sp-actions/README.md
+++ b/packages/sp-actions/README.md
@@ -17,7 +17,7 @@ Any wallet can make a claim on behalf of any node operator and their delegators 
 npm install -g @audius/sp-actions
 
 # 3. Setup a cron job with the following command: (NOTE: replace <npm_prefix> with the output from 'npm config get prefix')
-(crontab -l 2>/dev/null; echo "0 */6 * * * <npm_prefix>/node_modules/@audius/sp-actions/claim.js claim-rewards <spOwnerWallet> <privateKey>") | crontab -
+(crontab -l 2>/dev/null; echo "0 */6 * * * <npm_prefix>/bin/claim claim-rewards <spOwnerWallet> <privateKey>") | crontab -
 ```
 
 ```

--- a/packages/sp-actions/README.md
+++ b/packages/sp-actions/README.md
@@ -1,0 +1,61 @@
+## Automatic claims
+
+This utility enables Audius Service Providers to automatically run claim operations whenever a new round is initiated.
+
+This script can run on a recurring basis via cron and takes in two command line arguments: `spOwnerWallet` and `privateKey`.
+
+`spOwnerWallet` - The wallet address used to register the nodes
+
+`privateKey` - Not the private key of the `spOwnerWallet`. Should be a throwaway wallet used exclusively to claim with just enough ETH to make claims, no more than 1 ETH at any given time with an alert to top up.
+
+Any wallet can make a claim on behalf of any node operator and their delegators and the rewards will be distributed to the node operator and the delegators inside the staking system and not to the wallet performing the claim. In order to access the claim, the node operator or delegator would have to request to undelegate.
+
+```
+# 1. Ensure npm is installed on your system
+
+# 2. Install the actions utility
+npm install -g @audius/sp-actions
+
+# 3. Setup a cron job with the following command: (NOTE: replace <npm_prefix> with the output from 'npm config get prefix')
+(crontab -l 2>/dev/null; echo "0 */6 * * * <npm_prefix>/node_modules/@audius/sp-actions/claim.js claim-rewards <spOwnerWallet> <privateKey>") | crontab -
+```
+
+```
+Usage: claim [options] [command]
+
+Options:
+  -h, --help                                            display help for command
+
+Commands:
+  initiate-round [options] <privateKey>                 Initiates new round for claiming rewards
+  claim-rewards [options] <spOwnerWallet> <privateKey>  Claim rewards for given spOwnerWallet
+  help [command]                                        display help for command
+```
+
+```
+Usage: claim initiate-round [options] <privateKey>
+
+Initiates new round for claiming rewards
+
+Options:
+  --eth-registry-address <ethRegistryAddress>  Registry contract address (default: "0xd976d3b4f4e22a238c1A736b6612D22f17b6f64C")
+  --eth-token-address <ethTokenAddress>        Token contract address (default: "0x18aAA7115705e8be94bfFEBDE57Af9BFc265B998")
+  --web3-provider <web3Provider>               Web3 provider to use
+  --gas <gas>                                  ammount of gas to use (default: 100000)
+  --gas-price <gasPrice>                       gas price in gwei
+  -h, --help                                   display help for command
+```
+
+```
+Usage: claim claim-rewards [options] <spOwnerWallet> <privateKey>
+
+Claim rewards for given spOwnerWallet
+
+Options:
+  --eth-registry-address <ethRegistryAddress>  Registry contract address (default: "0xd976d3b4f4e22a238c1A736b6612D22f17b6f64C")
+  --eth-token-address <ethTokenAddress>        Token contract address (default: "0x18aAA7115705e8be94bfFEBDE57Af9BFc265B998")
+  --web3-provider <web3Provider>               Web3 provider to use
+  --gas <gas>                                  ammount of gas to use (default: 1000000)
+  --gas-price <gasPrice>                       gas price in gwei
+  -h, --help                                   display help for command
+```

--- a/packages/sp-actions/claim.js
+++ b/packages/sp-actions/claim.js
@@ -5,21 +5,21 @@ const Web3 = require('web3')
 const HDWalletProvider = require('@truffle/hdwallet-provider')
 const { program } = require('commander')
 
-const audius = require('@audius/libs')
+const { AudiusLibs } = require('@audius/sdk')
 
 const defaultRegistryAddress = '0xd976d3b4f4e22a238c1A736b6612D22f17b6f64C'
 const defaultTokenAddress = '0x18aAA7115705e8be94bfFEBDE57Af9BFc265B998'
 const defaultWeb3Provider = 'https://eth-mainnet.g.alchemy.com/v2/4hFRA61i6OFXz2UmkyFsSvgXBQBBOGgW'
 
 async function configureLibs(ethRegistryAddress, ethTokenAddress, web3Provider) {
-  const configuredWeb3 = await audius.Utils.configureWeb3(web3Provider, null, false)
+  const configuredWeb3 = await AudiusLibs.Utils.configureWeb3(web3Provider, null, false)
 
   const audiusLibsConfig = {
-    ethWeb3Config: audius.configEthWeb3(ethTokenAddress, ethRegistryAddress, configuredWeb3, '0x0'),
+    ethWeb3Config: AudiusLibs.configEthWeb3(ethTokenAddress, ethRegistryAddress, configuredWeb3, '0x0'),
     isServer: true,
   }
 
-  const libs = new audius(audiusLibsConfig)
+  const libs = new AudiusLibs(audiusLibsConfig)
   await libs.init()
 
   return libs
@@ -81,7 +81,7 @@ async function initiateRound(privateKey, { ethRegistryAddress, ethTokenAddress, 
   console.log('Successfully initiated Round')
 
   if (transferRewardsToSolana) {
-    const { transferCommunityRewardsToSolana } = require('@audius/libs/scripts/communityRewards/transferCommunityRewardsToSolana')
+    const { transferCommunityRewardsToSolana } = require('@audius/sdk/scripts/communityRewards/transferCommunityRewardsToSolana')
     console.log('Running rewards manager transfer')
     await transferCommunityRewardsToSolana()
     console.log('Successfully transferred rewards to solana')

--- a/packages/sp-actions/claim.js
+++ b/packages/sp-actions/claim.js
@@ -1,0 +1,165 @@
+#!/usr/bin/env node
+
+const axios = require('axios')
+const Web3 = require('web3')
+const HDWalletProvider = require('@truffle/hdwallet-provider')
+const { program } = require('commander')
+
+const audius = require('@audius/libs')
+
+const defaultRegistryAddress = '0xd976d3b4f4e22a238c1A736b6612D22f17b6f64C'
+const defaultTokenAddress = '0x18aAA7115705e8be94bfFEBDE57Af9BFc265B998'
+const defaultWeb3Provider = 'https://eth-mainnet.g.alchemy.com/v2/4hFRA61i6OFXz2UmkyFsSvgXBQBBOGgW'
+
+async function configureLibs(ethRegistryAddress, ethTokenAddress, web3Provider) {
+  const configuredWeb3 = await audius.Utils.configureWeb3(web3Provider, null, false)
+
+  const audiusLibsConfig = {
+    ethWeb3Config: audius.configEthWeb3(ethTokenAddress, ethRegistryAddress, configuredWeb3, '0x0'),
+    isServer: true,
+  }
+
+  const libs = new audius(audiusLibsConfig)
+  await libs.init()
+
+  return libs
+}
+
+async function getClaimsManagerContract(ethRegistryAddress, ethTokenAddress, web3) {
+  const audiusLibs = await configureLibs(ethRegistryAddress, ethTokenAddress, web3.eth.currentProvider)
+  await audiusLibs.ethContracts.ClaimsManagerClient.init()
+  return new web3.eth.Contract(
+    audiusLibs.ethContracts.ClaimsManagerClient._contract.options.jsonInterface,
+    audiusLibs.ethContracts.ClaimsManagerClient._contract.options.address
+  )
+}
+
+async function getDelegateManagerContract(ethRegistryAddress, ethTokenAddress, web3) {
+  const audiusLibs = await configureLibs(ethRegistryAddress, ethTokenAddress, web3.eth.currentProvider)
+  await audiusLibs.ethContracts.DelegateManagerClient.init()
+  return new web3.eth.Contract(
+    audiusLibs.ethContracts.DelegateManagerClient._contract.options.jsonInterface,
+    audiusLibs.ethContracts.DelegateManagerClient._contract.options.address
+  )
+}
+
+async function initiateRound(privateKey, { ethRegistryAddress, ethTokenAddress, web3Provider, gas, gasPrice, transferRewardsToSolana }) {
+  const web3 = new Web3(
+    new HDWalletProvider({
+      privateKeys: [privateKey],
+      providerOrUrl: web3Provider,
+    })
+  )
+
+  web3.eth.transactionPollingTimeout = 3600
+  const accountAddress = web3.eth.accounts.privateKeyToAccount(privateKey).address
+
+  const claimsManagerContract = await getClaimsManagerContract(ethRegistryAddress, ethTokenAddress, web3)
+
+  const lastFundedBlock = await claimsManagerContract.methods.getLastFundedBlock().call()
+  const requiredBlockDiff = await claimsManagerContract.methods.getFundingRoundBlockDiff().call()
+
+  const currentBlock = await web3.eth.getBlockNumber()
+  const blockDiff = currentBlock - lastFundedBlock - 12
+
+  if (blockDiff <= requiredBlockDiff) {
+    console.log(`Block difference of ${requiredBlockDiff} not met, ${requiredBlockDiff - blockDiff} blocks remaining`)
+    process.exit(1)
+  }
+
+  if (gas === undefined) {
+    console.log('Estimating Gas')
+    gas = await claimsManagerContract.methods.initiateRound().estimateGas()
+    console.log('Calculated Gas:', gas)
+  }
+
+  console.log('Initializing Round')
+  await claimsManagerContract.methods.initiateRound().send({
+    from: accountAddress,
+    gas
+  })
+  console.log('Successfully initiated Round')
+
+  if (transferRewardsToSolana) {
+    const { transferCommunityRewardsToSolana } = require('@audius/libs/scripts/communityRewards/transferCommunityRewardsToSolana')
+    console.log('Running rewards manager transfer')
+    await transferCommunityRewardsToSolana()
+    console.log('Successfully transferred rewards to solana')
+  }
+}
+
+async function claimRewards(
+  spOwnerWallet,
+  privateKey,
+  { ethRegistryAddress, ethTokenAddress, web3Provider, gas, gasPrice }
+) {
+  const web3 = new Web3(
+    new HDWalletProvider({
+      privateKeys: [privateKey],
+      providerOrUrl: web3Provider,
+    })
+  )
+
+  web3.eth.transactionPollingTimeout = 3600
+  const accountAddress = web3.eth.accounts.privateKeyToAccount(privateKey).address
+
+  const claimsManagerContract = await getClaimsManagerContract(ethRegistryAddress, ethTokenAddress, web3)
+  const delegateManagerContract = await getDelegateManagerContract(ethRegistryAddress, ethTokenAddress, web3)
+
+  const claimPending = await claimsManagerContract.methods.claimPending(spOwnerWallet).call()
+
+  if (claimPending) {
+    if (gas === undefined) {
+      console.log('Estimating Gas')
+      gas = await delegateManagerContract.methods.claimRewards(spOwnerWallet).estimateGas()
+      console.log('Calculated Gas:', gas)
+
+      const gasPrice = await web3.eth.getGasPrice()
+      const estimatedFee = gas * gasPrice
+      console.log('Estimated Fee:', web3.utils.fromWei(estimatedFee.toString(), 'ether'), 'ETH')
+    }
+
+    console.log('Claiming Rewards')
+    await delegateManagerContract.methods.claimRewards(spOwnerWallet).send({
+      from: accountAddress,
+      gas,
+      gasPrice: gasPrice ? web3.utils.toWei(gasPrice, 'gwei') : (await web3.eth.getGasPrice()),
+    })
+    console.log('Claimed Rewards successfully')
+  } else {
+    console.log('No claims pending')
+  }
+}
+
+async function main() {
+  program
+    .command('initiate-round <privateKey>')
+    .description('Initiates new round for claiming rewards')
+    .option('--eth-registry-address <ethRegistryAddress>', 'Registry contract address', defaultRegistryAddress)
+    .option('--eth-token-address <ethTokenAddress>', 'Token contract address', defaultTokenAddress)
+    .option('--web3-provider <web3Provider>', 'Web3 provider to use', defaultWeb3Provider)
+    .option('--gas <gas>', 'amount of gas to use')
+    .option('--gas-price <gasPrice>', 'gas price in gwei')
+    .option('--transfer-rewards-to-solana', 'whether to also transfer rewards to solana rewards manager on success. Requires env vars to be set.', false)
+    .action(initiateRound)
+
+  program
+    .command('claim-rewards <spOwnerWallet> <privateKey>')
+    .description('Claim rewards for given spOwnerWallet')
+    .option('--eth-registry-address <ethRegistryAddress>', 'Registry contract address', defaultRegistryAddress)
+    .option('--eth-token-address <ethTokenAddress>', 'Token contract address', defaultTokenAddress)
+    .option('--web3-provider <web3Provider>', 'Web3 provider to use', defaultWeb3Provider)
+    .option('--gas <gas>', 'ammount of gas to use')
+    .option('--gas-price <gasPrice>', 'gas price in gwei')
+    .action(claimRewards)
+
+  try {
+    await program.parseAsync(process.argv)
+    process.exit(0)
+  } catch (e) {
+    console.error(e)
+    process.exit(1)
+  }
+}
+
+main()

--- a/packages/sp-actions/package.json
+++ b/packages/sp-actions/package.json
@@ -8,7 +8,7 @@
   "author": "Audius",
   "license": "Apache-2.0",
   "dependencies": {
-    "@audius/libs": "1.2.118",
+    "@audius/sdk": "4.1.0",
     "@truffle/hdwallet-provider": "^1.2.2",
     "axios": "^0.21.0",
     "commander": "^6.2.1",

--- a/packages/sp-actions/package.json
+++ b/packages/sp-actions/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "@audius/sp-actions",
+  "version": "1.0.0",
+  "description": "A utility for audius service providers to claim token rewards.",
+  "bin": {
+      "claim": "claim.js"
+  },
+  "author": "Audius",
+  "license": "Apache-2.0",
+  "dependencies": {
+    "@audius/libs": "1.2.118",
+    "@truffle/hdwallet-provider": "^1.2.2",
+    "axios": "^0.21.0",
+    "commander": "^6.2.1",
+    "web3": "^1.3.4"
+  },
+  "bugs": {
+    "url": "https://github.com/AudiusProject/audius-protocol/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/AudiusProject/audius-protocol.git#main"
+  },
+  "homepage": "https://github.com/AudiusProject/audius-protocol/tree/main/packages/sp-actions",
+  "prettier": {
+    "semi": false,
+    "singleQuote": true
+  }
+}

--- a/scripts/publish-packages.sh
+++ b/scripts/publish-packages.sh
@@ -18,4 +18,4 @@ npx turbo run build lint typecheck test \
     --filter=@audius/spl \
 
 echo "Publishing packages..."
-npx changeset publish  
+npx changeset publish

--- a/scripts/publish-packages.sh
+++ b/scripts/publish-packages.sh
@@ -11,6 +11,7 @@ echo "Running build, lint, typecheck, and test..."
 # otherwise they won't get built/linted/tested before being published
 npx turbo run build lint typecheck test \
     --filter=create-audius-app \
+    --filter=@audius/sp-actions \
     --filter=@audius/fixed-decimal \
     --filter=@audius/harmony \
     --filter=@audius/sdk \


### PR DESCRIPTION
### Description

Since audius-docker-compose is being deprecated, we need a sensible place to put some of the utilities that node operators might still find useful. Since this utility relies on the sdk, it can't be easily incorporated into audius-ctl, so a standalone package will suffice.

### How Has This Been Tested?

Installed package locally and ensured command can be run. Relevant business logic has not been modified.