### PR TITLE
Fix libpq version dependency

### DIFF
--- a/packages/discovery-provider/Dockerfile.prod
+++ b/packages/discovery-provider/Dockerfile.prod
@@ -51,14 +51,13 @@ RUN curl -O 'http://openresty.org/package/admin@openresty.com-5ea678a6.rsa.pub' 
   opm get bsiara/dkjson && \
   mkdir /usr/local/openresty/conf /usr/local/openresty/logs
 
-RUN echo 'http://dl-cdn.alpinelinux.org/alpine/v3.10/main' >> /etc/apk/repositories && \
-  apk update && \
+RUN apk update && \
   apk add \
-  libpq=15.8-r0 \
-  postgresql15-client=15.8-r0 \
-  postgresql15-contrib=15.8-r0 \
-  postgresql15-dev=15.8-r0 \
-  postgresql15=15.8-r0
+  libpq \
+  postgresql15-client \
+  postgresql15-contrib \
+  postgresql15-dev \
+  postgresql15
 
 RUN python3 -m pip install --upgrade pip
 


### PR DESCRIPTION
### Description
Breaking integration test 
```
5.881 OK: 25849 distinct packages available
6.758 ERROR: unable to select packages:
6.761   libpq-15.9-r0:
6.761     breaks: world[libpq=15.8-r0]
6.761     satisfies: libpq-dev-15.9-r0[libpq=15.9-r0]
6.761                postgresql15-15.9-r0[so:libpq.so.5]
6.761                postgresql15-client-15.9-r0[so:libpq.so.5]
6.761                postgresql15-dev-15.9-r0[so:libpq.so.5]
6.761                postgresql15-contrib-15.9-r0[so:libpq.so.5]
6.761                libecpg-15.9-r0[so:libpq.so.5]
```
### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._
