### PR TITLE
[C-5144] Fix dupe comments by ensuring deterministic order

### DIFF
--- a/packages/discovery-provider/src/queries/get_comments.py
+++ b/packages/discovery-provider/src/queries/get_comments.py
@@ -195,7 +195,6 @@ def get_track_comments(args, track_id, current_user_id=None):
                     MutedUser.muted_user_id == None,
                     MutedUser.is_delete == True,
                 ),  # Exclude muted users' comments
-                Comment.is_delete == False,
             )
             .having(
                 (func.count(ReplyCountAlias.comment_id) > 0)
@@ -209,6 +208,7 @@ def get_track_comments(args, track_id, current_user_id=None):
             .order_by(
                 # pinned comments at the top, tombstone comments at the bottom, then all others inbetween
                 desc(Comment.comment_id == pinned_comment_id),
+                asc(Comment.is_delete),  # required for tombstone
                 sort_method_order_by,
                 desc(func.sum(AggregateUser.follower_count)),  # karma
                 desc(Comment.created_at),

--- a/packages/discovery-provider/src/queries/get_comments.py
+++ b/packages/discovery-provider/src/queries/get_comments.py
@@ -118,15 +118,15 @@ def get_track_comments(args, track_id, current_user_id=None):
     offset, limit = format_offset(args), format_limit(
         args, default_limit=COMMENT_THREADS_LIMIT
     )
-
     # default to top sort
     sort_method = args.get("sort_method", "top")
-
-    sort_method_order_by = desc(Comment.created_at)
     if sort_method == "top":
         sort_method_order_by = desc(func.count(CommentReaction.comment_id))
+    elif sort_method == "newest":
+        sort_method_order_by = desc(Comment.created_at)
     elif sort_method == "timestamp":
         sort_method_order_by = asc(Comment.track_timestamp_s).nullslast()
+
     track_comments = []
     db = get_db_read_replica()
 


### PR DESCRIPTION
### Description
Currently, there are cases of dupe comments because there's no definitive deterministic order. For example, if one user leaves a bunch of comments with no reactions, the default top sort will have no reaction count to go off of. Then, the limit and offset become non-deterministic. 

This change simply adds two tie-breakers: karma + comment creation date. Also moved the is_delete to a filter to prevent surfacing of deleted coments. 
 
### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._

Ran on stage and confirmed duped comments were not re-produceable. 