### PR TITLE
[PAY-3307] Upgrade chat blasts to chats in sdk (V2)

### DIFF
--- a/.changeset/chatty-cameras-yawn.md
+++ b/.changeset/chatty-cameras-yawn.md
@@ -1,0 +1,5 @@
+---
+'@audius/sdk': patch
+---
+
+Upgrade chat blasts to real chats internally

--- a/comms/discovery/rpcz/apply.go
+++ b/comms/discovery/rpcz/apply.go
@@ -462,6 +462,8 @@ func websocketNotify(rpcJson json.RawMessage, userId int32, timestamp time.Time)
 			websocketPush(subscribedUserId, j)
 		}
 
+	} else if gjson.GetBytes(rpcJson, "method").String() == "chat.blast" {
+		websocketPushAll(rpcJson, timestamp)
 	}
 }
 

--- a/comms/discovery/rpcz/apply.go
+++ b/comms/discovery/rpcz/apply.go
@@ -449,7 +449,9 @@ func websocketNotify(rpcJson json.RawMessage, userId int32, timestamp time.Time)
 			Metadata schema.Metadata `json:"metadata"`
 		}{
 			rpcJson,
-			schema.Metadata{Timestamp: timestamp.Format(time.RFC3339Nano), UserID: encodedUserId},
+			schema.Metadata{Timestamp: timestamp.Format(time.RFC3339Nano),
+				// Note this is the userId of the user sending the message
+				UserID: encodedUserId},
 		}
 
 		j, err := json.Marshal(data)

--- a/comms/discovery/rpcz/apply.go
+++ b/comms/discovery/rpcz/apply.go
@@ -19,6 +19,8 @@ import (
 	"golang.org/x/exp/slog"
 )
 
+const INVALID_USER_ID = -1
+
 type RPCProcessor struct {
 	sync.Mutex
 	validator *Validator
@@ -439,8 +441,10 @@ func websocketNotify(rpcJson json.RawMessage, userId int32, timestamp time.Time)
 		}
 
 		for _, receiverUserId := range userIds {
-			websocketPush(userId, receiverUserId, rpcJson, timestamp)
+			websocketPush(userId, receiverUserId, rpcJson, timestamp, false)
 		}
+	} else if gjson.GetBytes(rpcJson, "method").String() == "chat.blast" {
+		websocketPush(userId, INVALID_USER_ID, rpcJson, timestamp, true)
 	}
 }
 

--- a/comms/discovery/rpcz/apply.go
+++ b/comms/discovery/rpcz/apply.go
@@ -438,34 +438,9 @@ func websocketNotify(rpcJson json.RawMessage, userId int32, timestamp time.Time)
 			return
 		}
 
-		encodedUserId, _ := misc.EncodeHashId(int(userId))
-
-		// this struct should match ChatWebsocketEventData
-		// but we create a matching anon struct here
-		// so we can simply pass thru the RPC as a json.RawMessage
-		// which is simpler than satisfying the quicktype generated schema.RPC struct
-		data := struct {
-			RPC      json.RawMessage `json:"rpc"`
-			Metadata schema.Metadata `json:"metadata"`
-		}{
-			rpcJson,
-			schema.Metadata{Timestamp: timestamp.Format(time.RFC3339Nano),
-				// Note this is the userId of the user sending the message
-				UserID: encodedUserId},
+		for _, receiverUserId := range userIds {
+			websocketPush(userId, receiverUserId, rpcJson, timestamp)
 		}
-
-		j, err := json.Marshal(data)
-		if err != nil {
-			logger.Warn("invalid websocket json " + err.Error())
-			return
-		}
-
-		for _, subscribedUserId := range userIds {
-			websocketPush(subscribedUserId, j)
-		}
-
-	} else if gjson.GetBytes(rpcJson, "method").String() == "chat.blast" {
-		websocketPushAll(rpcJson, timestamp)
 	}
 }
 

--- a/comms/discovery/rpcz/apply.go
+++ b/comms/discovery/rpcz/apply.go
@@ -441,10 +441,10 @@ func websocketNotify(rpcJson json.RawMessage, userId int32, timestamp time.Time)
 		}
 
 		for _, receiverUserId := range userIds {
-			websocketPush(userId, receiverUserId, rpcJson, timestamp, false)
+			websocketPush(userId, receiverUserId, rpcJson, timestamp)
 		}
 	} else if gjson.GetBytes(rpcJson, "method").String() == "chat.blast" {
-		websocketPush(userId, INVALID_USER_ID, rpcJson, timestamp, true)
+		websocketPushAll(userId, rpcJson, timestamp)
 	}
 }
 

