### PR TITLE
Mediorum: skip image transcode

### DIFF
--- a/mediorum/server/audio_analysis.go
+++ b/mediorum/server/audio_analysis.go
@@ -40,7 +40,10 @@ func (ss *MediorumServer) startAudioAnalyzer() {
 	}
 
 	for _, upload := range uploads {
-		cid := upload.TranscodeResults["320"]
+		cid, ok := upload.TranscodeResults["320"]
+		if !ok {
+			continue
+		}
 		_, isMine := ss.rendezvousAllHosts(cid)
 		if isMine && upload.AudioAnalysisErrorCount < MAX_TRIES {
 			work <- upload

--- a/mediorum/server/serve_upload.go
+++ b/mediorum/server/serve_upload.go
@@ -218,6 +218,9 @@ func (ss *MediorumServer) postUpload(c echo.Context) error {
 
 			if template == JobTemplateImgSquare || template == JobTemplateImgBackdrop {
 				upload.TranscodeResults["original.jpg"] = formFileCID
+				upload.TranscodeProgress = 1
+				upload.TranscodedAt = time.Now().UTC()
+				upload.Status = JobStatusDone
 			}
 
 			return ss.crud.Create(upload)


### PR DESCRIPTION
### Description

Images for new uploads are dynamically resized at request time, so skip any "transcode" status.