### PR TITLE
[QA-1785] Fix remixes missing view all button

### DIFF
--- a/packages/mobile/src/screens/track-screen/TrackScreenRemixes.tsx
+++ b/packages/mobile/src/screens/track-screen/TrackScreenRemixes.tsx
@@ -35,7 +35,7 @@ type TrackScreenRemixesProps = {
 
 export const TrackScreenRemixes = (props: TrackScreenRemixesProps) => {
   const { track } = props
-  const { _remixes } = track
+  const { _remixes: remixes, _remixes_count: remixesCount } = track
   const navigation = useNavigation()
   const dispatch = useDispatch()
   const remixesLineup = useSelector(getRemixesTracksLineup)
@@ -59,7 +59,7 @@ export const TrackScreenRemixes = (props: TrackScreenRemixesProps) => {
     navigation.push('TrackRemixes', { id: track.track_id })
   }
 
-  const remixTrackIds = _remixes?.map(({ track_id }) => track_id) ?? null
+  const remixTrackIds = remixes?.map(({ track_id }) => track_id) ?? null
 
   if (!remixTrackIds || !remixTrackIds.length) {
     return null
@@ -82,7 +82,7 @@ export const TrackScreenRemixes = (props: TrackScreenRemixesProps) => {
           paddingVertical: 12
         }}
       />
-      {remixTrackIds.length > MAX_REMIXES_TO_DISPLAY ? (
+      {remixesCount && remixesCount > MAX_REMIXES_TO_DISPLAY ? (
         <Flex pt='m' alignItems='flex-start'>
           <Button
             iconRight={IconArrowRight}

--- a/packages/web/src/pages/track-page/components/TrackRemixes.tsx
+++ b/packages/web/src/pages/track-page/components/TrackRemixes.tsx
@@ -88,9 +88,14 @@ export const TrackRemixes = (props: TrackRemixesProrps) => {
     return null
   }
 
-  const { _remixes, permalink, comments_disabled } = track as unknown as Track
+  const {
+    _remixes: remixes,
+    _remixes_count: remixesCount,
+    permalink,
+    comments_disabled
+  } = track as unknown as Track
   const isCommentingEnabled = commentsFlagEnabled && !comments_disabled
-  const remixTrackIds = _remixes?.map(({ track_id }) => track_id) ?? null
+  const remixTrackIds = remixes?.map(({ track_id }) => track_id) ?? null
 
   const lineupVariant =
     (isCommentingEnabled && isDesktop) || isMobile
@@ -134,7 +139,7 @@ export const TrackRemixes = (props: TrackRemixesProrps) => {
         playTrack={handlePlay}
         pauseTrack={handlePause}
       />
-      {remixTrackIds.length > MAX_REMIXES_TO_DISPLAY ? (
+      {remixesCount > MAX_REMIXES_TO_DISPLAY ? (
         <Box alignSelf='flex-start'>
           <Button iconRight={IconArrowRight} size='xs' asChild>
             <Link to={trackRemixesPage(permalink)}>

--- a/packages/web/src/pages/track-page/components/TrackRemixes.tsx
+++ b/packages/web/src/pages/track-page/components/TrackRemixes.tsx
@@ -109,7 +109,7 @@ export const TrackRemixes = (props: TrackRemixesProrps) => {
   return (
     <Flex
       direction='column'
-      gap='l'
+      gap='s'
       w={!isDesktop || isCommentingEnabled ? '100%' : 720}
     >
       <Flex
@@ -139,7 +139,7 @@ export const TrackRemixes = (props: TrackRemixesProrps) => {
         playTrack={handlePlay}
         pauseTrack={handlePause}
       />
-      {remixesCount > MAX_REMIXES_TO_DISPLAY ? (
+      {remixesCount && remixesCount > MAX_REMIXES_TO_DISPLAY ? (
         <Box alignSelf='flex-start'>
           <Button iconRight={IconArrowRight} size='xs' asChild>
             <Link to={trackRemixesPage(permalink)}>

--- a/packages/web/src/pages/track-page/components/desktop/TrackPage.tsx
+++ b/packages/web/src/pages/track-page/components/desktop/TrackPage.tsx
@@ -281,7 +281,7 @@ const TrackPage = ({
               alignItems={
                 isCommentingEnabled && isDesktop ? 'flex-start' : 'center'
               }
-              gap='l'
+              gap='2xl'
               flex={1}
               css={{
                 minWidth: 330,
@@ -289,61 +289,70 @@ const TrackPage = ({
               }}
             >
               {hasRemixes ? <TrackRemixes trackId={defaults.trackId} /> : null}
-              {hasValidRemixParent
-                ? renderOriginalTrackTitle()
-                : renderMoreByTitle()}
-              <Lineup
-                lineup={tracks}
-                // Styles for leading element (original track if remix).
-                leadingElementId={defaults.remixParentTrackId}
-                leadingElementDelineator={
-                  <Flex gap='3xl' direction='column'>
-                    <Box
-                      alignSelf={isCommentingEnabled ? 'flex-start' : 'center'}
-                    >
-                      <ViewOtherRemixesButton
-                        parentTrackId={defaults.remixParentTrackId!}
-                        size={isCommentingEnabled ? 'xs' : 'small'}
-                      />
-                    </Box>
-                    <Flex
-                      mb='l'
-                      justifyContent={
-                        isCommentingEnabled ? 'flex-start' : 'center'
-                      }
-                    >
-                      {renderMoreByTitle()}
+              <Flex
+                direction='column'
+                alignItems='flex-start'
+                justifyContent='center'
+                gap='l'
+              >
+                {hasValidRemixParent
+                  ? renderOriginalTrackTitle()
+                  : renderMoreByTitle()}
+                <Lineup
+                  lineup={tracks}
+                  // Styles for leading element (original track if remix).
+                  leadingElementId={defaults.remixParentTrackId}
+                  leadingElementDelineator={
+                    <Flex gap='3xl' direction='column'>
+                      <Box
+                        alignSelf={
+                          isCommentingEnabled ? 'flex-start' : 'center'
+                        }
+                      >
+                        <ViewOtherRemixesButton
+                          parentTrackId={defaults.remixParentTrackId!}
+                          size={isCommentingEnabled ? 'xs' : 'small'}
+                        />
+                      </Box>
+                      <Flex
+                        mb='l'
+                        justifyContent={
+                          isCommentingEnabled ? 'flex-start' : 'center'
+                        }
+                      >
+                        {renderMoreByTitle()}
+                      </Flex>
                     </Flex>
-                  </Flex>
-                }
-                leadingElementTileProps={{ size: TrackTileSize.LARGE }}
-                laggingContainerClassName={
-                  !isCommentingEnabled
-                    ? styles.moreByArtistContainer
-                    : undefined
-                }
-                lineupContainerStyles={styles.width100}
-                showLeadingElementArtistPick={false}
-                applyLeadingElementStylesToSkeleton
-                // Don't render the first tile in the lineup since it's actually the "giant"
-                // track tile this page is about.
-                start={1}
-                // Show max 5 loading tiles
-                count={6}
-                // Managed from the parent rather than allowing the lineup to fetch content itself.
-                selfLoad={false}
-                variant={lineupVariant}
-                playingUid={currentQueueItem.uid}
-                playingSource={currentQueueItem.source}
-                playingTrackId={
-                  currentQueueItem.track && currentQueueItem.track.track_id
-                }
-                playing={isPlaying}
-                buffering={isBuffering}
-                playTrack={play}
-                pauseTrack={pause}
-                actions={tracksActions}
-              />
+                  }
+                  leadingElementTileProps={{ size: TrackTileSize.LARGE }}
+                  laggingContainerClassName={
+                    !isCommentingEnabled
+                      ? styles.moreByArtistContainer
+                      : undefined
+                  }
+                  lineupContainerStyles={styles.width100}
+                  showLeadingElementArtistPick={false}
+                  applyLeadingElementStylesToSkeleton
+                  // Don't render the first tile in the lineup since it's actually the "giant"
+                  // track tile this page is about.
+                  start={1}
+                  // Show max 5 loading tiles
+                  count={6}
+                  // Managed from the parent rather than allowing the lineup to fetch content itself.
+                  selfLoad={false}
+                  variant={lineupVariant}
+                  playingUid={currentQueueItem.uid}
+                  playingSource={currentQueueItem.source}
+                  playingTrackId={
+                    currentQueueItem.track && currentQueueItem.track.track_id
+                  }
+                  playing={isPlaying}
+                  buffering={isBuffering}
+                  playTrack={play}
+                  pauseTrack={pause}
+                  actions={tracksActions}
+                />
+              </Flex>
             </Flex>
           ) : null}
         </Flex>


### PR DESCRIPTION
### Description

I think SDK migration may have broken this because we were using list of results to determine whether to show the button. Good thing is that the fix is easy!

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._

<img width="616" alt="image" src="https://github.com/user-attachments/assets/1ebfaf63-6e79-469a-8ada-bd15f952ff03">
