### PR TITLE
Remove rule 13 from blocking relay

### DIFF
--- a/packages/discovery-provider/plugins/pedalboard/apps/relay/src/config/antiAbuseConfig.ts
+++ b/packages/discovery-provider/plugins/pedalboard/apps/relay/src/config/antiAbuseConfig.ts
@@ -14,9 +14,9 @@ export const newAntiAbuseConfig = (
   return {
     antiAbuseOracleUrl: url,
     allowRules: new Set([-17, -18]),
-    blockRelayAbuseErrorCodes: new Set([0, 8, 10, 13, 15, 18]),
+    blockRelayAbuseErrorCodes: new Set([0, 8, 10, 15, 18]),
     blockNotificationsErrorCodes: new Set([7, 9]),
-    blockEmailsErrorCodes: new Set([0, 1, 2, 3, 4, 8, 10, 13, 15]),
+    blockEmailsErrorCodes: new Set([0, 1, 2, 3, 4, 8, 10, 15]),
     useAao,
   };
 };


### PR DESCRIPTION
### Description

Rule 13 is only used in relays not reward attestations. 

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._
