### PR TITLE
[QA-1389] Fix listening history not queuing up properly

### DIFF
--- a/packages/web/src/common/store/pages/history/lineups/sagas.ts
+++ b/packages/web/src/common/store/pages/history/lineups/sagas.ts
@@ -1,5 +1,6 @@
 import {
   Id,
+  Kind,
   LineupEntry,
   Track,
   UserTrackMetadata
@@ -69,7 +70,7 @@ function* getHistoryTracks() {
 
 const keepTrackIdAndDateListened = (entry: LineupEntry<Track>) => ({
   uid: entry.uid,
-  kind: entry.kind,
+  kind: entry.kind ?? ('track_id' in entry ? Kind.TRACKS : Kind.COLLECTIONS),
   id: entry.track_id,
   dateListened: entry.dateListened
 })


### PR DESCRIPTION
### Description

Fixes listening history not queueing up properly. The reason is because `kind` was not being added to the history tracks, which makes it fall through both `if` statements [here](https://github.com/AudiusProject/audius-protocol/blob/jd/fix-listening-history-lineup/packages/web/src/common/store/queue/sagas.ts#L69)

![2024-06-27 16 32 54](https://github.com/AudiusProject/audius-protocol/assets/6711655/50827d64-f7f3-46ea-99b7-6734bba0e84c)


### How Has This Been Tested?

web:stage and ios:stage
