### PR TITLE
[PAY-3085] Move payout wallet radio input to labeled

### DIFF
--- a/packages/web/src/components/payout-wallet-modal/PayoutWalletModal.tsx
+++ b/packages/web/src/components/payout-wallet-modal/PayoutWalletModal.tsx
@@ -99,7 +99,12 @@ const PayoutWalletModalForm = ({
           </Text>
           <RadioGroup {...optionField}>
             <Flex gap='l' direction='column'>
-              <Flex gap='m' alignItems='center'>
+              <Flex
+                gap='m'
+                alignItems='center'
+                as='label'
+                css={{ cursor: 'pointer' }}
+              >
                 <Radio value='default' />
                 <Text variant='body' color='default' size='m'>
                   {messages.optionBuiltIn}
@@ -123,7 +128,12 @@ const PayoutWalletModalForm = ({
                 </Flex>
               ) : null}
               <Divider color='default' />
-              <Flex gap='m' alignItems='center'>
+              <Flex
+                gap='m'
+                alignItems='center'
+                as='label'
+                css={{ cursor: 'pointer' }}
+              >
                 <Radio value='custom' />
                 <Text variant='body' color='default' size='m'>
                   {messages.optionCustom}


### PR DESCRIPTION
### Description

This works to get the text to be clickable and seems to be a pattern we use elsewhere.

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._

`npm run web:stage`