### PR TITLE
QA-1028: disable artist preview on signup for users with no tracks

### DIFF
--- a/packages/web/src/components/follow-artist-card/FollowArtistCard.tsx
+++ b/packages/web/src/components/follow-artist-card/FollowArtistCard.tsx
@@ -54,6 +54,7 @@ export const FollowArtistCard = (props: FollowArtistTileProps) => {
   } = useContext(SelectArtistsPreviewContext)
 
   const isPlaying = isPreviewPlaying && nowPlayingArtistId === user_id
+  const hasTracks = track_count && track_count > 0
 
   const [avatar] = useHover((isHovered) => (
     <Box w={72} h={72} css={{ position: 'absolute', top: 34 }}>
@@ -63,7 +64,7 @@ export const FollowArtistCard = (props: FollowArtistTileProps) => {
         justifyContent='center'
         alignItems='center'
         css={{
-          visibility: isHovered || isPlaying ? 'visible' : 'hidden',
+          visibility: (isHovered || isPlaying) && hasTracks ? 'visible' : 'hidden',
           pointerEvents: 'none',
           position: 'absolute',
           top: 0,
@@ -75,17 +76,21 @@ export const FollowArtistCard = (props: FollowArtistTileProps) => {
           zIndex: 2
         }}
       >
-        {isPlaying ? (
+        {hasTracks ?
+          isPlaying ? (
           <IconPause size='l' color='staticWhite' />
         ) : (
           <Box pl='xs'>
             <IconPlay size='l' color='staticWhite' />
           </Box>
-        )}
+          )
+          : null
+        }
       </Flex>
       <Avatar
         variant='strong'
         userId={user_id}
+        css={{ cursor: hasTracks ? "pointer" : "default" }}
         onClick={() => {
           dispatch(
             make(Name.CREATE_ACCOUNT_ARTIST_PREVIEWED, {
@@ -93,7 +98,9 @@ export const FollowArtistCard = (props: FollowArtistTileProps) => {
               artistID: user_id
             })
           )
-          togglePreview(user_id)
+          if (hasTracks) {
+            togglePreview(user_id)
+          }
         }}
       />
     </Box>

--- a/packages/web/src/components/follow-artist-card/selectArtistsPreviewContext.tsx
+++ b/packages/web/src/components/follow-artist-card/selectArtistsPreviewContext.tsx
@@ -38,7 +38,7 @@ export const SelectArtistsPreviewContextProvider = (props: {
   })
   const { data: artistTracks } = useGetUserTracksByHandle(
     {
-      handle: artist!.handle,
+      handle: artist?.handle || "",
       currentUserId: null,
       // Unlikely we cant play an artist's first 3 tracks.
       limit: 3


### PR DESCRIPTION
### Description
Users with no tracks are sometimes recommended on sign up. This disables a play button for them until a track is uploaded.

### How Has This Been Tested?
`npm run web:prod`
