### PR TITLE
[C-4617, C-4439] Publish tracks along with playlist

### DIFF
--- a/packages/mobile/src/components/details-tile/DetailsTileActionButtons.tsx
+++ b/packages/mobile/src/components/details-tile/DetailsTileActionButtons.tsx
@@ -1,5 +1,7 @@
 import { useGetPlaylistById, useGetCurrentUserId } from '@audius/common/api'
+import { useFeatureFlag } from '@audius/common/hooks'
 import type { ID } from '@audius/common/models'
+import { FeatureFlags } from '@audius/common/services'
 import { cacheCollectionsSelectors } from '@audius/common/store'
 import type { CommonState } from '@audius/common/store'
 import { useSelector } from 'react-redux'
@@ -16,8 +18,6 @@ import { FavoriteButton } from 'app/components/favorite-button'
 import { RepostButton } from 'app/components/repost-button'
 import { makeStyles } from 'app/styles'
 import type { GestureResponderHandler } from 'app/types/gesture'
-import { useFeatureFlag } from '@audius/common/hooks'
-import { FeatureFlags } from '@audius/common/services'
 
 const { getCollectionHasHiddenTracks, getIsCollectionEmpty } =
   cacheCollectionsSelectors

--- a/packages/mobile/src/components/details-tile/DetailsTileActionButtons.tsx
+++ b/packages/mobile/src/components/details-tile/DetailsTileActionButtons.tsx
@@ -16,6 +16,8 @@ import { FavoriteButton } from 'app/components/favorite-button'
 import { RepostButton } from 'app/components/repost-button'
 import { makeStyles } from 'app/styles'
 import type { GestureResponderHandler } from 'app/types/gesture'
+import { useFeatureFlag } from '@audius/common/hooks'
+import { FeatureFlags } from '@audius/common/services'
 
 const { getCollectionHasHiddenTracks, getIsCollectionEmpty } =
   cacheCollectionsSelectors
@@ -79,6 +81,10 @@ export const DetailsTileActionButtons = ({
   onPressSave,
   onPressShare
 }: DetailsTileActionButtonsProps) => {
+  const { isEnabled: isHiddenPaidScheduledEnabled } = useFeatureFlag(
+    FeatureFlags.HIDDEN_PAID_SCHEDULED
+  )
+
   const styles = useStyles()
   const isCollectionEmpty = useSelector((state: CommonState) =>
     getIsCollectionEmpty(state, { id: collectionId })
@@ -155,7 +161,10 @@ export const DetailsTileActionButtons = ({
     <IconButton
       color='subdued'
       icon={IconRocket}
-      disabled={isCollectionEmpty || collectionHasHiddenTracks}
+      disabled={
+        isCollectionEmpty ||
+        (collectionHasHiddenTracks && !isHiddenPaidScheduledEnabled)
+      }
       disabledHint={
         collectionHasHiddenTracks
           ? messages.publishButtonHiddenDisabledContent

--- a/packages/web/src/common/store/cache/collections/commonSagas.ts
+++ b/packages/web/src/common/store/cache/collections/commonSagas.ts
@@ -30,7 +30,8 @@ import {
   confirmerActions,
   confirmTransaction,
   SubscriptionInfo,
-  Entry
+  Entry,
+  trackPageActions
 } from '@audius/common/store'
 import {
   squashNewLines,
@@ -481,6 +482,12 @@ function* publishPlaylistAsync(
     playlist,
     action.dismissToastKey
   )
+
+  for (const track of playlist.tracks ?? []) {
+    if (track.is_unlisted) {
+      yield* put(trackPageActions.makeTrackPublic(track.track_id))
+    }
+  }
 }
 
 function* confirmPublishPlaylist(

--- a/packages/web/src/common/store/pages/track/sagas.ts
+++ b/packages/web/src/common/store/pages/track/sagas.ts
@@ -232,6 +232,7 @@ function* watchTrackPageMakePublic() {
         ...track,
         is_unlisted: false,
         release_date: moment().toString(),
+        is_scheduled_release: false,
         field_visibility: {
           genre: true,
           mood: true,

--- a/packages/web/src/components/collection/desktop/PublishButton.tsx
+++ b/packages/web/src/components/collection/desktop/PublishButton.tsx
@@ -1,4 +1,5 @@
 import { Collection } from '@audius/common/models'
+import { FeatureFlags } from '@audius/common/src/services'
 import {
   cacheCollectionsSelectors,
   collectionPageSelectors,
@@ -9,6 +10,7 @@ import { useSelector } from 'react-redux'
 import { useToggle } from 'react-use'
 
 import { Tooltip } from 'components/tooltip'
+import { useFlag } from 'hooks/useRemoteConfig'
 
 import { PublishConfirmationModal } from './PublishConfirmationModal'
 
@@ -38,10 +40,17 @@ export const PublishButton = (props: PublishButtonProps) => {
     getCollectionHasHiddenTracks(state, { id: collectionId })
   )
 
+  const { isEnabled: isHiddenPaidScheduledEnabled } = useFlag(
+    FeatureFlags.HIDDEN_PAID_SCHEDULED
+  )
+
   const [isConfirming, toggleIsConfirming] = useToggle(false)
 
   const isDisabled =
-    !track_count || track_count === 0 || hasHiddenTracks || !cover_art_sizes
+    !track_count ||
+    track_count === 0 ||
+    (hasHiddenTracks && !isHiddenPaidScheduledEnabled) ||
+    !cover_art_sizes
 
   const publishButtonElement = (
     <IconButton

--- a/packages/web/src/components/collection/desktop/PublishConfirmationModal.tsx
+++ b/packages/web/src/components/collection/desktop/PublishConfirmationModal.tsx
@@ -27,7 +27,7 @@ const { publishPlaylist } = cacheCollectionsActions
 const messages = {
   title: 'Make Public',
   description: (collectionType: 'album' | 'playlist') =>
-    `Are you sure you want to make this ${collectionType} public? It will be shared to your feed and your subscribed followers will be notified.`,
+    `Are you sure you want to make this ${collectionType} public? Any hidden tracks in your ${collectionType} will become public and your followers will be notified.`,
   cancel: 'Cancel',
   publish: 'Make Public'
 }


### PR DESCRIPTION
### Description

- Unlock publish button for collections with hidden tracks
- On publish, also publish all hidden tracks in the collection

### How Has This Been Tested?

publish successfully cascaded to the child tracks
