### PR TITLE
[C-4778, C-4786] Update visibility change confirmation

### DIFF
--- a/packages/common/src/store/ui/edit-access-confirmation-modal/slice.ts
+++ b/packages/common/src/store/ui/edit-access-confirmation-modal/slice.ts
@@ -4,6 +4,7 @@ import { EditAccessConfirmationState, EditAccessType } from './types'
 
 export type OpenPayload = PayloadAction<{
   type: EditAccessType
+  isEarlyRelease?: boolean
   confirmCallback: () => void
   cancelCallback: () => void
 }>

--- a/packages/common/src/store/ui/edit-access-confirmation-modal/slice.ts
+++ b/packages/common/src/store/ui/edit-access-confirmation-modal/slice.ts
@@ -4,7 +4,6 @@ import { EditAccessConfirmationState, EditAccessType } from './types'
 
 export type OpenPayload = PayloadAction<{
   type: EditAccessType
-  isEarlyRelease?: boolean
   confirmCallback: () => void
   cancelCallback: () => void
 }>

--- a/packages/common/src/store/ui/edit-access-confirmation-modal/types.ts
+++ b/packages/common/src/store/ui/edit-access-confirmation-modal/types.ts
@@ -1,6 +1,6 @@
 import { Nullable } from '~/utils'
 
