### PR TITLE
[PAY-3331] Purchase/sale endpoint filtering by content id

### DIFF
--- a/.changeset/thin-crabs-brake.md
+++ b/.changeset/thin-crabs-brake.md
@@ -1,0 +1,5 @@
+---
+'@audius/sdk': patch
+---
+
+Allow purchase/sale filtering by track or album ID

--- a/packages/discovery-provider/integration_tests/queries/test_get_usdc_purchases.py
+++ b/packages/discovery-provider/integration_tests/queries/test_get_usdc_purchases.py
@@ -173,7 +173,7 @@ def test_get_purchases(app):
 
         specific_sale = get_usdc_purchases(
             {
-                "content_ids": 3,
+                "content_ids": [3],
                 "content_type": PurchaseType.track,
                 "sort_method": PurchaseSortMethod.date,
             }

--- a/packages/discovery-provider/src/api/v1/users.py
+++ b/packages/discovery-provider/src/api/v1/users.py
@@ -1,6 +1,6 @@
 import base64
 import json
-from typing import Optional
+from typing import List, Optional
 
 from eth_account.messages import encode_defunct
 from flask import Response, request
@@ -2188,6 +2188,13 @@ purchases_and_sales_parser.add_argument(
     type=str,
     choices=SortDirection._member_names_,
 )
+purchases_and_sales_parser.add_argument(
+    "content_ids",
+    required=False,
+    description="Content IDs to filter by",
+    type=int,
+    action="append",
+)
 
 
 purchases_response = make_full_response(
@@ -2218,18 +2225,27 @@ class FullPurchases(Resource):
         offset = get_default_max(args.get("offset"), 0)
         sort_method = args.get("sort_method", PurchaseSortMethod.date)
         sort_direction = args.get("sort_direction", None)
+        content_ids = args.get("content_ids", None)
         args = GetUSDCPurchasesArgs(
             buyer_user_id=decoded_id,
             limit=limit,
             offset=offset,
             sort_method=sort_method,
             sort_direction=sort_direction,
+            content_ids=content_ids,
         )
         purchases = get_usdc_purchases(args)
         return success_response(list(map(extend_purchase, purchases)))
 
 
 purchases_and_sales_count_parser = current_user_parser.copy()
+purchases_and_sales_count_parser.add_argument(
+    "content_ids",
+    required=False,
+    description="Content IDs to filter by",
+    type=int,
+    action="append",
+)
 
 
 @full_ns.route("/<string:id>/purchases/count")
@@ -2246,8 +2262,10 @@ class FullPurchasesCount(Resource):
         decoded_id = decode_with_abort(id, full_ns)
         check_authorized(decoded_id, authed_user_id)
         args = purchases_and_sales_count_parser.parse_args()
+        content_ids = args.get("content_ids", None)
         args = GetUSDCPurchasesCountArgs(
             buyer_user_id=decoded_id,
+            content_ids=content_ids,
         )
         count = get_usdc_purchases_count(args)
         return success_response(count)
@@ -2271,12 +2289,14 @@ class FullSales(Resource):
         offset = get_default_max(args.get("offset"), 0)
         sort_method = args.get("sort_method", PurchaseSortMethod.date)
         sort_direction = args.get("sort_direction", None)
+        content_ids = args.get("content_ids", None)
         args = GetUSDCPurchasesArgs(
             seller_user_id=decoded_id,
             limit=limit,
             offset=offset,
             sort_method=sort_method,
             sort_direction=sort_direction,
+            content_ids=content_ids,
         )
         purchases = get_usdc_purchases(args)
         return success_response(list(map(extend_purchase, purchases)))
@@ -2296,8 +2316,10 @@ class FullSalesCount(Resource):
         decoded_id = decode_with_abort(id, full_ns)
         check_authorized(decoded_id, authed_user_id)
         args = purchases_and_sales_count_parser.parse_args()
+        content_ids = args.get("content_ids", None)
         args = GetUSDCPurchasesCountArgs(
             seller_user_id=decoded_id,
+            content_ids=content_ids,
         )
         count = get_usdc_purchases_count(args)
         return success_response(count)

--- a/packages/discovery-provider/src/api/v1/users.py
+++ b/packages/discovery-provider/src/api/v1/users.py
@@ -1,6 +1,6 @@
 import base64
 import json
-from typing import List, Optional
+from typing import Optional
 
 from eth_account.messages import encode_defunct
 from flask import Response, request

--- a/packages/discovery-provider/src/api/v1/users.py
+++ b/packages/discovery-provider/src/api/v1/users.py
@@ -2191,8 +2191,8 @@ purchases_and_sales_parser.add_argument(
 purchases_and_sales_parser.add_argument(
     "content_ids",
     required=False,
-    description="Content IDs to filter by",
-    type=int,
+    description="Filters purchases by track or album IDs",
+    type=str,
     action="append",
 )
 
@@ -2225,14 +2225,15 @@ class FullPurchases(Resource):
         offset = get_default_max(args.get("offset"), 0)
         sort_method = args.get("sort_method", PurchaseSortMethod.date)
         sort_direction = args.get("sort_direction", None)
-        content_ids = args.get("content_ids", None)
+        content_ids = args.get("content_ids", [])
+        decoded_content_ids = decode_ids_array(content_ids) if content_ids else []
         args = GetUSDCPurchasesArgs(
             buyer_user_id=decoded_id,
             limit=limit,
             offset=offset,
             sort_method=sort_method,
             sort_direction=sort_direction,
-            content_ids=content_ids,
+            content_ids=decoded_content_ids,
         )
         purchases = get_usdc_purchases(args)
         return success_response(list(map(extend_purchase, purchases)))
@@ -2242,8 +2243,8 @@ purchases_and_sales_count_parser = current_user_parser.copy()
 purchases_and_sales_count_parser.add_argument(
     "content_ids",
     required=False,
-    description="Content IDs to filter by",
-    type=int,
+    description="Filters purchases by track or album IDs",
+    type=str,
     action="append",
 )
 
@@ -2262,10 +2263,11 @@ class FullPurchasesCount(Resource):
         decoded_id = decode_with_abort(id, full_ns)
         check_authorized(decoded_id, authed_user_id)
         args = purchases_and_sales_count_parser.parse_args()
-        content_ids = args.get("content_ids", None)
+        content_ids = args.get("content_ids", [])
+        decoded_content_ids = decode_ids_array(content_ids) if content_ids else []
         args = GetUSDCPurchasesCountArgs(
             buyer_user_id=decoded_id,
-            content_ids=content_ids,
+            content_ids=decoded_content_ids,
         )
         count = get_usdc_purchases_count(args)
         return success_response(count)
@@ -2289,14 +2291,15 @@ class FullSales(Resource):
         offset = get_default_max(args.get("offset"), 0)
         sort_method = args.get("sort_method", PurchaseSortMethod.date)
         sort_direction = args.get("sort_direction", None)
-        content_ids = args.get("content_ids", None)
+        content_ids = args.get("content_ids", [])
+        decoded_content_ids = decode_ids_array(content_ids) if content_ids else []
         args = GetUSDCPurchasesArgs(
             seller_user_id=decoded_id,
             limit=limit,
             offset=offset,
             sort_method=sort_method,
             sort_direction=sort_direction,
-            content_ids=content_ids,
+            content_ids=decoded_content_ids,
         )
         purchases = get_usdc_purchases(args)
         return success_response(list(map(extend_purchase, purchases)))
@@ -2316,10 +2319,11 @@ class FullSalesCount(Resource):
         decoded_id = decode_with_abort(id, full_ns)
         check_authorized(decoded_id, authed_user_id)
         args = purchases_and_sales_count_parser.parse_args()
-        content_ids = args.get("content_ids", None)
+        content_ids = args.get("content_ids", [])
+        decoded_content_ids = decode_ids_array(content_ids) if content_ids else []
         args = GetUSDCPurchasesCountArgs(
             seller_user_id=decoded_id,
-            content_ids=content_ids,
+            content_ids=decoded_content_ids,
         )
         count = get_usdc_purchases_count(args)
         return success_response(count)

--- a/packages/discovery-provider/src/queries/get_usdc_purchases.py
+++ b/packages/discovery-provider/src/queries/get_usdc_purchases.py
@@ -44,7 +44,7 @@ def _get_usdc_purchases(session, args: GetUSDCPurchasesCountArgs):
 
     # Basic filters
     if content_ids:
-        base_query = base_query.filter(USDCPurchase.content_id == content_ids)
+        base_query = base_query.filter(USDCPurchase.content_id.in_(content_ids))
     if buyer_user_id:
         base_query = base_query.filter(USDCPurchase.buyer_user_id == buyer_user_id)
     if seller_user_id:

--- a/packages/libs/src/sdk/api/generated/full/apis/UsersApi.ts
+++ b/packages/libs/src/sdk/api/generated/full/apis/UsersApi.ts
@@ -179,6 +179,7 @@ export interface GetPurchasesRequest {
     userId?: string;
     sortMethod?: GetPurchasesSortMethodEnum;
     sortDirection?: GetPurchasesSortDirectionEnum;
+    contentIds?: Array<string>;
     encodedDataMessage?: string;
     encodedDataSignature?: string;
 }
@@ -186,6 +187,7 @@ export interface GetPurchasesRequest {
 export interface GetPurchasesCountRequest {
     id: string;
     userId?: string;
+    contentIds?: Array<string>;
     encodedDataMessage?: string;
     encodedDataSignature?: string;
 }
@@ -218,6 +220,7 @@ export interface GetSalesRequest {
     userId?: string;
     sortMethod?: GetSalesSortMethodEnum;
     sortDirection?: GetSalesSortDirectionEnum;
+    contentIds?: Array<string>;
     encodedDataMessage?: string;
     encodedDataSignature?: string;
 }
@@ -225,6 +228,7 @@ export interface GetSalesRequest {
 export interface GetSalesCountRequest {
     id: string;
     userId?: string;
+    contentIds?: Array<string>;
     encodedDataMessage?: string;
     encodedDataSignature?: string;
 }
@@ -925,6 +929,10 @@ export class UsersApi extends runtime.BaseAPI {
             queryParameters['sort_direction'] = params.sortDirection;
         }
 
+        if (params.contentIds) {
+            queryParameters['content_ids'] = params.contentIds;
+        }
+
         const headerParameters: runtime.HTTPHeaders = {};
 
         if (params.encodedDataMessage !== undefined && params.encodedDataMessage !== null) {
@@ -966,6 +974,10 @@ export class UsersApi extends runtime.BaseAPI {
 
         if (params.userId !== undefined) {
             queryParameters['user_id'] = params.userId;
+        }
+
+        if (params.contentIds) {
+            queryParameters['content_ids'] = params.contentIds;
         }
 
         const headerParameters: runtime.HTTPHeaders = {};
@@ -1156,6 +1168,10 @@ export class UsersApi extends runtime.BaseAPI {
             queryParameters['sort_direction'] = params.sortDirection;
         }
 
+        if (params.contentIds) {
+            queryParameters['content_ids'] = params.contentIds;
+        }
+
         const headerParameters: runtime.HTTPHeaders = {};
 
         if (params.encodedDataMessage !== undefined && params.encodedDataMessage !== null) {
@@ -1197,6 +1213,10 @@ export class UsersApi extends runtime.BaseAPI {
 
         if (params.userId !== undefined) {
             queryParameters['user_id'] = params.userId;
+        }
+
+        if (params.contentIds) {
+            queryParameters['content_ids'] = params.contentIds;
         }
 
         const headerParameters: runtime.HTTPHeaders = {};


### PR DESCRIPTION
### Description
We will need to filter sales/purchases by a specific content ID to support the targeted DM creation flow.
* Added a query param for content ID to filter by
* Fixed a bug in the db query

### How Has This Been Tested?

Tested all four endpoints on local stack
`/sales`
`/sales/count`
`/purchases`
`/purchases/count`