### PR TITLE
[QA-1590] Remove private filter on album backlink

### DIFF
--- a/packages/trpc-server/src/routers/track-router.ts
+++ b/packages/trpc-server/src/routers/track-router.ts
@@ -73,7 +73,6 @@ export const trackRouter = router({
             must: [
               { term: { 'playlist_contents.track_ids.track': input.trackId } },
               { term: { is_delete: false } },
-              { term: { is_private: false } },
               { term: { is_album: true } },
             ],
             must_not: [],


### PR DESCRIPTION
### Description

Should be ok because we want to show these in most cases. User who moves a track into an album would already have access to the album and would voluntarily be giving their album to others w/ the private link

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._
