### PR TITLE
[PAY-3090] Add priority fees to SDK transactions (opt in)

### DIFF
--- a/packages/libs/src/sdk/services/Solana/programs/BaseSolanaProgramClient.ts
+++ b/packages/libs/src/sdk/services/Solana/programs/BaseSolanaProgramClient.ts
@@ -6,6 +6,7 @@ import {
   TransactionMessage,
   VersionedTransaction
 } from '@solana/web3.js'
+import { z } from 'zod'
 
 import { parseParams } from '../../../utils/parseParams'
 import type { SolanaWalletAdapter } from '../types'
@@ -13,11 +14,24 @@ import type { SolanaWalletAdapter } from '../types'
 import {
   BuildTransactionRequest,
   BuildTransactionSchema,
+  PrioritySchema,
   type BaseSolanaProgramConfigInternal
 } from './types'
 
 const isPublicKeyArray = (arr: any[]): arr is PublicKey[] =>
   arr.every((a) => a instanceof PublicKey)
+
+const priorityToPercentileMap: Record<
+  z.infer<typeof PrioritySchema>,
+  number
+> = {
+  MIN: 0,
+  LOW: 25,
+  MEDIUM: 50,
+  HIGH: 75,
+  VERY_HIGH: 95,
+  UNSAFE_MAX: 100
+}
 
 /**
  * Abstract class for initializing individual program clients.
@@ -92,7 +106,7 @@ export class BaseSolanaProgramClient {
       feePayer,
       recentBlockhash,
       addressLookupTables = [],
-      priorityPercentile
+      priorityFee
     } = await parseParams('buildTransaction', BuildTransactionSchema)(params)
 
     if (!recentBlockhash) {
@@ -100,17 +114,29 @@ export class BaseSolanaProgramClient {
       recentBlockhash = res.blockhash
     }
 
-    if (priorityPercentile) {
-      const res = await this.connection.getRecentPrioritizationFees()
-      const orderedFees = res.map((r) => r.prioritizationFee).sort()
-      const priorityFee =
-        orderedFees[Math.round(priorityPercentile * orderedFees.length)]
-      if (priorityFee) {
+    if (priorityFee !== undefined) {
+      if ('microLamports' in priorityFee) {
         instructions.push(
           ComputeBudgetProgram.setComputeUnitPrice({
-            microLamports: priorityFee
+            microLamports: priorityFee.microLamports
           })
         )
+      } else {
+        const res = await this.connection.getRecentPrioritizationFees()
+        const orderedFees = res.map((r) => r.prioritizationFee).sort()
+        const percentile =
+          'percentile' in priorityFee
+            ? priorityFee.percentile
+            : priorityToPercentileMap[priorityFee.priority]
+        const microLamports =
+          orderedFees[Math.round((percentile / 100.0) * orderedFees.length)]
+        if (microLamports !== undefined) {
+          instructions.push(
+            ComputeBudgetProgram.setComputeUnitPrice({
+              microLamports
+            })
+          )
+        }
       }
     }
 

--- a/packages/libs/src/sdk/services/Solana/programs/BaseSolanaProgramClient.ts
+++ b/packages/libs/src/sdk/services/Solana/programs/BaseSolanaProgramClient.ts
@@ -114,7 +114,7 @@ export class BaseSolanaProgramClient {
       recentBlockhash = res.blockhash
     }
 
-    if (priorityFee !== undefined) {
+    if (priorityFee) {
       if ('microLamports' in priorityFee) {
         instructions.push(
           ComputeBudgetProgram.setComputeUnitPrice({

--- a/packages/libs/src/sdk/services/Solana/programs/BaseSolanaProgramClient.ts
+++ b/packages/libs/src/sdk/services/Solana/programs/BaseSolanaProgramClient.ts
@@ -129,7 +129,12 @@ export class BaseSolanaProgramClient {
             ? priorityFee.percentile
             : priorityToPercentileMap[priorityFee.priority]
         const microLamports =
-          orderedFees[Math.round((percentile / 100.0) * orderedFees.length)]
+          orderedFees[
+            Math.max(
+              Math.round((percentile / 100.0) * orderedFees.length - 1),
+              0
+            )
+          ]
         if (microLamports !== undefined) {
           instructions.push(
             ComputeBudgetProgram.setComputeUnitPrice({

--- a/packages/libs/src/sdk/services/Solana/programs/types.ts
+++ b/packages/libs/src/sdk/services/Solana/programs/types.ts
@@ -14,6 +14,15 @@ export type BaseSolanaProgramConfigInternal = {
   rpcConfig?: ConnectionConfig
 }
 
+export const PrioritySchema = z.enum([
+  'MIN',
+  'LOW',
+  'MEDIUM',
+  'HIGH',
+  'VERY_HIGH',
+  'UNSAFE_MAX'
+])
+
 export const BuildTransactionSchema = z
   .object({
     instructions: z
@@ -40,7 +49,19 @@ export const BuildTransactionSchema = z
           .default([])
       ])
       .optional(),
-    priorityPercentile: z.number().min(0).max(100).optional()
+    priorityFee: z
+      .union([
+        z.object({
+          microLamports: z.number()
+        }),
+        z.object({
+          percentile: z.number().min(0).max(100)
+        }),
+        z.object({
+          priority: PrioritySchema
+        })
+      ])
+      .optional()
   })
   .strict()
 

--- a/packages/libs/src/sdk/services/Solana/programs/types.ts
+++ b/packages/libs/src/sdk/services/Solana/programs/types.ts
@@ -39,7 +39,8 @@ export const BuildTransactionSchema = z
           )
           .default([])
       ])
-      .optional()
+      .optional(),
+    priorityPercentile: z.number().min(0).max(100).optional()
   })
   .strict()
 


### PR DESCRIPTION
### Description

Allows callers to specify the priority of their transaction, as a percentile of recent fees.

Modeled based on https://docs.helius.dev/solana-rpc-nodes/priority-fee-api

### How Has This Been Tested?

TBD