### PR TITLE
[QA-1537] Remove unnecessary short circuit logic for gated tracks in get_remixes_of

### DIFF
--- a/packages/discovery-provider/src/queries/get_remixes_of.py
+++ b/packages/discovery-provider/src/queries/get_remixes_of.py
@@ -50,14 +50,6 @@ def get_remixes_of(args):
                 raise exceptions.ArgumentError("Invalid track_id provided")
 
             parent_track = parent_track_res[0]
-
-            # Return empty list of remixes if track is gated on conditions other than USDC purchase
-            if (
-                parent_track["is_stream_gated"]
-                and "usdc_purchase" not in parent_track["stream_conditions"]
-            ):
-                return ([], [], 0)
-
             track_owner_id = parent_track["owner_id"]
 
             # Get the 'children' remix tracks


### PR DESCRIPTION
### Description
The logic in `get_remixes_of` evolved over a few different tickets/features to a point where we are accidentally excluding remixes for all gated types that are _not_ usdc purchases. The original intention of this line was to fix a bug around remixes for usdc purchases. So it now appears to be unnecessary.

However, we _do_ still hide remixes in the client. And that needs to be resolved separately.

### How Has This Been Tested?
Local stack
