### PR TITLE
[PAY-3365] Chat reaction sets chat is_hidden to false

### DIFF
--- a/comms/discovery/rpcz/apply.go
+++ b/comms/discovery/rpcz/apply.go
@@ -250,7 +250,7 @@ func (proc *RPCProcessor) Apply(rpcLog *schema.RpcLog) error {
 			if err != nil {
 				return err
 			}
-			err = chatReactMessage(tx, userId, params.MessageID, params.Reaction, messageTs)
+			err = chatReactMessage(tx, userId, params.ChatID, params.MessageID, params.Reaction, messageTs)
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
### Description
On chat reaction, call `chatUpdateLatestFields` which will now set `is_hidden` to false if a reaction in that thread exists that was not created by the sender.

### How Has This Been Tested?

Tested locally, confirmed reaction from recipient causes 1-1 thread to appear on sender side.