### PR TITLE
[C-5011] Add comment_count to es-indexer

### DIFF
--- a/packages/discovery-provider/integration_tests/queries/test_search_track_tags.py
+++ b/packages/discovery-provider/integration_tests/queries/test_search_track_tags.py
@@ -24,7 +24,7 @@ def test_search_track_tags(app_module):
             {"track_id": 1, "tags": "", "owner_id": 1},
             {"track_id": 2, "owner_id": 1, "tags": "pop,rock,electric"},
             {"track_id": 3, "owner_id": 2},
-            {"track_id": 4, "owner_id": 2, "tags": "funk,pop", "is_stream_gated": True},
+            {"track_id": 4, "owner_id": 2, "tags": "funk,pop", "is_stream_gated": True,  "comments_disabled": True},
             {"track_id": 5, "owner_id": 2, "tags": "funk,pop"},
             {"track_id": 6, "owner_id": 2, "tags": "funk,Funk,kpop"},
         ],
@@ -41,6 +41,9 @@ def test_search_track_tags(app_module):
             {"repost_item_id": 5, "repost_type": "track", "user_id": 1},
             {"repost_item_id": 5, "repost_type": "track", "user_id": 2},
             {"repost_item_id": 5, "repost_type": "track", "user_id": 3},
+        ],
+        "comments": [
+            {"comment_id": 1, "entity_id": 5, "user_id": 1}
         ],
     }
 
@@ -64,6 +67,9 @@ def test_search_track_tags(app_module):
         assert tracks[0]["track_id"] == 5  # First w/ 3 reposts
         assert tracks[1]["track_id"] == 2  # Sec w/ 2 reposts
         assert tracks[2]["track_id"] == 4  # Third w/ 1 reposts
+        assert tracks[2]["comments_disabled"] == True  # Third w/ 1 reposts
+
+        assert tracks[0]["comment_count"] == 1
         # Track id 6 does not appear b/c kpop and pop are not exact matches
 
         # curent user

--- a/packages/discovery-provider/integration_tests/queries/test_search_track_tags.py
+++ b/packages/discovery-provider/integration_tests/queries/test_search_track_tags.py
@@ -24,7 +24,13 @@ def test_search_track_tags(app_module):
             {"track_id": 1, "tags": "", "owner_id": 1},
             {"track_id": 2, "owner_id": 1, "tags": "pop,rock,electric"},
             {"track_id": 3, "owner_id": 2},
-            {"track_id": 4, "owner_id": 2, "tags": "funk,pop", "is_stream_gated": True,  "comments_disabled": True},
+            {
+                "track_id": 4,
+                "owner_id": 2,
+                "tags": "funk,pop",
+                "is_stream_gated": True,
+                "comments_disabled": True,
+            },
             {"track_id": 5, "owner_id": 2, "tags": "funk,pop"},
             {"track_id": 6, "owner_id": 2, "tags": "funk,Funk,kpop"},
         ],
@@ -42,9 +48,7 @@ def test_search_track_tags(app_module):
             {"repost_item_id": 5, "repost_type": "track", "user_id": 2},
             {"repost_item_id": 5, "repost_type": "track", "user_id": 3},
         ],
-        "comments": [
-            {"comment_id": 1, "entity_id": 5, "user_id": 1}
-        ],
+        "comments": [{"comment_id": 1, "entity_id": 5, "user_id": 1}],
     }
 
     populate_mock_db(db, test_entities)

--- a/packages/discovery-provider/integration_tests/utils.py
+++ b/packages/discovery-provider/integration_tests/utils.py
@@ -255,6 +255,7 @@ def populate_mock_db(db, entities, block_offset=None):
                 playlists_previously_containing_track=track_meta.get(
                     "playlists_previously_containing_track", {}
                 ),
+                comments_disabled=track_meta.get("comments_disabled", False)
             )
             session.add(track)
         for i, track_price_history_meta in enumerate(track_price_history):
@@ -488,6 +489,7 @@ def populate_mock_db(db, entities, block_offset=None):
                 track_id=aggregate_track_meta.get("track_id", i),
                 repost_count=aggregate_track_meta.get("repost_count", 0),
                 save_count=aggregate_track_meta.get("save_count", 0),
+                comment_count=aggregate_track_meta.get("comment_count", 0),
             )
             session.add(aggregate_track)
 

