### PR TITLE
[PAY-3410][PAY-3406] Update Sales Table help link and "Value" => "Total"

### DIFF
--- a/packages/common/src/utils/linking.ts
+++ b/packages/common/src/utils/linking.ts
@@ -8,7 +8,8 @@ export const externalLinkAllowList = new Set([
   'link.audius.co',
   'audius.co',
   'discord.gg',
-  'solscan.io'
+  'solscan.io',
+  'help.audius.co'
 ])
 
 export const isAllowedExternalLink = (link: string) => {

--- a/packages/web/src/pages/pay-and-earn-page/components/SalesTab.tsx
+++ b/packages/web/src/pages/pay-and-earn-page/components/SalesTab.tsx
@@ -199,10 +199,11 @@ export const SalesTab = ({
           <IconMoneyBracket width={16} height={16} fill={color.neutral.n800} />
           <Text variant='body' size='s' textAlign='left'>
             {messages.networkSplitExplainer + ' '}
-            <ExternalTextLink to='' variant='visible'>
-              <Text variant='body' size='s' textAlign='left'>
-                {messages.learnMore}
-              </Text>
+            <ExternalTextLink
+              to='https://help.audius.co/help/network-fee'
+              variant='visible'
+            >
+              {messages.learnMore}
             </ExternalTextLink>
           </Text>
         </Flex>

--- a/packages/web/src/pages/pay-and-earn-page/components/SalesTable.tsx
+++ b/packages/web/src/pages/pay-and-earn-page/components/SalesTable.tsx
@@ -73,7 +73,7 @@ const renderValueCell = (cellInfo: PurchaseCell) => {
     BigInt(
       transaction.splits.find((s) => s.userId === transaction.sellerUserId)
         ?.amount || 0
-    )
+    ) + BigInt(transaction.extraAmount)
   ).toLocaleString()
   return total
 }

--- a/packages/web/src/pages/pay-and-earn-page/components/SalesTable.tsx
+++ b/packages/web/src/pages/pay-and-earn-page/components/SalesTable.tsx
@@ -3,8 +3,7 @@ import { MouseEvent, useCallback, useMemo } from 'react'
 import { useFeatureFlag } from '@audius/common/hooks'
 import { USDCPurchaseDetails } from '@audius/common/models'
 import { FeatureFlags } from '@audius/common/services'
-import { formatUSDCWeiToUSDString } from '@audius/common/utils'
-import { BN } from 'bn.js'
+import { USDC } from '@audius/fixed-decimal'
 import moment from 'moment'
 
 import { UserLink } from 'components/link'
@@ -70,8 +69,13 @@ const renderDateCell = (cellInfo: PurchaseCell) => {
 
 const renderValueCell = (cellInfo: PurchaseCell) => {
   const transaction = cellInfo.row.original
-  const total = new BN(transaction.amount).add(new BN(transaction.extraAmount))
-  return `$${formatUSDCWeiToUSDString(total)}`
+  const total = USDC(
+    BigInt(
+      transaction.splits.find((s) => s.userId === transaction.sellerUserId)
+        ?.amount || 0
+    )
+  ).toLocaleString()
+  return total
 }
 
 // Columns
@@ -105,7 +109,7 @@ const tableColumnMap = {
   },
   value: {
     id: 'value',
-    Header: 'Value',
+    Header: 'Total',
     accessor: 'amount',
     Cell: renderValueCell,
     maxWidth: 200,


### PR DESCRIPTION
### Description

- Updates the title of the "Value" column to be "Total"
- Updates the amount shown in "Value" to be the seller's amount (will need to revisit this during credit splits)
- Updates the link and adds the help.audius.co domain to the list of allowed "external" domains. (Also updates the link to not manually style the text after #9609 got merged)