### PR TITLE
More quickly backfill discovery audio analyses

### DIFF
--- a/packages/discovery-provider/plugins/pedalboard/apps/backfill-audio-analyses/src/backfill_discovery.ts
+++ b/packages/discovery-provider/plugins/pedalboard/apps/backfill-audio-analyses/src/backfill_discovery.ts
@@ -205,7 +205,7 @@ async function processBatches(db: any, batchSize: number): Promise<void> {
   }
 }
 
-export const backfill = async (app: App<SharedData>) => {
+export const backfillDiscovery = async (app: App<SharedData>) => {
   if (!config.delegatePrivateKey) {
     console.error('Missing required delegate private key. Terminating...')
     return

--- a/packages/discovery-provider/plugins/pedalboard/apps/backfill-audio-analyses/src/backfill_discovery.ts
+++ b/packages/discovery-provider/plugins/pedalboard/apps/backfill-audio-analyses/src/backfill_discovery.ts
@@ -85,6 +85,9 @@ async function getAudioAnalysis(contentNodes: string[], track: Track) {
           : 'audio_analysis_error_count'
         const results = response.data[resultsKey]
         const errorCount = response.data[errorCountKey]
+        if (!results) {
+          break
+        }
 
         let musicalKey = null
         let bpm = null
@@ -172,6 +175,8 @@ async function processBatches(db: any, batchSize: number): Promise<void> {
     const updates = (await Promise.all(analyzePromises)).filter(
       (u) => u !== null
     )
+
+    console.log(`Updating ${updates.length} tracks`)
 
     await db.transaction(async (trx: any) => {
       for (const update of updates) {

--- a/packages/discovery-provider/plugins/pedalboard/apps/backfill-audio-analyses/src/backfill_discovery.ts
+++ b/packages/discovery-provider/plugins/pedalboard/apps/backfill-audio-analyses/src/backfill_discovery.ts
@@ -48,10 +48,7 @@ function formatErrorLog(
   return errLog
 }
 
-async function getAudioAnalysis(
-  contentNodes: string[],
-  track: Track
-) {
+async function getAudioAnalysis(contentNodes: string[], track: Track) {
   const audioUploadId = track.audio_upload_id || ''
   const trackCid = track.track_cid
   if (!trackCid) return
@@ -71,10 +68,9 @@ async function getAudioAnalysis(
         analysisUrl = `${contentNode}/tracks/legacy/${trackCid}/analysis`
       }
 
-      const response = await axios.get(
-        analysisUrl,
-        { timeout: REQUEST_TIMEOUT }
-      )
+      const response = await axios.get(analysisUrl, {
+        timeout: REQUEST_TIMEOUT
+      })
       if (response.status == 200) {
         console.log(
           `Successfully retrieved audio analysis for track ID ${
@@ -84,7 +80,9 @@ async function getAudioAnalysis(
           } via ${contentNode}`
         )
         const resultsKey = isLegacyTrack ? 'results' : 'audio_analysis_results'
-        const errorCountKey = isLegacyTrack ? 'error_count' : 'audio_analysis_error_count'
+        const errorCountKey = isLegacyTrack
+          ? 'error_count'
+          : 'audio_analysis_error_count'
         const results = response.data[resultsKey]
         const errorCount = response.data[errorCountKey]
 
@@ -100,7 +98,7 @@ async function getAudioAnalysis(
         } else if (results?.BPM) {
           bpm = results?.BPM
         }
-        
+
         result = {
           track_id: track.track_id,
           musical_key: musicalKey,
@@ -171,7 +169,9 @@ async function processBatches(db: any, batchSize: number): Promise<void> {
         track
       )
     )
-    const updates = (await Promise.all(analyzePromises)).filter(u => u !== null)
+    const updates = (await Promise.all(analyzePromises)).filter(
+      (u) => u !== null
+    )
 
     await db.transaction(async (trx: any) => {
       for (const update of updates) {

--- a/packages/discovery-provider/plugins/pedalboard/apps/backfill-audio-analyses/src/backfill_discovery.ts
+++ b/packages/discovery-provider/plugins/pedalboard/apps/backfill-audio-analyses/src/backfill_discovery.ts
@@ -1,0 +1,218 @@
+import axios from 'axios'
+import { Semaphore } from 'await-semaphore'
+import { Knex } from 'knex'
+import { App } from '@pedalboard/basekit'
+import { config } from '.'
+import { SharedData } from './index'
+import {
+  storeDbOffset,
+  readDbOffset,
+  getCachedHealthyContentNodes
+} from './redis'
+
+const Web3 = require('web3')
+const web3 = new Web3()
+
+// concurrency control
+const MAX_CONCURRENT_REQUESTS = 10
+const semaphore = new Semaphore(MAX_CONCURRENT_REQUESTS)
+
+const REQUEST_TIMEOUT = 5000 // 5s
+
+const DB_OFFSET_KEY = 'discovery:backfill_audio_analyses:offset'
+
+interface Track {
+  track_id: number
+  track_cid: string
+  audio_upload_id: string | null
+  musical_key: string | null
+  bpm: number | null
+  audio_analysis_error_count: number | null
+}
+
+function formatErrorLog(
+  message: string,
+  track: Track,
+  node: string,
+  attemptNo: number
+): string {
+  let errLog = `Error retrieving audio analysis on ${node}: ${message}. Attempt #${attemptNo} for track ID ${track.track_id}, track CID ${track.track_cid}`
+  if (track.audio_upload_id) {
+    errLog += `, upload ID ${track.audio_upload_id}`
+  }
+  if (attemptNo < 5) {
+    errLog += '. Trying another content node...'
+  } else {
+    errLog += '. Skipping track...'
+  }
+  return errLog
+}
+
+async function getAudioAnalysis(
+  contentNodes: string[],
+  track: Track
+) {
+  const audioUploadId = track.audio_upload_id || ''
+  const trackCid = track.track_cid
+  if (!trackCid) return
+  const isLegacyTrack = !audioUploadId
+
+  const release = await semaphore.acquire() // acquire a semaphore permit
+
+  let result = null
+  // allow up to 5 attempts to get audio analysis for this track
+  for (let i = 0; i < 5; i++) {
+    // choose a random content node
+    const contentNode =
+      contentNodes[Math.floor(Math.random() * contentNodes.length)]
+    try {
+      let analysisUrl = `${contentNode}/uploads/${audioUploadId}`
+      if (isLegacyTrack) {
+        analysisUrl = `${contentNode}/tracks/legacy/${trackCid}/analysis`
+      }
+
+      const response = await axios.get(
+        analysisUrl,
+        { timeout: REQUEST_TIMEOUT }
+      )
+      if (response.status == 200) {
+        console.log(
+          `Successfully retrieved audio analysis for track ID ${
+            track.track_id
+          }, track CID ${trackCid}${
+            audioUploadId ? `, upload ID: ${audioUploadId}` : ''
+          } via ${contentNode}`
+        )
+        const resultsKey = isLegacyTrack ? 'results' : 'audio_analysis_results'
+        const errorCountKey = isLegacyTrack ? 'error_count' : 'audio_analysis_error_count'
+        const results = response.data[resultsKey]
+        const errorCount = response.data[errorCountKey]
+
+        let musicalKey = null
+        let bpm = null
+        if (results?.key) {
+          musicalKey = results?.key
+        } else if (results?.Key) {
+          musicalKey = results?.Key
+        }
+        if (results?.bpm) {
+          bpm = results?.bpm
+        } else if (results?.BPM) {
+          bpm = results?.BPM
+        }
+        
+        result = {
+          track_id: track.track_id,
+          musical_key: musicalKey,
+          bpm,
+          error_count: errorCount
+        }
+        break
+      } else {
+        console.log(
+          formatErrorLog(
+            `Received ${response.status} response`,
+            track,
+            contentNode,
+            i + 1
+          )
+        )
+        continue
+      }
+    } catch (error: any) {
+      console.log(formatErrorLog(error.message, track, contentNode, i + 1))
+      continue
+    }
+  }
+
+  release() // release the semaphore permit
+  return result
+}
+
+async function fetchTracks(
+  offset: number,
+  limit: number,
+  db: Knex
+): Promise<Track[]> {
+  return await db<Track>('tracks')
+    .where(function () {
+      this.whereNull('musical_key').orWhereNull('bpm')
+    })
+    .andWhere('audio_analysis_error_count', '<', 3)
+    .andWhere('track_cid', 'is not', null)
+    .orderBy('track_id', 'asc')
+    .offset(offset)
+    .limit(limit)
+}
+
+// trigger audio analyses for batchSize tracks at a time
+async function processBatches(db: any, batchSize: number): Promise<void> {
+  let offset
+  while (true) {
+    console.time('Batch processing time')
+    const contentNodes = await getCachedHealthyContentNodes()
+    if (contentNodes.length == 0) {
+      console.timeEnd('Batch processing time')
+      console.error(`No healthy content nodes found. Please investigate`)
+      return
+    }
+    offset = await readDbOffset(DB_OFFSET_KEY)
+    if (offset == null) {
+      offset = 0
+    }
+    const tracks = await fetchTracks(offset, batchSize, db)
+    if (tracks.length === 0) {
+      console.timeEnd('Batch processing time')
+      break
+    }
+    const analyzePromises = tracks.map((track) =>
+      getAudioAnalysis(
+        contentNodes.map((node) => node.endpoint),
+        track
+      )
+    )
+    const updates = (await Promise.all(analyzePromises)).filter(u => u !== null)
+
+    await db.transaction(async (trx: any) => {
+      for (const update of updates) {
+        await trx('tracks')
+          .where({ track_id: update!.track_id })
+          .update({
+            musical_key: update!.musical_key || trx.raw('musical_key'),
+            bpm: update!.bpm || trx.raw('bpm'),
+            audio_analysis_error_count: update!.error_count
+          })
+      }
+    })
+
+    offset += batchSize
+    await storeDbOffset(DB_OFFSET_KEY, offset)
+    console.timeEnd('Batch processing time')
+    console.log(`Processed ${tracks.length} tracks. New offset: ${offset}`)
+
+    if (config.testRun) {
+      console.log(
+        `[TEST RUN] Saved audio analyses for the following track IDs: ${tracks.map(
+          (track) => track.track_id
+        )}`
+      )
+      // only do 1 batch in a test run
+      break
+    }
+
+    // sleep for 30 seconds
+    await new Promise((resolve) => setTimeout(resolve, 30000))
+  }
+}
+
+export const backfill = async (app: App<SharedData>) => {
+  if (!config.delegatePrivateKey) {
+    console.error('Missing required delegate private key. Terminating...')
+    return
+  }
+  const db = app.getDnDb()
+  const BACKFILL_BATCH_SIZE = config.testRun ? 100 : 1000
+  await processBatches(db, BACKFILL_BATCH_SIZE)
+
+  console.log('backfill_discovery.ts | No more tracks to backfill. Goodbye!')
+}

--- a/packages/discovery-provider/plugins/pedalboard/apps/backfill-audio-analyses/src/backfill_discovery.ts
+++ b/packages/discovery-provider/plugins/pedalboard/apps/backfill-audio-analyses/src/backfill_discovery.ts
@@ -10,9 +10,6 @@ import {
   getCachedHealthyContentNodes
 } from './redis'
 
-const Web3 = require('web3')
-const web3 = new Web3()
-
 // concurrency control
 const MAX_CONCURRENT_REQUESTS = 10
 const semaphore = new Semaphore(MAX_CONCURRENT_REQUESTS)
@@ -173,7 +170,7 @@ async function processBatches(db: any, batchSize: number): Promise<void> {
       )
     )
     const updates = (await Promise.all(analyzePromises)).filter(
-      (u) => u !== null
+      (u) => u != null
     )
 
     console.log(`Updating ${updates.length} tracks`)

--- a/packages/discovery-provider/plugins/pedalboard/apps/backfill-audio-analyses/src/index.ts
+++ b/packages/discovery-provider/plugins/pedalboard/apps/backfill-audio-analyses/src/index.ts
@@ -1,7 +1,7 @@
 import { Config, readConfig } from './config'
 import { logger } from './logger'
 import { App } from '@pedalboard/basekit'
-import { backfill } from './backfill'
+import { backfillDiscovery } from './backfill_discovery'
 
 export type SharedData = {
   config: Config
@@ -10,7 +10,7 @@ export type SharedData = {
 export const config = readConfig()
 
 const main = async () => {
-  await new App<SharedData>({}).task(backfill).run()
+  await new App<SharedData>({}).task(backfillDiscovery).run()
   process.exit(0)
 }
 

--- a/packages/discovery-provider/plugins/pedalboard/apps/backfill-audio-analyses/src/redis.ts
+++ b/packages/discovery-provider/plugins/pedalboard/apps/backfill-audio-analyses/src/redis.ts
@@ -5,8 +5,6 @@ import { logger } from './logger'
 let redisClient: RedisClientType
 let isReady: boolean
 
-const DB_OFFSET_KEY = 'backfill_audio_analyses:offset'
-
 const parseArray = (json: string | null) => {
   try {
     const parsed = JSON.parse(json ?? '[]')
@@ -30,10 +28,10 @@ export const getRedisConnection = async () => {
   return redisClient
 }
 
-export const storeDbOffset = async (offset: number) => {
+export const storeDbOffset = async (key: string, offset: number) => {
   try {
     const redis = await getRedisConnection()
-    await redis.set(DB_OFFSET_KEY, offset.toString())
+    await redis.set(key, offset.toString())
   } catch (e) {
     logger.error({ error: e }, 'could not store db offset')
   }
@@ -41,10 +39,10 @@ export const storeDbOffset = async (offset: number) => {
 
 // reads the last recorded db offset from redis
 // returns null if not found
-export const readDbOffset = async (): Promise<number | null> => {
+export const readDbOffset = async (key: string): Promise<number | null> => {
   try {
     const redis = await getRedisConnection()
-    const cacheValue = await redis.get(DB_OFFSET_KEY)
+    const cacheValue = await redis.get(key)
     if (cacheValue == null) return null
     return parseInt(cacheValue, 10)
   } catch (e) {


### PR DESCRIPTION
### Description
since the discovery celery repairer is not parallelized and in implementation is taking 15 mins/1000 tracks. which is fine when repairing just new uploads but a little slow for pulling millions of analysis results from mediorum.

use this plugin instead. run in batches of 1000 tracks at a time with 10 workers processing each batch.

### How Has This Been Tested?
tested on a stage node.