### PR TITLE
[QA-1519] Fix buyer metadata caching

### DIFF
--- a/packages/common/src/api/purchases.ts
+++ b/packages/common/src/api/purchases.ts
@@ -68,7 +68,7 @@ const purchasesApi = createApi({
           userId: Id.parse(userId!)
         })
         const purchases = data.map(parsePurchase)
-        console.log('asdf purchases: ', purchases)
+
         // Pre-fetch track metadata
         const trackIdsToFetch = purchases
           .filter(
@@ -122,6 +122,7 @@ const purchasesApi = createApi({
         })
 
         const purchases = data.map(parsePurchase)
+
         // Pre-fetch track metadata
         const trackIdsToFetch = purchases
           .filter(
@@ -134,6 +135,7 @@ const purchasesApi = createApi({
             context
           )
         }
+        // fetch buyer metadata
         const userIdsToFetch = purchases.map(({ buyerUserId }) => buyerUserId)
         if (userIdsToFetch.length > 0) {
           await userApiFetch.getUsersByIds({ ids: userIdsToFetch }, context)

--- a/packages/common/src/api/purchases.ts
+++ b/packages/common/src/api/purchases.ts
@@ -10,6 +10,7 @@ import { StringUSDC } from '~/models/Wallet'
 import { Nullable } from '~/utils/typeUtils'
 
 import { trackApiFetch } from './track'
+import { userApiFetch } from './user'
 import { HashId, Id } from './utils'
 
 type GetPurchaseListArgs = {
@@ -67,7 +68,7 @@ const purchasesApi = createApi({
           userId: Id.parse(userId!)
         })
         const purchases = data.map(parsePurchase)
-
+        console.log('asdf purchases: ', purchases)
         // Pre-fetch track metadata
         const trackIdsToFetch = purchases
           .filter(
@@ -121,7 +122,6 @@ const purchasesApi = createApi({
         })
 
         const purchases = data.map(parsePurchase)
-
         // Pre-fetch track metadata
         const trackIdsToFetch = purchases
           .filter(
@@ -134,6 +134,11 @@ const purchasesApi = createApi({
             context
           )
         }
+        const userIdsToFetch = purchases.map(({ buyerUserId }) => buyerUserId)
+        if (userIdsToFetch.length > 0) {
+          await userApiFetch.getUsersByIds({ ids: userIdsToFetch }, context)
+        }
+
         // TODO: [PAY-2548] Purchaseable Albums - fetch metadata for albums
         return purchases
       },


### PR DESCRIPTION
### Description

Fixes small issue with buyer names missing if user is not already in cache. Adding a fetch for buyer metadata like we do for track.

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._

Mocked random buyer user IDs and confirmed uncached users IDs were then fetched.