### PR TITLE
[PAY-3394] Maintain chat list sort order on blast

### DIFF
--- a/packages/libs/src/sdk/api/chats/ChatsApi.ts
+++ b/packages/libs/src/sdk/api/chats/ChatsApi.ts
@@ -908,6 +908,19 @@ export class ChatsApi
         } else if (data.rpc.method === 'chat.blast') {
           const userId = data.metadata.receiverUserId
           await this.upgradeBlasts(userId)
+          this.eventEmitter.emit('blast', {
+            audience: data.rpc.params.audience,
+            audienceContentType: data.rpc.params.audience_content_type,
+            audienceContentId: data.rpc.params.audience_content_id,
+            message: {
+              message_id: data.rpc.params.blast_id,
+              message: data.rpc.params.message,
+              sender_user_id: userId,
+              created_at: data.metadata.timestamp,
+              reactions: [],
+              is_plaintext: true
+            }
+          })
         }
       }
       handleAsync()

--- a/packages/libs/src/sdk/api/chats/clientTypes.ts
+++ b/packages/libs/src/sdk/api/chats/clientTypes.ts
@@ -173,6 +173,12 @@ export type ChatEvents = {
     messageId: string
     reaction: ChatMessageNullableReaction
   }) => void
+  ['blast']: (params: {
+    audience: ChatBlastAudience
+    audienceContentType?: 'track' | 'album'
+    audienceContentId?: string
+    message: ChatMessage
+  }) => void
 }
 
 export type UnfurlResponse = {

--- a/packages/libs/src/sdk/api/chats/serverTypes.ts
+++ b/packages/libs/src/sdk/api/chats/serverTypes.ts
@@ -12,7 +12,7 @@ export type ChatBlastRPC = {
   params: {
     blast_id: string
     audience: ChatBlastAudience
-    audience_content_type?: string // if targeting buyers / remixers of a specific track or album
+    audience_content_type?: 'track' | 'album' // if targeting buyers / remixers of a specific track or album
     audience_content_id?: string // if targeting buyers / remixers of a specific track or album
     message: string
   }


### PR DESCRIPTION
### Description
When sending a blast, we don't want the order of the chat list (left bar) to shuffle around.

* Add blast RPC event emission to ChatsAPI and handle them in the middleware
* Update chat sort comparator to favor blasts, then sort alphabetically by chatId

### How Has This Been Tested?


https://github.com/user-attachments/assets/05eaeda0-3fcb-4b0f-bace-869160b1152f

