### PR TITLE
Don't decrypt plaintext chat.last_message

### DIFF
--- a/.changeset/cold-bees-rest.md
+++ b/.changeset/cold-bees-rest.md
@@ -1,0 +1,5 @@
+---
+'@audius/sdk': patch
+---
+
+Don't decrypt plaintext chat.last_message

--- a/comms/discovery/server/response_mapper.go
+++ b/comms/discovery/server/response_mapper.go
@@ -29,11 +29,12 @@ func ToChatMemberResponse(member db.ChatMember) schema.ChatMember {
 
 func ToChatResponse(chat queries.UserChatRow, members []db.ChatMember) schema.UserChat {
 	chatData := schema.UserChat{
-		ChatID:             chat.ChatID,
-		LastMessageAt:      chat.LastMessageAt.Format(time.RFC3339Nano),
-		InviteCode:         chat.InviteCode,
-		UnreadMessageCount: float64(chat.UnreadCount),
-		ChatMembers:        Map(members, ToChatMemberResponse),
+		ChatID:                 chat.ChatID,
+		LastMessageAt:          chat.LastMessageAt.Format(time.RFC3339Nano),
+		InviteCode:             chat.InviteCode,
+		UnreadMessageCount:     float64(chat.UnreadCount),
+		ChatMembers:            Map(members, ToChatMemberResponse),
+		LastMessageIsPlaintext: chat.LastMessageIsPlaintext,
 	}
 	chatData.RecheckPermissions = rpcz.RecheckPermissionsRequired(chat.LastMessageAt, members)
 	if chat.LastMessage.Valid {

--- a/packages/libs/src/sdk/api/chats/ChatsApi.ts
+++ b/packages/libs/src/sdk/api/chats/ChatsApi.ts
@@ -730,6 +730,7 @@ export class ChatsApi
   }
 
   private async decryptLastChatMessage(c: UserChat): Promise<UserChat> {
+    if (c.last_message_is_plaintext) return c
     let lastMessage = ''
     try {
       const sharedSecret = await this.getChatSecret(c.chat_id)


### PR DESCRIPTION
### Description
Don't decrypt `chat.last_message` if `chat.last_message_is_plaintext` is true
Fix bug where we forgot to pass that field along in the response.

Note: Needs changes from https://github.com/AudiusProject/audius-protocol/pull/9466 for sdk-init to pass

### How Has This Been Tested?

Working against local stack - tested both websocket case (incoming blast during live session) and fetch case (login after blast was sent)

<img width="729" alt="Screenshot 2024-08-15 at 10 44 05 PM" src="https://github.com/user-attachments/assets/aae41971-6e6a-4c02-9d56-4a6446de413a">
