### PR TITLE
Fix disabling notif arn endpoints

### DIFF
--- a/packages/discovery-provider/plugins/notifications/src/sns.ts
+++ b/packages/discovery-provider/plugins/notifications/src/sns.ts
@@ -7,7 +7,6 @@ import {
 } from '@aws-sdk/client-sns'
 import { logger } from './logger'
 import { DeviceType } from './processNotifications/mappers/userNotificationSettings'
-import { Knex } from 'knex'
 
 const region = process.env.AWS_REGION
 const accessKeyId = process.env.AWS_ACCESS_KEY_ID
@@ -27,6 +26,7 @@ export const publish = async (params: PublishCommandInput) => {
     logger.warn(
       `Error publishing push notification for awsARN ${params.TargetArn}: ${err.stack}`
     )
+    throw err.Error
   }
 }
 
@@ -145,11 +145,7 @@ export const sendPushNotification = async (
       })
     }
   } catch (e) {
-    if (
-      e &&
-      e.code &&
-      (e.code === 'EndpointDisabled' || e.code === 'InvalidParameter')
-    ) {
+    if (e?.Code === 'EndpointDisabled' || e?.Code === 'InvalidParameter') {
       return { endpointDisabled: true, arn: device.targetARN }
     }
   }


### PR DESCRIPTION
### Description
- Error was not getting re-thrown in `publish` fn
- Needed to unwrap the inner `Error` object
- `code` needed to be capitalized to `Code`

### How Has This Been Tested?

Tested by running the code on notifications plugin on prod DN1, confirmed we got some disabled rows in the db.
