### PR TITLE
Add mapping from old rewards to new rewards

### DIFF
--- a/packages/discovery-provider/src/tasks/index_rewards_manager.py
+++ b/packages/discovery-provider/src/tasks/index_rewards_manager.py
@@ -139,6 +139,17 @@ def get_challenge_type_map(
             )
             for challenge in challenges
         }
+    # Temporary change to map old challenge ids to new ones
+    challenge_type_map_global["p"] = challenge_type_map_global["profile-completion"]
+    challenge_type_map_global["l"] = challenge_type_map_global["listen-streak"]
+    challenge_type_map_global["u"] = challenge_type_map_global["track-upload"]
+    challenge_type_map_global["r"] = challenge_type_map_global["referrals"]
+    challenge_type_map_global["rv"] = challenge_type_map_global["ref-v"]
+    challenge_type_map_global["rd"] = challenge_type_map_global["referred"]
+    challenge_type_map_global["v"] = challenge_type_map_global["connect-verified"]
+    challenge_type_map_global["m"] = challenge_type_map_global["mobile-install"]
+    challenge_type_map_global["ft"] = challenge_type_map_global["send-first-tip"]
+    challenge_type_map_global["fp"] = challenge_type_map_global["first-playlist"]
 
     return challenge_type_map_global
 

--- a/packages/discovery-provider/src/tasks/index_rewards_manager.py
+++ b/packages/discovery-provider/src/tasks/index_rewards_manager.py
@@ -140,16 +140,16 @@ def get_challenge_type_map(
             for challenge in challenges
         }
     # Temporary change to map old challenge ids to new ones
-    challenge_type_map_global["p"] = challenge_type_map_global["profile-completion"]
-    challenge_type_map_global["l"] = challenge_type_map_global["listen-streak"]
-    challenge_type_map_global["u"] = challenge_type_map_global["track-upload"]
-    challenge_type_map_global["r"] = challenge_type_map_global["referrals"]
-    challenge_type_map_global["rv"] = challenge_type_map_global["ref-v"]
-    challenge_type_map_global["rd"] = challenge_type_map_global["referred"]
-    challenge_type_map_global["v"] = challenge_type_map_global["connect-verified"]
-    challenge_type_map_global["m"] = challenge_type_map_global["mobile-install"]
-    challenge_type_map_global["ft"] = challenge_type_map_global["send-first-tip"]
-    challenge_type_map_global["fp"] = challenge_type_map_global["first-playlist"]
+    challenge_type_map_global["profile-completion"] = challenge_type_map_global["p"]
+    challenge_type_map_global["listen-streak"] = challenge_type_map_global["l"]
+    challenge_type_map_global["track-upload"] = challenge_type_map_global["u"]
+    challenge_type_map_global["referrals"] = challenge_type_map_global["r"]
+    challenge_type_map_global["ref-v"] = challenge_type_map_global["rv"]
+    challenge_type_map_global["referred"] = challenge_type_map_global["rd"]
+    challenge_type_map_global["connect-verified"] = challenge_type_map_global["v"]
+    challenge_type_map_global["mobile-install"] = challenge_type_map_global["m"]
+    challenge_type_map_global["send-first-tip"] = challenge_type_map_global["ft"]
+    challenge_type_map_global["first-playlist"] = challenge_type_map_global["fp"]
 
     return challenge_type_map_global
 


### PR DESCRIPTION
### Description

While other nodes still have the old formats, add a temporary mapping.
Revert this PR after nodes all have 0.7.22 and up

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._

prod dn2 confirmed AudioTransactions are indexed ok

<img width="1512" alt="image" src="https://github.com/user-attachments/assets/05d41d5d-ac1e-4b31-b15b-6532406872c9">
