### PR TITLE
Fix challenge api tx confirming

### DIFF
--- a/.changeset/tricky-cooks-sell.md
+++ b/.changeset/tricky-cooks-sell.md
@@ -1,0 +1,5 @@
+---
+'@audius/sdk': minor
+---
+
+Fix issue with confirming reward claims.

--- a/packages/libs/src/sdk/api/challenges/ChallengesApi.ts
+++ b/packages/libs/src/sdk/api/challenges/ChallengesApi.ts
@@ -327,7 +327,9 @@ export class ChallengesApi extends GeneratedChallengesApi {
       transactions.push(submitTransaction)
     }
     return await Promise.all(
-      transactions.map((t) => this.rewardManager.sendTransaction(t))
+      transactions.map((t) => {
+        return { transactionSignature: this.rewardManager.sendTransaction(t) }
+      })
     )
   }
 

--- a/packages/libs/src/sdk/api/challenges/ChallengesApi.ts
+++ b/packages/libs/src/sdk/api/challenges/ChallengesApi.ts
@@ -278,7 +278,7 @@ export class ChallengesApi extends GeneratedChallengesApi {
     numberOfNodes: number
     excludeOwners: string[]
     logger?: LoggerService
-  }) {
+  }): Promise<Array<{ transactionSignature: Promise<string> }>> {
     const discoveryNodes =
       await this.discoveryNodeSelector.getUniquelyOwnedEndpoints(
         numberOfNodes,

--- a/packages/libs/src/sdk/api/challenges/ChallengesApi.ts
+++ b/packages/libs/src/sdk/api/challenges/ChallengesApi.ts
@@ -91,20 +91,6 @@ export class ChallengesApi extends GeneratedChallengesApi {
    * @see {@link generateSpecifier} to create the specifier argument.
    */
   public async claimReward(request: ClaimRewardsRequest) {
-    for (let i = 0; i < 5; i++) {
-      try {
-        return await this.claimRewardAttempt(request)
-      } catch (e) {
-        console.error(`Failed to claim reward attempt ${i}: ${e}`)
-        if (i === 4) {
-          throw e
-        }
-      }
-    }
-    throw new Error('Failed to claim reward.')
-  }
-
-  private async claimRewardAttempt(request: ClaimRewardsRequest) {
     const args = await parseParams('claimRewards', ClaimRewardsSchema)(request)
     const { challengeId, specifier, amount: inputAmount } = args
     const logger = this.logger.createPrefixedLogger(


### PR DESCRIPTION
### Description

`submitDiscoveryAttestations` should match the return type of `submitAntiAbuseOracleAttestation` otherwise it gets filtered out and not actually confirmed. Probably not the main reason for claiming instability but maybe part of it.


### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._

Ran locally against prod and confirmed that this was able to confirm then claim properly.