### PR TITLE
[QA-1545] Fix cover art size on album search results

### DIFF
--- a/packages/web/src/components/collection/CollectionCard.test.tsx
+++ b/packages/web/src/components/collection/CollectionCard.test.tsx
@@ -79,7 +79,7 @@ describe('CollectionCard', () => {
     renderCollectionCard()
     expect(screen.getByTestId('cover-art-1')).toHaveAttribute(
       'src',
-      'image-small.jpg'
+      'image-medium.jpg'
     )
   })
 

--- a/packages/web/src/components/collection/CollectionCard.tsx
+++ b/packages/web/src/components/collection/CollectionCard.tsx
@@ -44,7 +44,7 @@ type CollectionCardProps = Omit<CardProps, 'id'> & {
 
 const cardSizeToCoverArtSizeMap = {
   xs: SquareSizes.SIZE_150_BY_150,
-  s: SquareSizes.SIZE_150_BY_150,
+  s: SquareSizes.SIZE_480_BY_480,
   m: SquareSizes.SIZE_480_BY_480,
   l: SquareSizes.SIZE_480_BY_480
 }


### PR DESCRIPTION
### Description

Was too low res. Box is 180x180, plus we have to account for `@2x` displays

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._

local stage