### PR TITLE
[C-3251] Fix initial state for hidden price-audience field

### DIFF
--- a/packages/mobile/src/components/edit/PriceAndAudienceField/PriceAndAudienceScreen.tsx
+++ b/packages/mobile/src/components/edit/PriceAndAudienceField/PriceAndAudienceScreen.tsx
@@ -43,7 +43,6 @@ export const PriceAndAudienceScreen = () => {
     useField<boolean>('is_stream_gated')
   const [{ value: streamConditions }, , { setValue: setStreamConditions }] =
     useField<Nullable<AccessConditions>>('stream_conditions')
-  const [{ value: isUnlisted }] = useField<boolean>('is_unlisted')
   const [{ value: isScheduledRelease }] = useField<boolean>(
     'is_scheduled_release'
   )
@@ -75,9 +74,6 @@ export const PriceAndAudienceScreen = () => {
       isContentTipGated(streamConditions)
     ) {
       return StreamTrackAvailabilityType.SPECIAL_ACCESS
-    }
-    if (isUnlisted && !isScheduledRelease) {
-      return StreamTrackAvailabilityType.HIDDEN
     }
     return StreamTrackAvailabilityType.PUBLIC
     // we only care about what the initial value was here


### PR DESCRIPTION
### Description

Fixes issue where we incorrectly set the price-audience initial state to "hidden", which was a holdover from when this field also handled that. the result is that none of the public/premium radio options appear selected.