### PR TITLE
[QA-875] Use size for es query to fix feed pagination bug

### DIFF
--- a/packages/discovery-provider/integration_tests/tasks/test_get_feed_es.py
+++ b/packages/discovery-provider/integration_tests/tasks/test_get_feed_es.py
@@ -158,6 +158,12 @@ def test_get_feed_es(app):
         assert feed_results[1]["playlist_id"] == 3
         assert feed_results[2]["track_id"] == 5
 
+        # Test limit works
+        feed_results = get_feed_es({"user_id": "1"}, offset=1, limit=1)
+        assert len(feed_results) == 1
+        assert feed_results[0]["track_id"] == 1
+        assert feed_results[0]["save_count"] == 1
+
         # playlist <> track dedupe:
         # user2 follows user3
         # user3 should have one playlist and one track

--- a/packages/discovery-provider/src/queries/get_feed_es.py
+++ b/packages/discovery-provider/src/queries/get_feed_es.py
@@ -24,6 +24,8 @@ def get_feed_es(args, limit=10, offset=0):
     feed_filter = args.get("filter", "all")
     load_reposts = feed_filter in ["repost", "all"]
     load_orig = feed_filter in ["original", "all"]
+    # We use size to fetch es results to make sure we get enough results
+    size = offset + limit
 
     explicit_ids = args.get("followee_user_ids", [])
 
@@ -77,7 +79,7 @@ def get_feed_es(args, limit=10, offset=0):
                             "must_not": [{"exists": {"field": "stem_of"}}],
                         }
                     },
-                    "size": offset + limit,
+                    "size": offset + size,
                     "sort": {"created_at": "desc"},
                 },
                 {"index": ES_PLAYLISTS},
@@ -94,7 +96,7 @@ def get_feed_es(args, limit=10, offset=0):
                             ]
                         }
                     },
-                    "size": offset + limit,
+                    "size": offset + size,
                     "sort": {"created_at": "desc"},
                 },
             ]
@@ -168,7 +170,7 @@ def get_feed_es(args, limit=10, offset=0):
 
     # take a "soft limit" here.  Some tracks / reposts might get filtered out below
     # if is_delete, or if track is collectible gated
-    sorted_with_reposts = sorted_with_reposts[0 : (offset + limit) * 2]
+    sorted_with_reposts = sorted_with_reposts[0 : size * 2]
 
     mget_reposts = []
     keyed_reposts = {}
@@ -310,7 +312,7 @@ def get_feed_es(args, limit=10, offset=0):
         for item in sorted_feed
     ]
 
-    return sorted_feed[offset:limit]
+    return sorted_feed[offset:size]
 
 
 def following_ids_terms_lookup(current_user_id, field, explicit_ids=None):


### PR DESCRIPTION
### Description

When you query feed right now, you have to specify limit as `offset + limit`. We don't handle that well on the client because limit is meant to start from `offset`, e.g.
```
offset = 0
limit = 9

offset = 9
limit = 9
...
etc
```

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._

Update test to confirm correct limit behavior