### PR TITLE
Clearing chat history forces permission re-check.

### DIFF
--- a/packages/discovery-provider/ddl/functions/chat_allowed.sql
+++ b/packages/discovery-provider/ddl/functions/chat_allowed.sql
@@ -33,6 +33,7 @@ BEGIN
   JOIN chat_message USING (chat_id)
   WHERE member_a.user_id = from_user_id
     AND member_b.user_id = to_user_id
+    AND (member_b.cleared_history_at IS NULL OR chat_message.created_at > member_b.cleared_history_at)
   ;
 
   IF can_message THEN

--- a/packages/discovery-provider/ddl/tests/chat_allowed_test.sql
+++ b/packages/discovery-provider/ddl/tests/chat_allowed_test.sql
@@ -44,6 +44,10 @@ ASSERT (SELECT chat_allowed(11, 10) = TRUE);
 UPDATE chat_permissions SET allowed = FALSE WHERE user_id = 10 AND permits = 'followers';
 ASSERT (SELECT chat_allowed(2,10) = FALSE);
 
+-- 10 cleares history... now 10 + 11 preexisting chat is invalidated
+-- and followers-only applies
+UPDATE chat_member SET cleared_history_at = now() where user_id = 10;
+ASSERT (SELECT chat_allowed(11, 10) = FALSE);
 
 
 


### PR DESCRIPTION
### Description

A pre-existing chat will take precedence over inbox settings... but if recipient clears chat history inbox settings re-apply.
