### PR TITLE
[C-4620] Mobile Search State

### DIFF
--- a/packages/common/src/api/search.ts
+++ b/packages/common/src/api/search.ts
@@ -1,6 +1,22 @@
 import { createApi } from '~/audius-query'
+import { ModalSource } from '~/models'
 import { ID } from '~/models/Identifiers'
 import { SearchKind } from '~/store/pages/search-results/types'
+import { Genre } from '~/utils'
+
+export type SearchCategory = 'all' | 'tracks' | 'albums' | 'playlists' | 'users'
+
+export type SearchFilters = {
+  genre?: Genre
+  mood?: ModalSource
+  bpm?: string
+  key?: string
+  isVerified?: boolean
+  hasDownloads?: boolean
+  isPremium?: boolean
+}
+
+export type SearchFilter = keyof SearchFilters
 
 type getSearchArgs = {
   currentUserId: ID | null

--- a/packages/mobile/src/screens/app-screen/AppTabScreen.tsx
+++ b/packages/mobile/src/screens/app-screen/AppTabScreen.tsx
@@ -33,6 +33,7 @@ import {
   TagSearchScreen
 } from 'app/screens/search-results-screen'
 import { SearchScreen } from 'app/screens/search-screen'
+import type { SearchParams } from 'app/screens/search-screen-v2'
 import { SearchScreenV2 } from 'app/screens/search-screen-v2'
 import {
   AboutScreen,
@@ -85,7 +86,7 @@ export type AppTabScreenParamList = {
   Mutuals: { userId: ID }
   AiGeneratedTracks: { userId: ID }
   RelatedArtists: { userId: ID }
-  Search: undefined
+  Search: SearchParams
   SearchResults: { query: string }
   SupportingUsers: { userId: ID }
   TagSearch: { query: string }

--- a/packages/mobile/src/screens/search-screen-v2/SearchBarV2.tsx
+++ b/packages/mobile/src/screens/search-screen-v2/SearchBarV2.tsx
@@ -1,0 +1,27 @@
+import { Dimensions } from 'react-native'
+
+import { IconSearch, TextInput, TextInputSize } from '@audius/harmony-native'
+
+import { useSearchQuery } from './searchState'
+
+const searchBarWidth = Dimensions.get('window').width - 80
+
+const messages = {
+  label: 'Search'
+}
+
+export const SearchBarV2 = () => {
+  const [query, setQuery] = useSearchQuery()
+
+  return (
+    <TextInput
+      startIcon={IconSearch}
+      size={TextInputSize.SMALL}
+      label={messages.label}
+      placeholder={messages.label}
+      style={{ width: searchBarWidth }}
+      value={query}
+      onChangeText={setQuery}
+    />
+  )
+}

--- a/packages/mobile/src/screens/search-screen-v2/SearchCategoriesAndFilters.tsx
+++ b/packages/mobile/src/screens/search-screen-v2/SearchCategoriesAndFilters.tsx
@@ -2,7 +2,7 @@ import { ScrollView } from 'react-native'
 
 import { Flex, SelectablePill } from '@audius/harmony-native'
 
-export const SearchFilters = () => {
+export const SearchCategoriesAndFilters = () => {
   return (
     <Flex backgroundColor='white'>
       <ScrollView horizontal>

--- a/packages/mobile/src/screens/search-screen-v2/SearchScreenV2.tsx
+++ b/packages/mobile/src/screens/search-screen-v2/SearchScreenV2.tsx
@@ -7,6 +7,7 @@ import type {
 
 import { Flex } from '@audius/harmony-native'
 import { Screen } from 'app/components/core'
+import { useRoute } from 'app/hooks/useRoute'
 
 import { RecentSearches } from './RecentSearches'
 import { SearchBarV2 } from './SearchBarV2'
@@ -15,9 +16,14 @@ import { SearchCategoriesAndFilters } from './SearchCategoriesAndFilters'
 import { SearchContext } from './searchState'
 
 export const SearchScreenV2 = () => {
-  const [query, setQuery] = useState('')
-  const [category, setCategory] = useState<SearchCategory>('all')
-  const [filters, setFilters] = useState<SearchFiltersType>({})
+  const { params } = useRoute<'Search'>()
+  const [query, setQuery] = useState(params.query ?? '')
+  const [category, setCategory] = useState<SearchCategory>(
+    params.category ?? 'all'
+  )
+  const [filters, setFilters] = useState<SearchFiltersType>(
+    params.filters ?? {}
+  )
 
   const showSearchResults =
     query || Object.values(filters).some((filter) => filter)

--- a/packages/mobile/src/screens/search-screen-v2/SearchScreenV2.tsx
+++ b/packages/mobile/src/screens/search-screen-v2/SearchScreenV2.tsx
@@ -1,31 +1,40 @@
-import { Dimensions } from 'react-native'
+import { useState } from 'react'
+
+import type {
+  SearchCategory,
+  SearchFilters as SearchFiltersType
+} from '@audius/common/api'
 
 import { Flex } from '@audius/harmony-native'
 import { Screen } from 'app/components/core'
 
-import { SearchBar } from '../search-screen/SearchBar'
-
 import { RecentSearches } from './RecentSearches'
+import { SearchBarV2 } from './SearchBarV2'
 import { SearchCatalogTile } from './SearchCatalogTile'
-import { SearchFilters } from './SearchFilters'
-
-const searchBarWidth = Dimensions.get('window').width - 80
+import { SearchCategoriesAndFilters } from './SearchCategoriesAndFilters'
+import { SearchContext } from './searchState'
 
 export const SearchScreenV2 = () => {
-  const showSearchResults = false
+  const [query, setQuery] = useState('')
+  const [category, setCategory] = useState<SearchCategory>('all')
+  const [filters, setFilters] = useState<SearchFiltersType>({})
+
+  const showSearchResults =
+    query || Object.values(filters).some((filter) => filter)
+
   return (
-    <Screen
-      topbarRight={<SearchBar style={{ width: searchBarWidth }} />}
-      headerTitle={null}
-      variant='white'
-    >
-      <SearchFilters />
-      {!showSearchResults ? (
-        <Flex direction='column' alignItems='center' gap='xl'>
-          <SearchCatalogTile />
-          <RecentSearches />
-        </Flex>
-      ) : null}
+    <Screen topbarRight={<SearchBarV2 />} headerTitle={null} variant='white'>
+      <SearchContext.Provider
+        value={{ query, setQuery, category, setCategory, filters, setFilters }}
+      >
+        <SearchCategoriesAndFilters />
+        {!showSearchResults ? (
+          <Flex direction='column' alignItems='center' gap='xl'>
+            <SearchCatalogTile />
+            <RecentSearches />
+          </Flex>
+        ) : null}
+      </SearchContext.Provider>
     </Screen>
   )
 }

--- a/packages/mobile/src/screens/search-screen-v2/index.ts
+++ b/packages/mobile/src/screens/search-screen-v2/index.ts
@@ -1,1 +1,2 @@
 export { SearchScreenV2 } from './SearchScreenV2'
+export type { SearchParams } from './searchParams'

--- a/packages/mobile/src/screens/search-screen-v2/searchParams.ts
+++ b/packages/mobile/src/screens/search-screen-v2/searchParams.ts
@@ -1,0 +1,7 @@
+import type { SearchCategory, SearchFilters } from '@audius/common/api'
+
+export type SearchParams = {
+  query?: string
+  category?: SearchCategory
+  filters?: SearchFilters
+}

--- a/packages/mobile/src/screens/search-screen-v2/searchState.ts
+++ b/packages/mobile/src/screens/search-screen-v2/searchState.ts
@@ -1,0 +1,55 @@
+import type { Dispatch, SetStateAction } from 'react'
+import { createContext, useCallback, useContext } from 'react'
+
+import type {
+  SearchCategory,
+  SearchFilter,
+  SearchFilters
+} from '@audius/common/api'
+
+type SearchContextType = {
+  query: string
+  setQuery: Dispatch<SetStateAction<string>>
+  category: SearchCategory
+  setCategory: Dispatch<SetStateAction<SearchCategory>>
+  filters: SearchFilters
+  setFilters: Dispatch<SetStateAction<SearchFilters>>
+}
+
+export const SearchContext = createContext<SearchContextType>({
+  query: '',
+  setQuery: (_) => {},
+  category: 'all',
+  setCategory: (_) => {},
+  filters: {},
+  setFilters: (_) => {}
+})
+
+export const useSearchQuery = () => {
+  const { query, setQuery } = useContext(SearchContext)
+  return [query, setQuery] as const
+}
+
+export const useSearchCategory = () => {
+  const { category, setCategory } = useContext(SearchContext)
+  return [category, setCategory] as const
+}
+
+export const useSearchFilter = <F extends SearchFilter>(filterKey: F) => {
+  const { filters, setFilters } = useContext(SearchContext)
+
+  const filter = filters[filterKey]
+
+  const setFilter = useCallback(
+    (value: SearchFilters[F]) => {
+      setFilters((filters) => ({ ...filters, [filterKey]: value }))
+    },
+    [filterKey, setFilters]
+  )
+
+  const clearFilter = useCallback(() => {
+    setFilters((filters) => ({ ...filters, [filterKey]: undefined }))
+  }, [filterKey, setFilters])
+
+  return [filter, setFilter, clearFilter] as const
+}


### PR DESCRIPTION
### Description

Adds mobile search state pattern, using a combination of state, context and hooks. Essentially it creates custom hooks for query, category, and filters that feel like `useState`, but share a single state instance.

Also establishes search params and sets them as the search state initial values.

Also thinking we could use something like this to avoid my hand-rolled implementation? https://github.com/streamich/react-use/blob/HEAD/docs/createGlobalState.md

If we are thinking something else entirely, also down with that.