### PR TITLE
Use msgpack between servers.

### DIFF
--- a/comms/discovery/server/server.go
+++ b/comms/discovery/server/server.go
@@ -24,6 +24,7 @@ import (
 	"github.com/gobwas/ws/wsutil"
 	"github.com/labstack/echo/v4"
 	"github.com/labstack/echo/v4/middleware"
+	"github.com/vmihailenco/msgpack/v5"
 	"golang.org/x/exp/slog"
 )
 
@@ -615,10 +616,14 @@ func (ss *ChatServer) getRpcBulk(c echo.Context) error {
 		return err
 	}
 
-	// using this with debug=true
-	// pretty prints the json and sig match fails
-	// ouch!
-	// return c.JSON(200, rpcs)
+	// prefer msgpack moving forward...
+	if ok, _ := strconv.ParseBool(c.QueryParam("msgpack")); ok {
+		m, err := msgpack.Marshal(rpcs)
+		if err != nil {
+			return err
+		}
+		return c.Blob(200, "application/msgpack", m)
+	}
 
 	j, err := json.Marshal(rpcs)
 	if err != nil {

--- a/comms/go.mod
+++ b/comms/go.mod
@@ -36,6 +36,8 @@ require (
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/tidwall/match v1.1.1 // indirect
 	github.com/tidwall/pretty v1.2.0 // indirect
+	github.com/vmihailenco/msgpack/v5 v5.4.1 // indirect
+	github.com/vmihailenco/tagparser/v2 v2.0.0 // indirect
 	gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c // indirect
 )
 

--- a/comms/go.sum
+++ b/comms/go.sum
@@ -150,6 +150,10 @@ github.com/valyala/bytebufferpool v1.0.0/go.mod h1:6bBcMArwyJ5K/AmCkWv1jt77kVWyC
 github.com/valyala/fasttemplate v1.2.1/go.mod h1:KHLXt3tVN2HBp8eijSv/kGJopbvo7S+qRAEEKiv+SiQ=
 github.com/valyala/fasttemplate v1.2.2 h1:lxLXG0uE3Qnshl9QyaK6XJxMXlQZELvChBOCmQD0Loo=
 github.com/valyala/fasttemplate v1.2.2/go.mod h1:KHLXt3tVN2HBp8eijSv/kGJopbvo7S+qRAEEKiv+SiQ=
+github.com/vmihailenco/msgpack/v5 v5.4.1 h1:cQriyiUvjTwOHg8QZaPihLWeRAAVoCpE00IUPn0Bjt8=
+github.com/vmihailenco/msgpack/v5 v5.4.1/go.mod h1:GaZTsDaehaPpQVyxrf5mtQlH+pc21PIudVV/E3rRQok=
+github.com/vmihailenco/tagparser/v2 v2.0.0 h1:y09buUbR+b5aycVFQs/g70pqKVZNBmxwAhO7/IwNM9g=
+github.com/vmihailenco/tagparser/v2 v2.0.0/go.mod h1:Wri+At7QHww0WTrCBeu4J6bNtoV6mEfg5OIWRZA9qds=
 github.com/xrash/smetrics v0.0.0-20201216005158-039620a65673 h1:bAn7/zixMGCfxrRTfdpNzjtPYqr8smhKouy9mxVdGPU=
 golang.org/x/crypto v0.6.0 h1:qfktjS5LUO+fFKeJXZ+ikTRijMmljikvG68fpMMruSc=
 golang.org/x/crypto v0.6.0/go.mod h1:OFC/31mSvZgRz0V1QTNCzfAI1aIRzbiufJtkMIlEp58=


### PR DESCRIPTION
### Description

* Sweeper can request + receive msgpack in addition to JSON
* Other server looks for `?msgpack=t` query param and will send msgpack with `Content-Type: application/msgpack` in response header
* JSON will still work on both sides while servers upgrade

TODO:

* After 0.7.21 is on all nodes... push POST request can send msgpack too.
* Also after 0.7.21 is on all nodes... reset `rpc_cursor` to 10/23 to ensure no missed messages
