### PR TITLE
[C-4920] Only show bpm decimals if necessary

### DIFF
--- a/packages/common/src/hooks/useTrackMetadata.ts
+++ b/packages/common/src/hooks/useTrackMetadata.ts
@@ -74,7 +74,9 @@ export const useTrackMetadata = ({
     {
       id: TrackMetadataType.BPM,
       label: 'BPM',
-      value: bpm ? (bpm ?? 0).toFixed(isCustomBpm ? 2 : 0).toString() : '',
+      value: bpm
+        ? parseFloat((bpm ?? 0).toFixed(isCustomBpm ? 2 : 0)).toString()
+        : '',
       isHidden: !isSearchV2Enabled
     },
     {


### PR DESCRIPTION
### Description

With custom bpms, we were always showing decimals even for something like 140.00. This makes it so we only show decimals when necessary, like 140.25 or 140.5

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._
