### PR TITLE
[PAY-3119][PAY-3123] Hide some menu options in manager mode

### DIFF
--- a/packages/common/src/hooks/useAccountSwitcher.ts
+++ b/packages/common/src/hooks/useAccountSwitcher.ts
@@ -33,6 +33,7 @@ export const useAccountSwitcher = () => {
   return { switchAccount }
 }
 
+/** Determines if we are in Manager Mode, i.e. the current user is not the logged-in user */
 export const useIsManagedAccount = () => {
   const { data: currentWeb3User } = useGetCurrentWeb3User({})
   const { data: currentUserId } = useGetCurrentUserId({})

--- a/packages/web/src/components/share-modal/ShareModal.tsx
+++ b/packages/web/src/components/share-modal/ShareModal.tsx
@@ -25,6 +25,7 @@ import { ShareDialog } from './components/ShareDialog'
 import { ShareDrawer } from './components/ShareDrawer'
 import { messages } from './messages'
 import { getTwitterShareText } from './utils'
+import { useIsManagedAccount } from '@audius/common/hooks'
 const { getShareState } = shareModalUISelectors
 const { shareUser } = usersSocialActions
 const { shareTrack } = tracksSocialActions
@@ -42,6 +43,7 @@ export const ShareModal = () => {
   const { content, source } = useSelector(getShareState)
   const account = useSelector(getAccountUser)
   const { onOpen: openCreateChatModal } = useCreateChatModal()
+  const isManagerMode = useIsManagedAccount()
 
   const isOwner =
     content?.type === 'track' && account?.user_id === content.artist.user_id
@@ -120,7 +122,10 @@ export const ShareModal = () => {
   const shareProps = {
     isOpen,
     isOwner,
-    onShareToDirectMessage: handleShareToDirectMessage,
+    // Disable DM share in manager mode since we can't do that as a managed user
+    onShareToDirectMessage: isManagerMode
+      ? undefined
+      : handleShareToDirectMessage,
     onShareToTwitter: handleShareToTwitter,
     onCopyLink: handleCopyLink,
     onEmbed: ['playlist', 'album', 'track'].includes(content?.type ?? '')

--- a/packages/web/src/components/share-modal/ShareModal.tsx
+++ b/packages/web/src/components/share-modal/ShareModal.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useContext } from 'react'
 
+import { useIsManagedAccount } from '@audius/common/hooks'
 import { Name, PlayableType } from '@audius/common/models'
 import {
   accountSelectors,
@@ -25,7 +26,7 @@ import { ShareDialog } from './components/ShareDialog'
 import { ShareDrawer } from './components/ShareDrawer'
 import { messages } from './messages'
 import { getTwitterShareText } from './utils'
-import { useIsManagedAccount } from '@audius/common/hooks'
+
 const { getShareState } = shareModalUISelectors
 const { shareUser } = usersSocialActions
 const { shareTrack } = tracksSocialActions

--- a/packages/web/src/components/share-modal/components/ShareDialog.tsx
+++ b/packages/web/src/components/share-modal/components/ShareDialog.tsx
@@ -63,12 +63,14 @@ export const ShareDialog = ({
               : messages.shareDescription}
           </ModalContentText>
           <ul className={styles.actionList}>
-            <ShareActionListItem
-              iconLeft={IconMessage}
-              onClick={onShareToDirectMessage}
-            >
-              {messages.directMessage}
-            </ShareActionListItem>
+            {onShareToDirectMessage ? (
+              <ShareActionListItem
+                iconLeft={IconMessage}
+                onClick={onShareToDirectMessage}
+              >
+                {messages.directMessage}
+              </ShareActionListItem>
+            ) : null}
             <ShareActionListItem
               iconLeft={IconTwitterBird}
               onClick={onShareToTwitter}

--- a/packages/web/src/components/share-modal/types.ts
+++ b/packages/web/src/components/share-modal/types.ts
@@ -1,7 +1,8 @@
 import { ShareType } from '@audius/common/store'
 
 export type ShareProps = {
-  onShareToDirectMessage: () => void
+  /** If excluded, will disable rendering of a 'Direct Message' option */
+  onShareToDirectMessage?: () => void
   onShareToTwitter: () => void
   onCopyLink: () => void
   onEmbed?: () => void

--- a/packages/web/src/pages/settings-page/components/desktop/ManagerMode/AccountListItem.tsx
+++ b/packages/web/src/pages/settings-page/components/desktop/ManagerMode/AccountListItem.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useMemo } from 'react'
 
-import { useAccountSwitcher } from '@audius/common/hooks'
+import { useAccountSwitcher, useIsManagedAccount } from '@audius/common/hooks'
 import { User, UserMetadata } from '@audius/common/models'
 import { accountSelectors, chatSelectors } from '@audius/common/store'
 import {
@@ -65,6 +65,7 @@ export const AccountListItem = ({
   onReject
 }: AccountListItemProps) => {
   const currentUserId = useSelector(getUserId)
+  const isManagerMode = useIsManagedAccount()
 
   const navigate = useNavigateToPage()
   const goToProfile = useCallback(() => {
@@ -122,7 +123,10 @@ export const AccountListItem = ({
       onClick: goToProfile
     })
 
-    if (canCreateChat) {
+    // Don't show DM/switch options if we're in manager mode as the
+    // logged in user won't have permission to do those things on behalf of a
+    // managed account.
+    if (canCreateChat && !isManagerMode) {
       items.push({
         icon: <IconMessage />,
         text: messages.sendMessage,
@@ -130,7 +134,7 @@ export const AccountListItem = ({
       })
     }
 
-    if (isManagedAccount) {
+    if (isManagedAccount && !isManagerMode) {
       items.push({
         icon: <IconUserArrowRotate />,
         text: messages.switchToUser,
@@ -170,7 +174,7 @@ export const AccountListItem = ({
       aria-label={messages.moreOptions}
       icon={IconKebabHorizontal}
       color='default'
-      onClick={triggerPopup}
+      onClick={() => triggerPopup()}
     />
   )
 

--- a/packages/web/src/pages/settings-page/components/desktop/ManagerMode/AccountListItem.tsx
+++ b/packages/web/src/pages/settings-page/components/desktop/ManagerMode/AccountListItem.tsx
@@ -147,6 +147,7 @@ export const AccountListItem = ({
     user,
     switchAccount,
     isManagedAccount,
+    isManagerMode,
     isPending,
     handleCancelInvite,
     handleRemoveManager,


### PR DESCRIPTION
### Description
Hides a few menu options that don't make sense in manager mode.

Bonus: Fixes the popup trigger for the accounts in the "Accounts You Manage" modal to correctly close if clicked while it's open.

fixes PAY-3119
fixes PAY-3123

### How Has This Been Tested?
Tested manually on local client against staging.
