### PR TITLE
[PAY-3203] Chat permissions write updates for multi-select

### DIFF
--- a/.changeset/shiny-pugs-attend.md
+++ b/.changeset/shiny-pugs-attend.md
@@ -1,0 +1,5 @@
+---
+'@audius/sdk': patch
+---
+
+Chat permissions accepts permit_list

--- a/comms/discovery/rpcz/apply.go
+++ b/comms/discovery/rpcz/apply.go
@@ -281,7 +281,7 @@ func (proc *RPCProcessor) Apply(rpcLog *schema.RpcLog) error {
 			if err != nil {
 				return err
 			}
-			err = chatSetPermissions(tx, userId, params.Permit, params.Allow, messageTs)
+			err = chatSetPermissions(tx, userId, params.Permit, params.PermitList, params.Allow, messageTs)
 			if err != nil {
 				return err
 			}

--- a/comms/discovery/schema/schema.go
+++ b/comms/discovery/schema/schema.go
@@ -118,8 +118,9 @@ type ChatPermitRPC struct {
 }
 
 type ChatPermitRPCParams struct {
-	Allow  *bool          `json:"allow,omitempty"`
-	Permit ChatPermission `json:"permit"`
+	Allow      *bool            `json:"allow,omitempty"`
+	Permit     ChatPermission   `json:"permit"`
+	PermitList []ChatPermission `json:"permit_list"`
 }
 
 type RPCPayloadRequest struct {
@@ -143,6 +144,7 @@ type RPCPayloadRequestParams struct {
 	UserID              *string              `json:"user_id,omitempty"`
 	Allow               *bool                `json:"allow,omitempty"`
 	Permit              *ChatPermission      `json:"permit,omitempty"`
+	PermitList          []ChatPermission     `json:"permit_list,omitempty"`
 }
 
 type TentacledInvite struct {
@@ -290,6 +292,7 @@ type RPCPayloadParams struct {
 	UserID              *string              `json:"user_id,omitempty"`
 	Allow               *bool                `json:"allow,omitempty"`
 	Permit              *ChatPermission      `json:"permit,omitempty"`
+	PermitList          []ChatPermission     `json:"permit_list,omitempty"`
 }
 
 type StickyInvite struct {

--- a/packages/common/src/hooks/chats/index.ts
+++ b/packages/common/src/hooks/chats/index.ts
@@ -1,6 +1,7 @@
 export * from './types'
 export * from './useAudienceUsers'
 export * from './useCanSendMessage'
+export * from './useSetInboxPermissionsLegacy'
 export * from './useSetInboxPermissions'
 export * from './useTrackPlayer'
 export * from './useAudiusLinkResolver'

--- a/packages/common/src/hooks/chats/useSetInboxPermissions.ts
+++ b/packages/common/src/hooks/chats/useSetInboxPermissions.ts
@@ -1,11 +1,10 @@
-import { useCallback, useState } from 'react'
+import { useCallback } from 'react'
 
 import type { AudiusSdk } from '@audius/sdk'
 import { useDispatch, useSelector } from 'react-redux'
 
 import { useAppContext } from '~/context/appContext'
 import { Name } from '~/models/Analytics'
-import { Status } from '~/models/Status'
 import { accountSelectors } from '~/store/account'
 import {
   chatActions,
@@ -22,8 +21,6 @@ type useSetInboxPermissionsProps = {
   audiusSdk: () => Promise<AudiusSdk>
 }
 
-const INBOX_PERMISSIONS_SPINNER_TIMEOUT = 1000
-
 export const useSetInboxPermissions = ({
   audiusSdk
 }: useSetInboxPermissionsProps) => {
@@ -34,10 +31,6 @@ export const useSetInboxPermissions = ({
   } = useAppContext()
   const permissionsStatus = useSelector(getChatPermissionsStatus)
   const userId = useSelector(getUserId)
-  const [savePermissionStatus, setSavePermissionStatus] = useState<Status>(
-    Status.IDLE
-  )
-  const [showSpinner, setShowSpinner] = useState(false)
 
   const doFetchPermissions = useCallback(() => {
     if (userId) {
@@ -48,39 +41,28 @@ export const useSetInboxPermissions = ({
   const savePermissions = useCallback(
     async (permitMap: InboxSettingsFormValues) => {
       let permitList
-      if (savePermissionStatus !== Status.LOADING) {
-        setSavePermissionStatus(Status.LOADING)
-        setShowSpinner(false)
-        // Only show the spinner if saving takes a while
-        setTimeout(
-          () => setShowSpinner(true),
-          INBOX_PERMISSIONS_SPINNER_TIMEOUT
+      try {
+        const sdk = await audiusSdk()
+        permitList = transformMapToPermitList(permitMap)
+        await sdk.chats.permit({ permitList, allow: true })
+        doFetchPermissions()
+        track(
+          make({
+            eventName: Name.CHANGE_INBOX_SETTINGS_SUCCESS,
+            permitList
+          })
         )
-        try {
-          const sdk = await audiusSdk()
-          permitList = transformMapToPermitList(permitMap)
-          await sdk.chats.permit({ permitList, allow: true })
-          doFetchPermissions()
-          setSavePermissionStatus(Status.SUCCESS)
-          track(
-            make({
-              eventName: Name.CHANGE_INBOX_SETTINGS_SUCCESS,
-              permitList
-            })
-          )
-        } catch (e) {
-          console.error('Error saving chat permissions:', e)
-          setSavePermissionStatus(Status.ERROR)
-          track(
-            make({
-              eventName: Name.CHANGE_INBOX_SETTINGS_FAILURE,
-              permitList
-            })
-          )
-        }
+      } catch (e) {
+        console.error('Error saving chat permissions:', e)
+        track(
+          make({
+            eventName: Name.CHANGE_INBOX_SETTINGS_FAILURE,
+            permitList
+          })
+        )
       }
     },
-    [savePermissionStatus, audiusSdk, track, make, doFetchPermissions]
+    [audiusSdk, track, make, doFetchPermissions]
   )
 
   return {
@@ -99,16 +81,6 @@ export const useSetInboxPermissions = ({
     /**
      * Saves the current user's permissions to the backend.
      */
-    savePermissions,
-    /**
-     * The status of the save permissions operation.
-     */
-    savePermissionStatus,
-    /**
-     * Whether or not to show the spinner. Timer sets to
-     * true 1s after saving permissions, use in conjunction
-     * with savePermissionStatus.
-     */
-    showSpinner
+    savePermissions
   }
 }

--- a/packages/common/src/hooks/chats/useSetInboxPermissions.ts
+++ b/packages/common/src/hooks/chats/useSetInboxPermissions.ts
@@ -1,17 +1,21 @@
-import { useCallback, useEffect, useState } from 'react'
+import { useCallback, useState } from 'react'
 
 import type { AudiusSdk } from '@audius/sdk'
-import { ChatPermission } from '@audius/sdk'
 import { useDispatch, useSelector } from 'react-redux'
 
 import { useAppContext } from '~/context/appContext'
 import { Name } from '~/models/Analytics'
 import { Status } from '~/models/Status'
 import { accountSelectors } from '~/store/account'
-import { chatActions, chatSelectors } from '~/store/pages'
+import {
+  chatActions,
+  chatSelectors,
+  InboxSettingsFormValues
+} from '~/store/pages'
+import { transformMapToPermitList } from '~/utils/chatUtils'
 
 const { fetchPermissions } = chatActions
-const { getUserChatPermissions } = chatSelectors
+const { getChatPermissionsStatus, getUserChatPermissions } = chatSelectors
 const { getUserId } = accountSelectors
 
 type useSetInboxPermissionsProps = {
@@ -24,23 +28,16 @@ export const useSetInboxPermissions = ({
   audiusSdk
 }: useSetInboxPermissionsProps) => {
   const dispatch = useDispatch()
+  const permissions = useSelector(getUserChatPermissions)
   const {
     analytics: { track, make }
   } = useAppContext()
-  const permissions = useSelector(getUserChatPermissions)
+  const permissionsStatus = useSelector(getChatPermissionsStatus)
   const userId = useSelector(getUserId)
-  const currentPermission = permissions?.permits
-  const [permissionStatus, setPermissionStatus] = useState<Status>(Status.IDLE)
-  const [showSpinner, setShowSpinner] = useState(false)
-  const [localPermission, setLocalPermission] = useState<ChatPermission>(
-    currentPermission ?? ChatPermission.ALL
+  const [savePermissionStatus, setSavePermissionStatus] = useState<Status>(
+    Status.IDLE
   )
-
-  // Update local permission state when permissions change in store.
-  // Needed for when user closes/reopens settings before backend has updated.
-  useEffect(() => {
-    setLocalPermission(currentPermission ?? ChatPermission.ALL)
-  }, [currentPermission])
+  const [showSpinner, setShowSpinner] = useState(false)
 
   const doFetchPermissions = useCallback(() => {
     if (userId) {
@@ -48,10 +45,11 @@ export const useSetInboxPermissions = ({
     }
   }, [dispatch, userId])
 
-  const _savePermissions = useCallback(
-    async (permission: ChatPermission) => {
-      if (permissionStatus !== Status.LOADING) {
-        setPermissionStatus(Status.LOADING)
+  const savePermissions = useCallback(
+    async (permitMap: InboxSettingsFormValues) => {
+      let permitList
+      if (savePermissionStatus !== Status.LOADING) {
+        setSavePermissionStatus(Status.LOADING)
         setShowSpinner(false)
         // Only show the spinner if saving takes a while
         setTimeout(
@@ -60,55 +58,40 @@ export const useSetInboxPermissions = ({
         )
         try {
           const sdk = await audiusSdk()
-          await sdk.chats.permit({ permit: permission })
-          setPermissionStatus(Status.SUCCESS)
+          permitList = transformMapToPermitList(permitMap)
+          await sdk.chats.permit({ permitList, allow: true })
+          doFetchPermissions()
+          setSavePermissionStatus(Status.SUCCESS)
           track(
             make({
               eventName: Name.CHANGE_INBOX_SETTINGS_SUCCESS,
-              permission
+              permitList
             })
           )
         } catch (e) {
           console.error('Error saving chat permissions:', e)
-          setPermissionStatus(Status.ERROR)
+          setSavePermissionStatus(Status.ERROR)
           track(
             make({
               eventName: Name.CHANGE_INBOX_SETTINGS_FAILURE,
-              permission
+              permitList
             })
           )
         }
       }
     },
-    [audiusSdk, track, make, permissionStatus]
-  )
-
-  // Save local permission state to backend. Useful in scenarios where we
-  // want to save permissions on a button press, eg. desktop settings.
-  const savePermissions = useCallback(async () => {
-    await _savePermissions(localPermission)
-  }, [_savePermissions, localPermission])
-
-  // Set local permission state and save to backend. Useful in
-  // scenarios where we want to set and save all at once, eg. mobile
-  // settings screen with radio button options that fire when pressed.
-  const setAndSavePermissions = useCallback(
-    async (permission: ChatPermission) => {
-      setLocalPermission(permission)
-      await _savePermissions(permission)
-    },
-    [_savePermissions]
+    [savePermissionStatus, audiusSdk, track, make, doFetchPermissions]
   )
 
   return {
     /**
-     * The permission state that is set locally.
+     * The current user's permissions.
      */
-    localPermission,
+    permissions,
     /**
-     * Setter for local permission state.
+     * The current permissions status.
      */
-    setLocalPermission,
+    permissionsStatus,
     /**
      * Fetches the current user's permissions from the backend.
      */
@@ -118,17 +101,13 @@ export const useSetInboxPermissions = ({
      */
     savePermissions,
     /**
-     * Sets local permissions and saves it to the backend.
+     * The status of the save permissions operation.
      */
-    setAndSavePermissions,
-    /**
-     * The current save permission status.
-     */
-    permissionStatus,
+    savePermissionStatus,
     /**
      * Whether or not to show the spinner. Timer sets to
      * true 1s after saving permissions, use in conjunction
-     * with permissionsStatus.
+     * with savePermissionStatus.
      */
     showSpinner
   }

--- a/packages/common/src/hooks/chats/useSetInboxPermissionsLegacy.ts
+++ b/packages/common/src/hooks/chats/useSetInboxPermissionsLegacy.ts
@@ -1,0 +1,135 @@
+import { useCallback, useEffect, useState } from 'react'
+
+import type { AudiusSdk } from '@audius/sdk'
+import { ChatPermission } from '@audius/sdk'
+import { useDispatch, useSelector } from 'react-redux'
+
+import { useAppContext } from '~/context/appContext'
+import { Name } from '~/models/Analytics'
+import { Status } from '~/models/Status'
+import { accountSelectors } from '~/store/account'
+import { chatActions, chatSelectors } from '~/store/pages'
+
+const { fetchPermissions } = chatActions
+const { getUserChatPermissions } = chatSelectors
+const { getUserId } = accountSelectors
+
+type useSetInboxPermissionsProps = {
+  audiusSdk: () => Promise<AudiusSdk>
+}
+
+const INBOX_PERMISSIONS_SPINNER_TIMEOUT = 1000
+
+export const useSetInboxPermissionsLegacy = ({
+  audiusSdk
+}: useSetInboxPermissionsProps) => {
+  const dispatch = useDispatch()
+  const {
+    analytics: { track, make }
+  } = useAppContext()
+  const permissions = useSelector(getUserChatPermissions)
+  const userId = useSelector(getUserId)
+  const currentPermission = permissions?.permits
+  const [permissionStatus, setPermissionStatus] = useState<Status>(Status.IDLE)
+  const [showSpinner, setShowSpinner] = useState(false)
+  const [localPermission, setLocalPermission] = useState<ChatPermission>(
+    currentPermission ?? ChatPermission.ALL
+  )
+
+  // Update local permission state when permissions change in store.
+  // Needed for when user closes/reopens settings before backend has updated.
+  useEffect(() => {
+    setLocalPermission(currentPermission ?? ChatPermission.ALL)
+  }, [currentPermission])
+
+  const doFetchPermissions = useCallback(() => {
+    if (userId) {
+      dispatch(fetchPermissions({ userIds: [userId] }))
+    }
+  }, [dispatch, userId])
+
+  const _savePermissions = useCallback(
+    async (permission: ChatPermission) => {
+      if (permissionStatus !== Status.LOADING) {
+        setPermissionStatus(Status.LOADING)
+        setShowSpinner(false)
+        // Only show the spinner if saving takes a while
+        setTimeout(
+          () => setShowSpinner(true),
+          INBOX_PERMISSIONS_SPINNER_TIMEOUT
+        )
+        try {
+          const sdk = await audiusSdk()
+          await sdk.chats.permit({ permit: permission })
+          setPermissionStatus(Status.SUCCESS)
+          track(
+            make({
+              eventName: Name.CHANGE_INBOX_SETTINGS_SUCCESS,
+              permission
+            })
+          )
+        } catch (e) {
+          console.error('Error saving chat permissions:', e)
+          setPermissionStatus(Status.ERROR)
+          track(
+            make({
+              eventName: Name.CHANGE_INBOX_SETTINGS_FAILURE,
+              permission
+            })
+          )
+        }
+      }
+    },
+    [audiusSdk, track, make, permissionStatus]
+  )
+
+  // Save local permission state to backend. Useful in scenarios where we
+  // want to save permissions on a button press, eg. desktop settings.
+  const savePermissions = useCallback(async () => {
+    await _savePermissions(localPermission)
+  }, [_savePermissions, localPermission])
+
+  // Set local permission state and save to backend. Useful in
+  // scenarios where we want to set and save all at once, eg. mobile
+  // settings screen with radio button options that fire when pressed.
+  const setAndSavePermissions = useCallback(
+    async (permission: ChatPermission) => {
+      setLocalPermission(permission)
+      await _savePermissions(permission)
+    },
+    [_savePermissions]
+  )
+
+  return {
+    /**
+     * The permission state that is set locally.
+     */
+    localPermission,
+    /**
+     * Setter for local permission state.
+     */
+    setLocalPermission,
+    /**
+     * Fetches the current user's permissions from the backend.
+     */
+    doFetchPermissions,
+    /**
+     * Saves the current user's permissions to the backend.
+     */
+    savePermissions,
+    /**
+     * Sets local permissions and saves it to the backend.
+     */
+    setAndSavePermissions,
+    /**
+     * The current save permission status.
+     */
+    permissionStatus,
+    /**
+     * Whether or not to show the spinner. Timer sets to
+     * true 1s after saving permissions, use in conjunction
+     * with permissionsStatus.
+     */
+    showSpinner
+  }
+}

--- a/packages/common/src/models/Analytics.ts
+++ b/packages/common/src/models/Analytics.ts
@@ -2330,12 +2330,14 @@ type BlockUserFailure = {
 
 type ChangeInboxSettingsSuccess = {
   eventName: Name.CHANGE_INBOX_SETTINGS_SUCCESS
-  permission: ChatPermission
+  permission?: ChatPermission
+  permitList?: ChatPermission[]
 }
 
 type ChangeInboxSettingsFailure = {
   eventName: Name.CHANGE_INBOX_SETTINGS_FAILURE
-  permission: ChatPermission
+  permission?: ChatPermission
+  permitList?: ChatPermission[]
 }
 
 type SendMessageReactionSuccess = {

--- a/packages/common/src/store/pages/chat/selectors.ts
+++ b/packages/common/src/store/pages/chat/selectors.ts
@@ -47,7 +47,11 @@ export const getBlockees = (state: CommonState) => state.pages.chat.blockees
 
 export const getBlockers = (state: CommonState) => state.pages.chat.blockers
 
-const getChatPermissions = (state: CommonState) => state.pages.chat.permissions
+export const getChatPermissions = (state: CommonState) =>
+  state.pages.chat.permissions
+
+export const getChatPermissionsStatus = (state: CommonState) =>
+  state.pages.chat.permissionsStatus
 
 // Gets a chat and its optimistic read status
 export const getChat = createSelector(

--- a/packages/common/src/store/pages/chat/slice.ts
+++ b/packages/common/src/store/pages/chat/slice.ts
@@ -57,6 +57,7 @@ type ChatState = {
   blockees: ID[]
   blockers: ID[]
   permissions: Record<ID, ValidatedChatPermissions>
+  permissionsStatus: Status
   reactionsPopupMessageId: string | null
 }
 
@@ -140,6 +141,7 @@ const initialState: ChatState = {
   blockees: [],
   blockers: [],
   permissions: {},
+  permissionsStatus: Status.IDLE,
   reactionsPopupMessageId: null
 }
 
@@ -615,7 +617,8 @@ const slice = createSlice({
     unblockUser: (_state, _action: PayloadAction<{ userId: ID }>) => {
       // triggers saga
     },
-    fetchPermissions: (_state, _action: PayloadAction<{ userIds: ID[] }>) => {
+    fetchPermissions: (state, _action: PayloadAction<{ userIds: ID[] }>) => {
+      state.permissionsStatus = Status.LOADING
       // triggers saga
     },
     fetchPermissionsSucceeded: (
@@ -628,6 +631,7 @@ const slice = createSlice({
         ...state.permissions,
         ...action.payload.permissions
       }
+      state.permissionsStatus = Status.SUCCESS
     },
     // Note: is not associated with any chatId because there will be at most
     // one popup message at a time. Used for reactions popup overlay in mobile.

--- a/packages/common/src/store/pages/chat/types.ts
+++ b/packages/common/src/store/pages/chat/types.ts
@@ -1,3 +1,5 @@
+import { ChatPermission } from '@audius/sdk'
+
 /** Action current user can take to be able to message another user */
 export enum ChatPermissionAction {
   /** Permissions haven't loaded yet */
@@ -26,4 +28,13 @@ export class ChatWebsocketError extends Error {
   constructor(public code: string = 'UNKNOWN', public url?: string) {
     super(`Chat Websocket Error, code: ${code}`)
   }
+}
+
+export type InboxSettingsFormValues = {
+  [ChatPermission.ALL]: boolean
+  [ChatPermission.FOLLOWEES]: boolean
+  [ChatPermission.TIPPERS]: boolean
+  [ChatPermission.TIPPEES]: boolean
+  [ChatPermission.FOLLOWERS]: boolean
+  [ChatPermission.VERIFIED]: boolean
 }

--- a/packages/common/src/utils/chatUtils.ts
+++ b/packages/common/src/utils/chatUtils.ts
@@ -3,10 +3,12 @@ import {
   ChatMessage,
   Track,
   Playlist,
-  User
+  User,
+  ChatPermission
 } from '@audius/sdk'
 
 import { Status } from '~/models/Status'
+import { InboxSettingsFormValues } from '~/store'
 
 import { MESSAGE_GROUP_THRESHOLD_MINUTES } from './constants'
 import dayjs from './dayjs'
@@ -252,4 +254,52 @@ export const getChatBlastCTA = ({
         messages.blastCTABase + messages.blastCTARemixers(audienceContentId)
       )
   }
+}
+
+export const defaultChatPermitMap: InboxSettingsFormValues = {
+  [ChatPermission.ALL]: false,
+  [ChatPermission.FOLLOWERS]: false,
+  [ChatPermission.FOLLOWEES]: false,
+  [ChatPermission.TIPPERS]: false,
+  [ChatPermission.TIPPEES]: false,
+  [ChatPermission.VERIFIED]: false
+}
+
+export const transformPermitListToMap = (
+  permitList: ChatPermission[]
+): InboxSettingsFormValues => {
+  if (permitList.includes(ChatPermission.ALL)) {
+    return Object.keys(defaultChatPermitMap).reduce((acc, key) => {
+      acc[key as keyof InboxSettingsFormValues] = true
+      return acc
+    }, {} as InboxSettingsFormValues)
+  }
+
+  if (permitList.includes(ChatPermission.NONE)) {
+    return { ...defaultChatPermitMap }
+  }
+
+  return permitList.reduce(
+    (acc, permit) => {
+      if (permit in acc) {
+        acc[permit as keyof InboxSettingsFormValues] = true
+      }
+      return acc
+    },
+    { ...defaultChatPermitMap }
+  )
+}
+
+export const transformMapToPermitList = (
+  permitMap: InboxSettingsFormValues
+): ChatPermission[] => {
+  if (permitMap[ChatPermission.ALL]) {
+    return [ChatPermission.ALL]
+  }
+  if (Object.values(permitMap).every((value) => !value)) {
+    return [ChatPermission.NONE]
+  }
+  return Object.keys(permitMap).filter(
+    (key) => permitMap[key as keyof InboxSettingsFormValues]
+  ) as ChatPermission[]
 }

--- a/packages/common/src/utils/chatUtils.ts
+++ b/packages/common/src/utils/chatUtils.ts
@@ -6,6 +6,7 @@ import {
   User,
   ChatPermission
 } from '@audius/sdk'
+import { mapValues } from 'lodash'
 
 import { Status } from '~/models/Status'
 import { InboxSettingsFormValues } from '~/store'
@@ -269,10 +270,7 @@ export const transformPermitListToMap = (
   permitList: ChatPermission[]
 ): InboxSettingsFormValues => {
   if (permitList.includes(ChatPermission.ALL)) {
-    return Object.keys(defaultChatPermitMap).reduce((acc, key) => {
-      acc[key as keyof InboxSettingsFormValues] = true
-      return acc
-    }, {} as InboxSettingsFormValues)
+    return mapValues(defaultChatPermitMap, () => true)
   }
 
   if (permitList.includes(ChatPermission.NONE)) {
@@ -281,9 +279,7 @@ export const transformPermitListToMap = (
 
   return permitList.reduce(
     (acc, permit) => {
-      if (permit in acc) {
-        acc[permit as keyof InboxSettingsFormValues] = true
-      }
+      acc[permit as keyof InboxSettingsFormValues] = true
       return acc
     },
     { ...defaultChatPermitMap }

--- a/packages/libs/src/sdk/api/chats/ChatsApi.ts
+++ b/packages/libs/src/sdk/api/chats/ChatsApi.ts
@@ -66,7 +66,8 @@ import {
   type ValidatedChatPermissions,
   type ChatCreateRPC,
   type UpgradableChatBlast,
-  ChatBlastAudience
+  ChatBlastAudience,
+  ChatPermission
 } from './serverTypes'
 
 const GENERIC_MESSAGE_ERROR = 'Error: this message cannot be displayed'
@@ -659,7 +660,7 @@ export class ChatsApi
    * @returns the rpc object
    */
   public async permit(params: ChatPermitRequest) {
-    const { currentUserId, permit } = await parseParams(
+    const { currentUserId, permit, permitList, allow } = await parseParams(
       'permit',
       ChatPermitRequestSchema
     )(params)
@@ -667,7 +668,9 @@ export class ChatsApi
       current_user_id: currentUserId,
       method: 'chat.permit',
       params: {
-        permit
+        permit: permit ?? ChatPermission.ALL,
+        permit_list: permitList ?? [ChatPermission.ALL],
+        allow
       }
     })
   }

--- a/packages/libs/src/sdk/api/chats/clientTypes.ts
+++ b/packages/libs/src/sdk/api/chats/clientTypes.ts
@@ -130,7 +130,9 @@ export type ChatDeleteRequest = z.infer<typeof ChatDeleteRequestSchema>
 
 export const ChatPermitRequestSchema = z.object({
   currentUserId: z.optional(z.string()),
-  permit: z.nativeEnum(ChatPermission)
+  permit: z.optional(z.nativeEnum(ChatPermission)),
+  permitList: z.optional(z.array(z.nativeEnum(ChatPermission)).min(1)),
+  allow: z.optional(z.boolean())
 })
 
 export type ChatPermitRequest = z.infer<typeof ChatPermitRequestSchema>

--- a/packages/libs/src/sdk/api/chats/serverTypes.ts
+++ b/packages/libs/src/sdk/api/chats/serverTypes.ts
@@ -92,6 +92,7 @@ export type ChatPermitRPC = {
   method: 'chat.permit'
   params: {
     permit: ChatPermission
+    permit_list: ChatPermission[]
     allow?: boolean
   }
 }

--- a/packages/mobile/src/screens/settings-screen/InboxSettingsFields.tsx
+++ b/packages/mobile/src/screens/settings-screen/InboxSettingsFields.tsx
@@ -38,7 +38,7 @@ const options = [
 
 export const InboxSettingsFields = () => {
   const [allowAllField, , allowAllHelpers] = useField({
-    name: 'allowAll',
+    name: 'all',
     type: 'checkbox'
   })
 
@@ -71,7 +71,7 @@ export const InboxSettingsFields = () => {
 
 function SwitchField(props: { title: string; value: ChatPermission }) {
   const { title, value } = props
-  const [allowAllField] = useField({ name: 'allowAll', type: 'checkbox' })
+  const [allowAllField] = useField({ name: 'all', type: 'checkbox' })
 
   const [field, , helpers] = useField({
     name: value,
@@ -82,7 +82,7 @@ function SwitchField(props: { title: string; value: ChatPermission }) {
     <Flex row gap='l' key={title}>
       <Switch
         id={title}
-        value={field.checked}
+        value={field.checked || allowAllField.checked}
         disabled={allowAllField.checked}
         onValueChange={helpers.setValue}
       />

--- a/packages/mobile/src/screens/settings-screen/InboxSettingsScreenLegacy.tsx
+++ b/packages/mobile/src/screens/settings-screen/InboxSettingsScreenLegacy.tsx
@@ -1,6 +1,6 @@
 import { useEffect } from 'react'
 
-import { useSetInboxPermissions } from '@audius/common/hooks'
+import { useSetInboxPermissionsLegacy } from '@audius/common/hooks'
 import { ChatPermission } from '@audius/sdk'
 import { TouchableOpacity, View } from 'react-native'
 import { ScrollView } from 'react-native-gesture-handler'
@@ -99,7 +99,7 @@ const options = [
 export const InboxSettingsScreenLegacy = () => {
   const styles = useStyles()
   const { setAndSavePermissions, localPermission, doFetchPermissions } =
-    useSetInboxPermissions({
+    useSetInboxPermissionsLegacy({
       audiusSdk
     })
 

--- a/packages/mobile/src/screens/settings-screen/InboxSettingsScreenNew.tsx
+++ b/packages/mobile/src/screens/settings-screen/InboxSettingsScreenNew.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo } from 'react'
+import { useEffect, useMemo } from 'react'
 
 import { useSetInboxPermissions } from '@audius/common/hooks'
 import type { InboxSettingsFormValues } from '@audius/common/store'

--- a/packages/mobile/src/screens/settings-screen/InboxSettingsScreenNew.tsx
+++ b/packages/mobile/src/screens/settings-screen/InboxSettingsScreenNew.tsx
@@ -1,6 +1,8 @@
-import { useCallback, useEffect } from 'react'
+import { useCallback, useEffect, useMemo } from 'react'
 
 import { useSetInboxPermissions } from '@audius/common/hooks'
+import type { InboxSettingsFormValues } from '@audius/common/store'
+import { transformPermitListToMap } from '@audius/common/utils'
 import { ChatPermission } from '@audius/sdk'
 import { Formik } from 'formik'
 
@@ -17,53 +19,39 @@ const messages = {
   save: 'Save Changes'
 }
 
-type InboxSettingsFormValues = {
-  allowAll: boolean
-  [ChatPermission.FOLLOWEES]: boolean
-  [ChatPermission.TIPPERS]: boolean
-  [ChatPermission.TIPPEES]: boolean
-  [ChatPermission.FOLLOWERS]: boolean
-  [ChatPermission.VERIFIED]: boolean
-}
-
 export const InboxSettingsScreenNew = () => {
-  const { localPermission, doFetchPermissions } = useSetInboxPermissions({
+  const {
+    permissions,
+    doFetchPermissions,
+    permissionsStatus,
+    savePermissionStatus,
+    showSpinner,
+    savePermissions
+  } = useSetInboxPermissions({
     audiusSdk
   })
 
-  const allowAll = localPermission === ChatPermission.ALL
-  const initialValues = {
-    allowAll,
-    [ChatPermission.FOLLOWEES]:
-      allowAll || localPermission === ChatPermission.FOLLOWEES,
-    [ChatPermission.TIPPERS]:
-      allowAll || localPermission === ChatPermission.TIPPERS,
-    [ChatPermission.TIPPEES]:
-      allowAll || localPermission === ChatPermission.TIPPEES,
-    [ChatPermission.FOLLOWERS]:
-      allowAll || localPermission === ChatPermission.FOLLOWERS,
-    [ChatPermission.VERIFIED]:
-      allowAll || localPermission === ChatPermission.VERIFIED
-  }
+  const initialValues = useMemo(() => {
+    return transformPermitListToMap(
+      permissions?.permit_list ?? [ChatPermission.ALL]
+    )
+  }, [permissions])
 
   useEffect(() => {
     doFetchPermissions()
   }, [doFetchPermissions])
 
-  const handleSubmit = useCallback((values: typeof initialValues) => {
-    if (values.allowAll) {
-      // submit all permissions
-      alert(JSON.stringify({ allowAll: true }, null, 2))
-    } else {
-      // submit only the sub permissions that are checked
-      alert(JSON.stringify(values, null, 2))
-    }
-  }, [])
+  const handleSave = useCallback(
+    (values) => {
+      savePermissions(values)
+    },
+    [savePermissions]
+  )
 
   return (
     <Formik<InboxSettingsFormValues>
       initialValues={initialValues}
-      onSubmit={handleSubmit}
+      onSubmit={handleSave}
     >
       {({ submitForm, isSubmitting }) => (
         <FormScreen

--- a/packages/mobile/src/screens/settings-screen/InboxSettingsScreenNew.tsx
+++ b/packages/mobile/src/screens/settings-screen/InboxSettingsScreenNew.tsx
@@ -20,16 +20,10 @@ const messages = {
 }
 
 export const InboxSettingsScreenNew = () => {
-  const {
-    permissions,
-    doFetchPermissions,
-    permissionsStatus,
-    savePermissionStatus,
-    showSpinner,
-    savePermissions
-  } = useSetInboxPermissions({
-    audiusSdk
-  })
+  const { permissions, doFetchPermissions, savePermissions } =
+    useSetInboxPermissions({
+      audiusSdk
+    })
 
   const initialValues = useMemo(() => {
     return transformPermitListToMap(

--- a/packages/mobile/src/screens/settings-screen/InboxSettingsScreenNew.tsx
+++ b/packages/mobile/src/screens/settings-screen/InboxSettingsScreenNew.tsx
@@ -35,17 +35,10 @@ export const InboxSettingsScreenNew = () => {
     doFetchPermissions()
   }, [doFetchPermissions])
 
-  const handleSave = useCallback(
-    (values) => {
-      savePermissions(values)
-    },
-    [savePermissions]
-  )
-
   return (
     <Formik<InboxSettingsFormValues>
       initialValues={initialValues}
-      onSubmit={handleSave}
+      onSubmit={savePermissions}
     >
       {({ submitForm, isSubmitting }) => (
         <FormScreen

--- a/packages/web/src/components/inbox-settings-modal/InboxSettingsModalLegacy.tsx
+++ b/packages/web/src/components/inbox-settings-modal/InboxSettingsModalLegacy.tsx
@@ -1,6 +1,6 @@
 import { ChangeEvent, useCallback, useEffect } from 'react'
 
-import { useSetInboxPermissions } from '@audius/common/hooks'
+import { useSetInboxPermissionsLegacy } from '@audius/common/hooks'
 import { Status } from '@audius/common/models'
 import {
   Modal,
@@ -73,7 +73,7 @@ export const InboxSettingsModalLegacy = () => {
     doFetchPermissions,
     permissionStatus,
     showSpinner
-  } = useSetInboxPermissions({
+  } = useSetInboxPermissionsLegacy({
     audiusSdk
   })
 

--- a/packages/web/src/components/inbox-settings-modal/InboxSettingsModalNew.tsx
+++ b/packages/web/src/components/inbox-settings-modal/InboxSettingsModalNew.tsx
@@ -60,6 +60,21 @@ const options = [
   }
 ]
 
+const Spinner = () => (
+  <Flex
+    justifyContent='center'
+    alignItems='center'
+    m='xl'
+    p='4xl'
+    h='unit10'
+    css={{
+      opacity: 0.5
+    }}
+  >
+    <LoadingSpinner />
+  </Flex>
+)
+
 export const InboxSettingsModalNew = () => {
   const [isVisible, setIsVisible] = useModalState('InboxSettings')
   const handleClose = useCallback(() => setIsVisible(false), [setIsVisible])
@@ -68,8 +83,6 @@ export const InboxSettingsModalNew = () => {
     permissions,
     doFetchPermissions,
     permissionsStatus,
-    savePermissionStatus,
-    showSpinner,
     savePermissions
   } = useSetInboxPermissions({
     audiusSdk
@@ -101,24 +114,13 @@ export const InboxSettingsModalNew = () => {
         <ModalTitle title={messages.title} icon={<IconMessage />} />
       </ModalHeader>
       {statusIsNotFinalized(permissionsStatus) ? (
-        <Flex
-          justifyContent='center'
-          alignItems='center'
-          m='xl'
-          p='4xl'
-          h='unit10'
-          css={{
-            opacity: 0.5
-          }}
-        >
-          <LoadingSpinner />
-        </Flex>
+        <Spinner />
       ) : (
         <Formik<InboxSettingsFormValues>
           initialValues={initialValues}
           onSubmit={handleSave}
         >
-          {({ submitForm }) => (
+          {({ submitForm, isSubmitting }) => (
             <>
               <ModalContent>
                 <InboxSettingsModalFields
@@ -132,9 +134,8 @@ export const InboxSettingsModalNew = () => {
                   </Button>
                   <Button
                     variant='primary'
-                    isLoading={
-                      savePermissionStatus === Status.LOADING && showSpinner
-                    }
+                    isLoading={isSubmitting}
+                    disabled={isSubmitting}
                     type='submit'
                     onClick={submitForm}
                     fullWidth

--- a/packages/web/src/components/inbox-settings-modal/InboxSettingsModalNew.tsx
+++ b/packages/web/src/components/inbox-settings-modal/InboxSettingsModalNew.tsx
@@ -1,7 +1,9 @@
-import { useCallback, useEffect } from 'react'
+import { useCallback, useEffect, useMemo } from 'react'
 
 import { useSetInboxPermissions } from '@audius/common/hooks'
-import { Status } from '@audius/common/models'
+import { Status, statusIsNotFinalized } from '@audius/common/models'
+import { transformPermitListToMap } from '@audius/common/utils'
+import type { InboxSettingsFormValues } from '@audius/common/utils'
 import {
   Modal,
   ModalContent,
@@ -13,7 +15,8 @@ import {
   Text,
   Flex,
   Checkbox,
-  Switch
+  Switch,
+  LoadingSpinner
 } from '@audius/harmony'
 import { ChatPermission } from '@audius/sdk'
 import { Formik, useField } from 'formik'
@@ -57,40 +60,27 @@ const options = [
   }
 ]
 
-type InboxSettingsFormValues = {
-  allowAll: boolean
-  [ChatPermission.FOLLOWEES]: boolean
-  [ChatPermission.TIPPERS]: boolean
-  [ChatPermission.TIPPEES]: boolean
-  [ChatPermission.FOLLOWERS]: boolean
-  [ChatPermission.VERIFIED]: boolean
-}
-
 export const InboxSettingsModalNew = () => {
   const [isVisible, setIsVisible] = useModalState('InboxSettings')
   const handleClose = useCallback(() => setIsVisible(false), [setIsVisible])
 
   const {
-    localPermission,
+    permissions,
     doFetchPermissions,
-    permissionStatus,
-    showSpinner
-    // setAndSavePermissions
+    permissionsStatus,
+    savePermissionStatus,
+    showSpinner,
+    savePermissions
   } = useSetInboxPermissions({
     audiusSdk
   })
 
   const handleSave = useCallback(
     (values: InboxSettingsFormValues) => {
-      window.alert(JSON.stringify(values, null, 2))
-      if (values.allowAll) {
-        // setAndSavePermissions({ permit: ChatPermission.ALL })
-      }
-      // TODO: setAndSavePermissions doesn't accept multiple permissions yet
-      // setAndSavePermissions({})
+      savePermissions(values)
       handleClose()
     },
-    [handleClose]
+    [handleClose, savePermissions]
   )
 
   // Fetch the latest permissions for the current user when the modal is made visible
@@ -99,62 +89,81 @@ export const InboxSettingsModalNew = () => {
     doFetchPermissions()
   }, [doFetchPermissions])
 
-  const allowAll = localPermission === ChatPermission.ALL
-  const initialValues = {
-    allowAll,
-    [ChatPermission.FOLLOWEES]:
-      allowAll || localPermission === ChatPermission.FOLLOWEES,
-    [ChatPermission.TIPPERS]:
-      allowAll || localPermission === ChatPermission.TIPPERS,
-    [ChatPermission.TIPPEES]:
-      allowAll || localPermission === ChatPermission.TIPPEES,
-    [ChatPermission.FOLLOWERS]:
-      allowAll || localPermission === ChatPermission.FOLLOWERS,
-    [ChatPermission.VERIFIED]:
-      allowAll || localPermission === ChatPermission.VERIFIED
-  }
+  const initialValues = useMemo(() => {
+    return transformPermitListToMap(
+      permissions?.permit_list ?? [ChatPermission.ALL]
+    )
+  }, [permissions])
 
   return (
-    <Formik<InboxSettingsFormValues>
-      initialValues={initialValues}
-      onSubmit={handleSave}
-    >
-      {({ submitForm }) => (
-        <Modal onClose={handleClose} isOpen={isVisible} size='medium'>
-          <ModalHeader onClose={handleClose}>
-            <ModalTitle title={messages.title} icon={<IconMessage />} />
-          </ModalHeader>
-          <ModalContent>
-            <InboxSettingsModalFields />
-          </ModalContent>
-          <ModalFooter>
-            <Flex gap='xl' flex={1}>
-              <Button variant='secondary' fullWidth>
-                {messages.cancel}
-              </Button>
-              <Button
-                variant='primary'
-                isLoading={permissionStatus === Status.LOADING && showSpinner}
-                type='submit'
-                onClick={submitForm}
-                fullWidth
-              >
-                {messages.save}
-              </Button>
-            </Flex>
-          </ModalFooter>
-        </Modal>
+    <Modal onClose={handleClose} isOpen={isVisible} size='medium'>
+      <ModalHeader onClose={handleClose}>
+        <ModalTitle title={messages.title} icon={<IconMessage />} />
+      </ModalHeader>
+      {statusIsNotFinalized(permissionsStatus) ? (
+        <LoadingSpinner />
+      ) : (
+        <Formik<InboxSettingsFormValues>
+          initialValues={initialValues}
+          onSubmit={handleSave}
+        >
+          {({ submitForm }) => (
+            <>
+              <ModalContent>
+                <InboxSettingsModalFields
+                  permissionsStatus={permissionsStatus}
+                />
+              </ModalContent>
+              <ModalFooter>
+                <Flex gap='xl' flex={1}>
+                  <Button variant='secondary' fullWidth onClick={handleClose}>
+                    {messages.cancel}
+                  </Button>
+                  <Button
+                    variant='primary'
+                    isLoading={
+                      savePermissionStatus === Status.LOADING && showSpinner
+                    }
+                    type='submit'
+                    onClick={submitForm}
+                    fullWidth
+                  >
+                    {messages.save}
+                  </Button>
+                </Flex>
+              </ModalFooter>
+            </>
+          )}
+        </Formik>
       )}
-    </Formik>
+    </Modal>
   )
 }
 
-const InboxSettingsModalFields = () => {
-  const [allowAllField] = useField({ name: 'allowAll', type: 'checkbox' })
-  return (
+const InboxSettingsModalFields = ({
+  permissionsStatus
+}: {
+  permissionsStatus: Status
+}) => {
+  const [allowAllField, , { setValue: setAllowAll }] = useField({
+    name: 'all',
+    type: 'checkbox'
+  })
+
+  const handleAllChange = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      const isChecked = e.target.checked
+      setAllowAll(isChecked)
+    },
+    [setAllowAll]
+  )
+
+  return statusIsNotFinalized(permissionsStatus) ? (
+    <LoadingSpinner />
+  ) : (
     <Flex column gap='xl'>
       <Flex row gap='l'>
-        <Switch {...allowAllField} />
+        <Switch {...allowAllField} onChange={handleAllChange} />
         <Text variant='title' size='l'>
           {messages.allTitle}
         </Text>
@@ -177,20 +186,29 @@ const InboxSettingsModalFields = () => {
 
 function CheckboxField(props: { title: string; value: ChatPermission }) {
   const { title, value } = props
-  const [allowAllField] = useField({ name: 'allowAll', type: 'checkbox' })
+  const [allowAllField] = useField({ name: 'all', type: 'checkbox' })
 
-  const [field] = useField({
+  const [field, , { setValue }] = useField({
     name: value,
     type: 'checkbox'
   })
+
+  const handleChange = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      const isChecked = e.target.checked
+      setValue(isChecked)
+    },
+    [setValue]
+  )
 
   return (
     <Flex row gap='l' key={title}>
       <Checkbox
         {...field}
         id={title}
-        checked={field.checked}
+        checked={field.checked || allowAllField.checked}
         disabled={allowAllField.checked}
+        onChange={handleChange}
       />
       <Text tag='label' htmlFor={title} variant='title' strength='weak'>
         {title}

--- a/packages/web/src/components/inbox-settings-modal/InboxSettingsModalNew.tsx
+++ b/packages/web/src/components/inbox-settings-modal/InboxSettingsModalNew.tsx
@@ -2,8 +2,8 @@ import { useCallback, useEffect, useMemo } from 'react'
 
 import { useSetInboxPermissions } from '@audius/common/hooks'
 import { Status, statusIsNotFinalized } from '@audius/common/models'
+import { InboxSettingsFormValues } from '@audius/common/store'
 import { transformPermitListToMap } from '@audius/common/utils'
-import type { InboxSettingsFormValues } from '@audius/common/utils'
 import {
   Modal,
   ModalContent,
@@ -101,7 +101,18 @@ export const InboxSettingsModalNew = () => {
         <ModalTitle title={messages.title} icon={<IconMessage />} />
       </ModalHeader>
       {statusIsNotFinalized(permissionsStatus) ? (
-        <LoadingSpinner />
+        <Flex
+          justifyContent='center'
+          alignItems='center'
+          m='xl'
+          p='4xl'
+          h='unit10'
+          css={{
+            opacity: 0.5
+          }}
+        >
+          <LoadingSpinner />
+        </Flex>
       ) : (
         <Formik<InboxSettingsFormValues>
           initialValues={initialValues}
@@ -158,9 +169,7 @@ const InboxSettingsModalFields = ({
     [setAllowAll]
   )
 
-  return statusIsNotFinalized(permissionsStatus) ? (
-    <LoadingSpinner />
-  ) : (
+  return (
     <Flex column gap='xl'>
       <Flex row gap='l'>
         <Switch {...allowAllField} onChange={handleAllChange} />


### PR DESCRIPTION
### Description
- Update write endpoint for permissions updates to accept a list.
- New version of inbox settings hook - don't need to use local state anymore as we use formik.
- Add a status in the chats slice for permissions fetching
- UI updates

Could not sign in on mobile against local stack for some reason. Going to test once backend changes land on stage. Mobile will likely be broken right now as we need to move the formik wrapper further down the screen (but that doesn't work with FormScreen i think..)


### How Has This Been Tested?

Web functionality working! Tested against local stack

https://github.com/user-attachments/assets/f623dfbb-7a08-4414-8dcf-a9ddd9cf72e7

