### PR TITLE
[QA-1414] Force fetch playlist on navigate from playlist tile

### DIFF
--- a/packages/web/src/components/track/desktop/ConnectedPlaylistTile.tsx
+++ b/packages/web/src/components/track/desktop/ConnectedPlaylistTile.tsx
@@ -33,6 +33,7 @@ import {
 import { Text, IconKebabHorizontal } from '@audius/harmony'
 import cn from 'classnames'
 import { push as pushRoute } from 'connected-react-router'
+import { LocationState } from 'history'
 import { range } from 'lodash'
 import { connect } from 'react-redux'
 import { Dispatch } from 'redux'
@@ -65,7 +66,6 @@ import PlaylistTile from './PlaylistTile'
 import TrackListItem from './TrackListItem'
 import Stats from './stats/Stats'
 import { Flavor } from './stats/StatsText'
-import { LocationState } from 'history'
 const { getUid, getBuffering, getPlaying } = playerSelectors
 const { requestOpen: requestOpenShareModal } = shareModalUIActions
 const { getUserFromCollection } = cacheUsersSelectors

--- a/packages/web/src/components/track/desktop/ConnectedPlaylistTile.tsx
+++ b/packages/web/src/components/track/desktop/ConnectedPlaylistTile.tsx
@@ -65,6 +65,7 @@ import PlaylistTile from './PlaylistTile'
 import TrackListItem from './TrackListItem'
 import Stats from './stats/Stats'
 import { Flavor } from './stats/StatsText'
+import { LocationState } from 'history'
 const { getUid, getBuffering, getPlaying } = playerSelectors
 const { requestOpen: requestOpenShareModal } = shareModalUIActions
 const { getUserFromCollection } = cacheUsersSelectors
@@ -245,7 +246,7 @@ const ConnectedPlaylistTile = ({
   const onClickTitle = useCallback(
     (e: MouseEvent) => {
       e.stopPropagation()
-      goToRoute(href)
+      goToRoute(href, { forceFetch: true })
     },
     [goToRoute, href]
   )
@@ -556,7 +557,8 @@ function mapStateToProps(state: AppState, ownProps: OwnProps) {
 
 function mapDispatchToProps(dispatch: Dispatch) {
   return {
-    goToRoute: (route: string) => dispatch(pushRoute(route)),
+    goToRoute: (route: string, state?: LocationState) =>
+      dispatch(pushRoute(route, state)),
     record: (event: TrackEvent) => dispatch(event),
     shareCollection: (id: ID) =>
       dispatch(


### PR DESCRIPTION
### Description

When navigating to a collection detail page after the collection was initially loaded as a feed tile, the tracks not shown on the tile will never load. The playlist lineup shows only the first 5 tracks (those displayed on the tile preview). This is because we cache the incomplete copy of the tracks list and hit the cache when rendering the details page.

This solution (always force fetch when navigating from a collection tile) is a bit heavy-handed. Curious if anyone can think of a more elegant solution, but this works.

The cost incurred is only when navigating from a playlist tile, and is only extra cost when that playlist has already been fully loaded in. Other solutions include:
- We could do a check for length of the loaded lineup vs the reported tracks list length
- We could refuse to add partial metadata to the cache, or otherwise mark it as incomplete
- We could add logic to the lineup to know that it should expect more tracks here

### How Has This Been Tested?

Playlist was previously only loading the first 5 tracks (those loaded in the playlist tile preview). The rest of the tracks wouldn't load. With this change, all 24 tracks load into the lineup.