### PR TITLE
[C-5279] Exclude users from comments who are muted by the owner

### DIFF
--- a/packages/discovery-provider/integration_tests/queries/test_get_comments.py
+++ b/packages/discovery-provider/integration_tests/queries/test_get_comments.py
@@ -200,14 +200,6 @@ def test_get_comments_from_muted_user_by_track_owner(app):
                 "track_timestamp_s": 1,
             },
         ],
-        "comment_notification_settings": [
-            {
-                "user_id": 1,
-                "entity_id": 1,
-                "entity_type": "Comment",
-                "is_muted": True,
-            }
-        ],
         "muted_users": [
             {
                 "muted_user_id": 1,
@@ -224,6 +216,12 @@ def test_get_comments_from_muted_user_by_track_owner(app):
         # to a third party user, there should be no comments
         # because the track owner muted the user
         comments = get_track_comments({}, 1, current_user_id=2)
+        assert len(comments) == 0
+        # the muted user should see their own comment
+        comments = get_track_comments({}, 1, current_user_id=1)
+        assert len(comments) == 1
+        # the person who muted the user should not see the comment
+        comments = get_track_comments({}, 1, current_user_id=10)
         assert len(comments) == 0
 
 
@@ -248,14 +246,6 @@ def test_get_comment_replies_from_muted_user_by_track_owner(app):
             },
         ],
         "comment_threads": [{"parent_comment_id": 1, "comment_id": 2}],
-        "comment_notification_settings": [
-            {
-                "user_id": 1,
-                "entity_id": 1,
-                "entity_type": "Comment",
-                "is_muted": True,
-            }
-        ],
         "muted_users": [
             {
                 "muted_user_id": 1,
@@ -273,6 +263,16 @@ def test_get_comment_replies_from_muted_user_by_track_owner(app):
         # because the track owner muted the user
         comments = get_paginated_replies(
             {"limit": 10, "offset": 0, "sort_method": "newest"}, 1, current_user_id=2
+        )
+        assert len(comments) == 0
+        # the muted user should see their own comment
+        comments = get_paginated_replies(
+            {"limit": 10, "offset": 0, "sort_method": "newest"}, 1, current_user_id=1
+        )
+        assert len(comments) == 1
+        # the person who muted the user should not see the comment
+        comments = get_paginated_replies(
+            {"limit": 10, "offset": 0, "sort_method": "newest"}, 1, current_user_id=10
         )
         assert len(comments) == 0
 

--- a/packages/discovery-provider/integration_tests/queries/test_get_comments.py
+++ b/packages/discovery-provider/integration_tests/queries/test_get_comments.py
@@ -188,6 +188,95 @@ def test_get_muted_comments(app):
         assert comments[0]["is_muted"] == True
 
 
+def test_get_comments_from_muted_user_by_track_owner(app):
+    entities = {
+        "comments": [
+            {
+                "comment_id": 1,
+                "user_id": 1,
+                "entity_id": 1,
+                "entity_type": "Track",
+                "created_at": datetime(2022, 1, 1),
+                "track_timestamp_s": 1,
+            },
+        ],
+        "comment_notification_settings": [
+            {
+                "user_id": 1,
+                "entity_id": 1,
+                "entity_type": "Comment",
+                "is_muted": True,
+            }
+        ],
+        "muted_users": [
+            {
+                "muted_user_id": 1,
+                "user_id": 10,  # the owner of this track
+            }
+        ],
+        "tracks": [{"track_id": 1, "owner_id": 10}],
+    }
+
+    with app.app_context():
+        db = get_db()
+        populate_mock_db(db, entities)
+
+        # to a third party user, there should be no comments
+        # because the track owner muted the user
+        comments = get_track_comments({}, 1, current_user_id=2)
+        assert len(comments) == 0
+
+
+def test_get_comment_replies_from_muted_user_by_track_owner(app):
+    entities = {
+        "comments": [
+            {
+                "comment_id": 1,
+                "user_id": 1,
+                "entity_id": 1,
+                "entity_type": "Track",
+                "created_at": datetime(2022, 1, 1),
+                "track_timestamp_s": 1,
+            },
+            {
+                "comment_id": 2,
+                "user_id": 1,
+                "entity_id": 1,
+                "entity_type": "Track",
+                "created_at": datetime(2022, 1, 2),
+                "track_timestamp_s": 2,
+            },
+        ],
+        "comment_threads": [{"parent_comment_id": 1, "comment_id": 2}],
+        "comment_notification_settings": [
+            {
+                "user_id": 1,
+                "entity_id": 1,
+                "entity_type": "Comment",
+                "is_muted": True,
+            }
+        ],
+        "muted_users": [
+            {
+                "muted_user_id": 1,
+                "user_id": 10,  # the owner of this track
+            }
+        ],
+        "tracks": [{"track_id": 1, "owner_id": 10}],
+    }
+
+    with app.app_context():
+        db = get_db()
+        populate_mock_db(db, entities)
+
+        # to a third party user, there should be no comment replies
+        # because the track owner muted the user
+        comments = get_paginated_replies(
+            {"limit": 10, "offset": 0, "sort_method": "newest"}, 1, current_user_id=2
+        )
+        assert len(comments) == 0
+
+
 def test_get_deleted_comments(app):
     entities = {
         "comments": [

--- a/packages/discovery-provider/src/queries/get_comments.py
+++ b/packages/discovery-provider/src/queries/get_comments.py
@@ -121,6 +121,8 @@ def get_replies(
                 ),
                 CommentReport.is_delete == True,
             ),
+            # Exclude comments where the artist has muted the commenter
+            MutedUser.user_id != artist_id,
         )
         .order_by(asc(Comment.created_at))
         .offset(offset)
@@ -317,6 +319,8 @@ def get_track_comments(args, track_id, current_user_id=None):
                     MutedUser.muted_user_id == None,
                     MutedUser.is_delete == True,
                 ),  # Exclude muted users' comments
+                # Exclude comments where the artist has muted the commenter
+                MutedUser.user_id != artist_id,
             )
             .having(
                 (func.count(ReplyCountAlias.comment_id) > 0)

--- a/packages/discovery-provider/src/queries/get_comments.py
+++ b/packages/discovery-provider/src/queries/get_comments.py
@@ -99,9 +99,9 @@ def get_replies(
                 MutedUser.muted_user_id == Comment.user_id,
                 or_(
                     MutedUser.user_id == current_user_id,
+                    MutedUser.muted_user_id == current_user_id,
                     MutedUser.muted_user_id.in_(muted_by_karma),
                 ),
-                current_user_id != Comment.user_id,
             ),
         )
         .outerjoin(CommentReport, Comment.comment_id == CommentReport.comment_id)
