### PR TITLE
[C-4849] Fullwidth AI attribution dropdown

### DIFF
--- a/packages/web/src/components/edit/fields/SwitchRowField.module.css
+++ b/packages/web/src/components/edit/fields/SwitchRowField.module.css
@@ -8,6 +8,7 @@
   display: flex;
   flex-direction: column;
   gap: var(--harmony-unit-4);
+  width: 100%;
 }
 
 .switch :global(label) {


### PR DESCRIPTION
### Description

#### Before & After
<img width="966" alt="image" src="https://github.com/user-attachments/assets/21431d39-414c-4361-88c6-15f3e939310d">

![Screenshot 2024-07-19 at 2 50 46 PM](https://github.com/user-attachments/assets/8a9a0eba-e9a1-4dbe-acfb-8a16ca4017a1)

### How Has This Been Tested?

checked all other SwitchRowField instances for broken styling