### PR TITLE
Fix USDC user bank creation

### DIFF
--- a/.changeset/twelve-cycles-grow.md
+++ b/.changeset/twelve-cycles-grow.md
@@ -1,0 +1,5 @@
+---
+'@audius/sdk': patch
+---
+
+Fix getOrCreateUserBank failures due to low priority fees

--- a/packages/common/src/services/audius-backend/solana.ts
+++ b/packages/common/src/services/audius-backend/solana.ts
@@ -113,7 +113,6 @@ export const getTokenAccountInfo = async (
     commitment = 'processed'
   }: {
     tokenAccount: PublicKey
-    mint?: MintName
     commitment?: Commitment
   }
 ): Promise<Account | null> => {

--- a/packages/common/src/services/audius-backend/solana.ts
+++ b/packages/common/src/services/audius-backend/solana.ts
@@ -110,7 +110,6 @@ export const getTokenAccountInfo = async (
   audiusBackendInstance: AudiusBackend,
   {
     tokenAccount,
-    mint = DEFAULT_MINT,
     commitment = 'processed'
   }: {
     tokenAccount: PublicKey
@@ -120,11 +119,7 @@ export const getTokenAccountInfo = async (
 ): Promise<Account | null> => {
   return (
     await audiusBackendInstance.getAudiusLibs()
-  ).solanaWeb3Manager!.getTokenAccountInfo(
-    tokenAccount.toString(),
-    mint,
-    commitment
-  )
+  ).solanaWeb3Manager!.getTokenAccountInfo(tokenAccount.toString(), commitment)
 }
 
 export const deriveUserBankPubkey = async (

--- a/packages/common/src/store/buy-usdc/utils.ts
+++ b/packages/common/src/store/buy-usdc/utils.ts
@@ -19,8 +19,7 @@ const POLL_ACCOUNT_INFO_RETRIES = 30
 
 /**
  * Derives a USDC user bank for a given eth address, creating it if necessary.
- * Defaults to the wallet of the current user. Uses a channel to manage concurrent
- * requests so there is only one creation attempt in flight at a time.
+ * Defaults to the wallet of the current user.
  */
 export function* getOrCreateUSDCUserBank(ethAddress?: string) {
   const audiusSdk = yield* getContext('audiusSdk')


### PR DESCRIPTION
- Updates `getOrCreateUSDCUserBank` to use SDK
  - Prior, this was using libs and thus identity's relay, which doesn't have the same config for the RPCs and doesn't have the latest retry logic etc.
  - SDK's `ClaimableTokensClient` is a singleton, and its `getOrCreateUserBank` should be concurrency safe already, so no need for saga channels.
- Fixes an extraneous bug I found along the way where we were sending the mint name as the transaction commitment
- Fixes the SDK to use the default priority fee and add a compute budget limit when calling `getOrCreateUserBank` in the `ClaimableTokensClient`

Another bug I found is the funding of Solana relayers script is failing due to outdated `@solana/web3.js`. It was missed in the audit because its source is not on GitHub. I've funded the wallets and will publish a new repo for this script as well.