### PR TITLE
Enabling blocking users from commenting

### DIFF
--- a/packages/discovery-provider/src/models/users/chat_blocked_users.py
+++ b/packages/discovery-provider/src/models/users/chat_blocked_users.py
@@ -1,0 +1,12 @@
+from sqlalchemy import Column, DateTime, Integer
+
+from src.models.base import Base
+from src.models.model_utils import RepresentableMixin
+
+
+class ChatBlockedUser(Base, RepresentableMixin):
+    __tablename__ = "chat_blocked_users"
+
+    blocker_user_id = Column(Integer, primary_key=True, nullable=False)
+    blockee_user_id = Column(Integer, primary_key=True, nullable=False, index=True)
+    created_at = Column(DateTime, nullable=False)

--- a/packages/discovery-provider/src/queries/get_comments.py
+++ b/packages/discovery-provider/src/queries/get_comments.py
@@ -7,6 +7,8 @@ from src.api.v1.helpers import format_limit, format_offset
 from src.models.comments.comment import Comment
 from src.models.comments.comment_reaction import CommentReaction
 from src.models.comments.comment_thread import CommentThread
+from src.models.tracks.track import Track
+from src.models.users.chat_blocked_users import ChatBlockedUser
 from src.utils import redis_connection
 from src.utils.db_session import get_db_read_replica
 from src.utils.helpers import encode_int_id
@@ -66,6 +68,14 @@ def get_track_comments(args, track_id):
     CommentThreadAlias = aliased(CommentThread)
 
     with db.scoped_session() as session:
+        # Subquery to get blocked users for the track's owner
+        blocked_users_subquery = (
+            session.query(ChatBlockedUser.blockee_user_id)
+            .join(Track, Track.owner_id == ChatBlockedUser.blocker_user_id)
+            .filter(Track.track_id == track_id)
+            .all()
+        )
+
         track_comments = (
             session.query(Comment)
             .outerjoin(
@@ -78,6 +88,7 @@ def get_track_comments(args, track_id):
                 CommentThreadAlias.parent_comment_id
                 == None,  # Check if parent_comment_id is null
                 Comment.is_delete == False,
+                ~Comment.user_id.in_(blocked_users_subquery),  # Exclude blocked users
             )
             .order_by(desc(Comment.created_at))
             .offset(offset)

--- a/packages/web/src/components/comments/CommentSectionContext.tsx
+++ b/packages/web/src/components/comments/CommentSectionContext.tsx
@@ -24,6 +24,7 @@ import { EntityType, Comment } from '@audius/sdk'
 // Props passed in from above
 type CommentSectionContextProps = {
   userId: Nullable<ID>
+  artistId: ID
   entityId: ID
   entityType?: EntityType.TRACK
 }
@@ -65,6 +66,7 @@ export const CommentSectionProvider = ({
   userId,
   entityId,
   entityType = EntityType.TRACK,
+  artistId,
   children
 }: PropsWithChildren<CommentSectionContextProps>) => {
   const {
@@ -165,6 +167,7 @@ export const CommentSectionProvider = ({
       value={{
         userId,
         entityId,
+        artistId,
         entityType,
         comments,
         commentSectionLoading,

--- a/packages/web/src/components/comments/CommentSectionDesktop.tsx
+++ b/packages/web/src/components/comments/CommentSectionDesktop.tsx
@@ -1,5 +1,8 @@
 import { Status } from '@audius/common/models'
+import { chatSelectors } from '@audius/common/store'
 import { Button, Divider, Flex, Paper, Skeleton } from '@audius/harmony'
+
+import { useSelector } from 'utils/reducer'
 
 import { CommentForm } from './CommentForm'
 import { CommentHeader } from './CommentHeader'
@@ -7,9 +10,11 @@ import { useCurrentCommentSection } from './CommentSectionContext'
 import { CommentThread } from './CommentThread'
 import { NoComments } from './NoComments'
 
+const { getCanCreateChat } = chatSelectors
+
 export const CommentSectionDesktop = () => {
   const {
-    userId,
+    artistId,
     comments,
     commentSectionLoading,
     usePostComment,
@@ -19,7 +24,10 @@ export const CommentSectionDesktop = () => {
   const handlePostComment = (message: string) => {
     postComment(message, undefined)
   }
-  const commentPostAllowed = userId !== null
+
+  const { canCreateChat: commentPostAllowed } = useSelector((state) =>
+    getCanCreateChat(state, { userId: artistId })
+  )
 
   // Loading state
   if (commentSectionLoading)
@@ -50,7 +58,7 @@ export const CommentSectionDesktop = () => {
     <Flex gap='l' direction='column' w='100%' alignItems='flex-start'>
       <CommentHeader commentCount={comments.length} />
       <Paper w='100%' direction='column'>
-        {commentPostAllowed !== null ? (
+        {commentPostAllowed ? (
           <>
             <Flex gap='s' p='xl' w='100%' direction='column'>
               <CommentForm

--- a/packages/web/src/pages/track-page/components/desktop/TrackPage.tsx
+++ b/packages/web/src/pages/track-page/components/desktop/TrackPage.tsx
@@ -250,11 +250,12 @@ const TrackPage = ({
           css={{ maxWidth: 1080 }}
           justifyContent='center'
         >
-          {isCommentingEnabled ? (
+          {isCommentingEnabled && heroTrack?.owner_id ? (
             <Flex flex='3'>
               <CommentSectionProvider
                 userId={userId}
                 entityId={defaults.trackId}
+                artistId={heroTrack.owner_id}
               >
                 <CommentSectionDesktop />
               </CommentSectionProvider>


### PR DESCRIPTION
### Description

When an artist blocks a user from DMs, it'll also block the user from commenting. The comments from that blocked user will also be hidden.

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._

Blocked this user from commenting on my track. Confirmed that blocked user is unable to comment and non-blocked user comments still show. 

<img width="474" alt="Screenshot 2024-08-15 at 3 54 29 PM" src="https://github.com/user-attachments/assets/b14e5040-5798-4bc4-938c-f16263ccae4a">
