### PR TITLE
Fix concurrent user bank creations at the SDK level

### DIFF
--- a/.changeset/stupid-pens-happen.md
+++ b/.changeset/stupid-pens-happen.md
@@ -1,0 +1,5 @@
+---
+'@audius/sdk': patch
+---
+
+Fix concurrent getOrCreateUserBank requests

--- a/packages/web/src/common/store/pages/audio-rewards/sagas.ts
+++ b/packages/web/src/common/store/pages/audio-rewards/sagas.ts
@@ -339,28 +339,6 @@ function* claimSingleChallengeRewardAsync(
     env
   )
 
-  // Create user bank at the beginning before parallelizing
-  const user = yield* select(accountSelectors.getAccountUser)
-  if (user) {
-    const { wallet: ethWallet } = user
-    if (ethWallet) {
-      // Try to create the user bank _now_ so that subsequent calls inside
-      // claimReward won't accidentally try to stomp on each other.
-      // This waits until finalized, so should be safe to assume the next call
-      // will see the user bank exists.
-      yield* call(
-        [
-          sdk.services.claimableTokensClient,
-          sdk.services.claimableTokensClient.getOrCreateUserBank
-        ],
-        {
-          ethWallet,
-          mint: 'USDC'
-        }
-      )
-    }
-  }
-
   yield* call(waitForOptimisticChallengeToComplete, {
     challengeId,
     completionPollFrequency,
@@ -454,31 +432,6 @@ function* claimAllChallengeRewardsAsync(
     track,
     make({ eventName: Name.REWARDS_CLAIM_ALL_REQUEST, count: claims.length })
   )
-
-  // Create user bank at the beginning before parallelizing
-  const audiusSdk = yield* getContext('audiusSdk')
-  const sdk = yield* call(audiusSdk)
-  const user = yield* select(accountSelectors.getAccountUser)
-  if (user) {
-    const { wallet: ethWallet } = user
-    if (ethWallet) {
-      // Try to create the user bank _now_ so that subsequent calls inside
-      // claimReward won't accidentally try to stomp on each other.
-      // This waits until finalized, so should be safe to assume the next call
-      // will see the user bank exists.
-      yield* call(
-        [
-          sdk.services.claimableTokensClient,
-          sdk.services.claimableTokensClient.getOrCreateUserBank
-        ],
-        {
-          ethWallet,
-          mint: 'USDC'
-        }
-      )
-    }
-  }
-
   yield* all(
     claims.map((claim) =>
       call(function* () {

--- a/packages/web/src/common/store/pages/audio-rewards/sagas.ts
+++ b/packages/web/src/common/store/pages/audio-rewards/sagas.ts
@@ -339,6 +339,28 @@ function* claimSingleChallengeRewardAsync(
     env
   )
 
+  // Create user bank at the beginning before parallelizing
+  const user = yield* select(accountSelectors.getAccountUser)
+  if (user) {
+    const { wallet: ethWallet } = user
+    if (ethWallet) {
+      // Try to create the user bank _now_ so that subsequent calls inside
+      // claimReward won't accidentally try to stomp on each other.
+      // This waits until finalized, so should be safe to assume the next call
+      // will see the user bank exists.
+      yield* call(
+        [
+          sdk.services.claimableTokensClient,
+          sdk.services.claimableTokensClient.getOrCreateUserBank
+        ],
+        {
+          ethWallet,
+          mint: 'USDC'
+        }
+      )
+    }
+  }
+
   yield* call(waitForOptimisticChallengeToComplete, {
     challengeId,
     completionPollFrequency,
@@ -432,6 +454,31 @@ function* claimAllChallengeRewardsAsync(
     track,
     make({ eventName: Name.REWARDS_CLAIM_ALL_REQUEST, count: claims.length })
   )
+
+  // Create user bank at the beginning before parallelizing
+  const audiusSdk = yield* getContext('audiusSdk')
+  const sdk = yield* call(audiusSdk)
+  const user = yield* select(accountSelectors.getAccountUser)
+  if (user) {
+    const { wallet: ethWallet } = user
+    if (ethWallet) {
+      // Try to create the user bank _now_ so that subsequent calls inside
+      // claimReward won't accidentally try to stomp on each other.
+      // This waits until finalized, so should be safe to assume the next call
+      // will see the user bank exists.
+      yield* call(
+        [
+          sdk.services.claimableTokensClient,
+          sdk.services.claimableTokensClient.getOrCreateUserBank
+        ],
+        {
+          ethWallet,
+          mint: 'USDC'
+        }
+      )
+    }
+  }
+
   yield* all(
     claims.map((claim) =>
       call(function* () {


### PR DESCRIPTION
Inside the `claimReward` is a call to `getOrCreateUserBank` which creates a user bank if one doesn't exist. However, `claimReward` is called for each specifier there is to claim, often in parallel. If a user's user bank did not exist, multiple attempts to create it would occur. Unfortunately, the Claimable Tokens program doesn't support idempotent token account creation of these user banks, so those transactions would fail with custom error code 0x0 ("Account already allocated") on the inner system program instruction that attempts to allocate the user bank token account. (Sidenote: our SDK code would interpret that custom error code as coming from _our_ instruction, thus leading to the "Signature verification failed" misnomer for these errors in Amplitude or Sentry)

This PR attempts to fix that by ensuring only one creation is happening at a time per user bank address. It also introduces a cache, so that subsequent requests don't even have to check the RPC to see if the user bank exists if it has already been fetched or created in the same session. Because this is fixed at the SDK level, which is a singleton in its usage, consumers can safely call `getOrCreateUserBank` from wherever in any consuming clients without concern for concurrency or race conditions.