### PR TITLE
[PAY-3187] Fix messed up back button form state for payment settings

### DIFF
--- a/packages/mobile/src/components/edit/PriceAndAudienceField/PremiumRadioField/PremiumRadioField.tsx
+++ b/packages/mobile/src/components/edit/PriceAndAudienceField/PremiumRadioField/PremiumRadioField.tsx
@@ -40,7 +40,7 @@ export const PremiumRadioField = (props: PremiumRadioFieldProps) => {
   }, [previousStreamConditions])
 
   const [{ value: preview }] = useField(TRACK_PREVIEW)
-  const previewStartSeconds = useRef(preview ?? 0).current
+  const previewStartSeconds = useRef(preview ?? null).current
   const [{ value: entityType }] = useField('entityType')
 
   useEffect(() => {
@@ -49,7 +49,7 @@ export const PremiumRadioField = (props: PremiumRadioFieldProps) => {
         is_stream_gated: true,
         // @ts-ignore fully formed in saga (validated + added splits)
         stream_conditions: { usdc_purchase: selectedUsdcPurchaseValue },
-        preview_start_seconds: previewStartSeconds,
+        preview_start_seconds: previewStartSeconds ?? 0,
         'field_visibility.remixes': false
       })
     }

--- a/packages/mobile/src/components/edit/PriceAndAudienceField/PriceAndAudienceScreen.tsx
+++ b/packages/mobile/src/components/edit/PriceAndAudienceField/PriceAndAudienceScreen.tsx
@@ -18,6 +18,7 @@ import { useDispatch } from 'react-redux'
 
 import { Hint, IconCart } from '@audius/harmony-native'
 import { useNavigation } from 'app/hooks/useNavigation'
+import { useSetEntityAvailabilityFields } from 'app/hooks/useSetTrackAvailabilityFields'
 import { FormScreen } from 'app/screens/form-screen'
 
 import { EditPriceAndAudienceConfirmationDrawer } from '../../../screens/edit-track-screen/components/EditPriceAndAudienceConfirmationDrawer'
@@ -47,8 +48,8 @@ export const PriceAndAudienceScreen = () => {
     'is_scheduled_release'
   )
   const [{ value: remixOf }] = useField<RemixOfField>('remix_of')
-  const [{ value: isUpload }] = useField<boolean>('is_upload')
   const [{ value: entityType }] = useField<string>('entityType')
