### PR TITLE
terminate legacy audio analysis jobs at some point so they do not get infinitely tried

### DIFF
--- a/mediorum/server/legacy_audio_analysis.go
+++ b/mediorum/server/legacy_audio_analysis.go
@@ -74,7 +74,7 @@ func (ss *MediorumServer) startLegacyAudioAnalyzer() {
 
 	// poll periodically for analyses that slipped thru the cracks
 	for {
-		time.Sleep(time.Second * 30)
+		time.Sleep(time.Minute)
 		ss.findMissedLegacyAnalysisJobs(work, myHost)
 	}
 }

--- a/mediorum/server/serve_audio_analysis.go
+++ b/mediorum/server/serve_audio_analysis.go
@@ -16,7 +16,7 @@ func (ss *MediorumServer) analyzeUpload(c echo.Context) error {
 		return echo.NewHTTPError(404, err.Error())
 	}
 
-	if upload.Template == "audio" && upload.Status == JobStatusDone && (upload.AudioAnalysisStatus == JobStatusTimeout || upload.AudioAnalysisStatus == JobStatusError) {
+	if upload.Template == "audio" && upload.Status == JobStatusDone && upload.AudioAnalysisStatus != JobStatusDone {
 		upload.AudioAnalyzedAt = time.Now().UTC()
 		upload.AudioAnalysisStatus = ""
 		upload.AudioAnalysisError = ""

--- a/mediorum/server/serve_audio_analysis.go
+++ b/mediorum/server/serve_audio_analysis.go
@@ -16,7 +16,7 @@ func (ss *MediorumServer) analyzeUpload(c echo.Context) error {
 		return echo.NewHTTPError(404, err.Error())
 	}
 
-	if upload.Template == "audio" && upload.Status == JobStatusDone && upload.AudioAnalysisStatus != JobStatusDone {
+	if upload.Template == "audio" && upload.Status == JobStatusDone && (upload.AudioAnalysisStatus == JobStatusTimeout || upload.AudioAnalysisStatus == JobStatusError) {
 		upload.AudioAnalyzedAt = time.Now().UTC()
 		upload.AudioAnalysisStatus = ""
 		upload.AudioAnalysisError = ""
@@ -52,7 +52,7 @@ func (ss *MediorumServer) analyzeLegacyBlob(c echo.Context) error {
 		}
 		return c.JSON(200, newAnalysis)
 	}
-	if analysis.Status != JobStatusDone {
+	if analysis.Status == JobStatusError || analysis.Status == JobStatusTimeout {
 		if analysis.Error == "blob is not an audio file" {
 			return c.String(http.StatusBadRequest, "must specify a cid for an audio file")
 		}


### PR DESCRIPTION
### Description
if an analysis job is not found on the first 3 mirrors right now, it will never be terminated.
change so it checks all mirrors and terminates on any error if it reaches the last mirror, or after 45 minutes, so it doesn't get infinitely retried.

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._
