### PR TITLE
fix type for spl_usdc_payout_wallet on user adapter

### DIFF
--- a/packages/common/src/adapters/user.ts
+++ b/packages/common/src/adapters/user.ts
@@ -55,6 +55,7 @@ export const userMetadataFromSDK = (
     total_balance: input.totalBalance as StringWei,
     user_id: decodedUserId,
     spl_wallet: input.splWallet as SolanaWalletAddress,
+    spl_usdc_payout_wallet: input.splUsdcPayoutWallet as SolanaWalletAddress,
 
     // Legacy Overrides
     cover_photo: input.coverPhotoLegacy ?? null,


### PR DESCRIPTION
### Description
#9651 updated the type returned from SDK to include `spl_usdc_payout_wallet`, typed as a string. This need an explicit cast in our user adapter to be compatible with the type for `UserMetadata`

### How Has This Been Tested?
N/A as it's just a type fix
