### PR TITLE
Remove ToUserId in blast ws fan-out

### DIFF
--- a/comms/discovery/rpcz/chat_blast.go
+++ b/comms/discovery/rpcz/chat_blast.go
@@ -21,7 +21,6 @@ type ChatBlastResult struct {
 }
 
 type OutgoingChatMessage struct {
-	ToUserId       int32                 `json:"to_user_id"`
 	ChatMessageRPC schema.ChatMessageRPC `json:"chat_message_rpc"`
 }
 
@@ -131,7 +130,7 @@ func chatBlast(tx *sqlx.Tx, userId int32, ts time.Time, params schema.ChatBlastR
 		FROM targ
 		ON conflict do nothing
 	)
-	SELECT chat_id, to_user_id FROM targ;
+	SELECT chat_id FROM targ;
 	`
 
 	err = tx.Select(&results, fanOutSql, params.BlastID, ts)
@@ -145,7 +144,6 @@ func chatBlast(tx *sqlx.Tx, userId int32, ts time.Time, params schema.ChatBlastR
 		messageID := result.ChatID + params.BlastID
 
 		outgoingMessages = append(outgoingMessages, OutgoingChatMessage{
-			ToUserId: result.ToUserID,
 			ChatMessageRPC: schema.ChatMessageRPC{
 				Method: schema.MethodChatMessage,
 				Params: schema.ChatMessageRPCParams{


### PR DESCRIPTION
### Description
This field is unneeded, was used during dev but forgot to remove it.

### How Has This Been Tested?

Tested against local stack, chat blasts working fine.