### PR TITLE
[C-4557] Add sort by recency to search

### DIFF
--- a/packages/common/src/services/audius-api-client/AudiusAPIClient.ts
+++ b/packages/common/src/services/audius-api-client/AudiusAPIClient.ts
@@ -292,6 +292,7 @@ type GetSearchArgs = {
   isVerified?: boolean
   hasDownloads?: boolean
   isPremium?: boolean
+  sort?: string
 }
 
 type TrendingIdsResponse = {
@@ -1139,7 +1140,8 @@ export class AudiusAPIClient {
     key,
     isVerified,
     hasDownloads,
-    isPremium
+    isPremium,
+    sort
   }: GetSearchArgs) {
     this._assertInitialized()
     const encodedUserId = encodeHashId(currentUserId)
@@ -1157,7 +1159,8 @@ export class AudiusAPIClient {
       key,
       is_verified: isVerified,
       has_downloads: hasDownloads,
-      is_purchaseable: isPremium
+      is_purchaseable: isPremium,
+      sort_method: sort
     }
 
     const searchResponse =

--- a/packages/common/src/services/audius-api-client/AudiusAPIClient.ts
+++ b/packages/common/src/services/audius-api-client/AudiusAPIClient.ts
@@ -8,7 +8,10 @@ import {
   UserChallenge
 } from '../../models'
 import { UndisbursedUserChallenge } from '../../store'
-import { SearchKind } from '../../store/pages/search-results/types'
+import {
+  SearchKind,
+  SearchSortMethod
+} from '../../store/pages/search-results/types'
 import { decodeHashId, encodeHashId } from '../../utils/hashIds'
 import { Nullable, removeNullable } from '../../utils/typeUtils'
 import { AuthHeaders } from '../audius-backend'
@@ -292,7 +295,7 @@ type GetSearchArgs = {
   isVerified?: boolean
   hasDownloads?: boolean
   isPremium?: boolean
-  sort?: string
+  sortMethod?: SearchSortMethod
 }
 
 type TrendingIdsResponse = {
@@ -1141,7 +1144,7 @@ export class AudiusAPIClient {
     isVerified,
     hasDownloads,
     isPremium,
-    sort
+    sortMethod
   }: GetSearchArgs) {
     this._assertInitialized()
     const encodedUserId = encodeHashId(currentUserId)
@@ -1160,7 +1163,7 @@ export class AudiusAPIClient {
       is_verified: isVerified,
       has_downloads: hasDownloads,
       is_purchaseable: isPremium,
-      sort_method: sort
+      sort_method: sortMethod
     }
 
     const searchResponse =

--- a/packages/common/src/store/pages/search-results/actions.ts
+++ b/packages/common/src/store/pages/search-results/actions.ts
@@ -1,6 +1,6 @@
 import { Genre, Mood } from '@audius/sdk'
 
-import { SearchKind } from './types'
+import { SearchKind, SearchSortMethod } from './types'
 
 export const FETCH_SEARCH_PAGE_RESULTS = 'SEARCH/FETCH_SEARCH_PAGE_RESULTS'
 export const FETCH_SEARCH_PAGE_RESULTS_SUCCEEDED =
@@ -75,7 +75,7 @@ type FetchSearchPageResultsArgs = {
   isVerified?: boolean
   hasDownloads?: boolean
   isPremium?: boolean
-  sort?: string
+  sortMethod?: SearchSortMethod
 }
 
 export const fetchSearchPageResults = (

--- a/packages/common/src/store/pages/search-results/actions.ts
+++ b/packages/common/src/store/pages/search-results/actions.ts
@@ -75,6 +75,7 @@ type FetchSearchPageResultsArgs = {
   isVerified?: boolean
   hasDownloads?: boolean
   isPremium?: boolean
+  sort?: string
 }
 
 export const fetchSearchPageResults = (

--- a/packages/common/src/store/pages/search-results/types.ts
+++ b/packages/common/src/store/pages/search-results/types.ts
@@ -18,3 +18,5 @@ export enum SearchKind {
   ALBUMS = 'albums',
   ALL = 'all'
 }
+
+export type SearchSortMethod = 'relevant' | 'popular' | 'recent'

--- a/packages/discovery-provider/src/api/v1/helpers.py
+++ b/packages/discovery-provider/src/api/v1/helpers.py
@@ -17,6 +17,7 @@ from src.queries.get_undisbursed_challenges import UndisbursedChallengeResponse
 from src.queries.query_helpers import (
     CollectionLibrarySortMethod,
     LibraryFilterType,
+    SearchSortMethod,
     SortDirection,
     SortMethod,
 )
@@ -881,6 +882,13 @@ full_search_parser.add_argument(
     required=False,
     type=str,
     description="Only include tracks that have a bpm less than or equal to",
+)
+full_search_parser.add_argument(
+    "sort_method",
+    required=False,
+    description="The sort method",
+    type=str,
+    choices=SearchSortMethod._member_names_,
 )
 
 verify_token_parser = reqparse.RequestParser(argument_class=DescriptiveArgument)

--- a/packages/discovery-provider/src/api/v1/search.py
+++ b/packages/discovery-provider/src/api/v1/search.py
@@ -53,6 +53,7 @@ class FullSearch(Resource):
         keys = args.get("key")
         bpm_min = args.get("bpm_min")
         bpm_max = args.get("bpm_max")
+        sort_method = args.get("sort_method")
 
         search_args = {
             "is_auto_complete": False,
@@ -72,6 +73,7 @@ class FullSearch(Resource):
             "keys": keys,
             "bpm_min": bpm_min,
             "bpm_max": bpm_max,
+            "sort_method": sort_method,
         }
         resp = search(search_args)
         return success_response(resp)

--- a/packages/discovery-provider/src/queries/query_helpers.py
+++ b/packages/discovery-provider/src/queries/query_helpers.py
@@ -142,6 +142,12 @@ class TransactionSortMethod(str, enum.Enum):
     transaction_type = "transaction_type"
 
 
+class SearchSortMethod(str, enum.Enum):
+    relevant = "relevant"
+    popular = "popular"
+    recent = "recent"
+
+
 class SortDirection(str, enum.Enum):
     asc = "asc"
     desc = "desc"

--- a/packages/discovery-provider/src/queries/search_es.py
+++ b/packages/discovery-provider/src/queries/search_es.py
@@ -574,7 +574,7 @@ def track_dsl(
     query = default_function_score(dsl, "repost_count")
 
     if sort_method == "recent":
-        query["sort"] = [{"created_at": {"order": "desc"}}]
+        query["sort"] = [{"updated_at": {"order": "desc"}}]
 
     return query
 
@@ -585,7 +585,7 @@ def user_dsl(
     only_verified,
     must_saved=False,
     genres=[],
-    sort_method="relevance",
+    sort_method="relevant",
 ):
     # must_search_str = search_str + " " + search_str.replace(" ", "")
     dsl = {
@@ -774,7 +774,7 @@ def base_playlist_dsl(
     only_purchaseable,
     current_user_id,
     must_saved=False,
-    sort_method="relevance",
+    sort_method="relevant",
 ):
     dsl = {
         "must": [
@@ -920,7 +920,7 @@ def base_playlist_dsl(
                 {
                     "script_score": {
                         "script": {
-                            "source": """ 
+                            "source": """
                                 double matchedTracks = 0;
                                 for (track in params['_source'].tracks) {
                                     if (params.moods.contains(track.mood)) {
@@ -944,7 +944,7 @@ def base_playlist_dsl(
     query["query"]["function_score"]["query"] = {"bool": dsl}
 
     if sort_method == "recent":
-        query["sort"] = [{"created_at": {"order": "desc"}}]
+        query["sort"] = [{"updated_at": {"order": "desc"}}]
 
     return query
 
@@ -955,7 +955,7 @@ def playlist_dsl(
     must_saved=False,
     genres=[],
     moods=[],
-    sort_method="relevance",
+    sort_method="relevant",
 ):
     return base_playlist_dsl(
         search_str,
@@ -978,7 +978,7 @@ def album_dsl(
     must_saved=False,
     genres=[],
     moods=[],
-    sort_method="relevance",
+    sort_method="relevant",
 ):
     return base_playlist_dsl(
         search_str,

--- a/packages/web/src/common/store/pages/search-page/sagas.ts
+++ b/packages/web/src/common/store/pages/search-page/sagas.ts
@@ -113,6 +113,7 @@ type GetSearchResultsArgs = {
   isVerified?: boolean
   hasDownloads?: boolean
   isPremium?: boolean
+  sort?: string
 }
 
 export function* getSearchResults({
@@ -126,7 +127,8 @@ export function* getSearchResults({
   key,
   isVerified,
   hasDownloads,
-  isPremium
+  isPremium,
+  sort
 }: GetSearchResultsArgs) {
   yield* waitForRead()
   const getFeatureEnabled = yield* getContext('getFeatureEnabled')
@@ -163,7 +165,8 @@ export function* getSearchResults({
     key: formatKey(key),
     isVerified,
     hasDownloads,
-    isPremium
+    isPremium,
+    sort
   })
   const { tracks, albums, playlists, users } = results
 
@@ -185,8 +188,8 @@ function* fetchSearchPageResults(
 ) {
   yield* call(waitForRead)
 
-  const { type: ignoredType, ...rest } = action
-  const rawResults = yield* call(getSearchResults, rest)
+  const { type: ignoredType, ...params } = action
+  const rawResults = yield* call(getSearchResults, params)
   if (rawResults) {
     const results = {
       users:

--- a/packages/web/src/common/store/pages/search-page/sagas.ts
+++ b/packages/web/src/common/store/pages/search-page/sagas.ts
@@ -5,7 +5,8 @@ import {
   searchResultsPageTracksLineupActions as tracksLineupActions,
   searchResultsPageActions as searchPageActions,
   SearchKind,
-  getContext
+  getContext,
+  SearchSortMethod
 } from '@audius/common/store'
 import { Genre, trimToAlphaNumeric } from '@audius/common/utils'
 import { Mood } from '@audius/sdk'
@@ -113,7 +114,7 @@ type GetSearchResultsArgs = {
   isVerified?: boolean
   hasDownloads?: boolean
   isPremium?: boolean
-  sort?: string
+  sortMethod?: SearchSortMethod
 }
 
 export function* getSearchResults({
@@ -128,7 +129,7 @@ export function* getSearchResults({
   isVerified,
   hasDownloads,
   isPremium,
-  sort
+  sortMethod
 }: GetSearchResultsArgs) {
   yield* waitForRead()
   const getFeatureEnabled = yield* getContext('getFeatureEnabled')
@@ -166,7 +167,7 @@ export function* getSearchResults({
     isVerified,
     hasDownloads,
     isPremium,
-    sort
+    sortMethod
   })
   const { tracks, albums, playlists, users } = results
 

--- a/packages/web/src/pages/search-page-v2/ResultsAlbumsView.tsx
+++ b/packages/web/src/pages/search-page-v2/ResultsAlbumsView.tsx
@@ -25,7 +25,7 @@ const messages = {
 export const ResultsAlbumsView = () => {
   const results = useSelector(getSearchResults)
   const [urlSearchParams] = useSearchParams()
-  const updateSortParam = useUpdateSearchParams('sort')
+  const updateSortParam = useUpdateSearchParams('sortMethod')
   const routeMatch = useRouteMatch<{ category: string }>(SEARCH_PAGE)
   const isCategoryActive = useCallback(
     (category: CategoryView) => routeMatch?.category === category,
@@ -33,7 +33,7 @@ export const ResultsAlbumsView = () => {
   )
 
   const isLoading = results.status === Status.LOADING
-  const sort = urlSearchParams.get('sort')
+  const sortMethod = urlSearchParams.get('sortMethod')
   const albumLimit = isCategoryActive(CategoryView.ALBUMS) ? 100 : 5
   const albumIds = results.albumIds?.slice(0, albumLimit) ?? []
 
@@ -46,7 +46,7 @@ export const ResultsAlbumsView = () => {
         {isCategoryActive(CategoryView.ALBUMS) ? (
           <Flex gap='s'>
             <OptionsFilterButton
-              selection={sort ?? 'relevant'}
+              selection={sortMethod ?? 'relevant'}
               variant='replaceLabel'
               optionsLabel={messages.sortOptionsLabel}
               onChange={updateSortParam}

--- a/packages/web/src/pages/search-page-v2/ResultsPlaylistsView.tsx
+++ b/packages/web/src/pages/search-page-v2/ResultsPlaylistsView.tsx
@@ -27,7 +27,7 @@ export const ResultsPlaylistsView = () => {
   // const [playlistsLayout, setPlaylistsLayout] = useState<ViewLayout>('grid')
   const results = useSelector(getSearchResults)
   const [urlSearchParams] = useSearchParams()
-  const updateSortParam = useUpdateSearchParams('sort')
+  const updateSortParam = useUpdateSearchParams('sortMethod')
   const routeMatch = useRouteMatch<{ category: string }>(SEARCH_PAGE)
   const isCategoryActive = useCallback(
     (category: CategoryView) => routeMatch?.category === category,
@@ -35,7 +35,7 @@ export const ResultsPlaylistsView = () => {
   )
 
   const isLoading = results.status === Status.LOADING
-  const sort = urlSearchParams.get('sort')
+  const sortMethod = urlSearchParams.get('sortMethod')
   const playlistLimit = isCategoryActive(CategoryView.PLAYLISTS) ? 100 : 5
   const playlistIds = results.playlistIds?.slice(0, playlistLimit) ?? []
 
@@ -57,7 +57,7 @@ export const ResultsPlaylistsView = () => {
         {isCategoryActive(CategoryView.PLAYLISTS) ? (
           <Flex gap='s'>
             <OptionsFilterButton
-              selection={sort ?? 'relevant'}
+              selection={sortMethod ?? 'relevant'}
               variant='replaceLabel'
               optionsLabel={messages.sortOptionsLabel}
               onChange={updateSortParam}

--- a/packages/web/src/pages/search-page-v2/ResultsProfilesView.tsx
+++ b/packages/web/src/pages/search-page-v2/ResultsProfilesView.tsx
@@ -25,7 +25,7 @@ const messages = {
 export const ResultsProfilesView = () => {
   const results = useSelector(getSearchResults)
   const [urlSearchParams] = useSearchParams()
-  const updateSortParam = useUpdateSearchParams('sort')
+  const updateSortParam = useUpdateSearchParams('sortMethod')
   const routeMatch = useRouteMatch<{ category: string }>(SEARCH_PAGE)
   const isCategoryActive = useCallback(
     (category: CategoryView) => routeMatch?.category === category,
@@ -33,7 +33,7 @@ export const ResultsProfilesView = () => {
   )
 
   const isLoading = results.status === Status.LOADING
-  const sort = urlSearchParams.get('sort')
+  const sortMethod = urlSearchParams.get('sortMethod')
   const profileLimit = isCategoryActive(CategoryView.PROFILES) ? 100 : 5
   const profileIds = results.artistIds?.slice(0, profileLimit) ?? []
 
@@ -46,7 +46,7 @@ export const ResultsProfilesView = () => {
         {isCategoryActive(CategoryView.PROFILES) ? (
           <Flex gap='s'>
             <OptionsFilterButton
-              selection={sort ?? 'relevant'}
+              selection={sortMethod ?? 'relevant'}
               variant='replaceLabel'
               optionsLabel={messages.sortOptionsLabel}
               onChange={updateSortParam}

--- a/packages/web/src/pages/search-page-v2/ResultsTracksView.tsx
+++ b/packages/web/src/pages/search-page-v2/ResultsTracksView.tsx
@@ -49,7 +49,7 @@ export const ResultsTracksView = () => {
   const buffering = useSelector(getBuffering)
   const tracksLineup = useSelector(getTracksLineup)
   const [urlSearchParams] = useSearchParams()
-  const updateSortParam = useUpdateSearchParams('sort')
+  const updateSortParam = useUpdateSearchParams('sortMethod')
   const routeMatch = useRouteMatch<{ category: string }>(SEARCH_PAGE)
   const isCategoryActive = useCallback(
     (category: CategoryView) => routeMatch?.category === category,
@@ -60,7 +60,7 @@ export const ResultsTracksView = () => {
     !isCategoryActive(CategoryView.TRACKS) || tracksLayout === 'grid'
   const isLoading = results.status === Status.LOADING
   const query = urlSearchParams.get('query')
-  const sort = urlSearchParams.get('sort')
+  const sortMethod = urlSearchParams.get('sortMethod')
   const trackLimit = isCategoryActive(CategoryView.TRACKS) ? 100 : 10
   const trackIds = results.trackIds?.slice(0, trackLimit) ?? []
   const tracksData = {
@@ -91,7 +91,7 @@ export const ResultsTracksView = () => {
         {isCategoryActive(CategoryView.TRACKS) ? (
           <Flex gap='s'>
             <OptionsFilterButton
-              selection={sort ?? 'relevant'}
+              selection={sortMethod ?? 'relevant'}
               variant='replaceLabel'
               optionsLabel={messages.sortOptionsLabel}
               onChange={updateSortParam}

--- a/packages/web/src/pages/search-page-v2/SearchResults.tsx
+++ b/packages/web/src/pages/search-page-v2/SearchResults.tsx
@@ -4,7 +4,11 @@ import {
   fetchSearchPageTags,
   fetchSearchPageResults
 } from '@audius/common/src/store/pages/search-results/actions'
-import { SearchKind, searchResultsPageSelectors } from '@audius/common/store'
+import {
+  SearchKind,
+  SearchSortMethod,
+  searchResultsPageSelectors
+} from '@audius/common/store'
 import { Flex } from '@audius/harmony/src/components/layout'
 import { Genre, Mood } from '@audius/sdk'
 import { useDispatch } from 'react-redux'
@@ -27,7 +31,7 @@ export const SearchResults = () => {
   const routeMatch = useRouteMatch<{ category: string }>(SEARCH_PAGE)
   const [urlSearchParams] = useSearchParams()
   const query = urlSearchParams.get('query')
-  const sort = urlSearchParams.get('sort')
+  const sortMethod = urlSearchParams.get('sortMethod') as SearchSortMethod
   const genre = urlSearchParams.get('genre')
   const mood = urlSearchParams.get('mood')
   const bpm = urlSearchParams.get('bpm')
@@ -64,14 +68,14 @@ export const SearchResults = () => {
           isVerified: isVerified === 'true',
           hasDownloads: hasDownloads === 'true',
           isPremium: isPremium === 'true',
-          sort: sort || undefined
+          sortMethod: sortMethod || undefined
         })
       )
     }
   }, [
     dispatch,
     query,
-    sort,
+    sortMethod,
     genre,
     mood,
     isVerified,

--- a/packages/web/src/pages/search-page-v2/SearchResults.tsx
+++ b/packages/web/src/pages/search-page-v2/SearchResults.tsx
@@ -63,7 +63,8 @@ export const SearchResults = () => {
           key: key || undefined,
           isVerified: isVerified === 'true',
           hasDownloads: hasDownloads === 'true',
-          isPremium: isPremium === 'true'
+          isPremium: isPremium === 'true',
+          sort: sort || undefined
         })
       )
     }


### PR DESCRIPTION
### Description

Adds option to sort search results by recency, ie "updated_at" for tracks, users and collections. I'm personally a little confused on naming conventions, whether we should use "sort" or "sort_method". Im seeing both. Any convictions here would be great.