### PR TITLE
[C-4675] [C-4665] [C-4736] [C-4732] [C-4737] [C-4734] [C-4742] Advanced search UI qa fixes part 2

### DIFF
--- a/packages/common/src/store/search/selectors.ts
+++ b/packages/common/src/store/search/selectors.ts
@@ -1,5 +1,3 @@
-import { createSelector } from 'reselect'
-
 import { CommonState } from '../commonStore'
 
 import { isSearchItem } from './slice'
@@ -9,6 +7,5 @@ const getBaseState = (state: CommonState) => state.search
 export const getSearchHistory = (state: CommonState) =>
   getBaseState(state).history.filter((item) => !isSearchItem(item))
 
-export const getV2SearchHistory = createSelector(getSearchHistory, (history) =>
-  history.filter(isSearchItem)
-)
+export const getV2SearchHistory = (state: CommonState) =>
+  getBaseState(state).history.filter((item) => isSearchItem(item))

--- a/packages/common/src/store/search/selectors.ts
+++ b/packages/common/src/store/search/selectors.ts
@@ -1,11 +1,14 @@
 import { CommonState } from '../commonStore'
 
 import { isSearchItem } from './slice'
+import { SearchItem } from './types'
 
 const getBaseState = (state: CommonState) => state.search
 
 export const getSearchHistory = (state: CommonState) =>
   getBaseState(state).history.filter((item) => !isSearchItem(item))
 
-export const getV2SearchHistory = (state: CommonState) =>
-  getBaseState(state).history.filter((item) => isSearchItem(item))
+export const getV2SearchHistory = (state: CommonState): SearchItem[] =>
+  getBaseState(state).history.filter((item) =>
+    isSearchItem(item)
+  ) as SearchItem[]

