### PR TITLE
prune ops. advance crudr cursors. give all audio analysis work to storeall node

### DIFF
--- a/mediorum/ddl/drop_uploads_audio_analysis_ops.sql
+++ b/mediorum/ddl/drop_uploads_audio_analysis_ops.sql
@@ -1,0 +1,8 @@
+begin;
+    delete from ops where "table" = 'uploads' and action = 'update' and exists (
+        select 1
+        from jsonb_array_elements(data) as elem
+        where elem->>'audio_analysis_status' = 'timeout'
+        and elem->'selected_preview' = '{"Valid": false, "String": ""}'
+    );
+commit;

--- a/mediorum/server/audio_analysis.go
+++ b/mediorum/server/audio_analysis.go
@@ -45,6 +45,7 @@ func (ss *MediorumServer) startAudioAnalyzer() {
 			continue
 		}
 		_, isMine := ss.rendezvousAllHosts(cid)
+		isMine = isMine || (ss.Config.Env == "prod" && ss.Config.Self.Host == "https://creatornode2.audius.co")
 		if isMine && upload.AudioAnalysisErrorCount < MAX_TRIES {
 			work <- upload
 		}

--- a/mediorum/server/legacy_audio_analysis.go
+++ b/mediorum/server/legacy_audio_analysis.go
@@ -17,6 +17,11 @@ const MAX_TRIES = 5
 
 // scroll qm cids
 func (ss *MediorumServer) startLegacyAudioAnalyzer() {
+	if ss.Config.Env == "prod" && ss.Config.Self.Host != "https://creatornode2.audius.co" {
+		// prod CN2 (storeall node) analyzes all remaining legacy cids
+		return
+	}
+
 	ctx := context.Background()
 	logger := ss.logger
 
@@ -41,7 +46,7 @@ func (ss *MediorumServer) startLegacyAudioAnalyzer() {
 		}
 
 		preferredHosts, isMine := ss.rendezvousAllHosts(cid)
-		if !isMine {
+		if ss.Config.Env != "prod" && !isMine {
 			return nil
 		}
 

--- a/mediorum/server/legacy_audio_analysis.go
+++ b/mediorum/server/legacy_audio_analysis.go
@@ -13,7 +13,7 @@ import (
 	"gocloud.dev/gcerrors"
 )
 
-const MAX_TRIES = 5
+const MAX_TRIES = 3
 
 // scroll qm cids
 func (ss *MediorumServer) startLegacyAudioAnalyzer() {
@@ -27,7 +27,7 @@ func (ss *MediorumServer) startLegacyAudioAnalyzer() {
 
 	work := make(chan *QmAudioAnalysis)
 
-	numWorkers := 4
+	numWorkers := 5
 
 	// start workers
 	for i := 0; i < numWorkers; i++ {


### PR DESCRIPTION
### Description
- remove audio_analysis_status: timeout ops updates to the uploads table
- advance crudr cursors, which are currently weeks behind, to  `01J3C13JH1X7SHJYZ7PV250WPK` (`2024-07-22T01:32:42.913Z`)
- give all remaining legacy qm id work to the prod storeall node, since SPs are not picking up the remaining ~200,000 for some reason
- give ba analysis backfill jobs to prod cn2 in addition to the preferred hosts

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._
