### PR TITLE
Move debug to externals

### DIFF
--- a/packages/libs/rollup.config.ts
+++ b/packages/libs/rollup.config.ts
@@ -18,7 +18,8 @@ const external = [
   'ethers/lib/utils',
   'ethers/lib/index',
   'hashids/cjs',
-  'readable-stream'
+  'readable-stream',
+  'debug'
 ]
 
 const pluginTypescript = typescript({ tsconfig: './tsconfig.json' })
@@ -29,7 +30,7 @@ const pluginTypescript = typescript({ tsconfig: './tsconfig.json' })
  * - are ignored via `ignore`
  */
 const browserInternal = [
-  // '@metamask/eth-sig-util',
+  '@metamask/eth-sig-util',
   '@scure/base',
   'eth-sig-util',
   'ethereumjs-tx',


### PR DESCRIPTION
### Description
`eth-sig-util` has a nested prod dependency on `debug`. This doesn't play nicely with our Vite bundling for web due to `debug`'s usage of Node functionality. Moving debug explicitly to internals allows it to be bundled the "normal" way so that the node usage is resolved correctly.

### How Has This Been Tested?
Tested in local staging app and on a prod subdomain.
