### PR TITLE
Fix needsRecoveryEmail flag and add emails to sendgrid contacts

### DIFF
--- a/packages/identity-service/src/app.js
+++ b/packages/identity-service/src/app.js
@@ -2,6 +2,7 @@ const express = require('express')
 const bodyParser = require('body-parser')
 const cookieParser = require('cookie-parser')
 const sgMail = require('@sendgrid/mail')
+const sgClient = require('@sendgrid/client')
 const { redisClient, Lock } = require('./redis')
 const { createFpClient } = require('./fpClient')
 const optimizelySDK = require('@optimizely/optimizely-sdk')
@@ -174,8 +175,13 @@ class App {
     // Configure sendgrid instance
     if (config.get('sendgridApiKey')) {
       sgMail.setApiKey(config.get('sendgridApiKey'))
+      sgClient.setApiKey(config.get('sendgridApiKey'))
     }
     this.express.set('sendgrid', config.get('sendgridApiKey') ? sgMail : null)
+    this.express.set(
+      'sendgridClient',
+      config.get('sendgridApiKey') ? sgClient : null
+    )
   }
 
   configureSentry() {

--- a/packages/identity-service/src/routes/recovery.js
+++ b/packages/identity-service/src/routes/recovery.js
@@ -108,12 +108,15 @@ module.exports = function (app) {
       }
       try {
         await sg.send(emailParams)
-        await models.UserEvents.update(
-          { needsRecoveryEmail: false },
+        await models.UserEvents.upsert(
           {
-            where: {
-              walletAddress: walletFromSignature
-            }
+            walletAddress: walletFromSignature,
+            needsRecoveryEmail: false,
+            createdAt: new Date(),
+            updatedAt: new Date()
+          },
+          {
+            where: { walletAddress: walletFromSignature }
           }
         )
         return successResponse({ status: true })

--- a/packages/identity-service/src/routes/welcomeEmail.js
+++ b/packages/identity-service/src/routes/welcomeEmail.js
@@ -13,6 +13,7 @@ const { getWelcomeEmail } = require('../notifications/emails/welcome')
 require('@audius/sdk')
 const axios = require('axios')
 const audiusLibsWrapper = require('../audiusLibsInstance')
+const config = require('../config.js')
 
 module.exports = function (app) {
   /**
@@ -101,6 +102,19 @@ module.exports = function (app) {
             }
           }
         )
+        if (config.get('environment') === 'production') {
+          // Add email to SendGrid contacts
+          const sgClient = req.app.get('sendgridClient')
+          const addContactRequest = {
+            method: 'PUT',
+            url: '/v3/marketing/contacts',
+            body: {
+              contacts: [{ email: existingUser.email }]
+            }
+          }
+
+          await sgClient.request(addContactRequest)
+        }
 
         return successResponse({ status: true })
       } catch (e) {


### PR DESCRIPTION
### Description
* needsRecoveryEmail in UserEvents is always null on sign up because recovery is what creates the UserEvents row and it's missing fields. changing it to upsert makes it reliable.
* Add email to sendgrid contacts on sign up.

Fixes C-4525.
Fixes QA-1420.
### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._

Ran on staging. Confirmed needsRecoveryEmail is false on sign up and email gets added to sendgrid contacts.
