### PR TITLE
[C-5232] Fix clipped artist popovers on comments section

### DIFF
--- a/packages/web/src/components/comments/CommentSection.tsx
+++ b/packages/web/src/components/comments/CommentSection.tsx
@@ -95,7 +95,7 @@ export const CommentSectionInner = (props: CommentSectionInnerProps) => {
       ref={commentSectionRef}
     >
       <CommentHeader />
-      <Paper w='100%' direction='column'>
+      <Paper w='100%' direction='column' css={{ overflow: 'visible' }}>
         {commentPostAllowed ? (
           <>
             <Flex gap='s' p='xl' w='100%' direction='column'>


### PR DESCRIPTION
### Description

- Artist popovers were getting clipped by `overflow: hidden`

### How Has This Been Tested?

![Screenshot 2024-10-23 at 2 39 56 PM](https://github.com/user-attachments/assets/74b36dfc-fc0e-4680-a325-4bd797e34ad6)
