### PR TITLE
Apply autocorrection to last word in comment/DM

### DIFF
--- a/packages/mobile/src/components/composer-input/ComposerInput.tsx
+++ b/packages/mobile/src/components/composer-input/ComposerInput.tsx
@@ -302,6 +302,7 @@ export const ComposerInput = forwardRef(function ComposerInput(
     if (internalRef.current) {
       internalRef.current.blur()
       setTimeout(() => {
+        setValue('')
         const mentions =
           getUserMentions(latestValueRef.current)?.map((match) => {
             return {
@@ -310,7 +311,6 @@ export const ComposerInput = forwardRef(function ComposerInput(
             }
           }) ?? []
         onSubmit?.(restoreLinks(latestValueRef.current), mentions)
-        setValue('')
       }, 10)
     }
   }, [getUserMentions, onSubmit, restoreLinks, userIdMap])


### PR DESCRIPTION
### Description
There's a problem where submitting a comment/DM now does not apply autocorrection until after the comment is sent and then the autocorrected text persists.
https://github.com/user-attachments/assets/fd42593a-267c-4d1b-aa3c-4fb5d4ebdd99

The fix is to blur the reference to the text input so autocorrection is applied on submit, then submit a ref for the latest value and clearing any text.

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._

https://github.com/user-attachments/assets/94566351-5af0-4a00-9c12-d205703ddd02



