### PR TITLE
[PAY-3117] Fixes some issues with Identity notifications in manager mode

### DIFF
--- a/packages/common/src/services/audius-backend/AudiusBackend.ts
+++ b/packages/common/src/services/audius-backend/AudiusBackend.ts
@@ -2151,8 +2151,9 @@ export const audiusBackend = ({
         withTrendingTrack: true
       }
 
+      // Passing user_id to support manager mode
       const getNotificationsUrl = queryString.stringifyUrl({
-        url: `${identityServiceUrl}/notifications`,
+        url: `${identityServiceUrl}/notifications?user_id=${account.user_id}`,
         query
       })
 
@@ -2205,15 +2206,19 @@ export const audiusBackend = ({
     let notificationsReadResponse
     try {
       const { data, signature } = await signData()
-      const response = await fetch(`${identityServiceUrl}/notifications/all`, {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          [AuthHeaders.Message]: data,
-          [AuthHeaders.Signature]: signature
-        },
-        body: JSON.stringify({ isViewed: true, clearBadges: !!nativeMobile })
-      })
+      // Passing `user_id` to support manager mode
+      const response = await fetch(
+        `${identityServiceUrl}/notifications/all?user_id=${account.user_id}`,
+        {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            [AuthHeaders.Message]: data,
+            [AuthHeaders.Signature]: signature
+          },
+          body: JSON.stringify({ isViewed: true, clearBadges: !!nativeMobile })
+        }
+      )
       notificationsReadResponse = await response.json()
     } catch (e) {
       console.error(e)

--- a/packages/identity-service/src/authMiddleware.js
+++ b/packages/identity-service/src/authMiddleware.js
@@ -102,7 +102,7 @@ async function authMiddleware(req, res, next) {
     const encodedDataMessage = req.get('Encoded-Data-Message')
     const signature = req.get('Encoded-Data-Signature')
     const handle = req.query.handle
-    const actingUserId = req.query.user_id
+    const actingUserId = Number.parseInt(req.query.user_id, 10)
 
     if (!encodedDataMessage) throw new Error('[Error]: Encoded data missing')
     if (!signature) throw new Error('[Error]: Encoded data signature missing')

--- a/packages/identity-service/src/routes/notifications.js
+++ b/packages/identity-service/src/routes/notifications.js
@@ -624,7 +624,7 @@ module.exports = function (app) {
       }
       try {
         if (notificationType === NotificationType.Announcement) {
-          const announcementMap = app.get('announcementMap')
+          const announcementMap = app.get('announcementMap') ?? {}
           const announcement = announcementMap[notificationId]
           if (!announcement)
             return errorResponseBadRequest('[Error] Invalid notification id')
@@ -703,7 +703,7 @@ module.exports = function (app) {
 
         await models.SolanaNotification.update(update, { where: { userId } })
 
-        const announcementMap = app.get('announcementMap')
+        const announcementMap = app.get('announcementMap') ?? {}
         const unreadAnnouncementIds = Object.keys(announcementMap).reduce(
           (acc, id) => {
             if (moment(announcementMap[id].datePublished).isAfter(createdDate))
@@ -742,6 +742,7 @@ module.exports = function (app) {
         }
         return successResponse({ message: 'success' })
       } catch (err) {
+        req.logger.error(err)
         return errorResponseBadRequest({
           message: `[Error] Unable to mark notification as read/hidden`
         })


### PR DESCRIPTION
### Description
We support fetching and marking notifications as read in Manager Mode. Identity is getting support for this in #8844 , and this PR updates the two additional endpoints that need it.

I also fixed two issues that came up while testing this against Identity:
* We don't parse the query parameter for `user_id` into a number, so the `!==` check always fails (the user we fetch from discovery has a user_id that is a number)
* There are some usages of `announcementMap` that don't check the object is initialized before attempting to read it, and this throws an error at least locally (and likely on staging/production after a full restart of the service)

### How Has This Been Tested?
Tested locally against staging.
