### PR TITLE
[C-4804] Improve search performance pt 2

### DIFF
--- a/packages/common/src/api/search.ts
+++ b/packages/common/src/api/search.ts
@@ -118,4 +118,5 @@ const searchApi = createApi({
 
 export const { useGetSearchResults } = searchApi.hooks
 export const searchApiFetch = searchApi.fetch
+export const searchApiFetchSaga = searchApi.fetchSaga
 export const searchApiReducer = searchApi.reducer

--- a/packages/common/src/audius-query/createApi.ts
+++ b/packages/common/src/audius-query/createApi.ts
@@ -15,6 +15,7 @@ import { denormalize, normalize } from 'normalizr'
 import { useDispatch, useSelector } from 'react-redux'
 import { useDebounce } from 'react-use'
 import { Dispatch } from 'redux'
+import { call, select } from 'typed-redux-saga'
 
 import {
   Collection,
@@ -31,6 +32,7 @@ import { getTrack } from '~/store/cache/tracks/selectors'
 import { reformatUser } from '~/store/cache/users/utils'
 import { CommonState } from '~/store/reducers'
 import { getErrorMessage } from '~/utils/error'
+import { waitForValue } from '~/utils/sagaHelpers'
 import { Nullable, removeNullable } from '~/utils/typeUtils'
 
 import { Track } from '../models/Track'
@@ -92,7 +94,8 @@ export const createApi = <
   const api = {
     reducerPath,
     hooks: {},
-    fetch: {}
+    fetch: {},
+    fetchSaga: {}
   } as unknown as Api<EndpointDefinitions>
 
   const sliceConfig: SliceConfig = {
@@ -267,6 +270,7 @@ const useQueryState = <Args, Data>(
           schemaKey ? { [schemaKey]: cachedData } : cachedData,
           apiResponseSchema
         )
+
         return {
           normalizedData: result,
           status: Status.SUCCESS,
@@ -280,13 +284,13 @@ const useQueryState = <Args, Data>(
   }, isEqual)
 }
 
-// Rehydrate local normalizedData using entities from global normalized cache
-const useCacheData = <Args, Data>(
-  endpoint: EndpointConfig<Args, Data>,
-  normalizedData: any,
-  hookOptions?: QueryHookOptions
-) => {
-  return useSelector((state: CommonState) => {
+const createCacheDataSelector =
+  <Args, Data>(
+    endpoint: EndpointConfig<Args, Data>,
+    normalizedData: any,
+    hookOptions?: QueryHookOptions
+  ) =>
+  (state: CommonState) => {
     if (hookOptions?.shallow && !endpoint.options.kind) return normalizedData
     const entityMap = selectCommonEntityMap(
       state,
@@ -300,7 +304,18 @@ const useCacheData = <Args, Data>(
       return denormalize(normalizedData, apiResponseSchema, entityMap) as Data
     }
     return normalizedData
-  }, isEqual)
+  }
+
+// Rehydrate local normalizedData using entities from global normalized cache
+const useCacheData = <Args, Data>(
+  endpoint: EndpointConfig<Args, Data>,
+  normalizedData: any,
+  hookOptions?: QueryHookOptions
+) => {
+  return useSelector(
+    createCacheDataSelector(endpoint, normalizedData, hookOptions),
+    isEqual
+  )
 }
 
 const requestBatcher = createRequestBatcher()
@@ -546,6 +561,58 @@ const buildEndpointHooks = <
       }
     ]
   }
+
+  /**
+   * This is not actually a saga, but a function that can be called from a saga
+   * It supports the same caching logic as the useQuery hook and will skip
+   * making a request if cache data already exists or a request is in flight
+   */
+  function* fetchSaga(
+    fetchArgs: Args,
+    context: AudiusQueryContextType,
+    force?: boolean
+  ) {
+    if (!force) {
+      const key = getKeyFromFetchArgs(fetchArgs)
+
+      const getEndpointKeyState = (state: CommonState) =>
+        state.api[reducerPath][endpointName][key] ?? {}
+      const getEndpointKeyStatus = (state: CommonState) =>
+        getEndpointKeyState(state).status
+
+      const status = yield* select(getEndpointKeyStatus)
+
+      if ([Status.LOADING, Status.ERROR, Status.SUCCESS].includes(status)) {
+        // If a request is already in flight, wait for it to finish
+        yield* call(
+          waitForValue,
+          getEndpointKeyStatus,
+          {},
+          (s: Status) => s !== Status.LOADING
+        )
+
+        const endpointState = yield* select(getEndpointKeyState)
+        const { normalizedData } = endpointState
+
+        const cacheData = yield* select(
+          createCacheDataSelector(endpoint, normalizedData)
+        )
+
+        return cacheData
+      }
+    }
+
+    return yield* call(
+      fetchData as any,
+      fetchArgs,
+      endpointName,
+      endpoint,
+      actions,
+      context
+    )
+  }
+
+  api.fetchSaga[endpointName] = fetchSaga
 
   api.fetch[endpointName] = (
     fetchArgs: Args,

--- a/packages/common/src/audius-query/types.ts
+++ b/packages/common/src/audius-query/types.ts
@@ -56,6 +56,13 @@ export type Api<EndpointDefinitions extends DefaultEndpointDefinitions> = {
   fetch: {
     [Property in keyof EndpointDefinitions]: EndpointDefinitions[Property]['fetch']
   }
+  fetchSaga: {
+    [Property in keyof EndpointDefinitions]: (
+      fetchArgs: any,
+      context: AudiusQueryContextType,
+      force?: boolean
+    ) => Generator<any, any, any>
+  }
 }
 
 export type CreateApiConfig = {

--- a/packages/common/src/audius-query/utils.ts
+++ b/packages/common/src/audius-query/utils.ts
@@ -1,4 +1,5 @@
 import { mapValues } from 'lodash'
+import objectHash from 'object-hash'
 
 import { Kind } from '~/models/Kind'
 import { CommonState } from '~/store/reducers'
@@ -12,7 +13,7 @@ export function capitalize(str: string) {
 
 export const getKeyFromFetchArgs = (fetchArgs: any) => {
   if (fetchArgs === undefined) return 'default'
-  return JSON.stringify(fetchArgs)
+  return objectHash(fetchArgs)
 }
 
 export const selectCommonEntityMap = (

--- a/packages/mobile/src/harmony-native/components/Button/FilterButton/FilterButton.tsx
+++ b/packages/mobile/src/harmony-native/components/Button/FilterButton/FilterButton.tsx
@@ -3,7 +3,7 @@ import { useCallback, useEffect, useMemo, useState } from 'react'
 import type { ReactNativeStyle } from '@emotion/native'
 import { useTheme } from '@emotion/react'
 import { isNil } from 'lodash'
-import type { GestureResponderEvent } from 'react-native'
+import { Pressable, type GestureResponderEvent } from 'react-native'
 
 import type { IconProps } from '@audius/harmony-native'
 import { IconCloseAlt, Text } from '@audius/harmony-native'
@@ -114,14 +114,15 @@ export const FilterButton = (props: FilterButtonProps) => {
   const Icon = useMemo(() => {
     return variant === 'fillContainer' && !isNil(value)
       ? (props: IconProps) => (
-          <IconCloseAlt
-            aria-label='cancel'
+          <Pressable
+            hitSlop={20}
             onPress={(e: GestureResponderEvent) => {
               e.stopPropagation()
               onReset?.()
             }}
-            {...props}
-          />
+          >
+            <IconCloseAlt aria-label='cancel' {...props} />
+          </Pressable>
         )
       : iconRight ?? undefined
   }, [variant, value, onReset, iconRight])

--- a/packages/mobile/src/screens/app-screen/useAppScreenOptions.tsx
+++ b/packages/mobile/src/screens/app-screen/useAppScreenOptions.tsx
@@ -30,7 +30,10 @@ import type { AppScreenParamList } from './AppTabsScreen'
 
 const useStyles = makeStyles(({ palette, spacing, typography }) => ({
   headerLeft: { marginLeft: spacing(-2) + 1, width: 40 },
-  headerRight: { padding: spacing(2) },
+  headerRight: {
+    paddingVertical: spacing(2),
+    paddingLeft: spacing(2)
+  },
   title: {
     fontSize: 18,
     fontFamily: typography.fontByWeight.heavy,

--- a/packages/mobile/src/screens/app-screen/useAppScreenOptions.tsx
+++ b/packages/mobile/src/screens/app-screen/useAppScreenOptions.tsx
@@ -30,7 +30,7 @@ import type { AppScreenParamList } from './AppTabsScreen'
 
 const useStyles = makeStyles(({ palette, spacing, typography }) => ({
   headerLeft: { marginLeft: spacing(-2) + 1, width: 40 },
-  headerRight: {},
+  headerRight: { padding: spacing(2) },
   title: {
     fontSize: 18,
     fontFamily: typography.fontByWeight.heavy,
@@ -152,7 +152,7 @@ export const useAppScreenOptions = (
                 <IconButton
                   icon={IconSearch}
                   onPress={handlePressSearch}
-                  hitSlop={10}
+                  hitSlop={20}
                   color='subdued'
                   size='m'
                 />

--- a/packages/mobile/src/screens/search-screen-v2/search-results/TrackResults.tsx
+++ b/packages/mobile/src/screens/search-screen-v2/search-results/TrackResults.tsx
@@ -18,7 +18,6 @@ import { Lineup } from 'app/components/lineup'
 import { NoResultsTile } from '../NoResultsTile'
 import { SearchCatalogTile } from '../SearchCatalogTile'
 import {
-  ALL_RESULTS_LIMIT,
   useIsEmptySearch,
   useSearchFilters,
   useSearchQuery

--- a/packages/mobile/src/screens/search-screen-v2/search-results/TrackResults.tsx
+++ b/packages/mobile/src/screens/search-screen-v2/search-results/TrackResults.tsx
@@ -1,9 +1,9 @@
-import { useCallback, useEffect, useState } from 'react'
+import { useCallback, useEffect } from 'react'
 
 import { Kind, Status } from '@audius/common/models'
 import {
   lineupSelectors,
-  searchResultsPageTracksLineupActions as tracksActions,
+  searchResultsPageTracksLineupActions,
   searchResultsPageSelectors,
   SearchKind,
   searchActions
@@ -14,12 +14,11 @@ import { useDebounce } from 'react-use'
 
 import { Flex } from '@audius/harmony-native'
 import { Lineup } from 'app/components/lineup'
-import { LineupTileSkeleton } from 'app/components/lineup-tile'
 
 import { NoResultsTile } from '../NoResultsTile'
 import { SearchCatalogTile } from '../SearchCatalogTile'
 import {
-  useGetSearchResults,
+  ALL_RESULTS_LIMIT,
   useIsEmptySearch,
   useSearchFilters,
   useSearchQuery
@@ -33,50 +32,43 @@ const getSearchTracksLineupMetadatas = makeGetLineupMetadatas(
 const { addItem: addRecentSearch } = searchActions
 
 export const TrackResults = () => {
-  const { status } = useGetSearchResults('tracks')
   const [query] = useSearchQuery()
   const [filters] = useSearchFilters()
   const dispatch = useDispatch()
   const isEmptySearch = useIsEmptySearch()
-  const [isLoading, setIsLoading] = useState(false)
-  const [isResultsRequested, setIsResultsRequested] = useState(false)
 
   const lineup = useSelector(getSearchTracksLineupMetadatas)
 
   const getResults = useCallback(
     (offset: number, limit: number, overwrite: boolean) => {
       dispatch(
-        tracksActions.fetchLineupMetadatas(offset, limit, overwrite, {
-          category: SearchKind.TRACKS,
-          query,
-          filters,
-          dispatch
-        })
+        searchResultsPageTracksLineupActions.fetchLineupMetadatas(
+          offset,
+          limit,
+          overwrite,
+          {
+            category: SearchKind.TRACKS,
+            query,
+            filters,
+            dispatch
+          }
+        )
       )
     },
     [dispatch, query, filters]
   )
 
   useEffect(() => {
-    setIsLoading(true)
-  }, [query, filters])
+    dispatch(searchResultsPageTracksLineupActions.reset())
+  }, [dispatch, query, filters])
 
   useDebounce(
     () => {
-      dispatch(tracksActions.reset())
       getResults(0, 10, true)
-      setIsResultsRequested(true)
     },
     500,
-    [getResults]
+    [dispatch, getResults, query, filters]
   )
-
-  useEffect(() => {
-    if (isLoading && isResultsRequested && lineup.status === Status.SUCCESS) {
-      setIsLoading(false)
-      setIsResultsRequested(false)
-    }
-  }, [isLoading, isResultsRequested, lineup])
 
   const loadMore = useCallback(
     (offset: number, limit: number) => {
@@ -86,39 +78,32 @@ export const TrackResults = () => {
   )
 
   if (isEmptySearch) return <SearchCatalogTile />
-  if ((!lineup || lineup.entries.length === 0) && status === Status.SUCCESS) {
+  if (
+    (!lineup || lineup.entries.length === 0) &&
+    lineup.status === Status.SUCCESS
+  ) {
     return <NoResultsTile />
   }
 
   return (
     <Flex h='100%' backgroundColor='default'>
-      {status === Status.LOADING || isLoading ? (
-        <Flex p='m' gap='m'>
-          <LineupTileSkeleton />
-          <LineupTileSkeleton />
-          <LineupTileSkeleton />
-          <LineupTileSkeleton />
-          <LineupTileSkeleton />
-        </Flex>
-      ) : (
-        <Lineup
-          actions={tracksActions}
-          lineup={lineup}
-          loadMore={loadMore}
-          keyboardShouldPersistTaps='handled'
-          onPressItem={(id) => {
-            Keyboard.dismiss()
-            dispatch(
-              addRecentSearch({
-                searchItem: {
-                  kind: Kind.TRACKS,
-                  id
-                }
-              })
-            )
-          }}
-        />
-      )}
+      <Lineup
+        actions={searchResultsPageTracksLineupActions}
+        lineup={lineup}
+        loadMore={loadMore}
+        keyboardShouldPersistTaps='handled'
+        onPressItem={(id) => {
+          Keyboard.dismiss()
+          dispatch(
+            addRecentSearch({
+              searchItem: {
+                kind: Kind.TRACKS,
+                id
+              }
+            })
+          )
+        }}
+      />
     </Flex>
   )
 }

--- a/packages/mobile/src/screens/search-screen-v2/searchState.ts
+++ b/packages/mobile/src/screens/search-screen-v2/searchState.ts
@@ -13,6 +13,8 @@ import { useSelector } from 'react-redux'
 
 const { getUserId } = accountSelectors
 
+export const ALL_RESULTS_LIMIT = 5
+
 type SearchContextType = {
   query: string
   setQuery: Dispatch<SetStateAction<string>>
@@ -100,7 +102,8 @@ export const useGetSearchResults = <C extends SearchCategory>(
       ...filters,
       category,
       currentUserId,
-      limit: category === 'all' ? 5 : undefined
+      limit: category === 'all' ? ALL_RESULTS_LIMIT : undefined,
+      offset: 0
     },
     { debounce: 500 }
   )

--- a/packages/web/src/common/store/pages/search-page/lineups/tracks/sagas.ts
+++ b/packages/web/src/common/store/pages/search-page/lineups/tracks/sagas.ts
@@ -1,4 +1,4 @@
-import { searchApiFetch } from '@audius/common/api'
+import { searchApiFetchSaga } from '@audius/common/api'
 import { Track } from '@audius/common/models'
 import { FeatureFlags } from '@audius/common/services'
 import {
@@ -72,8 +72,9 @@ function* getSearchPageResultsTracks({
       } else {
         // searchApiFetch.getSearchResults already handles tag search,
         // so we don't need to specify isTagSearch necessarily
+
         const { tracks } = yield* call(
-          searchApiFetch.getSearchResults,
+          searchApiFetchSaga.getSearchResults,
           {
             currentUserId,
             query,

--- a/packages/web/src/pages/search-page-v2/search-results/AlbumResults.tsx
+++ b/packages/web/src/pages/search-page-v2/search-results/AlbumResults.tsx
@@ -91,17 +91,15 @@ export const AlbumResults = (props: AlbumResultsProps) => {
 export const AlbumResultsPage = () => {
   const isMobile = useIsMobile()
 
-  const { data, status } = useGetSearchResults('albums')
+  const { data: ids, status } = useGetSearchResults('albums')
   const isLoading = status === Status.LOADING
 
   const searchParams = useSearchParams()
   const { sortMethod } = searchParams
   const updateSortParam = useUpdateSearchParams('sortMethod')
 
-  const isResultsEmpty = data?.length === 0
+  const isResultsEmpty = ids?.length === 0
   const showNoResultsTile = !isLoading && isResultsEmpty
-
-  const ids = data?.map(({ playlist_id: id }) => id)
 
   return (
     <Flex direction='column' gap='xl'>

--- a/packages/web/src/pages/search-page-v2/search-results/AllResults.tsx
+++ b/packages/web/src/pages/search-page-v2/search-results/AllResults.tsx
@@ -39,6 +39,13 @@ export const AllResults = () => {
 
   if (showNoResultsTile) return <NoResultsTile />
 
+  const {
+    users: userIds,
+    tracks: trackIds,
+    playlists: playlistIds,
+    albums: albumIds
+  } = data ?? {}
+
   return (
     <Flex
       direction='column'
@@ -46,16 +53,16 @@ export const AllResults = () => {
       p={isMobile ? 'm' : undefined}
       ref={containerRef}
     >
-      {isLoading || data.users?.length ? (
+      {isLoading || userIds?.length ? (
         <Flex gap='xl' direction='column'>
           <Text variant='heading' textAlign='left'>
             {messages.profiles}
           </Text>
-          <ProfileResults skeletonCount={5} ids={data.users} limit={5} />
+          <ProfileResults skeletonCount={5} ids={userIds} limit={5} />
         </Flex>
       ) : null}
 
-      {isLoading || data.tracks?.length ? (
+      {isLoading || trackIds?.length ? (
         <Flex gap='xl' direction='column'>
           <Text variant='heading' textAlign='left'>
             {messages.tracks}
@@ -68,21 +75,21 @@ export const AllResults = () => {
         </Flex>
       ) : null}
 
-      {isLoading || data.albums?.length ? (
+      {isLoading || albumIds?.length ? (
         <Flex gap='xl' direction='column'>
           <Text variant='heading' textAlign='left'>
             {messages.albums}
           </Text>
-          <AlbumResults skeletonCount={5} ids={data.albums} limit={5} />
+          <AlbumResults skeletonCount={5} ids={albumIds} limit={5} />
         </Flex>
       ) : null}
 
-      {isLoading || data.playlists?.length ? (
+      {isLoading || playlistIds?.length ? (
         <Flex gap='xl' direction='column'>
           <Text variant='heading' textAlign='left'>
             {messages.playlists}
           </Text>
-          <PlaylistResults skeletonCount={5} ids={data.playlists} limit={5} />
+          <PlaylistResults skeletonCount={5} ids={playlistIds} limit={5} />
         </Flex>
       ) : null}
     </Flex>

--- a/packages/web/src/pages/search-page-v2/search-results/AllResults.tsx
+++ b/packages/web/src/pages/search-page-v2/search-results/AllResults.tsx
@@ -39,11 +39,6 @@ export const AllResults = () => {
 
   if (showNoResultsTile) return <NoResultsTile />
 
-  const userIds = data?.users.map(({ user_id: id }) => id)
-  const albumIds = data?.albums.map(({ playlist_id: id }) => id)
-  const playlistIds = data?.playlists.map(({ playlist_id: id }) => id)
-  const trackIds = data?.tracks.map(({ track_id: id }) => id)
-
   return (
     <Flex
       direction='column'
@@ -51,16 +46,16 @@ export const AllResults = () => {
       p={isMobile ? 'm' : undefined}
       ref={containerRef}
     >
-      {isLoading || userIds?.length ? (
+      {isLoading || data.users?.length ? (
         <Flex gap='xl' direction='column'>
           <Text variant='heading' textAlign='left'>
             {messages.profiles}
           </Text>
-          <ProfileResults skeletonCount={5} ids={userIds} limit={5} />
+          <ProfileResults skeletonCount={5} ids={data.users} limit={5} />
         </Flex>
       ) : null}
 
-      {isLoading || trackIds?.length ? (
+      {isLoading || data.tracks?.length ? (
         <Flex gap='xl' direction='column'>
           <Text variant='heading' textAlign='left'>
             {messages.tracks}
@@ -73,21 +68,21 @@ export const AllResults = () => {
         </Flex>
       ) : null}
 
-      {isLoading || albumIds?.length ? (
+      {isLoading || data.albums?.length ? (
         <Flex gap='xl' direction='column'>
           <Text variant='heading' textAlign='left'>
             {messages.albums}
           </Text>
-          <AlbumResults skeletonCount={5} ids={albumIds} limit={5} />
+          <AlbumResults skeletonCount={5} ids={data.albums} limit={5} />
         </Flex>
       ) : null}
 
-      {isLoading || playlistIds?.length ? (
+      {isLoading || data.playlists?.length ? (
         <Flex gap='xl' direction='column'>
           <Text variant='heading' textAlign='left'>
             {messages.playlists}
           </Text>
-          <PlaylistResults skeletonCount={5} ids={playlistIds} limit={5} />
+          <PlaylistResults skeletonCount={5} ids={data.playlists} limit={5} />
         </Flex>
       ) : null}
     </Flex>

--- a/packages/web/src/pages/search-page-v2/search-results/PlaylistResults.tsx
+++ b/packages/web/src/pages/search-page-v2/search-results/PlaylistResults.tsx
@@ -94,17 +94,15 @@ export const PlaylistResultsPage = () => {
 
   const isMobile = useIsMobile()
 
-  const { data, status } = useGetSearchResults('playlists')
+  const { data: ids, status } = useGetSearchResults('playlists')
   const isLoading = status === Status.LOADING
 
   const searchParams = useSearchParams()
   const { sortMethod } = searchParams
   const updateSortParam = useUpdateSearchParams('sortMethod')
 
-  const isResultsEmpty = data?.length === 0
+  const isResultsEmpty = ids?.length === 0
   const showNoResultsTile = !isLoading && isResultsEmpty
-
-  const ids = data?.map(({ playlist_id: id }) => id)
 
   // const playlistsLineupProps = useLineupProps({
   //   actions: searchResultsPagePlaylistsLineupActions,

--- a/packages/web/src/pages/search-page-v2/search-results/ProfileResults.tsx
+++ b/packages/web/src/pages/search-page-v2/search-results/ProfileResults.tsx
@@ -90,16 +90,14 @@ export const ProfileResults = (props: ProfileResultsProps) => {
 
 export const ProfileResultsPage = () => {
   const isMobile = useIsMobile()
-  const { data, status } = useGetSearchResults('users')
+  const { data: ids, status } = useGetSearchResults('users')
   const isLoading = status === Status.LOADING
 
   const updateSortParam = useUpdateSearchParams('sortMethod')
   const searchParams = useSearchParams()
   const { sortMethod } = searchParams
-  const isResultsEmpty = data?.length === 0
+  const isResultsEmpty = ids?.length === 0
   const showNoResultsTile = !isLoading && isResultsEmpty
-
-  const ids = data?.map(({ user_id: id }) => id)
 
   return (
     <Flex direction='column' gap='xl'>

--- a/packages/web/src/pages/search-page-v2/search-results/TrackResults.tsx
+++ b/packages/web/src/pages/search-page-v2/search-results/TrackResults.tsx
@@ -12,7 +12,6 @@ import {
 } from '@audius/common/store'
 import { Flex, OptionsFilterButton, Text } from '@audius/harmony'
 import { css } from '@emotion/css'
-import Search from 'antd/lib/transfer/search'
 import { useDispatch, useSelector } from 'react-redux'
 import { useDebounce, usePrevious } from 'react-use'
 

--- a/packages/web/src/pages/search-page-v2/search-results/TrackResults.tsx
+++ b/packages/web/src/pages/search-page-v2/search-results/TrackResults.tsx
@@ -90,7 +90,7 @@ export const TrackResults = (props: TrackResultsProps) => {
   useDebounce(
     () => {
       dispatch(searchResultsPageTracksLineupActions.reset())
-      getResults(0, 10, true)
+      getResults(0, 12, true)
     },
     500,
     [dispatch, searchParams, category]

--- a/packages/web/src/pages/search-page-v2/search-results/TrackResults.tsx
+++ b/packages/web/src/pages/search-page-v2/search-results/TrackResults.tsx
@@ -24,7 +24,11 @@ import { useMainContentRef } from 'pages/MainContentContext'
 
 import { NoResultsTile } from '../NoResultsTile'
 import { ViewLayout, viewLayoutOptions } from '../types'
-import { useSearchParams, useUpdateSearchParams } from '../utils'
+import {
+  ALL_RESULTS_LIMIT,
+  useSearchParams,
+  useUpdateSearchParams
+} from '../utils'
 
 const { makeGetLineupMetadatas } = lineupSelectors
 const { getBuffering, getPlaying } = playerSelectors
@@ -96,7 +100,7 @@ export const TrackResults = (props: TrackResultsProps) => {
         return
       }
       dispatch(searchResultsPageTracksLineupActions.reset())
-      getResults(0, 12, true)
+      getResults(0, ALL_RESULTS_LIMIT, true)
     },
     500,
     [dispatch, getResults]

--- a/packages/web/src/pages/search-page-v2/search-results/TrackResults.tsx
+++ b/packages/web/src/pages/search-page-v2/search-results/TrackResults.tsx
@@ -215,7 +215,7 @@ export const TrackResultsPage = () => {
           </Flex>
         </Flex>
       ) : null}
-      <TrackResults />
+      <TrackResults viewLayout={tracksLayout} />
     </Flex>
   )
 }

--- a/packages/web/src/pages/search-page-v2/search-results/TrackResults.tsx
+++ b/packages/web/src/pages/search-page-v2/search-results/TrackResults.tsx
@@ -92,7 +92,7 @@ export const TrackResults = (props: TrackResultsProps) => {
   useDebounce(
     () => {
       // Reuse the existing lineup if the search params haven't changed
-      if (searchParams === prevSearchParams && lineup.entries.length > 0) {
+      if (searchParams === prevSearchParams) {
         return
       }
       dispatch(searchResultsPageTracksLineupActions.reset())
@@ -104,12 +104,9 @@ export const TrackResults = (props: TrackResultsProps) => {
 
   const loadMore = useCallback(
     (offset: number, limit: number) => {
-      // Only load more if the initial fetch has already happened,
-      // see useDebounce above
-      if (lineup.entries.length === 0) return
       getResults(offset, limit, false)
     },
-    [getResults, lineup]
+    [getResults]
   )
 
   const handleClickTrackTile = useCallback(

--- a/packages/web/src/pages/search-page-v2/utils.tsx
+++ b/packages/web/src/pages/search-page-v2/utils.tsx
@@ -39,7 +39,8 @@ export const useGetSearchResults = <C extends SearchCategory>(
     ...filters,
     category,
     currentUserId,
-    limit: category === 'all' ? 12 : undefined
+    limit: category === 'all' ? 12 : undefined,
+    offset: 0
   }
 
   const { data, status } = useGetSearchResultsApi(params, {

--- a/packages/web/src/pages/search-page-v2/utils.tsx
+++ b/packages/web/src/pages/search-page-v2/utils.tsx
@@ -19,6 +19,8 @@ const { getAccountStatus, getUserId } = accountSelectors
 
 type SearchResultsApiType = ReturnType<typeof useGetSearchResultsApi>
 
+export const ALL_RESULTS_LIMIT = 12
+
 type SearchResultsType<C extends SearchCategory> = {
   status: SearchResultsApiType['status']
   data: C extends 'all'
@@ -44,7 +46,7 @@ export const useGetSearchResults = <C extends SearchCategory>(
     ...filters,
     category,
     currentUserId,
-    limit: category === 'all' ? 12 : undefined,
+    limit: category === 'all' ? ALL_RESULTS_LIMIT : undefined,
     offset: 0
   }
 

--- a/packages/web/src/pages/search-page-v2/utils.tsx
+++ b/packages/web/src/pages/search-page-v2/utils.tsx
@@ -62,7 +62,6 @@ export const useGetSearchResults = <C extends SearchCategory>(
     // or if the user is not logged in
     disabled: accountStatus === Status.LOADING || accountStatus === Status.IDLE
   })
-  // console.log('rerender new data')
 
   if (category === 'all') {
     return { data: data as any, status } as SearchResultsType<C>

--- a/packages/web/src/pages/search-page-v2/utils.tsx
+++ b/packages/web/src/pages/search-page-v2/utils.tsx
@@ -29,7 +29,7 @@ type SearchResultsType<C extends SearchCategory> = {
 export const useGetSearchResults = <C extends SearchCategory>(
   category: C
 ): SearchResultsType<C> => {
-  const { query, category: ignoredCategory, ...filters } = useSearchParams()
+  const { query, ...filters } = useSearchParams()
 
   const accountStatus = useSelector(getAccountStatus)
   const currentUserId = useSelector(getUserId)
@@ -45,6 +45,7 @@ export const useGetSearchResults = <C extends SearchCategory>(
 
   const { data, status } = useGetSearchResultsApi(params, {
     debounce: 500,
+    // TODO: do we need this on mobile too
     // Only search when the account has finished loading,
     // or if the user is not logged in
     disabled: accountStatus === Status.LOADING || accountStatus === Status.IDLE
@@ -60,12 +61,16 @@ export const useGetSearchResults = <C extends SearchCategory>(
   }
 }
 
-export const useSearchParams = () => {
-  const [urlSearchParams] = useParams()
-
+export const useSearchCategory = () => {
   const routeMatch = useRouteMatch<{ category: string }>(SEARCH_PAGE)
   const category =
     (routeMatch?.params.category as CategoryView) || CategoryView.ALL
+  return category
+}
+
+export const useSearchParams = () => {
+  const [urlSearchParams] = useParams()
+
   const query = urlSearchParams.get('query')
   const sortMethod = urlSearchParams.get('sortMethod') as SearchSortMethod
   const genre = urlSearchParams.get('genre')
@@ -79,7 +84,6 @@ export const useSearchParams = () => {
   const searchParams = useMemo(
     () => ({
       query,
-      category,
       genre: (genre || undefined) as Genre,
       mood: (mood || undefined) as Mood,
       bpm: bpm || undefined,
@@ -91,7 +95,6 @@ export const useSearchParams = () => {
     }),
     [
       query,
-      category,
       genre,
       mood,
       bpm,


### PR DESCRIPTION
### Description

* Adjust limit and offset params so requests have the same args and we don't make superfluous requests
* Keep track of previous search params so TrackResults doesn't refetch data that was already fetched on AllResults
* Add `fetchSaga` to audius-query that supports the same caching and request skipping logic `useQuery` does

Still working on some profiling because there seems to be a lot of render jank but this should be good to review so far!

### How Has This Been Tested?

Tested web search categories, confirmed no extra requests are being made, ran react profiler
