### PR TITLE
add check for no chain status at all in discprov

### DIFF
--- a/packages/discovery-provider/src/queries/get_health.py
+++ b/packages/discovery-provider/src/queries/get_health.py
@@ -478,7 +478,8 @@ def get_health(args: GetHealthArgs, use_redis_cache: bool = True) -> Tuple[Dict,
     if chain_health and chain_health["status"] == "Unhealthy":
         errors.append("unhealthy chain")
 
-    if not chain_health:
+    is_dev = shared_config["discprov"]["env"] == "dev"
+    if not is_dev and not chain_health:
         errors.append("no chain response")
 
     if verbose:

--- a/packages/discovery-provider/src/queries/get_health.py
+++ b/packages/discovery-provider/src/queries/get_health.py
@@ -478,6 +478,9 @@ def get_health(args: GetHealthArgs, use_redis_cache: bool = True) -> Tuple[Dict,
     if chain_health and chain_health["status"] == "Unhealthy":
         errors.append("unhealthy chain")
 
+    if not chain_health:
+        errors.append("no chain response")
+
     if verbose:
         api_healthy, reason = is_api_healthy(url)
         if not api_healthy:


### PR DESCRIPTION
### Description
`discovery_provider_healthy` reports true in the case of chain_health being null which shouldn't happen, this messes with sdk selection

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._
