### PR TITLE
Update mobile app versions during client release

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -174,6 +174,17 @@ jobs:
             CHANGELOG=$(git log --pretty=format:"[%h] %s %an" --date=short client-v${PREV_VERSION}..HEAD -- ${CLIENT_DIRS})
             npm i --ignore-scripts
             npm version patch -w @audius/web -w @audius/mobile --include-workspace-root --no-git-tag-version
+
+            # Update iOS Info.plist version
+            CURRENT_VERSION=$(grep -A1 'CFBundleShortVersionString' packages/mobile/ios/AudiusReactNative/Info.plist | tail -1 | sed 's/.*<string>\(.*\)<\/string>.*/\1/')
+            NEW_VERSION=$(echo $CURRENT_VERSION | awk -F. '{$NF = $NF + 1;} 1' OFS=.)
+            sed -i '' "s/$CURRENT_VERSION/$NEW_VERSION/" packages/mobile/ios/AudiusReactNative/Info.plist
+
+            # Update Android versionName
+            CURRENT_VERSION=$(grep -E 'versionName.*"[0-9]+\.[0-9]+\.[0-9]+"' packages/mobile/android/app/build.gradle | sed 's/.*"\([0-9.]*\)".*/\1/')
+            NEW_VERSION=$(echo $CURRENT_VERSION | awk -F. '{$NF = $NF + 1;} 1' OFS=.)
+            sed -i '' "s/versionName \"$CURRENT_VERSION\"/versionName \"$NEW_VERSION\"/" packages/mobile/android/app/build.gradle
+
             git add .
             VERSION=$(jq -r .version ./package.json)
             MESSAGE="Audius Client (Web and Mobile) v${VERSION}

--- a/.circleci/src/jobs/@mobile-jobs.yml
+++ b/.circleci/src/jobs/@mobile-jobs.yml
@@ -41,16 +41,6 @@ mobile-init:
           - packages/mobile/.env.stage
           - packages/mobile/.env.prod
 
-mobile-comment-native-code-change:
-  working_directory: ~/audius-protocol
-  docker:
-    - image: cimg/node:14.20
-  steps:
-    - checkout
-    - mobile-halt-if-no-native-changes
-    - web-pr-comment:
-        comment: 'It looks like there may be some changes to native mobile code, which requires triggering a full app release. Please follow the instructions here: https://www.notion.so/audiusproject/When-to-bump-app-version-2644a8f772364a4d91f44abcba44ce0b?pvs=4. cc @dylanjeffers @sliptype'
-
 mobile-build-staging-ios:
   working_directory: ~/audius-protocol
   # run on macos so app can be created and signed.

--- a/.circleci/src/workflows/mobile.yml
+++ b/.circleci/src/workflows/mobile.yml
@@ -3,12 +3,6 @@ jobs:
   - mobile-init:
       context: Audius Mobile Client
 
-  - mobile-comment-native-code-change:
-      context: Audius Mobile Client
-      filters:
-        branches:
-          ignore: /(^main|^release.*)$/
-
   - mobile-build-staging-ios:
       context: Audius Mobile Client
       requires:


### PR DESCRIPTION
### Description
Adds scripts to update the mobile app versions during client release, since we always shoot for full app version each week

Also removes native change alert, since it's irrelevant and hasnt helped us