### PR TITLE
[QA-1807] Fix Profile Page: Add entry to totalTileHeight map of 140 for grid lineup variant

### DIFF
--- a/packages/web/src/components/lineup/LineupProvider.tsx
+++ b/packages/web/src/components/lineup/LineupProvider.tsx
@@ -68,7 +68,8 @@ const totalTileHeight = {
   main: 152 + 16,
   section: 124 + 16,
   condensed: 124 + 8,
-  playlist: 350
+  playlist: 350,
+  grid: 140
 }
 
 const innerHeight = typeof window !== 'undefined' ? window.innerHeight : 0


### PR DESCRIPTION
The Profile page was broken in https://github.com/AudiusProject/audius-protocol/pull/10298 because the `totalTileHeight` object doesn't have a value for the `grid` variant.

This value is used to determine how many tracks to load based on how many fit on the screen at a time, so that we can load "pages" of tracks as they are visually needed.

Because the entry was missing, the math for that was returning `NaN`, and then the `LineupProvider` was throwing up an error `RangeError: Invalid array length` when trying to render the skeleton tiles (I think) based on the count that was supposed to be loading