### PR TITLE
[C-5378] Fade in mobile screen content on load

### DIFF
--- a/packages/mobile/src/components/core/Screen/ScreenPrimaryContent.tsx
+++ b/packages/mobile/src/components/core/Screen/ScreenPrimaryContent.tsx
@@ -26,6 +26,8 @@ export const ScreenPrimaryContent = (props: ScreenPrimaryContentProps) => {
     setIsPrimaryContentReady(true)
   }, [isScreenReady, setIsPrimaryContentReady])
 
+  // Note: not animating on Android because shadows are rendered natively behind the
+  // animated view and thus don't follow the animation.
   return isScreenReady ? (
     <Animated.View entering={Platform.OS === 'ios' ? FadeIn : undefined}>
       {children}

--- a/packages/mobile/src/components/core/Screen/ScreenPrimaryContent.tsx
+++ b/packages/mobile/src/components/core/Screen/ScreenPrimaryContent.tsx
@@ -1,5 +1,6 @@
 import { useEffect, type ReactNode } from 'react'
 
+import { Platform } from 'react-native'
 import Animated, { FadeIn } from 'react-native-reanimated'
 
 import { useScreenContext } from './ScreenContextProvider'
@@ -26,7 +27,9 @@ export const ScreenPrimaryContent = (props: ScreenPrimaryContentProps) => {
   }, [isScreenReady, setIsPrimaryContentReady])
 
   return isScreenReady ? (
-    <Animated.View entering={FadeIn}>{children}</Animated.View>
+    <Animated.View entering={Platform.OS === 'ios' ? FadeIn : undefined}>
+      {children}
+    </Animated.View>
   ) : (
     <>{skeleton ?? null}</>
   )

--- a/packages/mobile/src/components/core/Screen/ScreenPrimaryContent.tsx
+++ b/packages/mobile/src/components/core/Screen/ScreenPrimaryContent.tsx
@@ -1,5 +1,7 @@
 import { useEffect, type ReactNode } from 'react'
 
+import Animated, { FadeIn } from 'react-native-reanimated'
+
 import { useScreenContext } from './ScreenContextProvider'
 
 type ScreenPrimaryContentProps = {
@@ -23,5 +25,9 @@ export const ScreenPrimaryContent = (props: ScreenPrimaryContentProps) => {
     setIsPrimaryContentReady(true)
   }, [isScreenReady, setIsPrimaryContentReady])
 
-  return isScreenReady ? <>{children}</> : <>{skeleton ?? null}</>
+  return isScreenReady ? (
+    <Animated.View entering={FadeIn}>{children}</Animated.View>
+  ) : (
+    <>{skeleton ?? null}</>
+  )
 }

--- a/packages/mobile/src/components/core/Screen/ScreenSecondaryContent.tsx
+++ b/packages/mobile/src/components/core/Screen/ScreenSecondaryContent.tsx
@@ -1,5 +1,6 @@
 import type { ReactNode } from 'react'
 
+import { Platform } from 'react-native'
 import Animated, { FadeIn } from 'react-native-reanimated'
 
 import { useScreenContext } from './ScreenContextProvider'
@@ -21,7 +22,10 @@ export const ScreenSecondaryContent = (props: ScreenSecondaryContentProps) => {
   const { isPrimaryContentReady } = useScreenContext()
 
   return isPrimaryContentReady ? (
-    <Animated.View entering={FadeIn} style={{ flex: 1 }}>
+    <Animated.View
+      entering={Platform.OS === 'ios' ? FadeIn : undefined}
+      style={{ flex: 1 }}
+    >
       {children}
     </Animated.View>
   ) : (

--- a/packages/mobile/src/components/core/Screen/ScreenSecondaryContent.tsx
+++ b/packages/mobile/src/components/core/Screen/ScreenSecondaryContent.tsx
@@ -1,5 +1,7 @@
 import type { ReactNode } from 'react'
 
+import Animated, { FadeIn } from 'react-native-reanimated'
+
 import { useScreenContext } from './ScreenContextProvider'
 
 type ScreenSecondaryContentProps = {
@@ -18,5 +20,11 @@ export const ScreenSecondaryContent = (props: ScreenSecondaryContentProps) => {
   const { children, skeleton } = props
   const { isPrimaryContentReady } = useScreenContext()
 
-  return <>{isPrimaryContentReady ? children : skeleton ?? null}</>
+  return isPrimaryContentReady ? (
+    <Animated.View entering={FadeIn} style={{ flex: 1 }}>
+      {children}
+    </Animated.View>
+  ) : (
+    <>{skeleton ?? null}</>
+  )
 }

--- a/packages/mobile/src/components/core/Screen/ScreenSecondaryContent.tsx
+++ b/packages/mobile/src/components/core/Screen/ScreenSecondaryContent.tsx
@@ -21,6 +21,8 @@ export const ScreenSecondaryContent = (props: ScreenSecondaryContentProps) => {
   const { children, skeleton } = props
   const { isPrimaryContentReady } = useScreenContext()
 
+  // Note: not animating on Android because shadows are rendered natively behind the
+  // animated view and thus don't follow the animation.
   return isPrimaryContentReady ? (
     <Animated.View
       entering={Platform.OS === 'ios' ? FadeIn : undefined}


### PR DESCRIPTION
### Description
mostly authored by @amendelsohn 

Fade in animations for screen content as content loads in.

Do not use the animations on android because the shadows are rendered natively and appear behind the `Animated.View` before the animation begins. It looks bad. They work great on ios though.

We need `flex: 1` on the secondary content so that it grows to fit the parent container.

### How Has This Been Tested?

Tested on ios sim and android device