### PR TITLE
[C-5226] [C-5225] Allow ComposerInput scrolling with mentions

### DIFF
--- a/packages/mobile/src/components/comments/CommentBlock.tsx
+++ b/packages/mobile/src/components/comments/CommentBlock.tsx
@@ -87,7 +87,12 @@ export const CommentBlockInternal = (
         ) : null}
         {!isTombstone ? (
           <Flex direction='row' gap='s' alignItems='center' w='65%'>
-            <UserLink userId={userId} strength='strong' onPress={closeDrawer} />
+            <UserLink
+              userId={userId}
+              strength='strong'
+              onPress={closeDrawer}
+              lineHeight='single'
+            />
             <Flex direction='row' gap='xs' alignItems='center' h='100%'>
               <Timestamp time={dayjs.utc(createdAt).toDate()} />
               {trackTimestampS !== undefined ? (

--- a/packages/mobile/src/components/comments/CommentDrawer.tsx
+++ b/packages/mobile/src/components/comments/CommentDrawer.tsx
@@ -24,7 +24,8 @@ import {
 import type { ParamListBase } from '@react-navigation/native'
 import type { NativeStackNavigationProp } from '@react-navigation/native-stack'
 import type { TouchableOpacityProps } from 'react-native'
-import { TouchableOpacity } from 'react-native'
+import { Pressable, TouchableOpacity, View } from 'react-native'
+import { Gesture, GestureDetector } from 'react-native-gesture-handler'
 import { useSafeAreaInsets } from 'react-native-safe-area-context'
 import { useSelector } from 'react-redux'
 
@@ -239,23 +240,27 @@ export const CommentDrawer = (props: CommentDrawerProps) => {
     setAutoCompleteActive(active)
   }, [])
 
+  const gesture = Gesture.Pan()
+
   const renderFooterComponent = useCallback(
     (props: BottomSheetFooterProps) => (
-      <BottomSheetFooter {...props} bottomInset={insets.bottom}>
-        <Divider orientation='horizontal' />
-        <CommentSectionProvider
-          entityId={entityId}
-          replyingAndEditingState={replyingAndEditingState}
-          setReplyingAndEditingState={setReplyingAndEditingState}
-        >
-          <CommentDrawerForm
-            commentListRef={commentListRef}
-            onAutocompleteChange={onAutoCompleteChange}
-            setAutocompleteHandler={setAutocompleteHandler}
-            autoFocus={autoFocusInput}
-          />
-        </CommentSectionProvider>
-      </BottomSheetFooter>
+      <GestureDetector gesture={gesture}>
+        <BottomSheetFooter {...props} bottomInset={insets.bottom}>
+          <Divider orientation='horizontal' />
+          <CommentSectionProvider
+            entityId={entityId}
+            replyingAndEditingState={replyingAndEditingState}
+            setReplyingAndEditingState={setReplyingAndEditingState}
+          >
+            <CommentDrawerForm
+              commentListRef={commentListRef}
+              onAutocompleteChange={onAutoCompleteChange}
+              setAutocompleteHandler={setAutocompleteHandler}
+              autoFocus={autoFocusInput}
+            />
+          </CommentSectionProvider>
+        </BottomSheetFooter>
+      </GestureDetector>
     ),
     // intentionally excluding insets.bottom because it causes a rerender
     // when the keyboard is opened on android, causing the keyboard to close

--- a/packages/mobile/src/components/comments/CommentDrawer.tsx
+++ b/packages/mobile/src/components/comments/CommentDrawer.tsx
@@ -24,7 +24,7 @@ import {
 import type { ParamListBase } from '@react-navigation/native'
 import type { NativeStackNavigationProp } from '@react-navigation/native-stack'
 import type { TouchableOpacityProps } from 'react-native'
-import { Pressable, TouchableOpacity, View } from 'react-native'
+import { TouchableOpacity } from 'react-native'
 import { Gesture, GestureDetector } from 'react-native-gesture-handler'
 import { useSafeAreaInsets } from 'react-native-safe-area-context'
 import { useSelector } from 'react-redux'

--- a/packages/mobile/src/components/comments/CommentForm.tsx
+++ b/packages/mobile/src/components/comments/CommentForm.tsx
@@ -90,12 +90,8 @@ export const CommentForm = (props: CommentFormProps) => {
   } = props
   const [messageId, setMessageId] = useState(0)
   const [initialMessage, setInitialMessage] = useState(initialValue)
-  const {
-    currentUserId,
-    entityId,
-    replyingAndEditingState,
-    commentSectionLoading
-  } = useCurrentCommentSection()
+  const { currentUserId, entityId, replyingAndEditingState } =
+    useCurrentCommentSection()
   const { replyingToComment, editingComment } = replyingAndEditingState ?? {}
   const ref = useRef<RNTextInput>(null)
   const adjustedCursorPosition = useRef(false)

--- a/packages/mobile/src/components/comments/CommentForm.tsx
+++ b/packages/mobile/src/components/comments/CommentForm.tsx
@@ -185,9 +185,8 @@ export const CommentForm = (props: CommentFormProps) => {
             messageId={messageId}
             entityId={entityId}
             presetMessage={initialMessage}
-            placeholder={commentSectionLoading ? '' : messages.addComment}
+            placeholder={messages.addComment}
             onSubmit={handleSubmit}
-            displayCancelAccessory={!showHelperText}
             TextInputComponent={TextInputComponent}
             onLayout={handleLayout}
             maxLength={400}

--- a/packages/mobile/src/components/composer-input/ComposerInput.tsx
+++ b/packages/mobile/src/components/composer-input/ComposerInput.tsx
@@ -372,7 +372,7 @@ export const ComposerInput = forwardRef(function ComposerInput(
       hitSlop={spacing(2)}
       style={styles.submit}
     >
-      <Flex pb='xs'>
+      <Flex pv='xs'>
         {isLoading ? (
           <LoadingSpinner />
         ) : (

--- a/packages/mobile/src/components/composer-input/ComposerInput.tsx
+++ b/packages/mobile/src/components/composer-input/ComposerInput.tsx
@@ -21,7 +21,7 @@ import {
   splitOnNewline,
   timestampRegex
 } from '@audius/common/utils'
-import { Platform, TouchableOpacity, View } from 'react-native'
+import { Platform, TouchableOpacity } from 'react-native'
 import type { TextInput as RnTextInput } from 'react-native'
 import type {
   NativeSyntheticEvent,
@@ -44,6 +44,7 @@ import type { ComposerInputProps } from './types'
 const BACKSPACE_KEY = 'Backspace'
 const AT_KEY = '@'
 const SPACE_KEY = ' '
+const ENTER_KEY = 'Enter'
 
 const messages = {
   sendMessage: 'Send Message',
@@ -55,7 +56,7 @@ const createTextSections = (text: string) => {
   const splitText = splitOnNewline(text)
   return splitText.map((t) => (
     // eslint-disable-next-line react/jsx-key
-    <Text>{`${t === '\n' ? '\n\n' : t}`}</Text>
+    <Text allowNewline>{t}</Text>
   ))
 }
 
@@ -74,23 +75,6 @@ const useStyles = makeStyles(({ spacing, palette, typography }) => ({
     lineHeight: spacing(6),
     justifyContent: 'center',
     alignItems: 'center',
-    paddingTop: 0
-  },
-  overlayTextContainer: {
-    position: 'absolute',
-    pointerEvents: 'none',
-    right: spacing(10),
-    left: 0,
-    zIndex: 0,
-    paddingLeft: spacing(4) + 1,
-    paddingVertical: spacing(3) - 1
-  },
-  overlayText: {
-    fontSize: typography.fontSize.medium,
-    lineHeight: spacing(6),
-    justifyContent: 'center',
-    alignItems: 'center',
-    color: palette.neutral,
     paddingTop: 0
   },
   submit: {
@@ -119,7 +103,6 @@ export const ComposerInput = forwardRef(function ComposerInput(
     entityId,
     styles: propStyles,
     TextInputComponent,
-    displayCancelAccessory = false,
     onLayout,
     maxLength = 10000
   } = props
@@ -325,6 +308,10 @@ export const ComposerInput = forwardRef(function ComposerInput(
           setIsAutocompleteActive(false)
         }
 
+        if (key === ENTER_KEY) {
+          setIsAutocompleteActive(false)
+        }
+
         if (key === BACKSPACE_KEY) {
           const deletedChar = value[cursorPosition - 1]
           if (deletedChar === AT_KEY) {
@@ -385,7 +372,7 @@ export const ComposerInput = forwardRef(function ComposerInput(
       hitSlop={spacing(2)}
       style={styles.submit}
     >
-      <Flex pv='xs'>
+      <Flex pb='xs'>
         {isLoading ? (
           <LoadingSpinner />
         ) : (
@@ -506,24 +493,17 @@ export const ComposerInput = forwardRef(function ComposerInput(
         onSelectionChange={handleSelectionChange}
         onLayout={onLayout}
         multiline
-        value={value}
-        inputAccessoryViewID={
-          displayCancelAccessory ? 'cancelButtonAccessoryView' : 'none'
-        }
+        inputAccessoryViewID='none'
         maxLength={maxLength}
         autoCorrect
         TextInputComponent={TextInputComponent}
-      />
-      {isTextHighlighted ? (
-        <View
-          style={[
-            styles.overlayTextContainer,
-            Platform.OS === 'ios' ? { paddingBottom: spacing(1.5) } : null
-          ]}
-        >
-          <Text style={styles.overlayText}>{renderDisplayText(value)}</Text>
-        </View>
-      ) : null}
+      >
+        {isTextHighlighted ? (
+          <Text allowNewline>{renderDisplayText(value)}</Text>
+        ) : (
+          <Text allowNewline>{value}</Text>
+        )}
+      </TextInput>
     </>
   )
 })

--- a/packages/mobile/src/components/composer-input/types.ts
+++ b/packages/mobile/src/components/composer-input/types.ts
@@ -15,7 +15,6 @@ export type ComposerInputProps = {
   onSubmit?: (value: string, mentionIds: ID[]) => void
   onAutocompleteChange?: (isActive: boolean, value: string) => void
   setAutocompleteHandler?: (handler: (user: UserMetadata) => void) => void
-  displayCancelAccessory?: boolean
   presetMessage?: string
   isLoading?: boolean
   styles?: StylesProp<{

--- a/packages/mobile/src/components/core/TextInput.tsx
+++ b/packages/mobile/src/components/core/TextInput.tsx
@@ -142,6 +142,7 @@ export type TextInputProps = RNTextInputProps & {
    * @default 0.9
    */
   maxLengthWarningThreshold?: number
+  children?: ReactNode
 }
 
 export type TextInputRef = RNTextInput


### PR DESCRIPTION
### Description
* Replace composer input overlay with Text children. This should be less fragile and allows scrolling
* Improve lineheight of userlink in comment headers
* Fix issue with compose input placeholder
* Exit autocomplete on Enter key press
* remove things related to the Cancel accessory

https://github.com/user-attachments/assets/8cc094ab-f77c-4377-bdc9-ea076365a572


### How Has This Been Tested?
Tested on ios, testing on android in progress
