### PR TITLE
Fix Text component font and CAA API key

### DIFF
--- a/.changeset/moody-squids-thank.md
+++ b/.changeset/moody-squids-thank.md
@@ -1,0 +1,6 @@
+---
+'create-audius-app': patch
+'@audius/harmony': patch
+---
+
+Minor fixes to CAA defaults, and fix Harmony text component font

--- a/packages/create-audius-app/examples/react-hono/src/index.tsx
+++ b/packages/create-audius-app/examples/react-hono/src/index.tsx
@@ -6,7 +6,7 @@ import { logger } from 'hono/logger'
 import { HTTPException } from 'hono/http-exception'
 import type { AudiusSdk } from '@audius/sdk'
 
-const apiKey = import.meta.env.VITE_AUDIUS_API_SECRET as string
+const apiKey = import.meta.env.VITE_AUDIUS_API_KEY as string
 const apiSecret = import.meta.env.VITE_AUDIUS_API_SECRET as string
 
 const app = new Hono()

--- a/packages/harmony/src/components/text/Text.tsx
+++ b/packages/harmony/src/components/text/Text.tsx
@@ -40,8 +40,7 @@ export const Text = forwardRef(
 
     const variantConfig = variant && variantStylesMap[variant]
     const css = {
-      fontFamily: `'Avenir Next LT Pro', 'Helvetica Neue', Helvetica,
-    Arial, sans-serif`,
+      fontFamily: typography.font,
       position: 'relative',
       boxSizing: 'border-box',
       ...(color &&


### PR DESCRIPTION
### Description

- Fixes small bug where Harmony `Text` component overrides the theme font.
- Fixes small bug where the CreateAudiusApp was setting the secret to the API key by default
