### PR TITLE
Don't show preview for mobile mixed albums

### DIFF
--- a/packages/mobile/src/components/details-tile/DetailsTile.tsx
+++ b/packages/mobile/src/components/details-tile/DetailsTile.tsx
@@ -166,8 +166,10 @@ export const DetailsTile = ({
     (isPlayable && hasStreamAccess) || doesUserHaveAccessToAnyTrack
   const shouldShowPreview =
     isUSDCPurchaseGated &&
-    ((isOwner && !isCollection) || !hasStreamAccess) &&
-    onPressPreview
+    ((!isCollection && isOwner) || // own track
+      (isCollection && !hasStreamAccess && !shouldShowPlay) || // premium collection
+      (!isCollection && !hasStreamAccess)) && // premium track
+    !!onPressPreview
 
   const handlePressArtistName = useCallback(() => {
     if (!user) {


### PR DESCRIPTION
### Description
Noticed today on mobile that for a premium collection containing both premium and public tracks, we were showing both the play and preview buttons. This PR fixes that case - we should only show the play button if the user has access to _any_ of the containing tracks.

This is another +1 for splitting out the track vs collection `DetailsTile` components on mobile. The bug doesn't exist on web because they are split on web.

### How Has This Been Tested?
own album
![Simulator Screenshot - iPhone 15 Pro - 2024-05-31 at 14 56 49](https://github.com/AudiusProject/audius-protocol/assets/3893871/93bc18ab-43c5-43e3-a04e-e0a85ed2a124)
album containing both premium + public tracks
![Simulator Screenshot - iPhone 15 Pro - 2024-05-31 at 14 56 04](https://github.com/AudiusProject/audius-protocol/assets/3893871/5054aa09-06f2-450b-9073-36f9df2aa5c6)
unpurchased premium album 
![Simulator Screenshot - iPhone 15 Pro - 2024-05-31 at 14 56 09](https://github.com/AudiusProject/audius-protocol/assets/3893871/b616e536-2969-4945-a9c5-632cd2a970e0)
own track
![Simulator Screenshot - iPhone 15 Pro - 2024-05-31 at 14 56 27](https://github.com/AudiusProject/audius-protocol/assets/3893871/48c0ddaf-3cc6-47be-b9fe-7d7192e662e6)
public track
![Simulator Screenshot - iPhone 15 Pro - 2024-05-31 at 14 56 38](https://github.com/AudiusProject/audius-protocol/assets/3893871/810753e7-3da2-4656-915c-7aad9bb1769b)
premium track
![Simulator Screenshot - iPhone 15 Pro - 2024-05-31 at 13 08 01](https://github.com/AudiusProject/audius-protocol/assets/3893871/2c9a75cb-f6b4-4ea7-ba8e-73fadcc28e5b)

