### PR TITLE
[C-4519] Remove visibility options

### DIFF
--- a/packages/common/src/models/TrackAvailabilityType.ts
+++ b/packages/common/src/models/TrackAvailabilityType.ts
@@ -1,5 +1,7 @@
+// TODO: Remove hidden and public when we go live with upload/edit updates
 export enum StreamTrackAvailabilityType {
   PUBLIC = 'PUBLIC',
+  FREE = 'FREE',
   USDC_PURCHASE = 'USDC_PURCHASE',
   SPECIAL_ACCESS = 'SPECIAL_ACCESS',
   COLLECTIBLE_GATED = 'COLLECTIBLE_GATED',

--- a/packages/web/src/components/edit/fields/price-and-audience/PriceAndAudienceField.tsx
+++ b/packages/web/src/components/edit/fields/price-and-audience/PriceAndAudienceField.tsx
@@ -232,7 +232,10 @@ export const PriceAndAudienceField = (props: PriceAndAudienceFieldProps) => {
     set(initialValues, IS_DOWNLOADABLE, isDownloadable)
     set(initialValues, LAST_GATE_KEEPER, lastGateKeeper ?? {})
 
-    let availabilityType = StreamTrackAvailabilityType.PUBLIC
+    let availabilityType = isHiddenPaidScheduledEnabled
+      ? StreamTrackAvailabilityType.FREE
+      : StreamTrackAvailabilityType.PUBLIC
+
     if (isUsdcGated) {
       availabilityType = StreamTrackAvailabilityType.USDC_PURCHASE
       set(
@@ -249,7 +252,7 @@ export const PriceAndAudienceField = (props: PriceAndAudienceFieldProps) => {
     if (isCollectibleGated) {
       availabilityType = StreamTrackAvailabilityType.COLLECTIBLE_GATED
     }
-    if (isUnlisted && !isScheduledRelease) {
+    if (isUnlisted && !isScheduledRelease && !isHiddenPaidScheduledEnabled) {
       availabilityType = StreamTrackAvailabilityType.HIDDEN
     }
     set(initialValues, STREAM_AVAILABILITY_TYPE, availabilityType)
@@ -270,13 +273,14 @@ export const PriceAndAudienceField = (props: PriceAndAudienceFieldProps) => {
     downloadConditions,
     isDownloadable,
     lastGateKeeper,
-    isScheduledRelease,
-    fieldVisibility,
-    preview,
-    isCollectibleGated,
+    isHiddenPaidScheduledEnabled,
+    isUsdcGated,
     isFollowGated,
     isTipGated,
-    isUsdcGated
+    isCollectibleGated,
+    isScheduledRelease,
+    fieldVisibility,
+    preview
   ])
 
   const handleSubmit = useCallback(
@@ -479,7 +483,11 @@ export const PriceAndAudienceField = (props: PriceAndAudienceFieldProps) => {
       selectedValues = [specialAccessValue, messages.followersOnly]
     } else if (isContentTipGated(savedStreamConditions)) {
       selectedValues = [specialAccessValue, messages.supportersOnly]
-    } else if (isUnlisted && !isScheduledRelease) {
+    } else if (
+      isUnlisted &&
+      !isScheduledRelease &&
+      !isHiddenPaidScheduledEnabled
+    ) {
       const fieldVisibilityKeys = Object.keys(
         messages.fieldVisibility
       ) as Array<keyof FieldVisibility>

--- a/packages/web/src/components/edit/fields/price-and-audience/PriceAndAudienceMenuFields.tsx
+++ b/packages/web/src/components/edit/fields/price-and-audience/PriceAndAudienceMenuFields.tsx
@@ -28,8 +28,6 @@ import { CollectibleGatedRadioField } from '../stream-availability/collectible-g
 import { UsdcPurchaseGatedRadioField } from '../stream-availability/usdc-purchase-gated/UsdcPurchaseGatedRadioField'
 import { STREAM_AVAILABILITY_TYPE, STREAM_CONDITIONS } from '../types'
 
-import styles from './PriceAndAudienceField.module.css'
-
 const messagesV1 = {
   title: 'Access & Sale',
   modalDescription:
@@ -59,8 +57,8 @@ const messagesV1 = {
 const messagesV2 = {
   title: 'Price & Audience',
   modalDescription: '',
-  public: 'Free for Everyone',
-  publicSubtitle: (contentType: 'album' | 'track') =>
+  free: 'Free for Everyone',
+  freeSubtitle: (contentType: 'album' | 'track') =>
     `Everyone can play your ${contentType} for free.`,
   specialAccessSubtitle: 'Only fans who meet certain criteria can listen.'
 }
@@ -103,9 +101,7 @@ export const PriceAndAudienceMenuFields = (
     ? isPremiumAlbumsEnabled && isUsdcFlagUploadEnabled
     : isUsdcFlagUploadEnabled
 
-  const [availabilityField] = useField({
-    name: STREAM_AVAILABILITY_TYPE
-  })
+  const [availabilityField] = useField({ name: STREAM_AVAILABILITY_TYPE })
 
   const messages = useMessages(
     messagesV1,
@@ -139,13 +135,22 @@ export const PriceAndAudienceMenuFields = (
       )}
       {isPublishDisabled ? <Hint>{messages.publishDisabled}</Hint> : null}
       <RadioGroup {...availabilityField} aria-label={messages.title}>
-        <ModalRadioItem
-          icon={<IconVisibilityPublic className={styles.icon} />}
-          label={messages.public}
-          description={messages.publicSubtitle(isAlbum ? 'album' : 'track')}
-          value={StreamTrackAvailabilityType.PUBLIC}
-          disabled={isPublishDisabled}
-        />
+        {isHiddenPaidScheduledEnabled ? (
+          <ModalRadioItem
+            label={messages.free}
+            description={messages.freeSubtitle(isAlbum ? 'album' : 'track')}
+            value={StreamTrackAvailabilityType.FREE}
+            disabled={isPublishDisabled}
+          />
+        ) : (
+          <ModalRadioItem
+            icon={<IconVisibilityPublic />}
+            label={messages.public}
+            description={messages.publicSubtitle(isAlbum ? 'album' : 'track')}
+            value={StreamTrackAvailabilityType.PUBLIC}
+            disabled={isPublishDisabled}
+          />
+        )}
         {isUsdcUploadEnabled ? (
           <UsdcPurchaseGatedRadioField
             isRemix={isRemix}


### PR DESCRIPTION
### Description

Removes visibility options by preventing those values leaking into the experience when "HIDDEN_PAID_SCHEDULED" flag is on.

Im wondering if it's cleaner to implement all these changes without a feature flag at this point, it would help us clean up a A LOT of code if so. Right now my thinking is we get this reviewed by sammie, and then can fast follow a full removal of the old flow?