### PR TITLE
drop old audio analyses ops

### DIFF
--- a/mediorum/ddl/ddl.go
+++ b/mediorum/ddl/ddl.go
@@ -19,6 +19,9 @@ var addDelistReasonsDDL string
 //go:embed drop_blobs.sql
 var dropBlobs string
 
+//go:embed drop_audio_analysis_ops.sql
+var dropAnalysisOpsDDL string
+
 var mediorumMigrationTable = `
 	create table if not exists mediorum_migrations (
 		"hash" text primary key,
@@ -39,6 +42,8 @@ func Migrate(db *sql.DB, myHost string) {
 	runMigration(db, addDelistReasonsDDL)
 
 	runMigration(db, dropBlobs)
+
+	runMigration(db, dropAnalysisOpsDDL)
 
 	runMigration(db, `create index if not exists uploads_ts_idx on uploads(created_at, transcoded_at)`)
 

--- a/mediorum/ddl/drop_audio_analysis_ops.sql
+++ b/mediorum/ddl/drop_audio_analysis_ops.sql
@@ -1,0 +1,5 @@
+begin;
+
+delete from ops where "table" = 'qm_audio_analyses';
+
+commit;


### PR DESCRIPTION
### Description
crudr storm ops still seem to be being processed. stale data is causing duplicate work and overwriting results. drop all the old ops and allow the simplified mediorum analysis repairer, which issues minimal crudr ops, to move forward.

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._
