### PR TITLE
[C-4552] Show tooltips for collection action buttons

### DIFF
--- a/packages/web/src/components/collection/desktop/EditButton.tsx
+++ b/packages/web/src/components/collection/desktop/EditButton.tsx
@@ -1,7 +1,15 @@
 import { useCallback } from 'react'
 
+import { useGetCurrentUserId, useGetPlaylistById } from '@audius/common/api'
 import { useEditPlaylistModal } from '@audius/common/store'
 import { IconPencil, IconButton, IconButtonProps } from '@audius/harmony'
+import { capitalize } from 'lodash'
+
+import { Tooltip } from 'components/tooltip'
+
+const messages = {
+  edit: (type?: 'album' | 'playlist') => `Edit ${capitalize(type) ?? ''}`
+}
 
 type EditButtonProps = Partial<IconButtonProps> & {
   collectionId: number
@@ -9,6 +17,16 @@ type EditButtonProps = Partial<IconButtonProps> & {
 
 export const EditButton = (props: EditButtonProps) => {
   const { collectionId, ...other } = props
+  const { data: currentUserId } = useGetCurrentUserId({})
+  const { data: collection } = useGetPlaylistById({
+    playlistId: collectionId,
+    currentUserId
+  })
+  const collectionType = collection
+    ? collection?.is_album
+      ? 'album'
+      : 'playlist'
+    : undefined
 
   const { onOpen } = useEditPlaylistModal()
 
@@ -17,12 +35,14 @@ export const EditButton = (props: EditButtonProps) => {
   }, [collectionId, onOpen])
 
   return (
-    <IconButton
-      icon={IconPencil}
-      onClick={handleEdit}
-      aria-label='Edit Collection'
-      color='subdued'
-      {...other}
-    />
+    <Tooltip text={messages.edit(collectionType)}>
+      <IconButton
+        icon={IconPencil}
+        onClick={handleEdit}
+        aria-label='Edit Collection'
+        color='subdued'
+        {...other}
+      />
+    </Tooltip>
   )
 }

--- a/packages/web/src/components/collection/desktop/ShareButton.tsx
+++ b/packages/web/src/components/collection/desktop/ShareButton.tsx
@@ -59,11 +59,9 @@ export const ShareButton = (props: ShareButtonProps) => {
     />
   )
 
-  return tooltipText ? (
-    <Tooltip text={tooltipText}>
+  return (
+    <Tooltip text={tooltipText ?? messages.share}>
       <span>{buttonRender}</span>
     </Tooltip>
-  ) : (
-    buttonRender
   )
 }


### PR DESCRIPTION
### Description
Since we're moving to IconButtons we should always show tooltips in case the meanings of the icons aren't clear to the user.

### How Has This Been Tested?

<img width="794" alt="Screenshot 2024-06-28 at 2 57 53 PM" src="https://github.com/AudiusProject/audius-protocol/assets/3893871/01d97e64-3b9f-49e6-99e3-79faac594dd3">
<img width="819" alt="Screenshot 2024-06-28 at 2 51 25 PM" src="https://github.com/AudiusProject/audius-protocol/assets/3893871/c6c4eeaa-a859-472e-a636-99d659abb2fa">
