### PR TITLE
Fix validations for unreact comment

### DIFF
--- a/packages/discovery-provider/integration_tests/tasks/entity_manager/test_comment.py
+++ b/packages/discovery-provider/integration_tests/tasks/entity_manager/test_comment.py
@@ -253,6 +253,20 @@ def test_invalid_comment(app, mocker):
                 )
             },
         ],
+        "UnreactCommentNotExisting": [
+            {
+                "args": AttributeDict(
+                    {
+                        "_entityId": 1,
+                        "_entityType": "Comment",
+                        "_userId": 1,
+                        "_action": "Unreact",
+                        "_metadata": "",
+                        "_signer": "user1wallet",
+                    }
+                )
+            },
+        ],
     }
 
     db, index_transaction = setup_test(app, mocker, entities, tx_receipts)
@@ -269,6 +283,8 @@ def test_invalid_comment(app, mocker):
             session.query(Track).filter(Track.pinned_comment_id != None).all()
         )
         assert len(pinned_comments) == 0
+        comment_reactions: List[CommentReaction] = session.query(CommentReaction).all()
+        assert len(comment_reactions) == 0
 
 
 def test_comment_reply(app, mocker):

--- a/packages/discovery-provider/src/tasks/entity_manager/entities/comment.py
+++ b/packages/discovery-provider/src/tasks/entity_manager/entities/comment.py
@@ -506,6 +506,14 @@ def validate_comment_reaction_tx(params: ManageEntityParameters):
         raise IndexingValidationError(
             f"User {user_id} already reacted to comment {comment_id}"
         )
+    if (
+        params.action == Action.UNREACT
+        and (user_id, comment_id)
+        not in params.existing_records[EntityType.COMMENT_REACTION.value]
+    ):
+        raise IndexingValidationError(
+            f"User {user_id} has not reacted to comment {comment_id}"
+        )
 
 
 def react_comment(params: ManageEntityParameters):
@@ -613,7 +621,7 @@ def react_comment(params: ManageEntityParameters):
 
 
 def unreact_comment(params: ManageEntityParameters):
-    validate_signer(params)
+    validate_comment_reaction_tx(params)
     comment_id = params.entity_id
     user_id = params.user_id
 


### PR DESCRIPTION
### Description
Seeing some skipped transactions because of an error where the existing comment reaction doesn't exist when un-reacting. This modification ignores those txs instead of triggering a skip.

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._

Modified existing invalid test case.