### PR TITLE
[QA-1426] Fix audius-query array normalization

### DIFF
--- a/packages/common/src/audius-query/createApi.ts
+++ b/packages/common/src/audius-query/createApi.ts
@@ -288,7 +288,7 @@ const useCacheData = <Args, Data>(
       endpoint.options.kind,
       hookOptions?.shallow
     )
-    if (typeof normalizedData === 'object') {
+    if (typeof normalizedData === 'object' && !Array.isArray(normalizedData)) {
       return denormalize(normalizedData, apiResponseSchema, entityMap) as Data
     }
     return normalizedData
@@ -343,7 +343,7 @@ const fetchData = async <Args, Data>(
 
     let data: Data
 
-    if (typeof apiData === 'object') {
+    if (typeof apiData === 'object' && !Array.isArray(apiData)) {
       const { entities, result } = normalize(
         endpoint.options.schemaKey
           ? { [endpoint.options.schemaKey]: apiData }


### PR DESCRIPTION
### Description

We were using `typeof data === 'object'` check to determine whether to apply normalization, but that returns `true` for arrays since `typeof []` returns `'object'`

### How Has This Been Tested?

local web purchases table is working again