### PR TITLE
[PAY-3249] Implement pnagD trending strategy

### DIFF
--- a/packages/discovery-provider/ddl/migrations/0084_add_release_date_to_trending_params.sql
+++ b/packages/discovery-provider/ddl/migrations/0084_add_release_date_to_trending_params.sql
@@ -1,0 +1,241 @@
+-- Add release_date to trending params
+begin;
+
+CREATE OR REPLACE FUNCTION recreate_trending_params()
+RETURNS void AS
+$$
+BEGIN
+    create materialized view public.trending_params as
+    select
+    t.track_id,
+    t.release_date,
+    t.genre,
+    t.owner_id,
+    ap.play_count,
+    au.follower_count as owner_follower_count,
+    coalesce(aggregate_track.repost_count, 0) as repost_count,
+    coalesce(aggregate_track.save_count, 0) as save_count,
+    coalesce(repost_week.repost_count, (0) :: bigint) as repost_week_count,
+    coalesce(repost_month.repost_count, (0) :: bigint) as repost_month_count,
+    coalesce(repost_year.repost_count, (0) :: bigint) as repost_year_count,
+    coalesce(save_week.repost_count, (0) :: bigint) as save_week_count,
+    coalesce(save_month.repost_count, (0) :: bigint) as save_month_count,
+    coalesce(save_year.repost_count, (0) :: bigint) as save_year_count,
+    coalesce(karma.karma, (0) :: numeric) as karma
+    from
+    (
+        (
+            (
+                (
+                (
+                    (
+                        (
+                            (
+                            (
+                                (
+                                    public.tracks t
+                                    left join (
+                                        select
+                                        ap_1.count as play_count,
+                                        ap_1.play_item_id
+                                        from
+                                        public.aggregate_plays ap_1
+                                    ) ap on ((ap.play_item_id = t.track_id))
+                                )
+                                left join (
+                                    select
+                                        au_1.user_id,
+                                        au_1.follower_count
+                                    from
+                                        public.aggregate_user au_1
+                                ) au on ((au.user_id = t.owner_id))
+                            )
+                            left join (
+                                select
+                                    aggregate_track_1.track_id,
+                                    aggregate_track_1.repost_count,
+                                    aggregate_track_1.save_count
+                                from
+                                    public.aggregate_track aggregate_track_1
+                            ) aggregate_track on ((aggregate_track.track_id = t.track_id))
+                            )
+                            left join (
+                            select
+                                r.repost_item_id as track_id,
+                                count(r.repost_item_id) as repost_count
+                            from
+                                public.reposts r
+                            where
+                                (
+                                    (r.is_current is true)
+                                    and (r.repost_type = 'track' :: public.reposttype)
+                                    and (r.is_delete is false)
+                                    and (r.created_at > (now() - '1 year' :: interval))
+                                )
+                            group by
+                                r.repost_item_id
+                            ) repost_year on ((repost_year.track_id = t.track_id))
+                        )
+                        left join (
+                            select
+                            r.repost_item_id as track_id,
+                            count(r.repost_item_id) as repost_count
+                            from
+                            public.reposts r
+                            where
+                            (
+                                (r.is_current is true)
+                                and (r.repost_type = 'track' :: public.reposttype)
+                                and (r.is_delete is false)
+                                and (r.created_at > (now() - '1 mon' :: interval))
+                            )
+                            group by
+                            r.repost_item_id
+                        ) repost_month on ((repost_month.track_id = t.track_id))
+                    )
+                    left join (
+                        select
+                            r.repost_item_id as track_id,
+                            count(r.repost_item_id) as repost_count
+                        from
+                            public.reposts r
+                        where
+                            (
+                            (r.is_current is true)
+                            and (r.repost_type = 'track' :: public.reposttype)
+                            and (r.is_delete is false)
+                            and (r.created_at > (now() - '7 days' :: interval))
+                            )
+                        group by
+                            r.repost_item_id
+                    ) repost_week on ((repost_week.track_id = t.track_id))
+                )
+                left join (
+                    select
+                        r.save_item_id as track_id,
+                        count(r.save_item_id) as repost_count
+                    from
+                        public.saves r
+                    where
+                        (
+                            (r.is_current is true)
+                            and (r.save_type = 'track' :: public.savetype)
+                            and (r.is_delete is false)
+                            and (r.created_at > (now() - '1 year' :: interval))
+                        )
+                    group by
+                        r.save_item_id
+                ) save_year on ((save_year.track_id = t.track_id))
+                )
+                left join (
+                select
+                    r.save_item_id as track_id,
+                    count(r.save_item_id) as repost_count
+                from
+                    public.saves r
+                where
+                    (
+                        (r.is_current is true)
+                        and (r.save_type = 'track' :: public.savetype)
+                        and (r.is_delete is false)
+                        and (r.created_at > (now() - '1 mon' :: interval))
+                    )
+                group by
+                    r.save_item_id
+                ) save_month on ((save_month.track_id = t.track_id))
+            )
+            left join (
+                select
+                r.save_item_id as track_id,
+                count(r.save_item_id) as repost_count
+                from
+                public.saves r
+                where
+                (
+                    (r.is_current is true)
+                    and (r.save_type = 'track' :: public.savetype)
+                    and (r.is_delete is false)
+                    and (r.created_at > (now() - '7 days' :: interval))
+                )
+                group by
+                r.save_item_id
+            ) save_week on ((save_week.track_id = t.track_id))
+        )
+        left join (
+            select
+                save_and_reposts.item_id as track_id,
+                sum(au_1.follower_count) as karma
+            from
+                (
+                (
+                    select
+                        r_and_s.user_id,
+                        r_and_s.item_id
+                    from
+                        (
+                            (
+                            select
+                                reposts.user_id,
+                                reposts.repost_item_id as item_id
+                            from
+                                public.reposts
+                            where
+                                (
+                                    (reposts.is_delete is false)
+                                    and (reposts.is_current is true)
+                                    and (
+                                        reposts.repost_type = 'track' :: public.reposttype
+                                    )
+                                )
+                            union
+                            all
+                            select
+                                saves.user_id,
+                                saves.save_item_id as item_id
+                            from
+                                public.saves
+                            where
+                                (
+                                    (saves.is_delete is false)
+                                    and (saves.is_current is true)
+                                    and (saves.save_type = 'track' :: public.savetype)
+                                )
+                            ) r_and_s
+                            join public.users on ((r_and_s.user_id = users.user_id))
+                        )
+                    where
+                        (
+                            (
+                            (users.cover_photo is not null)
+                            or (users.cover_photo_sizes is not null)
+                            )
+                            and (
+                            (users.profile_picture is not null)
+                            or (users.profile_picture_sizes is not null)
+                            )
+                            and (users.bio is not null)
+                        )
+                ) save_and_reposts
+                join public.aggregate_user au_1 on ((save_and_reposts.user_id = au_1.user_id))
+                )
+            group by
+                save_and_reposts.item_id
+        ) karma on ((karma.track_id = t.track_id))
+    )
+    where
+    (
+        (t.is_current is true)
+        and (t.is_delete is false)
+        and (t.is_unlisted is false)
+        and (t.stem_of is null)
+    ) with no data;
+
+    create index trending_params_track_id_idx on public.trending_params using btree (track_id);
+END;
+$$
+LANGUAGE plpgsql;
+
+drop materialized view if exists trending_params;
+select recreate_trending_params();
+
+commit;

