### PR TITLE
[QA-1443] Remove faulty download all logic

### DIFF
--- a/packages/web/src/common/store/social/tracks/sagas.ts
+++ b/packages/web/src/common/store/social/tracks/sagas.ts
@@ -739,17 +739,6 @@ function* watchDownloadTrack() {
       const controller = new AbortController()
       const task = yield* fork(function* () {
         const { trackIds, parentTrackId, original } = action
-        if (
-          trackIds === undefined ||
-          trackIds.length === 0 ||
-          (trackIds.length > 1 && !parentTrackId)
-        ) {
-          console.error(
-            `Could not download track ${trackIds}: Invalid trackIds or missing parentTrackId`
-          )
-          return
-        }
-
         yield* call(waitForRead)
 
         // Check if there is a logged in account and if not,


### PR DESCRIPTION
### Description

We intentionally show download all for mobile when there's only the full track parent. This logic gets us no benefit because we handle the case where there is only a parentTrackId below. Anyway, downloads on moweb working well for me.

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._

Stage locally mobile web in browser