### PR TITLE
[QA-875] Fix short feed on web sign in

### DIFF
--- a/packages/web/src/components/lineup/LineupProvider.tsx
+++ b/packages/web/src/components/lineup/LineupProvider.tsx
@@ -796,7 +796,12 @@ class LineupProvider extends PureComponent<CombinedProps, LineupProviderState> {
               // to calculate scroll position.
               useWindow={isMobile}
               initialLoad={false}
-              getScrollParent={() => scrollParent}
+              getScrollParent={() => {
+                if (scrollParent?.id === 'mainContent') {
+                  return document.getElementById('mainContent')
+                }
+                return scrollParent
+              }}
               threshold={loadMoreThreshold}
               element='ol'
             >


### PR DESCRIPTION
### Description

On web sign in, feed doesn't infinitely scroll. This is because of a strange bug where the scrollParent seems to be outdated and not the actual element that's rendered. I was able to prove this out by logging out the element and noticing scrollParent would only link to the element on page after refresh. 

Instead of using the scrollParent that's passed down, I'm checking if it intends on using the mainContent element and fetching it from the DOM instead to ensure the reference is up to date. This is a weird workaround but not sure what else to do. 

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._

Confirmed feed can infinitely scroll on login. Sign up and mobile don't seem to have this issue. 