### PR TITLE
Support negative fractional numbers in FixedDecimal, default USDC formatting

### DIFF
--- a/.changeset/brave-games-tan.md
+++ b/.changeset/brave-games-tan.md
@@ -1,0 +1,5 @@
+---
+'@audius/fixed-decimal': minor
+---
+
+Add default formatting for toLocaleString to USDC, and support negative numbers

--- a/.changeset/brave-games-tan.md
+++ b/.changeset/brave-games-tan.md
@@ -2,4 +2,4 @@
 '@audius/fixed-decimal': minor
 ---
 
-Add default formatting for toLocaleString to USDC, and support negative numbers
+Add default formatting for toLocaleString to USDC, and support negative fractional numbers

--- a/packages/fixed-decimal/src/FixedDecimal.test.ts
+++ b/packages/fixed-decimal/src/FixedDecimal.test.ts
@@ -610,5 +610,9 @@ describe('FixedDecimal', function () {
         })
       ).toBe('0')
     })
+
+    it('handles fractional negatives correctly', function () {
+      expect(new FixedDecimal('-0.123').toLocaleString('en-US')).toBe('-0.123')
+    })
   })
 })

--- a/packages/fixed-decimal/src/currencies.test.ts
+++ b/packages/fixed-decimal/src/currencies.test.ts
@@ -62,4 +62,9 @@ describe('Currency tests', function () {
     // Don't throw for correct BN brand
     USDC(new BN(3) as BNUSDC)
   })
+
+  it('defaults to two decimals', function () {
+    expect(USDC(1.234567).toLocaleString()).toBe('$1.23')
+    expect(USDC(-1.234567).toLocaleString()).toBe('-$1.23')
+  })
 })

--- a/packages/fixed-decimal/src/currencies.ts
+++ b/packages/fixed-decimal/src/currencies.ts
@@ -9,10 +9,11 @@ import { Brand } from './utilityTypes'
  */
 const createTokenConstructor =
   <T extends bigint, K extends BN = BN>(
-    decimalPlaces: ConstructorParameters<typeof FixedDecimal<T, K>>[1]
+    decimalPlaces: ConstructorParameters<typeof FixedDecimal<T, K>>[1],
+    defaultFormatOptions?: ConstructorParameters<typeof FixedDecimal<T, K>>[2]
   ) =>
   (value: ConstructorParameters<typeof FixedDecimal<T, K>>[0]) =>
-    new FixedDecimal<T, K>(value, decimalPlaces)
+    new FixedDecimal<T, K>(value, decimalPlaces, defaultFormatOptions)
 
 /**
  * A `bigint` representing an amount of Ethereum ERC-20 AUDIO tokens, which have
@@ -83,4 +84,10 @@ export type BNUSDC = Brand<BN, 'BNUSDC'>
  * USDC is used for purchasing content in-app, and getting "USD" prices via
  * Jupiter for the wAUDIO token and SOL.
  */
-export const USDC = createTokenConstructor<UsdcWei, BNUSDC>(6)
+export const USDC = createTokenConstructor<UsdcWei, BNUSDC>(6, {
+  style: 'currency',
+  currency: 'USD',
+  currencyDisplay: 'narrowSymbol',
+  minimumFractionDigits: 2,
+  maximumFractionDigits: 2
+})

