### PR TITLE
Flip email deliverable boolean

### DIFF
--- a/packages/identity-service/src/routes/user.js
+++ b/packages/identity-service/src/routes/user.js
@@ -18,12 +18,8 @@ const bouncerApiKey = config.get('bouncerEmailValidationKey')
 
 const isEmailDeliverable = async (email, logger) => {
   try {
-    // remove subaddressing since usebouncer rejects those
-    const strippedEmail =
-      email.split('+')[0] + email.substring(email.indexOf('@'))
-
     const res = await axios.get(
-      `${BOUNCER_BASE_URL}?email=${encodeURIComponent(strippedEmail)}`,
+      `${BOUNCER_BASE_URL}?email=${encodeURIComponent(email)}`,
       {
         headers: {
           'x-api-key': bouncerApiKey

--- a/packages/identity-service/src/routes/user.js
+++ b/packages/identity-service/src/routes/user.js
@@ -18,15 +18,19 @@ const bouncerApiKey = config.get('bouncerEmailValidationKey')
 
 const isEmailDeliverable = async (email, logger) => {
   try {
+    // remove subaddressing since usebouncer rejects those
+    const strippedEmail =
+      email.split('+')[0] + email.substring(email.indexOf('@'))
+
     const res = await axios.get(
-      `${BOUNCER_BASE_URL}?email=${encodeURIComponent(email)}`,
+      `${BOUNCER_BASE_URL}?email=${encodeURIComponent(strippedEmail)}`,
       {
         headers: {
           'x-api-key': bouncerApiKey
         }
       }
     )
-    return res?.data?.status === 'undeliverable'
+    return res?.data?.status === 'deliverable'
   } catch (err) {
     // Couldn't figure out if delivable, so say it was
     logger.error(`Unable to validate email for ${email}`, err)


### PR DESCRIPTION
### Description

Recently added userBouncer API key on prod and noticed email deliverability still looked off because of this... isEmailDeliverable should check if the status is `deliverable` instead.

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._

Ran on staging and `isEmailDeliverable` looks correct now.