### PR TITLE
[PAY-3257] Default prices for premium albums/tracks

### DIFF
--- a/packages/web/src/components/edit/fields/stream-availability/usdc-purchase-gated/UsdcPurchaseFields.tsx
+++ b/packages/web/src/components/edit/fields/stream-availability/usdc-purchase-gated/UsdcPurchaseFields.tsx
@@ -129,6 +129,7 @@ export const UsdcPurchaseFields = (props: TrackAvailabilityFieldsProps) => {
             disabled={disabled}
             messaging={messages.price.albumPrice}
             fieldName={PRICE}
+            prefillValue={500}
           />
           {isUpload && (
             <PriceField
@@ -149,6 +150,7 @@ export const UsdcPurchaseFields = (props: TrackAvailabilityFieldsProps) => {
             disabled={disabled}
             messaging={messages.price.standaloneTrackPrice}
             fieldName={PRICE}
+            prefillValue={100}
           />
           <PreviewField disabled={disabled} />
           {downloadConditions ? (


### PR DESCRIPTION
### Description

Default values are now pre-filled for the price fields

![Screenshot 2024-07-29 at 3 55 18 PM](https://github.com/user-attachments/assets/b950faab-7a01-40ac-bf9e-ae53bf30d9ca)
![Screenshot 2024-07-29 at 3 55 06 PM](https://github.com/user-attachments/assets/51ca2abe-3322-426c-ba6b-12708333db7d)


### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._
