### PR TITLE
[C-5045] Fix TextLink positioning and styling

### DIFF
--- a/packages/common/src/utils/urlUtils.ts
+++ b/packages/common/src/utils/urlUtils.ts
@@ -15,7 +15,7 @@ const audiusUrlRegex =
   /^(?:https?:\/\/)?(?:[^@\/\n]+@)?(?:www\.)?(staging\.)?(audius\.co)(\/.+)?/gim
 
 export const isAudiusUrl = (url: string) => new RegExp(audiusUrlRegex).test(url)
-export const isInteralAudiusUrl = (url: string) =>
+export const isInternalAudiusUrl = (url: string) =>
   url.startsWith('/') ||
   (isAudiusUrl(url) &&
     !externalAudiusLinks.some((externalLink) => externalLink.includes(url)))

--- a/packages/mobile/src/components/core/UserGeneratedText.tsx
+++ b/packages/mobile/src/components/core/UserGeneratedText.tsx
@@ -15,7 +15,8 @@ import type { LayoutRectangle, Text as TextRef } from 'react-native'
 import Autolink from 'react-native-autolink'
 
 import type { TextLinkProps, TextProps } from '@audius/harmony-native'
-import { Text, TextLink } from '@audius/harmony-native'
+import { Text } from '@audius/harmony-native'
+import { TextLinkFlowing } from 'app/harmony-native/components/TextLink/TextLink'
 import { audiusSdk } from 'app/services/sdk/audius-sdk'
 
 const {
@@ -39,9 +40,10 @@ export type UserGeneratedTextProps = Omit<TextProps, 'children'> & {
 
 const Link = ({ children, url, ...other }: TextLinkProps & { url: string }) => {
   const [unfurledContent, setUnfurledContent] = useState<string>()
+  const shouldUnfurl = isAudiusUrl(url)
 
   useEffect(() => {
-    if (isAudiusUrl(url) && !unfurledContent) {
+    if (shouldUnfurl && !unfurledContent) {
       const fn = async () => {
         const sdk = await audiusSdk()
         const res = await sdk.resolve({ url })
@@ -59,12 +61,12 @@ const Link = ({ children, url, ...other }: TextLinkProps & { url: string }) => {
       }
       fn()
     }
-  }, [url, unfurledContent, setUnfurledContent])
+  }, [url, shouldUnfurl, unfurledContent, setUnfurledContent])
 
   return (
-    <TextLink {...other} url={url}>
+    <TextLinkFlowing {...other} url={url}>
       {unfurledContent ?? children}
-    </TextLink>
+    </TextLinkFlowing>
   )
 }
 

--- a/packages/mobile/src/harmony-native/components/TextLink/ExternalLink.tsx
+++ b/packages/mobile/src/harmony-native/components/TextLink/ExternalLink.tsx
@@ -9,6 +9,7 @@ import type {
 import { Linking, TouchableWithoutFeedback } from 'react-native'
 
 import { useToast } from 'app/hooks/useToast'
+import type { GestureResponderHandler } from 'app/types/gesture'
 
 import type { Source } from './types'
 
@@ -21,12 +22,16 @@ export type ExternalLinkProps = TouchableWithoutFeedbackProps & {
   source?: Source
 }
 
-export const ExternalLink = (props: ExternalLinkProps) => {
-  const { url, children, onPress, ...other } = props
+export const useExternalLinkHandlePress = ({
+  url,
+  onPress
+}: {
+  url: string
+  onPress?: GestureResponderHandler
+}) => {
   const { toast } = useToast()
   const { onOpen: openLeavingAudiusModal } = useLeavingAudiusModal()
-
-  const handlePress = useCallback(
+  return useCallback(
     async (e: GestureResponderEvent) => {
       const errorToastConfig = {
         content: messages.error,
@@ -52,6 +57,11 @@ export const ExternalLink = (props: ExternalLinkProps) => {
     },
     [onPress, openLeavingAudiusModal, toast, url]
   )
+}
+
+export const ExternalLink = (props: ExternalLinkProps) => {
+  const { url, children, onPress, ...other } = props
+  const handlePress = useExternalLinkHandlePress({ url, onPress })
 
   return (
     <TouchableWithoutFeedback onPress={handlePress} {...other}>

--- a/packages/mobile/src/harmony-native/components/TextLink/InternalLink.tsx
+++ b/packages/mobile/src/harmony-native/components/TextLink/InternalLink.tsx
@@ -8,6 +8,8 @@ import type { To } from '@react-navigation/native/lib/typescript/src/useLinkTo'
 import type { GestureResponderEvent } from 'react-native'
 import { TouchableOpacity } from 'react-native'
 
+import type { GestureResponderHandler } from 'app/types/gesture'
+
 export type InternalLinkToProps<
   ParamList extends ReactNavigation.RootParamList
 > = {
@@ -45,11 +47,16 @@ type InternalLinkProps = {
   children?: ReactNode
 }
 
-export const InternalLink = (props: InternalLinkProps) => {
-  const { url, onPress, children } = props
+export const useInternalLinkHandlePress = ({
+  url,
+  onPress
+}: {
+  url: string
+  onPress?: GestureResponderHandler
+}) => {
   const linkTo = useLinkTo()
 
-  const handlePress = useCallback(
+  return useCallback(
     (e: GestureResponderEvent) => {
       onPress?.(e)
       const internalLink = getPathFromAudiusUrl(url)
@@ -59,7 +66,11 @@ export const InternalLink = (props: InternalLinkProps) => {
     },
     [onPress, url, linkTo]
   )
+}
 
+export const InternalLink = (props: InternalLinkProps) => {
+  const { url, onPress, children } = props
+  const handlePress = useInternalLinkHandlePress({ url, onPress })
   return (
     <TouchableOpacity onPress={handlePress} accessibilityRole='link'>
       {children}

--- a/packages/mobile/src/harmony-native/components/TextLink/TextLink.tsx
+++ b/packages/mobile/src/harmony-native/components/TextLink/TextLink.tsx
@@ -33,9 +33,6 @@ const TextLinkAnimation = (props: TextLinkAnimationProps) => {
     showUnderline,
     style,
     animatedPressed,
-    onPressIn,
-    onPressOut,
-    onPress,
     ...other
   } = props
 
@@ -68,14 +65,7 @@ const TextLinkAnimation = (props: TextLinkAnimationProps) => {
   // Need to nest the AnimatedText inside a Text so the handlers & animation work
   // while still supporting proper Text layout
   return (
-    <Text
-      onPressIn={onPressIn}
-      onPressOut={onPressOut}
-      onPress={onPress}
-      suppressHighlighting
-      variant={textVariant}
-      {...other}
-    >
+    <Text suppressHighlighting variant={textVariant} {...other}>
       <AnimatedText
         style={[
           style,

--- a/packages/mobile/src/harmony-native/components/TextLink/TextLink.tsx
+++ b/packages/mobile/src/harmony-native/components/TextLink/TextLink.tsx
@@ -49,8 +49,8 @@ const TextLinkAnimation = (props: TextLinkAnimationProps) => {
   const variantPressingColors = {
     default: color.primary.p300,
     subdued: color.primary.p300,
-    visible: color.static.primary,
-    inverted: color.static.primary,
+    visible: color.static.white,
+    inverted: color.link.visible,
     active: color.primary.primary
   }
 

--- a/packages/mobile/src/harmony-native/components/TextLink/TextLink.tsx
+++ b/packages/mobile/src/harmony-native/components/TextLink/TextLink.tsx
@@ -70,9 +70,7 @@ const TextLinkAnimation = (props: TextLinkAnimationProps) => {
         style={[
           style,
           animatedStyles,
-          {
-            textDecorationLine: showUnderline ? 'underline' : 'none'
-          }
+          { textDecorationLine: showUnderline ? 'underline' : 'none' }
         ]}
       >
         {children}

--- a/packages/mobile/src/harmony-native/components/TextLink/types.ts
+++ b/packages/mobile/src/harmony-native/components/TextLink/types.ts
@@ -2,6 +2,7 @@ import type { ReactNode } from 'react'
 
 import type { ParamListBase } from '@react-navigation/native'
 import type { GestureResponderEvent } from 'react-native'
+import type { SharedValue } from 'react-native-reanimated'
 
 import type { TextProps } from '../Text/Text'
 
@@ -16,30 +17,44 @@ type NonLinkProps = {
   onPress?: (e: GestureResponderEvent) => void
 }
 
+export type TextLinkAnimationProps = TextLinkTextProps & {
+  /**
+   * Which variant to display. 'active' is temporary intil this pattern is removed
+   */
+  variant?: 'default' | 'subdued' | 'visible' | 'inverted' | 'active'
+
+  /**
+   * Which text variant to display.
+   */
+  textVariant?: TextProps['variant']
+
+  /**
+   * When true, always show the link underline. This can help emphasize that
+   * a text-link is present when next to other text.
+   */
+  showUnderline?: boolean
+
+  /**
+   * SharedValue that represents the pressed state.
+   */
+  animatedPressed: SharedValue<number>
+}
+
 export type TextLinkProps<
   ParamList extends ReactNavigation.RootParamList = ParamListBase
-> = TextLinkTextProps &
-  (InternalLinkToProps<ParamList> | ExternalLinkProps | NonLinkProps) & {
-    /**
-     * Which variant to display. 'active' is temporary intil this pattern is removed
-     */
-    variant?: 'default' | 'subdued' | 'visible' | 'inverted' | 'active'
-
-    /**
-     * Which text variant to display.
-     */
-    textVariant?: TextProps['variant']
-
-    /**
-     * When true, always show the link underline. This can help emphasize that
-     * a text-link is present when next to other text.
-     */
-    showUnderline?: boolean
-
+> = (InternalLinkToProps<ParamList> | ExternalLinkProps | NonLinkProps) &
+  TextLinkAnimationProps & {
     source?: Source
 
     /**
      * React element to the right side of the text link.
      */
     endAdornment?: ReactNode
+  }
+
+export type TextLinkFlowingProps<
+  ParamList extends ReactNavigation.RootParamList = ParamListBase
+> = (InternalLinkToProps<ParamList> | ExternalLinkProps | NonLinkProps) &
+  TextLinkAnimationProps & {
+    source?: Source
   }

--- a/packages/mobile/src/harmony-native/components/TextLink/types.ts
+++ b/packages/mobile/src/harmony-native/components/TextLink/types.ts
@@ -43,7 +43,7 @@ export type TextLinkAnimationProps = TextLinkTextProps & {
 export type TextLinkProps<
   ParamList extends ReactNavigation.RootParamList = ParamListBase
 > = (InternalLinkToProps<ParamList> | ExternalLinkProps | NonLinkProps) &
-  TextLinkAnimationProps & {
+  Omit<TextLinkAnimationProps, 'animatedPressed'> & {
     source?: Source
 
     /**
@@ -55,6 +55,6 @@ export type TextLinkProps<
 export type TextLinkFlowingProps<
   ParamList extends ReactNavigation.RootParamList = ParamListBase
 > = (InternalLinkToProps<ParamList> | ExternalLinkProps | NonLinkProps) &
-  TextLinkAnimationProps & {
+  Omit<TextLinkAnimationProps, 'animatedPressed'> & {
     source?: Source
   }


### PR DESCRIPTION
### Description

TextLink was not laying out properly inline with other Text components. This was a problem in UserGeneratedText

* Add TextLinkFlowing that directly uses Text components instead of wrapping with TouchableOpacity. This fixes the positioning problem
* Update link styling to remove the iOS system highlight and instead use the color animation. TextLinkFlowing does not have the opacity animation like TextLink although we could add it. TextLinkFlowing also does not support endAdornment

Perhaps another refactor to follow that renames TextLinkFlowing -> TextLink and makes it the default. And then adding TextLinkWithAdornment to support the endAdornment case. This all depends on where we land on whether or not our links should have both color AND opacity animation

![Simulator Screenshot - iPhone 15 Pro - 2024-09-23 at 15 32 10](https://github.com/user-attachments/assets/0e26ddb0-8dff-42af-80cf-26bb8b962601)

### How Has This Been Tested?

Tested TextLink & TextLinkFlowing, internal and external links, url and to props
