### PR TITLE
[C-4589] Add links from track tile screen to search screen

### DIFF
--- a/packages/mobile/src/components/details-tile/TrackMetadataList.tsx
+++ b/packages/mobile/src/components/details-tile/TrackMetadataList.tsx
@@ -1,3 +1,6 @@
+import { useCallback } from 'react'
+
+import type { SearchFilters } from '@audius/common/api'
 import { TrackMetadataType, useTrackMetadata } from '@audius/common/hooks'
 import type { ID } from '@audius/common/models'
 import type { Mood } from '@audius/sdk'
@@ -5,6 +8,7 @@ import { trpc } from '@audius/web/src/utils/trpcClientWeb'
 import { Image } from 'react-native'
 
 import { Flex, Text, TextLink, spacing } from '@audius/harmony-native'
+import { useNavigation } from 'app/hooks/useNavigation'
 import { moodMap } from 'app/utils/moods'
 
 import { MetadataItem } from './MetadataItem'
@@ -13,23 +17,48 @@ const messages = {
   album: 'Album'
 }
 
-const renderMood = (mood: string) => {
+const renderMood = (mood: string, onPress: () => void) => {
   return (
-    <Flex direction='row' gap='xs' alignItems='center'>
-      <Text variant='body' size='s' strength='strong'>
-        {mood}
-      </Text>
-      <Image
-        source={moodMap[mood as Mood]}
-        style={{ height: spacing.l, width: spacing.l }}
-      />
-    </Flex>
+    <TextLink variant='visible' onPress={onPress}>
+      <Flex direction='row' gap='xs' alignItems='center'>
+        <Text variant='body' size='s' strength='strong'>
+          {mood}
+        </Text>
+        <Image
+          source={moodMap[mood as Mood]}
+          style={{ height: spacing.l, width: spacing.l }}
+        />
+      </Flex>
+    </TextLink>
   )
 }
-const renderMetadataValue = (id: TrackMetadataType, value: string) => {
+
+const renderFilterLink = (value: string, onPress: () => void) => {
+  return (
+    <TextLink onPress={onPress}>
+      <Text variant='body' size='s' strength='strong'>
+        {value}
+      </Text>
+    </TextLink>
+  )
+}
+
+const renderMetadataValue = (
+  id: TrackMetadataType,
+  value: string,
+  handleFilterLinkPress: (filters: SearchFilters) => void
+) => {
   switch (id) {
     case TrackMetadataType.MOOD:
-      return renderMood(value)
+      return renderMood(value, () => {
+        handleFilterLinkPress({ mood: value as Mood })
+      })
+    // TODO: BPM and Key might need to be transformed to fit the search page's expected format
+    case TrackMetadataType.GENRE:
+    case TrackMetadataType.BPM:
+      return renderFilterLink(value, () => {
+        handleFilterLinkPress({ [id]: value })
+      })
     default:
       return value
   }
@@ -43,6 +72,15 @@ type TrackMetadataListProps = {
  * The additional metadata shown at the bottom of the Track Screen and Collection Screen Headers
  */
 export const TrackMetadataList = ({ trackId }: TrackMetadataListProps) => {
+  const navigation = useNavigation()
+
+  const handleFilterLinkPress = useCallback(
+    (filters: SearchFilters) => {
+      navigation.navigate('Search', { category: 'tracks', filters })
+    },
+    [navigation]
+  )
+
   const { data: albumInfo } = trpc.tracks.getAlbumBacklink.useQuery({
     trackId
   })
@@ -55,7 +93,7 @@ export const TrackMetadataList = ({ trackId }: TrackMetadataListProps) => {
     <Flex gap='l' w='100%' direction='row' wrap='wrap'>
       {metadataItems.map(({ id, label, value }) => (
         <MetadataItem key={id} label={label}>
-          {renderMetadataValue(id, value)}
+          {renderMetadataValue(id, value, handleFilterLinkPress)}
         </MetadataItem>
       ))}
       {albumInfo ? (

--- a/packages/mobile/src/components/details-tile/TrackMetadataList.tsx
+++ b/packages/mobile/src/components/details-tile/TrackMetadataList.tsx
@@ -3,12 +3,13 @@ import { useCallback } from 'react'
 import type { SearchFilters } from '@audius/common/api'
 import { TrackMetadataType, useTrackMetadata } from '@audius/common/hooks'
 import type { ID } from '@audius/common/models'
-import { Flex, Text, TextLink, spacing } from '@audius/harmony-native'
 import type { Mood } from '@audius/sdk'
 import { trpc } from '@audius/web/src/utils/trpcClientWeb'
+import { Image } from 'react-native'
+
+import { Flex, Text, TextLink, spacing } from '@audius/harmony-native'
 import { useNavigation } from 'app/hooks/useNavigation'
 import { moodMap } from 'app/utils/moods'
-import { Image } from 'react-native'
 
 import { MetadataItem } from './MetadataItem'
 

--- a/packages/mobile/src/components/details-tile/TrackMetadataList.tsx
+++ b/packages/mobile/src/components/details-tile/TrackMetadataList.tsx
@@ -3,13 +3,12 @@ import { useCallback } from 'react'
 import type { SearchFilters } from '@audius/common/api'
 import { TrackMetadataType, useTrackMetadata } from '@audius/common/hooks'
 import type { ID } from '@audius/common/models'
+import { Flex, Text, TextLink, spacing } from '@audius/harmony-native'
 import type { Mood } from '@audius/sdk'
 import { trpc } from '@audius/web/src/utils/trpcClientWeb'
-import { Image } from 'react-native'
-
-import { Flex, Text, TextLink, spacing } from '@audius/harmony-native'
 import { useNavigation } from 'app/hooks/useNavigation'
 import { moodMap } from 'app/utils/moods'
+import { Image } from 'react-native'
 
 import { MetadataItem } from './MetadataItem'
 
@@ -56,6 +55,7 @@ const renderMetadataValue = (
     // TODO: BPM and Key might need to be transformed to fit the search page's expected format
     case TrackMetadataType.GENRE:
     case TrackMetadataType.BPM:
+    case TrackMetadataType.KEY:
       return renderFilterLink(value, () => {
         handleFilterLinkPress({ [id]: value })
       })

--- a/packages/mobile/src/screens/search-screen-v2/SearchCategoriesAndFilters.tsx
+++ b/packages/mobile/src/screens/search-screen-v2/SearchCategoriesAndFilters.tsx
@@ -23,6 +23,7 @@ type SearchCategoryProps = {
 const SearchCategory = (props: SearchCategoryProps) => {
   const { category } = props
   const [currentCategory, setCategory] = useSearchCategory()
+  const [, setFilters] = useSearchFilters()
   const isSelected = currentCategory === category
 
   const labelByCategory = {
@@ -40,9 +41,11 @@ const SearchCategory = (props: SearchCategoryProps) => {
       value={category}
       label={labelByCategory[category]}
       isSelected={isSelected}
-      onChange={(value, isSelected) =>
+      onChange={(value, isSelected) => {
+        // Clear Filters and change category
+        setFilters({})
         setCategory(isSelected ? (value as SearchCategoryType) : 'all')
-      }
+      }}
       icon={isSelected ? IconCloseAlt : undefined}
     />
   )

--- a/packages/mobile/src/screens/search-screen-v2/SearchScreenV2.tsx
+++ b/packages/mobile/src/screens/search-screen-v2/SearchScreenV2.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 
 import type {
   SearchCategory,
@@ -67,6 +67,12 @@ export const SearchScreenStack = () => {
   const [filters, setFilters] = useState<SearchFiltersType>(
     params.filters ?? {}
   )
+
+  useEffect(() => {
+    setQuery(params.query ?? '')
+    setCategory(params.category ?? 'all')
+    setFilters(params.filters ?? {})
+  }, [params])
 
   const screenOptions = useAppScreenOptions()
 

--- a/packages/web/src/pages/search-page-v2/SearchPageV2.tsx
+++ b/packages/web/src/pages/search-page-v2/SearchPageV2.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useContext, useEffect } from 'react'
 
+import { SearchCategory } from '@audius/common/src/api/search'
 import { Flex } from '@audius/harmony'
 import { generatePath, useParams } from 'react-router-dom'
 import { useSearchParams } from 'react-router-dom-v5-compat'
@@ -90,7 +91,10 @@ export const SearchPageV2 = () => {
     <PageComponent
       title={query ?? 'Search'}
       description={`Search results for ${query}`}
-      canonicalUrl={fullSearchResultsPageV2(category, query ?? '')}
+      canonicalUrl={fullSearchResultsPageV2(
+        category as SearchCategory,
+        query ?? ''
+      )}
       header={header}
     >
       <Flex direction='column' w='100%'>

--- a/packages/web/src/utils/route.ts
+++ b/packages/web/src/utils/route.ts
@@ -1,4 +1,5 @@
 import type { ID } from '@audius/common/models'
+import { SearchCategory } from '@audius/common/src/api/search'
 import { Genre, Mood } from '@audius/sdk'
 import { push as pushRoute } from 'connected-react-router'
 import { Location } from 'history'
@@ -471,11 +472,17 @@ export const fullSearchResultsPage = (query: string) => {
   return `${BASE_URL}${searchResultsPage(query)}`
 }
 
-export const searchResultsPageV2 = (category: string, query: string) => {
+export const searchResultsPageV2 = (
+  category: SearchCategory,
+  query: string
+) => {
   return `/search/${category}/?query=${query}`
 }
 
-export const fullSearchResultsPageV2 = (category: string, query: string) => {
+export const fullSearchResultsPageV2 = (
+  category: SearchCategory,
+  query: string
+) => {
   return `${BASE_URL}${searchResultsPageV2(category, query)}`
 }
 

--- a/packages/web/src/utils/route.ts
+++ b/packages/web/src/utils/route.ts
@@ -1,5 +1,5 @@
+import { SearchCategory } from '@audius/common/api'
 import type { ID } from '@audius/common/models'
-import { SearchCategory } from '@audius/common/src/api/search'
 import { Genre, Mood } from '@audius/sdk'
 import { push as pushRoute } from 'connected-react-router'
 import { Location } from 'history'


### PR DESCRIPTION
### Description
Update Track details tile metadata items to link to the search page with the proper category and filters set
Update category buttons to clear search filters
Update search screen to update context state on params change

### How Has This Been Tested?
Manually tested
