### PR TITLE
[C-4996] Linkify web comments

### DIFF
--- a/packages/harmony/src/components/text/Text.tsx
+++ b/packages/harmony/src/components/text/Text.tsx
@@ -85,8 +85,8 @@ export const Text = forwardRef(
         overflow: 'hidden',
         display: '-webkit-box',
         lineClamp: `${maxLines}`,
-        '-webkit-line-clamp': `${maxLines}`,
-        '-webkit-box-orient': 'vertical'
+        WebkitLineClamp: `${maxLines}`,
+        WebkitBoxOrient: 'vertical'
       })
     }
 

--- a/packages/mobile/src/components/comments/CommentText.tsx
+++ b/packages/mobile/src/components/comments/CommentText.tsx
@@ -3,7 +3,7 @@ import { useCallback, useState } from 'react'
 import { useCurrentCommentSection } from '@audius/common/context'
 import { useGatedContentAccess } from '@audius/common/hooks'
 import { commentsMessages as messages } from '@audius/common/messages'
-import { isContentUSDCPurchaseGated, ModalSource } from '@audius/common/models'
+import { ModalSource } from '@audius/common/models'
 import {
   playerActions,
   PurchaseableContentType,
@@ -19,9 +19,9 @@ import { useDispatch, useSelector } from 'react-redux'
 
 import { Flex, Text, TextLink } from '@audius/harmony-native'
 import { UserGeneratedText } from 'app/components/core'
+
 const { tracksActions } = trackPageLineupActions
 const { getLineup } = trackPageSelectors
-
 const { seek } = playerActions
 
 const MAX_LINES = 3
@@ -37,12 +37,9 @@ const TimestampLink = (props: TimestampLinkProps) => {
   const dispatch = useDispatch()
   const { track } = useCurrentCommentSection()
   const lineup = useSelector(getLineup)
-  const { track_id: trackId, stream_conditions: streamConditions } = track
+  const { track_id: trackId } = track
 
-  const isUSDCPurchaseGated = isContentUSDCPurchaseGated(streamConditions)
   const { hasStreamAccess } = useGatedContentAccess(track)
-
-  const isLocked = isUSDCPurchaseGated && !hasStreamAccess
 
   const uid = lineup?.entries?.[0]?.uid
   const { onOpen: openPremiumContentPurchaseModal } =
@@ -51,7 +48,7 @@ const TimestampLink = (props: TimestampLinkProps) => {
   return (
     <TextLink
       onPress={() => {
-        if (isLocked) {
+        if (!hasStreamAccess) {
           openPremiumContentPurchaseModal(
             { contentId: trackId, contentType: PurchaseableContentType.TRACK },
             {
@@ -76,7 +73,8 @@ export type CommentTextProps = {
   isEdited?: boolean
 }
 
-export const CommentText = ({ children, isEdited }: CommentTextProps) => {
+export const CommentText = (props: CommentTextProps) => {
+  const { children, isEdited } = props
   const [isOverflowing, setIsOverflowing] = useState(false)
   const [isExpanded, setIsExpanded] = useState(false)
   const {

--- a/packages/mobile/src/components/core/UserGeneratedText.tsx
+++ b/packages/mobile/src/components/core/UserGeneratedText.tsx
@@ -115,6 +115,7 @@ export const UserGeneratedText = (props: UserGeneratedTextProps) => {
     linkProps,
     suffix,
     matchers,
+    internalLinksOnly,
     ...other
   } = props
 
@@ -191,7 +192,7 @@ export const UserGeneratedText = (props: UserGeneratedTextProps) => {
   const renderLink = useCallback(
     (text: string, match: Match) => {
       const url = match.getAnchorHref()
-      const shouldLinkify = !props.internalLinksOnly || isAudiusUrl(url)
+      const shouldLinkify = !internalLinksOnly || isAudiusUrl(url)
       return shouldLinkify ? (
         <Link
           {...other}

--- a/packages/web/src/components/comments/CommentBlock.tsx
+++ b/packages/web/src/components/comments/CommentBlock.tsx
@@ -7,7 +7,6 @@ import {
   useDeleteComment
 } from '@audius/common/context'
 import { useStatusChange } from '@audius/common/hooks'
-import { commentsMessages as messages } from '@audius/common/messages'
 import { Comment, ID, ReplyComment, Status } from '@audius/common/models'
 import { cacheUsersSelectors } from '@audius/common/store'
 import { Box, Flex, Text } from '@audius/harmony'
@@ -21,6 +20,7 @@ import { ArtistPick } from './ArtistPick'
 import { CommentActionBar } from './CommentActionBar'
 import { CommentBadge } from './CommentBadge'
 import { CommentForm } from './CommentForm'
+import { CommentText } from './CommentText'
 import { Timestamp } from './Timestamp'
 import { TimestampLink } from './TimestampLink'
 const { getUser } = cacheUsersSelectors
@@ -128,12 +128,7 @@ const CommentBlockInternal = (
             hideAvatar
           />
         ) : (
-          <Text variant='body' size='s' lineHeight='multi' textAlign='left'>
-            {message}
-            {isEdited ? (
-              <Text color='subdued'> ({messages.edited})</Text>
-            ) : null}
-          </Text>
+          <CommentText isEdited={isEdited}>{message}</CommentText>
         )}
         {hideActions ? null : (
           <CommentActionBar

--- a/packages/web/src/components/comments/CommentText.tsx
+++ b/packages/web/src/components/comments/CommentText.tsx
@@ -112,7 +112,7 @@ export const CommentText = (props: CommentTextProps) => {
           matchers={[
             {
               pattern: timestampRegex,
-              renderLink: (text) => {
+              renderLink: (text, _, index) => {
                 const matches = [...text.matchAll(new RegExp(timestampRegex))]
 
                 if (matches.length === 0) return null
@@ -124,12 +124,11 @@ export const CommentText = (props: CommentTextProps) => {
 
                 return showLink ? (
                   <TimestampLink
+                    key={index}
                     timestamp={text}
                     timestampSeconds={timestampSeconds}
                   />
-                ) : (
-                  <Text size='s'>{text}</Text>
-                )
+                ) : null
               }
             }
           ]}

--- a/packages/web/src/components/comments/CommentText.tsx
+++ b/packages/web/src/components/comments/CommentText.tsx
@@ -1,11 +1,72 @@
 import { useRef, useState } from 'react'
 
+import { useCurrentCommentSection } from '@audius/common/context'
+import { useGatedContentAccess } from '@audius/common/hooks'
+import { commentsMessages as messages } from '@audius/common/messages'
+import { ModalSource } from '@audius/common/models'
+import {
+  playerActions,
+  PurchaseableContentType,
+  trackPageLineupActions,
+  trackPageSelectors,
+  usePremiumContentPurchaseModal
+} from '@audius/common/store'
+import {
+  getDurationFromTimestampMatch,
+  timestampRegex
+} from '@audius/common/utils'
 import { Flex, Text, TextLink } from '@audius/harmony'
+import { useDispatch, useSelector } from 'react-redux'
 import { useEffectOnce } from 'react-use'
 
-const messages = {
-  seeMore: 'See More',
-  seeLess: 'See Less'
+import { UserGeneratedTextV2 } from 'components/user-generated-text/UserGeneratedTextV2'
+
+const { tracksActions } = trackPageLineupActions
+const { getLineup } = trackPageSelectors
+const { seek } = playerActions
+
+type TimestampLinkProps = {
+  timestamp: string
+  timestampSeconds: number
+}
+
+const TimestampLink = (props: TimestampLinkProps) => {
+  const { timestamp, timestampSeconds } = props
+
+  const dispatch = useDispatch()
+  const { track } = useCurrentCommentSection()
+  const lineup = useSelector(getLineup)
+  const { track_id: trackId } = track
+
+  const { hasStreamAccess } = useGatedContentAccess(track)
+
+  const uid = lineup?.entries?.[0]?.uid
+  const { onOpen: openPremiumContentPurchaseModal } =
+    usePremiumContentPurchaseModal()
+
+  return (
+    <TextLink
+      onClick={() => {
+        if (!hasStreamAccess) {
+          openPremiumContentPurchaseModal(
+            { contentId: trackId, contentType: PurchaseableContentType.TRACK },
+            {
+              source: ModalSource.Comment
+            }
+          )
+        } else {
+          dispatch(tracksActions.play(uid))
+          setTimeout(() => {
+            dispatch(seek({ seconds: timestampSeconds }))
+          })
+        }
+      }}
+      variant='visible'
+      size='s'
+    >
+      {timestamp}
+    </TextLink>
+  )
 }
 
 export type CommentTextProps = {
@@ -13,10 +74,14 @@ export type CommentTextProps = {
   isEdited?: boolean
 }
 
-export const CommentText = ({ children }: CommentTextProps) => {
+export const CommentText = (props: CommentTextProps) => {
+  const { children, isEdited } = props
   const textRef = useRef<HTMLElement>()
   const [isOverflowing, setIsOverflowing] = useState(false)
   const [isExpanded, setIsExpanded] = useState(false)
+  const {
+    track: { duration }
+  } = useCurrentCommentSection()
 
   useEffectOnce(() => {
     setIsOverflowing(
@@ -28,17 +93,48 @@ export const CommentText = ({ children }: CommentTextProps) => {
 
   return (
     <Flex direction='column' alignItems='flex-start' gap='xs'>
-      <Text
-        // Issue with the HTMLElement ref here and the ref type for Text component
-        // @ts-ignore
-        ref={textRef}
-        variant='body'
-        size='s'
-        color='default'
-        maxLines={isExpanded ? undefined : 3}
-      >
-        {children}
-      </Text>
+      <p css={{ textAlign: 'left' }}>
+        <UserGeneratedTextV2
+          size='s'
+          variant='body'
+          color='default'
+          ref={textRef}
+          // maxLines={isExpanded ? undefined : 3}
+          matchers={[
+            {
+              pattern: timestampRegex,
+              renderLink: (text) => {
+                const matches = [...text.matchAll(new RegExp(timestampRegex))]
+
+                if (matches.length === 0) return null
+
+                const timestampSeconds = getDurationFromTimestampMatch(
+                  matches[0]
+                )
+                const showLink = timestampSeconds <= duration
+
+                return showLink ? (
+                  <TimestampLink
+                    timestamp={text}
+                    timestampSeconds={timestampSeconds}
+                  />
+                ) : (
+                  <Text size='s'>{text}</Text>
+                )
+              }
+            }
+          ]}
+        >
+          {children}
+        </UserGeneratedTextV2>
+        {isEdited ? (
+          <Text color='subdued' size='s'>
+            {' '}
+            ({messages.edited})
+          </Text>
+        ) : null}
+      </p>
+
       {isOverflowing ? (
         <TextLink
           size='s'

--- a/packages/web/src/components/comments/CommentText.tsx
+++ b/packages/web/src/components/comments/CommentText.tsx
@@ -1,4 +1,4 @@
-import { useRef, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 
 import { useCurrentCommentSection } from '@audius/common/context'
 import { useGatedContentAccess } from '@audius/common/hooks'
@@ -83,13 +83,13 @@ export const CommentText = (props: CommentTextProps) => {
     track: { duration }
   } = useCurrentCommentSection()
 
-  useEffectOnce(() => {
+  useEffect(() => {
     setIsOverflowing(
       (textRef.current &&
         textRef.current.offsetHeight < textRef.current.scrollHeight) ||
         false
     )
-  })
+  }, [children])
 
   return (
     <Flex direction='column' alignItems='flex-start' gap='xs'>
@@ -99,7 +99,16 @@ export const CommentText = (props: CommentTextProps) => {
           variant='body'
           color='default'
           ref={textRef}
-          // maxLines={isExpanded ? undefined : 3}
+          internalLinksOnly
+          maxLines={isExpanded ? undefined : 3}
+          suffix={
+            isEdited ? (
+              <Text color='subdued' size='s'>
+                {' '}
+                ({messages.edited})
+              </Text>
+            ) : null
+          }
           matchers={[
             {
               pattern: timestampRegex,
@@ -127,12 +136,6 @@ export const CommentText = (props: CommentTextProps) => {
         >
           {children}
         </UserGeneratedTextV2>
-        {isEdited ? (
-          <Text color='subdued' size='s'>
-            {' '}
-            ({messages.edited})
-          </Text>
-        ) : null}
       </p>
 
       {isOverflowing ? (

--- a/packages/web/src/components/comments/CommentText.tsx
+++ b/packages/web/src/components/comments/CommentText.tsx
@@ -17,7 +17,6 @@ import {
 } from '@audius/common/utils'
 import { Flex, Text, TextLink } from '@audius/harmony'
 import { useDispatch, useSelector } from 'react-redux'
-import { useEffectOnce } from 'react-use'
 
 import { UserGeneratedTextV2 } from 'components/user-generated-text/UserGeneratedTextV2'
 

--- a/packages/web/src/components/user-generated-text/UserGeneratedTextV2.tsx
+++ b/packages/web/src/components/user-generated-text/UserGeneratedTextV2.tsx
@@ -1,0 +1,236 @@
+import {
+  ForwardedRef,
+  forwardRef,
+  ReactNode,
+  useCallback,
+  useState
+} from 'react'
+
+import { useGetUserByHandle } from '@audius/common/api'
+import { profilePage } from '@audius/common/src/utils/route'
+import { accountSelectors } from '@audius/common/store'
+import {
+  formatTrackName,
+  formatCollectionName,
+  formatUserName
+} from '@audius/common/utils'
+import { Text, TextProps } from '@audius/harmony'
+import {
+  instanceOfTrackResponse,
+  instanceOfPlaylistResponse,
+  instanceOfUserResponse
+} from '@audius/sdk'
+import { useSelector } from 'react-redux'
+import { useAsync } from 'react-use'
+
+import { TextLink, TextLinkProps } from 'components/link/TextLink'
+import { audiusSdk } from 'services/audius-sdk'
+import { restrictedHandles } from 'utils/restrictedHandles'
+import { getPathFromAudiusUrl, isAudiusUrl } from 'utils/urlUtils'
+
+const { getUserId } = accountSelectors
+
+type Matcher = {
+  pattern: RegExp
+  renderLink: (text: string, match: RegExpMatchArray) => JSX.Element | null
+}
+
+type UserGeneratedTextV2Props = {
+  children: string
+  matchers?: Matcher[]
+  linkProps?: Partial<TextLinkProps>
+
+  // If true, only linkify Audius URLs
+  internalLinksOnly?: boolean
+} & TextProps
+
+const formatExternalLink = (href: string) => {
+  const strippedHref = href.replace(/((?:https?):\/\/)|www./g, '')
+  return `https://${strippedHref}`
+}
+
+const formatAudiusUrl = (href: string) => {
+  return getPathFromAudiusUrl(href) as string
+}
+
+const Link = ({
+  children,
+  url,
+  ...other
+}: Omit<TextLinkProps, 'to'> & { url: string }) => {
+  const [unfurledContent, setUnfurledContent] = useState<string>()
+
+  useAsync(async () => {
+    if (isAudiusUrl(url) && !unfurledContent) {
+      const sdk = await audiusSdk()
+      const res = await sdk.resolve({ url })
+      if (res.data) {
+        if (instanceOfTrackResponse(res)) {
+          setUnfurledContent(formatTrackName({ track: res.data }))
+        } else if (instanceOfPlaylistResponse(res)) {
+          setUnfurledContent(formatCollectionName({ collection: res.data[0] }))
+        } else if (instanceOfUserResponse(res)) {
+          setUnfurledContent(formatUserName({ user: res.data }))
+        }
+      }
+    }
+  }, [url, unfurledContent, setUnfurledContent])
+
+  const isExternalLink = !isAudiusUrl(url)
+  const to = isExternalLink ? formatExternalLink(url) : formatAudiusUrl(url)
+
+  return (
+    <TextLink {...other} to={to} variant='visible' isExternal={isExternalLink}>
+      {unfurledContent ?? children}
+    </TextLink>
+  )
+}
+
+const HandleLink = ({
+  handle,
+  ...other
+}: Omit<TextLinkProps, 'to'> & { handle: string }) => {
+  const currentUserId = useSelector(getUserId)
+
+  const { data: user } = useGetUserByHandle({
+    handle: handle.replace('@', ''),
+    currentUserId
+  })
+
+  return user ? (
+    <TextLink {...other} to={profilePage(user.handle)}>
+      {handle}
+    </TextLink>
+  ) : (
+    <Text {...(other as any)} variant={other.textVariant}>
+      {handle}
+    </Text>
+  )
+}
+
+/**
+ * Hand rolled implementation of UserGeneratedText that supports custom matchers, unlike linkify-react
+ */
+export const UserGeneratedTextV2 = forwardRef(function (
+  props: UserGeneratedTextV2Props,
+  ref: ForwardedRef<HTMLElement | undefined>
+) {
+  const {
+    children,
+    matchers: matchersProp,
+    linkProps,
+    internalLinksOnly,
+    ...other
+  } = props
+
+  const renderLink = useCallback(
+    (text: string) => {
+      const shouldLinkify = !internalLinksOnly || isAudiusUrl(text)
+
+      return shouldLinkify ? (
+        <Link
+          {...(other as any)}
+          variant='visible'
+          textVariant={other.variant}
+          url={text}
+          {...linkProps}
+        />
+      ) : (
+        renderText(text)
+      )
+    },
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    []
+  )
+
+  const renderHandleLink = useCallback((text: string) => {
+    const isHandleUnrestricted = !restrictedHandles.has(text.toLowerCase())
+    return isHandleUnrestricted ? (
+      <HandleLink
+        {...(other as any)}
+        variant='visible'
+        textVariant={other.variant}
+        handle={text}
+        {...linkProps}
+      />
+    ) : (
+      renderText(text)
+    )
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
+
+  const renderText = useCallback(
+    (text: string) => <Text {...other}>{text}</Text>,
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    []
+  )
+
+  const matchers: Matcher[] = [
+    {
+      pattern:
+        /https?:\/\/([\w_-]+(?:(?:\.[\w_-]+)+))([\w.,@?^=%&:/~+#-]*[\w@?^=%&/~+#-])/g,
+      renderLink
+    },
+    // Handle matcher e.g. @handle
+    {
+      pattern: /@[a-zA-Z0-9_.]{1,15}/g,
+      renderLink: renderHandleLink
+    },
+    ...(matchersProp ?? [])
+  ]
+
+  // Function to split the text and insert rendered elements for matched tokens
+  const parseText = (text: string) => {
+    // Start with the entire text as a single unprocessed string
+    let elements: ReactNode[] = [text]
+
+    // Process each matcher sequentially
+    matchers.forEach(({ pattern, renderLink }) => {
+      const newElements: ReactNode[] = []
+      const regex = new RegExp(pattern)
+
+      // Iterate through the current elements array and apply the matcher
+      elements.forEach((element) => {
+        if (typeof element === 'string') {
+          // Iterate over the parts and alternate between text and the rendered link
+          let match
+          let lastIndex = 0
+
+          while ((match = regex.exec(element)) !== null) {
+            // Push the text before the match
+            newElements.push(element.substring(lastIndex, match.index))
+
+            // Push the rendered link component for the matched text
+            const link = renderLink(match[0], match)
+            if (link) {
+              newElements.push(link)
+            } else {
+              newElements.push(match[0])
+            }
+
+            // Update the last index to the end of the current match
+            lastIndex = match.index + match[0].length
+          }
+
+          // Push remaining text after the last match
+          newElements.push(element.substring(lastIndex))
+        } else {
+          // If it's already a React element (from a previous matcher), keep it as-is
+          newElements.push(element)
+        }
+      })
+
+      // Replace elements with the new ones after applying the current matcher
+      elements = newElements
+    })
+
+    return elements
+  }
+
+  // Render the parsed content
+  return (
+    <Text ref={ref as ForwardedRef<'p'>} {...other}>
+      {parseText(children)}
+    </Text>
+  )
+})

--- a/packages/web/src/components/user-generated-text/UserGeneratedTextV2.tsx
+++ b/packages/web/src/components/user-generated-text/UserGeneratedTextV2.tsx
@@ -42,6 +42,9 @@ type UserGeneratedTextV2Props = {
 
   // If true, only linkify Audius URLs
   internalLinksOnly?: boolean
+
+  // Suffix to append after the text. Used for "edited" text in comments
+  suffix?: ReactNode
 } & TextProps
 
 const formatExternalLink = (href: string) => {
@@ -120,6 +123,7 @@ export const UserGeneratedTextV2 = forwardRef(function (
     matchers: matchersProp,
     linkProps,
     internalLinksOnly,
+    suffix,
     ...other
   } = props
 
@@ -231,6 +235,7 @@ export const UserGeneratedTextV2 = forwardRef(function (
   return (
     <Text ref={ref as ForwardedRef<'p'>} {...other}>
       {parseText(children)}
+      {suffix}
     </Text>
   )
 })


### PR DESCRIPTION
### Description

* Add `UserGeneratedTextV2` which is a hand-rolled implementation of linkify because `linkify-react` is pretty limited and doesn't allow custom matchers like `react-native-autolink`. We can probably migrate exclusively to `UserGeneratedTextV2` on web but for now I kept it contained to CommentText
* Support link, user, and timestamp linking

<img width="429" alt="image" src="https://github.com/user-attachments/assets/32d654f8-c112-4a5e-a085-46224d37ec5f">

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._
