### PR TITLE
Make verified-notifications a private package

### DIFF
--- a/packages/discovery-provider/plugins/pedalboard/apps/verified-notifications/package.json
+++ b/packages/discovery-provider/plugins/pedalboard/apps/verified-notifications/package.json
@@ -4,6 +4,7 @@
   "description": "plugin for broadcasting verified notifications",
   "main": "src/index.js",
   "type": "module",
+  "private": true,
   "scripts": {
     "start": "node ./src/index.js",
     "build": "",


### PR DESCRIPTION
### Description

changesets attemps to publish all public packages by default. caused a non-fatal error here: https://github.com/AudiusProject/audius-protocol/actions/runs/10911031900/job/30283412848

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._
