### PR TITLE
[PAY-2829] Add analytics for manager mode

### DIFF
--- a/packages/common/src/hooks/useAccountSwitcher.ts
+++ b/packages/common/src/hooks/useAccountSwitcher.ts
@@ -2,11 +2,15 @@ import { useCallback } from 'react'
 
 import { useGetCurrentUserId, useGetCurrentWeb3User } from '~/api/account'
 import { useAppContext } from '~/context'
+import { Name } from '~/models/Analytics'
 import { UserMetadata } from '~/models/User'
 
 export const useAccountSwitcher = () => {
   const { localStorage } = useAppContext()
   const { data: currentWeb3User } = useGetCurrentWeb3User({})
+  const {
+    analytics: { make, track }
+  } = useAppContext()
 
   const switchAccount = useCallback(
     async (user: UserMetadata) => {
@@ -14,6 +18,12 @@ export const useAccountSwitcher = () => {
         console.error('User has no wallet address')
         return
       }
+      await track(
+        make({
+          eventName: Name.MANAGER_MODE_SWITCH_ACCOUNT,
+          managedUserId: user.user_id
+        })
+      )
 
       // Set an override if we aren't using the wallet of the "signed in" user
       if (currentWeb3User && currentWeb3User.wallet === user.wallet) {

--- a/packages/common/src/models/Analytics.ts
+++ b/packages/common/src/models/Analytics.ts
@@ -135,6 +135,8 @@ export enum Name {
   AUTHORIZED_APP_REMOVE_SUCCESS = 'Authorized Apps: Remove app success',
   AUTHORIZED_APP_REMOVE_ERROR = 'Authorized Apps: Remove app error',
 
+  // Manager Mode
+
   // Visualizer
   VISUALIZER_OPEN = 'Visualizer: Open',
   VISUALIZER_CLOSE = 'Visualizer: Close',
@@ -509,7 +511,15 @@ export enum Name {
   EXPORT_PRIVATE_KEY_PAGE_VIEWED = 'Export Private Key: Page Viewed',
   EXPORT_PRIVATE_KEY_MODAL_OPENED = 'Export Private Key: Modal Opened',
   EXPORT_PRIVATE_KEY_PUBLIC_ADDRESS_COPIED = 'Export Private Key: Public Address Copied',
-  EXPORT_PRIVATE_KEY_PRIVATE_KEY_COPIED = 'Export Private Key: Private Key Copied'
+  EXPORT_PRIVATE_KEY_PRIVATE_KEY_COPIED = 'Export Private Key: Private Key Copied',
+
+  // Manager Mode
+  MANAGER_MODE_SWITCH_ACCOUNT = 'Manager Mode: Switch Account',
+  MANAGER_MODE_INVITE_MANAGER = 'Manager Mode: Invite Manager',
+  MANAGER_MODE_ACCEPT_INVITE = 'Manager Mode: Accept Invite',
+  MANAGER_MODE_CANCEL_INVITE = 'Manager Mode: Cancel Invite',
+  MANAGER_MODE_REJECT_INVITE = 'Manager Mode: Reject Invite',
+  MANAGER_MODE_REMOVE_MANAGER = 'Manager Mode: Remove Manager'
 }
 
 type PageView = {
@@ -2396,6 +2406,36 @@ type ExportPrivateKeyPrivateKeyCopied = {
   userId: ID
 }
 
+type ManagerModeSwitchAccount = {
+  eventName: Name.MANAGER_MODE_SWITCH_ACCOUNT
+  managedUserId: ID
+}
+
+type ManagerModeInviteManager = {
+  eventName: Name.MANAGER_MODE_INVITE_MANAGER
+  managerId: ID
+}
+
+type ManagerModeAcceptInvite = {
+  eventName: Name.MANAGER_MODE_ACCEPT_INVITE
+  managedUserId: ID
+}
+
+type ManagerModeCancelInvite = {
+  eventName: Name.MANAGER_MODE_CANCEL_INVITE
+  managerId: ID
+}
+
+type ManagerModeRejectInvite = {
+  eventName: Name.MANAGER_MODE_REJECT_INVITE
+  managedUserId: ID
+}
+
+type ManagerModeRemoveManager = {
+  eventName: Name.MANAGER_MODE_REMOVE_MANAGER
+  managerId: ID
+}
+
 export type BaseAnalyticsEvent = { type: typeof ANALYTICS_TRACK_EVENT }
 
 export type AllTrackingEvents =
@@ -2710,3 +2750,9 @@ export type AllTrackingEvents =
   | ExportPrivateKeyModalOpened
   | ExportPrivateKeyPublicAddressCopied
   | ExportPrivateKeyPrivateKeyCopied
+  | ManagerModeSwitchAccount
+  | ManagerModeInviteManager
+  | ManagerModeAcceptInvite
+  | ManagerModeCancelInvite
+  | ManagerModeRejectInvite
+  | ManagerModeRemoveManager

--- a/packages/common/src/models/Analytics.ts
+++ b/packages/common/src/models/Analytics.ts
@@ -135,8 +135,6 @@ export enum Name {
   AUTHORIZED_APP_REMOVE_SUCCESS = 'Authorized Apps: Remove app success',
   AUTHORIZED_APP_REMOVE_ERROR = 'Authorized Apps: Remove app error',
 
-  // Manager Mode
-
   // Visualizer
   VISUALIZER_OPEN = 'Visualizer: Open',
   VISUALIZER_CLOSE = 'Visualizer: Close',

--- a/packages/web/src/common/store/account/sagas.js
+++ b/packages/web/src/common/store/account/sagas.js
@@ -61,6 +61,9 @@ const setSentryUser = (sentry, user, traits) => {
   if (traits.isVerified) {
     sentry.setTag('isVerified', `${traits.isVerified}`)
   }
+  if (traits.managerUserId) {
+    sentry.setTag('isManagerMode', 'true')
+  }
   sentry.configureScope((currentScope) => {
     currentScope.setUser({
       id: `${user.user_id}`,
@@ -97,21 +100,32 @@ function* onSignedIn({ payload: { account } }) {
   const sentry = yield getContext('sentry')
   const analytics = yield getContext('analytics')
   if (account && account.handle) {
-    let solanaWallet = ''
-    try {
-      solanaWallet = (yield call(
-        getRootSolanaAccount,
-        audiusBackendInstance
-      )).publicKey.toBase58()
-    } catch (e) {
-      console.error('Failed to fetch Solana root wallet during identify()', e)
-    }
-    // Set analytics user context
+    const libs = yield call(audiusBackendInstance.getAudiusLibs)
+    const web3User = yield call([libs.Account, libs.Account.getWeb3User])
+
     const traits = {
       isVerified: account.is_verified,
-      trackCount: account.track_count,
-      solanaWallet
+      trackCount: account.track_count
     }
+
+    // If operating as a managed account, identify the manager user id
+    if (web3User && web3User.user_id !== account.user_id) {
+      traits.managerUserId = web3User.user_id
+      traits.managerHandle = web3User.handle
+    } else {
+      // If not a managed account, identify the Solana wallet associated with
+      // the hedgehog wallet
+      try {
+        const solanaWallet = (yield call(
+          getRootSolanaAccount,
+          audiusBackendInstance
+        )).publicKey.toBase58()
+        traits.solanaWallet = solanaWallet
+      } catch (e) {
+        console.error('Failed to fetch Solana root wallet during identify()', e)
+      }
+    }
+
     yield put(identify(account.handle, traits))
     setSentryUser(sentry, account, traits)
   }

--- a/packages/web/src/common/store/account/sagas.js
+++ b/packages/web/src/common/store/account/sagas.js
@@ -103,27 +103,33 @@ function* onSignedIn({ payload: { account } }) {
     const libs = yield call(audiusBackendInstance.getAudiusLibs)
     const web3User = yield call([libs.Account, libs.Account.getWeb3User])
 
-    const traits = {
-      isVerified: account.is_verified,
-      trackCount: account.track_count
-    }
+    let solanaWallet
+    let managerUserId
+    let managerHandle
 
     // If operating as a managed account, identify the manager user id
     if (web3User && web3User.user_id !== account.user_id) {
-      traits.managerUserId = web3User.user_id
-      traits.managerHandle = web3User.handle
+      managerUserId = web3User.user_id
+      managerHandle = web3User.handle
     } else {
       // If not a managed account, identify the Solana wallet associated with
       // the hedgehog wallet
       try {
-        const solanaWallet = (yield call(
+        solanaWallet = (yield call(
           getRootSolanaAccount,
           audiusBackendInstance
         )).publicKey.toBase58()
-        traits.solanaWallet = solanaWallet
       } catch (e) {
         console.error('Failed to fetch Solana root wallet during identify()', e)
       }
+    }
+
+    const traits = {
+      isVerified: account.is_verified,
+      trackCount: account.track_count,
+      managerHandle,
+      managerUserId,
+      solanaWallet
     }
 
     yield put(identify(account.handle, traits))

--- a/packages/web/src/components/edit/fields/price-and-audience/PriceAndAudienceField.tsx
+++ b/packages/web/src/components/edit/fields/price-and-audience/PriceAndAudienceField.tsx
@@ -411,6 +411,7 @@ export const PriceAndAudienceField = (props: PriceAndAudienceFieldProps) => {
       setIsDownloadGated,
       setDownloadConditionsValue,
       setIsDownloadable,
+      isHiddenPaidScheduledEnabled,
       isDownloadable,
       setLastGateKeeper
     ]

--- a/packages/web/src/pages/settings-page/components/desktop/ManagerMode/AccountsManagingYouHomePage.tsx
+++ b/packages/web/src/pages/settings-page/components/desktop/ManagerMode/AccountsManagingYouHomePage.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useContext, useEffect } from 'react'
 
 import { useGetManagers, useRemoveManager } from '@audius/common/api'
+import { useAppContext } from '@audius/common/context'
 import { Name, Status } from '@audius/common/models'
 import { accountSelectors } from '@audius/common/store'
 import { Box, Button, Divider, Flex, IconPlus, Text } from '@audius/harmony'
@@ -12,7 +13,6 @@ import { useSelector } from 'utils/reducer'
 import { AccountListItem } from './AccountListItem'
 import { sharedMessages } from './sharedMessages'
 import { AccountsManagingYouPageProps, AccountsManagingYouPages } from './types'
-import { useAppContext } from '@audius/common/context'
 
 const { getUserId } = accountSelectors
 

--- a/packages/web/src/pages/settings-page/components/desktop/ManagerMode/AccountsManagingYouHomePage.tsx
+++ b/packages/web/src/pages/settings-page/components/desktop/ManagerMode/AccountsManagingYouHomePage.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useContext, useEffect } from 'react'
 
 import { useGetManagers, useRemoveManager } from '@audius/common/api'
-import { Status } from '@audius/common/models'
+import { Name, Status } from '@audius/common/models'
 import { accountSelectors } from '@audius/common/store'
 import { Box, Button, Divider, Flex, IconPlus, Text } from '@audius/harmony'
 
@@ -12,6 +12,7 @@ import { useSelector } from 'utils/reducer'
 import { AccountListItem } from './AccountListItem'
 import { sharedMessages } from './sharedMessages'
 import { AccountsManagingYouPageProps, AccountsManagingYouPages } from './types'
+import { useAppContext } from '@audius/common/context'
 
 const { getUserId } = accountSelectors
 
@@ -29,6 +30,9 @@ export const AccountsManagingYouHomePage = (
   const { setPage } = props
   const userId = useSelector(getUserId) as number
   const { toast } = useContext(ToastContext)
+  const {
+    analytics: { track, make }
+  } = useAppContext()
 
   const [removeManager, removeResult] = useRemoveManager()
   // Always update manager list when mounting this page
@@ -49,6 +53,12 @@ export const AccountsManagingYouHomePage = (
 
   const handleCancelInvite = useCallback(
     (params: { userId: number; managerUserId: number }) => {
+      track(
+        make({
+          eventName: Name.MANAGER_MODE_CANCEL_INVITE,
+          managerId: params.managerUserId
+        })
+      )
       removeManager(params)
     },
     [removeManager]

--- a/packages/web/src/pages/settings-page/components/desktop/ManagerMode/AccountsYouManageHomePage.tsx
+++ b/packages/web/src/pages/settings-page/components/desktop/ManagerMode/AccountsYouManageHomePage.tsx
@@ -5,7 +5,7 @@ import {
   useGetManagedAccounts,
   useRemoveManager
 } from '@audius/common/api'
-import { Status, UserMetadata } from '@audius/common/models'
+import { Name, Status, UserMetadata } from '@audius/common/models'
 import { accountSelectors } from '@audius/common/store'
 import { Box, Divider, Flex, Text } from '@audius/harmony'
 
@@ -17,6 +17,7 @@ import { AccountListItem } from './AccountListItem'
 import { sharedMessages } from './sharedMessages'
 import { AccountsYouManagePageProps, AccountsYouManagePages } from './types'
 import { usePendingInviteValidator } from './usePendingInviteValidator'
+import { useAppContext } from '@audius/common/context'
 const { getAccountUser } = accountSelectors
 
 const messages = {
@@ -44,6 +45,9 @@ export const AccountsYouManageHomePage = ({
   const [approveManagedAccount, approveResult] = useApproveManagedAccount()
   const [rejectManagedAccount, rejectResult] = useRemoveManager()
   const { toast } = useContext(ToastContext)
+  const {
+    analytics: { track, make }
+  } = useAppContext()
 
   usePendingInviteValidator({ managedAccounts, userId })
 
@@ -57,6 +61,12 @@ export const AccountsYouManageHomePage = ({
   const handleApprove = useCallback(
     ({ grantorUser }: { grantorUser: UserMetadata }) => {
       if (currentUser) {
+        track(
+          make({
+            eventName: Name.MANAGER_MODE_ACCEPT_INVITE,
+            managedUserId: grantorUser.user_id
+          })
+        )
         approveManagedAccount({
           userId: currentUser.user_id,
           grantorUser,
@@ -75,6 +85,12 @@ export const AccountsYouManageHomePage = ({
       currentUserId: number
       grantorUser: UserMetadata
     }) => {
+      track(
+        make({
+          eventName: Name.MANAGER_MODE_REJECT_INVITE,
+          managedUserId: grantorUser.user_id
+        })
+      )
       rejectManagedAccount({
         userId: grantorUser.user_id,
         managerUserId: currentUserId

--- a/packages/web/src/pages/settings-page/components/desktop/ManagerMode/AccountsYouManageHomePage.tsx
+++ b/packages/web/src/pages/settings-page/components/desktop/ManagerMode/AccountsYouManageHomePage.tsx
@@ -5,6 +5,7 @@ import {
   useGetManagedAccounts,
   useRemoveManager
 } from '@audius/common/api'
+import { useAppContext } from '@audius/common/context'
 import { Name, Status, UserMetadata } from '@audius/common/models'
 import { accountSelectors } from '@audius/common/store'
 import { Box, Divider, Flex, Text } from '@audius/harmony'
@@ -17,7 +18,6 @@ import { AccountListItem } from './AccountListItem'
 import { sharedMessages } from './sharedMessages'
 import { AccountsYouManagePageProps, AccountsYouManagePages } from './types'
 import { usePendingInviteValidator } from './usePendingInviteValidator'
-import { useAppContext } from '@audius/common/context'
 const { getAccountUser } = accountSelectors
 
 const messages = {

--- a/packages/web/src/pages/settings-page/components/desktop/ManagerMode/RemoveManagerConfirmationContent.tsx
+++ b/packages/web/src/pages/settings-page/components/desktop/ManagerMode/RemoveManagerConfirmationContent.tsx
@@ -1,10 +1,10 @@
 import { useCallback, useEffect } from 'react'
 
 import { useGetCurrentWeb3User, useRemoveManager } from '@audius/common/api'
+import { useAppContext } from '@audius/common/context'
 import { useAccountSwitcher } from '@audius/common/hooks'
 import { Name, Status } from '@audius/common/models'
 import { Button, Flex, Text } from '@audius/harmony'
-import { useAppContext } from '@audius/common/context'
 
 const messages = {
   cancel: 'Cancel',
@@ -45,7 +45,7 @@ export const RemoveManagerConfirmationContent = ({
       })
     )
     removeManager({ userId, managerUserId })
-  }, [userId, managerUserId, removeManager])
+  }, [userId, managerUserId, removeManager, make, track])
 
   useEffect(() => {
     if (status === Status.SUCCESS) {

--- a/packages/web/src/pages/settings-page/components/desktop/ManagerMode/RemoveManagerConfirmationContent.tsx
+++ b/packages/web/src/pages/settings-page/components/desktop/ManagerMode/RemoveManagerConfirmationContent.tsx
@@ -2,8 +2,9 @@ import { useCallback, useEffect } from 'react'
 
 import { useGetCurrentWeb3User, useRemoveManager } from '@audius/common/api'
 import { useAccountSwitcher } from '@audius/common/hooks'
-import { Status } from '@audius/common/models'
+import { Name, Status } from '@audius/common/models'
 import { Button, Flex, Text } from '@audius/harmony'
+import { useAppContext } from '@audius/common/context'
 
 const messages = {
   cancel: 'Cancel',
@@ -30,10 +31,19 @@ export const RemoveManagerConfirmationContent = ({
   const { data: currentWeb3User } = useGetCurrentWeb3User({})
   const managerIsCurrentWeb3User = currentWeb3User?.user_id === managerUserId
   const { switchToWeb3User } = useAccountSwitcher()
+  const {
+    analytics: { track, make }
+  } = useAppContext()
   const { status } = result
 
   const handleDelete = useCallback(() => {
     if (!userId || !managerUserId) return
+    track(
+      make({
+        eventName: Name.MANAGER_MODE_REMOVE_MANAGER,
+        managerId: managerUserId
+      })
+    )
     removeManager({ userId, managerUserId })
   }, [userId, managerUserId, removeManager])
 


### PR DESCRIPTION
### Description
* Added new fields to the `identify` phase so that Amplitude/Sentry can see current manager id/handle
* Don't link wallet info in manager mode (so that we don't overwrite managed user wallet info with the manager's wallet)
* Added events for the various interactions in manager mode

### How Has This Been Tested?
Tested locally against staging, examined payloads and debug output.
