### PR TITLE
Fix Profile page crash

### DIFF
--- a/packages/common/src/store/pages/profile/reducer.ts
+++ b/packages/common/src/store/pages/profile/reducer.ts
@@ -346,8 +346,7 @@ const reducer = (
   const { currentUser, entries } = state
 
   const profileHandle =
-    'handle' in action ? action.handle?.toLowerCase() : currentUser
-
+    ('handle' in action && action.handle?.toLowerCase()) ?? currentUser
   if (!profileHandle) return state
 
   let newEntry = entries[profileHandle] ?? initialProfileState

--- a/packages/common/src/store/pages/profile/reducer.ts
+++ b/packages/common/src/store/pages/profile/reducer.ts
@@ -346,7 +346,9 @@ const reducer = (
   const { currentUser, entries } = state
 
   const profileHandle =
-    ('handle' in action && action.handle?.toLowerCase()) ?? currentUser
+    'handle' in action
+      ? action.handle?.toLowerCase() ?? currentUser
+      : currentUser
   if (!profileHandle) return state
 
   let newEntry = entries[profileHandle] ?? initialProfileState


### PR DESCRIPTION
Profile pages were crashing due to the Lineup infinitely rendering. This is because the profileHandle was being set to undefined, since the `handle` key existed but was undefined on the action. This change fixes boolean logic introduced #10399 