### PR TITLE
[QA-1439] Don't block gated tracks from being remixes

### DIFF
--- a/packages/mobile/src/screens/edit-track-screen/screens/RemixSettingsScreen.tsx
+++ b/packages/mobile/src/screens/edit-track-screen/screens/RemixSettingsScreen.tsx
@@ -1,11 +1,7 @@
 import { useCallback, useEffect, useMemo, useState } from 'react'
 
 import { useGatedContentAccess } from '@audius/common/hooks'
-import {
-  Status,
-  isContentCollectibleGated,
-  isContentUSDCPurchaseGated
-} from '@audius/common/models'
+import { Status, isContentUSDCPurchaseGated } from '@audius/common/models'
 import type { AccessConditions } from '@audius/common/models'
 import { createRemixOfMetadata } from '@audius/common/schemas'
 import {
@@ -19,7 +15,7 @@ import { debounce } from 'lodash'
 import { View } from 'react-native'
 import { useDispatch, useSelector } from 'react-redux'
 
-import { Hint, IconCaretLeft, IconRemix, Button } from '@audius/harmony-native'
+import { IconCaretLeft, IconRemix, Button } from '@audius/harmony-native'
 import type { TextProps } from 'app/components/core'
 import { TextInput, Divider, Switch, Text } from 'app/components/core'
 import { InputErrorMessage } from 'app/components/core/InputErrorMessage'
@@ -50,10 +46,7 @@ const messages = {
   remixAccessError: 'Must have access to the original track',
   enterLink: 'Enter an Audius Link',
   changeAvailbilityPrefix: 'Availablity is set to',
-  changeAvailbilitySuffix: 'To enable these options, make your track free.',
-  premium: 'Premium (Pay-To-Unlock). ',
-  collectibleGated: 'Collectible Gated. ',
-  specialAccess: 'Special Access. '
+  changeAvailbilitySuffix: 'To enable these options, make your track free.'
 }
 
 const useStyles = makeStyles(({ palette, spacing, typography }) => ({
@@ -104,7 +97,6 @@ export const RemixSettingsScreen = () => {
   const [{ value: streamConditions }] =
     useField<Nullable<AccessConditions>>('stream_conditions')
   const isUsdcGated = isContentUSDCPurchaseGated(streamConditions)
-  const isCollectibleGated = isContentCollectibleGated(streamConditions)
 
   const parentTrackId = remixOf?.tracks[0].parent_track_id
   const [isTrackRemix, setIsTrackRemix] = useState(Boolean(parentTrackId))
@@ -231,22 +223,9 @@ export const RemixSettingsScreen = () => {
     >
       <View>
         <View style={styles.setting}>
-          {isStreamGated ? (
-            <Hint mb='xl'>{`${messages.changeAvailbilityPrefix} ${
-              isUsdcGated
-                ? messages.premium
-                : isCollectibleGated
-                ? messages.collectibleGated
-                : messages.specialAccess
-            } ${messages.changeAvailbilitySuffix}`}</Hint>
-          ) : null}
           <View style={styles.option}>
             <Text {...labelProps}>{messages.markRemix}</Text>
-            <Switch
-              value={isTrackRemix}
-              onValueChange={handleChangeIsRemix}
-              isDisabled={isStreamGated}
-            />
+            <Switch value={isTrackRemix} onValueChange={handleChangeIsRemix} />
           </View>
           {isTrackRemix ? (
             <View>

--- a/packages/mobile/src/screens/edit-track-screen/screens/RemixSettingsScreen.tsx
+++ b/packages/mobile/src/screens/edit-track-screen/screens/RemixSettingsScreen.tsx
@@ -264,7 +264,6 @@ export const RemixSettingsScreen = () => {
             <Switch
               value={!remixesVisible}
               onValueChange={(value) => setRemixesVisible(!value)}
-              isDisabled={isStreamGated && !isUsdcGated}
             />
           </View>
           <Text {...descriptionProps}>{messages.hideRemixesDescription}</Text>

--- a/packages/mobile/src/screens/edit-track-screen/screens/RemixSettingsScreen.tsx
+++ b/packages/mobile/src/screens/edit-track-screen/screens/RemixSettingsScreen.tsx
@@ -44,9 +44,7 @@ const messages = {
   invalidRemixUrl: 'Please paste a valid Audius track URL',
   missingRemixUrl: 'Must include a link to the original track',
   remixAccessError: 'Must have access to the original track',
-  enterLink: 'Enter an Audius Link',
-  changeAvailbilityPrefix: 'Availablity is set to',
-  changeAvailbilitySuffix: 'To enable these options, make your track free.'
+  enterLink: 'Enter an Audius Link'
 }
 
 const useStyles = makeStyles(({ palette, spacing, typography }) => ({

--- a/packages/web/src/components/edit/fields/RemixSettingsField/RemixSettingsMenuFields.tsx
+++ b/packages/web/src/components/edit/fields/RemixSettingsField/RemixSettingsMenuFields.tsx
@@ -29,11 +29,7 @@ const messages = {
     description:
       'Link your remix to the original track to increase visibility and credit the original artist.',
     linkLabel: 'Link to original track'
-  },
-  changeAvailabilityPrefix: 'Availablity is set to ',
-  changeAvailabilitySuffix: '. To enable these options, make your track free.',
-  collectibleGated: 'Collectible Gated',
-  specialAccess: 'Special Access'
+  }
 }
 
 export const RemixSettingsMenuFields = () => {

--- a/packages/web/src/components/edit/fields/RemixSettingsField/RemixSettingsMenuFields.tsx
+++ b/packages/web/src/components/edit/fields/RemixSettingsField/RemixSettingsMenuFields.tsx
@@ -38,7 +38,6 @@ const messages = {
   },
   changeAvailabilityPrefix: 'Availablity is set to ',
   changeAvailabilitySuffix: '. To enable these options, make your track free.',
-  premium: 'Premium (Pay-to-Unlock)',
   collectibleGated: 'Collectible Gated',
   specialAccess: 'Special Access'
 }
@@ -72,16 +71,10 @@ export const RemixSettingsMenuFields = () => {
 
   return (
     <div className={styles.fields}>
-      {isUSDCPurchaseGated ? (
-        <Hint icon={IconQuestionCircle}>
-          {`${messages.changeAvailabilityPrefix} ${messages.premium}${messages.changeAvailabilitySuffix}`}
-        </Hint>
-      ) : null}
       <SwitchRowField
         name={IS_REMIX}
         header={messages.remixOf.header}
         description={messages.remixOf.description}
-        disabled={isStreamGated}
       >
         <TextField name={REMIX_LINK} label={messages.remixOf.linkLabel} />
         {track ? <TrackInfo trackId={track.track_id} /> : null}

--- a/packages/web/src/components/edit/fields/RemixSettingsField/RemixSettingsMenuFields.tsx
+++ b/packages/web/src/components/edit/fields/RemixSettingsField/RemixSettingsMenuFields.tsx
@@ -2,13 +2,8 @@ import { useEffect } from 'react'
 
 import { useGetTrackByPermalink } from '@audius/common/api'
 import { useGatedContentAccess } from '@audius/common/hooks'
-import {
-  isContentCollectibleGated,
-  isContentUSDCPurchaseGated
-} from '@audius/common/models'
 import { accountSelectors } from '@audius/common/store'
 import { getPathFromTrackUrl } from '@audius/common/utils'
-import { Hint, IconQuestionCircle } from '@audius/harmony'
 import { useField } from 'formik'
 import { useSelector } from 'react-redux'
 import { useThrottle } from 'react-use'
@@ -17,7 +12,6 @@ import { Divider } from 'components/divider'
 import { TextField } from 'components/form-fields'
 
 import { SwitchRowField } from '../SwitchRowField'
-import { IS_STREAM_GATED, STREAM_CONDITIONS } from '../types'
 
 import styles from './RemixSettingsField.module.css'
 import { TrackInfo } from './TrackInfo'
@@ -43,8 +37,6 @@ const messages = {
 }
 
 export const RemixSettingsMenuFields = () => {
-  const [{ value: isStreamGated }] = useField(IS_STREAM_GATED)
-  const [{ value: streamConditions }] = useField(STREAM_CONDITIONS)
   const [{ value: trackUrl }] = useField(REMIX_LINK)
   const [, , { setValue: setCanRemixParent }] = useField(CAN_REMIX_PARENT)
   const permalink = useThrottle(getPathFromTrackUrl(trackUrl), 1000)
@@ -61,8 +53,6 @@ export const RemixSettingsMenuFields = () => {
   )
 
   const [, , { setValue: setParentTrackId }] = useField('parentTrackId')
-
-  const isUSDCPurchaseGated = isContentUSDCPurchaseGated(streamConditions)
 
   useEffect(() => {
     setParentTrackId(trackId)
@@ -82,23 +72,11 @@ export const RemixSettingsMenuFields = () => {
 
       <Divider />
 
-      {isStreamGated && !isUSDCPurchaseGated ? (
-        <Hint icon={IconQuestionCircle}>{`${
-          messages.changeAvailabilityPrefix
-        } ${
-          isContentCollectibleGated(streamConditions)
-            ? messages.collectibleGated
-            : messages.specialAccess
-        }${messages.changeAvailabilitySuffix}`}</Hint>
-      ) : null}
       <SwitchRowField
         name={SHOW_REMIXES}
         header={messages.hideRemix.header}
         description={messages.hideRemix.description}
         inverted
-        {...(isStreamGated && !isUSDCPurchaseGated
-          ? { checked: true, disabled: true }
-          : {})}
       />
     </div>
   )


### PR DESCRIPTION
### Description

- Removes the restriction preventing a track from being marked as a remix if it is access gated.
- Removes rule which forces `hide remixes` toggle to true when track is access gated

_Note: We already have a guard against remixing a track you don't have access to._
![Screenshot 2024-09-03 at 1 37 04 PM](https://github.com/user-attachments/assets/e91f8246-1ccb-48d9-9f28-5eebc626b7cc)


### How Has This Been Tested?

tested against local dev