### PR TITLE
[QA-1542] Fix mobile top supporters crashing profile page

### DIFF
--- a/packages/mobile/src/screens/notifications-screen/Notification/NotificationProfilePictureList.tsx
+++ b/packages/mobile/src/screens/notifications-screen/Notification/NotificationProfilePictureList.tsx
@@ -1,5 +1,5 @@
 import type { User } from '@audius/common/models'
-import { formatCount } from '@audius/common/utils'
+import { formatCount, removeNullable } from '@audius/common/utils'
 import type { StyleProp, ViewStyle } from 'react-native'
 import { View, Text } from 'react-native'
 
@@ -114,6 +114,7 @@ export const ProfilePictureList = (props: ProfilePictureListProps) => {
     <View style={[styles.root, style]}>
       {users
         .filter((u) => !u.is_deactivated)
+        .filter(removeNullable)
         .slice(0, sliceLimit)
         .map((user, idx) => (
           <NotificationProfilePicture

--- a/packages/mobile/src/screens/notifications-screen/Notification/NotificationProfilePictureList.tsx
+++ b/packages/mobile/src/screens/notifications-screen/Notification/NotificationProfilePictureList.tsx
@@ -1,5 +1,5 @@
 import type { User } from '@audius/common/models'
-import { formatCount, removeNullable } from '@audius/common/utils'
+import { formatCount } from '@audius/common/utils'
 import type { StyleProp, ViewStyle } from 'react-native'
 import { View, Text } from 'react-native'
 
@@ -114,7 +114,6 @@ export const ProfilePictureList = (props: ProfilePictureListProps) => {
     <View style={[styles.root, style]}>
       {users
         .filter((u) => !u.is_deactivated)
-        .filter(removeNullable)
         .slice(0, sliceLimit)
         .map((user, idx) => (
           <NotificationProfilePicture

--- a/packages/mobile/src/screens/profile-screen/ProfileHeader/TopSupporters.tsx
+++ b/packages/mobile/src/screens/profile-screen/ProfileHeader/TopSupporters.tsx
@@ -6,7 +6,10 @@ import {
   tippingSelectors,
   tippingActions
 } from '@audius/common/store'
-import { removeNullable } from '@audius/common/utils'
+import {
+  MAX_PROFILE_TOP_SUPPORTERS,
+  removeNullable
+} from '@audius/common/utils'
 import { Text, View } from 'react-native'
 import { TouchableOpacity } from 'react-native-gesture-handler'
 import { useDispatch, useSelector } from 'react-redux'
@@ -27,8 +30,6 @@ const messages = {
   topSupporters: 'Top Supporters',
   buttonTitle: 'View'
 }
-
-const MAX_PROFILE_SUPPORTERS_VIEW_ALL_USERS = 6
 
 const useStyles = makeStyles(({ spacing, palette, typography }) => ({
   root: {
@@ -126,7 +127,7 @@ export const TopSupporters = () => {
           <ProfilePictureList
             users={topSupporters}
             totalUserCount={supporter_count}
-            limit={MAX_PROFILE_SUPPORTERS_VIEW_ALL_USERS}
+            limit={MAX_PROFILE_TOP_SUPPORTERS}
             style={styles.profilePictureList}
             navigationType='push'
             interactive={false}
@@ -135,7 +136,7 @@ export const TopSupporters = () => {
         ) : (
           <ProfilePictureListSkeleton
             count={supporter_count}
-            limit={MAX_PROFILE_SUPPORTERS_VIEW_ALL_USERS}
+            limit={MAX_PROFILE_TOP_SUPPORTERS}
           />
         )}
         <View style={styles.alignRowCenter}>


### PR DESCRIPTION
### Description

Problem:
- The mismatch between the number of users fetched by topSupporters and the expected limit in the ProfilePictureList props caused an out of range lookup in `users`
- `NotificationProfilePicture` throws because of the undefined `profile.user_id`

Fix:
- Use the common constant for the expected user list limit

Side-effect:
- The user list now shows 5 users instead of 6. We could update the constant to fix this, but it would affect web too.

### How Has This Been Tested?

mobile no longer crashing on this profile and displays top supporters correctly
![image](https://github.com/user-attachments/assets/ede17d43-380a-42db-85e4-ad370a838000)
