### PR TITLE
[C-5335] Mobile follow button snappy

### DIFF
--- a/packages/mobile/src/components/user/FollowButton.tsx
+++ b/packages/mobile/src/components/user/FollowButton.tsx
@@ -28,11 +28,13 @@ export const FollowButton = (props: FollowButtonsProps) => {
   const handlePress = useCallback(
     (event: GestureResponderEvent) => {
       onPress?.(event)
-      if (isFollowing) {
-        dispatch(unfollowUser(userId, followSource))
-      } else {
-        dispatch(followUser(userId, followSource))
-      }
+      setTimeout(() => {
+        if (isFollowing) {
+          dispatch(unfollowUser(userId, followSource))
+        } else {
+          dispatch(followUser(userId, followSource))
+        }
+      }, 1)
     },
     [onPress, dispatch, isFollowing, userId, followSource]
   )

--- a/packages/mobile/src/components/user/FollowButton.tsx
+++ b/packages/mobile/src/components/user/FollowButton.tsx
@@ -28,13 +28,13 @@ export const FollowButton = (props: FollowButtonsProps) => {
   const handlePress = useCallback(
     (event: GestureResponderEvent) => {
       onPress?.(event)
-      setTimeout(() => {
+      requestAnimationFrame(() => {
         if (isFollowing) {
           dispatch(unfollowUser(userId, followSource))
         } else {
           dispatch(followUser(userId, followSource))
         }
-      }, 1)
+      })
     },
     [onPress, dispatch, isFollowing, userId, followSource]
   )

--- a/packages/mobile/src/harmony-native/components/Button/FollowButton/FollowButton.tsx
+++ b/packages/mobile/src/harmony-native/components/Button/FollowButton/FollowButton.tsx
@@ -2,6 +2,7 @@ import type { ChangeEvent } from 'react'
 import { useCallback, useEffect, useState } from 'react'
 
 import { css } from '@emotion/native'
+import type { GestureResponderEvent } from 'react-native'
 import { Pressable } from 'react-native'
 
 import {
@@ -32,7 +33,7 @@ export const FollowButton = (props: FollowButtonProps) => {
     onChange,
     ...other
   } = props
-  const { disabled } = other
+  const { disabled, onPress } = other
   const [following, setFollowing] = useState(isFollowing)
   const { color, cornerRadius } = useTheme()
   const isInput = !!onChange
@@ -43,18 +44,22 @@ export const FollowButton = (props: FollowButtonProps) => {
 
   const Icon = following ? IconUserFollowing : IconUserFollow
 
-  const handlePress = useCallback(() => {
-    if (following) {
-      onUnfollow?.()
-    } else {
-      haptics.medium()
-      onFollow?.()
-    }
-    onChange?.({
-      target: { value, checked: !following, type: 'checkbox' }
-    } as ChangeEvent<HTMLInputElement>)
-    setFollowing(!following)
-  }, [following, onChange, value, onUnfollow, onFollow])
+  const handlePress = useCallback(
+    (event: GestureResponderEvent) => {
+      if (following) {
+        onUnfollow?.()
+      } else {
+        haptics.medium()
+        onFollow?.()
+      }
+      onChange?.({
+        target: { value, checked: !following, type: 'checkbox' }
+      } as ChangeEvent<HTMLInputElement>)
+      setFollowing(!following)
+      onPress?.(event)
+    },
+    [following, onChange, value, onUnfollow, onFollow, onPress]
+  )
 
   const inputProps = isInput
     ? {
@@ -66,7 +71,7 @@ export const FollowButton = (props: FollowButtonProps) => {
     : null
 
   return (
-    <Pressable onPress={handlePress} {...other} {...inputProps}>
+    <Pressable onPress={handlePress} {...inputProps}>
       <Flex
         h={size === 'small' ? 28 : 32}
         direction='row'


### PR DESCRIPTION
### Description
2 things:
- Defer dispatching the follow actions slightly to push them to the back of the event loop.
- `onPress` was being passed in to `Pressable` via the `{...other}` props which was clobbering the explicit `onPress`. Cleaned that up by moving `onPress` into the `handlePress` inside `FollowButton`.
- Tradeoff is the subscription (bell) button takes a while to pop in, as this depends on the follow request coming back from the backend. I think this is fine for now. Ideally could do some optimistic thing but that gets hairy.

### How Has This Been Tested?
including full screen rec so you can see the keypresses

https://github.com/user-attachments/assets/027ffa0d-5144-4b86-a0c3-84a55bededde

