### PR TITLE
requery for audio analysis jobs every 15 min

### DIFF
--- a/mediorum/server/audio_analysis.go
+++ b/mediorum/server/audio_analysis.go
@@ -52,6 +52,8 @@ func (ss *MediorumServer) startAudioAnalyzer() {
 		case <-ticker.C:
 			cancel()
 		}
+
+		time.Sleep(time.Minute)
 	}
 }
 

--- a/mediorum/server/audio_analysis.go
+++ b/mediorum/server/audio_analysis.go
@@ -57,7 +57,7 @@ func (ss *MediorumServer) startAudioAnalyzer() {
 
 func (ss *MediorumServer) findMissedAudioAnalysisJobs(ctx context.Context, work chan<- *Upload) {
 	uploads := []*Upload{}
-	err := ss.crud.DB.Where("template = ? and audio_analysis_status != ?", JobTemplateAudio, JobStatusDone).
+	err := ss.crud.DB.Where("template = ? and (audio_analysis_status is null or audio_analysis_status != ?)", JobTemplateAudio, JobStatusDone).
 		Order("random()").
 		Find(&uploads).
 		Error

--- a/mediorum/server/audio_analysis.go
+++ b/mediorum/server/audio_analysis.go
@@ -82,7 +82,7 @@ func (ss *MediorumServer) findMissedAudioAnalysisJobs(ctx context.Context, work 
 		isMine = isMine || (ss.Config.Env == "prod" && ss.Config.Self.Host == "https://creatornode2.audius.co")
 		if isMine && upload.AudioAnalysisErrorCount < MAX_TRIES {
 			select {
-			case work <- analysis:
+			case work <- upload:
 				// successfully sent the job to the channel
 			case <-ctx.Done():
 				// if the context is done, stop processing

--- a/mediorum/server/legacy_audio_analysis.go
+++ b/mediorum/server/legacy_audio_analysis.go
@@ -18,9 +18,6 @@ const MAX_TRIES = 3
 
 // scroll qm cids
 func (ss *MediorumServer) startLegacyAudioAnalyzer() {
-	ctx := context.Background()
-	logger := ss.logger
-
 	work := make(chan *QmAudioAnalysis)
 
 	numWorkers := 5
@@ -41,10 +38,34 @@ func (ss *MediorumServer) startLegacyAudioAnalyzer() {
 
 	time.Sleep(time.Minute)
 
-	// find work
+	// find work, requerying every 15 minutes
+	ticker := time.NewTicker(15 * time.Minute)
+	defer ticker.Stop()
+
+	for {
+		ctx, cancel := context.WithTimeout(context.Background(), 15*time.Minute)
+		go func() {
+			defer cancel()
+			ss.findLegacyAudioAnalysisJobs(ctx, work)
+		}()
+
+		select {
+		case <-ticker.C:
+			cancel()
+		}
+	}
+}
+
+func (ss *MediorumServer) findLegacyAudioAnalysisJobs(ctx context.Context, work chan<- *QmAudioAnalysis) {
 	var cid string
 	rows, _ := ss.pgPool.Query(ctx, "select key from qm_cids where key not like '%.jpg' order by random()")
 	_, err := pgx.ForEachRow(rows, []any{&cid}, func() error {
+		select {
+		case <-ctx.Done():
+			// if the context is done, stop processing
+			return ctx.Err()
+		default:
+		}
 
 		if strings.HasSuffix(cid, ".jpg") {
 			return nil
@@ -68,15 +89,25 @@ func (ss *MediorumServer) startLegacyAudioAnalyzer() {
 		}
 
 		if analysis.Status != JobStatusDone && analysis.ErrorCount < MAX_TRIES {
-			work <- analysis
+			select {
+			case work <- analysis:
+				// successfully sent the job to the channel
+			case <-ctx.Done():
+				// if the context is done, stop processing
+				return ctx.Err()
+			}
 		}
 
 		return nil
 	})
-	if err != nil {
-		logger.Error("failed to find qm rows", "err", err)
-	}
 
+	if err != nil {
+		if err == context.Canceled {
+			ss.logger.Info("findLegacyAudioAnalysisJobs terminated")
+		} else {
+			ss.logger.Error("failed to find qm rows", "err", err)
+		}
+	}
 }
 
 func (ss *MediorumServer) startLegacyAudioAnalysisWorker(n int, work chan *QmAudioAnalysis) {

--- a/mediorum/server/legacy_audio_analysis.go
+++ b/mediorum/server/legacy_audio_analysis.go
@@ -53,6 +53,8 @@ func (ss *MediorumServer) startLegacyAudioAnalyzer() {
 		case <-ticker.C:
 			cancel()
 		}
+
+		time.Sleep(time.Minute)
 	}
 }
 


### PR DESCRIPTION
### Description
have observed that nodes do their audio analysis backfill work for 2 hours following a release, then they all stop working / picking up jobs. with the exception of prod cn2. not sure why because they certainly still have work to do - upon the next release, they start working again - so try re-querying for work (which essentially is rebuilding the queue) every 15 minutes.

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._
