### PR TITLE
[C-4777] Prevent public track with future release date

### DIFF
--- a/packages/discovery-provider/integration_tests/tasks/entity_manager/test_playlist_entity_manager.py
+++ b/packages/discovery-provider/integration_tests/tasks/entity_manager/test_playlist_entity_manager.py
@@ -1513,4 +1513,3 @@ def test_access_conditions(app, mocker, tx_receipts):
             .first()
         )
         assert album == None
-

--- a/packages/discovery-provider/integration_tests/tasks/entity_manager/test_track_entity_manager.py
+++ b/packages/discovery-provider/integration_tests/tasks/entity_manager/test_track_entity_manager.py
@@ -2002,7 +2002,7 @@ def test_release_date(app, mocker):
 
 
 def test_publish_track(app, mocker):
-    "Tests publishing a track should generate a notification"
+    "Tests publishing a track should generate a notification and update track fields"
     with app.app_context():
         db = get_db()
         web3 = Web3()

--- a/packages/discovery-provider/integration_tests/tasks/entity_manager/test_track_entity_manager.py
+++ b/packages/discovery-provider/integration_tests/tasks/entity_manager/test_track_entity_manager.py
@@ -2017,6 +2017,8 @@ def test_publish_track(app, mocker):
             "owner_id": 1,
             "is_unlisted": True,
             "is_playlist_upload": False,
+            "is_scheduled_release": True,
+            "release_date": "Fri Jan 26 2100 00:00:00 GMT+0000",
         },
         "PublishTrack": {
             **default_metadata,
@@ -2099,6 +2101,12 @@ def test_publish_track(app, mocker):
             block_timestamp=1585336000,
             block_hash=hex(0),
         )
