### PR TITLE
[C-4630] Update Confirm Modal copy

### DIFF
--- a/packages/web/src/components/upload-confirmation-modal/UploadConfirmationModal.tsx
+++ b/packages/web/src/components/upload-confirmation-modal/UploadConfirmationModal.tsx
@@ -4,12 +4,13 @@ import { uploadConfirmationModalUISelectors } from '@audius/common/store'
 import {
   Modal,
   ModalContent,
-  ModalContentText,
   ModalHeader,
   ModalTitle,
   ModalFooter,
   IconCloudUpload as IconUpload,
-  Button
+  Button,
+  Text,
+  Flex
 } from '@audius/harmony'
 
 import { useModalState } from 'common/hooks/useModalState'
@@ -47,11 +48,13 @@ export const UploadConfirmationModal = () => {
         <ModalTitle icon={<IconUpload />} title={messages.title} />
       </ModalHeader>
       <ModalContent>
-        <ModalContentText>
-          {hasPublicTracks
-            ? messages.publicDescription
-            : messages.hiddenDescription}
-        </ModalContentText>
+        <Flex justifyContent='center'>
+          <Text variant='body' size='l' textAlign='center'>
+            {hasPublicTracks
+              ? messages.publicDescription
+              : messages.hiddenDescription}
+          </Text>
+        </Flex>
       </ModalContent>
       <ModalFooter>
         <Button variant='secondary' fullWidth onClick={onClose}>

--- a/packages/web/src/pages/upload-page/UploadPage.tsx
+++ b/packages/web/src/pages/upload-page/UploadPage.tsx
@@ -101,11 +101,13 @@ export const UploadPage = (props: UploadPageProps) => {
             formState={formState}
             onContinue={(formState: UploadFormState) => {
               setFormState(formState)
+              const isPrivateCollection =
+                'metadata' in formState && formState.metadata?.is_private
               const hasPublicTracks =
                 formState.tracks?.some(
                   (track) => !track.metadata.is_unlisted
                 ) ?? true
-              openUploadConfirmation(hasPublicTracks)
+              openUploadConfirmation(hasPublicTracks && !isPrivateCollection)
             }}
           />
         )


### PR DESCRIPTION
### Description

Fixes conditional copy on upload publish confirmation modal when publishing hidden/scheduled albums.

_Note:_
The styling on the modals looks off compared to designs because the harmony modal components don't match the design spacing. Leaving this for its own separate work item, but we may want to fix it before we ship.

Also had to manually center the text in this modal, but ideally we fix it across harmony modals. Wasn't sure if we're ready to commit to that now.

Figma vs web:

<img width='45%' src='https://github.com/AudiusProject/audius-protocol/assets/2358254/dad271ed-24f5-49e3-80af-da88a56952df' /><img width='45%' src='https://github.com/AudiusProject/audius-protocol/assets/2358254/9f6ef10f-3450-4bb1-a019-dab96ad6612f' />


### How Has This Been Tested?

local web