### PR TITLE
Fix broken common tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -348,6 +348,10 @@ workflows:
             packages/libs/.* run-sdk-workflow true
             packages/libs/.* run-create-audius-app-workflow true
             packages/create-audius-app/.* run-create-audius-app-workflow true
+            packages/fixed-decimal/.* run-sdk-workflow true
+            packages/fixed-decimal/.* run-web-workflow true
+            packages/fixed-decimal/.* run-mobile-workflow true
+            packages/fixed-decimal/.* run-common-workflow true
           requires:
             - generate-config
             - init
@@ -403,6 +407,10 @@ workflows:
             packages/libs/.* run-sdk-workflow true
             packages/libs/.* run-create-audius-app-workflow true
             packages/create-audius-app/.* run-create-audius-app-workflow true
+            packages/fixed-decimal/.* run-sdk-workflow true
+            packages/fixed-decimal/.* run-web-workflow true
+            packages/fixed-decimal/.* run-mobile-workflow true
+            packages/fixed-decimal/.* run-common-workflow true
           requires:
             - generate-config
             - init

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -352,6 +352,8 @@ workflows:
             packages/fixed-decimal/.* run-web-workflow true
             packages/fixed-decimal/.* run-mobile-workflow true
             packages/fixed-decimal/.* run-common-workflow true
+            packages/spl/.* run-sdk-workflow true
+            packages/spl/.* run-identity-workflow true
           requires:
             - generate-config
             - init
@@ -411,6 +413,8 @@ workflows:
             packages/fixed-decimal/.* run-web-workflow true
             packages/fixed-decimal/.* run-mobile-workflow true
             packages/fixed-decimal/.* run-common-workflow true
+            packages/spl/.* run-sdk-workflow true
+            packages/spl/.* run-identity-workflow true
           requires:
             - generate-config
             - init

--- a/packages/common/src/utils/formatUtil.test.ts
+++ b/packages/common/src/utils/formatUtil.test.ts
@@ -83,6 +83,7 @@ describe('formatUtil', function () {
     const expected = '1,234,567.90'
     expect(
       USDC(cents / 100).toLocaleString('en-US', {
+        style: undefined,
         maximumFractionDigits: 2,
         minimumFractionDigits: 2,
         roundingMode: 'halfExpand'

--- a/packages/common/src/utils/wallet.test.ts
+++ b/packages/common/src/utils/wallet.test.ts
@@ -109,6 +109,7 @@ describe('wallet.ts currency formatting and conversion tests', function () {
     const expected = '12,345,678,901,234.57'
     expect(
       USDC(usdc).toLocaleString('en-US', {
+        style: undefined,
         maximumFractionDigits: precision,
         minimumFractionDigits: precision,
         roundingMode: 'ceil'


### PR DESCRIPTION
#9600 broke some common tests, but tests for common weren't running in CI. Also noticed `@audius/spl` isn't mapped, so added both `@audius/fixed-decimal` and `@audius/spl` mappings so that things that depend on them run their workflows in CI.

(Also fixes those common tests, obviously)
