### PR TITLE
[C-4634] Add popularity sort to users and collections

### DIFF
--- a/packages/discovery-provider/src/queries/search_es.py
+++ b/packages/discovery-provider/src/queries/search_es.py
@@ -716,7 +716,7 @@ def track_dsl(
                             double socialScore = followerCount;
                             // Get the current time and updated_at time in milliseconds
                             long currentTime = new Date().getTime();
-                            long updatedAt = doc['updated_at'].value.toInstant().toEpochMilli();
+                            long createdAt = doc['created_at'].value.toInstant().toEpochMilli();
 
                             // Define time thresholds in milliseconds
                             long oneWeek = 7L * 24L * 60L * 60L * 1000L;
@@ -724,7 +724,7 @@ def track_dsl(
 
                             // Calculate recency factor based on time thresholds
                             double recencyFactor;
-                            long timeDiff = currentTime - updatedAt;
+                            long timeDiff = currentTime - createdAt;
 
                             if (timeDiff <= oneWeek) {
                                 recencyFactor = 3.0;  // Most recent (week)
@@ -939,6 +939,26 @@ def user_dsl(
 
     if sort_method == "recent":
         query["sort"] = [{"created_at": {"order": "desc"}}]
+    elif sort_method == "popular":
+        query["sort"] = [
+            {
+                "_script": {
+                    "type": "number",
+                    "script": {
+                        "lang": "painless",
+                        "source": """
+                            boolean isVerified = doc['is_verified'].value;
+                            double followerCount = doc['follower_count'].value;
+                            double verifiedMultiplier = isVerified ? 2 : 1;
+
+                            // Calculate the popularity score
+                            return verifiedMultiplier * (followerCount * 0.1);
+                        """,
+                    },
+                    "order": "desc",
+                }
+            }
+        ]
 
     return query
 
@@ -1138,6 +1158,46 @@ def base_playlist_dsl(
 
     if sort_method == "recent":
         query["sort"] = [{"updated_at": {"order": "desc"}}]
+    elif sort_method == "popular":
+        query["sort"] = [
+            {
+                "_script": {
+                    "type": "number",
+                    "script": {
+                        "lang": "painless",
+                        "source": """
+                            double repostCount = doc['repost_count'].value;
+                            double saveCount = doc['save_count'].value;
+                            double followerCount = doc['user.follower_count'].value;
+                            double socialScore = followerCount;
+                            // Get the current time and updated_at time in milliseconds
+                            long currentTime = new Date().getTime();
+                            long updatedAt = doc['updated_at'].value.toInstant().toEpochMilli();
+
+                            // Define time thresholds in milliseconds
+                            long oneWeek = 7L * 24L * 60L * 60L * 1000L;
+                            long oneMonth = 30L * 24L * 60L * 60L * 1000L;
+
+                            // Calculate recency factor based on time thresholds
+                            double recencyFactor;
+                            long timeDiff = currentTime - updatedAt;
+
+                            if (timeDiff <= oneWeek) {
+                                recencyFactor = 3.0;  // Most recent (week)
+                            } else if (timeDiff <= oneMonth) {
+                                recencyFactor = 2.0;  // Recent (month)
+                            } else {
+                                recencyFactor = 1.0;  // Older
+                            }
+
+                            // Calculate the trending score
+                            return ((repostCount * 0.3) + (saveCount * 0.2) + (socialScore * 0.1)) * recencyFactor;
+                        """,
+                    },
+                    "order": "desc",
+                }
+            }
+        ]
 
     return query
 

--- a/packages/web/src/pages/search-page-v2/SortMethodFilterButton.tsx
+++ b/packages/web/src/pages/search-page-v2/SortMethodFilterButton.tsx
@@ -1,0 +1,27 @@
+import { OptionsFilterButton } from '@audius/harmony'
+
+import { useSearchParams, useUpdateSearchParams } from './utils'
+
+const messages = {
+  sortOptionsLabel: 'Sort By'
+}
+
+export const SortMethodFilterButton = () => {
+  const searchParams = useSearchParams()
+  const { sortMethod } = searchParams
+  const updateSortParam = useUpdateSearchParams('sortMethod')
+
+  return (
+    <OptionsFilterButton
+      selection={sortMethod ?? 'relevant'}
+      variant='replaceLabel'
+      optionsLabel={messages.sortOptionsLabel}
+      onChange={updateSortParam}
+      options={[
+        { label: 'Most Relevant', value: 'relevant' },
+        { label: 'Most Popular', value: 'popular' },
+        { label: 'Most Recent', value: 'recent' }
+      ]}
+    />
+  )
+}

--- a/packages/web/src/pages/search-page-v2/search-results/AlbumResults.tsx
+++ b/packages/web/src/pages/search-page-v2/search-results/AlbumResults.tsx
@@ -2,7 +2,7 @@ import { useCallback } from 'react'
 
 import { ID, Kind, Status } from '@audius/common/models'
 import { searchActions } from '@audius/common/store'
-import { Box, Flex, OptionsFilterButton, Text } from '@audius/harmony'
+import { Box, Flex, Text } from '@audius/harmony'
 import { range } from 'lodash'
 import { useDispatch } from 'react-redux'
 
@@ -10,17 +10,13 @@ import { CollectionCard } from 'components/collection'
 import { useIsMobile } from 'hooks/useIsMobile'
 
 import { NoResultsTile } from '../NoResultsTile'
-import {
-  useGetSearchResults,
-  useSearchParams,
-  useUpdateSearchParams
-} from '../utils'
+import { SortMethodFilterButton } from '../SortMethodFilterButton'
+import { useGetSearchResults } from '../utils'
 
 const { addItem: addRecentSearch } = searchActions
 
 const messages = {
-  albums: 'Albums',
-  sortOptionsLabel: 'Sort By'
+  albums: 'Albums'
 }
 
 type AlbumResultsProps = {
@@ -95,10 +91,6 @@ export const AlbumResultsPage = () => {
   const { data: ids, status } = useGetSearchResults('albums')
   const isLoading = status === Status.LOADING
 
-  const searchParams = useSearchParams()
-  const { sortMethod } = searchParams
-  const updateSortParam = useUpdateSearchParams('sortMethod')
-
   const isResultsEmpty = ids?.length === 0
   const showNoResultsTile = !isLoading && isResultsEmpty
 
@@ -109,18 +101,7 @@ export const AlbumResultsPage = () => {
           <Text variant='heading' textAlign='left'>
             {messages.albums}
           </Text>
-          <Flex gap='s'>
-            <OptionsFilterButton
-              selection={sortMethod ?? 'relevant'}
-              variant='replaceLabel'
-              optionsLabel={messages.sortOptionsLabel}
-              onChange={updateSortParam}
-              options={[
-                { label: 'Most Relevant', value: 'relevant' },
-                { label: 'Most Recent', value: 'recent' }
-              ]}
-            />
-          </Flex>
+          <SortMethodFilterButton />
         </Flex>
       ) : null}
       {showNoResultsTile ? <NoResultsTile /> : <AlbumResults ids={ids} />}

--- a/packages/web/src/pages/search-page-v2/search-results/PlaylistResults.tsx
+++ b/packages/web/src/pages/search-page-v2/search-results/PlaylistResults.tsx
@@ -2,7 +2,7 @@ import { useCallback } from 'react'
 
 import { ID, Kind, Status } from '@audius/common/models'
 import { searchActions } from '@audius/common/store'
-import { Box, Flex, OptionsFilterButton, Text } from '@audius/harmony'
+import { Box, Flex, Text } from '@audius/harmony'
 import { range } from 'lodash'
 import { useDispatch } from 'react-redux'
 
@@ -10,11 +10,8 @@ import { CollectionCard } from 'components/collection'
 import { useIsMobile } from 'hooks/useIsMobile'
 
 import { NoResultsTile } from '../NoResultsTile'
-import {
-  useGetSearchResults,
-  useSearchParams,
-  useUpdateSearchParams
-} from '../utils'
+import { SortMethodFilterButton } from '../SortMethodFilterButton'
+import { useGetSearchResults } from '../utils'
 
 const { addItem: addRecentSearch } = searchActions
 
@@ -98,10 +95,6 @@ export const PlaylistResultsPage = () => {
   const { data: ids, status } = useGetSearchResults('playlists')
   const isLoading = status === Status.LOADING
 
-  const searchParams = useSearchParams()
-  const { sortMethod } = searchParams
-  const updateSortParam = useUpdateSearchParams('sortMethod')
-
   const isResultsEmpty = ids?.length === 0
   const showNoResultsTile = !isLoading && isResultsEmpty
 
@@ -121,27 +114,16 @@ export const PlaylistResultsPage = () => {
           <Text variant='heading' textAlign='left'>
             {messages.playlists}
           </Text>
-          <Flex gap='s'>
-            <OptionsFilterButton
-              selection={sortMethod ?? 'relevant'}
-              variant='replaceLabel'
-              optionsLabel={messages.sortOptionsLabel}
-              onChange={updateSortParam}
-              options={[
-                { label: 'Most Relevant', value: 'relevant' },
-                { label: 'Most Recent', value: 'recent' }
-              ]}
-            />
-            {/* <OptionsFilterButton */}
-            {/*   selection={playlistsLayout} */}
-            {/*   variant='replaceLabel' */}
-            {/*   optionsLabel={messages.layoutOptionsLabel} */}
-            {/*   onChange={(value) => { */}
-            {/*     setPlaylistsLayout(value as ViewLayout) */}
-            {/*   }} */}
-            {/*   options={viewLayoutOptions} */}
-            {/* /> */}
-          </Flex>
+          <SortMethodFilterButton />
+          {/* <OptionsFilterButton */}
+          {/*   selection={playlistsLayout} */}
+          {/*   variant='replaceLabel' */}
+          {/*   optionsLabel={messages.layoutOptionsLabel} */}
+          {/*   onChange={(value) => { */}
+          {/*     setPlaylistsLayout(value as ViewLayout) */}
+          {/*   }} */}
+          {/*   options={viewLayoutOptions} */}
+          {/* /> */}
         </Flex>
       ) : null}
       {showNoResultsTile ? <NoResultsTile /> : <PlaylistResults ids={ids} />}

--- a/packages/web/src/pages/search-page-v2/search-results/ProfileResults.tsx
+++ b/packages/web/src/pages/search-page-v2/search-results/ProfileResults.tsx
@@ -2,7 +2,7 @@ import { useCallback } from 'react'
 
 import { ID, Kind, Status } from '@audius/common/models'
 import { searchActions } from '@audius/common/store'
-import { Box, Flex, OptionsFilterButton, Text } from '@audius/harmony'
+import { Box, Flex, Text } from '@audius/harmony'
 import { range } from 'lodash'
 import { useDispatch } from 'react-redux'
 
@@ -10,11 +10,8 @@ import { UserCard } from 'components/user-card'
 import { useIsMobile } from 'hooks/useIsMobile'
 
 import { NoResultsTile } from '../NoResultsTile'
-import {
-  useGetSearchResults,
-  useSearchParams,
-  useUpdateSearchParams
-} from '../utils'
+import { SortMethodFilterButton } from '../SortMethodFilterButton'
+import { useGetSearchResults } from '../utils'
 
 const { addItem: addRecentSearch } = searchActions
 
@@ -94,9 +91,6 @@ export const ProfileResultsPage = () => {
   const { data: ids, status } = useGetSearchResults('users')
   const isLoading = status === Status.LOADING
 
-  const updateSortParam = useUpdateSearchParams('sortMethod')
-  const searchParams = useSearchParams()
-  const { sortMethod } = searchParams
   const isResultsEmpty = ids?.length === 0
   const showNoResultsTile = !isLoading && isResultsEmpty
 
@@ -107,18 +101,7 @@ export const ProfileResultsPage = () => {
           <Text variant='heading' textAlign='left'>
             {messages.profiles}
           </Text>
-          <Flex gap='s'>
-            <OptionsFilterButton
-              selection={sortMethod ?? 'relevant'}
-              variant='replaceLabel'
-              optionsLabel={messages.sortOptionsLabel}
-              onChange={updateSortParam}
-              options={[
-                { label: 'Most Relevant', value: 'relevant' },
-                { label: 'Most Recent', value: 'recent' }
-              ]}
-            />
-          </Flex>
+          <SortMethodFilterButton />
         </Flex>
       ) : null}
       {showNoResultsTile ? <NoResultsTile /> : <ProfileResults ids={ids} />}

--- a/packages/web/src/pages/search-page-v2/search-results/TrackResults.tsx
+++ b/packages/web/src/pages/search-page-v2/search-results/TrackResults.tsx
@@ -21,12 +21,9 @@ import { useIsMobile } from 'hooks/useIsMobile'
 import { useMainContentRef } from 'pages/MainContentContext'
 
 import { NoResultsTile } from '../NoResultsTile'
+import { SortMethodFilterButton } from '../SortMethodFilterButton'
 import { ViewLayout, viewLayoutOptions } from '../types'
-import {
-  ALL_RESULTS_LIMIT,
-  useSearchParams,
-  useUpdateSearchParams
-} from '../utils'
+import { ALL_RESULTS_LIMIT, useSearchParams } from '../utils'
 
 const { makeGetLineupMetadatas } = lineupSelectors
 const { getBuffering, getPlaying } = playerSelectors
@@ -175,10 +172,6 @@ export const TrackResults = (props: TrackResultsProps) => {
 export const TrackResultsPage = () => {
   const isMobile = useIsMobile()
   const [tracksLayout, setTracksLayout] = useState<ViewLayout>('list')
-  const updateSortParam = useUpdateSearchParams('sortMethod')
-
-  const searchParams = useSearchParams()
-  const { sortMethod } = searchParams
 
   return (
     <Flex
@@ -193,17 +186,7 @@ export const TrackResultsPage = () => {
             {messages.tracks}
           </Text>
           <Flex gap='s'>
-            <OptionsFilterButton
-              selection={sortMethod ?? 'relevant'}
-              variant='replaceLabel'
-              optionsLabel={messages.sortOptionsLabel}
-              onChange={updateSortParam}
-              options={[
-                { label: 'Most Relevant', value: 'relevant' },
-                { label: 'Most Popular', value: 'popular' },
-                { label: 'Most Recent', value: 'recent' }
-              ]}
-            />
+            <SortMethodFilterButton />
             <OptionsFilterButton
               selection={tracksLayout}
               variant='replaceLabel'


### PR DESCRIPTION
### Description

- Adds popularity sort for users, based on followers and verification status
- Adds popularity sort for collections, based on likes/reposts and artist social score
- Updates track popularity time series based on created_at, not updated_at
- Consolidates and refactors sort-method-filter-button

Open question: should we include is_verified in the track/collection social score stat?