### PR TITLE
Fix mobile playback not working

### DIFF
--- a/packages/mobile/src/screens/app-drawer-screen/AppDrawerScreen.tsx
+++ b/packages/mobile/src/screens/app-drawer-screen/AppDrawerScreen.tsx
@@ -55,7 +55,9 @@ export const AppDrawerScreen = memo(
   () => {
     const [gesturesDisabled, setGesturesDisabled] = useState(false)
 
-    const useRNVideoPlayer = useFeatureFlag(FeatureFlags.USE_RN_VIDEO_PLAYER)
+    const { isEnabled: useRNVideoPlayer } = useFeatureFlag(
+      FeatureFlags.USE_RN_VIDEO_PLAYER
+    )
 
     const drawerScreenOptions = useMemo(
       () => ({


### PR DESCRIPTION
### Description

Currently the app is always defaulting to the experimental RN Video player, which seems to be broken on real devices (not broken on simulator for some reason?)

TODO: Still investigating whats wrong with the RN Video player itself, it appears like it should be working but no audio comes out 😓 

### How Has This Been Tested?

