### PR TITLE
[QA-1515] Remove dismiss on leave from popup

### DIFF
--- a/packages/web/src/components/table/components/OverflowMenuButton.tsx
+++ b/packages/web/src/components/table/components/OverflowMenuButton.tsx
@@ -55,7 +55,7 @@ export const OverflowMenuButton = (props: OverflowMenuButtonProps) => {
 
   return (
     <div onClick={onClick} className={cn(styles.tableOptionsButton, className)}>
-      <Menu menu={overflowMenu} dismissOnMouseLeave>
+      <Menu menu={overflowMenu}>
         {(ref, triggerPopup) => (
           <div
             className={tabStyles.iconKebabHorizontalWrapper}


### PR DESCRIPTION
### Description

Tweak tracks table popup behavior to not dismiss on mouse leave.

This makes for a pretty poor UX; its very easy to accidentally close the popup.

### How Has This Been Tested?

web:stage
