### PR TITLE
Update maxSize for bundle size check

### DIFF
--- a/packages/web/bundlesize.prod.config.json
+++ b/packages/web/bundlesize.prod.config.json
@@ -2,7 +2,7 @@
   "files": [
     {
       "path": "./build-ssr-production/server/chunks/chunk-*.js",
-      "maxSize": "30 kB"
+      "maxSize": "60 kB"
     }
   ]
 }

--- a/packages/web/bundlesize.stage.config.json
+++ b/packages/web/bundlesize.stage.config.json
@@ -2,7 +2,7 @@
   "files": [
     {
       "path": "./build-ssr-staging/server/chunks/chunk-*.js",
-      "maxSize": "30 kB"
+      "maxSize": "60 kB"
     }
   ]
 }


### PR DESCRIPTION
### Description
Bumped the max chunk size up to 60kb. This is an arbitrary max size that's really just to catch when libs is imported and the ssr bundle is too big 
