### PR TITLE
[C-4694] Add track_count to non-full playlist endpoint

### DIFF
--- a/packages/discovery-provider/src/api/v1/models/playlists.py
+++ b/packages/discovery-provider/src/api/v1/models/playlists.py
@@ -49,6 +49,7 @@ playlist_model = ns.model(
         "ddex_app": fields.String(allow_null=True),
         "access": fields.Nested(access),
         "upc": fields.String(allow_null=True),
+        "track_count": fields.Integer(required=True),
     },
 )
 


### PR DESCRIPTION
### Description
`track_count` was missing in the non-full playlist endpoint which caused this subtle bug: With a hidden playlist, If I load a playlist directly from its url, things are fine. But if I start from the library page and navigate to that playlist, the publish button is grayed out with the tooltip error saying "You must add at least 1 track to publish this playlist".

Is there any reason we shouldn't have `track_count` in the non-full endpoint?

### How Has This Been Tested?

Did not test locally - local stack was messed up for some reason. Can try again next week or on stage.