### PR TITLE
[PAY-3106][PAY-2914] Use SDK to withdraw USDC

### DIFF
--- a/.changeset/silver-buttons-turn.md
+++ b/.changeset/silver-buttons-turn.md
@@ -1,0 +1,5 @@
+---
+'@audius/sdk': patch
+---
+
+Updates the Solana clients that take a mint to allow for PublicKey arguments in addition to token names, and renames the type from Mint to TokenName.

--- a/packages/common/src/services/audius-backend/solana.ts
+++ b/packages/common/src/services/audius-backend/solana.ts
@@ -823,11 +823,8 @@ export const transferFromUserBank = async ({
     } catch (e) {
       // Throws if token account doesn't exist or account isn't a token account
       isCreatingTokenAccount = true
-      console.debug(e)
       console.debug(
-        'Associated token account',
-        destination.toBase58(),
-        'does not exist. Creating w/ transfer...'
+        `Associated token account ${destination.toBase58()} does not exist. Creating w/ transfer...`
       )
 
       // Historically, the token account was created in a separate transaction

--- a/packages/common/src/services/audius-backend/solana.ts
+++ b/packages/common/src/services/audius-backend/solana.ts
@@ -1,15 +1,19 @@
-import { AudiusLibs } from '@audius/sdk'
+import { AudiusLibs, AudiusSdk } from '@audius/sdk'
 import { u8 } from '@solana/buffer-layout'
 import {
   Account,
   TOKEN_PROGRAM_ID,
   TokenInstruction,
+  createAssociatedTokenAccountIdempotentInstruction,
   createTransferCheckedInstruction,
-  decodeTransferCheckedInstruction
+  decodeTransferCheckedInstruction,
+  getAccount,
+  getAssociatedTokenAddressSync
 } from '@solana/spl-token'
 import {
   AddressLookupTableAccount,
   ComputeBudgetProgram,
+  Connection,
   Keypair,
   PublicKey,
   Transaction,
@@ -18,6 +22,8 @@ import {
   VersionedTransaction
 } from '@solana/web3.js'
 import BN from 'bn.js'
+
+import { CommonStoreContext } from '~/store/storeContext'
 
 import {
   AnalyticsEvent,
@@ -385,56 +391,6 @@ export const findAssociatedTokenAddress = async (
   ).solanaWeb3Manager!.findAssociatedTokenAddress(solanaAddress, mint)
 }
 
-export const createRootWalletRecoveryTransaction = async (
-  audiusBackendInstance: AudiusBackend,
-  {
-    userBank,
-    wallet,
-    amount,
-    feePayer
-  }: {
-    userBank: PublicKey
-    wallet: Keypair
-    amount: bigint
-    feePayer?: PublicKey
-    usePaymentRouter?: boolean
-  }
-) => {
-  const libs = await audiusBackendInstance.getAudiusLibsTyped()
-  const solanaWeb3Manager = libs.solanaWeb3Manager!
-
-  // See: https://github.com/solana-labs/solana-program-library/blob/d6297495ea4dcc1bd48f3efdd6e3bbdaef25a495/memo/js/src/index.ts#L27
-  const memoInstruction = new TransactionInstruction({
-    keys: [
-      {
-        pubkey: wallet.publicKey,
-        isSigner: true,
-        isWritable: true
-      }
-    ],
-    programId: MEMO_PROGRAM_ID,
-    data: Buffer.from(RECOVERY_MEMO_STRING)
-  })
-
-  const [transferInstruction, routeInstruction] =
-    // All the memo related parameters are ignored
-    await solanaWeb3Manager.getPurchaseContentWithPaymentRouterInstructions({
-      id: 0, // ignored
-      type: 'track', // ignored
-      blocknumber: 0, // ignored
-      splits: { [userBank.toString()]: new BN(amount.toString()) },
-      purchaserUserId: 0, // ignored
-      senderAccount: wallet.publicKey,
-      purchaseAccess: PurchaseAccess.STREAM // ignored
-    })
-
-  const recentBlockhash = await getRecentBlockhash(audiusBackendInstance)
-
-  const tx = new Transaction({ recentBlockhash, feePayer })
-  tx.add(memoInstruction, transferInstruction, routeInstruction)
-  return tx
-}
-
 /** Converts a Coinflow transaction which transfers directly from root wallet USDC
  * account into a transaction that routes through the current user's USDC user bank, to
  * better facilitate indexing. The original transaction *must* use a TransferChecked instruction
@@ -755,5 +711,212 @@ export const createVersionedTransaction = async (
   return {
     transaction: new VersionedTransaction(message),
     addressLookupTableAccounts
+  }
+}
+
+// NOTE: The above all need to be updated to use SDK. The below is fresh.
+
+/**
+ * In the case of a failed Coinflow withdrawal, transfers the USDC back out of
+ * the root Solana account and into the user's user bank account.
+ *
+ * Note that this uses payment router to do the transfer, so that indexing sees
+ * this transfer and handles it appropriately.
+ */
+export const recoverUsdcFromRootWallet = async ({
+  sdk,
+  sender,
+  receiverEthWallet,
+  amount
+}: {
+  sdk: AudiusSdk
+  sender: Keypair
+  receiverEthWallet: string
+  amount: bigint
+}) => {
+  const { userBank } =
+    await sdk.services.claimableTokensClient.getOrCreateUserBank({
+      ethWallet: receiverEthWallet,
+      mint: 'USDC'
+    })
+
+  // See: https://github.com/solana-labs/solana-program-library/blob/d6297495ea4dcc1bd48f3efdd6e3bbdaef25a495/memo/js/src/index.ts#L27
+  const memoInstruction = new TransactionInstruction({
+    keys: [
+      {
+        pubkey: sender.publicKey,
+        isSigner: true,
+        isWritable: true
+      }
+    ],
+    programId: MEMO_PROGRAM_ID,
+    data: Buffer.from(RECOVERY_MEMO_STRING)
+  })
+  const transferInstruction =
+    await sdk.services.paymentRouterClient.createTransferInstruction({
+      total: amount,
+      sourceWallet: sender.publicKey,
+      mint: 'USDC'
+    })
+  const routeInstruction =
+    await sdk.services.paymentRouterClient.createRouteInstruction({
+      total: amount,
+      splits: [
+        {
+          amount,
+          wallet: userBank
+        }
+      ],
+      mint: 'USDC'
+    })
+  const transaction = await sdk.services.claimableTokensClient.buildTransaction(
+    { instructions: [memoInstruction, transferInstruction, routeInstruction] }
+  )
+  transaction.sign([sender])
+  const signature = await sdk.services.paymentRouterClient.sendTransaction(
+    transaction,
+    { skipPreflight: true }
+  )
+  return signature
+}
+
+/**
+ * Transfers tokens out of a user bank.
+ * Notes:
+ * - Including a signer will mark this transfer as a "withdrawal preparation"
+ *   by signing a memo indicating such. This prevents the transfer from showing
+ *   as a withdrawal on the withdrawal history page.
+ * - Users have restrictions on creating token accounts via relay, so if the
+ *   destination token account doesn't exist this might fail.
+ */
+export const transferFromUserBank = async ({
+  sdk,
+  mint,
+  connection,
+  amount,
+  ethWallet,
+  destinationWallet,
+  track,
+  make,
+  analyticsFields,
+  signer
+}: {
+  sdk: AudiusSdk
+  mint: PublicKey
+  connection: Connection
+  amount: number
+  ethWallet: string
+  destinationWallet: PublicKey
+  track: CommonStoreContext['analytics']['track']
+  make: CommonStoreContext['analytics']['make']
+  analyticsFields: any
+  signer?: Keypair
+}) => {
+  let isCreatingTokenAccount = false
+  try {
+    const instructions: TransactionInstruction[] = []
+
+    const destination = getAssociatedTokenAddressSync(mint, destinationWallet)
+
+    try {
+      await getAccount(connection, destination)
+    } catch (e) {
+      // Throws if token account doesn't exist or account isn't a token account
+      isCreatingTokenAccount = true
+      console.debug(e)
+      console.debug(
+        'Associated token account',
+        destination.toBase58(),
+        'does not exist. Creating w/ transfer...'
+      )
+
+      // Historically, the token account was created in a separate transaction
+      // after swapping USDC to SOL via Jupiter and funded via the root wallet.
+      // This is no longer the case. Reusing the same Amplitude events anyway.
+      await track(
+        make({
+          eventName: Name.WITHDRAW_USDC_CREATE_DEST_TOKEN_ACCOUNT_START,
+          ...analyticsFields
+        })
+      )
+      const payerKey = await sdk.services.solanaRelay.getFeePayer()
+      const createAtaInstruction =
+        createAssociatedTokenAccountIdempotentInstruction(
+          payerKey,
+          destination,
+          destinationWallet,
+          mint
+        )
+      instructions.push(createAtaInstruction)
+    }
+
+    const secpTransferInstruction =
+      await sdk.services.claimableTokensClient.createTransferSecpInstruction({
+        auth: sdk.services.auth,
+        amount,
+        ethWallet,
+        mint,
+        destination,
+        instructionIndex: instructions.length
+      })
+    instructions.push(secpTransferInstruction)
+
+    const transferInstruction =
+      await sdk.services.claimableTokensClient.createTransferInstruction({
+        ethWallet,
+        mint,
+        destination
+      })
+    instructions.push(transferInstruction)
+
+    if (signer) {
+      const memoInstruction = new TransactionInstruction({
+        keys: [
+          {
+            pubkey: signer.publicKey,
+            isSigner: true,
+            isWritable: true
+          }
+        ],
+        programId: MEMO_PROGRAM_ID,
+        data: Buffer.from(PREPARE_WITHDRAWAL_MEMO_STRING)
+      })
+      instructions.push(memoInstruction)
+    }
+
+    const transaction =
+      await sdk.services.claimableTokensClient.buildTransaction({
+        instructions
+      })
+
+    if (signer) {
+      transaction.sign([signer])
+    }
+
+    const signature = await sdk.services.claimableTokensClient.sendTransaction(
+      transaction
+    )
+
+    if (isCreatingTokenAccount) {
+      await track(
+        make({
+          eventName: Name.WITHDRAW_USDC_CREATE_DEST_TOKEN_ACCOUNT_SUCCESS,
+          ...analyticsFields
+        })
+      )
+    }
+
+    return signature
+  } catch (e) {
+    if (isCreatingTokenAccount) {
+      await track(
+        make({
+          eventName: Name.WITHDRAW_USDC_CREATE_DEST_TOKEN_ACCOUNT_FAILED,
+          ...analyticsFields,
+          error: e instanceof Error ? e.message : e
+        })
+      )
+    }
+    throw e
   }
 }

--- a/packages/discovery-provider/plugins/pedalboard/apps/solana-relay/package.json
+++ b/packages/discovery-provider/plugins/pedalboard/apps/solana-relay/package.json
@@ -13,6 +13,7 @@
   },
   "dependencies": {
     "@audius/spl": "*",
+    "@noble/curves": "1.4.2",
     "@pedalboard/basekit": "*",
     "@pedalboard/logger": "*",
     "@pedalboard/storage": "*",

--- a/packages/discovery-provider/plugins/pedalboard/apps/solana-relay/src/routes/relay/assertRelayAllowedInstructions.ts
+++ b/packages/discovery-provider/plugins/pedalboard/apps/solana-relay/src/routes/relay/assertRelayAllowedInstructions.ts
@@ -144,7 +144,10 @@ const assertAllowedAssociatedTokenAccountProgramInstruction = async (
             instr.keys.destination.pubkey
           )
       )
-    if (wallet) {
+    if (
+      wallet &&
+      matchingCreateInstructions.length !== matchingCloseInstructions.length
+    ) {
       try {
         await rateLimitTokenAccountCreation(wallet, !!isVerified)
       } catch (e) {

--- a/packages/discovery-provider/plugins/pedalboard/apps/solana-relay/src/routes/relay/relay.ts
+++ b/packages/discovery-provider/plugins/pedalboard/apps/solana-relay/src/routes/relay/relay.ts
@@ -14,6 +14,7 @@ import {
   broadcastTransaction,
   sendTransactionWithRetries
 } from '../../utils/transaction'
+import { verifySignatures } from '../../utils/verifySignatures'
 
 import { InvalidRelayInstructionError } from './InvalidRelayInstructionError'
 import { assertRelayAllowedInstructions } from './assertRelayAllowedInstructions'
@@ -49,24 +50,6 @@ const getLookupTableAccounts = async (lookupTableKeys: PublicKey[]) => {
       return res.value
     })
   )
-}
-
-/**
- * Checks that the transaction is signed
- *
- * TODO PAY-3106: Verify the signature is correct as well as non-empty.
- * @see {@link https://github.com/solana-labs/solana-web3.js/blob/9344bbfa5dd68f3e15918ff606284373ae18911f/packages/library-legacy/src/transaction/legacy.ts#L767 verifySignatures} for Transaction in @solana/web3.js
- * @param transaction the versioned transaction to check
- * @returns false if missing a signature, true if all signatures are present.
- */
-const verifySignatures = (transaction: VersionedTransaction) => {
-  for (const signature of transaction.signatures) {
-    if (signature === null || signature.every((b) => b === 0)) {
-      return false
-    }
-    // TODO PAY-3106: Use ed25519 to verify signature
-  }
-  return true
 }
 
 /**

--- a/packages/discovery-provider/plugins/pedalboard/apps/solana-relay/src/utils/verifySignatures.test.ts
+++ b/packages/discovery-provider/plugins/pedalboard/apps/solana-relay/src/utils/verifySignatures.test.ts
@@ -1,0 +1,71 @@
+import {
+  Keypair,
+  PublicKey,
+  SystemProgram,
+  TransactionMessage,
+  VersionedTransaction
+} from '@solana/web3.js'
+import { describe, it, expect } from 'vitest'
+
+import { verifySignatures } from './verifySignatures'
+
+describe('verifySignatures', () => {
+  it('fails when signature is missing', () => {
+    const toPubkey = PublicKey.unique()
+    const fromPubkey = PublicKey.unique()
+    const recentBlockhash = PublicKey.unique().toBase58()
+    const transfer = SystemProgram.transfer({
+      toPubkey,
+      fromPubkey,
+      lamports: 1
+    })
+    const message = new TransactionMessage({
+      recentBlockhash,
+      instructions: [transfer],
+      payerKey: fromPubkey
+    })
+    const transaction = new VersionedTransaction(message.compileToV0Message())
+    expect(verifySignatures(transaction)).toBe(false)
+  })
+
+  it('passes when signature is valid', () => {
+    const toPubkey = PublicKey.unique()
+    const payer = Keypair.generate()
+    const fromPubkey = payer.publicKey
+    const recentBlockhash = PublicKey.unique().toBase58()
+    const transfer = SystemProgram.transfer({
+      toPubkey,
+      fromPubkey,
+      lamports: 1
+    })
+    const message = new TransactionMessage({
+      recentBlockhash,
+      instructions: [transfer],
+      payerKey: fromPubkey
+    })
+    const transaction = new VersionedTransaction(message.compileToV0Message())
+    transaction.sign([payer])
+    expect(verifySignatures(transaction)).toBe(true)
+  })
+
+  it('fails when the signature is invalid', () => {
+    const toPubkey = PublicKey.unique()
+    const payer = Keypair.generate()
+    const fromPubkey = payer.publicKey
+    const recentBlockhash = PublicKey.unique().toBase58()
+    const transfer = SystemProgram.transfer({
+      toPubkey,
+      fromPubkey,
+      lamports: 1
+    })
+    const message = new TransactionMessage({
+      recentBlockhash,
+      instructions: [transfer],
+      payerKey: fromPubkey
+    })
+    const transaction = new VersionedTransaction(message.compileToV0Message())
+    transaction.sign([payer])
+    transaction.message.compiledInstructions[0].data[0] = -1
+    expect(verifySignatures(transaction)).toBe(false)
+  })
+})

--- a/packages/discovery-provider/plugins/pedalboard/apps/solana-relay/src/utils/verifySignatures.ts
+++ b/packages/discovery-provider/plugins/pedalboard/apps/solana-relay/src/utils/verifySignatures.ts
@@ -1,0 +1,30 @@
+import { ed25519 } from '@noble/curves/ed25519'
+import { VersionedTransaction } from '@solana/web3.js'
+
+/**
+ * Checks that the transaction is signed
+ *
+ * TODO PAY-3106: Verify the signature is correct as well as non-empty.
+ * @see {@link https://github.com/solana-labs/solana-web3.js/blob/9344bbfa5dd68f3e15918ff606284373ae18911f/packages/library-legacy/src/transaction/legacy.ts#L767 verifySignatures} for Transaction in @solana/web3.js
+ * @param transaction the versioned transaction to check
+ * @returns false if missing a signature, true if all signatures are present.
+ */
+export const verifySignatures = (transaction: VersionedTransaction) => {
+  for (let i = 0; i < transaction.message.header.numRequiredSignatures; i++) {
+    const signature = transaction.signatures[i]
+    const publicKey = transaction.message.staticAccountKeys[i].toBuffer()
+    if (
+      signature === undefined ||
+      signature === null ||
+      signature.every((b) => b === 0)
+    ) {
+      return false
+    }
+    const serialized = transaction.message.serialize()
+    const valid = ed25519.verify(signature, serialized, publicKey)
+    if (!valid) {
+      return false
+    }
+  }
+  return true
+}

--- a/packages/libs/package.json
+++ b/packages/libs/package.json
@@ -181,7 +181,7 @@
     "tslib": "^2.6.2",
     "type-fest": "2.17.0",
     "typed-emitter": "2.1.0",
-    "typescript": "5.0.4",
+    "typescript": "5.4.5",
     "wait-for-expect": "3.0.2"
   },
   "repository": {

--- a/packages/libs/src/sdk/services/Solana/programs/ClaimableTokensClient/ClaimableTokensClient.ts
+++ b/packages/libs/src/sdk/services/Solana/programs/ClaimableTokensClient/ClaimableTokensClient.ts
@@ -11,7 +11,7 @@ import { mergeConfigWithDefaults } from '../../../../utils/mergeConfigs'
 import { mintFixedDecimalMap } from '../../../../utils/mintFixedDecimalMap'
 import { parseMintToken } from '../../../../utils/parseMintToken'
 import { parseParams } from '../../../../utils/parseParams'
-import type { MintName } from '../../types'
+import type { TokenName } from '../../types'
 import { BaseSolanaProgramClient } from '../BaseSolanaProgramClient'
 
 import { getDefaultClaimableTokensConfig } from './getDefaultConfig'
@@ -37,9 +37,9 @@ export class ClaimableTokensClient extends BaseSolanaProgramClient {
   /** The program ID of the ClaimableTokensProgram instance. */
   private readonly programId: PublicKey
   /** Map from token mint name to public key address. */
-  private readonly mints: Record<MintName, PublicKey>
+  private readonly mints: Record<TokenName, PublicKey>
   /** Map from token mint name to derived user bank authority. */
-  private readonly authorities: Record<MintName, PublicKey>
+  private readonly authorities: Record<TokenName, PublicKey>
 
   constructor(config: ClaimableTokensConfig) {
     const configWithDefaults = mergeConfigWithDefaults(

--- a/packages/libs/src/sdk/services/Solana/programs/ClaimableTokensClient/types.ts
+++ b/packages/libs/src/sdk/services/Solana/programs/ClaimableTokensClient/types.ts
@@ -4,7 +4,7 @@ import { z } from 'zod'
 import type { Prettify } from '../../../../utils/prettify'
 import type { AuthService } from '../../../Auth'
 import {
-  Mint,
+  MintName,
   MintSchema,
   PublicKeySchema,
   SolanaWalletAdapter
@@ -15,12 +15,12 @@ export type ClaimableTokensConfigInternal = {
   /** The program ID of the ClaimableTokensProgram instance. */
   programId: PublicKey
   /** Map from token mint name to public key address. */
-  mints: Record<Mint, PublicKey>
+  mints: Record<MintName, PublicKey>
 } & BaseSolanaProgramConfigInternal
 
 export type ClaimableTokensConfig = Prettify<
   Partial<Omit<ClaimableTokensConfigInternal, 'mints'>> & {
-    mints?: Prettify<Partial<Record<Mint, PublicKey>>>
+    mints?: Prettify<Partial<Record<MintName, PublicKey>>>
     solanaWalletAdapter: SolanaWalletAdapter
   }
 >

--- a/packages/libs/src/sdk/services/Solana/programs/ClaimableTokensClient/types.ts
+++ b/packages/libs/src/sdk/services/Solana/programs/ClaimableTokensClient/types.ts
@@ -4,7 +4,7 @@ import { z } from 'zod'
 import type { Prettify } from '../../../../utils/prettify'
 import type { AuthService } from '../../../Auth'
 import {
-  MintName,
+  TokenName,
   MintSchema,
   PublicKeySchema,
   SolanaWalletAdapter
@@ -15,12 +15,12 @@ export type ClaimableTokensConfigInternal = {
   /** The program ID of the ClaimableTokensProgram instance. */
   programId: PublicKey
   /** Map from token mint name to public key address. */
-  mints: Record<MintName, PublicKey>
+  mints: Record<TokenName, PublicKey>
 } & BaseSolanaProgramConfigInternal
 
 export type ClaimableTokensConfig = Prettify<
   Partial<Omit<ClaimableTokensConfigInternal, 'mints'>> & {
-    mints?: Prettify<Partial<Record<MintName, PublicKey>>>
+    mints?: Prettify<Partial<Record<TokenName, PublicKey>>>
     solanaWalletAdapter: SolanaWalletAdapter
   }
 >

--- a/packages/libs/src/sdk/services/Solana/programs/PaymentRouterClient/PaymentRouterClient.ts
+++ b/packages/libs/src/sdk/services/Solana/programs/PaymentRouterClient/PaymentRouterClient.ts
@@ -23,7 +23,7 @@ import { parseMintToken } from '../../../../utils/parseMintToken'
 import { parseParams } from '../../../../utils/parseParams'
 import { Prettify } from '../../../../utils/prettify'
 import { MEMO_V2_PROGRAM_ID } from '../../constants'
-import { MintName } from '../../types'
+import { TokenName } from '../../types'
 import { BaseSolanaProgramClient } from '../BaseSolanaProgramClient'
 
 import { getDefaultPaymentRouterClientConfig } from './getDefaultConfig'
@@ -48,9 +48,9 @@ export class PaymentRouterClient extends BaseSolanaProgramClient {
   private readonly programAccount: PublicKey
   private readonly programAccountBumpSeed: number
 
-  private readonly mints: Prettify<Partial<Record<MintName, PublicKey>>>
+  private readonly mints: Prettify<Partial<Record<TokenName, PublicKey>>>
 
-  private existingTokenAccounts: Prettify<Partial<Record<MintName, Account>>>
+  private existingTokenAccounts: Prettify<Partial<Record<TokenName, Account>>>
 
   constructor(config: PaymentRouterClientConfig) {
     const configWithDefaults = mergeConfigWithDefaults(

--- a/packages/libs/src/sdk/services/Solana/programs/PaymentRouterClient/types.ts
+++ b/packages/libs/src/sdk/services/Solana/programs/PaymentRouterClient/types.ts
@@ -4,7 +4,7 @@ import { z } from 'zod'
 import { HashId } from '../../../../types/HashId'
 import { Prettify } from '../../../../utils/prettify'
 import {
-  MintName,
+  TokenName,
   MintSchema,
   PublicKeySchema,
   SolanaWalletAdapter
@@ -13,7 +13,7 @@ import { BaseSolanaProgramConfigInternal } from '../types'
 
 export type PaymentRouterClientConfigInternal = {
   programId: PublicKey
-  mints: Prettify<Partial<Record<MintName, PublicKey>>>
+  mints: Prettify<Partial<Record<TokenName, PublicKey>>>
 } & BaseSolanaProgramConfigInternal
 
 export type PaymentRouterClientConfig =

--- a/packages/libs/src/sdk/services/Solana/programs/PaymentRouterClient/types.ts
+++ b/packages/libs/src/sdk/services/Solana/programs/PaymentRouterClient/types.ts
@@ -4,7 +4,7 @@ import { z } from 'zod'
 import { HashId } from '../../../../types/HashId'
 import { Prettify } from '../../../../utils/prettify'
 import {
-  Mint,
+  MintName,
   MintSchema,
   PublicKeySchema,
   SolanaWalletAdapter
@@ -13,7 +13,7 @@ import { BaseSolanaProgramConfigInternal } from '../types'
 
 export type PaymentRouterClientConfigInternal = {
   programId: PublicKey
-  mints: Prettify<Partial<Record<Mint, PublicKey>>>
+  mints: Prettify<Partial<Record<MintName, PublicKey>>>
 } & BaseSolanaProgramConfigInternal
 
 export type PaymentRouterClientConfig =

--- a/packages/libs/src/sdk/services/Solana/types.ts
+++ b/packages/libs/src/sdk/services/Solana/types.ts
@@ -40,11 +40,11 @@ export const PublicKeySchema = z.union([
   })
 ])
 
-export const MintNameSchema = z.enum(['wAUDIO', 'USDC'])
+export const TokenNameSchema = z.enum(['wAUDIO', 'USDC'])
 
-export type MintName = z.input<typeof MintNameSchema>
+export type TokenName = z.input<typeof TokenNameSchema>
 
-export const MintSchema = z.union([MintNameSchema, PublicKeySchema])
+export const MintSchema = z.union([TokenNameSchema, PublicKeySchema])
 
 export type Mint = z.input<typeof MintSchema>
 

--- a/packages/libs/src/sdk/services/Solana/types.ts
+++ b/packages/libs/src/sdk/services/Solana/types.ts
@@ -23,18 +23,30 @@ export type SolanaConfig = {
 
 export type SolanaRelayService = SolanaRelay
 
-export const MintSchema = z.enum(['wAUDIO', 'USDC']).default('wAUDIO')
-
-export type Mint = z.infer<typeof MintSchema>
-
 export const PublicKeySchema = z.union([
-  z.string().transform<PublicKey>((data) => {
-    return new PublicKey(data)
+  z.string().transform<PublicKey>((data, ctx) => {
+    try {
+      return new PublicKey(data)
+    } catch (e) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: e instanceof Error ? e.message : 'Invalid PublicKey input'
+      })
+    }
+    return z.NEVER
   }),
   z.custom<PublicKey>((data) => {
     return data instanceof PublicKey
   })
 ])
+
+export const MintNameSchema = z.enum(['wAUDIO', 'USDC']).default('wAUDIO')
+
+export type MintName = z.infer<typeof MintNameSchema>
+
+export const MintSchema = MintNameSchema.or(PublicKeySchema)
+
+export type Mint = z.infer<typeof MintSchema>
 
 export const RelaySchema = z
   .object({

--- a/packages/libs/src/sdk/services/Solana/types.ts
+++ b/packages/libs/src/sdk/services/Solana/types.ts
@@ -40,13 +40,13 @@ export const PublicKeySchema = z.union([
   })
 ])
 
-export const MintNameSchema = z.enum(['wAUDIO', 'USDC']).default('wAUDIO')
+export const MintNameSchema = z.enum(['wAUDIO', 'USDC'])
 
-export type MintName = z.infer<typeof MintNameSchema>
+export type MintName = z.input<typeof MintNameSchema>
 
-export const MintSchema = MintNameSchema.or(PublicKeySchema)
+export const MintSchema = z.union([MintNameSchema, PublicKeySchema])
 
-export type Mint = z.infer<typeof MintSchema>
+export type Mint = z.input<typeof MintSchema>
 
 export const RelaySchema = z
   .object({

--- a/packages/libs/src/sdk/utils/parseMintToken.ts
+++ b/packages/libs/src/sdk/utils/parseMintToken.ts
@@ -1,0 +1,23 @@
+import { PublicKey } from '@solana/web3.js'
+
+import { MintName } from '../services'
+
+export const parseMintToken = (
+  mint: PublicKey | MintName,
+  mints: Partial<Record<MintName, PublicKey>>
+) => {
+  const mintKey = mint instanceof PublicKey ? mint : mints[mint]
+  if (!mintKey) {
+    throw Error('Mint not configured')
+  }
+  const mintName =
+    mint instanceof PublicKey
+      ? (Object.entries(mints!)!.find(
+          (m) => !!m[1] && mintKey.equals(m[1])
+        )?.[0] as MintName)
+      : mint
+  if (!mintName) {
+    throw Error('Mint not configured')
+  }
+  return { mintKey, mintName }
+}

--- a/packages/libs/src/sdk/utils/parseMintToken.ts
+++ b/packages/libs/src/sdk/utils/parseMintToken.ts
@@ -12,9 +12,9 @@ export const parseMintToken = (
   }
   const mintName =
     mint instanceof PublicKey
-      ? (Object.entries(mints!)!.find(
+      ? (Object.entries(mints).find(
           (m) => !!m[1] && mintKey.equals(m[1])
-        )?.[0] as MintName)
+        )?.[0] as MintName | undefined)
       : mint
   if (!mintName) {
     throw Error('Mint not configured')

--- a/packages/libs/src/sdk/utils/parseMintToken.ts
+++ b/packages/libs/src/sdk/utils/parseMintToken.ts
@@ -2,6 +2,13 @@ import { PublicKey } from '@solana/web3.js'
 
 import { TokenName } from '../services'
 
+/**
+ * Helper function to get both the token and mint address from one or the other.
+ * @param mintOrToken either the name of the token ('USDC') or its mint address
+ * @param mints a mapping of tokens to mint addresses
+ * @returns the mint address and token name
+ * @throws if the token isn't in the mint map
+ */
 export const parseMintToken = (
   mintOrToken: PublicKey | TokenName,
   mints: Partial<Record<TokenName, PublicKey>>

--- a/packages/libs/src/sdk/utils/parseMintToken.ts
+++ b/packages/libs/src/sdk/utils/parseMintToken.ts
@@ -1,10 +1,10 @@
 import { PublicKey } from '@solana/web3.js'
 
-import { MintName } from '../services'
+import { TokenName } from '../services'
 
 export const parseMintToken = (
-  mint: PublicKey | MintName,
-  mints: Partial<Record<MintName, PublicKey>>
+  mint: PublicKey | TokenName,
+  mints: Partial<Record<TokenName, PublicKey>>
 ) => {
   const mintKey = mint instanceof PublicKey ? mint : mints[mint]
   if (!mintKey) {
@@ -14,7 +14,7 @@ export const parseMintToken = (
     mint instanceof PublicKey
       ? (Object.entries(mints).find(
           (m) => !!m[1] && mintKey.equals(m[1])
-        )?.[0] as MintName | undefined)
+        )?.[0] as TokenName | undefined)
       : mint
   if (!mintName) {
     throw Error('Mint not configured')

--- a/packages/libs/src/sdk/utils/parseMintToken.ts
+++ b/packages/libs/src/sdk/utils/parseMintToken.ts
@@ -3,21 +3,22 @@ import { PublicKey } from '@solana/web3.js'
 import { TokenName } from '../services'
 
 export const parseMintToken = (
-  mint: PublicKey | TokenName,
+  mintOrToken: PublicKey | TokenName,
   mints: Partial<Record<TokenName, PublicKey>>
 ) => {
-  const mintKey = mint instanceof PublicKey ? mint : mints[mint]
-  if (!mintKey) {
+  const mint =
+    mintOrToken instanceof PublicKey ? mintOrToken : mints[mintOrToken]
+  if (!mint) {
     throw Error('Mint not configured')
   }
-  const mintName =
-    mint instanceof PublicKey
-      ? (Object.entries(mints).find(
-          (m) => !!m[1] && mintKey.equals(m[1])
-        )?.[0] as TokenName | undefined)
-      : mint
-  if (!mintName) {
+  const token =
+    mintOrToken instanceof PublicKey
+      ? (Object.entries(mints).find((m) => !!m[1] && mint.equals(m[1]))?.[0] as
+          | TokenName
+          | undefined)
+      : mintOrToken
+  if (!token) {
     throw Error('Mint not configured')
   }
-  return { mintKey, mintName }
+  return { mint, token }
 }

--- a/packages/libs/tsconfig.json
+++ b/packages/libs/tsconfig.json
@@ -10,11 +10,7 @@
     "moduleResolution": "node",
     "downlevelIteration": true,
     "isolatedModules": false,
-    "typeRoots": [
-      "./types",
-      "./node_modules/@types",
-      "../../node_modules/@types"
-    ],
+    "typeRoots": ["./types", "./node_modules/@types"],
     "exactOptionalPropertyTypes": false,
     "declaration": true,
     "outDir": "dist",

--- a/packages/web/src/services/solana/WithdrawUSDC.ts
+++ b/packages/web/src/services/solana/WithdrawUSDC.ts
@@ -67,7 +67,7 @@ export const transferUserBankUSDC = async ({
   analyticsFields: any
   signer?: Keypair
 }) => {
-  const connection = getSolanaConnection()
+  const connection = await getSolanaConnection()
   const sdk = await audiusSdk()
   let isCreatingTokenAccount = false
   const mint = new PublicKey(env.USDC_MINT_ADDRESS)

--- a/packages/web/src/services/solana/WithdrawUSDC.ts
+++ b/packages/web/src/services/solana/WithdrawUSDC.ts
@@ -165,7 +165,8 @@ export const transferUserBankUSDC = async ({
       await track(
         make({
           eventName: Name.WITHDRAW_USDC_CREATE_DEST_TOKEN_ACCOUNT_FAILED,
-          ...analyticsFields
+          ...analyticsFields,
+          error: e instanceof Error ? e.message : e
         })
       )
     }

--- a/packages/web/src/services/solana/WithdrawUSDC.ts
+++ b/packages/web/src/services/solana/WithdrawUSDC.ts
@@ -1,20 +1,15 @@
-import { Name } from '@audius/common/models'
 import {
   getRecentBlockhash,
   getLookupTableAccounts,
   IntKeys,
   BUY_SOL_VIA_TOKEN_SLIPPAGE_BPS,
-  FeatureFlags,
-  MEMO_PROGRAM_ID,
-  PREPARE_WITHDRAWAL_MEMO_STRING
+  FeatureFlags
 } from '@audius/common/services'
-import { CommonStoreContext } from '@audius/common/src/store/storeContext'
 import {
   createCloseAccountInstruction,
   NATIVE_MINT,
   createAssociatedTokenAccountIdempotentInstruction,
-  getAssociatedTokenAddressSync,
-  getAccount
+  getAssociatedTokenAddressSync
 } from '@solana/spl-token'
 import {
   Keypair,
@@ -35,144 +30,8 @@ import { env } from 'services/env'
 import { remoteConfigInstance } from 'services/remote-config/remote-config-instance'
 import {
   getAssociatedTokenAccountRent,
-  getSolanaConnection,
   getTransferTransactionFee
 } from 'services/solana/solana'
-
-/**
- * Transfers USDC out of a user bank.
- * Notes:
- * - Withdrawing via coinflow should pass the root wallet in signer so
- * that the transaction isn't marked as a transfer in indexing, and instead
- * the Coinflow withdrawal needs to be completed to mark the transfer as a
- * withdrawal.
- * - Users have restrictions on creating token accounts
- */
-export const transferFromUsdcUserBank = async ({
-  amount,
-  ethWallet,
-  destinationAccountKey,
-  destinationTokenAccountKey,
-  track,
-  make,
-  analyticsFields,
-  signer
-}: {
-  amount: number
-  ethWallet: string
-  destinationAccountKey: PublicKey
-  destinationTokenAccountKey: PublicKey
-  track: CommonStoreContext['analytics']['track']
-  make: CommonStoreContext['analytics']['make']
-  analyticsFields: any
-  signer?: Keypair
-}) => {
-  const connection = await getSolanaConnection()
-  const sdk = await audiusSdk()
-  let isCreatingTokenAccount = false
-  const mint = new PublicKey(env.USDC_MINT_ADDRESS)
-
-  try {
-    const instructions: TransactionInstruction[] = []
-
-    try {
-      await getAccount(connection, destinationAccountKey)
-    } catch (e) {
-      // Throws if token account doesn't exist or account isn't a token account
-      isCreatingTokenAccount = true
-      console.debug(
-        'Associated token account',
-        destinationTokenAccountKey.toBase58(),
-        'does not exist. Creating w/ transfer...'
-      )
-      await track(
-        make({
-          eventName: Name.WITHDRAW_USDC_CREATE_DEST_TOKEN_ACCOUNT_START,
-          ...analyticsFields
-        })
-      )
-      const payerKey = await sdk.services.solanaRelay.getFeePayer()
-      const createAtaInstruction =
-        createAssociatedTokenAccountIdempotentInstruction(
-          payerKey,
-          destinationTokenAccountKey,
-          destinationAccountKey,
-          mint
-        )
-      instructions.push(createAtaInstruction)
-    }
-
-    const secpTransferInstruction =
-      await sdk.services.claimableTokensClient.createTransferSecpInstruction({
-        auth: sdk.services.auth,
-        amount,
-        ethWallet,
-        mint: 'USDC',
-        destination: destinationTokenAccountKey,
-        instructionIndex: instructions.length
-      })
-    instructions.push(secpTransferInstruction)
-
-    const transferInstruction =
-      await sdk.services.claimableTokensClient.createTransferInstruction({
-        ethWallet,
-        mint: 'USDC',
-        destination: destinationTokenAccountKey
-      })
-    instructions.push(transferInstruction)
-
-    if (signer) {
-      const memoInstruction = new TransactionInstruction({
-        keys: [
-          {
-            pubkey: signer.publicKey,
-            isSigner: true,
-            isWritable: true
-          }
-        ],
-        programId: MEMO_PROGRAM_ID,
-        data: Buffer.from(PREPARE_WITHDRAWAL_MEMO_STRING)
-      })
-      instructions.push(memoInstruction)
-    }
-
-    const transaction =
-      await sdk.services.claimableTokensClient.buildTransaction({
-        instructions
-      })
-
-    if (signer) {
-      transaction.sign([signer])
-    }
-
-    const { signature } = await sdk.services.solanaRelay.relay({
-      transaction,
-      sendOptions: { skipPreflight: true }
-    })
-
-    if (isCreatingTokenAccount) {
-      await track(
-        make({
-          eventName: Name.WITHDRAW_USDC_CREATE_DEST_TOKEN_ACCOUNT_SUCCESS,
-          ...analyticsFields
-        })
-      )
-    }
-
-    return signature
-  } catch (e) {
-    if (isCreatingTokenAccount) {
-      await track(
-        make({
-          eventName: Name.WITHDRAW_USDC_CREATE_DEST_TOKEN_ACCOUNT_FAILED,
-          ...analyticsFields,
-          error: e instanceof Error ? e.message : e
-        })
-      )
-    }
-    throw e
-  }
-}
 
 export const getFundDestinationTokenAccountFees = async (
   account: PublicKey

--- a/packages/web/src/services/solana/WithdrawUSDC.ts
+++ b/packages/web/src/services/solana/WithdrawUSDC.ts
@@ -5,7 +5,6 @@ import {
   BUY_SOL_VIA_TOKEN_SLIPPAGE_BPS,
   FeatureFlags
 } from '@audius/common/services'
-import { MintName } from '@audius/sdk'
 import {
   createCloseAccountInstruction,
   NATIVE_MINT,
@@ -13,20 +12,20 @@ import {
   getAssociatedTokenAddressSync
 } from '@solana/spl-token'
 import {
+  Keypair,
   LAMPORTS_PER_SOL,
   PublicKey,
   TransactionInstruction,
   TransactionMessage,
   VersionedTransaction
 } from '@solana/web3.js'
-import BN from 'bn.js'
 
 import {
   JupiterSingleton,
   parseInstruction
 } from 'services/audius-backend/Jupiter'
 import { audiusBackendInstance } from 'services/audius-backend/audius-backend-instance'
-import { getLibs } from 'services/audius-libs'
+import { audiusSdk } from 'services/audius-sdk'
 import { env } from 'services/env'
 import { remoteConfigInstance } from 'services/remote-config/remote-config-instance'
 import {
@@ -46,18 +45,21 @@ export const getFundDestinationTokenAccountFees = async (
  * Creates instructions to swap from a user bank token into the given wallet as SOL.
  * These instructions are allowed in relay because every created token account is closed in the same transaction.
  */
-export const createSwapUserbankToSolInstructions = async ({
-  mint,
+export const swapUserBankUSDCToSol = async ({
   outSolAmount,
   wallet,
-  feePayer
+  ethWallet
 }: {
-  mint: MintName
   outSolAmount: number
-  feePayer: PublicKey
-  wallet: PublicKey
+  wallet: Keypair
+  ethWallet: string
 }) => {
-  const libs = await getLibs()
+  const sdk = await audiusSdk()
+  const claimableTokensClient = sdk.services.claimableTokensClient
+  const authService = sdk.services.auth
+  const mintName = 'USDC'
+  const mint = new PublicKey(env.USDC_MINT_ADDRESS)
+  const feePayer = await sdk.services.solanaRelay.getFeePayer()
   const slippageBps =
     remoteConfigInstance.getRemoteVar(
       IntKeys.BUY_SOL_WITH_TOKEN_SLIPPAGE_BPS
@@ -67,22 +69,22 @@ export const createSwapUserbankToSolInstructions = async ({
     mint
   })
   const walletTokenAccount = getAssociatedTokenAddressSync(
-    libs.solanaWeb3Manager!.mints[mint],
-    wallet
+    mint,
+    wallet.publicKey
   )
   const walletSolTokenAccount = getAssociatedTokenAddressSync(
     NATIVE_MINT,
-    wallet
+    wallet.publicKey
   )
-  const tokenSymbol = mint.toUpperCase()
+  const tokenSymbol = mintName
 
   // 1. Create a temporary token account on the wallet
   const createTemporaryTokenAccountInstruction =
     createAssociatedTokenAccountIdempotentInstruction(
       feePayer, // fee payer
       walletTokenAccount, // account to create
-      wallet, // owner
-      libs.solanaWeb3Manager!.mints[mint] // mint
+      wallet.publicKey, // owner
+      mint // mint
     )
 
   // 2-3. Transfer the tokens from the userbank to the wallet
@@ -98,14 +100,20 @@ export const createSwapUserbankToSolInstructions = async ({
   // Use the otherAmountThreshold which will account for max slippage.
   // We will end up with potentially extra SOL in the root account.
   const usdcNeededAmount = quoteRoute.otherAmountThreshold.amount
-  const transferToTemporaryTokenAccountInstructions =
-    await libs.solanaWeb3Manager!.createTransferInstructionsFromCurrentUser({
-      amount: new BN(usdcNeededAmount),
-      feePayerKey: feePayer,
-      senderSolanaAddress: usdcUserBank,
-      recipientSolanaAddress: walletTokenAccount.toString(),
-      instructionIndex: 1,
-      mint
+  const secpTransferInstruction =
+    await claimableTokensClient.createTransferSecpInstruction({
+      auth: authService,
+      amount: BigInt(usdcNeededAmount),
+      ethWallet,
+      mint: mintName,
+      destination: walletTokenAccount,
+      instructionIndex: 1
+    })
+  const transferInstruction =
+    await claimableTokensClient.createTransferInstruction({
+      ethWallet,
+      mint: mintName,
+      destination: walletTokenAccount
     })
 
   // 4. Create a temporary wSOL account on the wallet
@@ -113,7 +121,7 @@ export const createSwapUserbankToSolInstructions = async ({
     createAssociatedTokenAccountIdempotentInstruction(
       feePayer, // fee payer
       walletSolTokenAccount, // account to create
-      wallet, // owner
+      wallet.publicKey, // owner
       NATIVE_MINT // mint
     )
 
@@ -137,23 +145,23 @@ export const createSwapUserbankToSolInstructions = async ({
     lookupTableAddresses
   } = await JupiterSingleton.getSwapInstructions({
     quote: swapQuote.quote,
-    userPublicKey: wallet,
+    userPublicKey: wallet.publicKey,
     destinationTokenAccount: walletSolTokenAccount
   })
 
   // 6. Convert wSOL to SOL by closing the wSOL token account and setting the destination wallet
   const closeWSOLInstruction = createCloseAccountInstruction(
     walletSolTokenAccount, //  account to close
-    wallet, // fee destination
-    wallet //  owner
+    wallet.publicKey, // fee destination
+    wallet.publicKey //  owner
   )
 
   // 7. Recreate the wSOL account using the wallet so we can return the rent to the feepayer
   const createWSOLInstructionAgain =
     createAssociatedTokenAccountIdempotentInstruction(
-      wallet, // fee payer
+      wallet.publicKey, // fee payer
       walletSolTokenAccount, // account to create
-      wallet, // owner
+      wallet.publicKey, // owner
       NATIVE_MINT // mint
     )
 
@@ -161,20 +169,21 @@ export const createSwapUserbankToSolInstructions = async ({
   const closeWSOLInstructionAgain = createCloseAccountInstruction(
     walletSolTokenAccount, //  account to close
     feePayer, // fee destination
-    wallet //  owner
+    wallet.publicKey //  owner
   )
 
   // 9. Close the temporary token account on the wallet and return the rent to the feepayer
   const closeTemporaryTokenAccountInstruction = createCloseAccountInstruction(
     walletTokenAccount, //  account to close
     feePayer, // fee destination
-    wallet //  owner
+    wallet.publicKey //  owner
   )
 
-  return {
+  const transaction = await claimableTokensClient.buildTransaction({
     instructions: [
       createTemporaryTokenAccountInstruction,
-      ...transferToTemporaryTokenAccountInstructions,
+      secpTransferInstruction,
+      transferInstruction,
       createWSOLInstruction,
       parseInstruction(swapInstruction),
       closeWSOLInstruction,
@@ -182,7 +191,19 @@ export const createSwapUserbankToSolInstructions = async ({
       closeWSOLInstructionAgain,
       closeTemporaryTokenAccountInstruction
     ],
-    lookupTableAddresses,
+    addressLookupTables: lookupTableAddresses.map(
+      (address) => new PublicKey(address)
+    )
+  })
+
+  transaction.sign([wallet])
+
+  const signature = await claimableTokensClient.sendTransaction(transaction, {
+    skipPreflight: true
+  })
+
+  return {
+    signature,
     usdcNeededAmount
   }
 }

--- a/packages/web/src/services/solana/WithdrawUSDC.ts
+++ b/packages/web/src/services/solana/WithdrawUSDC.ts
@@ -48,7 +48,7 @@ import {
  * withdrawal.
  * - Users have restrictions on creating token accounts
  */
-export const transferUserBankUSDC = async ({
+export const transferFromUsdcUserBank = async ({
   amount,
   ethWallet,
   destinationAccountKey,

--- a/packages/web/src/services/solana/WithdrawUSDC.ts
+++ b/packages/web/src/services/solana/WithdrawUSDC.ts
@@ -44,6 +44,7 @@ export const getFundDestinationTokenAccountFees = async (
 /**
  * Creates instructions to swap from a user bank token into the given wallet as SOL.
  * These instructions are allowed in relay because every created token account is closed in the same transaction.
+ * @deprecated not necessary anymore as we allow users to fund one token account
  */
 export const swapUserBankUSDCToSol = async ({
   outSolAmount,

--- a/packages/web/src/services/solana/WithdrawUSDC.ts
+++ b/packages/web/src/services/solana/WithdrawUSDC.ts
@@ -8,6 +8,7 @@ import {
   MEMO_PROGRAM_ID,
   PREPARE_WITHDRAWAL_MEMO_STRING
 } from '@audius/common/services'
+import { CommonStoreContext } from '@audius/common/src/store/storeContext'
 import {
   createCloseAccountInstruction,
   NATIVE_MINT,
@@ -56,7 +57,16 @@ export const transferUserBankUSDC = async ({
   make,
   analyticsFields,
   signer
-}: any) => {
+}: {
+  amount: number
+  ethWallet: string
+  destinationAccountKey: PublicKey
+  destinationTokenAccountKey: PublicKey
+  track: CommonStoreContext['analytics']['track']
+  make: CommonStoreContext['analytics']['make']
+  analyticsFields: any
+  signer?: Keypair
+}) => {
   const connection = getSolanaConnection()
   const sdk = await audiusSdk()
   let isCreatingTokenAccount = false

--- a/packages/web/src/services/solana/solana.ts
+++ b/packages/web/src/services/solana/solana.ts
@@ -9,16 +9,14 @@ import {
 import { PublicKey, Transaction, Keypair } from '@solana/web3.js'
 
 import { getLibs } from 'services/audius-libs'
+import { audiusSdk } from 'services/audius-sdk'
 
 export const ROOT_ACCOUNT_SIZE = 0 // Root account takes 0 bytes, but still pays rent!
 export const TRANSACTION_FEE_FALLBACK = 10000
 
-/**
- * Gets the solana connection from libs.
- */
 export const getSolanaConnection = async () => {
-  const libs = await getLibs()
-  return libs.solanaWeb3Manager!.getConnection()
+  const sdk = await audiusSdk()
+  return sdk.services.claimableTokensClient.connection
 }
 
 /**

--- a/packages/web/src/store/application/ui/withdraw-usdc/sagas.ts
+++ b/packages/web/src/store/application/ui/withdraw-usdc/sagas.ts
@@ -11,7 +11,8 @@ import {
   WithdrawMethod,
   getContext,
   buyUSDCActions,
-  accountSelectors
+  accountSelectors,
+  getSDK
 } from '@audius/common/store'
 import { PublicKey } from '@solana/web3.js'
 import { takeLatest } from 'redux-saga/effects'
@@ -44,8 +45,7 @@ function* doWithdrawUSDCCoinflow({
   'amount' | 'currentBalance'
 >) {
   const { track, make } = yield* getContext('analytics')
-  const audiusSdk = yield* getContext('audiusSdk')
-  const sdk = yield* call(audiusSdk)
+  const sdk = yield* getSDK()
   yield* put(beginCoinflowWithdrawal())
   const mint = new PublicKey(env.USDC_MINT_ADDRESS)
 
@@ -205,8 +205,7 @@ function* doWithdrawUSDCManualTransfer({
   const { track, make } = yield* getContext('analytics')
   const withdrawalAmountDollars = amount / 100
   const mint = new PublicKey(env.USDC_MINT_ADDRESS)
-  const audiusSdk = yield* getContext('audiusSdk')
-  const sdk = yield* call(audiusSdk)
+  const sdk = yield* getSDK()
   const connection = yield* call(getSolanaConnection)
 
   const analyticsFields: WithdrawUSDCTransferEventFields = {

--- a/packages/web/src/store/application/ui/withdraw-usdc/sagas.ts
+++ b/packages/web/src/store/application/ui/withdraw-usdc/sagas.ts
@@ -1,6 +1,5 @@
 import {
   Name,
-  ErrorLevel,
   Status,
   WithdrawUSDCTransferEventFields
 } from '@audius/common/models'
@@ -192,7 +191,6 @@ function* doWithdrawUSDCCoinflow({
     )
 
     reportToSentry({
-      level: ErrorLevel.Error,
       error: e as Error
     })
   }
@@ -278,7 +276,6 @@ function* doWithdrawUSDCManualTransfer({
     )
 
     reportToSentry({
-      level: ErrorLevel.Error,
       error: e as Error
     })
   }

--- a/packages/web/src/store/application/ui/withdraw-usdc/sagas.ts
+++ b/packages/web/src/store/application/ui/withdraw-usdc/sagas.ts
@@ -180,14 +180,17 @@ function* doWithdrawUSDCCoinflow({
       }
     }
   } catch (e: unknown) {
-    const error = e as Error
     console.error('Withdraw USDC failed', e)
     const reportToSentry = yield* getContext('reportToSentry')
     yield* put(withdrawUSDCFailed({ error: e as Error }))
 
     yield* call(
       track,
-      make({ eventName: Name.WITHDRAW_USDC_FAILURE, ...analyticsFields, error })
+      make({
+        eventName: Name.WITHDRAW_USDC_FAILURE,
+        ...analyticsFields,
+        error: e instanceof Error ? e.message : e
+      })
     )
 
     reportToSentry({

--- a/packages/web/src/store/application/ui/withdraw-usdc/sagas.ts
+++ b/packages/web/src/store/application/ui/withdraw-usdc/sagas.ts
@@ -71,7 +71,7 @@ function* doWithdrawUSDCCoinflow({
 
     const user = yield* select(accountSelectors.getAccountUser)
     if (!user?.wallet) {
-      throw new Error('User not logged in')
+      throw new Error('Unable to find wallet. Is the user signed in?')
     }
     const ethWallet = user.wallet
     const destinationWallet = new PublicKey(destinationAddress)
@@ -225,7 +225,7 @@ function* doWithdrawUSDCManualTransfer({
 
     const user = yield* select(accountSelectors.getAccountUser)
     if (!user?.wallet) {
-      throw new Error('User not logged in')
+      throw new Error('Unable to find wallet. Is the user signed in?')
     }
     const ethWallet = user.wallet
     const destinationWallet = new PublicKey(destinationAddress)

--- a/packages/web/src/store/application/ui/withdraw-usdc/sagas.ts
+++ b/packages/web/src/store/application/ui/withdraw-usdc/sagas.ts
@@ -18,7 +18,7 @@ import { takeLatest } from 'redux-saga/effects'
 import { call, put, race, select, take } from 'typed-redux-saga'
 
 import { env } from 'services/env'
-import { transferUserBankUSDC } from 'services/solana/WithdrawUSDC'
+import { transferFromUsdcUserBank } from 'services/solana/WithdrawUSDC'
 import {
   getRootSolanaAccount,
   getSolanaConnection
@@ -82,7 +82,7 @@ function* doWithdrawUSDCCoinflow({
       destinationAccountKey
     )
 
-    const signature = yield* call(transferUserBankUSDC, {
+    const signature = yield* call(transferFromUsdcUserBank, {
       amount: amount / 100, // amount is given in cents, fn expects dollars
       ethWallet,
       destinationAccountKey,
@@ -240,7 +240,7 @@ function* doWithdrawUSDCManualTransfer({
       destinationAccountKey
     )
 
-    const signature = yield* call(transferUserBankUSDC, {
+    const signature = yield* call(transferFromUsdcUserBank, {
       amount: amount / 100, // amount is in cents, fn expects dollars
       ethWallet,
       destinationAccountKey,

--- a/packages/web/src/store/application/ui/withdraw-usdc/sagas.ts
+++ b/packages/web/src/store/application/ui/withdraw-usdc/sagas.ts
@@ -66,7 +66,7 @@ function* doWithdrawUSDCCoinflow({
     const rootSolanaAccount = yield* call(getRootSolanaAccount)
 
     const destinationAddress = rootSolanaAccount.publicKey.toString()
-    const connection = getSolanaConnection()
+    const connection = yield* call(getSolanaConnection)
 
     const user = yield* select(accountSelectors.getAccountUser)
     if (!user?.wallet) {

--- a/packages/web/src/store/application/ui/withdraw-usdc/sagas.ts
+++ b/packages/web/src/store/application/ui/withdraw-usdc/sagas.ts
@@ -2,55 +2,27 @@ import {
   Name,
   ErrorLevel,
   Status,
-  WithdrawUSDCTransferEventFields,
-  BNUSDC,
-  SolanaWalletAddress
+  WithdrawUSDCTransferEventFields
 } from '@audius/common/models'
 import {
-  MEMO_PROGRAM_ID,
-  PREPARE_WITHDRAWAL_MEMO_STRING,
-  getUserbankAccountInfo,
-  relayTransaction,
-  relayVersionedTransaction
-} from '@audius/common/services'
-import {
-  getUSDCUserBank,
-  solanaSelectors,
   withdrawUSDCActions,
   WithdrawUSDCModalPages,
   withdrawUSDCModalActions,
-  TOKEN_LISTING_MAP,
   WithdrawMethod,
   getContext,
-  buyUSDCActions
+  buyUSDCActions,
+  accountSelectors
 } from '@audius/common/store'
-import { formatUSDCWeiToFloorCentsNumber } from '@audius/common/utils'
-import {
-  createAssociatedTokenAccountInstruction,
-  getAssociatedTokenAddressSync
-} from '@solana/spl-token'
-import {
-  LAMPORTS_PER_SOL,
-  PublicKey,
-  Transaction,
-  TransactionInstruction,
-  sendAndConfirmTransaction
-} from '@solana/web3.js'
-import BN from 'bn.js'
+import { getAssociatedTokenAddressSync } from '@solana/spl-token'
+import { PublicKey } from '@solana/web3.js'
 import { takeLatest } from 'redux-saga/effects'
 import { call, put, race, select, take } from 'typed-redux-saga'
 
-import { getLibs } from 'services/audius-libs'
+import { env } from 'services/env'
+import { transferUserBankUSDC } from 'services/solana/WithdrawUSDC'
 import {
-  createSwapUserbankToSolInstructions,
-  createVersionedTransaction,
-  getFundDestinationTokenAccountFees
-} from 'services/solana/WithdrawUSDC'
-import {
-  isTokenAccount,
-  getTokenAccountInfo,
   getRootSolanaAccount,
-  ROOT_ACCOUNT_SIZE
+  getSolanaConnection
 } from 'services/solana/solana'
 
 const {
@@ -61,148 +33,10 @@ const {
   coinflowWithdrawalSucceeded,
   withdrawUSDCFailed,
   withdrawUSDCSucceeded,
-  updateAmount,
   cleanup: cleanupWithdrawUSDC
 } = withdrawUSDCActions
 const { set: setWithdrawUSDCModalData, close: closeWithdrawUSDCModal } =
   withdrawUSDCModalActions
-const { getFeePayer } = solanaSelectors
-
-/**
- * Swaps some of the USDC in the user's bank account for SOL and sends it to their root Solana wallet
- */
-function* swapUSDCToSol({
-  amount,
-  feePayer
-}: {
-  amount: number
-  feePayer: PublicKey
-}) {
-  const audiusBackendInstance = yield* getContext('audiusBackendInstance')
-  const rootSolanaAccount = yield* call(getRootSolanaAccount)
-  const { instructions, lookupTableAddresses, usdcNeededAmount } = yield* call(
-    createSwapUserbankToSolInstructions,
-    {
-      mint: 'usdc',
-      wallet: rootSolanaAccount.publicKey,
-      outSolAmount: amount,
-      feePayer
-    }
-  )
-  const { transaction, lookupTableAccounts } = yield* call(
-    createVersionedTransaction,
-    {
-      instructions,
-      lookupTableAddresses,
-      feePayer
-    }
-  )
-  transaction.sign([rootSolanaAccount])
-  const { res: transactionSignature, error: swapError } = yield* call(
-    relayVersionedTransaction,
-    audiusBackendInstance,
-    {
-      transaction,
-      addressLookupTableAccounts: lookupTableAccounts,
-      skipPreflight: true
-    }
-  )
-  if (swapError) {
-    throw new Error(`Swap transaction failed: ${swapError}`)
-  }
-  console.debug('Withdraw USDC - root wallet funded via swap.', {
-    transactionSignature
-  })
-  return { usdcNeededAmount }
-}
-
-/**
- * Creates an associated token account for USDC on the destination wallet using the user's root wallet.
- * Funds root wallet as necessary by swapping USDC for SOL.
- */
-function* createDestinationTokenAccount({
-  destinationWallet,
-  destinationTokenAccount,
-  feePayer
-}: {
-  destinationWallet: PublicKey
-  destinationTokenAccount: PublicKey
-  feePayer: PublicKey
-}) {
-  // Setup
-  const libs = yield* call(getLibs)
-  const rootSolanaAccount = yield* call(getRootSolanaAccount)
-  if (!libs.solanaWeb3Manager) {
-    throw new Error('Failed to get solana web3 manager')
-  }
-  const connection = libs.solanaWeb3Manager.getConnection()
-
-  // Check if there is enough SOL to fund the destination associated token account
-  const feeAmount = yield* call(
-    getFundDestinationTokenAccountFees,
-    destinationTokenAccount
-  )
-  const existingBalance =
-    (yield* call(
-      [connection, connection.getBalance],
-      rootSolanaAccount.publicKey
-    )) / LAMPORTS_PER_SOL
-  // Need to maintain a minimum balance to pay rent for root solana account
-  const rootSolanaAccountRent =
-    (yield* call(
-      [connection, connection.getMinimumBalanceForRentExemption],
-      ROOT_ACCOUNT_SIZE
-    )) / LAMPORTS_PER_SOL
-
-  const solRequired = feeAmount + rootSolanaAccountRent - existingBalance
-  let usdcNeededAmount = 0
-  if (solRequired > 0) {
-    // Swap USDC for SOL to fund the destination associated token account
-    console.debug(
-      'Withdraw USDC - not enough SOL to fund destination account, attempting to swap USDC for SOL...',
-      { solRequired, feeAmount, existingBalance, rootSolanaAccountRent }
-    )
-    const swapResponse = yield* call(swapUSDCToSol, {
-      amount: solRequired,
-      feePayer
-    })
-    usdcNeededAmount = swapResponse.usdcNeededAmount
-  }
-
-  // Then create and fund the destination associated token account
-  const { blockhash, lastValidBlockHeight } = yield* call([
-    connection,
-    connection.getLatestBlockhash
-  ])
-  const tx = new Transaction({ blockhash, lastValidBlockHeight })
-  const createTokenAccountInstruction = yield* call(
-    createAssociatedTokenAccountInstruction,
-    rootSolanaAccount.publicKey, // fee payer
-    destinationTokenAccount, // account to create
-    destinationWallet, // owner
-    libs.solanaWeb3Manager.mints.usdc // mint
-  )
-  tx.add(createTokenAccountInstruction)
-  console.debug(
-    'Withdraw USDC - Creating destination associated token account...',
-    {
-      account: destinationTokenAccount.toBase58(),
-      wallet: destinationWallet.toBase58()
-    }
-  )
-  const transactionSignature = yield* call(
-    sendAndConfirmTransaction,
-    connection,
-    tx,
-    [rootSolanaAccount],
-    { skipPreflight: true }
-  )
-  console.debug(
-    'Withdraw USDC - Successfully created destination associated token account.',
-    { transactionSignature }
-  )
-  return { usdcNeededAmount }
-}
 
 function* doWithdrawUSDCCoinflow({
   amount,
@@ -213,6 +47,7 @@ function* doWithdrawUSDCCoinflow({
 >) {
   const { track, make } = yield* getContext('analytics')
   yield* put(beginCoinflowWithdrawal())
+  const mint = new PublicKey(env.USDC_MINT_ADDRESS)
 
   const analyticsFields: WithdrawUSDCTransferEventFields = {
     destinationAddress: 'COINFLOW',
@@ -221,8 +56,6 @@ function* doWithdrawUSDCCoinflow({
     currentBalance: currentBalance / 100
   }
   try {
-    const audiusBackendInstance = yield* getContext('audiusBackendInstance')
-
     yield* call(
       track,
       make({
@@ -231,176 +64,40 @@ function* doWithdrawUSDCCoinflow({
       })
     )
 
-    const libs = yield* call(getLibs)
-    if (!libs.solanaWeb3Manager) {
-      throw new Error('Failed to get solana web3 manager')
-    }
     const rootSolanaAccount = yield* call(getRootSolanaAccount)
 
     const destinationAddress = rootSolanaAccount.publicKey.toString()
+    const connection = getSolanaConnection()
 
-    if (!destinationAddress || !amount) {
-      throw new Error('Please enter a valid destination address and amount')
+    const user = yield* select(accountSelectors.getAccountUser)
+    if (!user?.wallet) {
+      throw new Error('User not logged in')
     }
+    const ethWallet = user.wallet
 
-    let withdrawalAmount = amount
-    const feePayer = yield* select(getFeePayer)
-    if (feePayer === null) {
-      throw new Error('Missing Fee Payer.')
-    }
-    const feePayerPubkey = new PublicKey(feePayer)
-    const connection = libs.solanaWeb3Manager.getConnection()
-
-    const destinationPubkey = new PublicKey(destinationAddress)
-    let destinationTokenAccountAddress: string
-
-    // Check to see if the address is already an associated token account
-    const isTokenAccountAddress = yield* call(isTokenAccount, {
-      accountAddress: destinationAddress as SolanaWalletAddress,
-      mint: 'usdc'
-    })
-
-    const accountInfo = yield* call(
-      getUserbankAccountInfo,
-      audiusBackendInstance,
-      { mint: 'usdc' }
-    )
-    const latestBalance = accountInfo?.amount ?? BigInt('0')
-
-    if (isTokenAccountAddress) {
-      // If the destination is already a token account, we can transfer directly
-      destinationTokenAccountAddress = destinationAddress
-    } else {
-      // If it's not, derive the associated token account
-      const destinationWallet = destinationPubkey
-      const destinationTokenAccount = yield* call(
-        getAssociatedTokenAddressSync,
-        libs.solanaWeb3Manager.mints.usdc,
-        destinationWallet
-      )
-      destinationTokenAccountAddress = destinationTokenAccount.toBase58()
-
-      // Ensure the derived token account exists
-      const tokenAccountInfo = yield* call(getTokenAccountInfo, {
-        tokenAccount: destinationTokenAccount,
-        mint: 'usdc'
-      })
-
-      // If not, then create an associated token account
-      if (tokenAccountInfo === null) {
-        console.debug(
-          'Withdraw USDC - destination associated token account does not exist. Creating...'
-        )
-        try {
-          yield* call(
-            track,
-            make({
-              eventName: Name.WITHDRAW_USDC_CREATE_DEST_TOKEN_ACCOUNT_START,
-              ...analyticsFields
-            })
-          )
-          const { usdcNeededAmount } = yield* call(
-            createDestinationTokenAccount,
-            {
-              destinationWallet,
-              destinationTokenAccount,
-              feePayer: feePayerPubkey
-            }
-          )
-
-          withdrawalAmount = Math.min(
-            withdrawalAmount,
-            formatUSDCWeiToFloorCentsNumber(
-              new BN(
-                (latestBalance - BigInt(usdcNeededAmount)).toString()
-              ) as BNUSDC
-            )
-          )
-
-          yield* call(
-            track,
-            make({
-              eventName: Name.WITHDRAW_USDC_CREATE_DEST_TOKEN_ACCOUNT_SUCCESS,
-              ...analyticsFields
-            })
-          )
-        } catch (e: unknown) {
-          yield* call(
-            track,
-            make({
-              eventName: Name.WITHDRAW_USDC_CREATE_DEST_TOKEN_ACCOUNT_FAILED,
-              ...analyticsFields,
-              error: e as Error
-            })
-          )
-          throw e
-        }
-      }
-    }
-
-    yield* put(updateAmount({ amount: withdrawalAmount }))
-    // Multiply by 10^6 to account for USDC decimals, but also convert from cents to dollars
-    const withdrawalAmountWei = new BN(withdrawalAmount)
-      .mul(new BN(10 ** TOKEN_LISTING_MAP.USDC.decimals))
-      .div(new BN(100))
-    const usdcUserBank = yield* call(getUSDCUserBank)
-    const transferInstructions = yield* call(
-      [
-        libs.solanaWeb3Manager,
-        libs.solanaWeb3Manager.createTransferInstructionsFromCurrentUser
-      ],
-      {
-        amount: withdrawalAmountWei,
-        feePayerKey: feePayerPubkey,
-        senderSolanaAddress: usdcUserBank,
-        recipientSolanaAddress: destinationTokenAccountAddress,
-        mint: 'usdc'
-      }
+    // Ensure the derived token account exists
+    const destinationAccountKey = new PublicKey(destinationAddress)
+    const destinationTokenAccountKey = yield* call(
+      getAssociatedTokenAddressSync,
+      mint,
+      destinationAccountKey
     )
 
-    const memoInstruction = new TransactionInstruction({
-      keys: [
-        {
-          pubkey: rootSolanaAccount.publicKey,
-          isSigner: true,
-          isWritable: true
-        }
-      ],
-      programId: MEMO_PROGRAM_ID,
-      data: Buffer.from(PREPARE_WITHDRAWAL_MEMO_STRING)
+    const signature = yield* call(transferUserBankUSDC, {
+      amount: amount / 100, // amount is given in cents, fn expects dollars
+      ethWallet,
+      destinationAccountKey,
+      destinationTokenAccountKey,
+      track,
+      make,
+      analyticsFields,
+      signer: rootSolanaAccount
     })
-
-    // Relay the withdrawal transfer so that the user doesn't need SOL if the account already exists
-    const { blockhash, lastValidBlockHeight } = yield* call([
-      connection,
-      connection.getLatestBlockhash
-    ])
-    const transferTransaction = new Transaction({
-      blockhash,
-      lastValidBlockHeight,
-      feePayer: feePayerPubkey
-    })
-
-    transferTransaction.add(...transferInstructions, memoInstruction)
-    transferTransaction.partialSign(rootSolanaAccount)
-
-    const {
-      res: transactionSignature,
-      error,
-      errorCode
-    } = yield* call(relayTransaction, audiusBackendInstance, {
-      transaction: transferTransaction,
-      skipPreflight: true
-    })
-
-    if (!transactionSignature || error) {
-      throw new Error(`Failed to transfer: [${errorCode}] ${error}`)
-    }
 
     console.debug(
       'Withdraw USDC - successfully transferred USDC to root wallet for withdrawal.',
       {
-        transactionSignature
+        signature
       }
     )
 
@@ -412,9 +109,11 @@ function* doWithdrawUSDCCoinflow({
       })
     )
 
+    // Finalizes the transaction for our connection
+    // Should possibly be replaced by polling for balance?
     yield* call(
-      [libs.solanaWeb3Manager.getConnection(), 'confirmTransaction'],
-      transactionSignature,
+      [connection, connection.confirmTransaction],
+      signature,
       'finalized'
     )
 
@@ -508,15 +207,16 @@ function* doWithdrawUSDCManualTransfer({
   'amount' | 'currentBalance' | 'destinationAddress'
 >) {
   const { track, make } = yield* getContext('analytics')
+  const withdrawalAmountDollars = amount / 100
+  const mint = new PublicKey(env.USDC_MINT_ADDRESS)
+
   const analyticsFields: WithdrawUSDCTransferEventFields = {
     destinationAddress,
-    amount: amount / 100,
+    amount: withdrawalAmountDollars,
     // Incoming balance is in cents, analytics values are in dollars
     currentBalance: currentBalance / 100
   }
   try {
-    const audiusBackendInstance = yield* getContext('audiusBackendInstance')
-
     yield* call(
       track,
       make({
@@ -525,157 +225,35 @@ function* doWithdrawUSDCManualTransfer({
       })
     )
 
-    const libs = yield* call(getLibs)
-    if (!libs.solanaWeb3Manager) {
-      throw new Error('Failed to get solana web3 manager')
+    const user = yield* select(accountSelectors.getAccountUser)
+    if (!user?.wallet) {
+      throw new Error('User not logged in')
     }
-    if (!destinationAddress || !amount) {
-      throw new Error('Please enter a valid destination address and amount')
-    }
+    const ethWallet = user.wallet
 
-    let withdrawalAmount = amount
-    const feePayer = yield* select(getFeePayer)
-    if (feePayer === null) {
-      throw new Error('Missing Fee Payer.')
-    }
-    const feePayerPubkey = new PublicKey(feePayer)
-    const connection = libs.solanaWeb3Manager.getConnection()
-
-    const destinationPubkey = new PublicKey(destinationAddress)
-    let destinationTokenAccountAddress: string
-
-    // Check to see if the address is already an associated token account
-    const isTokenAccountAddress = yield* call(isTokenAccount, {
-      accountAddress: destinationAddress as SolanaWalletAddress,
-      mint: 'usdc'
-    })
-
-    const accountInfo = yield* call(
-      getUserbankAccountInfo,
-      audiusBackendInstance,
-      { mint: 'usdc' }
-    )
-    const latestBalance = accountInfo?.amount ?? BigInt('0')
-
-    if (isTokenAccountAddress) {
-      // If the destination is already a token account, we can transfer directly
-      destinationTokenAccountAddress = destinationAddress
-    } else {
-      // If it's not, derive the associated token account
-      const destinationWallet = destinationPubkey
-      const destinationTokenAccount = yield* call(
-        getAssociatedTokenAddressSync,
-        libs.solanaWeb3Manager.mints.usdc,
-        destinationWallet
-      )
-      destinationTokenAccountAddress = destinationTokenAccount.toBase58()
-
-      // Ensure the derived token account exists
-      const tokenAccountInfo = yield* call(getTokenAccountInfo, {
-        tokenAccount: destinationTokenAccount,
-        mint: 'usdc'
-      })
-
-      // If not, then create an associated token account
-      if (tokenAccountInfo === null) {
-        console.debug(
-          'Withdraw USDC - destination associated token account does not exist. Creating...'
-        )
-        try {
-          yield* call(
-            track,
-            make({
-              eventName: Name.WITHDRAW_USDC_CREATE_DEST_TOKEN_ACCOUNT_START,
-              ...analyticsFields
-            })
-          )
-          const { usdcNeededAmount } = yield* call(
-            createDestinationTokenAccount,
-            {
-              destinationWallet,
-              destinationTokenAccount,
-              feePayer: feePayerPubkey
-            }
-          )
-
-          withdrawalAmount = Math.min(
-            withdrawalAmount,
-            formatUSDCWeiToFloorCentsNumber(
-              new BN(
-                (latestBalance - BigInt(usdcNeededAmount)).toString()
-              ) as BNUSDC
-            )
-          )
-
-          yield* call(
-            track,
-            make({
-              eventName: Name.WITHDRAW_USDC_CREATE_DEST_TOKEN_ACCOUNT_SUCCESS,
-              ...analyticsFields
-            })
-          )
-        } catch (e: unknown) {
-          yield* call(
-            track,
-            make({
-              eventName: Name.WITHDRAW_USDC_CREATE_DEST_TOKEN_ACCOUNT_FAILED,
-              ...analyticsFields,
-              error: e as Error
-            })
-          )
-          throw e
-        }
-      }
-    }
-
-    yield* put(updateAmount({ amount: withdrawalAmount }))
-
-    // Multiply by 10^6 to account for USDC decimals, but also convert from cents to dollars
-    const withdrawalAmountWei = new BN(withdrawalAmount)
-      .mul(new BN(10 ** TOKEN_LISTING_MAP.USDC.decimals))
-      .div(new BN(100))
-    const usdcUserBank = yield* call(getUSDCUserBank)
-    const transferInstructions = yield* call(
-      [
-        libs.solanaWeb3Manager,
-        libs.solanaWeb3Manager.createTransferInstructionsFromCurrentUser
-      ],
-      {
-        amount: withdrawalAmountWei,
-        feePayerKey: feePayerPubkey,
-        senderSolanaAddress: usdcUserBank,
-        recipientSolanaAddress: destinationTokenAccountAddress,
-        mint: 'usdc'
-      }
+    // Ensure the derived token account exists
+    const destinationAccountKey = new PublicKey(destinationAddress)
+    const destinationTokenAccountKey = yield* call(
+      getAssociatedTokenAddressSync,
+      mint,
+      destinationAccountKey
     )
 
-    // Relay the withdrawal transfer so that the user doesn't need SOL if the account already exists
-    const { blockhash, lastValidBlockHeight } = yield* call([
-      connection,
-      connection.getLatestBlockhash
-    ])
-    const transferTransaction = new Transaction({
-      blockhash,
-      lastValidBlockHeight,
-      feePayer: feePayerPubkey
-    })
-    transferTransaction.add(...transferInstructions)
-    const {
-      res: transactionSignature,
-      error,
-      errorCode
-    } = yield* call(relayTransaction, audiusBackendInstance, {
-      transaction: transferTransaction,
-      skipPreflight: true
+    const signature = yield* call(transferUserBankUSDC, {
+      amount: amount / 100, // amount is in cents, fn expects dollars
+      ethWallet,
+      destinationAccountKey,
+      destinationTokenAccountKey,
+      track,
+      make,
+      analyticsFields
     })
 
-    if (!transactionSignature || error) {
-      throw new Error(`Failed to transfer: [${errorCode}] ${error}`)
-    }
     console.debug('Withdraw USDC - successfully transferred USDC.', {
-      transactionSignature
+      signature
     })
-    yield* put(withdrawUSDCSucceeded({ transaction: transactionSignature }))
+
+    yield* put(withdrawUSDCSucceeded({ transaction: signature }))
     yield* put(
       setWithdrawUSDCModalData({
         page: WithdrawUSDCModalPages.TRANSFER_SUCCESSFUL
@@ -686,14 +264,17 @@ function* doWithdrawUSDCManualTransfer({
       make({ eventName: Name.WITHDRAW_USDC_SUCCESS, ...analyticsFields })
     )
   } catch (e: unknown) {
-    const error = e as Error
     console.error('Withdraw USDC failed', e)
     const reportToSentry = yield* getContext('reportToSentry')
     yield* put(withdrawUSDCFailed({ error: e as Error }))
 
     yield* call(
       track,
-      make({ eventName: Name.WITHDRAW_USDC_FAILURE, ...analyticsFields, error })
+      make({
+        eventName: Name.WITHDRAW_USDC_FAILURE,
+        ...analyticsFields,
+        error: e instanceof Error ? e.message : e
+      })
     )
 
     reportToSentry({


### PR DESCRIPTION
### Description

- Fix for withdrawal swaps getting ratelimited on relay (currently breaking all withdrawals pretty sure)
- Fix to only check instructions are allowed if signing the transaction
- Implement proper signature verification on relay
- Changes withdrawal swap transaction to use SDK (also pigeonholes it to USDC=>SOL but I think that's ok)
  - Tempted to just rip this out entirely since it's dead code now?
- Creates new method that uses simpler transactions for withdrawals
- Updates Typescript for SDK to 5.4.5 from 5.0.4 (matches my VS Code plugin, fixes error with indexing arrays using an enum string)

### How Has This Been Tested?

Still testing