### PR TITLE
[C-4794] Hide social actions on now playing drawer for hidden tracks

### DIFF
--- a/packages/mobile/src/components/now-playing-drawer/ActionsBar.tsx
+++ b/packages/mobile/src/components/now-playing-drawer/ActionsBar.tsx
@@ -61,7 +61,8 @@ const messages = {
   favoriteProhibited: "You can't Favorite your own Track!",
   castLabel: 'Cast to Device',
   shareLabel: 'Share Content',
-  optionsLabel: 'More Options'
+  optionsLabel: 'More Options',
+  price: (price: number) => `$${formatPrice(price)}`
 }
 
 const useStyles = makeStyles(({ palette, spacing }) => ({
@@ -137,6 +138,7 @@ export const ActionsBar = ({ track }: ActionsBarProps) => {
     track?.stream_conditions &&
     'usdc_purchase' in track.stream_conditions &&
     !hasStreamAccess
+  const shouldShowActions = hasStreamAccess && !isUnlisted
 
   useLayoutEffect(() => {
     if (Platform.OS === 'android' && castMethod === 'airplay') {
@@ -213,7 +215,14 @@ export const ActionsBar = ({ track }: ActionsBarProps) => {
         })
       )
     }
-  }, [track, isOwner, albumInfo, playbackPositionInfo?.status, dispatch])
+  }, [
+    track,
+    isOwner,
+    isUnlisted,
+    albumInfo,
+    playbackPositionInfo?.status,
+    dispatch
+  ])
 
   const { openAirplayDialog } = useAirplay()
   const castDevices = useDevices()
@@ -225,8 +234,12 @@ export const ActionsBar = ({ track }: ActionsBarProps) => {
     ) {
       const price = track.stream_conditions.usdc_purchase.price
       return (
-        <Button style={styles.buyButton} onPress={handlePurchasePress}>
-          {formatPrice(price)}
+        <Button
+          color='lightGreen'
+          style={styles.buyButton}
+          onPress={handlePurchasePress}
+        >
+          {messages.price(price)}
         </Button>
       )
     }
@@ -314,10 +327,10 @@ export const ActionsBar = ({ track }: ActionsBarProps) => {
     <View style={styles.container}>
       {shouldShowPurchasePill ? renderPurchaseButton() : null}
       <View style={styles.actions}>
-        {!shouldShowPurchasePill ? renderCastButton() : null}
-        {!shouldShowPurchasePill ? renderRepostButton() : null}
-        {!shouldShowPurchasePill ? renderFavoriteButton() : null}
-        {renderShareButton()}
+        {renderCastButton()}
+        {shouldShowActions ? renderRepostButton() : null}
+        {shouldShowActions ? renderFavoriteButton() : null}
+        {shouldShowActions ? renderShareButton() : null}
         {renderOptionsButton()}
       </View>
     </View>

--- a/packages/web/src/components/now-playing/NowPlaying.tsx
+++ b/packages/web/src/components/now-playing/NowPlaying.tsx
@@ -232,8 +232,7 @@ const NowPlaying = g(
       _cover_art_sizes,
       has_current_user_saved,
       has_current_user_reposted,
-      _co_sign,
-      is_unlisted: isUnlisted
+      _co_sign
     } = displayInfo
 
     const { name, handle } = user

--- a/packages/web/src/components/now-playing/NowPlaying.tsx
+++ b/packages/web/src/components/now-playing/NowPlaying.tsx
@@ -232,7 +232,8 @@ const NowPlaying = g(
       _cover_art_sizes,
       has_current_user_saved,
       has_current_user_reposted,
-      _co_sign
+      _co_sign,
+      is_unlisted: isUnlisted
     } = displayInfo
 
     const { name, handle } = user
@@ -565,9 +566,7 @@ const NowPlaying = g(
             />
           ) : null}
           <ActionsBar
-            isOwner={currentUserId === owner_id}
-            hasReposted={has_current_user_reposted}
-            hasFavorited={has_current_user_saved}
+            trackId={track_id as ID}
             isCollectible={!!collectible}
             onToggleRepost={toggleRepost}
             onToggleFavorite={toggleFavorite}
