### PR TITLE
[PAY-3141] Always allow access if user previously paid for content

### DIFF
--- a/packages/discovery-provider/src/gated_content/content_access_checker.py
+++ b/packages/discovery-provider/src/gated_content/content_access_checker.py
@@ -367,7 +367,20 @@ class ContentAccessChecker:
                 condition_options=condition_options,
             )
             if not has_access:
-                return False
+                # perhaps content was previously (not currently) purchase gated
+                # so we check if user had previously purchased content
+                if condition != "usdc_purchase":
+                    user_purchased_content = does_user_have_usdc_access(
+                        session=session,
+                        user_id=user_id,
+                        content_id=content_id,
+                        content_type=content_type,
+                        condition_options=condition_options,
+                    )
+                    if not user_purchased_content:
+                        return False
+                else:
+                    return False
         return True
 
     def _check_stem_access(


### PR DESCRIPTION
### Description

Now that users may freely change the access type, we want to make sure that once a user has paid for content, they will always have access to it in the future.

We do this by _checking for purchase records (using already built in usdc access check)_ if content is currently gated by something other than usdc purchase and if user does not have access to that current gate.

### How Has This Been Tested?

Integration tests and manual local dn service test
