### PR TITLE
[C-4698] Route to solana play store in rate-cta-drawer

### DIFF
--- a/packages/mobile/src/components/rate-cta-drawer/RateCtaDrawer.tsx
+++ b/packages/mobile/src/components/rate-cta-drawer/RateCtaDrawer.tsx
@@ -3,7 +3,7 @@ import { useCallback, useState } from 'react'
 import { Name } from '@audius/common/models'
 import type { Nullable } from '@audius/common/utils'
 import AsyncStorage from '@react-native-async-storage/async-storage'
-import { View } from 'react-native'
+import { Linking, View } from 'react-native'
 import InAppReview from 'react-native-in-app-review'
 
 import {
@@ -18,6 +18,8 @@ import { NativeDrawer } from 'app/components/drawer'
 import { RATE_CTA_STORAGE_KEY } from 'app/constants/storage-keys'
 import { make, track } from 'app/services/analytics'
 import { makeStyles } from 'app/styles'
+import { isSolanaPhone } from 'app/utils/os'
+import { SOLANA_DAPP_STORE_LINK } from 'app/utils/playStore'
 import { useThemeColors } from 'app/utils/theme'
 
 const DRAWER_NAME = 'RateCallToAction'
@@ -65,19 +67,23 @@ export const RateCtaDrawer = () => {
     useState<Nullable<'YES' | 'NO'>>(null)
 
   const handleReviewConfirm = useCallback(() => {
-    const isAvailable = InAppReview.isAvailable()
+    const isAvailable = isSolanaPhone ? true : InAppReview.isAvailable()
     track(make({ eventName: Name.RATE_CTA_RESPONSE_YES }))
     setUserRateResponse('YES')
     AsyncStorage.setItem(RATE_CTA_STORAGE_KEY, 'YES')
 
     if (isAvailable) {
-      InAppReview.RequestInAppReview()
-        .then((hasFlowFinishedSuccessfully) => {
-          // Do things after the popup shows up
-        })
-        .catch((error) => {
-          console.error(error)
-        })
+      if (isSolanaPhone) {
+        Linking.openURL(SOLANA_DAPP_STORE_LINK)
+      } else {
+        InAppReview.RequestInAppReview()
+          .then((hasFlowFinishedSuccessfully) => {
+            // Do things after the popup shows up
+          })
+          .catch((error) => {
+            console.error(error)
+          })
+      }
     }
   }, [])
 

--- a/packages/mobile/src/screens/update-required-screen/UpdateRequiredScreen.tsx
+++ b/packages/mobile/src/screens/update-required-screen/UpdateRequiredScreen.tsx
@@ -1,11 +1,11 @@
-import { Platform } from 'react-native'
+import { isAndroid, isSolanaPhone } from 'app/utils/os'
+import {
+  ANDROID_PLAY_STORE_LINK,
+  IOS_APP_STORE_LINK,
+  SOLANA_DAPP_STORE_LINK
+} from 'app/utils/playStore'
 
 import { NewVersionPrompt } from './NewVersionPrompt'
-
-const SOLANA_DAPP_STORE_LINK = 'solanadappstore://details?id=co.audius.app'
-const ANDROID_PLAY_STORE_LINK =
-  'https://play.google.com/store/apps/details?id=co.audius.app'
-const IOS_APP_STORE_LINK = 'itms-apps://us/app/audius-music/id1491270519'
 
 const messages = {
   header: 'Please Update ✨',
@@ -16,9 +16,6 @@ const messages = {
 }
 
 export const UpdateRequiredScreen = () => {
-  const isAndroid = Platform.OS === 'android'
-  const isSolanaPhone =
-    Platform.OS === 'android' && Platform.constants.Model === 'Saga'
   const url = isSolanaPhone
     ? SOLANA_DAPP_STORE_LINK
     : isAndroid

--- a/packages/mobile/src/utils/os.ts
+++ b/packages/mobile/src/utils/os.ts
@@ -1,0 +1,8 @@
+import { Platform } from 'react-native'
+
+export const isIos = Platform.OS === 'ios'
+
+export const isAndroid = Platform.OS === 'android'
+
+export const isSolanaPhone =
+  Platform.OS === 'android' && Platform.constants.Model === 'Saga'

--- a/packages/mobile/src/utils/playStore.ts
+++ b/packages/mobile/src/utils/playStore.ts
@@ -1,0 +1,5 @@
+export const SOLANA_DAPP_STORE_LINK =
+  'solanadappstore://details?id=co.audius.app'
+export const ANDROID_PLAY_STORE_LINK =
+  'https://play.google.com/store/apps/details?id=co.audius.app'
+export const IOS_APP_STORE_LINK = 'itms-apps://us/app/audius-music/id1491270519'


### PR DESCRIPTION
### Description

Realized we also want to route to solana-dapp-store on rate-cta, not just update-screen

### How Has This Been Tested?

Tested on saga
