### PR TITLE
[PROTO-1979] Endpoint to generate an audio preview for a CID.

### DIFF
--- a/pkg/mediorum/server/db.go
+++ b/pkg/mediorum/server/db.go
@@ -87,10 +87,6 @@ const (
 	JobStatusBusy    = "busy"
 	JobStatusTimeout = "timeout"
 
-	JobStatusRetranscode      = "retranscode_preview"
-	JobStatusBusyRetranscode  = "busy_retranscode_preview"
-	JobStatusErrorRetranscode = "error_retranscode_preview"
-
 	JobStatusAudioAnalysis     = "audio_analysis"
 	JobStatusBusyAudioAnalysis = "busy_audio_analysis"
 

--- a/pkg/mediorum/server/db.go
+++ b/pkg/mediorum/server/db.go
@@ -58,6 +58,14 @@ type Upload struct {
 	// UpldateULID - this is the last ULID that change this thing
 }
 
+type AudioPreview struct {
+	CID                 string `json:"cid" gorm:"primaryKey;column:cid"`
+	SourceCID           string
+	PreviewStartSeconds string
+	CreatedBy           string    `json:"created_by" `
+	CreatedAt           time.Time `json:"created_at" gorm:"autoCreateTime:false"`
+}
+
 type AudioAnalysisResult struct {
 	BPM float64 `json:"bpm"`
 	Key string  `json:"key"`
@@ -135,13 +143,13 @@ func dbMustDial(dbPath string) *gorm.DB {
 func dbMigrate(crud *crudr.Crudr, myHost string) {
 	// Migrate the schema
 	slog.Info("db: gorm automigrate")
-	err := crud.DB.AutoMigrate(&Upload{}, &RepairTracker{}, &UploadCursor{}, &StorageAndDbSize{}, &DailyMetrics{}, &MonthlyMetrics{}, &QmAudioAnalysis{})
+	err := crud.DB.AutoMigrate(&Upload{}, &RepairTracker{}, &UploadCursor{}, &StorageAndDbSize{}, &DailyMetrics{}, &MonthlyMetrics{}, &QmAudioAnalysis{}, &AudioPreview{})
 	if err != nil {
 		panic(err)
 	}
 
 	// register any models to be managed by crudr
-	crud.RegisterModels(&Upload{}, &StorageAndDbSize{}, &QmAudioAnalysis{})
+	crud.RegisterModels(&Upload{}, &StorageAndDbSize{}, &QmAudioAnalysis{}, &AudioPreview{})
 
 	sqlDb, _ := crud.DB.DB()
 

--- a/pkg/mediorum/server/repair.go
+++ b/pkg/mediorum/server/repair.go
@@ -114,8 +114,7 @@ func (ss *MediorumServer) startRepairer() {
 		}
 		saveTracker()
 
-		// wait 10 minutes before running again
-		time.Sleep(time.Minute * 10)
+		time.Sleep(time.Hour)
 	}
 }
 

--- a/pkg/mediorum/server/repair.go
+++ b/pkg/mediorum/server/repair.go
@@ -56,8 +56,8 @@ func (ss *MediorumServer) startRepairer() {
 				// run the next job
 				tracker.CursorI = lastRun.CursorI + 1
 
-				// 50% of time run cleanup mode
-				if tracker.CursorI > 2 {
+				// every few runs, run cleanup mode
+				if tracker.CursorI > 4 {
 					tracker.CursorI = 1
 				}
 				tracker.CleanupMode = tracker.CursorI == 1

--- a/pkg/mediorum/server/serve_upload.go
+++ b/pkg/mediorum/server/serve_upload.go
@@ -7,6 +7,7 @@ import (
 	"mime/multipart"
 	"net/http"
 	"os"
+	"os/exec"
 	"strconv"
 	"strings"
 	"time"
@@ -58,6 +59,82 @@ func (ss *MediorumServer) serveUploadList(c echo.Context) error {
 
 type UpdateUploadBody struct {
 	PreviewStartSeconds string `json:"previewStartSeconds"`
+}
+
+// generatePreview endpoint will create a new 30s preview mp3
+// save the cid to the audio_previews table
+// and return to the client.
+func (ss *MediorumServer) generatePreview(c echo.Context) error {
+	ctx := c.Request().Context()
+	fileHash := c.Param("cid")
+
+	previewStartSeconds := c.Param("previewStartSeconds")
+
+	if !ss.haveInMyBucket(fileHash) {
+		_, err := ss.findAndPullBlob(ctx, fileHash)
+		if err != nil {
+			return err
+		}
+	}
+
+	// pull to temp file
+	temp, err := ss.getKeyToTempFile(fileHash)
+	if err != nil {
+		return err
+	}
+	defer os.Remove(temp.Name())
+
+	srcPath := temp.Name()
+	destPath := strings.TrimSuffix(srcPath, "_320.mp3") + "_320_preview.mp3"
+
+	// generate preview
+	cmd := exec.Command("ffmpeg",
+		"-y",
+		"-i", srcPath,
+		"-ss", previewStartSeconds, // set preview start time
+		"-t", audioPreviewDuration, // set preview duration
+		"-b:a", "320k", // set bitrate to 320k
+		"-ar", "48000", // set sample rate to 48000 Hz
+		"-f", "mp3", // force output to mp3
+		"-vn", // no video
+		destPath)
+
+	if err := cmd.Run(); err != nil {
+		return err
+	}
+
+	// replicate to peers
+	dest, err := os.Open(destPath)
+	if err != nil {
+		return err
+	}
+	defer dest.Close()
+	defer os.Remove(destPath)
+
+	previewCid, err := cidutil.ComputeFileCID(dest)
+	if err != nil {
+		return err
+	}
+
+	_, err = ss.replicateFileParallel(previewCid, destPath, nil)
+	if err != nil {
+		return err
+	}
+
+	// save preview cid to some previews table
+	audioPreview := &AudioPreview{
+		CID:                 previewCid,
+		SourceCID:           fileHash,
+		PreviewStartSeconds: previewStartSeconds,
+		CreatedBy:           ss.Config.Self.Host,
+		CreatedAt:           time.Now(),
+	}
+	err = ss.crud.Create(audioPreview)
+	if err != nil {
+		return err
+	}
+
+	return c.JSON(200, audioPreview)
 }
 
 func (ss *MediorumServer) updateUpload(c echo.Context) error {

--- a/pkg/mediorum/server/serve_upload_test.go
+++ b/pkg/mediorum/server/serve_upload_test.go
@@ -43,6 +43,16 @@ func TestUploadFile(t *testing.T) {
 	assert.Equal(t, u2.TranscodeProgress, 1.0)
 	assert.Len(t, u2.TranscodedMirrors, s1.Config.ReplicationFactor)
 
+	// test preview
+
+	{
+		var audioPreview AudioPreview
+		resp := s1.reqClient.R().
+			SetSuccessResult(&audioPreview).
+			MustPost(s1.Config.Self.Host + "/generate_preview/" + u2.TranscodeResults["320"] + "/1")
+		assert.Equal(t, resp.StatusCode, 200)
+		assert.Equal(t, "1", audioPreview.PreviewStartSeconds)
+	}
 }
 
 func TestUploadPlacement(t *testing.T) {

--- a/pkg/mediorum/server/server.go
+++ b/pkg/mediorum/server/server.go
@@ -314,6 +314,8 @@ func New(config MediorumConfig) (*MediorumServer, error) {
 		return c.NoContent(http.StatusNoContent)
 	})
 
+	routes.POST("/generate_preview/:cid/:previewStartSeconds", ss.generatePreview, ss.requireHealthy)
+
 	// legacy blob audio analysis
 	routes.GET("/tracks/legacy/:cid/analysis", ss.serveLegacyBlobAnalysis, ss.requireHealthy)
 

--- a/pkg/mediorum/server/transcode_preview.go
+++ b/pkg/mediorum/server/transcode_preview.go
@@ -1,0 +1,103 @@
+package server
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+
+	"github.com/AudiusProject/audius-protocol/pkg/mediorum/cidutil"
+)
+
+// generateAudioPreviewForUpload exists for the initial preview impl
+// which stored preview CID on the upload record itself.
+// This is still expected by client when creating + editing a preview.
+// When client is fully using generate_preview endpoint, this can probably go away.
+func (ss *MediorumServer) generateAudioPreviewForUpload(upload *Upload) error {
+	// if a start time is set, also transcode an audio preview from the full 320kbps downsample
+	if upload.SelectedPreview.Valid {
+		splitPreview := strings.Split(upload.SelectedPreview.String, "|")
+		previewStart := splitPreview[1]
+
+		audioPreview, err := ss.generateAudioPreview(context.Background(), upload.TranscodeResults["320"], previewStart)
+		if err != nil {
+			return err
+		}
+
+		upload.TranscodeResults[upload.SelectedPreview.String] = audioPreview.CID
+		return ss.crud.Update(upload)
+	}
+	return nil
+}
+
+// generateAudioPreview is the new preview impl which requires only a CID + previewStartSeconds, so that it works with Qm CIDs too.
+// It returns an AudioPreview record, and the client can use that to update a track record.
+func (ss *MediorumServer) generateAudioPreview(ctx context.Context, fileHash string, previewStartSeconds string) (*AudioPreview, error) {
+
+	if !ss.haveInMyBucket(fileHash) {
+		_, err := ss.findAndPullBlob(ctx, fileHash)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	// pull to temp file
+	temp, err := ss.getKeyToTempFile(fileHash)
+	if err != nil {
+		return nil, err
+	}
+	defer os.Remove(temp.Name())
+
+	srcPath := temp.Name()
+	destPath := strings.TrimSuffix(srcPath, "_320.mp3") + "_320_preview.mp3"
+
+	// generate preview
+	cmd := exec.Command("ffmpeg",
+		"-y",
+		"-i", srcPath,
+		"-ss", previewStartSeconds, // set preview start time
+		"-t", audioPreviewDuration, // set preview duration
+		"-b:a", "320k", // set bitrate to 320k
+		"-ar", "48000", // set sample rate to 48000 Hz
+		"-f", "mp3", // force output to mp3
+		"-vn", // no video
+		destPath)
+
+	if err := cmd.Run(); err != nil {
+		return nil, err
+	}
+
+	// replicate to peers
+	dest, err := os.Open(destPath)
+	if err != nil {
+		return nil, err
+	}
+	defer dest.Close()
+	defer os.Remove(destPath)
+
+	previewCid, err := cidutil.ComputeFileCID(dest)
+	if err != nil {
+		return nil, err
+	}
+
+	_, err = ss.replicateFileParallel(previewCid, destPath, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	// save preview cid to some previews table
+	audioPreview := &AudioPreview{
+		CID:                 previewCid,
+		SourceCID:           fileHash,
+		PreviewStartSeconds: previewStartSeconds,
+		CreatedBy:           ss.Config.Self.Host,
+		CreatedAt:           time.Now(),
+	}
+	err = ss.crud.Create(audioPreview)
+	if err != nil {
+		return nil, err
+	}
+
+	return audioPreview, nil
+}


### PR DESCRIPTION
### Description

```
POST /generate_preview/:cid/:second
```

Will generate 30s audio preview, replicate to peers, save a row in `audio_previews` table and return result to client.
Client should use `cid` from returned JSON.

