### PR TITLE
[C-5105] Fix issue with remixes lineup empty on track screen

### DIFF
--- a/packages/mobile/src/screens/track-screen/TrackScreenRemixes.tsx
+++ b/packages/mobile/src/screens/track-screen/TrackScreenRemixes.tsx
@@ -39,12 +39,13 @@ export const TrackScreenRemixes = (props: TrackScreenRemixesProps) => {
   const navigation = useNavigation()
   const dispatch = useDispatch()
   const remixesLineup = useSelector(getRemixesTracksLineup)
+  const trackId = track?.track_id
 
   useEffect(() => {
-    if (track) {
+    if (trackId) {
       dispatch(
         remixesPageLineupActions.fetchLineupMetadatas(0, 10, false, {
-          trackId: track.track_id
+          trackId
         })
       )
     }
@@ -52,7 +53,7 @@ export const TrackScreenRemixes = (props: TrackScreenRemixesProps) => {
     return function cleanup() {
       dispatch(remixesPageLineupActions.reset())
     }
-  }, [dispatch, track])
+  }, [dispatch, trackId])
 
   const handlePressGoToAllRemixes = () => {
     navigation.push('TrackRemixes', { id: track.track_id })


### PR DESCRIPTION
### Description

This one was kinda hard to track down because it was so non-deterministic. But I noticed in the redux debugger that the remixes lineup was being fetched & reset multiple times in a row. This was because the useEffect had a dependency on the entire `track` object, as opposed to the TrackRemixesScreen which only has a dependency on `trackId`. I updated this and now the lineup is only fetched once and it displays consistently (and is much quicker to load)

I assume the issue was a race condition between the `reset` actions being dispatched and the lineup fetch completing when it was being spammed, causing the lineup to be empty in some cases

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._
