### PR TITLE
Re-land changes to fix RN on xcode 16

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22727,106 +22727,66 @@
       }
     },
     "node_modules/@sentry-internal/feedback": {
-      "version": "7.100.1",
-      "license": "MIT",
+      "version": "7.119.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/feedback/-/feedback-7.119.0.tgz",
+      "integrity": "sha512-om8TkAU5CQGO8nkmr7qsSBVkP+/vfeS4JgtW3sjoTK0fhj26+DljR6RlfCGWtYQdPSP6XV7atcPTjbSnsmG9FQ==",
       "dependencies": {
-        "@sentry/core": "7.100.1",
-        "@sentry/types": "7.100.1",
-        "@sentry/utils": "7.100.1"
+        "@sentry/core": "7.119.0",
+        "@sentry/types": "7.119.0",
+        "@sentry/utils": "7.119.0"
       },
       "engines": {
         "node": ">=12"
-      }
-    },
-    "node_modules/@sentry-internal/feedback/node_modules/@sentry/core": {
-      "version": "7.100.1",
-      "license": "MIT",
-      "dependencies": {
-        "@sentry/types": "7.100.1",
-        "@sentry/utils": "7.100.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@sentry-internal/feedback/node_modules/@sentry/types": {
-      "version": "7.100.1",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@sentry-internal/feedback/node_modules/@sentry/utils": {
-      "version": "7.100.1",
-      "license": "MIT",
-      "dependencies": {
-        "@sentry/types": "7.100.1"
-      },
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/@sentry-internal/replay-canvas": {
-      "version": "7.100.1",
-      "license": "MIT",
+      "version": "7.119.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/replay-canvas/-/replay-canvas-7.119.0.tgz",
+      "integrity": "sha512-NL02VQx6ekPxtVRcsdp1bp5Tb5w6vnfBKSIfMKuDRBy5A10Uc3GSoy/c3mPyHjOxB84452A+xZSx6bliEzAnuA==",
       "dependencies": {
-        "@sentry/core": "7.100.1",
-        "@sentry/replay": "7.100.1",
-        "@sentry/types": "7.100.1",
-        "@sentry/utils": "7.100.1"
+        "@sentry/core": "7.119.0",
+        "@sentry/replay": "7.119.0",
+        "@sentry/types": "7.119.0",
+        "@sentry/utils": "7.119.0"
       },
       "engines": {
         "node": ">=12"
       }
     },
-    "node_modules/@sentry-internal/replay-canvas/node_modules/@sentry-internal/tracing": {
-      "version": "7.100.1",
-      "license": "MIT",
+    "node_modules/@sentry-internal/tracing": {
+      "version": "7.119.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/tracing/-/tracing-7.119.0.tgz",
+      "integrity": "sha512-oKdFJnn+56f0DHUADlL8o9l8jTib3VDLbWQBVkjD9EprxfaCwt2m8L5ACRBdQ8hmpxCEo4I8/6traZ7qAdBUqA==",
       "dependencies": {
-        "@sentry/core": "7.100.1",
-        "@sentry/types": "7.100.1",
-        "@sentry/utils": "7.100.1"
+        "@sentry/core": "7.119.0",
+        "@sentry/types": "7.119.0",
+        "@sentry/utils": "7.119.0"
       },
       "engines": {
         "node": ">=8"
       }
     },
-    "node_modules/@sentry-internal/replay-canvas/node_modules/@sentry/core": {
-      "version": "7.100.1",
-      "license": "MIT",
-      "dependencies": {
-        "@sentry/types": "7.100.1",
-        "@sentry/utils": "7.100.1"
-      },
+    "node_modules/@sentry/babel-plugin-component-annotate": {
+      "version": "2.20.1",
+      "resolved": "https://registry.npmjs.org/@sentry/babel-plugin-component-annotate/-/babel-plugin-component-annotate-2.20.1.tgz",
+      "integrity": "sha512-4mhEwYTK00bIb5Y9UWIELVUfru587Vaeg0DQGswv4aIRHIiMKLyNqCEejaaybQ/fNChIZOKmvyqXk430YVd7Qg==",
       "engines": {
-        "node": ">=8"
+        "node": ">= 14"
       }
     },
-    "node_modules/@sentry-internal/replay-canvas/node_modules/@sentry/replay": {
-      "version": "7.100.1",
-      "license": "MIT",
+    "node_modules/@sentry/browser": {
+      "version": "7.119.0",
+      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-7.119.0.tgz",
+      "integrity": "sha512-WwmW1Y4D764kVGeKmdsNvQESZiAn9t8LmCWO0ucBksrjL2zw9gBPtOpRcO6l064sCLeSxxzCN+kIxhRm1gDFEA==",
       "dependencies": {
-        "@sentry-internal/tracing": "7.100.1",
-        "@sentry/core": "7.100.1",
-        "@sentry/types": "7.100.1",
-        "@sentry/utils": "7.100.1"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@sentry-internal/replay-canvas/node_modules/@sentry/types": {
-      "version": "7.100.1",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@sentry-internal/replay-canvas/node_modules/@sentry/utils": {
-      "version": "7.100.1",
-      "license": "MIT",
-      "dependencies": {
-        "@sentry/types": "7.100.1"
+        "@sentry-internal/feedback": "7.119.0",
+        "@sentry-internal/replay-canvas": "7.119.0",
+        "@sentry-internal/tracing": "7.119.0",
+        "@sentry/core": "7.119.0",
+        "@sentry/integrations": "7.119.0",
+        "@sentry/replay": "7.119.0",
+        "@sentry/types": "7.119.0",
+        "@sentry/utils": "7.119.0"
       },
       "engines": {
         "node": ">=8"
@@ -22865,6 +22825,102 @@
       "optional": true,
       "os": [
         "darwin"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@sentry/cli-linux-arm": {
+      "version": "2.36.1",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-linux-arm/-/cli-linux-arm-2.36.1.tgz",
+      "integrity": "sha512-gvEOKN0fWL2AVqUBKHNXPRZfJNvKTs8kQhS8cQqahZGgZHiPCI4BqW45cKMq+ZTt1UUbLmt6khx5Dz7wi+0i5A==",
+      "cpu": [
+        "arm"
+      ],
+      "optional": true,
+      "os": [
+        "linux",
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@sentry/cli-linux-arm64": {
+      "version": "2.36.1",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-linux-arm64/-/cli-linux-arm64-2.36.1.tgz",
+      "integrity": "sha512-R//3ZEkbzvoStr3IA7nxBZNiBYyxOljOqAhgiTnejXHmnuwDzM3TBA2n5vKPE/kBFxboEBEw0UTzTIRb1T0bgw==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux",
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@sentry/cli-linux-i686": {
+      "version": "2.36.1",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-linux-i686/-/cli-linux-i686-2.36.1.tgz",
+      "integrity": "sha512-R7sW5Vk/HacVy2YgQoQB+PwccvFYf2CZVPSFSFm2z7MEfNe77UYHWUq+sjJ4vxWG6HDWGVmaX0fjxyDkE01JRA==",
+      "cpu": [
+        "x86",
+        "ia32"
+      ],
+      "optional": true,
+      "os": [
+        "linux",
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@sentry/cli-linux-x64": {
+      "version": "2.36.1",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-linux-x64/-/cli-linux-x64-2.36.1.tgz",
+      "integrity": "sha512-UMr3ik8ksA7zQfbzsfwCb+ztenLnaeAbX94Gp+bzANZwPfi/vVHf2bLyqsBs4OyVt9SPlN1bbM/RTGfMjZ3JOw==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux",
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@sentry/cli-win32-i686": {
+      "version": "2.36.1",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-win32-i686/-/cli-win32-i686-2.36.1.tgz",
+      "integrity": "sha512-CflvhnvxPEs5GWQuuDtYSLqPrBaPbcSJFlBuUIb+8WNzRxvVfjgw1qzfZmkQqABqiy/YEsEekllOoMFZAvCcVA==",
+      "cpu": [
+        "x86",
+        "ia32"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@sentry/cli-win32-x64": {
+      "version": "2.36.1",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-win32-x64/-/cli-win32-x64-2.36.1.tgz",
+      "integrity": "sha512-wWqht2xghcK3TGnooHZSzA3WSjdtno/xFjZLvWmw38rblGwgKMxLZnlxV6uDyS+OJ6CbfDTlCRay/0TIqA0N8g==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
       ],
       "engines": {
         "node": ">=10"
@@ -23000,6 +23056,18 @@
         "webidl-conversions": "^3.0.0"
       }
     },
+    "node_modules/@sentry/core": {
+      "version": "7.119.0",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-7.119.0.tgz",
+      "integrity": "sha512-CS2kUv9rAJJEjiRat6wle3JATHypB0SyD7pt4cpX5y0dN5dZ1JrF57oLHRMnga9fxRivydHz7tMTuBhSSwhzjw==",
+      "dependencies": {
+        "@sentry/types": "7.119.0",
+        "@sentry/utils": "7.119.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/@sentry/hub": {
       "version": "6.2.5",
       "license": "BSD-3-Clause",
@@ -23028,6 +23096,20 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/@sentry/integrations": {
+      "version": "7.119.0",
+      "resolved": "https://registry.npmjs.org/@sentry/integrations/-/integrations-7.119.0.tgz",
+      "integrity": "sha512-OHShvtsRW0A+ZL/ZbMnMqDEtJddPasndjq+1aQXw40mN+zeP7At/V1yPZyFaURy86iX7Ucxw5BtmzuNy7hLyTA==",
+      "dependencies": {
+        "@sentry/core": "7.119.0",
+        "@sentry/types": "7.119.0",
+        "@sentry/utils": "7.119.0",
+        "localforage": "^1.8.1"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/@sentry/minimal": {
@@ -23099,6 +23181,158 @@
         "node": ">=6"
       }
     },
+    "node_modules/@sentry/react": {
+      "version": "7.119.0",
+      "resolved": "https://registry.npmjs.org/@sentry/react/-/react-7.119.0.tgz",
+      "integrity": "sha512-cf8Cei+qdSA26gx+IMAuc/k44PeBImNzIpXi3930SLhUe44ypT5OZ/44L6xTODHZzTIyMSJPduf59vT2+eW9yg==",
+      "dependencies": {
+        "@sentry/browser": "7.119.0",
+        "@sentry/core": "7.119.0",
+        "@sentry/types": "7.119.0",
+        "@sentry/utils": "7.119.0",
+        "hoist-non-react-statics": "^3.3.2"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "peerDependencies": {
+        "react": "15.x || 16.x || 17.x || 18.x"
+      }
+    },
+    "node_modules/@sentry/react-native": {
+      "version": "5.33.1",
+      "resolved": "https://registry.npmjs.org/@sentry/react-native/-/react-native-5.33.1.tgz",
+      "integrity": "sha512-k463M0wC+5FNJrKvzsE6uq7cjMKOrzT+hNm79sFjxqbw6vXgMHOjOcYsji7jFr5Nqr0jEOHm2niwsVlYEXGVAg==",
+      "dependencies": {
+        "@sentry/babel-plugin-component-annotate": "2.20.1",
+        "@sentry/browser": "7.119.0",
+        "@sentry/cli": "2.36.1",
+        "@sentry/core": "7.119.0",
+        "@sentry/hub": "7.119.0",
+        "@sentry/integrations": "7.119.0",
+        "@sentry/react": "7.119.0",
+        "@sentry/types": "7.119.0",
+        "@sentry/utils": "7.119.0"
+      },
+      "bin": {
+        "sentry-expo-upload-sourcemaps": "scripts/expo-upload-sourcemaps.js"
+      },
+      "peerDependencies": {
+        "expo": ">=49.0.0",
+        "react": ">=17.0.0",
+        "react-native": ">=0.65.0"
+      },
+      "peerDependenciesMeta": {
+        "expo": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@sentry/react-native/node_modules/@sentry/cli": {
+      "version": "2.36.1",
+      "resolved": "https://registry.npmjs.org/@sentry/cli/-/cli-2.36.1.tgz",
+      "integrity": "sha512-gzK5uQKDWKhyH5udoB5+oaUNrS//urWyaXgKvHKz4gFfl744HuKY9dpLPP2nMnf0zLGmGM6xJnMXLqILq0mtxw==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "https-proxy-agent": "^5.0.0",
+        "node-fetch": "^2.6.7",
+        "progress": "^2.0.3",
+        "proxy-from-env": "^1.1.0",
+        "which": "^2.0.2"
+      },
+      "bin": {
+        "sentry-cli": "bin/sentry-cli"
+      },
+      "engines": {
+        "node": ">= 10"
+      },
+      "optionalDependencies": {
+        "@sentry/cli-darwin": "2.36.1",
+        "@sentry/cli-linux-arm": "2.36.1",
+        "@sentry/cli-linux-arm64": "2.36.1",
+        "@sentry/cli-linux-i686": "2.36.1",
+        "@sentry/cli-linux-x64": "2.36.1",
+        "@sentry/cli-win32-i686": "2.36.1",
+        "@sentry/cli-win32-x64": "2.36.1"
+      }
+    },
+    "node_modules/@sentry/react-native/node_modules/@sentry/cli-darwin": {
+      "version": "2.36.1",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-darwin/-/cli-darwin-2.36.1.tgz",
+      "integrity": "sha512-JOHQjVD8Kqxm1jUKioAP5ohLOITf+Dh6+DBz4gQjCNdotsvNW5m63TKROwq2oB811p+Jzv5304ujmN4cAqW1Ww==",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@sentry/react-native/node_modules/@sentry/hub": {
+      "version": "7.119.0",
+      "resolved": "https://registry.npmjs.org/@sentry/hub/-/hub-7.119.0.tgz",
+      "integrity": "sha512-183h5B/rZosLxpB+ZYOvFdHk0rwZbKskxqKFtcyPbDAfpCUgCass41UTqyxF6aH1qLgCRxX8GcLRF7frIa/SOg==",
+      "dependencies": {
+        "@sentry/core": "7.119.0",
+        "@sentry/types": "7.119.0",
+        "@sentry/utils": "7.119.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@sentry/react-native/node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@sentry/react-native/node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
+    },
+    "node_modules/@sentry/react-native/node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
+    },
+    "node_modules/@sentry/react-native/node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
+    },
+    "node_modules/@sentry/replay": {
+      "version": "7.119.0",
+      "resolved": "https://registry.npmjs.org/@sentry/replay/-/replay-7.119.0.tgz",
+      "integrity": "sha512-BnNsYL+X5I4WCH6wOpY6HQtp4MgVt0NVlhLUsEyrvMUiTs0bPkDBrulsgZQBUKJsbOr3l9nHrFoNVB/0i6WNLA==",
+      "dependencies": {
+        "@sentry-internal/tracing": "7.119.0",
+        "@sentry/core": "7.119.0",
+        "@sentry/types": "7.119.0",
+        "@sentry/utils": "7.119.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/@sentry/tracing": {
       "version": "6.2.5",
       "license": "MIT",
@@ -23129,6 +23363,25 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/@sentry/types": {
+      "version": "7.119.0",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.119.0.tgz",
+      "integrity": "sha512-27qQbutDBPKGbuJHROxhIWc1i0HJaGLA90tjMu11wt0E4UNxXRX+UQl4Twu68v4EV3CPvQcEpQfgsViYcXmq+w==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@sentry/utils": {
+      "version": "7.119.0",
+      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-7.119.0.tgz",
+      "integrity": "sha512-ZwyXexWn2ZIe2bBoYnXJVPc2esCSbKpdc6+0WJa8eutXfHq3FRKg4ohkfCBpfxljQGEfP1+kfin945lA21Ka+A==",
+      "dependencies": {
+        "@sentry/types": "7.119.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/@sideway/address": {
@@ -47080,13 +47333,14 @@
       }
     },
     "node_modules/appcenter-file-upload-client/node_modules/form-data": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.5.1.tgz",
-      "integrity": "sha512-m21N3WOmEEURgk6B9GLOE4RuWOFf28Lhh9qGYeNlGq4VDXUlJy2th2slBNU8Gp8EzloYZOibZJ7t5ecIrFSjVA==",
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.5.2.tgz",
+      "integrity": "sha512-GgwY0PS7DbXqajuGf4OYlsrIu3zgxD6Vvql43IBhm6MahqA5SK/7mwhtNj2AdH2z35YR34ujJ7BN+3fFC3jP5Q==",
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.6",
-        "mime-types": "^2.1.12"
+        "mime-types": "^2.1.12",
+        "safe-buffer": "^5.2.1"
       },
       "engines": {
         "node": ">= 0.12"
@@ -87202,6 +87456,31 @@
         "prop-types": "^15.7.2"
       }
     },
+    "node_modules/react-native-code-push": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/react-native-code-push/-/react-native-code-push-9.0.0.tgz",
+      "integrity": "sha512-9Tf5t1xixIRi23fsCI5EODB20TpOs9BONCm57yDEAWO9+TQuw5VoF0eJXYBFjyK2ZAxhTxxPvxzkrHcZKItKUQ==",
+      "dependencies": {
+        "code-push": "^4.2.2",
+        "glob": "^7.1.7",
+        "hoist-non-react-statics": "^3.3.2",
+        "inquirer": "^8.1.5",
+        "plist": "^3.0.4",
+        "semver": "^7.3.5",
+        "xcode": "3.0.1"
+      }
+    },
+    "node_modules/react-native-code-push/node_modules/semver": {
+      "version": "7.6.3",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
+      "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/react-native-collapsible-tab-view": {
       "version": "2.0.2",
       "license": "MIT",
@@ -87376,6 +87655,14 @@
       "peerDependencies": {
         "react": ">=15.1 || >=16.0.0",
         "react-native": ">=0.40"
+      }
+    },
+    "node_modules/react-native-image-crop-picker": {
+      "version": "0.41.2",
+      "resolved": "https://registry.npmjs.org/react-native-image-crop-picker/-/react-native-image-crop-picker-0.41.2.tgz",
+      "integrity": "sha512-GcDu/adXU/1y/MrxsbOfqcGRGWC2pTttt5VGy/jyRJ6GXfoC29fTQf8SG5kGtc5schSR6K+mKYO4uW6eJPljlQ==",
+      "peerDependencies": {
+        "react-native": ">=0.40.0"
       }
     },
     "node_modules/react-native-inset-shadow": {
@@ -87787,6 +88074,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/react-native-zip-archive": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/react-native-zip-archive/-/react-native-zip-archive-7.0.1.tgz",
+      "integrity": "sha512-Zd3TDVCUQkAC3jjvmFjjJHOoig+ryYcOMrh7iLiwQCqe8TgrGJm3rhDNDgpfHKdLRMlIletvz2sh9OOttb0dZQ==",
+      "peerDependencies": {
+        "react": ">=16.8.6",
+        "react-native": ">=0.60.0"
       }
     },
     "node_modules/react-native/node_modules/@jest/create-cache-key-function": {
@@ -140549,278 +140845,6 @@
         "url": "https://github.com/sponsors/sayem314"
       }
     },
-    "packages/mobile/node_modules/@sentry-internal/tracing": {
-      "version": "7.100.1",
-      "license": "MIT",
-      "dependencies": {
-        "@sentry/core": "7.100.1",
-        "@sentry/types": "7.100.1",
-        "@sentry/utils": "7.100.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "packages/mobile/node_modules/@sentry/browser": {
-      "version": "7.100.1",
-      "license": "MIT",
-      "dependencies": {
-        "@sentry-internal/feedback": "7.100.1",
-        "@sentry-internal/replay-canvas": "7.100.1",
-        "@sentry-internal/tracing": "7.100.1",
-        "@sentry/core": "7.100.1",
-        "@sentry/replay": "7.100.1",
-        "@sentry/types": "7.100.1",
-        "@sentry/utils": "7.100.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "packages/mobile/node_modules/@sentry/cli": {
-      "version": "2.30.0",
-      "hasInstallScript": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "https-proxy-agent": "^5.0.0",
-        "node-fetch": "^2.6.7",
-        "progress": "^2.0.3",
-        "proxy-from-env": "^1.1.0",
-        "which": "^2.0.2"
-      },
-      "bin": {
-        "sentry-cli": "bin/sentry-cli"
-      },
-      "engines": {
-        "node": ">= 10"
-      },
-      "optionalDependencies": {
-        "@sentry/cli-darwin": "2.30.0",
-        "@sentry/cli-linux-arm": "2.30.0",
-        "@sentry/cli-linux-arm64": "2.30.0",
-        "@sentry/cli-linux-i686": "2.30.0",
-        "@sentry/cli-linux-x64": "2.30.0",
-        "@sentry/cli-win32-i686": "2.30.0",
-        "@sentry/cli-win32-x64": "2.30.0"
-      }
-    },
-    "packages/mobile/node_modules/@sentry/cli-darwin": {
-      "version": "2.30.0",
-      "license": "BSD-3-Clause",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "packages/mobile/node_modules/@sentry/cli-linux-arm": {
-      "version": "2.30.0",
-      "resolved": "https://registry.npmjs.org/@sentry/cli-linux-arm/-/cli-linux-arm-2.30.0.tgz",
-      "integrity": "sha512-MDB3iS31WKg4krCcLo520yxbUERPeA2DCtk9Qs9vSDbQl6Er64dteHllOdx1SDOyX/7GKcxrQEQ6SMmbnOo6wg==",
-      "cpu": [
-        "arm"
-      ],
-      "optional": true,
-      "os": [
-        "linux",
-        "freebsd"
-      ],
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "packages/mobile/node_modules/@sentry/cli-linux-arm64": {
-      "version": "2.30.0",
-      "resolved": "https://registry.npmjs.org/@sentry/cli-linux-arm64/-/cli-linux-arm64-2.30.0.tgz",
-      "integrity": "sha512-JNXPkkMubKoZVlcFIoClSmTb9C/I6Bz08DuAZm2jnjRaaOMiCBxI/l50H3dmfVZ6apjEguG9JkjFdb0kqKB90w==",
-      "cpu": [
-        "arm64"
-      ],
-      "optional": true,
-      "os": [
-        "linux",
-        "freebsd"
-      ],
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "packages/mobile/node_modules/@sentry/cli-linux-i686": {
-      "version": "2.30.0",
-      "resolved": "https://registry.npmjs.org/@sentry/cli-linux-i686/-/cli-linux-i686-2.30.0.tgz",
-      "integrity": "sha512-WhVVziFQw/fO0Cc53pY8goPAzJtIs6ORTR89fVbKwa3ZDNkX++mEOECbP7RkmD87kuRxyKzN543RPV971PcAHw==",
-      "cpu": [
-        "x86",
-        "ia32"
-      ],
-      "optional": true,
-      "os": [
-        "linux",
-        "freebsd"
-      ],
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "packages/mobile/node_modules/@sentry/cli-linux-x64": {
-      "version": "2.30.0",
-      "resolved": "https://registry.npmjs.org/@sentry/cli-linux-x64/-/cli-linux-x64-2.30.0.tgz",
-      "integrity": "sha512-QkiVDeSfspotZ0Au5Yauv2DAm/BC1fL9BwPek/WwddM18I2HqnDp6l4TA4bQeEY++o0KEuNF53cPahpepltPjw==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "linux",
-        "freebsd"
-      ],
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "packages/mobile/node_modules/@sentry/cli-win32-i686": {
-      "version": "2.30.0",
-      "resolved": "https://registry.npmjs.org/@sentry/cli-win32-i686/-/cli-win32-i686-2.30.0.tgz",
-      "integrity": "sha512-xLY9B1EEGuNYPKpK6M9PMmcu2PzofdvRtbraTcU6Ck2zALS5oXB9kmWc4dDKucZ/uu9JB0m+Lo4ebaNlca45qQ==",
-      "cpu": [
-        "x86",
-        "ia32"
-      ],
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "packages/mobile/node_modules/@sentry/cli-win32-x64": {
-      "version": "2.30.0",
-      "resolved": "https://registry.npmjs.org/@sentry/cli-win32-x64/-/cli-win32-x64-2.30.0.tgz",
-      "integrity": "sha512-CiXuxnpJI0zho0XE5PVqIS9CwjDEYoMnHQRIr4Jj9OzlGTJ2iSSU6Zp3Ykd7lgo2iK4P6MfxIBm30gFQPnSvVA==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "packages/mobile/node_modules/@sentry/core": {
-      "version": "7.100.1",
-      "license": "MIT",
-      "dependencies": {
-        "@sentry/types": "7.100.1",
-        "@sentry/utils": "7.100.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "packages/mobile/node_modules/@sentry/hub": {
-      "version": "7.100.1",
-      "license": "MIT",
-      "dependencies": {
-        "@sentry/core": "7.100.1",
-        "@sentry/types": "7.100.1",
-        "@sentry/utils": "7.100.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "packages/mobile/node_modules/@sentry/integrations": {
-      "version": "7.100.1",
-      "license": "MIT",
-      "dependencies": {
-        "@sentry/core": "7.100.1",
-        "@sentry/types": "7.100.1",
-        "@sentry/utils": "7.100.1",
-        "localforage": "^1.8.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "packages/mobile/node_modules/@sentry/react": {
-      "version": "7.100.1",
-      "license": "MIT",
-      "dependencies": {
-        "@sentry/browser": "7.100.1",
-        "@sentry/core": "7.100.1",
-        "@sentry/types": "7.100.1",
-        "@sentry/utils": "7.100.1",
-        "hoist-non-react-statics": "^3.3.2"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "peerDependencies": {
-        "react": "15.x || 16.x || 17.x || 18.x"
-      }
-    },
-    "packages/mobile/node_modules/@sentry/react-native": {
-      "version": "5.19.3",
-      "license": "MIT",
-      "dependencies": {
-        "@sentry/browser": "7.100.1",
-        "@sentry/cli": "2.30.0",
-        "@sentry/core": "7.100.1",
-        "@sentry/hub": "7.100.1",
-        "@sentry/integrations": "7.100.1",
-        "@sentry/react": "7.100.1",
-        "@sentry/types": "7.100.1",
-        "@sentry/utils": "7.100.1"
-      },
-      "bin": {
-        "sentry-expo-upload-sourcemaps": "scripts/expo-upload-sourcemaps.js"
-      },
-      "peerDependencies": {
-        "expo": ">=49.0.0",
-        "react": ">=17.0.0",
-        "react-native": ">=0.65.0"
-      },
-      "peerDependenciesMeta": {
-        "expo": {
-          "optional": true
-        }
-      }
-    },
-    "packages/mobile/node_modules/@sentry/replay": {
-      "version": "7.100.1",
-      "license": "MIT",
-      "dependencies": {
-        "@sentry-internal/tracing": "7.100.1",
-        "@sentry/core": "7.100.1",
-        "@sentry/types": "7.100.1",
-        "@sentry/utils": "7.100.1"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "packages/mobile/node_modules/@sentry/types": {
-      "version": "7.100.1",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "packages/mobile/node_modules/@sentry/utils": {
-      "version": "7.100.1",
-      "license": "MIT",
-      "dependencies": {
-        "@sentry/types": "7.100.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "packages/mobile/node_modules/@solana/web3.js": {
       "version": "1.92.3",
       "license": "MIT",
@@ -141896,20 +141920,6 @@
         "node": ">=10.0.0"
       }
     },
-    "packages/mobile/node_modules/react-native-code-push": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/react-native-code-push/-/react-native-code-push-9.0.0.tgz",
-      "integrity": "sha512-9Tf5t1xixIRi23fsCI5EODB20TpOs9BONCm57yDEAWO9+TQuw5VoF0eJXYBFjyK2ZAxhTxxPvxzkrHcZKItKUQ==",
-      "dependencies": {
-        "code-push": "^4.2.2",
-        "glob": "^7.1.7",
-        "hoist-non-react-statics": "^3.3.2",
-        "inquirer": "^8.1.5",
-        "plist": "^3.0.4",
-        "semver": "^7.3.5",
-        "xcode": "3.0.1"
-      }
-    },
     "packages/mobile/node_modules/react-native-config": {
       "version": "1.5.1",
       "license": "MIT",
@@ -141944,13 +141954,6 @@
       "license": "MIT",
       "peerDependencies": {
         "react-native": ">=0.60.0"
-      }
-    },
-    "packages/mobile/node_modules/react-native-image-crop-picker": {
-      "version": "0.40.2",
-      "license": "MIT",
-      "peerDependencies": {
-        "react-native": ">=0.40.0"
       }
     },
     "packages/mobile/node_modules/react-native-image-picker": {
@@ -142112,15 +142115,6 @@
       "peerDependencies": {
         "react": "*",
         "react-native": "*"
-      }
-    },
-    "packages/mobile/node_modules/react-native-zip-archive": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/react-native-zip-archive/-/react-native-zip-archive-7.0.1.tgz",
-      "integrity": "sha512-Zd3TDVCUQkAC3jjvmFjjJHOoig+ryYcOMrh7iLiwQCqe8TgrGJm3rhDNDgpfHKdLRMlIletvz2sh9OOttb0dZQ==",
-      "peerDependencies": {
-        "react": ">=16.8.6",
-        "react-native": ">=0.60.0"
       }
     },
     "packages/mobile/node_modules/react-refresh": {

--- a/packages/mobile/android/app/build.gradle
+++ b/packages/mobile/android/app/build.gradle
@@ -56,7 +56,12 @@ project.ext.envConfigFiles = [
     releasecandidaterelease: ".env.prod"
 ]
 
-apply from: "../../node_modules/@sentry/react-native/sentry.gradle"
+def sentryGradleFile = file("../../../../node_modules/@sentry/react-native/sentry.gradle")
+if (!sentryGradleFile.exists()) {
+    sentryGradleFile = file("../../node_modules/@sentry/react-native/sentry.gradle")
+}
+
+apply from: sentryGradleFile
 apply from: project(':react-native-config').projectDir.getPath() + "/dotenv.gradle"
 
 /**
@@ -204,6 +209,8 @@ dependencies {
         implementation jscFlavor
     }
 }
+
+
 
 apply from: "../../node_modules/react-native-code-push/android/codepush.gradle"
 apply from: file("../../../../node_modules/@react-native-community/cli-platform-android/native_modules.gradle"); applyNativeModulesAppBuildGradle(project)

--- a/packages/mobile/ios/Podfile.lock
+++ b/packages/mobile/ios/Podfile.lock
@@ -1191,15 +1191,15 @@ PODS:
     - glog
     - RCT-Folly (= 2022.05.16.00)
     - React-Core
-  - RNImageCropPicker (0.40.2):
+  - RNImageCropPicker (0.41.2):
     - React-Core
     - React-RCTImage
-    - RNImageCropPicker/QBImagePickerController (= 0.40.2)
-    - TOCropViewController
-  - RNImageCropPicker/QBImagePickerController (0.40.2):
+    - RNImageCropPicker/QBImagePickerController (= 0.41.2)
+    - TOCropViewController (~> 2.7.4)
+  - RNImageCropPicker/QBImagePickerController (0.41.2):
     - React-Core
     - React-RCTImage
-    - TOCropViewController
+    - TOCropViewController (~> 2.7.4)
   - RNPermissions (4.0.1):
     - React-Core
   - RNReactNativeHapticFeedback (2.2.0):
@@ -1213,11 +1213,13 @@ PODS:
     - glog
     - RCT-Folly (= 2022.05.16.00)
     - React-Core
-  - RNSentry (5.19.3):
+  - RNSentry (5.33.1):
+    - glog
     - hermes-engine
+    - RCT-Folly (= 2022.05.16.00)
     - React-Core
     - React-hermes
-    - Sentry/HybridSDK (= 8.21.0)
+    - Sentry/HybridSDK (= 8.36.0)
   - RNShare (10.0.2):
     - React-Core
   - RNSVG (15.7.1):
@@ -1235,9 +1237,7 @@ PODS:
   - SDWebImageWebPCoder (0.8.5):
     - libwebp (~> 1.0)
     - SDWebImage/Core (~> 5.10)
-  - Sentry/HybridSDK (8.21.0):
-    - SentryPrivate (= 8.21.0)
-  - SentryPrivate (8.21.0)
+  - Sentry/HybridSDK (8.36.0)
   - snap-kit-react-native (0.4.0):
     - React-Core
     - SnapSDK/SCSDKCreativeKit (~> 1.15.0)
@@ -1348,15 +1348,15 @@ DEPENDENCIES:
   - "RNFingerprintjsPro (from `../node_modules/@fingerprintjs/fingerprintjs-pro-react-native`)"
   - RNFS (from `../../../node_modules/react-native-fs`)
   - RNGestureHandler (from `../../../node_modules/react-native-gesture-handler`)
-  - RNImageCropPicker (from `../node_modules/react-native-image-crop-picker`)
+  - RNImageCropPicker (from `../../../node_modules/react-native-image-crop-picker`)
   - RNPermissions (from `../node_modules/react-native-permissions`)
   - RNReactNativeHapticFeedback (from `../node_modules/react-native-haptic-feedback`)
   - RNReanimated (from `../../../node_modules/react-native-reanimated`)
   - RNScreens (from `../../../node_modules/react-native-screens`)
-  - "RNSentry (from `../node_modules/@sentry/react-native`)"
+  - "RNSentry (from `../../../node_modules/@sentry/react-native`)"
   - RNShare (from `../node_modules/react-native-share`)
   - RNSVG (from `../../../node_modules/react-native-svg`)
-  - RNZipArchive (from `../node_modules/react-native-zip-archive`)
+  - RNZipArchive (from `../../../node_modules/react-native-zip-archive`)
   - "snap-kit-react-native (from `../../../node_modules/@snapchat/snap-kit-react-native`)"
   - SRSRadialGradient (from `../node_modules/react-native-radial-gradient/ios`)
   - Yoga (from `../node_modules/react-native/ReactCommon/yoga`)
@@ -1380,7 +1380,6 @@ SPEC REPOS:
     - SDWebImage
     - SDWebImageWebPCoder
     - Sentry
-    - SentryPrivate
     - SnapSDK
     - SocketRocket
     - SSZipArchive
@@ -1565,7 +1564,7 @@ EXTERNAL SOURCES:
   RNGestureHandler:
     :path: "../../../node_modules/react-native-gesture-handler"
   RNImageCropPicker:
-    :path: "../node_modules/react-native-image-crop-picker"
+    :path: "../../../node_modules/react-native-image-crop-picker"
   RNPermissions:
     :path: "../node_modules/react-native-permissions"
   RNReactNativeHapticFeedback:
@@ -1575,13 +1574,13 @@ EXTERNAL SOURCES:
   RNScreens:
     :path: "../../../node_modules/react-native-screens"
   RNSentry:
-    :path: "../node_modules/@sentry/react-native"
+    :path: "../../../node_modules/@sentry/react-native"
   RNShare:
     :path: "../node_modules/react-native-share"
   RNSVG:
     :path: "../../../node_modules/react-native-svg"
   RNZipArchive:
-    :path: "../node_modules/react-native-zip-archive"
+    :path: "../../../node_modules/react-native-zip-archive"
   snap-kit-react-native:
     :path: "../../../node_modules/@snapchat/snap-kit-react-native"
   SRSRadialGradient:
@@ -1691,19 +1690,18 @@ SPEC CHECKSUMS:
   RNFingerprintjsPro: b92c7eeff80f567abea771a4a3aaa196799caf7c
   RNFS: 4ac0f0ea233904cb798630b3c077808c06931688
   RNGestureHandler: 61bfdfc05db9b79dd61f894dcd29d3dcc6db3c02
-  RNImageCropPicker: d9616a0cb9b72e8551ff94a7a5021fbd29050aa5
+  RNImageCropPicker: 771e2ca319d2cf92e04ebf334ece892ee9a6728f
   RNPermissions: e6379535a4f3166931b2ada9dfe6cdd10c80ae6a
   RNReactNativeHapticFeedback: ec56a5f81c3941206fd85625fa669ffc7b4545f9
   RNReanimated: 18faeee6e1d8eb9a60f1a62488bb357354569051
   RNScreens: b582cb834dc4133307562e930e8fa914b8c04ef2
-  RNSentry: 73baf47160d2f25b62e31a1850eb788f04c1706f
+  RNSentry: 4d242db00fcefeec086c80f4f7a4512a90c9b2ac
   RNShare: 859ff710211285676b0bcedd156c12437ea1d564
   RNSVG: 4590aa95758149fa27c5c83e54a6a466349a1688
   RNZipArchive: 7bb4c70d6aa2dd235212c0a4a3de0a4e237e2569
   SDWebImage: a7f831e1a65eb5e285e3fb046a23fcfbf08e696d
   SDWebImageWebPCoder: 908b83b6adda48effe7667cd2b7f78c897e5111d
-  Sentry: ebc12276bd17613a114ab359074096b6b3725203
-  SentryPrivate: d651efb234cf385ec9a1cdd3eff94b5e78a0e0fe
+  Sentry: f8374b5415bc38dfb5645941b3ae31230fbeae57
   snap-kit-react-native: 751006199818fccb38c8a01196495167bc25e9fb
   SnapSDK: 1e68aad748e080f49e3802559b3b76026666ef62
   SocketRocket: f32cd54efbe0f095c4d7594881e52619cfe80b17


### PR DESCRIPTION
### Description
The lockfile changes from #9830 got undone by accident with the big PR to split SDK from libs. This broke my local dev environment :-).
I manually uninstalled/re-installed the packages that were changed in that PR to get the lockfile back to a good state.

I still do not understand why NPM can't reconcile a version difference between one single `package.json` file and the repo-level `package-lock.json` file. It absolutely refuses to update the lockfile unless I manually uninstall/reinstall 🤷 .

### How Has This Been Tested?
Will confirm local dev can build and run the mobile app and that Ci passes.
