### PR TITLE
Only show blast audience list once users have loaded

### DIFF
--- a/packages/mobile/src/screens/chat-screen/ChatBlastAudienceDisplay.tsx
+++ b/packages/mobile/src/screens/chat-screen/ChatBlastAudienceDisplay.tsx
@@ -39,11 +39,13 @@ export const ChatBlastAudienceDisplay = (
       <Flex row gap='xs' alignItems='center'>
         <Text size='l'>{messages.description}</Text>
       </Flex>
-      <ProfilePictureList
-        users={users as User[]}
-        totalUserCount={audienceCount ?? 0}
-        limit={USER_LIST_LIMIT}
-      />
+      {users.length ? (
+        <ProfilePictureList
+          users={users as User[]}
+          totalUserCount={audienceCount ?? 0}
+          limit={USER_LIST_LIMIT}
+        />
+      ) : null}
     </Paper>
   )
 }

--- a/packages/web/src/pages/chat-page/components/ChatBlastAudienceDisplay.tsx
+++ b/packages/web/src/pages/chat-page/components/ChatBlastAudienceDisplay.tsx
@@ -49,11 +49,13 @@ export const ChatBlastAudienceDisplay = (
           <IconInfo color='subdued' size='s' />
         </Tooltip>
       </Flex>
-      <UserProfilePictureList
-        users={users as User[]}
-        totalUserCount={audienceCount ?? 0}
-        limit={USER_LIST_LIMIT}
-      />
+      {users.length ? (
+        <UserProfilePictureList
+          users={users as User[]}
+          totalUserCount={audienceCount ?? 0}
+          limit={USER_LIST_LIMIT}
+        />
+      ) : null}
     </Paper>
   )
 }


### PR DESCRIPTION
### Description
Fixes a bug on mobile where navigating to chat blast thread caused app to crash. This fix works but not sure why.. @amendelsohn maybe you know a better fix?

### How Has This Been Tested?

Tested on local mobile and web stage