### PR TITLE
[C-5224] Limit number of mentions to 10 in comment indexing

### DIFF
--- a/packages/discovery-provider/integration_tests/tasks/entity_manager/test_comment.py
+++ b/packages/discovery-provider/integration_tests/tasks/entity_manager/test_comment.py
@@ -30,6 +30,15 @@ entities = {
         {"user_id": 1, "wallet": "user1wallet"},
         {"user_id": 2, "wallet": "user2wallet"},
         {"user_id": 3, "wallet": "user3wallet"},
+        {"user_id": 4, "wallet": "user4wallet"},
+        {"user_id": 5, "wallet": "user5wallet"},
+        {"user_id": 6, "wallet": "user6wallet"},
+        {"user_id": 7, "wallet": "user7wallet"},
+        {"user_id": 8, "wallet": "user8wallet"},
+        {"user_id": 9, "wallet": "user9wallet"},
+        {"user_id": 10, "wallet": "user10wallet"},
+        {"user_id": 11, "wallet": "user11wallet"},
+        {"user_id": 12, "wallet": "user12wallet"},
     ],
     "tracks": [{"track_id": 1, "owner_id": 1}],
 }
@@ -290,6 +299,69 @@ def test_comment_mention(app, mocker):
         assert len(comment_notifications) == 0
 
 
