### PR TITLE
Allow gated content to be added to playlist

### DIFF
--- a/packages/mobile/src/components/lineup-tile/TrackTile.tsx
+++ b/packages/mobile/src/components/lineup-tile/TrackTile.tsx
@@ -112,7 +112,8 @@ export const TrackTileComponent = ({
     genre,
     stream_conditions: streamConditions,
     preview_cid,
-    ddex_app: ddexApp
+    ddex_app: ddexApp,
+    is_unlisted: isUnlisted
   } = track
 
   const hasPreview =
@@ -158,7 +159,7 @@ export const TrackTileComponent = ({
 
     const overflowActions = [
       isOwner && !ddexApp ? OverflowAction.ADD_TO_ALBUM : null,
-      OverflowAction.ADD_TO_PLAYLIST,
+      !isUnlisted || isOwner ? OverflowAction.ADD_TO_PLAYLIST : null,
       isLongFormContent
         ? OverflowAction.VIEW_EPISODE_PAGE
         : OverflowAction.VIEW_TRACK_PAGE,

--- a/packages/mobile/src/components/now-playing-drawer/ActionsBar.tsx
+++ b/packages/mobile/src/components/now-playing-drawer/ActionsBar.tsx
@@ -112,6 +112,7 @@ export const ActionsBar = ({ track }: ActionsBarProps) => {
   const isReachable = useSelector(getIsReachable)
 
   const isOwner = track?.owner_id === accountUser?.user_id
+  const isUnlisted = track?.is_unlisted
   const { onOpen: openPremiumContentPurchaseModal } =
     usePremiumContentPurchaseModal()
 
@@ -191,7 +192,7 @@ export const ActionsBar = ({ track }: ActionsBarProps) => {
         track.genre === Genre.PODCASTS || track.genre === Genre.AUDIOBOOKS
       const overflowActions = [
         isOwner && !track?.ddex_app ? OverflowAction.ADD_TO_ALBUM : null,
-        OverflowAction.ADD_TO_PLAYLIST,
+        !isUnlisted || isOwner ? OverflowAction.ADD_TO_PLAYLIST : null,
         isLongFormContent
           ? OverflowAction.VIEW_EPISODE_PAGE
           : OverflowAction.VIEW_TRACK_PAGE,

--- a/packages/mobile/src/components/track-list/TrackListItem.tsx
+++ b/packages/mobile/src/components/track-list/TrackListItem.tsx
@@ -264,11 +264,6 @@ const TrackListItemComponent = (props: TrackListItemComponentProps) => {
     }
   }
 
-  const { isEnabled: isNewPodcastControlsEnabled } = useFeatureFlag(
-    FeatureFlags.PODCAST_CONTROL_UPDATES_ENABLED,
-    FeatureFlags.PODCAST_CONTROL_UPDATES_ENABLED_FALLBACK
-  )
-
   const currentUserId = useSelector(getUserId)
   const isTrackOwner = currentUserId && currentUserId === owner_id
   const isContextPlaylistOwner =
@@ -303,11 +298,11 @@ const TrackListItemComponent = (props: TrackListItemComponentProps) => {
         : null,
       isTrackOwner && !ddexApp ? OverflowAction.ADD_TO_ALBUM : null,
       !isUnlisted || isTrackOwner ? OverflowAction.ADD_TO_PLAYLIST : null,
-      isNewPodcastControlsEnabled && isLongFormContent
+      isLongFormContent
         ? OverflowAction.VIEW_EPISODE_PAGE
         : OverflowAction.VIEW_TRACK_PAGE,
       !showViewAlbum && albumInfo ? OverflowAction.VIEW_ALBUM_PAGE : null,
-      isNewPodcastControlsEnabled && isLongFormContent
+      isLongFormContent
         ? playbackPositionInfo?.status === 'COMPLETED'
           ? OverflowAction.MARK_AS_UNPLAYED
           : OverflowAction.MARK_AS_PLAYED
@@ -333,7 +328,6 @@ const TrackListItemComponent = (props: TrackListItemComponentProps) => {
     has_current_user_reposted,
     isDeleted,
     ddexApp,
-    isNewPodcastControlsEnabled,
     isLongFormContent,
     showViewAlbum,
     albumInfo,

--- a/packages/mobile/src/components/track-list/TrackListItem.tsx
+++ b/packages/mobile/src/components/track-list/TrackListItem.tsx
@@ -10,7 +10,6 @@ import {
   type User,
   isContentUSDCPurchaseGated
 } from '@audius/common/models'
-import { FeatureFlags } from '@audius/common/services'
 import {
   accountSelectors,
   cacheCollectionsSelectors,
@@ -43,7 +42,6 @@ import {
   IconRemove
 } from '@audius/harmony-native'
 import UserBadges from 'app/components/user-badges'
-import { useFeatureFlag } from 'app/hooks/useRemoteConfig'
 import { flexRowCentered, font, makeStyles } from 'app/styles'
 
 import { TrackDownloadStatusIndicator } from '../offline-downloads/TrackDownloadStatusIndicator'

--- a/packages/mobile/src/screens/track-screen/TrackScreenDetailsTile.tsx
+++ b/packages/mobile/src/screens/track-screen/TrackScreenDetailsTile.tsx
@@ -379,7 +379,7 @@ export const TrackScreenDetailsTile = ({
       isOwner && !ddexApp ? OverflowAction.ADD_TO_ALBUM : null
     const overflowActions = [
       addToAlbumAction,
-      OverflowAction.ADD_TO_PLAYLIST,
+      !isUnlisted || isOwner ? OverflowAction.ADD_TO_PLAYLIST : null,
       isOwner
         ? null
         : user.does_current_user_follow

--- a/packages/web/src/components/track/desktop/ConnectedTrackTile.tsx
+++ b/packages/web/src/components/track/desktop/ConnectedTrackTile.tsx
@@ -194,7 +194,7 @@ const ConnectedTrackTile = ({
     const menu: Omit<TrackMenuProps, 'children'> = {
       extraMenuItems: [],
       handle,
-      includeAddToPlaylist: !isPrivate || isOwner,
+      includeAddToPlaylist: !isUnlisted || isOwner,
       includeAddToAlbum: isOwner && !ddexApp,
       includeArtistPick: handle === userHandle && !isUnlisted,
       includeEdit: handle === userHandle,

--- a/packages/web/src/components/track/desktop/ConnectedTrackTile.tsx
+++ b/packages/web/src/components/track/desktop/ConnectedTrackTile.tsx
@@ -194,7 +194,7 @@ const ConnectedTrackTile = ({
     const menu: Omit<TrackMenuProps, 'children'> = {
       extraMenuItems: [],
       handle,
-      includeAddToPlaylist: true,
+      includeAddToPlaylist: !isPrivate || isOwner,
       includeAddToAlbum: isOwner && !ddexApp,
       includeArtistPick: handle === userHandle && !isUnlisted,
       includeEdit: handle === userHandle,

--- a/packages/web/src/components/track/desktop/TrackListItem.tsx
+++ b/packages/web/src/components/track/desktop/TrackListItem.tsx
@@ -63,6 +63,7 @@ const TrackListItem = ({
   const menuRef = useRef<HTMLDivElement>(null)
   const { data: currentUserId } = useGetCurrentUserId({})
   const isOwner = track?.owner_id === currentUserId
+  const isPrivate = track?.is_unlisted
   const isPremium = isContentUSDCPurchaseGated(track?.stream_conditions)
   const { hasStreamAccess } = useGatedContentAccess(track as Track)
 
@@ -122,7 +123,7 @@ const TrackListItem = ({
 
   const menu: Omit<TrackMenuProps, 'children'> = {
     handle: track.user.handle,
-    includeAddToPlaylist: true,
+    includeAddToPlaylist: !isPrivate || isOwner,
     includeAddToAlbum: isOwner && !track?.ddex_app,
     includeArtistPick: false,
     includeEdit: false,

--- a/packages/web/src/components/tracks-table/TracksTable.tsx
+++ b/packages/web/src/components/tracks-table/TracksTable.tsx
@@ -443,11 +443,7 @@ export const TracksTable = ({
             includeShare: !isUnlisted || isOwner,
             includeEmbed: !isUnlisted,
             includeEdit: !disabledTrackEdit,
-            includeAddToPlaylist:
-              !isUnlisted &&
-              (!isStreamGated ||
-                (isContentUSDCPurchaseGated(streamConditions) &&
-                  hasStreamAccess)),
+            includeAddToPlaylist: !isUnlisted || isOwner,
             onRemove: onClickRemove,
             removeText
           }

--- a/packages/web/src/components/tracks-table/TracksTable.tsx
+++ b/packages/web/src/components/tracks-table/TracksTable.tsx
@@ -383,11 +383,8 @@ export const TracksTable = ({
   const renderOverflowMenuCell = useCallback(
     (cellInfo: TrackCell) => {
       const track = cellInfo.row.original
-      const {
-        stream_conditions: streamConditions,
-        is_stream_gated: isStreamGated,
-        is_unlisted: isUnlisted
-      } = track
+      const { stream_conditions: streamConditions, is_unlisted: isUnlisted } =
+        track
       const { isFetchingNFTAccess, hasStreamAccess } = trackAccessMap[
         track.track_id
       ] ?? { isFetchingNFTAccess: false, hasStreamAccess: true }


### PR DESCRIPTION
### Description
Spoke offline with design and confirmed we should now allow all gated content to be playlist-addable, even if it's locked.

Sliding in a feature flag cleanup while I was checking mobile allows this.

### How Has This Been Tested?


<img width="1099" alt="Screenshot 2024-07-12 at 9 24 03 PM" src="https://github.com/user-attachments/assets/02b6270d-68a1-4a16-bc55-210912c39ef3">
