### PR TITLE
[PAY-3370] Always use encoded content IDs in chats

### DIFF
--- a/comms/discovery/db/queries/get_chat_messages.go
+++ b/comms/discovery/db/queries/get_chat_messages.go
@@ -139,7 +139,7 @@ func ChatMessagesAndReactions(q db.Queryable, ctx context.Context, arg ChatMessa
 			WHERE b.from_user_id = $1
 				AND concat_ws(':', audience, audience_content_type, 
 					CASE 
-						WHEN audience_content_id IS NOT NULL THEN hashids.encode(audience_content_id) 
+						WHEN audience_content_id IS NOT NULL THEN hashids.encode(audience_content_id, 'azowernasdfoia') 
 						ELSE NULL 
 					END) = $2
 			  AND b.created_at < $3

--- a/comms/discovery/db/queries/get_chat_messages.go
+++ b/comms/discovery/db/queries/get_chat_messages.go
@@ -139,7 +139,7 @@ func ChatMessagesAndReactions(q db.Queryable, ctx context.Context, arg ChatMessa
 			WHERE b.from_user_id = $1
 				AND concat_ws(':', audience, audience_content_type, 
 					CASE 
-						WHEN audience_content_id IS NOT NULL THEN hashids.encode(audience_content_id, 'azowernasdfoia') 
+						WHEN audience_content_id IS NOT NULL THEN id_encode(audience_content_id)
 						ELSE NULL 
 					END) = $2
 			  AND b.created_at < $3

--- a/comms/discovery/db/queries/get_chat_messages.go
+++ b/comms/discovery/db/queries/get_chat_messages.go
@@ -120,15 +120,7 @@ func ChatMessagesAndReactions(q db.Queryable, ctx context.Context, arg ChatMessa
 		if len(parts) < 1 {
 			return nil, errors.New("bad request: invalid blast id")
 		}
-		var audience, audience_content_type, audience_content_id string
-
-		audience = parts[0]
-		if len(parts) > 1 {
-			audience_content_type = parts[1]
-		}
-		if len(parts) > 2 {
-			audience_content_id = parts[2]
-		}
+		audience := parts[0]
 
 		if schema.ChatBlastAudience(audience) == schema.FollowerAudience ||
 			schema.ChatBlastAudience(audience) == schema.TipperAudience ||
@@ -145,21 +137,20 @@ func ChatMessagesAndReactions(q db.Queryable, ctx context.Context, arg ChatMessa
 				'[]'::json AS reactions
 			FROM chat_blast b
 			WHERE b.from_user_id = $1
-			  AND b.audience = $3
-				AND b.audience_content_type = $4
-				AND b.audience_content_id = $5
-			  AND b.created_at < $6
-			  AND b.created_at > $7
+				AND concat_ws(':', audience, audience_content_type, 
+					CASE 
+						WHEN audience_content_id IS NOT NULL THEN hashids.encode(audience_content_id) 
+						ELSE NULL 
+					END) = $2
+			  AND b.created_at < $3
+			  AND b.created_at > $4
 			ORDER BY b.created_at DESC
-			LIMIT $8
+			LIMIT $5
 			`
 
 			err := q.SelectContext(ctx, &rows, outgoingBlastMessages,
 				arg.UserID,
 				arg.ChatID,
-				audience,
-				audience_content_type,
-				audience_content_id,
 				arg.Before,
 				arg.After,
 				arg.Limit,

--- a/comms/discovery/db/queries/get_chats.go
+++ b/comms/discovery/db/queries/get_chats.go
@@ -61,7 +61,11 @@ WHERE chat_member.user_id = $1 AND chat_member.chat_id = $2
 union all (
 
   SELECT DISTINCT ON (audience, audience_content_type, audience_content_id)
-    concat_ws(':', audience, audience_content_type, audience_content_id) as chat_id,
+    concat_ws(':', audience, audience_content_type, 
+			CASE 
+				WHEN audience_content_id IS NOT NULL THEN hashids.encode(audience_content_id) 
+				ELSE NULL 
+			END) as chat_id,
     min(created_at) over (partition by audience, audience_content_type, audience_content_id) as created_at,
     plaintext as last_message,
 		max(created_at) over (partition by audience, audience_content_type, audience_content_id) as last_message_at,
@@ -76,7 +80,11 @@ union all (
 		audience_content_id
   FROM chat_blast b
   WHERE from_user_id = $1
-    AND concat_ws(':', audience, audience_content_type, audience_content_id) = $2
+    AND concat_ws(':', audience, audience_content_type, 
+			CASE 
+				WHEN audience_content_id IS NOT NULL THEN hashids.encode(audience_content_id) 
+				ELSE NULL 
+			END) = $2
   ORDER BY
     audience,
     audience_content_type,
@@ -122,7 +130,11 @@ WHERE chat_member.user_id = $1
 union all (
 
   SELECT DISTINCT ON (audience, audience_content_type, audience_content_id)
-    concat_ws(':', audience, audience_content_type, audience_content_id) as chat_id,
+    concat_ws(':', audience, audience_content_type, 
+			CASE 
+				WHEN audience_content_id IS NOT NULL THEN hashids.encode(audience_content_id) 
+				ELSE NULL 
+			END) as chat_id,
     min(created_at) over (partition by audience, audience_content_type, audience_content_id) as created_at,
     plaintext as last_message,
 		max(created_at) over (partition by audience, audience_content_type, audience_content_id) as last_message_at,
@@ -142,7 +154,6 @@ union all (
     audience_content_type,
     audience_content_id,
     created_at DESC
-
 )
 
 ORDER BY last_message_at DESC, chat_id

--- a/comms/discovery/db/queries/get_chats.go
+++ b/comms/discovery/db/queries/get_chats.go
@@ -63,7 +63,7 @@ union all (
   SELECT DISTINCT ON (audience, audience_content_type, audience_content_id)
     concat_ws(':', audience, audience_content_type, 
 			CASE 
-				WHEN audience_content_id IS NOT NULL THEN hashids.encode(audience_content_id, 'azowernasdfoia') 
+				WHEN audience_content_id IS NOT NULL THEN id_encode(audience_content_id)
 				ELSE NULL 
 			END) as chat_id,
     min(created_at) over (partition by audience, audience_content_type, audience_content_id) as created_at,
@@ -82,7 +82,7 @@ union all (
   WHERE from_user_id = $1
     AND concat_ws(':', audience, audience_content_type, 
 			CASE 
-				WHEN audience_content_id IS NOT NULL THEN hashids.encode(audience_content_id, 'azowernasdfoia') 
+				WHEN audience_content_id IS NOT NULL THEN id_encode(audience_content_id)
 				ELSE NULL 
 			END) = $2
   ORDER BY
@@ -132,7 +132,7 @@ union all (
   SELECT DISTINCT ON (audience, audience_content_type, audience_content_id)
     concat_ws(':', audience, audience_content_type, 
 			CASE 
-				WHEN audience_content_id IS NOT NULL THEN hashids.encode(audience_content_id, 'azowernasdfoia') 
+				WHEN audience_content_id IS NOT NULL THEN id_encode(audience_content_id)
 				ELSE NULL 
 			END) as chat_id,
     min(created_at) over (partition by audience, audience_content_type, audience_content_id) as created_at,

--- a/comms/discovery/db/queries/get_chats.go
+++ b/comms/discovery/db/queries/get_chats.go
@@ -63,7 +63,7 @@ union all (
   SELECT DISTINCT ON (audience, audience_content_type, audience_content_id)
     concat_ws(':', audience, audience_content_type, 
 			CASE 
-				WHEN audience_content_id IS NOT NULL THEN hashids.encode(audience_content_id) 
+				WHEN audience_content_id IS NOT NULL THEN hashids.encode(audience_content_id, 'azowernasdfoia') 
 				ELSE NULL 
 			END) as chat_id,
     min(created_at) over (partition by audience, audience_content_type, audience_content_id) as created_at,
@@ -82,7 +82,7 @@ union all (
   WHERE from_user_id = $1
     AND concat_ws(':', audience, audience_content_type, 
 			CASE 
-				WHEN audience_content_id IS NOT NULL THEN hashids.encode(audience_content_id) 
+				WHEN audience_content_id IS NOT NULL THEN hashids.encode(audience_content_id, 'azowernasdfoia') 
 				ELSE NULL 
 			END) = $2
   ORDER BY
@@ -132,7 +132,7 @@ union all (
   SELECT DISTINCT ON (audience, audience_content_type, audience_content_id)
     concat_ws(':', audience, audience_content_type, 
 			CASE 
-				WHEN audience_content_id IS NOT NULL THEN hashids.encode(audience_content_id) 
+				WHEN audience_content_id IS NOT NULL THEN hashids.encode(audience_content_id, 'azowernasdfoia') 
 				ELSE NULL 
 			END) as chat_id,
     min(created_at) over (partition by audience, audience_content_type, audience_content_id) as created_at,

--- a/packages/common/src/store/pages/chat/sagas.ts
+++ b/packages/common/src/store/pages/chat/sagas.ts
@@ -470,9 +470,12 @@ function* doCreateChatBlast(action: ReturnType<typeof createChatBlast>) {
       throw new Error('User not found')
     }
 
+    const encodedContentId = audienceContentId
+      ? encodeHashId(audienceContentId)
+      : undefined
     const chatId = makeBlastChatId({
       audience,
-      audienceContentId,
+      audienceContentId: encodedContentId,
       audienceContentType
     })
 
@@ -485,7 +488,7 @@ function* doCreateChatBlast(action: ReturnType<typeof createChatBlast>) {
     if (!existingChat) {
       const newBlast: ChatBlast = {
         chat_id: chatId,
-        audience_content_id: audienceContentId,
+        audience_content_id: encodedContentId,
         audience_content_type: audienceContentType,
         is_blast: true,
         last_message_at: dayjs().toISOString(),

--- a/packages/common/src/store/pages/chat/slice.ts
+++ b/packages/common/src/store/pages/chat/slice.ts
@@ -162,7 +162,7 @@ const slice = createSlice({
       _state,
       _action: PayloadAction<{
         audience: ChatBlastAudience
-        audienceContentId?: string
+        audienceContentId?: number
         audienceContentType?: 'track' | 'album'
         skipNavigation?: boolean
         presetMessage?: string

--- a/packages/mobile/src/screens/create-chat-blast-screen/ChatBlastSelectAudienceScreen.tsx
+++ b/packages/mobile/src/screens/create-chat-blast-screen/ChatBlastSelectAudienceScreen.tsx
@@ -19,7 +19,7 @@ const messages = {
 
 type ChatBlastFormValues = {
   target_audience: ChatBlastAudience
-  purchased_content_id?: string
+  purchased_content_id?: number
   remixed_track_id?: string
 }
 

--- a/packages/web/src/pages/chat-page/components/ChatBlastModal.tsx
+++ b/packages/web/src/pages/chat-page/components/ChatBlastModal.tsx
@@ -63,14 +63,14 @@ const messages = {
 const TARGET_AUDIENCE_FIELD = 'target_audience'
 
 type PurchasableContentOption = {
-  contentId: string
+  contentId: number
   contentType: 'track' | 'album'
 }
 
 type ChatBlastFormValues = {
   target_audience: ChatBlastAudience
   purchased_content_metadata?: PurchasableContentOption
-  remixed_track_id?: string
+  remixed_track_id?: number
 }
 
 export const ChatBlastModal = () => {


### PR DESCRIPTION
### Description
We should handle `audience_content_id` as encoded hash ID for all endpoints.

### How Has This Been Tested?

Tested locally, confirmed fetching chats, chat messages, and sending messages + blasts works as expected.