### PR TITLE
Fix chat blast notif batching async/await

### DIFF
--- a/packages/discovery-provider/plugins/notifications/src/tasks/dmNotifications.ts
+++ b/packages/discovery-provider/plugins/notifications/src/tasks/dmNotifications.ts
@@ -362,8 +362,8 @@ export async function sendDMNotifications(
     const batches = chunk(notifications, config.notificationBatchSize)
     for (const batch of batches) {
       await Promise.all(
-        batch.map((notification) => {
-          notification.processNotification({
+        batch.map(async (notification) => {
+          await notification.processNotification({
             isLiveEmailEnabled: false,
             isBrowserPushEnabled
           })


### PR DESCRIPTION
### Description

Once again getting this error after sending many blasts on stage:
```
    const batches = chunk(notifications, config.notificationBatchSize)
    for (const batch of batches) {
      await Promise.all(
        batch.map((notification) => {
          notification.processNotification({
            isLiveEmailEnabled: false,
            isBrowserPushEnabled
          })
        })
      )
    }
```
I forgot to await the inner call to `processNotification`.


### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._
