### PR TITLE
Fix trending reward notifs

### DIFF
--- a/packages/common/src/models/AudioRewards.ts
+++ b/packages/common/src/models/AudioRewards.ts
@@ -39,7 +39,10 @@ export type Specifier = string
  */
 export enum ChallengeName {
   AudioMatchingBuy = 'b',
-  AudioMatchingSell = 's'
+  AudioMatchingSell = 's',
+  TrendingTrack = 'tt',
+  TrendingPlaylist = 'tp',
+  TrendingUndergroundTrack = 'tut'
 }
 
 export type ChallengeRewardID =
@@ -60,6 +63,9 @@ export type ChallengeRewardID =
   | 'top-api'
   | 'verified-upload'
   | 'trending-underground'
+  | ChallengeName.TrendingTrack
+  | ChallengeName.TrendingPlaylist
+  | ChallengeName.TrendingUndergroundTrack
 
 export enum FailureReason {
   // The attestation requires the user to fill out a captcha

--- a/packages/common/src/utils/challenges.ts
+++ b/packages/common/src/utils/challenges.ts
@@ -148,7 +148,19 @@ export const challengeRewardsConfig: Record<
     description: () => 'Winners are selected every Friday at Noon PT!',
     panelButtonText: 'See More'
   },
+  tp: {
+    id: 'trending-playlist',
+    title: 'Top 5 Trending Playlists',
+    description: () => 'Winners are selected every Friday at Noon PT!',
+    panelButtonText: 'See More'
+  },
   'trending-track': {
+    title: 'Top 5 Trending Tracks',
+    description: () => 'Winners are selected every Friday at Noon PT!',
+    panelButtonText: 'See More',
+    id: 'trending-track'
+  },
+  tt: {
     title: 'Top 5 Trending Tracks',
     description: () => 'Winners are selected every Friday at Noon PT!',
     panelButtonText: 'See More',
@@ -168,6 +180,12 @@ export const challengeRewardsConfig: Record<
     id: 'verified-upload'
   },
   'trending-underground': {
+    title: 'Top 5 Underground Trending',
+    description: () => 'Winners are selected every Friday at Noon PT!',
+    panelButtonText: 'See More',
+    id: 'trending-underground'
+  },
+  tut: {
     title: 'Top 5 Underground Trending',
     description: () => 'Winners are selected every Friday at Noon PT!',
     panelButtonText: 'See More',

--- a/packages/discovery-provider/ddl/functions/handle_user_challenges.sql
+++ b/packages/discovery-provider/ddl/functions/handle_user_challenges.sql
@@ -18,7 +18,7 @@ begin
             timestamp >= (new.completed_at - interval '1 hour')
             limit 1;
 
-            if existing_notification is null then
+            if existing_notification is null and new.challenge_id not in ('tt', 'tp', 'tut') then
                 insert into notification
                 (blocknumber, user_ids, timestamp, type, group_id, specifier, data)
                 values

--- a/packages/mobile/src/screens/notifications-screen/Notifications/ChallengeRewardNotification.tsx
+++ b/packages/mobile/src/screens/notifications-screen/Notifications/ChallengeRewardNotification.tsx
@@ -32,12 +32,23 @@ type ChallengeRewardNotificationProps = {
   notification: ChallengeRewardNotificationType
 }
 
+const trendingChallengeIdMapping = {
+  tt: 'trending-track',
+  tp: 'trending-playlist',
+  tut: 'trending-underground-track'
+}
+
 export const ChallengeRewardNotification = (
   props: ChallengeRewardNotificationProps
 ) => {
   const { notification } = props
   const { challengeId } = notification
-  const info = challengeRewardsConfig[challengeId]
+  const mappedChallengeRewardsConfigKey =
+    challengeId in trendingChallengeIdMapping
+      ? trendingChallengeIdMapping[challengeId]
+      : challengeId
+
+  const info = challengeRewardsConfig[mappedChallengeRewardsConfigKey]
   const amount = stringWeiToAudioBN(notification.amount)
   const navigation = useNotificationNavigation()
 

--- a/packages/mobile/src/utils/challenges.tsx
+++ b/packages/mobile/src/utils/challenges.tsx
@@ -152,7 +152,19 @@ const mobileChallengeConfig: Record<ChallengeRewardID, MobileChallengeConfig> =
         iconRight: IconCheck
       }
     },
