### PR TITLE
[C-5064] Fix comment_thread keys and notifications

### DIFF
--- a/packages/discovery-provider/ddl/functions/handle_comment_thread.sql
+++ b/packages/discovery-provider/ddl/functions/handle_comment_thread.sql
@@ -5,14 +5,16 @@ declare
   entity_user_id int;
   entity_id int;
   entity_type text;
+  blocknumber int;
+  created_at timestamp without time zone;
 begin
   select comments.user_id, comments.entity_id, comments.entity_type 
   into parent_comment_user_id, entity_id, entity_type 
   from comments 
   where comment_id = new.parent_comment_id;
 
-  select comments.user_id 
-  into comment_user_id 
+  select comments.user_id, comments.blocknumber, comments.created_at
+  into comment_user_id, blocknumber, created_at
   from comments 
   where comment_id = new.comment_id;
 
@@ -27,9 +29,9 @@ begin
         (blocknumber, user_ids, timestamp, type, specifier, group_id, data)
         values
         ( 
-          new.blocknumber,
+          blocknumber,
           ARRAY [parent_comment_user_id],
-          new.created_at, 
+          created_at, 
           'comment_thread',
           comment_user_id,
           'comment_thread:' || new.parent_comment_id,

--- a/packages/discovery-provider/ddl/functions/handle_comment_thread.sql
+++ b/packages/discovery-provider/ddl/functions/handle_comment_thread.sql
@@ -21,6 +21,8 @@ begin
   from tracks 
   where track_id = entity_id;
 
+  raise warning 'parent_comment_user_id: %, comment_user_id: %, entity_user_id: %, entity_id: %, entity_type: %', parent_comment_user_id, comment_user_id, entity_user_id, entity_id, entity_type;
+
   begin
     if comment_user_id != parent_comment_user_id then
       insert into notification

--- a/packages/discovery-provider/ddl/functions/handle_comment_thread.sql
+++ b/packages/discovery-provider/ddl/functions/handle_comment_thread.sql
@@ -21,8 +21,6 @@ begin
   from tracks 
   where track_id = entity_id;
 
-  raise warning 'parent_comment_user_id: %, comment_user_id: %, entity_user_id: %, entity_id: %, entity_type: %', parent_comment_user_id, comment_user_id, entity_user_id, entity_id, entity_type;
-
   begin
     if comment_user_id != parent_comment_user_id then
       insert into notification

--- a/packages/discovery-provider/integration_tests/tasks/entity_manager/test_comment.py
+++ b/packages/discovery-provider/integration_tests/tasks/entity_manager/test_comment.py
@@ -13,6 +13,7 @@ from src.models.comments.comment_mention import CommentMention
 from src.models.comments.comment_reaction import CommentReaction
 from src.models.comments.comment_report import CommentReport
 from src.models.comments.comment_thread import CommentThread
+from src.models.notifications.notification import Notification
 from src.tasks.entity_manager.entity_manager import entity_manager_update
 from src.utils.db_session import get_db
 
@@ -648,6 +649,9 @@ def test_comment_threads(app, mocker):
 
         comment_threads = session.query(CommentThread).all()
         assert len(comment_threads) == 1
-
         assert comment_threads[0].parent_comment_id == 1
         assert comment_threads[0].comment_id == 2
+
+        comment_notifications = session.query(Notification).all()
+        assert len(comment_notifications) == 1
+        assert comment_notifications[0].type == "comment_thread"

--- a/packages/discovery-provider/integration_tests/tasks/entity_manager/test_comment.py
+++ b/packages/discovery-provider/integration_tests/tasks/entity_manager/test_comment.py
@@ -12,6 +12,7 @@ from src.models.comments.comment import Comment
 from src.models.comments.comment_mention import CommentMention
 from src.models.comments.comment_reaction import CommentReaction
 from src.models.comments.comment_report import CommentReport
+from src.models.comments.comment_thread import CommentThread
 from src.tasks.entity_manager.entity_manager import entity_manager_update
 from src.utils.db_session import get_db
 
@@ -584,3 +585,69 @@ def test_comment_mentions(app, mocker):
 
         assert comment_mentions[2].is_delete == False
         assert comment_mentions[2].user_id == 3
+
+
+def test_comment_threads(app, mocker):
+    "Tests threads are saved to db"
+
+    reply_comment_metadata = {
+        "entity_id": 1,
+        "entity_type": "Track",
+        "user_id": 1,
+        "body": "reply comment text",
+        "parent_comment_id": 1,
+    }
+
+    entities = {
+        "users": [
+            {"user_id": 1, "handle": "artist1", "wallet": "user1wallet"},
+            {"user_id": 2, "handle": "artist2", "wallet": "user2wallet"},
+        ],
+        "tracks": [
+            {"track_id": 1, "owner_id": 1},
+        ],
+        "comments": [
+            {"comment_id": 1, "user_id": 2, "entity_id": 1, "entity_type": "Track"},
+        ],
+    }
+
+    tx_receipts = {
+        "CreateComment": [
+            {
+                "args": AttributeDict(
+                    {
+                        "_entityId": 2,
+                        "_entityType": "Comment",
+                        "_userId": 1,
+                        "_action": "Create",
+                        "_metadata": f'{{"cid": "", "data": {json.dumps(reply_comment_metadata)}}}',
+                        "_signer": "user1wallet",
+                    }
+                )
+            },
+        ],
+    }
+
+    entity_manager_txs, db, update_task = setup_test(app, mocker, entities, tx_receipts)
+
+    with db.scoped_session() as session:
+        # index transactions
+        entity_manager_update(
+            update_task,
+            session,
+            entity_manager_txs,
+            block_number=0,
+            block_timestamp=1585336422,
+            block_hash=hex(0),
+        )
+
+        # validate db records
+        comments = session.query(Comment).all()
+        assert len(comments) == 2
+        assert comments[1].text == "reply comment text"
+
+        comment_threads = session.query(CommentThread).all()
+        assert len(comment_threads) == 1
+
+        assert comment_threads[0].parent_comment_id == 1
+        assert comment_threads[0].comment_id == 2

--- a/packages/discovery-provider/integration_tests/utils.py
+++ b/packages/discovery-provider/integration_tests/utils.py
@@ -819,11 +819,6 @@ def populate_mock_db(db, entities, block_offset=None):
             comment_thread_record = CommentThread(
                 parent_comment_id=comment_threads_meta.get("parent_comment_id", i),
                 comment_id=comment_threads_meta.get("comment_id", i),
-                created_at=comment_threads_meta.get("created_at", datetime.now()),
-                updated_at=comment_threads_meta.get("updated_at", datetime.now()),
-                txhash=comment_threads_meta.get("txhash", str(i + block_offset)),
-                blockhash=comment_threads_meta.get("blockhash", str(i + block_offset)),
-                blocknumber=i + block_offset,
             )
             session.add(comment_thread_record)
         for i, comment_reactions_meta in enumerate(comment_reactions):

--- a/packages/discovery-provider/src/models/comments/comment_thread.py
+++ b/packages/discovery-provider/src/models/comments/comment_thread.py
@@ -1,4 +1,4 @@
-from sqlalchemy import Column, Integer, PrimaryKeyConstraint, Text
+from sqlalchemy import Column, Integer, PrimaryKeyConstraint
 
 from src.models.base import Base
 from src.models.model_utils import RepresentableMixin

--- a/packages/discovery-provider/src/models/comments/comment_thread.py
+++ b/packages/discovery-provider/src/models/comments/comment_thread.py
@@ -1,4 +1,4 @@
-from sqlalchemy import Column, DateTime, ForeignKey, Integer, PrimaryKeyConstraint, Text
+from sqlalchemy import Column, Integer, PrimaryKeyConstraint, Text
 
 from src.models.base import Base
 from src.models.model_utils import RepresentableMixin
@@ -10,11 +10,6 @@ class CommentThread(Base, RepresentableMixin):
     comment_id = Column(Integer)
     parent_comment_id = Column(Integer)
     PrimaryKeyConstraint(parent_comment_id, comment_id)
-    created_at = Column(DateTime, nullable=False)
-    updated_at = Column(DateTime, nullable=False)
-    txhash = Column(Text, nullable=False)
-    blockhash = Column(Text, nullable=False)
-    blocknumber = Column(Integer, ForeignKey("blocks.number"), nullable=False)
 
     def get_attributes_dict(self):
         return {col.name: getattr(self, col.name) for col in self.__table__.columns}

--- a/packages/discovery-provider/src/models/comments/comment_thread.py
+++ b/packages/discovery-provider/src/models/comments/comment_thread.py
@@ -9,7 +9,7 @@ class CommentThread(Base, RepresentableMixin):
 
     comment_id = Column(Integer)
     parent_comment_id = Column(Integer)
-    PrimaryKeyConstraint(comment_id, parent_comment_id)
+    PrimaryKeyConstraint(parent_comment_id, comment_id)
     created_at = Column(DateTime, nullable=False)
     updated_at = Column(DateTime, nullable=False)
     txhash = Column(Text, nullable=False)

--- a/packages/discovery-provider/src/tasks/entity_manager/entities/comment.py
+++ b/packages/discovery-provider/src/tasks/entity_manager/entities/comment.py
@@ -84,20 +84,22 @@ def create_comment(params: ManageEntityParameters):
                 EntityType.COMMENT_MENTION,
             )
 
