### PR TITLE
Fix track edit sdk issues

### DIFF
--- a/.changeset/polite-seahorses-sit.md
+++ b/.changeset/polite-seahorses-sit.md
@@ -1,0 +1,5 @@
+---
+'@audius/sdk': minor
+---
+
+Update track upload/update metadata schema to expect numeric ids in AccessConditions

--- a/packages/common/src/adapters/access.ts
+++ b/packages/common/src/adapters/access.ts
@@ -48,7 +48,7 @@ export const accessConditionsToSDK = (
 ): TrackMetadata['downloadConditions'] => {
   if (isContentFollowGated(input)) {
     return {
-      followUserId: Id.parse(input.follow_user_id)
+      followUserId: input.follow_user_id
     }
   } else if (isContentCollectibleGated(input)) {
     const collection = input.nft_collection as
@@ -61,7 +61,7 @@ export const accessConditionsToSDK = (
     }
   } else if (isContentTipGated(input)) {
     return {
-      tipUserId: Id.parse(input.tip_user_id)
+      tipUserId: input.tip_user_id
     }
   } else {
     throw new Error(

--- a/packages/common/src/adapters/access.ts
+++ b/packages/common/src/adapters/access.ts
@@ -13,7 +13,6 @@ import {
   AccessConditions,
   AccessConditionsEthNFTCollection,
   AccessConditionsSolNFTCollection,
-  Id,
   isContentCollectibleGated,
   isContentFollowGated,
   isContentTipGated,

--- a/packages/common/src/adapters/track.ts
+++ b/packages/common/src/adapters/track.ts
@@ -272,10 +272,10 @@ export const trackMetadataForUploadToSdk = (
     : undefined,
   downloadConditions: input.download_conditions
     ? accessConditionsToSDK(input.download_conditions)
-    : undefined,
+    : null,
   streamConditions: input.stream_conditions
     ? accessConditionsToSDK(input.stream_conditions)
-    : undefined,
+    : null,
   remixOf: input.remix_of
     ? {
         tracks: input.remix_of.tracks.map((track) => ({

--- a/packages/sdk/src/sdk/api/tracks/TracksApi.ts
+++ b/packages/sdk/src/sdk/api/tracks/TracksApi.ts
@@ -169,7 +169,15 @@ export class TracksApi extends GeneratedTracksApi {
       action: Action.CREATE,
       metadata: JSON.stringify({
         cid: '',
-        data: snakecaseKeys(updatedMetadata)
+        data: {
+          ...snakecaseKeys(updatedMetadata),
+          download_conditions:
+            updatedMetadata.downloadConditions &&
+            snakecaseKeys(updatedMetadata.downloadConditions),
+          stream_conditions:
+            updatedMetadata.streamConditions &&
+            snakecaseKeys(updatedMetadata.streamConditions)
+        }
       }),
       auth: this.auth,
       ...advancedOptions
@@ -264,7 +272,15 @@ export class TracksApi extends GeneratedTracksApi {
       action: Action.UPDATE,
       metadata: JSON.stringify({
         cid: '',
-        data: snakecaseKeys(updatedMetadata)
+        data: {
+          ...snakecaseKeys(updatedMetadata),
+          download_conditions:
+            updatedMetadata.downloadConditions &&
+            snakecaseKeys(updatedMetadata.downloadConditions),
+          stream_conditions:
+            updatedMetadata.streamConditions &&
+            snakecaseKeys(updatedMetadata.streamConditions)
+        }
       }),
       auth: this.auth,
       ...advancedOptions

--- a/packages/sdk/src/sdk/api/tracks/types.ts
+++ b/packages/sdk/src/sdk/api/tracks/types.ts
@@ -52,13 +52,13 @@ export const CollectibleGatedConditions = z
 
 export const FollowGatedConditions = z
   .object({
-    followUserId: HashId
+    followUserId: z.number()
   })
   .strict()
 
 export const TipGatedConditions = z
   .object({
-    tipUserId: HashId
+    tipUserId: z.number()
   })
   .strict()
 


### PR DESCRIPTION
### Description

* Fix unsetting stream_conditions and download_conditions by sending null instead of undefined
* Fix formatting of stream_conditions and download_conditions
  * update track upload/edit metadata schema AccessCondition ids to be numeric. This is because the api expects plain numbers instead of hash ids
  * transform streamConditions and downloadConditions objects to snake_case in sdk uploadTrack and updateTrack. This is to match the transformation happening on the read side
  * Change accessConditionsToSDK adapter to not parse number ids into hash ids

### How Has This Been Tested?

Tested setting and unsetting access conditions, including FollowGated and SupporterGated which include an id
