### PR TITLE
new config restrictions and networks

### DIFF
--- a/pkg/core/config/genesis/prod.json
+++ b/pkg/core/config/genesis/prod.json
@@ -1,16 +1,15 @@
 {
   "genesis_time": "2024-09-05T00:00:00.0000Z",
-  "chain_id": "audius-mainnet-test4",
+  "chain_id": "audius-mainnet-test5",
   "initial_height": "0",
   "consensus_params": {
     "block": {
-      "max_bytes": "104857600",
+      "max_bytes": "15728640",
       "max_gas": "10000000"
     },
     "evidence": {
-      "max_age_num_blocks": "100000",
-      "max_age_duration": "172800000000000",
-      "max_bytes": "104857600"
+      "max_age_num_blocks": "0",
+      "max_age_duration": "0"
     },
     "validator": {
       "pub_key_types": [
@@ -21,8 +20,8 @@
       "app": "0"
     },
     "synchrony": {
-      "precision": "500000000",
-      "message_delay": "2000000000"
+      "precision": "100000000",
+      "message_delay": "500000000"
     },
     "feature": {
       "vote_extensions_enable_height": "0",

--- a/pkg/core/config/genesis/stage.json
+++ b/pkg/core/config/genesis/stage.json
@@ -1,16 +1,15 @@
 {
   "genesis_time": "2024-08-09T00:00:00.0000Z",
-  "chain_id": "audius-testnet-6",
+  "chain_id": "audius-testnet-7",
   "initial_height": "0",
   "consensus_params": {
     "block": {
-      "max_bytes": "104857600",
+      "max_bytes": "15728640",
       "max_gas": "10000000"
     },
     "evidence": {
-      "max_age_num_blocks": "100000",
-      "max_age_duration": "172800000000000",
-      "max_bytes": "104857600"
+      "max_age_num_blocks": "0",
+      "max_age_duration": "0"
     },
     "validator": {
       "pub_key_types": [
@@ -21,8 +20,8 @@
       "app": "0"
     },
     "synchrony": {
-      "precision": "500000000",
-      "message_delay": "2000000000"
+      "precision": "100000000",
+      "message_delay": "500000000"
     },
     "feature": {
       "vote_extensions_enable_height": "0",


### PR DESCRIPTION
### Description
- sets new limits on block, tx, and mempool sizes for core
- blocks are limited to 15mb at the genesis level
- tx sizes are limited to 300kb
- mempool is restricted to 500mb to free up other core resources
- validator connection settings are boosted to get to faster block times
- non validator connection settings are nerfed to allow validators to create blocks with higher priority
- pex reactor is turned off because we don't need it and it's probably using unnecessary network bandwidth
- sets up new networks with these settings since there's some genesis level changes
- sets duplicate ip connections allowed to true, this will help with sandboxes
 
### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._
