### PR TITLE
[C-4787] Fix advanced search sort dropdowns

### DIFF
--- a/packages/harmony/src/components/button/FilterButton/FilterButton.tsx
+++ b/packages/harmony/src/components/button/FilterButton/FilterButton.tsx
@@ -123,11 +123,9 @@ export const FilterButton = forwardRef<HTMLButtonElement, FilterButtonProps>(
       if (onClick) {
         onClick()
       } else {
-        if (variant === 'fillContainer') {
-          setIsOpen((isOpen: boolean) => !isOpen)
-        }
+        setIsOpen((isOpen: boolean) => !isOpen)
       }
-    }, [variant, setIsOpen, onClick])
+    }, [setIsOpen, onClick])
 
     const Icon = useMemo(() => {
       return variant === 'fillContainer' && value !== null

--- a/packages/harmony/src/components/button/FilterButton/types.ts
+++ b/packages/harmony/src/components/button/FilterButton/types.ts
@@ -4,8 +4,9 @@ import { IconComponent } from 'components/icon'
 
 export type FilterButtonSize = 'default' | 'small'
 
-// TODO: is replaceLabel still needed?
-export type FilterButtonVariant = 'fillContainer' | 'replaceLabel'
+export type FilterButtonVariant =
+  | 'fillContainer' // When a value is present, the button will be in an active state and have a remove icon (default)
+  | 'replaceLabel' // Shows the value as the label of the button, but doesn't show an active state
 
 type ChildrenProps = {
   /**

--- a/packages/harmony/src/components/button/FilterButton/types.ts
+++ b/packages/harmony/src/components/button/FilterButton/types.ts
@@ -59,7 +59,7 @@ export type FilterButtonProps = {
 
   /**
    * The type of filter button
-   * @default FilterButtonType.FILL_CONTAINER
+   * @default 'fillContainer'
    */
   variant?: FilterButtonVariant
 


### PR DESCRIPTION
### Description

The #9112 changes caused only `fillContainer` variant FilterButtons to call `setIsOpen`, however the search sorting dropdowns as well as card vendor dropdown in the payment flow are `replaceLabel`. Afaict it should be fine to have these open on click

### How Has This Been Tested?

Confirmed both variants are working
