### PR TITLE
[PAY-3174][PAY-3179] Do not show confirmation modals for edit access during upload

### DIFF
--- a/packages/mobile/src/screens/edit-track-screen/EditTrackForm.tsx
+++ b/packages/mobile/src/screens/edit-track-screen/EditTrackForm.tsx
@@ -203,7 +203,7 @@ export const EditTrackForm = (props: EditTrackFormProps) => {
         </>
       </FormScreen>
       <CancelEditTrackDrawer />
-      {confirmDrawerType ? (
+      {!isUpload && confirmDrawerType ? (
         <ConfirmPublishTrackDrawer
           type={confirmDrawerType}
           onConfirm={handleSubmitProp}

--- a/packages/mobile/src/screens/edit-track-screen/EditTrackForm.tsx
+++ b/packages/mobile/src/screens/edit-track-screen/EditTrackForm.tsx
@@ -88,7 +88,7 @@ export const EditTrackForm = (props: EditTrackFormProps) => {
   const dispatch = useDispatch()
   const initiallyHidden = initialValues.is_unlisted
   const isInitiallyScheduled = initialValues.is_scheduled_release
-  const usersMayLoseAccess = !initiallyHidden && values.is_unlisted
+  const usersMayLoseAccess = !isUpload && !initiallyHidden && values.is_unlisted
   const isToBePublished = !isUpload && initiallyHidden && !values.is_unlisted
   const [confirmDrawerType, setConfirmDrawerType] =
     useState<Nullable<'release' | 'early_release' | 'hidden'>>(null)

--- a/packages/mobile/src/screens/edit-track-screen/EditTrackScreen.tsx
+++ b/packages/mobile/src/screens/edit-track-screen/EditTrackScreen.tsx
@@ -337,7 +337,11 @@ export const EditTrackScreen = (props: EditTrackScreenProps) => {
       validationSchema={editTrackSchema}
     >
       {(formikProps) => (
-        <EditTrackNavigator {...formikProps} {...screenProps} />
+        <EditTrackNavigator
+          {...formikProps}
+          {...screenProps}
+          isUpload={initialValuesProp.isUpload}
+        />
       )}
     </Formik>
   )

--- a/packages/mobile/src/screens/edit-track-screen/fields/VisibilityField/VisibilityScreen.tsx
+++ b/packages/mobile/src/screens/edit-track-screen/fields/VisibilityField/VisibilityScreen.tsx
@@ -112,20 +112,21 @@ export const VisibilityScreen = () => {
           description={messages.hiddenDescription}
           disabled={!isEditableAccessEnabled && isAlreadyPublic}
         />
-        <ExpandableRadio
-          value='scheduled'
-          label={messages.scheduledRelease}
-          description={messages.scheduledReleaseDescription}
-          disabled={!isEditableAccessEnabled && isAlreadyPublic}
-          checkedContent={
-            <ScheduledReleaseDateField
-              releaseDate={releaseDate}
-              onChange={setReleaseDate}
-              dateError={dateError}
-              dateTimeError={dateTimeError}
-            />
-          }
-        />
+        {!isAlreadyPublic ? (
+          <ExpandableRadio
+            value='scheduled'
+            label={messages.scheduledRelease}
+            description={messages.scheduledReleaseDescription}
+            checkedContent={
+              <ScheduledReleaseDateField
+                releaseDate={releaseDate}
+                onChange={setReleaseDate}
+                dateError={dateError}
+                dateTimeError={dateTimeError}
+              />
+            }
+          />
+        ) : null}
       </ExpandableRadioGroup>
     </FormScreen>
   )

--- a/packages/mobile/src/screens/edit-track-screen/screens/PriceAndAudienceScreen.tsx
+++ b/packages/mobile/src/screens/edit-track-screen/screens/PriceAndAudienceScreen.tsx
@@ -162,7 +162,7 @@ export const PriceAndAudienceScreen = () => {
   }, [availability, initialStreamConditions, specialAccessType])
 
   const handleSubmit = useCallback(() => {
-    if (isEditableAccessEnabled && usersMayLoseAccess) {
+    if (!isUpload && isEditableAccessEnabled && usersMayLoseAccess) {
       dispatch(
         modalsActions.setVisibility({
           modal: 'EditPriceAndAudienceConfirmation',
@@ -170,7 +170,7 @@ export const PriceAndAudienceScreen = () => {
         })
       )
     }
-  }, [dispatch, isEditableAccessEnabled, usersMayLoseAccess])
+  }, [dispatch, isEditableAccessEnabled, isUpload, usersMayLoseAccess])
 
   const handleCancel = useCallback(() => {
     dispatch(
@@ -217,10 +217,12 @@ export const PriceAndAudienceScreen = () => {
           previousStreamConditions={previousStreamConditions}
         />
       </ExpandableRadioGroup>
-      <EditPriceAndAudienceConfirmationDrawer
-        onConfirm={navigation.goBack}
-        onCancel={handleCancel}
-      />
+      {!isUpload ? (
+        <EditPriceAndAudienceConfirmationDrawer
+          onConfirm={navigation.goBack}
+          onCancel={handleCancel}
+        />
+      ) : null}
     </FormScreen>
   )
 }

--- a/packages/web/src/components/edit-track/EditTrackForm.tsx
+++ b/packages/web/src/components/edit-track/EditTrackForm.tsx
@@ -131,7 +131,7 @@ export const EditTrackForm = (props: EditTrackFormProps) => {
             hideContainer={hideContainer}
             onDeleteTrack={onDeleteTrack}
           />
-          {confirmDrawerType ? (
+          {!isUpload && confirmDrawerType ? (
             <ReleaseTrackConfirmationModal
               isOpen={isReleaseConfirmationOpen}
               onClose={() => setIsReleaseConfirmationOpen(false)}

--- a/packages/web/src/components/edit-track/EditTrackForm.tsx
+++ b/packages/web/src/components/edit-track/EditTrackForm.tsx
@@ -90,7 +90,7 @@ export const EditTrackForm = (props: EditTrackFormProps) => {
         onSubmit(values)
       } else {
         const usersMayLoseAccess =
-          !initiallyHidden && values.trackMetadatas[0].is_unlisted
+          !isUpload && !initiallyHidden && values.trackMetadatas[0].is_unlisted
         const isToBePublished =
           !isUpload && initiallyHidden && !values.trackMetadatas[0].is_unlisted
         const showConfirmDrawer = usersMayLoseAccess || isToBePublished

--- a/packages/web/src/components/edit/fields/price-and-audience/PriceAndAudienceField.tsx
+++ b/packages/web/src/components/edit/fields/price-and-audience/PriceAndAudienceField.tsx
@@ -597,7 +597,7 @@ export const PriceAndAudienceField = (props: PriceAndAudienceFieldProps) => {
             specialAccessType === SpecialAccessType.FOLLOW ? 'follow' : 'tip'
         })
 
-        if (isEditableAccessEnabled && usersMayLoseAccess) {
+        if (!isUpload && isEditableAccessEnabled && usersMayLoseAccess) {
           openEditAccessConfirmation({
             confirmCallback: () => handleSubmit(values),
             cancelCallback: () => {


### PR DESCRIPTION
### Description

Only show the confirmation modals/drawers during edit flows.

### How Has This Been Tested?

local web and ios vs stage
