### PR TITLE
Remove null checks for metadata items in useXMetadata

### DIFF
--- a/packages/common/src/hooks/useCollectionMetadata.ts
+++ b/packages/common/src/hooks/useCollectionMetadata.ts
@@ -62,13 +62,13 @@ export const useCollectionMetadata = ({
       id: CollectionMetadataType.RELEASE_DATE,
       value: formatDate(releaseDate ?? ''),
       label: 'Released',
-      isHidden: isPrivate || !releaseDate
+      isHidden: isPrivate
     },
     {
       id: CollectionMetadataType.UPDATED_AT,
       value: formatDate(updatedAt ?? ''),
       label: 'Updated',
-      isHidden: isPrivate || !updatedAt
+      isHidden: isPrivate
     }
   ].filter(({ isHidden, value }) => !isHidden && !!value)
 

--- a/packages/common/src/hooks/useTrackMetadata.ts
+++ b/packages/common/src/hooks/useTrackMetadata.ts
@@ -63,7 +63,7 @@ export const useTrackMetadata = ({
       id: TrackMetadataType.RELEASE_DATE,
       value: formatDate(releaseDate ?? ''),
       label: 'Released',
-      isHidden: isUnlisted || !releaseDate
+      isHidden: isUnlisted
     },
     {
       id: TrackMetadataType.MOOD,


### PR DESCRIPTION
### Description
Realized these are unneeded as null values are filtered out by default.

### How Has This Been Tested?
