### PR TITLE
Fix track updates missing userId

### DIFF
--- a/packages/commands/src/edit-track.mjs
+++ b/packages/commands/src/edit-track.mjs
@@ -1,60 +1,101 @@
-import chalk from "chalk";
-import { program } from "commander";
+import chalk from 'chalk'
+import { program } from 'commander'
 
-import { initializeAudiusLibs } from "./utils.mjs";
+import { initializeAudiusLibs } from './utils.mjs'
 
-program.command("edit-track")
-  .description("Update an existing track")
-  .argument("<trackId>", "Id of track to update")
-  .option("-t, --title <title>", "Title of track")
-  .option("-a, --tags <tags>", "Tags of track")
-  .option("-d, --description <description>", "Description of track")
-  .option("-m, --mood <mood>", "Mood of track")
-  .option("-g, --genre <genre>", "Genre of track")
-  .option("-s, --preview-start-seconds <seconds>", "Track preview start time (seconds)", null)
-  .option("-l, --license <license>", "License of track")
-  .option("-f, --from <from>", "The account to edit the track from")
-  .option("-r, --stream-conditions <stream conditions>", "The stream conditions object; sets track as stream gated", "")
-  .option("-v, --visibility <visibility>", "Change track visibility")
-  .option("-x, --remixOf <remixOf>", "Set the original track of this remix")
-  .action(async (trackId, { title, tags, description, mood, genre, previewStartSeconds, license, from, streamConditions, visibility, remixOf }) => {
-    const audiusLibs = await initializeAudiusLibs(from);
-    try {
-      const track = (await audiusLibs.Track.getTracks(100, 0, [trackId]))[0]
-      delete track.user
-      console.log(chalk.yellow.bold("Track before update: "), track);
+program
+  .command('edit-track')
+  .description('Update an existing track')
+  .argument('<trackId>', 'Id of track to update')
+  .option('-t, --title <title>', 'Title of track')
+  .option('-a, --tags <tags>', 'Tags of track')
+  .option('-d, --description <description>', 'Description of track')
+  .option('-m, --mood <mood>', 'Mood of track')
+  .option('-g, --genre <genre>', 'Genre of track')
+  .option(
+    '-s, --preview-start-seconds <seconds>',
+    'Track preview start time (seconds)',
+    null
+  )
+  .option('-l, --license <license>', 'License of track')
+  .option('-f, --from <from>', 'The account to edit the track from')
+  .option(
+    '-r, --stream-conditions <stream conditions>',
+    'The stream conditions object; sets track as stream gated',
+    ''
+  )
+  .option('-v, --visibility <visibility>', 'Change track visibility')
+  .option('-x, --remixOf <remixOf>', 'Set the original track of this remix')
+  .action(
+    async (
+      trackId,
+      {
+        title,
+        tags,
+        description,
+        mood,
+        genre,
+        previewStartSeconds,
+        license,
+        from,
+        streamConditions,
+        visibility,
+        remixOf
+      }
+    ) => {
+      const audiusLibs = await initializeAudiusLibs(from)
+      try {
+        const track = (await audiusLibs.Track.getTracks(100, 0, [trackId]))[0]
+        delete track.user
+        console.log(chalk.yellow.bold('Track before update: '), track)
 
-      const updatedMetadata = {
-        ...track,
-        title: title || track.title,
-        tags: tags || track.tags,
-        description: description || track.description,
-        mood: mood || track.mood,
-        genre: genre || track.genre,
-        license: license || track.license,
-        is_stream_gated: streamConditions ? true : track.is_stream_gated,
-        stream_conditions: streamConditions ? JSON.parse(streamConditions) : track.stream_conditions,
-        preview_start_seconds: previewStartSeconds ? parseInt(previewStartSeconds) : track.preview_start_seconds,
-        is_unlisted: visibility ? visibility === 'hidden' : track.is_unlisted,
-        remix_of: remixOf !== undefined ? { tracks: [{ parent_track_id: parseInt(remixOf) }] } : track.remix_of
+        const updatedMetadata = {
+          ...track,
+          title: title || track.title,
+          tags: tags || track.tags,
+          description: description || track.description,
+          mood: mood || track.mood,
+          genre: genre || track.genre,
+          license: license || track.license,
+          is_stream_gated: streamConditions ? true : track.is_stream_gated,
+          stream_conditions: streamConditions
+            ? JSON.parse(streamConditions)
+            : track.stream_conditions,
+          preview_start_seconds: previewStartSeconds
+            ? parseInt(previewStartSeconds)
+            : track.preview_start_seconds,
+          is_unlisted: visibility ? visibility === 'hidden' : track.is_unlisted,
+          remix_of:
+            remixOf !== undefined
+              ? { tracks: [{ parent_track_id: parseInt(remixOf) }] }
+              : track.remix_of
+        }
+
+        const transcodePreview =
+          previewStartSeconds != null &&
+          track.preview_start_seconds != parseInt(previewStartSeconds)
+        const response = await audiusLibs.Track.updateTrackV2(
+          audiusLibs.getCurrentUser().user_id,
+          updatedMetadata,
+          transcodePreview
+        )
+
+        if (response.error) {
+          program.error(chalk.red(response.error))
+        }
+
+        await new Promise((r) => setTimeout(r, 2000))
+
+        const updatedTrack = (
+          await audiusLibs.Track.getTracks(100, 0, [trackId])
+        )[0]
+        delete updatedTrack.user
+        console.log(chalk.green('Successfully updated track!'))
+        console.log(chalk.yellow.bold('Track after update: '), updatedTrack)
+      } catch (err) {
+        program.error(err.message)
       }
 
-      const transcodePreview = previewStartSeconds != null && track.preview_start_seconds != parseInt(previewStartSeconds)
-      const response = await audiusLibs.Track.updateTrackV2(updatedMetadata, transcodePreview)
-
-      if (response.error) {
-        program.error(chalk.red(response.error));
-      }
-
-      await new Promise(r => setTimeout(r, 2000));
-
-      const updatedTrack = (await audiusLibs.Track.getTracks(100, 0, [trackId]))[0]
-      delete updatedTrack.user
-      console.log(chalk.green("Successfully updated track!"));
-      console.log(chalk.yellow.bold("Track after update: "), updatedTrack);
-    } catch (err) {
-      program.error(err.message);
+      process.exit(0)
     }
-
-    process.exit(0);
-  });
+  )

--- a/packages/common/src/services/audius-backend/AudiusBackend.ts
+++ b/packages/common/src/services/audius-backend/AudiusBackend.ts
@@ -901,6 +901,7 @@ export const audiusBackend = ({
   }
 
   async function updateTrack(
+    userId: ID,
     _trackId: ID,
     metadata: TrackMetadata | TrackMetadataForUpload,
     transcodePreview?: boolean
@@ -914,6 +915,7 @@ export const audiusBackend = ({
       cleanedMetadata.cover_art_sizes = resp.id
     }
     return await audiusLibs.Track.updateTrackV2(
+      userId,
       cleanedMetadata,
       transcodePreview
     )

--- a/packages/web/src/common/store/cache/tracks/sagas.ts
+++ b/packages/web/src/common/store/cache/tracks/sagas.ts
@@ -290,8 +290,16 @@ function* confirmEditTrack(
     confirmerActions.requestConfirmation(
       makeKindId(Kind.TRACKS, trackId),
       function* () {
+        yield* waitForAccount()
+        // Need to poll with the new track name in case it changed
+        const userId = yield* select(getUserId)
+        if (!userId) {
+          throw new Error('No userId set, cannot edit track')
+        }
+
         const { blockHash, blockNumber } = yield* call(
           audiusBackendInstance.updateTrack,
+          userId,
           trackId,
           { ...formFields },
           transcodePreview
@@ -307,10 +315,6 @@ function* confirmEditTrack(
             `Could not confirm edit track for track id ${trackId}`
           )
         }
-
-        yield* waitForAccount()
-        // Need to poll with the new track name in case it changed
-        const userId = yield* select(getUserId)
 
         const { data } = yield* call(
           [sdk.full.tracks, sdk.full.tracks.getTrack],


### PR DESCRIPTION
### Description
I updated `updateTrackV2` to require passing `userId` in #9673 and missed updating the usages of it in `AudiusBackend` due to libs being untyped there. 😬 


### How Has This Been Tested?
Verified edits work again on local client against staging.