### PR TITLE
[QA-1589] Improve track search for titles without spaces

### DIFF
--- a/packages/discovery-provider/src/queries/search_es.py
+++ b/packages/discovery-provider/src/queries/search_es.py
@@ -585,6 +585,14 @@ def track_dsl(
                                 "boost": len(search_str) * 0.5,
                             }
                         },
+                        {
+                            "term": {
+                                "title": {
+                                    "value": search_str.replace(" ", ""),
+                                    "boost": len(search_str) * 0.5,
+                                }
+                            }
+                        },
                         *[
                             {
                                 "match": {


### PR DESCRIPTION
### Description
Some track titles stylistically don't include spaces. Allow searching with spaces to include/boost these tracks if they're an exact match.   

https://audius.co/search/tracks?query=pure+component for https://audius.co/stereosteve/purecomponent-453169
https://audius.co/search/tracks?query=not+so+simple for https://audius.co/sebbsolitude/notsosimple

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._

Tested on sandbox and ensured these surfaced properly. 