### PR TITLE
[QA-1412] Show play button and hide stats on smart collections

### DIFF
--- a/packages/mobile/src/screens/collection-screen/CollectionScreenDetailsTile.tsx
+++ b/packages/mobile/src/screens/collection-screen/CollectionScreenDetailsTile.tsx
@@ -276,7 +276,9 @@ export const CollectionScreenDetailsTile = ({
       : !areAllTracksDeleted && (isQueued || (trackCount > 0 && !!firstTrack))
 
   const shouldShowPlay =
-    (isPlayable && hasStreamAccess) || doesUserHaveAccessToAnyTrack
+    !numericCollectionId ||
+    (isPlayable && hasStreamAccess) ||
+    doesUserHaveAccessToAnyTrack
   const shouldShowPreview =
     isUSDCPurchaseGated && !hasStreamAccess && !shouldShowPlay
 
@@ -494,7 +496,7 @@ export const CollectionScreenDetailsTile = ({
             contentType={PurchaseableContentType.ALBUM}
           />
         ) : null}
-        {!isPublished ? null : (
+        {isPublished && numericCollectionId ? (
           <DetailsTileStats
             playCount={playCount}
             hidePlayCount={hidePlayCount}
@@ -505,7 +507,7 @@ export const CollectionScreenDetailsTile = ({
             onPressFavorites={onPressFavorites}
             onPressReposts={onPressReposts}
           />
-        )}
+        ) : null}
         {description ? (
           <Box w='100%'>
             <UserGeneratedText


### PR DESCRIPTION
### Description

- Counting stats are not relevant for smart collections, so we will hide them
- Play button was missing on smart collections

### How Has This Been Tested?

![Screenshot 2024-07-01 at 11 44 15 AM](https://github.com/AudiusProject/audius-protocol/assets/2358254/6854c6f3-2ad7-4162-8e2f-cd232196a961)
