### PR TITLE
fix core crashloop

### DIFF
--- a/core/config/comet.go
+++ b/core/config/comet.go
@@ -47,6 +47,7 @@ func InitComet(logger *common.Logger, cfg *Config) error {
 	if common.FileExists(privValKeyFile) {
 		logger.Info("Found private validator", "keyFile", privValKeyFile,
 			"stateFile", privValStateFile)
+		pv = privval.LoadFilePV(privValKeyFile, privValStateFile)
 	} else {
 		pv = privval.NewFilePV(key, privValKeyFile, privValStateFile)
 		pv.Save()


### PR DESCRIPTION
### Description
We didn't load the pv at the startup so when we get the address later it had a nil ref. This was a problem before because later the node actually reads the pv for it's own use. Since we use this now for the console it exposed the nil.

### How Has This Been Tested?
On main run `audius-compose up core core-content-1 core-content-2 core-content-3 db`.
Docker stop one of your core nodes `docker stop core-content-1`.
Start the container again `docker start core-content-1`. 
It will enter a crash loop on the `.getAddress()` call in `comet.go`.

After this change you can restart the node as many times as you'd like and it will correctly gather the address.

