### PR TITLE
move audio analysis retry logic to content

### DIFF
--- a/mediorum/server/audio_analysis.go
+++ b/mediorum/server/audio_analysis.go
@@ -74,6 +74,7 @@ func (ss *MediorumServer) startAudioAnalyzer() {
 	for {
 		time.Sleep(time.Second * 10)
 		ss.findMissedAnalysisJobs(work, myHost)
+		ss.retryAnalysisJobs(work, myHost)
 	}
 }
 
@@ -103,13 +104,6 @@ func (ss *MediorumServer) findMissedAnalysisJobs(work chan *Upload, myHost strin
 		myRank := myIdx + 1
 
 		logger := ss.logger.With("upload", upload.ID, "upload_status", upload.Status, "my_rank", myRank)
-
-		// this is already handled by a callback and there's a chance this job gets enqueued twice
-		if myRank == 1 && upload.Status == JobStatusAudioAnalysis {
-			logger.Info("my upload's audio analysis not started")
-			work <- upload
-			continue
-		}
 
 		// determine if #1 rank worker dropped ball
 		timedOut := false
@@ -144,6 +138,37 @@ func (ss *MediorumServer) findMissedAnalysisJobs(work chan *Upload, myHost strin
 			logger.Info("audio analysis never started")
 			work <- upload
 		}
+	}
+}
+
+func (ss *MediorumServer) retryAnalysisJobs(work chan *Upload, myHost string) {
+	uploads := []*Upload{}
+	ss.crud.DB.Where("audio_analysis_status = ? OR (audio_analysis_status = ? AND audio_analysis_error_count < ?)", JobStatusTimeout, JobStatusError, 3).
+		Where("status = ?", JobStatusDone).
+		Where("CAST(transcoded_mirrors AS jsonb)->>0 = ?", myHost).
+		Order("audio_analyzed_at ASC").
+		Limit(2).
+		Find(&uploads)
+
+	for _, upload := range uploads {
+		myIdx := slices.Index(upload.TranscodedMirrors, myHost)
+		if myIdx != 0 {
+			continue
+		}
+		myRank := myIdx + 1
+
+		logger := ss.logger.With("upload", upload.ID, "audio_analysis_status", upload.AudioAnalysisStatus, "my_rank", myRank)
+
+		if upload.AudioAnalysisStatus == JobStatusError {
+			logger.Info("retrying my errored audio analysis")
+		}
+		if upload.AudioAnalysisStatus == JobStatusTimeout {
+			logger.Info("retrying my timed out audio analysis... starting")
+		}
+		upload.AudioAnalyzedAt = time.Now().UTC()
+		// op callback will enqueue the job
+		upload.Status = JobStatusAudioAnalysis
+		ss.crud.Update(upload)
 	}
 }
 

--- a/mediorum/server/legacy_audio_analysis.go
+++ b/mediorum/server/legacy_audio_analysis.go
@@ -79,6 +79,7 @@ func (ss *MediorumServer) startLegacyAudioAnalyzer() {
 			select {
 			case <-ticker.C:
 				// find missed legacy analysis jobs every minute
+				// mark analyses as timed out
 				ss.findMissedLegacyAnalysisJobs(work, myHost)
 
 			case <-retryTicker.C:
@@ -88,7 +89,7 @@ func (ss *MediorumServer) startLegacyAudioAnalyzer() {
 		}
 	}()
 
-	// Block to keep running
+	// block to keep running
 	select {}
 }
 
@@ -185,7 +186,7 @@ func (ss *MediorumServer) retryLegacyAnalysisJobs(work chan *QmAudioAnalysis, my
 			logger.Info("retrying my errored legacy audio analysis")
 		}
 		if analysis.Status == JobStatusTimeout {
-			logger.Info("retrying my timed out legacy audio analysis... starting")
+			logger.Info("retrying my timed out legacy audio analysis")
 		}
 		analysis.AnalyzedAt = time.Now().UTC()
 		// op callback will enqueue the job

--- a/mediorum/server/legacy_audio_analysis.go
+++ b/mediorum/server/legacy_audio_analysis.go
@@ -68,14 +68,30 @@ func (ss *MediorumServer) startLegacyAudioAnalyzer() {
 	}
 
 	// poll periodically for analyses that slipped thru the cracks
-	for {
-		time.Sleep(time.Minute)
-		ss.findMissedLegacyAnalysisJobs(work, myHost)
-	}
+	go func() {
+		ticker := time.NewTicker(1 * time.Minute)
+		defer ticker.Stop()
+
+		retryTicker := time.NewTicker(30 * time.Minute)
+		defer retryTicker.Stop()
+
+		for {
+			select {
+			case <-ticker.C:
+				// find missed legacy analysis jobs every minute
+				ss.findMissedLegacyAnalysisJobs(work, myHost)
+
+			case <-retryTicker.C:
+				// retry legacy analysis jobs every 30 minutes
+				ss.retryLegacyAnalysisJobs(work, myHost)
+			}
+		}
+	}()
+
+	// Block to keep running
+	select {}
 }
 
