### PR TITLE
Fix purchasing without network split

### DIFF
--- a/.changeset/good-planets-give.md
+++ b/.changeset/good-planets-give.md
@@ -1,0 +1,5 @@
+---
+'@audius/sdk': patch
+---
+
+Fix purchases without network split

--- a/packages/libs/src/sdk/utils/preparePaymentSplits.ts
+++ b/packages/libs/src/sdk/utils/preparePaymentSplits.ts
@@ -22,7 +22,10 @@ export const prepareSplits = async ({
   claimableTokensClient: ClaimableTokensClient
   logger: LoggerService
 }) => {
-  const userSplitCount = splits.filter((s) => !s.userId).length
+  const userSplitCount = splits.filter((s) => !!s.userId).length
+  logger.debug(
+    `Splitting the extra ${extraAmount} between ${userSplitCount} user(s)...`
+  )
   // Convert splits to big int and spread extra amount to every split
   let amountSplits = splits.map((split, index) => {
     // Only give extra payments to users


### PR DESCRIPTION
### Description

Accidentally was filtering _out_ users, rather than filtering users _in_!

### How Has This Been Tested?

Tested with network split off in audius-cmd

Will cherry-pick before release!!