### PR TITLE
Make view content button large on mobile purchase success

### DIFF
--- a/packages/mobile/src/components/premium-content-purchase-drawer/PremiumContentPurchaseDrawer.tsx
+++ b/packages/mobile/src/components/premium-content-purchase-drawer/PremiumContentPurchaseDrawer.tsx
@@ -257,6 +257,9 @@ const RenderForm = ({
   const dispatch = useDispatch()
   const { primary } = useThemeColors()
   const presetValues = usePayExtraPresets()
+  const { isEnabled: isCoinflowEnabled } = useFeatureFlag(
+    FeatureFlags.BUY_WITH_COINFLOW
+  )
   const { isEnabled: isIOSUSDCPurchaseEnabled } = useFeatureFlag(
     FeatureFlags.IOS_USDC_PURCHASE_ENABLED
   )
@@ -284,9 +287,6 @@ const RenderForm = ({
     price,
     currentBalance: balance
   })
-  const { isEnabled: isCoinflowEnabled } = useFeatureFlag(
-    FeatureFlags.BUY_WITH_COINFLOW
-  )
   const coinflowMaximumCents = useRemoteVar(IntKeys.COINFLOW_MAXIMUM_CENTS)
 
   const { isExistingBalanceDisabled, totalPriceInCents } = usePurchaseMethod({

--- a/packages/mobile/src/components/premium-content-purchase-drawer/PurchaseSuccess.tsx
+++ b/packages/mobile/src/components/premium-content-purchase-drawer/PurchaseSuccess.tsx
@@ -124,6 +124,7 @@ export const PurchaseSuccess = ({
         variant='subdued'
         onPress={onPressViewTrack}
         iconRight={IconCaretRight}
+        size='large'
       >
         {messages.view(contentType)}
       </PlainButton>


### PR DESCRIPTION
### Description
Make this button bigger!

+ just moving some code around for cleanliness

### How Has This Been Tested?


![Simulator Screenshot - iPhone 15 Pro - 2024-07-09 at 17 10 06](https://github.com/AudiusProject/audius-protocol/assets/3893871/897ff0d2-59b7-48b2-8268-2ce83aad47dd)
