### PR TITLE
[QA-1790] Fix boolean logic error in profile page reducers

### DIFF
--- a/packages/common/src/store/pages/profile/reducer.ts
+++ b/packages/common/src/store/pages/profile/reducer.ts
@@ -346,7 +346,8 @@ const reducer = (
   const { currentUser, entries } = state
 
   const profileHandle =
-    ('handle' in action && action.handle?.toLowerCase()) ?? currentUser
+    'handle' in action ? action.handle?.toLowerCase() : currentUser
+
   if (!profileHandle) return state
 
   let newEntry = entries[profileHandle] ?? initialProfileState


### PR DESCRIPTION
### Description
Fixed a small boolean logic error in profile page reducers
We were doing `false ?? otherValue` but should have been doing `false || otherValue` bc false is not null
Changed it to a ternary to make it easier to read

### How Has This Been Tested?
Manually Tested