### PR TITLE
[PAY-3113] Styling fixes for artist info in Manager Mode Modals

### DIFF
--- a/packages/web/src/pages/settings-page/components/desktop/ManagerMode/AccountListItem.module.css
+++ b/packages/web/src/pages/settings-page/components/desktop/ManagerMode/AccountListItem.module.css
@@ -1,0 +1,27 @@
+:root {
+  --profile-picture-size: var(--harmony-unit-18);
+}
+
+.profilePictureWrapper {
+  height: var(--profile-picture-size);
+  width: var(--profile-picture-size);
+  flex: 0 0 var(--profile-picture-size);
+}
+
+.profilePicture {
+  box-sizing: border-box;
+  height: var(--profile-picture-size);
+  width: var(--profile-picture-size);
+  flex: 0 0 var(--profile-picture-size);
+  border: 1px solid var(--harmony-n-100);
+  border-radius: 50%;
+
+  background-size: cover;
+  background-position: center;
+  background-repeat: no-repeat;
+  background-color: var(--default-profile-picture-background);
+}
+
+.profilePictureSkeleton {
+  border-radius: 50%;
+}

--- a/packages/web/src/pages/settings-page/components/desktop/ManagerMode/AccountListItem.tsx
+++ b/packages/web/src/pages/settings-page/components/desktop/ManagerMode/AccountListItem.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useMemo } from 'react'
 
 import { useAccountSwitcher, useIsManagedAccount } from '@audius/common/hooks'
-import { User, UserMetadata } from '@audius/common/models'
+import { SquareSizes, User, UserMetadata } from '@audius/common/models'
 import { accountSelectors, chatSelectors } from '@audius/common/store'
 import {
   Button,
@@ -15,15 +15,19 @@ import {
   IconUser,
   IconUserArrowRotate,
   PopupMenu,
-  Text
+  Text,
+  useTheme
 } from '@audius/harmony'
 
-import ArtistChip from 'components/artist/ArtistChip'
 import { useNavigateToPage } from 'hooks/useNavigateToPage'
 import { useComposeChat } from 'pages/chat-page/components/useComposeChat'
 import { useSelector } from 'utils/reducer'
 import { profilePage } from 'utils/route'
 import zIndex from 'utils/zIndex'
+import { useProfilePicture } from 'hooks/useUserProfilePicture'
+import DynamicImage from 'components/dynamic-image/DynamicImage'
+import UserBadges from 'components/user-badges/UserBadges'
+import styles from './AccountListItem.module.css'
 
 const { getUserId } = accountSelectors
 const { getCanCreateChat } = chatSelectors
@@ -53,6 +57,33 @@ type AccountListItemProps = {
     currentUserId: number
     grantorUser: User | UserMetadata
   }) => void
+}
+
+const ArtistInfo = ({ user }: { user: UserMetadata }) => {
+  const profilePicture = useProfilePicture(
+    user.user_id,
+    SquareSizes.SIZE_150_BY_150
+  )
+  const { iconSizes, color } = useTheme()
+  return (
+    <Flex gap='m' alignItems='center' justifyContent='flex-start'>
+      <DynamicImage
+        wrapperClassName={styles.profilePictureWrapper}
+        skeletonClassName={styles.profilePictureSkeleton}
+        className={styles.profilePicture}
+        image={profilePicture}
+      />
+      <Flex direction='column' gap='xs'>
+        <Flex gap='xs' alignItems='center' justifyContent='flex-start'>
+          <Text variant='body' size='m' strength='strong'>
+            {user.name}
+          </Text>
+          <UserBadges userId={user.user_id} badgeSize={iconSizes.m} inline />
+        </Flex>
+        <Text variant='body' size='m'>{`@${user.handle}`}</Text>
+      </Flex>
+    </Flex>
+  )
 }
 
 export const AccountListItem = ({
@@ -174,7 +205,7 @@ export const AccountListItem = ({
       ref={anchorRef}
       aria-label={messages.moreOptions}
       icon={IconKebabHorizontal}
-      color='default'
+      color='subdued'
       onClick={() => triggerPopup()}
     />
   )
@@ -185,11 +216,13 @@ export const AccountListItem = ({
     <Flex
       alignItems='stretch'
       justifyContent='space-between'
-      ph='xl'
+      pl='xl'
+      pr='l'
       pv='l'
+      gap='l'
       border='default'
     >
-      <ArtistChip user={user as any} showPopover={false} />
+      <ArtistInfo user={user as any} />
       <Flex direction='column' justifyContent='space-between' alignItems='end'>
         {!isPending || !isManagedAccount ? (
           <PopupMenu

--- a/packages/web/src/pages/settings-page/components/desktop/ManagerMode/AccountListItem.tsx
+++ b/packages/web/src/pages/settings-page/components/desktop/ManagerMode/AccountListItem.tsx
@@ -19,14 +19,15 @@ import {
   useTheme
 } from '@audius/harmony'
 
+import DynamicImage from 'components/dynamic-image/DynamicImage'
+import UserBadges from 'components/user-badges/UserBadges'
 import { useNavigateToPage } from 'hooks/useNavigateToPage'
+import { useProfilePicture } from 'hooks/useUserProfilePicture'
 import { useComposeChat } from 'pages/chat-page/components/useComposeChat'
 import { useSelector } from 'utils/reducer'
 import { profilePage } from 'utils/route'
 import zIndex from 'utils/zIndex'
-import { useProfilePicture } from 'hooks/useUserProfilePicture'
-import DynamicImage from 'components/dynamic-image/DynamicImage'
-import UserBadges from 'components/user-badges/UserBadges'
+
 import styles from './AccountListItem.module.css'
 
 const { getUserId } = accountSelectors
@@ -64,7 +65,7 @@ const ArtistInfo = ({ user }: { user: UserMetadata }) => {
     user.user_id,
     SquareSizes.SIZE_150_BY_150
   )
-  const { iconSizes, color } = useTheme()
+  const { iconSizes } = useTheme()
   return (
     <Flex gap='m' alignItems='center' justifyContent='flex-start'>
       <DynamicImage

--- a/packages/web/src/pages/settings-page/components/desktop/ManagerMode/AccountListItem.tsx
+++ b/packages/web/src/pages/settings-page/components/desktop/ManagerMode/AccountListItem.tsx
@@ -223,7 +223,7 @@ export const AccountListItem = ({
       gap='l'
       border='default'
     >
-      <ArtistInfo user={user as any} />
+      <ArtistInfo user={user} />
       <Flex direction='column' justifyContent='space-between' alignItems='end'>
         {!isPending || !isManagedAccount ? (
           <PopupMenu


### PR DESCRIPTION
### Description

This removes the usage of `ArtistChip` in favor of a simplified component similar to what's used in the AccountSwitcher.
We don't need the follower/follows you information in the list (only in search for finding your manager), and the alignment/layout is different than what `ArtistChip` supports.

### How Has This Been Tested?

With my eyes. And also some DOM inspection to make sure padding values are correct :-p 


### Screenshots

**Before**

![image](https://github.com/AudiusProject/audius-protocol/assets/1815175/17cf835f-1ca2-4daa-80b9-615828bf6bb1)
---

![image](https://github.com/AudiusProject/audius-protocol/assets/1815175/caf1b81d-0eb0-4334-b9b2-12e383e91183)


**After**

![image](https://github.com/AudiusProject/audius-protocol/assets/1815175/11b4941d-5db5-4e11-b0e8-5355ec5074eb)

---

![image](https://github.com/AudiusProject/audius-protocol/assets/1815175/ac2af086-25e1-4770-8991-00031d9c138f)

