### PR TITLE
Compose Solana Client in SDK

### DIFF
--- a/.changeset/strong-bugs-invite.md
+++ b/.changeset/strong-bugs-invite.md
@@ -1,0 +1,5 @@
+---
+'@audius/sdk': major
+---
+
+Change Solana program clients to use composition over inheritance

--- a/packages/common/src/services/audius-backend/solana.ts
+++ b/packages/common/src/services/audius-backend/solana.ts
@@ -782,11 +782,11 @@ export const recoverUsdcFromRootWallet = async ({
       ],
       mint: 'USDC'
     })
-  const transaction = await sdk.services.claimableTokensClient.buildTransaction(
-    { instructions: [memoInstruction, transferInstruction, routeInstruction] }
-  )
+  const transaction = await sdk.services.solanaClient.buildTransaction({
+    instructions: [memoInstruction, transferInstruction, routeInstruction]
+  })
   transaction.sign([sender])
-  const signature = await sdk.services.paymentRouterClient.sendTransaction(
+  const signature = await sdk.services.claimableTokensClient.sendTransaction(
     transaction,
     { skipPreflight: true }
   )
@@ -902,10 +902,9 @@ export const transferFromUserBank = async ({
       instructions.push(memoInstruction)
     }
 
-    const transaction =
-      await sdk.services.claimableTokensClient.buildTransaction({
-        instructions
-      })
+    const transaction = await sdk.services.solanaClient.buildTransaction({
+      instructions
+    })
 
     if (signer) {
       transaction.sign([signer])

--- a/packages/libs/src/sdk/api/albums/AlbumsApi.test.ts
+++ b/packages/libs/src/sdk/api/albums/AlbumsApi.test.ts
@@ -18,6 +18,7 @@ import {
   PaymentRouterClient,
   getDefaultPaymentRouterClientConfig
 } from '../../services/Solana/programs/PaymentRouterClient'
+import { SolanaClient } from '../../services/Solana/programs/SolanaClient'
 import { Storage } from '../../services/Storage'
 import { StorageNodeSelector } from '../../services/StorageNodeSelector'
 import { Genre } from '../../types/Genre'
@@ -133,6 +134,9 @@ describe('AlbumsApi', () => {
         })
       )
     })
