### PR TITLE
[PAY-2783] Add filters to manager endpoints

### DIFF
--- a/.changeset/smooth-crews-rush.md
+++ b/.changeset/smooth-crews-rush.md
@@ -1,0 +1,5 @@
+---
+'@audius/sdk': patch
+---
+
+add filtering support for manager endpoints

--- a/packages/commands/README.md
+++ b/packages/commands/README.md
@@ -121,3 +121,19 @@ audius-cmd mint-tokens --from freddie_mercury --mint usdc 10000000
 
 audius-cmd purchase-content <track-id> --type track --from freddie_mercury
 ```
+
+**Managed accounts**
+
+```
+# Add a manager
+audius-cmd add-manager --from freddie_mercury jim_beach
+
+# Accept request from manager's account
+audius-cmd approve-manager-request --from jim_beach freddie_mercury
+
+# (OR) Reject request from manager's account
+audius-cmd reject-manager-request --from jim_beach freddie_mercury
+
+# Remove manager
+audius-cmd remove-manager --from freddie_mercury jim_beach
+```

--- a/packages/commands/src/account-managers.mjs
+++ b/packages/commands/src/account-managers.mjs
@@ -45,7 +45,7 @@ program
   })
 
 program
-  .command('approve-manager')
+  .command('approve-manager-request')
   .description('Approve a pending manager request')
   .argument('[handle]', 'The handle of the user to be managed')
   .option('-f, --from <from>', 'The manager account handle')
@@ -82,7 +82,7 @@ program
   })
 
 program
-  .command('reject-manager')
+  .command('reject-manager-request')
   .description('Reject a pending manager request')
   .argument('[handle]', 'The handle of the user to be managed')
   .option('-f, --from <from>', 'The manager account handle')
@@ -104,10 +104,10 @@ program
     try {
       const {
         data: { id: userId }
-      } = await audiusSdk.users.getUserByHandle({ handle: from })
+      } = await audiusSdk.users.getUserByHandle({ handle })
       const {
         data: { id: managerUserId }
-      } = await audiusSdk.users.getUserByHandle({ handle })
+      } = await audiusSdk.users.getUserByHandle({ handle: from })
 
       await audiusSdk.grants.removeManager({ userId, managerUserId })
       console.log(chalk.green(`Manager request rejected.`))

--- a/packages/commands/src/account-managers.mjs
+++ b/packages/commands/src/account-managers.mjs
@@ -1,13 +1,7 @@
-import fs from 'fs'
-
 import chalk from 'chalk'
 import { program } from 'commander'
 
-import {
-  initializeAudiusLibs,
-  initializeAudiusSdk,
-  parseUserId
-} from './utils.mjs'
+import { initializeAudiusLibs, initializeAudiusSdk } from './utils.mjs'
 
 program
   .command('add-manager')
@@ -80,6 +74,80 @@ program
 
       await audiusSdk.grants.approveGrant({ userId, grantorUserId })
       console.log(chalk.green(`Manager request approved!`))
+    } catch (err) {
+      program.error(err.message)
+    }
+
+    process.exit(0)
+  })
+
+program
+  .command('reject-manager')
+  .description('Reject a pending manager request')
+  .argument('[handle]', 'The handle of the user to be managed')
+  .option('-f, --from <from>', 'The manager account handle')
+  .action(async (handle, { from }) => {
+    const audiusLibs = await initializeAudiusLibs(from)
+    // extract privkey and pubkey from hedgehog
+    // only works with accounts created via audius-cmd
+    const wallet = audiusLibs?.hedgehog?.getWallet()
+    const privKey = wallet?.getPrivateKeyString()
+    const pubKey = wallet?.getAddressString()
+
+    // init sdk with priv and pub keys as api keys and secret
+    // this enables writes via sdk
+    const audiusSdk = await initializeAudiusSdk({
+      apiKey: pubKey,
+      apiSecret: privKey
+    })
+
+    try {
+      const {
+        data: { id: userId }
+      } = await audiusSdk.users.getUserByHandle({ handle: from })
+      const {
+        data: { id: managerUserId }
+      } = await audiusSdk.users.getUserByHandle({ handle })
+
+      await audiusSdk.grants.removeManager({ userId, managerUserId })
+      console.log(chalk.green(`Manager request rejected.`))
+    } catch (err) {
+      program.error(err.message)
+    }
+
+    process.exit(0)
+  })
+
+program
+  .command('remove-manager')
+  .description('Remove a manager')
+  .argument('[handle]', 'The handle of the manager')
+  .option('-f, --from <from>', 'The handle of the manager user')
+  .action(async (handle, { from }) => {
+    const audiusLibs = await initializeAudiusLibs(from)
+    // extract privkey and pubkey from hedgehog
+    // only works with accounts created via audius-cmd
+    const wallet = audiusLibs?.hedgehog?.getWallet()
+    const privKey = wallet?.getPrivateKeyString()
+    const pubKey = wallet?.getAddressString()
+
+    // init sdk with priv and pub keys as api keys and secret
+    // this enables writes via sdk
+    const audiusSdk = await initializeAudiusSdk({
+      apiKey: pubKey,
+      apiSecret: privKey
+    })
+
+    try {
+      const {
+        data: { id: userId }
+      } = await audiusSdk.users.getUserByHandle({ handle: from })
+      const {
+        data: { id: managerUserId }
+      } = await audiusSdk.users.getUserByHandle({ handle })
+
+      await audiusSdk.grants.removeManager({ userId, managerUserId })
+      console.log(chalk.green(`Manager removed.`))
     } catch (err) {
       program.error(err.message)
     }

--- a/packages/commands/src/index.mjs
+++ b/packages/commands/src/index.mjs
@@ -27,7 +27,7 @@ import './create-user-bank.mjs'
 import './purchase-content.mjs'
 import './route-tokens-to-user-bank.mjs'
 import './withdraw-tokens.mjs'
-import './add-manager.mjs'
+import './account-managers.mjs'
 import './claim-reward.mjs'
 
 async function main() {

--- a/packages/discovery-provider/integration_tests/tasks/entity_manager/test_grant_entity_manager.py
+++ b/packages/discovery-provider/integration_tests/tasks/entity_manager/test_grant_entity_manager.py
@@ -522,6 +522,7 @@ def test_index_grant(app, mocker):
         assert len(found_matches) == 2
         for match in found_matches:
             assert match.is_approved == False
+            assert match.is_revoked == True
 
     # Invalid reject grant
     tx_receipts = {

--- a/packages/discovery-provider/integration_tests/tasks/entity_manager/test_grant_entity_manager.py
+++ b/packages/discovery-provider/integration_tests/tasks/entity_manager/test_grant_entity_manager.py
@@ -11,39 +11,53 @@ from src.tasks.entity_manager.utils import Action, EntityType
 from src.utils.db_session import get_db
 
 new_grants_data = [
+    # Grant from user 1 -> dev app F4C4
     {
         "user_id": 1,
         "grantee_address": "0x3a388671bb4D6E1Ea08D79Ee191b40FB45A8F4C4",
         "is_user_grant": False,
     },
+    # Grant from user 1 -> dev app 2e0d
     {
         "user_id": 1,
         "grantee_address": "0x04c9fc3784120f50932436f84c59aebebb12e0d",
         "is_user_grant": False,
     },
+    # Grant from user 1 -> user 3
     {
         "user_id": 1,
         "grantee_address": "user3Wallet",
         "is_user_grant": True,
     },
+    # Grant from user 2 -> user 3
     {
         "user_id": 2,
         "grantee_address": "user3Wallet",
         "is_user_grant": True,
     },
+    # Grant from user 3 -> user 4
     {"user_id": 3, "grantee_address": "user4Wallet", "is_user_grant": True},
+    # Grant from user 1 -> user 4
     {
         "user_id": 1,
         "grantee_address": "user4Wallet",
         "is_user_grant": True,
     },
+    # Grant from user 5 -> user 1
     {
         "user_id": 5,
         "grantee_address": "user1Wallet",
         "is_user_grant": True,
     },
+    # Grant from user 4 -> user 5
     {
         "user_id": 4,
+        "grantee_address": "user5wallet",
+        "is_user_grant": True,
+    },
+    # Grant from user 3 -> user 5
+    {
+        "user_id": 3,
         "grantee_address": "user5wallet",
         "is_user_grant": True,
     },
@@ -170,6 +184,20 @@ def test_index_grant(app, mocker):
                         "_metadata": f"""{{"grantee_address": "{new_grants_data[7]["grantee_address"]}"}}""",
                         "_action": Action.CREATE,
                         "_signer": f"user{new_grants_data[7]['user_id']}wallet",
+                    }
+                )
+            },
+        ],
+        "CreateGrantTx9": [
+            {
+                "args": AttributeDict(
+                    {
+                        "_entityId": 0,
+                        "_entityType": EntityType.GRANT,
+                        "_userId": new_grants_data[8]["user_id"],
+                        "_metadata": f"""{{"grantee_address": "{new_grants_data[8]["grantee_address"]}"}}""",
+                        "_action": Action.CREATE,
+                        "_signer": f"user{new_grants_data[8]['user_id']}wallet",
                     }
                 )
             },
@@ -723,8 +751,8 @@ def test_index_grant(app, mocker):
                     {
                         "_entityId": 0,
                         "_entityType": EntityType.GRANT,
-                        "_userId": new_grants_data[7]["user_id"],
-                        "_metadata": f"""{{"grantee_address": "{new_grants_data[7]["grantee_address"]}"}}""",
+                        "_userId": new_grants_data[8]["user_id"],
+                        "_metadata": f"""{{"grantee_address": "{new_grants_data[8]["grantee_address"]}"}}""",
                         "_action": Action.DELETE,
                         "_signer": "user1wallet",
                     }
@@ -752,7 +780,7 @@ def test_index_grant(app, mocker):
         # validate db records
         all_grants: List[Grant] = session.query(Grant).all()
         assert len(all_grants) == NUM_VALID_GRANTS
-        deleted_grants_indices = [0, 1, 2, 5, 7]
+        deleted_grants_indices = [0, 1, 2, 5, 8]
         for index in deleted_grants_indices:
             expected_grant = new_grants_data[index]
             found_matches = [

--- a/packages/discovery-provider/src/tasks/entity_manager/entities/grant.py
+++ b/packages/discovery-provider/src/tasks/entity_manager/entities/grant.py
@@ -296,6 +296,7 @@ def reject_grant(params: ManageEntityParameters):
     )
 
     rejected_grant.is_approved = False
+    rejected_grant.is_revoked = True
 
     validate_grant_record(rejected_grant)
     params.add_record(grant_key, rejected_grant)

--- a/packages/discovery-provider/src/tasks/entity_manager/entities/grant.py
+++ b/packages/discovery-provider/src/tasks/entity_manager/entities/grant.py
@@ -211,6 +211,7 @@ def create_grant(params: ManageEntityParameters):
         ),  # cast to assert non null (since we validated above)
         is_current=True,
         is_approved=None if grantee_type == "user" else True,
+        is_revoked=False,
         txhash=params.txhash,
         blockhash=params.event_blockhash,
         blocknumber=params.block_number,

--- a/packages/libs/src/sdk/api/generated/default/apis/PlaylistsApi.ts
+++ b/packages/libs/src/sdk/api/generated/default/apis/PlaylistsApi.ts
@@ -65,7 +65,12 @@ export interface GetTrendingPlaylistsRequest {
 }
 
 export interface SearchPlaylistsRequest {
-    query: string;
+    query?: string;
+    genre?: Array<string>;
+    sortMethod?: SearchPlaylistsSortMethodEnum;
+    mood?: Array<string>;
+    includePurchaseable?: string;
+    hasDownloads?: string;
 }
 
 /**
@@ -284,14 +289,30 @@ export class PlaylistsApi extends runtime.BaseAPI {
      * Search for a playlist
      */
     async searchPlaylistsRaw(params: SearchPlaylistsRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<PlaylistSearchResult>> {
-        if (params.query === null || params.query === undefined) {
-            throw new runtime.RequiredError('query','Required parameter params.query was null or undefined when calling searchPlaylists.');
-        }
-
         const queryParameters: any = {};
 
         if (params.query !== undefined) {
             queryParameters['query'] = params.query;
+        }
+
+        if (params.genre) {
+            queryParameters['genre'] = params.genre;
+        }
+
+        if (params.sortMethod !== undefined) {
+            queryParameters['sort_method'] = params.sortMethod;
+        }
+
+        if (params.mood) {
+            queryParameters['mood'] = params.mood;
+        }
+
+        if (params.includePurchaseable !== undefined) {
+            queryParameters['includePurchaseable'] = params.includePurchaseable;
+        }
+
+        if (params.hasDownloads !== undefined) {
+            queryParameters['has_downloads'] = params.hasDownloads;
         }
 
         const headerParameters: runtime.HTTPHeaders = {};
@@ -309,7 +330,7 @@ export class PlaylistsApi extends runtime.BaseAPI {
     /**
      * Search for a playlist
      */
-    async searchPlaylists(params: SearchPlaylistsRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<PlaylistSearchResult> {
+    async searchPlaylists(params: SearchPlaylistsRequest = {}, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<PlaylistSearchResult> {
         const response = await this.searchPlaylistsRaw(params, initOverrides);
         return await response.value();
     }
@@ -326,3 +347,12 @@ export const GetTrendingPlaylistsTimeEnum = {
     AllTime: 'allTime'
 } as const;
 export type GetTrendingPlaylistsTimeEnum = typeof GetTrendingPlaylistsTimeEnum[keyof typeof GetTrendingPlaylistsTimeEnum];
+/**
+ * @export
+ */
+export const SearchPlaylistsSortMethodEnum = {
+    Relevant: 'relevant',
+    Popular: 'popular',
+    Recent: 'recent'
+} as const;
+export type SearchPlaylistsSortMethodEnum = typeof SearchPlaylistsSortMethodEnum[keyof typeof SearchPlaylistsSortMethodEnum];

--- a/packages/libs/src/sdk/api/generated/default/apis/TracksApi.ts
+++ b/packages/libs/src/sdk/api/generated/default/apis/TracksApi.ts
@@ -85,8 +85,17 @@ export interface InspectTrackRequest {
 }
 
 export interface SearchTracksRequest {
-    query: string;
+    query?: string;
+    genre?: Array<string>;
+    sortMethod?: SearchTracksSortMethodEnum;
+    mood?: Array<string>;
     onlyDownloadable?: string;
+    includePurchaseable?: string;
+    isPurchaseable?: string;
+    hasDownloads?: string;
+    key?: Array<string>;
+    bpmMin?: string;
+    bpmMax?: string;
 }
 
 export interface StreamTrackRequest {
@@ -419,18 +428,50 @@ export class TracksApi extends runtime.BaseAPI {
      * Search for a track or tracks
      */
     async searchTracksRaw(params: SearchTracksRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<TrackSearch>> {
-        if (params.query === null || params.query === undefined) {
-            throw new runtime.RequiredError('query','Required parameter params.query was null or undefined when calling searchTracks.');
-        }
-
         const queryParameters: any = {};
 
         if (params.query !== undefined) {
             queryParameters['query'] = params.query;
         }
 
+        if (params.genre) {
+            queryParameters['genre'] = params.genre;
+        }
+
+        if (params.sortMethod !== undefined) {
+            queryParameters['sort_method'] = params.sortMethod;
+        }
+
+        if (params.mood) {
+            queryParameters['mood'] = params.mood;
+        }
+
         if (params.onlyDownloadable !== undefined) {
             queryParameters['only_downloadable'] = params.onlyDownloadable;
+        }
+
+        if (params.includePurchaseable !== undefined) {
+            queryParameters['includePurchaseable'] = params.includePurchaseable;
+        }
+
+        if (params.isPurchaseable !== undefined) {
+            queryParameters['is_purchaseable'] = params.isPurchaseable;
+        }
+
+        if (params.hasDownloads !== undefined) {
+            queryParameters['has_downloads'] = params.hasDownloads;
+        }
+
+        if (params.key) {
+            queryParameters['key'] = params.key;
+        }
+
+        if (params.bpmMin !== undefined) {
+            queryParameters['bpm_min'] = params.bpmMin;
+        }
+
+        if (params.bpmMax !== undefined) {
+            queryParameters['bpm_max'] = params.bpmMax;
         }
 
         const headerParameters: runtime.HTTPHeaders = {};
@@ -448,7 +489,7 @@ export class TracksApi extends runtime.BaseAPI {
     /**
      * Search for a track or tracks
      */
-    async searchTracks(params: SearchTracksRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<TrackSearch> {
+    async searchTracks(params: SearchTracksRequest = {}, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<TrackSearch> {
         const response = await this.searchTracksRaw(params, initOverrides);
         return await response.value();
     }
@@ -533,3 +574,12 @@ export const GetTrendingTracksTimeEnum = {
     AllTime: 'allTime'
 } as const;
 export type GetTrendingTracksTimeEnum = typeof GetTrendingTracksTimeEnum[keyof typeof GetTrendingTracksTimeEnum];
+/**
+ * @export
+ */
+export const SearchTracksSortMethodEnum = {
+    Relevant: 'relevant',
+    Popular: 'popular',
+    Recent: 'recent'
+} as const;
+export type SearchTracksSortMethodEnum = typeof SearchTracksSortMethodEnum[keyof typeof SearchTracksSortMethodEnum];

--- a/packages/libs/src/sdk/api/generated/default/apis/UsersApi.ts
+++ b/packages/libs/src/sdk/api/generated/default/apis/UsersApi.ts
@@ -211,7 +211,10 @@ export interface GetUserIDFromWalletRequest {
 }
 
 export interface SearchUsersRequest {
-    query: string;
+    query?: string;
+    genre?: Array<string>;
+    sortMethod?: SearchUsersSortMethodEnum;
+    isVerified?: string;
 }
 
 export interface VerifyIDTokenRequest {
@@ -1090,14 +1093,22 @@ export class UsersApi extends runtime.BaseAPI {
      * Search for users that match the given query
      */
     async searchUsersRaw(params: SearchUsersRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<UserSearch>> {
-        if (params.query === null || params.query === undefined) {
-            throw new runtime.RequiredError('query','Required parameter params.query was null or undefined when calling searchUsers.');
-        }
-
         const queryParameters: any = {};
 
         if (params.query !== undefined) {
             queryParameters['query'] = params.query;
+        }
+
+        if (params.genre) {
+            queryParameters['genre'] = params.genre;
+        }
+
+        if (params.sortMethod !== undefined) {
+            queryParameters['sort_method'] = params.sortMethod;
+        }
+
+        if (params.isVerified !== undefined) {
+            queryParameters['is_verified'] = params.isVerified;
         }
 
         const headerParameters: runtime.HTTPHeaders = {};
@@ -1115,7 +1126,7 @@ export class UsersApi extends runtime.BaseAPI {
     /**
      * Search for users that match the given query
      */
-    async searchUsers(params: SearchUsersRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<UserSearch> {
+    async searchUsers(params: SearchUsersRequest = {}, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<UserSearch> {
         const response = await this.searchUsersRaw(params, initOverrides);
         return await response.value();
     }
@@ -1237,3 +1248,12 @@ export const GetTracksByUserFilterTracksEnum = {
     Unlisted: 'unlisted'
 } as const;
 export type GetTracksByUserFilterTracksEnum = typeof GetTracksByUserFilterTracksEnum[keyof typeof GetTracksByUserFilterTracksEnum];
+/**
+ * @export
+ */
+export const SearchUsersSortMethodEnum = {
+    Relevant: 'relevant',
+    Popular: 'popular',
+    Recent: 'recent'
+} as const;
+export type SearchUsersSortMethodEnum = typeof SearchUsersSortMethodEnum[keyof typeof SearchUsersSortMethodEnum];

--- a/packages/libs/src/sdk/api/generated/default/models/Playlist.ts
+++ b/packages/libs/src/sdk/api/generated/default/models/Playlist.ts
@@ -135,6 +135,12 @@ export interface Playlist {
      * @memberof Playlist
      */
     upc?: string;
+    /**
+     * 
+     * @type {number}
+     * @memberof Playlist
+     */
+    trackCount: number;
 }
 
 /**
@@ -151,6 +157,7 @@ export function instanceOfPlaylist(value: object): value is Playlist {
     isInstance = isInstance && "favoriteCount" in value && value["favoriteCount"] !== undefined;
     isInstance = isInstance && "totalPlayCount" in value && value["totalPlayCount"] !== undefined;
     isInstance = isInstance && "user" in value && value["user"] !== undefined;
+    isInstance = isInstance && "trackCount" in value && value["trackCount"] !== undefined;
 
     return isInstance;
 }
@@ -180,6 +187,7 @@ export function PlaylistFromJSONTyped(json: any, ignoreDiscriminator: boolean): 
         'ddexApp': !exists(json, 'ddex_app') ? undefined : json['ddex_app'],
         'access': !exists(json, 'access') ? undefined : AccessFromJSON(json['access']),
         'upc': !exists(json, 'upc') ? undefined : json['upc'],
+        'trackCount': json['track_count'],
     };
 }
 
@@ -207,6 +215,7 @@ export function PlaylistToJSON(value?: Playlist | null): any {
         'ddex_app': value.ddexApp,
         'access': AccessToJSON(value.access),
         'upc': value.upc,
+        'track_count': value.trackCount,
     };
 }
 

--- a/packages/libs/src/sdk/api/generated/full/apis/SearchApi.ts
+++ b/packages/libs/src/sdk/api/generated/full/apis/SearchApi.ts
@@ -27,23 +27,39 @@ import {
 } from '../models';
 
 export interface SearchRequest {
-    query: string;
     offset?: number;
     limit?: number;
     userId?: string;
+    query?: string;
     kind?: SearchKindEnum;
     includePurchaseable?: string;
     genre?: Array<string>;
+    mood?: Array<string>;
+    isVerified?: string;
+    hasDownloads?: string;
+    isPurchaseable?: string;
+    key?: Array<string>;
+    bpmMin?: string;
+    bpmMax?: string;
+    sortMethod?: SearchSortMethodEnum;
 }
 
 export interface SearchAutocompleteRequest {
-    query: string;
     offset?: number;
     limit?: number;
     userId?: string;
+    query?: string;
     kind?: SearchAutocompleteKindEnum;
     includePurchaseable?: string;
     genre?: Array<string>;
+    mood?: Array<string>;
+    isVerified?: string;
+    hasDownloads?: string;
+    isPurchaseable?: string;
+    key?: Array<string>;
+    bpmMin?: string;
+    bpmMax?: string;
+    sortMethod?: SearchAutocompleteSortMethodEnum;
 }
 
 /**
@@ -56,10 +72,6 @@ export class SearchApi extends runtime.BaseAPI {
      * Get Users/Tracks/Playlists/Albums that best match the search query
      */
     async searchRaw(params: SearchRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<SearchFullResponse>> {
-        if (params.query === null || params.query === undefined) {
-            throw new runtime.RequiredError('query','Required parameter params.query was null or undefined when calling search.');
-        }
-
         const queryParameters: any = {};
 
         if (params.offset !== undefined) {
@@ -88,6 +100,38 @@ export class SearchApi extends runtime.BaseAPI {
 
         if (params.genre) {
             queryParameters['genre'] = params.genre;
+        }
+
+        if (params.mood) {
+            queryParameters['mood'] = params.mood;
+        }
+
+        if (params.isVerified !== undefined) {
+            queryParameters['is_verified'] = params.isVerified;
+        }
+
+        if (params.hasDownloads !== undefined) {
+            queryParameters['has_downloads'] = params.hasDownloads;
+        }
+
+        if (params.isPurchaseable !== undefined) {
+            queryParameters['is_purchaseable'] = params.isPurchaseable;
+        }
+
+        if (params.key) {
+            queryParameters['key'] = params.key;
+        }
+
+        if (params.bpmMin !== undefined) {
+            queryParameters['bpm_min'] = params.bpmMin;
+        }
+
+        if (params.bpmMax !== undefined) {
+            queryParameters['bpm_max'] = params.bpmMax;
+        }
+
+        if (params.sortMethod !== undefined) {
+            queryParameters['sort_method'] = params.sortMethod;
         }
 
         const headerParameters: runtime.HTTPHeaders = {};
@@ -105,7 +149,7 @@ export class SearchApi extends runtime.BaseAPI {
     /**
      * Get Users/Tracks/Playlists/Albums that best match the search query
      */
-    async search(params: SearchRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<SearchFullResponse> {
+    async search(params: SearchRequest = {}, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<SearchFullResponse> {
         const response = await this.searchRaw(params, initOverrides);
         return await response.value();
     }
@@ -116,10 +160,6 @@ export class SearchApi extends runtime.BaseAPI {
      * Get Users/Tracks/Playlists/Albums that best match the search query
      */
     async searchAutocompleteRaw(params: SearchAutocompleteRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<SearchAutocompleteResponse>> {
-        if (params.query === null || params.query === undefined) {
-            throw new runtime.RequiredError('query','Required parameter params.query was null or undefined when calling searchAutocomplete.');
-        }
-
         const queryParameters: any = {};
 
         if (params.offset !== undefined) {
@@ -148,6 +188,38 @@ export class SearchApi extends runtime.BaseAPI {
 
         if (params.genre) {
             queryParameters['genre'] = params.genre;
+        }
+
+        if (params.mood) {
+            queryParameters['mood'] = params.mood;
+        }
+
+        if (params.isVerified !== undefined) {
+            queryParameters['is_verified'] = params.isVerified;
+        }
+
+        if (params.hasDownloads !== undefined) {
+            queryParameters['has_downloads'] = params.hasDownloads;
+        }
+
+        if (params.isPurchaseable !== undefined) {
+            queryParameters['is_purchaseable'] = params.isPurchaseable;
+        }
+
+        if (params.key) {
+            queryParameters['key'] = params.key;
+        }
+
+        if (params.bpmMin !== undefined) {
+            queryParameters['bpm_min'] = params.bpmMin;
+        }
+
+        if (params.bpmMax !== undefined) {
+            queryParameters['bpm_max'] = params.bpmMax;
+        }
+
+        if (params.sortMethod !== undefined) {
+            queryParameters['sort_method'] = params.sortMethod;
         }
 
         const headerParameters: runtime.HTTPHeaders = {};
@@ -166,7 +238,7 @@ export class SearchApi extends runtime.BaseAPI {
      * Same as search but optimized for quicker response at the cost of some entity information.
      * Get Users/Tracks/Playlists/Albums that best match the search query
      */
-    async searchAutocomplete(params: SearchAutocompleteRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<SearchAutocompleteResponse> {
+    async searchAutocomplete(params: SearchAutocompleteRequest = {}, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<SearchAutocompleteResponse> {
         const response = await this.searchAutocompleteRaw(params, initOverrides);
         return await response.value();
     }
@@ -187,6 +259,15 @@ export type SearchKindEnum = typeof SearchKindEnum[keyof typeof SearchKindEnum];
 /**
  * @export
  */
+export const SearchSortMethodEnum = {
+    Relevant: 'relevant',
+    Popular: 'popular',
+    Recent: 'recent'
+} as const;
+export type SearchSortMethodEnum = typeof SearchSortMethodEnum[keyof typeof SearchSortMethodEnum];
+/**
+ * @export
+ */
 export const SearchAutocompleteKindEnum = {
     All: 'all',
     Users: 'users',
@@ -195,3 +276,12 @@ export const SearchAutocompleteKindEnum = {
     Albums: 'albums'
 } as const;
 export type SearchAutocompleteKindEnum = typeof SearchAutocompleteKindEnum[keyof typeof SearchAutocompleteKindEnum];
+/**
+ * @export
+ */
+export const SearchAutocompleteSortMethodEnum = {
+    Relevant: 'relevant',
+    Popular: 'popular',
+    Recent: 'recent'
+} as const;
+export type SearchAutocompleteSortMethodEnum = typeof SearchAutocompleteSortMethodEnum[keyof typeof SearchAutocompleteSortMethodEnum];

--- a/packages/libs/src/sdk/api/generated/full/apis/UsersApi.ts
+++ b/packages/libs/src/sdk/api/generated/full/apis/UsersApi.ts
@@ -158,10 +158,18 @@ export interface GetFollowingRequest {
 
 export interface GetManagedUsersRequest {
     id: string;
+    isApproved?: boolean;
+    isRevoked?: boolean;
+    encodedDataMessage?: string;
+    encodedDataSignature?: string;
 }
 
 export interface GetManagersRequest {
     id: string;
+    isApproved?: boolean;
+    isRevoked?: boolean;
+    encodedDataMessage?: string;
+    encodedDataSignature?: string;
 }
 
 export interface GetPurchasesRequest {
@@ -803,7 +811,23 @@ export class UsersApi extends runtime.BaseAPI {
 
         const queryParameters: any = {};
 
+        if (params.isApproved !== undefined) {
+            queryParameters['is_approved'] = params.isApproved;
+        }
+
+        if (params.isRevoked !== undefined) {
+            queryParameters['is_revoked'] = params.isRevoked;
+        }
+
         const headerParameters: runtime.HTTPHeaders = {};
+
+        if (params.encodedDataMessage !== undefined && params.encodedDataMessage !== null) {
+            headerParameters['Encoded-Data-Message'] = String(params.encodedDataMessage);
+        }
+
+        if (params.encodedDataSignature !== undefined && params.encodedDataSignature !== null) {
+            headerParameters['Encoded-Data-Signature'] = String(params.encodedDataSignature);
+        }
 
         const response = await this.request({
             path: `/users/{id}/managed_users`.replace(`{${"id"}}`, encodeURIComponent(String(params.id))),
@@ -834,7 +858,23 @@ export class UsersApi extends runtime.BaseAPI {
 
         const queryParameters: any = {};
 
+        if (params.isApproved !== undefined) {
+            queryParameters['is_approved'] = params.isApproved;
+        }
+
+        if (params.isRevoked !== undefined) {
+            queryParameters['is_revoked'] = params.isRevoked;
+        }
+
         const headerParameters: runtime.HTTPHeaders = {};
+
+        if (params.encodedDataMessage !== undefined && params.encodedDataMessage !== null) {
+            headerParameters['Encoded-Data-Message'] = String(params.encodedDataMessage);
+        }
+
+        if (params.encodedDataSignature !== undefined && params.encodedDataSignature !== null) {
+            headerParameters['Encoded-Data-Signature'] = String(params.encodedDataSignature);
+        }
 
         const response = await this.request({
             path: `/users/{id}/managers`.replace(`{${"id"}}`, encodeURIComponent(String(params.id))),

--- a/packages/libs/src/sdk/api/generated/full/models/PlaylistFull.ts
+++ b/packages/libs/src/sdk/api/generated/full/models/PlaylistFull.ts
@@ -164,6 +164,12 @@ export interface PlaylistFull {
      * @type {number}
      * @memberof PlaylistFull
      */
+    trackCount: number;
+    /**
+     * 
+     * @type {number}
+     * @memberof PlaylistFull
+     */
     blocknumber: number;
     /**
      * 
@@ -251,12 +257,6 @@ export interface PlaylistFull {
     coverArtCids?: PlaylistArtwork;
     /**
      * 
-     * @type {number}
-     * @memberof PlaylistFull
-     */
-    trackCount: number;
-    /**
-     * 
      * @type {boolean}
      * @memberof PlaylistFull
      */
@@ -295,6 +295,7 @@ export function instanceOfPlaylistFull(value: object): value is PlaylistFull {
     isInstance = isInstance && "favoriteCount" in value && value["favoriteCount"] !== undefined;
     isInstance = isInstance && "totalPlayCount" in value && value["totalPlayCount"] !== undefined;
     isInstance = isInstance && "user" in value && value["user"] !== undefined;
+    isInstance = isInstance && "trackCount" in value && value["trackCount"] !== undefined;
     isInstance = isInstance && "blocknumber" in value && value["blocknumber"] !== undefined;
     isInstance = isInstance && "followeeReposts" in value && value["followeeReposts"] !== undefined;
     isInstance = isInstance && "followeeFavorites" in value && value["followeeFavorites"] !== undefined;
@@ -305,7 +306,6 @@ export function instanceOfPlaylistFull(value: object): value is PlaylistFull {
     isInstance = isInstance && "addedTimestamps" in value && value["addedTimestamps"] !== undefined;
     isInstance = isInstance && "userId" in value && value["userId"] !== undefined;
     isInstance = isInstance && "tracks" in value && value["tracks"] !== undefined;
-    isInstance = isInstance && "trackCount" in value && value["trackCount"] !== undefined;
     isInstance = isInstance && "isStreamGated" in value && value["isStreamGated"] !== undefined;
 
     return isInstance;
@@ -336,6 +336,7 @@ export function PlaylistFullFromJSONTyped(json: any, ignoreDiscriminator: boolea
         'ddexApp': !exists(json, 'ddex_app') ? undefined : json['ddex_app'],
         'access': !exists(json, 'access') ? undefined : AccessFromJSON(json['access']),
         'upc': !exists(json, 'upc') ? undefined : json['upc'],
+        'trackCount': json['track_count'],
         'blocknumber': json['blocknumber'],
         'createdAt': !exists(json, 'created_at') ? undefined : json['created_at'],
         'followeeReposts': ((json['followee_reposts'] as Array<any>).map(RepostFromJSON)),
@@ -351,7 +352,6 @@ export function PlaylistFullFromJSONTyped(json: any, ignoreDiscriminator: boolea
         'coverArt': !exists(json, 'cover_art') ? undefined : json['cover_art'],
         'coverArtSizes': !exists(json, 'cover_art_sizes') ? undefined : json['cover_art_sizes'],
         'coverArtCids': !exists(json, 'cover_art_cids') ? undefined : PlaylistArtworkFromJSON(json['cover_art_cids']),
-        'trackCount': json['track_count'],
         'isStreamGated': json['is_stream_gated'],
         'streamConditions': !exists(json, 'stream_conditions') ? undefined : AccessGateFromJSON(json['stream_conditions']),
         'isScheduledRelease': !exists(json, 'is_scheduled_release') ? undefined : json['is_scheduled_release'],
@@ -383,6 +383,7 @@ export function PlaylistFullToJSON(value?: PlaylistFull | null): any {
         'ddex_app': value.ddexApp,
         'access': AccessToJSON(value.access),
         'upc': value.upc,
+        'track_count': value.trackCount,
         'blocknumber': value.blocknumber,
         'created_at': value.createdAt,
         'followee_reposts': ((value.followeeReposts as Array<any>).map(RepostToJSON)),
@@ -398,7 +399,6 @@ export function PlaylistFullToJSON(value?: PlaylistFull | null): any {
         'cover_art': value.coverArt,
         'cover_art_sizes': value.coverArtSizes,
         'cover_art_cids': PlaylistArtworkToJSON(value.coverArtCids),
-        'track_count': value.trackCount,
         'is_stream_gated': value.isStreamGated,
         'stream_conditions': AccessGateToJSON(value.streamConditions),
         'is_scheduled_release': value.isScheduledRelease,

--- a/packages/libs/src/sdk/api/generated/full/models/PlaylistFullWithoutTracks.ts
+++ b/packages/libs/src/sdk/api/generated/full/models/PlaylistFullWithoutTracks.ts
@@ -164,6 +164,12 @@ export interface PlaylistFullWithoutTracks {
      * @type {number}
      * @memberof PlaylistFullWithoutTracks
      */
+    trackCount: number;
+    /**
+     * 
+     * @type {number}
+     * @memberof PlaylistFullWithoutTracks
+     */
     blocknumber: number;
     /**
      * 
@@ -251,12 +257,6 @@ export interface PlaylistFullWithoutTracks {
     coverArtCids?: PlaylistArtwork;
     /**
      * 
-     * @type {number}
-     * @memberof PlaylistFullWithoutTracks
-     */
-    trackCount: number;
-    /**
-     * 
      * @type {boolean}
      * @memberof PlaylistFullWithoutTracks
      */
@@ -295,6 +295,7 @@ export function instanceOfPlaylistFullWithoutTracks(value: object): value is Pla
     isInstance = isInstance && "favoriteCount" in value && value["favoriteCount"] !== undefined;
     isInstance = isInstance && "totalPlayCount" in value && value["totalPlayCount"] !== undefined;
     isInstance = isInstance && "user" in value && value["user"] !== undefined;
+    isInstance = isInstance && "trackCount" in value && value["trackCount"] !== undefined;
     isInstance = isInstance && "blocknumber" in value && value["blocknumber"] !== undefined;
     isInstance = isInstance && "followeeReposts" in value && value["followeeReposts"] !== undefined;
     isInstance = isInstance && "followeeFavorites" in value && value["followeeFavorites"] !== undefined;
@@ -304,7 +305,6 @@ export function instanceOfPlaylistFullWithoutTracks(value: object): value is Pla
     isInstance = isInstance && "isPrivate" in value && value["isPrivate"] !== undefined;
     isInstance = isInstance && "addedTimestamps" in value && value["addedTimestamps"] !== undefined;
     isInstance = isInstance && "userId" in value && value["userId"] !== undefined;
-    isInstance = isInstance && "trackCount" in value && value["trackCount"] !== undefined;
     isInstance = isInstance && "isStreamGated" in value && value["isStreamGated"] !== undefined;
 
     return isInstance;
@@ -335,6 +335,7 @@ export function PlaylistFullWithoutTracksFromJSONTyped(json: any, ignoreDiscrimi
         'ddexApp': !exists(json, 'ddex_app') ? undefined : json['ddex_app'],
         'access': !exists(json, 'access') ? undefined : AccessFromJSON(json['access']),
         'upc': !exists(json, 'upc') ? undefined : json['upc'],
+        'trackCount': json['track_count'],
         'blocknumber': json['blocknumber'],
         'createdAt': !exists(json, 'created_at') ? undefined : json['created_at'],
         'followeeReposts': ((json['followee_reposts'] as Array<any>).map(RepostFromJSON)),
@@ -350,7 +351,6 @@ export function PlaylistFullWithoutTracksFromJSONTyped(json: any, ignoreDiscrimi
         'coverArt': !exists(json, 'cover_art') ? undefined : json['cover_art'],
         'coverArtSizes': !exists(json, 'cover_art_sizes') ? undefined : json['cover_art_sizes'],
         'coverArtCids': !exists(json, 'cover_art_cids') ? undefined : PlaylistArtworkFromJSON(json['cover_art_cids']),
-        'trackCount': json['track_count'],
         'isStreamGated': json['is_stream_gated'],
         'streamConditions': !exists(json, 'stream_conditions') ? undefined : AccessGateFromJSON(json['stream_conditions']),
         'isScheduledRelease': !exists(json, 'is_scheduled_release') ? undefined : json['is_scheduled_release'],
@@ -382,6 +382,7 @@ export function PlaylistFullWithoutTracksToJSON(value?: PlaylistFullWithoutTrack
         'ddex_app': value.ddexApp,
         'access': AccessToJSON(value.access),
         'upc': value.upc,
+        'track_count': value.trackCount,
         'blocknumber': value.blocknumber,
         'created_at': value.createdAt,
         'followee_reposts': ((value.followeeReposts as Array<any>).map(RepostToJSON)),
@@ -397,7 +398,6 @@ export function PlaylistFullWithoutTracksToJSON(value?: PlaylistFullWithoutTrack
         'cover_art': value.coverArt,
         'cover_art_sizes': value.coverArtSizes,
         'cover_art_cids': PlaylistArtworkToJSON(value.coverArtCids),
-        'track_count': value.trackCount,
         'is_stream_gated': value.isStreamGated,
         'stream_conditions': AccessGateToJSON(value.streamConditions),
         'is_scheduled_release': value.isScheduledRelease,

--- a/packages/libs/src/sdk/api/grants/GrantsApi.ts
+++ b/packages/libs/src/sdk/api/grants/GrantsApi.ts
@@ -9,8 +9,6 @@ import {
   ApproveGrantRequest,
   AddManagerRequest,
   AddManagerSchema,
-  RejectGrantRequest,
-  RejectGrantSchema,
   CreateGrantRequest,
   CreateGrantSchema,
   RevokeGrantRequest,
@@ -157,27 +155,6 @@ export class GrantsApi {
       entityType: EntityType.GRANT,
       entityId: 0,
       action: Action.APPROVE,
-      metadata: JSON.stringify({
-        grantor_user_id: grantorUserId
-      }),
-      auth: this.auth
-    })
-  }
-
-  /**
-   * Reject manager request
-   */
-  async rejectGrant(params: RejectGrantRequest) {
-    const { userId, grantorUserId } = await parseParams(
-      'rejectGrant',
-      RejectGrantSchema
-    )(params)
-
-    return await this.entityManager.manageEntity({
-      userId,
-      entityType: EntityType.GRANT,
-      entityId: 0,
-      action: Action.REJECT,
       metadata: JSON.stringify({
         grantor_user_id: grantorUserId
       }),

--- a/packages/libs/src/sdk/api/grants/types.ts
+++ b/packages/libs/src/sdk/api/grants/types.ts
@@ -41,10 +41,3 @@ export const ApproveGrantSchema = z.object({
 })
 
 export type ApproveGrantRequest = z.input<typeof ApproveGrantSchema>
-
-export const RejectGrantSchema = z.object({
-  userId: HashId,
-  grantorUserId: HashId
-})
-
-export type RejectGrantRequest = z.input<typeof RejectGrantSchema>


### PR DESCRIPTION
### Description
This adds some basic filtering to the managers endpoints, allowing query parameters for `is_approved` and `is_revoked`. Note that the default behavior of these endpoints is a little particular. By default, the values are `is_approved=null` and `is_revoked=false`, which will return all non-revoked grants (i.e. both approved and pending requests). And if you wanted to filter it down to only approved grants, you would just do `?is_approved=true`. 

It's not actually possible to pass `is_revoked=null` to fetch all grants regardless of revocation status. But this is an edge case that isn't worth the effort to implement. The end result is that getting the full set of all grants will be two requests.
Some other related changes:
* Updated  GrantsApi to remove the `rejectGrant` call. During development, we decided that removing/revoking was functionally equivalent and we don't need the additional call or state variables.
* Updated `audius-cmd` to support all parts of the manager mode flow. Note the `reject-manager-request` command is an alias for `remove-manager` with the from/to values reversed. This is just a convenience function.
* Updated the entity manager indexing to set `is_revoked=False` when creating grants. This is also enforced by the table definition in SQL, but doesn't hurt to make it explicit
* Set `is_revoked=True` when processing the `REJECT` action. While we don't use this in SDK, it was implemented and we may want to use it later on, so making sure we maintain correct compatibility

### How Has This Been Tested?
Used audius-cmd against local stack to simulate combinations of accounts in various states and then cURLed with combinations of the filter flags to make sure we return the correct values.
