### PR TITLE
[PAY-3109] Switch back to web3 account when management access is revoked

### DIFF
--- a/packages/common/src/hooks/useAccountSwitcher.ts
+++ b/packages/common/src/hooks/useAccountSwitcher.ts
@@ -30,7 +30,16 @@ export const useAccountSwitcher = () => {
     [currentWeb3User, localStorage]
   )
 
-  return { switchAccount }
+  /** Convenience method to switch out of Manager Mode and back to the current web3 user */
+  const switchToWeb3User = useCallback(async () => {
+    if (!currentWeb3User) {
+      console.error('No current web3 user')
+      return
+    }
+    switchAccount(currentWeb3User)
+  }, [switchAccount, currentWeb3User])
+
+  return { switchAccount, switchToWeb3User }
 }
 
 /** Determines if we are in Manager Mode, i.e. the current user is not the logged-in user */

--- a/packages/web/src/components/nav/desktop/AccountSwitcher/AccountSwitcher.tsx
+++ b/packages/web/src/components/nav/desktop/AccountSwitcher/AccountSwitcher.tsx
@@ -65,9 +65,6 @@ export const AccountSwitcher = () => {
       currentUserId !== currentWeb3User.user_id &&
       !accounts.some(({ user: { user_id } }) => user_id === currentUserId)
     ) {
-      console.warn(
-        `Current user is not in managed accounts list. Switching to logged in user.`
-      )
       switchToWeb3User()
     }
   }, [

--- a/packages/web/src/components/nav/desktop/AccountSwitcher/AccountSwitcher.tsx
+++ b/packages/web/src/components/nav/desktop/AccountSwitcher/AccountSwitcher.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useRef, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 
 import {
   useGetCurrentUserId,
@@ -6,7 +6,7 @@ import {
   useGetManagedAccounts
 } from '@audius/common/api'
 import { useAccountSwitcher } from '@audius/common/hooks'
-import { UserMetadata } from '@audius/common/models'
+import { Status, UserMetadata } from '@audius/common/models'
 import { accountSelectors } from '@audius/common/store'
 import { Box, IconButton, IconCaretDown, Popup } from '@audius/harmony'
 import { useSelector } from 'react-redux'
@@ -16,6 +16,7 @@ import { AccountListContent } from './AccountListContent'
 export const AccountSwitcher = () => {
   const [isExpanded, setIsExpanded] = useState(false)
   const userId = useSelector(accountSelectors.getUserId)
+  const [checkedAccess, setCheckedAccess] = useState(false)
 
   const { data: currentWeb3User } = useGetCurrentWeb3User(
     {},
@@ -23,7 +24,7 @@ export const AccountSwitcher = () => {
   )
   const { data: currentUserId } = useGetCurrentUserId({}, { disabled: !userId })
 
-  const { switchAccount } = useAccountSwitcher()
+  const { switchAccount, switchToWeb3User } = useAccountSwitcher()
 
   const onAccountSelected = useCallback(
     (user: UserMetadata) => {
@@ -34,10 +35,8 @@ export const AccountSwitcher = () => {
 
   const web3UserId = currentWeb3User?.user_id ?? null
 
-  const { data: managedAccounts = [] } = useGetManagedAccounts(
-    { userId: web3UserId! },
-    { disabled: !web3UserId }
-  )
+  const { data: managedAccounts = [], status: accountsStatus } =
+    useGetManagedAccounts({ userId: web3UserId! }, { disabled: !web3UserId })
 
   const parentElementRef = useRef<HTMLDivElement>(null)
   const onClickExpander = useCallback(
@@ -48,6 +47,37 @@ export const AccountSwitcher = () => {
   const accounts = useMemo(() => {
     return managedAccounts.filter(({ grant }) => grant.is_approved)
   }, [managedAccounts])
+
+  // Reset to the web3User if we detect that the current user is no longer in
+  // the managed accounts list
+  useEffect(() => {
+    if (
+      !currentUserId ||
+      !currentWeb3User ||
+      accountsStatus !== Status.SUCCESS ||
+      checkedAccess
+    ) {
+      return
+    }
+    // Check this only once per mount
+    setCheckedAccess(true)
+    if (
+      currentUserId !== currentWeb3User.user_id &&
+      !accounts.some(({ user: { user_id } }) => user_id === currentUserId)
+    ) {
+      console.warn(
+        `Current user is not in managed accounts list. Switching to logged in user.`
+      )
+      switchToWeb3User()
+    }
+  }, [
+    accounts,
+    accountsStatus,
+    checkedAccess,
+    currentUserId,
+    currentWeb3User,
+    switchToWeb3User
+  ])
 
   return !currentWeb3User || !currentUserId || accounts.length === 0 ? null : (
     <Box ref={parentElementRef}>

--- a/packages/web/src/pages/settings-page/components/desktop/ManagerMode/RemoveManagerConfirmationContent.tsx
+++ b/packages/web/src/pages/settings-page/components/desktop/ManagerMode/RemoveManagerConfirmationContent.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect } from 'react'
 
-import { useRemoveManager } from '@audius/common/api'
+import { useGetCurrentWeb3User, useRemoveManager } from '@audius/common/api'
+import { useAccountSwitcher } from '@audius/common/hooks'
 import { Status } from '@audius/common/models'
 import { Button, Flex, Text } from '@audius/harmony'
 
@@ -26,6 +27,9 @@ export const RemoveManagerConfirmationContent = ({
   onCancel
 }: RemoveManagerConfirmationContentProps) => {
   const [removeManager, result] = useRemoveManager()
+  const { data: currentWeb3User } = useGetCurrentWeb3User({})
+  const managerIsCurrentWeb3User = currentWeb3User?.user_id === managerUserId
+  const { switchToWeb3User } = useAccountSwitcher()
   const { status } = result
 
   const handleDelete = useCallback(() => {
@@ -36,8 +40,9 @@ export const RemoveManagerConfirmationContent = ({
   useEffect(() => {
     if (status === Status.SUCCESS) {
       onSuccess()
+      if (managerIsCurrentWeb3User) switchToWeb3User()
     }
-  }, [status, onSuccess])
+  }, [status, managerIsCurrentWeb3User, switchToWeb3User, onSuccess])
 
   if (!managerUserId) return null
 


### PR DESCRIPTION
### Description
This handles two scenarios:
* Loading / reloading the page while switched into an account for which you have lost management access
* Removing yourself from the managers list via the Accounts Managing You dialog while switched into an account

In both scenarios, we will switch back to the current web3 user.

fixes PAY-3109

### How Has This Been Tested?
Tested locally against staging.