+    const solanaClient = new SolanaClient({
+      solanaWalletAdapter
+    })
     albums = new AlbumsApi(
       new Configuration(),
       new Storage({ storageNodeSelector, logger: new Logger() }),
@@ -141,17 +145,18 @@ describe('AlbumsApi', () => {
       logger,
       new ClaimableTokensClient({
         ...getDefaultClaimableTokensConfig(developmentConfig),
-        solanaWalletAdapter
+        solanaClient
       }),
       new PaymentRouterClient({
         ...getDefaultPaymentRouterClientConfig(developmentConfig),
-        solanaWalletAdapter
+        solanaClient
       }),
       new SolanaRelay(
         new Configuration({
           middleware: [discoveryNodeSelector.createMiddleware()]
         })
-      )
+      ),
+      solanaClient
     )
     jest.spyOn(console, 'warn').mockImplementation(() => {})
     jest.spyOn(console, 'info').mockImplementation(() => {})

--- a/packages/libs/src/sdk/api/albums/AlbumsApi.ts
+++ b/packages/libs/src/sdk/api/albums/AlbumsApi.ts
@@ -12,6 +12,7 @@ import type {
   AdvancedOptions
 } from '../../services/EntityManager/types'
 import type { LoggerService } from '../../services/Logger'
+import type { SolanaClient } from '../../services/Solana/programs/SolanaClient'
 import { parseParams } from '../../utils/parseParams'
 import { prepareSplits } from '../../utils/preparePaymentSplits'
 import {
@@ -55,7 +56,8 @@ export class AlbumsApi {
     private logger: LoggerService,
     private claimableTokensClient: ClaimableTokensClient,
     private paymentRouterClient: PaymentRouterClient,
-    private solanaRelay: SolanaRelayService
+    private solanaRelay: SolanaRelayService,
+    private solanaClient: SolanaClient
   ) {
     this.playlistsApi = new PlaylistsApi(
       configuration,
@@ -349,7 +351,7 @@ export class AlbumsApi {
           total,
           mint
         })
-      const transaction = await this.paymentRouterClient.buildTransaction({
+      const transaction = await this.solanaClient.buildTransaction({
         feePayer: wallet,
         instructions: [
           transferInstruction,
@@ -387,7 +389,7 @@ export class AlbumsApi {
           destination: paymentRouterTokenAccount.address,
           mint
         })
-      const transaction = await this.paymentRouterClient.buildTransaction({
+      const transaction = await this.solanaClient.buildTransaction({
         instructions: [
           transferSecpInstruction,
           transferInstruction,
@@ -416,9 +418,9 @@ export class AlbumsApi {
       }
       return await params.walletAdapter.sendTransaction(
         transaction,
-        this.paymentRouterClient.connection
+        this.solanaClient.connection
       )
     }
-    return this.paymentRouterClient.sendTransaction(transaction)
+    return this.solanaClient.sendTransaction(transaction)
   }
 }

--- a/packages/libs/src/sdk/api/challenges/ChallengesApi.ts
+++ b/packages/libs/src/sdk/api/challenges/ChallengesApi.ts
@@ -8,6 +8,7 @@ import type {
 } from '../../services'
 import { AntiAbuseOracleService } from '../../services/AntiAbuseOracle/types'
 import type { RewardManagerClient } from '../../services/Solana/programs/RewardManagerClient/RewardManagerClient'
+import type { SolanaClient } from '../../services/Solana/programs/SolanaClient'
 import { AntiAbuseOracleAttestationError } from '../../utils/errors'
 import { parseParams } from '../../utils/parseParams'
 import { BaseAPI, Configuration } from '../generated/default'
@@ -35,7 +36,8 @@ export class ChallengesApi extends BaseAPI {
     private readonly rewardManager: RewardManagerClient,
     private readonly claimableTokens: ClaimableTokensClient,
     private readonly antiAbuseOracle: AntiAbuseOracleService,
-    private readonly logger: LoggerService
+    private readonly logger: LoggerService,
+    private readonly solanaClient: SolanaClient
   ) {
     super(config)
     this.logger = logger.createPrefixedLogger('[challenges-api]')
@@ -177,7 +179,7 @@ export class ChallengesApi extends BaseAPI {
       })
 
     logger.debug('Confirming all attestation submissions...')
-    await this.rewardManager.confirmAllTransactions(
+    await this.solanaClient.confirmAllTransactions(
       attestationTransactionSignatures
     )
 
@@ -242,7 +244,7 @@ export class ChallengesApi extends BaseAPI {
         specifier,
         senderEthAddress: antiAbuseOracleEthAddress
       })
-    const submitAAOTransaction = await this.rewardManager.buildTransaction({
+    const submitAAOTransaction = await this.solanaClient.buildTransaction({
       instructions: [aaoSubmitSecpInstruction, aaoSubmitInstruction]
     })
     return {
@@ -316,7 +318,7 @@ export class ChallengesApi extends BaseAPI {
           specifier,
           senderEthAddress
         })
-      const submitTransaction = await this.rewardManager.buildTransaction({
+      const submitTransaction = await this.solanaClient.buildTransaction({
         instructions: [secpInstruction, submitInstruction]
       })
       transactions.push(submitTransaction)
@@ -350,7 +352,7 @@ export class ChallengesApi extends BaseAPI {
         antiAbuseOracleEthAddress,
         amount
       })
-    const transaction = await this.rewardManager.buildTransaction({
+    const transaction = await this.solanaClient.buildTransaction({
       instructions: [instruction]
     })
     // Skip preflight since we likely just submitted the attestations and

--- a/packages/libs/src/sdk/api/tracks/TracksApi.test.ts
+++ b/packages/libs/src/sdk/api/tracks/TracksApi.test.ts
@@ -18,6 +18,7 @@ import {
   ClaimableTokensClient,
   getDefaultClaimableTokensConfig
 } from '../../services/Solana/programs/ClaimableTokensClient'
+import { SolanaClient } from '../../services/Solana/programs/SolanaClient'
 import { Storage } from '../../services/Storage'
 import { StorageNodeSelector } from '../../services/StorageNodeSelector'
 import { Genre } from '../../types/Genre'
@@ -106,6 +107,9 @@ describe('TracksApi', () => {
         })
       )
     })
+    const solanaClient = new SolanaClient({
+      solanaWalletAdapter
+    })
     tracks = new TracksApi(
       new Configuration(),
       new DiscoveryNodeSelector(),
@@ -115,17 +119,18 @@ describe('TracksApi', () => {
       new Logger(),
       new ClaimableTokensClient({
         ...getDefaultClaimableTokensConfig(developmentConfig),
-        solanaWalletAdapter
+        solanaClient
       }),
       new PaymentRouterClient({
         ...getDefaultPaymentRouterClientConfig(developmentConfig),
-        solanaWalletAdapter
+        solanaClient
       }),
       new SolanaRelay(
         new Configuration({
           middleware: [discoveryNodeSelector.createMiddleware()]
         })
-      )
+      ),
+      solanaClient
     )
     jest.spyOn(console, 'warn').mockImplementation(() => {})
     jest.spyOn(console, 'info').mockImplementation(() => {})

--- a/packages/libs/src/sdk/api/tracks/TracksApi.ts
+++ b/packages/libs/src/sdk/api/tracks/TracksApi.ts
@@ -15,6 +15,7 @@ import {
   AdvancedOptions
 } from '../../services/EntityManager/types'
 import type { LoggerService } from '../../services/Logger'
+import type { SolanaClient } from '../../services/Solana/programs/SolanaClient'
 import type { StorageService } from '../../services/Storage'
 import { encodeHashId } from '../../utils/hashId'
 import { parseParams } from '../../utils/parseParams'
@@ -66,7 +67,8 @@ export class TracksApi extends GeneratedTracksApi {
     private readonly logger: LoggerService,
     private readonly claimableTokensClient: ClaimableTokensClient,
     private readonly paymentRouterClient: PaymentRouterClient,
-    private readonly solanaRelay: SolanaRelayService
+    private readonly solanaRelay: SolanaRelayService,
+    private readonly solanaClient: SolanaClient
   ) {
     super(configuration)
     this.trackUploadHelper = new TrackUploadHelper(configuration)
@@ -530,7 +532,7 @@ export class TracksApi extends GeneratedTracksApi {
           total,
           mint
         })
-      const transaction = await this.paymentRouterClient.buildTransaction({
+      const transaction = await this.solanaClient.buildTransaction({
         feePayer: wallet,
         instructions: [
           transferInstruction,
@@ -568,7 +570,7 @@ export class TracksApi extends GeneratedTracksApi {
           destination: paymentRouterTokenAccount.address,
           mint
         })
-      const transaction = await this.paymentRouterClient.buildTransaction({
+      const transaction = await this.solanaClient.buildTransaction({
         instructions: [
           transferSecpInstruction,
           transferInstruction,
@@ -597,9 +599,9 @@ export class TracksApi extends GeneratedTracksApi {
       }
       return await params.walletAdapter.sendTransaction(
         transaction,
-        this.paymentRouterClient.connection
+        this.solanaClient.connection
       )
     }
-    return this.paymentRouterClient.sendTransaction(transaction)
+    return this.solanaClient.sendTransaction(transaction)
   }
 }

--- a/packages/libs/src/sdk/api/users/UsersApi.test.ts
+++ b/packages/libs/src/sdk/api/users/UsersApi.test.ts
@@ -23,6 +23,7 @@ import {
 import { DiscoveryNodeSelector } from '../../services/DiscoveryNodeSelector'
 import { EntityManager } from '../../services/EntityManager'
 import { Logger } from '../../services/Logger'
+import { SolanaClient } from '../../services/Solana/programs/SolanaClient'
 import { Storage } from '../../services/Storage'
 import { StorageNodeSelector } from '../../services/StorageNodeSelector'
 import { getReaction } from '../../utils/reactionsMap'
@@ -76,9 +77,12 @@ const storageNodeSelector = new StorageNodeSelector({
   logger
 })
 const solanaRelay = new SolanaRelay()
+const solanaClient = new SolanaClient({
+  solanaWalletAdapter: new SolanaRelayWalletAdapter({ solanaRelay })
+})
 const claimableTokens = new ClaimableTokensClient({
   ...getDefaultClaimableTokensConfig(developmentConfig),
-  solanaWalletAdapter: new SolanaRelayWalletAdapter({ solanaRelay })
+  solanaClient
 })
 
 describe('UsersApi', () => {
@@ -89,7 +93,8 @@ describe('UsersApi', () => {
       new EntityManager({ discoveryNodeSelector: new DiscoveryNodeSelector() }),
       auth,
       new Logger(),
-      claimableTokens
+      claimableTokens,
+      solanaClient
     )
     jest.spyOn(console, 'warn').mockImplementation(() => {})
     jest.spyOn(console, 'info').mockImplementation(() => {})

--- a/packages/libs/src/sdk/api/users/UsersApi.ts
+++ b/packages/libs/src/sdk/api/users/UsersApi.ts
@@ -9,6 +9,7 @@ import {
 } from '../../services/EntityManager/types'
 import type { LoggerService } from '../../services/Logger'
 import type { ClaimableTokensClient } from '../../services/Solana/programs/ClaimableTokensClient/ClaimableTokensClient'
+import type { SolanaClient } from '../../services/Solana/programs/SolanaClient'
 import { parseParams } from '../../utils/parseParams'
 import { retry3 } from '../../utils/retry'
 import {
@@ -44,7 +45,8 @@ export class UsersApi extends GeneratedUsersApi {
     private readonly entityManager: EntityManagerService,
     private readonly auth: AuthService,
     private readonly logger: LoggerService,
-    private readonly claimableTokens: ClaimableTokensClient
+    private readonly claimableTokens: ClaimableTokensClient,
+    private readonly solanaClient: SolanaClient
   ) {
     super(configuration)
     this.logger = logger.createPrefixedLogger('[users-api]')
@@ -339,7 +341,7 @@ export class UsersApi extends GeneratedUsersApi {
       mint: 'wAUDIO'
     })
 
-    const transaction = await this.claimableTokens.buildTransaction({
+    const transaction = await this.solanaClient.buildTransaction({
       instructions: [secp, transfer]
     })
     return await this.claimableTokens.sendTransaction(transaction)

--- a/packages/libs/src/sdk/sdk.ts
+++ b/packages/libs/src/sdk/sdk.ts
@@ -59,6 +59,8 @@ import {
   RewardManagerClient,
   getDefaultRewardManagerClentConfig
 } from './services/Solana/programs/RewardManagerClient'
+import { SolanaClient } from './services/Solana/programs/SolanaClient'
+import { getDefaultSolanaClientConfig } from './services/Solana/programs/getDefaultConfig'
 import { Storage, getDefaultStorageServiceConfig } from './services/Storage'
 import {
   StorageNodeSelector,
@@ -189,28 +191,32 @@ const initializeServices = (config: SdkConfig) => {
       solanaRelay
     })
 
+  const solanaClient =
+    config.services?.solanaClient ??
+    new SolanaClient({
+      ...getDefaultSolanaClientConfig(servicesConfig),
+      solanaWalletAdapter
+    })
+
   const claimableTokensClient =
     config.services?.claimableTokensClient ??
     new ClaimableTokensClient({
       ...getDefaultClaimableTokensConfig(servicesConfig),
-      solanaWalletAdapter,
-      logger
+      solanaClient
     })
 
   const rewardManagerClient =
     config.services?.rewardManagerClient ??
     new RewardManagerClient({
       ...getDefaultRewardManagerClentConfig(servicesConfig),
-      solanaWalletAdapter,
-      logger
+      solanaClient
     })
 
   const paymentRouterClient =
     config.services?.paymentRouterClient ??
     new PaymentRouterClient({
       ...getDefaultPaymentRouterClientConfig(servicesConfig),
-      solanaWalletAdapter,
-      logger
+      solanaClient
     })
 
   const services: ServicesContainer = {
@@ -223,6 +229,7 @@ const initializeServices = (config: SdkConfig) => {
     claimableTokensClient,
     rewardManagerClient,
     paymentRouterClient,
+    solanaClient,
     solanaWalletAdapter,
     solanaRelay,
     antiAbuseOracle,

--- a/packages/libs/src/sdk/sdk.ts
+++ b/packages/libs/src/sdk/sdk.ts
@@ -266,7 +266,8 @@ const initializeApis = ({
     services.logger,
     services.claimableTokensClient,
     services.paymentRouterClient,
-    services.solanaRelay
+    services.solanaRelay,
+    services.solanaClient
   )
   const users = new UsersApi(
     generatedApiClientConfig,
@@ -274,7 +275,8 @@ const initializeApis = ({
     services.entityManager,
     services.auth,
     services.logger,
-    services.claimableTokensClient
+    services.claimableTokensClient,
+    services.solanaClient
   )
   const albums = new AlbumsApi(
     generatedApiClientConfig,
@@ -284,7 +286,8 @@ const initializeApis = ({
     services.logger,
     services.claimableTokensClient,
     services.paymentRouterClient,
-    services.solanaRelay
+    services.solanaRelay,
+    services.solanaClient
   )
   const playlists = new PlaylistsApi(
     generatedApiClientConfig,
@@ -337,7 +340,8 @@ const initializeApis = ({
     services.rewardManagerClient,
     services.claimableTokensClient,
     services.antiAbuseOracle,
-    services.logger
+    services.logger,
+    services.solanaClient
   )
 
   const generatedApiClientConfigFull = new ConfigurationFull({

--- a/packages/libs/src/sdk/services/Solana/programs/ClaimableTokensClient/getDefaultConfig.ts
+++ b/packages/libs/src/sdk/services/Solana/programs/ClaimableTokensClient/getDefaultConfig.ts
@@ -9,7 +9,6 @@ export const getDefaultClaimableTokensConfig = (
   config: SdkServicesConfig
 ): ClaimableTokensConfigInternal => ({
   programId: new PublicKey(config.solana.claimableTokensProgramAddress),
-  rpcEndpoint: config.solana.rpcEndpoint,
   mints: {
     wAUDIO: new PublicKey(config.solana.wAudioTokenMint),
     USDC: new PublicKey(config.solana.usdcTokenMint)

--- a/packages/libs/src/sdk/services/Solana/programs/ClaimableTokensClient/types.ts
+++ b/packages/libs/src/sdk/services/Solana/programs/ClaimableTokensClient/types.ts
@@ -3,6 +3,7 @@ import { z } from 'zod'
 
 import type { Prettify } from '../../../../utils/prettify'
 import type { AuthService } from '../../../Auth'
+import type { LoggerService } from '../../../Logger'
 import { TokenName, MintSchema, PublicKeySchema } from '../../types'
 import type { SolanaClient } from '../SolanaClient'
 
@@ -11,6 +12,7 @@ export type ClaimableTokensConfigInternal = {
   programId: PublicKey
   /** Map from token mint name to public key address. */
   mints: Record<TokenName, PublicKey>
+  logger: LoggerService
 }
 
 export type ClaimableTokensConfig = Prettify<

--- a/packages/libs/src/sdk/services/Solana/programs/ClaimableTokensClient/types.ts
+++ b/packages/libs/src/sdk/services/Solana/programs/ClaimableTokensClient/types.ts
@@ -3,25 +3,20 @@ import { z } from 'zod'
 
 import type { Prettify } from '../../../../utils/prettify'
 import type { AuthService } from '../../../Auth'
-import {
-  TokenName,
-  MintSchema,
-  PublicKeySchema,
-  SolanaWalletAdapter
-} from '../../types'
-import type { BaseSolanaProgramConfigInternal } from '../types'
+import { TokenName, MintSchema, PublicKeySchema } from '../../types'
+import type { SolanaClient } from '../SolanaClient'
 
 export type ClaimableTokensConfigInternal = {
   /** The program ID of the ClaimableTokensProgram instance. */
   programId: PublicKey
   /** Map from token mint name to public key address. */
   mints: Record<TokenName, PublicKey>
-} & BaseSolanaProgramConfigInternal
+}
 
 export type ClaimableTokensConfig = Prettify<
   Partial<Omit<ClaimableTokensConfigInternal, 'mints'>> & {
+    solanaClient: SolanaClient
     mints?: Prettify<Partial<Record<TokenName, PublicKey>>>
-    solanaWalletAdapter: SolanaWalletAdapter
   }
 >
 

--- a/packages/libs/src/sdk/services/Solana/programs/PaymentRouterClient/getDefaultConfig.ts
+++ b/packages/libs/src/sdk/services/Solana/programs/PaymentRouterClient/getDefaultConfig.ts
@@ -1,7 +1,6 @@
 import { PublicKey } from '@solana/web3.js'
 
 import { SdkServicesConfig } from '../../../../config/types'
-import { Logger } from '../../../Logger'
 
 import { PaymentRouterClientConfigInternal } from './types'
 

--- a/packages/libs/src/sdk/services/Solana/programs/PaymentRouterClient/getDefaultConfig.ts
+++ b/packages/libs/src/sdk/services/Solana/programs/PaymentRouterClient/getDefaultConfig.ts
@@ -9,7 +9,6 @@ export const getDefaultPaymentRouterClientConfig = (
   config: SdkServicesConfig
 ): PaymentRouterClientConfigInternal => ({
   programId: new PublicKey(config.solana.paymentRouterProgramAddress),
-  rpcEndpoint: config.solana.rpcEndpoint,
   mints: {
     USDC: new PublicKey(config.solana.usdcTokenMint),
     wAUDIO: new PublicKey(config.solana.wAudioTokenMint)

--- a/packages/libs/src/sdk/services/Solana/programs/PaymentRouterClient/getDefaultConfig.ts
+++ b/packages/libs/src/sdk/services/Solana/programs/PaymentRouterClient/getDefaultConfig.ts
@@ -12,6 +12,5 @@ export const getDefaultPaymentRouterClientConfig = (
   mints: {
     USDC: new PublicKey(config.solana.usdcTokenMint),
     wAUDIO: new PublicKey(config.solana.wAudioTokenMint)
-  },
-  logger: new Logger()
+  }
 })

--- a/packages/libs/src/sdk/services/Solana/programs/PaymentRouterClient/types.ts
+++ b/packages/libs/src/sdk/services/Solana/programs/PaymentRouterClient/types.ts
@@ -3,22 +3,17 @@ import { z } from 'zod'
 
 import { HashId } from '../../../../types/HashId'
 import { Prettify } from '../../../../utils/prettify'
-import {
-  TokenName,
-  MintSchema,
-  PublicKeySchema,
-  SolanaWalletAdapter
-} from '../../types'
-import { BaseSolanaProgramConfigInternal } from '../types'
+import { TokenName, MintSchema, PublicKeySchema } from '../../types'
+import type { SolanaClient } from '../SolanaClient'
 
 export type PaymentRouterClientConfigInternal = {
   programId: PublicKey
   mints: Prettify<Partial<Record<TokenName, PublicKey>>>
-} & BaseSolanaProgramConfigInternal
+}
 
 export type PaymentRouterClientConfig =
   Partial<PaymentRouterClientConfigInternal> & {
-    solanaWalletAdapter: SolanaWalletAdapter
+    solanaClient: SolanaClient
   }
 
 export const CreateTransferInstructionSchema = z.object({

--- a/packages/libs/src/sdk/services/Solana/programs/RewardManagerClient/RewardManagerClient.ts
+++ b/packages/libs/src/sdk/services/Solana/programs/RewardManagerClient/RewardManagerClient.ts
@@ -17,6 +17,8 @@ import {
 import { productionConfig } from '../../../../config/production'
 import { mergeConfigWithDefaults } from '../../../../utils/mergeConfigs'
 import { parseParams } from '../../../../utils/parseParams'
+import type { LoggerService } from '../../../Logger'
+import { CustomInstructionError } from '../CustomInstructionError'
 import { SolanaClient } from '../SolanaClient'
 
 import { getDefaultRewardManagerClentConfig } from './getDefaultConfig'
@@ -72,6 +74,7 @@ export class RewardManagerClient {
   private readonly rewardManagerStateAccount: PublicKey
   private readonly authority: PublicKey
   private rewardManagerState: RewardManagerStateData | null = null
+  private readonly logger: LoggerService
 
   constructor(config: RewardManagerClientConfig) {
     const configWithDefaults = mergeConfigWithDefaults(
@@ -85,6 +88,7 @@ export class RewardManagerClient {
       programId: configWithDefaults.programId,
       rewardManagerState: configWithDefaults.rewardManagerState
     })
+    this.logger = configWithDefaults.logger
   }
 
   public async createSenderInstruction(params: CreateSenderInstructionRequest) {
@@ -299,7 +303,7 @@ export class RewardManagerClient {
         try {
           const error = CustomInstructionError.parseSendTransactionError(e)
           if (error) {
-            const instructions = await this.getInstructions(transaction)
+            const instructions = await this.client.getInstructions(transaction)
             const instruction = instructions[error.instructionIndex]
             if (instruction && instruction.programId.equals(this.programId)) {
               const decodedInstruction =

--- a/packages/libs/src/sdk/services/Solana/programs/RewardManagerClient/getDefaultConfig.ts
+++ b/packages/libs/src/sdk/services/Solana/programs/RewardManagerClient/getDefaultConfig.ts
@@ -9,7 +9,5 @@ export const getDefaultRewardManagerClentConfig = (
   config: SdkServicesConfig
 ): RewardManagerClientConfigInternal => ({
   programId: new PublicKey(config.solana.rewardManagerProgramAddress),
-  rpcEndpoint: config.solana.rpcEndpoint,
-  rewardManagerState: new PublicKey(config.solana.rewardManagerStateAddress),
-  logger: new Logger()
+  rewardManagerState: new PublicKey(config.solana.rewardManagerStateAddress)
 })

--- a/packages/libs/src/sdk/services/Solana/programs/RewardManagerClient/getDefaultConfig.ts
+++ b/packages/libs/src/sdk/services/Solana/programs/RewardManagerClient/getDefaultConfig.ts
@@ -9,5 +9,6 @@ export const getDefaultRewardManagerClentConfig = (
   config: SdkServicesConfig
 ): RewardManagerClientConfigInternal => ({
   programId: new PublicKey(config.solana.rewardManagerProgramAddress),
-  rewardManagerState: new PublicKey(config.solana.rewardManagerStateAddress)
+  rewardManagerState: new PublicKey(config.solana.rewardManagerStateAddress),
+  logger: new Logger()
 })

--- a/packages/libs/src/sdk/services/Solana/programs/RewardManagerClient/types.ts
+++ b/packages/libs/src/sdk/services/Solana/programs/RewardManagerClient/types.ts
@@ -1,17 +1,17 @@
 import type { PublicKey } from '@solana/web3.js'
 import { z } from 'zod'
 
-import { PublicKeySchema, SolanaWalletAdapter } from '../../types'
-import type { BaseSolanaProgramConfigInternal } from '../types'
+import { PublicKeySchema } from '../../types'
+import type { SolanaClient } from '../SolanaClient'
 
 export type RewardManagerClientConfigInternal = {
   programId: PublicKey
   rewardManagerState: PublicKey
-} & BaseSolanaProgramConfigInternal
+}
 
 export type RewardManagerClientConfig =
   Partial<RewardManagerClientConfigInternal> & {
-    solanaWalletAdapter: SolanaWalletAdapter
+    solanaClient: SolanaClient
   }
 
 export const CreateSenderInstructionSchema = z.object({

--- a/packages/libs/src/sdk/services/Solana/programs/RewardManagerClient/types.ts
+++ b/packages/libs/src/sdk/services/Solana/programs/RewardManagerClient/types.ts
@@ -1,12 +1,14 @@
 import type { PublicKey } from '@solana/web3.js'
 import { z } from 'zod'
 
+import type { LoggerService } from '../../../Logger'
 import { PublicKeySchema } from '../../types'
 import type { SolanaClient } from '../SolanaClient'
 
 export type RewardManagerClientConfigInternal = {
   programId: PublicKey
   rewardManagerState: PublicKey
+  logger: LoggerService
 }
 
 export type RewardManagerClientConfig =

--- a/packages/libs/src/sdk/services/Solana/programs/SolanaClient.ts
+++ b/packages/libs/src/sdk/services/Solana/programs/SolanaClient.ts
@@ -12,7 +12,6 @@ import { z } from 'zod'
 import { productionConfig } from '../../../config/production'
 import { mergeConfigWithDefaults } from '../../../utils/mergeConfigs'
 import { parseParams } from '../../../utils/parseParams'
-import { LoggerService } from '../../Logger'
 import type { SolanaWalletAdapter } from '../types'
 
 import { getDefaultSolanaClientConfig } from './getDefaultConfig'
@@ -191,25 +190,10 @@ export class SolanaClient {
   }
 
   /**
-   * Fetches the address look up tables for populating transaction objects
-   */
-  protected async getLookupTableAccounts(lookupTableKeys: PublicKey[]) {
-    return await Promise.all(
-      lookupTableKeys.map(async (accountKey) => {
-        const res = await this.connection.getAddressLookupTable(accountKey)
-        if (res.value === null) {
-          throw new Error(`Lookup table not found: ${accountKey.toBase58()}`)
-        }
-        return res.value
-      })
-    )
-  }
-
-  /**
    * Normalizes the instructions as TransactionInstruction whether from
    * versioned transactions or legacy transactions.
    */
-  protected async getInstructions(
+  public async getInstructions(
     transaction: VersionedTransaction | Transaction
   ) {
     if ('version' in transaction) {
@@ -223,5 +207,20 @@ export class SolanaClient {
     } else {
       return transaction.instructions
     }
+  }
+
+  /**
+   * Fetches the address look up tables for populating transaction objects
+   */
+  public async getLookupTableAccounts(lookupTableKeys: PublicKey[]) {
+    return await Promise.all(
+      lookupTableKeys.map(async (accountKey) => {
+        const res = await this.connection.getAddressLookupTable(accountKey)
+        if (res.value === null) {
+          throw new Error(`Lookup table not found: ${accountKey.toBase58()}`)
+        }
+        return res.value
+      })
+    )
   }
 }

--- a/packages/libs/src/sdk/services/Solana/programs/getDefaultConfig.ts
+++ b/packages/libs/src/sdk/services/Solana/programs/getDefaultConfig.ts
@@ -1,0 +1,9 @@
+import type { SdkServicesConfig } from '../../../config/types'
+
+import type { SolanaClientConfigInternal } from './types'
+
+export const getDefaultSolanaClientConfig = (
+  servicesConfig: SdkServicesConfig
+): SolanaClientConfigInternal => ({
+  rpcEndpoints: [servicesConfig.solana.rpcEndpoint]
+})

--- a/packages/libs/src/sdk/services/Solana/programs/types.ts
+++ b/packages/libs/src/sdk/services/Solana/programs/types.ts
@@ -12,7 +12,6 @@ export type SolanaClientConfigInternal = {
   rpcEndpoints: string[]
   /** Configuration to use for the RPC connection. */
   rpcConfig?: ConnectionConfig
-  logger: LoggerService
 }
 
 export type SolanaClientConfig = Partial<SolanaClientConfigInternal> & {

--- a/packages/libs/src/sdk/services/Solana/programs/types.ts
+++ b/packages/libs/src/sdk/services/Solana/programs/types.ts
@@ -5,15 +5,18 @@ import {
 } from '@solana/web3.js'
 import { z } from 'zod'
 
-import { LoggerService } from '../../Logger'
-import { PublicKeySchema } from '../types'
+import { PublicKeySchema, type SolanaWalletAdapter } from '../types'
 
-export type BaseSolanaProgramConfigInternal = {
+export type SolanaClientConfigInternal = {
   /** Connection to interact with the Solana RPC */
-  rpcEndpoint: string
+  rpcEndpoints: string[]
   /** Configuration to use for the RPC connection. */
   rpcConfig?: ConnectionConfig
   logger: LoggerService
+}
+
+export type SolanaClientConfig = Partial<SolanaClientConfigInternal> & {
+  solanaWalletAdapter: SolanaWalletAdapter
 }
 
 export const PrioritySchema = z.enum([

--- a/packages/libs/src/sdk/types.ts
+++ b/packages/libs/src/sdk/types.ts
@@ -13,6 +13,7 @@ import type {
 } from './services/Solana'
 import { ClaimableTokensClient } from './services/Solana/programs/ClaimableTokensClient'
 import { RewardManagerClient } from './services/Solana/programs/RewardManagerClient'
+import type { SolanaClient } from './services/Solana/programs/SolanaClient'
 import type { StorageService } from './services/Storage'
 import type { StorageNodeSelectorService } from './services/StorageNodeSelector'
 
@@ -53,9 +54,14 @@ export type ServicesContainer = {
   solanaRelay: SolanaRelayService
 
   /**
-   * Service used to interact with the Solana blockchain
+   * Service used to interact with the Solana wallet
    */
   solanaWalletAdapter: SolanaWalletAdapter
+
+  /**
+   * Service used to interact with the Solana RPCs
+   */
+  solanaClient: SolanaClient
 
   /**
    * Claimable Tokens Program client for Solana

--- a/packages/web/src/components/payout-wallet-modal/PayoutWalletModal.tsx
+++ b/packages/web/src/components/payout-wallet-modal/PayoutWalletModal.tsx
@@ -195,7 +195,7 @@ export const PayoutWalletModal = () => {
 
         const usdcMint = new PublicKey(env.USDC_MINT_ADDRESS)
         const addressPubkey = new PublicKey(address)
-        const connection = sdk.services.claimableTokensClient.connection
+        const connection = sdk.services.solanaClient.connection
         const info = await connection.getAccountInfo(addressPubkey)
 
         let usdcAta: string | null = null
@@ -236,7 +236,7 @@ export const PayoutWalletModal = () => {
               const payer = await sdk.services.solanaRelay.getFeePayer()
               const res = await connection.getLatestBlockhash()
               const transaction =
-                await sdk.services.claimableTokensClient.buildTransaction({
+                await sdk.services.solanaClient.buildTransaction({
                   recentBlockhash: res.blockhash,
                   instructions: [
                     createAssociatedTokenAccountIdempotentInstruction(

--- a/packages/web/src/services/solana/WithdrawUSDC.ts
+++ b/packages/web/src/services/solana/WithdrawUSDC.ts
@@ -177,7 +177,7 @@ export const swapUserBankUSDCToSol = async ({
     wallet.publicKey //  owner
   )
 
-  const transaction = await claimableTokensClient.buildTransaction({
+  const transaction = await sdk.services.solanaClient.buildTransaction({
     instructions: [
       createTemporaryTokenAccountInstruction,
       secpTransferInstruction,

--- a/packages/web/src/services/solana/solana.ts
+++ b/packages/web/src/services/solana/solana.ts
@@ -16,7 +16,7 @@ export const TRANSACTION_FEE_FALLBACK = 10000
 
 export const getSolanaConnection = async () => {
   const sdk = await audiusSdk()
-  return sdk.services.claimableTokensClient.connection
+  return sdk.services.solanaClient.connection
 }
 
 /**


### PR DESCRIPTION
### Description

Before this change, all three of the program clients inherited from a `BaseSolanaProgramClient` which managed the RPC connection and had helpers for various tasks around building, sending, and confirming transactions. This PR breaks the inheritance model in favor of composition.

After this change, the structure of Solana in the SDK looks something like:

- `RewardManagerClient`, `ClaimableTokensClient`, `PaymentRouterClient` depend on `SolanaClient` for interacting with RPC connection, get fee payer etc
- `SolanaClient` depends on `SolanaWalletAdapter` to find out the fee payer and send transactions
- `SolanaRelayWalletAdapter` implements `SolanaWalletAdapter` using `SolanaRelay`, building a normal `WalletAdapter` out of the relay service
- `SolanaRelay` is the API interface for the Solana relay service endpoints

### How Has This Been Tested?

Tested sending a tip, will also test other flows though.