### PR TITLE
[PAY-3395] Chat sort order prefers blasts

### DIFF
--- a/comms/discovery/db/queries/get_chats.go
+++ b/comms/discovery/db/queries/get_chats.go
@@ -156,7 +156,7 @@ union all (
     created_at DESC
 )
 
-ORDER BY last_message_at DESC, chat_id
+ORDER BY last_message_at DESC, is_blast DESC, chat_id ASC
 LIMIT $2
 `
 


### PR DESCRIPTION
### Description
Enforce a server-side chat sort order where chats with `is_blast = true` are sorted before non-blast chats.

### How Has This Been Tested?

Tested query against stage, confirmed they line up with sort order of client.