### PR TITLE
[C-5404] Add FileReplaceContainer component to web

### DIFF
--- a/packages/web/src/components/file-replace-container/FileReplaceContainer.tsx
+++ b/packages/web/src/components/file-replace-container/FileReplaceContainer.tsx
@@ -1,0 +1,58 @@
+import {
+  IconPlay,
+  IconPause,
+  PlainButton,
+  Flex,
+  Button,
+  IconArrowUpToLine,
+  IconReceive
+} from '@audius/harmony'
+
+type FileReplaceContainerProps = {
+  fileName: string
+  downloadEnabled?: boolean
+  isPlaying?: boolean
+  onTogglePlay?: () => void
+  onClickReplace?: () => void
+  onClickDownload?: () => void
+}
+
+export const FileReplaceContainer = ({
+  fileName,
+  downloadEnabled,
+  isPlaying,
+  onTogglePlay,
+  onClickReplace,
+  onClickDownload
+}: FileReplaceContainerProps) => {
+  return (
+    <Flex justifyContent='space-between' alignItems='center' gap='l'>
+      <PlainButton
+        iconLeft={isPlaying ? IconPause : IconPlay}
+        onClick={onTogglePlay}
+      >
+        {fileName}
+      </PlainButton>
+      <Flex gap='s'>
+        <Button
+          variant='secondary'
+          size='small'
+          iconLeft={IconArrowUpToLine}
+          onClick={onClickReplace}
+        >
+          Replace
+        </Button>
+        {downloadEnabled ? (
+          <Button
+            variant='secondary'
+            size='small'
+            iconLeft={IconReceive}
+            onClick={onClickDownload}
+          >
+            Download
+          </Button>
+        ) : null}
+      </Flex>
+    </Flex>
+  )
+}

--- a/packages/web/src/components/file-replace-container/FileReplaceContainer.tsx
+++ b/packages/web/src/components/file-replace-container/FileReplaceContainer.tsx
@@ -8,6 +8,11 @@ import {
   IconReceive
 } from '@audius/harmony'
 
+const messages = {
+  replace: 'Replace',
+  download: 'Download'
+}
+
 type FileReplaceContainerProps = {
   fileName: string
   downloadEnabled?: boolean
@@ -40,7 +45,7 @@ export const FileReplaceContainer = ({
           iconLeft={IconArrowUpToLine}
           onClick={onClickReplace}
         >
-          Replace
+          {messages.replace}
         </Button>
         {downloadEnabled ? (
           <Button
@@ -49,7 +54,7 @@ export const FileReplaceContainer = ({
             iconLeft={IconReceive}
             onClick={onClickDownload}
           >
-            Download
+            {messages.download}
           </Button>
         ) : null}
       </Flex>


### PR DESCRIPTION
### Description
Added the component for use later

Went with a more simple display component that does not handle the playing or downloading of the track file bc the use in the different contexts around the app would make this a bit complex, but I'm willing to change this if we feel that the logic would be better here
