### PR TITLE
[PAY-3426] Set unread count when seeding chats with blasts

### DIFF
--- a/comms/discovery/rpcz/chat.go
+++ b/comms/discovery/rpcz/chat.go
@@ -54,16 +54,24 @@ func chatCreate(tx *sqlx.Tx, userId int32, ts time.Time, params schema.ChatCreat
 			return err
 		}
 
+		// Update unread count for the invited user. Do not update for the sender of the blast.
+		var unreadCount = 0
+		for _, blast := range blasts {
+			if int(blast.FromUserID) != invitedUserId {
+				unreadCount++
+			}
+		}
+
 		// similar to above... if there is a conflict when creating chat_member records
 		// keep the version with the earliest relayed_at (created_at) timestamp.
 		_, err = tx.Exec(`
 		insert into chat_member
-			(chat_id, invited_by_user_id, invite_code, user_id, created_at)
+			(chat_id, invited_by_user_id, invite_code, user_id, unread_count, created_at)
 		values
-			($1, $2, $3, $4, $5)
+			($1, $2, $3, $4, $5, $6)
 		on conflict (chat_id, user_id)
-		do update set invited_by_user_id=$2, invite_code=$3, created_at=$5 where chat_member.created_at > $5`,
-			params.ChatID, userId, invite.InviteCode, invitedUserId, ts)
+		do update set invited_by_user_id=$2, invite_code=$3, unread_count=$5, created_at=$6 where chat_member.created_at > $6`,
+			params.ChatID, userId, invite.InviteCode, invitedUserId, unreadCount, ts)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
### Description
Update unread count when upgrading blast to real chat thread. Only update the unread count for the recipient, not the sender of the blast.

### How Has This Been Tested?
Local stack

Receiver has unread count:
<img width="655" alt="Screenshot 2024-09-20 at 2 40 58 PM" src="https://github.com/user-attachments/assets/03f35522-a7a1-4457-a613-0e10d68fae29">

Sender has no unread count:
<img width="1371" alt="Screenshot 2024-09-20 at 2 41 09 PM" src="https://github.com/user-attachments/assets/881b97b1-9e27-41bf-925a-82a9b8e3fc97">

This user both received blasts and also sent a blast. After marking the 1-1 chat thread as read, the unread count was correctly cleared.
<img width="698" alt="Screenshot 2024-09-20 at 2 55 37 PM" src="https://github.com/user-attachments/assets/de2fc3ee-aeb5-482d-863d-46eef8ccc996">
<img width="976" alt="Screenshot 2024-09-20 at 3 01 31 PM" src="https://github.com/user-attachments/assets/dbb30256-a123-42de-b123-f6040a99b307">
