### PR TITLE
[C-5040] Enable animated mobile icons

### DIFF
--- a/packages/mobile/src/components/comments/CommentOverflowMenu.tsx
+++ b/packages/mobile/src/components/comments/CommentOverflowMenu.tsx
@@ -213,7 +213,7 @@ export const CommentOverflowMenu = (props: CommentOverflowMenuProps) => {
       content: messages.toasts.deleted,
       type: 'info'
     })
-  }, [deleteComment, id, toast])
+  }, [deleteComment, id, toast, parentCommentId])
 
   return (
     <>

--- a/packages/mobile/src/harmony-native/components/Button/Button/Button.tsx
+++ b/packages/mobile/src/harmony-native/components/Button/Button/Button.tsx
@@ -1,15 +1,13 @@
-import { useState } from 'react'
-
 import type { ReactNativeStyle } from '@emotion/native'
 import Color from 'color'
 import type { TextStyle, ViewStyle } from 'react-native'
 import {
   interpolateColor,
+  useAnimatedProps,
   useAnimatedStyle,
   useSharedValue
 } from 'react-native-reanimated'
 
-import type { IconColors } from '@audius/harmony-native'
 import type { IconProps } from 'app/harmony-native/icons'
 
 import { useTheme } from '../../../foundations/theme'
@@ -89,7 +87,7 @@ export const Button = (props: ButtonProps) => {
     default: {
       background: primaryOverrideColor ?? themeColors.primary.primary,
       text: themeColors.text.staticWhite,
-      icon: 'staticWhite',
+      icon: themeColors.icon.staticWhite,
       border: primaryOverrideColor ?? themeColors.primary.primary
     },
     press: {
@@ -97,7 +95,7 @@ export const Button = (props: ButtonProps) => {
         .darken(0.2)
         .hex(),
       text: themeColors.text.staticWhite,
-      icon: 'staticWhite',
+      icon: themeColors.icon.staticWhite,
       border: new Color(primaryOverrideColor ?? themeColors.primary.primary)
         .darken(0.2)
         .hex()
@@ -117,7 +115,7 @@ export const Button = (props: ButtonProps) => {
     default: {
       background: 'transparent',
       text: themeColors.text.default,
-      icon: 'default',
+      icon: themeColors.icon.default,
       border: themeColors.border.strong
     },
     press: {
@@ -125,7 +123,7 @@ export const Button = (props: ButtonProps) => {
         .darken(0.2)
         .hex(),
       text: themeColors.text.staticWhite,
-      icon: 'staticWhite',
+      icon: themeColors.icon.staticWhite,
       border: new Color(primaryOverrideColor ?? themeColors.primary.primary)
         .darken(0.2)
         .hex()
@@ -149,13 +147,13 @@ export const Button = (props: ButtonProps) => {
     default: {
       background: type === 'dark' ? '#32334d99' : '#ffffffd9',
       text: themeColors.text.default,
-      icon: 'default',
+      icon: themeColors.icon.default,
       border: themeColors.border.default
     },
     press: {
       background: themeColors.background.surface2,
       text: themeColors.text.default,
-      icon: 'default',
+      icon: themeColors.icon.default,
       border: themeColors.border.strong
     }
   }
@@ -173,13 +171,13 @@ export const Button = (props: ButtonProps) => {
     default: {
       background: 'transparent',
       text: themeColors.text.danger,
-      icon: 'danger',
+      icon: themeColors.icon.danger,
       border: themeColors.special.red
     },
     press: {
       background: themeColors.special.red,
       text: themeColors.text.staticWhite,
-      icon: 'staticWhite',
+      icon: themeColors.icon.staticWhite,
       border: themeColors.special.red
     }
   }
@@ -244,6 +242,20 @@ export const Button = (props: ButtonProps) => {
     }
   }, [variant])
 
+  const animatedIconProps = useAnimatedProps(
+    () => ({
+      fill:
+        isDisabled && variant === 'secondary'
+          ? themeColors.icon.staticWhite
+          : interpolateColor(
+              pressed.value,
+              [0, 1],
+              [dynamicStyles.default.icon, dynamicStyles.press.icon]
+            )
+    }),
+    [variant, isDisabled]
+  )
+
   const textColor =
     (variant === 'secondary' && !isDisabled) || variant === 'tertiary'
       ? 'default'
@@ -255,27 +267,8 @@ export const Button = (props: ButtonProps) => {
 
   const loaderSize = size === 'small' ? 16 : 20
 
-  const [isPressing, setIsPressing] = useState(false)
-
-  const handlePressIn = () => {
-    setIsPressing(true)
-  }
-  const handlePressOut = () => {
-    setIsPressing(false)
-  }
-
-  const iconColor =
-    isDisabled && variant === 'secondary'
-      ? 'staticWhite'
-      : isPressing && !isDisabled
-      ? dynamicStyles.press.icon
-      : dynamicStyles.default.icon
-
   return (
     <BaseButton
-      onPressIn={handlePressIn}
-      onPressOut={handlePressOut}
-      onLongPress={handlePressOut}
       disabled={isDisabled}
       style={[animatedButtonStyles, buttonStyles, style]}
       sharedValue={pressed}
@@ -287,7 +280,7 @@ export const Button = (props: ButtonProps) => {
           color: textColor
         },
         icon: {
-          color: iconColor as IconColors,
+          animatedProps: animatedIconProps,
           size: iconSize
         },
         loader: {

--- a/packages/mobile/src/harmony-native/components/Button/EntityActionButton/EntityActionButton.tsx
+++ b/packages/mobile/src/harmony-native/components/Button/EntityActionButton/EntityActionButton.tsx
@@ -1,10 +1,11 @@
-import { useCallback, useEffect, useMemo, useState } from 'react'
+import { useCallback, useEffect, useState } from 'react'
 
 import type { ReactNativeStyle } from '@emotion/native'
 import Color from 'color'
 import type { TextStyle } from 'react-native'
 import {
   interpolateColor,
+  useAnimatedProps,
   useAnimatedStyle,
   useSharedValue
 } from 'react-native-reanimated'
@@ -16,7 +17,7 @@ import { BaseButton } from '../BaseButton/BaseButton'
 import type { EntityActionButtonProps } from './types'
 
 export const EntityActionButton = (props: EntityActionButtonProps) => {
-  const { onPress, isActive, icon, style, ...other } = props
+  const { onPress, isActive, style, ...other } = props
   const { color, spacing, cornerRadius, typography } = useTheme()
   const pressed = useSharedValue(0)
 
@@ -43,13 +44,13 @@ export const EntityActionButton = (props: EntityActionButtonProps) => {
     default: {
       background: color.background.white,
       text: active ? color.primary.primary : color.text.default,
-      icon: 'staticWhite',
+      icon: active ? color.icon.active : color.icon.default,
       borderColor: active ? color.primary.primary : color.border.strong
     },
     press: {
       background: new Color(color.primary.primary).darken(0.2).hex(),
       text: color.text.staticWhite,
-      icon: 'staticWhite',
+      icon: color.icon.staticWhite,
       borderColor: new Color(color.primary.primary).darken(0.2).hex()
     }
   }
@@ -86,36 +87,23 @@ export const EntityActionButton = (props: EntityActionButtonProps) => {
     }
   }, [active])
 
-  const [isPressing, setIsPressing] = useState(false)
-
-  const handlePressIn = () => {
-    setIsPressing(true)
-  }
-  const handlePressOut = () => {
-    setIsPressing(false)
-  }
-
-  const iconColor = useMemo(() => {
-    return isPressing ? 'staticWhite' : active ? 'active' : 'default'
-  }, [isPressing, active])
+  const animatedIconProps = useAnimatedProps(() => {
+    return {
+      fill: interpolateColor(
+        pressed.value,
+        [0, 1],
+        [dynamicStyles.default.icon, dynamicStyles.press.icon]
+      )
+    }
+  }, [active])
 
   return (
     <BaseButton
-      onPressIn={handlePressIn}
-      onPressOut={handlePressOut}
-      onLongPress={handlePressOut}
       onPress={handlePress}
-      innerProps={{
-        icon: {
-          ...icon,
-          color: iconColor
-        }
-      }}
+      innerProps={{ icon: { animatedProps: animatedIconProps } }}
       style={[animatedButtonStyles, buttonStyles, style]}
       sharedValue={pressed}
-      styles={{
-        text: [textStyles, animatedTextStyles]
-      }}
+      styles={{ text: [textStyles, animatedTextStyles] }}
       {...other}
     />
   )

--- a/packages/mobile/src/harmony-native/components/Button/FilterButton/FilterButton.tsx
+++ b/packages/mobile/src/harmony-native/components/Button/FilterButton/FilterButton.tsx
@@ -46,18 +46,10 @@ export const FilterButton = <Value extends string>(
     paddingHorizontal: spacing.m,
     paddingVertical: spacing.s
   }
-  const defaultIconStyles: ReactNativeStyle = {
-    width: spacing.unit4,
-    height: spacing.unit4
-  }
 
   const smallStyles: ReactNativeStyle = {
     paddingHorizontal: spacing.m,
     height: spacing.unit8
-  }
-  const smallIconStyles: ReactNativeStyle = {
-    width: spacing.unit3,
-    height: spacing.unit3
   }
 
   // TODO: Update these are the button styles to use animated styles for the background, border, text, and icon
@@ -101,7 +93,9 @@ export const FilterButton = <Value extends string>(
     ...(variant === 'fillContainer' && !isNil(value) ? fillContainerStyles : {})
   }
 
-  const iconStyles = size === 'small' ? smallIconStyles : defaultIconStyles
+  const iconSize = size === 'small' ? '2xs' : 's'
+  const textColor =
+    !isNil(value) && variant === 'fillContainer' ? 'staticWhite' : 'default'
 
   useEffect(() => {
     if (isOpen) {
@@ -126,10 +120,6 @@ export const FilterButton = <Value extends string>(
     [onPress, options, screen, navigation, filterScreen, label, onChange, value]
   )
 
-  const iconSize = size === 'small' ? 's' : 'm'
-  const textColor =
-    !isNil(value) && variant === 'fillContainer' ? 'staticWhite' : 'default'
-
   const Icon = useMemo(() => {
     return variant === 'fillContainer' && !isNil(value)
       ? (props: IconProps) => (
@@ -151,13 +141,7 @@ export const FilterButton = <Value extends string>(
   return (
     <BaseButton
       style={buttonStyles}
-      styles={{ icon: iconStyles }}
-      innerProps={{
-        icon: {
-          color: 'staticWhite',
-          size: iconSize
-        }
-      }}
+      innerProps={{ icon: { color: 'staticWhite', size: iconSize } }}
       onPress={handlePress}
       iconRight={Icon}
       disabled={disabled}

--- a/packages/mobile/src/harmony-native/components/Button/PlainButton/PlainButton.tsx
+++ b/packages/mobile/src/harmony-native/components/Button/PlainButton/PlainButton.tsx
@@ -1,10 +1,9 @@
-import { useState } from 'react'
-
 import type { ReactNativeStyle } from '@emotion/native'
 import type { TextStyle } from 'react-native'
 import {
   interpolate,
   interpolateColor,
+  useAnimatedProps,
   useAnimatedStyle,
   useSharedValue
 } from 'react-native-reanimated'
@@ -25,14 +24,6 @@ export const PlainButton = (props: PlainButtonProps) => {
   const isPressable = !isDisabled && onPress
   const { color, spacing, typography } = useTheme()
   const pressed = useSharedValue(0)
-  const [isPressing, setIsPressing] = useState(false)
-
-  const handlePressIn = () => {
-    setIsPressing(true)
-  }
-  const handlePressOut = () => {
-    setIsPressing(false)
-  }
 
   // - Size Styles -
   const defaultStyles: ReactNativeStyle = {
@@ -107,6 +98,14 @@ export const PlainButton = (props: PlainButtonProps) => {
     [variant, isPressable]
   )
 
+  const animatedIconProps = useAnimatedProps(() => ({
+    fill: interpolateColor(
+      pressed.value,
+      [0, 1],
+      [dynamicStyles.default.text, dynamicStyles.press.text]
+    )
+  }))
+
   const textCss: TextStyle = useAnimatedStyle(
     () => ({
       ...(isPressable && {
@@ -122,11 +121,6 @@ export const PlainButton = (props: PlainButtonProps) => {
     [size, isPressable]
   )
 
-  const iconColor =
-    isPressing && isPressable
-      ? dynamicStyles.press.text
-      : dynamicStyles.default.text
-
   return (
     <BaseButton
       sharedValue={pressed}
@@ -134,12 +128,10 @@ export const PlainButton = (props: PlainButtonProps) => {
       styles={{ text: textCss, ...styles }}
       innerProps={{
         icon: {
-          fill: iconColor,
+          animatedProps: animatedIconProps,
           size: size === 'large' ? 'm' : 's'
         }
       }}
-      onPressIn={handlePressIn}
-      onPressOut={handlePressOut}
       {...baseProps}
     />
   )

--- a/packages/mobile/src/harmony-native/icons.ts
+++ b/packages/mobile/src/harmony-native/icons.ts
@@ -1,10 +1,14 @@
 import type { FunctionComponent } from 'react'
 
 import { type IconProps as HarmonyIconProps } from '@audius/harmony/src/components/icon'
+import type { AnimatedProps } from 'react-native-reanimated'
 import type { SvgProps } from 'react-native-svg'
 
 export type IconProps = Omit<SvgProps, 'color'> &
-  HarmonyIconProps & { fillSecondary?: string }
+  HarmonyIconProps &
+  AnimatedProps<SvgProps> & {
+    fillSecondary?: string
+  }
 
 export type IconComponent = FunctionComponent<IconProps>
 


### PR DESCRIPTION
### Description

Enables animated mobile icons, drastically improving filter-button and button icons. We can make further improvements to other pressable icons too. 

The impetus for this fix is to make the "show comments" plain button much smoother in the comments section.

This fix employs some somewhat subtle changes to the svgr-template.js. First thing it does is allow "animatedProps" passthrough for mobile, which is needed for animated icons: https://docs.swmansion.com/react-native-reanimated/docs/core/useAnimatedProps. Next, AnimatedPath is created and used only when "animatedProps" is provided. Finally, we do some subtle react-native-svg import rename: {Path as RNSVGPath), and define `Path = AnimatedPath | RNSVGPath` as needed. Note the underyling jsx looks something like this, which makes it work:
```
<Svg {...props}>
    <Path d={...} animatedProps={animatedProps} ... />
</Svg>
```


https://github.com/user-attachments/assets/4382411c-b2f3-4890-b7cd-b499205ea990
