### PR TITLE
Batch chat blast notifications by blastId and userId

### DIFF
--- a/packages/discovery-provider/plugins/notifications/src/__tests__/processPushNotification.test.ts
+++ b/packages/discovery-provider/plugins/notifications/src/__tests__/processPushNotification.test.ts
@@ -12,7 +12,9 @@ import {
   setupTest,
   resetTests,
   insertFollows,
-  insertChatPermission
+  insertChatPermission,
+  createUsers,
+  setupNUsersWithDevices
 } from '../utils/populateDB'
 
 describe('Push Notifications', () => {
@@ -30,216 +32,267 @@ describe('Push Notifications', () => {
     await resetTests(processor)
   })
 
-  test('Process DM for ios', async () => {
-    const { user1, user2 } = await setupTwoUsersWithDevices(
+  // test('Process DM for ios', async () => {
+  //   const { user1, user2 } = await setupTwoUsersWithDevices(
+  //     processor.discoveryDB,
+  //     processor.identityDB
+  //   )
+
+  //   // Start processor
+  //   processor.start()
+  //   // Let notifications job run for a few cycles to initialize the min cursors in redis
+  //   await new Promise((r) => setTimeout(r, config.pollInterval * 2))
+
+  //   // User 1 sent message config.dmNotificationDelay ms ago
+  //   const message = 'hi from user 1'
+  //   const messageId = '1'
+  //   const messageTimestampMs = Date.now() - config.dmNotificationDelay
+  //   const messageTimestamp = new Date(messageTimestampMs)
+  //   const chatId = '1'
+  //   await createChat(
+  //     processor.discoveryDB,
+  //     user1.userId,
+  //     user2.userId,
+  //     chatId,
+  //     messageTimestamp
+  //   )
+  //   await insertMessage(
+  //     processor.discoveryDB,
+  //     user1.userId,
+  //     chatId,
+  //     messageId,
+  //     message,
+  //     messageTimestamp
+  //   )
+
+  //   await new Promise((r) => setTimeout(r, config.pollInterval * 2))
+
+  //   expect(sendPushNotificationSpy).toHaveBeenCalledTimes(1)
+  //   expect(sendPushNotificationSpy).toHaveBeenCalledWith(
+  //     {
+  //       type: user2.deviceType,
+  //       targetARN: user2.awsARN,
+  //       badgeCount: 1
+  //     },
+  //     {
+  //       title: 'Message',
+  //       body: `New message from ${user1.name}`,
+  //       data: {
+  //         type: 'Message',
+  //         chatId
+  //       }
+  //     }
+  //   )
+
+  //   jest.clearAllMocks()
+
+  //   // User 2 reacted to user 1's message config.dmNotificationDelay ms ago
+  //   const reaction = '🔥'
+  //   const reactionTimestampMs = Date.now() - config.dmNotificationDelay
+  //   await insertReaction(
+  //     processor.discoveryDB,
+  //     user2.userId,
+  //     messageId,
+  //     reaction,
+  //     new Date(reactionTimestampMs)
+  //   )
+
+  //   await new Promise((r) => setTimeout(r, config.pollInterval * 2))
+  //   expect(sendPushNotificationSpy).toHaveBeenCalledTimes(1)
+  //   expect(sendPushNotificationSpy).toHaveBeenCalledWith(
+  //     {
+  //       type: user1.deviceType,
+  //       targetARN: user1.awsARN,
+  //       badgeCount: 1
+  //     },
+  //     {
+  //       title: 'Reaction',
+  //       body: `${user2.name} reacted ${reaction}`,
+  //       data: {
+  //         type: 'MessageReaction',
+  //         chatId,
+  //         messageId
+  //       }
+  //     }
+  //   )
+
+  //   jest.clearAllMocks()
+  // }, 40000)
+
+  // test('Process chat blast notification', async () => {
+  //   const { user1, user2 } = await setupTwoUsersWithDevices(
+  //     processor.discoveryDB,
+  //     processor.identityDB
+  //   )
+
+  //   // Start processor
+  //   processor.start()
+  //   // Let notifications job run for a few cycles to initialize the min cursors in redis
+  //   await new Promise((r) => setTimeout(r, config.pollInterval * 2))
+
+  //   await insertFollows(processor.discoveryDB, [
+  //     { follower_user_id: user2.userId, followee_user_id: user1.userId }
+  //   ])
+
+  //   await new Promise((r) => setTimeout(r, config.pollInterval * 2))
+  //   // User 1 sent message config.dmNotificationDelay ms ago
+  //   const message = 'hi from user 1'
+  //   const blastId = '1'
+  //   const messageTimestampMs = Date.now() - config.dmNotificationDelay
+  //   const messageTimestamp = new Date(messageTimestampMs)
+  //   const audience = 'follower_audience'
+  //   await insertBlast(
+  //     processor.discoveryDB,
+  //     user1.userId,
+  //     blastId,
+  //     message,
+  //     audience,
+  //     undefined,
+  //     undefined,
+  //     messageTimestamp
+  //   )
+
+  //   await new Promise((r) => setTimeout(r, config.pollInterval * 2))
+
+  //   expect(sendPushNotificationSpy).toHaveBeenCalledTimes(2)
+  //   expect(sendPushNotificationSpy).toHaveBeenNthCalledWith(
+  //     2,
+  //     {
+  //       type: user2.deviceType,
+  //       targetARN: user2.awsARN,
+  //       badgeCount: 1
+  //     },
+  //     {
+  //       title: 'Message',
+  //       body: `New message from ${user1.name}`,
+  //       data: {
+  //         type: 'Message'
+  //       }
+  //     }
+  //   )
+
+  //   // User 2 only allows tippers to message them
+  //   await insertChatPermission(processor.discoveryDB, user2.userId, 'tippers')
+
+  //   // User 1 sent message config.dmNotificationDelay ms ago
+  //   const message2 = 'please let me DM you'
+  //   const blastId2 = '2'
+  //   const messageTimestampMs2 = Date.now() - config.dmNotificationDelay
+  //   const messageTimestamp2 = new Date(messageTimestampMs2)
+  //   await insertBlast(
+  //     processor.discoveryDB,
+  //     user1.userId,
+  //     blastId2,
+  //     message2,
+  //     audience,
+  //     undefined,
+  //     undefined,
+  //     messageTimestamp2
+  //   )
+
+  //   await new Promise((r) => setTimeout(r, config.pollInterval * 2))
+
+  //   // No new notifications
+  //   expect(sendPushNotificationSpy).toHaveBeenCalledTimes(2)
+  //   jest.clearAllMocks()
+  // }, 40000)
+
+  // test('Test blast with existing chat', async () => {
+  //   const { user1, user2 } = await setupTwoUsersWithDevices(
+  //     processor.discoveryDB,
+  //     processor.identityDB
+  //   )
+
+  //   // Start processor
+  //   processor.start()
+  //   // Let notifications job run for a few cycles to initialize the min cursors in redis
+  //   await new Promise((r) => setTimeout(r, config.pollInterval * 2))
+
+  //   // user2 follows user1
+  //   await insertFollows(processor.discoveryDB, [
+  //     { follower_user_id: user2.userId, followee_user_id: user1.userId }
+  //   ])
+  //   await new Promise((r) => setTimeout(r, config.pollInterval * 2))
+  //   // Follow generates a notification
+  //   expect(sendPushNotificationSpy).toHaveBeenCalledTimes(1)
+
+  //   // Create a chat thread
+  //   const message = 'hi from user 1'
+  //   const messageTimestampMs = Date.now()
+  //   const messageTimestamp = new Date(messageTimestampMs)
+  //   const chatId = '1'
+  //   await createChat(
+  //     processor.discoveryDB,
+  //     user1.userId,
+  //     user2.userId,
+  //     chatId,
+  //     messageTimestamp
+  //   )
+
+  //   await new Promise((r) => setTimeout(r, config.pollInterval * 2))
+
+  //   // If the users have an existing chat thread and user1 sends a blast,
+  //   // in the real world user2 should receive a normal message notification
+  //   // from the blast fan-out, but that doesn't work in jest, so just confirm no
+  //   // new message notifications are sent
+  //   const blastId = '1'
+  //   const blastTimestampMs = Date.now() - config.dmNotificationDelay
+  //   const blastTimestamp = new Date(blastTimestampMs)
+  //   const audience = 'follower_audience'
+  //   await insertBlast(
+  //     processor.discoveryDB,
+  //     user1.userId,
+  //     blastId,
+  //     message,
+  //     audience,
+  //     undefined,
+  //     undefined,
+  //     blastTimestamp
+  //   )
+
+  //   await new Promise((r) => setTimeout(r, config.pollInterval * 2))
+
+  //   expect(sendPushNotificationSpy).toHaveBeenCalledTimes(1)
+
+  //   jest.clearAllMocks()
+  // }, 40000)
+
+  test('Test many blasts ', async () => {
+    jest.clearAllMocks()
+    const numUsers = 10
+    setupNUsersWithDevices(
       processor.discoveryDB,
-      processor.identityDB
+      processor.identityDB,
+      numUsers
     )
+
+    // All users follow user 0
+    for (let i = 1; i < numUsers; i++) {
+      await insertFollows(processor.discoveryDB, [
+        { follower_user_id: i, followee_user_id: 0 }
+      ])
+    }
 
     // Start processor
     processor.start()
     // Let notifications job run for a few cycles to initialize the min cursors in redis
     await new Promise((r) => setTimeout(r, config.pollInterval * 2))
 
-    // User 1 sent message config.dmNotificationDelay ms ago
-    const message = 'hi from user 1'
-    const messageId = '1'
-    const messageTimestampMs = Date.now() - config.dmNotificationDelay
-    const messageTimestamp = new Date(messageTimestampMs)
-    const chatId = '1'
-    await createChat(
-      processor.discoveryDB,
-      user1.userId,
-      user2.userId,
-      chatId,
-      messageTimestamp
-    )
-    await insertMessage(
-      processor.discoveryDB,
-      user1.userId,
-      chatId,
-      messageId,
-      message,
-      messageTimestamp
-    )
-
-    await new Promise((r) => setTimeout(r, config.pollInterval * 2))
-
-    expect(sendPushNotificationSpy).toHaveBeenCalledTimes(1)
-    expect(sendPushNotificationSpy).toHaveBeenCalledWith(
-      {
-        type: user2.deviceType,
-        targetARN: user2.awsARN,
-        badgeCount: 1
-      },
-      {
-        title: 'Message',
-        body: `New message from ${user1.name}`,
-        data: {
-          type: 'Message',
-          chatId
-        }
-      }
-    )
-
-    jest.clearAllMocks()
-
-    // User 2 reacted to user 1's message config.dmNotificationDelay ms ago
-    const reaction = '🔥'
-    const reactionTimestampMs = Date.now() - config.dmNotificationDelay
-    await insertReaction(
-      processor.discoveryDB,
-      user2.userId,
-      messageId,
-      reaction,
-      new Date(reactionTimestampMs)
-    )
-
-    await new Promise((r) => setTimeout(r, config.pollInterval * 2))
-    expect(sendPushNotificationSpy).toHaveBeenCalledTimes(1)
-    expect(sendPushNotificationSpy).toHaveBeenCalledWith(
-      {
-        type: user1.deviceType,
-        targetARN: user1.awsARN,
-        badgeCount: 1
-      },
-      {
-        title: 'Reaction',
-        body: `${user2.name} reacted ${reaction}`,
-        data: {
-          type: 'MessageReaction',
-          chatId,
-          messageId
-        }
-      }
-    )
-
-    jest.clearAllMocks()
-  }, 40000)
-
-  test('Process chat blast notification', async () => {
-    const { user1, user2 } = await setupTwoUsersWithDevices(
-      processor.discoveryDB,
-      processor.identityDB
-    )
-
-    // Start processor
-    processor.start()
-    // Let notifications job run for a few cycles to initialize the min cursors in redis
-    await new Promise((r) => setTimeout(r, config.pollInterval * 2))
-
-    await insertFollows(processor.discoveryDB, [
-      { follower_user_id: user2.userId, followee_user_id: user1.userId }
-    ])
-
-    await new Promise((r) => setTimeout(r, config.pollInterval * 2))
-    // User 1 sent message config.dmNotificationDelay ms ago
-    const message = 'hi from user 1'
-    const blastId = '1'
-    const messageTimestampMs = Date.now() - config.dmNotificationDelay
-    const messageTimestamp = new Date(messageTimestampMs)
-    const audience = 'follower_audience'
-    await insertBlast(
-      processor.discoveryDB,
-      user1.userId,
-      blastId,
-      message,
-      audience,
-      undefined,
-      undefined,
-      messageTimestamp
-    )
-
-    await new Promise((r) => setTimeout(r, config.pollInterval * 2))
-
-    expect(sendPushNotificationSpy).toHaveBeenCalledTimes(2)
-    expect(sendPushNotificationSpy).toHaveBeenNthCalledWith(
-      2,
-      {
-        type: user2.deviceType,
-        targetARN: user2.awsARN,
-        badgeCount: 1
-      },
-      {
-        title: 'Message',
-        body: `New message from ${user1.name}`,
-        data: {
-          type: 'Message'
-        }
-      }
-    )
-
-    // User 2 only allows tippers to message them
-    await insertChatPermission(processor.discoveryDB, user2.userId, 'tippers')
-
-    // User 1 sent message config.dmNotificationDelay ms ago
-    const message2 = 'please let me DM you'
-    const blastId2 = '2'
-    const messageTimestampMs2 = Date.now() - config.dmNotificationDelay
-    const messageTimestamp2 = new Date(messageTimestampMs2)
-    await insertBlast(
-      processor.discoveryDB,
-      user1.userId,
-      blastId2,
-      message2,
-      audience,
-      undefined,
-      undefined,
-      messageTimestamp2
-    )
-
-    await new Promise((r) => setTimeout(r, config.pollInterval * 2))
-
-    // No new notifications
-    expect(sendPushNotificationSpy).toHaveBeenCalledTimes(2)
-    jest.clearAllMocks()
-  }, 40000)
-
-  test('Test blast with existing chat', async () => {
-    const { user1, user2 } = await setupTwoUsersWithDevices(
-      processor.discoveryDB,
-      processor.identityDB
-    )
-
-    // Start processor
-    processor.start()
-    // Let notifications job run for a few cycles to initialize the min cursors in redis
-    await new Promise((r) => setTimeout(r, config.pollInterval * 2))
-
-    // user2 follows user1
-    await insertFollows(processor.discoveryDB, [
-      { follower_user_id: user2.userId, followee_user_id: user1.userId }
-    ])
-    await new Promise((r) => setTimeout(r, config.pollInterval * 2))
-    // Follow generates a notification
-    expect(sendPushNotificationSpy).toHaveBeenCalledTimes(1)
-
-    // Create a chat thread
-    const message = 'hi from user 1'
-    const messageTimestampMs = Date.now()
-    const messageTimestamp = new Date(messageTimestampMs)
-    const chatId = '1'
-    await createChat(
-      processor.discoveryDB,
-      user1.userId,
-      user2.userId,
-      chatId,
-      messageTimestamp
-    )
-
-    await new Promise((r) => setTimeout(r, config.pollInterval * 2))
+    // Follow notifs
+    expect(sendPushNotificationSpy).toHaveBeenCalledTimes(numUsers - 1)
 
     // If the users have an existing chat thread and user1 sends a blast,
     // in the real world user2 should receive a normal message notification
     // from the blast fan-out, but that doesn't work in jest, so just confirm no
     // new message notifications are sent
-    const blastId = '1'
+    const blastId = '0'
     const blastTimestampMs = Date.now() - config.dmNotificationDelay
     const blastTimestamp = new Date(blastTimestampMs)
     const audience = 'follower_audience'
+    const message = 'hi from user 0'
     await insertBlast(
       processor.discoveryDB,
-      user1.userId,
+      0,
       blastId,
       message,
       audience,
@@ -250,229 +303,229 @@ describe('Push Notifications', () => {
 
     await new Promise((r) => setTimeout(r, config.pollInterval * 2))
 
-    expect(sendPushNotificationSpy).toHaveBeenCalledTimes(1)
+    expect(sendPushNotificationSpy).toHaveBeenCalledTimes((numUsers - 1) * 2)
 
     jest.clearAllMocks()
   }, 40000)
 
-  test('Does not send DM notifications when sender is receiver', async () => {
-    const { user1, user2 } = await setupTwoUsersWithDevices(
-      processor.discoveryDB,
-      processor.identityDB
-    )
+  // test('Does not send DM notifications when sender is receiver', async () => {
+  //   const { user1, user2 } = await setupTwoUsersWithDevices(
+  //     processor.discoveryDB,
+  //     processor.identityDB
+  //   )
 
-    // Start processor
-    processor.start()
-    // Let notifications job run for a few cycles to initialize the min cursors in redis
-    await new Promise((r) => setTimeout(r, config.pollInterval * 2))
+  //   // Start processor
+  //   processor.start()
+  //   // Let notifications job run for a few cycles to initialize the min cursors in redis
+  //   await new Promise((r) => setTimeout(r, config.pollInterval * 2))
 
-    // User 1 sent message config.dmNotificationDelay ms ago
-    const message = 'hi from user 1'
-    const messageId = '1'
-    const messageTimestampMs = Date.now() - config.dmNotificationDelay
-    const messageTimestamp = new Date(messageTimestampMs)
-    const chatId = '1'
-    await createChat(
-      processor.discoveryDB,
-      user1.userId,
-      user2.userId,
-      chatId,
-      messageTimestamp
-    )
-    await insertMessage(
-      processor.discoveryDB,
-      user1.userId,
-      chatId,
-      messageId,
-      message,
-      messageTimestamp
-    )
+  //   // User 1 sent message config.dmNotificationDelay ms ago
+  //   const message = 'hi from user 1'
+  //   const messageId = '1'
+  //   const messageTimestampMs = Date.now() - config.dmNotificationDelay
+  //   const messageTimestamp = new Date(messageTimestampMs)
+  //   const chatId = '1'
+  //   await createChat(
+  //     processor.discoveryDB,
+  //     user1.userId,
+  //     user2.userId,
+  //     chatId,
+  //     messageTimestamp
+  //   )
+  //   await insertMessage(
+  //     processor.discoveryDB,
+  //     user1.userId,
+  //     chatId,
+  //     messageId,
+  //     message,
+  //     messageTimestamp
+  //   )
 
-    // expanded timeout because timeout was faster than delay
-    // see 'Does not send DM reaction notifications created fewer than delay minutes ago' test for why
-    // the spy might not have been called
-    await new Promise((r) => setTimeout(r, config.pollInterval * 5))
-    expect(sendPushNotificationSpy).toHaveBeenCalledTimes(1)
-    expect(sendPushNotificationSpy).toHaveBeenCalledWith(
-      {
-        type: user2.deviceType,
-        targetARN: user2.awsARN,
-        badgeCount: 1
-      },
-      {
-        title: 'Message',
-        body: `New message from ${user1.name}`,
-        data: {
-          type: 'Message',
-          chatId
-        }
-      }
-    )
+  //   // expanded timeout because timeout was faster than delay
+  //   // see 'Does not send DM reaction notifications created fewer than delay minutes ago' test for why
+  //   // the spy might not have been called
+  //   await new Promise((r) => setTimeout(r, config.pollInterval * 5))
+  //   expect(sendPushNotificationSpy).toHaveBeenCalledTimes(1)
+  //   expect(sendPushNotificationSpy).toHaveBeenCalledWith(
+  //     {
+  //       type: user2.deviceType,
+  //       targetARN: user2.awsARN,
+  //       badgeCount: 1
+  //     },
+  //     {
+  //       title: 'Message',
+  //       body: `New message from ${user1.name}`,
+  //       data: {
+  //         type: 'Message',
+  //         chatId
+  //       }
+  //     }
+  //   )
 
-    jest.clearAllMocks()
+  //   jest.clearAllMocks()
 
-    // User 1 reacted to user 1's message config.dmNotificationDelay ms ago
-    const reaction = '🔥'
-    const reactionTimestampMs = Date.now() - config.dmNotificationDelay
-    await insertReaction(
-      processor.discoveryDB,
-      user1.userId,
-      messageId,
-      reaction,
-      new Date(reactionTimestampMs)
-    )
+  //   // User 1 reacted to user 1's message config.dmNotificationDelay ms ago
+  //   const reaction = '🔥'
+  //   const reactionTimestampMs = Date.now() - config.dmNotificationDelay
+  //   await insertReaction(
+  //     processor.discoveryDB,
+  //     user1.userId,
+  //     messageId,
+  //     reaction,
+  //     new Date(reactionTimestampMs)
+  //   )
 
-    await new Promise((r) => setTimeout(r, config.pollInterval * 2))
-    expect(sendPushNotificationSpy).not.toHaveBeenCalled()
-  }, 40000)
+  //   await new Promise((r) => setTimeout(r, config.pollInterval * 2))
+  //   expect(sendPushNotificationSpy).not.toHaveBeenCalled()
+  // }, 40000)
 
-  test('Does not send DM notifications created fewer than delay minutes ago', async () => {
-    const { user1, user2 } = await setupTwoUsersWithDevices(
-      processor.discoveryDB,
-      processor.identityDB
-    )
+  // test('Does not send DM notifications created fewer than delay minutes ago', async () => {
+  //   const { user1, user2 } = await setupTwoUsersWithDevices(
+  //     processor.discoveryDB,
+  //     processor.identityDB
+  //   )
 
-    // Start processor
-    processor.start()
-    // Let notifications job run for a few cycles to initialize the min cursors in redis
-    await new Promise((r) => setTimeout(r, config.pollInterval * 2))
+  //   // Start processor
+  //   processor.start()
+  //   // Let notifications job run for a few cycles to initialize the min cursors in redis
+  //   await new Promise((r) => setTimeout(r, config.pollInterval * 2))
 
-    // User 1 sends message now
-    const message = 'hi from user 1'
-    const messageId = '1'
-    const messageTimestamp = new Date(Date.now())
-    const chatId = '1'
-    await createChat(
-      processor.discoveryDB,
-      user1.userId,
-      user2.userId,
-      chatId,
-      messageTimestamp
-    )
-    await insertMessage(
-      processor.discoveryDB,
-      user1.userId,
-      chatId,
-      messageId,
-      message,
-      messageTimestamp
-    )
+  //   // User 1 sends message now
+  //   const message = 'hi from user 1'
+  //   const messageId = '1'
+  //   const messageTimestamp = new Date(Date.now())
+  //   const chatId = '1'
+  //   await createChat(
+  //     processor.discoveryDB,
+  //     user1.userId,
+  //     user2.userId,
+  //     chatId,
+  //     messageTimestamp
+  //   )
+  //   await insertMessage(
+  //     processor.discoveryDB,
+  //     user1.userId,
+  //     chatId,
+  //     messageId,
+  //     message,
+  //     messageTimestamp
+  //   )
 
-    await new Promise((r) => setTimeout(r, config.pollInterval * 2))
-    expect(sendPushNotificationSpy).not.toHaveBeenCalled
-  })
+  //   await new Promise((r) => setTimeout(r, config.pollInterval * 2))
+  //   expect(sendPushNotificationSpy).not.toHaveBeenCalled
+  // })
 
-  test('Does not send DM reaction notifications created fewer than delay minutes ago', async () => {
-    const { user1, user2 } = await setupTwoUsersWithDevices(
-      processor.discoveryDB,
-      processor.identityDB
-    )
+  // test('Does not send DM reaction notifications created fewer than delay minutes ago', async () => {
+  //   const { user1, user2 } = await setupTwoUsersWithDevices(
+  //     processor.discoveryDB,
+  //     processor.identityDB
+  //   )
 
-    // Set up chat and message
-    const message = 'hi from user 1'
-    const messageId = '1'
-    const messageTimestamp = new Date(Date.now())
-    const chatId = '1'
-    await createChat(
-      processor.discoveryDB,
-      user1.userId,
-      user2.userId,
-      chatId,
-      messageTimestamp
-    )
-    await insertMessage(
-      processor.discoveryDB,
-      user1.userId,
-      chatId,
-      messageId,
-      message,
-      messageTimestamp
-    )
+  //   // Set up chat and message
+  //   const message = 'hi from user 1'
+  //   const messageId = '1'
+  //   const messageTimestamp = new Date(Date.now())
+  //   const chatId = '1'
+  //   await createChat(
+  //     processor.discoveryDB,
+  //     user1.userId,
+  //     user2.userId,
+  //     chatId,
+  //     messageTimestamp
+  //   )
+  //   await insertMessage(
+  //     processor.discoveryDB,
+  //     user1.userId,
+  //     chatId,
+  //     messageId,
+  //     message,
+  //     messageTimestamp
+  //   )
 
-    // Start processor
-    processor.start()
-    // Let notifications job run for a few cycles to initialize the min cursors in redis
-    await new Promise((r) => setTimeout(r, config.pollInterval * 2))
+  //   // Start processor
+  //   processor.start()
+  //   // Let notifications job run for a few cycles to initialize the min cursors in redis
+  //   await new Promise((r) => setTimeout(r, config.pollInterval * 2))
 
-    // User 2 reacts to user 1's message now
-    const reaction = '🔥'
-    await insertReaction(
-      processor.discoveryDB,
-      user2.userId,
-      messageId,
-      reaction,
-      new Date(Date.now())
-    )
+  //   // User 2 reacts to user 1's message now
+  //   const reaction = '🔥'
+  //   await insertReaction(
+  //     processor.discoveryDB,
+  //     user2.userId,
+  //     messageId,
+  //     reaction,
+  //     new Date(Date.now())
+  //   )
 
-    await new Promise((r) => setTimeout(r, config.pollInterval * 2))
-    expect(sendPushNotificationSpy).not.toHaveBeenCalled
-  })
+  //   await new Promise((r) => setTimeout(r, config.pollInterval * 2))
+  //   expect(sendPushNotificationSpy).not.toHaveBeenCalled
+  // })
 
-  test('Does not send DM notifications for messages that have been read', async () => {
-    const { user1, user2 } = await setupTwoUsersWithDevices(
-      processor.discoveryDB,
-      processor.identityDB
-    )
+  // test('Does not send DM notifications for messages that have been read', async () => {
+  //   const { user1, user2 } = await setupTwoUsersWithDevices(
+  //     processor.discoveryDB,
+  //     processor.identityDB
+  //   )
 
-    // Start processor
-    processor.start()
-    // Let notifications job run for a few cycles to initialize the min cursors in redis
-    await new Promise((r) => setTimeout(r, config.pollInterval * 2))
+  //   // Start processor
+  //   processor.start()
+  //   // Let notifications job run for a few cycles to initialize the min cursors in redis
+  //   await new Promise((r) => setTimeout(r, config.pollInterval * 2))
 
-    // User 1 sent message config.dmNotificationDelay ms ago
-    const message = 'hi from user 1'
-    const messageId = '1'
-    const messageTimestampMs = Date.now() - config.dmNotificationDelay
-    const messageTimestamp = new Date(messageTimestampMs)
-    const chatId = '1'
-    await createChat(
-      processor.discoveryDB,
-      user1.userId,
-      user2.userId,
-      chatId,
-      messageTimestamp
-    )
-    await insertMessage(
-      processor.discoveryDB,
-      user1.userId,
-      chatId,
-      messageId,
-      message,
-      messageTimestamp
-    )
-    // User 2 reads chat
-    await readChat(
-      processor.discoveryDB,
-      user2.userId,
-      chatId,
-      new Date(Date.now())
-    )
+  //   // User 1 sent message config.dmNotificationDelay ms ago
+  //   const message = 'hi from user 1'
+  //   const messageId = '1'
+  //   const messageTimestampMs = Date.now() - config.dmNotificationDelay
+  //   const messageTimestamp = new Date(messageTimestampMs)
+  //   const chatId = '1'
+  //   await createChat(
+  //     processor.discoveryDB,
+  //     user1.userId,
+  //     user2.userId,
+  //     chatId,
+  //     messageTimestamp
+  //   )
+  //   await insertMessage(
+  //     processor.discoveryDB,
+  //     user1.userId,
+  //     chatId,
+  //     messageId,
+  //     message,
+  //     messageTimestamp
+  //   )
+  //   // User 2 reads chat
+  //   await readChat(
+  //     processor.discoveryDB,
+  //     user2.userId,
+  //     chatId,
+  //     new Date(Date.now())
+  //   )
 
-    await new Promise((r) => setTimeout(r, config.pollInterval * 2))
-    expect(sendPushNotificationSpy).not.toHaveBeenCalled
+  //   await new Promise((r) => setTimeout(r, config.pollInterval * 2))
+  //   expect(sendPushNotificationSpy).not.toHaveBeenCalled
 
-    jest.clearAllMocks()
+  //   jest.clearAllMocks()
 
-    // User 2 reacted to user 1's message config.dmNotificationDelay ms ago
-    const reaction = '🔥'
-    const reactionTimestampMs = Date.now() - config.dmNotificationDelay
-    await insertReaction(
-      processor.discoveryDB,
-      user2.userId,
-      messageId,
-      reaction,
-      new Date(reactionTimestampMs)
-    )
+  //   // User 2 reacted to user 1's message config.dmNotificationDelay ms ago
+  //   const reaction = '🔥'
+  //   const reactionTimestampMs = Date.now() - config.dmNotificationDelay
+  //   await insertReaction(
+  //     processor.discoveryDB,
+  //     user2.userId,
+  //     messageId,
+  //     reaction,
+  //     new Date(reactionTimestampMs)
+  //   )
 
-    // User 1 reads chat
-    await readChat(
-      processor.discoveryDB,
-      user1.userId,
-      chatId,
-      new Date(Date.now())
-    )
+  //   // User 1 reads chat
+  //   await readChat(
+  //     processor.discoveryDB,
+  //     user1.userId,
+  //     chatId,
+  //     new Date(Date.now())
+  //   )
 
-    await new Promise((r) => setTimeout(r, config.pollInterval * 2))
-    expect(sendPushNotificationSpy).not.toHaveBeenCalled
-  })
+  //   await new Promise((r) => setTimeout(r, config.pollInterval * 2))
+  //   expect(sendPushNotificationSpy).not.toHaveBeenCalled
+  // })
 })

--- a/packages/discovery-provider/plugins/notifications/src/__tests__/processPushNotification.test.ts
+++ b/packages/discovery-provider/plugins/notifications/src/__tests__/processPushNotification.test.ts
@@ -13,7 +13,6 @@ import {
   resetTests,
   insertFollows,
   insertChatPermission,
-  createUsers,
   setupNUsersWithDevices
 } from '../utils/populateDB'
 
@@ -32,237 +31,258 @@ describe('Push Notifications', () => {
     await resetTests(processor)
   })
 
-  // test('Process DM for ios', async () => {
-  //   const { user1, user2 } = await setupTwoUsersWithDevices(
-  //     processor.discoveryDB,
-  //     processor.identityDB
-  //   )
+  test('Process DM for ios', async () => {
+    const { user1, user2 } = await setupTwoUsersWithDevices(
+      processor.discoveryDB,
+      processor.identityDB
+    )
 
-  //   // Start processor
-  //   processor.start()
-  //   // Let notifications job run for a few cycles to initialize the min cursors in redis
-  //   await new Promise((r) => setTimeout(r, config.pollInterval * 2))
+    // Start processor
+    processor.start()
+    // Let notifications job run for a few cycles to initialize the min cursors in redis
+    await new Promise((r) => setTimeout(r, config.pollInterval * 2))
 
-  //   // User 1 sent message config.dmNotificationDelay ms ago
-  //   const message = 'hi from user 1'
-  //   const messageId = '1'
-  //   const messageTimestampMs = Date.now() - config.dmNotificationDelay
-  //   const messageTimestamp = new Date(messageTimestampMs)
-  //   const chatId = '1'
-  //   await createChat(
-  //     processor.discoveryDB,
-  //     user1.userId,
-  //     user2.userId,
-  //     chatId,
-  //     messageTimestamp
-  //   )
-  //   await insertMessage(
-  //     processor.discoveryDB,
-  //     user1.userId,
-  //     chatId,
-  //     messageId,
-  //     message,
-  //     messageTimestamp
-  //   )
+    // User 1 sent message config.dmNotificationDelay ms ago
+    const message = 'hi from user 1'
+    const messageId = '1'
+    const messageTimestampMs = Date.now() - config.dmNotificationDelay
+    const messageTimestamp = new Date(messageTimestampMs)
+    const chatId = '1'
+    await createChat(
+      processor.discoveryDB,
+      user1.userId,
+      user2.userId,
+      chatId,
+      messageTimestamp
+    )
+    await insertMessage(
+      processor.discoveryDB,
+      user1.userId,
+      chatId,
+      messageId,
+      message,
+      messageTimestamp
+    )
 
-  //   await new Promise((r) => setTimeout(r, config.pollInterval * 2))
+    await new Promise((r) => setTimeout(r, config.pollInterval * 2))
 
-  //   expect(sendPushNotificationSpy).toHaveBeenCalledTimes(1)
-  //   expect(sendPushNotificationSpy).toHaveBeenCalledWith(
-  //     {
-  //       type: user2.deviceType,
-  //       targetARN: user2.awsARN,
-  //       badgeCount: 1
-  //     },
-  //     {
-  //       title: 'Message',
-  //       body: `New message from ${user1.name}`,
-  //       data: {
-  //         type: 'Message',
-  //         chatId
-  //       }
-  //     }
-  //   )
+    expect(sendPushNotificationSpy).toHaveBeenCalledTimes(1)
+    expect(sendPushNotificationSpy).toHaveBeenCalledWith(
+      {
+        type: user2.deviceType,
+        targetARN: user2.awsARN,
+        badgeCount: 1
+      },
+      {
+        title: 'Message',
+        body: `New message from ${user1.name}`,
+        data: {
+          type: 'Message',
+          chatId
+        }
+      }
+    )
 
-  //   jest.clearAllMocks()
+    // User 2 reacted to user 1's message config.dmNotificationDelay ms ago
+    const reaction = '🔥'
+    const reactionTimestampMs = Date.now() - config.dmNotificationDelay
+    await insertReaction(
+      processor.discoveryDB,
+      user2.userId,
+      messageId,
+      reaction,
+      new Date(reactionTimestampMs)
+    )
 
-  //   // User 2 reacted to user 1's message config.dmNotificationDelay ms ago
-  //   const reaction = '🔥'
-  //   const reactionTimestampMs = Date.now() - config.dmNotificationDelay
-  //   await insertReaction(
-  //     processor.discoveryDB,
-  //     user2.userId,
-  //     messageId,
-  //     reaction,
-  //     new Date(reactionTimestampMs)
-  //   )
+    await new Promise((r) => setTimeout(r, config.pollInterval * 2))
+    expect(sendPushNotificationSpy).toHaveBeenCalledTimes(2)
+    expect(sendPushNotificationSpy).toHaveBeenNthCalledWith(
+      2,
+      {
+        type: user1.deviceType,
+        targetARN: user1.awsARN,
+        badgeCount: 1
+      },
+      {
+        title: 'Reaction',
+        body: `${user2.name} reacted ${reaction}`,
+        data: {
+          type: 'MessageReaction',
+          chatId,
+          messageId
+        }
+      }
+    )
 
-  //   await new Promise((r) => setTimeout(r, config.pollInterval * 2))
-  //   expect(sendPushNotificationSpy).toHaveBeenCalledTimes(1)
-  //   expect(sendPushNotificationSpy).toHaveBeenCalledWith(
-  //     {
-  //       type: user1.deviceType,
-  //       targetARN: user1.awsARN,
-  //       badgeCount: 1
-  //     },
-  //     {
-  //       title: 'Reaction',
-  //       body: `${user2.name} reacted ${reaction}`,
-  //       data: {
-  //         type: 'MessageReaction',
-  //         chatId,
-  //         messageId
-  //       }
-  //     }
-  //   )
+    jest.clearAllMocks()
+  }, 40000)
 
-  //   jest.clearAllMocks()
-  // }, 40000)
+  test('Process chat blast notification', async () => {
+    const { user1, user2 } = await setupTwoUsersWithDevices(
+      processor.discoveryDB,
+      processor.identityDB
+    )
 
-  // test('Process chat blast notification', async () => {
-  //   const { user1, user2 } = await setupTwoUsersWithDevices(
-  //     processor.discoveryDB,
-  //     processor.identityDB
-  //   )
+    // Start processor
+    processor.start()
+    // Let notifications job run for a few cycles to initialize the min cursors in redis
+    await new Promise((r) => setTimeout(r, config.pollInterval * 2))
 
-  //   // Start processor
-  //   processor.start()
-  //   // Let notifications job run for a few cycles to initialize the min cursors in redis
-  //   await new Promise((r) => setTimeout(r, config.pollInterval * 2))
+    await insertFollows(processor.discoveryDB, [
+      { follower_user_id: user2.userId, followee_user_id: user1.userId }
+    ])
 
-  //   await insertFollows(processor.discoveryDB, [
-  //     { follower_user_id: user2.userId, followee_user_id: user1.userId }
-  //   ])
+    await new Promise((r) => setTimeout(r, config.pollInterval * 2))
 
-  //   await new Promise((r) => setTimeout(r, config.pollInterval * 2))
-  //   // User 1 sent message config.dmNotificationDelay ms ago
-  //   const message = 'hi from user 1'
-  //   const blastId = '1'
-  //   const messageTimestampMs = Date.now() - config.dmNotificationDelay
-  //   const messageTimestamp = new Date(messageTimestampMs)
-  //   const audience = 'follower_audience'
-  //   await insertBlast(
-  //     processor.discoveryDB,
-  //     user1.userId,
-  //     blastId,
-  //     message,
-  //     audience,
-  //     undefined,
-  //     undefined,
-  //     messageTimestamp
-  //   )
+    // follow notification
+    expect(sendPushNotificationSpy).toHaveBeenCalledTimes(1)
 
-  //   await new Promise((r) => setTimeout(r, config.pollInterval * 2))
+    // User 1 sent message config.dmNotificationDelay ms ago
+    const message = 'hi from user 1'
+    const blastId = '1'
+    const messageTimestampMs = Date.now() - config.dmNotificationDelay
+    const messageTimestamp = new Date(messageTimestampMs)
+    const audience = 'follower_audience'
+    await insertBlast(
+      processor.discoveryDB,
+      user1.userId,
+      blastId,
+      message,
+      audience,
+      undefined,
+      undefined,
+      messageTimestamp
+    )
 
-  //   expect(sendPushNotificationSpy).toHaveBeenCalledTimes(2)
-  //   expect(sendPushNotificationSpy).toHaveBeenNthCalledWith(
-  //     2,
-  //     {
-  //       type: user2.deviceType,
-  //       targetARN: user2.awsARN,
-  //       badgeCount: 1
-  //     },
-  //     {
-  //       title: 'Message',
-  //       body: `New message from ${user1.name}`,
-  //       data: {
-  //         type: 'Message'
-  //       }
-  //     }
-  //   )
+    await new Promise((r) => setTimeout(r, config.pollInterval * 2))
 
-  //   // User 2 only allows tippers to message them
-  //   await insertChatPermission(processor.discoveryDB, user2.userId, 'tippers')
+    // Expect 1 follow notif and 1 blast message notif
+    // expect(sendPushNotificationSpy).toHaveBeenCalledTimes(2)
+    const calls = sendPushNotificationSpy.mock.calls
+    const expectedCalls = [
+      [
+        expect.objectContaining({
+          type: user1.deviceType,
+          targetARN: user1.awsARN,
+          badgeCount: 1
+        }),
+        expect.objectContaining({
+          title: 'New Follow',
+          body: `${user2.name} followed you`,
+          data: expect.objectContaining({
+            type: 'Follow'
+          })
+        })
+      ],
+      [
+        // Another expected call structure, modify as necessary
+        expect.objectContaining({
+          type: user2.deviceType,
+          targetARN: user2.awsARN,
+          badgeCount: 1
+        }),
+        expect.objectContaining({
+          title: 'Message',
+          body: `New message from ${user1.name}`,
+          data: expect.objectContaining({
+            type: 'Message'
+          })
+        })
+      ]
+    ]
+    expect(calls).toEqual(expect.arrayContaining(expectedCalls))
 
-  //   // User 1 sent message config.dmNotificationDelay ms ago
-  //   const message2 = 'please let me DM you'
-  //   const blastId2 = '2'
-  //   const messageTimestampMs2 = Date.now() - config.dmNotificationDelay
-  //   const messageTimestamp2 = new Date(messageTimestampMs2)
-  //   await insertBlast(
-  //     processor.discoveryDB,
-  //     user1.userId,
-  //     blastId2,
-  //     message2,
-  //     audience,
-  //     undefined,
-  //     undefined,
-  //     messageTimestamp2
-  //   )
+    // User 2 only allows tippers to message them
+    await insertChatPermission(processor.discoveryDB, user2.userId, 'tippers')
 
-  //   await new Promise((r) => setTimeout(r, config.pollInterval * 2))
+    // User 1 sent message config.dmNotificationDelay ms ago
+    const message2 = 'please let me DM you'
+    const blastId2 = '2'
+    const messageTimestampMs2 = Date.now() - config.dmNotificationDelay
+    const messageTimestamp2 = new Date(messageTimestampMs2)
+    await insertBlast(
+      processor.discoveryDB,
+      user1.userId,
+      blastId2,
+      message2,
+      audience,
+      undefined,
+      undefined,
+      messageTimestamp2
+    )
 
-  //   // No new notifications
-  //   expect(sendPushNotificationSpy).toHaveBeenCalledTimes(2)
-  //   jest.clearAllMocks()
-  // }, 40000)
+    await new Promise((r) => setTimeout(r, config.pollInterval * 2))
 
-  // test('Test blast with existing chat', async () => {
-  //   const { user1, user2 } = await setupTwoUsersWithDevices(
-  //     processor.discoveryDB,
-  //     processor.identityDB
-  //   )
+    // No new notifications
+    expect(sendPushNotificationSpy).toHaveBeenCalledTimes(2)
+    jest.clearAllMocks()
+  }, 40000)
 
-  //   // Start processor
-  //   processor.start()
-  //   // Let notifications job run for a few cycles to initialize the min cursors in redis
-  //   await new Promise((r) => setTimeout(r, config.pollInterval * 2))
+  test('Test blast with existing chat', async () => {
+    const { user1, user2 } = await setupTwoUsersWithDevices(
+      processor.discoveryDB,
+      processor.identityDB
+    )
 
-  //   // user2 follows user1
-  //   await insertFollows(processor.discoveryDB, [
-  //     { follower_user_id: user2.userId, followee_user_id: user1.userId }
-  //   ])
-  //   await new Promise((r) => setTimeout(r, config.pollInterval * 2))
-  //   // Follow generates a notification
-  //   expect(sendPushNotificationSpy).toHaveBeenCalledTimes(1)
+    // Start processor
+    processor.start()
+    // Let notifications job run for a few cycles to initialize the min cursors in redis
+    await new Promise((r) => setTimeout(r, config.pollInterval * 2))
 
-  //   // Create a chat thread
-  //   const message = 'hi from user 1'
-  //   const messageTimestampMs = Date.now()
-  //   const messageTimestamp = new Date(messageTimestampMs)
-  //   const chatId = '1'
-  //   await createChat(
-  //     processor.discoveryDB,
-  //     user1.userId,
-  //     user2.userId,
-  //     chatId,
-  //     messageTimestamp
-  //   )
+    // user2 follows user1
+    await insertFollows(processor.discoveryDB, [
+      { follower_user_id: user2.userId, followee_user_id: user1.userId }
+    ])
+    await new Promise((r) => setTimeout(r, config.pollInterval * 2))
+    // Follow generates a notification
+    expect(sendPushNotificationSpy).toHaveBeenCalledTimes(1)
 
-  //   await new Promise((r) => setTimeout(r, config.pollInterval * 2))
+    // Create a chat thread
+    const message = 'hi from user 1'
+    const messageTimestampMs = Date.now()
+    const messageTimestamp = new Date(messageTimestampMs)
+    const chatId = '1'
+    await createChat(
+      processor.discoveryDB,
+      user1.userId,
+      user2.userId,
+      chatId,
+      messageTimestamp
+    )
 
-  //   // If the users have an existing chat thread and user1 sends a blast,
-  //   // in the real world user2 should receive a normal message notification
-  //   // from the blast fan-out, but that doesn't work in jest, so just confirm no
-  //   // new message notifications are sent
-  //   const blastId = '1'
-  //   const blastTimestampMs = Date.now() - config.dmNotificationDelay
-  //   const blastTimestamp = new Date(blastTimestampMs)
-  //   const audience = 'follower_audience'
-  //   await insertBlast(
-  //     processor.discoveryDB,
-  //     user1.userId,
-  //     blastId,
-  //     message,
-  //     audience,
-  //     undefined,
-  //     undefined,
-  //     blastTimestamp
-  //   )
+    await new Promise((r) => setTimeout(r, config.pollInterval * 2))
 
-  //   await new Promise((r) => setTimeout(r, config.pollInterval * 2))
+    // If the users have an existing chat thread and user1 sends a blast,
+    // in the real world user2 should receive a normal message notification
+    // from the blast fan-out, but that doesn't work in jest, so just confirm no
+    // new message notifications are sent
+    const blastId = '1'
+    const blastTimestampMs = Date.now() - config.dmNotificationDelay
+    const blastTimestamp = new Date(blastTimestampMs)
+    const audience = 'follower_audience'
+    await insertBlast(
+      processor.discoveryDB,
+      user1.userId,
+      blastId,
+      message,
+      audience,
+      undefined,
+      undefined,
+      blastTimestamp
+    )
 
-  //   expect(sendPushNotificationSpy).toHaveBeenCalledTimes(1)
+    await new Promise((r) => setTimeout(r, config.pollInterval * 2))
 
-  //   jest.clearAllMocks()
-  // }, 40000)
+    expect(sendPushNotificationSpy).toHaveBeenCalledTimes(1)
+
+    jest.clearAllMocks()
+  }, 40000)
 
   test('Test many blasts ', async () => {
-    jest.clearAllMocks()
     config.blastUserBatchSize = 2
     const numUsers = 5
     const numInitialFollowers = numUsers - 2
-    setupNUsersWithDevices(
+    const users = await setupNUsersWithDevices(
       processor.discoveryDB,
       processor.identityDB,
       numUsers
@@ -305,12 +325,26 @@ describe('Push Notifications', () => {
       setTimeout(r, config.pollInterval * (numUsers - 1))
     )
 
-    expect(sendPushNotificationSpy).toHaveBeenCalledTimes(
-      numInitialFollowers * 2
-    )
+    let notifsSoFar = numInitialFollowers * 2
+    expect(sendPushNotificationSpy).toHaveBeenCalledTimes(notifsSoFar)
+    for (let i = 0; i < numInitialFollowers; i++) {
+      expect(sendPushNotificationSpy).toHaveBeenNthCalledWith(
+        notifsSoFar - i,
+        expect.objectContaining({
+          type: users[0].deviceType
+        }),
+        expect.objectContaining({
+          title: 'Message',
+          body: `New message from ${users[0].name}`,
+          data: expect.objectContaining({
+            type: 'Message'
+          })
+        })
+      )
+    }
 
     // Test race condition when new follower whose userId is in the middle of a batch
-    //  is added in between processing a blast
+    // is added in between processing a blast
     blastId = '1'
     blastTimestampMs = Date.now() - config.dmNotificationDelay
     blastTimestamp = new Date(blastTimestampMs)
@@ -337,232 +371,283 @@ describe('Push Notifications', () => {
       setTimeout(r, config.pollInterval * (numUsers - 1))
     )
 
+    notifsSoFar = numInitialFollowers * 3 + 1
     // Expect 3 more blast notifs + 1 follow notif
-    expect(sendPushNotificationSpy).toHaveBeenCalledTimes(
-      numInitialFollowers * 3 + 1
+    expect(sendPushNotificationSpy).toHaveBeenCalledTimes(notifsSoFar)
+    expect(sendPushNotificationSpy).toHaveBeenNthCalledWith(
+      notifsSoFar,
+      expect.objectContaining({
+        type: users[0].deviceType
+      }),
+      expect.objectContaining({
+        title: 'Message',
+        body: `New message from ${users[0].name}`,
+        data: expect.objectContaining({
+          type: 'Message'
+        })
+      })
     )
+
+    const numFinalFollowers = numUsers - 1
+    blastId = '2'
+    blastTimestampMs = Date.now() - config.dmNotificationDelay
+    blastTimestamp = new Date(blastTimestampMs)
+    message = 'third blast from user 0'
+    await insertBlast(
+      processor.discoveryDB,
+      0,
+      blastId,
+      message,
+      audience,
+      undefined,
+      undefined,
+      blastTimestamp
+    )
+
+    await new Promise((r) =>
+      setTimeout(r, config.pollInterval * (numUsers - 1))
+    )
+
+    notifsSoFar = notifsSoFar + numFinalFollowers
+    // Expect all users to receive a blast notif now
+    expect(sendPushNotificationSpy).toHaveBeenCalledTimes(notifsSoFar)
+    for (let i = 0; i < numFinalFollowers; i++) {
+      expect(sendPushNotificationSpy).toHaveBeenNthCalledWith(
+        notifsSoFar - i,
+        expect.objectContaining({
+          type: users[0].deviceType
+        }),
+        expect.objectContaining({
+          title: 'Message',
+          body: `New message from ${users[0].name}`,
+          data: expect.objectContaining({
+            type: 'Message'
+          })
+        })
+      )
+    }
 
     jest.clearAllMocks()
   }, 40000)
 
-  // test('Does not send DM notifications when sender is receiver', async () => {
-  //   const { user1, user2 } = await setupTwoUsersWithDevices(
-  //     processor.discoveryDB,
-  //     processor.identityDB
-  //   )
+  test('Does not send DM notifications when sender is receiver', async () => {
+    const { user1, user2 } = await setupTwoUsersWithDevices(
+      processor.discoveryDB,
+      processor.identityDB
+    )
 
-  //   // Start processor
-  //   processor.start()
-  //   // Let notifications job run for a few cycles to initialize the min cursors in redis
-  //   await new Promise((r) => setTimeout(r, config.pollInterval * 2))
+    // Start processor
+    processor.start()
+    // Let notifications job run for a few cycles to initialize the min cursors in redis
+    await new Promise((r) => setTimeout(r, config.pollInterval * 2))
 
-  //   // User 1 sent message config.dmNotificationDelay ms ago
-  //   const message = 'hi from user 1'
-  //   const messageId = '1'
-  //   const messageTimestampMs = Date.now() - config.dmNotificationDelay
-  //   const messageTimestamp = new Date(messageTimestampMs)
-  //   const chatId = '1'
-  //   await createChat(
-  //     processor.discoveryDB,
-  //     user1.userId,
-  //     user2.userId,
-  //     chatId,
-  //     messageTimestamp
-  //   )
-  //   await insertMessage(
-  //     processor.discoveryDB,
-  //     user1.userId,
-  //     chatId,
-  //     messageId,
-  //     message,
-  //     messageTimestamp
-  //   )
+    // User 1 sent message config.dmNotificationDelay ms ago
+    const message = 'hi from user 1'
+    const messageId = '1'
+    const messageTimestampMs = Date.now() - config.dmNotificationDelay
+    const messageTimestamp = new Date(messageTimestampMs)
+    const chatId = '1'
+    await createChat(
+      processor.discoveryDB,
+      user1.userId,
+      user2.userId,
+      chatId,
+      messageTimestamp
+    )
+    await insertMessage(
+      processor.discoveryDB,
+      user1.userId,
+      chatId,
+      messageId,
+      message,
+      messageTimestamp
+    )
 
-  //   // expanded timeout because timeout was faster than delay
-  //   // see 'Does not send DM reaction notifications created fewer than delay minutes ago' test for why
-  //   // the spy might not have been called
-  //   await new Promise((r) => setTimeout(r, config.pollInterval * 5))
-  //   expect(sendPushNotificationSpy).toHaveBeenCalledTimes(1)
-  //   expect(sendPushNotificationSpy).toHaveBeenCalledWith(
-  //     {
-  //       type: user2.deviceType,
-  //       targetARN: user2.awsARN,
-  //       badgeCount: 1
-  //     },
-  //     {
-  //       title: 'Message',
-  //       body: `New message from ${user1.name}`,
-  //       data: {
-  //         type: 'Message',
-  //         chatId
-  //       }
-  //     }
-  //   )
+    // expanded timeout because timeout was faster than delay
+    // see 'Does not send DM reaction notifications created fewer than delay minutes ago' test for why
+    // the spy might not have been called
+    await new Promise((r) => setTimeout(r, config.pollInterval * 5))
+    expect(sendPushNotificationSpy).toHaveBeenCalledTimes(1)
+    expect(sendPushNotificationSpy).toHaveBeenCalledWith(
+      {
+        type: user2.deviceType,
+        targetARN: user2.awsARN,
+        badgeCount: 1
+      },
+      {
+        title: 'Message',
+        body: `New message from ${user1.name}`,
+        data: {
+          type: 'Message',
+          chatId
+        }
+      }
+    )
 
-  //   jest.clearAllMocks()
+    jest.clearAllMocks()
 
-  //   // User 1 reacted to user 1's message config.dmNotificationDelay ms ago
-  //   const reaction = '🔥'
-  //   const reactionTimestampMs = Date.now() - config.dmNotificationDelay
-  //   await insertReaction(
-  //     processor.discoveryDB,
-  //     user1.userId,
-  //     messageId,
-  //     reaction,
-  //     new Date(reactionTimestampMs)
-  //   )
+    // User 1 reacted to user 1's message config.dmNotificationDelay ms ago
+    const reaction = '🔥'
+    const reactionTimestampMs = Date.now() - config.dmNotificationDelay
+    await insertReaction(
+      processor.discoveryDB,
+      user1.userId,
+      messageId,
+      reaction,
+      new Date(reactionTimestampMs)
+    )
 
-  //   await new Promise((r) => setTimeout(r, config.pollInterval * 2))
-  //   expect(sendPushNotificationSpy).not.toHaveBeenCalled()
-  // }, 40000)
+    await new Promise((r) => setTimeout(r, config.pollInterval * 2))
+    expect(sendPushNotificationSpy).not.toHaveBeenCalled()
+  }, 40000)
 
-  // test('Does not send DM notifications created fewer than delay minutes ago', async () => {
-  //   const { user1, user2 } = await setupTwoUsersWithDevices(
-  //     processor.discoveryDB,
-  //     processor.identityDB
-  //   )
+  test('Does not send DM notifications created fewer than delay minutes ago', async () => {
+    const { user1, user2 } = await setupTwoUsersWithDevices(
+      processor.discoveryDB,
+      processor.identityDB
+    )
 
-  //   // Start processor
-  //   processor.start()
-  //   // Let notifications job run for a few cycles to initialize the min cursors in redis
-  //   await new Promise((r) => setTimeout(r, config.pollInterval * 2))
+    // Start processor
+    processor.start()
+    // Let notifications job run for a few cycles to initialize the min cursors in redis
+    await new Promise((r) => setTimeout(r, config.pollInterval * 2))
 
-  //   // User 1 sends message now
-  //   const message = 'hi from user 1'
-  //   const messageId = '1'
-  //   const messageTimestamp = new Date(Date.now())
-  //   const chatId = '1'
-  //   await createChat(
-  //     processor.discoveryDB,
-  //     user1.userId,
-  //     user2.userId,
-  //     chatId,
-  //     messageTimestamp
-  //   )
-  //   await insertMessage(
-  //     processor.discoveryDB,
-  //     user1.userId,
-  //     chatId,
-  //     messageId,
-  //     message,
-  //     messageTimestamp
-  //   )
+    // User 1 sends message now
+    const message = 'hi from user 1'
+    const messageId = '1'
+    const messageTimestamp = new Date(Date.now())
+    const chatId = '1'
+    await createChat(
+      processor.discoveryDB,
+      user1.userId,
+      user2.userId,
+      chatId,
+      messageTimestamp
+    )
+    await insertMessage(
+      processor.discoveryDB,
+      user1.userId,
+      chatId,
+      messageId,
+      message,
+      messageTimestamp
+    )
 
-  //   await new Promise((r) => setTimeout(r, config.pollInterval * 2))
-  //   expect(sendPushNotificationSpy).not.toHaveBeenCalled
-  // })
+    await new Promise((r) => setTimeout(r, config.pollInterval * 2))
+    expect(sendPushNotificationSpy).not.toHaveBeenCalled
+  })
 
-  // test('Does not send DM reaction notifications created fewer than delay minutes ago', async () => {
-  //   const { user1, user2 } = await setupTwoUsersWithDevices(
-  //     processor.discoveryDB,
-  //     processor.identityDB
-  //   )
+  test('Does not send DM reaction notifications created fewer than delay minutes ago', async () => {
+    const { user1, user2 } = await setupTwoUsersWithDevices(
+      processor.discoveryDB,
+      processor.identityDB
+    )
 
-  //   // Set up chat and message
-  //   const message = 'hi from user 1'
-  //   const messageId = '1'
-  //   const messageTimestamp = new Date(Date.now())
-  //   const chatId = '1'
-  //   await createChat(
-  //     processor.discoveryDB,
-  //     user1.userId,
-  //     user2.userId,
-  //     chatId,
-  //     messageTimestamp
-  //   )
-  //   await insertMessage(
-  //     processor.discoveryDB,
-  //     user1.userId,
-  //     chatId,
-  //     messageId,
-  //     message,
-  //     messageTimestamp
-  //   )
+    // Set up chat and message
+    const message = 'hi from user 1'
+    const messageId = '1'
+    const messageTimestamp = new Date(Date.now())
+    const chatId = '1'
+    await createChat(
+      processor.discoveryDB,
+      user1.userId,
+      user2.userId,
+      chatId,
+      messageTimestamp
+    )
+    await insertMessage(
+      processor.discoveryDB,
+      user1.userId,
+      chatId,
+      messageId,
+      message,
+      messageTimestamp
+    )
 
-  //   // Start processor
-  //   processor.start()
-  //   // Let notifications job run for a few cycles to initialize the min cursors in redis
-  //   await new Promise((r) => setTimeout(r, config.pollInterval * 2))
+    // Start processor
+    processor.start()
+    // Let notifications job run for a few cycles to initialize the min cursors in redis
+    await new Promise((r) => setTimeout(r, config.pollInterval * 2))
 
-  //   // User 2 reacts to user 1's message now
-  //   const reaction = '🔥'
-  //   await insertReaction(
-  //     processor.discoveryDB,
-  //     user2.userId,
-  //     messageId,
-  //     reaction,
-  //     new Date(Date.now())
-  //   )
+    // User 2 reacts to user 1's message now
+    const reaction = '🔥'
+    await insertReaction(
+      processor.discoveryDB,
+      user2.userId,
+      messageId,
+      reaction,
+      new Date(Date.now())
+    )
 
-  //   await new Promise((r) => setTimeout(r, config.pollInterval * 2))
-  //   expect(sendPushNotificationSpy).not.toHaveBeenCalled
-  // })
+    await new Promise((r) => setTimeout(r, config.pollInterval * 2))
+    expect(sendPushNotificationSpy).not.toHaveBeenCalled
+  })
 
-  // test('Does not send DM notifications for messages that have been read', async () => {
-  //   const { user1, user2 } = await setupTwoUsersWithDevices(
-  //     processor.discoveryDB,
-  //     processor.identityDB
-  //   )
+  test('Does not send DM notifications for messages that have been read', async () => {
+    const { user1, user2 } = await setupTwoUsersWithDevices(
+      processor.discoveryDB,
+      processor.identityDB
+    )
 
-  //   // Start processor
-  //   processor.start()
-  //   // Let notifications job run for a few cycles to initialize the min cursors in redis
-  //   await new Promise((r) => setTimeout(r, config.pollInterval * 2))
+    // Start processor
+    processor.start()
+    // Let notifications job run for a few cycles to initialize the min cursors in redis
+    await new Promise((r) => setTimeout(r, config.pollInterval * 2))
 
-  //   // User 1 sent message config.dmNotificationDelay ms ago
-  //   const message = 'hi from user 1'
-  //   const messageId = '1'
-  //   const messageTimestampMs = Date.now() - config.dmNotificationDelay
-  //   const messageTimestamp = new Date(messageTimestampMs)
-  //   const chatId = '1'
-  //   await createChat(
-  //     processor.discoveryDB,
-  //     user1.userId,
-  //     user2.userId,
-  //     chatId,
-  //     messageTimestamp
-  //   )
-  //   await insertMessage(
-  //     processor.discoveryDB,
-  //     user1.userId,
-  //     chatId,
-  //     messageId,
-  //     message,
-  //     messageTimestamp
-  //   )
-  //   // User 2 reads chat
-  //   await readChat(
-  //     processor.discoveryDB,
-  //     user2.userId,
-  //     chatId,
-  //     new Date(Date.now())
-  //   )
+    // User 1 sent message config.dmNotificationDelay ms ago
+    const message = 'hi from user 1'
+    const messageId = '1'
+    const messageTimestampMs = Date.now() - config.dmNotificationDelay
+    const messageTimestamp = new Date(messageTimestampMs)
+    const chatId = '1'
+    await createChat(
+      processor.discoveryDB,
+      user1.userId,
+      user2.userId,
+      chatId,
+      messageTimestamp
+    )
+    await insertMessage(
+      processor.discoveryDB,
+      user1.userId,
+      chatId,
+      messageId,
+      message,
+      messageTimestamp
+    )
+    // User 2 reads chat
+    await readChat(
+      processor.discoveryDB,
+      user2.userId,
+      chatId,
+      new Date(Date.now())
+    )
 
-  //   await new Promise((r) => setTimeout(r, config.pollInterval * 2))
-  //   expect(sendPushNotificationSpy).not.toHaveBeenCalled
+    await new Promise((r) => setTimeout(r, config.pollInterval * 2))
+    expect(sendPushNotificationSpy).not.toHaveBeenCalled
 
-  //   jest.clearAllMocks()
+    jest.clearAllMocks()
 
-  //   // User 2 reacted to user 1's message config.dmNotificationDelay ms ago
-  //   const reaction = '🔥'
-  //   const reactionTimestampMs = Date.now() - config.dmNotificationDelay
-  //   await insertReaction(
-  //     processor.discoveryDB,
-  //     user2.userId,
-  //     messageId,
-  //     reaction,
-  //     new Date(reactionTimestampMs)
-  //   )
+    // User 2 reacted to user 1's message config.dmNotificationDelay ms ago
+    const reaction = '🔥'
+    const reactionTimestampMs = Date.now() - config.dmNotificationDelay
+    await insertReaction(
+      processor.discoveryDB,
+      user2.userId,
+      messageId,
+      reaction,
+      new Date(reactionTimestampMs)
+    )
 
-  //   // User 1 reads chat
-  //   await readChat(
-  //     processor.discoveryDB,
-  //     user1.userId,
-  //     chatId,
-  //     new Date(Date.now())
-  //   )
+    // User 1 reads chat
+    await readChat(
+      processor.discoveryDB,
+      user1.userId,
+      chatId,
+      new Date(Date.now())
+    )
 
-  //   await new Promise((r) => setTimeout(r, config.pollInterval * 2))
-  //   expect(sendPushNotificationSpy).not.toHaveBeenCalled
-  // })
+    await new Promise((r) => setTimeout(r, config.pollInterval * 2))
+    expect(sendPushNotificationSpy).not.toHaveBeenCalled
+  })
 })

--- a/packages/discovery-provider/plugins/notifications/src/config.ts
+++ b/packages/discovery-provider/plugins/notifications/src/config.ts
@@ -4,5 +4,6 @@ export const config = {
   // ms between jobs
   pollInterval: 500,
   lastIndexedMessageRedisKey: 'latestDMNotificationTimestamp',
-  lastIndexedReactionRedisKey: 'latestDMReactionNotificationTimestamp'
+  lastIndexedReactionRedisKey: 'latestDMReactionNotificationTimestamp',
+  lastIndexedBlastRedisKey: 'latestBlastNotificationID'
 }

--- a/packages/discovery-provider/plugins/notifications/src/config.ts
+++ b/packages/discovery-provider/plugins/notifications/src/config.ts
@@ -3,7 +3,10 @@ export const config = {
   dmNotificationDelay: 500,
   // ms between jobs
   pollInterval: 500,
+  // Batch size of users for chat blast notifications
+  blastUserBatchSize: 100,
   lastIndexedMessageRedisKey: 'latestDMNotificationTimestamp',
   lastIndexedReactionRedisKey: 'latestDMReactionNotificationTimestamp',
-  lastIndexedBlastRedisKey: 'latestBlastNotificationID'
+  lastIndexedBlastIdRedisKey: 'latestBlastNotificationID',
+  lastIndexedBlastUserIdRedisKey: 'latestBlastNotificationUserID'
 }

--- a/packages/discovery-provider/plugins/notifications/src/tasks/dmNotifications.ts
+++ b/packages/discovery-provider/plugins/notifications/src/tasks/dmNotifications.ts
@@ -11,7 +11,6 @@ import type {
 import { getRedisConnection } from './../utils/redisConnection'
 import { Timer } from '../utils/timer'
 import { makeChatId } from '../utils/chatId'
-import { last } from 'lodash'
 
 // Sort notifications in ascending order according to timestamp
 function notificationTimestampComparator(
@@ -147,7 +146,12 @@ async function getNewBlasts(
       .from('chat_blast')
       .where('chat_blast.blast_id', lastIndexedBlastId)
       .first()
-    lastIndexedBlastTimestamp = result?.timestamp ?? new Date(0).toISOString()
+    lastIndexedBlastTimestamp = result?.timestamp
+  }
+
+  // First time running the task, set the timestamp cursor to a very old date
+  if (!lastIndexedBlastTimestamp) {
+    lastIndexedBlastTimestamp = new Date(0).toISOString()
   }
   const userId = lastIndexedBlastUserId
 
@@ -158,94 +162,94 @@ async function getNewBlasts(
   ) => {
     const messages = await discoveryDB.raw(
       `
-          WITH blast AS (
-            SELECT * FROM chat_blast WHERE ${blastCondition}
-          ),
-          aud AS (
-            -- follower_audience
-            SELECT blast_id, follower_user_id AS to_user_id
-            FROM follows
-            JOIN blast
-              ON blast.audience = 'follower_audience'
-              AND follows.followee_user_id = blast.from_user_id
-              AND follows.is_delete = false
-              AND follows.created_at < blast.created_at
+      WITH blast AS (
+        SELECT * FROM chat_blast WHERE ${blastCondition}
+      ),
+      aud AS (
+        -- follower_audience
+        SELECT blast_id, follower_user_id AS to_user_id
+        FROM follows
+        JOIN blast
+          ON blast.audience = 'follower_audience'
+          AND follows.followee_user_id = blast.from_user_id
+          AND follows.is_delete = false
+          AND follows.created_at < blast.created_at
 
-            UNION
+        UNION
 
-            -- tipper_audience
-            SELECT blast_id, sender_user_id AS to_user_id
-            FROM user_tips tip
-            JOIN blast
-              ON blast.audience = 'tipper_audience'
-              AND receiver_user_id = blast.from_user_id
-              AND tip.created_at < blast.created_at
+        -- tipper_audience
+        SELECT blast_id, sender_user_id AS to_user_id
+        FROM user_tips tip
+        JOIN blast
+          ON blast.audience = 'tipper_audience'
+          AND receiver_user_id = blast.from_user_id
+          AND tip.created_at < blast.created_at
 
-            UNION
+        UNION
 
-            -- remixer_audience
-            SELECT blast_id, t.owner_id AS to_user_id
-            FROM tracks t
-            JOIN remixes ON remixes.child_track_id = t.track_id
-            JOIN tracks og ON remixes.parent_track_id = og.track_id
-            JOIN blast
-              ON blast.audience = 'remixer_audience'
-              AND og.owner_id = blast.from_user_id
-              AND (
-                blast.audience_content_id IS NULL
-                OR (
-                  blast.audience_content_type = 'track'
-                  AND blast.audience_content_id = og.track_id
-                )
-              )
-
-            UNION
-
-            -- customer_audience
-            SELECT blast_id, buyer_user_id AS to_user_id
-            FROM usdc_purchases p
-            JOIN blast
-              ON blast.audience = 'customer_audience'
-              AND p.seller_user_id = blast.from_user_id
-              AND (
-                blast.audience_content_id IS NULL
-                OR (
-                  blast.audience_content_type = p.content_type::text
-                  AND blast.audience_content_id = p.content_id
-                )
-              )
-          ),
-          targ AS (
-            SELECT
-              blast_id,
-              from_user_id,
-              to_user_id,
-              blast.created_at
-            FROM blast
-            JOIN aud USING (blast_id)
-            LEFT JOIN chat_member member_a ON from_user_id = member_a.user_id
-            LEFT JOIN chat_member member_b ON to_user_id = member_b.user_id AND member_b.chat_id = member_a.chat_id
-            WHERE member_b.chat_id IS NULL
-            AND chat_allowed(from_user_id, to_user_id)
-            AND (${userCondition})
-            ORDER BY to_user_id ASC
-            LIMIT ?
+        -- remixer_audience
+        SELECT blast_id, t.owner_id AS to_user_id
+        FROM tracks t
+        JOIN remixes ON remixes.child_track_id = t.track_id
+        JOIN tracks og ON remixes.parent_track_id = og.track_id
+        JOIN blast
+          ON blast.audience = 'remixer_audience'
+          AND og.owner_id = blast.from_user_id
+          AND (
+            blast.audience_content_id IS NULL
+            OR (
+              blast.audience_content_type = 'track'
+              AND blast.audience_content_id = og.track_id
+            )
           )
-          SELECT blast_id, from_user_id AS sender_user_id, to_user_id AS receiver_user_id, created_at FROM targ;
-        `,
+
+        UNION
+
+        -- customer_audience
+        SELECT blast_id, buyer_user_id AS to_user_id
+        FROM usdc_purchases p
+        JOIN blast
+          ON blast.audience = 'customer_audience'
+          AND p.seller_user_id = blast.from_user_id
+          AND (
+            blast.audience_content_id IS NULL
+            OR (
+              blast.audience_content_type = p.content_type::text
+              AND blast.audience_content_id = p.content_id
+            )
+          )
+      ),
+      targ AS (
+        SELECT
+          blast_id,
+          from_user_id,
+          to_user_id,
+          blast.created_at
+        FROM blast
+        JOIN aud USING (blast_id)
+        LEFT JOIN chat_member member_a ON from_user_id = member_a.user_id
+        LEFT JOIN chat_member member_b ON to_user_id = member_b.user_id AND member_b.chat_id = member_a.chat_id
+        WHERE member_b.chat_id IS NULL -- !! note this is the opposite from the query in chat_blast.go
+        AND chat_allowed(from_user_id, to_user_id)
+        AND (${userCondition})
+        ORDER BY to_user_id ASC
+        LIMIT ?
+      )
+      SELECT blast_id, from_user_id AS sender_user_id, to_user_id AS receiver_user_id, created_at FROM targ;
+      `,
       params
     )
     return messages.rows
   }
 
-  // First attempt with last indexed blast and user ID
+  // First attempt with last indexed blast and user id
   let messages = await fetchMessages(
     'chat_blast.blast_id = ?',
     '?::INTEGER IS NULL OR to_user_id > ?',
     [lastIndexedBlastId, userId, userId, config.blastUserBatchSize]
   )
 
-  // If no messages found, move to next timestamp batch
+  // If no messages found, move to next blast id, with no user id conditions
   if (!messages?.length) {
     messages = await fetchMessages(
       'chat_blast.created_at > ? ORDER BY chat_blast.created_at ASC LIMIT 1',
@@ -254,16 +258,22 @@ async function getNewBlasts(
     )
   }
 
+  // Need to calculate pending chat ids for each message for deep linking
   const formattedMessages = messages?.map((message) => {
     return {
       ...message,
-      chatId: makeChatId([message.sender_user_id, message.receiver_user_id])
+      chat_id: makeChatId([message.sender_user_id, message.receiver_user_id])
     }
   })
 
+  // If there are no new messages, the cursors will remain the same. Otherwise,
+  // update them to the blast id of the current batch and the last user id in the batch.
+  const newBlastIdCursor = formattedMessages[0]?.blast_id ?? lastIndexedBlastId
+  const newUserIdCursor = formattedMessages.at(-1)?.receiver_user_id ?? null
+
   return {
-    lastIndexedBlastId: formattedMessages[0]?.blast_id ?? lastIndexedBlastId,
-    lastIndexedBlastUserId: formattedMessages.at(-1)?.receiver_user_id ?? null,
+    lastIndexedBlastId: newBlastIdCursor,
+    lastIndexedBlastUserId: newUserIdCursor,
     messages: formattedMessages
   }
 }

--- a/packages/discovery-provider/plugins/notifications/src/utils/populateDB.ts
+++ b/packages/discovery-provider/plugins/notifications/src/utils/populateDB.ts
@@ -872,3 +872,39 @@ export async function setupTwoUsersWithDevices(
     }
   }
 }
+
+export async function setupNUsersWithDevices(
+  discoveryDB: Knex,
+  identityDB: Knex,
+  numUsers: number
+): Promise<UserWithDevice[]> {
+  await createUsers(
+    discoveryDB,
+    Array.from({ length: numUsers }, (_, i) => {
+      return { user_id: i, name: `user${i}`, is_current: true }
+    })
+  )
+
+  await insertMobileSettings(
+    identityDB,
+    Array.from({ length: numUsers }, (_, i) => {
+      return { userId: i, messages: true }
+    })
+  )
+  const deviceType = enum_NotificationDeviceTokens_deviceType.ios
+  await insertMobileDevices(
+    identityDB,
+    Array.from({ length: numUsers }, (_, i) => {
+      return { userId: i, deviceType: deviceType, awsARN: `arn:${i}` }
+    })
+  )
+
+  return Array.from({ length: numUsers }, (_, i) => {
+    return {
+      userId: i,
+      name: `user${i}`,
+      deviceType: deviceType,
+      awsARN: `arn:${i}`
+    }
+  })
+}

--- a/packages/discovery-provider/plugins/notifications/src/utils/populateDB.ts
+++ b/packages/discovery-provider/plugins/notifications/src/utils/populateDB.ts
@@ -32,8 +32,7 @@ import {
 import { getDB } from '../conn'
 import { expect, jest } from '@jest/globals'
 import { Processor } from '../main'
-import { getRedisConnection } from './redisConnection'
-import { config } from '../config'
+import { clearRedisKeys } from './redisConnection'
 import { EmailFrequency } from '../processNotifications/mappers/userNotificationSettings'
 
 type SetupTestConfig = {
@@ -69,9 +68,7 @@ export const setupTest = async (setupConfig?: SetupTestConfig) => {
   if (mockTime) {
     Date.now = jest.fn(() => new Date('2020-05-13T12:33:37.000Z').getTime())
   }
-  const redis = await getRedisConnection()
-  redis.del(config.lastIndexedMessageRedisKey)
-  redis.del(config.lastIndexedReactionRedisKey)
+  await clearRedisKeys()
   return { processor }
 }
 

--- a/packages/discovery-provider/plugins/notifications/src/utils/redisConnection.ts
+++ b/packages/discovery-provider/plugins/notifications/src/utils/redisConnection.ts
@@ -16,3 +16,8 @@ export async function getRedisConnection(): Promise<RedisClientType> {
   }
   return redisClient
 }
+
+export async function clearRedisKeys() {
+  const redis = await getRedisConnection()
+  redis.flushAll()
+}


### PR DESCRIPTION
### Description
Current blast notifications were causing on oom on staging after QA. We need to batch the blast notifications that go out. Create two cursors: on for blastId, and one for userId. We paginate through the userIds for a given blast, so that max `config.blastUserBatchSize` goes out per task run.

### How Has This Been Tested?

Added new tests, all passing.
Specifically there's one test that checks a race condition when new follower whose userId is in the middle of a batch
is added in between processing a blast. We want to favor skipping the userId instead of duplicate notifs, hence using a cursor on userId instead of just limit/offset pagination.