### PR TITLE
mediorum: update intermediate audio analysis results for legacy tracks

### DIFF
--- a/mediorum/server/legacy_audio_analysis.go
+++ b/mediorum/server/legacy_audio_analysis.go
@@ -299,6 +299,7 @@ func (ss *MediorumServer) analyzeLegacyAudio(analysis *QmAudioAnalysis) error {
 	}()
 
 	var mu sync.Mutex
+	firstResult := true
 
 	for i := 0; i < 2; i++ {
 		select {
@@ -308,6 +309,10 @@ func (ss *MediorumServer) analyzeLegacyAudio(analysis *QmAudioAnalysis) error {
 				analysis.Results = &AudioAnalysisResult{}
 			}
 			analysis.Results.BPM = bpm
+			if firstResult {
+				ss.crud.Update(analysis)
+				firstResult = false
+			}
 			mu.Unlock()
 		case musicalKey := <-keyChan:
 			mu.Lock()
@@ -315,6 +320,10 @@ func (ss *MediorumServer) analyzeLegacyAudio(analysis *QmAudioAnalysis) error {
 				analysis.Results = &AudioAnalysisResult{}
 			}
 			analysis.Results.Key = musicalKey
+			if firstResult {
+				ss.crud.Update(analysis)
+				firstResult = false
+			}
 			mu.Unlock()
 		case err := <-errorChan:
 			return onError(err)


### PR DESCRIPTION
### Description
kept this logic out of the main mediorum backfill for legacy tracks' audio analyses to minimize the number of crudr updates. add it in so the repairer can read intermediate results if it retriggers any errored analyses. meaning a bpm error doesn't block a successfully key result, and vice versa.

this already happens for non-legacy uploads.

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._
