### PR TITLE
Fix comment mention entity type to table mapping

### DIFF
--- a/packages/discovery-provider/src/tasks/entity_manager/entity_manager.py
+++ b/packages/discovery-provider/src/tasks/entity_manager/entity_manager.py
@@ -438,6 +438,9 @@ def entity_manager_update(
                     logger.error(
                         f"entity_manager.py | Indexing error {e}", exc_info=True
                     )
+                    create_and_raise_indexing_error(
+                        indexing_error, update_task.redis, session
+                    )
                     logger.error(f"skipping transaction hash {indexing_error}")
 
         # compile records_to_save
@@ -480,7 +483,7 @@ def entity_manager_update(
             )
     except Exception as e:
         logger.error(f"entity_manager.py | Exception occurred {e}", exc_info=True)
-        # raise e
+        raise e
     return num_total_changes, changed_entity_ids
 
 

--- a/packages/discovery-provider/src/tasks/entity_manager/entity_manager.py
+++ b/packages/discovery-provider/src/tasks/entity_manager/entity_manager.py
@@ -135,6 +135,7 @@ entity_type_table_mapping = {
     "DeveloperApp": DeveloperApp.__tablename__,
     "Grant": Grant.__tablename__,
     "Comment": Comment.__tablename__,
+    "CommentMention": CommentMention.__tablename__,
     "CommentReaction": CommentReaction.__tablename__,
     "MutedUser": MutedUser.__tablename__,
     "CommentNotificationSetting": CommentNotificationSetting.__tablename__,
@@ -437,9 +438,6 @@ def entity_manager_update(
                     logger.error(
                         f"entity_manager.py | Indexing error {e}", exc_info=True
                     )
-                    create_and_raise_indexing_error(
-                        indexing_error, update_task.redis, session
-                    )
                     logger.error(f"skipping transaction hash {indexing_error}")
 
         # compile records_to_save
@@ -482,7 +480,7 @@ def entity_manager_update(
             )
     except Exception as e:
         logger.error(f"entity_manager.py | Exception occurred {e}", exc_info=True)
-        raise e
+        # raise e
     return num_total_changes, changed_entity_ids
 
 


### PR DESCRIPTION
### Description
```
prev_records[entity_type_table_mapping[record_type]].append(\n                 ~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^\nKeyError: <EntityType.COMMENT_MENTION: 'CommentMention'>"
```

Stage indexing stall came up in QA. This part of indexing is outside of the skippable scope. The error is simply because this comment mentions table isn't in the entity type -> table mapping. 

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._

Ran comment mentions locally and confirmed indexing is working.