### PR TITLE
bump web3 version for ci

### DIFF
--- a/packages/discovery-provider/requirements.txt
+++ b/packages/discovery-provider/requirements.txt
@@ -12,7 +12,7 @@ types-pytz==2021.1.2
 types-freezegun==1.1.10
 types-Flask==1.1.6
 
-web3==6.6.1
+web3==6.20.2
 hexbytes==0.3.1
 Flask==1.0.4
 # pin itsdangerous and markupsafe https://github.com/pallets/flask/issues/4455


### PR DESCRIPTION
### Description
transient python deps again, `eth_typing` had an issue with exporting `ContractName`, is fixed in a future web3 version so upgraded.
https://github.com/ethereum/eth-typing/issues/63

### How Has This Been Tested?
`audius-compose test discovery-provider`
