### PR TITLE
Move web TrackTile hidden label to mid-left

### DIFF
--- a/packages/web/src/components/track/desktop/TrackTile.tsx
+++ b/packages/web/src/components/track/desktop/TrackTile.tsx
@@ -49,6 +49,7 @@ import {
 
 import { BottomRow } from './BottomRow'
 import styles from './TrackTile.module.css'
+import { VisibilityLabel } from 'components/visibility-label/VisibilityLabel'
 
 const { getUserId } = accountSelectors
 const { getTrackPosition } = playbackPositionSelectors
@@ -341,7 +342,7 @@ const TrackTile = ({
             ) : (
               <>
                 {specialContentLabel}
-                <ScheduledReleaseLabel
+                <VisibilityLabel
                   releaseDate={releaseDate}
                   isUnlisted={isUnlisted}
                   isScheduledRelease={isScheduledRelease}
@@ -351,12 +352,6 @@ const TrackTile = ({
             )}
           </Text>
           <Text variant='body' size='xs' className={styles.topRight}>
-            {isUnlisted && !isScheduledRelease ? (
-              <div className={styles.topRightIconLabel}>
-                <IconVisibilityHidden className={styles.topRightIcon} />
-                {messages.hiddenTrack}
-              </div>
-            ) : null}
             {!isLoading && duration !== null && duration !== undefined ? (
               <div className={styles.duration}>{getDurationText()}</div>
             ) : null}

--- a/packages/web/src/components/track/mobile/TrackTile.tsx
+++ b/packages/web/src/components/track/mobile/TrackTile.tsx
@@ -38,11 +38,11 @@ import RepostButton from 'components/alt-button/RepostButton'
 import { DogEar } from 'components/dog-ear'
 import { TextLink, UserLink } from 'components/link'
 import { LockedStatusPill } from 'components/locked-status-pill'
-import { ScheduledReleaseLabel } from 'components/scheduled-release-label/ScheduledReleaseLabel'
 import Skeleton from 'components/skeleton/Skeleton'
 import { GatedContentLabel } from 'components/track/GatedContentLabel'
 import { TrackTileProps } from 'components/track/types'
 import UserBadges from 'components/user-badges/UserBadges'
+import { VisibilityLabel } from 'components/visibility-label/VisibilityLabel'
 import { useAuthenticatedClickCallback } from 'hooks/useAuthenticatedCallback'
 
 import { GatedConditionsPill } from '../GatedConditionsPill'
@@ -434,7 +434,7 @@ const TrackTile = (props: CombinedProps) => {
               className={styles.rankIconContainer}
             />
             {specialContentLabel}
-            <ScheduledReleaseLabel
+            <VisibilityLabel
               releaseDate={releaseDate}
               isUnlisted={isUnlisted}
               isScheduledRelease={isScheduledRelease}

--- a/packages/web/src/components/visibility-label/VisibilityLabel.tsx
+++ b/packages/web/src/components/visibility-label/VisibilityLabel.tsx
@@ -1,10 +1,17 @@
 import { formatReleaseDate } from '@audius/common/utils'
-import { Text, IconCalendarMonth, Flex, useTheme } from '@audius/harmony'
+import {
+  Text,
+  IconCalendarMonth,
+  Flex,
+  useTheme,
+  IconVisibilityHidden
+} from '@audius/harmony'
 import dayjs from 'dayjs'
 
 import { getLocalTimezone } from 'utils/dateUtils'
 
 const messages = {
+  hidden: 'Hidden',
   releases: (date: string) =>
     `Releases ${formatReleaseDate({
       date,
@@ -12,25 +19,38 @@ const messages = {
     })} ${getLocalTimezone()}`
 }
 
-export type ScheduledReleaseLabelProps = {
+export type VisibilityLabelProps = {
   releaseDate?: string | null
   isUnlisted?: boolean
   isScheduledRelease?: boolean
 }
 
-export const ScheduledReleaseLabel = ({
+export const VisibilityLabel = ({
   releaseDate,
   isUnlisted,
   isScheduledRelease
-}: ScheduledReleaseLabelProps) => {
+}: VisibilityLabelProps) => {
   const { color } = useTheme()
+
+  if (isUnlisted && !isScheduledRelease) {
+    return (
+      <Flex alignItems='center' gap='xs' w='100%'>
+        <IconVisibilityHidden size='s' color='subdued' />
+        <Text variant='body' size='xs' color='subdued'>
+          {messages.hidden}
+        </Text>
+      </Flex>
+    )
+  }
+
   if (
     !releaseDate ||
     !isUnlisted ||
     !isScheduledRelease ||
     dayjs(releaseDate).isBefore(dayjs())
-  )
+  ) {
     return null
+  }
 
   return (
     <Flex alignItems='center' gap='xs' w='100%'>


### PR DESCRIPTION
### Description
Move the label from the top-right to the mid-left of the tile.

Native mobile already has this change.

### How Has This Been Tested?

<img width="418" alt="Screenshot 2024-06-17 at 4 52 06 PM" src="https://github.com/AudiusProject/audius-protocol/assets/3893871/175bcc01-157d-43c1-8b1c-cbc12eea38af">
<img width="759" alt="Screenshot 2024-06-17 at 4 51 18 PM" src="https://github.com/AudiusProject/audius-protocol/assets/3893871/2600b44e-85ec-4e5d-9bfd-b9324d9893e6">
