### PR TITLE
[PAY-2919] Migrate playlists endpoints from apiClient -> sdk

### DIFF
--- a/packages/common/src/adapters/collection.ts
+++ b/packages/common/src/adapters/collection.ts
@@ -1,4 +1,5 @@
 import { full } from '@audius/sdk'
+import dayjs from 'dayjs'
 import { omit } from 'lodash'
 import snakecaseKeys from 'snakecase-keys'
 
@@ -58,6 +59,18 @@ export const userCollectionMetadataFromSDK = (
 
     variant: Variant.USER_GENERATED,
 
+    // Conversions
+    playlist_id: decodedPlaylistId,
+    playlist_owner_id: decodedOwnerId,
+    // TODO: Remove this when api is fixed to return UTC dates
+    release_date: input.releaseDate
+      ? dayjs
+          .utc(input.releaseDate)
+          .local()
+          // utc -> local
+          .format('ddd MMM DD YYYY HH:mm:ss [GMT]ZZ')
+      : null,
+
     // Nested Transformed Fields
     artists: input.artists
       ? transformAndCleanList(input.artists, resourceContributorFromSDK)
@@ -83,8 +96,6 @@ export const userCollectionMetadataFromSDK = (
         addedTimestampToPlaylistTrackId
       )
     },
-    playlist_id: decodedPlaylistId,
-    playlist_owner_id: decodedOwnerId,
     producer_copyright_line: input.producerCopyrightLine
       ? (snakecaseKeys(input.producerCopyrightLine) as Copyright)
       : null,
@@ -100,8 +111,7 @@ export const userCollectionMetadataFromSDK = (
     // Nullable fields
     cover_art: input.coverArt ?? null,
     cover_art_sizes: input.coverArtSizes ?? null,
-    description: input.description ?? null,
-    release_date: input.releaseDate ?? null
+    description: input.description ?? null
   }
 
   return newCollection

