### PR TITLE
Make content node metric recording non-blocking

### DIFF
--- a/mediorum/server/serve_blob.go
+++ b/mediorum/server/serve_blob.go
@@ -203,7 +203,7 @@ func (ss *MediorumServer) serveBlob(c echo.Context) error {
 		}
 
 		if isAudioFile {
-			ss.recordMetric(StreamTrack)
+			go ss.recordMetric(StreamTrack)
 			http.ServeContent(c.Response(), c.Request(), cid, blob.ModTime(), blob)
 			return nil
 		}
@@ -212,7 +212,7 @@ func (ss *MediorumServer) serveBlob(c echo.Context) error {
 		if err != nil {
 			return err
 		}
-		ss.recordMetric(ServeImage)
+		go ss.recordMetric(ServeImage)
 		return c.Blob(200, blob.ContentType(), blobData)
 	}
 


### PR DESCRIPTION
### Description

@raymondjacobson @dylanjeffers and I were picking apart content node code to see if we can optimize anything for better audio playback performance.

This `recordMetrics` call seems like low hanging fruit for a call that could be non-blocking. (chat GPT concurred)

### How Has This Been Tested?

going to test after it hits staging 🙈 
![](https://i.giphy.com/media/v1.Y2lkPTc5MGI3NjExMHZ5MDQwMTZ5Mml3dXh5Z2pkY2ZzeXZ1dzBvdmhmd2ZqbXB2bWtiNCZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/q7UpJegIZjsk0/giphy.gif)
