### PR TITLE
[PAY-3152] Fix Accounts You Manage modal showing after switching accounts

### DIFF
--- a/packages/web/src/pages/settings-page/components/desktop/ManagerMode/AccountsYouManageSettingsCard.tsx
+++ b/packages/web/src/pages/settings-page/components/desktop/ManagerMode/AccountsYouManageSettingsCard.tsx
@@ -25,16 +25,11 @@ export const AccountsYouManageSettingsCard = () => {
   const [isModalOpen, setIsModalOpen] = useState(false)
   const dispatch = useDispatch()
   const location = useLocation()
-  const isManagedAccountsRoute = doesMatchRoute(
-    location,
-    ACCOUNTS_YOU_MANAGE_SETTINGS_PAGE
-  )
-
   useEffect(() => {
-    if (isManagedAccountsRoute) {
+    if (doesMatchRoute(location, ACCOUNTS_YOU_MANAGE_SETTINGS_PAGE)) {
       setIsModalOpen(true)
     }
-  }, [isManagedAccountsRoute])
+  }, [location])
 
   const handleOpen = useCallback(() => {
     setIsModalOpen(true)
@@ -42,10 +37,10 @@ export const AccountsYouManageSettingsCard = () => {
 
   const handleClose = useCallback(() => {
     setIsModalOpen(false)
-    if (isManagedAccountsRoute) {
+    if (doesMatchRoute(location, ACCOUNTS_YOU_MANAGE_SETTINGS_PAGE)) {
       dispatch(replace(SETTINGS_PAGE))
     }
-  }, [isManagedAccountsRoute, dispatch])
+  }, [location, dispatch])
 
   return (
     <>

--- a/packages/web/src/pages/settings-page/components/desktop/ManagerMode/AccountsYouManageSettingsCard.tsx
+++ b/packages/web/src/pages/settings-page/components/desktop/ManagerMode/AccountsYouManageSettingsCard.tsx
@@ -2,6 +2,8 @@ import { useCallback, useEffect, useState } from 'react'
 
 import { route } from '@audius/common/utils'
 import { Button, IconUserArrowRotate } from '@audius/harmony'
+import { replace } from 'connected-react-router'
+import { useDispatch } from 'react-redux'
 import { useLocation } from 'react-router-dom'
 
 import { doesMatchRoute } from 'utils/route'
@@ -10,7 +12,7 @@ import SettingsCard from '../SettingsCard'
 
 import { AccountsYouManageSettingsModal } from './AccountsYouManageSettingsModal'
 
-const { ACCOUNTS_YOU_MANAGE_SETTINGS_PAGE } = route
+const { ACCOUNTS_YOU_MANAGE_SETTINGS_PAGE, SETTINGS_PAGE } = route
 
 const messages = {
   accountsYouManageTitle: 'Accounts You Manage',
@@ -21,14 +23,18 @@ const messages = {
 
 export const AccountsYouManageSettingsCard = () => {
   const [isModalOpen, setIsModalOpen] = useState(false)
+  const dispatch = useDispatch()
   const location = useLocation()
+  const isManagedAccountsRoute = doesMatchRoute(
+    location,
+    ACCOUNTS_YOU_MANAGE_SETTINGS_PAGE
+  )
 
   useEffect(() => {
-    const match = doesMatchRoute(location, ACCOUNTS_YOU_MANAGE_SETTINGS_PAGE)
-    if (match) {
+    if (isManagedAccountsRoute) {
       setIsModalOpen(true)
     }
-  }, [location])
+  }, [isManagedAccountsRoute])
 
   const handleOpen = useCallback(() => {
     setIsModalOpen(true)
@@ -36,7 +42,10 @@ export const AccountsYouManageSettingsCard = () => {
 
   const handleClose = useCallback(() => {
     setIsModalOpen(false)
-  }, [])
+    if (isManagedAccountsRoute) {
+      dispatch(replace(SETTINGS_PAGE))
+    }
+  }, [isManagedAccountsRoute, dispatch])
 
   return (
     <>


### PR DESCRIPTION
### Description
There was an edge case with the new manager flow:
1. Click on a deeplink to open the 'Accounts You Manage' modal
2. Do whatever in the modal and then close it
3. Switch accounts

The page will refresh with the `/accounts-you-manage` suffix still on the URL, which will trigger showing the 'Accounts You Manage' modal for the managed account. This is usually not what we want.

Easy fix: when closing the modal, remove the suffix from the route.

### How Has This Been Tested?
Tested locally against staging.
