### PR TITLE
[PAY-3455] Update unread element scroll function and fix chat page styling again

### DIFF
--- a/packages/web/src/pages/chat-page/ChatPage.module.css
+++ b/packages/web/src/pages/chat-page/ChatPage.module.css
@@ -12,7 +12,7 @@
   margin-top: -37px;
   width: 100%;
   max-width: 100%;
-  height: calc(100% + 37px);
+  height: calc(100% - 80px);
 }
 
 .layout {
@@ -30,7 +30,7 @@
 }
 
 .chatArea {
-  height: calc(100% - 117px); /* 100% - headerHeight */
+  height: 100%;
   flex: 1;
   display: flex;
   flex-direction: column;

--- a/packages/web/src/pages/chat-page/components/ChatMessageList.tsx
+++ b/packages/web/src/pages/chat-page/components/ChatMessageList.tsx
@@ -161,7 +161,6 @@ export const ChatMessageList = forwardRef<HTMLDivElement, ChatMessageListProps>(
 
     const scrollIntoViewOnMount = useCallback((el: HTMLDivElement) => {
       if (el) {
-        el.scrollIntoView()
         // On initial render, can't scroll yet, as the component isn't fully rendered.
         // Instead, queue a scroll by triggering a rerender via a state change.
         setUnreadIndicatorEl(el)
@@ -170,7 +169,15 @@ export const ChatMessageList = forwardRef<HTMLDivElement, ChatMessageListProps>(
 
     useLayoutEffect(() => {
       if (unreadIndicatorEl) {
-        unreadIndicatorEl.scrollIntoView()
+        const listItemScrollContainer =
+          unreadIndicatorEl.parentElement?.parentElement
+        if (listItemScrollContainer) {
+          listItemScrollContainer.scrollTop = Math.max(
+            unreadIndicatorEl.offsetTop - 150,
+            0
+          )
+        }
+
         // One more state change, this keeps chats unread until the user scrolls to the bottom on their own
         setLastScrolledChatId(chatId)
       }


### PR DESCRIPTION
### Description
Small updates to the styling and the function that scrolls the unread messages into view. I tried doing this with refs and ids to avoid just grabbing the parent id, but they were not working well so I just left it as is.

### How Has This Been Tested?
Manually tested
