### PR TITLE
[C-4958] Improve web comment disabled state

### DIFF
--- a/packages/web/src/pages/track-page/components/desktop/TrackPage.tsx
+++ b/packages/web/src/pages/track-page/components/desktop/TrackPage.tsx
@@ -280,8 +280,14 @@ const TrackPage = ({
                 leadingElementId={defaults.remixParentTrackId}
                 leadingElementDelineator={
                   <Flex gap='3xl' direction='column'>
-                    <Box alignSelf='flex-start'>
-                      <Button size='xs' iconRight={IconArrowRight} asChild>
+                    <Box
+                      alignSelf={isCommentingEnabled ? 'flex-start' : 'center'}
+                    >
+                      <Button
+                        size={isCommentingEnabled ? 'xs' : 'small'}
+                        iconRight={IconArrowRight}
+                        asChild
+                      >
                         <Link to={trackRemixesPage(permalink)}>
                           {messages.viewOtherRemixes}
                         </Link>

--- a/packages/web/src/pages/track-page/components/mobile/TrackPage.tsx
+++ b/packages/web/src/pages/track-page/components/mobile/TrackPage.tsx
@@ -131,7 +131,7 @@ const TrackPage = ({
     FeatureFlags.COMMENTS_ENABLED
   )
   const isCommentingEnabled =
-    commentsFlagEnabled && !heroTrack?.comments_disabled
+    commentsFlagEnabled && heroTrack?.comments_disabled
 
   const loading = !heroTrack || isFetchingNFTAccess
 
@@ -241,7 +241,7 @@ const TrackPage = ({
             // Styles for leading element (original track if remix).
             leadingElementId={defaults.remixParentTrackId}
             leadingElementDelineator={
-              <Flex>
+              <Flex direction='column' gap='xl'>
                 <Box alignSelf='flex-start'>
                   <Button size='xs' iconRight={IconArrowRight} asChild>
                     <Link to={trackRemixesPage(permalink)}>


### PR DESCRIPTION
### Description

Improves various comments-enabled/disabled states for remixes/remixable/track for web and mobile-web
<img width="1243" alt="Test Premium" src="https://github.com/user-attachments/assets/31c42226-9996-4c03-992d-456798a2b606">
<img width="1243" alt="Pasted Graphic 1" src="https://github.com/user-attachments/assets/502be73f-3df2-40fd-ba16-cc1e0e6d2ea0">
<img width="1243" alt="tuning-fork-440-hz-resonance-box-" src="https://github.com/user-attachments/assets/f84c790b-f211-4b89-b15e-70a1390e452d">
<img width="411" alt="View Other Remixes -" src="https://github.com/user-attachments/assets/20ba3ab5-d79f-4434-8540-c373d25d60f1">
<img width="411" alt="More by DeeJay" src="https://github.com/user-attachments/assets/959178ea-5e15-4d69-8dc3-95e72302773a">