### PR TITLE
[PAY-3397] Fix mobile layout with UserGeneratedText in DMs

### DIFF
--- a/packages/mobile/src/components/core/UserGeneratedText.tsx
+++ b/packages/mobile/src/components/core/UserGeneratedText.tsx
@@ -171,7 +171,7 @@ export const UserGeneratedText = (props: UserGeneratedTextProps) => {
   )
 
   return (
-    <>
+    <View>
       <View
         pointerEvents={allowPointerEventsToPassThrough ? 'none' : undefined}
         ref={linkContainerRef}
@@ -205,12 +205,13 @@ export const UserGeneratedText = (props: UserGeneratedTextProps) => {
               }}
               url={match.getAnchorHref()}
               source={source}
+              {...linkProps}
             >
               {text}
             </Link>
           ) : null
         })}
       </View>
-    </>
+    </View>
   )
 }


### PR DESCRIPTION
### Description

This PR
https://github.com/AudiusProject/audius-protocol/pull/9533
introduced `allowPointerEventsToPassThrough` on the DMs UserGeneratedText component, which is missing (1) link props styles and (2) absolute positioning relative to the message itself

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._

<img width="49%" src="https://github.com/user-attachments/assets/3792d1d1-587c-411e-96d9-3c34f6aab094" />

Also paired through this with @amendelsohn (big props) and tested user bios which are the other place we pass `allowPointerEventsToPassThrough`
