### PR TITLE
[QA-1419] Fix twitter/instagram oauth exiting early

### DIFF
--- a/packages/mobile/src/components/oauth/OAuthWebView.tsx
+++ b/packages/mobile/src/components/oauth/OAuthWebView.tsx
@@ -34,7 +34,7 @@ const TWITTER_POLLER = `
 
           const oauthToken = query.get('oauth_token')
           const oauthVerifier = query.get('oauth_verifier')
-          if (!oauthToken || !oauthVerifier) exit()
+          if (!oauthToken || !oauthVerifier) return
 
           window.ReactNativeWebView.postMessage(
             JSON.stringify({
@@ -75,7 +75,7 @@ const INSTAGRAM_POLLER = `
           const query = new URLSearchParams(window.location.search)
 
           const instagramCode = query.get('code')
-          if (!instagramCode) exit()
+          if (!instagramCode) return
 
           window.ReactNativeWebView.postMessage(
             JSON.stringify({ 


### PR DESCRIPTION
### Description

We were calling `exit()` from the polling loop which causes the auth popup to close entirely. Instead, we want to return from the polling function and wait until all the conditions are met.

### How Has This Been Tested?

Working twitter and instagram auth on mobile sim prod. Broken before change but working now.