### PR TITLE
[C-4646] Fix stream_conditions optimistic update on track edit

### DIFF
--- a/packages/common/src/store/cache/reducer.ts
+++ b/packages/common/src/store/cache/reducer.ts
@@ -124,6 +124,10 @@ export const mergeCustomizer = (objValue: any, srcValue: any, key: string) => {
     return srcValue || objValue
   }
 
+  if (key === 'stream_conditions' || key === 'download_conditions') {
+    return srcValue || objValue
+  }
+
   // For playlist_contents, this is trickier.
   // We want to never merge because playlists can have
   // tracks be deleted since last time, but


### PR DESCRIPTION
### Description
On the cache entity update, `lodash` `mergeWith` was giving us `stream_conditions` that looked like:
```
stream_conditions: {
    follow_user_id: x,
    usdc_purchase: { xyz}
}
```
and ended up just accepting the first member again. We needed to special-case this to only take the new value.

### How Has This Been Tested?


https://github.com/user-attachments/assets/aa2daab2-7100-4e64-8a0f-82bb9e3acc0b

