### PR TITLE
[C-4437] Allow add to playlist for all track types

### DIFF
--- a/packages/common/src/hooks/purchaseContent/utils.ts
+++ b/packages/common/src/hooks/purchaseContent/utils.ts
@@ -59,20 +59,3 @@ export const isTrackDownloadPurchaseable = (
 ): metadata is PurchaseableTrackDownloadMetadata =>
   'download_conditions' in metadata &&
   isContentUSDCPurchaseGated(metadata.download_conditions)
-
-export const useIsGatedContentPlaylistAddable = (
-  contentArg?: Nullable<Partial<Track | UserTrackMetadata | Collection>>
-) => {
-  const content = contentArg ?? {}
-  const {
-    stream_conditions: streamConditions,
-    is_stream_gated: isStreamGated,
-    ddex_app: ddexApp
-  } = content
-  const { hasStreamAccess } = useGatedContentAccess(content)
-  return (
-    !ddexApp &&
-    (!isStreamGated ||
-      (isContentUSDCPurchaseGated(streamConditions) && hasStreamAccess))
-  )
-}

--- a/packages/common/src/hooks/purchaseContent/utils.ts
+++ b/packages/common/src/hooks/purchaseContent/utils.ts
@@ -1,8 +1,4 @@
-import { Collection, Track } from '~/models'
-import { UserTrackMetadata, isContentUSDCPurchaseGated } from '~/models/Track'
-import { Nullable } from '~/utils'
-
-import { useGatedContentAccess } from '../useGatedContent'
+import { isContentUSDCPurchaseGated } from '~/models/Track'
 
 import {
   PayExtraAmountPresetValues,

--- a/packages/mobile/src/components/lineup-tile/TrackTile.tsx
+++ b/packages/mobile/src/components/lineup-tile/TrackTile.tsx
@@ -186,7 +186,6 @@ export const TrackTileComponent = ({
     genre,
     isOwner,
     ddexApp,
-    isPlaylistAddable,
     albumInfo,
     playbackPositionInfo?.status,
     isOnArtistsTracksTab,

--- a/packages/mobile/src/components/lineup-tile/TrackTile.tsx
+++ b/packages/mobile/src/components/lineup-tile/TrackTile.tsx
@@ -1,6 +1,5 @@
 import { useCallback } from 'react'
 
-import { useIsGatedContentPlaylistAddable } from '@audius/common/hooks'
 import {
   ShareSource,
   RepostSource,
@@ -118,7 +117,6 @@ export const TrackTileComponent = ({
     isUSDCEnabled &&
     isContentUSDCPurchaseGated(streamConditions) &&
     !!preview_cid
-  const isPlaylistAddable = useIsGatedContentPlaylistAddable(track)
 
   const renderImage = useCallback(
     (props: ImageProps) => (
@@ -158,7 +156,7 @@ export const TrackTileComponent = ({
 
     const overflowActions = [
       isOwner && !ddexApp ? OverflowAction.ADD_TO_ALBUM : null,
-      isPlaylistAddable ? OverflowAction.ADD_TO_PLAYLIST : null,
+      OverflowAction.ADD_TO_PLAYLIST,
       isLongFormContent
         ? OverflowAction.VIEW_EPISODE_PAGE
         : OverflowAction.VIEW_TRACK_PAGE,

--- a/packages/mobile/src/components/now-playing-drawer/ActionsBar.tsx
+++ b/packages/mobile/src/components/now-playing-drawer/ActionsBar.tsx
@@ -1,9 +1,6 @@
 import { useCallback, useLayoutEffect } from 'react'
 
-import {
-  useGatedContentAccess,
-  useIsGatedContentPlaylistAddable
-} from '@audius/common/hooks'
+import { useGatedContentAccess } from '@audius/common/hooks'
 import {
   ShareSource,
   RepostSource,
@@ -116,11 +113,6 @@ export const ActionsBar = ({ track }: ActionsBarProps) => {
   const { neutral, neutralLight6, primary } = useThemeColors()
   const dispatch = useDispatch()
   const isReachable = useSelector(getIsReachable)
-  const { isEnabled: isNewPodcastControlsEnabled } = useFeatureFlag(
-    FeatureFlags.PODCAST_CONTROL_UPDATES_ENABLED,
-    FeatureFlags.PODCAST_CONTROL_UPDATES_ENABLED_FALLBACK
-  )
-  const isPlaylistAddable = useIsGatedContentPlaylistAddable(track)
 
   const isOwner = track?.owner_id === accountUser?.user_id
   const { onOpen: openPremiumContentPurchaseModal } =
@@ -201,13 +193,13 @@ export const ActionsBar = ({ track }: ActionsBarProps) => {
       const isLongFormContent =
         track.genre === Genre.PODCASTS || track.genre === Genre.AUDIOBOOKS
       const overflowActions = [
-        isOwner ? OverflowAction.ADD_TO_ALBUM : null,
-        isPlaylistAddable ? OverflowAction.ADD_TO_PLAYLIST : null,
-        isNewPodcastControlsEnabled && isLongFormContent
+        isOwner && !track?.ddex_app ? OverflowAction.ADD_TO_ALBUM : null,
+        OverflowAction.ADD_TO_PLAYLIST,
+        isLongFormContent
           ? OverflowAction.VIEW_EPISODE_PAGE
           : OverflowAction.VIEW_TRACK_PAGE,
         albumInfo ? OverflowAction.VIEW_ALBUM_PAGE : null,
-        isNewPodcastControlsEnabled && isLongFormContent
+        isLongFormContent
           ? playbackPositionInfo?.status === 'COMPLETED'
             ? OverflowAction.MARK_AS_UNPLAYED
             : OverflowAction.MARK_AS_PLAYED
@@ -226,7 +218,6 @@ export const ActionsBar = ({ track }: ActionsBarProps) => {
   }, [
     track,
     isOwner,
-    isPlaylistAddable,
     isNewPodcastControlsEnabled,
     albumInfo,
     playbackPositionInfo?.status,

--- a/packages/mobile/src/components/now-playing-drawer/ActionsBar.tsx
+++ b/packages/mobile/src/components/now-playing-drawer/ActionsBar.tsx
@@ -8,7 +8,6 @@ import {
   ModalSource
 } from '@audius/common/models'
 import type { Track } from '@audius/common/models'
-import { FeatureFlags } from '@audius/common/services'
 import {
   accountSelectors,
   castSelectors,
@@ -39,7 +38,6 @@ import {
 } from '@audius/harmony-native'
 import { useAirplay } from 'app/components/audio/Airplay'
 import { Button } from 'app/components/core'
-import { useFeatureFlag } from 'app/hooks/useRemoteConfig'
 import { useToast } from 'app/hooks/useToast'
 import { makeStyles } from 'app/styles'
 import { spacing } from 'app/styles/spacing'
@@ -215,14 +213,7 @@ export const ActionsBar = ({ track }: ActionsBarProps) => {
         })
       )
     }
-  }, [
-    track,
-    isOwner,
-    isNewPodcastControlsEnabled,
-    albumInfo,
-    playbackPositionInfo?.status,
-    dispatch
-  ])
+  }, [track, isOwner, albumInfo, playbackPositionInfo?.status, dispatch])
 
   const { openAirplayDialog } = useAirplay()
   const castDevices = useDevices()

--- a/packages/mobile/src/components/track-list/TrackListItem.tsx
+++ b/packages/mobile/src/components/track-list/TrackListItem.tsx
@@ -333,7 +333,6 @@ const TrackListItemComponent = (props: TrackListItemComponentProps) => {
     has_current_user_reposted,
     isDeleted,
     ddexApp,
-    isPlaylistAddable,
     isNewPodcastControlsEnabled,
     isLongFormContent,
     showViewAlbum,

--- a/packages/mobile/src/components/track-list/TrackListItem.tsx
+++ b/packages/mobile/src/components/track-list/TrackListItem.tsx
@@ -1,10 +1,7 @@
 import type { ComponentType } from 'react'
 import { memo, useCallback, useMemo, useState } from 'react'
 
-import {
-  useGatedContentAccess,
-  useIsGatedContentPlaylistAddable
-} from '@audius/common/hooks'
+import { useGatedContentAccess } from '@audius/common/hooks'
 import {
   type Collection,
   type ID,
@@ -242,7 +239,6 @@ const TrackListItemComponent = (props: TrackListItemComponentProps) => {
   const isPlaying = useSelector((state) => {
     return isActive && getPlaying(state)
   })
-  const isPlaylistAddable = useIsGatedContentPlaylistAddable(track)
   // Unlike other gated tracks, USDC purchase gated tracks are playable because they have previews
   const isPlayable =
     !isDeleted && (!isLocked || isContentUSDCPurchaseGated(streamConditions))
@@ -307,7 +303,7 @@ const TrackListItemComponent = (props: TrackListItemComponentProps) => {
         ? OverflowAction.PURCHASE_TRACK
         : null,
       isTrackOwner && !ddexApp ? OverflowAction.ADD_TO_ALBUM : null,
-      isPlaylistAddable ? OverflowAction.ADD_TO_PLAYLIST : null,
+      OverflowAction.ADD_TO_PLAYLIST,
       isNewPodcastControlsEnabled && isLongFormContent
         ? OverflowAction.VIEW_EPISODE_PAGE
         : OverflowAction.VIEW_TRACK_PAGE,

--- a/packages/mobile/src/screens/track-screen/TrackScreenDetailsTile.tsx
+++ b/packages/mobile/src/screens/track-screen/TrackScreenDetailsTile.tsx
@@ -1,9 +1,6 @@
 import { useCallback } from 'react'
 
-import {
-  useGatedContentAccess,
-  useIsGatedContentPlaylistAddable
-} from '@audius/common/hooks'
+import { useGatedContentAccess } from '@audius/common/hooks'
 import {
   Name,
   ShareSource,
@@ -146,7 +143,6 @@ export const TrackScreenDetailsTile = ({
   const hasDownloadableAssets =
     (track as Track)?.is_downloadable ||
     ((track as Track)?._stems?.length ?? 0) > 0
-  const isPlaylistAddable = useIsGatedContentPlaylistAddable(track as Track)
 
   const { data: albumInfo } = trpc.tracks.getAlbumBacklink.useQuery(
     { trackId },
@@ -253,12 +249,9 @@ export const TrackScreenDetailsTile = ({
       genre === Genre.PODCASTS || genre === Genre.AUDIOBOOKS
     const addToAlbumAction =
       isOwner && !ddexApp ? OverflowAction.ADD_TO_ALBUM : null
-    const addToPlaylistAction = isPlaylistAddable
-      ? OverflowAction.ADD_TO_PLAYLIST
-      : null
     const overflowActions = [
       addToAlbumAction,
-      addToPlaylistAction,
+      OverflowAction.ADD_TO_PLAYLIST,
       isOwner
         ? null
         : user.does_current_user_follow

--- a/packages/web/src/components/track/GiantTrackTile.tsx
+++ b/packages/web/src/components/track/GiantTrackTile.tsx
@@ -434,7 +434,6 @@ export const GiantTrackTile = ({
       isUnlisted,
       includeEmbed: !(isUnlisted || isStreamGated),
       includeArtistPick: !isUnlisted,
-      includeAddToPlaylist: true,
       includeAddToAlbum: isOwner && !ddexApp,
       extraMenuItems: overflowMenuExtraItems
     }

--- a/packages/web/src/components/track/GiantTrackTile.tsx
+++ b/packages/web/src/components/track/GiantTrackTile.tsx
@@ -1,6 +1,5 @@
 import { Suspense, lazy, useCallback, useState } from 'react'
 
-import { useIsGatedContentPlaylistAddable } from '@audius/common/hooks'
 import {
   isContentUSDCPurchaseGated,
   ID,
@@ -212,7 +211,6 @@ export const GiantTrackTile = ({
   const showPreview = isUSDCPurchaseGated && (isOwner || !hasStreamAccess)
   // Play button is conditionally hidden for USDC-gated tracks when the user does not have access
   const showPlay = isUSDCPurchaseGated ? hasStreamAccess : true
-  const isPlaylistAddable = useIsGatedContentPlaylistAddable(track)
   const shouldShowScheduledRelease = dayjs(releaseDate).isAfter(dayjs())
   const renderCardTitle = (className: string) => {
     return (
@@ -436,8 +434,8 @@ export const GiantTrackTile = ({
       isUnlisted,
       includeEmbed: !(isUnlisted || isStreamGated),
       includeArtistPick: !isUnlisted,
-      includeAddToPlaylist: isPlaylistAddable,
-      includeAddToAlbum: isPlaylistAddable,
+      includeAddToPlaylist: true,
+      includeAddToAlbum: isOwner && !ddexApp,
       extraMenuItems: overflowMenuExtraItems
     }
   }

--- a/packages/web/src/components/track/desktop/ConnectedTrackTile.tsx
+++ b/packages/web/src/components/track/desktop/ConnectedTrackTile.tsx
@@ -1,9 +1,6 @@
 import { memo, useCallback, useEffect, MouseEvent, useRef } from 'react'
 
-import {
-  useGatedContentAccess,
-  useIsGatedContentPlaylistAddable
-} from '@audius/common/hooks'
+import { useGatedContentAccess } from '@audius/common/hooks'
 import {
   ShareSource,
   RepostSource,
@@ -133,7 +130,8 @@ const ConnectedTrackTile = ({
     _cover_art_sizes,
     play_count,
     duration,
-    release_date: releaseDate
+    release_date: releaseDate,
+    ddex_app: ddexApp
   } = trackWithFallback
 
   const {
@@ -154,7 +152,6 @@ const ConnectedTrackTile = ({
   const { isFetchingNFTAccess, hasStreamAccess } =
     useGatedContentAccess(trackWithFallback)
   const loading = isLoading || isFetchingNFTAccess
-  const isPlaylistAddable = useIsGatedContentPlaylistAddable(trackWithFallback)
 
   const dispatch = useDispatch()
   const [, setLockedContentVisibility] = useModalState('LockedContent')
@@ -197,8 +194,8 @@ const ConnectedTrackTile = ({
     const menu: Omit<TrackMenuProps, 'children'> = {
       extraMenuItems: [],
       handle,
-      includeAddToPlaylist: isPlaylistAddable,
-      includeAddToAlbum: isOwner,
+      includeAddToPlaylist: true,
+      includeAddToAlbum: isOwner && !ddexApp,
       includeArtistPick: handle === userHandle && !isUnlisted,
       includeEdit: handle === userHandle,
       ddexApp: track?.ddex_app,

--- a/packages/web/src/components/track/desktop/TrackListItem.tsx
+++ b/packages/web/src/components/track/desktop/TrackListItem.tsx
@@ -1,10 +1,7 @@
 import { memo, MouseEvent, useRef } from 'react'
 
 import { useGetCurrentUserId } from '@audius/common/api'
-import {
-  useGatedContentAccess,
-  useIsGatedContentPlaylistAddable
-} from '@audius/common/hooks'
+import { useGatedContentAccess } from '@audius/common/hooks'
 import {
   ID,
   isContentUSDCPurchaseGated,
@@ -66,7 +63,6 @@ const TrackListItem = ({
   const menuRef = useRef<HTMLDivElement>(null)
   const { data: currentUserId } = useGetCurrentUserId({})
   const isOwner = track?.owner_id === currentUserId
-  const isPlaylistAddable = useIsGatedContentPlaylistAddable(track as Track)
   const isPremium = isContentUSDCPurchaseGated(track?.stream_conditions)
   const { hasStreamAccess } = useGatedContentAccess(track as Track)
 
@@ -126,8 +122,8 @@ const TrackListItem = ({
 
   const menu: Omit<TrackMenuProps, 'children'> = {
     handle: track.user.handle,
-    includeAddToPlaylist: isPlaylistAddable,
-    includeAddToAlbum: isOwner,
+    includeAddToPlaylist: true,
+    includeAddToAlbum: isOwner && !track?.ddex_app,
     includeArtistPick: false,
     includeEdit: false,
     includeFavorite: true,

--- a/packages/web/src/components/track/helpers.ts
+++ b/packages/web/src/components/track/helpers.ts
@@ -46,7 +46,8 @@ export const getTrackWithFallback = (track: Track | null) => {
         '1000x1000': '',
         OVERRIDE: ''
       },
-      release_date: ''
+      release_date: '',
+      ddex_app: null
     }
   )
 }

--- a/packages/web/src/components/track/mobile/ConnectedTrackListItem.tsx
+++ b/packages/web/src/components/track/mobile/ConnectedTrackListItem.tsx
@@ -1,7 +1,6 @@
 import { memo, useCallback } from 'react'
 
 import { useGetTrackById } from '@audius/common/api'
-import { useIsGatedContentPlaylistAddable } from '@audius/common/hooks'
 import {
   RepostSource,
   FavoriteSource,
@@ -77,7 +76,6 @@ const ConnectedTrackListItem = (props: ConnectedTrackListItemProps) => {
     dispatch(setLockedContentId({ id: trackId }))
     setLockedContentVisibility(true)
   }, [dispatch, trackId, setLockedContentVisibility])
-  const isPlaylistAddable = useIsGatedContentPlaylistAddable(track)
 
   const onClickOverflow = () => {
     const overflowActions = [
@@ -97,7 +95,7 @@ const ConnectedTrackListItem = (props: ConnectedTrackListItemProps) => {
       user?.user_id === currentUserId && !ddexApp
         ? OverflowAction.ADD_TO_ALBUM
         : null,
-      isPlaylistAddable ? OverflowAction.ADD_TO_PLAYLIST : null,
+      OverflowAction.ADD_TO_PLAYLIST,
       OverflowAction.VIEW_TRACK_PAGE,
       albumInfo ? OverflowAction.VIEW_ALBUM_PAGE : null,
       OverflowAction.VIEW_ARTIST_PAGE

--- a/packages/web/src/components/track/mobile/ConnectedTrackListItem.tsx
+++ b/packages/web/src/components/track/mobile/ConnectedTrackListItem.tsx
@@ -1,6 +1,5 @@
 import { memo, useCallback } from 'react'
 
-import { useGetTrackById } from '@audius/common/api'
 import {
   RepostSource,
   FavoriteSource,
@@ -67,7 +66,6 @@ const ConnectedTrackListItem = (props: ConnectedTrackListItemProps) => {
     { trackId },
     { enabled: !!trackId }
   )
-  const { data: track } = useGetTrackById({ id: trackId })
   const dispatch = useDispatch()
   const { onOpen: openPremiumContentPurchaseModal } =
     usePremiumContentPurchaseModal()

--- a/packages/web/src/components/track/mobile/ConnectedTrackTile.tsx
+++ b/packages/web/src/components/track/mobile/ConnectedTrackTile.tsx
@@ -1,9 +1,6 @@
 import { memo, MouseEvent } from 'react'
 
-import {
-  useGatedContentAccess,
-  useIsGatedContentPlaylistAddable
-} from '@audius/common/hooks'
+import { useGatedContentAccess } from '@audius/common/hooks'
 import {
   ShareSource,
   RepostSource,
@@ -137,7 +134,8 @@ const ConnectedTrackTile = ({
     is_scheduled_release: isScheduledRelease,
     release_date: releaseDate,
     duration,
-    preview_cid
+    preview_cid,
+    ddex_app: ddexApp
   } = trackWithFallback
 
   const { artist_pick_track_id, user_id, handle, name, is_verified } =
@@ -155,7 +153,6 @@ const ConnectedTrackTile = ({
   )
   const { isFetchingNFTAccess, hasStreamAccess } =
     useGatedContentAccess(trackWithFallback)
-  const isPlaylistAddable = useIsGatedContentPlaylistAddable(track)
   const loading = isLoading || isFetchingNFTAccess
 
   const toggleSave = (trackId: ID) => {
@@ -207,15 +204,13 @@ const ConnectedTrackTile = ({
           ? OverflowAction.UNFAVORITE
           : OverflowAction.FAVORITE
         : null
-    const addToAlbumAction = isOwner ? OverflowAction.ADD_TO_ALBUM : null
-    const addToPlaylistAction = isPlaylistAddable
-      ? OverflowAction.ADD_TO_PLAYLIST
-      : null
+    const addToAlbumAction =
+      isOwner && !ddexApp ? OverflowAction.ADD_TO_ALBUM : null
     const overflowActions = [
       repostAction,
       favoriteAction,
       addToAlbumAction,
-      addToPlaylistAction,
+      OverflowAction.ADD_TO_PLAYLIST,
       isNewPodcastControlsEnabled && isLongFormContent
         ? OverflowAction.VIEW_EPISODE_PAGE
         : OverflowAction.VIEW_TRACK_PAGE,

--- a/packages/web/src/pages/track-page/components/mobile/TrackHeader.tsx
+++ b/packages/web/src/pages/track-page/components/mobile/TrackHeader.tsx
@@ -1,7 +1,6 @@
 import { Suspense, useCallback } from 'react'
 
 import { imageBlank as placeholderArt } from '@audius/common/assets'
-import { useIsGatedContentPlaylistAddable } from '@audius/common/hooks'
 import {
   SquareSizes,
   isContentCollectibleGated,
@@ -178,7 +177,6 @@ const TrackHeader = ({
   saveCount,
   repostCount,
   listenCount,
-  mood,
   tags,
   aiAttributedUserId,
   onPlay,
@@ -210,7 +208,6 @@ const TrackHeader = ({
     { trackId },
     { enabled: !!trackId }
   )
-  const isPlaylistAddable = useIsGatedContentPlaylistAddable(track)
   const shouldShowScheduledRelease =
     track?.release_date && dayjs(track.release_date).isAfter(dayjs())
 
@@ -237,8 +234,8 @@ const TrackHeader = ({
         : isSaved
         ? OverflowAction.UNFAVORITE
         : OverflowAction.FAVORITE,
-      isOwner ? OverflowAction.ADD_TO_ALBUM : null,
-      isPlaylistAddable ? OverflowAction.ADD_TO_PLAYLIST : null,
+      isOwner && !track?.ddex_app ? OverflowAction.ADD_TO_ALBUM : null,
+      OverflowAction.ADD_TO_PLAYLIST,
       albumInfo ? OverflowAction.VIEW_ALBUM_PAGE : null,
       isFollowing
         ? OverflowAction.UNFOLLOW_ARTIST


### PR DESCRIPTION
### Description
All track types should now be able to be added to playlists.

Hidden tracks still aren't able to be added to public playlists - will follow up with that.

cc-ing @michellebrier bc i noticed the add to album option was sometimes disallowed if the track was uploaded via ddex. Noticed a few places where that was missed, just checking that this is the intention? (I think this is disallowed at the protocol level as well.)

### How Has This Been Tested?

Added a follow-gated track to a playlist, things are working and didn't notice any UI weirdness.