### PR TITLE
[QA-1449] [C-4808] Reassign playlist_contents in get_bulk_playlists

### DIFF
--- a/packages/discovery-provider/src/api/v1/playlists.py
+++ b/packages/discovery-provider/src/api/v1/playlists.py
@@ -150,6 +150,12 @@ def get_bulk_playlists(
     playlists = get_playlists(args)
     if playlists:
         extendedPlaylists = list(map(extend_playlist, playlists))
+
+        def add_playlist_contents(playlist):
+            playlist["playlist_contents"] = playlist["added_timestamps"]
+            return playlist
+
+        extendedPlaylists = list(map(add_playlist_contents, playlists))
         return extendedPlaylists
     return None
 


### PR DESCRIPTION
### Description

Interesting timing, there was an outstanding issue with `get_bulk_playlists` not populating `playlist_contents`.

The logic to filter out hidden tracks #8985 expects `playlist_contents` to exist but the `get_bulk_playlists` wasn't populating it from `added_timestamps` like `get_playlist` is. Ironic that we were just discussing #9217 

### How Has This Been Tested?
Can properly fetch playlists using bulk endpoint on local stack
