### PR TITLE
[C-4955] Comment action drawer

### DIFF
--- a/packages/common/src/context/commentsContext.tsx
+++ b/packages/common/src/context/commentsContext.tsx
@@ -69,7 +69,6 @@ export const CommentSectionProvider = ({
     { entityId },
     {
       pageSize: 5,
-      force: true,
       disabled: entityId === 0
     }
   )

--- a/packages/mobile/src/app/App.tsx
+++ b/packages/mobile/src/app/App.tsx
@@ -95,6 +95,7 @@ const App = () => {
                               <NotificationReminder />
                               <RateCtaReminder />
                               <PortalHost name='ChatReactionsPortal' />
+                              <PortalHost name='DrawerPortal' />
                             </BottomSheetModalProvider>
                           </NavigationContainer>
                         </ErrorBoundary>

--- a/packages/mobile/src/components/action-drawer/ActionDrawerWithoutRedux.tsx
+++ b/packages/mobile/src/components/action-drawer/ActionDrawerWithoutRedux.tsx
@@ -1,0 +1,37 @@
+import type { SetOptional } from 'type-fest'
+
+import Drawer from '../drawer'
+import type { DrawerProps } from '../drawer/Drawer'
+
+import type { ActionDrawerContentProps } from './ActionDrawer'
+import { ActionDrawerContent } from './ActionDrawer'
+
+type ActionDrawerWithoutReduxProps = ActionDrawerContentProps &
+  SetOptional<DrawerProps, 'children'>
+
+/** ActionDrawer that isn't coupled to redux */
+export const ActionDrawerWithoutRedux = (
+  props: ActionDrawerWithoutReduxProps
+) => {
+  const {
+    rows,
+    styles: stylesProp,
+    disableAutoClose,
+    children,
+    ...other
+  } = props
+  const { onClose } = props
+
+  return (
+    <Drawer {...other}>
+      <ActionDrawerContent
+        onClose={onClose}
+        rows={rows}
+        styles={stylesProp}
+        disableAutoClose={disableAutoClose}
+      >
+        {children}
+      </ActionDrawerContent>
+    </Drawer>
+  )
+}

--- a/packages/mobile/src/components/action-drawer/index.ts
+++ b/packages/mobile/src/components/action-drawer/index.ts
@@ -1,1 +1,3 @@
 export { default } from './ActionDrawer'
+export { ActionDrawerWithoutRedux } from './ActionDrawerWithoutRedux'
+export type { ActionDrawerRow } from './ActionDrawer'

--- a/packages/mobile/src/components/comments/CommentBlock.tsx
+++ b/packages/mobile/src/components/comments/CommentBlock.tsx
@@ -135,7 +135,7 @@ export const CommentBlock = (props: CommentBlockProps) => {
               >
                 {messages.reply}
               </PlainButton>
-              <CommentOverflowMenu commentId={commentId} isPinned={isPinned} />
+              <CommentOverflowMenu comment={comment} />
             </Flex>
           </>
         ) : null}

--- a/packages/mobile/src/components/comments/CommentBlock.tsx
+++ b/packages/mobile/src/components/comments/CommentBlock.tsx
@@ -9,7 +9,6 @@ import {
   Flex,
   IconButton,
   IconHeart,
-  IconKebabHorizontal,
   IconPencil,
   PlainButton,
   Text,
@@ -20,6 +19,8 @@ import { formatCommentTrackTimestamp } from 'app/utils/comments'
 
 import { ProfilePicture } from '../core/ProfilePicture'
 import { UserLink } from '../user-link'
+
+import { CommentOverflowMenu } from './CommentOverflowMenu'
 
 const messages = {
   pinned: 'Pinned by artist',
@@ -134,13 +135,7 @@ export const CommentBlock = (props: CommentBlockProps) => {
               >
                 {messages.reply}
               </PlainButton>
-              <IconButton
-                aria-label='edit comment'
-                icon={IconKebabHorizontal}
-                size='s'
-                color='subdued'
-                onPress={() => {}}
-              />
+              <CommentOverflowMenu commentId={commentId} isPinned={isPinned} />
             </Flex>
           </>
         ) : null}

--- a/packages/mobile/src/components/comments/CommentOverflowMenu.tsx
+++ b/packages/mobile/src/components/comments/CommentOverflowMenu.tsx
@@ -1,0 +1,85 @@
+import React, { useState } from 'react'
+
+import {
+  CommentSectionProvider,
+  useCurrentCommentSection,
+  useDeleteComment,
+  usePinComment
+} from '@audius/common/context'
+import { accountSelectors } from '@audius/common/store'
+import { Portal } from '@gorhom/portal'
+import { useSelector } from 'react-redux'
+
+import { IconButton, IconKebabHorizontal } from '@audius/harmony-native'
+
+import {
+  ActionDrawerWithoutRedux,
+  type ActionDrawerRow
+} from '../action-drawer'
+
+const { getUserId } = accountSelectors
+
+type CommentOverflowMenuProps = {
+  commentId: string
+  isPinned: boolean
+}
+
+export const CommentOverflowMenu = (props: CommentOverflowMenuProps) => {
+  const { commentId, isPinned } = props
+
+  // Need isOpen and isVisible to account for the closing animation
+  const [isOpen, setIsOpen] = useState(false)
+  const [isVisible, setIsVisible] = useState(false)
+
+  const currentUserId = useSelector(getUserId)
+  const { artistId, entityId, isEntityOwner } = useCurrentCommentSection()
+
+  const [pinComment] = usePinComment()
+  const [deleteComment] = useDeleteComment()
+
+  const rows: ActionDrawerRow[] = [
+    {
+      text: 'Pin',
+      callback: () => pinComment(commentId, isPinned)
+    },
+    {
+      text: 'Delete',
+      callback: () => deleteComment(commentId),
+      isDestructive: true
+    }
+  ]
+
+  return (
+    <>
+      <IconButton
+        aria-label='more actions'
+        icon={IconKebabHorizontal}
+        size='s'
+        color='subdued'
+        onPress={() => {
+          setIsOpen(!isOpen)
+          setIsVisible(!isVisible)
+        }}
+      />
+
+      {isVisible ? (
+        <Portal hostName='DrawerPortal'>
+          <CommentSectionProvider
+            currentUserId={currentUserId}
+            artistId={artistId}
+            entityId={entityId}
+            isEntityOwner={isEntityOwner}
+            playTrack={() => {}}
+          >
+            <ActionDrawerWithoutRedux
+              rows={rows}
+              isOpen={isOpen}
+              onClose={() => setIsOpen(false)}
+              onClosed={() => setIsVisible(false)}
+            />
+          </CommentSectionProvider>
+        </Portal>
+      ) : null}
+    </>
+  )
+}

--- a/packages/mobile/src/components/comments/CommentOverflowMenu.tsx
+++ b/packages/mobile/src/components/comments/CommentOverflowMenu.tsx
@@ -18,6 +18,16 @@ import {
   type ActionDrawerRow
 } from '../action-drawer'
 
+const messages = {
+  pin: 'Pin',
+  flagAndRemove: 'Flag & Remove',
+  muteUser: 'Mute User',
+  turnOffNotifications: 'Turn Off Notifications',
+  edit: 'Edit',
+  delete: 'Delete',
+  moreActions: 'more actions'
+}
+
 type CommentOverflowMenuProps = {
   comment: Comment
 }
@@ -44,29 +54,29 @@ export const CommentOverflowMenu = (props: CommentOverflowMenuProps) => {
 
   const rows: ActionDrawerRow[] = [
     isEntityOwner && {
-      text: 'Pin',
+      text: messages.pin,
       callback: () => pinComment(id, isPinned)
     },
     isEntityOwner &&
       !isCommentOwner && {
-        text: 'Flag & Remove',
+        text: messages.flagAndRemove,
         callback: () => reportComment(id)
       },
     !isCommentOwner && {
-      text: 'Mute User',
+      text: messages.muteUser,
       callback: () => {} // TODO
     },
     // TODO: check if receiving notifications
     isCommentOwner && {
-      text: 'Turn Off Notifications',
+      text: messages.turnOffNotifications,
       callback: () => {} // TODO
     },
     isCommentOwner && {
-      text: 'Edit',
+      text: messages.edit,
       callback: () => {} // TODO
     },
     isCommentOwner && {
-      text: 'Delete',
+      text: messages.delete,
       callback: () => deleteComment(id),
       isDestructive: true
     }
@@ -75,7 +85,7 @@ export const CommentOverflowMenu = (props: CommentOverflowMenuProps) => {
   return (
     <>
       <IconButton
-        aria-label='more actions'
+        aria-label={messages.moreActions}
         icon={IconKebabHorizontal}
         size='s'
         color='subdued'


### PR DESCRIPTION
### Description

Add CommentOverflowMenu via ActionDrawerWithoutRedux. Open to input on this! Added a portal at the root and then conditionally render the action drawer when needed. This makes the actual implementation in CommentOverflowMenu very clean, and we have access to all of our context and hooks 🙌 

### How Has This Been Tested?

Tested new ActionDrawer and the redux ones
