### PR TITLE
[C-5168] Fix android toasts

### DIFF
--- a/packages/mobile/src/components/toasts/Toast.tsx
+++ b/packages/mobile/src/components/toasts/Toast.tsx
@@ -71,6 +71,8 @@ export const Toast = (props: ToastProps) => {
   const dispatch = useDispatch()
 
   const handleDismiss = useCallback(() => {
+    // Hack alert: For some reason, dismissing toasts on Android breaks the toast
+    // system. It should be okay to let toasts persist on android for now.
     if (Platform.OS === 'ios') {
       dispatch(dismissToast({ key }))
     }

--- a/packages/mobile/src/components/toasts/Toast.tsx
+++ b/packages/mobile/src/components/toasts/Toast.tsx
@@ -4,7 +4,7 @@ import type { Toast as ToastType } from '@audius/common/store'
 import { toastActions } from '@audius/common/store'
 import { Link } from '@react-navigation/native'
 import type { To } from '@react-navigation/native/lib/typescript/src/useLinkTo'
-import { Animated, View } from 'react-native'
+import { Animated, Platform, View } from 'react-native'
 import { useSafeAreaInsets } from 'react-native-safe-area-context'
 import { useDispatch } from 'react-redux'
 
@@ -71,7 +71,9 @@ export const Toast = (props: ToastProps) => {
   const dispatch = useDispatch()
 
   const handleDismiss = useCallback(() => {
-    dispatch(dismissToast({ key }))
+    if (Platform.OS === 'ios') {
+      dispatch(dismissToast({ key }))
+    }
   }, [dispatch, key])
 
   const animateOut = useCallback(() => {


### PR DESCRIPTION
### Description

"Fixes" issue where android toasts stop working after the first one or two. I traced down the issue to the "dismissToast" call. It works on ios, but doesn't on android. The thing is, we dont really need to dismiss them from the store, they will just continue to be "off", even if the data stays collected in redux. Ideally we figure out a better solution, but i think this is okay for now, because i dont expect the number of toasts per session to be that much to lead to performance impacts.

@schottra added you because i remember we discussed this as while back
