### PR TITLE
fix essentia pkg config on stage/prod nodes

### DIFF
--- a/mediorum/Dockerfile
+++ b/mediorum/Dockerfile
@@ -47,7 +47,7 @@ RUN cmake -DCMAKE_INSTALL_PREFIX=/usr/local -DBUILD_TESTING=OFF -S . -B build &&
     cmake --install build
 
 # Clone and build Essentia
-ENV PKG_CONFIG_PATH="/usr/local/lib/pkgconfig:/usr/lib/pkgconfig:/usr/lib/aarch64-linux-gnu/pkgconfig"
+ENV PKG_CONFIG_PATH="/usr/local/lib/pkgconfig:$(find /usr/lib -type d -name pkgconfig | tr '\n' ':')"
 ENV LD_LIBRARY_PATH="/usr/local/lib:/usr/lib"
 RUN git clone https://github.com/MTG/essentia.git /essentia
 WORKDIR /essentia

--- a/mediorum/Dockerfile.dev
+++ b/mediorum/Dockerfile.dev
@@ -33,7 +33,7 @@ RUN cmake -DCMAKE_INSTALL_PREFIX=/usr/local -DBUILD_TESTING=OFF -S . -B build &&
     cmake --install build
 
 # Clone and build Essentia
-ENV PKG_CONFIG_PATH="/usr/local/lib/pkgconfig:/usr/lib/pkgconfig:/usr/lib/aarch64-linux-gnu/pkgconfig"
+ENV PKG_CONFIG_PATH="/usr/local/lib/pkgconfig:$(find /usr/lib -type d -name pkgconfig | tr '\n' ':')"
 ENV LD_LIBRARY_PATH="/usr/local/lib:/usr/lib"
 RUN git clone https://github.com/MTG/essentia.git /essentia
 WORKDIR /essentia


### PR DESCRIPTION
### Description
was failing to analyze on a stage node bc the pkgconfig deps were in `/usr/lib/x86_64-linux-gnu/pkgconfig`, as opposed to on my local machine where they were in `/usr/lib/aarch64-linux-gnu/pkgconfig`. fix so that it adds any paths matching `/usr/lib/*/pkgconfig` to the `PKG_CONFIG_PATH` envvar.

### How Has This Been Tested?
tested `python3 waf configure` in `/essentia` worked on a stage node with this fixed `PKG_CONFIG_PATH` envvar