### PR TITLE
[PAY-3526] Hide scroll on message inbox

### DIFF
--- a/packages/web/src/pages/chat-page/components/ChatListBlastItem.tsx
+++ b/packages/web/src/pages/chat-page/components/ChatListBlastItem.tsx
@@ -43,7 +43,7 @@ export const ChatListBlastItem = (props: ChatListBlastItemProps) => {
     >
       <Flex row gap='s' w='100%' className={styles.headingContainer}>
         <IconTowerBroadcast size='l' color='default' />
-        <Box css={{ flexShrink: 0 }} className={styles.messagePreview}>
+        <Box css={{ flexShrink: 0 }} className={styles.blastPreview}>
           <Text size='l' strength='strong'>
             {chatBlastTitle}
           </Text>
@@ -54,7 +54,7 @@ export const ChatListBlastItem = (props: ChatListBlastItemProps) => {
             color='subdued'
             ellipses
             css={{ display: 'block' }}
-            className={styles.messagePreview}
+            className={styles.blastPreview}
           >
             {contentTitle}
           </Text>
@@ -63,7 +63,7 @@ export const ChatListBlastItem = (props: ChatListBlastItemProps) => {
       <Flex
         justifyContent='space-between'
         w='100%'
-        className={styles.messagePreview}
+        className={styles.blastPreview}
       >
         <Text variant='label' textTransform='capitalize' color='subdued'>
           {messages.audience}

--- a/packages/web/src/pages/chat-page/components/ChatListItem.module.css
+++ b/packages/web/src/pages/chat-page/components/ChatListItem.module.css
@@ -61,7 +61,8 @@
 
   .messagePreview,
   .userText,
-  .unreadIndicatorTag {
+  .unreadIndicatorTag,
+  .blastPreview {
     display: none;
   }
 }


### PR DESCRIPTION
### Description
This [PR](https://github.com/AudiusProject/audius-protocol/pull/10057/files) added class `messagePreview` to the blast list items, but that class caused an unexpected scroll on larger screen. 

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._
- Navigate to message inbox
- Send a blast
- Ensure there is no horizontal scroll
