### PR TITLE
[QA-1403] Fix "Not enough signers" simulation error in "Claim All Rewards" flow

### DIFF
--- a/.changeset/curly-trainers-act.md
+++ b/.changeset/curly-trainers-act.md
@@ -1,0 +1,6 @@
+---
+'@audius/sdk': patch
+'@audius/spl': patch
+---
+
+Fix instanceof check for version mismatches of @solana/web3.js and skip preflight on evaluateAttestations

--- a/dev-tools/compose/docker-compose.discovery.prod.yml
+++ b/dev-tools/compose/docker-compose.discovery.prod.yml
@@ -12,8 +12,6 @@ services:
     deploy:
       mode: replicated
       replicas: '${DISCOVERY_PROVIDER_REPLICAS}'
-    ports:
-      - '6379:6379'
     profiles:
       - discovery
 

--- a/packages/commands/src/claim-reward.mjs
+++ b/packages/commands/src/claim-reward.mjs
@@ -34,9 +34,9 @@ program.command("claim-reward")
             console.log(chalk.yellow("Transaction Signature:"), res);
         } catch (err) {
             if ('response' in err) {
-                console.log(chalk.red('Request ID'), err.response.headers.get('X-Request-ID'))
-                console.log(chalk.red('Request URL'), err.response.url)
-                console.log(chalk.red('Response Body'), await err.response.text())
+                console.log(chalk.red('Request ID:'), err.response.headers.get('X-Request-ID'))
+                console.log(chalk.red('Request URL:'), err.response.url)
+                console.log(chalk.red('Response Body:'), await err.response.text())
             }
             program.error(err.message);
         }

--- a/packages/commands/src/claim-reward.mjs
+++ b/packages/commands/src/claim-reward.mjs
@@ -1,0 +1,45 @@
+
+import chalk from "chalk";
+import { program } from "commander";
+
+import { initializeAudiusLibs, initializeAudiusSdk } from "./utils.mjs";
+import { Utils } from '@audius/sdk'
+
+program.command("claim-reward")
+    .description("Claim a challenge reward")
+    .argument("<challengeId>", "The ID of the challenge to claim")
+    .argument("<specifier>", "The specifier of the challenge to claim")
+    .argument("<amount>", "The amount to claim", parseFloat)
+    .option("-f, --from [from]", "The account to claim from")
+    .action(async (challengeId, specifier, amount, { from }) => {
+        const audiusLibs = await initializeAudiusLibs(from)
+
+        // extract privkey and pubkey from hedgehog
+        // only works with accounts created via audius-cmd
+        const wallet = audiusLibs?.hedgehog?.getWallet()
+        const privKey = wallet?.getPrivateKeyString()
+        const pubKey = wallet?.getAddressString()
+
+        // Get hashID user id of current user
+        const userIdNumber = audiusLibs.userStateManager.getCurrentUserId()
+        const userId = Utils.encodeHashId(userIdNumber)
+
+        // init sdk with priv and pub keys as api keys and secret
+        // this enables writes via sdk
+        const audiusSdk = await initializeAudiusSdk({ apiKey: pubKey, apiSecret: privKey })
+
+        try {
+            const res = await audiusSdk.challenges.claimReward({ userId, challengeId, specifier, amount });
+            console.log(chalk.green("Successfully claimed reward"));
+            console.log(chalk.yellow("Transaction Signature:"), res);
+        } catch (err) {
+            if ('response' in err) {
+                console.log(chalk.red('Request ID'), err.response.headers.get('X-Request-ID'))
+                console.log(chalk.red('Request URL'), err.response.url)
+                console.log(chalk.red('Response Body'), await err.response.text())
+            }
+            program.error(err.message);
+        }
+
+        process.exit(0);
+    });

--- a/packages/commands/src/index.mjs
+++ b/packages/commands/src/index.mjs
@@ -28,6 +28,7 @@ import './purchase-content.mjs'
 import './route-tokens-to-user-bank.mjs'
 import './withdraw-tokens.mjs'
 import './add-manager.mjs'
