### PR TITLE
[PAY-3347] Analytics for create chat blast funnel

### DIFF
--- a/packages/common/src/models/Analytics.ts
+++ b/packages/common/src/models/Analytics.ts
@@ -2315,7 +2315,7 @@ type CreateChatBlastSuccess = {
   eventName: Name.CREATE_CHAT_BLAST_SUCCESS
   audience: string
   audienceContentType?: string
-  audienceContentId?: string
+  audienceContentId?: ID
   sentBy: ID
 }
 
@@ -2323,7 +2323,7 @@ type CreateChatBlastFailure = {
   eventName: Name.CREATE_CHAT_BLAST_FAILURE
   audience: string
   audienceContentType?: string
-  audienceContentId?: string
+  audienceContentId?: ID
   sentBy?: ID
 }
 
@@ -2331,7 +2331,7 @@ type ChatBlastMessageSent = {
   eventName: Name.CHAT_BLAST_MESSAGE_SENT
   audience: string
   audienceContentType?: string
-  audienceContentId?: string
+  audienceContentId?: ID
 }
 
 type SendMessageSuccess = {

--- a/packages/common/src/models/Analytics.ts
+++ b/packages/common/src/models/Analytics.ts
@@ -482,8 +482,10 @@ export enum Name {
   // Chat
   CREATE_CHAT_SUCCESS = 'Create Chat: Success',
   CREATE_CHAT_FAILURE = 'Create Chat: Failure',
-  CREATE_CHAT_BLAST_SUCCESS = 'Create Chat Blast: Success',
-  CREATE_CHAT_BLAST_FAILURE = 'Create Chat Blast: Failure',
+  CHAT_BLAST_CTA_CLICKED = 'Chat Blast: CTA Clicked',
+  CREATE_CHAT_BLAST_SUCCESS = 'Chat Blast: Create - Success',
+  CREATE_CHAT_BLAST_FAILURE = 'Chat Blast: Create - Failure',
+  CHAT_BLAST_MESSAGE_SENT = 'Chat Blast: Message Sent',
   SEND_MESSAGE_SUCCESS = 'Send Message: Success',
   SEND_MESSAGE_FAILURE = 'Send Message: Failure',
   DELETE_CHAT_SUCCESS = 'Delete Chat: Success',
@@ -2297,6 +2299,10 @@ type ConnectWalletError = {
   error: string
 }
 
+type ChatBlastCTAClicked = {
+  eventName: Name.CHAT_BLAST_CTA_CLICKED
+}
+
 type CreateChatSuccess = {
   eventName: Name.CREATE_CHAT_SUCCESS
 }
@@ -2309,7 +2315,7 @@ type CreateChatBlastSuccess = {
   eventName: Name.CREATE_CHAT_BLAST_SUCCESS
   audience: string
   audienceContentType?: string
-  audienceContentId?: number
+  audienceContentId?: string
   sentBy: ID
 }
 
@@ -2317,8 +2323,15 @@ type CreateChatBlastFailure = {
   eventName: Name.CREATE_CHAT_BLAST_FAILURE
   audience: string
   audienceContentType?: string
-  audienceContentId?: number
+  audienceContentId?: string
   sentBy?: ID
+}
+
+type ChatBlastMessageSent = {
+  eventName: Name.CHAT_BLAST_MESSAGE_SENT
+  audience: string
+  audienceContentType?: string
+  audienceContentId?: string
 }
 
 type SendMessageSuccess = {
@@ -2761,7 +2774,8 @@ export type AllTrackingEvents =
   | ConnectWalletAlreadyAssociated
   | ConnectWalletAssociationError
   | ConnectWalletError
-  | SendMessageSuccess
+  | ChatBlastCTAClicked
+  | ChatBlastMessageSent
   | CreateChatSuccess
   | CreateChatFailure
   | CreateChatBlastSuccess

--- a/packages/common/src/models/Analytics.ts
+++ b/packages/common/src/models/Analytics.ts
@@ -482,6 +482,8 @@ export enum Name {
   // Chat
   CREATE_CHAT_SUCCESS = 'Create Chat: Success',
   CREATE_CHAT_FAILURE = 'Create Chat: Failure',
+  CREATE_CHAT_BLAST_SUCCESS = 'Create Chat Blast: Success',
+  CREATE_CHAT_BLAST_FAILURE = 'Create Chat Blast: Failure',
   SEND_MESSAGE_SUCCESS = 'Send Message: Success',
   SEND_MESSAGE_FAILURE = 'Send Message: Failure',
   DELETE_CHAT_SUCCESS = 'Delete Chat: Success',
@@ -2303,6 +2305,22 @@ type CreateChatFailure = {
   eventName: Name.CREATE_CHAT_FAILURE
 }
 
+type CreateChatBlastSuccess = {
+  eventName: Name.CREATE_CHAT_BLAST_SUCCESS
+  audience: string
+  audienceContentType?: string
+  audienceContentId?: number
+  sentBy: ID
+}
+
+type CreateChatBlastFailure = {
+  eventName: Name.CREATE_CHAT_BLAST_FAILURE
+  audience: string
+  audienceContentType?: string
+  audienceContentId?: number
+  sentBy?: ID
+}
+
 type SendMessageSuccess = {
   eventName: Name.SEND_MESSAGE_SUCCESS
 }
@@ -2746,6 +2764,8 @@ export type AllTrackingEvents =
   | SendMessageSuccess
   | CreateChatSuccess
   | CreateChatFailure
+  | CreateChatBlastSuccess
+  | CreateChatBlastFailure
   | SendMessageSuccess
   | SendMessageFailure
   | DeleteChatSuccess

--- a/packages/common/src/store/pages/chat/sagas.ts
+++ b/packages/common/src/store/pages/chat/sagas.ts
@@ -1,5 +1,6 @@
 import {
   ChatBlast,
+  HashId,
   type ChatMessage,
   type TypedCommsResponse,
   type UserChat,
@@ -505,7 +506,7 @@ function* doCreateChatBlast(action: ReturnType<typeof createChatBlast>) {
           eventName: Name.CREATE_CHAT_BLAST_SUCCESS,
           audience,
           audienceContentType,
-          audienceContentId: encodedContentId,
+          audienceContentId,
           sentBy: currentUserId
         })
       )
@@ -529,17 +530,13 @@ function* doCreateChatBlast(action: ReturnType<typeof createChatBlast>) {
       }
     })
 
-    const encodedContentId = audienceContentId
-      ? encodeHashId(audienceContentId)
-      : undefined
-
     yield* call(
       track,
       make({
         eventName: Name.CREATE_CHAT_BLAST_FAILURE,
         audience,
         audienceContentType,
-        audienceContentId: encodedContentId,
+        audienceContentId,
         sentBy: currentUserId ?? undefined
       })
     )
@@ -628,7 +625,7 @@ function* doSendMessage(action: ReturnType<typeof sendMessage>) {
           eventName: Name.CHAT_BLAST_MESSAGE_SENT,
           audience: chat.audience,
           audienceContentType: chat.audience_content_type,
-          audienceContentId: chat.audience_content_id ?? undefined
+          audienceContentId: HashId.parse(chat.audience_content_id)
         })
       )
     } else {

--- a/packages/common/src/store/pages/chat/sagas.ts
+++ b/packages/common/src/store/pages/chat/sagas.ts
@@ -505,7 +505,7 @@ function* doCreateChatBlast(action: ReturnType<typeof createChatBlast>) {
           eventName: Name.CREATE_CHAT_BLAST_SUCCESS,
           audience,
           audienceContentType,
-          audienceContentId,
+          audienceContentId: encodedContentId,
           sentBy: currentUserId
         })
       )
