### PR TITLE
[PAY-3260] Use 'Today' for matching release dates

### DIFF
--- a/packages/common/src/utils/formatUtil.ts
+++ b/packages/common/src/utils/formatUtil.ts
@@ -285,7 +285,7 @@ export const formatReleaseDate = ({
 
   if (daysDifference >= 0 && daysDifference < 7) {
     return (
-      `${releaseDate.format('dddd')}` +
+      `${daysDifference === 0 ? 'Today' : releaseDate.format('dddd')}` +
       (withHour ? ` @ ${releaseDate.format('h A')}` : '')
     )
   } else {

--- a/packages/common/src/utils/formatUtil.ts
+++ b/packages/common/src/utils/formatUtil.ts
@@ -281,11 +281,13 @@ export const formatReleaseDate = ({
   const releaseDate = dayjs(date)
   const now = dayjs()
 
+  // Can't use daysDifference === 0 because anything under 24 hours counts
+  const isToday = releaseDate.isSame(now, 'day')
   const daysDifference = releaseDate.diff(now, 'days')
 
   if (daysDifference >= 0 && daysDifference < 7) {
     return (
-      `${daysDifference === 0 ? 'Today' : releaseDate.format('dddd')}` +
+      `${isToday ? 'Today' : releaseDate.format('dddd')}` +
       (withHour ? ` @ ${releaseDate.format('h A')}` : '')
     )
   } else {


### PR DESCRIPTION
### Description

![Screenshot 2024-07-29 at 3 35 33 PM](https://github.com/user-attachments/assets/db5ea37b-c591-4653-ad97-da9ad5dd46da)
![Screenshot 2024-07-29 at 3 35 30 PM](https://github.com/user-attachments/assets/36b25801-4493-41c7-b4a0-069e401bda4b)

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._
