### PR TITLE
[QA-1787, QA-1786] Fix offline collections filtering and playback

### DIFF
--- a/packages/common/src/store/lineup/actions.ts
+++ b/packages/common/src/store/lineup/actions.ts
@@ -124,7 +124,8 @@ export class LineupActions {
     limit: number,
     deleted: number,
     nullCount: number,
-    handle?: string
+    handle?: string,
+    hasMore?: boolean
   ) {
     return {
       type: addPrefix(this.prefix, FETCH_LINEUP_METADATAS_SUCCEEDED),
@@ -133,7 +134,8 @@ export class LineupActions {
       limit,
       deleted,
       nullCount,
-      handle
+      handle,
+      hasMore
     }
   }
 

--- a/packages/common/src/store/lineup/reducer.ts
+++ b/packages/common/src/store/lineup/reducer.ts
@@ -73,6 +73,7 @@ type FetchLineupMetadatasSucceededAction<T> = {
   nullCount: number
   limit: number
   offset: number
+  hasMore?: boolean
 }
 
 type FetchLineupMetadatasFailedAction = {
@@ -153,7 +154,8 @@ export const actionsMap = {
     const newState = { ...state }
     newState.isMetadataLoading = false
     newState.status = Status.SUCCESS
-    newState.hasMore = action.entries.length + action.deleted >= action.limit
+    newState.hasMore =
+      action.hasMore ?? action.entries.length + action.deleted >= action.limit
 
     // Hack alert:
     // For lineups with max entries (such as trending playlists) and deleted content,

--- a/packages/mobile/src/screens/collection-screen/useFetchCollectionLineup.ts
+++ b/packages/mobile/src/screens/collection-screen/useFetchCollectionLineup.ts
@@ -112,7 +112,9 @@ export const useFetchCollectionLineup = (
           0,
           sortedTracks.length,
           0,
-          0
+          0,
+          undefined,
+          false /* hasMore override */
         )
       )
     }

--- a/packages/mobile/src/screens/favorites-screen/useCollectionsScreenData.ts
+++ b/packages/mobile/src/screens/favorites-screen/useCollectionsScreenData.ts
@@ -136,6 +136,12 @@ export const useCollectionsScreenData = ({
             collection.playlist_contents.track_ids.map(
               (trackData) => trackData.track
             ) ?? []
+          if (
+            (collectionType === 'albums' && !collection.is_album) ||
+            (collectionType === 'playlists' && collection.is_album)
+          ) {
+            return false
+          }
           // Don't show a playlist in Offline Mode if it has at least one track but none of the tracks have been downloaded yet OR if it is not marked for download
           return (
             trackIds.length === 0 ||


### PR DESCRIPTION
### Description

- Offline playlists were showing up in albums tab and vice versa
- Offline lineups were breaking and showing stuck loading state after playing a track near the end of the lineup

### How Has This Been Tested?

local sim. Lineup loading and collection tile filtering are both working properly now