### PR TITLE
PROTO-1881: custom date for rewards bot

### DIFF
--- a/packages/discovery-provider/plugins/pedalboard/apps/trending-challenge-rewards/src/queries.ts
+++ b/packages/discovery-provider/plugins/pedalboard/apps/trending-challenge-rewards/src/queries.ts
@@ -1,5 +1,6 @@
 import { Knex } from 'knex'
 import { Table, UserChallenges } from '@pedalboard/storage'
+import { discoveryDb } from './utils'
 
 export type ChallengeDisbursementUserbank = {
   challenge_id: string
@@ -110,4 +111,17 @@ export const getTrendingChallenges = async (
     // only use tt because we just need a trending challenge
     .where('challenge_id', '=', 'tt')
     .orderBy('completed_blocknumber', 'desc')
+    .limit(100)
+
+// queries for trending challenges by a particular date in order to get the starting block number
+export const getTrendingChallengesByDate = async (
+  discoveryDb: Knex,
+  specifierPrefix: string
+): Promise<UserChallenges[]> =>
+  discoveryDb
+    .select()
+    .from<UserChallenges>(Table.UserChallenges)
+    // only use tt because we just need a trending challenge
+    .where('challenge_id', '=', 'tt')
+    .where('specifier', 'like', `${specifierPrefix}%`)
     .limit(100)

--- a/packages/discovery-provider/plugins/pedalboard/apps/trending-challenge-rewards/src/slack.ts
+++ b/packages/discovery-provider/plugins/pedalboard/apps/trending-challenge-rewards/src/slack.ts
@@ -9,6 +9,7 @@ import { SharedData } from './config'
 import { onDisburse } from './app'
 import { ChallengeDisbursementUserbankFriendly } from './queries'
 import { announceTopFiveTrending } from './trending'
+import { isValidDate } from './utils'
 
 export const establishSlackConnection = async (app: App<SharedData>) => {
   const slack = initSlack(app).unwrap()
@@ -64,7 +65,15 @@ const disburse = async (
 ): Promise<void> => {
   const { command, ack, respond } = args
   await ack()
-  await onDisburse(app, dryRun)
+
+  // parse out command date if exists
+  const cmdText = command.text
+  const isValidSpecifier = isValidDate(cmdText)
+  if (!isValidSpecifier) {
+    await respond(`${cmdText} not a valid date, please format in YYYY-MM-DD`)
+    return
+  }
+  await onDisburse(app, dryRun, cmdText)
 }
 
 const trending = async (

--- a/packages/discovery-provider/plugins/pedalboard/apps/trending-challenge-rewards/src/utils.ts
+++ b/packages/discovery-provider/plugins/pedalboard/apps/trending-challenge-rewards/src/utils.ts
@@ -15,3 +15,19 @@ export const intoResult = async <T>(
     return new Err(`${e}`);
   }
 };
+
+export const isValidDate = (dateString: string): boolean => {
+  const dateFormat = /^\d{4}-\d{2}-\d{2}$/;
+  if (!dateFormat.test(dateString)) {
+    return false;
+  }
+
+  const date = new Date(dateString);
+  const [year, month, day] = dateString.split('-').map(Number);
+
+  return (
+    date.getFullYear() === year &&
+    date.getMonth() + 1 === month &&
+    date.getDate() === day
+  );
+}


### PR DESCRIPTION
### Description
When run manually the bot will take in a custom specifier so rewards can be disbursed from past weeks with ease.

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._
