### PR TITLE
Fixes zodError when purchasing album with Coinflow

### DIFF
--- a/.changeset/funny-nails-enjoy.md
+++ b/.changeset/funny-nails-enjoy.md
@@ -1,0 +1,5 @@
+---
+'@audius/sdk': patch
+---
+
+Fix purchase flows with external wallets

--- a/packages/common/src/store/purchase-content/sagas.ts
+++ b/packages/common/src/store/purchase-content/sagas.ts
@@ -474,7 +474,6 @@ function* purchaseAlbumWithCoinflow(args: {
     extraAmount: args.extraAmount,
     albumId: encodeHashId(albumId),
     userId: encodeHashId(userId),
-    wallet: wallet.publicKey,
     includeNetworkCut
   }
 

--- a/packages/libs/src/sdk/api/albums/types.ts
+++ b/packages/libs/src/sdk/api/albums/types.ts
@@ -180,7 +180,6 @@ const PurchaseAlbumSchemaBase = z.object({
 export const GetPurchaseAlbumInstructionsSchema = z
   .object({})
   .merge(PurchaseAlbumSchemaBase)
-  .strict()
 
 export type GetPurchaseAlbumInstructionsRequest = z.input<
   typeof GetPurchaseAlbumInstructionsSchema

--- a/packages/libs/src/sdk/api/tracks/types.ts
+++ b/packages/libs/src/sdk/api/tracks/types.ts
@@ -321,7 +321,6 @@ const PurchaseTrackSchemaBase = z.object({
 export const GetPurchaseTrackInstructionsSchema = z
   .object({})
   .merge(PurchaseTrackSchemaBase)
-  .strict()
 
 export type GetPurchaseTrackInstructionsRequest = z.input<
   typeof GetPurchaseTrackInstructionsSchema


### PR DESCRIPTION
### Description

Error occurs due to extra parameter `wallet` being passed into the `getPurchaseAlbumInstructions` call - we no longer do the transfer in that call since shipping "pay with anything" so this failed zod parsing. Notably, the `purchase` variants would also include extra parameters, so made the "instructions" variants non-strict going forward.