@@ -529,13 +529,17 @@ function* doCreateChatBlast(action: ReturnType<typeof createChatBlast>) {
       }
     })
 
+    const encodedContentId = audienceContentId
+      ? encodeHashId(audienceContentId)
+      : undefined
+
     yield* call(
       track,
       make({
         eventName: Name.CREATE_CHAT_BLAST_FAILURE,
         audience,
         audienceContentType,
-        audienceContentId,
+        audienceContentId: encodedContentId,
         sentBy: currentUserId ?? undefined
       })
     )
@@ -618,6 +622,15 @@ function* doSendMessage(action: ReturnType<typeof sendMessage>) {
         blastId: messageIdToUse,
         message
       })
+      yield* call(
+        track,
+        make({
+          eventName: Name.CHAT_BLAST_MESSAGE_SENT,
+          audience: chat.audience,
+          audienceContentType: chat.audience_content_type,
+          audienceContentId: chat.audience_content_id ?? undefined
+        })
+      )
     } else {
       yield* call([sdk.chats, sdk.chats.message], {
         chatId,

--- a/packages/common/src/store/pages/chat/sagas.ts
+++ b/packages/common/src/store/pages/chat/sagas.ts
@@ -464,8 +464,8 @@ function* doCreateChatBlast(action: ReturnType<typeof createChatBlast>) {
   } = action.payload
 
   const { track, make } = yield* getContext('analytics')
+  const currentUserId = yield* select(getUserId)
   try {
-    const currentUserId = yield* select(getUserId)
     if (!currentUserId) {
       throw new Error('User not found')
     }
@@ -499,7 +499,16 @@ function* doCreateChatBlast(action: ReturnType<typeof createChatBlast>) {
           chat: newBlast
         })
       )
-      yield* call(track, make({ eventName: Name.CREATE_CHAT_SUCCESS }))
+      yield* call(
+        track,
+        make({
+          eventName: Name.CREATE_CHAT_BLAST_SUCCESS,
+          audience,
+          audienceContentType,
+          audienceContentId,
+          sentBy: currentUserId
+        })
+      )
     }
   } catch (e) {
     console.error('createChatBlastFailed', e)
@@ -519,7 +528,17 @@ function* doCreateChatBlast(action: ReturnType<typeof createChatBlast>) {
         audienceContentType
       }
     })
