### PR TITLE
[PAY-3525] Fix text overflow

### DIFF
--- a/packages/harmony/src/components/text/Text.tsx
+++ b/packages/harmony/src/components/text/Text.tsx
@@ -68,7 +68,11 @@ export const Text = forwardRef(
           ],
         // @ts-ignore
         fontWeight: typography.weight[variantConfig.fontWeight[strength]],
-        ...('css' in variantConfig && variantConfig.css)
+        ...('css' in variantConfig && variantConfig.css),
+        ...(lineHeight === 'multi' && {
+          wordBreak: 'break-word',
+          hyphens: 'auto'
+        })
       }),
       ...(shadow && {
         textShadow: typography.shadow[shadow]

--- a/packages/web/src/components/track/GiantTrackTile.module.css
+++ b/packages/web/src/components/track/GiantTrackTile.module.css
@@ -194,6 +194,7 @@
 .description {
   padding-top: var(--harmony-unit-3);
   line-height: 26px;
+  word-break: break-all;
 }
 
 .verified {

--- a/packages/web/src/components/track/GiantTrackTile.module.css
+++ b/packages/web/src/components/track/GiantTrackTile.module.css
@@ -191,12 +191,6 @@
   margin-left: var(--harmony-unit-1);
 }
 
-.description {
-  padding-top: var(--harmony-unit-3);
-  line-height: 26px;
-  word-break: break-all;
-}
-
 .verified {
   margin-left: var(--harmony-unit-2);
   display: inline-block;

--- a/packages/web/src/components/track/GiantTrackTile.tsx
+++ b/packages/web/src/components/track/GiantTrackTile.tsx
@@ -607,7 +607,12 @@ export const GiantTrackTile = ({
         >
           <TrackMetadataList trackId={trackId} />
           {description ? (
-            <UserGeneratedText tag='h3' size='s' className={styles.description}>
+            <UserGeneratedText
+              tag='h3'
+              size='s'
+              lineHeight='multi'
+              css={(theme) => ({ paddingTop: theme.spacing.m })}
+            >
               {description}
             </UserGeneratedText>
           ) : null}


### PR DESCRIPTION
### Description

Noticed that track pages allow for text overflow in descriptions which causes a horizontal scroll on mobile pages. This is a quick fix for that. 

### How Has This Been Tested?
On prod env starting on main branch: 
- Navigate to [this](https://audius.co/BenWest/was-len-sassaman-satoshi-a-notebooklm-pod)
- Make your screen small
- Notice the text overflow
- Switch to this branch
- Refresh 
- Notice the text overflow is gone

Before: 
![Screenshot 2024-10-15 at 7 37 32 PM](https://github.com/user-attachments/assets/8b300084-e58a-4587-9bce-f1141b40931c)

After:
![image](https://github.com/user-attachments/assets/85400a23-f918-4326-a588-5df152cf19ee)


_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._
