### PR TITLE
Make is_stream_gated and is_download_gated nullable in upload schema

### DIFF
--- a/packages/common/src/schemas/upload/uploadFormSchema.ts
+++ b/packages/common/src/schemas/upload/uploadFormSchema.ts
@@ -94,7 +94,7 @@ const DDEXRightsController = z
   .strict()
 
 const premiumMetadataSchema = z.object({
-  is_stream_gated: z.optional(z.boolean()),
+  is_stream_gated: z.optional(z.boolean()).nullable(),
   stream_conditions: z
     .optional(
       z.union([
@@ -105,7 +105,7 @@ const premiumMetadataSchema = z.object({
       ])
     )
     .nullable(),
-  is_download_gated: z.optional(z.boolean()),
+  is_download_gated: z.optional(z.boolean()).nullable(),
   download_conditions: z
     .optional(
       z.union([


### PR DESCRIPTION
### Description

https://github.com/AudiusProject/audius-protocol/pull/10146 removed `is_stream_gated` and `is_download_gated` from backend and returns null when they aren't present. This caused an issue with our upload/edit form validation

### How Has This Been Tested?

Confirmed edit collection works
