### PR TITLE
[C-5014] Remove search input auto-correct

### DIFF
--- a/packages/mobile/src/screens/search-screen/SearchBar.tsx
+++ b/packages/mobile/src/screens/search-screen/SearchBar.tsx
@@ -111,6 +111,8 @@ export const SearchBar = (props: SearchBarProps) => {
   return (
     <TextInput
       {...props}
+      autoCapitalize='none'
+      autoCorrect={false}
       startIcon={IconSearch}
       size={TextInputSize.SMALL}
       label={messages.label}


### PR DESCRIPTION
### Description

Removes auto-correct and auto-capitalize from mobile search input, which is the general standard for search. Just to be explicit:
- This prevents auto-capitalization of the first element
- This prevents auto-correct changing invalid words to common mis-spelled words
- This preserves auto-complete, which are the words that appear above the keyboard, which is typically present.
