### PR TITLE
Pin Rust version to 1.79.0

### DIFF
--- a/packages/discovery-provider/Dockerfile.dev
+++ b/packages/discovery-provider/Dockerfile.dev
@@ -37,6 +37,7 @@ RUN apk update && \
 
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
 ENV PATH="/root/.cargo/bin:${PATH}"
+RUN rustup default 1.79.0
 
 RUN curl -O 'http://openresty.org/package/admin@openresty.com-5ea678a6.rsa.pub' && \
   mv 'admin@openresty.com-5ea678a6.rsa.pub' /etc/apk/keys/ && \


### PR DESCRIPTION
### Description

Fixes DN failing to build with:
```
[INFO] [stdout] error[E0282]: type annotations needed for `Box<_>`
```
See: https://github.com/rust-lang/rust/issues/127343#issuecomment-2218261296

Not a true fix. True fix is updating all the deps so that the problematic `time` package is updated
