### PR TITLE
Add react-router dependency

### DIFF
--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -63,6 +63,7 @@
     "proxy-memoize": "1.2.0",
     "query-string": "8.1.0",
     "react-redux": "8.0.5",
+    "react-router": "5.1.20",
     "react-use": "17.4.0",
     "redux": "4.0.5",
     "redux-persist": "6.0.0",

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -63,7 +63,7 @@
     "proxy-memoize": "1.2.0",
     "query-string": "8.1.0",
     "react-redux": "8.0.5",
-    "react-router": "5.1.20",
+    "react-router": "5.3.4",
     "react-use": "17.4.0",
     "redux": "4.0.5",
     "redux-persist": "6.0.0",


### PR DESCRIPTION
### Description
`push-protocol-dashboard` job failing because of this error 

```
107.5 ******-protocol-dashboard:build: [vite]: Rollup failed to resolve import "react-router" from "/app/packages/common/src/utils/route.ts".
107.5 ******-protocol-dashboard:build: This is most likely unintended because it can break your application at runtime.
107.5 ******-protocol-dashboard:build: If you do want to externalize this module explicitly add it to
107.5 ******-protocol-dashboard:build: `build.rollupOptions.external`
107.5 ******-protocol-dashboard:build: error during build:
107.5 ******-protocol-dashboard:build: Error: [vite]: Rollup failed to resolve import "react-router" from "/app/packages
```

which i think matches the timing of this https://github.com/AudiusProject/audius-protocol/pull/9492/files



### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._

Ran `audius-compose push --prod "dashboard"` locally and seems to work