### PR TITLE
[C-4695] Fix remix field visibility

### DIFF
--- a/packages/libs/src/api/Track.ts
+++ b/packages/libs/src/api/Track.ts
@@ -25,7 +25,8 @@ const TRACK_PROPS = [
   'is_original_available',
   'is_downloadable',
   'ai_attribution_user_id',
-  'allowed_api_keys'
+  'allowed_api_keys',
+  'field_visibility'
 ]
 const TRACK_REQUIRED_PROPS = ['owner_id', 'title']
 
@@ -656,6 +657,7 @@ export class Track extends Base {
       bpm,
       musical_key,
       audio_analysis_error_count,
+      field_visibility,
       ...other
     } = trackMetadata
     if (typeof other !== 'undefined') {
@@ -712,7 +714,8 @@ export class Track extends Base {
       allowed_api_keys,
       bpm,
       musical_key,
-      audio_analysis_error_count
+      audio_analysis_error_count,
+      field_visibility
     }
   }
 }

--- a/packages/libs/src/utils/types.ts
+++ b/packages/libs/src/utils/types.ts
@@ -130,6 +130,15 @@ type Copyright = {
   text: string
 }
 
+type FieldVisibility = {
+  mood?: boolean
+  tags?: boolean
+  genre?: boolean
+  share?: boolean
+  playCount?: boolean
+  remixes?: boolean
+}
+
 export type GatedConditions = {
   nft_collection?: EthCollectibleGatedConditions | SolCollectibleGatedConditions
   follow_user_id?: number
@@ -210,6 +219,7 @@ export type TrackMetadata = {
   bpm?: Nullable<number>
   musical_key?: Nullable<string>
   audio_analysis_error_count?: number
+  field_visibility?: FieldVisibility
 }
 
 export type CollectionMetadata = {

--- a/packages/web/src/components/edit-track/EditTrackForm.tsx
+++ b/packages/web/src/components/edit-track/EditTrackForm.tsx
@@ -150,7 +150,7 @@ const TrackEditForm = (
                   }
                 }}
               />
-              <RemixSettingsField />
+              <RemixSettingsField isUpload={isUpload} />
             </div>
             <PreviewButton
               // Since edit form is a single component, render a different preview for each track

