### PR TITLE
[QA-1434] Fix hanging uploads due to errors on mobile

### DIFF
--- a/packages/common/src/store/upload/selectors.ts
+++ b/packages/common/src/store/upload/selectors.ts
@@ -8,6 +8,7 @@ export const getStems = (state: CommonState) => state.upload.stems
 export const getUploadProgress = (state: CommonState) =>
   state.upload.uploadProgress
 export const getUploadSuccess = (state: CommonState) => state.upload.success
+export const getUploadError = (state: CommonState) => state.upload.error
 export const getTracks = (state: CommonState) => state.upload.tracks
 export const getIsUploading = (state: CommonState) => state.upload.uploading
 export const getShouldReset = (state: CommonState) => state.upload.shouldReset

--- a/packages/libs/src/services/discoveryProvider/DiscoveryProvider.ts
+++ b/packages/libs/src/services/discoveryProvider/DiscoveryProvider.ts
@@ -16,7 +16,8 @@ import {
   FetchError,
   Genre,
   Middleware,
-  Mood
+  Mood,
+  ResponseError
 } from '../../sdk'
 import type { CurrentUser, UserStateManager } from '../../userStateManager'
 import { CollectionMetadata, Nullable, User, Utils } from '../../utils'
@@ -1219,7 +1220,10 @@ export class DiscoveryProvider {
         response
       })) ?? response
 
-    return await response.json()
+    if (response && response.status >= 200 && response.status < 300) {
+      return await response.json()
+    }
+    throw new ResponseError(response, 'Response returned an error code')
   }
 
   /**

--- a/packages/libs/src/services/discoveryProvider/DiscoveryProvider.ts
+++ b/packages/libs/src/services/discoveryProvider/DiscoveryProvider.ts
@@ -1220,10 +1220,15 @@ export class DiscoveryProvider {
         response
       })) ?? response
 
-    if (response && response.status >= 200 && response.status < 300) {
-      return await response.json()
+    // Matches logic from SDK `request` method
+    if (!response || response.status < 200 || response.status >= 300) {
+      throw new ResponseError(
+        response,
+        'Response did not contain a successful status code'
+      )
     }
-    throw new ResponseError(response, 'Response returned an error code')
+
+    return await response.json()
   }
 
   /**
@@ -1651,6 +1656,14 @@ export class DiscoveryProvider {
         ...fetchParams,
         response
       })) ?? response
+
+    // Matches logic from SDK `request` method
+    if (!response || response.status < 200 || response.status >= 300) {
+      throw new ResponseError(
+        response,
+        'Response did not contain a successful status code'
+      )
+    }
 
     const responseBody: DiscoveryResponse<Response> = await response.json()
 

--- a/packages/libs/src/services/discoveryProvider/DiscoveryProvider.ts
+++ b/packages/libs/src/services/discoveryProvider/DiscoveryProvider.ts
@@ -1657,14 +1657,6 @@ export class DiscoveryProvider {
         response
       })) ?? response
 
-    // Matches logic from SDK `request` method
-    if (!response || response.status < 200 || response.status >= 300) {
-      throw new ResponseError(
-        response,
-        'Response did not contain a successful status code'
-      )
-    }
-
     const responseBody: DiscoveryResponse<Response> = await response.json()
 
     if (blockNumber && responseBody.latest_indexed_block < blockNumber) {

--- a/packages/mobile/src/screens/edit-track-screen/EditTrackScreen.tsx
+++ b/packages/mobile/src/screens/edit-track-screen/EditTrackScreen.tsx
@@ -250,7 +250,7 @@ export const EditTrackScreen = (props: EditTrackScreenProps) => {
   }
 
   const handleSubmit = useCallback(
-    (values: FormValues) => {
+    (values: FormValues, { setSubmitting }) => {
       const {
         licenseType: ignoredLicenseType,
         trackArtwork: ignoredTrackArtwork,
@@ -328,6 +328,7 @@ export const EditTrackScreen = (props: EditTrackScreenProps) => {
 
       // submit the metadata
       onSubmit(metadata)
+      setSubmitting(false)
     },
     [initialValuesProp, onSubmit]
   )

--- a/packages/mobile/src/screens/upload-screen/screens/CompleteTrackScreen.tsx
+++ b/packages/mobile/src/screens/upload-screen/screens/CompleteTrackScreen.tsx
@@ -1,4 +1,4 @@
-import { useCallback } from 'react'
+import { useCallback, useState } from 'react'
 
 import type {
   TrackForUpload,
@@ -21,15 +21,19 @@ export type CompleteTrackParams = TrackForUpload
 export const CompleteTrackScreen = () => {
   const { params } = useRoute<UploadRouteProp<'CompleteTrack'>>()
   const { metadata, file } = params
+  const [uploadAttempt, setUploadAttempt] = useState(1)
   const navigation = useNavigation<UploadParamList>()
 
   const handleSubmit = useCallback(
     (metadata: TrackMetadataForUpload) => {
       navigation.push('UploadingTracks', {
-        tracks: [{ file, preview: null, metadata }]
+        tracks: [{ file, preview: null, metadata }],
+        uploadAttempt
       })
+      // Increment attempt count in case we get sent back here after an error
+      setUploadAttempt(uploadAttempt + 1)
     },
-    [navigation, file]
+    [navigation, file, uploadAttempt]
   )
 
   return (


### PR DESCRIPTION
### Description
The `relay` method doesn't throw errors when the response comes back as unsuccessful. This causes a hang in the upload process on mobile in the cases where the user gets assigned a node that is "healthy" but doesn't have a good chain connection. This PR updates the `relay` method to throw for non 2xx results so that the sagas above it can catch the error and correctly show and error screen.

Note: I am intentionally _not_ updating the internal request method in `DiscoveryProvider` to follow this pattern because there are a number of cases where this actually breaks the application due to the `ResponseError` not being handled correctly above. I'd prefer to leave these as they are and fix the unhandled errors when migrating to SDK.

### How Has This Been Tested?
Tested locally on simulator and web against prod and staging respectively.
