### PR TITLE
Fix chat deadlock

### DIFF
--- a/comms/discovery/rpcz/websocket.go
+++ b/comms/discovery/rpcz/websocket.go
@@ -46,9 +46,6 @@ func RegisterWebsocket(userId int32, conn net.Conn) {
 }
 
 func removeWebsocket(userId int32, toRemove net.Conn) {
-	mu.Lock()
-	defer mu.Unlock()
-
 	keep := make([]net.Conn, 0, len(websockets[userId]))
 	for _, s := range websockets[userId] {
 		if s == toRemove {


### PR DESCRIPTION
### Description
Whoops! mutex is held by calling function. If the websocket push fails, we'd call `removeWebsocket` and hit the deadlock condition.

### How Has This Been Tested?

DMs working on local stack again