### PR TITLE
correct default discovery listens behavior

### DIFF
--- a/mediorum/main.go
+++ b/mediorum/main.go
@@ -448,5 +448,9 @@ func refreshPeersAndSigners(ss *server.MediorumServer, g registrar.PeerProvider)
 }
 
 func discoveryListensEndpoints() []string {
-	return strings.Split(os.Getenv("discoveryListensEndpoints"), ",")
+	endpoints := os.Getenv("discoveryListensEndpoints")
+	if endpoints == "" {
+		return []string{}
+	}
+	return strings.Split(endpoints, ",")
 }


### PR DESCRIPTION
### Description
go will default this to an empty array with a single empty string element

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._
