### PR TITLE
[QA-1529] Add guard for -1 ids to audius-query api hooks

### DIFF
--- a/packages/common/src/api/collection.ts
+++ b/packages/common/src/api/collection.ts
@@ -28,7 +28,7 @@ const collectionApi = createApi({
         }: { playlistId: Nullable<ID>; currentUserId?: Nullable<ID> },
         { audiusSdk }
       ) => {
-        if (!playlistId) return null
+        if (!playlistId || playlistId === -1) return null
         const sdk = await audiusSdk()
         const { data = [] } = await sdk.full.playlists.getPlaylist({
           playlistId: Id.parse(playlistId),
@@ -44,7 +44,7 @@ const collectionApi = createApi({
       ) => {
         const sdk = await audiusSdk()
         const { data = [] } = await sdk.full.playlists.getBulkPlaylists({
-          id: ids.map((id) => Id.parse(id)),
+          id: ids.filter((id) => id && id !== -1).map((id) => Id.parse(id)),
           userId: OptionalId.parse(currentUserId)
         })
         return transformAndCleanList(data, userCollectionMetadataFromSDK)

--- a/packages/common/src/api/track.ts
+++ b/packages/common/src/api/track.ts
@@ -15,10 +15,8 @@ const trackApi = createApi({
         { id, currentUserId }: { id: ID; currentUserId?: Nullable<ID> },
         { audiusSdk }
       ) => {
+        if (!id || id === -1) return null
         const sdk = await audiusSdk()
-        if (!id || id === -1) {
-          return null
-        }
         const { data } = await sdk.full.tracks.getTrack({
           trackId: Id.parse(id),
           userId: OptionalId.parse(currentUserId)

--- a/packages/common/src/api/track.ts
+++ b/packages/common/src/api/track.ts
@@ -16,6 +16,9 @@ const trackApi = createApi({
         { audiusSdk }
       ) => {
         const sdk = await audiusSdk()
+        if (!id || id === -1) {
+          return null
+        }
         const { data } = await sdk.full.tracks.getTrack({
           trackId: Id.parse(id),
           userId: OptionalId.parse(currentUserId)
@@ -28,7 +31,7 @@ const trackApi = createApi({
       ) => {
         const sdk = await audiusSdk()
         const { data = [] } = await sdk.full.tracks.getBulkTracks({
-          id: ids.map((id) => Id.parse(id)),
+          id: ids.filter((id) => id && id !== -1).map((id) => Id.parse(id)),
           userId: OptionalId.parse(currentUserId)
         })
         return transformAndCleanList(data, userTrackMetadataFromSDK)

--- a/packages/common/src/api/user.ts
+++ b/packages/common/src/api/user.ts
@@ -52,6 +52,7 @@ const userApi = createApi({
         { id, currentUserId }: { id: ID; currentUserId?: Nullable<ID> },
         { audiusSdk }
       ) => {
+        if (!id || id === -1) return null
         const sdk = await audiusSdk()
         const { data: users = [] } = await sdk.full.users.getUser({
           id: Id.parse(id),
@@ -65,7 +66,7 @@ const userApi = createApi({
       ) => {
         const sdk = await audiusSdk()
         const { data: users = [] } = await sdk.full.users.getBulkUsers({
-          id: ids.map((id) => Id.parse(id)),
+          id: ids.filter((id) => id && id !== -1).map((id) => Id.parse(id)),
           userId: OptionalId.parse(currentUserId)
         })
         return userMetadataListFromSDK(users)


### PR DESCRIPTION
### Description

We're getting errors where `Id.parse` fails on id `-1` values. These values shouldn't make it into audius-query fetch in the first place, but adding guards since I wasn't able to track down the caller(s).

I have suspicion about https://github.com/AudiusProject/audius-protocol/blob/main/packages/web/src/components/track/helpers.ts#L16 but wasn't able to trace it to a `useGetTrackById` usage

### How Has This Been Tested?

this is a best effort change