### PR TITLE
Revert "Add X-Forwarded-Proto to nginx config to fix resolve endpoint (#10239)"

### DIFF
--- a/packages/discovery-provider/nginx_conf/nginx_container.conf
+++ b/packages/discovery-provider/nginx_conf/nginx_container.conf
@@ -60,7 +60,6 @@ http {
 
         proxy_set_header Host $http_host;
         proxy_set_header X-Forwarded-For $remote_addr;
-        proxy_set_header X-Forwarded-Proto $scheme;
 
         location = /openresty_pubkey {
             content_by_lua_block {
@@ -297,7 +296,6 @@ http {
             proxy_pass http://$upstream;
             proxy_set_header Host $http_host;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-            proxy_set_header X-Forwarded-Proto $scheme;
         }
 
         location /sitemaps/ {


### PR DESCRIPTION
This reverts commit 1c91f857655026a3f3debc3d9fbf44c38d9b16fe.

The X-Forwarded-Proto being set by nginx had the unintended behavior of being set to http instead of https, because Caddy sits in front of our nginx.

See https://github.com/AudiusProject/audius-docker-compose/pull/545 for the Caddy change