### PR TITLE
[PAY-3147] Allow unsave/unrepost hidden track/album

### DIFF
--- a/packages/discovery-provider/integration_tests/tasks/entity_manager/test_social_feature_entity_manager.py
+++ b/packages/discovery-provider/integration_tests/tasks/entity_manager/test_social_feature_entity_manager.py
@@ -1038,7 +1038,7 @@ def test_index_social_feature_playlist_type(app, mocker):
 
 
 def test_index_social_feature_hidden_item(app, mocker):
-    # create an unlisted playlist and unlisted track, see if faving does anything
+    # ensure that favoriting/reposting a track/playlist works
     "Tests a playlist update and repost in the same block"
     bus_mock = mocker.patch(
         "src.challenges.challenge_event_bus.ChallengeEventBus", autospec=True
@@ -1059,7 +1059,7 @@ def test_index_social_feature_hidden_item(app, mocker):
                         "_entityType": "Playlist",
                         "_userId": 11,
                         # metadata is formatted invalid, should be string
-                        "_metadata": 1,
+                        "_metadata": "",
                         "_action": "Repost",
                         "_signer": "user11wallet",
                     }
@@ -1070,11 +1070,11 @@ def test_index_social_feature_hidden_item(app, mocker):
             {
                 "args": AttributeDict(
                     {
-                        "_entityId": 2,
+                        "_entityId": 1,
                         "_entityType": "Track",
                         "_userId": 11,
                         # metadata is formatted invalid, should be string
-                        "_metadata": 1,
+                        "_metadata": "",
                         "_action": "Save",
                         "_signer": "user11wallet",
                     }
@@ -1103,7 +1103,7 @@ def test_index_social_feature_hidden_item(app, mocker):
             for i in range(1, 13)
         ],
         "playlists": [{"playlist_id": 1, "playlist_owner_id": 10, "is_private": True}],
-        "tracks": [{"track_id": 1, "owner_id": 10, "is_private": True}],
+        "tracks": [{"track_id": 1, "owner_id": 10, "is_unlisted": True}],
     }
     populate_mock_db(db, entities)
 
@@ -1119,5 +1119,5 @@ def test_index_social_feature_hidden_item(app, mocker):
         )
         all_reposts: List[Repost] = session.query(Repost).all()
         all_favorites: List[Save] = session.query(Save).all()
-        assert len(all_reposts) == 0
-        assert len(all_favorites) == 0
+        assert len(all_reposts) == 1
+        assert len(all_favorites) == 1

--- a/packages/discovery-provider/integration_tests/tasks/entity_manager/test_social_feature_entity_manager.py
+++ b/packages/discovery-provider/integration_tests/tasks/entity_manager/test_social_feature_entity_manager.py
@@ -1038,7 +1038,7 @@ def test_index_social_feature_playlist_type(app, mocker):
 
 
 def test_index_social_feature_hidden_item(app, mocker):
