### PR TITLE
Blast getMessages supports all audiences

### DIFF
--- a/comms/discovery/db/queries/get_chat_messages.go
+++ b/comms/discovery/db/queries/get_chat_messages.go
@@ -122,7 +122,10 @@ func ChatMessagesAndReactions(q db.Queryable, ctx context.Context, arg ChatMessa
 		}
 		audience := parts[0]
 
-		if schema.ChatBlastAudience(audience) == schema.FollowerAudience {
+		if schema.ChatBlastAudience(audience) == schema.FollowerAudience ||
+			schema.ChatBlastAudience(audience) == schema.TipperAudience ||
+			schema.ChatBlastAudience(audience) == schema.CustomerAudience ||
+			schema.ChatBlastAudience(audience) == schema.RemixerAudience {
 			const outgoingBlastMessages = `
 			SELECT
 				b.blast_id as message_id,


### PR DESCRIPTION
### Description
Need to update the list of blast audience types we support for `getMessages` endpoint.

### How Has This Been Tested?

Tested locally with tipper audience, confirmed fetch works on sender side