### PR TITLE
[PAY-3274] Show 'releases today' on mobile

### DIFF
--- a/packages/mobile/src/components/lineup-tile/LineupTileStats.tsx
+++ b/packages/mobile/src/components/lineup-tile/LineupTileStats.tsx
@@ -8,11 +8,7 @@ import {
   PurchaseableContentType
 } from '@audius/common/store'
 import type { RepostType } from '@audius/common/store'
-import {
-  formatCount,
-  formatReleaseDate,
-  getLocalTimezone
-} from '@audius/common/utils'
+import { formatCount, formatReleaseDate } from '@audius/common/utils'
 import type { Nullable } from '@audius/common/utils'
 import moment from 'moment'
 import { View, TouchableOpacity } from 'react-native'

--- a/packages/mobile/src/components/lineup-tile/LineupTileStats.tsx
+++ b/packages/mobile/src/components/lineup-tile/LineupTileStats.tsx
@@ -56,7 +56,7 @@ const messages = {
     `Releases ${formatReleaseDate({
       date,
       withHour: true
-    })} ${getLocalTimezone()}`
+    })}`
 }
 
 const useStyles = makeStyles(({ spacing }) => ({

--- a/packages/mobile/src/screens/collection-screen/CollectionScreenDetailsTile.tsx
+++ b/packages/mobile/src/screens/collection-screen/CollectionScreenDetailsTile.tsx
@@ -24,7 +24,11 @@ import {
   PurchaseableContentType,
   queueActions
 } from '@audius/common/store'
-import { getDogEarType, getLocalTimezone } from '@audius/common/utils'
+import {
+  formatReleaseDate,
+  getDogEarType,
+  getLocalTimezone
+} from '@audius/common/utils'
 import type { Maybe, Nullable } from '@audius/common/utils'
 import dayjs from 'dayjs'
 import { TouchableOpacity } from 'react-native'
@@ -127,9 +131,7 @@ const getMessages = (
   preview: 'Preview',
   hidden: 'Hidden',
   releases: (releaseDate: string) =>
-    `Releases ${dayjs(releaseDate).format(
-      'M/D/YY [@] h:mm A'
-    )} ${getLocalTimezone()}`
+    `Releases ${formatReleaseDate({ date: releaseDate, withHour: true })}`
 })
 
 const useStyles = makeStyles(({ palette, spacing }) => ({

--- a/packages/mobile/src/screens/collection-screen/CollectionScreenDetailsTile.tsx
+++ b/packages/mobile/src/screens/collection-screen/CollectionScreenDetailsTile.tsx
@@ -24,11 +24,7 @@ import {
   PurchaseableContentType,
   queueActions
 } from '@audius/common/store'
-import {
-  formatReleaseDate,
-  getDogEarType,
-  getLocalTimezone
-} from '@audius/common/utils'
+import { formatReleaseDate, getDogEarType } from '@audius/common/utils'
 import type { Maybe, Nullable } from '@audius/common/utils'
 import dayjs from 'dayjs'
 import { TouchableOpacity } from 'react-native'

--- a/packages/mobile/src/screens/track-screen/TrackScreenDetailsTile.tsx
+++ b/packages/mobile/src/screens/track-screen/TrackScreenDetailsTile.tsx
@@ -43,7 +43,6 @@ import {
   formatReleaseDate,
   Genre,
   getDogEarType,
-  getLocalTimezone,
   removeNullable
 } from '@audius/common/utils'
 import dayjs from 'dayjs'

--- a/packages/mobile/src/screens/track-screen/TrackScreenDetailsTile.tsx
+++ b/packages/mobile/src/screens/track-screen/TrackScreenDetailsTile.tsx
@@ -40,6 +40,7 @@ import {
   usePublishContentModal
 } from '@audius/common/store'
 import {
+  formatReleaseDate,
   Genre,
   getDogEarType,
   getLocalTimezone,
@@ -115,9 +116,7 @@ const messages = {
   preview: 'Preview',
   hidden: 'Hidden',
   releases: (releaseDate: string) =>
-    `Releases ${dayjs(releaseDate).format(
-      'M/D/YY [@] h:mm A'
-    )} ${getLocalTimezone()}`
+    `Releases ${formatReleaseDate({ date: releaseDate, withHour: true })}`
 }
 
 const useStyles = makeStyles(({ palette, spacing }) => ({


### PR DESCRIPTION
### Description

Use the common release date formatter which accounts for same day release dates

![Screenshot 2024-07-30 at 2 20 11 PM](https://github.com/user-attachments/assets/2acf3acd-e420-4f0b-a72a-e184f66fc5ca)


### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._