+        all_tracks: List[Track] = session.query(Track).all()
+        track = all_tracks[0]
+        assert track.is_unlisted == True
+        assert track.is_scheduled_release == True
+        assert track.release_date == datetime(2100, 1, 26, 0, 0)
+
     with db.scoped_session() as session:
         entity_manager_update(
             update_task,
@@ -2116,7 +2124,12 @@ def test_publish_track(app, mocker):
 
         all_tracks: List[Track] = session.query(Track).all()
         assert len(all_tracks) == 1
-        assert all_tracks[0].is_unlisted == False
+        track = all_tracks[0]
+        assert track.is_unlisted == False
+
+        # Protocol should update these fields when publishing track
+        assert track.is_scheduled_release == False
+        assert track.release_date != datetime(2100, 1, 26, 0, 0)
 
         all_notifications: List[Notification] = session.query(Notification).all()
         assert len(all_notifications) == 1

--- a/packages/discovery-provider/src/tasks/entity_manager/entities/playlist.py
+++ b/packages/discovery-provider/src/tasks/entity_manager/entities/playlist.py
@@ -661,6 +661,15 @@ def populate_playlist_record_metadata(
                         parsed_release_date
                     )
         elif key == "is_private":
+            # if playlist is being published, set release date to now.
+            if (
+                playlist_record.is_private
+                and not playlist_metadata["is_private"]
+                and action == Action.UPDATE
+            ):
+                playlist_record.is_scheduled_release = False
+                playlist_record.release_date = str(datetime.now())  # type: ignore
+
             if "is_private" in playlist_metadata:
                 playlist_record.is_private = playlist_metadata["is_private"]
 

--- a/packages/discovery-provider/src/tasks/entity_manager/entities/playlist.py
+++ b/packages/discovery-provider/src/tasks/entity_manager/entities/playlist.py
@@ -665,7 +665,8 @@ def populate_playlist_record_metadata(
             # override release_date and is_scheduled_release.
             if (
                 playlist_record.is_private
-                and not playlist_metadata["is_private"]
+                # default to true so this statement doesn't trigger if is_private is missing
+                and not playlist_metadata.get("is_private", True)
                 and action == Action.UPDATE
             ):
                 playlist_record.is_scheduled_release = False

--- a/packages/discovery-provider/src/tasks/entity_manager/entities/playlist.py
+++ b/packages/discovery-provider/src/tasks/entity_manager/entities/playlist.py
@@ -661,7 +661,8 @@ def populate_playlist_record_metadata(
                         parsed_release_date
                     )
         elif key == "is_private":
-            # if playlist is being published, set release date to now.
+            # if playlist is being published (changing from private to public),
+            # override release_date and is_scheduled_release.
             if (
                 playlist_record.is_private
                 and not playlist_metadata["is_private"]

--- a/packages/discovery-provider/src/tasks/entity_manager/entities/track.py
+++ b/packages/discovery-provider/src/tasks/entity_manager/entities/track.py
@@ -304,7 +304,8 @@ def populate_track_record_metadata(track_record: Track, track_metadata, handle, 
                 if parsed_release_date:
                     track_record.release_date = str(parsed_release_date)  # type: ignore
         elif key == "is_unlisted":
-            # if track is being published, set release date to now.
+            # if track is being published (changing from private to public),
+            # override release_date and is_scheduled_release.
             if (
                 track_record.is_unlisted
                 and not track_metadata["is_unlisted"]

--- a/packages/discovery-provider/src/tasks/entity_manager/entities/track.py
+++ b/packages/discovery-provider/src/tasks/entity_manager/entities/track.py
@@ -304,13 +304,17 @@ def populate_track_record_metadata(track_record: Track, track_metadata, handle, 
                 if parsed_release_date:
                     track_record.release_date = str(parsed_release_date)  # type: ignore
         elif key == "is_unlisted":
-            if "is_unlisted" in track_metadata:
-                track_record.is_unlisted = track_metadata["is_unlisted"]
-
             # if track is being published, set release date to now.
-            if not track_record.is_unlisted and action == Action.UPDATE:
+            if (
+                track_record.is_unlisted
+                and not track_metadata["is_unlisted"]
+                and action == Action.UPDATE
+            ):
                 track_record.is_scheduled_release = False
                 track_record.release_date = str(datetime.now())  # type: ignore
+
+            if "is_unlisted" in track_metadata:
+                track_record.is_unlisted = track_metadata["is_unlisted"]
 
             # allow scheduled_releases to override is_unlisted value based on release date
             # only for CREATE because publish_scheduled releases will publish this once

--- a/packages/discovery-provider/src/tasks/entity_manager/entities/track.py
+++ b/packages/discovery-provider/src/tasks/entity_manager/entities/track.py
@@ -308,7 +308,8 @@ def populate_track_record_metadata(track_record: Track, track_metadata, handle, 
             # override release_date and is_scheduled_release.
             if (
                 track_record.is_unlisted
-                and not track_metadata["is_unlisted"]
+                # default to true so this statement doesn't trigger if is_private is missing
+                and not track_metadata.get("is_unlisted", True)
                 and action == Action.UPDATE
             ):
                 track_record.is_scheduled_release = False

--- a/packages/discovery-provider/src/tasks/entity_manager/entities/track.py
+++ b/packages/discovery-provider/src/tasks/entity_manager/entities/track.py
@@ -307,6 +307,11 @@ def populate_track_record_metadata(track_record: Track, track_metadata, handle, 
             if "is_unlisted" in track_metadata:
                 track_record.is_unlisted = track_metadata["is_unlisted"]
 
+            # if track is being published, set release date to now.
+            if not track_record.is_unlisted and action == Action.UPDATE:
+                track_record.is_scheduled_release = False
+                track_record.release_date = str(datetime.now())  # type: ignore
+
             # allow scheduled_releases to override is_unlisted value based on release date
             # only for CREATE because publish_scheduled releases will publish this once
             if (

--- a/packages/mobile/src/screens/collection-screen/CollectionScreenDetailsTile.tsx
+++ b/packages/mobile/src/screens/collection-screen/CollectionScreenDetailsTile.tsx
@@ -258,8 +258,11 @@ export const CollectionScreenDetailsTile = ({
   const firstTrack = useSelector(selectFirstTrack)
   const messages = getMessages(isAlbum ? 'album' : 'playlist', isStreamGated)
   const isPublished = !isPrivate || isPublishing
-  const isUnpublishedScheduledRelease =
-    isScheduledRelease && isPrivate && releaseDate
+  const shouldShowScheduledRelease =
+    isScheduledRelease &&
+    isPrivate &&
+    releaseDate &&
+    dayjs(releaseDate).isAfter(dayjs())
   const shouldHideOverflow =
     hideOverflow || !isReachable || (isPrivate && !isOwner)
   const shouldHideActions = hideActions || (isPrivate && !isOwner)
@@ -285,7 +288,7 @@ export const CollectionScreenDetailsTile = ({
   useRefetchLineupOnTrackAdd(collectionId)
 
   const badges = [
-    isUnpublishedScheduledRelease ? (
+    shouldShowScheduledRelease ? (
       <MusicBadge variant='accent' icon={IconCalendarMonth}>
         {messages.releases(releaseDate)}
       </MusicBadge>

--- a/packages/mobile/src/screens/track-screen/TrackScreenDetailsTile.tsx
+++ b/packages/mobile/src/screens/track-screen/TrackScreenDetailsTile.tsx
@@ -215,8 +215,11 @@ export const TrackScreenDetailsTile = ({
 
   const isPlayingPreview = isPreviewing && isPlaying
   const isPlayingFullAccess = isPlaying && !isPreviewing
-  const isUnpublishedScheduledRelease =
-    track?.is_scheduled_release && track?.is_unlisted && releaseDate
+  const shouldShowScheduledRelease =
+    isScheduledRelease &&
+    isUnlisted &&
+    releaseDate &&
+    dayjs(releaseDate).isAfter(dayjs())
   const shouldShowPreview = isUSDCPurchaseGated && (isOwner || !hasStreamAccess)
   const shouldHideFavoriteCount =
     isUnlisted || (!isOwner && (saveCount ?? 0) <= 0)
@@ -242,7 +245,7 @@ export const TrackScreenDetailsTile = ({
     aiAttributionUserId ? (
       <DetailsTileAiAttribution userId={aiAttributionUserId} />
     ) : null,
-    isUnpublishedScheduledRelease ? (
+    shouldShowScheduledRelease ? (
       <MusicBadge variant='accent' icon={IconCalendarMonth}>
         {messages.releases(releaseDate)}
       </MusicBadge>

--- a/packages/web/src/components/collection/desktop/CollectionHeader.tsx
+++ b/packages/web/src/components/collection/desktop/CollectionHeader.tsx
@@ -14,7 +14,7 @@ import {
   CollectionsPageType,
   PurchaseableContentType
 } from '@audius/common/store'
-import { Nullable, formatReleaseDate } from '@audius/common/utils'
+import { Nullable, dayjs, formatReleaseDate } from '@audius/common/utils'
 import {
   Text,
   IconVisibilityHidden,
@@ -141,6 +141,8 @@ export const CollectionHeader = (props: CollectionHeaderProps) => {
 
   const hasStreamAccess = access?.stream
   const shouldShowStats = variant !== Variant.SMART && (!isPrivate || isOwner)
+  const shouldShowScheduledRelease =
+    isScheduledRelease && releaseDate && dayjs(releaseDate).isAfter(dayjs())
 
   const handleFilterChange = useCallback(
     (e: ChangeEvent<HTMLInputElement>) => {
@@ -272,7 +274,7 @@ export const CollectionHeader = (props: CollectionHeaderProps) => {
         css={{ position: 'absolute', right: spacing.l, top: spacing.l }}
       >
         {!isPublished ? (
-          isScheduledRelease && releaseDate ? (
+          shouldShowScheduledRelease ? (
             <MusicBadge variant='accent' icon={IconCalendarMonth}>
               {messages.releases(releaseDate)}
             </MusicBadge>

--- a/packages/web/src/components/collection/mobile/CollectionHeader.tsx
+++ b/packages/web/src/components/collection/mobile/CollectionHeader.tsx
@@ -13,7 +13,7 @@ import {
   OverflowAction,
   PurchaseableContentType
 } from '@audius/common/store'
-import { formatReleaseDate, getDogEarType } from '@audius/common/utils'
+import { dayjs, formatReleaseDate, getDogEarType } from '@audius/common/utils'
 import {
   Box,
   Button,
@@ -149,6 +149,8 @@ const CollectionHeader = ({
     isPremiumAlbumsEnabled && isAlbum && streamConditions && collectionId
   const shouldShowStats =
     isPublished && variant !== Variant.SMART && (!isPrivate || isOwner)
+  const shouldShowScheduledRelease =
+    isScheduledRelease && releaseDate && dayjs(releaseDate).isAfter(dayjs())
 
   const onSaveCollection = () => {
     if (!isOwner) onSave?.()
@@ -230,7 +232,7 @@ const CollectionHeader = ({
       {renderDogEar()}
       <Flex direction='column' alignItems='center' p='l' gap='l'>
         {!isPublished ? (
-          isScheduledRelease && releaseDate ? (
+          shouldShowScheduledRelease ? (
             <MusicBadge variant='accent' icon={IconCalendarMonth} size='s'>
               {messages.releases(releaseDate)}
             </MusicBadge>

--- a/packages/web/src/components/track/GiantTrackTile.tsx
+++ b/packages/web/src/components/track/GiantTrackTile.tsx
@@ -211,7 +211,8 @@ export const GiantTrackTile = ({
   const showPreview = isUSDCPurchaseGated && (isOwner || !hasStreamAccess)
   // Play button is conditionally hidden for USDC-gated tracks when the user does not have access
   const showPlay = isUSDCPurchaseGated ? hasStreamAccess : true
-  const shouldShowScheduledRelease = dayjs(releaseDate).isAfter(dayjs())
+  const shouldShowScheduledRelease =
+    isScheduledRelease && dayjs(releaseDate).isAfter(dayjs())
   const renderCardTitle = (className: string) => {
     return (
       <CardTitle


### PR DESCRIPTION
### Description
The problem: I had a scheduled album and hit the publish button. The "releases on x date" music badge at the top right was still present, indicating that the `is_scheduled_release` flag was still true, and `release_date` was still set to a future date.

- Front-end fix: don't show scheduled release music badge if `is_unlisted` and `is_scheduled_release` are false.
- Protocol fix: if publishing a track/playlist that was previously unlisted/private, set `is_scheduled_release` to false and `release_date` to now. Assuming everything is in UTC.
- Add a unit test for this change.

Note: order matters in entity manager - we update `release_date` _before_ updating `is_unlisted`, so the override for `release_date` should work correctly.

### How Has This Been Tested?

Unit tests pass, confirmed UI fix on web stage.