### PR TITLE
Improve mobile inner-form revert

### DIFF
--- a/packages/mobile/src/components/edit/PriceAndAudienceField/PriceAndAudienceScreen.tsx
+++ b/packages/mobile/src/components/edit/PriceAndAudienceField/PriceAndAudienceScreen.tsx
@@ -18,7 +18,6 @@ import { useDispatch } from 'react-redux'
 
 import { Hint, IconCart } from '@audius/harmony-native'
 import { useNavigation } from 'app/hooks/useNavigation'
-import { useSetEntityAvailabilityFields } from 'app/hooks/useSetTrackAvailabilityFields'
 import { FormScreen } from 'app/screens/form-screen'
 
 import { EditPriceAndAudienceConfirmationDrawer } from '../../../screens/edit-track-screen/components/EditPriceAndAudienceConfirmationDrawer'
@@ -109,7 +108,6 @@ export const PriceAndAudienceScreen = () => {
 
   const [{ value: price }, { error: priceError }] = useField(TRACK_PRICE)
   const [{ value: preview }, { error: previewError }] = useField(TRACK_PREVIEW)
-  const setFields = useSetEntityAvailabilityFields()
 
   const usdcGateIsInvalid = useMemo(() => {
     // first time user selects usdc purchase option
@@ -184,33 +182,6 @@ export const PriceAndAudienceScreen = () => {
     )
   }, [dispatch])
 
-  // Listen for `navigation.goBack` events and in the case of going back
-  // reset the availability fields.
-  // Note that this is a stop gap against a better model which would be to have
-  // each radio subgroup manage its own state. That requires a larger refactor.
-  useEffect(() => {
-    const listener = navigation.addListener('beforeRemove', ({ data }) => {
-      if (isFormInvalid && data.action.type === 'GO_BACK') {
-        setFields({
-          is_stream_gated: initialValues.is_stream_gated,
-          stream_conditions: initialValues.stream_conditions,
-          is_unlisted: initialValues.is_unlisted,
-          preview_start_seconds: initialValues.preview_start_seconds,
-          'field_visibility.genre': initialValues.field_visibility?.genre,
-          'field_visibility.mood': initialValues.field_visibility?.mood,
-          'field_visibility.tags': initialValues.field_visibility?.tags,
-          'field_visibility.share': initialValues.field_visibility?.share,
-          'field_visibility.play_count':
-            initialValues.field_visibility?.play_count,
-          'field_visibility.remixes': initialValues.field_visibility?.remixes
-        })
-      }
-    })
-    return () => {
-      navigation.removeListener('beforeRemove', listener)
-    }
-  }, [initialValues, navigation, setFields, isFormInvalid])
-
   return (
     <FormScreen
       title={messages.title}
@@ -219,6 +190,7 @@ export const PriceAndAudienceScreen = () => {
       disableSubmit={isFormInvalid}
       stopNavigation={!isUpload && usersMayLoseAccess}
       onSubmit={handleSubmit}
+      revertOnCancel
     >
       {isRemix ? <Hint m='l'>{messages.markedAsRemix}</Hint> : null}
       <ExpandableRadioGroup

--- a/packages/mobile/src/screens/app-screen/useAppScreenOptions.tsx
+++ b/packages/mobile/src/screens/app-screen/useAppScreenOptions.tsx
@@ -114,7 +114,7 @@ export const useAppScreenOptions = (
                     color='subdued'
                     size='l'
                     {...other}
-                    onPress={navigation.goBack}
+                    onPress={() => navigation.pop()}
                   />
                 </View>
               )

--- a/packages/mobile/src/screens/form-screen/FormScreen.tsx
+++ b/packages/mobile/src/screens/form-screen/FormScreen.tsx
@@ -7,6 +7,8 @@ import type { ScreenProps } from 'app/components/core'
 import { Screen } from 'app/components/core'
 import { useNavigation } from 'app/hooks/useNavigation'
 
+import { useRevertOnCancel } from './useRevertOnCancel'
+
 const messages = {
   done: 'Done',
   clear: 'Clear'
@@ -19,6 +21,7 @@ export type FormScreenProps = ScreenProps & {
   clearable?: boolean
   stopNavigation?: boolean
   disableSubmit?: boolean
+  revertOnCancel?: boolean
 }
 
 export const FormScreen = (props: FormScreenProps) => {
@@ -31,6 +34,7 @@ export const FormScreen = (props: FormScreenProps) => {
     onSubmit,
     stopNavigation,
     disableSubmit,
+    revertOnCancel,
     ...other
   } = props
   const navigation = useNavigation()
@@ -38,10 +42,12 @@ export const FormScreen = (props: FormScreenProps) => {
 
   const handleSubmit = useCallback(() => {
     if (!stopNavigation) {
-      navigation.pop()
+      navigation.goBack()
     }
     onSubmit?.()
   }, [stopNavigation, navigation, onSubmit])
+
+  useRevertOnCancel(revertOnCancel)
 
   return (
     <Screen

--- a/packages/mobile/src/screens/form-screen/useRevertOnCancel.ts
+++ b/packages/mobile/src/screens/form-screen/useRevertOnCancel.ts
@@ -1,0 +1,26 @@
+import { useEffect, useMemo } from 'react'
+
+import { useFormikContext } from 'formik'
+
+import { useNavigation } from 'app/hooks/useNavigation'
+
+export const useRevertOnCancel = (active?: boolean) => {
+  const { values, setValues } = useFormikContext()
+  const navigation = useNavigation()
+
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  const initialValues = useMemo(() => values, [])
+
+  useEffect(() => {
+    if (!active) return
+    const listener = navigation.addListener('beforeRemove', ({ data }) => {
+      if (data.action.type === 'POP') {
+        setValues(initialValues)
+      }
+    })
+
+    return () => {
+      navigation.removeListener('beforeRemove', listener)
+    }
+  }, [navigation, initialValues, setValues, active])
+}


### PR DESCRIPTION
### Description

Adds feature to revert form values back to "initialValues" when the inner form was opened.

Potential big changes here are updating default back button to use pop, which is probably good because gesture-back is pop as well. This means i needed to update onSubmit back to "goBack" so we can distinguish between "cancel" and "submit".

Gated this feature behind "revertOnCancel" prop, but will roll this out to all inner forms soon.
