### PR TITLE
[PAY-3592] Always mark chat as read (temp fix)

### DIFF
--- a/packages/common/src/store/pages/chat/sagas.ts
+++ b/packages/common/src/store/pages/chat/sagas.ts
@@ -541,21 +541,10 @@ function* doMarkChatAsRead(action: ReturnType<typeof markChatAsRead>) {
     // Use non-optimistic chat here so that the calculation of whether to mark
     // the chat as read or not are consistent with values in backend
     const chat = yield* select((state) => getNonOptimisticChat(state, chatId))
-    if (chat?.is_blast) {
-      return
-    }
-    if (
-      !chat ||
-      !chat?.last_read_at ||
-      dayjs(chat?.last_read_at).isBefore(chat?.last_message_at)
-    ) {
-      yield* call([sdk.chats, sdk.chats.read], { chatId })
-      yield* put(markChatAsReadSucceeded({ chatId }))
-    } else {
-      // Mark the write as 'failed' in this case (just means we already marked this as read somehow)
-      // to delete the optimistic read status
-      yield* put(markChatAsReadFailed({ chatId }))
-    }
+    if (chat?.is_blast) return
+
+    yield* call([sdk.chats, sdk.chats.read], { chatId })
+    yield* put(markChatAsReadSucceeded({ chatId }))
   } catch (e) {
     yield* put(markChatAsReadFailed({ chatId }))
     const reportToSentry = yield* getContext('reportToSentry')


### PR DESCRIPTION
### Description
While we wait for https://github.com/AudiusProject/audius-protocol/pull/10396 to go out, this is a client fix that will always mark the chat as read (at the expense of firing off more `chat.read` requests).

We can revert this logic down the line - already made a ticket.

### How Has This Been Tested?

Tested on local stack + web