### PR TITLE
Fix prod mediorum dockerfile to have keyfinder dependency

### DIFF
--- a/mediorum/Dockerfile
+++ b/mediorum/Dockerfile
@@ -34,6 +34,7 @@ RUN python3 -m pip install numpy aubio
 COPY --from=builder /go/bin/* /bin
 COPY --from=builder /app/mediorum /bin/mediorum
 COPY --from=builder /app/mediorum-cmd /bin/mediorum-cmd
+COPY --from=builder /usr/local/lib/libkeyfinder.so* /usr/local/lib/
 COPY --from=builder /app/analyze-key /bin/analyze-key
 
 # ARGs can be optionally defined with --build-arg while doing docker build eg in CI and then set to env vars


### PR DESCRIPTION
### Description
Copy libkeyfinder dep to the final build stage in the prod dockerfile. currently the keyfinder is not working on stage bc this dep is missing.
![image](https://github.com/AudiusProject/audius-protocol/assets/25782182/f4f3101d-09ad-44d4-9783-be5ffc13926c)
(doesn't affect upload success at all)

### How Has This Been Tested?
built image but haven't been able to run it without the env configs. pretty sure this should fix it though