### PR TITLE
decouple console and comet

### DIFF
--- a/core/console/components/components.go
+++ b/core/console/components/components.go
@@ -3,16 +3,16 @@ package components
 import (
 	"github.com/AudiusProject/audius-protocol/core/config"
 	"github.com/AudiusProject/audius-protocol/core/db"
-	"github.com/cometbft/cometbft/rpc/client/local"
+	"github.com/cometbft/cometbft/rpc/client"
 )
 
 type Components struct {
 	config *config.Config
-	rpc    *local.Local
+	rpc    client.Client
 	db     *db.Queries
 }
 
-func NewComponents(config *config.Config, rpc *local.Local, db *db.Queries) *Components {
+func NewComponents(config *config.Config, rpc client.Client, db *db.Queries) *Components {
 	return &Components{
 		config: config,
 		rpc:    rpc,

--- a/core/console/console.go
+++ b/core/console/console.go
@@ -8,6 +8,7 @@ import (
 	"github.com/AudiusProject/audius-protocol/core/console/components"
 	"github.com/AudiusProject/audius-protocol/core/console/middleware"
 	"github.com/AudiusProject/audius-protocol/core/db"
+	"github.com/cometbft/cometbft/rpc/client"
 	"github.com/cometbft/cometbft/rpc/client/local"
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/labstack/echo/v4"
@@ -15,7 +16,7 @@ import (
 
 type Console struct {
 	config *config.Config
-	rpc    *local.Local
+	rpc    client.Client
 	db     *db.Queries
 	e      *echo.Echo
 	logger *common.Logger

--- a/core/console/console.go
+++ b/core/console/console.go
@@ -3,12 +3,18 @@
 package console
 
 import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
 	"github.com/AudiusProject/audius-protocol/core/common"
 	"github.com/AudiusProject/audius-protocol/core/config"
 	"github.com/AudiusProject/audius-protocol/core/console/components"
 	"github.com/AudiusProject/audius-protocol/core/console/middleware"
 	"github.com/AudiusProject/audius-protocol/core/db"
 	"github.com/cometbft/cometbft/rpc/client"
+	rpchttp "github.com/cometbft/cometbft/rpc/client/http"
 	"github.com/cometbft/cometbft/rpc/client/local"
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/labstack/echo/v4"
@@ -23,14 +29,19 @@ type Console struct {
 	c      *components.Components
 }
 
-func NewConsole(config *config.Config, logger *common.Logger, e *echo.Echo, rpc *local.Local, pool *pgxpool.Pool) (*Console, error) {
+func NewConsole(config *config.Config, logger *common.Logger, e *echo.Echo, rpcUrl string, pool *pgxpool.Pool) (*Console, error) {
+	httpClient, err := rpchttp.New(rpcUrl)
+	if err != nil {
+		return nil, fmt.Errorf("could not create rpc client: %v", err)
+	}
+
 	c := &Console{
 		config: config,
-		rpc:    rpc,
+		rpc:    httpClient,
 		e:      e,
 		logger: logger.Child("console"),
 		db:     db.New(pool),
-		c:      components.NewComponents(config, rpc, db.New(pool)),
+		c:      components.NewComponents(config, httpClient, db.New(pool)),
 	}
 
 	consoleBase := e.Group("/console")
@@ -53,4 +64,28 @@ func (c *Console) registerRoutes(logger *common.Logger, groups ...*echo.Group) {
 
 		g.GET("/headerinfo", c.headerInfo)
 	}
+}
+
+func (c *Console) AwaitLocalRpc(rpc *local.Local) error {
+	ctx := context.Background()
+	retries := 60
+	for tries := retries; tries >= 0; tries-- {
+		res, err := rpc.Status(ctx)
+		if err != nil {
+			time.Sleep(10 * time.Second)
+			continue
+		}
+
+		if res.SyncInfo.CatchingUp {
+			c.logger.Infof("comet catching up: latest seen block %d", res.SyncInfo.LatestBlockHeight)
+			time.Sleep(10 * time.Second)
+			continue
+		}
+
+		// no health error nor catching up
+		// change internal rpc to local instead of http
+		c.rpc = rpc
+		return nil
+	}
+	return errors.New("timeout waiting for comet to catch up")
 }

--- a/core/run.go
+++ b/core/run.go
@@ -85,7 +85,7 @@ func run(logger *common.Logger) error {
 		return fmt.Errorf("server init error: %v", err)
 	}
 
-	_, err = console.NewConsole(config, logger, e, rpc, pool)
+	csl, err := console.NewConsole(config, logger, e, cometConfig.RPC.ListenAddress, pool)
 	if err != nil {
 		return fmt.Errorf("console init error: %v", err)
 	}
@@ -114,6 +114,15 @@ func run(logger *common.Logger) error {
 	eg.Go(func() error {
 		logger.Info("core http server starting")
 		return e.Start(config.CoreServerAddr)
+	})
+
+	eg.Go(func() error {
+		err := csl.AwaitLocalRpc(rpc)
+		if err != nil {
+			logger.Errorf("could not setup local rpc for console, using http: %v", err)
+		}
+
+		return nil
 	})
 
 	// cometbft


### PR DESCRIPTION
### Description
- uses an http connection prior to the local rpc, if the local rpc syncs then it'll replace the http one

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._
