### PR TITLE
Fix comment optimistic writes

### DIFF
--- a/packages/common/src/api/comments.ts
+++ b/packages/common/src/api/comments.ts
@@ -191,7 +191,7 @@ const commentsApi = createApi({
             userId
           )
         }
-        return { tempId: newId }
+        return { newId }
       }
     },
     deleteCommentById: {

--- a/packages/web/src/components/comments/CommentBlock.tsx
+++ b/packages/web/src/components/comments/CommentBlock.tsx
@@ -139,7 +139,7 @@ const CommentBlockInternal = (
             onClickReply={() => setShowReplyInput((prev) => !prev)}
             onClickEdit={() => setShowEditInput((prev) => !prev)}
             onClickDelete={() => deleteComment(commentId)}
-            isDisabled={isCommentLoading || isTombstone}
+            isDisabled={isTombstone}
             hideReactCount={isTombstone}
           />
         )}

--- a/packages/web/src/components/comments/CommentBlock.tsx
+++ b/packages/web/src/components/comments/CommentBlock.tsx
@@ -62,7 +62,6 @@ const CommentBlockInternal = (
   // This status checks specifically for this comment - no matter where the post request originated
   const commentPostStatus = useCommentPostStatus(comment)
 
-  const isCommentLoading = commentPostStatus === Status.LOADING
   useStatusChange(commentPostStatus, {
     onSuccess: () => setShowReplyInput(false)
   })


### PR DESCRIPTION
### Description

Fixed the bug where writes on optimistic/in-confirmation comments to not work.

The bug was painfully simple; we weren't passing the new id we were generating in client properly, so the SDK was generating & using a different id than client 🙈 

I re-enabled the action buttons and its working as expected now 👍 

![2024-09-26 10 53 03](https://github.com/user-attachments/assets/b1259c3d-6b23-47ff-a123-0020cef1d59f)


### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._
