### PR TITLE
Simplify legacy audio analysis queue code.

### DIFF
--- a/mediorum/server/serve_audio_analysis.go
+++ b/mediorum/server/serve_audio_analysis.go
@@ -1,8 +1,6 @@
 package server
 
 import (
-	"time"
-
 	"github.com/labstack/echo/v4"
 )
 
@@ -28,46 +26,6 @@ func (ss *MediorumServer) analyzeUpload(c echo.Context) error {
 	// }
 
 	return c.JSON(200, upload)
-}
-
-// triggers audio analysis on a legacy blob if a previous analysis failed or does not exist.
-// does nothing and returns the analysis results if analysis previously succeeded.
-func (ss *MediorumServer) analyzeLegacyBlob(c echo.Context) error {
-	cid := c.Param("cid")
-	var analysis *QmAudioAnalysis
-	err := ss.crud.DB.First(&analysis, "cid = ?", cid).Error
-	if err != nil {
-		preferredHosts, _ := ss.rendezvousAllHosts(cid)
-		newAnalysis := &QmAudioAnalysis{
-			CID:        cid,
-			Mirrors:    preferredHosts[:ss.Config.ReplicationFactor],
-			Status:     JobStatusAudioAnalysis,
-			AnalyzedAt: time.Now().UTC(),
-		}
-		err = ss.crud.Create(newAnalysis)
-		if err != nil {
-			ss.logger.Warn("create legacy audio analysis failed", "err", err)
-			return c.String(500, "failed to create new audio analysis")
-		}
-		return c.JSON(200, newAnalysis)
-	}
-	// if analysis.Status == JobStatusError || analysis.Status == JobStatusTimeout {
-	// 	if analysis.Error == "blob is not an audio file" {
-	// 		// set ErrorCount to 3 so discovery repairer stops retrying this cid
-	// 		analysis.ErrorCount = 3
-	// 		ss.crud.Update(analysis)
-	// 		return c.String(http.StatusBadRequest, "must specify a cid for an audio file")
-	// 	}
-	// 	analysis.Status = JobStatusAudioAnalysis
-	// 	analysis.AnalyzedAt = time.Now().UTC()
-	// 	analysis.Error = ""
-	// 	err = ss.crud.Update(analysis)
-	// 	if err != nil {
-	// 		ss.logger.Warn("update legacy audio analysis failed", "err", err)
-	// 		return c.String(500, "failed to trigger audio analysis")
-	// 	}
-	// }
-	return c.JSON(200, analysis)
 }
 
 func (ss *MediorumServer) serveLegacyBlobAnalysis(c echo.Context) error {

--- a/mediorum/server/server.go
+++ b/mediorum/server/server.go
@@ -308,7 +308,7 @@ func New(config MediorumConfig) (*MediorumServer, error) {
 
 	// legacy blob audio analysis
 	routes.GET("/tracks/legacy/:cid/analysis", ss.serveLegacyBlobAnalysis, ss.requireHealthy)
-	routes.POST("/tracks/legacy/:cid/analyze", ss.analyzeLegacyBlob, ss.requireHealthy, ss.requireRegisteredSignature)
+	routes.POST("/tracks/legacy/:cid/analyze", ss.serveLegacyBlobAnalysis, ss.requireHealthy)
 
 	// serve blob (audio)
 	routes.HEAD("/ipfs/:cid", ss.serveBlob, ss.requireHealthy, ss.ensureNotDelisted)


### PR DESCRIPTION
### Description

Simplifies legacy audio analysis queue backlog.

Each node scrolls over all `Qm` CIDs in random order and will start a job if node `isMine` is true and job's not done.

Notes:

* Status can be checked in psql with query `select status, count(*) from qm_audio_analyses group by 1;`
* We should pause the "backfill" crawler for a bit while this runs.
* When this is getting closer to done we should update the `order by random()` query to be smarter about finding work.

### How Has This Been Tested?

Deployed on prod CN3, confirmed making much better progress.
