### PR TITLE
trigger audio analysis if not found on content nodes

### DIFF
--- a/packages/discovery-provider/src/tasks/repair_audio_analyses.py
+++ b/packages/discovery-provider/src/tasks/repair_audio_analyses.py
@@ -161,7 +161,15 @@ def repair(session: Session, redis: Redis):
 
         if not success:
             logger.warning(
-                f"repair_audio_analyses.py | failed to query audio analysis for track {track.track_id} (track_cid: {track.track_cid}, audio_upload_id: {track.audio_upload_id}). tried {nodes}"
+                f"repair_audio_analyses.py | failed to query audio analysis for track {track.track_id} (track_cid: {track.track_cid}, audio_upload_id: {track.audio_upload_id}). tried {nodes}. triggering analysis..."
+            )
+            num_analyses_retriggered += 1
+            retrigger_audio_analysis(
+                nodes,
+                track.track_id,
+                track.track_cid,
+                track.audio_upload_id,
+                legacy_track,
             )
 
     logger.info(

--- a/packages/discovery-provider/src/tasks/repair_audio_analyses.py
+++ b/packages/discovery-provider/src/tasks/repair_audio_analyses.py
@@ -101,7 +101,7 @@ def repair(session: Session, redis: Redis):
             # Only analyze streamable tracks
             continue
         legacy_track = not track.audio_upload_id
-        success = False
+        found = False
         for node in nodes:
             try:
                 # Query random content node for the audio upload id
@@ -156,10 +156,10 @@ def repair(session: Session, redis: Redis):
                 logger.warning(
                     f"repair_audio_analyses.py | Track ID {track.track_id} (track_cid: {track.track_cid}, audio_upload_id: {track.audio_upload_id}) failed audio analysis >= 3 times"
                 )
-            success = True
+            found = True
             break
 
-        if not success:
+        if not found:
             logger.warning(
                 f"repair_audio_analyses.py | failed to query audio analysis for track {track.track_id} (track_cid: {track.track_cid}, audio_upload_id: {track.audio_upload_id}). tried {nodes}. triggering analysis..."
             )


### PR DESCRIPTION
### Description
retrigger analysis if the cid/upload was not found on 5 random content nodes, meaning it was never successfully started during the content node migration. seeing a couple instances of this on stage, i think from the time it was running before i merged a change allowing ba cids without audio upload ids to use the legacy audio analysis path

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._
