### PR TITLE
[C-4361] Add grid and list layouts for new search track view

### DIFF
--- a/packages/web/src/components/lineup/LineupProvider.tsx
+++ b/packages/web/src/components/lineup/LineupProvider.tsx
@@ -195,6 +195,8 @@ export interface LineupProviderProps {
   buffering: boolean
   ordered?: boolean
   lineupContainerStyles?: string
+  tileContainerStyles?: string
+  tileStyles?: string
   setInView?: (inView: boolean) => void
   playingSource: string | null
   emptyElement?: JSX.Element
@@ -486,6 +488,8 @@ class LineupProvider extends PureComponent<CombinedProps, LineupProviderState> {
       extraPrecedingElement,
       endOfLineup,
       lineupContainerStyles,
+      tileContainerStyles,
+      tileStyles,
       showLeadingElementArtistPick = true,
       lineup: { isMetadataLoading, page, entries = [] },
       numPlaylistSkeletonRows,
@@ -780,6 +784,9 @@ class LineupProvider extends PureComponent<CombinedProps, LineupProviderState> {
             <InfiniteScroll
               aria-label={this.props['aria-label']}
               pageStart={0}
+              className={cn({
+                [tileContainerStyles!]: !!tileContainerStyles
+              })}
               loadMore={lineup.hasMore ? this.loadMore : () => {}}
               hasMore={lineup.hasMore && canLoadMore}
               // If we're on mobile, we scroll the entire page so we should use the window
@@ -792,7 +799,9 @@ class LineupProvider extends PureComponent<CombinedProps, LineupProviderState> {
             >
               {showFeedTipTile ? <FeedTipTile /> : null}
               {tiles.map((tile, index) => (
-                <li key={index}>{tile}</li>
+                <li key={index} className={cn({ [tileStyles!]: !!tileStyles })}>
+                  {tile}
+                </li>
               ))}
             </InfiniteScroll>
           )}

--- a/packages/web/src/components/payout-wallet-modal/PayoutWalletModal.tsx
+++ b/packages/web/src/components/payout-wallet-modal/PayoutWalletModal.tsx
@@ -292,9 +292,9 @@ export const PayoutWalletModal = () => {
 
   const initialValues: PayoutWalletValues = user?.spl_usdc_payout_wallet
     ? {
-      option: 'custom',
-      address: payoutWallet ?? ''
-    }
+        option: 'custom',
+        address: payoutWallet ?? ''
+      }
     : { option: 'default' }
 
   return (


### PR DESCRIPTION
### Description
Small updates to add a grid and list layout for the track tiles that defaults to the grid layout when viewing all search results

### How Has This Been Tested?
Manually Tested
