### PR TITLE
[C-4538] Add genre search param for profiles

### DIFF
--- a/packages/web/src/pages/search-page-v2/SearchResults.tsx
+++ b/packages/web/src/pages/search-page-v2/SearchResults.tsx
@@ -99,7 +99,7 @@ export const SearchResults = ({ query }: SearchResultsProps) => {
   const sort = urlSearchParams.get('sort')
   const genre = urlSearchParams.get('genre')
   const mood = urlSearchParams.get('mood')
-  const isVerified = urlSearchParams.get('is_verified')
+  const isVerified = urlSearchParams.get('isVerified')
 
   const isLoading = results.status === Status.LOADING
   const dispatch = useDispatch()


### PR DESCRIPTION
### Description
* Add genre search param for profiles
* Any profile with a track matching a given genre will be included in the results
* Profiles with multiple tracks matching the genre will be boosted with a logarithm, this is to prevent profiles with tons of tracks from dominated search results

### How Has This Been Tested?

Tested locally with mock data
