### PR TITLE
Make email check case insensitive

### DIFF
--- a/packages/identity-service/src/routes/authentication.js
+++ b/packages/identity-service/src/routes/authentication.js
@@ -62,7 +62,7 @@ module.exports = function (app) {
               })
             } catch (err) {
               // keep address as null for future user recovery
-              req.logger.error('Error recovering users signed address', err)
+              req.logger.error(err, 'Error recovering users signed address')
             }
           }
 
@@ -256,7 +256,10 @@ module.exports = function (app) {
           req,
           authUser: existingUser
         })
-        if (associatedEmail && email !== associatedEmail) {
+        if (
+          associatedEmail &&
+          email.toLowerCase() !== associatedEmail.toLowerCase()
+        ) {
           req.logger.error(
             {
               reqEmail: email,
@@ -267,7 +270,7 @@ module.exports = function (app) {
           )
           return errorResponseBadRequest('Invalid credentials')
         } else {
-          email = associatedEmail || email
+          email = (associatedEmail || email).toLowerCase()
         }
 
         if (await shouldSendOtp({ req, email, redis })) {


### PR DESCRIPTION
Was seeing [these errors](https://app.axiom.co/audius-Lu52/stream/identity?q=%7B%22children%22%3A%5B%7B%22field%22%3A%22requestUrl%22%2C%22op%22%3A%22%3D%3D%22%2C%22value%22%3A%22%2Fauthentication%22%7D%2C%7B%22field%22%3A%22level%22%2C%22op%22%3A%22%3D%3D%22%2C%22value%22%3A%22error%22%7D%2C%7B%22field%22%3A%22msg%22%2C%22op%22%3A%22%21%3D%22%2C%22value%22%3A%22Missing%20otp%22%7D%2C%7B%22field%22%3A%22msg%22%2C%22op%22%3A%22not-starts-with%22%2C%22value%22%3A%22Error%20processing%20request%22%7D%5D%2C%22field%22%3A%22%22%2C%22op%22%3A%22and%22%7D) in Axiom:

```
error getting user record from existing user: user email and auth param mismatch
```

looks like on mobile people are capitalizing the first character of their email, so strict equals isn't matching their saved email.
