### PR TITLE
decouple console from rpc

### DIFF
--- a/cmd/core/Makefile
+++ b/cmd/core/Makefile
@@ -52,7 +52,7 @@ $(GEN_ARTIFACTS): $(GEN_SRCS)
 	)
 	cd ../../pkg/core && go generate ./...
 	cd ../../pkg/core/db && sqlc generate
-	protoc --go_out=../../pkg/core/gen --go-grpc_out=../../pkg/core/gen ../../pkg/core/protocol.proto
+	protoc --go_out=../../pkg/core/gen --go-grpc_out=../../pkg/core/gen --proto_path=../../pkg/core ../../pkg/core/protocol.proto
 	go mod tidy
 
 .PHONY: core-dev

--- a/pkg/core/console/block.go
+++ b/pkg/core/console/block.go
@@ -1,13 +1,9 @@
 package console
 
 import (
-	"encoding/hex"
-	"fmt"
 	"strconv"
-	"strings"
 
 	"github.com/AudiusProject/audius-protocol/pkg/core/console/views/pages"
-	coretypes "github.com/cometbft/cometbft/rpc/core/types"
 	"github.com/labstack/echo/v4"
 )
 
@@ -15,37 +11,32 @@ func (con *Console) blockPage(c echo.Context) error {
 	ctx := c.Request().Context()
 	blockID := c.Param("block")
 
-	rpc := con.rpc
-
-	var block *coretypes.ResultBlock
-
 	// if block field is number then use it as height
 	// otherwise assume it's block hash
 	blockNum, err := strconv.ParseInt(blockID, 10, 64)
 	if err != nil {
-		blockHash, err := hex.DecodeString(strings.ToLower(blockID))
-		if err != nil {
-			return err
-		}
-		resultBlock, err := rpc.BlockByHash(ctx, blockHash)
-		if err != nil {
-			return err
-		}
-		block = resultBlock
-	} else {
-		resultBlock, err := rpc.Block(ctx, &blockNum)
-		if err != nil {
-			return err
-		}
-		block = resultBlock
+		return err
+	}
+
+	block, err := con.db.GetBlock(ctx, blockNum)
+	if err != nil {
+		return err
+	}
+
+	blockTxs, err := con.db.GetBlockTransactions(ctx, blockNum)
+	if err != nil {
+		return err
+	}
+
+	txs := [][]byte{}
+	for _, tx := range blockTxs{
+		txs = append(txs, tx.TxResult)
 	}
 
 	data := &pages.BlockView{
-		Height:    fmt.Sprint(block.Block.Height),
-		Hash:      hex.EncodeToString(block.Block.Hash()),
-		Proposer:  block.Block.Header.ProposerAddress.String(),
-		Timestamp: block.Block.Time,
-		Txs:       block.Block.Txs.ToSliceOfBytes(),
+		Height:    block.Height,
+		Timestamp: block.CreatedAt.Time,
+		Txs:       txs,
 	}
 
 	return con.views.RenderBlockView(c, data)

--- a/pkg/core/console/views/layout/base.templ
+++ b/pkg/core/console/views/layout/base.templ
@@ -1,6 +1,6 @@
 package layout
 
-import "github.com/AudiusProject/audius-protocol/core/console/assets"
+import "github.com/AudiusProject/audius-protocol/pkg/core/console/assets"
 
 templ (l *Layout) Base() {
 	<!DOCTYPE html>

--- a/pkg/core/console/views/layout/site_frame.templ
+++ b/pkg/core/console/views/layout/site_frame.templ
@@ -2,8 +2,8 @@ package layout
 
 import (
 	"fmt"
-	"github.com/AudiusProject/audius-protocol/core/config"
-	"github.com/AudiusProject/audius-protocol/core/console/assets"
+	"github.com/AudiusProject/audius-protocol/pkg/core/config"
+	"github.com/AudiusProject/audius-protocol/pkg/core/console/assets"
 )
 
 var gitCommit = templ.URL(fmt.Sprintf("https://github.com/AudiusProject/audius-protocol/commits/%s", config.Version))

--- a/pkg/core/console/views/pages/block_page.templ
+++ b/pkg/core/console/views/pages/block_page.templ
@@ -3,7 +3,7 @@ package pages
 import (
 	"encoding/json"
 	"fmt"
-	gen_proto "github.com/AudiusProject/audius-protocol/core/gen/proto"
+	gen_proto "github.com/AudiusProject/audius-protocol/pkg/core/gen/proto"
 	"github.com/dustin/go-humanize"
 	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/proto"

--- a/pkg/core/console/views/pages/block_page.templ
+++ b/pkg/core/console/views/pages/block_page.templ
@@ -11,7 +11,7 @@ import (
 )
 
 type BlockView struct {
-	Height    string
+	Height    int64
 	Hash      string
 	Proposer  string
 	Timestamp time.Time
@@ -58,7 +58,7 @@ func (p *Pages) BlockPageJSON(data *BlockView) (*BlockPageJSONResponse, error) {
 	resTxs := CamelCaseKeys(result)
 
 	return &BlockPageJSONResponse{
-		Height:   data.Height,
+		Height:   fmt.Sprint(data.Height),
 		Hash:     data.Hash,
 		Proposer: data.Proposer,
 		Txs:      resTxs,
@@ -67,24 +67,32 @@ func (p *Pages) BlockPageJSON(data *BlockView) (*BlockPageJSONResponse, error) {
 
 templ (p *Pages) BlockPageHTML(view *BlockView) {
 	@p.layout.SiteFrame() {
-		<div>
+		<div class="flex justify-between mt-4 text-sm">
+			@p.components.Link("/block/%d", view.Height-1) {
+				<div>Previous Block</div>
+			}
+			@p.components.Link("/block/%d", view.Height+1) {
+				<div>Next Block</div>
+			}
+		</div>
+		<div class="p-4">
 			<h1 class="text-xl">
-				Block Details
+				Block { fmt.Sprint(view.Height) } Details
 			</h1>
 			<div class="p-4 h-full">
+				// <div>
+				// 	@p.components.Link("/block/%s", view.Hash) {
+				// 		<div>Hash: { view.Hash }</div>
+				// 	}
+				// </div>
+				// <div>
+				// 	@p.components.Link("/nodes/%s", view.Proposer) {
+				// 		<div>Proposer: { view.Proposer }</div>
+				// 	}
+				// </div>
 				<div>
-					@p.components.Link("/block/%s", view.Hash) {
-						<div>Hash: { view.Hash }</div>
-					}
-				</div>
-				<div>
-					@p.components.Link("/nodes/%s", view.Proposer) {
-						<div>Proposer: { view.Proposer }</div>
-					}
-				</div>
-				<div>
-					@p.components.Link("/block/%s", view.Height) {
-						<div>Height: { view.Height }</div>
+					@p.components.Link("/block/%d", view.Height) {
+						<div>Height: { fmt.Sprint(view.Height) }</div>
 					}
 				</div>
 				<div>

--- a/pkg/core/console/views/pages/block_page_templ.go
+++ b/pkg/core/console/views/pages/block_page_templ.go
@@ -19,7 +19,7 @@ import (
 )
 
 type BlockView struct {
-	Height    string
+	Height    int64
 	Hash      string
 	Proposer  string
 	Timestamp time.Time
@@ -66,7 +66,7 @@ func (p *Pages) BlockPageJSON(data *BlockView) (*BlockPageJSONResponse, error) {
 	resTxs := CamelCaseKeys(result)
 
 	return &BlockPageJSONResponse{
-		Height:   data.Height,
+		Height:   fmt.Sprint(data.Height),
 		Hash:     data.Hash,
 		Proposer: data.Proposer,
 		Txs:      resTxs,
@@ -106,7 +106,7 @@ func (p *Pages) BlockPageHTML(view *BlockView) templ.Component {
 				}()
 			}
 			ctx = templ.InitializeContext(ctx)
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString("<div><h1 class=\"text-xl\">Block Details</h1><div class=\"p-4 h-full\"><div>")
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString("<div class=\"flex justify-between mt-4 text-sm\">")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -122,34 +122,17 @@ func (p *Pages) BlockPageHTML(view *BlockView) templ.Component {
 					}()
 				}
 				ctx = templ.InitializeContext(ctx)
-				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString("<div>Hash: ")
-				if templ_7745c5c3_Err != nil {
-					return templ_7745c5c3_Err
-				}
-				var templ_7745c5c3_Var4 string
-				templ_7745c5c3_Var4, templ_7745c5c3_Err = templ.JoinStringErrs(view.Hash)
-				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `views/pages/block_page.templ`, Line: 77, Col: 28}
-				}
-				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var4))
-				if templ_7745c5c3_Err != nil {
-					return templ_7745c5c3_Err
-				}
-				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString("</div>")
+				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString("<div>Previous Block</div>")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
 				return templ_7745c5c3_Err
 			})
-			templ_7745c5c3_Err = p.components.Link("/block/%s", view.Hash).Render(templ.WithChildren(ctx, templ_7745c5c3_Var3), templ_7745c5c3_Buffer)
+			templ_7745c5c3_Err = p.components.Link("/block/%d", view.Height-1).Render(templ.WithChildren(ctx, templ_7745c5c3_Var3), templ_7745c5c3_Buffer)
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString("</div><div>")
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-			templ_7745c5c3_Var5 := templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
+			templ_7745c5c3_Var4 := templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
 				templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
 				templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
 				if !templ_7745c5c3_IsBuffer {
@@ -161,34 +144,34 @@ func (p *Pages) BlockPageHTML(view *BlockView) templ.Component {
 					}()
 				}
 				ctx = templ.InitializeContext(ctx)
-				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString("<div>Proposer: ")
-				if templ_7745c5c3_Err != nil {
-					return templ_7745c5c3_Err
-				}
-				var templ_7745c5c3_Var6 string
-				templ_7745c5c3_Var6, templ_7745c5c3_Err = templ.JoinStringErrs(view.Proposer)
-				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `views/pages/block_page.templ`, Line: 82, Col: 36}
-				}
-				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var6))
-				if templ_7745c5c3_Err != nil {
-					return templ_7745c5c3_Err
-				}
-				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString("</div>")
+				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString("<div>Next Block</div>")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
 				return templ_7745c5c3_Err
 			})
