### PR TITLE
[QA-1287] Fix multiple popovers on tracks table

### DIFF
--- a/packages/web/src/components/menu/Menu.tsx
+++ b/packages/web/src/components/menu/Menu.tsx
@@ -20,12 +20,10 @@ export type MenuType = MenuOptionType['type']
 export type MenuProps = {
   children: PopupMenuProps['renderTrigger']
   menu: MenuOptionType
-  onClose?: () => void
-  zIndex?: number
-}
+} & Omit<PopupMenuProps, 'renderTrigger' | 'items'>
 
 const Menu = forwardRef<HTMLDivElement, MenuProps>((props, ref) => {
-  const { menu, onClose, zIndex } = props
+  const { menu, onClose, zIndex, children, ...other } = props
 
   const { mainContentRef } = useContext(MainContentContext)
 
@@ -35,9 +33,10 @@ const Menu = forwardRef<HTMLDivElement, MenuProps>((props, ref) => {
       onClose={onClose}
       anchorOrigin={{ vertical: 'bottom', horizontal: 'right' }}
       ref={ref}
-      renderTrigger={props.children}
+      renderTrigger={children}
       zIndex={zIndex}
       containerRef={mainContentRef}
+      {...other}
     />
   )
 
@@ -45,7 +44,7 @@ const Menu = forwardRef<HTMLDivElement, MenuProps>((props, ref) => {
     return <UserMenu {...menu}>{renderMenu}</UserMenu>
   } else if (menu.type === 'album' || menu.type === 'playlist') {
     return (
-      <CollectionMenu onClose={props.onClose} {...menu}>
+      <CollectionMenu onClose={onClose} {...menu}>
         {renderMenu}
       </CollectionMenu>
     )

--- a/packages/web/src/components/table/components/OverflowMenuButton.tsx
+++ b/packages/web/src/components/table/components/OverflowMenuButton.tsx
@@ -56,7 +56,7 @@ export const OverflowMenuButton = (props: OverflowMenuButtonProps) => {
 
   return (
     <div onClick={onClick} className={cn(styles.tableOptionsButton, className)}>
-      <Menu menu={overflowMenu}>
+      <Menu menu={overflowMenu} dismissOnMouseLeave>
         {(ref, triggerPopup) => (
           <div
             className={tabStyles.iconKebabHorizontalWrapper}


### PR DESCRIPTION
### Description

Fixes issue where multiple popovers can appear on tracks table because clicking another popover overflow menu does not dismiss any active ones because of a `stopPropogation` which is needed to prevent the track from playing. The solution here is to dismiss the popup on mouse leave, which is actually much nicer