--- a/packages/web/src/components/edit/fields/RemixSettingsField/RemixSettingsField.tsx
+++ b/packages/web/src/components/edit/fields/RemixSettingsField/RemixSettingsField.tsx
@@ -46,7 +46,12 @@ const messages = {
 
 export type RemixOfField = Nullable<{ tracks: { parent_track_id: ID }[] }>
 
-export const RemixSettingsField = () => {
+type RemixSettingsFieldProps = {
+  isUpload: boolean
+}
+
+export const RemixSettingsField = (props: RemixSettingsFieldProps) => {
+  const { isUpload } = props
   // These refer to the field in the outer EditForm
   const [{ value: showRemixes }, , { setValue: setShowRemixes }] =
     useTrackField<FieldVisibility[typeof SHOW_REMIXES_BASE]>(SHOW_REMIXES)
@@ -95,15 +100,16 @@ export const RemixSettingsField = () => {
 
   const isUSDCPurchaseGated = isContentUSDCPurchaseGated(streamConditions)
 
-  // If the track is public or usdc purchase gated, default to showing remixes.
+  // When uploading, if the track is public or usdc purchase gated, default to showing remixes.
   // Otherwise, default to hiding remixes.
   useEffect(() => {
+    if (!isUpload) return
     if (!isStreamGated || isUSDCPurchaseGated) {
       setShowRemixes(true)
     } else if (isStreamGated) {
       setShowRemixes(false)
     }
-  }, [isStreamGated, isUSDCPurchaseGated, setShowRemixes])
+  }, [isUpload, isStreamGated, isUSDCPurchaseGated, setShowRemixes])
 
   const handleSubmit = useCallback(
     (values: RemixSettingsFormValues) => {

--- a/packages/web/src/components/edit/fields/RemixSettingsField/RemixSettingsMenuFields.tsx
+++ b/packages/web/src/components/edit/fields/RemixSettingsField/RemixSettingsMenuFields.tsx
@@ -71,9 +71,9 @@ export const RemixSettingsMenuFields = () => {
     setCanRemixParent(canRemixParent)
   }, [trackId, setParentTrackId, canRemixParent, setCanRemixParent])
 
-  const renderGatedContentCallout = () => {
-    if (isStreamGated && !isUSDCPurchaseGated) {
-      return (
+  return (
+    <div className={styles.fields}>
+      {isStreamGated && !isUSDCPurchaseGated ? (
         <Hint icon={IconQuestionCircle}>{`${
           messages.changeAvailabilityPrefix
         } ${
@@ -81,51 +81,24 @@ export const RemixSettingsMenuFields = () => {
             ? messages.collectibleGated
             : messages.specialAccess
         }${messages.changeAvailabilitySuffix}`}</Hint>
-      )
-    }
-    return null
-  }
-
-  const renderUsdcPurchaseGatedContentCallout = () => {
-    if (isUSDCPurchaseGated) {
-      return (
-        <Hint icon={IconQuestionCircle}>
-          {`${messages.changeAvailabilityPrefix} ${messages.premium}${messages.changeAvailabilitySuffix}`}
-        </Hint>
-      )
-    }
-    return null
-  }
-
-  const renderHideRemixesField = () => {
-    if (isStreamGated && !isUSDCPurchaseGated) {
-      return (
-        <SwitchRowField
-          name={SHOW_REMIXES}
-          header={messages.hideRemix.header}
-          description={messages.hideRemix.description}
-          inverted
-          checked
-          disabled
-        />
-      )
-    }
-    return (
+      ) : null}
       <SwitchRowField
         name={SHOW_REMIXES}
         header={messages.hideRemix.header}
         description={messages.hideRemix.description}
         inverted
+        {...(isStreamGated && !isUSDCPurchaseGated
+          ? { checked: true, disabled: true }
+          : {})}
       />
-    )
-  }
 
-  return (
-    <div className={styles.fields}>
-      {renderGatedContentCallout()}
-      {renderHideRemixesField()}
       <Divider />
-      {renderUsdcPurchaseGatedContentCallout()}
+
+      {isUSDCPurchaseGated ? (
+        <Hint icon={IconQuestionCircle}>
+          {`${messages.changeAvailabilityPrefix} ${messages.premium}${messages.changeAvailabilitySuffix}`}
+        </Hint>
+      ) : null}
       <SwitchRowField
         name={IS_REMIX}
         header={messages.remixOf.header}

--- a/packages/web/src/components/edit/fields/RemixSettingsField/RemixSettingsMenuFields.tsx
+++ b/packages/web/src/components/edit/fields/RemixSettingsField/RemixSettingsMenuFields.tsx
@@ -34,7 +34,7 @@ const messages = {
     header: 'Identify as Remix',
     description:
       'Link your remix to the original track to increase visibility and credit the original artist.',
-    linkLabel: 'Enter an Audius Link'
+    linkLabel: 'Link to original track'
   },
   changeAvailabilityPrefix: 'Availablity is set to ',
   changeAvailabilitySuffix:
@@ -73,6 +73,23 @@ export const RemixSettingsMenuFields = () => {
 
   return (
     <div className={styles.fields}>
+      {isUSDCPurchaseGated ? (
+        <Hint icon={IconQuestionCircle}>
+          {`${messages.changeAvailabilityPrefix} ${messages.premium}${messages.changeAvailabilitySuffix}`}
+        </Hint>
+      ) : null}
+      <SwitchRowField
+        name={IS_REMIX}
+        header={messages.remixOf.header}
+        description={messages.remixOf.description}
+        disabled={isStreamGated}
+      >
+        <TextField name={REMIX_LINK} label={messages.remixOf.linkLabel} />
+        {track ? <TrackInfo trackId={track.track_id} /> : null}
+      </SwitchRowField>
+
+      <Divider />
+
       {isStreamGated && !isUSDCPurchaseGated ? (
         <Hint icon={IconQuestionCircle}>{`${
           messages.changeAvailabilityPrefix
@@ -91,23 +108,6 @@ export const RemixSettingsMenuFields = () => {
           ? { checked: true, disabled: true }
           : {})}
       />
-
-      <Divider />
-
-      {isUSDCPurchaseGated ? (
-        <Hint icon={IconQuestionCircle}>
-          {`${messages.changeAvailabilityPrefix} ${messages.premium}${messages.changeAvailabilitySuffix}`}
-        </Hint>
-      ) : null}
-      <SwitchRowField
-        name={IS_REMIX}
-        header={messages.remixOf.header}
-        description={messages.remixOf.description}
-        disabled={isStreamGated}
-      >
-        <TextField name={REMIX_LINK} label={messages.remixOf.linkLabel} />
-        {track ? <TrackInfo trackId={track.track_id} /> : null}
-      </SwitchRowField>
     </div>
   )
 }


### PR DESCRIPTION
### Description

Fixes subtle issue where remix visibility on edit. Primarily this is because the Track api schema did not contain field_visibility, which means field_visibiilty gets removed from the edit metadata before being sent as a transaction. I'm pretty sure we want to include this, even though we are now hiding the field_visibility generally? @szonana and @rickyrombo for context.

Also fixes copy and ordering of fields in the remix-settings modal
