### PR TITLE
[C-4633] Remove scheduled suffix from artist dashboard tables

### DIFF
--- a/packages/web/src/components/collections-table/CollectionsTable.tsx
+++ b/packages/web/src/components/collections-table/CollectionsTable.tsx
@@ -120,17 +120,8 @@ export const CollectionsTable = ({
 
   const renderReleaseDateCell = useCallback((cellInfo: CollectionCell) => {
     const collection = cellInfo.row.original
-    let suffix = ''
-    if (
-      collection.release_date &&
-      moment(collection.release_date).isAfter(moment.now())
-    ) {
-      suffix = ' (Scheduled)'
-    }
-    return (
-      moment(collection.release_date ?? collection.created_at).format(
-        'M/D/YY'
-      ) + suffix
+    return moment(collection.release_date ?? collection.created_at).format(
+      'M/D/YY'
     )
   }, [])
 

--- a/packages/web/src/components/tracks-table/TracksTable.tsx
+++ b/packages/web/src/components/tracks-table/TracksTable.tsx
@@ -296,16 +296,7 @@ export const TracksTable = ({
 
   const renderReleaseDateCell = useCallback((cellInfo: TrackCell) => {
     const track = cellInfo.row.original
-    let suffix = ''
-    if (
-      track.release_date &&
-      moment(track.release_date).isAfter(moment.now())
-    ) {
-      suffix = ' (Scheduled)'
-    }
-    return (
-      moment(track.release_date ?? track.created_at).format('M/D/YY') + suffix
-    )
+    return moment(track.release_date ?? track.created_at).format('M/D/YY')
   }, [])
 
   const renderListenDateCell = useCallback((cellInfo: TrackCell) => {


### PR DESCRIPTION
### Description
For tracks/albums scheduled to release in the future, we don't want to show the "scheduled" suffix anymore, just the future release date.

### How Has This Been Tested?

Local web stage