### PR TITLE
[C-4567] Fix purchase content not updating prefetch correctly

### DIFF
--- a/packages/mobile/src/components/audio/AudioPlayer.tsx
+++ b/packages/mobile/src/components/audio/AudioPlayer.tsx
@@ -343,12 +343,16 @@ export const AudioPlayer = () => {
       let url: string
 
       // If we pre-fetched a stream url, prefer to use that
-      const trackStreamUrl = trackStreamUrls[trackId]
+      const prefetchedStreamUrl = trackStreamUrls[trackId]
       if (offlineTrackAvailable && isCollectionMarkedForDownload) {
         const audioFilePath = getLocalAudioPath(trackId)
         url = `file://${audioFilePath}`
-      } else if (trackStreamUrl && isStreamPrefetchEnabled && !noPrefetch) {
-        url = trackStreamUrl
+      } else if (
+        prefetchedStreamUrl &&
+        isStreamPrefetchEnabled &&
+        !noPrefetch
+      ) {
+        url = prefetchedStreamUrl
       } else {
         let queryParams = trackQueryParams.current[trackId]
 

--- a/packages/web/src/common/store/cache/tracks/sagas.ts
+++ b/packages/web/src/common/store/cache/tracks/sagas.ts
@@ -67,30 +67,31 @@ function* watchAdd() {
   yield* takeEvery(
     cacheActions.ADD_SUCCEEDED,
     function* (action: ReturnType<typeof cacheActions.addSucceeded>) {
-      if (action.kind === Kind.TRACKS) {
-        // Fetch repost data
-        const isNativeMobile = yield* getContext('isNativeMobile')
-        if (!isNativeMobile) {
-          yield* fork(fetchRepostInfo, action.entries as Entry<Collection>[])
-        }
+      // This code only applies to tracks
+      if (action.kind !== Kind.TRACKS) return
 
-        // Prefetch stream urls
-        const getFeatureEnabled = yield* getContext('getFeatureEnabled')
-        const isPrefetchEnabled = yield* call(
-          getFeatureEnabled,
-          FeatureFlags.PREFETCH_STREAM_URLS
-        )
-        if (isPrefetchEnabled) {
-          yield* fork(fetchTrackStreamUrls, {
-            trackIds: action.entries.map((e) => e.id)
-          })
-        }
+      // Fetch repost data
+      const isNativeMobile = yield* getContext('isNativeMobile')
+      if (!isNativeMobile) {
+        yield* fork(fetchRepostInfo, action.entries as Entry<Collection>[])
+      }
+
+      // Prefetch stream urls
+      const getFeatureEnabled = yield* getContext('getFeatureEnabled')
+      const isPrefetchEnabled = yield* call(
+        getFeatureEnabled,
+        FeatureFlags.PREFETCH_STREAM_URLS
+      )
+      if (isPrefetchEnabled) {
+        yield* fork(fetchTrackStreamUrls, {
+          trackIds: action.entries.map((e) => e.id)
+        })
       }
     }
   )
 }
 
-function* watchUpdate() {
+function* watchCacheUpdate() {
   yield* takeEvery(
     cacheActions.UPDATE,
     function* (action: ReturnType<typeof cacheActions.update>) {
@@ -480,7 +481,7 @@ const sagas = () => {
     watchEditTrack,
     watchDeleteTrack,
     watchFetchCoverArt,
-    watchUpdate
+    watchCacheUpdate
   ]
 }
 

--- a/packages/web/src/common/store/cache/tracks/sagas.ts
+++ b/packages/web/src/common/store/cache/tracks/sagas.ts
@@ -104,7 +104,7 @@ function* watchUpdate() {
       if (action.kind === Kind.TRACKS) {
         // Check for tracks with any changed access. If so we need to update the prefetched stream url
         const tracksWithChangedAccess = action.entries
-          .filter((track) => track.metadata.access.stream !== undefined)
+          .filter((track) => track?.metadata?.access?.stream !== undefined)
           .map((track) => track.id)
         // Re-trigger prefetching stream urls for any changed tracks
         if (tracksWithChangedAccess.length > 0) {

--- a/packages/web/src/common/store/cache/tracks/utils/fetchTrackStreamUrls.ts
+++ b/packages/web/src/common/store/cache/tracks/utils/fetchTrackStreamUrls.ts
@@ -16,7 +16,13 @@ const { setStreamUrls } = cacheTracksActions
 const { getNftAccessSignatureMap } = gatedContentSelectors
 const { getPlayerBehavior } = queueSelectors
 
-export function* fetchTrackStreamUrls({ trackIds }: { trackIds: ID[] }) {
+export function* fetchTrackStreamUrls({
+  trackIds,
+  isUpdate
+}: {
+  trackIds: ID[]
+  isUpdate?: boolean
+}) {
   const apiClient = yield* getContext('apiClient')
   const audiusBackendInstance = yield* getContext('audiusBackendInstance')
   const reportToSentry = yield* getContext('reportToSentry')
@@ -30,7 +36,7 @@ export function* fetchTrackStreamUrls({ trackIds }: { trackIds: ID[] }) {
       try {
         const existingUrl = yield* select(getTrackStreamUrl, id)
 
-        if (existingUrl) {
+        if (existingUrl && !isUpdate) {
           return { [id]: existingUrl }
         }
 


### PR DESCRIPTION
### Description

Add another saga to watch for cache updates for stream access changes to refetch/update stream urls in the cache.

More specifically I'm only checking changes to `access.stream` and retriggering the same prefetch logic with the updated track ids.

### How Has This Been Tested?

web:stage
