### PR TITLE
[QA-1499] Fix long usernames overflowing manager mode button

### DIFF
--- a/packages/web/src/components/nav/desktop/AccountDetails.tsx
+++ b/packages/web/src/components/nav/desktop/AccountDetails.tsx
@@ -84,6 +84,9 @@ export const AccountDetails = () => {
                     badgeSize='xs'
                     css={{
                       flex: 1,
+                      overflow: 'hidden',
+                      textOverflow: 'ellipsis',
+                      wordBreak: 'break-word',
                       ...(isManagedAccount && {
                         color: color.secondary.s500,
                         '&:hover': { color: color.secondary.s500 }


### PR DESCRIPTION
### Description

Fixes long names pushing the manager mode button out of view
![image](https://github.com/user-attachments/assets/d68566cf-78fb-4e3e-bbcd-962515cfd083)


### How Has This Been Tested?

web:stage with a hardcoded long name
