### PR TITLE
Add row and column props to flex

### DIFF
--- a/.changeset/ninety-shoes-live.md
+++ b/.changeset/ninety-shoes-live.md
@@ -1,0 +1,5 @@
+---
+'@audius/harmony': patch
+---
+
+Add row and column props to flex

--- a/packages/harmony/src/components/layout/Flex/Flex.tsx
+++ b/packages/harmony/src/components/layout/Flex/Flex.tsx
@@ -20,7 +20,9 @@ export const Flex = styled(Box, {
     gap,
     rowGap,
     columnGap,
-    inline
+    inline,
+    row,
+    column
   } = props
   const { spacing } = theme
 
@@ -28,7 +30,7 @@ export const Flex = styled(Box, {
     display: inline ? 'inline-flex' : 'flex',
     alignItems,
     justifyContent,
-    flexDirection: direction,
+    flexDirection: direction ?? (row ? 'row' : column ? 'column' : undefined),
     flexWrap: wrap,
     gap: gap && spacing[gap],
     rowGap: rowGap && spacing[rowGap],

--- a/packages/harmony/src/components/layout/Flex/types.ts
+++ b/packages/harmony/src/components/layout/Flex/types.ts
@@ -12,6 +12,8 @@ export type BaseFlexProps = {
   justifyContent?: CSSProperties['justifyContent']
   wrap?: CSSProperties['flexWrap']
   inline?: boolean
+  row?: boolean
+  column?: boolean
 }
 
 export type FlexProps = BaseFlexProps & BoxProps

--- a/packages/mobile/src/harmony-native/components/layout/Flex/Flex.tsx
+++ b/packages/mobile/src/harmony-native/components/layout/Flex/Flex.tsx
@@ -25,7 +25,9 @@ export const Flex = styled(Box, {
     justifyContent,
     gap,
     rowGap,
-    columnGap
+    columnGap,
+    row,
+    column
   } = props
   const { spacing } = theme
 
@@ -33,7 +35,7 @@ export const Flex = styled(Box, {
     display: 'flex',
     alignItems,
     justifyContent,
-    flexDirection: direction,
+    flexDirection: direction ?? (row ? 'row' : column ? 'column' : undefined),
     flexWrap: wrap,
     gap: gap && spacing[gap],
     rowGap: rowGap && spacing[rowGap],


### PR DESCRIPTION
### Description

Adds row and column props to flex, to make it even easier to create layouts. shoutout to @amendelsohn for the idea.

Additional changes coming to flex:
flex-direction = row by default for web and mobile