### PR TITLE
[QA-1753] Fix Suggested Artists Popup lag

### DIFF
--- a/packages/web/src/components/artist-recommendations/ArtistRecommendations.tsx
+++ b/packages/web/src/components/artist-recommendations/ArtistRecommendations.tsx
@@ -141,7 +141,7 @@ export const ArtistRecommendations = forwardRef<
 
   const [idsToFollow, setIdsToFollow] = useState<ID[] | null>(null)
   const artistsToFollow = useSelector<CommonState, User[]>((state) =>
-    Object.values(getUsers(state, { ids: idsToFollow }))
+    Object.values(getUsers(state, { ids: idsToFollow ?? [] }))
   )
 
   // Start fetching the related artists
@@ -236,7 +236,7 @@ export const ArtistRecommendations = forwardRef<
                 closeParent={onClose}
               />
             ))
-            .reduce((prev, curr) => [prev, ', ', curr])}
+            .reduce((prev, curr) => [prev, ', ', curr], '')}
           {artistsToFollow.length > 3
             ? `, and ${artistsToFollow.length - 3} others.`
             : ''}


### PR DESCRIPTION
### Description
The first render of the recommendations had the idsToFollow as null which, when passed to the selector, would fetch and then get the profile pictures for every single user in the cache. Not very cash money

Falling back to an empty array fixes this

### How Has This Been Tested?
Manually Tested
