### PR TITLE
boost solana relay health check startup timeframe

### DIFF
--- a/dev-tools/compose/docker-compose.pedalboard.prod.yml
+++ b/dev-tools/compose/docker-compose.pedalboard.prod.yml
@@ -92,7 +92,7 @@ services:
         ]
       interval: 5s
       timeout: 30s
-      retries: 5
+      retries: 15
       start_period: 5s
     depends_on:
       db:


### PR DESCRIPTION
### Description
Solana relay can take a long time to start up for some reason, this time took 34 seconds.

```
[INFO] 02:12:41 ts-node-dev ver. 2.0.0 (using ts-node ver. 10.9.1, typescript ver. 5.0.4)
{"level":30,"time":"2024-06-25T02:13:02.081Z","name":"solana-relay","msg":"running on dev network"}
{"level":30,"time":"2024-06-25T02:13:12.570Z","name":"solana-relay","serverHost":"0.0.0.0","serverPort":6002,"msg":"server initialized"}
{"level":30,"time":"2024-06-25T02:13:15.481Z","name":"solana-relay","requestId":"1853f237-dbc7-48c8-ac66-5a94eac33031","path":"/solana/health_check","method":"GET","startTime":"2024-06-25T02:13:15.481Z","body":{},"msg":"incoming request"}
```
Previously this was 30 seconds so it was very likely a toss up before the health timeout would be hit and docker would think solana-relay was unhealthy. After the fact you'd check docker and it would be fine. 

This change boosts the total to 80s which should be more than enough for the dev server to be healthy.

### How Has This Been Tested?
`audius-compose up`
