### PR TITLE
Fix FilterButtonOptionsList label prop

### DIFF
--- a/packages/harmony/src/components/button/FilterButton/FilterButtonOptionsList.tsx
+++ b/packages/harmony/src/components/button/FilterButton/FilterButtonOptionsList.tsx
@@ -97,6 +97,7 @@ export const OptionsList = <Value extends string>({
             }}
             key={option.value}
             {...option}
+            label={option.label ?? option.value}
             onChange={onChange}
             isActive={option.value === activeValue}
           />


### PR DESCRIPTION
### Description

The refactor of FilterButton to use MenuItem broke the fallback logic when label isn't provided for an option. See harmony.audius.co:

<img width="1057" alt="image" src="https://github.com/user-attachments/assets/c1f4c47e-e87b-4d33-9b2e-318618ee1d95">

This also broke the harmony tests which is blocking npm publish currently: https://github.com/AudiusProject/audius-protocol/actions/runs/11674036614/job/32506307574

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._
