### PR TITLE
[PROTO-1935] Always relaunch under the hood in audius-ctl up

### DIFF
--- a/pkg/orchestration/docker.go
+++ b/pkg/orchestration/docker.go
@@ -61,8 +61,24 @@ func runNode(
 	}
 	defer dockerClient.Close()
 
+	var adcDir string
+	switch config.Type {
+	case conf.Content:
+		adcDir = "creator-node"
+	case conf.Discovery:
+		adcDir = "discovery-provider"
+	case conf.Identity:
+		adcDir = "identity-service"
+	}
+
 	if isContainerRunning(dockerClient, host) {
 		logger.Infof("audius-d container already running on %s", host)
+		logger.Info("Re-upping internal services for good measure...")
+		if err := audiusCli(dockerClient, host, "launch", "-y", adcDir); err != nil {
+			return logger.Error("Failed to launch node:", err)
+		}
+		logger.Infof("Done re-upping internal services on %s", host)
+		logger.Infof("Use 'audius-ctl restart %s' for a clean restart", host)
 		return nil
 	} else if isContainerNameInUse(dockerClient, host) {
 		logger.Infof("stopped audius-d container exists on %s, removing and starting with current config", host)
@@ -226,15 +242,6 @@ func runNode(
 	}
 
 	// copy the override.env file to the server and then into the wrapper container
-	var adcDir string
-	switch config.Type {
-	case conf.Content:
-		adcDir = "creator-node"
-	case conf.Discovery:
-		adcDir = "discovery-provider"
-	case conf.Identity:
-		adcDir = "identity-service"
-	}
 	overrideFile, err := os.Open(localOverridePath)
 	if err != nil {
 		return logger.Error(err)


### PR DESCRIPTION
### Description

Always run audius-cli launch under the hood if `audius-ctl up` is invoked and the wrapper container is already running.

### How Has This Been Tested?

`bin/audius-ctl-native up discoveryprovider2.staging.audius.co`
