### PR TITLE
[C-5094] Press comment stat to navigate to comments

### DIFF
--- a/packages/mobile/src/components/lineup-tile/LineupTileStats.tsx
+++ b/packages/mobile/src/components/lineup-tile/LineupTileStats.tsx
@@ -154,6 +154,11 @@ export const LineupTileStats = ({
     navigation.push('Reposts', { id, repostType })
   }, [dispatch, id, navigation, repostType])
 
+  const handlePressComments = useCallback(() => {
+    dispatch(setFavorite(id, favoriteType))
+    navigation.push('Track', { id, showComments: true })
+  }, [dispatch, id, navigation, favoriteType])
+
   const downloadStatusIndicator = isCollection ? (
     <CollectionDownloadStatusIndicator size='s' collectionId={id} />
   ) : (
@@ -268,7 +273,8 @@ export const LineupTileStats = ({
                     styles.statItem,
                     !commentCount ? styles.disabledStatItem : null
                   ]}
-                  disabled
+                  disabled={!commentCount || isReadonly}
+                  onPress={handlePressComments}
                 >
                   <IconMessage color='subdued' size='s' />
                   <Text style={trackTileStyles.statText}>

--- a/packages/mobile/src/screens/app-screen/AppTabScreen.tsx
+++ b/packages/mobile/src/screens/app-screen/AppTabScreen.tsx
@@ -72,6 +72,7 @@ export type AppTabScreenParamList = {
     canBeUnlisted?: boolean
     handle?: string
     slug?: string
+    showComments?: boolean
   }
   TrackRemixes: { id: ID } | { handle: string; slug: string }
   Profile: { handle: string; id?: ID } | { handle?: string; id: ID }

--- a/packages/mobile/src/screens/track-screen/TrackScreen.tsx
+++ b/packages/mobile/src/screens/track-screen/TrackScreen.tsx
@@ -11,6 +11,7 @@ import {
 } from '@audius/common/store'
 import { useFocusEffect } from '@react-navigation/native'
 import { useDispatch, useSelector } from 'react-redux'
+import { useEffectOnce } from 'react-use'
 
 import { IconArrowRight, Button, Text, Flex } from '@audius/harmony-native'
 import { CommentSection } from 'app/components/comments/CommentSection'
@@ -20,6 +21,7 @@ import {
   VirtualizedScrollView
 } from 'app/components/core'
 import { Lineup } from 'app/components/lineup'
+import { useDrawer } from 'app/hooks/useDrawer'
 import { useNavigation } from 'app/hooks/useNavigation'
 import { useRoute } from 'app/hooks/useRoute'
 
@@ -45,7 +47,22 @@ export const TrackScreen = () => {
   const dispatch = useDispatch()
   const isReachable = useSelector(getIsReachable)
 
-  const { searchTrack, id, canBeUnlisted = true, handle, slug } = params ?? {}
+  const {
+    searchTrack,
+    id,
+    canBeUnlisted = true,
+    handle,
+    slug,
+    showComments
+  } = params ?? {}
+
+  const { onOpen: openDrawer } = useDrawer('Comment')
+
+  useEffectOnce(() => {
+    if (showComments) {
+      openDrawer({ entityId: id })
+    }
+  })
 
   const cachedTrack = useSelector((state) => getTrack(state, params))
 

--- a/packages/web/src/components/comments/CommentSectionDesktop.tsx
+++ b/packages/web/src/components/comments/CommentSectionDesktop.tsx
@@ -1,4 +1,4 @@
-import { useRef } from 'react'
+import { useEffect, useRef, useState } from 'react'
 
 import { useCurrentCommentSection } from '@audius/common/context'
 import { useFeatureFlag } from '@audius/common/hooks'
@@ -12,6 +12,7 @@ import {
   Skeleton
 } from '@audius/harmony'
 import InfiniteScroll from 'react-infinite-scroller'
+import { useSearchParams } from 'react-router-dom-v5-compat'
 
 import { useMainContentRef } from 'pages/MainContentContext'
 
@@ -76,6 +77,23 @@ export const CommentSectionDesktop = () => {
   const commentPostAllowed = currentUserId !== undefined && commentPostFlag
   const commentSectionRef = useRef<HTMLDivElement | null>(null)
   const showCommentSortBar = commentIds.length > 1
+
+  const [searchParams] = useSearchParams()
+  const showComments = searchParams.get('showComments')
+  const [hasScrolledIntoView, setHasScrolledIntoView] = useState(false)
+
+  // Scroll to the comment section if the showComments query param is present
+  useEffect(() => {
+    if (
+      showComments &&
+      !hasScrolledIntoView &&
+      !commentSectionLoading &&
+      commentSectionRef.current
+    ) {
+      commentSectionRef.current.scrollIntoView()
+      setHasScrolledIntoView(true)
+    }
+  }, [commentSectionLoading, showComments, hasScrolledIntoView])
 
   if (commentSectionLoading) {
     return <FullCommentSkeletons />

--- a/packages/web/src/components/comments/CommentSectionMobile.tsx
+++ b/packages/web/src/components/comments/CommentSectionMobile.tsx
@@ -1,3 +1,5 @@
+import { useEffect, useState } from 'react'
+
 import { useGetTrackById } from '@audius/common/api'
 import { useCurrentCommentSection } from '@audius/common/context'
 import { commentsMessages as messages } from '@audius/common/messages'
@@ -9,7 +11,12 @@ import {
   Skeleton,
   Text
 } from '@audius/harmony'
+import { push as pushRoute } from 'connected-react-router'
+import { useDispatch } from 'react-redux'
 import { Link } from 'react-router-dom'
+import { useSearchParams } from 'react-router-dom-v5-compat'
+
+import { useHistoryContext } from 'app/HistoryProvider'
 
 import { CommentBlock } from './CommentBlock'
 import { CommentForm } from './CommentForm'
@@ -81,6 +88,20 @@ const CommentSectionContent = () => {
 }
 
 export const CommentSectionMobile = () => {
+  const dispatch = useDispatch()
+  const { track } = useCurrentCommentSection()
+  const [searchParams] = useSearchParams()
+  const showComments = searchParams.get('showComments')
+  const { history } = useHistoryContext()
+
+  // Show the comment screen if the showComments query param is present
+  useEffect(() => {
+    if (showComments) {
+      history.replace({ search: '' })
+      dispatch(pushRoute(`${track?.permalink}/comments`))
+    }
+  }, [showComments, track, dispatch, searchParams, history])
+
   return (
     <Flex gap='s' direction='column' w='100%' alignItems='flex-start'>
       <CommentSectionHeader />

--- a/packages/web/src/components/comments/CommentSectionMobile.tsx
+++ b/packages/web/src/components/comments/CommentSectionMobile.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react'
+import { useEffect } from 'react'
 
 import { useGetTrackById } from '@audius/common/api'
 import { useCurrentCommentSection } from '@audius/common/context'

--- a/packages/web/src/components/track/desktop/ConnectedTrackTile.tsx
+++ b/packages/web/src/components/track/desktop/ConnectedTrackTile.tsx
@@ -21,6 +21,7 @@ import {
 import { Genre } from '@audius/common/utils'
 import { IconKebabHorizontal } from '@audius/harmony'
 import cn from 'classnames'
+import { push } from 'connected-react-router'
 import { connect, useDispatch } from 'react-redux'
 import { Dispatch } from 'redux'
 
@@ -109,7 +110,8 @@ const ConnectedTrackTile = ({
   isFeed = false,
   showRankIcon,
   onClick,
-  statSize = 'large'
+  statSize = 'large',
+  goToRoute
 }: ConnectedTrackTileProps) => {
   const trackWithFallback = getTrackWithFallback(track)
   const {
@@ -174,6 +176,10 @@ const ConnectedTrackTile = ({
   const onClickStatFavorite = () => {
     setFavoriteUsers(trackId)
     setModalVisibility()
+  }
+
+  const onClickStatComment = () => {
+    goToRoute(permalink + '?showComments=true')
   }
 
   useEffect(() => {
@@ -281,6 +287,7 @@ const ConnectedTrackTile = ({
             count={comment_count}
             contentTitle={contentTitle}
             size={statSize}
+            onClick={onClickStatComment}
             flavor={Flavor.COMMENT}
             isOwner={isOwner}
           />
@@ -477,7 +484,8 @@ function mapDispatchToProps(dispatch: Dispatch) {
           id: trackID
         })
       ),
-    setModalVisibility: () => dispatch(setVisibility(true))
+    setModalVisibility: () => dispatch(setVisibility(true)),
+    goToRoute: (route: string) => dispatch(push(route))
   }
 }
 

--- a/packages/web/src/components/track/mobile/ConnectedTrackTile.tsx
+++ b/packages/web/src/components/track/mobile/ConnectedTrackTile.tsx
@@ -190,6 +190,11 @@ const ConnectedTrackTile = ({
       goToRoute(FAVORITING_USERS_ROUTE)
     }
 
+  const makeGoToCommentsPage = (_: ID) => (e: MouseEvent<HTMLElement>) => {
+    e.stopPropagation()
+    goToRoute(track?.permalink + '?showComments=true')
+  }
+
   const onClickOverflow = (trackId: ID) => {
     const isLongFormContent =
       genre === Genre.PODCASTS || genre === Genre.AUDIOBOOKS
@@ -274,6 +279,7 @@ const ConnectedTrackTile = ({
       toggleRepost={toggleRepost}
       makeGoToRepostsPage={makeGoToRepostsPage}
       makeGoToFavoritesPage={makeGoToFavoritesPage}
+      makeGoToCommentsPage={makeGoToCommentsPage}
       goToRoute={goToRoute}
       isOwner={isOwner}
       darkMode={darkMode}

--- a/packages/web/src/components/track/mobile/TrackTile.tsx
+++ b/packages/web/src/components/track/mobile/TrackTile.tsx
@@ -65,6 +65,7 @@ type ExtraProps = {
   onShare: (trackId: ID) => void
   makeGoToRepostsPage: (trackId: ID) => (e: MouseEvent<HTMLElement>) => void
   makeGoToFavoritesPage: (trackId: ID) => (e: MouseEvent<HTMLElement>) => void
+  makeGoToCommentsPage: (trackId: ID) => (e: MouseEvent<HTMLElement>) => void
   isOwner: boolean
   darkMode: boolean
   isMatrix: boolean
@@ -470,12 +471,17 @@ const TrackTile = (props: CombinedProps) => {
                       props.isUnlisted ||
                       props.commentsDisabled
                   })}
+                  onClick={
+                    props.commentCount && !isReadonly
+                      ? props.makeGoToCommentsPage(id)
+                      : undefined
+                  }
                 >
                   <IconMessage
                     className={styles.favoriteButton}
                     color='subdued'
                   />
-                  {formatCount(props.saveCount)}
+                  {formatCount(props.commentCount)}
                 </div>
               </>
             )}


### PR DESCRIPTION
### Description

* Hook up pressing on TrackTile comment stat to navigate to comments
On web I used a `showComments` query param to trigger scrolling/navigating to comments

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._