--- a/packages/common/src/adapters/collection.ts
+++ b/packages/common/src/adapters/collection.ts
@@ -64,11 +64,7 @@ export const userCollectionMetadataFromSDK = (
     playlist_owner_id: decodedOwnerId,
     // TODO: Remove this when api is fixed to return UTC dates
     release_date: input.releaseDate
-      ? dayjs
-          .utc(input.releaseDate)
-          .local()
-          // utc -> local
-          .format('ddd MMM DD YYYY HH:mm:ss [GMT]ZZ')
+      ? dayjs.utc(input.releaseDate).local().toString()
       : null,
 
     // Nested Transformed Fields

--- a/packages/common/src/adapters/track.ts
+++ b/packages/common/src/adapters/track.ts
@@ -57,6 +57,7 @@ export const userTrackMetadataFromSDK = (
     // Conversions
     track_id: decodedTrackId,
     owner_id: decodedOwnerId,
+    // TODO: Remove this when api is fixed to return UTC dates
     release_date: input.releaseDate
       ? dayjs
           .utc(input.releaseDate)

--- a/packages/common/src/api/collection.ts
+++ b/packages/common/src/api/collection.ts
@@ -1,5 +1,6 @@
+import { userCollectionMetadataFromSDK } from '~/adapters'
 import { createApi } from '~/audius-query'
-import { ID, Kind } from '~/models'
+import { ID, Id, Kind, OptionalId } from '~/models'
 import { Nullable } from '~/utils'
 
 const collectionApi = createApi({
@@ -11,15 +12,15 @@ const collectionApi = createApi({
           playlistId,
           currentUserId
         }: { playlistId: Nullable<ID>; currentUserId?: Nullable<ID> },
-        { apiClient }
+        { audiusSdk }
       ) => {
         if (!playlistId) return null
-        return (
-          await apiClient.getPlaylist({
-            playlistId,
-            currentUserId: currentUserId ?? null
-          })
-        )[0]
+        const sdk = await audiusSdk()
+        const { data = [] } = await sdk.full.playlists.getPlaylist({
+          playlistId: Id.parse(playlistId),
+          userId: OptionalId.parse(currentUserId)
+        })
+        return data.length ? userCollectionMetadataFromSDK(data[0]) : null
       },
       fetchBatch: async (
         { ids, currentUserId }: { ids: ID[]; currentUserId?: Nullable<ID> },

--- a/packages/common/src/api/collection.ts
+++ b/packages/common/src/api/collection.ts
@@ -1,4 +1,7 @@
-import { userCollectionMetadataFromSDK } from '~/adapters'
+import {
+  transformAndCleanList,
+  userCollectionMetadataFromSDK
+} from '~/adapters'
 import { createApi } from '~/audius-query'
 import { ID, Id, Kind, OptionalId } from '~/models'
 import { Nullable } from '~/utils'
@@ -24,12 +27,14 @@ const collectionApi = createApi({
       },
       fetchBatch: async (
         { ids, currentUserId }: { ids: ID[]; currentUserId?: Nullable<ID> },
-        { apiClient }
+        { audiusSdk }
       ) => {
-        return await apiClient.getPlaylists({
-          playlistIds: ids,
-          currentUserId: currentUserId ?? null
+        const sdk = await audiusSdk()
+        const { data = [] } = await sdk.full.playlists.getBulkPlaylists({
+          id: ids.map((id) => Id.parse(id)),
+          userId: OptionalId.parse(currentUserId)
         })
+        return transformAndCleanList(data, userCollectionMetadataFromSDK)
       },
       options: {
         idArgKey: 'playlistId',

--- a/packages/common/src/api/collection.ts
+++ b/packages/common/src/api/collection.ts
@@ -34,7 +34,9 @@ const collectionApi = createApi({
           playlistId: Id.parse(playlistId),
           userId: OptionalId.parse(currentUserId)
         })
-        return data.length ? userCollectionMetadataFromSDK(data[0]) : null
+        return data.length
+          ? userCollectionMetadataFromSDK(data[0]) ?? null
+          : null
       },
       fetchBatch: async (
         { ids, currentUserId }: { ids: ID[]; currentUserId?: Nullable<ID> },

--- a/packages/common/src/services/audius-api-client/AudiusAPIClient.ts
+++ b/packages/common/src/services/audius-api-client/AudiusAPIClient.ts
@@ -49,8 +49,6 @@ const FULL_ENDPOINT_MAP = {
     experiment ? `/playlists/trending/${experiment}` : '/playlists/trending',
   playlistUpdates: (userId: OpaqueID) =>
     `/notifications/${userId}/playlist_updates`,
-  getPlaylistByPermalink: (handle: string, slug: string) =>
-    `/playlists/by_permalink/${handle}/${slug}`,
   getTrackStreamUrl: (trackId: OpaqueID) => `/tracks/${trackId}/stream`,
   searchFull: `/search/full`,
   searchAutocomplete: `/search/autocomplete`,
@@ -71,11 +69,6 @@ type GetTrackStreamUrlArgs = {
     handle: string
   }
   abortOnUnreachable?: boolean
-}
-
-type GetPlaylistByPermalinkArgs = {
-  permalink: string
-  currentUserId: Nullable<ID>
 }
 
 type GetSearchArgs = {
@@ -255,35 +248,6 @@ export class AudiusAPIClient {
     )
 
     return trackUrl?.data
-  }
-
-  async getPlaylistByPermalink({
-    permalink,
-    currentUserId
-  }: GetPlaylistByPermalinkArgs) {
-    this._assertInitialized()
-    const encodedCurrentUserId = encodeHashId(currentUserId)
-    const params = {
-      user_id: encodedCurrentUserId || undefined
-    }
-    const splitPermalink = permalink.split('/')
-    if (splitPermalink.length !== 4) {
-      throw Error(
-        'Permalink formatted incorrectly. Should follow /<handle>/playlist/<slug> format.'
-      )
-    }
-    const [, handle, , slug] = splitPermalink
-    const response = await this._getResponse<APIResponse<APIPlaylist[]>>(
-      FULL_ENDPOINT_MAP.getPlaylistByPermalink(handle, slug),
-      params
-    )
-
-    if (!response) return []
-
-    const adapted = response.data
-      .map(adapter.makePlaylist)
-      .filter(removeNullable)
-    return adapted
   }
 
   async getSearchFull({

--- a/packages/common/src/services/audius-api-client/AudiusAPIClient.ts
+++ b/packages/common/src/services/audius-api-client/AudiusAPIClient.ts
@@ -1,6 +1,6 @@
 import type { AudiusLibs, Genre, Mood } from '@audius/sdk'
 
-import { ID, CollectionMetadata } from '../../models'
+import { ID } from '../../models'
 import {
   SearchKind,
   SearchSortMethod
@@ -41,8 +41,7 @@ enum PathType {
 const ROOT_ENDPOINT_MAP = {
   feed: `/feed`,
   healthCheck: '/health_check',
-  blockConfirmation: '/block_confirmation',
-  getCollectionMetadata: '/playlists'
+  blockConfirmation: '/block_confirmation'
 }
 
 const FULL_ENDPOINT_MAP = {
@@ -71,12 +70,6 @@ type GetTrackStreamUrlArgs = {
     urlTitle: string
     handle: string
   }
-  abortOnUnreachable?: boolean
-}
-
-type GetCollectionMetadataArgs = {
-  collectionId: ID
-  currentUserId: ID
   abortOnUnreachable?: boolean
 }
 
@@ -262,26 +255,6 @@ export class AudiusAPIClient {
     )
 
     return trackUrl?.data
-  }
-
-  async getCollectionMetadata({
-    collectionId,
-    currentUserId,
-    abortOnUnreachable
-  }: GetCollectionMetadataArgs) {
-    this._assertInitialized()
-
-    const headers = { 'X-User-ID': currentUserId.toString() }
-    const params = { playlist_id: collectionId }
-    const response = await this._getResponse<APIResponse<CollectionMetadata[]>>(
-      ROOT_ENDPOINT_MAP.getCollectionMetadata,
-      params,
-      false,
-      PathType.RootPath,
-      headers,
-      abortOnUnreachable
-    )
-    return response?.data?.[0]
   }
 
   async getPlaylistByPermalink({

--- a/packages/common/src/services/audius-api-client/AudiusAPIClient.ts
+++ b/packages/common/src/services/audius-api-client/AudiusAPIClient.ts
@@ -50,7 +50,6 @@ const FULL_ENDPOINT_MAP = {
     experiment ? `/playlists/trending/${experiment}` : '/playlists/trending',
   playlistUpdates: (userId: OpaqueID) =>
     `/notifications/${userId}/playlist_updates`,
-  getPlaylists: '/playlists',
   getPlaylistByPermalink: (handle: string, slug: string) =>
     `/playlists/by_permalink/${handle}/${slug}`,
   getTrackStreamUrl: (trackId: OpaqueID) => `/tracks/${trackId}/stream`,
@@ -78,12 +77,6 @@ type GetTrackStreamUrlArgs = {
 type GetCollectionMetadataArgs = {
   collectionId: ID
   currentUserId: ID
-  abortOnUnreachable?: boolean
-}
-
-type GetPlaylistsArgs = {
-  playlistIds: ID[]
-  currentUserId: Nullable<ID>
   abortOnUnreachable?: boolean
 }
 
@@ -289,38 +282,6 @@ export class AudiusAPIClient {
       abortOnUnreachable
     )
     return response?.data?.[0]
-  }
-
-  async getPlaylists({
-    playlistIds,
-    currentUserId,
-    abortOnUnreachable
-  }: GetPlaylistsArgs) {
-    this._assertInitialized()
-    const encodedCurrentUserId = encodeHashId(currentUserId)
-    const encodedPlaylistIds = playlistIds.map((id) => this._encodeOrThrow(id))
-
-    const params = {
-      id: encodedPlaylistIds,
-      user_id: encodedCurrentUserId || undefined,
-      limit: encodedPlaylistIds.length
-    }
-
-    const response = await this._getResponse<APIResponse<APIPlaylist[]>>(
-      FULL_ENDPOINT_MAP.getPlaylists,
-      params,
-      undefined,
-      undefined,
-      undefined,
-      abortOnUnreachable
-    )
-
-    if (!response) return []
-
-    const adapted = response.data
-      .map(adapter.makePlaylist)
-      .filter(removeNullable)
-    return adapted
   }
 
   async getPlaylistByPermalink({

--- a/packages/common/src/services/audius-api-client/AudiusAPIClient.ts
+++ b/packages/common/src/services/audius-api-client/AudiusAPIClient.ts
@@ -50,7 +50,6 @@ const FULL_ENDPOINT_MAP = {
     experiment ? `/playlists/trending/${experiment}` : '/playlists/trending',
   playlistUpdates: (userId: OpaqueID) =>
     `/notifications/${userId}/playlist_updates`,
-  getPlaylist: (playlistId: OpaqueID) => `/playlists/${playlistId}`,
   getPlaylists: '/playlists',
   getPlaylistByPermalink: (handle: string, slug: string) =>
     `/playlists/by_permalink/${handle}/${slug}`,
@@ -79,12 +78,6 @@ type GetTrackStreamUrlArgs = {
 type GetCollectionMetadataArgs = {
   collectionId: ID
   currentUserId: ID
-  abortOnUnreachable?: boolean
-}
-
-type GetPlaylistArgs = {
-  playlistId: ID
-  currentUserId: Nullable<ID>
   abortOnUnreachable?: boolean
 }
 
@@ -296,35 +289,6 @@ export class AudiusAPIClient {
       abortOnUnreachable
     )
     return response?.data?.[0]
-  }
-
-  async getPlaylist({
-    playlistId,
-    currentUserId,
-    abortOnUnreachable
-  }: GetPlaylistArgs) {
-    this._assertInitialized()
-    const encodedCurrentUserId = encodeHashId(currentUserId)
-    const encodedPlaylistId = this._encodeOrThrow(playlistId)
-    const params = {
-      user_id: encodedCurrentUserId || undefined
-    }
-
-    const response = await this._getResponse<APIResponse<APIPlaylist[]>>(
-      FULL_ENDPOINT_MAP.getPlaylist(encodedPlaylistId),
-      params,
-      undefined,
-      undefined,
-      undefined,
-      abortOnUnreachable
-    )
-
-    if (!response) return []
-
-    const adapted = response.data
-      .map(adapter.makePlaylist)
-      .filter(removeNullable)
-    return adapted
   }
 
   async getPlaylists({

--- a/packages/web/src/common/store/cache/collections/utils/retrieveCollections.ts
+++ b/packages/web/src/common/store/cache/collections/utils/retrieveCollections.ts
@@ -2,6 +2,7 @@ import {
   transformAndCleanList,
   userCollectionMetadataFromSDK
 } from '@audius/common/adapters'
+import { playlistPermalinkToHandleAndSlug } from '@audius/common/api'
 import {
   Kind,
   CollectionMetadata,
@@ -121,15 +122,15 @@ export function* retrieveCollection({
   permalink
 }: retrieveCollectionArgs) {
   yield* waitForRead()
-  const apiClient = yield* getContext('apiClient')
   const sdk = yield* getSDK()
   const currentUserId = yield* select(getUserId)
   if (permalink) {
-    const playlists = yield* call([apiClient, 'getPlaylistByPermalink'], {
-      currentUserId,
-      permalink
-    })
-    return playlists
+    const { handle, slug } = playlistPermalinkToHandleAndSlug(permalink)
+    const { data = [] } = yield* call(
+      [sdk.full.playlists, sdk.full.playlists.getPlaylistByHandleAndSlug],
+      { handle, slug, userId: OptionalId.parse(currentUserId) }
+    )
+    return transformAndCleanList(data, userCollectionMetadataFromSDK)
   }
   if (playlistId) {
     const { data = [] } = yield* call(


### PR DESCRIPTION
### Description
Migrates the following endpoints previously implemented in `apiClient` to their SDK counterparts
* `getPlaylist`
* `getPlaylists`
* `getCollectionMetadata` (alias for the default/public version of `getPlaylist`)
* `getPlaylistByPermalink`
* `getTrendingPlaylists`

Note: Most of our `getPlaylist` calls use AudiusBackend, which calls a non-v1 endpoint. Those will be replaced separately when I start doing the endpoints implemented in the notorious `queries` file. They need a little bit of extra work.

### How Has This Been Tested?
Used `compareSDKResponse` to verify that updated versions were functionally equivalent. Extra bonus, this process revealed a minor difference between the way `release_date` is converted on collections that would have resulted in a regression!
