### PR TITLE
[QA-1374] Fix play/preview logic on track page

### DIFF
--- a/packages/common/src/store/player/selectors.ts
+++ b/packages/common/src/store/player/selectors.ts
@@ -18,6 +18,8 @@ export const getBuffering = (state: CommonState) => state.player.buffering
 export const getSeek = (state: CommonState) => state.player.seek
 export const getSeekCounter = (state: CommonState) => state.player.seekCounter
 export const getPlaybackRate = (state: CommonState) => state.player.playbackRate
+export const getPlayerBehavior = (state: CommonState) =>
+  state.player.playerBehavior
 
 export const getCurrentTrack = (state: CommonState) =>
   getTrack(state, { id: getTrackId(state) })

--- a/packages/common/src/store/player/slice.ts
+++ b/packages/common/src/store/player/slice.ts
@@ -36,6 +36,8 @@ export type PlayerState = {
 
   // Counter to track seek calls for times where we seek to the same position multiple times
   seekCounter: number
+
+  playerBehavior?: PlayerBehavior
 }
 
 export const initialState: PlayerState = {
@@ -121,7 +123,9 @@ const slice = createSlice({
   name: 'player',
   initialState,
   reducers: {
-    play: (_state, _action: PayloadAction<PlayPayload>) => {},
+    play: (state, action: PayloadAction<PlayPayload>) => {
+      state.playerBehavior = action.payload?.playerBehavior
+    },
     playSucceeded: (state, action: PayloadAction<PlaySucceededPayload>) => {
       const { uid, trackId } = action.payload
       state.playing = true

--- a/packages/web/src/common/store/player/sagas.ts
+++ b/packages/web/src/common/store/player/sagas.ts
@@ -105,6 +105,7 @@ export function* watchPlay() {
       const audiusBackendInstance = yield* getContext('audiusBackendInstance')
       const apiClient = yield* getContext('apiClient')
       const currentUserId = yield* select(getUserId)
+      const isOwner = currentUserId === track.owner_id
 
       const encodedTrackId = encodeHashId(trackId)
 
@@ -151,7 +152,13 @@ export function* watchPlay() {
       const isLongFormContent =
         track.genre === Genre.PODCASTS || track.genre === Genre.AUDIOBOOKS
 
-      const url = usePrefetchStreamUrls && streamUrl ? streamUrl : mp3Url
+      // Always prefer stream url unless an owner is previewing their own track,
+      // since we haven't prefetched the preview.
+      const url =
+        usePrefetchStreamUrls && streamUrl && !(shouldPreview && isOwner)
+          ? streamUrl
+          : mp3Url
+
       const endChannel = eventChannel((emitter) => {
         audioPlayer.load(
           trackDuration ||

--- a/packages/web/src/common/store/queue/sagas.ts
+++ b/packages/web/src/common/store/queue/sagas.ts
@@ -38,7 +38,6 @@ import { getLocation } from 'store/routing/selectors'
 const {
   getCollectible,
   getId: getQueueTrackId,
-  getPlayerBehavior,
   getIndex,
   getLength,
   getOvershot,
@@ -50,7 +49,11 @@ const {
   getCurrentArtist
 } = queueSelectors
 
-const { getTrackId: getPlayerTrackId, getUid: getPlayerUid } = playerSelectors
+const {
+  getTrackId: getPlayerTrackId,
+  getUid: getPlayerUid,
+  getPlayerBehavior
+} = playerSelectors
 
 const { add, clear, next, pause, play, queueAutoplay, previous, remove } =
   queueActions
@@ -158,6 +161,7 @@ export function* watchPlay() {
     // Play a specific uid
     const playerUid = yield* select(getPlayerUid)
     const playerTrackId = yield* select(getPlayerTrackId)
+    const playerPlayerBehavior = yield* select(getPlayerBehavior)
 
     if (uid || trackId) {
       const playActionTrack = yield* select(
@@ -200,7 +204,15 @@ export function* watchPlay() {
       const trackIsDifferent = playerTrackId !== playActionTrack.track_id
       const trackIsSameButDifferentUid =
         playerTrackId === playActionTrack.track_id && uid !== playerUid
-      if (noTrackPlaying || trackIsDifferent || trackIsSameButDifferentUid) {
+      const trackIsSameButDifferentPlayerBehavior =
+        playerTrackId === playActionTrack.track_id &&
+        playerPlayerBehavior !== playerBehavior
+      if (
+        noTrackPlaying ||
+        trackIsDifferent ||
+        trackIsSameButDifferentUid ||
+        trackIsSameButDifferentPlayerBehavior
+      ) {
         yield* put(
           playerActions.play({
             uid,

--- a/packages/web/src/pages/track-page/TrackPageProvider.tsx
+++ b/packages/web/src/pages/track-page/TrackPageProvider.tsx
@@ -266,20 +266,13 @@ class TrackPageProvider extends Component<
 
     const isOwner = track?.owner_id === userId
     const shouldPreview = isPreview && isOwner
-    if (isPlaying && previewing === shouldPreview) {
-      pause()
-      record(
-        make(Name.PLAYBACK_PAUSE, {
-          id: `${track.id}`,
-          source: PlaybackSource.TRACK_PAGE
-        })
-      )
-    } else if (
-      currentQueueItem.track &&
-      currentQueueItem.track.track_id === track.id &&
-      previewing === shouldPreview
-    ) {
-      play()
+
+    const isSameTrack =
+      currentQueueItem.track && currentQueueItem.track.track_id === track.id
+
+    if (previewing !== isPreview || !isSameTrack) {
+      stop()
+      play(track.uid, { isPreview: shouldPreview })
       record(
         make(Name.PLAYBACK_PLAY, {
           id: `${track.id}`,
@@ -287,9 +280,16 @@ class TrackPageProvider extends Component<
           source: PlaybackSource.TRACK_PAGE
         })
       )
-    } else if (track) {
-      stop()
-      play(track.uid, { isPreview: shouldPreview && isOwner })
+    } else if (isPlaying) {
+      pause()
+      record(
+        make(Name.PLAYBACK_PAUSE, {
+          id: `${track.id}`,
+          source: PlaybackSource.TRACK_PAGE
+        })
+      )
+    } else {
+      play()
       record(
         make(Name.PLAYBACK_PLAY, {
           id: `${track.id}`,


### PR DESCRIPTION
Fixes switching between play/preview for owner premium track
Fixes now-playing issue where track position doesnt reset when switching between preview and full track.