### PR TITLE
Fix Coinflow purchases via SDK

### DIFF
--- a/packages/discovery-provider/plugins/pedalboard/apps/solana-relay/src/routes/relay/assertRelayAllowedInstructions.ts
+++ b/packages/discovery-provider/plugins/pedalboard/apps/solana-relay/src/routes/relay/assertRelayAllowedInstructions.ts
@@ -39,6 +39,7 @@ const TRACK_LISTEN_COUNT_PROGRAM_ID = config.trackListenCountProgramId
 const PAYMENT_ROUTER_PROGRAM_ID = config.paymentRouterProgramId
 const JUPITER_AGGREGATOR_V6_PROGRAM_ID =
   'JUP6LkbZbjS1jKKwapdHNy74zcZ3tLUZoi5QNyVTaV4'
+const COINFLOW_PROGRAM_ID = 'FD1amxhTsDpwzoVX41dxp2ygAESURV2zdUACzxM1Dfw9'
 
 const waudioMintAddress = config.waudioMintAddress
 const usdcMintAddress = config.usdcMintAddress
@@ -446,6 +447,7 @@ export const assertRelayAllowedInstructions = async (
       case MEMO_V2_PROGRAM_ID:
       case TRACK_LISTEN_COUNT_PROGRAM_ID:
       case ComputeBudgetProgram.programId.toBase58():
+      case COINFLOW_PROGRAM_ID:
         // All instructions of these programs are allowed
         break
       default:

--- a/packages/discovery-provider/plugins/pedalboard/apps/solana-relay/src/routes/relay/relay.ts
+++ b/packages/discovery-provider/plugins/pedalboard/apps/solana-relay/src/routes/relay/relay.ts
@@ -17,6 +17,11 @@ import {
 
 import { assertRelayAllowedInstructions } from './assertRelayAllowedInstructions'
 
+/**
+ * Gets the specified fee payer's key pair from the config.
+ * @param feePayerPublicKey the fee payer to find
+ * @returns the Keypair of the given fee payer or null if not found
+ */
 const getFeePayerKeyPair = (feePayerPublicKey?: PublicKey) => {
   if (!feePayerPublicKey) {
     return null
@@ -63,6 +68,14 @@ const verifySignatures = (transaction: VersionedTransaction) => {
   return true
 }
 
+/**
+ * The core Solana relay route, /solana/relay.
+ *
+ * This endpoint takes a transaction and some options in the POST body,
+ * and signs the transaction (if necessary) and sends it (with retry logic).
+ * If successful, it broadcasts the resulting transaction metadata to the
+ * other discovery nodes to help them save on RPC calls when indexing.
+ */
 export const relay = async (
   req: Request<unknown, unknown, RelayRequestBody>,
   res: Response,

--- a/packages/web/src/components/coinflow-onramp-modal/CoinflowOnrampModal.tsx
+++ b/packages/web/src/components/coinflow-onramp-modal/CoinflowOnrampModal.tsx
@@ -6,7 +6,7 @@ import {
   useCoinflowOnrampModal
 } from '@audius/common/store'
 import { CoinflowPurchase } from '@coinflowlabs/react'
-import { Transaction } from '@solana/web3.js'
+import { VersionedTransaction } from '@solana/web3.js'
 import { useDispatch } from 'react-redux'
 
 import ModalDrawer from 'pages/audio-rewards-page/components/modals/ModalDrawer'
@@ -29,19 +29,19 @@ export const CoinflowOnrampModal = () => {
     onClosed
   } = useCoinflowOnrampModal()
   const dispatch = useDispatch()
-  const [transaction, setTransaction] = useState<Transaction | undefined>(
-    undefined
-  )
+  const [transaction, setTransaction] = useState<
+    VersionedTransaction | undefined
+  >(undefined)
 
   const adapter = useCoinflowAdapter()
 
   useEffect(() => {
     if (serializedTransaction) {
       try {
-        const deserialized = Transaction.from(
+        const tx = VersionedTransaction.deserialize(
           Buffer.from(serializedTransaction, 'base64')
         )
-        setTransaction(deserialized)
+        setTransaction(tx)
       } catch (e) {
         console.error(e)
       }

--- a/scripts/preinstall.sh
+++ b/scripts/preinstall.sh
@@ -13,7 +13,7 @@ fi
 export NVM_DIR=$HOME/.nvm;
 source $NVM_DIR/nvm.sh;
 
-printf "${GREEN}Confirming node, python, and ruby environents...\n${NC}"
+printf "${GREEN}Confirming node, python, and ruby environments...\n${NC}"
 {
   nvm install
   cp .python-version-dev .python-version


### PR DESCRIPTION
### Description

❗ _**Attention Reviewers:** It might be easier to review commit by commit_

Coinflow purchases via SDK failed due to bugs with how the Coinflow modal and adapter handle the VersionedTransaction, as well as how relay handles the Coinflow transaction. These bugs didn't affect non-Coinflow purchases.

The bugs:
- The new SDK uses `VersionedTransaction`, but when deserializing we were assuming the transaction was the legacy `Transaction` type in the `CoinflowOnrampModal`
- On relay, we were modifying the purchase transaction after the client had already signed it with the user's root wallet, which makes the signature invalid
  - This was an oversight during the discussion around adding geo, I forgot that the client needs to sign the Coinflow transactions as Coinflow doesn't know how to put USDC into user banks, so we use root wallet instead. Theoretically, could try putting the money directly into the Payment Router to avoid needing this signature 🤔 
- Relay was blocking instructions from the Coinflow program (prior implementation sent via client, not relay)
- By the time relay was getting the transaction, often the recent blockhash expired
- Relay was not equipped to handle lookup tables, which Coinflow uses, and would fail to deserialize the transaction for validating the instructions and pulling out the feePayer.

### How Has This Been Tested?

Tested by running the `solana-relay` locally and configuring it with the prod env variables, and adjusting the prod env variable for the client to point at the local `solana-relay` and running `web:prod` and testing purchases manually. We will be testing more heavily tomorrow during our QA session.
