### PR TITLE
safer blob close

### DIFF
--- a/mediorum/server/serve_blob.go
+++ b/mediorum/server/serve_blob.go
@@ -190,7 +190,11 @@ func (ss *MediorumServer) serveBlob(c echo.Context) error {
 		return err
 	}
 
-	defer blob.Close()
+	defer func() {
+		if blob != nil {
+			blob.Close()
+		}
+	}()
 
 	if c.Request().Method == "HEAD" {
 		return c.NoContent(200)


### PR DESCRIPTION
See this panic occasionally:

```
[PANIC RECOVER] runtime error: invalid memory address or nil pointer dereference goroutine 136680045 [running]:
github.com/AudiusProject/audius-protocol/mediorum/server.New.Recover.RecoverWithConfig.func14.1.1()
	/go/pkg/mod/github.com/labstack/echo/v4@v4.10.0/middleware/recover.go:93 +0x15d
panic({0x19caa40?, 0x31bbb20?})
	/usr/local/go/src/runtime/panic.go:770 +0x132
gocloud.dev/blob.(*Reader).Close(0xc00af02b40)
	/go/pkg/mod/gocloud.dev@v0.34.0/blob/blob.go:200 +0x26
github.com/AudiusProject/audius-protocol/mediorum/server.(*MediorumServer).serveBlob(0xc0008f8808, {0x23c2910, 0xc01480aaa0})
	/app/server/serve_blob.go:213 +0xa17

...

github.com/labstack/echo/v4.(*Echo).add.func1({0x23c2910, 0xc01480aaa0})
	/go/pkg/mod/github.com/labstack/echo/v4@v4.10.0/echo.go:546 +0x4b
github.com/AudiusProject/audius-protocol/mediorum/server.timingMiddleware.func1({0x23c2910, 0xc01480aaa0})
	/app/server/server.go:421 +0x1df
github.com/labstack/echo/v4/middleware.CORSWithConfig.func1.1({0x23c2910, 0xc01480aaa0})
	/go/pkg/mod/github.com/labstack/echo/v4@v4.10.0/middleware/cors.go:190 +0x463
github.com/labstack/echo/v4/middleware.LoggerWithConfig.func2.1({0x23c2910, 0xc01480aaa0})
	/go/pkg/mod/github.com/labstack/echo/v4@v4.10.0/middleware/logger.go:126 +0xd8
github.com/AudiusProject/audius-protocol/mediorum/server.New.Recover.RecoverWithConfig.func14.1({0x23c2910, 0xc01480aaa0})
	/go/pkg/mod/github.com/labstack/echo/v4@v4.10.0/middleware/recover.go:119 +0xea
github.com/labstack/echo/v4.(*Echo).ServeHTTP(0xc0006c6248, {0x23a2010, 0xc0006ced20}, 0xc00c9c65a0)
	/go/pkg/mod/github.com/labstack/echo/v4@v4.10.0/echo.go:633 +0x327
net/http.serverHandler.ServeHTTP({0xc01982b7a0?}, {0x23a2010?, 0xc0006ced20?}, 0x6?)
	/usr/local/go/src/net/http/server.go:3137 +0x8e
net/http.(*conn).serve(0xc017310750, {0x23a6610, 0xc000a00390})
	/usr/local/go/src/net/http/server.go:2039 +0x5e8
created by net/http.(*Server).Serve in goroutine 102
	/usr/local/go/src/net/http/server.go:3285 +0x4b4
```