### PR TITLE
[QA-1840] Fix Offline Mode errors

### DIFF
--- a/packages/mobile/src/store/offline-downloads/sagas/offlineQueueSagas/workers/downloadTrackWorker.ts
+++ b/packages/mobile/src/store/offline-downloads/sagas/offlineQueueSagas/workers/downloadTrackWorker.ts
@@ -178,7 +178,7 @@ function* downloadTrackAudio(track: UserTrackMetadata, userId: ID) {
   queryParams.filename = `${title}.mp3`
 
   const trackAudioUri = apiClient.makeUrl(
-    `/tracks/${encodedTrackId}/download`,
+    `/tracks/${encodedTrackId}/stream`,
     queryParams
   )
   const response = yield* call(downloadFile, trackAudioUri, trackFilePath)

--- a/packages/web/src/common/store/queue/sagas.ts
+++ b/packages/web/src/common/store/queue/sagas.ts
@@ -1,3 +1,5 @@
+import { error } from 'console'
+
 import {
   Kind,
   ID,
@@ -11,6 +13,7 @@ import {
   UserTrackMetadata,
   LineupEntry
 } from '@audius/common/models'
+import { getIsReachable } from '@audius/common/src/store/reachability/selectors'
 import {
   accountSelectors,
   cacheCollectionsSelectors,
@@ -411,6 +414,8 @@ export function* watchQueueAutoplay() {
     queueAutoplay.type,
     function* (action: ReturnType<typeof queueAutoplay>) {
       const { genre, exclusionList, currentUserId } = action.payload
+      const isReachable = yield* select(getIsReachable)
+      if (!isReachable) return
       const tracks: UserTrackMetadata[] = yield* call(
         getRecommendedTracks,
         genre,

--- a/packages/web/src/common/store/queue/sagas.ts
+++ b/packages/web/src/common/store/queue/sagas.ts
@@ -1,5 +1,3 @@
-import { error } from 'console'
-
 import {
   Kind,
   ID,

--- a/packages/web/src/common/store/queue/sagas.ts
+++ b/packages/web/src/common/store/queue/sagas.ts
@@ -11,7 +11,6 @@ import {
   UserTrackMetadata,
   LineupEntry
 } from '@audius/common/models'
-import { getIsReachable } from '@audius/common/src/store/reachability/selectors'
 import {
   accountSelectors,
   cacheCollectionsSelectors,
@@ -22,6 +21,7 @@ import {
   lineupRegistry,
   queueActions,
   queueSelectors,
+  reachabilitySelectors,
   RepeatMode,
   QueueSource,
   getContext,
@@ -61,7 +61,8 @@ const { getId } = cacheSelectors
 const { getUser } = cacheUsersSelectors
 const { getTrack } = cacheTracksSelectors
 const { getCollection } = cacheCollectionsSelectors
-const getUserId = accountSelectors.getUserId
+const { getUserId } = accountSelectors
+const { getIsReachable } = reachabilitySelectors
 
 const QUEUE_SUBSCRIBER_NAME = 'QUEUE'
 


### PR DESCRIPTION
### Description

Fixes two issues with offline mode:
- Tracks were not downloading in offline mode unless marked available for download by the artist. Fix is to use the `/stream` endpoint instead for fetching the offline audio.
- Offline lineups were showing an error toast on track play near end of playlist because we were failing to fetch recommended autoplay tracks. Disabled this behavior while offline.

According to the charts, these errors spiked starting Nov 5th, around the time we shipped changes to the stream endpoint mirroring. Unsure the full root cause, but could be related?

### How Has This Been Tested?

tested on ios sim and android device