### PR TITLE
[C-4364] Add search filters

### DIFF
--- a/.changeset/empty-apes-fetch.md
+++ b/.changeset/empty-apes-fetch.md
@@ -1,0 +1,5 @@
+---
+'@audius/harmony': minor
+---
+
+Add showFilterInput and popupMaxHeight to FilterButton

--- a/packages/common/src/audius-query/README.md
+++ b/packages/common/src/audius-query/README.md
@@ -13,6 +13,7 @@
   - [Pre-fetching related entities](#pre-fetching-related-entities)
     - [Cascading hooks](#cascading-hooks)
     - [Pre-fetching in endpoint implementations](#pre-fetching-in-endpoint-implementations)
+  - [Batching requests](#batching-requests)
   - [Query Hook options](#query-hook-options)
   - [Caching](#caching)
     - [Endpoint response caching](#endpoint-response-caching)

--- a/packages/harmony/src/components/button/FilterButton/FilterButton.tsx
+++ b/packages/harmony/src/components/button/FilterButton/FilterButton.tsx
@@ -6,9 +6,10 @@ import { BaseButton } from 'components/button/BaseButton/BaseButton'
 import { Flex, Paper } from 'components/layout'
 import { Popup } from 'components/popup'
 import { useControlled } from 'hooks/useControlled'
-import { IconCaretDown, IconCloseAlt } from 'icons'
+import { IconCaretDown, IconCloseAlt, IconSearch } from 'icons'
 
 import { FilterButtonOption, FilterButtonProps } from './types'
+import { TextInput, TextInputSize } from 'components/input'
 
 export const FilterButton = forwardRef<HTMLButtonElement, FilterButtonProps>(
   function FilterButton(props, ref) {
@@ -18,6 +19,7 @@ export const FilterButton = forwardRef<HTMLButtonElement, FilterButtonProps>(
       options,
       onSelect,
       disabled,
+      showFilterInput,
       variant = 'fillContainer',
       size = 'default',
       iconRight = IconCaretDown,
@@ -34,6 +36,7 @@ export const FilterButton = forwardRef<HTMLButtonElement, FilterButtonProps>(
       stateName: 'selection',
       componentName: 'FilterButton'
     })
+    const [filterInputValue, setFilterInputValue] = useState('')
     const selectedOption = options.find((option) => option.value === selection)
     const selectedLabel = selectedOption?.label ?? selectedOption?.value
 
@@ -144,6 +147,7 @@ export const FilterButton = forwardRef<HTMLButtonElement, FilterButtonProps>(
     }
 
     const handleButtonClick = useCallback(() => {
+      setFilterInputValue('')
       if (variant === 'fillContainer' && selection !== null) {
         setSelection(null)
         // @ts-ignore
@@ -200,21 +204,46 @@ export const FilterButton = forwardRef<HTMLButtonElement, FilterButtonProps>(
               aria-activedescendant={selectedLabel}
               css={{ maxHeight: popupMaxHeight, overflowY: 'auto' }}
             >
-              {options.map((option) => (
-                <BaseButton
-                  key={option.value}
-                  iconLeft={option.icon}
-                  styles={{
-                    button: optionCss,
-                    icon: optionIconCss
-                  }}
-                  onClick={() => handleOptionSelect(option)}
-                  aria-label={option.label ?? option.value}
-                  role='option'
-                >
-                  {option.label ?? option.value}
-                </BaseButton>
-              ))}
+              <Flex direction='column' w='100%' gap='s'>
+                {showFilterInput ? (
+                  <TextInput
+                    placeholder='Search'
+                    label='Search'
+                    size={TextInputSize.SMALL}
+                    startIcon={IconSearch}
+                    onClick={(e) => {
+                      e.stopPropagation()
+                    }}
+                    onChange={(e) => {
+                      setFilterInputValue(e.target.value)
+                    }}
+                  />
+                ) : null}
+                {options
+                  .filter(({ label }) => {
+                    return (
+                      !filterInputValue ||
+                      label
+                        ?.toLowerCase()
+                        .includes(filterInputValue.toLowerCase())
+                    )
+                  })
+                  .map((option) => (
+                    <BaseButton
+                      key={option.value}
+                      iconLeft={option.icon}
+                      styles={{
+                        button: optionCss,
+                        icon: optionIconCss
+                      }}
+                      onClick={() => handleOptionSelect(option)}
+                      aria-label={option.label ?? option.value}
+                      role='option'
+                    >
+                      {option.label ?? option.value}
+                    </BaseButton>
+                  ))}
+              </Flex>
             </Flex>
           </Paper>
         </Popup>

--- a/packages/harmony/src/components/button/FilterButton/FilterButton.tsx
+++ b/packages/harmony/src/components/button/FilterButton/FilterButton.tsx
@@ -20,6 +20,7 @@ export const FilterButton = forwardRef<HTMLButtonElement, FilterButtonProps>(
       onSelect,
       disabled,
       showFilterInput,
+      filterInputPlaceholder = 'Search',
       variant = 'fillContainer',
       size = 'default',
       iconRight = IconCaretDown,
@@ -207,8 +208,8 @@ export const FilterButton = forwardRef<HTMLButtonElement, FilterButtonProps>(
               <Flex direction='column' w='100%' gap='s'>
                 {showFilterInput ? (
                   <TextInput
-                    placeholder='Search'
-                    label='Search'
+                    placeholder={filterInputPlaceholder}
+                    label={filterInputPlaceholder}
                     size={TextInputSize.SMALL}
                     startIcon={IconSearch}
                     onClick={(e) => {

--- a/packages/harmony/src/components/button/FilterButton/FilterButton.tsx
+++ b/packages/harmony/src/components/button/FilterButton/FilterButton.tsx
@@ -3,7 +3,7 @@ import { forwardRef, RefObject, useRef, useState, useCallback } from 'react'
 import { CSSObject, useTheme } from '@emotion/react'
 
 import { BaseButton } from 'components/button/BaseButton/BaseButton'
-import { Box, Flex, Paper } from 'components/layout'
+import { Flex, Paper } from 'components/layout'
 import { Popup } from 'components/popup'
 import { useControlled } from 'hooks/useControlled'
 import { IconCaretDown, IconCloseAlt } from 'icons'
@@ -22,6 +22,7 @@ export const FilterButton = forwardRef<HTMLButtonElement, FilterButtonProps>(
       size = 'default',
       iconRight = IconCaretDown,
       popupAnchorOrigin,
+      popupMaxHeight,
       popupTransformOrigin,
       popupPortalLocation,
       popupZIndex
@@ -190,32 +191,31 @@ export const FilterButton = forwardRef<HTMLButtonElement, FilterButtonProps>(
           zIndex={popupZIndex}
         >
           <Paper mt='s' border='strong' shadow='far'>
-            <Box p='s'>
-              <Flex
-                direction='column'
-                alignItems='flex-start'
-                justifyContent='center'
-                role='listbox'
-                aria-label={selectedLabel ?? label ?? props['aria-label']}
-                aria-activedescendant={selectedLabel}
-              >
-                {options.map((option) => (
-                  <BaseButton
-                    key={option.value}
-                    iconLeft={option.icon}
-                    styles={{
-                      button: optionCss,
-                      icon: optionIconCss
-                    }}
-                    onClick={() => handleOptionSelect(option)}
-                    aria-label={option.label ?? option.value}
-                    role='option'
-                  >
-                    {option.label ?? option.value}
-                  </BaseButton>
-                ))}
-              </Flex>
-            </Box>
+            <Flex
+              p='s'
+              direction='column'
+              alignItems='flex-start'
+              role='listbox'
+              aria-label={selectedLabel ?? label ?? props['aria-label']}
+              aria-activedescendant={selectedLabel}
+              css={{ maxHeight: popupMaxHeight, overflowY: 'auto' }}
+            >
+              {options.map((option) => (
+                <BaseButton
+                  key={option.value}
+                  iconLeft={option.icon}
+                  styles={{
+                    button: optionCss,
+                    icon: optionIconCss
+                  }}
+                  onClick={() => handleOptionSelect(option)}
+                  aria-label={option.label ?? option.value}
+                  role='option'
+                >
+                  {option.label ?? option.value}
+                </BaseButton>
+              ))}
+            </Flex>
           </Paper>
         </Popup>
       </BaseButton>

--- a/packages/harmony/src/components/button/FilterButton/types.ts
+++ b/packages/harmony/src/components/button/FilterButton/types.ts
@@ -77,6 +77,11 @@ export type FilterButtonProps = {
   popupAnchorOrigin?: Origin
 
   /**
+   * Popup max height
+   */
+  popupMaxHeight?: number
+
+  /**
    * Popup transform origin
    * @default { horizontal: 'center', vertical: 'top' }
    */

--- a/packages/harmony/src/components/button/FilterButton/types.ts
+++ b/packages/harmony/src/components/button/FilterButton/types.ts
@@ -96,4 +96,9 @@ export type FilterButtonProps = {
    * zIndex applied to the inner Popup component
    */
   popupZIndex?: number
+
+  /**
+   * Show a text input to filter the options
+   */
+  showFilterInput?: boolean
 }

--- a/packages/harmony/src/components/button/FilterButton/types.ts
+++ b/packages/harmony/src/components/button/FilterButton/types.ts
@@ -101,4 +101,9 @@ export type FilterButtonProps = {
    * Show a text input to filter the options
    */
   showFilterInput?: boolean
+
+  /**
+   * Placeholder text for the filter input
+   */
+  filterInputPlaceholder?: string
 }

--- a/packages/web/src/pages/search-page-v2/RecentSearches.tsx
+++ b/packages/web/src/pages/search-page-v2/RecentSearches.tsx
@@ -211,7 +211,9 @@ const RecentSearchUser = (props: RecentSearchUserProps) => {
     >
       <Avatar userId={id} w={40} borderWidth='thin' />
       <Flex direction='column' alignItems='flex-start'>
-        <UserLink userId={user.user_id} variant='secondary' size='xs' />
+        <Text variant='body' size='s'>
+          <UserLink userId={user.user_id} size='s' badgeSize='xs' />
+        </Text>
         <Text variant='body' size='xs' color='subdued'>
           Profile
         </Text>

--- a/packages/web/src/pages/search-page-v2/SearchHeader.tsx
+++ b/packages/web/src/pages/search-page-v2/SearchHeader.tsx
@@ -1,0 +1,183 @@
+import { ChangeEvent, ReactNode, useCallback } from 'react'
+
+import { Maybe } from '@audius/common/utils'
+import {
+  FilterButton,
+  Flex,
+  IconAlbum,
+  IconNote,
+  IconPlaylists,
+  IconUser,
+  RadioGroup,
+  SelectablePill,
+  Text
+} from '@audius/harmony'
+import { capitalize } from 'lodash'
+
+import Header from 'components/header/desktop/Header'
+import { useMedia } from 'hooks/useMedia'
+import { Category, Filter } from './types'
+
+export const categories = {
+  all: { filters: [] },
+  profiles: { icon: IconUser, filters: ['genre', 'isVerified'] },
+  tracks: {
+    icon: IconNote,
+    filters: ['genre', 'mood', 'key', 'bpm', 'isPremium', 'hasDownloads']
+  },
+  albums: { icon: IconAlbum, filters: ['genre', 'mood'] },
+  playlists: { icon: IconPlaylists, filters: ['genre', 'mood'] }
+} satisfies Record<string, Category>
+
+export type CategoryKey = keyof typeof categories
+
+type SearchHeaderProps = {
+  category?: CategoryKey
+  setCategory: (category: CategoryKey) => void
+  title: string
+  query: Maybe<string>
+}
+
+const filters: Record<Filter, ReactNode> = {
+  genre: (
+    <FilterButton
+      label='Genre'
+      options={[
+        {
+          value: 'Filter'
+        }
+      ]}
+    />
+  ),
+  mood: (
+    <FilterButton
+      label='Mood'
+      options={[
+        {
+          value: 'Filter'
+        }
+      ]}
+    />
+  ),
+  key: (
+    <FilterButton
+      label='Key'
+      options={[
+        {
+          value: 'Filter'
+        }
+      ]}
+    />
+  ),
+  bpm: (
+    <FilterButton
+      label='BPM'
+      options={[
+        {
+          value: 'Filter'
+        }
+      ]}
+    />
+  ),
+  isPremium: (
+    <FilterButton
+      label='Premium'
+      options={[
+        {
+          value: 'Filter'
+        }
+      ]}
+    />
+  ),
+  hasDownloads: (
+    <FilterButton
+      label='Downloads Available'
+      options={[
+        {
+          value: 'Filter'
+        }
+      ]}
+    />
+  ),
+  isVerified: (
+    <FilterButton
+      label='Verified'
+      options={[
+        {
+          value: 'Filter'
+        }
+      ]}
+    />
+  )
+}
+
+export const SearchHeader = (props: SearchHeaderProps) => {
+  const { category: categoryKey = 'all', setCategory, query, title } = props
+
+  const { isMobile } = useMedia()
+
+  const handleChange = useCallback(
+    (e: ChangeEvent<HTMLInputElement>) => {
+      const value = e.target.value
+      setCategory(value as CategoryKey)
+    },
+    [setCategory]
+  )
+
+  const filterKeys = categories[categoryKey].filters
+
+  const categoryRadioGroup = (
+    <RadioGroup
+      direction='row'
+      gap='s'
+      aria-label={'Select search category'}
+      name='searchcategory'
+      value={categoryKey}
+      onChange={handleChange}
+    >
+      {Object.entries(categories)
+        .filter(([key]) => !isMobile || key !== 'all')
+        .map(([key, category]) => (
+          <SelectablePill
+            aria-label={`${key} search category`}
+            icon={(category as Category).icon}
+            key={key}
+            label={capitalize(key)}
+            size='large'
+            type='radio'
+            value={key}
+            checked={key === categoryKey}
+          />
+        ))}
+    </RadioGroup>
+  )
+
+  return isMobile ? (
+    <Flex p='s' css={{ overflow: 'scroll' }}>
+      {categoryRadioGroup}
+    </Flex>
+  ) : (
+    <Header
+      {...props}
+      primary={title}
+      secondary={
+        query ? (
+          <Flex ml='l'>
+            <Text variant='heading' strength='weak'>
+              &#8220;{query}&#8221;
+            </Text>
+          </Flex>
+        ) : null
+      }
+      bottomBar={
+        <Flex direction='row' gap='s' mv='m'>
+          {filterKeys.map((filterKey) => (
+            <div key={filterKey}>{filters[filterKey]}</div>
+          ))}
+        </Flex>
+      }
+      rightDecorator={categoryRadioGroup}
+      variant='main'
+    />
+  )
+}

--- a/packages/web/src/pages/search-page-v2/SearchHeader.tsx
+++ b/packages/web/src/pages/search-page-v2/SearchHeader.tsx
@@ -23,7 +23,6 @@ import { capitalize } from 'lodash'
 import Header from 'components/header/desktop/Header'
 import { useMedia } from 'hooks/useMedia'
 import { Category, Filter } from './types'
-import { useParams } from 'react-router-dom'
 import { useSearchParams } from 'react-router-dom-v5-compat'
 
 export const categories = {
@@ -69,6 +68,7 @@ const filters: Record<Filter, () => ReactElement> = {
           label: genre,
           value: convertGenreLabelToValue(genre)
         }))}
+        showFilterInput
       />
     )
   },

--- a/packages/web/src/pages/search-page-v2/SearchHeader.tsx
+++ b/packages/web/src/pages/search-page-v2/SearchHeader.tsx
@@ -1,6 +1,12 @@
-import { ChangeEvent, ReactNode, useCallback } from 'react'
+import {
+  ChangeEvent,
+  Component,
+  ReactElement,
+  ReactNode,
+  useCallback
+} from 'react'
 
-import { Maybe } from '@audius/common/utils'
+import { GENRES, Maybe, convertGenreLabelToValue } from '@audius/common/utils'
 import {
   FilterButton,
   Flex,
@@ -17,6 +23,8 @@ import { capitalize } from 'lodash'
 import Header from 'components/header/desktop/Header'
 import { useMedia } from 'hooks/useMedia'
 import { Category, Filter } from './types'
+import { useParams } from 'react-router-dom'
+import { useSearchParams } from 'react-router-dom-v5-compat'
 
 export const categories = {
   all: { filters: [] },
@@ -38,18 +46,33 @@ type SearchHeaderProps = {
   query: Maybe<string>
 }
 
-const filters: Record<Filter, ReactNode> = {
-  genre: (
-    <FilterButton
-      label='Genre'
-      options={[
-        {
-          value: 'Filter'
-        }
-      ]}
-    />
-  ),
-  mood: (
+const filters: Record<Filter, () => ReactElement> = {
+  genre: () => {
+    const [urlSearchParams, setUrlSearchParams] = useSearchParams()
+    const genre = urlSearchParams.get('genre')
+
+    return (
+      <FilterButton
+        label='Genre'
+        popupAnchorOrigin={{ vertical: 'bottom', horizontal: 'left' }}
+        popupMaxHeight={300}
+        popupTransformOrigin={{ vertical: 'top', horizontal: 'left' }}
+        selection={genre}
+        onSelect={(value) => {
+          if (value) {
+            setUrlSearchParams((params) => ({ ...params, genre: value }))
+          } else {
+            setUrlSearchParams(({ genre, ...params }: any) => params)
+          }
+        }}
+        options={GENRES.map((genre) => ({
+          label: genre,
+          value: convertGenreLabelToValue(genre)
+        }))}
+      />
+    )
+  },
+  mood: () => (
     <FilterButton
       label='Mood'
       options={[
@@ -59,7 +82,7 @@ const filters: Record<Filter, ReactNode> = {
       ]}
     />
   ),
-  key: (
+  key: () => (
     <FilterButton
       label='Key'
       options={[
@@ -69,7 +92,7 @@ const filters: Record<Filter, ReactNode> = {
       ]}
     />
   ),
-  bpm: (
+  bpm: () => (
     <FilterButton
       label='BPM'
       options={[
@@ -79,7 +102,7 @@ const filters: Record<Filter, ReactNode> = {
       ]}
     />
   ),
-  isPremium: (
+  isPremium: () => (
     <FilterButton
       label='Premium'
       options={[
@@ -89,7 +112,7 @@ const filters: Record<Filter, ReactNode> = {
       ]}
     />
   ),
-  hasDownloads: (
+  hasDownloads: () => (
     <FilterButton
       label='Downloads Available'
       options={[
@@ -99,7 +122,7 @@ const filters: Record<Filter, ReactNode> = {
       ]}
     />
   ),
-  isVerified: (
+  isVerified: () => (
     <FilterButton
       label='Verified'
       options={[
@@ -171,9 +194,10 @@ export const SearchHeader = (props: SearchHeaderProps) => {
       }
       bottomBar={
         <Flex direction='row' gap='s' mv='m'>
-          {filterKeys.map((filterKey) => (
-            <div key={filterKey}>{filters[filterKey]}</div>
-          ))}
+          {filterKeys.map((filterKey) => {
+            const FilterComponent = filters[filterKey]
+            return <FilterComponent key={filterKey}>{}</FilterComponent>
+          })}
         </Flex>
       }
       rightDecorator={categoryRadioGroup}

--- a/packages/web/src/pages/search-page-v2/SearchHeader.tsx
+++ b/packages/web/src/pages/search-page-v2/SearchHeader.tsx
@@ -54,7 +54,7 @@ const filters: Record<Filter, () => ReactElement> = {
       <FilterButton
         label='Genre'
         popupAnchorOrigin={{ vertical: 'bottom', horizontal: 'left' }}
-        popupMaxHeight={300}
+        popupMaxHeight={400}
         popupTransformOrigin={{ vertical: 'top', horizontal: 'left' }}
         selection={genre}
         onSelect={(value) => {
@@ -69,6 +69,7 @@ const filters: Record<Filter, () => ReactElement> = {
           value: convertGenreLabelToValue(genre)
         }))}
         showFilterInput
+        filterInputPlaceholder='Search genre'
       />
     )
   },

--- a/packages/web/src/pages/search-page-v2/SearchPageV2.tsx
+++ b/packages/web/src/pages/search-page-v2/SearchPageV2.tsx
@@ -3,6 +3,7 @@ import { ChangeEvent, useCallback, useContext, useEffect } from 'react'
 import { Status } from '@audius/common/models'
 import { Maybe } from '@audius/common/utils'
 import {
+  FilterButton,
   Flex,
   IconAlbum,
   IconComponent,
@@ -30,102 +31,8 @@ import { useMedia } from 'hooks/useMedia'
 
 import { RecentSearches } from './RecentSearches'
 import { SearchCatalogTile } from './SearchCatalogTile'
-
-type Filter =
-  | 'genre'
-  | 'mood'
-  | 'key'
-  | 'bpm'
-  | 'isPremium'
-  | 'hasDownloads'
-  | 'isVerified'
-
-type Category = {
-  filters: Filter[]
-  icon?: IconComponent
-}
-
-const categories = {
-  all: { filters: [] },
-  profiles: { icon: IconUser, filters: ['genre', 'isVerified'] },
-  tracks: {
-    icon: IconNote,
-    filters: ['genre', 'mood', 'key', 'bpm', 'isPremium', 'hasDownloads']
-  },
-  albums: { icon: IconAlbum, filters: ['genre', 'mood'] },
-  playlists: { icon: IconPlaylists, filters: ['genre', 'mood'] }
-} satisfies Record<string, Category>
-
-type CategoryKey = keyof typeof categories
-
-type SearchHeaderProps = {
-  category?: CategoryKey
-  setCategory: (category: CategoryKey) => void
-  title: string
-  query: Maybe<string>
-}
-
-const SearchHeader = (props: SearchHeaderProps) => {
-  const { category: categoryKey = 'all', setCategory, query, title } = props
-
-  const { isMobile } = useMedia()
-
-  const handleChange = useCallback(
-    (e: ChangeEvent<HTMLInputElement>) => {
-      const value = e.target.value
-      setCategory(value as CategoryKey)
-    },
-    [setCategory]
-  )
-
-  const categoryRadioGroup = (
-    <RadioGroup
-      direction='row'
-      gap='s'
-      aria-label={'Select search category'}
-      name='searchcategory'
-      value={categoryKey}
-      onChange={handleChange}
-    >
-      {Object.entries(categories)
-        .filter(([key]) => !isMobile || key !== 'all')
-        .map(([key, category]) => (
-          <SelectablePill
-            aria-label={`${key} search category`}
-            icon={(category as Category).icon}
-            key={key}
-            label={capitalize(key)}
-            size='large'
-            type='radio'
-            value={key}
-            checked={key === categoryKey}
-          />
-        ))}
-    </RadioGroup>
-  )
-
-  return isMobile ? (
-    <Flex p='s' css={{ overflow: 'scroll' }}>
-      {categoryRadioGroup}
-    </Flex>
-  ) : (
-    <Header
-      {...props}
-      primary={title}
-      secondary={
-        query ? (
-          <Flex ml='l'>
-            <Text variant='heading' strength='weak'>
-              &#8220;{query}&#8221;
-            </Text>
-          </Flex>
-        ) : null
-      }
-      rightDecorator={categoryRadioGroup}
-      variant='main'
-    />
-  )
-}
+import { Category } from './types'
+import { CategoryKey, SearchHeader } from './SearchHeader'
 
 export const SearchPageV2 = () => {
   const { isMobile } = useMedia()

--- a/packages/web/src/pages/search-page-v2/types.ts
+++ b/packages/web/src/pages/search-page-v2/types.ts
@@ -1,0 +1,15 @@
+import { IconComponent } from '@audius/harmony'
+
+export type Filter =
+  | 'genre'
+  | 'mood'
+  | 'key'
+  | 'bpm'
+  | 'isPremium'
+  | 'hasDownloads'
+  | 'isVerified'
+
+export type Category = {
+  filters: Filter[]
+  icon?: IconComponent
+}


### PR DESCRIPTION
### Description

* Add filter scaffolding for each category
* Populate the genre filter
* Add filter input to FilterButton

I ended up going with the `categories` config object after all because it was already kind of wired into the ui and seemed easier to stick with the pattern than rip it out. We can revisit though for sure!

<img width="912" alt="image" src="https://github.com/AudiusProject/audius-protocol/assets/19916043/7060eea7-3362-4937-8b93-45124cac2674">


### How Has This Been Tested?

Locally
