### PR TITLE
[C-4694] Add track_count to playlists query endpoint

### DIFF
--- a/packages/discovery-provider/src/queries/query_helpers.py
+++ b/packages/discovery-provider/src/queries/query_helpers.py
@@ -961,6 +961,10 @@ def populate_playlist_metadata(
             total_play_count += play_count_dict.get(track["track"], 0)
         playlist[response_name_constants.total_play_count] = total_play_count
 
+        playlist[response_name_constants.track_count] = len(
+            playlist["playlist_contents"]["track_ids"]
+        )
+
         # current user specific
         playlist[
             response_name_constants.followee_reposts


### PR DESCRIPTION
### Description
Thought I had already fixed this but turns out there is yet another old legacy endpoint that is actually the one currently used by our client.

Ideally we should migrate to the v1 endpoints but that's a deeper dive.

### How Has This Been Tested?

Confirmed `track_count` is present in the response.

Something about the way the client fetches collections is different between local stack vs stage - i couldn't figure out how to make sure the client actually reads the data from this endpoint correctly but i made a ticket to follow-up on this once it lands on stage.