### PR TITLE
[PAY-3574] Simplify chat unread count logic

### DIFF
--- a/comms/discovery/rpcz/chat_blast.go
+++ b/comms/discovery/rpcz/chat_blast.go
@@ -74,12 +74,6 @@ func chatBlast(tx *sqlx.Tx, userId int32, ts time.Time, params schema.ChatBlastR
 			blast_id
 		FROM targ
 		ON conflict do nothing
-	),
-	update_unread_count AS (
-    UPDATE chat_member
-    SET unread_count = unread_count + 1
-    WHERE chat_id IN (SELECT chat_id FROM targ)
-		AND user_id IN (SELECT to_user_id FROM targ)
 	)
 	SELECT chat_id FROM targ;
 	`

--- a/packages/common/src/store/pages/chat/slice.ts
+++ b/packages/common/src/store/pages/chat/slice.ts
@@ -506,6 +506,41 @@ const slice = createSlice({
         changes
       })
 
+      // Handle unread counts
+      if (existingChat && !existingChat.is_blast) {
+        const optimisticRead = state.optimisticChatRead[chatId]
+        const existingUnreadCount = optimisticRead
+          ? optimisticRead.unread_message_count
+          : existingChat?.unread_message_count ?? 0
+        if (!isSelfMessage) {
+          // If we're actively reading, this will immediately get marked as read.
+          // Ignore the unread bump to prevent flicker
+          if (state.activeChatId !== chatId) {
+            chatsAdapter.updateOne(state.chats, {
+              id: chatId,
+              changes: { unread_message_count: existingUnreadCount + 1 }
+            })
+          }
+
+          // Web or mobile: update optimistic unread count
+          state.optimisticUnreadMessagesCount =
+            (state.optimisticUnreadMessagesCount ?? state.unreadMessagesCount) +
+            1
+        } else {
+          // Mark chat as read if its our own
+          chatsAdapter.updateOne(state.chats, {
+            id: chatId,
+            changes: {
+              unread_message_count: 0,
+              last_read_at: message.created_at
+            }
+          })
+          state.optimisticUnreadMessagesCount =
+            (state.optimisticUnreadMessagesCount ?? state.unreadMessagesCount) -
+            existingUnreadCount
+        }
+      }
+
       // If no chatId, don't add the message
       // and abort early, relying on the saga
       // to fetch the chat
@@ -537,36 +572,6 @@ const slice = createSlice({
 
       // Recalculate tails
       recalculatePreviousMessageHasTail(state.messages[chatId], 0)
-
-      // Handle unread counts
-      if (!existingChat || existingChat.is_blast) return
-      const optimisticRead = state.optimisticChatRead[chatId]
-      const existingUnreadCount = optimisticRead
-        ? optimisticRead.unread_message_count
-        : existingChat?.unread_message_count ?? 0
-      if (!isSelfMessage) {
-        // If we're actively reading, this will immediately get marked as read.
-        // Ignore the unread bump to prevent flicker
-        if (state.activeChatId !== chatId) {
-          chatsAdapter.updateOne(state.chats, {
-            id: chatId,
-            changes: { unread_message_count: existingUnreadCount + 1 }
-          })
-        }
-
-        // Web or mobile: update optimistic unread count
-        state.optimisticUnreadMessagesCount =
-          (state.optimisticUnreadMessagesCount ?? state.unreadMessagesCount) + 1
-      } else {
-        // Mark chat as read if its our own
-        chatsAdapter.updateOne(state.chats, {
-          id: chatId,
-          changes: { unread_message_count: 0, last_read_at: message.created_at }
-        })
-        state.optimisticUnreadMessagesCount =
-          (state.optimisticUnreadMessagesCount ?? state.unreadMessagesCount) -
-          existingUnreadCount
-      }
     },
     /**
      * Marks the chat as currently being read.

--- a/packages/web/src/pages/chat-page/components/ChatMessageList.tsx
+++ b/packages/web/src/pages/chat-page/components/ChatMessageList.tsx
@@ -194,6 +194,10 @@ export const ChatMessageList = forwardRef<HTMLDivElement, ChatMessageListProps>(
         dispatch(fetchMoreMessages({ chatId }))
         dispatch(setActiveChat({ chatId }))
       }
+      // Unset active chat when component unmounts
+      return () => {
+        dispatch(setActiveChat({ chatId: null }))
+      }
     }, [dispatch, chatId, chat?.messagesStatus])
 
     // Fix for if the initial load doesn't have enough messages to cause scrolling


### PR DESCRIPTION
### Description
Here's what we think happened:

Bug from PAY-3573 meant that a blast was not broadcast for some time, so it existed on only one node.

The recipient connected to that node and upgraded the blast. the chat create RPC was broadcast across the network.

Later when the fix for PAY-3573 went out, the missing blast was finally broadcast to the network.

This set the chat.last_message_at back in time, but did increment the chat.unread_count. By that time the chat_member.last_active_at was already past chat.last_message_at, so [this line](https://github.com/AudiusProject/audius-protocol/blob/0a8a5937130c4bd57864cf14e0620b179ac89f4a/packages/common/src/store/pages/chat/sagas.ts#L550) did not trigger and the client did not send out a chat.read request.

We will couple this fix with a temporary client fix to always send out a chat.read request (delete the line cited above) - ticket is PAY-3592

Frankly I don't fully understand why this necessitated client changes, but I noticed that after the backend change the client unread count logic was buggy. I think this rewrite makes more sense though.

Note that we have to unset the activeChatId when navigating away from the chat now.

### How Has This Been Tested?
Tested on local dev

https://github.com/user-attachments/assets/add3039e-fca3-4607-9939-c059801e1aa9

