### PR TITLE
[C-4609] Fix hidden album header text on mobile

### DIFF
--- a/packages/mobile/src/screens/collection-screen/CollectionScreenDetailsTile.tsx
+++ b/packages/mobile/src/screens/collection-screen/CollectionScreenDetailsTile.tsx
@@ -120,7 +120,6 @@ const getMessages = (
   emptyPublic: `This ${collectionType} is empty`,
   detailsPlaceholder: '---',
   collectionType: `${isPremium ? 'premium ' : ''}${collectionType}`,
-  hiddenType: `Hidden ${collectionType}`,
   play: 'Play',
   pause: 'Pause',
   resume: 'Resume',
@@ -258,7 +257,6 @@ export const CollectionScreenDetailsTile = ({
   const playingTrackId = playingTrack?.track_id
   const firstTrack = useSelector(selectFirstTrack)
   const messages = getMessages(isAlbum ? 'album' : 'playlist', isStreamGated)
-  const headerText = isPrivate ? messages.hiddenType : messages.collectionType
   const isPublished = !isPrivate || isPublishing
   const isUnpublishedScheduledRelease =
     isScheduledRelease && isPrivate && releaseDate
@@ -414,7 +412,7 @@ export const CollectionScreenDetailsTile = ({
           textTransform='uppercase'
           color='subdued'
         >
-          {headerText}
+          {messages.collectionType}
         </Text>
 
         {badges.length > 0 ? (


### PR DESCRIPTION
### Description
Missed a spot - headers should no longer read "Hidden x" as we're moving the hidden denotation over to the MusicBadges.

### How Has This Been Tested?

![Simulator Screenshot - iPhone 15 Pro - 2024-06-25 at 16 06 40](https://github.com/AudiusProject/audius-protocol/assets/3893871/67329c95-3c3f-4c76-a967-27d0c2bc7d35)

