### PR TITLE
[QA-1714] Fix mobile web track-page loading

### DIFF
--- a/packages/web/src/components/track/mobile/TrackTile.tsx
+++ b/packages/web/src/components/track/mobile/TrackTile.tsx
@@ -359,16 +359,19 @@ const TrackTile = (props: CombinedProps) => {
               isActive={isActive}
               applyHoverStylesToInnerSvg
             >
-              <Text ellipses>{title}</Text>
+              <Text ellipses>{title || messages.loading}</Text>
               {isPlaying ? <IconVolume size='m' /> : null}
-              {showSkeleton && (
+              {showSkeleton ? (
                 <Skeleton className={styles.skeleton} height='20px' />
-              )}
+              ) : null}
             </TextLink>
             <UserLink userId={userId} badgeSize='xs'>
-              {showSkeleton && (
-                <Skeleton className={styles.skeleton} height='20px' />
-              )}
+              {showSkeleton ? (
+                <>
+                  <Text>{messages.loading}</Text>
+                  <Skeleton className={styles.skeleton} height='20px' />
+                </>
+              ) : null}
             </UserLink>
           </Flex>
           {coSign && (

--- a/packages/web/src/components/track/trackTileMessages.ts
+++ b/packages/web/src/components/track/trackTileMessages.ts
@@ -8,5 +8,6 @@ export const messages = {
   played: 'Played',
   reposted: 'Reposted',
   repostedAndFavorited: 'Reposted & Favorited',
-  timeLeft: 'left'
+  timeLeft: 'left',
+  loading: 'Loading...'
 }


### PR DESCRIPTION
### Description

Fixes really poor track tile loading on mobile web. This is defintely a bit of a hack, but honestly happy with it given mobile web. Essentially this ensures `Text` component always has text in it, so the skeleton can properly overlay on top of it. The "loading" text will actually never show up.