### PR TITLE
Make main trigger the same relevant workflows as PRs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -538,40 +538,63 @@ workflows:
           base-revision: main~1
           config-path: ../workspace/.circleci/continue_config.yml
           mapping: |
-            .* run-integration-workflow true
-            .* run-creator-workflow true
-            .* run-discovery-workflow true
-            .* run-identity-workflow true
-            .* run-eth-contracts-workflow true
-            .* run-contracts-workflow true
-            .* run-release-workflow false
-            .* run-sdk-workflow true
-            .* run-harmony-workflow true
-            .* run-ddex-stage-workflow true
-            .circleci/.* run-web-workflow true
-            .circleci/.* run-mobile-workflow true
-            .circleci/.* run-protocol-dashboard-workflow true
-            packages/common/.* run-common-workflow true
-            packages/common/.* run-web-workflow true
-            packages/common/.* run-mobile-workflow true
-            packages/eslint-config-audius/.* run-web-workflow true
-            packages/eslint-config-audius/.* run-mobile-workflow true
-            packages/libs/.* run-web-workflow true
-            packages/libs/.* run-mobile-workflow true
-            packages/libs/.* run-create-audius-app-workflow true
-            packages/harmony/.* run-web-workflow true
-            packages/harmony/.* run-mobile-workflow true
-            packages/mobile/.* run-mobile-workflow true
-            packages/web/.* run-web-workflow true
-            packages/embed/.* run-embed-workflow true
+            comms/.* run-discovery-workflow true
+            mediorum/.* run-creator-workflow true
+            packages/identity-service/.* run-identity-workflow true
+            packages/identity-service/.* run-integration-workflow true
             packages/ddex/webapp/.* run-ddex-webapp-workflow true
             packages/ddex/webapp/.* run-ddex-e2e-workflow true
             packages/ddex/ingester/.* run-ddex-e2e-workflow true
             packages/ddex/processor/.* run-ddex-processor-workflow true
             packages/ddex/publisher/.* run-ddex-publisher-workflow true
-            packages/create-audius-app/.* run-create-audius-app-workflow true
-            protocol-dashboard/.* run-protocol-dashboard-workflow true
+            eth-contracts/.* run-eth-contracts-workflow true
             monitoring/healthz/.* run-healthz-workflow true
+            protocol-dashboard/.* run-protocol-dashboard-workflow true
+            contracts/.* run-contracts-workflow true
+            .circleci/.* run-discovery-workflow true
+            .circleci/.* run-creator-workflow true
+            .circleci/.* run-identity-workflow true
+            .circleci/.* run-eth-contracts-workflow true
+            .circleci/.* run-protocol-dashboard-workflow true
+            .circleci/.* run-ddex-webapp-workflow true
+            .circleci/.* run-ddex-e2e-workflow true
+            .circleci/.* run-ddex-processor-workflow true
+            .circleci/.* run-ddex-publisher-workflow true
+            .circleci/.* run-healthz-workflow true
+            .circleci/.* run-contracts-workflow true
+            .circleci/.* run-sdk-workflow true
+            .circleci/.* run-web-workflow true
+            .circleci/.* run-mobile-workflow true
+            .circleci/.* run-harmony-workflow true
+            .circleci/.* run-embed-workflow true
+            package-lock.json run-sdk-workflow true
+            package-lock.json run-harmony-workflow true
+            .* run-release-workflow false
+            .* run-integration-workflow true
+            packages/discovery-provider/.* run-discovery-workflow true
+            packages/web/.* run-web-workflow true
+            packages/mobile/.* run-mobile-workflow true
+            packages/embed/.* run-embed-workflow true
+            packages/common/.* run-common-workflow true
+            packages/common/.* run-web-workflow true
+            packages/common/.* run-mobile-workflow true
+            packages/harmony/.* run-harmony-workflow true
+            packages/harmony/.* run-web-workflow true
+            packages/eslint-config-audius/.* run-web-workflow true
+            packages/eslint-config-audius/.* run-mobile-workflow true
+            packages/eslint-config-audius/.* run-harmony-workflow true
+            packages/libs/.* run-creator-workflow true
+            packages/libs/.* run-identity-workflow true
+            packages/libs/.* run-protocol-dashboard-workflow true
+            packages/libs/.* run-ddex-webapp-workflow true
+            packages/libs/.* run-ddex-processor-workflow true
+            packages/libs/.* run-ddex-publisher-workflow true
+            packages/libs/.* run-sdk-workflow true
+            packages/libs/.* run-web-workflow true
+            packages/libs/.* run-mobile-workflow true
+            packages/libs/.* run-embed-workflow true
+            packages/libs/.* run-create-audius-app-workflow true
+            packages/create-audius-app/.* run-create-audius-app-workflow true
           requires:
             - generate-config
             - init

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -468,6 +468,7 @@ workflows:
           base-revision: main
           config-path: ../workspace/.circleci/continue_config.yml
           mapping: |
+            packages/ddex/.* run-ddex-stage-workflow true
             comms/.* run-discovery-workflow true
             mediorum/.* run-creator-workflow true
             packages/identity-service/.* run-identity-workflow true


### PR DESCRIPTION
### Description

Prior to this change, we were running discovery et. al on every main commit. This is just a copy/paste of the `trigger-relevant-workflows` filters so that we only run relevant things on main.

Goal here is to reduce the CI usage a bit.
