### PR TITLE
PAY-3326 Remove optionality from include_network_cut

### DIFF
--- a/packages/discovery-provider/integration_tests/queries/test_get_extended_purchase_gate.py
+++ b/packages/discovery-provider/integration_tests/queries/test_get_extended_purchase_gate.py
@@ -177,7 +177,6 @@ def test_get_extended_splits_with_network_cut(app):
                 }
             },
             session,
-            include_network_cut=True,
         )
         assert res is not None
         assert res["usdc_purchase"]["splits"][0]["amount"] == 900000
@@ -193,7 +192,7 @@ def test_get_extended_splits_with_network_cut(app):
             session, [{"user_id": 1, "percentage": 100}], datetime.date(2024, 5, 2)
         )
         assert splits[0]["payout_wallet"] == "first-wallet"
-        splits = calculate_split_amounts(100, splits, include_network_cut=True)
+        splits = calculate_split_amounts(100, splits)
         legacy_splits = to_wallet_amount_map(splits)
         assert "first-wallet" in legacy_splits
         assert legacy_splits["first-wallet"] == 900000
@@ -205,9 +204,7 @@ def test_get_extended_splits_with_network_cut(app):
             session, [{"user_id": 1, "percentage": 100}], datetime.date(2024, 4, 1)
         )
         assert even_older_splits[0]["payout_wallet"] == "user-bank"
-        even_older_splits = calculate_split_amounts(
-            100, even_older_splits, include_network_cut=True
-        )
+        even_older_splits = calculate_split_amounts(100, even_older_splits)
         legacy_splits = to_wallet_amount_map(even_older_splits)
         assert "user-bank" in legacy_splits
         assert legacy_splits["user-bank"] == 900000
@@ -219,9 +216,7 @@ def test_get_extended_splits_with_network_cut(app):
             session, [{"user_id": 2, "percentage": 100}], datetime.date(2024, 4, 1)
         )
         assert other_user_splits[0]["payout_wallet"] is None
-        other_user_splits = calculate_split_amounts(
-            100, other_user_splits, include_network_cut=True
-        )
+        other_user_splits = calculate_split_amounts(100, other_user_splits)
         other_user_splits = to_wallet_amount_map(other_user_splits)
         assert "3XmVeZ6M1FYDdUQaNeQZf8dipvtzNP6NVb5xjDkdeiNb" in other_user_splits
         assert (

--- a/packages/discovery-provider/src/api/v1/playlists.py
+++ b/packages/discovery-provider/src/api/v1/playlists.py
@@ -688,14 +688,6 @@ access_info_response = make_response(
     "access_info_response", ns, fields.Nested(album_access_info)
 )
 
-access_info_parser = current_user_parser.copy()
-access_info_parser.add_argument(
-    "include_network_cut",
-    required=False,
-    type=bool,
-    description="Whether to include the staking system as a recipient",
-)
-
 
 @ns.route("/<string:playlist_id>/access-info")
 class GetPlaylistAccessInfo(Resource):
@@ -705,11 +697,10 @@ class GetPlaylistAccessInfo(Resource):
         description="Gets the information necessary to access the playlist and what access the given user has.",
         params={"playlist_id": "A Playlist ID"},
     )
-    @ns.expect(access_info_parser)
+    @ns.expect(current_user_parser)
     @ns.marshal_with(access_info_response)
     def get(self, playlist_id: str):
         args = current_user_parser.parse_args()
