### PR TITLE
[C-4610] Fix styling on web track header text

### DIFF
--- a/packages/web/src/components/collection/desktop/CollectionHeader.tsx
+++ b/packages/web/src/components/collection/desktop/CollectionHeader.tsx
@@ -193,11 +193,7 @@ export const CollectionHeader = (props: CollectionHeaderProps) => {
           ) : (
             <Flex gap='s' mt='s' alignItems='center'>
               {isPremium ? <IconCart size='s' color='subdued' /> : null}
-              <Text
-                variant='label'
-                color='subdued'
-                css={{ letterSpacing: '2px' }}
-              >
+              <Text variant='label' color='subdued'>
                 {isPremium ? `${messages.premiumLabel} ` : ''}
                 {type === 'playlist' && !isPublished
                   ? messages.hiddenPlaylistLabel

--- a/packages/web/src/components/collection/mobile/CollectionHeader.tsx
+++ b/packages/web/src/components/collection/mobile/CollectionHeader.tsx
@@ -207,7 +207,7 @@ const CollectionHeader = ({
     <Flex direction='column'>
       {renderDogEar()}
       <Flex direction='column' alignItems='center' p='l' gap='l'>
-        <Text variant='label' css={{ letterSpacing: '2px' }} color='subdued'>
+        <Text variant='label' color='subdued'>
           {type === 'playlist' && !isPublished
             ? isPublishing
               ? messages.publishing

--- a/packages/web/src/components/track/CardTitle.tsx
+++ b/packages/web/src/components/track/CardTitle.tsx
@@ -8,7 +8,8 @@ import {
   Text,
   IconCart,
   IconCollectible,
-  IconSpecialAccess
+  IconSpecialAccess,
+  Flex
 } from '@audius/harmony'
 import cn from 'classnames'
 
@@ -36,8 +37,6 @@ type CardTitleProps = {
 
 export const CardTitle = ({
   className,
-  isScheduledRelease,
-  isUnlisted,
   isRemix,
   isStreamGated,
   isPodcast,
@@ -51,30 +50,32 @@ export const CardTitle = ({
     let icon
     let message
     if (isContentCollectibleGated(streamConditions)) {
-      icon = <IconCollectible />
+      icon = <IconCollectible size='s' color='subdued' />
       message = messages.collectibleGated
     } else if (isContentUSDCPurchaseGated(streamConditions)) {
-      icon = <IconCart />
+      icon = <IconCart size='s' color='subdued' />
       message = messages.premiumTrack
     } else {
-      icon = <IconSpecialAccess />
+      icon = <IconSpecialAccess size='s' color='subdued' />
       message = messages.specialAccess
     }
     content = (
-      <div className={cn(styles.typeLabel, styles.gatedContentLabel)}>
+      <Flex gap='s' alignItems='center' justifyContent='center'>
         {icon}
-        {message}
-      </div>
+        <Text variant='label' color='subdued' css={{ letterSpacing: '2px' }}>
+          {message}
+        </Text>
+      </Flex>
     )
   } else {
     content = (
-      <div className={styles.typeLabel}>
+      <Text variant='label' color='subdued' css={{ letterSpacing: '2px' }}>
         {isRemix
           ? messages.remixTitle
           : isPodcast
           ? messages.podcastTitle
           : messages.trackTitle}
-      </div>
+      </Text>
     )
   }
 

--- a/packages/web/src/components/track/CardTitle.tsx
+++ b/packages/web/src/components/track/CardTitle.tsx
@@ -62,14 +62,14 @@ export const CardTitle = ({
     content = (
       <Flex gap='s' alignItems='center' justifyContent='center'>
         {icon}
-        <Text variant='label' color='subdued' css={{ letterSpacing: '2px' }}>
+        <Text variant='label' color='subdued'>
           {message}
         </Text>
       </Flex>
     )
   } else {
     content = (
-      <Text variant='label' color='subdued' css={{ letterSpacing: '2px' }}>
+      <Text variant='label' color='subdued'>
         {isRemix
           ? messages.remixTitle
           : isPodcast

--- a/packages/web/src/pages/track-page/components/mobile/TrackHeader.module.css
+++ b/packages/web/src/pages/track-page/components/mobile/TrackHeader.module.css
@@ -21,17 +21,6 @@
   left: calc(-1 * var(--border-width));
 }
 
-.typeLabel {
-  height: 18px;
-  color: var(--harmony-n-400);
-  font-family: var(--harmony-font-family);
-  font-size: var(--harmony-font-s);
-  font-weight: var(--harmony-font-demi-bold);
-  letter-spacing: 2px;
-  text-align: center;
-  text-transform: uppercase;
-}
-
 .coverArt {
   height: 195px;
   width: 195px;
@@ -196,21 +185,6 @@
   height: 24px;
   width: 100% !important;
   margin-bottom: 24px;
-}
-
-.gatedContentLabel {
-  display: flex;
-  align-items: center;
-  gap: var(--harmony-unit-2);
-}
-
-.gatedContentLabel svg {
-  width: calc(var(--harmony-unit) * 4.5);
-  height: calc(var(--harmony-unit) * 4.5);
-}
-
-.gatedContentLabel path {
-  fill: var(--harmony-text-subdued);
 }
 
 .gatedContentSectionWrapper {

--- a/packages/web/src/pages/track-page/components/mobile/TrackHeader.tsx
+++ b/packages/web/src/pages/track-page/components/mobile/TrackHeader.tsx
@@ -329,13 +329,7 @@ const TrackHeader = ({
       return (
         <Flex gap='xs' justifyContent='center' alignItems='center'>
           <IconComponent color='subdued' size='s' />
-          <Text
-            variant='label'
-            color='subdued'
-            css={{
-              letterSpacing: '2px'
-            }}
-          >
+          <Text variant='label' color='subdued'>
             {titleMessage}
           </Text>
         </Flex>
@@ -344,13 +338,7 @@ const TrackHeader = ({
 
     return (
       <Flex justifyContent='center' alignItems='center'>
-        <Text
-          variant='label'
-          color='subdued'
-          css={{
-            letterSpacing: '2px'
-          }}
-        >
+        <Text variant='label' color='subdued'>
           {isRemix ? messages.remix : messages.track}
         </Text>
       </Flex>

--- a/packages/web/src/pages/track-page/components/mobile/TrackHeader.tsx
+++ b/packages/web/src/pages/track-page/components/mobile/TrackHeader.tsx
@@ -31,7 +31,8 @@ import {
   IconCart,
   Box,
   Button,
-  MusicBadge
+  MusicBadge,
+  Text
 } from '@audius/harmony'
 import IconCalendarMonth from '@audius/harmony/src/assets/icons/CalendarMonth.svg'
 import IconRobot from '@audius/harmony/src/assets/icons/Robot.svg'
@@ -326,17 +327,33 @@ const TrackHeader = ({
         titleMessage = messages.premiumTrack
       }
       return (
-        <div className={cn(styles.typeLabel, styles.gatedContentLabel)}>
-          <IconComponent />
-          <span>{titleMessage}</span>
-        </div>
+        <Flex gap='xs' justifyContent='center' alignItems='center'>
+          <IconComponent color='subdued' size='s' />
+          <Text
+            variant='label'
+            color='subdued'
+            css={{
+              letterSpacing: '2px'
+            }}
+          >
+            {titleMessage}
+          </Text>
+        </Flex>
       )
     }
 
     return (
-      <div className={styles.typeLabel}>
-        {isRemix ? messages.remix : messages.track}
-      </div>
+      <Flex justifyContent='center' alignItems='center'>
+        <Text
+          variant='label'
+          color='subdued'
+          css={{
+            letterSpacing: '2px'
+          }}
+        >
+          {isRemix ? messages.remix : messages.track}
+        </Text>
+      </Flex>
     )
   }
 


### PR DESCRIPTION
### Description
Noticed header text styling was different between tracks and albums on web. Check the linear issue to see examples of how it was broken.

### How Has This Been Tested?

<img width="449" alt="Screenshot 2024-06-25 at 3 54 59 PM" src="https://github.com/AudiusProject/audius-protocol/assets/3893871/ca7354c9-512c-48a5-8e55-2dad42a0c4ac">
<img width="438" alt="Screenshot 2024-06-25 at 3 55 12 PM" src="https://github.com/AudiusProject/audius-protocol/assets/3893871/1be2c173-f860-4f04-9aa8-e086a306da59">
<img width="962" alt="Screenshot 2024-06-25 at 3 53 59 PM" src="https://github.com/AudiusProject/audius-protocol/assets/3893871/1353afa7-3759-4675-aeda-bca7058adb89">
<img width="898" alt="Screenshot 2024-06-25 at 3 54 03 PM" src="https://github.com/AudiusProject/audius-protocol/assets/3893871/483db507-cc00-4669-9b5d-92d84f5d7344">
<img width="478" alt="Screenshot 2024-06-25 at 3 54 23 PM" src="https://github.com/AudiusProject/audius-protocol/assets/3893871/09836940-fb84-455a-a6af-d239c63f6406">
