### PR TITLE
[PROTO-1951] Add localhost node configuration

### DIFF
--- a/.circleci/src/jobs/@audiusd-jobs.yml
+++ b/.circleci/src/jobs/@audiusd-jobs.yml
@@ -74,6 +74,14 @@ test-audiusd-devnet:
         name: Teardown
         command: |
           audius-ctl --debug down -af
+    - run:
+        name: test isLocalhost config
+        command: |
+          audius-ctl config create-context test-localhost -f dev-tools/templates/test-localhost.yaml
+          audius-ctl up --debug
+          audius-ctl restart -f --debug
+          audius-ctl down -f --debug
+          audius-ctl devnet down --debug
 
 test-config-subcommands:
   docker:

--- a/cmd/audius-ctl/jump.go
+++ b/cmd/audius-ctl/jump.go
@@ -20,7 +20,7 @@ var (
 			if _, ok := ctx.Nodes[args[0]]; !ok {
 				return logger.Errorf("No host named '%s' in the current context.", args[0])
 			}
-			return orchestration.ShellIntoNode(args[0])
+			return orchestration.ShellIntoNode(args[0], ctx.Nodes[args[0]].IsLocalhost)
 		},
 	}
 )

--- a/dev-tools/templates/test-localhost.yaml
+++ b/dev-tools/templates/test-localhost.yaml
@@ -1,0 +1,14 @@
+network:
+  deployOn: devnet
+nodes:
+  creator-localhost.devnet.audius-d:
+    type: content
+    isLocalhost: true
+    httpPort: 4000
+    httpsPort: 4001
+    version: prerelease
+    privateKey: 21118f9a6de181061a2abd549511105adb4877cf9026f271092e6813b7cf58ab
+    wallet: 0x0D38e653eC28bdea5A2296fD5940aaB2D0B8875c
+    rewardsWallet: 0xb3c66e682Bf9a85F6800c769AC5A05c18C3F331d
+    corePortP2P: 36656
+    corePortRPC: 36657

--- a/pkg/conf/model.go
+++ b/pkg/conf/model.go
@@ -32,6 +32,9 @@ type NodeConfig struct {
 
 	// *** Optional fields ***
 
+	// Whether this node is launched on the local machine.
+	IsLocalhost bool `yaml:"isLocalhost"`
+
 	// The version of the audius protocol to run (defaults to "current" behavior if omitted)
 	// "current"  - Run the latest tested release
 	// "edge"     - Run the latest release
@@ -63,7 +66,7 @@ type NodeConfig struct {
 	// (for compatibility with audius-docker-compose migrations)
 	OverrideConfig map[string]string `yaml:"overrideConfig,omitempty"`
 
-	// Path (on host machine) to env file containing additional private configuration
+	// (EXPERIMENTAL) Path on host machine to env file containing additional private configuration
 	RemoteConfigFile string `yaml:"remoteConfigFile,omitempty"`
 
 	PluginsConfig map[PluginName]map[string]string `yaml:"plugins,omitempty"`

--- a/pkg/orchestration/docker.go
+++ b/pkg/orchestration/docker.go
@@ -55,7 +55,12 @@ func runNode(
 	nconf conf.NetworkConfig,
 	audiusdTag string,
 ) error {
-	dockerClient, err := getDockerClient(host)
+	execHost := host
+	if config.IsLocalhost {
+		execHost = "localhost"
+	}
+
+	dockerClient, err := getDockerClient(execHost)
 	if err != nil {
 		return logger.Error(err)
 	}
@@ -107,7 +112,7 @@ func runNode(
 		},
 	}
 	for _, vol := range internalVolumes[config.Type] {
-		if exists, err := dirExistsOnHost(host, vol); err != nil {
+		if exists, err := dirExistsOnHost(execHost, vol); err != nil {
 			return logger.Error(err)
 		} else if exists { // data is leftover from a migrated host
 			hostConfig.Mounts = append(hostConfig.Mounts, mount.Mount{
@@ -226,19 +231,20 @@ func runNode(
 	logger.Info("Configuring audius node...")
 
 	if config.Type != conf.Identity {
-		privateKey, err := NormalizedPrivateKey(host, config.PrivateKey)
+		privateKey, err := NormalizedPrivateKey(execHost, config.PrivateKey)
 		if err != nil {
 			return logger.Error(err)
 		}
 		config.PrivateKey = privateKey
 	}
 	override := config.ToOverrideEnv(host, nconf)
+
 	// generate the override.env file locally
 	// WARNING: not thread safe due to constant filename
-	if err := appendRemoteConfig(host, override, config.RemoteConfigFile); err != nil {
+	localOverridePath := "./override.env"
+	if err := appendRemoteConfig(execHost, override, config.RemoteConfigFile); err != nil {
 		return logger.Error(err)
 	}
-	localOverridePath := "./override.env"
 	if err := godotenv.Write(override, localOverridePath); err != nil {
 		return logger.Error(err)
 	}
@@ -418,8 +424,12 @@ func startDevnetDocker() error {
 	return nil
 }
 
-func downDockerNode(host string) error {
-	dockerClient, err := getDockerClient(host)
+func downDockerNode(host string, isLocalhost bool) error {
+	execHost := host
+	if isLocalhost {
+		execHost = "localhost"
+	}
+	dockerClient, err := getDockerClient(execHost)
 	if err != nil {
 		return logger.Error(err)
 	}


### PR DESCRIPTION
### Description

Allows a node configuration to be run on localhost without the need to modify /etc/hosts. Just add `isLocalhost: true` to the node config.

Also makes running `audius-ctl up|down|restart` more convenient by not requiring `--all` or any hostname arguments if your config contains only a single node.

### How Has This Been Tested?

New tests added to CI
