### PR TITLE
Fix challenge claim notification amount

### DIFF
--- a/packages/common/src/services/audius-backend/AudiusBackend.ts
+++ b/packages/common/src/services/audius-backend/AudiusBackend.ts
@@ -1739,6 +1739,7 @@ export const audiusBackend = ({
         type: NotificationType.ChallengeReward,
         challengeId,
         entityType: Entity.User,
+        amount: data.amount as StringWei,
         ...formatBaseNotification(notification)
       }
     } else if (notification.type === 'claimable_reward') {

--- a/packages/common/src/store/notifications/types.ts
+++ b/packages/common/src/store/notifications/types.ts
@@ -802,6 +802,7 @@ export type ChallengeRewardNotification = BaseNotification & {
   type: NotificationType.ChallengeReward
   challengeId: ChallengeRewardID
   entityType: string
+  amount: StringWei
 }
 
 export type ClaimableRewardNotification = BaseNotification & {

--- a/packages/mobile/src/screens/notifications-screen/Notifications/ChallengeRewardNotification.tsx
+++ b/packages/mobile/src/screens/notifications-screen/Notifications/ChallengeRewardNotification.tsx
@@ -1,7 +1,11 @@
 import { useCallback } from 'react'
 
-import type { ChallengeRewardID } from '@audius/common/models'
+import type { BNAudio } from '@audius/common/models'
 import type { ChallengeRewardNotification as ChallengeRewardNotificationType } from '@audius/common/store'
+import {
+  challengeRewardsConfig,
+  stringWeiToAudioBN
+} from '@audius/common/utils'
 import { Platform } from 'react-native'
 
 import { IconAudiusLogo } from '@audius/harmony-native'
@@ -16,62 +20,12 @@ import {
 } from '../Notification'
 
 const messages = {
-  amountEarned: (amount: number) => `You've earned ${amount} $AUDIO`,
+  amountEarned: (amount: BNAudio) => `You've earned ${amount} $AUDIO`,
   referredText:
     ' for being referred! Invite your friends to join to earn more!',
   challengeCompleteText: ' for completing this challenge!',
   twitterShareText:
     'I earned $AUDIO for completing challenges on @audius #AudioRewards'
-}
-
-const challengeInfoMap: Partial<
-  Record<
-    ChallengeRewardID,
-    { title: string; amount: number; iosTitle?: string }
-  >
-> = {
-  'profile-completion': {
-    title: '✅️ Complete Your Profile',
-    amount: 1
-  },
-  'listen-streak': {
-    title: '🎧 Listening Streak: 7 Days',
-    amount: 1
-  },
-  'track-upload': {
-    title: '🎶 Upload 3 Tracks',
-    amount: 1
-  },
-  referrals: {
-    title: '📨 Invite Your Friends',
-    amount: 1
-  },
-  'ref-v': {
-    title: '📨 Invite Your Fans',
-    amount: 1
-  },
-  referred: {
-    title: '📨 Invite Your Friends',
-    amount: 1
-  },
-  'connect-verified': {
-    title: '✅️ Link Verified Accounts',
-    amount: 5
-  },
-  'mobile-install': {
-    title: '📲 Get the App',
-    amount: 1
-  },
-  'send-first-tip': {
-    title: '🤑 Send Your First Tip',
-    // NOTE: Send tip -> Send $AUDIO change
-    iosTitle: '🤑 Send Your First $AUDIO',
-    amount: 2
-  },
-  'first-playlist': {
-    title: '🎼 Create a Playlist',
-    amount: 2
-  }
 }
 
 type ChallengeRewardNotificationProps = {
@@ -83,7 +37,8 @@ export const ChallengeRewardNotification = (
 ) => {
   const { notification } = props
   const { challengeId } = notification
-  const info = challengeInfoMap[challengeId]
+  const info = challengeRewardsConfig[challengeId]
+  const amount = stringWeiToAudioBN(notification.amount)
   const navigation = useNotificationNavigation()
 
   const handlePress = useCallback(() => {
@@ -91,13 +46,14 @@ export const ChallengeRewardNotification = (
   }, [navigation, notification])
 
   if (!info) return null
-  const { title, amount, iosTitle } = info
-
+  const { title } = info
   return (
     <NotificationTile notification={notification} onPress={handlePress}>
       <NotificationHeader icon={IconAudiusLogo}>
         <NotificationTitle>
-          {Platform.OS === 'ios' && iosTitle != null ? iosTitle : title}
+          {Platform.OS === 'ios' && title.includes('Tip')
+            ? title.replace('Tip', '$AUDIO')
+            : title}
         </NotificationTitle>
       </NotificationHeader>
       <NotificationText>

--- a/packages/web/src/components/notification/Notification/ChallengeRewardNotification.tsx
+++ b/packages/web/src/components/notification/Notification/ChallengeRewardNotification.tsx
@@ -1,14 +1,11 @@
 import { useCallback } from 'react'
 
-import { Name } from '@audius/common/models'
-import {
-  audioRewardsPageSelectors,
-  ChallengeRewardNotification as ChallengeRewardNotificationType
-} from '@audius/common/store'
+import { BNAudio, Name } from '@audius/common/models'
+import { ChallengeRewardNotification as ChallengeRewardNotificationType } from '@audius/common/store'
+import { stringWeiToAudioBN } from '@audius/common/utils'
 import { push } from 'connected-react-router'
 import { useDispatch } from 'react-redux'
 
-import { useSelector } from 'common/hooks/useSelector'
 import { make, useRecord } from 'common/store/analytics/actions'
 import { getChallengeConfig } from 'pages/audio-rewards-page/config'
 import { env } from 'services/env'
@@ -22,10 +19,8 @@ import { NotificationTitle } from './components/NotificationTitle'
 import { TwitterShareButton } from './components/TwitterShareButton'
 import { IconRewards } from './components/icons'
 
-const { getUserChallenge } = audioRewardsPageSelectors
-
 const messages = {
-  amountEarned: (amount: number) => `You've earned ${amount} $AUDIO`,
+  amountEarned: (amount: BNAudio) => `You've earned ${amount} $AUDIO`,
   referredText:
     ' for being referred! Invite your friends to join to earn more!',
   challengeCompleteText: ' for completing this challenge!',
@@ -48,10 +43,7 @@ export const ChallengeRewardNotification = (
   const record = useRecord()
 
   const { title, icon } = getChallengeConfig(challengeId)
-  const { amount } = useSelector((state) =>
-    getUserChallenge(state, { challengeId })
-  )
-
+  const amount = stringWeiToAudioBN(notification.amount)
   const handleClick = useCallback(() => {
     dispatch(push(AUDIO_PAGE))
     record(


### PR DESCRIPTION
### Description
AUDIO match notification amounts would default to 1 before because the amount came from the generic user challenge not the actual notification amount.

On mobile, this notification appears to be completely missing as well as others because this challege info mapping lags behind common.  

### How Has This Been Tested?
Ran on web + mobile and confirmed notification is there w correct amount.

<img width="364" alt="Screenshot 2024-08-19 at 1 07 13 PM" src="https://github.com/user-attachments/assets/a2bac64b-b98d-4b15-a1cd-086a94a3d6d5">
<img width="413" alt="Screenshot 2024-08-19 at 12 35 03 PM" src="https://github.com/user-attachments/assets/0f9c40f1-2c4b-4a16-92bf-e0ae27db3b5c">

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._
