### PR TITLE
Fix mobile single-OTP signup

### DIFF
--- a/packages/mobile/src/screens/sign-on-screen/screens/ConfirmEmailScreen.tsx
+++ b/packages/mobile/src/screens/sign-on-screen/screens/ConfirmEmailScreen.tsx
@@ -19,6 +19,7 @@ import { toFormikValidationSchema } from 'zod-formik-adapter'
 import { Text, TextLink } from '@audius/harmony-native'
 import { HarmonyTextField } from 'app/components/fields'
 import { useToast } from 'app/hooks/useToast'
+import { fingerprintClient } from 'app/services/fingerprint'
 
 import { Heading, Page, PageFooter } from '../components/layout'
 import { useTrackScreen } from '../utils/useTrackScreen'
@@ -43,11 +44,12 @@ export const ConfirmEmailScreen = () => {
   useTrackScreen('ConfirmEmail')
 
   const handleSubmit = useCallback(
-    (values: ConfirmEmailValues) => {
+    async (values: ConfirmEmailValues) => {
       const { otp } = values
       const sanitizedOtp = otp.replace(/\s/g, '')
       dispatch(setValueField('otp', sanitizedOtp))
-      dispatch(signIn(email, password, undefined, sanitizedOtp))
+      const visitorId = await fingerprintClient.identify(email, 'mobile')
+      dispatch(signIn(email, password, visitorId, sanitizedOtp))
     },
     [dispatch, email, password]
   )

--- a/packages/mobile/src/screens/sign-on-screen/screens/SignInScreen.tsx
+++ b/packages/mobile/src/screens/sign-on-screen/screens/SignInScreen.tsx
@@ -58,8 +58,7 @@ export const SignInScreen = () => {
   const handleSubmit = useCallback(
     async (values: SignInValues) => {
       const { email, password } = values
-      const fpResponse = await fingerprintClient.identify(email, 'mobile')
-      const visitorId = fpResponse?.visitorId
+      const visitorId = await fingerprintClient.identify(email, 'mobile')
       dispatch(setValueField('email', email))
       dispatch(setValueField('password', password))
       dispatch(signIn(email, password, visitorId))


### PR DESCRIPTION
### Description
Fixes OTP on mobile - we weren't sending the fingerprint on signup after OTP.

Also for some reason the response from fingerprint was just the string directly - not wrapped in any object, seems to be different from web.

Not sure this async stuff is the best pattern but it works for now. Probably `useAsync`?

### How Has This Been Tested?

Tested on local ios stage