### PR TITLE
[C-4608] Allow premium hidden uploads

### DIFF
--- a/packages/web/src/components/edit/fields/price-and-audience/PriceAndAudienceField.tsx
+++ b/packages/web/src/components/edit/fields/price-and-audience/PriceAndAudienceField.tsx
@@ -300,10 +300,12 @@ export const PriceAndAudienceField = (props: PriceAndAudienceFieldProps) => {
       setStreamConditionsValue(null)
       setPreviewValue(undefined)
 
-      if (availabilityType === StreamTrackAvailabilityType.HIDDEN) {
-        setIsUnlistedValue(true)
-      } else {
-        setIsUnlistedValue(false)
+      if (!isHiddenPaidScheduledEnabled) {
+        if (availabilityType === StreamTrackAvailabilityType.HIDDEN) {
+          setIsUnlistedValue(true)
+        } else {
+          setIsUnlistedValue(false)
+        }
       }
 
       // For gated options, extract the correct stream conditions based on the selected availability type


### PR DESCRIPTION
### Description

- When `HIDDEN_PAID_SCHEDULED` feature flag is on, unlink the automatic setting of hidden/public when changing premium gates

### How Has This Been Tested?

working locally, can upload hidden premium