### PR TITLE
Update comment-section-api

### DIFF
--- a/packages/common/src/context/commentsContext.tsx
+++ b/packages/common/src/context/commentsContext.tsx
@@ -27,28 +27,19 @@ import {
 
 const { tracksActions } = trackPageLineupActions
 
-/**
- * Context object to avoid prop drilling and share a common API with web/native code
- */
-
-// Props passed in from above (also get forwarded thru)
-type CommentSectionContextProps = {
-  currentUserId: Nullable<ID>
-  artistId: ID
-  entityId: ID
-  entityType?: EntityType.TRACK
-  isEntityOwner: boolean
-  playTrack: () => void
-}
-
 export enum CommentSortMethod {
   top = 'top',
   newest = 'newest',
   timestamp = 'timestamp'
 }
 
-// Props sent down to context (some are handled inside the context component)
-type CommentSectionContextType = CommentSectionContextProps & {
+type CommentSectionContextType = {
+  currentUserId: Nullable<ID>
+  artistId: ID
+  entityId: ID
+  entityType?: EntityType.TRACK
+  isEntityOwner: boolean
+  playTrack: () => void
   commentSectionLoading: boolean
   comments: Comment[]
   currentSort: CommentSortMethod

--- a/packages/common/src/context/commentsContext.tsx
+++ b/packages/common/src/context/commentsContext.tsx
@@ -12,7 +12,6 @@ import { useDispatch, useSelector } from 'react-redux'
 
 import { usePaginatedQuery } from '..//audius-query'
 import { ID, Status } from '..//models'
-import { playerSelectors, trackPageLineupActions } from '..//store'
 import { Nullable } from '..//utils'
 import {
   useDeleteCommentById,
@@ -24,8 +23,8 @@ import {
   useGetCurrentUserId,
   useGetTrackById
 } from '../api'
-
-const { tracksActions } = trackPageLineupActions
+import { tracksActions } from '../store/pages/track/lineup/actions'
+import { playerSelectors } from '../store/player'
 
 export enum CommentSortMethod {
   top = 'top',

--- a/packages/mobile/src/components/comments/CommentDrawer.tsx
+++ b/packages/mobile/src/components/comments/CommentDrawer.tsx
@@ -4,7 +4,6 @@ import {
   CommentSectionProvider,
   useCurrentCommentSection
 } from '@audius/common/context'
-import { accountSelectors } from '@audius/common/store'
 import {
   BottomSheetFlatList,
   BottomSheetBackdrop,
@@ -12,7 +11,6 @@ import {
   BottomSheetModal
 } from '@gorhom/bottom-sheet'
 import { useSafeAreaInsets } from 'react-native-safe-area-context'
-import { useSelector } from 'react-redux'
 
 import { Box, Divider, Flex } from '@audius/harmony-native'
 import { useDrawer } from 'app/hooks/useDrawer'
@@ -25,11 +23,7 @@ import { CommentDrawerHeader } from './CommentDrawerHeader'
 import { CommentThread } from './CommentThread'
 import { NoComments } from './NoComments'
 
-const { getUserId } = accountSelectors
-
-type CommentDrawerContentProps = {}
-
-const CommentDrawerContent = (props: CommentDrawerContentProps) => {
+const CommentDrawerContent = () => {
   const { comments, commentSectionLoading: isLoading } =
     useCurrentCommentSection()
 
@@ -93,11 +87,10 @@ const useStyles = makeStyles(({ palette }) => ({
 export const CommentDrawer = () => {
   const styles = useStyles()
   const insets = useSafeAreaInsets()
-  const currentUserId = useSelector(getUserId)
 
   const bottomSheetModalRef = useRef<BottomSheetModal>(null)
   const {
-    data: { entityId, isEntityOwner, artistId },
+    data: { entityId },
     isOpen,
     onClosed
   } = useDrawer('Comment')
@@ -129,26 +122,14 @@ export const CommentDrawer = () => {
         )}
         footerComponent={(props) => (
           <BottomSheetFooter {...props} bottomInset={insets.bottom}>
-            <CommentSectionProvider
-              currentUserId={currentUserId}
-              artistId={artistId}
-              entityId={entityId}
-              isEntityOwner={isEntityOwner}
-              playTrack={() => {}} // TODO
-            >
+            <CommentSectionProvider entityId={entityId}>
               <CommentDrawerForm />
             </CommentSectionProvider>
           </BottomSheetFooter>
         )}
         onDismiss={handleClose}
       >
-        <CommentSectionProvider
-          currentUserId={currentUserId}
-          artistId={artistId}
-          entityId={entityId}
-          isEntityOwner={isEntityOwner}
-          playTrack={() => {}} // TODO
-        >
+        <CommentSectionProvider entityId={entityId}>
           <CommentDrawerHeader bottomSheetModalRef={bottomSheetModalRef} />
 
           <Divider orientation='horizontal' />

--- a/packages/mobile/src/components/comments/CommentSection.tsx
+++ b/packages/mobile/src/components/comments/CommentSection.tsx
@@ -1,7 +1,9 @@
 import {
+  CommentSectionProvider,
   useCurrentCommentSection,
   usePostComment
 } from '@audius/common/context'
+import type { ID } from '@audius/common/models'
 import { Status } from '@audius/common/models'
 import { TouchableOpacity } from 'react-native'
 
@@ -106,24 +108,29 @@ const CommentSectionContent = () => {
   return <CommentBlock comment={comments[0]} hideActions />
 }
 
-export const CommentSection = () => {
-  const { artistId, currentUserId, entityId, isEntityOwner } =
-    useCurrentCommentSection()
+type CommentSectionProps = {
+  entityId: ID
+}
+
+export const CommentSection = (props: CommentSectionProps) => {
+  const { entityId } = props
 
   const { onOpen: openDrawer } = useDrawer('Comment')
 
   const handlePress = () => {
-    openDrawer({ userId: currentUserId, entityId, isEntityOwner, artistId })
+    openDrawer({ entityId })
   }
 
   return (
-    <Flex gap='s' direction='column' w='100%' alignItems='flex-start'>
-      <CommentSectionHeader />
-      <Paper w='100%' direction='column' gap='s' p='l'>
-        <TouchableOpacity onPress={handlePress}>
-          <CommentSectionContent />
-        </TouchableOpacity>
-      </Paper>
-    </Flex>
+    <CommentSectionProvider entityId={entityId}>
+      <Flex gap='s' direction='column' w='100%' alignItems='flex-start'>
+        <CommentSectionHeader />
+        <Paper w='100%' direction='column' gap='s' p='l'>
+          <TouchableOpacity onPress={handlePress}>
+            <CommentSectionContent />
+          </TouchableOpacity>
+        </Paper>
+      </Flex>
+    </CommentSectionProvider>
   )
 }

--- a/packages/mobile/src/screens/track-screen/TrackScreenMainContent.tsx
+++ b/packages/mobile/src/screens/track-screen/TrackScreenMainContent.tsx
@@ -51,15 +51,16 @@ export const TrackScreenMainContent = ({
 }: TrackScreenMainContentProps) => {
   const navigation = useNavigation()
   const styles = useStyles()
-  const currentUserId = useSelector(getUserId)
   const { isEnabled: isCommentingEnabled } = useFeatureFlag(
     FeatureFlags.COMMENTS_ENABLED
   )
 
-  const remixTrackIds = track._remixes?.map(({ track_id }) => track_id) ?? null
+  const { track_id, _remixes, field_visibility, _remixes_count } = track
+
+  const remixTrackIds = _remixes?.map(({ track_id }) => track_id) ?? null
 
   const handlePressGoToRemixes = () => {
-    navigation.push('TrackRemixes', { id: track.track_id })
+    navigation.push('TrackRemixes', { id: track_id })
   }
   return (
     <View style={styles.root}>
@@ -71,27 +72,19 @@ export const TrackScreenMainContent = ({
           isLineupLoading={!lineup?.entries?.[0]}
         />
 
-        {track.field_visibility?.remixes &&
+        {field_visibility?.remixes &&
           remixTrackIds &&
           remixTrackIds.length > 0 && (
             <TrackScreenRemixes
               trackIds={remixTrackIds}
               onPressGoToRemixes={handlePressGoToRemixes}
-              count={track._remixes_count ?? null}
+              count={_remixes_count ?? null}
             />
           )}
 
         {isCommentingEnabled ? (
           <Flex flex={3}>
-            <CommentSectionProvider
-              artistId={track.owner_id}
-              currentUserId={currentUserId}
-              entityId={track.track_id}
-              isEntityOwner={user.user_id === track.owner_id}
-              playTrack={() => {}} // TODO
-            >
-              <CommentSection />
-            </CommentSectionProvider>
+            <CommentSection entityId={track_id} />
           </Flex>
         ) : null}
         {lineupHeader}

--- a/packages/mobile/src/screens/track-screen/TrackScreenMainContent.tsx
+++ b/packages/mobile/src/screens/track-screen/TrackScreenMainContent.tsx
@@ -1,6 +1,5 @@
 import type { ReactNode } from 'react'
 
-import { CommentSectionProvider } from '@audius/common/context'
 import { useFeatureFlag } from '@audius/common/hooks'
 import type {
   LineupState,
@@ -10,27 +9,14 @@ import type {
   User
 } from '@audius/common/models'
 import { FeatureFlags } from '@audius/common/services'
-import { accountSelectors } from '@audius/common/store'
 import type { Nullable } from '@audius/common/utils'
-import { View } from 'react-native'
-import { useSelector } from 'react-redux'
 
 import { Flex } from '@audius/harmony-native'
 import { CommentSection } from 'app/components/comments/CommentSection'
 import { useNavigation } from 'app/hooks/useNavigation'
-import { makeStyles } from 'app/styles'
 
 import { TrackScreenDetailsTile } from './TrackScreenDetailsTile'
 import { TrackScreenRemixes } from './TrackScreenRemixes'
-
-const { getUserId } = accountSelectors
-
-const useStyles = makeStyles(({ spacing }) => ({
-  root: {
-    padding: spacing(3),
-    paddingBottom: 0
-  }
-}))
 
 type TrackScreenMainContentProps = {
   lineup: LineupState<Track>
@@ -50,7 +36,6 @@ export const TrackScreenMainContent = ({
   user
 }: TrackScreenMainContentProps) => {
   const navigation = useNavigation()
-  const styles = useStyles()
   const { isEnabled: isCommentingEnabled } = useFeatureFlag(
     FeatureFlags.COMMENTS_ENABLED
   )
@@ -63,7 +48,7 @@ export const TrackScreenMainContent = ({
     navigation.push('TrackRemixes', { id: track_id })
   }
   return (
-    <View style={styles.root}>
+    <Flex p='m' pb={0}>
       <Flex gap='2xl'>
         <TrackScreenDetailsTile
           track={track}
@@ -89,6 +74,6 @@ export const TrackScreenMainContent = ({
         ) : null}
         {lineupHeader}
       </Flex>
-    </View>
+    </Flex>
   )
 }

--- a/packages/web/src/components/comments/CommentSection.tsx
+++ b/packages/web/src/components/comments/CommentSection.tsx
@@ -1,0 +1,23 @@
+import { CommentSectionProvider } from '@audius/common/context'
+import { ID } from '@audius/common/models'
+import { EntityType } from '@audius/sdk'
+
+import { useIsMobile } from 'hooks/useIsMobile'
+
+import { CommentSectionDesktop } from './CommentSectionDesktop'
+
+type CommentSectionProps = {
+  entityId: ID
+  entityType?: EntityType.TRACK
+}
+
+export const CommentSection = (props: CommentSectionProps) => {
+  const { entityId, entityType } = props
+  const isMobile = useIsMobile()
+
+  return (
+    <CommentSectionProvider entityId={entityId} entityType={entityType}>
+      {isMobile ? null : <CommentSectionDesktop />}
+    </CommentSectionProvider>
+  )
+}

--- a/packages/web/src/pages/track-page/components/desktop/TrackPage.tsx
+++ b/packages/web/src/pages/track-page/components/desktop/TrackPage.tsx
@@ -5,6 +5,7 @@ import { FeatureFlags } from '@audius/common/services'
 import { trackPageLineupActions, QueueItem } from '@audius/common/store'
 import { Box, Flex, Text } from '@audius/harmony'
 
+import { CommentSection } from 'components/comments/CommentSection'
 import { CommentSectionDesktop } from 'components/comments/CommentSectionDesktop'
 import CoverPhoto from 'components/cover-photo/CoverPhoto'
 import Lineup from 'components/lineup/Lineup'
@@ -252,17 +253,7 @@ const TrackPage = ({
         >
           {isCommentingEnabled && heroTrack?.owner_id ? (
             <Flex flex='3'>
-              <CommentSectionProvider
-                currentUserId={userId}
-                entityId={defaults.trackId}
-                playTrack={() => {
-                  play(currentQueueItem.uid ?? undefined)
-                }}
-                isEntityOwner={isOwner}
-                artistId={heroTrack.owner_id}
-              >
-                <CommentSectionDesktop />
-              </CommentSectionProvider>
+              <CommentSection entityId={defaults.trackId} />
             </Flex>
           ) : null}
           {hasMoreByTracks ? (

--- a/packages/web/src/pages/track-page/components/desktop/TrackPage.tsx
+++ b/packages/web/src/pages/track-page/components/desktop/TrackPage.tsx
@@ -1,4 +1,3 @@
-import { CommentSectionProvider } from '@audius/common/context'
 import { useFeatureFlag, useGatedContentAccess } from '@audius/common/hooks'
 import { ID, LineupState, Track, User } from '@audius/common/models'
 import { FeatureFlags } from '@audius/common/services'
@@ -6,7 +5,6 @@ import { trackPageLineupActions, QueueItem } from '@audius/common/store'
 import { Box, Flex, Text } from '@audius/harmony'
 
 import { CommentSection } from 'components/comments/CommentSection'
-import { CommentSectionDesktop } from 'components/comments/CommentSectionDesktop'
 import CoverPhoto from 'components/cover-photo/CoverPhoto'
 import Lineup from 'components/lineup/Lineup'
 import { LineupVariant } from 'components/lineup/types'


### PR DESCRIPTION
### Description

Small update to how comment sections get initialized. Realizing we can derive all the necessary information from entityId rather than having to provide a bunch of props to the context. Additionally i moved the context initialization inside the comment section, since ideally users can drag/drop it wherever. This makes implementing mobile-web comment section a bit easier, too!