### PR TITLE
[PAY-3419] Fetch chat if necessary on chat reaction

### DIFF
--- a/packages/common/src/store/pages/chat/sagas.ts
+++ b/packages/common/src/store/pages/chat/sagas.ts
@@ -867,6 +867,12 @@ function* watchAddMessage() {
   yield takeEvery(addMessage, ({ payload }) => doFetchChatIfNecessary(payload))
 }
 
+function* watchSetMessageReactionSucceeded() {
+  yield takeEvery(setMessageReactionSucceeded, ({ payload }) =>
+    doFetchChatIfNecessary(payload)
+  )
+}
+
 function* watchFetchChatIfNecessary() {
   yield takeEvery(fetchChatIfNecessary, ({ payload }) =>
     doFetchChatIfNecessary(payload)
@@ -955,6 +961,7 @@ export const sagas = () => {
     watchMarkChatAsRead,
     watchSendMessage,
     watchAddMessage,
+    watchSetMessageReactionSucceeded,
     watchFetchBlockees,
     watchFetchBlockers,
     watchBlockUser,

--- a/packages/common/src/store/pages/chat/slice.ts
+++ b/packages/common/src/store/pages/chat/slice.ts
@@ -361,7 +361,10 @@ const slice = createSlice({
       const { chatId, messageId, reaction } = action.payload
       delete state.optimisticReactions[messageId]
 
-      // Ensure the message exists
+      // Ensure the chat and message exists. If not, saga will fetch.
+      if (!(chatId in state.messages)) {
+        return
+      }
       const existingMessage = getMessage(state.messages[chatId], messageId)
       if (!existingMessage) {
         return


### PR DESCRIPTION
### Description
- Incoming reaction websocket event triggers fetching chat if the chat and message that was reacted to don't exist in local state.
- Fix bug where we were getting `entities is not defined` when checking that message exists in reaction slice.

### How Has This Been Tested?

https://github.com/user-attachments/assets/4057cc0d-435b-406e-9f38-faf9b37ee3b4