### PR TITLE
[PAY-3071][PAY-3072] Fix track listing in manager mode

### DIFF
--- a/packages/discovery-provider/src/api/v1/access_helpers.py
+++ b/packages/discovery-provider/src/api/v1/access_helpers.py
@@ -2,38 +2,9 @@ import logging
 
 from flask_restx.errors import abort
 
-from src.queries.get_managed_users import (
-    GetUserManagersArgs,
-    get_user_managers_with_grants,
-)
+from src.queries.get_managed_users import is_active_manager
 
 logger = logging.getLogger(__name__)
-
-
-def is_active_manager(user_id: int, manager_id: int) -> bool:
-    """
-    Check if a manager is active for a given user.
-
-    Args:
-        user_id (int): The ID of the user.
-        manager_id (int): The ID of the manager.
-
-    Returns:
-        bool: True if the manager is active for the user, False otherwise.
-    """
-    try:
-        grants = get_user_managers_with_grants(
-            GetUserManagersArgs(user_id=user_id, is_approved=True, is_revoked=False)
-        )
-        for grant in grants:
-            manager = grant.get("manager")
-            if manager and manager.get("user_id") == manager_id:
-                return True
-    except Exception as e:
-        logger.error(
-            f"access_helpers.py | Unexpected exception checking managers for user: {e}"
-        )
-    return False
 
 
 def check_authorized(user_id, authed_user_id):

--- a/packages/discovery-provider/src/queries/get_managed_users.py
+++ b/packages/discovery-provider/src/queries/get_managed_users.py
@@ -156,3 +156,29 @@ def get_managed_users_with_grants(args: GetManagedUsersArgs) -> List[Dict]:
         grants = query_result_to_list(grants)
 
         return make_managed_users_list(users, grants)
+
+
+def is_active_manager(user_id: int, manager_id: int) -> bool:
+    """
+    Check if a manager is active for a given user.
+
+    Args:
+        user_id (int): The ID of the user.
+        manager_id (int): The ID of the manager.
+
+    Returns:
+        bool: True if the manager is active for the user, False otherwise.
+    """
+    try:
+        grants = get_user_managers_with_grants(
+            GetUserManagersArgs(user_id=user_id, is_approved=True, is_revoked=False)
+        )
+        for grant in grants:
+            manager = grant.get("manager")
+            if manager and manager.get("user_id") == manager_id:
+                return True
+    except Exception as e:
+        logger.error(
+            f"get_managed_users.py | Unexpected exception checking managers for user: {e}"
+        )
+    return False


### PR DESCRIPTION
### Description
This updates the `get_tracks` query to include unlisted tracks when `current_user_id == user_id` and the current authenticated user is either the owner or an active manager of the owner.

fixes PAY-3071
fixes PAY-3072

### How Has This Been Tested?
Updated integration tests to verify correct behavior.
