### PR TITLE
[C-4487, C-4554, C-4523, C-4631, C-4492]Copy updates for upload/edit

### DIFF
--- a/packages/web/src/components/edit/fields/AdvancedField.tsx
+++ b/packages/web/src/components/edit/fields/AdvancedField.tsx
@@ -28,12 +28,12 @@ import { computeLicenseIcons } from 'components/edit-track/utils/computeLicenseI
 import { TextField } from 'components/form-fields'
 import { SegmentedControlField } from 'components/form-fields/SegmentedControlField'
 import layoutStyles from 'components/layout/layout.module.css'
+import { Tooltip } from 'components/tooltip'
 import { env } from 'services/env'
 
 import styles from './AdvancedField.module.css'
 import { KeySelectField } from './KeySelectField'
 import { SwitchRowField } from './SwitchRowField'
-import { Tooltip } from 'components/tooltip'
 
 const { computeLicense, ALL_RIGHTS_RESERVED_TYPE } = creativeCommons
 

--- a/packages/web/src/components/edit/fields/AdvancedField.tsx
+++ b/packages/web/src/components/edit/fields/AdvancedField.tsx
@@ -5,6 +5,7 @@ import {
   Box,
   Flex,
   IconCcBy as IconCreativeCommons,
+  IconInfo,
   IconRobot,
   Text
 } from '@audius/harmony'
@@ -32,6 +33,7 @@ import { env } from 'services/env'
 import styles from './AdvancedField.module.css'
 import { KeySelectField } from './KeySelectField'
 import { SwitchRowField } from './SwitchRowField'
+import { Tooltip } from 'components/tooltip'
 
 const { computeLicense, ALL_RIGHTS_RESERVED_TYPE } = creativeCommons
 
