### PR TITLE
[PAY-3459] Chat blast fan-out updates unread count

### DIFF
--- a/comms/discovery/rpcz/chat_blast.go
+++ b/comms/discovery/rpcz/chat_blast.go
@@ -130,6 +130,12 @@ func chatBlast(tx *sqlx.Tx, userId int32, ts time.Time, params schema.ChatBlastR
 		FROM targ
 		WHERE chat_allowed(from_user_id, to_user_id)
 		ON conflict do nothing
+	),
+	update_unread_count AS (
+    UPDATE chat_member
+    SET unread_count = unread_count + 1
+    WHERE chat_id IN (SELECT chat_id FROM targ)
+		AND user_id IN (SELECT to_user_id FROM targ)
 	)
 	SELECT chat_id FROM targ;
 	`


### PR DESCRIPTION
### Description
We need to update the `unread_count` for _only_ the recipient during chat blast fan-out.

This is getting pretty ugly.. now we have 3 places where we attempt to update unread count. Open to suggestions.

### How Has This Been Tested?

Tested locally with 2 users against local stack - observed unread count getting updated correctly on chat blast sends.