### PR TITLE
Remove scheduled release timezone on access-type-labels

### DIFF
--- a/packages/mobile/src/components/core/AccessTypeLabel.tsx
+++ b/packages/mobile/src/components/core/AccessTypeLabel.tsx
@@ -1,6 +1,5 @@
 import { AccessType } from '@audius/common/models'
 import { formatReleaseDate } from '@audius/common/utils'
-import { getLocalTimezone } from 'utils/dateUtils'
 
 import type { IconColors, IconComponent } from '@audius/harmony-native'
 import {
@@ -27,10 +26,7 @@ type AccessTypeConfig = {
 }
 
 const formatScheduledDate = (date: string) =>
-  `Releases ${formatReleaseDate({
-    date,
-    withHour: true
-  })} ${getLocalTimezone()}`
+  `Releases ${formatReleaseDate({ date, withHour: true })}`
 
 const ACCESS_TYPE_CONFIG: Record<AccessType, AccessTypeConfig> = {
   [AccessType.SCHEDULED_RELEASE]: {

--- a/packages/web/src/components/access-type-label/AccessTypeLabel.tsx
+++ b/packages/web/src/components/access-type-label/AccessTypeLabel.tsx
@@ -12,8 +12,6 @@ import {
   Text
 } from '@audius/harmony'
 
-import { getLocalTimezone } from 'utils/dateUtils'
-
 type AccessTypeLabelProps = {
   type?: AccessType
   scheduledReleaseDate?: string
@@ -27,10 +25,7 @@ type AccessTypeConfig = {
 }
 
 const formatScheduledDate = (date: string) =>
-  `Releases ${formatReleaseDate({
-    date,
-    withHour: true
-  })} ${getLocalTimezone()}`
+  `Releases ${formatReleaseDate({ date, withHour: true })}`
 
 const ACCESS_TYPE_CONFIG: Record<AccessType, AccessTypeConfig> = {
   [AccessType.SCHEDULED_RELEASE]: {


### PR DESCRIPTION
### Description

Small fix to remove the timezone section for access-type-labels