### PR TITLE
[C-4594] Fix user-generated-text links

### DIFF
--- a/packages/web/src/components/user-generated-text/UserGeneratedText.tsx
+++ b/packages/web/src/components/user-generated-text/UserGeneratedText.tsx
@@ -60,7 +60,7 @@ export const UserGeneratedText = forwardRef(function <T extends ElementType>(
 ) {
   const {
     children: childrenProp,
-    variant = 'body',
+    variant,
     color,
     size,
     strength,
@@ -73,7 +73,13 @@ export const UserGeneratedText = forwardRef(function <T extends ElementType>(
   const options: Opts = useMemo(
     () => ({
       render: renderLink,
-      attributes: { source: linkSource, onClick: onClickLink }
+      attributes: {
+        source: linkSource,
+        onClick: onClickLink,
+        textVariant: variant,
+        size,
+        strength
+      }
     }),
     [linkSource, onClickLink]
   )
@@ -89,7 +95,6 @@ export const UserGeneratedText = forwardRef(function <T extends ElementType>(
       as={LinkifyText}
       innerRef={ref}
       tag={tag}
-      variant={variant}
       color={color}
       size={size}
       strength={strength}

--- a/packages/web/src/pages/profile-page/components/desktop/ProfileBio.tsx
+++ b/packages/web/src/pages/profile-page/components/desktop/ProfileBio.tsx
@@ -220,7 +220,7 @@ export const ProfileBio = ({
   return (
     <div>
       <UserGeneratedText
-        size='xs'
+        size='s'
         ref={bioRef}
         className={cn(styles.description, {
           [styles.truncated]: isCollapsed


### PR DESCRIPTION
### Description

Fixes issue where user-generated text-links are not receiving context from parent text element, likely due to how linkify renders stuff. Explicitly passing through textVariant, size and strength fixes this.