### PR TITLE
[PAY-3375] get chat endpoint correctly filters for audience:type:id

### DIFF
--- a/comms/discovery/db/queries/get_chats.go
+++ b/comms/discovery/db/queries/get_chats.go
@@ -76,6 +76,7 @@ union all (
 		audience_content_id
   FROM chat_blast b
   WHERE from_user_id = $1
+    AND concat_ws(':', audience, audience_content_type, audience_content_id) = $2
   ORDER BY
     audience,
     audience_content_type,


### PR DESCRIPTION
### Description

Get chat endpoint works correctly for blast audience like: `customer_audience:track:1`
