### PR TITLE
Use subdued color for mobile MetadataItem

### DIFF
--- a/packages/mobile/src/components/details-tile/DetailsTile.tsx
+++ b/packages/mobile/src/components/details-tile/DetailsTile.tsx
@@ -377,12 +377,14 @@ export const DetailsTile = ({
         ) : null}
         {!isPublished ? null : (
           <DetailsTileStats
+            playCount={playCount}
+            hidePlayCount={hidePlayCount}
             favoriteCount={saveCount}
             hideFavoriteCount={hideFavoriteCount}
+            repostCount={repostCount}
             hideRepostCount={hideRepostCount}
             onPressFavorites={onPressFavorites}
             onPressReposts={onPressReposts}
-            repostCount={repostCount}
           />
         )}
         {description ? (

--- a/packages/mobile/src/components/details-tile/DetailsTileStats.tsx
+++ b/packages/mobile/src/components/details-tile/DetailsTileStats.tsx
@@ -24,9 +24,9 @@ type DetailsTileStatsProps = {
  * The stats displayed on track and playlist screens
  */
 export const DetailsTileStats = ({
-  playCount,
-  repostCount,
-  favoriteCount,
+  playCount = 0,
+  repostCount = 0,
+  favoriteCount = 0,
   hidePlayCount,
   hideRepostCount,
   hideFavoriteCount,
@@ -47,12 +47,12 @@ export const DetailsTileStats = ({
       alignItems='center'
       justifyContent='flex-start'
     >
-      {hidePlayCount ? null : (
-        <DetailsTileStat count={playCount ?? 0} icon={IconPlay} />
+      {hidePlayCount && playCount > 0 ? null : (
+        <DetailsTileStat count={playCount} icon={IconPlay} />
       )}
       {hideRepostCount ? null : (
         <DetailsTileStat
-          count={repostCount ?? 0}
+          count={repostCount}
           onPress={onPressReposts}
           icon={IconRepost}
           label={messages.reposts}
@@ -60,7 +60,7 @@ export const DetailsTileStats = ({
       )}
       {hideFavoriteCount ? null : (
         <DetailsTileStat
-          count={favoriteCount ?? 0}
+          count={favoriteCount}
           onPress={onPressFavorites}
           icon={IconHeart}
           label={messages.favorites}

--- a/packages/mobile/src/components/details-tile/DetailsTileStats.tsx
+++ b/packages/mobile/src/components/details-tile/DetailsTileStats.tsx
@@ -1,4 +1,4 @@
-import { pluralize } from '~/utils'
+import { pluralize } from '@audius/common/utils'
 
 import { Flex, IconHeart, IconPlay, IconRepost } from '@audius/harmony-native'
 import type { GestureResponderHandler } from 'app/types/gesture'

--- a/packages/mobile/src/components/details-tile/DetailsTileStats.tsx
+++ b/packages/mobile/src/components/details-tile/DetailsTileStats.tsx
@@ -1,8 +1,9 @@
+import { pluralize } from '~/utils'
+
 import { Flex, IconHeart, IconPlay, IconRepost } from '@audius/harmony-native'
 import type { GestureResponderHandler } from 'app/types/gesture'
 
 import { DetailsTileStat } from './DetailsStat'
-import { pluralize } from '~/utils'
 
 const messages = {
   favorites: (count: number) => `${pluralize('Favorite', count)}`,
@@ -41,10 +42,10 @@ export const DetailsTileStats = ({
       alignItems='center'
       justifyContent='flex-start'
     >
-      {hidePlayCount || playCount <= 0 ? null : (
+      {hidePlayCount ? null : (
         <DetailsTileStat count={playCount} icon={IconPlay} />
       )}
-      {hideRepostCount || repostCount <= 0 ? null : (
+      {hideRepostCount ? null : (
         <DetailsTileStat
           count={repostCount}
           onPress={onPressReposts}
@@ -52,7 +53,7 @@ export const DetailsTileStats = ({
           label={messages.reposts(repostCount)}
         />
       )}
-      {hideFavoriteCount || favoriteCount <= 0 ? null : (
+      {hideFavoriteCount ? null : (
         <DetailsTileStat
           count={favoriteCount}
           onPress={onPressFavorites}

--- a/packages/mobile/src/components/details-tile/DetailsTileStats.tsx
+++ b/packages/mobile/src/components/details-tile/DetailsTileStats.tsx
@@ -2,18 +2,18 @@ import { Flex, IconHeart, IconPlay, IconRepost } from '@audius/harmony-native'
 import type { GestureResponderHandler } from 'app/types/gesture'
 
 import { DetailsTileStat } from './DetailsStat'
+import { pluralize } from '~/utils'
 
 const messages = {
-  plays: 'Plays',
-  favorites: 'Favorites',
-  reposts: 'Reposts'
+  favorites: (count: number) => `${pluralize('Favorite', count)}`,
+  reposts: (count: number) => `${pluralize('Repost', count)}`
 }
 
 type DetailsTileStatsProps = {
   playCount?: number
   repostCount?: number
   favoriteCount?: number
-  hidePlayCount?: number
+  hidePlayCount?: boolean
   hideRepostCount?: boolean
   hideFavoriteCount?: boolean
   onPressFavorites?: GestureResponderHandler
@@ -33,12 +33,6 @@ export const DetailsTileStats = ({
   onPressFavorites,
   onPressReposts
 }: DetailsTileStatsProps) => {
-  if (
-    (hideFavoriteCount && hideRepostCount && hidePlayCount) ||
-    (!favoriteCount && !repostCount && !playCount)
-  ) {
-    return null
-  }
   return (
     <Flex
       w='100%'
@@ -47,23 +41,23 @@ export const DetailsTileStats = ({
       alignItems='center'
       justifyContent='flex-start'
     >
-      {hidePlayCount && playCount > 0 ? null : (
+      {hidePlayCount || playCount <= 0 ? null : (
         <DetailsTileStat count={playCount} icon={IconPlay} />
       )}
-      {hideRepostCount ? null : (
+      {hideRepostCount || repostCount <= 0 ? null : (
         <DetailsTileStat
           count={repostCount}
           onPress={onPressReposts}
           icon={IconRepost}
-          label={messages.reposts}
+          label={messages.reposts(repostCount)}
         />
       )}
-      {hideFavoriteCount ? null : (
+      {hideFavoriteCount || favoriteCount <= 0 ? null : (
         <DetailsTileStat
           count={favoriteCount}
           onPress={onPressFavorites}
           icon={IconHeart}
-          label={messages.favorites}
+          label={messages.favorites(favoriteCount)}
         />
       )}
     </Flex>

--- a/packages/mobile/src/components/details-tile/MetadataItem.tsx
+++ b/packages/mobile/src/components/details-tile/MetadataItem.tsx
@@ -9,7 +9,9 @@ type MetadataItemProps = PropsWithChildren<{
 export const MetadataItem = ({ label, children }: MetadataItemProps) => {
   return (
     <Flex direction='row' alignItems='center' key={label} gap='xs'>
-      <Text variant='label'>{label}</Text>
+      <Text variant='label' color='subdued'>
+        {label}
+      </Text>
       <Text variant='body' size='s' strength='strong'>
         {children}
       </Text>

--- a/packages/mobile/src/screens/track-screen/TrackScreenDetailsTile.tsx
+++ b/packages/mobile/src/screens/track-screen/TrackScreenDetailsTile.tsx
@@ -314,9 +314,13 @@ export const TrackScreenDetailsTile = ({
       hideRepost={hideRepost}
       hideShare={isUnlisted && !isOwner}
       hideOverflow={!isReachable || (isUnlisted && !isOwner)}
-      hideFavoriteCount={isUnlisted}
-      hidePlayCount={(!isOwner && isUnlisted) || isStreamGated}
-      hideRepostCount={isUnlisted}
+      hideFavoriteCount={isUnlisted || (!isOwner && (save_count ?? 0) <= 0)}
+      hidePlayCount={
+        (!isOwner && isUnlisted) ||
+        isStreamGated ||
+        (!isOwner && (play_count ?? 0) <= 0)
+      }
+      hideRepostCount={isUnlisted || (!isOwner && (repost_count ?? 0) <= 0)}
       isPlaying={isPlaying && isPlayingId}
       isPreviewing={isPreviewing}
       isUnlisted={isUnlisted}


### PR DESCRIPTION
### Description
- Forgot to add `color='subdued'` to the labels.
- Hide the stats (plays, reposts, favorites) counts if it's 0 and user is not the owner
- Fix bug where `playCount` wasn't getting passed in correctly.

Note - ugly code in the `hideX` logic. Ideally we'd calculate this inside `DetailsTileStats` itself - but this won't work since track/collection tiles are shared right now. This fix works for now.

### How Has This Been Tested?
Before repost
![Simulator Screenshot - iPhone 15 Pro - 2024-06-18 at 16 16 49](https://github.com/AudiusProject/audius-protocol/assets/3893871/7203014e-e95d-460a-b206-8419ed638324)

After repost + play
![Simulator Screenshot - iPhone 15 Pro - 2024-06-18 at 16 24 15](https://github.com/AudiusProject/audius-protocol/assets/3893871/4f08e622-829f-46a5-b390-7364537f6580)

Show 0 for owners
![Simulator Screenshot - iPhone 15 Pro - 2024-06-18 at 16 42 50](https://github.com/AudiusProject/audius-protocol/assets/3893871/b04fd0ff-846d-4f74-8b36-d41980a1b5b7)

pluralized
![Simulator Screenshot - iPhone 15 Pro - 2024-06-18 at 16 24 00](https://github.com/AudiusProject/audius-protocol/assets/3893871/e6139eac-b4cc-4933-a324-f7fd82054ce4)
