### PR TITLE
[QA-1517] Include UserID in websocket metadata

### DIFF
--- a/comms/discovery/rpcz/websocket.go
+++ b/comms/discovery/rpcz/websocket.go
@@ -74,7 +74,7 @@ func websocketPush(senderUserId int32, receiverUserId int32, rpcJson json.RawMes
 			Metadata schema.Metadata `json:"metadata"`
 		}{
 			rpcJson,
-			schema.Metadata{Timestamp: timestamp.Format(time.RFC3339Nano), SenderUserID: encodedSenderUserId, ReceiverUserID: encodedReceiverUserId},
+			schema.Metadata{Timestamp: timestamp.Format(time.RFC3339Nano), SenderUserID: encodedSenderUserId, ReceiverUserID: encodedReceiverUserId, UserID: encodedSenderUserId},
 		}
 
 		payload, err := json.Marshal(data)

--- a/comms/discovery/schema/schema.go
+++ b/comms/discovery/schema/schema.go
@@ -229,6 +229,8 @@ type Metadata struct {
 	Timestamp      string `json:"timestamp"`
 	SenderUserID   string `json:"senderUserId"`
 	ReceiverUserID string `json:"receiverUserId"`
+	// Deprecated: Use SenderUserID instead
+	UserID string `json:"userId"`
 }
 
 type RPCPayload struct {


### PR DESCRIPTION
### Description
This was causing a bug on older clients where two reactions were being shown when a user reacted to a chat message.

Old version of websocket push included `UserID` as a metadata field, and this was getting used in the reaction state updates. We changed the metadata fields to `SenderUserID` and `ReceiverUserID` but we should keep the old one around for backwards compatibility at least for a while.

### How Has This Been Tested?


