### PR TITLE
Fix "date required" error when selecting date

### DIFF
--- a/packages/web/src/components/edit/fields/DatePickerField.tsx
+++ b/packages/web/src/components/edit/fields/DatePickerField.tsx
@@ -94,7 +94,7 @@ export const DatePickerField = (props: DatePickerFieldProps) => {
               date={moment(value)}
               onDateChange={(value) => {
                 helpers.setValue(value?.toString())
-                helpers.setTouched(true)
+                helpers.setTouched(true, false)
               }}
               isOutsideRange={(day) => {
                 if (futureDatesOnly) {


### PR DESCRIPTION
### Description

Fixes issue where after selecting a date, we would get a "select date" error message. This is because we call `setValue` and then `setTouched` back to back, and setTouched calls validate again, which clears out the releaseDate for some reason. Passing `false` as second argument skips validation after touch.