-// do not bother setting a timeout like in findMissedAnalysisJobs. this is not triggered
-// by the client during the upload flow so it can afford to take > 1 minute
 func (ss *MediorumServer) findMissedLegacyAnalysisJobs(work chan *QmAudioAnalysis, myHost string) {
 	analyses := []*QmAudioAnalysis{}
 	ss.crud.DB.Where("status in ?", []string{JobStatusAudioAnalysis, JobStatusBusyAudioAnalysis}).Find(&analyses)
@@ -100,13 +116,6 @@ func (ss *MediorumServer) findMissedLegacyAnalysisJobs(work chan *QmAudioAnalysi
 		myRank := myIdx + 1
 
 		logger := ss.logger.With("analysis_cid", analysis.CID, "analysis_status", analysis.Status, "my_rank", myRank)
-
-		// this is already handled by a callback and there's a chance this job gets enqueued twice
-		if myRank == 1 && analysis.Status == JobStatusAudioAnalysis {
-			logger.Info("my legacy cid's audio analysis not started")
-			work <- analysis
-			continue
-		}
 
 		// determine if #1 rank worker dropped ball
 		timedOut := false
@@ -152,6 +161,36 @@ func (ss *MediorumServer) findMissedLegacyAnalysisJobs(work chan *QmAudioAnalysi
 			logger.Info("legacy audio analysis never started")
 			work <- analysis
 		}
+	}
+}
+
+func (ss *MediorumServer) retryLegacyAnalysisJobs(work chan *QmAudioAnalysis, myHost string) {
+	analyses := []*QmAudioAnalysis{}
+	ss.crud.DB.Where("status = ? OR (status = ? AND error_count < ?)", JobStatusTimeout, JobStatusError, 3).
+		Where("CAST(mirrors AS jsonb)->>0 ?", myHost).
+		Order("analyzed_at ASC").
+		Limit(100).
+		Find(&analyses)
+
+	for _, analysis := range analyses {
+		myIdx := slices.Index(analysis.Mirrors, myHost)
+		if myIdx != 0 {
+			continue
+		}
+		myRank := myIdx + 1
+
+		logger := ss.logger.With("analysis_cid", analysis.CID, "analysis_status", analysis.Status, "my_rank", myRank)
+
+		if analysis.Status == JobStatusError {
+			logger.Info("retrying my errored legacy audio analysis")
+		}
+		if analysis.Status == JobStatusTimeout {
+			logger.Info("retrying my timed out legacy audio analysis... starting")
+		}
+		analysis.AnalyzedAt = time.Now().UTC()
+		// op callback will enqueue the job
+		analysis.Status = JobStatusAudioAnalysis
+		ss.crud.Update(analysis)
 	}
 }
 

--- a/mediorum/server/serve_audio_analysis.go
+++ b/mediorum/server/serve_audio_analysis.go
@@ -1,7 +1,6 @@
 package server
 
 import (
-	"net/http"
 	"time"
 
 	"github.com/labstack/echo/v4"
@@ -16,17 +15,17 @@ func (ss *MediorumServer) analyzeUpload(c echo.Context) error {
 		return echo.NewHTTPError(404, err.Error())
 	}
 
-	if upload.Template == "audio" && upload.Status == JobStatusDone && upload.AudioAnalysisStatus != JobStatusDone {
-		upload.AudioAnalyzedAt = time.Now().UTC()
-		upload.AudioAnalysisStatus = ""
-		upload.AudioAnalysisError = ""
-		upload.Status = JobStatusAudioAnalysis
-		err = ss.crud.Update(upload)
-		if err != nil {
-			ss.logger.Warn("update upload failed", "err", err)
-			return c.String(500, "failed to trigger audio analysis")
-		}
-	}
+	// if upload.Template == "audio" && upload.Status == JobStatusDone && upload.AudioAnalysisStatus != JobStatusDone {
+	// 	upload.AudioAnalyzedAt = time.Now().UTC()
+	// 	upload.AudioAnalysisStatus = ""
+	// 	upload.AudioAnalysisError = ""
+	// 	upload.Status = JobStatusAudioAnalysis
+	// 	err = ss.crud.Update(upload)
+	// 	if err != nil {
+	// 		ss.logger.Warn("update upload failed", "err", err)
+	// 		return c.String(500, "failed to trigger audio analysis")
+	// 	}
+	// }
 
 	return c.JSON(200, upload)
 }
@@ -52,22 +51,22 @@ func (ss *MediorumServer) analyzeLegacyBlob(c echo.Context) error {
 		}
 		return c.JSON(200, newAnalysis)
 	}
