### PR TITLE
[Protodash] Fix unique users top line number on protocol dashboard [QA-1397]

### DIFF
--- a/protocol-dashboard/src/components/UniqueUsersChart/UniqueUsersChart.tsx
+++ b/protocol-dashboard/src/components/UniqueUsersChart/UniqueUsersChart.tsx
@@ -2,7 +2,7 @@ import React, { useState } from 'react'
 
 import { UniqueUsersInfoTooltip } from 'components/InfoTooltip/InfoTooltips'
 import LineChart from 'components/LineChart'
-import { useApiCalls, useTrailingApiCalls } from 'store/cache/analytics/hooks'
+import { useApiCalls } from 'store/cache/analytics/hooks'
 import { Bucket, MetricError } from 'store/cache/analytics/slice'
 import { datesToSkip } from 'utils/consts'
 
@@ -16,17 +16,15 @@ type UniqueUsersBucket =
   | Bucket.ALL_TIME
   | Bucket.YEAR
 
+const BUCKET_TO_TOPLINE_LABEL = {
+  [Bucket.ALL_TIME]: 'Monthly',
+  [Bucket.YEAR]: 'Monthly',
+  [Bucket.MONTH]: 'Daily',
+  [Bucket.WEEK]: 'Daily'
+}
+
 const UniqueUsersChart: React.FC<UniqueUsersChartProps> = () => {
   const [bucket, setBucket] = useState<UniqueUsersBucket>(Bucket.ALL_TIME)
-  const { apiCalls: trailingApiCalls } = useTrailingApiCalls(
-    bucket === Bucket.ALL_TIME ? Bucket.MONTH : bucket
-  )
-  let topNumber: number
-  if (trailingApiCalls === MetricError.ERROR) {
-    topNumber = null
-  } else {
-    topNumber = trailingApiCalls?.summed_unique_count ?? null
-  }
 
   const { apiCalls } = useApiCalls(bucket)
   let error, labels, data
@@ -47,8 +45,8 @@ const UniqueUsersChart: React.FC<UniqueUsersChartProps> = () => {
   return (
     <LineChart
       titleTooltipComponent={UniqueUsersInfoTooltip}
-      topNumber={topNumber}
-      title='Unique Users'
+      title={`Unique ${BUCKET_TO_TOPLINE_LABEL[bucket]} Users`}
+      topNumber={data ? data[data.length - 1] : undefined}
       tooltipTitle='Users'
       data={data}
       labels={labels}

--- a/protocol-dashboard/src/components/UniqueUsersChart/UniqueUsersChart.tsx
+++ b/protocol-dashboard/src/components/UniqueUsersChart/UniqueUsersChart.tsx
@@ -16,11 +16,16 @@ type UniqueUsersBucket =
   | Bucket.ALL_TIME
   | Bucket.YEAR
 
+const messages = {
+  monthlyTitle: 'Monthly',
+  dailyTitle: 'Daily'
+}
+
 const BUCKET_TO_TOPLINE_LABEL = {
-  [Bucket.ALL_TIME]: 'Monthly',
-  [Bucket.YEAR]: 'Monthly',
-  [Bucket.MONTH]: 'Daily',
-  [Bucket.WEEK]: 'Daily'
+  [Bucket.ALL_TIME]: messages.monthlyTitle,
+  [Bucket.YEAR]: messages.monthlyTitle,
+  [Bucket.MONTH]: messages.dailyTitle,
+  [Bucket.WEEK]: messages.dailyTitle
 }
 
 const UniqueUsersChart: React.FC<UniqueUsersChartProps> = () => {

--- a/protocol-dashboard/src/components/UniqueUsersStat/UniqueUsersStat.tsx
+++ b/protocol-dashboard/src/components/UniqueUsersStat/UniqueUsersStat.tsx
@@ -3,7 +3,7 @@ import React from 'react'
 import { TextProps } from '@audius/harmony'
 
 import Stat from 'components/Stat'
-import { useTrailingApiCalls } from 'store/cache/analytics/hooks'
+import { useApiCalls } from 'store/cache/analytics/hooks'
 import { Bucket, MetricError } from 'store/cache/analytics/slice'
 import { formatNumber } from 'utils/format'
 
@@ -12,13 +12,14 @@ type OwnProps = {}
 type UniqueUsersStatProps = OwnProps & TextProps
 
 const UniqueUsersStat: React.FC<UniqueUsersStatProps> = (textProps) => {
-  const { apiCalls } = useTrailingApiCalls(Bucket.MONTH)
+  const { apiCalls } = useApiCalls(Bucket.ALL_TIME)
+
   let error, stat
   if (apiCalls === MetricError.ERROR) {
     error = true
     stat = null
   } else {
-    stat = apiCalls?.summed_unique_count ?? null
+    stat = apiCalls?.[apiCalls.length - 1].summed_unique_count ?? null
   }
   return (
     <Stat


### PR DESCRIPTION
### Description
Previously the unique users top line number on the Analytics page was pulling from the wrong API -- so the number didn't align with the numbers in the chart.

Discussed solution w Ray, which is:
- Changing the top line label to be "Monthly" or "Daily" depending on the time period selected & how the data is bucketed in that time period
- Use the last data point on the chart as the top line number

### How Has This Been Tested?
Local against prod.

<img width="519" alt="Screenshot 2024-06-24 at 6 40 20 PM" src="https://github.com/AudiusProject/audius-protocol/assets/36916764/e9ac0ac9-ce83-46ca-8c9e-1e9e7222e248">
<img width="537" alt="Screenshot 2024-06-24 at 6 40 29 PM" src="https://github.com/AudiusProject/audius-protocol/assets/36916764/9c5f1e72-dc57-4f22-986d-1c1e59236161">
<img width="546" alt="Screenshot 2024-06-24 at 6 47 38 PM" src="https://github.com/AudiusProject/audius-protocol/assets/36916764/3af3f93f-bd0e-4b65-985d-162e7c422308">
