### PR TITLE
[PAY-3132] Manager Mode Modal Movement Mending

### DIFF
--- a/packages/harmony/src/components/modal/ModalContentPages.tsx
+++ b/packages/harmony/src/components/modal/ModalContentPages.tsx
@@ -1,4 +1,4 @@
-import { Children, ReactChild, useState } from 'react'
+import { Children, ReactNode, useState } from 'react'
 
 import { ResizeObserver } from '@juggle/resize-observer'
 import cn from 'classnames'
@@ -33,19 +33,24 @@ const getSwipeTransitions = (direction: 'back' | 'forward') =>
         leave: { opacity: 0, transform: 'translate3d(100%, 0, 0)' }
       }
 
+export type ModalContentPagesProps = {
+  currentPage: number
+  width?: number
+  contentClassName?: string
+  verticalPadding?: number
+  children: ReactNode | ReactNode[]
+  /** Allows override of transition direction for next page change */
+  transitionDirection?: 'back' | 'forward'
+} & ModalContentProps
+
 export const ModalContentPages = ({
   currentPage,
   width,
   contentClassName,
   children,
+  transitionDirection,
   ...modalContentProps
-}: {
-  currentPage: number
-  width?: number
-  contentClassName?: string
-  verticalPadding?: number
-  children: ReactChild | ReactChild[]
-} & ModalContentProps) => {
+}: ModalContentPagesProps) => {
   const [lastPage, setLastPage] = useState(0)
   const [transitions, setTransitions] = useState<
     ReturnType<typeof getSwipeTransitions>
@@ -65,7 +70,9 @@ export const ModalContentPages = ({
 
   if (lastPage !== currentPage) {
     setTransitions(
-      getSwipeTransitions(currentPage > lastPage ? 'forward' : 'back')
+      getSwipeTransitions(
+        transitionDirection ?? (currentPage > lastPage ? 'forward' : 'back')
+      )
     )
     setLastPage(currentPage)
   }

--- a/packages/web/src/pages/settings-page/components/desktop/ManagerMode/AccountListItem/ManagerListItem.tsx
+++ b/packages/web/src/pages/settings-page/components/desktop/ManagerMode/AccountListItem/ManagerListItem.tsx
@@ -155,19 +155,18 @@ export const ManagerListItem = ({
     >
       <ArtistInfo user={manager} />
       <Flex direction='column' justifyContent='space-between' alignItems='end'>
+        <PopupMenu
+          renderTrigger={renderTrigger}
+          items={popupMenuItems}
+          zIndex={zIndex.MODAL_OVERFLOW_MENU_POPUP}
+          anchorOrigin={{ horizontal: 'right', vertical: 'bottom' }}
+          transformOrigin={{ horizontal: 'right', vertical: 'top' }}
+        />
         {isPending ? (
           <Text variant='label' size='s' color='subdued'>
             {messages.invitePending}
           </Text>
-        ) : (
-          <PopupMenu
-            renderTrigger={renderTrigger}
-            items={popupMenuItems}
-            zIndex={zIndex.MODAL_OVERFLOW_MENU_POPUP}
-            anchorOrigin={{ horizontal: 'right', vertical: 'bottom' }}
-            transformOrigin={{ horizontal: 'right', vertical: 'top' }}
-          />
-        )}
+        ) : null}
       </Flex>
     </Flex>
   )

--- a/packages/web/src/pages/settings-page/components/desktop/ManagerMode/AccountsManagingYouHomePage.tsx
+++ b/packages/web/src/pages/settings-page/components/desktop/ManagerMode/AccountsManagingYouHomePage.tsx
@@ -25,7 +25,7 @@ type AccountsManagingYouHomePageProps = AccountsManagingYouPageProps
 export const AccountsManagingYouHomePage = (
   props: AccountsManagingYouHomePageProps
 ) => {
-  const { setPage } = props
+  const { setPageState } = props
   const userId = useSelector(getUserId) as number
 
   // Always update manager list when mounting this page
@@ -39,9 +39,12 @@ export const AccountsManagingYouHomePage = (
 
   const handleRemoveManager = useCallback(
     (params: { userId: number; managerUserId: number }) => {
-      setPage(AccountsManagingYouPages.CONFIRM_REMOVE_MANAGER, params)
+      setPageState({
+        page: AccountsManagingYouPages.CONFIRM_REMOVE_MANAGER,
+        params
+      })
     },
-    [setPage]
+    [setPageState]
   )
 
   return (
@@ -57,7 +60,11 @@ export const AccountsManagingYouHomePage = (
         <Button
           variant='secondary'
           iconLeft={IconPlus}
-          onClick={() => setPage(AccountsManagingYouPages.FIND_ACCOUNT_MANAGER)}
+          onClick={() =>
+            setPageState({
+              page: AccountsManagingYouPages.FIND_ACCOUNT_MANAGER
+            })
+          }
         >
           {messages.inviteButton}
         </Button>

--- a/packages/web/src/pages/settings-page/components/desktop/ManagerMode/AccountsManagingYouSettingsModal.tsx
+++ b/packages/web/src/pages/settings-page/components/desktop/ManagerMode/AccountsManagingYouSettingsModal.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from 'react'
+import { useEffect, useState } from 'react'
 
 import {
   IconShieldUser,
@@ -14,10 +14,7 @@ import styles from './AccountsManagingYouSettingsModal.module.css'
 import { ConfirmAccountManagerPage } from './ConfirmAccountManagerPage'
 import { FindAccountManagerPage } from './FindAccountManagerPage'
 import { RemoveManagerConfirmationPage } from './RemoveManagerConfirmationPage'
-import {
-  AccountsManagingYouPages,
-  AccountsManagingYouPagesParams
-} from './types'
+import { AccountsManagingYouPageState, AccountsManagingYouPages } from './types'
 
 const messages = {
   accountsManagingYou: 'Accounts Managing You',
@@ -52,29 +49,14 @@ export const AccountsManagingYouSettingsModal = (
   props: AccountsManagingYouSettingsModalProps
 ) => {
   const { isOpen } = props
-  const [currentPage, setCurrentPage] = useState(AccountsManagingYouPages.HOME)
-
-  const [currentPageParams, setCurrentPageParams] = useState<
-    AccountsManagingYouPagesParams | undefined
-  >()
-
-  const handleSetPage = useCallback(
-    (
-      page: AccountsManagingYouPages,
-      params?: AccountsManagingYouPagesParams
-    ) => {
-      setCurrentPage(page)
-      if (params) {
-        setCurrentPageParams(params)
-      }
-    },
-    []
-  )
+  const [{ page, params, transitionDirection }, setPageState] =
+    useState<AccountsManagingYouPageState>({
+      page: AccountsManagingYouPages.HOME
+    })
 
   useEffect(() => {
     if (!isOpen) {
-      setCurrentPage(AccountsManagingYouPages.HOME)
-      setCurrentPageParams(undefined)
+      setPageState({ page: AccountsManagingYouPages.HOME })
     }
   }, [isOpen])
 
@@ -83,9 +65,9 @@ export const AccountsManagingYouSettingsModal = (
       <Modal {...props} size='small'>
         <ModalHeader>
           <ModalTitle
-            title={PAGE_TO_TITLE[currentPage]}
+            title={PAGE_TO_TITLE[page]}
             icon={
-              currentPage ===
+              page ===
               AccountsManagingYouPages.CONFIRM_REMOVE_MANAGER ? null : (
                 <IconShieldUser />
               )
@@ -94,20 +76,18 @@ export const AccountsManagingYouSettingsModal = (
         </ModalHeader>
         <ModalContentPages
           className={styles.noPaddingH}
-          currentPage={getCurrentPage(currentPage)}
+          currentPage={getCurrentPage(page)}
+          transitionDirection={transitionDirection}
         >
-          <AccountsManagingYouHomePage setPage={handleSetPage} />
-          <FindAccountManagerPage
-            setPage={handleSetPage}
-            params={currentPageParams}
-          />
+          <AccountsManagingYouHomePage setPageState={setPageState} />
+          <FindAccountManagerPage setPageState={setPageState} params={params} />
           <ConfirmAccountManagerPage
-            setPage={handleSetPage}
-            params={currentPageParams}
+            setPageState={setPageState}
+            params={params}
           />
           <RemoveManagerConfirmationPage
-            setPage={handleSetPage}
-            params={currentPageParams}
+            setPageState={setPageState}
+            params={params}
           />
         </ModalContentPages>
       </Modal>

--- a/packages/web/src/pages/settings-page/components/desktop/ManagerMode/AccountsYouManageHomePage.tsx
+++ b/packages/web/src/pages/settings-page/components/desktop/ManagerMode/AccountsYouManageHomePage.tsx
@@ -22,7 +22,7 @@ const messages = {
 }
 
 export const AccountsYouManageHomePage = ({
-  setPage
+  setPageState
 }: AccountsYouManagePageProps) => {
   const currentUser = useSelector(getAccountUser)
   const userId = currentUser?.user_id
@@ -40,9 +40,12 @@ export const AccountsYouManageHomePage = ({
 
   const handleStopManaging = useCallback(
     ({ userId }: { userId: number; managerUserId: number }) => {
-      setPage(AccountsYouManagePages.STOP_MANAGING, { user_id: userId })
+      setPageState({
+        page: AccountsYouManagePages.STOP_MANAGING,
+        params: { user_id: userId }
+      })
     },
-    [setPage]
+    [setPageState]
   )
 
   return (

--- a/packages/web/src/pages/settings-page/components/desktop/ManagerMode/AccountsYouManageSettingsModal.tsx
+++ b/packages/web/src/pages/settings-page/components/desktop/ManagerMode/AccountsYouManageSettingsModal.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from 'react'
+import { useEffect, useState } from 'react'
 
 import {
   IconUserArrowRotate,
@@ -11,7 +11,7 @@ import {
 
 import { AccountsYouManageHomePage } from './AccountsYouManageHomePage'
 import { StopManagingConfirmationPage } from './StopManagingConfirmationPage'
-import { AccountsYouManagePages, AccountsYouManagePagesParams } from './types'
+import { AccountsYouManagePageState, AccountsYouManagePages } from './types'
 
 const messages = {
   accountsYouManage: 'Accounts You Manage',
@@ -38,25 +38,14 @@ export const AccountsYouManageSettingsModal = (
   props: AccountsYouManageSettingsModalProps
 ) => {
   const { isOpen } = props
-  const [currentPage, setCurrentPage] = useState(AccountsYouManagePages.HOME)
-
-  const [currentPageParams, setCurrentPageParams] =
-    useState<AccountsYouManagePagesParams>()
-
-  const handleSetPage = useCallback(
-    (page: AccountsYouManagePages, params?: AccountsYouManagePagesParams) => {
-      setCurrentPage(page)
-      if (params) {
-        setCurrentPageParams(params)
-      }
-    },
-    []
-  )
+  const [{ page, params, transitionDirection }, setPageState] =
+    useState<AccountsYouManagePageState>({
+      page: AccountsYouManagePages.HOME
+    })
 
   useEffect(() => {
     if (!isOpen) {
-      setCurrentPage(AccountsYouManagePages.HOME)
-      setCurrentPageParams(undefined)
+      setPageState({ page: AccountsYouManagePages.HOME })
     }
   }, [isOpen])
 
@@ -65,16 +54,19 @@ export const AccountsYouManageSettingsModal = (
       <Modal {...props} size='small'>
         <ModalHeader>
           <ModalTitle
-            title={PAGE_TO_TITLE[currentPage]}
+            title={PAGE_TO_TITLE[page]}
             icon={<IconUserArrowRotate />}
           />
         </ModalHeader>
-        <ModalContentPages currentPage={getCurrentPage(currentPage)}>
-          <AccountsYouManageHomePage setPage={handleSetPage} />
+        <ModalContentPages
+          transitionDirection={transitionDirection}
+          currentPage={getCurrentPage(page)}
+        >
+          <AccountsYouManageHomePage setPageState={setPageState} />
 
           <StopManagingConfirmationPage
-            setPage={handleSetPage}
-            params={currentPageParams}
+            setPageState={setPageState}
+            params={params}
           />
         </ModalContentPages>
       </Modal>

--- a/packages/web/src/pages/settings-page/components/desktop/ManagerMode/ConfirmAccountManagerPage.tsx
+++ b/packages/web/src/pages/settings-page/components/desktop/ManagerMode/ConfirmAccountManagerPage.tsx
@@ -36,7 +36,7 @@ const messages = {
 export const ConfirmAccountManagerPage = (
   props: ConfirmAccountManagerPageProps
 ) => {
-  const { setPage, params } = props
+  const { setPageState, params } = props
   const userId = useSelector(getUserId)
   const [submitting, setIsSubmitting] = useState(false)
   const [error, setError] = useState<string | null>(null)
@@ -46,9 +46,12 @@ export const ConfirmAccountManagerPage = (
   const manager = params?.user
   useEffect(() => {
     if (status === Status.SUCCESS) {
-      setPage(AccountsManagingYouPages.HOME)
+      setPageState({
+        page: AccountsManagingYouPages.HOME,
+        transitionDirection: 'forward'
+      })
     }
-  }, [setPage, status])
+  }, [setPageState, status])
 
   useEffect(() => {
     if (status === Status.ERROR) {
@@ -91,8 +94,11 @@ export const ConfirmAccountManagerPage = (
             iconLeft={IconCaretLeft}
             disabled={submitting}
             onClick={() =>
-              setPage(AccountsManagingYouPages.FIND_ACCOUNT_MANAGER, {
-                query: params?.query
+              setPageState({
+                page: AccountsManagingYouPages.FIND_ACCOUNT_MANAGER,
+                params: {
+                  query: params?.query
+                }
               })
             }
           >

--- a/packages/web/src/pages/settings-page/components/desktop/ManagerMode/FindAccountManagerPage.tsx
+++ b/packages/web/src/pages/settings-page/components/desktop/ManagerMode/FindAccountManagerPage.tsx
@@ -22,7 +22,7 @@ const messages = {
 }
 
 export const FindAccountManagerPage = (props: FindAccountManagerPageProps) => {
-  const { setPage, params } = props
+  const { setPageState, params } = props
   const [query, setQuery] = useState(params?.query ?? '')
   const userId = useSelector(getUserId)
   const { data: managers } = useGetManagers(
@@ -70,16 +70,19 @@ export const FindAccountManagerPage = (props: FindAccountManagerPageProps) => {
             user={user as any}
             showPopover={false}
             onClickArtistName={() => {
-              setPage(AccountsManagingYouPages.CONFIRM_NEW_MANAGER, {
-                user,
-                query
+              setPageState({
+                page: AccountsManagingYouPages.CONFIRM_NEW_MANAGER,
+                params: {
+                  user,
+                  query
+                }
               })
             }}
           />
         </Box>
       )
     },
-    [query, setPage]
+    [query, setPageState]
   )
 
   return (

--- a/packages/web/src/pages/settings-page/components/desktop/ManagerMode/RemoveManagerConfirmationPage.tsx
+++ b/packages/web/src/pages/settings-page/components/desktop/ManagerMode/RemoveManagerConfirmationPage.tsx
@@ -23,13 +23,23 @@ const messages = {
 export const RemoveManagerConfirmationPage = (
   props: RemoveManagerConfirmationPageProps
 ) => {
-  const { params, setPage } = props
+  const { params, setPageState } = props
   const userId = useSelector(getUserId)
   const managerUserId = params?.managerUserId
 
-  const navigateToHome = useCallback(() => {
-    setPage(AccountsManagingYouPages.HOME)
-  }, [setPage])
+  const handleSuccess = useCallback(() => {
+    setPageState({
+      page: AccountsManagingYouPages.HOME,
+      transitionDirection: 'forward'
+    })
+  }, [setPageState])
+
+  const handleCancel = useCallback(() => {
+    setPageState({
+      page: AccountsManagingYouPages.HOME,
+      transitionDirection: 'back'
+    })
+  }, [setPageState])
 
   if (!managerUserId || !userId) return null
 
@@ -37,8 +47,8 @@ export const RemoveManagerConfirmationPage = (
     <Box ph='xl'>
       <RemoveManagerConfirmationContent
         confirmationMessage={messages.removeManagerConfirmation}
-        onCancel={navigateToHome}
-        onSuccess={navigateToHome}
+        onCancel={handleCancel}
+        onSuccess={handleSuccess}
         userId={userId}
         managerUserId={managerUserId}
       />

--- a/packages/web/src/pages/settings-page/components/desktop/ManagerMode/StopManagingConfirmationPage.tsx
+++ b/packages/web/src/pages/settings-page/components/desktop/ManagerMode/StopManagingConfirmationPage.tsx
@@ -19,20 +19,30 @@ const messages = {
 export const StopManagingConfirmationPage = (
   props: StopManagingConfirmationPageProps
 ) => {
-  const { params, setPage } = props
+  const { params, setPageState } = props
   const managerUserId = useSelector(getUserId)
   const userId = params?.user_id
 
-  const navigateToHome = useCallback(() => {
-    setPage(AccountsYouManagePages.HOME)
-  }, [setPage])
+  const handleCancel = useCallback(() => {
+    setPageState({
+      page: AccountsYouManagePages.HOME,
+      transitionDirection: 'back'
+    })
+  }, [setPageState])
+
+  const handleSuccess = useCallback(() => {
+    setPageState({
+      page: AccountsYouManagePages.HOME,
+      transitionDirection: 'forward'
+    })
+  }, [setPageState])
 
   if (!managerUserId || !userId) return null
 
   return (
     <RemoveManagerConfirmationContent
-      onCancel={navigateToHome}
-      onSuccess={navigateToHome}
+      onCancel={handleCancel}
+      onSuccess={handleSuccess}
       userId={userId}
       managerUserId={managerUserId}
       confirmationMessage={messages.stopManagingConfirmation}

--- a/packages/web/src/pages/settings-page/components/desktop/ManagerMode/types.ts
+++ b/packages/web/src/pages/settings-page/components/desktop/ManagerMode/types.ts
@@ -13,11 +13,14 @@ export type AccountsManagingYouPagesParams = {
   managerUserId?: number
 }
 
+export type AccountsManagingYouPageState = {
+  page: AccountsManagingYouPages
+  params?: AccountsManagingYouPagesParams
+  transitionDirection?: 'back' | 'forward'
+}
+
 export type AccountsManagingYouPageProps = {
-  setPage: (
-    page: AccountsManagingYouPages,
-    params?: AccountsManagingYouPagesParams
-  ) => void
+  setPageState: (newState: AccountsManagingYouPageState) => void
 }
 
 type AccountsManagingYouPagePropsWithParams = AccountsManagingYouPageProps & {
@@ -41,10 +44,13 @@ export type AccountsYouManagePagesParams = {
   user_id?: number
 }
 
+export type AccountsYouManagePageState = {
+  page: AccountsYouManagePages
+  params?: AccountsYouManagePagesParams
+  transitionDirection?: 'back' | 'forward'
+}
+
 export type AccountsYouManagePageProps = {
-  setPage: (
-    page: AccountsYouManagePages,
-    params?: AccountsYouManagePagesParams
-  ) => void
+  setPageState: (newState: AccountsYouManagePageState) => void
   params?: AccountsYouManagePagesParams
 }


### PR DESCRIPTION
### Description
In case the overly cute but vague title didn't make it obvious... 
This updates the `ModalContentPages` component to allow manual overriding of the transition direction for special cases and then updates the modals used for Manager Mode to use a 'forward' direction when transitioning from confirmation states on the final page back to the home page.

Bonus fix: In a previous PR, I had messed up the logic for when to show the overflow menu such that you could not longer cancel a pending invite.

### How Has This Been Tested?
Tested locally against staging


### Screen recording

https://github.com/AudiusProject/audius-protocol/assets/1815175/e27500b5-c9fc-47b5-a9b6-2781cfd2f321

