### PR TITLE
[QA-1794] Reset padding for Safari buttons

### DIFF
--- a/packages/harmony/src/components/button/BaseButton/BaseButton.tsx
+++ b/packages/harmony/src/components/button/BaseButton/BaseButton.tsx
@@ -62,6 +62,10 @@ export const BaseButton = forwardRef<HTMLButtonElement, BaseButtonProps>(
       textAlign: 'center',
       userSelect: 'none',
       whiteSpace: 'nowrap',
+      paddingInlineStart: 0,
+      paddingInlineEnd: 0,
+      '-webkit-padding-start': 0,
+      '-webkit-padding-end': 0,
       transition: `
         transform ${motion.hover},
         border-color ${motion.hover},


### PR DESCRIPTION
### Description

Safari mobile user agent stylesheet was applying extra padding to inline buttons, causing the stats to overflow on track screen. This resets the safari padding

### How Has This Been Tested?

Did a quick pass to confirm buttons are correct throughout app