-    if params.metadata["parent_comment_id"]:
+    if params.metadata.get("parent_comment_id"):
+        parent_comment_id = params.metadata.get("parent_comment_id")
         existing_comment_thread = (
             params.session.query(CommentThread)
             .filter_by(
-                parent_comment_id=params.metadata["parent_comment_id"],
+                parent_comment_id=parent_comment_id,
                 comment_id=comment_id,
             )
             .first()
         )
+
         if existing_comment_thread:
             return
 
         comment_thread = CommentThread(
-            parent_comment_id=params.metadata["parent_comment_id"],
+            parent_comment_id=parent_comment_id,
             comment_id=comment_id,
             txhash=params.txhash,
             blockhash=params.event_blockhash,
@@ -105,7 +107,9 @@ def create_comment(params: ManageEntityParameters):
             created_at=params.block_datetime,
             updated_at=params.block_datetime,
         )
-        params.session.add(comment_thread)
+        params.add_record(
+            (parent_comment_id, comment_id), comment_thread, EntityType.COMMENT_THREAD
+        )
 
 
 def update_comment(params: ManageEntityParameters):

--- a/packages/discovery-provider/src/tasks/entity_manager/entities/comment.py
+++ b/packages/discovery-provider/src/tasks/entity_manager/entities/comment.py
@@ -101,11 +101,6 @@ def create_comment(params: ManageEntityParameters):
         comment_thread = CommentThread(
             parent_comment_id=parent_comment_id,
             comment_id=comment_id,
-            txhash=params.txhash,
-            blockhash=params.event_blockhash,
-            blocknumber=params.block_number,
-            created_at=params.block_datetime,
-            updated_at=params.block_datetime,
         )
         params.add_record(
             (parent_comment_id, comment_id), comment_thread, EntityType.COMMENT_THREAD

--- a/packages/discovery-provider/src/tasks/entity_manager/utils.py
+++ b/packages/discovery-provider/src/tasks/entity_manager/utils.py
@@ -16,6 +16,7 @@ from src.models.comments.comment import Comment
 from src.models.comments.comment_mention import CommentMention
 from src.models.comments.comment_reaction import CommentReaction
 from src.models.comments.comment_report import CommentReport
+from src.models.comments.comment_thread import CommentThread
 from src.models.dashboard_wallet_user.dashboard_wallet_user import DashboardWalletUser
 from src.models.grants.developer_app import DeveloperApp
 from src.models.grants.grant import Grant
@@ -114,6 +115,7 @@ class EntityType(str, Enum):
     COMMENT = "Comment"
     COMMENT_REACTION = "CommentReaction"
     COMMENT_REPORT = "CommentReport"
+    COMMENT_THREAD = "CommentThread"
     COMMENT_MENTION = "CommentMention"
     MUTED_USER = "MutedUser"
     REPORTED_COMMENT = "ReportedComment"
@@ -175,6 +177,7 @@ class ExistingRecordDict(TypedDict):
     CommentReaction: Dict[Tuple, CommentReaction]
     CommentReport: Dict[Tuple, CommentReport]
     CommentMention: Dict[Tuple, CommentMention]
+    CommentThread: Dict[Tuple, CommentThread]
     MutedUser: Dict[Tuple, MutedUser]
     ReportedComment: Dict[Tuple, ReportedComment]
 


### PR DESCRIPTION
### Description

Fixes a few issues i noticed with comment_threads and issues with notifications
- We were not constructing pkeys correctly, it should be (parent_comment_id, comment_id)
- We were not adding comment_threads to the records to commit correctly, resulting in them being commited before the comment was committed, which resulted in no thread notifications to be constructed.

There is also another issue where we are doing a sql query inline the `create_comment` code, shouldn't we be prefetching them efficiently like we do with other entities?

### How Has This Been Tested?

Added a new indexing test to ensure this is working as expected
