### PR TITLE
Fix mac prod build, remove warnings

### DIFF
--- a/.circleci/src/jobs/@web-jobs.yml
+++ b/.circleci/src/jobs/@web-jobs.yml
@@ -318,7 +318,7 @@ web-dist-linux-staging:
 web-dist-mac-production:
   working_directory: ~/audius-protocol
   # run on macos so dmg can be created and signed.
-  resource_class: macos.m1.medium.gen1
+  resource_class: macos.m1.large.gen1
   macos:
     xcode: '15.2.0'
   steps:

--- a/packages/web/scripts/dist.js
+++ b/packages/web/scripts/dist.js
@@ -153,7 +153,8 @@ const makeBuildParams = (isProduction) => {
         target: {
           target: 'default',
           arch: 'universal'
-        }
+        },
+        minimumSystemVersion: '12'
       },
       dmg: {
         icon: dmgIcns,


### PR DESCRIPTION
### Description
- Fixes mac prod build which didn't have enough resources to complete
- Removes mac build warning that our minimum mac version was too low
