### PR TITLE
Add UTM tracking in amplitude

### DIFF
--- a/packages/web/src/services/analytics/amplitude.ts
+++ b/packages/web/src/services/analytics/amplitude.ts
@@ -23,7 +23,14 @@ export const init = async (isMobile: boolean) => {
       amplitude
         .getInstance()
         // Note: https is prepended to the apiEndpoint url specified
-        .init(AMP_API_KEY, undefined, { apiEndpoint: AMPLITUDE_PROXY })
+        .init(AMP_API_KEY, undefined, {
+          apiEndpoint: AMPLITUDE_PROXY,
+          includeUtm: true,
+          includeReferrer: true,
+          includeFbclid: true,
+          includeGclid: true,
+          saveParamsReferrerOncePerSession: false
+        })
       amp = amplitude
       const source = getSource(isMobile)
       amp.getInstance().logEvent(Name.SESSION_START, { source })


### PR DESCRIPTION
### Description

Add UTM tracking to web client. Useful for tracking traffic sources like emails, ads, direct link referrals, etc.

Unfortunately the react native SDK doesn't have this option but i think it could be manually set. Will do if this proves useful.
https://community.amplitude.com/data-instrumentation-57/is-it-possible-to-track-utm-parameters-for-mobile-apps-1832

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._

Confirmed URLs like `http://localhost:3002/feed?utm_source=isaactest2` now record UTM and referrer data. 