### PR TITLE
[C-4611] Debounce disbursed notification

### DIFF
--- a/packages/discovery-provider/ddl/functions/handle_challenge_disbursements.sql
+++ b/packages/discovery-provider/ddl/functions/handle_challenge_disbursements.sql
@@ -1,25 +1,36 @@
 create or replace function handle_challenge_disbursement() returns trigger as $$
 declare
   reward_manager_tx reward_manager_txs%ROWTYPE;
+	existing_notification integer;
 begin
 
   select * into reward_manager_tx from reward_manager_txs where reward_manager_txs.signature = new.signature limit 1;
-	
+
   if reward_manager_tx is not null then
-	  -- create a notification for the challenge disbursement
-	  insert into notification
-		(slot, user_ids, timestamp, type, group_id, specifier, data)
-	  values
-		(
-			new.slot,
-			ARRAY [new.user_id],
-			reward_manager_tx.created_at,
-			'challenge_reward',
-			'challenge_reward:' || new.user_id || ':challenge:' || new.challenge_id || ':specifier:' || new.specifier,
-			new.user_id,
-			json_build_object('specifier', new.specifier, 'challenge_id', new.challenge_id, 'amount', new.amount)
-		)
-	  on conflict do nothing;
+		select id into existing_notification 
+		from notification
+		where
+		type = 'challenge_reward' and
+		new.user_id = any(user_ids) and
+		timestamp >= (new.created_at - interval '1 hour')
+		limit 1;
+		
+		if existing_notification is null then
+			-- create a notification for the challenge disbursement
+			insert into notification
+			(slot, user_ids, timestamp, type, group_id, specifier, data)
+			values
+			(
+				new.slot,
+				ARRAY [new.user_id],
+				new.created_at,
+				'challenge_reward',
+				'challenge_reward:' || new.user_id || ':challenge:' || new.challenge_id || ':specifier:' || new.specifier,
+				new.user_id,
+				json_build_object('specifier', new.specifier, 'challenge_id', new.challenge_id, 'amount', new.amount)
+			)
+			on conflict do nothing;
+		end if;
   end if;
   return null;
 

--- a/packages/discovery-provider/integration_tests/notifications/test_challenge_disbursement.py
+++ b/packages/discovery-provider/integration_tests/notifications/test_challenge_disbursement.py
@@ -1,4 +1,5 @@
 import logging
+from datetime import datetime
 from typing import List
 
 from sqlalchemy import desc
@@ -23,10 +24,7 @@ def test_challenge_disbursement_notification(app):
     populate_mock_db(db, entities)
     entities = {
         "challenge_disbursements": [
-            {
-                "challenge_id": i,
-                "user_id": 1,
-            }
+            {"challenge_id": i, "user_id": 1, "created_at": datetime(2023, 1, i + 1)}
             for i in range(3)
         ],
     }

--- a/packages/discovery-provider/plugins/notifications/src/__tests__/mappings/challengeReward.test.ts
+++ b/packages/discovery-provider/plugins/notifications/src/__tests__/mappings/challengeReward.test.ts
@@ -69,7 +69,7 @@ describe('Challenge Reward Notification', () => {
         title: `✅️ Complete your Profile`,
         body: `You’ve earned 1 $AUDIO for completing this challenge!`,
         data: {
-          id: 'timestamp:1589373217:group_id:challenge_reward:1:challenge:profile-completion:specifier:1',
+          id: 'timestamp:1589373:group_id:challenge_reward:1:challenge:profile-completion:specifier:1',
           type: 'ChallengeReward'
         }
       }

--- a/packages/discovery-provider/plugins/notifications/src/__tests__/mappings/challengeReward.test.ts
+++ b/packages/discovery-provider/plugins/notifications/src/__tests__/mappings/challengeReward.test.ts
@@ -43,7 +43,8 @@ describe('Challenge Reward Notification', () => {
         challenge_id: 'profile-completion',
         user_id: 1,
         specifier: '1',
-        amount: '100000000'
+        amount: '100000000',
+        created_at: new Date(1589373217)
       }
     ])
     await insertMobileSettings(processor.identityDB, [{ userId: 1 }])

--- a/packages/discovery-provider/plugins/notifications/src/types/dn.ts
+++ b/packages/discovery-provider/plugins/notifications/src/types/dn.ts
@@ -156,6 +156,7 @@ export interface ChallengeDisbursementRow {
   slot: number
   specifier: string
   user_id: number
+  created_at: Date
 }
 export interface ChallengeListenStreakRow {
   last_listen_date?: Date | null


### PR DESCRIPTION
### Description

To prevent overwhelming users with reward notifications, this change makes it so users are only notified about reward disbursements at most once an hour. Other disbursements within that window are de-duplicated.

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._

Ran on sandbox and confirmed disbursements only notify once an hour.
Updated tests.