### PR TITLE
Add undefined check for managers before mapping

### DIFF
--- a/packages/web/src/pages/settings-page/components/desktop/ManagerMode/FindAccountManagerPage.tsx
+++ b/packages/web/src/pages/settings-page/components/desktop/ManagerMode/FindAccountManagerPage.tsx
@@ -30,7 +30,7 @@ export const FindAccountManagerPage = (props: FindAccountManagerPageProps) => {
     { disabled: userId == null }
   )
   const excludedUserIds = useMemo(() => {
-    const res: number[] = managers.map((m) => m.manager.user_id)
+    const res: number[] = managers?.map((m) => m.manager.user_id) ?? []
     if (userId) {
       res.push(userId)
     }


### PR DESCRIPTION
### Description

Audius query state is an empty object prior to the fetch completing, so the managers list key is undefined until the request completes as well.