### PR TITLE
[PAY-3457] Fix chat blast triggering chatlist resort

### DIFF
--- a/packages/common/src/store/pages/chat/slice.ts
+++ b/packages/common/src/store/pages/chat/slice.ts
@@ -487,7 +487,8 @@ const slice = createSlice({
 
       // Always update the last message, but don't update
       // last_message_at if it's a blast message sent by current user,
-      // to avoid chat list re-sorting
+      // to avoid chat list re-sorting.
+      // Note: is_plaintext indicates that the message originated from a blast
       const existingChat = getChat(state, chatId)
       const changes = {
         last_message: message.message,

--- a/packages/common/src/store/pages/chat/slice.ts
+++ b/packages/common/src/store/pages/chat/slice.ts
@@ -490,12 +490,15 @@ const slice = createSlice({
       // to avoid chat list re-sorting.
       // Note: is_plaintext indicates that the message originated from a blast
       const existingChat = getChat(state, chatId)
-      const changes = {
-        last_message: message.message,
-        ...(message.is_plaintext && isSelfMessage && !existingChat?.is_blast
-          ? {}
-          : { last_message_at: message.created_at })
-      }
+      const changes =
+        message.is_plaintext && isSelfMessage && !existingChat?.is_blast
+          ? {
+              last_message: message.message
+            }
+          : {
+              last_message: message.message,
+              last_message_at: message.created_at
+            }
 
       chatsAdapter.updateOne(state.chats, {
         id: chatId,


### PR DESCRIPTION
### Description
Previously, sending a blast would cause the left chat list bar to re-sort, as the blast was fanned-out to the 1-1 chat threads, causing their `last_message_at` timestamp to be updated sequentially.

This PR only updates `last_message_at` when:
- the sender of the message is the current user
- it's a blast message (using `is_plaintext` as a proxy for whether the message came from a blast or not)
- the current chat is not the blast thread itself

### How Has This Been Tested?

https://github.com/user-attachments/assets/b0bd34c9-d08f-46e0-87df-24515aef8bdf


