### PR TITLE
[PAY-3081] Use DN socials across the stack

### DIFF
--- a/packages/common/src/services/audius-backend/AudiusBackend.ts
+++ b/packages/common/src/services/audius-backend/AudiusBackend.ts
@@ -742,9 +742,6 @@ export const audiusBackend = ({
       const account = audiusLibs.Account.getCurrentUser()
       if (!account) return null
 
-      const socialHandles = await getSocialHandles(account)
-      Object.assign(account, socialHandles)
-
       try {
         const userBank = await audiusLibs.solanaWeb3Manager.deriveUserBank()
         account.userBank = userBank.toString()
@@ -956,42 +953,6 @@ export const audiusBackend = ({
     }
   }
 
-  async function getSocialHandles(user: User) {
-    // Fetch the socials from identity service if we didn't get anything back from discovery node.
-    // Before the final production migration runs, identity may have more up to date data.
-    const userHasSocials =
-      user.twitter_handle ||
-      user.instagram_handle ||
-      user.tiktok_handle ||
-      user.website ||
-      user.donation ||
-      user.verified_with_twitter ||
-      user.verified_with_instagram ||
-      user.verified_with_tiktok
-    if (userHasSocials) {
-      return user
-    }
-    try {
-      const res = await fetch(
-        `${identityServiceUrl}/social_handles?handle=${user.handle}`
-      )
-      const json = await res.json()
-      return {
-        twitter_handle: json.twitterHandle || null,
-        instagram_handle: json.instagramHandle || null,
-        tiktok_handle: json.tikTokHandle || null,
-        website: json.website || null,
-        donation: json.donation || null,
-        verified_with_twitter: json.twitterVerified || false,
-        verified_with_instagram: json.instagramVerified || false,
-        verified_with_tiktok: json.tikTokVerified || false
-      }
-    } catch (e) {
-      console.error(e)
-      return {}
-    }
-  }
-
   /**
    * Retrieves the user's eth associated wallets from IPFS using the user's metadata CID and creator node endpoints
    * @param user The user metadata which contains the CID for the metadata multihash
@@ -1066,39 +1027,6 @@ export const audiusBackend = ({
           newMetadata.updatedCoverPhoto.file
         )
         newMetadata.cover_photo_sizes = resp.id
-      }
-
-      // Leave this here for now, but this should be removed once we believe
-      // that old clients have caught up and are updating socials via entity manager to DN.
-      try {
-        if (
-          typeof newMetadata.twitter_handle === 'string' ||
-          typeof newMetadata.instagram_handle === 'string' ||
-          typeof newMetadata.tiktok_handle === 'string' ||
-          typeof newMetadata.website === 'string' ||
-          typeof newMetadata.donation === 'string'
-        ) {
-          const { data, signature } = await signData()
-          await fetch(`${identityServiceUrl}/social_handles`, {
-            method: 'POST',
-            headers: {
-              'Content-Type': 'application/json',
-              [AuthHeaders.Message]: data,
-              [AuthHeaders.Signature]: signature
-            },
-            body: JSON.stringify({
-              twitterHandle: newMetadata.twitter_handle,
-              instagramHandle: newMetadata.instagram_handle,
-              tikTokHandle: newMetadata.tiktok_handle,
-              website: newMetadata.website,
-              donation: newMetadata.donation
-            })
-          })
-        }
-      } catch (e) {
-        console.error(
-          `Could not update socials in identity, but they should still be updated in DN with code below. Error: ${e}`
-        )
       }
 
       newMetadata = schemas.newUserMetadata(newMetadata, true)
@@ -3081,7 +3009,6 @@ export const audiusBackend = ({
     getBrowserPushSubscription,
     getCollectionImages,
     getCreators,
-    getSocialHandles,
     getEmailNotificationSettings,
     getFolloweeFollows,
     getImageUrl,

--- a/packages/discovery-provider/plugins/notifications/src/email/notifications/renderEmail.ts
+++ b/packages/discovery-provider/plugins/notifications/src/email/notifications/renderEmail.ts
@@ -130,6 +130,9 @@ export const fetchResources = async (
     .select(
       'users.user_id',
       'users.handle',
+      'users.twitter_handle as twitterHandle',
+      'users.instagram_handle as instagramHandle',
+      'users.tiktok_handle as tikTokHandle',
       'users.name',
       'users.profile_picture_sizes',
       'users.profile_picture',
@@ -139,20 +142,8 @@ export const fetchResources = async (
     .whereIn('user_id', Array.from(ids.users))
     .andWhere('is_current', true)
 
-  const userHandles = userRows.map((row) => row.handle)
-  const identityUserRows = await identityDb
-    .select('handle', 'twitterHandle', 'instagramHandle', 'tikTokHandle')
-    .from('SocialHandles')
-    .whereIn('handle', userHandles)
-  const userSocialHandles = identityUserRows.reduce((acc, user) => {
-    acc[user.handle] = user
-    return acc
-  }, {} as { [handle: string]: { twitterHandle: string; instagramHandle: string; tikTokHandle: string } })
-
   const users = userRows.reduce((acc, user) => {
-    const userSocial = userSocialHandles[user.handle] || {}
     acc[user.user_id] = {
-      ...userSocial,
       ...user,
       imageUrl: getUserProfileUrl(user)
     }

--- a/packages/discovery-provider/plugins/notifications/src/types/identity.ts
+++ b/packages/discovery-provider/plugins/notifications/src/types/identity.ts
@@ -142,17 +142,6 @@ export interface RewardAttesterValueRow {
 export interface SequelizeMetaRow {
   name: string
 }
-export interface SocialHandleRow {
-  createdAt: Date
-  donation?: string | null
-  handle: string
-  instagramHandle?: string | null
-  pinnedTrackId?: number | null
-  tikTokHandle?: string | null
-  twitterHandle?: string | null
-  updatedAt: Date
-  website?: string | null
-}
 export interface SolanaNotificationActionRow {
   actionEntityId: number
   actionEntityType: string

--- a/packages/discovery-provider/plugins/pedalboard/packages/storage/src/index.ts
+++ b/packages/discovery-provider/plugins/pedalboard/packages/storage/src/index.ts
@@ -1154,6 +1154,14 @@ export type Users = {
   creator_node_endpoint: string | null;
   blocknumber: number | null;
   is_verified: boolean;
+  twitter_handle: string | null;
+  instagram_handle: string | null;
+  tiktok_handle: string | null;
+  verified_with_twitter: boolean;
+  verified_with_instagram: boolean;
+  verified_with_tiktok: boolean;
+  website: string | null;
+  donation: string | null;
   created_at: Date;
   updated_at: Date;
   handle_lc: string | null;

--- a/packages/discovery-provider/plugins/verified-uploads/src/handlers/users.js
+++ b/packages/discovery-provider/plugins/verified-uploads/src/handlers/users.js
@@ -1,15 +1,11 @@
-import retry from 'async-retry'
 import { dp_db } from '../db.js'
 import { slack } from '../slack.js'
 import dotenv from 'dotenv'
-import axios from 'axios'
 import { getPreviousState } from './utils.js'
 
 dotenv.config()
-const { audius_discprov_identity_service_url, USERS_SLACK_CHANNEL } =
+const { USERS_SLACK_CHANNEL } =
   process.env
-const social_handle_url = (handle) =>
-  `${audius_discprov_identity_service_url}/social_handles?handle=${handle}`
 
 // TODO: send blocknumber through pg trigger
 export default async ({ user_id, blocknumber }) => {

--- a/packages/identity-service/src/notifications/fetchNotificationMetadata.js
+++ b/packages/identity-service/src/notifications/fetchNotificationMetadata.js
@@ -484,20 +484,10 @@ async function fetchNotificationMetadata(
     )
   }
 
-  // Fetch all the social handles and attach to the users - For twitter sharing
-  const socialHandles = await models.SocialHandles.findAll({
-    where: {
-      handle: users.map(({ handle }) => handle)
-    }
-  })
-  const twitterHandleMap = socialHandles.reduce(
-    (handleMapping, socialHandle) => {
-      if (socialHandle.twitterHandle)
-        handleMapping[socialHandle.handle] = socialHandle.twitterHandle
-      return handleMapping
-    },
-    {}
-  )
+  const twitterHandleMap = users.reduce((handleMapping, user) => {
+    if (user.twitter_handle) handleMapping[user.handle] = user.twitter_handle
+    return handleMapping
+  }, {})
 
   users = await Promise.all(
     users.map(async (user) => {

--- a/packages/identity-service/src/routes/idSignals.js
+++ b/packages/identity-service/src/routes/idSignals.js
@@ -28,10 +28,6 @@ module.exports = function (app) {
       const [
         captchaScores,
         cognitoFlowScores,
-        socialHandles,
-        twitterUser,
-        instagramUser,
-        tikTokUser,
         deviceUserCount,
         userIPRecord,
         handleSimilarity
@@ -58,30 +54,6 @@ module.exports = function (app) {
             type: QueryTypes.SELECT
           }
         ),
-        models.SocialHandles.findOne({
-          where: { handle }
-        }),
-        models.TwitterUser.findOne({
-          where: {
-            // Twitter stores case sensitive screen names
-            'twitterProfile.screen_name': handle,
-            verified: true
-          }
-        }),
-        models.InstagramUser.findOne({
-          where: {
-            // Instagram does not store case sensitive screen names
-            'profile.username': handle.toLowerCase(),
-            verified: true
-          }
-        }),
-        models.TikTokUser.findOne({
-          where: {
-            // TikTok does not store case sensitive screen names
-            'profile.display_name': handle.toLowerCase(),
-            verified: true
-          }
-        }),
         getDeviceIDCountForUserId(req.user.blockchainUserId),
         models.UserIPs.findOne({ where: { handle } }),
         models.sequelize.query(
@@ -105,14 +77,6 @@ module.exports = function (app) {
         handleSimilarity: handleSimilarity[0]?.count ?? 0
       }
 
-      if (socialHandles) {
-        response.socialSignals = {
-          ...socialHandles.dataValues,
-          twitterVerified: !!twitterUser,
-          instagramVerified: !!instagramUser,
-          tikTokVerified: !!tikTokUser
-        }
-      }
       return successResponse(response)
     })
   )

--- a/packages/mobile/src/components/share-drawer/utils.ts
+++ b/packages/mobile/src/components/share-drawer/utils.ts
@@ -2,7 +2,6 @@ import type { ShareContent } from '@audius/common/store'
 import { makeTwitterShareUrl } from '@audius/common/utils'
 import type { User } from '~/models'
 
-import { audiusBackendInstance } from 'app/services/audius-backend-instance'
 import {
   getCollectionRoute,
   getTrackRoute,
@@ -36,9 +35,8 @@ export const getContentUrl = (content: ShareContent) => {
   }
 }
 
-const getTwitterShareHandle = async (user: User) => {
-  const { twitter_handle: twitterHandle } =
-    await audiusBackendInstance.getSocialHandles(user)
+const getTwitterShareHandle = (user: User) => {
+  const twitterHandle = user.twitter_handle
   return twitterHandle ? `@${twitterHandle}` : user.handle
 }
 
@@ -49,11 +47,11 @@ export const getTwitterShareText = async (content: ShareContent) => {
         track: { title },
         artist
       } = content
-      return messages.trackShareText(title, await getTwitterShareHandle(artist))
+      return messages.trackShareText(title, getTwitterShareHandle(artist))
     }
     case 'profile': {
       const { profile } = content
-      return messages.profileShareText(await getTwitterShareHandle(profile))
+      return messages.profileShareText(getTwitterShareHandle(profile))
     }
     case 'album': {
       const {
@@ -62,7 +60,7 @@ export const getTwitterShareText = async (content: ShareContent) => {
       } = content
       return messages.albumShareText(
         playlist_name,
-        await getTwitterShareHandle(artist)
+        getTwitterShareHandle(artist)
       )
     }
     case 'playlist': {
@@ -72,7 +70,7 @@ export const getTwitterShareText = async (content: ShareContent) => {
       } = content
       return messages.playlistShareText(
         playlist_name,
-        await getTwitterShareHandle(creator)
+        getTwitterShareHandle(creator)
       )
     }
     case 'audioNftPlaylist': {

--- a/packages/web/src/common/store/cache/users/sagas.ts
+++ b/packages/web/src/common/store/cache/users/sagas.ts
@@ -355,25 +355,23 @@ function* watchFetchCoverPhoto() {
 export function* fetchUserSocials({
   handle
 }: ReturnType<typeof userActions.fetchUserSocials>) {
-  const audiusBackendInstance = yield* getContext('audiusBackendInstance')
   let user = yield* select(getUser, { handle })
   if (!user) {
     yield* call(fetchUserByHandle, handle, new Set())
   }
   user = yield* call(waitForValue, getUser, { handle })
   if (!user) return
-  const socials = yield* call(audiusBackendInstance.getSocialHandles, user)
 
   yield* put(
     cacheActions.update(Kind.USERS, [
       {
         id: user.user_id,
         metadata: {
-          twitter_handle: socials.twitter_handle || null,
-          instagram_handle: socials.instagram_handle || null,
-          tiktok_handle: socials.tiktok_handle || null,
-          website: socials.website || null,
-          donation: socials.donation || null
+          twitter_handle: user.twitter_handle || null,
+          instagram_handle: user.instagram_handle || null,
+          tiktok_handle: user.tiktok_handle || null,
+          website: user.website || null,
+          donation: user.donation || null
         }
       }
     ])

--- a/packages/web/src/components/notification/Notification/utils.ts
+++ b/packages/web/src/components/notification/Notification/utils.ts
@@ -1,7 +1,5 @@
-import { User } from '@audius/common/models'
 import { Entity, EntityType } from '@audius/common/store'
 
-import { audiusBackendInstance } from 'services/audius-backend/audius-backend-instance'
 import { UserListEntityType } from 'store/application/ui/userListModal/types'
 import { fullCollectionPage, fullTrackPage, collectionPage } from 'utils/route'
 
@@ -27,12 +25,6 @@ export const getRankSuffix = (rank: number) => {
   if (rank === 2) return 'nd'
   if (rank === 3) return 'rd'
   return 'th'
-}
-
-export const getTwitterHandleByUserHandle = async (user: User) => {
-  const { twitter_handle: twitterHandle } =
-    await audiusBackendInstance.getSocialHandles(user)
-  return twitterHandle || ''
 }
 
 export const USER_LENGTH_LIMIT = 9

--- a/packages/web/src/components/share-modal/utils.ts
+++ b/packages/web/src/components/share-modal/utils.ts
@@ -1,7 +1,6 @@
 import { ShareToTwitter, User } from '@audius/common/models'
 import { ShareContent } from '@audius/common/store'
 
-import { getTwitterHandleByUserHandle } from 'components/notification/Notification/utils'
 import {
   fullCollectionPage,
   fullProfilePage,
@@ -13,8 +12,8 @@ import { messages } from './messages'
 
 type ShareToTwitterEvent = Omit<ShareToTwitter, 'eventName' | 'source'>
 
-const getTwitterShareHandle = async (user: User) => {
-  const twitterHandle = await getTwitterHandleByUserHandle(user)
+const getTwitterShareHandle = (user: User) => {
+  const twitterHandle = user.twitter_handle
   return twitterHandle ? `@${twitterHandle}` : user.handle
 }
 
@@ -43,7 +42,7 @@ export const getTwitterShareText = async (
       } = content
       twitterText = messageConfig.trackShareText(
         title,
-        await getTwitterShareHandle(artist)
+        getTwitterShareHandle(artist)
       )
       link = fullTrackPage(permalink)
       analyticsEvent = { kind: 'track', id: track_id, url: link }
@@ -52,7 +51,7 @@ export const getTwitterShareText = async (
     case 'profile': {
       const { profile } = content
       twitterText = messageConfig.profileShareText(
-        await getTwitterShareHandle(profile)
+        getTwitterShareHandle(profile)
       )
       link = fullProfilePage(profile.handle)
       analyticsEvent = { kind: 'profile', id: profile.user_id, url: link }
@@ -65,7 +64,7 @@ export const getTwitterShareText = async (
       } = content
       twitterText = messageConfig.albumShareText(
         playlist_name,
-        await getTwitterShareHandle(artist)
+        getTwitterShareHandle(artist)
       )
       link = fullCollectionPage(
         artist.handle,
@@ -84,7 +83,7 @@ export const getTwitterShareText = async (
       } = content
       twitterText = messageConfig.playlistShareText(
         playlist_name,
-        await getTwitterShareHandle(creator)
+        getTwitterShareHandle(creator)
       )
       link = fullCollectionPage(
         creator.handle,


### PR DESCRIPTION
### Description

We previously left in the read and write of socials in identity in addition to discovery, for backwards compatibility with old client. We are now removing that so, where identity socials were being used, DN socials are now being used.

Note: I haven't removed identity's `socialHandles.js` file in case some old clients are still using, so that these clients don't break. But we can remove some time soon when we are either confident no clients are using, or we don't care if old clients break of this.

### How Has This Been Tested?

Local web dapp vs stage
