### PR TITLE
[QA-1813] Fix useTabs leave animation opacity

### DIFF
--- a/packages/web/src/hooks/useTabs/useTabs.tsx
+++ b/packages/web/src/hooks/useTabs/useTabs.tsx
@@ -799,7 +799,7 @@ const BodyContainer = memo(
           transform: `translate3d(${movingToLeft ? '-' : ''}${
             containerWidth + interElementSpacing
           }px, 0px, 0px)`,
-          opacity: 1
+          opacity: 0
         }
       },
       enter: (_: any) => {


### PR DESCRIPTION
### Description
Set leave opacity to zero to avoid visible content jumping on the way out

### How Has This Been Tested?
Manually Tested