### PR TITLE
Fix usage of missing SDK function for Manager Mode reject flow

### DIFF
--- a/packages/web/src/pages/settings-page/components/desktop/ManagerMode/ManagerModeSettingsModal.tsx
+++ b/packages/web/src/pages/settings-page/components/desktop/ManagerMode/ManagerModeSettingsModal.tsx
@@ -79,9 +79,9 @@ const useManagerModeState = () => {
             })
             break
           case 'reject':
-            result = await sdk.grants.rejectGrant({
-              userId: currentUserId,
-              grantorUserId: targetUserId
+            result = await sdk.grants.removeManager({
+              userId: targetUserId,
+              managerUserId: currentUserId
             })
             break
           case 'revoke':


### PR DESCRIPTION
### Description
This was taken out in a previous PR as the reject was just an alias for `removeManager`. I forgot to update the one place we call it.

### How Has This Been Tested?
Tested locally against staging