-	if analysis.Status == JobStatusError || analysis.Status == JobStatusTimeout {
-		if analysis.Error == "blob is not an audio file" {
-			// set ErrorCount to 3 so discovery repairer stops retrying this cid
-			analysis.ErrorCount = 3
-			ss.crud.Update(analysis)
-			return c.String(http.StatusBadRequest, "must specify a cid for an audio file")
-		}
-		analysis.Status = JobStatusAudioAnalysis
-		analysis.AnalyzedAt = time.Now().UTC()
-		analysis.Error = ""
-		err = ss.crud.Update(analysis)
-		if err != nil {
-			ss.logger.Warn("update legacy audio analysis failed", "err", err)
-			return c.String(500, "failed to trigger audio analysis")
-		}
-	}
+	// if analysis.Status == JobStatusError || analysis.Status == JobStatusTimeout {
+	// 	if analysis.Error == "blob is not an audio file" {
+	// 		// set ErrorCount to 3 so discovery repairer stops retrying this cid
+	// 		analysis.ErrorCount = 3
+	// 		ss.crud.Update(analysis)
+	// 		return c.String(http.StatusBadRequest, "must specify a cid for an audio file")
+	// 	}
+	// 	analysis.Status = JobStatusAudioAnalysis
+	// 	analysis.AnalyzedAt = time.Now().UTC()
+	// 	analysis.Error = ""
+	// 	err = ss.crud.Update(analysis)
+	// 	if err != nil {
+	// 		ss.logger.Warn("update legacy audio analysis failed", "err", err)
+	// 		return c.String(500, "failed to trigger audio analysis")
+	// 	}
+	// }
 	return c.JSON(200, analysis)
 }
 

--- a/packages/discovery-provider/src/tasks/repair_audio_analyses.py
+++ b/packages/discovery-provider/src/tasks/repair_audio_analyses.py
@@ -157,16 +157,16 @@ def repair(session: Session, redis: Redis):
                 num_tracks_updated += 1
 
             # Failures get retried up to 3 times
-            if (not key or not bpm) and error_count < 3:
-                # Trigger another audio analysis but don't bother polling for result. Will read it in next batch.
-                num_analyses_retriggered += 1
-                retrigger_audio_analysis(
-                    nodes,
-                    track.track_id,
-                    track.track_cid,
-                    track.audio_upload_id,
-                    legacy_track,
-                )
+            # if (not key or not bpm) and error_count < 3:
+            #     # Trigger another audio analysis but don't bother polling for result. Will read it in next batch.
+            #     num_analyses_retriggered += 1
+            #     retrigger_audio_analysis(
+            #         nodes,
+            #         track.track_id,
+            #         track.track_cid,
+            #         track.audio_upload_id,
+            #         legacy_track,
+            #     )
             if error_count >= 3:
                 logger.warning(
                     f"repair_audio_analyses.py | Track ID {track.track_id} (track_cid: {track.track_cid}, audio_upload_id: {track.audio_upload_id}) failed audio analysis >= 3 times"


### PR DESCRIPTION
### Description
instead of having discovery retrigger analyses, content nodes are responsible for retrying their timed out or failed analyses if they are the first mirror based on periodic db queries. discovery just polls the results.

still uses a push-based approach based on crudr ops but it should at least enqueue jobs more efficiently than discovery. if the first mirror is online querying the db for timeouts/errors, it is updating its own db with the enqueued status, so the jobs gets properly queued without relying on crudr pushing and sweeping.

ran these queries on prod cn2:
```
audius_creator_node=# select count(*) from qm_audio_analyses where (status = 'timeout' or (status = 'error' and error_count < 3)) and CAST(mirrors AS jsonb)->>0 = 'https://creatornode2.audius.co';
 count
-------
  9723
(1 row)

audius_creator_node=# select count(*) from uploads where (audio_analysis_status = 'timeout' or (audio_analysis_status = 'error' and audio_analysis_error_count < 3)) and status = 'done' and CAST(transcoded_mirrors AS jsonb)->>0 = 'https://creatornode2.audius.co';
 count
-------
   275
(1 row)
```
for legacy cids: enqueue 100 timed out or errored jobs every 30 minutes. this allows 18s per job. if cn2 processes at that rate, which should be enough time per job, it should be caught up in about 48 hours.
for ba cids: enqueue 2 jobs every 30s (lower number, higher freq bc the timeout is much shorter and don't want to flood the work queue, which needs to remain available to analyze new uploads) = 15s per job. this should catch up in about an hour.

Note: this relies on the 1st mirror being online to process retries. I think I'll keep this approach just for the backfill to minimize duplicate work but when everything is totally caught up, I'll either switch it back to discovery initiating retries or add logic for each mirror to process retries based on the analyzed_at timestamp.

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._
