### PR TITLE
Use mediorum/mediorum_pkg/.version.json while pkg re-org in flight

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -108,9 +108,9 @@ jobs:
             NEW_VERSION=$(echo ${OLD_VERSION} | awk -F. '{$NF = $NF + 1;} 1' | sed 's/ /./g')
 
             # Bump version for content node
-            jq --arg version "$NEW_VERSION" '.version=$version' mediorum/.version.json > /tmp/.version.json
-            mv /tmp/.version.json mediorum/.version.json
-            git add mediorum/.version.json
+            jq --arg version "$NEW_VERSION" '.version=$version' mediorum/mediorum_pkg/.version.json > /tmp/.version.json
+            mv /tmp/.version.json mediorum/mediorum_pkg/.version.json
+            git add mediorum/mediorum_pkg/.version.json
 
             # Bump version for discovery node
             jq --arg version "$NEW_VERSION" '.version=$version' packages/discovery-provider/.version.json > /tmp/.version.json

--- a/dev-tools/audius-compose
+++ b/dev-tools/audius-compose
@@ -87,7 +87,7 @@ def generate_env(
     env["DISCOVERY_PROVIDER_REPLICAS"] = str(discovery_provider_replicas)
 
     env["CONTENT_NODE_VERSION"] = json.loads(
-        (protocol_dir / "mediorum/.version.json").read_text(),
+        (protocol_dir / "mediorum/mediorum_pkg/.version.json").read_text(),
     )["version"]
 
     env["DISCOVERY_NODE_VERSION"] = json.loads(

--- a/mediorum/.version.json
+++ b/mediorum/.version.json
@@ -1,4 +1,0 @@
-{
-  "version": "0.7.2",
-  "service": "content-node"
-}

--- a/mediorum/mediorum_pkg/.version.json
+++ b/mediorum/mediorum_pkg/.version.json
@@ -1,4 +1,4 @@
 {
-  "version": "0.6.197",
+  "version": "0.7.2",
   "service": "content-node"
 }


### PR DESCRIPTION
Old version number was baked in after wrapping `mediorum` as a package.