### PR TITLE
[C-5252] Fix external links on mobile

### DIFF
--- a/packages/mobile/src/components/core/Link.tsx
+++ b/packages/mobile/src/components/core/Link.tsx
@@ -24,11 +24,18 @@ export const useOnOpenLink = (
       }
 
       try {
-        const supported = await Linking.canOpenURL(url)
+        const urlWithPrefix = url.startsWith('http') ? url : `https://${url}`
+        const supported = await Linking.canOpenURL(urlWithPrefix)
         if (supported) {
-          await Linking.openURL(url)
+          await Linking.openURL(urlWithPrefix)
           if (source) {
-            track(make({ eventName: EventNames.LINK_CLICKING, url, source }))
+            track(
+              make({
+                eventName: EventNames.LINK_CLICKING,
+                url: urlWithPrefix,
+                source
+              })
+            )
           }
         } else {
           toast(errorToastConfig)


### PR DESCRIPTION
### Description

Links weren't guaranteed to start with `http(s)://`
Interestingly, `Linking.canOpenURL` would return true because it would try to open the file in the local directory of the app (e.g. `"Unable to open URL: file:///.../Audius%20Music.app/www.google.com"`)

Added check to add the prefix if not present.

### How Has This Been Tested?

The link now opens properly. Checked that we don't use this Link component for internal routing that would break with http prefix.