### PR TITLE
[PAY-3215] ChatBlastCTA in own followers and supporters screens

### DIFF
--- a/packages/mobile/src/screens/chat-screen/ChatBlastFollowersCTA.tsx
+++ b/packages/mobile/src/screens/chat-screen/ChatBlastFollowersCTA.tsx
@@ -1,0 +1,75 @@
+import React, { useCallback } from 'react'
+
+import { useCanSendChatBlast } from '@audius/common/hooks'
+import { chatActions } from '@audius/common/store'
+import { ChatBlastAudience } from '@audius/sdk'
+import { TouchableHighlight } from 'react-native-gesture-handler'
+import { useDispatch } from 'react-redux'
+
+import {
+  Box,
+  Flex,
+  Text,
+  IconTowerBroadcast,
+  IconCaretRight
+} from '@audius/harmony-native'
+
+const { createChatBlast } = chatActions
+
+const getMessages = (audience: ChatBlastAudience) => {
+  switch (audience) {
+    case ChatBlastAudience.FOLLOWERS:
+      return {
+        title: 'Message Blast Your Followers',
+        description: 'Send bulk messages to your followers.'
+      }
+    case ChatBlastAudience.TIPPERS:
+      return {
+        title: 'Message Blast Your Tip Supporters',
+        description: 'Bulk message everyone who’s sent you a tip.'
+      }
+  }
+}
+
+type ChatBlastWithAudienceCTAProps = {
+  audience: ChatBlastAudience
+}
+
+export const ChatBlastWithAudienceCTA = (
+  props: ChatBlastWithAudienceCTAProps
+) => {
+  const { audience } = props
+  const messages = getMessages(audience)
+
+  const dispatch = useDispatch()
+  const handleClick = useCallback(() => {
+    dispatch(createChatBlast({ audience }))
+  }, [audience, dispatch])
+
+  const userMeetsRequirements = useCanSendChatBlast()
+  if (!userMeetsRequirements || !messages) {
+    return null
+  }
+
+  return (
+    <TouchableHighlight onPress={handleClick}>
+      <Box backgroundColor='surface1' ph='xl' pv='l' borderTop='strong'>
+        <Flex
+          direction='row'
+          alignItems='center'
+          gap='l'
+          justifyContent='space-between'
+        >
+          <Flex direction='row' alignItems='center' gap='s'>
+            <IconTowerBroadcast size='3xl' color='default' />
+            <Flex direction='column' gap='xs'>
+              <Text variant='title'>{messages.title}</Text>
+              <Text size='s'>{messages.description}</Text>
+            </Flex>
+          </Flex>
+          <IconCaretRight size='s' color='default' />
+        </Flex>
+      </Box>
+    </TouchableHighlight>
+  )
+}

--- a/packages/mobile/src/screens/chat-screen/ChatBlastFollowersCTA.tsx
+++ b/packages/mobile/src/screens/chat-screen/ChatBlastFollowersCTA.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback } from 'react'
+import { useCallback } from 'react'
 
 import { useCanSendChatBlast } from '@audius/common/hooks'
 import { chatActions } from '@audius/common/store'
