### PR TITLE
[C-4651] Fix stems upload refetch bug

### DIFF
--- a/packages/common/src/services/audius-api-client/AudiusAPIClient.ts
+++ b/packages/common/src/services/audius-api-client/AudiusAPIClient.ts
@@ -90,7 +90,10 @@ const FULL_ENDPOINT_MAP = {
   getTrackStreamUrl: (trackId: OpaqueID) => `/tracks/${trackId}/stream`,
   getTracks: () => `/tracks`,
   getTrackByHandleAndSlug: `/tracks`,
-  getStems: (trackId: OpaqueID) => `/tracks/${trackId}/stems`,
+  getStems: (trackId: OpaqueID, stemIds?: ID[]) =>
+    `/tracks/${trackId}/stems${
+      stemIds ? `?stemIds=${stemIds?.join(',')}` : ''
+    }`,
   getRemixes: (trackId: OpaqueID) => `/tracks/${trackId}/remixes`,
   getRemixing: (trackId: OpaqueID) => `/tracks/${trackId}/remixing`,
   searchFull: `/search/full`,
@@ -259,6 +262,7 @@ type GetPlaylistByPermalinkArgs = {
 
 type GetStemsArgs = {
   trackId: ID
+  stemIds?: ID[]
 }
 
 type GetRemixesArgs = {
@@ -753,11 +757,14 @@ export class AudiusAPIClient {
     return adapter.makeTrack(trackResponse.data)
   }
 
-  async getStems({ trackId }: GetStemsArgs): Promise<StemTrackMetadata[]> {
+  async getStems({
+    trackId,
+    stemIds
+  }: GetStemsArgs): Promise<StemTrackMetadata[]> {
     this._assertInitialized()
     const encodedTrackId = this._encodeOrThrow(trackId)
     const response = await this._getResponse<APIResponse<APIStem[]>>(
-      FULL_ENDPOINT_MAP.getStems(encodedTrackId)
+      FULL_ENDPOINT_MAP.getStems(encodedTrackId, stemIds)
     )
 
     if (!response) return []

--- a/packages/web/src/common/store/cache/tracks/utils/fetchAndProcessStems.ts
+++ b/packages/web/src/common/store/cache/tracks/utils/fetchAndProcessStems.ts
@@ -25,15 +25,13 @@ const { getTrack } = cacheTracksSelectors
  *
  * @param trackId the parent track for which to fetch stems
  */
-export function* fetchAndProcessStems(trackId: ID) {
+export function* fetchAndProcessStems(trackId: ID, stemIds?: ID[]) {
   yield* waitForRead()
   const apiClient = yield* getContext('apiClient')
 
   const stems: StemTrackMetadata[] = yield call(
-    (args) => apiClient.getStems(args),
-    {
-      trackId
-    }
+    [apiClient, apiClient.getStems],
+    { trackId, stemIds }
   )
 
   if (stems.length) {

--- a/packages/web/src/common/store/cache/tracks/utils/retrieveTracks.ts
+++ b/packages/web/src/common/store/cache/tracks/utils/retrieveTracks.ts
@@ -42,6 +42,7 @@ type RetrieveTracksArgs = {
   trackIds: ID[] | UnlistedTrackRequest[]
   canBeUnlisted?: boolean
   withStems?: boolean
+  stemIds?: ID[]
   withRemixes?: boolean
   withRemixParents?: boolean
   forceRetrieveFromSource?: boolean
@@ -157,6 +158,7 @@ export function* retrieveTracks({
   trackIds,
   canBeUnlisted = false,
   withStems = false,
+  stemIds,
   withRemixes = false,
   withRemixParents = false
 }: RetrieveTracksArgs) {
@@ -246,7 +248,7 @@ export function* retrieveTracks({
         console.error('Stems endpoint only supports fetching single tracks')
         return
       }
-      yield* call(fetchAndProcessStems, trackId)
+      yield* call(fetchAndProcessStems, trackId, stemIds)
     })
   }
 

--- a/packages/web/src/components/user-generated-text/UserGeneratedText.tsx
+++ b/packages/web/src/components/user-generated-text/UserGeneratedText.tsx
@@ -81,7 +81,7 @@ export const UserGeneratedText = forwardRef(function <T extends ElementType>(
         strength
       }
     }),
-    [linkSource, onClickLink]
+    [linkSource, onClickLink, variant, size, strength]
   )
 
   const children =

--- a/packages/web/src/store/application/ui/stemsUpload/sagas.ts
+++ b/packages/web/src/store/application/ui/stemsUpload/sagas.ts
@@ -48,7 +48,8 @@ function* watchUploadStems() {
       // Retrieve the parent track to refresh stems
       yield* call(retrieveTracks, {
         trackIds: [parentId],
-        withStems: true
+        withStems: true,
+        stemIds: trackIds
       })
     }
   )


### PR DESCRIPTION
### Description

Fixes subtle issue where refetching track stems gives old data due to caching layer. The fix here is to add newly added stemIds to getStems request to ensure we get a cache miss.

This has brought up larger questions around stale data when editing content, which ill bring up to larger audience this week.