### PR TITLE
[C-5203] Fix comment unpin

### DIFF
--- a/packages/discovery-provider/plugins/notifications/src/types/dn.ts
+++ b/packages/discovery-provider/plugins/notifications/src/types/dn.ts
@@ -659,6 +659,7 @@ export interface TrackRow {
   musical_key?: string | null
   is_custom_musical_key?: boolean | null
   audio_analysis_error_count?: number
+  pinned_comment_id?: number | null
 }
 export interface TrendingParamRow {
   genre?: string | null
@@ -837,7 +838,6 @@ export interface CommentRow {
   text: string
   is_delete: boolean
   is_visible: boolean
-  is_pinned: boolean
   is_edited: boolean
   txhash?: string
 }

--- a/packages/discovery-provider/src/tasks/entity_manager/entities/comment.py
+++ b/packages/discovery-provider/src/tasks/entity_manager/entities/comment.py
@@ -328,7 +328,7 @@ def pin_comment(params: ManageEntityParameters):
 
 
 def unpin_comment(params: ManageEntityParameters):
-    validate_pin_tx(params, True)
+    validate_pin_tx(params, False)
     track_id = params.metadata["entity_id"]
     existing_track = params.existing_records[EntityType.TRACK.value][track_id]
 


### PR DESCRIPTION
### Description
Fixes issue where comment unpin always fails validation because of a misconfigured validation call. Adds tests to ensure pin, unpin, and pin override work