### PR TITLE
[QA-1740] Prevent upload progress from jumping backwards on retries

### DIFF
--- a/packages/common/src/store/upload/reducer.ts
+++ b/packages/common/src/store/upload/reducer.ts
@@ -155,7 +155,8 @@ const actionsMap = {
     const nextProgress = { ...prevProgress }
     nextProgress.status = progress.status
     if (progress.loaded && progress.total) {
-      nextProgress.loaded = progress.loaded
+      // Don't allow progress to jump backwards on retries
+      nextProgress.loaded = Math.max(nextProgress.loaded ?? 0, progress.loaded)
       nextProgress.total = progress.total
     }
     if (progress.transcode) {


### PR DESCRIPTION
### Description
Since we use retries under the hood and they all share the same progress callback it's possible to receive a value that's _less_ than the previous upload progress value. While that's technically correct, it's not a great UX. So we're opting to let the upload progress sit for a bit if a retry occurs, until we catch up to the latest point and make it further.

Future upload resilience improvements can make this better.

### How Has This Been Tested?
Tested in local client against staging. Used network developer tools to simulate an offline environment part way through the upload and verified that it didn't jump backwards on the next retry.
