### PR TITLE
Use rf instead of ref for sign up

### DIFF
--- a/packages/mobile/src/components/challenge-rewards-drawer/ReferralRewardContents.tsx
+++ b/packages/mobile/src/components/challenge-rewards-drawer/ReferralRewardContents.tsx
@@ -14,7 +14,7 @@ export const ReferralRewardContents = ({
   isVerified: boolean
 }) => {
   const handle = useSelector(accountSelectors.getUserHandle)
-  const inviteUrl = `audius.co/signup?ref=${handle}`
+  const inviteUrl = `audius.co/signup?rf=${handle}`
 
   return (
     <Flex gap='m'>

--- a/packages/web/src/pages/audio-rewards-page/components/modals/ChallengeRewardsModal/ChallengeRewardsModal.tsx
+++ b/packages/web/src/pages/audio-rewards-page/components/modals/ChallengeRewardsModal/ChallengeRewardsModal.tsx
@@ -90,7 +90,7 @@ export const useRewardsModalType = (): [
   )
   return [modalType, setModalType]
 }
-const inviteLink = getCopyableLink('/signup?ref=%0')
+const inviteLink = getCopyableLink('/signup?rf=%0')
 
 const messages = {
   audio: '$AUDIO',

--- a/packages/web/src/pages/sign-on-page/SignOnPage.tsx
+++ b/packages/web/src/pages/sign-on-page/SignOnPage.tsx
@@ -285,9 +285,12 @@ export const SignOnPage = () => {
 
   useEffectOnce(() => {
     // Check for referrals and set them in the store
-    const referrerHandle = new URLSearchParams(location.search).get('ref')
-    if (referrerHandle) {
-      dispatch(fetchReferrer(referrerHandle))
+    const rf = new URLSearchParams(location.search).get('rf')
+    const ref = new URLSearchParams(location.search).get('ref')
+    if (rf) {
+      dispatch(fetchReferrer(rf))
+    } else if (ref) {
+      dispatch(fetchReferrer(ref))
     }
   })
 


### PR DESCRIPTION
### Description

Telegram does not respect `ref` query param

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._

copied referral link from challenge modal.
does mobile sign up not support this? i couldn't find any code