### PR TITLE
Set default comment entity_type in indexing

### DIFF
--- a/packages/common/src/context/commentsContext.tsx
+++ b/packages/common/src/context/commentsContext.tsx
@@ -60,7 +60,7 @@ type CommentSectionProviderProps = {
 export const CommentSectionProvider = (
   props: PropsWithChildren<CommentSectionProviderProps>
 ) => {
-  const { entityId, entityType, children } = props
+  const { entityId, entityType = EntityType.TRACK, children } = props
   const { data: track } = useGetTrackById({ id: entityId })
   const {
     data: comments = [],

--- a/packages/discovery-provider/src/tasks/entity_manager/entities/comment.py
+++ b/packages/discovery-provider/src/tasks/entity_manager/entities/comment.py
@@ -32,7 +32,7 @@ def create_comment(params: ManageEntityParameters):
         comment_id=comment_id,
         user_id=params.user_id,
         text=params.metadata["body"],
-        entity_type=params.metadata["entity_type"],
+        entity_type=params.metadata["entity_type"] or EntityType.TRACK.value,
         entity_id=params.metadata["entity_id"],
         track_timestamp_s=params.metadata["track_timestamp_s"],
         txhash=params.txhash,


### PR DESCRIPTION
### Description

Fixes issue where front-end code dropped setting entity_type default.

The fix includes
1. Re-adding default entity_type on client
2. Add default entity_type on indexing side, since we dont want sdk/api usage to cause stall if user doesn't set entity_type
