### PR TITLE
Fix withdrawals not showing coinflow modal

### DIFF
--- a/packages/web/src/store/application/ui/withdraw-usdc/sagas.ts
+++ b/packages/web/src/store/application/ui/withdraw-usdc/sagas.ts
@@ -32,7 +32,8 @@ const {
   coinflowWithdrawalSucceeded,
   withdrawUSDCFailed,
   withdrawUSDCSucceeded,
-  cleanup: cleanupWithdrawUSDC
+  cleanup: cleanupWithdrawUSDC,
+  updateAmount
 } = withdrawUSDCActions
 const { set: setWithdrawUSDCModalData, close: closeWithdrawUSDCModal } =
   withdrawUSDCModalActions
@@ -110,6 +111,8 @@ function* doWithdrawUSDCCoinflow({
       signature,
       'finalized'
     )
+
+    yield* put(updateAmount({ amount }))
 
     yield* call(
       track,


### PR DESCRIPTION
### Description

The Coinflow modal wasn't being rendered because the amount was unset.

### How Has This Been Tested?

Tested locally against prod.