### PR TITLE
Improve Solana Relay error logging

### DIFF
--- a/packages/discovery-provider/plugins/pedalboard/apps/solana-relay/src/middleware/errorHandler.ts
+++ b/packages/discovery-provider/plugins/pedalboard/apps/solana-relay/src/middleware/errorHandler.ts
@@ -10,9 +10,17 @@ export const errorHandlerMiddleware = (
   _next: NextFunction
 ) => {
   const error =
-    err instanceof ResponseError ? err : new InternalServerError(String(err))
+    err instanceof ResponseError
+      ? err
+      : new InternalServerError(
+          err instanceof Error ? err.message : String(err)
+        )
   if (!res.headersSent) {
-    res.status(error.status).send({ error: error.name })
+    res
+      .status(error.status)
+      .set('X-Request-ID', res.locals.requestId)
+      .set('Access-Control-Expose-Headers', 'X-Request-ID')
+      .send({ error: error.message })
   }
   // in milliseconds
   const responseTime = new Date().getTime() - res.locals.requestStartTime

--- a/packages/discovery-provider/plugins/pedalboard/apps/solana-relay/src/middleware/locals.ts
+++ b/packages/discovery-provider/plugins/pedalboard/apps/solana-relay/src/middleware/locals.ts
@@ -5,6 +5,7 @@ import { Logger } from 'pino'
 declare global {
   namespace Express {
     interface Locals {
+      requestId: string
       signerUser?: Users
       isSignedByDiscovery?: boolean
       logger: Logger

--- a/packages/discovery-provider/plugins/pedalboard/apps/solana-relay/src/middleware/logging.ts
+++ b/packages/discovery-provider/plugins/pedalboard/apps/solana-relay/src/middleware/logging.ts
@@ -12,6 +12,7 @@ export const incomingRequestLogger = (
   response.locals.requestStartTime = startTime
   const requestId = uuidv4()
   const { path, method } = request
+  response.locals.requestId = requestId
   response.locals.logger = logger.child({
     requestId,
     path,

--- a/packages/discovery-provider/plugins/pedalboard/apps/solana-relay/src/routes/relay/relay.ts
+++ b/packages/discovery-provider/plugins/pedalboard/apps/solana-relay/src/routes/relay/relay.ts
@@ -111,10 +111,12 @@ export const relay = async (
         feePayer: feePayerKey.toBase58()
       })
     } catch (e) {
-      res.locals.logger.error({
-        error: e instanceof InvalidRelayInstructionError ? e.toString() : ''
-      })
-      throw new BadRequestError('Invalid relay instructions')
+      if (e instanceof InvalidRelayInstructionError) {
+        res.locals.logger.error(e.toString())
+        throw new BadRequestError('Invalid relay instructions')
+      } else {
+        throw e
+      }
     }
 
     if (feePayerKeyPair) {

--- a/packages/web/src/store/errors/reportToSentry.ts
+++ b/packages/web/src/store/errors/reportToSentry.ts
@@ -54,6 +54,7 @@ export const reportToSentry = async ({
         additionalInfo = {
           ...additionalInfo,
           response: error.response,
+          requestId: error.response.headers.get('X-Request-ID'),
           responseBody
         }
       }


### PR DESCRIPTION
### Description

Small improvements to help aid in debugging errors with claiming rewards.

- Exposes the request ID to the client so that it can be reported via Sentry on failures
- JSON.stringify the RPC error so that it logs correctly instead of `[Object object]`
- Remove manual timeout and instead rely on blockhash expiry

### How Has This Been Tested?

Tested locally by sending tips with no balance and ensuring the `additionalInfo` of Sentry included the request ID and the error.