### PR TITLE
Fix offline mode after fast load change

### DIFF
--- a/packages/mobile/src/components/offline-placeholder/OfflinePlaceholder.tsx
+++ b/packages/mobile/src/components/offline-placeholder/OfflinePlaceholder.tsx
@@ -22,24 +22,10 @@ const messages = {
 }
 
 const useStyles = makeStyles(({ typography, spacing }) => ({
-  container: {
-    justifyContent: 'center',
-    alignItems: 'center'
-  },
-  header: {
-    fontSize: typography.fontSize.xxl,
-    fontFamily: typography.fontByWeight.bold,
-    marginVertical: spacing(4)
-  },
   root: {
     padding: spacing(4),
     paddingBottom: spacing(0),
     margin: spacing(3)
-  },
-  subHeading: {
-    fontSize: typography.fontSize.small,
-    textAlign: 'center',
-    lineHeight: 21
   }
 }))
 

--- a/packages/mobile/src/components/offline-placeholder/OfflinePlaceholder.tsx
+++ b/packages/mobile/src/components/offline-placeholder/OfflinePlaceholder.tsx
@@ -3,8 +3,14 @@ import NetInfo from '@react-native-community/netinfo'
 import { View } from 'react-native'
 import { useAsyncFn } from 'react-use'
 
-import { IconNoWifi, IconRefresh, Button } from '@audius/harmony-native'
-import { Text, Tile } from 'app/components/core'
+import {
+  IconNoWifi,
+  Text,
+  IconRefresh,
+  Button,
+  Flex
+} from '@audius/harmony-native'
+import { Tile } from 'app/components/core'
 import { makeStyles } from 'app/styles'
 import { useThemeColors } from 'app/utils/theme'
 
@@ -53,10 +59,12 @@ export const OfflinePlaceholder = (props: OfflinePlaceholderProps) => {
   const { neutralLight4 } = useThemeColors()
 
   const body = (
-    <View style={styles.container}>
-      <IconNoWifi fill={neutralLight4} />
-      <Text style={styles.header}>{messages.title}</Text>
-      <Text style={styles.subHeading} allowNewline>
+    <Flex justifyContent='center' alignItems='center' gap='l' pv='l'>
+      <IconNoWifi height={80} width={80} fill={neutralLight4} />
+      <Text variant='heading' size='l'>
+        {messages.title}
+      </Text>
+      <Text variant='body' size='m' textAlign='center'>
         {messages.subtitle}
       </Text>
       <Button
@@ -67,7 +75,7 @@ export const OfflinePlaceholder = (props: OfflinePlaceholderProps) => {
       >
         {messages.reloading(isRefreshing)}
       </Button>
-    </View>
+    </Flex>
   )
 
   return unboxed ? (

--- a/packages/web/src/common/store/account/sagas.js
+++ b/packages/web/src/common/store/account/sagas.js
@@ -170,7 +170,6 @@ export function* fetchAccountAsync({ isSignUp = false }) {
 
   const account = yield call(audiusBackendInstance.getAccount)
   if (!account) {
-    yield put(accountActions.resetAccount())
     yield put(
       fetchAccountFailed({
         reason: 'ACCOUNT_NOT_FOUND'

--- a/packages/web/src/common/store/backend/sagas.ts
+++ b/packages/web/src/common/store/backend/sagas.ts
@@ -67,8 +67,7 @@ export function* setupBackend() {
   apiClient.init()
 
   const establishedReachability = yield* call(awaitReachability)
-  // If we couldn't connect, show the error page
-  // and just sit here waiting for reachability.
+  // If we couldn't connect, just sit here waiting for reachability.
   if (!establishedReachability) {
     console.warn('No internet connectivity')
     yield* put(accountActions.fetchAccountNoInternet())


### PR DESCRIPTION
### Description

To some degree the idea of offline mode and the changes in https://github.com/AudiusProject/audius-protocol/pull/9121 aren't really compatible. We can't afford to clear out the current user if the fetch fails for some reason. And we also can't really count on reachability to be the reason for the failure -- it could be a spotty connection.

So, instead here just don't reset the account if the fetch fails. Confirmed offline mode works & fixed the styling which was broken since some of the harmony move.

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._

Testing is very painful, you have to do a complete build every time you want to see your changes when the device is offline
```
npm run ios:stage -- -- --device "Raymond’s iPhone"
> quit app
> airplane mode
> open app
```