### PR TITLE
[PAY-3057][PAY-3099][PAY-3065] Fix misc account switcher UI issues

### DIFF
--- a/packages/libs/src/api/Account.ts
+++ b/packages/libs/src/api/Account.ts
@@ -97,6 +97,7 @@ export class Account extends Base {
     )
     if (userAccount) {
       this.userStateManager.setCurrentUser(userAccount)
+      this.userStateManager.setWeb3User(userAccount)
       const randomNodes = await this.ServiceProvider.autoSelectStorageV2Nodes(
         1,
         userAccount.wallet

--- a/packages/web/src/components/nav/desktop/AccountDetails.tsx
+++ b/packages/web/src/components/nav/desktop/AccountDetails.tsx
@@ -84,8 +84,8 @@ export const AccountDetails = () => {
                     css={{
                       flex: 1,
                       ...(isManagedAccount && {
-                        color: color.text.accent,
-                        '&:hover': { color: color.text.accent }
+                        color: color.secondary.s500,
+                        '&:hover': { color: color.secondary.s500 }
                       })
                     }}
                   />
@@ -96,8 +96,8 @@ export const AccountDetails = () => {
                   to={profileLink}
                   css={
                     isManagedAccount && {
-                      color: color.text.accent,
-                      '&:hover': { color: color.text.accent }
+                      color: color.secondary.s500,
+                      '&:hover': { color: color.secondary.s500 }
                     }
                   }
                 >{`@${account.handle}`}</TextLink>

--- a/packages/web/src/components/nav/desktop/AccountDetails.tsx
+++ b/packages/web/src/components/nav/desktop/AccountDetails.tsx
@@ -75,6 +75,7 @@ export const AccountDetails = () => {
                   alignItems='center'
                   justifyContent='space-between'
                   gap='s'
+                  h={20}
                 >
                   <UserLink
                     textVariant='title'

--- a/packages/web/src/components/nav/desktop/AccountSwitcher/AccountSwitcher.tsx
+++ b/packages/web/src/components/nav/desktop/AccountSwitcher/AccountSwitcher.tsx
@@ -7,15 +7,21 @@ import {
 } from '@audius/common/api'
 import { useAccountSwitcher } from '@audius/common/hooks'
 import { UserMetadata } from '@audius/common/models'
+import { accountSelectors } from '@audius/common/store'
 import { Box, IconButton, IconCaretDown, Popup } from '@audius/harmony'
+import { useSelector } from 'react-redux'
 
 import { AccountListContent } from './AccountListContent'
 
 export const AccountSwitcher = () => {
   const [isExpanded, setIsExpanded] = useState(false)
+  const userId = useSelector(accountSelectors.getUserId)
 
-  const { data: currentWeb3User } = useGetCurrentWeb3User({})
-  const { data: currentUserId } = useGetCurrentUserId({})
+  const { data: currentWeb3User } = useGetCurrentWeb3User(
+    {},
+    { disabled: !userId }
+  )
+  const { data: currentUserId } = useGetCurrentUserId({}, { disabled: !userId })
 
   const { switchAccount } = useAccountSwitcher()
 

--- a/packages/web/src/components/nav/desktop/AccountSwitcher/AccountSwitcherRow.tsx
+++ b/packages/web/src/components/nav/desktop/AccountSwitcher/AccountSwitcherRow.tsx
@@ -67,7 +67,9 @@ export const AccountSwitcherRow = ({
           <Text
             variant='title'
             size='m'
-            color={isSelected ? 'accent' : 'default'}
+            css={{
+              color: isSelected ? color.secondary.s500 : color.neutral.neutral
+            }}
           >
             {user.name}
           </Text>
@@ -76,7 +78,9 @@ export const AccountSwitcherRow = ({
         <Text
           variant='body'
           size='s'
-          color={isSelected ? 'accent' : 'default'}
+          css={{
+            color: isSelected ? color.secondary.s500 : color.neutral.neutral
+          }}
         >{`@${user.handle}`}</Text>
       </Flex>
     </Flex>


### PR DESCRIPTION
### Description

* Use s500 for text so dark mode is better
* Fix jitter on load due to height changing when switcher pops in
* Fix account switcher load on first login. This is b/c sign in doesn't set web3 user and the hooks run before any user is signed in

Can review commit by commit

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._

```
npm run web:stage
```