### PR TITLE
Fix trending POA Block

### DIFF
--- a/packages/discovery-provider/ddl/migrations/0075_fix_trending_poa_block.sql
+++ b/packages/discovery-provider/ddl/migrations/0075_fix_trending_poa_block.sql
@@ -1,0 +1,3 @@
+begin;
+update user_challenges set completed_blocknumber = 69657400 where completed_blocknumber = 38244400;
+commit;

--- a/packages/discovery-provider/src/tasks/calculate_trending_challenges.py
+++ b/packages/discovery-provider/src/tasks/calculate_trending_challenges.py
@@ -96,10 +96,11 @@ def enqueue_trending_challenges(
             return
 
         # subtract final poa block because db is final_poa_block + latest_acdc_block
-        latest_blocknumber = latest_blocknumber - helpers.get_final_poa_block()
 
         latest_block_datetime = datetime.fromtimestamp(
-            web3.eth.get_block(latest_blocknumber)["timestamp"]
+            web3.eth.get_block(latest_blocknumber - helpers.get_final_poa_block())[
+                "timestamp"
+            ]
         )
 
         trending_track_versions = trending_strategy_factory.get_versions_for_type(


### PR DESCRIPTION
### Description

Follow up: https://github.com/AudiusProject/audius-protocol/pull/8626

This fixed my previous bug but led to ACDC block being dispatched into the `user_challenges`. 

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._

Ran on sandbox and confirmed undisbursed shows trending results

https://isaac.sandbox.audius.co/v1/challenges/undisbursed?completed_blocknumber=69663399