### PR TITLE
Include specifiers for Audio Match in migration

### DIFF
--- a/packages/discovery-provider/ddl/migrations/0102_shorten_challenge_ids.sql
+++ b/packages/discovery-provider/ddl/migrations/0102_shorten_challenge_ids.sql
@@ -244,7 +244,7 @@ SET
       to_hex(split_part(specifier, '=>', 1)::integer) || 
       ':' || 
       to_hex(split_part(specifier, '=>', 2)::integer)
-WHERE challenge_id = 'b';
+WHERE challenge_id = 'b' AND STRPOS(specifier, '=>') > 0;
 
 UPDATE challenge_disbursements 
 SET 
@@ -252,7 +252,7 @@ SET
       to_hex(split_part(specifier, '=>', 1)::integer) || 
       ':' || 
       to_hex(split_part(specifier, '=>', 2)::integer)
-WHERE challenge_id = 's';
+WHERE challenge_id = 's' AND STRPOS(specifier, '=>') > 0 ;
 
 -- readd pkey
 ALTER TABLE ONLY challenge_disbursements

--- a/packages/discovery-provider/ddl/migrations/0102_shorten_challenge_ids.sql
+++ b/packages/discovery-provider/ddl/migrations/0102_shorten_challenge_ids.sql
@@ -116,6 +116,22 @@ SET
       to_hex(split_part(specifier, '=>', 2)::integer)
 WHERE challenge_id = 'ref-v';
 
+UPDATE user_challenges 
+SET
+    specifier = 
+      to_hex(split_part(specifier, '=>', 1)::integer) || 
+      ':' || 
+      to_hex(split_part(specifier, '=>', 2)::integer)
+WHERE challenge_id = 'b';
+
+UPDATE user_challenges 
+SET 
+    specifier = 
+      to_hex(split_part(specifier, '=>', 1)::integer) || 
+      ':' || 
+      to_hex(split_part(specifier, '=>', 2)::integer)
+WHERE challenge_id = 's';
+
 -- readd index (probably not super necessary since the pkey covers this anyway, but whatevs)
 CREATE INDEX user_challenges_challenge_idx ON public.user_challenges USING btree (challenge_id);
 
@@ -221,6 +237,22 @@ SET
       ':' || 
       to_hex(split_part(specifier, '=>', 2)::integer)
 WHERE challenge_id = 'ref-v';
+
+UPDATE challenge_disbursements 
+SET
+    specifier = 
+      to_hex(split_part(specifier, '=>', 1)::integer) || 
+      ':' || 
+      to_hex(split_part(specifier, '=>', 2)::integer)
+WHERE challenge_id = 'b';
+
+UPDATE challenge_disbursements 
+SET 
+    specifier = 
+      to_hex(split_part(specifier, '=>', 1)::integer) || 
+      ':' || 
+      to_hex(split_part(specifier, '=>', 2)::integer)
+WHERE challenge_id = 's';
 
 -- readd pkey
 ALTER TABLE ONLY challenge_disbursements


### PR DESCRIPTION
Because the `challenge_id` didn't change for these, I mistakenly left them out of the migration.

For consistency across all specifiers, they should be included as well and have their specifiers hexed and delimited with a `:`

