### PR TITLE
fix block page hash link

### DIFF
--- a/pkg/core/console/block.go
+++ b/pkg/core/console/block.go
@@ -4,6 +4,8 @@ import (
 	"strconv"
 
 	"github.com/AudiusProject/audius-protocol/pkg/core/console/views/pages"
+	abci "github.com/cometbft/cometbft/abci/types"
+	gogo_proto "github.com/cosmos/gogoproto/proto"
 	"github.com/labstack/echo/v4"
 )
 
@@ -30,7 +32,11 @@ func (con *Console) blockPage(c echo.Context) error {
 
 	txs := [][]byte{}
 	for _, tx := range blockTxs{
-		txs = append(txs, tx.TxResult)
+		var result abci.TxResult
+		if err := gogo_proto.Unmarshal(tx.TxResult, &result); err != nil {
+			return err
+		}
+		txs = append(txs, result.GetTx())
 	}
 
 	data := &pages.BlockView{


### PR DESCRIPTION
### Description
when you click a tx on the block page it doesn't resolve, this is because we're hashing the full tx result not the tx itself
### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._