+    tp: {
+      icon: ArrowUp,
+      buttonInfo: {
+        iconRight: IconCheck
+      }
+    },
     'trending-track': {
+      icon: ChartIncreasing,
+      buttonInfo: {
+        iconRight: IconCheck
+      }
+    },
+    tt: {
       icon: ChartIncreasing,
       buttonInfo: {
         iconRight: IconCheck
@@ -177,6 +189,13 @@ const mobileChallengeConfig: Record<ChallengeRewardID, MobileChallengeConfig> =
         iconRight: IconCheck
       }
     },
+    tut: {
+      icon: BarChart,
+      buttonInfo: {
+        iconRight: IconCheck
+      }
+    },
+
     [ChallengeName.AudioMatchingBuy]: {
       icon: Cart,
       buttonInfo: {

--- a/packages/web/src/components/notification/Notification/ChallengeRewardNotification.tsx
+++ b/packages/web/src/components/notification/Notification/ChallengeRewardNotification.tsx
@@ -1,6 +1,6 @@
 import { useCallback } from 'react'
 
-import { Name, BNAudio } from '@audius/common/models'
+import { Name, BNAudio, ChallengeRewardID } from '@audius/common/models'
 import { ChallengeRewardNotification as ChallengeRewardNotificationType } from '@audius/common/store'
 import { route, stringWeiToAudioBN } from '@audius/common/utils'
 import { push } from 'connected-react-router'
@@ -35,6 +35,14 @@ type ChallengeRewardNotificationProps = {
   notification: ChallengeRewardNotificationType
 }
 
+const trendingChallengeIdMapping: {
+  [key in ChallengeRewardID]?: ChallengeRewardID
+} = {
+  tt: 'trending-track',
+  tp: 'trending-playlist',
+  tut: 'trending-underground'
+}
+
 export const ChallengeRewardNotification = (
   props: ChallengeRewardNotificationProps
 ) => {
@@ -42,8 +50,10 @@ export const ChallengeRewardNotification = (
   const { challengeId, timeLabel, isViewed, type } = notification
   const dispatch = useDispatch()
   const record = useRecord()
+  const mappedChallengeRewardsConfigKey =
+    trendingChallengeIdMapping[challengeId] ?? challengeId
 
-  const { title, icon } = getChallengeConfig(challengeId)
+  const { title, icon } = getChallengeConfig(mappedChallengeRewardsConfigKey)
   const amount = stringWeiToAudioBN(notification.amount)
   const handleClick = useCallback(() => {
     dispatch(push(AUDIO_PAGE))

--- a/packages/web/src/pages/audio-rewards-page/config.tsx
+++ b/packages/web/src/pages/audio-rewards-page/config.tsx
@@ -188,8 +188,14 @@ const webChallengesConfig: Record<ChallengeRewardID, WebChallengeInfo> = {
   'trending-playlist': {
     icon: <i className='emoji large arrow-curve-up' />
   },
+  tp: {
+    icon: <i className='emoji large arrow-curve-up' />
+  },
   'trending-track': {
     icon: <i className='emoji large chart-increasing' />
+  },
+  tt: {
+    icon: <i className='emoji large arrow-curve-up' />
   },
   'top-api': {
     icon: <i className='emoji large gear' />
@@ -198,6 +204,9 @@ const webChallengesConfig: Record<ChallengeRewardID, WebChallengeInfo> = {
     icon: <i className='emoji large white-heavy-check-mark' />
   },
   'trending-underground': {
+    icon: <i className='emoji large chart-bar' />
+  },
+  tut: {
     icon: <i className='emoji large chart-bar' />
   }
 }


### PR DESCRIPTION
### Description

* Removes trending claimable_reward notifications since these rewards are an exception and not actionable for users, they are automatically disbursed.
* Add title and icon info to trending challenge reward notifs. This is probably a longstanding bug. 

Seems like there are places in the client that use a full trending challenge name `trending-track` instead of the id `tt` so left that part alone for now. It should be using the ID like the other abbreviated IDs `s` `b`.

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._

Ran against stage. Confirmed a new trending user challenge does not trigger a claimable_reward notif. Confirmed web and mobile include titl
<img width="404" alt="Screenshot 2024-08-23 at 1 08 36 PM" src="https://github.com/user-attachments/assets/7acf105b-993a-4ac3-8a14-2e559e1c60a8">
e and icon.

<img width="389" alt="Screenshot 2024-08-23 at 1 09 35 PM" src="https://github.com/user-attachments/assets/8b91e9df-1232-4c68-a52d-845e6e7bd9ee">

