### PR TITLE
[PAY-3389] Fix duplicate blast messages in 1:1 threads

### DIFF
--- a/comms/discovery/rpcz/chat_blast.go
+++ b/comms/discovery/rpcz/chat_blast.go
@@ -141,7 +141,7 @@ func chatBlast(tx *sqlx.Tx, userId int32, ts time.Time, params schema.ChatBlastR
 	// Formulate chat rpc messages for recipients who have an existing chat with sender
 	var outgoingMessages []OutgoingChatMessage
 	for _, result := range results {
-		messageID := result.ChatID + params.BlastID
+		messageID := params.BlastID + result.ChatID
 
 		outgoingMessages = append(outgoingMessages, OutgoingChatMessage{
 			ChatMessageRPC: schema.ChatMessageRPC{


### PR DESCRIPTION
### Description
Bug was that in the query (line 125 in same file) we were using `blast_id || chat_id` as the message_id, but then in the fan-outs we were using `chat_id + blast_id`. We should use the same ordering everywhere and respect the ordering in the db.

### How Has This Been Tested?

Confirmed bug repro on local dev without fix, confirmed fix eliminated bug.
