### PR TITLE
[QA-1536] Remove download all buttons

### DIFF
--- a/packages/mobile/src/screens/track-screen/DownloadSection.tsx
+++ b/packages/mobile/src/screens/track-screen/DownloadSection.tsx
@@ -2,8 +2,7 @@ import { useCallback, useState } from 'react'
 
 import {
   useCurrentStems,
-  useDownloadableContentAccess,
-  useGatedContentAccess
+  useDownloadableContentAccess
 } from '@audius/common/hooks'
 import type { ID } from '@audius/common/models'
 import { DownloadQuality, ModalSource } from '@audius/common/models'
@@ -47,7 +46,6 @@ const messages = {
   choose: 'Choose File Quality',
   mp3: 'MP3',
   lossless: 'Lossless',
-  downloadAll: 'Download All',
   unlockAll: (price: string) => `Unlock All $${price}`,
   purchased: 'purchased',
   followToDownload: 'Must follow artist to download.',
@@ -67,10 +65,6 @@ export const DownloadSection = ({ trackId }: { trackId: ID }) => {
     getTrack(state, { id: trackId })
   )
   const { stemTracks } = useCurrentStems({ trackId })
-  const { hasDownloadAccess } = useGatedContentAccess(track)
-  const shouldDisplayDownloadAll =
-    (track?.is_downloadable ? 1 : 0) + stemTracks.length > 1 &&
-    hasDownloadAccess
   const {
     price,
     shouldDisplayPremiumDownloadLocked,
@@ -262,23 +256,6 @@ export const DownloadSection = ({ trackId }: { trackId: ID }) => {
             isOriginal={quality === DownloadQuality.ORIGINAL}
           />
         ))}
-        {shouldDisplayDownloadAll ? (
-          <Flex p='l' borderTop='default' justifyContent='center'>
-            <Button
-              variant='secondary'
-              iconLeft={IconReceive}
-              size='small'
-              onPress={() =>
-                handleDownload({
-                  trackIds: stemTracks.map((t) => t.id),
-                  parentTrackId: trackId
-                })
-              }
-            >
-              {messages.downloadAll}
-            </Button>
-          </Flex>
-        ) : null}
       </Expandable>
     </Flex>
   )

--- a/packages/web/src/components/track/DownloadSection.tsx
+++ b/packages/web/src/components/track/DownloadSection.tsx
@@ -4,7 +4,6 @@ import {
   useCurrentStems,
   useFileSizes,
   useDownloadableContentAccess,
-  useGatedContentAccess,
   useUploadingStems
 } from '@audius/common/hooks'
 import {
@@ -55,7 +54,6 @@ const STEM_INDEX_OFFSET_WITH_ORIGINAL_TRACK = 2
 
 const messages = {
   title: 'Stems & Downloads',
-  downloadAll: 'Download All',
   unlockAll: (price: string) => `Unlock All $${price}`,
   purchased: 'purchased',
   followToDownload: 'Must follow artist to download.',
@@ -76,7 +74,6 @@ export const DownloadSection = ({ trackId }: DownloadSectionProps) => {
     shallowEqual
   )
   const { stemTracks } = useCurrentStems({ trackId })
-  const { hasDownloadAccess } = useGatedContentAccess(track)
   const { uploadingTracks: uploadingStems } = useUploadingStems({ trackId })
   const {
     price,
@@ -85,10 +82,6 @@ export const DownloadSection = ({ trackId }: DownloadSectionProps) => {
     shouldDisplayDownloadFollowGated,
     shouldDisplayOwnerPremiumDownloads
   } = useDownloadableContentAccess({ trackId })
-
-  const shouldDisplayDownloadAll =
-    (track?.is_downloadable ? 1 : 0) + stemTracks.length > 1 &&
-    hasDownloadAccess
 
   const downloadQuality = DownloadQuality.ORIGINAL
   const shouldHideDownload =
@@ -164,25 +157,6 @@ export const DownloadSection = ({ trackId }: DownloadSectionProps) => {
       shouldDisplayDownloadFollowGated,
       track
     ]
-  )
-
-  const downloadAllButton = () => (
-    <Button
-      variant='secondary'
-      size='small'
-      iconLeft={IconReceive}
-      onClick={() =>
-        handleDownload({
-          trackIds: stemTracks.map((s) => s.id),
-          parentTrackId: trackId
-        })
-      }
-      disabled={
-        shouldDisplayDownloadFollowGated || shouldDisplayPremiumDownloadLocked
-      }
-    >
-      {messages.downloadAll}
-    </Button>
   )
 
   return (
@@ -313,11 +287,6 @@ export const DownloadSection = ({ trackId }: DownloadSectionProps) => {
                 isLoading
               />
             ))}
-            {shouldDisplayDownloadAll || isMobile ? (
-              <Flex borderTop='default' p='l' justifyContent='center'>
-                {downloadAllButton()}
-              </Flex>
-            ) : null}
           </Box>
         </Expandable>
       </Flex>


### PR DESCRIPTION
### Description
Per discussion, we have decided to remove the download all button as its failure rate is ~50%.

### How Has This Been Tested?

<img width="1920" alt="Screenshot 2024-08-29 at 4 22 06 PM" src="https://github.com/user-attachments/assets/c4f5e597-3ebc-4d97-ad74-49d258b600f2">

