### PR TITLE
Fix condition for adding hidden track to playlist

### DIFF
--- a/packages/mobile/src/components/add-to-collection-drawer/AddToCollectionDrawer.tsx
+++ b/packages/mobile/src/components/add-to-collection-drawer/AddToCollectionDrawer.tsx
@@ -138,7 +138,7 @@ export const AddToCollectionDrawer = () => {
             // Don't add if the track is hidden, but collection is public
             if (
               !isHiddenPaidScheduledEnabled &&
-              !isTrackUnlisted &&
+              isTrackUnlisted &&
               !item.is_private
             ) {
               toast({ content: messages.hiddenAdd })


### PR DESCRIPTION
### Description
Tracks from feed or private playlists were not able to be added to a public playlist because of this conditional. It says if the track is hidden but the code wasn't matching up.

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._

Confirmed against prod. Public tracks on feed and private playlists could be added to a public playlist. Private tracks could not be added to a public playlist.