### PR TITLE
Fix solana-relay logging, fix eslint config

### DIFF
--- a/packages/discovery-provider/plugins/pedalboard/apps/solana-relay/.eslintrc.js
+++ b/packages/discovery-provider/plugins/pedalboard/apps/solana-relay/.eslintrc.js
@@ -1,4 +1,4 @@
 module.exports = {
   root: true,
-  extends: ["custom-server"],
-};
+  extends: ['audius']
+}

--- a/packages/discovery-provider/plugins/pedalboard/apps/solana-relay/src/config.ts
+++ b/packages/discovery-provider/plugins/pedalboard/apps/solana-relay/src/config.ts
@@ -1,10 +1,15 @@
+import { Keypair, PublicKey } from '@solana/web3.js'
 import dotenv from 'dotenv'
 import { cleanEnv, str, num, json } from 'envalid'
-import { logger } from './logger'
-import { Keypair, PublicKey } from '@solana/web3.js'
 
-export const ClockProgram = new PublicKey('SysvarC1ock11111111111111111111111111111111')
-export const InstructionsProgram = new PublicKey('Sysvar1nstructions1111111111111111111111111')
+import { logger } from './logger'
+
+export const ClockProgram = new PublicKey(
+  'SysvarC1ock11111111111111111111111111111111'
+)
+export const InstructionsProgram = new PublicKey(
+  'Sysvar1nstructions1111111111111111111111111'
+)
 
 // reads .env file based on environment
 const readDotEnv = () => {
@@ -35,7 +40,7 @@ type Config = {
   usdcMintAddress: string
   waudioMintAddress: string
   solanaFeePayerWallets: Keypair[]
-  delegatePrivateKey: Buffer,
+  delegatePrivateKey: Buffer
   ipdataApiKey: string | null
   listensValidSigner: string
   solanaSignerPrivateKey: string
@@ -104,13 +109,14 @@ const readConfig = (): Config => {
       default: '01b633611c0b57babd56a6fdf7400b21340956e1840da6dd788f9c37'
     }),
     audius_solana_eth_registry_program: str({
-      default: 'testBgRfFcage1hN7zmTsktdQCJZkHEhM1eguYPaeKg',
+      default: 'testBgRfFcage1hN7zmTsktdQCJZkHEhM1eguYPaeKg'
     }),
     audius_solana_listens_valid_signer: str({
-      default: 'yM9adjwKaRbYxQzLPF6zvZMSAfKUNte5xvK4B3iGbkL',
+      default: 'yM9adjwKaRbYxQzLPF6zvZMSAfKUNte5xvK4B3iGbkL'
     }),
     audius_solana_signer_private_key: str({
-      default: 'd242765e718801781440d77572b9dafcdc9baadf0269eff24cf61510ddbf1003',
+      default:
+        'd242765e718801781440d77572b9dafcdc9baadf0269eff24cf61510ddbf1003'
     })
   })
   const solanaFeePayerWalletsParsed = env.audius_solana_fee_payer_wallets
@@ -125,26 +131,27 @@ const readConfig = (): Config => {
     : Buffer.from([])
 
   cachedConfig = {
-      endpoint: env.audius_discprov_url,
-      discoveryDbConnectionString: env.audius_db_url,
-      redisUrl: env.audius_redis_url,
-      serverHost: env.solana_relay_server_host,
-      serverPort: env.solana_relay_server_port,
-      solanaEndpoints: env.audius_solana_endpoint.split(','),
-      rewardsManagerProgramId: env.audius_solana_rewards_manager_program_address,
-      rewardsManagerAccountAddress: env.audius_solana_rewards_manager_account,
-      claimableTokenProgramId: env.audius_solana_user_bank_program_address,
-      paymentRouterProgramId: env.audius_solana_payment_router_program_address,
-      trackListenCountProgramId: env.audius_solana_track_listen_count_address,
-      usdcMintAddress: env.audius_solana_usdc_mint,
-      waudioMintAddress: env.audius_solana_waudio_mint,
-      solanaFeePayerWallets,
-      delegatePrivateKey,
-      ipdataApiKey: env.audius_ipdata_api_key === ""  ? null : env.audius_ipdata_api_key,
-      listensValidSigner: env.audius_solana_listens_valid_signer,
-      ethRegistryProgramId: env.audius_solana_eth_registry_program,
-      solanaSignerPrivateKey: env.audius_solana_signer_private_key
-    }
+    endpoint: env.audius_discprov_url,
+    discoveryDbConnectionString: env.audius_db_url,
+    redisUrl: env.audius_redis_url,
+    serverHost: env.solana_relay_server_host,
+    serverPort: env.solana_relay_server_port,
+    solanaEndpoints: env.audius_solana_endpoint.split(','),
+    rewardsManagerProgramId: env.audius_solana_rewards_manager_program_address,
+    rewardsManagerAccountAddress: env.audius_solana_rewards_manager_account,
+    claimableTokenProgramId: env.audius_solana_user_bank_program_address,
+    paymentRouterProgramId: env.audius_solana_payment_router_program_address,
+    trackListenCountProgramId: env.audius_solana_track_listen_count_address,
+    usdcMintAddress: env.audius_solana_usdc_mint,
+    waudioMintAddress: env.audius_solana_waudio_mint,
+    solanaFeePayerWallets,
+    delegatePrivateKey,
+    ipdataApiKey:
+      env.audius_ipdata_api_key === '' ? null : env.audius_ipdata_api_key,
+    listensValidSigner: env.audius_solana_listens_valid_signer,
+    ethRegistryProgramId: env.audius_solana_eth_registry_program,
+    solanaSignerPrivateKey: env.audius_solana_signer_private_key
+  }
   return readConfig()
 }
 

--- a/packages/discovery-provider/plugins/pedalboard/apps/solana-relay/src/index.ts
+++ b/packages/discovery-provider/plugins/pedalboard/apps/solana-relay/src/index.ts
@@ -1,22 +1,23 @@
-import express from 'express'
 import { json } from 'body-parser'
 import cors from 'cors'
+import express from 'express'
+
 import { config } from './config'
 import { logger } from './logger'
+import { errorHandlerMiddleware } from './middleware/errorHandler'
 import {
   incomingRequestLogger,
   outgoingRequestLogger
 } from './middleware/logging'
-import { relay } from './routes/relay/relay'
-import { errorHandlerMiddleware } from './middleware/errorHandler'
 import {
   userSignerRecoveryMiddleware,
-  discoveryNodeSignerRecoveryMiddleware,
+  discoveryNodeSignerRecoveryMiddleware
 } from './middleware/signerRecovery'
 import { cache } from './routes/cache'
 import { feePayer } from './routes/feePayer'
 import { health } from './routes/health/health'
 import { listen } from './routes/listen/listen'
+import { relay } from './routes/relay/relay'
 
 const main = async () => {
   const { serverHost, serverPort } = config
@@ -39,4 +40,4 @@ const main = async () => {
   })
 }
 
-main().catch(logger.error.bind(logger))
+main().catch((e) => logger.error({ error: e }, 'Fatal error in main!'))

