### PR TITLE
[QA-1459] Fix broken slugs

### DIFF
--- a/packages/discovery-provider/ddl/migrations/0087_fix_slugs_with_slash.sql
+++ b/packages/discovery-provider/ddl/migrations/0087_fix_slugs_with_slash.sql
@@ -1,0 +1,8 @@
+begin;
+
+update playlist_routes
+set slug = replace(slug, '/', ''),
+    title_slug = replace(title_slug, '/', '')
+where slug like '%/%' or title_slug like '%/%';
+
+commit;


### PR DESCRIPTION
### Description

About 3k broken playlists on prod :/
This bug is no longer happening though because we parse out `/` in slugs

https://github.com/AudiusProject/audius-protocol/blob/6e17e518ba7e308d6c172936c375bbc2e73cc3c4/packages/discovery-provider/src/utils/helpers.py#L368

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._

Tested by running this on a staging node and confirming playlist are unbroken