### PR TITLE
core: retry registration faster and always persist app state

### DIFF
--- a/core/chain/abci.go
+++ b/core/chain/abci.go
@@ -45,8 +45,6 @@ func (app *CoreApplication) Info(ctx context.Context, info *abcitypes.InfoReques
 		return nil, err
 	}
 
-	app.logger.Infof("info called: %v", latest)
-
 	// if at genesis, tell comet there's no blocks indexed
 	if latest.BlockHeight < 2 {
 		return &abcitypes.InfoResponse{}, nil

--- a/core/chain/abci.go
+++ b/core/chain/abci.go
@@ -161,16 +161,14 @@ func (app *CoreApplication) FinalizeBlock(ctx context.Context, req *abcitypes.Fi
 		return &abcitypes.FinalizeBlockResponse{}, nil
 	}
 
+	var nextAppHash []byte
 	// use last app hash on empty blocks since state didn't change
 	if len(txs) == 0 {
-		return &abcitypes.FinalizeBlockResponse{
-			TxResults: txs,
-			AppHash:   prevAppState.AppHash,
-		}, nil
+		nextAppHash = prevAppState.AppHash
+	} else {
+		nextAppHash = app.serializeAppState(prevAppState.AppHash, req.GetTxs())
 	}
 
-	// persist latest app state when commited
-	nextAppHash := app.serializeAppState(prevAppState.AppHash, req.GetTxs())
 	app.getDb().UpsertAppState(ctx, db.UpsertAppStateParams{
 		BlockHeight: req.Height,
 		AppHash:     nextAppHash,

--- a/core/chain/abci.go
+++ b/core/chain/abci.go
@@ -104,14 +104,10 @@ func (app *CoreApplication) FinalizeBlock(ctx context.Context, req *abcitypes.Fi
 	var txs = make([]*abcitypes.ExecTxResult, len(req.Txs))
 
 	// open in progres pg transaction
-	err := app.startInProgressTx(ctx)
-	if err != nil {
-		app.logger.Errorf("start in progress tx fail: %v", err)
-	}
+	app.startInProgressTx(ctx)
 	for i, tx := range req.Txs {
 		protoEvent, err := app.isValidProtoEvent(tx)
 		if err == nil {
-			app.logger.Info("found proto event")
 			if err := app.finalizeEvent(ctx, protoEvent); err != nil {
 				app.logger.Errorf("error finalizing event: %v", err)
 				txs[i] = &abcitypes.ExecTxResult{Code: 2}
@@ -164,8 +160,6 @@ func (app *CoreApplication) FinalizeBlock(ctx context.Context, req *abcitypes.Fi
 		app.logger.Errorf("prev app state not found: %v", err)
 		return &abcitypes.FinalizeBlockResponse{}, nil
 	}
-
-	app.logger.Infof("prev app state %v", prevAppState)
 
 	nextAppHash := app.serializeAppState(prevAppState.AppHash, req.GetTxs())
 	// if empty block and previous was not genesis, use prior state

--- a/core/chain/abci.go
+++ b/core/chain/abci.go
@@ -105,15 +105,12 @@ func (app *CoreApplication) FinalizeBlock(ctx context.Context, req *abcitypes.Fi
 	logger := app.logger
 	var txs = make([]*abcitypes.ExecTxResult, len(req.Txs))
 
-	logger.Infof("finalize: %v", req)
-
 	// open in progres pg transaction
 	err := app.startInProgressTx(ctx)
 	if err != nil {
 		app.logger.Errorf("start in progress tx fail: %v", err)
 	}
 	for i, tx := range req.Txs {
-		app.logger.Infof("processing tx %d", i)
 		protoEvent, err := app.isValidProtoEvent(tx)
 		if err == nil {
 			app.logger.Info("found proto event")
@@ -121,7 +118,6 @@ func (app *CoreApplication) FinalizeBlock(ctx context.Context, req *abcitypes.Fi
 				app.logger.Errorf("error finalizing event: %v", err)
 				txs[i] = &abcitypes.ExecTxResult{Code: 2}
 			}
-			app.logger.Infof("proto event success %d", i)
 			txs[i] = &abcitypes.ExecTxResult{Code: abcitypes.CodeTypeOK}
 			continue
 		}
@@ -130,7 +126,6 @@ func (app *CoreApplication) FinalizeBlock(ctx context.Context, req *abcitypes.Fi
 			logger.Errorf("Error: invalid transaction index %v", i)
 			txs[i] = &abcitypes.ExecTxResult{Code: code}
 		} else {
-			logger.Infof("found kv store tx %d", i)
 			parts := bytes.SplitN(tx, []byte("="), 2)
 			key, value := parts[0], parts[1]
 			logger.Infof("Adding key %s with value %s", key, value)

--- a/core/chain/register_node.go
+++ b/core/chain/register_node.go
@@ -81,8 +81,6 @@ func (core *CoreApplication) finalizeRegisterNode(ctx context.Context, e *gen_pr
 		return fmt.Errorf("invalid register node event: %v", err)
 	}
 
-	core.logger.Info("finalizing register node")
-
 	qtx := core.getDb()
 
 	event := e.GetRegisterNode()

--- a/core/registry_bridge/bridge.go
+++ b/core/registry_bridge/bridge.go
@@ -1,10 +1,18 @@
 package registry_bridge
 
-import "time"
+import (
+	"context"
+	"time"
+)
 
 func (r *Registry) Start() error {
 	retries := 60
 	delay := 1 * time.Minute
+
+	if err := r.awaitNodeCatchup(context.Background()); err != nil {
+		return err
+	}
+
 	for {
 		if err := r.RegisterSelf(); err != nil {
 			r.logger.Errorf("node registration failed, will try again: %v", err)

--- a/core/registry_bridge/bridge.go
+++ b/core/registry_bridge/bridge.go
@@ -3,28 +3,20 @@ package registry_bridge
 import "time"
 
 func (r *Registry) Start() error {
-	timeToWait := 8 * time.Hour
-
-	// query local chain every 10 secs because it's free
-	if r.config.Environment == "dev" || r.config.Environment == "sandbox" {
-		timeToWait = 30 * time.Second
-	}
-
-	r.stopChan = make(chan struct{})
-
+	retries := 60
+	delay := 1 * time.Minute
 	for {
 		if err := r.RegisterSelf(); err != nil {
 			r.logger.Errorf("node registration failed, will try again: %v", err)
-		}
-
-		select {
-		case <-time.After(timeToWait):
-		case <-r.stopChan:
+			time.Sleep(delay)
+			retries -= 1
+			if retries == 0 {
+				r.logger.Warn("exhaused registration retries")
+				break
+			}
+		} else {
 			return nil
 		}
 	}
-}
-
-func (r *Registry) Stop() {
-	close(r.stopChan)
+	return nil
 }

--- a/core/registry_bridge/registry.go
+++ b/core/registry_bridge/registry.go
@@ -19,7 +19,6 @@ type Registry struct {
 	rpc       *local.Local
 	contracts *contracts.AudiusContracts
 	queries   *db.Queries
-	stopChan  chan struct{}
 }
 
 func NewRegistryBridge(logger *common.Logger, cfg *config.Config, rpc *local.Local, contracts *contracts.AudiusContracts, pool *pgxpool.Pool) (*Registry, error) {

--- a/core/run.go
+++ b/core/run.go
@@ -108,7 +108,6 @@ func run(logger *common.Logger) error {
 	defer e.Shutdown(ctx)
 	defer node.Stop()
 	defer grpcLis.Close()
-	defer registryBridge.Stop()
 	defer ethrpc.Close()
 
 	// console

--- a/core/sdk/sdk.go
+++ b/core/sdk/sdk.go
@@ -3,8 +3,12 @@
 package sdk
 
 import (
+	"context"
+	"time"
+
 	"github.com/AudiusProject/audius-protocol/core/gen/proto"
 	"github.com/cometbft/cometbft/rpc/client/http"
+	"golang.org/x/sync/errgroup"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
 )
@@ -24,29 +28,78 @@ func defaultSdk() *Sdk {
 	}
 }
 
+const (
+	retries = 10
+	delay   = 3 * time.Second
+)
+
 func initSdk(sdk *Sdk) error {
+	ctx := context.Background()
 	// TODO: add default environment here if not set
 
 	// TODO: add node selection logic here, based on environement, if endpoint not configured
 
+	g, ctx := errgroup.WithContext(ctx)
+
 	// initialize grpc client
 	if sdk.GRPCEndpoint != "" {
-		grpcConn, err := grpc.NewClient(sdk.GRPCEndpoint, grpc.WithTransportCredentials(insecure.NewCredentials()))
-		if err != nil {
-			return err
-		}
-		// TODO: add signing middleware here if privkey
-		grpcClient := proto.NewProtocolClient(grpcConn)
-		sdk.ProtocolClient = grpcClient
+		g.Go(func() error {
+			grpcConn, err := grpc.NewClient(sdk.GRPCEndpoint, grpc.WithTransportCredentials(insecure.NewCredentials()))
+			if err != nil {
+				return err
+			}
+
+			grpcClient := proto.NewProtocolClient(grpcConn)
+
+			for tries := retries; tries >= 0; tries-- {
+				_, err := grpcClient.Ping(ctx, &proto.PingRequest{})
+				if err == nil {
+					break
+				}
+
+				if tries == 0 {
+					sdk.logger.Error("exhausted grpc retries", "error", err, "endpoint", sdk.GRPCEndpoint)
+					return err
+				}
+
+				time.Sleep(delay)
+			}
+
+			sdk.ProtocolClient = grpcClient
+			return nil
+		})
 	}
 
 	// initialize jsonrpc client
 	if sdk.JRPCEndpoint != "" {
-		jrpcConn, err := http.New(sdk.JRPCEndpoint)
-		if err != nil {
-			return err
-		}
-		sdk.HTTP = *jrpcConn
+		g.Go(func() error {
+			jrpcConn, err := http.New(sdk.JRPCEndpoint)
+			if err != nil {
+				return err
+			}
+
+			for tries := retries; tries >= 0; tries-- {
+				_, err := jrpcConn.Health(ctx)
+				if err == nil {
+					break
+				}
+
+				if tries == 0 {
+					sdk.logger.Error("exhausted jrpc retries", "error", err, "endpoint", sdk.GRPCEndpoint)
+					return err
+				}
+
+				time.Sleep(delay)
+			}
+
+			sdk.HTTP = *jrpcConn
+			return nil
+		})
+	}
+
+	if err := g.Wait(); err != nil {
+		sdk.logger.Error("init sdk error", "error", err)
+		return err
 	}
 
 	if sdk.privKey == "" {


### PR DESCRIPTION
### Description
- node registration sometimes fails on startup as it's faster than the node catch up, this makes it retry quicker and fail after an hour
- always persists app state, even on empty blocks which was being left out before
### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._
