### PR TITLE
[PAY-3271] Prevent navigation prompt from showing on delete

### DIFF
--- a/packages/web/src/components/edit-collection/CollectionNavigationPrompt.tsx
+++ b/packages/web/src/components/edit-collection/CollectionNavigationPrompt.tsx
@@ -19,16 +19,17 @@ const messages = {
 
 type CollectionNavigationPromptProps = {
   isUpload?: boolean
+  disabled?: boolean
 }
 
 export const CollectionNavigationPrompt = (
   props: CollectionNavigationPromptProps
 ) => {
-  const { isUpload } = props
+  const { isUpload, disabled } = props
   const { dirty, isSubmitting } = useFormikContext()
   return (
     <NavigationPrompt
-      when={dirty && !isSubmitting}
+      when={dirty && !isSubmitting && !disabled}
       messages={
         isUpload
           ? messages.uploadNavigationPrompt

--- a/packages/web/src/components/edit-collection/EditCollectionForm.tsx
+++ b/packages/web/src/components/edit-collection/EditCollectionForm.tsx
@@ -125,7 +125,7 @@ export const EditCollectionForm = (props: EditCollectionFormProps) => {
       validationSchema={toFormikValidationSchema(validationSchema)}
     >
       <Form className={styles.root} id={formId}>
-        <CollectionNavigationPrompt />
+        <CollectionNavigationPrompt disabled={isDeleteConfirmationOpen} />
         <Tile className={styles.collectionFields} elevation='mid'>
           <div className={styles.row}>
             <ArtworkField
@@ -207,7 +207,6 @@ export const EditCollectionForm = (props: EditCollectionFormProps) => {
               collectionId={playlist_id}
               entity={collectionTypeName}
               onCancel={() => setIsDeleteConfirmationOpen(false)}
-              onDelete={() => setIsDeleteConfirmationOpen(false)}
             />
             {!isUpload && confirmDrawerType ? (
               <ReleaseCollectionConfirmationModal

--- a/packages/web/src/components/edit-track/EditTrackForm.tsx
+++ b/packages/web/src/components/edit-track/EditTrackForm.tsx
@@ -66,6 +66,7 @@ type EditTrackFormProps = {
   onSubmit: (values: TrackEditFormValues) => void
   onDeleteTrack?: () => void
   hideContainer?: boolean
+  disableNavigationPrompt?: boolean
 }
 
 const EditFormValidationSchema = z.object({
@@ -73,7 +74,13 @@ const EditFormValidationSchema = z.object({
 })
 
 export const EditTrackForm = (props: EditTrackFormProps) => {
-  const { initialValues, onSubmit, onDeleteTrack, hideContainer } = props
+  const {
+    initialValues,
+    onSubmit,
+    onDeleteTrack,
+    hideContainer,
+    disableNavigationPrompt
+  } = props
   const [isReleaseConfirmationOpen, setIsReleaseConfirmationOpen] =
     useState(false)
   const [confirmDrawerType, setConfirmDrawerType] =
@@ -130,6 +137,7 @@ export const EditTrackForm = (props: EditTrackFormProps) => {
             {...props}
             hideContainer={hideContainer}
             onDeleteTrack={onDeleteTrack}
+            disableNavigationPrompt={disableNavigationPrompt}
           />
           {!isUpload && confirmDrawerType ? (
             <ReleaseTrackConfirmationModal
@@ -149,6 +157,7 @@ const TrackEditForm = (
   props: FormikProps<TrackEditFormValues> & {
     hideContainer?: boolean
     onDeleteTrack?: () => void
+    disableNavigationPrompt?: boolean
   }
 ) => {
   const {
@@ -156,6 +165,7 @@ const TrackEditForm = (
     dirty,
     isSubmitting,
     onDeleteTrack,
+    disableNavigationPrompt = false,
     hideContainer = false
   } = props
   const isMultiTrack = values.trackMetadatas.length > 1
@@ -174,7 +184,7 @@ const TrackEditForm = (
   return (
     <Form id={formId}>
       <NavigationPrompt
-        when={dirty && !isSubmitting}
+        when={dirty && !isSubmitting && !disableNavigationPrompt}
         messages={
           isUpload
             ? messages.uploadNavigationPrompt

--- a/packages/web/src/pages/edit-page/EditTrackPage.tsx
+++ b/packages/web/src/pages/edit-page/EditTrackPage.tsx
@@ -71,7 +71,6 @@ export const EditTrackPage = (props: EditPageProps) => {
   const onDeleteTrack = () => {
     if (!track) return
     dispatch(deleteTrack(track.track_id))
-    setShowDeleteConfirmation(false)
     dispatch(pushRoute(`/${track.user.handle}`))
   }
 
@@ -128,6 +127,7 @@ export const EditTrackPage = (props: EditPageProps) => {
             initialValues={initialValues}
             onSubmit={onSubmit}
             onDeleteTrack={() => setShowDeleteConfirmation(true)}
+            disableNavigationPrompt={showDeleteConfirmation}
           />
         </EditFormScrollContext.Provider>
       )}


### PR DESCRIPTION
### Description

- The navigation as part of the delete handler was triggering the `NavigationPrompt`s
- Fix is to check `DeleteConfirmationModal` open state on the nav prompt

### How Has This Been Tested?

nav prompt is showing except when deleting and submitting 👍