### PR TITLE
[PAY-3262] Fix edit new playlist

### DIFF
--- a/packages/common/src/audius-query/createApi.ts
+++ b/packages/common/src/audius-query/createApi.ts
@@ -69,7 +69,7 @@ import { capitalize, getKeyFromFetchArgs, selectCommonEntityMap } from './utils'
 
 const { getUserId } = accountSelectors
 
-type ForceType = 'force' | 'forcing' | 'forced' | false
+type ForceType = 'force' | 'forcing' | false
 
 type Entity = Collection | Track | User
 

--- a/packages/common/src/audius-query/createApi.ts
+++ b/packages/common/src/audius-query/createApi.ts
@@ -69,7 +69,7 @@ import { capitalize, getKeyFromFetchArgs, selectCommonEntityMap } from './utils'
 
 const { getUserId } = accountSelectors
 
-type ForceType = 'force' | 'forcing' | false
+type ForceType = 'force' | 'forcing' | 'forced' | false
 
 type Entity = Collection | Track | User
 
@@ -372,7 +372,11 @@ const fetchData = async <Args, Data>(
           { ...defaultRetryConfig, ...endpoint.options.retryConfig }
         )
       : await fetch(fetchArgs, context)
-    if (apiData == null) {
+
+    if (!apiData) {
+      if (force?.current) {
+        force.current = false
+      }
       throw new RemoteDataNotFoundError('Remote data not found')
     }
 
@@ -480,7 +484,12 @@ const buildEndpointHooks = <
     )
 
     // If `force`, ignore queryState and force a fetch
-    const state = force.current ? null : queryState
+    const state = force.current
+      ? {
+          normalizedData: null,
+          status: force.current === 'forcing' ? Status.LOADING : Status.IDLE
+        }
+      : queryState
 
     const { normalizedData, status, errorMessage, isInitialValue } = state ?? {
       normalizedData: null,

--- a/packages/common/src/services/audius-api-client/ResponseAdapter.ts
+++ b/packages/common/src/services/audius-api-client/ResponseAdapter.ts
@@ -379,7 +379,7 @@ export const makePlaylist = (
     access,
     // TODO: Remove this when api is fixed to return UTC dates
     release_date: playlist.release_date
-      ? dayjs.utc(playlist.release_date).local()
+      ? dayjs.utc(playlist.release_date).local().toString()
       : undefined, // utc -> local
 
     // Fields to prune

--- a/packages/web/src/pages/edit-collection-page/desktop/EditCollectionPage.tsx
+++ b/packages/web/src/pages/edit-collection-page/desktop/EditCollectionPage.tsx
@@ -6,7 +6,8 @@ import { Name, SquareSizes, Status } from '@audius/common/models'
 import { CollectionValues } from '@audius/common/schemas'
 import {
   EditCollectionValues,
-  cacheCollectionsActions
+  cacheCollectionsActions,
+  cacheCollectionsSelectors
 } from '@audius/common/store'
 import { replace } from 'connected-react-router'
 import { isEqual } from 'lodash'
@@ -23,10 +24,12 @@ import { useCollectionCoverArt2 } from 'hooks/useCollectionCoverArt'
 import { useIsUnauthorizedForHandleRedirect } from 'hooks/useManagedAccountNotAllowedRedirect'
 import { useRequiresAccount } from 'hooks/useRequiresAccount'
 import { track } from 'services/analytics'
+import { useSelector } from 'utils/reducer'
 
 import { updatePlaylistContents } from '../utils'
 
 const { editPlaylist } = cacheCollectionsActions
+const { getCollection } = cacheCollectionsSelectors
 
 type EditCollectionPageParams = {
   handle: string
@@ -48,13 +51,19 @@ export const EditCollectionPage = () => {
   useIsUnauthorizedForHandleRedirect(handle)
 
   const { data: currentUserId } = useGetCurrentUserId({})
-  const { data: collection, status } = useGetPlaylistByPermalink(
+  const { data: apiCollection, status } = useGetPlaylistByPermalink(
     {
       permalink,
       currentUserId
     },
     { disabled: !currentUserId, force: true }
   )
+
+  const localCollection = useSelector((state) =>
+    getCollection(state, { permalink })
+  )
+
+  const collection = status === Status.ERROR ? localCollection : apiCollection
 
   const { playlist_id, tracks, description } = collection ?? {}
 
@@ -103,14 +112,14 @@ export const EditCollectionPage = () => {
       ...restValues
     }
 
-    dispatch(editPlaylist(playlist_id, collection as EditCollectionValues))
+    dispatch(editPlaylist(playlist_id!, collection as EditCollectionValues))
 
     dispatch(replace(permalink))
   }
 
   return (
     <Page header={<Header primary={messages.title(isAlbum)} showBackButton />}>
-      {status !== Status.SUCCESS || !artworkUrl ? (
+      {status === Status.IDLE || status === Status.LOADING || !artworkUrl ? (
         <LoadingSpinnerFullPage />
       ) : (
         <EditCollectionForm

--- a/packages/web/src/pages/edit-page/EditTrackPage.tsx
+++ b/packages/web/src/pages/edit-page/EditTrackPage.tsx
@@ -44,7 +44,6 @@ type EditPageProps = {
 
 export const EditFormScrollContext = createContext(() => {})
 
-// This component is in development, only used behind the EDIT_TRACK_REDESIGN feature flag
 export const EditTrackPage = (props: EditPageProps) => {
   const { scrollToTop } = props
   const { handle, slug } = useParams<{ handle: string; slug: string }>()


### PR DESCRIPTION
### Description

Fixes issue where editing a new playlist didn't work because the force-fetch would fail. Updating the status codes of the "force" path, and adding a case where the fetch fails to set force to false.

In edit-page we use the apiCollection or the localCollection if something wrong happens. def a bit complicated, so maybe this fallback logic can get wrapped up in audius-query at some point.


@rickyrombo also fixes some issues with release-date, due to a bad release-date format in common, not sure how many things this fixes