### PR TITLE
[QA-1711] Fix remix field not editable

### DIFF
--- a/packages/web/src/components/data-entry/ContextualMenu.module.css
+++ b/packages/web/src/components/data-entry/ContextualMenu.module.css
@@ -38,6 +38,7 @@
 }
 
 .selectedValue {
+  position: relative;
   height: 28px;
   display: inline-flex;
   align-self: flex-start;


### PR DESCRIPTION
### Description
Fixes issue where remix field was not editable because there was an absolutely postioned read-only element above the input field, because it's container wasn't position: relative