### PR TITLE
[PAY-3228] Implement composer unfurl in mobile

### DIFF
--- a/packages/common/src/hooks/chats/useAudiusLinkResolver.ts
+++ b/packages/common/src/hooks/chats/useAudiusLinkResolver.ts
@@ -180,7 +180,6 @@ export const useAudiusLinkResolver = ({
       const matched = Object.keys(humanToData).find((i) =>
         textBeforeCursor.endsWith(i)
       )
-      console.log(matched)
       if (matched) {
         return (value: string) =>
           value.slice(0, cursorPosition - matched.length) +

--- a/packages/common/src/hooks/chats/useAudiusLinkResolver.ts
+++ b/packages/common/src/hooks/chats/useAudiusLinkResolver.ts
@@ -180,6 +180,7 @@ export const useAudiusLinkResolver = ({
       const matched = Object.keys(humanToData).find((i) =>
         textBeforeCursor.endsWith(i)
       )
+      console.log(matched)
       if (matched) {
         return (value: string) =>
           value.slice(0, cursorPosition - matched.length) +

--- a/packages/mobile/src/components/core/UserGeneratedText.tsx
+++ b/packages/mobile/src/components/core/UserGeneratedText.tsx
@@ -1,6 +1,13 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
 
-import { squashNewLines } from '@audius/common/utils'
+import {
+  formatCollectionName,
+  formatTrackName,
+  formatUserName,
+  isAudiusUrl,
+  squashNewLines
+} from '@audius/common/utils'
+import { ResolveApi } from '@audius/sdk'
 import { css } from '@emotion/native'
 import type { Match } from 'autolinker/dist/es2015'
 import { View } from 'react-native'
@@ -9,6 +16,13 @@ import Autolink from 'react-native-autolink'
 
 import type { TextLinkProps, TextProps } from '@audius/harmony-native'
 import { Text, TextLink } from '@audius/harmony-native'
+import { audiusSdk } from 'app/services/sdk/audius-sdk'
+
+const {
+  instanceOfTrackResponse,
+  instanceOfUserResponse,
+  instanceOfPlaylistResponse
+} = ResolveApi
 
 type PositionedLink = {
   text: string
@@ -21,6 +35,37 @@ export type UserGeneratedTextProps = Omit<TextProps, 'children'> & {
   // Pass touches through text elements
   allowPointerEventsToPassThrough?: boolean
   linkProps?: Partial<TextLinkProps>
+}
+
+const Link = ({ children, url, ...other }: TextLinkProps & { url: string }) => {
+  const [unfurledContent, setUnfurledContent] = useState<string>()
+
+  useEffect(() => {
+    if (isAudiusUrl(url) && !unfurledContent) {
+      const fn = async () => {
+        const sdk = await audiusSdk()
+        const res = await sdk.resolve({ url })
+        if (res.data) {
+          if (instanceOfTrackResponse(res)) {
+            setUnfurledContent(formatTrackName({ track: res.data }))
+          } else if (instanceOfPlaylistResponse(res)) {
+            setUnfurledContent(
+              formatCollectionName({ collection: res.data[0] })
+            )
+          } else if (instanceOfUserResponse(res)) {
+            setUnfurledContent(formatUserName({ user: res.data }))
+          }
+        }
+      }
+      fn()
+    }
+  }, [url, unfurledContent, setUnfurledContent])
+
+  return (
+    <TextLink {...other} url={url}>
+      {unfurledContent ?? children}
+    </TextLink>
+  )
 }
 
 export const UserGeneratedText = (props: UserGeneratedTextProps) => {
@@ -105,7 +150,7 @@ export const UserGeneratedText = (props: UserGeneratedTextProps) => {
 
   const renderLink = useCallback(
     (text: string, match: Match) => (
-      <TextLink
+      <Link
         {...other}
         variant='visible'
         textVariant={other.variant}
@@ -113,7 +158,7 @@ export const UserGeneratedText = (props: UserGeneratedTextProps) => {
         {...linkProps}
       >
         {text}
-      </TextLink>
+      </Link>
     ),
     // eslint-disable-next-line react-hooks/exhaustive-deps
     []
@@ -148,7 +193,7 @@ export const UserGeneratedText = (props: UserGeneratedTextProps) => {
           const linkLayout = linkLayouts[index]
 
           return linkLayout && linkContainerLayout ? (
-            <TextLink
+            <Link
               {...other}
               variant='visible'
               textVariant={other.variant}
@@ -162,7 +207,7 @@ export const UserGeneratedText = (props: UserGeneratedTextProps) => {
               source={source}
             >
               {text}
-            </TextLink>
+            </Link>
           ) : null
         })}
       </View>

--- a/packages/mobile/src/harmony-native/components/input/TextInput/types.ts
+++ b/packages/mobile/src/harmony-native/components/input/TextInput/types.ts
@@ -3,7 +3,8 @@ import type { ReactNode } from 'react'
 import type {
   TextInputProps as RNTextInputProps,
   TextInput as RNTextInput,
-  ViewStyle
+  ViewStyle,
+  TextStyle
 } from 'react-native'
 
 import type { IconComponent, IconProps } from '../../../icons'
@@ -111,7 +112,12 @@ export type TextInputProps = RNTextInputProps & {
   /**
    * Styles to apply to the inner flex container that wraps the input, label, and adornments
    */
-  innerContainerStyle?: ViewStyle
+  innerContainerStyle?: TextStyle
+
+  /**
+   * Styles to apply to the text component
+   */
+  textStyle?: ViewStyle
 
   TextInputComponent?: typeof RNTextInput
 } & InternalProps

--- a/packages/mobile/src/screens/chat-screen/ChatTextInput.tsx
+++ b/packages/mobile/src/screens/chat-screen/ChatTextInput.tsx
@@ -1,14 +1,25 @@
-import { useCallback, useState } from 'react'
+import { useCallback, useEffect, useState } from 'react'
 
+import { useAudiusLinkResolver } from '@audius/common/hooks'
 import { chatActions, playerSelectors } from '@audius/common/store'
-import { Platform, TouchableOpacity } from 'react-native'
+import { splitOnNewline } from '@audius/common/utils'
+import type {
+  NativeSyntheticEvent,
+  TextInputKeyPressEventData,
+  TextInputSelectionChangeEventData
+} from 'react-native'
+import { Platform, TouchableOpacity, View } from 'react-native'
 import { useDispatch, useSelector } from 'react-redux'
 
-import { IconSend } from '@audius/harmony-native'
-import { TextInput } from 'app/components/core'
+import { Flex, IconSend } from '@audius/harmony-native'
+import { Text, TextInput } from 'app/components/core'
+import { env } from 'app/env'
+import { audiusSdk } from 'app/services/sdk/audius-sdk'
 import { makeStyles } from 'app/styles'
 import { spacing } from 'app/styles/spacing'
 import { useThemeColors } from 'app/utils/theme'
+
+import { ComposerCollectionInfo, ComposerTrackInfo } from './ComposePreviewInfo'
 
 const { sendMessage } = chatActions
 const { getHasTrack } = playerSelectors
@@ -17,11 +28,13 @@ const messages = {
   startNewMessage: ' Start typing...'
 }
 
+const BACKSPACE_KEY = 'Backspace'
+
 const useStyles = makeStyles(({ spacing, palette, typography }) => ({
   composeTextContainer: {
     display: 'flex',
     alignItems: 'center',
-    backgroundColor: palette.neutralLight10,
+    backgroundColor: 'transparent',
     paddingLeft: spacing(4),
     paddingVertical: spacing(2),
     borderRadius: spacing(1)
@@ -31,6 +44,23 @@ const useStyles = makeStyles(({ spacing, palette, typography }) => ({
     lineHeight: spacing(6),
     justifyContent: 'center',
     alignItems: 'center',
+    paddingTop: 0,
+    color: 'transparent'
+  },
+  overlayTextContainer: {
+    position: 'absolute',
+    right: 40,
+    left: 0,
+    zIndex: 0,
+    paddingLeft: spacing(4) + 1,
+    paddingVertical: spacing(3) - 1
+  },
+  overlayText: {
+    fontSize: typography.fontSize.medium,
+    lineHeight: spacing(6),
+    justifyContent: 'center',
+    alignItems: 'center',
+    color: palette.neutral,
     paddingTop: 0
   },
   submit: {
@@ -60,14 +90,80 @@ export const ChatTextInput = ({
   const [inputMessage, setInputMessage] = useState(presetMessage ?? '')
   const hasLength = inputMessage.length > 0
   const hasCurrentlyPlayingTrack = useSelector(getHasTrack)
+  const [selection, setSelection] = useState<{ start: number; end: number }>()
+
+  const {
+    trackId,
+    collectionId,
+    resolveLinks,
+    restoreLinks,
+    getMatches,
+    handleBackspace,
+    reset
+  } = useAudiusLinkResolver({
+    value: inputMessage,
+    hostname: env.PUBLIC_HOSTNAME,
+    audiusSdk
+  })
+
+  useEffect(() => {
+    const fn = async () => {
+      if (presetMessage) {
+        const editedValue = await resolveLinks(presetMessage)
+        setInputMessage(editedValue)
+      }
+    }
+    fn()
+  }, [presetMessage, resolveLinks])
+
+  const handleChange = useCallback(
+    async (value: string) => {
+      setInputMessage(value)
+      const editedValue = await resolveLinks(value)
+      setInputMessage(editedValue)
+    },
+    [setInputMessage, resolveLinks]
+  )
+
+  const handleSelectionChange = useCallback(
+    (e: NativeSyntheticEvent<TextInputSelectionChangeEventData>) => {
+      setSelection(e.nativeEvent.selection)
+    },
+    [setSelection]
+  )
+
+  const handleKeyDown = useCallback(
+    (e: NativeSyntheticEvent<TextInputKeyPressEventData>) => {
+      if (e.nativeEvent.key === BACKSPACE_KEY && selection) {
+        const textBeforeCursor = inputMessage.slice(0, selection.start)
+        const cursorPosition = selection.start
+        const editValue = handleBackspace({
+          cursorPosition,
+          textBeforeCursor
+        })
+
+        if (editValue) {
+          // Delay the deleting of the matched word because
+          // in react native text change will fire on backspace anyway
+          // and we want the handleChange callback to run first.
+          // This is a bit of a hack. In search of a better way!
+          setTimeout(() => {
+            setInputMessage(editValue)
+          }, 100)
+        }
+      }
+    },
+    [selection, handleBackspace, setInputMessage, inputMessage]
+  )
 
   const handleSubmit = useCallback(() => {
     if (chatId && inputMessage) {
-      dispatch(sendMessage({ chatId, message: inputMessage }))
+      dispatch(sendMessage({ chatId, message: restoreLinks(inputMessage) }))
       setInputMessage('')
       onMessageSent()
+      reset()
     }
-  }, [inputMessage, chatId, dispatch, onMessageSent])
+  }, [inputMessage, chatId, dispatch, onMessageSent, restoreLinks, reset])
 
   const renderIcon = () => (
     <TouchableOpacity
@@ -83,24 +179,98 @@ export const ChatTextInput = ({
     </TouchableOpacity>
   )
 
+  const renderChatDisplay = (value: string) => {
+    const matches = getMatches(value)
+    if (!matches) {
+      const text = splitOnNewline(value)
+      return text.map((t, i) => <Text key={i}>{`${t}\n`}</Text>)
+    }
+    const parts: JSX.Element[] = []
+    let lastIndex = 0
+    for (const match of matches) {
+      const { index } = match
+      if (index === undefined) {
+        continue
+      }
+
+      if (index > lastIndex) {
+        // Add text before the match
+        const text = splitOnNewline(value.slice(lastIndex, index))
+        parts.push(
+          ...text.map((t, i) => (
+            <Text key={`${lastIndex}${i}`}>{`${t}\n`}</Text>
+          ))
+        )
+      }
+      // Add the matched word with accent color
+      parts.push(
+        <Text color='secondary' key={index}>
+          {match[0]}
+        </Text>
+      )
+      // Update lastIndex to the end of the current match
+      lastIndex = index + match[0].length
+    }
+
+    // Add remaining text after the last match
+    if (lastIndex < value.length) {
+      const text = splitOnNewline(value.slice(lastIndex))
+      parts.push(
+        ...text.map((t, i) => <Text key={`${lastIndex}${i}`}>{`${t}\n`}</Text>)
+      )
+    }
+
+    return parts
+  }
+
   return (
-    <TextInput
-      placeholder={messages.startNewMessage}
-      Icon={renderIcon}
-      styles={{
-        root: styles.composeTextContainer,
-        input: [
-          styles.composeTextInput,
-          Platform.OS === 'ios' ? { paddingBottom: spacing(1.5) } : null,
-          { maxHeight: hasCurrentlyPlayingTrack ? spacing(70) : spacing(80) }
-        ]
-      }}
-      onChangeText={setInputMessage}
-      inputAccessoryViewID='none'
-      multiline
-      value={inputMessage}
-      maxLength={10000}
-      autoCorrect
-    />
+    <Flex>
+      {trackId ? (
+        <ComposerTrackInfo trackId={trackId} />
+      ) : collectionId ? (
+        <ComposerCollectionInfo collectionId={collectionId} />
+      ) : null}
+      <Flex
+        style={{
+          position: 'relative',
+          maxHeight: hasCurrentlyPlayingTrack ? spacing(70) : spacing(80),
+          paddingBottom: Platform.OS === 'ios' ? spacing(1.5) : undefined
+        }}
+      >
+        <View
+          style={[
+            styles.overlayTextContainer,
+            Platform.OS === 'ios' ? { paddingBottom: spacing(1.5) } : null,
+            { maxHeight: hasCurrentlyPlayingTrack ? spacing(70) : spacing(80) }
+          ]}
+        >
+          <Text style={styles.overlayText}>
+            {renderChatDisplay(inputMessage)}
+          </Text>
+        </View>
+        <TextInput
+          placeholder={messages.startNewMessage}
+          Icon={renderIcon}
+          styles={{
+            root: styles.composeTextContainer,
+            input: [
+              styles.composeTextInput,
+              Platform.OS === 'ios' ? { paddingBottom: spacing(1.5) } : null,
+              {
+                maxHeight: hasCurrentlyPlayingTrack ? spacing(70) : spacing(80)
+              }
+            ]
+          }}
+          onChangeText={handleChange}
+          onKeyPress={handleKeyDown}
+          onSelectionChange={handleSelectionChange}
+          inputAccessoryViewID='none'
+          multiline
+          value={inputMessage}
+          maxLength={10000}
+          autoCorrect
+        />
+      </Flex>
+    </Flex>
   )
 }

--- a/packages/mobile/src/screens/chat-screen/ChatTextInput.tsx
+++ b/packages/mobile/src/screens/chat-screen/ChatTextInput.tsx
@@ -1,21 +1,20 @@
 import { useCallback, useState } from 'react'
 
 import { chatActions, playerSelectors } from '@audius/common/store'
-import { Platform, Pressable } from 'react-native'
+import { Platform, TouchableOpacity } from 'react-native'
 import { useDispatch, useSelector } from 'react-redux'
 
 import { IconSend } from '@audius/harmony-native'
 import { TextInput } from 'app/components/core'
 import { makeStyles } from 'app/styles'
 import { spacing } from 'app/styles/spacing'
-import { convertHexToRGBA } from 'app/utils/convertHexToRGBA'
 import { useThemeColors } from 'app/utils/theme'
 
 const { sendMessage } = chatActions
 const { getHasTrack } = playerSelectors
 
 const messages = {
-  startNewMessage: ' Start a New Message'
+  startNewMessage: ' Start typing...'
 }
 
 const useStyles = makeStyles(({ spacing, palette, typography }) => ({
@@ -24,7 +23,7 @@ const useStyles = makeStyles(({ spacing, palette, typography }) => ({
     alignItems: 'center',
     backgroundColor: palette.neutralLight10,
     paddingLeft: spacing(4),
-    paddingVertical: spacing(1),
+    paddingVertical: spacing(2),
     borderRadius: spacing(1)
   },
   composeTextInput: {
@@ -34,16 +33,12 @@ const useStyles = makeStyles(({ spacing, palette, typography }) => ({
     alignItems: 'center',
     paddingTop: 0
   },
-  icon: {
-    width: spacing(5),
-    height: spacing(5),
-    fill: palette.white
+  submit: {
+    paddingRight: spacing(1)
   },
-  iconCircle: {
-    borderRadius: spacing(5),
-    paddingVertical: spacing(1.5),
-    paddingLeft: 5,
-    paddingRight: 7
+  icon: {
+    width: spacing(6),
+    height: spacing(6)
   }
 }))
 
@@ -60,7 +55,7 @@ export const ChatTextInput = ({
 }: ChatTextInputProps) => {
   const styles = useStyles()
   const dispatch = useDispatch()
-  const { primary, primaryDark2 } = useThemeColors()
+  const { primary, neutralLight7 } = useThemeColors()
 
   const [inputMessage, setInputMessage] = useState(presetMessage ?? '')
   const hasLength = inputMessage.length > 0
@@ -75,28 +70,17 @@ export const ChatTextInput = ({
   }, [inputMessage, chatId, dispatch, onMessageSent])
 
   const renderIcon = () => (
-    <Pressable
+    <TouchableOpacity
       onPress={handleSubmit}
       hitSlop={spacing(2)}
-      style={({ pressed }) => [
-        styles.iconCircle,
-        {
-          backgroundColor: hasLength
-            ? pressed
-              ? primaryDark2
-              : primary
-            : // Setting opacity style affects both the background and icon
-              // on Android, this workaround keeps the icon always white.
-              convertHexToRGBA(primary, 50)
-        }
-      ]}
+      style={styles.submit}
     >
       <IconSend
         width={styles.icon.width}
         height={styles.icon.height}
-        fill={styles.icon.fill}
+        fill={hasLength ? primary : neutralLight7}
       />
-    </Pressable>
+    </TouchableOpacity>
   )
 
   return (

--- a/packages/mobile/src/screens/chat-screen/ChatTextInput.tsx
+++ b/packages/mobile/src/screens/chat-screen/ChatTextInput.tsx
@@ -99,7 +99,7 @@ export const ChatTextInput = ({
     restoreLinks,
     getMatches,
     handleBackspace,
-    reset
+    clearLinks
   } = useAudiusLinkResolver({
     value: inputMessage,
     hostname: env.PUBLIC_HOSTNAME,
@@ -161,9 +161,9 @@ export const ChatTextInput = ({
       dispatch(sendMessage({ chatId, message: restoreLinks(inputMessage) }))
       setInputMessage('')
       onMessageSent()
-      reset()
+      clearLinks()
     }
-  }, [inputMessage, chatId, dispatch, onMessageSent, restoreLinks, reset])
+  }, [inputMessage, chatId, dispatch, onMessageSent, restoreLinks, clearLinks])
 
   const renderIcon = () => (
     <TouchableOpacity

--- a/packages/mobile/src/screens/chat-screen/ChatTextInput.tsx
+++ b/packages/mobile/src/screens/chat-screen/ChatTextInput.tsx
@@ -49,7 +49,7 @@ const useStyles = makeStyles(({ spacing, palette, typography }) => ({
   },
   overlayTextContainer: {
     position: 'absolute',
-    right: 40,
+    right: spacing(10),
     left: 0,
     zIndex: 0,
     paddingLeft: spacing(4) + 1,

--- a/packages/mobile/src/screens/chat-screen/ComposePreviewInfo.tsx
+++ b/packages/mobile/src/screens/chat-screen/ComposePreviewInfo.tsx
@@ -1,0 +1,97 @@
+import type { ReactNode } from 'react'
+
+import { useGetPlaylistById, useGetTrackById } from '@audius/common/api'
+import type { ID, UserMetadata } from '@audius/common/models'
+import { SquareSizes } from '@audius/common/models'
+
+import { Flex, Text } from '@audius/harmony-native'
+import { CollectionImageV2 } from 'app/components/image/CollectionImageV2'
+import { TrackImageV2 } from 'app/components/image/TrackImageV2'
+import UserBadges from 'app/components/user-badges'
+
+type ComposePreviewInfoProps = {
+  title: string
+  name: string
+  user: UserMetadata
+  image?: ReactNode
+}
+
+const ComposePreviewInfo = (props: ComposePreviewInfoProps) => {
+  const { title, name, user, image } = props
+  return (
+    <Flex direction='row' pv='s' gap='s' borderBottom='default'>
+      <Flex
+        direction='row'
+        borderRadius='s'
+        h='unit12'
+        w='unit12'
+        style={{ overflow: 'hidden' }}
+      >
+        {image}
+      </Flex>
+      <Flex direction='column' alignItems='flex-start' justifyContent='center'>
+        <Text variant='body' strength='strong'>
+          {title}
+        </Text>
+        <Flex direction='row' alignItems='center' gap='xs'>
+          <Text variant='body' strength='strong'>
+            {name}
+          </Text>
+          <UserBadges hideName user={user} badgeSize={14} />
+        </Flex>
+      </Flex>
+    </Flex>
+  )
+}
+
+type ComposerTrackInfoProps = {
+  trackId: ID
+}
+
+export const ComposerTrackInfo = (props: ComposerTrackInfoProps) => {
+  const { trackId } = props
+
+  const { data: track } = useGetTrackById({ id: trackId }, { force: true })
+
+  if (!track) return null
+
+  return (
+    <ComposePreviewInfo
+      title={track.title}
+      name={track.user.name}
+      user={track.user}
+      image={
+        <TrackImageV2 trackId={trackId} size={SquareSizes.SIZE_150_BY_150} />
+      }
+    />
+  )
+}
+
+type ComposerCollectionInfoProps = {
+  collectionId: ID
+}
+
+export const ComposerCollectionInfo = (props: ComposerCollectionInfoProps) => {
+  const { collectionId } = props
+
+  const { data: collection } = useGetPlaylistById(
+    { playlistId: collectionId },
+    { force: true }
+  )
+
+  if (!collection) return null
+
+  return (
+    <ComposePreviewInfo
+      title={collection.playlist_name}
+      name={collection.user.name}
+      user={collection.user}
+      image={
+        <CollectionImageV2
+          collectionId={collectionId}
+          size={SquareSizes.SIZE_150_BY_150}
+        />
+      }
+    />
+  )
+}

--- a/packages/web/src/pages/chat-page/components/ChatComposer.tsx
+++ b/packages/web/src/pages/chat-page/components/ChatComposer.tsx
@@ -23,6 +23,7 @@ import styles from './ChatComposer.module.css'
 import { ComposerCollectionInfo, ComposerTrackInfo } from './ComposePreviewInfo'
 
 const { sendMessage } = chatActions
+
 const messages = {
   sendMessage: 'Send Message',
   sendMessagePlaceholder: 'Start typing...'


### PR DESCRIPTION
### Description

Implement composer changes for message on mobile, following same patterns from web
* Unfurl display text for tracks, collections, and users inline
* Tracks and collections unfurl above with some content
* Backspace deletes entire row
* Unfurl in the messages themselves

<img src="https://github.com/user-attachments/assets/3e48f741-4024-49a7-8979-afcf6a1716ce" width="200" />

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._

Staging on simulator, verified sharing of all content forms. Some potential concerns I want to test on app:
* How responsive entering text is. It seemed a little slower than just the input on mobile, versus web which is near instant
* Backspace behavior (see inline comment)