### PR TITLE
Fix purchases with external wallet and wallet adapter

### DIFF
--- a/.changeset/unlucky-taxis-admire.md
+++ b/.changeset/unlucky-taxis-admire.md
@@ -1,0 +1,5 @@
+---
+'@audius/sdk': patch
+---
+
+Fix purchasing tracks and albums with external wallet

--- a/packages/sdk/.eslintrc
+++ b/packages/sdk/.eslintrc
@@ -3,7 +3,11 @@
   "plugins": ["mocha"],
   "rules": {
     "mocha/no-mocha-arrows": "off",
-    "mocha/max-top-level-suites": "off"
+    "mocha/max-top-level-suites": "off",
+    "@typescript-eslint/no-unused-vars": [
+      "error",
+      { "ignoreRestSiblings": true }
+    ]
   },
   "ignorePatterns": ["jest.config.ts"]
 }

--- a/packages/sdk/.eslintrc
+++ b/packages/sdk/.eslintrc
@@ -3,11 +3,7 @@
   "plugins": ["mocha"],
   "rules": {
     "mocha/no-mocha-arrows": "off",
-    "mocha/max-top-level-suites": "off",
-    "@typescript-eslint/no-unused-vars": [
-      "error",
-      { "ignoreRestSiblings": true }
-    ]
+    "mocha/max-top-level-suites": "off"
   },
   "ignorePatterns": ["jest.config.ts"]
 }

--- a/packages/sdk/src/sdk/api/albums/AlbumsApi.ts
+++ b/packages/sdk/src/sdk/api/albums/AlbumsApi.ts
@@ -368,8 +368,8 @@ export class AlbumsApi {
 
     const {
       // only send the base params to getPurchaseInstructions
-      wallet: _wallet,
-      walletAdapter: _walletAdapter,
+      wallet: ignoredWallet,
+      walletAdapter: ignoredWalletAdapter,
       ...baseParams
     } = params
     const {

--- a/packages/sdk/src/sdk/api/albums/AlbumsApi.ts
+++ b/packages/sdk/src/sdk/api/albums/AlbumsApi.ts
@@ -365,6 +365,13 @@ export class AlbumsApi {
       'purchaseAlbum',
       PurchaseAlbumSchema
     )(params)
+
+    const {
+      // only send the base params to getPurchaseInstructions
+      wallet: _wallet,
+      walletAdapter: _walletAdapter,
+      ...baseParams
+    } = params
     const {
       instructions: {
         routeInstruction,
@@ -372,7 +379,7 @@ export class AlbumsApi {
         locationMemoInstruction
       },
       total
-    } = await this.getPurchaseAlbumInstructions(params)
+    } = await this.getPurchaseAlbumInstructions(baseParams)
 
     let transaction
     const mint = 'USDC'

--- a/packages/sdk/src/sdk/api/tracks/TracksApi.ts
+++ b/packages/sdk/src/sdk/api/tracks/TracksApi.ts
@@ -547,13 +547,19 @@ export class TracksApi extends GeneratedTracksApi {
     )(params)
 
     const {
+      // only send the base params to getPurchaseInstructions
+      wallet: _wallet,
+      walletAdapter: _walletAdapter,
+      ...baseParams
+    } = params
+    const {
       instructions: {
         routeInstruction,
         memoInstruction,
         locationMemoInstruction
       },
       total
-    } = await this.getPurchaseTrackInstructions(params)
+    } = await this.getPurchaseTrackInstructions(baseParams)
 
     let transaction
     const mint = 'USDC'

--- a/packages/sdk/src/sdk/api/tracks/TracksApi.ts
+++ b/packages/sdk/src/sdk/api/tracks/TracksApi.ts
@@ -548,8 +548,8 @@ export class TracksApi extends GeneratedTracksApi {
 
     const {
       // only send the base params to getPurchaseInstructions
-      wallet: _wallet,
-      walletAdapter: _walletAdapter,
+      wallet: ignoredWallet,
+      walletAdapter: ignoredWalletAdapter,
       ...baseParams
     } = params
     const {


### PR DESCRIPTION
Prior to this change, purchasing tracks or albums with external wallet would throw a Zod error for the extra parameters being passed into `getPurcahseInstructions`
