### PR TITLE
[C-5118] Fix android keyboard for comments

### DIFF
--- a/packages/mobile/src/app/App.tsx
+++ b/packages/mobile/src/app/App.tsx
@@ -102,8 +102,8 @@ const App = () => {
                                 <NotificationReminder />
                                 <RateCtaReminder />
                                 <PortalHost name='ChatReactionsPortal' />
-                                <PortalHost name='DrawerPortal' />
                               </BottomSheetModalProvider>
+                              <PortalHost name='DrawerPortal' />
                             </NavigationContainer>
                           </ErrorBoundary>
                         </PortalProvider>

--- a/packages/mobile/src/app/App.tsx
+++ b/packages/mobile/src/app/App.tsx
@@ -102,8 +102,8 @@ const App = () => {
                                 <NotificationReminder />
                                 <RateCtaReminder />
                                 <PortalHost name='ChatReactionsPortal' />
+                                <PortalHost name='DrawerPortal' />
                               </BottomSheetModalProvider>
-                              <PortalHost name='DrawerPortal' />
                             </NavigationContainer>
                           </ErrorBoundary>
                         </PortalProvider>

--- a/packages/mobile/src/components/comments/CommentDrawer.tsx
+++ b/packages/mobile/src/components/comments/CommentDrawer.tsx
@@ -258,10 +258,12 @@ export const CommentDrawer = () => {
         </CommentSectionProvider>
       </BottomSheetFooter>
     ),
+    // intentionally excluding insets.bottom because it causes a rerender
+    // when the keyboard is opened on android, causing the keyboard to close
+    // eslint-disable-next-line react-hooks/exhaustive-deps
     [
       editingComment,
       entityId,
-      insets.bottom,
       onAutoCompleteChange,
       replyingToComment,
       setAutocompleteHandler
@@ -292,6 +294,7 @@ export const CommentDrawer = () => {
         )}
         footerComponent={renderFooterComponent}
         onDismiss={handleClose}
+        android_keyboardInputMode='adjustResize'
       >
         <CommentSectionProvider
           entityId={entityId}


### PR DESCRIPTION
### Description

Android keyboard was closing immediately upon focusing the compose input. Glad there was a straightforward fix! Could've been a whole thing

* Exclude `insets.bottom` from the dependency array of the `footerComponent` function. We should be safe to use the initial calculated insets values for the life of the session
* Set `android_keyboardInputMode='adjustResize` to match our android keyboard settings

### How Has This Been Tested?

Tested both android and ios keyboard behavior with comments drawer
