### PR TITLE
Remove SOLANA_LISTEN_ENABLED feature flag

### DIFF
--- a/packages/common/src/services/audius-backend/AudiusBackend.ts
+++ b/packages/common/src/services/audius-backend/AudiusBackend.ts
@@ -834,7 +834,7 @@ export const audiusBackend = ({
         trackId,
         unauthenticatedUuid,
         userId,
-        await getFeatureEnabled(FeatureFlags.SOLANA_LISTEN_ENABLED)
+        true
       )
       return listen
     } catch (err) {

--- a/packages/common/src/services/remote-config/feature-flags.ts
+++ b/packages/common/src/services/remote-config/feature-flags.ts
@@ -2,7 +2,6 @@ import { Environment } from '../env'
 
 /* FeatureFlags must be lowercase snake case */
 export enum FeatureFlags {
-  SOLANA_LISTEN_ENABLED = 'solana_listen_enabled',
   SURFACE_AUDIO_ENABLED = 'surface_audio_enabled',
   PREFER_HIGHER_PATCH_FOR_PRIMARY = 'prefer_higher_patch_for_primary',
   PREFER_HIGHER_PATCH_FOR_SECONDARIES = 'prefer_higher_patch_for_secondaries',
@@ -77,7 +76,6 @@ export const environmentFlagDefaults: Record<
  * If optimizely errors, these default values are used.
  */
 export const flagDefaults: FlagDefaults = {
-  [FeatureFlags.SOLANA_LISTEN_ENABLED]: false,
   [FeatureFlags.SURFACE_AUDIO_ENABLED]: false,
   [FeatureFlags.PREFER_HIGHER_PATCH_FOR_PRIMARY]: true,
   [FeatureFlags.PREFER_HIGHER_PATCH_FOR_SECONDARIES]: true,

--- a/packages/identity-service/src/featureFlag.js
+++ b/packages/identity-service/src/featureFlag.js
@@ -2,7 +2,6 @@ const uuidv4 = require('uuid/v4')
 
 // Declaration of feature flags set in optimizely
 const FEATURE_FLAGS = Object.freeze({
-  SOLANA_LISTEN_ENABLED_SERVER: 'solana_listen_enabled_server',
   SOLANA_SEND_RAW_TRANSACTION: 'solana_send_raw_transaction',
   REWARDS_ATTESTATION_ENABLED: 'rewards_attestation_enabled',
   REWARDS_NOTIFICATIONS_ENABLED: 'rewards_notifications_enabled',
@@ -21,7 +20,6 @@ const FEATURE_FLAGS = Object.freeze({
 // Generally, these should be never seen unless variables are
 // consumed within a few seconds of server init
 const DEFAULTS = Object.freeze({
-  [FEATURE_FLAGS.SOLANA_LISTEN_ENABLED_SERVER]: false,
   [FEATURE_FLAGS.SOLANA_SEND_RAW_TRANSACTION]: false,
   [FEATURE_FLAGS.REWARDS_ATTESTATION_ENABLED]: false,
   [FEATURE_FLAGS.REWARDS_NOTIFICATIONS_ENABLED]: false,


### PR DESCRIPTION
### Description
Feature flag cleanup.

### How Has This Been Tested?

The flag appears to be on in optimizely: 
<img width="947" alt="Screenshot 2024-11-19 at 12 12 30 AM" src="https://github.com/user-attachments/assets/7760c0a7-fddd-4412-b91b-f18bb3f4fdcc">
