### PR TITLE
Fix off-by-one error in fetching mirrors

### DIFF
--- a/packages/discovery-provider/src/queries/query_helpers.py
+++ b/packages/discovery-provider/src/queries/query_helpers.py
@@ -654,7 +654,7 @@ def get_content_url_with_mirrors(
                 *[re.sub("/$", "", node["endpoint"].lower()) for node in healthy_nodes]
             )
 
-            content_nodes = rendezvous.get_n(mirrorCount, cid)
+            content_nodes = rendezvous.get_n(mirrorCount + 1, cid)
 
     if len(content_nodes) == 0:
         logger.warning(


### PR DESCRIPTION
Was fetching mirrorCount, but using the first selected as the canonical "non-mirror" - need to fetch mirrorCount + 1 to account for this.
