### PR TITLE
[QA-1455] Fix disappearing playlists in sidebar

### DIFF
--- a/packages/common/src/audius-query/createApi.ts
+++ b/packages/common/src/audius-query/createApi.ts
@@ -36,6 +36,7 @@ import { waitForValue } from '~/utils/sagaHelpers'
 import { Nullable, removeNullable } from '~/utils/typeUtils'
 
 import { Track } from '../models/Track'
+import { accountSelectors } from '../store/account'
 import * as cacheActions from '../store/cache/actions'
 import * as cacheSelectors from '../store/cache/selectors'
 
@@ -65,7 +66,6 @@ import {
   MutationHookResults
 } from './types'
 import { capitalize, getKeyFromFetchArgs, selectCommonEntityMap } from './utils'
-import { accountSelectors } from '../store/account'
 
 const { getUserId } = accountSelectors
 
@@ -510,7 +510,7 @@ const buildEndpointHooks = <
         force,
         currentUserId
       )
-    }, [context, fetchArgs, hookOptions?.disabled, status])
+    }, [context, fetchArgs, hookOptions?.disabled, status, currentUserId])
 
     useDebounce(
       () => {


### PR DESCRIPTION
### Description

Fixes issue where "force: true" option can replace the instance of the current user, leading to an issue where all the sidebar playlists disappear. This is due to a big issue adding account information in the user cache. Rather than deal with that now, since that would require a big refactor, we are adding a hack in audius-query to delete the current user from the addEntries call when force is true.