### PR TITLE
[PAY-3248][PAY-3256][PAY-3234] Fix misc android issues

### DIFF
--- a/packages/mobile/src/app/App.tsx
+++ b/packages/mobile/src/app/App.tsx
@@ -93,6 +93,8 @@ const App = () => {
                             <NotificationReminder />
                             <RateCtaReminder />
                             <PortalHost name='ChatReactionsPortal' />
+                            <PortalHost name='ConfirmPublishTrackPortal' />
+                            <PortalHost name='EditPriceAndAudienceConfirmation' />
                           </NavigationContainer>
                         </ErrorBoundary>
                       </PortalProvider>

--- a/packages/mobile/src/components/core/DateTimeInput.tsx
+++ b/packages/mobile/src/components/core/DateTimeInput.tsx
@@ -4,7 +4,6 @@ import dayjs from 'dayjs'
 import { Pressable } from 'react-native'
 import type { ReactNativeModalDateTimePickerProps } from 'react-native-modal-datetime-picker'
 import DateTimePickerModal from 'react-native-modal-datetime-picker'
-import { useToggle } from 'react-use'
 
 import { TextInput, useTheme } from '@audius/harmony-native'
 import type { TextInputProps } from '@audius/harmony-native'

--- a/packages/mobile/src/components/core/DateTimeInput.tsx
+++ b/packages/mobile/src/components/core/DateTimeInput.tsx
@@ -1,4 +1,4 @@
-import { useCallback } from 'react'
+import { useCallback, useState } from 'react'
 
 import dayjs from 'dayjs'
 import { Pressable } from 'react-native'
@@ -29,14 +29,22 @@ export const DateTimeInput = (props: DateTimeModalProps) => {
       dayjs(date).format(mode === 'date' ? 'M/D/YY' : 'h:mm A')
   } = props
   const { color, type } = useTheme()
-  const [isDateTimeOpen, toggleDateTimeOpen] = useToggle(false)
+  const [isDateTimeOpen, setIsDateTimeOpen] = useState(false)
+
+  const openDateTime = useCallback(() => {
+    setIsDateTimeOpen(true)
+  }, [setIsDateTimeOpen])
+
+  const closeDateTime = useCallback(() => {
+    setIsDateTimeOpen(false)
+  }, [setIsDateTimeOpen])
 
   const handleChange = useCallback(
     (date: Date) => {
       onChange(date.toString())
-      toggleDateTimeOpen()
+      setIsDateTimeOpen((d) => !d)
     },
-    [onChange, toggleDateTimeOpen]
+    [onChange, setIsDateTimeOpen]
   )
 
   const dateProps: Partial<ReactNativeModalDateTimePickerProps> = {
@@ -48,7 +56,7 @@ export const DateTimeInput = (props: DateTimeModalProps) => {
 
   return (
     <>
-      <Pressable onPress={toggleDateTimeOpen}>
+      <Pressable onPress={openDateTime}>
         <TextInput
           readOnly
           _disablePointerEvents
@@ -62,7 +70,7 @@ export const DateTimeInput = (props: DateTimeModalProps) => {
         mode={mode}
         isVisible={isDateTimeOpen}
         onConfirm={handleChange}
-        onCancel={toggleDateTimeOpen}
+        onCancel={closeDateTime}
         {...(mode === 'date' ? dateProps : {})}
       />
     </>

--- a/packages/mobile/src/screens/edit-track-screen/EditTrackForm.tsx
+++ b/packages/mobile/src/screens/edit-track-screen/EditTrackForm.tsx
@@ -113,6 +113,7 @@ export const EditTrackForm = (props: EditTrackFormProps) => {
   }, [dirty, navigation, dispatch])
 
   const handleSubmit = useCallback(() => {
+    Keyboard.dismiss()
     const showConfirmDrawer = usersMayLoseAccess || isToBePublished
     if (showConfirmDrawer) {
       if (usersMayLoseAccess) {

--- a/packages/mobile/src/screens/edit-track-screen/components/ConfirmPublishDrawer.tsx
+++ b/packages/mobile/src/screens/edit-track-screen/components/ConfirmPublishDrawer.tsx
@@ -1,3 +1,5 @@
+import { Portal } from '@gorhom/portal'
+
 import { ConfirmationDrawer } from 'app/components/drawers'
 
 const messages = {
@@ -42,11 +44,13 @@ export const ConfirmPublishTrackDrawer = (
       : messages.hidden
 
   return (
-    <ConfirmationDrawer
-      variant='affirmative'
-      modalName='EditAccessConfirmation'
-      onConfirm={onConfirm}
-      messages={confirmationMessages}
-    />
+    <Portal hostName='ConfirmPublishTrackPortal'>
+      <ConfirmationDrawer
+        variant='affirmative'
+        modalName='EditAccessConfirmation'
+        onConfirm={onConfirm}
+        messages={confirmationMessages}
+      />
+    </Portal>
   )
 }

--- a/packages/mobile/src/screens/edit-track-screen/components/EditPriceAndAudienceConfirmationDrawer.tsx
+++ b/packages/mobile/src/screens/edit-track-screen/components/EditPriceAndAudienceConfirmationDrawer.tsx
@@ -1,3 +1,5 @@
+import { Portal } from '@gorhom/portal'
+
 import { ConfirmationDrawer } from 'app/components/drawers'
 
 const messages = {
@@ -17,12 +19,14 @@ export const EditPriceAndAudienceConfirmationDrawer = (
   props: EditPriceAndAudienceConfirmationDrawerProps
 ) => {
   return (
-    <ConfirmationDrawer
-      variant='affirmative'
-      modalName='EditPriceAndAudienceConfirmation'
-      onConfirm={props.onConfirm}
-      onCancel={props.onCancel}
-      messages={messages}
-    />
+    <Portal hostName='EditPriceAndAudienceConfirmation'>
+      <ConfirmationDrawer
+        variant='affirmative'
+        modalName='EditPriceAndAudienceConfirmation'
+        onConfirm={props.onConfirm}
+        onCancel={props.onCancel}
+        messages={messages}
+      />
+    </Portal>
   )
 }

--- a/packages/mobile/src/screens/form-screen/FormScreen.tsx
+++ b/packages/mobile/src/screens/form-screen/FormScreen.tsx
@@ -1,5 +1,6 @@
 import { useCallback, type ReactNode } from 'react'
 
+import { Keyboard } from 'react-native'
 import { useSafeAreaInsets } from 'react-native-safe-area-context'
 
 import { Button, Flex, PlainButton } from '@audius/harmony-native'
@@ -41,6 +42,7 @@ export const FormScreen = (props: FormScreenProps) => {
   const insets = useSafeAreaInsets()
 
   const handleSubmit = useCallback(() => {
+    Keyboard.dismiss()
     if (!stopNavigation) {
       navigation.goBack()
     }


### PR DESCRIPTION
### Description

[[](https://github.com/AudiusProject/audius-protocol/commit/bb80a0a327ed81a94aa89a3c550b4dc4d57accd8)[PAY-3248](https://linear.app/audius/issue/PAY-3248)[] Portal out edit confirmation drawers](https://github.com/AudiusProject/audius-protocol/commit/bb80a0a327ed81a94aa89a3c550b4dc4d57accd8)
* I figured portaling was simpler than rewriting the nav order. We've done this pattern before for DMs

[[](https://github.com/AudiusProject/audius-protocol/commit/73723c576a06c48148b03f30a1d216ed040e0edf)[PAY-3256](https://linear.app/audius/issue/PAY-3256)[] Dismiss keyboard when submitting form screen](https://github.com/AudiusProject/audius-protocol/commit/73723c576a06c48148b03f30a1d216ed040e0edf)
* Form screen often leaves the keyboard open, so just try to dismiss it when we submit forms in general

[[](https://github.com/AudiusProject/audius-protocol/commit/aad62479c7ad664e5888ad775073978a3b6ef0cf)[PAY-3234](https://linear.app/audius/issue/PAY-3234)[] Handle closing date time more directly](https://github.com/AudiusProject/audius-protocol/commit/aad62479c7ad664e5888ad775073978a3b6ef0cf)
* I believe this issue is because the react native date time picker fires onCancel sometimes when onConfirm also runs, which doesn't work nicely with a toggle. Instead be explicit about state.

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._

Android physical device w/ staging