### PR TITLE
Fix malformed json in auto-approve script

### DIFF
--- a/.circleci/scripts/auto-approve-release.sh
+++ b/.circleci/scripts/auto-approve-release.sh
@@ -2,10 +2,20 @@
 set -e
 
 function send_slack_message() {
-  json_content="{ \"blocks\": ["
-  json_content+="\"type\": \"section\","
-  json_content+="\"text\": { \"type\": \"mrkdwn\", \"text\": \"$1\" }"
-  json_content+="}]}"
+  json_content="$(cat <<EOF
+{ 
+  "blocks": [
+    {
+      "type": "section",
+      "text": {
+        "type": "mrkdwn",
+        "text": "$1"
+      }
+    }
+  ]
+}
+EOF
+  )"
 
   curl -f -X POST -H 'Content-type: application/json' \
     --data "$json_content" \


### PR DESCRIPTION
### Description

as title

### How Has This Been Tested?

```
$ foo="random string"
$ json_content="$(cat <<EOF
{
  "blocks": [
    {
      "type": "section",
      "text": {
        "type": "mrkdwn",
        "text": "$foo"
      }
    }
  ]
}
EOF
)"
$ curl -X POST https://httpbin.org/post \
     -H "Content-Type: application/json" \
     --data "$json_content" | jq '.json.blocks[0].text.text'

> random string
```