@@ -42,7 +42,7 @@ export const ChatBlastWithAudienceCTA = (
   const messages = getMessages(audience)
 
   const dispatch = useDispatch()
-  const handleClick = useCallback(() => {
+  const handlePress = useCallback(() => {
     dispatch(createChatBlast({ audience }))
   }, [audience, dispatch])
 
@@ -52,7 +52,7 @@ export const ChatBlastWithAudienceCTA = (
   }
 
   return (
-    <TouchableHighlight onPress={handleClick}>
+    <TouchableHighlight onPress={handlePress}>
       <Box backgroundColor='surface1' ph='xl' pv='l' borderTop='strong'>
         <Flex
           direction='row'

--- a/packages/mobile/src/screens/user-list-screen/FollowersScreen.tsx
+++ b/packages/mobile/src/screens/user-list-screen/FollowersScreen.tsx
@@ -8,11 +8,11 @@ import {
   followersUserListSelectors
 } from '@audius/common/store'
 import { ChatBlastAudience } from '@audius/sdk'
+import { css } from '@emotion/native'
 import { useDispatch } from 'react-redux'
 
 import { Box, IconUserFollowers } from '@audius/harmony-native'
 import { useProfileRoute } from 'app/hooks/useRoute'
-import { makeStyles } from 'app/styles'
 
 import { ChatBlastWithAudienceCTA } from '../chat-screen/ChatBlastFollowersCTA'
 
@@ -25,21 +25,11 @@ const messages = {
   title: 'Followers'
 }
 
-const useStyles = makeStyles(() => ({
-  footerContainer: {
-    position: 'absolute',
-    bottom: 0,
-    width: '100%'
-  }
-}))
-
 export const FollowersScreen = () => {
   const { params } = useProfileRoute<'Followers'>()
   const { userId } = params
   const { data: currentUserId } = useGetCurrentUserId({})
   const dispatch = useDispatch()
-
-  const styles = useStyles()
 
   const handleSetFollowers = useCallback(() => {
     dispatch(setFollowers(userId))
@@ -57,7 +47,13 @@ export const FollowersScreen = () => {
           setUserList={handleSetFollowers}
         />
         {isOneToManyDMsEnabled && currentUserId === userId ? (
-          <Box style={styles.footerContainer}>
+          <Box
+            style={css({
+              position: 'absolute',
+              bottom: 0,
+              width: '100%'
+            })}
+          >
             <ChatBlastWithAudienceCTA audience={ChatBlastAudience.FOLLOWERS} />
           </Box>
         ) : null}

--- a/packages/mobile/src/screens/user-list-screen/FollowersScreen.tsx
+++ b/packages/mobile/src/screens/user-list-screen/FollowersScreen.tsx
@@ -1,13 +1,20 @@
 import { useCallback } from 'react'
 
+import { useGetCurrentUserId } from '@audius/common/api'
+import { useFeatureFlag } from '@audius/common/hooks'
+import { FeatureFlags } from '@audius/common/services'
 import {
   followersUserListActions,
   followersUserListSelectors
 } from '@audius/common/store'
+import { ChatBlastAudience } from '@audius/sdk'
 import { useDispatch } from 'react-redux'
 
-import { IconUserFollowers } from '@audius/harmony-native'
+import { Box, IconUserFollowers } from '@audius/harmony-native'
 import { useProfileRoute } from 'app/hooks/useRoute'
+import { makeStyles } from 'app/styles'
+
+import { ChatBlastWithAudienceCTA } from '../chat-screen/ChatBlastFollowersCTA'
 
 import { UserList } from './UserList'
 import { UserListScreen } from './UserListScreen'
@@ -18,22 +25,43 @@ const messages = {
   title: 'Followers'
 }
 
+const useStyles = makeStyles(() => ({
+  footerContainer: {
+    position: 'absolute',
+    bottom: 0,
+    width: '100%'
+  }
+}))
+
 export const FollowersScreen = () => {
   const { params } = useProfileRoute<'Followers'>()
   const { userId } = params
+  const { data: currentUserId } = useGetCurrentUserId({})
   const dispatch = useDispatch()
+
+  const styles = useStyles()
 
   const handleSetFollowers = useCallback(() => {
     dispatch(setFollowers(userId))
   }, [dispatch, userId])
+  const { isEnabled: isOneToManyDMsEnabled } = useFeatureFlag(
+    FeatureFlags.ONE_TO_MANY_DMS
+  )
 
   return (
     <UserListScreen title={messages.title} titleIcon={IconUserFollowers}>
-      <UserList
-        userSelector={getUserList}
-        tag='FOLLOWERS'
-        setUserList={handleSetFollowers}
-      />
+      <>
+        <UserList
+          userSelector={getUserList}
+          tag='FOLLOWERS'
+          setUserList={handleSetFollowers}
+        />
+        {isOneToManyDMsEnabled && currentUserId === userId ? (
+          <Box style={styles.footerContainer}>
+            <ChatBlastWithAudienceCTA audience={ChatBlastAudience.FOLLOWERS} />
+          </Box>
+        ) : null}
+      </>
     </UserListScreen>
   )
 }

--- a/packages/mobile/src/screens/user-list-screen/TopSupportersScreen.tsx
+++ b/packages/mobile/src/screens/user-list-screen/TopSupportersScreen.tsx
@@ -9,6 +9,7 @@ import {
   topSupportersUserListSelectors
 } from '@audius/common/store'
 import { ChatBlastAudience } from '@audius/sdk'
+import { css } from '@emotion/native'
 import { View } from 'react-native'
 import { useDispatch, useSelector } from 'react-redux'
 
@@ -37,11 +38,6 @@ const useStyles = makeStyles(({ spacing }) => ({
   },
   titleName: {
     maxWidth: 120
-  },
-  footerContainer: {
-    position: 'absolute',
-    bottom: 0,
-    width: '100%'
   }
 }))
 
@@ -84,7 +80,13 @@ export const TopSupportersScreen = () => {
           setUserList={handleSetSupporters}
         />
         {isOneToManyDMsEnabled && currentUserId === userId ? (
-          <Box style={styles.footerContainer}>
+          <Box
+            style={css({
+              position: 'absolute',
+              bottom: 0,
+              width: '100%'
+            })}
+          >
             <ChatBlastWithAudienceCTA audience={ChatBlastAudience.TIPPERS} />
           </Box>
         ) : null}


### PR DESCRIPTION
### Description

- Adds CTA to end of user list modals if you are the owner and have chat blast permissions
- Clicking the CTA creates a new blast for that audience (if not exists) and navigates to the chat screen

### How Has This Been Tested?

![Screenshot 2024-09-18 at 4 47 13 PM](https://github.com/user-attachments/assets/a41d0146-d8db-418e-9d95-aa8780721fd4)
