### PR TITLE
[C-4473] Enable edit rules in new edit form

### DIFF
--- a/packages/ddex/webapp/client/src/pages/Releases/Releases.tsx
+++ b/packages/ddex/webapp/client/src/pages/Releases/Releases.tsx
@@ -6,6 +6,7 @@ import {
   TextLink,
   OptionsFilterButton
 } from '@audius/harmony'
+
 import {
   CollectionData,
   PaginatedTable

--- a/packages/ddex/webapp/client/src/pages/Releases/Releases.tsx
+++ b/packages/ddex/webapp/client/src/pages/Releases/Releases.tsx
@@ -6,7 +6,6 @@ import {
   TextLink,
   OptionsFilterButton
 } from '@audius/harmony'
-
 import {
   CollectionData,
   PaginatedTable

--- a/packages/web/src/components/edit-track/EditTrackForm.tsx
+++ b/packages/web/src/components/edit-track/EditTrackForm.tsx
@@ -77,7 +77,7 @@ const TrackEditForm = (
 ) => {
   const { values, dirty, isSubmitting, hideContainer = false } = props
   const isMultiTrack = values.trackMetadatas.length > 1
-  const isUpload = !values.trackMetadatas[0].track_id === undefined
+  const isUpload = values.trackMetadatas[0].track_id === undefined
   const trackIdx = values.trackMetadatasIndex
   const [, , { setValue: setIndex }] = useField('trackMetadatasIndex')
   useUnmount(() => {

--- a/packages/web/src/components/edit-track/EditTrackForm.tsx
+++ b/packages/web/src/components/edit-track/EditTrackForm.tsx
@@ -117,7 +117,7 @@ const TrackEditForm = (
                 <ReleaseDateFieldLegacy />
               )}
               <AccessAndSaleField
-                isUpload
+                isUpload={!isEdit}
                 forceOpen={forceOpenAccessAndSale}
                 setForceOpen={setForceOpenAccessAndSale}
               />

--- a/packages/web/src/components/edit-track/EditTrackForm.tsx
+++ b/packages/web/src/components/edit-track/EditTrackForm.tsx
@@ -77,7 +77,7 @@ const TrackEditForm = (
 ) => {
   const { values, dirty, isSubmitting, hideContainer = false } = props
   const isMultiTrack = values.trackMetadatas.length > 1
-  const isEdit = values.trackMetadatas[0].track_id !== undefined
+  const isUpload = !values.trackMetadatas[0].track_id === undefined
   const trackIdx = values.trackMetadatasIndex
   const [, , { setValue: setIndex }] = useField('trackMetadatasIndex')
   useUnmount(() => {
@@ -117,12 +117,13 @@ const TrackEditForm = (
                 <ReleaseDateFieldLegacy />
               )}
               <AccessAndSaleField
-                isUpload={!isEdit}
+                isUpload={isUpload}
                 forceOpen={forceOpenAccessAndSale}
                 setForceOpen={setForceOpenAccessAndSale}
               />
               <AttributionField />
               <StemsAndDownloadsField
+                isUpload={isUpload}
                 closeMenuCallback={(data) => {
                   if (data === MenuFormCallbackStatus.OPEN_ACCESS_AND_SALE) {
                     setForceOpenAccessAndSale(true)
@@ -142,11 +143,13 @@ const TrackEditForm = (
         </div>
         {isMultiTrack ? <MultiTrackSidebar /> : null}
       </div>
-      {isEdit ? (
+      {isUpload ? (
+        !isMultiTrack ? (
+          <AnchoredSubmitRow />
+        ) : null
+      ) : (
         <AnchoredSubmitRowEdit />
-      ) : !isMultiTrack ? (
-        <AnchoredSubmitRow />
-      ) : null}
+      )}
     </Form>
   )
 }

--- a/packages/web/src/components/edit/fields/AccessAndSaleField.tsx
+++ b/packages/web/src/components/edit/fields/AccessAndSaleField.tsx
@@ -243,8 +243,8 @@ type AccessAndSaleFieldProps = {
 
 export const AccessAndSaleField = (props: AccessAndSaleFieldProps) => {
   const {
-    isUpload = false,
-    isAlbum = false,
+    isUpload,
+    isAlbum,
     forceOpen,
     setForceOpen,
     isPublishDisabled = false
@@ -269,6 +269,8 @@ export const AccessAndSaleField = (props: AccessAndSaleFieldProps) => {
   const parentFormInitialStreamConditions =
     'stream_conditions' in parentFormInitialValues
       ? (parentFormInitialValues.stream_conditions as AccessConditions)
+      : 'trackMetadatas' in parentFormInitialValues
+      ? parentFormInitialValues.trackMetadatas[index].stream_conditions
       : undefined
 
   // Fields from the outer form

--- a/packages/web/src/components/edit/fields/StemsAndDownloadsField.tsx
+++ b/packages/web/src/components/edit/fields/StemsAndDownloadsField.tsx
@@ -62,12 +62,12 @@ const messages = {
 }
 
 type StemsAndDownloadsFieldProps = {
+  isUpload: boolean
   closeMenuCallback?: (data?: any) => void
 }
 
-export const StemsAndDownloadsField = ({
-  closeMenuCallback
-}: StemsAndDownloadsFieldProps) => {
+export const StemsAndDownloadsField = (props: StemsAndDownloadsFieldProps) => {
+  const { isUpload, closeMenuCallback } = props
   const { isEnabled: isUsdcUploadEnabled } = useFeatureFlag(
     FeatureFlags.USDC_PURCHASES_UPLOAD
   )
@@ -279,7 +279,7 @@ export const StemsAndDownloadsField = ({
       )}
       menuFields={
         <StemsAndDownloadsMenuFields
-          isUpload
+          isUpload={isUpload}
           initialDownloadConditions={savedDownloadConditions}
         />
       }

--- a/packages/web/src/components/edit/fields/download-availability/DownloadAvailability.tsx
+++ b/packages/web/src/components/edit/fields/download-availability/DownloadAvailability.tsx
@@ -39,25 +39,28 @@ import { DownloadPriceField } from './DownloadPriceField'
 
 const WAITLIST_TYPEFORM = 'https://link.audius.co/waitlist'
 
-const messages = {
+const getMessages = (props: DownloadAvailabilityProps) => ({
   downloadAvailability: 'Download Availability',
   customize: 'Customize who has access to download your files.',
   public: 'Public',
   followers: 'Followers',
   premium: 'Premium',
   callout: {
-    premium:
-      "You're uploading a Premium track. By default, purchasers will be able to download your available files. If you'd like to only sell your files, set your track to Public or Hidden in the",
-    specialAccess:
-      "You're uploading a Special Access track. By default, users who unlock your track will be able to download your available files. If you'd like to only sell your files, set your track to Public or Hidden in the",
-    collectibleGated:
-      "You're uploading a Collectible Gated track. By default, users who unlock your track will be able to download your available files. If you'd like to only sell your files, set your track to Public or Hidden in the",
+    premium: `You're ${
+      props.isUpload ? 'uploading' : 'editing'
+    } a Premium track. By default, purchasers will be able to download your available files. If you'd like to only sell your files, set your track to Public or Hidden in the`,
+    specialAccess: `You're ${
+      props.isUpload ? 'uploading' : 'editing'
+    } a Special Access track. By default, users who unlock your track will be able to download your available files. If you'd like to only sell your files, set your track to Public or Hidden in the`,
+    collectibleGated: `You're ${
+      props.isUpload ? 'uploading' : 'editing'
+    } a Collectible Gated track. By default, users who unlock your track will be able to download your available files. If you'd like to only sell your files, set your track to Public or Hidden in the`,
     accessAndSale: 'Access & Sale Settings'
   },
   waitlist:
     'Start selling your music on Audius today! Limited access beta now available.',
   join: 'Join the Waitlist'
-}
+})
 
 type DownloadAvailabilityProps = {
   isUpload: boolean
@@ -66,12 +69,9 @@ type DownloadAvailabilityProps = {
   setValue: (value: DownloadTrackAvailabilityType) => void
 }
 
-export const DownloadAvailability = ({
-  isUpload,
-  initialDownloadConditions,
-  value,
-  setValue
-}: DownloadAvailabilityProps) => {
+export const DownloadAvailability = (props: DownloadAvailabilityProps) => {
+  const { isUpload, initialDownloadConditions, value, setValue } = props
+  const messages = getMessages(props)
   const { isEnabled: isUsdcUploadEnabled } = useFeatureFlag(
     FeatureFlags.USDC_PURCHASES_UPLOAD
   )


### PR DESCRIPTION
### Description

Turns out the rules had all been migrated since we were using the new fields in the old form already. However, we were relying on boundary layer components like `AccessAndSaleTriggerLegacy` to pass the initial values through.

- Fixes passing of `initialValues` and `isUpload` through to the contextual menu field components
- Fix some copy

### How Has This Been Tested?

Confirmed we didn't break existing rules for track and collection edit