### PR TITLE
[C-4542] OptionsFilterButton improvements

### DIFF
--- a/packages/harmony/src/components/button/FilterButton/FilterButton.tsx
+++ b/packages/harmony/src/components/button/FilterButton/FilterButton.tsx
@@ -1,4 +1,4 @@
-import { forwardRef, useRef, useState, useCallback } from 'react'
+import { forwardRef, useRef, useState, useCallback, useEffect } from 'react'
 
 import { CSSObject, useTheme } from '@emotion/react'
 
@@ -16,6 +16,7 @@ export const FilterButton = forwardRef<HTMLButtonElement, FilterButtonProps>(
       label: labelProp,
       onChange,
       onClick,
+      onOpen,
       onReset,
       disabled,
       variant = 'fillContainer',
@@ -137,6 +138,12 @@ export const FilterButton = forwardRef<HTMLButtonElement, FilterButtonProps>(
       onClick,
       onReset
     ])
+
+    useEffect(() => {
+      if (isOpen) {
+        onOpen?.()
+      }
+    }, [isOpen, onOpen])
 
     const handleChange = useCallback(
       (value: string, label: string) => {

--- a/packages/harmony/src/components/button/FilterButton/FilterButton.tsx
+++ b/packages/harmony/src/components/button/FilterButton/FilterButton.tsx
@@ -80,6 +80,11 @@ export const FilterButton = forwardRef<HTMLButtonElement, FilterButtonProps>(
           }
         : {}
 
+    const hoverStyle = {
+      border: `1px solid ${color.neutral.n800}`,
+      transform: 'none'
+    }
+
     // Button Styles
     const buttonCss: CSSObject = {
       background: 'transparent',
@@ -95,10 +100,8 @@ export const FilterButton = forwardRef<HTMLButtonElement, FilterButtonProps>(
       lineHeight: typography.lineHeight.s,
       opacity: disabled ? 0.6 : 1,
 
-      '&:hover': {
-        border: `1px solid ${color.neutral.n800}`,
-        transform: 'none'
-      },
+      '&:hover': hoverStyle,
+      '&:focus': hoverStyle,
 
       '&:active': {
         ...activeStyle,

--- a/packages/harmony/src/components/button/FilterButton/types.ts
+++ b/packages/harmony/src/components/button/FilterButton/types.ts
@@ -88,6 +88,11 @@ export type FilterButtonProps = {
   onChange?: (value: string) => void
 
   /**
+   * What to do when the filter button is opened
+   */
+  onOpen?: () => void
+
+  /**
    * If provided, will be called when the selected value is reset
    */
   onReset?: () => void

--- a/packages/harmony/src/components/button/OptionsFilterButton/OptionsFilterButton.tsx
+++ b/packages/harmony/src/components/button/OptionsFilterButton/OptionsFilterButton.tsx
@@ -1,4 +1,11 @@
-import { forwardRef, RefObject, useState, useCallback, useRef } from 'react'
+import {
+  forwardRef,
+  RefObject,
+  useState,
+  useCallback,
+  useRef,
+  useMemo
+} from 'react'
 
 import { CSSObject, useTheme } from '@emotion/react'
 
@@ -13,22 +20,33 @@ import { IconCaretDown, IconSearch } from 'icons'
 import { FilterButton } from '../FilterButton/FilterButton'
 
 import { OptionsFilterButtonProps, OptionsFilterButtonOption } from './types'
+import { SelectPopupKeyHandler } from './SelectPopupKeyHandler'
+
+const messages = {
+  noMatches: 'No matches'
+}
 
 type FilterButtonOptionsProps = {
+  activeValue?: string | null
   options: OptionsFilterButtonOption[]
+  optionRefs?: RefObject<HTMLButtonElement[]>
   onChange: (option: OptionsFilterButtonOption) => void
 }
 
-export const FilterButtonOptions = ({
-  options,
-  onChange
-}: FilterButtonOptionsProps) => {
+export const FilterButtonOptions = (props: FilterButtonOptionsProps) => {
+  const { activeValue, options, onChange, optionRefs } = props
   const { color, cornerRadius, spacing, typography } = useTheme()
 
   // Popup Styles
   const optionIconCss: CSSObject = {
     width: spacing.unit4,
     height: spacing.unit4
+  }
+
+  const activeOptionCss: CSSObject = {
+    transform: 'none',
+    backgroundColor: color.secondary.s300,
+    color: color.special.white
   }
 
   const optionCss: CSSObject = {
@@ -45,30 +63,44 @@ export const FilterButtonOptions = ({
     borderRadius: cornerRadius.s,
     justifyContent: 'flex-start',
 
-    '&:hover': {
-      transform: 'none',
-      backgroundColor: color.secondary.s300,
-      color: color.special.white
-    },
+    '&:hover': activeOptionCss,
 
     '&:active': {
       transform: 'none'
     }
   }
 
+  if (!options.length) {
+    return (
+      <Flex justifyContent='center'>
+        <Text variant='body' color='subdued' size='s'>
+          {messages.noMatches}
+        </Text>
+      </Flex>
+    )
+  }
+
   return (
-    <>
-      {options.map((option) => (
+    <Flex direction='column'>
+      {options.map((option, index) => (
         <BaseButton
           key={option.value}
           iconLeft={option.icon}
           styles={{
-            button: optionCss,
+            button: {
+              ...optionCss,
+              ...(option.value === activeValue ? activeOptionCss : {})
+            },
             icon: optionIconCss
           }}
           onClick={() => onChange(option)}
           aria-label={option.label ?? option.value}
           role='option'
+          ref={(el) => {
+            if (optionRefs && optionRefs.current && el) {
+              optionRefs.current[index] = el
+            }
+          }}
         >
           {option.leadingElement ?? null}
           <Text variant='body' strength='strong'>
@@ -81,7 +113,7 @@ export const FilterButtonOptions = ({
           ) : null}
         </BaseButton>
       ))}
-    </>
+    </Flex>
   )
 }
 
@@ -102,6 +134,7 @@ export const OptionsFilterButton = forwardRef<
     popupZIndex,
     ...filterButtonProps
   } = props
+
   const [selection, setSelection] = useControlled({
     controlledProp: selectionProp,
     defaultValue: null,
@@ -113,12 +146,18 @@ export const OptionsFilterButton = forwardRef<
   const selectedOption = options.find((option) => option.value === selection)
   const selectedLabel = selectedOption?.label ?? selectedOption?.value
   const inputRef = useRef<HTMLInputElement>(null)
+  const optionRefs = useRef([])
+  const scrollRef = useRef<HTMLDivElement>(null)
 
   const handleOptionSelect = useCallback(
-    (handleChange: (value: string, label: string) => void) =>
+    (
+        handleChange: (value: string, label: string) => void,
+        setIsOpen: (isOpen: boolean) => void
+      ) =>
       (option: OptionsFilterButtonOption) => {
         setSelection(option.value)
         handleChange(option.value, option.label ?? '')
+        setIsOpen(false)
       },
     [setSelection]
   )
@@ -130,6 +169,17 @@ export const OptionsFilterButton = forwardRef<
     }, 0)
   }, [inputRef])
 
+  const filteredOptions = useMemo(
+    () =>
+      options.filter(({ label }) => {
+        return (
+          !filterInputValue ||
+          label?.toLowerCase().includes(filterInputValue.toLowerCase())
+        )
+      }),
+    [options, filterInputValue]
+  )
+
   return (
     <FilterButton
       iconRight={IconCaretDown}
@@ -140,70 +190,80 @@ export const OptionsFilterButton = forwardRef<
       label={selectedLabel ?? filterButtonProps.label}
     >
       {({ isOpen, setIsOpen, handleChange, anchorRef }) => (
-        <Popup
-          anchorRef={(ref as RefObject<HTMLElement>) || anchorRef}
-          isVisible={isOpen}
-          onClose={() => setIsOpen(false)}
-          anchorOrigin={popupAnchorOrigin}
-          transformOrigin={popupTransformOrigin}
-          portalLocation={popupPortalLocation}
-          zIndex={popupZIndex}
-          onAfterClose={() => setFilterInputValue('')}
+        <SelectPopupKeyHandler
+          options={filteredOptions}
+          disabled={!isOpen}
+          onOptionSelect={handleOptionSelect(handleChange, setIsOpen)}
+          optionRefs={optionRefs}
+          scrollRef={scrollRef}
         >
-          <Paper mt='s' border='strong' shadow='far'>
-            <Flex
-              p='s'
-              direction='column'
-              alignItems='flex-start'
-              role='listbox'
-              aria-label={
-                selectedLabel ?? filterButtonProps.label ?? props['aria-label']
-              }
-              aria-activedescendant={selectedLabel}
-              css={{ maxHeight: popupMaxHeight, overflowY: 'auto' }}
+          {(activeValue) => (
+            <Popup
+              anchorRef={(ref as RefObject<HTMLElement>) || anchorRef}
+              isVisible={isOpen}
+              onClose={() => setIsOpen(false)}
+              anchorOrigin={popupAnchorOrigin}
+              transformOrigin={popupTransformOrigin}
+              portalLocation={popupPortalLocation}
+              zIndex={popupZIndex}
+              onAfterClose={() => setFilterInputValue('')}
             >
-              <Flex direction='column' w='100%' gap='s'>
-                {showFilterInput ? (
-                  <TextInput
-                    ref={inputRef}
-                    placeholder={filterInputPlaceholder}
-                    label={filterInputPlaceholder}
-                    size={TextInputSize.SMALL}
-                    startIcon={IconSearch}
-                    onClick={(e) => {
-                      e.stopPropagation()
-                    }}
-                    onChange={(e) => {
-                      setFilterInputValue(e.target.value)
-                    }}
-                  />
-                ) : null}
-                {optionsLabel ? (
-                  <Box pt='s' ph='m'>
-                    <Text variant='label' size='xs'>
-                      {optionsLabel}
-                    </Text>
-                  </Box>
-                ) : null}
-                <Flex direction='column'>
-                  <FilterButtonOptions
-                    options={options.filter(({ label }) => {
-                      return (
-                        !filterInputValue ||
-                        label
-                          ?.toLowerCase()
-                          .includes(filterInputValue.toLowerCase())
-                      )
-                    })}
-                    onChange={(option) =>
-                      handleOptionSelect(handleChange)(option)
-                    }
-                  />
+              <Paper
+                mt='s'
+                border='strong'
+                shadow='far'
+                onClick={(e) => e.stopPropagation()}
+              >
+                <Flex
+                  p='s'
+                  direction='column'
+                  alignItems='flex-start'
+                  role='listbox'
+                  aria-label={
+                    selectedLabel ??
+                    filterButtonProps.label ??
+                    props['aria-label']
+                  }
+                  aria-activedescendant={selectedLabel}
+                  css={{ maxHeight: popupMaxHeight, overflowY: 'auto' }}
+                  ref={scrollRef}
+                >
+                  <Flex direction='column' w='100%' gap='s'>
+                    {showFilterInput ? (
+                      <TextInput
+                        ref={inputRef}
+                        placeholder={filterInputPlaceholder}
+                        label={filterInputPlaceholder}
+                        size={TextInputSize.SMALL}
+                        startIcon={IconSearch}
+                        onClick={(e) => {
+                          e.stopPropagation()
+                        }}
+                        onChange={(e) => {
+                          setFilterInputValue(e.target.value)
+                        }}
+                        autoComplete='off'
+                      />
+                    ) : null}
+                    {optionsLabel ? (
+                      <Box pt='s' ph='m'>
+                        <Text variant='label' size='xs'>
+                          {optionsLabel}
+                        </Text>
+                      </Box>
+                    ) : null}
+                    <FilterButtonOptions
+                      activeValue={activeValue}
+                      options={filteredOptions}
+                      optionRefs={optionRefs}
+                      onChange={handleOptionSelect(handleChange, setIsOpen)}
+                    />
+                  </Flex>
                 </Flex>
-              </Flex>
-            </Flex>
-          </Paper>
-        </Popup>
+              </Paper>
+            </Popup>
+          )}
+        </SelectPopupKeyHandler>
       )}
     </FilterButton>
   )

--- a/packages/harmony/src/components/button/OptionsFilterButton/OptionsFilterButton.tsx
+++ b/packages/harmony/src/components/button/OptionsFilterButton/OptionsFilterButton.tsx
@@ -1,4 +1,4 @@
-import { forwardRef, RefObject, useState, useCallback } from 'react'
+import { forwardRef, RefObject, useState, useCallback, useRef } from 'react'
 
 import { CSSObject, useTheme } from '@emotion/react'
 
@@ -112,6 +112,7 @@ export const OptionsFilterButton = forwardRef<
   const [filterInputValue, setFilterInputValue] = useState('')
   const selectedOption = options.find((option) => option.value === selection)
   const selectedLabel = selectedOption?.label ?? selectedOption?.value
+  const inputRef = useRef<HTMLInputElement>(null)
 
   const handleOptionSelect = useCallback(
     (handleChange: (value: string, label: string) => void) =>
@@ -122,11 +123,19 @@ export const OptionsFilterButton = forwardRef<
     [setSelection]
   )
 
+  const handleOpen = useCallback(() => {
+    // Focus the input after the popup is open
+    setTimeout(() => {
+      inputRef.current?.focus({ preventScroll: true })
+    }, 0)
+  }, [inputRef])
+
   return (
     <FilterButton
       iconRight={IconCaretDown}
       {...filterButtonProps}
       value={selection}
+      onOpen={handleOpen}
       onReset={() => setFilterInputValue('')}
       label={selectedLabel ?? filterButtonProps.label}
     >
@@ -156,6 +165,7 @@ export const OptionsFilterButton = forwardRef<
               <Flex direction='column' w='100%' gap='s'>
                 {showFilterInput ? (
                   <TextInput
+                    ref={inputRef}
                     placeholder={filterInputPlaceholder}
                     label={filterInputPlaceholder}
                     size={TextInputSize.SMALL}
@@ -175,19 +185,21 @@ export const OptionsFilterButton = forwardRef<
                     </Text>
                   </Box>
                 ) : null}
-                <FilterButtonOptions
-                  options={options.filter(({ label }) => {
-                    return (
-                      !filterInputValue ||
-                      label
-                        ?.toLowerCase()
-                        .includes(filterInputValue.toLowerCase())
-                    )
-                  })}
-                  onChange={(option) =>
-                    handleOptionSelect(handleChange)(option)
-                  }
-                />
+                <Flex direction='column'>
+                  <FilterButtonOptions
+                    options={options.filter(({ label }) => {
+                      return (
+                        !filterInputValue ||
+                        label
+                          ?.toLowerCase()
+                          .includes(filterInputValue.toLowerCase())
+                      )
+                    })}
+                    onChange={(option) =>
+                      handleOptionSelect(handleChange)(option)
+                    }
+                  />
+                </Flex>
               </Flex>
             </Flex>
           </Paper>

--- a/packages/harmony/src/components/button/OptionsFilterButton/OptionsFilterButton.tsx
+++ b/packages/harmony/src/components/button/OptionsFilterButton/OptionsFilterButton.tsx
@@ -19,8 +19,8 @@ import { IconCaretDown, IconSearch } from 'icons'
 
 import { FilterButton } from '../FilterButton/FilterButton'
 
-import { OptionsFilterButtonProps, OptionsFilterButtonOption } from './types'
 import { SelectPopupKeyHandler } from './SelectPopupKeyHandler'
+import { OptionsFilterButtonProps, OptionsFilterButtonOption } from './types'
 
 const messages = {
   noMatches: 'No matches'

--- a/packages/harmony/src/components/button/OptionsFilterButton/SelectPopupKeyHandler.tsx
+++ b/packages/harmony/src/components/button/OptionsFilterButton/SelectPopupKeyHandler.tsx
@@ -14,7 +14,7 @@ type SelectPopupKeyHandlerProps = {
 /**
  * Handles key events for the popup inside the Select component
  *
- * Call the `children` function with the currently active value
+ * Calls the `children` function with the currently active value
  */
 export const SelectPopupKeyHandler = (props: SelectPopupKeyHandlerProps) => {
   const { disabled, options, onOptionSelect, optionRefs, scrollRef, children } =
@@ -43,6 +43,8 @@ export const SelectPopupKeyHandler = (props: SelectPopupKeyHandlerProps) => {
 
       switch (event.key) {
         case 'ArrowUp':
+          event.stopPropagation()
+          event.preventDefault()
           setActiveIndex((prevIndex) => {
             const getNewIndex = () => {
               if (prevIndex === null) {
@@ -59,6 +61,8 @@ export const SelectPopupKeyHandler = (props: SelectPopupKeyHandlerProps) => {
           })
           break
         case 'ArrowDown':
+          event.stopPropagation()
+          event.preventDefault()
           setActiveIndex((prevIndex) => {
             const getNewIndex = () => {
               if (prevIndex === null) {

--- a/packages/harmony/src/components/button/OptionsFilterButton/SelectPopupKeyHandler.tsx
+++ b/packages/harmony/src/components/button/OptionsFilterButton/SelectPopupKeyHandler.tsx
@@ -75,6 +75,8 @@ export const SelectPopupKeyHandler = (props: SelectPopupKeyHandler) => {
           })
           break
         case 'Enter':
+          event.stopPropagation()
+          event.preventDefault()
           if (activeIndex !== null && options[activeIndex]) {
             onOptionSelect(options[activeIndex])
           }

--- a/packages/harmony/src/components/button/OptionsFilterButton/SelectPopupKeyHandler.tsx
+++ b/packages/harmony/src/components/button/OptionsFilterButton/SelectPopupKeyHandler.tsx
@@ -2,7 +2,7 @@ import { RefObject, useState, ReactNode, useEffect } from 'react'
 
 import { FilterButtonOption } from '../FilterButton/types'
 
-type SelectPopupKeyHandler = {
+type SelectPopupKeyHandlerProps = {
   children: (activeValue: string | null) => ReactNode
   disabled?: boolean
   onOptionSelect: (option: FilterButtonOption) => void
@@ -16,7 +16,7 @@ type SelectPopupKeyHandler = {
  *
  * Call the `children` function with the currently active value
  */
-export const SelectPopupKeyHandler = (props: SelectPopupKeyHandler) => {
+export const SelectPopupKeyHandler = (props: SelectPopupKeyHandlerProps) => {
   const { disabled, options, onOptionSelect, optionRefs, scrollRef, children } =
     props
   const [activeIndex, setActiveIndex] = useState<number | null>(null)

--- a/packages/harmony/src/components/button/OptionsFilterButton/SelectPopupKeyHandler.tsx
+++ b/packages/harmony/src/components/button/OptionsFilterButton/SelectPopupKeyHandler.tsx
@@ -1,0 +1,95 @@
+import { RefObject, useState, ReactNode, useEffect } from 'react'
+
+import { FilterButtonOption } from '../FilterButton/types'
+
+type SelectPopupKeyHandler = {
+  children: (activeValue: string | null) => ReactNode
+  disabled?: boolean
+  onOptionSelect: (option: FilterButtonOption) => void
+  optionRefs: RefObject<HTMLButtonElement[]>
+  options: FilterButtonOption[]
+  scrollRef: RefObject<HTMLDivElement>
+}
+
+/**
+ * Handles key events for the popup inside the Select component
+ *
+ * Call the `children` function with the currently active value
+ */
+export const SelectPopupKeyHandler = (props: SelectPopupKeyHandler) => {
+  const { disabled, options, onOptionSelect, optionRefs, scrollRef, children } =
+    props
+  const [activeIndex, setActiveIndex] = useState<number | null>(null)
+  const activeValue = activeIndex !== null ? options[activeIndex]?.value : null
+
+  useEffect(() => {
+    const adjustScrollPosition = (newIndex: number | null) => {
+      if (newIndex !== null) {
+        if (optionRefs.current) {
+          optionRefs.current[newIndex].scrollIntoView({
+            behavior: 'smooth',
+            block: 'start'
+          })
+        }
+      } else {
+        scrollRef.current?.scrollTo({ top: 0, behavior: 'smooth' })
+      }
+    }
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (disabled) {
+        return
+      }
+
+      switch (event.key) {
+        case 'ArrowUp':
+          setActiveIndex((prevIndex) => {
+            const getNewIndex = () => {
+              if (prevIndex === null) {
+                return options.length - 1
+              }
+
+              return prevIndex > 0 ? prevIndex - 1 : null
+            }
+
+            const newIndex = getNewIndex()
+            adjustScrollPosition(newIndex)
+
+            return newIndex
+          })
+          break
+        case 'ArrowDown':
+          setActiveIndex((prevIndex) => {
+            const getNewIndex = () => {
+              if (prevIndex === null) {
+                return 0
+              }
+
+              return prevIndex < options.length - 1 ? prevIndex + 1 : null
+            }
+
+            const newIndex = getNewIndex()
+            adjustScrollPosition(newIndex)
+
+            return newIndex
+          })
+          break
+        case 'Enter':
+          if (activeIndex !== null && options[activeIndex]) {
+            onOptionSelect(options[activeIndex])
+          }
+          break
+        default:
+          break
+      }
+    }
+
+    window.addEventListener('keydown', handleKeyDown)
+
+    return () => {
+      window.removeEventListener('keydown', handleKeyDown)
+    }
+  }, [disabled, options, activeIndex, scrollRef, optionRefs])
+
+  return <>{children(activeValue)}</>
+}

--- a/packages/harmony/src/components/popup/Popup.tsx
+++ b/packages/harmony/src/components/popup/Popup.tsx
@@ -353,6 +353,7 @@ export const Popup = forwardRef<HTMLDivElement, PopupProps>(function Popup(
       setPopupState('opening')
     } else if (popupState === 'open' && !isVisibleProp) {
       setPopupState('closing')
+      anchorRef.current?.focus()
     }
   }, [isVisibleProp, popupState])
 

--- a/packages/web/src/pages/search-page-v2/SearchFilters.tsx
+++ b/packages/web/src/pages/search-page-v2/SearchFilters.tsx
@@ -13,6 +13,7 @@ import {
   Divider,
   Box
 } from '@audius/harmony'
+import { CSSObject } from '@emotion/react'
 import { useSearchParams } from 'react-router-dom-v5-compat'
 
 import { BpmFilter } from './BpmFilter'
@@ -58,10 +59,17 @@ const MoodFilter = () => {
   const mood = urlSearchParams.get('mood')
   const updateSearchParams = useUpdateSearchParams('mood')
   const sortedKeys = Object.keys(MOODS).sort()
+
+  const moodCss = {
+    '& .emoji': {
+      marginBottom: 0
+    }
+  }
+
   const moodOptions = sortedKeys.map((mood) => ({
     label: MOODS[mood].label,
     value: MOODS[mood].value,
-    leadingElement: MOODS[mood].icon
+    leadingElement: <Box css={moodCss}>{MOODS[mood].icon}</Box>
   }))
 
   return (

--- a/packages/web/src/pages/search-page-v2/SearchFilters.tsx
+++ b/packages/web/src/pages/search-page-v2/SearchFilters.tsx
@@ -13,7 +13,6 @@ import {
   Divider,
   Box
 } from '@audius/harmony'
-import { CSSObject } from '@emotion/react'
 import { useSearchParams } from 'react-router-dom-v5-compat'
 
 import { BpmFilter } from './BpmFilter'


### PR DESCRIPTION
### Description



* Make OptionsFilterButton navigable via keyboard
  Video is keyboard only:

https://github.com/AudiusProject/audius-protocol/assets/19916043/2794cdf4-61a0-4e21-9e1f-96348cbeb8ba




* Handle focus state of the filter input
* Add a `No matches` message when all options are filtered out
* Remove margin from bottom of emojis in dropdown

Still left to do:
* Rename to `Select`
* Use an input internally so onChange accepts a `ChangeEvent`

### How Has This Been Tested?

Tested locally
