### PR TITLE
[QA-1501] Fix mobile search input

### DIFF
--- a/packages/mobile/src/screens/app-screen/AppTabScreen.tsx
+++ b/packages/mobile/src/screens/app-screen/AppTabScreen.tsx
@@ -37,7 +37,7 @@ import {
 } from 'app/screens/search-results-screen'
 import { SearchScreen } from 'app/screens/search-screen'
 import type { SearchParams } from 'app/screens/search-screen-v2'
-import { SearchScreenV2 } from 'app/screens/search-screen-v2'
+import { SearchScreenStack } from 'app/screens/search-screen-v2'
 import {
   AboutScreen,
   AccountSettingsScreen,
@@ -223,8 +223,8 @@ export const AppTabScreen = ({ baseScreen, Stack }: AppTabScreenProps) => {
       {isSearchV2Enabled ? (
         <Stack.Screen
           name='Search'
-          component={SearchScreenV2}
-          options={screenOptions}
+          component={SearchScreenStack}
+          options={{ ...screenOptions, headerShown: false }}
         />
       ) : (
         <Stack.Group>

--- a/packages/mobile/src/screens/search-screen-v2/SearchScreenV2.tsx
+++ b/packages/mobile/src/screens/search-screen-v2/SearchScreenV2.tsx
@@ -142,7 +142,8 @@ export const SearchScreenStack = () => {
         filters,
         setFilters,
         bpmType,
-        setBpmType
+        setBpmType,
+        active: true
       }}
     >
       <Stack.Navigator screenOptions={screenOptions}>

--- a/packages/mobile/src/screens/search-screen-v2/index.ts
+++ b/packages/mobile/src/screens/search-screen-v2/index.ts
@@ -1,2 +1,2 @@
-export { SearchScreenV2 } from './SearchScreenV2'
+export { SearchScreenStack } from './SearchScreenV2'
 export type { SearchParams } from './searchParams'

--- a/packages/mobile/src/screens/search-screen-v2/search-results/AllResults.tsx
+++ b/packages/mobile/src/screens/search-screen-v2/search-results/AllResults.tsx
@@ -63,9 +63,7 @@ const AllResultsItem = ({
   }, [item, dispatch, query])
 
   return item.status === Status.LOADING ? (
-    <Box ph='m'>
-      <SearchItemSkeleton />
-    </Box>
+    <SearchItemSkeleton />
   ) : (
     <SearchItem searchItem={item} onPress={handlePress} />
   )

--- a/packages/mobile/src/screens/search-screen-v2/search-results/AllResults.tsx
+++ b/packages/mobile/src/screens/search-screen-v2/search-results/AllResults.tsx
@@ -9,7 +9,7 @@ import { range } from 'lodash'
 import { Keyboard } from 'react-native'
 import { useDispatch } from 'react-redux'
 
-import { Box, Divider, Flex, Text } from '@audius/harmony-native'
+import { Divider, Flex, Text } from '@audius/harmony-native'
 import { SectionList } from 'app/components/core'
 import { make, track as record } from 'app/services/analytics'
 

--- a/packages/mobile/src/screens/search-screen-v2/searchState.ts
+++ b/packages/mobile/src/screens/search-screen-v2/searchState.ts
@@ -26,6 +26,7 @@ type SearchContextType = {
   setBpmType: Dispatch<SetStateAction<string>>
   autoFocus: boolean
   setAutoFocus: Dispatch<SetStateAction<boolean>>
+  active: boolean
 }
 
 export const SearchContext = createContext<SearchContextType>({
@@ -40,7 +41,8 @@ export const SearchContext = createContext<SearchContextType>({
   setBpmType: (_) => {},
   // Special state to determine if the search query input should be focused automatically
   autoFocus: false,
-  setAutoFocus: (_) => {}
+  setAutoFocus: (_) => {},
+  active: false
 })
 
 export const useIsEmptySearch = () => {

--- a/packages/mobile/src/screens/search-screen-v2/searchState.ts
+++ b/packages/mobile/src/screens/search-screen-v2/searchState.ts
@@ -26,7 +26,6 @@ type SearchContextType = {
   setBpmType: Dispatch<SetStateAction<string>>
   autoFocus: boolean
   setAutoFocus: Dispatch<SetStateAction<boolean>>
-  active: boolean
 }
 
 export const SearchContext = createContext<SearchContextType>({
@@ -41,8 +40,7 @@ export const SearchContext = createContext<SearchContextType>({
   setBpmType: (_) => {},
   // Special state to determine if the search query input should be focused automatically
   autoFocus: false,
-  setAutoFocus: (_) => {},
-  active: false
+  setAutoFocus: (_) => {}
 })
 
 export const useIsEmptySearch = () => {


### PR DESCRIPTION
### Description

The component restructure in #9385 caused the search input on mobile to not accept any values. For some reason calling `setQuery` from `SearchBarV2` was not causing `query` to update in `SearchPageV2`, but I couldn't figure out why. Potentially something to do with `react-navigation` and how it mounts screens.

Anyway, going back to wrapping the search screen in a stack navigator fixes the issue

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._
