### PR TITLE
[PAY-3456] Fix chat last message sometimes wrong

### DIFF
--- a/packages/common/src/store/pages/chat/slice.ts
+++ b/packages/common/src/store/pages/chat/slice.ts
@@ -486,13 +486,6 @@ const slice = createSlice({
       // triggers saga to get chat if not exists
       const { chatId, message, status, isSelfMessage } = action.payload
 
-      // If no chatId, don't add the message
-      // and abort early, relying on the saga
-      // to fetch the chat
-      if (!(chatId in state.messages)) {
-        return
-      }
-
       // Always update the last message, but don't update
       // last_message_at if it's a blast message sent by current user,
       // to avoid chat list re-sorting.
@@ -512,6 +505,13 @@ const slice = createSlice({
         id: chatId,
         changes
       })
+
+      // If no chatId, don't add the message
+      // and abort early, relying on the saga
+      // to fetch the chat
+      if (!(chatId in state.messages)) {
+        return
+      }
 
       // Return early if we've seen this message: don't update
       // recheck_permissions unless it's a message received from someone else


### PR DESCRIPTION
### Description
We were skipping the updates to the `chats` entity adapter if the `messages` entity adapter didn't contain an entry for that chatId. But we should still update the `chats` entity adapter!

### How Has This Been Tested?


https://github.com/user-attachments/assets/bf44ff23-7f34-4bf5-aa24-6e43ee508119