--- a/packages/discovery-provider/integration_tests/challenges/test_trending_challenge.py
+++ b/packages/discovery-provider/integration_tests/challenges/test_trending_challenge.py
@@ -73,7 +73,7 @@ def test_trending_challenge_should_update(app):
                 rank=1,
                 id="1",
                 type="tracks",
-                version="EJ57D",
+                version="pnagD",
                 week="2021-08-20",
             )
         )

--- a/packages/discovery-provider/integration_tests/challenges/test_trending_challenge.py
+++ b/packages/discovery-provider/integration_tests/challenges/test_trending_challenge.py
@@ -291,8 +291,7 @@ def test_trending_challenge_job(app):
             strategy = trending_strategy_factory.get_strategy(
                 TrendingType.TRACKS, version
             )
-            if strategy.use_mat_view:
-                strategy.update_track_score_query(session)
+            strategy.update_track_score_query(session)
 
         session.commit()
     web3 = MockWeb3()

--- a/packages/discovery-provider/integration_tests/tasks/test_update_trending.py
+++ b/packages/discovery-provider/integration_tests/tasks/test_update_trending.py
@@ -5,8 +5,8 @@ from integration_tests.utils import populate_mock_db
 from src.models.social.aggregate_interval_plays import t_aggregate_interval_plays
 from src.models.tracks.track_trending_score import TrackTrendingScore
 from src.models.tracks.trending_param import t_trending_params
-from src.trending_strategies.EJ57D_trending_tracks_strategy import (
-    TrendingTracksStrategyEJ57D,
+from src.trending_strategies.pnagD_trending_tracks_strategy import (
+    TrendingTracksStrategypnagD,
 )
 from src.utils.db_session import get_db
 
@@ -341,7 +341,7 @@ def test_update_track_score_query(app):
 
     # setup
     setup_trending(db)
-    udpated_strategy = TrendingTracksStrategyEJ57D()
+    udpated_strategy = TrendingTracksStrategypnagD()
 
     with db.scoped_session() as session:
         session.execute("REFRESH MATERIALIZED VIEW aggregate_interval_plays")

--- a/packages/discovery-provider/integration_tests/tasks/test_update_trending.py
+++ b/packages/discovery-provider/integration_tests/tasks/test_update_trending.py
@@ -341,12 +341,12 @@ def test_update_track_score_query(app):
 
     # setup
     setup_trending(db)
-    udpated_strategy = TrendingTracksStrategypnagD()
+    updated_strategy = TrendingTracksStrategypnagD()
 
     with db.scoped_session() as session:
         session.execute("REFRESH MATERIALIZED VIEW aggregate_interval_plays")
         session.execute("REFRESH MATERIALIZED VIEW trending_params")
-        udpated_strategy.update_track_score_query(session)
+        updated_strategy.update_track_score_query(session)
         scores = session.query(TrackTrendingScore).all()
         # Test that scores are not generated for hidden/deleted tracks
         # There should be 7 valid tracks * 3 valid time ranges (week/month/year)
@@ -369,10 +369,10 @@ def test_update_track_score_query(app):
 
         # Check that the type and version fields are correct
         for score in scores:
-            assert score.type == udpated_strategy.trending_type.name
-            assert score.version == udpated_strategy.version.name
+            assert score.type == updated_strategy.trending_type.name
+            assert score.version == updated_strategy.version.name
 
         # Check that the type and version fields are correct
         for score in scores:
-            assert score.type == udpated_strategy.trending_type.name
-            assert score.version == udpated_strategy.version.name
+            assert score.type == updated_strategy.trending_type.name
+            assert score.version == updated_strategy.version.name

--- a/packages/discovery-provider/integration_tests/utils.py
+++ b/packages/discovery-provider/integration_tests/utils.py
@@ -230,7 +230,7 @@ def populate_mock_db(db, entities, block_offset=None):
                 release_date=(
                     str(track_meta.get("release_date"))
                     if track_meta.get("release_date")
-                    else None
+                    else track_meta.get("created_at", track_created_at)
                 ),
                 is_unlisted=track_meta.get("is_unlisted", False),
                 is_scheduled_release=track_meta.get("is_scheduled_release", False),
@@ -306,7 +306,9 @@ def populate_mock_db(db, entities, block_offset=None):
                 is_stream_gated=playlist_meta.get("is_stream_gated", False),
                 stream_conditions=playlist_meta.get("stream_conditions", None),
                 is_scheduled_release=playlist_meta.get("is_scheduled_release", False),
-                release_date=playlist_meta.get("release_date", None),
+                release_date=playlist_meta.get(
+                    "release_date", playlist_meta.get("created_at", playlist_created_at)
+                ),
             )
             session.add(playlist)
         for i, playlist_track_meta in enumerate(playlist_tracks):

