### PR TITLE
[PAY-3115][PAY-3124] Fix issues with pending invite query param

### DIFF
--- a/packages/common/src/utils/stringUtils.ts
+++ b/packages/common/src/utils/stringUtils.ts
@@ -41,3 +41,10 @@ export const parsePlaylistIdFromPermalink = (permalink: string) => {
 export const parseIntList = (str: string) => {
   return str.split(',').map((s) => Number.parseInt(s))
 }
+
+/** Attempts to parse a potentially empty string to a base 10 number. Returns `null` on failure. */
+export const attemptStringToNumber = (value?: string | null) => {
+  if (value == null) return null
+  const parsed = Number.parseInt(value, 10)
+  return Number.isNaN(parsed) ? null : parsed
+}

--- a/packages/web/src/hooks/useQueryParamConsumer.ts
+++ b/packages/web/src/hooks/useQueryParamConsumer.ts
@@ -1,0 +1,50 @@
+import { useEffect, useState } from 'react'
+
+import queryString from 'query-string'
+import { useHistory, useLocation } from 'react-router-dom'
+
+/** Picks the given query param out of the URL and optionally replaces the path.
+ * Will only pick once per mount.
+ */
+export const useQueryParamConsumer = ({
+  replacementRoute,
+  paramName
+}: {
+  replacementRoute?: string
+  paramName: string
+}) => {
+  const [value, setValue] = useState<string | null>(null)
+  const [hasConsumed, setHasConsumed] = useState(false)
+  const { search, pathname, state: locationState } = useLocation()
+  const history = useHistory()
+
+  useEffect(() => {
+    // Only consume once per mount
+    if (hasConsumed) return
+
+    const { [paramName]: parsedValue, ...restParams } =
+      queryString.parse(search)
+
+    if (parsedValue != null) {
+      setHasConsumed(true)
+      setValue(Array.isArray(parsedValue) ? parsedValue[0] : parsedValue)
+
+      // Remove the query param from the URL and replace with replacement path
+      // if defined
+      const newPath = `${replacementRoute ?? pathname}?${queryString.stringify(
+        restParams
+      )}`
+      history.replace(newPath, locationState)
+    }
+  }, [
+    hasConsumed,
+    pathname,
+    search,
+    locationState,
+    history,
+    paramName,
+    replacementRoute
+  ])
+
+  return value
+}

--- a/packages/web/src/pages/settings-page/components/desktop/ManagerMode/AccountsYouManageHomePage.tsx
+++ b/packages/web/src/pages/settings-page/components/desktop/ManagerMode/AccountsYouManageHomePage.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useContext, useEffect, useMemo, useState } from 'react'
+import { useCallback, useContext, useEffect } from 'react'
 
 import {
   useApproveManagedAccount,
@@ -8,8 +8,6 @@ import {
 import { Status, UserMetadata } from '@audius/common/models'
 import { accountSelectors } from '@audius/common/store'
 import { Box, Divider, Flex, Text } from '@audius/harmony'
-import queryString from 'query-string'
-import { useLocation } from 'react-router-dom'
 
 import LoadingSpinner from 'components/loading-spinner/LoadingSpinner'
 import { ToastContext } from 'components/toast/ToastContext'
@@ -18,6 +16,7 @@ import { useSelector } from 'utils/reducer'
 import { AccountListItem } from './AccountListItem'
 import { sharedMessages } from './sharedMessages'
 import { AccountsYouManagePageProps, AccountsYouManagePages } from './types'
+import { usePendingInviteValidator } from './usePendingInviteValidator'
 const { getAccountUser } = accountSelectors
 
 const messages = {
@@ -31,12 +30,7 @@ const messages = {
 export const AccountsYouManageHomePage = ({
   setPage
 }: AccountsYouManagePageProps) => {
-  const { search } = useLocation()
-  const pending = useMemo(() => queryString.parse(search)?.pending, [search])
   const currentUser = useSelector(getAccountUser)
-  const [hasInviteParamToValidate, setHasInviteParamToValidate] = useState(
-    pending != null
-  )
   const userId = currentUser?.user_id
   const { data: managedAccounts, status } = useGetManagedAccounts(
     { userId: userId! },
@@ -46,30 +40,7 @@ export const AccountsYouManageHomePage = ({
   const [rejectManagedAccount, rejectResult] = useRemoveManager()
   const { toast } = useContext(ToastContext)
 
-  useEffect(() => {
-    if (managedAccounts == null || !hasInviteParamToValidate) {
-      return
-    }
-    if (
-      pending != null &&
-      typeof pending === 'string' &&
-      pending.trim() !== '' &&
-      !isNaN(Number(pending))
-    ) {
-      const pendingUserId = Number(pending)
-      const pendingManagedAccount = managedAccounts.find(
-        (m) => m.grant.user_id === pendingUserId
-      )
-      if (!pendingManagedAccount) {
-        toast(messages.invalidInvitation)
-        return
-      }
-      if (pendingManagedAccount.grant.is_approved) {
-        toast(messages.alreadyAcceptedInvitation)
-      }
-    }
-    setHasInviteParamToValidate(false)
-  }, [toast, managedAccounts, hasInviteParamToValidate, pending])
+  usePendingInviteValidator({ managedAccounts, userId })
 
   const handleStopManaging = useCallback(
     ({ userId }: { userId: number; managerUserId: number }) => {

--- a/packages/web/src/pages/settings-page/components/desktop/ManagerMode/usePendingInviteValidator.ts
+++ b/packages/web/src/pages/settings-page/components/desktop/ManagerMode/usePendingInviteValidator.ts
@@ -1,0 +1,63 @@
+import { useContext, useEffect, useState } from 'react'
+
+import { ManagedUserMetadata } from '@audius/common/models'
+import { attemptStringToNumber } from '@audius/common/utils'
+
+import { ToastContext } from 'components/toast/ToastContext'
+import { useQueryParamConsumer } from 'hooks/useQueryParamConsumer'
+import { SETTINGS_PAGE } from 'utils/route'
+
+const PENDING_ID_QUERY_PARAM = 'pending'
+
+const messages = {
+  invalidInvitation: 'This invitation is no longer valid',
+  alreadyAcceptedInvitation: 'You already accepted this invitation'
+}
+
+/** Watches for a valid pending id value in the URL, extracts it and shows a toast
+ * if the invite is invalid or has already been accepted.
+ */
+export const usePendingInviteValidator = ({
+  userId,
+  managedAccounts
+}: {
+  userId?: number
+  managedAccounts?: ManagedUserMetadata[]
+}) => {
+  const pendingIdString = useQueryParamConsumer({
+    paramName: PENDING_ID_QUERY_PARAM,
+    replacementRoute: SETTINGS_PAGE
+  })
+  const [lastValidatedIdParam, setLastValidatedIdParam] = useState<
+    string | null
+  >(null)
+
+  const { toast } = useContext(ToastContext)
+
+  useEffect(() => {
+    if (
+      userId == null ||
+      managedAccounts == null ||
+      pendingIdString === lastValidatedIdParam
+    ) {
+      return
+    }
+    setLastValidatedIdParam(pendingIdString)
+
+    const pendingId = attemptStringToNumber(pendingIdString)
+    if (pendingId == null) {
+      return
+    }
+
+    const pendingManagedAccount = managedAccounts.find(
+      (m) => m.grant.user_id === pendingId
+    )
+    if (!pendingManagedAccount) {
+      toast(messages.invalidInvitation)
+      return
+    }
+    if (pendingManagedAccount.grant.is_approved) {
+      toast(messages.alreadyAcceptedInvitation)
+    }
+  }, [managedAccounts, userId, pendingIdString, lastValidatedIdParam, toast])
+}


### PR DESCRIPTION
### Description
This updates the code in the "Accounts Managing You" modal so that the query params and deeplink route are consumed when the component mounts and replaced with the `/settings` path (leaving any other query params in place). This fixes problems with refreshing the page and/or switching into an account after accepting the invite.

This also fixes the issue of attempting to switch into another account after following a pending invite link, since that was due to the deeplink and query param being carried across into the new user context (where it's most definitely invalid).

This "consume query param" pattern is a little different and I'm open to discussion on it!

* Added utility hook for consuming a query param and optionally replacing the path
* Moved the invite validation logic into a separate hook
* Updated page in the modal to pass managed accounts and userid into the validation hook

fixes PAY-3115
fixes PAY-3124

### How Has This Been Tested?
Tested locally against staging


### Screen Recording
**Take note of the URL after the component mounts. The route and query params are stripped**

https://github.com/AudiusProject/audius-protocol/assets/1815175/30c8f201-6ba9-4b0e-9b14-eb1034631fa3

