### PR TITLE
[PAY-3374] Fix selection colors for composer

### DIFF
--- a/packages/web/src/components/data-entry/TextAreaV2.module.css
+++ b/packages/web/src/components/data-entry/TextAreaV2.module.css
@@ -27,6 +27,7 @@
   font-weight: var(--harmony-font-medium);
   line-height: 150%;
   overflow: visible;
+  caret-color: var(--harmony-secondary);
 }
 .root:hover textarea {
   border-color: var(--harmony-n-200);
@@ -83,9 +84,17 @@
   width: 100%;
 }
 
+textarea::selection {
+  background: #a116b7;
+  color: var(--harmony-white);
+}
+
 textarea.transparentTextArea {
   color: transparent;
-  caret-color: black;
+  position: absolute;
+  left: 0;
+  top: 0;
+  z-index: 1;
 }
 
 .displayElementContainer {


### PR DESCRIPTION
### Description

Fix highlight on composer by putting text selection on top of composer ui and settings correct css elements. Should move to harmony long term, but keeping the code where it's all defined for now.

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._

<img width="351" alt="image" src="https://github.com/user-attachments/assets/c8146e3c-3af5-4dcf-b70a-2dc3199d54f9">

<img width="399" alt="image" src="https://github.com/user-attachments/assets/3441c1da-16b9-4f89-a1e3-469d5d01ba30">