### PR TITLE
[QA-1513] Remove validation on payout wallet

### DIFF
--- a/packages/discovery-provider/src/tasks/entity_manager/entities/user.py
+++ b/packages/discovery-provider/src/tasks/entity_manager/entities/user.py
@@ -163,18 +163,6 @@ def validate_user_metadata(
         if str(pubkey) != wallet:
             raise IndexingValidationError(f"Invalid spl address {wallet}")
 
-        account_info = solana_client_manager.get_account_info_json_parsed(pubkey)
-
-        if account_info.owner != SPL_TOKEN_PUBKEY:
-            raise IndexingValidationError(
-                f"Spl address is not a token account {wallet}"
-            )
-
-        if account_info.data.parsed["info"]["mint"] != USDC_MINT:
-            raise IndexingValidationError(
-                f"Spl address is not a USDC token account {wallet}"
-            )
-
 
 def validate_user_handle(handle: Union[str, None]):
     if not handle:


### PR DESCRIPTION
### Description

Currently if a solana RPC node that a DN uses is behind the one that the client uses, we can end up in a situation where indexing payout wallets fails.

A prior version of this PR did some retry on the validation, but the truth is I don't think we should have this at all because:
1. If you try to pay a recipient that isn't a valid USDC token account, the purchase will fail (no $ is lost)
2. If we wanted to do some validation API side we could, but that feels kind of ick to me -- slower API request and also nothing you really can do in that situation except have clients be smarter.

So... just remove the validation. We do validation on audius.co anyway.

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._
