### PR TITLE
[C-5212] Open comment drawer from empty state

### DIFF
--- a/packages/mobile/src/components/comments/CommentDrawer.tsx
+++ b/packages/mobile/src/components/comments/CommentDrawer.tsx
@@ -199,6 +199,7 @@ const BORDER_RADIUS = 40
 export type CommentDrawerData = {
   entityId: number
   navigation: NativeStackNavigationProp<ParamListBase>
+  autoFocusInput?: boolean
 }
 
 type CommentDrawerProps = {
@@ -207,7 +208,13 @@ type CommentDrawerProps = {
 } & CommentDrawerData
 
 export const CommentDrawer = (props: CommentDrawerProps) => {
-  const { entityId, navigation, bottomSheetModalRef, handleClose } = props
+  const {
+    entityId,
+    navigation,
+    bottomSheetModalRef,
+    handleClose,
+    autoFocusInput
+  } = props
   const { color } = useTheme()
   const insets = useSafeAreaInsets()
   const commentListRef = useRef<BottomSheetFlatListMethods>(null)
@@ -245,6 +252,7 @@ export const CommentDrawer = (props: CommentDrawerProps) => {
             commentListRef={commentListRef}
             onAutocompleteChange={onAutoCompleteChange}
             setAutocompleteHandler={setAutocompleteHandler}
+            autoFocus={autoFocusInput}
           />
         </CommentSectionProvider>
       </BottomSheetFooter>

--- a/packages/mobile/src/components/comments/CommentDrawerContext.tsx
+++ b/packages/mobile/src/components/comments/CommentDrawerContext.tsx
@@ -54,8 +54,7 @@ export const CommentDrawerProvider = (props: PropsWithChildren) => {
       {children}
       {drawerData ? (
         <CommentDrawer
-          entityId={drawerData!.entityId}
-          navigation={drawerData!.navigation}
+          {...drawerData}
           bottomSheetModalRef={bottomSheetModalRef}
           handleClose={close}
         />

--- a/packages/mobile/src/components/comments/CommentDrawerForm.tsx
+++ b/packages/mobile/src/components/comments/CommentDrawerForm.tsx
@@ -23,10 +23,16 @@ type CommentDrawerFormProps = {
   commentListRef: RefObject<BottomSheetFlatListMethods>
   onAutocompleteChange?: (isActive: boolean, value: string) => void
   setAutocompleteHandler?: (handler: (user: UserMetadata) => void) => void
+  autoFocus?: boolean
 }
 
 export const CommentDrawerForm = (props: CommentDrawerFormProps) => {
-  const { commentListRef, onAutocompleteChange, setAutocompleteHandler } = props
+  const {
+    commentListRef,
+    onAutocompleteChange,
+    setAutocompleteHandler,
+    autoFocus
+  } = props
   const insets = useSafeAreaInsets()
   const { entityId, replyingAndEditingState, setReplyingAndEditingState } =
     useCurrentCommentSection()
@@ -69,6 +75,7 @@ export const CommentDrawerForm = (props: CommentDrawerFormProps) => {
         onAutocompleteChange={onAutocompleteChange}
         setAutocompleteHandler={setAutocompleteHandler}
         TextInputComponent={BottomSheetTextInput as any}
+        autoFocus={autoFocus}
       />
     </Box>
   )

--- a/packages/mobile/src/components/comments/CommentForm.tsx
+++ b/packages/mobile/src/components/comments/CommentForm.tsx
@@ -75,6 +75,7 @@ type CommentFormProps = {
   onAutocompleteChange?: (isActive: boolean, value: string) => void
   setAutocompleteHandler?: (handler: (user: UserMetadata) => void) => void
   TextInputComponent?: typeof RNTextInput
+  autoFocus?: boolean
 }
 
 export const CommentForm = (props: CommentFormProps) => {
@@ -84,7 +85,8 @@ export const CommentForm = (props: CommentFormProps) => {
     onAutocompleteChange,
     onSubmit,
     initialValue,
-    TextInputComponent
+    TextInputComponent,
+    autoFocus
   } = props
   const [messageId, setMessageId] = useState(0)
   const [initialMessage, setInitialMessage] = useState(initialValue)
@@ -127,6 +129,12 @@ export const CommentForm = (props: CommentFormProps) => {
       ref.current?.focus()
     }
   }, [editingComment])
+
+  useEffect(() => {
+    if (autoFocus) {
+      ref.current?.focus()
+    }
+  }, [autoFocus])
 
   const handleLayout = useCallback(() => {
     if (

--- a/packages/mobile/src/components/comments/CommentForm.tsx
+++ b/packages/mobile/src/components/comments/CommentForm.tsx
@@ -69,7 +69,7 @@ const CommentFormHelperText = (props: CommentFormHelperTextProps) => {
 }
 
 type CommentFormProps = {
-  onSubmit: (commentMessage: string, mentions?: ID[]) => void
+  onSubmit?: (commentMessage: string, mentions?: ID[]) => void
   initialValue?: string
   isLoading?: boolean
   onAutocompleteChange?: (isActive: boolean, value: string) => void
@@ -83,7 +83,7 @@ export const CommentForm = (props: CommentFormProps) => {
     isLoading,
     setAutocompleteHandler,
     onAutocompleteChange,
-    onSubmit,
+    onSubmit = () => {},
     initialValue,
     TextInputComponent,
     autoFocus

--- a/packages/mobile/src/components/comments/CommentSection.tsx
+++ b/packages/mobile/src/components/comments/CommentSection.tsx
@@ -69,7 +69,7 @@ const CommentSectionHeader = (props: CommentSectionHeaderProps) => {
 }
 
 type CommentSectionContentProps = {
-  openCommentDrawer: (autoFocus?: boolean) => void
+  openCommentDrawer: (args?: { autoFocusInput?: boolean }) => void
 }
 
 const CommentSectionContent = (props: CommentSectionContentProps) => {
@@ -85,7 +85,7 @@ const CommentSectionContent = (props: CommentSectionContentProps) => {
   }, [openCommentDrawer])
 
   const handleFormPress = useCallback(() => {
-    openCommentDrawer(true)
+    openCommentDrawer({ autoFocusInput: true })
   }, [openCommentDrawer])
 
   // Loading state
@@ -140,7 +140,8 @@ export const CommentSection = (props: CommentSectionProps) => {
   const { open } = useCommentDrawer()
 
   const openCommentDrawer = useCallback(
-    (autoFocusInput?: boolean) => {
+    (args: { autoFocusInput?: boolean } = {}) => {
+      const { autoFocusInput } = args
       open({ entityId, navigation, autoFocusInput })
     },
     [open, entityId, navigation]

--- a/packages/mobile/src/components/comments/CommentSection.tsx
+++ b/packages/mobile/src/components/comments/CommentSection.tsx
@@ -2,8 +2,7 @@ import { useCallback } from 'react'
 
 import {
   CommentSectionProvider,
-  useCurrentCommentSection,
-  usePostComment
+  useCurrentCommentSection
 } from '@audius/common/context'
 import { commentsMessages as messages } from '@audius/common/messages'
 import type { ID } from '@audius/common/models'
@@ -81,12 +80,6 @@ const CommentSectionContent = (props: CommentSectionContentProps) => {
     isEntityOwner
   } = useCurrentCommentSection()
 
-  const [postComment] = usePostComment()
-
-  const handlePostComment = (message: string, mentions?: ID[]) => {
-    postComment(message, undefined, undefined, mentions)
-  }
-
   const handlePress = useCallback(() => {
     openCommentDrawer()
   }, [openCommentDrawer])
@@ -118,7 +111,7 @@ const CommentSectionContent = (props: CommentSectionContentProps) => {
         <TouchableWithoutFeedback onPress={handleFormPress}>
           <View>
             <View pointerEvents='none'>
-              <CommentForm onSubmit={handlePostComment} />
+              <CommentForm />
             </View>
           </View>
         </TouchableWithoutFeedback>


### PR DESCRIPTION
### Description

* Pressing the comment form in the empty state opens the comment drawer and focuses the input

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._
