### PR TITLE
Mediorum timing header

### DIFF
--- a/mediorum/server/repair_test.go
+++ b/mediorum/server/repair_test.go
@@ -71,6 +71,7 @@ func TestRepair(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Equal(t, 200, resp.StatusCode)
 		assert.Len(t, uploads, 1)
+		assert.NotEmpty(t, resp.GetHeader("x-took"))
 	}
 
 	// force sweep (since blob changes SkipBroadcast)

--- a/mediorum/server/serve_blob.go
+++ b/mediorum/server/serve_blob.go
@@ -204,6 +204,7 @@ func (ss *MediorumServer) serveBlob(c echo.Context) error {
 
 		if isAudioFile {
 			go ss.recordMetric(StreamTrack)
+			setTimingHeader(c)
 			http.ServeContent(c.Response(), c.Request(), cid, blob.ModTime(), blob)
 			return nil
 		}

--- a/mediorum/server/serve_image.go
+++ b/mediorum/server/serve_image.go
@@ -27,6 +27,7 @@ func (ss *MediorumServer) serveImage(c echo.Context) error {
 	cacheKey := jobID + variant
 
 	serveSuccessWithBytes := func(blobData []byte, modTime time.Time) error {
+		setTimingHeader(c)
 		c.Response().Header().Set(echo.HeaderCacheControl, "public, max-age=2592000, immutable")
 		http.ServeContent(c.Response(), c.Request(), cacheKey, modTime, bytes.NewReader(blobData))
 		return nil

--- a/mediorum/server/serve_image_test.go
+++ b/mediorum/server/serve_image_test.go
@@ -33,6 +33,8 @@ func TestServeImage(t *testing.T) {
 		assert.Equal(t, 200, resp.StatusCode)
 		assert.NotEmpty(t, resp.Header.Get("x-fetch-ok"))
 		assert.NotEmpty(t, resp.Header.Get("x-resize-ok"))
+		assert.NotEmpty(t, resp.Header.Get("x-took"))
+
 		assert.Empty(t, resp.Header.Get("x-image-cache-hit"))
 	}
 


### PR DESCRIPTION
### Description

Set `x-took` response header to measure how long server spent processing request (wall clock time).

If `x-took` is slow we need to optimize server code.

If `x-took` is fast, but request takes long time... there is a network or proxy issue along the way.
