### PR TITLE
[C-4702] Add empty states for mobile search results and fix track search request

### DIFF
--- a/packages/common/src/api/search.ts
+++ b/packages/common/src/api/search.ts
@@ -1,4 +1,5 @@
 import { Mood } from '@audius/sdk'
+import { isEmpty } from 'lodash'
 
 import { createApi } from '~/audius-query'
 import { ID } from '~/models/Identifiers'
@@ -26,16 +27,42 @@ type getSearchArgs = {
   limit?: number
   offset?: number
   includePurchaseable?: boolean
-}
+} & SearchFilters
 
 const searchApi = createApi({
   reducerPath: 'searchApi',
   endpoints: {
     getSearchResults: {
       fetch: async (args: getSearchArgs, { apiClient }) => {
-        const { category, ...rest } = args
+        const {
+          category,
+          currentUserId,
+          query,
+          limit,
+          offset,
+          includePurchaseable,
+          ...filters
+        } = args
+
         const kind = category as SearchKind
-        return await apiClient.getSearchFull({ kind, ...rest })
+        if (!query && isEmpty(filters)) {
+          return {
+            tracks: [],
+            users: [],
+            albums: [],
+            playlists: []
+          }
+        }
+
+        return await apiClient.getSearchFull({
+          kind,
+          currentUserId,
+          query,
+          limit,
+          offset,
+          includePurchaseable,
+          ...filters
+        })
       },
       options: {}
     }

--- a/packages/mobile/src/screens/search-screen-v2/NoResultsTile.tsx
+++ b/packages/mobile/src/screens/search-screen-v2/NoResultsTile.tsx
@@ -1,0 +1,33 @@
+import { searchCatalogTileMessages } from '@audius/common/messages'
+
+import { IconSearch, Paper, Text } from '@audius/harmony-native'
+
+const messages = {
+  ...searchCatalogTileMessages,
+  noResults: 'No Results'
+}
+
+export const NoResultsTile = () => {
+  return (
+    <Paper
+      pv='2xl'
+      ph='l'
+      mv='s'
+      mh='xl'
+      direction='column'
+      gap='s'
+      alignItems='center'
+      shadow='flat'
+      backgroundColor='surface1'
+      border='default'
+    >
+      <IconSearch color='default' size='l' />
+      <Text variant='title' size='l'>
+        {messages.noResults}
+      </Text>
+      <Text variant='body' size='m' textAlign='center'>
+        {messages.description}
+      </Text>
+    </Paper>
+  )
+}

--- a/packages/mobile/src/screens/search-screen-v2/search-results/AlbumResults.tsx
+++ b/packages/mobile/src/screens/search-screen-v2/search-results/AlbumResults.tsx
@@ -1,12 +1,28 @@
 import { Status } from '@audius/common/models'
+import { isEmpty } from 'lodash'
 
 import { Flex } from '@audius/harmony-native'
 import { CollectionList } from 'app/components/collection-list/CollectionList'
 
-import { useGetSearchResults } from '../searchState'
+import { NoResultsTile } from '../NoResultsTile'
+import { SearchCatalogTile } from '../SearchCatalogTile'
+import {
+  useGetSearchResults,
+  useSearchFilters,
+  useSearchQuery
+} from '../searchState'
 
 export const AlbumResults = () => {
   const { data, status } = useGetSearchResults('albums')
+  const [query] = useSearchQuery()
+  const [filters] = useSearchFilters()
+  const isNoSearch = !query && isEmpty(filters)
+
+  if (isNoSearch) return <SearchCatalogTile />
+  if ((!data || data.length === 0) && status === Status.SUCCESS) {
+    return <NoResultsTile />
+  }
+
   return (
     <Flex h='100%' backgroundColor='default' pt='m'>
       <CollectionList

--- a/packages/mobile/src/screens/search-screen-v2/search-results/AlbumResults.tsx
+++ b/packages/mobile/src/screens/search-screen-v2/search-results/AlbumResults.tsx
@@ -1,34 +1,29 @@
 import { Status } from '@audius/common/models'
-import { isEmpty } from 'lodash'
 
 import { Flex } from '@audius/harmony-native'
 import { CollectionList } from 'app/components/collection-list/CollectionList'
 
 import { NoResultsTile } from '../NoResultsTile'
 import { SearchCatalogTile } from '../SearchCatalogTile'
-import {
-  useGetSearchResults,
-  useSearchFilters,
-  useSearchQuery
-} from '../searchState'
+import { useGetSearchResults, useIsEmptySearch } from '../searchState'
 
 export const AlbumResults = () => {
   const { data, status } = useGetSearchResults('albums')
-  const [query] = useSearchQuery()
-  const [filters] = useSearchFilters()
-  const isNoSearch = !query && isEmpty(filters)
+  const isEmptySearch = useIsEmptySearch()
+  const hasNoResults = (!data || data.length === 0) && status === Status.SUCCESS
 
-  if (isNoSearch) return <SearchCatalogTile />
-  if ((!data || data.length === 0) && status === Status.SUCCESS) {
-    return <NoResultsTile />
-  }
+  if (isEmptySearch) return <SearchCatalogTile />
 
   return (
     <Flex h='100%' backgroundColor='default' pt='m'>
-      <CollectionList
-        isLoading={status === Status.LOADING}
-        collection={data as any[]}
-      />
+      {hasNoResults ? (
+        <NoResultsTile />
+      ) : (
+        <CollectionList
+          isLoading={status === Status.LOADING}
+          collection={data as any[]}
+        />
+      )}
     </Flex>
   )
 }

--- a/packages/mobile/src/screens/search-screen-v2/search-results/AllResults.tsx
+++ b/packages/mobile/src/screens/search-screen-v2/search-results/AllResults.tsx
@@ -8,6 +8,7 @@ import { Divider, Flex, Text } from '@audius/harmony-native'
 import { SectionList } from 'app/components/core'
 import { WithLoader } from 'app/components/with-loader/WithLoader'
 
+import { NoResultsTile } from '../NoResultsTile'
 import { SearchItem } from '../SearchItem'
 import { useGetSearchResults } from '../searchState'
 
@@ -68,26 +69,32 @@ export const AllResults = () => {
     [data]
   )
 
+  const hasNoResults = (!data || sections.length === 0) && status === Status.SUCCESS
+
   // TODO: we should add a better loading state here
   return (
     <Flex onTouchStart={Keyboard.dismiss}>
       <WithLoader loading={status === Status.LOADING}>
-        <SectionList<SearchItemType>
-          keyboardShouldPersistTaps='always'
-          stickySectionHeadersEnabled={false}
-          sections={sections}
-          keyExtractor={({ id, kind }) => `${kind}-${id}`}
-          renderItem={({ item }) => (
-            <Flex ph='l'>
-              <SearchItem searchItem={item} />
-            </Flex>
-          )}
-          renderSectionHeader={({ section: { title } }) => (
-            <Flex ph='l' mt='l'>
-              <SearchSectionHeader title={title} />
-            </Flex>
-          )}
-        />
+        {hasNoResults ? (
+          <NoResultsTile />
+        ) : (
+          <SectionList<SearchItemType>
+            keyboardShouldPersistTaps='always'
+            stickySectionHeadersEnabled={false}
+            sections={sections}
+            keyExtractor={({ id, kind }) => `${kind}-${id}`}
+            renderItem={({ item }) => (
+              <Flex ph='l'>
+                <SearchItem searchItem={item} />
+              </Flex>
+            )}
+            renderSectionHeader={({ section: { title } }) => (
+              <Flex ph='l' mt='l'>
+                <SearchSectionHeader title={title} />
+              </Flex>
+            )}
+          />
+        )}
       </WithLoader>
     </Flex>
   )

--- a/packages/mobile/src/screens/search-screen-v2/search-results/AllResults.tsx
+++ b/packages/mobile/src/screens/search-screen-v2/search-results/AllResults.tsx
@@ -69,7 +69,8 @@ export const AllResults = () => {
     [data]
   )
 
-  const hasNoResults = (!data || sections.length === 0) && status === Status.SUCCESS
+  const hasNoResults =
+    (!data || sections.length === 0) && status === Status.SUCCESS
 
   // TODO: we should add a better loading state here
   return (

--- a/packages/mobile/src/screens/search-screen-v2/search-results/PlaylistResults.tsx
+++ b/packages/mobile/src/screens/search-screen-v2/search-results/PlaylistResults.tsx
@@ -1,12 +1,28 @@
 import { Status } from '@audius/common/models'
+import { isEmpty } from 'lodash'
 
 import { Flex } from '@audius/harmony-native'
 import { CollectionList } from 'app/components/collection-list/CollectionList'
 
-import { useGetSearchResults } from '../searchState'
+import { NoResultsTile } from '../NoResultsTile'
+import { SearchCatalogTile } from '../SearchCatalogTile'
+import {
+  useGetSearchResults,
+  useSearchFilters,
+  useSearchQuery
+} from '../searchState'
 
 export const PlaylistResults = () => {
   const { data, status } = useGetSearchResults('playlists')
+  const [query] = useSearchQuery()
+  const [filters] = useSearchFilters()
+  const isNoSearch = !query && isEmpty(filters)
+
+  if (isNoSearch) return <SearchCatalogTile />
+  if ((!data || data.length === 0) && status === Status.SUCCESS) {
+    return <NoResultsTile />
+  }
+
   return (
     <Flex h='100%' backgroundColor='default' pt='m'>
       <CollectionList

--- a/packages/mobile/src/screens/search-screen-v2/search-results/PlaylistResults.tsx
+++ b/packages/mobile/src/screens/search-screen-v2/search-results/PlaylistResults.tsx
@@ -1,34 +1,29 @@
 import { Status } from '@audius/common/models'
-import { isEmpty } from 'lodash'
 
 import { Flex } from '@audius/harmony-native'
 import { CollectionList } from 'app/components/collection-list/CollectionList'
 
 import { NoResultsTile } from '../NoResultsTile'
 import { SearchCatalogTile } from '../SearchCatalogTile'
-import {
-  useGetSearchResults,
-  useSearchFilters,
-  useSearchQuery
-} from '../searchState'
+import { useGetSearchResults, useIsEmptySearch } from '../searchState'
 
 export const PlaylistResults = () => {
   const { data, status } = useGetSearchResults('playlists')
-  const [query] = useSearchQuery()
-  const [filters] = useSearchFilters()
-  const isNoSearch = !query && isEmpty(filters)
+  const isEmptySearch = useIsEmptySearch()
+  const hasNoResults = (!data || data.length === 0) && status === Status.SUCCESS
 
-  if (isNoSearch) return <SearchCatalogTile />
-  if ((!data || data.length === 0) && status === Status.SUCCESS) {
-    return <NoResultsTile />
-  }
+  if (isEmptySearch) return <SearchCatalogTile />
 
   return (
     <Flex h='100%' backgroundColor='default' pt='m'>
-      <CollectionList
-        isLoading={status === Status.LOADING}
-        collection={data as any[]}
-      />
+      {hasNoResults ? (
+        <NoResultsTile />
+      ) : (
+        <CollectionList
+          isLoading={status === Status.LOADING}
+          collection={data as any[]}
+        />
+      )}
     </Flex>
   )
 }

--- a/packages/mobile/src/screens/search-screen-v2/search-results/ProfileResults.tsx
+++ b/packages/mobile/src/screens/search-screen-v2/search-results/ProfileResults.tsx
@@ -1,10 +1,26 @@
 import { Status } from '@audius/common/models'
+import { isEmpty } from 'lodash'
 
 import { UserList } from 'app/components/user-list'
 
-import { useGetSearchResults } from '../searchState'
+import { NoResultsTile } from '../NoResultsTile'
+import { SearchCatalogTile } from '../SearchCatalogTile'
+import {
+  useGetSearchResults,
+  useSearchFilters,
+  useSearchQuery
+} from '../searchState'
 
 export const ProfileResults = () => {
   const { data, status } = useGetSearchResults('users')
+  const [query] = useSearchQuery()
+  const [filters] = useSearchFilters()
+  const isNoSearch = !query && isEmpty(filters)
+
+  if (isNoSearch) return <SearchCatalogTile />
+  if ((!data || data.length === 0) && status === Status.SUCCESS) {
+    return <NoResultsTile />
+  }
+
   return <UserList profiles={data} isLoading={status === Status.LOADING} />
 }

--- a/packages/mobile/src/screens/search-screen-v2/search-results/ProfileResults.tsx
+++ b/packages/mobile/src/screens/search-screen-v2/search-results/ProfileResults.tsx
@@ -1,26 +1,18 @@
 import { Status } from '@audius/common/models'
-import { isEmpty } from 'lodash'
 
 import { UserList } from 'app/components/user-list'
 
 import { NoResultsTile } from '../NoResultsTile'
 import { SearchCatalogTile } from '../SearchCatalogTile'
-import {
-  useGetSearchResults,
-  useSearchFilters,
-  useSearchQuery
-} from '../searchState'
+import { useGetSearchResults, useIsEmptySearch } from '../searchState'
 
 export const ProfileResults = () => {
   const { data, status } = useGetSearchResults('users')
-  const [query] = useSearchQuery()
-  const [filters] = useSearchFilters()
-  const isNoSearch = !query && isEmpty(filters)
+  const isEmptySearch = useIsEmptySearch()
+  const hasNoResults = (!data || data.length === 0) && status === Status.SUCCESS
 
-  if (isNoSearch) return <SearchCatalogTile />
-  if ((!data || data.length === 0) && status === Status.SUCCESS) {
-    return <NoResultsTile />
-  }
+  if (isEmptySearch) return <SearchCatalogTile />
+  if (hasNoResults) return <NoResultsTile />
 
   return <UserList profiles={data} isLoading={status === Status.LOADING} />
 }

--- a/packages/mobile/src/screens/search-screen-v2/search-results/TrackResults.tsx
+++ b/packages/mobile/src/screens/search-screen-v2/search-results/TrackResults.tsx
@@ -1,18 +1,26 @@
 import { useCallback } from 'react'
 
+import { Status } from '@audius/common/models'
 import {
   lineupSelectors,
   searchResultsPageTracksLineupActions as tracksActions,
   searchResultsPageSelectors,
   SearchKind
 } from '@audius/common/store'
+import { isEmpty } from 'lodash'
 import { useDispatch, useSelector } from 'react-redux'
 import { useDebounce } from 'react-use'
 
 import { Flex } from '@audius/harmony-native'
 import { Lineup } from 'app/components/lineup'
 
-import { useSearchFilters, useSearchQuery } from '../searchState'
+import { NoResultsTile } from '../NoResultsTile'
+import { SearchCatalogTile } from '../SearchCatalogTile'
+import {
+  useGetSearchResults,
+  useSearchFilters,
+  useSearchQuery
+} from '../searchState'
 
 const { getSearchTracksLineup } = searchResultsPageSelectors
 const { makeGetLineupMetadatas } = lineupSelectors
@@ -21,9 +29,11 @@ const getSearchTracksLineupMetadatas = makeGetLineupMetadatas(
 )
 
 export const TrackResults = () => {
+  const { status } = useGetSearchResults('tracks')
   const [query] = useSearchQuery()
-  const filters = useSearchFilters()
+  const [filters] = useSearchFilters()
   const dispatch = useDispatch()
+  const isNoSearch = !query && isEmpty(filters)
 
   const lineup = useSelector(getSearchTracksLineupMetadatas)
 
@@ -57,6 +67,11 @@ export const TrackResults = () => {
     },
     [getResults]
   )
+
+  if (isNoSearch) return <SearchCatalogTile />
+  if ((!lineup || lineup.entries.length === 0) && status === Status.SUCCESS) {
+    return <NoResultsTile />
+  }
 
   return (
     <Flex h='100%' backgroundColor='default'>

--- a/packages/mobile/src/screens/search-screen-v2/search-results/TrackResults.tsx
+++ b/packages/mobile/src/screens/search-screen-v2/search-results/TrackResults.tsx
@@ -7,7 +7,6 @@ import {
   searchResultsPageSelectors,
   SearchKind
 } from '@audius/common/store'
-import { isEmpty } from 'lodash'
 import { useDispatch, useSelector } from 'react-redux'
 import { useDebounce } from 'react-use'
 

--- a/packages/mobile/src/screens/search-screen-v2/search-results/TrackResults.tsx
+++ b/packages/mobile/src/screens/search-screen-v2/search-results/TrackResults.tsx
@@ -18,6 +18,7 @@ import { NoResultsTile } from '../NoResultsTile'
 import { SearchCatalogTile } from '../SearchCatalogTile'
 import {
   useGetSearchResults,
+  useIsEmptySearch,
   useSearchFilters,
   useSearchQuery
 } from '../searchState'
@@ -33,7 +34,7 @@ export const TrackResults = () => {
   const [query] = useSearchQuery()
   const [filters] = useSearchFilters()
   const dispatch = useDispatch()
-  const isNoSearch = !query && isEmpty(filters)
+  const isEmptySearch = useIsEmptySearch()
 
   const lineup = useSelector(getSearchTracksLineupMetadatas)
 
@@ -68,7 +69,7 @@ export const TrackResults = () => {
     [getResults]
   )
 
-  if (isNoSearch) return <SearchCatalogTile />
+  if (isEmptySearch) return <SearchCatalogTile />
   if ((!lineup || lineup.entries.length === 0) && status === Status.SUCCESS) {
     return <NoResultsTile />
   }

--- a/packages/mobile/src/screens/search-screen-v2/searchState.ts
+++ b/packages/mobile/src/screens/search-screen-v2/searchState.ts
@@ -8,6 +8,7 @@ import {
   type SearchFilters
 } from '@audius/common/api'
 import { accountSelectors } from '@audius/common/store'
+import { isEmpty } from 'lodash'
 import { useSelector } from 'react-redux'
 
 const { getUserId } = accountSelectors
@@ -29,6 +30,11 @@ export const SearchContext = createContext<SearchContextType>({
   filters: {},
   setFilters: (_) => {}
 })
+
+export const useIsEmptySearch = () => {
+  const { query, filters } = useContext(SearchContext)
+  return !query && isEmpty(filters)
+}
 
 export const useSearchQuery = () => {
   const { query, setQuery } = useContext(SearchContext)


### PR DESCRIPTION
### Description
* Add NoResultsTile
* Add empty state for search results screens
* Update search to not request when no filters or query are passed
* Fix TrackResults screen pass filters properly and to avoid constant rerenders

### How Has This Been Tested?
Manually tested