### PR TITLE
[C-4595] Fix addEntries call in asCache reducers

### DIFF
--- a/packages/common/src/store/cache/collections/reducer.ts
+++ b/packages/common/src/store/cache/collections/reducer.ts
@@ -64,10 +64,11 @@ const actionsMap = {
   },
   [ADD_ENTRIES](
     state: CollectionsCacheState,
-    action: AddEntriesAction<Collection>
+    action: AddEntriesAction<Collection>,
+    kind: Kind
   ) {
     const { entriesByKind } = action
-    const matchingEntries = entriesByKind[Kind.COLLECTIONS]
+    const matchingEntries = entriesByKind[kind]
 
     if (!matchingEntries) return state
     const cacheableEntries: Entry[] = Object.entries(matchingEntries).map(

--- a/packages/common/src/store/cache/collections/reducer.ts
+++ b/packages/common/src/store/cache/collections/reducer.ts
@@ -11,6 +11,7 @@ import {
 
 import { SET_PERMALINK, setPermalink } from './actions'
 import { CollectionsCacheState } from './types'
+import { Entry } from '../types'
 
 const initialState = {
   ...initialCacheState,
@@ -63,14 +64,19 @@ const actionsMap = {
   },
   [ADD_ENTRIES](
     state: CollectionsCacheState,
-    action: AddEntriesAction<Collection>,
-    kind: Kind
+    action: AddEntriesAction<Collection>
   ) {
     const { entriesByKind } = action
-    const matchingEntries = entriesByKind[kind]
+    const matchingEntries = entriesByKind[Kind.COLLECTIONS]
 
     if (!matchingEntries) return state
-    return addEntries(state, matchingEntries)
+    const cacheableEntries: Entry[] = Object.entries(matchingEntries).map(
+      ([id, entry]) => ({
+        id: parseInt(id, 10),
+        metadata: entry
+      })
+    )
+    return addEntries(state, cacheableEntries)
   },
   [SET_PERMALINK](
     state: CollectionsCacheState,
@@ -89,10 +95,10 @@ const actionsMap = {
   }
 }
 
-const reducer = (state = initialState, action: any) => {
+const reducer = (state = initialState, action: any, kind: Kind) => {
   const matchingReduceFunction = actionsMap[action.type]
   if (!matchingReduceFunction) return state
-  return matchingReduceFunction(state, action)
+  return matchingReduceFunction(state, action, kind)
 }
 
 export default reducer

--- a/packages/common/src/store/cache/collections/reducer.ts
+++ b/packages/common/src/store/cache/collections/reducer.ts
@@ -8,10 +8,10 @@ import {
   ADD_ENTRIES,
   ADD_SUCCEEDED
 } from '../actions'
+import { Entry } from '../types'
 
 import { SET_PERMALINK, setPermalink } from './actions'
 import { CollectionsCacheState } from './types'
-import { Entry } from '../types'
 
 const initialState = {
   ...initialCacheState,

--- a/packages/common/src/store/cache/reducer.ts
+++ b/packages/common/src/store/cache/reducer.ts
@@ -21,7 +21,7 @@ import {
   SetCacheConfigAction,
   SET_CACHE_CONFIG
 } from './actions'
-import { CacheType, Metadata, SubscriptionInfo } from './types'
+import { CacheType, Entry, Metadata, SubscriptionInfo } from './types'
 
 type CacheState = {
   entries: Record<ID, { _timestamp: number; metadata: Metadata }>
@@ -177,7 +177,7 @@ const updateImageCache = (existing: Metadata, next: Metadata, merged: any) => {
   return merged
 }
 
-const addEntries = (state: CacheState, entries: any[], replace?: boolean) => {
+const addEntries = (state: CacheState, entries: Entry[], replace?: boolean) => {
   const { cacheType, simple, entryTTL } = state
   const newEntries = { ...state.entries }
   const newUids = { ...state.uids }
@@ -228,13 +228,14 @@ const addEntries = (state: CacheState, entries: any[], replace?: boolean) => {
     }
 
     if (!simple) {
-      newUids[entity.uid] = entity.id
-      if (entity.id in newSubscribers) {
-        newSubscribers[entity.id].add(entity.uid)
-      } else {
-        newSubscribers[entity.id] = new Set([entity.uid])
+      if (entity.uid) {
+        newUids[entity.uid] = entity.id
+        if (entity.id in newSubscribers) {
+          newSubscribers[entity.id].add(entity.uid)
+        } else {
+          newSubscribers[entity.id] = new Set([entity.uid])
+        }
       }
-
       newIdsToPrune.delete(entity.id)
     }
   }
@@ -273,9 +274,9 @@ const actionsMap = {
   [ADD_ENTRIES](state: CacheState, action: AddEntriesAction, kind: Kind) {
     const { entriesByKind, replace } = action
     const matchingEntries = entriesByKind[kind] ?? {}
-    const cacheableEntries = Object.entries(matchingEntries).map(
+    const cacheableEntries: Entry[] = Object.entries(matchingEntries).map(
       ([id, entry]) => ({
-        id,
+        id: parseInt(id, 10),
         metadata: entry
       })
     )
@@ -453,7 +454,7 @@ const actionsMap = {
 export const asCache =
   (
     reducer: {
-      (state: CacheState | undefined, action: any): {
+      (state: CacheState | undefined, action: any, kind: Kind): {
         // id => entry
         entries: {}
         // id => status
@@ -488,5 +489,5 @@ export const asCache =
       updatedState = matchingReduceFunction(state, action, kind)
     }
 
-    return reducer(updatedState, action)
+    return reducer(updatedState, action, kind)
   }

--- a/packages/common/src/store/cache/tracks/reducer.ts
+++ b/packages/common/src/store/cache/tracks/reducer.ts
@@ -10,6 +10,7 @@ import {
   ADD_ENTRIES,
   ADD_SUCCEEDED
 } from '../actions'
+import { Entry } from '../types'
 
 import {
   SET_PERMALINK,
@@ -18,7 +19,6 @@ import {
   setStreamUrls
 } from './actions'
 import { TracksCacheState } from './types'
-import { Entry } from '../types'
 
 const initialState: TracksCacheState = {
   ...(initialCacheState as unknown as Cache<Track>),

--- a/packages/common/src/store/cache/tracks/reducer.ts
+++ b/packages/common/src/store/cache/tracks/reducer.ts
@@ -18,6 +18,7 @@ import {
   setStreamUrls
 } from './actions'
 import { TracksCacheState } from './types'
+import { Entry } from '../types'
 
 const initialState: TracksCacheState = {
   ...(initialCacheState as unknown as Cache<Track>),
@@ -25,7 +26,7 @@ const initialState: TracksCacheState = {
   streamUrls: {}
 }
 
-const addEntries = (state: TracksCacheState, entries: any[]) => {
+const addEntries = (state: TracksCacheState, entries: Entry[]) => {
   const newPermalinks: Record<string, ID> = {}
 
   for (const entry of entries) {
@@ -62,7 +63,13 @@ const actionsMap = {
     const matchingEntries = entriesByKind[kind]
 
     if (!matchingEntries) return state
-    return addEntries(state, matchingEntries)
+    const cacheableEntries: Entry[] = Object.entries(matchingEntries).map(
+      ([id, entry]) => ({
+        id: parseInt(id, 10),
+        metadata: entry
+      })
+    )
+    return addEntries(state, cacheableEntries)
   },
   [SET_PERMALINK](
     state: TracksCacheState,
@@ -92,11 +99,12 @@ const actionsMap = {
 
 const reducer = (
   state: TracksCacheState = initialState,
-  action: AddSuccededAction<Track>
+  action: any,
+  kind: Kind
 ) => {
   const matchingReduceFunction = actionsMap[action.type]
   if (!matchingReduceFunction) return state
-  return matchingReduceFunction(state, action)
+  return matchingReduceFunction(state, action, kind)
 }
 
 export default reducer

--- a/packages/common/src/store/cache/types.ts
+++ b/packages/common/src/store/cache/types.ts
@@ -10,8 +10,12 @@ export type Entry<EntryT extends Metadata = Metadata> = {
   timestamp?: number
 }
 
+export type EntryMap<EntryT extends Metadata = Metadata> = {
+  [id: string]: Entry<EntryT>
+}
+
 export type EntriesByKind<EntryT extends Metadata = Metadata> = {
-  [key in Kind]?: Entry<EntryT>[]
+  [key in Kind]?: EntryMap<EntryT>
 }
 
 export type Metadata = {

--- a/packages/common/src/store/cache/users/reducer.ts
+++ b/packages/common/src/store/cache/users/reducer.ts
@@ -10,9 +10,9 @@ import {
   ADD_ENTRIES,
   ADD_SUCCEEDED
 } from '../actions'
+import { Entry } from '../types'
 
 import type { UsersCacheState } from './types'
-import { Entry } from '../types'
 
 const initialState: UsersCacheState = {
   ...(initialCacheState as unknown as Cache<User>),

--- a/packages/common/src/store/cache/users/reducer.ts
+++ b/packages/common/src/store/cache/users/reducer.ts
@@ -12,13 +12,14 @@ import {
 } from '../actions'
 
 import type { UsersCacheState } from './types'
+import { Entry } from '../types'
 
 const initialState: UsersCacheState = {
   ...(initialCacheState as unknown as Cache<User>),
   handles: {}
 }
 
-const addEntries = (state: UsersCacheState, entries: any[]) => {
+const addEntries = (state: UsersCacheState, entries: Entry[]) => {
   const newHandles: Record<string, ID> = {}
 
   for (const entry of entries) {
@@ -54,17 +55,24 @@ const actionsMap = {
     const matchingEntries = entriesByKind[kind]
 
     if (!matchingEntries) return state
-    return addEntries(state, matchingEntries)
+    const cacheableEntries: Entry[] = Object.entries(matchingEntries).map(
+      ([id, entry]) => ({
+        id: parseInt(id, 10),
+        metadata: entry
+      })
+    )
+    return addEntries(state, cacheableEntries)
   }
 }
 
 const reducer = (
   state: UsersCacheState = initialState,
-  action: AddSuccededAction<User>
+  action: any,
+  kind: Kind
 ) => {
   const matchingReduceFunction = actionsMap[action.type]
   if (!matchingReduceFunction) return state
-  return matchingReduceFunction(state, action)
+  return matchingReduceFunction(state, action, kind)
 }
 
 export default reducer


### PR DESCRIPTION
### Description

#### Root cause
`fetchCollectionTracks` was failing in mobile because the permalink wasn't set in cache. This broke the cache's track fetching logic.

The reason permalink was missing is that the `asCache` reducer 'inheritance' was not passing the kind through properly. Additionally, the types were incorrect which led us to unpack the entity data improperly. Because of the above, the `addEntries` helper was not able to add the permalinks to the cache

#### Fixes
- Pass `kind` through `asCache` reducers
- Fix `EntriesByKind` types
- Unpack entries properly in cache/ [collections, tracks, users] reducers

### How Has This Been Tested?

Fixed lineup example on mobile:
<img width='40%' src='https://github.com/user-attachments/assets/94a1f30d-8474-4c0b-bc13-1340572b0f9c' />
