### PR TITLE
Fix get new blasts endpoint sql error

### DIFF
--- a/comms/discovery/db/queries/get_new_blasts.go
+++ b/comms/discovery/db/queries/get_new_blasts.go
@@ -36,7 +36,7 @@ func GetNewBlasts(q db.Queryable, ctx context.Context, arg ChatMembershipParams)
 			select created_at as t from chat_blocked_users where blocker_user_id = $1
 			union
 			select to_timestamp(0)
-		)
+		) as timestamp_subquery
 	),
 	all_new as (
 		select *


### PR DESCRIPTION
### Description
We were getting this error when calling the get new blasts endpoint:
```
pq: subquery in FROM must have an alias
```

turns out it fails in postgres 15 but is ok in postgres 16 which is why it was ok in the comms tests, but not ok once deployed. @stereosteve is going to specify the version in tests docker.

### How Has This Been Tested?

Tested in local stack, get new blasts endpoint succeeds!