### PR TITLE
Remove PREFER_HIGHER_PATCH_FOR_PRIMARY/SECONDARIES feature flags

### DIFF
--- a/packages/common/src/services/audius-backend/AudiusBackend.ts
+++ b/packages/common/src/services/audius-backend/AudiusBackend.ts
@@ -605,12 +605,8 @@ export const audiusBackend = ({
         // i.e. there is no way to instruct captcha that the domain is "file://"
         captchaConfig: isElectron ? undefined : { siteKey: recaptchaSiteKey },
         isServer: false,
-        preferHigherPatchForPrimary: await getFeatureEnabled(
-          FeatureFlags.PREFER_HIGHER_PATCH_FOR_PRIMARY
-        ),
-        preferHigherPatchForSecondaries: await getFeatureEnabled(
-          FeatureFlags.PREFER_HIGHER_PATCH_FOR_SECONDARIES
-        ),
+        preferHigherPatchForPrimary: true,
+        preferHigherPatchForSecondaries: false,
         hedgehogConfig,
         userId,
         wallet

--- a/packages/common/src/services/remote-config/feature-flags.ts
+++ b/packages/common/src/services/remote-config/feature-flags.ts
@@ -3,7 +3,6 @@ import { Environment } from '../env'
 /* FeatureFlags must be lowercase snake case */
 export enum FeatureFlags {
   SURFACE_AUDIO_ENABLED = 'surface_audio_enabled',
-  PREFER_HIGHER_PATCH_FOR_PRIMARY = 'prefer_higher_patch_for_primary',
   PREFER_HIGHER_PATCH_FOR_SECONDARIES = 'prefer_higher_patch_for_secondaries',
   DISABLE_SIGN_UP_CONFIRMATION = 'disable_sign_up_confirmation',
   NEW_ARTIST_DASHBOARD_TABLE = 'new_artist_dashboard_table',
@@ -72,7 +71,6 @@ export const environmentFlagDefaults: Record<
  */
 export const flagDefaults: FlagDefaults = {
   [FeatureFlags.SURFACE_AUDIO_ENABLED]: false,
-  [FeatureFlags.PREFER_HIGHER_PATCH_FOR_PRIMARY]: true,
   [FeatureFlags.PREFER_HIGHER_PATCH_FOR_SECONDARIES]: true,
   [FeatureFlags.DISABLE_SIGN_UP_CONFIRMATION]: false,
   [FeatureFlags.NEW_ARTIST_DASHBOARD_TABLE]: false,


### PR DESCRIPTION
### Description
Feature flag cleanup

### How Has This Been Tested?
The primary one was turned on but the secondary one was turned off? not sure if it matters


<img width="955" alt="Screenshot 2024-11-19 at 8 37 24 PM" src="https://github.com/user-attachments/assets/c7483dff-cde0-437a-8357-585fb20fc9e7">
<img width="980" alt="Screenshot 2024-11-19 at 8 37 39 PM" src="https://github.com/user-attachments/assets/fa279d67-5235-4c58-8d61-7dc9f009c4f4">
