### PR TITLE
Filter genre metrics endpoint by allowlist

### DIFF
--- a/packages/discovery-provider/src/queries/get_genre_metrics.py
+++ b/packages/discovery-provider/src/queries/get_genre_metrics.py
@@ -4,6 +4,7 @@ from sqlalchemy import desc, func
 
 from src.models.tracks.track import Track
 from src.utils import db_session
+from src.utils.hardcoded_data import genre_allowlist
 
 logger = logging.getLogger(__name__)
 
@@ -32,6 +33,7 @@ def _get_genre_metrics(session, args):
         .filter(
             Track.genre != None,
             Track.genre != "",
+            Track.genre.in_(genre_allowlist),
             Track.is_current == True,
             Track.created_at > args.get("start_time"),
         )


### PR DESCRIPTION
### Description
Makes this endpoint usable as a list of official genres on Audius

### How Has This Been Tested?
cURL against a local DN at (`/v1/metrics/genres`) with edits to the allowlist to make sure the filtering works correctly.