+import './claim-reward.mjs'
 
 async function main() {
   program.parseAsync(process.argv)

--- a/packages/commands/src/tip-audio.mjs
+++ b/packages/commands/src/tip-audio.mjs
@@ -29,10 +29,12 @@ program.command("tip-audio")
     try {
       const res = await audiusSdk.users.sendTip({ senderUserId, receiverUserId: Utils.encodeHashId(userId), amount });
       console.log(chalk.green("Successfully tipped audio"));
-      console.log(chalk.yellow("Transaction Signature:"), tx);
+      console.log(chalk.yellow("Transaction Signature:"), res);
     } catch (err) {
-      console.log(chalk.red("Request ID:"), err.response.headers.get('x-request-id'))
-      console.log(chalk.red("Response JSON:"), await err.response.json())
+      if ('response' in err) {
+        console.log(chalk.red("Request ID:"), err.response.headers.get('x-request-id'))
+        console.log(chalk.red("Response JSON:"), await err.response.json())
+      }
       program.error(err.message);
     }
 

--- a/packages/commands/src/tip-audio.mjs
+++ b/packages/commands/src/tip-audio.mjs
@@ -1,23 +1,38 @@
-import BN from "bn.js";
 import chalk from "chalk";
 import { program } from "commander";
 
-import { parseSplWallet, initializeAudiusLibs } from "./utils.mjs";
+import { initializeAudiusLibs, initializeAudiusSdk } from "./utils.mjs";
+import { Utils } from '@audius/sdk'
 
 program.command("tip-audio")
   .description("Send a tip")
-  .argument("<account>", "The account to tip tokens to; can be a @handle, #userId, or splWallet")
-  .argument("<amount>", "The amount of tokens to tip (in wei)")
+  .argument("<userId>", "The user ID to tip tokens to")
+  .argument("<amount>", "The amount of tokens to tip (in wAUDIO)", parseFloat)
   .option("-f, --from [from]", "The account to tip from")
-  .action(async (account, amount, { from }) => {
-    const audiusLibs = await initializeAudiusLibs(from);
-    const splWallet = await parseSplWallet(account);
+  .action(async (userId, amount, { from }) => {
+    const audiusLibs = await initializeAudiusLibs(from)
+
+    // extract privkey and pubkey from hedgehog
+    // only works with accounts created via audius-cmd
+    const wallet = audiusLibs?.hedgehog?.getWallet()
+    const privKey = wallet?.getPrivateKeyString()
+    const pubKey = wallet?.getAddressString()
+
+    // Get hashID user id of current user
+    const userIdNumber = audiusLibs.userStateManager.getCurrentUserId()
+    const senderUserId = Utils.encodeHashId(userIdNumber)
+
+    // init sdk with priv and pub keys as api keys and secret
+    // this enables writes via sdk
+    const audiusSdk = await initializeAudiusSdk({ apiKey: pubKey, apiSecret: privKey })
 
     try {
-      const { res: tx } = await audiusLibs.solanaWeb3Manager.transferWAudio(splWallet, new BN(amount));
+      const res = await audiusSdk.users.sendTip({ senderUserId, receiverUserId: Utils.encodeHashId(userId), amount });
       console.log(chalk.green("Successfully tipped audio"));
       console.log(chalk.yellow("Transaction Signature:"), tx);
     } catch (err) {
+      console.log(chalk.red("Request ID:"), err.response.headers.get('x-request-id'))
+      console.log(chalk.red("Response JSON:"), await err.response.json())
       program.error(err.message);
     }
 

--- a/packages/discovery-provider/plugins/pedalboard/apps/solana-relay/package.json
+++ b/packages/discovery-provider/plugins/pedalboard/apps/solana-relay/package.json
@@ -3,8 +3,8 @@
   "version": "0.0.23",
   "private": true,
   "scripts": {
-    "start": "ts-node ./src/index.ts",
-    "dev": "ts-node-dev ./src/index.ts",
+    "start": "npx tsx ./src/index.ts",
+    "dev": "npx tsx watch ./src/index.ts",
     "test": "vitest",
     "lint": "tsc --noEmit && eslint \"src/**/*.ts*\""
   },
@@ -16,7 +16,7 @@
     "@pedalboard/basekit": "*",
     "@pedalboard/logger": "*",
     "@pedalboard/storage": "*",
-    "@solana/web3.js": "1.78.4",
+    "@solana/web3.js": "1.93.4",
     "axios": "1.6.8",
     "body-parser": "1.19.0",
     "borsh": "0.3.1",
@@ -52,8 +52,6 @@
     "esbuild-register": "3.3.2",
     "eslint": "7.32.0",
     "eslint-config-custom-server": "*",
-    "ts-node": "10.7.0",
-    "ts-node-dev": "2.0.0",
     "tsconfig": "*",
     "typescript": "4.5.3",
     "vitest": "0.34.6"

--- a/packages/discovery-provider/plugins/pedalboard/apps/solana-relay/package.json
+++ b/packages/discovery-provider/plugins/pedalboard/apps/solana-relay/package.json
@@ -3,8 +3,8 @@
   "version": "0.0.23",
   "private": true,
   "scripts": {
-    "start": "npx tsx ./src/index.ts",
-    "dev": "npx tsx watch ./src/index.ts",
+    "start": "npx tsx@4.16.0 ./src/index.ts",
+    "dev": "npx tsx@4.16.0 watch ./src/index.ts",
     "test": "vitest",
     "lint": "tsc --noEmit && eslint \"src/**/*.ts*\""
   },

--- a/packages/discovery-provider/plugins/pedalboard/apps/solana-relay/src/middleware/assertRateLimiter.test.ts
+++ b/packages/discovery-provider/plugins/pedalboard/apps/solana-relay/src/middleware/assertRateLimiter.test.ts
@@ -1,73 +1,97 @@
-import { beforeEach, describe, expect, it } from "vitest";
-import { RateLimiter } from "./rateLimiter";
-import { config } from "../config";
-import { getRedisConnection } from "../redis";
+import { beforeEach, describe, expect, it } from 'vitest'
+
+import { config } from '../config'
+import { getRedisConnection } from '../redis'
+
+import { RateLimiter } from './rateLimiter'
 
 beforeEach(async () => {
-    // run with npm run test with audius-compose up
-    config.redisUrl = "redis://0.0.0.0:6379/00"
-    const redis = await getRedisConnection()
-    let cursor = '0';
-    do {
-        for await (const key of redis.scanIterator()) {
-            if (key.startsWith('listens-rate-limit')) {
-                await redis.del(key)
-            }
-        }
-    } while (cursor !== '0')
+  // run with npm run test with audius-compose up
+  config.redisUrl = 'redis://audius-protocol-discovery-provider-redis-1/00'
+  const redis = await getRedisConnection()
+  for await (const key of redis.scanIterator()) {
+    if (key.startsWith('listens-rate-limit')) {
+      await redis.del(key)
+    }
+  }
 })
 
 describe('Rate Limiter', function () {
-    describe('Rate Limiter Rate Limits', function () {
-        it('disallows when one limit is reached', async function () {
-            const userIP = "1.2.3.4"
+  describe('Rate Limiter Rate Limits', function () {
+    it('disallows when one limit is reached', async function () {
+      const userIP = '1.2.3.4'
 
-            const hourLimitLimiter = new RateLimiter({ prefix: "listens-rate-limit-hour", hourlyLimit: 1, dailyLimit: 2, weeklyLimit: 2 })
-            await hourLimitLimiter.checkLimit(userIP)
-            const checkHour = await hourLimitLimiter.checkLimit(userIP)
-            expect(checkHour.allowed).toBe(false)
-            expect(checkHour.hourLimitReached).toBe(true)
-            expect(checkHour.dayLimitReached).toBe(false)
-            expect(checkHour.weekLimitReached).toBe(false)
+      const hourLimitLimiter = new RateLimiter({
+        prefix: 'listens-rate-limit-hour',
+        hourlyLimit: 1,
+        dailyLimit: 2,
+        weeklyLimit: 2
+      })
+      await hourLimitLimiter.checkLimit(userIP)
+      const checkHour = await hourLimitLimiter.checkLimit(userIP)
+      expect(checkHour.allowed).toBe(false)
+      expect(checkHour.hourLimitReached).toBe(true)
+      expect(checkHour.dayLimitReached).toBe(false)
+      expect(checkHour.weekLimitReached).toBe(false)
 
-            const dayLimitLimiter = new RateLimiter({ prefix: "listens-rate-limit-day", hourlyLimit: 2, dailyLimit: 1, weeklyLimit: 2 })
-            await dayLimitLimiter.checkLimit(userIP)
-            const checkDay = await dayLimitLimiter.checkLimit(userIP)
-            expect(checkDay.allowed).toBe(false)
-            expect(checkDay.hourLimitReached).toBe(false)
-            expect(checkDay.dayLimitReached).toBe(true)
-            expect(checkDay.weekLimitReached).toBe(false)
+      const dayLimitLimiter = new RateLimiter({
+        prefix: 'listens-rate-limit-day',
+        hourlyLimit: 2,
+        dailyLimit: 1,
+        weeklyLimit: 2
+      })
+      await dayLimitLimiter.checkLimit(userIP)
+      const checkDay = await dayLimitLimiter.checkLimit(userIP)
+      expect(checkDay.allowed).toBe(false)
+      expect(checkDay.hourLimitReached).toBe(false)
+      expect(checkDay.dayLimitReached).toBe(true)
+      expect(checkDay.weekLimitReached).toBe(false)
 
-            const weekLimitLimiter = new RateLimiter({ prefix: "listens-rate-limit-week", hourlyLimit: 2, dailyLimit: 2, weeklyLimit: 1 })
-            await weekLimitLimiter.checkLimit(userIP)
-            const checkWeek = await weekLimitLimiter.checkLimit(userIP)
-            expect(checkWeek.allowed).toBe(false)
-            expect(checkWeek.hourLimitReached).toBe(false)
-            expect(checkWeek.dayLimitReached).toBe(false)
-            expect(checkWeek.weekLimitReached).toBe(true)
+      const weekLimitLimiter = new RateLimiter({
+        prefix: 'listens-rate-limit-week',
+        hourlyLimit: 2,
+        dailyLimit: 2,
+        weeklyLimit: 1
+      })
+      await weekLimitLimiter.checkLimit(userIP)
+      const checkWeek = await weekLimitLimiter.checkLimit(userIP)
+      expect(checkWeek.allowed).toBe(false)
+      expect(checkWeek.hourLimitReached).toBe(false)
+      expect(checkWeek.dayLimitReached).toBe(false)
+      expect(checkWeek.weekLimitReached).toBe(true)
 
-            const allowedRateLimiter = new RateLimiter({ prefix: "listens-rate-limit-allowed", hourlyLimit: 2, dailyLimit: 2, weeklyLimit: 2 })
-            const checkAllowed = await allowedRateLimiter.checkLimit(userIP)
-            expect(checkAllowed.allowed).toBe(true)
-            expect(checkAllowed.hourLimitReached).toBe(false)
-            expect(checkAllowed.dayLimitReached).toBe(false)
-            expect(checkAllowed.weekLimitReached).toBe(false)
-        })
-        it('allows one user through while another is blocked', async function () {
-            const userIP1 = "1.2.3.4"
-            const userIP2 = "9.8.7.6"
-
-            const hourLimitLimiter = new RateLimiter({ prefix: "listens-rate-limit-hour", hourlyLimit: 3, dailyLimit: 5, weeklyLimit: 10 })
-            // reach hourly limit for user 1
-            await hourLimitLimiter.checkLimit(userIP1)
-            await hourLimitLimiter.checkLimit(userIP1)
-            await hourLimitLimiter.checkLimit(userIP1)
-            const user1check = await hourLimitLimiter.checkLimit(userIP1)
-            expect(user1check.allowed).toBe(false)
-
-            await hourLimitLimiter.checkLimit(userIP2)
-            const user2check = await hourLimitLimiter.checkLimit(userIP2)
-            expect(user2check.allowed).toBe(true)
-        })
+      const allowedRateLimiter = new RateLimiter({
+        prefix: 'listens-rate-limit-allowed',
+        hourlyLimit: 2,
+        dailyLimit: 2,
+        weeklyLimit: 2
+      })
+      const checkAllowed = await allowedRateLimiter.checkLimit(userIP)
+      expect(checkAllowed.allowed).toBe(true)
+      expect(checkAllowed.hourLimitReached).toBe(false)
+      expect(checkAllowed.dayLimitReached).toBe(false)
+      expect(checkAllowed.weekLimitReached).toBe(false)
     })
+    it('allows one user through while another is blocked', async function () {
+      const userIP1 = '1.2.3.4'
+      const userIP2 = '9.8.7.6'
+
+      const hourLimitLimiter = new RateLimiter({
+        prefix: 'listens-rate-limit-hour',
+        hourlyLimit: 3,
+        dailyLimit: 5,
+        weeklyLimit: 10
+      })
+      // reach hourly limit for user 1
+      await hourLimitLimiter.checkLimit(userIP1)
+      await hourLimitLimiter.checkLimit(userIP1)
+      await hourLimitLimiter.checkLimit(userIP1)
+      const user1check = await hourLimitLimiter.checkLimit(userIP1)
+      expect(user1check.allowed).toBe(false)
+
+      await hourLimitLimiter.checkLimit(userIP2)
+      const user2check = await hourLimitLimiter.checkLimit(userIP2)
+      expect(user2check.allowed).toBe(true)
+    })
+  })
 })

--- a/packages/discovery-provider/plugins/pedalboard/apps/solana-relay/src/middleware/errorHandler.ts
+++ b/packages/discovery-provider/plugins/pedalboard/apps/solana-relay/src/middleware/errorHandler.ts
@@ -1,37 +1,28 @@
 import { NextFunction, Request, Response } from 'express'
 
-import { InternalServerError, ResponseError } from '../errors'
+import { ResponseError } from '../errors'
 import { logger as rootLogger } from '../logger'
 
 export const errorHandlerMiddleware = (
-  err: unknown,
+  error: unknown,
   _req: Request,
   res: Response,
   _next: NextFunction
 ) => {
-  const error =
-    err instanceof ResponseError
-      ? err
-      : new InternalServerError(
-          err instanceof Error ? err.message : String(err)
-        )
+  const status = error instanceof ResponseError ? error.status : 500
   if (!res.headersSent) {
     res
-      .status(error.status)
+      .status(status)
       .set('X-Request-ID', res.locals.requestId)
       .set('Access-Control-Expose-Headers', 'X-Request-ID')
-      .send({ error: error.message })
+      .send({ error: (error as any).toString() })
   }
   // in milliseconds
   const responseTime = new Date().getTime() - res.locals.requestStartTime
   const statusCode = res.statusCode
-  const logger = res.locals.logger ?? rootLogger
-  logger.error(
-    {
-      responseTime,
-      statusCode,
-      error: error.message
-    },
-    'request completed'
-  )
+  const logger = (res.locals.logger ?? rootLogger).child({
+    responseTime,
+    statusCode
+  })
+  logger.error(error, 'request completed')
 }

--- a/packages/discovery-provider/plugins/pedalboard/apps/solana-relay/src/middleware/rateLimiter.ts
+++ b/packages/discovery-provider/plugins/pedalboard/apps/solana-relay/src/middleware/rateLimiter.ts
@@ -1,66 +1,81 @@
-import { getRedisConnection } from "../redis"
+import { getRedisConnection } from '../redis'
 
 export class RateLimiter {
-    private hourlyLimit: number
-    private dailyLimit: number
-    private weeklyLimit: number
-    private prefix: string
+  private hourlyLimit: number
+  private dailyLimit: number
+  private weeklyLimit: number
+  private prefix: string
 
-    constructor(params: { prefix: string, hourlyLimit: number, dailyLimit: number, weeklyLimit: number }) {
-        const { prefix, hourlyLimit, dailyLimit, weeklyLimit } = params
-        this.prefix = prefix
-        this.hourlyLimit = hourlyLimit
-        this.dailyLimit = dailyLimit
-        this.weeklyLimit = weeklyLimit
+  constructor(params: {
+    prefix: string
+    hourlyLimit: number
+    dailyLimit: number
+    weeklyLimit: number
+  }) {
+    const { prefix, hourlyLimit, dailyLimit, weeklyLimit } = params
+    this.prefix = prefix
+    this.hourlyLimit = hourlyLimit
+    this.dailyLimit = dailyLimit
+    this.weeklyLimit = weeklyLimit
+  }
+
+  private getRedisKey(entityKey: string, period: string): string {
+    return `${this.prefix}:${entityKey}:${period}`
+  }
+
+  private async consume(
+    entityKey: string,
+    period: string,
+    limit: number,
+    expiry: number
+  ): Promise<boolean> {
+    const key = this.getRedisKey(entityKey, period)
+    const redis = await getRedisConnection()
+    const currentCount = await redis.incr(key)
+    if (currentCount === 1) {
+      await redis.expire(key, expiry)
+    }
+    return currentCount > limit
+  }
+
+  public async checkLimit(entityKey: string): Promise<{
+    hourLimitReached: boolean
+    dayLimitReached: boolean
+    weekLimitReached: boolean
+    allowed: boolean
+  }> {
+    const promises = [
+      this.consume(entityKey, 'hour', this.hourlyLimit, 3600),
+      this.consume(entityKey, 'day', this.dailyLimit, 86400),
+      this.consume(entityKey, 'week', this.weeklyLimit, 604800)
+    ]
+
+    const [hourLimitReached, dayLimitReached, weekLimitReached] =
+      await Promise.all(promises)
+
+    const allowed = !(hourLimitReached || dayLimitReached || weekLimitReached)
+
+    return { allowed, hourLimitReached, dayLimitReached, weekLimitReached }
+  }
+
+  // set limits after instantiation, primarily for tests
+  public setLimits(limits: {
+    hourlyLimit?: number
+    dailyLimit?: number
+    weeklyLimit?: number
+  }) {
+    const { hourlyLimit, dailyLimit, weeklyLimit } = limits
+
+    if (hourlyLimit !== undefined) {
+      this.hourlyLimit = hourlyLimit
     }
 
-    private getRedisKey(entityKey: string, period: string): string {
-        return `${this.prefix}:${entityKey}:${period}`
+    if (dailyLimit !== undefined) {
+      this.dailyLimit = dailyLimit
     }
 
-    private async consume(entityKey: string, period: string, limit: number, expiry: number): Promise<boolean> {
-        const key = this.getRedisKey(entityKey, period)
-        const redis = await getRedisConnection()
-        const currentCount = await redis.incr(key)
-        if (currentCount === 1) {
-            await redis.expire(key, expiry)
-        }
-        return currentCount > limit
+    if (weeklyLimit !== undefined) {
+      this.weeklyLimit = weeklyLimit
     }
-
-    public async checkLimit(entityKey: string): Promise<{
-        hourLimitReached: boolean,
-        dayLimitReached: boolean,
-        weekLimitReached: boolean,
-        allowed: boolean
-    }> {
-        const promises = [
-            this.consume(entityKey, 'hour', this.hourlyLimit, 3600),
-            this.consume(entityKey, 'day', this.dailyLimit, 86400),
-            this.consume(entityKey, 'week', this.weeklyLimit, 604800)
-        ]
-
-        const [hourLimitReached, dayLimitReached, weekLimitReached] = await Promise.all(promises)
-
-        const allowed = !(hourLimitReached || dayLimitReached || weekLimitReached)
-
-        return { allowed, hourLimitReached, dayLimitReached, weekLimitReached }
-    }
-
-    // set limits after instantiation, primarily for tests
-    public setLimits(limits: { hourlyLimit?: number, dailyLimit?: number, weeklyLimit?: number }) {
-        const { hourlyLimit, dailyLimit, weeklyLimit } = limits
-
-        if (hourlyLimit !== undefined) {
-            this.hourlyLimit = hourlyLimit
-        }
-
-        if (dailyLimit !== undefined) {
-            this.dailyLimit = dailyLimit
-        }
-
-        if (weeklyLimit !== undefined) {
-            this.weeklyLimit = weeklyLimit
-        }
-    }
+  }
 }

--- a/packages/discovery-provider/plugins/pedalboard/apps/solana-relay/src/routes/listen/assertListenRateLimiter.test.ts
+++ b/packages/discovery-provider/plugins/pedalboard/apps/solana-relay/src/routes/listen/assertListenRateLimiter.test.ts
@@ -1,178 +1,272 @@
-import { beforeEach, describe, expect, it } from "vitest";
-import { LISTENS_RATE_LIMIT_IP_PREFIX, LISTENS_RATE_LIMIT_TRACK_PREFIX, config } from "../../config";
-import { getRedisConnection } from "../../redis";
-import { listenRouteRateLimiter, listensIpRateLimiter, listensIpTrackRateLimiter } from "./listen";
+import { beforeEach, describe, expect, it } from 'vitest'
+
+import {
+  LISTENS_RATE_LIMIT_IP_PREFIX,
+  LISTENS_RATE_LIMIT_TRACK_PREFIX,
+  config
+} from '../../config'
+import { getRedisConnection } from '../../redis'
+
+import {
+  listenRouteRateLimiter,
+  listensIpRateLimiter,
+  listensIpTrackRateLimiter
+} from './listen'
 
 beforeEach(async () => {
-    // run with npm run test with audius-compose up
-    config.redisUrl = "redis://0.0.0.0:6379/00"
-    const redis = await getRedisConnection()
-    let cursor = '0';
-    do {
-        for await (const key of redis.scanIterator()) {
-            if (key.startsWith(LISTENS_RATE_LIMIT_IP_PREFIX) || key.startsWith(LISTENS_RATE_LIMIT_TRACK_PREFIX)) {
-                await redis.del(key)
-            }
-        }
-    } while (cursor !== '0')
+  // run with npm run test with audius-compose up
+  config.redisUrl = 'redis://audius-protocol-discovery-provider-redis-1/00'
+  const redis = await getRedisConnection()
+  for await (const key of redis.scanIterator()) {
+    if (
+      key.startsWith(LISTENS_RATE_LIMIT_IP_PREFIX) ||
+      key.startsWith(LISTENS_RATE_LIMIT_TRACK_PREFIX)
+    ) {
+      await redis.del(key)
+    }
+  }
 })
 
 describe('Listens Route Rate Limiter', function () {
-    it('limits independent tracks and users by ip hourly', async function () {
-        const track1 = "track1"
-        const ipOne = "1.2.3.4"
+  it('limits independent tracks and users by ip hourly', async function () {
+    const track1 = 'track1'
+    const ipOne = '1.2.3.4'
 
-        const track2 = "track2"
-        const ipTwo = "2.3.4.5"
+    const track2 = 'track2'
+    const ipTwo = '2.3.4.5'
 
-        listensIpRateLimiter.setLimits({ hourlyLimit: 10 })
-        listensIpTrackRateLimiter.setLimits({ hourlyLimit: 40 })
+    listensIpRateLimiter.setLimits({ hourlyLimit: 10 })
+    listensIpTrackRateLimiter.setLimits({ hourlyLimit: 40 })
 
-        // ten listens for user one with track one
-        for (let i = 0; i < 9; i++) {
-            await listenRouteRateLimiter({ ip: ipOne, trackId: track1 })
-        }
-        const trackOneAllowed = await listenRouteRateLimiter({ ip: ipOne, trackId: track1 })
-        expect(trackOneAllowed.allowed).toBe(true)
-        const trackOneNotAllowed = await listenRouteRateLimiter({ ip: ipOne, trackId: track1 })
-        expect(trackOneNotAllowed.allowed).toBe(false)
-
-        // ten listens for another track with same user
-        await listenRouteRateLimiter({ ip: ipOne, trackId: track2 })
-        // user one can no longer record listens to any tracks because they're blocked at ip level
-        const trackTwoNotAllowed = await listenRouteRateLimiter({ ip: ipOne, trackId: track2 })
-        expect(trackTwoNotAllowed.allowed).toBe(false)
-
-        // ten listens for second user and track one, first user is blocked on this one
-        for (let i = 0; i < 9; i++) {
-            await listenRouteRateLimiter({ ip: ipTwo, trackId: track1 })
-        }
-        const trackOneAllowedUserTwo = await listenRouteRateLimiter({ ip: ipTwo, trackId: track1 })
-        expect(trackOneAllowedUserTwo.allowed).toBe(true)
-
-        // assert both users now blocked on both tracks
-        const trackOneNotAllowedUserTwo = await listenRouteRateLimiter({ ip: ipTwo, trackId: track1 })
-        expect(trackOneNotAllowedUserTwo.allowed).toBe(false)
-        const trackOneNotAllowedUserOne = await listenRouteRateLimiter({ ip: ipOne, trackId: track1 })
-        expect(trackOneNotAllowedUserOne.allowed).toBe(false)
-
-        // assert both users now blocked on both tracks
-        const trackTwoNotAllowedUserTwo = await listenRouteRateLimiter({ ip: ipTwo, trackId: track2 })
-        expect(trackTwoNotAllowedUserTwo.allowed).toBe(false)
-        const trackTwoNotAllowedUserOne = await listenRouteRateLimiter({ ip: ipOne, trackId: track2 })
-        expect(trackTwoNotAllowedUserOne.allowed).toBe(false)
+    // ten listens for user one with track one
+    for (let i = 0; i < 9; i++) {
+      await listenRouteRateLimiter({ ip: ipOne, trackId: track1 })
+    }
+    const trackOneAllowed = await listenRouteRateLimiter({
+      ip: ipOne,
+      trackId: track1
     })
-
-    it('limits independent tracks and users by track and ip hourly', async function () {
-        const track1 = "track1"
-        const ipOne = "1.2.3.4"
-
-        const track2 = "track2"
-        const ipTwo = "2.3.4.5"
-
-        // set config so hourly track and ip is the lowest
-        listensIpRateLimiter.setLimits({ hourlyLimit: 100 })
-        listensIpTrackRateLimiter.setLimits({ hourlyLimit: 10 })
-
-        // ten listens for user one with track one
-        for (let i = 0; i < 9; i++) {
-            await listenRouteRateLimiter({ ip: ipOne, trackId: track1 })
-        }
-        const trackOneAllowed = await listenRouteRateLimiter({ ip: ipOne, trackId: track1 })
-        expect(trackOneAllowed.allowed).toBe(true)
-        const trackOneNotAllowed = await listenRouteRateLimiter({ ip: ipOne, trackId: track1 })
-        expect(trackOneNotAllowed.allowed).toBe(false)
-
-        // ten listens for another track with same user
-        for (let i = 0; i < 9; i++) {
-            await listenRouteRateLimiter({ ip: ipOne, trackId: track2 })
-        }
-        const trackTwoAllowed = await listenRouteRateLimiter({ ip: ipOne, trackId: track2 })
-        expect(trackTwoAllowed.allowed).toBe(true)
-        const trackTwoNotAllowed = await listenRouteRateLimiter({ ip: ipOne, trackId: track2 })
-        expect(trackTwoNotAllowed.allowed).toBe(false)
-
-        // ten listens for second user and track one, first user is blocked on this one
-        for (let i = 0; i < 9; i++) {
-            await listenRouteRateLimiter({ ip: ipTwo, trackId: track1 })
-        }
-
-        const trackOneAllowedUserTwo = await listenRouteRateLimiter({ ip: ipTwo, trackId: track1 })
-        expect(trackOneAllowedUserTwo.allowed).toBe(true)
-
-        // assert both users now blocked on both tracks
-        const trackOneNotAllowedUserTwo = await listenRouteRateLimiter({ ip: ipTwo, trackId: track1 })
-        expect(trackOneNotAllowedUserTwo.allowed).toBe(false)
-        const trackOneNotAllowedUserOne = await listenRouteRateLimiter({ ip: ipOne, trackId: track1 })
-        expect(trackOneNotAllowedUserOne.allowed).toBe(false)
-
-        // ten listens for second track from second user
-        for (let i = 0; i < 9; i++) {
-            await listenRouteRateLimiter({ ip: ipTwo, trackId: track2 })
-        }
-        const trackTwoAllowedUserTwo = await listenRouteRateLimiter({ ip: ipTwo, trackId: track2 })
-        expect(trackTwoAllowedUserTwo.allowed).toBe(true)
-
-        // assert both users now blocked on both tracks
-        const trackTwoNotAllowedUserTwo = await listenRouteRateLimiter({ ip: ipTwo, trackId: track2 })
-        expect(trackTwoNotAllowedUserTwo.allowed).toBe(false)
-        const trackTwoNotAllowedUserOne = await listenRouteRateLimiter({ ip: ipOne, trackId: track2 })
-        expect(trackTwoNotAllowedUserOne.allowed).toBe(false)
+    expect(trackOneAllowed.allowed).toBe(true)
+    const trackOneNotAllowed = await listenRouteRateLimiter({
+      ip: ipOne,
+      trackId: track1
     })
+    expect(trackOneNotAllowed.allowed).toBe(false)
 
-    it('limits independent tracks and users by track and ip weekly', async function () {
-        const track1 = "track1"
-        const ipOne = "1.2.3.4"
-
-        const track2 = "track2"
-        const ipTwo = "2.3.4.5"
-
-        // set config so weekly track and ip is the lowest
-        listensIpRateLimiter.setLimits({ hourlyLimit: 100 })
-        listensIpTrackRateLimiter.setLimits({ hourlyLimit: 100, weeklyLimit: 10 })
-
-        // ten listens for user one with track one
-        for (let i = 0; i < 9; i++) {
-            await listenRouteRateLimiter({ ip: ipOne, trackId: track1 })
-        }
-        const trackOneAllowed = await listenRouteRateLimiter({ ip: ipOne, trackId: track1 })
-        expect(trackOneAllowed.allowed).toBe(true)
-        const trackOneNotAllowed = await listenRouteRateLimiter({ ip: ipOne, trackId: track1 })
-        expect(trackOneNotAllowed.allowed).toBe(false)
-
-        // ten listens for another track with same user
-        for (let i = 0; i < 9; i++) {
-            await listenRouteRateLimiter({ ip: ipOne, trackId: track2 })
-        }
-        const trackTwoAllowed = await listenRouteRateLimiter({ ip: ipOne, trackId: track2 })
-        expect(trackTwoAllowed.allowed).toBe(true)
-        const trackTwoNotAllowed = await listenRouteRateLimiter({ ip: ipOne, trackId: track2 })
-        expect(trackTwoNotAllowed.allowed).toBe(false)
-
-        // ten listens for second user and track one, first user is blocked on this one
-        for (let i = 0; i < 9; i++) {
-            await listenRouteRateLimiter({ ip: ipTwo, trackId: track1 })
-        }
-        const trackOneAllowedUserTwo = await listenRouteRateLimiter({ ip: ipTwo, trackId: track1 })
-        expect(trackOneAllowedUserTwo.allowed).toBe(true)
-
-        // assert both users now blocked on both tracks
-        const trackOneNotAllowedUserTwo = await listenRouteRateLimiter({ ip: ipTwo, trackId: track1 })
-        expect(trackOneNotAllowedUserTwo.allowed).toBe(false)
-        const trackOneNotAllowedUserOne = await listenRouteRateLimiter({ ip: ipOne, trackId: track1 })
-        expect(trackOneNotAllowedUserOne.allowed).toBe(false)
-
-        // ten listens for second track from second user
-        for (let i = 0; i < 9; i++) {
-            await listenRouteRateLimiter({ ip: ipTwo, trackId: track2 })
-        }
-        const trackTwoAllowedUserTwo = await listenRouteRateLimiter({ ip: ipTwo, trackId: track2 })
-        expect(trackTwoAllowedUserTwo.allowed).toBe(true)
-
-        // assert both users now blocked on both tracks
-        const trackTwoNotAllowedUserTwo = await listenRouteRateLimiter({ ip: ipTwo, trackId: track2 })
-        expect(trackTwoNotAllowedUserTwo.allowed).toBe(false)
-        const trackTwoNotAllowedUserOne = await listenRouteRateLimiter({ ip: ipOne, trackId: track2 })
-        expect(trackTwoNotAllowedUserOne.allowed).toBe(false)
+    // ten listens for another track with same user
+    await listenRouteRateLimiter({ ip: ipOne, trackId: track2 })
+    // user one can no longer record listens to any tracks because they're blocked at ip level
+    const trackTwoNotAllowed = await listenRouteRateLimiter({
+      ip: ipOne,
+      trackId: track2
     })
+    expect(trackTwoNotAllowed.allowed).toBe(false)
+
+    // ten listens for second user and track one, first user is blocked on this one
+    for (let i = 0; i < 9; i++) {
+      await listenRouteRateLimiter({ ip: ipTwo, trackId: track1 })
+    }
+    const trackOneAllowedUserTwo = await listenRouteRateLimiter({
+      ip: ipTwo,
+      trackId: track1
+    })
+    expect(trackOneAllowedUserTwo.allowed).toBe(true)
+
+    // assert both users now blocked on both tracks
+    const trackOneNotAllowedUserTwo = await listenRouteRateLimiter({
+      ip: ipTwo,
+      trackId: track1
+    })
+    expect(trackOneNotAllowedUserTwo.allowed).toBe(false)
+    const trackOneNotAllowedUserOne = await listenRouteRateLimiter({
+      ip: ipOne,
+      trackId: track1
+    })
+    expect(trackOneNotAllowedUserOne.allowed).toBe(false)
+
+    // assert both users now blocked on both tracks
+    const trackTwoNotAllowedUserTwo = await listenRouteRateLimiter({
+      ip: ipTwo,
+      trackId: track2
+    })
+    expect(trackTwoNotAllowedUserTwo.allowed).toBe(false)
+    const trackTwoNotAllowedUserOne = await listenRouteRateLimiter({
+      ip: ipOne,
+      trackId: track2
+    })
+    expect(trackTwoNotAllowedUserOne.allowed).toBe(false)
+  })
+
+  it('limits independent tracks and users by track and ip hourly', async function () {
+    const track1 = 'track1'
+    const ipOne = '1.2.3.4'
+
+    const track2 = 'track2'
+    const ipTwo = '2.3.4.5'
+
+    // set config so hourly track and ip is the lowest
+    listensIpRateLimiter.setLimits({ hourlyLimit: 100 })
+    listensIpTrackRateLimiter.setLimits({ hourlyLimit: 10 })
+
+    // ten listens for user one with track one
+    for (let i = 0; i < 9; i++) {
+      await listenRouteRateLimiter({ ip: ipOne, trackId: track1 })
+    }
+    const trackOneAllowed = await listenRouteRateLimiter({
+      ip: ipOne,
+      trackId: track1
+    })
+    expect(trackOneAllowed.allowed).toBe(true)
+    const trackOneNotAllowed = await listenRouteRateLimiter({
+      ip: ipOne,
+      trackId: track1
+    })
+    expect(trackOneNotAllowed.allowed).toBe(false)
+
+    // ten listens for another track with same user
+    for (let i = 0; i < 9; i++) {
+      await listenRouteRateLimiter({ ip: ipOne, trackId: track2 })
+    }
+    const trackTwoAllowed = await listenRouteRateLimiter({
+      ip: ipOne,
+      trackId: track2
+    })
+    expect(trackTwoAllowed.allowed).toBe(true)
+    const trackTwoNotAllowed = await listenRouteRateLimiter({
+      ip: ipOne,
+      trackId: track2
+    })
+    expect(trackTwoNotAllowed.allowed).toBe(false)
+
+    // ten listens for second user and track one, first user is blocked on this one
+    for (let i = 0; i < 9; i++) {
+      await listenRouteRateLimiter({ ip: ipTwo, trackId: track1 })
+    }
+
+    const trackOneAllowedUserTwo = await listenRouteRateLimiter({
+      ip: ipTwo,
+      trackId: track1
+    })
+    expect(trackOneAllowedUserTwo.allowed).toBe(true)
+
+    // assert both users now blocked on both tracks
+    const trackOneNotAllowedUserTwo = await listenRouteRateLimiter({
+      ip: ipTwo,
+      trackId: track1
+    })
+    expect(trackOneNotAllowedUserTwo.allowed).toBe(false)
+    const trackOneNotAllowedUserOne = await listenRouteRateLimiter({
+      ip: ipOne,
+      trackId: track1
+    })
+    expect(trackOneNotAllowedUserOne.allowed).toBe(false)
+
+    // ten listens for second track from second user
+    for (let i = 0; i < 9; i++) {
+      await listenRouteRateLimiter({ ip: ipTwo, trackId: track2 })
+    }
+    const trackTwoAllowedUserTwo = await listenRouteRateLimiter({
+      ip: ipTwo,
+      trackId: track2
+    })
+    expect(trackTwoAllowedUserTwo.allowed).toBe(true)
+
+    // assert both users now blocked on both tracks
+    const trackTwoNotAllowedUserTwo = await listenRouteRateLimiter({
+      ip: ipTwo,
+      trackId: track2
+    })
+    expect(trackTwoNotAllowedUserTwo.allowed).toBe(false)
+    const trackTwoNotAllowedUserOne = await listenRouteRateLimiter({
+      ip: ipOne,
+      trackId: track2
+    })
+    expect(trackTwoNotAllowedUserOne.allowed).toBe(false)
+  })
+
+  it('limits independent tracks and users by track and ip weekly', async function () {
+    const track1 = 'track1'
+    const ipOne = '1.2.3.4'
+
+    const track2 = 'track2'
+    const ipTwo = '2.3.4.5'
+
+    // set config so weekly track and ip is the lowest
+    listensIpRateLimiter.setLimits({ hourlyLimit: 100 })
+    listensIpTrackRateLimiter.setLimits({ hourlyLimit: 100, weeklyLimit: 10 })
+
+    // ten listens for user one with track one
+    for (let i = 0; i < 9; i++) {
+      await listenRouteRateLimiter({ ip: ipOne, trackId: track1 })
+    }
+    const trackOneAllowed = await listenRouteRateLimiter({
+      ip: ipOne,
+      trackId: track1
+    })
+    expect(trackOneAllowed.allowed).toBe(true)
+    const trackOneNotAllowed = await listenRouteRateLimiter({
+      ip: ipOne,
+      trackId: track1
+    })
+    expect(trackOneNotAllowed.allowed).toBe(false)
+
+    // ten listens for another track with same user
+    for (let i = 0; i < 9; i++) {
+      await listenRouteRateLimiter({ ip: ipOne, trackId: track2 })
+    }
+    const trackTwoAllowed = await listenRouteRateLimiter({
+      ip: ipOne,
+      trackId: track2
+    })
+    expect(trackTwoAllowed.allowed).toBe(true)
+    const trackTwoNotAllowed = await listenRouteRateLimiter({
+      ip: ipOne,
+      trackId: track2
+    })
+    expect(trackTwoNotAllowed.allowed).toBe(false)
+
+    // ten listens for second user and track one, first user is blocked on this one
+    for (let i = 0; i < 9; i++) {
+      await listenRouteRateLimiter({ ip: ipTwo, trackId: track1 })
+    }
+    const trackOneAllowedUserTwo = await listenRouteRateLimiter({
+      ip: ipTwo,
+      trackId: track1
+    })
+    expect(trackOneAllowedUserTwo.allowed).toBe(true)
+
+    // assert both users now blocked on both tracks
+    const trackOneNotAllowedUserTwo = await listenRouteRateLimiter({
+      ip: ipTwo,
+      trackId: track1
+    })
+    expect(trackOneNotAllowedUserTwo.allowed).toBe(false)
+    const trackOneNotAllowedUserOne = await listenRouteRateLimiter({
+      ip: ipOne,
+      trackId: track1
+    })
+    expect(trackOneNotAllowedUserOne.allowed).toBe(false)
+
+    // ten listens for second track from second user
+    for (let i = 0; i < 9; i++) {
+      await listenRouteRateLimiter({ ip: ipTwo, trackId: track2 })
+    }
+    const trackTwoAllowedUserTwo = await listenRouteRateLimiter({
+      ip: ipTwo,
+      trackId: track2
+    })
+    expect(trackTwoAllowedUserTwo.allowed).toBe(true)
+
+    // assert both users now blocked on both tracks
+    const trackTwoNotAllowedUserTwo = await listenRouteRateLimiter({
+      ip: ipTwo,
+      trackId: track2
+    })
+    expect(trackTwoNotAllowedUserTwo.allowed).toBe(false)
+    const trackTwoNotAllowedUserOne = await listenRouteRateLimiter({
+      ip: ipOne,
+      trackId: track2
+    })
+    expect(trackTwoNotAllowedUserOne.allowed).toBe(false)
+  })
 })

--- a/packages/discovery-provider/plugins/pedalboard/apps/solana-relay/src/routes/relay/assertRelayAllowedInstructions.ts
+++ b/packages/discovery-provider/plugins/pedalboard/apps/solana-relay/src/routes/relay/assertRelayAllowedInstructions.ts
@@ -367,13 +367,8 @@ const assertValidSecp256k1ProgramInstruction = (
   instructionIndex: number,
   instruction: TransactionInstruction
 ) => {
-  try {
-    if (
-      !Secp256k1Program.verifySignature(Secp256k1Program.decode(instruction))
-    ) {
-      throw new Error('Signer does not match')
-    }
-  } catch (e) {
+  const decoded = Secp256k1Program.decode(instruction)
+  if (!Secp256k1Program.verifySignature(decoded)) {
     throw new InvalidRelayInstructionError(
       instructionIndex,
       'Invalid Secp256k1Program instruction'

--- a/packages/discovery-provider/plugins/pedalboard/apps/solana-relay/src/routes/relay/relay.ts
+++ b/packages/discovery-provider/plugins/pedalboard/apps/solana-relay/src/routes/relay/relay.ts
@@ -112,8 +112,7 @@ export const relay = async (
       })
     } catch (e) {
       if (e instanceof InvalidRelayInstructionError) {
-        res.locals.logger.error(e.toString())
-        throw new BadRequestError('Invalid relay instructions')
+        throw new BadRequestError('Invalid relay instructions', { cause: e })
       } else {
         throw e
       }

--- a/packages/discovery-provider/plugins/pedalboard/apps/solana-relay/tsconfig.json
+++ b/packages/discovery-provider/plugins/pedalboard/apps/solana-relay/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
-    "lib": ["es2021"],
-    "module": "CommonJS",
+    "lib": ["es2022"],
+    "module": "es2022",
     "outDir": "./dist",
     "rootDir": "./src"
   },

--- a/packages/libs/src/sdk/api/challenges/ChallengesApi.ts
+++ b/packages/libs/src/sdk/api/challenges/ChallengesApi.ts
@@ -174,8 +174,7 @@ export class ChallengesApi extends BaseAPI {
 
     logger.debug('Confirming all attestation submissions...')
     await this.rewardManager.confirmAllTransactions(
-      attestationTransactionSignatures,
-      'finalized' // for some reason, only works when finalized...
+      attestationTransactionSignatures
     )
 
     logger.debug('Disbursing claim...')
@@ -350,6 +349,10 @@ export class ChallengesApi extends BaseAPI {
     const transaction = await this.rewardManager.buildTransaction({
       instructions: [instruction]
     })
-    return await this.rewardManager.sendTransaction(transaction)
+    // Skip preflight since we likely just submitted the attestations and
+    // the chosen RPC's state might not yet reflect that
+    return await this.rewardManager.sendTransaction(transaction, {
+      skipPreflight: true
+    })
   }
 }

--- a/packages/libs/src/sdk/services/Solana/SolanaRelayWalletAdapter.ts
+++ b/packages/libs/src/sdk/services/Solana/SolanaRelayWalletAdapter.ts
@@ -1,10 +1,11 @@
 import type {
+  SendTransactionOptions,
   SupportedTransactionVersions,
   TransactionOrVersionedTransaction,
   WalletName,
   WalletReadyState
 } from '@solana/wallet-adapter-base'
-import type { PublicKey } from '@solana/web3.js'
+import type { Connection, PublicKey } from '@solana/web3.js'
 
 import type { SolanaRelay } from './SolanaRelay'
 import type { SolanaWalletAdapter } from './types'
@@ -83,9 +84,14 @@ export class SolanaRelayWalletAdapter implements SolanaWalletAdapter {
   public async sendTransaction(
     transaction: TransactionOrVersionedTransaction<
       this['supportedTransactionVersions']
-    >
+    >,
+    _connection?: Connection,
+    sendOptions?: SendTransactionOptions
   ) {
-    const { signature } = await this.solanaRelay.relay({ transaction })
+    const { signature } = await this.solanaRelay.relay({
+      transaction,
+      sendOptions
+    })
     return signature
   }
 }

--- a/packages/spl/src/secp256k1/Secp256k1Program.ts
+++ b/packages/spl/src/secp256k1/Secp256k1Program.ts
@@ -53,9 +53,7 @@ export class Secp256k1Program extends BaseSecp256k1Program {
    */
   static decode(instructionOrData: TransactionInstruction | Uint8Array) {
     const data =
-      instructionOrData instanceof TransactionInstruction
-        ? instructionOrData.data
-        : instructionOrData
+      'data' in instructionOrData ? instructionOrData.data : instructionOrData
     const decoded = SECP256K1_INSTRUCTION_LAYOUT.decode(data)
     const message = data.subarray(
       decoded.messageDataOffset,


### PR DESCRIPTION
### Description

tl;dr -

- Makes `evaluateAttestations` skip preflight
- Makes `solana-relay` logging and error handling better
- Changes target of `solana-relay` to ES2022
- Changes runtime of `solana-relay` to use `tsx`
- Adds `audius-cmd claim-reward`
- Changes `audius-cmd tip-audio` to use SDK
- Makes `@audius/spl`'s `Secp256k1Program` less brittle when verifying `TransactionInstruction` signatures
- Changes the way `solana-relay` tests should be run (should be `docker exec -it audius-protocol-solana-relay-1 npm run test` if we want connections to Redis)


When claiming rewards, one of the common errors is "Custom error 0x3" which corresponds to "Not enough signers", meaning the 'verified messages' account doesn't have all the required attestations (3 DN and 1 AAO on prod). Notably, this error comes from simulation. What I believe is happening is the same thing that plagues us everywhere else - we expect the state the simulation is run on to reflect a transaction we just confirmed (in this case, not only confirmed but _finalized_). Unfortunately, this isn't always the case - especially when we run the simulation on a potentially different RPC than the one we confirmed on.

Instead, this PR ensures that the `evaluateAttestations` instruction runs without a preflight simulation check. **This is the main solve of the PR**, the rest is just logging, error handling and other things to help debug the next one of these

Additionally, this error was hard to debug due to a number of factors about the logging in `solana-relay`. I changed the error handler to log the error like `pino` expects, and to use `cause` for `InvalidInstructionError` => `BadRequestError`. In order to use `cause` in TS, I had to update to ES2022. Unfortunately that isn't supported by the version of Typescript used by `ts-node` it appears, so I just swapped it out for `tsx`. But `tsx` uses `esbuild` under the hood, which requires some native code, and we dev on macs and then put the code in a linux docker container, so we were getting the wrong deps. Thus I swapped out installing `tsx` locally with running `npx tsx` instead.

Now we also get logs from simulation failures, so we can not only see the custom error code but the human-readable translation as well:

example audius-cmd client response:
```sh
❯ audius-cmd tip-audio 325911193 1
bigint: Failed to load bindings, pure JS will be used (try npm run rebuild?)
[audius-sdk][discovery-node-selector] Selecting new discovery node...
[audius-sdk][discovery-node-selector] health_check http://audius-protocol-discovery-provider-1 healthy
[audius-sdk][discovery-node-selector] Refreshed service list with 3 nodes.
[audius-sdk][storage-node-selector] Updating list of available content nodes
[audius-sdk][discovery-node-selector] Selected discprov http://audius-protocol-discovery-provider-1 [
  { stage: 'Get All Services', val: [ [Object] ] },
  { stage: 'Filter Out Known Unhealthy', val: [ [Object] ] },
  { stage: 'Get Selection Round', val: [ [Object] ] },
  {
    stage: 'Made A Selection',
    val: 'http://audius-protocol-discovery-provider-1'
  }
] { attemptedServicesCount: 1 }
[audius-sdk][storage-node-selector] Updating list of available content nodes
Request ID: 3fe78b40-1d51-42c8-ab0c-efebf9635ea9
Response JSON: {
  error: 'Error: Simulation failed. \n' +
    'Message: {"InstructionError":[1,"InsufficientFunds"]}. \n' +
    'Logs: \n' +
    '[\n' +
    '  "Program testHKV1B56fbvop4w6f2cTGEub9dRQ2Euta5VmqdX9 invoke [1]",\n' +
    '  "Program log: Instruction: Transfer",\n' +
    '  "Program 11111111111111111111111111111111 invoke [2]",\n' +
    '  "Program 11111111111111111111111111111111 success",\n' +
    '  "Program log: Error: InsufficientFunds",\n' +
    '  "Program testHKV1B56fbvop4w6f2cTGEub9dRQ2Euta5VmqdX9 consumed 23233 of 1400000 compute units",\n' +
    '  "Program testHKV1B56fbvop4w6f2cTGEub9dRQ2Euta5VmqdX9 failed: insufficient funds for instruction"\n' +
    ']. \n' +
    'Catch the `SendTransactionError` and call `getLogs()` on it for full details.'
}
Response returned an error code
```

example log in solana-relay:
```sh
{
  "level": 50,
  "time": "2024-06-30T08:18:18.858Z",
  "name": "solana-relay",
  "requestId": "3fe78b40-1d51-42c8-ab0c-efebf9635ea9",
  "path": "/solana/relay",
  "method": "POST",
  "responseTime": 84,
  "statusCode": 500,
  "err": {
    "type": "SendTransactionError",
    "message": "Simulation failed. \nMessage: {\"InstructionError\":[1,\"InsufficientFunds\"]}. \nLogs: \n[\n  \"Program testHKV1B56fbvop4w6f2cTGEub9dRQ2Euta5VmqdX9 invoke [1]\",\n  \"Program log: Instruction: Transfer\",\n  \"Program 11111111111111111111111111111111 invoke [2]\",\n  \"Program 11111111111111111111111111111111 success\",\n  \"Program log: Error: InsufficientFunds\",\n  \"Program testHKV1B56fbvop4w6f2cTGEub9dRQ2Euta5VmqdX9 consumed 23233 of 1400000 compute units\",\n  \"Program testHKV1B56fbvop4w6f2cTGEub9dRQ2Euta5VmqdX9 failed: insufficient funds for instruction\"\n]. \nCatch the `SendTransactionError` and call `getLogs()` on it for full details.",
    "stack": "Error: Simulation failed. \nMessage: {\"InstructionError\":[1,\"InsufficientFunds\"]}. \nLogs: \n[\n  \"Program testHKV1B56fbvop4w6f2cTGEub9dRQ2Euta5VmqdX9 invoke [1]\",\n  \"Program log: Instruction: Transfer\",\n  \"Program 11111111111111111111111111111111 invoke [2]\",\n  \"Program 11111111111111111111111111111111 success\",\n  \"Program log: Error: InsufficientFunds\",\n  \"Program testHKV1B56fbvop4w6f2cTGEub9dRQ2Euta5VmqdX9 consumed 23233 of 1400000 compute units\",\n  \"Program testHKV1B56fbvop4w6f2cTGEub9dRQ2Euta5VmqdX9 failed: insufficient funds for instruction\"\n]. \nCatch the `SendTransactionError` and call `getLogs()` on it for full details.\n    at sendTransactionWithRetries (/app/packages/discovery-provider/plugins/pedalboard/apps/solana-relay/src/utils/transaction.ts:114:15)\n    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)\n    at relay (/app/packages/discovery-provider/plugins/pedalboard/apps/solana-relay/src/routes/relay/relay.ts:143:5)",
    "signature": "tU3CeEVAhCPhSydgksnWi9ZhAkajcinde5aioAGwsS4EVqz8S3o1Bb7j5V9Li1h5cDHPKijgwc6Uok8vtYdzDt5",
    "transactionMessage": "{\"InstructionError\":[1,\"InsufficientFunds\"]}",
    "transactionLogs": [
      "Program testHKV1B56fbvop4w6f2cTGEub9dRQ2Euta5VmqdX9 invoke [1]",
      "Program log: Instruction: Transfer",
      "Program 11111111111111111111111111111111 invoke [2]",
      "Program 11111111111111111111111111111111 success",
      "Program log: Error: InsufficientFunds",
      "Program testHKV1B56fbvop4w6f2cTGEub9dRQ2Euta5VmqdX9 consumed 23233 of 1400000 compute units",
      "Program testHKV1B56fbvop4w6f2cTGEub9dRQ2Euta5VmqdX9 failed: insufficient funds for instruction"
    ]
  },
  "msg": "request completed"
}

```

I wanted to keep this looking the same as what you would get using `@solana/web3.js`and saw their type `SendTransactionError` and reached for it before realizing it was in a new version of `@solana/web3.js` we weren't using. I researched the changelog and it looked safe, so I upgraded it for `solana-relay`. I then realized (after changing the way errors are thrown from signature verification failure of Secp256k1 instructions) due to the version mismatch between `@audius/spl`'s `@solana/web3.js` and `solana-relay`'s, we weren't getting `instanceof TransactionInstruction` to return true, which seems fairly brittle so I changed that check to check for `.data` field instead. Additionally, Typescript seemed confused about which version of `@solana/web3.js` I was using and would Typerror, so I added `@ts-ignore` to the usages from the new version... though we should fix...

Lastly, there was a bug in the way we were doing the docker-compose config for the DN Redis containers, in that we attempted to expose multiple replicas to the same port on the host. This doesn't work, and instead we should just run the tests within the `solana-relay` container or remove the dep on the other container from the tests. Also autoformatted those test files to boot.

### How Has This Been Tested?

Tested using `audius-cmd` locally with 3 local DNs and AAO. I reproed the error case locally before the changes but did not repro after the changes