### PR TITLE
[PAY-3265, PAY-3241] Disallow scheduled playlists in upload/edit; Fix mood placeholder

### DIFF
--- a/packages/web/src/components/edit/fields/visibility/VisibilityField.tsx
+++ b/packages/web/src/components/edit/fields/visibility/VisibilityField.tsx
@@ -219,7 +219,8 @@ const VisibilityMenuFields = (props: VisibilityMenuFieldsProps) => {
         }
       />
       {!initiallyPublic &&
-      (entityType === 'track' || isPaidScheduledEnabled) ? (
+      (entityType === 'track' ||
+        (isPaidScheduledEnabled && entityType === 'album')) ? (
         <ModalRadioItem
           value='scheduled'
           label={messages.scheduledRelease}

--- a/packages/web/src/pages/edit-page/EditTrackPage.tsx
+++ b/packages/web/src/pages/edit-page/EditTrackPage.tsx
@@ -95,6 +95,7 @@ export const EditTrackPage = (props: EditPageProps) => {
 
   const trackAsMetadataForUpload: TrackMetadataForUpload = {
     ...(track as TrackMetadata),
+    mood: track?.mood || null,
     artwork: {
       url: coverArtUrl || ''
     },


### PR DESCRIPTION
### Description

- Don't show scheduled visibility option for playlists
- Show mood placeholder when mood is `''`

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._
