### PR TITLE
[PAY-3359] Chat blast thread UI on sender side

### DIFF
--- a/.changeset/eighty-cherries-admire.md
+++ b/.changeset/eighty-cherries-admire.md
@@ -1,0 +1,5 @@
+---
+'@audius/sdk': patch
+---
+
+getChat + getMessages working for chat blasts

--- a/comms/discovery/db/queries/get_chat_messages.go
+++ b/comms/discovery/db/queries/get_chat_messages.go
@@ -54,11 +54,12 @@ LIMIT $3
 `
 
 type ChatMessagesAndReactionsParams struct {
-	UserID int32     `db:"user_id" json:"user_id"`
-	ChatID string    `db:"chat_id" json:"chat_id"`
-	Limit  int32     `json:"limit"`
-	Before time.Time `json:"before"`
-	After  time.Time `json:"after"`
+	UserID  int32     `db:"user_id" json:"user_id"`
+	ChatID  string    `db:"chat_id" json:"chat_id"`
+	Limit   int32     `json:"limit"`
+	Before  time.Time `json:"before"`
+	After   time.Time `json:"after"`
+	IsBlast bool      `json:"is_blast"`
 }
 
 type ChatMessageAndReactionsRow struct {
@@ -114,12 +115,12 @@ func ChatMessagesAndReactions(q db.Queryable, ctx context.Context, arg ChatMessa
 	var rows []ChatMessageAndReactionsRow
 
 	// special case to handle outgoing blasts...
-	if strings.HasPrefix(arg.ChatID, "blast:") {
+	if arg.IsBlast {
 		parts := strings.Split(arg.ChatID, ":")
-		if len(parts) < 2 {
+		if len(parts) < 1 {
 			return nil, errors.New("bad request: invalid blast id")
 		}
-		audience := parts[1]
+		audience := parts[0]
 
 		if schema.ChatBlastAudience(audience) == schema.FollowerAudience {
 			const outgoingBlastMessages = `

