### PR TITLE
[C-5008] Add single and multi lineHeight options to Text

### DIFF
--- a/.changeset/rare-panthers-accept.md
+++ b/.changeset/rare-panthers-accept.md
@@ -1,0 +1,5 @@
+---
+'@audius/harmony': patch
+---
+
+Add lineHeight prop to configure single/multi line styles

--- a/packages/harmony/src/components/text/Text.tsx
+++ b/packages/harmony/src/components/text/Text.tsx
@@ -5,7 +5,7 @@ import { Slot } from '@radix-ui/react-slot'
 
 import { typography } from '../../foundations/typography'
 
-import { variantStylesMap, variantTagMap } from './constants'
+import { bodyLineHeightMap, variantStylesMap, variantTagMap } from './constants'
 import { TextContext } from './textContext'
 import type { TextProps } from './types'
 
@@ -27,6 +27,7 @@ export const Text = forwardRef(
       textTransform,
       ellipses,
       maxLines,
+      lineHeight,
       ...other
     } = props
 
@@ -56,8 +57,16 @@ export const Text = forwardRef(
       ...(variantConfig && {
         // @ts-ignore
         fontSize: typography.size[variantConfig.fontSize[size]],
-        // @ts-ignore
-        lineHeight: typography.lineHeight[variantConfig.lineHeight[size]],
+
+        lineHeight:
+          // @ts-ignore
+          typography.lineHeight[
+            lineHeight && variant === 'body' && size
+              ? // @ts-ignore
+                bodyLineHeightMap[size][lineHeight]
+              : // @ts-ignore
+                variantConfig.lineHeight[size]
+          ],
         // @ts-ignore
         fontWeight: typography.weight[variantConfig.fontWeight[strength]],
         ...('css' in variantConfig && variantConfig.css)

--- a/packages/harmony/src/components/text/constants.ts
+++ b/packages/harmony/src/components/text/constants.ts
@@ -54,3 +54,10 @@ export const variantStylesMap = {
     fontWeight: { default: 'medium', strong: 'demiBold' }
   }
 }
+
+export const bodyLineHeightMap = {
+  xs: { single: 'xs', multi: 's' },
+  s: { single: 's', multi: 'l' },
+  m: { single: 's', multi: 'l' },
+  l: { single: 'm', multi: 'bl' }
+}

--- a/packages/harmony/src/components/text/types.ts
+++ b/packages/harmony/src/components/text/types.ts
@@ -21,6 +21,7 @@ export type BaseTextProps<TextComponentType extends ElementType = 'p'> = {
   ellipses?: boolean
   maxLines?: number
   textTransform?: CSSProperties['textTransform']
+  lineHeight?: 'single' | 'multi'
 }
 
 export type TextProps<TextComponentType extends ElementType = 'p'> =

--- a/packages/harmony/src/foundations/typography/typography.ts
+++ b/packages/harmony/src/foundations/typography/typography.ts
@@ -31,6 +31,8 @@ export const typography = {
     s: '16px',
     m: '20px',
     l: '24px',
+    // body multi-line one-off
+    bl: '28px',
     xl: '32px',
     // heading large one-off
     hl: '36px',

--- a/packages/mobile/src/harmony-native/components/Comments/CommentText/CommentText.tsx
+++ b/packages/mobile/src/harmony-native/components/Comments/CommentText/CommentText.tsx
@@ -29,7 +29,7 @@ export const CommentText = ({ children }: CommentTextProps) => {
       <Text
         variant='body'
         size='s'
-        color='default'
+        lineHeight='multi'
         onTextLayout={onTextLayout}
         numberOfLines={isOverflowing && !isExpanded ? MAX_LINES : undefined}
       >

--- a/packages/mobile/src/harmony-native/components/Text/Text.tsx
+++ b/packages/mobile/src/harmony-native/components/Text/Text.tsx
@@ -1,7 +1,10 @@
 import { forwardRef, useContext } from 'react'
 
 import type { BaseTextProps } from '@audius/harmony/src/components/text'
-import { variantStylesMap } from '@audius/harmony/src/components/text/constants'
+import {
+  variantStylesMap,
+  bodyLineHeightMap
+} from '@audius/harmony/src/components/text/constants'
 import { TextContext } from '@audius/harmony/src/components/text/textContext'
 import { css } from '@emotion/native'
 import type { TextProps as NativeTextProps, TextStyle } from 'react-native'
@@ -28,6 +31,7 @@ export const Text = forwardRef<TextBase, TextProps>((props, ref) => {
     textTransform,
     shadow,
     flexShrink,
+    lineHeight,
     ...other
   } = props
   const theme = useTheme()
@@ -50,7 +54,13 @@ export const Text = forwardRef<TextBase, TextProps>((props, ref) => {
   const textStyles: TextStyle = css({
     ...(variantStyles && {
       fontSize: size && t.size[variantStyles.fontSize[size]],
-      lineHeight: size && t.lineHeight[variantStyles.lineHeight[size]],
+      lineHeight:
+        size &&
+        t.lineHeight[
+          lineHeight && variant === 'body'
+            ? bodyLineHeightMap[size][lineHeight]
+            : variantStyles.lineHeight[size]
+        ],
       fontFamily:
         strength && t.fontByWeight[variantStyles.fontWeight[strength]],
       ...('css' in variantStyles ? variantStyles.css ?? {} : {})
@@ -88,5 +98,5 @@ export const Text = forwardRef<TextBase, TextProps>((props, ref) => {
   )
 })
 
-export { variantStylesMap }
+export { variantStylesMap, bodyLineHeightMap }
 export type { TextSize } from '@audius/harmony/src/components/text/types'

--- a/packages/mobile/src/screens/chat-screen/ChatMessageListItem.tsx
+++ b/packages/mobile/src/screens/chat-screen/ChatMessageListItem.tsx
@@ -311,7 +311,9 @@ export const ChatMessageListItem = memo(function ChatMessageListItem(
                     >
                       <UserGeneratedText
                         variant='body'
+                        lineHeight='multi'
                         color={isAuthor ? 'staticWhite' : 'default'}
+                        textAlign='left'
                         linkProps={{
                           variant: isAuthor ? 'inverted' : 'visible',
                           showUnderline: true

--- a/packages/web/src/components/comments/CommentBlock.tsx
+++ b/packages/web/src/components/comments/CommentBlock.tsx
@@ -119,7 +119,9 @@ export const CommentBlock = (props: CommentBlockProps) => {
             hideAvatar
           />
         ) : (
-          <Text color='default'>{message}</Text>
+          <Text variant='body' size='s' lineHeight='multi' textAlign='left'>
+            {message}
+          </Text>
         )}
         {hideActions ? null : (
           <CommentActionBar

--- a/packages/web/src/components/user-generated-text/UserGeneratedText.tsx
+++ b/packages/web/src/components/user-generated-text/UserGeneratedText.tsx
@@ -14,7 +14,7 @@ import {
   formatTrackName,
   formatUserName
 } from '@audius/common/utils'
-import { Text, TextProps } from '@audius/harmony'
+import { Text, TextLinkProps, TextProps } from '@audius/harmony'
 import { ResolveApi } from '@audius/sdk'
 import Linkify from 'linkify-react'
 import { IntermediateRepresentation, Opts } from 'linkifyjs'
@@ -41,6 +41,7 @@ const LinkifyText = forwardRef((props: LinkifyTextProps, ref) => {
 })
 
 type UserGeneratedTextProps<T extends ElementType> = TextProps<T> & {
+  linkProps?: Partial<TextLinkProps>
   linkSource?: 'profile page' | 'track page' | 'collection page'
   onClickLink?: (event: MouseEvent<HTMLAnchorElement>) => void
 }
@@ -101,9 +102,11 @@ export const UserGeneratedText = forwardRef(function <T extends ElementType>(
     color,
     size,
     strength,
+    lineHeight,
     tag = 'p',
     linkSource,
     onClickLink,
+    linkProps: textLinkProps,
     ...other
   } = props
 
@@ -115,10 +118,20 @@ export const UserGeneratedText = forwardRef(function <T extends ElementType>(
         onClick: onClickLink,
         textVariant: variant,
         size,
-        strength
+        strength,
+        lineHeight,
+        ...textLinkProps
       }
     }),
-    [linkSource, onClickLink, variant, size, strength]
+    [
+      linkSource,
+      onClickLink,
+      variant,
+      size,
+      strength,
+      lineHeight,
+      textLinkProps
+    ]
   )
 
   const children =
@@ -135,6 +148,7 @@ export const UserGeneratedText = forwardRef(function <T extends ElementType>(
       color={color}
       size={size}
       strength={strength}
+      lineHeight={lineHeight}
       css={{ whiteSpace: 'pre-line' }}
       {...other}
     >

--- a/packages/web/src/pages/chat-page/components/ChatMessageListItem.module.css
+++ b/packages/web/src/pages/chat-page/components/ChatMessageListItem.module.css
@@ -29,11 +29,6 @@
   overflow: hidden;
 }
 
-.text a {
-  color: var(--harmony-neutral);
-  text-decoration: underline !important;
-}
-
 .bubble:not(.nonInteractive):hover {
   --bubble-color: var(--harmony-n-25);
   filter: var(--drop-shadow-far);
@@ -41,10 +36,6 @@
 
 .isAuthor .bubble {
   --bubble-color: var(--harmony-s-100);
-}
-
-.isAuthor .text a {
-  color: var(--harmony-static-white);
 }
 
 .isAuthor .bubble:hover {
@@ -67,8 +58,6 @@
   padding: var(--harmony-unit-4);
   white-space: pre-wrap;
   word-break: break-word;
-  text-align: left;
-  line-height: 150%;
   user-select: text;
   background-color: var(--bubble-color);
 }

--- a/packages/web/src/pages/chat-page/components/ChatMessageListItem.tsx
+++ b/packages/web/src/pages/chat-page/components/ChatMessageListItem.tsx
@@ -211,8 +211,14 @@ export const ChatMessageListItem = (props: ChatMessageListItemProps) => {
           ) : null}
           {!hideMessage ? (
             <UserGeneratedText
+              lineHeight='multi'
               className={styles.text}
               color={isAuthor ? 'staticWhite' : 'default'}
+              textAlign='left'
+              linkProps={{
+                variant: isAuthor ? 'inverted' : 'visible',
+                showUnderline: true
+              }}
             >
               {message.message}
             </UserGeneratedText>


### PR DESCRIPTION
### Description

To improve multi-line text, design has updated lineHeights for text that should be multiple lines. This covers a few UserGeneratedText situations. For now I am just updating DMs and Comments features to use multi-line text.

Note that we now have 3 line-height options for body:
1. Legacy
2. Single-line
3. Multil-line

To prevent too many style changes, we have opted to keep legacy as the default, and introduce the other two options as add-ons. In the future we will likely default to single-line line-height as the default, with multiline as a configurable option.