### PR TITLE
Fix mobile profile header sticky

### DIFF
--- a/packages/mobile/src/components/top-tab-bar/CollapsibleTopTabNavigator.tsx
+++ b/packages/mobile/src/components/top-tab-bar/CollapsibleTopTabNavigator.tsx
@@ -59,6 +59,10 @@ const tabBar = (props: MaterialTopTabBarProps) => <TopTabBar {...props} />
 
 type CollapsibleTabNavigatorProps = {
   /**
+   * Function that renders the collapsible header
+   */
+  renderHeader: () => ReactNode
+  /**
    * Animated value to capture scrolling. If unset, an
    * animated value is created.
    */
@@ -71,6 +75,7 @@ type CollapsibleTabNavigatorProps = {
 }
 
 export const CollapsibleTabNavigator = ({
+  renderHeader,
   animatedValue,
   initialScreenName,
   children,
@@ -78,8 +83,8 @@ export const CollapsibleTabNavigator = ({
   headerHeight
 }: CollapsibleTabNavigatorProps) => {
   const collapsibleOptions = useMemo(
-    () => ({ disableSnap: true, animatedValue, headerHeight }),
-    [animatedValue, headerHeight]
+    () => ({ renderHeader, disableSnap: true, animatedValue, headerHeight }),
+    [animatedValue, headerHeight, renderHeader]
   )
 
   return (

--- a/packages/mobile/src/screens/profile-screen/ProfileHeader/ProfileHeader.tsx
+++ b/packages/mobile/src/screens/profile-screen/ProfileHeader/ProfileHeader.tsx
@@ -11,8 +11,6 @@ import { useToggle } from 'react-use'
 import { Box, Divider, Flex, useTheme } from '@audius/harmony-native'
 import { ProfilePicture } from 'app/components/core'
 import { ScreenContext } from 'app/components/core/Screen/ScreenContextProvider'
-import { ScreenPrimaryContent } from 'app/components/core/Screen/ScreenPrimaryContent'
-import { ScreenSecondaryContent } from 'app/components/core/Screen/ScreenSecondaryContent'
 import { OnlineOnly } from 'app/components/offline-placeholder/OnlineOnly'
 import { zIndex } from 'app/utils/zIndex'
 
@@ -20,10 +18,6 @@ import { ArtistRecommendations } from '../ArtistRecommendations'
 import { ProfileCoverPhoto } from '../ProfileCoverPhoto'
 import { ProfileInfo } from '../ProfileInfo'
 import { ProfileMetrics } from '../ProfileMetrics'
-import {
-  ExpandableSectionSkeleton,
-  ProfileScreenSkeleton
-} from '../ProfileScreenSkeleton'
 import { TipAudioButton } from '../TipAudioButton'
 import { UploadTrackButton } from '../UploadTrackButton'
 import { useSelectProfile } from '../selectors'
@@ -123,56 +117,52 @@ export const ProfileHeader = memo((props: ProfileHeaderProps) => {
 
   return (
     <>
-      <ScreenPrimaryContent skeleton={<ProfileScreenSkeleton />}>
-        <ProfileCoverPhoto scrollY={scrollY} />
-        <Box
-          style={css({
-            position: 'absolute',
-            top: spacing.unit13,
-            left: spacing.unit3,
-            zIndex: zIndex.PROFILE_PAGE_PROFILE_PICTURE
-          })}
-          pointerEvents='none'
-        >
-          <ProfilePicture userId={userId} size='xl' />
-        </Box>
-        <Flex
-          column
-          pointerEvents='box-none'
-          backgroundColor='white'
-          pv='s'
-          ph='m'
-          gap='s'
-          borderBottom='default'
-        >
-          <ProfileInfo onFollow={handleFollow} />
-          <OnlineOnly>
-            <ProfileMetrics />
-            <ScreenSecondaryContent skeleton={<ExpandableSectionSkeleton />}>
-              {isExpanded ? (
-                <ExpandedSection />
-              ) : (
-                <CollapsedSection
-                  isExpandable={isExpandable}
-                  setIsExpandable={setIsExpandable}
-                />
-              )}
-              {isExpandable ? (
-                <ExpandHeaderToggleButton
-                  isExpanded={isExpanded}
-                  onPress={handleToggleExpand}
-                />
-              ) : null}
-              <Divider mh={-12} />
-              {!hasUserFollowed ? null : (
-                <ArtistRecommendations onClose={handleCloseArtistRecs} />
-              )}
-              {isOwner ? <UploadTrackButton /> : <TipAudioButton />}
-              <TopSupporters />
-            </ScreenSecondaryContent>
-          </OnlineOnly>
-        </Flex>
-      </ScreenPrimaryContent>
+      <ProfileCoverPhoto scrollY={scrollY} />
+      <Box
+        style={css({
+          position: 'absolute',
+          top: spacing.unit13,
+          left: spacing.unit3,
+          zIndex: zIndex.PROFILE_PAGE_PROFILE_PICTURE
+        })}
+        pointerEvents='none'
+      >
+        <ProfilePicture userId={userId} size='xl' />
+      </Box>
+      <Flex
+        column
+        pointerEvents='box-none'
+        backgroundColor='white'
+        pv='s'
+        ph='m'
+        gap='s'
+        borderBottom='default'
+      >
+        <ProfileInfo onFollow={handleFollow} />
+        <OnlineOnly>
+          <ProfileMetrics />
+          {isExpanded ? (
+            <ExpandedSection />
+          ) : (
+            <CollapsedSection
+              isExpandable={isExpandable}
+              setIsExpandable={setIsExpandable}
+            />
+          )}
+          {isExpandable ? (
+            <ExpandHeaderToggleButton
+              isExpanded={isExpanded}
+              onPress={handleToggleExpand}
+            />
+          ) : null}
+          <Divider mh={-12} />
+          {!hasUserFollowed ? null : (
+            <ArtistRecommendations onClose={handleCloseArtistRecs} />
+          )}
+          {isOwner ? <UploadTrackButton /> : <TipAudioButton />}
+          <TopSupporters />
+        </OnlineOnly>
+      </Flex>
     </>
   )
 })

--- a/packages/mobile/src/screens/profile-screen/ProfileScreen.tsx
+++ b/packages/mobile/src/screens/profile-screen/ProfileScreen.tsx
@@ -23,6 +23,7 @@ import {
   IconShare
 } from '@audius/harmony-native'
 import { Screen, ScreenContent } from 'app/components/core'
+import { ScreenPrimaryContent } from 'app/components/core/Screen/ScreenPrimaryContent'
 import { ScreenSecondaryContent } from 'app/components/core/Screen/ScreenSecondaryContent'
 import { useIsScreenReady } from 'app/components/core/Screen/hooks/useIsScreenReady'
 import { OfflinePlaceholder } from 'app/components/offline-placeholder'
@@ -30,10 +31,7 @@ import { useRoute } from 'app/hooks/useRoute'
 import { makeStyles } from 'app/styles'
 
 import { ProfileHeader } from './ProfileHeader'
-import {
-  ProfileScreenSkeleton,
-  ProfileTabsSkeleton
-} from './ProfileScreenSkeleton'
+import { ProfileScreenSkeleton } from './ProfileScreenSkeleton'
 import { ProfileTabNavigator } from './ProfileTabs/ProfileTabNavigator'
 import { getIsOwner, useSelectProfileRoot } from './selectors'
 const { requestOpen: requestOpenShareModal } = shareModalUIActions
@@ -202,21 +200,20 @@ export const ProfileScreen = () => {
             <View style={styles.navigator}>
               {isNotReachable ? (
                 <>
-                  {renderHeader()}
                   <OfflinePlaceholder />
                 </>
               ) : (
-                <>
+                <ScreenPrimaryContent skeleton={<ProfileScreenSkeleton />}>
                   <PortalHost name='PullToRefreshPortalHost' />
-                  {renderHeader()}
-                  <ScreenSecondaryContent skeleton={<ProfileTabsSkeleton />}>
+                  <ScreenSecondaryContent skeleton={<ProfileScreenSkeleton />}>
                     <ProfileTabNavigator
+                      renderHeader={renderHeader}
                       animatedValue={scrollY}
                       refreshing={isRefreshing}
                       onRefresh={handleRefresh}
                     />
                   </ScreenSecondaryContent>
-                </>
+                </ScreenPrimaryContent>
               )}
             </View>
           </>

--- a/packages/mobile/src/screens/profile-screen/ProfileScreenSkeleton.tsx
+++ b/packages/mobile/src/screens/profile-screen/ProfileScreenSkeleton.tsx
@@ -1,5 +1,3 @@
-import { memo } from 'react'
-
 import { times, random } from 'lodash'
 import { View } from 'react-native'
 
@@ -109,7 +107,7 @@ const useStyles = makeStyles(({ palette, spacing }) => ({
   }
 }))
 
-const BioSkeleton = memo(() => {
+const BioSkeleton = () => {
   const baseStyle = {
     height: 12,
     marginRight: 4,
@@ -127,9 +125,9 @@ const BioSkeleton = memo(() => {
       ))}
     </>
   )
-})
+}
 
-export const ExpandableSectionSkeleton = memo(() => {
+export const ExpandableSectionSkeleton = () => {
   const styles = useStyles()
   return (
     <Flex column gap='s'>
@@ -147,9 +145,9 @@ export const ExpandableSectionSkeleton = memo(() => {
       {/* TODO: add tip button and supporters skeletons */}
     </Flex>
   )
-})
+}
 
-export const ProfileHeaderSkeleton = memo(() => {
+export const ProfileHeaderSkeleton = () => {
   const styles = useStyles()
   const statSkeleton = <Skeleton style={styles.stat} />
 
@@ -176,9 +174,9 @@ export const ProfileHeaderSkeleton = memo(() => {
       </Flex>
     </Flex>
   )
-})
+}
 
-export const ProfileTabsSkeleton = memo(() => {
+export const ProfileTabsSkeleton = () => {
   const styles = useStyles()
 
   const lineupTile = (
@@ -195,9 +193,9 @@ export const ProfileTabsSkeleton = memo(() => {
       {lineupTile}
     </>
   )
-})
+}
 
-export const ProfileScreenSkeleton = memo(() => {
+export const ProfileScreenSkeleton = () => {
   return (
     <Flex column h='100%'>
       <ProfileHeaderSkeleton />
@@ -205,4 +203,4 @@ export const ProfileScreenSkeleton = memo(() => {
       <ProfileTabsSkeleton />
     </Flex>
   )
-})
+}

--- a/packages/mobile/src/screens/profile-screen/ProfileTabs/ProfileTabNavigator.tsx
+++ b/packages/mobile/src/screens/profile-screen/ProfileTabs/ProfileTabNavigator.tsx
@@ -22,11 +22,16 @@ import { CollectiblesTab } from './CollectiblesTab'
 import { PlaylistsTab } from './PlaylistsTab'
 import { RepostsTab } from './RepostsTab'
 import { TracksTab } from './TracksTab'
+import { ReactNode } from 'react'
 
 // Height of a typical profile header
 const INITIAL_PROFILE_HEADER_HEIGHT = 1081
 
 type ProfileTabNavigatorProps = {
+  /**
+   * Function that renders the collapsible header
+   */
+  renderHeader: () => ReactNode
   /**
    * Animated value to capture scrolling. If unset, an
    * animated value is created.
@@ -38,6 +43,7 @@ type ProfileTabNavigatorProps = {
 }
 
 export const ProfileTabNavigator = ({
+  renderHeader,
   animatedValue,
   refreshing,
   onRefresh
@@ -103,6 +109,7 @@ export const ProfileTabNavigator = ({
   if (isArtist) {
     return (
       <CollapsibleTabNavigator
+        renderHeader={renderHeader}
         animatedValue={animatedValue}
         headerHeight={INITIAL_PROFILE_HEADER_HEIGHT}
       >
@@ -117,6 +124,7 @@ export const ProfileTabNavigator = ({
 
   return (
     <CollapsibleTabNavigator
+      renderHeader={renderHeader}
       animatedValue={animatedValue}
       headerHeight={INITIAL_PROFILE_HEADER_HEIGHT}
     >


### PR DESCRIPTION
### Description
- Undo the change that pulls out the profile screen header and renders it outside the navigator. This results in the entire profile header screen being sticky as we scroll down the profile screen, which is not what we want.
- Also remove memos from profile screen skeletons (not needed)

### How Has This Been Tested?

Tested on ios stage