### PR TITLE
Add virtualized filter button, Fix option select

### DIFF
--- a/.changeset/popular-wombats-serve.md
+++ b/.changeset/popular-wombats-serve.md
@@ -1,0 +1,5 @@
+---
+'@audius/harmony': patch
+---
+
+Add `virtualized` option for filter-button, Fix filter-button select option not closing menu

--- a/packages/harmony/package.json
+++ b/packages/harmony/package.json
@@ -94,7 +94,8 @@
     "react-merge-refs": "^2.0.1",
     "react-perfect-scrollbar": "^1.5.8",
     "react-spring": "^8.0.27",
+    "react-use": "^17.5.0",
     "react-use-measure": "^2.1.1",
-    "react-use": "^17.5.0"
+    "react-virtualized": "9.22.3"
   }
 }

--- a/packages/harmony/src/components/button/FilterButton/FilterButton.stories.tsx
+++ b/packages/harmony/src/components/button/FilterButton/FilterButton.stories.tsx
@@ -132,3 +132,22 @@ export const Accessibility: Story = {
     ).toBeInTheDocument()
   }
 }
+
+export const Virtualized: Story = {
+  render: (props) => (
+    <Box h='200px'>
+      <Flex pv='2xl' justifyContent='space-around'>
+        <FilterButton
+          {...props}
+          virtualized
+          menuProps={{ maxHeight: 400, width: 200 }}
+          options={[1, 2, 3, 4, 5, 6, 7, 8, 9, 10].flatMap((index) =>
+            (props.options ?? []).map((option) => ({
+              value: `${option.value} ${index}` as string
+            }))
+          )}
+        />
+      </Flex>
+    </Box>
+  )
+}

--- a/packages/harmony/src/components/button/FilterButton/FilterButton.tsx
+++ b/packages/harmony/src/components/button/FilterButton/FilterButton.tsx
@@ -15,13 +15,12 @@ import { BaseButton } from 'components/button/BaseButton/BaseButton'
 import { IconComponent, IconProps } from 'components/icon'
 import { TextInput, TextInputSize } from 'components/input/TextInput'
 import { Menu } from 'components/internal/Menu'
-import { MenuItem } from 'components/internal/MenuItem'
-import { OptionKeyHandler } from 'components/internal/OptionKeyHandler'
 import { Flex, Box } from 'components/layout'
 import { Text } from 'components/text/Text'
 import { useControlled } from 'hooks/useControlled'
 import { IconCaretDown, IconCloseAlt, IconSearch } from 'icons'
 
