### PR TITLE
Remove marshalling for nft-gated-signatures

### DIFF
--- a/packages/discovery-provider/src/api/v1/tracks.py
+++ b/packages/discovery-provider/src/api/v1/tracks.py
@@ -1767,7 +1767,7 @@ class NFTGatedTrackSignatures(Resource):
         },
     )
     @full_ns.expect(track_signatures_parser)
-    @full_ns.marshal_with(full_nft_gated_track_signatures_response)
+    @full_ns.response(200, "Success", full_nft_gated_track_signatures_response)
     @cache(ttl_sec=5)
     def get(self, user_id):
         decoded_user_id = decode_with_abort(user_id, full_ns)


### PR DESCRIPTION
### Description
Wasn't able to test this correctly and it bit me!
The keys in the `dict` that comes back from the db query are numbers. The type we were using for marshaling (Wildcard) only works with strings. So attempting to marshal was throwing an exception.

However, since this is a very simple object that doesn't require any transformation, we can get by with just specifying the response type for documentation sake (and generating SDK code) and then return the response without attempting to marshal it. It gets `jsonify`-d anyway, and the numbers will be converted to strings as part of that process. Prior to client SDK migration, this is what we were doing.

### How Has This Been Tested?
Spun up a local stack and got a user created with an NFT-connected wallet. Uploaded a NFT-gated track. Checked access to said track to make sure the endpoint was functioning again.
