### PR TITLE
Fix stage track edit

### DIFF
--- a/packages/web/src/common/store/cache/tracks/sagas.ts
+++ b/packages/web/src/common/store/cache/tracks/sagas.ts
@@ -155,7 +155,7 @@ function* editTrackAsync(action: ReturnType<typeof trackActions.editTrack>) {
 
   const track = { ...trackForEdit } as Track & TrackMetadataForUpload
   track.track_id = action.trackId
-  if ('file' in track.artwork && track.artwork?.file) {
+  if (track.artwork && 'file' in track.artwork && track.artwork.file) {
     track._cover_art_sizes = {
       ...track._cover_art_sizes,
       [DefaultSizes.OVERRIDE]: track.artwork.url


### PR DESCRIPTION
### Description

This code is still gross, but have a plan to fix it up.
Currently backend returns `artwork` and frontend uses `artwork` for updates, so it really has two shapes.
Want to change this so backend returns `artwork` and frontend doesn't mutate that object at all and instead just uploads files directly through SDK, bypassing the need to even have a type.

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._

Simulator, edits working