### PR TITLE
[QA-1409] Fix mobile nowplaying images not loading after failure state

### DIFF
--- a/packages/mobile/src/hooks/useContentNodeImage.ts
+++ b/packages/mobile/src/hooks/useContentNodeImage.ts
@@ -1,4 +1,4 @@
-import { useState, useMemo, useCallback } from 'react'
+import { useState, useMemo, useCallback, useEffect } from 'react'
 
 import { useAppContext } from '@audius/common/context'
 import type { SquareSizes, WidthSizes, CID } from '@audius/common/models'
@@ -159,6 +159,14 @@ export const useContentNodeImage = (
       setFailedToLoad(true)
     }
   }, [imageSourceIndex, imageSources])
+
+  useEffect(() => {
+    // Any time a new image loads reset our failure states
+    if (failedToLoad) {
+      setFailedToLoad(false)
+      setImageSourceIndex(0)
+    }
+  }, [cid])
 
   // when localSource is a number, it's a placeholder image, so we should show fallback image
   const showFallbackImage =


### PR DESCRIPTION
### Description

Better resolves the NowPlaying drawer image issue where it fails and gets stuck in a fail state.

The solution was to reset the fail state logic after changing cids. We didn't have anything resetting it before so once the error was triggered it just never recovered.

Note: This doesn't fix the underlying issue causing the failures but just recovers better. If one image fails it will stay broken but if you change songs it will 


Sample of what it looks like now:

Notice how the track "may" breaks initially, "dreams aaaaag" also breaks, but then the track after works fine. Going back to "may" it eventually recovered and works again. "dreams aaaaag" in this particular instance stayed broken; unclear why. Either way its better behavior than everything staying broken

https://github.com/AudiusProject/audius-protocol/assets/6711655/3ae66378-7740-4ed7-b97d-760f18a09c0c


### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._
