### PR TITLE
[C-4936] FilterButton fixes

### DIFF
--- a/packages/harmony/src/components/button/FilterButton/FilterButton.tsx
+++ b/packages/harmony/src/components/button/FilterButton/FilterButton.tsx
@@ -193,8 +193,9 @@ export const FilterButton = forwardRef(function FilterButton<
     (value: Value) => {
       setValue(value)
       onChange?.(value)
+      setIsOpen(false)
     },
-    [onChange, setValue]
+    [onChange, setValue, setIsOpen]
   )
 
   const filteredOptions = useMemo(
@@ -226,7 +227,7 @@ export const FilterButton = forwardRef(function FilterButton<
             key={option.value}
             option={option}
             onChange={handleChange}
-            activeValue={value || activeValue}
+            activeValue={activeValue}
           />
         ))
       }
@@ -247,11 +248,9 @@ export const FilterButton = forwardRef(function FilterButton<
       {selectedLabel ? renderLabel(selectedLabel) : label}
       <Popup
         anchorRef={anchorRef}
-        ref={scrollRef}
         isVisible={isOpen}
         onClose={() => setIsOpen(false)}
         {...popupProps}
-        css={[{ overflowY: 'auto' }, popupProps?.css]}
       >
         <Paper mt='s' border='strong' shadow='far'>
           {children ? (
@@ -265,6 +264,8 @@ export const FilterButton = forwardRef(function FilterButton<
               role='listbox'
               aria-label={selectedLabel ?? label ?? props['aria-label']}
               aria-activedescendant={selectedLabel}
+              css={{ maxHeight: popupProps?.css?.maxHeight, overflowY: 'auto' }}
+              ref={scrollRef}
             >
               {showFilterInput && filterInputProps ? (
                 <TextInput
@@ -296,7 +297,9 @@ export const FilterButton = forwardRef(function FilterButton<
                   </Text>
                 </Flex>
               ) : (
-                <Flex direction='column'>{optionElements}</Flex>
+                <Flex direction='column' w='100%'>
+                  {optionElements}
+                </Flex>
               )}
             </Flex>
           )}

--- a/packages/harmony/src/components/button/FilterButton/FilterButtonOption.tsx
+++ b/packages/harmony/src/components/button/FilterButton/FilterButtonOption.tsx
@@ -1,4 +1,4 @@
-import { forwardRef, Ref, useCallback } from 'react'
+import { forwardRef, MouseEventHandler, Ref, useCallback } from 'react'
 
 import { CSSObject } from '@emotion/react'
 
@@ -58,9 +58,13 @@ export const FilterButtonOption = forwardRef(function <Value extends string>(
     }
   }
 
-  const handleChange = useCallback(() => {
-    onChange(option.value)
-  }, [option.value, onChange])
+  const handleChange = useCallback<MouseEventHandler>(
+    (e) => {
+      e.stopPropagation()
+      onChange(option.value)
+    },
+    [option.value, onChange]
+  )
 
   return (
     <BaseButton


### PR DESCRIPTION
### Description

Fix a few small issues with FilterButton:

* Make the top Paper the scroll container. Having the Popup be the scroll container causes the Paper to scroll inside the Popup, which isn't the behavior we want and results in this weird margin at the top:
![image](https://github.com/user-attachments/assets/80e48242-8274-4ad0-a853-0b39624f1be9)
![image](https://github.com/user-attachments/assets/21f965d7-2c6b-4b60-8ff9-cf07fac60482)
* Close the popup on option select
* Don't highlight the selected option in the menu. This is for parity with prod and keeps the active state backgrounds from bleeding into each other
![image](https://github.com/user-attachments/assets/8b8bf367-675f-4b7e-aebc-5cd4777a0f87)
* Make options full width

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._
