### PR TITLE
[QA-1827] Fix queuing short profile lineups issue

### DIFF
--- a/packages/web/src/common/store/queue/sagas.ts
+++ b/packages/web/src/common/store/queue/sagas.ts
@@ -45,8 +45,7 @@ const {
   getShuffle,
   getSource,
   getUid,
-  getUndershot,
-  getCurrentArtist
+  getUndershot
 } = queueSelectors
 
 const {
@@ -176,7 +175,14 @@ export function* watchPlay() {
       const isNearEndOfQueue = index + 3 >= length
 
       if (isNearEndOfQueue) {
-        yield* call(fetchLineupTracks)
+        /* Fetch more lineup tracks if available. Ideally, this would run async after we've started
+        playing the next track. But since we may skip the next track, we need the lineup and/or autoplay
+        logic to be run ahead of time.
+        Important note: Using the track we're being asked to play, as the lineup
+        source may be changing with that track, and we don't want to look up a lineup
+        using the "currentTrack" in the player.
+        */
+        yield* call(fetchLineupTracks, playActionTrack)
       }
 
       yield* call(handleQueueAutoplay, {
@@ -287,15 +293,18 @@ export function* watchPlay() {
 
 // Fetches more lineup tracks if available. This is needed for cases
 // where the user hasn't scrolled through the lineup.
-function* fetchLineupTracks() {
+function* fetchLineupTracks(currentTrack: Track) {
   const source = yield* select(getSource)
   if (!source) return
 
   const lineupEntry = lineupRegistry[source]
   if (!lineupEntry) return
 
-  const currentArtist = yield* select(getCurrentArtist)
-  const lineup = yield* select(lineupEntry.selector, currentArtist?.handle)
+  const currentTrackOwner = yield* select(getUser, {
+    id: currentTrack.owner_id
+  })
+
+  const lineup = yield* select(lineupEntry.selector, currentTrackOwner?.handle)
 
   if (lineup.hasMore) {
     const offset = lineup.entries.length + lineup.deleted + lineup.nullCount


### PR DESCRIPTION
### Description
This is a fun one. The behavior exhibited is:
1. Start playing a track (from the feed is a good source)
2. Navigate to a profile with less than 3 tracks on it. Or scroll through the tracks in the profile until you've loaded the entire lineup for said profile.
3. Play a track from the profile that's less than 3 items from the end of the list
4. Watch the track feed disappear.

What's actually happening to cause this:
We have some logic in the queue saga that checks if the queue has less than 3 items in it. If so, and we're currently playing from a lineup source, it will trigger a fetch on that lineup to further populate the queue. But it uses the artist of the currently playing track as input to the lineup selector. For a profile lineup selector, that's only valid if the currently playing track is a track from said profile. But due to where this logic lives, the "current track" will be likely from a different artist than the profile lineup we just queued. If that's confusing, here's the order of operations that was happening:

1. Hit play on feed, queuing state gets set to the feed lineup with all the items in it. We start playing whatever item you selected. (Purposely skipping a bunch of substeps here)
2. Hit play on an item from any profile other than the artist currently playing
3. The Profile lineup saga will clear the queue, then insert the item any fetched items after that item in the profile lineup. Then it calls `play()` to tell the queue saga to play the item you just selected.
4. The queue saga runs, checks the current queue to see if we're close to the end (always true for a 1 item profile lineup), calls `fetchLineupTracks` to make sure that we get any additional lineup items that may not have been fetched yet.
5. `fetchLineupTracks` reads the current `source` from the queue (which is now the profile lineup items), then attempts to get the lineup entry for that source (which again is a _profile_ lineup now), then reads the `currentArtist` from the player state and attempts to look up the profile saga state for that artist.
6. `fetchLineupTracks` calls into the profile saga for that "current artist" to get more items, not the profile saga for the artist owning the track you just started playing from the profile page. Since the profile lineup for the "current" artist in the player was likely never fetched (unless you visited their profile already), it's going to be in an IDLE state, with no `handle` set. And that's going to cause things to blow up.
7. If you do not pass a `handle` to profile/profile lineup sagas, it defaults to using the `currentUser`, which is the user whose profile you currently have open (or maybe last browsed to? I don't think we clear it on unmount). So when the fetch begins, we clear the current user profile lineup. And when it fails, we obviously are left with no tracks in the current user profile lineup.


There's a lot going on here, and it's pretty messy. And lineups need to die.
For right now, I _think_ using the handle for the user whose track you are attempting to play is a better strategy for checking the lineup then the user whose track is currently in the player.

I'm open to suggestions here, because I don't have a complete understanding of all the ways we end up in queue sagas.


### How Has This Been Tested?
Tested manually in local client against staging. Not sure if I exercised all the possible flows.