### PR TITLE
[QA-1513] Account for token account creation drift in payout indexing

### DIFF
--- a/packages/discovery-provider/src/solana/solana_client_manager.py
+++ b/packages/discovery-provider/src/solana/solana_client_manager.py
@@ -200,14 +200,16 @@ class SolanaClientManager:
         )
 
     def get_account_info_json_parsed(
-        self, account: Pubkey, retries=DEFAULT_MAX_RETRIES
+        self, account: Pubkey, retries=DEFAULT_MAX_RETRIES, commitment=None
     ):
         def _get_account_info_json_parsed(client: Client, index):
             endpoint = self.endpoints[index]
             num_retries = retries
             while num_retries > 0:
                 try:
-                    response = client.get_account_info_json_parsed(account)
+                    response = client.get_account_info_json_parsed(
+                        account, commitment=commitment
+                    )
                     return response.value
                 except Exception as e:
                     logger.error(


### PR DESCRIPTION
### Description

Lmk if you'd want to think about this differently, but we've seen a few "indexing skips" from this behavior where we throw because we can't fetch account info from Solana.

The best I can think of is some limited, but larger number of retries w/ confirmation level set. This would amount to ~20-30 seconds of waiting before we give up

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._

Ran python code in repl