### PR TITLE
Rt share

### DIFF
--- a/packages/mobile/src/components/details-tile/DetailsTileActionButtons.tsx
+++ b/packages/mobile/src/components/details-tile/DetailsTileActionButtons.tsx
@@ -178,10 +178,11 @@ export const DetailsTileActionButtons = ({
 
   return (
     <Flex direction='row' justifyContent='center' gap='xl'>
-      {isOwner && !ddexApp ? editButton : hideRepost ? null : repostButton}
+      {!isOwner && !ddexApp && !hideRepost ? repostButton : null}
       {isOwner || hideFavorite ? null : favoriteButton}
-      {isOwner && !isPublished ? publishButton : null}
       {hideShare ? null : shareButton}
+      {isOwner && !ddexApp ? editButton : null}
+      {isOwner && !isPublished ? publishButton : null}
       {hideOverflow ? null : overflowMenu}
     </Flex>
   )

--- a/packages/mobile/src/components/details-tile/DetailsTileActionButtons.tsx
+++ b/packages/mobile/src/components/details-tile/DetailsTileActionButtons.tsx
@@ -178,10 +178,10 @@ export const DetailsTileActionButtons = ({
 
   return (
     <Flex direction='row' justifyContent='center' gap='xl'>
-      {hideShare ? null : shareButton}
       {isOwner && !ddexApp ? editButton : hideRepost ? null : repostButton}
       {isOwner || hideFavorite ? null : favoriteButton}
       {isOwner && !isPublished ? publishButton : null}
+      {hideShare ? null : shareButton}
       {hideOverflow ? null : overflowMenu}
     </Flex>
   )

--- a/packages/mobile/src/components/details-tile/DetailsTileActionButtons.tsx
+++ b/packages/mobile/src/components/details-tile/DetailsTileActionButtons.tsx
@@ -178,7 +178,7 @@ export const DetailsTileActionButtons = ({
 
   return (
     <Flex direction='row' justifyContent='center' gap='xl'>
-      {!isOwner && !ddexApp && !hideRepost ? repostButton : null}
+      {isOwner || ddexApp || hideRepost ? null : repostButton}
       {isOwner || hideFavorite ? null : favoriteButton}
       {hideShare ? null : shareButton}
       {isOwner && !ddexApp ? editButton : null}


### PR DESCRIPTION
### Description
Missed one place where we wanted to change the order of the social action buttons. Share should appear after the others.

### How Has This Been Tested?

Non-owner
![Simulator Screenshot - iPhone 15 Pro - 2024-07-22 at 15 15 21](https://github.com/user-attachments/assets/daa6952d-0dc2-40dd-bb63-a47789fa5f21)

Owner
![Simulator Screenshot - iPhone 15 Pro - 2024-07-22 at 15 19 43](https://github.com/user-attachments/assets/71251ac7-b0b4-47fa-8c08-ffc3ee95acf0)
