### PR TITLE
[QA-1491] Fix balance polling bug

### DIFF
--- a/packages/common/src/hooks/useUSDCBalance.ts
+++ b/packages/common/src/hooks/useUSDCBalance.ts
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useState } from 'react'
 
+import { Commitment } from '@solana/web3.js'
 import BN from 'bn.js'
 import { useDispatch, useSelector } from 'react-redux'
 
@@ -23,10 +24,12 @@ import { useInterval } from './useInterval'
  */
 export const useUSDCBalance = ({
   isPolling,
-  pollingInterval = 1000
+  pollingInterval = 1000,
+  commitment = 'processed'
 }: {
   isPolling?: boolean
   pollingInterval?: number
+  commitment?: Commitment
 } = {}) => {
   const { audiusBackend } = useAppContext()
   const dispatch = useDispatch()
@@ -44,16 +47,20 @@ export const useUSDCBalance = ({
   const refresh = useCallback(async () => {
     setBalanceStatus(Status.LOADING)
     try {
-      const account = await getUserbankAccountInfo(audiusBackend, {
-        mint: 'usdc'
-      })
+      const account = await getUserbankAccountInfo(
+        audiusBackend,
+        {
+          mint: 'usdc'
+        },
+        commitment
+      )
       const balance = (account?.amount ?? new BN(0)) as BNUSDC
       setData(balance)
       setBalanceStatus(Status.SUCCESS)
     } catch (e) {
       setBalanceStatus(Status.ERROR)
     }
-  }, [audiusBackend, setData])
+  }, [audiusBackend, setData, commitment])
 
   // Refresh balance on mount
   useEffect(() => {

--- a/packages/common/src/services/audius-backend/solana.ts
+++ b/packages/common/src/services/audius-backend/solana.ts
@@ -9,6 +9,7 @@ import {
 } from '@solana/spl-token'
 import {
   AddressLookupTableAccount,
+  Commitment,
   ComputeBudgetProgram,
   Keypair,
   PublicKey,
@@ -101,16 +102,22 @@ export const getRecentBlockhash = async (
 export const getTokenAccountInfo = async (
   audiusBackendInstance: AudiusBackend,
   {
+    tokenAccount,
     mint = DEFAULT_MINT,
-    tokenAccount
+    commitment
   }: {
-    mint?: MintName
     tokenAccount: PublicKey
+    mint?: MintName
+    commitment?: Commitment
   }
 ): Promise<Account | null> => {
   return (
     await audiusBackendInstance.getAudiusLibs()
-  ).solanaWeb3Manager!.getTokenAccountInfo(tokenAccount.toString(), mint)
+  ).solanaWeb3Manager!.getTokenAccountInfo(
+    tokenAccount.toString(),
+    mint,
+    commitment
+  )
 }
 
 export const deriveUserBankPubkey = async (
@@ -174,7 +181,8 @@ function isCreateUserBankIfNeededError(
  */
 export const getUserbankAccountInfo = async (
   audiusBackendInstance: AudiusBackend,
-  { ethAddress: sourceEthAddress, mint = DEFAULT_MINT }: UserBankConfig = {}
+  { ethAddress: sourceEthAddress, mint = DEFAULT_MINT }: UserBankConfig = {},
+  commitment?: Commitment
 ): Promise<Account | null> => {
   const audiusLibs: AudiusLibs = await audiusBackendInstance.getAudiusLibs()
   const ethAddress =
@@ -193,7 +201,8 @@ export const getUserbankAccountInfo = async (
 
   return getTokenAccountInfo(audiusBackendInstance, {
     tokenAccount,
-    mint
+    mint,
+    commitment
   })
 }
 

--- a/packages/common/src/services/audius-backend/solana.ts
+++ b/packages/common/src/services/audius-backend/solana.ts
@@ -104,7 +104,7 @@ export const getTokenAccountInfo = async (
   {
     tokenAccount,
     mint = DEFAULT_MINT,
-    commitment
+    commitment = 'processed'
   }: {
     tokenAccount: PublicKey
     mint?: MintName

--- a/packages/libs/src/services/solana/SolanaWeb3Manager.ts
+++ b/packages/libs/src/services/solana/SolanaWeb3Manager.ts
@@ -409,11 +409,15 @@ export class SolanaWeb3Manager {
    * Gets the info for a user bank/wAudio token account given a spl-token address.
    * If the address is not a valid token account, returns `null`
    */
-  async getTokenAccountInfo(solanaAddress: string) {
+  async getTokenAccountInfo(
+    solanaAddress: string,
+    commitment?: solanaWeb3.Commitment
+  ) {
     try {
       const res = await getTokenAccountInfo({
         tokenAccountAddressKey: new PublicKey(solanaAddress),
-        connection: this.getConnection()
+        connection: this.getConnection(),
+        commitment
       })
       return res
     } catch (e) {

--- a/packages/libs/src/services/solana/tokenAccount.ts
+++ b/packages/libs/src/services/solana/tokenAccount.ts
@@ -3,7 +3,8 @@ import {
   PublicKey,
   SystemProgram,
   SYSVAR_RENT_PUBKEY,
-  Connection
+  Connection,
+  Commitment
 } from '@solana/web3.js'
 
 import type { Nullable } from '../../utils'
@@ -37,6 +38,7 @@ export async function findAssociatedTokenAddress({
 type GetTokenAccountInfoConfig = {
   tokenAccountAddressKey: PublicKey
   connection: Connection
+  commitment?: Commitment
 }
 
 /**
@@ -44,13 +46,14 @@ type GetTokenAccountInfoConfig = {
  */
 export async function getTokenAccountInfo({
   tokenAccountAddressKey,
-  connection
+  connection,
+  commitment = 'processed'
 }: GetTokenAccountInfoConfig) {
   // Fetch token info with 'processed commitment to get any recently changed amounts.
   // NOTE: Our version of spl-token omits the second argument
   // in the type definitions even though it's actually available,
   // so we suppress error until we can upgrade.
-  const info = await getAccount(connection, tokenAccountAddressKey, 'processed')
+  const info = await getAccount(connection, tokenAccountAddressKey, commitment)
   return info
 }
 

--- a/packages/mobile/src/components/premium-content-purchase-drawer/PremiumContentPurchaseDrawer.tsx
+++ b/packages/mobile/src/components/premium-content-purchase-drawer/PremiumContentPurchaseDrawer.tsx
@@ -282,7 +282,10 @@ const RenderForm = ({
     setPurchaseVendor(purchaseVendor)
   }, [purchaseVendor, setPurchaseVendor])
 
-  const { data: balance } = useUSDCBalance({ isPolling: true })
+  const { data: balance } = useUSDCBalance({
+    isPolling: true,
+    commitment: 'confirmed'
+  })
   const { extraAmount } = usePurchaseSummaryValues({
     price,
     currentBalance: balance

--- a/packages/mobile/src/components/usdc-balance-row/USDCBalanceRow.tsx
+++ b/packages/mobile/src/components/usdc-balance-row/USDCBalanceRow.tsx
@@ -41,7 +41,8 @@ export const USDCBalanceRow = ({
   const styles = useStyles()
   const { data: usdcBalance } = useUSDCBalance({
     isPolling: true,
-    pollingInterval
+    pollingInterval,
+    commitment: 'confirmed'
   })
   const isUsdcBalanceLoading = usdcBalance === null
   const balanceCents = formatUSDCWeiToFloorCentsNumber(

--- a/packages/web/src/components/add-funds/AddFunds.tsx
+++ b/packages/web/src/components/add-funds/AddFunds.tsx
@@ -44,7 +44,10 @@ export const AddFunds = ({
   >(undefined)
 
   const isMobile = useIsMobile()
-  const { data: balanceBN } = useUSDCBalance({ isPolling: true })
+  const { data: balanceBN } = useUSDCBalance({
+    isPolling: true,
+    commitment: 'confirmed'
+  })
   const balance = USDC(balanceBN ?? new BN(0)).value
 
   const buyUSDCStage = useSelector(getBuyUSDCFlowStage)

--- a/packages/web/src/components/address-tile/AddressTile.tsx
+++ b/packages/web/src/components/address-tile/AddressTile.tsx
@@ -37,8 +37,10 @@ export const AddressTile = ({
   const { color } = useTheme()
   const { toast } = useContext(ToastContext)
   const isMobile = useIsMobile()
-  const { data: balanceBN } = useUSDCBalance({ isPolling: true })
-
+  const { data: balanceBN } = useUSDCBalance({
+    isPolling: true,
+    commitment: 'confirmed'
+  })
   const handleCopyPress = useCallback(() => {
     copyToClipboard(address)
     toast(messages.copied)

--- a/packages/web/src/components/premium-content-purchase-modal/components/PurchaseContentFormFields.tsx
+++ b/packages/web/src/components/premium-content-purchase-modal/components/PurchaseContentFormFields.tsx
@@ -56,7 +56,10 @@ export const PurchaseContentFormFields = ({
     useField(PURCHASE_VENDOR)
   const isPurchased = stage === PurchaseContentStage.FINISH
 
-  const { data: balanceBN } = useUSDCBalance({ isPolling: true })
+  const { data: balanceBN } = useUSDCBalance({
+    isPolling: true,
+    commitment: 'confirmed'
+  })
   const { extraAmount } = usePurchaseSummaryValues({
     price,
     currentBalance: balanceBN


### PR DESCRIPTION
### Description

Consider the following scenario:
1. I go to check out with 0 $USDC balance
2. I click "Transfer via crypto"
3. I send 1 $USDC from my external wallet to my token account using `processed` commitment level (I can't control this, phantom, etc. would)
4. The client polls for balance using `processed` commitment on the FE RPC endpoint and sees that we have 1 $USDC now
5.  I click buy and my tx fails because the RPC that relays the tx doesn't know the balance yet

To fix, introduce a commitment level from the audius-fe perspective. This should dramatically dramatically reduce the probability of this happening. Yes this does come at the cost of your balance not showing up as fast, but that's also probably the right call versus failed tx.

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._

Purchased some stuff on stage