### PR TITLE
Improve mobile search state and navigation

### DIFF
--- a/packages/mobile/src/screens/app-screen/AppTabScreen.tsx
+++ b/packages/mobile/src/screens/app-screen/AppTabScreen.tsx
@@ -16,7 +16,6 @@ import type {
 import type { EventArg, NavigationState } from '@react-navigation/native'
 import type { createNativeStackNavigator } from '@react-navigation/native-stack'
 
-import { Text } from '@audius/harmony-native'
 import { useDrawer } from 'app/hooks/useDrawer'
 import { useFeatureFlag } from 'app/hooks/useRemoteConfig'
 import { AiGeneratedTracksScreen } from 'app/screens/ai-generated-tracks-screen'
@@ -35,11 +34,7 @@ import {
 } from 'app/screens/search-results-screen'
 import { SearchScreen } from 'app/screens/search-screen'
 import type { SearchParams } from 'app/screens/search-screen-v2'
-import {
-  SelectMoodScreen,
-  SelectGenreScreen,
-  SearchScreenV2
-} from 'app/screens/search-screen-v2'
+import { SearchScreenStack } from 'app/screens/search-screen-v2'
 import {
   AboutScreen,
   AccountSettingsScreen,
@@ -227,19 +222,11 @@ export const AppTabScreen = ({ baseScreen, Stack }: AppTabScreenProps) => {
         options={screenOptions}
       />
       {isSearchV2Enabled ? (
-        <Stack.Group>
-          <Stack.Screen name='Search' component={SearchScreenV2} />
-          <Stack.Screen name='SearchGenre' component={SelectGenreScreen} />
-          <Stack.Screen name='SearchMood' component={SelectMoodScreen} />
-          <Stack.Screen
-            name='SearchBpm'
-            component={() => <Text>BPM Filter Here</Text>}
-          />
-          <Stack.Screen
-            name='SearchKey'
-            component={() => <Text>Key Filter Here</Text>}
-          />
-        </Stack.Group>
+        <Stack.Screen
+          name='Search'
+          component={SearchScreenStack}
+          options={{ ...screenOptions, headerShown: false }}
+        />
       ) : (
         <Stack.Group>
           <Stack.Screen

--- a/packages/mobile/src/screens/search-screen-v2/SearchBarV2.tsx
+++ b/packages/mobile/src/screens/search-screen-v2/SearchBarV2.tsx
@@ -1,7 +1,8 @@
 import { Dimensions } from 'react-native'
 
 import { IconSearch, TextInput, TextInputSize } from '@audius/harmony-native'
-import type { TextInputProps } from '@audius/harmony-native'
+
+import { useSearchQuery } from './searchState'
 
 const searchBarWidth = Dimensions.get('window').width - 80
 
@@ -9,9 +10,8 @@ const messages = {
   label: 'Search'
 }
 
-type SeacrhBarV2Props = Partial<TextInputProps>
-
-export const SearchBarV2 = (props: SeacrhBarV2Props) => {
+export const SearchBarV2 = () => {
+  const [query, setQuery] = useSearchQuery()
   return (
     <TextInput
       startIcon={IconSearch}
@@ -19,7 +19,8 @@ export const SearchBarV2 = (props: SeacrhBarV2Props) => {
       label={messages.label}
       placeholder={messages.label}
       style={{ width: searchBarWidth }}
-      {...props}
+      value={query}
+      onChangeText={setQuery}
     />
   )
 }

--- a/packages/mobile/src/screens/search-screen-v2/SearchCategoriesAndFilters.tsx
+++ b/packages/mobile/src/screens/search-screen-v2/SearchCategoriesAndFilters.tsx
@@ -55,10 +55,10 @@ const SearchCategory = (props: SearchCategoryProps) => {
 // - IconClose looks thicker than the designs
 
 const filterInfoMap: Record<SearchFilter, { label: string; screen: string }> = {
-  genre: { label: 'Genre', screen: 'SearchGenre' },
-  mood: { label: 'Mood', screen: 'SearchMood' },
-  key: { label: 'Key', screen: 'SearchKey' },
-  bpm: { label: 'BPM', screen: 'SearchBpm' },
+  genre: { label: 'Genre', screen: 'FilterGenre' },
+  mood: { label: 'Mood', screen: 'FilterMood' },
+  key: { label: 'Key', screen: 'FilterKey' },
+  bpm: { label: 'BPM', screen: 'FilterBpm' },
   isVerified: { label: 'Verified', screen: '' },
   isPremium: { label: 'Premium', screen: '' },
   hasDownloads: { label: 'Downloadable', screen: '' }

--- a/packages/mobile/src/screens/search-screen-v2/SearchScreenV2.tsx
+++ b/packages/mobile/src/screens/search-screen-v2/SearchScreenV2.tsx
@@ -52,27 +52,6 @@ export const SearchScreenV2 = () => {
   )
 }
 
-type SearchScreenProps = {
-  Stack: any
-}
-
-export const SearchScreen = (props: SearchScreenProps) => {
-  const { Stack } = props
-  return (
-    <Stack.Group>
-      <Stack.Screen name='Search' component={SearchScreenV2} />
-    </Stack.Group>
-  )
-}
-
-export const searchScreenStack = (Stack: any) => {
-  return (
-    <Stack.Group>
-      <Stack.Screen name='Search' component={SearchScreenV2} />
-    </Stack.Group>
-  )
-}
-
 export const SearchScreenStack = () => {
   const { params = {} } = useRoute<'Search'>()
   const [query, setQuery] = useState(params.query ?? '')

--- a/packages/mobile/src/screens/search-screen-v2/SearchScreenV2.tsx
+++ b/packages/mobile/src/screens/search-screen-v2/SearchScreenV2.tsx
@@ -4,19 +4,76 @@ import type {
   SearchCategory,
   SearchFilters as SearchFiltersType
 } from '@audius/common/api'
+import { createNativeStackNavigator } from '@react-navigation/native-stack'
 
 import { Flex } from '@audius/harmony-native'
 import { Screen } from 'app/components/core'
 import { useRoute } from 'app/hooks/useRoute'
+
+import { useAppScreenOptions } from '../app-screen/useAppScreenOptions'
 
 import { RecentSearches } from './RecentSearches'
 import { SearchBarV2 } from './SearchBarV2'
 import { SearchCatalogTile } from './SearchCatalogTile'
 import { SearchCategoriesAndFilters } from './SearchCategoriesAndFilters'
 import { SearchResults } from './SearchResults'
-import { SearchContext } from './searchState'
+import { SelectGenreScreen } from './components'
+import { SelectMoodScreen } from './components/SelectMoodScreen'
+import {
+  SearchContext,
+  useSearchCategory,
+  useSearchFilters,
+  useSearchQuery
+} from './searchState'
+
+const Stack = createNativeStackNavigator()
 
 export const SearchScreenV2 = () => {
+  const [query] = useSearchQuery()
+  const [category] = useSearchCategory()
+  const [filters] = useSearchFilters()
+  const showSearchResults =
+    query ||
+    category !== 'all' ||
+    Object.values(filters).some((filter) => filter)
+
+  return (
+    <Screen topbarRight={<SearchBarV2 />} headerTitle={null} variant='white'>
+      <SearchCategoriesAndFilters />
+      {!showSearchResults ? (
+        <Flex direction='column' alignItems='center' gap='xl'>
+          <SearchCatalogTile />
+          <RecentSearches />
+        </Flex>
+      ) : (
+        <SearchResults />
+      )}
+    </Screen>
+  )
+}
+
+type SearchScreenProps = {
+  Stack: any
+}
+
+export const SearchScreen = (props: SearchScreenProps) => {
+  const { Stack } = props
+  return (
+    <Stack.Group>
+      <Stack.Screen name='Search' component={SearchScreenV2} />
+    </Stack.Group>
+  )
+}
+
+export const searchScreenStack = (Stack: any) => {
+  return (
+    <Stack.Group>
+      <Stack.Screen name='Search' component={SearchScreenV2} />
+    </Stack.Group>
+  )
+}
+
+export const SearchScreenStack = () => {
   const { params = {} } = useRoute<'Search'>()
   const [query, setQuery] = useState(params.query ?? '')
   const [category, setCategory] = useState<SearchCategory>(
@@ -26,28 +83,19 @@ export const SearchScreenV2 = () => {
     params.filters ?? {}
   )
 
-  const showSearchResults =
-    query || category || Object.values(filters).some((filter) => filter)
+  const screenOptions = useAppScreenOptions()
 
   return (
     <SearchContext.Provider
       value={{ query, setQuery, category, setCategory, filters, setFilters }}
     >
-      <Screen
-        topbarRight={<SearchBarV2 value={query} onChangeText={setQuery} />}
-        headerTitle={null}
-        variant='white'
-      >
-        <SearchCategoriesAndFilters />
-        {!showSearchResults ? (
-          <Flex direction='column' alignItems='center' gap='xl'>
-            <SearchCatalogTile />
-            <RecentSearches />
-          </Flex>
-        ) : (
-          <SearchResults />
-        )}
-      </Screen>
+      <Stack.Navigator screenOptions={screenOptions}>
+        <Stack.Screen name='SearchResults' component={SearchScreenV2} />
+        <Stack.Group screenOptions={{ presentation: 'fullScreenModal' }}>
+          <Stack.Screen name='FilterMood' component={SelectMoodScreen} />
+          <Stack.Screen name='FilterGenre' component={SelectGenreScreen} />
+        </Stack.Group>
+      </Stack.Navigator>
     </SearchContext.Provider>
   )
 }

--- a/packages/mobile/src/screens/search-screen-v2/index.ts
+++ b/packages/mobile/src/screens/search-screen-v2/index.ts
@@ -1,3 +1,3 @@
 export { SelectGenreScreen, SelectMoodScreen } from './components'
-export { SearchScreenV2 } from './SearchScreenV2'
+export { SearchScreenStack } from './SearchScreenV2'
 export type { SearchParams } from './searchParams'

--- a/packages/mobile/src/screens/search-screen-v2/searchState.ts
+++ b/packages/mobile/src/screens/search-screen-v2/searchState.ts
@@ -40,6 +40,11 @@ export const useSearchCategory = () => {
   return [category, setCategory] as const
 }
 
+export const useSearchFilters = () => {
+  const { filters, setFilters } = useContext(SearchContext)
+  return [filters, setFilters] as const
+}
+
 export const useSearchFilter = <F extends SearchFilter>(filterKey: F) => {
   const { filters, setFilters } = useContext(SearchContext)
 


### PR DESCRIPTION
### Description

Improves search state and search navigation by:
1. Creating a search navigator. This can help us isolate all the search screens together, which feels nice
2. Now that we have a navigator for search, we can wrap the whole thing in the state context, so search bar and all the filter screens have access to state 🔥 


Note im not liking the search stack in SearchScreenV2, should probably separate things, but we can figure out what feels best later.