-			templ_7745c5c3_Err = p.components.Link("/nodes/%s", view.Proposer).Render(templ.WithChildren(ctx, templ_7745c5c3_Var5), templ_7745c5c3_Buffer)
+			templ_7745c5c3_Err = p.components.Link("/block/%d", view.Height+1).Render(templ.WithChildren(ctx, templ_7745c5c3_Var4), templ_7745c5c3_Buffer)
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString("</div><div>")
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString("</div><div class=\"p-4\"><h1 class=\"text-xl\">Block ")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Var7 := templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
+			var templ_7745c5c3_Var5 string
+			templ_7745c5c3_Var5, templ_7745c5c3_Err = templ.JoinStringErrs(fmt.Sprint(view.Height))
+			if templ_7745c5c3_Err != nil {
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `views/pages/block_page.templ`, Line: 80, Col: 35}
+			}
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var5))
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(" Details</h1><div class=\"p-4 h-full\"><div>")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Var6 := templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
 				templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
 				templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
 				if !templ_7745c5c3_IsBuffer {
@@ -204,12 +187,12 @@ func (p *Pages) BlockPageHTML(view *BlockView) templ.Component {
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				var templ_7745c5c3_Var8 string
-				templ_7745c5c3_Var8, templ_7745c5c3_Err = templ.JoinStringErrs(view.Height)
+				var templ_7745c5c3_Var7 string
+				templ_7745c5c3_Var7, templ_7745c5c3_Err = templ.JoinStringErrs(fmt.Sprint(view.Height))
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `views/pages/block_page.templ`, Line: 87, Col: 32}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `views/pages/block_page.templ`, Line: 95, Col: 44}
 				}
