### PR TITLE
[C-4603] Fix edit page back button

### DIFF
--- a/packages/web/src/pages/edit-page/EditTrackPage.tsx
+++ b/packages/web/src/pages/edit-page/EditTrackPage.tsx
@@ -19,6 +19,7 @@ import { push as pushRoute } from 'connected-react-router'
 import { useDispatch } from 'react-redux'
 import { useParams } from 'react-router'
 
+import { useHistoryContext } from 'app/HistoryProvider'
 import { useSelector } from 'common/hooks/useSelector'
 import { DeleteConfirmationModal } from 'components/delete-confirmation'
 import { EditTrackForm } from 'components/edit-track/EditTrackForm'
@@ -27,7 +28,6 @@ import Header from 'components/header/desktop/Header'
 import LoadingSpinnerFullPage from 'components/loading-spinner-full-page/LoadingSpinnerFullPage'
 import Page from 'components/page/Page'
 import { useTrackCoverArt2 } from 'hooks/useTrackCoverArt'
-import { useHistoryContext } from 'app/HistoryProvider'
 
 const { deleteTrack, editTrack } = cacheTracksActions
 const { getStems } = cacheTracksSelectors

--- a/packages/web/src/pages/edit-page/EditTrackPage.tsx
+++ b/packages/web/src/pages/edit-page/EditTrackPage.tsx
@@ -27,6 +27,7 @@ import Header from 'components/header/desktop/Header'
 import LoadingSpinnerFullPage from 'components/loading-spinner-full-page/LoadingSpinnerFullPage'
 import Page from 'components/page/Page'
 import { useTrackCoverArt2 } from 'hooks/useTrackCoverArt'
+import { useHistoryContext } from 'app/HistoryProvider'
 
 const { deleteTrack, editTrack } = cacheTracksActions
 const { getStems } = cacheTracksSelectors
@@ -45,10 +46,9 @@ export const EditFormScrollContext = createContext(() => {})
 // This component is in development, only used behind the EDIT_TRACK_REDESIGN feature flag
 export const EditTrackPage = (props: EditPageProps) => {
   const { scrollToTop } = props
-  //   const dispatch = useDispatch()
-  //   const [formState, setFormState] = useState<UploadFormState>(initialFormState)
   const { handle, slug } = useParams<{ handle: string; slug: string }>()
   const dispatch = useDispatch()
+  const { history } = useHistoryContext()
 
   const { data: currentUserId } = useGetCurrentUserId({})
   const permalink = `/${handle}/${slug}`
@@ -126,7 +126,13 @@ export const EditTrackPage = (props: EditPageProps) => {
   return (
     <Page
       title={messages.title}
-      header={<Header primary={messages.title} showBackButton />}
+      header={
+        <Header
+          primary={messages.title}
+          showBackButton
+          onClickBack={history.goBack}
+        />
+      }
     >
       {trackStatus !== Status.SUCCESS || !coverArtUrl ? (
         <LoadingSpinnerFullPage />


### PR DESCRIPTION
### Description

Edit page back button callback wasn't implemented

TODO:
If the user navigates directly to the edit page in the browser, clicking back or cancel button will navigate back as if the user clicked the back button on their browser. This means if the previous location was external to Audius (e.g. the browser's new tab page) they will be sent back there.

I looked into trying to detect whether there was history within Audius, but the history context doesn't have the previous pathname exposed. Ideally we default to going back to the track page if there's no previous app page to return to.

One way would be to pass the previous location when opening the edit page, but that seems overly complex. Looking for ideas here.

### How Has This Been Tested?

back button works now