### PR TITLE
[C-5391] Add session replay to sentry

### DIFF
--- a/packages/web/src/services/sentry.ts
+++ b/packages/web/src/services/sentry.ts
@@ -30,7 +30,12 @@ export const initializeSentry = () => {
       // Catch failed network requests
       Sentry.httpClientIntegration(),
       // Capture console.errors in sentry
-      Sentry.captureConsoleIntegration({ levels: ['error'] })
+      Sentry.captureConsoleIntegration({ levels: ['error'] }),
+      // Capture a session recording
+      Sentry.replayIntegration({
+        maskAllText: false,
+        blockAllMedia: false
+      })
     ],
 
     normalizeDepth: 5,
@@ -54,6 +59,12 @@ export const initializeSentry = () => {
         }
       }
       return breadCrumb
-    }
+    },
+    // This sets the sample rate to be 10%. You may want this to be 100% while
+    // in development and sample at a lower rate in production
+    replaysSessionSampleRate: 0.1,
+    // If the entire session is not sampled, use the below sample rate to sample
+    // sessions when an error occurs.
+    replaysOnErrorSampleRate: 1.0
   })
 }

--- a/packages/web/src/services/sentry.ts
+++ b/packages/web/src/services/sentry.ts
@@ -32,10 +32,7 @@ export const initializeSentry = () => {
       // Capture console.errors in sentry
       Sentry.captureConsoleIntegration({ levels: ['error'] }),
       // Capture a session recording
-      Sentry.replayIntegration({
-        maskAllText: false,
-        blockAllMedia: false
-      })
+      Sentry.replayIntegration({})
     ],
 
     normalizeDepth: 5,
@@ -60,11 +57,9 @@ export const initializeSentry = () => {
       }
       return breadCrumb
     },
-    // This sets the sample rate to be 10%. You may want this to be 100% while
-    // in development and sample at a lower rate in production
-    replaysSessionSampleRate: 0.1,
-    // If the entire session is not sampled, use the below sample rate to sample
-    // sessions when an error occurs.
+    // This is the sample rate for healthy sessions without errors - set to 0 since we only care about errors
+    replaysSessionSampleRate: 0,
+    // This is a sample rate specific to when errors occur. We want to see 100% of them
     replaysOnErrorSampleRate: 1.0
   })
 }


### PR DESCRIPTION
### Description

Enables session replay in sentry. 
Sets it to only work when errors are triggered - although with our code this is likely to still be a lot of users 💀 
May need tweaking if we hit our recording limits way too quickly

### How Has This Been Tested?

web:stage + got a replay to show up here: https://audius.sentry.io/replays/02e2450ddfe04f77b3d7698e3d337182/?referrer=%2Fissues%2F%3AgroupId%2Fevents%2F%3AeventId%2Freplays%2F&t=5.899700000047684&t_main=errors