### PR TITLE
[QA-1446] Fix popup alignment

### DIFF
--- a/packages/harmony/src/components/popup/Popup.tsx
+++ b/packages/harmony/src/components/popup/Popup.tsx
@@ -61,10 +61,9 @@ const getComputedOrigins = (
     containerHeight =
       containerRect.height + containerRect.y - CONTAINER_INSET_PADDING
   } else {
-    containerWidth =
-      portal.getBoundingClientRect().width - CONTAINER_INSET_PADDING
-    containerHeight =
-      portal.getBoundingClientRect().height - CONTAINER_INSET_PADDING
+    const portalRect = portal.getBoundingClientRect()
+    containerWidth = portalRect.width + portalRect.x - CONTAINER_INSET_PADDING
+    containerHeight = portalRect.height + portalRect.y - CONTAINER_INSET_PADDING
   }
 
   // Get new wrapper position

--- a/packages/harmony/src/components/popup/Popup.tsx
+++ b/packages/harmony/src/components/popup/Popup.tsx
@@ -55,12 +55,11 @@ const getComputedOrigins = (
 
   let containerWidth, containerHeight
   if (containerRef && containerRef.current) {
+    const containerRect = containerRef.current.getBoundingClientRect()
     containerWidth =
-      containerRef.current.getBoundingClientRect().width -
-      CONTAINER_INSET_PADDING
+      containerRect.width + containerRect.x - CONTAINER_INSET_PADDING
     containerHeight =
-      containerRef.current.getBoundingClientRect().height -
-      CONTAINER_INSET_PADDING
+      containerRect.height + containerRect.y - CONTAINER_INSET_PADDING
   } else {
     containerWidth =
       portal.getBoundingClientRect().width - CONTAINER_INSET_PADDING

--- a/packages/web/src/components/menu/Menu.tsx
+++ b/packages/web/src/components/menu/Menu.tsx
@@ -31,6 +31,7 @@ const Menu = forwardRef<HTMLDivElement, MenuProps>((props, ref) => {
       items={items}
       onClose={onClose}
       anchorOrigin={{ vertical: 'bottom', horizontal: 'right' }}
+      transformOrigin={{ vertical: 'top', horizontal: 'left' }}
       ref={ref}
       renderTrigger={children}
       zIndex={zIndex}


### PR DESCRIPTION
### Description

Popup alignment is off because we don't take into account the x/y offset of the container when checking if we would overflow 

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._

<img width="962" alt="image" src="https://github.com/user-attachments/assets/93612eb6-92f8-4721-a1be-5e5705bfefaa">