### PR TITLE
[PAY-3498] Fix remix track audience targeting

### DIFF
--- a/packages/common/src/api/user.ts
+++ b/packages/common/src/api/user.ts
@@ -3,7 +3,7 @@ import { full } from '@audius/sdk'
 import { transformAndCleanList, userTrackMetadataFromSDK } from '~/adapters'
 import { userMetadataListFromSDK } from '~/adapters/user'
 import { createApi } from '~/audius-query'
-import { ID, Kind, OptionalId, StringUSDC } from '~/models'
+import { HashId, ID, Kind, OptionalId, StringUSDC } from '~/models'
 import {
   USDCTransactionDetails,
   USDCTransactionMethod,
@@ -316,7 +316,11 @@ const userApi = createApi({
         const { data = [] } = await sdk.users.getUserTracksRemixed({
           id: Id.parse(userId)
         })
-        return data
+
+        return data.map((item) => ({
+          ...item,
+          trackId: HashId.parse(item.trackId)
+        }))
       },
       options: {}
     },
@@ -326,6 +330,7 @@ const userApi = createApi({
         const { data } = await sdk.users.getSalesAggregate({
           id: Id.parse(userId)
         })
+
         return data
       },
       options: {}


### PR DESCRIPTION
### Description

The migration to the new remixers endpoint broke the options in the form.

The root cause was we weren't decoding the hashIds after receiving the data. Trying to call `encodeHashId` on the hashId resulted in `''` which was submitted as the target trackId for the chatBlast audience.

### How Has This Been Tested?

wasn't working now it's working 👍