### PR TITLE
Fix backfill of social data

### DIFF
--- a/packages/discovery-provider/ddl/migrations/0079_backfill_prod_user_socials.sql
+++ b/packages/discovery-provider/ddl/migrations/0079_backfill_prod_user_socials.sql
@@ -6,7 +6,7 @@ begin
     if exists (select * from "blocks" where "blockhash" = '0x8d5e6984014505e1e11bcbb1ca1a13bcc6ae85ac74014710a73271d82ca49f01') then
 
         -- check whether the data has already been backfilled and return early for idempotency
-        if exists (select 1 from users where website is not null) then
+        if exists (select 1 from users where handle_lc = 'rayjacobson' and donation is not null) then
             return;
         end if;
 


### PR DESCRIPTION
### Description

Issues:
* Current gating for prod migration does not work because we opted to do dual writes, and many users already have a website. So switch the gating onto the profile `rayjacobson` containing no donation link (which it will get after the migration)
* Lots of commas in the CSV file that were not escaped by quotes.

Note that the changes to the .sql file will cause the migration to run again because the md5 will not match

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._

Manually ran on prod dn1