### PR TITLE
[PAY-3380] Skip geo indexing on local dev stack

### DIFF
--- a/packages/discovery-provider/src/tasks/index_payment_router.py
+++ b/packages/discovery-provider/src/tasks/index_payment_router.py
@@ -255,7 +255,10 @@ def parse_route_transaction_memos(
                     type=RouteTransactionMemoType.recovery, metadata=None
                 )
                 continue
-            if memo.startswith(GEO_MEMO_STRING):
+            if (
+                memo.startswith(GEO_MEMO_STRING)
+                and shared_config["discprov"]["env"] != "dev"
+            ):
                 geo_data = json.loads(memo.replace(GEO_MEMO_STRING, ""))
                 if not geo_data:
                     raise Exception("No geo data found in geo memo")

--- a/packages/discovery-provider/src/tasks/index_payment_router.py
+++ b/packages/discovery-provider/src/tasks/index_payment_router.py
@@ -255,10 +255,7 @@ def parse_route_transaction_memos(
                     type=RouteTransactionMemoType.recovery, metadata=None
                 )
                 continue
-            if (
-                memo.startswith(GEO_MEMO_STRING)
-                and shared_config["discprov"]["env"] != "dev"
-            ):
+            if memo.startswith(GEO_MEMO_STRING):
                 geo_data = json.loads(memo.replace(GEO_MEMO_STRING, ""))
                 if not geo_data:
                     logger.warn(

--- a/packages/discovery-provider/src/tasks/index_payment_router.py
+++ b/packages/discovery-provider/src/tasks/index_payment_router.py
@@ -261,12 +261,18 @@ def parse_route_transaction_memos(
             ):
                 geo_data = json.loads(memo.replace(GEO_MEMO_STRING, ""))
                 if not geo_data:
-                    raise Exception("No geo data found in geo memo")
+                    logger.warn(
+                        f"index_payment_router.py | No geo data found in geo memo: {memo}"
+                    )
+                    continue
                 city = geo_data.get("city")
                 region = geo_data.get("region")
                 country = geo_data.get("country")
                 if not country:
-                    raise Exception("No country found in geo data")
+                    logger.warn(
+                        f"index_payment_router.py | No country found in geo memo: {memo}"
+                    )
+                    continue
                 geo_memo = GeoMetadataDict(
                     {
                         "city": city,


### PR DESCRIPTION
### Description
Something changed on the tx we send for purchases, it now includes `geo:null` as the memo data for the geo memo. We could try to not send the memo when performing purchases on local stack, or we could skip the geo step on local stack which is what this PR does. Either way is unclean so figured it doesn't make a difference.

### How Has This Been Tested?

Local purchase successfully indexed
