### PR TITLE
rerun discovery backfill plugin

### DIFF
--- a/packages/discovery-provider/plugins/pedalboard/apps/backfill-audio-analyses/src/backfill_discovery.ts
+++ b/packages/discovery-provider/plugins/pedalboard/apps/backfill-audio-analyses/src/backfill_discovery.ts
@@ -249,6 +249,10 @@ export const backfillDiscovery = async (app: App<SharedData>) => {
     console.error('Missing required delegate private key. Terminating...')
     return
   }
+  if (config.environment != 'prod') {
+    console.log('Discovery audio analysis backfill is only meant to run on prod. Terminating...')
+    return
+  }
   const db = app.getDnDb()
   const BACKFILL_BATCH_SIZE = config.testRun ? 100 : 3000
   await processBatches(db, BACKFILL_BATCH_SIZE)

--- a/packages/discovery-provider/plugins/pedalboard/apps/backfill-audio-analyses/src/backfill_discovery.ts
+++ b/packages/discovery-provider/plugins/pedalboard/apps/backfill-audio-analyses/src/backfill_discovery.ts
@@ -78,13 +78,6 @@ async function getAudioAnalysis(contentNodes: string[], track: Track) {
         timeout: REQUEST_TIMEOUT
       })
       if (response.status == 200) {
-        console.log(
-          `Successfully retrieved audio analysis for track ID ${
-            track.track_id
-          }, track CID ${trackCid}${
-            audioUploadId ? `, upload ID: ${audioUploadId}` : ''
-          } via ${contentNode}`
-        )
         const resultsKey = isLegacyTrack ? 'results' : 'audio_analysis_results'
         const errorCountKey = isLegacyTrack
           ? 'error_count'
@@ -92,19 +85,31 @@ async function getAudioAnalysis(contentNodes: string[], track: Track) {
         const results = response.data[resultsKey]
         const errorCount = response.data[errorCountKey]
         if (!results) {
-          break
+          continue
         }
+
+        console.log(
+          `Successfully retrieved audio analysis results for track ID ${
+            track.track_id
+          }, track CID ${trackCid}${
+            audioUploadId ? `, upload ID: ${audioUploadId}` : ''
+          } via ${contentNode}`
+        )
 
         let musicalKey = null
         let bpm = null
         if (results?.key) {
-          if (results?.key.length <= 12) {
-            musicalKey = results?.key
+          if (results?.key.length > 12) {
+            console.log(`Skipping bad musical key from ${analysisUrl}`)
+            continue
           }
+          musicalKey = results?.key
         } else if (results?.Key) {
-          if (results?.Key.length <= 12) {
-            musicalKey = results?.Key
+          if (results?.Key.length > 12) {
+            console.log(`Skipping bad musical key from ${analysisUrl}`)
+            continue
           }
+          musicalKey = results?.Key
         }
         if (results?.bpm) {
           bpm = results?.bpm

--- a/packages/discovery-provider/plugins/pedalboard/apps/backfill-audio-analyses/src/backfill_discovery.ts
+++ b/packages/discovery-provider/plugins/pedalboard/apps/backfill-audio-analyses/src/backfill_discovery.ts
@@ -16,7 +16,7 @@ const semaphore = new Semaphore(MAX_CONCURRENT_REQUESTS)
 
 const REQUEST_TIMEOUT = 5000 // 5s
 
-const DB_OFFSET_KEY = 'discovery:backfill_audio_analyses:offset'
+const DB_OFFSET_KEY = 'discovery:backfill_audio_analyses:offset2'
 
 interface Track {
   track_id: number
@@ -49,14 +49,10 @@ async function getAudioAnalysis(contentNodes: string[], track: Track) {
   let result = null
 
   const trackCid = track.track_cid
+  if (!trackCid) return result
   // skip tracks that already have their audio analyses
-  if (
-    !trackCid ||
-    track.musical_key ||
-    track.bpm ||
-    track.audio_analysis_error_count! > 0
-  )
-    return result
+  if (track.musical_key && track.bpm) return result
+  if (track.audio_analysis_error_count! >= 3) return result
 
   const audioUploadId = track.audio_upload_id || ''
   const isLegacyTrack = !audioUploadId

--- a/packages/discovery-provider/plugins/pedalboard/apps/backfill-audio-analyses/src/backfill_discovery.ts
+++ b/packages/discovery-provider/plugins/pedalboard/apps/backfill-audio-analyses/src/backfill_discovery.ts
@@ -52,7 +52,6 @@ async function getAudioAnalysis(contentNodes: string[], track: Track) {
   if (!trackCid) return formattedResult
   // skip tracks that already have their audio analyses
   if (track.musical_key && track.bpm) return formattedResult
-  if (track.audio_analysis_error_count! >= 3) return formattedResult
 
   const audioUploadId = track.audio_upload_id || ''
   const isLegacyTrack = !audioUploadId
@@ -67,6 +66,10 @@ async function getAudioAnalysis(contentNodes: string[], track: Track) {
       // choose a random content node
       contentNode =
         contentNodes[Math.floor(Math.random() * contentNodes.length)]
+    }
+    // check storeall node first for any retried errors
+    if (track.audio_analysis_error_count! >= 3 && i == 0) {
+      contentNode = "https://creatornode2.audius.co"
     }
     try {
       let analysisUrl = `${contentNode}/uploads/${audioUploadId}`
@@ -169,6 +172,9 @@ async function fetchTracks(
       'audio_analysis_error_count'
     )
     .andWhere('track_cid', 'is not', null)
+    .andWhere('genre', '!=', 'Podcasts')
+    .andWhere('genre', '!=', 'Podcast')
+    .andWhere('genre', '!=', 'Audiobooks')
     .orderBy('track_id', 'asc')
     .offset(offset)
     .limit(limit)

--- a/packages/discovery-provider/plugins/pedalboard/apps/backfill-audio-analyses/src/backfill_discovery.ts
+++ b/packages/discovery-provider/plugins/pedalboard/apps/backfill-audio-analyses/src/backfill_discovery.ts
@@ -85,9 +85,13 @@ async function getAudioAnalysis(contentNodes: string[], track: Track) {
         const errorCountKey = isLegacyTrack
           ? 'error_count'
           : 'audio_analysis_error_count'
+        const statusKey = isLegacyTrack
+          ? 'status'
+          : 'audio_analysis_status'
         const results = response.data[resultsKey]
         const errorCount = response.data[errorCountKey]
-        if (!results) {
+        const analysisStatus = response.data[statusKey]
+        if (!results && analysisStatus != 'error') {
           continue
         }
 

--- a/packages/discovery-provider/plugins/pedalboard/apps/backfill-audio-analyses/src/backfill_discovery.ts
+++ b/packages/discovery-provider/plugins/pedalboard/apps/backfill-audio-analyses/src/backfill_discovery.ts
@@ -46,13 +46,13 @@ function formatErrorLog(
 }
 
 async function getAudioAnalysis(contentNodes: string[], track: Track) {
-  let result = null
+  let formattedResult = null
 
   const trackCid = track.track_cid
-  if (!trackCid) return result
+  if (!trackCid) return formattedResult
   // skip tracks that already have their audio analyses
-  if (track.musical_key && track.bpm) return result
-  if (track.audio_analysis_error_count! >= 3) return result
+  if (track.musical_key && track.bpm) return formattedResult
+  if (track.audio_analysis_error_count! >= 3) return formattedResult
 
   const audioUploadId = track.audio_upload_id || ''
   const isLegacyTrack = !audioUploadId
@@ -126,7 +126,7 @@ async function getAudioAnalysis(contentNodes: string[], track: Track) {
           break
         }
 
-        result = {
+        formattedResult = {
           track_id: track.track_id,
           musical_key: musicalKey,
           bpm,
@@ -151,7 +151,7 @@ async function getAudioAnalysis(contentNodes: string[], track: Track) {
   }
 
   release() // release the semaphore permit
-  return result
+  return formattedResult
 }
 
 async function fetchTracks(

--- a/packages/discovery-provider/plugins/pedalboard/apps/backfill-audio-analyses/src/backfill_discovery.ts
+++ b/packages/discovery-provider/plugins/pedalboard/apps/backfill-audio-analyses/src/backfill_discovery.ts
@@ -61,9 +61,13 @@ async function getAudioAnalysis(contentNodes: string[], track: Track) {
 
   // allow up to 5 attempts to get audio analysis for this track
   for (let i = 0; i < 5; i++) {
-    // choose a random content node
-    const contentNode =
-      contentNodes[Math.floor(Math.random() * contentNodes.length)]
+    // last attempt will always be to the storeall node
+    let contentNode = "https://creatornode2.audius.co"
+    if (i < 4) {
+      // choose a random content node
+      contentNode =
+        contentNodes[Math.floor(Math.random() * contentNodes.length)]
+    }
     try {
       let analysisUrl = `${contentNode}/uploads/${audioUploadId}`
       if (isLegacyTrack) {

--- a/packages/discovery-provider/src/tasks/repair_audio_analyses.py
+++ b/packages/discovery-provider/src/tasks/repair_audio_analyses.py
@@ -41,7 +41,7 @@ def query_tracks(session: Session) -> List[Track]:
             Track.genre != "Podcast",
             Track.genre != "Audiobooks",
         )
-        .order_by(Track.track_id.asc())
+        .order_by(Track.track_id.desc())
         .limit(BATCH_SIZE)
         .all()
     )


### PR DESCRIPTION
### Description
merge and run on every node after mediorum 100% done backfilling
this is faster than the repairer, which is more meant for fixing 1-off failures from new uploads

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._
