### PR TITLE
ONC: add check for old uploads

### DIFF
--- a/packages/discovery-provider/plugins/verified-uploads/src/handlers/tracks.js
+++ b/packages/discovery-provider/plugins/verified-uploads/src/handlers/tracks.js
@@ -20,6 +20,11 @@ export default async ({ track_id, updated_at, created_at }) => {
     created_at !== undefined
   if (!isUpload) return
 
+  if (isOldUpload(created_at)) {
+    console.log({ created_at, track_id }, "old upload")
+    return
+  }
+
   const trackId = track_id
   const results = await dp_db('tracks')
     .innerJoin('users', 'tracks.owner_id', '=', 'users.user_id')


### PR DESCRIPTION
### Description
We used to use this utility function to block old notifications that get retriggered by PG but it's actually unused at the moment. This will stop old uploads that have matching created_at and updated_at fields from showing up in the channel.

As for why they get retriggered not sure yet. Maybe a bug with indexing that isn't changing the "updated_at" field correctly or a pg trigger on some other event. This will at least make the channel correct.

Update: I believe it was this PR that triggered the old notifs because it modifies the tracks table, doesn't update "updated_at", then the bot sees that the dates for "created_at" and "updated_at" are the same. Since this guard wasn't in place it then notified the channel. 
https://github.com/AudiusProject/audius-protocol/commit/ddaa1b35950c92a2d3a15db1622a13a5e31137e5#diff-54af271ff4da22a5f60b60d1fb23345ff5b7e61d86e6812e516bf9108186468aR39-R97

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._
