### PR TITLE
Fix resolve scheme in url_for

### DIFF
--- a/packages/discovery-provider/src/api/v1/utils/resolve_url.py
+++ b/packages/discovery-provider/src/api/v1/utils/resolve_url.py
@@ -8,15 +8,23 @@ from src.api.v1.playlists import ns as playlists_ns
 from src.api.v1.tracks import ns as tracks_ns
 from src.api.v1.users import ns as users_ns
 from src.models.users.user import User
+from src.utils.config import shared_config
 from src.utils.helpers import encode_int_id
 
 track_url_regex = re.compile(r"^/(?P<handle>[^/]*)/(?P<slug>[^/]*)$")
 playlist_url_regex = re.compile(r"/(?P<handle>[^/]*)/(playlist|album)/(?P<slug>[^/]*)$")
 user_url_regex = re.compile(r"^/(?P<handle>[^/]*)$")
 
+env = shared_config["discprov"]["env"]
+
 
 def ns_url_for(ns, route, **kwargs):
-    return url_for(f"{api_v1.bp.name}.{ns.name}_{route}", **kwargs)
+    return url_for(
+        f"{api_v1.bp.name}.{ns.name}_{route}",
+        _scheme="https" if env == "stage" or env == "prod" else None,
+        _external=True if env == "stage" or env == "prod" else None,
+        **kwargs,
+    )
 
 
 def resolve_url(session, url):


### PR DESCRIPTION
### Description

There could be arbitrary proxies eating the {scheme} before this app code executes, so just set https if we in a stage or prod env. Could cause some issues for people running a prod config locally, but idc too much abt that given how hard this is to fix in prod.

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._

deployed to stage dn and tested
```
await fetch('https://discoveryprovider5.staging.audius.co/v1/resolve?url=https://staging.audius.co/isaactest/large-file')
```

🤞  that this works on prod the way we hope for other nodes