### PR TITLE
Typo Update log-in-with-audius.mdx

### DIFF
--- a/docs/docs/developers/guides/log-in-with-audius.mdx
+++ b/docs/docs/developers/guides/log-in-with-audius.mdx
@@ -380,7 +380,7 @@ login page with the following URL:
 https://audius.co/oauth/auth?scope=read&app_name=My%20Demo%20App&redirect_uri=https://mydemoapp.com/oauth/receive-token&state=a4e0761e-8c21-4e20-819d-5a4daeab4ea9
 ```
 
-when the user successsfully authenticates, the login page would redirect to:
+when the user successfully authenticates, the login page would redirect to:
 
 `https://mydemoapp.com/oauth/receive-token#state=a4e0761e-8c21-4e20-819d-5a4daeab4ea9&token={JWT}`
 


### PR DESCRIPTION
### Description

<img width="616" alt="Снимок экрана 2024-11-12 в 19 10 32" src="https://github.com/user-attachments/assets/f7ef3fc3-54c1-4e14-863d-86978f2adca5">

The text contains a typo.

The word "successsfully" is correctly spelled as "**successfully**."

It has been corrected.

### How Has This Been Tested?

I found the typo by reviewing the text closely. I noticed the word "successsfully," which stands out due to the extra "s" in the middle.
