### PR TITLE
Fix empty genre on web track pages

### DIFF
--- a/packages/web/src/components/track/TrackMetadataList.tsx
+++ b/packages/web/src/components/track/TrackMetadataList.tsx
@@ -8,7 +8,6 @@ import {
 } from '@audius/common/hooks'
 import { ID } from '@audius/common/models'
 import { FeatureFlags } from '@audius/common/services'
-import { getCanonicalName } from '@audius/common/utils'
 import { Flex } from '@audius/harmony'
 import { Genre, Mood } from '@audius/sdk'
 
@@ -33,7 +32,7 @@ const renderMoodLegacy = (mood: Mood) => {
 const renderGenre = (genre: Genre) => {
   return (
     <TextLink to={getSearchPageLocation({ category: 'tracks', genre })}>
-      {getCanonicalName(genre)}
+      {genre}
     </TextLink>
   )
 }
@@ -85,7 +84,7 @@ export const TrackMetadataList = ({ trackId }: TrackMetadataListProps) => {
     (id: TrackMetadataType, value: string) => {
       switch (id) {
         case TrackMetadataType.GENRE:
-          return isSearchV2Enabled ? renderGenre(value as Genre) : undefined
+          return isSearchV2Enabled ? renderGenre(value as Genre) : value
         case TrackMetadataType.MOOD:
           return isSearchV2Enabled
             ? renderMood(value as Mood)


### PR DESCRIPTION
### Description
Bug! Missed filling out the value when `SEARCH_V2` feature flag is disabled.

### How Has This Been Tested?

Local web stage

<img width="635" alt="Screenshot 2024-06-24 at 9 16 52 PM" src="https://github.com/AudiusProject/audius-protocol/assets/3893871/2bc6ef6c-c1b3-46c0-a402-ce4b1f9d6f1b">
