### PR TITLE
[Notifications] Use placeholder profile pic in Manager Mode transactional email if user has no profile pic [PAY-3134]

### DIFF
--- a/packages/discovery-provider/plugins/notifications/src/processNotifications/mappers/base.ts
+++ b/packages/discovery-provider/plugins/notifications/src/processNotifications/mappers/base.ts
@@ -3,7 +3,7 @@ import { ResourceIds, Resources } from '../../email/notifications/renderEmail'
 import { PlaylistRow, TrackRow, UserRow } from '../../types/dn'
 import { EntityType } from '../../email/notifications/types'
 
-type UserBasicInfo = {
+export type UserBasicInfo = {
   user_id: number
   name: string
   handle: string

--- a/packages/discovery-provider/plugins/notifications/src/processNotifications/mappers/requestManager.ts
+++ b/packages/discovery-provider/plugins/notifications/src/processNotifications/mappers/requestManager.ts
@@ -6,7 +6,8 @@ import { sendPushNotification } from '../../sns'
 import { NotificationRow } from '../../types/dn'
 import { RequestManagerNotification } from '../../types/notifications'
 import { disableDeviceArns } from '../../utils/disableArnEndpoint'
-import { getContentNode, getHostname } from '../../utils/env'
+import { getHostname } from '../../utils/env'
+import { formatProfilePictureUrl } from '../../utils/format'
 import { sendBrowserNotification } from '../../web'
 import { BaseNotification } from './base'
 import {
@@ -109,18 +110,11 @@ export class RequestManager extends BaseNotification<RequestManagerRow> {
       html: email({
         managedAccountHandle: managedAccountUser.handle,
         managedAccountName: managedAccountName,
-        managedAccountProfilePicture: managedAccountUser.profile_picture_sizes
-          ? `${getContentNode()}/content/${
-              managedAccountUser.profile_picture_sizes
-            }/480x480.jpg`
-          : `${getContentNode()}/content/${managedAccountUser.profile_picture}`,
+        managedAccountProfilePicture:
+          formatProfilePictureUrl(managedAccountUser),
         managerHandle: managerUser.handle,
         managerName: managerUser.name,
-        managerProfilePicture: managerUser.profile_picture_sizes
-          ? `${getContentNode()}/content/${
-              managerUser.profile_picture_sizes
-            }/480x480.jpg`
-          : `${getContentNode()}/content/${managerUser.profile_picture}`,
+        managerProfilePicture: formatProfilePictureUrl(managerUser),
         link: `${getHostname()}/settings/accounts-you-manage?pending=${
           managedAccountUser.user_id
         }`

--- a/packages/discovery-provider/plugins/notifications/src/utils/format.ts
+++ b/packages/discovery-provider/plugins/notifications/src/utils/format.ts
@@ -1,4 +1,5 @@
 import BN from 'bn.js'
+import { UserBasicInfo } from '../processNotifications/mappers/base'
 import { getContentNode, getHostname } from './env'
 
 export const formatNumberCommas = (num) => {
@@ -80,6 +81,19 @@ export const getNumberSuffix = (num) => {
 
 export const formatImageUrl = (profilePictureSizes: string, size: number) => {
   return `${getContentNode()}/content/${profilePictureSizes}/${size}x${size}.jpg`
+}
+
+const PROFILE_PICTURE_PLACEHOLDER_URL =
+  'https://download.audius.co/static-resources/email/imageProfilePicEmpty.png'
+
+export const formatProfilePictureUrl = (user: UserBasicInfo) => {
+  if (user.profile_picture_sizes) {
+    return formatImageUrl(user.profile_picture_sizes, 480)
+  } else if (user.profile_picture) {
+    return `${getContentNode()}/content/${user.profile_picture}`
+  } else {
+    return PROFILE_PICTURE_PLACEHOLDER_URL
+  }
 }
 
 export const formatProfileUrl = (handle: string) => {


### PR DESCRIPTION
### Description
See title.
https://linear.app/audius/issue/PAY-3134/[qa]-manager-mode-email-placeholder-profile-picture-missing

### How Has This Been Tested?
Jest snapshot testing

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._
