### PR TITLE
Fix migration for challenge shortening

### DIFF
--- a/packages/discovery-provider/ddl/migrations/0095_shorten_challenge_ids.sql
+++ b/packages/discovery-provider/ddl/migrations/0095_shorten_challenge_ids.sql
@@ -1,4 +1,16 @@
 BEGIN;
+
+UPDATE challenges SET challenge_id = 'p' WHERE challenge_id = 'profile-completion';
+UPDATE challenges SET challenge_id = 'l' WHERE challenge_id = 'listen-streak';
+UPDATE challenges SET challenge_id = 'u' WHERE challenge_id = 'track-upload';
+UPDATE challenges SET challenge_id = 'r' WHERE challenge_id = 'referrals';
+UPDATE challenges SET challenge_id = 'rv' WHERE challenge_id = 'ref-v';
+UPDATE challenges SET challenge_id = 'rd' WHERE challenge_id = 'referred';
+UPDATE challenges SET challenge_id = 'v' WHERE challenge_id = 'connect-verified';
+UPDATE challenges SET challenge_id = 'm' WHERE challenge_id = 'mobile-install';
+UPDATE challenges SET challenge_id = 'ft' WHERE challenge_id = 'send-first-tip';
+UPDATE challenges SET challenge_id = 'fp' WHERE challenge_id = 'first-playlist';
+
 UPDATE user_challenges SET challenge_id = 'p' WHERE challenge_id = 'profile-completion';
 UPDATE user_challenges SET challenge_id = 'l' WHERE challenge_id = 'listen-streak';
 UPDATE user_challenges SET challenge_id = 'u' WHERE challenge_id = 'track-upload';


### PR DESCRIPTION
Turns out these were enums and also need updating. Didn't have this problem on localhost since the JSON seeds the correct data.

Fixes #9803 
