### PR TITLE
[C-4583] Allow hidden tracks to be added to public playlists in UI

### DIFF
--- a/packages/mobile/src/components/add-to-collection-drawer/AddToCollectionDrawer.tsx
+++ b/packages/mobile/src/components/add-to-collection-drawer/AddToCollectionDrawer.tsx
@@ -24,6 +24,8 @@ import { CollectionList } from '../collection-list'
 import { AddCollectionCard } from '../collection-list/AddCollectionCard'
 import { CollectionCard } from '../collection-list/CollectionCard'
 import { FilterInput } from '../filter-input'
+import { useFeatureFlag } from '@audius/common/hooks'
+import { FeatureFlags } from '@audius/common/services'
 
 const { addTrackToPlaylist, createAlbum, createPlaylist } =
   cacheCollectionsActions
@@ -71,6 +73,9 @@ export const AddToCollectionDrawer = () => {
   const trackTitle = useSelector(getTrackTitle)
   const isTrackUnlisted = useSelector(getTrackIsUnlisted)
   const [filter, setFilter] = useState('')
+  const { isEnabled: isHiddenPaidScheduledEnabled } = useFeatureFlag(
+    FeatureFlags.HIDDEN_PAID_SCHEDULED
+  )
 
   const messages = getMessages(collectionType)
 
@@ -131,7 +136,11 @@ export const AddToCollectionDrawer = () => {
             if (!trackId) return
 
             // Don't add if the track is hidden, but collection is public
-            if (isTrackUnlisted && !item.is_private) {
+            if (
+              !isHiddenPaidScheduledEnabled &&
+              !isTrackUnlisted &&
+              !item.is_private
+            ) {
               toast({ content: messages.hiddenAdd })
               return
             }

--- a/packages/mobile/src/components/add-to-collection-drawer/AddToCollectionDrawer.tsx
+++ b/packages/mobile/src/components/add-to-collection-drawer/AddToCollectionDrawer.tsx
@@ -1,7 +1,9 @@
 import { useCallback, useMemo, useState } from 'react'
 
+import { useFeatureFlag } from '@audius/common/hooks'
 import type { Collection } from '@audius/common/models'
 import { CreatePlaylistSource } from '@audius/common/models'
+import { FeatureFlags } from '@audius/common/services'
 import type { CommonState } from '@audius/common/store'
 import {
   accountSelectors,
@@ -24,8 +26,6 @@ import { CollectionList } from '../collection-list'
 import { AddCollectionCard } from '../collection-list/AddCollectionCard'
 import { CollectionCard } from '../collection-list/CollectionCard'
 import { FilterInput } from '../filter-input'
-import { useFeatureFlag } from '@audius/common/hooks'
-import { FeatureFlags } from '@audius/common/services'
 
 const { addTrackToPlaylist, createAlbum, createPlaylist } =
   cacheCollectionsActions
@@ -171,6 +171,7 @@ export const AddToCollectionDrawer = () => {
       collectionType,
       isTrackUnlisted,
       messages,
+      isHiddenPaidScheduledEnabled,
       onClose,
       toast,
       dispatch

--- a/packages/web/src/components/add-to-collection/desktop/AddToCollectionModal.tsx
+++ b/packages/web/src/components/add-to-collection/desktop/AddToCollectionModal.tsx
@@ -5,6 +5,7 @@ import {
   SquareSizes,
   Collection
 } from '@audius/common/models'
+import { FeatureFlags } from '@audius/common/services'
 import {
   accountSelectors,
   cacheCollectionsActions,
@@ -22,11 +23,10 @@ import DynamicImage from 'components/dynamic-image/DynamicImage'
 import SearchBar from 'components/search-bar/SearchBar'
 import { Tooltip } from 'components/tooltip'
 import { useCollectionCoverArt } from 'hooks/useCollectionCoverArt'
+import { useFlag } from 'hooks/useRemoteConfig'
 import { collectionPage } from 'utils/route'
 
 import styles from './AddToCollectionModal.module.css'
-import { useFlag } from 'hooks/useRemoteConfig'
-import { FeatureFlags } from '@audius/common/services'
 const { getCollectionType, getTrackId, getTrackTitle, getTrackIsUnlisted } =
   addToCollectionUISelectors
 const { addTrackToPlaylist, createAlbum, createPlaylist } =

--- a/packages/web/src/components/add-to-collection/desktop/AddToCollectionModal.tsx
+++ b/packages/web/src/components/add-to-collection/desktop/AddToCollectionModal.tsx
@@ -25,6 +25,8 @@ import { useCollectionCoverArt } from 'hooks/useCollectionCoverArt'
 import { collectionPage } from 'utils/route'
 
 import styles from './AddToCollectionModal.module.css'
+import { useFlag } from 'hooks/useRemoteConfig'
+import { FeatureFlags } from '@audius/common/services'
 const { getCollectionType, getTrackId, getTrackTitle, getTrackIsUnlisted } =
   addToCollectionUISelectors
 const { addTrackToPlaylist, createAlbum, createPlaylist } =
@@ -55,6 +57,9 @@ const AddToCollectionModal = () => {
   const isAlbumType = collectionType === 'album'
   const account = useSelector(getAccountWithNameSortedPlaylistsAndAlbums)
   const [searchValue, setSearchValue] = useState('')
+  const { isEnabled: isHiddenPaidScheduledEnabled } = useFlag(
+    FeatureFlags.HIDDEN_PAID_SCHEDULED
+  )
 
   const messages = getMessages(collectionType)
 
@@ -168,7 +173,11 @@ const AddToCollectionModal = () => {
               <div key={`${collection.playlist_id}`}>
                 <CollectionItem
                   collectionType={collectionType}
-                  disabled={isTrackUnlisted && !collection.is_private}
+                  disabled={
+                    !isHiddenPaidScheduledEnabled &&
+                    isTrackUnlisted &&
+                    !collection.is_private
+                  }
                   collection={collection}
                   handleClick={
                     isTrackUnlisted && !collection.is_private


### PR DESCRIPTION
### Description
No longer filter out public playlists from the add to playlists modal/drawer.

### How Has This Been Tested?

ff off:
<img width="540" alt="Screenshot 2024-06-28 at 9 44 40 AM" src="https://github.com/AudiusProject/audius-protocol/assets/3893871/590aec5f-b01b-4633-b2be-8b729dc66845">

ff on:
<img width="592" alt="Screenshot 2024-06-28 at 9 44 23 AM" src="https://github.com/AudiusProject/audius-protocol/assets/3893871/5a266a13-ffb8-4dea-88df-729fd9979291">

Harder to see on ios but also tested there.
