### PR TITLE
[C-4579] Add filters to tag search

### DIFF
--- a/packages/common/src/services/audius-backend/AudiusBackend.ts
+++ b/packages/common/src/services/audius-backend/AudiusBackend.ts
@@ -765,7 +765,17 @@ export const audiusBackend = ({
     userTagCount,
     kind,
     offset,
-    limit
+    limit,
+    genre,
+    mood,
+    bpmMin,
+    bpmMax,
+    key,
+    isVerified,
+    hasDownloads,
+    // @ts-ignore - isPremium -> is_purchasable
+    isPremium,
+    sortMethod
   }: DiscoveryAPIParams<typeof DiscoveryAPI.searchTags>) {
     try {
       const searchTags = await withEagerOption(
@@ -777,7 +787,16 @@ export const audiusBackend = ({
         userTagCount,
         kind,
         limit,
-        offset
+        offset,
+        genre,
+        mood,
+        bpmMin,
+        bpmMax,
+        key,
+        isVerified,
+        hasDownloads,
+        isPremium,
+        sortMethod
       )
 
       const {

--- a/packages/common/src/store/pages/search-results/actions.ts
+++ b/packages/common/src/store/pages/search-results/actions.ts
@@ -51,6 +51,14 @@ export type FetchSearchPageTagsAction = {
   searchKind: SearchKind
   limit: number
   offset: number
+  genre?: Genre
+  mood?: Mood
+  bpm?: string
+  key?: string
+  isVerified?: boolean
+  hasDownloads?: boolean
+  isPremium?: boolean
+  sortMethod?: SearchSortMethod
 }
 
 export type SearchPageActions =
@@ -101,12 +109,20 @@ export const fetchSearchPageResultsFailed = (): SearchPageActions => ({
   type: FETCH_SEARCH_PAGE_RESULTS_FAILED
 })
 
-// Tag-based searcxh
+// Tag-based search
 type FetchSearchPageTagsArgs = {
   tag: string
   searchKind: SearchKind
   limit: number
   offset: number
+  genre?: Genre
+  mood?: Mood
+  bpm?: string
+  key?: string
+  isVerified?: boolean
+  hasDownloads?: boolean
+  isPremium?: boolean
+  sortMethod?: SearchSortMethod
 }
 
 export const fetchSearchPageTags = (

--- a/packages/discovery-provider/src/queries/search_es.py
+++ b/packages/discovery-provider/src/queries/search_es.py
@@ -135,7 +135,7 @@ def search_es_full(args: dict):
                 {"index": ES_TRACKS},
                 track_dsl(
                     search_str=search_str,
-                    tag_search='',
+                    tag_search="",
                     current_user_id=current_user_id,
                     must_saved=False,
                     only_downloadable=only_downloadable,
@@ -159,7 +159,7 @@ def search_es_full(args: dict):
                 {"index": ES_USERS},
                 user_dsl(
                     search_str=search_str,
-                    tag_search='',
+                    tag_search="",
                     current_user_id=current_user_id,
                     must_saved=False,
                     only_verified=only_verified,
@@ -260,7 +260,9 @@ def search_tags_es(args: dict):
     keys = format_keys(args.get("key", []))
 
     only_downloadable = False
-    include_purchaseable = parse_bool_param(args.get("include_purchaseable", False)) or False
+    include_purchaseable = (
+        parse_bool_param(args.get("include_purchaseable", False)) or False
+    )
     only_verified = parse_bool_param(args.get("is_verified", False)) or False
     only_with_downloads = parse_bool_param(args.get("has_downloads", False)) or False
     only_purchaseable = parse_bool_param(args.get("is_purchasable", False)) or False
@@ -270,38 +272,42 @@ def search_tags_es(args: dict):
     mdsl: Any = []
 
     if do_tracks:
-        mdsl.extend([
-            {"index": ES_TRACKS},
-            track_dsl(
-                search_str="",
-                tag_search=tag_search,
-                current_user_id=current_user_id,
-                genres=genres,
-                moods=moods,
-                bpm_min=bpm_min,
-                bpm_max=bpm_max,
-                keys=keys,
-                only_downloadable=only_downloadable,
-                only_with_downloads=only_with_downloads,
-                only_purchaseable=only_purchaseable,
-                include_purchaseable=include_purchaseable,
-                sort_method=sort_method
-            )
-        ])
+        mdsl.extend(
+            [
+                {"index": ES_TRACKS},
+                track_dsl(
+                    search_str="",
+                    tag_search=tag_search,
+                    current_user_id=current_user_id,
+                    genres=genres,
+                    moods=moods,
+                    bpm_min=bpm_min,
+                    bpm_max=bpm_max,
+                    keys=keys,
+                    only_downloadable=only_downloadable,
+                    only_with_downloads=only_with_downloads,
+                    only_purchaseable=only_purchaseable,
+                    include_purchaseable=include_purchaseable,
+                    sort_method=sort_method,
+                ),
+            ]
+        )
 
     if do_users:
-        mdsl.extend([
-            {"index": ES_USERS},
-            user_dsl(
-                search_str="",
-                tag_search=tag_search,
-                current_user_id=current_user_id,
-                must_saved=False,
-                genres=genres,
-                only_verified=only_verified,
-                sort_method=sort_method
-            )
-        ])
+        mdsl.extend(
+            [
+                {"index": ES_USERS},
+                user_dsl(
+                    search_str="",
+                    tag_search=tag_search,
+                    current_user_id=current_user_id,
+                    must_saved=False,
+                    genres=genres,
+                    only_verified=only_verified,
+                    sort_method=sort_method,
+                ),
+            ]
+        )
 
     mdsl_limit_offset(mdsl, limit, offset)
     mfound = esclient.msearch(searches=mdsl)
@@ -570,19 +576,21 @@ def track_dsl(
     }
 
     if tag_search:
-        dsl["must"].append({
-            "bool": {
-                "should": [
-                    {
-                        "match": {
-                            "tag_list": {
-                                "query": tag_search,
+        dsl["must"].append(
+            {
+                "bool": {
+                    "should": [
+                        {
+                            "match": {
+                                "tag_list": {
+                                    "query": tag_search,
+                                }
                             }
-                        }
-                    },
-                ],
+                        },
+                    ],
+                }
             }
-        })
+        )
 
     if genres:
         dsl["filter"].append({"terms": {"genre": genres}})
@@ -799,19 +807,21 @@ def user_dsl(
     }
 
     if tag_search:
-        dsl["must"].append({
-            "bool": {
-                "should": [
-                    {
-                        "match": {
-                            "tracks.tags": {
-                                "query": tag_search,
+        dsl["must"].append(
+            {
+                "bool": {
+                    "should": [
+                        {
+                            "match": {
+                                "tracks.tags": {
+                                    "query": tag_search,
+                                }
                             }
-                        }
-                    },
-                ],
+                        },
+                    ],
+                }
             }
-        })
+        )
 
     if current_user_id and must_saved:
         dsl["must"].append(be_followed(current_user_id))

--- a/packages/discovery-provider/src/queries/search_es.py
+++ b/packages/discovery-provider/src/queries/search_es.py
@@ -1,8 +1,7 @@
-import copy
 import logging
 from typing import Any, Dict, Optional
 
-from src.api.v1.helpers import extend_playlist, extend_track, extend_user
+from src.api.v1.helpers import extend_playlist, extend_track, extend_user, parse_bool_param
 from src.queries.get_feed_es import fetch_followed_saves_and_reposts, item_key
 from src.queries.query_helpers import (
     _populate_gated_content_metadata,
@@ -30,7 +29,10 @@ def get_capitalized_genre(genre):
     return lowercase_to_capitalized_genre.get(genre.lower())
 
 
-def format_genres(genres: list[str] | None):
+def format_genres(g: list[str] | str | None):
+    genres = g
+    if isinstance(g, str):
+        genres = [g]
     if not genres:
         return None
 
@@ -47,6 +49,18 @@ lowercase_to_capitalized_mood = {mood.lower(): mood for mood in mood_allowlist}
 
 def get_capitalized_mood(mood):
     return lowercase_to_capitalized_mood.get(mood.lower())
+
+
+def format_moods(m: list[str] | str | None):
+    moods = m
+    if isinstance(m, str):
+        moods = [m]
+    if not moods:
+        return None
+
+    capitalized_moods = [get_capitalized_mood(mood) for mood in moods]
+
+    return list(set(capitalized_moods))
 
 
 def sharp_to_flat(key):
@@ -85,11 +99,11 @@ def search_es_full(args: dict):
     limit = args.get("limit", 10)
     offset = args.get("offset", 0)
     search_type = args.get("kind", "all")
-    only_downloadable = args.get("only_downloadable")
     is_auto_complete = args.get("is_auto_complete")
+    only_downloadable = args.get("only_downloadable", False)
     include_purchaseable = args.get("include_purchaseable", False)
     genres = format_genres(args.get("genres", []))
-    moods = args.get("moods", [])
+    moods = format_moods(args.get("moods", []))
     bpm_min = args.get("bpm_min")
     bpm_max = args.get("bpm_max")
     keys = args.get("keys", [])
@@ -116,9 +130,11 @@ def search_es_full(args: dict):
                 {"index": ES_TRACKS},
                 track_dsl(
                     search_str=search_str,
+                    tag_search='',
                     current_user_id=current_user_id,
                     must_saved=False,
                     only_downloadable=only_downloadable,
+                    only_purchaseable=only_purchaseable,
                     include_purchaseable=include_purchaseable,
                     genres=genres,
                     moods=moods,
@@ -126,7 +142,6 @@ def search_es_full(args: dict):
                     bpm_max=bpm_max,
                     keys=keys,
                     only_with_downloads=only_with_downloads,
-                    only_purchaseable=only_purchaseable,
                     sort_method=sort_method,
                 ),
             ]
@@ -139,6 +154,7 @@ def search_es_full(args: dict):
                 {"index": ES_USERS},
                 user_dsl(
                     search_str=search_str,
+                    tag_search='',
                     current_user_id=current_user_id,
                     must_saved=False,
                     only_verified=only_verified,
@@ -211,42 +227,76 @@ def search_es_full(args: dict):
     return response
 
 
-def search_tags_es(q: str, kind="all", current_user_id=None, limit=10, offset=0):
+def format_keys(k: list[str] | str | None):
+    if not k:
+        return None
+    elif isinstance(k, str):
+        return [k]
+    else:
+        return k
+
+
+def search_tags_es(args: dict):
     esclient = get_esclient()
     if not esclient:
         raise Exception("esclient is None")
 
-    do_tracks = kind == "all" or kind == "tracks"
-    do_users = kind == "all" or kind == "users"
+    tag_search = (args.get("query", "") or "").strip()
+    current_user_id = args.get("current_user_id", None)
+    limit = args.get("limit", 10)
+    offset = args.get("offset", 0)
+    search_type = args.get("kind", "all")
+    sort_method = args.get("sort_method", "relevant")
+
+    genres = format_genres(args.get("genre"))
+    moods = format_moods(args.get("mood"))
+    bpm_min = args.get("bpm_min")
+    bpm_max = args.get("bpm_max")
+    keys = format_keys(args.get("key", []))
+
+    only_downloadable = False
+    include_purchaseable = parse_bool_param(args.get("include_purchaseable", False)) or False
+    only_verified = parse_bool_param(args.get("is_verified", False)) or False
+    only_with_downloads = parse_bool_param(args.get("has_downloads", False)) or False
+    only_purchaseable = parse_bool_param(args.get("is_purchasable", False)) or False
+
+    do_tracks = search_type == "all" or search_type == "tracks"
+    do_users = search_type == "all" or search_type == "users"
     mdsl: Any = []
 
-    def tag_match(fieldname, sort_by):
-        match = {
-            "query": {
-                "bool": {
-                    "must": [{"match": {fieldname: {"query": q}}}],
-                    "must_not": [{"term": {"purchaseable": {"value": True}}}],
-                    "should": [],
-                }
-            },
-            "sort": [{sort_by: "desc"}],
-        }
-        return match
-
     if do_tracks:
-        dsl = tag_match("tag_list", "repost_count")
-        mdsl.extend([{"index": ES_TRACKS}, dsl])
-        if current_user_id:
-            dsl = copy.deepcopy(dsl)
-            dsl["query"]["bool"]["must"].append(be_saved(current_user_id))
-            mdsl.extend([{"index": ES_TRACKS}, dsl])
+        mdsl.extend([
+            {"index": ES_TRACKS},
+            track_dsl(
+                search_str="",
+                tag_search=tag_search,
+                current_user_id=current_user_id,
+                genres=genres,
+                moods=moods,
+                bpm_min=bpm_min,
+                bpm_max=bpm_max,
+                keys=keys,
+                only_downloadable=only_downloadable,
+                only_with_downloads=only_with_downloads,
+                only_purchaseable=only_purchaseable,
+                include_purchaseable=include_purchaseable,
+                sort_method=sort_method
+            )
+        ])
 
     if do_users:
-        mdsl.extend([{"index": ES_USERS}, tag_match("tracks.tags", "follower_count")])
-        if current_user_id:
-            dsl = tag_match("tracks.tags", "follower_count")
-            dsl["query"]["bool"]["must"].append(be_followed(current_user_id))
-            mdsl.extend([{"index": ES_USERS}, dsl])
+        mdsl.extend([
+            {"index": ES_USERS},
+            user_dsl(
+                search_str="",
+                tag_search=tag_search,
+                current_user_id=current_user_id,
+                must_saved=False,
+                genres=genres,
+                only_verified=only_verified,
+                sort_method=sort_method
+            )
+        ])
 
     mdsl_limit_offset(mdsl, limit, offset)
     mfound = esclient.msearch(searches=mdsl)
@@ -260,13 +310,9 @@ def search_tags_es(q: str, kind="all", current_user_id=None, limit=10, offset=0)
 
     if do_tracks:
         response["tracks"] = pluck_hits(mfound["responses"].pop(0))
-        if current_user_id:
-            response["saved_tracks"] = pluck_hits(mfound["responses"].pop(0))
 
     if do_users:
         response["users"] = pluck_hits(mfound["responses"].pop(0))
-        if current_user_id:
-            response["followed_users"] = pluck_hits(mfound["responses"].pop(0))
 
     finalize_response(response, limit, current_user_id)
     return response
@@ -435,18 +481,19 @@ def default_function_score(dsl, ranking_field, factor=0.1):
 
 def track_dsl(
     search_str,
+    tag_search,
     current_user_id,
-    bpm_min,
-    bpm_max,
     must_saved=False,
-    only_downloadable=False,
-    only_purchaseable=False,
-    include_purchaseable=False,
     genres=[],
     moods=[],
+    bpm_min=None,
+    bpm_max=None,
     keys=[],
-    only_with_downloads=False,
     sort_method="relevant",
+    only_downloadable=False,
+    only_with_downloads=False,
+    only_purchaseable=False,
+    include_purchaseable=False,
 ):
     dsl = {
         "must": [
@@ -517,18 +564,26 @@ def track_dsl(
         "filter": [],
     }
 
+    if tag_search:
+        dsl["must"].append({
+            "bool": {
+                "should": [
+                    {
+                        "match": {
+                            "tag_list": {
+                                "query": tag_search,
+                            }
+                        }
+                    },
+                ],
+            }
+        })
+
     if genres:
         dsl["filter"].append({"terms": {"genre": genres}})
 
     if moods:
-        capitalized_moods = list(
-            filter(
-                None, [get_capitalized_mood(mood) for mood in moods if mood is not None]
-            )
-        )
-
-        if capitalized_moods:
-            dsl["filter"].append({"terms": {"mood": capitalized_moods}})
+        dsl["filter"].append({"terms": {"mood": moods}})
 
     if bpm_min:
         dsl["filter"].append({"range": {"bpm": {"gte": bpm_min}}})
@@ -630,6 +685,7 @@ def track_dsl(
 
 def user_dsl(
     search_str,
+    tag_search,
     current_user_id,
     only_verified,
     must_saved=False,
@@ -736,6 +792,21 @@ def user_dsl(
             {"term": {"is_verified": {"value": True, "boost": 5}}},
         ],
     }
+
+    if tag_search:
+        dsl["must"].append({
+            "bool": {
+                "should": [
+                    {
+                        "match": {
+                            "tracks.tags": {
+                                "query": tag_search,
+                            }
+                        }
+                    },
+                ],
+            }
+        })
 
     if current_user_id and must_saved:
         dsl["must"].append(be_followed(current_user_id))

--- a/packages/discovery-provider/src/queries/search_es.py
+++ b/packages/discovery-provider/src/queries/search_es.py
@@ -1,7 +1,12 @@
 import logging
 from typing import Any, Dict, Optional
 
-from src.api.v1.helpers import extend_playlist, extend_track, extend_user, parse_bool_param
+from src.api.v1.helpers import (
+    extend_playlist,
+    extend_track,
+    extend_user,
+    parse_bool_param,
+)
 from src.queries.get_feed_es import fetch_followed_saves_and_reposts, item_key
 from src.queries.query_helpers import (
     _populate_gated_content_metadata,

--- a/packages/discovery-provider/src/queries/search_queries.py
+++ b/packages/discovery-provider/src/queries/search_queries.py
@@ -46,14 +46,16 @@ def search_tags():
 
     (limit, offset) = get_pagination_vars()
 
-    hits = search_tags_es({
-        **request.args,
-        "query": search_str,
-        "kind": kind,
-        "current_user_id": current_user_id,
-        "limit": limit,
-        "offset": offset,
-    })
+    hits = search_tags_es(
+        {
+            **request.args,
+            "query": search_str,
+            "kind": kind,
+            "current_user_id": current_user_id,
+            "limit": limit,
+            "offset": offset,
+        }
+    )
     return api_helpers.success_response(hits)
 
 

--- a/packages/libs/src/api/Account.ts
+++ b/packages/libs/src/api/Account.ts
@@ -3,6 +3,7 @@ import { PublicKey } from '@solana/web3.js'
 import type { BN } from 'ethereumjs-util'
 
 import { AuthHeaders } from '../constants'
+import { Genre, Mood } from '../sdk'
 import { Nullable, UserMetadata, Utils } from '../utils'
 import { getPermitDigest, sign } from '../utils/signatures'
 
@@ -387,7 +388,16 @@ export class Account extends Base {
     userTagCount = 2,
     kind: string,
     limit = 100,
-    offset = 0
+    offset = 0,
+    genre?: Genre,
+    mood?: Mood,
+    bpmMin?: string,
+    bpmMax?: string,
+    key?: string,
+    isVerified?: boolean,
+    hasDownloads?: boolean,
+    isPremium?: boolean,
+    sortMethod?: 'recent' | 'relevant' | 'popular'
   ) {
     this.REQUIRES(Services.DISCOVERY_PROVIDER)
     return await this.discoveryProvider.searchTags(
@@ -395,7 +405,16 @@ export class Account extends Base {
       userTagCount,
       kind,
       limit,
-      offset
+      offset,
+      genre,
+      mood,
+      bpmMin,
+      bpmMax,
+      key,
+      isVerified,
+      hasDownloads,
+      isPremium,
+      sortMethod
     )
   }
 

--- a/packages/libs/src/services/discoveryProvider/DiscoveryProvider.ts
+++ b/packages/libs/src/services/discoveryProvider/DiscoveryProvider.ts
@@ -11,7 +11,13 @@ import { cloneDeep } from 'lodash'
 import urlJoin, { PathArg } from 'proper-url-join/es/index.js'
 import type { TransactionReceipt } from 'web3-core'
 
-import { DiscoveryNodeSelector, FetchError, Middleware } from '../../sdk'
+import {
+  DiscoveryNodeSelector,
+  FetchError,
+  Genre,
+  Middleware,
+  Mood
+} from '../../sdk'
 import type { CurrentUser, UserStateManager } from '../../userStateManager'
 import { CollectionMetadata, Nullable, User, Utils } from '../../utils'
 import type { LocalStorage } from '../../utils/localStorage'
@@ -824,9 +830,33 @@ export class DiscoveryProvider {
     userTagCount = 2,
     kind = 'all',
     limit = 100,
-    offset = 0
+    offset = 0,
+    genre?: Genre,
+    mood?: Mood,
+    bpmMin?: string,
+    bpmMax?: string,
+    key?: string,
+    isVerified?: boolean,
+    hasDownloads?: boolean,
+    isPremium?: boolean,
+    sortMethod?: 'recent' | 'relevant' | 'popular'
   ) {
-    const req = Requests.searchTags(text, userTagCount, kind, limit, offset)
+    const req = Requests.searchTags(
+      text,
+      userTagCount,
+      kind,
+      limit,
+      offset,
+      genre,
+      mood,
+      bpmMin,
+      bpmMax,
+      key,
+      isVerified,
+      hasDownloads,
+      isPremium,
+      sortMethod
+    )
     return await this._makeRequest(req)
   }
 

--- a/packages/libs/src/services/discoveryProvider/requests.ts
+++ b/packages/libs/src/services/discoveryProvider/requests.ts
@@ -2,6 +2,7 @@
 
 import type { ResponseType } from 'axios'
 
+import { Genre, Mood } from '../../sdk'
 import type { Nullable } from '../../utils'
 
 export const getUsers = (
@@ -433,7 +434,16 @@ export const searchTags = (
   userTagCount = 2,
   kind = 'all',
   limit = 100,
-  offset = 0
+  offset = 0,
+  genre?: Genre,
+  mood?: Mood,
+  bpmMin?: string,
+  bpmMax?: string,
+  key?: string,
+  isVerified?: boolean,
+  hasDownloads?: boolean,
+  isPurchasable?: boolean,
+  sortMethod?: 'recent' | 'relevant' | 'popular'
 ) => {
   return {
     endpoint: 'search/tags',
@@ -442,7 +452,16 @@ export const searchTags = (
       user_tag_count: userTagCount,
       kind,
       limit,
-      offset
+      offset,
+      genre,
+      mood,
+      bpm_min: bpmMin,
+      bpm_max: bpmMax,
+      key,
+      is_verified: isVerified,
+      has_downloads: hasDownloads,
+      is_purchasable: isPurchasable,
+      sort_method: sortMethod
     }
   }
 }

--- a/packages/web/src/common/store/pages/search-page/sagas.ts
+++ b/packages/web/src/common/store/pages/search-page/sagas.ts
@@ -24,15 +24,45 @@ export function* getTagSearchResults(
   tag: string,
   kind: SearchKind,
   limit: number,
-  offset: number
+  offset: number,
+  genre?: Genre,
+  mood?: Mood,
+  bpm?: string,
+  key?: string,
+  isVerified?: boolean,
+  hasDownloads?: boolean,
+  isPremium?: boolean,
+  sortMethod?: SearchSortMethod
 ) {
   const audiusBackendInstance = yield* getContext('audiusBackendInstance')
+
+  const bpmParts = bpm ? bpm.split('-') : [undefined, undefined]
+  const bpmMin = bpmParts[0] ? parseFloat(bpmParts[0]) : undefined
+  const bpmMax = bpmParts[1] ? parseFloat(bpmParts[1]) : bpmMin
+
+  const formatKey = (key?: string) => {
+    if (!key) return undefined
+    const keyParts = key.split(' ')
+    const pitch = keyParts[0].slice(0, 1)
+    const isFlat = keyParts[0].length > 1
+    return `${pitch}${isFlat ? ' flat' : ''} ${keyParts[1].toLowerCase()}`
+  }
+
   const results = yield* call(audiusBackendInstance.searchTags, {
     query: tag.toLowerCase(),
     userTagCount: 1,
     kind,
     limit,
-    offset
+    offset,
+    genre,
+    mood,
+    bpmMin,
+    bpmMax,
+    key: formatKey(key),
+    isVerified,
+    hasDownloads,
+    isPremium,
+    sortMethod
   })
   const { users, tracks } = results
 
@@ -64,7 +94,15 @@ export function* fetchSearchPageTags(
     query,
     action.searchKind,
     action.limit,
-    action.offset
+    action.offset,
+    action.genre,
+    action.mood,
+    action.bpm,
+    action.key,
+    action.isVerified,
+    action.hasDownloads,
+    action.isPremium,
+    action.sortMethod
   )
   if (rawResults) {
     const results = {

--- a/packages/web/src/common/store/pages/search-page/sagas.ts
+++ b/packages/web/src/common/store/pages/search-page/sagas.ts
@@ -20,6 +20,21 @@ import { waitForRead } from 'utils/sagaHelpers'
 
 const getUserId = accountSelectors.getUserId
 
+const getMinMaxFromBpm = (bpm?: string) => {
+  const bpmParts = bpm ? bpm.split('-') : [undefined, undefined]
+  const bpmMin = bpmParts[0] ? parseFloat(bpmParts[0]) : undefined
+  const bpmMax = bpmParts[1] ? parseFloat(bpmParts[1]) : bpmMin
+  return [bpmMin, bpmMax]
+}
+
+const formatKey = (key?: string) => {
+  if (!key) return undefined
+  const keyParts = key.split(' ')
+  const pitch = keyParts[0].slice(0, 1)
+  const isFlat = keyParts[0].length > 1
+  return `${pitch}${isFlat ? ' flat' : ''} ${keyParts[1].toLowerCase()}`
+}
+
 export function* getTagSearchResults(
   tag: string,
   kind: SearchKind,
@@ -35,19 +50,9 @@ export function* getTagSearchResults(
   sortMethod?: SearchSortMethod
 ) {
   const audiusBackendInstance = yield* getContext('audiusBackendInstance')
+  const [bpmMin, bpmMax] = getMinMaxFromBpm(bpm)
 
-  const bpmParts = bpm ? bpm.split('-') : [undefined, undefined]
-  const bpmMin = bpmParts[0] ? parseFloat(bpmParts[0]) : undefined
-  const bpmMax = bpmParts[1] ? parseFloat(bpmParts[1]) : bpmMin
-
-  const formatKey = (key?: string) => {
-    if (!key) return undefined
-    const keyParts = key.split(' ')
-    const pitch = keyParts[0].slice(0, 1)
-    const isFlat = keyParts[0].length > 1
-    return `${pitch}${isFlat ? ' flat' : ''} ${keyParts[1].toLowerCase()}`
-  }
-
+  // @ts-ignore
   const results = yield* call(audiusBackendInstance.searchTags, {
     query: tag.toLowerCase(),
     userTagCount: 1,
@@ -178,17 +183,7 @@ export function* getSearchResults({
 
   const apiClient = yield* getContext('apiClient')
   const userId = yield* select(getUserId)
-  const bpmParts = bpm ? bpm.split('-') : [undefined, undefined]
-  const bpmMin = bpmParts[0] ? parseFloat(bpmParts[0]) : undefined
-  const bpmMax = bpmParts[1] ? parseFloat(bpmParts[1]) : bpmMin
-
-  const formatKey = (key?: string) => {
-    if (!key) return undefined
-    const keyParts = key.split(' ')
-    const pitch = keyParts[0].slice(0, 1)
-    const isFlat = keyParts[0].length > 1
-    return `${pitch}${isFlat ? ' flat' : ''} ${keyParts[1].toLowerCase()}`
-  }
+  const [bpmMin, bpmMax] = getMinMaxFromBpm(bpm)
 
   const results = yield* call([apiClient, 'getSearchFull'], {
     currentUserId: userId,

--- a/packages/web/src/pages/search-page-v2/SearchResults.tsx
+++ b/packages/web/src/pages/search-page-v2/SearchResults.tsx
@@ -42,16 +42,25 @@ export const SearchResults = () => {
 
   const dispatch = useDispatch()
   useEffect(() => {
+    const queryParams = {
+      limit: 50,
+      offset: 0,
+      genre: (genre || undefined) as Genre,
+      mood: (mood || undefined) as Mood,
+      bpm: bpm || undefined,
+      key: key || undefined,
+      isVerified: isVerified === 'true',
+      hasDownloads: hasDownloads === 'true',
+      isPremium: isPremium === 'true',
+      sortMethod: sortMethod || undefined
+    }
+
     if (query?.[0] === '#') {
       dispatch(
         fetchSearchPageTags({
           tag: query || '',
           searchKind: SearchKind.ALL,
-          limit: 50,
-          offset: 0
-          // genre: (genre || undefined) as Genre,
-          // mood: (mood || undefined) as Mood,
-          // isVerified: isVerified === 'true'
+          ...queryParams
         })
       )
     } else {
@@ -59,16 +68,7 @@ export const SearchResults = () => {
         fetchSearchPageResults({
           searchText: query || '',
           kind: SearchKind.ALL,
-          limit: 50,
-          offset: 0,
-          genre: (genre || undefined) as Genre,
-          mood: (mood || undefined) as Mood,
-          bpm: bpm || undefined,
-          key: key || undefined,
-          isVerified: isVerified === 'true',
-          hasDownloads: hasDownloads === 'true',
-          isPremium: isPremium === 'true',
-          sortMethod: sortMethod || undefined
+          ...queryParams
         })
       )
     }


### PR DESCRIPTION
### Description
Update sagas and elastic search for tag search to handle the filters. Reuses the track_dsl and user_dsl from the normal search

### How Has This Been Tested?
Lots of testing on local stack
