### PR TITLE
Add support for expand rounding mode to FixedDecimal

### DIFF
--- a/.changeset/warm-spies-shake.md
+++ b/.changeset/warm-spies-shake.md
@@ -1,0 +1,5 @@
+---
+'@audius/fixed-decimal': minor
+---
+
+Add support for "expand" rounding mode

--- a/packages/fixed-decimal/src/FixedDecimal.test.ts
+++ b/packages/fixed-decimal/src/FixedDecimal.test.ts
@@ -339,6 +339,60 @@ describe('FixedDecimal', function () {
     })
   })
 
+  describe('expand', function () {
+    it('expands positive decimals correctly', function () {
+      expect(new FixedDecimal(1.2345).expand().toString()).toBe('2.0000')
+    })
+
+    it('expands negative decimals correctly', function () {
+      expect(new FixedDecimal(-1.2345).expand().toString()).toBe('-2.0000')
+    })
+
+    it('expands 0 correctly', function () {
+      expect(new FixedDecimal(0, 3).expand().toString()).toBe('0.000')
+    })
+
+    it('expands whole numbers correctly', function () {
+      expect(new FixedDecimal(4, 3).expand().toString()).toBe('4.000')
+    })
+
+    it('expands large numbers correctly', function () {
+      expect(
+        new FixedDecimal(BigInt('1234567890123456789099999999999999999999'), 20)
+          .expand()
+          .toString()
+      ).toBe('12345678901234567891.00000000000000000000')
+    })
+
+    it('expands tiny numbers correctly', function () {
+      expect(new FixedDecimal(BigInt('1'), 20).expand().toString()).toBe(
+        '1.00000000000000000000'
+      )
+    })
+
+    it('expands to arbitrary decimal places correctly', function () {
+      expect(
+        new FixedDecimal(BigInt('1234567890123456789099999999999999999999'), 20)
+          .expand(2)
+          .toString()
+      ).toBe('12345678901234567891.00000000000000000000')
+    })
+
+    it('throws when decimal places are out of range', function () {
+      expect(() =>
+        new FixedDecimal(BigInt('1234567890123456789099999999999999999999'), 20)
+          .expand(50)
+          .toString()
+      ).toThrow('Digits must be non-negative')
+    })
+
+    it('expands to 1s place of represented place if decimal places is beyond number', function () {
+      expect(new FixedDecimal(BigInt('12345'), 3).expand(-10).toString()).toBe(
+        '10000000000.000'
+      )
+    })
+  })
+
   describe('toPrecision', function () {
     it('work on positive numbers', function () {
       expect(new FixedDecimal('1234.56789').toPrecision(7)).toBe('1234.56700')

--- a/packages/fixed-decimal/src/FixedDecimal.ts
+++ b/packages/fixed-decimal/src/FixedDecimal.ts
@@ -81,11 +81,16 @@ type FixedDecimalFormatOptions = Omit<
    *    > Ties away from 0. Values above the half-increment round away from
    *      zero, and below towards 0. Does what Math.round() does.
    *
-   * Note: Does not support `'expand'`, `'halfCeil'`, `'halfFloor'`,
-   * `'halfTrunc'` or `'halfEven'`
+   * `'expand'`
+   *    > round away from 0. The magnitude of the value is always increased by
+   *      rounding. Positive values round up.
+   *      Negative values round "more negative".
+   *
+   * Note: Does not support `'halfCeil'`, `'halfFloor'`, `'halfTrunc'`
+   * or `'halfEven'`
    * @defaultValue `'trunc'`
    */
-  roundingMode?: 'ceil' | 'floor' | 'trunc' | 'halfExpand'
+  roundingMode?: 'ceil' | 'floor' | 'trunc' | 'halfExpand' | 'expand'
   /**
    * The strategy for displaying trailing zeros on whole numbers.
    *
@@ -342,6 +347,36 @@ export class FixedDecimal<
   }
 
   /**
+   * Rounds away from zero. (Opposite of trunc())
+   * @param decimalPlaces The number of decimal places to round to.
+   * @returns A new {@link FixedDecimal} with the result for chaining.
+   */
+  public expand(decimalPlaces?: number) {
+    const digits = this.decimalPlaces - (decimalPlaces ?? 0)
+    return this._expand(digits)
+  }
+
+  private _expand(digitsToRemove: number) {
+    if (digitsToRemove < 0) {
+      throw new RangeError('Digits must be non-negative')
+    }
+    const signMultiplier = this.value > 0 ? BigInt(1) : BigInt(-1)
+    const dividend = signMultiplier * this.value
+    const divisor = BigInt(10 ** digitsToRemove)
+    const quotient = dividend / divisor
+    const remainder = dividend - quotient * divisor
+    // If whole number, do nothing
+    if (remainder === BigInt(0)) {
+      return this
+    }
+    // If not, truncate, add 1 to the place we're rounding to and convert sign
+    return new FixedDecimal<BigIntBrand, BNBrand>(
+      signMultiplier * (quotient * divisor + divisor),
+      this.decimalPlaces
+    )
+  }
+
+  /**
    * Number.toPrecision() but for {@link FixedDecimal}.
    * @param significantDigits The number of significant digits to keep.
    * @returns The number truncated to the significant digits specified as a string.
@@ -430,6 +465,9 @@ export class FixedDecimal<
         break
       case 'halfExpand':
         str = this.round(mergedOptions.maximumFractionDigits).toString()
+        break
+      case 'expand':
+        str = this.expand(mergedOptions.maximumFractionDigits).toString()
         break
     }
 

--- a/packages/fixed-decimal/src/FixedDecimal.ts
+++ b/packages/fixed-decimal/src/FixedDecimal.ts
@@ -360,18 +360,16 @@ export class FixedDecimal<
     if (digitsToRemove < 0) {
       throw new RangeError('Digits must be non-negative')
     }
-    const signMultiplier = this.value > 0 ? BigInt(1) : BigInt(-1)
-    const dividend = signMultiplier * this.value
     const divisor = BigInt(10 ** digitsToRemove)
-    const quotient = dividend / divisor
-    const remainder = dividend - quotient * divisor
+    const remainder = this.value % divisor
     // If whole number, do nothing
     if (remainder === BigInt(0)) {
       return this
     }
-    // If not, truncate, add 1 to the place we're rounding to and convert sign
+    const signMultiplier = this.value > 0 ? BigInt(1) : BigInt(-1)
+    // If not, truncate and add/sub 1 to the place we're rounding to
     return new FixedDecimal<BigIntBrand, BNBrand>(
-      signMultiplier * (quotient * divisor + divisor),
+      (this.value / divisor) * divisor + divisor * signMultiplier,
       this.decimalPlaces
     )
   }


### PR DESCRIPTION
### Description

Allows for rounding mode to be "expand", which rounds away from zero. See: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/NumberFormat/NumberFormat#expand

### How Has This Been Tested?

Added tests
