### PR TITLE
add bpm edit flag col

### DIFF
--- a/packages/discovery-provider/ddl/migrations/0086_add_bpm_edit_flag.sql
+++ b/packages/discovery-provider/ddl/migrations/0086_add_bpm_edit_flag.sql
@@ -1,0 +1,5 @@
+begin;
+
+alter table tracks add column if not exists is_custom_bpm boolean default false;
+
+commit;

--- a/packages/discovery-provider/integration_tests/tasks/entity_manager/test_utils.py
+++ b/packages/discovery-provider/integration_tests/tasks/entity_manager/test_utils.py
@@ -196,6 +196,7 @@ def test_valid_parse_metadata(app):
                 "parental_warning_type": None,
                 "allowed_api_keys": None,
                 "bpm": None,
+                "is_custom_bpm": False,
                 "musical_key": None,
                 "audio_analysis_error_count": 0,
             },

--- a/packages/discovery-provider/plugins/notifications/src/types/dn.ts
+++ b/packages/discovery-provider/plugins/notifications/src/types/dn.ts
@@ -655,6 +655,7 @@ export interface TrackRow {
   producer_copyright_line?: any | null
   parental_warning_type?: any | null
   bpm?: number | null
+  is_custom_bpm?: boolean | null
   musical_key?: string | null
   audio_analysis_error_count?: number
 }

--- a/packages/discovery-provider/plugins/pedalboard/packages/storage/src/index.ts
+++ b/packages/discovery-provider/plugins/pedalboard/packages/storage/src/index.ts
@@ -1004,6 +1004,7 @@ export type Tracks = {
   producer_copyright_line: unknown | null;
   parental_warning_type: string | null;
   bpm: number | null;
+  is_custom_bpm: boolean | null;
   musical_key: string | null;
   audio_analysis_error_count: number;
 };

--- a/packages/discovery-provider/src/api/v1/models/tracks.py
+++ b/packages/discovery-provider/src/api/v1/models/tracks.py
@@ -174,6 +174,7 @@ track_full = ns.clone(
         "audio_upload_id": fields.String,
         "preview_start_seconds": fields.Float,
         "bpm": fields.Float,
+        "is_custom_bpm": fields.Boolean,
         "musical_key": fields.String,
         "audio_analysis_error_count": fields.Integer,
         # DDEX fields

--- a/packages/discovery-provider/src/models/tracks/track.py
+++ b/packages/discovery-provider/src/models/tracks/track.py
@@ -100,6 +100,7 @@ class Track(Base, RepresentableMixin):
 
     # Audio analysis
     bpm = Column(Float)
+    is_custom_bpm = Column(Boolean, server_default=text("false"))
     musical_key = Column(String)
     audio_analysis_error_count = Column(
         Integer, nullable=False, server_default=text("0")

--- a/packages/discovery-provider/src/schemas/track_schema.json
+++ b/packages/discovery-provider/src/schemas/track_schema.json
@@ -365,6 +365,10 @@
           ],
           "default": null
         },