@@ -110,10 +110,6 @@ def get_replies(
             CommentThread.parent_comment_id == parent_comment_id,
             Comment.is_delete == False,
             or_(
-                MutedUser.muted_user_id == None,
-                MutedUser.is_delete == True,
-            ),  # Exclude muted users' comments
-            or_(
                 CommentReport.comment_id == None,
                 and_(
                     CommentReport.user_id != current_user_id,
@@ -121,8 +117,19 @@ def get_replies(
                 ),
                 CommentReport.is_delete == True,
             ),
-            # Exclude comments where the artist has muted the commenter
-            MutedUser.user_id != artist_id,
+            or_(
+                # Include comments where muting was undone
+                MutedUser.is_delete == True,
+                # Include comments where the current user is muted
+                # (Even if I am muted, I can still see my own comments)
+                MutedUser.muted_user_id == current_user_id,
+                # Include comments where the artist has not muted the commenter
+                and_(
+                    MutedUser.muted_user_id == Comment.user_id,
+                    MutedUser.user_id != artist_id,
+                    artist_id == current_user_id,
+                ),
+            ),
         )
         .order_by(asc(Comment.created_at))
         .offset(offset)
@@ -283,9 +290,9 @@ def get_track_comments(args, track_id, current_user_id=None):
                     MutedUser.muted_user_id == Comment.user_id,
                     or_(
                         MutedUser.user_id == current_user_id,
+                        MutedUser.muted_user_id == current_user_id,
                         MutedUser.muted_user_id.in_(muted_by_karma),
                     ),
-                    current_user_id != Comment.user_id,  # show comment to comment owner
                 ),
             )
             .outerjoin(
@@ -316,11 +323,18 @@ def get_track_comments(args, track_id, current_user_id=None):
                     CommentReport.is_delete == True,
                 ),
                 or_(
-                    MutedUser.muted_user_id == None,
+                    # Include comments where muting was undone
                     MutedUser.is_delete == True,
-                ),  # Exclude muted users' comments
-                # Exclude comments where the artist has muted the commenter
-                MutedUser.user_id != artist_id,
+                    # Include comments where the current user is muted
+                    # (Even if I am muted, I can still see my own comments)
+                    MutedUser.muted_user_id == current_user_id,
+                    # Include comments where the artist has not muted the commenter
+                    and_(
+                        MutedUser.muted_user_id == Comment.user_id,
+                        MutedUser.user_id != artist_id,
+                        artist_id == current_user_id,
+                    ),
+                ),
             )
             .having(
                 (func.count(ReplyCountAlias.comment_id) > 0)


### PR DESCRIPTION
### Description

Filter out comments from users muted by the track owner, except if I am the one muted.

This logic is a bit dicey / hard for me to grok because I don't have the full background. I believe this what we want to do, but could use extra scrutiny.

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._

"integration" tests via TDD

```
docker exec -it audius-protocol-test-test-discovery-provider-1 /bin/sh
pytest integration_tests/queries/test_get_comments.py
```