### PR TITLE
Respect schema key arrays

### DIFF
--- a/packages/common/src/audius-query/createApi.ts
+++ b/packages/common/src/audius-query/createApi.ts
@@ -288,7 +288,10 @@ const useCacheData = <Args, Data>(
       endpoint.options.kind,
       hookOptions?.shallow
     )
-    if (typeof normalizedData === 'object' && !Array.isArray(normalizedData)) {
+    if (
+      endpoint.options.schemaKey ||
+      (typeof normalizedData === 'object' && !Array.isArray(normalizedData))
+    ) {
       return denormalize(normalizedData, apiResponseSchema, entityMap) as Data
     }
     return normalizedData
@@ -343,7 +346,10 @@ const fetchData = async <Args, Data>(
 
     let data: Data
 
-    if (typeof apiData === 'object' && !Array.isArray(apiData)) {
+    if (
+      endpoint.options.schemaKey ||
+      (typeof apiData === 'object' && !Array.isArray(apiData))
+    ) {
       const { entities, result } = normalize(
         endpoint.options.schemaKey
           ? { [endpoint.options.schemaKey]: apiData }


### PR DESCRIPTION
### Description

Missed a case in https://github.com/AudiusProject/audius-protocol/pull/9060 where the api data is an array, but we want to wrap it in the schema key.

### How Has This Been Tested?

`useGetFeaturedArtists` was returning undefined but is now working

Also tested other usages of audius-query which all look good