### PR TITLE
[QA-1775] Fix validation error in mobile EditCollection

### DIFF
--- a/packages/mobile/src/screens/edit-collection-screen/EditCollectionScreen.tsx
+++ b/packages/mobile/src/screens/edit-collection-screen/EditCollectionScreen.tsx
@@ -47,12 +47,11 @@ export const EditCollectionScreen = () => {
 
   if (!playlist) return null
 
-  const { tracks: tracksIgnored, ...restPlaylist } = playlist
-
   const initialValues: EditCollectionValues = {
-    entityType: restPlaylist.is_album ? 'album' : 'playlist',
-    ...restPlaylist,
-    description: restPlaylist.description ?? '',
+    entityType: playlist.is_album ? 'album' : 'playlist',
+    ...playlist,
+    tracks: [],
+    description: playlist.description ?? '',
     artwork: {
       url:
         trackImage && isImageUriSource(trackImage.source)


### PR DESCRIPTION
### Description

We wanted to omit the existing tracks list, but tracks is required in the schema.
Need to instantiate the initial values properly

### How Has This Been Tested?

saving is working now; double checked that the empty tracks value does not result in deleting any existing tracks on save