### PR TITLE
Fix purchasers endpoint

### DIFF
--- a/packages/discovery-provider/src/queries/get_purchasers.py
+++ b/packages/discovery-provider/src/queries/get_purchasers.py
@@ -32,7 +32,6 @@ def _get_purchasers(session, args: GetPurchasersArgs):
         session.query(USDCPurchase.buyer_user_id)
         .distinct()
         .filter(USDCPurchase.seller_user_id == seller_user_id)
-        .all()
     )
 
     # Optionally filter by given content type and id


### PR DESCRIPTION
### Description

Calling `.all()` before calling `add_query_pagination` meant we were passing a list of results as the query arg to `add_query_pagination`. Calling `.limit()` failed because it wasn't being called on a query.

Also note that we're already calling `.all()` in this line below after adding pagination:
```
rows = add_query_pagination(query, limit, offset).all()
```

### How Has This Been Tested?

working on local stack