+        "is_custom_bpm": {
+          "type": ["boolean"],
+          "default": false
+        },
         "musical_key": {
           "type": [
             "string",

--- a/packages/discovery-provider/src/tasks/metadata.py
+++ b/packages/discovery-provider/src/tasks/metadata.py
@@ -134,6 +134,7 @@ class TrackMetadata(TypedDict):
     parental_warning_type: Optional[str]
     allowed_api_keys: Optional[str]
     bpm: Optional[float]
+    is_custom_bpm: Optional[bool]
     musical_key: Optional[str]
     audio_analysis_error_count: Optional[int]
 
@@ -189,6 +190,7 @@ track_metadata_format: TrackMetadata = {
     "parental_warning_type": None,
     "allowed_api_keys": None,
     "bpm": None,
+    "is_custom_bpm": False,
     "musical_key": None,
     "audio_analysis_error_count": 0,
 }

--- a/packages/libs/src/api/Track.ts
+++ b/packages/libs/src/api/Track.ts
@@ -654,6 +654,7 @@ export class Track extends Base {
       ai_attribution_user_id,
       allowed_api_keys,
       bpm,
+      is_custom_bpm,
       musical_key,
       audio_analysis_error_count,
       field_visibility,
@@ -712,6 +713,7 @@ export class Track extends Base {
       ai_attribution_user_id,
       allowed_api_keys,
       bpm,
+      is_custom_bpm,
       musical_key,
       audio_analysis_error_count,
       field_visibility

--- a/packages/libs/src/sdk/api/generated/full/models/TrackFull.ts
+++ b/packages/libs/src/sdk/api/generated/full/models/TrackFull.ts
@@ -413,6 +413,12 @@ export interface TrackFull {
     bpm?: number;
     /**
      * 
+     * @type {boolean}
+     * @memberof TrackFull
+     */
+    isCustomBpm?: boolean;
+    /**
+     * 
      * @type {string}
      * @memberof TrackFull
      */
@@ -602,6 +608,7 @@ export function TrackFullFromJSONTyped(json: any, ignoreDiscriminator: boolean):
         'audioUploadId': !exists(json, 'audio_upload_id') ? undefined : json['audio_upload_id'],
         'previewStartSeconds': !exists(json, 'preview_start_seconds') ? undefined : json['preview_start_seconds'],
         'bpm': !exists(json, 'bpm') ? undefined : json['bpm'],
+        'isCustomBpm': !exists(json, 'is_custom_bpm') ? undefined : json['is_custom_bpm'],
         'musicalKey': !exists(json, 'musical_key') ? undefined : json['musical_key'],
         'audioAnalysisErrorCount': !exists(json, 'audio_analysis_error_count') ? undefined : json['audio_analysis_error_count'],
         'ddexReleaseIds': !exists(json, 'ddex_release_ids') ? undefined : json['ddex_release_ids'],
@@ -682,6 +689,7 @@ export function TrackFullToJSON(value?: TrackFull | null): any {
         'audio_upload_id': value.audioUploadId,
         'preview_start_seconds': value.previewStartSeconds,
         'bpm': value.bpm,
+        'is_custom_bpm': value.isCustomBpm,
         'musical_key': value.musicalKey,
         'audio_analysis_error_count': value.audioAnalysisErrorCount,
         'ddex_release_ids': value.ddexReleaseIds,

--- a/packages/libs/src/sdk/api/tracks/types.ts
+++ b/packages/libs/src/sdk/api/tracks/types.ts
@@ -171,6 +171,7 @@ export const createUploadTrackMetadataSchema = () =>
     producerCopyrightLine: z.optional(DDEXCopyright.nullable()),
     parentalWarningType: z.optional(z.string().nullable()),
     bpm: z.optional(z.number().nullable()),
+    isCustomBpm: z.optional(z.boolean()),
     musicalKey: z.optional(z.string().nullable()),
     audioAnalysisErrorCount: z.optional(z.number())
   })

--- a/packages/libs/src/services/schemaValidator/schemas/trackSchema.json
+++ b/packages/libs/src/services/schemaValidator/schemas/trackSchema.json
@@ -358,6 +358,10 @@
           ],
           "default": null
         },
+        "is_custom_bpm": {
+          "type": ["boolean"],
+          "default": false
+        },
         "musical_key": {
           "type": [
             "string",

--- a/packages/libs/src/utils/types.ts
+++ b/packages/libs/src/utils/types.ts
@@ -217,6 +217,7 @@ export type TrackMetadata = {
   ai_attribution_user_id?: Nullable<ID>
   allowed_api_keys?: Nullable<string[]>
   bpm?: Nullable<number>
+  is_custom_bpm?: boolean
   musical_key?: Nullable<string>
   audio_analysis_error_count?: number
   field_visibility?: FieldVisibility


### PR DESCRIPTION
### Description
Client can set this field to true if a user manually edits/inputs a track bpm. If `is_custom_bpm` is true, the client will display bpm decimal points.

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._