@@ -48,8 +50,8 @@ const messages = {
   musicalKey: 'Key',
   aiGenerated: {
     header: 'Mark this track as AI generated',
-    description:
-      'If your AI generated track was trained on an existing Audius artist, you can give them credit here. Only users who have opted-in will appear in this list.',
+    tooltip:
+      'If your AI-generated track was trained on an existing Audius artist, you can give them credit here. Only users who have opted-in will appear in this list.',
     placeholder: 'Search for Users',
     requiredError: 'Valid user must be selected.'
   },
@@ -58,7 +60,7 @@ const messages = {
     description:
       'Keep your track from being streamed on third-party apps or services that utilize the Audius API.'
   },
-
+  isrcTooltip: `ISRC is used to identify individual sound recordings and music videos. ISWC is used to identify the underlying musical composition – the music and lyrics`,
   isrc: {
     header: 'ISRC',
     placeholder: 'CC-XXX-YY-NNNNN',
@@ -455,7 +457,12 @@ const AdvancedModalFields = () => {
       <Divider />
       <div className={cn(layoutStyles.col, layoutStyles.gap4)}>
         <Text variant='title' size='l' tag='h3'>
-          {`${messages.isrc.header} / ${messages.iswc.header}`}
+          <Flex alignItems='center' gap='xs'>
+            {`${messages.isrc.header} / ${messages.iswc.header}`}
+            <Tooltip text={messages.isrcTooltip}>
+              <IconInfo size='m' color='subdued' />
+            </Tooltip>
+          </Flex>
         </Text>
         <span className={cn(layoutStyles.row, layoutStyles.gap6)}>
           <div className={styles.textFieldContainer}>
@@ -512,7 +519,7 @@ const AdvancedModalFields = () => {
       <SwitchRowField
         name={IS_AI_ATTRIBUTED}
         header={messages.aiGenerated.header}
-        description={messages.aiGenerated.description}
+        tooltipText={messages.aiGenerated.tooltip}
       >
         <AiAttributionDropdown
           {...aiUserIdField}

--- a/packages/web/src/components/edit/fields/RemixSettingsField/RemixSettingsMenuFields.tsx
+++ b/packages/web/src/components/edit/fields/RemixSettingsField/RemixSettingsMenuFields.tsx
@@ -28,13 +28,13 @@ const messages = {
   hideRemix: {
     header: 'Hide Remixes of This Track',
     description:
-      'Enable this option if you want to prevent remixes of your track by other artists from appearing on your track page.'
+      'Prevent remixes of your track by other artists from appearing on your track page. '
   },
   remixOf: {
     header: 'Identify as Remix',
     description:
-      "Paste the original Audius track link if yours is a remix. Your remix will typically appear on the original track's page.",
-    linkLabel: 'Link to Remix'
+      'Link your remix to the original track to increase visibility and credit the original artist.',
+    linkLabel: 'Enter an Audius Link'
   },
   changeAvailabilityPrefix: 'Availablity is set to ',
   changeAvailabilitySuffix:

--- a/packages/web/src/components/edit/fields/StemsAndDownloadsMenuFields.tsx
+++ b/packages/web/src/components/edit/fields/StemsAndDownloadsMenuFields.tsx
@@ -39,7 +39,8 @@ const messages = {
     'Upload your stems and source files to allow fans to remix your track. This does not affect users ability to listen offline.',
   [IS_DOWNLOADABLE]: {
     header: 'Allow Full Track Download',
-    description: 'Allow your fans to download a copy of your full track.'
+    description:
+      'Allow your fans to download a lossless copy of your full track.'
   },
   priceTooLow: (minPrice: number) =>
     `Price must be at least $${formatPrice(minPrice)}.`,

--- a/packages/web/src/components/edit/fields/SwitchRowField.tsx
+++ b/packages/web/src/components/edit/fields/SwitchRowField.tsx
@@ -4,17 +4,26 @@ import { Switch, Text } from '@audius/harmony'
 import { useField } from 'formik'
 
 import styles from './SwitchRowField.module.css'
+import { Tooltip } from 'components/tooltip'
 
 type ToggleFieldProps = PropsWithChildren & {
   name: string
   header: string
-  description: string
+  description?: string
   inverted?: boolean
+  tooltipText?: string
 } & Partial<ComponentProps<'input'>>
 
 export const SwitchRowField = (props: ToggleFieldProps) => {
-  const { name, header, description, inverted, children, ...inputOverrides } =
-    props
+  const {
+    name,
+    header,
+    description,
+    inverted,
+    tooltipText,
+    children,
+    ...inputOverrides
+  } = props
 
   const [field] = useField({ name, type: 'checkbox' })
 
@@ -34,12 +43,16 @@ export const SwitchRowField = (props: ToggleFieldProps) => {
   return (
     <div className={styles.root}>
       <div className={styles.content}>
-        <Text tag='label' htmlFor={inputId} variant='title' size='l'>
-          {header}
-        </Text>
-        <Text id={descriptionId} variant='body'>
-          {description}
-        </Text>
+        <Tooltip text={tooltipText} disabled={!tooltipText}>
+          <Text tag='label' htmlFor={inputId} variant='title' size='l'>
+            {header}
+          </Text>
+        </Tooltip>
+        {description ? (
+          <Text id={descriptionId} variant='body'>
+            {description}
+          </Text>
+        ) : null}
         {(inverted ? !field.checked : field.checked) ? children : null}
       </div>
       <Switch

--- a/packages/web/src/components/edit/fields/SwitchRowField.tsx
+++ b/packages/web/src/components/edit/fields/SwitchRowField.tsx
@@ -3,8 +3,9 @@ import { ChangeEvent, ComponentProps, PropsWithChildren } from 'react'
 import { Switch, Text } from '@audius/harmony'
 import { useField } from 'formik'
 
-import styles from './SwitchRowField.module.css'
 import { Tooltip } from 'components/tooltip'
+
+import styles from './SwitchRowField.module.css'
 
 type ToggleFieldProps = PropsWithChildren & {
   name: string

--- a/packages/web/src/components/edit/fields/download-availability/DownloadAvailability.tsx
+++ b/packages/web/src/components/edit/fields/download-availability/DownloadAvailability.tsx
@@ -41,21 +41,21 @@ const WAITLIST_TYPEFORM = 'https://link.audius.co/waitlist'
 
 const getMessages = (props: DownloadAvailabilityProps) => ({
   downloadAvailability: 'Download Availability',
-  customize: 'Customize who has access to download your files.',
+  customize: 'Specify who has access to download your files.',
   public: 'Public',
   followers: 'Followers',
   premium: 'Premium',
   callout: {
     premium: `You're ${
       props.isUpload ? 'uploading' : 'editing'
-    } a Premium track. By default, purchasers will be able to download your available files. If you'd like to only sell your files, set your track to Public or Hidden in the`,
+    } a Premium track. By default, purchasers will be able to download your available files. If you'd like to sell your files, set your track to Public or Hidden in the`,
     specialAccess: `You're ${
       props.isUpload ? 'uploading' : 'editing'
-    } a Special Access track. By default, users who unlock your track will be able to download your available files. If you'd like to only sell your files, set your track to Public or Hidden in the`,
+    } a Special Access track. By default, users who unlock your track will be able to download your available files. If you'd like to sell your files, set your track to Public or Hidden in the`,
     collectibleGated: `You're ${
       props.isUpload ? 'uploading' : 'editing'
-    } a Collectible Gated track. By default, users who unlock your track will be able to download your available files. If you'd like to only sell your files, set your track to Public or Hidden in the`,
-    accessAndSale: 'Access & Sale Settings'
+    } a Collectible Gated track. By default, users who unlock your track will be able to download your available files. If you'd like to sell your files, set your track to Public or Hidden in the`,
+    priceAndAudience: 'Price & Audience Settings'
   },
   waitlist:
     'Start selling your music on Audius today! Limited access beta now available.',
@@ -209,7 +209,7 @@ export const DownloadAvailability = (props: DownloadAvailabilityProps) => {
           icon={IconError}
           actions={
             <TextLink onClick={handleCalloutClick} variant='visible'>
-              {messages.callout.accessAndSale}
+              {messages.callout.priceAndAudience}
             </TextLink>
           }
         >

--- a/packages/web/src/components/edit/fields/download-availability/DownloadPriceField.tsx
+++ b/packages/web/src/components/edit/fields/download-availability/DownloadPriceField.tsx
@@ -18,8 +18,7 @@ import { DOWNLOAD_PRICE } from '../types'
 const messages = {
   price: {
     title: 'Set a Price',
-    description:
-      'Set the price fans must pay to access your stem files (minimum price of $1.00)',
+    description: 'The price to unlock your stem files (min $1)',
     label: 'Cost to download',
     placeholder: '1.00'
   },

--- a/packages/web/src/components/edit/fields/price-and-audience/PriceAndAudienceMenuFields.tsx
+++ b/packages/web/src/components/edit/fields/price-and-audience/PriceAndAudienceMenuFields.tsx
@@ -51,7 +51,11 @@ const messagesV1 = {
     'Hidden albums remain invisible to your followers, visible only to you on your profile. They can be shared and listened to via direct link.',
   hiddenHint: 'Scheduled tracks are hidden by default until release.',
   publishDisabled:
-    'Publishing is disabled for empty albums and albums containing hidden tracks.'
+    'Publishing is disabled for empty albums and albums containing hidden tracks.',
+  fromFreeHint: (
+    contentType: 'album' | 'track',
+    gatedType: 'gated' | 'premium'
+  ) => `You can't make a free ${contentType} ${gatedType}.`
 }
 
 const messagesV2 = {
@@ -172,6 +176,10 @@ export const PriceAndAudienceMenuFields = (
             checkedContent={
               <SpecialAccessFields disabled={disableSpecialAccessGateFields} />
             }
+            tooltipText={messages.fromFreeHint(
+              isAlbum ? 'album' : 'track',
+              'gated'
+            )}
           />
         ) : null}
         {!isAlbum ? (

--- a/packages/web/src/components/edit/fields/stream-availability/collectible-gated/CollectibleGatedRadioField.tsx
+++ b/packages/web/src/components/edit/fields/stream-availability/collectible-gated/CollectibleGatedRadioField.tsx
@@ -16,7 +16,7 @@ import { CollectibleGatedFields } from './CollectibleGatedFields'
 const messages = {
   collectibleGated: 'Collectible Gated',
   noCollectibles:
-    'No Collectibles found. To enable this option, link a wallet containing a collectible.',
+    'No collectibles found. Link a wallet containing a digital collectible to enable this option.',
   fromFreeHint: (contentType: 'album' | 'track') =>
     `You can't make a free ${contentType} premium.`
 }
@@ -65,10 +65,10 @@ export const CollectibleGatedRadioField = (
       }
       checkedContent={<CollectibleGatedFields disabled={fieldsDisabled} />}
       tooltipText={
-        disabled
-          ? messages.fromFreeHint(isAlbum ? 'album' : 'track')
-          : hasNoCollectibles
+        hasNoCollectibles
           ? messages.noCollectibles
+          : disabled
+          ? messages.fromFreeHint(isAlbum ? 'album' : 'track')
           : undefined
       }
     />

--- a/packages/web/src/components/edit/fields/stream-availability/collectible-gated/CollectibleGatedRadioField.tsx
+++ b/packages/web/src/components/edit/fields/stream-availability/collectible-gated/CollectibleGatedRadioField.tsx
@@ -16,12 +16,15 @@ import { CollectibleGatedFields } from './CollectibleGatedFields'
 const messages = {
   collectibleGated: 'Collectible Gated',
   noCollectibles:
-    'No Collectibles found. To enable this option, link a wallet containing a collectible.'
+    'No Collectibles found. To enable this option, link a wallet containing a collectible.',
+  fromFreeHint: (contentType: 'album' | 'track') =>
+    `You can't make a free ${contentType} premium.`
 }
 
 type CollectibleGatedRadioFieldProps = {
   isRemix: boolean
   isUpload?: boolean
+  isAlbum?: boolean
   initialStreamConditions?: AccessConditions
   isInitiallyUnlisted?: boolean
 }
@@ -29,8 +32,13 @@ type CollectibleGatedRadioFieldProps = {
 export const CollectibleGatedRadioField = (
   props: CollectibleGatedRadioFieldProps
 ) => {
-  const { isRemix, isUpload, initialStreamConditions, isInitiallyUnlisted } =
-    props
+  const {
+    isRemix,
+    isUpload,
+    isAlbum,
+    initialStreamConditions,
+    isInitiallyUnlisted
+  } = props
 
   const hasNoCollectibles = useHasNoCollectibles()
   const {
@@ -49,7 +57,6 @@ export const CollectibleGatedRadioField = (
       label={messages.collectibleGated}
       value={StreamTrackAvailabilityType.COLLECTIBLE_GATED}
       disabled={disabled}
-      hintContent={disabled ? messages.noCollectibles : undefined}
       description={
         <CollectibleGatedDescription
           hasCollectibles={!hasNoCollectibles}
@@ -57,6 +64,13 @@ export const CollectibleGatedRadioField = (
         />
       }
       checkedContent={<CollectibleGatedFields disabled={fieldsDisabled} />}
+      tooltipText={
+        disabled
+          ? messages.fromFreeHint(isAlbum ? 'album' : 'track')
+          : hasNoCollectibles
+          ? messages.noCollectibles
+          : undefined
+      }
     />
   )
 }

--- a/packages/web/src/components/edit/fields/stream-availability/usdc-purchase-gated/UsdcPurchaseGatedRadioField.tsx
+++ b/packages/web/src/components/edit/fields/stream-availability/usdc-purchase-gated/UsdcPurchaseGatedRadioField.tsx
@@ -36,7 +36,9 @@ const messagesV1 = {
 const messagesV2 = {
   usdcPurchase: 'Premium',
   usdcPurchaseSubtitle: (contentType: 'album' | 'track') =>
-    `Only fans who make a purchase can play your ${contentType}.`
+    `Only fans who make a purchase can play your ${contentType}.`,
+  fromFreeHint: (contentType: 'album' | 'track') =>
+    `You can't make a free ${contentType} premium.`
 }
 
 type UsdcPurchaseGatedRadioFieldProps = {
@@ -115,6 +117,11 @@ export const UsdcPurchaseGatedRadioField = (
           isAlbum={isAlbum}
           isUpload={isUpload}
         />
+      }
+      tooltipText={
+        disableUsdcGate
+          ? messages.fromFreeHint(isAlbum ? 'album' : 'track')
+          : undefined
       }
     />
   )

--- a/packages/web/src/components/edit/fields/visibility/VisibilityField.tsx
+++ b/packages/web/src/components/edit/fields/visibility/VisibilityField.tsx
@@ -191,7 +191,7 @@ const VisibilityMenuFields = (props: VisibilityMenuFieldsProps) => {
         label={messages.hidden}
         description={messages.hiddenDescription}
         disabled={initiallyPublic}
-        hintContent={
+        tooltipText={
           initiallyPublic ? messages.hiddenHint(entityType) : undefined
         }
       />

--- a/packages/web/src/components/edit/fields/visibility/VisibilityField.tsx
+++ b/packages/web/src/components/edit/fields/visibility/VisibilityField.tsx
@@ -201,7 +201,6 @@ const VisibilityMenuFields = (props: VisibilityMenuFieldsProps) => {
           label={messages.scheduledRelease}
           description={messages.scheduledReleaseDescription}
           checkedContent={<ReleaseDateField />}
-          disabled={initiallyPublic}
         />
       ) : null}
     </RadioGroup>

--- a/packages/web/src/components/modal-radio/ModalRadioItem.tsx
+++ b/packages/web/src/components/modal-radio/ModalRadioItem.tsx
@@ -16,6 +16,7 @@ import useMeasure from 'react-use-measure'
 import layoutStyles from 'components/layout/layout.module.css'
 
 import styles from './ModalRadioItem.module.css'
+import { Tooltip } from 'components/tooltip'
 
 type ModalRadioItemProps = {
   label: string
@@ -28,6 +29,7 @@ type ModalRadioItemProps = {
   disabled?: boolean
   icon?: ReactNode
   checkedContent?: ReactNode
+  tooltipText?: string
 }
 
 export const ModalRadioItem = (props: ModalRadioItemProps) => {
@@ -41,7 +43,8 @@ export const ModalRadioItem = (props: ModalRadioItemProps) => {
     description,
     value,
     disabled,
-    checkedContent
+    checkedContent,
+    tooltipText
   } = props
   const [isCollapsed, setIsCollapsed] = useState(true)
   const radioGroup = useContext(RadioGroupContext)
@@ -73,11 +76,13 @@ export const ModalRadioItem = (props: ModalRadioItemProps) => {
           disabled={disabled}
           inputClassName={styles.input}
         />
-        <Text className={styles.optionTitle} variant='title' size='l'>
-          {icon}
-          <span>{title ?? label}</span>
-        </Text>
-        {tag ? <Tag className={styles.tag}>{tag}</Tag> : null}
+        <Tooltip text={tooltipText} disabled={!tooltipText}>
+          <Text className={styles.optionTitle} variant='title' size='l'>
+            {icon}
+            <span>{title ?? label}</span>
+          </Text>
+          {tag ? <Tag className={styles.tag}>{tag}</Tag> : null}
+        </Tooltip>
       </div>
       {hintContent ? <Hint icon={hintIcon}>{hintContent}</Hint> : null}
       {checkedContent || description ? (

--- a/packages/web/src/components/modal-radio/ModalRadioItem.tsx
+++ b/packages/web/src/components/modal-radio/ModalRadioItem.tsx
@@ -14,9 +14,9 @@ import cn from 'classnames'
 import useMeasure from 'react-use-measure'
 
 import layoutStyles from 'components/layout/layout.module.css'
+import { Tooltip } from 'components/tooltip'
 
 import styles from './ModalRadioItem.module.css'
-import { Tooltip } from 'components/tooltip'
 
 type ModalRadioItemProps = {
   label: string

--- a/packages/web/src/components/upload/AudioQuality.tsx
+++ b/packages/web/src/components/upload/AudioQuality.tsx
@@ -6,7 +6,7 @@ const messages = {
 }
 
 const AUDIO_FILE_FORMATS_LINK =
-  'https://support.audius.co/help/What-Audio-File-Formats-Can-I-Upload-to-Audius-ab4c8'
+  'https://help.audius.co/help/What-Audio-File-Formats-Can-I-Upload-to-Audius-ab4c8'
 
 export const AudioQuality = () => {
   return (


### PR DESCRIPTION
### Description

- Copy updates across the upload/edit fields. Source of truth [in ticket description](https://linear.app/audius/issue/C-4487/update-copy-for-uploadedit-flow).
- Migrate to tooltips instead of hint boxes for disabled radio items
- Includes fix for disabling access options for public tracks.

### How Has This Been Tested?

local web