### PR TITLE
Only send blast notifs when no existing chat

### DIFF
--- a/packages/discovery-provider/plugins/notifications/src/__tests__/processPushNotification.test.ts
+++ b/packages/discovery-provider/plugins/notifications/src/__tests__/processPushNotification.test.ts
@@ -113,6 +113,8 @@ describe('Push Notifications', () => {
         }
       }
     )
+
+    jest.clearAllMocks()
   }, 40000)
 
   test('Process chat blast notification', async () => {
@@ -190,6 +192,65 @@ describe('Push Notifications', () => {
 
     // No new notifications
     expect(sendPushNotificationSpy).toHaveBeenCalledTimes(2)
+    jest.clearAllMocks()
+  }, 40000)
+
+  test('Test blast with existing chat', async () => {
+    const { user1, user2 } = await setupTwoUsersWithDevices(
+      processor.discoveryDB,
+      processor.identityDB
+    )
+
+    // Start processor
+    processor.start()
+    // Let notifications job run for a few cycles to initialize the min cursors in redis
+    await new Promise((r) => setTimeout(r, config.pollInterval * 2))
+
+    // user2 follows user1
+    await insertFollows(processor.discoveryDB, [
+      { follower_user_id: user2.userId, followee_user_id: user1.userId }
+    ])
+    await new Promise((r) => setTimeout(r, config.pollInterval * 2))
+    // Follow generates a notification
+    expect(sendPushNotificationSpy).toHaveBeenCalledTimes(1)
+
+    // Create a chat thread
+    const message = 'hi from user 1'
+    const messageTimestampMs = Date.now()
+    const messageTimestamp = new Date(messageTimestampMs)
+    const chatId = '1'
+    await createChat(
+      processor.discoveryDB,
+      user1.userId,
+      user2.userId,
+      chatId,
+      messageTimestamp
+    )
+
+    await new Promise((r) => setTimeout(r, config.pollInterval * 2))
+
+    // If the users have an existing chat thread and user1 sends a blast,
+    // in the real world user2 should receive a normal message notification
+    // from the blast fan-out, but that doesn't work in jest, so just confirm no
+    // new message notifications are sent
+    const blastId = '1'
+    const blastTimestampMs = Date.now() - config.dmNotificationDelay
+    const blastTimestamp = new Date(blastTimestampMs)
+    const audience = 'follower_audience'
+    await insertBlast(
+      processor.discoveryDB,
+      user1.userId,
+      blastId,
+      message,
+      audience,
+      undefined,
+      undefined,
+      blastTimestamp
+    )
+
+    await new Promise((r) => setTimeout(r, config.pollInterval * 2))
+
+    expect(sendPushNotificationSpy).toHaveBeenCalledTimes(1)
 
     jest.clearAllMocks()
   }, 40000)

--- a/packages/discovery-provider/plugins/notifications/src/tasks/dmNotifications.ts
+++ b/packages/discovery-provider/plugins/notifications/src/tasks/dmNotifications.ts
@@ -126,7 +126,7 @@ async function getNewBlasts(
     WITH blast AS (
       SELECT * FROM chat_blast
     ),
-    aud as (
+    aud AS (
       -- follower_audience
       SELECT blast_id, follower_user_id AS to_user_id
       FROM follows
@@ -180,7 +180,7 @@ async function getNewBlasts(
           )
         )
     ),
-      targ AS (
+    targ AS (
       SELECT
         blast_id,
         from_user_id,
@@ -190,10 +190,11 @@ async function getNewBlasts(
       JOIN aud USING (blast_id)
       LEFT JOIN chat_member member_a on from_user_id = member_a.user_id
       LEFT JOIN chat_member member_b on to_user_id = member_b.user_id and member_b.chat_id = member_a.chat_id
-      WHERE date_trunc('milliseconds', blast.created_at) > greatest(member_b.last_active_at, ?)
+      WHERE member_b.chat_id IS NULL -- !! note this is the opposite from the query in chat_blast.go
+      AND date_trunc('milliseconds', blast.created_at) > ?
       AND date_trunc('milliseconds', blast.created_at) <= ?
     )
-    SELECT from_user_id as sender_user_id, to_user_id as receiver_user_id, created_at FROM targ where chat_allowed(from_user_id, to_user_id);
+    SELECT from_user_id AS sender_user_id, to_user_id AS receiver_user_id, created_at FROM targ WHERE chat_allowed(from_user_id, to_user_id);
     `,
     [minTimestamp.toISOString(), maxTimestamp.toISOString()]
   )


### PR DESCRIPTION
### Description
Previous PR (https://github.com/AudiusProject/audius-protocol/pull/9880) had a bug - we actually want to do the inverse of the query in chat blast fan-out, and send notifications only for blasts where there's no existing chat between the two users.

### How Has This Been Tested?

Added a DN notif plugin test