### PR TITLE
[PAY-3437] Add names to chats sentry reports

### DIFF
--- a/packages/common/src/store/pages/chat/sagas.ts
+++ b/packages/common/src/store/pages/chat/sagas.ts
@@ -16,7 +16,6 @@ import {
 import { ulid } from 'ulid'
 
 import { Name } from '~/models/Analytics'
-import { ErrorLevel } from '~/models/ErrorReporting'
 import { ID } from '~/models/Identifiers'
 import { Status } from '~/models/Status'
 import { getAccountUser, getUserId } from '~/store/account/selectors'
@@ -26,7 +25,6 @@ import dayjs from '~/utils/dayjs'
 import {
   decodeHashId,
   encodeHashId,
-  ErrorWithCause,
   makeBlastChatId,
   removeNullable
 } from '../../../utils'
@@ -48,6 +46,7 @@ const {
   createChatBlast,
   createChatSucceeded,
   fetchUnreadMessagesCount,
+  fetchUnreadMessagesCountSucceeded,
   fetchUnreadMessagesCountFailed,
   goToChat,
   fetchChatIfNecessary,
@@ -114,7 +113,12 @@ function* fetchUsersForChats(chats: UserChat[]) {
 
 function* doFetchUnreadMessagesCount() {
   try {
-    throw new Error('test2')
+    const audiusSdk = yield* getContext('audiusSdk')
+    const sdk = yield* call(audiusSdk)
+    const response = yield* call([sdk.chats, sdk.chats.getUnreadCount])
+    yield* put(
+      fetchUnreadMessagesCountSucceeded({ unreadMessagesCount: response.data })
+    )
   } catch (e) {
     yield* put(fetchUnreadMessagesCountFailed())
     const reportToSentry = yield* getContext('reportToSentry')

--- a/packages/common/src/store/pages/chat/sagas.ts
+++ b/packages/common/src/store/pages/chat/sagas.ts
@@ -120,8 +120,7 @@ function* doFetchUnreadMessagesCount() {
     const reportToSentry = yield* getContext('reportToSentry')
     reportToSentry({
       name: 'Chats',
-      level: ErrorLevel.Error,
-      error: new ErrorWithCause('fetchUnreadMessagesCountFailed', e)
+      error: e as Error
     })
   }
 }
@@ -168,8 +167,7 @@ function* doFetchLatestChats() {
     const reportToSentry = yield* getContext('reportToSentry')
     reportToSentry({
       name: 'Chats',
-      level: ErrorLevel.Error,
-      error: new ErrorWithCause('fetchLatestChatsFailed', e)
+      error: e as Error
     })
   }
 }
@@ -196,8 +194,7 @@ function* doFetchMoreChats() {
     const reportToSentry = yield* getContext('reportToSentry')
     reportToSentry({
       name: 'Chats',
-      level: ErrorLevel.Error,
-      error: new ErrorWithCause('fetchMoreChatsFailed', e)
+      error: e as Error
     })
   }
 }
@@ -261,8 +258,7 @@ function* doFetchLatestMessages(
     const reportToSentry = yield* getContext('reportToSentry')
     reportToSentry({
       name: 'Chats',
-      level: ErrorLevel.Error,
-      error: new ErrorWithCause('fetchLatestChatMessagesFailed', e),
+      error: e as Error,
       additionalInfo: {
         chatId
       }
@@ -323,8 +319,7 @@ function* doFetchMoreMessages(action: ReturnType<typeof fetchMoreMessages>) {
     const reportToSentry = yield* getContext('reportToSentry')
     reportToSentry({
       name: 'Chats',
-      level: ErrorLevel.Error,
-      error: new ErrorWithCause('fetchMoreMessagesFailed', e),
+      error: e as Error,
       additionalInfo: {
         chatId
       }
@@ -371,8 +366,7 @@ function* doSetMessageReaction(action: ReturnType<typeof setMessageReaction>) {
     const reportToSentry = yield* getContext('reportToSentry')
     reportToSentry({
       name: 'Chats',
-      level: ErrorLevel.Error,
-      error: new ErrorWithCause('setMessageReactionFailed', e),
+      error: e as Error,
       additionalInfo: {
         chatId,
         messageId,
@@ -438,8 +432,7 @@ function* doCreateChat(action: ReturnType<typeof createChat>) {
     const reportToSentry = yield* getContext('reportToSentry')
     reportToSentry({
       name: 'Chats',
-      level: ErrorLevel.Error,
-      error: new ErrorWithCause('createChatFailed', e),
+      error: e as Error,
       additionalInfo: {
         userIds
       }
@@ -506,8 +499,7 @@ function* doCreateChatBlast(action: ReturnType<typeof createChatBlast>) {
     const reportToSentry = yield* getContext('reportToSentry')
     reportToSentry({
       name: 'Chats',
-      level: ErrorLevel.Error,
-      error: new ErrorWithCause('createChatBlastFailed', e),
+      error: e as Error,
       additionalInfo: {
         audience,
         audienceContentId,
@@ -546,8 +538,7 @@ function* doMarkChatAsRead(action: ReturnType<typeof markChatAsRead>) {
     const reportToSentry = yield* getContext('reportToSentry')
     reportToSentry({
       name: 'Chats',
-      level: ErrorLevel.Error,
-      error: new ErrorWithCause('markChatAsReadFailed', e),
+      error: e as Error,
       additionalInfo: {
         chatId
       }
@@ -624,8 +615,7 @@ function* doSendMessage(action: ReturnType<typeof sendMessage>) {
     const reportToSentry = yield* getContext('reportToSentry')
     reportToSentry({
       name: 'Chats',
-      level: ErrorLevel.Error,
-      error: new ErrorWithCause('sendMessageFailed', e),
+      error: e as Error,
       additionalInfo: {
         chatId,
         messageId: messageIdToUse
@@ -669,8 +659,7 @@ function* doFetchBlockees() {
     const reportToSentry = yield* getContext('reportToSentry')
     reportToSentry({
       name: 'Chats',
-      level: ErrorLevel.Error,
-      error: new ErrorWithCause('fetchBlockeesFailed', e)
+      error: e as Error
     })
   }
 }
@@ -691,8 +680,7 @@ function* doFetchBlockers() {
     const reportToSentry = yield* getContext('reportToSentry')
     reportToSentry({
       name: 'Chats',
-      level: ErrorLevel.Error,
-      error: new ErrorWithCause('fetchBlockersFailed', e)
+      error: e as Error
     })
   }
 }
@@ -715,8 +703,7 @@ function* doBlockUser(action: ReturnType<typeof blockUser>) {
     const reportToSentry = yield* getContext('reportToSentry')
     reportToSentry({
       name: 'Chats',
-      level: ErrorLevel.Error,
-      error: new ErrorWithCause('blockUserFailed', e)
+      error: e as Error
     })
     yield* call(
       track,
@@ -737,8 +724,7 @@ function* doUnblockUser(action: ReturnType<typeof unblockUser>) {
     const reportToSentry = yield* getContext('reportToSentry')
     reportToSentry({
       name: 'Chats',
-      level: ErrorLevel.Error,
-      error: new ErrorWithCause('unblockUserFailed', e)
+      error: e as Error
     })
   }
 }
@@ -769,8 +755,7 @@ function* doFetchPermissions(action: ReturnType<typeof fetchPermissions>) {
     const reportToSentry = yield* getContext('reportToSentry')
     reportToSentry({
       name: 'Chats',
-      level: ErrorLevel.Error,
-      error: new ErrorWithCause('fetchPermissionsFailed', e)
+      error: e as Error
     })
   }
 }
@@ -798,8 +783,7 @@ function* doFetchLinkUnfurlMetadata(
     const reportToSentry = yield* getContext('reportToSentry')
     reportToSentry({
       name: 'Chats',
-      level: ErrorLevel.Error,
-      error: new ErrorWithCause('fetchLinkUnfurlMetadataFailed', e),
+      error: e as Error,
       additionalInfo: {
         chatId,
         messageId,
@@ -829,8 +813,7 @@ function* doDeleteChat(action: ReturnType<typeof deleteChat>) {
     const reportToSentry = yield* getContext('reportToSentry')
     reportToSentry({
       name: 'Chats',
-      level: ErrorLevel.Error,
-      error: new ErrorWithCause('deleteChatFailed', e),
+      error: e as Error,
       additionalInfo: {
         chatId
       }
@@ -845,8 +828,7 @@ function* doLogError({ payload: { error } }: ReturnType<typeof logError>) {
   const { code, url } = error
   reportToSentry({
     name: 'Chats',
-    level: ErrorLevel.Error,
-    error: new ErrorWithCause('Chat Websocket Error', error),
+    error,
     additionalInfo: {
       code,
       url

--- a/packages/common/src/store/pages/chat/sagas.ts
+++ b/packages/common/src/store/pages/chat/sagas.ts
@@ -125,6 +125,7 @@ function* doFetchUnreadMessagesCount() {
     yield* put(fetchUnreadMessagesCountFailed())
     const reportToSentry = yield* getContext('reportToSentry')
     reportToSentry({
+      name: 'fetchUnreadMessagesCountFailed',
       level: ErrorLevel.Error,
       error: e as Error
     })
@@ -173,6 +174,7 @@ function* doFetchLatestChats() {
     yield* put(fetchMoreChatsFailed())
     const reportToSentry = yield* getContext('reportToSentry')
     reportToSentry({
+      name: 'fetchLatestChatsFailed',
       level: ErrorLevel.Error,
       error: e as Error
     })
@@ -201,6 +203,7 @@ function* doFetchMoreChats() {
     yield* put(fetchMoreChatsFailed())
     const reportToSentry = yield* getContext('reportToSentry')
     reportToSentry({
+      name: 'fetchMoreChatsFailed',
       level: ErrorLevel.Error,
       error: e as Error
     })
@@ -266,6 +269,7 @@ function* doFetchLatestMessages(
     yield* put(fetchMoreMessagesFailed({ chatId }))
     const reportToSentry = yield* getContext('reportToSentry')
     reportToSentry({
+      name: 'fetchLatestChatMessagesFailed',
       level: ErrorLevel.Error,
       error: e as Error,
       additionalInfo: {
@@ -328,6 +332,7 @@ function* doFetchMoreMessages(action: ReturnType<typeof fetchMoreMessages>) {
     yield* put(fetchMoreMessagesFailed({ chatId }))
     const reportToSentry = yield* getContext('reportToSentry')
     reportToSentry({
+      name: 'fetchMoreChatMessagesFailed',
       level: ErrorLevel.Error,
       error: e as Error,
       additionalInfo: {
@@ -376,6 +381,7 @@ function* doSetMessageReaction(action: ReturnType<typeof setMessageReaction>) {
     yield* put(setMessageReactionFailed(action.payload))
     const reportToSentry = yield* getContext('reportToSentry')
     reportToSentry({
+      name: 'setMessageReactionFailed',
       level: ErrorLevel.Error,
       error: e as Error,
       additionalInfo: {
@@ -443,6 +449,7 @@ function* doCreateChat(action: ReturnType<typeof createChat>) {
     )
     const reportToSentry = yield* getContext('reportToSentry')
     reportToSentry({
+      name: 'createChatFailed',
       level: ErrorLevel.Error,
       error: e as Error,
       additionalInfo: {
@@ -511,6 +518,7 @@ function* doCreateChatBlast(action: ReturnType<typeof createChatBlast>) {
     )
     const reportToSentry = yield* getContext('reportToSentry')
     reportToSentry({
+      name: 'createChatBlastFailed',
       level: ErrorLevel.Error,
       error: e as Error,
       additionalInfo: {
@@ -551,6 +559,7 @@ function* doMarkChatAsRead(action: ReturnType<typeof markChatAsRead>) {
     yield* put(markChatAsReadFailed({ chatId }))
     const reportToSentry = yield* getContext('reportToSentry')
     reportToSentry({
+      name: 'markChatAsReadFailed',
       level: ErrorLevel.Error,
       error: e as Error,
       additionalInfo: {
@@ -629,6 +638,7 @@ function* doSendMessage(action: ReturnType<typeof sendMessage>) {
     }
     const reportToSentry = yield* getContext('reportToSentry')
     reportToSentry({
+      name: 'sendMessageFailed',
       level: ErrorLevel.Error,
       error: e as Error,
       additionalInfo: {
@@ -674,6 +684,7 @@ function* doFetchBlockees() {
     console.error('fetchBlockeesFailed', e)
     const reportToSentry = yield* getContext('reportToSentry')
     reportToSentry({
+      name: 'fetchBlockeesFailed',
       level: ErrorLevel.Error,
       error: e as Error
     })
@@ -696,6 +707,7 @@ function* doFetchBlockers() {
     console.error('fetchBlockersFailed', e)
     const reportToSentry = yield* getContext('reportToSentry')
     reportToSentry({
+      name: 'fetchBlockersFailed',
       level: ErrorLevel.Error,
       error: e as Error
     })
@@ -720,6 +732,7 @@ function* doBlockUser(action: ReturnType<typeof blockUser>) {
     console.error('blockUserFailed', e)
     const reportToSentry = yield* getContext('reportToSentry')
     reportToSentry({
+      name: 'blockUserFailed',
       level: ErrorLevel.Error,
       error: e as Error
     })
@@ -742,6 +755,7 @@ function* doUnblockUser(action: ReturnType<typeof unblockUser>) {
     console.error('unblockUserFailed', e)
     const reportToSentry = yield* getContext('reportToSentry')
     reportToSentry({
+      name: 'unblockUserFailed',
       level: ErrorLevel.Error,
       error: e as Error
     })
@@ -774,6 +788,7 @@ function* doFetchPermissions(action: ReturnType<typeof fetchPermissions>) {
     console.error('fetchPermissionsFailed', e)
     const reportToSentry = yield* getContext('reportToSentry')
     reportToSentry({
+      name: 'fetchPermissionsFailed',
       level: ErrorLevel.Error,
       error: e as Error
     })
@@ -803,6 +818,7 @@ function* doFetchLinkUnfurlMetadata(
     console.error('fetchUnfurlFailed', e)
     const reportToSentry = yield* getContext('reportToSentry')
     reportToSentry({
+      name: 'fetchLinkUnfurlMetadataFailed',
       level: ErrorLevel.Error,
       error: e as Error,
       additionalInfo: {
@@ -834,6 +850,7 @@ function* doDeleteChat(action: ReturnType<typeof deleteChat>) {
     console.error('deleteChat failed', e, { chatId })
     const reportToSentry = yield* getContext('reportToSentry')
     reportToSentry({
+      name: 'deleteChatFailed',
       level: ErrorLevel.Error,
       error: e as Error,
       additionalInfo: {

--- a/packages/common/src/store/pages/chat/sagas.ts
+++ b/packages/common/src/store/pages/chat/sagas.ts
@@ -28,8 +28,7 @@ import {
   encodeHashId,
   ErrorWithCause,
   makeBlastChatId,
-  removeNullable,
-  toErrorWithMessage
+  removeNullable
 } from '../../../utils'
 import { cacheUsersActions } from '../../cache'
 import { getContext } from '../../effects'
@@ -49,7 +48,6 @@ const {
   createChatBlast,
   createChatSucceeded,
   fetchUnreadMessagesCount,
-  fetchUnreadMessagesCountSucceeded,
   fetchUnreadMessagesCountFailed,
   goToChat,
   fetchChatIfNecessary,

--- a/packages/common/src/store/pages/chat/sagas.ts
+++ b/packages/common/src/store/pages/chat/sagas.ts
@@ -26,8 +26,10 @@ import dayjs from '~/utils/dayjs'
 import {
   decodeHashId,
   encodeHashId,
+  ErrorWithCause,
   makeBlastChatId,
-  removeNullable
+  removeNullable,
+  toErrorWithMessage
 } from '../../../utils'
 import { cacheUsersActions } from '../../cache'
 import { getContext } from '../../effects'
@@ -114,20 +116,14 @@ function* fetchUsersForChats(chats: UserChat[]) {
 
 function* doFetchUnreadMessagesCount() {
   try {
-    const audiusSdk = yield* getContext('audiusSdk')
-    const sdk = yield* call(audiusSdk)
-    const response = yield* call([sdk.chats, sdk.chats.getUnreadCount])
-    yield* put(
-      fetchUnreadMessagesCountSucceeded({ unreadMessagesCount: response.data })
-    )
+    throw new Error('test2')
   } catch (e) {
-    console.error('fetchUnreadMessagesCountFailed', e)
     yield* put(fetchUnreadMessagesCountFailed())
     const reportToSentry = yield* getContext('reportToSentry')
     reportToSentry({
-      name: 'fetchUnreadMessagesCountFailed',
+      name: 'Chats',
       level: ErrorLevel.Error,
-      error: e as Error
+      error: new ErrorWithCause('fetchUnreadMessagesCountFailed', e)
     })
   }
 }
@@ -170,13 +166,12 @@ function* doFetchLatestChats() {
       })
     )
   } catch (e) {
-    console.error('fetchLatestChatsFailed', e)
     yield* put(fetchMoreChatsFailed())
     const reportToSentry = yield* getContext('reportToSentry')
     reportToSentry({
-      name: 'fetchLatestChatsFailed',
+      name: 'Chats',
       level: ErrorLevel.Error,
-      error: e as Error
+      error: new ErrorWithCause('fetchLatestChatsFailed', e)
     })
   }
 }
@@ -199,13 +194,12 @@ function* doFetchMoreChats() {
     yield* fetchUsersForChats(response.data)
     yield* put(fetchMoreChatsSucceeded(response))
   } catch (e) {
-    console.error('fetchMoreChatsFailed', e)
     yield* put(fetchMoreChatsFailed())
     const reportToSentry = yield* getContext('reportToSentry')
     reportToSentry({
-      name: 'fetchMoreChatsFailed',
+      name: 'Chats',
       level: ErrorLevel.Error,
-      error: e as Error
+      error: new ErrorWithCause('fetchMoreChatsFailed', e)
     })
   }
 }
@@ -265,13 +259,12 @@ function* doFetchLatestMessages(
       })
     )
   } catch (e) {
-    console.error('fetchLatestChatMessagesFailed', e)
     yield* put(fetchMoreMessagesFailed({ chatId }))
     const reportToSentry = yield* getContext('reportToSentry')
     reportToSentry({
-      name: 'fetchLatestChatMessagesFailed',
+      name: 'Chats',
       level: ErrorLevel.Error,
-      error: e as Error,
+      error: new ErrorWithCause('fetchLatestChatMessagesFailed', e),
       additionalInfo: {
         chatId
       }
@@ -328,13 +321,12 @@ function* doFetchMoreMessages(action: ReturnType<typeof fetchMoreMessages>) {
       })
     )
   } catch (e) {
-    console.error('fetchMoreChatMessagesFailed', e)
     yield* put(fetchMoreMessagesFailed({ chatId }))
     const reportToSentry = yield* getContext('reportToSentry')
     reportToSentry({
-      name: 'fetchMoreChatMessagesFailed',
+      name: 'Chats',
       level: ErrorLevel.Error,
-      error: e as Error,
+      error: new ErrorWithCause('fetchMoreMessagesFailed', e),
       additionalInfo: {
         chatId
       }
@@ -377,13 +369,12 @@ function* doSetMessageReaction(action: ReturnType<typeof setMessageReaction>) {
       })
     )
   } catch (e) {
-    console.error('setMessageReactionFailed', e)
     yield* put(setMessageReactionFailed(action.payload))
     const reportToSentry = yield* getContext('reportToSentry')
     reportToSentry({
-      name: 'setMessageReactionFailed',
+      name: 'Chats',
       level: ErrorLevel.Error,
-      error: e as Error,
+      error: new ErrorWithCause('setMessageReactionFailed', e),
       additionalInfo: {
         chatId,
         messageId,
@@ -440,7 +431,6 @@ function* doCreateChat(action: ReturnType<typeof createChat>) {
       yield* call(track, make({ eventName: Name.CREATE_CHAT_SUCCESS }))
     }
   } catch (e) {
-    console.error('createChatFailed', e)
     yield* put(
       toast({
         type: 'error',
@@ -449,9 +439,9 @@ function* doCreateChat(action: ReturnType<typeof createChat>) {
     )
     const reportToSentry = yield* getContext('reportToSentry')
     reportToSentry({
-      name: 'createChatFailed',
+      name: 'Chats',
       level: ErrorLevel.Error,
-      error: e as Error,
+      error: new ErrorWithCause('createChatFailed', e),
       additionalInfo: {
         userIds
       }
@@ -509,7 +499,6 @@ function* doCreateChatBlast(action: ReturnType<typeof createChatBlast>) {
       yield* call(track, make({ eventName: Name.CREATE_CHAT_SUCCESS }))
     }
   } catch (e) {
-    console.error('createChatBlastFailed', e)
     yield* put(
       toast({
         type: 'error',
@@ -518,9 +507,9 @@ function* doCreateChatBlast(action: ReturnType<typeof createChatBlast>) {
     )
     const reportToSentry = yield* getContext('reportToSentry')
     reportToSentry({
-      name: 'createChatBlastFailed',
+      name: 'Chats',
       level: ErrorLevel.Error,
-      error: e as Error,
+      error: new ErrorWithCause('createChatBlastFailed', e),
       additionalInfo: {
         audience,
         audienceContentId,
@@ -555,13 +544,12 @@ function* doMarkChatAsRead(action: ReturnType<typeof markChatAsRead>) {
       yield* put(markChatAsReadFailed({ chatId }))
     }
   } catch (e) {
-    console.error('markChatAsReadFailed', e)
     yield* put(markChatAsReadFailed({ chatId }))
     const reportToSentry = yield* getContext('reportToSentry')
     reportToSentry({
-      name: 'markChatAsReadFailed',
+      name: 'Chats',
       level: ErrorLevel.Error,
-      error: e as Error,
+      error: new ErrorWithCause('markChatAsReadFailed', e),
       additionalInfo: {
         chatId
       }
@@ -617,7 +605,6 @@ function* doSendMessage(action: ReturnType<typeof sendMessage>) {
     }
     yield* call(track, make({ eventName: Name.SEND_MESSAGE_SUCCESS }))
   } catch (e) {
-    console.error('sendMessageFailed', e)
     yield* put(sendMessageFailed({ chatId, messageId: messageIdToUse }))
 
     // Fetch the chat to see if permissions need rechecking
@@ -638,9 +625,9 @@ function* doSendMessage(action: ReturnType<typeof sendMessage>) {
     }
     const reportToSentry = yield* getContext('reportToSentry')
     reportToSentry({
-      name: 'sendMessageFailed',
+      name: 'Chats',
       level: ErrorLevel.Error,
-      error: e as Error,
+      error: new ErrorWithCause('sendMessageFailed', e),
       additionalInfo: {
         chatId,
         messageId: messageIdToUse
@@ -681,12 +668,11 @@ function* doFetchBlockees() {
       })
     )
   } catch (e) {
-    console.error('fetchBlockeesFailed', e)
     const reportToSentry = yield* getContext('reportToSentry')
     reportToSentry({
-      name: 'fetchBlockeesFailed',
+      name: 'Chats',
       level: ErrorLevel.Error,
-      error: e as Error
+      error: new ErrorWithCause('fetchBlockeesFailed', e)
     })
   }
 }
@@ -704,12 +690,11 @@ function* doFetchBlockers() {
       })
     )
   } catch (e) {
-    console.error('fetchBlockersFailed', e)
     const reportToSentry = yield* getContext('reportToSentry')
     reportToSentry({
-      name: 'fetchBlockersFailed',
+      name: 'Chats',
       level: ErrorLevel.Error,
-      error: e as Error
+      error: new ErrorWithCause('fetchBlockersFailed', e)
     })
   }
 }
@@ -729,12 +714,11 @@ function* doBlockUser(action: ReturnType<typeof blockUser>) {
       make({ eventName: Name.BLOCK_USER_SUCCESS, blockedUserId: userId })
     )
   } catch (e) {
-    console.error('blockUserFailed', e)
     const reportToSentry = yield* getContext('reportToSentry')
     reportToSentry({
-      name: 'blockUserFailed',
+      name: 'Chats',
       level: ErrorLevel.Error,
-      error: e as Error
+      error: new ErrorWithCause('blockUserFailed', e)
     })
     yield* call(
       track,
@@ -752,12 +736,11 @@ function* doUnblockUser(action: ReturnType<typeof unblockUser>) {
     })
     yield* put(fetchBlockees())
   } catch (e) {
-    console.error('unblockUserFailed', e)
     const reportToSentry = yield* getContext('reportToSentry')
     reportToSentry({
-      name: 'unblockUserFailed',
+      name: 'Chats',
       level: ErrorLevel.Error,
-      error: e as Error
+      error: new ErrorWithCause('unblockUserFailed', e)
     })
   }
 }
@@ -785,12 +768,11 @@ function* doFetchPermissions(action: ReturnType<typeof fetchPermissions>) {
       })
     )
   } catch (e) {
-    console.error('fetchPermissionsFailed', e)
     const reportToSentry = yield* getContext('reportToSentry')
     reportToSentry({
-      name: 'fetchPermissionsFailed',
+      name: 'Chats',
       level: ErrorLevel.Error,
-      error: e as Error
+      error: new ErrorWithCause('fetchPermissionsFailed', e)
     })
   }
 }
@@ -815,12 +797,11 @@ function* doFetchLinkUnfurlMetadata(
       fetchLinkUnfurlSucceeded({ chatId, messageId, unfurlMetadata: data[0] })
     )
   } catch (e) {
-    console.error('fetchUnfurlFailed', e)
     const reportToSentry = yield* getContext('reportToSentry')
     reportToSentry({
-      name: 'fetchLinkUnfurlMetadataFailed',
+      name: 'Chats',
       level: ErrorLevel.Error,
-      error: e as Error,
+      error: new ErrorWithCause('fetchLinkUnfurlMetadataFailed', e),
       additionalInfo: {
         chatId,
         messageId,
@@ -847,12 +828,11 @@ function* doDeleteChat(action: ReturnType<typeof deleteChat>) {
     yield* put(deleteChatSucceeded({ chatId }))
     yield* call(track, make({ eventName: Name.DELETE_CHAT_SUCCESS }))
   } catch (e) {
-    console.error('deleteChat failed', e, { chatId })
     const reportToSentry = yield* getContext('reportToSentry')
     reportToSentry({
-      name: 'deleteChatFailed',
+      name: 'Chats',
       level: ErrorLevel.Error,
-      error: e as Error,
+      error: new ErrorWithCause('deleteChatFailed', e),
       additionalInfo: {
         chatId
       }
@@ -866,8 +846,9 @@ function* doLogError({ payload: { error } }: ReturnType<typeof logError>) {
   const reportToSentry = yield* getContext('reportToSentry')
   const { code, url } = error
   reportToSentry({
+    name: 'Chats',
     level: ErrorLevel.Error,
-    error,
+    error: new ErrorWithCause('Chat Websocket Error', error),
     additionalInfo: {
       code,
       url

--- a/packages/common/src/utils/error.ts
+++ b/packages/common/src/utils/error.ts
@@ -32,15 +32,3 @@ export function getErrorMessage(error: unknown) {
 
 export const isResponseError = (error: unknown): error is ResponseError =>
   error instanceof Error && error.name === 'ResponseError'
-
-export class ErrorWithCause extends Error {
-  cause: unknown
-
-  constructor(message: string, cause?: unknown) {
-    super(message)
-    this.name = 'ErrorWithCause'
-    this.cause = cause
-
-    Object.setPrototypeOf(this, ErrorWithCause.prototype)
-  }
-}

--- a/packages/common/src/utils/error.ts
+++ b/packages/common/src/utils/error.ts
@@ -32,3 +32,15 @@ export function getErrorMessage(error: unknown) {
 
 export const isResponseError = (error: unknown): error is ResponseError =>
   error instanceof Error && error.name === 'ResponseError'
+
+export class ErrorWithCause extends Error {
+  cause: unknown
+
+  constructor(message: string, cause?: unknown) {
+    super(message)
+    this.name = 'ErrorWithCause'
+    this.cause = cause
+
+    Object.setPrototypeOf(this, ErrorWithCause.prototype)
+  }
+}

--- a/packages/mobile/src/screens/settings-screen/InboxSettingsScreenNew.tsx
+++ b/packages/mobile/src/screens/settings-screen/InboxSettingsScreenNew.tsx
@@ -8,7 +8,6 @@ import { Formik } from 'formik'
 
 import { Button, Flex, IconMessage } from '@audius/harmony-native'
 import { HeaderShadow, ScreenContent } from 'app/components/core'
-import { audiusSdk } from 'app/services/sdk/audius-sdk'
 
 import { FormScreen } from '../form-screen'
 
@@ -21,9 +20,7 @@ const messages = {
 
 export const InboxSettingsScreenNew = () => {
   const { permissions, doFetchPermissions, savePermissions } =
-    useSetInboxPermissions({
-      audiusSdk
-    })
+    useSetInboxPermissions()
 
   const initialValues = useMemo(() => {
     return transformPermitListToMap(

--- a/packages/web/src/components/inbox-settings-modal/InboxSettingsModalNew.tsx
+++ b/packages/web/src/components/inbox-settings-modal/InboxSettingsModalNew.tsx
@@ -22,7 +22,6 @@ import { ChatPermission } from '@audius/sdk'
 import { Formik, useField, useFormikContext } from 'formik'
 
 import { useModalState } from 'common/hooks/useModalState'
-import { audiusSdk } from 'services/audius-sdk'
 
 const messages = {
   title: 'Inbox Settings',
@@ -84,9 +83,7 @@ export const InboxSettingsModalNew = () => {
     doFetchPermissions,
     permissionsStatus,
     savePermissions
-  } = useSetInboxPermissions({
-    audiusSdk
-  })
+  } = useSetInboxPermissions()
 
   const handleSave = useCallback(
     (values: InboxSettingsFormValues) => {


### PR DESCRIPTION
### Description
- update sentry errors to all use same name
- remove console.errors (no need to send duplicate data to sentry?)

### How Has This Been Tested?
Tested with local events sending to sentry being turned on
Example sentry event: https://audius.sentry.io/issues/5991820262/?query=is%3Aunresolved%20issue.priority%3A%5Bhigh%2C%20medium%5D&referrer=issue-stream&statsPeriod=24h&stream_index=1
Added alert: https://audius.sentry.io/alerts/rules/audius-client/15506983/details/
