### PR TITLE
[C-4676] Fix es search returning deactivated content

### DIFF
--- a/packages/es-indexer/src/indexNames.ts
+++ b/packages/es-indexer/src/indexNames.ts
@@ -1,7 +1,7 @@
 export const indexNames = {
-  playlists: 'playlists21',
+  playlists: 'playlists22',
   reposts: 'reposts13',
   saves: 'saves13',
-  tracks: 'tracks22',
+  tracks: 'tracks23',
   users: 'users16',
 }

--- a/packages/es-indexer/src/indexers/PlaylistIndexer.ts
+++ b/packages/es-indexer/src/indexers/PlaylistIndexer.ts
@@ -122,7 +122,8 @@ export class PlaylistIndexer extends BaseIndexer<PlaylistDoc> {
           'follower_count', follower_count,
           'is_verified', users.is_verified,
           'created_at', users.created_at,
-          'updated_at', users.updated_at
+          'updated_at', users.updated_at,
+          'is_deactivated', users.is_deactivated
         ) as user,
 
         array(

--- a/packages/es-indexer/src/indexers/TrackIndexer.ts
+++ b/packages/es-indexer/src/indexers/TrackIndexer.ts
@@ -120,7 +120,8 @@ export class TrackIndexer extends BaseIndexer<TrackDoc> {
         'follower_count', follower_count,
         'is_verified', users.is_verified,
         'created_at', users.created_at,
-        'updated_at', users.updated_at
+        'updated_at', users.updated_at,
+        'is_deactivated', users.is_deactivated
       ) as user,
 
       array(

--- a/packages/es-indexer/src/listener.ts
+++ b/packages/es-indexer/src/listener.ts
@@ -95,8 +95,22 @@ export async function startListener() {
       // pending.userIds.add(follow.followee_user_id)
       pending.userIds.add(follow.follower_user_id)
     },
-    users: (user: UserRow) => {
+    users: async (user: UserRow) => {
       pending.userIds.add(user.user_id)
+      // re-index any playlists owned by this user
+      const playlists = await client.query(
+        `select playlist_id from playlists where playlist_owner_id = ${user.user_id}`
+      )
+      for (const r of playlists.rows) {
+        pending.playlistIds.add(r.playlist_id)
+      }
+      // re-index any tracks owned by this user
+      const tracks = await client.query(
+        `select track_id from tracks where owner_id = ${user.user_id}`
+      )
+      for (const r of tracks.rows) {
+        pending.trackIds.add(r.track_id)
+      }
     },
     tracks: async (track: TrackRow) => {
       pending.trackIds.add(track.track_id)


### PR DESCRIPTION
### Description

Previous PR wasn't fully working
* Get `is_deactivated` from sql query in indexer
* Reindex tracks and playlists when the user updates

### How Has This Been Tested?

Confirmed tracks and playlists from deactivated users don't appear in search results
