### PR TITLE
[Protodash] Show pending transactions on Overview page; tell users they have to come back to undelegate [QA-1396]

### DIFF
--- a/protocol-dashboard/src/components/ManageService/ManageService.tsx
+++ b/protocol-dashboard/src/components/ManageService/ManageService.tsx
@@ -61,6 +61,9 @@ import { useModalControls } from 'utils/hooks'
 
 import styles from './ManageService.module.css'
 import { RegisterNewServiceBtn } from './RegisterNewServiceBtn'
+import { InfoBox } from 'components/InfoBox/InfoBox'
+import { sharedMessages } from 'utils/sharedMessages'
+import { COOLDOWN_PERIOD_DOCS_URL } from 'utils/routes'
 
 const messages = {
   ownerTitle: 'Your Nodes',
@@ -179,11 +182,18 @@ const UndelegateSection = ({
   }, [undelegateStake, delegates, wallet])
 
   const bottomBox = (
-    <ToOperator
-      name={name || formatShortWallet(wallet ?? '')}
-      wallet={wallet}
-      isFrom
-    />
+    <Flex direction='column' gap='xl' mb='xl'>
+      <ToOperator
+        name={name || formatShortWallet(wallet ?? '')}
+        wallet={wallet}
+        isFrom
+      />
+      <InfoBox
+        description={sharedMessages.undelegateCooldown}
+        ctaHref={COOLDOWN_PERIOD_DOCS_URL}
+        ctaText={sharedMessages.unddelegateCooldownCta}
+      />
+    </Flex>
   )
   const undelegateBox = <Delegating isUndelegating amount={delegates} />
 

--- a/protocol-dashboard/src/components/UpdateDelegationModal/UpdateDelegationModal.tsx
+++ b/protocol-dashboard/src/components/UpdateDelegationModal/UpdateDelegationModal.tsx
@@ -41,6 +41,8 @@ import { checkWeiNumber, parseWeiNumber } from 'utils/numeric'
 import { sharedMessages } from 'utils/sharedMessages'
 
 import styles from './UpdateDelegationModal.module.css'
+import { InfoBox } from 'components/InfoBox/InfoBox'
+import { COOLDOWN_PERIOD_DOCS_URL } from 'utils/routes'
 
 const messages = {
   manageDelegation: 'Manage Delegation',
@@ -382,6 +384,13 @@ const UpdateDelegationModal: React.FC<UpdateDelegationModalProps> = ({
                       text={messages.saveChanges}
                       type={ButtonType.PRIMARY}
                       onClick={onConfirm}
+                    />
+                  )}
+                  {isIncrease ? null : (
+                    <InfoBox
+                      description={sharedMessages.undelegateCooldown}
+                      ctaHref={COOLDOWN_PERIOD_DOCS_URL}
+                      ctaText={sharedMessages.unddelegateCooldownCta}
                     />
                   )}
                 </Flex>

--- a/protocol-dashboard/src/containers/Home/Home.tsx
+++ b/protocol-dashboard/src/containers/Home/Home.tsx
@@ -46,6 +46,7 @@ import {
 import desktopStyles from './Home.module.css'
 import mobileStyles from './HomeMobile.module.css'
 import { InfoCard } from './InfoCard'
+import TransactionStatus from 'components/TransactionStatus'
 
 const styles = createStyles({ desktopStyles, mobileStyles })
 
@@ -179,7 +180,12 @@ const Home = () => {
           <EstimatedWeeklyStat />
           <EstimatedAnnualStat />
         </Card>
-        {isLoggedIn && wallet ? <ManageAccountCard wallet={wallet} /> : null}
+        {isLoggedIn && wallet ? (
+          <>
+            <TransactionStatus />
+            <ManageAccountCard wallet={wallet} />
+          </>
+        ) : null}
         <RewardsTimingCard />
         <Paper className={styles.proposals}>
           <Box p='xl'>

--- a/protocol-dashboard/src/utils/routes.ts
+++ b/protocol-dashboard/src/utils/routes.ts
@@ -84,6 +84,8 @@ export const AUDIUS_DAPP_URL =
 export const DOCS_URL = 'https://docs.audius.org/'
 export const REGISTER_NODE_DOCS_URL =
   'https://docs.audius.org/node-operator/setup/overview'
+export const COOLDOWN_PERIOD_DOCS_URL =
+  'https://docs.audius.org/node-operator/staking/delegate#cooldown-period'
 
 // Get Routes
 export const accountPage = (address: string) => {

--- a/protocol-dashboard/src/utils/sharedMessages.ts
+++ b/protocol-dashboard/src/utils/sharedMessages.ts
@@ -1,4 +1,7 @@
 export const sharedMessages = {
   twoPopupsWarning:
-    'There will be 2 consecutive transaction requests to approve in your wallet.'
+    'There will be 2 consecutive transaction requests to approve in your wallet.',
+  undelegateCooldown:
+    'After submitting, your transaction will appear under "Pending Transactions" on the Overview page. Come back after 7 days to confirm the transaction.',
+  unddelegateCooldownCta: 'Cooldown Period'
 }


### PR DESCRIPTION
### Description
-Show pending transactions on Overview Page
-When undelegating or decreasing delegation, tell user they have to come back after cooldown period + link to related docs.

Should resolve the semi regular inflow of support issues about this.

### How Has This Been Tested?
Locally against stage

<img width="1487" alt="Screenshot 2024-06-20 at 10 33 39 PM" src="https://github.com/AudiusProject/audius-protocol/assets/36916764/cf06e209-9f86-4493-b2c0-6bc9304ff5bd">
<img width="792" alt="Screenshot 2024-06-20 at 11 10 51 PM" src="https://github.com/AudiusProject/audius-protocol/assets/36916764/525dfa46-b98e-4b09-b068-f8d6b60f777c">
<img width="785" alt="Screenshot 2024-06-20 at 11 15 41 PM" src="https://github.com/AudiusProject/audius-protocol/assets/36916764/82b58b0c-7770-4786-aeeb-b1dc8405a3ce">