### PR TITLE
[C-5333, C-5334] Fix animated button perf; fix useFeatureFlag perf

### DIFF
--- a/packages/common/src/hooks/helpers.ts
+++ b/packages/common/src/hooks/helpers.ts
@@ -1,7 +1,7 @@
 import { useSelector } from 'react-redux'
 
-import { getAccountUser } from '~/store/account/selectors'
+import { getHasAccount } from '~/store/account/selectors'
 import { isRemoteConfigLoaded } from '~/store/remote-config/selectors'
 
-export const useHasAccount = () => !!useSelector(getAccountUser)
+export const useHasAccount = () => useSelector(getHasAccount)
 export const useHasConfigLoaded = () => !!useSelector(isRemoteConfigLoaded)

--- a/packages/common/src/hooks/useGatedContent.ts
+++ b/packages/common/src/hooks/useGatedContent.ts
@@ -15,7 +15,7 @@ import {
   isContentTipGated,
   isContentUSDCPurchaseGated
 } from '~/models/Track'
-import { getAccountUser } from '~/store/account/selectors'
+import { getHasAccount } from '~/store/account/selectors'
 import { cacheTracksSelectors, cacheUsersSelectors } from '~/store/cache'
 import { gatedContentSelectors } from '~/store/gated-content'
 import { CommonState } from '~/store/reducers'
@@ -31,7 +31,7 @@ export const useGatedContentAccess = (
   content: Nullable<Partial<Track | Collection>>
 ) => {
   const nftAccessSignatureMap = useSelector(getNftAccessSignatureMap)
-  const user = useSelector(getAccountUser)
+  const hasAccount = useSelector(getHasAccount)
 
   const { isFetchingNFTAccess, hasStreamAccess, hasDownloadAccess } =
     useMemo(() => {
@@ -66,14 +66,14 @@ export const useGatedContentAccess = (
         // if nft gated track, the signature would have been fetched separately
         nftAccessSignatureMap[trackId] === undefined &&
         // signature is fetched only if the user is logged in
-        !!user
+        hasAccount
 
       return {
         isFetchingNFTAccess: !hasNftAccessSignature && isSignatureToBeFetched,
         hasStreamAccess: !isStreamGated || !!stream,
         hasDownloadAccess: !isDownloadGated || !!download
       }
-    }, [content, nftAccessSignatureMap, user])
+    }, [content, nftAccessSignatureMap, hasAccount])
 
   return { isFetchingNFTAccess, hasStreamAccess, hasDownloadAccess }
 }
@@ -83,7 +83,7 @@ export const useGatedContentAccess = (
 // {[id: ID]: { isFetchingNFTAccess: boolean, hasStreamAccess: boolean }}
 export const useGatedContentAccessMap = (tracks: Partial<Track>[]) => {
   const nftAccessSignatureMap = useSelector(getNftAccessSignatureMap)
-  const user = useSelector(getAccountUser)
+  const hasAccount = useSelector(getHasAccount)
 
   const result = useMemo(() => {
     const map: {
@@ -105,7 +105,7 @@ export const useGatedContentAccessMap = (tracks: Partial<Track>[]) => {
         // if nft gated track, the signature would have been fetched separately
         nftAccessSignatureMap[trackId] === undefined &&
         // signature is fetched only if the user is logged in
-        !!user
+        hasAccount
 
       map[trackId] = {
         isFetchingNFTAccess: !hasNftAccessSignature && isSignatureToBeFetched,
@@ -114,7 +114,7 @@ export const useGatedContentAccessMap = (tracks: Partial<Track>[]) => {
     })
 
     return map
-  }, [tracks, nftAccessSignatureMap, user])
+  }, [tracks, nftAccessSignatureMap, hasAccount])
 
   return result
 }

--- a/packages/mobile/src/components/core/AnimatedButton.tsx
+++ b/packages/mobile/src/components/core/AnimatedButton.tsx
@@ -50,7 +50,7 @@ export const AnimatedButton = ({
   wrapperStyle,
   haptics,
   hapticsConfig,
-  waitForAnimationFinish,
+  waitForAnimationFinish = true,
   children,
   lottieProps,
   ...pressableProps
@@ -118,8 +118,8 @@ export const AnimatedButton = ({
     handleHaptics()
 
     if (hasMultipleStates || !isActive) {
-      setIsPlaying(true)
       animationRef.current?.play()
+      setIsPlaying(true)
     }
     if (!waitForAnimationFinish) {
       onPress?.()
@@ -148,8 +148,8 @@ export const AnimatedButton = ({
   useEffect(() => {
     if (hasMultipleStates) {
       if (isActive !== previousActiveState && !isPlaying) {
-        setIsPlaying(true)
         animationRef.current?.play()
+        setIsPlaying(true)
       }
     }
   }, [

--- a/packages/mobile/src/hooks/useRemoteConfig.ts
+++ b/packages/mobile/src/hooks/useRemoteConfig.ts
@@ -8,11 +8,11 @@ import { useSelector } from 'react-redux'
 
 import { remoteConfigInstance } from 'app/services/remote-config/remote-config-instance'
 const { isRemoteConfigLoaded } = remoteConfigSelectors
-const { getAccountUser } = accountSelectors
+const { getHasAccount } = accountSelectors
 
 export const useFeatureFlag = createUseFeatureFlagHook({
   remoteConfigInstance,
-  useHasAccount: () => !!useSelector(getAccountUser),
+  useHasAccount: () => useSelector(getHasAccount),
   useHasConfigLoaded: () => !!useSelector(isRemoteConfigLoaded),
   setLocalStorageItem: AsyncStorage.setItem,
   getLocalStorageItem: AsyncStorage.getItem
@@ -20,6 +20,6 @@ export const useFeatureFlag = createUseFeatureFlagHook({
 
 export const useRemoteVar = createUseRemoteVarHook({
   remoteConfigInstance,
-  useHasAccount: () => !!useSelector(getAccountUser),
+  useHasAccount: () => useSelector(getHasAccount),
   useHasConfigLoaded: () => !!useSelector(isRemoteConfigLoaded)
 })


### PR DESCRIPTION
### Description

- Fix issue where `useFeatureFlag` hook was rerendering every time `user` changed
	- This was causing every track tile on feed to rerender on favorite
- Changed default to wait for `AnimationButton` to finish animating before calling the `onPress` callback
	- This makes Favorite, Repost, Play, Repeat, Repost, Shuffle buttons all feel SNAPPY AF

### How Has This Been Tested?

https://github.com/user-attachments/assets/8b3a8c10-8582-4b72-8e74-86ead925f00b