--- a/packages/mobile/src/components/user-list/UserCard.tsx
+++ b/packages/mobile/src/components/user-list/UserCard.tsx
@@ -58,7 +58,7 @@ export const UserCard = (props: UserCardProps) => {
       <Avatar source={source} onError={handleError} aria-hidden p='m' pb='s' />
       <Flex ph='l' pb='s' gap='xs' pointerEvents='none'>
         <UserLink userId={userId} textVariant='title' />
-        <Text ellipses textAlign='center'>
+        <Text numberOfLines={1} textAlign='center'>
           @{handle}
         </Text>
       </Flex>

--- a/packages/mobile/src/harmony-native/components/Text/Text.tsx
+++ b/packages/mobile/src/harmony-native/components/Text/Text.tsx
@@ -10,7 +10,7 @@ import { Platform, Text as TextBase } from 'react-native'
 import { useTheme } from '../../foundations/theme'
 
 export type TextProps = NativeTextProps &
-  Omit<BaseTextProps, 'textAlign'> & {
+  Omit<BaseTextProps, 'textAlign' | 'ellipsis'> & {
     textAlign?: TextStyle['textAlign']
     textTransform?: TextStyle['textTransform']
     // Needed for proper text wrapping

--- a/packages/mobile/src/screens/app-screen/useAppScreenOptions.tsx
+++ b/packages/mobile/src/screens/app-screen/useAppScreenOptions.tsx
@@ -152,6 +152,7 @@ export const useAppScreenOptions = (
                 <IconButton
                   icon={IconSearch}
                   onPress={handlePressSearch}
+                  hitSlop={10}
                   color='subdued'
                   size='m'
                 />

--- a/packages/mobile/src/screens/list-selection-screen/ListSelectionScreen.tsx
+++ b/packages/mobile/src/screens/list-selection-screen/ListSelectionScreen.tsx
@@ -87,7 +87,7 @@ export const ListSelectionScreen = (props: ListSelectionProps) => {
       {...other}
     >
       <View style={[styles.content, footer ? styles.noFlex : undefined]}>
-        <Flex p='l'>{header}</Flex>
+        {header ? <Flex p='l'>{header}</Flex> : null}
         {disableSearch ? null : (
           <Flex p='l'>
             <TextInput

--- a/packages/mobile/src/screens/search-screen-v2/SearchCatalogTile.tsx
+++ b/packages/mobile/src/screens/search-screen-v2/SearchCatalogTile.tsx
@@ -8,7 +8,7 @@ export const SearchCatalogTile = () => {
       pv='2xl'
       ph='l'
       mv='s'
-      mh='xl'
+      mh='m'
       direction='column'
       gap='s'
       alignItems='center'

--- a/packages/mobile/src/screens/search-screen-v2/SearchItem.tsx
+++ b/packages/mobile/src/screens/search-screen-v2/SearchItem.tsx
@@ -84,7 +84,7 @@ const SearchItemContainer = (props: SearchItemContainerProps) => {
 }
 
 export const SearchItemSkeleton = () => (
-  <Flex direction='row' w='100%' pv='s' justifyContent='space-between'>
+  <Flex direction='row' w='100%' justifyContent='space-between' ph='l' pv='s'>
     <Flex direction='row' w='100%' gap='m'>
       <Skeleton width={40} height={40} />
 

--- a/packages/web/src/pages/search-page-v2/RecentSearches.tsx
+++ b/packages/web/src/pages/search-page-v2/RecentSearches.tsx
@@ -40,7 +40,7 @@ import { CategoryView } from './types'
 const MAX_RECENT_SEARCHES = 12
 
 const { removeItem, clearHistory } = searchActions
-const { getSearchHistory } = searchSelectors
+const { getV2SearchHistory: getSearchHistory } = searchSelectors
 
 const RecentSearchSkeleton = () => (
   <Flex w='100%' pv='s' ph='xl' justifyContent='space-between'>
@@ -269,7 +269,7 @@ export const RecentSearches = () => {
   const category = routeMatch?.params.category
 
   const categoryKind: Kind | null = category
-    ? itemKindByCategory[category]
+    ? itemKindByCategory[category as CategoryView]
     : null
 
   const filteredSearchItems = useMemo(() => {
@@ -302,7 +302,8 @@ export const RecentSearches = () => {
         {(truncatedSearchItems || []).map((searchItem) => {
           if (isSearchItem(searchItem)) {
             const { kind, id } = searchItem
-            const ItemComponent = itemComponentByKind[kind]
+            const ItemComponent =
+              itemComponentByKind[kind as keyof typeof itemComponentByKind]
             return <ItemComponent searchItem={searchItem} key={id} />
           }
           return null

--- a/packages/web/src/pages/search-page-v2/SearchHeader.tsx
+++ b/packages/web/src/pages/search-page-v2/SearchHeader.tsx
@@ -109,8 +109,8 @@ export const SearchHeader = (props: SearchHeaderProps) => {
       primary={title}
       secondary={
         query ? (
-          <Flex ml='l'>
-            <Text variant='heading' strength='weak'>
+          <Flex ml='l' css={{ maxWidth: 200 }}>
+            <Text variant='heading' strength='weak' ellipses>
               &#8220;{query}&#8221;
             </Text>
           </Flex>

--- a/packages/web/src/pages/search-page-v2/SearchHeader.tsx
+++ b/packages/web/src/pages/search-page-v2/SearchHeader.tsx
@@ -117,7 +117,7 @@ export const SearchHeader = (props: SearchHeaderProps) => {
         ) : null
       }
       bottomBar={
-        <Flex direction='row' gap='s' mv='m'>
+        <Flex direction='row' gap='s' mv={filterKeys.length ? 'm' : undefined}>
           {filterKeys.map((filterKey) => {
             const FilterComponent = filters[filterKey]
             return <FilterComponent key={filterKey} />


### PR DESCRIPTION
### Description

Decided to knock out a bunch of the easy ones, going to tackle the more high pri / difficult ones next!

* Truncate query with ellipsis when it overflows
* Decrease padding below web search header in All category
* Reduce spacing above Select Genre input in the genre drawer
* Bigger touch target for search icon in navbar
* Artist card handles should only be a single line
* Align Search the Catalog tile margins with recent searches
* Recent searches loading state padding incorrect

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._
