### PR TITLE
[QA-1761] Fix mobile profile page username spacing

### DIFF
--- a/packages/mobile/src/screens/profile-screen/ProfileInfo.tsx
+++ b/packages/mobile/src/screens/profile-screen/ProfileInfo.tsx
@@ -93,7 +93,7 @@ export const ProfileInfo = (props: ProfileInfoProps) => {
     )
 
   return (
-    <Flex pointerEvents='box-none' pv='s'>
+    <Flex pointerEvents='box-none' pv='s' gap='s'>
       <Flex
         direction='row'
         justifyContent='flex-end'


### PR DESCRIPTION
Before: 
<img width="408" alt="image" src="https://github.com/user-attachments/assets/57cb70c5-75b6-429e-8e51-cb9c2c3e95f6">

After: 
<img width="408" alt="image" src="https://github.com/user-attachments/assets/6a8a4e69-f777-46f4-9326-1e6115be71a9">
