### PR TITLE
fix padding for duration minutes

### DIFF
--- a/packages/harmony/src/utils/formatTrackTimestamp.ts
+++ b/packages/harmony/src/utils/formatTrackTimestamp.ts
@@ -7,7 +7,8 @@ export const formatTrackTimestamp = (timestampSecs: number) => {
   const minutes = Math.floor((timestampSecs / 60) % 60)
   const seconds = `${Math.floor(timestampSecs) % 60}`.padStart(2, '0')
   if (hours > 0) {
-    return `${hours}:${minutes}:${seconds}`
+    const paddedMinutes = minutes.toString().padStart(2, '0')
+    return `${hours}:${paddedMinutes}:${seconds}`
   } else {
     return `${minutes}:${seconds}`
   }


### PR DESCRIPTION
### Description

Need to pad minutes to 2 digits whenever hours is present.

### How Has This Been Tested?

`1h 20m -> 1:20:00`
`4m -> 4:00`
`1h 3m -> 1:03:00`