### PR TITLE
Re-enable SDK type verification

### DIFF
--- a/.circleci/src/jobs/@integration-jobs.yml
+++ b/.circleci/src/jobs/@integration-jobs.yml
@@ -53,8 +53,6 @@ integration-test:
           . ~/.profile
           audius-compose connect --nopass
           ./scripts/check-generated-types.sh
-          echo 'WARNING: errors have been ignored due to test flakiness.'
-          echo 'Please manually inspect output.'
     - run:
         name: install playwright
         command: sudo NEEDRESTART_MODE=l PLAYWRIGHT_BROWSERS_PATH=/home/circleci/.cache/ms-playwright npx playwright install --with-deps

--- a/.circleci/src/jobs/@integration-jobs.yml
+++ b/.circleci/src/jobs/@integration-jobs.yml
@@ -52,13 +52,13 @@ integration-test:
           cd ~/audius-protocol/packages/libs
           . ~/.profile
           audius-compose connect --nopass
-          ./scripts/check-generated-types.sh || true
+          ./scripts/check-generated-types.sh
           echo 'WARNING: errors have been ignored due to test flakiness.'
           echo 'Please manually inspect output.'
-    - run: 
+    - run:
         name: install playwright
         command: sudo NEEDRESTART_MODE=l PLAYWRIGHT_BROWSERS_PATH=/home/circleci/.cache/ms-playwright npx playwright install --with-deps
-    - run: 
+    - run:
         name: run playwright tests
         command: |
           cd packages/web 


### PR DESCRIPTION
### Description

We disabled this when we disabled our playwright tests, but imo it should be enabled to keep us from pushing api changes without updating the sdk. 

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._
