### PR TITLE
[C-5173] Fix sort by top comments out of date

### DIFF
--- a/packages/common/src/context/comments/commentsContext.tsx
+++ b/packages/common/src/context/comments/commentsContext.tsx
@@ -7,7 +7,10 @@ import {
   useState
 } from 'react'
 
-import { EntityType, TrackCommentsSortMethodEnum } from '@audius/sdk'
+import {
+  EntityType,
+  TrackCommentsSortMethodEnum as CommentSortMethod
+} from '@audius/sdk'
 import { useQueryClient } from '@tanstack/react-query'
 import { useDispatch, useSelector } from 'react-redux'
 
@@ -60,11 +63,11 @@ type CommentSectionContextType = {
   playTrack: (timestampSeconds?: number) => void
   commentSectionLoading: boolean
   commentIds: ID[]
-  currentSort: TrackCommentsSortMethodEnum
+  currentSort: CommentSortMethod
   isLoadingMorePages: boolean
   hasMorePages: boolean
   reset: (hard?: boolean) => void
-  setCurrentSort: (sort: TrackCommentsSortMethodEnum) => void
+  setCurrentSort: (sort: CommentSortMethod) => void
   loadMorePages: () => void
 } & CommentSectionProviderProps
 
@@ -84,9 +87,13 @@ export const CommentSectionProvider = (
   } = props
   const { data: track } = useGetTrackById({ id: entityId })
 
-  const [currentSort, setCurrentSort] = useState<TrackCommentsSortMethodEnum>(
-    TrackCommentsSortMethodEnum.Top
+  const [currentSort, setCurrentSort] = useState<CommentSortMethod>(
+    CommentSortMethod.Top
   )
+  const handleSetCurrentSort = (sortMethod: CommentSortMethod) => {
+    queryClient.resetQueries({ queryKey: [QUERY_KEYS.trackCommentList] })
+    setCurrentSort(sortMethod)
+  }
 
   const { data: currentUserId } = useGetCurrentUserId({})
   const {
@@ -176,7 +183,7 @@ export const CommentSectionProvider = (
         currentSort,
         replyingAndEditingState,
         setReplyingAndEditingState,
-        setCurrentSort,
+        setCurrentSort: handleSetCurrentSort,
         playTrack,
         loadMorePages
       }}


### PR DESCRIPTION
### Description

The way the cache here is set up is that the cache disappears as soon as the query using them unmounts. On web this results in every sort button resulting in a "fresh load".
On mobile however, sort by top was not being refreshed because there are two context providers and one is still holding on to the cached query data.
I made it explicitly clear the cache on sort change to fix

### How Has This Been Tested?

ios:stage
