### PR TITLE
Fix purchasers count in chat blast modal

### DIFF
--- a/packages/common/src/api/user.ts
+++ b/packages/common/src/api/user.ts
@@ -213,13 +213,13 @@ const userApi = createApi({
           userId,
           contentId,
           contentType
-        }: { userId: ID; contentId?: string; contentType: string },
+        }: { userId: ID; contentId?: number; contentType: string },
         { audiusSdk }
       ) => {
         const sdk = await audiusSdk()
         const { data } = await sdk.full.users.getPurchasersCount({
           id: encodeHashId(userId),
-          contentId: contentId ? Id.parse(contentId) : undefined,
+          contentId: contentId ? encodeHashId(contentId) : undefined,
           contentType
         })
         return data ?? 0

--- a/packages/common/src/api/user.ts
+++ b/packages/common/src/api/user.ts
@@ -213,7 +213,7 @@ const userApi = createApi({
           userId,
           contentId,
           contentType
-        }: { userId: ID; contentId?: number; contentType: string },
+        }: { userId: ID; contentId?: number; contentType?: string },
         { audiusSdk }
       ) => {
         const sdk = await audiusSdk()

--- a/packages/common/src/api/user.ts
+++ b/packages/common/src/api/user.ts
@@ -213,7 +213,7 @@ const userApi = createApi({
           userId,
           contentId,
           contentType
-        }: { userId: ID; contentId?: number; contentType?: string },
+        }: { userId: ID; contentId?: number; contentType: string },
         { audiusSdk }
       ) => {
         const sdk = await audiusSdk()

--- a/packages/web/src/pages/chat-page/components/ChatListBlastItem.tsx
+++ b/packages/web/src/pages/chat-page/components/ChatListBlastItem.tsx
@@ -1,14 +1,10 @@
-import { useCallback, useMemo } from 'react'
+import { useCallback } from 'react'
 
 import {
   useGetCurrentUser,
-  useGetCurrentUserId,
   useGetPlaylistById,
-  useGetPurchasersCount,
-  useGetRemixersCount,
   useGetTrackById
 } from '@audius/common/api'
-import { usersSocialActions } from '@audius/common/store'
 import { Flex, IconTowerBroadcast, IconUser, Text } from '@audius/harmony'
 import { ChatBlast, ChatBlastAudience } from '@audius/sdk'
 import cn from 'classnames'
@@ -49,10 +45,9 @@ export const ChatListBlastItem = (props: ChatListBlastItemProps) => {
   } = chat
   const isCurrentChat = currentChatId && currentChatId === chatId
   const decodedContentId = audienceContentId
-    ? decodeHashId(audienceContentId) ?? undefined
+    ? decodeHashId(audienceContentId)
     : undefined
 
-  const { data: currentUserId } = useGetCurrentUserId({})
   const { data: user } = useGetCurrentUser()
   const { data: track } = useGetTrackById(
     {
@@ -67,46 +62,7 @@ export const ChatListBlastItem = (props: ChatListBlastItemProps) => {
     { disabled: !audienceContentId || audienceContentType !== 'album' }
   )
 
-  const { data: purchasersCount } = useGetPurchasersCount(
-    {
-      userId: currentUserId!,
-      contentId: decodedContentId,
-      contentType: audienceContentType
-    },
-    {
-      disabled: audience !== ChatBlastAudience.CUSTOMERS || !currentUserId
-    }
-  )
-  const { data: remixersCount } = useGetRemixersCount(
-    {
-      userId: currentUserId!,
-      trackId: decodedContentId
-    },
-    {
-      disabled: audience !== ChatBlastAudience.REMIXERS || !currentUserId
-    }
-  )
-
-  const audienceCount = useMemo(() => {
-    switch (audience) {
-      case ChatBlastAudience.FOLLOWERS:
-        return user.follower_count
-      case ChatBlastAudience.TIPPERS:
-        return user.supporter_count
-      case ChatBlastAudience.CUSTOMERS:
-        return purchasersCount
-      case ChatBlastAudience.REMIXERS:
-        return remixersCount
-      default:
-        return 0
-    }
-  }, [
-    audience,
-    user.follower_count,
-    user.supporter_count,
-    purchasersCount,
-    remixersCount
-  ])
+  const audienceCount = user?.follower_count ?? 0
 
   const handleClick = useCallback(() => {
     onChatClicked(chatId)


### PR DESCRIPTION
### Description
Need to encode the content id before requesting the purchasers count endpoint

### How Has This Been Tested?

<img width="507" alt="Screenshot 2024-09-04 at 4 34 16 PM" src="https://github.com/user-attachments/assets/1f2bfd44-1de0-4ca7-89a5-f5c0df5275ee">
