### PR TITLE
QA-1347: filter query result response formatter on only users that were found

### DIFF
--- a/packages/discovery-provider/src/queries/get_support_for_user.py
+++ b/packages/discovery-provider/src/queries/get_support_for_user.py
@@ -24,11 +24,15 @@ def query_result_to_support_response(
         {
             "rank": row[0],
             "amount": row[1].amount,
-            "user": users[
-                row[1].sender_user_id if user_is_sender else row[1].receiver_user_id
-            ],
+            "user": users[user_id],
         }
         for row in results
+        if (
+            user_id := (
+                row[1].sender_user_id if user_is_sender else row[1].receiver_user_id
+            )
+        )
+        in users
     ]
 
 
@@ -234,6 +238,6 @@ def get_support_sent_by_user(args) -> List[SupportResponse]:
         rows: List[Tuple[int, AggregateUserTip]] = query.all()
         user_ids = [row[1].receiver_user_id for row in rows]
         users = get_users_by_id(session, user_ids, current_user_id)
-
+        print(f"TEST users {users}")
         support = query_result_to_support_response(rows, users, user_is_sender=False)
     return support

--- a/packages/discovery-provider/src/queries/get_support_for_user.py
+++ b/packages/discovery-provider/src/queries/get_support_for_user.py
@@ -238,6 +238,6 @@ def get_support_sent_by_user(args) -> List[SupportResponse]:
         rows: List[Tuple[int, AggregateUserTip]] = query.all()
         user_ids = [row[1].receiver_user_id for row in rows]
         users = get_users_by_id(session, user_ids, current_user_id)
-        print(f"TEST users {users}")
+
         support = query_result_to_support_response(rows, users, user_is_sender=False)
     return support


### PR DESCRIPTION
### Description
This is probably a two parter. This PR filters the response formatter to not include users that don't exist (or have a handle). This will fix the rendering error and the endpoint that Reed and Randy discovered.

Second part would be to migrate bad user ids in the aggregate user tips table to their good ones and fix whatever indexing step is putting these in there.

### How Has This Been Tested?
Running on sandbox.
https://alec.sandbox.audius.co/v1/full/users/lzl4w/supporting?limit=500&offset=0&app_name=audius-client