### PR TITLE
[C-4829] Fix mobile web drawer overflow

### DIFF
--- a/packages/web/src/components/drawer/Drawer.module.css
+++ b/packages/web/src/components/drawer/Drawer.module.css
@@ -3,7 +3,7 @@
   position: fixed;
   right: 0;
   left: 0;
-  top: 100vh;
+  top: 100%;
   background: var(--harmony-white);
   margin-bottom: 0px;
   padding-top: 0px;
@@ -51,20 +51,6 @@
   left: 0;
   top: 0;
   bottom: 0;
-}
-
-/*
- * Fixes positioning on ios Safari due to the navigation
- * bar that appears while scrolling up / down.
- * When testing this, make sure to test Safari embedded inside Twitter.
- */
-@supports (-webkit-overflow-scrolling: touch) {
-  .drawer:not(.fullDrawer).isOpen {
-    top: calc(100vh - 100px);
-  }
-  .drawer:not(.fullDrawer):not(.isOpen) {
-    top: calc(100vh + 100px);
-  }
 }
 
 .skirt {


### PR DESCRIPTION
### Description

Fixes issue with mobile web drawer overflow on mobile browsers. The issue was using `vh` since mobile browsers view height includes the browser ui, leading to incorrect overflow. This being corrected with an arbitrary 100px, which was inconsistent for most browsers. The fix is to ultimately just use 100% which will calculate based on the actually available space.