-    yield* call(track, make({ eventName: Name.CREATE_CHAT_FAILURE }))
+
+    yield* call(
+      track,
+      make({
+        eventName: Name.CREATE_CHAT_BLAST_FAILURE,
+        audience,
+        audienceContentType,
+        audienceContentId,
+        sentBy: currentUserId ?? undefined
+      })
+    )
   }
 }
 

--- a/packages/mobile/src/screens/chat-screen/ChatBlastCTA.tsx
+++ b/packages/mobile/src/screens/chat-screen/ChatBlastCTA.tsx
@@ -1,6 +1,7 @@
 import React, { useCallback } from 'react'
 
 import { useCanSendChatBlast } from '@audius/common/hooks'
+import { Name } from '@audius/common/models'
 import { TouchableHighlight } from 'react-native-gesture-handler'
 
 import {
@@ -12,6 +13,7 @@ import {
 } from '@audius/harmony-native'
 import { KeyboardAvoidingView } from 'app/components/core'
 import { PLAY_BAR_HEIGHT } from 'app/components/now-playing-drawer/constants'
+import { make, track } from 'app/services/analytics'
 
 import { useAppDrawerNavigation } from '../app-drawer-screen'
 
@@ -32,6 +34,7 @@ export const ChatBlastCTA = () => {
 
   const handleClick = useCallback(() => {
     navigation.navigate('CreateChatBlast')
+    track(make({ eventName: Name.CHAT_BLAST_CTA_CLICKED }))
   }, [navigation])
 
   const userMeetsRequirements = useCanSendChatBlast()

--- a/packages/web/src/pages/chat-page/components/ChatBlastCTA.tsx
+++ b/packages/web/src/pages/chat-page/components/ChatBlastCTA.tsx
@@ -1,6 +1,7 @@
 import { useCallback } from 'react'
 
 import { useCanSendChatBlast } from '@audius/common/hooks'
+import { Name } from '@audius/common/models'
 import { useChatBlastModal } from '@audius/common/src/store'
 import {
   Box,
@@ -13,6 +14,7 @@ import {
   IconTokenBronze
 } from '@audius/harmony'
 
+import { make, track } from 'services/analytics'
 const messages = {
   title: 'Send a Message Blast',
   description: 'Send messages to your fans in bulk.',
@@ -32,6 +34,7 @@ export const ChatBlastCTA = (props: ChatBlastCTAProps) => {
   const handleClick = useCallback(() => {
     onClick()
     openChatBlastModal()
+    track(make({ eventName: Name.CHAT_BLAST_CTA_CLICKED }))
   }, [onClick, openChatBlastModal])
 
   const userMeetsRequirements = useCanSendChatBlast()


### PR DESCRIPTION
### Description

- Adds amplitude tracking events for create chat blast funnel
    - `CHAT_BLAST_CTA_CLICKED`
    - `CREATE_CHAT_BLAST_SUCCESS`
    - `CHAT_BLAST_MESSAGE_SENT`

### How Has This Been Tested?

staging amplitude
![Screenshot 2024-10-14 at 4 56 28 PM](https://github.com/user-attachments/assets/bca50f8b-49af-4740-82c5-68ec7aeb5189)
