### PR TITLE
Specifiers should be strings in challenge notifs

### DIFF
--- a/packages/discovery-provider/src/api/v1/utils/extend_notification.py
+++ b/packages/discovery-provider/src/api/v1/utils/extend_notification.py
@@ -328,7 +328,7 @@ def extend_supporter_dethroned(action: NotificationAction):
 def extend_challenge_reward(action: NotificationAction):
     data: ChallengeRewardNotification = action["data"]  # type: ignore
     return {
-        "specifier": encode_int_id(int(action["specifier"])),
+        "specifier": action["specifier"],
         "type": action["type"],
         "timestamp": (
             datetime.timestamp(action["timestamp"])
@@ -346,7 +346,7 @@ def extend_challenge_reward(action: NotificationAction):
 def extend_claimable_reward(action: NotificationAction):
     data: ClaimableRewardNotification = action["data"]  # type: ignore
     return {
-        "specifier": encode_int_id(int(action["specifier"])),
+        "specifier": action["specifier"],
         "type": action["type"],
         "timestamp": (
             datetime.timestamp(action["timestamp"])


### PR DESCRIPTION
### Description

The specifier looks like "1=>2" and can't be int-encoded.

Currently my notifs on stage won't load. Seems like we handle this as a string client side anyway https://github.com/AudiusProject/audius-protocol/blob/165a890c8e9ecfcfcb6367d9d5edb741da09abd4/packages/discovery-provider/plugins/notifications/src/types/notifications.ts#L131

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._
