### PR TITLE
fix node syncing

### DIFF
--- a/core/chain/abci.go
+++ b/core/chain/abci.go
@@ -46,11 +46,6 @@ func (app *CoreApplication) Info(ctx context.Context, info *abcitypes.InfoReques
 	if err != nil && !errors.Is(err, pgx.ErrNoRows) {
 		// Log the error and return a default response
 		app.logger.Errorf("Error retrieving app state: %v", err)
-		return nil, err
-	}
-
-	// if at genesis, tell comet there's no blocks indexed
-	if latest.BlockHeight < 2 {
 		return &abcitypes.InfoResponse{}, nil
 	}
 
@@ -126,25 +121,9 @@ func (app *CoreApplication) FinalizeBlock(ctx context.Context, req *abcitypes.Fi
 		}
 	}
 
-	lastBlock := req.Height - 1
-	prevAppState, err := app.getDb().GetAppStateAtHeight(ctx, req.Height-1)
-	if err != nil && !errors.Is(err, pgx.ErrNoRows) {
-		app.logger.Errorf("prev app state not found: %v", err)
-		return &abcitypes.FinalizeBlockResponse{}, nil
-	}
+	nextAppHash := app.serializeAppState([]byte{}, req.GetTxs())
 
-	nextAppHash := []byte{}
-	if lastBlock == 1 {
-		nextAppHash = app.serializeAppState([]byte{}, req.GetTxs())
-	} else {
-		app.serializeAppState(prevAppState.AppHash, req.GetTxs())
-	}
-	// if empty block and previous was not genesis, use prior state
-	if len(txs) == 0 && req.Height > 2 {
-		nextAppHash = prevAppState.AppHash
-	}
-
-	if err = app.getDb().UpsertAppState(ctx, db.UpsertAppStateParams{
+	if err := app.getDb().UpsertAppState(ctx, db.UpsertAppStateParams{
 		BlockHeight: req.Height,
 		AppHash:     nextAppHash,
 	}); err != nil {

--- a/core/config/genesis/stage.json
+++ b/core/config/genesis/stage.json
@@ -1,6 +1,6 @@
 {
   "genesis_time": "2024-08-09T00:00:00.0000Z",
-  "chain_id": "audius-testnet-4",
+  "chain_id": "audius-testnet-5",
   "initial_height": "0",
   "consensus_params": {
     "block": {

--- a/core/infra/docker-compose.yml
+++ b/core/infra/docker-compose.yml
@@ -8,10 +8,10 @@ services:
       - ./dev_config/sandbox-one.env
     restart: unless-stopped
     ports:
-      - "6610:26656" # CometBFT P2P Server
-      - "6611:26657" # CometBFT RPC Server
-      - "6612:50051" # Core GRPC Server
-      - "6613:26659" # Core Web Server
+      - "6611:26656" # CometBFT P2P Server
+      - "6612:26657" # CometBFT RPC Server
+      - "6613:50051" # Core GRPC Server
+      - "6614:26659" # Core Web Server
     networks:
       - sandbox-core-net
 

--- a/core/scripts/sandbox.go
+++ b/core/scripts/sandbox.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"context"
-	"fmt"
 	"log"
 	"time"
 
@@ -26,8 +25,6 @@ func main() {
 
 	_, err = sdk.Ping(ctx, &proto.PingRequest{})
 	checkErr(err)
-
-	fmt.Println("pinged")
 
 	for {
 		time.Sleep(1 * time.Second)

--- a/core/scripts/sandbox.go
+++ b/core/scripts/sandbox.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"fmt"
 	"log"
 	"time"
 
@@ -20,11 +21,13 @@ func checkErr(e error) {
 func main() {
 	ctx := context.Background()
 
-	sdk, err := sdk.NewSdk(sdk.WithGrpcendpoint("0.0.0.0:6612"), sdk.WithJrpcendpoint("http://0.0.0.0:6611"))
+	sdk, err := sdk.NewSdk(sdk.WithGrpcendpoint("0.0.0.0:6613"), sdk.WithJrpcendpoint("http://0.0.0.0:6612"))
 	checkErr(err)
 
 	_, err = sdk.Ping(ctx, &proto.PingRequest{})
 	checkErr(err)
+
+	fmt.Println("pinged")
 
 	for {
 		time.Sleep(1 * time.Second)

--- a/core/setup.go
+++ b/core/setup.go
@@ -132,6 +132,10 @@ func setupNode(logger *common.Logger) (*config.Config, *cconfig.Config, error) {
 	// db and state config
 	cometConfig.Consensus.CreateEmptyBlocks = false
 
+	// mempool
+	cometConfig.Mempool.Recheck = true
+	cometConfig.Mempool.Size = 100000
+
 	// peering
 	cometConfig.P2P.PexReactor = true
 	cometConfig.P2P.AddrBookStrict = envConfig.AddrBookStrict


### PR DESCRIPTION
### Description
- changes the app state to just be the block data, no merkle for now
- increases the mempool size
- ups stage network id to isolate this change
### How Has This Been Tested?
with `audius-compose up core...` ran some txs then took down creator 3, ran some more. looked at the logs to see that creator had caught up and just ran the blocks it didn't see. then completely nuked 3. watched it's logs and verified in the db that it also completely synced back up
