### PR TITLE
[QA-1452] Fix edit playlist issues

### DIFF
--- a/packages/libs/src/services/schemaValidator/schemas/playlistSchema.json
+++ b/packages/libs/src/services/schemaValidator/schemas/playlistSchema.json
@@ -64,13 +64,7 @@
           "default": null
         }
       },
-      "required": [
-        "playlist_name",
-        "playlist_id",
-        "description",
-        "is_album",
-        "is_private"
-      ],
+      "required": ["playlist_name", "playlist_id"],
       "title": "Playlist"
     },
     "CID": {


### PR DESCRIPTION
### Description

Fixes issue where playlists with no description fail to update. Also went ahead and removed is_album, and is_private, since those are also not required