### PR TITLE
add key + bpm fields to discovery track metadata

### DIFF
--- a/packages/common/src/models/Track.ts
+++ b/packages/common/src/models/Track.ts
@@ -237,6 +237,8 @@ export type TrackMetadata = {
   copyright_line?: Copyright | null
   producer_copyright_line?: Copyright | null
   parental_warning_type?: string | null
+  bpm?: number | null
+  musical_key?: string | null
 
   // Optional Fields
   is_playlist_upload?: boolean

--- a/packages/common/src/models/Track.ts
+++ b/packages/common/src/models/Track.ts
@@ -239,6 +239,7 @@ export type TrackMetadata = {
   parental_warning_type?: string | null
   bpm?: number | null
   musical_key?: string | null
+  audio_analysis_error_count?: number
 
   // Optional Fields
   is_playlist_upload?: boolean

--- a/packages/common/src/schemas/metadata.ts
+++ b/packages/common/src/schemas/metadata.ts
@@ -62,7 +62,9 @@ const trackMetadataSchema = {
   copyright_line: null,
   producer_copyright_line: null,
   parental_warning_type: null,
-  allowed_api_keys: null
+  allowed_api_keys: null,
+  bpm: null,
+  musical_key: null,
 }
 
 export const newTrackMetadata = (fields, validate = false): TrackMetadata => {

--- a/packages/common/src/schemas/metadata.ts
+++ b/packages/common/src/schemas/metadata.ts
@@ -65,6 +65,7 @@ const trackMetadataSchema = {
   allowed_api_keys: null,
   bpm: null,
   musical_key: null,
+  audio_analysis_error_count: 0
 }
 
 export const newTrackMetadata = (fields, validate = false): TrackMetadata => {

--- a/packages/common/src/schemas/upload/uploadFormSchema.ts
+++ b/packages/common/src/schemas/upload/uploadFormSchema.ts
@@ -191,7 +191,9 @@ const createSdkSchema = () =>
       rightsController: z.optional(DDEXRightsController).nullable(),
       copyrightLine: z.optional(DDEXCopyright.nullable()),
       producerCopyrightLine: z.optional(DDEXCopyright.nullable()),
-      parentalWarningType: z.optional(z.string().nullable())
+      parentalWarningType: z.optional(z.string().nullable()),
+      bpm: z.optional(z.number().nullable()),
+      musicalKey: z.optional(z.string().nullable())
     })
     .merge(premiumMetadataSchema)
     .merge(hiddenMetadataSchema)

--- a/packages/discovery-provider/ddl/migrations/0077_add_audio_analysis_columns.sql
+++ b/packages/discovery-provider/ddl/migrations/0077_add_audio_analysis_columns.sql
@@ -1,0 +1,7 @@
+begin;
+
+alter table tracks
+add column if not exists bpm float;
+add column if not exists musical_key character varying,
+
+commit;

--- a/packages/discovery-provider/ddl/migrations/0077_add_audio_analysis_columns.sql
+++ b/packages/discovery-provider/ddl/migrations/0077_add_audio_analysis_columns.sql
@@ -1,7 +1,9 @@
 begin;
 
-alter table tracks
-add column if not exists bpm float;
-add column if not exists musical_key character varying,
+alter table tracks add column if not exists bpm float; 
+alter table tracks add column if not exists musical_key character varying;
+alter table tracks add column if not exists audio_analysis_error_count integer not null default 0;
+
+update tracks set audio_analysis_error_count = 0 where audio_analysis_error_count is null;
 
 commit;

--- a/packages/discovery-provider/integration_tests/tasks/entity_manager/test_utils.py
+++ b/packages/discovery-provider/integration_tests/tasks/entity_manager/test_utils.py
@@ -195,6 +195,8 @@ def test_valid_parse_metadata(app):
                 "producer_copyright_line": None,
                 "parental_warning_type": None,
                 "allowed_api_keys": None,
+                "bpm": None,
+                "musical_key": None,
             },
             "QmUpdatePlaylist1": {
                 "playlist_id": 1,

--- a/packages/discovery-provider/integration_tests/tasks/entity_manager/test_utils.py
+++ b/packages/discovery-provider/integration_tests/tasks/entity_manager/test_utils.py
@@ -197,6 +197,7 @@ def test_valid_parse_metadata(app):
                 "allowed_api_keys": None,
                 "bpm": None,
                 "musical_key": None,
+                "audio_analysis_error_count": 0,
             },
             "QmUpdatePlaylist1": {
                 "playlist_id": 1,

--- a/packages/discovery-provider/plugins/notifications/src/types/dn.ts
+++ b/packages/discovery-provider/plugins/notifications/src/types/dn.ts
@@ -653,6 +653,8 @@ export interface TrackRow {
   copyright_line?: any | null
   producer_copyright_line?: any | null
   parental_warning_type?: any | null
+  bpm?: number | null
+  musical_key?: string | null
 }
 export interface TrendingParamRow {
   genre?: string | null

--- a/packages/discovery-provider/plugins/notifications/src/types/dn.ts
+++ b/packages/discovery-provider/plugins/notifications/src/types/dn.ts
@@ -655,6 +655,7 @@ export interface TrackRow {
   parental_warning_type?: any | null
   bpm?: number | null
   musical_key?: string | null
+  audio_analysis_error_count?: number
 }
 export interface TrendingParamRow {
   genre?: string | null

--- a/packages/discovery-provider/plugins/pedalboard/packages/storage/src/index.ts
+++ b/packages/discovery-provider/plugins/pedalboard/packages/storage/src/index.ts
@@ -1005,6 +1005,7 @@ export type Tracks = {
   parental_warning_type: string | null;
   bpm: number | null;
   musical_key: string | null;
+  audio_analysis_error_count: number;
 };
 
 export type TrendingResults = {

--- a/packages/discovery-provider/plugins/pedalboard/packages/storage/src/index.ts
+++ b/packages/discovery-provider/plugins/pedalboard/packages/storage/src/index.ts
@@ -1003,6 +1003,8 @@ export type Tracks = {
   copyright_line: unknown | null;
   producer_copyright_line: unknown | null;
   parental_warning_type: string | null;
+  bpm: number | null;
+  musical_key: string | null;
 };
 
 export type TrendingResults = {

--- a/packages/discovery-provider/src/api/v1/models/tracks.py
+++ b/packages/discovery-provider/src/api/v1/models/tracks.py
@@ -168,6 +168,8 @@ track_full = ns.clone(
         "allowed_api_keys": fields.List(fields.String, allow_null=True),
         "audio_upload_id": fields.String,
         "preview_start_seconds": fields.Float,
+        "bpm": fields.Float,
+        "musical_key": fields.String,
         # DDEX fields
         "ddex_release_ids": fields.Raw(allow_null=True),
         "artists": fields.Raw(allow_null=True),

--- a/packages/discovery-provider/src/api/v1/models/tracks.py
+++ b/packages/discovery-provider/src/api/v1/models/tracks.py
@@ -170,6 +170,7 @@ track_full = ns.clone(
         "preview_start_seconds": fields.Float,
         "bpm": fields.Float,
         "musical_key": fields.String,
+        "audio_analysis_error_count": fields.Integer,
         # DDEX fields
         "ddex_release_ids": fields.Raw(allow_null=True),
         "artists": fields.Raw(allow_null=True),

--- a/packages/discovery-provider/src/models/tracks/track.py
+++ b/packages/discovery-provider/src/models/tracks/track.py
@@ -108,6 +108,8 @@ class Track(Base, RepresentableMixin):
     copyright_line = Column(JSONB())
     producer_copyright_line = Column(JSONB())
     parental_warning_type = Column(String)
+    bpm = Column(Float)
+    musical_key = Column(String)
 
     block1 = relationship(  # type: ignore
         "Block", primaryjoin="Track.blocknumber == Block.number"

--- a/packages/discovery-provider/src/models/tracks/track.py
+++ b/packages/discovery-provider/src/models/tracks/track.py
@@ -110,6 +110,9 @@ class Track(Base, RepresentableMixin):
     parental_warning_type = Column(String)
     bpm = Column(Float)
     musical_key = Column(String)
+    audio_analysis_error_count = Column(
+        Integer, nullable=False, server_default=text("0")
+    )
 
     block1 = relationship(  # type: ignore
         "Block", primaryjoin="Track.blocknumber == Block.number"

--- a/packages/discovery-provider/src/schemas/track_schema.json
+++ b/packages/discovery-provider/src/schemas/track_schema.json
@@ -371,6 +371,12 @@
             "null"
           ],
           "default": null
+        },
+        "audio_analysis_error_count": {
+          "type": [
+            "integer"
+          ],
+          "default": 0
         }
       },
       "required": [

--- a/packages/discovery-provider/src/schemas/track_schema.json
+++ b/packages/discovery-provider/src/schemas/track_schema.json
@@ -357,6 +357,20 @@
             "null"
           ],
           "default": null
+        },
+        "bpm": {
+          "type": [
+            "float",
+            "null"
+          ],
+          "default": null
+        },
+        "musical_key": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "default": null
         }
       },
       "required": [

--- a/packages/discovery-provider/src/tasks/metadata.py
+++ b/packages/discovery-provider/src/tasks/metadata.py
@@ -99,6 +99,7 @@ class TrackMetadata(TypedDict):
     allowed_api_keys: Optional[str]
     bpm: Optional[float]
     musical_key: Optional[str]
+    audio_analysis_error_count: Optional[int]
 
 
 track_metadata_format: TrackMetadata = {
@@ -153,6 +154,7 @@ track_metadata_format: TrackMetadata = {
     "allowed_api_keys": None,
     "bpm": None,
     "musical_key": None,
+    "audio_analysis_error_count": 0,
 }
 
 # Required format for user metadata retrieved from the content system

--- a/packages/discovery-provider/src/tasks/metadata.py
+++ b/packages/discovery-provider/src/tasks/metadata.py
@@ -97,6 +97,8 @@ class TrackMetadata(TypedDict):
     producer_copyright_line: Optional[Copyright]
     parental_warning_type: Optional[str]
     allowed_api_keys: Optional[str]
+    bpm: Optional[float]
+    musical_key: Optional[str]
 
 
 track_metadata_format: TrackMetadata = {
@@ -149,6 +151,8 @@ track_metadata_format: TrackMetadata = {
     "producer_copyright_line": None,
     "parental_warning_type": None,
     "allowed_api_keys": None,
+    "bpm": None,
+    "musical_key": None,
 }
 
 # Required format for user metadata retrieved from the content system

--- a/packages/discovery-provider/src/tasks/metadata.py
+++ b/packages/discovery-provider/src/tasks/metadata.py
@@ -256,6 +256,7 @@ immutable_track_fields = immutable_fields | {
     "orig_filename",
     "duration",
     "is_available",
+    "audio_analysis_error_count",
 }
 
 immutable_user_fields = immutable_fields | {

--- a/packages/es-indexer/src/types/db.ts
+++ b/packages/es-indexer/src/types/db.ts
@@ -717,6 +717,8 @@ export interface TrackRow {
   'copyright_line'?: any | null;
   'producer_copyright_line'?: any | null;
   'parental_warning_type'?: string | null;
+  'bpm': number | null;
+  'musical_key': string | null;
 }
 export interface TrendingParamRow {
   'genre': string | null;

--- a/packages/libs/src/api/Track.ts
+++ b/packages/libs/src/api/Track.ts
@@ -653,6 +653,9 @@ export class Track extends Base {
       remix_of,
       ai_attribution_user_id,
       allowed_api_keys,
+      bpm,
+      musical_key,
+      audio_analysis_error_count,
       ...other
     } = trackMetadata
     if (typeof other !== 'undefined') {
@@ -706,7 +709,10 @@ export class Track extends Base {
       dateListened,
       remix_of,
       ai_attribution_user_id,
-      allowed_api_keys
+      allowed_api_keys,
+      bpm,
+      musical_key,
+      audio_analysis_error_count
     }
   }
 }

--- a/packages/libs/src/sdk/api/tracks/types.ts
+++ b/packages/libs/src/sdk/api/tracks/types.ts
@@ -158,7 +158,10 @@ export const createUploadTrackMetadataSchema = () =>
     rightsController: z.optional(DDEXRightsController.nullable()),
     copyrightLine: z.optional(DDEXCopyright.nullable()),
     producerCopyrightLine: z.optional(DDEXCopyright.nullable()),
-    parentalWarningType: z.optional(z.string().nullable())
+    parentalWarningType: z.optional(z.string().nullable()),
+    bpm: z.optional(z.number().nullable()),
+    musicalKey: z.optional(z.string().nullable()),
+    audioAnalysisErrorCount: z.optional(z.number())
   })
 
 export type TrackMetadata = z.input<

--- a/packages/libs/src/services/schemaValidator/schemas/trackSchema.json
+++ b/packages/libs/src/services/schemaValidator/schemas/trackSchema.json
@@ -350,6 +350,26 @@
             "null"
           ],
           "default": null
+        },
+        "bpm": {
+          "type": [
+            "float",
+            "null"
+          ],
+          "default": null
+        },
+        "musical_key": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "default": null
+        },
+        "audio_analysis_error_count": {
+          "type": [
+            "integer"
+          ],
+          "default": 0
         }
       },
       "required": [

--- a/packages/libs/src/utils/types.ts
+++ b/packages/libs/src/utils/types.ts
@@ -207,6 +207,9 @@ export type TrackMetadata = {
   is_playlist_upload?: boolean
   ai_attribution_user_id?: Nullable<ID>
   allowed_api_keys?: Nullable<string[]>
+  bpm?: Nullable<number>
+  musical_key?: Nullable<string>
+  audio_analysis_error_count?: number
 }
 
 export type CollectionMetadata = {
@@ -259,4 +262,7 @@ export type UploadTrackMetadata = Omit<
   | 'audio_upload_id'
   | 'orig_file_cid'
   | 'orig_filename'
+  | 'bpm'
+  | 'musical_key'
+  | 'audio_analysis_error_count'
 >

--- a/packages/sql-ts/res/discovery-node.ts
+++ b/packages/sql-ts/res/discovery-node.ts
@@ -660,6 +660,8 @@ export interface TrackRow {
   'copyright_line'?: any | null;
   'producer_copyright_line'?: any | null;
   'parental_warning_type'?: string | null;
+  'bpm'?: number | null;
+  'musical_key'?: string | null;
 }
 export interface TrendingParamRow {
   'genre'?: string | null;

--- a/packages/sql-ts/res/discovery-node.ts
+++ b/packages/sql-ts/res/discovery-node.ts
@@ -662,6 +662,7 @@ export interface TrackRow {
   'parental_warning_type'?: string | null;
   'bpm'?: number | null;
   'musical_key'?: string | null;
+  'audio_analysis_error_count'?: number;
 }
 export interface TrendingParamRow {
   'genre'?: string | null;


### PR DESCRIPTION
### Description
Add key and bpm to discovery track metadata. EM will now persist key/bpm if it is included in the track metadata sent in the tx.

### How Has This Been Tested?
