### PR TITLE
[QA-1405] Fix price formatting on collection screens

### DIFF
--- a/packages/web/src/components/tracks-table/TracksTable.tsx
+++ b/packages/web/src/components/tracks-table/TracksTable.tsx
@@ -495,7 +495,15 @@ export const TracksTable = ({
       if (!isLocked || deleted || isOwner || !isPremiumEnabled) {
         return null
       }
+
       if (isContentUSDCPurchaseGated(track.stream_conditions)) {
+        // Format the price with 2 digit decimal cents
+        const formattedPrice = (
+          track.stream_conditions.usdc_purchase.price / 100
+        ).toLocaleString('en-US', {
+          minimumFractionDigits: 2,
+          maximumFractionDigits: 2
+        })
         return (
           <Button
             size='small'
@@ -506,7 +514,7 @@ export const TracksTable = ({
               onClickPurchase?.(track)
             }}
           >
-            ${track.stream_conditions.usdc_purchase.price / 100}.00
+            ${formattedPrice}
           </Button>
         )
       }

--- a/packages/web/src/components/tracks-table/TracksTable.tsx
+++ b/packages/web/src/components/tracks-table/TracksTable.tsx
@@ -497,7 +497,7 @@ export const TracksTable = ({
       }
 
       if (isContentUSDCPurchaseGated(track.stream_conditions)) {
-        // Format the price with 2 digit decimal cents
+        // Format the price as $$ with 2 digit decimal cents
         const formattedPrice = (
           track.stream_conditions.usdc_purchase.price / 100
         ).toLocaleString('en-US', {

--- a/packages/web/src/components/tracks-table/TracksTable.tsx
+++ b/packages/web/src/components/tracks-table/TracksTable.tsx
@@ -8,7 +8,7 @@ import {
   isContentFollowGated,
   isContentUSDCPurchaseGated
 } from '@audius/common/models'
-import { formatCount, formatSeconds } from '@audius/common/utils'
+import { formatCount, formatPrice, formatSeconds } from '@audius/common/utils'
 import {
   IconVisibilityHidden,
   IconLock,
@@ -498,12 +498,9 @@ export const TracksTable = ({
 
       if (isContentUSDCPurchaseGated(track.stream_conditions)) {
         // Format the price as $$ with 2 digit decimal cents
-        const formattedPrice = (
-          track.stream_conditions.usdc_purchase.price / 100
-        ).toLocaleString('en-US', {
-          minimumFractionDigits: 2,
-          maximumFractionDigits: 2
-        })
+        const formattedPrice = formatPrice(
+          track.stream_conditions.usdc_purchase.price
+        )
         return (
           <Button
             size='small'


### PR DESCRIPTION
### Description

Fix price formatting logic not accounting for prices that already include have decimals

![image](https://github.com/AudiusProject/audius-protocol/assets/6711655/059293b3-21b2-4a86-a200-38ab7f4b7bec)


### How Has This Been Tested?

web:prod using this album:
https://audius.co/eloquinuk/album/eloquin-dubpack
