### PR TITLE
[C-4793, C-4791] Don't favorite hidden album tracks on purchase

### DIFF
--- a/packages/common/src/store/purchase-content/sagas.ts
+++ b/packages/common/src/store/purchase-content/sagas.ts
@@ -1,7 +1,6 @@
 import { USDC } from '@audius/fixed-decimal'
 import { type AudiusSdk } from '@audius/sdk'
 import BN from 'bn.js'
-import { is } from 'immer/dist/internal'
 import { sumBy } from 'lodash'
 import { takeLatest } from 'redux-saga/effects'
 import { call, put, race, select, take } from 'typed-redux-saga'

--- a/packages/common/src/store/purchase-content/sagas.ts
+++ b/packages/common/src/store/purchase-content/sagas.ts
@@ -1,6 +1,7 @@
 import { USDC } from '@audius/fixed-decimal'
 import { type AudiusSdk } from '@audius/sdk'
 import BN from 'bn.js'
+import { is } from 'immer/dist/internal'
 import { sumBy } from 'lodash'
 import { takeLatest } from 'redux-saga/effects'
 import { call, put, race, select, take } from 'typed-redux-saga'
@@ -652,19 +653,20 @@ function* doStartPurchaseContentFlow({
     // Poll to confirm purchase (waiting for a signature)
     yield* pollForPurchaseConfirmation({ contentId, contentType })
 
+    const { metadata } = yield* call(getContentInfo, {
+      contentId,
+      contentType
+    })
     // Auto-favorite the purchased item
     if (contentType === PurchaseableContentType.TRACK) {
       yield* put(saveTrack(contentId, FavoriteSource.IMPLICIT))
     }
     if (contentType === PurchaseableContentType.ALBUM) {
-      const { metadata } = yield* call(getContentInfo, {
-        contentId,
-        contentType
-      })
       yield* put(saveCollection(contentId, FavoriteSource.IMPLICIT))
       if (
         'playlist_contents' in metadata &&
-        metadata.playlist_contents.track_ids
+        metadata.playlist_contents.track_ids &&
+        !metadata.is_private
       ) {
         for (const track of metadata.playlist_contents.track_ids) {
           yield* put(saveTrack(track.track, FavoriteSource.IMPLICIT))
@@ -675,11 +677,17 @@ function* doStartPurchaseContentFlow({
     // Check if playing the purchased track's preview and if so, stop it
     const isPreviewing = yield* select(getPreviewing)
     const nowPlayingTrackId = yield* select(getTrackId)
-    if (
+    const isPlayingTrackInAlbum =
+      contentType === PurchaseableContentType.ALBUM &&
+      'playlist_contents' in metadata &&
+      metadata.playlist_contents.track_ids.some(
+        ({ track: trackId }) => trackId === nowPlayingTrackId
+      )
+    const isPlayingPurchasedTrack =
       contentType === PurchaseableContentType.TRACK &&
-      contentId === nowPlayingTrackId &&
-      isPreviewing
-    ) {
+      contentId === nowPlayingTrackId
+
+    if (isPreviewing && (isPlayingTrackInAlbum || isPlayingPurchasedTrack)) {
       yield* put(stop({}))
     }
 


### PR DESCRIPTION
### Description

- Fixes issue where tracks purchased as part of a hidden album purchase were appearing in library during the same session they were purchased
- Also adds album tracks to logic that stops in-progress preview playback on successful purchase. When restarted, the track will play in full

### How Has This Been Tested?

Purchased hidden album on mobile, tracks did not show in library. In progress preview also stopped correctly then played full track when restarted.