### PR TITLE
[C-4670] Fix track search with deleted premium stems

### DIFF
--- a/packages/discovery-provider/src/queries/search_es.py
+++ b/packages/discovery-provider/src/queries/search_es.py
@@ -686,7 +686,14 @@ def track_dsl(
                 "bool": {
                     "should": [
                         {"term": {"purchaseable": {"value": True}}},
-                        {"term": {"purchaseable_download": {"value": True}}},
+                        { 
+                            "bool": {
+                                "must": [
+                                    {"term": {"purchaseable_download": {"value": True}}},
+                                    {"term": {"has_stems": {"value": True}}}
+                                ]
+                            }
+                        }
                     ]
                 }
             }

--- a/packages/discovery-provider/src/queries/search_es.py
+++ b/packages/discovery-provider/src/queries/search_es.py
@@ -679,21 +679,40 @@ def track_dsl(
             }
         )
 
-    # Only include the track if it is purchaseable or has purchaseable stems
+    # Only include the track if it is purchaseable or has purchaseable stems/download
     if only_purchaseable:
         dsl["must"].append(
             {
                 "bool": {
                     "should": [
                         {"term": {"purchaseable": {"value": True}}},
-                        { 
+                        {
                             "bool": {
                                 "must": [
-                                    {"term": {"purchaseable_download": {"value": True}}},
-                                    {"term": {"has_stems": {"value": True}}}
+                                    {
+                                        "term": {
+                                            "purchaseable_download": {"value": True}
+                                        }
+                                    },
+                                    {
+                                        "bool": {
+                                            "should": [
+                                                {
+                                                    "term": {
+                                                        "has_stems": {"value": True}
+                                                    }
+                                                },
+                                                {
+                                                    "term": {
+                                                        "downloadable": {"value": True}
+                                                    }
+                                                },
+                                            ]
+                                        }
+                                    },
                                 ]
                             }
-                        }
+                        },
                     ]
                 }
             }

--- a/packages/es-indexer/src/indexNames.ts
+++ b/packages/es-indexer/src/indexNames.ts
@@ -2,6 +2,6 @@ export const indexNames = {
   playlists: 'playlists21',
   reposts: 'reposts13',
   saves: 'saves13',
-  tracks: 'tracks21',
+  tracks: 'tracks22',
   users: 'users16',
 }

--- a/packages/es-indexer/src/listener.ts
+++ b/packages/es-indexer/src/listener.ts
@@ -107,6 +107,13 @@ export async function startListener() {
       for (const r of playlists.rows) {
         pending.playlistIds.add(r.playlist_id)
       }
+      // re-index any tracks this is a stem of
+      const tracks = await client.query(
+        `select parent_track_id from stems where child_track_id = ${track.track_id}`
+      )
+      for (const r of tracks.rows) {
+        pending.trackIds.add(r.parent_track_id)
+      }
     },
     playlists: (playlist: PlaylistRow) => {
       pending.playlistIds.add(playlist.playlist_id)


### PR DESCRIPTION
### Description

Fixes issue where tracks with deleted premium stems were being included in the "premium" search filter.

The fix is two-fold:
- Ensure when premium-conditions set for stems, we actually have stems
- Update triggers to ensure tracks with deleted/added stems are re-indexed, so `has_stems` get's recalculated

@stereosteve not sure if we need to include a reindex change?