### PR TITLE
[C-5020] Search filter fixes for FilterButton

### DIFF
--- a/packages/harmony/src/components/button/FilterButton/FilterButton.tsx
+++ b/packages/harmony/src/components/button/FilterButton/FilterButton.tsx
@@ -14,9 +14,8 @@ import { mergeRefs } from 'react-merge-refs'
 import { BaseButton } from 'components/button/BaseButton/BaseButton'
 import { IconComponent, IconProps } from 'components/icon'
 import { TextInput, TextInputSize } from 'components/input/TextInput'
-import { Menu } from 'components/internal/Menu'
-import { Flex, Box, Paper } from 'components/layout'
-import { Popup } from 'components/popup'
+import { Menu, MenuContent } from 'components/internal/Menu'
+import { Flex, Box } from 'components/layout'
 import { Text } from 'components/text/Text'
 import { useControlled } from 'hooks/useControlled'
 import { IconCaretDown, IconCloseAlt, IconSearch } from 'icons'
@@ -248,65 +247,66 @@ export const FilterButton = forwardRef(function FilterButton<
     >
       {leadingElement}
       {selectedLabel ? renderLabel(selectedLabel) : label}
-      {children ? (
-        <Popup
-          anchorRef={anchorRef}
-          isVisible={isOpen}
-          onClose={() => setIsOpen(false)}
-        >
-          <Paper mt='s' border='strong' shadow='far'>
+
+      <Menu
+        anchorRef={anchorRef}
+        isVisible={isOpen}
+        onClose={() => setIsOpen(false)}
+        aria-label={selectedLabel ?? label ?? props['aria-label']}
+        aria-activedescendant={selectedLabel}
+        PaperProps={menuProps?.PaperProps}
+      >
+        {children ? (
+          <Flex onClick={(e) => e.stopPropagation()}>
             {children({
               onChange: handleChange,
               options: optionElements,
               setIsOpen
             })}
-          </Paper>
-        </Popup>
-      ) : (
-        <Menu
-          anchorRef={anchorRef}
-          isVisible={isOpen}
-          onClose={() => setIsOpen(false)}
-          aria-label={selectedLabel ?? label ?? props['aria-label']}
-          aria-activedescendant={selectedLabel}
-          scrollRef={scrollRef}
-          {...menuProps}
-        >
-          {showFilterInput && filterInputProps ? (
-            <TextInput
-              ref={inputRef}
-              size={TextInputSize.SMALL}
-              startIcon={IconSearch}
-              onClick={(e) => {
-                e.stopPropagation()
-              }}
-              onChange={(e) => {
-                setFilterInputValue(e.target.value)
-              }}
-              autoComplete='off'
-              {...filterInputProps}
-            />
-          ) : null}
-          {optionsLabel ? (
-            <Box pt='s' ph='m'>
-              <Text variant='label' size='xs'>
-                {optionsLabel}
-              </Text>
-            </Box>
-          ) : null}
-          {filteredOptions && filteredOptions.length === 0 ? (
-            <Flex justifyContent='center'>
-              <Text variant='body' color='subdued' size='s'>
-                {messages.noMatches}
-              </Text>
-            </Flex>
-          ) : (
-            <Flex direction='column' w='100%'>
-              {optionElements}
-            </Flex>
-          )}
-        </Menu>
-      )}
+          </Flex>
+        ) : (
+          <MenuContent
+            maxHeight={menuProps?.maxHeight}
+            width={menuProps?.width}
+            scrollRef={scrollRef}
+            MenuListProps={menuProps?.MenuListProps}
+          >
+            {showFilterInput && filterInputProps ? (
+              <TextInput
+                ref={inputRef}
+                size={TextInputSize.SMALL}
+                startIcon={IconSearch}
+                onClick={(e) => {
+                  e.stopPropagation()
+                }}
+                onChange={(e) => {
+                  setFilterInputValue(e.target.value)
+                }}
+                autoComplete='off'
+                {...filterInputProps}
+              />
+            ) : null}
+            {optionsLabel ? (
+              <Box pt='s' ph='m'>
+                <Text variant='label' size='xs'>
+                  {optionsLabel}
+                </Text>
+              </Box>
+            ) : null}
+            {filteredOptions && filteredOptions.length === 0 ? (
+              <Flex justifyContent='center'>
+                <Text variant='body' color='subdued' size='s'>
+                  {messages.noMatches}
+                </Text>
+              </Flex>
+            ) : (
+              <Flex direction='column' w='100%'>
+                {optionElements}
+              </Flex>
+            )}
+          </MenuContent>
+        )}
+      </Menu>
     </BaseButton>
   )
 })

--- a/packages/harmony/src/components/button/FilterButton/FilterButton.tsx
+++ b/packages/harmony/src/components/button/FilterButton/FilterButton.tsx
@@ -15,7 +15,8 @@ import { BaseButton } from 'components/button/BaseButton/BaseButton'
 import { IconComponent, IconProps } from 'components/icon'
 import { TextInput, TextInputSize } from 'components/input/TextInput'
 import { Menu } from 'components/internal/Menu'
