### PR TITLE
[PAY-3412] Include network splits in CSV downloads of sales/purchases

### DIFF
--- a/packages/discovery-provider/src/queries/download_csv.py
+++ b/packages/discovery-provider/src/queries/download_csv.py
@@ -21,6 +21,10 @@ from src.utils.db_session import get_db_read_replica
 
 env = shared_config["discprov"]["env"]
 
+staking_bridge_usdc_payout_wallet = shared_config["solana"][
+    "staking_bridge_usdc_payout_wallet"
+]
+
 
 class DownloadPurchasesArgs(TypedDict):
     buyer_user_id: int
@@ -46,6 +50,7 @@ def get_purchases_or_sales(user_id: int, is_purchases: bool):
                     USDCPurchase.created_at.label("created_at"),
                     USDCPurchase.amount.label("amount"),
                     USDCPurchase.extra_amount.label("extra_amount"),
+                    USDCPurchase.splits.label("splits"),
                     User.handle.label("seller_handle"),
                     User.name.label("seller_name"),
                 )
@@ -61,6 +66,7 @@ def get_purchases_or_sales(user_id: int, is_purchases: bool):
                     USDCPurchase.created_at.label("created_at"),
                     USDCPurchase.amount.label("amount"),
                     USDCPurchase.extra_amount.label("extra_amount"),
+                    USDCPurchase.splits.label("splits"),
                     USDCPurchase.country.label("country"),
                     User.name.label("buyer_name"),
                 )
@@ -178,8 +184,26 @@ def download_sales(args: DownloadSalesArgs):
                 "link": get_link(result.content_type, seller_handle, result.slug),
                 "purchased by": result.buyer_name,
                 "date": result.created_at,
-                "value": get_dollar_amount(result.amount),
+                "sale price": get_dollar_amount(result.amount),
+                "network fee": next(
+                    (
+                        0 - get_dollar_amount(item["amount"])
+                        for item in result.splits
+                        if item["payout_wallet"] == staking_bridge_usdc_payout_wallet
+                    ),
+                    None,
+                ),
                 "pay extra": get_dollar_amount(result.extra_amount),
+                "total": next(
+                    (
+                        get_dollar_amount(
+                            str(int(item["amount"]) + int(result.extra_amount))
+                        )
+                        for item in result.splits
+                        if item["user_id"] == seller_user_id
+                    ),
+                    None,
+                ),
                 "country": result.country,
             },
             results,


### PR DESCRIPTION
Purchases:
```
title,link,artist,date,paid to artist,network fee,pay extra,total
title D25B,/handle8F89/title-d25b,name 8F89,2024-09-04 01:51:44.079978,1.107,0.123,3.21,4.44
```

Note: I went with "paid to artist" instead of "sale price" so that the sum of the columns could equal the total

Sales:
```
title,link,purchased by,date,sale price,network fee,pay extra,total,country
title 8D6D,/seller/title-8d6d,name F588,2024-09-04 01:35:34.730161,1.01,-0.101,3.02,3.929,
```


Adds a fair amount of technical debt we'll need to cover for credit splits. I think our whole "splits" system needs another iteration.