### PR TITLE
[C-5218] [C-5154] Restrict mobile comment input length

### DIFF
--- a/packages/mobile/src/components/comments/CommentDrawerHeader.tsx
+++ b/packages/mobile/src/components/comments/CommentDrawerHeader.tsx
@@ -70,10 +70,10 @@ export const CommentDrawerHeader = (props: CommentDrawerHeaderProps) => {
 
   return (
     <>
-      <Flex p='l' gap='m'>
-        <TouchableWithoutFeedback onPress={dismissKeyboard}>
-          <View>
-            <View pointerEvents={keyboardShown ? 'none' : undefined}>
+      <TouchableWithoutFeedback onPress={dismissKeyboard}>
+        <View>
+          <View pointerEvents={keyboardShown ? 'none' : undefined}>
+            <Flex p='l' gap='m'>
               <Flex
                 direction='row'
                 w='100%'
@@ -104,10 +104,10 @@ export const CommentDrawerHeader = (props: CommentDrawerHeaderProps) => {
                 />
               </Flex>
               {showCommentSortBar && !minimal ? <CommentSortBar /> : null}
-            </View>
+            </Flex>
           </View>
-        </TouchableWithoutFeedback>
-      </Flex>
+        </View>
+      </TouchableWithoutFeedback>
       {isOwner ? (
         <Portal hostName='DrawerPortal'>
           <ActionDrawerWithoutRedux

--- a/packages/mobile/src/components/comments/CommentForm.tsx
+++ b/packages/mobile/src/components/comments/CommentForm.tsx
@@ -167,10 +167,12 @@ export const CommentForm = (props: CommentFormProps) => {
   return (
     <Flex direction='row' gap='m' alignItems='center'>
       {currentUserId ? (
-        <ProfilePicture
-          userId={currentUserId}
-          style={{ width: 40, height: 40, flexShrink: 0 }}
-        />
+        <Flex alignSelf='flex-start' pt='unit1' alignItems='center'>
+          <ProfilePicture
+            userId={currentUserId}
+            style={{ width: 40, height: 40, flexShrink: 0 }}
+          />
+        </Flex>
       ) : null}
       <Flex flex={1}>
         {showHelperText ? (
@@ -192,6 +194,7 @@ export const CommentForm = (props: CommentFormProps) => {
             displayCancelAccessory={!showHelperText}
             TextInputComponent={TextInputComponent}
             onLayout={handleLayout}
+            maxLength={400}
             styles={{
               container: {
                 borderTopLeftRadius: showHelperText ? 0 : spacing.unit1,

--- a/packages/mobile/src/components/composer-input/ComposerInput.tsx
+++ b/packages/mobile/src/components/composer-input/ComposerInput.tsx
@@ -120,7 +120,8 @@ export const ComposerInput = forwardRef(function ComposerInput(
     styles: propStyles,
     TextInputComponent,
     displayCancelAccessory = false,
-    onLayout
+    onLayout,
+    maxLength = 10000
   } = props
   const { data: currentUserId } = useGetCurrentUserId({})
   const [value, setValue] = useState(presetMessage ?? '')
@@ -507,7 +508,7 @@ export const ComposerInput = forwardRef(function ComposerInput(
         inputAccessoryViewID={
           displayCancelAccessory ? 'cancelButtonAccessoryView' : 'none'
         }
-        maxLength={10000}
+        maxLength={maxLength}
         autoCorrect
         TextInputComponent={TextInputComponent}
       />

--- a/packages/mobile/src/components/composer-input/ComposerInput.tsx
+++ b/packages/mobile/src/components/composer-input/ComposerInput.tsx
@@ -29,7 +29,7 @@ import type {
   TextInputSelectionChangeEventData
 } from 'react-native/types'
 
-import { IconSend, mergeRefs } from '@audius/harmony-native'
+import { Flex, IconSend, mergeRefs } from '@audius/harmony-native'
 import { Text, TextInput } from 'app/components/core'
 import { env } from 'app/env'
 import { audiusSdk } from 'app/services/sdk/audius-sdk'
@@ -385,15 +385,17 @@ export const ComposerInput = forwardRef(function ComposerInput(
       hitSlop={spacing(2)}
       style={styles.submit}
     >
-      {isLoading ? (
-        <LoadingSpinner />
-      ) : (
-        <IconSend
-          width={styles.icon.width}
-          height={styles.icon.height}
-          fill={hasLength ? primary : neutralLight7}
-        />
-      )}
+      <Flex pv='xs'>
+        {isLoading ? (
+          <LoadingSpinner />
+        ) : (
+          <IconSend
+            width={styles.icon.width}
+            height={styles.icon.height}
+            fill={hasLength ? primary : neutralLight7}
+          />
+        )}
+      </Flex>
     </TouchableOpacity>
   )
 

--- a/packages/mobile/src/components/core/TextInput.tsx
+++ b/packages/mobile/src/components/core/TextInput.tsx
@@ -439,13 +439,11 @@ export const TextInput = forwardRef<RNTextInput, TextInputProps>(
                 </TouchableWithoutFeedback>
               </Animated.View>
             ) : Icon ? (
-              <Flex pv='xs'>
-                <Icon
-                  fill={iconProps.fill}
-                  height={iconProps.height}
-                  width={iconProps.width}
-                />
-              </Flex>
+              <Icon
+                fill={iconProps.fill}
+                height={iconProps.height}
+                width={iconProps.width}
+              />
             ) : null}
             {endAdornment ? (
               <View style={styles.endAdornment}>{endAdornment}</View>

--- a/packages/mobile/src/components/core/TextInput.tsx
+++ b/packages/mobile/src/components/core/TextInput.tsx
@@ -23,8 +23,7 @@ import {
   Animated,
   TextInput as RNTextInput,
   View,
-  Pressable,
-  Text
+  Pressable
 } from 'react-native'
 import { TouchableWithoutFeedback } from 'react-native-gesture-handler'
 import type { SvgProps } from 'react-native-svg'
@@ -101,11 +100,6 @@ const useStyles = makeStyles(({ typography, palette, spacing }) => ({
   doneButton: {
     marginRight: spacing(4),
     marginVertical: spacing(3)
-  },
-  maxLength: {
-    color: palette.neutralLight4,
-    fontSize: typography.fontSize.small,
-    marginLeft: spacing(2)
   }
 }))
 


### PR DESCRIPTION
### Description

* Restrict comment input length to 400
  ComposeInput is still using the legacy TextInput which did not support max length display. I attempted to migrate it to harmony TextInput but it ended up being quite a lot of work. Instead I added the max length display to the legacy TextInput. This is kinda gross because it's importing harmony components. But we can always come back and clean it up ™️ 
* Went ahead and knocked out the layout changes in C-5154 because the positioning of the max length display depended on it
* Fixed small layout issue with drawer header I caused
![Simulator Screenshot - iPhone 15 Pro - 2024-10-21 at 15 49 31](https://github.com/user-attachments/assets/8b7b013c-7ca2-429a-999e-40925ba38c4a)

### How Has This Been Tested?

Tested max length on ios, tested inputs app wide to confirm no breaking changes
