### PR TITLE
Cache trending premium tracks for explore

### DIFF
--- a/packages/discovery-provider/src/queries/get_premium_tracks.py
+++ b/packages/discovery-provider/src/queries/get_premium_tracks.py
@@ -32,14 +32,11 @@ def get_usdc_purchase_tracks(args, strategy):
         key = make_trending_tracks_cache_key(time_range, genre, strategy.version)
         key += ":usdc_purchase_only"
 
-        # The index_trending task runs every 10 seconds, so we set the TTL to 10 seconds
-        ttl_sec = 10
-
         # Will try to hit cached trending from task, falling back
         # to generating it here if necessary and storing it with no TTL
         (tracks, track_ids) = use_redis_cache(
             key,
-            ttl_sec,
+            None,
             make_generate_unpopulated_trending(
                 session=session,
                 genre=genre,

--- a/packages/discovery-provider/src/tasks/index_trending.py
+++ b/packages/discovery-provider/src/tasks/index_trending.py
@@ -123,6 +123,24 @@ def index_trending(self, db: SessionManager, redis: Redis, timestamp):
                         f"index_trending.py | Cached trending ({version.name} version) \
                         for {genre}-{time_range} in {total_time} seconds"
                     )
+            # Cache premium tracks
+            cache_start_time = time.time()
+            res = generate_unpopulated_trending_from_mat_views(
+                session=session,
+                genre=genre,
+                time_range="week",
+                strategy=strategy,
+                usdc_purchase_only=True,
+            )
+            key = make_trending_tracks_cache_key("week", None, strategy.version)
+            key += ":usdc_purchase_only"
+            set_json_cached_key(redis, key, res)
+            cache_end_time = time.time()
+            total_time = cache_end_time - cache_start_time
+            logger.debug(
+                f"index_trending.py | Cached premium tracks ({version.name} version) \
+                -in {total_time} seconds"
+            )
 
         # Cache underground trending
         underground_trending_versions = trending_strategy_factory.get_versions_for_type(


### PR DESCRIPTION
### Description

Querying for trending premium tracks for explore is really slow. This is probably because of the short 10 sec TTL on the cache. By moving the caching to the async indexing jo, we can leave the TTL to not expire so it's always fetching from cache like we do for trending.

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._

Ran on sandbox. Confirmed indexing saved to redis cache and queries are faster. 