### PR TITLE
Filter out searchv2 history items for search v1

### DIFF
--- a/packages/common/src/store/search/selectors.ts
+++ b/packages/common/src/store/search/selectors.ts
@@ -7,7 +7,7 @@ import { isSearchItem } from './slice'
 const getBaseState = (state: CommonState) => state.search
 
 export const getSearchHistory = (state: CommonState) =>
-  getBaseState(state).history
+  getBaseState(state).history.filter((item) => !isSearchItem(item))
 
 export const getV2SearchHistory = createSelector(getSearchHistory, (history) =>
   history.filter(isSearchItem)


### PR DESCRIPTION
### Description

This was causing a crash for users who had Search V2 enabled, populated their recent searches, and then went back to search v1

### How Has This Been Tested?

Both search v1 and v2 work
