### PR TITLE
Show content title in chat blast item

### DIFF
--- a/packages/common/src/store/pages/chat/sagas.ts
+++ b/packages/common/src/store/pages/chat/sagas.ts
@@ -481,14 +481,12 @@ function* doCreateChatBlast(action: ReturnType<typeof createChatBlast>) {
       yield* put(goToChat({ chatId, presetMessage, replaceNavigation }))
     }
 
-    // TODO: fetch chat history
-    // try {
-    //   yield* call(doFetchChatIfNecessary, { chatId })
-    // } catch {}
     const existingChat = yield* select((state) => getChat(state, chatId))
     if (!existingChat) {
       const newBlast: ChatBlast = {
         chat_id: chatId,
+        audience_content_id: audienceContentId,
+        audience_content_type: audienceContentType,
         is_blast: true,
         last_message_at: dayjs().toISOString(),
         audience

--- a/packages/web/src/pages/chat-page/components/ChatBlastModal.tsx
+++ b/packages/web/src/pages/chat-page/components/ChatBlastModal.tsx
@@ -341,7 +341,7 @@ const RemixCreatorsMessageField = () => {
   const { data: remixedTracks } = useGetRemixedTracks({
     userId: currentUserId!
   })
-  const isDisabled = remixedTracks.length === 0
+  const isDisabled = remixedTracks?.length === 0
 
   const isSelected = value === ChatBlastAudience.REMIXERS
 


### PR DESCRIPTION
### Description
Previously chat blast creations were ignoring `audienceContentType` and `audienceContentId`, so all purchase/remix blasts were the same even if specific contents had been selected.

Also, display the content title in the chat blast item.

### How Has This Been Tested?

<img width="519" alt="Screenshot 2024-09-03 at 10 59 10 PM" src="https://github.com/user-attachments/assets/d9b524bc-1e55-45a5-aad1-c0059d083a47">

