### PR TITLE
initialize topNumber var

### DIFF
--- a/protocol-dashboard/src/components/TotalApiCallsChart/TotalApiCallsChart.tsx
+++ b/protocol-dashboard/src/components/TotalApiCallsChart/TotalApiCallsChart.tsx
@@ -17,6 +17,7 @@ const TotalApiCallsChart: React.FC = () => {
   const { apiCalls: trailingApiCalls } = useTrailingApiCalls(
     bucket === Bucket.ALL_TIME ? Bucket.MONTH : bucket
   )
+  let topNumber = null
   if (trailingApiCalls === MetricError.ERROR) {
     topNumber = null
   } else {


### PR DESCRIPTION
### Description
variable was not initialized and resulted in a blank analytics page

### How Has This Been Tested?
`npm run start:prod`
