### PR TITLE
Add CHAT routes to static_routes

### DIFF
--- a/packages/common/src/utils/route.ts
+++ b/packages/common/src/utils/route.ts
@@ -342,7 +342,9 @@ export const staticRoutes = new Set([
   TRENDING_GENRES,
   PURCHASES_PAGE,
   SALES_PAGE,
-  WITHDRAWALS_PAGE
+  WITHDRAWALS_PAGE,
+  CHAT_PAGE,
+  CHATS_PAGE
 ])
 
 export const profilePage = (handle: string) => {


### PR DESCRIPTION
### Description
This fixes a bug where if the user was on the profile page, then tried to navigate to the chat page, they'd hit the error screen due to this request failing:
`https://discoveryprovider2.staging.audius.co/v1/full/users/handle/messages?user_id=mvGY1zw`. This is not a real route, it should be `/comms/messages`.

The source of the bug is in this line which returns null if the given route is in `static_routes`:
https://github.com/AudiusProject/audius-protocol/blob/2d838c5ba3592fdb1d92eb99ef15ee9e84699bc0/packages/web/src/utils/route/userRouteParser.ts#L19

Fix is to add chat routes to `static_routes`. Plz flag if you can think of any reason we shouldn't do this!

Not sure why we didn't catch this sooner..

### How Has This Been Tested?

Confirmed can nav to chat page from profile page locally against stage