### PR TITLE
[PAY-3294] Hide save/repost for locked albums on mobile

### DIFF
--- a/packages/mobile/src/screens/collection-screen/CollectionScreenDetailsTile.tsx
+++ b/packages/mobile/src/screens/collection-screen/CollectionScreenDetailsTile.tsx
@@ -265,7 +265,9 @@ export const CollectionScreenDetailsTile = ({
     dayjs(releaseDate).isAfter(dayjs())
   const shouldHideOverflow =
     hideOverflow || !isReachable || (isPrivate && !isOwner)
-  const shouldHideActions = hideActions || (isPrivate && !isOwner)
+  const shouldHideActions =
+    hideActions || (isPrivate && !isOwner) || !hasStreamAccess
+  const shouldeHideShare = hideActions || (isPrivate && !isOwner)
   const isUSDCPurchaseGated = isContentUSDCPurchaseGated(streamConditions)
 
   const uids = isLineupLoading ? Array(Math.min(5, trackCount ?? 0)) : trackUids
@@ -459,7 +461,7 @@ export const CollectionScreenDetailsTile = ({
           hideFavorite={shouldHideActions}
           hideOverflow={shouldHideOverflow}
           hideRepost={shouldHideActions}
-          hideShare={shouldHideActions}
+          hideShare={shouldeHideShare}
           isOwner={isOwner}
           isCollection
           collectionId={numericCollectionId}


### PR DESCRIPTION
### Description
Forgot to include `hasStreamAccess` in this biz logic. Another point for sharing this logic.

### How Has This Been Tested?

locked:
![Simulator Screenshot - iPhone 15 Pro - 2024-07-31 at 16 16 57](https://github.com/user-attachments/assets/9c4f9027-5659-431f-8658-2c62a6b84365)
unlocked:
![Simulator Screenshot - iPhone 15 Pro - 2024-07-31 at 16 19 29](https://github.com/user-attachments/assets/f3f025b1-6c7b-4335-89c0-149f2f672ac4)

mocks (compare far-left (locked) vs far-right (unlocked))
<img width="580" alt="Screenshot 2024-07-31 at 4 22 08 PM" src="https://github.com/user-attachments/assets/66fd2cbd-5b68-4dbe-971e-17dfa55587b6">

