### PR TITLE
[PAY-3544] Fix flashing empty state on mobile chat screen

### DIFF
--- a/packages/common/src/store/pages/chat/slice.ts
+++ b/packages/common/src/store/pages/chat/slice.ts
@@ -28,7 +28,7 @@ import { ChatWebsocketError } from './types'
 export type Chat = UserChat | ChatBlast
 
 export type UserChatWithMessagesStatus = Chat & {
-  messagesStatus?: Status
+  messagesStatus?: Status | 'PENDING'
   messagesSummary?: TypedCommsResponse<ChatMessage>['summary']
 }
 
@@ -404,7 +404,7 @@ const slice = createSlice({
       }
       const existingChat = getChat(state, chat.chat_id)
       // If the chat already exists, use its existing messagesStatus, otherwise default to IDLE
-      const messagesStatus = existingChat?.messagesStatus ?? Status.IDLE
+      const messagesStatus = existingChat?.messagesStatus ?? 'PENDING'
       chatsAdapter.upsertOne(state.chats, {
         ...chat,
         messagesStatus

--- a/packages/common/src/store/pages/chat/slice.ts
+++ b/packages/common/src/store/pages/chat/slice.ts
@@ -403,7 +403,7 @@ const slice = createSlice({
         chat.last_message = ''
       }
       const existingChat = getChat(state, chat.chat_id)
-      // If the chat already exists, use its existing messagesStatus, otherwise default to IDLE
+      // If the chat already exists, use its existing messagesStatus, otherwise default to PENDING
       const messagesStatus = existingChat?.messagesStatus ?? 'PENDING'
       chatsAdapter.upsertOne(state.chats, {
         ...chat,

--- a/packages/common/src/utils/chatUtils.ts
+++ b/packages/common/src/utils/chatUtils.ts
@@ -90,7 +90,7 @@ export const isEarliestUnread = ({
  * there are previous messages to fetch
  */
 export const chatCanFetchMoreMessages = (
-  messagesStatus?: Status,
+  messagesStatus?: Status | 'PENDING',
   prevCount?: number
 ) => {
   return !!messagesStatus && messagesStatus !== Status.LOADING && !!prevCount

--- a/packages/mobile/src/screens/chat-screen/ChatScreen.tsx
+++ b/packages/mobile/src/screens/chat-screen/ChatScreen.tsx
@@ -257,9 +257,7 @@ export const ChatScreen = () => {
   const chatMessages = useSelector((state) =>
     getChatMessages(state, chatId ?? '')
   )
-  const isLoading =
-    (chat?.messagesStatus ?? Status.LOADING) === Status.LOADING &&
-    chatMessages?.length === 0
+  const isLoading = (chat?.messagesStatus ?? 'PENDING') === 'PENDING'
   // Only show the end reached indicator if there are no previous messages, more than 10 messages,
   // and the flatlist is scrollable.
   const shouldShowEndReachedIndicator =

--- a/packages/web/src/pages/chat-page/components/ChatMessageList.tsx
+++ b/packages/web/src/pages/chat-page/components/ChatMessageList.tsx
@@ -187,6 +187,7 @@ export const ChatMessageList = forwardRef<HTMLDivElement, ChatMessageListProps>(
       if (
         chatId &&
         (chat?.messagesStatus === Status.IDLE ||
+          chat?.messagesStatus === 'PENDING' ||
           chat?.messagesStatus === undefined)
       ) {
         // Initial fetch


### PR DESCRIPTION
### Description
Bug: the fix from [this PR](https://github.com/AudiusProject/audius-protocol/pull/10025) in `packages/common/src/store/pages/chat/slice.ts` was breaking an assumption on mobile ChatScreen: that the loading state is only true when `messagesStatus === 'IDLE'`. After that PR, the first time loading a chat `messagesStatus` would be initialized to `IDLE` but the messages fetch was in progress. Previously it was initialized to `undefined` which would coalesce to `LOADING` [on this line](https://github.com/AudiusProject/audius-protocol/blob/ed5b59abdfba4e079211fdc8927f4d9a57dc4c44/packages/mobile/src/screens/chat-screen/ChatScreen.tsx#L260).

Solution was to add a new status: `PENDING` that's for the first time loading a chat. This draws inspiration from [tanstack](https://tanstack.com/query/v5/docs/framework/react/guides/queries).

### How Has This Been Tested?

Tested both loading unfetched chats and creating new chats on ios sim and web