### PR TITLE
Allow unlisting tracks and playlists in DN indexing

### DIFF
--- a/packages/discovery-provider/integration_tests/tasks/entity_manager/test_playlist_entity_manager.py
+++ b/packages/discovery-provider/integration_tests/tasks/entity_manager/test_playlist_entity_manager.py
@@ -1000,7 +1000,7 @@ def test_index_invalid_playlists(app, mocker):
             .first()
         )
         assert current_playlist.is_current == True
-        assert current_playlist.is_private == False
+        assert current_playlist.is_private == True
         assert current_playlist.is_album == False
 
         current_album: Playlist = (

--- a/packages/discovery-provider/src/tasks/entity_manager/entities/playlist.py
+++ b/packages/discovery-provider/src/tasks/entity_manager/entities/playlist.py
@@ -365,12 +365,6 @@ def validate_playlist_tx(params: ManageEntityParameters):
                     f"Playlist {playlist_id} exceeds track limit {PLAYLIST_TRACK_LIMIT}"
                 )
 
-        if (
-            params.action == Action.UPDATE
-            and not existing_playlist.is_private
-            and params.metadata.get("is_private")
-        ):
-            raise IndexingValidationError(f"Cannot unlist playlist {playlist_id}")
         validate_access_conditions(params)
 
 

--- a/packages/discovery-provider/src/tasks/entity_manager/entities/track.py
+++ b/packages/discovery-provider/src/tasks/entity_manager/entities/track.py
@@ -461,13 +461,6 @@ def validate_track_tx(params: ManageEntityParameters):
                 f"Existing track {track_id} does not match user"
             )
 
-        if (
-            params.action == Action.UPDATE
-            and not existing_track.is_unlisted
-            and params.metadata.get("is_unlisted")
-        ):
-            raise IndexingValidationError(f"Cannot unlist track {track_id}")
-
     if params.action != Action.DELETE:
         ai_attribution_user_id = params.metadata.get("ai_attribution_user_id")
         if ai_attribution_user_id:


### PR DESCRIPTION
### Description

Allows tracks and playlists to be unlisted in DN indexing.
Missed this when I was relaxing indexing constraints.

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._
