### PR TITLE
[C-5144] Disable caching on unclaimed comment ID

### DIFF
--- a/packages/discovery-provider/nginx_conf/nginx_container.conf
+++ b/packages/discovery-provider/nginx_conf/nginx_container.conf
@@ -188,6 +188,26 @@ http {
             add_header Cache-Control no-cache;
         }
 
+        location /v1/comments/unclaimed_id {
+            access_by_lua_block {
+                local main = require "main"
+                main.mark_request_processing()
+                return main.limit_to_rps()
+            }
+
+            log_by_lua_block {
+                local main = require "main"
+                main.mark_request_processed()
+            }
+
+            resolver 127.0.0.11 valid=30s;
+            set $upstream server:5000;
+            proxy_pass http://$upstream;
+            proxy_set_header Host $http_host;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            add_header Cache-Control no-cache;
+        }
+
         # Do not redirect any /v1/challenges/... requests, which need to resolve
         # to the node that the request was intended for. Selection of
         # nodes to respond to challenge attestations is intentional.


### PR DESCRIPTION
### Description
Successive comments would show as duped and then disappear because they were using conflicting comment IDs. This is because discovery is caching IDs in the openresty layer.  

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._

Confirmed unclaimed IDs are no longer cached and spamming comments are saved as expected.