### PR TITLE
Fix show premium downloads message

### DIFF
--- a/packages/web/src/components/edit/fields/price-and-audience/PriceAndAudienceField.tsx
+++ b/packages/web/src/components/edit/fields/price-and-audience/PriceAndAudienceField.tsx
@@ -273,7 +273,7 @@ export const PriceAndAudienceField = (props: PriceAndAudienceFieldProps) => {
     }
     set(initialValues, STREAM_AVAILABILITY_TYPE, availabilityType)
     set(initialValues, FIELD_VISIBILITY, fieldVisibility)
-    set(initialValues, PREVIEW, preview)
+    set(initialValues, PREVIEW, preview ?? 0)
     set(
       initialValues,
       SPECIAL_ACCESS_TYPE,

--- a/packages/web/src/components/edit/fields/stream-availability/SpecialAccessFields.tsx
+++ b/packages/web/src/components/edit/fields/stream-availability/SpecialAccessFields.tsx
@@ -13,6 +13,8 @@ import Tooltip from 'components/tooltip/Tooltip'
 import {
   AccessAndSaleFormValues,
   DOWNLOAD_CONDITIONS,
+  GateKeeper,
+  LAST_GATE_KEEPER,
   STREAM_CONDITIONS,
   SpecialAccessType
 } from '../types'
@@ -41,13 +43,16 @@ export const SpecialAccessFields = (props: TrackAvailabilityFieldsProps) => {
   const [specialAccessTypeField] = useField({
     name: SPECIAL_ACCESS_TYPE
   })
+  const [{ value: downloadConditions }] =
+    useField<Nullable<AccessConditions>>(DOWNLOAD_CONDITIONS)
+  const [{ value: lastGateKeeper }] = useField<GateKeeper>(LAST_GATE_KEEPER)
+  const showPremiumDownloadsMessage =
+    downloadConditions && lastGateKeeper.access === 'stemsAndDownloads'
 
   const [, , { setValue: setStreamConditionsValue }] =
     useField<AccessAndSaleFormValues[typeof STREAM_CONDITIONS]>(
       STREAM_CONDITIONS
     )
-  const [{ value: downloadConditions }] =
-    useField<Nullable<AccessConditions>>(DOWNLOAD_CONDITIONS)
 
   const handleChange = useCallback(
     (e: ChangeEvent<HTMLInputElement>) => {
@@ -102,7 +107,7 @@ export const SpecialAccessFields = (props: TrackAvailabilityFieldsProps) => {
           </Tooltip>
         </label>
       </RadioGroup>
-      {downloadConditions ? (
+      {showPremiumDownloadsMessage ? (
         <Hint icon={IconInfo}>{messages.premiumDownloads}</Hint>
       ) : null}
     </>

--- a/packages/web/src/components/edit/fields/stream-availability/collectible-gated/CollectibleGatedFields.tsx
+++ b/packages/web/src/components/edit/fields/stream-availability/collectible-gated/CollectibleGatedFields.tsx
@@ -19,6 +19,8 @@ import LoadingSpinner from 'components/loading-spinner/LoadingSpinner'
 import {
   AccessAndSaleFormValues,
   DOWNLOAD_CONDITIONS,
+  GateKeeper,
+  LAST_GATE_KEEPER,
   STREAM_AVAILABILITY_TYPE,
   STREAM_CONDITIONS
 } from '../../types'
@@ -53,6 +55,9 @@ export const CollectibleGatedFields = (props: CollectibleGatedFieldsProps) => {
     )
   const [{ value: downloadConditions }] =
     useField<Nullable<AccessConditions>>(DOWNLOAD_CONDITIONS)
+  const [{ value: lastGateKeeper }] = useField<GateKeeper>(LAST_GATE_KEEPER)
+  const showPremiumDownloadsMessage =
+    downloadConditions && lastGateKeeper.access === 'stemsAndDownloads'
 
   const { ethCollectionMap, solCollectionMap, isLoading } = useSelector(
     getSupportedUserCollections
@@ -172,7 +177,7 @@ export const CollectibleGatedFields = (props: CollectibleGatedFieldsProps) => {
         dropdownInputStyle={styles.dropdownInput}
         disabled={disabled}
       />
-      {downloadConditions ? (
+      {showPremiumDownloadsMessage ? (
         <Box mt='l'>
           <Hint icon={IconInfo}>{messages.premiumDownloads}</Hint>
         </Box>

--- a/packages/web/src/components/edit/fields/stream-availability/usdc-purchase-gated/UsdcPurchaseFields.tsx
+++ b/packages/web/src/components/edit/fields/stream-availability/usdc-purchase-gated/UsdcPurchaseFields.tsx
@@ -26,7 +26,9 @@ import {
   DOWNLOAD_CONDITIONS,
   PREVIEW,
   PRICE,
-  ALBUM_TRACK_PRICE
+  ALBUM_TRACK_PRICE,
+  GateKeeper,
+  LAST_GATE_KEEPER
 } from '../../types'
 
 const messagesV1 = {
@@ -114,6 +116,9 @@ export const UsdcPurchaseFields = (props: TrackAvailabilityFieldsProps) => {
   const { disabled, isAlbum, isUpload } = props
   const [{ value: downloadConditions }] =
     useField<Nullable<AccessConditions>>(DOWNLOAD_CONDITIONS)
+  const [{ value: lastGateKeeper }] = useField<GateKeeper>(LAST_GATE_KEEPER)
+  const showPremiumDownloadsMessage =
+    downloadConditions && lastGateKeeper.access === 'stemsAndDownloads'
 
   const messages = useMessages(
     messagesV1,
@@ -140,9 +145,6 @@ export const UsdcPurchaseFields = (props: TrackAvailabilityFieldsProps) => {
             />
           )}
           <input type='hidden' name={PREVIEW} value='0' />
-          {downloadConditions && !isAlbum ? (
-            <Hint icon={IconInfo}>{messages.premiumDownloads}</Hint>
-          ) : null}
         </>
       ) : (
         <>
@@ -153,7 +155,7 @@ export const UsdcPurchaseFields = (props: TrackAvailabilityFieldsProps) => {
             prefillValue={100}
           />
           <PreviewField disabled={disabled} />
-          {downloadConditions ? (
+          {showPremiumDownloadsMessage ? (
             <Hint icon={IconInfo}>{messages.premiumDownloads}</Hint>
           ) : null}
         </>


### PR DESCRIPTION
### Description

- Use the download gate keeper context to determine where the original setting came from to prevent this UI from showing if we didn't come from stem gated
![image (90)](https://github.com/user-attachments/assets/a19ee71a-1682-4986-ae81-63f9e44bae00)
- Fix preview default to 0

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._

local staging web