### PR TITLE
[QA-1716] Fix removing songs from playlists

### DIFF
--- a/packages/web/src/common/store/pages/collection/lineups/sagas.js
+++ b/packages/web/src/common/store/pages/collection/lineups/sagas.js
@@ -39,7 +39,7 @@ function* getCollectionTracks() {
   // Some playlists & albums may not have a metadata time, so use the time if not.
   // If for whatever reason, the metadata time is off, prefer the release date
   const times = tracks.map((t) =>
-    Math.max(t.metadata_time || t.time, collection.release_date)
+    Math.max(t.metadata_time || t.time, moment(collection.release_date).unix())
   )
 
   // Reconcile fetching this playlist with the queue.
@@ -80,10 +80,7 @@ function* getCollectionTracks() {
         if (!metadata.track_id) return null
 
         if (times[i]) {
-          metadata.dateAdded =
-            typeof times[i] === 'string'
-              ? moment(times[i])
-              : moment.unix(times[i])
+          metadata.dateAdded = moment.unix(times[i])
         }
         if (uidForSource[id] && uidForSource[id].length > 0) {
           metadata.uid = uidForSource[id].shift()


### PR DESCRIPTION
`release_date` is a string, not a number, so the `dateAdded` would be undefined. We attempt to call `.unix()` on the undefined timestamp, causing an error.

Introduced in https://github.com/AudiusProject/audius-protocol/pull/9529