### PR TITLE
[C-4771] Hide stats in TracksTable for hidden tracks

### DIFF
--- a/packages/web/src/components/tracks-table/TracksTable.tsx
+++ b/packages/web/src/components/tracks-table/TracksTable.tsx
@@ -249,14 +249,12 @@ export const TracksTable = ({
   const renderPlaysCell = useCallback(
     (cellInfo: TrackCell) => {
       const track = cellInfo.row.original
-      const { plays } = track
       const isOwner = track.owner_id === userId
-      // negative plays indicates the track is hidden
-      if (plays === -1) return '-'
       if (
-        track.is_stream_gated &&
-        isContentUSDCPurchaseGated(track.stream_conditions) &&
-        !isOwner
+        !isOwner &&
+        ((track.is_stream_gated &&
+          isContentUSDCPurchaseGated(track.stream_conditions)) ||
+          track.is_unlisted)
       )
         return null
       return formatCount(track.plays)
@@ -266,8 +264,9 @@ export const TracksTable = ({
 
   const renderRepostsCell = useCallback((cellInfo: TrackCell) => {
     const track = cellInfo.row.original
-    const { is_unlisted: isUnlisted } = track
-    if (isUnlisted) return null
+    const { is_unlisted: isUnlisted, owner_id: ownerId } = track
+    const isOwner = ownerId === userId
+    if (isUnlisted && !isOwner) return null
     return formatCount(track.repost_count)
   }, [])
 
@@ -293,6 +292,9 @@ export const TracksTable = ({
 
   const renderSavesCell = useCallback((cellInfo: TrackCell) => {
     const track = cellInfo.row.original
+    const { is_unlisted: isUnlisted, owner_id: ownerId } = track
+    const isOwner = ownerId === userId
+    if (isUnlisted && !isOwner) return null
     return formatCount(track.save_count)
   }, [])
 

--- a/packages/web/src/components/tracks-table/TracksTable.tsx
+++ b/packages/web/src/components/tracks-table/TracksTable.tsx
@@ -266,6 +266,8 @@ export const TracksTable = ({
 
   const renderRepostsCell = useCallback((cellInfo: TrackCell) => {
     const track = cellInfo.row.original
+    const { is_unlisted: isUnlisted } = track
+    if (isUnlisted) return null
     return formatCount(track.repost_count)
   }, [])
 


### PR DESCRIPTION
### Description
Hide plays, saves, reposts counts for hidden tracks

### How Has This Been Tested?

non-owner
<img width="785" alt="Screenshot 2024-07-15 at 12 37 31 PM" src="https://github.com/user-attachments/assets/447bb6a5-9432-400a-8617-c9239076a7ab">
owner
<img width="797" alt="Screenshot 2024-07-15 at 12 37 41 PM" src="https://github.com/user-attachments/assets/a3581ced-877c-48bd-8fe3-14ad790d1b8e">
library (has both hidden and purchase-gated)
<img width="1151" alt="Screenshot 2024-07-15 at 1 41 16 PM" src="https://github.com/user-attachments/assets/4f17b117-cfae-44c3-8ee9-70b25fb2e55c">
