### PR TITLE
Disable sort buttons while mutating data

### DIFF
--- a/packages/common/src/context/comments/commentsContext.tsx
+++ b/packages/common/src/context/comments/commentsContext.tsx
@@ -42,17 +42,17 @@ type CommentSectionContextType = {
   artistId: ID
   isEntityOwner: boolean
   commentCount: number
-  playTrack: () => void
   commentSectionLoading: boolean
   comments: Comment[]
   currentSort: TrackCommentsSortMethodEnum
   isLoadingMorePages: boolean
   hasMorePages: boolean
+  isMutating: boolean
+  setIsMutating: (isMutating: boolean) => void
+  playTrack: () => void
   reset: (hard?: boolean) => void
   setCurrentSort: (sort: TrackCommentsSortMethodEnum) => void
   loadMorePages: () => void
-  handleLoadMoreReplies: (commentId: string) => void
-  handleMuteEntityNotifications: () => void
 } & CommentSectionProviderProps
 
 export const CommentSectionContext = createContext<
@@ -76,6 +76,7 @@ export const CommentSectionProvider = (
   const [currentSort, setCurrentSort] = useState<TrackCommentsSortMethodEnum>(
     TrackCommentsSortMethodEnum.Top
   )
+  const [isMutating, setIsMutating] = useState(false)
 
   const { data: currentUserId } = useGetCurrentUserId({})
   const {
@@ -100,13 +101,6 @@ export const CommentSectionProvider = (
   const commentSectionLoading =
     status === Status.LOADING || status === Status.IDLE
 
-  const handleLoadMoreReplies = (commentId: string) => {
-    console.log('Loading more replies for', commentId)
-  }
-  const handleMuteEntityNotifications = () => {
-    console.log('Muting all notifs for ', entityId)
-  }
-
   if (!track) {
     return null
   }
@@ -125,6 +119,8 @@ export const CommentSectionProvider = (
         commentSectionLoading,
         isEntityOwner: currentUserId === owner_id,
         isLoadingMorePages: status === PaginatedStatus.LOADING_MORE,
+        isMutating,
+        setIsMutating,
         reset,
         hasMorePages,
         currentSort,
@@ -134,9 +130,7 @@ export const CommentSectionProvider = (
         setEditingComment,
         setCurrentSort,
         playTrack,
-        handleLoadMoreReplies,
-        loadMorePages: loadMore,
-        handleMuteEntityNotifications
+        loadMorePages: loadMore
       }}
     >
       {children}

--- a/packages/web/src/components/comments/CommentHeader.tsx
+++ b/packages/web/src/components/comments/CommentHeader.tsx
@@ -29,7 +29,7 @@ export const CommentHeader = (props: CommentHeaderProps) => {
   return (
     <Flex justifyContent='space-between' w='100%'>
       <Text variant='title' size='l'>
-        Comments ({!isLoading ? commentCount : '...'})
+        Comments {!isLoading ? `(${commentCount})` : null}
       </Text>
       {isEntityOwner && !isLoading ? (
         <PopupMenu

--- a/packages/web/src/components/comments/CommentSortBar.tsx
+++ b/packages/web/src/components/comments/CommentSortBar.tsx
@@ -9,23 +9,30 @@ const messages = {
 }
 
 export const CommentSortBar = () => {
-  const { currentSort, setCurrentSort } = useCurrentCommentSection()
+  const { currentSort, setCurrentSort, isMutating } = useCurrentCommentSection()
   return (
     <Flex gap='s'>
       <SelectablePill
         label={messages.top}
         isSelected={currentSort === TrackCommentsSortMethodEnum.Top}
         onClick={() => setCurrentSort(TrackCommentsSortMethodEnum.Top)}
+        disabled={isMutating && currentSort !== TrackCommentsSortMethodEnum.Top}
       />
       <SelectablePill
         label={messages.newest}
         isSelected={currentSort === TrackCommentsSortMethodEnum.Newest}
         onClick={() => setCurrentSort(TrackCommentsSortMethodEnum.Newest)}
+        disabled={
+          isMutating && currentSort !== TrackCommentsSortMethodEnum.Newest
+        }
       />
       <SelectablePill
         label={messages.timestamp}
         isSelected={currentSort === TrackCommentsSortMethodEnum.Timestamp}
         onClick={() => setCurrentSort(TrackCommentsSortMethodEnum.Timestamp)}
+        disabled={
+          isMutating && currentSort !== TrackCommentsSortMethodEnum.Timestamp
+        }
       />
     </Flex>
   )


### PR DESCRIPTION
### Description

Problem:
Changing the sort method refreshes the data and this overwrites any ongoing optimistic write changes we made

![2024-09-24 10 51 12](https://github.com/user-attachments/assets/5c70d332-cf1b-4c57-910f-c31a848efcb6)


Solution:
Only add optimistic updates to the current sort method data 
&
Disable the buttons until writes have gone through (confirmed/error)
![2024-09-24 11 03 20](https://github.com/user-attachments/assets/fdda6f3e-3630-4146-8281-1d8778d52185)

### How Has This Been Tested?

web:stage