### PR TITLE
Add better error messages for Claimable Tokens Program

### DIFF
--- a/.changeset/unlucky-chicken-listen.md
+++ b/.changeset/unlucky-chicken-listen.md
@@ -1,0 +1,6 @@
+---
+'@audius/sdk': patch
+'@audius/spl': patch
+---
+
+Improve error messages from Claimable Tokens program

--- a/packages/libs/src/sdk/sdk.ts
+++ b/packages/libs/src/sdk/sdk.ts
@@ -192,21 +192,24 @@ const initializeServices = (config: SdkConfig) => {
     config.services?.claimableTokensClient ??
     new ClaimableTokensClient({
       ...getDefaultClaimableTokensConfig(servicesConfig),
-      solanaWalletAdapter
+      solanaWalletAdapter,
+      logger
     })
 
   const rewardManagerClient =
     config.services?.rewardManagerClient ??
     new RewardManagerClient({
       ...getDefaultRewardManagerClentConfig(servicesConfig),
-      solanaWalletAdapter
+      solanaWalletAdapter,
+      logger
     })
 
   const paymentRouterClient =
     config.services?.paymentRouterClient ??
     new PaymentRouterClient({
       ...getDefaultPaymentRouterClientConfig(servicesConfig),
-      solanaWalletAdapter
+      solanaWalletAdapter,
+      logger
     })
 
   const services: ServicesContainer = {

--- a/packages/libs/src/sdk/services/Solana/programs/BaseSolanaProgramClient.ts
+++ b/packages/libs/src/sdk/services/Solana/programs/BaseSolanaProgramClient.ts
@@ -194,7 +194,7 @@ export class BaseSolanaProgramClient {
   protected async getInstructions(
     transaction: VersionedTransaction | Transaction
   ) {
-    if (!('instructions' in transaction)) {
+    if ('version' in transaction) {
       const lookupTableAccounts = await this.getLookupTableAccounts(
         transaction.message.addressTableLookups.map((k) => k.accountKey)
       )

--- a/packages/libs/src/sdk/services/Solana/programs/BaseSolanaProgramClient.ts
+++ b/packages/libs/src/sdk/services/Solana/programs/BaseSolanaProgramClient.ts
@@ -3,12 +3,14 @@ import {
   ComputeBudgetProgram,
   Connection,
   PublicKey,
+  Transaction,
   TransactionMessage,
   VersionedTransaction
 } from '@solana/web3.js'
 import { z } from 'zod'
 
 import { parseParams } from '../../../utils/parseParams'
+import { LoggerService } from '../../Logger'
 import type { SolanaWalletAdapter } from '../types'
 
 import {
@@ -39,11 +41,13 @@ const priorityToPercentileMap: Record<
 export class BaseSolanaProgramClient {
   /** The Solana RPC client. */
   public readonly connection: Connection
+  protected readonly logger: LoggerService
   constructor(
     config: BaseSolanaProgramConfigInternal,
     protected wallet: SolanaWalletAdapter
   ) {
     this.connection = new Connection(config.rpcEndpoint, config.rpcConfig)
+    this.logger = config.logger
   }
 
   /**
@@ -168,7 +172,10 @@ export class BaseSolanaProgramClient {
     return this.wallet.publicKey!
   }
 
-  private async getLookupTableAccounts(lookupTableKeys: PublicKey[]) {
+  /**
+   * Fetches the address look up tables for populating transaction objects
+   */
+  protected async getLookupTableAccounts(lookupTableKeys: PublicKey[]) {
     return await Promise.all(
       lookupTableKeys.map(async (accountKey) => {
         const res = await this.connection.getAddressLookupTable(accountKey)
@@ -178,5 +185,25 @@ export class BaseSolanaProgramClient {
         return res.value
       })
     )
+  }
+
+  /**
+   * Normalizes the instructions as TransactionInstruction whether from
+   * versioned transactions or legacy transactions.
+   */
+  protected async getInstructions(
+    transaction: VersionedTransaction | Transaction
+  ) {
+    if (!('instructions' in transaction)) {
+      const lookupTableAccounts = await this.getLookupTableAccounts(
+        transaction.message.addressTableLookups.map((k) => k.accountKey)
+      )
+      const decompiled = TransactionMessage.decompile(transaction.message, {
+        addressLookupTableAccounts: lookupTableAccounts
+      })
+      return decompiled.instructions
+    } else {
+      return transaction.instructions
+    }
   }
 }

--- a/packages/libs/src/sdk/services/Solana/programs/ClaimableTokensClient/ClaimableTokensClient.ts
+++ b/packages/libs/src/sdk/services/Solana/programs/ClaimableTokensClient/ClaimableTokensClient.ts
@@ -124,10 +124,7 @@ export class ClaimableTokensClient extends BaseSolanaProgramClient {
         instructions: [createUserBankInstruction]
       }).compileToLegacyMessage()
       const transaction = new VersionedTransaction(message)
-      const signature = await this.wallet.sendTransaction(
-        transaction,
-        this.connection
-      )
+      const signature = await this.sendTransaction(transaction)
       const confirmationStrategy = { ...confirmationStrategyArgs, signature }
       await this.connection.confirmTransaction(
         confirmationStrategy,

--- a/packages/libs/src/sdk/services/Solana/programs/ClaimableTokensClient/ClaimableTokensClient.ts
+++ b/packages/libs/src/sdk/services/Solana/programs/ClaimableTokensClient/ClaimableTokensClient.ts
@@ -35,7 +35,7 @@ import {
 } from './types'
 
 export class ClaimableTokensError extends Error {
-  override name = 'RewardManagerError'
+  override name = 'ClaimableTokensError'
   public code: number
   public instructionName: string
   public customErrorName?: string

--- a/packages/libs/src/sdk/services/Solana/programs/ClaimableTokensClient/getDefaultConfig.ts
+++ b/packages/libs/src/sdk/services/Solana/programs/ClaimableTokensClient/getDefaultConfig.ts
@@ -1,6 +1,7 @@
 import { PublicKey } from '@solana/web3.js'
 
 import type { SdkServicesConfig } from '../../../../config/types'
+import { Logger } from '../../../Logger'
 
 import type { ClaimableTokensConfigInternal } from './types'
 
@@ -12,5 +13,6 @@ export const getDefaultClaimableTokensConfig = (
   mints: {
     wAUDIO: new PublicKey(config.solana.wAudioTokenMint),
     USDC: new PublicKey(config.solana.usdcTokenMint)
-  }
+  },
+  logger: new Logger()
 })

--- a/packages/libs/src/sdk/services/Solana/programs/CustomInstructionError.ts
+++ b/packages/libs/src/sdk/services/Solana/programs/CustomInstructionError.ts
@@ -13,9 +13,6 @@ export class CustomInstructionError extends Error {
     )
   }
 
-  /**
-   * @throws if the error message isn't a custom error
-   */
   public static parseSendTransactionError(error: SendTransactionError) {
     try {
       const parsed = JSON.parse(

--- a/packages/libs/src/sdk/services/Solana/programs/CustomInstructionError.ts
+++ b/packages/libs/src/sdk/services/Solana/programs/CustomInstructionError.ts
@@ -1,0 +1,35 @@
+import { SendTransactionError } from '@solana/web3.js'
+
+type CustomInstructionErrorMessage = {
+  InstructionError: [number, { Custom: number }]
+}
+
+export class CustomInstructionError extends Error {
+  constructor(public instructionIndex: number, public code: number) {
+    super(
+      JSON.stringify({
+        InstructionError: [instructionIndex, { Custom: code }]
+      })
+    )
+  }
+
+  /**
+   * @throws if the error message isn't a custom error
+   */
+  public static parseSendTransactionError(error: SendTransactionError) {
+    try {
+      const parsed = JSON.parse(
+        error.transactionError.message
+      ) as CustomInstructionErrorMessage
+      if (typeof parsed?.InstructionError?.[1]?.Custom === 'number') {
+        return new CustomInstructionError(
+          parsed.InstructionError[0],
+          parsed.InstructionError[1].Custom
+        )
+      }
+      return null
+    } catch (e) {
+      return null
+    }
+  }
+}

--- a/packages/libs/src/sdk/services/Solana/programs/PaymentRouterClient/getDefaultConfig.ts
+++ b/packages/libs/src/sdk/services/Solana/programs/PaymentRouterClient/getDefaultConfig.ts
@@ -1,6 +1,7 @@
 import { PublicKey } from '@solana/web3.js'
 
 import { SdkServicesConfig } from '../../../../config/types'
+import { Logger } from '../../../Logger'
 
 import { PaymentRouterClientConfigInternal } from './types'
 
@@ -12,5 +13,6 @@ export const getDefaultPaymentRouterClientConfig = (
   mints: {
     USDC: new PublicKey(config.solana.usdcTokenMint),
     wAUDIO: new PublicKey(config.solana.wAudioTokenMint)
-  }
+  },
+  logger: new Logger()
 })

--- a/packages/libs/src/sdk/services/Solana/programs/RewardManagerClient/RewardManagerClient.ts
+++ b/packages/libs/src/sdk/services/Solana/programs/RewardManagerClient/RewardManagerClient.ts
@@ -1,7 +1,8 @@
 import {
   RewardManagerInstruction,
   RewardManagerErrorCode,
-  RewardManagerProgram
+  RewardManagerProgram,
+  RewardManagerErrorMessages
 } from '@audius/spl'
 import type { RewardManagerStateData } from '@audius/spl/dist/types/reward-manager/types'
 import { SendTransactionOptions } from '@solana/wallet-adapter-base'
@@ -17,6 +18,7 @@ import { productionConfig } from '../../../../config/production'
 import { mergeConfigWithDefaults } from '../../../../utils/mergeConfigs'
 import { parseParams } from '../../../../utils/parseParams'
 import { BaseSolanaProgramClient } from '../BaseSolanaProgramClient'
+import { CustomInstructionError } from '../CustomInstructionError'
 
 import { getDefaultRewardManagerClentConfig } from './getDefaultConfig'
 import {
@@ -33,36 +35,6 @@ import {
   GetSubmittedAttestationsSchema
 } from './types'
 
-type CustomInstructionErrorMessage = {
-  InstructionError: [number, { Custom: number }]
-}
-
-/**
- * Mapping of custom instruction error codes to error messages
- * @see {@link https://github.com/AudiusProject/audius-protocol/blob/2a37bcff1bb1a82efdf187d1723b3457dc0dcb9b/solana-programs/reward-manager/program/src/error.rs solana-programs/reward-manager/program/src/errors.rs}
- */
-const codeMessageMap: Record<RewardManagerErrorCode, string> = {
-  [RewardManagerErrorCode.IncorrectOwner]:
-    'Input account owner is not the program address',
-  [RewardManagerErrorCode.SignCollision]:
-    'Signature with an already met principal',
-  [RewardManagerErrorCode.WrongSigner]: 'Unexpected signer met',
-  [RewardManagerErrorCode.NotEnoughSigners]: "Isn't enough signers keys",
-  [RewardManagerErrorCode.Secp256InstructionMissing]:
-    'Secp256 instruction missing',
-  [RewardManagerErrorCode.InstructionLoadError]: 'Instruction load error',
-  [RewardManagerErrorCode.RepeatedSenders]: 'Repeated sender',
-  [RewardManagerErrorCode.SignatureVerificationFailed]:
-    'Signature verification failed',
-  [RewardManagerErrorCode.OperatorCollision]:
-    'Some signers have same operators',
-  [RewardManagerErrorCode.AlreadySent]: 'Funds already sent',
-  [RewardManagerErrorCode.IncorrectMessages]: 'Incorrect messages',
-  [RewardManagerErrorCode.MessagesOverflow]: 'Messages overflow',
-  [RewardManagerErrorCode.MathOverflow]: 'Math overflow',
-  [RewardManagerErrorCode.InvalidRecipient]: 'Invalid Recipient'
-}
-
 export class RewardManagerError extends Error {
   override name = 'RewardManagerError'
   public code: number
@@ -78,7 +50,7 @@ export class RewardManagerError extends Error {
     cause?: Error
   }) {
     super(
-      codeMessageMap[code as RewardManagerErrorCode] ??
+      RewardManagerErrorMessages[code as RewardManagerErrorCode] ??
         `Unknown error: ${code}`,
       { cause }
     )
@@ -325,57 +297,26 @@ export class RewardManagerClient extends BaseSolanaProgramClient {
     } catch (e) {
       if (e instanceof SendTransactionError) {
         try {
-          const error = JSON.parse(
-            e.transactionError.message
-          ) as CustomInstructionErrorMessage
-          if (error && error.InstructionError) {
-            const instructionIndex = error.InstructionError[0]
-            const code = error.InstructionError[1]?.Custom
-
-            // Parse the different transaction types differently
-            if ('instructions' in transaction) {
-              // Legacy Transaction
-              const instruction = transaction.instructions[instructionIndex]
-              // Check error instruction is from RewardManagerProgram
-              if (instruction && instruction.programId.equals(this.programId)) {
-                const decodedInstruction =
-                  RewardManagerProgram.decodeInstruction(instruction)
-                throw new RewardManagerError({
-                  code,
-                  instructionName:
-                    RewardManagerInstruction[
-                      decodedInstruction.data.instruction
-                    ] ?? 'Unknown',
-                  cause: e
-                })
-              }
-            } else {
-              // VersionedTransaction
-              const instruction =
-                transaction.message.compiledInstructions[instructionIndex]
-              // Check error instruction is from RewardManagerProgram
-              if (
-                instruction &&
-                transaction.message.staticAccountKeys[
-                  instruction.programIdIndex
-                ]?.equals(this.programId)
-              ) {
-                throw new RewardManagerError({
-                  code,
-                  instructionName:
-                    RewardManagerInstruction[instruction!.data[0] as number] ??
-                    'Unknown',
-                  cause: e
-                })
-              }
+          const error = CustomInstructionError.parseSendTransactionError(e)
+          if (error) {
+            const instructions = await this.getInstructions(transaction)
+            const instruction = instructions[error.instructionIndex]
+            if (instruction && instruction.programId.equals(this.programId)) {
+              const decodedInstruction =
+                RewardManagerProgram.decodeInstruction(instruction)
+              throw new RewardManagerError({
+                code: error.code,
+                instructionName:
+                  RewardManagerInstruction[
+                    decodedInstruction.data.instruction
+                  ] ?? 'Unknown',
+                cause: e
+              })
             }
           }
         } catch (e) {
-          if (e instanceof RewardManagerError) {
-            throw e
-          }
           // If failed to provide user friendly error, surface original error
-          console.warn('Failed to parse RewardManagerError error', e)
+          this.logger.warn('Failed to parse RewardManagerError error', e)
         }
       }
       throw e

--- a/packages/libs/src/sdk/services/Solana/programs/RewardManagerClient/getDefaultConfig.ts
+++ b/packages/libs/src/sdk/services/Solana/programs/RewardManagerClient/getDefaultConfig.ts
@@ -1,6 +1,7 @@
 import { PublicKey } from '@solana/web3.js'
 
 import type { SdkServicesConfig } from '../../../../config/types'
+import { Logger } from '../../../Logger'
 
 import type { RewardManagerClientConfigInternal } from './types'
 
@@ -9,5 +10,6 @@ export const getDefaultRewardManagerClentConfig = (
 ): RewardManagerClientConfigInternal => ({
   programId: new PublicKey(config.solana.rewardManagerProgramAddress),
   rpcEndpoint: config.solana.rpcEndpoint,
-  rewardManagerState: new PublicKey(config.solana.rewardManagerStateAddress)
+  rewardManagerState: new PublicKey(config.solana.rewardManagerStateAddress),
+  logger: new Logger()
 })

--- a/packages/libs/src/sdk/services/Solana/programs/types.ts
+++ b/packages/libs/src/sdk/services/Solana/programs/types.ts
@@ -5,6 +5,7 @@ import {
 } from '@solana/web3.js'
 import { z } from 'zod'
 
+import { LoggerService } from '../../Logger'
 import { PublicKeySchema } from '../types'
 
 export type BaseSolanaProgramConfigInternal = {
@@ -12,6 +13,7 @@ export type BaseSolanaProgramConfigInternal = {
   rpcEndpoint: string
   /** Configuration to use for the RPC connection. */
   rpcConfig?: ConnectionConfig
+  logger: LoggerService
 }
 
 export const PrioritySchema = z.enum([

--- a/packages/spl/src/claimable-tokens/constants.ts
+++ b/packages/spl/src/claimable-tokens/constants.ts
@@ -2,3 +2,30 @@ export enum ClaimableTokensInstruction {
   Create = 0,
   Transfer = 1
 }
+
+/**
+ * Custom error codes from the Claimable Tokens program
+ * @see {@link https://github.com/AudiusProject/audius-protocol/blob/2a37bcff1bb1a82efdf187d1723b3457dc0dcb9b/solana-programs/claimable-tokens/program/src/error.rs solana-programs/claimable-tokens/program/src/error.rs}
+ */
+export enum ClaimableTokensErrorCode {
+  SignatureVerificationFailed = 0,
+  Secp256InstructionLosing,
+  InstructionLoadError,
+  NonceVerificationError
+}
+
+/**
+ * The UI friendly error messages for each error code.
+ * @see {@link https://github.com/AudiusProject/audius-protocol/blob/2a37bcff1bb1a82efdf187d1723b3457dc0dcb9b/solana-programs/claimable-tokens/program/src/error.rs solana-programs/claimable-tokens/program/src/error.rs}
+ */
+export const ClaimableTokensErrorMessages: Record<
+  ClaimableTokensErrorCode,
+  string
+> = {
+  [ClaimableTokensErrorCode.SignatureVerificationFailed]:
+    'Signature verification failed',
+  [ClaimableTokensErrorCode.Secp256InstructionLosing]:
+    'Secp256 instruction losing',
+  [ClaimableTokensErrorCode.InstructionLoadError]: 'Instruction load error',
+  [ClaimableTokensErrorCode.NonceVerificationError]: 'Nonce verification failed'
+}

--- a/packages/spl/src/index.ts
+++ b/packages/spl/src/index.ts
@@ -1,9 +1,7 @@
 export { ClaimableTokensProgram } from './claimable-tokens/ClaimableTokensProgram'
-export {
-  RewardManagerInstruction,
-  RewardManagerErrorCode
-} from './reward-manager/constants'
+export * from './claimable-tokens/constants'
 export { RewardManagerProgram } from './reward-manager/RewardManagerProgram'
+export * from './reward-manager/constants'
 export { Secp256k1Program } from './secp256k1/Secp256k1Program'
 export { ethAddress } from './layout-utils'
 export * from './associated-token'

--- a/packages/spl/src/reward-manager/constants.ts
+++ b/packages/spl/src/reward-manager/constants.ts
@@ -10,7 +10,7 @@ export enum RewardManagerInstruction {
 }
 
 /**
- * Possible custom error messages from the Reward Manager program
+ * Custom error codes from the Reward Manager program
  * @see {@link https://github.com/AudiusProject/audius-protocol/blob/2a37bcff1bb1a82efdf187d1723b3457dc0dcb9b/solana-programs/reward-manager/program/src/error.rs solana-programs/reward-manager/program/src/errors.rs}
  */
 export enum RewardManagerErrorCode {
@@ -28,4 +28,33 @@ export enum RewardManagerErrorCode {
   MessagesOverflow,
   MathOverflow,
   InvalidRecipient
+}
+
+/**
+ * The UI friendly error messages for each error code.
+ * @see {@link https://github.com/AudiusProject/audius-protocol/blob/2a37bcff1bb1a82efdf187d1723b3457dc0dcb9b/solana-programs/reward-manager/program/src/error.rs solana-programs/reward-manager/program/src/errors.rs}
+ */
+export const RewardManagerErrorMessages: Record<
+  RewardManagerErrorCode,
+  string
+> = {
+  [RewardManagerErrorCode.IncorrectOwner]:
+    'Input account owner is not the program address',
+  [RewardManagerErrorCode.SignCollision]:
+    'Signature with an already met principal',
+  [RewardManagerErrorCode.WrongSigner]: 'Unexpected signer met',
+  [RewardManagerErrorCode.NotEnoughSigners]: "Isn't enough signers keys",
+  [RewardManagerErrorCode.Secp256InstructionMissing]:
+    'Secp256 instruction missing',
+  [RewardManagerErrorCode.InstructionLoadError]: 'Instruction load error',
+  [RewardManagerErrorCode.RepeatedSenders]: 'Repeated sender',
+  [RewardManagerErrorCode.SignatureVerificationFailed]:
+    'Signature verification failed',
+  [RewardManagerErrorCode.OperatorCollision]:
+    'Some signers have same operators',
+  [RewardManagerErrorCode.AlreadySent]: 'Funds already sent',
+  [RewardManagerErrorCode.IncorrectMessages]: 'Incorrect messages',
+  [RewardManagerErrorCode.MessagesOverflow]: 'Messages overflow',
+  [RewardManagerErrorCode.MathOverflow]: 'Math overflow',
+  [RewardManagerErrorCode.InvalidRecipient]: 'Invalid Recipient'
 }

--- a/packages/web/src/common/store/tipping/sagas.ts
+++ b/packages/web/src/common/store/tipping/sagas.ts
@@ -405,7 +405,7 @@ function* sendTipAsync() {
         senderHandle: sender.handle,
         recipientHandle: receiver.handle,
         amount,
-        error: e.message,
+        error: 'transactionMessage' in e ? e.transactionMessage : e.message,
         device,
         source
       })


### PR DESCRIPTION
### Description

- Adds logger to the Solana Program Clients in SDK
- Moves error messages to `@audius/spl`
- Adds error message and custom error wrapper for Claimable Tokens

### How Has This Been Tested?

Tested manually locally by trying to send a tip with no money