+def test_comment_mention_limit(app, mocker):
+    """
+    Test that only the first 10 mentions are saved and notified
+    """
+
+    mention_comment_metadata = {
+        **comment_metadata,
+        "body": "@user-1 @user-2 @user-3 @user-4 @user-5 @user-6 @user-7 @user-8 @user-9 @user-10 @user-11 @user-12 comment text",
+        "mentions": [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12],
+    }
+
+    tx_receipts = {
+        "CreateComment": [
+            {
+                "args": AttributeDict(
+                    {
+                        "_entityId": 1,
+                        "_entityType": "Comment",
+                        "_userId": 3,
+                        "_action": "Create",
+                        "_metadata": f'{{"cid": "", "data": {json.dumps(mention_comment_metadata)}}}',
+                        "_signer": "user3wallet",
+                    }
+                )
+            },
+        ],
+    }
+
+    db, index_transaction = setup_test(app, mocker, entities, tx_receipts)
+
+    with db.scoped_session() as session:
+        index_transaction(session)
+
+        assert len(session.query(Comment).all()) == 1
+        assert len(session.query(CommentMention).all()) == 10
+
+        # Assert only the first 10 mentions receive notifications
+        comment_mention_notifications = (
+            session.query(Notification)
+            .filter(Notification.type == "comment_mention")
+            .order_by(Notification.user_ids)
+            .all()
+        )
+        assert len(comment_mention_notifications) == 9  # Excluding track owner (user 1)
+        assert [n.user_ids[0] for n in comment_mention_notifications] == [
+            1,
+            2,
+            4,
+            5,
+            6,
+            7,
+            8,
+            9,
+            10,
+        ]
+
+        # Assert track owner does not receive comment notification
+        comment_notifications = (
+            session.query(Notification).filter(Notification.type == "comment").all()
+        )
+        assert len(comment_notifications) == 0
+
+
 def test_comment_mention_reply(app, mocker):
     """
     Test that a comment reply that mentions the parent comment user only sends them a reply notification
@@ -461,6 +533,101 @@ def test_edit_comment(app, mocker):
         assert mention_notifications[1].user_ids == [3]
         # TODO ideally we can prevent this if it's in the same block
         assert mention_notifications[2].user_ids == [4]
+
+
+def test_edit_comment_mention_limit(app, mocker):
+    """
+    Test that editing a comment only persists and notifies the first 10 mentions
+    """
+
+    initial_comment_metadata = {
+        **comment_metadata,
+        "body": "Initial comment text",
+        "mentions": [],
+    }
+
+    edit_comment_metadata = {
+        **comment_metadata,
+        "body": "@user-1 @user-2 @user-3 @user-4 @user-5 @user-6 @user-7 @user-8 @user-9 @user-10 @user-11 @user-12 edited comment text",
+        "mentions": [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12],
+    }
+
+    edit_comment_entities = {
+        **entities,
+        "comments": [{"comment_id": 1, "user_id": 3, "entity_id": 1}],
+    }
+
+    tx_receipts = {
+        "CreateComment": [
+            {
+                "args": AttributeDict(
+                    {
+                        "_entityId": 1,
+                        "_entityType": "Comment",
+                        "_userId": 3,
+                        "_action": "Create",
+                        "_metadata": f'{{"cid": "", "data": {json.dumps(initial_comment_metadata)}}}',
+                        "_signer": "user3wallet",
+                    }
+                )
+            },
+        ],
+        "UpdateComment": [
+            {
+                "args": AttributeDict(
+                    {
+                        "_entityId": 1,
+                        "_entityType": "Comment",
+                        "_userId": 3,
+                        "_action": "Update",
+                        "_metadata": f'{{"cid": "", "data": {json.dumps(edit_comment_metadata)}}}',
+                        "_signer": "user3wallet",
+                    }
+                )
+            },
+        ],
+    }
+
+    db, index_transaction = setup_test(app, mocker, edit_comment_entities, tx_receipts)
+
+    with db.scoped_session() as session:
+        index_transaction(session)
+
+        comments = session.query(Comment).all()
+        assert len(comments) == 1
+        assert (
+            comments[0].text
+            == "@user-1 @user-2 @user-3 @user-4 @user-5 @user-6 @user-7 @user-8 @user-9 @user-10 @user-11 @user-12 edited comment text"
+        )
+        assert comments[0].is_edited == True
+
+        comment_mentions = session.query(CommentMention).all()
+        assert len(comment_mentions) == 10
+
+        mention_notifications = (
+            session.query(Notification)
+            .filter(Notification.type == "comment_mention")
+            .order_by(Notification.user_ids)
+            .all()
+        )
+        assert len(mention_notifications) == 9  # Excluding track owner (user 1)
+        assert [n.user_ids[0] for n in mention_notifications] == [
+            1,
+            2,
+            4,
+            5,
+            6,
+            7,
+            8,
+            9,
+            10,
+        ]
+
+        # Assert track owner does not receive comment notification
+        comment_notifications = (
+            session.query(Notification).filter(Notification.type == "comment").all()
+        )
+        assert len(comment_notifications) == 0
 
 
 def test_pin_comment(app, mocker):

--- a/packages/discovery-provider/src/tasks/entity_manager/entities/comment.py
+++ b/packages/discovery-provider/src/tasks/entity_manager/entities/comment.py
@@ -84,7 +84,9 @@ def create_comment(params: ManageEntityParameters):
     entity_id = metadata.get("entity_id")
     entity_type = metadata.get("entity_type", EntityType.TRACK.value)
     entity_user_id = existing_records[EntityType.TRACK.value][entity_id].owner_id
-    mentions = set(metadata.get("mentions") or [])
+    mentions = set(
+        list(metadata.get("mentions") or [])[:10]
+    )  # Only persist the first 10 mentions
     is_owner_mentioned = entity_user_id in mentions
     parent_comment_id = metadata.get("parent_comment_id")
     parent_comment = (
@@ -291,7 +293,9 @@ def update_comment(params: ManageEntityParameters):
         or False
     )
 
-    mentions = set(metadata.get("mentions") or [])
+    mentions = set(
+        list(metadata.get("mentions") or [])[:10]
+    )  # Only persist the first 10 mentions
     parent_comment_id = metadata.get("parent_comment_id")
     parent_comment = existing_records[EntityType.COMMENT.value].get(parent_comment_id)
     parent_comment_user_id = parent_comment.user_id if parent_comment else None


### PR DESCRIPTION
### Description

* Limit number of mentions in comment create and update to 10. This doesn't throw an error when the mentions exceed the limit, it silently uses only the first 10

Follow up work for the UI next

### How Has This Been Tested?

Added tests for create and update mention limit. All tests pass
