### PR TITLE
Add completed at to undisbursed response

### DIFF
--- a/packages/discovery-provider/src/api/v1/models/challenges.py
+++ b/packages/discovery-provider/src/api/v1/models/challenges.py
@@ -21,6 +21,7 @@ undisbursed_challenge = ns.model(
         "handle": fields.String(required=True),
         "wallet": fields.String(required=True),
         "created_at": fields.String(required=True),
+        "completed_at": fields.String(required=True),
         "cooldown_days": fields.Integer(required=False),
     },
 )


### PR DESCRIPTION
### Description
Undisbursed response needs this completed_at field for determining claimable challenges

https://github.com/AudiusProject/audius-protocol/blob/main/packages/common/src/utils/challenges.ts#L258

Not sure how this was working before, something must've changed. 

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._

Tested on stage. Rewards that were at an incorrect later date were now claimable.