### PR TITLE
getChatMessages respects audience content type and id

### DIFF
--- a/comms/discovery/db/queries/get_chat_messages.go
+++ b/comms/discovery/db/queries/get_chat_messages.go
@@ -120,7 +120,15 @@ func ChatMessagesAndReactions(q db.Queryable, ctx context.Context, arg ChatMessa
 		if len(parts) < 1 {
 			return nil, errors.New("bad request: invalid blast id")
 		}
-		audience := parts[0]
+		var audience, audience_content_type, audience_content_id string
+
+		audience = parts[0]
+		if len(parts) > 1 {
+			audience_content_type = parts[1]
+		}
+		if len(parts) > 2 {
+			audience_content_id = parts[2]
+		}
 
 		if schema.ChatBlastAudience(audience) == schema.FollowerAudience ||
 			schema.ChatBlastAudience(audience) == schema.TipperAudience ||
@@ -138,16 +146,20 @@ func ChatMessagesAndReactions(q db.Queryable, ctx context.Context, arg ChatMessa
 			FROM chat_blast b
 			WHERE b.from_user_id = $1
 			  AND b.audience = $3
-			  AND b.created_at < $4
-			  AND b.created_at > $5
+				AND b.audience_content_type = $4
+				AND b.audience_content_id = $5
+			  AND b.created_at < $6
+			  AND b.created_at > $7
 			ORDER BY b.created_at DESC
-			LIMIT $6
+			LIMIT $8
 			`
 
 			err := q.SelectContext(ctx, &rows, outgoingBlastMessages,
 				arg.UserID,
 				arg.ChatID,
 				audience,
+				audience_content_type,
+				audience_content_id,
 				arg.Before,
 				arg.After,
 				arg.Limit,


### PR DESCRIPTION
### Description
Previously all purchase/remix blasts were showing the same messages even if specific contents had been selected. Update the queries to take `audience_content_type` and `audience_content_id` into account.

### How Has This Been Tested?

Tested locally, confirmed 2 purchase blast threads with different contents were separate.