### PR TITLE
Simplify audio analysis for ba cids

### DIFF
--- a/mediorum/server/serve_audio_analysis.go
+++ b/mediorum/server/serve_audio_analysis.go
@@ -4,27 +4,13 @@ import (
 	"github.com/labstack/echo/v4"
 )
 
-// triggers audio analysis on an upload if a previous analysis failed or never ran.
-// does nothing and returns the analysis results if analysis previously succeeded.
+// returns analysis results if analysis previously succeeded.
 func (ss *MediorumServer) analyzeUpload(c echo.Context) error {
 	var upload *Upload
 	err := ss.crud.DB.First(&upload, "id = ?", c.Param("id")).Error
 	if err != nil {
 		return echo.NewHTTPError(404, err.Error())
 	}
-
-	// if upload.Template == "audio" && upload.Status == JobStatusDone && upload.AudioAnalysisStatus != JobStatusDone {
-	// 	upload.AudioAnalyzedAt = time.Now().UTC()
-	// 	upload.AudioAnalysisStatus = ""
-	// 	upload.AudioAnalysisError = ""
-	// 	upload.Status = JobStatusAudioAnalysis
-	// 	err = ss.crud.Update(upload)
-	// 	if err != nil {
-	// 		ss.logger.Warn("update upload failed", "err", err)
-	// 		return c.String(500, "failed to trigger audio analysis")
-	// 	}
-	// }
-
 	return c.JSON(200, upload)
 }
 


### PR DESCRIPTION
### Description

Similar to https://github.com/AudiusProject/audius-protocol/pull/9026 for ba cids.

* Moves analysis call into transocde function to ensure minimal latency (since client will wait for audio analysis anyway).
* In background, worker looks for `uploads` records that have incomplete analysis, and greedily takes jobs if it has the file.


