### PR TITLE
Fix user state issues with signUp breaking follows

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -142109,6 +142109,7 @@
         "abi-decoder": "2.4.0",
         "ajv": "6.12.2",
         "assert": "2.0.0",
+        "async-mutex": "0.5.0",
         "async-retry": "1.3.1",
         "axios": "0.19.2",
         "bn.js": "5.2.1",
@@ -143388,6 +143389,14 @@
       "license": "MIT",
       "engines": {
         "node": ">=12"
+      }
+    },
+    "packages/sdk/node_modules/async-mutex": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/async-mutex/-/async-mutex-0.5.0.tgz",
+      "integrity": "sha512-1A94B18jkJ3DYq284ohPxoXbfTA5HsQ7/Mf4DEhcyLx3Bz27Rh59iScbB6EPiP+B+joue6YCxcMXSbFC1tZKwA==",
+      "dependencies": {
+        "tslib": "^2.4.0"
       }
     },
     "packages/sdk/node_modules/async-retry": {
@@ -145014,7 +145023,6 @@
     },
     "packages/sdk/node_modules/tslib": {
       "version": "2.7.0",
-      "dev": true,
       "license": "0BSD"
     },
     "packages/sdk/node_modules/tsx": {

--- a/packages/libs/src/NativeAudiusLibs.ts
+++ b/packages/libs/src/NativeAudiusLibs.ts
@@ -434,6 +434,7 @@ export class AudiusLibs {
       await this.determineCreatorNodeEndpointForWallet(wallet)
     )
     this.discoveryProvider?.setCurrentUser(userId)
+    this.EntityManager?.setCurrentUserId(userId)
   }
 
   getCurrentUser() {
@@ -446,6 +447,7 @@ export class AudiusLibs {
     delete this.currentUserId
     this.creatorNode?.setEndpoint(this.creatorNodeConfig.fallbackUrl)
     this.discoveryProvider?.clearCurrentUser()
+    this.EntityManager?.clearCurrentUserId()
   }
 
   /** Init services based on presence of a relevant config. */

--- a/packages/libs/src/WebAudiusLibs.ts
+++ b/packages/libs/src/WebAudiusLibs.ts
@@ -458,6 +458,7 @@ export class AudiusLibs {
       await this.determineCreatorNodeEndpointForWallet(wallet)
     )
     this.discoveryProvider?.setCurrentUser(userId)
+    this.EntityManager?.setCurrentUserId(userId)
   }
 
   getCurrentUser() {
@@ -470,6 +471,7 @@ export class AudiusLibs {
     delete this.currentUserId
     this.creatorNode?.setEndpoint(this.creatorNodeConfig.fallbackUrl)
     this.discoveryProvider?.clearCurrentUser()
+    this.EntityManager?.clearCurrentUserId()
   }
 
   /** Init services based on presence of a relevant config. */

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -76,6 +76,7 @@
     "abi-decoder": "2.4.0",
     "ajv": "6.12.2",
     "assert": "2.0.0",
+    "async-mutex": "0.5.0",
     "async-retry": "1.3.1",
     "axios": "0.19.2",
     "bn.js": "5.2.1",


### PR DESCRIPTION
### Description
Two-pronged problem:
1. I missed updating `WebAudiusLibs` and `NativeAudiusLibs` with some fixes for entity manager user state.
2. `addRequestSignatureMiddleware` continues to be prone to race conditions in the code that checks for various conditions that require updating the signature. This results in occasionally failing to fetch the user right after signup due to requests using the wrong wallet address.

First issue is an easy fix. For the latter, I decided to ditch the complicated promise-based stuff because I think what we really want here is an exclusive queue where each request has a chance to examine the current parameters determining the signature and update them if needed without fear that another request will be reading/writing at the same time. So I switched it to using a proper mutex for the section of code that reads/writes the shared signature parameters.

### How Has This Been Tested?
Tested on local client against staging. Went through signup flow and did the user follows. Navigated to one of said users and refreshed to make sure the follow had actually stuck.

I put this branch on a subdomain and compared FCP times against prod using a fixed DN. I did not notice any significant change in performance. If anything, it was slightly faster.
