### PR TITLE
audio analysis repairer: handle 404 upload ids

### DIFF
--- a/packages/discovery-provider/src/tasks/repair_audio_analyses.py
+++ b/packages/discovery-provider/src/tasks/repair_audio_analyses.py
@@ -111,6 +111,10 @@ def repair(session: Session, redis: Redis):
                     else f"{node}/uploads/{track.audio_upload_id}"
                 )
                 resp = requests.get(endpoint, timeout=5)
+                if resp.status_code == 404 and not legacy_track:
+                    # Use legacy path for upload ids that are not found
+                    # (I think there are some edge cases from early storage v2 migration days)
+                    legacy_track = True
                 resp.raise_for_status()
                 data = resp.json()
             except Exception:


### PR DESCRIPTION
### Description
found a case on stage with an upload id that doesn't exist in content nodes' `uploads` tables, which i think is an edge case from changes in the early days of storage v2. direct these cases to the legacy audio analysis path

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._
