### PR TITLE
As/fix es indexer build

### DIFF
--- a/packages/es-indexer/Dockerfile
+++ b/packages/es-indexer/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:18:17-alpine
+FROM node:18-alpine
 
 WORKDIR /app
 COPY . .

--- a/packages/es-indexer/Dockerfile
+++ b/packages/es-indexer/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:alpine
+FROM node:18:17
 
 WORKDIR /app
 COPY . .

--- a/packages/es-indexer/Dockerfile
+++ b/packages/es-indexer/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:18:17
+FROM node:18:17-alpine
 
 WORKDIR /app
 COPY . .

--- a/packages/trpc-server/Dockerfile
+++ b/packages/trpc-server/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:18:17-alpine
+FROM node:18-alpine
 
 WORKDIR /app
 COPY . .

--- a/packages/trpc-server/Dockerfile
+++ b/packages/trpc-server/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:alpine
+FROM node:18:17
 
 WORKDIR /app
 COPY . .

--- a/packages/trpc-server/Dockerfile
+++ b/packages/trpc-server/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:18:17
+FROM node:18:17-alpine
 
 WORKDIR /app
 COPY . .


### PR DESCRIPTION
### Description
pins both es-indexer and trpc docker images to node 18 as there was an issue with node 20

### How Has This Been Tested?
local `audius-compose up es-indexer` and `audius-compose up trpc` build correctly
