### PR TITLE
Set audienceContentType=track for remix chat blasts

### DIFF
--- a/.changeset/strong-emus-exist.md
+++ b/.changeset/strong-emus-exist.md
@@ -1,0 +1,5 @@
+---
+'@audius/sdk': patch
+---
+
+Chat blast audienceContentType = track if remixer audience

--- a/packages/libs/src/sdk/api/chats/ChatsApi.ts
+++ b/packages/libs/src/sdk/api/chats/ChatsApi.ts
@@ -57,15 +57,16 @@ import {
   TypedCommsResponse,
   UnfurlResponse
 } from './clientTypes'
-import type {
-  ChatInvite,
-  UserChat,
-  ChatMessage,
-  ChatWebsocketEventData,
-  RPCPayloadRequest,
-  ValidatedChatPermissions,
-  ChatCreateRPC,
-  UpgradableChatBlast
+import {
+  type ChatInvite,
+  type UserChat,
+  type ChatMessage,
+  type ChatWebsocketEventData,
+  type RPCPayloadRequest,
+  type ValidatedChatPermissions,
+  type ChatCreateRPC,
+  type UpgradableChatBlast,
+  ChatBlastAudience
 } from './serverTypes'
 
 const GENERIC_MESSAGE_ERROR = 'Error: this message cannot be displayed'
@@ -526,8 +527,13 @@ export class ChatsApi
       message,
       audience,
       audienceContentId,
-      audienceContentType
+      audienceContentType: audienceContentTypeParam
     } = await parseParams('messageBlast', ChatBlastMessageRequestSchema)(params)
+
+    let audienceContentType = audienceContentTypeParam
+    if (audience === ChatBlastAudience.REMIXERS && !!audienceContentId) {
+      audienceContentType = 'track'
+    }
 
     return await this.sendRpc({
       current_user_id: currentUserId,

--- a/packages/web/src/pages/chat-page/components/ChatBlastModal.tsx
+++ b/packages/web/src/pages/chat-page/components/ChatBlastModal.tsx
@@ -89,11 +89,15 @@ export const ChatBlastModal = () => {
       values.target_audience === ChatBlastAudience.CUSTOMERS
         ? values.purchased_content_metadata?.contentId
         : values.remixed_track_id
+    const audienceContentType =
+      values.target_audience === ChatBlastAudience.REMIXERS
+        ? 'track'
+        : values.purchased_content_metadata?.contentType
     dispatch(
       createChatBlast({
         audience: values.target_audience,
         audienceContentId,
-        audienceContentType: values.purchased_content_metadata?.contentType
+        audienceContentType
       })
     )
   }


### PR DESCRIPTION
### Description
Set `audienceContentType='track'` if a chat blast is created with remixer audience.

Also set a default at the API layer.

### How Has This Been Tested?

Against local web stage:
Tested the API default by not passing it in from client - confirmed backend is correct
Tested the normal case of passing in from client