### PR TITLE
[PAY-3160] Try other tables for txhash if users table doesn't work.

### DIFF
--- a/comms/DockerfileFast
+++ b/comms/DockerfileFast
@@ -30,4 +30,4 @@ COPY --from=builder /go/bin/* /bin
 COPY ./build/comms-amd64 /bin/comms
 
 VOLUME ["/tmp"]
-ENTRYPOINT ["comms"]
+ENTRYPOINT ["comms", "discovery"]


### PR DESCRIPTION
### Description

Initially was thinking we could query eth directly, but since there is still a relay step, the outer tx is not actually signed by user's wallet.

So try other tables to find a txhash that is signed by user.

### How Has This Been Tested?

Deployed to sandbox, modified users txhash + cleared cache + tested with affected user's pubkey.
