### PR TITLE
[PAY-3522] Hides keyboard when opening purchase drawer from a DM

### DIFF
--- a/packages/mobile/src/components/drawer/Drawer.tsx
+++ b/packages/mobile/src/components/drawer/Drawer.tsx
@@ -1,12 +1,5 @@
 import type { ComponentType, ReactNode } from 'react'
-import {
-  useLayoutEffect,
-  useMemo,
-  useCallback,
-  useEffect,
-  useRef,
-  useState
-} from 'react'
+import { useMemo, useCallback, useEffect, useRef, useState } from 'react'
 
 import type {
   GestureResponderEvent,
@@ -427,11 +420,11 @@ export const Drawer: DrawerComponent = ({
   )
 
   // If keyboard was visible when a drawer opens, hide it.
-  useLayoutEffect(() => {
-    if (dismissKeyboardOnOpen && Keyboard.isVisible()) {
+  useEffect(() => {
+    if (isOpen && dismissKeyboardOnOpen && Keyboard.isVisible()) {
       Keyboard.dismiss()
     }
-  })
+  }, [isOpen, dismissKeyboardOnOpen])
 
   useEffect(() => {
     if (isOpen) {

--- a/packages/mobile/src/components/drawer/Drawer.tsx
+++ b/packages/mobile/src/components/drawer/Drawer.tsx
@@ -1,5 +1,12 @@
 import type { ComponentType, ReactNode } from 'react'
-import { useMemo, useCallback, useEffect, useRef, useState } from 'react'
+import {
+  useLayoutEffect,
+  useMemo,
+  useCallback,
+  useEffect,
+  useRef,
+  useState
+} from 'react'
 
 import type {
   GestureResponderEvent,
@@ -9,6 +16,7 @@ import type {
   ViewStyle
 } from 'react-native'
 import {
+  Keyboard,
   Animated,
   PanResponder,
   Platform,
@@ -158,6 +166,10 @@ export type DrawerProps = {
    */
   initialOffsetPosition?: number
   /**
+   * Dismiss the keyboard when this drawer opens. Defaults to `false`
+   */
+  dismissKeyboardOnOpen?: boolean
+  /**
    * Whether or not the drawer should close to the initial offset. i.e.
    * has it been opened to the offset once?
    */
@@ -280,7 +292,8 @@ export const Drawer: DrawerComponent = ({
   onPanResponderMove,
   onPanResponderRelease,
   translationAnim: providedTranslationAnim,
-  disableSafeAreaView
+  disableSafeAreaView,
+  dismissKeyboardOnOpen = false
 }: DrawerProps) => {
   const styles = useStyles()
   const insets = useSafeAreaInsets()
@@ -412,6 +425,13 @@ export const Drawer: DrawerComponent = ({
       drawerHeight
     ]
   )
+
+  // If keyboard was visible when a drawer opens, hide it.
+  useLayoutEffect(() => {
+    if (dismissKeyboardOnOpen && Keyboard.isVisible()) {
+      Keyboard.dismiss()
+    }
+  })
 
   useEffect(() => {
     if (isOpen) {

--- a/packages/mobile/src/components/premium-content-purchase-drawer/PremiumContentPurchaseDrawer.tsx
+++ b/packages/mobile/src/components/premium-content-purchase-drawer/PremiumContentPurchaseDrawer.tsx
@@ -521,6 +521,7 @@ export const PremiumContentPurchaseDrawer = () => {
       onClosed={handleClosed}
       isGestureSupported={false}
       isFullscreen
+      dismissKeyboardOnOpen
     >
       {isLoading ? (
         <View style={styles.spinnerContainer}>

--- a/packages/sdk/src/sdk/api/generated/full/models/SearchTrackFull.ts
+++ b/packages/sdk/src/sdk/api/generated/full/models/SearchTrackFull.ts
@@ -525,12 +525,6 @@ export interface SearchTrackFull {
      * @memberof SearchTrackFull
      */
     downloadConditions?: AccessGate;
-    /**
-     * 
-     * @type {number}
-     * @memberof SearchTrackFull
-     */
-    pinnedCommentId?: number;
 }
 
 /**
@@ -656,7 +650,6 @@ export function SearchTrackFullFromJSONTyped(json: any, ignoreDiscriminator: boo
         'streamConditions': !exists(json, 'stream_conditions') ? undefined : AccessGateFromJSON(json['stream_conditions']),
         'isDownloadGated': json['is_download_gated'],
         'downloadConditions': !exists(json, 'download_conditions') ? undefined : AccessGateFromJSON(json['download_conditions']),
-        'pinnedCommentId': !exists(json, 'pinned_comment_id') ? undefined : json['pinned_comment_id'],
     };
 }
 
@@ -742,7 +735,6 @@ export function SearchTrackFullToJSON(value?: SearchTrackFull | null): any {
         'stream_conditions': AccessGateToJSON(value.streamConditions),
         'is_download_gated': value.isDownloadGated,
         'download_conditions': AccessGateToJSON(value.downloadConditions),
-        'pinned_comment_id': value.pinnedCommentId,
     };
 }
 

--- a/packages/sdk/src/sdk/api/generated/full/models/TrackFull.ts
+++ b/packages/sdk/src/sdk/api/generated/full/models/TrackFull.ts
@@ -525,12 +525,6 @@ export interface TrackFull {
      * @memberof TrackFull
      */
     downloadConditions?: AccessGate;
-    /**
-     * 
-     * @type {number}
-     * @memberof TrackFull
-     */
-    pinnedCommentId?: number;
 }
 
 /**
@@ -658,7 +652,6 @@ export function TrackFullFromJSONTyped(json: any, ignoreDiscriminator: boolean):
         'streamConditions': !exists(json, 'stream_conditions') ? undefined : AccessGateFromJSON(json['stream_conditions']),
         'isDownloadGated': json['is_download_gated'],
         'downloadConditions': !exists(json, 'download_conditions') ? undefined : AccessGateFromJSON(json['download_conditions']),
-        'pinnedCommentId': !exists(json, 'pinned_comment_id') ? undefined : json['pinned_comment_id'],
     };
 }
 
@@ -744,7 +737,6 @@ export function TrackFullToJSON(value?: TrackFull | null): any {
         'stream_conditions': AccessGateToJSON(value.streamConditions),
         'is_download_gated': value.isDownloadGated,
         'download_conditions': AccessGateToJSON(value.downloadConditions),
-        'pinned_comment_id': value.pinnedCommentId,
     };
 }
 


### PR DESCRIPTION
### Description
We explicitly disable keyboard hiding on tap for the FlatList so that you can scroll around in the chat and interact with items (favoriting tracks etc) without losing your in progress message composition.

I settled on implementing an optional behavior in `Drawer` that will dismiss the keyboard on mount, and then configured the purchase drawer to use that behavior. I didn't want to make this the default behavior for all drawers due to the large surface area that would impact and also the strange interaction that happens if you tap a track inside a DM to play it (player is also a drawer 😄 )


### How Has This Been Tested?
Tested on simulator against staging.

### Screen recording
https://github.com/user-attachments/assets/dbecf068-28c8-4a9a-a851-874a002e7357

