### PR TITLE
Unblock download track geo indexing

### DIFF
--- a/packages/discovery-provider/src/tasks/entity_manager/entities/track.py
+++ b/packages/discovery-provider/src/tasks/entity_manager/entities/track.py
@@ -498,6 +498,10 @@ def validate_track_tx(params: ManageEntityParameters):
     if params.action == Action.DOWNLOAD:
         if track_id not in params.existing_records["Track"]:
             raise IndexingValidationError(f"Track {track_id} does not exist")
+        if not params.metadata:
+            raise IndexingValidationError(
+                f"Download track {track_id} must have metadata"
+            )
 
     if params.action != Action.DELETE and params.action != Action.DOWNLOAD:
         ai_attribution_user_id = params.metadata.get("ai_attribution_user_id")


### PR DESCRIPTION
### Description
```
in download_track\n    city=params.metadata.get(\"city\"),\n         ^^^^^^^^^^^^^^^^^^^\nAttributeError: 'str' object has no attribute 'get'", 
```

may want more validation on having city, or default to null

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._
