### PR TITLE
Fix premium content label text wrap

### DIFF
--- a/packages/web/src/components/track/DownloadRow.tsx
+++ b/packages/web/src/components/track/DownloadRow.tsx
@@ -102,7 +102,7 @@ export const DownloadRow = ({
             css={{
               overflow: 'hidden',
               textOverflow: 'ellipsis',
-              'white-space': 'nowrap'
+              whiteSpace: 'nowrap'
             }}
           >
             {getDownloadFilename({
@@ -119,7 +119,7 @@ export const DownloadRow = ({
             size='s'
             color='subdued'
             css={{
-              'white-space': 'nowrap'
+              whiteSpace: 'nowrap'
             }}
           >
             {formatBytes(size)}

--- a/packages/web/src/components/track/GatedContentLabel.tsx
+++ b/packages/web/src/components/track/GatedContentLabel.tsx
@@ -57,7 +57,7 @@ export const GatedContentLabel = ({
     isOwner || !hasStreamAccess ? specialColor : color.icon.default
 
   return (
-    <Flex alignItems='center' gap='xs'>
+    <Flex alignItems='center' gap='xs' css={{ whiteSpace: 'nowrap' }}>
       <IconComponent size='s' fill={finalColor} />
       <Text variant='body' size='xs' css={{ color: finalColor }}>
         {message}


### PR DESCRIPTION
### Description
Noticed that the "special access" and "collectible gated" labels on track tiles were wrapping to 2 lines.

Also sliding in a small code cleanup changing the css prop `'white-space'` to `whiteSpace` in `DownloadRow`.

### How Has This Been Tested?

<img width="746" alt="Screenshot 2024-06-21 at 4 07 38 PM" src="https://github.com/AudiusProject/audius-protocol/assets/3893871/6a834bc2-65ab-4c1f-8c1f-2a64cf049095">
