### PR TITLE
Fix get playlist API playlist contents

### DIFF
--- a/packages/discovery-provider/src/api/v1/playlists.py
+++ b/packages/discovery-provider/src/api/v1/playlists.py
@@ -186,6 +186,8 @@ class Playlist(Resource):
             playlist_id=playlist_id,
         )
         if playlist:
+            tracks = get_tracks_for_playlist(playlist_id, current_user_id)
+            playlist["tracks"] = tracks
             filter_hidden_tracks(playlist, current_user_id)
         response = success_response([playlist] if playlist else [])
         return response


### PR DESCRIPTION
### Description

playlist_contents is missing tracks

```
{
"artwork": {
"150x150": "https://blockdaemon-audius-content-02.bdnodes.net/content/01J8KC8NCWZ1F036HKNYANKH2Q/150x150.jpg",
"480x480": "https://blockdaemon-audius-content-02.bdnodes.net/content/01J8KC8NCWZ1F036HKNYANKH2Q/480x480.jpg",
"1000x1000": "https://blockdaemon-audius-content-02.bdnodes.net/content/01J8KC8NCWZ1F036HKNYANKH2Q/1000x1000.jpg"
},
"description": "Songs to solve a ton of errors to. Happy hacking!",
"permalink": "[/mynameiscards/playlist/trick-cheneys-hackathon-trackathon-2024](https://discoveryprovider.audius.co/mynameiscards/playlist/trick-cheneys-hackathon-trackathon-2024)",
"id": "q7OlBmM",
"is_album": false,
"is_image_autogenerated": false,
"playlist_name": "TRICK CHENEY.'s Hackathon Trackathon 2024",
"playlist_contents": [],
```

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._

Ran on sandbox and confirmed playlist_contents were correctly added.