### PR TITLE
[C-5141] Generate comment id in onMutate

### DIFF
--- a/packages/common/src/api/tan-query/comments.ts
+++ b/packages/common/src/api/tan-query/comments.ts
@@ -245,7 +245,8 @@ export const usePostComment = () => {
       const isReply = parentCommentId !== undefined
       // This executes before the mutationFn is called, and the reference to comment is the same in both
       // therefore, this sets the id that will be posted to the server
-      const newId = Math.floor(Math.random() * 1000000) // TODO: need to request an unused id instead of a random number
+      const sdk = await audiusSdk()
+      const newId = await sdk.comments.generateCommentId()
       // hack alert: there is no way to send context from onMutate to mutationFn so we hack it into the args
       args.newId = newId
       const newComment: Comment = {

--- a/packages/libs/src/sdk/api/comments/CommentsAPI.ts
+++ b/packages/libs/src/sdk/api/comments/CommentsAPI.ts
@@ -38,7 +38,7 @@ export class CommentsApi extends GeneratedCommentsApi {
     super(configuration)
   }
 
-  private async generateCommentId() {
+  async generateCommentId() {
     const response = await this.getUnclaimedCommentID()
     const { data: unclaimedId } = response
     if (!unclaimedId) {


### PR DESCRIPTION
### Description
Updates comment tan-query implementation to generate commentId for optimistic update before postComment.