### PR TITLE
[PAY-3299] Chat blast sender endpoints

### DIFF
--- a/comms/Makefile
+++ b/comms/Makefile
@@ -18,7 +18,7 @@ test::
 
 
 steve.test::
-	docker compose -f docker-compose.test.yml down
+	# docker compose -f docker-compose.test.yml down
 	docker compose -f docker-compose.test.yml up -d
 
 	audius_db_url="postgresql://postgres:password@localhost:25432/postgres?sslmode=disable" \

--- a/comms/discovery/db/queries/get_chat_messages.go
+++ b/comms/discovery/db/queries/get_chat_messages.go
@@ -136,6 +136,7 @@ func ChatMessagesAndReactions(q db.Queryable, ctx context.Context, arg ChatMessa
 			  AND b.created_at < $4
 			  AND b.created_at > $5
 			ORDER BY b.created_at DESC
+			LIMIT $6
 			`
 
 			err := q.SelectContext(ctx, &rows, outgoingBlastMessages,
@@ -144,6 +145,7 @@ func ChatMessagesAndReactions(q db.Queryable, ctx context.Context, arg ChatMessa
 				audience,
 				arg.Before,
 				arg.After,
+				arg.Limit,
 			)
 			return rows, err
 		} else {

--- a/comms/discovery/rpcz/chat_blast_test.go
+++ b/comms/discovery/rpcz/chat_blast_test.go
@@ -34,8 +34,8 @@ func TestChatBlast(t *testing.T) {
 			UserID: userID,
 			ChatID: chatID,
 			Limit:  10,
-			Before: time.Now().Add(time.Hour * 12),
-			After:  time.Now().Add(time.Hour * -12),
+			Before: time.Now().Add(time.Hour * 2).UTC(),
+			After:  time.Now().Add(time.Hour * -2).UTC(),
 		})
 		if err != nil {
 			panic(err)
@@ -273,6 +273,18 @@ func TestChatBlast(t *testing.T) {
 			}
 		}
 
+	}
+
+	// ------ sender can get blasts in a given thread ----------
+	{
+		messages, err := queries.ChatMessagesAndReactions(tx, ctx, queries.ChatMessagesAndReactionsParams{
+			UserID: 69,
+			ChatID: "blast:asdf:follower_audience",
+			Before: time.Now().Add(time.Hour * 2).UTC(),
+			After:  time.Now().Add(time.Hour * -2).UTC(),
+		})
+		assert.NoError(t, err)
+		assert.Len(t, messages, 2)
 	}
 
 	err = tx.Rollback()

--- a/comms/discovery/rpcz/chat_blast_test.go
+++ b/comms/discovery/rpcz/chat_blast_test.go
@@ -324,9 +324,10 @@ func TestChatBlast(t *testing.T) {
 	{
 		messages, err := queries.ChatMessagesAndReactions(tx, ctx, queries.ChatMessagesAndReactionsParams{
 			UserID: 69,
-			ChatID: "blast:asdf:follower_audience",
+			ChatID: "blast:69:follower_audience",
 			Before: time.Now().Add(time.Hour * 2).UTC(),
 			After:  time.Now().Add(time.Hour * -2).UTC(),
+			Limit:  10,
 		})
 		assert.NoError(t, err)
 		assert.Len(t, messages, 2)


### PR DESCRIPTION
### Description

* `/chats` endpoint includes outgoing blasts from current user ID.  ID is generated as `blast:userId:audience:contentType:contentId` so e.g. `blast:1:follower_audience`
* `/chats/blast:1:follower_audience` will return outgoing blasts from current user for a specific audience.
