### PR TITLE
Remote config for chat blast tier requirement

### DIFF
--- a/packages/common/src/services/remote-config/defaults.ts
+++ b/packages/common/src/services/remote-config/defaults.ts
@@ -51,7 +51,8 @@ export const remoteConfigIntDefaults: { [key in IntKeys]: number | null } = {
     DEFAULT_HANDLE_VERIFICATION_TIMEOUT_MILLIS,
   [IntKeys.COINFLOW_MAXIMUM_CENTS]: 11000,
   [IntKeys.MIN_USDC_WITHDRAW_BALANCE_CENTS]: 500,
-  [IntKeys.BUY_SOL_WITH_TOKEN_SLIPPAGE_BPS]: BUY_SOL_VIA_TOKEN_SLIPPAGE_BPS
+  [IntKeys.BUY_SOL_WITH_TOKEN_SLIPPAGE_BPS]: BUY_SOL_VIA_TOKEN_SLIPPAGE_BPS,
+  [IntKeys.CHAT_BLAST_TIER_REQUIREMENT]: 1
 }
 
 export const remoteConfigStringDefaults: {

--- a/packages/common/src/services/remote-config/types.ts
+++ b/packages/common/src/services/remote-config/types.ts
@@ -208,7 +208,10 @@ export enum IntKeys {
   COINFLOW_MAXIMUM_CENTS = 'COINFLOW_MAXIMUM_CENTS',
 
   /** Minimum balance required to initiate a USDC cash transfer */
-  MIN_USDC_WITHDRAW_BALANCE_CENTS = 'MIN_USDC_WITHDRAW_BALANCE_CENTS'
+  MIN_USDC_WITHDRAW_BALANCE_CENTS = 'MIN_USDC_WITHDRAW_BALANCE_CENTS',
+
+  /** User must meet this tier requirement to send chat blasts */
+  CHAT_BLAST_TIER_REQUIREMENT = 'CHAT_BLAST_TIER_REQUIREMENT'
 }
 
 export enum BooleanKeys {

--- a/packages/web/src/pages/chat-page/components/ChatBlastCTA.tsx
+++ b/packages/web/src/pages/chat-page/components/ChatBlastCTA.tsx
@@ -1,7 +1,8 @@
 import React, { useCallback } from 'react'
 
 import { useGetCurrentUserId } from '@audius/common/api'
-import { useSelectTierInfo } from '@audius/common/hooks'
+import { useRemoteVar, useSelectTierInfo } from '@audius/common/hooks'
+import { IntKeys } from '@audius/common/services'
 import { useChatBlastModal } from '@audius/common/src/store/ui/modals/create-chat-blast-modal'
 import {
   Box,
@@ -33,7 +34,9 @@ export const ChatBlastCTA = (props: ChatBlastCTAProps) => {
 
   const { data: userId } = useGetCurrentUserId({})
   const { tierNumber, isVerified } = useSelectTierInfo(userId ?? 0) ?? {}
-  const userMeetsRequirements = isVerified || (tierNumber && tierNumber > 0)
+  const chatBlastTier = useRemoteVar(IntKeys.CHAT_BLAST_TIER_REQUIREMENT)
+  const userMeetsRequirements =
+    isVerified || (tierNumber && tierNumber >= chatBlastTier)
 
   const handleClick = useCallback(() => {
     onClick()


### PR DESCRIPTION
### Description
Set a remote config variable for the tier requirement that restricts chat blasts feature.

Functionality documented in description of remote config var.

### How Has This Been Tested?

Confirmed enabled on local web stage, but disabled for non-tiered user on prod