### PR TITLE
Fix same day scheduled release on web

### DIFF
--- a/packages/web/src/components/edit/fields/visibility/ScheduledReleaseDateField.tsx
+++ b/packages/web/src/components/edit/fields/visibility/ScheduledReleaseDateField.tsx
@@ -1,12 +1,14 @@
 import { visibilityMessages } from '@audius/common/messages'
 import { Box, Flex, Hint } from '@audius/harmony'
-import { useField } from 'formik'
+import { useField, useFormikContext } from 'formik'
 
 import { HarmonyTextField } from 'components/form-fields/HarmonyTextField'
 import { SelectField } from 'components/form-fields/SelectField'
 import { getLocalTimezone } from 'utils/dateUtils'
 
 import { DatePickerField } from '../DatePickerField'
+import { useEffect } from 'react'
+import dayjs from 'dayjs'
 
 const messages = {
   ...visibilityMessages,
@@ -16,6 +18,14 @@ const messages = {
 
 export const ScheduledReleaseDateField = () => {
   const [{ value: releaseDate }, { touched }] = useField('releaseDate')
+  const { setFieldValue } = useFormikContext()
+
+  useEffect(() => {
+    if (releaseDate && touched && dayjs().isSame(dayjs(releaseDate), 'day')) {
+      setFieldValue('releaseDateTime', '11:59')
+      setFieldValue('releaseDateMeridian', 'PM')
+    }
+  }, [releaseDate, touched])
 
   return (
     <Flex direction='column' gap='l'>

--- a/packages/web/src/components/edit/fields/visibility/ScheduledReleaseDateField.tsx
+++ b/packages/web/src/components/edit/fields/visibility/ScheduledReleaseDateField.tsx
@@ -1,5 +1,8 @@
+import { useEffect } from 'react'
+
 import { visibilityMessages } from '@audius/common/messages'
 import { Box, Flex, Hint } from '@audius/harmony'
+import dayjs from 'dayjs'
 import { useField, useFormikContext } from 'formik'
 
 import { HarmonyTextField } from 'components/form-fields/HarmonyTextField'
@@ -7,8 +10,6 @@ import { SelectField } from 'components/form-fields/SelectField'
 import { getLocalTimezone } from 'utils/dateUtils'
 
 import { DatePickerField } from '../DatePickerField'
-import { useEffect } from 'react'
-import dayjs from 'dayjs'
 
 const messages = {
   ...visibilityMessages,
@@ -25,6 +26,7 @@ export const ScheduledReleaseDateField = () => {
       setFieldValue('releaseDateTime', '11:59')
       setFieldValue('releaseDateMeridian', 'PM')
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [releaseDate, touched])
 
   return (


### PR DESCRIPTION
### Description

Improves same day scheduled release on web by setting time to 11:59 pm when releaseDate selected for same day. This already exists on mobile.