### PR TITLE
Update all emails: updated design, manage preferences

### DIFF
--- a/packages/discovery-provider/plugins/notifications/src/__tests__/mappings/usdcPurchaseBuyer.test.ts
+++ b/packages/discovery-provider/plugins/notifications/src/__tests__/mappings/usdcPurchaseBuyer.test.ts
@@ -113,7 +113,7 @@ describe('USDC Purchase Buyer', () => {
     expect(sendTransactionalEmailSpy).toHaveBeenCalledWith({
       email: 'user_2@gmail.com',
       html: expect.anything(),
-      subject: 'Thank You For Your Support'
+      subject: 'Thank you for your purchase!'
     })
   })
 

--- a/packages/discovery-provider/plugins/notifications/src/__tests__/mappings/usdcPurchaseSeller.test.ts
+++ b/packages/discovery-provider/plugins/notifications/src/__tests__/mappings/usdcPurchaseSeller.test.ts
@@ -114,7 +114,7 @@ describe('USDC Purchase Seller', () => {
     expect(sendTransactionalEmailSpy).toHaveBeenCalledWith({
       email: 'user_1@gmail.com',
       html: expect.anything(),
-      subject: 'Your Track Has Been Purchased'
+      subject: "Congrats! You've made a sale on Audius!"
     })
   })
 

--- a/packages/discovery-provider/plugins/notifications/src/__tests__/mappings/usdcTransfer.test.ts
+++ b/packages/discovery-provider/plugins/notifications/src/__tests__/mappings/usdcTransfer.test.ts
@@ -56,7 +56,7 @@ describe('USDC Transfer', () => {
     expect(sendTransactionalEmailSpy).toHaveBeenCalledWith({
       email: 'user_1@gmail.com',
       html: expect.anything(),
-      subject: 'Your Transfer Has Been Started'
+      subject: 'Your USDC Transfer is Complete!'
     })
   })
 })

--- a/packages/discovery-provider/plugins/notifications/src/__tests__/mappings/usdcWithdrawal.test.ts
+++ b/packages/discovery-provider/plugins/notifications/src/__tests__/mappings/usdcWithdrawal.test.ts
@@ -56,7 +56,7 @@ describe('USDC Withdrawal', () => {
     expect(sendTransactionalEmailSpy).toHaveBeenCalledWith({
       email: 'user_1@gmail.com',
       html: expect.anything(),
-      subject: 'Your Withdrawal Has Been Started'
+      subject: 'Your USDC Transfer is Complete!'
     })
   })
 })

