### PR TITLE
Add new shortened Challenge IDs to valid ID list on mobile

### DIFF
--- a/packages/mobile/src/components/challenge-rewards-drawer/ChallengeRewardsDrawerProvider.tsx
+++ b/packages/mobile/src/components/challenge-rewards-drawer/ChallengeRewardsDrawerProvider.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect } from 'react'
 
+import { ChallengeName } from '@audius/common/models'
 import { IntKeys, StringKeys } from '@audius/common/services'
 import type { CommonState } from '@audius/common/store'
 import {
@@ -141,11 +142,14 @@ export const ChallengeRewardsDrawerProvider = () => {
     switch (modalType) {
       case 'referrals':
       case 'ref-v':
+      case ChallengeName.Referrals:
+      case ChallengeName.ReferralsVerified:
         contents = (
           <ReferralRewardContents isVerified={!!config.isVerifiedChallenge} />
         )
         break
       case 'track-upload':
+      case ChallengeName.TrackUpload:
         contents = config?.buttonInfo && (
           <Button
             iconRight={config.buttonInfo.iconRight}
@@ -159,6 +163,7 @@ export const ChallengeRewardsDrawerProvider = () => {
         )
         break
       case 'profile-completion':
+      case ChallengeName.ProfileCompletion:
         contents = (
           <ProfileCompletionChecks
             isComplete={hasChallengeCompleted}

--- a/packages/mobile/src/screens/audio-screen/ChallengeRewards.tsx
+++ b/packages/mobile/src/screens/audio-screen/ChallengeRewards.tsx
@@ -62,7 +62,17 @@ const validRewardIds: Set<ChallengeRewardID> = new Set([
   'send-first-tip',
   'first-playlist',
   ChallengeName.AudioMatchingBuy, // $AUDIO matching buyer
-  ChallengeName.AudioMatchingSell // $AUDIO matching seller
+  ChallengeName.AudioMatchingSell, // $AUDIO matching seller
+  ChallengeName.ConnectVerified,
+  ChallengeName.FirstPlaylist,
+  ChallengeName.FirstTip,
+  ChallengeName.ListenStreak,
+  ChallengeName.MobileInstall,
+  ChallengeName.ProfileCompletion,
+  ChallengeName.Referrals,
+  ChallengeName.ReferralsVerified,
+  ChallengeName.Referred,
+  ChallengeName.TrackUpload
 ])
 
 type ClaimableSummaryTableItem = SummaryTableItem & {

--- a/packages/web/src/common/store/cache/collections/addTrackToPlaylistSaga.ts
+++ b/packages/web/src/common/store/cache/collections/addTrackToPlaylistSaga.ts
@@ -1,4 +1,10 @@
-import { Name, Kind, Collection, ID } from '@audius/common/models'
+import {
+  Name,
+  Kind,
+  Collection,
+  ID,
+  ChallengeName
+} from '@audius/common/models'
 import {
   cacheCollectionsActions,
   cacheCollectionsSelectors,
@@ -22,6 +28,7 @@ import { call, put, select, takeEvery } from 'typed-redux-saga'
 
 import { make } from 'common/store/analytics/actions'
 import { ensureLoggedIn } from 'common/utils/ensureLoggedIn'
+import { encodeHashId } from 'utils/hashIds'
 import { waitForWrite } from 'utils/sagaHelpers'
 
 import { optimisticUpdateCollection } from './utils/optimisticUpdateCollection'
@@ -126,6 +133,13 @@ function* addTrackToPlaylistAsync(action: AddTrackToPlaylistAction) {
     setOptimisticChallengeCompleted({
       challengeId: 'first-playlist',
       specifier: userId.toString()
+    })
+  )
+
+  yield* put(
+    setOptimisticChallengeCompleted({
+      challengeId: ChallengeName.FirstPlaylist,
+      specifier: encodeHashId(userId)
     })
   )
 

--- a/packages/web/src/pages/audio-rewards-page/components/modals/ChallengeRewardsModal/ChallengeRewardsModal.tsx
+++ b/packages/web/src/pages/audio-rewards-page/components/modals/ChallengeRewardsModal/ChallengeRewardsModal.tsx
@@ -4,6 +4,7 @@ import {
   formatCooldownChallenges,
   useChallengeCooldownSchedule
 } from '@audius/common/hooks'
+import { ChallengeName } from '@audius/common/models'
 import {
   accountSelectors,
   challengesSelectors,
@@ -107,8 +108,18 @@ const messages = {
   claimErrorAAO:
     'Your account is unable to claim rewards at this time. Please try again later or contact support@audius.co. ',
   claimableAmountLabel: (amount: number) => `Claim $${amount} AUDIO`,
-  twitterShare: (modalType: 'referrals' | 'ref-v') =>
-    `Share Invite With Your ${modalType === 'referrals' ? 'Friends' : 'Fans'}`,
+  twitterShare: (
+    modalType:
+      | 'referrals'
+      | 'ref-v'
+      | ChallengeName.Referrals
+      | ChallengeName.ReferralsVerified
+  ) =>
+    `Share Invite With Your ${
+      modalType === 'referrals' || modalType === ChallengeName.Referrals
+        ? 'Friends'
+        : 'Fans'
+    }`,
   twitterCopy: `Come support me on @audius! Use my link and we both earn $AUDIO when you sign up.\n\n #Audius #AudioRewards\n\n`,
   twitterReferralLabel: 'Share referral link on Twitter',
   verifiedChallenge: 'VERIFIED CHALLENGE',
@@ -170,7 +181,11 @@ export const InviteLink = ({ className, inviteLink }: InviteLinkProps) => {
 }
 
 type TwitterShareButtonProps = {
-  modalType: 'referrals' | 'ref-v'
+  modalType:
+    | 'referrals'
+    | 'ref-v'
+    | ChallengeName.Referrals
+    | ChallengeName.ReferralsVerified
   inviteLink: string
 }
 
@@ -483,7 +498,13 @@ const ChallengeRewardsBody = ({ dismissModal }: BodyProps) => {
   }
 
   const renderReferralContent = () => {
-    if (userHandle && (modalType === 'referrals' || modalType === 'ref-v')) {
+    if (
+      userHandle &&
+      (modalType === 'referrals' ||
+        modalType === 'ref-v' ||
+        modalType === ChallengeName.Referrals ||
+        modalType === ChallengeName.ReferralsVerified)
+    ) {
       return (
         <div className={wm(styles.buttonContainer)}>
           <TwitterShareButton modalType={modalType} inviteLink={inviteLink} />
@@ -496,7 +517,7 @@ const ChallengeRewardsBody = ({ dismissModal }: BodyProps) => {
   }
 
   const renderMobileInstallContent = () => {
-    if (modalType === 'mobile-install') {
+    if (modalType === 'mobile-install' || modalType === 'm') {
       return (
         <div className={wm(styles.qrContainer)}>
           <img className={styles.qr} src={QRCode} alt='QR Code' />
@@ -577,7 +598,10 @@ const ChallengeRewardsBody = ({ dismissModal }: BodyProps) => {
                 {renderProgressStatusLabel()}
               </Flex>
             </Paper>
-            {modalType === 'profile-completion' ? <ProfileChecks /> : null}
+            {modalType === 'profile-completion' ||
+            modalType === ChallengeName.ProfileCompletion ? (
+              <ProfileChecks />
+            ) : null}
             {renderCooldownSummaryTable()}
           </>
         ) : (
@@ -612,7 +636,10 @@ const ChallengeRewardsBody = ({ dismissModal }: BodyProps) => {
                 {renderProgressStatusLabel()}
                 {renderProgressBar()}
               </Flex>
-              {modalType === 'profile-completion' ? <ProfileChecks /> : null}
+              {modalType === 'profile-completion' ||
+              modalType === ChallengeName.ProfileCompletion ? (
+                <ProfileChecks />
+              ) : null}
             </Paper>
             {renderCooldownSummaryTable()}
           </>


### PR DESCRIPTION
### Description

Addresses missed UI updates from #9801 partially due to masked typings via `modalType`

- Updates Mobile to allow the new challenge IDs to display
- Updates referrals modal to respect the fan/friends language
- Addresses same check from `profile-completion` challenge to show the progress bar
etc.