### PR TITLE
[PAY-3164] Allow editing access for download-only gated tracks

### DIFF
--- a/packages/web/src/components/edit/fields/download-availability/DownloadAvailability.tsx
+++ b/packages/web/src/components/edit/fields/download-availability/DownloadAvailability.tsx
@@ -72,6 +72,9 @@ type DownloadAvailabilityProps = {
 export const DownloadAvailability = (props: DownloadAvailabilityProps) => {
   const { isUpload, initialDownloadConditions, value, setValue } = props
   const messages = getMessages(props)
+  const { isEnabled: isEditableAccessEnabled } = useFeatureFlag(
+    FeatureFlags.EDITABLE_ACCESS_ENABLED
+  )
   const { isEnabled: isUsdcUploadEnabled } = useFeatureFlag(
     FeatureFlags.USDC_PURCHASES_UPLOAD
   )
@@ -112,9 +115,13 @@ export const DownloadAvailability = (props: DownloadAvailabilityProps) => {
   }, [setStatus, submitForm])
 
   const isFollowersOptionDisabled =
-    !isUpload && !isContentFollowGated(initialDownloadConditions)
+    !isEditableAccessEnabled &&
+    !isUpload &&
+    !isContentFollowGated(initialDownloadConditions)
   const isPremiumOptionDisabled =
-    !isUpload && !isContentUSDCPurchaseGated(initialDownloadConditions)
+    !isEditableAccessEnabled &&
+    !isUpload &&
+    !isContentUSDCPurchaseGated(initialDownloadConditions)
   const options: Option<DownloadTrackAvailabilityType>[] = [
     {
       key: DownloadTrackAvailabilityType.PUBLIC,


### PR DESCRIPTION
### Description

Allow editing access for download-only gated tracks.

### How Has This Been Tested?

Local web dapp vs stage.
