### PR TITLE
Use replaceRecentBlockhash to fix BlockhashNotFound error

### DIFF
--- a/packages/discovery-provider/plugins/pedalboard/apps/solana-relay/src/utils/transaction.ts
+++ b/packages/discovery-provider/plugins/pedalboard/apps/solana-relay/src/utils/transaction.ts
@@ -108,7 +108,9 @@ export const sendTransactionWithRetries = async ({
   let success = false
   try {
     if (!sendOptions?.skipPreflight) {
-      const simulatedRes = await connection.simulateTransaction(transaction)
+      const simulatedRes = await connection.simulateTransaction(transaction, {
+        replaceRecentBlockhash: true
+      })
       if (simulatedRes.value.err) {
         throw new SendTransactionError({
           action: 'simulate',


### PR DESCRIPTION
I'm not sure when this was added or if i just missed it before, but this should solve our BlockhashNotFound errors.

https://solana.com/docs/advanced/confirmation#be-wary-of-lagging-rpc-nodes-when-sending-transactions