### PR TITLE
[QA-1773] Fix corner overflow on GiantTrackTile

### DIFF
--- a/packages/web/src/components/track/GiantTrackTile.tsx
+++ b/packages/web/src/components/track/GiantTrackTile.tsx
@@ -31,7 +31,8 @@ import {
   IconShare,
   IconRocket,
   Button,
-  MusicBadge
+  MusicBadge,
+  Paper
 } from '@audius/harmony'
 import IconCalendarMonth from '@audius/harmony/src/assets/icons/CalendarMonth.svg'
 import IconRobot from '@audius/harmony/src/assets/icons/Robot.svg'
@@ -444,7 +445,7 @@ export const GiantTrackTile = ({
   }
 
   return (
-    <Flex className={styles.giantTrackTile}>
+    <Paper className={styles.giantTrackTile}>
       <Tile
         dogEar={dogEarType}
         size='large'
@@ -627,6 +628,6 @@ export const GiantTrackTile = ({
           ) : null}
         </Flex>
       </Tile>
-    </Flex>
+    </Paper>
   )
 }


### PR DESCRIPTION
### Description

The bottom corners on GiantTrackTile were overflowing

Fixed using Paper instead of Flex for the top level container as Paper has overflow:hidden and is appropriate here anyway.

### How Has This Been Tested?

![image](https://github.com/user-attachments/assets/c672685f-d266-4314-ba3c-f1d1bab7eb93)
