### PR TITLE
Fix mediorum audio analysis bugs, add better logs

### DIFF
--- a/mediorum/server/audio_analysis.go
+++ b/mediorum/server/audio_analysis.go
@@ -182,7 +182,6 @@ func (ss *MediorumServer) startAudioAnalysisWorker(n int, work chan *Upload) {
 }
 
 func (ss *MediorumServer) analyzeAudio(upload *Upload) error {
-	// TODO michelle time this work and abort if taking > 1 min
 	upload.AudioAnalyzedBy = ss.Config.Self.Host
 	upload.Status = JobStatusBusyAudioAnalysis
 	ss.crud.Update(upload)

--- a/mediorum/server/audio_analysis.go
+++ b/mediorum/server/audio_analysis.go
@@ -168,11 +168,12 @@ func (ss *MediorumServer) startAudioAnalysisWorker(n int, work chan *Upload) {
 			logger.Info("audio analysis window has passed. skipping job")
 		}
 
-		ss.logger.Debug("analyzing audio", "upload", upload.ID)
+		logger.Debug("analyzing audio")
 		startTime := time.Now().UTC()
 		err := ss.analyzeAudio(upload)
 		elapsedTime := time.Since(startTime)
 		logger = logger.With("duration", elapsedTime, "start_time", startTime)
+
 		if err != nil {
 			logger.Warn("audio analysis failed", "err", err)
 		} else {

--- a/mediorum/server/db.go
+++ b/mediorum/server/db.go
@@ -37,11 +37,12 @@ type Upload struct {
 	TranscodedAt      time.Time         `json:"transcoded_at"`
 	TranscodeResults  map[string]string `json:"results" gorm:"serializer:json"`
 
-	AudioAnalysisStatus  string            `json:"audio_analysis_status"`
-	AudioAnalysisError   string            `json:"audio_analysis_error,omitempty"`
-	AudioAnalyzedBy      string            `json:"audio_analyzed_by"`
-	AudioAnalyzedAt      time.Time         `json:"audio_analyzed_at"`
-	AudioAnalysisResults map[string]string `json:"audio_analysis_results" gorm:"serializer:json"`
+	AudioAnalysisStatus     string            `json:"audio_analysis_status"`
+	AudioAnalysisError      string            `json:"audio_analysis_error,omitempty"`
+	AudioAnalysisErrorCount int               `json:"audio_analysis_error_count,omitempty"`
+	AudioAnalyzedBy         string            `json:"audio_analyzed_by"`
+	AudioAnalyzedAt         time.Time         `json:"audio_analyzed_at"`
+	AudioAnalysisResults    map[string]string `json:"audio_analysis_results" gorm:"serializer:json"`
 
 	// UpldateULID - this is the last ULID that change this thing
 }


### PR DESCRIPTION
### Description
Checked the analysis logs, found some bugs. Most notably was accidentally using `upload.Mirrors` instead of `upload.TranscodeMirrors` in the `findMissedAnalysisJobs` function 🤦‍♀️ so there were many "file not found on node" errors bc the audio analysis uses the transcoded audio, not the original audio.

Another major issue I found was the timeout in `findMissedAnalysisJobs` is sometimes overriding real analysis results that took only a few seconds to complete... added a log to see if perhaps this is because it's finding a large number of in-progress audio analyses and the query is taking so long the data is becoming stale, or if this is because crudr is slow to synchronize the upload state between nodes. I hope it's not the latter... that would be much more annoying to work around.

Also add an audio analysis err count col for discovery to read from.

### How Has This Been Tested?
Ran locally.