### PR TITLE
[QA-1512] Mediorum transcode fixes

### DIFF
--- a/mediorum/ddl/ddl.go
+++ b/mediorum/ddl/ddl.go
@@ -50,6 +50,12 @@ func Migrate(db *sql.DB, myHost string) {
 	runMigration(db, qmSyncTable)
 
 	runMigration(db, cleanUploadsAudioAnalysesDDL)
+
+	// cleanup crudr spam from blob not found errors
+	runMigration(db, `
+	delete from ops where
+	data->0->>'error' like 'blob (key%NotFound%'
+	`)
 }
 
 func runMigration(db *sql.DB, ddl string) {

--- a/mediorum/server/audio_analysis.go
+++ b/mediorum/server/audio_analysis.go
@@ -40,23 +40,16 @@ func (ss *MediorumServer) startAudioAnalyzer() {
 
 	time.Sleep(time.Minute)
 
+	// in prod... only look for old work on StoreAll nodes
+	// see transcode.go line 123 for longer comment
+	if ss.Config.Env == "prod" && !ss.Config.StoreAll {
+		return
+	}
+
 	// find old work from backlog
-	ticker := time.NewTicker(15 * time.Minute)
-	defer ticker.Stop()
-
 	for {
-		ctx, cancel := context.WithTimeout(context.Background(), 15*time.Minute)
-		go func() {
-			defer cancel()
-			ss.findMissedAudioAnalysisJobs(ctx, work)
-		}()
-
-		select {
-		case <-ticker.C:
-			cancel()
-		}
-
-		time.Sleep(time.Minute)
+		ss.findMissedAudioAnalysisJobs(context.Background(), work)
+		time.Sleep(time.Minute * 5)
 	}
 }
 

--- a/mediorum/server/repair.go
+++ b/mediorum/server/repair.go
@@ -321,7 +321,7 @@ func (ss *MediorumServer) repairCid(cid string, placementHosts []string, tracker
 	// don't delete if we replicated the blob within the past week
 	wasReplicatedThisWeek := attrs.CreateTime.After(time.Now().Add(-24 * 7 * time.Hour))
 
-	if !isPlaced && !ss.Config.StoreAll && tracker.CleanupMode && alreadyHave && myRank > ss.Config.ReplicationFactor+2 && !wasReplicatedThisWeek {
+	if !isPlaced && !ss.Config.StoreAll && tracker.CleanupMode && alreadyHave && myRank > ss.Config.ReplicationFactor*3 && !wasReplicatedThisWeek {
 		// if i'm the first node that over-replicated, keep the file for a week as a buffer since a node ahead of me in the preferred order will likely be down temporarily at some point
 		tracker.Counters["delete_over_replicated_needed"]++
 		err = ss.dropFromMyBucket(cid)

--- a/mediorum/server/repair.go
+++ b/mediorum/server/repair.go
@@ -319,9 +319,20 @@ func (ss *MediorumServer) repairCid(cid string, placementHosts []string, tracker
 	// check all healthy nodes ahead of me in the preferred order to ensure they have it.
 	// if R+1 healthy nodes in front of me have it, I can safely delete.
 	// don't delete if we replicated the blob within the past week
-	wasReplicatedThisWeek := attrs.CreateTime.After(time.Now().Add(-24 * 7 * time.Hour))
+	wasReplicatedThisWeek := attrs.ModTime.After(time.Now().Add(-24 * 7 * time.Hour))
 
-	if !isPlaced && !ss.Config.StoreAll && tracker.CleanupMode && alreadyHave && myRank > ss.Config.ReplicationFactor*3 && !wasReplicatedThisWeek {
+	// by default retain blob if our rank < ReplicationFactor+2
+	// but nodes with more free disk space will use a higher threshold
+	// to accomidate "spill over" from nodes that might be full or down.
+	rankThreshold := ss.Config.ReplicationFactor + 2
+	diskPercentFree := float64(ss.mediorumPathFree) / float64(ss.mediorumPathSize)
+	if diskPercentFree > 0.4 {
+		rankThreshold = ss.Config.ReplicationFactor * 3
+	} else if diskPercentFree > 0.2 {
+		rankThreshold = ss.Config.ReplicationFactor * 2
+	}
+
+	if !isPlaced && !ss.Config.StoreAll && tracker.CleanupMode && alreadyHave && myRank > rankThreshold && !wasReplicatedThisWeek {
 		// if i'm the first node that over-replicated, keep the file for a week as a buffer since a node ahead of me in the preferred order will likely be down temporarily at some point
 		tracker.Counters["delete_over_replicated_needed"]++
 		err = ss.dropFromMyBucket(cid)


### PR DESCRIPTION
### Description

Hash migration broke some assumptions around retry logic for transcode jobs... which was causing a lot of crud spam with failures.

We were planning to get rid of all this "implicit work queue" stuff and move transcode inline to upload request... which I think makes more sense now.

This is a temporary fix to only do retry logic to StoreAll nodes so as to cut down on the crud spam.