### PR TITLE
[C-4792] Disallow Add To Playlist for hidden tracks

### DIFF
--- a/packages/web/src/components/menu/TrackMenu.tsx
+++ b/packages/web/src/components/menu/TrackMenu.tsx
@@ -302,7 +302,7 @@ const TrackMenu = (props: TrackMenuProps) => {
     if (includeAddToAlbum && !isDeleted && isOwner) {
       menu.items.push(addToAlbumMenuItem)
     }
-    if (includeAddToPlaylist && !isDeleted) {
+    if (includeAddToPlaylist && !isDeleted && (!isUnlisted || isOwner)) {
       menu.items.push(addToPlaylistMenuItem)
     }
     if (trackId && trackTitle && !isDeleted) {

--- a/packages/web/src/components/now-playing/NowPlaying.tsx
+++ b/packages/web/src/components/now-playing/NowPlaying.tsx
@@ -320,7 +320,7 @@ const NowPlaying = g(
             : OverflowAction.FAVORITE
           : null,
         isOwner ? OverflowAction.ADD_TO_ALBUM : null,
-        !collectible && !track?.is_stream_gated
+        !collectible && (!track?.is_unlisted || isOwner)
           ? OverflowAction.ADD_TO_PLAYLIST
           : null,
         track && OverflowAction.VIEW_TRACK_PAGE,

--- a/packages/web/src/components/track/mobile/ConnectedTrackListItem.tsx
+++ b/packages/web/src/components/track/mobile/ConnectedTrackListItem.tsx
@@ -76,6 +76,7 @@ const ConnectedTrackListItem = (props: ConnectedTrackListItemProps) => {
     setLockedContentVisibility(true)
   }, [dispatch, trackId, setLockedContentVisibility])
 
+  const isOwner = user?.user_id === currentUserId
   const onClickOverflow = () => {
     const overflowActions = [
       isPurchase && !hasStreamAccess && !isDeleted
@@ -94,7 +95,7 @@ const ConnectedTrackListItem = (props: ConnectedTrackListItemProps) => {
       user?.user_id === currentUserId && !ddexApp
         ? OverflowAction.ADD_TO_ALBUM
         : null,
-      OverflowAction.ADD_TO_PLAYLIST,
+      !isUnlisted || isOwner ? OverflowAction.ADD_TO_PLAYLIST : null,
       OverflowAction.VIEW_TRACK_PAGE,
       albumInfo ? OverflowAction.VIEW_ALBUM_PAGE : null,
       OverflowAction.VIEW_ARTIST_PAGE

--- a/packages/web/src/components/track/mobile/ConnectedTrackTile.tsx
+++ b/packages/web/src/components/track/mobile/ConnectedTrackTile.tsx
@@ -210,7 +210,7 @@ const ConnectedTrackTile = ({
       repostAction,
       favoriteAction,
       addToAlbumAction,
-      OverflowAction.ADD_TO_PLAYLIST,
+      !is_unlisted || isOwner ? OverflowAction.ADD_TO_PLAYLIST : null,
       isNewPodcastControlsEnabled && isLongFormContent
         ? OverflowAction.VIEW_EPISODE_PAGE
         : OverflowAction.VIEW_TRACK_PAGE,

--- a/packages/web/src/pages/track-page/components/mobile/TrackHeader.tsx
+++ b/packages/web/src/pages/track-page/components/mobile/TrackHeader.tsx
@@ -236,7 +236,7 @@ const TrackHeader = ({
         ? OverflowAction.UNFAVORITE
         : OverflowAction.FAVORITE,
       isOwner && !track?.ddex_app ? OverflowAction.ADD_TO_ALBUM : null,
-      OverflowAction.ADD_TO_PLAYLIST,
+      isOwner || !isUnlisted ? OverflowAction.ADD_TO_PLAYLIST : null,
       albumInfo ? OverflowAction.VIEW_ALBUM_PAGE : null,
       isFollowing
         ? OverflowAction.UNFOLLOW_ARTIST


### PR DESCRIPTION
### Description

Gated content is allowed in playlists, but not hidden content unless you're the owner.

We missed a case on web and a few cases on mobile + mobile web

![Screenshot 2024-07-22 at 4 26 33 PM](https://github.com/user-attachments/assets/77589a74-ea35-4d29-a3c0-629db86e9a2a)


### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._
