### PR TITLE
[C-4649] fix jumping date picker popup

### DIFF
--- a/packages/web/src/components/edit/fields/DatePickerField.module.css
+++ b/packages/web/src/components/edit/fields/DatePickerField.module.css
@@ -7,6 +7,10 @@
   width: 300px;
 }
 
+.datePicker {
+  height: 296px;
+}
+
 .label {
   color: var(--harmony-n-400);
   font-size: var(--harmony-font-s);


### PR DESCRIPTION
### Description

We suspect that popup height was being calculated before the date picker fully rendered, causing it to position below the input. Hard coding the height helps seed the initial calculation so it chooses the correct position from the start.

### How Has This Been Tested?

had consistent repro of the bug locally, it stopped with the fix