### PR TITLE
[QA-1511] Fix space & arrow hotkeys not working

### DIFF
--- a/.changeset/forty-bags-refuse.md
+++ b/.changeset/forty-bags-refuse.md
@@ -1,0 +1,5 @@
+---
+'@audius/harmony': patch
+---
+
+Fix hotkeys not working when clicking on main

--- a/packages/harmony/src/hooks/useHotKeys.ts
+++ b/packages/harmony/src/hooks/useHotKeys.ts
@@ -32,7 +32,8 @@ function allowGlobalHotkeyPress() {
     (document.activeElement === document.body ||
       document.activeElement.nodeName === 'A' /* <a> */ ||
       document.activeElement.nodeName === 'BUTTON' /* <button> */ ||
-      document.activeElement.getAttribute('role') === 'button')
+      document.activeElement.getAttribute('role') === 'button' ||
+      document.activeElement.getAttribute('role') === 'main')
   ) /* Lottie button */
 }
 


### PR DESCRIPTION
### Description

Hotkeys aren't working whenever you click on this `main` area, so I included in this `allowGlobalHotkeyPress` method

![image](https://github.com/user-attachments/assets/3cce2893-f2f8-4f54-be72-a663694a0343)

### How Has This Been Tested?

Clicking around app web:stage