### PR TITLE
PROTO-1847: identity discprov plays

### DIFF
--- a/packages/discovery-provider/plugins/pedalboard/apps/solana-relay/src/config.ts
+++ b/packages/discovery-provider/plugins/pedalboard/apps/solana-relay/src/config.ts
@@ -47,6 +47,7 @@ type Config = {
   ipdataApiKey: string | null
   listensValidSigner: string
   solanaSignerPrivateKey: string
+  identityRelayerPublicKey: string
   listensIpHourlyRateLimit: number
   listensIpDailyRateLimit: number
   listensIpWeeklyRateLimit: number
@@ -127,6 +128,9 @@ const readConfig = (): Config => {
       default:
         'd242765e718801781440d77572b9dafcdc9baadf0269eff24cf61510ddbf1003'
     }),
+    audius_identity_relayer_public_key: str({
+      default: "0xaaaa90Fc2bfa70028D6b444BB9754066d9E2703b"
+    }),
     audius_solana_listens_ip_hourly_rate_limit: num({ default: 120 }),
     audius_solana_listens_ip_daily_rate_limit: num({ default: 50000 }),
     audius_solana_listens_ip_weekly_rate_limit: num({ default: 50000000 }),
@@ -166,6 +170,7 @@ const readConfig = (): Config => {
     listensValidSigner: env.audius_solana_listens_valid_signer,
     ethRegistryProgramId: env.audius_solana_eth_registry_program,
     solanaSignerPrivateKey: env.audius_solana_signer_private_key,
+    identityRelayerPublicKey: env.audius_identity_relayer_public_key,
     listensIpHourlyRateLimit: env.audius_solana_listens_ip_hourly_rate_limit,
     listensIpDailyRateLimit: env.audius_solana_listens_ip_daily_rate_limit,
     listensIpWeeklyRateLimit: env.audius_solana_listens_ip_weekly_rate_limit,

--- a/packages/discovery-provider/plugins/pedalboard/apps/solana-relay/src/index.ts
+++ b/packages/discovery-provider/plugins/pedalboard/apps/solana-relay/src/index.ts
@@ -27,12 +27,7 @@ const main = async () => {
   app.use(cors())
   app.use(incomingRequestLogger)
   app.get('/solana/health_check', health)
-  app.post(
-    '/solana/tracks/:trackId/listen',
-    incomingRequestLogger,
-    listen,
-    outgoingRequestLogger
-  )
+  app.post('/solana/tracks/:trackId/listen', listen)
   app.use(userSignerRecoveryMiddleware)
   app.use(discoveryNodeSignerRecoveryMiddleware)
   app.post('/solana/relay', relay)

--- a/packages/discovery-provider/plugins/pedalboard/apps/solana-relay/src/routes/health/health.ts
+++ b/packages/discovery-provider/plugins/pedalboard/apps/solana-relay/src/routes/health/health.ts
@@ -1,7 +1,8 @@
-import { Request, Response } from 'express'
+import { NextFunction, Request, Response } from 'express'
 
-export const health = async (_req: Request, res: Response) => {
+export const health = async (_req: Request, res: Response, next: NextFunction) => {
   res.status(200).json({
     isHealthy: true
   })
+  next()
 }

--- a/packages/discovery-provider/plugins/pedalboard/apps/solana-relay/src/routes/listen/listen.ts
+++ b/packages/discovery-provider/plugins/pedalboard/apps/solana-relay/src/routes/listen/listen.ts
@@ -148,6 +148,13 @@ export const validateListenSignature = async (
   const hashedData = keccak256(data)
   const recoveredWallet = recover(hashedData, signature)
   const contentNodes = await getCachedContentNodes()
+
+  // if from identity service
+  if (recoveredWallet === config.identityRelayerPublicKey) {
+    return true
+  }
+
+  // if from registered content node
   for (const { delegateOwnerWallet } of contentNodes) {
     if (recoveredWallet === delegateOwnerWallet) return true
   }

--- a/packages/discovery-provider/plugins/pedalboard/apps/solana-relay/src/routes/listen/listen.ts
+++ b/packages/discovery-provider/plugins/pedalboard/apps/solana-relay/src/routes/listen/listen.ts
@@ -149,8 +149,6 @@ export const validateListenSignature = async (
   const recoveredWallet = recover(hashedData, signature)
   const contentNodes = await getCachedContentNodes()
 
-  console.log({ recoveredWallet, timestamp, signature, identity: config.identityRelayerPublicKey, contentNodes })
-
   // if from identity service
   if (recoveredWallet === config.identityRelayerPublicKey) {
     return true
@@ -206,8 +204,6 @@ export const listen = async (req: Request, res: Response, next: NextFunction) =>
       return
     }
 
-    console.log("passed validation")
-
     // check rate limit on forwarded IP and track
     const allowed = await listenRouteRateLimiter({ ip, trackId, logger })
     if (!allowed) {
@@ -223,7 +219,7 @@ export const listen = async (req: Request, res: Response, next: NextFunction) =>
     if (e instanceof z.ZodError) {
       logger?.error({ error: String(e) }, "validation error")
       return res
-        .status(404)
+        .status(400)
         .json({ message: 'Validation Error', errors: e.errors })
     }
     if (e instanceof Error) {

--- a/packages/identity-service/package.json
+++ b/packages/identity-service/package.json
@@ -97,7 +97,8 @@
     "uuid": "3.3.2",
     "web-push": "3.4.3",
     "web3": "1.2.7",
-    "web3-eth-accounts": "1.2.7"
+    "web3-eth-accounts": "1.2.7",
+    "web3-utils": "^4.2.3"
   },
   "devDependencies": {
     "@babel/cli": "7.7.0",

--- a/packages/identity-service/package.json
+++ b/packages/identity-service/package.json
@@ -97,8 +97,7 @@
     "uuid": "3.3.2",
     "web-push": "3.4.3",
     "web3": "1.2.7",
-    "web3-eth-accounts": "1.2.7",
-    "web3-utils": "^4.2.3"
+    "web3-eth-accounts": "1.2.7"
   },
   "devDependencies": {
     "@babel/cli": "7.7.0",

--- a/packages/identity-service/src/config.js
+++ b/packages/identity-service/src/config.js
@@ -909,7 +909,7 @@ const config = convict({
     doc: 'Forward listen requests to discovery',
     format: Boolean,
     env: 'useDiscoveryListens',
-    default: false
+    default: true
   }
 })
 

--- a/packages/identity-service/src/config.js
+++ b/packages/identity-service/src/config.js
@@ -904,6 +904,12 @@ const config = convict({
     format: String,
     env: 'fpServerApiKey',
     default: ''
+  },
+  useDiscoveryListens: {
+    doc: 'Forward listen requests to discovery',
+    format: Boolean,
+    env: 'useDiscoveryListens',
+    default: false
   }
 })
 

--- a/packages/identity-service/src/routes/trackListens.js
+++ b/packages/identity-service/src/routes/trackListens.js
@@ -72,7 +72,7 @@ const parseTimeframe = (inputTime) => {
   return inputTime
 }
 
-export const sortKeys = (x) => {
+const sortKeys = (x) => {
   if (typeof x !== 'object' || !x) {
     return x
   }

--- a/packages/identity-service/src/routes/trackListens.js
+++ b/packages/identity-service/src/routes/trackListens.js
@@ -87,20 +87,22 @@ export const sortKeys = (x) => {
 const getDiscoveryListensEndpoint = () => {
   const env = config.get('environment')
   switch (env) {
-    case "staging":
-      return "https://discoveryprovider.staging.audius.co"
-    case "production":
-      return "https://discoveryprovider.audius.co"
-    case "development":
+    case 'staging':
+      return 'https://discoveryprovider.staging.audius.co'
+    case 'production':
+      return 'https://discoveryprovider.audius.co'
+    case 'development':
     default:
-      return "http://audius-protocol-discovery-provider-1"
+      return 'http://audius-protocol-discovery-provider-1'
   }
 }
 
 const sign = (data) => {
   const privateKey = config.get('relayerPrivateKey')
   const msgHash = keccak256(data)
-  const signature = ethSigUtil.personalSign(Buffer.from(privateKey, 'hex'), { data: msgHash })
+  const signature = ethSigUtil.personalSign(Buffer.from(privateKey, 'hex'), {
+    data: msgHash
+  })
   return signature
 }
 
@@ -472,10 +474,14 @@ module.exports = function (app) {
           const endpoint = `${getDiscoveryListensEndpoint()}/solana/tracks/${trackId}/listen`
           const res = await axios.post(endpoint, body, { headers })
           if (res === null) {
-            throw new Error("failed to forward listen to discovery, sending to solana")
+            throw new Error(
+              'failed to forward listen to discovery, sending to solana'
+            )
           }
 
-          req.logger.info(`TrackListen discovery res=${JSON.stringify(res.data)}`)
+          req.logger.info(
+            `TrackListen discovery res=${JSON.stringify(res.data)}`
+          )
 
           const { solTxSignature } = res.data
 
@@ -483,7 +489,9 @@ module.exports = function (app) {
             solTxSignature
           })
         } catch (e) {
-          req.logger.error(`TrackListen discovery error, trackId=${trackId} userId=${userId} : ${e}`)
+          req.logger.error(
+            `TrackListen discovery error, trackId=${trackId} userId=${userId} : ${e}`
+          )
         }
       }
 

--- a/packages/identity-service/src/routes/trackListens.js
+++ b/packages/identity-service/src/routes/trackListens.js
@@ -3,6 +3,8 @@ const moment = require('moment-timezone')
 const retry = require('async-retry')
 const uuidv4 = require('uuid/v4')
 const axios = require('axios')
+const ethSigUtil = require('eth-sig-util')
+const ethUtil = require('ethereumjs-util')
 const { getIP } = require('../rateLimiter')
 const models = require('../models')
 const {
@@ -67,6 +69,46 @@ const parseTimeframe = (inputTime) => {
     inputTime = 'millennium'
   }
   return inputTime
+}
+
+const getDiscoveryListensEndpoint = () => {
+  const env = config.get('environment')
+  switch (env) {
+    case "staging":
+      return "https://discoveryprovider.staging.audius.co"
+    case "production":
+      return "https://discoveryprovider.audius.co"
+    case "development":
+    default:
+      return "http://audius-protocol-discovery-provider-1"
+  }
+}
+
+const sign = (data) => {
+  const privateKey = config.get('relayerPrivateKey')
+  const msgHash = ethUtil.hashPersonalMessage(Buffer.from(data))
+  const signature = ethSigUtil.personalSign(Buffer.from(privateKey, 'hex'), { data: msgHash })
+  return signature
+}
+
+const basicAuthNonce = () => {
+  const ts = Date.now().toString()
+  const sig = sign(ts)
+  const signatureHex = '0x' + sig.toString('hex')
+  const basic = `${ts}:${signatureHex}`
+  const signature = 'Basic ' + Buffer.from(basic).toString('base64')
+  return signature
+}
+
+const generateListenTimestampAndSignature = () => {
+  const timestamp = new Date().toISOString()
+  const data = JSON.stringify({ data: 'listen', timestamp })
+  const sig = sign(data)
+  const signature = `0x${sig.toString('hex')}`
+  return {
+    signature,
+    timestamp
+  }
 }
 
 const getTrackListens = async (
@@ -389,6 +431,42 @@ module.exports = function (app) {
       const suffix = currentHour.toISOString()
       const entropy = uuidv4()
       const { ip, isWhitelisted } = getIP(req)
+
+      const useDiscoveryListens = config.get('useDiscoveryListens')
+      if (useDiscoveryListens) {
+        // attempt to forward listen to discovery
+        // if it fails, submit to solana like normal
+        try {
+          req.logger.info(
+            `TrackListen userId=${userId} ip=${ip} isWhitelisted=${isWhitelisted} useDiscoveryListens=${useDiscoveryListens}`
+          )
+
+          // sign
+          const { signature, timestamp } = generateListenTimestampAndSignature()
+
+          const body = {
+            userId,
+            timestamp,
+            signature,
+            solanaListen: false,
+          }
+
+          const headers = {
+            Authorization: basicAuthNonce(),
+            'x-forwarded-for': ip
+          }
+
+          const endpoint = `${getDiscoveryListensEndpoint()}/solana/tracks/${trackId}/listen`
+          const { solTxSignature } = (await axios.post(endpoint, body, { headers })).data
+
+          return successResponse({
+            solTxSignature
+          })
+        } catch (e) {
+          req.logger.error(`TrackListen discovery error, trackId=${trackId} userId=${userId} : ${e}`)
+        }
+      }
+
       req.logger.info(
         `TrackListen userId=${userId} ip=${ip} isWhitelisted=${isWhitelisted}`
       )


### PR DESCRIPTION
### Description
Signs the play with the identity relayer wallet, adds the public key of this wallet to solana relay so they can be verified, and forwards listens from identity. If it fails, identity falls back and submits it to solana itself.

should be merged after https://github.com/AudiusProject/audius-docker-compose/pull/523

### How Has This Been Tested?
`npm run web:dev` against local stack and listening to an uploaded track.
