### PR TITLE
[PAY-3466] Improve composer input responsiveness on mobile

### DIFF
--- a/packages/mobile/src/components/composer-input/ComposerInput.tsx
+++ b/packages/mobile/src/components/composer-input/ComposerInput.tsx
@@ -326,13 +326,13 @@ export const ComposerInput = forwardRef(function ComposerInput(
         lastKeyPressMsRef.current = Date.now()
       }
 
-      if (isAutocompleteActive && selectionRef.current) {
+      const cursorPosition = selectionRef.current?.start
+      if (isAutocompleteActive && !!cursorPosition) {
         if (key === SPACE_KEY) {
           setIsAutocompleteActive(false)
         }
 
-        if (key === BACKSPACE_KEY && selectionRef.current) {
-          const cursorPosition = selectionRef.current.start
+        if (key === BACKSPACE_KEY) {
           const deletedChar = value[cursorPosition - 1]
           if (deletedChar === AT_KEY) {
             setIsAutocompleteActive(false)
@@ -340,7 +340,6 @@ export const ComposerInput = forwardRef(function ComposerInput(
         }
 
         const autocompleteRange = getAutocompleteRange()
-        const cursorPosition = selectionRef.current.start
 
         if (
           autocompleteRange &&
@@ -355,14 +354,12 @@ export const ComposerInput = forwardRef(function ComposerInput(
 
       // Start user autocomplete
       if (key === AT_KEY && onAutocompleteChange) {
-        const cursorPosition = selectionRef.current?.start ?? 0
-        setAutocompletePosition(cursorPosition)
+        setAutocompletePosition(cursorPosition ?? 0)
         setIsAutocompleteActive(true)
       }
 
-      if (key === BACKSPACE_KEY && selectionRef.current) {
-        const textBeforeCursor = value.slice(0, selectionRef.current.start)
-        const cursorPosition = selectionRef.current.start
+      if (key === BACKSPACE_KEY && !!cursorPosition) {
+        const textBeforeCursor = value.slice(0, cursorPosition)
         const { editValue } = handleBackspace({
           cursorPosition,
           textBeforeCursor

--- a/packages/mobile/src/components/composer-input/ComposerInput.tsx
+++ b/packages/mobile/src/components/composer-input/ComposerInput.tsx
@@ -141,7 +141,7 @@ export const ComposerInput = forwardRef(function ComposerInput(
     handle: presetUserMention.slice(1), // slice to remove the @
     currentUserId
   })
-  const selectionRef = useRef<{ start: number; end: number }>()
+  const selectionRef = useRef<TextInputSelectionChangeEventData['selection']>()
   const { primary, neutralLight7 } = useThemeColors()
   const hasLength = value.length > 0
   const internalRef = useRef<RnTextInput>(null)

--- a/packages/mobile/src/screens/chat-screen/ChatTextInput.tsx
+++ b/packages/mobile/src/screens/chat-screen/ChatTextInput.tsx
@@ -34,7 +34,6 @@ export const ChatTextInput = ({
 }: ChatTextInputProps) => {
   const dispatch = useDispatch()
   const [messageId, setMessageId] = useState(0)
-  const [value, setValue] = useState(presetMessage ?? '')
   // The track and collection ids used to render the composer preview
   const [trackId, setTrackId] = useState<Nullable<ID>>(null)
   const [collectionId, setCollectionId] = useState<Nullable<ID>>(null)
@@ -42,8 +41,6 @@ export const ChatTextInput = ({
   const handleChange = useCallback(
     // (value: string, linkEntities: LinkEntity[]) => {
     (value: string, linkEntities: any[]) => {
-      setValue(value)
-
       const track = linkEntities.find((e) => e.type === 'track')
       setTrackId(track ? decodeHashId(track.data.id) : null)
 
@@ -53,13 +50,16 @@ export const ChatTextInput = ({
     []
   )
 
-  const handleSubmit = useCallback(async () => {
-    if (chatId && value) {
-      dispatch(sendMessage({ chatId, message: value }))
-      onMessageSent()
-      setMessageId((id) => ++id)
-    }
-  }, [chatId, dispatch, onMessageSent, value])
+  const handleSubmit = useCallback(
+    async (value: string) => {
+      if (chatId && value) {
+        dispatch(sendMessage({ chatId, message: value }))
+        onMessageSent()
+        setMessageId((id) => ++id)
+      }
+    },
+    [chatId, dispatch, onMessageSent]
+  )
 
   // For iOS: default padding + extra padding
   // For Android: extra padding is slightly larger than iOS, and only


### PR DESCRIPTION
### Description

Currently when you press a keystroke into the composer input, we trigger 3 re-renders of the input itself
1. Because `value` changes
2. Because we have state to track selection (this can be a ref)
3. Because the parent component maintains its own state for `value` which alters the `onSubmit`

Reduce this to one re-render. Should help a lot!

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._

Tested on simulator with logs, will test on android device after it builds.
TBH i've actually noticed that this is more performant on pixel 6 than iphone 14, so that's kinda cool