### PR TITLE
Fix CTA empty states reversed web/mobile

### DIFF
--- a/packages/mobile/src/screens/chat-screen/ChatBlastCTA.tsx
+++ b/packages/mobile/src/screens/chat-screen/ChatBlastCTA.tsx
@@ -10,10 +10,7 @@ import {
   Flex,
   Text,
   IconTowerBroadcast,
-  IconCaretRight,
-  useTheme,
-  IconVerified,
-  IconTokenBronze
+  IconCaretRight
 } from '@audius/harmony-native'
 
 const messages = {
@@ -42,7 +39,7 @@ export const ChatBlastCTA = (props: ChatBlastCTAProps) => {
   }, [onClick, openChatBlastModal])
 
   if (!userMeetsRequirements) {
-    return <ChatBlastDisabled />
+    return null
   }
 
   return (
@@ -65,54 +62,5 @@ export const ChatBlastCTA = (props: ChatBlastCTAProps) => {
         </Flex>
       </Box>
     </TouchableHighlight>
-  )
-}
-
-const ChatBlastDisabled = () => {
-  const { spacing } = useTheme()
-
-  return (
-    <Flex
-      direction='row'
-      backgroundColor='surface1'
-      ph='xl'
-      pv='l'
-      borderTop='strong'
-      wrap='nowrap'
-      justifyContent='space-between'
-    >
-      <Flex
-        direction='row'
-        alignItems='center'
-        gap='s'
-        style={{ opacity: 0.5 }}
-      >
-        <IconTowerBroadcast size='l' color='default' />
-        <Text strength='strong'>{messages.title}</Text>
-      </Flex>
-      <Flex direction='row' border='strong' borderRadius='m' wrap='nowrap'>
-        <Box ph='s' pv={spacing.unitHalf}>
-          <Text size='s' strength='strong'>
-            {messages.badgeRequired}
-          </Text>
-        </Box>
-        <Flex
-          direction='row'
-          borderLeft='strong'
-          ph='s'
-          gap='xs'
-          alignItems='center'
-          backgroundColor='surface2'
-          borderTopRightRadius='m'
-          borderBottomRightRadius='m'
-        >
-          <IconVerified size='s' />
-          <Text size='s' strength='strong'>
-            {messages.or}
-          </Text>
-          <IconTokenBronze size='s' />
-        </Flex>
-      </Flex>
-    </Flex>
   )
 }

--- a/packages/web/src/pages/chat-page/components/ChatBlastCTA.tsx
+++ b/packages/web/src/pages/chat-page/components/ChatBlastCTA.tsx
@@ -10,7 +10,9 @@ import {
   Text,
   IconTowerBroadcast,
   IconCaretRight,
-  useTheme
+  useTheme,
+  IconVerified,
+  IconTokenBronze
 } from '@audius/harmony'
 
 const messages = {
@@ -42,7 +44,7 @@ export const ChatBlastCTA = (props: ChatBlastCTAProps) => {
   }, [onClick, openChatBlastModal])
 
   if (!userMeetsRequirements) {
-    return null
+    return <ChatBlastDisabled />
   }
 
   return (
@@ -69,5 +71,45 @@ export const ChatBlastCTA = (props: ChatBlastCTAProps) => {
         <IconCaretRight size='s' color='default' />
       </Flex>
     </Box>
+  )
+}
+
+const ChatBlastDisabled = () => {
+  const { spacing } = useTheme()
+
+  return (
+    <Flex
+      backgroundColor='surface1'
+      ph='xl'
+      pv='l'
+      borderTop='strong'
+      wrap='nowrap'
+      justifyContent='space-between'
+    >
+      <Flex alignItems='center' gap='s' css={{ opacity: 0.5 }}>
+        <IconTowerBroadcast size='l' color='default' />
+        <Text variant='title'>{messages.title}</Text>
+      </Flex>
+      <Flex border='strong' borderRadius='m' wrap='nowrap'>
+        <Box ph='s' pv={spacing.unitHalf}>
+          <Text size='s' strength='strong'>
+            {messages.badgeRequired}
+          </Text>
+        </Box>
+        <Flex
+          borderLeft='strong'
+          ph='s'
+          gap='xs'
+          alignItems='center'
+          backgroundColor='surface2'
+          borderTopRightRadius='m'
+          borderBottomRightRadius='m'
+        >
+          <IconVerified size='s' />
+          <Text size='s'>{messages.or}</Text>
+          <IconTokenBronze size='s' />
+        </Flex>
+      </Flex>
+    </Flex>
   )
 }


### PR DESCRIPTION
### Description

Accidentally removed the disabled state from web instead of mobile.

This change puts it back for web and removes it on mobile as intended.

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._
