### PR TITLE
[QA-1564] Redirect to feed if user is already authed

### DIFF
--- a/packages/web/src/pages/sign-on-page/SignOnPage.tsx
+++ b/packages/web/src/pages/sign-on-page/SignOnPage.tsx
@@ -1,5 +1,6 @@
 import { ReactNode, useEffect, useLayoutEffect, useRef, useState } from 'react'
 
+import { FEED_PAGE } from '@audius/common/src/utils/route'
 import { route } from '@audius/common/utils'
 import {
   Box,
@@ -10,14 +11,15 @@ import {
   TextLink,
   useTheme
 } from '@audius/harmony'
-import { useDispatch } from 'react-redux'
-import { Link, Route, Switch, useRouteMatch } from 'react-router-dom'
+import { useDispatch, useSelector } from 'react-redux'
+import { Link, Redirect, Route, Switch, useRouteMatch } from 'react-router-dom'
 import { useEffectOnce, useLocation, useMeasure } from 'react-use'
 
 import djBackground from 'assets/img/2-DJ-4-3.jpg'
 import djPortrait from 'assets/img/DJportrait.jpg'
 import imagePhone from 'assets/img/imagePhone.png'
 import { fetchReferrer } from 'common/store/pages/signon/actions'
+import { getHasCompletedAccount } from 'common/store/pages/signon/selectors'
 import { useMedia } from 'hooks/useMedia'
 import { SignInPage } from 'pages/sign-in-page'
 import { AudiusValues } from 'pages/sign-on-page/AudiusValues'
@@ -273,6 +275,7 @@ const MobileSignOnRoot = (props: MobileSignOnRootProps) => {
 
 export const SignOnPage = () => {
   const { isMobile } = useMedia()
+  const hasCompletedAccount = useSelector(getHasCompletedAccount)
   const location = useLocation()
   const dispatch = useDispatch()
 
@@ -290,6 +293,10 @@ export const SignOnPage = () => {
   useEffectOnce(() => {
     setIsLoaded(true)
   })
+
+  if (hasCompletedAccount) {
+    return <Redirect to={FEED_PAGE} />
+  }
 
   return (
     <SignOnRoot isLoaded={isLoaded}>


### PR DESCRIPTION
### Description

![2024-09-10 11 03 49](https://github.com/user-attachments/assets/4afb9ed2-a806-4cea-a509-92e5ae9ff3fc)

If you go to https://staging.audius.co/signin it will still show sign in even if you're already signed in.

This selector is what we already use in mobile to do the same thing.

note: sign up routes are redirecting properly, its just sign in

### How Has This Been Tested?

- [x] Navigating directly to /signin now redirects to /feed
- [x] Signin page still shows if you're signed out 
