### PR TITLE
[C-5119] Fix android comments drawer stacking

### DIFF
--- a/packages/mobile/src/app/App.tsx
+++ b/packages/mobile/src/app/App.tsx
@@ -102,8 +102,8 @@ const App = () => {
                                 <NotificationReminder />
                                 <RateCtaReminder />
                                 <PortalHost name='ChatReactionsPortal' />
-                                <PortalHost name='DrawerPortal' />
                               </BottomSheetModalProvider>
+                              <PortalHost name='DrawerPortal' />
                             </NavigationContainer>
                           </ErrorBoundary>
                         </PortalProvider>

--- a/packages/mobile/src/components/comments/CommentDrawer.tsx
+++ b/packages/mobile/src/components/comments/CommentDrawer.tsx
@@ -258,10 +258,12 @@ export const CommentDrawer = () => {
         </CommentSectionProvider>
       </BottomSheetFooter>
     ),
+    // intentionally excluding insets.bottom because it causes a rerender
+    // when the keyboard is opened on android, causing the keyboard to close
+    // eslint-disable-next-line react-hooks/exhaustive-deps
     [
       editingComment,
       entityId,
-      insets.bottom,
       onAutoCompleteChange,
       replyingToComment,
       setAutocompleteHandler
@@ -292,6 +294,7 @@ export const CommentDrawer = () => {
         )}
         footerComponent={renderFooterComponent}
         onDismiss={handleClose}
+        android_keyboardInputMode='adjustResize'
       >
         <CommentSectionProvider
           entityId={entityId}


### PR DESCRIPTION
### Description

On android, the action and confirmation drawers were occasionally appearing behind the comments drawer. Moving the DrawerPortal outside of the BottomSheetModalProvider fixes this. I also confirmed that drawers using commentsContext are still able to be portaled properly

Also contains changes from https://github.com/AudiusProject/audius-protocol/pull/9990 so that should be merged first

### How Has This Been Tested?

Tested comment drawer, action drawers, and confirmation drawers on android and ios
