### PR TITLE
[C-5054] Fix tombstone comments + add tests

### DIFF
--- a/packages/discovery-provider/integration_tests/queries/test_get_comments.py
+++ b/packages/discovery-provider/integration_tests/queries/test_get_comments.py
@@ -155,3 +155,103 @@ def test_get_comments_replies(app):
         )
         for comment in comments:
             assert 103 <= decode_string_id(comment["id"]) <= 105
+
+
+def test_get_deleted_comments(app):
+    entities = {
+        "comments": [
+            {
+                "comment_id": 0,
+                "user_id": 1,
+                "entity_id": 1,
+                "entity_type": "Track",
+                "created_at": datetime(2022, 1, 2),
+                "track_timestamp_s": 2,
+            },
+            {
+                "comment_id": 1,
+                "user_id": 1,
+                "entity_id": 1,
+                "entity_type": "Track",
+                "created_at": datetime(2022, 1, 2),
+                "track_timestamp_s": 3,
+                "is_delete": True,
+            },
+        ],
+        "tracks": [{"track_id": 1, "owner_id": 10}],
+    }
+
+    with app.app_context():
+        db = get_db()
+        populate_mock_db(db, entities)
+
+        comments = get_track_comments({"sort_method": "top"}, 1)
+        assert len(comments) == 1
+
+
+def test_get_tombstone_comments(app):
+    entities = {
+        "comments": [
+            {
+                "comment_id": i,
+                "user_id": 1,
+                "entity_id": 1,
+                "entity_type": "Track",
+                "created_at": datetime(2022, 1, 2),
+                "track_timestamp_s": 2,
+                "is_pinned": True,
+            }
+            for i in range(1, 5)
+        ]
+        + [
+            {  # deleted comment
+                "comment_id": 0,
+                "user_id": 1,
+                "entity_id": 1,
+                "entity_type": "Track",
+                "created_at": datetime(2022, 1, 1),
+                "track_timestamp_s": 1,
+                "is_delete": True,
+            },
+            {  # this comment is a reply to the deleted comment
+                "comment_id": 6,
+                "user_id": 1,
+                "entity_id": 1,
+                "entity_type": "Track",
+                "created_at": datetime(2022, 1, 2),
+                "track_timestamp_s": 2,
+                "is_pinned": False,
+            },
+        ],
+        "tracks": [{"track_id": 1, "owner_id": 10}],
+        "comment_threads": [{"parent_comment_id": 0, "comment_id": 6}],
+    }
+
+    with app.app_context():
+        db = get_db()
+        populate_mock_db(db, entities)
+
+        # sort by top
+        comments = get_track_comments({"sort_method": "top"}, 1)
+
+        assert decode_string_id(comments[0]["id"]) == 1  # misc comment should be top
+        assert (
+            decode_string_id(comments[-1]["id"]) == 0
+        )  # deleted comment should be last
+        assert comments[-1]["is_tombstone"] == True  # deleted comment should be last
+
+        # sort by newest
+        comments = get_track_comments({"sort_method": "newest"}, 1)
+        assert decode_string_id(comments[0]["id"]) == 1  # misc comment should be top
+        assert (
+            decode_string_id(comments[-1]["id"]) == 0
+        )  # deleted comment should be last
+        assert comments[-1]["is_tombstone"] == True  # deleted comment should be last
+
+        # sort by timestamp
+        comments = get_track_comments({"sort_method": "timestamp"}, 1)
+        assert decode_string_id(comments[0]["id"]) == 1  # misc comment should be top
+        assert (
+            decode_string_id(comments[-1]["id"])
+        ) == 0  # deleted comment should be last
+        assert comments[-1]["is_tombstone"] == True  # deleted comment should be last

--- a/packages/discovery-provider/integration_tests/utils.py
+++ b/packages/discovery-provider/integration_tests/utils.py
@@ -805,6 +805,7 @@ def populate_mock_db(db, entities, block_offset=None):
                 text=comment_meta.get("text", ""),
                 is_pinned=comment_meta.get("is_pinned", False),
                 is_edited=comment_meta.get("is_edited", False),
+                is_delete=comment_meta.get("is_delete", False),
                 created_at=comment_meta.get("created_at", datetime.now()),
                 updated_at=comment_meta.get("updated_at", datetime.now()),
                 track_timestamp_s=comment_meta.get("track_timestamp_s", None),


### PR DESCRIPTION
### Description

On stage right now if you go to a track with "tombstone" comments (e.g. https://staging.audius.co/dejayjdstaging/a-little-gambling-copy-15-3) 
You'll notice that the data between the sorts are different. 
Reason is because the way I implemented "tombstone" comments was incorrect; I was filtering them out in python instead of SQL - this meant sometimes the page count was less than we expected and the pagination would just stop on the client side.

Fixed by incorporating the reply count check into the SQL query

Updated test too

### How Has This Been Tested?

web:dev & pytest