### PR TITLE
default connection strings

### DIFF
--- a/core/config/config.go
+++ b/core/config/config.go
@@ -66,12 +66,12 @@ func ReadConfig(logger *common.Logger) (*Config, error) {
 	if isDiscovery {
 		cfg.Environment = os.Getenv("audius_discprov_env")
 		cfg.DelegatePrivateKey = os.Getenv("audius_delegate_private_key")
-		cfg.PSQLConn = os.Getenv("audius_db_url")
+		cfg.PSQLConn = getEnvString("audius_db_url", DefaultDiscoveryPostgresConnectionString)
 	} else {
 		// isContent
 		cfg.Environment = os.Getenv("MEDIORUM_ENV")
 		cfg.DelegatePrivateKey = os.Getenv("delegatePrivateKey")
-		cfg.PSQLConn = os.Getenv("dbUrl")
+		cfg.PSQLConn = getEnvString("dbUrl", DefaultContentPostgresConnectionString)
 	}
 
 	if cfg.Environment == "" {

--- a/core/config/defaults.go
+++ b/core/config/defaults.go
@@ -4,4 +4,7 @@ const (
 	DefaultRPCAddress             = "tcp://0.0.0.0:26657"
 	DefaultP2PAddress             = "tcp://0.0.0.0:26656"
 	DefaultTestnetPersistentPeers = "0f4be2aaa70e9570eee3485d8fa54502cf1a9fc0@34.67.210.7:26656"
+
+	DefaultDiscoveryPostgresConnectionString = "postgresql://postgres:postgres@db:5432/audius_discovery"
+	DefaultContentPostgresConnectionString   = "postgres://postgres:postgres@db:5432/audius_creator_node"
 )


### PR DESCRIPTION
### Description
mediorum doesn't get pg string through env var, it's hardcoded into mediorum

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._
