### PR TITLE
[DOCS] - amplify hackathon announcement bar

### DIFF
--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -68,9 +68,17 @@ const config = {
           hideable: true,
         },
       },
+      announcementBar: {
+        id: 'amplify_hackathon',
+        content:
+          '👩‍💻 <a target="_blank" rel="noopener noreferrer" href="https://www.audius.events/e/hackathon">Join the Amplify Hackathon!</a> 🚀   Registration Open September 23-30, 2024',
+        backgroundColor: '#7e1bcc',
+        textColor: '#fff',
+        isCloseable: false,
+      },
       navbar: {
         title: 'Audius',
-        hideOnScroll: true,
+        hideOnScroll: false,
         logo: {
           alt: 'Audius Logo',
           src: 'img/logo.png',

--- a/docs/src/css/custom.css
+++ b/docs/src/css/custom.css
@@ -363,3 +363,51 @@ html[data-theme='dark'] .navbar__items > a:nth-child(1):hover {
   visibility: hidden;
   height: 0;
 }
+
+
+/* Announcement banner */
+
+:root {
+  --docusaurus-announcement-bar-height: auto !important;
+}
+
+div[class^="announcementBar"][role="banner"] {
+  border-bottom-color: var(--deepdark);
+  height: 50px;
+
+  button.close {
+    svg {
+      fill: white;
+    }
+  }
+}
+
+div[class^="announcementBarContent"] {
+  line-height: 50px;
+  font-weight: bold;
+  padding: 8px 30px;
+
+  a {
+    text-decoration: underline;
+    display: inline-block;
+    color: var(--brand) !important;
+
+    &:hover {
+      color: var(--ifm-color-primary) !important;
+    }
+  }
+}
+
+@media only screen and (max-width: 768px) {
+  .announcement {
+    font-size: 18px;
+  }
+}
+
+@media only screen and (max-width: 500px) {
+  .announcement {
+    font-size: 15px;
+    line-height: 22px;
+    padding: 6px 30px;
+  }
+}


### PR DESCRIPTION
### Description

Added announcement bar to docs linking to amplify hackathon registration page

<img width="750" alt="image" src="https://github.com/user-attachments/assets/d3eeec8b-873b-4198-9fc9-01bec6c3fbd2">

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._
