### PR TITLE
[C-4593] Hide bpm/key when SEARCH_V2 ff is off

### DIFF
--- a/packages/common/src/hooks/useCollectionMetadata.ts
+++ b/packages/common/src/hooks/useCollectionMetadata.ts
@@ -50,12 +50,7 @@ export const useCollectionMetadata = ({
   } = collection
   const numTracks = collection.playlist_contents?.track_ids?.length ?? 0
 
-  const metadataItems: {
-    id: CollectionMetadataType
-    isHidden?: boolean
-    label: string
-    value: any
-  }[] = [
+  const metadataItems = [
     {
       id: CollectionMetadataType.DURATION,
       label: 'Duration',

--- a/packages/common/src/hooks/useTrackMetadata.ts
+++ b/packages/common/src/hooks/useTrackMetadata.ts
@@ -84,9 +84,7 @@ export const useTrackMetadata = ({
       value: musical_key,
       isHidden: !isSearchV2Enabled
     }
-  ]
+  ].filter(({ isHidden, value }) => !isHidden && !!value)
 
-  const ret = labels.filter(({ isHidden, value }) => !isHidden && !!value)
-
-  return ret
+  return labels
 }

--- a/packages/common/src/hooks/useTrackMetadata.ts
+++ b/packages/common/src/hooks/useTrackMetadata.ts
@@ -26,7 +26,7 @@ type TrackMetadataProps = {
 type TrackMetadataInfo = {
   id: TrackMetadataType
   label: string
-  value?: Nullable<string | number>
+  value: string
 }
 
 export const useTrackMetadata = ({
@@ -74,14 +74,14 @@ export const useTrackMetadata = ({
     {
       id: TrackMetadataType.BPM,
       label: 'BPM',
-      value: bpm,
+      value: Math.round(bpm ?? 0).toString(),
       isHidden: !isSearchV2Enabled
     },
     {
       id: TrackMetadataType.KEY,
       label: 'Key',
       // TODO: KJ - Might need a map for this to map to key options
-      value: musical_key,
+      value: musical_key ?? '',
       isHidden: !isSearchV2Enabled
     }
   ].filter(({ isHidden, value }) => !isHidden && !!value)

--- a/packages/common/src/hooks/useTrackMetadata.ts
+++ b/packages/common/src/hooks/useTrackMetadata.ts
@@ -1,7 +1,6 @@
 import { useGetTrackById } from '~/api/track'
 import { ID } from '~/models'
 import { FeatureFlags } from '~/services/remote-config/feature-flags'
-import { Nullable } from '~/utils/typeUtils'
 
 import { getCanonicalName } from '../utils/genres'
 import { formatDate, formatSecondsAsText } from '../utils/timeUtil'

--- a/packages/mobile/src/components/details-tile/CollectionMetadataList.tsx
+++ b/packages/mobile/src/components/details-tile/CollectionMetadataList.tsx
@@ -10,7 +10,7 @@ type CollectionMetadataProps = {
 }
 
 /**
- * The additional metadata shown at the bottom of the Collection Screen Headers
+ * The additional metadata shown at the bottom of the Collection Screen Header
  */
 export const CollectionMetadataList = ({
   collectionId

--- a/packages/web/src/components/collection/CollectionMetadataList.tsx
+++ b/packages/web/src/components/collection/CollectionMetadataList.tsx
@@ -8,6 +8,9 @@ type CollectionMetadataListProps = {
   collectionId: ID
 }
 
+/**
+ * The additional metadata shown at the bottom of the Collection Page Header
+ */
 export const CollectionMetadataList = ({
   collectionId
 }: CollectionMetadataListProps) => {

--- a/packages/web/src/components/track/TrackMetadataList.tsx
+++ b/packages/web/src/components/track/TrackMetadataList.tsx
@@ -18,10 +18,6 @@ import { moodMap } from 'utils/Moods'
 import { getSearchPageLocation } from 'utils/route'
 import { trpc } from 'utils/trpcClientWeb'
 
-type TrackMetadataListProps = {
-  trackId: ID
-}
-
 const renderMood = (mood: Mood) => {
   return (
     <TextLink to={getSearchPageLocation({ category: 'tracks', mood })}>
@@ -66,6 +62,13 @@ const renderAlbum = (albumInfo: AlbumInfo) => {
   )
 }
 
+type TrackMetadataListProps = {
+  trackId: ID
+}
+
+/**
+ * The additional metadata shown at the bottom of the Track Page Header
+ */
 export const TrackMetadataList = ({ trackId }: TrackMetadataListProps) => {
   const { isEnabled: isSearchV2Enabled } = useFeatureFlag(
     FeatureFlags.SEARCH_V2


### PR DESCRIPTION
### Description
These were still visible but with no value when the ff was off.

Already getting value out of sharing the show/hide logic between mobile+web :)

### How Has This Been Tested?

FF off:
<img width="811" alt="Screenshot 2024-06-24 at 2 18 03 PM" src="https://github.com/AudiusProject/audius-protocol/assets/3893871/86bcb35c-7b03-4d4c-85d1-bcd4a0929b02">

FF on:
<img width="784" alt="Screenshot 2024-06-24 at 2 19 39 PM" src="https://github.com/AudiusProject/audius-protocol/assets/3893871/0b77de2a-a953-472d-9f7b-8bd5b05bd0a5">
