### PR TITLE
[QA-1514] Fix search filter typing

### DIFF
--- a/packages/harmony/src/components/button/FilterButton/FilterButton.tsx
+++ b/packages/harmony/src/components/button/FilterButton/FilterButton.tsx
@@ -154,7 +154,7 @@ export const FilterButton = forwardRef(function FilterButton<
     } else {
       setIsOpen((isOpen: boolean) => !isOpen)
     }
-  }, [setIsOpen, onClick])
+  }, [onClick])
 
   const hasOptions = options && options.length > 0
 
@@ -193,9 +193,16 @@ export const FilterButton = forwardRef(function FilterButton<
     (value: Value) => {
       setValue(value)
       onChange?.(value)
+    },
+    [onChange, setValue]
+  )
+
+  const handleOptionSelected = useCallback(
+    (value: Value) => {
+      handleChange(value)
       setIsOpen(false)
     },
-    [onChange, setValue, setIsOpen]
+    [handleChange]
   )
 
   const filteredOptions = useMemo(
@@ -212,7 +219,7 @@ export const FilterButton = forwardRef(function FilterButton<
     <FilterButtonKeyHandler
       options={filteredOptions}
       disabled={!isOpen}
-      onChange={handleChange}
+      onChange={handleOptionSelected}
       optionRefs={optionRefs}
       scrollRef={scrollRef}
     >
@@ -226,7 +233,7 @@ export const FilterButton = forwardRef(function FilterButton<
             }}
             key={option.value}
             option={option}
-            onChange={handleChange}
+            onChange={handleOptionSelected}
             activeValue={activeValue}
           />
         ))
@@ -252,9 +259,18 @@ export const FilterButton = forwardRef(function FilterButton<
         onClose={() => setIsOpen(false)}
         {...popupProps}
       >
-        <Paper mt='s' border='strong' shadow='far'>
+        <Paper
+          mt='s'
+          border='strong'
+          shadow='far'
+          onClick={(e) => e.stopPropagation()}
+        >
           {children ? (
-            children({ onChange: handleChange, options: optionElements })
+            children({
+              onChange: handleChange,
+              options: optionElements,
+              setIsOpen
+            })
           ) : (
             <Flex
               direction='column'

--- a/packages/harmony/src/components/button/FilterButton/types.ts
+++ b/packages/harmony/src/components/button/FilterButton/types.ts
@@ -36,6 +36,7 @@ type ChildrenProps<Value> = {
    */
   onChange: (value: Value) => void
   options: ReactNode
+  setIsOpen: (isOpen: boolean) => void
 }
 
 export type FilterButtonProps<Value extends string = string> = {

--- a/packages/web/src/pages/search-page-v2/BpmFilter.tsx
+++ b/packages/web/src/pages/search-page-v2/BpmFilter.tsx
@@ -84,9 +84,10 @@ const messages = {
 type ViewProps = {
   value: string | null
   handleChange: (value: string, label: string) => void
+  setIsOpen: (isOpen: boolean) => void
 }
 
-const BpmRangeView = ({ value, handleChange }: ViewProps) => {
+const BpmRangeView = ({ value, handleChange, setIsOpen }: ViewProps) => {
   const minMaxValue = value?.includes('-') ? value.split('-') : null
   const isValueRangeOption = Boolean(
     bpmOptions.find((opt) => opt.value === value)
@@ -179,9 +180,10 @@ const BpmRangeView = ({ value, handleChange }: ViewProps) => {
             activeValue={
               isValueRangeOption && !(minBpm || maxBpm) ? value : undefined
             }
-            onChange={() =>
+            onChange={() => {
               handleChange(option.value, option.helperText ?? option.value)
-            }
+              setIsOpen(false)
+            }}
           />
         ))}
       </Flex>
@@ -299,14 +301,7 @@ const BpmTargetView = ({ value, handleChange }: ViewProps) => {
   }, [bpmTarget, bpmTargetType, error, hasChanged, onChange])
 
   return (
-    <Flex
-      direction='column'
-      w='100%'
-      ph='s'
-      gap='s'
-      // NOTE: Adds a little flexibility so the user doesn't close the popup by accident
-      onClick={(e) => e.stopPropagation()}
-    >
+    <Flex direction='column' w='100%' ph='s' gap='s'>
       <TextInput
         defaultValue={initialTargetValue ?? ''}
         label={messages.bpm}
@@ -368,7 +363,7 @@ export const BpmFilter = () => {
         transformOrigin: { vertical: 'top', horizontal: 'left' }
       }}
     >
-      {({ onChange }) => (
+      {({ onChange, setIsOpen }) => (
         <Flex
           w='100%'
           pv='s'
@@ -393,7 +388,11 @@ export const BpmFilter = () => {
             />
           </Flex>
           <Divider css={{ width: '100%' }} />
-          <InputView value={validatedBpm} handleChange={onChange} />
+          <InputView
+            value={validatedBpm}
+            handleChange={onChange}
+            setIsOpen={setIsOpen}
+          />
         </Flex>
       )}
     </FilterButton>


### PR DESCRIPTION
### Description

Fix an issue where typing in an input in a search filter (BPM filter) closes the popup immediately.

This was because we were setting isOpen false in `handleChange` which is called for all value changes, including typing in the bpm input. Needed to update it to only close when a FilterButtonOption is selected. Also I moved the e.stopPropagation to the root of the popup so that accidental clicks in the popup container do not close the popup

Will cherry pick and deploy to prod and cherry pick to this weeks release branch also

### How Has This Been Tested?

Confirmed all search filters work as expected