### PR TITLE
Use 1 CPU for audio analysis

### DIFF
--- a/mediorum/server/audio_analysis.go
+++ b/mediorum/server/audio_analysis.go
@@ -8,7 +8,6 @@ import (
 	"log"
 	"os"
 	"os/exec"
-	"runtime"
 	"strconv"
 	"strings"
 	"sync"
@@ -24,11 +23,8 @@ func (ss *MediorumServer) startAudioAnalyzer() {
 	myHost := ss.Config.Self.Host
 	work := make(chan *Upload)
 
-	// use most cpus
-	numWorkers := runtime.NumCPU() - 2
-	if numWorkers < 2 {
-		numWorkers = 2
-	}
+	// use one cpu
+	numWorkers := 1
 
 	// on boot... reset any of my wip jobs
 	tx := ss.crud.DB.Model(Upload{}).

--- a/mediorum/server/legacy_audio_analysis.go
+++ b/mediorum/server/legacy_audio_analysis.go
@@ -7,7 +7,6 @@ import (
 	"io"
 	"log"
 	"os"
-	"runtime"
 	"strings"
 	"sync"
 	"time"
@@ -22,11 +21,8 @@ func (ss *MediorumServer) startLegacyAudioAnalyzer() {
 	myHost := ss.Config.Self.Host
 	work := make(chan *QmAudioAnalysis)
 
-	// use most cpus
-	numWorkers := runtime.NumCPU() - 2
-	if numWorkers < 2 {
-		numWorkers = 2
-	}
+	// use aone cpu
+	numWorkers := 1
 
 	// on boot... reset any of my wip jobs
 	tx := ss.crud.DB.Model(QmAudioAnalysis{}).


### PR DESCRIPTION
All the workers are trying to use most of the CPUs.  This takes it down to 1 each for audio analysis.  We can maybe bump it up later, but might make sense to have a more centralized worker pool thing for resource management stuff.