### PR TITLE
[C-4964] Comment header changes

### DIFF
--- a/packages/common/src/context/commentsContext.tsx
+++ b/packages/common/src/context/commentsContext.tsx
@@ -19,11 +19,12 @@ import {
  * Context object to avoid prop drilling and share a common API with web/native code
  */
 
-// Props passed in from above
+// Props passed in from above (also get forwarded thru)
 type CommentSectionContextProps = {
   userId: Nullable<ID>
   entityId: ID
   entityType?: EntityType.TRACK
+  isEntityOwner: boolean
 }
 
 // Helper type to rewrap our mutation hooks with data from this context
@@ -53,6 +54,7 @@ type CommentSectionContextType = CommentSectionContextProps & {
   useReportComment: WrappedMutationHook<(commentId: string) => void, void>
   handleLoadMoreRootComments: () => void
   handleLoadMoreReplies: (commentId: string) => void
+  handleMuteEntityNotifications: () => void
 }
 
 export const CommentSectionContext = createContext<
@@ -62,6 +64,7 @@ export const CommentSectionContext = createContext<
 export const CommentSectionProvider = ({
   userId,
   entityId,
+  isEntityOwner,
   entityType = EntityType.TRACK,
   children
 }: PropsWithChildren<CommentSectionContextProps>) => {
@@ -157,6 +160,9 @@ export const CommentSectionProvider = ({
   const handleLoadMoreReplies = (commentId: string) => {
     console.log('Loading more replies for', commentId)
   }
+  const handleMuteEntityNotifications = () => {
+    console.log('Muting all notifs for ', entityId)
+  }
 
   return (
     <CommentSectionContext.Provider
@@ -166,6 +172,7 @@ export const CommentSectionProvider = ({
         entityType,
         comments,
         commentSectionLoading,
+        isEntityOwner,
         usePostComment,
         useDeleteComment,
         useEditComment,
@@ -173,7 +180,8 @@ export const CommentSectionProvider = ({
         useReactToComment,
         useReportComment,
         handleLoadMoreReplies,
-        handleLoadMoreRootComments
+        handleLoadMoreRootComments,
+        handleMuteEntityNotifications
       }}
     >
       {children}

--- a/packages/web/src/components/comments/CommentHeader.tsx
+++ b/packages/web/src/components/comments/CommentHeader.tsx
@@ -1,15 +1,74 @@
-import { Text } from '@audius/harmony'
+import { useContext, useState } from 'react'
+
+import { CommentSectionContext } from '@audius/common/context'
+import {
+  Flex,
+  IconButton,
+  IconKebabHorizontal,
+  PopupMenu,
+  PopupMenuItem,
+  Text
+} from '@audius/harmony'
+import { css } from '@emotion/react'
+
+const messages = {
+  turnOffNotifs: 'Turn off notifications'
+}
+
+type CommentHeaderProps = {
+  commentCount?: number
+  isLoading?: boolean
+}
 
 export const CommentHeader = ({
   commentCount,
   isLoading
-}: {
-  commentCount?: number
-  isLoading?: boolean
-}) => {
+}: CommentHeaderProps) => {
+  const { handleMuteEntityNotifications, isEntityOwner } = useContext(
+    CommentSectionContext
+  )!
+  const popupMenuItems: PopupMenuItem[] = [
+    { onClick: handleMuteEntityNotifications, text: messages.turnOffNotifs }
+  ]
+  const [isPopupOpen, setIsPopupOpen] = useState(false)
+
   return (
-    <Text variant='title' size='l'>
-      Comments ({!isLoading ? commentCount : '...'})
-    </Text>
+    <Flex
+      justifyContent='space-between'
+      w='100%'
+      css={css`
+        &:hover .kebabIcon {
+          opacity: 1;
+        }
+      `}
+    >
+      <Text variant='title' size='l'>
+        Comments ({!isLoading ? commentCount : '...'})
+      </Text>
+      {isEntityOwner && !isLoading ? (
+        <PopupMenu
+          items={popupMenuItems}
+          onClose={() => setIsPopupOpen(false)}
+          renderTrigger={(anchorRef, triggerPopup) => (
+            <IconButton
+              aria-label='Show comment options'
+              icon={IconKebabHorizontal}
+              color='subdued'
+              ref={anchorRef}
+              css={{
+                cursor: 'pointer',
+                opacity: isPopupOpen ? 1 : 0, // keep icon visible when popup is open
+                transition: 'ease all 0.3s'
+              }}
+              onClick={() => {
+                setIsPopupOpen(true)
+                triggerPopup()
+              }}
+              className='kebabIcon'
+            />
+          )}
+        />
+      ) : null}
+    </Flex>
   )
 }

--- a/packages/web/src/components/comments/CommentHeader.tsx
+++ b/packages/web/src/components/comments/CommentHeader.tsx
@@ -9,7 +9,7 @@ import {
   PopupMenuItem,
   Text
 } from '@audius/harmony'
-import { css } from '@emotion/react'
+import { css, useTheme } from '@emotion/react'
 
 const messages = {
   turnOffNotifs: 'Turn off notifications'
@@ -27,6 +27,7 @@ export const CommentHeader = ({
   const { handleMuteEntityNotifications, isEntityOwner } = useContext(
     CommentSectionContext
   )!
+  const { motion } = useTheme()
   const popupMenuItems: PopupMenuItem[] = [
     { onClick: handleMuteEntityNotifications, text: messages.turnOffNotifs }
   ]
@@ -58,7 +59,7 @@ export const CommentHeader = ({
               css={{
                 cursor: 'pointer',
                 opacity: isPopupOpen ? 1 : 0, // keep icon visible when popup is open
-                transition: 'ease all 0.3s'
+                transition: motion.hover
               }}
               onClick={() => {
                 setIsPopupOpen(true)

--- a/packages/web/src/components/comments/CommentSectionDesktop.tsx
+++ b/packages/web/src/components/comments/CommentSectionDesktop.tsx
@@ -1,9 +1,10 @@
 import { useCurrentCommentSection } from '@audius/common/context'
 import { Status } from '@audius/common/models'
-import { Button, Divider, Flex, Paper, Skeleton } from '@audius/harmony'
+import { Button, Divider, Flex, Paper } from '@audius/harmony'
 
 import { CommentForm } from './CommentForm'
 import { CommentHeader } from './CommentHeader'
+import { CommentSkeletons } from './CommentSkeletons'
 import { CommentThread } from './CommentThread'
 import { NoComments } from './NoComments'
 
@@ -21,30 +22,9 @@ export const CommentSectionDesktop = () => {
   }
   const commentPostAllowed = userId !== null
 
-  // Loading state
-  if (commentSectionLoading)
-    return (
-      <Flex gap='l' direction='column' w='100%' alignItems='flex-start'>
-        <CommentHeader isLoading />
-        <Paper p='xl' w='100%' direction='column' gap='xl'>
-          <Flex
-            gap='s'
-            w='100%'
-            h='60px'
-            alignItems='center'
-            justifyContent='center'
-          >
-            <Skeleton w='40px' h='40px' css={{ borderRadius: '100%' }} />
-            <Skeleton w='100%' h='60px' />
-          </Flex>
-          <Divider color='default' orientation='horizontal' />
-          <Skeleton w='100%' h='120px' />
-          <Skeleton w='100%' h='120px' />
-          <Skeleton w='100%' h='120px' />
-          <Skeleton w='100%' h='120px' />
-        </Paper>
-      </Flex>
-    )
+  if (commentSectionLoading) {
+    return <CommentSkeletons />
+  }
 
   return (
     <Flex gap='l' direction='column' w='100%' alignItems='flex-start'>

--- a/packages/web/src/components/comments/CommentSkeletons.tsx
+++ b/packages/web/src/components/comments/CommentSkeletons.tsx
@@ -1,0 +1,27 @@
+import { Divider, Flex, Paper, Skeleton } from '@audius/harmony'
+
+import { CommentHeader } from './CommentHeader'
+
+// TODO: mobile can also go in here
+export const CommentSkeletons = () => (
+  <Flex gap='l' direction='column' w='100%' alignItems='flex-start'>
+    <CommentHeader isLoading />
+    <Paper p='xl' w='100%' direction='column' gap='xl'>
+      <Flex
+        gap='s'
+        w='100%'
+        h='60px'
+        alignItems='center'
+        justifyContent='center'
+      >
+        <Skeleton w='40px' h='40px' css={{ borderRadius: '100%' }} />
+        <Skeleton w='100%' h='60px' />
+      </Flex>
+      <Divider color='default' orientation='horizontal' />
+      <Skeleton w='100%' h='120px' />
+      <Skeleton w='100%' h='120px' />
+      <Skeleton w='100%' h='120px' />
+      <Skeleton w='100%' h='120px' />
+    </Paper>
+  </Flex>
+)

--- a/packages/web/src/pages/track-page/components/desktop/TrackPage.tsx
+++ b/packages/web/src/pages/track-page/components/desktop/TrackPage.tsx
@@ -255,6 +255,7 @@ const TrackPage = ({
               <CommentSectionProvider
                 userId={userId}
                 entityId={defaults.trackId}
+                isEntityOwner={isOwner}
               >
                 <CommentSectionDesktop />
               </CommentSectionProvider>


### PR DESCRIPTION
### Description

Changes to the CommentHeader. 
Adds a popup menu that will be used to disable notifs. It shows on hover over the comment header but only for track owners (personally I think it could potentially be nice to have for non track owners, but this isnt currently in the spec and def lower priority for non track owners). 
Also moved skeleton UI to its own component

Also need to discuss with design about the "hover" state; seems like it would be easy to miss so maybe we just skip hovering?

![2024-08-14 13 11 52](https://github.com/user-attachments/assets/e121e97a-cc28-4611-9c55-6ffce001f184)

### How Has This Been Tested?

web:stage