+import { OptionsList, VirtualizedOptionsList } from './FilterButtonOptionsList'
 import { FilterButtonProps } from './types'
 
 const messages = {
@@ -49,7 +48,8 @@ export const FilterButton = forwardRef(function FilterButton<
     showFilterInput,
     filterInputProps,
     optionsLabel,
-    renderLabel = (label) => label
+    renderLabel = (label) => label,
+    virtualized
   } = props
   const { color, cornerRadius, spacing, typography } = useTheme()
   const [value, setValue] = useControlled({
@@ -216,30 +216,23 @@ export const FilterButton = forwardRef(function FilterButton<
   )
 
   const optionElements = filteredOptions ? (
-    <OptionKeyHandler
-      options={filteredOptions}
-      disabled={!isOpen}
-      onChange={handleOptionSelected}
-      optionRefs={optionRefs}
-      scrollRef={scrollRef}
-    >
-      {(activeValue) =>
-        filteredOptions.map((option, index) => (
-          <MenuItem
-            variant='option'
-            ref={(el) => {
-              if (optionRefs && optionRefs.current && el) {
-                optionRefs.current[index] = el
-              }
-            }}
-            key={option.value}
-            {...option}
-            onChange={handleChange}
-            isActive={option.value === activeValue}
-          />
-        ))
-      }
-    </OptionKeyHandler>
+    virtualized ? (
+      <VirtualizedOptionsList
+        options={filteredOptions}
+        optionRefs={optionRefs}
+        onChange={handleOptionSelected}
+        height={menuProps?.maxHeight}
+        width={menuProps?.width}
+      />
+    ) : (
+      <OptionsList
+        options={filteredOptions}
+        isOpen={isOpen}
+        optionRefs={optionRefs}
+        scrollRef={scrollRef}
+        onChange={handleOptionSelected}
+      />
+    )
   ) : null
 
   return (

--- a/packages/harmony/src/components/button/FilterButton/FilterButtonOptionsList.tsx
+++ b/packages/harmony/src/components/button/FilterButton/FilterButtonOptionsList.tsx
@@ -1,0 +1,107 @@
+import { useState, useCallback, useEffect, RefObject } from 'react'
+
+import { CSSObject } from '@emotion/react'
+import { List, ListRowProps } from 'react-virtualized'
+
+import { MenuItem } from 'components/internal/MenuItem'
+import { OptionKeyHandler } from 'components/internal/OptionKeyHandler'
+
+import { FilterButtonOptionType } from './types'
+
+type OptionsListProps<Value extends string> = {
+  options: FilterButtonOptionType<Value>[]
+  isOpen: boolean
+  optionRefs: RefObject<HTMLButtonElement[]>
+  scrollRef: RefObject<HTMLDivElement>
+  onChange: (value: Value) => void
+}
+
+type VirtualizedOptionsListProps<Value extends string> = {
+  options: FilterButtonOptionType<Value>[]
+  optionRefs: RefObject<HTMLButtonElement[]>
+  onChange: (value: Value) => void
+  height: CSSObject['height']
+  width: CSSObject['width']
+}
+
+export const VirtualizedOptionsList = <Value extends string>({
+  options,
+  optionRefs,
+  onChange,
+  height = 100,
+  width = 100
+}: VirtualizedOptionsListProps<Value>) => {
+  const [rowHeight, setRowHeight] = useState(50)
+  useEffect(() => {
+    if (optionRefs.current?.[0]) {
+      setRowHeight(optionRefs.current?.[0].offsetHeight)
+    }
+  }, [optionRefs])
+
+  const renderItem = useCallback(
+    ({ index, style }: ListRowProps) => {
+      const option = options[index]
+
+      return (
+        <MenuItem
+          style={style}
+          variant='option'
+          ref={(el) => {
+            if (optionRefs && optionRefs.current && el) {
+              optionRefs.current[index] = el
+            }
+          }}
+          key={option.value}
+          {...option}
+          onChange={onChange}
+        />
+      )
+    },
+    [onChange, optionRefs, options]
+  )
+
+  return (
+    <List
+      width={Number(width)}
+      height={Number(height)}
+      rowCount={options.length}
+      rowHeight={rowHeight}
+      rowRenderer={renderItem}
+    />
+  )
+}
+
+export const OptionsList = <Value extends string>({
+  options,
+  isOpen,
+  optionRefs,
+  scrollRef,
+  onChange
+}: OptionsListProps<Value>) => {
+  return (
+    <OptionKeyHandler
+      options={options}
+      disabled={!isOpen}
+      onChange={onChange}
+      optionRefs={optionRefs}
+      scrollRef={scrollRef}
+    >
+      {(activeValue) =>
+        options.map((option, index) => (
+          <MenuItem
+            variant='option'
+            ref={(el) => {
+              if (optionRefs && optionRefs.current && el) {
+                optionRefs.current[index] = el
+              }
+            }}
+            key={option.value}
+            {...option}
+            onChange={onChange}
+            isActive={option.value === activeValue}
+          />
+        ))
+      }
+    </OptionKeyHandler>
+  )
+}

--- a/packages/harmony/src/components/button/FilterButton/types.ts
+++ b/packages/harmony/src/components/button/FilterButton/types.ts
@@ -129,4 +129,8 @@ export type FilterButtonProps<Value extends string = string> = {
 
   menuProps?: Partial<MenuProps> & { css?: CSSObject }
   renderLabel?: (label: string) => ReactNode
+  /**
+   * Whether or not to virtualize the options
+   */
+  virtualized?: boolean
 }

--- a/packages/harmony/src/components/internal/Menu.tsx
+++ b/packages/harmony/src/components/internal/Menu.tsx
@@ -12,6 +12,7 @@ import { WithCSS } from 'foundations'
 
 export type MenuProps = Omit<PopupProps, 'children'> & {
   maxHeight?: CSSObject['maxHeight']
+  width?: CSSObject['width']
   children: ReactNode
   PaperProps?: WithCSS<Partial<PaperProps>>
   MenuListProps?: WithCSS<Partial<FlexProps>>
@@ -22,6 +23,7 @@ export const Menu = (props: MenuProps) => {
   const {
     children,
     maxHeight,
+    width,
     PaperProps,
     MenuListProps,
     scrollRef,
@@ -37,7 +39,7 @@ export const Menu = (props: MenuProps) => {
           gap='s'
           alignItems='flex-start'
           role='listbox'
-          css={{ maxHeight, overflowY: 'auto' }}
+          css={{ maxHeight, width, overflowY: 'auto' }}
           ref={scrollRef}
           {...MenuListProps}
         >

--- a/packages/web/src/pages/search-page-v2/SearchFilters.tsx
+++ b/packages/web/src/pages/search-page-v2/SearchFilters.tsx
@@ -131,7 +131,7 @@ const KeyFilter = () => {
       menuProps={{
         anchorOrigin: { vertical: 'bottom', horizontal: 'left' },
         transformOrigin: { vertical: 'top', horizontal: 'left' },
-        css: { minWidth: 200 }
+        width: 200
       }}
       options={keyOptions}
     >


### PR DESCRIPTION
### Description

- Adds virtualized filter button based on changes introduced in pay-with-anything feature branch. In the future the virtualized option should be incorporated in the internal/menu, so all menu-openers can benefit.

- Fixes issue where selecting an option does not close the menu. this was introduced by another fix to prevent onChange from triggering menu-close. Now we just ensure all option selects trigger onChange and setIsOpen.

### How Has This Been Tested?

Tested on pay-with-anytihng branch and through new "virtualized" storybook story