### PR TITLE
Fix type error from SDK update

### DIFF
--- a/packages/common/src/api/library.ts
+++ b/packages/common/src/api/library.ts
@@ -58,7 +58,7 @@ const fetchLibraryCollections = async ({
       ? await sdk.full.users.getUserLibraryAlbums(requestParams)
       : await sdk.full.users.getUserLibraryPlaylists(requestParams)
   const collections = rawCollections
-    .map((r: APIActivityV2) => makeActivity(r))
+    .map((r) => makeActivity(r as APIActivityV2))
     .filter(removeNullable) as UserCollectionMetadata[]
   return collections
 }


### PR DESCRIPTION
### Description
There is another PR in the pipeline that will update this code to use the new transformers. But until that is merged, this will fix the type error on `main`

### How Has This Been Tested?
`npm run verify -w @audius/web -w @audius/mobile -w @audius/common`
