### PR TITLE
Fix chat header too long on mobile

### DIFF
--- a/packages/mobile/src/screens/chat-screen/UserChatHeader.tsx
+++ b/packages/mobile/src/screens/chat-screen/UserChatHeader.tsx
@@ -1,41 +1,23 @@
 import type { User } from '@audius/common/models'
-import { TouchableOpacity } from 'react-native'
+import { css } from '@emotion/native'
 
+import { Flex } from '@audius/harmony-native'
 import { ProfilePicture } from 'app/components/core'
-import UserBadges from 'app/components/user-badges'
-import { useNavigation } from 'app/hooks/useNavigation'
-import { makeStyles } from 'app/styles'
-
-import type { AppTabScreenParamList } from '../app-screen'
-
-const useStyles = makeStyles(({ spacing, palette, typography }) => ({
-  profileTitle: {
-    display: 'flex',
-    flexDirection: 'row',
-    alignItems: 'center'
-  },
-  userBadgeTitle: {
-    fontSize: typography.fontSize.medium,
-    fontFamily: typography.fontByWeight.bold,
-    color: palette.neutral
-  }
-}))
+import { UserLink } from 'app/components/user-link'
 
 export const UserChatHeader = ({ user }: { user: User }) => {
-  const styles = useStyles()
-  const navigation = useNavigation<AppTabScreenParamList>()
   return (
-    <TouchableOpacity
-      onPress={() => navigation.push('Profile', { id: user.user_id })}
-      style={styles.profileTitle}
+    <Flex
+      direction='row'
+      justifyContent='center'
+      alignItems='center'
+      style={css({
+        maxWidth: '70%'
+      })}
+      gap='s'
     >
-      <ProfilePicture
-        userId={user.user_id}
-        size='small'
-        mr='s'
-        strokeWidth='thin'
-      />
-      <UserBadges user={user} nameStyle={styles.userBadgeTitle} />
-    </TouchableOpacity>
+      <ProfilePicture userId={user.user_id} size='small' strokeWidth='thin' />
+      <UserLink userId={user.user_id} textVariant='title' />
+    </Flex>
   )
 }

--- a/packages/mobile/src/screens/chat-screen/UserChatHeader.tsx
+++ b/packages/mobile/src/screens/chat-screen/UserChatHeader.tsx
@@ -1,23 +1,39 @@
 import type { User } from '@audius/common/models'
 import { css } from '@emotion/native'
+import { TouchableOpacity } from 'react-native'
 
 import { Flex } from '@audius/harmony-native'
 import { ProfilePicture } from 'app/components/core'
 import { UserLink } from 'app/components/user-link'
+import { useNavigation } from 'app/hooks/useNavigation'
+
+import type { AppTabScreenParamList } from '../app-screen'
 
 export const UserChatHeader = ({ user }: { user: User }) => {
+  const navigation = useNavigation<AppTabScreenParamList>()
   return (
     <Flex
-      direction='row'
-      justifyContent='center'
-      alignItems='center'
       style={css({
         maxWidth: '70%'
       })}
-      gap='s'
     >
-      <ProfilePicture userId={user.user_id} size='small' strokeWidth='thin' />
-      <UserLink userId={user.user_id} textVariant='title' />
+      <TouchableOpacity
+        onPress={() => navigation.push('Profile', { id: user.user_id })}
+      >
+        <Flex
+          direction='row'
+          justifyContent='center'
+          alignItems='center'
+          gap='s'
+        >
+          <ProfilePicture
+            userId={user.user_id}
+            size='small'
+            strokeWidth='thin'
+          />
+          <UserLink userId={user.user_id} textVariant='title' />
+        </Flex>
+      </TouchableOpacity>
     </Flex>
   )
 }


### PR DESCRIPTION
### Description
Bit of a janky fix but works.. not sure what the situation is with the bounding header for screens in RN, so trying to stuff like flex-shrink and `w=100%` weren't working.

### How Has This Been Tested?

before:
![Simulator Screenshot - iPhone 15 Pro - 2024-10-16 at 17 14 48](https://github.com/user-attachments/assets/3a394af4-8a35-4003-9c08-73be0d3480a2)

after:
![Simulator Screenshot - iPhone 15 Pro - 2024-10-16 at 17 14 43](https://github.com/user-attachments/assets/0ef08da6-e62b-4b4f-8f59-af5845fa774a)
