### PR TITLE
[PAY-3181][PAY-3182] Remove hidden tracks from trending

### DIFF
--- a/packages/web/src/common/store/pages/trending/lineups/trending/retrieveTrending.ts
+++ b/packages/web/src/common/store/pages/trending/lineups/trending/retrieveTrending.ts
@@ -69,10 +69,19 @@ export function* retrieveTrending({
     currentUserId,
     timeRange
   })
+
   // DN may return hidden tracks in trending because of its cache
   // i.e. when a track is in trending and the owner makes it hidden,
   // it will still be returned in the trending api for a little while.
-  apiTracks = apiTracks.filter((t) => !t.is_unlisted)
+  // We check the store to see if any of the returned tracks are locally hidden,
+  // if so, we filter them out.
+  const tracksMap: ReturnType<typeof getTracks> = yield select(
+    (state: AppState) =>
+      getTracks(state, { ids: apiTracks.map((t) => t.track_id) })
+  )
+  apiTracks = apiTracks.filter(
+    (t) => !tracksMap[t.track_id] || !tracksMap[t.track_id].is_unlisted
+  )
 
   if (TF.size > 0) {
     apiTracks = apiTracks.filter((t) => {

--- a/packages/web/src/common/store/pages/trending/lineups/trending/retrieveTrending.ts
+++ b/packages/web/src/common/store/pages/trending/lineups/trending/retrieveTrending.ts
@@ -56,7 +56,9 @@ export function* retrieveTrending({
     const tracksMap: ReturnType<typeof getTracks> = yield select(
       (state: AppState) => getTracks(state, { ids: trackIds })
     )
-    const tracks = trackIds.map((id) => tracksMap[id])
+    const tracks = trackIds
+      .map((id) => tracksMap[id])
+      .filter((t) => t && !t.is_unlisted)
     return tracks
   }
 
@@ -67,6 +69,7 @@ export function* retrieveTrending({
     currentUserId,
     timeRange
   })
+  apiTracks = apiTracks.filter((t) => !t.is_unlisted)
 
   if (TF.size > 0) {
     apiTracks = apiTracks.filter((t) => {

--- a/packages/web/src/common/store/pages/trending/lineups/trending/retrieveTrending.ts
+++ b/packages/web/src/common/store/pages/trending/lineups/trending/retrieveTrending.ts
@@ -69,6 +69,9 @@ export function* retrieveTrending({
     currentUserId,
     timeRange
   })
+  // DN may return hidden tracks in trending because of its cache
+  // i.e. when a track is in trending and the owner makes it hidden,
+  // it will still be returned in the trending api for a little while.
   apiTracks = apiTracks.filter((t) => !t.is_unlisted)
 
   if (TF.size > 0) {


### PR DESCRIPTION
### Description

Remove hidden tracks from trending. Need both the DN and client filters. DN because the trending generation was missing the filter, client because DN may return temporarily hidden tracks because of its cache.

Even with this change, itt is possible that trending still has hidden tracks because when DN returns the cache hidden tracks, it will return them as if they are not hidden because the value in the cache would have been `is_unlisted: false`. The only fully correct solution I can think of here is remove the cache in DN entirely. An alternative is to reduce the cache TTL. _My fix_ here is that if client already sees a track as hidden, e.g. user already visited hidden track page in same session then goes to trending, the trending list would not show that hidden track.

Please let me know your thoughts here.

### How Has This Been Tested?

Local web vs stage
