### PR TITLE
[PAY-3404] Fix floor() for negative numbers that are already floored

### DIFF
--- a/.changeset/hot-dolphins-complain.md
+++ b/.changeset/hot-dolphins-complain.md
@@ -1,0 +1,5 @@
+---
+'@audius/fixed-decimal': patch
+---
+
+Fix floor for negative numbers with no remainder

--- a/packages/fixed-decimal/src/FixedDecimal.test.ts
+++ b/packages/fixed-decimal/src/FixedDecimal.test.ts
@@ -130,6 +130,12 @@ describe('FixedDecimal', function () {
       expect(new FixedDecimal(4, 3).floor().toString()).toBe('4.000')
     })
 
+    it('floors no-op correctly', function () {
+      expect(new FixedDecimal(BigInt(-100000), 6).floor(2).toString()).toBe(
+        '-0.100000'
+      )
+    })
+
     it('floors large numbers correctly', function () {
       expect(
         new FixedDecimal(BigInt('1234567890123456789099999999999999999999'), 20)

--- a/packages/fixed-decimal/src/FixedDecimal.ts
+++ b/packages/fixed-decimal/src/FixedDecimal.ts
@@ -286,12 +286,16 @@ export class FixedDecimal<
       throw new RangeError('Digits must be non-negative')
     }
     const divisor = BigInt(10 ** digitsToRemove)
-    const signOffset =
-      this.value < 0 && this.value % divisor !== BigInt(0)
-        ? BigInt(-1 * 10 ** digitsToRemove)
-        : BigInt(0)
+    // Subtract one if negative w/ remainder
+    if (this.value < 0 && this.value % divisor !== BigInt(0)) {
+      return new FixedDecimal<BigIntBrand, BNBrand>({
+        value: ((this.value / divisor) * divisor - divisor) as BigIntBrand,
+        decimalPlaces: this.decimalPlaces
+      })
+    }
+    // Truncate otherwise
     return new FixedDecimal<BigIntBrand, BNBrand>({
-      value: ((this.value / divisor) * divisor + signOffset) as BigIntBrand,
+      value: ((this.value / divisor) * divisor) as BigIntBrand,
       decimalPlaces: this.decimalPlaces
     })
   }

--- a/packages/fixed-decimal/src/FixedDecimal.ts
+++ b/packages/fixed-decimal/src/FixedDecimal.ts
@@ -287,7 +287,7 @@ export class FixedDecimal<
     }
     const divisor = BigInt(10 ** digitsToRemove)
     const signOffset =
-      this.value < 0 && digitsToRemove > 0
+      this.value < 0 && this.value % divisor !== BigInt(0)
         ? BigInt(-1 * 10 ** digitsToRemove)
         : BigInt(0)
     return new FixedDecimal<BigIntBrand, BNBrand>({


### PR DESCRIPTION
### Description

Prior to this change, was erroneously "rounding down" negative numbers even when there was no remainder to round.

### How Has This Been Tested?

Added a test.