### PR TITLE
[PAY-3111][PAY-3112] Fixes some timing issues with invites

### DIFF
--- a/packages/web/src/pages/settings-page/components/desktop/ManagerMode/AccountsManagingYouHomePage.tsx
+++ b/packages/web/src/pages/settings-page/components/desktop/ManagerMode/AccountsManagingYouHomePage.tsx
@@ -31,7 +31,11 @@ export const AccountsManagingYouHomePage = (
   const { toast } = useContext(ToastContext)
 
   const [removeManager, removeResult] = useRemoveManager()
-  const { data: managers, status: managersStatus } = useGetManagers({ userId })
+  // Always update manager list when mounting this page
+  const { data: managers, status: managersStatus } = useGetManagers(
+    { userId },
+    { force: true }
+  )
 
   const handleRemoveManager = useCallback(
     (params: { userId: number; managerUserId: number }) => {

--- a/packages/web/src/pages/settings-page/components/desktop/ManagerMode/AccountsManagingYouHomePage.tsx
+++ b/packages/web/src/pages/settings-page/components/desktop/ManagerMode/AccountsManagingYouHomePage.tsx
@@ -36,6 +36,9 @@ export const AccountsManagingYouHomePage = (
     { userId },
     { force: true }
   )
+  // Don't flash loading spinner if we are refreshing the cache
+  const isLoading =
+    managersStatus !== Status.SUCCESS && (!managers || managers.length === 0)
 
   const handleRemoveManager = useCallback(
     (params: { userId: number; managerUserId: number }) => {
@@ -76,7 +79,7 @@ export const AccountsManagingYouHomePage = (
         </Button>
       </Flex>
       <Flex direction='column' gap='s'>
-        {managersStatus !== Status.SUCCESS ? (
+        {isLoading ? (
           <Box pv='2xl'>
             <LoadingSpinner
               css={({ spacing }) => ({

--- a/packages/web/src/pages/settings-page/components/desktop/ManagerMode/AccountsYouManageHomePage.tsx
+++ b/packages/web/src/pages/settings-page/components/desktop/ManagerMode/AccountsYouManageHomePage.tsx
@@ -35,7 +35,6 @@ export const AccountsYouManageHomePage = ({
   const { data: managedAccounts, status } = useGetManagedAccounts(
     { userId: userId! },
     // Always update managed accounts list when mounting this page
-    // TODO: This pattern causes a flash on both modals, maybe update it to SWR-style
     { disabled: userId == null, force: true }
   )
   // Don't flash loading spinner if we are refreshing the cache

--- a/packages/web/src/pages/settings-page/components/desktop/ManagerMode/AccountsYouManageHomePage.tsx
+++ b/packages/web/src/pages/settings-page/components/desktop/ManagerMode/AccountsYouManageHomePage.tsx
@@ -34,7 +34,9 @@ export const AccountsYouManageHomePage = ({
   const userId = currentUser?.user_id
   const { data: managedAccounts, status } = useGetManagedAccounts(
     { userId: userId! },
-    { disabled: userId == null }
+    // Always update managed accounts list when mounting this page
+    // TODO: This pattern causes a flash on both modals, maybe update it to SWR-style
+    { disabled: userId == null, force: true }
   )
   const [approveManagedAccount, approveResult] = useApproveManagedAccount()
   const [rejectManagedAccount, rejectResult] = useRemoveManager()

--- a/packages/web/src/pages/settings-page/components/desktop/ManagerMode/AccountsYouManageHomePage.tsx
+++ b/packages/web/src/pages/settings-page/components/desktop/ManagerMode/AccountsYouManageHomePage.tsx
@@ -38,6 +38,10 @@ export const AccountsYouManageHomePage = ({
     // TODO: This pattern causes a flash on both modals, maybe update it to SWR-style
     { disabled: userId == null, force: true }
   )
+  // Don't flash loading spinner if we are refreshing the cache
+  const isLoading =
+    status !== Status.SUCCESS &&
+    (!managedAccounts || managedAccounts.length === 0)
   const [approveManagedAccount, approveResult] = useApproveManagedAccount()
   const [rejectManagedAccount, rejectResult] = useRemoveManager()
   const { toast } = useContext(ToastContext)
@@ -97,7 +101,7 @@ export const AccountsYouManageHomePage = ({
       <Text variant='body' size='l'>
         {messages.takeControl}{' '}
       </Text>
-      {status !== Status.SUCCESS ? (
+      {isLoading ? (
         <Box pv='2xl'>
           <LoadingSpinner
             css={({ spacing }) => ({

--- a/packages/web/src/pages/settings-page/components/desktop/ManagerMode/AccountsYouManageSettingsCard.tsx
+++ b/packages/web/src/pages/settings-page/components/desktop/ManagerMode/AccountsYouManageSettingsCard.tsx
@@ -1,8 +1,8 @@
 import { useCallback, useEffect, useState } from 'react'
 
 import { Button, IconUserArrowRotate } from '@audius/harmony'
+import { useLocation } from 'react-router-dom'
 
-import { useHistoryContext } from 'app/HistoryProvider'
 import { ACCOUNTS_YOU_MANAGE_SETTINGS_PAGE, doesMatchRoute } from 'utils/route'
 
 import SettingsCard from '../SettingsCard'
@@ -18,17 +18,14 @@ const messages = {
 
 export const AccountsYouManageSettingsCard = () => {
   const [isModalOpen, setIsModalOpen] = useState(false)
-  const { history } = useHistoryContext()
+  const location = useLocation()
 
   useEffect(() => {
-    const match = doesMatchRoute(
-      history.location,
-      ACCOUNTS_YOU_MANAGE_SETTINGS_PAGE
-    )
+    const match = doesMatchRoute(location, ACCOUNTS_YOU_MANAGE_SETTINGS_PAGE)
     if (match) {
       setIsModalOpen(true)
     }
-  }, [history.location])
+  }, [location])
 
   const handleOpen = useCallback(() => {
     setIsModalOpen(true)


### PR DESCRIPTION
### Description
* Force refresh on the managers/managed accounts whenever the list page of either modal mounts. This will help prevent stale state.
* Don't show the loading spinner if we have already loaded once. This prevents rapid flashes of different sizes due to jumping between the already loaded list and the loading spinner. It's fine if the list takes a second and then the items change
* Update the matching logic to use react-router location instead of the history context, since the former correctly updates and triggers the effect if changed while on the same route.

fixes PAY-3111
fixes PAY-3112

### How Has This Been Tested?
Tested locally against staging.
