### PR TITLE
[C-5167] Improve mobile comments perf

### DIFF
--- a/packages/mobile/src/components/comments/CommentActionBar.tsx
+++ b/packages/mobile/src/components/comments/CommentActionBar.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useCallback, useState } from 'react'
 
 import {
   useCurrentCommentSection,
@@ -27,10 +27,17 @@ export const CommentActionBar = (props: CommentActionBarProps) => {
   const [reactionState, setReactionState] = useState(isCurrentUserReacted) // TODO: need to pull starting value from metadata
   const { setReplyingAndEditingState } = useCurrentCommentSection()
 
-  const handleCommentReact = () => {
+  const handleCommentReact = useCallback(() => {
     setReactionState(!reactionState)
     reactToComment(commentId, !reactionState)
-  }
+  }, [commentId, reactToComment, reactionState])
+
+  const handleReply = useCallback(() => {
+    setReplyingAndEditingState?.({
+      replyingToComment: comment,
+      replyingToCommentId: parentCommentId ?? comment.id
+    })
+  }, [comment, parentCommentId, setReplyingAndEditingState])
 
   return (
     <>
@@ -50,12 +57,7 @@ export const CommentActionBar = (props: CommentActionBarProps) => {
         </Flex>
         <PlainButton
           variant='subdued'
-          onPress={() => {
-            setReplyingAndEditingState?.({
-              replyingToComment: comment,
-              replyingToCommentId: parentCommentId ?? comment.id
-            })
-          }}
+          onPress={handleReply}
           disabled={isDisabled}
         >
           {messages.reply}

--- a/packages/mobile/src/components/comments/CommentOverflowMenu.tsx
+++ b/packages/mobile/src/components/comments/CommentOverflowMenu.tsx
@@ -34,7 +34,7 @@ type CommentOverflowMenuProps = {
   parentCommentId?: ID
 }
 
-const CommentOverflowMenuComponent = (props: CommentOverflowMenuProps) => {
+export const CommentOverflowMenu = (props: CommentOverflowMenuProps) => {
   const {
     comment,
     comment: { id, userId },
@@ -325,7 +325,3 @@ const CommentOverflowMenuComponent = (props: CommentOverflowMenuProps) => {
     </>
   )
 }
-
-CommentOverflowMenuComponent.whyDidYouRender = true
-
-export const CommentOverflowMenu = CommentOverflowMenuComponent

--- a/packages/mobile/src/components/comments/CommentOverflowMenu.tsx
+++ b/packages/mobile/src/components/comments/CommentOverflowMenu.tsx
@@ -1,6 +1,5 @@
 import React, { useCallback, useState } from 'react'
 
-import { useGetUserById } from '@audius/common/api'
 import {
   CommentSectionProvider,
   useCurrentCommentSection,
@@ -12,11 +11,14 @@ import {
 } from '@audius/common/context'
 import { commentsMessages as messages } from '@audius/common/messages'
 import type { Comment, ID, ReplyComment } from '@audius/common/models'
+import { cacheUsersSelectors } from '@audius/common/store'
 import { removeNullable } from '@audius/common/utils'
 import { Portal } from '@gorhom/portal'
+import { useSelector } from 'react-redux'
 
 import { Hint, IconButton, IconKebabHorizontal } from '@audius/harmony-native'
 import { useToast } from 'app/hooks/useToast'
+import type { AppState } from 'app/store'
 
 import {
   ActionDrawerWithoutRedux,
@@ -24,13 +26,15 @@ import {
 } from '../action-drawer'
 import { ConfirmationDrawerWithoutRedux } from '../drawers'
 
+const { getUser } = cacheUsersSelectors
+
 type CommentOverflowMenuProps = {
   comment: Comment | ReplyComment
   disabled?: boolean
   parentCommentId?: ID
 }
 
-export const CommentOverflowMenu = (props: CommentOverflowMenuProps) => {
+const CommentOverflowMenuComponent = (props: CommentOverflowMenuProps) => {
   const {
     comment,
     comment: { id, userId },
@@ -42,9 +46,9 @@ export const CommentOverflowMenu = (props: CommentOverflowMenuProps) => {
   const isMuted = 'isMuted' in comment ? comment.isMuted : false
   const isParentComment = 'replyCount' in comment
 
-  const { data: commentUser } = useGetUserById({
-    id: Number(userId)
-  })
+  const userDisplayName = useSelector(
+    (state: AppState) => getUser(state, { id: Number(userId) })?.name
+  )
 
   const { toast } = useToast()
 
@@ -213,7 +217,12 @@ export const CommentOverflowMenu = (props: CommentOverflowMenuProps) => {
       content: messages.toasts.deleted,
       type: 'info'
     })
-  }, [deleteComment, id, toast, parentCommentId])
+  }, [deleteComment, id, parentCommentId, toast])
+
+  const handlePress = useCallback(() => {
+    setIsOpen(!isOpen)
+    setIsVisible(!isVisible)
+  }, [isOpen, isVisible])
 
   return (
     <>
@@ -222,10 +231,7 @@ export const CommentOverflowMenu = (props: CommentOverflowMenuProps) => {
         icon={IconKebabHorizontal}
         size='s'
         color='subdued'
-        onPress={() => {
-          setIsOpen(!isOpen)
-          setIsVisible(!isVisible)
-        }}
+        onPress={handlePress}
         disabled={disabled}
       />
 
@@ -248,7 +254,7 @@ export const CommentOverflowMenu = (props: CommentOverflowMenuProps) => {
             onClosed={() => setIsFlagAndHideConfirmationVisible(false)}
             messages={{
               header: messages.popups.flagAndHide.title,
-              description: messages.popups.flagAndHide.body(commentUser?.name),
+              description: messages.popups.flagAndHide.body(userDisplayName),
               confirm: messages.popups.flagAndHide.confirm
             }}
             onConfirm={handleFlagComment}
@@ -262,9 +268,7 @@ export const CommentOverflowMenu = (props: CommentOverflowMenuProps) => {
             onClosed={() => setIsFlagAndRemoveConfirmationVisible(false)}
             messages={{
               header: messages.popups.flagAndRemove.title,
-              description: messages.popups.flagAndRemove.body(
-                commentUser?.name
-              ),
+              description: messages.popups.flagAndRemove.body(userDisplayName),
               confirm: messages.popups.flagAndRemove.confirm
             }}
             onConfirm={handleFlagAndRemoveComment}
@@ -295,7 +299,7 @@ export const CommentOverflowMenu = (props: CommentOverflowMenuProps) => {
               header: messages.popups.delete.title,
               description: isCommentOwner
                 ? messages.popups.delete.body
-                : messages.popups.artistDelete.body(commentUser?.name),
+                : messages.popups.artistDelete.body(userDisplayName),
               confirm: messages.popups.delete.confirm
             }}
             onConfirm={handleDeleteComment}
@@ -309,7 +313,7 @@ export const CommentOverflowMenu = (props: CommentOverflowMenuProps) => {
             onClosed={() => setIsMuteUserConfirmationVisible(false)}
             messages={{
               header: messages.popups.muteUser.title,
-              description: messages.popups.muteUser.body(commentUser?.handle),
+              description: messages.popups.muteUser.body(userDisplayName),
               confirm: messages.popups.muteUser.confirm
             }}
             onConfirm={handleMuteUser}
@@ -321,3 +325,7 @@ export const CommentOverflowMenu = (props: CommentOverflowMenuProps) => {
     </>
   )
 }
+
+CommentOverflowMenuComponent.whyDidYouRender = true
+
+export const CommentOverflowMenu = CommentOverflowMenuComponent

--- a/packages/mobile/src/components/comments/CommentSection.tsx
+++ b/packages/mobile/src/components/comments/CommentSection.tsx
@@ -1,3 +1,5 @@
+import { useState } from 'react'
+
 import {
   CommentSectionProvider,
   useCurrentCommentSection,
@@ -6,6 +8,7 @@ import {
 import { commentsMessages as messages } from '@audius/common/messages'
 import type { ID } from '@audius/common/models'
 import { TouchableOpacity } from 'react-native'
+import { useEffectOnce } from 'react-use'
 
 import {
   Flex,
@@ -15,6 +18,7 @@ import {
   Text
 } from '@audius/harmony-native'
 import { useDrawer } from 'app/hooks/useDrawer'
+import { useRoute } from 'app/hooks/useRoute'
 
 import Skeleton from '../skeleton'
 
@@ -106,12 +110,21 @@ const CommentSectionContent = () => {
 
 type CommentSectionProps = {
   entityId: ID
-  isDrawerOpen: boolean
-  setIsDrawerOpen: (isOpen: boolean) => void
 }
 
 export const CommentSection = (props: CommentSectionProps) => {
-  const { entityId, isDrawerOpen, setIsDrawerOpen } = props
+  const { entityId } = props
+
+  const { params } = useRoute<'Track'>()
+  const { showComments } = params ?? {}
+
+  const [isDrawerOpen, setIsDrawerOpen] = useState(false)
+
+  useEffectOnce(() => {
+    if (showComments) {
+      setIsDrawerOpen(true)
+    }
+  })
 
   const handlePress = () => {
     setIsDrawerOpen(true)

--- a/packages/mobile/src/components/core/UserGeneratedText.tsx
+++ b/packages/mobile/src/components/core/UserGeneratedText.tsx
@@ -177,32 +177,34 @@ export const UserGeneratedText = (props: UserGeneratedTextProps) => {
     useState<LayoutRectangle>()
 
   useEffect(() => {
-    let layouts = {}
-    const linkKeys = Object.keys(links)
+    if (allowPointerEventsToPassThrough) {
+      let layouts = {}
+      const linkKeys = Object.keys(links)
 
-    // Measure the layout of each link
-    linkKeys.forEach((key) => {
-      const linkRef = linkRefs[key]
-      if (linkRef) {
-        // Need to use `measureInWindow` instead of `onLayout` or `measure` because
-        // android doesn't return the correct layout for nested text elements
-        linkRef.measureInWindow((x, y, width, height) => {
-          layouts = { ...layouts, [key]: { x, y, width, height } }
+      // Measure the layout of each link
+      linkKeys.forEach((key) => {
+        const linkRef = linkRefs[key]
+        if (linkRef) {
+          // Need to use `measureInWindow` instead of `onLayout` or `measure` because
+          // android doesn't return the correct layout for nested text elements
+          linkRef.measureInWindow((x, y, width, height) => {
+            layouts = { ...layouts, [key]: { x, y, width, height } }
 
-          // If all the links have been measured, update state
-          if (linkKeys.length === Object.keys(layouts).length) {
-            setLinkLayouts(layouts)
-          }
-        })
+            // If all the links have been measured, update state
+            if (linkKeys.length === Object.keys(layouts).length) {
+              setLinkLayouts(layouts)
+            }
+          })
+        }
+      })
+
+      if (linkContainerRef.current) {
+        linkContainerRef.current.measureInWindow((x, y, width, height) =>
+          setLinkContainerLayout({ x, y, width, height })
+        )
       }
-    })
-
-    if (linkContainerRef.current) {
-      linkContainerRef.current.measureInWindow((x, y, width, height) =>
-        setLinkContainerLayout({ x, y, width, height })
-      )
     }
-  }, [links, linkRefs, linkContainerRef])
+  }, [allowPointerEventsToPassThrough, links, linkRefs, linkContainerRef])
 
   // We let Autolink lay out each link invisibly, and capture their position and data
   const renderHiddenLink = useCallback(

--- a/packages/mobile/src/harmony-native/components/Button/BaseButton/BaseButton.tsx
+++ b/packages/mobile/src/harmony-native/components/Button/BaseButton/BaseButton.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useState } from 'react'
+import { useCallback } from 'react'
 
 import { Pressable } from 'react-native'
 import type {
@@ -31,7 +31,6 @@ export const BaseButton = (props: BaseButtonProps) => {
     iconRight: RightIconComponent,
     isLoading,
     isStaticIcon,
-    widthToHideText,
     innerProps,
     children,
     style,
@@ -47,21 +46,12 @@ export const BaseButton = (props: BaseButtonProps) => {
   const pressedInternal = useSharedValue(0)
   const pressed = sharedValueProp || pressedInternal
   const { spacing, motion } = useTheme()
-  const [buttonWidth, setButtonWidth] = useState<number | null>(null)
   const isTextChild = typeof children === 'string'
 
-  const isTextHidden =
-    isTextChild &&
-    widthToHideText &&
-    buttonWidth &&
-    buttonWidth <= widthToHideText
-
   const childElement = isTextChild ? (
-    !isTextHidden ? (
-      <AnimatedText {...innerProps?.text} style={styles?.text}>
-        {children}
-      </AnimatedText>
-    ) : null
+    <AnimatedText {...innerProps?.text} style={styles?.text}>
+      {children}
+    </AnimatedText>
   ) : (
     children
   )
@@ -96,8 +86,8 @@ export const BaseButton = (props: BaseButtonProps) => {
   }))
 
   const handleLayoutChange = useCallback((event: LayoutChangeEvent) => {
-    const { width } = event.nativeEvent.layout
-    setButtonWidth(width)
+    // const { width } = event.nativeEvent.layout
+    // setButtonWidth(width)
   }, [])
 
   const handlePress = useCallback(

--- a/packages/mobile/src/harmony-native/components/Button/BaseButton/BaseButton.tsx
+++ b/packages/mobile/src/harmony-native/components/Button/BaseButton/BaseButton.tsx
@@ -85,11 +85,6 @@ export const BaseButton = (props: BaseButtonProps) => {
     })
   }))
 
-  const handleLayoutChange = useCallback((event: LayoutChangeEvent) => {
-    // const { width } = event.nativeEvent.layout
-    // setButtonWidth(width)
-  }, [])
-
   const handlePress = useCallback(
     (e: GestureResponderEvent) => {
       onPress?.(e)
@@ -104,7 +99,6 @@ export const BaseButton = (props: BaseButtonProps) => {
     <GestureDetector gesture={tap}>
       <AnimatedPressable
         style={[rootStyles, animatedStyles, style]}
-        onLayout={handleLayoutChange}
         onPress={handlePress}
         {...other}
       >

--- a/packages/mobile/src/screens/track-screen/TrackScreen.tsx
+++ b/packages/mobile/src/screens/track-screen/TrackScreen.tsx
@@ -46,22 +46,7 @@ export const TrackScreen = () => {
   const dispatch = useDispatch()
   const isReachable = useSelector(getIsReachable)
 
-  const [isCommentDrawerOpen, setIsCommentDrawerOpen] = useState(false)
-
-  const {
-    searchTrack,
-    id,
-    canBeUnlisted = true,
-    handle,
-    slug,
-    showComments
-  } = params ?? {}
-
-  useEffectOnce(() => {
-    if (showComments) {
-      setIsCommentDrawerOpen(true)
-    }
-  })
+  const { searchTrack, id, canBeUnlisted = true, handle, slug } = params ?? {}
 
   const cachedTrack = useSelector((state) => getTrack(state, params))
 
@@ -161,11 +146,7 @@ export const TrackScreen = () => {
                 {/* Comments */}
                 {isCommentingEnabled && !comments_disabled ? (
                   <Flex flex={3}>
-                    <CommentSection
-                      entityId={track_id}
-                      isDrawerOpen={isCommentDrawerOpen}
-                      setIsDrawerOpen={setIsCommentDrawerOpen}
-                    />
+                    <CommentSection entityId={track_id} />
                   </Flex>
                 ) : null}
 


### PR DESCRIPTION
### Description

* Prevent rerender of TrackScreen when drawer opens by moving drawer open state into CommentSection
* Use useSelector instead of useGetUserById in CommentOverflowMenu. For some reason audius-query incurs a render here, we should probably migrate to tan-query!
* Remove state in BaseButton that was measuring width and causing a rerender. widthToHideText wasn't used anywhere
* Prevent measuring of layout in UserGeneratedText when `allowPointerEventsToPassThrough` is not enabled
* Wrap callbacks in useCallback


Performance profile of opening the comment drawer
Before:
![image](https://github.com/user-attachments/assets/f4d1fe0c-c7ac-4801-9fe5-5c92fd7173f3)


After:
![image](https://github.com/user-attachments/assets/16e46208-6277-4b1d-8180-fe32150346c8)


### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._
