### PR TITLE
[PAY-3211] Chat blast audience display (mobile)

### DIFF
--- a/packages/mobile/src/screens/chat-screen/ChatBlastAudienceDisplay.tsx
+++ b/packages/mobile/src/screens/chat-screen/ChatBlastAudienceDisplay.tsx
@@ -1,0 +1,49 @@
+import {
+  useAudienceUsers,
+  useChatBlastAudienceContent
+} from '@audius/common/hooks'
+import type { User } from '@audius/common/models'
+import type { ChatBlast } from '@audius/sdk'
+
+import { Flex, Text, IconTowerBroadcast, Paper } from '@audius/harmony-native'
+
+import { ProfilePictureList } from '../notifications-screen/Notification/NotificationProfilePictureList'
+
+const USER_LIST_LIMIT = 7
+
+const messages = {
+  title: 'Send a Message Blast',
+  description: 'Send direct messages in bulk.'
+}
+
+interface ChatBlastAudienceDisplayProps {
+  chat: ChatBlast
+}
+
+export const ChatBlastAudienceDisplay = (
+  props: ChatBlastAudienceDisplayProps
+) => {
+  const { chat } = props
+
+  const { audienceCount } = useChatBlastAudienceContent({ chat })
+
+  // Add 1 to the limit to ensure we have a bg photo for the overflow count
+  const users = useAudienceUsers(chat, USER_LIST_LIMIT + 1)
+
+  return (
+    <Paper column gap='l' alignItems='center' p='xl' mh='l' mv='2xl'>
+      <IconTowerBroadcast color='subdued' size='3xl' />
+      <Text variant='heading' size='s'>
+        {messages.title}
+      </Text>
+      <Flex row gap='xs' alignItems='center'>
+        <Text size='l'>{messages.description}</Text>
+      </Flex>
+      <ProfilePictureList
+        users={users as User[]}
+        totalUserCount={audienceCount ?? 0}
+        limit={USER_LIST_LIMIT}
+      />
+    </Paper>
+  )
+}

--- a/packages/mobile/src/screens/chat-screen/ChatScreen.tsx
+++ b/packages/mobile/src/screens/chat-screen/ChatScreen.tsx
@@ -635,20 +635,22 @@ export const ChatScreen = () => {
                     // https://github.com/facebook/react-native/issues/21196
                     // This is better than doing a rotation transform because when the react bug is fixed,
                     // our workaround won't re-introduce the bug!
-                    <View style={styles.emptyContainer}>
-                      <EmptyChatMessages />
-                    </View>
+                    !chat?.is_blast ? (
+                      <View style={styles.emptyContainer}>
+                        <EmptyChatMessages />
+                      </View>
+                    ) : null
                   }
                   ListHeaderComponent={
                     !canSendMessage ? <ChatUnavailable chatId={chatId} /> : null
                   }
                   ListFooterComponent={
-                    shouldShowEndReachedIndicator ? (
+                    chat?.is_blast ? (
+                      <ChatBlastAudienceDisplay chat={chat as ChatBlast} />
+                    ) : shouldShowEndReachedIndicator ? (
                       <ChatMessageSeparator
                         content={messages.beginningReached}
                       />
-                    ) : chat?.is_blast ? (
-                      <ChatBlastAudienceDisplay chat={chat as ChatBlast} />
                     ) : null
                   }
                   scrollEnabled={popupMessageId == null}

--- a/packages/mobile/src/screens/chat-screen/ChatScreen.tsx
+++ b/packages/mobile/src/screens/chat-screen/ChatScreen.tsx
@@ -51,6 +51,7 @@ import { makeStyles } from 'app/styles'
 import { spacing } from 'app/styles/spacing'
 import { useThemePalette } from 'app/utils/theme'
 
+import { ChatBlastAudienceDisplay } from './ChatBlastAudienceDisplay'
 import { ChatBlastHeader } from './ChatBlastHeader'
 import { ChatBlastSubHeader } from './ChatBlastSubHeader'
 import { ChatMessageListItem } from './ChatMessageListItem'
@@ -639,13 +640,15 @@ export const ChatScreen = () => {
                     </View>
                   }
                   ListHeaderComponent={
-                    canSendMessage ? null : <ChatUnavailable chatId={chatId} />
+                    !canSendMessage ? <ChatUnavailable chatId={chatId} /> : null
                   }
                   ListFooterComponent={
                     shouldShowEndReachedIndicator ? (
                       <ChatMessageSeparator
                         content={messages.beginningReached}
                       />
+                    ) : chat?.is_blast ? (
+                      <ChatBlastAudienceDisplay chat={chat as ChatBlast} />
                     ) : null
                   }
                   scrollEnabled={popupMessageId == null}

--- a/packages/mobile/src/screens/notifications-screen/Notification/NotificationProfilePictureList.tsx
+++ b/packages/mobile/src/screens/notifications-screen/Notification/NotificationProfilePictureList.tsx
@@ -11,6 +11,11 @@ import { PROFILE_PICTURE_BORDER_WIDTH } from './constants'
 const USER_LENGTH_LIMIT = 9
 const BASE_ZINDEX = 1
 
+const messages = {
+  count: (remainingUsersCount: number) =>
+    `${remainingUsersCount < 100 ? '+' : ''}${formatCount(remainingUsersCount)}`
+}
+
 /**
  * Not all profile picture lists have the same profile picture size.
  * Some components pass in the dimensions (width and height) while others
@@ -46,7 +51,7 @@ const useStyles = makeStyles(({ spacing, palette, typography }) => ({
   imageCount: {
     textAlign: 'center',
     color: palette.staticWhite,
-    fontSize: typography.fontSize.small,
+    fontSize: typography.fontSize.xs,
     fontFamily: typography.fontByWeight.bold,
     textShadowColor: 'rgba(0,0,0,0.25)',
     textShadowOffset: { width: 0, height: 2 },
@@ -154,8 +159,10 @@ export const ProfilePictureList = (props: ProfilePictureListProps) => {
                 styles.imageCount,
                 useSmallText && styles.imageCountSmall
               ]}
+              numberOfLines={1}
+              ellipsizeMode='clip'
             >
-              {`+${formatCount(remainingUsersCount)}`}
+              {messages.count(remainingUsersCount)}
             </Text>
           </View>
         </View>


### PR DESCRIPTION
### Description

- Adds `ChatBlastAudienceDisplay` component displayed at top of blast chat history
- Fix count wrapping on `NotificaitonProfilePictureList`

### How Has This Been Tested?

![Screenshot 2024-09-18 at 4 16 31 PM](https://github.com/user-attachments/assets/ba70a15e-ae4a-447a-acff-d5b3f46dc036)

