### PR TITLE
[C-4865] Make metadata links visible

### DIFF
--- a/packages/mobile/src/components/details-tile/CollectionMetadataList.tsx
+++ b/packages/mobile/src/components/details-tile/CollectionMetadataList.tsx
@@ -1,7 +1,7 @@
 import { useCollectionMetadata } from '@audius/common/hooks'
 import type { ID } from '@audius/common/models'
 
-import { Flex } from '@audius/harmony-native'
+import { Flex, Text } from '@audius/harmony-native'
 
 import { MetadataItem } from './MetadataItem'
 
@@ -21,7 +21,9 @@ export const CollectionMetadataList = ({
     <Flex gap='l' w='100%' direction='row' wrap='wrap'>
       {metadataItems.map(({ label, id, value }) => (
         <MetadataItem key={id} label={label}>
-          {value}
+          <Text variant='body' size='s' strength='strong'>
+            {value}
+          </Text>
         </MetadataItem>
       ))}
     </Flex>

--- a/packages/mobile/src/components/details-tile/MetadataItem.tsx
+++ b/packages/mobile/src/components/details-tile/MetadataItem.tsx
@@ -12,9 +12,7 @@ export const MetadataItem = ({ label, children }: MetadataItemProps) => {
       <Text variant='label' color='subdued'>
         {label}
       </Text>
-      <Text variant='body' size='s' strength='strong'>
-        {children}
-      </Text>
+      {children}
     </Flex>
   )
 }

--- a/packages/mobile/src/components/details-tile/TrackMetadataList.tsx
+++ b/packages/mobile/src/components/details-tile/TrackMetadataList.tsx
@@ -20,27 +20,36 @@ const messages = {
 
 const renderMood = (mood: string, onPress: () => void) => {
   return (
-    <TextLink variant='visible' onPress={onPress}>
-      <Flex direction='row' gap='xs' alignItems='center'>
-        <Text variant='body' size='s' strength='strong'>
+    <Flex direction='row' gap='xs' alignItems='center'>
+      <Image
+        source={moodMap[mood as Mood]}
+        style={{ height: spacing.l, width: spacing.l }}
+      />
+
+      <Text variant='body' size='s' strength='strong'>
+        <TextLink variant='visible' onPress={onPress}>
           {mood}
-        </Text>
-        <Image
-          source={moodMap[mood as Mood]}
-          style={{ height: spacing.l, width: spacing.l }}
-        />
-      </Flex>
-    </TextLink>
+        </TextLink>
+      </Text>
+    </Flex>
   )
 }
 
 const renderFilterLink = (value: string, onPress: () => void) => {
   return (
-    <TextLink onPress={onPress}>
-      <Text variant='body' size='s' strength='strong'>
+    <Text variant='body' size='s' strength='strong'>
+      <TextLink variant='visible' onPress={onPress}>
         {value}
-      </Text>
-    </TextLink>
+      </TextLink>
+    </Text>
+  )
+}
+
+const renderText = (value: string) => {
+  return (
+    <Text variant='body' size='s' strength='strong'>
+      {value}
+    </Text>
   )
 }
 
@@ -67,7 +76,7 @@ const renderMetadataValue = (
         })
       })
     default:
-      return value
+      return renderText(value)
   }
 }
 
@@ -105,9 +114,11 @@ export const TrackMetadataList = ({ trackId }: TrackMetadataListProps) => {
       ))}
       {albumInfo ? (
         <MetadataItem label={messages.album}>
-          <TextLink to={albumInfo.permalink}>
-            {albumInfo.playlist_name}
-          </TextLink>
+          <Text variant='body' size='s' strength='strong'>
+            <TextLink variant='visible' to={albumInfo.permalink}>
+              {albumInfo.playlist_name}
+            </TextLink>
+          </Text>
         </MetadataItem>
       ) : null}
     </Flex>


### PR DESCRIPTION
### Description

The Text component styling was overriding the visible link styling because it was nested inside. Moving the Text outside fixes the issue
![Simulator Screenshot - iPhone 15 Pro - 2024-07-23 at 16 32 13](https://github.com/user-attachments/assets/8761cda4-6eab-4397-bf5d-ad26840fc202)



### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._
