### PR TITLE
[QA-1819] Fix missing userId in backend calls

### DIFF
--- a/packages/common/src/services/audius-backend/AudiusBackend.ts
+++ b/packages/common/src/services/audius-backend/AudiusBackend.ts
@@ -829,11 +829,12 @@ export const audiusBackend = ({
     }
   }
 
-  async function recordTrackListen(trackId: ID) {
+  async function recordTrackListen(userId: ID, trackId: ID) {
     try {
       const listen = await audiusLibs.Track.logTrackListen(
         trackId,
         unauthenticatedUuid,
+        userId,
         await getFeatureEnabled(FeatureFlags.SOLANA_LISTEN_ENABLED)
       )
       return listen
@@ -1260,9 +1261,13 @@ export const audiusBackend = ({
     }
   }
 
-  async function deleteTrack(trackId: ID) {
+  async function deleteTrack(userId: ID, trackId: ID) {
     try {
-      const { txReceipt } = await audiusLibs.Track.deleteTrack(trackId, true)
+      const { txReceipt } = await audiusLibs.Track.deleteTrack(
+        userId,
+        trackId,
+        true
+      )
       return {
         blockHash: txReceipt.blockHash,
         blockNumber: txReceipt.blockNumber

--- a/packages/web/src/common/store/cache/tracks/sagas.ts
+++ b/packages/web/src/common/store/cache/tracks/sagas.ts
@@ -352,8 +352,15 @@ function* confirmDeleteTrack(trackId: ID) {
     confirmerActions.requestConfirmation(
       makeKindId(Kind.TRACKS, trackId),
       function* () {
+        yield* waitForAccount()
+        const userId = yield* select(getUserId)
+        if (!userId) {
+          throw new Error('No userId set, cannot delete track')
+        }
+
         const { blockHash, blockNumber } = yield* call(
           audiusBackendInstance.deleteTrack,
+          userId,
           trackId
         )
 
@@ -369,8 +376,6 @@ function* confirmDeleteTrack(trackId: ID) {
         }
 
         const track = yield* select(getTrack, { id: trackId })
-        yield* waitForAccount()
-        const userId = yield* select(getUserId)
 
         if (!track) return
         const { data } = yield* call(

--- a/packages/web/src/common/store/social/tracks/recordListen.ts
+++ b/packages/web/src/common/store/social/tracks/recordListen.ts
@@ -28,7 +28,7 @@ function* recordListen(action: { trackId: number }) {
     return
   }
 
-  yield* call(audiusBackendInstance.recordTrackListen, trackId)
+  yield* call(audiusBackendInstance.recordTrackListen, userId, trackId)
 
   yield* put(make(Name.LISTEN, { trackId }))
   if (track.is_stream_gated) {

--- a/packages/web/src/common/store/social/tracks/store.test.ts
+++ b/packages/web/src/common/store/social/tracks/store.test.ts
@@ -307,7 +307,7 @@ describe('recordListen', () => {
         [matchers.call.fn(audiusBackendInstance.recordTrackListen), true]
       ])
       .dispatch(actions.recordListen(1))
-      .call(audiusBackendInstance.recordTrackListen, 1)
+      .call(audiusBackendInstance.recordTrackListen, 1, 1)
       .silentRun()
   })
 

--- a/packages/web/src/common/store/upload/sagas.ts
+++ b/packages/web/src/common/store/upload/sagas.ts
@@ -948,7 +948,7 @@ export function* uploadCollection(
         )
         try {
           yield* all(
-            trackIds.map((id) => audiusBackendInstance.deleteTrack(id))
+            trackIds.map((id) => audiusBackendInstance.deleteTrack(userId, id))
           )
           console.debug('Deleted tracks.')
         } catch (err) {


### PR DESCRIPTION
### Description
A few calls in `AudiusBackend` were missed with the removal of UserStateManager and are failing to pass `userId`. This will fix it for now until we move those code paths over to SDK.

### How Has This Been Tested?
Local client against staging.