-				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var8))
+				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var7))
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
@@ -219,7 +202,7 @@ func (p *Pages) BlockPageHTML(view *BlockView) templ.Component {
 				}
 				return templ_7745c5c3_Err
 			})
-			templ_7745c5c3_Err = p.components.Link("/block/%s", view.Height).Render(templ.WithChildren(ctx, templ_7745c5c3_Var7), templ_7745c5c3_Buffer)
+			templ_7745c5c3_Err = p.components.Link("/block/%d", view.Height).Render(templ.WithChildren(ctx, templ_7745c5c3_Var6), templ_7745c5c3_Buffer)
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -227,12 +210,12 @@ func (p *Pages) BlockPageHTML(view *BlockView) templ.Component {
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			var templ_7745c5c3_Var9 string
-			templ_7745c5c3_Var9, templ_7745c5c3_Err = templ.JoinStringErrs(humanize.Time(view.Timestamp))
+			var templ_7745c5c3_Var8 string
+			templ_7745c5c3_Var8, templ_7745c5c3_Err = templ.JoinStringErrs(humanize.Time(view.Timestamp))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `views/pages/block_page.templ`, Line: 91, Col: 41}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `views/pages/block_page.templ`, Line: 99, Col: 41}
 			}
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var9))
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var8))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -245,7 +228,7 @@ func (p *Pages) BlockPageHTML(view *BlockView) templ.Component {
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				templ_7745c5c3_Var10 := templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
+				templ_7745c5c3_Var9 := templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
 					templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
 					templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
 					if !templ_7745c5c3_IsBuffer {
@@ -261,12 +244,12 @@ func (p *Pages) BlockPageHTML(view *BlockView) templ.Component {
 					if templ_7745c5c3_Err != nil {
 						return templ_7745c5c3_Err
 					}
-					var templ_7745c5c3_Var11 string
-					templ_7745c5c3_Var11, templ_7745c5c3_Err = templ.JoinStringErrs(p.components.ToTxHash(tx))
+					var templ_7745c5c3_Var10 string
+					templ_7745c5c3_Var10, templ_7745c5c3_Err = templ.JoinStringErrs(p.components.ToTxHash(tx))
 					if templ_7745c5c3_Err != nil {
-						return templ.Error{Err: templ_7745c5c3_Err, FileName: `views/pages/block_page.templ`, Line: 100, Col: 48}
+						return templ.Error{Err: templ_7745c5c3_Err, FileName: `views/pages/block_page.templ`, Line: 108, Col: 48}
 					}
-					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var11))
+					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var10))
 					if templ_7745c5c3_Err != nil {
 						return templ_7745c5c3_Err
 					}
