### PR TITLE
Remove audius-cmd purchase-content

### DIFF
--- a/packages/commands/src/purchase-content.mjs
+++ b/packages/commands/src/purchase-content.mjs
@@ -5,92 +5,16 @@ import { initializeAudiusLibs, initializeAudiusSdk } from './utils.mjs'
 import { Utils } from '@audius/sdk'
 
 program
-  .command('purchase-content')
-  .description('Purchases a track or album using USDC')
-  .argument('<id>', 'The track_id or playlist_id to purchase')
-  .option('-f, --from [from]', 'The account purchasing the content (handle)')
-  .option('-t, --type [type]', 'The content type to purchase (album or track)')
-  .option(
-    '-e, --extra-amount [amount]',
-    'Extra amount to pay in addition to the price (in cents)'
-  )
-  .action(async (contentId, { from, type, extraAmount: extraAmountCents }) => {
-    type = type || 'track'
-    const audiusLibs = await initializeAudiusLibs(from)
-    const user = audiusLibs.userStateManager.getCurrentUser()
-
-    let blocknumber
-    let streamConditions
-    if (type === 'track') {
-      const track = (await audiusLibs.Track.getTracks(100, 0, [contentId]))[0]
-      if (!track.stream_conditions || !track.is_stream_gated) {
-        program.error('Track is not stream gated')
-      }
-      if (!track.stream_conditions?.usdc_purchase?.splits) {
-        program.error('Track is not purchaseable')
-      }
-      blocknumber = track.blocknumber
-      streamConditions = track.stream_conditions
-    } else if (type === 'album') {
-      const album = (
-        await audiusLibs.Playlist.getPlaylists(100, 0, [contentId])
-      )[0]
-      if (!album.is_album) {
-        program.error('Playlist is not an album')
-      }
-      if (!album.stream_conditions || !album.is_stream_gated) {
-        program.error('Album is not stream gated')
-      }
-      if (!album.stream_conditions?.usdc_purchase?.splits) {
-        program.error('Album is not purchaseable')
-      }
-      blocknumber = album.blocknumber
-      streamConditions = album.stream_conditions
-    } else {
-      program.error('Invalid type')
-    }
-
-    let extraAmount
-    if (extraAmountCents) {
-      const parsedExtraAmount = Number.parseInt(extraAmountCents)
-      if (!Number.isFinite(parsedExtraAmount) || parsedExtraAmount <= 0) {
-        program.error(`Invalid extra amount: ${extraAmountCents}`)
-      }
-      extraAmount = parsedExtraAmount * 10 ** 4
-    }
-
-    try {
-      const response = await audiusLibs.solanaWeb3Manager.purchaseContent({
-        id: contentId,
-        extraAmount,
-        type,
-        blocknumber,
-        splits: streamConditions.usdc_purchase.splits,
-        purchaserUserId: user.user_id,
-        purchaseAccess: 'stream'
-      })
-      if (response.error) {
-        program.error(chalk.red(response.error))
-      }
-      console.log(chalk.green(`Successfully purchased ${type}`))
-      console.log(chalk.yellow('Transaction Signature:'), response.res)
-    } catch (err) {
-      program.error(err.message)
-    }
-
-    process.exit(0)
-  })
-
-
-program.command('purchase-track')
+  .command('purchase-track')
   .description('Buys a track using USDC')
   .argument('<id>', 'The track ID')
   .argument('<price>', 'The expected price of the track', parseFloat)
   .option('-f, --from [from]', 'The account purchasing the content (handle)')
   .option(
     '-e, --extra-amount [amount]',
-    'Extra amount to pay in addition to the price (in dollars)'
-    , parseFloat)
+    'Extra amount to pay in addition to the price (in dollars)',
+    parseFloat
+  )
   .action(async (id, price, { from, extraAmount }) => {
     const audiusLibs = await initializeAudiusLibs(from)
     const userIdNumber = audiusLibs.userStateManager.getCurrentUserId()
@@ -105,11 +29,24 @@ program.command('purchase-track')
 
     // init sdk with priv and pub keys as api keys and secret
     // this enables writes via sdk
-    const audiusSdk = await initializeAudiusSdk({ apiKey: pubKey, apiSecret: privKey })
+    const audiusSdk = await initializeAudiusSdk({
+      apiKey: pubKey,
+      apiSecret: privKey
+    })
 
     try {
-      console.log('Purchasing track...', { trackId, userId, price, extraAmount })
-      const response = await audiusSdk.tracks.purchaseTrack({ trackId, userId, price, extraAmount })
+      console.log('Purchasing track...', {
+        trackId,
+        userId,
+        price,
+        extraAmount
+      })
+      const response = await audiusSdk.tracks.purchaseTrack({
+        trackId,
+        userId,
+        price,
+        extraAmount
+      })
       console.log(chalk.green('Successfully purchased track'))
       console.log(chalk.yellow('Transaction Signature:'), response)
     } catch (err) {
@@ -118,15 +55,17 @@ program.command('purchase-track')
     process.exit(0)
   })
 
-program.command('purchase-album')
+program
+  .command('purchase-album')
   .description('Buys an album using USDC')
   .argument('<id>', 'The album ID')
   .argument('<price>', 'The expected price of the album', parseFloat)
   .option('-f, --from [from]', 'The account purchasing the content (handle)')
   .option(
     '-e, --extra-amount [amount]',
-    'Extra amount to pay in addition to the price (in dollars)'
-    , parseFloat)
+    'Extra amount to pay in addition to the price (in dollars)',
+    parseFloat
+  )
   .action(async (id, price, { from, extraAmount }) => {
     const audiusLibs = await initializeAudiusLibs(from)
     const userIdNumber = audiusLibs.userStateManager.getCurrentUserId()
@@ -141,11 +80,24 @@ program.command('purchase-album')
 
     // init sdk with priv and pub keys as api keys and secret
     // this enables writes via sdk
-    const audiusSdk = await initializeAudiusSdk({ apiKey: pubKey, apiSecret: privKey })
+    const audiusSdk = await initializeAudiusSdk({
+      apiKey: pubKey,
+      apiSecret: privKey
+    })
 
     try {
-      console.log('Purchasing album...', { albumId, userId, price, extraAmount })
-      const response = await audiusSdk.albums.purchaseAlbum({ albumId, userId, price, extraAmount })
+      console.log('Purchasing album...', {
+        albumId,
+        userId,
+        price,
+        extraAmount
+      })
+      const response = await audiusSdk.albums.purchaseAlbum({
+        albumId,
+        userId,
+        price,
+        extraAmount
+      })
       console.log(chalk.green('Successfully purchased album'))
       console.log(chalk.yellow('Transaction Signature:'), response)
     } catch (err) {


### PR DESCRIPTION
### Description
`purchase-content` breaks due to purchasing via libs and not sdk.
Favor `purchase-track` and `purchase-album` instead.

### How Has This Been Tested?
`purchase-track` succeeds on local stack

