### PR TITLE
[PAY-3126] Refresh signature headers when wallet changes

### DIFF
--- a/.changeset/big-beers-remain.md
+++ b/.changeset/big-beers-remain.md
@@ -1,0 +1,5 @@
+---
+'@audius/sdk': patch
+---
+
+fix stale signatures when auth address changes

--- a/packages/libs/src/sdk/middleware/addRequestSignatureMiddleware.ts
+++ b/packages/libs/src/sdk/middleware/addRequestSignatureMiddleware.ts
@@ -10,7 +10,7 @@ const MESSAGE_HEADER = 'Encoded-Data-Message'
 const SIGNATURE_HEADER = 'Encoded-Data-Signature'
 
 let message: string | null = null
-let address: string | null = null
+let signatureAddress: string | null = null
 let signature: string | null = null
 let timestamp: number | null = null
 
@@ -28,13 +28,18 @@ export const addRequestSignatureMiddleware = ({
     pre: async (context: RequestContext): Promise<FetchParams> => {
       const { auth, logger } = services
       try {
-        const walletAddress = await auth.getAddress()
+        const currentAddress = await auth.getAddress()
         const currentTimestamp = new Date().getTime()
         const isExpired =
           !timestamp || timestamp + SIGNATURE_EXPIRY_MS < currentTimestamp
 
-        if (!message || !signature || isExpired || address !== walletAddress) {
-          address = walletAddress
+        if (
+          !message ||
+          !signature ||
+          isExpired ||
+          signatureAddress !== currentAddress
+        ) {
+          signatureAddress = currentAddress
           const m = `signature:${currentTimestamp}`
           // Add Ethereum-specific prefixes
           const prefix = `\x19Ethereum Signed Message:\n${m.length}`


### PR DESCRIPTION
### Description
This fixes a subtle class of signon/signup bugs due to the SDK signature being stale. The process is:
1. SDK is initialized with `auth` service and signature middleware signs its first request. We store the computed message and a timestamp so that we aren't trying to re-sign the same message on every request using an expensive operations
2. The underlying hedgehog wallet changes (either due to completing sign-in or completing sign-up).
3. SDK starts making request to endpoints with a new contextual user, but using the cached signature from the previous wallet address
4. DNs and Identity may reject the request because the recovered wallet from the signature doesn't match the user making the request
-- 60 seconds later.... --
5. The timestamp expires and we generate a new signature, from the updated wallet. Requests from here on out succeed.

It's kind of specific to a handful of flows, but it _really_ messes with things :-)

The fix for now is to track the address returned by the `auth` service and regenerate the signature whenever that doesn't match our cached address. It would be nice to do this in a future via a method that does not require an `await` on every request. But the code on the other side of the `await` is quick, so this isn't adding a lot of overhead.

fixes PAY-3126

### How Has This Been Tested?
Tested in local client against local protocol stack by creating users and then attempting to fetch managers via the settings page within 60 seconds of finishing account creation.
