### PR TITLE
[C-4597] Show locked badge for private premium albums

### DIFF
--- a/packages/mobile/src/components/collection-list/CollectionCard.tsx
+++ b/packages/mobile/src/components/collection-list/CollectionCard.tsx
@@ -72,7 +72,7 @@ export const CollectionCard = (props: CollectionCardProps) => {
     playlist_owner_id,
     repost_count,
     save_count,
-    is_private,
+    is_private: isPrivate,
     access,
     stream_conditions,
     release_date: releaseDate,
@@ -108,7 +108,7 @@ export const CollectionCard = (props: CollectionCardProps) => {
         borderBottomLeftRadius='m'
         borderBottomRightRadius='m'
       >
-        {is_private ? (
+        {isPrivate ? (
           <Text
             variant='body'
             size='s'
@@ -135,11 +135,11 @@ export const CollectionCard = (props: CollectionCardProps) => {
                 {formatCount(save_count)}
               </Text>
             </Flex>
-            {isPurchase && !isOwner ? (
-              <LockedStatusBadge variant='purchase' locked={!access.stream} />
-            ) : null}
           </>
         )}
+        {isPurchase && !isOwner ? (
+          <LockedStatusBadge variant='purchase' locked={!access.stream} />
+        ) : null}
       </Flex>
     </Paper>
   )

--- a/packages/web/src/components/collection/CollectionCard.tsx
+++ b/packages/web/src/components/collection/CollectionCard.tsx
@@ -162,11 +162,11 @@ export const CollectionCard = forwardRef(
                   {formatCount(save_count)}
                 </Text>
               </Flex>
-              {isPurchase && !isOwner ? (
-                <LockedStatusPill variant='premium' locked={!access.stream} />
-              ) : null}
             </>
           )}
+          {isPurchase && !isOwner ? (
+            <LockedStatusPill variant='premium' locked={!access.stream} />
+          ) : null}
         </CardFooter>
       </Card>
     )


### PR DESCRIPTION
### Description
Move the `LockedStatusBadge` outside the ternary so it shows in all cases where the collection is premium.

### How Has This Been Tested?

Local web stage
web:
<img width="240" alt="Screenshot 2024-06-24 at 4 31 13 PM" src="https://github.com/AudiusProject/audius-protocol/assets/3893871/93016f68-f269-4783-991c-8fac18fc39ad">

mobile-web:
<img width="153" alt="Screenshot 2024-06-24 at 4 34 31 PM" src="https://github.com/AudiusProject/audius-protocol/assets/3893871/eb981b0b-2aa8-43ba-b2a1-826082b54f02">

mobile:
<img width="193" alt="Screenshot 2024-06-24 at 4 36 01 PM" src="https://github.com/AudiusProject/audius-protocol/assets/3893871/e5834e43-0f7d-4350-8f33-13ecd220a00a">
