### PR TITLE
[C-4810, C-4801, C-4790, PAY-3171] Fix publish album tracks behavior; update confirmation modals

### DIFF
--- a/packages/web/src/common/store/cache/collections/commonSagas.ts
+++ b/packages/web/src/common/store/cache/collections/commonSagas.ts
@@ -213,8 +213,23 @@ function* confirmEditPlaylist(
         )
 
         if (playlistBeforeEdit?.is_private && !confirmedPlaylist.is_private) {
-          for (const track of confirmedPlaylist.tracks ?? []) {
-            if (track.is_unlisted) {
+          const playlistTracks = yield* select(getCollectionTracks, {
+            id: playlistId
+          })
+
+          // Publish all hidden tracks
+          // If the playlist is a scheduled release
+          //    AND all tracks are scheduled releases, publish them all
+          const isEachTrackScheduled = playlistTracks?.every(
+            (track) => track.is_unlisted && track.is_scheduled_release
+          )
+          const isEarlyRelease =
+            playlistBeforeEdit.is_scheduled_release && isEachTrackScheduled
+          for (const track of playlistTracks ?? []) {
+            if (
+              track.is_unlisted &&
+              (!track.is_scheduled_release || isEarlyRelease)
+            ) {
               yield* put(trackPageActions.makeTrackPublic(track.track_id))
             }
           }
@@ -536,8 +551,22 @@ function* confirmPublishPlaylist(
           ])
         )
 
-        for (const track of confirmedPlaylist.tracks ?? []) {
-          if (track.is_unlisted) {
+        const playlistTracks = yield* select(getCollectionTracks, {
+          id: playlistId
+        })
+        // Publish all hidden tracks
+        // If the playlist is a scheduled release
+        //    AND all tracks are scheduled releases, publish them all
+        const isEachTrackScheduled = playlistTracks?.every(
+          (track) => track.is_unlisted && track.is_scheduled_release
+        )
+        const isEarlyRelease =
+          playlist.is_scheduled_release && isEachTrackScheduled
+        for (const track of playlistTracks ?? []) {
+          if (
+            track.is_unlisted &&
+            (!track.is_scheduled_release || isEarlyRelease)
+          ) {
             yield* put(trackPageActions.makeTrackPublic(track.track_id))
           }
         }

--- a/packages/web/src/components/edit-collection/EditCollectionForm.tsx
+++ b/packages/web/src/components/edit-collection/EditCollectionForm.tsx
@@ -182,7 +182,7 @@ export const EditCollectionForm = (props: EditCollectionFormProps) => {
               onCancel={() => setIsDeleteConfirmationOpen(false)}
               onDelete={() => setIsDeleteConfirmationOpen(false)}
             />
-            {isAlbum ? null : (
+            {isAlbum ? (
               <ReleaseCollectionConfirmationModal
                 isOpen={isReleaseConfirmationOpen}
                 onClose={() => setIsReleaseConfirmationOpen(false)}
@@ -190,7 +190,7 @@ export const EditCollectionForm = (props: EditCollectionFormProps) => {
                 releaseType={!is_scheduled_release ? 'scheduled' : 'hidden'}
                 formId={formId}
               />
-            )}
+            ) : null}
           </>
         ) : null}
       </Form>

--- a/packages/web/src/components/edit-track/ReleaseTrackConfirmationModal.tsx
+++ b/packages/web/src/components/edit-track/ReleaseTrackConfirmationModal.tsx
@@ -1,0 +1,54 @@
+import {
+  Button,
+  IconRocket,
+  Modal,
+  ModalContent,
+  ModalContentText,
+  ModalFooter,
+  ModalHeader,
+  ModalProps,
+  ModalTitle
+} from '@audius/harmony'
+
+const messages = {
+  title: {
+    hidden: 'Confirm Release',
+    scheduled: 'Confirm Early Release'
+  },
+  description: {
+    hidden: `Are you sure you want to make this track public? Your followers will be notified.`,
+    scheduled: `Do you want to release your track now? Your followers will be notified.`
+  },
+  goBack: 'Go Back',
+  release: `Release Now`
+}
+
+type Props = Omit<ModalProps, 'children'> & {
+  formId: string
+  releaseType: 'hidden' | 'scheduled'
+}
+
+export const ReleaseTrackConfirmationModal = (props: Props) => {
+  const { formId, releaseType, ...other } = props
+  const { onClose } = other
+  return (
+    <Modal {...other} size='small'>
+      <ModalHeader>
+        <ModalTitle icon={<IconRocket />} title={messages.title[releaseType]} />
+      </ModalHeader>
+      <ModalContent>
+        <ModalContentText css={{ textAlign: 'center' }}>
+          {messages.description[releaseType]}
+        </ModalContentText>
+      </ModalContent>
+      <ModalFooter>
+        <Button variant='secondary' onClick={onClose} fullWidth>
+          {messages.goBack}
+        </Button>
+        <Button variant='primary' type='submit' form={formId} fullWidth>
+          {messages.release}
+        </Button>
+      </ModalFooter>
+    </Modal>
+  )
+}

--- a/packages/web/src/components/publish-track-confirmation-modal/PublishTrackConfirmationModal.tsx
+++ b/packages/web/src/components/publish-track-confirmation-modal/PublishTrackConfirmationModal.tsx
@@ -20,9 +20,9 @@ const { getConfirmCallback } = publishTrackConfirmationModalUISelectors
 const messages = {
   title: 'Confirm Release',
   description:
-    'Ready to release your new track? Your followers will be notified and your track will be released to the public.',
+    'Are you sure you want to make this track public? Your followers will be notified.',
   cancel: 'Go Back',
-  release: 'Release Now '
+  release: 'Release Now'
 }
 
 export const PublishTrackConfirmationModal = () => {
@@ -44,7 +44,9 @@ export const PublishTrackConfirmationModal = () => {
         <ModalTitle icon={<IconRocket />} title={messages.title} />
       </ModalHeader>
       <ModalContent>
-        <ModalContentText>{messages.description}</ModalContentText>
+        <ModalContentText css={{ textAlign: 'center' }}>
+          {messages.description}
+        </ModalContentText>
       </ModalContent>
       <ModalFooter>
         <Button fullWidth variant='secondary' onClick={onClose}>


### PR DESCRIPTION
### Description

- Fix cascading track publish in several cases (applies to album edit and release button)
	- When all tracks are scheduled AND album is scheduled, release the tracks
	- In all other cases, when mixed hidden, public, and scheduled, only release the hidden tracks
- Fix publish album confirmation modal
	- `isAlbum` conditional ternary rendering was backwards
- Add publish track confirmation modal to track edit onSubmit
- Remove change confirmation on VisibilityField since we do it on edit form submit now

#### Examples
![Screenshot 2024-07-17 at 4 32 18 PM](https://github.com/user-attachments/assets/c4f7c73e-78bf-4c5c-b95d-fcaf185f8772)
![Screenshot 2024-07-17 at 7 08 53 PM](https://github.com/user-attachments/assets/bf41db7c-6d05-45fc-96da-6a1f6beb815f)

![Screenshot 2024-07-17 at 4 27 31 PM](https://github.com/user-attachments/assets/bba5b89e-6b86-4520-9e3f-41a04d369b95)


### How Has This Been Tested?

Tested several cases with different configurations of hidden/scheduled/public tracks in each type of album. The correct modal displayed in each case.