### PR TITLE
[PAY-3387] Chat ws respects chat_member.is_hidden

### DIFF
--- a/comms/discovery/rpcz/apply.go
+++ b/comms/discovery/rpcz/apply.go
@@ -441,7 +441,7 @@ func websocketNotify(rpcJson json.RawMessage, userId int32, timestamp time.Time)
 	if chatId := gjson.GetBytes(rpcJson, "params.chat_id").String(); chatId != "" {
 
 		var userIds []int32
-		err := db.Conn.Select(&userIds, `select user_id from chat_member where chat_id = $1`, chatId)
+		err := db.Conn.Select(&userIds, `select user_id from chat_member where chat_id = $1 and is_hidden = false`, chatId)
 		if err != nil {
 			logger.Warn("failed to load chat members for websocket push " + err.Error())
 			return


### PR DESCRIPTION
### Description
When selecting which users to send a chat websocket rpc to, respect the `chat_member.is_hidden` field and don't fire websocket events to those users for whom it is `true`.

### How Has This Been Tested?
In this example, reed sends a blast to 2 followers, andrew and steve. andrew has responded, so the chat appears on reed's end. steve has not. notice that after blasting, on reed's side, there is still only one chat with andrew. the chat with steve remains hidden from reed (currently, the steve chat would appear but then disappear on refresh).

https://github.com/user-attachments/assets/a7e0ff5b-9d68-49e8-a155-8bbef86cc853

