### PR TITLE
Batch chat notifs to fix max connection limit reached

### DIFF
--- a/packages/discovery-provider/plugins/notifications/src/config.ts
+++ b/packages/discovery-provider/plugins/notifications/src/config.ts
@@ -5,6 +5,8 @@ export const config = {
   pollInterval: 500,
   // Batch size of users for chat blast notifications
   blastUserBatchSize: 100,
+  // Batch size of notifications to be processed together
+  notificationBatchSize: 30,
   lastIndexedMessageRedisKey: 'latestDMNotificationTimestamp',
   lastIndexedReactionRedisKey: 'latestDMReactionNotificationTimestamp',
   lastIndexedBlastIdRedisKey: 'latestBlastNotificationID',


### PR DESCRIPTION
### Description

We were hitting this error after sending out a test blast with 13000 recipients on stage:
```
KnexTimeoutError: Knex: Timeout acquiring a connection. The pool is probably full. Are you missing a .transacting(trx) call?
```
The stacktrace pointed to `buildUserNotificationSettings` which is inside `processNotifications`. Marcus realized that that call wasn't being awaited, which is likely the culprit of the max connection limit reached. So the fix is to await them, but process them in batches so they don't take super long.

### How Has This Been Tested?

Tests pass locally. Will have to test with large recipient count again on stage.