### PR TITLE
Fix mobile composer input newlines and unfurl overflow

### DIFF
--- a/packages/mobile/src/screens/chat-screen/ChatTextInput.tsx
+++ b/packages/mobile/src/screens/chat-screen/ChatTextInput.tsx
@@ -183,7 +183,9 @@ export const ChatTextInput = ({
     const matches = getMatches(value)
     if (!matches) {
       const text = splitOnNewline(value)
-      return text.map((t, i) => <Text key={i}>{`${t}\n`}</Text>)
+      return text.map((t, i) => (
+        <Text key={i}>{`${t === '\n' ? '\n\n' : t}`}</Text>
+      ))
     }
     const parts: JSX.Element[] = []
     let lastIndex = 0
@@ -198,7 +200,7 @@ export const ChatTextInput = ({
         const text = splitOnNewline(value.slice(lastIndex, index))
         parts.push(
           ...text.map((t, i) => (
-            <Text key={`${lastIndex}${i}`}>{`${t}\n`}</Text>
+            <Text key={`${lastIndex}${i}`}>{`${t === '\n' ? '\n\n' : t}`}</Text>
           ))
         )
       }

--- a/packages/mobile/src/screens/chat-screen/ComposePreviewInfo.tsx
+++ b/packages/mobile/src/screens/chat-screen/ComposePreviewInfo.tsx
@@ -29,8 +29,14 @@ const ComposePreviewInfo = (props: ComposePreviewInfoProps) => {
       >
         {image}
       </Flex>
-      <Flex direction='column' alignItems='flex-start' justifyContent='center'>
-        <Text variant='body' strength='strong'>
+      <Flex
+        direction='column'
+        alignItems='flex-start'
+        justifyContent='center'
+        backgroundColor='surface1'
+        mr='4xl'
+      >
+        <Text variant='body' strength='strong' numberOfLines={1}>
           {title}
         </Text>
         <Flex direction='row' alignItems='center' gap='xs'>


### PR DESCRIPTION
### Description

* New lines need to be double counted for to emulate behavior of textarea
* Text overflow on the DMs unfurl UI

<img width="422" alt="image" src="https://github.com/user-attachments/assets/9af581f4-0e25-4941-a563-b51b1280572a">

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._

Locally w/ staging