### PR TITLE
[QA-1553] Remove extra space below mobile profile socials

### DIFF
--- a/packages/mobile/src/screens/profile-screen/ProfileHeader/ProfileSocials.tsx
+++ b/packages/mobile/src/screens/profile-screen/ProfileHeader/ProfileSocials.tsx
@@ -23,16 +23,14 @@ const { fetchUserSocials } = cacheUsersActions
 const useStyles = makeStyles(({ spacing }) => ({
   root: {
     flexDirection: 'row',
-    alignItems: 'center',
-    height: 50
+    alignItems: 'center'
   },
   audioTier: {
     paddingLeft: spacing(3)
   },
   socials: {
     flexDirection: 'row',
-    flex: 4,
-    marginVertical: spacing(3)
+    flex: 4
   },
   socialsCentered: {
     justifyContent: 'center'
@@ -120,7 +118,6 @@ export const ProfileSocials = () => {
       </Fragment>
     ))
   }
-
   return (
     <View pointerEvents='box-none' style={styles.root}>
       {tier !== 'none' ? (


### PR DESCRIPTION
### Description

* margin bottom and hardcoded height was resulting in big blank space on profiles without socials. Space doesn't seem to be needed at all

![Simulator Screenshot - iPhone 15 Pro - 2024-09-10 at 14 21 33](https://github.com/user-attachments/assets/74d7a691-d849-4419-93a7-524fc9cf21be)
![Simulator Screenshot - iPhone 15 Pro - 2024-09-10 at 14 21 24](https://github.com/user-attachments/assets/0b616eb9-e3dd-4ac6-b318-421df9686885)
![Simulator Screenshot - iPhone 15 Pro - 2024-09-10 at 14 21 14](https://github.com/user-attachments/assets/773bc66c-5a12-4f8c-956d-870dee84bcdc)


### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._
