### PR TITLE
[PAY-3277] Show release date for all public tracks/collections

### DIFF
--- a/packages/common/src/hooks/useCollectionMetadata.ts
+++ b/packages/common/src/hooks/useCollectionMetadata.ts
@@ -45,7 +45,6 @@ export const useCollectionMetadata = ({
   const {
     is_private: isPrivate,
     updated_at: updatedAt,
-    is_scheduled_release: isScheduledRelease,
     release_date: releaseDate
   } = collection
   const numTracks = collection.playlist_contents?.track_ids?.length ?? 0
@@ -63,7 +62,7 @@ export const useCollectionMetadata = ({
       id: CollectionMetadataType.RELEASE_DATE,
       value: formatDate(releaseDate ?? ''),
       label: 'Released',
-      isHidden: isPrivate || !releaseDate || isScheduledRelease
+      isHidden: isPrivate || !releaseDate
     },
     {
       id: CollectionMetadataType.UPDATED_AT,

--- a/packages/common/src/hooks/useTrackMetadata.ts
+++ b/packages/common/src/hooks/useTrackMetadata.ts
@@ -42,7 +42,6 @@ export const useTrackMetadata = ({
     duration,
     genre,
     release_date: releaseDate,
-    is_scheduled_release: isScheduledRelease,
     mood,
     is_unlisted: isUnlisted,
     musical_key,
@@ -64,7 +63,7 @@ export const useTrackMetadata = ({
       id: TrackMetadataType.RELEASE_DATE,
       value: formatDate(releaseDate ?? ''),
       label: 'Released',
-      isHidden: isUnlisted || !releaseDate || isScheduledRelease
+      isHidden: isUnlisted || !releaseDate
     },
     {
       id: TrackMetadataType.MOOD,


### PR DESCRIPTION
### Description
When a scheduled track/album is published, we flip `is_private` or `is_unlisted` but leave `is_scheduled_release` as-is. So we shouldn't hide the release date based on this field.

### How Has This Been Tested?

<img width="1006" alt="Screenshot 2024-07-30 at 5 15 16 PM" src="https://github.com/user-attachments/assets/41ceb447-9478-4fb1-a0b8-9cf38fde8b0d">
