### PR TITLE
[C-5229] Fix comment input focus on android

### DIFF
--- a/packages/common/src/context/comments/commentsContext.tsx
+++ b/packages/common/src/context/comments/commentsContext.tsx
@@ -125,6 +125,11 @@ export function CommentSectionProvider<NavigationProp>(
   const { onOpen: openPremiumContentPurchaseModal } =
     usePremiumContentPurchaseModal()
 
+  const handleCloseDrawer = useCallback(() => {
+    closeDrawer?.()
+    setReplyingAndEditingState?.(undefined)
+  }, [closeDrawer, setReplyingAndEditingState])
+
   const playTrack = useCallback(
     (timestampSeconds?: number) => {
       const uid = lineup?.entries?.[0]?.uid
@@ -188,7 +193,7 @@ export function CommentSectionProvider<NavigationProp>(
         playTrack,
         loadMorePages,
         navigation,
-        closeDrawer
+        closeDrawer: handleCloseDrawer
       }}
     >
       {children}

--- a/packages/mobile/src/components/comments/CommentForm.tsx
+++ b/packages/mobile/src/components/comments/CommentForm.tsx
@@ -115,15 +115,20 @@ export const CommentForm = (props: CommentFormProps) => {
     setMessageId((id) => ++id)
   }
 
+  const focusInput = useCallback(() => {
+    // setTimeout is required to focus the input on android
+    setTimeout(() => ref.current?.focus())
+  }, [ref])
+
   /**
    * Populate and focus input when replying to a comment
    */
   useEffect(() => {
     if (replyingToComment && replyingToUser) {
       setInitialMessage(replyInitialMessage(replyingToUser.handle))
-      ref.current?.focus()
+      focusInput()
     }
-  }, [replyingToComment, replyingToUser])
+  }, [replyingToComment, replyingToUser, focusInput])
 
   /**
    * Populate and focus input when editing a comment
@@ -131,16 +136,15 @@ export const CommentForm = (props: CommentFormProps) => {
   useEffect(() => {
     if (editingComment) {
       setInitialMessage(editingComment.message)
-      ref.current?.focus()
+      focusInput()
     }
-  }, [editingComment])
+  }, [editingComment, focusInput])
 
   useEffect(() => {
     if (autoFocus) {
-      // setTimeout is required to focus the input on android
-      setTimeout(() => ref.current?.focus(), 0)
+      focusInput()
     }
-  }, [autoFocus])
+  }, [autoFocus, focusInput])
 
   const handleLayout = useCallback(() => {
     if (


### PR DESCRIPTION
### Description

* Fix showing keyboard when autofocusing input on android
* Fix clearing of replyingAndEditingState when closing the drawer (broken in #10103 )

### How Has This Been Tested?

Confirmed keyboard opens as expected
