### PR TITLE
[C-4613] Set `is_scheduled_release` on collection track uploads

### DIFF
--- a/packages/common/src/schemas/upload/uploadFormSchema.ts
+++ b/packages/common/src/schemas/upload/uploadFormSchema.ts
@@ -265,6 +265,7 @@ export const createCollectionSchema = (collectionType: 'playlist' | 'album') =>
       }),
       description: z.optional(z.string().max(1000)),
       release_date: z.optional(z.string()).nullable(),
+      is_scheduled_release: z.optional(z.boolean()),
       trackDetails: z.object({
         genre: GenreSchema,
         mood: MoodSchema,

--- a/packages/web/src/common/store/upload/sagas.ts
+++ b/packages/web/src/common/store/upload/sagas.ts
@@ -100,8 +100,11 @@ function* combineMetadata(
   if (!metadata.genre)
     metadata.genre = collectionMetadata.trackDetails.genre ?? ''
   if (!metadata.mood) metadata.mood = collectionMetadata.trackDetails.mood ?? ''
-  if (!metadata.release_date)
+  if (!metadata.release_date) {
     metadata.release_date = collectionMetadata.release_date ?? null
+    metadata.is_scheduled_release =
+      collectionMetadata.is_scheduled_release ?? false
+  }
 
   if (metadata.tags === null && collectionMetadata.trackDetails.tags) {
     // Take collection tags


### PR DESCRIPTION
### Description

Tracks will inherit `is_scheduled_release` flag from the collection if release date is set on the collection but not the track

### How Has This Been Tested?

tested cases with release date set and not set on collection. Correct data appears on resulting track metadata