### PR TITLE
[C-4867] Fix collection release date timezone

### DIFF
--- a/packages/common/src/services/audius-api-client/ResponseAdapter.ts
+++ b/packages/common/src/services/audius-api-client/ResponseAdapter.ts
@@ -376,6 +376,9 @@ export const makePlaylist = (
     is_stream_gated,
     stream_conditions,
     access,
+    release_date: playlist.release_date
+      ? dayjs.utc(playlist.release_date).local()
+      : undefined, // utc -> local
 
     // Fields to prune
     id: undefined,

--- a/packages/common/src/services/audius-api-client/ResponseAdapter.ts
+++ b/packages/common/src/services/audius-api-client/ResponseAdapter.ts
@@ -264,6 +264,7 @@ export const makeTrack = (
         : null,
 
     stem_of: track.stem_of.parent_track_id === null ? null : track.stem_of,
+    // TODO: Remove this when api is fixed to return UTC dates
     release_date: dayjs
       .utc(track.release_date)
       .local()
@@ -376,6 +377,7 @@ export const makePlaylist = (
     is_stream_gated,
     stream_conditions,
     access,
+    // TODO: Remove this when api is fixed to return UTC dates
     release_date: playlist.release_date
       ? dayjs.utc(playlist.release_date).local()
       : undefined, // utc -> local

--- a/packages/common/src/services/audius-api-client/types.ts
+++ b/packages/common/src/services/audius-api-client/types.ts
@@ -216,6 +216,7 @@ export type APIPlaylist = {
   cover_art_cids: Nullable<CoverArtSizes>
   is_stream_gated: boolean
   stream_conditions: Nullable<AccessConditions>
+  release_date?: string
 }
 
 export type APISearchPlaylist = Omit<


### PR DESCRIPTION
### Description

Fix collection release date formatting by ensuring all release_dates are in utc format. This should be fixed in our api layer, but this is a hotfix for now.