### PR TITLE
Include all save types in library collections endpoints

### DIFF
--- a/packages/discovery-provider/src/queries/get_collection_library.py
+++ b/packages/discovery-provider/src/queries/get_collection_library.py
@@ -198,20 +198,8 @@ def _get_collection_library(args: GetCollectionLibraryArgs, session):
         session,
         playlist_ids,
         playlists,
-        [
-            (
-                RepostType.playlist
-                if collection_type == CollectionType.playlist
-                else RepostType.album
-            )
-        ],
-        [
-            (
-                SaveType.playlist
-                if collection_type == CollectionType.playlist
-                else SaveType.album
-            )
-        ],
+        [RepostType.playlist, RepostType.album],
+        [SaveType.playlist, SaveType.album],
         user_id,
     )
 


### PR DESCRIPTION
### Description
See this comment on line 94 of `get_collection_library.py`
```
# Both albums and playlists have SaveType.playlist at the moment, will filter albums with the join as necessary
```
But we are actually filtering by `SaveType.playlist` or `SaveType.album` in the query. We shouldn't do this until we migrate the saves to have correct save type.

Unclear how this was ever working..


### How Has This Been Tested?

Tested against local stack:
- Created 1 playlist and 1 album from user A.
- User B favorites both.
- Confirmed each of them appear in the correct tab in library.

@amendelsohn will follow up and confirm that this is good on staging.
