### PR TITLE
[QA-1210] Fix popup scrolling issues

### DIFF
--- a/.changeset/five-beers-end.md
+++ b/.changeset/five-beers-end.md
@@ -1,0 +1,5 @@
+---
+'@audius/harmony': patch
+---
+
+Fix popup issue with scrolling & rerendering

--- a/packages/harmony/src/components/popup/Popup.tsx
+++ b/packages/harmony/src/components/popup/Popup.tsx
@@ -13,6 +13,7 @@ import { useTheme } from '@emotion/react'
 import cn from 'classnames'
 import ReactDOM from 'react-dom'
 import { useTransition, animated } from 'react-spring'
+import { usePrevious } from 'react-use'
 
 import { PlainButton } from 'components/button'
 import { IconClose } from 'icons'
@@ -250,6 +251,7 @@ export const PopupInternal = forwardRef<
   const { spring, shadows } = useTheme()
 
   const isVisible = popupState !== 'closed'
+  const previousIsVisible = usePrevious(isVisible)
 
   const handleClose = useCallback(() => {
     onClose?.()
@@ -279,7 +281,7 @@ export const PopupInternal = forwardRef<
 
   // On visible, set the position
   useEffect(() => {
-    if (isVisible) {
+    if (isVisible && !previousIsVisible) {
       const [anchorRect, wrapperRect] = [anchorRef, wrapperRef].map((r) =>
         r?.current?.getBoundingClientRect()
       )
@@ -324,7 +326,7 @@ export const PopupInternal = forwardRef<
 
       originalTopPosition.current = top
     }
-  }, [isVisible, wrapperRef, anchorRef, anchorOrigin, transformOrigin, setComputedTransformOrigin, originalTopPosition, portalLocation, containerRef])
+  }, [isVisible, wrapperRef, anchorRef, anchorOrigin, transformOrigin, setComputedTransformOrigin, originalTopPosition, portalLocation, containerRef, previousIsVisible])
 
   // Callback invoked on each scroll. Uses original top position to scroll with content.
   // Takes scrollParent to get the current scroll position as well as the intitial scroll position


### PR DESCRIPTION
### Description

Right now when you scroll after opening the suggested artists popup it does weird flickering and sometimes sticks to the bottom of the screen.

The reason is because we have logic to attempt to pivot around the origin to fit inside the window if possible (i.e. if above origin has not enough real estate, go bottom, etc). This logic seems like it's only meant to trigger when the popup is first opened; not on every rerender.

SIDE NOTE: The animations (opening mainly) on this popup are still pretty janky; this bug + the still janky animation is wondering if we should swap out to a library under the hood

**before**
![2024-08-20 17 48 03](https://github.com/user-attachments/assets/7f8cfdfb-8886-482c-bedf-674be87f7c9b)

**after**
![2024-08-21 11 18 26](https://github.com/user-attachments/assets/6bdee949-260e-43b7-97d7-da45d5aa9bca)

### How Has This Been Tested?

web:stage
