### PR TITLE
[QA-1335] Fix embed for non-premium tracks

### DIFF
--- a/packages/embed/src/components/collection/CollectionPlayerCard.jsx
+++ b/packages/embed/src/components/collection/CollectionPlayerCard.jsx
@@ -95,7 +95,8 @@ const CollectionPlayerCard = ({
 }) => {
   const makeOnTogglePlay = (index) => () => onTogglePlay(index)
   const permalink = `${stripLeadingSlash(collection.permalink)}`
-  const isPurchaseable = instanceOfPurchaseGate(streamConditions)
+  const isPurchaseable =
+    streamConditions && instanceOfPurchaseGate(streamConditions)
   return (
     <Card
       isTwitter={isTwitter}

--- a/packages/embed/src/components/collection/CollectionPlayerContainer.jsx
+++ b/packages/embed/src/components/collection/CollectionPlayerContainer.jsx
@@ -33,9 +33,9 @@ const CollectionPlayerContainer = ({
   const getTrackInfoForPlayback = useCallback(
     (trackIndex) => {
       const activeTrack = collection.tracks[trackIndex]
-      const isPurchaseable = instanceOfPurchaseGate(
-        activeTrack.streamConditions
-      )
+      const isPurchaseable =
+        activeTrack.streamConditions &&
+        instanceOfPurchaseGate(activeTrack.streamConditions)
       if (activeTrack == null) {
         return null
       }

--- a/packages/embed/src/components/pausedpopover/ListenOnAudiusCTA.jsx
+++ b/packages/embed/src/components/pausedpopover/ListenOnAudiusCTA.jsx
@@ -13,7 +13,8 @@ const ListenOnAudiusCTA = ({ audiusURL, streamConditions }) => {
   const onClick = () => {
     window.open(getCopyableLink(audiusURL), '_blank')
   }
-  const isPurchaseable = instanceOfPurchaseGate(streamConditions)
+  const isPurchaseable =
+    streamConditions && instanceOfPurchaseGate(streamConditions)
 
   return (
     <Button

--- a/packages/embed/src/components/pausedpopover/PrimaryLabel.jsx
+++ b/packages/embed/src/components/pausedpopover/PrimaryLabel.jsx
@@ -7,7 +7,8 @@ const messages = {
 }
 
 const PrimaryLabel = ({ streamConditions, isTrack }) => {
-  const isPurchaseable = instanceOfPurchaseGate(streamConditions)
+  const isPurchaseable =
+    streamConditions && instanceOfPurchaseGate(streamConditions)
 
   return (
     <Text color='default' variant='heading' size='s'>

--- a/packages/embed/src/components/track/TrackPlayerCard.jsx
+++ b/packages/embed/src/components/track/TrackPlayerCard.jsx
@@ -60,7 +60,8 @@ const TrackPlayerCard = ({
     }
     setArtworkWrapperStyle(newStyle)
   }, [height, width])
-  const isPurchaseable = instanceOfPurchaseGate(streamConditions)
+  const isPurchaseable =
+    streamConditions && instanceOfPurchaseGate(streamConditions)
 
   return (
     <Card

--- a/packages/embed/src/components/track/TrackPlayerCompact.jsx
+++ b/packages/embed/src/components/track/TrackPlayerCompact.jsx
@@ -27,7 +27,8 @@ const TrackPlayerCompact = ({
   backgroundColor,
   streamConditions
 }) => {
-  const isPurchaseable = instanceOfPurchaseGate(streamConditions)
+  const isPurchaseable =
+    streamConditions && instanceOfPurchaseGate(streamConditions)
 
   return (
     <div

--- a/packages/embed/src/components/track/TrackPlayerContainer.jsx
+++ b/packages/embed/src/components/track/TrackPlayerContainer.jsx
@@ -52,7 +52,7 @@ const TrackPlayerContainer = ({
 
   const trackInfoForPlayback = useMemo(() => {
     const isPurchaseable =
-      streamConditions && instanceOfPurchaseGate(track.streamConditions)
+      track.streamConditions && instanceOfPurchaseGate(track.streamConditions)
     return {
       gateways: formatGateways(track.user.creatorNodeEndpoint),
       title: track.title,

--- a/packages/embed/src/components/track/TrackPlayerContainer.jsx
+++ b/packages/embed/src/components/track/TrackPlayerContainer.jsx
@@ -51,7 +51,8 @@ const TrackPlayerContainer = ({
   } = usePlayback(track.id, onTrackEnd)
 
   const trackInfoForPlayback = useMemo(() => {
-    const isPurchaseable = instanceOfPurchaseGate(track.streamConditions)
+    const isPurchaseable =
+      streamConditions && instanceOfPurchaseGate(track.streamConditions)
     return {
       gateways: formatGateways(track.user.creatorNodeEndpoint),
       title: track.title,

--- a/packages/embed/src/components/track/TrackPlayerTiny.jsx
+++ b/packages/embed/src/components/track/TrackPlayerTiny.jsx
@@ -74,7 +74,8 @@ const TrackPlayerTiny = ({
     infoStyle['--info-width'] = `${infoWidth + MARQUEE_SPACING}px`
   }
 
-  const isPurchaseable = instanceOfPurchaseGate(streamConditions)
+  const isPurchaseable =
+    streamConditions && instanceOfPurchaseGate(streamConditions)
 
   return (
     <div className={styles.wrapper}>


### PR DESCRIPTION
### Description
Add null-check for `streamConditions` on embed player (they are all js)

### How Has This Been Tested?

Local web
track:
<img width="1920" alt="Screenshot 2024-05-30 at 3 22 21 PM" src="https://github.com/AudiusProject/audius-protocol/assets/3893871/ace3c783-dfae-4cda-b7d2-ad10a111beed">
album:
<img width="1920" alt="Screenshot 2024-05-30 at 3 27 24 PM" src="https://github.com/AudiusProject/audius-protocol/assets/3893871/9a7d516c-e014-4ba9-8d20-b09695b07d42">

