### PR TITLE
[QA-1498] Fix long press on DMs

### DIFF
--- a/packages/mobile/src/screens/chat-screen/ChatMessageListItem.tsx
+++ b/packages/mobile/src/screens/chat-screen/ChatMessageListItem.tsx
@@ -317,6 +317,7 @@ export const ChatMessageListItem = memo(function ChatMessageListItem(
                           showUnderline: true
                         }}
                         onPress={Keyboard.dismiss}
+                        allowPointerEventsToPassThrough
                       >
                         {message.message}
                       </UserGeneratedText>


### PR DESCRIPTION
### Description

Right now the text is pressable and interfering with the long press to show the emote wheel

### How Has This Been Tested?

local ios device

TODO: verify with an android; can do on staging
