### PR TITLE
Add trendingBlue and aiGreen harmony colors

### DIFF
--- a/packages/harmony/src/foundations/color/primitive.ts
+++ b/packages/harmony/src/foundations/color/primitive.ts
@@ -46,6 +46,8 @@ export const primitiveTheme = {
       darkRed: '#BB0218',
       green: '#0F9E48',
       lightGreen: '#13C65A',
+      trendingBlue: '#216FDC',
+      aiGreen: '#1FD187',
       gradient: 'linear-gradient(315deg, #5b23e1 0%, #a22feb 100%)'
     }
   },
@@ -97,6 +99,8 @@ export const primitiveTheme = {
       darkRed: '#C43047',
       green: '#6CDF44',
       lightGreen: '#13C65A',
+      trendingBlue: '#216FDC',
+      aiGreen: '#1FD187',
       gradient: 'linear-gradient(315deg, #7652cc 0%, #b05ce6 100%)'
     }
   },
@@ -147,6 +151,8 @@ export const primitiveTheme = {
       darkRed: '#C43047',
       green: '#6CDF44',
       lightGreen: '#13C65A',
+      trendingBlue: '#216FDC',
+      aiGreen: '#1FD187',
       gradient: 'linear-gradient(323.08deg, #4FF069 36.13%, #09BD51 133.51%)'
     }
   }


### PR DESCRIPTION
### Description
To be used in `MusicBadge` components. Don't want to keep hardcoding these. Got approval from design.

### How Has This Been Tested?

<img width="641" alt="Screenshot 2024-06-07 at 5 22 03 PM" src="https://github.com/AudiusProject/audius-protocol/assets/3893871/68eacab3-6388-407c-818b-4570cf5ebe0b">
