### PR TITLE
Fix include_network_cut parameter

### DIFF
--- a/packages/discovery-provider/src/api/v1/tracks.py
+++ b/packages/discovery-provider/src/api/v1/tracks.py
@@ -1843,7 +1843,7 @@ access_info_parser = current_user_parser.copy()
 access_info_parser.add_argument(
     "include_network_cut",
     required=False,
-    type=bool,
+    type=inputs.boolean,
     description="Whether to include the staking system as a recipient",
 )
 
@@ -1859,7 +1859,7 @@ class GetTrackAccessInfo(Resource):
     @ns.expect(access_info_parser)
     @ns.marshal_with(access_info_response)
     def get(self, track_id: str):
-        args = current_user_parser.parse_args()
+        args = access_info_parser.parse_args()
         include_network_cut = args.get("include_network_cut")
         decoded_id = decode_with_abort(track_id, full_ns)
         current_user_id = get_current_user_id(args)

--- a/packages/discovery-provider/src/queries/get_extended_purchase_gate.py
+++ b/packages/discovery-provider/src/queries/get_extended_purchase_gate.py
@@ -234,7 +234,8 @@ def _get_extended_purchase_gate(
     session: Session, gate: PurchaseGate, include_network_cut=False
 ):
     price = gate.get("usdc_purchase", {}).get("price", None)
-    splits = gate.get("usdc_purchase", {}).get("splits", [])
+    original_splits = gate.get("usdc_purchase", {}).get("splits", [])
+    splits = [orig.copy() for orig in original_splits]
     splits = add_wallet_info_to_splits(session, splits, datetime.now())
     splits = calculate_split_amounts(price, splits, include_network_cut)
     extended_splits = [cast(ExtendedSplit, split) for split in splits]


### PR DESCRIPTION
### Description

- The wrong parser was being used in the `access-info` endpoint
- The wrong type was being used for the argument
- The internal `_get_extended_purchase_gate()` method was mutating the passed in "gate" info splits, causing the amounts to be wrong for the `access-info` endpoint.

### How Has This Been Tested?

Tested that the endpoint returns as expected when run locally. Still need to test E2E, but need to deploy a "staking bridge" (probably just default to the local owner wallet) locally first