### PR TITLE
Make track description text selectable on web

### DIFF
--- a/packages/web/src/components/track/GiantTrackTile.tsx
+++ b/packages/web/src/components/track/GiantTrackTile.tsx
@@ -612,7 +612,10 @@ export const GiantTrackTile = ({
               tag='h3'
               size='s'
               lineHeight='multi'
-              css={(theme) => ({ paddingTop: theme.spacing.m })}
+              css={(theme) => ({
+                paddingTop: theme.spacing.m,
+                userSelect: 'text'
+              })}
             >
               {description}
             </UserGeneratedText>


### PR DESCRIPTION
### Description

* Make track description selectable on web

We really should just remove: https://github.com/AudiusProject/audius-protocol/blob/main/packages/web/src/assets/styles/index.css#L26 and selectively have user-select: none on elements we don't want selectable. This would be better for accessibility too

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._
