### PR TITLE
PAY-3233 Disable reset on select field for AM/PM

### DIFF
--- a/packages/harmony/src/components/select/Select/Select.tsx
+++ b/packages/harmony/src/components/select/Select/Select.tsx
@@ -135,7 +135,7 @@ export const Select = forwardRef<HTMLInputElement, SelectProps>(function Select(
     controlledProp: selectionProp,
     defaultValue: null,
     stateName: 'selection',
-    componentName: 'FilterButton'
+    componentName: 'Select'
   })
 
   // TODO: implement filtering

--- a/packages/harmony/src/components/select/SelectInput/SelectInput.tsx
+++ b/packages/harmony/src/components/select/SelectInput/SelectInput.tsx
@@ -17,6 +17,7 @@ import { SelectInputProps } from './types'
 export const SelectInput = forwardRef<HTMLInputElement, SelectInputProps>(
   function Select(props, ref) {
     const {
+      disableReset,
       value: valueProp,
       children,
       onChange,
@@ -47,7 +48,7 @@ export const SelectInput = forwardRef<HTMLInputElement, SelectInputProps>(
       (e) => {
         e.stopPropagation()
         e.preventDefault()
-        if (value !== null) {
+        if (value !== null && !disableReset) {
           setValue(null)
           // @ts-ignore
           onChange?.(null)
@@ -56,7 +57,7 @@ export const SelectInput = forwardRef<HTMLInputElement, SelectInputProps>(
           setIsOpen((isOpen: boolean) => !isOpen)
         }
       },
-      [value, setIsOpen, setValue, onChange, onReset]
+      [value, setIsOpen, setValue, onChange, onReset, disableReset]
     )
 
     useEffect(() => {
@@ -81,7 +82,11 @@ export const SelectInput = forwardRef<HTMLInputElement, SelectInputProps>(
         <TextInput
           {...inputProps}
           onClick={handleClick}
-          endIcon={value !== null ? IconCloseAlt : IconCaretDown || undefined}
+          endIcon={
+            value !== null && !disableReset
+              ? IconCloseAlt
+              : IconCaretDown || undefined
+          }
           IconProps={{ onClick: handleClickIcon }}
           aria-haspopup='listbox'
           aria-expanded={isOpen}

--- a/packages/harmony/src/components/select/SelectInput/types.ts
+++ b/packages/harmony/src/components/select/SelectInput/types.ts
@@ -53,4 +53,6 @@ export type SelectInputProps = Omit<TextInputProps, 'children' | 'value'> & {
    * This will override the default behavior of toggling isOpen
    */
   onClick?: () => void
+
+  disableReset?: boolean
 }

--- a/packages/web/src/components/edit/fields/visibility/ScheduledReleaseDateField.tsx
+++ b/packages/web/src/components/edit/fields/visibility/ScheduledReleaseDateField.tsx
@@ -65,6 +65,7 @@ export const ScheduledReleaseDateField = () => {
                 { value: 'AM', label: 'AM' },
                 { value: 'PM', label: 'PM' }
               ]}
+              disableReset={true}
             />
           </Box>
         </Flex>


### PR DESCRIPTION
### Description

Adds `disableReset` prop to the `Select` component that disables the "reset" mechanism. Used in the "Visibility" field for scheduled releases AM/PM.

Also odd to me that it's got a text input at all... Maybe we're using the wrong component here? This should be a simple select imo, not like "filter button"?

