### PR TITLE
Don't decrypt plaintext messages

### DIFF
--- a/.changeset/few-numbers-march.md
+++ b/.changeset/few-numbers-march.md
@@ -1,0 +1,5 @@
+---
+'@audius/sdk': patch
+---
+
+Support plaintext messages

--- a/packages/libs/src/sdk/api/chats/ChatsApi.ts
+++ b/packages/libs/src/sdk/api/chats/ChatsApi.ts
@@ -263,17 +263,19 @@ export class ChatsApi
     const decrypted = await Promise.all(
       json.data.map(async (m) => ({
         ...m,
-        message: await this.decryptString(
-          sharedSecret,
-          base64.decode(m.message)
-        ).catch((e) => {
-          this.logger.error(
-            "[audius-sdk]: Error: Couldn't decrypt chat message",
-            m,
-            e
-          )
-          return GENERIC_MESSAGE_ERROR
-        })
+        message: m.is_plaintext
+          ? m.message
+          : await this.decryptString(
+              sharedSecret,
+              base64.decode(m.message)
+            ).catch((e) => {
+              this.logger.error(
+                "[audius-sdk]: Error: Couldn't decrypt chat message",
+                m,
+                e
+              )
+              return GENERIC_MESSAGE_ERROR
+            })
       }))
     )
     return {
@@ -840,7 +842,8 @@ export class ChatsApi
               }),
               sender_user_id: data.metadata.userId,
               created_at: data.metadata.timestamp,
-              reactions: []
+              reactions: [],
+              is_plaintext: false
             }
           })
         } else if (data.rpc.method === 'chat.react') {


### PR DESCRIPTION
### Description
Conditionally decrypt on `is_plaintext` field.

Will still need to add this logic as well as the `is_plaintext` field to `chat.last_message` sigh.

### How Has This Been Tested?

Messages are displayed on local stack.