### PR TITLE
Fix useClickOutside

### DIFF
--- a/packages/harmony/src/components/modal/Modal.tsx
+++ b/packages/harmony/src/components/modal/Modal.tsx
@@ -237,6 +237,7 @@ export const Modal = forwardRef<HTMLDivElement, ModalProps>(function Modal(
   const modalContentClickedRef = useRef<boolean>(false)
   const outsideClickRef = useClickOutside(
     onClose,
+    isOpen,
     // Check to see if the click outside is not another modal wrapper.
     // If it is, that means we have a nested modal situation and shouldn't
     // dismiss "this" modal. We let the useClickOutside in "that" modal to
@@ -262,8 +263,7 @@ export const Modal = forwardRef<HTMLDivElement, ModalProps>(function Modal(
         return isModalWrapper && !isThisModalWrapper
       }
       return false
-    },
-    isOpen
+    }
   )
 
   const handleEscape = useCallback(() => {

--- a/packages/harmony/src/components/popup/Popup.tsx
+++ b/packages/harmony/src/components/popup/Popup.tsx
@@ -267,8 +267,8 @@ export const PopupInternal = forwardRef<
 
   const popupRef: React.MutableRefObject<HTMLDivElement> = useClickOutside(
     handleClose,
-    checkIfClickInside,
     isVisible,
+    checkIfClickInside,
     typeof ref === 'function' ? undefined : ref
   )
 

--- a/packages/harmony/src/hooks/useClickOutside.ts
+++ b/packages/harmony/src/hooks/useClickOutside.ts
@@ -14,8 +14,8 @@ import { MutableRefObject, useEffect, useRef } from 'react'
  */
 export const useClickOutside = (
   onClick: () => void,
-  ignoreClick: (target: EventTarget) => boolean = () => false,
   isVisible: boolean,
+  ignoreClick?: (target: EventTarget) => boolean,
   defaultRef?: MutableRefObject<any> | null
 ) => {
   const ref = useRef(defaultRef?.current ?? null)


### PR DESCRIPTION
### Description

This block was misbehaving because ignoreClick had a default value of `() => false` which caused the ternary to always follow the truthy branch even when ignoreClick wasn't provided by the caller.

```
if (
  ignoreClick
    ? ignoreClick(e.target)
    : !ref.current || (ref.current && ref.current.contains(e.target))
) {
  return
}
```

### How Has This Been Tested?

Clicking outside closes the modal while clicking inside does not. Noted that clicking inside then dragging outside does not close the modal on mouseup, but clicking outside then dragging in will still close it on mouseup inside the modal. @sliptype for context. Was this a tradeoff of the change, or has my fix regressed it?
