### PR TITLE
[C-5137] Set android cursor position when replying/editing

### DIFF
--- a/packages/mobile/src/components/comments/CommentDrawer.tsx
+++ b/packages/mobile/src/components/comments/CommentDrawer.tsx
@@ -241,6 +241,7 @@ export const CommentDrawer = (props: CommentDrawerPropsType) => {
 
   const handleClose = useCallback(() => {
     setIsOpen(false)
+    setReplyingAndEditingState?.(undefined)
   }, [setIsOpen])
 
   const renderFooterComponent = useCallback(

--- a/packages/mobile/src/components/comments/CommentForm.tsx
+++ b/packages/mobile/src/components/comments/CommentForm.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 
 import { useGetUserById } from '@audius/common/api'
 import { useCurrentCommentSection } from '@audius/common/context'
@@ -113,9 +113,7 @@ export const CommentForm = (props: CommentFormProps) => {
   useEffect(() => {
     if (replyingToComment && replyingToUser) {
       setInitialMessage(replyInitialMessage(replyingToUser.handle))
-      if (ref.current) {
-        ref.current.focus()
-      }
+      ref.current?.focus()
     }
   }, [replyingToComment, replyingToUser])
 

--- a/packages/mobile/src/components/composer-input/ComposerInput.tsx
+++ b/packages/mobile/src/components/composer-input/ComposerInput.tsx
@@ -127,7 +127,8 @@ export const ComposerInput = forwardRef(function ComposerInput(
     entityId,
     styles: propStyles,
     TextInputComponent,
-    displayCancelAccessory = false
+    displayCancelAccessory = false,
+    onLayout
   } = props
   const { data: currentUserId } = useGetCurrentUserId({})
   const [value, setValue] = useState(presetMessage ?? '')
@@ -523,6 +524,7 @@ export const ComposerInput = forwardRef(function ComposerInput(
         onChangeText={handleChange}
         onKeyPress={handleKeyDown}
         onSelectionChange={handleSelectionChange}
+        onLayout={onLayout}
         multiline
         value={value}
         inputAccessoryViewID={

--- a/packages/mobile/src/components/composer-input/types.ts
+++ b/packages/mobile/src/components/composer-input/types.ts
@@ -25,5 +25,5 @@ export type ComposerInputProps = {
   TextInputComponent?: typeof TextInput
 } & Pick<
   TextInputProps,
-  'maxLength' | 'placeholder' | 'onPressIn' | 'readOnly' | 'id'
+  'maxLength' | 'placeholder' | 'onPressIn' | 'readOnly' | 'id' | 'onLayout'
 >


### PR DESCRIPTION
### Description

* Use `onLayout` to set cursor position on android when replying/editing
* Add hitSlop to 'cancel' button in ComposeInputHelper
* Clear editing/replying state when closing drawer

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._
