### PR TITLE
[C-4602] Add delete button to edit track page

### DIFF
--- a/packages/web/src/components/edit-track/EditTrackForm.tsx
+++ b/packages/web/src/components/edit-track/EditTrackForm.tsx
@@ -54,7 +54,7 @@ const messages = {
 type EditTrackFormProps = {
   initialValues: TrackEditFormValues
   onSubmit: (values: TrackEditFormValues) => void
-  onDeleteTrack: () => void
+  onDeleteTrack?: () => void
   hideContainer?: boolean
 }
 
@@ -85,7 +85,7 @@ export const EditTrackForm = (props: EditTrackFormProps) => {
 const TrackEditForm = (
   props: FormikProps<TrackEditFormValues> & {
     hideContainer?: boolean
-    onDeleteTrack: () => void
+    onDeleteTrack?: () => void
   }
 ) => {
   const {

--- a/packages/web/src/components/edit-track/EditTrackForm.tsx
+++ b/packages/web/src/components/edit-track/EditTrackForm.tsx
@@ -7,7 +7,9 @@ import {
   IconCaretLeft,
   IconCaretRight,
   Text,
-  PlainButton
+  PlainButton,
+  Button,
+  IconTrash
 } from '@audius/harmony'
 import cn from 'classnames'
 import { Form, Formik, FormikProps, useField } from 'formik'
@@ -40,6 +42,7 @@ const messages = {
   prev: 'Prev',
   next: 'Next Track',
   preview: 'Preview',
+  deleteTrack: 'DELETE TRACK',
   navigationPrompt: {
     title: 'Discard upload?',
     body: "Are you sure you want to leave this page?\nAny changes you've made will be lost.",
@@ -51,6 +54,7 @@ const messages = {
 type EditTrackFormProps = {
   initialValues: TrackEditFormValues
   onSubmit: (values: TrackEditFormValues) => void
+  onDeleteTrack: () => void
   hideContainer?: boolean
 }
 
@@ -59,7 +63,7 @@ const EditFormValidationSchema = z.object({
 })
 
 export const EditTrackForm = (props: EditTrackFormProps) => {
-  const { initialValues, onSubmit, hideContainer } = props
+  const { initialValues, onSubmit, onDeleteTrack, hideContainer } = props
 
   return (
     <Formik<TrackEditFormValues>
@@ -67,15 +71,30 @@ export const EditTrackForm = (props: EditTrackFormProps) => {
       onSubmit={onSubmit}
       validationSchema={toFormikValidationSchema(EditFormValidationSchema)}
     >
-      {(props) => <TrackEditForm {...props} hideContainer={hideContainer} />}
+      {(props) => (
+        <TrackEditForm
+          {...props}
+          hideContainer={hideContainer}
+          onDeleteTrack={onDeleteTrack}
+        />
+      )}
     </Formik>
   )
 }
 
 const TrackEditForm = (
-  props: FormikProps<TrackEditFormValues> & { hideContainer?: boolean }
+  props: FormikProps<TrackEditFormValues> & {
+    hideContainer?: boolean
+    onDeleteTrack: () => void
+  }
 ) => {
-  const { values, dirty, isSubmitting, hideContainer = false } = props
+  const {
+    values,
+    dirty,
+    isSubmitting,
+    onDeleteTrack,
+    hideContainer = false
+  } = props
   const isMultiTrack = values.trackMetadatas.length > 1
   const isUpload = values.trackMetadatas[0].track_id === undefined
   const trackIdx = values.trackMetadatasIndex
@@ -139,6 +158,17 @@ const TrackEditForm = (
               className={styles.previewButton}
               index={trackIdx}
             />
+            {!isUpload ? (
+              <Button
+                variant='destructive'
+                size='small'
+                onClick={onDeleteTrack}
+                iconLeft={IconTrash}
+                css={{ alignSelf: 'flex-start' }}
+              >
+                {messages.deleteTrack}
+              </Button>
+            ) : null}
           </div>
           {isMultiTrack ? <MultiTrackFooter /> : null}
         </div>

--- a/packages/web/src/pages/edit-page/EditTrackPage.tsx
+++ b/packages/web/src/pages/edit-page/EditTrackPage.tsx
@@ -17,6 +17,8 @@ import Header from 'components/header/desktop/Header'
 import LoadingSpinnerFullPage from 'components/loading-spinner-full-page/LoadingSpinnerFullPage'
 import Page from 'components/page/Page'
 import { useTrackCoverArt2 } from 'hooks/useTrackCoverArt'
+import { Button } from '@audius/harmony'
+import { HOME_PAGE, PROFILE_PAGE } from 'utils/route'
 
 const { deleteTrack, editTrack } = cacheTracksActions
 
@@ -60,6 +62,7 @@ export const EditTrackPage = (props: EditPageProps) => {
     if (!track) return
     dispatch(deleteTrack(track.track_id))
     setShowDeleteConfirmation(false)
+    dispatch(pushRoute(`/${track.user.handle}`))
   }
 
   const coverArtUrl = useTrackCoverArt2(
@@ -104,7 +107,11 @@ export const EditTrackPage = (props: EditPageProps) => {
         <LoadingSpinnerFullPage />
       ) : (
         <EditFormScrollContext.Provider value={scrollToTop}>
-          <EditTrackForm initialValues={initialValues} onSubmit={onSubmit} />
+          <EditTrackForm
+            initialValues={initialValues}
+            onSubmit={onSubmit}
+            onDeleteTrack={() => setShowDeleteConfirmation(true)}
+          />
         </EditFormScrollContext.Provider>
       )}
       <DeleteConfirmationModal

--- a/packages/web/src/pages/edit-page/EditTrackPage.tsx
+++ b/packages/web/src/pages/edit-page/EditTrackPage.tsx
@@ -17,8 +17,6 @@ import Header from 'components/header/desktop/Header'
 import LoadingSpinnerFullPage from 'components/loading-spinner-full-page/LoadingSpinnerFullPage'
 import Page from 'components/page/Page'
 import { useTrackCoverArt2 } from 'hooks/useTrackCoverArt'
-import { Button } from '@audius/harmony'
-import { HOME_PAGE, PROFILE_PAGE } from 'utils/route'
 
 const { deleteTrack, editTrack } = cacheTracksActions
 


### PR DESCRIPTION
### Description

- Add delete button to edit track form
- Hidden on upload
- Opens confirmation modal
- Redirects to profile page on delete

![Screenshot 2024-06-24 at 3 53 38 PM](https://github.com/AudiusProject/audius-protocol/assets/2358254/83bb5dce-e4c9-4742-b0a7-44efaea5b359)

![Screenshot 2024-06-24 at 3 56 11 PM](https://github.com/AudiusProject/audius-protocol/assets/2358254/c94196f5-c0d9-4885-898c-8f0929fa103e)


### How Has This Been Tested?

button working on edit, hidden on upload