### PR TITLE
[PAY-3424] Restrict imports from SDK 'dist' folder in client code

### DIFF
--- a/packages/common/.eslintrc.js
+++ b/packages/common/.eslintrc.js
@@ -9,6 +9,18 @@ module.exports = {
         message:
           'Do NOT use `Promise.allSettled` as it will be undefined. Use `allSettled` from `utils/allSettled.ts` instead.'
       }
+    ],
+    'no-restricted-imports': [
+      'error',
+      {
+        patterns: [
+          {
+            group: ['@audius/sdk/dist*'],
+            message:
+              'Do not import from the SDK dist folder. If needed, update SDK to export the item you wish to use.'
+          }
+        ]
+      }
     ]
   }
 }

--- a/packages/mobile/.eslintrc.js
+++ b/packages/mobile/.eslintrc.js
@@ -57,6 +57,13 @@ module.exports = {
             message:
               'Use @audius/harmony-native instead. If needing to access an @audius/harmony export, reference it directly with @audius/harmony/src/..'
           }
+        ],
+        patterns: [
+          {
+            group: ['@audius/sdk/dist*'],
+            message:
+              'Do not import from the SDK dist folder. If needed, update SDK to export the item you wish to use.'
+          }
         ]
       }
     ]

--- a/packages/web/.eslintrc.js
+++ b/packages/web/.eslintrc.js
@@ -42,6 +42,11 @@ module.exports = {
           {
             group: ['react-spring*'],
             message: 'Please use @react-spring/web instead'
+          },
+          {
+            group: ['@audius/sdk/dist*'],
+            message:
+              'Do not import from the SDK dist folder. If needed, update SDK to export the item you wish to use.'
           }
         ]
       }


### PR DESCRIPTION
### Description
Direct imports from the `dist` folder often cause weird build or runtime issues for us. We shouldn't ever need to do this. It is still a pattern used for libs imports. But that code is now coming from a separate package. So this rule will generate an error for any direct `dist` imports from SDK. It applies only to web/mobile/common.

### How Has This Been Tested?
Temporarily added some code that breaks the rule and verified it triggers appropriately.
