### PR TITLE
[WIP] ::  [DOCS] Developer intro page work

### DIFF
--- a/docs/docs/developers/introduction/overview.mdx
+++ b/docs/docs/developers/introduction/overview.mdx
@@ -35,11 +35,12 @@ description: Audius Protocol Documentation
 
 > Join the developer community, get direct support, and file issues.
 
-- [Join the Discord](https://discord.com/invite/audius) and head to the **Developers** section
-- [Book a meeting with Developer Relations](https://calendar.google.com/calendar/u/0/appointments/schedules/AcZssZ1IRk54J0XtTCavF8PbFSIxbaHX5tnybxKFLqEPvAXWYMgqNN9D9a6iFa_p6zCfTXsPbK8zIkKU)
-  to get one on one support.
-- [Report a bug or make a feature request](https://github.com/AudiusProject/audius-protocol/issues/new/choose)
-  in the code repository.
+- [Developer Discord](https://discord.com/invite/audius) - Join the community and head to the
+  **Developers** section
+- [Get one on one support](https://calendar.google.com/calendar/u/0/appointments/schedules/AcZssZ1IRk54J0XtTCavF8PbFSIxbaHX5tnybxKFLqEPvAXWYMgqNN9D9a6iFa_p6zCfTXsPbK8zIkKU) -
+  Book a meeting with Developer Relations.
+- [Report a bug or make a feature request](https://github.com/AudiusProject/audius-protocol/issues/new/choose) -
+  Better yet, see a bug you have a fix for? Open a PR!
 
 ---
 


### PR DESCRIPTION
### Description

Moves "use the REST API higher on the page
Adds a "getting help & reporting bigs" section with links to github issue templates, calendar slots, and discord invites

<img width="967" alt="image" src="https://github.com/user-attachments/assets/0ffc7a9e-04a7-4687-b12b-0a6765149613">
