### PR TITLE
Prevent service restarts when installing apt packages

### DIFF
--- a/dev-tools/setup.sh
+++ b/dev-tools/setup.sh
@@ -12,7 +12,7 @@ debian | ubuntu)
 
     # Install packages to allow apt to use a repository over HTTPS
     sudo apt-get update
-    sudo apt-get install -y ca-certificates curl gnupg lsb-release
+    sudo NEEDRESTART_MODE=l apt-get install -y ca-certificates curl gnupg lsb-release
 
     # Add Docker's official GPG key:
     if ! [ -f /etc/apt/keyrings/docker.gpg ]; then


### PR DESCRIPTION
### Description

CI jobs will hang and fail if [apt is waiting for interaction](https://app.circleci.com/pipelines/github/AudiusProject/audius-protocol/60844/workflows/4ea33469-3c8f-4a9a-9a01-2af078497f36/jobs/891525) to restart services.

### How Has This Been Tested?

CI