### PR TITLE
[PAY-3523] Fix bug where share to DM persists in input

### DIFF
--- a/packages/web/src/pages/chat-page/ChatPageProvider.tsx
+++ b/packages/web/src/pages/chat-page/ChatPageProvider.tsx
@@ -1,5 +1,8 @@
+import { useEffect } from 'react'
+
 import { RouteComponentProps } from 'react-router-dom'
 
+import { useHistoryContext } from 'app/HistoryProvider'
 import { useIsMobile } from 'hooks/useIsMobile'
 import { useManagedAccountNotAllowedRedirect } from 'hooks/useManagedAccountNotAllowedRedirect'
 
@@ -18,6 +21,14 @@ export const ChatPageProvider = ({
   const currentChatId = match.params.id
   const presetMessage = location.state?.presetMessage
   const isMobile = useIsMobile()
+  const { history } = useHistoryContext()
+
+  // Replace the preset message in browser history after the first navigation
+  useEffect(() => {
+    if (presetMessage) {
+      history.replace({ state: { presetMessage: undefined } })
+    }
+  }, [history, presetMessage])
 
   if (isMobile) {
     return <MobileChatPage />


### PR DESCRIPTION
### Description

The back button pulls the previous state from browser history. Add effect to chat page provider to clear the state after "first use" to prevent the bug.

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._

`npm run web:stage`  - bug does not repro with steps:

1. share a track with someone from the track share dialog
2. go to the track page from the dm you just sent
3. press back