-        include_network_cut = args.get("include_network_cut")
         decoded_id = decode_with_abort(playlist_id, ns)
         current_user_id = get_current_user_id(args)
         playlists = get_playlists(
@@ -722,9 +713,7 @@ class GetPlaylistAccessInfo(Resource):
         if not playlists:
             abort_not_found(playlist_id, ns)
         raw = playlists[0]
-        stream_conditions = get_extended_purchase_gate(
-            gate=raw["stream_conditions"], include_network_cut=include_network_cut
-        )
+        stream_conditions = get_extended_purchase_gate(gate=raw["stream_conditions"])
         playlist = extend_playlist(raw)
         playlist["stream_conditions"] = stream_conditions
         return success_response(playlist)

--- a/packages/discovery-provider/src/queries/get_extended_purchase_gate.py
+++ b/packages/discovery-provider/src/queries/get_extended_purchase_gate.py
@@ -103,7 +103,7 @@ staking_bridge_usdc_payout_wallet = shared_config["solana"][
 
 
 def calculate_split_amounts(
-    price: int | None, splits: List[Split], include_network_cut=False
+    price: int | None, splits: List[Split]
 ) -> List[ExtendedSplit]:
     """
     Deterministically calculates the USDC amounts to pay to each person,
@@ -117,9 +117,8 @@ def calculate_split_amounts(
     new_splits: List[Dict] = []
 
     # Deduct network cut from the total price
-    if include_network_cut:
-        network_cut = int(price_in_usdc * network_take_rate / 100)
-        price_in_usdc -= network_cut
+    network_cut = int(price_in_usdc * network_take_rate / 100)
+    price_in_usdc -= network_cut
 
     for index in range(len(splits)):
         split = splits[index]
@@ -156,14 +155,14 @@ def calculate_split_amounts(
         del s["_index"]
         del s["_amount_fractional"]
 
-    if include_network_cut:
-        new_splits.append(
-            {
-                "percentage": network_take_rate,
-                "amount": network_cut,
-                "payout_wallet": staking_bridge_usdc_payout_wallet,
-            }
-        )
+    # append network cut
+    new_splits.append(
+        {
+            "percentage": network_take_rate,
+            "amount": network_cut,
+            "payout_wallet": staking_bridge_usdc_payout_wallet,
+        }
+    )
     return [cast(ExtendedSplit, split) for split in new_splits]
 
 
@@ -230,46 +229,40 @@ def to_wallet_amount_map(splits: List[ExtendedSplit]):
     }
 
 
-def _get_extended_purchase_gate(
-    session: Session, gate: PurchaseGate, include_network_cut=False
-):
+def _get_extended_purchase_gate(session: Session, gate: PurchaseGate):
     price = gate.get("usdc_purchase", {}).get("price", None)
     original_splits = gate.get("usdc_purchase", {}).get("splits", [])
     splits = [orig.copy() for orig in original_splits]
     splits = add_wallet_info_to_splits(session, splits, datetime.now())
-    extended_splits = calculate_split_amounts(price, splits, include_network_cut)
+    extended_splits = calculate_split_amounts(price, splits)
     extended_gate: ExtendedPurchaseGate = {
         "usdc_purchase": {"price": price, "splits": extended_splits}
     }
     return extended_gate
 
 
-def get_extended_purchase_gate(
-    gate: AccessGate, session=None, include_network_cut=False
-):
+def get_extended_purchase_gate(gate: AccessGate, session=None):
     if gate and "usdc_purchase" in gate:
         # mypy gets confused....
         gate = cast(PurchaseGate, gate)
         if session:
-            return _get_extended_purchase_gate(session, gate, include_network_cut)
+            return _get_extended_purchase_gate(session, gate)
         else:
             db: SessionManager = get_db_read_replica()
             with db.scoped_session() as session:
-                return _get_extended_purchase_gate(session, gate, include_network_cut)
+                return _get_extended_purchase_gate(session, gate)
 
 
-def get_legacy_purchase_gate(gate: AccessGate, session=None, include_network_cut=False):
+def get_legacy_purchase_gate(gate: AccessGate, session=None):
     if gate and "usdc_purchase" in gate:
         # mypy gets confused....
         gate = cast(PurchaseGate, gate)
         if session:
-            new_gate = _get_extended_purchase_gate(session, gate, include_network_cut)
+            new_gate = _get_extended_purchase_gate(session, gate)
         else:
             db: SessionManager = get_db_read_replica()
             with db.scoped_session() as session:
-                new_gate = _get_extended_purchase_gate(
-                    session, gate, include_network_cut
-                )
+                new_gate = _get_extended_purchase_gate(session, gate)
         extended_splits = new_gate["usdc_purchase"]["splits"]
         splits = to_wallet_amount_map(extended_splits)
         new_gate["usdc_purchase"]["splits"] = splits

--- a/packages/discovery-provider/src/tasks/index_payment_router.py
+++ b/packages/discovery-provider/src/tasks/index_payment_router.py
@@ -240,7 +240,7 @@ def get_tx_in_db(session: Session, tx_sig: str) -> bool:
 
 
 def parse_route_transaction_memos(
-    session: Session, memos: List[str], timestamp: datetime, include_network_cut: bool
+    session: Session, memos: List[str], timestamp: datetime
 ) -> Tuple[RouteTransactionMemo | None, GeoMetadataDict | None]:
     """Checks the list of memos for one matching a format of a purchase's content_metadata, and then uses that content_metadata to find the stream_conditions associated with that content to get the price"""
     if len(memos) == 0:
@@ -372,9 +372,7 @@ def parse_route_transaction_memos(
                 and content_owner_id is not None
             ):
                 wallet_splits = add_wallet_info_to_splits(session, splits, timestamp)
-                extended_splits = calculate_split_amounts(
-                    price, wallet_splits, include_network_cut=include_network_cut
-                )
+                extended_splits = calculate_split_amounts(price, wallet_splits)
                 route_transaction_memo = RouteTransactionMemo(
                     type=RouteTransactionMemoType.purchase,
                     metadata={
@@ -757,16 +755,9 @@ def process_route_instruction(
         )
     elif is_usdc:
         logger.debug(f"index_payment_router.py | Parsing memos: {memos}")
-        include_network_cut = (
-            shared_config["solana"]["staking_bridge_usdc_payout_wallet"]
-            in receiver_accounts
-        )
 
         memo, geo_metadata = parse_route_transaction_memos(
-            session=session,
-            memos=memos,
-            timestamp=timestamp,
-            include_network_cut=include_network_cut,
+            session=session, memos=memos, timestamp=timestamp
         )
         validate_and_index_usdc_transfers(
             session=session,


### PR DESCRIPTION
### Description

Makes including a network split non-optional.

### How Has This Been Tested?

`audius-cmd` purchased content and then tried to repurchase, says already purchased. Displayed network split in debug console logs