### PR TITLE
SDK adds signature query param to uploads

### DIFF
--- a/packages/sdk/src/sdk/api/playlists/PlaylistsApi.ts
+++ b/packages/sdk/src/sdk/api/playlists/PlaylistsApi.ts
@@ -80,7 +80,8 @@ export class PlaylistsApi extends GeneratedPlaylistsApi {
           await this.storage.uploadFile({
             file: coverArtFile,
             onProgress,
-            template: 'img_square'
+            template: 'img_square',
+            auth: this.auth
           }),
         (e) => {
           this.logger.info('Retrying uploadPlaylistCoverArt', e)
@@ -461,7 +462,8 @@ export class PlaylistsApi extends GeneratedPlaylistsApi {
           await this.storage.uploadFile({
             file: coverArtFile,
             onProgress,
-            template: 'img_square'
+            template: 'img_square',
+            auth: this.auth
           }),
         (e) => {
           this.logger.info('Retrying uploadPlaylistCoverArt', e)
@@ -477,7 +479,8 @@ export class PlaylistsApi extends GeneratedPlaylistsApi {
                 template: 'audio',
                 options: this.trackUploadHelper.extractMediorumUploadOptions(
                   trackMetadatas[idx]!
-                )
+                ),
+                auth: this.auth
               }),
             (e) => {
               this.logger.info('Retrying uploadTrackAudio', e)
@@ -591,7 +594,8 @@ export class PlaylistsApi extends GeneratedPlaylistsApi {
           await this.storage.uploadFile({
             file: coverArtFile,
             onProgress,
-            template: 'img_square'
+            template: 'img_square',
+            auth: this.auth
           }),
         (e) => {
           this.logger.info('Retrying uploadPlaylistCoverArt', e)

--- a/packages/sdk/src/sdk/api/tracks/TracksApi.ts
+++ b/packages/sdk/src/sdk/api/tracks/TracksApi.ts
@@ -128,7 +128,8 @@ export class TracksApi extends GeneratedTracksApi {
           await this.storage.uploadFile({
             file: coverArtFile,
             onProgress,
-            template: 'img_square'
+            template: 'img_square',
+            auth: this.auth
           }),
         (e) => {
           this.logger.info('Retrying uploadTrackCoverArt', e)
@@ -141,7 +142,8 @@ export class TracksApi extends GeneratedTracksApi {
             onProgress,
             template: 'audio',
             options:
-              this.trackUploadHelper.extractMediorumUploadOptions(metadata)
+              this.trackUploadHelper.extractMediorumUploadOptions(metadata),
+            auth: this.auth
           }),
         (e) => {
           this.logger.info('Retrying uploadTrackAudio', e)
@@ -211,7 +213,8 @@ export class TracksApi extends GeneratedTracksApi {
           await this.storage.uploadFile({
             file: coverArtFile,
             onProgress,
-            template: 'img_square'
+            template: 'img_square',
+            auth: this.auth
           }),
         (e) => {
           this.logger.info('Retrying uploadTrackCoverArt', e)

--- a/packages/sdk/src/sdk/api/users/UsersApi.ts
+++ b/packages/sdk/src/sdk/api/users/UsersApi.ts
@@ -70,7 +70,8 @@ export class UsersApi extends GeneratedUsersApi {
             await this.storage.uploadFile({
               file: profilePictureFile,
               onProgress,
-              template: 'img_square'
+              template: 'img_square',
+              auth: this.auth
             }),
           (e) => {
             this.logger.info('Retrying uploadProfilePicture', e)
@@ -82,7 +83,8 @@ export class UsersApi extends GeneratedUsersApi {
             await this.storage.uploadFile({
               file: coverArtFile,
               onProgress,
-              template: 'img_backdrop'
+              template: 'img_backdrop',
+              auth: this.auth
             }),
           (e) => {
             this.logger.info('Retrying uploadProfileCoverArt', e)

--- a/packages/sdk/src/sdk/services/Auth/UserAuth.ts
+++ b/packages/sdk/src/sdk/services/Auth/UserAuth.ts
@@ -1,4 +1,5 @@
 import { GetFn, Hedgehog, SetAuthFn, SetUserFn } from '@audius/hedgehog'
+import { personalSign } from '@metamask/eth-sig-util'
 import { keccak_256 } from '@noble/hashes/sha3'
 import * as secp from '@noble/secp256k1'
 import { EIP712TypedData, MessageData, signTypedData } from 'eth-sig-util'
@@ -138,8 +139,13 @@ export class UserAuth implements AuthService {
     })
   }
 
-  hashAndSign: (data: string) => Promise<string> = () => {
-    throw new Error('hashAndSign not initialized')
+  hashAndSign: (data: string) => Promise<string> = async (data) => {
+    const wallet = this.hedgehog.getWallet()
+    if (!wallet) throw new Error('No wallet')
+    return personalSign({
+      privateKey: wallet.getPrivateKey(),
+      data: keccak_256(data)
+    })
   }
 
   signTransaction: (

--- a/packages/sdk/src/sdk/services/EntityManager/EntityManager.ts
+++ b/packages/sdk/src/sdk/services/EntityManager/EntityManager.ts
@@ -148,7 +148,7 @@ export class EntityManager implements EntityManagerService {
       )
     } else {
       throw new Error(
-        `Error making relay request${
+        `Error making relay request ${response.status} ${
           jsonResponse?.error?.message ? `: ${jsonResponse.error.message}` : '.'
         }`
       )

--- a/packages/sdk/src/sdk/services/Storage/types.ts
+++ b/packages/sdk/src/sdk/services/Storage/types.ts
@@ -26,12 +26,14 @@ export type StorageService = {
     file,
     onProgress,
     template,
-    options
+    options,
+    auth
   }: {
     file: File
     onProgress?: ProgressCB
     template: FileTemplate
     options?: { [key: string]: string }
+    auth: AuthService
   }) => Promise<UploadResponse>
   editFile: ({
     uploadId,

--- a/pkg/mediorum/server/serve_upload.go
+++ b/pkg/mediorum/server/serve_upload.go
@@ -127,13 +127,21 @@ func (ss *MediorumServer) postUpload(c echo.Context) error {
 		return c.String(http.StatusServiceUnavailable, "disk is too full to accept new uploads")
 	}
 
-	// Parse X-User-Wallet header
-	userWalletHeader := c.Request().Header.Get("X-User-Wallet-Addr")
+	// read user wallet from ?signature query string
+	// ... fall back to (legacy) X-User-Wallet header
 	userWallet := sql.NullString{Valid: false}
-	if userWalletHeader != "" {
+	if signerWallet, ok := c.Get("signer-wallet").(string); ok {
 		userWallet = sql.NullString{
-			String: userWalletHeader,
+			String: signerWallet,
 			Valid:  true,
+		}
+	} else {
+		userWalletHeader := c.Request().Header.Get("X-User-Wallet-Addr")
+		if userWalletHeader != "" {
+			userWallet = sql.NullString{
+				String: userWalletHeader,
+				Valid:  true,
+			}
 		}
 	}
 

--- a/pkg/mediorum/server/server_basic_auth.go
+++ b/pkg/mediorum/server/server_basic_auth.go
@@ -73,7 +73,7 @@ func (ss *MediorumServer) requireUserSignature(next echo.HandlerFunc) echo.Handl
 			})
 		} else {
 			// check it is for this upload id
-			if sig.Data.UploadID != id {
+			if id != "" && sig.Data.UploadID != id {
 				return c.JSON(401, map[string]string{
 					"error":  "signature contains incorrect ID",
 					"detail": fmt.Sprintf("url: %s, signature %s", id, sig.Data.UploadID),


### PR DESCRIPTION
Uses the same strategy as the "edit upload" flow:  A signature query param.

Updates mediorum to read this in the create upload code path.