### PR TITLE
Fix previously scheduled edit flow

### DIFF
--- a/packages/mobile/src/components/edit/VisibilityField/VisibilityScreen.tsx
+++ b/packages/mobile/src/components/edit/VisibilityField/VisibilityScreen.tsx
@@ -41,7 +41,7 @@ export const VisibilityScreen = () => {
   const initiallyPublic = !isUpload && !initialValues[hiddenKey]
 
   const initialVisibilityType =
-    is_scheduled_release && release_date
+    is_scheduled_release && isHidden
       ? 'scheduled'
       : isHidden
       ? 'hidden'


### PR DESCRIPTION
### Description

Fixes issue where previously scheduled tracks and collections did not properly set visibility radio items, because it incorrectly calculated visibilityType === 'scheduled' since we weren't checking for isPrivate