### PR TITLE
fix gorm automigrate typo

### DIFF
--- a/mediorum/ddl/ddl.go
+++ b/mediorum/ddl/ddl.go
@@ -22,6 +22,9 @@ var dropBlobs string
 //go:embed drop_old_audio_analyses.sql
 var dropAudioAnalysesDDL string
 
+//go:embed fix-qm-audio-analyses-typo.sql
+var fixQmAudioAnlaysesDDL string
+
 var mediorumMigrationTable = `
 	create table if not exists mediorum_migrations (
 		"hash" text primary key,
@@ -50,6 +53,7 @@ func Migrate(db *sql.DB, myHost string) {
 	runMigration(db, qmSyncTable)
 
 	runMigration(db, dropAudioAnalysesDDL)
+	runMigration(db, fixQmAudioAnlaysesDDL)
 }
 
 func runMigration(db *sql.DB, ddl string) {

--- a/mediorum/ddl/fix-qm-audio-analyses-typo.sql
+++ b/mediorum/ddl/fix-qm-audio-analyses-typo.sql
@@ -1,0 +1,13 @@
+begin;
+DO $$
+BEGIN
+    IF EXISTS (
+        SELECT 1 
+        FROM information_schema.columns 
+        WHERE table_name = 'qm_audio_analyses' 
+          AND column_name = 'c_id'
+    ) THEN
+        ALTER TABLE qm_audio_analyses DROP COLUMN c_id;
+    END IF;
+END $$;
+commit;

--- a/mediorum/server/db.go
+++ b/mediorum/server/db.go
@@ -13,7 +13,7 @@ import (
 )
 
 type QmAudioAnalysis struct {
-	CID        string               `json:"cid" gorm:"primaryKey"`
+	CID        string               `json:"cid" gorm:"primaryKey,column:cid"`
 	Mirrors    []string             `json:"mirrors" gorm:"serializer:json"`
 	Status     string               `json:"status"`
 	Error      string               `json:"error,omitempty"`


### PR DESCRIPTION
### Description
gorm automigrate named this col c_id instead of cid. erroneous col name is only on stage nodes rn - will remove the ddl after all stage nodes have run the migration.

### How Has This Been Tested?
tested locally