@@ -276,7 +259,7 @@ func (p *Pages) BlockPageHTML(view *BlockView) templ.Component {
 					}
 					return templ_7745c5c3_Err
 				})
-				templ_7745c5c3_Err = p.components.Link("/tx/%s", p.components.ToTxHash(tx)).Render(templ.WithChildren(ctx, templ_7745c5c3_Var10), templ_7745c5c3_Buffer)
+				templ_7745c5c3_Err = p.components.Link("/tx/%s", p.components.ToTxHash(tx)).Render(templ.WithChildren(ctx, templ_7745c5c3_Var9), templ_7745c5c3_Buffer)
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}

--- a/pkg/core/console/views/pages/nodes_page.templ
+++ b/pkg/core/console/views/pages/nodes_page.templ
@@ -1,6 +1,6 @@
 package pages
 
-import "github.com/AudiusProject/audius-protocol/core/db"
+import "github.com/AudiusProject/audius-protocol/pkg/core/db"
 
 type NodesView struct {
 	Nodes []db.CoreValidator

--- a/pkg/core/console/views/pages/overview_page.templ
+++ b/pkg/core/console/views/pages/overview_page.templ
@@ -2,7 +2,7 @@ package pages
 
 import (
 	"fmt"
-	"github.com/AudiusProject/audius-protocol/core/db"
+	"github.com/AudiusProject/audius-protocol/pkg/core/db"
 	"github.com/dustin/go-humanize"
 )
 

--- a/pkg/core/console/views/pages/overview_page.templ
+++ b/pkg/core/console/views/pages/overview_page.templ
@@ -22,20 +22,23 @@ templ (p *Pages) OverviewPageHTML(data *OverviewPageView) {
 					for _, block := range data.Blocks {
 						<div class="text-sm">
 							<div class="p-6">
+								// <div>
+								// 	@p.components.Link("/block/%s", block.Hash) {
+								// 		<div>Hash: { block.Hash }</div>
+								// 	}
+								// </div>
+								// <div>
+								// 	@p.components.Link("/node/%s", block.Proposer) {
+								// 		<div>Proposer: { block.Proposer }</div>
+								// 	}
+								// </div>
 								<div>
-									@p.components.Link("/block/%s", block.Hash) {
-										<div>Hash: { block.Hash }</div>
+									@p.components.Link("/block/%d", block.Height) {
+										<div>Height: { fmt.Sprint(block.Height) }</div>
 									}
 								</div>
 								<div>
-									@p.components.Link("/node/%s", block.Proposer) {
-										<div>Proposer: { block.Proposer }</div>
-									}
-								</div>
-								<div>
-									@p.components.Link("/block/%s", block.Height) {
-										<div>Height: { block.Height }</div>
-									}
+									Transactions: { fmt.Sprint(len(block.Txs)) }
 								</div>
 								<div>
 									Age: { humanize.Time(block.Timestamp) }

--- a/pkg/core/console/views/pages/overview_page_templ.go
+++ b/pkg/core/console/views/pages/overview_page_templ.go
@@ -75,14 +75,14 @@ func (p *Pages) OverviewPageHTML(data *OverviewPageView) templ.Component {
 						}()
 					}
 					ctx = templ.InitializeContext(ctx)
-					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString("<div>Hash: ")
+					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString("<div>Height: ")
 					if templ_7745c5c3_Err != nil {
 						return templ_7745c5c3_Err
 					}
 					var templ_7745c5c3_Var4 string
-					templ_7745c5c3_Var4, templ_7745c5c3_Err = templ.JoinStringErrs(block.Hash)
+					templ_7745c5c3_Var4, templ_7745c5c3_Err = templ.JoinStringErrs(fmt.Sprint(block.Height))
 					if templ_7745c5c3_Err != nil {
-						return templ.Error{Err: templ_7745c5c3_Err, FileName: `views/pages/overview_page.templ`, Line: 27, Col: 33}
+						return templ.Error{Err: templ_7745c5c3_Err, FileName: `views/pages/overview_page.templ`, Line: 37, Col: 49}
 					}
 					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var4))
 					if templ_7745c5c3_Err != nil {
@@ -94,85 +94,20 @@ func (p *Pages) OverviewPageHTML(data *OverviewPageView) templ.Component {
 					}
 					return templ_7745c5c3_Err
 				})
