### PR TITLE
[C-5308] Fix react crash in UserGeneratedText

### DIFF
--- a/packages/web/src/components/user-generated-text/UserGeneratedText.tsx
+++ b/packages/web/src/components/user-generated-text/UserGeneratedText.tsx
@@ -107,7 +107,7 @@ export const UserGeneratedText = forwardRef(function <T extends ElementType>(
 
   const options: Opts = useMemo(
     () => ({
-      render: RenderLink,
+      render: (linkProps) => <RenderLink {...linkProps} />,
       attributes: {
         source: linkSource,
         onClick: onClickLink,


### PR DESCRIPTION
### Description

`Linkify` component wasn't rendering our component properly so React got confused when changing pages and threw an error about hooks being called inconsistently

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._
