### PR TITLE
[C-5164] Add max height to mobile ComposerInput

### DIFF
--- a/packages/mobile/src/components/composer-input/ComposerInput.tsx
+++ b/packages/mobile/src/components/composer-input/ComposerInput.tsx
@@ -66,7 +66,8 @@ const useStyles = makeStyles(({ spacing, palette, typography }) => ({
     backgroundColor: 'transparent',
     paddingLeft: spacing(4),
     paddingVertical: spacing(2),
-    borderRadius: spacing(1)
+    borderRadius: spacing(1),
+    maxHeight: 240
   },
   composeTextInput: {
     fontSize: typography.fontSize.medium,


### PR DESCRIPTION
### Description
Add a maxheight to the mobile ComposerInput to prevent it from overflowing the screen and soft locking the user

### How Has This Been Tested?
Manually Tested