-				templ_7745c5c3_Err = p.components.Link("/block/%s", block.Hash).Render(templ.WithChildren(ctx, templ_7745c5c3_Var3), templ_7745c5c3_Buffer)
+				templ_7745c5c3_Err = p.components.Link("/block/%d", block.Height).Render(templ.WithChildren(ctx, templ_7745c5c3_Var3), templ_7745c5c3_Buffer)
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString("</div><div>")
+				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString("</div><div>Transactions: ")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				templ_7745c5c3_Var5 := templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
-					templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
-					templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
-					if !templ_7745c5c3_IsBuffer {
-						defer func() {
-							templ_7745c5c3_BufErr := templruntime.ReleaseBuffer(templ_7745c5c3_Buffer)
-							if templ_7745c5c3_Err == nil {
-								templ_7745c5c3_Err = templ_7745c5c3_BufErr
-							}
-						}()
-					}
-					ctx = templ.InitializeContext(ctx)
-					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString("<div>Proposer: ")
-					if templ_7745c5c3_Err != nil {
-						return templ_7745c5c3_Err
-					}
-					var templ_7745c5c3_Var6 string
-					templ_7745c5c3_Var6, templ_7745c5c3_Err = templ.JoinStringErrs(block.Proposer)
-					if templ_7745c5c3_Err != nil {
-						return templ.Error{Err: templ_7745c5c3_Err, FileName: `views/pages/overview_page.templ`, Line: 32, Col: 41}
-					}
-					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var6))
-					if templ_7745c5c3_Err != nil {
-						return templ_7745c5c3_Err
-					}
-					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString("</div>")
-					if templ_7745c5c3_Err != nil {
-						return templ_7745c5c3_Err
-					}
-					return templ_7745c5c3_Err
-				})
-				templ_7745c5c3_Err = p.components.Link("/node/%s", block.Proposer).Render(templ.WithChildren(ctx, templ_7745c5c3_Var5), templ_7745c5c3_Buffer)
+				var templ_7745c5c3_Var5 string
+				templ_7745c5c3_Var5, templ_7745c5c3_Err = templ.JoinStringErrs(fmt.Sprint(len(block.Txs)))
 				if templ_7745c5c3_Err != nil {
-					return templ_7745c5c3_Err
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `views/pages/overview_page.templ`, Line: 41, Col: 51}
 				}
