### PR TITLE
[C-5336] Load more items on mobile feed/trending

### DIFF
--- a/packages/mobile/src/components/lineup/Lineup.tsx
+++ b/packages/mobile/src/components/lineup/Lineup.tsx
@@ -8,7 +8,6 @@ import type { SectionList as RNSectionList, ViewStyle } from 'react-native'
 import { Dimensions, StyleSheet, View } from 'react-native'
 import { useDispatch, useSelector } from 'react-redux'
 
-import { Text } from '@audius/harmony-native'
 import { SectionList } from 'app/components/core'
 import {
   CollectionTile,
@@ -540,7 +539,6 @@ export const Lineup = ({
 
   return (
     <View style={styles.root}>
-      <Text>length: {lineupLength}</Text>
       <SectionList
         {...listProps}
         {...pullToRefreshProps}

--- a/packages/mobile/src/components/lineup/Lineup.tsx
+++ b/packages/mobile/src/components/lineup/Lineup.tsx
@@ -8,6 +8,7 @@ import type { SectionList as RNSectionList, ViewStyle } from 'react-native'
 import { Dimensions, StyleSheet, View } from 'react-native'
 import { useDispatch, useSelector } from 'react-redux'
 
+import { Text } from '@audius/harmony-native'
 import { SectionList } from 'app/components/core'
 import {
   CollectionTile,
@@ -42,12 +43,12 @@ const MAX_COUNT_LOADING_TILES = 18
 
 // The inital multiplier for number of tracks to fetch on lineup load
 // multiplied by the number of tracks that fit the screen height
-export const INITIAL_LOAD_TRACKS_MULTIPLIER = 1.75
-export const INITIAL_PLAYLISTS_MULTIPLER = 1
+export const INITIAL_LOAD_TRACKS_MULTIPLIER = 3
+export const INITIAL_PLAYLISTS_MULTIPLER = 2
 
 // A multiplier for the number of tiles to fill a page to be
 // loaded in on each call (after the intial call)
-const TRACKS_AHEAD_MULTIPLIER = 0.75
+const TRACKS_AHEAD_MULTIPLIER = 2
 
 // Threshold for how far away from the bottom (of the list) the user has to be
 // before fetching more tracks as a percentage of the list height
@@ -539,6 +540,7 @@ export const Lineup = ({
 
   return (
     <View style={styles.root}>
+      <Text>length: {lineupLength}</Text>
       <SectionList
         {...listProps}
         {...pullToRefreshProps}


### PR DESCRIPTION
### Description

- Bumped lineup batch size constants
- In practice, on my device this led to initial page of 15 items, and subsequent pages of 10. Up from 9 and 4 respectively.

Should we go higher?

### How Has This Been Tested?

android physical device, ios sim