### PR TITLE
[C-4840] Update search screen to auto focus the input

### DIFF
--- a/packages/mobile/src/screens/app-screen/useAppScreenOptions.tsx
+++ b/packages/mobile/src/screens/app-screen/useAppScreenOptions.tsx
@@ -82,7 +82,7 @@ export const useAppScreenOptions = (
 
   const handlePressSearch = useCallback(() => {
     dispatch(clearSearch())
-    navigation.navigate('Search', {})
+    navigation.navigate('Search', { autoFocus: true })
   }, [dispatch, navigation])
 
   const { isEnabled: isEarlyAccess } = useFeatureFlag(FeatureFlags.EARLY_ACCESS)

--- a/packages/mobile/src/screens/search-screen-v2/SearchBarV2.tsx
+++ b/packages/mobile/src/screens/search-screen-v2/SearchBarV2.tsx
@@ -1,3 +1,7 @@
+import type { Ref } from 'react'
+import { forwardRef } from 'react'
+
+import type { TextInput as RNTextInput } from 'react-native'
 import { Dimensions } from 'react-native'
 
 import {
@@ -17,34 +21,42 @@ const messages = {
   label: 'Search'
 }
 
-export const SearchBarV2 = () => {
-  const [query, setQuery] = useSearchQuery()
-
-  const clearQuery = () => {
-    setQuery('')
-  }
-
-  return (
-    <TextInput
-      startIcon={IconSearch}
-      endIcon={() =>
-        query ? (
-          <IconButton
-            icon={IconCloseAlt}
-            size='s'
-            color='subdued'
-            onPress={clearQuery}
-            hitSlop={10}
-          />
-        ) : null
-      }
-      size={TextInputSize.SMALL}
-      label={messages.label}
-      placeholder={messages.label}
-      style={{ width: searchBarWidth }}
-      innerContainerStyle={query ? { paddingRight: spacing.s } : {}}
-      value={query}
-      onChangeText={setQuery}
-    />
-  )
+type SearchBarV2Props = {
+  autoFocus?: boolean
 }
+
+export const SearchBarV2 = forwardRef(
+  ({ autoFocus = false }: SearchBarV2Props, ref: Ref<RNTextInput>) => {
+    const [query, setQuery] = useSearchQuery()
+
+    const clearQuery = () => {
+      setQuery('')
+    }
+
+    return (
+      <TextInput
+        ref={ref}
+        autoFocus={autoFocus}
+        startIcon={IconSearch}
+        endIcon={() =>
+          query ? (
+            <IconButton
+              icon={IconCloseAlt}
+              size='s'
+              color='subdued'
+              onPress={clearQuery}
+              hitSlop={10}
+            />
+          ) : null
+        }
+        size={TextInputSize.SMALL}
+        label={messages.label}
+        placeholder={messages.label}
+        style={{ width: searchBarWidth }}
+        innerContainerStyle={query ? { paddingRight: spacing.s } : {}}
+        value={query}
+        onChangeText={setQuery}
+      />
+    )
+  }
+)

--- a/packages/mobile/src/screens/search-screen-v2/SearchScreenV2.tsx
+++ b/packages/mobile/src/screens/search-screen-v2/SearchScreenV2.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react'
+import { useEffect, useMemo, useRef, useState } from 'react'
 
 import type {
   SearchCategory,
@@ -6,8 +6,11 @@ import type {
 } from '@audius/common/api'
 import { Kind } from '@audius/common/models'
 import { searchSelectors } from '@audius/common/store'
+import { useIsFocused } from '@react-navigation/core'
 import { createNativeStackNavigator } from '@react-navigation/native-stack'
+import type { TextInput } from 'react-native/types'
 import { useSelector } from 'react-redux'
+import { useEffectOnce } from 'react-use'
 
 import { Flex } from '@audius/harmony-native'
 import { Screen } from 'app/components/core'
@@ -28,6 +31,7 @@ import {
 import { SearchResults } from './search-results/SearchResults'
 import {
   SearchContext,
+  useSearchAutoFocus,
   useSearchCategory,
   useSearchFilters,
   useSearchQuery
@@ -48,6 +52,7 @@ export const SearchScreenV2 = () => {
   const [query] = useSearchQuery()
   const [category] = useSearchCategory()
   const [filters] = useSearchFilters()
+  const [autoFocus, setAutoFocus] = useSearchAutoFocus()
   const history = useSelector(getV2SearchHistory)
   const categoryKind: Kind | null = category
     ? itemKindByCategory[category]
@@ -64,8 +69,27 @@ export const SearchScreenV2 = () => {
   const showSearchResults =
     query || Object.values(filters).some((filter) => filter)
 
+  const searchBarRef = useRef<TextInput>(null)
+  const isFocused = useIsFocused()
+  const [refsSet, setRefsSet] = useState(false)
+
+  useEffectOnce(() => {
+    setRefsSet(true)
+  })
+
+  useEffect(() => {
+    if (isFocused && refsSet && autoFocus) {
+      setAutoFocus(false)
+      searchBarRef.current?.focus()
+    }
+  }, [autoFocus, isFocused, refsSet, setAutoFocus])
+
   return (
-    <Screen topbarRight={<SearchBarV2 />} headerTitle={null} variant='white'>
+    <Screen
+      topbarRight={<SearchBarV2 ref={searchBarRef} autoFocus />}
+      headerTitle={null}
+      variant='white'
+    >
       <SearchCategoriesAndFilters />
       <Flex flex={1}>
         {!showSearchResults ? (
@@ -89,6 +113,7 @@ export const SearchScreenV2 = () => {
 
 export const SearchScreenStack = () => {
   const { params = {} } = useRoute<'Search'>()
+  const [autoFocus, setAutoFocus] = useState(params.autoFocus ?? false)
   const [query, setQuery] = useState(params.query ?? '')
   const [category, setCategory] = useState<SearchCategory>(
     params.category ?? 'all'
@@ -102,6 +127,7 @@ export const SearchScreenStack = () => {
     setQuery(params.query ?? '')
     setCategory(params.category ?? 'all')
     setFilters(params.filters ?? {})
+    setAutoFocus(params.autoFocus ?? false)
   }, [params])
 
   const screenOptions = useAppScreenOptions()
@@ -109,6 +135,8 @@ export const SearchScreenStack = () => {
   return (
     <SearchContext.Provider
       value={{
+        autoFocus,
+        setAutoFocus,
         query,
         setQuery,
         category,

--- a/packages/mobile/src/screens/search-screen-v2/SearchScreenV2.tsx
+++ b/packages/mobile/src/screens/search-screen-v2/SearchScreenV2.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 
 import type {
   SearchCategory,
@@ -6,7 +6,7 @@ import type {
 } from '@audius/common/api'
 import { Kind } from '@audius/common/models'
 import { searchSelectors } from '@audius/common/store'
-import { useIsFocused } from '@react-navigation/core'
+import { useFocusEffect } from '@react-navigation/native'
 import { createNativeStackNavigator } from '@react-navigation/native-stack'
 import type { TextInput } from 'react-native/types'
 import { useSelector } from 'react-redux'
@@ -70,19 +70,20 @@ export const SearchScreenV2 = () => {
     query || Object.values(filters).some((filter) => filter)
 
   const searchBarRef = useRef<TextInput>(null)
-  const isFocused = useIsFocused()
   const [refsSet, setRefsSet] = useState(false)
 
   useEffectOnce(() => {
     setRefsSet(true)
   })
 
-  useEffect(() => {
-    if (isFocused && refsSet && autoFocus) {
-      setAutoFocus(false)
-      searchBarRef.current?.focus()
-    }
-  }, [autoFocus, isFocused, refsSet, setAutoFocus])
+  useFocusEffect(
+    useCallback(() => {
+      if (refsSet && autoFocus) {
+        setAutoFocus(false)
+        searchBarRef.current?.focus()
+      }
+    }, [autoFocus, refsSet, setAutoFocus])
+  )
 
   return (
     <Screen

--- a/packages/mobile/src/screens/search-screen-v2/searchParams.ts
+++ b/packages/mobile/src/screens/search-screen-v2/searchParams.ts
@@ -4,4 +4,5 @@ export type SearchParams = {
   query?: string
   category?: SearchCategory
   filters?: SearchFilters
+  autoFocus?: boolean
 }

--- a/packages/mobile/src/screens/search-screen-v2/searchState.ts
+++ b/packages/mobile/src/screens/search-screen-v2/searchState.ts
@@ -24,6 +24,8 @@ type SearchContextType = {
   setFilters: Dispatch<SetStateAction<SearchFilters>>
   bpmType: string
   setBpmType: Dispatch<SetStateAction<string>>
+  autoFocus: boolean
+  setAutoFocus: Dispatch<SetStateAction<boolean>>
 }
 
 export const SearchContext = createContext<SearchContextType>({
@@ -35,7 +37,10 @@ export const SearchContext = createContext<SearchContextType>({
   setFilters: (_) => {},
   // Special state to track how bpm is being set
   bpmType: 'range',
-  setBpmType: (_) => {}
+  setBpmType: (_) => {},
+  // Special state to determine if the search query input should be focused automatically
+  autoFocus: false,
+  setAutoFocus: (_) => {}
 })
 
 export const useIsEmptySearch = () => {
@@ -46,6 +51,11 @@ export const useIsEmptySearch = () => {
 export const useSearchQuery = () => {
   const { query, setQuery } = useContext(SearchContext)
   return [query, setQuery] as const
+}
+
+export const useSearchAutoFocus = () => {
+  const { autoFocus, setAutoFocus } = useContext(SearchContext)
+  return [autoFocus, setAutoFocus] as const
 }
 
 export const useSearchBpmType = () => {


### PR DESCRIPTION
### Description
Updates to add a search screen param to autofocus the input and update the search screen to respect the param and focus the input automatically.

Interesting/hacky configuration to make sure that it focuses the first time, but not when a filter drawer is closed or when navigating back from results.

### How Has This Been Tested?
Manually tested
