### PR TITLE
Fix duplicate error name in sentry

### DIFF
--- a/packages/web/src/common/store/pages/audio-rewards/sagas.ts
+++ b/packages/web/src/common/store/pages/audio-rewards/sagas.ts
@@ -375,7 +375,7 @@ function* claimSingleChallengeRewardAsync(
       } else {
         yield* call(reportToSentry, {
           error,
-          name: `ClaimRewards: ${error.name}`,
+          name: 'ClaimRewards',
           additionalInfo: {
             challengeId,
             specifier: res.specifier,

--- a/packages/web/src/common/store/tipping/sagas.ts
+++ b/packages/web/src/common/store/tipping/sagas.ts
@@ -411,7 +411,7 @@ function* sendTipAsync() {
       })
     )
     yield* call(reportToSentry, {
-      name: `SendTip: ${e.name}`,
+      name: 'SendTip',
       error: e,
       additionalInfo: {
         senderUserId,

--- a/packages/web/src/common/store/upload/sagas.test.ts
+++ b/packages/web/src/common/store/upload/sagas.test.ts
@@ -270,7 +270,7 @@ describe('upload', () => {
         ])
         // Reports to sentry
         .call(reportToSentry, {
-          name: 'Upload Worker Failed: Error',
+          name: 'Upload Worker Failed',
           error: mockError,
           additionalInfo: {
             trackId: 3,
@@ -289,7 +289,7 @@ describe('upload', () => {
           fn: reportToSentry,
           args: [
             {
-              name: 'Upload Worker Failed: Error',
+              name: 'Upload Worker Failed',
               additionalInfo: {
                 trackId: 1,
                 metadata: testTrack.metadata,

--- a/packages/web/src/common/store/upload/sagas.ts
+++ b/packages/web/src/common/store/upload/sagas.ts
@@ -624,7 +624,7 @@ export function* handleUploads({
     // Report to sentry
     const e = error instanceof Error ? error : new Error(String(error))
     yield* call(reportToSentry, {
-      name: `Upload Worker Failed: ${e.name}`,
+      name: 'Upload Worker Failed',
       error: e,
       additionalInfo: {
         trackId,

--- a/packages/web/src/common/store/upload/sagas.ts
+++ b/packages/web/src/common/store/upload/sagas.ts
@@ -928,7 +928,7 @@ export function* uploadCollection(
         }
         // Handle error loses error details, so call reportToSentry explicitly
         yield* call(reportToSentry, {
-          name: `Upload: ${error.name}`,
+          name: 'Upload',
           error,
           additionalInfo: {
             trackIds,


### PR DESCRIPTION
Was resulting in silly looking errors in Sentry like `ClaimRewards: ResponseError: ResponseError`