--- a/packages/discovery-provider/plugins/pedalboard/apps/solana-relay/src/middleware/errorHandler.ts
+++ b/packages/discovery-provider/plugins/pedalboard/apps/solana-relay/src/middleware/errorHandler.ts
@@ -1,15 +1,17 @@
-import { Request, Response } from 'express'
+import { NextFunction, Request, Response } from 'express'
+
 import { InternalServerError, ResponseError } from '../errors'
 import { logger as rootLogger } from '../logger'
 
 export const errorHandlerMiddleware = (
   err: unknown,
-  req: Request,
-  res: Response
+  _req: Request,
+  res: Response,
+  _next: NextFunction
 ) => {
   const error =
     err instanceof ResponseError ? err : new InternalServerError(String(err))
-  if (!res.writableEnded) {
+  if (!res.headersSent) {
     res.status(error.status).send({ error: error.name })
   }
   // in milliseconds

--- a/packages/discovery-provider/plugins/pedalboard/apps/solana-relay/src/middleware/locals.ts
+++ b/packages/discovery-provider/plugins/pedalboard/apps/solana-relay/src/middleware/locals.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-namespace */
 import { Users } from '@pedalboard/storage'
 import { Logger } from 'pino'
 

--- a/packages/discovery-provider/plugins/pedalboard/apps/solana-relay/src/middleware/logging.ts
+++ b/packages/discovery-provider/plugins/pedalboard/apps/solana-relay/src/middleware/logging.ts
@@ -25,9 +25,9 @@ export const incomingRequestLogger = (
 
 export const outgoingLog = (_request: Request, response: Response) => {
   // in milliseconds
-  const responseTime = new Date().getTime() - response.locals.requestStartTime
+  const requestTime = new Date().getTime() - response.locals.requestStartTime
   const statusCode = response.statusCode
-  response.locals.logger.info({ responseTime, statusCode }, 'request completed')
+  response.locals.logger.info({ requestTime, statusCode }, 'request completed')
 }
 
 export const outgoingRequestLogger = (

--- a/packages/discovery-provider/plugins/pedalboard/apps/solana-relay/src/middleware/logging.ts
+++ b/packages/discovery-provider/plugins/pedalboard/apps/solana-relay/src/middleware/logging.ts
@@ -1,5 +1,6 @@
 import { NextFunction, Request, Response } from 'express'
 import { v4 as uuidv4 } from 'uuid'
+
 import { logger } from '../logger'
 
 export const incomingRequestLogger = (

--- a/packages/discovery-provider/plugins/pedalboard/apps/solana-relay/src/middleware/signerRecovery.ts
+++ b/packages/discovery-provider/plugins/pedalboard/apps/solana-relay/src/middleware/signerRecovery.ts
@@ -1,7 +1,8 @@
-import { NextFunction, Request, Response } from 'express'
-import { recoverPersonalSignature } from 'eth-sig-util'
-import { Table, Users } from '@pedalboard/storage'
 import { initializeDiscoveryDb } from '@pedalboard/basekit'
+import { Table, Users } from '@pedalboard/storage'
+import { recoverPersonalSignature } from 'eth-sig-util'
+import { NextFunction, Request, Response } from 'express'
+
 import { config } from '../config'
 import { getCachedDiscoveryNodes } from '../redis'
 

--- a/packages/discovery-provider/plugins/pedalboard/apps/solana-relay/src/redis.ts
+++ b/packages/discovery-provider/plugins/pedalboard/apps/solana-relay/src/redis.ts
@@ -1,4 +1,5 @@
 import { createClient, RedisClientType } from 'redis'
+
 import { config } from './config'
 
 let redisClient: RedisClientType

--- a/packages/discovery-provider/plugins/pedalboard/apps/solana-relay/src/routes/cache.ts
+++ b/packages/discovery-provider/plugins/pedalboard/apps/solana-relay/src/routes/cache.ts
@@ -1,7 +1,8 @@
+import { TransactionResponse } from '@solana/web3.js'
 import { NextFunction, Request, Response } from 'express'
+
 import { BadRequestError, UnauthorizedError } from '../errors'
 import { cacheTransaction } from '../redis'
-import { TransactionResponse } from '@solana/web3.js'
 
 type RequestBody = {
   transaction: string

--- a/packages/discovery-provider/plugins/pedalboard/apps/solana-relay/src/routes/feePayer.ts
+++ b/packages/discovery-provider/plugins/pedalboard/apps/solana-relay/src/routes/feePayer.ts
@@ -1,4 +1,5 @@
 import { NextFunction, Request, Response } from 'express'
+
 import { config } from '../config'
 import { InternalServerError } from '../errors'
 

--- a/packages/discovery-provider/plugins/pedalboard/apps/solana-relay/src/routes/listen/listen.ts
+++ b/packages/discovery-provider/plugins/pedalboard/apps/solana-relay/src/routes/listen/listen.ts
@@ -1,151 +1,191 @@
-import { Request, Response } from 'express'
-import { z } from 'zod'
-import { Logger } from 'pino'
-import { getIP, getIpData } from '../../utils/ipData'
-import { getConnection } from '../../utils/connections'
-import { createTrackListenInstructions, getFeePayerKeyPair } from './trackListenInstructions'
-import { Transaction, TransactionMessage, VersionedTransaction } from '@solana/web3.js'
+import {
+  Transaction,
+  TransactionMessage,
+  VersionedTransaction
+} from '@solana/web3.js'
 import bs58 from 'bs58'
-import { broadcastTransaction, sendTransactionWithRetries } from '../../utils/transaction'
-import { keccak256 } from 'web3-utils'
-import { sortKeys } from '../../utils/sortKeys'
+import { Request, Response } from 'express'
+import { Logger } from 'pino'
 import { recover } from 'web3-eth-accounts'
-import { getCachedContentNodes } from '../../redis'
+import { keccak256 } from 'web3-utils'
+import { z } from 'zod'
 
-export type LocationData = { city: string, region: string, country: string } | null
+import { getCachedContentNodes } from '../../redis'
+import { getConnection } from '../../utils/connections'
+import { getIP, getIpData } from '../../utils/ipData'
+import { sortKeys } from '../../utils/sortKeys'
+import {
+  broadcastTransaction,
+  sendTransactionWithRetries
+} from '../../utils/transaction'
+
+import {
+  createTrackListenInstructions,
+  getFeePayerKeyPair
+} from './trackListenInstructions'
+
+export type LocationData = {
+  city: string
+  region: string
+  country: string
+} | null
 
 export const recordListenBodySchema = z.object({
-    userId: z.string(),
-    timestamp: z.string(),
-    signature: z.string()
+  userId: z.string(),
+  timestamp: z.string(),
+  signature: z.string()
 })
 
 export const recordListenParamsSchema = z.object({
-    // validate that it can parse as an int
-    trackId: z.string().transform((s) => parseInt(s)).refine((val) => !isNaN(val), {
-        message: "trackId must be a numeric string",
-    }).transform((val) => val.toString()),
+  // validate that it can parse as an int
+  trackId: z
+    .string()
+    .transform((s) => parseInt(s))
+    .refine((val) => !isNaN(val), {
+      message: 'trackId must be a numeric string'
+    })
+    .transform((val) => val.toString())
 })
 
 export interface RecordListenRequest extends Request {
-    body: z.infer<typeof recordListenBodySchema>;
-    params: z.infer<typeof recordListenParamsSchema>;
+  body: z.infer<typeof recordListenBodySchema>
+  params: z.infer<typeof recordListenParamsSchema>
 }
 
 export type RecordListenParams = {
-    logger: Logger
-    trackId: string
-    userId: string
-    ip: string
+  logger: Logger
+  trackId: string
+  userId: string
+  ip: string
 }
 
 export type RecordListenResponse = {
-    solTxSignature: string | null
+  solTxSignature: string | null
 }
 
-export const recordListen = async (params: RecordListenParams): Promise<RecordListenResponse> => {
-    const { logger: parentLogger, userId, trackId, ip } = params
-    const logger = parentLogger.child({ id: `${userId}-${trackId}-${new Date().getUTCSeconds()}` })
+export const recordListen = async (
+  params: RecordListenParams
+): Promise<RecordListenResponse> => {
+  const { logger: parentLogger, userId, trackId, ip } = params
+  const logger = parentLogger.child({
+    id: `${userId}-${trackId}-${new Date().getUTCSeconds()}`
+  })
 
-    logger.info({ ip }, "record listen")
+  logger.info({ ip }, 'record listen')
 
-    const location = await getIpData(logger, ip)
+  const location = await getIpData(logger, ip)
 
-    logger.info({ location }, "location")
+  logger.info({ location }, 'location')
 
-    const [secpInstruction, listenInstruction] = await createTrackListenInstructions({
-        logger,
-        userId,
-        trackId,
-        location,
+  const [secpInstruction, listenInstruction] =
+    await createTrackListenInstructions({
+      logger,
+      userId,
+      trackId,
+      location
     })
 
-    logger.info({ secpInstruction, listenInstruction }, "instructions")
-    const latestBlockHash = await getConnection().getLatestBlockhash()
+  logger.info({ secpInstruction, listenInstruction }, 'instructions')
+  const latestBlockHash = await getConnection().getLatestBlockhash()
 
-    const feePayer = getFeePayerKeyPair()
-    const tx = new Transaction({
-        blockhash: latestBlockHash.blockhash,
-        lastValidBlockHeight: latestBlockHash.lastValidBlockHeight
-    })
-        .add(secpInstruction)
-        .add(listenInstruction)
-    tx.feePayer = feePayer.publicKey
-    tx.sign(feePayer)
+  const feePayer = getFeePayerKeyPair()
+  const tx = new Transaction({
+    blockhash: latestBlockHash.blockhash,
+    lastValidBlockHeight: latestBlockHash.lastValidBlockHeight
+  })
+    .add(secpInstruction)
+    .add(listenInstruction)
+  tx.feePayer = feePayer.publicKey
+  tx.sign(feePayer)
 
-    logger.info({ tx }, "tx")
+  logger.info({ tx }, 'tx')
 
-    const message = new TransactionMessage({
-        payerKey: feePayer.publicKey,
-        recentBlockhash: latestBlockHash.blockhash,
-        instructions: tx.instructions
-    })
+  const message = new TransactionMessage({
+    payerKey: feePayer.publicKey,
+    recentBlockhash: latestBlockHash.blockhash,
+    instructions: tx.instructions
+  })
 
-    const versionedMessage = message.compileToV0Message()
+  const versionedMessage = message.compileToV0Message()
 
-    const transaction = new VersionedTransaction(versionedMessage)
-    transaction.sign([feePayer])
+  const transaction = new VersionedTransaction(versionedMessage)
+  transaction.sign([feePayer])
 
-    const signature = bs58.encode(transaction.signatures[0])
-    const confirmationStrategy = { ...latestBlockHash, signature }
+  const signature = bs58.encode(transaction.signatures[0])
+  const confirmationStrategy = { ...latestBlockHash, signature }
 
-    logger.info({ latestBlockHash, versionedMessage, transaction, signature }, "pre send")
+  logger.info(
+    { latestBlockHash, versionedMessage, transaction, signature },
+    'pre send'
+  )
 
-    const solTxSignature = await sendTransactionWithRetries({
-        transaction,
-        commitment: 'confirmed',
-        confirmationStrategy,
-        logger,
-    })
+  const solTxSignature = await sendTransactionWithRetries({
+    transaction,
+    commitment: 'confirmed',
+    confirmationStrategy,
+    logger
+  })
 
-    logger.info({ solTxSignature }, "transaction sig")
+  logger.info({ solTxSignature }, 'transaction sig')
 
-    // no need to confirm since we already confirm in the sendTransactionWithRetries
-    await broadcastTransaction({ logger, signature: solTxSignature })
+  // no need to confirm since we already confirm in the sendTransactionWithRetries
+  await broadcastTransaction({ logger, signature: solTxSignature })
 
-    return { solTxSignature }
+  return { solTxSignature }
 }
 
-export const validateListenSignature = async (timestamp: string, signature: string): Promise<boolean> => {
-    const data = JSON.stringify(sortKeys({ "data": "listen", "timestamp": timestamp }))
-    const hashedData = keccak256(data)
-    const recoveredWallet = recover(hashedData, signature)
-    const contentNodes = await getCachedContentNodes()
-    for (const { delegateOwnerWallet } of contentNodes) {
-        if (recoveredWallet === delegateOwnerWallet) return true
-    }
-    return false
+export const validateListenSignature = async (
+  timestamp: string,
+  signature: string
+): Promise<boolean> => {
+  const data = JSON.stringify(sortKeys({ data: 'listen', timestamp }))
+  const hashedData = keccak256(data)
+  const recoveredWallet = recover(hashedData, signature)
+  const contentNodes = await getCachedContentNodes()
+  for (const { delegateOwnerWallet } of contentNodes) {
+    if (recoveredWallet === delegateOwnerWallet) return true
+  }
+  return false
 }
 
 export const listen = async (req: Request, res: Response) => {
-    let logger
-    try {
-        // validation
-        const { userId, timestamp, signature } = recordListenBodySchema.parse(req.body)
-        const { trackId } = recordListenParamsSchema.parse(req.params)
-        logger = res.locals.logger.child({ userId, trackId })
-        const ip = getIP(req)
+  let logger
+  try {
+    // validation
+    const { userId, timestamp, signature } = recordListenBodySchema.parse(
+      req.body
+    )
+    const { trackId } = recordListenParamsSchema.parse(req.params)
+    logger = res.locals.logger.child({ userId, trackId })
+    const ip = getIP(req)
 
-        if (!(await validateListenSignature(timestamp, signature))) {
-            logger.info({ userId, trackId, ip, timestamp, signature }, "unauthorized request")
-            return res.status(401).json({ message: 'Unauthorized Error' })
-        }
-
-
-        // record listen after validation
-        const record = await recordListen({ userId, trackId, logger, ip })
-        return res.status(200).json(record)
-    } catch (e: unknown) {
-        if (e instanceof z.ZodError) {
-            return res.status(400).json({ message: 'Validation Error', errors: e.errors });
-        }
-        if (e instanceof Error) {
-            logger?.error({ message: e.message, stack: e.stack, name: e.name }, "listen error");
-        } else if (typeof e === 'object' && e !== null) {
-            logger?.error({ error: JSON.stringify(e) }, "listen error");
-        } else {
-            logger?.error({ error: String(e) }, "listen error");
-        }
-        return res.status(500).json({ message: 'Internal Server Error' });
+    if (!(await validateListenSignature(timestamp, signature))) {
+      logger.info(
+        { userId, trackId, ip, timestamp, signature },
+        'unauthorized request'
+      )
+      return res.status(401).json({ message: 'Unauthorized Error' })
     }
+
+    // record listen after validation
+    const record = await recordListen({ userId, trackId, logger, ip })
+    return res.status(200).json(record)
+  } catch (e: unknown) {
+    if (e instanceof z.ZodError) {
+      return res
+        .status(400)
+        .json({ message: 'Validation Error', errors: e.errors })
+    }
+    if (e instanceof Error) {
+      logger?.error(
+        { message: e.message, stack: e.stack, name: e.name },
+        'listen error'
+      )
+    } else if (typeof e === 'object' && e !== null) {
+      logger?.error({ error: JSON.stringify(e) }, 'listen error')
+    } else {
+      logger?.error({ error: String(e) }, 'listen error')
+    }
+    return res.status(500).json({ message: 'Internal Server Error' })
+  }
 }

--- a/packages/discovery-provider/plugins/pedalboard/apps/solana-relay/src/routes/listen/trackListenInstructions.ts
+++ b/packages/discovery-provider/plugins/pedalboard/apps/solana-relay/src/routes/listen/trackListenInstructions.ts
@@ -1,211 +1,251 @@
-import { Connection, Keypair, PublicKey, Secp256k1Program, TransactionInstruction } from "@solana/web3.js";
-import { LocationData } from "../../utils/ipData";
-import secp256k1 from "secp256k1"
-import { connections } from "../../utils/connections";
-import { serialize } from "borsh";
-import keccak256 from "keccak256";
-import { ClockProgram, InstructionsProgram, config } from "../../config";
-import { Logger } from "pino";
+import {
+  Connection,
+  Keypair,
+  PublicKey,
+  Secp256k1Program,
+  TransactionInstruction
+} from '@solana/web3.js'
+import { serialize } from 'borsh'
+import keccak256 from 'keccak256'
+import { Logger } from 'pino'
+import secp256k1 from 'secp256k1'
+
+import { ClockProgram, InstructionsProgram, config } from '../../config'
+import { connections } from '../../utils/connections'
+import { LocationData } from '../../utils/ipData'
 
 class TrackData {
-
-    userId: string;
-    trackId: string;
-    source: string;
-    timestamp: number;
-    constructor({ userId, trackId, source, timestamp }: { userId: string, trackId: string, source: string, timestamp: number }) {
-        this.userId = userId
-        this.trackId = trackId
-        this.source = source
-        this.timestamp = timestamp
-    }
+  userId: string
+  trackId: string
+  source: string
+  timestamp: number
+  constructor({
+    userId,
+    trackId,
+    source,
+    timestamp
+  }: {
+    userId: string
+    trackId: string
+    source: string
+    timestamp: number
+  }) {
+    this.userId = userId
+    this.trackId = trackId
+    this.source = source
+    this.timestamp = timestamp
+  }
 }
 
 const trackDataSchema = new Map([
-    [
-        TrackData,
-        {
-            kind: 'struct',
-            fields: [
-                ['userId', 'string'],
-                ['trackId', 'string'],
-                ['source', 'string'],
-                ['timestamp', 'u64']
-            ]
-        }
-    ]
+  [
+    TrackData,
+    {
+      kind: 'struct',
+      fields: [
+        ['userId', 'string'],
+        ['trackId', 'string'],
+        ['source', 'string'],
+        ['timestamp', 'u64']
+      ]
+    }
+  ]
 ])
 
 class InstructionArgs {
-    trackData: TrackData;
-    signature: number[];
-    recoveryId: number;
-    constructor({ trackData, signature, recoveryId }: { trackData: TrackData, signature: number[], recoveryId: number }) {
-        this.trackData = trackData
-        this.signature = signature
-        this.recoveryId = recoveryId
-    }
+  trackData: TrackData
+  signature: number[]
+  recoveryId: number
+  constructor({
+    trackData,
+    signature,
+    recoveryId
+  }: {
+    trackData: TrackData
+    signature: number[]
+    recoveryId: number
+  }) {
+    this.trackData = trackData
+    this.signature = signature
+    this.recoveryId = recoveryId
+  }
 }
 
 class InstructionEnum {
-    instruction: InstructionArgs;
-    choose: string;
-    constructor({ instruction, choose }: { instruction: InstructionArgs, choose: string }) {
-        this.instruction = instruction
-        this.choose = choose
-    }
+  instruction: InstructionArgs
+  choose: string
+  constructor({
+    instruction,
+    choose
+  }: {
+    instruction: InstructionArgs
+    choose: string
+  }) {
+    this.instruction = instruction
+    this.choose = choose
+  }
 }
 
 // @ts-expect-error instructionSchema doesn't have correct type when converted from js
 const instructionSchema = new Map([
-    [
-        InstructionEnum,
-        {
-            kind: 'enum',
-            field: 'choose',
-            values: [['instruction', InstructionArgs]]
-        }
-    ],
-    [
-        InstructionArgs,
-        {
-            kind: 'struct',
-            fields: [
-                ['trackData', TrackData],
-                ['signature', [64]],
-                ['recoveryId', 'u8']
-            ]
-        }
-    ],
-    [
-        TrackData,
-        {
-            kind: 'struct',
-            fields: [
-                ['userId', 'string'],
-                ['trackId', 'string'],
-                ['source', 'string'],
-                ['timestamp', 'u64']
-            ]
-        }
-    ]
+  [
+    InstructionEnum,
+    {
+      kind: 'enum',
+      field: 'choose',
+      values: [['instruction', InstructionArgs]]
+    }
+  ],
+  [
+    InstructionArgs,
+    {
+      kind: 'struct',
+      fields: [
+        ['trackData', TrackData],
+        ['signature', [64]],
+        ['recoveryId', 'u8']
+      ]
+    }
+  ],
+  [
+    TrackData,
+    {
+      kind: 'struct',
+      fields: [
+        ['userId', 'string'],
+        ['trackId', 'string'],
+        ['source', 'string'],
+        ['timestamp', 'u64']
+      ]
+    }
+  ]
 ])
 
 let cachedListenBlocktime: number | null = null
 let lastRetrievedListenBlocktime: number | null = null
 
 async function getListenTimestamp(connection: Connection) {
-    const currentEpochInSec = Math.round(Date.now() / 1000)
-    if (
-        cachedListenBlocktime && lastRetrievedListenBlocktime &&
-        Math.abs(lastRetrievedListenBlocktime - currentEpochInSec) < 30
-    ) {
-        return cachedListenBlocktime
-    }
+  const currentEpochInSec = Math.round(Date.now() / 1000)
+  if (
+    cachedListenBlocktime &&
+    lastRetrievedListenBlocktime &&
+    Math.abs(lastRetrievedListenBlocktime - currentEpochInSec) < 30
+  ) {
+    return cachedListenBlocktime
+  }
 
-    const slot = await connection.getSlot('finalized')
-    const blockTime = await connection.getBlockTime(slot)
+  const slot = await connection.getSlot('finalized')
+  const blockTime = await connection.getBlockTime(slot)
 
-    // update cached values
-    cachedListenBlocktime = blockTime
-    lastRetrievedListenBlocktime = currentEpochInSec
+  // update cached values
+  cachedListenBlocktime = blockTime
+  lastRetrievedListenBlocktime = currentEpochInSec
 
-    return blockTime
+  return blockTime
 }
 
 export function getFeePayerKeyPair(): Keypair {
-    const feePayers = config.solanaFeePayerWallets
-    const randomFeePayerIndex = Math.floor(
-        Math.random() * feePayers.length
-    )
-    return feePayers[randomFeePayerIndex]
+  const feePayers = config.solanaFeePayerWallets
+  const randomFeePayerIndex = Math.floor(Math.random() * feePayers.length)
+  return feePayers[randomFeePayerIndex]
 }
 
 export async function createTrackListenInstructions({
-    logger,
+  logger,
+  userId,
+  trackId,
+  location
+}: {
+  logger: Logger
+  userId: string
+  trackId: string
+  location: LocationData
+}): Promise<TransactionInstruction[]> {
+  const trackListenProgram = new PublicKey(config.trackListenCountProgramId)
+  const ethRegistryProgram = new PublicKey(config.ethRegistryProgramId)
+  const validSignerPubK = new PublicKey(config.listensValidSigner)
+  const privKey = Buffer.from(config.solanaSignerPrivateKey, 'hex')
+  const pubKey = secp256k1.publicKeyCreate(privKey, false).slice(1)
+
+  logger.info(
+    { trackListenProgram, ethRegistryProgram, validSignerPubK },
+    'ids and keys'
+  )
+
+  const connection = connections[0]
+  const source = 'relay'
+
+  const accInfo = await connection.getAccountInfo(validSignerPubK)
+  const accPublicKeyInit = accInfo?.data.toJSON().data.slice(1, 33)
+
+  logger.info({ accInfo }, 'account info')
+
+  if (accPublicKeyInit === undefined) {
+    throw new Error('pub key not found for acc info')
+  }
+
+  const signerGroup = new PublicKey(accPublicKeyInit)
+
+  const sourceData =
+    location === null ? source : JSON.stringify({ source, location })
+
+  const trackData = new TrackData({
     userId,
     trackId,
-    location
-}: { logger: Logger,userId: string, trackId: string, location: LocationData }): Promise<TransactionInstruction[]> {
-    const trackListenProgram = new PublicKey(config.trackListenCountProgramId)
-    const ethRegistryProgram = new PublicKey(config.ethRegistryProgramId)
-    const validSignerPubK = new PublicKey(config.listensValidSigner)
-    const privKey = Buffer.from(config.solanaSignerPrivateKey, 'hex')
-    const pubKey = secp256k1.publicKeyCreate(privKey, false).slice(1)
+    source: sourceData,
+    timestamp:
+      (await getListenTimestamp(connection)) ||
+      Math.round(new Date().getTime() / 1000)
+  })
 
-    logger.info({ trackListenProgram, ethRegistryProgram, validSignerPubK }, "ids and keys")
+  logger.info({ signerGroup, sourceData, trackData }, 'some data')
 
-    const connection = connections[0]
-    const source = 'relay'
+  const serializedTrackData = serialize(trackDataSchema, trackData)
+  const buffered = Buffer.from(serializedTrackData)
+  const msgHash = keccak256(buffered)
 
-    const accInfo = await connection.getAccountInfo(validSignerPubK)
-    const accPublicKeyInit = accInfo?.data.toJSON().data.slice(1, 33)
+  const sigObj = secp256k1.ecdsaSign(Uint8Array.from(msgHash), privKey)
 
-    logger.info({ accInfo }, "account info")
+  const instructionArgs = new InstructionArgs({
+    trackData,
+    signature: Array.from(sigObj.signature),
+    recoveryId: sigObj.recid
+  })
 
-    if (accPublicKeyInit === undefined) {
-        throw new Error("pub key not found for acc info")
-    }
+  const instructionData = new InstructionEnum({
+    instruction: instructionArgs,
+    choose: 'instruction'
+  })
 
-    const signerGroup = new PublicKey(accPublicKeyInit)
+  const serializedInstructionArgs = serialize(
+    instructionSchema,
+    instructionData
+  )
 
-    const sourceData = location === null ? source : JSON.stringify({ source, location })
+  logger.info({ serializedTrackData, serializedInstructionArgs }, 'serialized')
 
-    const trackData = new TrackData({
-        userId,
-        trackId,
-        source: sourceData,
-        timestamp:
-            (await getListenTimestamp(connection)) ||
-            Math.round(new Date().getTime() / 1000)
-    })
+  const secpInstruction = Secp256k1Program.createInstructionWithPublicKey({
+    publicKey: pubKey,
+    message: serializedTrackData,
+    signature: sigObj.signature,
+    recoveryId: sigObj.recid
+  })
 
-    logger.info({ signerGroup, sourceData, trackData }, "some data")
+  const listenInstruction = new TransactionInstruction({
+    keys: [
+      { pubkey: validSignerPubK, isSigner: false, isWritable: false },
+      { pubkey: signerGroup, isSigner: false, isWritable: false },
+      {
+        pubkey: ethRegistryProgram,
+        isSigner: false,
+        isWritable: false
+      },
+      { pubkey: InstructionsProgram, isSigner: false, isWritable: false },
+      { pubkey: ClockProgram, isSigner: false, isWritable: false }
+    ],
+    programId: trackListenProgram,
+    data: Buffer.from(serializedInstructionArgs)
+  })
 
-    const serializedTrackData = serialize(trackDataSchema, trackData)
-    const buffered = Buffer.from(serializedTrackData)
-    const msgHash = keccak256(buffered)
-
-    const sigObj = secp256k1.ecdsaSign(Uint8Array.from(msgHash), privKey)
-
-    const instructionArgs = new InstructionArgs({
-        trackData,
-        signature: Array.from(sigObj.signature),
-        recoveryId: sigObj.recid
-    })
-
-    const instructionData = new InstructionEnum({
-        instruction: instructionArgs,
-        choose: 'instruction'
-    })
-
-    const serializedInstructionArgs = serialize(instructionSchema, instructionData)
-
-    logger.info({ serializedTrackData, serializedInstructionArgs }, "serialized")
-
-
-    const secpInstruction = Secp256k1Program.createInstructionWithPublicKey({
-        publicKey: pubKey,
-        message: serializedTrackData,
-        signature: sigObj.signature,
-        recoveryId: sigObj.recid
-    })
-
-    const listenInstruction = new TransactionInstruction({
-        keys: [
-            { pubkey: validSignerPubK, isSigner: false, isWritable: false },
-            { pubkey: signerGroup, isSigner: false, isWritable: false },
-            {
-                pubkey: ethRegistryProgram,
-                isSigner: false,
-                isWritable: false
-            },
-            { pubkey: InstructionsProgram, isSigner: false, isWritable: false },
-            { pubkey: ClockProgram, isSigner: false, isWritable: false }
-        ],
-        programId: trackListenProgram,
-        data: Buffer.from(serializedInstructionArgs)
-    })
-
-    return [secpInstruction, listenInstruction]
+  return [secpInstruction, listenInstruction]
 }

--- a/packages/discovery-provider/plugins/pedalboard/apps/solana-relay/src/routes/relay/assertRelayAllowedInstructions.test.ts
+++ b/packages/discovery-provider/plugins/pedalboard/apps/solana-relay/src/routes/relay/assertRelayAllowedInstructions.test.ts
@@ -1,3 +1,10 @@
+import assert from 'assert'
+
+import {
+  ClaimableTokensProgram,
+  RewardManagerProgram,
+  RewardManagerInstruction
+} from '@audius/spl'
 import {
   NATIVE_MINT,
   TOKEN_PROGRAM_ID,
@@ -15,16 +22,12 @@ import {
   SystemProgram,
   TransactionInstruction
 } from '@solana/web3.js'
-import assert from 'assert'
-import { assertRelayAllowedInstructions } from './assertRelayAllowedInstructions'
-import { config } from '../../config'
-import {
-  ClaimableTokensProgram,
-  RewardManagerProgram,
-  RewardManagerInstruction
-} from '@audius/spl'
-import { InvalidRelayInstructionError } from './InvalidRelayInstructionError'
 import { describe, it } from 'vitest'
+
+import { config } from '../../config'
+
+import { InvalidRelayInstructionError } from './InvalidRelayInstructionError'
+import { assertRelayAllowedInstructions } from './assertRelayAllowedInstructions'
 
 const CLAIMABLE_TOKEN_PROGRAM_ID = new PublicKey(config.claimableTokenProgramId)
 

--- a/packages/discovery-provider/plugins/pedalboard/apps/solana-relay/src/routes/relay/assertRelayAllowedInstructions.ts
+++ b/packages/discovery-provider/plugins/pedalboard/apps/solana-relay/src/routes/relay/assertRelayAllowedInstructions.ts
@@ -1,4 +1,12 @@
 import {
+  decodeAssociatedTokenAccountInstruction,
+  ClaimableTokensProgram,
+  RewardManagerProgram,
+  isCreateAssociatedTokenAccountIdempotentInstruction,
+  isCreateAssociatedTokenAccountInstruction,
+  Secp256k1Program
+} from '@audius/spl'
+import {
   NATIVE_MINT,
   ASSOCIATED_TOKEN_PROGRAM_ID,
   TOKEN_PROGRAM_ID,
@@ -15,18 +23,11 @@ import {
   SystemInstruction,
   ComputeBudgetProgram
 } from '@solana/web3.js'
-import { InvalidRelayInstructionError } from './InvalidRelayInstructionError'
-
-import {
-  decodeAssociatedTokenAccountInstruction,
-  ClaimableTokensProgram,
-  RewardManagerProgram,
-  isCreateAssociatedTokenAccountIdempotentInstruction,
-  isCreateAssociatedTokenAccountInstruction,
-  Secp256k1Program
-} from '@audius/spl'
-import { config } from '../../config'
 import bs58 from 'bs58'
+
+import { config } from '../../config'
+
+import { InvalidRelayInstructionError } from './InvalidRelayInstructionError'
 
 const MEMO_PROGRAM_ID = 'Memo1UhkJRfHyvLMcVucJwxXeuD728EqVDDwQDxFMNo'
 const MEMO_V2_PROGRAM_ID = 'MemoSq4gqABAXKb96qnH8TysNcWxMyWCqXgDLGmfcHr'
@@ -174,7 +175,7 @@ const assertAllowedTokenProgramInstruction = async (
     const destination = decodedInstruction.keys.destination.pubkey
     const userbank = await deriveUserBank(
       wallet,
-      claimableTokenAuthorities['usdc']
+      claimableTokenAuthorities.usdc
     )
 
     // Check that destination is either a userbank or a payment router token account
@@ -229,8 +230,8 @@ const assertAllowedClaimableTokenProgramInstruction = async (
     ClaimableTokensProgram.decodeInstruction(instruction)
   const authority = decodedInstruction.keys.authority.pubkey
   if (
-    !authority.equals(claimableTokenAuthorities['usdc']) &&
-    !authority.equals(claimableTokenAuthorities['waudio'])
+    !authority.equals(claimableTokenAuthorities.usdc) &&
+    !authority.equals(claimableTokenAuthorities.waudio)
   ) {
     throw new InvalidRelayInstructionError(
       instructionIndex,

--- a/packages/discovery-provider/plugins/pedalboard/apps/solana-relay/src/routes/relay/attachLocationData.test.ts
+++ b/packages/discovery-provider/plugins/pedalboard/apps/solana-relay/src/routes/relay/attachLocationData.test.ts
@@ -1,14 +1,17 @@
+import assert from 'assert'
+
 import { PaymentRouterProgram } from '@audius/spl'
 import {
   Keypair,
   PublicKey,
   TransactionInstruction,
-  TransactionMessage,
+  TransactionMessage
 } from '@solana/web3.js'
-import { config } from '../../config'
 import { describe, it } from 'vitest'
+
+import { config } from '../../config'
+
 import { attachLocationData, isPaymentTransaction } from './attachLocationData'
-import assert from 'assert'
 
 const PAYMENT_ROUTER_PROGRAM_ID = new PublicKey(config.paymentRouterProgramId)
 const MEMO_V2_PROGRAM_ID = new PublicKey(
@@ -18,50 +21,52 @@ const MEMO_V2_PROGRAM_ID = new PublicKey(
 const getRandomPublicKey = () => Keypair.generate().publicKey
 
 describe('isPaymentTransaction', () => {
-    it('returns true when instructions are a payment', async () => {
-      const [pda, bump] = PublicKey.findProgramAddressSync(
-        [new TextEncoder().encode('payment_router')],
-        new PublicKey(PAYMENT_ROUTER_PROGRAM_ID)
-      )
-      const instructions = [
-        await PaymentRouterProgram.createRouteInstruction({
-          sender: getRandomPublicKey(),
-          senderOwner: pda,
-          paymentRouterPdaBump: bump,
-          recipients: [getRandomPublicKey()],
-          amounts: [BigInt(100)],
-          totalAmount: BigInt(100),
-          programId: PAYMENT_ROUTER_PROGRAM_ID
-        })
-      ]
-      const isPayment = await isPaymentTransaction(instructions)
-      assert.strictEqual(isPayment, true)
-    })
+  it('returns true when instructions are a payment', async () => {
+    const [pda, bump] = PublicKey.findProgramAddressSync(
+      [new TextEncoder().encode('payment_router')],
+      new PublicKey(PAYMENT_ROUTER_PROGRAM_ID)
+    )
+    const instructions = [
+      await PaymentRouterProgram.createRouteInstruction({
+        sender: getRandomPublicKey(),
+        senderOwner: pda,
+        paymentRouterPdaBump: bump,
+        recipients: [getRandomPublicKey()],
+        amounts: [BigInt(100)],
+        totalAmount: BigInt(100),
+        programId: PAYMENT_ROUTER_PROGRAM_ID
+      })
+    ]
+    const isPayment = await isPaymentTransaction(instructions)
+    assert.strictEqual(isPayment, true)
+  })
 
-    it('returns false whe instructions are a recovery', async () => {
-      const [pda, bump] = PublicKey.findProgramAddressSync(
-        [new TextEncoder().encode('payment_router')],
-        new PublicKey(PAYMENT_ROUTER_PROGRAM_ID)
-      )
-      const instructions = [
-        await PaymentRouterProgram.createRouteInstruction({
-          sender: getRandomPublicKey(),
-          senderOwner: pda,
-          paymentRouterPdaBump: bump,
-          recipients: [getRandomPublicKey()],
-          amounts: [BigInt(100)],
-          totalAmount: BigInt(100),
-          programId: PAYMENT_ROUTER_PROGRAM_ID
-        }),
-        new TransactionInstruction({
-          keys: [{ pubkey: getRandomPublicKey(), isSigner: true, isWritable: true }],
-          data: Buffer.from('Recover Withdrawal'),
-          programId: MEMO_V2_PROGRAM_ID
-        })
-      ]
-      const isPayment = await isPaymentTransaction(instructions)
-      assert.strictEqual(isPayment, false)
-    })
+  it('returns false whe instructions are a recovery', async () => {
+    const [pda, bump] = PublicKey.findProgramAddressSync(
+      [new TextEncoder().encode('payment_router')],
+      new PublicKey(PAYMENT_ROUTER_PROGRAM_ID)
+    )
+    const instructions = [
+      await PaymentRouterProgram.createRouteInstruction({
+        sender: getRandomPublicKey(),
+        senderOwner: pda,
+        paymentRouterPdaBump: bump,
+        recipients: [getRandomPublicKey()],
+        amounts: [BigInt(100)],
+        totalAmount: BigInt(100),
+        programId: PAYMENT_ROUTER_PROGRAM_ID
+      }),
+      new TransactionInstruction({
+        keys: [
+          { pubkey: getRandomPublicKey(), isSigner: true, isWritable: true }
+        ],
+        data: Buffer.from('Recover Withdrawal'),
+        programId: MEMO_V2_PROGRAM_ID
+      })
+    ]
+    const isPayment = await isPaymentTransaction(instructions)
+    assert.strictEqual(isPayment, false)
+  })
 })
 
 describe('attachLocationData', () => {
@@ -83,7 +88,9 @@ describe('attachLocationData', () => {
         programId: PAYMENT_ROUTER_PROGRAM_ID
       }),
       new TransactionInstruction({
-        keys: [{ pubkey: getRandomPublicKey(), isSigner: true, isWritable: true }],
+        keys: [
+          { pubkey: getRandomPublicKey(), isSigner: true, isWritable: true }
+        ],
         data: Buffer.from('Some random memo'),
         programId: MEMO_V2_PROGRAM_ID
       })
@@ -95,7 +102,7 @@ describe('attachLocationData', () => {
     })
     const updatedMessage = attachLocationData({
       transactionMessage: message,
-      location: {city: 'Nashville', region: 'TN', country: 'United States'}
+      location: { city: 'Nashville', region: 'TN', country: 'United States' }
     })
     assert.strictEqual(updatedMessage.instructions.length, 3)
 

--- a/packages/discovery-provider/plugins/pedalboard/apps/solana-relay/src/routes/relay/attachLocationData.ts
+++ b/packages/discovery-provider/plugins/pedalboard/apps/solana-relay/src/routes/relay/attachLocationData.ts
@@ -3,6 +3,7 @@ import {
   TransactionInstruction,
   TransactionMessage
 } from '@solana/web3.js'
+
 import { config } from '../../config'
 import { LocationData } from '../../utils/ipData'
 
@@ -10,8 +11,8 @@ const MEMO_PROGRAM_ID = 'Memo1UhkJRfHyvLMcVucJwxXeuD728EqVDDwQDxFMNo'
 const MEMO_V2_PROGRAM_ID = 'MemoSq4gqABAXKb96qnH8TysNcWxMyWCqXgDLGmfcHr'
 const PAYMENT_ROUTER_PROGRAM_ID = config.paymentRouterProgramId
 
-const RECOVERY_MEMO_STRING = "Recover Withdrawal"
-const GEO_MEMO_STRING = "geo"
+const RECOVERY_MEMO_STRING = 'Recover Withdrawal'
+const GEO_MEMO_STRING = 'geo'
 
 /**
  * Determines whether or not the provided instructions are from a payment transaction
@@ -47,19 +48,27 @@ export const isPaymentTransaction = (
 /**
  * Attaches location data to a TransactionMessage
  */
-export const attachLocationData = (
-  { transactionMessage, location }:
-  {
-    transactionMessage: TransactionMessage,
-    location: LocationData
-  }
-): TransactionMessage => {
+export const attachLocationData = ({
+  transactionMessage,
+  location
+}: {
+  transactionMessage: TransactionMessage
+  location: LocationData
+}): TransactionMessage => {
   const memoInstruction = new TransactionInstruction({
-    keys: [{ pubkey: transactionMessage.payerKey, isSigner: true, isWritable: true }],
-    data: Buffer.from(`${GEO_MEMO_STRING}:${JSON.stringify(location)}`, 'utf-8'),
+    keys: [
+      { pubkey: transactionMessage.payerKey, isSigner: true, isWritable: true }
+    ],
+    data: Buffer.from(
+      `${GEO_MEMO_STRING}:${JSON.stringify(location)}`,
+      'utf-8'
+    ),
     programId: new PublicKey(MEMO_V2_PROGRAM_ID)
   })
-  const updatedInstructions = [...transactionMessage.instructions, memoInstruction]
+  const updatedInstructions = [
+    ...transactionMessage.instructions,
+    memoInstruction
+  ]
   const msg = new TransactionMessage({
     payerKey: transactionMessage.payerKey,
     recentBlockhash: transactionMessage.recentBlockhash,

--- a/packages/discovery-provider/plugins/pedalboard/apps/solana-relay/src/routes/relay/relay.ts
+++ b/packages/discovery-provider/plugins/pedalboard/apps/solana-relay/src/routes/relay/relay.ts
@@ -13,7 +13,10 @@ import type { RelayRequestBody } from '@audius/sdk'
 import { getRequestIpData } from '../../utils/ipData'
 import { attachLocationData, isPaymentTransaction } from './attachLocationData'
 import { connections } from '../../utils/connections'
-import { broadcastTransaction, sendTransactionWithRetries } from '../../utils/transaction'
+import {
+  broadcastTransaction,
+  sendTransactionWithRetries
+} from '../../utils/transaction'
 
 const getFeePayerKeyPair = (feePayerPublicKey?: PublicKey) => {
   if (!feePayerPublicKey) {
@@ -86,8 +89,10 @@ export const relay = async (
       logger
     })
     res.status(200).send({ signature })
-    next()
+    const responseTime = new Date().getTime() - res.locals.requestStartTime
+    logger.info({ responseTime, statusCode: res.statusCode }, 'response sent')
     await broadcastTransaction({ logger, signature })
+    next()
   } catch (e) {
     next(e)
   }

--- a/packages/discovery-provider/plugins/pedalboard/apps/solana-relay/src/routes/relay/relay.ts
+++ b/packages/discovery-provider/plugins/pedalboard/apps/solana-relay/src/routes/relay/relay.ts
@@ -1,22 +1,23 @@
+import type { RelayRequestBody } from '@audius/sdk'
 import {
   PublicKey,
   TransactionMessage,
   VersionedTransaction
 } from '@solana/web3.js'
+import bs58 from 'bs58'
 import { Request, Response, NextFunction } from 'express'
+
 import { config } from '../../config'
 import { BadRequestError } from '../../errors'
-import { assertRelayAllowedInstructions } from './assertRelayAllowedInstructions'
-import {} from 'cross-fetch'
-import bs58 from 'bs58'
-import type { RelayRequestBody } from '@audius/sdk'
-import { getRequestIpData } from '../../utils/ipData'
-import { attachLocationData, isPaymentTransaction } from './attachLocationData'
 import { connections } from '../../utils/connections'
+import { getRequestIpData } from '../../utils/ipData'
 import {
   broadcastTransaction,
   sendTransactionWithRetries
 } from '../../utils/transaction'
+
+import { assertRelayAllowedInstructions } from './assertRelayAllowedInstructions'
+import { attachLocationData, isPaymentTransaction } from './attachLocationData'
 
 const getFeePayerKeyPair = (feePayerPublicKey?: PublicKey) => {
   if (!feePayerPublicKey) {

--- a/packages/discovery-provider/plugins/pedalboard/apps/solana-relay/src/utils/connections.ts
+++ b/packages/discovery-provider/plugins/pedalboard/apps/solana-relay/src/utils/connections.ts
@@ -1,11 +1,12 @@
-import { Connection } from "@solana/web3.js";
-import { config } from "../config";
+import { Connection } from '@solana/web3.js'
+
+import { config } from '../config'
 
 export const connections = config.solanaEndpoints.map(
-    (endpoint) => new Connection(endpoint)
+  (endpoint) => new Connection(endpoint)
 )
 
 export const getConnection = (): Connection => {
-    const randomIndex = Math.floor(Math.random() * connections.length);
-    return connections[randomIndex];
+  const randomIndex = Math.floor(Math.random() * connections.length)
+  return connections[randomIndex]
 }

--- a/packages/discovery-provider/plugins/pedalboard/apps/solana-relay/src/utils/delay.ts
+++ b/packages/discovery-provider/plugins/pedalboard/apps/solana-relay/src/utils/delay.ts
@@ -1,17 +1,17 @@
 export const delay = async (ms: number, options?: { signal: AbortSignal }) => {
-    const signal = options?.signal
-    return new Promise<void>((resolve, reject) => {
-        if (signal?.aborted) {
-            reject()
-        }
-        const listener = () => {
-            clearTimeout(timer)
-            reject()
-        }
-        const timer = setTimeout(() => {
-            signal?.removeEventListener('abort', listener)
-            resolve()
-        }, ms)
-        signal?.addEventListener('abort', listener)
-    })
+  const signal = options?.signal
+  return new Promise<void>((resolve, reject) => {
+    if (signal?.aborted) {
+      reject(new Error('Aborted'))
+    }
+    const listener = () => {
+      clearTimeout(timer)
+      reject(new Error('Timed out'))
+    }
+    const timer = setTimeout(() => {
+      signal?.removeEventListener('abort', listener)
+      resolve()
+    }, ms)
+    signal?.addEventListener('abort', listener)
+  })
 }

--- a/packages/discovery-provider/plugins/pedalboard/apps/solana-relay/src/utils/ipData.ts
+++ b/packages/discovery-provider/plugins/pedalboard/apps/solana-relay/src/utils/ipData.ts
@@ -1,63 +1,81 @@
-import { Logger } from "pino"
-import { Request } from "express"
-import axios from "axios"
-import { getClientIp } from "request-ip"
-import { config } from "../config"
-import { logger } from "../logger"
+import axios from 'axios'
+import { Request } from 'express'
+import { Logger } from 'pino'
+import { getClientIp } from 'request-ip'
 
-export type LocationData = { city: string, region: string, country: string } | null
+import { config } from '../config'
+import { logger } from '../logger'
+
+export type LocationData = {
+  city: string
+  region: string
+  country: string
+} | null
 
 // gets ip data from api.ipdata.co, returns an empty object {} if api key not configured or an error occurs
-export const getIpData = async (logger: Logger, ip: string): Promise<LocationData> => {
-    const ipdataApiKey = config.ipdataApiKey
-    if (ipdataApiKey === null) {
-        logger.warn({}, "ip data requested but api key not configured")
-        return null
-    }
-    const url = `https://api.ipdata.co/${ip}?api-key=${ipdataApiKey}`
-    try {
-        const response = await axios.get(url)
-            .then(({ data: { city, region, country_name } }: { data: { city: string, region: string, country_name: string } }) => {
-                return { city, region, country: country_name }
-            })
-        return response
-    } catch (e: unknown) {
-        logger.error({ error: e }, "error requesting ip data")
-        return null
-    }
+export const getIpData = async (
+  logger: Logger,
+  ip: string
+): Promise<LocationData> => {
+  const ipdataApiKey = config.ipdataApiKey
+  if (ipdataApiKey === null) {
+    logger.warn({}, 'ip data requested but api key not configured')
+    return null
+  }
+  const url = `https://api.ipdata.co/${ip}?api-key=${ipdataApiKey}`
+  try {
+    const response = await axios
+      .get(url)
+      .then(
+        ({
+          data: { city, region, country_name }
+        }: {
+          data: { city: string; region: string; country_name: string }
+        }) => {
+          return { city, region, country: country_name }
+        }
+      )
+    return response
+  } catch (e: unknown) {
+    logger.error({ error: e }, 'error requesting ip data')
+    return null
+  }
 }
 
 // gets ip data from api.ipdata.co, returns an empty object {} if api key not configured or an error occurs
-export const getRequestIpData = async (logger: Logger, req: Request<unknown>): Promise<LocationData> => {
-    try {
-        const ip = getIP(req)
-        return getIpData(logger, ip)
-    } catch (e) {
-        logger.error({ e }, "error requesting ip data")
-        return null
-    }
+export const getRequestIpData = async (
+  logger: Logger,
+  req: Request<unknown>
+): Promise<LocationData> => {
+  try {
+    const ip = getIP(req)
+    return getIpData(logger, ip)
+  } catch (e) {
+    logger.error({ e }, 'error requesting ip data')
+    return null
+  }
 }
 
 // Utility to gather the IP from an incoming express request.
 // Prioritizes 'X-Forwarded-For' if it exists. Otherwise returns the request objects ip.
 // Throws if neither can be found.
 export const getIP = (req: Request<unknown>): string => {
-    const clientIP = getClientIp(req)
-    // https://github.com/pbojinov/request-ip?tab=readme-ov-file#how-it-works
-    if (clientIP === null) {
-        throw new Error("could not find client ip")
-    }
-    return clientIP
+  const clientIP = getClientIp(req)
+  // https://github.com/pbojinov/request-ip?tab=readme-ov-file#how-it-works
+  if (clientIP === null) {
+    throw new Error('could not find client ip')
+  }
+  return clientIP
 }
 
 // Utility to gather the IP from an incoming express request.
 // Prioritizes 'X-Forwarded-For' if it exists. Otherwise returns the request objects ip.
 // Catches errors and returns an empty string as a default.
 export const getIPwithDefault = (req: Request): string => {
-    try {
-        return getIP(req)
-    } catch (e) {
-        logger.error({ e }, "could not get IP")
-        return ""
-    }
+  try {
+    return getIP(req)
+  } catch (e) {
+    logger.error({ e }, 'could not get IP')
+    return ''
+  }
 }

--- a/packages/discovery-provider/plugins/pedalboard/apps/solana-relay/src/utils/sortKeys.ts
+++ b/packages/discovery-provider/plugins/pedalboard/apps/solana-relay/src/utils/sortKeys.ts
@@ -1,12 +1,12 @@
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export const sortKeys = (x: any): any => {
-    if (typeof x !== 'object' || !x) {
-      return x
-    }
-    if (Array.isArray(x)) {
-      return x.map(sortKeys)
-    }
-    return Object.keys(x)
-      .sort()
-      .reduce((o, k) => ({ ...o, [k]: sortKeys(x[k]) }), {})
+  if (typeof x !== 'object' || !x) {
+    return x
   }
+  if (Array.isArray(x)) {
+    return x.map(sortKeys)
+  }
+  return Object.keys(x)
+    .sort()
+    .reduce((o, k) => ({ ...o, [k]: sortKeys(x[k]) }), {})
+}

--- a/packages/discovery-provider/plugins/pedalboard/apps/solana-relay/src/utils/transaction.ts
+++ b/packages/discovery-provider/plugins/pedalboard/apps/solana-relay/src/utils/transaction.ts
@@ -1,11 +1,20 @@
-import { Commitment, Connection, SendOptions, TransactionConfirmationStrategy, VersionedTransaction } from "@solana/web3.js"
-import { connections, getConnection } from "./connections"
-import { cacheTransaction, getCachedDiscoveryNodes } from "../redis"
-import { Logger } from "pino"
-import { logger as defaultLogger } from "../logger"
-import { personalSign } from "eth-sig-util"
-import { config } from "../config"
-import { delay } from "./delay"
+import {
+  Commitment,
+  Connection,
+  SendOptions,
+  TransactionConfirmationStrategy,
+  VersionedTransaction
+} from '@solana/web3.js'
+import fetch from 'cross-fetch'
+import { personalSign } from 'eth-sig-util'
+import { Logger } from 'pino'
+
+import { config } from '../config'
+import { logger as defaultLogger } from '../logger'
+import { cacheTransaction, getCachedDiscoveryNodes } from '../redis'
+
+import { connections, getConnection } from './connections'
+import { delay } from './delay'
 
 const RETRY_DELAY_MS = 2 * 1000
 const RETRY_TIMEOUT_MS = 60 * 1000
@@ -15,44 +24,44 @@ const RETRY_TIMEOUT_MS = 60 * 1000
  * nodes so that they can cache it to lighten the RPC load on indexing.
  */
 const forwardTransaction = async (logger: Logger, transaction: string) => {
-    const endpoints = await getCachedDiscoveryNodes()
-    logger.info(`Forwarding to ${endpoints.length} endpoints...`)
-    const body = JSON.stringify({ transaction })
-    await Promise.all(
-        endpoints
-            .filter((p) => p.endpoint !== config.endpoint)
-            .map(({ endpoint }) =>
-                fetch(`${endpoint}/solana/cache`, {
-                    method: 'POST',
-                    body,
-                    headers: {
-                        'content-type': 'application/json',
-                        'Discovery-Signature': personalSign(config.delegatePrivateKey, {
-                            data: body
-                        })
-                    }
-                })
-                    .then((res) => {
-                        if (res.ok) {
-                            logger.info(
-                                { endpoint, status: res.status },
-                                `Forwarded successfully`
-                            )
-                        } else {
-                            logger.warn(
-                                { endpoint },
-                                `Failed to forward transaction to endpoint: ${res.statusText}`
-                            )
-                        }
-                    })
-                    .catch((e) => {
-                        logger.warn(
-                            { endpoint },
-                            `Failed to forward transaction to endpoint: ${e}`
-                        )
-                    })
+  const endpoints = await getCachedDiscoveryNodes()
+  logger.info(`Forwarding to ${endpoints.length} endpoints...`)
+  const body = JSON.stringify({ transaction })
+  await Promise.all(
+    endpoints
+      .filter((p) => p.endpoint !== config.endpoint)
+      .map(({ endpoint }) =>
+        fetch(`${endpoint}/solana/cache`, {
+          method: 'POST',
+          body,
+          headers: {
+            'content-type': 'application/json',
+            'Discovery-Signature': personalSign(config.delegatePrivateKey, {
+              data: body
+            })
+          }
+        })
+          .then((res) => {
+            if (res.ok) {
+              logger.info(
+                { endpoint, status: res.status },
+                `Forwarded successfully`
+              )
+            } else {
+              logger.warn(
+                { endpoint },
+                `Failed to forward transaction to endpoint: ${res.statusText}`
+              )
+            }
+          })
+          .catch((e) => {
+            logger.warn(
+              { endpoint },
+              `Failed to forward transaction to endpoint: ${e}`
             )
-    )
+          })
+      )
+  )
 }
 
 /**
@@ -61,129 +70,137 @@ const forwardTransaction = async (logger: Logger, transaction: string) => {
  * or times out.
  */
 export const sendTransactionWithRetries = async ({
-    transaction,
-    commitment,
-    confirmationStrategy,
-    sendOptions,
-    logger
+  transaction,
+  commitment,
+  confirmationStrategy,
+  sendOptions,
+  logger
 }: {
-    transaction: VersionedTransaction
-    commitment: Commitment
-    confirmationStrategy: TransactionConfirmationStrategy
-    sendOptions?: SendOptions
-    logger: Logger
+  transaction: VersionedTransaction
+  commitment: Commitment
+  confirmationStrategy: TransactionConfirmationStrategy
+  sendOptions?: SendOptions
+  logger: Logger
 }) => {
-    const serializedTx = transaction.serialize()
+  const serializedTx = transaction.serialize()
 
-    let retryCount = 0
-    const createRetryPromise = async (signal: AbortSignal): Promise<void> => {
-        while (!signal.aborted) {
-            Promise.any(
-                connections.map((connection) =>
-                    connection.sendRawTransaction(serializedTx, {
-                        skipPreflight: true,
-                        maxRetries: 0,
-                        ...sendOptions
-                    })
-                )
-            ).catch((error) => {
-                logger.warn({ error, retryCount }, `Failed retry...`)
-            })
-            await delay(RETRY_DELAY_MS)
-            retryCount++
-        }
-    }
-
-    const createTimeoutPromise = async (signal: AbortSignal) => {
-        await delay(RETRY_TIMEOUT_MS)
-        if (!signal.aborted) {
-            logger.error('Timed out sending transaction')
-        }
-    }
-
-    const start = Date.now()
-    const connection = connections[0]
-    const abortController = new AbortController()
-    try {
-        if (!sendOptions?.skipPreflight) {
-            const simulatedRes = await connection.simulateTransaction(transaction)
-            if (simulatedRes.value.err) {
-                logger.error(
-                    { error: simulatedRes.value.err },
-                    'Transaction simulation failed'
-                )
-                throw simulatedRes.value.err
-            }
-        }
-
-        const res = await Promise.race([
-            createRetryPromise(abortController.signal),
-            connection.confirmTransaction(
-                { ...confirmationStrategy, abortSignal: abortController.signal },
-                commitment
-            ),
-            createTimeoutPromise(abortController.signal)
-        ])
-
-        if (!res || res.value.err) {
-            throw res?.value.err ?? 'Transaction polling timed out.'
-        }
-        logger.info({ commitment }, 'Transaction sent successfully')
-        return confirmationStrategy.signature
-    } catch (error) {
-        logger.error({ error }, 'Transaction failed to send')
-        throw error
-    } finally {
-        // Stop the other operations
-        abortController.abort()
-        const end = Date.now()
-        const elapsedMs = end - start
-        logger.info(
-            { elapsedMs, retryCount },
-            'sendTransactionWithRetries completed.'
+  let retryCount = 0
+  const createRetryPromise = async (signal: AbortSignal): Promise<void> => {
+    while (!signal.aborted) {
+      Promise.any(
+        connections.map((connection) =>
+          connection.sendRawTransaction(serializedTx, {
+            skipPreflight: true,
+            maxRetries: 0,
+            ...sendOptions
+          })
         )
+      ).catch((error) => {
+        logger.warn({ error, retryCount }, `Failed retry...`)
+      })
+      await delay(RETRY_DELAY_MS)
+      retryCount++
     }
+  }
+
+  const createTimeoutPromise = async (signal: AbortSignal) => {
+    await delay(RETRY_TIMEOUT_MS)
+    if (!signal.aborted) {
+      logger.error('Timed out sending transaction')
+    }
+  }
+
+  const start = Date.now()
+  const connection = connections[0]
+  const abortController = new AbortController()
+  try {
+    if (!sendOptions?.skipPreflight) {
+      const simulatedRes = await connection.simulateTransaction(transaction)
+      if (simulatedRes.value.err) {
+        logger.error(
+          { error: simulatedRes.value.err },
+          'Transaction simulation failed'
+        )
+        throw new Error(JSON.stringify(simulatedRes.value.err))
+      }
+    }
+
+    const res = await Promise.race([
+      createRetryPromise(abortController.signal),
+      connection.confirmTransaction(
+        { ...confirmationStrategy, abortSignal: abortController.signal },
+        commitment
+      ),
+      createTimeoutPromise(abortController.signal)
+    ])
+
+    if (!res || res.value.err) {
+      throw res?.value.err ?? 'Transaction polling timed out.'
+    }
+    logger.info({ commitment }, 'Transaction sent successfully')
+    return confirmationStrategy.signature
+  } catch (error) {
+    logger.error({ error }, 'Transaction failed to send')
+    throw error
+  } finally {
+    // Stop the other operations
+    abortController.abort()
+    const end = Date.now()
+    const elapsedMs = end - start
+    logger.info(
+      { elapsedMs, retryCount },
+      'sendTransactionWithRetries completed.'
+    )
+  }
 }
 
 /**
- * Confirms a transaction if skipConfirmation is false or not passed. Stores the given transaction in 
- * redis and then broadcasts it to all other discovery nodes using forwardTransaction. 
+ * Confirms a transaction if skipConfirmation is false or not passed. Stores the given transaction in
+ * redis and then broadcasts it to all other discovery nodes using forwardTransaction.
  */
-export const broadcastTransaction = async ({ signature, skipConfirmation = false, logger }: { signature: string, skipConfirmation?: boolean, logger?: Logger }) => {
-    logger = logger !== undefined ? logger : defaultLogger
-    const connection = getConnection()
-    if (!skipConfirmation) {
-        // Confirm, fetch, cache and forward after success response.
-        // The transaction may be confirmed from specifying commitment before,
-        // but that may have been a different RPC. So confirm again.
-        logger.info(`Confirming transaction before fetching...`)
-        const strategy = await connection.getLatestBlockhash()
-        const confirmationStrategy = { ...strategy, signature }
-        await connection.confirmTransaction(confirmationStrategy, 'confirmed')
+export const broadcastTransaction = async ({
+  signature,
+  skipConfirmation = false,
+  logger
+}: {
+  signature: string
+  skipConfirmation?: boolean
+  logger?: Logger
+}) => {
+  logger = logger !== undefined ? logger : defaultLogger
+  const connection = getConnection()
+  if (!skipConfirmation) {
+    // Confirm, fetch, cache and forward after success response.
+    // The transaction may be confirmed from specifying commitment before,
+    // but that may have been a different RPC. So confirm again.
+    logger.info(`Confirming transaction before fetching...`)
+    const strategy = await connection.getLatestBlockhash()
+    const confirmationStrategy = { ...strategy, signature }
+    await connection.confirmTransaction(confirmationStrategy, 'confirmed')
+  }
+  logger.info('Fetching transaction for caching...')
+  // Dangerously relying on the internals of connection to do the fetch.
+  // Calling connection.getTransaction will result in the library parsing the
+  // results and getting us back our object again, but we need the raw JSON
+  // for Solders to know what we're talking about when indexing.
+  const rpcResponse = await (
+    connection as Connection & {
+      _rpcRequest: (
+        methodName: string,
+        args: Array<unknown>
+      ) => Promise<unknown>
     }
-    logger.info('Fetching transaction for caching...')
-    // Dangerously relying on the internals of connection to do the fetch.
-    // Calling connection.getTransaction will result in the library parsing the
-    // results and getting us back our object again, but we need the raw JSON
-    // for Solders to know what we're talking about when indexing.
-    const rpcResponse = await (
-        connection as Connection & {
-            _rpcRequest: (
-                methodName: string,
-                args: Array<unknown>
-            ) => Promise<unknown>
-        }
-    )._rpcRequest('getTransaction', [
-        signature,
-        {
-            maxSupportedTransactionVersion: 0,
-            commitment: 'confirmed',
-            encoding: 'json'
-        }
-    ])
-    const formattedResponse = JSON.stringify(rpcResponse)
-    logger.info('Caching transaction...')
-    await cacheTransaction(signature, formattedResponse)
-    logger.info('Forwarding transaction to other nodes to cache...')
-    await forwardTransaction(logger, formattedResponse)
+  )._rpcRequest('getTransaction', [
+    signature,
+    {
+      maxSupportedTransactionVersion: 0,
+      commitment: 'confirmed',
+      encoding: 'json'
+    }
+  ])
+  const formattedResponse = JSON.stringify(rpcResponse)
+  logger.info('Caching transaction...')
+  await cacheTransaction(signature, formattedResponse)
+  logger.info('Forwarding transaction to other nodes to cache...')
+  await forwardTransaction(logger, formattedResponse)
 }


### PR DESCRIPTION
### Description

Solana relay logs would log `[Object object]` on failures because the error handling middleware neglected to have the fourth parameter. Annoyingly, when I added the fourth (unused) parameter, eslint was complaining (even with an `_`). I realized we were using a different eslint config than client, so I changed that. Which cascaded to a bunch of formatting changes (sorry).

I'll annotate the differences to help with review