--- a/comms/discovery/rpcz/apply.go
+++ b/comms/discovery/rpcz/apply.go
@@ -19,8 +19,6 @@ import (
 	"golang.org/x/exp/slog"
 )
 
-const INVALID_USER_ID = -1
-
 type RPCProcessor struct {
 	sync.Mutex
 	validator *Validator

--- a/comms/discovery/rpcz/websocket.go
+++ b/comms/discovery/rpcz/websocket.go
@@ -46,6 +46,9 @@ func RegisterWebsocket(userId int32, conn net.Conn) {
 }
 
 func removeWebsocket(userId int32, toRemove net.Conn) {
+	mu.Lock()
+	defer mu.Unlock()
+
 	keep := make([]net.Conn, 0, len(websockets[userId]))
 	for _, s := range websockets[userId] {
 		if s == toRemove {

--- a/comms/discovery/rpcz/websocket.go
+++ b/comms/discovery/rpcz/websocket.go
@@ -57,76 +57,24 @@ func removeWebsocket(userId int32, toRemove net.Conn) {
 	websockets[userId] = keep
 }
 
-func websocketPush(senderUserId int32, receiverUserId int32, rpcJson json.RawMessage, timestamp time.Time, pushAll bool) {
+func websocketPush(senderUserId int32, receiverUserId int32, rpcJson json.RawMessage, timestamp time.Time) {
 	mu.Lock()
 	defer mu.Unlock()
 
-	for userId := range websockets {
-		if !pushAll && receiverUserId != userId {
-			continue
-		}
+	for _, s := range websockets[receiverUserId] {
+		encodedSenderUserId, _ := misc.EncodeHashId(int(senderUserId))
+		encodedReceiverUserId, _ := misc.EncodeHashId(int(receiverUserId))
 
-		for _, s := range websockets[receiverUserId] {
-			encodedSenderUserId, _ := misc.EncodeHashId(int(senderUserId))
-			encodedReceiverUserId, _ := misc.EncodeHashId(int(receiverUserId))
-
-			// this struct should match ChatWebsocketEventData
-			// but we create a matching anon struct here
-			// so we can simply pass thru the RPC as a json.RawMessage
-			// which is simpler than satisfying the quicktype generated schema.RPC struct
-			data := struct {
-				RPC      json.RawMessage `json:"rpc"`
-				Metadata schema.Metadata `json:"metadata"`
-			}{
-				rpcJson,
-				schema.Metadata{Timestamp: timestamp.Format(time.RFC3339Nano), SenderUserID: encodedSenderUserId, ReceiverUserID: encodedReceiverUserId},
-			}
-
-			payload, err := json.Marshal(data)
-			if err != nil {
-				logger.Warn("invalid websocket json " + err.Error())
-				return
-			}
-			err = wsutil.WriteServerMessage(s, ws.OpText, payload)
-			if err != nil {
-				logger.Info("websocket push failed: " + err.Error())
-				removeWebsocket(receiverUserId, s)
-			} else {
-				logger.Debug("websocket push", "userId", receiverUserId, "payload", string(payload))
-			}
-
-			// filter out expired messages and append new one
-			recent2 := []*recentMessage{}
-			for _, r := range recentMessages {
-				if time.Since(r.sentAt) < time.Second*10 {
-					recent2 = append(recent2, r)
-				}
-			}
-			recent2 = append(recent2, &recentMessage{
-				userId:  receiverUserId,
-				sentAt:  time.Now(),
-				payload: payload,
-			})
-			recentMessages = recent2
-		}
-	}
-}
-
-func websocketPushAll(rpcJson json.RawMessage, timestamp time.Time) {
-	mu.Lock()
-	defer mu.Unlock()
-
-	for _, s := range websockets {
-		encodedUserId, _ := misc.EncodeHashId(int(s.userId))
-
+		// this struct should match ChatWebsocketEventData
+		// but we create a matching anon struct here
+		// so we can simply pass thru the RPC as a json.RawMessage
+		// which is simpler than satisfying the quicktype generated schema.RPC struct
 		data := struct {
 			RPC      json.RawMessage `json:"rpc"`
 			Metadata schema.Metadata `json:"metadata"`
 		}{
 			rpcJson,
-			schema.Metadata{Timestamp: timestamp.Format(time.RFC3339Nano),
-				// Note this is the userId of the user receiving the message
-				UserID: encodedUserId},
+			schema.Metadata{Timestamp: timestamp.Format(time.RFC3339Nano), SenderUserID: encodedSenderUserId, ReceiverUserID: encodedReceiverUserId},
 		}
 
 		payload, err := json.Marshal(data)
@@ -134,13 +82,32 @@ func websocketPushAll(rpcJson json.RawMessage, timestamp time.Time) {
 			logger.Warn("invalid websocket json " + err.Error())
 			return
 		}
-
-		err = wsutil.WriteServerMessage(s.conn, ws.OpText, payload)
+		err = wsutil.WriteServerMessage(s, ws.OpText, payload)
 		if err != nil {
 			logger.Info("websocket push failed: " + err.Error())
-			removeWebsocket(s)
+			removeWebsocket(receiverUserId, s)
 		} else {
-			logger.Debug("websocket push all", "payload", string(payload))
+			logger.Debug("websocket push", "userId", receiverUserId, "payload", string(payload))
 		}
+
+		// filter out expired messages and append new one
+		recent2 := []*recentMessage{}
+		for _, r := range recentMessages {
+			if time.Since(r.sentAt) < time.Second*10 {
+				recent2 = append(recent2, r)
+			}
+		}
+		recent2 = append(recent2, &recentMessage{
+			userId:  receiverUserId,
+			sentAt:  time.Now(),
+			payload: payload,
+		})
+		recentMessages = recent2
+	}
+}
+
+func websocketPushAll(senderUserId int32, rpcJson json.RawMessage, timestamp time.Time) {
+	for receiverUserId := range websockets {
+		websocketPush(senderUserId, receiverUserId, rpcJson, timestamp)
 	}
 }

--- a/comms/discovery/rpcz/websocket.go
+++ b/comms/discovery/rpcz/websocket.go
@@ -15,7 +15,7 @@ import (
 
 var (
 	mu             sync.Mutex
-	websockets     = []userWebsocket{}
+	websockets     = make(map[int32][]net.Conn)
 	recentMessages = []*recentMessage{}
 	logger         = slog.Default()
 )
@@ -26,13 +26,7 @@ type recentMessage struct {
 	payload []byte
 }
 
-type userWebsocket struct {
-	userId int32
-	conn   net.Conn
-}
-
 func RegisterWebsocket(userId int32, conn net.Conn) {
-
 	var pushErr error
 	for _, r := range recentMessages {
 		if time.Since(r.sentAt) < time.Second*10 && r.userId == userId {
@@ -46,24 +40,21 @@ func RegisterWebsocket(userId int32, conn net.Conn) {
 
 	if pushErr == nil {
 		mu.Lock()
-		websockets = append(websockets, userWebsocket{
-			userId,
-			conn,
-		})
+		websockets[userId] = append(websockets[userId], conn)
 		mu.Unlock()
 	}
 }
 
-func removeWebsocket(toRemove userWebsocket) {
-	keep := make([]userWebsocket, 0, len(websockets))
-	for _, s := range websockets {
+func removeWebsocket(userId int32, toRemove net.Conn) {
+	keep := make([]net.Conn, 0, len(websockets[userId]))
+	for _, s := range websockets[userId] {
 		if s == toRemove {
-			s.conn.Close()
+			s.Close()
 		} else {
 			keep = append(keep, s)
 		}
 	}
-	websockets = keep
+	websockets[userId] = keep
 }
 
 func websocketPush(userId int32, payload []byte) {
@@ -84,15 +75,11 @@ func websocketPush(userId int32, payload []byte) {
 	})
 	recentMessages = recent2
 
-	for _, s := range websockets {
-		if s.userId != userId {
-			continue
-		}
-
-		err := wsutil.WriteServerMessage(s.conn, ws.OpText, payload)
+	for _, s := range websockets[userId] {
+		err := wsutil.WriteServerMessage(s, ws.OpText, payload)
 		if err != nil {
 			logger.Info("websocket push failed: " + err.Error())
-			removeWebsocket(s)
+			removeWebsocket(userId, s)
 		} else {
 			logger.Debug("websocket push", "userId", userId, "payload", string(payload))
 		}

--- a/comms/discovery/rpcz/websocket.go
+++ b/comms/discovery/rpcz/websocket.go
@@ -57,54 +57,59 @@ func removeWebsocket(userId int32, toRemove net.Conn) {
 	websockets[userId] = keep
 }
 
-func websocketPush(senderUserId int32, receiverUserId int32, rpcJson json.RawMessage, timestamp time.Time) {
+func websocketPush(senderUserId int32, receiverUserId int32, rpcJson json.RawMessage, timestamp time.Time, pushAll bool) {
 	mu.Lock()
 	defer mu.Unlock()
 
-	for _, s := range websockets[receiverUserId] {
-		encodedSenderUserId, _ := misc.EncodeHashId(int(senderUserId))
-		encodedReceiverUserId, _ := misc.EncodeHashId(int(receiverUserId))
-
-		// this struct should match ChatWebsocketEventData
-		// but we create a matching anon struct here
-		// so we can simply pass thru the RPC as a json.RawMessage
-		// which is simpler than satisfying the quicktype generated schema.RPC struct
-		data := struct {
-			RPC      json.RawMessage `json:"rpc"`
-			Metadata schema.Metadata `json:"metadata"`
-		}{
-			rpcJson,
-			schema.Metadata{Timestamp: timestamp.Format(time.RFC3339Nano), SenderUserID: encodedSenderUserId, ReceiverUserID: encodedReceiverUserId},
+	for userId := range websockets {
+		if !pushAll && receiverUserId != userId {
+			continue
 		}
 
-		payload, err := json.Marshal(data)
-		if err != nil {
-			logger.Warn("invalid websocket json " + err.Error())
-			return
-		}
-		err = wsutil.WriteServerMessage(s, ws.OpText, payload)
-		if err != nil {
-			logger.Info("websocket push failed: " + err.Error())
-			removeWebsocket(receiverUserId, s)
-		} else {
-			logger.Debug("websocket push", "userId", receiverUserId, "payload", string(payload))
-		}
+		for _, s := range websockets[receiverUserId] {
+			encodedSenderUserId, _ := misc.EncodeHashId(int(senderUserId))
+			encodedReceiverUserId, _ := misc.EncodeHashId(int(receiverUserId))
 
-		// filter out expired messages and append new one
-		recent2 := []*recentMessage{}
-		for _, r := range recentMessages {
-			if time.Since(r.sentAt) < time.Second*10 {
-				recent2 = append(recent2, r)
+			// this struct should match ChatWebsocketEventData
+			// but we create a matching anon struct here
+			// so we can simply pass thru the RPC as a json.RawMessage
+			// which is simpler than satisfying the quicktype generated schema.RPC struct
+			data := struct {
+				RPC      json.RawMessage `json:"rpc"`
+				Metadata schema.Metadata `json:"metadata"`
+			}{
+				rpcJson,
+				schema.Metadata{Timestamp: timestamp.Format(time.RFC3339Nano), SenderUserID: encodedSenderUserId, ReceiverUserID: encodedReceiverUserId},
 			}
-		}
-		recent2 = append(recent2, &recentMessage{
-			userId:  receiverUserId,
-			sentAt:  time.Now(),
-			payload: payload,
-		})
-		recentMessages = recent2
-	}
 
+			payload, err := json.Marshal(data)
+			if err != nil {
+				logger.Warn("invalid websocket json " + err.Error())
+				return
+			}
+			err = wsutil.WriteServerMessage(s, ws.OpText, payload)
+			if err != nil {
+				logger.Info("websocket push failed: " + err.Error())
+				removeWebsocket(receiverUserId, s)
+			} else {
+				logger.Debug("websocket push", "userId", receiverUserId, "payload", string(payload))
+			}
+
+			// filter out expired messages and append new one
+			recent2 := []*recentMessage{}
+			for _, r := range recentMessages {
+				if time.Since(r.sentAt) < time.Second*10 {
+					recent2 = append(recent2, r)
+				}
+			}
+			recent2 = append(recent2, &recentMessage{
+				userId:  receiverUserId,
+				sentAt:  time.Now(),
+				payload: payload,
+			})
+			recentMessages = recent2
+		}
+	}
 }
 
 func websocketPushAll(rpcJson json.RawMessage, timestamp time.Time) {

--- a/comms/discovery/rpcz/websocket.go
+++ b/comms/discovery/rpcz/websocket.go
@@ -112,7 +112,9 @@ func websocketPushAll(rpcJson json.RawMessage, timestamp time.Time) {
 			Metadata schema.Metadata `json:"metadata"`
 		}{
 			rpcJson,
-			schema.Metadata{Timestamp: timestamp.Format(time.RFC3339Nano), UserID: encodedUserId},
+			schema.Metadata{Timestamp: timestamp.Format(time.RFC3339Nano),
+				// Note this is the userId of the user receiving the message
+				UserID: encodedUserId},
 		}
 
 		payload, err := json.Marshal(data)

--- a/comms/discovery/schema/schema.go
+++ b/comms/discovery/schema/schema.go
@@ -223,8 +223,9 @@ type ChatWebsocketEventData struct {
 }
 
 type Metadata struct {
-	Timestamp string `json:"timestamp"`
-	UserID    string `json:"userId"`
+	Timestamp      string `json:"timestamp"`
+	SenderUserID   string `json:"userId"`
+	ReceiverUserID string `json:"userId"`
 }
 
 type RPCPayload struct {

--- a/comms/discovery/schema/schema.go
+++ b/comms/discovery/schema/schema.go
@@ -224,8 +224,8 @@ type ChatWebsocketEventData struct {
 
 type Metadata struct {
 	Timestamp      string `json:"timestamp"`
-	SenderUserID   string `json:"userId"`
-	ReceiverUserID string `json:"userId"`
+	SenderUserID   string `json:"senderUserId"`
+	ReceiverUserID string `json:"receiverUserId"`
 }
 
 type RPCPayload struct {

--- a/packages/common/src/store/pages/chat/sagas.ts
+++ b/packages/common/src/store/pages/chat/sagas.ts
@@ -484,9 +484,7 @@ function* doCreateChatBlast(action: ReturnType<typeof createChatBlast>) {
         chat_id: chatId,
         is_blast: true,
         last_message_at: dayjs().toISOString(),
-        audience,
-        content_type: contentType,
-        content_id: contentId?.toString()
+        audience
       }
       yield* put(
         createChatSucceeded({

--- a/packages/common/src/store/pages/chat/sagas.ts
+++ b/packages/common/src/store/pages/chat/sagas.ts
@@ -146,7 +146,7 @@ function* doFetchLatestChats() {
     }
     while (hasMoreChats) {
       const response = yield* call([sdk.chats, sdk.chats.getAll], {
-        userId: currentUserId,
+        userId: encodeHashId(currentUserId)!,
         before,
         after: summary?.next_cursor,
         limit: CHAT_PAGE_SIZE

--- a/packages/common/src/store/pages/chat/sagas.ts
+++ b/packages/common/src/store/pages/chat/sagas.ts
@@ -140,8 +140,13 @@ function* doFetchLatestChats() {
     let hasMoreChats = true
     let data: UserChat[] = []
     let firstResponse: TypedCommsResponse<UserChat[]> | undefined
+    const currentUserId = yield* select(getUserId)
+    if (!currentUserId) {
+      throw new Error('User not found')
+    }
     while (hasMoreChats) {
       const response = yield* call([sdk.chats, sdk.chats.getAll], {
+        userId: currentUserId,
         before,
         after: summary?.next_cursor,
         limit: CHAT_PAGE_SIZE
@@ -177,7 +182,12 @@ function* doFetchMoreChats() {
     const sdk = yield* call(audiusSdk)
     const summary = yield* select(getChatsSummary)
     const before = summary?.prev_cursor
+    const currentUserId = yield* select(getUserId)
+    if (!currentUserId) {
+      throw new Error('User not found')
+    }
     const response = yield* call([sdk.chats, sdk.chats.getAll], {
+      userId: encodeHashId(currentUserId)!,
       before,
       limit: CHAT_PAGE_SIZE
     })

--- a/packages/libs/src/sdk/api/chats/ChatsApi.ts
+++ b/packages/libs/src/sdk/api/chats/ChatsApi.ts
@@ -892,7 +892,6 @@ export class ChatsApi
               sender_user_id: data.metadata.senderUserId,
               created_at: data.metadata.timestamp,
               reactions: [],
-              // TODO: need to set this for blast chats
               is_plaintext: false
             }
           })

--- a/packages/libs/src/sdk/api/chats/ChatsApi.ts
+++ b/packages/libs/src/sdk/api/chats/ChatsApi.ts
@@ -889,7 +889,7 @@ export class ChatsApi
                 )
                 return GENERIC_MESSAGE_ERROR
               }),
-              sender_user_id: data.metadata.userId,
+              sender_user_id: data.metadata.senderUserId,
               created_at: data.metadata.timestamp,
               reactions: [],
               // TODO: need to set this for blast chats
@@ -902,7 +902,7 @@ export class ChatsApi
             messageId: data.rpc.params.message_id,
             reaction: {
               reaction: data.rpc.params.reaction,
-              user_id: data.metadata.userId,
+              user_id: data.metadata.senderUserId,
               created_at: data.metadata.timestamp
             }
           })

--- a/packages/libs/src/sdk/api/chats/ChatsApi.ts
+++ b/packages/libs/src/sdk/api/chats/ChatsApi.ts
@@ -67,7 +67,8 @@ import type {
   RPCPayloadRequest,
   ValidatedChatPermissions,
   ChatBlast,
-  ChatCreateRPC
+  ChatCreateRPC,
+  UpgradableChatBlast
 } from './serverTypes'
 
 const GENERIC_MESSAGE_ERROR = 'Error: this message cannot be displayed'
@@ -295,7 +296,7 @@ export class ChatsApi
    * Gets a list of chat blasts for which chats haven't been created yet
    * @returns the blast messages list response
    */
-  public async getBlasts(): Promise<TypedCommsResponse<ChatBlast[]>> {
+  public async getBlasts() {
     const query: HTTPQuery = {
       timestamp: new Date().getTime()
     }
@@ -305,7 +306,7 @@ export class ChatsApi
       headers: {},
       query
     })
-    return (await res.json()) as TypedCommsResponse<ChatBlast[]>
+    return (await res.json()) as TypedCommsResponse<UpgradableChatBlast[]>
   }
 
   /**

--- a/packages/libs/src/sdk/api/chats/ChatsApi.ts
+++ b/packages/libs/src/sdk/api/chats/ChatsApi.ts
@@ -11,6 +11,7 @@ import type { AuthService } from '../../services/Auth'
 import type { DiscoveryNodeSelectorService } from '../../services/DiscoveryNodeSelector/types'
 import type { LoggerService } from '../../services/Logger'
 import type { EventEmitterTarget } from '../../utils/EventEmitterTarget'
+import { encodeHashId } from '../../utils/hashId'
 import { parseParams } from '../../utils/parseParams'
 import {
   BaseAPI,
@@ -64,10 +65,12 @@ import type {
   ChatMessage,
   ChatWebsocketEventData,
   RPCPayloadRequest,
-  ValidatedChatPermissions
+  ValidatedChatPermissions,
+  ChatBlast,
+  ChatCreateRPC
 } from './serverTypes'
 
-const GENERIC_MESSAGE_ERROR = 'Error: this message can not be displayed'
+const GENERIC_MESSAGE_ERROR = 'Error: this message cannot be displayed'
 
 export class ChatsApi
   extends BaseAPI
@@ -173,14 +176,18 @@ export class ChatsApi
    * @param params.limit the max number of chats to get
    * @param params.before a timestamp cursor for pagination
    * @param params.after a timestamp cursor for pagination
-   * @param params.currentUserId the user to act on behalf of
+   * @param params.userId the user to act on behalf of
    * @returns the chat list response
    */
   public async getAll(params?: ChatGetAllRequest) {
-    const { currentUserId, limit, before, after } = await parseParams(
+    const { userId, limit, before, after } = await parseParams(
       'getAll',
       ChatGetAllRequestSchema
     )(params)
+
+    // Get new blasts and upgrade them to chats
+    this.upgradeBlasts(userId)
+
     const path = `/comms/chats`
     const query: HTTPQuery = {
       timestamp: new Date().getTime()
@@ -194,8 +201,8 @@ export class ChatsApi
     if (after) {
       query.after = after
     }
-    if (currentUserId) {
-      query.current_user_id = currentUserId
+    if (userId) {
+      query.current_user_id = userId
     }
     const response = await this.signAndSendRequest({
       method: 'GET',
@@ -282,6 +289,23 @@ export class ChatsApi
       ...json,
       data: decrypted
     }
+  }
+
+  /**
+   * Gets a list of chat blasts for which chats haven't been created yet
+   * @returns the blast messages list response
+   */
+  public async getBlasts(): Promise<TypedCommsResponse<ChatBlast[]>> {
+    const query: HTTPQuery = {
+      timestamp: new Date().getTime()
+    }
+    const res = await this.signAndSendRequest({
+      method: 'GET',
+      path: `/comms/blasts`,
+      headers: {},
+      query
+    })
+    return (await res.json()) as TypedCommsResponse<ChatBlast[]>
   }
 
   /**
@@ -420,7 +444,7 @@ export class ChatsApi
    * @param params.currentUserId the user to act on behalf of
    * @returns the rpc object
    */
-  public async create(params: ChatCreateRequest) {
+  public async create(params: ChatCreateRequest): Promise<ChatCreateRPC> {
     const { currentUserId, userId, invitedUserIds } = await parseParams(
       'create',
       ChatCreateRequestSchema
@@ -430,14 +454,14 @@ export class ChatsApi
     const chatSecret = secp.utils.randomPrivateKey()
     const invites = await this.createInvites(userId, invitedUserIds, chatSecret)
 
-    return await this.sendRpc({
+    return (await this.sendRpc({
       current_user_id: currentUserId,
       method: 'chat.create',
       params: {
         chat_id: chatId,
         invites
       }
-    })
+    })) as ChatCreateRPC
   }
 
   /**
@@ -769,6 +793,31 @@ export class ChatsApi
     return base64.decode(json.data)
   }
 
+  private async upgradeBlasts(userId: string) {
+    const blasts = await this.getBlasts()
+    Promise.all(
+      blasts.data.map(async (blast) => {
+        const encodedSenderId = encodeHashId(blast.from_user_id)
+        if (encodedSenderId) {
+          await this.create({
+            userId,
+            invitedUserIds: [encodedSenderId]
+          })
+          this.eventEmitter.emit('message', {
+            chatId: blast.pending_chat_id,
+            message: {
+              message_id: blast.pending_chat_id + blast.chat_id,
+              message: blast.plaintext,
+              sender_user_id: encodedSenderId,
+              created_at: blast.created_at,
+              reactions: []
+            }
+          })
+        }
+      })
+    )
+  }
+
   private async getSignatureHeader(payload: string) {
     const [allSignatureBytes, recoveryByte] = await this.auth.sign(payload)
     const signatureBytes = new Uint8Array(65)
@@ -857,6 +906,9 @@ export class ChatsApi
               created_at: data.metadata.timestamp
             }
           })
+        } else if (data.rpc.method === 'chat.blast') {
+          const userId = data.metadata.userId
+          await this.upgradeBlasts(userId)
         }
       }
       handleAsync()

--- a/packages/libs/src/sdk/api/chats/ChatsApi.ts
+++ b/packages/libs/src/sdk/api/chats/ChatsApi.ts
@@ -810,7 +810,8 @@ export class ChatsApi
               message: blast.plaintext,
               sender_user_id: encodedSenderId,
               created_at: blast.created_at,
-              reactions: []
+              reactions: [],
+              is_plaintext: true
             }
           })
         }

--- a/packages/libs/src/sdk/api/chats/ChatsApi.ts
+++ b/packages/libs/src/sdk/api/chats/ChatsApi.ts
@@ -66,7 +66,6 @@ import type {
   ChatWebsocketEventData,
   RPCPayloadRequest,
   ValidatedChatPermissions,
-  ChatBlast,
   ChatCreateRPC,
   UpgradableChatBlast
 } from './serverTypes'

--- a/packages/libs/src/sdk/api/chats/ChatsApi.ts
+++ b/packages/libs/src/sdk/api/chats/ChatsApi.ts
@@ -906,7 +906,7 @@ export class ChatsApi
             }
           })
         } else if (data.rpc.method === 'chat.blast') {
-          const userId = data.metadata.userId
+          const userId = data.metadata.receiverUserId
           await this.upgradeBlasts(userId)
         }
       }

--- a/packages/libs/src/sdk/api/chats/clientTypes.ts
+++ b/packages/libs/src/sdk/api/chats/clientTypes.ts
@@ -19,7 +19,7 @@ export const ChatListenRequestSchema = z.optional(
 export type ChatListenRequest = z.infer<typeof ChatListenRequestSchema>
 
 export const ChatGetAllRequestSchema = z.object({
-  currentUserId: z.optional(z.string()),
+  userId: z.string(),
   limit: z.optional(z.number()),
   before: z.optional(z.string()),
   after: z.optional(z.string())

--- a/packages/libs/src/sdk/api/chats/serverTypes.ts
+++ b/packages/libs/src/sdk/api/chats/serverTypes.ts
@@ -104,7 +104,6 @@ export type RPCPayloadRequest =
   | ChatBlockRPC
   | ChatUnblockRPC
   | ChatPermitRPC
-  | ChatBlastRPC
   | ValidateCanChatRPC
 
 export type RPCPayload = RPCPayloadRequest & {
@@ -131,15 +130,6 @@ export type UserChat = {
 
   // User chats are not blasts
   is_blast: false
-}
-
-export type ChatBlast = {
-  chat_id: string
-  audience: ChatBlastAudience
-  content_id?: string
-  content_type?: 'track' | 'album'
-  is_blast: true
-  last_message_at: string
 }
 
 export type ChatMessageReaction = {

--- a/packages/libs/src/sdk/api/chats/serverTypes.ts
+++ b/packages/libs/src/sdk/api/chats/serverTypes.ts
@@ -170,6 +170,16 @@ export type ChatInvite = {
   invite_code: string
 }
 
+export type ChatBlast = {
+  chat_id: string
+  pending_chat_id: string
+  from_user_id: number
+  plaintext: string
+  created_at: string
+  audience: ChatBlastAudience
+  audience_track_id?: number
+}
+
 export type ValidatedChatPermissions = {
   user_id: string
   permits: ChatPermission

--- a/packages/libs/src/sdk/api/chats/serverTypes.ts
+++ b/packages/libs/src/sdk/api/chats/serverTypes.ts
@@ -161,8 +161,8 @@ export type ChatInvite = {
 }
 
 export type ChatBlast = {
-  chat_id: string
-  pending_chat_id: string
+  chat_id: string // maps to blast_id on the backend
+  pending_chat_id: string // chat_id to be created when upgrading to UserChat
   from_user_id: number
   plaintext: string
   created_at: string

--- a/packages/libs/src/sdk/api/chats/serverTypes.ts
+++ b/packages/libs/src/sdk/api/chats/serverTypes.ts
@@ -234,7 +234,8 @@ export type CommsResponse = {
 export type ChatWebsocketEventData = {
   rpc: RPCPayload
   metadata: {
-    userId: string
+    senderUserId: string
+    receiverUserId: string
     timestamp: string
   }
 }

--- a/packages/libs/src/sdk/api/chats/serverTypes.ts
+++ b/packages/libs/src/sdk/api/chats/serverTypes.ts
@@ -166,8 +166,11 @@ export type ChatBlast = {
   from_user_id: number
   plaintext: string
   created_at: string
+  last_message_at: string
   audience: ChatBlastAudience
-  audience_track_id?: number
+  content_id?: number
+  content_type?: 'track' | 'album'
+  is_blast: true
 }
 
 export type ValidatedChatPermissions = {

--- a/packages/libs/src/sdk/api/chats/serverTypes.ts
+++ b/packages/libs/src/sdk/api/chats/serverTypes.ts
@@ -160,17 +160,25 @@ export type ChatInvite = {
   invite_code: string
 }
 
-export type ChatBlast = {
+type ChatBlastBase = {
   chat_id: string // maps to blast_id on the backend
+  audience: ChatBlastAudience
+  audience_content_id?: string
+  audience_content_type?: 'track' | 'album'
+}
+
+// Return type of getNewBlasts
+export type UpgradableChatBlast = ChatBlastBase & {
   pending_chat_id: string // chat_id to be created when upgrading to UserChat
   from_user_id: number
   plaintext: string
   created_at: string
-  last_message_at: string
-  audience: ChatBlastAudience
-  content_id?: number
-  content_type?: 'track' | 'album'
+}
+
+// Client-side chat blast
+export type ChatBlast = ChatBlastBase & {
   is_blast: true
+  last_message_at: string
 }
 
 export type ValidatedChatPermissions = {


### PR DESCRIPTION
### Description

Second attempt at https://github.com/AudiusProject/audius-protocol/pull/9438

* In sdk getAll function, always fetch pending blasts and upgrade them. Note this will also get called on further pagination calls to getAll. I think this is fine? Alternative is to upgrade manually on client. Feels better to encapsulate this functionality inside sdk.
* Always include currentUserId param in calls to getAll on our client. We need this to upgrade the blasts (as Chats API in sdk was designed to be stateless).
* Modify rpc metadata to include both `senderUserId` and `receiverUserId` to support stateless chats api.
* Modify websocket server to maintain a map of userId to list of websockets, instead of just a flatlist of websockets+userId structs.
* Add websocketPushAll function to comms server that iterates through all keys in the map and calls `websocketPush` on each key.

### How Has This Been Tested?

* Sent a blast from reed to followers andrew and steve while steve was logged in.
* Confirmed steve received the blast
* Subsequent normal 1-on-1 chat functionality works fine
* Confirmed functionality even when steve is logged in on 2 separate tabs (2 separate websockets)

Video 
https://github.com/user-attachments/assets/fe62d439-d793-40aa-8204-ff44fced5d07

* Also tested the case where steve wasn't logged in when the blast was sent, confirmed it is upgraded on login.