### PR TITLE
handle ba cids without upload id in audio analysis backfill

### DIFF
--- a/mediorum/server/serve_audio_analysis.go
+++ b/mediorum/server/serve_audio_analysis.go
@@ -4,8 +4,6 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/AudiusProject/audius-protocol/mediorum/cidutil"
-
 	"github.com/labstack/echo/v4"
 )
 
@@ -37,10 +35,6 @@ func (ss *MediorumServer) analyzeUpload(c echo.Context) error {
 // does nothing and returns the analysis results if analysis previously succeeded.
 func (ss *MediorumServer) analyzeLegacyBlob(c echo.Context) error {
 	cid := c.Param("cid")
-	if !cidutil.IsLegacyCIDStrict(cid) {
-		return c.String(http.StatusBadRequest, "must specify a legacy cid")
-	}
-
 	var analysis *QmAudioAnalysis
 	err := ss.crud.DB.First(&analysis, "cid = ?", cid).Error
 	if err != nil {
@@ -76,10 +70,6 @@ func (ss *MediorumServer) analyzeLegacyBlob(c echo.Context) error {
 
 func (ss *MediorumServer) serveLegacyBlobAnalysis(c echo.Context) error {
 	cid := c.Param("cid")
-	if !cidutil.IsLegacyCIDStrict(cid) {
-		return c.String(http.StatusBadRequest, "must specify a legacy cid")
-	}
-
 	var analysis *QmAudioAnalysis
 	err := ss.crud.DB.First(&analysis, "cid = ?", cid).Error
 	if err != nil {

--- a/packages/discovery-provider/plugins/pedalboard/apps/backfill-audio-analyses/src/backfill.ts
+++ b/packages/discovery-provider/plugins/pedalboard/apps/backfill-audio-analyses/src/backfill.ts
@@ -63,7 +63,7 @@ async function analyzeAudio(
   const trackCid = track.track_cid
   // only analyze streamable tracks
   if (!trackCid) return
-  const isLegacyTrack = !audioUploadId && trackCid.startsWith('Qm')
+  const isLegacyTrack = !audioUploadId
 
   const release = await semaphore.acquire() // acquire a semaphore permit
 


### PR DESCRIPTION
### Description
noticed some valid, streamable `track` records in discovery with ba `track_cid`s but no `audio_upload_id` after running the mediorum audio analysis backfill on stage. i assume this is from some intermediate state during the storage v2 migration. handle these tracks the same way as the legacy Qm track cids.

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._
