### PR TITLE
Add test to ensure updating playlist_id fails

### DIFF
--- a/packages/discovery-provider/integration_tests/tasks/entity_manager/test_playlist_entity_manager.py
+++ b/packages/discovery-provider/integration_tests/tasks/entity_manager/test_playlist_entity_manager.py
@@ -720,11 +720,15 @@ def test_index_invalid_playlists(app, mocker):
         "CreatePlaylistInvalidTracks": {
             "playlist_contents": {"track_ids": [{"track": 1}]}
         },
+        "UpdatePlaylistInvalidPlaylistId": {"playlist_id": 1234},
     }
     private_metadata = json.dumps(test_metadata["UpdatePlaylistInvalidPrivate"])
     album_metadata = json.dumps(test_metadata["UpdatePlaylistInvalidAlbum"])
     invalid_release_date_metadata = json.dumps(
         test_metadata["UpdatePlaylistInvalidReleaseDate"]
+    )
+    invalid_playlist_id_metadata = json.dumps(
+        test_metadata["UpdatePlaylistInvalidPlaylistId"]
     )
     playlist_metadata = json.dumps(test_metadata["CreatePlaylistInvalidTracks"])
 
@@ -923,6 +927,20 @@ def test_index_invalid_playlists(app, mocker):
                         "_userId": 1,
                         "_action": "Update",
                         "_metadata": f'{{"cid": "UpdatePlaylistInvalidReleaseDate", "data": {invalid_release_date_metadata}}}',
+                        "_signer": "user1wallet",
+                    }
+                )
+            },
+        ],
+        "UpdatePlaylistInvalidPlaylistId": [
+            {
+                "args": AttributeDict(
+                    {
+                        "_entityId": PLAYLIST_ID_OFFSET,
+                        "_entityType": "Playlist",
+                        "_userId": 1,
+                        "_action": "Update",
+                        "_metadata": f'{{"cid": "UpdatePlaylistInvalidPlaylistId", "data": {invalid_playlist_id_metadata}}}',
                         "_signer": "user1wallet",
                     }
                 )


### PR DESCRIPTION
### Description
Add a test to ensure `playlist_id` is immutable and cannot be changed at the protocol level.

We have a similar test for `track_id` [here](https://github.com/AudiusProject/audius-protocol/blob/6a9274775f2d99932306cdff835e1473c2e40ad5/packages/discovery-provider/integration_tests/tasks/entity_manager/test_track_entity_manager.py#L670).

### How Has This Been Tested?

Test passes locally
