### PR TITLE
[C-4599] Scheduled MusicBadge on web collections

### DIFF
--- a/packages/harmony/src/components/music-badge/MusicBadge.tsx
+++ b/packages/harmony/src/components/music-badge/MusicBadge.tsx
@@ -80,7 +80,11 @@ export const MusicBadge = (props: MusicBadgeProps) => {
       }}
     >
       {Icon ? <Icon size={size} fill={iconColor} /> : null}
-      <Text variant='label' size={size} css={{ color: textColor }}>
+      <Text
+        variant='label'
+        size={size}
+        css={{ color: textColor, whiteSpace: 'nowrap' }}
+      >
         {children}
       </Text>
     </Flex>

--- a/packages/web/src/components/collection/desktop/CollectionHeader.tsx
+++ b/packages/web/src/components/collection/desktop/CollectionHeader.tsx
@@ -1,6 +1,6 @@
 import { ChangeEvent, useCallback, useState } from 'react'
 
-import { useGetCurrentUserId } from '@audius/common/api'
+import { useGetCurrentUserId, useGetPlaylistById } from '@audius/common/api'
 import {
   AccessConditions,
   AccessPermissions,
@@ -16,7 +16,7 @@ import {
   PurchaseableContentType,
   useEditPlaylistModal
 } from '@audius/common/store'
-import { Nullable } from '@audius/common/utils'
+import { Nullable, formatReleaseDate } from '@audius/common/utils'
 import {
   Text,
   IconVisibilityHidden,
@@ -28,7 +28,8 @@ import {
   IconCart,
   useTheme,
   IconComponent,
-  MusicBadge
+  MusicBadge,
+  IconCalendarMonth
 } from '@audius/harmony'
 import cn from 'classnames'
 
@@ -51,7 +52,9 @@ const messages = {
   premiumLabel: 'premium',
   hiddenPlaylistLabel: 'hidden playlist',
   by: 'By ',
-  hidden: 'Hidden'
+  hidden: 'Hidden',
+  releases: (releaseDate: string) =>
+    `Releases ${formatReleaseDate({ date: releaseDate, withHour: true })}`
 }
 
 type CollectionHeaderProps = {
@@ -128,6 +131,14 @@ export const CollectionHeader = (props: CollectionHeaderProps) => {
     FeatureFlags.PREMIUM_ALBUMS_ENABLED
   )
   const { data: currentUserId } = useGetCurrentUserId({})
+  const { data: collection } = useGetPlaylistById({
+    playlistId: collectionId,
+    currentUserId
+  })
+  const {
+    is_scheduled_release: isScheduledRelease,
+    release_date: releaseDate
+  } = collection ?? {}
   const [artworkLoading, setIsArtworkLoading] = useState(true)
   const [filterText, setFilterText] = useState('')
   const { spacing } = useTheme()
@@ -268,7 +279,15 @@ export const CollectionHeader = (props: CollectionHeaderProps) => {
         css={{ position: 'absolute', right: spacing.l, top: spacing.l }}
       >
         {!isPublished ? (
-          <MusicBadge icon={IconVisibilityHidden}>{messages.hidden}</MusicBadge>
+          isScheduledRelease && releaseDate ? (
+            <MusicBadge variant='accent' icon={IconCalendarMonth}>
+              {messages.releases(releaseDate)}
+            </MusicBadge>
+          ) : (
+            <MusicBadge icon={IconVisibilityHidden}>
+              {messages.hidden}
+            </MusicBadge>
+          )
         ) : onFilterChange ? (
           <TextInput
             label={

--- a/packages/web/src/components/collection/mobile/CollectionHeader.tsx
+++ b/packages/web/src/components/collection/mobile/CollectionHeader.tsx
@@ -14,8 +14,18 @@ import {
   PurchaseableContentType,
   useEditPlaylistModal
 } from '@audius/common/store'
-import { getDogEarType } from '@audius/common/utils'
-import { Box, Button, Flex, IconPause, IconPlay, Text } from '@audius/harmony'
+import { formatReleaseDate, getDogEarType } from '@audius/common/utils'
+import {
+  Box,
+  Button,
+  Flex,
+  IconCalendarMonth,
+  IconPause,
+  IconPlay,
+  IconVisibilityHidden,
+  MusicBadge,
+  Text
+} from '@audius/harmony'
 import cn from 'classnames'
 import { useSelector } from 'react-redux'
 
@@ -45,7 +55,10 @@ const messages = {
   play: 'PLAY',
   pause: 'PAUSE',
   preview: 'PREVIEW',
-  coverArtAltText: 'Collection Cover Art'
+  coverArtAltText: 'Collection Cover Art',
+  hidden: 'Hidden',
+  releases: (releaseDate: string) =>
+    `Releases ${formatReleaseDate({ date: releaseDate, withHour: true })}`
 }
 
 type MobileCollectionHeaderProps = CollectionHeaderProps & {
@@ -108,7 +121,12 @@ const CollectionHeader = ({
     currentUserId
   })
   const { hasStreamAccess } = useGatedContentAccess(collection)
-  const { is_private: isPrivate, is_stream_gated: isPremium } = collection ?? {}
+  const {
+    is_private: isPrivate,
+    is_stream_gated: isPremium,
+    is_scheduled_release: isScheduledRelease,
+    release_date: releaseDate
+  } = collection ?? {}
 
   const tracks = useSelector((state: CommonState) =>
     getCollectionTracks(state, { id: collectionId })
@@ -207,13 +225,17 @@ const CollectionHeader = ({
     <Flex direction='column'>
       {renderDogEar()}
       <Flex direction='column' alignItems='center' p='l' gap='l'>
-        <Text variant='label' color='subdued'>
-          {type === 'playlist' && !isPublished
-            ? isPublishing
-              ? messages.publishing
-              : messages.hiddenPlaylist
-            : type}
-        </Text>
+        {!isPublished ? (
+          isScheduledRelease && releaseDate ? (
+            <MusicBadge variant='accent' icon={IconCalendarMonth} size='s'>
+              {messages.releases(releaseDate)}
+            </MusicBadge>
+          ) : (
+            <MusicBadge icon={IconVisibilityHidden} size='s'>
+              {messages.hidden}
+            </MusicBadge>
+          )
+        ) : null}
         <DynamicImage
           alt={messages.coverArtAltText}
           wrapperClassName={styles.coverArt}


### PR DESCRIPTION
### Description
Add scheduled MusicBadges to collection headers.

Also add `white-space: nowrap` to `MusicBadge`.

### How Has This Been Tested?

<img width="1167" alt="Screenshot 2024-06-28 at 9 40 35 AM" src="https://github.com/AudiusProject/audius-protocol/assets/3893871/578a7f80-0fd2-4dbe-861d-ef79af0f5c2c">
<img width="457" alt="Screenshot 2024-06-28 at 9 38 30 AM" src="https://github.com/AudiusProject/audius-protocol/assets/3893871/01ad74de-2b7f-44b5-93eb-fc3962139e02">
<img width="1109" alt="Screenshot 2024-06-28 at 9 38 17 AM" src="https://github.com/AudiusProject/audius-protocol/assets/3893871/eb3f649f-a94b-4ff9-88bb-aec05545f4d5">
<img width="450" alt="Screenshot 2024-06-28 at 9 37 23 AM" src="https://github.com/AudiusProject/audius-protocol/assets/3893871/73891c2d-9fae-471a-ae91-e0ffaac37d1f">
