### PR TITLE
Revert change to create-audius-app until new SDK version is published

### DIFF
--- a/packages/create-audius-app/examples/react/src/App.tsx
+++ b/packages/create-audius-app/examples/react/src/App.tsx
@@ -87,7 +87,7 @@ export default function App() {
     if (trackId === playingTrackId) {
       setIsPlaying((prev) => !prev)
     } else {
-      setPlayingTrackSrc(await audiusSdk.tracks.getTrackStreamUrl({ trackId }))
+      setPlayingTrackSrc(await audiusSdk.tracks.streamTrack({ trackId }))
       setPlayingTrackId(trackId)
       setIsPlaying(true)
     }


### PR DESCRIPTION
### Description
I updated this in a previous PR to match the changes to the Tracks API in SDK. However, that version hasn't been published yet, so this change needs to wait.

### How Has This Been Tested?
N/A
