### PR TITLE
[QA-1361] Fix audio-nfts playlist

### DIFF
--- a/packages/web/src/common/store/player/sagas.ts
+++ b/packages/web/src/common/store/player/sagas.ts
@@ -253,6 +253,7 @@ export function* watchCollectiblePlay() {
     playCollectible.type,
     function* (action: ReturnType<typeof playCollectible>) {
       const { collectible, onEnd } = action.payload
+      const { animationUrl, videoUrl } = collectible
       const audioPlayer = yield* getContext('audioPlayer')
       const endChannel = eventChannel((emitter) => {
         audioPlayer.load(
@@ -262,7 +263,7 @@ export function* watchCollectiblePlay() {
               emitter(onEnd({}))
             }
           },
-          collectible.animationUrl
+          animationUrl ?? videoUrl
         )
         return () => {}
       })

--- a/packages/web/src/components/collectibles/components/CollectiblesPage.tsx
+++ b/packages/web/src/components/collectibles/components/CollectiblesPage.tsx
@@ -471,13 +471,6 @@ const CollectiblesPage = (props: CollectiblesPageProps) => {
     return []
   }, [collectiblesMetadata, collectibleList, hasCollectibles])
 
-  // const getAudioCollectibles = useCallback(() => {
-  //   const visibleCollectibles = getVisibleCollectibles()
-  //   return visibleCollectibles?.filter(c =>
-  //     ['mp3', 'wav', 'oga'].some(ext => c.animationUrl?.endsWith(ext))
-  //   )
-  // }, [getVisibleCollectibles])
-
   const getHiddenCollectibles = useCallback(() => {
     if (collectibleList) {
       const visibleCollectibleKeySet = new Set(

--- a/packages/web/src/components/nav/desktop/PlaylistLibrary/useAddAudioNftPlaylistToLibrary.ts
+++ b/packages/web/src/components/nav/desktop/PlaylistLibrary/useAddAudioNftPlaylistToLibrary.ts
@@ -32,9 +32,10 @@ export const useAddAudioNftPlaylistToLibrary = () => {
     }
     const accountCollectibles = getAccountCollectibles(state)
     const hasAudioNfts = accountCollectibles?.some((collectible) => {
-      const { hasAudio, animationUrl } = collectible
+      const { hasAudio, animationUrl, videoUrl } = collectible
       if (hasAudio) return true
-      const collectibleExtension = animationUrl?.split('.').pop()
+      const mediaUrl = animationUrl ?? videoUrl
+      const collectibleExtension = mediaUrl?.split('.').pop()
       return collectibleExtension && audioFormatSet.has(collectibleExtension)
     })
 

--- a/packages/web/src/pages/collectibles-playlist-page/CollectiblesPlaylistPageProvider.tsx
+++ b/packages/web/src/pages/collectibles-playlist-page/CollectiblesPlaylistPageProvider.tsx
@@ -116,6 +116,7 @@ export const CollectiblesPlaylistPageProvider = ({
   const hasFetchedCollectibles = useRef(false)
   const [hasFetchedAllCollectibles, setHasFetchedAllCollectibles] =
     useState(false)
+
   useEffect(() => {
     const asyncFn = async (cs: Collectible[]) => {
       const collectibleIds = Object.keys(user?.collectibles ?? {})
@@ -136,8 +137,8 @@ export const CollectiblesPlaylistPageProvider = ({
 
       const potentiallyHasAudio = (c: Collectible) =>
         c.hasAudio ||
-        ['mp3', 'wav', 'oga', 'mp4'].some((ext) =>
-          c.animationUrl?.endsWith(ext)
+        ['mp3', 'wav', 'oga', 'mp4'].some(
+          (ext) => c.animationUrl?.endsWith(ext) || c.videoUrl?.endsWith(ext)
         )
 
       const filteredAndSortedCollectibles = cs
@@ -147,19 +148,19 @@ export const CollectiblesPlaylistPageProvider = ({
 
       await Promise.all(
         filteredAndSortedCollectibles.map(async (collectible, index) => {
-          if (collectible.animationUrl?.endsWith('mp4')) {
+          if (collectible.videoUrl?.endsWith('mp4')) {
             const v = document.createElement('video')
             v.muted = true
             const duration: Promise<number> = new Promise((resolve) => {
-              setTimeout(() => resolve(0), 60000)
+              setTimeout(() => resolve(0), 4000)
               v.onloadedmetadata = () => {
                 resolve(v.duration)
               }
             })
 
             v.preload = 'metadata'
-            v.src = collectible.animationUrl
-            collectible.duration = await duration
+            v.src = collectible.videoUrl
+            collectible = { ...collectible, duration: await duration }
             v.play().catch((e) => console.error('video error', e))
 
             const videoHasAudio = await new Promise((resolve) => {
@@ -188,14 +189,14 @@ export const CollectiblesPlaylistPageProvider = ({
           } else {
             const a = new Audio()
             const duration: Promise<number> = new Promise((resolve) => {
-              setTimeout(() => resolve(0), 60000)
+              setTimeout(() => resolve(0), 4000)
               a.onloadedmetadata = () => {
                 resolve(a.duration)
               }
             })
             a.preload = 'metadata'
-            a.src = collectible.animationUrl ?? ''
-            collectible.duration = await duration
+            a.src = collectible.animationUrl ?? collectible.videoUrl ?? ''
+            collectible = { ...collectible, duration: await duration }
           }
           if (collectible) {
             setAudioCollectibles((currentCollectibles) => {


### PR DESCRIPTION
### Description
Fixes issue with audio-nfts playlist not loading, likely due to updates to fetch-nft. The main fix is including "videoUrl" in many places, as often the audio-nfts are videos, which now only set videoUrl