-				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString("</div><div>")
-				if templ_7745c5c3_Err != nil {
-					return templ_7745c5c3_Err
-				}
-				templ_7745c5c3_Var7 := templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
-					templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
-					templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
-					if !templ_7745c5c3_IsBuffer {
-						defer func() {
-							templ_7745c5c3_BufErr := templruntime.ReleaseBuffer(templ_7745c5c3_Buffer)
-							if templ_7745c5c3_Err == nil {
-								templ_7745c5c3_Err = templ_7745c5c3_BufErr
-							}
-						}()
-					}
-					ctx = templ.InitializeContext(ctx)
-					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString("<div>Height: ")
-					if templ_7745c5c3_Err != nil {
-						return templ_7745c5c3_Err
-					}
-					var templ_7745c5c3_Var8 string
-					templ_7745c5c3_Var8, templ_7745c5c3_Err = templ.JoinStringErrs(block.Height)
-					if templ_7745c5c3_Err != nil {
-						return templ.Error{Err: templ_7745c5c3_Err, FileName: `views/pages/overview_page.templ`, Line: 37, Col: 37}
-					}
-					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var8))
-					if templ_7745c5c3_Err != nil {
-						return templ_7745c5c3_Err
-					}
-					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString("</div>")
-					if templ_7745c5c3_Err != nil {
-						return templ_7745c5c3_Err
-					}
-					return templ_7745c5c3_Err
-				})
-				templ_7745c5c3_Err = p.components.Link("/block/%s", block.Height).Render(templ.WithChildren(ctx, templ_7745c5c3_Var7), templ_7745c5c3_Buffer)
+				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var5))
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
@@ -180,12 +115,12 @@ func (p *Pages) OverviewPageHTML(data *OverviewPageView) templ.Component {
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				var templ_7745c5c3_Var9 string
-				templ_7745c5c3_Var9, templ_7745c5c3_Err = templ.JoinStringErrs(humanize.Time(block.Timestamp))
+				var templ_7745c5c3_Var6 string
+				templ_7745c5c3_Var6, templ_7745c5c3_Err = templ.JoinStringErrs(humanize.Time(block.Timestamp))
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `views/pages/overview_page.templ`, Line: 41, Col: 46}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `views/pages/overview_page.templ`, Line: 44, Col: 46}
 				}
-				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var9))
+				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var6))
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
@@ -203,8 +138,8 @@ func (p *Pages) OverviewPageHTML(data *OverviewPageView) templ.Component {
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				var templ_7745c5c3_Var10 templ.SafeURL = templ.URL(fmt.Sprintf("/console/tx/%s", tx.TxHash))
-				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(string(templ_7745c5c3_Var10)))
+				var templ_7745c5c3_Var7 templ.SafeURL = templ.URL(fmt.Sprintf("/console/tx/%s", tx.TxHash))
+				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(string(templ_7745c5c3_Var7)))
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
@@ -212,12 +147,12 @@ func (p *Pages) OverviewPageHTML(data *OverviewPageView) templ.Component {
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				var templ_7745c5c3_Var11 string
-				templ_7745c5c3_Var11, templ_7745c5c3_Err = templ.JoinStringErrs(tx.TxHash)
+				var templ_7745c5c3_Var8 string
+				templ_7745c5c3_Var8, templ_7745c5c3_Err = templ.JoinStringErrs(tx.TxHash)
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `views/pages/overview_page.templ`, Line: 55, Col: 90}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `views/pages/overview_page.templ`, Line: 58, Col: 90}
 				}
