### PR TITLE
Fix track preview generation

### DIFF
--- a/packages/mobile/src/screens/track-screen/TrackScreenDetailsTile.tsx
+++ b/packages/mobile/src/screens/track-screen/TrackScreenDetailsTile.tsx
@@ -195,7 +195,8 @@ export const TrackScreenDetailsTile = ({
     is_delete: isDeleted,
     release_date: releaseDate,
     is_scheduled_release: isScheduledRelease,
-    _is_publishing
+    _is_publishing,
+    preview_cid
   } = track as Track
 
   const isOwner = ownerId === currentUserId
@@ -227,7 +228,8 @@ export const TrackScreenDetailsTile = ({
     isUnlisted &&
     releaseDate &&
     dayjs(releaseDate).isAfter(dayjs())
-  const shouldShowPreview = isUSDCPurchaseGated && (isOwner || !hasStreamAccess)
+  const shouldShowPreview =
+    isUSDCPurchaseGated && (isOwner || !hasStreamAccess) && preview_cid
   const shouldHideFavoriteCount =
     isUnlisted || (!isOwner && (saveCount ?? 0) <= 0)
   const shouldHideRepostCount =

--- a/packages/web/src/common/store/cache/tracks/sagas.ts
+++ b/packages/web/src/common/store/cache/tracks/sagas.ts
@@ -275,8 +275,10 @@ function* confirmEditTrack(
   const audiusBackendInstance = yield* getContext('audiusBackendInstance')
   const apiClient = yield* getContext('apiClient')
   const transcodePreview =
-    !!formFields.preview_start_seconds &&
+    formFields.preview_start_seconds !== null &&
+    formFields.preview_start_seconds !== undefined &&
     currentTrack.preview_start_seconds !== formFields.preview_start_seconds
+
   yield* put(
     confirmerActions.requestConfirmation(
       makeKindId(Kind.TRACKS, trackId),

--- a/packages/web/src/components/track/GiantTrackTile.tsx
+++ b/packages/web/src/components/track/GiantTrackTile.tsx
@@ -208,7 +208,8 @@ export const GiantTrackTile = ({
     track?.is_downloadable || (track?._stems?.length ?? 0) > 0
   // Preview button is shown for USDC-gated tracks if user does not have access
   // or is the owner
-  const showPreview = isUSDCPurchaseGated && (isOwner || !hasStreamAccess)
+  const showPreview =
+    isUSDCPurchaseGated && (isOwner || !hasStreamAccess) && track?.preview_cid
   // Play button is conditionally hidden for USDC-gated tracks when the user does not have access
   const showPlay = isUSDCPurchaseGated ? hasStreamAccess : true
   const shouldShowScheduledRelease =


### PR DESCRIPTION
### Description

Fixes issue where track previews were not generated for tracks with preview seconds === 0, since that be falsey