--- a/packages/discovery-provider/plugins/notifications/src/email/notifications/preRendered/claimableReward.ts
+++ b/packages/discovery-provider/plugins/notifications/src/email/notifications/preRendered/claimableReward.ts
@@ -1054,7 +1054,14 @@ export const email = ({
   </tr>
   <tr>
   <td style="vertical-align: middle;" align="center">
-  <div style="line-height:14px;text-align:center;"><span style="color:#6a677a;font-family:Inter,Arial,sans-serif;font-size:12px;line-height:14px;text-align:center;">No longer want to receive these emails? </span><span style="color:#7e1bcc;font-family:Inter,Arial,sans-serif;font-size:12px;line-height:14px;text-align:center;">Unsubscribe </span><span style="color:#6a677a;font-family:Inter,Arial,sans-serif;font-size:12px;line-height:14px;text-align:center;">or</span><span style="color:#7e1bcc;font-family:Inter,Arial,sans-serif;font-size:12px;line-height:14px;text-align:center;"> Manage Email Preferences</span></div>
+  <div style="line-height:14px;text-align:center;"><span
+      style="color:#6a677a;font-family:Inter,Arial,sans-serif;font-size:12px;line-height:14px;text-align:center;">No
+      longer want to receive these emails? </span><a href="<%asm_group_unsubscribe_raw_url%>"><span
+      style="color:#7e1bcc;font-family:Inter,Arial,sans-serif;font-size:12px;line-height:14px;text-align:center;">Unsubscribe
+      </span></a><span
+      style="color:#6a677a;font-family:Inter,Arial,sans-serif;font-size:12px;line-height:14px;text-align:center;">or</span><a href="<%asm_preferences_raw_url%>"><span
+      style="color:#7e1bcc;font-family:Inter,Arial,sans-serif;font-size:12px;line-height:14px;text-align:center;"> Manage
+      Email Preferences</span></a></div>
   </td>
   </tr>
   </table>

--- a/packages/discovery-provider/plugins/notifications/src/email/notifications/preRendered/claimableReward.ts
+++ b/packages/discovery-provider/plugins/notifications/src/email/notifications/preRendered/claimableReward.ts
@@ -37,6 +37,7 @@ export const email = ({
   <link href="https://fonts.googleapis.com/css?family=Inter:900" rel="stylesheet" type="text/css">
   <link href="https://fonts.googleapis.com/css?family=Inter:500" rel="stylesheet" type="text/css">
   <style>
+  @import url('https://fonts.googleapis.com/css2?family=Inter:wght@100..900&display=swap');
   html {
       margin: 0 !important;
       padding: 0 !important;
@@ -274,8 +275,8 @@ export const email = ({
   <td align="center">
   <table cellspacing="0" cellpadding="0" border="0">
   <tr>
-  <td style="vertical-align: middle;" width="200" align="center"><img src="https://download.audius.co/emails/claimable-reward/H6iLdtDPafmBTBzLVTEm2ybTV6lF0F.gif" width="200" border="0" style="min-width:200px; width:200px;
-          border-radius:8px; height: auto; display: block;"></td>
+  <td style="vertical-align: middle;" width="200" align="center"><a href="https://audius.co/audio"><img src="https://download.audius.co/emails/claimable-reward/H6iLdtDPafmBTBzLVTEm2ybTV6lF0F.gif" width="200" border="0" style="min-width:200px; width:200px;
+          border-radius:8px; height: auto; display: block;"></a></td>
   </tr>
   </table>
   </td>

--- a/packages/discovery-provider/plugins/notifications/src/email/notifications/preRendered/purchase.ts
+++ b/packages/discovery-provider/plugins/notifications/src/email/notifications/preRendered/purchase.ts
@@ -52,6 +52,7 @@ export const email = ({
   <link href="https://fonts.googleapis.com/css?family=Inter:600" rel="stylesheet" type="text/css">
   <link href="https://fonts.googleapis.com/css?family=Inter:500" rel="stylesheet" type="text/css">
   <style>
+	@import url('https://fonts.googleapis.com/css2?family=Inter:wght@100..900&display=swap');
   html {
       margin: 0 !important;
       padding: 0 !important;
@@ -340,8 +341,8 @@ export const email = ({
   <td align="center">
   <table cellspacing="0" cellpadding="0" border="0">
   <tr>
-  <td style="vertical-align: middle;" width="180" class="stack-column-center" align="center"><img src="${contentImage}" width="180" border="0" style="min-width:180px; width:180px;
-          border-radius:8px; height: auto; display: block;"></td>
+  <td style="vertical-align: middle;" width="180" class="stack-column-center" align="center"><a href="${contentLink}"><img src="${contentImage}" width="180" border="0" style="min-width:180px; width:180px;
+          border-radius:8px; height: auto; display: block;"></a></td>
   </tr>
   </table>
   </td>
@@ -475,7 +476,7 @@ export const email = ({
   <div style="line-height:24px;text-align:left;"><span style="color:#52505f;font-family:Inter,Arial,sans-serif;font-size:16px;line-height:24px;text-align:left;">${contentTitle} by ${artistName}</span></div>
   </td>
   <td width="126">
-  <div style="line-height:24px;text-align:right;"><span style="color:#3a3843;font-family:Inter,Arial,sans-serif;font-size:16px;line-height:24px;text-align:right;">${price}</span></div>
+  <div style="line-height:24px;text-align:right;"><span style="color:#3a3843;font-family:Inter,Arial,sans-serif;font-size:16px;line-height:24px;text-align:right;">$${price}</span></div>
   </td>
   </tr>
   <tr>
@@ -484,18 +485,21 @@ export const email = ({
   </table>
   </td>
   </tr>
+	${
+    payExtra !== '0.00'
+      ? `
   <tr>
   <td width="100%" style=" border-width: 0px 0px 1px 0px; border-color:#e9e9eb; border-style:solid;">
   <table width="100%" border="0" cellpadding="0" cellspacing="0">
   <tr>
   <td height="16" style="height:16px; min-height:16px; line-height:16px;"></td>
   </tr>
-  <tr>
+	<tr>
   <td>
   <div style="line-height:24px;text-align:left;"><span style="color:#52505f;font-family:Inter,Arial,sans-serif;font-size:16px;line-height:24px;text-align:left;">Pay Extra</span></div>
   </td>
   <td width="126">
-  <div style="line-height:24px;text-align:right;"><span style="color:#3a3843;font-family:Inter,Arial,sans-serif;font-size:16px;line-height:24px;text-align:right;">${payExtra}</span></div>
+  <div style="line-height:24px;text-align:right;"><span style="color:#3a3843;font-family:Inter,Arial,sans-serif;font-size:16px;line-height:24px;text-align:right;">$${payExtra}</span></div>
   </td>
   </tr>
   <tr>
@@ -503,8 +507,10 @@ export const email = ({
   </tr>
   </table>
   </td>
-  </tr>
-  <tr>
+  </tr>`
+      : ''
+  }
+	<tr>
   <td width="100%">
   <table width="100%" border="0" cellpadding="0" cellspacing="0">
   <tr>
@@ -515,7 +521,7 @@ export const email = ({
   <div style="line-height:24px;text-align:left;"><span style="color:#52505f;font-weight:600;font-family:Inter,Arial,sans-serif;font-size:16px;line-height:24px;text-align:left;">Total</span></div>
   </td>
   <td width="126">
-  <div style="line-height:24px;text-align:right;"><span style="color:#3a3843;font-weight:600;font-family:Inter,Arial,sans-serif;font-size:16px;line-height:24px;text-align:right;">${total}</span></div>
+  <div style="line-height:24px;text-align:right;"><span style="color:#3a3843;font-weight:600;font-family:Inter,Arial,sans-serif;font-size:16px;line-height:24px;text-align:right;">$${total}</span></div>
   </td>
   </tr>
   <tr>
@@ -579,6 +585,9 @@ export const email = ({
   </table>
   </td>
   </tr>
+			`
+      : ``
+  }
   <tr>
   <td width="600">
   <table cellspacing="0" cellpadding="0" border="0">
@@ -640,8 +649,8 @@ export const email = ({
   <td width="552" align="center" style="vertical-align: middle;  ">
   <table class="table-w-full-mobile" width="100%" border="0" cellpadding="0" cellspacing="0">
   <tr>
-  <td style="vertical-align: middle;" width="156" class="stack-column-center" align="center"><img src="https://download.audius.co/emails/buyer-purchase/guB0eiO4uponvKRUonMnRIFuICSoqM.png" width="156" border="0" style="min-width:156px; width:156px;
-          border-radius:8px; height: auto; display: block;"></td>
+  <td style="vertical-align: middle;" width="156" class="stack-column-center" align="center"><a href="https://audius.co/audio"><img src="https://download.audius.co/emails/buyer-purchase/guB0eiO4uponvKRUonMnRIFuICSoqM.png" width="156" border="0" style="min-width:156px; width:156px;
+          border-radius:8px; height: auto; display: block;"></a></td>
   <td class="stack-column-center" height="16" style="width:16px; min-width:16px; height:16px; min-height:16px;" width="16"></td>
   <td style="vertical-align: middle;" align="center" class="stack-column-center">
   <table width="100%" cellspacing="0" cellpadding="0" border="0">
@@ -789,9 +798,7 @@ export const email = ({
   </table>
   </td>
   </tr>
-`
-      : ``
-  }
+
   <tr>
   <td width="100%">
   <table width="100%" cellspacing="0" cellpadding="0" border="0">

--- a/packages/discovery-provider/plugins/notifications/src/email/notifications/preRendered/purchase.ts
+++ b/packages/discovery-provider/plugins/notifications/src/email/notifications/preRendered/purchase.ts
@@ -1152,7 +1152,14 @@ export const email = ({
   </tr>
   <tr>
   <td style="vertical-align: middle;" align="center">
-  <div style="line-height:14px;text-align:center;"><span style="color:#6a677a;font-family:Inter,Arial,sans-serif;font-size:12px;line-height:14px;text-align:center;">No longer want to receive these emails? </span><span style="color:#7e1bcc;font-family:Inter,Arial,sans-serif;font-size:12px;line-height:14px;text-align:center;">Unsubscribe </span><span style="color:#6a677a;font-family:Inter,Arial,sans-serif;font-size:12px;line-height:14px;text-align:center;">or</span><span style="color:#7e1bcc;font-family:Inter,Arial,sans-serif;font-size:12px;line-height:14px;text-align:center;"> Manage Email Preferences</span></div>
+	<div style="line-height:14px;text-align:center;"><span
+			style="color:#6a677a;font-family:Inter,Arial,sans-serif;font-size:12px;line-height:14px;text-align:center;">No
+			longer want to receive these emails? </span><a href="<%asm_group_unsubscribe_raw_url%>"><span
+			style="color:#7e1bcc;font-family:Inter,Arial,sans-serif;font-size:12px;line-height:14px;text-align:center;">Unsubscribe
+			</span></a><span
+			style="color:#6a677a;font-family:Inter,Arial,sans-serif;font-size:12px;line-height:14px;text-align:center;">or</span><a href="<%asm_preferences_raw_url%>"><span
+			style="color:#7e1bcc;font-family:Inter,Arial,sans-serif;font-size:12px;line-height:14px;text-align:center;"> Manage
+			Email Preferences</span></a></div>
   </td>
   </tr>
   </table>

--- a/packages/discovery-provider/plugins/notifications/src/email/notifications/preRendered/rewardInCooldown.ts
+++ b/packages/discovery-provider/plugins/notifications/src/email/notifications/preRendered/rewardInCooldown.ts
@@ -5,7 +5,8 @@ export const email = ({
   profileLink,
   amount,
   challengeTitle,
-  challengeDescription
+  challengeDescription,
+  challengeImage
 }: {
   name: string
   handle: string
@@ -14,6 +15,7 @@ export const email = ({
   amount: number
   challengeTitle: string
   challengeDescription: string
+  challengeImage: string
 }) => {
   const copyrightYear = new Date().getFullYear().toString()
 
@@ -42,6 +44,7 @@ export const email = ({
   <link href="https://download.audius.co/emails/reward-in-cooldown/css(3)" rel="stylesheet" type="text/css">
   <link href="https://download.audius.co/emails/reward-in-cooldown/css(4)" rel="stylesheet" type="text/css">
   <style>
+  @import url('https://fonts.googleapis.com/css2?family=Inter:wght@100..900&display=swap');
   html {
       margin: 0 !important;
       padding: 0 !important;
@@ -77,7 +80,6 @@ export const email = ({
           min-width: 414px !important;
       }
   }
-  
   </style>
   <!--[if gte mso 9]>
           <xml>
@@ -334,7 +336,7 @@ export const email = ({
   <td width="552" align="center" style="vertical-align: middle;  ">
   <table class="table-w-full-mobile" width="100%" border="0" cellpadding="0" cellspacing="0">
   <tbody><tr>
-  <td style="vertical-align: middle;" width="156" class="stack-column-center" align="center"><img src="https://download.audius.co/emails/reward-in-cooldown/vPcgae71HXCYuWxXBDYqIBDQzJw75y.png" width="156" border="0" style="min-width:156px; width:156px;
+  <td style="vertical-align: middle;" width="156" class="stack-column-center" align="center"><img src="https://download.audius.co/emails/reward-in-cooldown/${challengeImage}" width="156" border="0" style="min-width:156px; width:156px;
           border-radius:8px; height: auto; display: block;"></td>
   <td class="stack-column-center" height="16" style="width:16px; min-width:16px; height:16px; min-height:16px;" width="16">&nbsp;</td>
   <td style="vertical-align: middle;" align="center" class="stack-column-center">
@@ -1255,7 +1257,14 @@ export const email = ({
   </tr>
   <tr>
   <td style="vertical-align: middle;" align="center">
-  <div style="line-height:14px;text-align:center;"><span style="color:#6a677a;font-family:Inter,Arial,sans-serif;font-size:12px;line-height:14px;text-align:center;">No longer want to receive these emails? </span><span style="color:#7e1bcc;font-family:Inter,Arial,sans-serif;font-size:12px;line-height:14px;text-align:center;">Unsubscribe </span><span style="color:#6a677a;font-family:Inter,Arial,sans-serif;font-size:12px;line-height:14px;text-align:center;">or</span><span style="color:#7e1bcc;font-family:Inter,Arial,sans-serif;font-size:12px;line-height:14px;text-align:center;"> Manage Email Preferences</span></div>
+  <div style="line-height:14px;text-align:center;"><span
+    style="color:#6a677a;font-family:Inter,Arial,sans-serif;font-size:12px;line-height:14px;text-align:center;">No
+    longer want to receive these emails? </span><a href="<%asm_group_unsubscribe_raw_url%>"><span
+    style="color:#7e1bcc;font-family:Inter,Arial,sans-serif;font-size:12px;line-height:14px;text-align:center;">Unsubscribe
+  </span></a><span
+    style="color:#6a677a;font-family:Inter,Arial,sans-serif;font-size:12px;line-height:14px;text-align:center;">or</span><a href="<%asm_preferences_raw_url%>"><span
+    style="color:#7e1bcc;font-family:Inter,Arial,sans-serif;font-size:12px;line-height:14px;text-align:center;"> Manage
+    Email Preferences</span></a></div>
   </td>
   </tr>
   </tbody></table>
@@ -1295,5 +1304,6 @@ export const email = ({
   </div>
   
   
-  </body></html>`
+  </body></html>
+  `
 }

--- a/packages/discovery-provider/plugins/notifications/src/email/notifications/preRendered/rewardInCooldown.ts
+++ b/packages/discovery-provider/plugins/notifications/src/email/notifications/preRendered/rewardInCooldown.ts
@@ -20,14 +20,15 @@ export const email = ({
   const copyrightYear = new Date().getFullYear().toString()
 
   return `
-  <!DOCTYPE html>
-  <!-- saved from url=(0124)file:///Users/isaacsolo/Downloads/Transactional/Reward%20Earned/Congratulations!%20You%E2%80%99ve%20earned%20a%20reward.html -->
-  <html lang="en" xmlns="http://www.w3.org/1999/xhtml" xmlns:v="urn:schemas-microsoft-com:vml" xmlns:o="urn:schemas-microsoft-com:office:office"><head><meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
-  
-  <meta content="width=device-width" name="viewport">
-  <meta content="IE=edge" http-equiv="X-UA-Compatible">
-  <meta name="x-apple-disable-message-reformatting">
-  <meta content="telephone=no,address=no,email=no,date=no,url=no" name="format-detection">
+  <!doctype html>
+  <html lang="en" xmlns="http://www.w3.org/1999/xhtml" xmlns:v="urn:schemas-microsoft-com:vml" xmlns:o="urn:schemas-microsoft-com:office:office">
+
+  <head>
+  <meta charset="utf-8" />
+  <meta content="width=device-width" name="viewport" />
+  <meta content="IE=edge" http-equiv="X-UA-Compatible" />
+  <meta name="x-apple-disable-message-reformatting" />
+  <meta content="telephone=no,address=no,email=no,date=no,url=no" name="format-detection" />
   <title>Congratulations! 🏆 You’ve earned a reward! </title>
   <!--[if mso]>
               <style>
@@ -38,18 +39,17 @@ export const email = ({
           <![endif]-->
   <!--[if !mso]><!-->
   <!-- <![endif]-->
-  <link href="https://download.audius.co/emails/reward-in-cooldown/css" rel="stylesheet" type="text/css">
-  <link href="https://download.audius.co/emails/reward-in-cooldown/css(1)" rel="stylesheet" type="text/css">
-  <link href="https://download.audius.co/emails/reward-in-cooldown/css(2)" rel="stylesheet" type="text/css">
-  <link href="https://download.audius.co/emails/reward-in-cooldown/css(3)" rel="stylesheet" type="text/css">
-  <link href="https://download.audius.co/emails/reward-in-cooldown/css(4)" rel="stylesheet" type="text/css">
+  <link href="https://fonts.googleapis.com/css?family=Inter:700" rel="stylesheet" type="text/css">
+  <link href="https://fonts.googleapis.com/css?family=Inter:400" rel="stylesheet" type="text/css">
+  <link href="https://fonts.googleapis.com/css?family=Inter:600" rel="stylesheet" type="text/css">
+  <link href="https://fonts.googleapis.com/css?family=Inter:900" rel="stylesheet" type="text/css">
+  <link href="https://fonts.googleapis.com/css?family=Inter:500" rel="stylesheet" type="text/css">
   <style>
-  @import url('https://fonts.googleapis.com/css2?family=Inter:wght@100..900&display=swap');
   html {
       margin: 0 !important;
       padding: 0 !important;
   }
-  
+
   * {
       -ms-text-size-adjust: 100%;
       -webkit-text-size-adjust: 100%;
@@ -80,6 +80,7 @@ export const email = ({
           min-width: 414px !important;
       }
   }
+
   </style>
   <!--[if gte mso 9]>
           <xml>
@@ -91,7 +92,7 @@ export const email = ({
           <![endif]-->
   <style>
   @media only screen and (max-device-width: 599px), only screen and (max-width: 599px) {
-  
+
       .eh {
           height:auto !important;
       }
@@ -125,46 +126,46 @@ export const email = ({
       .wid-auto {
           width:auto !important;
       }
-  
+
       .table-w-full-mobile {
           width: 100%;
       }
-  
+
       
       
-  
+
       .mobile-center {
           text-align: center;
       }
-  
+
       .mobile-center > table {
           display: inline-block;
           vertical-align: inherit;
       }
-  
+
       .mobile-left {
           text-align: left;
       }
-  
+
       .mobile-left > table {
           display: inline-block;
           vertical-align: inherit;
       }
-  
+
       .mobile-right {
           text-align: right;
       }
-  
+
       .mobile-right > table {
           display: inline-block;
           vertical-align: inherit;
       }
-  
+
   }
-  
+
   </style>
   </head>
-  
+
   <body width="100%" style="background-color:#e9e9eb;margin:0;padding:0!important;mso-line-height-rule:exactly;">
   <div style="background-color:#e9e9eb">
   <!--[if gte mso 9]>
@@ -173,46 +174,46 @@ export const email = ({
                                               </v:background>
                                               <![endif]-->
   <table width="100%" cellpadding="0" cellspacing="0" border="0">
-  <tbody><tr>
+  <tr>
   <td valign="top" align="center">
   <div id="preview_text" style="display: none; font-size: 1px; line-height: 1px; max-height: 0px; max-width: 0px; opacity: 0; overflow: hidden; mso-hide: all; font-family: sans-serif;"> You’ve earned ${amount} $AUDIO tokens for completing a reward! </div>
   <!-- Visually Hidden Preheader Text : END -->
   <!-- Preview Text Spacing Hack : BEGIN -->
-  <div style="display: none; font-size: 1px; line-height: 1px; max-height: 0px; max-width: 0px; opacity: 0; overflow: hidden; mso-hide: all; font-family: sans-serif;"> ‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp; </div>
+  <div style="display: none; font-size: 1px; line-height: 1px; max-height: 0px; max-width: 0px; opacity: 0; overflow: hidden; mso-hide: all; font-family: sans-serif;"> &zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp; </div>
   <table bgcolor="#ffffff" style="margin:0 auto;" align="center" id="brick_container" cellspacing="0" cellpadding="0" border="0" width="600" class="email-container">
-  <tbody><tr>
+  <tr>
   <td width="600">
   <table cellspacing="0" cellpadding="0" border="0">
-  <tbody><tr>
+  <tr>
   <td width="600" style="background-color:#ffffff;  " bgcolor="#ffffff">
   <table width="100%" border="0" cellpadding="0" cellspacing="0">
-  <tbody><tr>
+  <tr>
   <td width="100%">
   <table width="100%" cellspacing="0" cellpadding="0" border="0">
-  <tbody><tr>
+  <tr>
   <td width="100%" align="center" style="vertical-align: middle; background-color:#ffffff;   padding-left:8px; padding-right:8px;" bgcolor="#ffffff">
   <table border="0" cellpadding="0" cellspacing="0">
-  <tbody><tr>
+  <tr>
   <td height="8" style="height:8px; min-height:8px; line-height:8px;"></td>
   </tr>
   <tr>
   <td style="vertical-align: middle;" width="492">
   <table cellspacing="0" cellpadding="0" border="0">
-  <tbody><tr>
+  <tr>
   <td width="492" style="vertical-align: middle;  ">
   <table border="0" cellpadding="0" cellspacing="0">
-  <tbody><tr>
+  <tr>
   <td style="vertical-align: middle;" width="60"><img src="${profilePicture}" width="60" border="0" style="min-width:60px; width:60px;
           border-radius:64px; height: auto; display: block;"></td>
   <td style="width:16px; min-width:16px;" width="16"></td>
   <td style="vertical-align: middle;">
   <table cellspacing="0" cellpadding="0" border="0">
-  <tbody><tr>
+  <tr>
   <td style="vertical-align: middle;  ">
   <table width="100%" border="0" cellpadding="0" cellspacing="0">
-  <tbody><tr>
+  <tr>
   <td style="vertical-align: middle;">
-  <div style="line-height:24px;text-align:left;"><a target="_blank" href="${profileLink}"><span style="color:#52505f;font-weight:700;font-family:Inter,Arial,sans-serif;font-size:16px;letter-spacing:-0.02em;line-height:24px;text-align:left;">${name}</span></a></div>
+  <div style="line-height:24px;text-align:left;"><a href="${profileLink}"><span style="color:#52505f;font-weight:700;font-family:Inter,Arial,sans-serif;font-size:16px;letter-spacing:-0.02em;line-height:24px;text-align:left;">${name}</span></a></div>
   </td>
   </tr>
   <tr>
@@ -221,43 +222,43 @@ export const email = ({
   <tr>
   <td>
   <table cellspacing="0" cellpadding="0" border="0">
-  <tbody><tr>
+  <tr>
   <td style="vertical-align: middle;">
-  <div style="line-height:24px;text-align:left;"><a target="_blank" href="${profileLink}"><span style="color:#52505f;font-family:Inter,Arial,sans-serif;font-size:16px;line-height:24px;text-align:left;">@${handle}</span></a></div>
+  <div style="line-height:24px;text-align:left;"><a href="${profileLink}"><span style="color:#52505f;font-family:Inter,Arial,sans-serif;font-size:16px;line-height:24px;text-align:left;">@${handle}</span></a></div>
   </td>
   </tr>
-  </tbody></table>
+  </table>
   </td>
   </tr>
-  </tbody></table>
+  </table>
   </td>
   </tr>
-  </tbody></table>
+  </table>
   </td>
   </tr>
-  </tbody></table>
+  </table>
   </td>
   </tr>
-  </tbody></table>
+  </table>
   </td>
   <td style="width:8px; min-width:8px;" width="8"></td>
-  <td style="vertical-align: middle;" width="72" align="center"><img src="https://download.audius.co/emails/reward-in-cooldown/wjpZtP1xhyBviTyxW3eiX3mNsICvfZ.jpeg" width="72" border="0" style="min-width:72px; width:72px;
-           height: auto; display: block;"></td>
+  <td style="vertical-align: middle;" width="72" align="center"><img src="https://download.audius.co/emails/reward-in-cooldown/m8H7uCcnQi19596DRmY3q97kVWGSkM.jpeg" width="72" border="0" style="min-width:72px; width:72px;
+          height: auto; display: block;"></td>
   </tr>
   <tr>
   <td height="8" style="height:8px; min-height:8px; line-height:8px;"></td>
   </tr>
-  </tbody></table>
+  </table>
   </td>
   </tr>
-  </tbody></table>
+  </table>
   </td>
   </tr>
   <tr>
-  <td width="100%" align="center" class="2CrBPysesYMq3T3HpT8feOpQPwhsDF invert-bg" style="background-repeat:no-repeat !important; background-position: center center !important; background-size: cover !important; border-collapse:separate !important; padding-left:24px; padding-right:24px;" background="https://download.audius.co/emails/reward-in-cooldown/2CrBPysesYMq3T3HpT8feOpQPwhsDF.png">
+  <td width="100%" align="center" class="V8yh8wNHh676KghIfYX2bSxLJMyrt7 invert-bg" style="background-repeat:no-repeat !important; background-position: center center !important; background-size: cover !important; border-collapse:separate !important; padding-left:24px; padding-right:24px;" background="https://download.audius.co/emails/reward-in-cooldown/V8yh8wNHh676KghIfYX2bSxLJMyrt7.png">
   <!--[if gte mso 9]>
                   <v:image xmlns:v="urn:schemas-microsoft-com:vml" fill="true" stroke="false" style=" border: 0;display: inline-block; width: 600px; height:296px;"
-                  src="https://download.audius.co/emails/reward-in-cooldown/2CrBPysesYMq3T3HpT8feOpQPwhsDF.png"
+                  src="https://download.audius.co/emails/reward-in-cooldown/V8yh8wNHh676KghIfYX2bSxLJMyrt7.png"
                   />
                   <v:rect xmlns:v="urn:schemas-microsoft-com:vml" fill="true" stroke="false" style=" border: 0;display: inline-block;position: absolute; width: 600px; height:296px;">
                   <v:fill opacity="0%" color="#000" />
@@ -265,13 +266,13 @@ export const email = ({
                   <![endif]-->
   <div>
   <table width="100%" border="0" cellpadding="0" cellspacing="0">
-  <tbody><tr>
+  <tr>
   <td height="48" style="height:48px; min-height:48px; line-height:48px;"></td>
   </tr>
   <tr>
   <td width="100%" align="center" style="  padding-left:24px; padding-right:24px;">
   <table width="100%" border="0" cellpadding="0" cellspacing="0">
-  <tbody><tr>
+  <tr>
   <td align="center">
   <div style="line-height:24px;text-align:center;"><span style="color:#7e1bcc;font-weight:600;font-family:Inter,Arial,sans-serif;font-size:16px;line-height:24px;text-align:center;">Congratulations!</span></div>
   </td>
@@ -281,7 +282,7 @@ export const email = ({
   </tr>
   <tr>
   <td align="center">
-  <div style="line-height:48px;text-align:center;"><span style="color:#101828;font-weight:900;font-family:Inter,Arial,sans-serif;font-size:43px;letter-spacing:-0.02em;line-height:48px;text-align:center;">You’ve Earned a Reward!</span></div>
+  <div style="line-height:48px;text-align:center;"><span style="color:#3a3843;font-weight:900;font-family:Inter,Arial,sans-serif;font-size:43px;letter-spacing:-0.02em;line-height:48px;text-align:center;">You’ve Earned a Reward!</span></div>
   </td>
   </tr>
   <tr>
@@ -292,13 +293,13 @@ export const email = ({
   <div style="line-height:24px;text-align:center;"><span style="color:#3a3843;font-family:Inter,Arial,sans-serif;font-size:16px;line-height:24px;text-align:center;">You’ve earned ${amount} $AUDIO tokens for completing a reward!</span></div>
   </td>
   </tr>
-  </tbody></table>
+  </table>
   </td>
   </tr>
   <tr>
   <td height="48" style="height:48px; min-height:48px; line-height:48px;"></td>
   </tr>
-  </tbody></table>
+  </table>
   </div>
   <!--[if gte mso 9]>
                   </v:textbox>
@@ -311,46 +312,46 @@ export const email = ({
   <tr>
   <td>
   <table cellspacing="0" cellpadding="0" border="0">
-  <tbody><tr>
+  <tr>
   <td align="center" style="background-color:#ffffff;  " bgcolor="#ffffff">
   <table width="100%" border="0" cellpadding="0" cellspacing="0">
-  <tbody><tr>
+  <tr>
   <td>
   <table cellspacing="0" cellpadding="0" border="0">
-  <tbody><tr>
+  <tr>
   <td align="center" style="background-color:#ffffff;  " bgcolor="#ffffff">
   <table width="100%" border="0" cellpadding="0" cellspacing="0">
-  <tbody><tr>
+  <tr>
   <td width="600">
   <table cellspacing="0" cellpadding="0" border="0">
-  <tbody><tr>
+  <tr>
   <td width="552" align="center" style="vertical-align: middle; background-color:#ffffff;   padding-left:24px; padding-right:24px;" bgcolor="#ffffff">
   <table width="100%" border="0" cellpadding="0" cellspacing="0">
-  <tbody><tr>
+  <tr>
   <td height="24" style="height:24px; min-height:24px; line-height:24px;"></td>
   </tr>
   <tr>
   <td style="vertical-align: middle;" width="100%">
   <table width="100%" cellspacing="0" cellpadding="0" border="0">
-  <tbody><tr>
+  <tr>
   <td width="552" align="center" style="vertical-align: middle;  ">
   <table class="table-w-full-mobile" width="100%" border="0" cellpadding="0" cellspacing="0">
-  <tbody><tr>
-  <td style="vertical-align: middle;" width="156" class="stack-column-center" align="center"><img src="https://download.audius.co/emails/reward-in-cooldown/${challengeImage}" width="156" border="0" style="min-width:156px; width:156px;
-          border-radius:8px; height: auto; display: block;"></td>
-  <td class="stack-column-center" height="16" style="width:16px; min-width:16px; height:16px; min-height:16px;" width="16">&nbsp;</td>
+  <tr>
+  <td style="vertical-align: middle;" width="156" class="stack-column-center" align="center"><a href="https://audius.co/audio"><img src="https://download.audius.co/emails/reward-in-cooldown/${challengeImage}" width="156" border="0" style="min-width:156px; width:156px;
+          height: auto; display: block;"></a></td>
+  <td class="stack-column-center" height="16" style="width:16px; min-width:16px; height:16px; min-height:16px;" width="16"></td>
   <td style="vertical-align: middle;" align="center" class="stack-column-center">
   <table width="100%" cellspacing="0" cellpadding="0" border="0">
-  <tbody><tr>
+  <tr>
   <td>
   <table width="100%" border="0" cellpadding="0" cellspacing="0">
-  <tbody><tr>
+  <tr>
   <td width="100%">
   <table width="100%" border="0" cellpadding="0" cellspacing="0">
-  <tbody><tr>
+  <tr>
   <td width="100%">
   <table width="100%" border="0" cellpadding="0" cellspacing="0">
-  <tbody><tr>
+  <tr>
   <td>
   <div style="line-height:36px;text-align:left;"><span style="color:#3a3843;font-weight:700;font-family:Inter,Arial,sans-serif;font-size:27px;letter-spacing:-0.02em;line-height:36px;text-align:left;">${challengeTitle}</span></div>
   </td>
@@ -360,25 +361,25 @@ export const email = ({
   </tr>
   <tr>
   <td>
-  <div style="line-height:24px;text-align:left;"><span style="color:#3a3843;font-family:Inter,Arial,sans-serif;font-size:16px;line-height:24px;text-align:left;">${challengeDescription}</span></div>
+  <div style="line-height:24px;text-align:left;"><span style="color:#52505f;font-family:Inter,Arial,sans-serif;font-size:16px;line-height:24px;text-align:left;">${challengeDescription}</span></div>
   </td>
   </tr>
-  </tbody></table>
+  </table>
   </td>
   </tr>
-  </tbody></table>
+  </table>
   </td>
   </tr>
-  </tbody></table>
+  </table>
   </td>
   </tr>
-  </tbody></table>
+  </table>
   </td>
   </tr>
-  </tbody></table>
+  </table>
   </td>
   </tr>
-  </tbody></table>
+  </table>
   </td>
   </tr>
   <tr>
@@ -387,22 +388,22 @@ export const email = ({
   <tr>
   <td style="vertical-align: middle;" width="100%">
   <table width="100%" cellspacing="0" cellpadding="0" border="0">
-  <tbody><tr>
+  <tr>
   <td width="552" align="center" style="vertical-align: middle;  ">
   <table class="table-w-full-mobile" width="100%" border="0" cellpadding="0" cellspacing="0">
-  <tbody><tr>
+  <tr>
   <td style="vertical-align: middle;" align="center" width="100%" class="stack-column-center">
   <table width="100%" cellspacing="0" cellpadding="0" border="0">
-  <tbody><tr>
+  <tr>
   <td width="100%" align="center" style="vertical-align: middle; background-color:#ffffff;  " bgcolor="#ffffff">
   <table width="100%" border="0" cellpadding="0" cellspacing="0">
-  <tbody><tr>
+  <tr>
   <td style="vertical-align: middle;" width="100%">
   <table width="100%" cellspacing="0" cellpadding="0" border="0">
-  <tbody><tr>
+  <tr>
   <td width="100%" align="center" style="vertical-align: middle; background-color:#f9f7fc; border-radius:4px; border:1px solid #ebe4f6; padding-left:24px; padding-right:24px;" bgcolor="#f9f7fc">
   <table width="100%" border="0" cellpadding="0" cellspacing="0">
-  <tbody><tr>
+  <tr>
   <td height="16" style="height:16px; min-height:16px; line-height:16px;"></td>
   </tr>
   <tr>
@@ -413,85 +414,85 @@ export const email = ({
   <tr>
   <td height="16" style="height:16px; min-height:16px; line-height:16px;"></td>
   </tr>
-  </tbody></table>
+  </table>
   </td>
   </tr>
-  </tbody></table>
+  </table>
   </td>
   </tr>
-  </tbody></table>
+  </table>
   </td>
   </tr>
-  </tbody></table>
+  </table>
   </td>
   </tr>
-  </tbody></table>
+  </table>
   </td>
   </tr>
-  </tbody></table>
+  </table>
   </td>
   </tr>
   <tr>
   <td height="24" style="height:24px; min-height:24px; line-height:24px;"></td>
   </tr>
-  </tbody></table>
+  </table>
   </td>
   </tr>
-  </tbody></table>
+  </table>
   </td>
   </tr>
-  </tbody></table>
+  </table>
   </td>
   </tr>
-  </tbody></table>
+  </table>
   </td>
   </tr>
-  </tbody></table>
+  </table>
   </td>
   </tr>
-  </tbody></table>
+  </table>
   </td>
   </tr>
   <tr>
   <td width="600">
   <table cellspacing="0" cellpadding="0" border="0">
-  <tbody><tr>
+  <tr>
   <td width="552" style="vertical-align: middle; height:48px; background-color:#ffffff;   padding-left:24px; padding-right:24px;" bgcolor="#ffffff">
   <table width="100%" border="0" cellpadding="0" cellspacing="0">
-  <tbody><tr>
+  <tr>
   <td height="12" style="height:12px; min-height:12px; line-height:12px;"></td>
   </tr>
   <tr>
   <td style="vertical-align: middle;" width="552">
   <table cellspacing="0" cellpadding="0" border="0">
-  <tbody><tr>
+  <tr>
   <td width="552">
   <table cellpadding="0" cellspacing="0" height="1" width="100%" style="line-height:1px;height:1px!important; border:1px solid #e9e9eb; border-collapse:separate !important;margin:0 auto;text-align:center;">
-  <tbody><tr>
+  <tr>
   <td> </td>
   </tr>
-  </tbody></table>
+  </table>
   </td>
   </tr>
-  </tbody></table>
+  </table>
   </td>
   </tr>
   <tr>
   <td height="12" style="height:12px; min-height:12px; line-height:12px;"></td>
   </tr>
-  </tbody></table>
+  </table>
   </td>
   </tr>
-  </tbody></table>
+  </table>
   </td>
   </tr>
   <tr>
   <td width="600">
   <table cellspacing="0" cellpadding="0" border="0">
-  <tbody><tr>
+  <tr>
   <td width="552" align="center" style="vertical-align: middle; background-color:#ffffff;   padding-left:24px; padding-right:24px;" bgcolor="#ffffff">
   <table width="100%" border="0" cellpadding="0" cellspacing="0">
-  <tbody><tr>
+  <tr>
   <td height="24" style="height:24px; min-height:24px; line-height:24px;"></td>
   </tr>
   <tr>
@@ -510,56 +511,56 @@ export const email = ({
   <tr>
   <td height="16" style="height:16px; min-height:16px; line-height:16px;"></td>
   </tr>
-  </tbody></table>
+  </table>
   </td>
   </tr>
-  </tbody></table>
+  </table>
   </td>
   </tr>
   <tr>
   <td width="600">
   <table cellspacing="0" cellpadding="0" border="0">
-  <tbody><tr>
+  <tr>
   <td width="552" style="background-color:#ffffff;   padding-left:24px; padding-right:24px;" bgcolor="#ffffff">
   <table width="100%" border="0" cellpadding="0" cellspacing="0">
-  <tbody><tr>
+  <tr>
   <td height="24" style="height:24px; min-height:24px; line-height:24px;"></td>
   </tr>
   <tr>
   <td width="552" align="center">
   <table class="table-w-full-mobile" width="100%" border="0" cellpadding="0" cellspacing="0">
-  <tbody><tr>
+  <tr>
   <td align="center" width="47.83%" class="stack-column-center">
   <table width="100%" cellspacing="0" cellpadding="0" border="0">
-  <tbody><tr>
+  <tr>
   <td align="center">
   <table width="100%" border="0" cellpadding="0" cellspacing="0">
-  <tbody><tr>
+  <tr>
   <td align="center">
   <table cellspacing="0" cellpadding="0" border="0">
-  <tbody><tr>
+  <tr>
   <td>
   <table cellspacing="0" cellpadding="0" border="0">
-  <tbody><tr>
+  <tr>
   <td style="background-color:#f9f7fc; border-radius:32px; border:1px solid #ebe4f6; padding-left:16px; padding-right:16px;" bgcolor="#f9f7fc">
   <table width="100%" border="0" cellpadding="0" cellspacing="0">
-  <tbody><tr>
-  <td height="16" style="height:16px; min-height:16px; line-height:16px;"></td>
-  </tr>
-  <tr>
-  <td width="24"><img src="https://download.audius.co/emails/reward-in-cooldown/oc5hUVWNbPpKxHmYw80DXToOBmDJBM.png" width="24" border="0" style="min-width:24px; width:24px;
-           height: auto; display: block;"></td>
-  </tr>
   <tr>
   <td height="16" style="height:16px; min-height:16px; line-height:16px;"></td>
   </tr>
-  </tbody></table>
+  <tr>
+  <td width="24"><img src="https://download.audius.co/emails/reward-in-cooldown/KmKtcqknCIQBqZDYFImeroF07GkQWl.png" width="24" border="0" style="min-width:24px; width:24px;
+          height: auto; display: block;"></td>
+  </tr>
+  <tr>
+  <td height="16" style="height:16px; min-height:16px; line-height:16px;"></td>
+  </tr>
+  </table>
   </td>
   </tr>
-  </tbody></table>
+  </table>
   </td>
   </tr>
-  </tbody></table>
+  </table>
   </td>
   </tr>
   <tr>
@@ -568,7 +569,7 @@ export const email = ({
   <tr>
   <td width="100%">
   <table width="100%" border="0" cellpadding="0" cellspacing="0">
-  <tbody><tr>
+  <tr>
   <td>
   <div style="line-height:24px;text-align:center;"><span style="color:#3a3843;font-weight:700;font-family:Inter,Arial,sans-serif;font-size:16px;letter-spacing:-0.02em;line-height:24px;text-align:center;">Send a Tip!</span></div>
   </td>
@@ -581,46 +582,46 @@ export const email = ({
   <div style="line-height:24px;text-align:center;"><span style="color:#52505f;font-family:Inter,Arial,sans-serif;font-size:16px;line-height:24px;text-align:center;">Tip your favorite Audius creators to show them some love.</span></div>
   </td>
   </tr>
-  </tbody></table>
+  </table>
   </td>
   </tr>
-  </tbody></table>
+  </table>
   </td>
   </tr>
-  </tbody></table>
+  </table>
   </td>
-  <td class="stack-column-center" height="24" style="width:24px; min-width:24px; height:24px; min-height:24px;" width="24">&nbsp;</td>
+  <td class="stack-column-center" height="24" style="width:24px; min-width:24px; height:24px; min-height:24px;" width="24"></td>
   <td align="center" width="47.83%" class="stack-column-center">
   <table width="100%" cellspacing="0" cellpadding="0" border="0">
-  <tbody><tr>
+  <tr>
   <td align="center">
   <table width="100%" border="0" cellpadding="0" cellspacing="0">
-  <tbody><tr>
+  <tr>
   <td align="center">
   <table cellspacing="0" cellpadding="0" border="0">
-  <tbody><tr>
+  <tr>
   <td>
   <table cellspacing="0" cellpadding="0" border="0">
-  <tbody><tr>
+  <tr>
   <td style="background-color:#f9f7fc; border-radius:32px; border:1px solid #ebe4f6; padding-left:16px; padding-right:16px;" bgcolor="#f9f7fc">
   <table width="100%" border="0" cellpadding="0" cellspacing="0">
-  <tbody><tr>
-  <td height="16" style="height:16px; min-height:16px; line-height:16px;"></td>
-  </tr>
-  <tr>
-  <td width="24"><img src="https://download.audius.co/emails/reward-in-cooldown/xtAvsz4kPIlTRsuf3ooujdGQ7itdfU.png" width="24" border="0" style="min-width:24px; width:24px;
-           height: auto; display: block;"></td>
-  </tr>
   <tr>
   <td height="16" style="height:16px; min-height:16px; line-height:16px;"></td>
   </tr>
-  </tbody></table>
+  <tr>
+  <td width="24"><img src="https://download.audius.co/emails/reward-in-cooldown/zYVlg7RCLpeDyuwcdZUX5pewdb90oG.png" width="24" border="0" style="min-width:24px; width:24px;
+          height: auto; display: block;"></td>
+  </tr>
+  <tr>
+  <td height="16" style="height:16px; min-height:16px; line-height:16px;"></td>
+  </tr>
+  </table>
   </td>
   </tr>
-  </tbody></table>
+  </table>
   </td>
   </tr>
-  </tbody></table>
+  </table>
   </td>
   </tr>
   <tr>
@@ -629,7 +630,7 @@ export const email = ({
   <tr>
   <td width="100%">
   <table width="100%" border="0" cellpadding="0" cellspacing="0">
-  <tbody><tr>
+  <tr>
   <td>
   <div style="line-height:24px;text-align:center;"><span style="color:#3a3843;font-weight:700;font-family:Inter,Arial,sans-serif;font-size:16px;letter-spacing:-0.02em;line-height:24px;text-align:center;">VIP Badges</span></div>
   </td>
@@ -642,16 +643,16 @@ export const email = ({
   <div style="line-height:24px;text-align:center;"><span style="color:#52505f;font-family:Inter,Arial,sans-serif;font-size:16px;line-height:24px;text-align:center;">Stand out with a VIP a badge next to your name throughout the app.</span></div>
   </td>
   </tr>
-  </tbody></table>
+  </table>
   </td>
   </tr>
-  </tbody></table>
+  </table>
   </td>
   </tr>
-  </tbody></table>
+  </table>
   </td>
   </tr>
-  </tbody></table>
+  </table>
   </td>
   </tr>
   <tr>
@@ -660,38 +661,38 @@ export const email = ({
   <tr>
   <td width="552" align="center">
   <table class="table-w-full-mobile" width="100%" border="0" cellpadding="0" cellspacing="0">
-  <tbody><tr>
+  <tr>
   <td align="center" width="47.83%" class="stack-column-center">
   <table width="100%" cellspacing="0" cellpadding="0" border="0">
-  <tbody><tr>
+  <tr>
   <td align="center">
   <table width="100%" border="0" cellpadding="0" cellspacing="0">
-  <tbody><tr>
+  <tr>
   <td align="center">
   <table cellspacing="0" cellpadding="0" border="0">
-  <tbody><tr>
+  <tr>
   <td>
   <table cellspacing="0" cellpadding="0" border="0">
-  <tbody><tr>
+  <tr>
   <td style="background-color:#f9f7fc; border-radius:32px; border:1px solid #ebe4f6; padding-left:16px; padding-right:16px;" bgcolor="#f9f7fc">
   <table width="100%" border="0" cellpadding="0" cellspacing="0">
-  <tbody><tr>
-  <td height="16" style="height:16px; min-height:16px; line-height:16px;"></td>
-  </tr>
-  <tr>
-  <td width="24"><img src="https://download.audius.co/emails/reward-in-cooldown/YKrUBKvkgjguE1walsGI7woIPKp9gk.png" width="24" border="0" style="min-width:24px; width:24px;
-           height: auto; display: block;"></td>
-  </tr>
   <tr>
   <td height="16" style="height:16px; min-height:16px; line-height:16px;"></td>
   </tr>
-  </tbody></table>
+  <tr>
+  <td width="24"><img src="https://download.audius.co/emails/reward-in-cooldown/udw6GqtQFqeX82xQZQvAxAD6HnoVaQ.png" width="24" border="0" style="min-width:24px; width:24px;
+          height: auto; display: block;"></td>
+  </tr>
+  <tr>
+  <td height="16" style="height:16px; min-height:16px; line-height:16px;"></td>
+  </tr>
+  </table>
   </td>
   </tr>
-  </tbody></table>
+  </table>
   </td>
   </tr>
-  </tbody></table>
+  </table>
   </td>
   </tr>
   <tr>
@@ -700,7 +701,7 @@ export const email = ({
   <tr>
   <td width="100%">
   <table width="100%" border="0" cellpadding="0" cellspacing="0">
-  <tbody><tr>
+  <tr>
   <td>
   <div style="line-height:24px;text-align:center;"><span style="color:#3a3843;font-weight:700;font-family:Inter,Arial,sans-serif;font-size:16px;letter-spacing:-0.02em;line-height:24px;text-align:center;">Discord Roles</span></div>
   </td>
@@ -713,46 +714,46 @@ export const email = ({
   <div style="line-height:24px;text-align:center;"><span style="color:#52505f;font-family:Inter,Arial,sans-serif;font-size:16px;line-height:24px;text-align:center;">VIP Badge holders unlock custom roles in our Discord Community!</span></div>
   </td>
   </tr>
-  </tbody></table>
+  </table>
   </td>
   </tr>
-  </tbody></table>
+  </table>
   </td>
   </tr>
-  </tbody></table>
+  </table>
   </td>
-  <td class="stack-column-center" height="24" style="width:24px; min-width:24px; height:24px; min-height:24px;" width="24">&nbsp;</td>
+  <td class="stack-column-center" height="24" style="width:24px; min-width:24px; height:24px; min-height:24px;" width="24"></td>
   <td align="center" width="47.83%" class="stack-column-center">
   <table width="100%" cellspacing="0" cellpadding="0" border="0">
-  <tbody><tr>
+  <tr>
   <td align="center">
   <table width="100%" border="0" cellpadding="0" cellspacing="0">
-  <tbody><tr>
+  <tr>
   <td align="center">
   <table cellspacing="0" cellpadding="0" border="0">
-  <tbody><tr>
+  <tr>
   <td>
   <table cellspacing="0" cellpadding="0" border="0">
-  <tbody><tr>
+  <tr>
   <td style="background-color:#f9f7fc; border-radius:32px; border:1px solid #ebe4f6; padding-left:16px; padding-right:16px;" bgcolor="#f9f7fc">
   <table width="100%" border="0" cellpadding="0" cellspacing="0">
-  <tbody><tr>
-  <td height="16" style="height:16px; min-height:16px; line-height:16px;"></td>
-  </tr>
-  <tr>
-  <td width="24"><img src="https://download.audius.co/emails/reward-in-cooldown/g3byDkrkP9kHERR1lEqTJZfFpsaHB0.png" width="24" border="0" style="min-width:24px; width:24px;
-           height: auto; display: block;"></td>
-  </tr>
   <tr>
   <td height="16" style="height:16px; min-height:16px; line-height:16px;"></td>
   </tr>
-  </tbody></table>
+  <tr>
+  <td width="24"><img src="https://download.audius.co/emails/reward-in-cooldown/KvVtOUBI8QS0dYdenns7Q2sj53Z2qj.png" width="24" border="0" style="min-width:24px; width:24px;
+          height: auto; display: block;"></td>
+  </tr>
+  <tr>
+  <td height="16" style="height:16px; min-height:16px; line-height:16px;"></td>
+  </tr>
+  </table>
   </td>
   </tr>
-  </tbody></table>
+  </table>
   </td>
   </tr>
-  </tbody></table>
+  </table>
   </td>
   </tr>
   <tr>
@@ -761,7 +762,7 @@ export const email = ({
   <tr>
   <td width="100%">
   <table width="100%" border="0" cellpadding="0" cellspacing="0">
-  <tbody><tr>
+  <tr>
   <td>
   <div style="line-height:24px;text-align:center;"><span style="color:#3a3843;font-weight:700;font-family:Inter,Arial,sans-serif;font-size:16px;letter-spacing:-0.02em;line-height:24px;text-align:center;">Exclusive Features</span></div>
   </td>
@@ -774,67 +775,67 @@ export const email = ({
   <div style="line-height:24px;text-align:center;"><span style="color:#52505f;font-family:Inter,Arial,sans-serif;font-size:16px;line-height:24px;text-align:center;">Access to exclusive features reserved for VIP Badge holders.</span></div>
   </td>
   </tr>
-  </tbody></table>
+  </table>
   </td>
   </tr>
-  </tbody></table>
+  </table>
   </td>
   </tr>
-  </tbody></table>
+  </table>
   </td>
   </tr>
-  </tbody></table>
+  </table>
   </td>
   </tr>
   <tr>
   <td height="24" style="height:24px; min-height:24px; line-height:24px;"></td>
   </tr>
-  </tbody></table>
+  </table>
   </td>
   </tr>
-  </tbody></table>
+  </table>
   </td>
   </tr>
   <tr>
   <td width="600">
   <table cellspacing="0" cellpadding="0" border="0">
-  <tbody><tr>
+  <tr>
   <td width="552" style="vertical-align: middle; height:36px; background-color:#ffffff;   padding-left:24px; padding-right:24px;" bgcolor="#ffffff">
   <table width="100%" border="0" cellpadding="0" cellspacing="0">
-  <tbody><tr>
+  <tr>
   <td height="12" style="height:12px; min-height:12px; line-height:12px;"></td>
   </tr>
   <tr>
   <td style="vertical-align: middle;" width="552">
   <table cellspacing="0" cellpadding="0" border="0">
-  <tbody><tr>
+  <tr>
   <td width="552">
   <table cellpadding="0" cellspacing="0" height="1" width="100%" style="line-height:1px;height:1px!important; border:1px solid #e9e9eb; border-collapse:separate !important;margin:0 auto;text-align:center;">
-  <tbody><tr>
+  <tr>
   <td> </td>
   </tr>
-  </tbody></table>
+  </table>
   </td>
   </tr>
-  </tbody></table>
+  </table>
   </td>
   </tr>
   <tr>
   <td height="12" style="height:12px; min-height:12px; line-height:12px;"></td>
   </tr>
-  </tbody></table>
+  </table>
   </td>
   </tr>
-  </tbody></table>
+  </table>
   </td>
   </tr>
   <tr>
   <td width="600">
   <table cellspacing="0" cellpadding="0" border="0">
-  <tbody><tr>
+  <tr>
   <td width="552" align="center" style="background-color:#ffffff;   padding-left:24px; padding-right:24px;" bgcolor="#ffffff">
   <table width="100%" border="0" cellpadding="0" cellspacing="0">
-  <tbody><tr>
+  <tr>
   <td height="24" style="height:24px; min-height:24px; line-height:24px;"></td>
   </tr>
   <tr>
@@ -842,31 +843,31 @@ export const email = ({
   <div style="line-height:24px;text-align:center;"><span style="color:#52505f;font-weight:700;font-family:Inter,Arial,sans-serif;font-size:16px;letter-spacing:-0.02em;line-height:24px;text-align:center;">Looking for ways to earn? <br>Check out your rewards page for more info.</span></div>
   </td>
   </tr>
-  </tbody></table>
+  </table>
   </td>
   </tr>
-  </tbody></table>
+  </table>
   </td>
   </tr>
   <tr>
   <td width="600">
   <table cellspacing="0" cellpadding="0" border="0">
-  <tbody><tr>
+  <tr>
   <td width="552" align="center" style="vertical-align: middle; background-color:#ffffff;   padding-left:24px; padding-right:24px;" bgcolor="#ffffff">
   <table width="100%" border="0" cellpadding="0" cellspacing="0">
-  <tbody><tr>
+  <tr>
   <td height="16" style="height:16px; min-height:16px; line-height:16px;"></td>
   </tr>
   <tr>
   <td align="center">
   <table cellspacing="0" cellpadding="0" border="0">
-  <tbody><tr>
+  <tr>
   <td style="vertical-align: middle;" width="420">
   <table cellspacing="0" cellpadding="0" border="0">
-  <tbody><tr>
+  <tr>
   <td width="420" align="center">
   <table class="table-w-full-mobile" width="100%" border="0" cellpadding="0" cellspacing="0">
-  <tbody><tr>
+  <tr>
   <td class="stack-column-center" align="center">
   <div>
   <!--[if mso]>
@@ -875,42 +876,42 @@ export const email = ({
                           <center style="white-space:nowrap;display:inline-block;text-align:center;color:#3a3843;font-weight:600;font-family:Inter,Arial,sans-serif;font-size:18px;">More Ways to Earn</center>
                           </v:roundrect>
                       <![endif]-->
-  <a target="_blank" href="https://audius.co/audio" style="white-space:nowrap;background-color:#ffffff;border-radius:8px; border:1px solid #b5b4bb;display:inline-block;text-align:center;color:#3a3843;font-weight:600;font-family:Inter,Arial,sans-serif;font-size:18px;line-height:48px;width:100%; -webkit-text-size-adjust:none;mso-hide:all;">More Ways to Earn</a>
+  <a href="https://audius.co/audio" style="white-space:nowrap;background-color:#ffffff;border-radius:8px; border:1px solid #b5b4bb;display:inline-block;text-align:center;color:#3a3843;font-weight:600;font-family:Inter,Arial,sans-serif;font-size:18px;line-height:48px;width:100%; -webkit-text-size-adjust:none;mso-hide:all;">More Ways to Earn</a>
   </div>
   </td>
   </tr>
-  </tbody></table>
+  </table>
   </td>
   </tr>
-  </tbody></table>
+  </table>
   </td>
   </tr>
-  </tbody></table>
+  </table>
   </td>
   </tr>
   <tr>
   <td height="48" style="height:48px; min-height:48px; line-height:48px;"></td>
   </tr>
-  </tbody></table>
+  </table>
   </td>
   </tr>
-  </tbody></table>
+  </table>
   </td>
   </tr>
   <tr>
   <td width="100%">
   <table width="100%" cellspacing="0" cellpadding="0" border="0">
-  <tbody><tr>
+  <tr>
   <td width="100%" align="center" style="background-color:#ffffff;   padding-left:24px; padding-right:24px;" bgcolor="#ffffff">
   <table width="100%" border="0" cellpadding="0" cellspacing="0">
-  <tbody><tr>
+  <tr>
   <td height="24" style="height:24px; min-height:24px; line-height:24px;"></td>
   </tr>
   <tr>
-  <td width="100%" align="center" class="QTz2bR6R8NezOfP6k0grnIDfVele7g invert-bg" style="vertical-align: middle; background-repeat:no-repeat !important; background-position: center center !important; background-size: cover !important;border-radius:12px; border-collapse:separate !important; padding-left:24px; padding-right:24px;" background="https://download.audius.co/emails/reward-in-cooldown/QTz2bR6R8NezOfP6k0grnIDfVele7g.png">
+  <td width="100%" align="center" class="quvdArz9j4zgsQ2WuFSFC7PL1QReAc invert-bg" style="vertical-align: middle; background-repeat:no-repeat !important; background-position: center center !important; background-size: cover !important;border-radius:12px; border-collapse:separate !important; padding-left:24px; padding-right:24px;" background="https://download.audius.co/emails/reward-in-cooldown/quvdArz9j4zgsQ2WuFSFC7PL1QReAc.png">
   <!--[if gte mso 9]>
                   <v:image xmlns:v="urn:schemas-microsoft-com:vml" fill="true" stroke="false" style=" border: 0;display: inline-block; width: 552px; height:182px;"
-                  src="https://download.audius.co/emails/reward-in-cooldown/QTz2bR6R8NezOfP6k0grnIDfVele7g.png"
+                  src="https://download.audius.co/emails/reward-in-cooldown/quvdArz9j4zgsQ2WuFSFC7PL1QReAc.png"
                   />
                   <v:rect xmlns:v="urn:schemas-microsoft-com:vml" fill="true" stroke="false" style=" border: 0;display: inline-block;position: absolute; width: 552px; height:182px;">
                   <v:fill opacity="0%" color="#000" />
@@ -918,24 +919,24 @@ export const email = ({
                   <![endif]-->
   <div>
   <table width="100%" border="0" cellpadding="0" cellspacing="0">
-  <tbody><tr>
+  <tr>
   <td height="36" style="height:36px; min-height:36px; line-height:36px;"></td>
   </tr>
   <tr>
   <td style="vertical-align: middle;" width="100%">
   <table width="100%" cellspacing="0" cellpadding="0" border="0">
-  <tbody><tr>
+  <tr>
   <td width="100%" align="center" style="vertical-align: middle;  ">
   <table width="100%" border="0" cellpadding="0" cellspacing="0">
-  <tbody><tr>
+  <tr>
   <td style="vertical-align: middle;" align="center">
   <div style="line-height:36px;text-align:center;"><span style="color:#3a3843;font-weight:700;font-family:Inter,Arial,sans-serif;font-size:27px;letter-spacing:-0.02em;line-height:36px;text-align:center;">Download The App!</span></div>
   </td>
   </tr>
-  </tbody></table>
+  </table>
   </td>
   </tr>
-  </tbody></table>
+  </table>
   </td>
   </tr>
   <tr>
@@ -944,32 +945,32 @@ export const email = ({
   <tr>
   <td style="vertical-align: middle;" width="100%">
   <table width="100%" cellspacing="0" cellpadding="0" border="0">
-  <tbody><tr>
+  <tr>
   <td width="100%" align="center">
   <table width="100%" border="0" cellpadding="0" cellspacing="0">
-  <tbody><tr>
+  <tr>
   <td width="504" align="center" style="vertical-align: middle;  ">
   <table class="table-w-full-mobile" border="0" cellpadding="0" cellspacing="0">
-  <tbody><tr>
-  <td style="vertical-align: middle;" class="stack-column-center" align="center"><a target="_blank" href="https://apps.apple.com/us/app/audius-music/id1491270519"><img src="https://download.audius.co/emails/reward-in-cooldown/ETvbWek1R5LtoPkpa9jyqluDlUJ68K.png" width="142" border="0" style="min-width:142px; width:142px;
-           height: auto; display: block;"></a></td>
-  <td class="stack-column-center" height="12" style="width:12px; min-width:12px; height:12px; min-height:12px;" width="12">&nbsp;</td>
-  <td style="vertical-align: middle;" class="stack-column-center" align="center"><a target="_blank" href="https://play.google.com/store/apps/details?id=co.audius.app&amp;hl=en_US&amp;gl=US"><img src="https://download.audius.co/emails/reward-in-cooldown/I0jhzVTlYEh6zPVjYhWOdLP8WQOriv.png" width="166" border="0" style="min-width:166px; width:166px;
-           height: auto; display: block;"></a></td>
+  <tr>
+  <td style="vertical-align: middle;" class="stack-column-center" align="center"><a href="https://apps.apple.com/us/app/audius-music/id1491270519"><img src="https://download.audius.co/emails/reward-in-cooldown/3bVb8sO4ZGmmuPzntmpniLZbY4Gn3y.png" width="142" border="0" style="min-width:142px; width:142px;
+          height: auto; display: block;"></a></td>
+  <td class="stack-column-center" height="12" style="width:12px; min-width:12px; height:12px; min-height:12px;" width="12"></td>
+  <td style="vertical-align: middle;" class="stack-column-center" align="center"><a href="https://play.google.com/store/apps/details?id=co.audius.app&hl=en_US&gl=US"><img src="https://download.audius.co/emails/reward-in-cooldown/vpzcW2TtQTeCoiU8N1D4uRhrGeMsOv.png" width="166" border="0" style="min-width:166px; width:166px;
+          height: auto; display: block;"></a></td>
   </tr>
-  </tbody></table>
+  </table>
   </td>
   </tr>
-  </tbody></table>
+  </table>
   </td>
   </tr>
-  </tbody></table>
+  </table>
   </td>
   </tr>
   <tr>
   <td height="36" style="height:36px; min-height:36px; line-height:36px;"></td>
   </tr>
-  </tbody></table>
+  </table>
   </div>
   <!--[if gte mso 9]>
                   </v:textbox>
@@ -982,124 +983,124 @@ export const email = ({
   <tr>
   <td height="24" style="height:24px; min-height:24px; line-height:24px;"></td>
   </tr>
-  </tbody></table>
+  </table>
   </td>
   </tr>
-  </tbody></table>
+  </table>
   </td>
   </tr>
   <tr>
   <td width="600">
   <table cellspacing="0" cellpadding="0" border="0">
-  <tbody><tr>
+  <tr>
   <td width="552" align="center" style="vertical-align: middle; background-color:#f9f9f9;  border-width: 1px 0px 0px 0px; border-color:#e9e9eb; border-style:solid; padding-left:24px; padding-right:24px;" bgcolor="#f9f9f9">
   <table width="100%" border="0" cellpadding="0" cellspacing="0">
-  <tbody><tr>
+  <tr>
   <td height="48" style="height:48px; min-height:48px; line-height:48px;"></td>
   </tr>
   <tr>
   <td style="vertical-align: middle;" width="100%">
   <table width="100%" cellspacing="0" cellpadding="0" border="0">
-  <tbody><tr>
+  <tr>
   <td width="100%" align="center" style="vertical-align: middle; border-radius:8px; ">
   <table width="100%" border="0" cellpadding="0" cellspacing="0">
-  <tbody><tr>
+  <tr>
   <td height="24" style="height:24px; min-height:24px; line-height:24px;"></td>
   </tr>
   <tr>
   <td style="vertical-align: middle;" width="100%">
   <table width="100%" cellspacing="0" cellpadding="0" border="0">
-  <tbody><tr>
+  <tr>
   <td width="100%" style="  padding-left:12px; padding-right:12px;">
   <table width="100%" border="0" cellpadding="0" cellspacing="0">
-  <tbody><tr>
+  <tr>
   <td height="12" style="height:12px; min-height:12px; line-height:12px;"></td>
   </tr>
   <tr>
   <td width="528" align="center" style="vertical-align: middle;  ">
   <table class="table-w-full-mobile" width="100%" border="0" cellpadding="0" cellspacing="0">
-  <tbody><tr>
-  <td style="vertical-align: middle;" class="stack-column-center" align="center"><a target="_blank" href="https://www.audius.co/"><img src="https://download.audius.co/emails/reward-in-cooldown/T7wyNCOkTAKSCsXI0teWRVPL9ohvew.png" width="168" border="0" style="min-width:168px; width:168px;
+  <tr>
+  <td style="vertical-align: middle;" class="stack-column-center" align="center"><a href="https://www.audius.co"><img src="https://download.audius.co/emails/reward-in-cooldown/iqtUcr2oioqTednUMi6ZzordmD7EJ8.png" width="168" border="0" style="min-width:168px; width:168px;
           border-radius:2px; height: auto; display: block;"></a></td>
-  <td class="stack-column-center" height="12" style="width:12px; min-width:12px; height:12px; min-height:12px;" width="12">&nbsp;</td>
-  <td class="stack-column-center" style="width:168px;">&nbsp;</td>
-  <td class="stack-column-center" height="12" style="width:12px; min-width:12px; height:12px; min-height:12px;" width="12">&nbsp;</td>
+  <td class="stack-column-center" height="12" style="width:12px; min-width:12px; height:12px; min-height:12px;" width="12"></td>
+  <td class="stack-column-center" style="width:168px;"></td>
+  <td class="stack-column-center" height="12" style="width:12px; min-width:12px; height:12px; min-height:12px;" width="12"></td>
   <td style="vertical-align: middle;" align="center" class="stack-column-center">
   <table width="100%" cellspacing="0" cellpadding="0" border="0">
-  <tbody><tr>
+  <tr>
   <td align="center" style="vertical-align: middle; border-radius:2px;  padding-left:4px; padding-right:4px;">
   <table width="100%" border="0" cellpadding="0" cellspacing="0">
-  <tbody><tr>
+  <tr>
   <td height="4" style="height:4px; min-height:4px; line-height:4px;"></td>
   </tr>
   <tr>
   <td align="center">
   <table cellspacing="0" cellpadding="0" border="0">
-  <tbody><tr>
+  <tr>
   <td style="vertical-align: middle;">
   <table cellspacing="0" cellpadding="0" border="0">
-  <tbody><tr>
+  <tr>
   <td align="right" style="vertical-align: middle; height:32px; border-radius:2px;  padding-left:4px; padding-right:4px;">
   <table width="100%" border="0" cellpadding="0" cellspacing="0">
-  <tbody><tr>
+  <tr>
   <td height="4" style="height:4px; min-height:4px; line-height:4px;"></td>
   </tr>
   <tr>
   <td style="vertical-align: middle;" width="144">
   <table cellspacing="0" cellpadding="0" border="0">
-  <tbody><tr>
+  <tr>
   <td width="144" style="vertical-align: middle;  ">
   <table width="100%" border="0" cellpadding="0" cellspacing="0">
-  <tbody><tr>
-  <td style="vertical-align: middle;"><a target="_blank" href="https://twitter.com/audius"><img src="https://download.audius.co/emails/reward-in-cooldown/DmrnxdHiR36f3jwmrTB3j20i5VTVeY.png" width="24" border="0" style="min-width:24px; width:24px;
-           height: auto; display: block;"></a></td>
+  <tr>
+  <td style="vertical-align: middle;"><a href="https://twitter.com/audius"><img src="https://download.audius.co/emails/reward-in-cooldown/ZfXnf2En2bXRFNqsI4Ki0OYpPm9vaQ.png" width="24" border="0" style="min-width:24px; width:24px;
+          height: auto; display: block;"></a></td>
   <td style="width:16px; min-width:16px;" width="16"></td>
-  <td style="vertical-align: middle;"><a target="_blank" href="https://www.instagram.com/audius/"><img src="https://download.audius.co/emails/reward-in-cooldown/XeiGn0Dq0YLZM2O5kdfTimZsbAuAyc.png" width="24" border="0" style="min-width:24px; width:24px;
-           height: auto; display: block;"></a></td>
+  <td style="vertical-align: middle;"><a href="https://www.instagram.com/audius/"><img src="https://download.audius.co/emails/reward-in-cooldown/Fod8ysormzRjCMsIKldEbx02pHy99G.png" width="24" border="0" style="min-width:24px; width:24px;
+          height: auto; display: block;"></a></td>
   <td style="width:16px; min-width:16px;" width="16"></td>
-  <td style="vertical-align: middle;"><a target="_blank" href="https://tiktok.com/@audius"><img src="https://download.audius.co/emails/reward-in-cooldown/XncIM9pRTX9uGCfbhHQbiDihzZRI0c.png" width="24" border="0" style="min-width:24px; width:24px;
-           height: auto; display: block;"></a></td>
+  <td style="vertical-align: middle;"><a href="https://tiktok.com/@audius"><img src="https://download.audius.co/emails/reward-in-cooldown/3uvjnwWdSlds7ym1j9rtpGAWOWv1jH.png" width="24" border="0" style="min-width:24px; width:24px;
+          height: auto; display: block;"></a></td>
   <td style="width:16px; min-width:16px;" width="16"></td>
-  <td style="vertical-align: middle;"><a target="_blank" href="https://www.youtube.com/@AudiusMusic"><img src="https://download.audius.co/emails/reward-in-cooldown/vpROD76ueF3gh3NH474jQecMgPBZgW.png" width="24" border="0" style="min-width:24px; width:24px;
-           height: auto; display: block;"></a></td>
+  <td style="vertical-align: middle;"><a href="https://www.youtube.com/@AudiusMusic"><img src="https://download.audius.co/emails/reward-in-cooldown/BmHgxumE0gEZCX37hnPuOZOI39EBp3.png" width="24" border="0" style="min-width:24px; width:24px;
+          height: auto; display: block;"></a></td>
   </tr>
-  </tbody></table>
+  </table>
   </td>
   </tr>
-  </tbody></table>
+  </table>
   </td>
   </tr>
   <tr>
   <td height="4" style="height:4px; min-height:4px; line-height:4px;"></td>
   </tr>
-  </tbody></table>
+  </table>
   </td>
   </tr>
-  </tbody></table>
+  </table>
   </td>
   </tr>
-  </tbody></table>
+  </table>
   </td>
   </tr>
   <tr>
   <td height="4" style="height:4px; min-height:4px; line-height:4px;"></td>
   </tr>
-  </tbody></table>
+  </table>
   </td>
   </tr>
-  </tbody></table>
+  </table>
   </td>
   </tr>
-  </tbody></table>
+  </table>
   </td>
   </tr>
   <tr>
   <td height="12" style="height:12px; min-height:12px; line-height:12px;"></td>
   </tr>
-  </tbody></table>
+  </table>
   </td>
   </tr>
-  </tbody></table>
+  </table>
   </td>
   </tr>
   <tr>
@@ -1108,128 +1109,128 @@ export const email = ({
   <tr>
   <td align="center">
   <table cellspacing="0" cellpadding="0" border="0">
-  <tbody><tr>
+  <tr>
   <td style="vertical-align: middle;" width="528">
   <table cellspacing="0" cellpadding="0" border="0">
-  <tbody><tr>
+  <tr>
   <td width="528" align="center" style="vertical-align: middle;  ">
   <table class="table-w-full-mobile" border="0" cellpadding="0" cellspacing="0">
-  <tbody><tr>
-  <td height="16" style="height:16px; min-height:16px; line-height:16px;"></td>
-  </tr>
-  <tr>
-  <td style="vertical-align: middle;" align="center" width="32.32%" class="stack-column-center">
-  <table width="100%" cellspacing="0" cellpadding="0" border="0">
-  <tbody><tr>
-  <td align="center" style="vertical-align: middle; border-radius:2px;  padding-left:16px; padding-right:16px;">
-  <table width="100%" border="0" cellpadding="0" cellspacing="0">
-  <tbody><tr>
-  <td align="center">
-  <table cellspacing="0" cellpadding="0" border="0">
-  <tbody><tr>
-  <td style="vertical-align: middle;" align="center">
-  <div style="line-height:14px;text-align:center;"><a target="_blank" href="https://www.audius.co/"><span style="color:#6a677a;font-weight:500;font-family:Inter,Arial,sans-serif;font-size:14px;line-height:14px;text-align:center;">Audius Music</span></a></div>
-  </td>
-  </tr>
-  </tbody></table>
-  </td>
-  </tr>
-  <tr>
-  <td height="8" style="height:8px; min-height:8px; line-height:8px;"></td>
-  </tr>
-  <tr>
-  <td style="vertical-align: middle;" align="center">
-  <div style="line-height:14px;text-align:center;"><a target="_blank" href="https://help.audius.co/"><span style="color:#6a677a;font-weight:500;font-family:Inter,Arial,sans-serif;font-size:14px;line-height:14px;text-align:center;">Help &amp; Support</span></a></div>
-  </td>
-  </tr>
-  </tbody></table>
-  </td>
-  </tr>
-  </tbody></table>
-  </td>
-  <td class="stack-column-center" height="8" style="width:8px; min-width:8px; height:8px; min-height:8px;" width="8">&nbsp;</td>
-  <td style="vertical-align: middle;" align="center" width="32.32%" class="stack-column-center">
-  <table width="100%" cellspacing="0" cellpadding="0" border="0">
-  <tbody><tr>
-  <td align="center" style="vertical-align: middle; border-radius:2px;  padding-left:16px; padding-right:16px;">
-  <table width="100%" border="0" cellpadding="0" cellspacing="0">
-  <tbody><tr>
-  <td align="center">
-  <table cellspacing="0" cellpadding="0" border="0">
-  <tbody><tr>
-  <td style="vertical-align: middle;" align="center">
-  <div style="line-height:14px;text-align:center;"><a target="_blank" href="https://blog.audius.co/"><span style="color:#6a677a;font-weight:500;font-family:Inter,Arial,sans-serif;font-size:14px;line-height:14px;text-align:center;">The Blog</span></a></div>
-  </td>
-  </tr>
-  </tbody></table>
-  </td>
-  </tr>
-  <tr>
-  <td height="8" style="height:8px; min-height:8px; line-height:8px;"></td>
-  </tr>
-  <tr>
-  <td align="center">
-  <table cellspacing="0" cellpadding="0" border="0">
-  <tbody><tr>
-  <td style="vertical-align: middle;" align="center">
-  <div style="line-height:14px;text-align:center;"><a target="_blank" href="https://www.audius.events/"><span style="color:#6a677a;font-weight:500;font-family:Inter,Arial,sans-serif;font-size:14px;line-height:14px;text-align:center;">Events</span></a></div>
-  </td>
-  </tr>
-  </tbody></table>
-  </td>
-  </tr>
-  </tbody></table>
-  </td>
-  </tr>
-  </tbody></table>
-  </td>
-  <td class="stack-column-center" height="8" style="width:8px; min-width:8px; height:8px; min-height:8px;" width="8">&nbsp;</td>
-  <td style="vertical-align: middle;" align="center" width="32.32%" class="stack-column-center">
-  <table width="100%" cellspacing="0" cellpadding="0" border="0">
-  <tbody><tr>
-  <td align="center" style="vertical-align: middle; border-radius:2px;  padding-left:16px; padding-right:16px;">
-  <table width="100%" border="0" cellpadding="0" cellspacing="0">
-  <tbody><tr>
-  <td align="center">
-  <table cellspacing="0" cellpadding="0" border="0">
-  <tbody><tr>
-  <td style="vertical-align: middle;" align="center">
-  <div style="line-height:14px;text-align:center;"><a target="_blank" href="https://brand.audius.co/"><span style="color:#6a677a;font-weight:500;font-family:Inter,Arial,sans-serif;font-size:14px;line-height:14px;text-align:center;">Brand / Press</span></a></div>
-  </td>
-  </tr>
-  </tbody></table>
-  </td>
-  </tr>
-  <tr>
-  <td height="8" style="height:8px; min-height:8px; line-height:8px;"></td>
-  </tr>
-  <tr>
-  <td align="center">
-  <table cellspacing="0" cellpadding="0" border="0">
-  <tbody><tr>
-  <td style="vertical-align: middle;" align="center">
-  <div style="line-height:14px;text-align:center;"><a target="_blank" href="https://merch.audius.co/"><span style="color:#6a677a;font-weight:500;font-family:Inter,Arial,sans-serif;font-size:14px;line-height:14px;text-align:center;">Merch Store</span></a></div>
-  </td>
-  </tr>
-  </tbody></table>
-  </td>
-  </tr>
-  </tbody></table>
-  </td>
-  </tr>
-  </tbody></table>
-  </td>
-  </tr>
   <tr>
   <td height="16" style="height:16px; min-height:16px; line-height:16px;"></td>
   </tr>
-  </tbody></table>
+  <tr>
+  <td style="vertical-align: middle;" align="center" width="32.32%" class="stack-column-center">
+  <table width="100%" cellspacing="0" cellpadding="0" border="0">
+  <tr>
+  <td align="center" style="vertical-align: middle; border-radius:2px;  padding-left:16px; padding-right:16px;">
+  <table width="100%" border="0" cellpadding="0" cellspacing="0">
+  <tr>
+  <td align="center">
+  <table cellspacing="0" cellpadding="0" border="0">
+  <tr>
+  <td style="vertical-align: middle;" align="center">
+  <div style="line-height:14px;text-align:center;"><a href="https://www.audius.co"><span style="color:#6a677a;font-weight:500;font-family:Inter,Arial,sans-serif;font-size:14px;line-height:14px;text-align:center;">Audius Music</span></a></div>
   </td>
   </tr>
-  </tbody></table>
+  </table>
   </td>
   </tr>
-  </tbody></table>
+  <tr>
+  <td height="8" style="height:8px; min-height:8px; line-height:8px;"></td>
+  </tr>
+  <tr>
+  <td style="vertical-align: middle;" align="center">
+  <div style="line-height:14px;text-align:center;"><a href="https://help.audius.co"><span style="color:#6a677a;font-weight:500;font-family:Inter,Arial,sans-serif;font-size:14px;line-height:14px;text-align:center;">Help & Support</span></a></div>
+  </td>
+  </tr>
+  </table>
+  </td>
+  </tr>
+  </table>
+  </td>
+  <td class="stack-column-center" height="8" style="width:8px; min-width:8px; height:8px; min-height:8px;" width="8"></td>
+  <td style="vertical-align: middle;" align="center" width="32.32%" class="stack-column-center">
+  <table width="100%" cellspacing="0" cellpadding="0" border="0">
+  <tr>
+  <td align="center" style="vertical-align: middle; border-radius:2px;  padding-left:16px; padding-right:16px;">
+  <table width="100%" border="0" cellpadding="0" cellspacing="0">
+  <tr>
+  <td align="center">
+  <table cellspacing="0" cellpadding="0" border="0">
+  <tr>
+  <td style="vertical-align: middle;" align="center">
+  <div style="line-height:14px;text-align:center;"><a href="https://blog.audius.co"><span style="color:#6a677a;font-weight:500;font-family:Inter,Arial,sans-serif;font-size:14px;line-height:14px;text-align:center;">The Blog</span></a></div>
+  </td>
+  </tr>
+  </table>
+  </td>
+  </tr>
+  <tr>
+  <td height="8" style="height:8px; min-height:8px; line-height:8px;"></td>
+  </tr>
+  <tr>
+  <td align="center">
+  <table cellspacing="0" cellpadding="0" border="0">
+  <tr>
+  <td style="vertical-align: middle;" align="center">
+  <div style="line-height:14px;text-align:center;"><a href="https://www.audius.events"><span style="color:#6a677a;font-weight:500;font-family:Inter,Arial,sans-serif;font-size:14px;line-height:14px;text-align:center;">Events</span></a></div>
+  </td>
+  </tr>
+  </table>
+  </td>
+  </tr>
+  </table>
+  </td>
+  </tr>
+  </table>
+  </td>
+  <td class="stack-column-center" height="8" style="width:8px; min-width:8px; height:8px; min-height:8px;" width="8"></td>
+  <td style="vertical-align: middle;" align="center" width="32.32%" class="stack-column-center">
+  <table width="100%" cellspacing="0" cellpadding="0" border="0">
+  <tr>
+  <td align="center" style="vertical-align: middle; border-radius:2px;  padding-left:16px; padding-right:16px;">
+  <table width="100%" border="0" cellpadding="0" cellspacing="0">
+  <tr>
+  <td align="center">
+  <table cellspacing="0" cellpadding="0" border="0">
+  <tr>
+  <td style="vertical-align: middle;" align="center">
+  <div style="line-height:14px;text-align:center;"><a href="https://brand.audius.co"><span style="color:#6a677a;font-weight:500;font-family:Inter,Arial,sans-serif;font-size:14px;line-height:14px;text-align:center;">Brand / Press</span></a></div>
+  </td>
+  </tr>
+  </table>
+  </td>
+  </tr>
+  <tr>
+  <td height="8" style="height:8px; min-height:8px; line-height:8px;"></td>
+  </tr>
+  <tr>
+  <td align="center">
+  <table cellspacing="0" cellpadding="0" border="0">
+  <tr>
+  <td style="vertical-align: middle;" align="center">
+  <div style="line-height:14px;text-align:center;"><a href="https://merch.audius.co"><span style="color:#6a677a;font-weight:500;font-family:Inter,Arial,sans-serif;font-size:14px;line-height:14px;text-align:center;">Merch Store</span></a></div>
+  </td>
+  </tr>
+  </table>
+  </td>
+  </tr>
+  </table>
+  </td>
+  </tr>
+  </table>
+  </td>
+  </tr>
+  <tr>
+  <td height="16" style="height:16px; min-height:16px; line-height:16px;"></td>
+  </tr>
+  </table>
+  </td>
+  </tr>
+  </table>
+  </td>
+  </tr>
+  </table>
   </td>
   </tr>
   <tr>
@@ -1238,18 +1239,18 @@ export const email = ({
   <tr>
   <td style="vertical-align: middle;" width="100%">
   <table width="100%" cellspacing="0" cellpadding="0" border="0">
-  <tbody><tr>
+  <tr>
   <td width="100%" align="center" style="vertical-align: middle;  ">
   <table width="100%" border="0" cellpadding="0" cellspacing="0">
-  <tbody><tr>
+  <tr>
   <td align="center">
   <table cellspacing="0" cellpadding="0" border="0">
-  <tbody><tr>
+  <tr>
   <td style="vertical-align: middle;" align="center">
   <div style="line-height:14px;text-align:center;"><span style="color:#6a677a;font-family:Inter,Arial,sans-serif;font-size:12px;line-height:14px;text-align:center;">© ${copyrightYear} Audius, Inc. All Rights Reserved.</span></div>
   </td>
   </tr>
-  </tbody></table>
+  </table>
   </td>
   </tr>
   <tr>
@@ -1267,43 +1268,43 @@ export const email = ({
     Email Preferences</span></a></div>
   </td>
   </tr>
-  </tbody></table>
+  </table>
   </td>
   </tr>
-  </tbody></table>
+  </table>
   </td>
   </tr>
   <tr>
   <td height="24" style="height:24px; min-height:24px; line-height:24px;"></td>
   </tr>
-  </tbody></table>
+  </table>
   </td>
   </tr>
-  </tbody></table>
+  </table>
   </td>
   </tr>
   <tr>
   <td height="48" style="height:48px; min-height:48px; line-height:48px;"></td>
   </tr>
-  </tbody></table>
+  </table>
   </td>
   </tr>
-  </tbody></table>
+  </table>
   </td>
   </tr>
-  </tbody></table>
+  </table>
   </td>
   </tr>
-  </tbody></table>
+  </table>
   </td>
   </tr>
-  </tbody></table>
+  </table>
   </td>
   </tr>
-  </tbody></table>
+  </table>
   </div>
-  
-  
-  </body></html>
-  `
+  </body>
+
+  </html>
+`
 }

--- a/packages/discovery-provider/plugins/notifications/src/email/notifications/preRendered/sale.ts
+++ b/packages/discovery-provider/plugins/notifications/src/email/notifications/preRendered/sale.ts
@@ -54,6 +54,7 @@ export const email = ({
   <link href="https://fonts.googleapis.com/css?family=Inter:600" rel="stylesheet" type="text/css">
   <link href="https://fonts.googleapis.com/css?family=Inter:500" rel="stylesheet" type="text/css">
   <style>
+  @import url('https://fonts.googleapis.com/css2?family=Inter:wght@100..900&display=swap');
   html {
       margin: 0 !important;
       padding: 0 !important;
@@ -1122,7 +1123,14 @@ export const email = ({
   </tr>
   <tr>
   <td style="vertical-align: middle;" align="center">
-  <div style="line-height:14px;text-align:center;"><span style="color:#6a677a;font-family:Inter,Arial,sans-serif;font-size:12px;line-height:14px;text-align:center;">No longer want to receive these emails? </span><span style="color:#7e1bcc;font-family:Inter,Arial,sans-serif;font-size:12px;line-height:14px;text-align:center;">Unsubscribe </span><span style="color:#6a677a;font-family:Inter,Arial,sans-serif;font-size:12px;line-height:14px;text-align:center;">or</span><span style="color:#7e1bcc;font-family:Inter,Arial,sans-serif;font-size:12px;line-height:14px;text-align:center;"> Manage Email Preferences</span></div>
+  <div style="line-height:14px;text-align:center;"><span
+      style="color:#6a677a;font-family:Inter,Arial,sans-serif;font-size:12px;line-height:14px;text-align:center;">No
+      longer want to receive these emails? </span><a href="<%asm_group_unsubscribe_raw_url%>"><span
+      style="color:#7e1bcc;font-family:Inter,Arial,sans-serif;font-size:12px;line-height:14px;text-align:center;">Unsubscribe
+      </span></a><span
+      style="color:#6a677a;font-family:Inter,Arial,sans-serif;font-size:12px;line-height:14px;text-align:center;">or</span><a href="<%asm_preferences_raw_url%>"><span
+      style="color:#7e1bcc;font-family:Inter,Arial,sans-serif;font-size:12px;line-height:14px;text-align:center;"> Manage
+      Email Preferences</span></a></div>
   </td>
   </tr>
   </table>

--- a/packages/discovery-provider/plugins/notifications/src/email/notifications/preRendered/sale.ts
+++ b/packages/discovery-provider/plugins/notifications/src/email/notifications/preRendered/sale.ts
@@ -54,7 +54,6 @@ export const email = ({
   <link href="https://fonts.googleapis.com/css?family=Inter:600" rel="stylesheet" type="text/css">
   <link href="https://fonts.googleapis.com/css?family=Inter:500" rel="stylesheet" type="text/css">
   <style>
-  @import url('https://fonts.googleapis.com/css2?family=Inter:wght@100..900&display=swap');
   html {
       margin: 0 !important;
       padding: 0 !important;
@@ -339,8 +338,8 @@ export const email = ({
   <td align="center">
   <table cellspacing="0" cellpadding="0" border="0">
   <tr>
-  <td style="vertical-align: middle;" width="180" class="stack-column-center" align="center"><img src="${contentImage}" width="180" border="0" style="min-width:180px; width:180px;
-		  border-radius:8px; height: auto; display: block;"></td>
+  <td style="vertical-align: middle;" width="180" class="stack-column-center" align="center"><a href="${contentLink}"><img src="${contentImage}" width="180" border="0" style="min-width:180px; width:180px;
+		  border-radius:8px; height: auto; display: block;"></a></td>
   </tr>
   </table>
   </td>
@@ -440,7 +439,7 @@ export const email = ({
   <div style="line-height:24px;text-align:left;"><span style="color:#52505f;font-family:Inter,Arial,sans-serif;font-size:16px;line-height:24px;text-align:left;">${contentTitle}</span></div>
   </td>
   <td width="126">
-  <div style="line-height:24px;text-align:right;"><span style="color:#3a3843;font-family:Inter,Arial,sans-serif;font-size:16px;line-height:24px;text-align:right;">${price}</span></div>
+  <div style="line-height:24px;text-align:right;"><span style="color:#3a3843;font-family:Inter,Arial,sans-serif;font-size:16px;line-height:24px;text-align:right;">$${price}</span></div>
   </td>
   </tr>
   <tr>
@@ -449,18 +448,22 @@ export const email = ({
   </table>
   </td>
   </tr>
+${
+  payExtra !== '0.00'
+    ? `
+
   <tr>
   <td width="100%" style=" border-width: 0px 0px 1px 0px; border-color:#e9e9eb; border-style:solid;">
   <table width="100%" border="0" cellpadding="0" cellspacing="0">
   <tr>
   <td height="16" style="height:16px; min-height:16px; line-height:16px;"></td>
   </tr>
-  <tr>
+	<tr>
   <td>
   <div style="line-height:24px;text-align:left;"><span style="color:#52505f;font-family:Inter,Arial,sans-serif;font-size:16px;line-height:24px;text-align:left;">Pay Extra</span></div>
   </td>
   <td width="126">
-  <div style="line-height:24px;text-align:right;"><span style="color:#3a3843;font-family:Inter,Arial,sans-serif;font-size:16px;line-height:24px;text-align:right;">${payExtra}</span></div>
+  <div style="line-height:24px;text-align:right;"><span style="color:#3a3843;font-family:Inter,Arial,sans-serif;font-size:16px;line-height:24px;text-align:right;">$${payExtra}</span></div>
   </td>
   </tr>
   <tr>
@@ -468,7 +471,9 @@ export const email = ({
   </tr>
   </table>
   </td>
-  </tr>
+  </tr>`
+    : ''
+}
   <tr>
   <td width="100%">
   <table width="100%" border="0" cellpadding="0" cellspacing="0">
@@ -480,7 +485,7 @@ export const email = ({
   <div style="line-height:24px;text-align:left;"><span style="color:#52505f;font-weight:600;font-family:Inter,Arial,sans-serif;font-size:16px;line-height:24px;text-align:left;">Total</span></div>
   </td>
   <td width="126">
-  <div style="line-height:24px;text-align:right;"><span style="color:#3a3843;font-weight:600;font-family:Inter,Arial,sans-serif;font-size:16px;line-height:24px;text-align:right;">${total}</span></div>
+  <div style="line-height:24px;text-align:right;"><span style="color:#3a3843;font-weight:600;font-family:Inter,Arial,sans-serif;font-size:16px;line-height:24px;text-align:right;">$${total}</span></div>
   </td>
   </tr>
   <tr>
@@ -614,9 +619,9 @@ export const email = ({
   <td width="552" align="center" style="vertical-align: middle;  ">
   <table class="table-w-full-mobile" width="100%" border="0" cellpadding="0" cellspacing="0">
   <tr>
-  <td style="vertical-align: middle;" width="156" class="stack-column-center" align="center"><img src="https://download.audius.co/emails/sale/rSmBSTo31vPg57RGHElPRThJbO9bpx.png" width="156" border="0" style="min-width:156px; width:156px;
-          border-radius:8px; height: auto; display: block;"></td>
-  <td class="stack-column-center" height="16" style="width:16px; min-width:16px; height:16px; min-height:16px;" width="16"> </td>
+  <td style="vertical-align: middle;" width="156" class="stack-column-center" align="center"><a href="https://audius.co/audio"><img src="https://download.audius.co/emails/sale/rSmBSTo31vPg57RGHElPRThJbO9bpx.png" width="156" border="0" style="min-width:156px; width:156px;
+          border-radius:8px; height: auto; display: block;"></a></td>
+  <td class="stack-column-center" height="16" style="width:16px; min-width:16px; height:16px; min-height:16px;" width="16"></td>
   <td style="vertical-align: middle;" align="center" class="stack-column-center">
   <table width="100%" cellspacing="0" cellpadding="0" border="0">
   <tr>
@@ -819,7 +824,7 @@ export const email = ({
   <tr>
   <td style="vertical-align: middle;" class="stack-column-center" align="center"><a target="_blank" href="https://apps.apple.com/us/app/audius-music/id1491270519"><img src="https://download.audius.co/emails/sale/a76lEcuwOLTSTjvvtWBVUF909dr9pP.png" width="142" border="0" style="min-width:142px; width:142px;
           height: auto; display: block;"></a></td>
-  <td class="stack-column-center" height="12" style="width:12px; min-width:12px; height:12px; min-height:12px;" width="12"> </td>
+  <td class="stack-column-center" height="12" style="width:12px; min-width:12px; height:12px; min-height:12px;" width="12"></td>
   <td style="vertical-align: middle;" class="stack-column-center" align="center"><a target="_blank" href="https://play.google.com/store/apps/details?id=co.audius.app&hl=en_US&gl=US"><img src="https://download.audius.co/emails/sale/wj2tggnvemzH13lGDyiOmATZTcrKms.png" width="166" border="0" style="min-width:166px; width:166px;
           height: auto; display: block;"></a></td>
   </tr>
@@ -887,9 +892,9 @@ export const email = ({
   <tr>
   <td style="vertical-align: middle;" class="stack-column-center" align="center"><a target="_blank" href="https://www.audius.co"><img src="https://download.audius.co/emails/sale/k50h9dCyk90lpr01oTY4kf592hh0hm.png" width="168" border="0" style="min-width:168px; width:168px;
           border-radius:2px; height: auto; display: block;"></a></td>
-  <td class="stack-column-center" height="12" style="width:12px; min-width:12px; height:12px; min-height:12px;" width="12"> </td>
-  <td class="stack-column-center" style="width:168px;"> </td>
-  <td class="stack-column-center" height="12" style="width:12px; min-width:12px; height:12px; min-height:12px;" width="12"> </td>
+  <td class="stack-column-center" height="12" style="width:12px; min-width:12px; height:12px; min-height:12px;" width="12"></td>
+  <td class="stack-column-center" style="width:168px;"></td>
+  <td class="stack-column-center" height="12" style="width:12px; min-width:12px; height:12px; min-height:12px;" width="12"></td>
   <td style="vertical-align: middle;" align="center" class="stack-column-center">
   <table width="100%" cellspacing="0" cellpadding="0" border="0">
   <tr>
@@ -1013,7 +1018,7 @@ export const email = ({
   </tr>
   </table>
   </td>
-  <td class="stack-column-center" height="8" style="width:8px; min-width:8px; height:8px; min-height:8px;" width="8"> </td>
+  <td class="stack-column-center" height="8" style="width:8px; min-width:8px; height:8px; min-height:8px;" width="8"></td>
   <td style="vertical-align: middle;" align="center" width="32.32%" class="stack-column-center">
   <table width="100%" cellspacing="0" cellpadding="0" border="0">
   <tr>
@@ -1049,7 +1054,7 @@ export const email = ({
   </tr>
   </table>
   </td>
-  <td class="stack-column-center" height="8" style="width:8px; min-width:8px; height:8px; min-height:8px;" width="8"> </td>
+  <td class="stack-column-center" height="8" style="width:8px; min-width:8px; height:8px; min-height:8px;" width="8"></td>
   <td style="vertical-align: middle;" align="center" width="32.32%" class="stack-column-center">
   <table width="100%" cellspacing="0" cellpadding="0" border="0">
   <tr>

--- a/packages/discovery-provider/plugins/notifications/src/email/notifications/preRendered/transfer.ts
+++ b/packages/discovery-provider/plugins/notifications/src/email/notifications/preRendered/transfer.ts
@@ -20,7 +20,7 @@ export const email = ({
   return `
   <!doctype html>
   <html lang="en" xmlns="http://www.w3.org/1999/xhtml" xmlns:v="urn:schemas-microsoft-com:vml" xmlns:o="urn:schemas-microsoft-com:office:office">
-  
+
   <head>
   <meta charset="utf-8" />
   <meta content="width=device-width" name="viewport" />
@@ -29,12 +29,12 @@ export const email = ({
   <meta content="telephone=no,address=no,email=no,date=no,url=no" name="format-detection" />
   <title>Your USDC Transfer is Complete!</title>
   <!--[if mso]>
-			  <style>
-				  * {
-					  font-family: sans-serif !important;
-				  }
-			  </style>
-		  <![endif]-->
+              <style>
+                  * {
+                      font-family: sans-serif !important;
+                  }
+              </style>
+          <![endif]-->
   <!--[if !mso]><!-->
   <!-- <![endif]-->
   <link href="https://fonts.googleapis.com/css?family=Inter:700" rel="stylesheet" type="text/css">
@@ -42,133 +42,133 @@ export const email = ({
   <link href="https://fonts.googleapis.com/css?family=Inter:500" rel="stylesheet" type="text/css">
   <style>
   html {
-	  margin: 0 !important;
-	  padding: 0 !important;
+      margin: 0 !important;
+      padding: 0 !important;
   }
-  
+
   * {
-	  -ms-text-size-adjust: 100%;
-	  -webkit-text-size-adjust: 100%;
+      -ms-text-size-adjust: 100%;
+      -webkit-text-size-adjust: 100%;
   }
   td {
-	  vertical-align: top;
-	  mso-table-lspace: 0pt !important;
-	  mso-table-rspace: 0pt !important;
+      vertical-align: top;
+      mso-table-lspace: 0pt !important;
+      mso-table-rspace: 0pt !important;
   }
   a {
-	  text-decoration: none;
+      text-decoration: none;
   }
   img {
-	  -ms-interpolation-mode:bicubic;
+      -ms-interpolation-mode:bicubic;
   }
   @media only screen and (min-device-width: 320px) and (max-device-width: 374px) {
-	  u ~ div .email-container {
-		  min-width: 320px !important;
-	  }
+      u ~ div .email-container {
+          min-width: 320px !important;
+      }
   }
   @media only screen and (min-device-width: 375px) and (max-device-width: 413px) {
-	  u ~ div .email-container {
-		  min-width: 375px !important;
-	  }
+      u ~ div .email-container {
+          min-width: 375px !important;
+      }
   }
   @media only screen and (min-device-width: 414px) {
-	  u ~ div .email-container {
-		  min-width: 414px !important;
-	  }
+      u ~ div .email-container {
+          min-width: 414px !important;
+      }
   }
-  
+
   </style>
   <!--[if gte mso 9]>
-		  <xml>
-			  <o:OfficeDocumentSettings>
-				  <o:AllowPNG/>
-				  <o:PixelsPerInch>96</o:PixelsPerInch>
-			  </o:OfficeDocumentSettings>
-		  </xml>
-		  <![endif]-->
+          <xml>
+              <o:OfficeDocumentSettings>
+                  <o:AllowPNG/>
+                  <o:PixelsPerInch>96</o:PixelsPerInch>
+              </o:OfficeDocumentSettings>
+          </xml>
+          <![endif]-->
   <style>
   @media only screen and (max-device-width: 599px), only screen and (max-width: 599px) {
-  
-	  .eh {
-		  height:auto !important;
-	  }
-	  .desktop {
-		  display: none !important;
-		  height: 0 !important;
-		  margin: 0 !important;
-		  max-height: 0 !important;
-		  overflow: hidden !important;
-		  padding: 0 !important;
-		  visibility: hidden !important;
-		  width: 0 !important;
-	  }
-	  .mobile {
-		  display: block !important;
-		  width: auto !important;
-		  height: auto !important;
-		  float: none !important;
-	  }
-	  .email-container {
-		  width: 100% !important;
-		  margin: auto !important;
-	  }
-	  .stack-column,
-	  .stack-column-center {
-		  display: block !important;
-		  width: 100% !important;
-		  max-width: 100% !important;
-		  direction: ltr !important;
-	  }
-	  .wid-auto {
-		  width:auto !important;
-	  }
-  
-	  .table-w-full-mobile {
-		  width: 100%;
-	  }
-  
-	  
-	  
-  
-	  .mobile-center {
-		  text-align: center;
-	  }
-  
-	  .mobile-center > table {
-		  display: inline-block;
-		  vertical-align: inherit;
-	  }
-  
-	  .mobile-left {
-		  text-align: left;
-	  }
-  
-	  .mobile-left > table {
-		  display: inline-block;
-		  vertical-align: inherit;
-	  }
-  
-	  .mobile-right {
-		  text-align: right;
-	  }
-  
-	  .mobile-right > table {
-		  display: inline-block;
-		  vertical-align: inherit;
-	  }
-  
+
+      .eh {
+          height:auto !important;
+      }
+      .desktop {
+          display: none !important;
+          height: 0 !important;
+          margin: 0 !important;
+          max-height: 0 !important;
+          overflow: hidden !important;
+          padding: 0 !important;
+          visibility: hidden !important;
+          width: 0 !important;
+      }
+      .mobile {
+          display: block !important;
+          width: auto !important;
+          height: auto !important;
+          float: none !important;
+      }
+      .email-container {
+          width: 100% !important;
+          margin: auto !important;
+      }
+      .stack-column,
+      .stack-column-center {
+          display: block !important;
+          width: 100% !important;
+          max-width: 100% !important;
+          direction: ltr !important;
+      }
+      .wid-auto {
+          width:auto !important;
+      }
+
+      .table-w-full-mobile {
+          width: 100%;
+      }
+
+      
+      
+
+      .mobile-center {
+          text-align: center;
+      }
+
+      .mobile-center > table {
+          display: inline-block;
+          vertical-align: inherit;
+      }
+
+      .mobile-left {
+          text-align: left;
+      }
+
+      .mobile-left > table {
+          display: inline-block;
+          vertical-align: inherit;
+      }
+
+      .mobile-right {
+          text-align: right;
+      }
+
+      .mobile-right > table {
+          display: inline-block;
+          vertical-align: inherit;
+      }
+
   }
-  
+
   </style>
   </head>
-  
+
   <body width="100%" style="background-color:#e9e9eb;margin:0;padding:0!important;mso-line-height-rule:exactly;">
   <div style="background-color:#e9e9eb">
   <!--[if gte mso 9]>
-											  <v:background xmlns:v="urn:schemas-microsoft-com:vml" fill="t">
-											  <v:fill type="tile" color="#e9e9eb"/>
-											  </v:background>
-											  <![endif]-->
+                                              <v:background xmlns:v="urn:schemas-microsoft-com:vml" fill="t">
+                                              <v:fill type="tile" color="#e9e9eb"/>
+                                              </v:background>
+                                              <![endif]-->
   <table width="100%" cellpadding="0" cellspacing="0" border="0">
   <tr>
   <td valign="top" align="center">
@@ -196,7 +196,7 @@ export const email = ({
   <table border="0" cellpadding="0" cellspacing="0">
   <tr>
   <td style="vertical-align: middle;" width="60"><img src="${profilePicture}" width="60" border="0" style="min-width:60px; width:60px;
-		  border-radius:64px; height: auto; display: block;"></td>
+          border-radius:64px; height: auto; display: block;"></td>
   <td style="width:16px; min-width:16px;" width="16"></td>
   <td style="vertical-align: middle;">
   <table cellspacing="0" cellpadding="0" border="0">
@@ -205,7 +205,7 @@ export const email = ({
   <table width="100%" border="0" cellpadding="0" cellspacing="0">
   <tr>
   <td style="vertical-align: middle;">
-  <div style="line-height:24px;text-align:left;"><a target="_blank" href="${profileLink}"><span style="color:#52505f;font-weight:700;font-family:Inter,Arial,sans-serif;font-size:16px;letter-spacing:-0.02em;line-height:24px;text-align:left;">${name}</span></a></div>
+  <div style="line-height:24px;text-align:left;"><a href="${profileLink}"><span style="color:#52505f;font-weight:700;font-family:Inter,Arial,sans-serif;font-size:16px;letter-spacing:-0.02em;line-height:24px;text-align:left;">${name}</span></a></div>
   </td>
   </tr>
   <tr>
@@ -216,7 +216,7 @@ export const email = ({
   <table cellspacing="0" cellpadding="0" border="0">
   <tr>
   <td style="vertical-align: middle;">
-  <div style="line-height:24px;text-align:left;"><a target="_blank" href="${profileLink}"><span style="color:#52505f;font-family:Inter,Arial,sans-serif;font-size:16px;line-height:24px;text-align:left;">@${handle}</span></a></div>
+  <div style="line-height:24px;text-align:left;"><a href="${profileLink}"><span style="color:#52505f;font-family:Inter,Arial,sans-serif;font-size:16px;line-height:24px;text-align:left;">@${handle}</span></a></div>
   </td>
   </tr>
   </table>
@@ -235,7 +235,7 @@ export const email = ({
   </td>
   <td style="width:8px; min-width:8px;" width="8"></td>
   <td style="vertical-align: middle;" width="72" align="center"><img src="https://download.audius.co/emails/transfer/1KOBjANaTfYUAtJMAIAXnyXOEEi8x2.jpeg" width="72" border="0" style="min-width:72px; width:72px;
-		   height: auto; display: block;"></td>
+      height: auto; display: block;"></td>
   </tr>
   <tr>
   <td height="8" style="height:8px; min-height:8px; line-height:8px;"></td>
@@ -314,7 +314,7 @@ export const email = ({
   </tr>
   <tr>
   <td>
-  <div style="line-height:24px;text-align:left;"><span style="color:#52505f;font-family:Inter,Arial,sans-serif;font-size:16px;line-height:24px;text-align:left;">Transfer Amount: ${amount} USDC<br>Transfer To: ${wallet}</span></div>
+  <div style="line-height:24px;text-align:left;"><span style="color:#52505f;font-family:Inter,Arial,sans-serif;font-size:16px;line-height:24px;text-align:left;">Transfer Amount: $${amount} USDC<br>Transfer To: ${wallet}</span></div>
   </td>
   </tr>
   <tr>
@@ -347,15 +347,15 @@ export const email = ({
   <td height="24" style="height:24px; min-height:24px; line-height:24px;"></td>
   </tr>
   <tr>
-  <td width="100%" align="center" class="B31OswCc82HjbYK8nl2C5LpXpBSCg1 invert-bg" style="vertical-align: middle; background-repeat:no-repeat !important; background-position: center center !important; background-size: cover !important;border-radius:12px; border-collapse:separate !important; padding-left:24px; padding-right:24px;" background="https://download.audius.co/emails/transfer/B31OswCc82HjbYK8nl2C5LpXpBSCg1.png">
+  <td width="100%" align="center" class="qGhZIzDXR5RmuaAmA3enPpUgSAPdO2 invert-bg" style="vertical-align: middle; background-repeat:no-repeat !important; background-position: center center !important; background-size: cover !important;border-radius:12px; border-collapse:separate !important; padding-left:24px; padding-right:24px;" background="https://download.audius.co/emails/transfer/B31OswCc82HjbYK8nl2C5LpXpBSCg1.png">
   <!--[if gte mso 9]>
-				  <v:image xmlns:v="urn:schemas-microsoft-com:vml" fill="true" stroke="false" style=" border: 0;display: inline-block; width: 552px; height:182px;"
-				  src="https://download.audius.co/emails/transfer/B31OswCc82HjbYK8nl2C5LpXpBSCg1.png"
-				  />
-				  <v:rect xmlns:v="urn:schemas-microsoft-com:vml" fill="true" stroke="false" style=" border: 0;display: inline-block;position: absolute; width: 552px; height:182px;">
-				  <v:fill opacity="0%" color="#000" />
-				  <v:textbox inset="0,0,0,0">
-				  <![endif]-->
+                  <v:image xmlns:v="urn:schemas-microsoft-com:vml" fill="true" stroke="false" style=" border: 0;display: inline-block; width: 552px; height:182px;"
+                  src="https://download.audius.co/emails/transfer/B31OswCc82HjbYK8nl2C5LpXpBSCg1.png"
+                  />
+                  <v:rect xmlns:v="urn:schemas-microsoft-com:vml" fill="true" stroke="false" style=" border: 0;display: inline-block;position: absolute; width: 552px; height:182px;">
+                  <v:fill opacity="0%" color="#000" />
+                  <v:textbox inset="0,0,0,0">
+                  <![endif]-->
   <div>
   <table width="100%" border="0" cellpadding="0" cellspacing="0">
   <tr>
@@ -391,11 +391,11 @@ export const email = ({
   <td width="504" align="center" style="vertical-align: middle;  ">
   <table class="table-w-full-mobile" border="0" cellpadding="0" cellspacing="0">
   <tr>
-  <td style="vertical-align: middle;" class="stack-column-center" align="center"><a target="_blank" href="https://apps.apple.com/us/app/audius-music/id1491270519"><img src="https://download.audius.co/emails/transfer/XSShP2c68DczmwiHpr5mUv4t7Od1dL.png" width="142" border="0" style="min-width:142px; width:142px;
-		   height: auto; display: block;"></a></td>
+  <td style="vertical-align: middle;" class="stack-column-center" align="center"><a href="https://apps.apple.com/us/app/audius-music/id1491270519"><img src="https://download.audius.co/emails/transfer/XSShP2c68DczmwiHpr5mUv4t7Od1dL.png" width="142" border="0" style="min-width:142px; width:142px;
+          height: auto; display: block;"></a></td>
   <td class="stack-column-center" height="12" style="width:12px; min-width:12px; height:12px; min-height:12px;" width="12"></td>
-  <td style="vertical-align: middle;" class="stack-column-center" align="center"><a target="_blank" href="https://play.google.com/store/apps/details?id=co.audius.app&hl=en_US&gl=US"><img src="https://download.audius.co/emails/transfer/RIExgLjh8wZIVtsUv8Chbcskqwizaw.png" width="166" border="0" style="min-width:166px; width:166px;
-		   height: auto; display: block;"></a></td>
+  <td style="vertical-align: middle;" class="stack-column-center" align="center"><a href="https://play.google.com/store/apps/details?id=co.audius.app&hl=en_US&gl=US"><img src="https://download.audius.co/emails/transfer/RIExgLjh8wZIVtsUv8Chbcskqwizaw.png" width="166" border="0" style="min-width:166px; width:166px;
+          height: auto; display: block;"></a></td>
   </tr>
   </table>
   </td>
@@ -412,11 +412,11 @@ export const email = ({
   </table>
   </div>
   <!--[if gte mso 9]>
-				  </v:textbox>
-				  </v:fill>
-				  </v:rect>
-				  </v:image>
-				  <![endif]-->
+                  </v:textbox>
+                  </v:fill>
+                  </v:rect>
+                  </v:image>
+                  <![endif]-->
   </td>
   </tr>
   <tr>
@@ -459,8 +459,8 @@ export const email = ({
   <td width="528" align="center" style="vertical-align: middle;  ">
   <table class="table-w-full-mobile" width="100%" border="0" cellpadding="0" cellspacing="0">
   <tr>
-  <td style="vertical-align: middle;" class="stack-column-center" align="center"><a target="_blank" href="https://www.audius.co"><img src="https://download.audius.co/emails/transfer/HQsDwSXBDcUHH0nmUGTFHNFbYr01wI.png" width="168" border="0" style="min-width:168px; width:168px;
-		  border-radius:2px; height: auto; display: block;"></a></td>
+  <td style="vertical-align: middle;" class="stack-column-center" align="center"><a href="https://www.audius.co"><img src="https://download.audius.co/emails/transfer/HQsDwSXBDcUHH0nmUGTFHNFbYr01wI.png" width="168" border="0" style="min-width:168px; width:168px;
+          border-radius:2px; height: auto; display: block;"></a></td>
   <td class="stack-column-center" height="12" style="width:12px; min-width:12px; height:12px; min-height:12px;" width="12"></td>
   <td class="stack-column-center" style="width:168px;"></td>
   <td class="stack-column-center" height="12" style="width:12px; min-width:12px; height:12px; min-height:12px;" width="12"></td>
@@ -491,17 +491,17 @@ export const email = ({
   <td width="144" style="vertical-align: middle;  ">
   <table width="100%" border="0" cellpadding="0" cellspacing="0">
   <tr>
-  <td style="vertical-align: middle;"><a target="_blank" href="https://twitter.com/audius"><img src="https://download.audius.co/emails/transfer/GG3zzuqXbGVjlaJellblYLs9wA8DC4.png" width="24" border="0" style="min-width:24px; width:24px;
-		   height: auto; display: block;"></a></td>
+  <td style="vertical-align: middle;"><a href="https://twitter.com/audius"><img src="images/9knFl6CO4CbZKY4Tw9zEHHHIjwv298.png" width="24" border="0" style="min-width:24px; width:24px;
+          height: auto; display: block;"></a></td>
   <td style="width:16px; min-width:16px;" width="16"></td>
-  <td style="vertical-align: middle;"><a target="_blank" href="https://www.instagram.com/audius/"><img src="https://download.audius.co/emails/transfer/4lMfEeqODhCbbN7MIfwMWsQQQgx46v.png" width="24" border="0" style="min-width:24px; width:24px;
-		   height: auto; display: block;"></a></td>
+  <td style="vertical-align: middle;"><a href="https://www.instagram.com/audius/"><img src="images/HDsIb0SnpER1RYjmy5KGnKd5WWFI8l.png" width="24" border="0" style="min-width:24px; width:24px;
+          height: auto; display: block;"></a></td>
   <td style="width:16px; min-width:16px;" width="16"></td>
-  <td style="vertical-align: middle;"><a target="_blank" href="https://tiktok.com/@audius"><img src="https://download.audius.co/emails/transfer/3HBoSDXYIpzfT0khm6zYK1pKsspHvI.png" width="24" border="0" style="min-width:24px; width:24px;
-		   height: auto; display: block;"></a></td>
+  <td style="vertical-align: middle;"><a href="https://tiktok.com/@audius"><img src="images/mJ5ZrzSdU7iJ6egPcWiLSMladg16zH.png" width="24" border="0" style="min-width:24px; width:24px;
+          height: auto; display: block;"></a></td>
   <td style="width:16px; min-width:16px;" width="16"></td>
-  <td style="vertical-align: middle;"><a target="_blank" href="https://www.youtube.com/@AudiusMusic"><img src="https://download.audius.co/emails/transfer/9EXVUKaX5lZHaXoehmLfDP7S2EjFZa.png" width="24" border="0" style="min-width:24px; width:24px;
-		   height: auto; display: block;"></a></td>
+  <td style="vertical-align: middle;"><a href="https://www.youtube.com/@AudiusMusic"><img src="images/OhoBO4IHsyCwPLYSX7KbIvCAnyMEVT.png" width="24" border="0" style="min-width:24px; width:24px;
+          height: auto; display: block;"></a></td>
   </tr>
   </table>
   </td>
@@ -568,7 +568,7 @@ export const email = ({
   <table cellspacing="0" cellpadding="0" border="0">
   <tr>
   <td style="vertical-align: middle;" align="center">
-  <div style="line-height:14px;text-align:center;"><a target="_blank" href="https://www.audius.co"><span style="color:#6a677a;font-weight:500;font-family:Inter,Arial,sans-serif;font-size:14px;line-height:14px;text-align:center;">Audius Music</span></a></div>
+  <div style="line-height:14px;text-align:center;"><a href="https://www.audius.co"><span style="color:#6a677a;font-weight:500;font-family:Inter,Arial,sans-serif;font-size:14px;line-height:14px;text-align:center;">Audius Music</span></a></div>
   </td>
   </tr>
   </table>
@@ -579,7 +579,7 @@ export const email = ({
   </tr>
   <tr>
   <td style="vertical-align: middle;" align="center">
-  <div style="line-height:14px;text-align:center;"><a target="_blank" href="https://help.audius.co"><span style="color:#6a677a;font-weight:500;font-family:Inter,Arial,sans-serif;font-size:14px;line-height:14px;text-align:center;">Help & Support</span></a></div>
+  <div style="line-height:14px;text-align:center;"><a href="https://help.audius.co"><span style="color:#6a677a;font-weight:500;font-family:Inter,Arial,sans-serif;font-size:14px;line-height:14px;text-align:center;">Help & Support</span></a></div>
   </td>
   </tr>
   </table>
@@ -598,7 +598,7 @@ export const email = ({
   <table cellspacing="0" cellpadding="0" border="0">
   <tr>
   <td style="vertical-align: middle;" align="center">
-  <div style="line-height:14px;text-align:center;"><a target="_blank" href="https://blog.audius.co"><span style="color:#6a677a;font-weight:500;font-family:Inter,Arial,sans-serif;font-size:14px;line-height:14px;text-align:center;">The Blog</span></a></div>
+  <div style="line-height:14px;text-align:center;"><a href="https://blog.audius.co"><span style="color:#6a677a;font-weight:500;font-family:Inter,Arial,sans-serif;font-size:14px;line-height:14px;text-align:center;">The Blog</span></a></div>
   </td>
   </tr>
   </table>
@@ -612,7 +612,7 @@ export const email = ({
   <table cellspacing="0" cellpadding="0" border="0">
   <tr>
   <td style="vertical-align: middle;" align="center">
-  <div style="line-height:14px;text-align:center;"><a target="_blank" href="https://www.audius.events"><span style="color:#6a677a;font-weight:500;font-family:Inter,Arial,sans-serif;font-size:14px;line-height:14px;text-align:center;">Events</span></a></div>
+  <div style="line-height:14px;text-align:center;"><a href="https://www.audius.events"><span style="color:#6a677a;font-weight:500;font-family:Inter,Arial,sans-serif;font-size:14px;line-height:14px;text-align:center;">Events</span></a></div>
   </td>
   </tr>
   </table>
@@ -634,7 +634,7 @@ export const email = ({
   <table cellspacing="0" cellpadding="0" border="0">
   <tr>
   <td style="vertical-align: middle;" align="center">
-  <div style="line-height:14px;text-align:center;"><a target="_blank" href="https://brand.audius.co"><span style="color:#6a677a;font-weight:500;font-family:Inter,Arial,sans-serif;font-size:14px;line-height:14px;text-align:center;">Brand / Press</span></a></div>
+  <div style="line-height:14px;text-align:center;"><a href="https://brand.audius.co"><span style="color:#6a677a;font-weight:500;font-family:Inter,Arial,sans-serif;font-size:14px;line-height:14px;text-align:center;">Brand / Press</span></a></div>
   </td>
   </tr>
   </table>
@@ -648,7 +648,7 @@ export const email = ({
   <table cellspacing="0" cellpadding="0" border="0">
   <tr>
   <td style="vertical-align: middle;" align="center">
-  <div style="line-height:14px;text-align:center;"><a target="_blank" href="https://merch.audius.co"><span style="color:#6a677a;font-weight:500;font-family:Inter,Arial,sans-serif;font-size:14px;line-height:14px;text-align:center;">Merch Store</span></a></div>
+  <div style="line-height:14px;text-align:center;"><a href="https://merch.audius.co"><span style="color:#6a677a;font-weight:500;font-family:Inter,Arial,sans-serif;font-size:14px;line-height:14px;text-align:center;">Merch Store</span></a></div>
   </td>
   </tr>
   </table>
@@ -692,6 +692,14 @@ export const email = ({
   </table>
   </td>
   </tr>
+  <tr>
+  <td height="8" style="height:8px; min-height:8px; line-height:8px;"></td>
+  </tr>
+  <tr>
+  <td style="vertical-align: middle;" align="center">
+  <div style="line-height:14px;text-align:center;"><span style="color:#6a677a;font-family:Inter,Arial,sans-serif;font-size:12px;line-height:14px;text-align:center;">No longer want to receive these emails? </span><span style="color:#7e1bcc;font-family:Inter,Arial,sans-serif;font-size:12px;line-height:14px;text-align:center;">Unsubscribe </span><span style="color:#6a677a;font-family:Inter,Arial,sans-serif;font-size:12px;line-height:14px;text-align:center;">or</span><span style="color:#7e1bcc;font-family:Inter,Arial,sans-serif;font-size:12px;line-height:14px;text-align:center;"> Manage Email Preferences</span></div>
+  </td>
+  </tr>
   </table>
   </td>
   </tr>
@@ -728,6 +736,7 @@ export const email = ({
   </table>
   </div>
   </body>
+
   </html>
 `
 }

--- a/packages/discovery-provider/plugins/notifications/src/email/notifications/preRendered/withdrawal.ts
+++ b/packages/discovery-provider/plugins/notifications/src/email/notifications/preRendered/withdrawal.ts
@@ -15,21 +15,21 @@ export const email = ({
   return `
   <!doctype html>
   <html lang="en" xmlns="http://www.w3.org/1999/xhtml" xmlns:v="urn:schemas-microsoft-com:vml" xmlns:o="urn:schemas-microsoft-com:office:office">
-  
+
   <head>
   <meta charset="utf-8" />
   <meta content="width=device-width" name="viewport" />
   <meta content="IE=edge" http-equiv="X-UA-Compatible" />
   <meta name="x-apple-disable-message-reformatting" />
   <meta content="telephone=no,address=no,email=no,date=no,url=no" name="format-detection" />
-  <title>Your USDC Transfer is Complete!</title>
+  <title>Your Withdrawal is Complete!</title>
   <!--[if mso]>
-			  <style>
-				  * {
-					  font-family: sans-serif !important;
-				  }
-			  </style>
-		  <![endif]-->
+              <style>
+                  * {
+                      font-family: sans-serif !important;
+                  }
+              </style>
+          <![endif]-->
   <!--[if !mso]><!-->
   <!-- <![endif]-->
   <link href="https://fonts.googleapis.com/css?family=Inter:700" rel="stylesheet" type="text/css">
@@ -37,133 +37,133 @@ export const email = ({
   <link href="https://fonts.googleapis.com/css?family=Inter:500" rel="stylesheet" type="text/css">
   <style>
   html {
-	  margin: 0 !important;
-	  padding: 0 !important;
+      margin: 0 !important;
+      padding: 0 !important;
   }
-  
+
   * {
-	  -ms-text-size-adjust: 100%;
-	  -webkit-text-size-adjust: 100%;
+      -ms-text-size-adjust: 100%;
+      -webkit-text-size-adjust: 100%;
   }
   td {
-	  vertical-align: top;
-	  mso-table-lspace: 0pt !important;
-	  mso-table-rspace: 0pt !important;
+      vertical-align: top;
+      mso-table-lspace: 0pt !important;
+      mso-table-rspace: 0pt !important;
   }
   a {
-	  text-decoration: none;
+      text-decoration: none;
   }
   img {
-	  -ms-interpolation-mode:bicubic;
+      -ms-interpolation-mode:bicubic;
   }
   @media only screen and (min-device-width: 320px) and (max-device-width: 374px) {
-	  u ~ div .email-container {
-		  min-width: 320px !important;
-	  }
+      u ~ div .email-container {
+          min-width: 320px !important;
+      }
   }
   @media only screen and (min-device-width: 375px) and (max-device-width: 413px) {
-	  u ~ div .email-container {
-		  min-width: 375px !important;
-	  }
+      u ~ div .email-container {
+          min-width: 375px !important;
+      }
   }
   @media only screen and (min-device-width: 414px) {
-	  u ~ div .email-container {
-		  min-width: 414px !important;
-	  }
+      u ~ div .email-container {
+          min-width: 414px !important;
+      }
   }
-  
+
   </style>
   <!--[if gte mso 9]>
-		  <xml>
-			  <o:OfficeDocumentSettings>
-				  <o:AllowPNG/>
-				  <o:PixelsPerInch>96</o:PixelsPerInch>
-			  </o:OfficeDocumentSettings>
-		  </xml>
-		  <![endif]-->
+          <xml>
+              <o:OfficeDocumentSettings>
+                  <o:AllowPNG/>
+                  <o:PixelsPerInch>96</o:PixelsPerInch>
+              </o:OfficeDocumentSettings>
+          </xml>
+          <![endif]-->
   <style>
   @media only screen and (max-device-width: 599px), only screen and (max-width: 599px) {
-  
-	  .eh {
-		  height:auto !important;
-	  }
-	  .desktop {
-		  display: none !important;
-		  height: 0 !important;
-		  margin: 0 !important;
-		  max-height: 0 !important;
-		  overflow: hidden !important;
-		  padding: 0 !important;
-		  visibility: hidden !important;
-		  width: 0 !important;
-	  }
-	  .mobile {
-		  display: block !important;
-		  width: auto !important;
-		  height: auto !important;
-		  float: none !important;
-	  }
-	  .email-container {
-		  width: 100% !important;
-		  margin: auto !important;
-	  }
-	  .stack-column,
-	  .stack-column-center {
-		  display: block !important;
-		  width: 100% !important;
-		  max-width: 100% !important;
-		  direction: ltr !important;
-	  }
-	  .wid-auto {
-		  width:auto !important;
-	  }
-  
-	  .table-w-full-mobile {
-		  width: 100%;
-	  }
-  
-	  
-	  
-  
-	  .mobile-center {
-		  text-align: center;
-	  }
-  
-	  .mobile-center > table {
-		  display: inline-block;
-		  vertical-align: inherit;
-	  }
-  
-	  .mobile-left {
-		  text-align: left;
-	  }
-  
-	  .mobile-left > table {
-		  display: inline-block;
-		  vertical-align: inherit;
-	  }
-  
-	  .mobile-right {
-		  text-align: right;
-	  }
-  
-	  .mobile-right > table {
-		  display: inline-block;
-		  vertical-align: inherit;
-	  }
-  
+
+      .eh {
+          height:auto !important;
+      }
+      .desktop {
+          display: none !important;
+          height: 0 !important;
+          margin: 0 !important;
+          max-height: 0 !important;
+          overflow: hidden !important;
+          padding: 0 !important;
+          visibility: hidden !important;
+          width: 0 !important;
+      }
+      .mobile {
+          display: block !important;
+          width: auto !important;
+          height: auto !important;
+          float: none !important;
+      }
+      .email-container {
+          width: 100% !important;
+          margin: auto !important;
+      }
+      .stack-column,
+      .stack-column-center {
+          display: block !important;
+          width: 100% !important;
+          max-width: 100% !important;
+          direction: ltr !important;
+      }
+      .wid-auto {
+          width:auto !important;
+      }
+
+      .table-w-full-mobile {
+          width: 100%;
+      }
+
+      
+      
+
+      .mobile-center {
+          text-align: center;
+      }
+
+      .mobile-center > table {
+          display: inline-block;
+          vertical-align: inherit;
+      }
+
+      .mobile-left {
+          text-align: left;
+      }
+
+      .mobile-left > table {
+          display: inline-block;
+          vertical-align: inherit;
+      }
+
+      .mobile-right {
+          text-align: right;
+      }
+
+      .mobile-right > table {
+          display: inline-block;
+          vertical-align: inherit;
+      }
+
   }
-  
+
   </style>
   </head>
-  
+
   <body width="100%" style="background-color:#e9e9eb;margin:0;padding:0!important;mso-line-height-rule:exactly;">
   <div style="background-color:#e9e9eb">
   <!--[if gte mso 9]>
-											  <v:background xmlns:v="urn:schemas-microsoft-com:vml" fill="t">
-											  <v:fill type="tile" color="#e9e9eb"/>
-											  </v:background>
-											  <![endif]-->
+                                              <v:background xmlns:v="urn:schemas-microsoft-com:vml" fill="t">
+                                              <v:fill type="tile" color="#e9e9eb"/>
+                                              </v:background>
+                                              <![endif]-->
   <table width="100%" cellpadding="0" cellspacing="0" border="0">
   <tr>
   <td valign="top" align="center">
@@ -191,7 +191,7 @@ export const email = ({
   <table border="0" cellpadding="0" cellspacing="0">
   <tr>
   <td style="vertical-align: middle;" width="60"><img src="${profilePicture}" width="60" border="0" style="min-width:60px; width:60px;
-		  border-radius:64px; height: auto; display: block;"></td>
+          border-radius:64px; height: auto; display: block;"></td>
   <td style="width:16px; min-width:16px;" width="16"></td>
   <td style="vertical-align: middle;">
   <table cellspacing="0" cellpadding="0" border="0">
@@ -200,7 +200,7 @@ export const email = ({
   <table width="100%" border="0" cellpadding="0" cellspacing="0">
   <tr>
   <td style="vertical-align: middle;">
-  <div style="line-height:24px;text-align:left;"><a target="_blank" href="${profileLink}"><span style="color:#52505f;font-weight:700;font-family:Inter,Arial,sans-serif;font-size:16px;letter-spacing:-0.02em;line-height:24px;text-align:left;">${name}</span></a></div>
+  <div style="line-height:24px;text-align:left;"><a href="${profileLink}"><span style="color:#52505f;font-weight:700;font-family:Inter,Arial,sans-serif;font-size:16px;letter-spacing:-0.02em;line-height:24px;text-align:left;">${name}</span></a></div>
   </td>
   </tr>
   <tr>
@@ -211,7 +211,7 @@ export const email = ({
   <table cellspacing="0" cellpadding="0" border="0">
   <tr>
   <td style="vertical-align: middle;">
-  <div style="line-height:24px;text-align:left;"><a target="_blank" href="${profileLink}"><span style="color:#52505f;font-family:Inter,Arial,sans-serif;font-size:16px;line-height:24px;text-align:left;">@${handle}</span></a></div>
+  <div style="line-height:24px;text-align:left;"><a href="${profileLink}"><span style="color:#52505f;font-family:Inter,Arial,sans-serif;font-size:16px;line-height:24px;text-align:left;">@${handle}</span></a></div>
   </td>
   </tr>
   </table>
@@ -230,7 +230,7 @@ export const email = ({
   </td>
   <td style="width:8px; min-width:8px;" width="8"></td>
   <td style="vertical-align: middle;" width="72" align="center"><img src="https://download.audius.co/emails/withdrawal/BSO6Pwu0dZGFQVFQQKZ8VtvWxBUw5S.jpeg" width="72" border="0" style="min-width:72px; width:72px;
-		   height: auto; display: block;"></td>
+          height: auto; display: block;"></td>
   </tr>
   <tr>
   <td height="8" style="height:8px; min-height:8px; line-height:8px;"></td>
@@ -267,7 +267,7 @@ export const email = ({
   </tr>
   <tr>
   <td style="vertical-align: middle;">
-  <div style="line-height:36px;text-align:left;"><span style="color:#3a3843;font-weight:700;font-family:Inter,Arial,sans-serif;font-size:27px;letter-spacing:-0.02em;line-height:36px;text-align:left;">Funds Transfer Confirmation</span></div>
+  <div style="line-height:36px;text-align:left;"><span style="color:#3a3843;font-weight:700;font-family:Inter,Arial,sans-serif;font-size:27px;letter-spacing:-0.02em;line-height:36px;text-align:left;">Funds Withdrawal Confirmation</span></div>
   </td>
   </tr>
   <tr>
@@ -275,7 +275,7 @@ export const email = ({
   </tr>
   <tr>
   <td style="vertical-align: middle;">
-  <div style="line-height:24px;text-align:left;"><span style="color:#52505f;font-family:Inter,Arial,sans-serif;font-size:16px;line-height:24px;text-align:left;">We have successfully processed your Solana USD (USDC) transfer.</span></div>
+  <div style="line-height:24px;text-align:left;"><span style="color:#52505f;font-family:Inter,Arial,sans-serif;font-size:16px;line-height:24px;text-align:left;">We have successfully processed your funds withdrawal.</span></div>
   </td>
   </tr>
   <tr>
@@ -301,7 +301,7 @@ export const email = ({
   <table width="100%" border="0" cellpadding="0" cellspacing="0">
   <tr>
   <td>
-  <div style="line-height:24px;text-align:left;"><span style="color:#3a3843;font-weight:700;font-family:Inter,Arial,sans-serif;font-size:16px;letter-spacing:-0.02em;line-height:24px;text-align:left;">Transfer Details</span></div>
+  <div style="line-height:24px;text-align:left;"><span style="color:#3a3843;font-weight:700;font-family:Inter,Arial,sans-serif;font-size:16px;letter-spacing:-0.02em;line-height:24px;text-align:left;">Withdrawal Details</span></div>
   </td>
   </tr>
   <tr>
@@ -309,7 +309,7 @@ export const email = ({
   </tr>
   <tr>
   <td>
-  <div style="line-height:24px;text-align:left;"><span style="color:#52505f;font-family:Inter,Arial,sans-serif;font-size:16px;line-height:24px;text-align:left;">Transfer Amount: ${amount} USDC</span></div>
+  <div style="line-height:24px;text-align:left;"><span style="color:#52505f;font-family:Inter,Arial,sans-serif;font-size:16px;line-height:24px;text-align:left;">Withdrawal Amount: $${amount} USDC</span></div>
   </td>
   </tr>
   </table>
@@ -334,15 +334,15 @@ export const email = ({
   <td height="24" style="height:24px; min-height:24px; line-height:24px;"></td>
   </tr>
   <tr>
-  <td width="100%" align="center" class="2DsnnC4ovok27ac7AXLqfMQEbhtxLo invert-bg" style="vertical-align: middle; background-repeat:no-repeat !important; background-position: center center !important; background-size: cover !important;border-radius:12px; border-collapse:separate !important; padding-left:24px; padding-right:24px;" background="https://download.audius.co/emails/withdrawal/2DsnnC4ovok27ac7AXLqfMQEbhtxLo.png">
+  <td width="100%" align="center" class="g6mVTlN1jHGAR2CFDjJfUQyLqm2pCR invert-bg" style="vertical-align: middle; background-repeat:no-repeat !important; background-position: center center !important; background-size: cover !important;border-radius:12px; border-collapse:separate !important; padding-left:24px; padding-right:24px;" background="https://download.audius.co/emails/withdrawal/2DsnnC4ovok27ac7AXLqfMQEbhtxLo.png">
   <!--[if gte mso 9]>
-				  <v:image xmlns:v="urn:schemas-microsoft-com:vml" fill="true" stroke="false" style=" border: 0;display: inline-block; width: 552px; height:182px;"
-				  src="https://download.audius.co/emails/withdrawal/2DsnnC4ovok27ac7AXLqfMQEbhtxLo.png"
-				  />
-				  <v:rect xmlns:v="urn:schemas-microsoft-com:vml" fill="true" stroke="false" style=" border: 0;display: inline-block;position: absolute; width: 552px; height:182px;">
-				  <v:fill opacity="0%" color="#000" />
-				  <v:textbox inset="0,0,0,0">
-				  <![endif]-->
+                  <v:image xmlns:v="urn:schemas-microsoft-com:vml" fill="true" stroke="false" style=" border: 0;display: inline-block; width: 552px; height:182px;"
+                  src="https://download.audius.co/emails/withdrawal/2DsnnC4ovok27ac7AXLqfMQEbhtxLo.png"
+                  />
+                  <v:rect xmlns:v="urn:schemas-microsoft-com:vml" fill="true" stroke="false" style=" border: 0;display: inline-block;position: absolute; width: 552px; height:182px;">
+                  <v:fill opacity="0%" color="#000" />
+                  <v:textbox inset="0,0,0,0">
+                  <![endif]-->
   <div>
   <table width="100%" border="0" cellpadding="0" cellspacing="0">
   <tr>
@@ -379,10 +379,10 @@ export const email = ({
   <table class="table-w-full-mobile" border="0" cellpadding="0" cellspacing="0">
   <tr>
   <td style="vertical-align: middle;" class="stack-column-center" align="center"><a target="_blank" href="https://apps.apple.com/us/app/audius-music/id1491270519"><img src="https://download.audius.co/emails/withdrawal/oxyCkIsHBvNleiZLGnyXvV7j9yM9KE.png" width="142" border="0" style="min-width:142px; width:142px;
-		   height: auto; display: block;"></a></td>
+          height: auto; display: block;"></a></td>
   <td class="stack-column-center" height="12" style="width:12px; min-width:12px; height:12px; min-height:12px;" width="12"></td>
-  <td style="vertical-align: middle;" class="stack-column-center" align="center"><a target="_blank" href="https://play.google.com/store/apps/details?id=co.audius.app&hl=en_US&gl=US"><img src="https://download.audius.co/emails/withdrawal/q1evAW5GIFOanhNG9Tf8GGyFeQE4AX.png" width="166" border="0" style="min-width:166px; width:166px;
-		   height: auto; display: block;"></a></td>
+  <td style="vertical-align: middle;" class="stack-column-center" align="center"><a href="https://play.google.com/store/apps/details?id=co.audius.app&hl=en_US&gl=US"><img src="en_US&gl=US"><img src="https://download.audius.co/emails/withdrawal/q1evAW5GIFOanhNG9Tf8GGyFeQE4AX.png" width="166" border="0" style="min-width:166px; width:166px;
+          height: auto; display: block;"></a></td>
   </tr>
   </table>
   </td>
@@ -399,11 +399,11 @@ export const email = ({
   </table>
   </div>
   <!--[if gte mso 9]>
-				  </v:textbox>
-				  </v:fill>
-				  </v:rect>
-				  </v:image>
-				  <![endif]-->
+                  </v:textbox>
+                  </v:fill>
+                  </v:rect>
+                  </v:image>
+                  <![endif]-->
   </td>
   </tr>
   <tr>
@@ -446,8 +446,8 @@ export const email = ({
   <td width="528" align="center" style="vertical-align: middle;  ">
   <table class="table-w-full-mobile" width="100%" border="0" cellpadding="0" cellspacing="0">
   <tr>
-  <td style="vertical-align: middle;" class="stack-column-center" align="center"><a target="_blank" href="https://www.audius.co"><img src="https://download.audius.co/emails/withdrawal/NQYOVr4BMjSzOkhCNPtzsCUxMFeq1w.png" width="168" border="0" style="min-width:168px; width:168px;
-		  border-radius:2px; height: auto; display: block;"></a></td>
+  <td style="vertical-align: middle;" class="stack-column-center" align="center"><a href="https://www.audius.co"><img src="https://download.audius.co/emails/withdrawal/NQYOVr4BMjSzOkhCNPtzsCUxMFeq1w.png" width="168" border="0" style="min-width:168px; width:168px;
+          border-radius:2px; height: auto; display: block;"></a></td>
   <td class="stack-column-center" height="12" style="width:12px; min-width:12px; height:12px; min-height:12px;" width="12"></td>
   <td class="stack-column-center" style="width:168px;"></td>
   <td class="stack-column-center" height="12" style="width:12px; min-width:12px; height:12px; min-height:12px;" width="12"></td>
@@ -478,17 +478,17 @@ export const email = ({
   <td width="144" style="vertical-align: middle;  ">
   <table width="100%" border="0" cellpadding="0" cellspacing="0">
   <tr>
-  <td style="vertical-align: middle;"><a target="_blank" href="https://twitter.com/audius"><img src="https://download.audius.co/emails/withdrawal/90NyRomVtFDITFNfgY3QmVpY7Xvzvv.png" width="24" border="0" style="min-width:24px; width:24px;
-		   height: auto; display: block;"></a></td>
+  <td style="vertical-align: middle;"><a href="https://twitter.com/audius"><img src="https://download.audius.co/emails/withdrawal/90NyRomVtFDITFNfgY3QmVpY7Xvzvv.png" width="24" border="0" style="min-width:24px; width:24px;
+          height: auto; display: block;"></a></td>
   <td style="width:16px; min-width:16px;" width="16"></td>
-  <td style="vertical-align: middle;"><a target="_blank" href="https://www.instagram.com/audius/"><img src="https://download.audius.co/emails/withdrawal/UVUMcCdSVSWrgQAce3eaW4rDG6E6mI.png" width="24" border="0" style="min-width:24px; width:24px;
-		   height: auto; display: block;"></a></td>
+  <td style="vertical-align: middle;"><a href="https://www.instagram.com/audius/"><img src="https://download.audius.co/emails/withdrawal/UVUMcCdSVSWrgQAce3eaW4rDG6E6mI.png" width="24" border="0" style="min-width:24px; width:24px;
+          height: auto; display: block;"></a></td>
   <td style="width:16px; min-width:16px;" width="16"></td>
-  <td style="vertical-align: middle;"><a target="_blank" href="https://tiktok.com/@audius"><img src="https://download.audius.co/emails/withdrawal/Ck8b7F53y061dHkJghL8EXiX0SaCLy.png" width="24" border="0" style="min-width:24px; width:24px;
-		   height: auto; display: block;"></a></td>
+  <td style="vertical-align: middle;"><a href="https://tiktok.com/@audius"><img src="https://download.audius.co/emails/withdrawal/Ck8b7F53y061dHkJghL8EXiX0SaCLy.png" width="24" border="0" style="min-width:24px; width:24px;
+          height: auto; display: block;"></a></td>
   <td style="width:16px; min-width:16px;" width="16"></td>
-  <td style="vertical-align: middle;"><a target="_blank" href="https://www.youtube.com/@AudiusMusic"><img src="https://download.audius.co/emails/withdrawal/Z5Qtu3Hg8UearT1uQMk58SvvfoQhhe.png" width="24" border="0" style="min-width:24px; width:24px;
-		   height: auto; display: block;"></a></td>
+  <td style="vertical-align: middle;"><a href="https://www.youtube.com/@AudiusMusic"><img src="https://download.audius.co/emails/withdrawal/Z5Qtu3Hg8UearT1uQMk58SvvfoQhhe.png" width="24" border="0" style="min-width:24px; width:24px;
+          height: auto; display: block;"></a></td>
   </tr>
   </table>
   </td>
@@ -555,7 +555,7 @@ export const email = ({
   <table cellspacing="0" cellpadding="0" border="0">
   <tr>
   <td style="vertical-align: middle;" align="center">
-  <div style="line-height:14px;text-align:center;"><a target="_blank" href="https://www.audius.co"><span style="color:#6a677a;font-weight:500;font-family:Inter,Arial,sans-serif;font-size:14px;line-height:14px;text-align:center;">Audius Music</span></a></div>
+  <div style="line-height:14px;text-align:center;"><a href="https://www.audius.co"><span style="color:#6a677a;font-weight:500;font-family:Inter,Arial,sans-serif;font-size:14px;line-height:14px;text-align:center;">Audius Music</span></a></div>
   </td>
   </tr>
   </table>
@@ -566,7 +566,7 @@ export const email = ({
   </tr>
   <tr>
   <td style="vertical-align: middle;" align="center">
-  <div style="line-height:14px;text-align:center;"><a target="_blank" href="https://help.audius.co"><span style="color:#6a677a;font-weight:500;font-family:Inter,Arial,sans-serif;font-size:14px;line-height:14px;text-align:center;">Help & Support</span></a></div>
+  <div style="line-height:14px;text-align:center;"><a href="https://help.audius.co"><span style="color:#6a677a;font-weight:500;font-family:Inter,Arial,sans-serif;font-size:14px;line-height:14px;text-align:center;">Help & Support</span></a></div>
   </td>
   </tr>
   </table>
@@ -585,7 +585,7 @@ export const email = ({
   <table cellspacing="0" cellpadding="0" border="0">
   <tr>
   <td style="vertical-align: middle;" align="center">
-  <div style="line-height:14px;text-align:center;"><a target="_blank" href="https://blog.audius.co"><span style="color:#6a677a;font-weight:500;font-family:Inter,Arial,sans-serif;font-size:14px;line-height:14px;text-align:center;">The Blog</span></a></div>
+  <div style="line-height:14px;text-align:center;"><a href="https://blog.audius.co"><span style="color:#6a677a;font-weight:500;font-family:Inter,Arial,sans-serif;font-size:14px;line-height:14px;text-align:center;">The Blog</span></a></div>
   </td>
   </tr>
   </table>
@@ -599,7 +599,7 @@ export const email = ({
   <table cellspacing="0" cellpadding="0" border="0">
   <tr>
   <td style="vertical-align: middle;" align="center">
-  <div style="line-height:14px;text-align:center;"><a target="_blank" href="https://www.audius.events"><span style="color:#6a677a;font-weight:500;font-family:Inter,Arial,sans-serif;font-size:14px;line-height:14px;text-align:center;">Events</span></a></div>
+  <div style="line-height:14px;text-align:center;"><a href="https://www.audius.events"><span style="color:#6a677a;font-weight:500;font-family:Inter,Arial,sans-serif;font-size:14px;line-height:14px;text-align:center;">Events</span></a></div>
   </td>
   </tr>
   </table>
@@ -621,7 +621,7 @@ export const email = ({
   <table cellspacing="0" cellpadding="0" border="0">
   <tr>
   <td style="vertical-align: middle;" align="center">
-  <div style="line-height:14px;text-align:center;"><a target="_blank" href="https://brand.audius.co"><span style="color:#6a677a;font-weight:500;font-family:Inter,Arial,sans-serif;font-size:14px;line-height:14px;text-align:center;">Brand / Press</span></a></div>
+  <div style="line-height:14px;text-align:center;"><a href="https://brand.audius.co"><span style="color:#6a677a;font-weight:500;font-family:Inter,Arial,sans-serif;font-size:14px;line-height:14px;text-align:center;">Brand / Press</span></a></div>
   </td>
   </tr>
   </table>
@@ -635,7 +635,7 @@ export const email = ({
   <table cellspacing="0" cellpadding="0" border="0">
   <tr>
   <td style="vertical-align: middle;" align="center">
-  <div style="line-height:14px;text-align:center;"><a target="_blank" href="https://merch.audius.co"><span style="color:#6a677a;font-weight:500;font-family:Inter,Arial,sans-serif;font-size:14px;line-height:14px;text-align:center;">Merch Store</span></a></div>
+  <div style="line-height:14px;text-align:center;"><a href="https://merch.audius.co"><span style="color:#6a677a;font-weight:500;font-family:Inter,Arial,sans-serif;font-size:14px;line-height:14px;text-align:center;">Merch Store</span></a></div>
   </td>
   </tr>
   </table>
@@ -679,6 +679,14 @@ export const email = ({
   </table>
   </td>
   </tr>
+  <tr>
+  <td height="8" style="height:8px; min-height:8px; line-height:8px;"></td>
+  </tr>
+  <tr>
+  <td style="vertical-align: middle;" align="center">
+  <div style="line-height:14px;text-align:center;"><span style="color:#6a677a;font-family:Inter,Arial,sans-serif;font-size:12px;line-height:14px;text-align:center;">No longer want to receive these emails? </span><span style="color:#7e1bcc;font-family:Inter,Arial,sans-serif;font-size:12px;line-height:14px;text-align:center;">Unsubscribe </span><span style="color:#6a677a;font-family:Inter,Arial,sans-serif;font-size:12px;line-height:14px;text-align:center;">or</span><span style="color:#7e1bcc;font-family:Inter,Arial,sans-serif;font-size:12px;line-height:14px;text-align:center;"> Manage Email Preferences</span></div>
+  </td>
+  </tr>
   </table>
   </td>
   </tr>
@@ -715,6 +723,7 @@ export const email = ({
   </table>
   </div>
   </body>
+
   </html>
-  `
+`
 }

--- a/packages/discovery-provider/plugins/notifications/src/processNotifications/indexAppNotifications.ts
+++ b/packages/discovery-provider/plugins/notifications/src/processNotifications/indexAppNotifications.ts
@@ -78,7 +78,8 @@ export const notificationTypeMapping = {
   request_manager: MappingVariable.PushRequestManager,
   approve_manager_request: MappingVariable.PushApproveManagerRequest,
   announcement: MappingVariable.PushAnnouncement,
-  reaction: MappingVariable.PushReaction
+  reaction: MappingVariable.PushReaction,
+  reward_in_cooldown: MappingVariable.PushRewardInCooldown
 }
 
 export class AppNotificationsProcessor {

--- a/packages/discovery-provider/plugins/notifications/src/processNotifications/mappers/rewardInCooldown.ts
+++ b/packages/discovery-provider/plugins/notifications/src/processNotifications/mappers/rewardInCooldown.ts
@@ -16,36 +16,66 @@ type RewardInCooldownRow = Omit<NotificationRow, 'data'> & {
 const challengeMessages = {
   'send-first-tip': {
     title: 'Send Your First Tip',
-    description: 'Show some love to your favorite artist by sending them a tip.'
+    description:
+      'Show some love to your favorite artist by sending them a tip.',
+    imageUrl: 'Ky4Qr1byW9wnawVFUbRlpTaLf8d4n0.png'
   },
   'track-upload': {
     title: 'Upload 3 Tracks',
-    description: 'Earn 1 $AUDIO for uploading 3 tracks.'
+    description: 'Earn 1 $AUDIO for uploading 3 tracks.',
+    imageUrl: '72WyVN4Vds7CvNZr5yQA912GLFhDOs.png'
   },
   'first-playlist': {
     title: 'Create a Playlist',
-    description: 'Create a playlist and add a track.'
-  },
-  'mobile-install': {
-    title: 'Get the Mobile App',
-    description:
-      'Download the Audius app for iOS or Android and sign in to Earn 1 $AUDIO.'
+    description: 'Create a playlist and add a track.',
+    imageUrl: 'PH1vcT5H8RRADIqSZwaKvNztiiKIDm.png'
   },
   'ref-v': {
     title: 'Link Verified Accounts',
-    description: 'Link your verified social media accounts to get 5 $AUDIO.'
+    description: 'Link your verified social media accounts to get 5 $AUDIO.',
+    imageUrl: 'XFmTX9RIkyTzsEEsQopzDdGXeGnxXA.png'
   },
   referrals: {
     title: 'Invite Your Friends!',
-    description: 'Earn 1 $AUDIO for you and your friend.'
+    description: 'Earn 1 $AUDIO for you and your friend.',
+    imageUrl: 'XFmTX9RIkyTzsEEsQopzDdGXeGnxXA.png'
   },
   referred: {
     title: 'You Accepted An Invite!',
-    description: 'You earned 1 $AUDIO for being invited.'
+    description: 'You earned 1 $AUDIO for being invited.',
+    imageUrl: 'XFmTX9RIkyTzsEEsQopzDdGXeGnxXA.png'
+  },
+  'connect-verified': {
+    title: 'Link Verified Accounts',
+    description: 'Link your verified social media accounts to earn 5 $AUDIO.',
+    imageUrl: 'bpwwTf7HiZxlMd1PkX82qw45tiEpXX.png'
   },
   'profile-completion': {
     title: 'Complete Your Profile',
-    description: 'Complete your Audius profile to earn 1 $AUDIO.'
+    description: 'Complete your Audius profile to earn 1 $AUDIO.',
+    imageUrl: '8JCdZg2rcQdqovWtNYfUA3RZDAiyX3.png'
+  },
+  'listen-streak': {
+    title: 'Listening Streak: 7 Days',
+    description: 'Complete your Audius profile to earn 1 $AUDIO.',
+    imageUrl: '8JCdZg2rcQdqovWtNYfUA3RZDAiyX3.png'
+  },
+  'mobile-install': {
+    title: 'Get the Audius Mobile App',
+    description:
+      'Download the Audius app for iOS or Android and sign in to Earn 1 $AUDIO.',
+    imageUrl: 'uVztPmheWeIzdv2C4vnvgBgnH221sU.png'
+  },
+  s: {
+    title: 'Sell to Earn',
+    description:
+      'Receive 1 additional $AUDIO for each dollar earned from sales',
+    imageUrl: 'AXu4i3Zj3QCGifxQ5ug5z8Pp8am9mS.png'
+  },
+  b: {
+    title: 'Spend to Earn',
+    description: 'Earn 1 $AUDIO for each dollar you spend on Audius.',
+    imageUrl: 'AXu4i3Zj3QCGifxQ5ug5z8Pp8am9mS.png'
   }
 }
 
@@ -67,7 +97,6 @@ export class RewardInCooldown extends BaseNotification<RewardInCooldownRow> {
   }
 
   async processNotification() {
-    logger.info(`asdf processNotification`)
     const users = await this.getUsersBasicInfo([this.userId])
     const user = users[this.userId]
     if (!user) {
@@ -89,7 +118,8 @@ export class RewardInCooldown extends BaseNotification<RewardInCooldownRow> {
         profileLink: formatProfileUrl(user.handle),
         amount: this.amount,
         challengeTitle: challengeMessage.title,
-        challengeDescription: challengeMessage.description
+        challengeDescription: challengeMessage.description,
+        challengeImage: challengeMessage.imageUrl
       }),
       subject: 'Congratulations! 🏆 You’ve earned a reward! 🎉'
     })

--- a/packages/discovery-provider/plugins/notifications/src/processNotifications/mappers/rewardInCooldown.ts
+++ b/packages/discovery-provider/plugins/notifications/src/processNotifications/mappers/rewardInCooldown.ts
@@ -121,7 +121,7 @@ export class RewardInCooldown extends BaseNotification<RewardInCooldownRow> {
         challengeDescription: challengeMessage.description,
         challengeImage: challengeMessage.imageUrl
       }),
-      subject: 'Congratulations! 🏆 You’ve earned a reward! 🎉'
+      subject: 'Congratulations! 🏆 You’ve earned a reward!'
     })
   }
 }

--- a/packages/discovery-provider/plugins/notifications/src/processNotifications/mappers/usdcPurchaseBuyer.ts
+++ b/packages/discovery-provider/plugins/notifications/src/processNotifications/mappers/usdcPurchaseBuyer.ts
@@ -185,7 +185,7 @@ export class USDCPurchaseBuyer extends BaseNotification<USDCPurchaseBuyerRow> {
         total: this.totalAmount,
         vendor: this.vendor
       }),
-      subject: 'Thank You For Your Support'
+      subject: 'Thank you for your purchase!'
     })
   }
 

--- a/packages/discovery-provider/plugins/notifications/src/processNotifications/mappers/usdcPurchaseSeller.ts
+++ b/packages/discovery-provider/plugins/notifications/src/processNotifications/mappers/usdcPurchaseSeller.ts
@@ -193,7 +193,7 @@ export class USDCPurchaseSeller extends BaseNotification<USDCPurchaseSellerRow> 
         payExtra: this.extraAmount,
         total: this.totalAmount
       }),
-      subject: `Your ${capitalize(this.contentType)} Has Been Purchased`
+      subject: `Congrats! You've made a sale on Audius!`
     })
   }
 

--- a/packages/discovery-provider/plugins/notifications/src/processNotifications/mappers/usdcTransfer.ts
+++ b/packages/discovery-provider/plugins/notifications/src/processNotifications/mappers/usdcTransfer.ts
@@ -61,7 +61,7 @@ export class USDCTransfer extends BaseNotification<USDCTransferRow> {
         wallet: this.receiverAccount,
         signature: this.signature
       }),
-      subject: 'Your Transfer Has Been Started'
+      subject: 'Your USDC Transfer is Complete!'
     })
   }
 }

--- a/packages/discovery-provider/plugins/notifications/src/processNotifications/mappers/usdcWithdrawal.ts
+++ b/packages/discovery-provider/plugins/notifications/src/processNotifications/mappers/usdcWithdrawal.ts
@@ -59,7 +59,7 @@ export class USDCWithdrawal extends BaseNotification<USDCWithdrawalRow> {
         profileLink: formatProfileUrl(user.handle),
         amount: this.amount
       }),
-      subject: 'Your Withdrawal Has Been Started'
+      subject: 'Your USDC Transfer is Complete!'
     })
   }
 }

--- a/packages/discovery-provider/plugins/notifications/src/remoteConfig.ts
+++ b/packages/discovery-provider/plugins/notifications/src/remoteConfig.ts
@@ -35,7 +35,8 @@ export enum MappingVariable {
   PushUSDCTransfer = 'push_usdc_transfer',
   PushUSDCWithdrawal = 'push_usdc_withdrawal',
   PushRequestManager = 'push_request_manager',
-  PushApproveManagerRequest = 'push_approve_manager_request'
+  PushApproveManagerRequest = 'push_approve_manager_request',
+  PushRewardInCooldown = 'push_reward_in_cooldown'
 }
 
 export const NotificationsEmailPlugin = 'notification_email_plugin'

--- a/packages/identity-service/src/notifications/emails/downloadMobileApp.html
+++ b/packages/identity-service/src/notifications/emails/downloadMobileApp.html
@@ -234,10 +234,11 @@
                                   <td align="center">
                                     <table cellspacing="0" cellpadding="0" border="0">
                                       <tr>
-                                        <td width="200" align="center"><img
-                                            src="https://download.audius.co/emails/mobile-install/097FN5AQrHc8Oc3LTNCFNxmRYFyNJv.png"
-                                            width="200" border="0" style="min-width:200px; width:200px;
-        border-radius:8px; height: auto; display: block;"></td>
+                                        <td width="200" align="center"><a
+                                            href="https://apps.apple.com/us/app/audius-music/id1491270519"><img
+                                              src="https://download.audius.co/emails/mobile-install/097FN5AQrHc8Oc3LTNCFNxmRYFyNJv.png"
+                                              width="200" border="0" style="min-width:200px; width:200px;
+        border-radius:8px; height: auto; display: block;"></a></td>
                                       </tr>
                                     </table>
                                   </td>
@@ -1110,12 +1111,15 @@
                                                               <td style="vertical-align: middle;" align="center">
                                                                 <div style="line-height:14px;text-align:center;"><span
                                                                     style="color:#6a677a;font-family:Inter,Arial,sans-serif;font-size:12px;line-height:14px;text-align:center;">No
-                                                                    longer want to receive these emails? </span><span
-                                                                    style="color:#7e1bcc;font-family:Inter,Arial,sans-serif;font-size:12px;line-height:14px;text-align:center;">Unsubscribe
-                                                                  </span><span
-                                                                    style="color:#6a677a;font-family:Inter,Arial,sans-serif;font-size:12px;line-height:14px;text-align:center;">or</span><span
-                                                                    style="color:#7e1bcc;font-family:Inter,Arial,sans-serif;font-size:12px;line-height:14px;text-align:center;">
-                                                                    Manage Email Preferences</span></div>
+                                                                    longer want to receive these emails? </span><a
+                                                                    href="<%asm_group_unsubscribe_raw_url%>"><span
+                                                                      style="color:#7e1bcc;font-family:Inter,Arial,sans-serif;font-size:12px;line-height:14px;text-align:center;">Unsubscribe
+                                                                    </span></a><span
+                                                                    style="color:#6a677a;font-family:Inter,Arial,sans-serif;font-size:12px;line-height:14px;text-align:center;">or</span><a
+                                                                    href="<%asm_preferences_raw_url%>"><span
+                                                                      style="color:#7e1bcc;font-family:Inter,Arial,sans-serif;font-size:12px;line-height:14px;text-align:center;">
+                                                                      Manage
+                                                                      Email Preferences</span></a></div>
                                                               </td>
                                                             </tr>
                                                           </table>

--- a/packages/identity-service/src/notifications/emails/otp.js
+++ b/packages/identity-service/src/notifications/emails/otp.js
@@ -2,7 +2,7 @@ const getOtpEmail = ({ otp, copyrightYear }) => {
   return `
   <!doctype html>
   <html lang="en" xmlns="http://www.w3.org/1999/xhtml" xmlns:v="urn:schemas-microsoft-com:vml" xmlns:o="urn:schemas-microsoft-com:office:office">
-  
+
   <head>
   <meta charset="utf-8" />
   <meta content="width=device-width" name="viewport" />
@@ -28,7 +28,7 @@ const getOtpEmail = ({ otp, copyrightYear }) => {
       margin: 0 !important;
       padding: 0 !important;
   }
-  
+
   * {
       -ms-text-size-adjust: 100%;
       -webkit-text-size-adjust: 100%;
@@ -59,7 +59,7 @@ const getOtpEmail = ({ otp, copyrightYear }) => {
           min-width: 414px !important;
       }
   }
-  
+
   </style>
   <!--[if gte mso 9]>
           <xml>
@@ -71,7 +71,7 @@ const getOtpEmail = ({ otp, copyrightYear }) => {
           <![endif]-->
   <style>
   @media only screen and (max-device-width: 599px), only screen and (max-width: 599px) {
-  
+
       .eh {
           height:auto !important;
       }
@@ -105,46 +105,46 @@ const getOtpEmail = ({ otp, copyrightYear }) => {
       .wid-auto {
           width:auto !important;
       }
-  
+
       .table-w-full-mobile {
           width: 100%;
       }
-  
+
       
       
-  
+
       .mobile-center {
           text-align: center;
       }
-  
+
       .mobile-center > table {
           display: inline-block;
           vertical-align: inherit;
       }
-  
+
       .mobile-left {
           text-align: left;
       }
-  
+
       .mobile-left > table {
           display: inline-block;
           vertical-align: inherit;
       }
-  
+
       .mobile-right {
           text-align: right;
       }
-  
+
       .mobile-right > table {
           display: inline-block;
           vertical-align: inherit;
       }
-  
+
   }
-  
+
   </style>
   </head>
-  
+
   <body width="100%" style="background-color:#e9e9eb;margin:0;padding:0!important;mso-line-height-rule:exactly;">
   <div style="background-color:#e9e9eb">
   <!--[if gte mso 9]>
@@ -176,7 +176,7 @@ const getOtpEmail = ({ otp, copyrightYear }) => {
   <table cellspacing="0" cellpadding="0" border="0">
   <tr>
   <td style="vertical-align: middle;" width="224" align="center"><img src="https://download.audius.co/otp-email/qIQFWyjCV3zgmD1szUv72xc3ksmpzo.jpeg" width="224" border="0" style="max-width:224px; width: 100%;
-           height: auto; display: block;"></td>
+          height: auto; display: block;"></td>
   </tr>
   </table>
   </td>
@@ -279,7 +279,7 @@ const getOtpEmail = ({ otp, copyrightYear }) => {
   <table cellspacing="0" cellpadding="0" border="0">
   <tr>
   <td style="vertical-align: middle;" align="center">
-  <div style="line-height:14px;text-align:left;"><span style="color:#52505f;font-family:Inter,Arial,sans-serif;font-size:12px;line-height:14px;text-align:left;">This code will expire in 10 minutes.</span></div>
+  <div style="line-height:14px;text-align:center;"><span style="color:#52505f;font-family:Inter,Arial,sans-serif;font-size:12px;line-height:14px;text-align:center;">This code will expire in 10 minutes. <br><br>If you didn’t make this request, please change your password.</span></div>
   </td>
   </tr>
   </table>
@@ -356,7 +356,7 @@ const getOtpEmail = ({ otp, copyrightYear }) => {
   </tr>
   <tr>
   <td width="24"><img src="https://download.audius.co/otp-email/lG9OMpWZZ229WdHzcggAJwqpl1rt7D.png" width="24" border="0" style="min-width:24px; width:24px;
-           height: auto; display: block;"></td>
+          height: auto; display: block;"></td>
   </tr>
   <tr>
   <td height="16" style="height:16px; min-height:16px; line-height:16px;"></td>
@@ -403,7 +403,7 @@ const getOtpEmail = ({ otp, copyrightYear }) => {
   </tr>
   <tr>
   <td style="vertical-align: middle;" align="center">
-  <div style="line-height:20px;text-align:center;"><span style="color:#cc0fe0;font-family:Inter,Arial,sans-serif;font-size:15px;line-height:20px;text-align:center;text-decoration:underline;">Visit Audius Support</span></div>
+  <div style="line-height:20px;text-align:center;"><a href="https://help.audius.co"><span style="color:#cc0fe0;font-family:Inter,Arial,sans-serif;font-size:15px;line-height:20px;text-align:center;text-decoration:underline;">Visit Audius Support</span></a></div>
   </td>
   </tr>
   </table>
@@ -431,7 +431,7 @@ const getOtpEmail = ({ otp, copyrightYear }) => {
   <td height="24" style="height:24px; min-height:24px; line-height:24px;"></td>
   </tr>
   <tr>
-  <td width="100%" align="center" class="Z4mhke0ZNGrkz2iorzyhsjsPJGeLbL invert-bg" style="vertical-align: middle; background-repeat:no-repeat !important; background-position: center center !important; background-size: cover !important;border-radius:12px; border-collapse:separate !important; padding-left:24px; padding-right:24px;" background="https://download.audius.co/otp-email/Z4mhke0ZNGrkz2iorzyhsjsPJGeLbL.png">
+  <td width="100%" align="center" class="Oiu4JCYLgxzifKn2u1Ao8jKSMSZZgR invert-bg" style="vertical-align: middle; background-repeat:no-repeat !important; background-position: center center !important; background-size: cover !important;border-radius:12px; border-collapse:separate !important; padding-left:24px; padding-right:24px;" background="https://download.audius.co/otp-email/Z4mhke0ZNGrkz2iorzyhsjsPJGeLbL.png">
   <!--[if gte mso 9]>
                   <v:image xmlns:v="urn:schemas-microsoft-com:vml" fill="true" stroke="false" style=" border: 0;display: inline-block; width: 552px; height:182px;"
                   src="https://download.audius.co/otp-email/Z4mhke0ZNGrkz2iorzyhsjsPJGeLbL.png"
@@ -476,10 +476,10 @@ const getOtpEmail = ({ otp, copyrightYear }) => {
   <table class="table-w-full-mobile" border="0" cellpadding="0" cellspacing="0">
   <tr>
   <td style="vertical-align: middle;" class="stack-column-center" align="center"><a href="https://apps.apple.com/us/app/audius-music/id1491270519"><img src="https://download.audius.co/otp-email/8iTgTOaaiwRWb8uRr4oZdK5L1QGrG4.png" width="142" border="0" style="min-width:142px; width:142px;
-           height: auto; display: block;"></a></td>
+          height: auto; display: block;"></a></td>
   <td class="stack-column-center" height="12" style="width:12px; min-width:12px; height:12px; min-height:12px;" width="12"></td>
   <td style="vertical-align: middle;" class="stack-column-center" align="center"><a href="https://play.google.com/store/apps/details?id=co.audius.app&hl=en_US&gl=US"><img src="https://download.audius.co/otp-email/NGijEbnPxazoCCBikLQCvcF8Z0q2C5.png" width="166" border="0" style="min-width:166px; width:166px;
-           height: auto; display: block;"></a></td>
+          height: auto; display: block;"></a></td>
   </tr>
   </table>
   </td>
@@ -576,16 +576,16 @@ const getOtpEmail = ({ otp, copyrightYear }) => {
   <table width="100%" border="0" cellpadding="0" cellspacing="0">
   <tr>
   <td style="vertical-align: middle;"><a href="https://twitter.com/audius"><img src="https://download.audius.co/otp-email/1m7EkfYSkLovQaAoa7vTgx23UexqJ1.png" width="24" border="0" style="min-width:24px; width:24px;
-           height: auto; display: block;"></a></td>
+          height: auto; display: block;"></a></td>
   <td style="width:16px; min-width:16px;" width="16"></td>
   <td style="vertical-align: middle;"><a href="https://www.instagram.com/audius/"><img src="https://download.audius.co/otp-email/7UFlMNIXrXJgupPPV4ZxeIv0iuAzeL.png" width="24" border="0" style="min-width:24px; width:24px;
-           height: auto; display: block;"></a></td>
+          height: auto; display: block;"></a></td>
   <td style="width:16px; min-width:16px;" width="16"></td>
   <td style="vertical-align: middle;"><a href="https://tiktok.com/@audius"><img src="https://download.audius.co/otp-email/kREPF5mLWgYcrf2QbtuNPWS24I6FJK.png" width="24" border="0" style="min-width:24px; width:24px;
-           height: auto; display: block;"></a></td>
+          height: auto; display: block;"></a></td>
   <td style="width:16px; min-width:16px;" width="16"></td>
   <td style="vertical-align: middle;"><a href="https://www.youtube.com/@AudiusMusic"><img src="https://download.audius.co/otp-email/wR9Fi09CPhxJRLkeTxWd2W1l2Hs2QM.png" width="24" border="0" style="min-width:24px; width:24px;
-           height: auto; display: block;"></a></td>
+          height: auto; display: block;"></a></td>
   </tr>
   </table>
   </td>
@@ -812,7 +812,6 @@ const getOtpEmail = ({ otp, copyrightYear }) => {
   </table>
   </div>
   </body>
-  
   </html>
 `
 }

--- a/packages/identity-service/src/notifications/emails/welcome.js
+++ b/packages/identity-service/src/notifications/emails/welcome.js
@@ -615,7 +615,7 @@ const getWelcomeEmail = ({ name, copyrightYear, featuredContent }) => {
   <td align="center">
   <table width="100%" border="0" cellpadding="0" cellspacing="0">
   <tr>
-  <td width="168" align="center"><a href="${featuredContent?.[0]?.route_id}"><img src=${featuredContent?.[0]?.artwork?.['480x480']} width="168" border="0" style="width: 100%;
+  <td width="168" align="center"><a href="https://audius.co${featuredContent?.[0]?.permalink}"><img src=${featuredContent?.[0]?.artwork?.['480x480']} width="168" border="0" style="width: 100%;
           border-radius:8px; height: auto; display: block;"></td>
   </tr>
   <tr>
@@ -664,7 +664,7 @@ const getWelcomeEmail = ({ name, copyrightYear, featuredContent }) => {
   <td align="center">
   <table width="100%" border="0" cellpadding="0" cellspacing="0">
   <tr>
-  <td width="168" align="center"><a href="${featuredContent?.[1]?.route_id}"><img src=${featuredContent?.[1]?.artwork?.['480x480']} width="168" border="0" style="width: 100%;
+  <td width="168" align="center"><a href="https://audius.co${featuredContent?.[1]?.permalink}"><img src=${featuredContent?.[1]?.artwork?.['480x480']} width="168" border="0" style="width: 100%;
           border-radius:8px; height: auto; display: block;"></a></td>
   </tr>
   <tr>
@@ -713,7 +713,7 @@ const getWelcomeEmail = ({ name, copyrightYear, featuredContent }) => {
   <td align="center">
   <table width="100%" border="0" cellpadding="0" cellspacing="0">
   <tr>
-  <td width="168" align="center"><a href="${featuredContent?.[2]?.route_id}"><img src=${featuredContent?.[2]?.artwork?.['480x480']} width="168" border="0" style="width: 100%;
+  <td width="168" align="center"><a href="https://audius.co${featuredContent?.[2]?.permalink}"><img src=${featuredContent?.[2]?.artwork?.['480x480']} width="168" border="0" style="width: 100%;
           border-radius:8px; height: auto; display: block;"></td>
   </tr>
   <tr>

--- a/packages/identity-service/src/notifications/emails/welcome.js
+++ b/packages/identity-service/src/notifications/emails/welcome.js
@@ -615,7 +615,7 @@ const getWelcomeEmail = ({ name, copyrightYear, featuredContent }) => {
   <td align="center">
   <table width="100%" border="0" cellpadding="0" cellspacing="0">
   <tr>
-  <td width="168" align="center"><img src=${featuredContent?.[0]?.artwork?.['150x150']} width="168" border="0" style="width: 100%;
+  <td width="168" align="center"><a href="${featuredContent?.[0]?.route_id}"><img src=${featuredContent?.[0]?.artwork?.['480x480']} width="168" border="0" style="width: 100%;
           border-radius:8px; height: auto; display: block;"></td>
   </tr>
   <tr>
@@ -664,8 +664,8 @@ const getWelcomeEmail = ({ name, copyrightYear, featuredContent }) => {
   <td align="center">
   <table width="100%" border="0" cellpadding="0" cellspacing="0">
   <tr>
-  <td width="168" align="center"><img src=${featuredContent?.[1]?.artwork?.['150x150']} width="168" border="0" style="width: 100%;
-          border-radius:8px; height: auto; display: block;"></td>
+  <td width="168" align="center"><a href="${featuredContent?.[1]?.route_id}"><img src=${featuredContent?.[1]?.artwork?.['480x480']} width="168" border="0" style="width: 100%;
+          border-radius:8px; height: auto; display: block;"></a></td>
   </tr>
   <tr>
   <td height="16" style="height:16px; min-height:16px; line-height:16px;"></td>
@@ -713,7 +713,7 @@ const getWelcomeEmail = ({ name, copyrightYear, featuredContent }) => {
   <td align="center">
   <table width="100%" border="0" cellpadding="0" cellspacing="0">
   <tr>
-  <td width="168" align="center"><img src=${featuredContent?.[2]?.artwork?.['150x150']} width="168" border="0" style="width: 100%;
+  <td width="168" align="center"><a href="${featuredContent?.[2]?.route_id}"><img src=${featuredContent?.[2]?.artwork?.['480x480']} width="168" border="0" style="width: 100%;
           border-radius:8px; height: auto; display: block;"></td>
   </tr>
   <tr>
@@ -1210,7 +1210,14 @@ const getWelcomeEmail = ({ name, copyrightYear, featuredContent }) => {
   </tr>
   <tr>
   <td style="vertical-align: middle;" align="center">
-  <div style="line-height:14px;text-align:center;"><span style="color:#a5a4ad;font-family:Inter,Arial,sans-serif;font-size:12px;line-height:14px;text-align:center;">No longer want to receive these emails? </span><span style="color:#7e1bcc;font-family:Inter,Arial,sans-serif;font-size:12px;line-height:14px;text-align:center;">Unsubscribe</span></div>
+  <div style="line-height:14px;text-align:center;"><span
+    style="color:#6a677a;font-family:Inter,Arial,sans-serif;font-size:12px;line-height:14px;text-align:center;">No
+    longer want to receive these emails? </span><a href="<%asm_group_unsubscribe_raw_url%>"><span
+    style="color:#7e1bcc;font-family:Inter,Arial,sans-serif;font-size:12px;line-height:14px;text-align:center;">Unsubscribe
+  </span></a><span
+    style="color:#6a677a;font-family:Inter,Arial,sans-serif;font-size:12px;line-height:14px;text-align:center;">or</span><a href="<%asm_preferences_raw_url%>"><span
+    style="color:#7e1bcc;font-family:Inter,Arial,sans-serif;font-size:12px;line-height:14px;text-align:center;"> Manage
+    Email Preferences</span></a></div>
   </td>
   </tr>
   </table>

--- a/packages/identity-service/src/notifications/sendDownloadAppEmails.js
+++ b/packages/identity-service/src/notifications/sendDownloadAppEmails.js
@@ -93,7 +93,7 @@ async function renderAndSendDownloadAppEmail(sg, userEmail) {
       to: userEmail,
       bcc: ['forrest@audius.co'],
       html: downloadAppHtml,
-      subject: 'Have You Tried Our App?',
+      subject: 'Have you tried the Audius app?',
       asm: {
         groupId: 19141 // id of unsubscribe group at https://mc.sendgrid.com/unsubscribe-groups
       }

--- a/packages/identity-service/src/routes/recovery.js
+++ b/packages/identity-service/src/routes/recovery.js
@@ -103,7 +103,7 @@ module.exports = function (app) {
         subject: 'Save This Email: Audius Password Recovery',
         html: recoveryHtml,
         asm: {
-          groupId: 19141 // id of unsubscribe group at https://mc.sendgrid.com/unsubscribe-groups
+          groupId: 26666 // same group as otp, exempt from unsubscribing
         }
       }
       try {

--- a/packages/identity-service/src/routes/welcomeEmail.js
+++ b/packages/identity-service/src/routes/welcomeEmail.js
@@ -78,7 +78,7 @@ module.exports = function (app) {
         from: 'The Audius Team <team@audius.co>',
         to: existingUser.email,
         bcc: ['forrest@audius.co'],
-        subject: 'Welcome to Audius!',
+        subject: 'Welcome to Audius! 👋',
         html: welcomeHtml,
         asm: {
           groupId: 19141 // id of unsubscribe group at https://mc.sendgrid.com/unsubscribe-groups

--- a/packages/identity-service/src/utils/otp.js
+++ b/packages/identity-service/src/utils/otp.js
@@ -91,7 +91,7 @@ const sendOtp = async ({ email, redis, sendgrid }) => {
     subject: 'Your Audius Verification Code',
     html,
     asm: {
-      groupId: 26666 // id of unsubscribe group at https://mc.sendgrid.com/unsubscribe-groups
+      groupId: 26666 // group exempt from unsubscribing
     }
   }
 


### PR DESCRIPTION
### Description
Includes many misc QA changes for emails.
* Add optimizely config for new reward in cooldown notification.
* Only OTP and recovery do not have un-subscription. Unsubscribe and email preferences are now linked to html template.
* Remove download icons on large images by adding a link to them.
* Add links to content for album/track art. 
* Use higher res track art for welcome page in responsive display.
* Email subject lines to match titles of emails.
* Add $ to dollar values and only show pay extra field when it's not 0.
* Update trophies for different rewards.

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._

Ran various emails on stage for sanity check but will do full QA pass as soon as it's on stage. 