### PR TITLE
Chat create from blast validator

### DIFF
--- a/comms/discovery/rpcz/chat_blast_test.go
+++ b/comms/discovery/rpcz/chat_blast_test.go
@@ -218,6 +218,8 @@ func TestChatBlast(t *testing.T) {
 
 	// user 999 does not
 	{
+		assertChatCreateAllowed(t, tx, 999, 69, false)
+
 		blasts, err := queries.GetNewBlasts(tx, ctx, queries.ChatMembershipParams{
 			UserID: 999,
 		})
@@ -227,6 +229,9 @@ func TestChatBlast(t *testing.T) {
 
 	// user 101 upgrades it to a real DM
 	{
+
+		assertChatCreateAllowed(t, tx, 101, 69, true)
+
 		err = chatCreate(tx, 101, t3, schema.ChatCreateRPCParams{
 			ChatID: chatId_101_69,
 			Invites: []schema.PurpleInvite{

--- a/comms/discovery/rpcz/chat_blast_test.go
+++ b/comms/discovery/rpcz/chat_blast_test.go
@@ -62,6 +62,11 @@ func TestChatBlast(t *testing.T) {
 	`, t0)
 	assert.NoError(t, err)
 
+	// Blaster (user 69) closes inbox
+	// But recipients should still be able to upgrade.
+	err = chatSetPermissions(tx, 69, schema.None, nil, nil, t0)
+	assert.NoError(t, err)
+
 	// ----------------- some threads already exist -------------
 	// user 100 starts a thread with 69 before first blast
 	chatId_100_69 := misc.ChatID(100, 69)
@@ -398,6 +403,11 @@ func TestChatBlast(t *testing.T) {
 	}
 
 	// ------- bi-directional blasting works with upgrade --------
+
+	// 69 re-opens inbox
+	err = chatSetPermissions(tx, 69, schema.All, nil, nil, t0)
+	assert.NoError(t, err)
+
 	// 68 sends a blast
 	chatId_68_69 := misc.ChatID(68, 69)
 

--- a/comms/discovery/rpcz/chat_permissions_test.go
+++ b/comms/discovery/rpcz/chat_permissions_test.go
@@ -38,19 +38,7 @@ func TestChatPermissions(t *testing.T) {
 	assert.NoError(t, err)
 
 	assertPermissionValidation := func(tx *sqlx.Tx, sender int32, receiver int32, chatId string, errorExpected bool) {
-		senderEncoded, err := misc.EncodeHashId(int(sender))
-		assert.NoError(t, err)
-		receiverEncoded, err := misc.EncodeHashId(int(receiver))
-		assert.NoError(t, err)
-		exampleRpc := schema.RawRPC{
-			Params: []byte(fmt.Sprintf(`{"chat_id": "%s", "invites": [{"user_id": "%s", "invite_code": "%s"}, {"user_id": "%s", "invite_code": "%s"}]}`, chatId, senderEncoded, senderEncoded, receiverEncoded, senderEncoded)),
-		}
-		err = testValidator.validateChatCreate(tx, sender, exampleRpc)
-		if errorExpected {
-			assert.ErrorContains(t, err, "Not permitted to send messages to this user")
-		} else {
-			assert.NoError(t, err)
-		}
+		assertChatCreateAllowed(t, tx, sender, receiver, !errorExpected)
 	}
 
 	// validate user1Id can set permissions
@@ -100,4 +88,19 @@ func TestChatPermissions(t *testing.T) {
 	assertPermissionValidation(tx, user3Id, user1Id, chat2Id, false)
 
 	tx.Rollback()
+}
+
+func assertChatCreateAllowed(t *testing.T, tx *sqlx.Tx, sender int32, receiver int32, shouldWork bool) {
+	chatId := misc.ChatID(int(sender), int(receiver))
+	senderEncoded := misc.MustEncodeHashID(int(sender))
+	receiverEncoded := misc.MustEncodeHashID(int(receiver))
+	exampleRpc := schema.RawRPC{
+		Params: []byte(fmt.Sprintf(`{"chat_id": "%s", "invites": [{"user_id": "%s", "invite_code": "%s"}, {"user_id": "%s", "invite_code": "%s"}]}`, chatId, senderEncoded, senderEncoded, receiverEncoded, senderEncoded)),
+	}
+	err := testValidator.validateChatCreate(tx, sender, exampleRpc)
+	if shouldWork {
+		assert.NoError(t, err)
+	} else {
+		assert.ErrorContains(t, err, "Not permitted to send messages to this user")
+	}
 }

--- a/comms/discovery/rpcz/chat_permissions_test.go
+++ b/comms/discovery/rpcz/chat_permissions_test.go
@@ -64,7 +64,7 @@ func TestChatPermissions(t *testing.T) {
 	}
 
 	// user 1 sets chat permissions to followees only
-	err = chatSetPermissions(tx, int32(user1Id), schema.Followees, nil, time.Now())
+	err = chatSetPermissions(tx, int32(user1Id), schema.Followees, nil, nil, time.Now())
 	assert.NoError(t, err)
 	// user 2 can message user 1 since 1 follows 2
 	assertPermissionValidation(tx, user2Id, user1Id, chat1Id, false)
@@ -72,7 +72,7 @@ func TestChatPermissions(t *testing.T) {
 	assertPermissionValidation(tx, user3Id, user1Id, chat2Id, true)
 
 	// user 1 sets chat permissions to tippers only
-	err = chatSetPermissions(tx, int32(user1Id), schema.Tippers, nil, time.Now())
+	err = chatSetPermissions(tx, int32(user1Id), schema.Tippers, nil, nil, time.Now())
 	assert.NoError(t, err)
 	// user 2 cannot message user 1 since 2 has never tipped 1
 	assertPermissionValidation(tx, user2Id, user1Id, chat1Id, true)
@@ -80,19 +80,19 @@ func TestChatPermissions(t *testing.T) {
 	assertPermissionValidation(tx, user3Id, user1Id, chat2Id, false)
 
 	// user 1 changes chat permissions to none
-	err = chatSetPermissions(tx, int32(user1Id), schema.None, nil, time.Now())
+	err = chatSetPermissions(tx, int32(user1Id), schema.None, nil, nil, time.Now())
 	assert.NoError(t, err)
 	// no one can message user 1
 	assertPermissionValidation(tx, user2Id, user1Id, chat1Id, true)
 	assertPermissionValidation(tx, user3Id, user1Id, chat2Id, true)
 
 	// user 1 changes chat permissions to all
-	err = chatSetPermissions(tx, int32(user1Id), schema.All, nil, time.Now())
+	err = chatSetPermissions(tx, int32(user1Id), schema.All, nil, nil, time.Now())
 	assert.NoError(t, err)
 
 	// meanwhile... a "late" permission update is ignored
 	// the "all" setting should prevail
-	err = chatSetPermissions(tx, int32(user1Id), schema.None, nil, time.Now().Add(-time.Hour))
+	err = chatSetPermissions(tx, int32(user1Id), schema.None, nil, nil, time.Now().Add(-time.Hour))
 	assert.NoError(t, err)
 
 	// anyone can message user 1


### PR DESCRIPTION
### Description

Reed pointed out:

> if artist has closed their inbox, then sends out blast, then fan upgrades blast.. will the chat create work? will permissions prevent that?

This changes `validateChatCreate` to skip the `chat_allowed` UDF check if user is creating a chat from a blast.

### How Has This Been Tested?

In `chat_blast_test.go` blaster closes inbox... tests will fail without change to `validateChatCreate` but pass afterwards so that's a good sign.
