### PR TITLE
Bump chat create rate limit to unblock blasts

### DIFF
--- a/comms/discovery/config/constants.go
+++ b/comms/discovery/config/constants.go
@@ -15,7 +15,7 @@ var (
 		RateLimitTimeframeHours:             24,
 		RateLimitMaxNumMessages:             2000,
 		RateLimitMaxNumMessagesPerRecipient: 1000,
-		RateLimitMaxNumNewChats:             100,
+		RateLimitMaxNumNewChats:             100000,
 	}
 
 	// honorary nodes used to create db snapshots


### PR DESCRIPTION
### Description

Ty @rickyrombo and @dharit-tan for the assists

- Blast senders were hitting the rate limit on this query during future chat creates
```
const maxNumNewChatsSince = `
WITH counts AS (
	SELECT COUNT(*) AS count
	FROM chat
	JOIN chat_member on chat.chat_id = chat_member.chat_id
	WHERE chat_member.user_id IN (:Users) AND chat.created_at > :Cursor
	GROUP BY chat_member.user_id
)
SELECT COALESCE(MAX(count), 0) FROM counts;
`
```
- For now, just bumping the limit up to 100k, but we'll want to circle back and update this query to ignore messages that resulted from a blast upgrade so we can put the rate limit back after
