### PR TITLE
Only add blasts to store for sender

### DIFF
--- a/.changeset/spotty-ads-share.md
+++ b/.changeset/spotty-ads-share.md
@@ -1,0 +1,5 @@
+---
+'@audius/sdk': patch
+---
+
+Fix blast sender ID

--- a/packages/common/src/store/pages/chat/middleware.ts
+++ b/packages/common/src/store/pages/chat/middleware.ts
@@ -53,18 +53,21 @@ export const chatMiddleware =
             const currentUserId = getUserId(store.getState())
             const isSelfMessage =
               message.sender_user_id === encodeHashId(currentUserId)
-            store.dispatch(
-              addMessage({
-                chatId: makeBlastChatId({
-                  audience,
-                  audienceContentType,
-                  audienceContentId
-                }),
-                message,
-                status: Status.SUCCESS,
-                isSelfMessage
-              })
-            )
+            // Only add blasts that current user sent as blast UI should only be visible to sender.
+            if (isSelfMessage) {
+              store.dispatch(
+                addMessage({
+                  chatId: makeBlastChatId({
+                    audience,
+                    audienceContentType,
+                    audienceContentId
+                  }),
+                  message,
+                  status: Status.SUCCESS,
+                  isSelfMessage
+                })
+              )
+            }
           }
           reactionListener = ({ chatId, messageId, reaction }) => {
             store.dispatch(

--- a/packages/libs/src/sdk/api/chats/ChatsApi.ts
+++ b/packages/libs/src/sdk/api/chats/ChatsApi.ts
@@ -915,7 +915,7 @@ export class ChatsApi
             message: {
               message_id: data.rpc.params.blast_id,
               message: data.rpc.params.message,
-              sender_user_id: userId,
+              sender_user_id: data.metadata.senderUserId,
               created_at: data.metadata.timestamp,
               reactions: [],
               is_plaintext: true


### PR DESCRIPTION
### Description
- Fix bug where API was tagging blasts as always sent from current user
- Only add blast messages to store if current user is the sender - don't want to trigger blast fetches for the recipients

### How Has This Been Tested?

Tested against local stack. Previously recipients were attempting to fetch blast threads and getting 404, triggering a "something went wrong" toast.
