### PR TITLE
[QA-1473] Fix duplicate purchase button in TracksTable row

### DIFF
--- a/packages/web/src/components/tracks-table/TracksTable.tsx
+++ b/packages/web/src/components/tracks-table/TracksTable.tsx
@@ -15,11 +15,10 @@ import {
   gatedContentSelectors,
   usePremiumContentPurchaseModal
 } from '@audius/common/store'
-import { formatCount, formatPrice, formatSeconds } from '@audius/common/utils'
+import { formatCount, formatSeconds } from '@audius/common/utils'
 import {
   IconVisibilityHidden,
   IconLock,
-  Button,
   Flex,
   IconSpecialAccess,
   IconCollectible,
@@ -98,7 +97,6 @@ type TracksTableProps = {
   isReorderable?: boolean
   isAlbumPage?: boolean
   isAlbumPremium?: boolean
-  isPremiumEnabled?: boolean
   shouldShowGatedType?: boolean
   loading?: boolean
   onClickFavorite?: (track: any) => void
@@ -148,13 +146,11 @@ export const TracksTable = ({
   isPaginated = false,
   isReorderable = false,
   isAlbumPage = false,
-  isAlbumPremium = false,
   fetchBatchSize,
   fetchMoreTracks,
   fetchPage,
   fetchThreshold,
   isVirtualized = false,
-  isPremiumEnabled = false,
   shouldShowGatedType = false,
   loading = false,
   onClickFavorite,
@@ -202,12 +198,12 @@ export const TracksTable = ({
           paused={!playing}
           playing={active}
           hideDefault={false}
-          isTrackPremium={isTrackPremium && isPremiumEnabled}
+          isTrackPremium={isTrackPremium}
           isLocked={isLocked}
         />
       )
     },
-    [isPremiumEnabled, playing, playingIndex, trackAccessMap]
+    [playing, playingIndex, trackAccessMap]
   )
 
   const renderTrackNameCell = useCallback(
@@ -550,7 +546,7 @@ export const TracksTable = ({
       const deleted =
         track.is_delete || track._marked_deleted || !!track.user?.is_deactivated
 
-      if (!isLocked || deleted || isOwner || !isPremiumEnabled) {
+      if (!isLocked || deleted || isOwner) {
         return null
       }
       return (
@@ -569,7 +565,6 @@ export const TracksTable = ({
     },
     [
       gatedTrackStatusMap,
-      isPremiumEnabled,
       onClickGatedPill,
       onClickPremiumPill,
       trackAccessMap,

--- a/packages/web/src/pages/collection-page/components/desktop/CollectionPage.tsx
+++ b/packages/web/src/pages/collection-page/components/desktop/CollectionPage.tsx
@@ -11,7 +11,6 @@ import {
   ModalSource,
   Track
 } from '@audius/common/models'
-import { FeatureFlags } from '@audius/common/services'
 import {
   CollectionTrack,
   CollectionsPageType,
@@ -32,7 +31,6 @@ import { SuggestedTracks } from 'components/suggested-tracks'
 import { Tile } from 'components/tile'
 import { TracksTable, TracksTableColumn } from 'components/tracks-table'
 import { useAuthenticatedCallback } from 'hooks/useAuthenticatedCallback'
-import { useFlag } from 'hooks/useRemoteConfig'
 import { smartCollectionIcons } from 'pages/collection-page/smartCollectionIcons'
 import { computeCollectionMetadataProps } from 'pages/collection-page/store/utils'
 
@@ -132,7 +130,6 @@ const CollectionPage = ({
   onClickRow,
   onClickSave,
   onClickRepostTrack,
-  onClickPurchaseTrack,
   onSortTracks,
   onReorderTracks,
   onClickRemove,
@@ -140,9 +137,6 @@ const CollectionPage = ({
   onClickFavorites
 }: CollectionPageProps) => {
   const { status, metadata, user } = collection
-  const { isEnabled: isPremiumAlbumsEnabled } = useFlag(
-    FeatureFlags.PREMIUM_ALBUMS_ENABLED
-  )
 
   // TODO: Consider dynamic lineups, esp. for caching improvement.
   const [dataSource, playingIndex] =
@@ -326,7 +320,7 @@ const CollectionPage = ({
         className={styles.bodyWrapper}
         size='large'
         elevation='mid'
-        dogEar={isPremiumAlbumsEnabled ? dogEarType : undefined}
+        dogEar={dogEarType}
       >
         <div className={styles.topSectionWrapper}>{topSection}</div>
         {!collectionLoading && isEmpty ? (
@@ -352,7 +346,6 @@ const CollectionPage = ({
               onClickRemove={isOwner ? onClickRemove : undefined}
               onClickRepost={onClickRepostTrack}
               onClickPurchase={openPurchaseModal}
-              isPremiumEnabled={isPremiumAlbumsEnabled}
               onReorderTracks={onReorderTracks}
               onSortTracks={onSortTracks}
               isReorderable={

--- a/packages/web/src/pages/saved-page/components/desktop/SavedPage.tsx
+++ b/packages/web/src/pages/saved-page/components/desktop/SavedPage.tsx
@@ -1,8 +1,6 @@
 import { useContext } from 'react'
 
-import { useFeatureFlag } from '@audius/common/hooks'
 import { Kind, Status, ID, UID, Lineup, User } from '@audius/common/models'
-import { FeatureFlags } from '@audius/common/services'
 import {
   savedPageSelectors,
   LibraryCategory,
@@ -124,10 +122,6 @@ const SavedPage = ({
 }: SavedPageProps) => {
   const { mainContentRef } = useContext(MainContentContext)
   const initFetch = useSelector(getInitialFetchStatus)
-
-  const { isEnabled: isPremiumEnabled } = useFeatureFlag(
-    FeatureFlags.PREMIUM_ALBUMS_ENABLED
-  )
 
   const emptyTracksHeader = useSelector((state: CommonState) => {
     const selectedCategory = getCategory(state, {
@@ -256,7 +250,6 @@ const SavedPage = ({
           useLocalSort={allTracksFetched}
           fetchBatchSize={50}
           userId={account ? account.user_id : 0}
-          isPremiumEnabled={isPremiumEnabled}
         />
       ),
       <AlbumsTabPage key='albums' />,

--- a/packages/web/src/pages/saved-page/components/desktop/SavedPage.tsx
+++ b/packages/web/src/pages/saved-page/components/desktop/SavedPage.tsx
@@ -1,6 +1,8 @@
 import { useContext } from 'react'
 
+import { useFeatureFlag } from '@audius/common/hooks'
 import { Kind, Status, ID, UID, Lineup, User } from '@audius/common/models'
+import { FeatureFlags } from '@audius/common/services'
 import {
   savedPageSelectors,
   LibraryCategory,
@@ -122,6 +124,11 @@ const SavedPage = ({
 }: SavedPageProps) => {
   const { mainContentRef } = useContext(MainContentContext)
   const initFetch = useSelector(getInitialFetchStatus)
+
+  const { isEnabled: isPremiumEnabled } = useFeatureFlag(
+    FeatureFlags.PREMIUM_ALBUMS_ENABLED
+  )
+
   const emptyTracksHeader = useSelector((state: CommonState) => {
     const selectedCategory = getCategory(state, {
       currentTab: SavedPageTabs.TRACKS
@@ -249,6 +256,7 @@ const SavedPage = ({
           useLocalSort={allTracksFetched}
           fetchBatchSize={50}
           userId={account ? account.user_id : 0}
+          isPremiumEnabled={isPremiumEnabled}
         />
       ),
       <AlbumsTabPage key='albums' />,


### PR DESCRIPTION
### Description

Fix duplicate purchase button in TracksTable row.

The `isPremiumEnabled` feature flag wasn't being passed into TracksTable on the SavedPage which caused us to think we needed to add the button. But the button already existed so we ended up with 2 buttons on Collection pages. The fix is to strictly use the `GatedConditionsPill` and pass the flag into TracksTable

### How Has This Been Tested?

Tested Library, Album, and Playlists pages
