### PR TITLE
[PAY-2837] Handle disallowed actions when acting as managed user

### DIFF
--- a/packages/web/src/components/nav/desktop/NavMenuButton.tsx
+++ b/packages/web/src/components/nav/desktop/NavMenuButton.tsx
@@ -1,4 +1,7 @@
-import { useAccountHasClaimableRewards } from '@audius/common/hooks'
+import {
+  useAccountHasClaimableRewards,
+  useIsManagedAccount
+} from '@audius/common/hooks'
 import { Name } from '@audius/common/models'
 import { StringKeys } from '@audius/common/services'
 import { chatSelectors } from '@audius/common/store'
@@ -52,6 +55,7 @@ export const NavMenuButton = () => {
   const isUSDCEnabled = useIsUSDCEnabled()
   const challengeRewardIds = useRemoteVar(StringKeys.CHALLENGE_REWARD_IDS)
   const hasClaimableRewards = useAccountHasClaimableRewards(challengeRewardIds)
+  const isManagedAccount = useIsManagedAccount()
   const showNotificationBubble = hasUnreadMessages || hasClaimableRewards
 
   const messagesIcon = hasUnreadMessages ? (
@@ -65,16 +69,18 @@ export const NavMenuButton = () => {
   ) : (
     <IconMessage />
   )
-  const messagesItem = {
-    className: styles.item,
-    text: messages.messages,
-    onClick: () => {
-      navigate(CHATS_PAGE)
-      dispatch(make(Name.CHAT_ENTRY_POINT, { source: 'navmenu' }))
-    },
-    icon: messagesIcon,
-    iconClassName: styles.menuItemIcon
-  }
+  const messagesItem = isManagedAccount
+    ? null
+    : {
+        className: styles.item,
+        text: messages.messages,
+        onClick: () => {
+          navigate(CHATS_PAGE)
+          dispatch(make(Name.CHAT_ENTRY_POINT, { source: 'navmenu' }))
+        },
+        icon: messagesIcon,
+        iconClassName: styles.menuItemIcon
+      }
 
   const payAndEarnItem = isUSDCEnabled
     ? {

--- a/packages/web/src/components/premium-content-purchase-modal/PremiumContentPurchaseModal.tsx
+++ b/packages/web/src/components/premium-content-purchase-modal/PremiumContentPurchaseModal.tsx
@@ -52,6 +52,7 @@ import { LockedContentDetailsTile } from 'components/track/LockedContentDetailsT
 import { USDCManualTransfer } from 'components/usdc-manual-transfer/USDCManualTransfer'
 import { useIsMobile } from 'hooks/useIsMobile'
 import { useIsUSDCEnabled } from 'hooks/useIsUSDCEnabled'
+import { useManagedAccountNotAllowedCallback } from 'hooks/useManagedAccountNotAllowedRedirect'
 import ModalDrawer from 'pages/audio-rewards-page/components/modals/ModalDrawer'
 import { pushUniqueRoute } from 'utils/route'
 import zIndex from 'utils/zIndex'
@@ -274,6 +275,8 @@ export const PremiumContentPurchaseModal = () => {
     dispatch(cleanup())
     dispatch(cleanupUSDCRecovery())
   }, [onClosed, dispatch])
+
+  useManagedAccountNotAllowedCallback(isOpen, handleClose)
 
   if (
     !metadata ||

--- a/packages/web/src/components/premium-content-purchase-modal/PremiumContentPurchaseModal.tsx
+++ b/packages/web/src/components/premium-content-purchase-modal/PremiumContentPurchaseModal.tsx
@@ -276,7 +276,10 @@ export const PremiumContentPurchaseModal = () => {
     dispatch(cleanupUSDCRecovery())
   }, [onClosed, dispatch])
 
-  useManagedAccountNotAllowedCallback(isOpen, handleClose)
+  useManagedAccountNotAllowedCallback({
+    trigger: isOpen,
+    callback: handleClose
+  })
 
   if (
     !metadata ||

--- a/packages/web/src/components/stat-banner/StatBanner.tsx
+++ b/packages/web/src/components/stat-banner/StatBanner.tsx
@@ -1,5 +1,6 @@
 import { useRef } from 'react'
 
+import { useIsManagedAccount } from '@audius/common/hooks'
 import { ID } from '@audius/common/models'
 import {
   IconMessageBlock,
@@ -80,6 +81,7 @@ const StatsPopupMenu = ({
   onBlock,
   onUnblock
 }: StatsMenuPopupProps) => {
+  const isManagedAccount = useIsManagedAccount()
   const menuItems = [
     {
       text: messages.shareProfile,
@@ -88,7 +90,7 @@ const StatsPopupMenu = ({
     }
   ]
 
-  if (accountUserId) {
+  if (accountUserId && !isManagedAccount) {
     menuItems.push(
       isBlocked
         ? {
@@ -152,6 +154,7 @@ export const StatBanner = (props: StatsBannerProps) => {
   } = props
   let buttons = null
   const followButtonRef = useRef<HTMLButtonElement>(null)
+  const isManagedAccount = useIsManagedAccount()
 
   const shareButton = (
     <Button
@@ -211,7 +214,7 @@ export const StatBanner = (props: StatsBannerProps) => {
                 onBlock={onBlock}
                 onUnblock={onUnblock}
               />
-              {onMessage ? (
+              {onMessage && !isManagedAccount ? (
                 <Button
                   variant='secondary'
                   size='small'

--- a/packages/web/src/components/tipping/tip-audio/TipAudioButton.tsx
+++ b/packages/web/src/components/tipping/tip-audio/TipAudioButton.tsx
@@ -1,3 +1,4 @@
+import { useIsManagedAccount } from '@audius/common/hooks'
 import { profilePageSelectors, tippingActions } from '@audius/common/store'
 import { Button, IconTokenGold } from '@audius/harmony'
 import { useDispatch } from 'react-redux'
@@ -13,12 +14,17 @@ const messages = {
 }
 
 export const TipAudioButton = () => {
+  const isManagedAccount = useIsManagedAccount()
   const dispatch = useDispatch()
   const profile = useSelector(getProfileUser)
 
   const handleClick = useAuthenticatedCallback(() => {
     dispatch(beginTip({ user: profile, source: 'profile' }))
   }, [dispatch, profile])
+
+  if (isManagedAccount) {
+    return null
+  }
 
   return (
     <Button

--- a/packages/web/src/components/tipping/tip-audio/TipAudioModal.tsx
+++ b/packages/web/src/components/tipping/tip-audio/TipAudioModal.tsx
@@ -162,7 +162,7 @@ export const TipAudioModal = () => {
 
   const isOpen = sendStatus !== null
 
-  useManagedAccountNotAllowedCallback(isOpen, onClose)
+  useManagedAccountNotAllowedCallback({ trigger: isOpen, callback: onClose })
 
   return (
     <Modal

--- a/packages/web/src/components/tipping/tip-audio/TipAudioModal.tsx
+++ b/packages/web/src/components/tipping/tip-audio/TipAudioModal.tsx
@@ -23,6 +23,7 @@ import { usePrevious } from 'react-use'
 
 import IconGoldBadge from 'assets/img/tokenBadgeGold48@2x.webp'
 import { useSelector } from 'common/hooks/useSelector'
+import { useManagedAccountNotAllowedCallback } from 'hooks/useManagedAccountNotAllowedRedirect'
 import { useRemoteVar } from 'hooks/useRemoteConfig'
 
 import { ConfirmSendTip } from './ConfirmSendTip'
@@ -159,9 +160,13 @@ export const TipAudioModal = () => {
       ? nextScreenTransition
       : previousScreenTransition
 
+  const isOpen = sendStatus !== null
+
+  useManagedAccountNotAllowedCallback(isOpen, onClose)
+
   return (
     <Modal
-      isOpen={sendStatus !== null}
+      isOpen={isOpen}
       onClose={onClose}
       bodyClassName={cn(styles.modalBody, {
         [styles.biggerModalBody]: !!audioFeaturesDegradedText

--- a/packages/web/src/components/usdc-purchase-details-modal/components/SaleModalContent.tsx
+++ b/packages/web/src/components/usdc-purchase-details-modal/components/SaleModalContent.tsx
@@ -1,5 +1,6 @@
 import { useCallback } from 'react'
 
+import { useIsManagedAccount } from '@audius/common/hooks'
 import { USDCPurchaseDetails } from '@audius/common/models'
 import {
   chatActions,
@@ -64,6 +65,7 @@ export const SaleModalContent = ({
   onClose
 }: SaleModalContentProps) => {
   const dispatch = useDispatch()
+  const isManagedAccount = useIsManagedAccount()
 
   const { onOpen: openInboxUnavailableModal } = useInboxUnavailableModal()
   const { canCreateChat } = useSelector((state: CommonState) =>
@@ -115,14 +117,16 @@ export const SaleModalContent = ({
           <DetailSection
             label={messages.purchasedBy}
             actionButton={
-              <Button
-                iconLeft={IconMessage}
-                variant='secondary'
-                size='small'
-                onClick={handleClickMessageBuyer}
-              >
-                {messages.sayThanks}
-              </Button>
+              isManagedAccount ? undefined : (
+                <Button
+                  iconLeft={IconMessage}
+                  variant='secondary'
+                  size='small'
+                  onClick={handleClickMessageBuyer}
+                >
+                  {messages.sayThanks}
+                </Button>
+              )
             }
           >
             <UserLink userId={purchaseDetails.buyerUserId} popover size='l' />

--- a/packages/web/src/components/user-name-and-badges/UserNameAndBadges.tsx
+++ b/packages/web/src/components/user-name-and-badges/UserNameAndBadges.tsx
@@ -8,7 +8,7 @@ import { useSelector } from 'react-redux'
 
 import { ArtistPopover } from 'components/artist/ArtistPopover'
 import UserBadges from 'components/user-badges/UserBadges'
-import { useGoToRoute } from 'hooks/useGoToRoute'
+import { useNavigateToPage } from 'hooks/useNavigateToPage'
 import { profilePage } from 'utils/route'
 
 import styles from './UserNameAndBadges.module.css'
@@ -33,14 +33,14 @@ type UserNameAndBadgesProps =
 
 const UserNameAndBadgesImpl = (props: UserNameAndBadgesImplProps) => {
   const { user, onNavigateAway, classes } = props
-  const goToRoute = useGoToRoute()
+  const navigate = useNavigateToPage()
   const handleClick: MouseEventHandler = useCallback(
     (event) => {
       event.stopPropagation()
-      goToRoute(profilePage(user.handle))
+      navigate(profilePage(user.handle))
       onNavigateAway?.()
     },
-    [goToRoute, onNavigateAway, user]
+    [navigate, onNavigateAway, user]
   )
   if (!user) {
     return null

--- a/packages/web/src/hooks/useGoToRoute.ts
+++ b/packages/web/src/hooks/useGoToRoute.ts
@@ -1,9 +1,0 @@
-import { useCallback } from 'react'
-
-import { push as pushRoute } from 'connected-react-router'
-import { useDispatch } from 'react-redux'
-
-export function useGoToRoute() {
-  const dispatch = useDispatch()
-  return useCallback((route: string) => dispatch(pushRoute(route)), [dispatch])
-}

--- a/packages/web/src/hooks/useManagedAccountNotAllowedRedirect.ts
+++ b/packages/web/src/hooks/useManagedAccountNotAllowedRedirect.ts
@@ -35,10 +35,13 @@ export const useManagedAccountNotAllowedRedirect = (
  * @param trigger condition that when true, fires the callback (e.g. modal is open)
  * @param callback callback to fire when the action is performed (e.g. close the modal)
  */
-export const useManagedAccountNotAllowedCallback = (
-  trigger: boolean,
+export const useManagedAccountNotAllowedCallback = ({
+  trigger,
+  callback
+}: {
+  trigger: boolean
   callback: () => void
-) => {
+}) => {
   const isManagedAccount = useIsManagedAccount()
   const { toast } = useContext(ToastContext)
 

--- a/packages/web/src/hooks/useManagedAccountNotAllowedRedirect.ts
+++ b/packages/web/src/hooks/useManagedAccountNotAllowedRedirect.ts
@@ -1,0 +1,51 @@
+import { useContext, useEffect } from 'react'
+
+import { useIsManagedAccount } from '@audius/common/hooks'
+
+import { ToastContext } from 'components/toast/ToastContext'
+import { FEED_PAGE } from 'utils/route'
+
+import { useNavigateToPage } from './useNavigateToPage'
+
+const messages = {
+  unauthorized: `You can't do that as a managed user`
+}
+
+/**
+ * Hook to redirect a managed account from accessing a particular route
+ * @param route route to redirect the user to
+ */
+export const useManagedAccountNotAllowedRedirect = (
+  route: string = FEED_PAGE
+) => {
+  const isManagedAccount = useIsManagedAccount()
+  const navigate = useNavigateToPage()
+  const { toast } = useContext(ToastContext)
+
+  useEffect(() => {
+    if (isManagedAccount) {
+      navigate(route)
+      toast(messages.unauthorized)
+    }
+  }, [isManagedAccount, navigate, route, toast])
+}
+
+/**
+ * Hook to prevent a managed account from some action (e.g. opening a modal)
+ * @param trigger condition that when true, fires the callback (e.g. modal is open)
+ * @param callback callback to fire when the action is performed (e.g. close the modal)
+ */
+export const useManagedAccountNotAllowedCallback = (
+  trigger: boolean,
+  callback: () => void
+) => {
+  const isManagedAccount = useIsManagedAccount()
+  const { toast } = useContext(ToastContext)
+
+  useEffect(() => {
+    if (isManagedAccount && trigger) {
+      callback()
+      toast(messages.unauthorized)
+    }
+  }, [isManagedAccount, callback, toast, trigger])
+}

--- a/packages/web/src/pages/audio-rewards-page/components/WalletManagementTile.tsx
+++ b/packages/web/src/pages/audio-rewards-page/components/WalletManagementTile.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useContext, useEffect, useMemo } from 'react'
 
+import { useIsManagedAccount } from '@audius/common/hooks'
 import { Client, BNWei } from '@audius/common/models'
 import { StringKeys, FeatureFlags, Location } from '@audius/common/services'
 import {
@@ -288,6 +289,7 @@ const ManageWalletsButton = () => {
   )
 }
 export const WalletManagementTile = () => {
+  const isManagedAccount = useIsManagedAccount()
   const totalBalance = useSelector(getAccountTotalBalance)
   const hasMultipleWallets = useSelector(getHasAssociatedWallets)
   const balanceLoadDidFail = useSelector(getTotalBalanceLoadDidFail)
@@ -348,38 +350,44 @@ export const WalletManagementTile = () => {
         </div>
       </div>
       <div className={styles.container}>
-        {!isMobileWeb() && onRampProviders[primaryProvider].isEnabled ? (
+        {!isManagedAccount &&
+        !isMobileWeb() &&
+        onRampProviders[primaryProvider].isEnabled ? (
           <OnRampTooltipButton
             provider={primaryProvider}
             isDisabled={!isAnyProviderAllowed}
             bannedState={onRampProviders[primaryProvider].bannedState}
           />
         ) : null}
-        <WalletActions />
+        {!isManagedAccount ? (
+          <>
+            <WalletActions />
 
-        <Flex
-          alignItems='center'
-          justifyContent='center'
-          gap='xl'
-          borderTop='default'
-          pt='xl'
-          pb='s'
-          wrap='wrap'
-        >
-          <Text variant='label' size='s' strength='default' color='subdued'>
-            {messages.onRampsPowered}
-          </Text>
-          <IconLogoLinkByStripe
-            width={'6em'}
-            height={'1.33em'}
-            color='subdued'
-          />
-          <IconLogoCoinbasePay
-            width={'6em'}
-            height={'1.33em'}
-            color='subdued'
-          />
-        </Flex>
+            <Flex
+              alignItems='center'
+              justifyContent='center'
+              gap='xl'
+              borderTop='default'
+              pt='xl'
+              pb='s'
+              wrap='wrap'
+            >
+              <Text variant='label' size='s' strength='default' color='subdued'>
+                {messages.onRampsPowered}
+              </Text>
+              <IconLogoLinkByStripe
+                width={'6em'}
+                height={'1.33em'}
+                color='subdued'
+              />
+              <IconLogoCoinbasePay
+                width={'6em'}
+                height={'1.33em'}
+                color='subdued'
+              />
+            </Flex>
+          </>
+        ) : null}
       </div>
     </div>
   )

--- a/packages/web/src/pages/chat-page/ChatPageProvider.tsx
+++ b/packages/web/src/pages/chat-page/ChatPageProvider.tsx
@@ -1,6 +1,7 @@
 import { RouteComponentProps } from 'react-router-dom'
 
 import { useIsMobile } from 'hooks/useIsMobile'
+import { useManagedAccountNotAllowedRedirect } from 'hooks/useManagedAccountNotAllowedRedirect'
 
 import { ChatPage as DesktopChatPage } from './ChatPage'
 import { SkeletonChatPage as MobileChatPage } from './components/mobile/SkeletonChatPage'
@@ -13,9 +14,11 @@ export const ChatPageProvider = ({
   any,
   { presetMessage?: string } | undefined
 >) => {
+  useManagedAccountNotAllowedRedirect()
   const currentChatId = match.params.id
   const presetMessage = location.state?.presetMessage
   const isMobile = useIsMobile()
+
   if (isMobile) {
     return <MobileChatPage />
   }

--- a/packages/web/src/pages/chat-page/components/ChatUser.tsx
+++ b/packages/web/src/pages/chat-page/components/ChatUser.tsx
@@ -6,7 +6,7 @@ import cn from 'classnames'
 import { ArtistPopover } from 'components/artist/ArtistPopover'
 import { ProfilePicture } from 'components/notification/Notification/components/ProfilePicture'
 import UserBadges from 'components/user-badges/UserBadges'
-import { useGoToRoute } from 'hooks/useGoToRoute'
+import { useNavigateToPage } from 'hooks/useNavigateToPage'
 import { profilePage } from 'utils/route'
 
 import styles from './ChatUser.module.css'
@@ -20,10 +20,10 @@ export const ChatUser = ({
   children?: ReactNode
   textClassName?: string
 }) => {
-  const goToRoute = useGoToRoute()
+  const navigate = useNavigateToPage()
   const goToProfile = useCallback(
-    () => goToRoute(profilePage(user.handle)),
-    [goToRoute, user]
+    () => navigate(profilePage(user.handle)),
+    [navigate, user]
   )
 
   return (

--- a/packages/web/src/pages/dashboard-page/components/ArtistDashboardAlbumsTab.tsx
+++ b/packages/web/src/pages/dashboard-page/components/ArtistDashboardAlbumsTab.tsx
@@ -8,7 +8,7 @@ import {
   CollectionsTable,
   CollectionsTableColumn
 } from 'components/collections-table'
-import { useGoToRoute } from 'hooks/useGoToRoute'
+import { useNavigateToPage } from 'hooks/useNavigateToPage'
 
 import styles from '../DashboardPage.module.css'
 import { makeGetDashboard } from '../store/selectors'
@@ -37,7 +37,7 @@ export const ArtistDashboardAlbumsTab = ({
   selectedFilter,
   filterText
 }: ArtistDashboardAlbumsTabProps) => {
-  const goToRoute = useGoToRoute()
+  const navigate = useNavigateToPage()
   const { account } = useSelector(makeGetDashboard())
   const filteredData = useFilteredAlbumData({
     selectedFilter,
@@ -47,9 +47,9 @@ export const ArtistDashboardAlbumsTab = ({
   const onClickRow = useCallback(
     (collection: any) => {
       if (!account) return
-      goToRoute(collection.permalink)
+      navigate(collection.permalink)
     },
-    [account, goToRoute]
+    [account, navigate]
   )
 
   return !filteredData.length || !account ? (

--- a/packages/web/src/pages/dashboard-page/components/ArtistDashboardTracksTab.tsx
+++ b/packages/web/src/pages/dashboard-page/components/ArtistDashboardTracksTab.tsx
@@ -6,7 +6,7 @@ import { Flex } from '@audius/harmony'
 import { useDispatch, useSelector } from 'react-redux'
 
 import { TracksTable, TracksTableColumn } from 'components/tracks-table'
-import { useGoToRoute } from 'hooks/useGoToRoute'
+import { useNavigateToPage } from 'hooks/useNavigateToPage'
 
 import styles from '../DashboardPage.module.css'
 import { getDashboardTracksStatus, makeGetDashboard } from '../store/selectors'
@@ -39,7 +39,7 @@ export const ArtistDashboardTracksTab = ({
   filterText
 }: ArtistDashboardTracksTabProps) => {
   const dispatch = useDispatch()
-  const goToRoute = useGoToRoute()
+  const navigate = useNavigateToPage()
   const tracksStatus = useSelector(getDashboardTracksStatus)
   const { account } = useSelector(makeGetDashboard())
   const filteredData = useFilteredTrackData({
@@ -59,9 +59,9 @@ export const ArtistDashboardTracksTab = ({
   const onClickRow = useCallback(
     (track: any) => {
       if (!account) return
-      goToRoute(track.permalink)
+      navigate(track.permalink)
     },
-    [account, goToRoute]
+    [account, navigate]
   )
 
   return !filteredData.length || !account ? (

--- a/packages/web/src/pages/edit-page/components/AnchoredSubmitRowEdit.tsx
+++ b/packages/web/src/pages/edit-page/components/AnchoredSubmitRowEdit.tsx
@@ -4,7 +4,7 @@ import { Button, Flex, IconError, Text } from '@audius/harmony'
 import { useFormikContext } from 'formik'
 
 import { useHistoryContext } from 'app/HistoryProvider'
-import { useGoToRoute } from 'hooks/useGoToRoute'
+import { useNavigateToPage } from 'hooks/useNavigateToPage'
 import { FEED_PAGE } from 'utils/route'
 
 import { EditFormScrollContext } from '../EditTrackPage'
@@ -30,7 +30,7 @@ export const AnchoredSubmitRowEdit = () => {
   }, [isValid])
 
   const { history } = useHistoryContext()
-  const goToRoute = useGoToRoute()
+  const navigate = useNavigateToPage()
 
   return (
     <>
@@ -40,7 +40,7 @@ export const AnchoredSubmitRowEdit = () => {
             variant='secondary'
             size='default'
             onClick={() =>
-              history.length > 0 ? history.goBack() : goToRoute(FEED_PAGE)
+              history.length > 0 ? history.goBack() : navigate(FEED_PAGE)
             }
           >
             {messages.cancel}

--- a/packages/web/src/pages/pay-and-earn-page/components/USDCCard.tsx
+++ b/packages/web/src/pages/pay-and-earn-page/components/USDCCard.tsx
@@ -1,6 +1,6 @@
 import { useCallback } from 'react'
 
-import { useUSDCBalance } from '@audius/common/hooks'
+import { useIsManagedAccount, useUSDCBalance } from '@audius/common/hooks'
 import { Name, Status, BNUSDC } from '@audius/common/models'
 import {
   WithdrawUSDCModalPages,
@@ -42,6 +42,7 @@ const messages = {
 }
 
 export const USDCCard = () => {
+  const isManagedAccount = useIsManagedAccount()
   const { onOpen: openWithdrawUSDCModal } = useWithdrawUSDCModal()
   const { onOpen: openAddFundsModal } = useAddFundsModal()
   const { data: balance, status: balanceStatus } = useUSDCBalance()
@@ -123,28 +124,30 @@ export const USDCCard = () => {
           </PlainButton>
         </div>
       </div>
-      <div className={styles.withdrawContainer}>
-        <div className={styles.addFundsButton}>
-          <Button
-            variant='secondary'
-            fullWidth
-            onClick={handleAddFunds}
-            disabled={balanceStatus === Status.LOADING}
-          >
-            {messages.addFunds}
-          </Button>
+      {!isManagedAccount ? (
+        <div className={styles.withdrawContainer}>
+          <div className={styles.addFundsButton}>
+            <Button
+              variant='secondary'
+              fullWidth
+              onClick={handleAddFunds}
+              disabled={balanceStatus === Status.LOADING}
+            >
+              {messages.addFunds}
+            </Button>
+          </div>
+          <div className={styles.withdrawButton}>
+            <Button
+              variant='secondary'
+              fullWidth
+              onClick={handleWithdraw}
+              disabled={balanceStatus === Status.LOADING}
+            >
+              {messages.withdraw}
+            </Button>
+          </div>
         </div>
-        <div className={styles.withdrawButton}>
-          <Button
-            variant='secondary'
-            fullWidth
-            onClick={handleWithdraw}
-            disabled={balanceStatus === Status.LOADING}
-          >
-            {messages.withdraw}
-          </Button>
-        </div>
-      </div>
+      ) : null}
     </Paper>
   )
 }

--- a/packages/web/src/pages/saved-page/components/desktop/AlbumsTabPage.tsx
+++ b/packages/web/src/pages/saved-page/components/desktop/AlbumsTabPage.tsx
@@ -13,8 +13,9 @@ import { CollectionCard } from 'components/collection'
 import { InfiniteCardLineup } from 'components/lineup/InfiniteCardLineup'
 import LoadingSpinner from 'components/loading-spinner/LoadingSpinner'
 import EmptyTable from 'components/tracks-table/EmptyTable'
-import { useGoToRoute } from 'hooks/useGoToRoute'
+import { useNavigateToPage } from 'hooks/useNavigateToPage'
 import { useCollectionsData } from 'pages/saved-page/hooks/useCollectionsData'
+import { TRENDING_PAGE } from 'utils/route'
 
 import { emptyStateMessages } from '../emptyStateMessages'
 
@@ -28,7 +29,7 @@ const messages = {
 }
 
 export const AlbumsTabPage = () => {
-  const goToRoute = useGoToRoute()
+  const navigate = useNavigateToPage()
   const {
     status,
     hasMore,
@@ -72,7 +73,7 @@ export const AlbumsTabPage = () => {
         primaryText={emptyAlbumsHeader}
         secondaryText={messages.emptyAlbumsBody}
         buttonLabel={messages.goToTrending}
-        onClick={() => goToRoute('/trending')}
+        onClick={() => navigate(TRENDING_PAGE)}
       />
     )
   }

--- a/packages/web/src/pages/saved-page/components/mobile/SavedPage.tsx
+++ b/packages/web/src/pages/saved-page/components/mobile/SavedPage.tsx
@@ -39,7 +39,7 @@ import MobilePageContainer from 'components/mobile-page-container/MobilePageCont
 import { useMainPageHeader } from 'components/nav/mobile/NavContext'
 import TrackList from 'components/track/mobile/TrackList'
 import { TrackItemAction } from 'components/track/mobile/TrackListItem'
-import { useGoToRoute } from 'hooks/useGoToRoute'
+import { useNavigateToPage } from 'hooks/useNavigateToPage'
 import useTabs from 'hooks/useTabs/useTabs'
 import { useCollectionsData } from 'pages/saved-page/hooks/useCollectionsData'
 import { TRENDING_PAGE } from 'utils/route'
@@ -287,7 +287,7 @@ const TracksLineup = ({
 }
 
 const AlbumCardLineup = () => {
-  const goToRoute = useGoToRoute()
+  const navigate = useNavigateToPage()
 
   const [filterText, setFilterText] = useState('')
   const {
@@ -316,8 +316,8 @@ const AlbumCardLineup = () => {
   })
 
   const handleGoToTrending = useCallback(
-    () => goToRoute(TRENDING_PAGE),
-    [goToRoute]
+    () => navigate(TRENDING_PAGE),
+    [navigate]
   )
   const debouncedSetFilter = useDebouncedCallback(
     (value: string) => {

--- a/packages/web/src/pages/settings-page/components/desktop/ManagerMode/AccountListItem.tsx
+++ b/packages/web/src/pages/settings-page/components/desktop/ManagerMode/AccountListItem.tsx
@@ -19,7 +19,7 @@ import {
 } from '@audius/harmony'
 
 import ArtistChip from 'components/artist/ArtistChip'
-import { useGoToRoute } from 'hooks/useGoToRoute'
+import { useNavigateToPage } from 'hooks/useNavigateToPage'
 import { useComposeChat } from 'pages/chat-page/components/useComposeChat'
 import { useSelector } from 'utils/reducer'
 import { profilePage } from 'utils/route'
@@ -66,11 +66,11 @@ export const AccountListItem = ({
 }: AccountListItemProps) => {
   const currentUserId = useSelector(getUserId)
 
-  const goToRoute = useGoToRoute()
+  const navigate = useNavigateToPage()
   const goToProfile = useCallback(() => {
     if (!user) return
-    goToRoute(profilePage(user.handle))
-  }, [goToRoute, user])
+    navigate(profilePage(user.handle))
+  }, [navigate, user])
 
   const { switchAccount } = useAccountSwitcher()
 

--- a/packages/web/src/pages/settings-page/components/desktop/NotificationSettings.tsx
+++ b/packages/web/src/pages/settings-page/components/desktop/NotificationSettings.tsx
@@ -1,5 +1,6 @@
 import { useCallback } from 'react'
 
+import { useIsManagedAccount } from '@audius/common/hooks'
 import {
   BrowserNotificationSetting,
   EmailFrequency,
@@ -73,6 +74,7 @@ type NotificationSettingsProps = {
 }
 
 const NotificationSettings = (props: NotificationSettingsProps) => {
+  const isManagedAccount = useIsManagedAccount()
   const browserPushEnabled =
     props.settings[BrowserNotificationSetting.BrowserPush]
   const notificationToggles = [
@@ -142,7 +144,7 @@ const NotificationSettings = (props: NotificationSettingsProps) => {
           <div className={styles.title}>{messages.title}</div>
         </div>
         <div className={styles.divider}></div>
-        {!isElectron() && (
+        {!isElectron() && !isManagedAccount ? (
           <>
             <div className={styles.description}>
               <ToggleNotification
@@ -168,7 +170,7 @@ const NotificationSettings = (props: NotificationSettingsProps) => {
             </div>
             <div className={styles.divider}></div>
           </>
-        )}
+        ) : null}
         <div className={styles.emailContainer}>
           <div className={cn(styles.bodyText, styles.email)}>
             {messages.emailFrequency}

--- a/packages/web/src/pages/settings-page/components/desktop/SettingsPage.tsx
+++ b/packages/web/src/pages/settings-page/components/desktop/SettingsPage.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useMemo, useState } from 'react'
 
+import { useIsManagedAccount } from '@audius/common/hooks'
 import { ID, Name, OS, ProfilePictureSizes, Theme } from '@audius/common/models'
 import { FeatureFlags } from '@audius/common/services'
 import {
@@ -189,6 +190,7 @@ export const SettingsPage = (props: SettingsPageProps) => {
     updateEmailFrequency,
     emailFrequency
   } = props
+  const isManagedAccount = useIsManagedAccount()
 
   const [isSignOutModalVisible, setIsSignOutModalVisible] = useState(false)
   const [
@@ -327,34 +329,38 @@ export const SettingsPage = (props: SettingsPageProps) => {
       header={header}
     >
       <div className={styles.settings}>
-        <SettingsCard
-          icon={<IconAppearance />}
-          title={messages.appearanceCardTitle}
-          description={messages.appearanceCardDescription}
-        >
-          <SegmentedControl
-            fullWidth
-            label={messages.appearanceCardTitle}
-            options={appearanceOptions}
-            selected={theme || Theme.DEFAULT}
-            onSelectOption={(option) => toggleTheme(option)}
-            key={`tab-slider-${appearanceOptions.length}`}
-          />
-        </SettingsCard>
-        {isPayoutWalletEnabled ? <PayoutWalletSettingsCard /> : null}
-        <SettingsCard
-          icon={<IconMessage />}
-          title={messages.inboxSettingsCardTitle}
-          description={messages.inboxSettingsCardDescription}
-        >
-          <Button
-            variant='secondary'
-            onClick={openInboxSettingsModal}
-            fullWidth
+        {!isManagedAccount ? (
+          <SettingsCard
+            icon={<IconAppearance />}
+            title={messages.appearanceCardTitle}
+            description={messages.appearanceCardDescription}
           >
-            {messages.inboxSettingsButtonText}
-          </Button>
-        </SettingsCard>
+            <SegmentedControl
+              fullWidth
+              label={messages.appearanceCardTitle}
+              options={appearanceOptions}
+              selected={theme || Theme.DEFAULT}
+              onSelectOption={(option) => toggleTheme(option)}
+              key={`tab-slider-${appearanceOptions.length}`}
+            />
+          </SettingsCard>
+        ) : null}
+        {isPayoutWalletEnabled ? <PayoutWalletSettingsCard /> : null}
+        {!isManagedAccount ? (
+          <SettingsCard
+            icon={<IconMessage />}
+            title={messages.inboxSettingsCardTitle}
+            description={messages.inboxSettingsCardDescription}
+          >
+            <Button
+              variant='secondary'
+              onClick={openInboxSettingsModal}
+              fullWidth
+            >
+              {messages.inboxSettingsButtonText}
+            </Button>
+          </SettingsCard>
+        ) : null}
         <SettingsCard
           icon={<IconNotification />}
           title={messages.notificationsCardTitle}
@@ -368,45 +374,55 @@ export const SettingsPage = (props: SettingsPageProps) => {
             {messages.notificationsButtonText}
           </Button>
         </SettingsCard>
-        <SettingsCard
-          icon={<IconMail />}
-          title={messages.accountRecoveryCardTitle}
-          description={messages.accountRecoveryCardDescription}
-        >
-          <Toast
-            tooltipClassName={styles.cardToast}
-            text={emailToastText}
-            open={isEmailToastVisible}
-            placement={ComponentPlacement.BOTTOM}
-            fillParent={false}
+        {!isManagedAccount ? (
+          <SettingsCard
+            icon={<IconMail />}
+            title={messages.accountRecoveryCardTitle}
+            description={messages.accountRecoveryCardDescription}
           >
-            <Button onClick={showEmailToast} variant='secondary' fullWidth>
-              {messages.accountRecoveryButtonText}
+            <Toast
+              tooltipClassName={styles.cardToast}
+              text={emailToastText}
+              open={isEmailToastVisible}
+              placement={ComponentPlacement.BOTTOM}
+              fillParent={false}
+            >
+              <Button onClick={showEmailToast} variant='secondary' fullWidth>
+                {messages.accountRecoveryButtonText}
+              </Button>
+            </Toast>
+          </SettingsCard>
+        ) : null}
+        {!isManagedAccount ? (
+          <SettingsCard
+            icon={<IconEmailAddress />}
+            title={messages.changeEmailCardTitle}
+            description={messages.changeEmailCardDescription}
+          >
+            <Button
+              onClick={openChangeEmailModal}
+              variant='secondary'
+              fullWidth
+            >
+              {messages.changeEmailButtonText}
             </Button>
-          </Toast>
-        </SettingsCard>
-        <SettingsCard
-          icon={<IconEmailAddress />}
-          title={messages.changeEmailCardTitle}
-          description={messages.changeEmailCardDescription}
-        >
-          <Button onClick={openChangeEmailModal} variant='secondary' fullWidth>
-            {messages.changeEmailButtonText}
-          </Button>
-        </SettingsCard>
-        <SettingsCard
-          icon={<IconKey />}
-          title={messages.changePasswordCardTitle}
-          description={messages.changePasswordCardDescription}
-        >
-          <Button
-            onClick={openChangePasswordModal}
-            variant='secondary'
-            fullWidth
+          </SettingsCard>
+        ) : null}
+        {!isManagedAccount ? (
+          <SettingsCard
+            icon={<IconKey />}
+            title={messages.changePasswordCardTitle}
+            description={messages.changePasswordCardDescription}
           >
-            {messages.changePasswordButtonText}
-          </Button>
-        </SettingsCard>
+            <Button
+              onClick={openChangePasswordModal}
+              variant='secondary'
+              fullWidth
+            >
+              {messages.changePasswordButtonText}
+            </Button>
+          </SettingsCard>
+        ) : null}
         {isManagerModeEnabled ? (
           <>
             <AccountsManagingYouSettingsCard />
@@ -499,13 +515,15 @@ export const SettingsPage = (props: SettingsPageProps) => {
             {messages.privacy}
           </Link>
         </span>
-        <Link
-          className={cn(styles.link, styles.showPrivateKey)}
-          to={PRIVATE_KEY_EXPORTER_SETTINGS_PAGE}
-          onClick={recordExportPrivateKeyLinkClicked}
-        >
-          {messages.showPrivateKey}
-        </Link>
+        {!isManagedAccount ? (
+          <Link
+            className={cn(styles.link, styles.showPrivateKey)}
+            to={PRIVATE_KEY_EXPORTER_SETTINGS_PAGE}
+            onClick={recordExportPrivateKeyLinkClicked}
+          >
+            {messages.showPrivateKey}
+          </Link>
+        ) : null}
       </div>
       <Modal
         isOpen={isSignOutModalVisible}


### PR DESCRIPTION
### Description

Everything in the ticket + some things collected from meeting notes:

========== from ticket ===========

DMs

- Hide menu item in left nav
- Redirect to feed if we land on any chats route
- Hide DM button in artist page
- Hide "Block Messages" menu item in artist page
- Hide DM button in purchase history details modal
- Hide settings tiles that aren't applicable
- Hide "Show Private Key"
- Hide Tipping button on profiles
Show toast for:
- Attempting to open the purchase content modal
- Attempting to open the tip-to-unlock modal

========== from notes ===========

Pay & Earn
    - You should be allowed to see the sales/purchases/withdrawal history
    - Hide “Add Funds” and “Withdraw” buttons
Audio page
    - Rewards should show audio balance, but no buttons
Messages
    - Drop you back to the feed with a toast “No authorized”
Settings
    - Hide export private key
    - Hide tiles
        1. Appearance tile
            - Because this is local
        2. Change email
        3. Change password
        4. Recovery email
        5. Inbox settings
        6. Notifications: Browser Push Notifications
            - Can keep the “live/daily/weekly”

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._


```
npm run web:stage
```
lots of click around
