### PR TITLE
[QA-875][QA-850] Fix lineup pagination when dupes are present

### DIFF
--- a/packages/web/src/common/store/lineup/sagas.ts
+++ b/packages/web/src/common/store/lineup/sagas.ts
@@ -353,6 +353,7 @@ function* fetchLineupMetadatasAsync<T extends Track | Collection>(
       }
       const currentUserId = yield* select(getUserId)
       // Retain specified info in the lineup itself and resolve with success.
+      let duplicateCount = 0
       const lineupEntries = allMetadatas
         .map(retainSelector)
         .map((m, i) => {
@@ -369,7 +370,10 @@ function* fetchLineupMetadatasAsync<T extends Track | Collection>(
         .filter((metadata, idx) => {
           if (lineup.dedupe && lineup.entryIds) {
             const entryId = getEntryId(metadata)
-            if (lineup.entryIds.has(entryId)) return false
+            if (lineup.entryIds.has(entryId)) {
+              duplicateCount += 1
+              return false
+            }
             lineup.entryIds.add(entryId)
           }
           return true
@@ -378,7 +382,8 @@ function* fetchLineupMetadatasAsync<T extends Track | Collection>(
       const deletedCount =
         lineupMetadatasResponse.length -
         responseFilteredDeletes.length -
-        nullCount
+        nullCount +
+        duplicateCount
       yield* put(
         lineupActions.fetchLineupMetadatasSucceeded(
           lineupEntries,

--- a/packages/web/src/common/store/pages/feed/lineup/sagas.ts
+++ b/packages/web/src/common/store/pages/feed/lineup/sagas.ts
@@ -51,7 +51,7 @@ function* getTracks({
 
   const params: GetSocialFeedArgs = {
     offset,
-    limit: offset + limit,
+    limit,
     filter,
     with_users: true,
     current_user_id: currentUser.user_id


### PR DESCRIPTION
### Description

Currently if a lineup comes back from the backend with duplicates (e.g. feed because of how pagination works), we don't tally that correctly.

I think this is something we could probably address within the feed implementation itself, but I also think this is sufficient for now.

Lineup needs a rewrite.

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._

Ran locally and can now paginate feed well. Currently we way over fetch client side.