### PR TITLE
[C-5371] Improve tile press responsiveness

### DIFF
--- a/packages/mobile/src/components/lineup-tile/CollectionTile.tsx
+++ b/packages/mobile/src/components/lineup-tile/CollectionTile.tsx
@@ -157,11 +157,13 @@ const CollectionTileComponent = ({
   const handlePress = useCallback(() => {
     if (!tracks.length) return
 
-    togglePlay({
-      uid: currentTrack?.uid ?? tracks[0]?.uid ?? null,
-      id: currentTrack?.track_id ?? tracks[0]?.track_id ?? null,
-      source: PlaybackSource.PLAYLIST_TILE_TRACK
-    })
+    setTimeout(() => {
+      togglePlay({
+        uid: currentTrack?.uid ?? tracks[0]?.uid ?? null,
+        id: currentTrack?.track_id ?? tracks[0]?.track_id ?? null,
+        source: PlaybackSource.PLAYLIST_TILE_TRACK
+      })
+    }, 100)
   }, [currentTrack, togglePlay, tracks])
 
   const handlePressTitle = useCallback(() => {

--- a/packages/mobile/src/components/lineup-tile/TrackTile.tsx
+++ b/packages/mobile/src/components/lineup-tile/TrackTile.tsx
@@ -30,6 +30,7 @@ import {
 import type { CommonState } from '@audius/common/store'
 import { Genre, removeNullable } from '@audius/common/utils'
 import { useNavigationState } from '@react-navigation/native'
+import { InteractionManager } from 'react-native'
 import { useDispatch, useSelector } from 'react-redux'
 
 import type { ImageProps } from '@audius/harmony-native'
@@ -146,12 +147,14 @@ export const TrackTileComponent = ({
   )
 
   const handlePress = useCallback(() => {
-    togglePlay({
-      uid: lineupTileProps.uid,
-      id: track_id,
-      source: PlaybackSource.TRACK_TILE
-    })
-    onPress?.(track_id)
+    setTimeout(() => {
+      togglePlay({
+        uid: lineupTileProps.uid,
+        id: track_id,
+        source: PlaybackSource.TRACK_TILE
+      })
+      onPress?.(track_id)
+    }, 100)
   }, [togglePlay, lineupTileProps.uid, track_id, onPress])
 
   const handlePressTitle = useCallback(() => {


### PR DESCRIPTION
### Description

The depress animation is colliding with the callback processing to start the player
- Deferring the player computation slightly allows a window for the animation to complete
- This does incur a cost of 100ms on playback speed. This is still a net improvement in perceived performance, but we should try to follow up and do better

I tried other solutions, but this was the best balance for the time we have available

### How Has This Been Tested?

android physical device, ios sim