### PR TITLE
Fix rate limiting of viewing notifications

### DIFF
--- a/packages/discovery-provider/plugins/pedalboard/apps/relay/src/config/rateLimitConfig.ts
+++ b/packages/discovery-provider/plugins/pedalboard/apps/relay/src/config/rateLimitConfig.ts
@@ -221,13 +221,13 @@ const RELAY_RATE_LIMITS = {
     allowlist: 1000,
   },
   ViewNotification: {
-    owner: 100,
-    app: 0,
+    owner: 1000,
+    app: 1000,
     allowlist: 1000,
   },
   ViewPlaylistNotification: {
-    owner: 100,
-    app: 100,
+    owner: 1000,
+    app: 1000,
     allowlist: 1000,
   },
   CreateDeveloperApp: {

--- a/packages/discovery-provider/plugins/pedalboard/apps/relay/src/middleware/rateLimiter.ts
+++ b/packages/discovery-provider/plugins/pedalboard/apps/relay/src/middleware/rateLimiter.ts
@@ -63,7 +63,6 @@ export const rateLimiterMiddleware = async (
 
   const limit = await determineLimit(
     signerIsUser,
-    isAnonymousAllowed,
     config.rateLimitAllowList,
     signer
   )
@@ -110,11 +109,9 @@ const insertReplyHeaders = (res: Response, data: RateLimiterRes) => {
 
 const determineLimit = async (
   isUser: boolean,
-  isAnonymousAllowed: boolean,
   allowList: string[],
   signer: string
 ): Promise<ValidLimits> => {
-  if (isAnonymousAllowed) return 'app'
   const isAllowed = allowList.includes(signer)
   if (isAllowed) return 'allowlist'
   if (isUser) return 'owner'


### PR DESCRIPTION
We recently made viewing notifications allowed for anonymous accounts (in order to bypass the abuse checks) which had the side effect of making viewing notifications use the "app" rate limit, as we short circuit to "app" for anonymous-allowed writes.

Instead, remove the short circuit for anonymous writes, which will fall back to "app" if not signed and not allowlisted, and bump the rate limit for viewing notifications anyway. This makes sense as owner/allowlisted limits should be higher than "app" anyway, so the short circuit isn't necessary