### PR TITLE
[PAY-3481, PAY-3512] ChatBlastCTA float above mobile keyboard

### DIFF
--- a/packages/mobile/src/screens/chat-screen/ChatBlastCTA.tsx
+++ b/packages/mobile/src/screens/chat-screen/ChatBlastCTA.tsx
@@ -10,8 +10,12 @@ import {
   IconTowerBroadcast,
   IconCaretRight
 } from '@audius/harmony-native'
+import { KeyboardAvoidingView } from 'app/components/core'
+import { PLAY_BAR_HEIGHT } from 'app/components/now-playing-drawer/constants'
 
 import { useAppDrawerNavigation } from '../app-drawer-screen'
+
+import { useKeyboardAvoidingPlaybarStyle } from './hooks/useKeyboardAvoidingPlaybarStyle'
 
 const messages = {
   title: 'Send a Message Blast',
@@ -22,6 +26,7 @@ const messages = {
 
 export const ChatBlastCTA = () => {
   const navigation = useAppDrawerNavigation()
+  const keyboardAvoidingPlaybarStyle = useKeyboardAvoidingPlaybarStyle()
 
   const handleClick = useCallback(() => {
     navigation.navigate('CreateChatBlast')
@@ -33,24 +38,29 @@ export const ChatBlastCTA = () => {
   }
 
   return (
-    <TouchableHighlight onPress={handleClick}>
-      <Box backgroundColor='surface1' ph='xl' pv='l' borderTop='strong'>
-        <Flex
-          direction='row'
-          alignItems='center'
-          gap='l'
-          justifyContent='space-between'
-        >
-          <Flex direction='row' alignItems='center' gap='s'>
-            <IconTowerBroadcast size='3xl' color='default' />
-            <Flex direction='column' gap='xs'>
-              <Text variant='title'>{messages.title}</Text>
-              <Text size='s'>{messages.description}</Text>
+    <KeyboardAvoidingView
+      keyboardShowingOffset={80 + PLAY_BAR_HEIGHT}
+      style={keyboardAvoidingPlaybarStyle}
+    >
+      <TouchableHighlight onPress={handleClick}>
+        <Box backgroundColor='surface1' ph='xl' pv='l' borderTop='strong'>
+          <Flex
+            direction='row'
+            alignItems='center'
+            gap='l'
+            justifyContent='space-between'
+          >
+            <Flex direction='row' alignItems='center' gap='s'>
+              <IconTowerBroadcast size='3xl' color='default' />
+              <Flex direction='column' gap='xs'>
+                <Text variant='title'>{messages.title}</Text>
+                <Text size='s'>{messages.description}</Text>
+              </Flex>
             </Flex>
+            <IconCaretRight size='s' color='default' />
           </Flex>
-          <IconCaretRight size='s' color='default' />
-        </Flex>
-      </Box>
-    </TouchableHighlight>
+        </Box>
+      </TouchableHighlight>
+    </KeyboardAvoidingView>
   )
 }

--- a/packages/mobile/src/screens/chat-screen/ChatBlastCTA.tsx
+++ b/packages/mobile/src/screens/chat-screen/ChatBlastCTA.tsx
@@ -17,6 +17,8 @@ import { useAppDrawerNavigation } from '../app-drawer-screen'
 
 import { useKeyboardAvoidingPlaybarStyle } from './hooks/useKeyboardAvoidingPlaybarStyle'
 
+const CTA_HEIGHT = 80
+
 const messages = {
   title: 'Send a Message Blast',
   description: 'Send messages to your fans in bulk.',
@@ -39,7 +41,7 @@ export const ChatBlastCTA = () => {
 
   return (
     <KeyboardAvoidingView
-      keyboardShowingOffset={80 + PLAY_BAR_HEIGHT}
+      keyboardShowingOffset={CTA_HEIGHT + PLAY_BAR_HEIGHT}
       style={keyboardAvoidingPlaybarStyle}
     >
       <TouchableHighlight onPress={handleClick}>

--- a/packages/mobile/src/screens/chat-screen/ChatScreen.tsx
+++ b/packages/mobile/src/screens/chat-screen/ChatScreen.tsx
@@ -18,7 +18,6 @@ import {
 } from '@audius/common/utils'
 import type { ChatBlast } from '@audius/sdk'
 import { Portal } from '@gorhom/portal'
-import { useKeyboard } from '@react-native-community/hooks'
 import { useFocusEffect } from '@react-navigation/native'
 import type { FlatListProps, LayoutChangeEvent } from 'react-native'
 import {
@@ -174,11 +173,6 @@ type ContainerLayoutStatus = {
   bottom: number
 }
 
-type ReactionContainerStyle = {
-  paddingTop: number
-  bottom: number
-}
-
 const getAutoscrollThreshold = ({ top, bottom }: ContainerLayoutStatus) => {
   return (bottom - top) / 4
 }
@@ -250,7 +244,6 @@ export const ChatScreen = () => {
   const scrollPosition = useRef(0)
   const latestMessageId = useRef('')
   const flatListInnerHeight = useRef(0)
-  const { keyboardShown } = useKeyboard()
   const insets = useSafeAreaInsets()
 
   const hasCurrentlyPlayingTrack = useSelector(getHasTrack)

--- a/packages/mobile/src/screens/chat-screen/ChatScreen.tsx
+++ b/packages/mobile/src/screens/chat-screen/ChatScreen.tsx
@@ -66,6 +66,7 @@ import {
   NEW_MESSAGE_TOAST_SCROLL_THRESHOLD,
   SCROLL_TO_BOTTOM_THRESHOLD
 } from './constants'
+import { useKeyboardAvoidingPlaybarStyle } from './hooks/useKeyboardAvoidingPlaybarStyle'
 
 type ChatFlatListProps = FlatListProps<ChatMessageWithExtras>
 type ChatListEventHandler<K extends keyof ChatFlatListProps> = NonNullable<
@@ -545,20 +546,7 @@ export const ChatScreen = () => {
     }, 0)
   }, [flatListRef])
 
-  // For some reason the bottom padding behavior is different between the platforms.
-  const getKeyboardAvoidingPlaybarAwareStyle = useCallback(() => {
-    const style = {} as ReactionContainerStyle
-    if (Platform.OS === 'ios') {
-      style.bottom = hasCurrentlyPlayingTrack ? PLAY_BAR_HEIGHT : 0
-      style.paddingTop = hasCurrentlyPlayingTrack ? PLAY_BAR_HEIGHT : 0
-    } else if (Platform.OS === 'android') {
-      style.bottom =
-        hasCurrentlyPlayingTrack && !keyboardShown ? PLAY_BAR_HEIGHT : 0
-      style.paddingTop =
-        hasCurrentlyPlayingTrack && !keyboardShown ? PLAY_BAR_HEIGHT : 0
-    }
-    return style
-  }, [hasCurrentlyPlayingTrack, keyboardShown])
+  const keyboardAvoidingPlaybarStyle = useKeyboardAvoidingPlaybarStyle()
 
   return (
     <Screen
@@ -598,10 +586,7 @@ export const ChatScreen = () => {
                 ? PLAY_BAR_HEIGHT + BOTTOM_BAR_HEIGHT + insets.bottom
                 : BOTTOM_BAR_HEIGHT + insets.bottom
             }
-            style={[
-              styles.keyboardAvoiding,
-              getKeyboardAvoidingPlaybarAwareStyle()
-            ]}
+            style={[styles.keyboardAvoiding, keyboardAvoidingPlaybarStyle]}
             onKeyboardHide={measureChatContainerBottom}
             onKeyboardShow={measureChatContainerBottom}
           >

--- a/packages/mobile/src/screens/chat-screen/hooks/useKeyboardAvoidingPlaybarStyle.ts
+++ b/packages/mobile/src/screens/chat-screen/hooks/useKeyboardAvoidingPlaybarStyle.ts
@@ -1,0 +1,40 @@
+import { useMemo } from 'react'
+
+import { playerSelectors } from '@audius/common/store'
+import { useKeyboard } from '@react-native-community/hooks'
+import { Platform } from 'react-native'
+import { useSelector } from 'react-redux'
+
+import { PLAY_BAR_HEIGHT } from 'app/components/now-playing-drawer'
+
+const { getHasTrack } = playerSelectors
+
+type KeyboardAvoidingPlaybarStyle = {
+  paddingTop: number
+  bottom: number
+}
+
+export const useKeyboardAvoidingPlaybarStyle =
+  (): KeyboardAvoidingPlaybarStyle => {
+    const { keyboardShown } = useKeyboard()
+    const hasCurrentlyPlayingTrack = useSelector(getHasTrack)
+
+    return useMemo(() => {
+      const style: KeyboardAvoidingPlaybarStyle = {
+        paddingTop: 0,
+        bottom: 0
+      }
+
+      if (Platform.OS === 'ios') {
+        style.bottom = hasCurrentlyPlayingTrack ? PLAY_BAR_HEIGHT : 0
+        style.paddingTop = hasCurrentlyPlayingTrack ? PLAY_BAR_HEIGHT : 0
+      } else if (Platform.OS === 'android') {
+        style.bottom =
+          hasCurrentlyPlayingTrack && !keyboardShown ? PLAY_BAR_HEIGHT : 0
+        style.paddingTop =
+          hasCurrentlyPlayingTrack && !keyboardShown ? PLAY_BAR_HEIGHT : 0
+      }
+
+      return style
+    }, [hasCurrentlyPlayingTrack, keyboardShown])
+  }


### PR DESCRIPTION
### Description

- Move `getKeyboardAvoidingPlaybarStyle` to new custom hook
- Use KeyboardAwareView with the new hook to float at correct height above keyboard

### How Has This Been Tested?

![Screenshot 2024-10-10 at 5 28 16 PM](https://github.com/user-attachments/assets/5638027e-35c3-49a4-8b74-339775c0ebf8)
