### PR TITLE
Fix bad claimable challenge state due to nullable max_steps

### DIFF
--- a/packages/common/src/adapters/challenge.ts
+++ b/packages/common/src/adapters/challenge.ts
@@ -18,7 +18,7 @@ export const userChallengeFromSDK = (
     challenge_type: input.challengeType as ChallengeType,
     cooldown_days: input.cooldownDays ?? 0,
     current_step_count: input.currentStepCount ?? 0,
-    max_steps: input.maxSteps ?? 0,
+    max_steps: input.maxSteps ?? null,
     specifier: input.specifier ?? ''
   }
 }

--- a/packages/common/src/hooks/useAudioRewards.ts
+++ b/packages/common/src/hooks/useAudioRewards.ts
@@ -32,7 +32,10 @@ export const useFormattedProgressLabel = ({
       label = messages.readyToClaim
     } else if (pending) {
       label = messages.pendingRewards
-    } else if (challenge?.challenge_type === 'aggregate') {
+    } else if (
+      challenge?.challenge_type === 'aggregate' &&
+      challenge?.max_steps !== null
+    ) {
       // Count down
       label = fillString(
         remainingLabel ?? '',
@@ -49,7 +52,10 @@ export const useFormattedProgressLabel = ({
         formatNumberCommas(challenge?.max_steps?.toString() ?? '')
       )
     }
-  } else if (challenge?.challenge_type === 'aggregate') {
+  } else if (
+    challenge?.challenge_type === 'aggregate' &&
+    challenge?.max_steps !== null
+  ) {
     // Count down
     label = fillString(
       remainingLabel ?? '',

--- a/packages/common/src/models/AudioRewards.ts
+++ b/packages/common/src/models/AudioRewards.ts
@@ -1,3 +1,5 @@
+import { Nullable } from '~/utils/typeUtils'
+
 export type ChallengeType = 'boolean' | 'numeric' | 'aggregate' | 'trending'
 
 // TODO: Fix the types here so they are consistent with API
@@ -10,7 +12,7 @@ export type UserChallenge = {
   is_active: boolean
   is_complete: boolean
   is_disbursed: boolean
-  max_steps: number
+  max_steps: Nullable<number>
   specifier: Specifier
   user_id: string
   amount: number

--- a/packages/common/src/store/challenges/selectors/optimistic-challenges.ts
+++ b/packages/common/src/store/challenges/selectors/optimistic-challenges.ts
@@ -84,7 +84,11 @@ const toOptimisticChallenge = (
 
   // The client is more up to date than Discovery Nodes, so override whenever possible.
   // Don't override if the challenge is already marked as completed on Discovery.
-  if (!challenge.is_complete && currentStepCountOverride !== undefined) {
+  if (
+    !challenge.is_complete &&
+    currentStepCountOverride !== undefined &&
+    challengeOverridden.max_steps !== null
+  ) {
     challengeOverridden.current_step_count = currentStepCountOverride
     challengeOverridden.is_complete =
       currentStepCountOverride >= challengeOverridden.max_steps
@@ -102,7 +106,7 @@ const toOptimisticChallenge = (
   // you'd get when completing every step of the challenge
   // -- i.e. for referrals, show 1 audio x 5 steps = 5 audio
   const totalAmount =
-    challenge.challenge_type === 'aggregate'
+    challenge.challenge_type === 'aggregate' && challenge.max_steps !== null
       ? challenge.amount * challenge.max_steps
       : challenge.amount
 

--- a/packages/mobile/src/components/challenge-rewards-drawer/ChallengeRewardsDrawerProvider.tsx
+++ b/packages/mobile/src/components/challenge-rewards-drawer/ChallengeRewardsDrawerProvider.tsx
@@ -215,7 +215,7 @@ export const ChallengeRewardsDrawerProvider = () => {
           isCooldownChallenge={challenge && challenge.cooldown_days > 0}
           challengeState={challenge.state}
           currentStep={challenge.current_step_count}
-          stepCount={challenge.max_steps}
+          stepCount={challenge.max_steps ?? undefined}
           claimableAmount={audioToClaim}
           claimedAmount={audioClaimedSoFar}
           claimStatus={claimStatus}
@@ -223,7 +223,9 @@ export const ChallengeRewardsDrawerProvider = () => {
           onClaim={hasConfig ? onClaim : undefined}
           isVerifiedChallenge={!!config.isVerifiedChallenge}
           showProgressBar={
-            challenge.challenge_type !== 'aggregate' && challenge.max_steps > 1
+            challenge.challenge_type !== 'aggregate' &&
+            challenge.max_steps !== null &&
+            challenge.max_steps > 1
           }
         >
           {contents}

--- a/packages/web/src/pages/audio-rewards-page/ChallengeRewardsTile.tsx
+++ b/packages/web/src/pages/audio-rewards-page/ChallengeRewardsTile.tsx
@@ -133,6 +133,7 @@ const RewardPanel = ({
   const needsDisbursement = challenge && challenge.claimableAmount > 0
   const shouldShowProgressBar =
     challenge &&
+    challenge.max_steps &&
     challenge.max_steps > 1 &&
     challenge.challenge_type !== 'aggregate' &&
     !hasDisbursed
@@ -188,7 +189,7 @@ const RewardPanel = ({
         <div className={wm(styles.rewardProgress)}>
           {needsDisbursement && <IconCheck className={wm(styles.iconCheck)} />}
           <p className={styles.rewardProgressLabel}>{formattedProgressLabel}</p>
-          {shouldShowProgressBar && (
+          {shouldShowProgressBar && challenge.max_steps && (
             <ProgressBar
               className={styles.rewardProgressBar}
               value={challenge?.current_step_count ?? 0}

--- a/packages/web/src/pages/audio-rewards-page/components/modals/ChallengeRewardsModal/ChallengeRewardsModal.tsx
+++ b/packages/web/src/pages/audio-rewards-page/components/modals/ChallengeRewardsModal/ChallengeRewardsModal.tsx
@@ -295,6 +295,7 @@ const ChallengeRewardsBody = ({ dismissModal }: BodyProps) => {
 
   const showProgressBar =
     challenge &&
+    challenge.max_steps &&
     challenge.max_steps > 1 &&
     challenge.challenge_type !== 'aggregate'
 
@@ -435,7 +436,7 @@ const ChallengeRewardsBody = ({ dismissModal }: BodyProps) => {
   }
 
   const renderProgressBar = () => {
-    if (showProgressBar) {
+    if (showProgressBar && challenge.max_steps) {
       return (
         <div className={wm(styles.progressBarSection)}>
           {isMobile ? (


### PR DESCRIPTION
### Description


#9432 Made an assumption that since a lot of the code reading `max_steps` assumed it was a valid number, `0` was a safe default. What was actually happening was that the type was wrong and we were casting around it in apiClient. `max_steps` should be Nullable, since not all challenge types use it. I updated the type, removed the default value of 0, and fixed all the places in the code that were using the bad assumption that it's always a number.

The symptom exhibited by this bug was that users with no claimable challenges would see a notification dot due to challenges with `max_steps=null` getting coerced to `0` and a check of `current_step_count === max_step_count`. 


### How Has This Been Tested?
Tested locally against staging with accounts that have claimable challenges and no claimable challenges.
