### PR TITLE
QA-1378: fix withdrawal history extra grey space

### DIFF
--- a/packages/web/src/pages/pay-and-earn-page/components/WithdrawalsTab.tsx
+++ b/packages/web/src/pages/pay-and-earn-page/components/WithdrawalsTab.tsx
@@ -327,7 +327,6 @@ export const WithdrawalsTab = ({
           onSort={onSort}
           onClickRow={onClickRow}
           fetchMore={fetchMore}
-          isVirtualized={true}
           scrollRef={mainContentRef}
           totalRowCount={count}
           fetchBatchSize={TRANSACTIONS_BATCH_SIZE}


### PR DESCRIPTION
### Description
- turns off react virtualized for withdrawal page which matches how the purchase history works
- 
<img width="2046" alt="Screenshot 2024-09-10 at 11 32 57 AM" src="https://github.com/user-attachments/assets/4ef414cf-5444-4a77-9971-13ef66ba36a7">

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._
