### PR TITLE
admonition css link color fixes

### DIFF
--- a/docs/src/css/custom.css
+++ b/docs/src/css/custom.css
@@ -286,7 +286,12 @@ article a:link {
 /* force underline on links in admonitions */
 .alert a {
   text-decoration: underline;
-  color: white;
+  color: blue;
+}
+
+html[data-theme='dark'] .alert a {
+  text-decoration: underline;
+  color: #0f82af;
 }
 
 .alert,


### PR DESCRIPTION
### Description

Correct Admonition link text colors

| mode       | before                                                                                                                | after                                                                                                                |
| ---------- | --------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------- |
| light mode | ![before-light](https://github.com/AudiusProject/audius-protocol/assets/1404219/238dd08c-c467-4c02-8374-1a93c5248b31) | ![after-light](https://github.com/AudiusProject/audius-protocol/assets/1404219/bfa1fbf7-4e13-4453-9990-9b517b4cd867) |
| dark mode  | ![before-dark](https://github.com/AudiusProject/audius-protocol/assets/1404219/7cedeecb-bf13-4cac-99ff-aa195017775a)  | ![after-dark](https://github.com/AudiusProject/audius-protocol/assets/1404219/4279a4f9-8d01-44da-bca7-37af191a8f22)  |
