### PR TITLE
order tracks in query in audio analysis repairer

### DIFF
--- a/packages/discovery-provider/src/app.py
+++ b/packages/discovery-provider/src/app.py
@@ -440,10 +440,6 @@ def configure_celery(celery, test_config=None):
                 "task": "create_engagement_notifications",
                 "schedule": timedelta(minutes=10),
             },
-            "repair_audio_analyses": {
-                "task": "repair_audio_analyses",
-                "schedule": timedelta(minutes=2),
-            },
         },
         task_serializer="json",
         accept_content=["json"],

--- a/packages/discovery-provider/src/tasks/repair_audio_analyses.py
+++ b/packages/discovery-provider/src/tasks/repair_audio_analyses.py
@@ -32,6 +32,7 @@ def query_tracks(session: Session) -> List[Track]:
             Track.audio_analysis_error_count < 3,
             Track.track_cid != None,
         )
+        .order_by(Track.track_id.asc())
         .limit(BATCH_SIZE)
         .all()
     )


### PR DESCRIPTION
### Description
order by track id
also do not run task yet. found some issues that slowed down the prod backfill and would like nodes to pick up some mediorum fixes first + the backfill to complete. will put up a PR enabling this task so it can run later than originally planned - prob Friday afternoon as opposed to Friday during deploy.

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._
