### PR TITLE
[C-5107] Fix replying to a reply on mobile

### DIFF
--- a/packages/common/src/context/comments/commentsContext.tsx
+++ b/packages/common/src/context/comments/commentsContext.tsx
@@ -38,10 +38,17 @@ type CommentSectionProviderProps = {
 
   // These are optional because they are only used on mobile
   // and provided for the components in CommentDrawer
+  replyingAndEditingState?: ReplyingAndEditingState
+  setReplyingAndEditingState?: (
+    state: ReplyingAndEditingState | undefined
+  ) => void
+}
+
+export type ReplyingAndEditingState = {
   replyingToComment?: Comment | ReplyComment
-  setReplyingToComment?: (comment: Comment | ReplyComment | undefined) => void
+  // This can be different from replyingToComment if we are replying to a reply
+  replyingToCommentId?: ID
   editingComment?: Comment | ReplyComment
-  setEditingComment?: (comment: Comment | ReplyComment | undefined) => void
 }
 
 type CommentSectionContextType = {
@@ -72,10 +79,8 @@ export const CommentSectionProvider = (
     entityId,
     entityType = EntityType.TRACK,
     children,
-    replyingToComment,
-    setReplyingToComment,
-    editingComment,
-    setEditingComment
+    replyingAndEditingState,
+    setReplyingAndEditingState
   } = props
   const { data: track } = useGetTrackById({ id: entityId })
 
@@ -168,10 +173,8 @@ export const CommentSectionProvider = (
         reset,
         hasMorePages: !!hasNextPage,
         currentSort,
-        replyingToComment,
-        setReplyingToComment,
-        editingComment,
-        setEditingComment,
+        replyingAndEditingState,
+        setReplyingAndEditingState,
         setCurrentSort,
         playTrack,
         loadMorePages

--- a/packages/mobile/src/components/comments/CommentActionBar.tsx
+++ b/packages/mobile/src/components/comments/CommentActionBar.tsx
@@ -5,7 +5,7 @@ import {
   useReactToComment
 } from '@audius/common/context'
 import { commentsMessages as messages } from '@audius/common/messages'
-import type { Comment, ReplyComment } from '@audius/common/models'
+import type { Comment, ID, ReplyComment } from '@audius/common/models'
 
 import { Flex, PlainButton, Text } from '@audius/harmony-native'
 
@@ -17,14 +17,15 @@ type CommentActionBarProps = {
   comment: Comment | ReplyComment
   isDisabled?: boolean
   hideReactCount?: boolean
+  parentCommentId?: ID
 }
 export const CommentActionBar = (props: CommentActionBarProps) => {
-  const { isDisabled, comment, hideReactCount } = props
+  const { isDisabled, comment, hideReactCount, parentCommentId } = props
   const { isCurrentUserReacted, reactCount, id: commentId } = comment
 
   const [reactToComment] = useReactToComment()
   const [reactionState, setReactionState] = useState(isCurrentUserReacted) // TODO: need to pull starting value from metadata
-  const { setReplyingToComment } = useCurrentCommentSection()
+  const { setReplyingAndEditingState } = useCurrentCommentSection()
 
   const handleCommentReact = () => {
     setReactionState(!reactionState)
@@ -50,7 +51,10 @@ export const CommentActionBar = (props: CommentActionBarProps) => {
         <PlainButton
           variant='subdued'
           onPress={() => {
-            setReplyingToComment?.(comment)
+            setReplyingAndEditingState?.({
+              replyingToComment: comment,
+              replyingToCommentId: parentCommentId ?? comment.id
+            })
           }}
           disabled={isDisabled}
         >

--- a/packages/mobile/src/components/comments/CommentBlock.tsx
+++ b/packages/mobile/src/components/comments/CommentBlock.tsx
@@ -26,7 +26,7 @@ export const CommentBlockInternal = (
     comment: Comment | ReplyComment
   }
 ) => {
-  const { comment, hideActions } = props
+  const { comment, hideActions, parentCommentId } = props
   const { artistId } = useCurrentCommentSection()
   const {
     message,
@@ -86,6 +86,7 @@ export const CommentBlockInternal = (
             comment={comment}
             isDisabled={isTombstone}
             hideReactCount={isTombstone}
+            parentCommentId={parentCommentId}
           />
         ) : null}
       </Flex>

--- a/packages/mobile/src/components/comments/CommentDrawer.tsx
+++ b/packages/mobile/src/components/comments/CommentDrawer.tsx
@@ -3,11 +3,12 @@ import React, { useCallback, useEffect, useRef, useState } from 'react'
 
 import type { SearchCategory } from '@audius/common/api'
 import { useGetSearchResults } from '@audius/common/api'
+import type { ReplyingAndEditingState } from '@audius/common/context'
 import {
   CommentSectionProvider,
   useCurrentCommentSection
 } from '@audius/common/context'
-import type { Comment, ReplyComment, UserMetadata } from '@audius/common/models'
+import type { UserMetadata } from '@audius/common/models'
 import { Status } from '@audius/common/models'
 import { accountSelectors } from '@audius/common/store'
 import type {
@@ -205,10 +206,8 @@ export const CommentDrawer = () => {
   >(() => {})
   const [autoCompleteActive, setAutoCompleteActive] = useState(false)
   const [acText, setAcText] = useState('')
-  const [replyingToComment, setReplyingToComment] = useState<
-    Comment | ReplyComment
-  >()
-  const [editingComment, setEditingComment] = useState<Comment | ReplyComment>()
+  const [replyingAndEditingState, setReplyingAndEditingState] =
+    useState<ReplyingAndEditingState>()
 
   const setAutocompleteHandler = useCallback(
     (autocompleteHandler: (user: UserMetadata) => void) => {
@@ -245,10 +244,8 @@ export const CommentDrawer = () => {
         <Divider orientation='horizontal' />
         <CommentSectionProvider
           entityId={entityId}
-          replyingToComment={replyingToComment}
-          setReplyingToComment={setReplyingToComment}
-          editingComment={editingComment}
-          setEditingComment={setEditingComment}
+          replyingAndEditingState={replyingAndEditingState}
+          setReplyingAndEditingState={setReplyingAndEditingState}
         >
           <CommentDrawerForm
             commentListRef={commentListRef}
@@ -259,12 +256,11 @@ export const CommentDrawer = () => {
       </BottomSheetFooter>
     ),
     [
-      editingComment,
       entityId,
       insets.bottom,
       onAutoCompleteChange,
-      replyingToComment,
-      setAutocompleteHandler
+      setAutocompleteHandler,
+      replyingAndEditingState
     ]
   )
 
@@ -295,10 +291,8 @@ export const CommentDrawer = () => {
       >
         <CommentSectionProvider
           entityId={entityId}
-          replyingToComment={replyingToComment}
-          setReplyingToComment={setReplyingToComment}
-          editingComment={editingComment}
-          setEditingComment={setEditingComment}
+          replyingAndEditingState={replyingAndEditingState}
+          setReplyingAndEditingState={setReplyingAndEditingState}
         >
           <CommentDrawerHeader
             minimal={autoCompleteActive}

--- a/packages/mobile/src/components/comments/CommentDrawerForm.tsx
+++ b/packages/mobile/src/components/comments/CommentDrawerForm.tsx
@@ -24,12 +24,10 @@ type CommentDrawerFormProps = {
 
 export const CommentDrawerForm = (props: CommentDrawerFormProps) => {
   const { commentListRef, onAutocompleteChange, setAutocompleteHandler } = props
-  const {
-    editingComment,
-    replyingToComment,
-    setReplyingToComment,
-    setEditingComment
-  } = useCurrentCommentSection()
+  const { replyingAndEditingState, setReplyingAndEditingState } =
+    useCurrentCommentSection()
+  const { replyingToComment, replyingToCommentId, editingComment } =
+    replyingAndEditingState ?? {}
   const [postComment] = usePostComment()
   const [editComment] = useEditComment()
 
@@ -37,7 +35,7 @@ export const CommentDrawerForm = (props: CommentDrawerFormProps) => {
     if (editingComment) {
       editComment(editingComment.id, message, mentions)
     } else {
-      postComment(message, replyingToComment?.id)
+      postComment(message, replyingToCommentId ?? replyingToComment?.id)
     }
 
     // Scroll to top of comments when posting a new comment
@@ -45,8 +43,7 @@ export const CommentDrawerForm = (props: CommentDrawerFormProps) => {
       commentListRef.current?.scrollToOffset({ offset: 0 })
     }
 
-    setReplyingToComment?.(undefined)
-    setEditingComment?.(undefined)
+    setReplyingAndEditingState?.(undefined)
   }
 
   // TODO:

--- a/packages/mobile/src/components/comments/CommentForm.tsx
+++ b/packages/mobile/src/components/comments/CommentForm.tsx
@@ -25,18 +25,18 @@ type CommentFormHelperTextProps = {
 
 const CommentFormHelperText = (props: CommentFormHelperTextProps) => {
   const { replyingToUserHandle } = props
-  const { replyingToComment, setReplyingToComment, setEditingComment } =
+  const { replyingAndEditingState, setReplyingAndEditingState } =
     useCurrentCommentSection()
   const { color, spacing } = useTheme()
+  const { replyingToComment } = replyingAndEditingState ?? {}
 
   const text = replyingToComment
     ? messages.replyingTo(replyingToUserHandle ?? '')
     : messages.editing
 
   const handlePressClear = useCallback(() => {
-    setReplyingToComment?.(undefined)
-    setEditingComment?.(undefined)
-  }, [setEditingComment, setReplyingToComment])
+    setReplyingAndEditingState?.(undefined)
+  }, [setReplyingAndEditingState])
 
   return (
     <Flex
@@ -85,13 +85,9 @@ export const CommentForm = (props: CommentFormProps) => {
   } = props
   const [messageId, setMessageId] = useState(0)
   const [initialMessage, setInitialMessage] = useState(initialValue)
-  const {
-    currentUserId,
-    commentIds,
-    entityId,
-    replyingToComment,
-    editingComment
-  } = useCurrentCommentSection()
+  const { currentUserId, commentIds, entityId, replyingAndEditingState } =
+    useCurrentCommentSection()
+  const { replyingToComment, editingComment } = replyingAndEditingState ?? {}
   const ref = useRef<RNTextInput>(null)
 
   const replyingToUserId = Number(replyingToComment?.userId)

--- a/packages/mobile/src/components/comments/CommentOverflowMenu.tsx
+++ b/packages/mobile/src/components/comments/CommentOverflowMenu.tsx
@@ -81,7 +81,7 @@ export const CommentOverflowMenu = (props: CommentOverflowMenuProps) => {
     entityId,
     isEntityOwner,
     currentUserId,
-    setEditingComment,
+    setReplyingAndEditingState,
     currentSort
   } = useCurrentCommentSection()
   const isCommentOwner = Number(userId) === currentUserId
@@ -148,7 +148,8 @@ export const CommentOverflowMenu = (props: CommentOverflowMenuProps) => {
     },
     isCommentOwner && {
       text: messages.menuActions.edit,
-      callback: () => setEditingComment?.(props.comment)
+      callback: () =>
+        setReplyingAndEditingState?.({ editingComment: props.comment })
     },
     (isCommentOwner || isEntityOwner) && {
       text: messages.menuActions.delete,


### PR DESCRIPTION
### Description

* Consolidate replying and editing state into a single state var
* Store `parentCommentId` in this state var, needs to be a separate piece of state from `replyingToComment`
* Update all usages and pass parentCommentId into CommentActionBar so it can be set into `replyingAndEditingState`

### How Has This Been Tested?

Confirmed replying to root comments and replies works as expected
