### PR TITLE
[QA-1483] Remove artist-pick in feed

### DIFF
--- a/packages/web/src/pages/feed-page/components/desktop/FeedPageContent.tsx
+++ b/packages/web/src/pages/feed-page/components/desktop/FeedPageContent.tsx
@@ -95,6 +95,7 @@ const FeedPageContent = ({
         endOfLineup={<EndOfLineup key='endOfLineup' />}
         key='feed'
         showFeedTipTile={!isUSDCEnabled}
+        showLeadingElementArtistPick={false}
         {...feedLineupProps}
         {...mainLineupProps}
       />

--- a/packages/web/src/pages/feed-page/components/mobile/FeedPageContent.tsx
+++ b/packages/web/src/pages/feed-page/components/mobile/FeedPageContent.tsx
@@ -68,6 +68,7 @@ const FeedPageMobileContent = ({
     playTrack: playFeedTrack,
     pauseTrack: pauseFeedTrack,
     actions: feedActions,
+    showLeadingElementArtistPick: false,
     delineate: true
   }
 


### PR DESCRIPTION
### Description

Fixes issue where you can set your artist pick in feed, which is a pretty silly mechanic. likely user would only do this on their profile.