-				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var11))
+				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var8))
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
@@ -225,8 +160,8 @@ func (p *Pages) OverviewPageHTML(data *OverviewPageView) templ.Component {
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				var templ_7745c5c3_Var12 templ.SafeURL = templ.URL(fmt.Sprintf("/console/block/%s", fmt.Sprint(tx.BlockID)))
-				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(string(templ_7745c5c3_Var12)))
+				var templ_7745c5c3_Var9 templ.SafeURL = templ.URL(fmt.Sprintf("/console/block/%s", fmt.Sprint(tx.BlockID)))
+				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(string(templ_7745c5c3_Var9)))
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
@@ -234,12 +169,12 @@ func (p *Pages) OverviewPageHTML(data *OverviewPageView) templ.Component {
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				var templ_7745c5c3_Var13 string
-				templ_7745c5c3_Var13, templ_7745c5c3_Err = templ.JoinStringErrs(fmt.Sprint(tx.BlockID))
+				var templ_7745c5c3_Var10 string
+				templ_7745c5c3_Var10, templ_7745c5c3_Err = templ.JoinStringErrs(fmt.Sprint(tx.BlockID))
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `views/pages/overview_page.templ`, Line: 57, Col: 118}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `views/pages/overview_page.templ`, Line: 60, Col: 118}
 				}
-				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var13))
+				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var10))
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
@@ -247,12 +182,12 @@ func (p *Pages) OverviewPageHTML(data *OverviewPageView) templ.Component {
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				var templ_7745c5c3_Var14 string
-				templ_7745c5c3_Var14, templ_7745c5c3_Err = templ.JoinStringErrs(humanize.Time(tx.CreatedAt.Time))
+				var templ_7745c5c3_Var11 string
+				templ_7745c5c3_Var11, templ_7745c5c3_Err = templ.JoinStringErrs(humanize.Time(tx.CreatedAt.Time))
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `views/pages/overview_page.templ`, Line: 58, Col: 53}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `views/pages/overview_page.templ`, Line: 61, Col: 53}
 				}
-				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var14))
+				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var11))
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}

