### PR TITLE
[PAY-3121] Use current user wallet to fetch AUDIO balance

### DIFF
--- a/packages/common/src/services/audius-backend/AudiusBackend.ts
+++ b/packages/common/src/services/audius-backend/AudiusBackend.ts
@@ -2711,11 +2711,22 @@ export const audiusBackend = ({
   /**
    * Make a request to fetch the eth AUDIO balance of the the user
    * @params {bool} bustCache
+   * @params {string} ethAddress - Optional ETH wallet address. Defaults to hedgehog wallet
    * @returns {Promise<BN | null>} balance or null if failed to fetch balance
    */
-  async function getBalance(bustCache = false) {
+  async function getBalance({
+    ethAddress,
+    bustCache = false
+  }: {
+    ethAddress?: string
+    bustCache?: boolean
+  } = {}): Promise<BN | null> {
     await waitForLibsInit()
-    const wallet = audiusLibs.web3Manager.getWalletAddress()
+
+    const wallet =
+      ethAddress !== undefined
+        ? ethAddress
+        : audiusLibs.web3Manager.getWalletAddress()
     if (!wallet) return null
 
     try {
@@ -2737,13 +2748,16 @@ export const audiusBackend = ({
 
   /**
    * Make a request to fetch the sol wrapped audio balance of the the user
-   * @returns {Promise<BN>} balance
+   * @params {string} ethAddress - Optional ETH wallet address to derive user bank. Defaults to hedgehog wallet
+   * @returns {Promise<BN>} balance or null if failed to fetch balance
    */
-  async function getWAudioBalance() {
+  async function getWAudioBalance(ethAddress?: string): Promise<BN | null> {
     await waitForLibsInit()
 
     try {
-      const userBank = await audiusLibs.solanaWeb3Manager.deriveUserBank()
+      const userBank = await audiusLibs.solanaWeb3Manager.deriveUserBank({
+        ethAddress
+      })
       const ownerWAudioBalance =
         await audiusLibs.solanaWeb3Manager.getWAudioBalance(userBank)
       if (isNullOrUndefined(ownerWAudioBalance)) {
@@ -2892,7 +2906,7 @@ export const audiusBackend = ({
    *   logs: Array<string>
    * }
    */
-  async function transferAudioToWAudio(balance: number) {
+  async function transferAudioToWAudio(balance: BN) {
     await waitForLibsInit()
     const userBank = await audiusLibs.solanaWeb3Manager.deriveUserBank()
     return audiusLibs.Account.proxySendTokensFromEthToSol(

--- a/packages/common/src/services/wallet-client/WalletClient.ts
+++ b/packages/common/src/services/wallet-client/WalletClient.ts
@@ -37,9 +37,15 @@ export class WalletClient {
   }
 
   /** Get user's current ETH Audio balance. Returns null on failure. */
-  async getCurrentBalance(bustCache = false): Promise<BNWei | null> {
+  async getCurrentBalance({
+    ethAddress,
+    bustCache
+  }: { ethAddress?: string; bustCache?: boolean } = {}): Promise<BNWei | null> {
     try {
-      const balance = await this.audiusBackendInstance.getBalance(bustCache)
+      const balance = await this.audiusBackendInstance.getBalance({
+        ethAddress,
+        bustCache
+      })
       return balance as BNWei
     } catch (err) {
       console.error(err)
@@ -48,8 +54,10 @@ export class WalletClient {
   }
 
   /** Get user's current SOL Audio balance. Returns null on failure. */
-  async getCurrentWAudioBalance(): Promise<BNWei | null> {
-    const balance = await this.audiusBackendInstance.getWAudioBalance()
+  async getCurrentWAudioBalance(ethAddress?: string): Promise<BNWei | null> {
+    const balance = await this.audiusBackendInstance.getWAudioBalance(
+      ethAddress
+    )
     return (
       isNullOrUndefined(balance) ? null : new BN(balance.toString())
     ) as BNWei | null
@@ -73,7 +81,9 @@ export class WalletClient {
       throw new Error('No userbank account.')
     }
 
-    const ercAudioBalance = await this.audiusBackendInstance.getBalance(true)
+    const ercAudioBalance = await this.audiusBackendInstance.getBalance({
+      bustCache: true
+    })
     if (
       !isNullOrUndefined(ercAudioBalance) &&
       ercAudioBalance.gt(new BN('0'))

--- a/packages/web/src/common/store/wallet/sagas.ts
+++ b/packages/web/src/common/store/wallet/sagas.ts
@@ -210,7 +210,7 @@ function* fetchBalanceAsync() {
   const getFeatureEnabled = yield* getContext('getFeatureEnabled')
 
   const account = yield* select(getAccountUser)
-  if (!account) return
+  if (!account || !account.wallet) return
 
   try {
     // Opt out of balance refreshes if the balance
@@ -227,11 +227,11 @@ function* fetchBalanceAsync() {
     )
 
     const [currentEthAudioWeiBalance, currentSolAudioWeiBalance] = yield* all([
-      call(
-        [walletClient, 'getCurrentBalance'],
-        /* bustCache */ localBalanceChange
-      ),
-      call([walletClient, 'getCurrentWAudioBalance'])
+      call([walletClient, 'getCurrentBalance'], {
+        ethAddress: account.wallet,
+        bustCache: localBalanceChange
+      }),
+      call([walletClient, 'getCurrentWAudioBalance'], account.wallet)
     ])
 
     if (isNullOrUndefined(currentEthAudioWeiBalance)) {


### PR DESCRIPTION
### Description
This adds optional behavior to the functions in `WalletClient` and `AudiusBackend` to use a specific wallet address when fetching balance and updates the wallet saga to use the wallet address we load from the current user Account. Ideally, we will remove `WalletClient` and `AudiusBackend` altogether. But I wanted to limit the surface area of this change to just fixing the balance display bug when switched into a managed account.

fixes PAY-3121

### How Has This Been Tested?
Tested with local client against staging. Verified that we show the correct balance in both managed and unmanaged modes.
