### PR TITLE
Fix visibility field tests

### DIFF
--- a/packages/web/src/components/edit/fields/visibility/VisibilityField.test.tsx
+++ b/packages/web/src/components/edit/fields/visibility/VisibilityField.test.tsx
@@ -24,7 +24,7 @@ const renderTrackVisibilityField = (options?: { initialValues: any }) => {
     trackMetadatasIndex: 0,
     trackMetadatas: [
       {
-        is_unlisted: false,
+        is_unlisted: true,
         is_scheduled_release: false
       }
     ]
@@ -54,7 +54,9 @@ describe('VisibilityField', () => {
   })
 
   it('renders visibility field with "public" initial value', () => {
-    renderTrackVisibilityField()
+    renderTrackVisibilityField({
+      initialValues: { trackMetadatas: [{ is_unlisted: false }] }
+    })
 
     expect(
       screen.getByRole('heading', { name: 'Visibility' })


### PR DESCRIPTION
### Description

We removed the scheduled release option on tracks that are not already hidden or scheduled (because you can't set a public track to scheduled or hidden).

This broke expectations in the tests. Fixed by rendering hidden state as the default test data, and setting public manually for the one test that cares.

### How Has This Been Tested?

will only merge if passing tests