### PR TITLE
[QA-1430] Fix duplicate trending playlist

### DIFF
--- a/packages/web/src/common/store/pages/trending-playlists/lineups/sagas.ts
+++ b/packages/web/src/common/store/pages/trending-playlists/lineups/sagas.ts
@@ -15,6 +15,8 @@ import { waitForRead } from 'utils/sagaHelpers'
 const { getLineup } = trendingPlaylistsPageLineupSelectors
 const getUserId = accountSelectors.getUserId
 
+let numberOfFilteredPlaylists = 0
+
 function* getPlaylists({ limit, offset }: { limit: number; offset: number }) {
   yield* waitForRead()
   const apiClient = yield* getContext('apiClient')
@@ -40,7 +42,7 @@ function* getPlaylists({ limit, offset }: { limit: number; offset: number }) {
     {
       currentUserId,
       limit: TMP_LIMIT,
-      offset,
+      offset: offset + numberOfFilteredPlaylists,
       time
     }
   )
@@ -63,6 +65,7 @@ function* getPlaylists({ limit, offset }: { limit: number; offset: number }) {
   const trendingPlaylists = playlists.filter(
     (playlist) => !userIdsToOmit.has(`${playlist.playlist_owner_id}`)
   )
+  numberOfFilteredPlaylists += playlists.length - trendingPlaylists.length
 
   const processed = yield* processAndCacheCollections(trendingPlaylists, false)
 


### PR DESCRIPTION
### Description

Duplicate playlists show in playlist trending because of a pagination bug. Client side we filter out some accounts (actually, just `@audiusproject`). This change checks to see how many playlists are filtered out and increments the fetching offset by that number. Will follow up to see if we still even care about this behavior, but this change is safe.

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._

```
npm run web:prod
```
no dupes