### PR TITLE
[C-5275] Fix react dupe key error in notifs

### DIFF
--- a/packages/common/src/adapters/notification.ts
+++ b/packages/common/src/adapters/notification.ts
@@ -577,20 +577,16 @@ export const notificationFromSDK = (
       let entityId = 0
       let entityType = Entity.Track
       let entityUserId = 0
-      const userIds = Array.from(
-        new Set(
-          notification.actions
-            .map((action) => {
-              const data = action.data
-              entityId = HashId.parse(data.entityId)
-              entityUserId = HashId.parse(data.entityUserId)
-              // @ts-ignore
-              entityType = data.type
-              return HashId.parse(data.commentUserId)
-            })
-            .filter(removeNullable)
-        )
-      )
+      const userIds = notification.actions
+        .map((action) => {
+          const data = action.data
+          entityId = HashId.parse(data.entityId)
+          entityUserId = HashId.parse(data.entityUserId)
+          // @ts-ignore
+          entityType = data.type
+          return HashId.parse(data.commentUserId)
+        })
+        .filter(removeNullable)
       return {
         type: NotificationType.CommentMention,
         userIds,
@@ -604,20 +600,16 @@ export const notificationFromSDK = (
       let entityId = 0
       let entityType = Entity.Track
       let entityUserId = 0
-      const userIds = Array.from(
-        new Set(
-          notification.actions
-            .map((action) => {
-              const data = action.data
-              entityId = HashId.parse(data.entityId)
-              entityUserId = HashId.parse(data.entityUserId)
-              // @ts-ignore
-              entityType = data.type
-              return HashId.parse(data.reacterUserId)
-            })
-            .filter(removeNullable)
-        )
-      )
+      const userIds = notification.actions
+        .map((action) => {
+          const data = action.data
+          entityId = HashId.parse(data.entityId)
+          entityUserId = HashId.parse(data.entityUserId)
+          // @ts-ignore
+          entityType = data.type
+          return HashId.parse(data.reacterUserId)
+        })
+        .filter(removeNullable)
       return {
         type: NotificationType.CommentReaction,
         userIds,

--- a/packages/common/src/store/notifications/selectors.ts
+++ b/packages/common/src/store/notifications/selectors.ts
@@ -82,7 +82,7 @@ export const getNotificationUsers = (
   limit: number
 ) => {
   if ('userIds' in notification) {
-    const userIds = notification.userIds.slice(0, limit)
+    const userIds = [...new Set(notification.userIds.slice(0, limit))]
     const userMap = getUsers(state, { ids: userIds })
     return userIds.map((id) => userMap[id])
   }

--- a/packages/common/src/store/notifications/selectors.ts
+++ b/packages/common/src/store/notifications/selectors.ts
@@ -82,7 +82,7 @@ export const getNotificationUsers = (
   limit: number
 ) => {
   if ('userIds' in notification) {
-    const userIds = [...new Set(notification.userIds.slice(0, limit))]
+    const userIds = notification.userIds.slice(0, limit)
     const userMap = getUsers(state, { ids: userIds })
     return userIds.map((id) => userMap[id])
   }

--- a/packages/web/src/components/notification/NotificationPanel.tsx
+++ b/packages/web/src/components/notification/NotificationPanel.tsx
@@ -149,7 +149,12 @@ export const NotificationPanel = ({ anchorRef }: NotificationPanelProps) => {
               initialLoad={status === Status.IDLE}
               useWindow={false}
               threshold={SCROLL_THRESHOLD}
-              loader={<LoadingSpinner className={styles.spinner} />}
+              loader={
+                <LoadingSpinner
+                  key='loading-spinner'
+                  className={styles.spinner}
+                />
+              }
               getScrollParent={getScrollParent}
               className={styles.content}
               element='ul'


### PR DESCRIPTION
### Description

```
 ERROR  Warning: Encountered two children with the same key, `283281549`. Keys should be unique so that components maintain their identity across updates. Non-unique keys may cause children to be duplicated and/or omitted — the behavior is unsupported and could change in a future version.
    in RCTView (created by View)
    in View (created by ProfilePictureList)
    in ProfilePictureList (created by CommentThreadNotification)
    in RCTView (created by View)
    in View (created by NotificationHeader)
    in NotificationHeader (created by CommentThreadNotification)
```

This would probably fix the ticket - I don't think there should ever be a case where a notification has duplicate user ids (which would lead to a key error in the notifications `profile` component).

I couldn't get a repro though.

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._

Tried a few ways to leave comments on threads etc and couldn't get the duplicate key error. I also could not get any errors fetching comment thread mentions _with_ this change either