### PR TITLE
only analyze first 90s of song

### DIFF
--- a/mediorum/server/audio_analysis.go
+++ b/mediorum/server/audio_analysis.go
@@ -242,7 +242,7 @@ func (ss *MediorumServer) analyzeBPM(filename string) (float64, error) {
 
 // converts an MP3 file to WAV format using ffmpeg
 func convertToWav(inputFile, outputFile string) error {
-	cmd := exec.Command("ffmpeg", "-i", inputFile, "-f", "wav", "-t", "300", outputFile)
+	cmd := exec.Command("ffmpeg", "-i", inputFile, "-f", "wav", "-t", "90", outputFile)
 	if output, err := cmd.CombinedOutput(); err != nil {
 		return fmt.Errorf("failed to convert to WAV: %v, output: %s", err, string(output))
 	}


### PR DESCRIPTION
### Description
analyze faster by only analyzing the first 90s of a song. tested with sebastian's test [data](https://docs.google.com/spreadsheets/d/1mGKArjvdqfbjOIerSRJk0K4pDAtMCNw47tmyQG6debs/edit?usp=sharing) and verified key and bpm analyses were still accurate.

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._
