### PR TITLE
PAY-3186 Fixes issue preventing edit screen from opening twice

### DIFF
--- a/packages/mobile/src/hooks/useNavigation.ts
+++ b/packages/mobile/src/hooks/useNavigation.ts
@@ -8,7 +8,6 @@ import { useNavigation as useNativeNavigation } from '@react-navigation/native'
 import type { NativeStackNavigationProp } from '@react-navigation/native-stack'
 import { isEqual } from 'lodash'
 
-import { lastNavAction, setLastNavAction } from 'app/screens/app-screen'
 import { getNearestStackNavigator } from 'app/utils/navigation'
 
 export type ContextualParams = {
@@ -27,6 +26,11 @@ type PerformNavigationConfig<
 
 type UseNavigationOptions<NavigationProp extends RNNavigationProp<any>> = {
   customNavigation?: NavigationProp
+}
+
+let lastNavAction: any
+export const setLastNavAction = (action: any) => {
+  lastNavAction = action
 }
 
 /**

--- a/packages/mobile/src/screens/app-screen/AppScreen.tsx
+++ b/packages/mobile/src/screens/app-screen/AppScreen.tsx
@@ -1,6 +1,10 @@
+import { useCallback } from 'react'
+
 import { MobileOS } from '@audius/common/models'
 import { createNativeStackNavigator } from '@react-navigation/native-stack'
 import { Platform } from 'react-native'
+
+import { setLastNavAction } from 'app/hooks/useNavigation'
 
 import { ChangeEmailModalScreen } from '../change-email-screen/ChangeEmailScreen'
 import { ChangePasswordModalScreen } from '../change-password-screen'
@@ -16,8 +20,21 @@ import { AppTabsScreen } from './AppTabsScreen'
 const Stack = createNativeStackNavigator()
 
 export const AppScreen = () => {
+  /**
+   * Reset lastNavAction on transitionEnd
+   * Need to do this via screenListeners on the Navigator because listening
+   * via navigation.addListener inside a screen does not always
+   * catch events from other screens
+   */
+  const handleTransitionEnd = useCallback(() => {
+    setLastNavAction(undefined)
+  }, [])
+
   return (
-    <Stack.Navigator screenOptions={{ headerShown: false }}>
+    <Stack.Navigator
+      screenOptions={{ headerShown: false }}
+      screenListeners={{ transitionEnd: handleTransitionEnd }}
+    >
       <Stack.Screen name='AppTabs' component={AppTabsScreen} />
       <Stack.Group screenOptions={{ presentation: 'fullScreenModal' }}>
         <Stack.Screen
@@ -29,7 +46,13 @@ export const AppScreen = () => {
           }
         />
         <Stack.Screen name='Upload' component={UploadModalScreen} />
-        <Stack.Screen name='EditTrack' component={EditTrackModalScreen} />
+        <Stack.Screen
+          name='EditTrack'
+          component={EditTrackModalScreen}
+          options={
+            Platform.OS === MobileOS.ANDROID ? { animation: 'none' } : undefined
+          }
+        />
         <Stack.Screen name='EditCollection' component={EditCollectionScreen} />
         <Stack.Screen
           name='WalletConnect'

--- a/packages/mobile/src/screens/app-screen/AppTabScreen.tsx
+++ b/packages/mobile/src/screens/app-screen/AppTabScreen.tsx
@@ -17,6 +17,7 @@ import type { EventArg, NavigationState } from '@react-navigation/native'
 import type { createNativeStackNavigator } from '@react-navigation/native-stack'
 
 import { useDrawer } from 'app/hooks/useDrawer'
+import { setLastNavAction } from 'app/hooks/useNavigation'
 import { useFeatureFlag } from 'app/hooks/useRemoteConfig'
 import { AiGeneratedTracksScreen } from 'app/screens/ai-generated-tracks-screen'
 import { AppDrawerContext } from 'app/screens/app-drawer-screen'
@@ -145,11 +146,6 @@ type AppTabScreenProps = {
   Stack: ReturnType<typeof createNativeStackNavigator>
 }
 
-export let lastNavAction: any
-export const setLastNavAction = (action: any) => {
-  lastNavAction = action
-}
-
 /**
  * This is the base tab screen that includes common screens
  * like track and profile
@@ -185,7 +181,7 @@ export const AppTabScreen = ({ baseScreen, Stack }: AppTabScreenProps) => {
    * catch events from other screens
    */
   const handleTransitionEnd = useCallback(() => {
-    lastNavAction = undefined
+    setLastNavAction(undefined)
   }, [])
 
   useEffect(() => {


### PR DESCRIPTION
### Description

React Navigation's native stack navigator has an issue that allows the same screen to get pushed on the stack multiple times, so we've created a custom "push" callback that prevents duplicate screens from getting pushed. However, in this case, the "back" navigation happens in the context of a different stack navigator, so the "last action" is still the "edit track screen" when the user backs out of editing their track, causing our custom override to erroneously consider it a dupe if we tried to edit the track again.

This PR follows the same logic used in the AppTabScreen to unset the lastAction on the transition end of the stack navigator, also moving the logical components to the hook file to keep them close to the usage. Additionally, to prevent white screens for the edit track screen on Android, this PR copies the logic used for the TipArtist modal screen to prevent the animations that cause the white screen.

### How Has This Been Tested?

Tested on Android simulator