### PR TITLE
[PAY-3462] Fix blast message ID ordering

### DIFF
--- a/comms/discovery/misc/blast_message_id.go
+++ b/comms/discovery/misc/blast_message_id.go
@@ -1,0 +1,6 @@
+package misc
+
+// Returns a unique Message ID for a blast message in a chat.
+func BlastMessageID(blastID, chatID string) string {
+	return blastID + chatID
+}

--- a/comms/discovery/rpcz/chat.go
+++ b/comms/discovery/rpcz/chat.go
@@ -85,7 +85,7 @@ func chatCreate(tx *sqlx.Tx, userId int32, ts time.Time, params schema.ChatCreat
 		values
 			($1, $2, $3, $4, $5)
 		on conflict do nothing
-		`, params.ChatID+blast.BlastID, params.ChatID, blast.FromUserID, blast.CreatedAt, blast.BlastID)
+		`, misc.BlastMessageID(blast.BlastID, params.ChatID), params.ChatID, blast.FromUserID, blast.CreatedAt, blast.BlastID)
 		if err != nil {
 			return err
 		}

--- a/comms/discovery/rpcz/chat_blast.go
+++ b/comms/discovery/rpcz/chat_blast.go
@@ -122,7 +122,7 @@ func chatBlast(tx *sqlx.Tx, userId int32, ts time.Time, params schema.ChatBlastR
 		INSERT INTO chat_message
 			(message_id, chat_id, user_id, created_at, blast_id)
 		SELECT
-			blast_id || targ.chat_id,
+			blast_id || targ.chat_id, -- this ordering needs to match Misc.BlastMessageID
 			targ.chat_id,
 			targ.from_user_id,
 			$2,
@@ -142,7 +142,7 @@ func chatBlast(tx *sqlx.Tx, userId int32, ts time.Time, params schema.ChatBlastR
 	// Formulate chat rpc messages for recipients who have an existing chat with sender
 	var outgoingMessages []OutgoingChatMessage
 	for _, result := range results {
-		messageID := params.BlastID + result.ChatID
+		messageID := misc.BlastMessageID(params.BlastID, result.ChatID)
 
 		isPlaintext := true
 		outgoingMessages = append(outgoingMessages, OutgoingChatMessage{


### PR DESCRIPTION
### Description
Need to enforce consistent message IDs for messages that came from blasts.

### How Has This Been Tested?
Tested on local stack - confirmed `chat_message` created from blast upgrade vs blast fan-out have consistent message IDs.
