### PR TITLE
[PAY-3309] Add is_hidden column to chat_member

### DIFF
--- a/comms/discovery/db/queries/get_chats.go
+++ b/comms/discovery/db/queries/get_chats.go
@@ -72,6 +72,7 @@ SELECT
 FROM chat_member
 JOIN chat ON chat.chat_id = chat_member.chat_id
 WHERE chat_member.user_id = $1
+  AND chat_member.is_hidden = false
   AND chat.last_message IS NOT NULL
 	AND chat.last_message_at < $3
 	AND chat.last_message_at > $4

--- a/packages/discovery-provider/ddl/migrations/0092_chat_member_hidden.sql
+++ b/packages/discovery-provider/ddl/migrations/0092_chat_member_hidden.sql
@@ -1,0 +1,5 @@
+begin;
+
+ALTER TABLE chat_member ADD COLUMN IF NOT EXISTS is_hidden boolean not null default false;
+
+commit;


### PR DESCRIPTION
Hides a thread unless there are valid chat messages or blasts from the other party.