--- a/pkg/core/console/views/pages/tx_page.templ
+++ b/pkg/core/console/views/pages/tx_page.templ
@@ -2,7 +2,7 @@ package pages
 
 import (
 	"encoding/json"
-	gen_proto "github.com/AudiusProject/audius-protocol/core/gen/proto"
+	gen_proto "github.com/AudiusProject/audius-protocol/pkg/core/gen/proto"
 	"github.com/dustin/go-humanize"
 	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/proto"

--- a/pkg/core/console/views/pages/uptime_page.templ
+++ b/pkg/core/console/views/pages/uptime_page.templ
@@ -2,7 +2,7 @@ package pages
 
 import (
 	"fmt"
-	"github.com/AudiusProject/audius-protocol/core/db"
+	"github.com/AudiusProject/audius-protocol/pkg/core/db"
 )
 
 type UptimePageView struct {

--- a/pkg/core/core.go
+++ b/pkg/core/core.go
@@ -21,7 +21,6 @@ import (
 	"github.com/cometbft/cometbft/p2p"
 	"github.com/cometbft/cometbft/privval"
 
-	rpchttp "github.com/cometbft/cometbft/rpc/client/http"
 	"github.com/cometbft/cometbft/rpc/client/local"
 	"github.com/ethereum/go-ethereum/ethclient"
 	"github.com/improbable-eng/grpc-web/go/grpcweb"
@@ -58,30 +57,13 @@ func run(ctx context.Context, logger *common.Logger) error {
 	}
 	defer pool.Close()
 
+	// Create an errgroup to manage concurrent tasks with context
+	eg, ctx := errgroup.WithContext(ctx)
+
 	e := echo.New()
 	e.Pre(middleware.RemoveTrailingSlash())
 	e.Use(middleware.Recover())
 	e.HideBanner = true
-
-	if config.StandaloneConsole && cometConfig == nil {
-		httprpc, err := rpchttp.New(config.RPCladdr)
-		if err != nil {
-			return fmt.Errorf("could not create rpc client: %v", err)
-		}
-
-		// run console in isolation
-		_, err = console.NewConsole(config, logger, e, httprpc, pool)
-		if err != nil {
-			return fmt.Errorf("console init error: %v", err)
-		}
-
-		go func() {
-			<-ctx.Done()
-			logger.Info("Shutting down HTTP server...")
-			e.Shutdown(ctx)
-		}()
-		return e.Start(config.CoreServerAddr)
-	}
 
 	ethrpc, err := ethclient.Dial(config.EthRPCUrl)
 	if err != nil {
@@ -100,6 +82,12 @@ func run(ctx context.Context, logger *common.Logger) error {
 		return fmt.Errorf("node init error: %v", err)
 	}
 
+	// Start the node (cometbft)
+	eg.Go(func() error {
+		logger.Info("core CometBFT node starting")
+		return node.Start()
+	})
+
 	logger.Info("new node created")
 
 	rpc := local.New(node)
@@ -111,10 +99,21 @@ func run(ctx context.Context, logger *common.Logger) error {
 		return fmt.Errorf("registry bridge init error: %v", err)
 	}
 
-	con, err := console.NewConsole(config, logger, e, rpc, pool)
+	// Start the registry bridge
+	eg.Go(func() error {
+		logger.Info("core registry bridge starting")
+		return registryBridge.Start()
+	})
+
+	con, err := console.NewConsole(config, logger, e, pool)
 	if err != nil {
 		return fmt.Errorf("console init error: %v", err)
 	}
+
+	eg.Go(func() error {
+		logger.Info("core Console starting")
+		return con.Start()
+	})
 
 	grpcServer, err := grpc.NewGRPCServer(logger, config, rpc, pool)
 	if err != nil {
@@ -130,13 +129,22 @@ func run(ctx context.Context, logger *common.Logger) error {
 		return fmt.Errorf("server init error: %v", err)
 	}
 
+	// Start the HTTP server
+	eg.Go(func() error {
+		logger.Info("core HTTP server starting")
+		return e.Start(config.CoreServerAddr)
+	})
+
 	grpcLis, err := net.Listen("tcp", config.GRPCladdr)
 	if err != nil {
 		return fmt.Errorf("grpc listener not created: %v", err)
 	}
 
-	// Create an errgroup to manage concurrent tasks with context
-	eg, ctx := errgroup.WithContext(ctx)
+	// Start the gRPC server
+	eg.Go(func() error {
+		logger.Info("core gRPC server starting")
+		return grpcServer.Serve(grpcLis)
+	})
 
 	// Close all services when the context is canceled
 	defer func() {
@@ -146,35 +154,6 @@ func run(ctx context.Context, logger *common.Logger) error {
 		grpcLis.Close()
 		ethrpc.Close()
 	}()
-
-	// Start the HTTP server
-	eg.Go(func() error {
-		logger.Info("core HTTP server starting")
-		return e.Start(config.CoreServerAddr)
-	})
-
-	// Start the node (cometbft)
-	eg.Go(func() error {
-		logger.Info("core CometBFT node starting")
-		return node.Start()
-	})
-
-	// Start the gRPC server
-	eg.Go(func() error {
-		logger.Info("core gRPC server starting")
-		return grpcServer.Serve(grpcLis)
-	})
-
-	// Start the registry bridge
-	eg.Go(func() error {
-		logger.Info("core registry bridge starting")
-		return registryBridge.Start()
-	})
-
-	eg.Go(func() error {
-		logger.Info("core Console starting")
-		return con.Start()
-	})
 
 	// Wait for all services to finish or for context cancellation
 	return eg.Wait()

--- a/pkg/core/db/sql/reads.sql
+++ b/pkg/core/db/sql/reads.sql
@@ -80,3 +80,9 @@ from core_tx_stats
 where created_at >= now() - interval '1 day'
 group by hour, tx_type 
 order by hour asc;
+
+-- name: GetBlockTransactions :many
+select * from core_tx_results where block_id = $1 order by created_at desc;
+
+-- name: GetBlock :one
+select * from core_blocks where height = $1;


### PR DESCRIPTION
### Description
- mostly decouples console from the rpc
- in the core.go console is started prior to the node starting up
- it does create an http rpc connection for data like node status, we can add smarter logic around using a local instance for this later
- uses the block and tx models from the db for views, this table does not have proposer or other info. once we implement data companion we'll have more control over what's available in these models
- fixes the core-gen command with console
- adds a previous and back button to the block pages for simple nav

### How Has This Been Tested?

`make core-gen && make core-dev`
