### PR TITLE
Fix preview times longer than track duration not erroring

### DIFF
--- a/packages/web/src/components/edit/fields/price-and-audience/PriceAndAudienceField.tsx
+++ b/packages/web/src/components/edit/fields/price-and-audience/PriceAndAudienceField.tsx
@@ -130,11 +130,13 @@ export const PriceAndAudienceField = (props: PriceAndAudienceFieldProps) => {
   const isHiddenFieldName = isAlbum ? IS_PRIVATE : IS_UNLISTED
 
   const [{ value: index }] = useField('trackMetadatasIndex')
-  const [{ value: trackLength }] = useIndexedField<number>(
+  const [{ value: previewTrackLength }] = useIndexedField<number>(
     'tracks',
     index,
     'preview.duration'
   )
+  const [{ value: trackDuration }] = useTrackField<number>('duration')
+  const trackLength = isUpload ? previewTrackLength : trackDuration
 
   const usdcPurchaseConfig = useUSDCPurchaseConfig()
 

--- a/packages/web/src/components/edit/fields/price-and-audience/priceAndAudienceSchema.ts
+++ b/packages/web/src/components/edit/fields/price-and-audience/priceAndAudienceSchema.ts
@@ -142,8 +142,8 @@ export const priceAndAudienceSchema = (
             formValues[PREVIEW] === undefined ||
             isNaN(trackLength) ||
             (formValues[PREVIEW] >= 0 &&
-              formValues[PREVIEW] < trackLength - 30) ||
-            (trackLength <= 30 && formValues[PREVIEW] < trackLength)
+              (formValues[PREVIEW] < trackLength - 30 ||
+                (trackLength <= 30 && formValues[PREVIEW] < trackLength)))
           )
         }
         return true


### PR DESCRIPTION
### Description
Edit preview duration for usdc-gated tracks was working on upload but broken for edit track (now that we're sharing the form between both). We need to get the track duration from the metadata directly in the edit case.

Also updating the validation logic for preview - we should be checking that preview >= 0 in all cases.

### How Has This Been Tested?

<img width="711" alt="Screenshot 2024-07-05 at 5 46 46 PM" src="https://github.com/AudiusProject/audius-protocol/assets/3893871/e766cbad-7039-403c-a78a-bc228a1ffb43">
