### PR TITLE
Fix account playlists entering cache and caching of currentWeb3User

### DIFF
--- a/packages/common/src/api/account.ts
+++ b/packages/common/src/api/account.ts
@@ -42,9 +42,6 @@ const accountApi = createApi({
     getCurrentWeb3User: {
       async fetch(_, { audiusBackend }) {
         const libs = await audiusBackend.getAudiusLibsTyped()
-        // TODO: https://linear.app/audius/issue/PAY-2838/separate-walletentropy-user-and-current-user-in-state
-        // What happens in the cache if something here is null?
-
         return libs.Account?.getWeb3User() as UserMetadata | null
       },
       options: {

--- a/packages/common/src/api/account.ts
+++ b/packages/common/src/api/account.ts
@@ -48,10 +48,8 @@ const accountApi = createApi({
         return libs.Account?.getWeb3User() as UserMetadata | null
       },
       options: {
-        type: 'query'
-        // TODO: Cannot cache the response from this unless we fully decorate it
-        // https://linear.app/audius/issue/PAY-3066/getcurrentweb3user-breaks-decorated-account-info
-        // schemaKey: 'currentWeb3User'
+        type: 'query',
+        schemaKey: 'currentWeb3User'
       }
     },
     resetPassword: {

--- a/packages/common/src/api/account.ts
+++ b/packages/common/src/api/account.ts
@@ -49,6 +49,8 @@ const accountApi = createApi({
       },
       options: {
         type: 'query',
+        // Note that this schema key is used to prevent caching of the
+        // web3 user as it does not match the standard user schema.
         schemaKey: 'currentWeb3User'
       }
     },

--- a/packages/common/src/audius-query/schema.ts
+++ b/packages/common/src/audius-query/schema.ts
@@ -10,6 +10,8 @@ export const userSchema = new schema.Entity(
   { idAttribute: 'user_id' }
 )
 
+// export const web3UserSchema = new schema.Object({})
+
 export const trackSchema = new schema.Entity(
   Kind.TRACKS,
   { user: userSchema },
@@ -31,7 +33,7 @@ export const userManagerSchema = new schema.Object({
 })
 
 export const schemas = {
-  currentWeb3User: userSchema,
+  // currentWeb3User: web3UserSchema,
   managedUsers: new schema.Array(managedUserSchema),
   user: userSchema,
   userManagers: new schema.Array(userManagerSchema),

--- a/packages/common/src/audius-query/schema.ts
+++ b/packages/common/src/audius-query/schema.ts
@@ -10,8 +10,6 @@ export const userSchema = new schema.Entity(
   { idAttribute: 'user_id' }
 )
 
-// export const web3UserSchema = new schema.Object({})
-
 export const trackSchema = new schema.Entity(
   Kind.TRACKS,
   { user: userSchema },
@@ -33,7 +31,6 @@ export const userManagerSchema = new schema.Object({
 })
 
 export const schemas = {
-  // currentWeb3User: web3UserSchema,
   managedUsers: new schema.Array(managedUserSchema),
   user: userSchema,
   userManagers: new schema.Array(userManagerSchema),

--- a/packages/common/src/store/cache/collections/reducer.ts
+++ b/packages/common/src/store/cache/collections/reducer.ts
@@ -24,8 +24,7 @@ const addEntries = (state: CollectionsCacheState, entries: any[]) => {
   // Add uids to track info in playlist_contents
   // This allows collection tiles to be played when uid would not normally be present
   entries.forEach((entry) => {
-    console.log('collection fetch', entry.metadata, entry.metadata.playlist_name, entry.metadata.playlist_contents)
-    // if (entry.metadata.playlist_contents) {
+    if (entry.metadata.playlist_contents) {
       entry.metadata.playlist_contents.track_ids.forEach(
         (track: PlaylistTrackId) => {
           if (!track.uid) {
@@ -37,7 +36,7 @@ const addEntries = (state: CollectionsCacheState, entries: any[]) => {
           }
         }
       )
-    // }
+    }
   })
 
   for (const entry of entries) {

--- a/packages/common/src/store/cache/collections/reducer.ts
+++ b/packages/common/src/store/cache/collections/reducer.ts
@@ -24,19 +24,17 @@ const addEntries = (state: CollectionsCacheState, entries: any[]) => {
   // Add uids to track info in playlist_contents
   // This allows collection tiles to be played when uid would not normally be present
   entries.forEach((entry) => {
-    if (entry.metadata.playlist_contents) {
-      entry.metadata.playlist_contents.track_ids.forEach(
-        (track: PlaylistTrackId) => {
-          if (!track.uid) {
-            track.uid = makeUid(
-              Kind.TRACKS,
-              track.track,
-              `collection:${entry.metadata.playlist_id}`
-            )
-          }
+    entry.metadata.playlist_contents.track_ids.forEach(
+      (track: PlaylistTrackId) => {
+        if (!track.uid) {
+          track.uid = makeUid(
+            Kind.TRACKS,
+            track.track,
+            `collection:${entry.metadata.playlist_id}`
+          )
         }
-      )
-    }
+      }
+    )
   })
 
   for (const entry of entries) {

--- a/packages/common/src/store/cache/collections/reducer.ts
+++ b/packages/common/src/store/cache/collections/reducer.ts
@@ -24,17 +24,20 @@ const addEntries = (state: CollectionsCacheState, entries: any[]) => {
   // Add uids to track info in playlist_contents
   // This allows collection tiles to be played when uid would not normally be present
   entries.forEach((entry) => {
-    entry.metadata.playlist_contents.track_ids.forEach(
-      (track: PlaylistTrackId) => {
-        if (!track.uid) {
-          track.uid = makeUid(
-            Kind.TRACKS,
-            track.track,
-            `collection:${entry.metadata.playlist_id}`
-          )
+    console.log('collection fetch', entry.metadata, entry.metadata.playlist_name, entry.metadata.playlist_contents)
+    // if (entry.metadata.playlist_contents) {
+      entry.metadata.playlist_contents.track_ids.forEach(
+        (track: PlaylistTrackId) => {
+          if (!track.uid) {
+            track.uid = makeUid(
+              Kind.TRACKS,
+              track.track,
+              `collection:${entry.metadata.playlist_id}`
+            )
+          }
         }
-      }
-    )
+      )
+    // }
   })
 
   for (const entry of entries) {


### PR DESCRIPTION
### Description

Currently the `currentWeb3User` gets cached as a top level schema and the playlists under it get matched to the playlist schema. Because they are stubs, they don't get cached properly and prevent the web3 user from being cached.

The symptom of this is the account switcher doesn't load.

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._

Account switcher now loads