### PR TITLE
[PAY-3499, PAY-3500] Fix truncation on blasts with content audience

### DIFF
--- a/packages/web/src/pages/chat-page/components/ChatBlastHeader.tsx
+++ b/packages/web/src/pages/chat-page/components/ChatBlastHeader.tsx
@@ -37,15 +37,16 @@ export const ChatBlastHeader = ({ chat }: { chat: ChatBlast }) => {
           <Artwork
             src={audienceContentType === 'track' ? trackArtwork : albumArtwork}
             w='48px'
+            css={{ flexShrink: 0 }}
           />
         ) : null}
         <Flex column gap='xs' alignItems='flex-start'>
           <Flex gap='s' alignItems='center'>
             <IconTowerBroadcast size='m' color='default' />
-            <Text variant='title' size='l' ellipses>
+            <Text variant='title' size='l'>
               {chatBlastSecondaryTitle}
             </Text>
-            <Text variant='title' size='l' color='subdued' ellipses>
+            <Text variant='title' size='l' color='subdued' maxLines={1}>
               {contentTitle}
             </Text>
           </Flex>

--- a/packages/web/src/pages/chat-page/components/ChatListBlastItem.tsx
+++ b/packages/web/src/pages/chat-page/components/ChatListBlastItem.tsx
@@ -2,7 +2,7 @@ import { useCallback } from 'react'
 
 import { useChatBlastAudienceContent } from '@audius/common/hooks'
 import { formatCount } from '@audius/common/utils'
-import { Flex, IconTowerBroadcast, IconUser, Text } from '@audius/harmony'
+import { Box, Flex, IconTowerBroadcast, IconUser, Text } from '@audius/harmony'
 import { ChatBlast } from '@audius/sdk'
 import cn from 'classnames'
 
@@ -41,21 +41,15 @@ export const ChatListBlastItem = (props: ChatListBlastItemProps) => {
       onClick={handleClick}
       className={cn(styles.root, { [styles.active]: isCurrentChat })}
     >
-      <Flex gap='s' css={{ overflow: 'hidden' }}>
+      <Flex row gap='s' w='100%'>
         <IconTowerBroadcast size='l' color='default' />
-        <Text size='l' strength='strong' css={{ whiteSpace: 'nowrap' }}>
-          {chatBlastTitle}
-        </Text>
+        <Box css={{ flexShrink: 0 }}>
+          <Text size='l' strength='strong'>
+            {chatBlastTitle}
+          </Text>
+        </Box>
         {contentTitle ? (
-          <Text
-            size='l'
-            color='subdued'
-            css={{
-              whiteSpace: 'nowrap',
-              overflow: 'hidden',
-              textOverflow: 'ellipsis'
-            }}
-          >
+          <Text size='l' color='subdued' ellipses css={{ display: 'block' }}>
             {contentTitle}
           </Text>
         ) : null}


### PR DESCRIPTION
### Description

- Fixes truncation of remixed/purchased content titles on `ChatListBlastItem` and `ChatListHeader`

### How Has This Been Tested?

![Screenshot 2024-10-09 at 5 36 06 PM](https://github.com/user-attachments/assets/b07baa10-eb04-44fd-bc6a-8422cb3e40ca)
![Screenshot 2024-10-09 at 5 46 41 PM](https://github.com/user-attachments/assets/9b43d0dc-a79f-4083-82cb-4b240834717c)
