### PR TITLE
Small repairer clean up

### DIFF
--- a/packages/discovery-provider/src/tasks/repair_audio_analyses.py
+++ b/packages/discovery-provider/src/tasks/repair_audio_analyses.py
@@ -41,7 +41,7 @@ def query_tracks(session: Session) -> List[Track]:
             Track.genre != "Podcast",
             Track.genre != "Audiobooks",
         )
-        .order_by(Track.track_id.desc())
+        .order_by(Track.created_at.desc())
         .limit(BATCH_SIZE)
         .all()
     )
@@ -74,10 +74,6 @@ def repair(session: Session, redis: Redis):
                     else f"{node}/uploads/{track.audio_upload_id}"
                 )
                 resp = requests.get(endpoint, timeout=5)
-                if resp.status_code == 404 and not legacy_track:
-                    # Use legacy path for upload ids that are not found
-                    # (I think there are some edge cases from early storage v2 migration days)
-                    legacy_track = True
                 resp.raise_for_status()
                 data = resp.json()
             except Exception:


### PR DESCRIPTION
### Description
- track_id is randomized. better to order by created_at
- remove 404 clause; is not be relevant after backfill
- tx is running and idle for 10mins bc of the network reqs. fix by only opening a db session for the query, then each write

### How Has This Been Tested?

will test on stage