### PR TITLE
[QA-1357] Remove excessive polling and amplitude events in unlock

### DIFF
--- a/packages/common/src/store/gated-content/sagas.ts
+++ b/packages/common/src/store/gated-content/sagas.ts
@@ -328,7 +328,6 @@ function* updateGatedContentAccess(
     | ReturnType<typeof updateUserEthCollectibles>
     | ReturnType<typeof updateUserSolCollectibles>
     | ReturnType<typeof cacheActions.addSucceeded>
-    | ReturnType<typeof cacheActions.update>
 ) {
   const account = yield* select(getAccountUser)
 
@@ -702,7 +701,6 @@ function* watchGatedTracks() {
   yield* takeEvery(
     [
       cacheActions.ADD_SUCCEEDED,
-      cacheActions.UPDATE,
       updateUserEthCollectibles.type,
       updateUserSolCollectibles.type
     ],


### PR DESCRIPTION
### Description

Removes listening for cache updates in the gated content unlock flow. This fixes an issue where every time the polling function runs, it issues a cache update, which triggers another poller to run (firing about 100 amplitude events when unlocking a single track).

The original change was made here: https://github.com/AudiusProject/audius-client/pull/2642/files#diff-c0963e4a508d816d128ccb03764a0ccd0b61a04092b2c672f89ee778dfb15130L336
I don't understand the original intent - as in - I'm not sure when an update would need to trigger polling for content access, but @sddioulde you may know?

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._

Unlocked a follow-gated track on stage

Also completed a purchase and an nft unlock for sanity