### PR TITLE
[C-4942] Add un-authed logic to web comments

### DIFF
--- a/packages/common/src/context/comments/commentsHooks.ts
+++ b/packages/common/src/context/comments/commentsHooks.ts
@@ -32,14 +32,13 @@ export const usePostComment = () => {
   return [wrappedHandler, postCommentResponse] as const
 }
 
-export const useReactToComment = () => {
+export const useReactToComment = (authFlowCallback?: () => void) => {
   const [reactToComment, reactToCommentResponse] = useReactToCommentById()
   const { currentUserId } = useCurrentCommentSection()
   const wrappedHandler = async (commentId: string, isLiked: boolean) => {
     if (currentUserId) {
       reactToComment({ id: commentId, userId: currentUserId, isLiked })
     }
-    // TODO: trigger auth flow here
   }
   return [wrappedHandler, reactToCommentResponse] as const
 }

--- a/packages/web/src/components/comments/CommentActionBar.tsx
+++ b/packages/web/src/components/comments/CommentActionBar.tsx
@@ -22,13 +22,19 @@ import {
   TextLink
 } from '@audius/harmony'
 import { Comment, ReplyComment } from '@audius/sdk'
+import { useDispatch } from 'react-redux'
 import { useToggle } from 'react-use'
 
 import { DownloadMobileAppDrawer } from 'components/download-mobile-app-drawer/DownloadMobileAppDrawer'
+import {
+  openAuthModal,
+  useAuthenticatedCallback
+} from 'hooks/useAuthenticatedCallback'
 import { useIsMobile } from 'hooks/useIsMobile'
 
 const messages = {
   pin: (isPinned: boolean) => (isPinned ? 'Unpin Comment' : 'Pin Comment'),
+  reply: 'Reply',
   edit: 'Edit Comment',
   delete: 'Delete Comment',
   report: 'Report Comment',
@@ -57,6 +63,7 @@ export const CommentActionBar = ({
 
   // context actions & values
   const { currentUserId, isEntityOwner } = useCurrentCommentSection()
+  const dispatch = useDispatch()
 
   const [reactToComment] = useReactToComment()
   const [pinComment] = usePinComment()
@@ -70,7 +77,7 @@ export const CommentActionBar = ({
   const isUserGettingNotifs = true // TODO: Need to set up API to provide this
   const notificationsMuted = false // TODO: Need to set up API to provide this
 
-  const handleCommentReact = useCallback(() => {
+  const handleCommentReact = useAuthenticatedCallback(() => {
     setReactionState(!reactionState)
     reactToComment(commentId, !reactionState)
   }, [commentId, reactToComment, reactionState])
@@ -87,9 +94,13 @@ export const CommentActionBar = ({
     if (isMobile) {
       toggleIsMobileAppDrawer()
     } else {
-      onClickReply()
+      if (currentUserId === undefined) {
+        openAuthModal(dispatch)
+      } else {
+        onClickReply()
+      }
     }
-  }, [isMobile, onClickReply, toggleIsMobileAppDrawer])
+  }, [currentUserId, dispatch, isMobile, onClickReply, toggleIsMobileAppDrawer])
 
   const popupMenuItems = useMemo(() => {
     let items: PopupMenuItem[] = []
@@ -168,7 +179,7 @@ export const CommentActionBar = ({
         size='m'
         disabled={isDisabled}
       >
-        Reply
+        {messages.reply}
       </TextLink>
 
       <PopupMenu
@@ -184,7 +195,11 @@ export const CommentActionBar = ({
               if (isMobile) {
                 toggleIsMobileAppDrawer()
               } else {
-                triggerPopup()
+                if (currentUserId === undefined) {
+                  openAuthModal(dispatch)
+                } else {
+                  triggerPopup()
+                }
               }
             }}
           />

--- a/packages/web/src/components/comments/CommentSectionDesktop.tsx
+++ b/packages/web/src/components/comments/CommentSectionDesktop.tsx
@@ -1,6 +1,8 @@
 import { useEffect, useRef } from 'react'
 
 import { useCurrentCommentSection } from '@audius/common/context'
+import { useFeatureFlag } from '@audius/common/hooks'
+import { FeatureFlags } from '@audius/common/services'
 import { Button, Divider, Flex, LoadingSpinner, Paper } from '@audius/harmony'
 import InfiniteScroll from 'react-infinite-scroller'
 
@@ -31,7 +33,10 @@ export const CommentSectionDesktop = () => {
   } = useCurrentCommentSection()
 
   const mainContentRef = useMainContentRef()
-  const commentPostAllowed = currentUserId !== null
+  const { isEnabled: commentPostFlag = false } = useFeatureFlag(
+    FeatureFlags.COMMENT_POSTING_ENABLED
+  )
+  const commentPostAllowed = currentUserId !== undefined && commentPostFlag
   const commentSectionRef = useRef<HTMLDivElement | null>(null)
 
   // Need refs for these values because the scroll handler will not be able to access state changes
@@ -64,7 +69,7 @@ export const CommentSectionDesktop = () => {
         Refresh{' '}
       </Button>
       <Paper w='100%' direction='column'>
-        {commentPostAllowed !== null ? (
+        {commentPostAllowed ? (
           <>
             <Flex gap='s' p='xl' w='100%' direction='column'>
               <CommentForm />

--- a/packages/web/src/hooks/useAuthenticatedCallback.ts
+++ b/packages/web/src/hooks/useAuthenticatedCallback.ts
@@ -2,6 +2,7 @@ import { MouseEvent as ReactMouseEvent, useCallback } from 'react'
 
 import { accountSelectors } from '@audius/common/store'
 import { useDispatch } from 'react-redux'
+import { Dispatch } from 'redux'
 
 import {
   openSignOn,
@@ -9,6 +10,14 @@ import {
 } from 'common/store/pages/signon/actions'
 import { useSelector } from 'utils/reducer'
 const { getHasAccount } = accountSelectors
+
+/**
+ * Static callback that can be used to auth modal opening logic
+ * */
+export const openAuthModal = (dispatch: Dispatch) => {
+  dispatch(openSignOn(/** signIn */ false))
+  dispatch(showRequiresAccountModal())
+}
 
 /**
  * Like useCallback but designed to be used to redirect unauthenticated users
@@ -26,8 +35,7 @@ export const useAuthenticatedCallback = <T extends (...args: any) => any>(
   return useCallback(
     (...args: Parameters<T>) => {
       if (!isSignedIn) {
-        dispatch(openSignOn(/** signIn */ false))
-        dispatch(showRequiresAccountModal())
+        openAuthModal(dispatch)
       } else {
         // eslint-disable-next-line n/no-callback-literal
         return callback(...args)


### PR DESCRIPTION
### Description

Triggers auth modal when you interact with comments (react, reply, overflow menu) while being signed out
![2024-09-09 12 14 52](https://github.com/user-attachments/assets/193dcb9c-c372-41d6-ac60-16925f8fac7a)



### How Has This Been Tested?

web:stage
