### PR TITLE
check musical key enum in EM and repairer

### DIFF
--- a/packages/discovery-provider/plugins/pedalboard/apps/backfill-audio-analyses/src/backfill_discovery.ts
+++ b/packages/discovery-provider/plugins/pedalboard/apps/backfill-audio-analyses/src/backfill_discovery.ts
@@ -98,9 +98,13 @@ async function getAudioAnalysis(contentNodes: string[], track: Track) {
         let musicalKey = null
         let bpm = null
         if (results?.key) {
-          musicalKey = results?.key
+          if (results?.key.length <= 12) {
+            musicalKey = results?.key
+          }
         } else if (results?.Key) {
-          musicalKey = results?.Key
+          if (results?.Key.length <= 12) {
+            musicalKey = results?.Key
+          }
         }
         if (results?.bpm) {
           bpm = results?.bpm

--- a/packages/discovery-provider/src/tasks/entity_manager/entities/track.py
+++ b/packages/discovery-provider/src/tasks/entity_manager/entities/track.py
@@ -32,7 +32,7 @@ from src.tasks.entity_manager.utils import (
     parse_release_date,
     validate_signer,
 )
-from src.tasks.metadata import immutable_track_fields
+from src.tasks.metadata import immutable_track_fields, is_valid_musical_key
 from src.tasks.task_helpers import generate_slug_and_collision_id
 from src.utils import helpers
 from src.utils.hardcoded_data import genre_allowlist
@@ -418,6 +418,13 @@ def populate_track_record_metadata(track_record: Track, track_metadata, handle, 
                     track_record.bpm = float(track_metadata["bpm"])  # type: ignore
                 except ValueError:
                     continue
+
+        elif key == "musical_key":
+            if "musical_key" in track_metadata and track_metadata["musical_key"]:
+                if isinstance(
+                    track_metadata["musical_key"], str
+                ) and is_valid_musical_key(track_metadata["musical_key"]):
+                    track_record.musical_key = track_metadata["musical_key"]
 
         else:
             # For most fields, update the track_record when the corresponding field exists

--- a/packages/discovery-provider/src/tasks/metadata.py
+++ b/packages/discovery-provider/src/tasks/metadata.py
@@ -1,6 +1,42 @@
+from enum import Enum
 from typing import Any, List, Optional, TypedDict
 
 # Required format for track metadata retrieved from the content system
+
+
+class MusicalKey(str, Enum):
+    A_MAJOR = "A major"
+    A_MINOR = "A minor"
+    B_FLAT_MAJOR = "B flat major"
+    B_FLAT_MINOR = "B flat minor"
+    B_MAJOR = "B major"
+    B_MINOR = "B minor"
+    C_MAJOR = "C major"
+    C_MINOR = "C minor"
+    D_FLAT_MAJOR = "D flat major"
+    D_FLAT_MINOR = "D flat minor"
+    D_MAJOR = "D major"
+    D_MINOR = "D minor"
+    E_FLAT_MAJOR = "E flat major"
+    E_FLAT_MINOR = "E flat minor"
+    E_MAJOR = "E major"
+    E_MINOR = "E minor"
+    F_MAJOR = "F major"
+    F_MINOR = "F minor"
+    G_FLAT_MAJOR = "G flat major"
+    G_FLAT_MINOR = "G flat minor"
+    G_MAJOR = "G major"
+    G_MINOR = "G minor"
+    A_FLAT_MAJOR = "A flat major"
+    A_FLAT_MINOR = "A flat minor"
+    SILENCE = "Silence"
+
+    def __str__(self) -> str:
+        return str.__str__(self)
+
+
+def is_valid_musical_key(musical_key: str) -> bool:
+    return musical_key in MusicalKey.__members__.values()
 
 
 class TrackParent(TypedDict):

--- a/packages/discovery-provider/src/tasks/repair_audio_analyses.py
+++ b/packages/discovery-provider/src/tasks/repair_audio_analyses.py
@@ -9,6 +9,7 @@ from sqlalchemy.orm.session import Session
 
 from src.models.tracks.track import Track
 from src.tasks.celery_app import celery
+from src.tasks.metadata import is_valid_musical_key
 from src.utils import get_all_nodes
 from src.utils.prometheus_metric import save_duration_metric
 from src.utils.structured_logger import StructuredLogger, log_duration
@@ -21,7 +22,7 @@ BATCH_SIZE = 5000
 
 
 def valid_musical_key(musical_key):
-    return isinstance(musical_key, str) and len(musical_key) <= 12
+    return isinstance(musical_key, str) and is_valid_musical_key(musical_key)
 
 
 def valid_bpm(bpm):


### PR DESCRIPTION
### Description
add stricter musical key validation to the backend by defining an enum that matches the keys output by the c++ keyfinder https://github.com/AudiusProject/audius-protocol/blob/main/mediorum/cpp/keyfinder.cpp#L10

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._