-export type EditAccessType = 'visibility' | 'audience'
+export type EditAccessType = 'audience' | 'release' | 'early_release' | 'hidden'
 
 export type EditAccessConfirmationState = {
   type: Nullable<EditAccessType>

--- a/packages/web/src/components/edit-access-confirmation-modal/EditAccessConfirmationModal.tsx
+++ b/packages/web/src/components/edit-access-confirmation-modal/EditAccessConfirmationModal.tsx
@@ -8,7 +8,6 @@ import {
   Modal,
   ModalContent,
   ModalHeader,
-  ModalTitle,
   ModalFooter,
   Button,
   Text,
@@ -26,6 +25,8 @@ const getMessages = (type: EditAccessType | null) => ({
   title:
     type === 'audience' || type === 'hidden'
       ? 'Confirm Update'
+      : type === 'early_release'
+      ? 'Confirm Early Release'
       : 'Confirm Release',
   description:
     type === 'audience'

--- a/packages/web/src/components/edit-access-confirmation-modal/EditAccessConfirmationModal.tsx
+++ b/packages/web/src/components/edit-access-confirmation-modal/EditAccessConfirmationModal.tsx
@@ -12,7 +12,8 @@ import {
   ModalFooter,
   Button,
   Text,
-  Flex
+  Flex,
+  IconRocket
 } from '@audius/harmony'
 
 import { useModalState } from 'common/hooks/useModalState'
@@ -21,24 +22,34 @@ import { useSelector } from 'common/hooks/useSelector'
 const { getType, getConfirmCallback, getCancelCallback } =
   editAccessConfirmationModalUISelectors
 
-const messages = {
-  title: 'Confirm Update',
-  description: (type: EditAccessType) => {
-    return type === 'visibility'
-      ? ''
-      : "You're about to change the audience for your content.  This update may cause others to lose the ability to listen and share."
-  },
+const getMessages = (type: EditAccessType | null) => ({
+  title:
+    type === 'audience' || type === 'hidden'
+      ? 'Confirm Update'
+      : 'Confirm Release',
+  description:
+    type === 'audience'
+      ? "You're about to change the audience for your content.  This update may cause others to lose the ability to listen and share."
+      : type === 'hidden'
+      ? "You're about to make your content hidden.  This update may cause others to lose the ability to listen and share."
+      : type === 'early_release'
+      ? 'Do you want to release your track now? Your followers will be notified.'
+      : 'Are you sure you want to make this track public? Your followers will be notified.',
   cancel: 'Cancel',
-  upload: (type: EditAccessType) => {
-    return type === 'visibility' ? 'Change Visibility' : 'Update Audience'
-  }
-}
+  upload:
+    type === 'audience'
+      ? 'Update Audience'
+      : type === 'release' || type === 'early_release'
+      ? 'Release Now'
+      : 'Hide Track'
+})
 
 export const EditAccessConfirmationModal = () => {
   const type = useSelector(getType)
   const confirmCallback = useSelector(getConfirmCallback)
   const cancelCallback = useSelector(getCancelCallback)
   const [isOpen, setIsOpen] = useModalState('EditAccessConfirmation')
+  const messages = getMessages(type)
 
   const onClose = useCallback(() => {
     setIsOpen(false)
@@ -59,12 +70,19 @@ export const EditAccessConfirmationModal = () => {
   return (
     <Modal isOpen={isOpen} onClose={onClose} size='small'>
       <ModalHeader>
-        <ModalTitle title={messages.title} />
+        <Flex alignSelf='center' gap='s'>
+          {type === 'release' || type === 'early_release' ? (
+            <IconRocket color='default' size='l' />
+          ) : null}
+          <Text variant='label' size='xl' strength='strong'>
+            {messages.title}
+          </Text>
+        </Flex>
       </ModalHeader>
       <ModalContent>
         <Flex justifyContent='center'>
           <Text variant='body' size='l' textAlign='center'>
-            {messages.description(type)}
+            {messages.description}
           </Text>
         </Flex>
       </ModalContent>
@@ -73,7 +91,7 @@ export const EditAccessConfirmationModal = () => {
           {messages.cancel}
         </Button>
         <Button variant='primary' fullWidth onClick={handleConfirm}>
-          {messages.upload(type)}
+          {messages.upload}
         </Button>
       </ModalFooter>
     </Modal>

--- a/packages/web/src/components/edit/fields/visibility/VisibilityField.tsx
+++ b/packages/web/src/components/edit/fields/visibility/VisibilityField.tsx
@@ -180,9 +180,9 @@ export const VisibilityField = (props: VisibilityFieldProps) => {
 
         const usersMayLoseAccess =
           !initiallyHidden && values.visibilityType !== 'public'
-        const willPublish =
+        const isToBePublished =
           initiallyHidden && values.visibilityType === 'public'
-        if (!isUpload && (usersMayLoseAccess || willPublish)) {
+        if (!isUpload && (usersMayLoseAccess || isToBePublished)) {
           dispatch(
             openEditAccessConfirmationModal({
               type: usersMayLoseAccess

--- a/packages/web/src/components/edit/fields/visibility/VisibilityField.tsx
+++ b/packages/web/src/components/edit/fields/visibility/VisibilityField.tsx
@@ -82,8 +82,11 @@ export const VisibilityField = (props: VisibilityFieldProps) => {
   const { isEnabled: isEditableAccessEnabled } = useFeatureFlag(
     FeatureFlags.EDITABLE_ACCESS_ENABLED
   )
-  const [{ value: isScheduledRelease }, , { setValue: setIsScheduledRelease }] =
-    useEntityField<boolean>(IS_SCHEDULED_RELEASE)
+  const [
+    { value: isScheduledRelease },
+    { initialValue: isInitiallyScheduled },
+    { setValue: setIsScheduledRelease }
+  ] = useEntityField<boolean>(IS_SCHEDULED_RELEASE)
 
   const [{ value: releaseDate }, , { setValue: setReleaseDate }] =
     useEntityField<string>('release_date')
@@ -131,25 +134,6 @@ export const VisibilityField = (props: VisibilityFieldProps) => {
     ...scheduledReleaseValues
   }
 
-  const openEditAccessConfirmation = useCallback(
-    ({
-      confirmCallback,
-      cancelCallback
-    }: {
-      confirmCallback: () => void
-      cancelCallback: () => void
-    }) => {
-      dispatch(
-        openEditAccessConfirmationModal({
-          type: 'visibility',
-          confirmCallback,
-          cancelCallback
-        })
-      )
-    },
-    [dispatch]
-  )
-
   return (
     <ContextualMenu
       label={messages.title}
@@ -196,13 +180,22 @@ export const VisibilityField = (props: VisibilityFieldProps) => {
 
         const usersMayLoseAccess =
           !initiallyHidden && values.visibilityType !== 'public'
-        if (isEditableAccessEnabled && usersMayLoseAccess) {
-          openEditAccessConfirmation({
-            confirmCallback: submit,
-            cancelCallback: () => {
-              setIsConfirmationCancelled(true)
-            }
-          })
+        const willPublish =
+          initiallyHidden && values.visibilityType === 'public'
+        if (!isUpload && (usersMayLoseAccess || willPublish)) {
+          dispatch(
+            openEditAccessConfirmationModal({
+              type: usersMayLoseAccess
+                ? 'hidden'
+                : isInitiallyScheduled
+                ? 'early_release'
+                : 'release',
+              confirmCallback: submit,
+              cancelCallback: () => {
+                setIsConfirmationCancelled(true)
+              }
+            })
+          )
         } else {
           submit()
         }


### PR DESCRIPTION
### Description

_Note: Some of this is pending design review. CC: @julianbaker check out the screenshots below and confirm whether we want the confirm on edit field behavior. (As opposed to on form submit)_

- Show visibility/audience change modal in all relevant cases
- Update modal copy
- Both confirmations now show on save of the ContextualMenu

![Screenshot 2024-07-15 at 4 16 35 PM](https://github.com/user-attachments/assets/93edcaf2-ed77-4b59-8aa4-a3f638123d89)
![image](https://github.com/user-attachments/assets/3ad9c22a-5018-4396-b398-945fd580f9eb)
![Screenshot 2024-07-15 at 4 19 59 PM](https://github.com/user-attachments/assets/fa7c1993-9a78-44bc-9557-df6596511188)


### How Has This Been Tested?

working for each combination of starting and ending states