### PR TITLE
[PD-442] Hide action buttons on private content

### DIFF
--- a/packages/mobile/src/components/details-tile/types.ts
+++ b/packages/mobile/src/components/details-tile/types.ts
@@ -76,6 +76,9 @@ export type DetailsTileProps = {
   /** Hide the share button */
   hideShare?: boolean
 
+  /** Hide all action buttons */
+  hideActions?: boolean
+
   /** Is the item playing */
   isPlaying?: boolean
 

--- a/packages/mobile/src/screens/collection-screen/CollectionScreenDetailsTile.tsx
+++ b/packages/mobile/src/screens/collection-screen/CollectionScreenDetailsTile.tsx
@@ -189,12 +189,10 @@ export const CollectionScreenDetailsTile = ({
   trackCount: trackCountProp,
   isOwner = false,
   hideOverflow,
-  hideRepost,
-  hideFavorite,
+  hideActions,
   hasStreamAccess,
   streamConditions,
   ddexApp,
-  hideShare,
   playCount,
   hidePlayCount,
   hideFavoriteCount,
@@ -266,6 +264,7 @@ export const CollectionScreenDetailsTile = ({
     isScheduledRelease && isPrivate && releaseDate
   const shouldHideOverflow =
     hideOverflow || !isReachable || (isPrivate && !isOwner)
+  const shouldeHideActions = hideActions || (isPrivate && !isOwner)
   const isUSDCPurchaseGated = isContentUSDCPurchaseGated(streamConditions)
 
   const uids = isLineupLoading ? Array(Math.min(5, trackCount ?? 0)) : trackUids
@@ -454,10 +453,10 @@ export const CollectionScreenDetailsTile = ({
           ddexApp={ddexApp}
           hasReposted={!!hasReposted}
           hasSaved={!!hasSaved}
-          hideFavorite={hideFavorite}
+          hideFavorite={shouldeHideActions}
           hideOverflow={shouldHideOverflow}
-          hideRepost={hideRepost}
-          hideShare={hideShare}
+          hideRepost={shouldeHideActions}
+          hideShare={shouldeHideActions}
           isOwner={isOwner}
           isCollection
           collectionId={numericCollectionId}

--- a/packages/mobile/src/screens/collection-screen/CollectionScreenDetailsTile.tsx
+++ b/packages/mobile/src/screens/collection-screen/CollectionScreenDetailsTile.tsx
@@ -264,7 +264,7 @@ export const CollectionScreenDetailsTile = ({
     isScheduledRelease && isPrivate && releaseDate
   const shouldHideOverflow =
     hideOverflow || !isReachable || (isPrivate && !isOwner)
-  const shouldeHideActions = hideActions || (isPrivate && !isOwner)
+  const shouldHideActions = hideActions || (isPrivate && !isOwner)
   const isUSDCPurchaseGated = isContentUSDCPurchaseGated(streamConditions)
 
   const uids = isLineupLoading ? Array(Math.min(5, trackCount ?? 0)) : trackUids
@@ -453,10 +453,10 @@ export const CollectionScreenDetailsTile = ({
           ddexApp={ddexApp}
           hasReposted={!!hasReposted}
           hasSaved={!!hasSaved}
-          hideFavorite={shouldeHideActions}
+          hideFavorite={shouldHideActions}
           hideOverflow={shouldHideOverflow}
-          hideRepost={shouldeHideActions}
-          hideShare={shouldeHideActions}
+          hideRepost={shouldHideActions}
+          hideShare={shouldHideActions}
           isOwner={isOwner}
           isCollection
           collectionId={numericCollectionId}

--- a/packages/mobile/src/screens/smart-collection-screen/SmartCollectionScreen.tsx
+++ b/packages/mobile/src/screens/smart-collection-screen/SmartCollectionScreen.tsx
@@ -114,9 +114,8 @@ export const SmartCollectionScreen = (props: SmartCollectionScreenProps) => {
         hasSaved={isSaved}
         hideFavoriteCount
         hideOverflow
-        hideRepost
         hideRepostCount
-        hideShare
+        hideActions
         onPressSave={handlePressSave}
         renderImage={renderImage}
         title={playlistName}

--- a/packages/web/src/components/collection/desktop/ViewerActionButtons.tsx
+++ b/packages/web/src/components/collection/desktop/ViewerActionButtons.tsx
@@ -18,11 +18,11 @@ export const ViewerActionButtons = (props: ViewerActionButtonsProps) => {
     getCollection(state, { id: collectionId })
   ) as Collection | null
 
-  const { track_count, is_private, access } = collection ?? {}
-  const isDisabled = !collection || track_count === 0 || is_private
+  const { track_count, is_private: isPrivate, access } = collection ?? {}
+  const isDisabled = !collection || track_count === 0 || isPrivate
   const hasStreamAccess = access?.stream
 
-  return (
+  return isPrivate ? null : (
     <>
       {hasStreamAccess ? (
         <>
@@ -30,9 +30,7 @@ export const ViewerActionButtons = (props: ViewerActionButtonsProps) => {
           <FavoriteButton disabled={isDisabled} collectionId={collectionId} />
         </>
       ) : null}
-
       <ShareButton disabled={isDisabled} collectionId={collectionId} />
-
       <OverflowMenuButton collectionId={collectionId} />
     </>
   )

--- a/packages/web/src/components/collection/mobile/CollectionHeader.tsx
+++ b/packages/web/src/components/collection/mobile/CollectionHeader.tsx
@@ -108,7 +108,7 @@ const CollectionHeader = ({
     currentUserId
   })
   const { hasStreamAccess } = useGatedContentAccess(collection)
-  const isPremium = collection?.is_stream_gated
+  const { is_private: isPrivate, is_stream_gated: isPremium } = collection ?? {}
 
   const tracks = useSelector((state: CommonState) =>
     getCollectionTracks(state, { id: collectionId })
@@ -273,10 +273,18 @@ const CollectionHeader = ({
           onRepost={onRepost}
           onClickOverflow={onClickOverflow}
           onClickEdit={handleClickEdit}
-          showFavorite={!!onSave && !isOwner && hasStreamAccess}
-          showRepost={variant !== Variant.SMART && !isOwner && hasStreamAccess}
-          showShare={variant !== Variant.SMART || type === 'Audio NFT Playlist'}
-          showOverflow={variant !== Variant.SMART}
+          showFavorite={!!onSave && !isOwner && hasStreamAccess && !isPrivate}
+          showRepost={
+            variant !== Variant.SMART &&
+            !isOwner &&
+            hasStreamAccess &&
+            !isPrivate
+          }
+          showShare={
+            (variant !== Variant.SMART || type === 'Audio NFT Playlist') &&
+            !isPrivate
+          }
+          showOverflow={variant !== Variant.SMART && !isPrivate}
           darkMode={isDarkMode()}
           showEdit={variant !== Variant.SMART && isOwner}
         />


### PR DESCRIPTION
### Description
Hide action buttons (repost, share, save, overflow) for hidden tracks and collections.

### How Has This Been Tested?

Web track
<img width="969" alt="Screenshot 2024-06-25 at 1 21 31 PM" src="https://github.com/AudiusProject/audius-protocol/assets/3893871/60ad280d-0d48-4d2d-9d3c-0b577a02a842">

Web collection
<img width="909" alt="Screenshot 2024-06-25 at 1 21 49 PM" src="https://github.com/AudiusProject/audius-protocol/assets/3893871/659c7dfc-d711-46dc-9bd9-d95c879f9418">

mobile-web track
<img width="473" alt="Screenshot 2024-06-25 at 1 27 35 PM" src="https://github.com/AudiusProject/audius-protocol/assets/3893871/0e729a01-a3a8-4273-a78c-239594c9ac64">

mobile-web collection
<img width="449" alt="Screenshot 2024-06-25 at 1 30 48 PM" src="https://github.com/AudiusProject/audius-protocol/assets/3893871/28891386-2d29-4dec-8f46-ec101ebeeedc">

Mobile track
![Simulator Screenshot - iPhone 15 Pro - 2024-06-25 at 13 22 07](https://github.com/AudiusProject/audius-protocol/assets/3893871/cbc56576-934f-4743-97a2-13577b230114)

Mobile collection
![Simulator Screenshot - iPhone 15 Pro - 2024-06-25 at 13 22 13](https://github.com/AudiusProject/audius-protocol/assets/3893871/d45222de-1c78-4afa-9014-4ae755fa25a1)