-    # ensure that favoriting/reposting a track/playlist works
+    # ensure that favoriting/reposting a hidden track/playlist works
     "Tests a playlist update and repost in the same block"
     bus_mock = mocker.patch(
         "src.challenges.challenge_event_bus.ChallengeEventBus", autospec=True

--- a/packages/discovery-provider/src/tasks/entity_manager/entities/social_features.py
+++ b/packages/discovery-provider/src/tasks/entity_manager/entities/social_features.py
@@ -228,24 +228,6 @@ def validate_social_feature(params: ManageEntityParameters):
     if params.entity_id not in params.existing_records[params.entity_type]:
         raise IndexingValidationError(f"Entity {params.entity_id} does not exist")
 
-    if (
-        params.entity_type == EntityType.PLAYLIST
-        and params.entity_id in params.existing_records[params.entity_type]
-        and params.existing_records[params.entity_type][params.entity_id].is_private
-    ):
-        raise IndexingValidationError(
-            f"Playlist {params.entity_id} is private, cannot execute social feature"
-        )
-
-    if (
-        params.entity_type == EntityType.TRACK
-        and params.entity_id in params.existing_records[params.entity_type]
-        and params.existing_records[params.entity_type][params.entity_id].is_unlisted
-    ):
-        raise IndexingValidationError(
-            f"Track {params.entity_id} is private, cannot execute social feature"
-        )
-
     # User cannot use social feature on themself
     if params.action in (
         Action.FOLLOW,

--- a/packages/mobile/src/components/track-list/TrackListItem.tsx
+++ b/packages/mobile/src/components/track-list/TrackListItem.tsx
@@ -289,12 +289,12 @@ const TrackListItemComponent = (props: TrackListItemComponentProps) => {
   const handleOpenOverflowMenu = useCallback(() => {
     const overflowActions = [
       OverflowAction.SHARE,
-      !isTrackOwner && !isLocked
+      !isTrackOwner && !isLocked && (!isUnlisted || has_current_user_saved)
         ? has_current_user_saved
           ? OverflowAction.UNFAVORITE
           : OverflowAction.FAVORITE
         : null,
-      !isTrackOwner && !isLocked
+      !isTrackOwner && !isLocked && (!isUnlisted || has_current_user_reposted)
         ? has_current_user_reposted
           ? OverflowAction.UNREPOST
           : OverflowAction.REPOST

--- a/packages/mobile/src/components/track-list/TrackListItem.tsx
+++ b/packages/mobile/src/components/track-list/TrackListItem.tsx
@@ -329,6 +329,7 @@ const TrackListItemComponent = (props: TrackListItemComponentProps) => {
   }, [
     isTrackOwner,
     isLocked,
+    isUnlisted,
     has_current_user_saved,
     has_current_user_reposted,
     isDeleted,

--- a/packages/web/src/components/edit-collection/mobile/EditPlaylistPage.tsx
+++ b/packages/web/src/components/edit-collection/mobile/EditPlaylistPage.tsx
@@ -360,6 +360,7 @@ const EditPlaylistPage = g(
           time: playlistTrack?.time,
           isStreamGated: t.is_stream_gated,
           isDeleted: t.is_delete || !!t.user.is_deactivated,
+          isUnlisted: t.is_unlisted,
           isLocked,
           isRemoveActive
         }

--- a/packages/web/src/components/track/mobile/ConnectedTrackListItem.tsx
+++ b/packages/web/src/components/track/mobile/ConnectedTrackListItem.tsx
@@ -55,6 +55,7 @@ const ConnectedTrackListItem = (props: ConnectedTrackListItemProps) => {
     ddexApp,
     hasStreamAccess,
     isLocked,
+    isUnlisted,
     isReposted,
     isSaved,
     streamConditions,
@@ -80,12 +81,12 @@ const ConnectedTrackListItem = (props: ConnectedTrackListItemProps) => {
       isPurchase && !hasStreamAccess && !isDeleted
         ? OverflowAction.PURCHASE_TRACK
         : null,
-      isLocked
+      isLocked || (isUnlisted && !isReposted)
         ? null
         : isReposted
         ? OverflowAction.UNREPOST
         : OverflowAction.REPOST,
-      isLocked
+      isLocked || (isUnlisted && !isSaved)
         ? null
         : isSaved
         ? OverflowAction.UNFAVORITE

--- a/packages/web/src/components/track/mobile/TrackList.tsx
+++ b/packages/web/src/components/track/mobile/TrackList.tsx
@@ -15,6 +15,7 @@ type TrackListProps = {
   tracks: Array<{
     isLoading: boolean
     isStreamGated?: boolean
+    isUnlisted?: boolean
     isSaved?: boolean
     isReposted?: boolean
     isActive?: boolean
@@ -92,6 +93,7 @@ const TrackList = ({
           trackId={track.trackId}
           className={itemClassName}
           isLoading={track.isLoading}
+          isUnlisted={track.isUnlisted}
           isSaved={track.isSaved}
           isReposted={track.isReposted}
           isActive={track.isActive}

--- a/packages/web/src/components/track/mobile/TrackListItem.tsx
+++ b/packages/web/src/components/track/mobile/TrackListItem.tsx
@@ -110,6 +110,7 @@ export type TrackListItemProps = {
   index: number
   isLoading: boolean
   isStreamGated?: boolean
+  isUnlisted?: boolean
   isSaved?: boolean
   isReposted?: boolean
   isActive?: boolean

--- a/packages/web/src/components/tracks-table/TracksTable.tsx
+++ b/packages/web/src/components/tracks-table/TracksTable.tsx
@@ -325,7 +325,8 @@ export const TracksTable = ({
         track.is_delete || track._marked_deleted || !!track.user?.is_deactivated
       const isOwner = track.owner_id === userId
       const isUnlisted = track.is_unlisted
-      if (isLocked || deleted || isOwner || isUnlisted) {
+      const isFavorited = track.has_current_user_saved
+      if (isLocked || deleted || isOwner || (isUnlisted && !isFavorited)) {
         return null
       }
 
@@ -360,8 +361,9 @@ export const TracksTable = ({
       const deleted =
         track.is_delete || track._marked_deleted || !!track.user?.is_deactivated
       const isUnlisted = track.is_unlisted
+      const isReposted = track.has_current_user_reposted
       const isOwner = track.owner_id === userId
-      if (isLocked || deleted || isOwner || isUnlisted) {
+      if (isLocked || deleted || isOwner || (isUnlisted && !isReposted)) {
         return null
       }
 

--- a/packages/web/src/pages/collection-page/components/mobile/CollectionPage.tsx
+++ b/packages/web/src/pages/collection-page/components/mobile/CollectionPage.tsx
@@ -220,6 +220,7 @@ const CollectionPage = ({
     const isLocked = !isFetchingNFTAccess && !hasStreamAccess
     return {
       isLoading: false,
+      isUnlisted: entry.is_unlisted,
       isSaved: entry.has_current_user_saved,
       isReposted: entry.has_current_user_reposted,
       isActive: playingUid === entry.uid,

--- a/packages/web/src/pages/history-page/components/mobile/HistoryPage.tsx
+++ b/packages/web/src/pages/history-page/components/mobile/HistoryPage.tsx
@@ -65,6 +65,7 @@ const HistoryPage = ({
     return {
       isLoading: loading,
       isStreamGated: track.is_stream_gated,
+      isUnlisted: track.is_unlisted,
       isReposted: track.has_current_user_reposted,
       isSaved: track.has_current_user_saved,
       isActive,

--- a/packages/web/src/pages/saved-page/components/mobile/SavedPage.tsx
+++ b/packages/web/src/pages/saved-page/components/mobile/SavedPage.tsx
@@ -195,6 +195,7 @@ const TracksLineup = ({
       return {
         isLoading: false,
         isStreamGated: entry.is_stream_gated,
+        isUnlisted: entry.is_unlisted,
         isSaved: entry.has_current_user_saved,
         isReposted: entry.has_current_user_reposted,
         isActive: playingUid === entry.uid,


### PR DESCRIPTION
### Description

We currently disable the favorite/repost actions on hidden tracks/albums. But, given that we now allow artists to hide their tracks/albums after having made them public, it is possible for users to see hidden tracks/albums in their library, so we want to allow users to be able to remove those hidden tracks/albums by unfavoriting/unreposting them.

- allow social actions on hidden tracks/albums in indexing
- show favorite/repost buttons in user library if hidden and favorited/reposted so user can undo

### How Has This Been Tested?

- updated dn integration test
- tested library page local client v stage
