### PR TITLE
[QA-1533] Filter out deactivated users from UserList queries

### DIFF
--- a/packages/discovery-provider/src/queries/get_followees_for_user.py
+++ b/packages/discovery-provider/src/queries/get_followees_for_user.py
@@ -10,14 +10,16 @@ SELECT
     followee_user_id
 from
     follows
-    left outer join aggregate_user on followee_user_id = user_id
+    join users on users.user_id = follows.followee_user_id
+    left outer join aggregate_user on followee_user_id = aggregate_user.user_id
 where
-    is_current = true
-    and is_delete = false
+    follows.is_current = true
+    and follows.is_delete = false
+    and users.is_deactivated = false
     and follower_user_id = :follower_user_id
 order by
     follower_count desc,
-    user_id asc
+    aggregate_user.user_id asc
 offset :offset
 limit :limit;
 """

--- a/packages/discovery-provider/src/queries/get_followers_for_user.py
+++ b/packages/discovery-provider/src/queries/get_followers_for_user.py
@@ -10,14 +10,16 @@ SELECT
     follower_user_id
 from
     follows
-    left outer join aggregate_user on follower_user_id = user_id
+    join users on users.user_id = follows.follower_user_id
+    left outer join aggregate_user on follower_user_id = aggregate_user.user_id
 where
-    is_current = true
-    and is_delete = false
+    follows.is_current = true
+    and follows.is_delete = false
+    and users.is_deactivated = false
     and followee_user_id = :followee_user_id
 order by
     follower_count desc,
-    user_id asc
+    aggregate_user.user_id asc
 offset :offset
 limit :limit;
 """


### PR DESCRIPTION
### Description
Bug was: if user follows many other users who are deactivated, there's a possibility that the first page of followees would be almost entirely deactivated, which get filtered out on client. This wouldn't be an issue except it also breaks pagination on the client because there's no way to know when the end of the list is reached.

Note that this could be a problem with other modals that use UserList. Maybe need a bigger discussion around how to handle deactivated users, perhaps those follow counts should be omitted from `aggregate_user` as well, and all queries should filter them out by default.

But this PR fixes the immediate problem.

### How Has This Been Tested?

Local stack - created many users who logged-in user follows, checked which ones were getting returned in the first page and set some of those to deactivated, confirmed modal works with pagination.

https://github.com/user-attachments/assets/4312d524-c566-4b0d-b362-f216af8260c9
