### PR TITLE
Fix unlocked premium content label color

### DIFF
--- a/packages/web/src/components/track/GatedContentLabel.tsx
+++ b/packages/web/src/components/track/GatedContentLabel.tsx
@@ -54,7 +54,7 @@ export const GatedContentLabel = ({
   }
 
   const finalColor =
-    isOwner || !hasStreamAccess ? specialColor : color.icon.default
+    isOwner || !hasStreamAccess ? specialColor : color.icon.subdued
 
   return (
     <Flex alignItems='center' gap='xs' css={{ whiteSpace: 'nowrap' }}>


### PR DESCRIPTION
### Description
Small bug I noticed - wrong color when the gated content was unlocked.

### How Has This Been Tested?

<img width="473" alt="Screenshot 2024-07-09 at 12 56 37 PM" src="https://github.com/AudiusProject/audius-protocol/assets/3893871/75ab7923-35f3-4157-8b4f-c94e6bca12a0">