+  const isUpload = !initialValues?.track_id
   const isRemix = !!remixOf
 
   const { isEnabled: isEditableAccessEnabled } = useFeatureFlag(
@@ -112,6 +113,7 @@ export const PriceAndAudienceScreen = () => {
 
   const [{ value: price }, { error: priceError }] = useField(TRACK_PRICE)
   const [{ value: preview }, { error: previewError }] = useField(TRACK_PREVIEW)
+  const { set: setTrackAvailabilityFields } = useSetEntityAvailabilityFields()
 
   const usdcGateIsInvalid = useMemo(() => {
     // first time user selects usdc purchase option
@@ -186,13 +188,40 @@ export const PriceAndAudienceScreen = () => {
     )
   }, [dispatch])
 
+  // Listen for `navigation.goBack` events and in the case of going back
+  // reset the availability fields.
+  // Note that this is a stop gap against a better model which would be to have
+  // each radio subgroup manage its own state. That requires a larger refactor.
+  useEffect(() => {
+    const listener = navigation.addListener('beforeRemove', ({ data }) => {
+      if (isFormInvalid && data.action.type === 'GO_BACK') {
+        setTrackAvailabilityFields({
+          is_stream_gated: initialValues.is_stream_gated,
+          stream_conditions: initialValues.stream_conditions,
+          is_unlisted: initialValues.is_unlisted,
+          preview_start_seconds: initialValues.preview_start_seconds,
+          'field_visibility.genre': initialValues.field_visibility?.genre,
+          'field_visibility.mood': initialValues.field_visibility?.mood,
+          'field_visibility.tags': initialValues.field_visibility?.tags,
+          'field_visibility.share': initialValues.field_visibility?.share,
+          'field_visibility.play_count':
+            initialValues.field_visibility?.play_count,
+          'field_visibility.remixes': initialValues.field_visibility?.remixes
+        })
+      }
+    })
+    return () => {
+      navigation.removeListener('beforeRemove', listener)
+    }
+  }, [initialValues, navigation, setTrackAvailabilityFields, isFormInvalid])
+
   return (
     <FormScreen
       title={messages.title}
       icon={IconCart}
       variant='white'
       disableSubmit={isFormInvalid}
-      stopNavigation={usersMayLoseAccess}
+      stopNavigation={!isUpload && usersMayLoseAccess}
       onSubmit={handleSubmit}
     >
       {isRemix ? <Hint m='l'>{messages.markedAsRemix}</Hint> : null}

--- a/packages/mobile/src/components/edit/PriceAndAudienceField/PriceAndAudienceScreen.tsx
+++ b/packages/mobile/src/components/edit/PriceAndAudienceField/PriceAndAudienceScreen.tsx
@@ -49,7 +49,7 @@ export const PriceAndAudienceScreen = () => {
   )
   const [{ value: remixOf }] = useField<RemixOfField>('remix_of')
   const [{ value: entityType }] = useField<string>('entityType')
-  const isUpload = !initialValues?.track_id
+  const [{ value: isUpload }] = useField<boolean>('isUpload')
   const isRemix = !!remixOf
 
   const { isEnabled: isEditableAccessEnabled } = useFeatureFlag(

--- a/packages/mobile/src/hooks/useSetTrackAvailabilityFields.ts
+++ b/packages/mobile/src/hooks/useSetTrackAvailabilityFields.ts
@@ -4,6 +4,19 @@ import type { AccessConditions } from '@audius/common/models'
 import type { Nullable } from '@audius/common/utils'
 import { useField } from 'formik'
 
+type TrackAvailabilityField = {
+  is_stream_gated: boolean
+  stream_conditions: Nullable<AccessConditions>
+  is_unlisted: boolean
+  preview_start_seconds: Nullable<Number>
+  'field_visibility.genre': boolean
+  'field_visibility.mood': boolean
+  'field_visibility.tags': boolean
+  'field_visibility.share': boolean
+  'field_visibility.play_count': boolean
+  'field_visibility.remixes': boolean
+}
+
 // This hook allows us to set track availability fields during upload.
 // It has to be used with a Formik context because it uses formik's useField hook.
 export const useSetEntityAvailabilityFields = () => {
@@ -50,7 +63,6 @@ export const useSetEntityAvailabilityFields = () => {
     }),
     [isScheduledRelease, isUnlisted]
   )
-  type TrackAvailabilityField = typeof defaultTrackAvailabilityFields
 
   const fieldSetters = useMemo(() => {
     return {

--- a/packages/mobile/src/screens/form-screen/FormScreen.tsx
+++ b/packages/mobile/src/screens/form-screen/FormScreen.tsx
@@ -38,7 +38,7 @@ export const FormScreen = (props: FormScreenProps) => {
 
   const handleSubmit = useCallback(() => {
     if (!stopNavigation) {
-      navigation.goBack()
+      navigation.pop()
     }
     onSubmit?.()
   }, [stopNavigation, navigation, onSubmit])


### PR DESCRIPTION
### Description

I wish I had a bit of better fix for this, but it requires a much larger refactor that I now understand.

* Fix bug where you can brick yourself with invalid price / audience state (pay-3187)
* Fix bad initial state val for preview
* Fix isUpload check (back to what it was)
* Fix stop navigation check from failing during upload

This change works by listening to GO_BACK actions from the navigator and re-setting the changes that the inner form made on the formik context.

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._

1. Upload track
2. Visit Price & Audience section
3. Press Premium
4. Go back
5. See that Free For Everyone sticks (previously we would get payment setting set with `null`)

Same flow, but type a number value and press done and see that it will stick