### PR TITLE
Honor existing chat

### DIFF
--- a/packages/discovery-provider/ddl/functions/chat_allowed.sql
+++ b/packages/discovery-provider/ddl/functions/chat_allowed.sql
@@ -29,7 +29,7 @@ BEGIN
   -- existing chat takes priority over permissions
   SELECT COUNT(*) > 0 INTO can_message
   FROM chat_member member_a
-	JOIN chat_member member_b USING (chat_id)
+  JOIN chat_member member_b USING (chat_id)
   JOIN chat_message USING (chat_id)
   WHERE member_a.user_id = from_user_id
     AND member_b.user_id = to_user_id

--- a/packages/discovery-provider/ddl/functions/chat_allowed.sql
+++ b/packages/discovery-provider/ddl/functions/chat_allowed.sql
@@ -26,6 +26,19 @@ BEGIN
     RETURN TRUE;
   END IF;
 
+  -- existing chat takes priority over permissions
+  SELECT COUNT(*) > 0 INTO can_message
+  FROM chat_member member_a
+	JOIN chat_member member_b USING (chat_id)
+  JOIN chat_message USING (chat_id)
+  WHERE member_a.user_id = from_user_id
+    AND member_b.user_id = to_user_id
+  ;
+
+  IF can_message THEN
+    RETURN TRUE;
+  END IF;
+
 
   -- check permissions in turn:
   FOR permission_row IN select * from chat_permissions WHERE user_id = to_user_id AND allowed = TRUE

--- a/packages/discovery-provider/ddl/tests/chat_allowed_test.sql
+++ b/packages/discovery-provider/ddl/tests/chat_allowed_test.sql
@@ -9,6 +9,21 @@ ASSERT (SELECT chat_allowed(1,2) = TRUE);
 insert into chat_blocked_users values (2, 1, now());
 ASSERT (SELECT chat_allowed(1,2) = FALSE);
 
+
+-- create a pre-existing chat for USER 10 + USER 11
+insert into chat (chat_id, created_at, last_message_at) values ('preexisting', now(), now());
+
+insert into chat_member
+  (chat_id, user_id, invited_by_user_id, invite_code, created_at)
+values
+  ('preexisting', 10, 10, '', now()),
+  ('preexisting', 11, 10, '', now());
+
+insert into chat_message
+  (message_id, chat_id, user_id, created_at)
+values
+  ('first', 'preexisting', 11, now());
+
 -- USER 10 allows followers
 insert into chat_permissions values (10, 'followers', now());
 ASSERT (SELECT chat_allowed(1,10) = FALSE);
@@ -20,9 +35,15 @@ values
   (2, 10, true, false, now());
 ASSERT (SELECT chat_allowed(2,10) = TRUE);
 
+-- USER 10 + 11 had preexisting chat, so can still chat after 10 goes followers-only
+-- because of preexisting chat
+ASSERT (SELECT chat_allowed(10, 11) = TRUE);
+ASSERT (SELECT chat_allowed(11, 10) = TRUE);
+
 -- USER 10 revokes followers
 UPDATE chat_permissions SET allowed = FALSE WHERE user_id = 10 AND permits = 'followers';
 ASSERT (SELECT chat_allowed(2,10) = FALSE);
+
 
 
 


### PR DESCRIPTION
* An existing chat is allowed even if a user further restricts their inbox settings after it's creation.
* fix tests: handle null `cleared_history_at` 
