### PR TITLE
[C-5053] Rework desktop comment load skeletons

### DIFF
--- a/packages/common/src/api/tan-query/comments.ts
+++ b/packages/common/src/api/tan-query/comments.ts
@@ -264,7 +264,7 @@ export const usePostComment = () => {
         isEdited: false,
         trackTimestampS,
         reactCount: 0,
-        replyCount: 0,
+        replyCount: !isReply ? 0 : undefined,
         replies: undefined,
         createdAt: new Date().toISOString(),
         updatedAt: undefined

--- a/packages/common/src/api/tan-query/comments.ts
+++ b/packages/common/src/api/tan-query/comments.ts
@@ -264,7 +264,7 @@ export const usePostComment = () => {
         isEdited: false,
         trackTimestampS,
         reactCount: 0,
-        replyCount: !isReply ? 0 : undefined,
+        replyCount: 0,
         replies: undefined,
         createdAt: new Date().toISOString(),
         updatedAt: undefined

--- a/packages/web/src/components/comments/CommentActionBar.tsx
+++ b/packages/web/src/components/comments/CommentActionBar.tsx
@@ -83,7 +83,7 @@ export const CommentActionBar = ({
     useCurrentCommentSection()
   const { reactCount, id: commentId, userId, isCurrentUserReacted } = comment
   const isMuted = 'isMuted' in comment ? comment.isMuted : false
-  const isParentComment = 'replyCount' in comment
+  const isParentComment = parentCommentId === undefined
   const isPinned = track.pinned_comment_id === commentId
   const isTombstone = 'isTombstone' in comment ? !!comment.isTombstone : false
 

--- a/packages/web/src/components/comments/CommentForm.tsx
+++ b/packages/web/src/components/comments/CommentForm.tsx
@@ -33,6 +33,7 @@ type CommentFormProps = {
   parentCommentId?: ID
   isEdit?: boolean
   autoFocus?: boolean
+  disabled?: boolean
 }
 
 export const CommentForm = ({
@@ -43,7 +44,8 @@ export const CommentForm = ({
   parentCommentId,
   isEdit,
   hideAvatar = false,
-  autoFocus
+  autoFocus,
+  disabled = false
 }: CommentFormProps) => {
   const { currentUserId, entityId, entityType } = useCurrentCommentSection()
   const isMobile = useIsMobile()
@@ -121,6 +123,7 @@ export const CommentForm = ({
           onSubmit={(value: string, _, mentions) => {
             handleSubmit({ commentMessage: value, mentions })
           }}
+          disabled={disabled}
         />
       </Flex>
       <DownloadMobileAppDrawer

--- a/packages/web/src/components/comments/CommentList.tsx
+++ b/packages/web/src/components/comments/CommentList.tsx
@@ -1,24 +1,28 @@
 import { useCurrentCommentSection } from '@audius/common/context'
 import { Flex } from '@audius/harmony'
 
-import { CommentSkeletons } from './CommentSkeletons'
+import { CommentBlockSkeletons } from './CommentSkeletons'
 import { CommentThread } from './CommentThread'
 import { NoComments } from './NoComments'
 
 export const CommentList = () => {
   const { commentIds, commentSectionLoading } = useCurrentCommentSection()
 
-  // TODO: break out list skeleton from reply skeleton
-  if (commentSectionLoading) {
-    return <CommentSkeletons />
-  }
-
   return (
     <Flex p='l' as='ul' column gap='xl' w='100%' backgroundColor='white'>
-      {commentIds.length === 0 ? <NoComments /> : null}
-      {commentIds.map((id) => (
-        <CommentThread commentId={id} key={id} />
-      ))}
+      {commentSectionLoading ? (
+        <>
+          <CommentBlockSkeletons />
+          <CommentBlockSkeletons />
+        </>
+      ) : (
+        <>
+          {commentIds.length === 0 ? <NoComments /> : null}
+          {commentIds.map((id) => (
+            <CommentThread commentId={id} key={id} />
+          ))}
+        </>
+      )}
     </Flex>
   )
 }

--- a/packages/web/src/components/comments/CommentList.tsx
+++ b/packages/web/src/components/comments/CommentList.tsx
@@ -11,10 +11,7 @@ export const CommentList = () => {
   return (
     <Flex p='l' as='ul' column gap='xl' w='100%' backgroundColor='white'>
       {commentSectionLoading ? (
-        <>
-          <CommentBlockSkeletons />
-          <CommentBlockSkeletons />
-        </>
+        <CommentBlockSkeletons />
       ) : (
         <>
           {commentIds.length === 0 ? <NoComments /> : null}

--- a/packages/web/src/components/comments/CommentSection.tsx
+++ b/packages/web/src/components/comments/CommentSection.tsx
@@ -7,7 +7,7 @@ import {
 import { useFeatureFlag } from '@audius/common/hooks'
 import { ID } from '@audius/common/models'
 import { FeatureFlags } from '@audius/common/services'
-import { Divider, Flex, LoadingSpinner, Paper, Skeleton } from '@audius/harmony'
+import { Divider, Flex, LoadingSpinner, Paper } from '@audius/harmony'
 import InfiniteScroll from 'react-infinite-scroller'
 import { useSearchParams } from 'react-router-dom-v5-compat'
 
@@ -17,34 +17,13 @@ import { useMainContentRef } from 'pages/MainContentContext'
 import { CommentForm } from './CommentForm'
 import { CommentHeader } from './CommentHeader'
 import {
-  CommentBlockSkeleton,
   CommentBlockSkeletons,
+  CommentFormSkeleton,
   SortBarSkeletons
 } from './CommentSkeletons'
 import { CommentSortBar } from './CommentSortBar'
 import { CommentThread } from './CommentThread'
 import { NoComments } from './NoComments'
-
-const FullCommentSkeletons = () => (
-  <Flex gap='l' direction='column' w='100%' alignItems='flex-start'>
-    <CommentHeader isLoading />
-    <Paper p='xl' w='100%' direction='column' gap='xl'>
-      <Flex
-        gap='s'
-        w='100%'
-        h='60px'
-        alignItems='center'
-        justifyContent='center'
-      >
-        <Skeleton w='40px' h='40px' css={{ borderRadius: '100%' }} />
-        <Skeleton w='100%' h='60px' />
-      </Flex>
-      <Divider color='default' orientation='horizontal' />
-
-      <CommentBlockSkeletons />
-    </Paper>
-  </Flex>
-)
 
 type CommentSectionInnerProps = {
   commentSectionRef: React.RefObject<HTMLDivElement>
@@ -107,10 +86,6 @@ export const CommentSectionInner = (props: CommentSectionInnerProps) => {
     history
   ])
 
-  if (commentSectionLoading && isFirstLoad) {
-    return <FullCommentSkeletons />
-  }
-
   return (
     <Flex
       gap='l'
@@ -124,7 +99,11 @@ export const CommentSectionInner = (props: CommentSectionInnerProps) => {
         {commentPostAllowed ? (
           <>
             <Flex gap='s' p='xl' w='100%' direction='column'>
-              <CommentForm disabled={commentSectionLoading} />
+              {commentSectionLoading && isFirstLoad ? (
+                <CommentFormSkeleton />
+              ) : (
+                <CommentForm disabled={commentSectionLoading} />
+              )}
             </Flex>
 
             <Divider color='default' orientation='horizontal' />

--- a/packages/web/src/components/comments/CommentSkeletons.tsx
+++ b/packages/web/src/components/comments/CommentSkeletons.tsx
@@ -1,19 +1,49 @@
 import { Flex, Skeleton } from '@audius/harmony'
 
-const CommentBlockSkeleton = () => (
-  <Flex direction='row' gap='s' alignItems='center' p='l'>
-    <Skeleton w={40} h={40} css={{ borderRadius: 100, flexShrink: 0 }} />
-    <Flex gap='s' direction='column'>
-      <Skeleton h={20} w={240} />
-      <Skeleton h={20} w={160} />
+import { useIsMobile } from 'hooks/useIsMobile'
+
+export const CommentBlockSkeleton = () => {
+  const isMobile = useIsMobile()
+  return (
+    <Flex direction='row' gap='l' alignItems='center' w='100%'>
+      <Skeleton
+        w={40}
+        h={40}
+        ml='2px'
+        css={{ borderRadius: 100, flexShrink: 0, alignSelf: 'flex-start' }}
+      />
+      <Flex gap='s' direction='column' w='100%'>
+        <Skeleton h={isMobile ? 20 : 28} w='100%' />
+        <Skeleton h={isMobile ? 20 : 28} w='80%' />
+        {!isMobile ? <Skeleton h={20} w='30%' /> : null}
+      </Flex>
     </Flex>
+  )
+}
+
+export const CommentBlockSkeletons = () => {
+  return (
+    <>
+      <CommentBlockSkeleton />
+      <CommentBlockSkeleton />
+      <CommentBlockSkeleton />
+      <CommentBlockSkeleton />
+      <CommentBlockSkeleton />
+    </>
+  )
+}
+
+export const SortBarSkeletons = () => (
+  <Flex gap='s' direction='row'>
+    <Skeleton w='55px' h='26px' css={{ borderRadius: 100 }} />
+    <Skeleton w='80px' h='26px' css={{ borderRadius: 100 }} />
+    <Skeleton w='110px' h='26px' css={{ borderRadius: 100 }} />
   </Flex>
 )
 
-// TODO: mobile can also go in here
 export const CommentSkeletons = () => (
   <Flex
-    gap='s'
+    gap='xl'
     direction='column'
     w='100%'
     h='100%'

--- a/packages/web/src/components/comments/CommentSkeletons.tsx
+++ b/packages/web/src/components/comments/CommentSkeletons.tsx
@@ -21,6 +21,13 @@ export const CommentBlockSkeleton = () => {
   )
 }
 
+export const CommentFormSkeleton = () => (
+  <Flex gap='s' w='100%' h='60px' alignItems='center' justifyContent='center'>
+    <Skeleton w='40px' h='40px' css={{ borderRadius: '100%' }} />
+    <Skeleton w='100%' h='60px' />
+  </Flex>
+)
+
 export const CommentBlockSkeletons = () => {
   return (
     <>


### PR DESCRIPTION
### Description

Improves the load skeletons on desktop (most notably doesn't reload the whole section on a sort swap). 
Combines the code between mobile web & desktop better
Also, I found a bug with new replies having the option to "pin" - so I squeezed that fix in.

![2024-10-23 12 50 21](https://github.com/user-attachments/assets/ee536571-e695-4937-a50a-e1a77eb9bb92)
![2024-10-23 12 51 08](https://github.com/user-attachments/assets/68e8916d-6b50-420d-94a8-13f006ade627)



### How Has This Been Tested?

web:stage
