### PR TITLE
[PAY-3580] Make user bank logic for first time buyers more robust

### DIFF
--- a/packages/common/src/store/buy-usdc/sagas.ts
+++ b/packages/common/src/store/buy-usdc/sagas.ts
@@ -48,7 +48,11 @@ import {
   recoveryStatusChanged
 } from './slice'
 import { BuyUSDCError, BuyUSDCErrorCode } from './types'
-import { getBuyUSDCRemoteConfig, getUSDCUserBank } from './utils'
+import {
+  getBuyUSDCRemoteConfig,
+  getOrCreateUSDCUserBank,
+  pollForTokenAccountInfo
+} from './utils'
 
 type PurchaseStepParams = {
   desiredAmount: number
@@ -236,7 +240,7 @@ function* doBuyUSDC({
   const audiusBackendInstance = yield* getContext('audiusBackendInstance')
   const config = yield* call(getBuyUSDCRemoteConfig)
 
-  const userBank = yield* getUSDCUserBank()
+  const userBank = yield* getOrCreateUSDCUserBank()
   const rootAccount = yield* call(getRootSolanaAccount, audiusBackendInstance)
 
   try {
@@ -434,15 +438,11 @@ function* recoverPurchaseIfNecessary() {
       return
     }
 
-    const userBank = yield* getUSDCUserBank()
-    const userBankAccountInfo = yield* call(
-      getTokenAccountInfo,
-      audiusBackendInstance,
-      {
-        tokenAccount: userBank,
-        mint: 'usdc'
-      }
-    )
+    const userBank = yield* getOrCreateUSDCUserBank()
+    const userBankAccountInfo = yield* call(pollForTokenAccountInfo, {
+      tokenAccount: userBank,
+      mint: 'usdc'
+    })
 
     const userBankInitialBalance = userBankAccountInfo?.amount ?? BigInt(0)
 

--- a/packages/common/src/store/buy-usdc/utils.ts
+++ b/packages/common/src/store/buy-usdc/utils.ts
@@ -1,6 +1,12 @@
-import { call, select } from 'typed-redux-saga'
+import { PublicKey } from '@solana/web3.js'
+import { channel, Channel } from 'redux-saga'
+import { call, delay, select, take } from 'typed-redux-saga'
 
-import { createUserBankIfNeeded } from '~/services/audius-backend/solana'
+import {
+  createUserBankIfNeeded,
+  getTokenAccountInfo,
+  MintName
+} from '~/services/audius-backend/solana'
 import { IntKeys } from '~/services/remote-config'
 import {
   MAX_CONTENT_PRICE_CENTS,
@@ -9,26 +15,99 @@ import {
   MIN_USDC_PURCHASE_AMOUNT_CENTS,
   BUY_TOKEN_VIA_SOL_SLIPPAGE_BPS
 } from '~/services/remote-config/defaults'
-import { getContext } from '~/store/effects'
-import { getFeePayer } from '~/store/solana/selectors'
+
+import { getContext } from '../effects'
+import { getFeePayer } from '../solana/selectors'
+
+const POLL_ACCOUNT_INFO_DELAY_MS = 1000
+const POLL_ACCOUNT_INFO_RETRIES = 30
+
+// Create a channel to manage concurrent requests
+let pendingUserBankCreation: Channel<{
+  result?: Awaited<ReturnType<typeof createUserBankIfNeeded>>
+  error?: Error
+}> | null = null
 
 /**
  * Derives a USDC user bank for a given eth address, creating it if necessary.
- * Defaults to the wallet of the current user.
+ * Defaults to the wallet of the current user. Uses a channel to manage concurrent
+ * requests so there is only one creation attempt in flight at a time.
  */
-export function* getUSDCUserBank(ethAddress?: string) {
-  const audiusBackendInstance = yield* getContext('audiusBackendInstance')
-  const { track } = yield* getContext('analytics')
-  const feePayerOverride = yield* select(getFeePayer)
-  if (!feePayerOverride) {
-    throw new Error('getUSDCUserBank: unexpectedly no fee payer override')
+export function* getOrCreateUSDCUserBank(ethAddress?: string) {
+  // If there's already a pending operation, wait for its result
+  if (pendingUserBankCreation) {
+    const { result, error } = yield* take(pendingUserBankCreation)
+    if (error) throw error
+    if (!result)
+      throw new Error('No user bank returned from createUserBankIfNeeded')
+    return result
   }
-  return yield* call(createUserBankIfNeeded, audiusBackendInstance, {
-    ethAddress,
-    feePayerOverride,
-    mint: 'usdc',
-    recordAnalytics: track
-  })
+
+  // Create a new channel for this bank creation
+  pendingUserBankCreation = channel()
+  try {
+    const audiusBackendInstance = yield* getContext('audiusBackendInstance')
+    const { track } = yield* getContext('analytics')
+    const feePayerOverride = yield* select(getFeePayer)
+
+    if (!feePayerOverride) {
+      throw new Error(
+        'getOrCreateUSDCUserBank: unexpectedly no fee payer override'
+      )
+    }
+
+    // Perform the bank creation
+    const result = yield* call(createUserBankIfNeeded, audiusBackendInstance, {
+      ethAddress,
+      feePayerOverride,
+      mint: 'usdc',
+      recordAnalytics: track
+    })
+
+    // Put the successful result on the channel
+    pendingUserBankCreation.put({ result })
+    return result
+  } catch (error) {
+    // Put the error on the channel
+    pendingUserBankCreation.put({ error: error as Error })
+    throw error
+  } finally {
+    // Close and cleanup the channel
+    pendingUserBankCreation.close()
+    pendingUserBankCreation = null
+  }
+}
+
+/** Polls for the given token account info up to a maximum retry count. Useful
+ * for ensuring account is returned if it may have just been created.
+ */
+export function* pollForTokenAccountInfo({
+  retryDelayMs = POLL_ACCOUNT_INFO_DELAY_MS,
+  maxRetryCount = POLL_ACCOUNT_INFO_RETRIES,
+  ...getTokenAccountInfoArgs
+}: {
+  tokenAccount: PublicKey
+  mint?: MintName
+  retryDelayMs?: number
+  maxRetryCount?: number
+}) {
+  const audiusBackendInstance = yield* getContext('audiusBackendInstance')
+
+  let retries = 0
+  let tokenAccount
+  while (retries < maxRetryCount && !tokenAccount) {
+    tokenAccount = yield* call(
+      getTokenAccountInfo,
+      audiusBackendInstance,
+      getTokenAccountInfoArgs
+    )
+    retries += 1
+    yield* delay(retryDelayMs)
+  }
+  if (!tokenAccount) {
+    throw new Error('Failed to fetch USDC user bank token account info')
+  }
+  return tokenAccount
 }
 
 export function* getBuyUSDCRemoteConfig() {

--- a/packages/common/src/store/buy-usdc/utils.ts
+++ b/packages/common/src/store/buy-usdc/utils.ts
@@ -94,9 +94,9 @@ export function* pollForTokenAccountInfo({
   const audiusBackendInstance = yield* getContext('audiusBackendInstance')
 
   let retries = 0
-  let tokenAccount
-  while (retries < maxRetryCount && !tokenAccount) {
-    tokenAccount = yield* call(
+  let result
+  while (retries < maxRetryCount && !result) {
+    result = yield* call(
       getTokenAccountInfo,
       audiusBackendInstance,
       getTokenAccountInfoArgs
@@ -104,10 +104,12 @@ export function* pollForTokenAccountInfo({
     retries += 1
     yield* delay(retryDelayMs)
   }
-  if (!tokenAccount) {
-    throw new Error('Failed to fetch USDC user bank token account info')
+  if (!result) {
+    throw new Error(
+      `Failed to fetch USDC user bank token account info for ${getTokenAccountInfoArgs.tokenAccount.toString()}`
+    )
   }
-  return tokenAccount
+  return result
 }
 
 export function* getBuyUSDCRemoteConfig() {

--- a/packages/common/src/store/purchase-content/sagas.ts
+++ b/packages/common/src/store/purchase-content/sagas.ts
@@ -91,7 +91,7 @@ import {
   usdcBalanceSufficient,
   purchaseContentFlowFailed,
   startPurchaseContentFlow,
-  ensureUserBankExists
+  eagerCreateUserBank
 } from './slice'
 import {
   PurchaseableContentType,
@@ -1155,17 +1155,16 @@ function* watchStartPurchaseContentFlow() {
   yield takeLatest(startPurchaseContentFlow, doStartPurchaseContentFlow)
 }
 
-function* watchEnsureUserBankExists() {
-  yield takeEvery(ensureUserBankExists, function* () {
+function* watchEagerCreateUserBank() {
+  yield takeEvery(eagerCreateUserBank, function* () {
     try {
       yield* call(getOrCreateUSDCUserBank)
     } catch (e) {
-      // No need to bubble here as later flows will still attempt to create it
-      console.warn(`ensureUserBankExists failed: ${e}`)
+      console.error(`eagerCreateUserBank failed: ${e}`)
     }
   })
 }
 
 export default function sagas() {
-  return [watchStartPurchaseContentFlow, watchEnsureUserBankExists]
+  return [watchStartPurchaseContentFlow, watchEagerCreateUserBank]
 }

--- a/packages/common/src/store/purchase-content/slice.ts
+++ b/packages/common/src/store/purchase-content/slice.ts
@@ -110,7 +110,8 @@ const slice = createSlice({
     ) => {
       state.error = action.payload.error
     },
-    cleanup: () => initialState
+    cleanup: () => initialState,
+    ensureUserBankExists: (_state) => {}
   }
 })
 
@@ -122,7 +123,8 @@ export const {
   purchaseConfirmed,
   purchaseCanceled,
   purchaseContentFlowFailed,
-  cleanup
+  cleanup,
+  ensureUserBankExists
 } = slice.actions
 
 export default slice.reducer

--- a/packages/common/src/store/purchase-content/slice.ts
+++ b/packages/common/src/store/purchase-content/slice.ts
@@ -111,7 +111,7 @@ const slice = createSlice({
       state.error = action.payload.error
     },
     cleanup: () => initialState,
-    ensureUserBankExists: (_state) => {}
+    eagerCreateUserBank: (_state) => {}
   }
 })
 
@@ -124,7 +124,7 @@ export const {
   purchaseCanceled,
   purchaseContentFlowFailed,
   cleanup,
-  ensureUserBankExists
+  eagerCreateUserBank
 } = slice.actions
 
 export default slice.reducer

--- a/packages/mobile/src/components/premium-content-purchase-drawer/PremiumContentPurchaseDrawer.tsx
+++ b/packages/mobile/src/components/premium-content-purchase-drawer/PremiumContentPurchaseDrawer.tsx
@@ -81,7 +81,7 @@ import { usePurchaseSummaryValues } from './hooks/usePurchaseSummaryValues'
 
 const { getPurchaseContentFlowStage, getPurchaseContentError } =
   purchaseContentSelectors
-const { setPurchasePage } = purchaseContentActions
+const { setPurchasePage, ensureUserBankExists } = purchaseContentActions
 
 const messages = {
   buy: 'Buy',
@@ -256,6 +256,9 @@ const RenderForm = ({
   const { submitForm, resetForm } = useFormikContext()
 
   useEffect(() => resetForm, [contentId, resetForm])
+
+  // Pre-create user bank if needed so it's ready by purchase time
+  useEffect(() => dispatch(ensureUserBankExists()), [dispatch])
 
   const {
     usdc_purchase: { price }

--- a/packages/mobile/src/components/premium-content-purchase-drawer/PremiumContentPurchaseDrawer.tsx
+++ b/packages/mobile/src/components/premium-content-purchase-drawer/PremiumContentPurchaseDrawer.tsx
@@ -81,7 +81,7 @@ import { usePurchaseSummaryValues } from './hooks/usePurchaseSummaryValues'
 
 const { getPurchaseContentFlowStage, getPurchaseContentError } =
   purchaseContentSelectors
-const { setPurchasePage, ensureUserBankExists } = purchaseContentActions
+const { setPurchasePage, eagerCreateUserBank } = purchaseContentActions
 
 const messages = {
   buy: 'Buy',
@@ -258,7 +258,7 @@ const RenderForm = ({
   useEffect(() => resetForm, [contentId, resetForm])
 
   // Pre-create user bank if needed so it's ready by purchase time
-  useEffect(() => dispatch(ensureUserBankExists()), [dispatch])
+  useEffect(() => dispatch(eagerCreateUserBank()), [dispatch])
 
   const {
     usdc_purchase: { price }

--- a/packages/web/src/common/store/upload/sagaHelpers.ts
+++ b/packages/web/src/common/store/upload/sagaHelpers.ts
@@ -10,7 +10,7 @@ import {
 import { FeatureFlags } from '@audius/common/services'
 import {
   accountSelectors,
-  getUSDCUserBank,
+  getOrCreateUSDCUserBank,
   getContext,
   TrackForUpload
 } from '@audius/common/store'
@@ -101,7 +101,7 @@ export function* recordGatedTracks(tracks: (TrackForUpload | TrackMetadata)[]) {
 export function* getUSDCMetadata(stream_conditions: USDCPurchaseConditions) {
   const ownerAccount = yield* select(getAccountUser)
   const wallet = ownerAccount?.erc_wallet ?? ownerAccount?.wallet
-  const ownerUserbank = yield* call(getUSDCUserBank, wallet)
+  const ownerUserbank = yield* call(getOrCreateUSDCUserBank, wallet)
   const priceCents = stream_conditions.usdc_purchase.price
   const priceWei = new BN(priceCents).mul(BN_USDC_CENT_WEI).toNumber()
   const conditionsWithMetadata: USDCPurchaseConditions = {

--- a/packages/web/src/components/premium-content-purchase-modal/PremiumContentPurchaseModal.tsx
+++ b/packages/web/src/components/premium-content-purchase-modal/PremiumContentPurchaseModal.tsx
@@ -64,8 +64,7 @@ import { usePurchaseContentFormState } from './hooks/usePurchaseContentFormState
 
 const { startRecoveryIfNecessary, cleanup: cleanupUSDCRecovery } =
   buyUSDCActions
-const { cleanup, setPurchasePage, ensureUserBankExists } =
-  purchaseContentActions
+const { cleanup, setPurchasePage, eagerCreateUserBank } = purchaseContentActions
 const { getPurchaseContentFlowStage, getPurchaseContentError } =
   purchaseContentSelectors
 
@@ -257,8 +256,8 @@ export const PremiumContentPurchaseModal = () => {
   // On form mount, pre-create user bank if needed and check for any usdc stuck
   // in root wallet from an aborted withdrawal
   useEffect(() => {
-    dispatch(ensureUserBankExists)
-    dispatch(startRecoveryIfNecessary)
+    dispatch(eagerCreateUserBank())
+    dispatch(startRecoveryIfNecessary())
   }, [dispatch])
 
   const handleClose = useCallback(() => {

--- a/packages/web/src/components/premium-content-purchase-modal/PremiumContentPurchaseModal.tsx
+++ b/packages/web/src/components/premium-content-purchase-modal/PremiumContentPurchaseModal.tsx
@@ -64,7 +64,8 @@ import { usePurchaseContentFormState } from './hooks/usePurchaseContentFormState
 
 const { startRecoveryIfNecessary, cleanup: cleanupUSDCRecovery } =
   buyUSDCActions
-const { cleanup, setPurchasePage } = purchaseContentActions
+const { cleanup, setPurchasePage, ensureUserBankExists } =
+  purchaseContentActions
 const { getPurchaseContentFlowStage, getPurchaseContentError } =
   purchaseContentSelectors
 
@@ -253,8 +254,10 @@ export const PremiumContentPurchaseModal = () => {
         : PurchaseVendor.STRIPE
     })
 
-  // Attempt recovery once on re-mount of the form
+  // On form mount, pre-create user bank if needed and check for any usdc stuck
+  // in root wallet from an aborted withdrawal
   useEffect(() => {
+    dispatch(ensureUserBankExists)
     dispatch(startRecoveryIfNecessary)
   }, [dispatch])
 


### PR DESCRIPTION
### Description
We were seeing a number of failures in fetching token accounts due to the fact that we "getOrCreate" it and then immediately attempt to read the account info.
This PR fixes that. Plus a little more.

* Updated `getUSDCUserBank` to be `getOrCreateUSDCUserBank`.
* Added concurrency protection around the above saga function so that only the first entrance will kick off the async logic to create the user bank first time. Other sagas will listen for the channel event and use the result instead.
* Added a helper function for polling the token account, so we're less likely to fail in scenarios where the transaction to create the account hasn't quite finalized and it doesn't exist on whatever RPC we're talking to
* Updated the handful of sagas which use the create->immediate get pattern to use the polling function instead.
* Updated the modal/drawer for purchases to kick off a quick call to `getOrCreateUSDCUserBank` upon mount so that we jump start the process and the user doesn't wait as long at the end of the purchase flow.


### How Has This Been Tested?
Tested on local client against stage by creating new accounts and then going into the purchase flow and using pay with anything.
