### PR TITLE
[QA-1496] fix unsafe read of audio analysis field

### DIFF
--- a/packages/libs/src/sdk/services/Storage/types.ts
+++ b/packages/libs/src/sdk/services/Storage/types.ts
@@ -62,7 +62,7 @@ export type UploadResponse = {
   orig_file_cid: string
   orig_filename: string
   audio_analysis_error_count: number
-  audio_analysis_results: {
+  audio_analysis_results?: {
     [key: string]: string
   }
   probe: {

--- a/packages/libs/src/services/creatorNode/CreatorNode.ts
+++ b/packages/libs/src/services/creatorNode/CreatorNode.ts
@@ -245,7 +245,7 @@ export class CreatorNode {
       const previewKey = `320_preview|${updatedMetadata.preview_start_seconds}`
       updatedMetadata.preview_cid = audioResp.results[previewKey]
     }
-    if (audioResp.audio_analysis_results !== null) {
+    if (audioResp.audio_analysis_results != null) {
       if ('bpm' in audioResp.audio_analysis_results) {
         updatedMetadata.bpm = audioResp.audio_analysis_results.bpm
       }


### PR DESCRIPTION
### Description
If mediorum fails to analyze a file, it returns `undefined` for this field. So a strict-equals on `null` will allow the following statements that attempt to use the `in` operator. This updates the type in the Storage API and fixes the type check.


