### PR TITLE
[QA-1789] Fix more by artist width

### DIFF
--- a/packages/web/src/pages/track-page/components/desktop/TrackPage.tsx
+++ b/packages/web/src/pages/track-page/components/desktop/TrackPage.tsx
@@ -294,6 +294,7 @@ const TrackPage = ({
                 alignItems='flex-start'
                 justifyContent='center'
                 gap='l'
+                w='100%'
               >
                 {hasValidRemixParent
                   ? renderOriginalTrackTitle()


### PR DESCRIPTION
### Description

Before the 'more by artist' track tiles were either too wide or too narrow.
This snaps both to the expected width

### How Has This Been Tested?

width is now correct
also checked the responsive changes where the more by section goes below comments. This looks good too.