### PR TITLE
[C-4866] Fix edit collection form submit

### DIFF
--- a/packages/web/src/components/edit-collection/EditCollectionForm.tsx
+++ b/packages/web/src/components/edit-collection/EditCollectionForm.tsx
@@ -101,8 +101,11 @@ export const EditCollectionForm = (props: EditCollectionFormProps) => {
           } else {
             setConfirmDrawerType('release')
           }
+          setIsReleaseConfirmationOpen(true)
+        } else {
+          setIsReleaseConfirmationOpen(false)
+          onSubmit(values)
         }
-        setIsReleaseConfirmationOpen(true)
       }
     },
     [


### PR DESCRIPTION
### Description

Fixes edit collection form submission requiring two clicks. Ultimately issue had to do with not calling onSubmit when release confirmation drawer is not necessary. I checked edit track and now both operate the same way.