### PR TITLE
[PROTO-1850] Upgrade to circleci machine runner

### DIFF
--- a/.circleci/scripts/circleci-startup-script.sh
+++ b/.circleci/scripts/circleci-startup-script.sh
@@ -47,6 +47,9 @@ RUNNER_AUTH_TOKEN="$(gcloud secrets versions access 1 --secret=$gcp_key)"
 export RUNNER_AUTH_TOKEN
 sed -i "s/<< AUTH_TOKEN >>/$RUNNER_AUTH_TOKEN/g" /etc/circleci-runner/circleci-runner-config.yaml
 
+# allow sudo
+echo "circleci ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/circleci
+chmod 440 /etc/sudoers.d/circleci
 
 systemctl enable circleci-runner
 systemctl start circleci-runner

--- a/.circleci/scripts/circleci-startup-script.sh
+++ b/.circleci/scripts/circleci-startup-script.sh
@@ -51,5 +51,9 @@ sed -i "s/<< AUTH_TOKEN >>/$RUNNER_AUTH_TOKEN/g" /etc/circleci-runner/circleci-r
 echo "circleci ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/circleci
 chmod 440 /etc/sudoers.d/circleci
 
+# allow docker
+groupadd -f docker
+usermod -aG docker circleci
+
 systemctl enable circleci-runner
 systemctl start circleci-runner

--- a/.circleci/scripts/circleci-startup-script.sh
+++ b/.circleci/scripts/circleci-startup-script.sh
@@ -5,8 +5,8 @@ set -ex
 # Self-hosted runners should link to this file as the startup script.
 
 # Stop circleci if it exists and is running
-systemctl stop circleci.service &>/dev/null || true
-systemctl disable circleci.service &>/dev/null || true
+systemctl stop circleci-runner &>/dev/null || true
+systemctl disable circleci-runner &>/dev/null || true
 
 
 # set platform used for circleci installer and token
@@ -37,70 +37,16 @@ esac
 apt install -y git coreutils curl
 
 
-# download and run circleci agent installer script
-curl -L https://raw.githubusercontent.com/CircleCI-Public/runner-installation-files/main/download-launch-agent.sh -o download-launch-agent.sh
-sh ./download-launch-agent.sh
-rm download-launch-agent.sh
-
-
-# setup user and dirs
-id -u circleci &>/dev/null || adduser --disabled-password --gecos GECOS circleci
-groupadd -f docker
-usermod -aG docker circleci
-mkdir -p /var/opt/circleci
-chmod 0750 /var/opt/circleci
-chown -R circleci /var/opt/circleci /opt/circleci
+# download and run circleci cli installer script
+curl -s https://packagecloud.io/install/repositories/circleci/runner/script.deb.sh?any=true | bash
+apt install -y circleci-runner
 
 
 # setup config
-mkdir -p /etc/opt/circleci && touch /etc/opt/circleci/launch-agent-config.yaml
-chown -R circleci: /etc/opt/circleci
-chmod 600 /etc/opt/circleci/launch-agent-config.yaml
-cat <<EOT > /etc/opt/circleci/launch-agent-config.yaml
-api:
-  auth_token: $(gcloud secrets versions access 1 --secret=$gcp_key)
-
-runner:
-  name: $(hostname)
-  working_directory: /var/opt/circleci/workdir
-  cleanup_working_directory: true
-EOT
+RUNNER_AUTH_TOKEN="$(gcloud secrets versions access 1 --secret=$gcp_key)"
+export RUNNER_AUTH_TOKEN
+sed -i "s/<< AUTH_TOKEN >>/$RUNNER_AUTH_TOKEN/g" /etc/circleci-runner/circleci-runner-config.yaml
 
 
-# allow sudo
-echo "circleci ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/circleci
-chmod 440 /etc/sudoers.d/circleci
-
-
-# setup circleci systemd service
-touch /usr/lib/systemd/system/circleci.service
-chown root: /usr/lib/systemd/system/circleci.service
-chmod 755 /usr/lib/systemd/system/circleci.service
-cat <<EOT > /usr/lib/systemd/system/circleci.service
-[Unit]
-Description=CircleCI Runner
-After=network.target
-[Service]
-ExecStart=/opt/circleci/circleci-launch-agent --config /etc/opt/circleci/launch-agent-config.yaml
-Restart=always
-User=circleci
-NotifyAccess=exec
-TimeoutStopSec=18300
-[Install]
-WantedBy = multi-user.target
-EOT
-systemctl enable circleci.service
-systemctl start circleci.service
-
-cleanup_comment='# circleci runner auto-prune'
-
-# remove existing cleanup job from crontab if present
-tmpcron="$(mktemp)"
-grep -v "$cleanup_comment" /etc/crontab > "$tmpcron"
-cat "$tmpcron" > /etc/crontab
-
-# remove deprecated hourly cleanup script
-rm /etc/cron.hourly/audius-ci-hourly || true
-
-# remove deprecated periodic-cleanup script
-rm /usr/local/sbin/periodic-cleanup || true
+systemctl enable circleci-runner
+systemctl start circleci-runner


### PR DESCRIPTION
### Description

CircleCI is deprecating the original self-hosted runner setup in favor of a (hopefully) more simplified system.

### How Has This Been Tested?

Created circleci-runner-test instance and ensured it could successfully complete a CI job.