--- a/packages/mobile/src/screens/track-screen/DownloadSection.tsx
+++ b/packages/mobile/src/screens/track-screen/DownloadSection.tsx
@@ -42,11 +42,11 @@ const STEM_INDEX_OFFSET_WITH_ORIGINAL_TRACK = 2
 
 const messages = {
   title: 'Stems & Downloads',
-  unlockAll: (price: string) => `Unlock All $${price}`,
+  unlockAll: (price: string) => `Unlock All ${price}`,
   purchased: 'purchased',
   followToDownload: 'Must follow artist to download.',
   purchaseableIsOwner: (price: string) =>
-    `Fans can unlock & download these files for a one time purchase of $${price}`
+    `Fans can unlock & download these files for a one time purchase of ${price}`
 }
 
 export const DownloadSection = ({ trackId }: { trackId: ID }) => {
@@ -67,13 +67,7 @@ export const DownloadSection = ({ trackId }: { trackId: ID }) => {
     shouldDisplayDownloadFollowGated,
     shouldDisplayOwnerPremiumDownloads
   } = useDownloadableContentAccess({ trackId })
-  const formattedPrice = price
-    ? USDC(price / 100).toLocaleString('en-us', {
-        roundingMode: 'floor',
-        minimumFractionDigits: 2,
-        maximumFractionDigits: 2
-      })
-    : undefined
+  const formattedPrice = price ? USDC(price / 100).toLocaleString() : undefined
   const shouldHideDownload =
     !track?.access.download && !shouldDisplayDownloadFollowGated
   const downloadQuality = DownloadQuality.ORIGINAL

--- a/packages/web/src/components/add-funds/AddFunds.tsx
+++ b/packages/web/src/components/add-funds/AddFunds.tsx
@@ -75,11 +75,7 @@ export const AddFunds = ({
                 </Box>
               </Flex>
               <Text variant='title' size='l' strength='strong'>
-                {`$${USDC(balance).toLocaleString('en-us', {
-                  roundingMode: 'floor',
-                  minimumFractionDigits: 2,
-                  maximumFractionDigits: 2
-                })}`}
+                {USDC(balance).toLocaleString()}
               </Text>
             </Flex>
           </Box>

--- a/packages/web/src/components/address-tile/AddressTile.tsx
+++ b/packages/web/src/components/address-tile/AddressTile.tsx
@@ -64,11 +64,7 @@ export const AddressTile = ({
           </Box>
         </Flex>
         <Text variant='title' size='l' strength='strong'>
-          {`$${USDC(balanceBN ?? new BN(0)).toLocaleString('en-us', {
-            roundingMode: 'floor',
-            minimumFractionDigits: 2,
-            maximumFractionDigits: 2
-          })}`}
+          {USDC(balanceBN ?? new BN(0)).toLocaleString()}
         </Text>
       </Flex>
       <Flex

--- a/packages/web/src/components/track/DownloadSection.tsx
+++ b/packages/web/src/components/track/DownloadSection.tsx
@@ -54,11 +54,11 @@ const STEM_INDEX_OFFSET_WITH_ORIGINAL_TRACK = 2
 
 const messages = {
   title: 'Stems & Downloads',
-  unlockAll: (price: string) => `Unlock All $${price}`,
+  unlockAll: (price: string) => `Unlock All ${price}`,
   purchased: 'purchased',
   followToDownload: 'Must follow artist to download.',
   purchaseableIsOwner: (price: string) =>
-    `Fans can unlock & download these files for a one time purchase of $${price}`
+    `Fans can unlock & download these files for a one time purchase of ${price}`
 }
 
 type DownloadSectionProps = {
@@ -86,13 +86,7 @@ export const DownloadSection = ({ trackId }: DownloadSectionProps) => {
   const downloadQuality = DownloadQuality.ORIGINAL
   const shouldHideDownload =
     !track?.access.download && !shouldDisplayDownloadFollowGated
-  const formattedPrice = price
-    ? USDC(price / 100).toLocaleString('en-us', {
-        roundingMode: 'floor',
-        minimumFractionDigits: 2,
-        maximumFractionDigits: 2
-      })
-    : undefined
+  const formattedPrice = price ? USDC(price / 100).toLocaleString() : undefined
   const [expanded, setExpanded] = useState(false)
   const [lockedContentModalVisibility, setLockedContentModalVisibility] =
     useModalState('LockedContent')

--- a/packages/web/src/components/usdc-manual-transfer/USDCManualTransfer.tsx
+++ b/packages/web/src/components/usdc-manual-transfer/USDCManualTransfer.tsx
@@ -45,7 +45,7 @@ const messages = {
   copy: 'Copy Wallet Address',
   goBack: 'Go Back',
   copied: 'Copied to Clipboard!',
-  buy: (amount: string) => `Buy $${amount}`
+  buy: (amount: string) => `Buy ${amount}`
 }
 
 export const USDCManualTransfer = ({
@@ -140,9 +140,7 @@ export const USDCManualTransfer = ({
             >
               {messages.buy(
                 USDC(amount).toLocaleString('en-us', {
-                  roundingMode: 'ceil',
-                  minimumFractionDigits: 2,
-                  maximumFractionDigits: 2
+                  roundingMode: 'ceil'
                 })
               )}
             </Button>


### PR DESCRIPTION
### Description

Prior to this change, "-0.123" would be misrepresented as "-.123" when calling `toString()` and break in `toLocaleString()`

Also adds default formatting to `toLocaleString()` for USDC to give it 2 decimal points exactly and a '$' prepended, which should make life easier when using it.

NOTE: I changed the rounding behavior in a few places from `floor` to `trunc`, but all those usages are always positive so they should work the same anyway.