### PR TITLE
Active styles for web chat blasts

### DIFF
--- a/packages/web/src/pages/chat-page/components/ChatList.tsx
+++ b/packages/web/src/pages/chat-page/components/ChatList.tsx
@@ -74,6 +74,7 @@ export const ChatList = (props: ChatListProps) => {
                 key={chat.chat_id}
                 chat={chat}
                 onChatClicked={onChatClicked}
+                currentChatId={currentChatId}
               />
             ) : (
               <ChatListItem

--- a/packages/web/src/pages/chat-page/components/ChatListBlastItem.tsx
+++ b/packages/web/src/pages/chat-page/components/ChatListBlastItem.tsx
@@ -1,6 +1,11 @@
+import { useCallback } from 'react'
+
 import { useGetCurrentUser } from '@audius/common/api'
 import { Flex, IconTowerBroadcast, IconUser, Text } from '@audius/harmony'
 import { ChatBlast, ChatBlastAudience } from '@audius/sdk'
+import cn from 'classnames'
+
+import styles from './ChatListItem.module.css'
 
 const messages = {
   audience: 'AUDIENCE',
@@ -22,15 +27,21 @@ const messages = {
 
 type ChatListBlastItemProps = {
   chat: ChatBlast
+  currentChatId?: string
   onChatClicked: (chatId: string) => void
 }
 
 export const ChatListBlastItem = (props: ChatListBlastItemProps) => {
-  const { chat, onChatClicked } = props
+  const { chat, onChatClicked, currentChatId } = props
   const { chat_id: chatId, audience } = chat
+  const isCurrentChat = currentChatId && currentChatId === chatId
 
   const { data: user } = useGetCurrentUser()
   const audienceCount = user?.follower_count ?? 0
+
+  const handleClick = useCallback(() => {
+    onChatClicked(chatId)
+  }, [chatId, onChatClicked])
 
   return (
     <Flex
@@ -39,7 +50,8 @@ export const ChatListBlastItem = (props: ChatListBlastItemProps) => {
       direction='column'
       gap='s'
       borderBottom='default'
-      onClick={() => onChatClicked(chatId)}
+      onClick={handleClick}
+      className={cn(styles.root, { [styles.active]: isCurrentChat })}
     >
       <Flex gap='s'>
         <IconTowerBroadcast size='l' color='default' />
@@ -47,7 +59,7 @@ export const ChatListBlastItem = (props: ChatListBlastItemProps) => {
           {messages[audience].title}
         </Text>
       </Flex>
-      <Flex justifyContent='space-between'>
+      <Flex justifyContent='space-between' w='100%'>
         <Text variant='label' textTransform='capitalize' color='subdued'>
           {messages.audience}
         </Text>


### PR DESCRIPTION
### Description
Adding active styles for the blast list item

### How Has This Been Tested?

<img width="919" alt="Screenshot 2024-08-22 at 12 05 46 PM" src="https://github.com/user-attachments/assets/25153e29-9023-4e8e-942c-75aac43a10df">
