### PR TITLE
[Web] Manager Mode QA - Fix caching issue when accepting multiple invites; remove query param from in app notif link [C-4615] [PAY-3135]

### DIFF
--- a/packages/common/src/api/account.ts
+++ b/packages/common/src/api/account.ts
@@ -23,7 +23,6 @@ type RemoveManagerPayload = {
 
 type ApproveManagedAccountPayload = {
   userId: number
-  userWalletAddress: string
   grantorUser: UserMetadata | User
 }
 
@@ -225,38 +224,25 @@ const accountApi = createApi({
         return payload
       },
       options: {
-        idArgKey: 'grantorUser.user_id',
         type: 'mutation'
       },
       async onQueryStarted(
         payload: ApproveManagedAccountPayload,
         { dispatch }
       ) {
-        const { userId, grantorUser, userWalletAddress } = payload
+        const { userId, grantorUser } = payload
         dispatch(
           accountApi.util.updateQueryData(
             'getManagedAccounts',
             { userId },
             (state) => {
-              const currentTime = dayjs().format('YYYY-MM-DD HH:mm:ss')
               // TODO(C-4330) - The state type is incorrect - fix.
               // @ts-expect-error
               const foundIndex = state.managedUsers.findIndex(
                 (m: { user: number }) => m.user === grantorUser.user_id
               )
               // @ts-expect-error
-              state.managedUsers.splice(foundIndex, 1, {
-                grant: {
-                  created_at: currentTime,
-                  // TODO(nkang - C-4332) - Fill this in
-                  grantee_address: userWalletAddress,
-                  is_approved: true,
-                  is_revoked: false,
-                  updated_at: currentTime,
-                  user_id: userId
-                },
-                user: grantorUser
-              })
+              state.managedUsers[foundIndex].grant.is_approved = true
             }
           )
         )

--- a/packages/web/src/components/notification/Notification/RequestManagerNotification.tsx
+++ b/packages/web/src/components/notification/Notification/RequestManagerNotification.tsx
@@ -9,7 +9,7 @@ import { push } from 'connected-react-router'
 import { useDispatch } from 'react-redux'
 
 import { useSelector } from 'utils/reducer'
-import { accountManagerInvitePage } from 'utils/route'
+import { ACCOUNTS_YOU_MANAGE_SETTINGS_PAGE } from 'utils/route'
 
 import { NotificationBody } from './components/NotificationBody'
 import { NotificationFooter } from './components/NotificationFooter'
@@ -41,7 +41,7 @@ export const RequestManagerNotification = (
 
   const handleClick = useCallback(() => {
     if (managedAccountUser?.user_id) {
-      dispatch(push(accountManagerInvitePage(managedAccountUser?.user_id)))
+      dispatch(push(ACCOUNTS_YOU_MANAGE_SETTINGS_PAGE))
     }
   }, [dispatch, managedAccountUser?.user_id])
 

--- a/packages/web/src/pages/settings-page/components/desktop/ManagerMode/AccountsYouManageHomePage.tsx
+++ b/packages/web/src/pages/settings-page/components/desktop/ManagerMode/AccountsYouManageHomePage.tsx
@@ -59,8 +59,7 @@ export const AccountsYouManageHomePage = ({
       if (currentUser) {
         approveManagedAccount({
           userId: currentUser.user_id,
-          grantorUser,
-          userWalletAddress: currentUser.erc_wallet
+          grantorUser
         })
       }
     },

--- a/packages/web/src/utils/route.ts
+++ b/packages/web/src/utils/route.ts
@@ -169,8 +169,6 @@ export const CHANGE_PASSWORD_SETTINGS_PAGE = '/settings/change-password'
 export const AUTHORIZED_APPS_SETTINGS_PAGE = '/settings/authorized-apps'
 export const ACCOUNTS_MANAGING_YOU_SETTINGS_PAGE = '/settings/managing-you'
 export const ACCOUNTS_YOU_MANAGE_SETTINGS_PAGE = '/settings/accounts-you-manage'
-export const accountManagerInvitePage = (pendingManagedAccountUserId: number) =>
-  `${ACCOUNTS_YOU_MANAGE_SETTINGS_PAGE}?pending=${pendingManagedAccountUserId}`
 export const TRENDING_GENRES = '/trending/genres'
 export const EMPTY_PAGE = '/empty_page'
 


### PR DESCRIPTION
### Description
- Remove `invite=` query param from Manager Requested in-app notification since it was unnecessary and error-prone
- Fix issue with optimistic updates when accepting multiple manager invites (explained in comment)

### How Has This Been Tested?
Web against stage
