### PR TITLE
Handle inline-transcode for older servers.

### DIFF
--- a/mediorum/server/peer_health.go
+++ b/mediorum/server/peer_health.go
@@ -59,6 +59,10 @@ func (ss *MediorumServer) startHealthPoller() {
 						}
 						ss.peerHealths[peer.Host].LastReachable = time.Now()
 
+						if v, ok := data["version"].(string); ok {
+							ss.peerHealths[peer.Host].Version = v
+						}
+
 						// set node's reachable peers
 						for host, hostPeerHealths := range peerHealthsMap {
 							if peerHealth, ok := hostPeerHealths.(map[string]interface{}); ok {
@@ -92,6 +96,12 @@ func (ss *MediorumServer) startHealthPoller() {
 			time.Sleep(time.Minute * 2)
 		}
 	}
+}
+
+func (ss *MediorumServer) getPeerHealth(peer string) *PeerHealth {
+	ss.peerHealthsMutex.Lock()
+	defer ss.peerHealthsMutex.Unlock()
+	return ss.peerHealths[peer]
 }
 
 // @dev lock ss.peerHealthsMutex before calling this

--- a/mediorum/server/server.go
+++ b/mediorum/server/server.go
@@ -122,6 +122,7 @@ type MediorumServer struct {
 }
 
 type PeerHealth struct {
+	Version        string               `json:"version"`
 	LastReachable  time.Time            `json:"lastReachable"`
 	LastHealthy    time.Time            `json:"lastHealthy"`
 	ReachablePeers map[string]time.Time `json:"reachablePeers"`


### PR DESCRIPTION
StoreAll node will pick up transcode jobs for servers running old code.  We can undo this when all servers are > 0.6.190
