### PR TITLE
[C-5022] Fix cached-image artwork and avatar

### DIFF
--- a/packages/harmony/src/components/artwork/Artwork.tsx
+++ b/packages/harmony/src/components/artwork/Artwork.tsx
@@ -1,4 +1,4 @@
-import { ComponentProps, useEffect, useState } from 'react'
+import { ComponentProps, useEffect, useRef, useState } from 'react'
 
 import { useTheme } from '@emotion/react'
 
@@ -32,12 +32,19 @@ export const Artwork = (props: ArtworkProps) => {
     'data-testid': testId,
     ...other
   } = props
+  const imgRef = useRef<HTMLImageElement | null>(null)
   const [isLoadingState, setIsLoadingState] = useState(true)
   const isLoading = isLoadingProp ?? isLoadingState
   const { color, motion } = useTheme()
 
   useEffect(() => {
     setIsLoadingState(true)
+  }, [src])
+
+  useEffect(() => {
+    if (imgRef.current?.complete) {
+      setIsLoadingState(false)
+    }
   }, [src])
 
   return (
@@ -68,6 +75,7 @@ export const Artwork = (props: ArtworkProps) => {
         {src ? (
           <Box
             as='img'
+            ref={imgRef}
             borderRadius={borderRadius}
             h='100%'
             w='100%'

--- a/packages/web/src/components/avatar/Avatar.tsx
+++ b/packages/web/src/components/avatar/Avatar.tsx
@@ -1,18 +1,17 @@
 import { imageProfilePicEmpty } from '@audius/common/assets'
 import { SquareSizes, ID } from '@audius/common/models'
 import { accountSelectors, cacheUsersSelectors } from '@audius/common/store'
-import { Maybe, route } from '@audius/common/utils'
+import { Maybe } from '@audius/common/utils'
 import {
   Avatar as HarmonyAvatar,
   type AvatarProps as HarmonyAvatarProps
 } from '@audius/harmony'
-import { Link } from 'react-router-dom'
 
 import { UserLink } from 'components/link'
+import { MountPlacement } from 'components/types'
 import { useProfilePicture } from 'hooks/useUserProfilePicture'
 import { useSelector } from 'utils/reducer'
 
-const { SIGN_IN_PAGE, profilePage } = route
 const { getAccountUser } = accountSelectors
 
 const { getUser } = cacheUsersSelectors
@@ -44,13 +43,6 @@ export const Avatar = (props: AvatarProps) => {
 
   const image = userId ? profileImage : imageProfilePicEmpty
 
-  const userLink = useSelector((state) => {
-    const profile = getUser(state, { id: userId })
-    if (!profile) return SIGN_IN_PAGE
-    const { handle } = profile
-    return profilePage(handle)
-  })
-
   const userName = useSelector((state) => {
     const user = getUser(state, { id: userId })
     const currentUser = getAccountUser(state)
@@ -77,13 +69,19 @@ export const Avatar = (props: AvatarProps) => {
     )
   }
 
-  return typeof userId === 'number' ? (
-    <UserLink userId={userId} popover={popover} noText aria-label={label}>
-      <HarmonyAvatar src={image} {...other} />
-    </UserLink>
-  ) : (
-    <Link to={userLink} aria-label={label}>
-      <HarmonyAvatar src={image} {...other} />
-    </Link>
-  )
+  if (userId) {
+    return (
+      <UserLink
+        userId={userId}
+        popover={popover}
+        noText
+        aria-label={label}
+        popoverMount={MountPlacement.PARENT}
+      >
+        <HarmonyAvatar src={image} {...other} />
+      </UserLink>
+    )
+  }
+
+  return <HarmonyAvatar src={image} {...other} />
 }

--- a/packages/web/src/components/comments/CommentBlock.tsx
+++ b/packages/web/src/components/comments/CommentBlock.tsx
@@ -79,17 +79,7 @@ const CommentBlockInternal = (
   return (
     <Flex w='100%' gap='l' css={{ opacity: isTombstone ? 0.5 : 1 }}>
       <Box css={{ flexShrink: 0, width: 44 }}>
-        <Avatar
-          userId={userId}
-          css={{
-            width: 44,
-            height: 44,
-            cursor: isTombstone ? 'default' : 'pointer'
-          }}
-          // TODO: This is a hack - currently if you provide an undefined userId it will link to signin/feed
-          onClick={isTombstone ? () => {} : undefined}
-          popover
-        />
+        <Avatar userId={userId} size='medium' popover />
       </Box>
       <Flex direction='column' gap='s' w='100%' alignItems='flex-start'>
         <Box css={{ position: 'absolute', top: 0, right: 0 }}>


### PR DESCRIPTION
### Description

Fixes a few isuses:
1. Fixes issue where Artwork doesn't fire onLoad when image is cached, so we first check if "complete" is true (ie cached), and trigger setLoading(false)
2. Fixes issue where web/Avatar went to sign-up screen when userId={undefined}. really not sure what i was thinking there. Additionally drops another unecessary if condition.
3. Cleans up comment avatar to use standard size, and removes the tombstone hack since the above component is fixed 