### PR TITLE
[C-5273] Add user select to comment text

### DIFF
--- a/packages/web/src/components/comments/CommentText.tsx
+++ b/packages/web/src/components/comments/CommentText.tsx
@@ -45,7 +45,11 @@ export const CommentText = (props: CommentTextProps) => {
         mentions={mentions}
         internalLinksOnly
         maxLines={isExpanded ? undefined : 3}
-        css={{ textAlign: 'left', wordBreak: 'break-word' }}
+        css={{
+          textAlign: 'left',
+          wordBreak: 'break-word',
+          userSelect: 'text'
+        }}
         suffix={
           isEdited ? <Text color='subdued'> ({messages.edited})</Text> : null
         }

--- a/packages/web/src/components/user-generated-text/UserGeneratedTextV2.tsx
+++ b/packages/web/src/components/user-generated-text/UserGeneratedTextV2.tsx
@@ -313,7 +313,15 @@ export const UserGeneratedTextV2 = forwardRef(function (
 
   return (
     <Text
-      style={{ whiteSpace: 'pre-wrap' }}
+      style={{
+        whiteSpace: 'pre-wrap'
+      }}
+      css={{
+        '&::selection': {
+          backgroundColor: '#a116b7',
+          color: 'var(--harmony-white)'
+        }
+      }}
       ref={ref as ForwardedRef<'p'>}
       {...other}
     >


### PR DESCRIPTION
### Description

Add user select to web comments, using colors we use elsewhere throughout our app

<img width="716" alt="image" src="https://github.com/user-attachments/assets/7998ecd2-d64a-4ff7-8cad-83d39fa67c43">

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._

```
npm run web:stage
```