### PR TITLE
Don't show empty chat prompt for blasts

### DIFF
--- a/packages/web/src/pages/chat-page/components/ChatMessageList.tsx
+++ b/packages/web/src/pages/chat-page/components/ChatMessageList.tsx
@@ -221,7 +221,8 @@ export const ChatMessageList = forwardRef<HTMLDivElement, ChatMessageListProps>(
             />
           ) : null}
           {chat?.messagesStatus === Status.SUCCESS &&
-          chatMessages?.length === 0 ? (
+          chatMessages?.length === 0 &&
+          !chat?.is_blast ? (
             <SendMessagePrompt />
           ) : null}
           {chatId &&


### PR DESCRIPTION
### Description
We were erroneously showing this empty state for blast threads. Already handled correctly on mobile.

### How Has This Been Tested?

<img width="1310" alt="Screenshot 2024-09-20 at 4 18 11 PM" src="https://github.com/user-attachments/assets/9d3d126a-d083-4ed5-b2a5-cddfd32bdb30">
