### PR TITLE
[PAY-3148] Add better support for gated tracks in library

### DIFF
--- a/packages/common/src/models/Analytics.ts
+++ b/packages/common/src/models/Analytics.ts
@@ -1427,6 +1427,7 @@ export enum ModalSource {
   LineUpCollectionTile = 'collection tile - lineup',
   TrackListItem = 'track list item',
   OverflowMenu = 'overflow menu',
+  TrackLibrary = 'track library',
   // Should never be used, but helps with type-checking
   Unknown = 'unknown'
 }

--- a/packages/web/src/components/table/Table.tsx
+++ b/packages/web/src/components/table/Table.tsx
@@ -7,6 +7,7 @@ import {
   useState
 } from 'react'
 
+import { useGatedContentAccessMap } from '@audius/common/hooks'
 import { Kind, ID, TrackMetadata } from '@audius/common/models'
 import {
   IconCaretDown,
@@ -39,7 +40,6 @@ import Tooltip from 'components/tooltip/Tooltip'
 
 import styles from './Table.module.css'
 import { TableLoadingSpinner } from './components/TableLoadingSpinner'
-import { useGatedContentAccessMap } from '@audius/common/hooks'
 
 // - Infinite scroll constants -
 // Fetch the next group of rows when the user scroll within X rows of the bottom
@@ -140,6 +140,8 @@ export const Table = ({
   useLocalSort = false,
   wrapperClassName
 }: TableProps) => {
+  const trackAccessMap = useGatedContentAccessMap(isTracksTable ? data : [])
+
   useEffect(() => {
     if (totalRowCount == null && isPaginated) {
       console.error(
@@ -343,8 +345,6 @@ export const Table = ({
     []
   )
 
-  const trackAccessMap = useGatedContentAccessMap(data)
-
   const renderTableRow = useCallback(
     (row: Row, key: string, props: TableRowProps, className = '') => {
       const cells = row.cells.filter(
@@ -391,7 +391,14 @@ export const Table = ({
         </Row>
       )
     },
-    [activeIndex, getRowClassName, onClickRow, renderCell, isVirtualized]
+    [
+      trackAccessMap,
+      activeIndex,
+      getRowClassName,
+      onClickRow,
+      renderCell,
+      isVirtualized
+    ]
   )
 
   const renderSkeletonRow = useCallback(

--- a/packages/web/src/components/table/components/TablePlayButton.tsx
+++ b/packages/web/src/components/table/components/TablePlayButton.tsx
@@ -28,6 +28,7 @@ export const TablePlayButton = ({
 }: TablePlayButtonProps) => {
   const {
     color: {
+      neutral: { n150 },
       special: { lightGreen },
       primary: { p300 }
     }
@@ -45,7 +46,7 @@ export const TablePlayButton = ({
           className={cn(styles.icon, {
             [styles.hideDefault]: hideDefault && !playing
           })}
-          fill={shouldShowPremiumColor ? lightGreen : p300}
+          fill={isLocked ? n150 : shouldShowPremiumColor ? lightGreen : p300}
         />
       )}
     </div>


### PR DESCRIPTION
### Description

Show locked and premium buy buttons for locked tracks in library and allow user to unlock. Make rows unclickable until user has access.

### How Has This Been Tested?

local web dapp vs stage

https://github.com/user-attachments/assets/b3732b5c-1ab8-4672-bfc6-e31231f50278


