### PR TITLE
[C-4601] Disallow hiding public tracks in edit

### DIFF
--- a/packages/web/src/components/edit-collection/desktop/EditCollectionForm.tsx
+++ b/packages/web/src/components/edit-collection/desktop/EditCollectionForm.tsx
@@ -43,10 +43,11 @@ type EditCollectionFormProps = {
   initialValues: CollectionValues
   onSubmit: (values: CollectionValues) => void
   isAlbum: boolean
+  isUpload: boolean
 }
 
 export const EditCollectionForm = (props: EditCollectionFormProps) => {
-  const { initialValues, onSubmit, isAlbum } = props
+  const { initialValues, onSubmit, isAlbum, isUpload } = props
   const { isEnabled: isPremiumAlbumsEnabled } = useFeatureFlag(
     FeatureFlags.PREMIUM_ALBUMS_ENABLED
   )
@@ -95,7 +96,10 @@ export const EditCollectionForm = (props: EditCollectionFormProps) => {
             </div>
           </div>
           {isHiddenPaidScheduledEnabled ? (
-            <VisibilityField entityType={isAlbum ? 'album' : 'playlist'} />
+            <VisibilityField
+              entityType={isAlbum ? 'album' : 'playlist'}
+              isUpload={isUpload}
+            />
           ) : (
             <ReleaseDateFieldLegacy />
           )}

--- a/packages/web/src/components/edit-track/EditTrackForm.tsx
+++ b/packages/web/src/components/edit-track/EditTrackForm.tsx
@@ -113,7 +113,7 @@ const TrackEditForm = (
             <TrackMetadataFields />
             <div className={cn(layoutStyles.col, layoutStyles.gap4)}>
               {isHiddenPaidScheduledEnabled ? (
-                <VisibilityField entityType='track' />
+                <VisibilityField entityType='track' isUpload={isUpload} />
               ) : (
                 <ReleaseDateField />
               )}

--- a/packages/web/src/components/edit/fields/visibility/VisibilityField.test.tsx
+++ b/packages/web/src/components/edit/fields/visibility/VisibilityField.test.tsx
@@ -36,7 +36,7 @@ const renderTrackVisibilityField = (options?: { initialValues: any }) => {
       onSubmit={submitSpy}
     >
       <Form>
-        <VisibilityField entityType='track' />
+        <VisibilityField entityType='track' isUpload={false} />
         <button type='submit'>Submit</button>
       </Form>
     </Formik>

--- a/packages/web/src/pages/upload-page/forms/EditCollectionFormForUpload.tsx
+++ b/packages/web/src/pages/upload-page/forms/EditCollectionFormForUpload.tsx
@@ -51,6 +51,7 @@ export const EditCollectionFormForUpload = (props: EditCollectionFormProps) => {
       isAlbum={isAlbum}
       initialValues={initialValues}
       onSubmit={handleSubmit}
+      isUpload
     />
   )
 }


### PR DESCRIPTION
### Description

In the edit redesign, it was possible to set a public track to hidden or scheduled. This change disables those options for public trakcs.

### How Has This Been Tested?

local working for upload and edit in multiple cases