### PR TITLE
[QA-808] Clip long artist names on mobile signup

### DIFF
--- a/packages/mobile/src/components/core/UserDisplayName.tsx
+++ b/packages/mobile/src/components/core/UserDisplayName.tsx
@@ -31,8 +31,15 @@ export const UserDisplayName = (props: UserDisplayProps) => {
   const badgeSize = fontSize - 2
 
   return (
-    <Flex direction='row' gap='xs' alignItems='center' style={style}>
-      <Text variant={variant} size={size} {...other}>
+    <Flex
+      direction='row'
+      gap='xs'
+      alignItems='center'
+      style={style}
+      w='100%'
+      ph={isVerified ? 'xl' : 'l'}
+    >
+      <Text ellipses variant={variant} size={size} {...other} numberOfLines={1}>
         {displayName}
       </Text>
       {isVerified ? (

--- a/packages/mobile/src/components/core/UserDisplayName.tsx
+++ b/packages/mobile/src/components/core/UserDisplayName.tsx
@@ -32,7 +32,7 @@ export const UserDisplayName = (props: UserDisplayProps) => {
 
   return (
     <Flex
-      direction='row'
+      row
       gap='xs'
       alignItems='center'
       style={style}

--- a/packages/mobile/src/components/core/UserDisplayName.tsx
+++ b/packages/mobile/src/components/core/UserDisplayName.tsx
@@ -36,7 +36,6 @@ export const UserDisplayName = (props: UserDisplayProps) => {
       gap='xs'
       alignItems='center'
       style={style}
-      w='100%'
       ph={isVerified ? 'xl' : 'l'}
     >
       <Text ellipses variant={variant} size={size} {...other} numberOfLines={1}>


### PR DESCRIPTION
### Description
Long names were overflowing on signup flow artist cards

### How Has This Been Tested?

![Simulator Screenshot - iPhone 15 Pro - 2024-09-10 at 11 39 59](https://github.com/user-attachments/assets/eda27cee-03ce-4fb8-a478-0ebd487a8c8e)
