### PR TITLE
[PAY-2918] Migrate track endpoints to SDK, Round 2

### DIFF
--- a/packages/common/src/adapters/track.ts
+++ b/packages/common/src/adapters/track.ts
@@ -92,7 +92,7 @@ export const userTrackMetadataFromSDK = (
           category: input.stemOf.category as StemCategory,
           parent_track_id: input.stemOf.parentTrackId
         }
-      : null,
+      : undefined,
     stream_conditions: input.streamConditions
       ? accessConditionsFromSDK(input.streamConditions)
       : null,

--- a/packages/common/src/adapters/track.ts
+++ b/packages/common/src/adapters/track.ts
@@ -92,7 +92,7 @@ export const userTrackMetadataFromSDK = (
           category: input.stemOf.category as StemCategory,
           parent_track_id: input.stemOf.parentTrackId
         }
-      : undefined,
+      : null,
     stream_conditions: input.streamConditions
       ? accessConditionsFromSDK(input.streamConditions)
       : null,
@@ -113,6 +113,7 @@ export const userTrackMetadataFromSDK = (
       ? (snakecaseKeys(input.copyrightLine) as Copyright)
       : null,
     cover_art: input.coverArt ?? null,
+    create_date: input.createDate ?? null,
     credits_splits: input.creditsSplits ?? null,
     ddex_app: input.ddexApp ?? null,
     ddex_release_ids: input.ddexReleaseIds ?? null,

--- a/packages/common/src/api/track.ts
+++ b/packages/common/src/api/track.ts
@@ -1,6 +1,6 @@
+import { userTrackMetadataFromSDK } from '~/adapters'
 import { createApi } from '~/audius-query'
-import { ID, Kind } from '~/models'
-import { parseTrackRouteFromPermalink } from '~/utils/stringUtils'
+import { ID, Id, Kind, OptionalId } from '~/models'
 import { Nullable } from '~/utils/typeUtils'
 
 const trackApi = createApi({
@@ -9,9 +9,14 @@ const trackApi = createApi({
     getTrackById: {
       fetch: async (
         { id, currentUserId }: { id: ID; currentUserId?: Nullable<ID> },
-        { apiClient }
+        { audiusSdk }
       ) => {
-        return await apiClient.getTrack({ id, currentUserId })
+        const sdk = await audiusSdk()
+        const { data } = await sdk.full.tracks.getTrack({
+          trackId: Id.parse(id),
+          userId: OptionalId.parse(currentUserId)
+        })
+        return data ? userTrackMetadataFromSDK(data) : null
       },
       fetchBatch: async (
         { ids, currentUserId }: { ids: ID[]; currentUserId?: Nullable<ID> },
@@ -36,18 +41,20 @@ const trackApi = createApi({
           permalink,
           currentUserId
         }: { permalink: Nullable<string>; currentUserId: Nullable<ID> },
-        { apiClient }
+        { audiusSdk }
       ) => {
         if (!permalink) {
           console.error('Attempting to get track but permalink is null...')
           return
         }
-        const { handle, slug } = parseTrackRouteFromPermalink(permalink)
-        return await apiClient.getTrackByHandleAndSlug({
-          handle,
-          slug,
-          currentUserId
+        const sdk = await audiusSdk()
+        const { data } = await sdk.full.tracks.getBulkTracks({
+          permalink: [permalink],
+          userId: OptionalId.parse(currentUserId)
         })
+        return data && data.length > 0
+          ? userTrackMetadataFromSDK(data[0])
+          : null
       },
       options: {
         permalinkArgKey: 'permalink',

--- a/packages/common/src/models/Track.ts
+++ b/packages/common/src/models/Track.ts
@@ -191,6 +191,7 @@ export type TrackMetadata = {
   is_delete: boolean
   track_id: number
   created_at: string
+  create_date: Nullable<string>
   isrc: Nullable<string>
   iswc: Nullable<string>
   credits_splits: Nullable<string>
@@ -247,10 +248,10 @@ export type TrackMetadata = {
   // Optional Fields
   is_playlist_upload?: boolean
   is_invalid?: boolean
-  stem_of?: {
+  stem_of?: Nullable<{
     parent_track_id: ID
     category: StemCategory
-  }
+  }>
   remix_of: Nullable<RemixOf>
   preview_cid?: Nullable<CID>
   preview_start_seconds?: Nullable<number>

--- a/packages/common/src/models/Track.ts
+++ b/packages/common/src/models/Track.ts
@@ -248,10 +248,10 @@ export type TrackMetadata = {
   // Optional Fields
   is_playlist_upload?: boolean
   is_invalid?: boolean
-  stem_of?: Nullable<{
+  stem_of?: {
     parent_track_id: ID
     category: StemCategory
-  }>
+  }
   remix_of: Nullable<RemixOf>
   preview_cid?: Nullable<CID>
   preview_start_seconds?: Nullable<number>

--- a/packages/common/src/services/audius-api-client/AudiusAPIClient.ts
+++ b/packages/common/src/services/audius-api-client/AudiusAPIClient.ts
@@ -63,7 +63,6 @@ const FULL_ENDPOINT_MAP = {
     `/playlists/by_permalink/${handle}/${slug}`,
   getTrackStreamUrl: (trackId: OpaqueID) => `/tracks/${trackId}/stream`,
   getTracks: () => `/tracks`,
-  getTrackByHandleAndSlug: `/tracks`,
   getStems: (trackId: OpaqueID, stemIds?: ID[]) =>
     `/tracks/${trackId}/stems${
       stemIds ? `?stemIds=${stemIds?.join(',')}` : ''
@@ -96,12 +95,6 @@ type GetTrackStreamUrlArgs = {
 
 type GetTracksArgs = {
   ids: ID[]
-  currentUserId: Nullable<ID>
-}
-
-type GetTrackByHandleAndSlugArgs = {
-  handle: string
-  slug: string
   currentUserId: Nullable<ID>
 }
 
@@ -384,30 +377,6 @@ export class AudiusAPIClient {
       .map((track) => adapter.makeTrack(track))
       .filter(removeNullable)
     return adapted
-  }
-
-  async getTrackByHandleAndSlug({
-    handle,
-    slug,
-    currentUserId
-  }: GetTrackByHandleAndSlugArgs) {
-    this._assertInitialized()
-    const encodedCurrentUserId = encodeHashId(currentUserId)
-    const params = {
-      handle,
-      slug,
-      user_id: encodedCurrentUserId || undefined
-    }
-
-    const trackResponse = await this._getResponse<APIResponse<APITrack>>(
-      FULL_ENDPOINT_MAP.getTrackByHandleAndSlug,
-      params,
-      true
-    )
-    if (!trackResponse) {
-      return null
-    }
-    return adapter.makeTrack(trackResponse.data)
   }
 
   async getStems({

--- a/packages/common/src/services/audius-api-client/AudiusAPIClient.ts
+++ b/packages/common/src/services/audius-api-client/AudiusAPIClient.ts
@@ -62,7 +62,6 @@ const FULL_ENDPOINT_MAP = {
   getPlaylistByPermalink: (handle: string, slug: string) =>
     `/playlists/by_permalink/${handle}/${slug}`,
   getTrackStreamUrl: (trackId: OpaqueID) => `/tracks/${trackId}/stream`,
-  getTracks: () => `/tracks`,
   getStems: (trackId: OpaqueID, stemIds?: ID[]) =>
     `/tracks/${trackId}/stems${
       stemIds ? `?stemIds=${stemIds?.join(',')}` : ''
@@ -91,11 +90,6 @@ type GetTrackStreamUrlArgs = {
     handle: string
   }
   abortOnUnreachable?: boolean
-}
-
-type GetTracksArgs = {
-  ids: ID[]
-  currentUserId: Nullable<ID>
 }
 
 type GetUserTracksByHandleArgs = {
@@ -353,30 +347,6 @@ export class AudiusAPIClient {
     )
 
     return trackUrl?.data
-  }
-
-  async getTracks({ ids, currentUserId }: GetTracksArgs) {
-    this._assertInitialized()
-    const encodedTrackIds = ids.map((id) => this._encodeOrThrow(id))
-    const encodedCurrentUserId = encodeHashId(currentUserId)
-    const params = {
-      id: encodedTrackIds,
-      user_id: encodedCurrentUserId || undefined,
-      limit: encodedTrackIds.length
-    }
-
-    const trackResponse = await this._getResponse<APIResponse<APITrack[]>>(
-      FULL_ENDPOINT_MAP.getTracks(),
-      params,
-      true
-    )
-    if (!trackResponse) {
-      return null
-    }
-    const adapted = trackResponse.data
-      .map((track) => adapter.makeTrack(track))
-      .filter(removeNullable)
-    return adapted
   }
 
   async getStems({

--- a/packages/common/src/services/audius-api-client/AudiusAPIClient.ts
+++ b/packages/common/src/services/audius-api-client/AudiusAPIClient.ts
@@ -61,7 +61,6 @@ const FULL_ENDPOINT_MAP = {
   getPlaylists: '/playlists',
   getPlaylistByPermalink: (handle: string, slug: string) =>
     `/playlists/by_permalink/${handle}/${slug}`,
-  getTrack: (trackId: OpaqueID) => `/tracks/${trackId}`,
   getTrackStreamUrl: (trackId: OpaqueID) => `/tracks/${trackId}/stream`,
   getTracks: () => `/tracks`,
   getTrackByHandleAndSlug: `/tracks`,
@@ -82,16 +81,6 @@ const FULL_ENDPOINT_MAP = {
 
 export type QueryParams = {
   [key: string]: string | number | undefined | boolean | string[] | null
-}
-
-type GetTrackArgs = {
-  id: ID
-  currentUserId?: Nullable<ID>
-  unlistedArgs?: {
-    urlTitle: string
-    handle: string
-  }
-  abortOnUnreachable?: boolean
 }
 
 type GetTrackStreamUrlArgs = {
@@ -340,36 +329,6 @@ export class AudiusAPIClient {
 
   setIsReachable(isReachable: boolean) {
     this.isReachable = isReachable
-  }
-
-  async getTrack(
-    { id, currentUserId, unlistedArgs, abortOnUnreachable }: GetTrackArgs,
-    retry = true
-  ) {
-    const encodedTrackId = this._encodeOrThrow(id)
-    const encodedCurrentUserId = encodeHashId(currentUserId ?? null)
-
-    this._assertInitialized()
-
-    const args = {
-      user_id: encodedCurrentUserId,
-      url_title: unlistedArgs?.urlTitle,
-      handle: unlistedArgs?.handle,
-      show_unlisted: !!unlistedArgs
-    }
-
-    const trackResponse = await this._getResponse<APIResponse<APITrack>>(
-      FULL_ENDPOINT_MAP.getTrack(encodedTrackId),
-      args,
-      retry,
-      undefined,
-      undefined,
-      abortOnUnreachable
-    )
-
-    if (!trackResponse) return null
-    const adapted = adapter.makeTrack(trackResponse.data)
-    return adapted
   }
 
   async getTrackStreamUrl(

--- a/packages/common/src/services/audius-api-client/ResponseAdapter.ts
+++ b/packages/common/src/services/audius-api-client/ResponseAdapter.ts
@@ -415,6 +415,7 @@ export const makeStemTrack = (stem: APIStem): StemTrackMetadata | undefined => {
     isrc: null,
     iswc: null,
     credits_splits: null,
+    create_date: null,
     description: null,
     followee_reposts: [],
     followee_saves: [],

--- a/packages/mobile/src/store/offline-downloads/sagas/offlineQueueSagas/workers/downloadTrackWorker.ts
+++ b/packages/mobile/src/store/offline-downloads/sagas/offlineQueueSagas/workers/downloadTrackWorker.ts
@@ -1,21 +1,24 @@
+import { userTrackMetadataFromSDK } from '@audius/common/adapters'
 import type {
   ID,
   TrackMetadata,
   Track,
   UserTrackMetadata
 } from '@audius/common/models'
-import { SquareSizes } from '@audius/common/models'
+import { Id, OptionalId, SquareSizes } from '@audius/common/models'
 import type { QueryParams } from '@audius/common/services'
 import {
   accountSelectors,
   getContext,
-  gatedContentSelectors
+  gatedContentSelectors,
+  getSDK
 } from '@audius/common/store'
 import {
   encodeHashId,
   removeNullable,
   getQueryParams
 } from '@audius/common/utils'
+import { current } from '@reduxjs/toolkit'
 import ReactNativeBlobUtil from 'react-native-blob-util'
 import { select, call, put, all, take, race } from 'typed-redux-saga'
 
@@ -129,16 +132,13 @@ function* downloadTrackAsync(
 ): Generator<any, OfflineDownloadStatus> {
   const currentUserId = yield* select(getUserId)
   if (!currentUserId) return OfflineDownloadStatus.ERROR
+  const sdk = yield* getSDK()
 
-  const apiClient = yield* getContext('apiClient')
-
-  const track = yield* call([apiClient, apiClient.getTrack], {
-    id: trackId,
-    currentUserId,
-    // Needed to ensure APIClient doesn't abort when we become unreachable,
-    // allowing this job time to self-cancel
-    abortOnUnreachable: false
+  const { data } = yield* call([sdk.full.tracks, sdk.full.tracks.getTrack], {
+    trackId: Id.parse(trackId),
+    userId: OptionalId.parse(current)
   })
+  const track = data ? userTrackMetadataFromSDK(data) : null
 
   if (!track) return OfflineDownloadStatus.ERROR
 

--- a/packages/web/src/common/store/cache/tracks/utils/retrieveTracks.ts
+++ b/packages/web/src/common/store/cache/tracks/utils/retrieveTracks.ts
@@ -82,19 +82,13 @@ export function* retrieveTrackByHandleAndSlug({
     },
     retrieveFromSource: function* (permalinks: string[]) {
       yield* waitForRead()
-      const apiClient = yield* getContext('apiClient')
+      const sdk = yield* getSDK()
       const userId = yield* select(getUserId)
-      const track = yield* call((args) => {
-        const split = args[0].split('/')
-        const handle = split[1]
-        const slug = split.slice(2).join('')
-        return apiClient.getTrackByHandleAndSlug({
-          handle,
-          slug,
-          currentUserId: userId
-        })
-      }, permalinks)
-      return track
+      const { data } = yield* call(
+        [sdk.full.tracks, sdk.full.tracks.getBulkTracks],
+        { permalink: permalinks, userId: OptionalId.parse(userId) }
+      )
+      return data ? userTrackMetadataFromSDK(data[0]) : null
     },
     kind: Kind.TRACKS,
     idField: 'track_id',

--- a/packages/web/src/common/store/upload/sagas.test.ts
+++ b/packages/web/src/common/store/upload/sagas.test.ts
@@ -39,6 +39,7 @@ const emptyMetadata: TrackMetadataForUpload = {
   is_delete: false,
   track_id: 0,
   created_at: '',
+  create_date: null,
   isrc: null,
   iswc: null,
   credits_splits: null,


### PR DESCRIPTION
### Description
Endpoints migrated:
* `getTrack`
* `getTracks` (`getBulkTracks`)
* `getTrackByHandleAndSlug` (syntactic sugar for `getBulkTracks` using a single item `permalink` array and taking the first returned result)

Also had to modify the type for `TrackMetadata` to correctly reflect the `Nullable` nature of `create_date`, We don't actually use this field and it's slated to be removed. However it _is_ required in upload/edit metadata (even though it's always `null`), and the SDK adapter was not setting it to `null` the way it does for other nullable fields. This was causing a validation error when attempting to edit a track that was fetched via SDK.

See PAY-3364 for details on the future removal of `create_date`


### How Has This Been Tested?
Used `compareSDKResponse` against responses from prod entities to verify we get back the same response shape