### PR TITLE
fix libkeyfinder dependencies again

### DIFF
--- a/mediorum/Dockerfile
+++ b/mediorum/Dockerfile
@@ -1,8 +1,23 @@
 FROM golang:alpine AS builder
 
-RUN apk add build-base make ffmpeg cmake fftw-dev libsndfile-dev git python3-dev py3-pip
+RUN apk add build-base make ffmpeg
 
 WORKDIR /app
+
+ENV CGO_ENABLED=0
+
+COPY go.mod go.sum ./
+RUN go mod graph | awk '{if ($1 !~ "@") print $2}' | xargs go get
+
+COPY . .
+
+RUN go build
+RUN go build -o mediorum-cmd cmd/main.go
+
+FROM alpine:3.17 AS final
+
+RUN apk add curl ffmpeg cmake fftw-dev libsndfile-dev git python3-dev py3-pip build-base
+RUN python3 -m pip install numpy aubio
 
 # Build and install libkeyfinder
 RUN git clone https://github.com/mixxxdj/libKeyFinder.git /libKeyFinder
@@ -12,31 +27,15 @@ RUN cmake -DCMAKE_INSTALL_PREFIX=/usr/local -DBUILD_TESTING=OFF -S . -B build &&
     cmake --install build
 
 WORKDIR /app
-ENV CGO_ENABLED=0
-
-COPY go.mod go.sum ./
-RUN go mod graph | awk '{if ($1 !~ "@") print $2}' | xargs go get
-
-COPY . .
-
-# Compile the keyfinder C++ executable
-RUN g++ -o analyze-key cpp/keyfinder.cpp -I/usr/local/include -L/usr/local/lib -lkeyfinder -lsndfile && \
-    chmod +x analyze-key
-
-RUN go build
-RUN go build -o mediorum-cmd cmd/main.go
-
-FROM alpine:3.17 AS final
-
-RUN apk add curl ffmpeg fftw-dev libsndfile-dev python3-dev py3-pip build-base
-RUN python3 -m pip install numpy aubio
 
 COPY --from=builder /go/bin/* /bin
 COPY --from=builder /app/mediorum /bin/mediorum
 COPY --from=builder /app/mediorum-cmd /bin/mediorum-cmd
-COPY --from=builder /usr/local/lib/libkeyfinder.so* /usr/local/lib/
-COPY --from=builder /usr/local/include/keyfinder /usr/local/include/keyfinder
-COPY --from=builder /app/analyze-key /bin/analyze-key
+COPY --from=builder /app/cpp /app/cpp
+
+# Compile the keyfinder C++ executable
+RUN g++ -o /bin/analyze-key /app/cpp/keyfinder.cpp -I/usr/local/include -L/usr/local/lib -lkeyfinder -lsndfile && \
+    chmod +x /bin/analyze-key
 
 # ARGs can be optionally defined with --build-arg while doing docker build eg in CI and then set to env vars
 ARG git_sha

--- a/mediorum/Dockerfile
+++ b/mediorum/Dockerfile
@@ -26,7 +26,7 @@ RUN cmake -DCMAKE_INSTALL_PREFIX=/usr/local -DBUILD_TESTING=OFF -S . -B build &&
     cmake --build build --parallel $(nproc) && \
     cmake --install build
 
-WORKDIR /app
+WORKDIR /
 
 COPY --from=builder /go/bin/* /bin
 COPY --from=builder /app/mediorum /bin/mediorum

--- a/mediorum/Dockerfile
+++ b/mediorum/Dockerfile
@@ -28,13 +28,14 @@ RUN go build -o mediorum-cmd cmd/main.go
 
 FROM alpine:3.17 AS final
 
-RUN apk add curl ffmpeg libsndfile python3-dev py3-pip build-base
+RUN apk add curl ffmpeg fftw-dev libsndfile-dev python3-dev py3-pip build-base
 RUN python3 -m pip install numpy aubio
 
 COPY --from=builder /go/bin/* /bin
 COPY --from=builder /app/mediorum /bin/mediorum
 COPY --from=builder /app/mediorum-cmd /bin/mediorum-cmd
 COPY --from=builder /usr/local/lib/libkeyfinder.so* /usr/local/lib/
+COPY --from=builder /usr/local/include/keyfinder /usr/local/include/keyfinder
 COPY --from=builder /app/analyze-key /bin/analyze-key
 
 # ARGs can be optionally defined with --build-arg while doing docker build eg in CI and then set to env vars


### PR DESCRIPTION
### Description
was still missing dependencies in the final build stage, so /bin/analyze-key was erroring. moved the /bin/analyze-key compilation to the final stage

### How Has This Been Tested?
built and tested this on stage, verified it works