### PR TITLE
[QA-1822] Only extend playlists at the api level

### DIFF
--- a/packages/discovery-provider/src/api/v1/playlists.py
+++ b/packages/discovery-provider/src/api/v1/playlists.py
@@ -637,6 +637,7 @@ class FullTrendingPlaylists(Resource):
             TrendingType.PLAYLISTS, version_list[0]
         )
         playlists = get_full_trending_playlists(request, args, strategy)
+        playlists = list(map(extend_playlist, playlists))
         return success_response(playlists)
 
 

--- a/packages/discovery-provider/src/queries/get_top_playlists_es.py
+++ b/packages/discovery-provider/src/queries/get_top_playlists_es.py
@@ -1,6 +1,5 @@
 import time
 
-from src.api.v1.helpers import extend_playlist
 from src.queries.query_helpers import filter_playlists_with_only_hidden_tracks
 from src.utils.db_session import get_db_read_replica
 from src.utils.elasticdsl import (
@@ -101,6 +100,5 @@ def get_top_playlists_es(kind, args):
         u = user_by_id[str(p["playlist_owner_id"])]
         # omit current_user because top playlists are cached across users
         p["user"] = populate_user_metadata_es(u, None)
-        extend_playlist(p)
 
     return playlists

--- a/packages/discovery-provider/src/queries/get_trending_playlists.py
+++ b/packages/discovery-provider/src/queries/get_trending_playlists.py
@@ -8,13 +8,7 @@ from sqlalchemy.orm.session import Session
 from sqlalchemy.sql.functions import GenericFunction
 from sqlalchemy.sql.type_api import TypeEngine
 
-from src.api.v1.helpers import (
-    extend_playlist,
-    extend_track,
-    format_limit,
-    format_offset,
-    to_dict,
-)
+from src.api.v1.helpers import extend_track, format_limit, format_offset, to_dict
 from src.models.playlists.aggregate_playlist import AggregatePlaylist
 from src.models.playlists.playlist import Playlist
 from src.models.social.repost import RepostType
@@ -362,9 +356,6 @@ def _get_trending_playlists_with_session(
         user = users[playlist["playlist_owner_id"]]
         if user:
             playlist["user"] = user
-
-    # Extend the playlists
-    playlists = list(map(extend_playlist, playlists))
     return sorted_playlists
 
 


### PR DESCRIPTION
When calling extend playlist at the API level for top albums, we are doing it _twice_ since the query level already did so.