### PR TITLE
[C-4719] Fix local collections selector

### DIFF
--- a/packages/common/src/store/cache/collections/selectors.ts
+++ b/packages/common/src/store/cache/collections/selectors.ts
@@ -213,8 +213,8 @@ export const getCollectionWithUser = (
   const user = getUserById(state, { id: userId })
   if (collection && user) {
     return {
-      user,
-      ...collection
+      ...collection,
+      user
     }
   }
   return null


### PR DESCRIPTION
### Description

The user was being fetched but then overwritten if collection has a user field.

This begs the question if user should have a populated value in cache, but in normalized entities, we'll have a user id reference in that spot.

Because the returned user had `user: string`, downstream user.handle call failed.

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._
