### PR TITLE
[PAY-3509] Show InboxUnavailableModal instead of disabled button

### DIFF
--- a/packages/web/src/components/stat-banner/StatBanner.tsx
+++ b/packages/web/src/components/stat-banner/StatBanner.tsx
@@ -1,13 +1,8 @@
 import { useRef } from 'react'
 
-import { useGetUserById } from '@audius/common/api'
 import { useFeatureFlag, useIsManagedAccount } from '@audius/common/hooks'
-import { ID, User } from '@audius/common/models'
+import { ID } from '@audius/common/models'
 import { FeatureFlags } from '@audius/common/services'
-import {
-  useInboxUnavailableModal,
-  createChatModalActions
-} from '@audius/common/store'
 import {
   IconMessageBlock,
   IconMessageUnblock,
@@ -26,7 +21,6 @@ import cn from 'classnames'
 import { ArtistRecommendationsPopup } from 'components/artist-recommendations/ArtistRecommendationsPopup'
 import Stats, { StatProps } from 'components/stats/Stats'
 import SubscribeButton from 'components/subscribe-button/SubscribeButton'
-import { useComposeChat } from 'pages/chat-page/components/useComposeChat'
 
 import styles from './StatBanner.module.css'
 
@@ -189,8 +183,6 @@ export const StatBanner = (props: StatsBannerProps) => {
     isSubscribed,
     onToggleSubscribe
   } = props
-
-  const { onOpen: openInboxUnavailableModal } = useInboxUnavailableModal()
   let buttons = null
   const followButtonRef = useRef<HTMLButtonElement>(null)
   const isManagedAccount = useIsManagedAccount()
@@ -206,21 +198,6 @@ export const StatBanner = (props: StatsBannerProps) => {
       {messages.share}
     </Button>
   )
-
-  const { data: user } = useGetUserById(
-    { id: profileId! },
-    { disabled: !profileId }
-  )
-
-  const handleComposeClicked = useComposeChat({
-    user: user as User,
-    onInboxUnavailable: (user) =>
-      openInboxUnavailableModal({
-        userId: user.user_id,
-        onSuccessAction: createChatModalActions.open({}),
-        onCancelAction: createChatModalActions.close()
-      })
-  })
 
   switch (mode) {
     case 'owner':
@@ -276,7 +253,7 @@ export const StatBanner = (props: StatsBannerProps) => {
                   size='small'
                   aria-label={messages.message}
                   iconLeft={canCreateChat ? IconMessage : IconMessageLocked}
-                  onClick={handleComposeClicked}
+                  onClick={onMessage}
                 />
               ) : null}
             </>


### PR DESCRIPTION
### Description

The message button on web profile was disabled when the user is not permitted to dm the profile. We have logic to show the InboxUnavailable modal which shows the appropriate CTA instead, but it's being eclipsed due to the disabled button.

### How Has This Been Tested?

![Screenshot 2024-10-16 at 12 23 08 PM](https://github.com/user-attachments/assets/2f813656-b7ef-4aea-9f01-b35607415d3b)
