### PR TITLE
Add make targets to force release core image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -94,6 +94,7 @@ clean:
 install-deps:
 	@go install github.com/onsi/ginkgo/v2/ginkgo@v2.19.0
 	@brew install protobuf
+	@brew install crane
 	@go install github.com/sqlc-dev/sqlc/cmd/sqlc@latest
 	@go install google.golang.org/protobuf/cmd/protoc-gen-go@latest
 	@go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@latest
@@ -169,6 +170,16 @@ bin/core: $(BUILD_SRCS)
 core-build-amd64: bin/core-amd64
 bin/core-amd64: $(BUILD_SRCS)
 	@GOOS=linux GOARCH=amd64 go build -ldflags "$(VERSION_LDFLAG)" -o bin/core-amd64 ./cmd/core/main.go
+
+.PHONY: core-force-release-stage core-force-release-foundation core-force-release-sps
+core-force-release-stage:
+	@bash scripts/release-core.sh $@
+
+core-force-release-foundation:
+	@bash scripts/release-core.sh $@
+
+core-force-release-sps:
+	@bash scripts/release-core.sh $@
 
 .PHONY: core-dev
 core-dev: gen

--- a/scripts/release-core.sh
+++ b/scripts/release-core.sh
@@ -1,0 +1,32 @@
+# This script should be run from the Makefile only.
+make_target="$1"
+
+if [ -n "$(git status -s)" ]; then 
+    echo "You have uncommitted changes. Commit them first before releasing a docker image."
+    exit 1
+fi
+
+if ! which -s crane; then
+    echo "No crane installation found. Run 'make install-deps' and try again."
+    exit 1
+fi
+
+case "$make_target" in
+    core-force-release-stage)
+        img_tag=prerelease
+        ;;
+    core-force-release-foundation)
+        img_tag=edge
+        ;;
+    core-force-release-sps)
+        img_tag=current
+        ;;
+    *)
+        exit 1
+        ;;
+esac
+
+CURRENT_SHA=$(git rev-parse HEAD)
+
+DOCKER_DEFAULT_PLATFORM=linux/amd64 audius-compose push --prod "core"
+crane copy "audius/core:${CURRENT_SHA}" "audius/core:${img_tag}"


### PR DESCRIPTION
### Description

Useful for faster dev cycles, and since core is not currently vital infra.

### How Has This Been Tested?

shellcheck + dry run, although the image has not been built and published.
