### PR TITLE
[QA-1528] Move audius-query force ref tracking to useState

### DIFF
--- a/packages/common/src/api/account.ts
+++ b/packages/common/src/api/account.ts
@@ -36,9 +36,7 @@ const accountApi = createApi({
         const account = await audiusBackend.getAccount()
         return account?.user_id || null
       },
-      options: {
-        type: 'query'
-      }
+      options: {}
     },
     getCurrentWeb3User: {
       async fetch(_, { audiusBackend }) {
@@ -46,7 +44,6 @@ const accountApi = createApi({
         return libs.Account?.getWeb3User() as UserMetadata | null
       },
       options: {
-        type: 'query',
         // Note that this schema key is used to prevent caching of the
         // web3 user as it does not match the standard user schema.
         schemaKey: 'currentWeb3User'
@@ -75,8 +72,6 @@ const accountApi = createApi({
         return managedUserListFromSDK(data)
       },
       options: {
-        type: 'query',
-        idArgKey: 'manager.user_id',
         schemaKey: 'managedUsers'
       }
     },
@@ -92,8 +87,6 @@ const accountApi = createApi({
         return userManagerListFromSDK(data)
       },
       options: {
-        type: 'query',
-        idArgKey: 'user.user_id',
         schemaKey: 'userManagers'
       }
     },
@@ -113,7 +106,6 @@ const accountApi = createApi({
         return payload
       },
       options: {
-        idArgKey: 'managerUser.user_id',
         type: 'mutation',
         schemaKey: 'userManagers'
       },
@@ -162,7 +154,6 @@ const accountApi = createApi({
         return payload
       },
       options: {
-        idArgKey: 'managerUserId',
         type: 'mutation',
         schemaKey: 'userManagers'
       },

--- a/packages/common/src/api/comments.ts
+++ b/packages/common/src/api/comments.ts
@@ -75,7 +75,7 @@ const commentsApi = createApi({
         // We ultimately only use this query expecting to hit the cache
         return undefined
       },
-      options: { type: 'query' }
+      options: {}
     },
     getCommentRepliesById: {
       async fetch(


### PR DESCRIPTION
### Description

`useRef` does not cause a rerender on value changed. This caused `useQuery` to not rerender after `fetchData` set the force flag back to false. `useQuery` manually sets the `LOADING` status as long as `force.current === 'forcing'` but we never got a rerender trigger after the fresh data came back if the value of the data didn't actually change.

Moved the force tracking to `useState` which triggers rerenders on value update. This resolved the issue.

Also cleaned up some endpoint options:
- 'query' is the default endpoint type
- `idArgKey` was being used incorrectly. It only applies to entities available in the legacy entity cache when the `kind` option is also provided

### How Has This Been Tested?

Accounts you manage settings modal no longer infinite loads. Also checked that it does properly fetch new data on every open of the modal.