### PR TITLE
misc audio analysis improvements

### DIFF
--- a/packages/discovery-provider/src/tasks/repair_audio_analyses.py
+++ b/packages/discovery-provider/src/tasks/repair_audio_analyses.py
@@ -31,6 +31,9 @@ def query_tracks(session: Session) -> List[Track]:
             or_(Track.musical_key == None, Track.bpm == None),
             Track.audio_analysis_error_count < 3,
             Track.track_cid != None,
+            Track.genre != "Podcasts",
+            Track.genre != "Podcast",
+            Track.genre != "Audiobooks",
         )
         .order_by(Track.track_id.asc())
         .limit(BATCH_SIZE)

--- a/packages/discovery-provider/src/tasks/repair_audio_analyses.py
+++ b/packages/discovery-provider/src/tasks/repair_audio_analyses.py
@@ -142,18 +142,19 @@ def repair(session: Session, redis: Redis):
             key = results.get("key", None) or results.get("Key", None)
             bpm = results.get("bpm", None) or results.get("BPM", None)
 
-            # Populate analysis results and err count if present
-            if (
-                key != track.musical_key
-                or bpm != track.bpm
-                or error_count != track.audio_analysis_error_count
-            ):
-                num_tracks_updated += 1
-            if key:
+            # Fill in missing analysis results and err count if present
+            track_updated = False
+            if key and not track.musical_key:
+                track_updated = True
                 track.musical_key = key
-            if bpm:
+            if bpm and not track.bpm:
+                track_updated = True
                 track.bpm = bpm
-            track.audio_analysis_error_count = error_count
+            if error_count != track.audio_analysis_error_count:
+                track_updated = True
+                track.audio_analysis_error_count = error_count
+            if track_updated:
+                num_tracks_updated += 1
 
             # Failures get retried up to 3 times
             if (not key or not bpm) and error_count < 3:


### PR DESCRIPTION
### Description
- have all nodes, not just the mirrors, check for and mark jobs as timed out.
- repairer: do not try to analyze podcasts and audio books.
- repairer: do not override non-null key/bpm values with the audio analysis results from content (for the future, when users may edit and save differing values)

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._