-import { Flex, Box } from 'components/layout'
+import { Flex, Box, Paper } from 'components/layout'
+import { Popup } from 'components/popup'
 import { Text } from 'components/text/Text'
 import { useControlled } from 'hooks/useControlled'
 import { IconCaretDown, IconCloseAlt, IconSearch } from 'icons'
@@ -247,59 +248,65 @@ export const FilterButton = forwardRef(function FilterButton<
     >
       {leadingElement}
       {selectedLabel ? renderLabel(selectedLabel) : label}
-      <Menu
-        anchorRef={anchorRef}
-        isVisible={isOpen}
-        onClose={() => setIsOpen(false)}
-        aria-label={selectedLabel ?? label ?? props['aria-label']}
-        aria-activedescendant={selectedLabel}
-        scrollRef={scrollRef}
-        {...menuProps}
-      >
-        {children ? (
-          children({
-            onChange: handleChange,
-            options: optionElements,
-            setIsOpen
-          })
-        ) : (
-          <>
-            {showFilterInput && filterInputProps ? (
-              <TextInput
-                ref={inputRef}
-                size={TextInputSize.SMALL}
-                startIcon={IconSearch}
-                onClick={(e) => {
-                  e.stopPropagation()
-                }}
-                onChange={(e) => {
-                  setFilterInputValue(e.target.value)
-                }}
-                autoComplete='off'
-                {...filterInputProps}
-              />
-            ) : null}
-            {optionsLabel ? (
-              <Box pt='s' ph='m'>
-                <Text variant='label' size='xs'>
-                  {optionsLabel}
-                </Text>
-              </Box>
-            ) : null}
-            {filteredOptions && filteredOptions.length === 0 ? (
-              <Flex justifyContent='center'>
-                <Text variant='body' color='subdued' size='s'>
-                  {messages.noMatches}
-                </Text>
-              </Flex>
-            ) : (
-              <Flex direction='column' w='100%'>
-                {optionElements}
-              </Flex>
-            )}
-          </>
-        )}
-      </Menu>
+      {children ? (
+        <Popup
+          anchorRef={anchorRef}
+          isVisible={isOpen}
+          onClose={() => setIsOpen(false)}
+        >
+          <Paper mt='s' border='strong' shadow='far'>
+            {children({
+              onChange: handleChange,
+              options: optionElements,
+              setIsOpen
+            })}
+          </Paper>
+        </Popup>
+      ) : (
+        <Menu
+          anchorRef={anchorRef}
+          isVisible={isOpen}
+          onClose={() => setIsOpen(false)}
+          aria-label={selectedLabel ?? label ?? props['aria-label']}
+          aria-activedescendant={selectedLabel}
+          scrollRef={scrollRef}
+          {...menuProps}
+        >
+          {showFilterInput && filterInputProps ? (
+            <TextInput
+              ref={inputRef}
+              size={TextInputSize.SMALL}
+              startIcon={IconSearch}
+              onClick={(e) => {
+                e.stopPropagation()
+              }}
+              onChange={(e) => {
+                setFilterInputValue(e.target.value)
+              }}
+              autoComplete='off'
+              {...filterInputProps}
+            />
+          ) : null}
+          {optionsLabel ? (
+            <Box pt='s' ph='m'>
+              <Text variant='label' size='xs'>
+                {optionsLabel}
+              </Text>
+            </Box>
+          ) : null}
+          {filteredOptions && filteredOptions.length === 0 ? (
+            <Flex justifyContent='center'>
+              <Text variant='body' color='subdued' size='s'>
+                {messages.noMatches}
+              </Text>
+            </Flex>
+          ) : (
+            <Flex direction='column' w='100%'>
+              {optionElements}
+            </Flex>
+          )}
+        </Menu>
+      )}
     </BaseButton>
   )
 })

--- a/packages/harmony/src/components/button/FilterButton/types.ts
+++ b/packages/harmony/src/components/button/FilterButton/types.ts
@@ -4,7 +4,7 @@ import { CSSObject } from '@emotion/react'
 
 import { IconComponent } from 'components/icon'
 import { TextInputProps } from 'components/input'
-import { MenuProps } from 'components/internal/Menu'
+import { MenuContentProps, MenuProps } from 'components/internal/Menu'
 
 export type FilterButtonSize = 'default' | 'small'
 
