### PR TITLE
Improve mobile composer input render perf

### DIFF
--- a/packages/mobile/src/components/composer-input/ComposerInput.tsx
+++ b/packages/mobile/src/components/composer-input/ComposerInput.tsx
@@ -81,9 +81,6 @@ const useStyles = makeStyles(({ spacing, palette, typography }) => ({
     alignItems: 'center',
     paddingTop: 0
   },
-  hideText: {
-    color: 'transparent'
-  },
   overlayTextContainer: {
     position: 'absolute',
     pointerEvents: 'none',
@@ -516,8 +513,7 @@ export const ComposerInput = forwardRef(function ComposerInput(
           root: [styles.composeTextContainer, propStyles?.container],
           input: [
             styles.composeTextInput,
-            Platform.OS === 'ios' ? { paddingBottom: spacing(1.5) } : null,
-            isTextHighlighted ? styles.hideText : null
+            Platform.OS === 'ios' ? { paddingBottom: spacing(1.5) } : null
           ]
         }}
         onChangeText={handleChange}


### PR DESCRIPTION
### Description

The rendering of our custom elements is slower on mobile than web. I think this has to do with the React Native render cycle and bridging that paint back to the host OS. On web this isn't a problem, so when the input text behind where you're typing is transparent, things seem fast and responsive.

On mobile, it feels slow though. The transparent text is laid out almost immediately (yes, controlled inputs are fine), but the "rendered on top" text comes in a few ms later.

What makes this PR possible though ... is I've noticed that painting our rendered UI on top of the input (when transparency is removed) doesn't seem to cause any aliasing or glyph-ing that tends to happen on web (hence the original transparency change). I think that means we don't have to make the input itself have transparent text when we render above it.

This certainly could be a wrong assumption I have... because I haven't tested it exhaustively on all devices... BUT I do think it works from my observation.

So maybe here's how we can evaluate this change:

Before:
* Text feels kind of sluggish (only a couple ms delay, but if you type really fast, it feels off)
* You will never get into a situation where you see duplicate text

After:
* Text feels fast
* It is possible for you to see split seconds of "shadow" text where you type something, it autocompletes, the input changes and then the text on top changes. Feels kind of like there's a ghost
* It is possible for there to be a major layout bug where the text doesn't line up and you see duplicate text. Though I would argue, we should fix this regardless and it's not unique to this change

I am cool with either
1. closing PR
2. merging PR and testing on device
3. keeping it on the backburner

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._

Simulator, extensive logging & spamming