### PR TITLE
Add buy button metrics

### DIFF
--- a/packages/common/src/models/Analytics.ts
+++ b/packages/common/src/models/Analytics.ts
@@ -458,6 +458,7 @@ export enum Name {
   STRIPE_REJECTED = 'Stripe Modal: Rejected',
 
   // Purchase Content
+  PURCHASE_CONTENT_BUY_CLICKED = 'Purchase Content: Buy Clicked',
   PURCHASE_CONTENT_STARTED = 'Purchase Content: Started',
   PURCHASE_CONTENT_SUCCESS = 'Purchase Content: Success',
   PURCHASE_CONTENT_FAILURE = 'Purchase Content: Failure',
@@ -2211,6 +2212,12 @@ type ContentPurchaseMetadata = {
   isVerifiedArtist: boolean
 }
 
+type PurchaseContentBuyClicked = {
+  eventName: Name.PURCHASE_CONTENT_BUY_CLICKED
+  contentId: number
+  contentType: string
+}
+
 type PurchaseContentStarted = ContentPurchaseMetadata & {
   eventName: Name.PURCHASE_CONTENT_STARTED
 }
@@ -2715,6 +2722,7 @@ export type AllTrackingEvents =
   | StripeFulfillmentComplete
   | StripeError
   | StripeRejected
+  | PurchaseContentBuyClicked
   | PurchaseContentStarted
   | PurchaseContentSuccess
   | PurchaseContentFailure

--- a/packages/mobile/src/components/details-tile/DetailsTileNoAccess.tsx
+++ b/packages/mobile/src/components/details-tile/DetailsTileNoAccess.tsx
@@ -39,8 +39,10 @@ import LoadingSpinner from 'app/components/loading-spinner'
 import UserBadges from 'app/components/user-badges'
 import { useDrawer } from 'app/hooks/useDrawer'
 import { useNavigation } from 'app/hooks/useNavigation'
+import { make, track } from 'app/services/analytics'
 import { flexRowCentered, makeStyles } from 'app/styles'
 import { spacing } from 'app/styles/spacing'
+import { EventNames } from 'app/types/analytics'
 
 const { getGatedContentStatusMap } = gatedContentSelectors
 const { followUser } = usersSocialActions
@@ -215,6 +217,14 @@ export const DetailsTileNoAccess = (props: DetailsTileNoAccessProps) => {
   }, [tippedUser, navigation, dispatch, source, trackId])
 
   const handlePurchasePress = useCallback(() => {
+    track(
+      make({
+        eventName: EventNames.PURCHASE_CONTENT_BUY_CLICKED,
+        contentId: trackId,
+        contentType
+      })
+    )
+
     openPremiumContentPurchaseModal(
       { contentId: trackId, contentType },
       {

--- a/packages/mobile/src/components/lineup-tile/LineupTileAccessStatus.tsx
+++ b/packages/mobile/src/components/lineup-tile/LineupTileAccessStatus.tsx
@@ -22,8 +22,10 @@ import {
 } from '@audius/harmony-native'
 import LoadingSpinner from 'app/components/loading-spinner'
 import { useIsUSDCEnabled } from 'app/hooks/useIsUSDCEnabled'
+import { make, track } from 'app/services/analytics'
 import { setVisibility } from 'app/store/drawers/slice'
 import { makeStyles } from 'app/styles'
+import { EventNames } from 'app/types/analytics'
 
 import { LineupTileSource } from './types'
 
@@ -73,6 +75,13 @@ export const LineupTileAccessStatus = ({
       return
     }
     if (isUSDCPurchase) {
+      track(
+        make({
+          eventName: EventNames.PURCHASE_CONTENT_BUY_CLICKED,
+          contentId,
+          contentType
+        })
+      )
       const determineModalSource = () => {
         if (tileSource === LineupTileSource.DM_COLLECTION) {
           return ModalSource.DirectMessageCollectionTile

--- a/packages/web/src/components/now-playing/NowPlaying.tsx
+++ b/packages/web/src/components/now-playing/NowPlaying.tsx
@@ -562,6 +562,8 @@ const NowPlaying = g(
               onClick={onClickPill}
               className={styles.premiumPill}
               buttonSize='large'
+              contentId={track_id as ID}
+              contentType='track'
             />
           ) : null}
           <ActionsBar

--- a/packages/web/src/components/play-bar/desktop/components/SocialActions.tsx
+++ b/packages/web/src/components/play-bar/desktop/components/SocialActions.tsx
@@ -82,6 +82,8 @@ export const SocialActions = ({
           streamConditions={track.stream_conditions}
           unlocking={gatedTrackStatus === 'UNLOCKING'}
           onClick={onClickPill}
+          contentId={track.track_id}
+          contentType={'track'}
         />
       ) : (
         <>

--- a/packages/web/src/components/track/GatedConditionsPill.tsx
+++ b/packages/web/src/components/track/GatedConditionsPill.tsx
@@ -2,10 +2,13 @@ import type { MouseEvent } from 'react'
 
 import {
   isContentUSDCPurchaseGated,
-  AccessConditions
+  AccessConditions,
+  Name
 } from '@audius/common/models'
 import { formatPrice } from '@audius/common/utils'
 import { Button, ButtonSize, IconLock } from '@audius/harmony'
+
+import { make, track } from 'services/analytics'
 
 const messages = {
   unlocking: 'Unlocking',
@@ -18,7 +21,9 @@ export const GatedConditionsPill = ({
   unlocking,
   onClick,
   showIcon = true,
-  buttonSize = 'small'
+  buttonSize = 'small',
+  contentId,
+  contentType
 }: {
   streamConditions: AccessConditions
   unlocking: boolean
@@ -26,6 +31,8 @@ export const GatedConditionsPill = ({
   showIcon?: boolean
   className?: string
   buttonSize?: ButtonSize
+  contentId: number
+  contentType: string
 }) => {
   const isPurchase = isContentUSDCPurchaseGated(streamConditions)
 
@@ -43,7 +50,17 @@ export const GatedConditionsPill = ({
     <Button
       className={className}
       size={buttonSize}
-      onClick={onClick}
+      onClick={(e) => {
+        track(
+          make({
+            eventName: Name.PURCHASE_CONTENT_BUY_CLICKED,
+            contentId,
+            contentType
+          })
+        )
+
+        onClick?.(e)
+      }}
       color={isPurchase ? 'lightGreen' : 'blue'}
       isLoading={unlocking}
       iconLeft={showIcon ? IconLock : undefined}

--- a/packages/web/src/components/track/GatedContentSection.tsx
+++ b/packages/web/src/components/track/GatedContentSection.tsx
@@ -1,6 +1,7 @@
 import { useCallback } from 'react'
 
 import {
+  Name,
   FollowSource,
   ModalSource,
   Chain,
@@ -46,6 +47,7 @@ import LoadingSpinner from 'components/loading-spinner/LoadingSpinner'
 import UserBadges from 'components/user-badges/UserBadges'
 import { useAuthenticatedCallback } from 'hooks/useAuthenticatedCallback'
 import { emptyStringGuard } from 'pages/track-page/utils'
+import { make, track } from 'services/analytics'
 import { AppState } from 'store/types'
 import { profilePage } from 'utils/route'
 
@@ -305,7 +307,16 @@ const LockedGatedContentSection = ({
         <Button
           variant='primary'
           color='lightGreen'
-          onClick={handlePurchase}
+          onClick={() => {
+            track(
+              make({
+                eventName: Name.PURCHASE_CONTENT_BUY_CLICKED,
+                contentId,
+                contentType
+              })
+            )
+            handlePurchase()
+          }}
           fullWidth
         >
           {messages.buy(formatPrice(streamConditions.usdc_purchase.price))}

--- a/packages/web/src/components/track/ViewerActionButtons.tsx
+++ b/packages/web/src/components/track/ViewerActionButtons.tsx
@@ -168,6 +168,8 @@ const BaseViewerActionButtons = ({
             streamConditions={streamConditions}
             unlocking={gatedStatus === 'UNLOCKING'}
             onClick={onClickGatedUnlockPill}
+            contentId={contentId}
+            contentType={'track'}
           />
         </Text>
         <Flex>{rightActions}</Flex>

--- a/packages/web/src/components/track/mobile/BottomButtons.tsx
+++ b/packages/web/src/components/track/mobile/BottomButtons.tsx
@@ -37,6 +37,8 @@ type BottomButtonsProps = {
   streamConditions?: Nullable<AccessConditions>
   gatedTrackStatus?: GatedContentStatus
   isMatrixMode: boolean
+  contentId: number
+  contentType: string
 }
 
 const BottomButtons = (props: BottomButtonsProps) => {
@@ -75,6 +77,8 @@ const BottomButtons = (props: BottomButtonsProps) => {
             streamConditions={props.streamConditions}
             unlocking={props.gatedTrackStatus === 'UNLOCKING'}
             onClick={props.onClickGatedUnlockPill}
+            contentId={props.contentId}
+            contentType={props.contentType}
           />
         </Text>
         {props.readonly ? null : moreButton}

--- a/packages/web/src/components/track/mobile/PlaylistTile.tsx
+++ b/packages/web/src/components/track/mobile/PlaylistTile.tsx
@@ -195,6 +195,7 @@ type LockedOrPlaysContentProps = Pick<
   | 'isStreamGated'
   | 'streamConditions'
   | 'variant'
+  | 'id'
 > & {
   lockedContentType: 'premium' | 'gated'
   gatedTrackStatus?: GatedContentStatus
@@ -202,6 +203,7 @@ type LockedOrPlaysContentProps = Pick<
 }
 
 const renderLockedContent = ({
+  id,
   hasStreamAccess,
   isOwner,
   isStreamGated,
@@ -223,6 +225,8 @@ const renderLockedContent = ({
           unlocking={gatedTrackStatus === 'UNLOCKING'}
           onClick={onClickGatedUnlockPill}
           buttonSize='small'
+          contentId={id}
+          contentType={lockedContentType}
         />
       )
     }
@@ -477,6 +481,7 @@ const PlaylistTile = (props: PlaylistTileProps & ExtraProps) => {
               className={cn(styles.bottomRight, fadeIn)}
             >
               {renderLockedContent({
+                id,
                 hasStreamAccess,
                 isOwner,
                 isStreamGated,
@@ -515,6 +520,8 @@ const PlaylistTile = (props: PlaylistTileProps & ExtraProps) => {
               hasStreamAccess={props.hasStreamAccess}
               streamConditions={props.streamConditions}
               isUnlisted={isUnlisted}
+              contentId={id}
+              contentType='playlist'
             />
           </div>
         ) : null}

--- a/packages/web/src/components/track/mobile/TrackTile.tsx
+++ b/packages/web/src/components/track/mobile/TrackTile.tsx
@@ -69,12 +69,14 @@ type ExtraProps = {
   streamConditions?: Nullable<AccessConditions>
   hasPreview?: boolean
   hasStreamAccess: boolean
+  trackId?: number
 }
 
 type CombinedProps = TrackTileProps & ExtraProps
 
 type LockedOrPlaysContentProps = Pick<
   CombinedProps,
+  | 'trackId'
   | 'hasStreamAccess'
   | 'isOwner'
   | 'isStreamGated'
@@ -88,6 +90,7 @@ type LockedOrPlaysContentProps = Pick<
 }
 
 const renderLockedContentOrPlayCount = ({
+  trackId,
   hasStreamAccess,
   isOwner,
   isStreamGated,
@@ -102,7 +105,8 @@ const renderLockedContentOrPlayCount = ({
     if (
       !hasStreamAccess &&
       lockedContentType === 'premium' &&
-      variant === 'readonly'
+      variant === 'readonly' &&
+      trackId
     ) {
       return (
         <GatedConditionsPill
@@ -110,6 +114,8 @@ const renderLockedContentOrPlayCount = ({
           unlocking={gatedTrackStatus === 'UNLOCKING'}
           onClick={onClickGatedUnlockPill}
           buttonSize='small'
+          contentId={trackId}
+          contentType='track'
         />
       )
     }
@@ -452,6 +458,7 @@ const TrackTile = (props: CombinedProps) => {
           >
             {!isLoading
               ? renderLockedContentOrPlayCount({
+                  trackId: id,
                   hasStreamAccess,
                   isOwner,
                   isStreamGated,
@@ -485,6 +492,8 @@ const TrackTile = (props: CombinedProps) => {
             isDarkMode={darkMode}
             isMatrixMode={isMatrix}
             isTrack
+            contentId={id}
+            contentType='track'
           />
         )}
       </div>

--- a/packages/web/src/components/tracks-table/TracksTable.tsx
+++ b/packages/web/src/components/tracks-table/TracksTable.tsx
@@ -553,6 +553,8 @@ export const TracksTable = ({
           }}
           buttonSize='small'
           showIcon={false}
+          contentId={track.track_id}
+          contentType='track'
         />
       )
     },


### PR DESCRIPTION
### Description

Adding amplitude metrics on all buy buttons. This will help determine if a button clicked redirects to sign up or the premium purchase modal. Which may inform certain features.

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._

Ran on mobile, web, mobile web. Confirmed all buttons are logging metrics.