@@ -575,8 +574,6 @@ const NowPlaying = g(
             onClickOverflow={onClickOverflow}
             isDarkMode={isDarkMode()}
             isMatrixMode={matrix}
-            showRepost={!shouldShowPurchasePreview}
-            showFavorite={!shouldShowPurchasePreview}
           />
         </div>
       </div>

--- a/packages/web/src/components/play-bar/desktop/components/SocialActions.tsx
+++ b/packages/web/src/components/play-bar/desktop/components/SocialActions.tsx
@@ -8,6 +8,7 @@ import {
   CommonState,
   PurchaseableContentType
 } from '@audius/common/store'
+import { Flex } from '@audius/harmony'
 import { useSelector } from 'react-redux'
 
 import FavoriteButton from 'components/alt-button/FavoriteButton'
@@ -51,6 +52,7 @@ export const SocialActions = ({
   const isFavoriteAndRepostDisabled = !uid || isOwner
   const favorited = track?.has_current_user_saved ?? false
   const reposted = track?.has_current_user_reposted ?? false
+  const isUnlisted = track?.is_unlisted
   const favoriteText = favorited ? messages.unfavorite : messages.favorite
   const repostText = reposted ? messages.reposted : messages.repost
 
@@ -71,7 +73,7 @@ export const SocialActions = ({
   const matrix = theme === Theme.MATRIX
 
   return (
-    <div className={styles.root}>
+    <Flex className={styles.root}>
       {track?.stream_conditions &&
       'usdc_purchase' in track.stream_conditions &&
       !hasStreamAccess ? (
@@ -83,46 +85,54 @@ export const SocialActions = ({
         />
       ) : (
         <>
-          <div className={styles.toggleRepostContainer}>
+          <Flex className={styles.toggleRepostContainer}>
             <Tooltip
               text={repostText}
               disabled={isFavoriteAndRepostDisabled}
               mount='body'
               placement='top'
             >
-              <span>
-                <RepostButton
-                  aria-label={repostText}
-                  onClick={() => onToggleRepost(reposted, trackId)}
-                  isActive={reposted}
-                  isDisabled={isFavoriteAndRepostDisabled || track?.is_unlisted}
-                  isDarkMode={shouldShowDark(theme)}
-                  isMatrixMode={matrix}
-                />
-              </span>
+              <Flex>
+                {!isUnlisted ? (
+                  <RepostButton
+                    aria-label={repostText}
+                    onClick={() => onToggleRepost(reposted, trackId)}
+                    isActive={reposted}
+                    isDisabled={
+                      isFavoriteAndRepostDisabled || track?.is_unlisted
+                    }
+                    isDarkMode={shouldShowDark(theme)}
+                    isMatrixMode={matrix}
+                  />
+                ) : null}
+              </Flex>
             </Tooltip>
-          </div>
+          </Flex>
 
-          <div className={styles.toggleFavoriteContainer}>
+          <Flex className={styles.toggleFavoriteContainer}>
             <Tooltip
               text={favoriteText}
               disabled={isFavoriteAndRepostDisabled}
               placement='top'
               mount='body'
             >
-              <span>
-                <FavoriteButton
-                  isDisabled={isFavoriteAndRepostDisabled || track?.is_unlisted}
-                  isMatrixMode={matrix}
-                  isActive={favorited}
-                  isDarkMode={shouldShowDark(theme)}
-                  onClick={() => onToggleFavorite(favorited, trackId)}
-                />
-              </span>
+              <Flex>
+                {!isUnlisted ? (
+                  <FavoriteButton
+                    isDisabled={
+                      isFavoriteAndRepostDisabled || track?.is_unlisted
+                    }
+                    isMatrixMode={matrix}
+                    isActive={favorited}
+                    isDarkMode={shouldShowDark(theme)}
+                    onClick={() => onToggleFavorite(favorited, trackId)}
+                  />
+                ) : null}
+              </Flex>
             </Tooltip>
-          </div>
+          </Flex>
         </>
       )}
-    </div>
+    </Flex>
   )
 }

--- a/packages/web/src/components/play-bar/mobile/PlayBar.tsx
+++ b/packages/web/src/components/play-bar/mobile/PlayBar.tsx
@@ -110,11 +110,18 @@ const PlayBar = ({
       title: collectible?.name,
       track_id: collectible?.id,
       has_current_user_saved: false,
-      _co_sign: null
+      _co_sign: null,
+      is_unlisted: false
     }
   }
 
-  const { title, track_id, has_current_user_saved, _co_sign } = getDisplayInfo()
+  const {
+    title,
+    track_id,
+    has_current_user_saved,
+    _co_sign,
+    is_unlisted: isUnlisted
+  } = getDisplayInfo()
 
   const { name } = user
 
@@ -158,7 +165,7 @@ const PlayBar = ({
       <div className={styles.playBar}>
         <TrackingBar percentComplete={percentComplete} />
         <div className={styles.controls}>
-          {shouldShowPreviewLock ? null : (
+          {shouldShowPreviewLock || isUnlisted ? null : (
             <FavoriteButton
               isDisabled={track?.is_unlisted}
               onClick={toggleFavorite}


### PR DESCRIPTION
### Description
Hide all social actions on now playing bar/drawer.

on mobile we still want to show the cast option and the overflow menu.

### How Has This Been Tested?

web
<img width="1422" alt="Screenshot 2024-07-16 at 7 21 38 PM" src="https://github.com/user-attachments/assets/ff4cdc5e-1051-4a45-ba61-08e8dfbd28c3">

mobile-web
<img width="1920" alt="Screenshot 2024-07-16 at 7 23 37 PM" src="https://github.com/user-attachments/assets/06b23ac8-9ffb-449e-bf88-f0cbea37ef21">

ios
![Simulator Screenshot - iPhone 15 Pro - 2024-07-16 at 19 43 21](https://github.com/user-attachments/assets/cbc253cd-c7c4-4677-a7fa-4fd0cf8ce46d)
