### PR TITLE
Fix trending playlists

### DIFF
--- a/packages/discovery-provider/src/queries/get_extended_purchase_gate.py
+++ b/packages/discovery-provider/src/queries/get_extended_purchase_gate.py
@@ -259,6 +259,8 @@ def get_legacy_purchase_gate(gate: AccessGate, session=None):
     if gate and "usdc_purchase" in gate:
         # mypy gets confused....
         gate = cast(PurchaseGate, gate)
+        if isinstance(gate["usdc_purchase"]["splits"], dict):
+            return gate
         if session:
             new_gate = _get_extended_purchase_gate(session, gate)
         else:

--- a/packages/discovery-provider/src/queries/get_trending_playlists.py
+++ b/packages/discovery-provider/src/queries/get_trending_playlists.py
@@ -342,13 +342,14 @@ def _get_trending_playlists_with_session(
 
         # Re-associate tracks with playlists
         # track_id -> populated_track
-        populated_track_map = {track["track_id"]: track for track in populated_tracks}
+        populated_track_map = {
+            track["track_id"]: extend_track(track) for track in populated_tracks
+        }
         for playlist in playlists_map.values():
             for i in range(len(playlist["tracks"])):
                 track_id = playlist["tracks"][i]["track_id"]
                 populated = populated_track_map[track_id]
                 playlist["tracks"][i] = populated
-            playlist["tracks"] = list(map(extend_track, playlist["tracks"]))
 
     # re-sort playlists to original order, because populate_playlist_metadata
     # unsorts.


### PR DESCRIPTION
We had two (or more) playlists on trending that shared one (or more) tracks.

In the query for trending playlists, we extend the tracks which calls into `get_legacy_purchase_gate`.

However, since the track was in two or more playlists, we'd try to extend it twice, which would then call `get_legacy_purchase_gate` _again_ on the already converted purchase gate.

This PR makes it so we don't call extend track multiple times on the same track, and even if we do, `get_legacy_purchase_gate` is updated to be idempotent and return early if it sees a dict instead of a list of splits.