### PR TITLE
[C-4711] Hide play/repost stats for hidden content

### DIFF
--- a/packages/mobile/src/components/lineup-tile/CollectionTile.tsx
+++ b/packages/mobile/src/components/lineup-tile/CollectionTile.tsx
@@ -29,7 +29,6 @@ import { useDispatch, useSelector } from 'react-redux'
 
 import type { ImageProps } from '@audius/harmony-native'
 import { CollectionImage } from 'app/components/image/CollectionImage'
-import { useIsUSDCEnabled } from 'app/hooks/useIsUSDCEnabled'
 import { useNavigation } from 'app/hooks/useNavigation'
 import { setVisibility } from 'app/store/drawers/slice'
 import { getIsCollectionMarkedForDownload } from 'app/store/offline-downloads/selectors'
@@ -113,7 +112,6 @@ const CollectionTileComponent = ({
   variant,
   ...lineupTileProps
 }: CollectionTileProps) => {
-  const isUSDCEnabled = useIsUSDCEnabled()
   const dispatch = useDispatch()
   const navigation = useNavigation()
   const currentUserId = useSelector(getUserId)
@@ -133,11 +131,11 @@ const CollectionTileComponent = ({
     playlist_id,
     playlist_name,
     playlist_owner_id,
-    stream_conditions
+    stream_conditions,
+    is_private: isPrivate
   } = collection
 
-  const hasPreview =
-    isUSDCEnabled && isContentUSDCPurchaseGated(stream_conditions)
+  const hasPreview = isContentUSDCPurchaseGated(stream_conditions)
 
   const isOwner = playlist_owner_id === currentUserId
 
@@ -273,6 +271,7 @@ const CollectionTileComponent = ({
       item={collection}
       user={user}
       variant={variant}
+      isUnlisted={isPrivate}
     >
       <CollectionTileTrackList
         tracks={tracks}

--- a/packages/web/src/components/collection/components/RepostsFavoritesStats.tsx
+++ b/packages/web/src/components/collection/components/RepostsFavoritesStats.tsx
@@ -11,7 +11,6 @@ import {
 import { useIsMobile } from 'hooks/useIsMobile'
 
 type RepostsFavoritesStatsProps = {
-  isUnlisted: boolean
   repostCount: number
   saveCount: number
   onClickReposts?: () => void
@@ -27,7 +26,6 @@ const messages = {
 // NOTE: this is a newer version of the other RepostsFavoritesStats component;
 // unclear if designers want to deprecate the old one just yet so this is a standalone component for CollectionHeader
 export const RepostsFavoritesStats = ({
-  isUnlisted,
   repostCount,
   saveCount,
   onClickReposts,
@@ -51,7 +49,6 @@ export const RepostsFavoritesStats = ({
     [onClickFavorites]
   )
 
-  if (isUnlisted) return null
   return !!repostCount || !!saveCount ? (
     <Flex alignItems='center' gap={isMobile ? 'xl' : 'l'}>
       {!!repostCount && (

--- a/packages/web/src/components/collection/desktop/CollectionHeader.tsx
+++ b/packages/web/src/components/collection/desktop/CollectionHeader.tsx
@@ -126,9 +126,7 @@ export const CollectionHeader = (props: CollectionHeaderProps) => {
     streamConditions
   } = props
 
-  const { isEnabled: isPremiumAlbumsEnabled } = useFlag(
-    FeatureFlags.PREMIUM_ALBUMS_ENABLED
-  )
+  const { spacing } = useTheme()
   const { data: currentUserId } = useGetCurrentUserId({})
   const { data: collection } = useGetPlaylistById({
     playlistId: collectionId,
@@ -137,13 +135,14 @@ export const CollectionHeader = (props: CollectionHeaderProps) => {
   const {
     is_scheduled_release: isScheduledRelease,
     release_date: releaseDate,
-    permalink
+    permalink,
+    is_private: isPrivate
   } = collection ?? {}
   const [artworkLoading, setIsArtworkLoading] = useState(true)
   const [filterText, setFilterText] = useState('')
-  const { spacing } = useTheme()
 
   const hasStreamAccess = access?.stream
+  const shouldShowStats = !isPrivate || isOwner
 
   const handleFilterChange = useCallback(
     (e: ChangeEvent<HTMLInputElement>) => {
@@ -160,15 +159,14 @@ export const CollectionHeader = (props: CollectionHeaderProps) => {
 
   const renderStatsRow = (isLoading: boolean) => {
     if (isLoading) return <Skeleton height='20px' width='120px' />
-    return (
+    return shouldShowStats ? (
       <RepostsFavoritesStats
-        isUnlisted={false}
         repostCount={reposts}
         saveCount={saves}
         onClickReposts={onClickReposts}
         onClickFavorites={onClickFavorites}
       />
-    )
+    ) : null
   }
 
   const isLoading = loading || artworkLoading
@@ -313,7 +311,7 @@ export const CollectionHeader = (props: CollectionHeaderProps) => {
       borderTop='strong'
       borderBottom='strong'
     >
-      {isPremiumAlbumsEnabled && isStreamGated && streamConditions ? (
+      {isStreamGated && streamConditions ? (
         <GatedContentSection
           isLoading={isLoading}
           contentId={collectionId}

--- a/packages/web/src/components/collection/desktop/CollectionHeader.tsx
+++ b/packages/web/src/components/collection/desktop/CollectionHeader.tsx
@@ -140,7 +140,7 @@ export const CollectionHeader = (props: CollectionHeaderProps) => {
   const [filterText, setFilterText] = useState('')
 
   const hasStreamAccess = access?.stream
-  const shouldShowStats = !isPrivate || isOwner
+  const shouldShowStats = variant !== Variant.SMART && (!isPrivate || isOwner)
 
   const handleFilterChange = useCallback(
     (e: ChangeEvent<HTMLInputElement>) => {

--- a/packages/web/src/components/collection/desktop/CollectionHeader.tsx
+++ b/packages/web/src/components/collection/desktop/CollectionHeader.tsx
@@ -10,7 +10,6 @@ import {
   Variant,
   isContentUSDCPurchaseGated
 } from '@audius/common/models'
-import { FeatureFlags } from '@audius/common/services'
 import {
   CollectionsPageType,
   PurchaseableContentType
@@ -37,7 +36,6 @@ import { UserLink } from 'components/link'
 import Skeleton from 'components/skeleton/Skeleton'
 import { GatedContentSection } from 'components/track/GatedContentSection'
 import { UserGeneratedText } from 'components/user-generated-text'
-import { useFlag } from 'hooks/useRemoteConfig'
 
 import { CollectionMetadataList } from '../CollectionMetadataList'
 import { RepostsFavoritesStats } from '../components/RepostsFavoritesStats'

--- a/packages/web/src/components/collection/mobile/CollectionHeader.tsx
+++ b/packages/web/src/components/collection/mobile/CollectionHeader.tsx
@@ -147,6 +147,8 @@ const CollectionHeader = ({
 
   const showPremiumSection =
     isPremiumAlbumsEnabled && isAlbum && streamConditions && collectionId
+  const shouldShowStats =
+    isPublished && variant !== Variant.SMART && (!isPrivate || isOwner)
 
   const onSaveCollection = () => {
     if (!isOwner) onSave?.()
@@ -338,9 +340,8 @@ const CollectionHeader = ({
             />
           </Box>
         ) : null}
-        {isPublished && variant !== Variant.SMART ? (
+        {shouldShowStats ? (
           <RepostsFavoritesStats
-            isUnlisted={false}
             repostCount={reposts}
             saveCount={saves}
             onClickReposts={onClickReposts}

--- a/packages/web/src/components/track/mobile/PlaylistTile.tsx
+++ b/packages/web/src/components/track/mobile/PlaylistTile.tsx
@@ -1,5 +1,6 @@
 import { useEffect, MouseEvent, useCallback } from 'react'
 
+import { useGetCurrentUserId, useGetPlaylistById } from '@audius/common/api'
 import {
   ID,
   UID,
@@ -24,6 +25,7 @@ import {
 import {
   Box,
   Flex,
+  IconVisibilityHidden,
   IconVolumeLevel2 as IconVolume,
   Text
 } from '@audius/harmony'
@@ -65,7 +67,8 @@ const DISPLAY_TRACK_COUNT = 5
 
 const messages = {
   by: 'by',
-  deleted: '[Deleted by Artist]'
+  deleted: '[Deleted by Artist]',
+  hidden: 'Hidden'
 }
 
 const TrackItem = (props: TrackItemProps) => {
@@ -253,6 +256,19 @@ const PlaylistTile = (props: PlaylistTileProps & ExtraProps) => {
     streamConditions,
     source
   } = props
+
+  const { data: currentUserId } = useGetCurrentUserId({})
+  const { data: collection } = useGetPlaylistById({
+    playlistId: id,
+    currentUserId
+  })
+
+  const {
+    is_private: isPrivate,
+    repost_count: repostCount,
+    save_count: saveCount
+  } = collection ?? {}
+
   useEffect(() => {
     if (!showSkeleton) {
       hasLoaded(index)
@@ -267,6 +283,7 @@ const PlaylistTile = (props: PlaylistTileProps & ExtraProps) => {
   }
   const gatedContentStatusMap = useSelector(getGatedContentStatusMap)
   const gatedContentStatus = id ? gatedContentStatusMap[id] : undefined
+  const shouldShowStats = !isPrivate && !!(repostCount || saveCount)
 
   const [, setModalVisibility] = useModalState('LockedContent')
   const dispatch = useDispatch()
@@ -305,7 +322,6 @@ const PlaylistTile = (props: PlaylistTileProps & ExtraProps) => {
   })
 
   let specialContentLabel = null
-
   if (isStreamGated) {
     specialContentLabel = (
       <GatedContentLabel
@@ -313,6 +329,16 @@ const PlaylistTile = (props: PlaylistTileProps & ExtraProps) => {
         hasStreamAccess={!!hasStreamAccess}
         isOwner={isOwner}
       />
+    )
+  }
+  if (isPrivate) {
+    specialContentLabel = (
+      <Flex alignItems='center' gap='xs' css={{ whiteSpace: 'nowrap' }}>
+        <IconVisibilityHidden size='s' color='subdued' />
+        <Text variant='body' size='xs' color='subdued'>
+          {messages.hidden}
+        </Text>
+      </Flex>
     )
   }
 
@@ -403,7 +429,7 @@ const PlaylistTile = (props: PlaylistTileProps & ExtraProps) => {
                   {specialContentLabel}
                 </Text>
               ) : null}
-              {!!(props.repostCount || props.saveCount) && (
+              {shouldShowStats ? (
                 <>
                   <Flex
                     gap='xs'
@@ -448,7 +474,7 @@ const PlaylistTile = (props: PlaylistTileProps & ExtraProps) => {
                     {formatCount(props.repostCount)}
                   </Flex>
                 </>
-              )}
+              ) : null}
             </Flex>
             <Text
               variant='body'


### PR DESCRIPTION
### Description
Hide all stats in the following places:
- Collection Page
- Tiles (DMs)

### How Has This Been Tested?

<img width="50%" alt="Screenshot 2024-07-11 at 5 35 29 PM" src="https://github.com/user-attachments/assets/098d525b-715b-46cb-828e-dddcdb714746">
<img width='50%' src='https://github.com/user-attachments/assets/9537fbd6-a15a-40d7-92c6-ed84b13c8c44' >
<img width='50%' src='https://github.com/user-attachments/assets/ff04c015-d5a3-4571-9dde-207d24c0bac5'>
<img width="50%" alt="Screenshot 2024-07-11 at 5 33 46 PM" src="https://github.com/user-attachments/assets/3f092a3c-b64e-4c1f-9ce1-45aa682f829f">

track from owner's perspective still shows stats:
<img width="50%" alt="Screenshot 2024-07-11 at 5 36 41 PM" src="https://github.com/user-attachments/assets/46244c88-26c6-4def-b996-fb55ac7bfc5d">