### PR TITLE
Payment router exception for when no geo_data found in memo

### DIFF
--- a/packages/discovery-provider/src/tasks/index_payment_router.py
+++ b/packages/discovery-provider/src/tasks/index_payment_router.py
@@ -257,6 +257,8 @@ def parse_route_transaction_memos(
                 continue
             if memo.startswith(GEO_MEMO_STRING):
                 geo_data = json.loads(memo.replace(GEO_MEMO_STRING, ""))
+                if not geo_data:
+                    raise Exception("No geo data found in geo memo")
                 city = geo_data.get("city")
                 region = geo_data.get("region")
                 country = geo_data.get("country")


### PR DESCRIPTION
### Description
This was breaking purchases on local dev.

Error:
```
{"level": "ERROR", "msg": "Task index_payment_router[b6fcc1b2-8273-4ae9-906d-5406486bff1c] raised unexpected: AttributeError(\"'NoneType' object has no attribute 'get'\")\nTraceback (most recent call last):\n  File \"/usr/lib/python3.11/site-packages/celery/app/trace.py\", line 477, in trace_task\n    R = retval = fun(*args, **kwargs)\n                 ^^^^^^^^^^^^^^^^^^^^\n  File \"/usr/lib/python3.11/site-packages/celery/app/trace.py\", line 760, in __protected_call__\n    return self.run(*args, **kwargs)\n           ^^^^^^^^^^^^^^^^^^^^^^^^^\n  File \"/app/packages/discovery-provider/src/utils/prometheus_metric.py\", line 57, in wrapper\n    raise e\n  File \"/app/packages/discovery-provider/src/utils/prometheus_metric.py\", line 30, in wrapper\n    result = func(*args, **kwargs)\n             ^^^^^^^^^^^^^^^^^^^^^\n  File \"/app/packages/discovery-provider/src/tasks/index_payment_router.py\", line 1076, in index_payment_router\n    raise e\n  File \"/app/packages/discovery-provider/src/tasks/index_payment_router.py\", line 1068, in index_payment_router\n    process_payment_router_txs()\n  File \"/app/packages/discovery-provider/src/tasks/index_payment_router.py\", line 1009, in process_payment_router_txs\n    process_payment_router_tx_details(\n  File \"/app/packages/discovery-provider/src/tasks/index_payment_router.py\", line 824, in process_payment_router_tx_details\n    process_route_instruction(\n  File \"/app/packages/discovery-provider/src/tasks/index_payment_router.py\", line 758, in process_route_instruction\n    memo, geo_metadata = parse_route_transaction_memos(\n                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n  File \"/app/packages/discovery-provider/src/tasks/index_payment_router.py\", line 262, in parse_route_transaction_memos\n    city = geo_data.get(\"city\")\n           ^^^^^^^^^^^^\nAttributeError: 'NoneType' object has no attribute 'get'", "timestamp": "2024-08-08 19:03:16,582", "service": "worker", "otelSpanID": "0", "otelTraceID": "0", "otelServiceName": "discovery-provider", "data": {"hostname": "celery@5107fbc8bdc9", "id": "b6fcc1b2-8273-4ae9-906d-5406486bff1c", "name": "index_payment_router", "exc": "AttributeError(\"'NoneType' object has no attribute 'get'\")", "traceback": "Traceback (most recent call last):\n  File \"/usr/lib/python3.11/site-packages/celery/app/trace.py\", line 477, in trace_task\n    R = retval = fun(*args, **kwargs)\n                 ^^^^^^^^^^^^^^^^^^^^\n  File \"/usr/lib/python3.11/site-packages/celery/app/trace.py\", line 760, in __protected_call__\n    return self.run(*args, **kwargs)\n           ^^^^^^^^^^^^^^^^^^^^^^^^^\n  File \"/app/packages/discovery-provider/src/utils/prometheus_metric.py\", line 57, in wrapper\n    raise e\n  File \"/app/packages/discovery-provider/src/utils/prometheus_metric.py\", line 30, in wrapper\n    result = func(*args, **kwargs)\n             ^^^^^^^^^^^^^^^^^^^^^\n  File \"/app/packages/discovery-provider/src/tasks/index_payment_router.py\", line 1076, in index_payment_router\n    raise e\n  File \"/app/packages/discovery-provider/src/tasks/index_payment_router.py\", line 1068, in index_payment_router\n    process_payment_router_txs()\n  File \"/app/packages/discovery-provider/src/tasks/index_payment_router.py\", line 1009, in process_payment_router_txs\n    process_payment_router_tx_details(\n  File \"/app/packages/discovery-provider/src/tasks/index_payment_router.py\", line 824, in process_payment_router_tx_details\n    process_route_instruction(\n  File \"/app/packages/discovery-provider/src/tasks/index_payment_router.py\", line 758, in process_route_instruction\n    memo, geo_metadata = parse_route_transaction_memos(\n                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n  File \"/app/packages/discovery-provider/src/tasks/index_payment_router.py\", line 262, in parse_route_transaction_memos\n    city = geo_data.get(\"city\")\n           ^^^^^^^^^^^^\nAttributeError: 'NoneType' object has no attribute 'get'\n", "args": "[]", "kwargs": "{}", "description": "raised unexpected", "internal": false}}
```

### How Has This Been Tested?

audius-cmd purchase-track works now