--- a/comms/discovery/db/queries/get_chat_messages.go
+++ b/comms/discovery/db/queries/get_chat_messages.go
@@ -116,11 +116,10 @@ func ChatMessagesAndReactions(q db.Queryable, ctx context.Context, arg ChatMessa
 	// special case to handle outgoing blasts...
 	if strings.HasPrefix(arg.ChatID, "blast:") {
 		parts := strings.Split(arg.ChatID, ":")
-		if len(parts) < 3 {
+		if len(parts) < 2 {
 			return nil, errors.New("bad request: invalid blast id")
 		}
-		// encodedUserID := parts[1]
-		audience := parts[2]
+		audience := parts[1]
 
 		if schema.ChatBlastAudience(audience) == schema.FollowerAudience {
 			const outgoingBlastMessages = `

--- a/comms/discovery/db/queries/get_chats.go
+++ b/comms/discovery/db/queries/get_chats.go
@@ -61,7 +61,7 @@ WHERE chat_member.user_id = $1 AND chat_member.chat_id = $2
 union all (
 
   SELECT DISTINCT ON (audience, audience_content_type, audience_content_id)
-    concat_ws(':', 'blast', audience, audience_content_type, audience_content_id) as chat_id,
+    concat_ws(':', audience, audience_content_type, audience_content_id) as chat_id,
     min(created_at) over (partition by audience, audience_content_type, audience_content_id) as created_at,
     plaintext as last_message,
     created_at as last_message_at,
@@ -121,7 +121,7 @@ WHERE chat_member.user_id = $1
 union all (
 
   SELECT DISTINCT ON (audience, audience_content_type, audience_content_id)
-    concat_ws(':', 'blast', audience, audience_content_type, audience_content_id) as chat_id,
+    concat_ws(':', audience, audience_content_type, audience_content_id) as chat_id,
     min(created_at) over (partition by audience, audience_content_type, audience_content_id) as created_at,
     plaintext as last_message,
     created_at as last_message_at,

--- a/comms/discovery/db/queries/get_chats.go
+++ b/comms/discovery/db/queries/get_chats.go
@@ -19,6 +19,10 @@ type UserChatRow struct {
 	LastActiveAt           sql.NullTime   `db:"last_active_at" json:"last_active_at"`
 	UnreadCount            int32          `db:"unread_count" json:"unread_count"`
 	ClearedHistoryAt       sql.NullTime   `db:"cleared_history_at" json:"cleared_history_at"`
+	IsBlast                bool           `db:"is_blast" json:"is_blast"`
+	Audience               sql.NullString `db:"audience" json:"audience"`
+	AudienceContentType    sql.NullString `db:"audience_content_type" json:"audience_content_type"`
+	AudienceContentID      sql.NullInt32  `db:"audience_content_id" json:"audience_content_id"`
 }
 
 // Get a chat's last_message_at
@@ -45,7 +49,11 @@ SELECT
   chat_member.invite_code,
   chat_member.last_active_at,
   chat_member.unread_count,
-  chat_member.cleared_history_at
+  chat_member.cleared_history_at,
+	false as is_blast,
+	null as audience,
+	null as audience_content_type,
+	null as audience_content_id
 FROM chat_member
 JOIN chat ON chat.chat_id = chat_member.chat_id
 WHERE chat_member.user_id = $1 AND chat_member.chat_id = $2
@@ -68,7 +76,11 @@ SELECT
   chat_member.invite_code,
   chat_member.last_active_at,
   chat_member.unread_count,
-  chat_member.cleared_history_at
+  chat_member.cleared_history_at,
+	false as is_blast,
+	null as audience,
+	null as audience_content_type,
+	null as audience_content_id
 FROM chat_member
 JOIN chat ON chat.chat_id = chat_member.chat_id
 WHERE chat_member.user_id = $1
@@ -91,7 +103,11 @@ union all (
     '' as invite_code,
     created_at as last_active_at,
     0 as unread_count,
-    null as cleared_history_at
+    null as cleared_history_at,
+		true as is_blast,
+		audience,
+		audience_content_type,
+		audience_content_id
   FROM chat_blast b
   WHERE from_user_id = $1
   ORDER BY

--- a/comms/discovery/rpcz/chat_blast_test.go
+++ b/comms/discovery/rpcz/chat_blast_test.go
@@ -165,7 +165,7 @@ func TestChatBlast(t *testing.T) {
 				blastCount++
 			}
 		}
-		assert.Equal(t, "blast:69:follower_audience", chats[0].ChatID)
+		assert.Equal(t, "blast:follower_audience", chats[0].ChatID)
 		assert.Equal(t, 1, blastCount)
 	}
 
@@ -367,7 +367,7 @@ func TestChatBlast(t *testing.T) {
 	{
 		messages, err := queries.ChatMessagesAndReactions(tx, ctx, queries.ChatMessagesAndReactionsParams{
 			UserID: 69,
-			ChatID: "blast:69:follower_audience",
+			ChatID: "blast:follower_audience",
 			Before: time.Now().Add(time.Hour * 2).UTC(),
 			After:  time.Now().Add(time.Hour * -2).UTC(),
 			Limit:  10,

--- a/comms/discovery/rpcz/chat_blast_test.go
+++ b/comms/discovery/rpcz/chat_blast_test.go
@@ -3,7 +3,6 @@ package rpcz
 import (
 	"context"
 	"fmt"
-	"strings"
 	"testing"
 	"time"
 
@@ -161,11 +160,11 @@ func TestChatBlast(t *testing.T) {
 
 		blastCount := 0
 		for _, c := range chats {
-			if strings.HasPrefix(c.ChatID, "blast:") {
+			if c.IsBlast {
 				blastCount++
 			}
 		}
-		assert.Equal(t, "blast:follower_audience", chats[0].ChatID)
+		assert.Equal(t, "follower_audience", chats[1].ChatID)
 		assert.Equal(t, 1, blastCount)
 	}
 
@@ -366,11 +365,12 @@ func TestChatBlast(t *testing.T) {
 	// ------ sender can get blasts in a given thread ----------
 	{
 		messages, err := queries.ChatMessagesAndReactions(tx, ctx, queries.ChatMessagesAndReactionsParams{
-			UserID: 69,
-			ChatID: "blast:follower_audience",
-			Before: time.Now().Add(time.Hour * 2).UTC(),
-			After:  time.Now().Add(time.Hour * -2).UTC(),
-			Limit:  10,
+			UserID:  69,
+			ChatID:  "follower_audience",
+			IsBlast: true,
+			Before:  time.Now().Add(time.Hour * 2).UTC(),
+			After:   time.Now().Add(time.Hour * -2).UTC(),
+			Limit:   10,
 		})
 		assert.NoError(t, err)
 		assert.Len(t, messages, 2)

--- a/comms/discovery/schema/schema.go
+++ b/comms/discovery/schema/schema.go
@@ -148,16 +148,20 @@ type TentacledInvite struct {
 }
 
 type UserChat struct {
-	ChatID                 string       `json:"chat_id"`
-	ChatMembers            []ChatMember `json:"chat_members"`
-	ClearedHistoryAt       string       `json:"cleared_history_at"`
-	InviteCode             string       `json:"invite_code"`
-	LastMessage            string       `json:"last_message"`
-	LastMessageAt          string       `json:"last_message_at"`
-	LastMessageIsPlaintext bool         `json:"last_message_is_plaintext"`
-	LastReadAt             string       `json:"last_read_at"`
-	RecheckPermissions     bool         `json:"recheck_permissions"`
-	UnreadMessageCount     float64      `json:"unread_message_count"`
+	ChatID                 string            `json:"chat_id"`
+	ChatMembers            []ChatMember      `json:"chat_members"`
+	ClearedHistoryAt       string            `json:"cleared_history_at"`
+	InviteCode             string            `json:"invite_code"`
+	LastMessage            string            `json:"last_message"`
+	LastMessageAt          string            `json:"last_message_at"`
+	LastMessageIsPlaintext bool              `json:"last_message_is_plaintext"`
+	LastReadAt             string            `json:"last_read_at"`
+	RecheckPermissions     bool              `json:"recheck_permissions"`
+	UnreadMessageCount     float64           `json:"unread_message_count"`
+	IsBlast                bool              `json:"is_blast"`
+	Audience               ChatBlastAudience `json:"audience"`
+	AudienceContentType    string            `json:"audience_content_type"`
+	AudienceContentID      string            `json:"audience_content_id"`
 }
 
 type ChatMember struct {

--- a/comms/discovery/schema/schema.go
+++ b/comms/discovery/schema/schema.go
@@ -160,8 +160,8 @@ type UserChat struct {
 	UnreadMessageCount     float64           `json:"unread_message_count"`
 	IsBlast                bool              `json:"is_blast"`
 	Audience               ChatBlastAudience `json:"audience"`
-	AudienceContentType    string            `json:"audience_content_type"`
-	AudienceContentID      string            `json:"audience_content_id"`
+	AudienceContentType    *string           `json:"audience_content_type,omitempty"`
+	AudienceContentID      *string           `json:"audience_content_id,omitempty"`
 }
 
 type ChatMember struct {

--- a/comms/discovery/server/response_mapper.go
+++ b/comms/discovery/server/response_mapper.go
@@ -28,11 +28,18 @@ func ToChatMemberResponse(member db.ChatMember) schema.ChatMember {
 }
 
 func ToChatResponse(chat queries.UserChatRow, members []db.ChatMember) schema.UserChat {
-	var encodedContentId string
-
+	var encodedContentId *string
 	if chat.AudienceContentID.Valid {
-		encodedContentId, _ = misc.EncodeHashId(int(chat.AudienceContentID.Int32))
+		id, _ := misc.EncodeHashId(int(chat.AudienceContentID.Int32))
+		encodedContentId = &id
 	}
+
+	var audienceContentType *string
+	if chat.AudienceContentType.Valid {
+		contentType := chat.AudienceContentType.String
+		audienceContentType = &contentType
+	}
+
 	chatData := schema.UserChat{
 		ChatID:                 chat.ChatID,
 		LastMessageAt:          chat.LastMessageAt.Format(time.RFC3339Nano),
@@ -42,7 +49,7 @@ func ToChatResponse(chat queries.UserChatRow, members []db.ChatMember) schema.Us
 		LastMessageIsPlaintext: chat.LastMessageIsPlaintext,
 		IsBlast:                chat.IsBlast,
 		Audience:               schema.ChatBlastAudience(chat.Audience.String),
-		AudienceContentType:    chat.AudienceContentType.String,
+		AudienceContentType:    audienceContentType,
 		AudienceContentID:      encodedContentId,
 	}
 	chatData.RecheckPermissions = rpcz.RecheckPermissionsRequired(chat.LastMessageAt, members)

--- a/comms/discovery/server/response_mapper.go
+++ b/comms/discovery/server/response_mapper.go
@@ -28,6 +28,11 @@ func ToChatMemberResponse(member db.ChatMember) schema.ChatMember {
 }
 
 func ToChatResponse(chat queries.UserChatRow, members []db.ChatMember) schema.UserChat {
+	var encodedContentId string
+
+	if chat.AudienceContentID.Valid {
+		encodedContentId, _ = misc.EncodeHashId(int(chat.AudienceContentID.Int32))
+	}
 	chatData := schema.UserChat{
 		ChatID:                 chat.ChatID,
 		LastMessageAt:          chat.LastMessageAt.Format(time.RFC3339Nano),
@@ -35,6 +40,10 @@ func ToChatResponse(chat queries.UserChatRow, members []db.ChatMember) schema.Us
 		UnreadMessageCount:     float64(chat.UnreadCount),
 		ChatMembers:            Map(members, ToChatMemberResponse),
 		LastMessageIsPlaintext: chat.LastMessageIsPlaintext,
+		IsBlast:                chat.IsBlast,
+		Audience:               schema.ChatBlastAudience(chat.Audience.String),
+		AudienceContentType:    chat.AudienceContentType.String,
+		AudienceContentID:      encodedContentId,
 	}
 	chatData.RecheckPermissions = rpcz.RecheckPermissionsRequired(chat.LastMessageAt, members)
 	if chat.LastMessage.Valid {

--- a/comms/discovery/server/server.go
+++ b/comms/discovery/server/server.go
@@ -422,7 +422,14 @@ func (s *ChatServer) getMessages(c echo.Context) error {
 		return c.String(400, "bad request: "+err.Error())
 	}
 
-	params := queries.ChatMessagesAndReactionsParams{UserID: int32(userId), ChatID: c.Param("id"), Before: time.Now().UTC(), After: time.Time{}, Limit: 50}
+	params := queries.ChatMessagesAndReactionsParams{UserID: int32(userId), ChatID: c.Param("id"), IsBlast: false, Before: time.Now().UTC(), After: time.Time{}, Limit: 50}
+	if c.QueryParam("is_blast") != "" {
+		isBlast, err := strconv.ParseBool(c.QueryParam("is_blast"))
+		if err != nil {
+			return err
+		}
+		params.IsBlast = isBlast
+	}
 	if c.QueryParam("before") != "" {
 		beforeCursor, err := time.Parse(time.RFC3339Nano, c.QueryParam("before"))
 		if err != nil {

--- a/packages/common/src/store/pages/chat/sagas.ts
+++ b/packages/common/src/store/pages/chat/sagas.ts
@@ -239,6 +239,7 @@ function* doFetchLatestMessages(
       // and batching by MESSAGE_PAGE_SIZE. Sends one extra request to get the 0 response but oh well
       const response = yield* call([sdk.chats, sdk.chats.getMessages], {
         chatId,
+        isBlast: chat.is_blast,
         before,
         after,
         limit: MESSAGES_PAGE_SIZE
@@ -296,6 +297,7 @@ function* doFetchMoreMessages(action: ReturnType<typeof fetchMoreMessages>) {
       const response = yield* call([sdk.chats, sdk.chats.getMessages], {
         chatId,
         before,
+        isBlast: chat?.is_blast,
         limit: MESSAGES_PAGE_SIZE
       })
       // Only save the last response summary. Pagination is one-way

--- a/packages/common/src/store/pages/chat/sagas.ts
+++ b/packages/common/src/store/pages/chat/sagas.ts
@@ -296,8 +296,8 @@ function* doFetchMoreMessages(action: ReturnType<typeof fetchMoreMessages>) {
     while (hasMoreUnread) {
       const response = yield* call([sdk.chats, sdk.chats.getMessages], {
         chatId,
-        before,
         isBlast: chat?.is_blast,
+        before,
         limit: MESSAGES_PAGE_SIZE
       })
       // Only save the last response summary. Pagination is one-way

--- a/packages/common/src/utils/chatUtils.ts
+++ b/packages/common/src/utils/chatUtils.ts
@@ -148,7 +148,7 @@ export const makeBlastChatId = ({
   audienceContentId?: string
 }) => {
   return (
-    `blast:${audience}` +
+    `${audience}` +
     (audienceContentType ? `:${audienceContentType}` : '') +
     (audienceContentId ? `:${audienceContentId}` : '')
   )

--- a/packages/common/src/utils/chatUtils.ts
+++ b/packages/common/src/utils/chatUtils.ts
@@ -148,7 +148,7 @@ export const makeBlastChatId = ({
   audienceContentId?: string
 }) => {
   return (
-    `${audience}` +
+    `blast:${audience}` +
     (audienceContentType ? `:${audienceContentType}` : '') +
     (audienceContentId ? `:${audienceContentId}` : '')
   )

--- a/packages/libs/src/sdk/api/chats/ChatsApi.ts
+++ b/packages/libs/src/sdk/api/chats/ChatsApi.ts
@@ -237,6 +237,9 @@ export class ChatsApi
     const query: HTTPQuery = {
       timestamp: new Date().getTime()
     }
+    if (isBlast) {
+      query.is_blast = isBlast
+    }
     if (limit) {
       query.limit = limit
     }

--- a/packages/libs/src/sdk/api/chats/ChatsApi.ts
+++ b/packages/libs/src/sdk/api/chats/ChatsApi.ts
@@ -221,17 +221,17 @@ export class ChatsApi
   public async getMessages(
     params: ChatGetMessagesRequest
   ): Promise<TypedCommsResponse<ChatMessage[]>> {
-    const { currentUserId, chatId, limit, before, after } = await parseParams(
-      'getMessages',
-      ChatGetMessagesRequestSchema
-    )(params)
+    const { currentUserId, chatId, isBlast, limit, before, after } =
+      await parseParams('getMessages', ChatGetMessagesRequestSchema)(params)
 
     let sharedSecret: Uint8Array
-    try {
-      sharedSecret = await this.getChatSecret(chatId)
-    } catch (e) {
-      this.logger.error("[audius-sdk] Couldn't get chat secret", e)
-      throw new Error("[audius-sdk] Couldn't get chat secret")
+    if (!isBlast) {
+      try {
+        sharedSecret = await this.getChatSecret(chatId)
+      } catch (e) {
+        this.logger.error("[audius-sdk] Couldn't get chat secret", e)
+        throw new Error("[audius-sdk] Couldn't get chat secret")
+      }
     }
     const path = `/comms/chats/${chatId}/messages`
     const query: HTTPQuery = {

--- a/packages/libs/src/sdk/api/chats/clientTypes.ts
+++ b/packages/libs/src/sdk/api/chats/clientTypes.ts
@@ -29,6 +29,7 @@ export type ChatGetRequest = z.infer<typeof ChatGetRequestSchema>
 export const ChatGetMessagesRequestSchema = z.object({
   currentUserId: z.optional(z.string()),
   chatId: z.string(),
+  isBlast: z.optional(z.boolean()),
   limit: z.optional(z.number()),
   before: z.optional(z.string()),
   after: z.optional(z.string())


### PR DESCRIPTION
### Description
- Change `chatId` for blasts to not include "blast:<userId>", only `concat_ws(':', audience, audience_content_type, audience_content_id) as chat_id`
- `getChat` and `getMessages` working for chat blasts
- Responses for above include `audience_content_type` and `audience_content_id` only when they are not null
- Add `is_blast` to `getChat` response (use this instead of "blast" prefix)

Potentially annoying to have to include `is_blast` in the request but I think this is the better pattern? open to ideas.

### How Has This Been Tested?

comms tests pass

https://github.com/user-attachments/assets/7955de52-bd1e-4ad7-a74d-9ddbfd43bb99

