### PR TITLE
Tag mri plugin container in discprov release

### DIFF
--- a/.circleci/src/commands/@docker-commands.yml
+++ b/.circleci/src/commands/@docker-commands.yml
@@ -52,6 +52,7 @@ docker-tag-images:
             solana-relay
             trending-challenge-rewards
             crm
+            mri
             trpc
             backfill-audio-analyses
             verified-notifications


### PR DESCRIPTION
### Description

This plugin was left out of CI