### PR TITLE
[PAY-3358] Fire chat message RPCs on blast write

### DIFF
--- a/comms/discovery/rpcz/apply.go
+++ b/comms/discovery/rpcz/apply.go
@@ -330,8 +330,9 @@ func (proc *RPCProcessor) Apply(rpcLog *schema.RpcLog) error {
 				j, err := json.Marshal(outgoingMessage.ChatMessageRPC)
 				if err != nil {
 					slog.Error("err: invalid json", "err", err)
+				} else {
+					websocketNotify(json.RawMessage(j), userId, messageTs.Round(time.Microsecond))
 				}
-				websocketNotify(json.RawMessage(j), userId, messageTs.Round(time.Microsecond))
 			}
 		default:
 			logger.Warn("no handler for ", rawRpc.Method)

--- a/comms/discovery/rpcz/chat_blast_test.go
+++ b/comms/discovery/rpcz/chat_blast_test.go
@@ -102,7 +102,7 @@ func TestChatBlast(t *testing.T) {
 	// ----------------- a first blast ------------------------
 	chatId_101_69 := misc.ChatID(101, 69)
 
-	err = chatBlast(tx, 69, t2, schema.ChatBlastRPCParams{
+	_, err = chatBlast(tx, 69, t2, schema.ChatBlastRPCParams{
 		BlastID:  "b1",
 		Audience: schema.FollowerAudience,
 		Message:  "what up fam",
@@ -221,7 +221,7 @@ func TestChatBlast(t *testing.T) {
 	}
 
 	// ----------------- a second message ------------------------
-	err = chatBlast(tx, 69, t4, schema.ChatBlastRPCParams{
+	_, err = chatBlast(tx, 69, t4, schema.ChatBlastRPCParams{
 		BlastID:  "b2",
 		Audience: schema.FollowerAudience,
 		Message:  "happy wed",

--- a/comms/discovery/schema/schema.go
+++ b/comms/discovery/schema/schema.go
@@ -71,6 +71,7 @@ type ChatMessageRPCParams struct {
 	Message         string  `json:"message"`
 	MessageID       string  `json:"message_id"`
 	ParentMessageID *string `json:"parent_message_id,omitempty"`
+	IsPlaintext     bool    `json:"is_plaintext"`
 }
 
 type ChatReactRPC struct {

--- a/packages/libs/src/sdk/api/chats/ChatsApi.ts
+++ b/packages/libs/src/sdk/api/chats/ChatsApi.ts
@@ -887,21 +887,23 @@ export class ChatsApi
             chatId: data.rpc.params.chat_id,
             message: {
               message_id: data.rpc.params.message_id,
-              message: await this.decryptString(
-                sharedSecret,
-                base64.decode(data.rpc.params.message)
-              ).catch((e) => {
-                this.logger.error(
-                  "[audius-sdk]: Error: Couldn't decrypt websocket chat message",
-                  data,
-                  e
-                )
-                return GENERIC_MESSAGE_ERROR
-              }),
+              message: data.rpc.params.is_plaintext
+                ? data.rpc.params.message
+                : await this.decryptString(
+                    sharedSecret,
+                    base64.decode(data.rpc.params.message)
+                  ).catch((e) => {
+                    this.logger.error(
+                      "[audius-sdk]: Error: Couldn't decrypt websocket chat message",
+                      data,
+                      e
+                    )
+                    return GENERIC_MESSAGE_ERROR
+                  }),
               sender_user_id: data.metadata.senderUserId,
               created_at: data.metadata.timestamp,
               reactions: [],
-              is_plaintext: false
+              is_plaintext: !!data.rpc.params.is_plaintext
             }
           })
         } else if (data.rpc.method === 'chat.react') {

--- a/packages/libs/src/sdk/api/chats/serverTypes.ts
+++ b/packages/libs/src/sdk/api/chats/serverTypes.ts
@@ -54,6 +54,7 @@ export type ChatMessageRPC = {
     message_id: string
     message: string
     parent_message_id?: string
+    is_plaintext?: boolean
   }
 }
 


### PR DESCRIPTION
### Description
If artist sends a chat blast, for users who have an existing thread with the artist, the backend will insert rows to chat_message table but won't fire websocket events.

This PR:
- Formulates `ChatMessageRPC`'s for each user who has an existing chat
- Fires them off via `websocketNotify`
- Adds `is_plaintext` field to `ChatMessageRPC` so the client knows not to decrypt them. 

### How Has This Been Tested?

https://github.com/user-attachments/assets/02008afd-a1d2-4014-8560-a89a49aa588f