@@ -131,7 +131,8 @@ export type FilterButtonProps<Value extends string = string> = {
    */
   optionsLabel?: string
 
-  menuProps?: Partial<MenuProps> & { css?: CSSObject }
+  menuProps?: Partial<MenuProps> &
+    Partial<MenuContentProps> & { css?: CSSObject }
 
   renderLabel?: (label: string) => ReactNode
   /**

--- a/packages/harmony/src/components/internal/Menu.tsx
+++ b/packages/harmony/src/components/internal/Menu.tsx
@@ -11,41 +11,46 @@ import { WithCSS } from 'foundations'
 // TODO menu label
 
 export type MenuProps = Omit<PopupProps, 'children'> & {
-  maxHeight?: CSSObject['maxHeight']
-  width?: CSSObject['width']
   children: ReactNode
   PaperProps?: WithCSS<Partial<PaperProps>>
+}
+
+export type MenuContentProps = {
+  children: ReactNode
+  maxHeight?: CSSObject['maxHeight']
+  width?: CSSObject['width']
   MenuListProps?: WithCSS<Partial<FlexProps>>
   scrollRef: Ref<HTMLDivElement>
 }
 
 export const Menu = (props: MenuProps) => {
-  const {
-    children,
-    maxHeight,
-    width,
-    PaperProps,
-    MenuListProps,
-    scrollRef,
-    ...other
-  } = props
+  const { children, PaperProps, ...other } = props
 
   return (
     <Popup {...other}>
       <Paper mt='s' border='strong' shadow='far' {...PaperProps}>
-        <Flex
-          direction='column'
-          p='s'
-          gap='s'
-          alignItems='flex-start'
-          role='listbox'
-          css={{ maxHeight, width, overflowY: 'auto' }}
-          ref={scrollRef}
-          {...MenuListProps}
-        >
-          {children}
-        </Flex>
+        {children}
       </Paper>
     </Popup>
+  )
+}
+
+export const MenuContent = (props: MenuContentProps) => {
+  const { children, maxHeight, width, MenuListProps, scrollRef } = props
+
+  return (
+    <Flex
+      direction='column'
+      p='s'
+      gap='s'
+      alignItems='flex-start'
+      role='listbox'
+      css={{ maxHeight, width, overflowY: 'auto' }}
+      ref={scrollRef}
+      onClick={(e) => e.stopPropagation()}
+      {...MenuListProps}
+    >
+      {children}
+    </Flex>
   )
 }

--- a/packages/harmony/src/components/select/Select/Select.tsx
+++ b/packages/harmony/src/components/select/Select/Select.tsx
@@ -12,7 +12,7 @@ import {
 import { mergeRefs } from 'react-merge-refs'
 
 import { TextInput } from 'components/input'
-import { Menu, MenuProps } from 'components/internal/Menu'
+import { Menu, MenuContent, MenuProps } from 'components/internal/Menu'
 import { MenuItem } from 'components/internal/MenuItem'
 import { OptionKeyHandler } from 'components/internal/OptionKeyHandler'
 import { Flex } from 'components/layout'
@@ -195,16 +195,22 @@ export const Select = forwardRef(function Select<Value extends string>(
       <Menu
         anchorRef={anchorRef}
         isVisible={isOpen}
-        scrollRef={scrollRef}
         aria-label={selectedLabel ?? label ?? props['aria-label']}
         aria-activedescendant={selectedLabel}
         onClose={() => setIsOpen(false)}
         {...defaultMenuProps}
-        {...menuProps}
+        PaperProps={menuProps?.PaperProps}
       >
-        {children
-          ? children({ onChange: handleChange, options: optionElements })
-          : optionElements}
+        <MenuContent
+          maxHeight={menuProps?.maxHeight}
+          width={menuProps?.width}
+          scrollRef={scrollRef}
+          MenuListProps={menuProps?.MenuListProps}
+        >
+          {children
+            ? children({ onChange: handleChange, options: optionElements })
+            : optionElements}
+        </MenuContent>
       </Menu>
     </Flex>
   )

--- a/packages/harmony/src/components/select/Select/types.ts
+++ b/packages/harmony/src/components/select/Select/types.ts
@@ -2,7 +2,7 @@ import { ReactNode } from 'react'
 
 import { IconComponent } from 'components/icon'
 import { TextInputProps } from 'components/input'
-import { MenuProps } from 'components/internal/Menu'
+import { MenuContentProps, MenuProps } from 'components/internal/Menu'
 
 export type SelectOption<Value extends string> = {
   value: Value
@@ -46,6 +46,6 @@ export type SelectProps<Value extends string = string> = {
    */
   optionsLabel?: string
   InputProps?: Partial<TextInputProps>
-  menuProps?: Partial<MenuProps>
+  menuProps?: Partial<MenuProps> & Partial<MenuContentProps>
   clearable?: boolean
 } & Omit<TextInputProps, 'value' | 'onChange' | 'children'>


### PR DESCRIPTION
### Description

Fix a couple issues with Key & BPM filters on prod:
* Extra padding
* Popup closes when clicking in input 

https://github.com/user-attachments/assets/769d68a1-fa23-435a-af6f-0e43124cd0e0



These issues were fixed in #9484 but reintroduced in #9427 . The issue is with the `Menu` abstraction. `Menu` works great for the default case of menus rendering a list of options. But it causes problems for FilterButtons with a custom menu such as BPM and Key

Fix is to use composition to conditionally nest the menu content in the flex with the list properties applied. I still wanted to keep a single `menuOptions` prop in FilterButton and Select, so there is a bit of prop mangling. But this seemed to be the cleanest option

### How Has This Been Tested?

Tested default and custom FilterButtons on web
