### PR TITLE
[QA-1755] Fix toggling on native genre pills

### DIFF
--- a/packages/mobile/src/screens/sign-on-screen/screens/SelectGenresScreen.tsx
+++ b/packages/mobile/src/screens/sign-on-screen/screens/SelectGenresScreen.tsx
@@ -29,7 +29,10 @@ const initialValues: SelectGenresValue = { genres: [] }
 /* Memoized SelectablePill to fix a performance issue.
  * The code below is arranged so that the pills don't need to re-render,
  * And the memoization here is just forcing it to never re-render. */
-const MemoSelectablePill = memo(SelectablePill, () => true)
+const MemoSelectablePill = memo(
+  SelectablePill,
+  (prevProps, nextProps) => prevProps.isSelected === nextProps.isSelected
+)
 
 const SelectGenresFieldArray = () => {
   // Storing values as state alongside Formik purely because setState provides access to the previous values
@@ -76,6 +79,7 @@ const SelectGenresFieldArray = () => {
             onPress={() => {
               handlePress(genre.value)
             }}
+            isSelected={formValues.includes(genre.value)}
             key={genre.value}
           />
         ))}


### PR DESCRIPTION
### Description

Fix issue where the genre pills were not re-rendering when the value changed.
Pills would become selected but not unselected.

Updated the memoization to re-render when the value changes. The comment above seems to indicate this isn't necessary, but it wasn't working in my testing. @DejayJD if you know a better fix, pls lmk

### How Has This Been Tested?

toggling on and off genres is working, produces the right values