### PR TITLE
[PAY-3445] Fix Chat Blast CTA footer positioning

### DIFF
--- a/packages/web/src/components/search-users-modal/SearchUsersModal.tsx
+++ b/packages/web/src/components/search-users-modal/SearchUsersModal.tsx
@@ -238,9 +238,7 @@ export const SearchUsersModal = ({
         onClose={handleClose}
         {...rest}
       />
-      <Box w='100%' css={{ position: 'absolute', bottom: 0 }}>
-        {footer ?? null}
-      </Box>
+      {footer ?? null}
     </Modal>
   )
 }


### PR DESCRIPTION
### Description

- Don't overlay the CTA on the dms user list

### How Has This Been Tested?

scrolling works again, and scrolls the full user list. Loading indicator is visible north of the CTA instead of hidden behind it