### PR TITLE
QA-1355: add exit button to web rewards modal

### DIFF
--- a/packages/web/src/pages/audio-rewards-page/components/modals/ChallengeRewardsModal/ClaimAllRewardsModal.tsx
+++ b/packages/web/src/pages/audio-rewards-page/components/modals/ChallengeRewardsModal/ClaimAllRewardsModal.tsx
@@ -53,7 +53,6 @@ const { getClaimStatus } = audioRewardsPageSelectors
 export const ClaimAllRewardsModal = () => {
   const dispatch = useDispatch()
   const { toast } = useContext(ToastContext)
-  const wm = useWithMobileStyle(styles.mobile)
   const [isOpen, setOpen] = useModalState('ClaimAllRewards')
   const claimStatus = useSelector(getClaimStatus)
   const { claimableAmount, claimableChallenges, cooldownChallenges, summary } =

--- a/packages/web/src/pages/audio-rewards-page/components/modals/ChallengeRewardsModal/ClaimAllRewardsModal.tsx
+++ b/packages/web/src/pages/audio-rewards-page/components/modals/ChallengeRewardsModal/ClaimAllRewardsModal.tsx
@@ -16,7 +16,10 @@ import {
   Button,
   Flex,
   IconArrowRight,
+  Modal,
   ModalContent,
+  ModalHeader,
+  ModalTitle,
   ProgressBar,
   Text
 } from '@audius/harmony'
@@ -121,16 +124,10 @@ export const ClaimAllRewardsModal = () => {
   }, [])
 
   return (
-    <ModalDrawer
-      title={messages.rewards}
-      showTitleHeader
-      isOpen={isOpen}
-      onClose={handleClose}
-      isFullscreen={true}
-      useGradientTitle={false}
-      titleClassName={wm(styles.title)}
-      headerContainerClassName={styles.header}
-    >
+    <Modal size='medium' isOpen={isOpen} onClose={handleClose}>
+      <ModalHeader onClose={handleClose}>
+        <ModalTitle title={messages.rewards} />
+      </ModalHeader>
       <ModalContent>
         <Flex direction='column' gap='2xl' mt='s'>
           <Text variant='body' textAlign='left'>
@@ -196,6 +193,6 @@ export const ClaimAllRewardsModal = () => {
           )}
         </Flex>
       </ModalContent>
-    </ModalDrawer>
+    </Modal>
   )
 }

--- a/packages/web/src/pages/audio-rewards-page/components/modals/ChallengeRewardsModal/ClaimAllRewardsModal.tsx
+++ b/packages/web/src/pages/audio-rewards-page/components/modals/ChallengeRewardsModal/ClaimAllRewardsModal.tsx
@@ -32,8 +32,6 @@ import { ToastContext } from 'components/toast/ToastContext'
 import { useWithMobileStyle } from 'hooks/useWithMobileStyle'
 import { CLAIM_REWARD_TOAST_TIMEOUT_MILLIS } from 'utils/constants'
 
-import ModalDrawer from '../ModalDrawer'
-
 import styles from './styles.module.css'
 
 const messages = {

--- a/packages/web/src/pages/audio-rewards-page/components/modals/ChallengeRewardsModal/ClaimAllRewardsModal.tsx
+++ b/packages/web/src/pages/audio-rewards-page/components/modals/ChallengeRewardsModal/ClaimAllRewardsModal.tsx
@@ -29,10 +29,7 @@ import { useModalState } from 'common/hooks/useModalState'
 import LoadingSpinner from 'components/loading-spinner/LoadingSpinner'
 import { SummaryTable } from 'components/summary-table'
 import { ToastContext } from 'components/toast/ToastContext'
-import { useWithMobileStyle } from 'hooks/useWithMobileStyle'
 import { CLAIM_REWARD_TOAST_TIMEOUT_MILLIS } from 'utils/constants'
-
-import styles from './styles.module.css'
 
 const messages = {
   upcomingRewards: 'Upcoming Rewards',


### PR DESCRIPTION
### Description
Switches from using ModalDrawer to Modal and manually creating a header, passes in the onOpen and onClose events as it was previously implemented.

### How Has This Been Tested?

![Screenshot 2024-06-07 at 11 24 55 AM](https://github.com/AudiusProject/audius-protocol/assets/16739903/2decd06e-ca24-4646-ad85-ebd3d8ef233a)