--- a/packages/discovery-provider/integration_tests/utils.py
+++ b/packages/discovery-provider/integration_tests/utils.py
@@ -255,7 +255,7 @@ def populate_mock_db(db, entities, block_offset=None):
                 playlists_previously_containing_track=track_meta.get(
                     "playlists_previously_containing_track", {}
                 ),
-                comments_disabled=track_meta.get("comments_disabled", False)
+                comments_disabled=track_meta.get("comments_disabled", False),
             )
             session.add(track)
         for i, track_price_history_meta in enumerate(track_price_history):

--- a/packages/discovery-provider/src/queries/search_es.py
+++ b/packages/discovery-provider/src/queries/search_es.py
@@ -1102,7 +1102,6 @@ def base_playlist_dsl(
     }
 
     if tag_search:
-        print("sebastian tag search appending", tag_search)
         dsl["must"].append(
             {
                 "bool": {

--- a/packages/es-indexer/src/indexers/TrackIndexer.ts
+++ b/packages/es-indexer/src/indexers/TrackIndexer.ts
@@ -112,6 +112,7 @@ export class TrackIndexer extends BaseIndexer<TrackDoc> {
       end as purchaseable_download,
       tracks.is_downloadable as downloadable,
       coalesce(aggregate_plays.count, 0) as play_count,
+      coalesce(aggregate_track.comment_count, 0) as comment_count,
   
       json_build_object(
         'handle', users.handle,
@@ -165,6 +166,7 @@ export class TrackIndexer extends BaseIndexer<TrackDoc> {
       join users on owner_id = user_id 
       left join aggregate_user on users.user_id = aggregate_user.user_id
       left join aggregate_plays on tracks.track_id = aggregate_plays.play_item_id
+      left join aggregate_track using (track_id)
     WHERE 1=1 
     `
   }

--- a/packages/es-indexer/src/listener.ts
+++ b/packages/es-indexer/src/listener.ts
@@ -1,5 +1,6 @@
 import {
   AggregatePlayRow,
+  AggregateTrackRow,
   AggregateUserRow,
   FollowRow,
   PlaylistRow,
@@ -14,6 +15,7 @@ import { logger } from './logger'
 export const LISTEN_TABLES = [
   'aggregate_plays',
   'aggregate_user',
+  'aggregate_track',
   'follows',
   'playlists',
   'reposts',
@@ -67,6 +69,10 @@ export async function startListener() {
     aggregate_plays: (row: AggregatePlayRow) => {
       if (!row.play_item_id) return // when could this happen?
       pending.trackIds.add(row.play_item_id)
+    },
+    aggregate_track: (row: AggregateTrackRow) => {
+      if (!row.track_id) return // when could this happen?
+      pending.trackIds.add(row.track_id)
     },
     // TODO: can we do trigger on agg playlist matview?
     saves: (save: SaveRow) => {

--- a/packages/es-indexer/src/setup.ts
+++ b/packages/es-indexer/src/setup.ts
@@ -4,6 +4,7 @@ import { logger } from './logger'
 export const LISTEN_TABLES = [
   'aggregate_plays',
   'aggregate_user',
+  'aggregate_track',
   'follows',
   'playlists',
   'reposts',
@@ -24,6 +25,8 @@ begin
       PERFORM pg_notify(TG_TABLE_NAME, json_build_object('user_id', new.user_id)::text);
     when 'playlists' then
       PERFORM pg_notify(TG_TABLE_NAME, json_build_object('playlist_id', new.playlist_id)::text);
+    when 'comments' then
+      PERFORM pg_notify(TG_TABLE_NAME, json_build_object('comment_id', new.comment_id)::text);
     else
       PERFORM pg_notify(TG_TABLE_NAME, to_json(new)::text);
   end case;

--- a/packages/es-indexer/src/types/docs.ts
+++ b/packages/es-indexer/src/types/docs.ts
@@ -50,6 +50,7 @@ export type TrackDoc = TrackRow & {
   repost_count: number
   save_count: number
   favorite_count: number
+  comment_count: number
   play_count: any // todo: is it a string or number?  pg returns string
   downloadable: boolean
   purchaseable: boolean


### PR DESCRIPTION
### Description

Adds comment_count to es-indexer, which fixes issue where feed and search track tiles have comments = 0.
Note we are not making comment_count an index because search doesn't need to rely on it. However if we want to incorporate comment_count into "popular" ranking for search, we can introduce it.