### PR TITLE
audio analysis: handle non audio file failures

### DIFF
--- a/mediorum/server/legacy_audio_analysis.go
+++ b/mediorum/server/legacy_audio_analysis.go
@@ -181,7 +181,12 @@ func (ss *MediorumServer) analyzeLegacyAudio(analysis *QmAudioAnalysis) error {
 
 	onError := func(err error) error {
 		analysis.Error = err.Error()
-		analysis.ErrorCount = analysis.ErrorCount + 1
+		if analysis.Error == "blob is not an audio file" {
+			// set ErrorCount to 3 so discovery repairer stops retrying this cid
+			analysis.ErrorCount = 3
+		} else {
+			analysis.ErrorCount = analysis.ErrorCount + 1
+		}
 		analysis.AnalyzedAt = time.Now().UTC()
 		analysis.Status = JobStatusError
 		ss.crud.Update(analysis)

--- a/mediorum/server/serve_audio_analysis.go
+++ b/mediorum/server/serve_audio_analysis.go
@@ -54,6 +54,9 @@ func (ss *MediorumServer) analyzeLegacyBlob(c echo.Context) error {
 	}
 	if analysis.Status == JobStatusError || analysis.Status == JobStatusTimeout {
 		if analysis.Error == "blob is not an audio file" {
+			// set ErrorCount to 3 so discovery repairer stops retrying this cid
+			analysis.ErrorCount = 3
+			ss.crud.Update(analysis)
 			return c.String(http.StatusBadRequest, "must specify a cid for an audio file")
 		}
 		analysis.Status = JobStatusAudioAnalysis

--- a/packages/discovery-provider/src/tasks/repair_audio_analyses.py
+++ b/packages/discovery-provider/src/tasks/repair_audio_analyses.py
@@ -80,6 +80,12 @@ def retrigger_audio_analysis(
                 else f"{node}/uploads/{upload_id}/analyze"
             )
             resp = requests.post(endpoint, params=params, timeout=5)
+            if resp.status_code == 400:
+                # should only return a 400 if content found the specified ID to not be an audio file, therefore unable to be analyzed
+                logger.warning(
+                    f"repair_audio_analyses.py | attempt to trigger audio analysis for track {track_id} (track_cid: {track_cid}, audio_upload_id: {upload_id}) failed with status code {resp.status_code}: {resp.text}"
+                )
+                return
             resp.raise_for_status()
             return
         except Exception:

--- a/packages/discovery-provider/src/tasks/repair_audio_analyses.py
+++ b/packages/discovery-provider/src/tasks/repair_audio_analyses.py
@@ -81,7 +81,8 @@ def retrigger_audio_analysis(
             )
             resp = requests.post(endpoint, params=params, timeout=5)
             if resp.status_code == 400:
-                # should only return a 400 if content found the specified ID to not be an audio file, therefore unable to be analyzed
+                # Should only return a 400 if content found the track_cid to not be an audio file, therefore unable to be analyzed.
+                # Quit early because all CNs will 400 for this cid.
                 logger.warning(
                     f"repair_audio_analyses.py | attempt to trigger audio analysis for track {track_id} (track_cid: {track_cid}, audio_upload_id: {upload_id}) failed with status code {resp.status_code}: {resp.text}"
                 )


### PR DESCRIPTION
### Description
seeing some cases where the cid isn't an audio file. checked on the storeall node and they appear to be type `text/plain; charset=utf-8` in the bucket for some reason. these files can't be analyzed so they're (correctly) erroring but the server shortcut is not incrementing the error count so the repairer keeps retrying their audio analyses. set the error count to 3 in mediorum so the repairer can move on.

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._
