### PR TITLE
Fix web external-text-link style propagation

### DIFF
--- a/packages/web/src/components/link/ExternalTextLink.tsx
+++ b/packages/web/src/components/link/ExternalTextLink.tsx
@@ -1,7 +1,4 @@
-import {
-  TextLink,
-  TextLinkProps
-} from '@audius/harmony/src/components/text-link'
+import { TextLink, TextLinkProps } from '@audius/harmony'
 
 import { ExternalLink, ExternalLinkProps } from './ExternalLink'
 


### PR DESCRIPTION
### Description

Fixes issue where ExternalTextLink wasn't aware of it's context because it was imported as src instead of from root, which meant the "TextContext" was different.

@rickyrombo if you integrate this fix to your pr, you should be able to simplify the link definition!
