### PR TITLE
Do not require tracks in full playlist response type

### DIFF
--- a/.changeset/quick-eels-pay.md
+++ b/.changeset/quick-eels-pay.md
@@ -1,0 +1,5 @@
+---
+'@audius/sdk': minor
+---
+
+Update full playlist.tracks response type

--- a/packages/discovery-provider/src/api/v1/models/playlists.py
+++ b/packages/discovery-provider/src/api/v1/models/playlists.py
@@ -124,7 +124,9 @@ full_playlist_model = ns.clone(
     "playlist_full",
     full_playlist_without_tracks_model,
     {
-        "tracks": fields.List(fields.Nested(track_full), required=True),
+        # Fetching playlists by ids will give tracks, but fetching
+        # playlists associated with a user will not
+        "tracks": fields.List(fields.Nested(track_full), required=False),
     },
 )
 

--- a/packages/discovery-provider/src/api/v1/users.py
+++ b/packages/discovery-provider/src/api/v1/users.py
@@ -69,7 +69,10 @@ from src.api.v1.models.extensions.fields import NestedOneOf
 from src.api.v1.models.extensions.models import WildcardModel
 from src.api.v1.models.feed import user_feed_item
 from src.api.v1.models.grants import managed_user, user_manager
-from src.api.v1.models.playlists import full_playlist_model, playlist_model
+from src.api.v1.models.playlists import (
+    full_playlist_without_tracks_model,
+    playlist_model,
+)
 from src.api.v1.models.support import (
     supporter_response,
     supporter_response_full,
@@ -893,7 +896,9 @@ USER_PLAYLISTS_ROUTE = "/<string:id>/playlists"
 
 
 playlists_response_full = make_full_response(
-    "playlists_response_full", full_ns, fields.List(fields.Nested(full_playlist_model))
+    "playlists_response_full",
+    full_ns,
+    fields.List(fields.Nested(full_playlist_without_tracks_model)),
 )
 
 
@@ -964,7 +969,9 @@ USER_ALBUMS_ROUTE = "/<string:id>/albums"
 
 
 albums_response_full = make_full_response(
-    "albums_response_full", ns, fields.List(fields.Nested(full_playlist_model))
+    "albums_response_full",
+    ns,
+    fields.List(fields.Nested(full_playlist_without_tracks_model)),
 )
 
 

--- a/packages/sdk/src/sdk/api/generated/full/models/PlaylistFull.ts
+++ b/packages/sdk/src/sdk/api/generated/full/models/PlaylistFull.ts
@@ -242,7 +242,7 @@ export interface PlaylistFull {
      * @type {Array<TrackFull>}
      * @memberof PlaylistFull
      */
-    tracks: Array<TrackFull>;
+    tracks?: Array<TrackFull>;
     /**
      * 
      * @type {string}
@@ -345,7 +345,6 @@ export function instanceOfPlaylistFull(value: object): value is PlaylistFull {
     isInstance = isInstance && "updatedAt" in value && value["updatedAt"] !== undefined;
     isInstance = isInstance && "addedTimestamps" in value && value["addedTimestamps"] !== undefined;
     isInstance = isInstance && "userId" in value && value["userId"] !== undefined;
-    isInstance = isInstance && "tracks" in value && value["tracks"] !== undefined;
     isInstance = isInstance && "isStreamGated" in value && value["isStreamGated"] !== undefined;
     isInstance = isInstance && "isScheduledRelease" in value && value["isScheduledRelease"] !== undefined;
 
@@ -389,7 +388,7 @@ export function PlaylistFullFromJSONTyped(json: any, ignoreDiscriminator: boolea
         'updatedAt': json['updated_at'],
         'addedTimestamps': ((json['added_timestamps'] as Array<any>).map(PlaylistAddedTimestampFromJSON)),
         'userId': json['user_id'],
-        'tracks': ((json['tracks'] as Array<any>).map(TrackFullFromJSON)),
+        'tracks': !exists(json, 'tracks') ? undefined : ((json['tracks'] as Array<any>).map(TrackFullFromJSON)),
         'coverArt': !exists(json, 'cover_art') ? undefined : json['cover_art'],
         'coverArtSizes': !exists(json, 'cover_art_sizes') ? undefined : json['cover_art_sizes'],
         'coverArtCids': !exists(json, 'cover_art_cids') ? undefined : PlaylistArtworkFromJSON(json['cover_art_cids']),
@@ -441,7 +440,7 @@ export function PlaylistFullToJSON(value?: PlaylistFull | null): any {
         'updated_at': value.updatedAt,
         'added_timestamps': ((value.addedTimestamps as Array<any>).map(PlaylistAddedTimestampToJSON)),
         'user_id': value.userId,
-        'tracks': ((value.tracks as Array<any>).map(TrackFullToJSON)),
+        'tracks': value.tracks === undefined ? undefined : ((value.tracks as Array<any>).map(TrackFullToJSON)),
         'cover_art': value.coverArt,
         'cover_art_sizes': value.coverArtSizes,
         'cover_art_cids': PlaylistArtworkToJSON(value.coverArtCids),


### PR DESCRIPTION
### Description

When fetching playlists/albums by user id, we don't populate tracks (it could be quite expensive - imagine a user with 50 playlists each with 100 tracks).

Currently the type here is required, so make it not required!

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._

Local stack