### PR TITLE
Improve mobile ts autocomplete

### DIFF
--- a/packages/mobile/tsconfig.json
+++ b/packages/mobile/tsconfig.json
@@ -23,7 +23,7 @@
     "paths": {
       "@audius/harmony-native": ["./src/harmony-native/index.ts"],
       "@audius/common/*": ["../common/src/*"],
-      // "~/*": ["../common/src/*"],
+      "~/*": ["../common/src/*"],
       "app/*": ["./src/*"],
       // Remove these when no longer dependent on @audius/web
       "audio/*": ["../../node_modules/@audius/web/src/audio/*"],

--- a/packages/mobile/tsconfig.json
+++ b/packages/mobile/tsconfig.json
@@ -22,9 +22,8 @@
     "module": "esnext",
     "paths": {
       "@audius/harmony-native": ["./src/harmony-native/index.ts"],
-      "@audius/common/src/*": ["../../common/src/*"],
-      "~/*": ["../common/src/*"],
-      "@audius/common/*": ["../../common/src/*"],
+      "@audius/common/*": ["../common/src/*"],
+      // "~/*": ["../common/src/*"],
       "app/*": ["./src/*"],
       // Remove these when no longer dependent on @audius/web
       "audio/*": ["../../node_modules/@audius/web/src/audio/*"],


### PR DESCRIPTION
### Description

Small update to mobile tsconfig to ensure `@audius/common/` imports have the highest preference over `~` imports. this aids autocomplete