### PR TITLE
wrong core defaults

### DIFF
--- a/core/config/defaults.go
+++ b/core/config/defaults.go
@@ -2,6 +2,6 @@ package config
 
 const (
 	DefaultRPCAddress             = "tcp://0.0.0.0:26657"
-	DefaultP2PAddress             = "0.0.0.0:26656"
+	DefaultP2PAddress             = "tcp://0.0.0.0:26656"
 	DefaultTestnetPersistentPeers = "0f4be2aaa70e9570eee3485d8fa54502cf1a9fc0@34.67.210.7:26656"
 )

--- a/core/config/defaults.go
+++ b/core/config/defaults.go
@@ -1,7 +1,7 @@
 package config
 
 const (
-	DefaultRPCAddress             = "0.0.0.0:26657"
+	DefaultRPCAddress             = "tcp://0.0.0.0:26657"
 	DefaultP2PAddress             = "0.0.0.0:26656"
 	DefaultTestnetPersistentPeers = "0f4be2aaa70e9570eee3485d8fa54502cf1a9fc0@34.67.210.7:26656"
 )


### PR DESCRIPTION
### Description
these need the tcp protocol identified here

### How Has This Been Tested?
stage wasn't peering because the tcp was missing, overriding with .env fixed it so defaulting in here
