### PR TITLE
[PAY-3324] Purchase/Sales details w/ take rate

### DIFF
--- a/.changeset/thick-sloths-rest.md
+++ b/.changeset/thick-sloths-rest.md
@@ -1,0 +1,5 @@
+---
+'@audius/sdk': patch
+---
+
+Only spend payExtra amount on users, not on the network take rate.

--- a/packages/common/src/models/USDCTransactions.ts
+++ b/packages/common/src/models/USDCTransactions.ts
@@ -1,3 +1,5 @@
+import type { PurchaseSplit } from '@audius/sdk/dist/sdk/api/generated/full'
+
 import { Nullable } from '../utils/typeUtils'
 
 import { PurchaseAccess } from './PurchaseContent'
@@ -30,6 +32,7 @@ export type USDCPurchaseDetails = {
   contentId: number
   createdAt: string
   access: PurchaseAccess
+  splits: PurchaseSplit[]
 }
 
 export type USDCTransactionDetails = {

--- a/packages/libs/src/sdk/utils/preparePaymentSplits.ts
+++ b/packages/libs/src/sdk/utils/preparePaymentSplits.ts
@@ -22,9 +22,14 @@ export const prepareSplits = async ({
   claimableTokensClient: ClaimableTokensClient
   logger: LoggerService
 }) => {
+  const userSplitCount = splits.filter((s) => !s.userId).length
   // Convert splits to big int and spread extra amount to every split
-  let amountSplits = splits.map((split, index, arr) => {
-    const amountToAdd = extraAmount / BigInt(arr.length - index)
+  let amountSplits = splits.map((split, index) => {
+    // Only give extra payments to users
+    if (!split.userId) {
+      return { ...split, amount: BigInt(split.amount) }
+    }
+    const amountToAdd = extraAmount / BigInt(userSplitCount - index)
     extraAmount = USDC(extraAmount - amountToAdd).value
     return {
       ...split,

--- a/packages/web/src/components/usdc-purchase-details-modal/components/ContentLink.tsx
+++ b/packages/web/src/components/usdc-purchase-details-modal/components/ContentLink.tsx
@@ -1,12 +1,13 @@
 import { Text } from '@audius/harmony'
 
-import { TextLink } from 'components/link'
+import { TextLink, type TextLinkProps } from 'components/link'
 
-export const ContentLink = (props: {
-  link: string
-  title: string
-  onClick: () => void
-}) => {
+export const ContentLink = (
+  props: {
+    link: string
+    title: string
+  } & Omit<TextLinkProps, 'to' | 'size'>
+) => {
   const { link, title, ...other } = props
   return (
     <TextLink to={link} size='l' {...other}>

--- a/packages/web/src/components/usdc-purchase-details-modal/components/DetailSection.tsx
+++ b/packages/web/src/components/usdc-purchase-details-modal/components/DetailSection.tsx
@@ -16,7 +16,7 @@ export const DetailSection = ({
     alignItems={actionButton ? undefined : 'center'}
     css={{ overflow: 'hidden' }}
   >
-    <Flex gap='s' direction='column' w='100%'>
+    <Flex gap='s' direction='column' w='100%' p='s'>
       <Text variant='label' size='l' color='subdued'>
         {label}
       </Text>

--- a/packages/web/src/components/usdc-purchase-details-modal/components/PurchaseModalContent.tsx
+++ b/packages/web/src/components/usdc-purchase-details-modal/components/PurchaseModalContent.tsx
@@ -1,19 +1,21 @@
+import { useCallback } from 'react'
+
 import { USDCPurchaseDetails } from '@audius/common/models'
-import { makeSolanaTransactionLink } from '@audius/common/utils'
 import {
   ModalContent,
   ModalHeader,
   ModalTitle,
   ModalFooter,
   Button,
+  Text,
   Flex,
-  IconExternalLink,
-  Text
+  IconArrowRight
 } from '@audius/harmony'
 import moment from 'moment'
 
 import DynamicImage from 'components/dynamic-image/DynamicImage'
-import { ExternalLink, UserLink } from 'components/link'
+import { UserLink } from 'components/link'
+import { useNavigateToPage } from 'hooks/useNavigateToPage'
 
 import { ContentLink } from './ContentLink'
 import { DetailSection } from './DetailSection'
@@ -22,11 +24,10 @@ import styles from './styles.module.css'
 
 const messages = {
   by: 'by',
-  date: 'Date',
-  transactionDate: 'Transaction Date',
+  transactionDate: 'Date',
   done: 'Done',
   purchaseDetails: 'Purchase Details',
-  visitTrack: 'Visit Track',
+  visit: 'Visit',
   transaction: 'Explore Transaction'
 }
 
@@ -47,59 +48,65 @@ export const PurchaseModalContent = ({
   artwork,
   onClose
 }: PurchaseModalContentProps) => {
+  const navigate = useNavigateToPage()
+  const onVisitClicked = useCallback(() => {
+    navigate(link)
+    onClose()
+  }, [link, navigate, onClose])
   return (
     <>
       <ModalHeader>
         <ModalTitle title={messages.purchaseDetails} />
       </ModalHeader>
-      <ModalContent className={styles.content}>
-        <Flex borderBottom='default' gap='l' w='100%' pb='xl'>
-          <DynamicImage
-            image={artwork}
-            wrapperClassName={styles.artworkContainer}
-          />
-          <DetailSection label={contentLabel}>
-            <ContentLink onClick={onClose} title={contentTitle} link={link} />
-            <Flex gap='xs'>
-              <Text variant='body' size='l'>
-                {messages.by}
-              </Text>
-              <UserLink
-                userId={purchaseDetails.sellerUserId}
-                popover
-                size='l'
-                onClick={onClose}
+      <ModalContent>
+        <Flex gap='l' direction='column'>
+          <DetailSection
+            label={contentLabel}
+            actionButton={
+              <DynamicImage
+                image={artwork}
+                wrapperClassName={styles.artworkContainer}
               />
-            </Flex>
+            }
+          >
+            <ContentLink
+              variant='visible'
+              onClick={onClose}
+              title={contentTitle}
+              link={link}
+            />
           </DetailSection>
+          <DetailSection label={messages.by}>
+            <UserLink
+              variant='visible'
+              userId={purchaseDetails.sellerUserId}
+              popover
+              size='l'
+              onClick={onClose}
+            />
+          </DetailSection>
+          <DetailSection label={messages.transactionDate}>
+            <Text variant='body' size='l'>
+              {moment(purchaseDetails.createdAt).format('MMM DD, YYYY')}
+            </Text>
+          </DetailSection>
+          <TransactionSummary transaction={purchaseDetails} />
         </Flex>
-        <DetailSection
-          label={messages.transactionDate}
-          actionButton={
-            <Button
-              iconLeft={IconExternalLink}
-              variant='secondary'
-              size='small'
-              asChild
-            >
-              <ExternalLink
-                to={makeSolanaTransactionLink(purchaseDetails.signature)}
-              >
-                {messages.transaction}
-              </ExternalLink>
-            </Button>
-          }
-        >
-          <Text variant='body' size='l'>
-            {moment(purchaseDetails.createdAt).format('MMM DD, YYYY')}
-          </Text>
-        </DetailSection>
-        <TransactionSummary transaction={purchaseDetails} />
       </ModalContent>
       <ModalFooter style={{ paddingTop: 0 }}>
-        <Button onClick={onClose} fullWidth>
-          {messages.done}
-        </Button>
+        <Flex w='100%' gap='s'>
+          <Button
+            onClick={onVisitClicked}
+            fullWidth
+            variant='secondary'
+            iconRight={IconArrowRight}
+          >
+            {messages.visit} {contentLabel}
+          </Button>
+          <Button onClick={onClose} fullWidth>
+            {messages.done}
+          </Button>
+        </Flex>
       </ModalFooter>
     </>
   )

--- a/packages/web/src/components/usdc-purchase-details-modal/components/SaleModalContent.tsx
+++ b/packages/web/src/components/usdc-purchase-details-modal/components/SaleModalContent.tsx
@@ -3,28 +3,26 @@ import { useCallback } from 'react'
 import { useIsManagedAccount } from '@audius/common/hooks'
 import { USDCPurchaseDetails } from '@audius/common/models'
 import {
-  chatActions,
   chatSelectors,
+  chatActions,
   useInboxUnavailableModal,
-  CommonState
+  type CommonState
 } from '@audius/common/store'
-import { makeSolanaTransactionLink } from '@audius/common/utils'
 import {
   ModalContent,
   ModalHeader,
   ModalTitle,
   ModalFooter,
   Button,
+  Text,
   Flex,
-  IconExternalLink,
-  IconMessage,
-  Text
+  IconMessage
 } from '@audius/harmony'
 import moment from 'moment'
 import { useDispatch, useSelector } from 'react-redux'
 
 import DynamicImage from 'components/dynamic-image/DynamicImage'
-import { ExternalLink, UserLink } from 'components/link'
+import { UserLink } from 'components/link'
 
 import { ContentLink } from './ContentLink'
 import { DetailSection } from './DetailSection'
@@ -35,16 +33,12 @@ const { getCanCreateChat } = chatSelectors
 const { createChat } = chatActions
 
 const messages = {
-  by: 'by',
-  date: 'Date',
+  by: 'Purchased By',
+  transactionDate: 'Date',
   done: 'Done',
-  messageBuyer: 'Message Buyer',
-  purchasedBy: 'Purchased By',
   saleDetails: 'Sale Details',
-  trackPurchased: 'Track Purchased',
-  transaction: 'Explore Transaction',
-  transactionDate: 'Transaction Date',
-  sayThanks: 'Say Thanks'
+  messageBuyer: 'Message Buyer',
+  transaction: 'Explore Transaction'
 }
 
 type SaleModalContentProps = {
@@ -92,73 +86,57 @@ export const SaleModalContent = ({
       <ModalHeader>
         <ModalTitle title={messages.saleDetails} />
       </ModalHeader>
-      <ModalContent className={styles.content}>
-        <Flex borderBottom='default' gap='l' w='100%' pb='xl'>
-          <DynamicImage
-            image={artwork}
-            wrapperClassName={styles.artworkContainer}
-          />
-          <DetailSection label={contentLabel}>
-            <ContentLink onClick={onClose} title={contentTitle} link={link} />
-            <Flex gap='xs'>
-              <Text variant='body' size='l'>
-                {messages.by}
-              </Text>
-              <UserLink
-                userId={purchaseDetails.sellerUserId}
-                popover
-                size='l'
-                onClick={onClose}
-              />
-            </Flex>
-          </DetailSection>
-        </Flex>
-        <Flex borderBottom='default' w='100%' pb='xl'>
+      <ModalContent>
+        <Flex gap='l' direction='column'>
           <DetailSection
-            label={messages.purchasedBy}
+            label={contentLabel}
             actionButton={
-              isManagedAccount ? undefined : (
-                <Button
-                  iconLeft={IconMessage}
-                  variant='secondary'
-                  size='small'
-                  onClick={handleClickMessageBuyer}
-                >
-                  {messages.sayThanks}
-                </Button>
-              )
+              <DynamicImage
+                image={artwork}
+                wrapperClassName={styles.artworkContainer}
+              />
             }
           >
-            <UserLink userId={purchaseDetails.buyerUserId} popover size='l' />
+            <ContentLink
+              variant='visible'
+              onClick={onClose}
+              title={contentTitle}
+              link={link}
+            />
           </DetailSection>
+          <DetailSection label={messages.by}>
+            <UserLink
+              variant='visible'
+              userId={purchaseDetails.buyerUserId}
+              popover
+              size='l'
+              onClick={onClose}
+            />
+          </DetailSection>
+          <DetailSection label={messages.transactionDate}>
+            <Text variant='body' size='l'>
+              {moment(purchaseDetails.createdAt).format('MMM DD, YYYY')}
+            </Text>
+          </DetailSection>
+          <TransactionSummary isSale transaction={purchaseDetails} />
         </Flex>
-        <DetailSection
-          label={messages.transactionDate}
-          actionButton={
-            <Button
-              iconLeft={IconExternalLink}
-              variant='secondary'
-              size='small'
-              asChild
-            >
-              <ExternalLink
-                to={makeSolanaTransactionLink(purchaseDetails.signature)}
-              >
-                {messages.transaction}
-              </ExternalLink>
-            </Button>
-          }
-        >
-          <Text variant='body' size='l'>
-            {moment(purchaseDetails.createdAt).format('MMM DD, YYYY')}
-          </Text>
-        </DetailSection>
-        <TransactionSummary transaction={purchaseDetails} />
       </ModalContent>
       <ModalFooter style={{ paddingTop: 0 }}>
-        <Button onClick={onClose} fullWidth>
-          {messages.done}
-        </Button>
+        <Flex w='100%' gap='s'>
+          {!isManagedAccount ? (
+            <Button
+              onClick={handleClickMessageBuyer}
+              fullWidth
+              variant='secondary'
+              iconLeft={IconMessage}
+            >
+              {messages.messageBuyer}
+            </Button>
+          ) : null}
+          <Button onClick={onClose} fullWidth>
+            {messages.done}
+          </Button>
+        </Flex>
       </ModalFooter>
     </>
   )

--- a/packages/web/src/components/usdc-purchase-details-modal/components/TransactionSummary.tsx
+++ b/packages/web/src/components/usdc-purchase-details-modal/components/TransactionSummary.tsx
@@ -5,26 +5,35 @@ import {
   USDCContentPurchaseType,
   USDCPurchaseDetails
 } from '@audius/common/models'
-import { formatUSDCWeiToUSDString } from '@audius/common/utils'
+import { USDC } from '@audius/fixed-decimal'
+import { Flex, IconInfo, Text } from '@audius/harmony'
 import BN from 'bn.js'
 
 import { SummaryTable, SummaryTableItem } from 'components/summary-table'
+import { Tooltip } from 'components/tooltip'
+
+import styles from './styles.module.css'
 
 const messages = {
   payExtra: 'Pay Extra',
   downloadable: (count: number) => `Downloadable Files (${count})`,
-  title: 'Transaction Summary',
   total: 'Total',
-  albumCost: 'Album Cost',
-  trackCost: 'Track Cost'
+  subtotal: 'Subtotal',
+  networkFee: 'Network Fee',
+  networkFeeRate: '(10%)',
+  networkFeeHelp:
+    'This fee flows to the community treasury to support the Audius network.'
 }
 
 export const TransactionSummary = ({
-  transaction
+  transaction,
+  isSale = false
 }: {
   transaction: USDCPurchaseDetails
+  isSale?: boolean
 }) => {
-  const amountBN = new BN(transaction.amount)
+  const amount = BigInt(transaction.amount)
+  const extraAmount = BigInt(transaction.extraAmount)
   const { contentId, contentType } = transaction
   const isTrack = contentType === USDCContentPurchaseType.TRACK
   const { data: track } = useGetTrackById({ id: contentId })
@@ -34,39 +43,82 @@ export const TransactionSummary = ({
   const downloadableCount =
     stemTracks.length + (track?.is_original_available ? 1 : 0)
 
+  let creatorTotal = BigInt(0)
+  let networkFee = BigInt(0)
+  for (const split of transaction.splits) {
+    if (split.userId) {
+      creatorTotal += BigInt(split.amount)
+    } else {
+      networkFee += BigInt(split.amount)
+    }
+  }
+  const subtotal = isSale ? amount : creatorTotal
+  const total = isSale ? extraAmount + creatorTotal : extraAmount + amount
+
   const items: SummaryTableItem[] = []
   if (transaction.access === PurchaseAccess.STREAM) {
     items.push({
       id: 'cost',
-      label: isTrack ? messages.trackCost : messages.albumCost,
-      value: `$${formatUSDCWeiToUSDString(amountBN)}`
+      label: messages.subtotal,
+      value: USDC(subtotal).toLocaleString()
     })
   } else if (transaction.access === PurchaseAccess.DOWNLOAD) {
     items.push({
       id: 'download',
       label: messages.downloadable(downloadableCount),
-      value: `$${formatUSDCWeiToUSDString(amountBN)}`
+      value: USDC(subtotal).toLocaleString('en-US', { roundingMode: 'floor' })
     })
   }
 
-  const extraAmountBN = new BN(transaction.extraAmount)
-  if (!extraAmountBN.isZero()) {
+  if (extraAmount !== BigInt(0)) {
     items.push({
       id: 'payExtra',
       label: messages.payExtra,
-      value: `$${formatUSDCWeiToUSDString(extraAmountBN)}`
+      value: USDC(extraAmount).toLocaleString()
+    })
+  }
+
+  if (networkFee > 0) {
+    items.push({
+      id: 'networkFee',
+      label: (
+        <Flex gap='s' alignItems='center'>
+          <Text>
+            {messages.networkFee + ' '}
+            <Text color='subdued'>{messages.networkFeeRate}</Text>
+          </Text>
+          <Tooltip
+            className={styles.tooltip}
+            color='secondary'
+            shouldWrapContent={false}
+            text={
+              <Text variant='body' size='m'>
+                {messages.networkFeeHelp}
+              </Text>
+            }
+            mount='body'
+          >
+            <IconInfo color='subdued' size='s' />
+          </Tooltip>
+        </Flex>
+      ),
+      value: USDC(isSale ? BigInt(0) - networkFee : networkFee).toLocaleString(
+        'en-US',
+        { roundingMode: 'ceil' }
+      )
     })
   }
 
   return (
     <SummaryTable
-      title={messages.title}
+      collapsible={true}
+      title={messages.total}
+      secondaryTitle={
+        <Text tag='span' color='accent'>
+          {USDC(total).toLocaleString()}
+        </Text>
+      }
       items={items}
-      summaryItem={{
-        id: 'total',
-        label: messages.total,
-        value: `$${formatUSDCWeiToUSDString(amountBN.add(extraAmountBN))}`
-      }}
     />
   )
 }

--- a/packages/web/src/components/usdc-purchase-details-modal/components/TransactionSummary.tsx
+++ b/packages/web/src/components/usdc-purchase-details-modal/components/TransactionSummary.tsx
@@ -59,7 +59,9 @@ export const TransactionSummary = ({
     items.push({
       id: 'cost',
       label: messages.subtotal,
-      value: USDC(subtotal).toLocaleString()
+      value: USDC(subtotal).toLocaleString('en-US', {
+        roundingMode: isSale ? 'floor' : 'ceil'
+      })
     })
   } else if (transaction.access === PurchaseAccess.DOWNLOAD) {
     items.push({
@@ -103,7 +105,7 @@ export const TransactionSummary = ({
       ),
       value: USDC(isSale ? BigInt(0) - networkFee : networkFee).toLocaleString(
         'en-US',
-        { roundingMode: 'ceil' }
+        { roundingMode: 'floor' }
       )
     })
   }

--- a/packages/web/src/components/usdc-purchase-details-modal/components/TransactionSummary.tsx
+++ b/packages/web/src/components/usdc-purchase-details-modal/components/TransactionSummary.tsx
@@ -7,7 +7,6 @@ import {
 } from '@audius/common/models'
 import { USDC } from '@audius/fixed-decimal'
 import { Flex, IconInfo, Text } from '@audius/harmony'
-import BN from 'bn.js'
 
 import { SummaryTable, SummaryTableItem } from 'components/summary-table'
 import { Tooltip } from 'components/tooltip'

--- a/packages/web/src/components/usdc-purchase-details-modal/components/styles.module.css
+++ b/packages/web/src/components/usdc-purchase-details-modal/components/styles.module.css
@@ -1,10 +1,3 @@
-.content > div:first-child {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  gap: var(--harmony-unit-6);
-}
-
 .trackRow {
   align-items: center∂;
   display: flex;
@@ -35,7 +28,12 @@
   border-radius: var(--harmony-unit-1);
   border: 1px solid var(--harmony-border-default);
   overflow: hidden;
-  width: var(--harmony-unit-24);
-  height: var(--harmony-unit-24);
-  flex: 0 0 var(--harmony-unit-24);
+  width: var(--harmony-unit-16);
+  height: var(--harmony-unit-16);
+  flex: 0 0 var(--harmony-unit-16);
+}
+
+.tooltip :global(.ant-tooltip-inner) {
+  border-radius: 8px;
+  padding: 12px 24px;
 }

--- a/packages/web/src/components/usdc-purchase-details-modal/components/styles.module.css
+++ b/packages/web/src/components/usdc-purchase-details-modal/components/styles.module.css
@@ -34,6 +34,6 @@
 }
 
 .tooltip :global(.ant-tooltip-inner) {
-  border-radius: 8px;
-  padding: 12px 24px;
+  border-radius: var(--harmony-unit-2);
+  padding: var(--harmony-unit-3) var(--harmony-unit-6);
 }


### PR DESCRIPTION
Adds the UI components for the Purchase/Sales transaction details modal. Note that the Network fee _always_ rounds up, and the subtotal _always_ rounds down for sales, and vice versa for purchases.

Also includes important change to ensure only users get the payExtra amount, which prior to this change would be split equally between the user and the network 🤯 

**SALES DETAILS:**

Note: The table says "Value: $2.06" but the total here is "$1.95". This feels a bit awkward to me.

![image](https://github.com/user-attachments/assets/68a33f18-2784-4e6c-8c7a-171da4e74b83)

**PURCHASE DETAILS:**
![image](https://github.com/user-attachments/assets/1ec4899a-7729-4831-b417-7e4d5d369496)
