### PR TITLE
[PAY-3372] Add sales aggregate endpoint

### DIFF
--- a/packages/discovery-provider/src/api/v1/models/users.py
+++ b/packages/discovery-provider/src/api/v1/models/users.py
@@ -171,3 +171,12 @@ purchase = ns.model(
         "access": StringEnumToLower(required=True),
     },
 )
+
+sales_aggregate = ns.model(
+    "sales_aggregate",
+    {
+        "content_type": StringEnumToLower(required=True, discriminator=True),
+        "content_id": fields.String(required=True),
+        "purchase_count": fields.Integer(required=True),
+    },
+)

--- a/packages/discovery-provider/src/api/v1/users.py
+++ b/packages/discovery-provider/src/api/v1/users.py
@@ -75,6 +75,7 @@ from src.api.v1.models.users import (
     decoded_user_token,
     encoded_user_id,
     purchase,
+    sales_aggregate,
     user_model,
     user_model_full,
     user_subscribers,
@@ -118,6 +119,7 @@ from src.queries.get_purchasers import (
 from src.queries.get_related_artists import get_related_artists
 from src.queries.get_remixers import GetRemixersArgs, get_remixers, get_remixers_count
 from src.queries.get_repost_feed_for_user import get_repost_feed_for_user
+from src.queries.get_sales_aggregate import GetSalesAggregateArgs, get_sales_aggregate
 from src.queries.get_saves import get_saves
 from src.queries.get_subscribers import (
     get_subscribers_for_user,
@@ -2337,6 +2339,37 @@ class FullSalesCount(Resource):
         )
         count = get_usdc_purchases_count(args)
         return success_response(count)
+
+
+sales_aggregate_parser = pagination_with_current_user_parser.copy()
+
+sales_aggregate_response = make_response(
+    "sales_aggregate_response", ns, fields.List(fields.Nested(sales_aggregate))
+)
+
+
+@ns.route("/<string:id>/sales/aggregate")
+class SalesAggregate(Resource):
+    @ns.doc(
+        id="Get Sales Aggregate",
+        description="Gets the aggregated sales data for the user",
+        params={"id": "A User ID"},
+    )
+    @ns.expect(sales_aggregate_parser)
+    @auth_middleware(sales_aggregate_parser)
+    def get(self, id, authed_user_id):
+        decoded_id = decode_with_abort(id, ns)
+        check_authorized(decoded_id, authed_user_id)
+        args = sales_aggregate_parser.parse_args()
+        limit = get_default_max(args.get("limit"), 10, 100)
+        offset = get_default_max(args.get("offset"), 0)
+        args = GetSalesAggregateArgs(
+            seller_user_id=decoded_id,
+            limit=limit,
+            offset=offset,
+        )
+        sales_aggregate = get_sales_aggregate(args)
+        return success_response(list(sales_aggregate))
 
 
 purchases_download_parser = current_user_parser.copy()

--- a/packages/discovery-provider/src/queries/get_sales_aggregate.py
+++ b/packages/discovery-provider/src/queries/get_sales_aggregate.py
@@ -1,0 +1,41 @@
+from typing import Optional, TypedDict
+
+from sqlalchemy import func
+
+from src.models.users.usdc_purchase import USDCPurchase
+from src.queries.query_helpers import add_query_pagination
+from src.utils.db_session import get_db_read_replica
+
+
+class GetSalesAggregateArgs(TypedDict):
+    seller_user_id: Optional[int]
+    limit: int
+    offset: int
+
+
+def _get_sales_aggregate(session, args: GetSalesAggregateArgs):
+    query = (
+        session.query(
+            USDCPurchase.content_id,
+            USDCPurchase.content_type,
+            func.count(USDCPurchase.buyer_user_id).label("purchase_count"),
+        )
+        .filter(USDCPurchase.seller_user_id == args.get("seller_user_id"))
+        .group_by(USDCPurchase.content_id, USDCPurchase.content_type)
+    )
+
+    return query
+
+
+def get_sales_aggregate(args: GetSalesAggregateArgs):
+    """Aggregates USDCPurchase count by content_id and content_type for a given seller_user_id."""
+    db = get_db_read_replica()
+    with db.scoped_session() as session:
+        query = _get_sales_aggregate(session, args)
+        limit = args.get("limit")
+        offset = args.get("offset")
+
+        results = add_query_pagination(query, limit, offset).all()
+        sales_aggregate_list = [row._asdict() for row in results]
+
+        return sales_aggregate_list

--- a/packages/libs/src/sdk/api/generated/default/apis/UsersApi.ts
+++ b/packages/libs/src/sdk/api/generated/default/apis/UsersApi.ts
@@ -184,6 +184,15 @@ export interface GetRepostsRequest {
     userId?: string;
 }
 
+export interface GetSalesAggregateRequest {
+    id: string;
+    offset?: number;
+    limit?: number;
+    userId?: string;
+    encodedDataMessage?: string;
+    encodedDataSignature?: string;
+}
+
 export interface GetSubscribersRequest {
     id: string;
     offset?: number;
@@ -888,6 +897,56 @@ export class UsersApi extends runtime.BaseAPI {
     async getReposts(params: GetRepostsRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<Reposts> {
         const response = await this.getRepostsRaw(params, initOverrides);
         return await response.value();
+    }
+
+    /**
+     * @hidden
+     * Gets the aggregated sales data for the user
+     */
+    async getSalesAggregateRaw(params: GetSalesAggregateRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<void>> {
+        if (params.id === null || params.id === undefined) {
+            throw new runtime.RequiredError('id','Required parameter params.id was null or undefined when calling getSalesAggregate.');
+        }
+
+        const queryParameters: any = {};
+
+        if (params.offset !== undefined) {
+            queryParameters['offset'] = params.offset;
+        }
+
+        if (params.limit !== undefined) {
+            queryParameters['limit'] = params.limit;
+        }
+
+        if (params.userId !== undefined) {
+            queryParameters['user_id'] = params.userId;
+        }
+
+        const headerParameters: runtime.HTTPHeaders = {};
+
+        if (params.encodedDataMessage !== undefined && params.encodedDataMessage !== null) {
+            headerParameters['Encoded-Data-Message'] = String(params.encodedDataMessage);
+        }
+
+        if (params.encodedDataSignature !== undefined && params.encodedDataSignature !== null) {
+            headerParameters['Encoded-Data-Signature'] = String(params.encodedDataSignature);
+        }
+
+        const response = await this.request({
+            path: `/users/{id}/sales/aggregate`.replace(`{${"id"}}`, encodeURIComponent(String(params.id))),
+            method: 'GET',
+            headers: headerParameters,
+            query: queryParameters,
+        }, initOverrides);
+
+        return new runtime.VoidApiResponse(response);
+    }
+
+    /**
+     * Gets the aggregated sales data for the user
+     */
+    async getSalesAggregate(params: GetSalesAggregateRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<void> {
+        await this.getSalesAggregateRaw(params, initOverrides);
     }
 
     /**


### PR DESCRIPTION
### Description

Adds `/user/<id>/sales/aggregate` endpoint which returns the following for each piece of purchasable content owned by the user
```
{
	content_id: string
	content_type: 'track' | 'album'
	purchase_count: number
}
```

### How Has This Been Tested?

![Screenshot 2024-08-29 at 3 05 29 PM](https://github.com/user-attachments/assets/948c2c0c-78e7-4992-b223-c2121b9757b7)