--- a/packages/discovery-provider/src/queries/generate_unpopulated_trending_tracks.py
+++ b/packages/discovery-provider/src/queries/generate_unpopulated_trending_tracks.py
@@ -12,7 +12,6 @@ from src.gated_content.constants import (
 from src.models.tracks.track import Track
 from src.models.tracks.track_trending_score import TrackTrendingScore
 from src.queries.get_unpopulated_tracks import get_unpopulated_tracks
-from src.tasks.generate_trending import generate_trending
 from src.trending_strategies.base_trending_strategy import BaseTrendingStrategy
 from src.trending_strategies.trending_strategy_factory import DEFAULT_TRENDING_VERSIONS
 from src.trending_strategies.trending_type_and_version import (
@@ -36,111 +35,6 @@ def make_trending_tracks_cache_key(
         else ""
     )
     return f"generated-trending{version_name}:{time_range}:{(genre.lower() if genre else '')}"
-
-
-def generate_unpopulated_trending(
-    session,
-    genre,
-    time_range,
-    strategy,
-    exclude_gated=SHOULD_TRENDING_EXCLUDE_GATED_TRACKS,
-    exclude_collectible_gated=SHOULD_TRENDING_EXCLUDE_COLLECTIBLE_GATED_TRACKS,
-    usdc_purchase_only=False,
-    limit=TRENDING_TRACKS_LIMIT,
-):
-    # We use limit * 2 here to apply a soft limit so that
-    # when we later filter out gated tracks,
-    # we will probabilistically satisfy the given limit.
-    trending_tracks = generate_trending(
-        session, time_range, genre, limit * 2, 0, strategy.version
-    )
-
-    track_scores = [
-        strategy.get_track_score(time_range, track)
-        for track in trending_tracks["listen_counts"]
-    ]
-
-    # If usdc_purchase_only is true, then filter out track ids belonging to
-    # non-USDC purchase tracks before applying the limit.
-    if usdc_purchase_only:
-        ids = [track["track_id"] for track in track_scores]
-        usdc_purchase_track_ids = (
-            session.query(Track.track_id)
-            .filter(
-                Track.track_id.in_(ids),
-                Track.is_current == True,
-                Track.is_delete == False,
-                Track.stem_of == None,
-                Track.is_stream_gated == True,
-                text("CAST(stream_conditions AS TEXT) LIKE '%usdc_purchase%'"),
-            )
-            .all()
-        )
-        usdc_purchase_track_id_set = set(map(lambda t: t[0], usdc_purchase_track_ids))
-        track_scores = list(
-            filter(lambda t: t["track_id"] in usdc_purchase_track_id_set, track_scores)
-        )
-    # If exclude_gated is true, then filter out track ids
-    # belonging to gated tracks before applying the limit.
-    elif exclude_gated:
-        ids = [track["track_id"] for track in track_scores]
-        non_stream_gated_track_ids = (
-            session.query(Track.track_id)
-            .filter(
-                Track.track_id.in_(ids),
-                Track.is_current == True,
-                Track.is_delete == False,
-                Track.stem_of == None,
-                Track.is_stream_gated == False,
-            )
-            .all()
-        )
-        non_stream_gated_track_id_set = set(
-            map(lambda t: t[0], non_stream_gated_track_ids)
-        )
-        track_scores = list(
-            filter(
-                lambda t: t["track_id"] in non_stream_gated_track_id_set, track_scores
-            )
-        )
-    elif exclude_collectible_gated:
-        ids = [track["track_id"] for track in track_scores]
-        non_collectible_gated_track_ids = (
-            session.query(Track.track_id)
-            .filter(
-                Track.track_id.in_(ids),
-                Track.is_current == True,
-                Track.is_delete == False,
-                Track.stem_of == None,
-                or_(
-                    Track.is_stream_gated == False,
-                    not_(
-                        text("CAST(stream_conditions AS TEXT) LIKE '%nft_collection%'")
-                    ),
-                ),
-            )
-            .all()
-        )
-        non_collectible_gated_track_id_set = set(
-            map(lambda t: t[0], non_collectible_gated_track_ids)
-        )
-        track_scores = list(
-            filter(
-                lambda t: t["track_id"] in non_collectible_gated_track_id_set,
-                track_scores,
-            )
-        )
-
-    sorted_track_scores = sorted(
-        track_scores, key=lambda k: (k["score"], k["track_id"]), reverse=True
-    )
-    sorted_track_scores = sorted_track_scores[:limit]
-
-    # Get unpopulated metadata
-    track_ids = [track["track_id"] for track in sorted_track_scores]
-    tracks = get_unpopulated_tracks(session, track_ids, exclude_gated=exclude_gated)
-
-    return (tracks, track_ids)
 
 
 def generate_unpopulated_trending_from_mat_views(
@@ -240,16 +134,7 @@ def make_generate_unpopulated_trending(
     expects to be passed a function with no arguments."""
 
     def wrapped():
-        if strategy.use_mat_view:
-            return generate_unpopulated_trending_from_mat_views(
-                session=session,
-                genre=genre,
-                time_range=time_range,
-                strategy=strategy,
-                exclude_gated=exclude_gated,
-                usdc_purchase_only=usdc_purchase_only,
-            )
-        return generate_unpopulated_trending(
+        return generate_unpopulated_trending_from_mat_views(
             session=session,
             genre=genre,
             time_range=time_range,

--- a/packages/discovery-provider/src/queries/generate_unpopulated_trending_tracks.py
+++ b/packages/discovery-provider/src/queries/generate_unpopulated_trending_tracks.py
@@ -14,10 +14,7 @@ from src.models.tracks.track_trending_score import TrackTrendingScore
 from src.queries.get_unpopulated_tracks import get_unpopulated_tracks
 from src.trending_strategies.base_trending_strategy import BaseTrendingStrategy
 from src.trending_strategies.trending_strategy_factory import DEFAULT_TRENDING_VERSIONS
-from src.trending_strategies.trending_type_and_version import (
-    TrendingType,
-    TrendingVersion,
-)
+from src.trending_strategies.trending_type_and_version import TrendingType
 
 logger = logging.getLogger(__name__)
 
@@ -47,11 +44,9 @@ def generate_unpopulated_trending_from_mat_views(
     usdc_purchase_only=False,
     limit=TRENDING_TRACKS_LIMIT,
 ):
-    # use all time instead of year for version EJ57D
-    if strategy.version == TrendingVersion.EJ57D and time_range == "year":
+    # year time_range equates to allTime for current implementations
+    if time_range == "year":
         time_range = "allTime"
-    elif strategy.version != TrendingVersion.EJ57D and time_range == "allTime":
-        time_range = "year"
 
     trending_scores_query = session.query(
         TrackTrendingScore.track_id, TrackTrendingScore.score

--- a/packages/discovery-provider/src/queries/get_underground_trending.py
+++ b/packages/discovery-provider/src/queries/get_underground_trending.py
@@ -54,6 +54,7 @@ def get_scorable_track_data(session, redis_instance, strategy):
     Returns a map: {
         "track_id": string
         "created_at": string
+        "release_date": string
         "owner_id": number
         "windowed_save_count": number
         "save_count": number
@@ -89,6 +90,7 @@ def get_scorable_track_data(session, redis_instance, strategy):
             AggregateUser.follower_count,
             AggregatePlay.count,
             Track.created_at,
+            Track.release_date,
             User.is_verified,
             Track.is_stream_gated,
             Track.stream_conditions,
@@ -114,6 +116,7 @@ def get_scorable_track_data(session, redis_instance, strategy):
         record[0]: {
             "track_id": record[0],
             "created_at": record[4].isoformat(timespec="seconds"),
+            "release_date": record[5].isoformat(timespec="seconds"),
             "owner_id": record[1],
             "windowed_save_count": 0,
             "save_count": 0,
@@ -122,9 +125,9 @@ def get_scorable_track_data(session, redis_instance, strategy):
             "owner_follower_count": record[2],
             "karma": 1,
             "listens": record[3],
-            "owner_verified": record[5],
-            "is_stream_gated": record[6],
-            "stream_conditions": record[7],
+            "owner_verified": record[6],
+            "is_stream_gated": record[7],
+            "stream_conditions": record[8],
         }
         for record in base_query
     }

--- a/packages/discovery-provider/src/queries/response_name_constants.py
+++ b/packages/discovery-provider/src/queries/response_name_constants.py
@@ -33,6 +33,7 @@ track_count = "track_count"  # integer - total count of tracks created by given 
 # integer - total count of tracks saves created by given user
 track_save_count = "track_save_count"
 created_at = "created_at"  # datetime - time track was created
+
 repost_count = "repost_count"  # integer - total count of reposts by given user
 # integer - blocknumber of latest track for user
 track_blocknumber = "track_blocknumber"

--- a/packages/discovery-provider/src/tasks/index_trending.py
+++ b/packages/discovery-provider/src/tasks/index_trending.py
@@ -12,7 +12,6 @@ from src.models.indexing.block import Block
 from src.models.notifications.notification import Notification
 from src.models.tracks.track import Track
 from src.queries.generate_unpopulated_trending_tracks import (
-    generate_unpopulated_trending,
     generate_unpopulated_trending_from_mat_views,
     make_trending_tracks_cache_key,
 )
@@ -101,8 +100,7 @@ def index_trending(self, db: SessionManager, redis: Redis, timestamp):
             strategy = trending_strategy_factory.get_strategy(
                 TrendingType.TRACKS, version
             )
-            if strategy.use_mat_view:
-                strategy.update_track_score_query(session)
+            strategy.update_track_score_query(session)
 
         for version in trending_track_versions:
             strategy = trending_strategy_factory.get_strategy(
@@ -111,20 +109,12 @@ def index_trending(self, db: SessionManager, redis: Redis, timestamp):
             for genre in genres:
                 for time_range in time_ranges:
                     cache_start_time = time.time()
-                    if strategy.use_mat_view:
-                        res = generate_unpopulated_trending_from_mat_views(
-                            session=session,
-                            genre=genre,
-                            time_range=time_range,
-                            strategy=strategy,
-                        )
-                    else:
-                        res = generate_unpopulated_trending(
-                            session=session,
-                            genre=genre,
-                            time_range=time_range,
-                            strategy=strategy,
-                        )
+                    res = generate_unpopulated_trending_from_mat_views(
+                        session=session,
+                        genre=genre,
+                        time_range=time_range,
+                        strategy=strategy,
+                    )
                     key = make_trending_tracks_cache_key(time_range, genre, version)
                     set_json_cached_key(redis, key, res)
                     cache_end_time = time.time()

--- a/packages/discovery-provider/src/trending_strategies/EJ57D_trending_tracks_strategy.py
+++ b/packages/discovery-provider/src/trending_strategies/EJ57D_trending_tracks_strategy.py
@@ -52,7 +52,7 @@ def z(time, track):
 
 class TrendingTracksStrategyEJ57D(BaseTrendingStrategy):
     def __init__(self):
-        super().__init__(TrendingType.TRACKS, TrendingVersion.EJ57D, True)
+        super().__init__(TrendingType.TRACKS, TrendingVersion.EJ57D)
 
     def get_track_score(self, time_range, track):
         logger.error(

--- a/packages/discovery-provider/src/trending_strategies/base_trending_strategy.py
+++ b/packages/discovery-provider/src/trending_strategies/base_trending_strategy.py
@@ -7,12 +7,9 @@ from src.trending_strategies.trending_type_and_version import (
 
 
 class BaseTrendingStrategy(ABC):
-    def __init__(
-        self, trending_type: TrendingType, version: TrendingVersion, use_mat_view=False
-    ):
+    def __init__(self, trending_type: TrendingType, version: TrendingVersion):
         self.trending_type = trending_type
         self.version = version
-        self.use_mat_view = use_mat_view
 
     @abstractmethod
     def get_track_score(self, time_range: str, track):

--- a/packages/discovery-provider/src/trending_strategies/pnagD_trending_playlists_strategy.py
+++ b/packages/discovery-provider/src/trending_strategies/pnagD_trending_playlists_strategy.py
@@ -1,9 +1,23 @@
+from datetime import datetime
+
+from dateutil.parser import parse
+
 from src.trending_strategies.base_trending_strategy import BaseTrendingStrategy
-from src.trending_strategies.pnagD_trending_tracks_strategy import z
 from src.trending_strategies.trending_type_and_version import (
     TrendingType,
     TrendingVersion,
 )
+
+N = 1
+a = max
+M = pow
+F = 50
+O = 1
+R = 0.25
+i = 0.01
+q = 100000.0
+T = {"day": 1, "week": 7, "month": 30, "year": 365, "allTime": 100000}
+y = 3
 
 
 class TrendingPlaylistsStrategypnagD(BaseTrendingStrategy):
@@ -11,7 +25,30 @@ class TrendingPlaylistsStrategypnagD(BaseTrendingStrategy):
         super().__init__(TrendingType.PLAYLISTS, TrendingVersion.pnagD)
 
     def get_track_score(self, time_range, playlist):
-        return z(time_range, playlist)
+        # pylint: disable=W,C,R
+        E = playlist["listens"]
+        e = playlist["windowed_repost_count"]
+        t = playlist["repost_count"]
+        x = playlist["windowed_save_count"]
+        A = playlist["save_count"]
+        o = playlist["created_at"]
+        v = playlist["release_date"]
+        l = playlist["owner_follower_count"]
+        j = playlist["karma"]
+        if l < y:
+            return {"score": 0, **playlist}
+        H = (N * E + F * e + O * x + R * t + i * A) * j
+        L = T[time_range]
+        K = datetime.now()
+        w = parse(o)
+        wv = parse(v)
+        if wv > K:
+            wv = w
+        k = (K - max(w, wv)).days
+        Q = 1
+        if k > L:
+            Q = a((1.0 / q), (M(q, (1 - k / L))))
+        return {"score": H * Q, **playlist}
 
     def get_score_params(self):
         return {"zq": 1000, "xf": True, "pt": 0, "mt": 3}

--- a/packages/discovery-provider/src/trending_strategies/pnagD_trending_playlists_strategy.py
+++ b/packages/discovery-provider/src/trending_strategies/pnagD_trending_playlists_strategy.py
@@ -1,0 +1,17 @@
+from src.trending_strategies.base_trending_strategy import BaseTrendingStrategy
+from src.trending_strategies.pnagD_trending_tracks_strategy import z
+from src.trending_strategies.trending_type_and_version import (
+    TrendingType,
+    TrendingVersion,
+)
+
+
+class TrendingPlaylistsStrategypnagD(BaseTrendingStrategy):
+    def __init__(self):
+        super().__init__(TrendingType.PLAYLISTS, TrendingVersion.pnagD)
+
+    def get_track_score(self, time_range, playlist):
+        return z(time_range, playlist)
+
+    def get_score_params(self):
+        return {"zq": 1000, "xf": True, "pt": 0, "mt": 3}

--- a/packages/discovery-provider/src/trending_strategies/pnagD_trending_tracks_strategy.py
+++ b/packages/discovery-provider/src/trending_strategies/pnagD_trending_tracks_strategy.py
@@ -1,8 +1,6 @@
 import logging
 import time
-from datetime import datetime
 
-from dateutil.parser import parse
 from sqlalchemy.sql import text
 
 from src.trending_strategies.base_trending_strategy import BaseTrendingStrategy
@@ -25,33 +23,6 @@ i = 0.01
 q = 100000.0
 T = {"day": 1, "week": 7, "month": 30, "year": 365, "allTime": 100000}
 y = 3
-
-
-def z(time, track):
-    # pylint: disable=W,C,R
-    E = track["listens"]
-    e = track["windowed_repost_count"]
-    t = track["repost_count"]
-    x = track["windowed_save_count"]
-    A = track["save_count"]
-    o = track["created_at"]
-    v = track["release_date"]
-    l = track["owner_follower_count"]
-    j = track["karma"]
-    if l < y:
-        return {"score": 0, **track}
-    H = (N * E + F * e + O * x + R * t + i * A) * j
-    L = T[time]
-    K = datetime.now()
-    w = parse(o)
-    wv = parse(v)
-    if wv > K:
-        wv = w
-    k = (K - max(w, wv)).days
-    Q = 1
-    if k > L:
-        Q = a((1.0 / q), (M(q, (1 - k / L))))
-    return {"score": H * Q, **track}
 
 
 class TrendingTracksStrategypnagD(BaseTrendingStrategy):
@@ -80,9 +51,40 @@ class TrendingTracksStrategypnagD(BaseTrendingStrategy):
                         CASE
                         WHEN tp.owner_follower_count < :y
                             THEN 0
-                        WHEN EXTRACT(DAYS from now() - aip.created_at) > :week
-                            THEN greatest(1.0/:q, pow(:q, greatest(-10, 1.0 - 1.0*EXTRACT(DAYS from now() - aip.created_at)/:week))) * (:N * aip.week_listen_counts + :F * tp.repost_week_count + :O * tp.save_week_count + :R * tp.repost_count + :i * tp.save_count) * tp.karma
-                        ELSE (:N * aip.week_listen_counts + :F * tp.repost_week_count + :O * tp.save_week_count + :R * tp.repost_count + :i * tp.save_count) * tp.karma
+                        WHEN EXTRACT(DAYS FROM now() - (
+                            CASE
+                                WHEN tp.release_date > now() THEN aip.created_at
+                                ELSE GREATEST(tp.release_date, aip.created_at)
+                            END
+                        )) > :week
+                            THEN GREATEST(
+                                1.0 / :q,
+                                POW(
+                                    :q,
+                                    GREATEST(
+                                        -10,
+                                        1.0 - 1.0 * EXTRACT(DAYS FROM now() - (
+                                            CASE
+                                                WHEN tp.release_date > now() THEN aip.created_at
+                                                ELSE GREATEST(tp.release_date, aip.created_at)
+                                            END
+                                        )) / :week
+                                    )
+                                )
+                            ) * (
+                                :N * aip.week_listen_counts + 
+                                :F * tp.repost_week_count + 
+                                :O * tp.save_week_count + 
+                                :R * tp.repost_count + 
+                                :i * tp.save_count
+                            ) * tp.karma
+                        ELSE (
+                            :N * aip.week_listen_counts + 
+                            :F * tp.repost_week_count + 
+                            :O * tp.save_week_count + 
+                            :R * tp.repost_count + 
+                            :i * tp.save_count
+                        ) * tp.karma
                         END as week_score,
                         now()
                     from trending_params tp
@@ -99,9 +101,40 @@ class TrendingTracksStrategypnagD(BaseTrendingStrategy):
                         CASE
                         WHEN tp.owner_follower_count < :y
                             THEN 0
-                        WHEN EXTRACT(DAYS from now() - aip.created_at) > :month
-                            THEN greatest(1.0/:q, pow(:q, greatest(-10, 1.0 - 1.0*EXTRACT(DAYS from now() - aip.created_at)/:month))) * (:N * aip.month_listen_counts + :F * tp.repost_month_count + :O * tp.save_month_count + :R * tp.repost_count + :i * tp.save_count) * tp.karma
-                        ELSE (:N * aip.month_listen_counts + :F * tp.repost_month_count + :O * tp.save_month_count + :R * tp.repost_count + :i * tp.save_count) * tp.karma
+                        WHEN EXTRACT(DAYS FROM now() - (
+                            CASE
+                                WHEN tp.release_date > now() THEN aip.created_at
+                                ELSE GREATEST(tp.release_date, aip.created_at)
+                            END
+                        )) > :month
+                            THEN GREATEST(
+                                1.0 / :q,
+                                POW(
+                                    :q, 
+                                    GREATEST(
+                                        -10,
+                                        1.0 - 1.0 * EXTRACT(DAYS FROM now() - (
+                                            CASE
+                                                WHEN tp.release_date > now() THEN aip.created_at
+                                                ELSE GREATEST(tp.release_date, aip.created_at)
+                                            END
+                                        )) / :month
+                                    )
+                                )
+                            ) * (
+                                :N * aip.month_listen_counts + 
+                                :F * tp.repost_month_count + 
+                                :O * tp.save_month_count + 
+                                :R * tp.repost_count + 
+                                :i * tp.save_count
+                            ) * tp.karma
+                        ELSE (
+                            :N * aip.month_listen_counts + 
+                            :F * tp.repost_month_count + 
+                            :O * tp.save_month_count + 
+                            :R * tp.repost_count + 
+                            :i * tp.save_count
+                        ) * tp.karma
                         END as month_score,
                         now()
                     from trending_params tp

--- a/packages/discovery-provider/src/trending_strategies/pnagD_trending_tracks_strategy.py
+++ b/packages/discovery-provider/src/trending_strategies/pnagD_trending_tracks_strategy.py
@@ -1,0 +1,168 @@
+import logging
+import time
+from datetime import datetime
+
+from dateutil.parser import parse
+from sqlalchemy.sql import text
+
+from src.trending_strategies.base_trending_strategy import BaseTrendingStrategy
+from src.trending_strategies.trending_type_and_version import (
+    TrendingType,
+    TrendingVersion,
+)
+
+logger = logging.getLogger(__name__)
+
+
+# Trending Parameters
+N = 1
+a = max
+M = pow
+F = 50
+O = 1
+R = 0.25
+i = 0.01
+q = 100000.0
+T = {"day": 1, "week": 7, "month": 30, "year": 365, "allTime": 100000}
+y = 3
+
+
+def z(time, track):
+    # pylint: disable=W,C,R
+    E = track["listens"]
+    e = track["windowed_repost_count"]
+    t = track["repost_count"]
+    x = track["windowed_save_count"]
+    A = track["save_count"]
+    o = track["created_at"]
+    v = track["release_date"]
+    l = track["owner_follower_count"]
+    j = track["karma"]
+    if l < y:
+        return {"score": 0, **track}
+    H = (N * E + F * e + O * x + R * t + i * A) * j
+    L = T[time]
+    K = datetime.now()
+    w = parse(o)
+    wv = parse(v)
+    if wv > K:
+        wv = w
+    k = (K - max(w, wv)).days
+    Q = 1
+    if k > L:
+        Q = a((1.0 / q), (M(q, (1 - k / L))))
+    return {"score": H * Q, **track}
+
+
+class TrendingTracksStrategypnagD(BaseTrendingStrategy):
+    def __init__(self):
+        super().__init__(TrendingType.TRACKS, TrendingVersion.pnagD)
+
+    def get_track_score(self, time_range, track):
+        logger.error(
+            f"get_track_score not implemented for Trending Tracks Strategy with version {TrendingVersion.pnagD}"
+        )
+
+    def update_track_score_query(self, session):
+        start_time = time.time()
+        trending_track_query = text(
+            """
+            begin;
+                DELETE FROM track_trending_scores WHERE type=:type AND version=:version;
+                INSERT INTO track_trending_scores
+                    (track_id, genre, type, version, time_range, score, created_at)
+                    select
+                        tp.track_id,
+                        tp.genre,
+                        :type,
+                        :version,
+                        :week_time_range,
+                        CASE
+                        WHEN tp.owner_follower_count < :y
+                            THEN 0
+                        WHEN EXTRACT(DAYS from now() - aip.created_at) > :week
+                            THEN greatest(1.0/:q, pow(:q, greatest(-10, 1.0 - 1.0*EXTRACT(DAYS from now() - aip.created_at)/:week))) * (:N * aip.week_listen_counts + :F * tp.repost_week_count + :O * tp.save_week_count + :R * tp.repost_count + :i * tp.save_count) * tp.karma
+                        ELSE (:N * aip.week_listen_counts + :F * tp.repost_week_count + :O * tp.save_week_count + :R * tp.repost_count + :i * tp.save_count) * tp.karma
+                        END as week_score,
+                        now()
+                    from trending_params tp
+                    inner join aggregate_interval_plays aip
+                        on tp.track_id = aip.track_id;
+                INSERT INTO track_trending_scores
+                    (track_id, genre, type, version, time_range, score, created_at)
+                    select
+                        tp.track_id,
+                        tp.genre,
+                        :type,
+                        :version,
+                        :month_time_range,
+                        CASE
+                        WHEN tp.owner_follower_count < :y
+                            THEN 0
+                        WHEN EXTRACT(DAYS from now() - aip.created_at) > :month
+                            THEN greatest(1.0/:q, pow(:q, greatest(-10, 1.0 - 1.0*EXTRACT(DAYS from now() - aip.created_at)/:month))) * (:N * aip.month_listen_counts + :F * tp.repost_month_count + :O * tp.save_month_count + :R * tp.repost_count + :i * tp.save_count) * tp.karma
+                        ELSE (:N * aip.month_listen_counts + :F * tp.repost_month_count + :O * tp.save_month_count + :R * tp.repost_count + :i * tp.save_count) * tp.karma
+                        END as month_score,
+                        now()
+                    from trending_params tp
+                    inner join aggregate_interval_plays aip
+                        on tp.track_id = aip.track_id;
+                INSERT INTO track_trending_scores
+                    (track_id, genre, type, version, time_range, score, created_at)
+                    select
+                        tp.track_id,
+                        tp.genre,
+                        :type,
+                        :version,
+                        :all_time_time_range,
+                        CASE
+                        WHEN tp.owner_follower_count < :y
+                            THEN 0
+                        ELSE (:N * ap.count + :R * tp.repost_count + :i * tp.save_count) * tp.karma
+                        END as all_time_score,
+                        now()
+                    from trending_params tp
+                    inner join aggregate_plays ap
+                        on tp.track_id = ap.play_item_id
+                    inner join tracks t
+                        on ap.play_item_id = t.track_id
+                    where -- same filtering for aggregate_interval_plays
+                        t.is_current is True AND
+                        t.is_delete is False AND
+                        t.is_unlisted is False AND
+                        t.stem_of is Null;
+            commit;
+        """
+        )
+        session.execute(
+            trending_track_query,
+            {
+                "week": T["week"],
+                "month": T["month"],
+                "N": N,
+                "F": F,
+                "O": O,
+                "R": R,
+                "i": i,
+                "q": q,
+                "y": y,
+                "type": self.trending_type.name,
+                "version": self.version.name,
+                "week_time_range": "week",
+                "month_time_range": "month",
+                "all_time_time_range": "allTime",
+            },
+        )
+        duration = time.time() - start_time
+        logger.info(
+            f"trending_tracks_strategy | Finished calculating trending scores in {duration} seconds",
+            extra={
+                "id": "trending_strategy",
+                "type": self.trending_type.name,
+                "version": self.version.name,
+                "duration": duration,
+            },
+        )
+
+    def get_score_params(self):
+        return {"xf": True, "pt": 0, "nm": 5}

--- a/packages/discovery-provider/src/trending_strategies/pnagD_underground_trending_tracks_strategy.py
+++ b/packages/discovery-provider/src/trending_strategies/pnagD_underground_trending_tracks_strategy.py
@@ -1,0 +1,69 @@
+from datetime import datetime
+
+from dateutil.parser import parse
+
+from src.trending_strategies.base_trending_strategy import BaseTrendingStrategy
+from src.trending_strategies.trending_type_and_version import (
+    TrendingType,
+    TrendingVersion,
+)
+
+b = 5
+qw = 50
+hg = 1
+ie = 0.25
+pn = 0.01
+u = 30.0
+qq = 0.001
+oi = 20
+nb = 750
+
+
+class UndergroundTrendingTracksStrategypnagD(BaseTrendingStrategy):
+    def __init__(self):
+        super().__init__(TrendingType.UNDERGROUND_TRACKS, TrendingVersion.pnagD)
+
+    def get_track_score(self, time_range, track):
+        # pylint: disable=W,C,R
+        mn = track["listens"]
+        c = track["windowed_repost_count"]
+        x = track["repost_count"]
+        v = track["windowed_save_count"]
+        ut = track["save_count"]
+        ll = track["created_at"]
+        lv = track["release_date"]
+        bq = track["owner_follower_count"]
+        ty = track["owner_verified"]
+        kz = track["karma"]
+        xy = max
+        uk = pow
+        if bq < 3:
+            return {"score": 0, **track}
+        oj = qq if ty else 1
+        zu = 1
+        if bq >= nb:
+            zu = xy(uk(oi, 1 - ((1 / nb) * (bq - nb) + 1)), 1 / oi)
+        vb = (b * mn + qw * c + hg * v + ie * x + pn * ut + zu * bq) * kz * zu * oj
+        te = 7
+        fd = datetime.now()
+        xn = parse(ll)
+        xv = parse(lv)
+        if xv > fd:
+            xv = xn
+        ul = (fd - max(xn, xv)).days
+        rq = 1
+        if ul > te:
+            rq = xy((1.0 / u), (uk(u, (1 - ul / te))))
+        return {"score": vb * rq, **track}
+
+    def get_score_params(self):
+        return {
+            "S": 1500,
+            "r": 1500,
+            "q": 50,
+            "o": 21,
+            "f": 7,
+            "qr": 10,
+            "xf": True,
+            "pt": 0,
+        }

--- a/packages/discovery-provider/src/trending_strategies/trending_strategy_factory.py
+++ b/packages/discovery-provider/src/trending_strategies/trending_strategy_factory.py
@@ -7,6 +7,15 @@ from src.trending_strategies.EJ57D_trending_tracks_strategy import (
 from src.trending_strategies.EJ57D_underground_trending_tracks_strategy import (
     UndergroundTrendingTracksStrategyEJ57D,
 )
+from src.trending_strategies.pnagD_trending_playlists_strategy import (
+    TrendingPlaylistsStrategypnagD,
+)
+from src.trending_strategies.pnagD_trending_tracks_strategy import (
+    TrendingTracksStrategypnagD,
+)
+from src.trending_strategies.pnagD_underground_trending_tracks_strategy import (
+    UndergroundTrendingTracksStrategypnagD,
+)
 from src.trending_strategies.trending_type_and_version import (
     TrendingType,
     TrendingVersion,
@@ -24,12 +33,15 @@ class TrendingStrategyFactory:
         self.strategies = {
             TrendingType.TRACKS: {
                 TrendingVersion.EJ57D: TrendingTracksStrategyEJ57D(),
+                TrendingVersion.pnagD: TrendingTracksStrategypnagD(),
             },
             TrendingType.UNDERGROUND_TRACKS: {
                 TrendingVersion.EJ57D: UndergroundTrendingTracksStrategyEJ57D(),
+                TrendingVersion.pnagD: UndergroundTrendingTracksStrategypnagD(),
             },
             TrendingType.PLAYLISTS: {
                 TrendingVersion.BDNxn: TrendingPlaylistsStrategyBDNxn(),
+                TrendingVersion.pnagD: TrendingPlaylistsStrategypnagD(),
             },
         }
 

--- a/packages/discovery-provider/src/trending_strategies/trending_type_and_version.py
+++ b/packages/discovery-provider/src/trending_strategies/trending_type_and_version.py
@@ -10,3 +10,4 @@ class TrendingType(Enum):
 class TrendingVersion(Enum):
     EJ57D = "EJ57D"
     BDNxn = "BDNxn"
+    pnagD = "pnagD"


### PR DESCRIPTION
### Description

Review commit by commit pls!

The main change of this PR is very small, just some other dead code cleanup along the way.

`k` is defined as our coefficient of decay. Our algo is `finalScore = score ^ (1 - k / time_period)`
this can be seen as decaying the final score from score to 1 based on what %age of the time period (e.g. trending this week) we have covered.

in existing trending `k` is defined as `k = now - created_at`
I update the calculation here to be
```
k = new - max(created_at, release_date if release_date < now else created_at)
```
basically, if release date is in the future, use created_at, and if release date is in the past, use max(created_at, release_date)

here's the diff
<img width="1147" alt="image" src="https://github.com/user-attachments/assets/32cd6e7b-d10b-4bd3-9170-c91f7da437be">



### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._

We will be able to soak this on stage & prod before switching the default strategy over