### PR TITLE
[C-4714] Disallow share/add to playlist for hidden tracks

### DIFF
--- a/packages/mobile/src/components/track-list/TrackListItem.tsx
+++ b/packages/mobile/src/components/track-list/TrackListItem.tsx
@@ -216,7 +216,7 @@ const TrackListItemComponent = (props: TrackListItemComponentProps) => {
     has_current_user_saved,
     has_current_user_reposted,
     is_delete,
-    is_unlisted,
+    is_unlisted: isUnlisted,
     title,
     track_id,
     owner_id,
@@ -226,7 +226,6 @@ const TrackListItemComponent = (props: TrackListItemComponentProps) => {
   const { is_deactivated, name } = user
 
   const isDeleted = is_delete || !!is_deactivated
-  const isUnlisted = is_unlisted
 
   const { isFetchingNFTAccess, hasStreamAccess } = useGatedContentAccess(track)
   const isLocked = !isFetchingNFTAccess && !hasStreamAccess
@@ -288,7 +287,7 @@ const TrackListItemComponent = (props: TrackListItemComponentProps) => {
 
   const handleOpenOverflowMenu = useCallback(() => {
     const overflowActions = [
-      OverflowAction.SHARE,
+      !isUnlisted || isTrackOwner ? OverflowAction.SHARE : null,
       !isTrackOwner && !isLocked && !isUnlisted
         ? has_current_user_saved
           ? OverflowAction.UNFAVORITE
@@ -303,7 +302,7 @@ const TrackListItemComponent = (props: TrackListItemComponentProps) => {
         ? OverflowAction.PURCHASE_TRACK
         : null,
       isTrackOwner && !ddexApp ? OverflowAction.ADD_TO_ALBUM : null,
-      OverflowAction.ADD_TO_PLAYLIST,
+      !isUnlisted || isTrackOwner ? OverflowAction.ADD_TO_PLAYLIST : null,
       isNewPodcastControlsEnabled && isLongFormContent
         ? OverflowAction.VIEW_EPISODE_PAGE
         : OverflowAction.VIEW_TRACK_PAGE,

--- a/packages/web/src/components/table/components/OverflowMenuButton.tsx
+++ b/packages/web/src/components/table/components/OverflowMenuButton.tsx
@@ -46,7 +46,6 @@ export const OverflowMenuButton = (props: OverflowMenuButtonProps) => {
     type: 'track' as const,
     mount: 'page',
     includeEdit,
-    includeShare: true,
     extraMenuItems: onRemove ? [removeMenuItem] : []
   }
 

--- a/packages/web/src/components/tracks-table/TracksTable.tsx
+++ b/packages/web/src/components/tracks-table/TracksTable.tsx
@@ -385,7 +385,8 @@ export const TracksTable = ({
       const track = cellInfo.row.original
       const {
         stream_conditions: streamConditions,
-        is_stream_gated: isStreamGated
+        is_stream_gated: isStreamGated,
+        is_unlisted: isUnlisted
       } = track
       const { isFetchingNFTAccess, hasStreamAccess } = trackAccessMap[
         track.track_id
@@ -418,7 +419,7 @@ export const TracksTable = ({
         className: styles.tableActionButton,
         isDeleted: deleted,
         includeAlbumPage: !isAlbumPage,
-        includeFavorite: !isLocked && !track.is_unlisted,
+        includeFavorite: !isLocked && !isUnlisted,
         handle: track.handle,
         trackId: track.track_id,
         uid: track.uid,
@@ -438,10 +439,14 @@ export const TracksTable = ({
             includeAddToAlbum: false
           }
         : {
+            includeShare: !isUnlisted,
+            includeEmbed: !isUnlisted,
             includeEdit: !disabledTrackEdit,
             includeAddToPlaylist:
-              !isStreamGated ||
-              (isContentUSDCPurchaseGated(streamConditions) && hasStreamAccess),
+              !isUnlisted &&
+              (!isStreamGated ||
+                (isContentUSDCPurchaseGated(streamConditions) &&
+                  hasStreamAccess)),
             onRemove: onClickRemove,
             removeText
           }

--- a/packages/web/src/components/tracks-table/TracksTable.tsx
+++ b/packages/web/src/components/tracks-table/TracksTable.tsx
@@ -391,6 +391,7 @@ export const TracksTable = ({
       const { isFetchingNFTAccess, hasStreamAccess } = trackAccessMap[
         track.track_id
       ] ?? { isFetchingNFTAccess: false, hasStreamAccess: true }
+      const isOwner = track.owner_id === userId
       const isLocked = !isFetchingNFTAccess && !hasStreamAccess
       const isDdex = !!track.ddex_app
       const deleted =
@@ -425,7 +426,7 @@ export const TracksTable = ({
         uid: track.uid,
         date: track.date,
         isFavorited: track.has_current_user_saved,
-        isOwner: track.owner_id === userId,
+        isOwner,
         isOwnerDeactivated: !!track.user?.is_deactivated,
         isArtistPick: track.user?.artist_pick_track_id === track.track_id,
         index: cellInfo.row.index,
@@ -439,7 +440,7 @@ export const TracksTable = ({
             includeAddToAlbum: false
           }
         : {
-            includeShare: !isUnlisted,
+            includeShare: !isUnlisted || isOwner,
             includeEmbed: !isUnlisted,
             includeEdit: !disabledTrackEdit,
             includeAddToPlaylist:


### PR DESCRIPTION
### Description
Never allow share and add to playlist options for hidden tracks, unless you're the track owner.

We'd overlooked the overflow menu in the tracks table inside the collection page.

### How Has This Been Tested?

public:
<img width="1920" alt="Screenshot 2024-07-12 at 2 59 23 PM" src="https://github.com/user-attachments/assets/15151512-34c1-408c-8f30-18348a179e8a">
hidden:
<img width="1920" alt="Screenshot 2024-07-12 at 2 59 37 PM" src="https://github.com/user-attachments/assets/403e6790-3b75-4967-9790-ceb21e25a804">
owner:
<img width="1920" alt="Screenshot 2024-07-12 at 3 16 59 PM" src="https://github.com/user-attachments/assets/556481f8-4f89-4972-a03a-7f81b08d3469">

public:
<img width='80%' src='https://github.com/user-attachments/assets/c802f98f-dd68-4bc3-8e22-031ec1000f4b'>
hidden:
<img width='80%' src='https://github.com/user-attachments/assets/da2cf800-3913-4553-a39b-e010efd867fb'>
owner:
<img width='80%' src='https://github.com/user-attachments/assets/c2a7363b-b4d6-495f-a804-1a9eb1265747'>

