### PR TITLE
Optimize prefetch logic to not wait on long calls

### DIFF
--- a/packages/web/src/common/store/cache/tracks/utils/fetchTrackStreamUrls.ts
+++ b/packages/web/src/common/store/cache/tracks/utils/fetchTrackStreamUrls.ts
@@ -9,7 +9,16 @@ import {
   calculatePlayerBehavior
 } from '@audius/common/store'
 import { getQueryParams } from '@audius/common/utils'
-import { all, call, select, put } from 'typed-redux-saga'
+import {
+  all,
+  call,
+  select,
+  put,
+  race,
+  delay,
+  fork,
+  cancel
+} from 'typed-redux-saga'
 const { getUserId } = accountSelectors
 const { getTrackStreamUrl, getTrack } = cacheTracksSelectors
 const { setStreamUrls } = cacheTracksActions
@@ -27,63 +36,102 @@ export function* fetchTrackStreamUrls({
   const audiusBackendInstance = yield* getContext('audiusBackendInstance')
   const reportToSentry = yield* getContext('reportToSentry')
   const playerBehavior = yield* select(getPlayerBehavior)
-
   const currentUserId = yield* select(getUserId)
 
   try {
-    // TODO: Ideally we should batch these fetches (needs a backend change to support)
-    const streamUrlCallEffects = trackIds.map(function* (id: ID) {
-      try {
-        const existingUrl = yield* select(getTrackStreamUrl, id)
+    let partialResults: { [id: number]: string | undefined }[] = []
+    // TODO: Long term it probably makes more sense to batch these fetches (needs a backend change to support)
+    const streamUrlCallEffects = trackIds.map((id) =>
+      call(function* () {
+        try {
+          const existingUrl = yield* select(getTrackStreamUrl, id)
 
-        if (existingUrl && !isUpdate) {
-          return { [id]: existingUrl }
-        }
+          if (existingUrl && !isUpdate) {
+            return { [id]: existingUrl }
+          }
 
-        const track = yield* select(getTrack, { id })
-        const { shouldSkip, shouldPreview } = calculatePlayerBehavior(
-          track,
-          playerBehavior
-        )
+          const track = yield* select(getTrack, { id })
+          const { shouldSkip, shouldPreview } = calculatePlayerBehavior(
+            track,
+            playerBehavior
+          )
 
-        if (shouldSkip) {
-          return undefined
+          if (shouldSkip) {
+            return undefined
+          }
+          const nftAccessSignatureMap = yield* select(getNftAccessSignatureMap)
+          const nftAccessSignature = nftAccessSignatureMap[id]?.mp3 ?? null
+          const queryParams = yield* call(getQueryParams, {
+            audiusBackendInstance,
+            nftAccessSignature,
+            userId: currentUserId
+          })
+          if (shouldPreview) {
+            queryParams.preview = true
+          }
+          const streamUrl = yield* call([apiClient, 'getTrackStreamUrl'], {
+            id,
+            currentUserId,
+            queryParams,
+            abortOnUnreachable: true
+          })
+          partialResults.push({ [id]: streamUrl })
+          return streamUrl !== undefined ? { [id]: streamUrl } : undefined
+        } catch (e) {
+          reportToSentry({
+            error: e as Error,
+            name: 'Stream Prefetch',
+            additionalInfo: { trackId: id }
+          })
         }
-        const nftAccessSignatureMap = yield* select(getNftAccessSignatureMap)
-        const nftAccessSignature = nftAccessSignatureMap[id]?.mp3 ?? null
-        const queryParams = yield* call(getQueryParams, {
-          audiusBackendInstance,
-          nftAccessSignature,
-          userId: currentUserId
-        })
-        if (shouldPreview) {
-          queryParams.preview = true
-        }
-        const streamUrl = yield* call([apiClient, 'getTrackStreamUrl'], {
-          id,
-          currentUserId,
-          queryParams,
-          abortOnUnreachable: true
-        })
-        return streamUrl !== undefined ? { [id]: streamUrl } : undefined
-      } catch (e) {
-        reportToSentry({
-          error: e as Error,
-          name: 'Stream Prefetch',
-          additionalInfo: { trackId: id }
-        })
+      })
+    )
+    // Intentionally don't use yield* so we don't block here
+    const streamUrlResults = all(streamUrlCallEffects)
+
+    let earlyResults: { [id: number]: string | undefined } = {}
+
+    // This early results handler is an optimization to make sure that if any particular network request is taking longer than 1s,
+    // we don't hold up the rest of the requests. This code waits for 1s and puts whatever
+    // @ts-ignore
+    function* earlyResultsHandler() {
+      yield* delay(1000)
+      if (partialResults.length > 0) {
+        // Convert array to obj and remove undefined values
+        earlyResults = partialResults.reduce((acc, curr) => {
+          if (Object.values(curr)[0] === undefined) {
+            return acc
+          }
+
+          return { ...acc, ...curr }
+        }, {})
+        // Put the early results in the store
+        yield* put(setStreamUrls(earlyResults))
       }
-    })
+    }
 
-    // Fetch stream urls concurrently
-    const streamUrlArray = yield* all(streamUrlCallEffects)
+    const getEarlyResultsFork = yield* fork(earlyResultsHandler)
 
-    // Convert to an object & put it in the store
-    const streamUrls = streamUrlArray.reduce(
-      (acc, streamUrl) => ({ ...acc, ...streamUrl }),
-      {}
-    ) as { [trackId: ID]: string }
-    yield* put(setStreamUrls(streamUrls))
+    // Now we block and wait for all stream urls to come back
+    const yieldedResults = yield* streamUrlResults
+
+    // Filter out the results that we already put earlier
+    const slowerResultsArr = yieldedResults.filter(
+      (track) =>
+        track !== undefined && earlyResults[Object.keys(track)[0]] === undefined
+    )
+    if (slowerResultsArr.length > 0) {
+      const slowerResultsObj = slowerResultsArr.reduce((acc, curr) => {
+        // Check for any undefined values early
+        if (curr === undefined || Object.values(curr)[0] === undefined) {
+          return acc
+        }
+        return { ...acc, ...curr }
+      }, {}) as { [id: number]: string } // from array of objs to one obj
+      yield* put(setStreamUrls(slowerResultsObj))
+    }
+
+    yield* cancel(getEarlyResultsFork)
   } catch (e) {
     reportToSentry({
       error: e as Error,

--- a/packages/web/src/common/store/cache/tracks/utils/fetchTrackStreamUrls.ts
+++ b/packages/web/src/common/store/cache/tracks/utils/fetchTrackStreamUrls.ts
@@ -9,16 +9,7 @@ import {
   calculatePlayerBehavior
 } from '@audius/common/store'
 import { getQueryParams } from '@audius/common/utils'
-import {
-  all,
-  call,
-  select,
-  put,
-  race,
-  delay,
-  fork,
-  cancel
-} from 'typed-redux-saga'
+import { all, call, select, put, delay, fork, cancel } from 'typed-redux-saga'
 const { getUserId } = accountSelectors
 const { getTrackStreamUrl, getTrack } = cacheTracksSelectors
 const { setStreamUrls } = cacheTracksActions
@@ -39,7 +30,7 @@ export function* fetchTrackStreamUrls({
   const currentUserId = yield* select(getUserId)
 
   try {
-    let partialResults: { [id: number]: string | undefined }[] = []
+    const partialResults: { [id: number]: string | undefined }[] = []
     // TODO: Long term it probably makes more sense to batch these fetches (needs a backend change to support)
     const streamUrlCallEffects = trackIds.map((id) =>
       call(function* () {

--- a/packages/web/src/common/store/cache/tracks/utils/fetchTrackStreamUrls.ts
+++ b/packages/web/src/common/store/cache/tracks/utils/fetchTrackStreamUrls.ts
@@ -86,7 +86,7 @@ export function* fetchTrackStreamUrls({
     // we don't hold up the rest of the requests. This code waits for 1s and puts whatever
     // @ts-ignore
     function* earlyResultsHandler() {
-      yield* delay(1000)
+      yield* delay(1500)
       if (partialResults.length > 0) {
         // Convert array to obj and remove undefined values
         earlyResults = partialResults.reduce((acc, curr) => {


### PR DESCRIPTION
### Description

Context: To avoid tons of redux spam I batched all the stream prefetches together and had them wait till they all finish before putting them in the store. Once we got to prod though, I noticed that some calls can take a long time and this holds back all of the quick returning ones (this doesn't cause any bugs, it just ruins the point of the optimization; aka to have the prefetched urls ready before the user clicks anything).

To solve, this change tweaks the saga logic to see what's ready after 1.5s and put that into the store before waiting on the rest. This should solve for the majority of calls since most are under ~1s

### How Has This Been Tested?

web:stage