### PR TITLE
[QA-1549] Fix offline collection downloads

### DIFF
--- a/packages/common/src/adapters/collection.ts
+++ b/packages/common/src/adapters/collection.ts
@@ -37,10 +37,13 @@ const addedTimestampToPlaylistTrackId = ({
 }
 
 export const userCollectionMetadataFromSDK = (
-  input: full.PlaylistFullWithoutTracks | full.SearchPlaylistFull
+  input:
+    | full.PlaylistFullWithoutTracks
+    | full.SearchPlaylistFull
+    | full.PlaylistFull
 ): UserCollectionMetadata | undefined => {
   const decodedPlaylistId = decodeHashId(input.id)
-  const decodedOwnerId = decodeHashId(input.userId)
+  const decodedOwnerId = decodeHashId(input.userId ?? input.user.id)
   const user = userMetadataFromSDK(input.user)
   if (!decodedPlaylistId || !decodedOwnerId || !user) {
     return undefined
@@ -88,7 +91,7 @@ export const userCollectionMetadataFromSDK = (
     // TODO: Use playlistContents
     playlist_contents: {
       track_ids: transformAndCleanList(
-        input.addedTimestamps,
+        input.playlistContents ?? input.addedTimestamps,
         addedTimestampToPlaylistTrackId
       )
     },

--- a/packages/common/src/adapters/collection.ts
+++ b/packages/common/src/adapters/collection.ts
@@ -88,10 +88,9 @@ export const userCollectionMetadataFromSDK = (
       input.followeeFavorites,
       favoriteFromSDK
     ),
-    // TODO: Use playlistContents
     playlist_contents: {
       track_ids: transformAndCleanList(
-        input.playlistContents ?? input.addedTimestamps,
+        input.addedTimestamps ?? input.playlistContents,
         addedTimestampToPlaylistTrackId
       )
     },

--- a/packages/mobile/src/store/offline-downloads/sagas/requestDownloadCollectionSaga.ts
+++ b/packages/mobile/src/store/offline-downloads/sagas/requestDownloadCollectionSaga.ts
@@ -39,7 +39,7 @@ function* downloadCollection(action: CollectionAction) {
   const sdk = yield* getSDK()
 
   const { data = [] } = yield* call(
-    [sdk.playlists, sdk.playlists.getPlaylist],
+    [sdk.playlists, sdk.full.playlists.getPlaylist],
     {
       playlistId: Id.parse(collectionId),
       userId: OptionalId.parse(currentUserId)


### PR DESCRIPTION
### Description

All offline collection downloads were failing to enqueue because they weren't making it through the `userCollectionMetadataFromSDK` adapter .

Despite the data coming directly from sdk, the expected `input.userId` field did not exist. @schottra curious if the proper fix here is to update the data returned from sdk?

Also, neither `input.tracks` nor `input.addedTimestamps` was populated, so switched to using `input.playlistContents`

### How Has This Been Tested?

Previously, the toggle would go on, but none of the tracks would enqueue. Now collection and its tracks are downloading properly 🎉

![Screenshot 2024-10-24 at 6 41 00 PM](https://github.com/user-attachments/assets/18464203-b954-4924-9bf1-105c6ee8328b)
