### PR TITLE
Fix bad useEffects calls in PremiumContentPurchaseDrawer

### DIFF
--- a/packages/mobile/src/components/premium-content-purchase-drawer/PremiumContentPurchaseDrawer.tsx
+++ b/packages/mobile/src/components/premium-content-purchase-drawer/PremiumContentPurchaseDrawer.tsx
@@ -255,10 +255,14 @@ const RenderForm = ({
 
   const { submitForm, resetForm } = useFormikContext()
 
-  useEffect(() => resetForm, [contentId, resetForm])
+  useEffect(() => {
+    resetForm()
+  }, [contentId, resetForm])
 
   // Pre-create user bank if needed so it's ready by purchase time
-  useEffect(() => dispatch(eagerCreateUserBank()), [dispatch])
+  useEffect(() => {
+    dispatch(eagerCreateUserBank())
+  }, [dispatch])
 
   const {
     usdc_purchase: { price }

--- a/packages/web/src/components/premium-content-purchase-modal/PremiumContentPurchaseModal.tsx
+++ b/packages/web/src/components/premium-content-purchase-modal/PremiumContentPurchaseModal.tsx
@@ -114,7 +114,9 @@ const RenderForm = ({
   const { history } = useHistoryContext()
 
   // Reset form on track change
-  useEffect(() => resetForm, [contentId, resetForm])
+  useEffect(() => {
+    resetForm()
+  }, [contentId, resetForm])
 
   // Navigate to track on successful purchase behind the modal
   useEffect(() => {


### PR DESCRIPTION
### Description
I'm not sure how this even worked before. But I suspect what was happening is:
* The intended usage of useEffect is that if you return a function, it will be invoked when the component unmounts. 
* We're returning the `resetForm` function from one of them. I believe the intended usage was to _call_ that function inside the effect when the form changes. But what actually happens is that it's called after the form unmounts. And I believe this is referencing something in Formik Context that no longer exists.

We also had another `useEffect` call in this component that was throwing warnings about returning objects, so I wrapped it in braces so we are no longer returning the result of `dispatch`.

### How Has This Been Tested?
Tested on simulator against staging.
