### PR TITLE
[QA-1169] Fix mobile text-link finalized state

### DIFF
--- a/packages/mobile/src/harmony-native/components/TextLink/TextLink.tsx
+++ b/packages/mobile/src/harmony-native/components/TextLink/TextLink.tsx
@@ -64,9 +64,13 @@ export const TextLink = <ParamList extends ReactNavigation.RootParamList>(
     active: color.primary.primary
   }
 
-  const tap = Gesture.Tap().onBegin(() => {
-    pressed.value = withTiming(1, motion.press)
-  })
+  const tap = Gesture.Tap()
+    .onBegin(() => {
+      pressed.value = withTiming(1, motion.press)
+    })
+    .onFinalize(() => {
+      pressed.value = withTiming(0, motion.press)
+    })
 
   const animatedLinkStyles = useAnimatedStyle(() => ({
     color: interpolateColor(


### PR DESCRIPTION
### Description

Fixes issue where links were not resetting back to default color after "finalizing" ie pressOut/cancel, leading to issues where links would stay active unexpectedly