### PR TITLE
Use quotes to escape job name for jq

### DIFF
--- a/.circleci/scripts/auto-approve-release.sh
+++ b/.circleci/scripts/auto-approve-release.sh
@@ -96,7 +96,7 @@ workflow_id=$(curl --request GET \
 # Fetch the appropriate deployment job
 job_id=$(curl --request GET \
   "https://circleci.com/api/v2/workflow/$workflow_id/job" \
-  --header "Circle-Token: $CIRCLE_DAILY_DEPLOY_API_TOKEN" | jq -r '.items[] | select(.name=='"$job_name"' and .status=="on_hold") | .id')
+  --header "Circle-Token: $CIRCLE_DAILY_DEPLOY_API_TOKEN" | jq -r '.items[] | select(.name=='"\"$job_name\""' and .status=="on_hold") | .id')
 
 # If we found the job, approve it automatically
 if [ -n "$job_id" ]; then


### PR DESCRIPTION
### Description

jq splits tokens by `-` character

### How Has This Been Tested?

```
$ jobname='auto-approve-foundation'
$ echo '{"items":[{"name":"auto-approve-founcation","status":"on_hold","id":"abc123"}]}' | jq -r '.items[] | select(.name=='"\"$jobname\""' and .status=="on_hold") | .id'

> abc123
```
