### PR TITLE
[PAY-3604] Add migration for emails

### DIFF
--- a/packages/discovery-provider/ddl/migrations/0107_add_email_tables.sql
+++ b/packages/discovery-provider/ddl/migrations/0107_add_email_tables.sql
@@ -5,7 +5,6 @@ CREATE TABLE IF NOT EXISTS encrypted_emails (
     id SERIAL PRIMARY KEY, 
     email_address_owner_user_id INTEGER NOT NULL,
     primary_access_user_id INTEGER NOT NULL,
-    delegated_access_user_id INTEGER NOT NULL,
     encrypted_email TEXT NOT NULL,  -- base64 encoded
     created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
     updated_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP
@@ -14,7 +13,6 @@ CREATE TABLE IF NOT EXISTS encrypted_emails (
 COMMENT ON TABLE encrypted_emails IS 'Stores encrypted emails and their metadata for secure communication between users';
 COMMENT ON COLUMN encrypted_emails.email_address_owner_user_id IS 'User ID of the person who owns the actual email address';
 COMMENT ON COLUMN encrypted_emails.primary_access_user_id IS 'User ID of the person who has full control over the encrypted email';
-COMMENT ON COLUMN encrypted_emails.delegated_access_user_id IS 'User ID of the person who has been granted revocable access to view the email';
 COMMENT ON COLUMN encrypted_emails.encrypted_email IS 'Base64 encoded encrypted email content';
 
 -- Store the encryption keys for primary access holders
@@ -48,7 +46,6 @@ COMMENT ON COLUMN email_access_keys.delegated_access_user_id IS 'User ID of the 
 COMMENT ON COLUMN email_access_keys.encrypted_key IS 'Base64 encoded encryption key for the delegated access holder';
 
 -- Add indexes for performance
-CREATE INDEX IF NOT EXISTS idx_encrypted_emails_delegated_access_user_id ON encrypted_emails(delegated_access_user_id);
 CREATE INDEX IF NOT EXISTS idx_encrypted_emails_primary_access_user_id ON encrypted_emails(primary_access_user_id);
 CREATE INDEX IF NOT EXISTS idx_encrypted_emails_email_address_owner_user_id ON encrypted_emails(email_address_owner_user_id);
 

--- a/packages/discovery-provider/ddl/migrations/0107_add_email_tables.sql
+++ b/packages/discovery-provider/ddl/migrations/0107_add_email_tables.sql
@@ -3,8 +3,8 @@ begin;
 -- Store encrypted emails with their metadata
 CREATE TABLE IF NOT EXISTS encrypted_emails (
     id SERIAL PRIMARY KEY, 
-    email_address_owner_user_id INTEGER NOT NULL,
-    primary_access_user_id INTEGER NOT NULL,
+    email_address_owner_user_id INTEGER NOT NULL REFERENCES users(user_id) ON DELETE CASCADE,
+    primary_user_id INTEGER NOT NULL REFERENCES users(user_id) ON DELETE CASCADE,
     encrypted_email TEXT NOT NULL,  -- base64 encoded
     created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
     updated_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP
@@ -12,42 +12,42 @@ CREATE TABLE IF NOT EXISTS encrypted_emails (
 
 COMMENT ON TABLE encrypted_emails IS 'Stores encrypted emails and their metadata for secure communication between users';
 COMMENT ON COLUMN encrypted_emails.email_address_owner_user_id IS 'User ID of the person who owns the actual email address';
-COMMENT ON COLUMN encrypted_emails.primary_access_user_id IS 'User ID of the person who has full control over the encrypted email';
+COMMENT ON COLUMN encrypted_emails.primary_user_id IS 'User ID of the person who has full control over the encrypted email';
 COMMENT ON COLUMN encrypted_emails.encrypted_email IS 'Base64 encoded encrypted email content';
 
 -- Store the encryption keys for primary access holders
 CREATE TABLE IF NOT EXISTS email_encryption_keys (
     id SERIAL PRIMARY KEY,
-    primary_access_user_id INTEGER NOT NULL,
+    primary_user_id INTEGER NOT NULL REFERENCES users(user_id) ON DELETE CASCADE,
     encrypted_key TEXT NOT NULL,  -- base64 encoded
     created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
     updated_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
-    UNIQUE(primary_access_user_id)  -- one key per primary access holder
+    UNIQUE(primary_user_id)  -- one key per primary access holder
 );
 
 COMMENT ON TABLE email_encryption_keys IS 'Stores encryption keys for users with primary access to manage encrypted emails';
-COMMENT ON COLUMN email_encryption_keys.primary_access_user_id IS 'User ID of the person with primary access';
+COMMENT ON COLUMN email_encryption_keys.primary_user_id IS 'User ID of the person with primary access';
 COMMENT ON COLUMN email_encryption_keys.encrypted_key IS 'Base64 encoded encryption key for the primary access holder';
 
 -- Store the encrypted keys for delegated access
 CREATE TABLE IF NOT EXISTS email_access_keys (
     id SERIAL PRIMARY KEY,
-    primary_access_user_id INTEGER NOT NULL,
-    delegated_access_user_id INTEGER NOT NULL,
+    primary_user_id INTEGER NOT NULL REFERENCES users(user_id) ON DELETE CASCADE,
+    delegated_user_id INTEGER NOT NULL REFERENCES users(user_id) ON DELETE CASCADE,
     encrypted_key TEXT NOT NULL,  -- base64 encoded
     created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
     updated_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
-    UNIQUE(primary_access_user_id, delegated_access_user_id)  -- one key per primary-delegated pair
+    UNIQUE(primary_user_id, delegated_user_id)  -- one key per primary-delegated pair
 );
 
 COMMENT ON TABLE email_access_keys IS 'Stores encrypted keys for users with delegated access to view emails';
-COMMENT ON COLUMN email_access_keys.primary_access_user_id IS 'User ID of the person who granted access';
-COMMENT ON COLUMN email_access_keys.delegated_access_user_id IS 'User ID of the person who received delegated access';
+COMMENT ON COLUMN email_access_keys.primary_user_id IS 'User ID of the person who granted access';
+COMMENT ON COLUMN email_access_keys.delegated_user_id IS 'User ID of the person who received delegated access';
 COMMENT ON COLUMN email_access_keys.encrypted_key IS 'Base64 encoded encryption key for the delegated access holder';
 
 -- Add indexes for performance
-CREATE INDEX IF NOT EXISTS idx_encrypted_emails_primary_access_user_id ON encrypted_emails(primary_access_user_id);
+CREATE INDEX IF NOT EXISTS idx_encrypted_emails_primary_user_id ON encrypted_emails(primary_user_id);
 CREATE INDEX IF NOT EXISTS idx_encrypted_emails_email_address_owner_user_id ON encrypted_emails(email_address_owner_user_id);
-CREATE INDEX IF NOT EXISTS idx_email_access_keys_delegated_access_user_id ON email_access_keys(delegated_access_user_id);
+CREATE INDEX IF NOT EXISTS idx_email_access_keys_delegated_user_id ON email_access_keys(delegated_user_id);
 
 commit;

--- a/packages/discovery-provider/ddl/migrations/0107_add_email_tables.sql
+++ b/packages/discovery-provider/ddl/migrations/0107_add_email_tables.sql
@@ -3,15 +3,16 @@ begin;
 -- Store encrypted emails with their metadata
 CREATE TABLE IF NOT EXISTS encrypted_emails (
     id SERIAL PRIMARY KEY, 
-    email_address_owner_user_id INTEGER NOT NULL REFERENCES users(user_id) ON DELETE CASCADE,
+    email_owner_user_id INTEGER NOT NULL REFERENCES users(user_id) ON DELETE CASCADE,
     primary_user_id INTEGER NOT NULL REFERENCES users(user_id) ON DELETE CASCADE,
     encrypted_email TEXT NOT NULL,  -- base64 encoded
     created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
-    updated_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP
+    updated_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+    UNIQUE (email_owner_user_id, primary_user_id)
 );
 
 COMMENT ON TABLE encrypted_emails IS 'Stores encrypted emails and their metadata for secure communication between users';
-COMMENT ON COLUMN encrypted_emails.email_address_owner_user_id IS 'User ID of the person who owns the actual email address';
+COMMENT ON COLUMN encrypted_emails.email_owner_user_id IS 'User ID of the person who owns the actual email address';
 COMMENT ON COLUMN encrypted_emails.primary_user_id IS 'User ID of the person who has full control over the encrypted email';
 COMMENT ON COLUMN encrypted_emails.encrypted_email IS 'Base64 encoded encrypted email content';
 
@@ -47,7 +48,7 @@ COMMENT ON COLUMN email_access_keys.encrypted_key IS 'Base64 encoded encryption 
 
 -- Add indexes for performance
 CREATE INDEX IF NOT EXISTS idx_encrypted_emails_primary_user_id ON encrypted_emails(primary_user_id);
-CREATE INDEX IF NOT EXISTS idx_encrypted_emails_email_address_owner_user_id ON encrypted_emails(email_address_owner_user_id);
+CREATE INDEX IF NOT EXISTS idx_encrypted_emails_email_address_owner_user_id ON encrypted_emails(email_owner_user_id);
 CREATE INDEX IF NOT EXISTS idx_email_access_keys_delegated_user_id ON email_access_keys(delegated_user_id);
 
 commit;

--- a/packages/discovery-provider/ddl/migrations/0107_add_email_tables.sql
+++ b/packages/discovery-provider/ddl/migrations/0107_add_email_tables.sql
@@ -42,6 +42,5 @@ COMMENT ON COLUMN email_grantee_keys.encrypted_key IS 'Base64 encoded encryption
 
 -- Add indexes for performance
 CREATE INDEX IF NOT EXISTS idx_encrypted_emails_seller ON encrypted_emails(seller_user_id);
-CREATE INDEX IF NOT EXISTS idx_email_grantee_keys_seller_grantee ON email_grantee_keys(seller_user_id, grantee_user_id);
 
 end;

--- a/packages/discovery-provider/ddl/migrations/0107_add_email_tables.sql
+++ b/packages/discovery-provider/ddl/migrations/0107_add_email_tables.sql
@@ -48,5 +48,6 @@ COMMENT ON COLUMN email_access_keys.encrypted_key IS 'Base64 encoded encryption 
 -- Add indexes for performance
 CREATE INDEX IF NOT EXISTS idx_encrypted_emails_primary_access_user_id ON encrypted_emails(primary_access_user_id);
 CREATE INDEX IF NOT EXISTS idx_encrypted_emails_email_address_owner_user_id ON encrypted_emails(email_address_owner_user_id);
+CREATE INDEX IF NOT EXISTS idx_email_access_keys_delegated_access_user_id ON email_access_keys(delegated_access_user_id);
 
 commit;

--- a/packages/discovery-provider/ddl/migrations/0107_add_email_tables.sql
+++ b/packages/discovery-provider/ddl/migrations/0107_add_email_tables.sql
@@ -3,8 +3,8 @@ begin;
 -- Store encrypted emails with their metadata
 CREATE TABLE IF NOT EXISTS encrypted_emails (
     id SERIAL PRIMARY KEY, 
-    email_owner_user_id INTEGER NOT NULL REFERENCES users(user_id) ON DELETE CASCADE,
-    primary_user_id INTEGER NOT NULL REFERENCES users(user_id) ON DELETE CASCADE,
+    email_owner_user_id INTEGER NOT NULL,
+    primary_user_id INTEGER NOT NULL,
     encrypted_email TEXT NOT NULL,  -- base64 encoded
     created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
     updated_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
@@ -19,7 +19,7 @@ COMMENT ON COLUMN encrypted_emails.encrypted_email IS 'Base64 encoded encrypted 
 -- Store the encryption keys for primary access holders
 CREATE TABLE IF NOT EXISTS email_encryption_keys (
     id SERIAL PRIMARY KEY,
-    primary_user_id INTEGER NOT NULL REFERENCES users(user_id) ON DELETE CASCADE,
+    primary_user_id INTEGER NOT NULL,
     encrypted_key TEXT NOT NULL,  -- base64 encoded
     created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
     updated_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
@@ -33,8 +33,8 @@ COMMENT ON COLUMN email_encryption_keys.encrypted_key IS 'Base64 encoded encrypt
 -- Store the encrypted keys for delegated access
 CREATE TABLE IF NOT EXISTS email_access_keys (
     id SERIAL PRIMARY KEY,
-    primary_user_id INTEGER NOT NULL REFERENCES users(user_id) ON DELETE CASCADE,
-    delegated_user_id INTEGER NOT NULL REFERENCES users(user_id) ON DELETE CASCADE,
+    primary_user_id INTEGER NOT NULL,
+    delegated_user_id INTEGER NOT NULL,
     encrypted_key TEXT NOT NULL,  -- base64 encoded
     created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
     updated_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,

--- a/packages/discovery-provider/ddl/migrations/0107_add_email_tables.sql
+++ b/packages/discovery-provider/ddl/migrations/0107_add_email_tables.sql
@@ -2,32 +2,32 @@ begin;
 
 -- Store encrypted emails with their metadata
 CREATE TABLE IF NOT EXISTS encrypted_emails (
-    email_id INTEGER PRIMARY KEY,
+    id SERIAL PRIMARY KEY,
     seller_user_id INTEGER NOT NULL,
+    email_owner_user_id INTEGER NOT NULL,
     encrypted_email TEXT NOT NULL  -- base64 encoded
 );
 
 COMMENT ON TABLE encrypted_emails IS 'Stores encrypted emails and their metadata for secure communication between sellers and buyers';
-COMMENT ON COLUMN encrypted_emails.email_id IS 'Unique identifier for each encrypted email record';
 COMMENT ON COLUMN encrypted_emails.seller_user_id IS 'User ID of the seller who owns the encrypted email';
+COMMENT ON COLUMN encrypted_emails.email_owner_user_id IS 'User ID of the owner of the email address';
 COMMENT ON COLUMN encrypted_emails.encrypted_email IS 'Base64 encoded encrypted email content';
 
--- Store the encryption keys for sellers and grantees
+-- Store the encryption keys for sellers
 CREATE TABLE IF NOT EXISTS email_encryption_keys (
-    key_id INTEGER PRIMARY KEY,
+    id SERIAL PRIMARY KEY,
     seller_user_id INTEGER NOT NULL,
     owner_key TEXT NOT NULL,  -- base64 encoded
     UNIQUE(seller_user_id)  -- one owner key per seller
 );
 
 COMMENT ON TABLE email_encryption_keys IS 'Stores encryption keys for sellers to manage their encrypted emails';
-COMMENT ON COLUMN email_encryption_keys.key_id IS 'Unique identifier for each encryption key record';
 COMMENT ON COLUMN email_encryption_keys.seller_user_id IS 'User ID of the seller who owns the encryption key';
 COMMENT ON COLUMN email_encryption_keys.owner_key IS 'Base64 encoded encryption key owned by the seller';
 
 -- Store the encrypted keys for grantees
 CREATE TABLE IF NOT EXISTS email_grantee_keys (
-    grantee_key_id INTEGER PRIMARY KEY,
+    id SERIAL PRIMARY KEY,
     seller_user_id INTEGER NOT NULL,
     grantee_user_id INTEGER NOT NULL,
     encrypted_key TEXT NOT NULL,  -- base64 encoded
@@ -35,12 +35,11 @@ CREATE TABLE IF NOT EXISTS email_grantee_keys (
 );
 
 COMMENT ON TABLE email_grantee_keys IS 'Stores encrypted keys for grantees who have been given access to decrypt emails';
-COMMENT ON COLUMN email_grantee_keys.grantee_key_id IS 'Unique identifier for each grantee key record';
 COMMENT ON COLUMN email_grantee_keys.seller_user_id IS 'User ID of the seller who granted access';
 COMMENT ON COLUMN email_grantee_keys.grantee_user_id IS 'User ID of the grantee who received access';
 COMMENT ON COLUMN email_grantee_keys.encrypted_key IS 'Base64 encoded encryption key encrypted for the grantee';
 
 -- Add indexes for performance
-CREATE INDEX IF NOT EXISTS idx_encrypted_emails_seller ON encrypted_emails(seller_user_id);
+CREATE INDEX IF NOT EXISTS idx_encrypted_emails_seller_user_id ON encrypted_emails(seller_user_id);
 
-end;
+commit;

--- a/packages/discovery-provider/ddl/migrations/0107_add_email_tables.sql
+++ b/packages/discovery-provider/ddl/migrations/0107_add_email_tables.sql
@@ -2,44 +2,54 @@ begin;
 
 -- Store encrypted emails with their metadata
 CREATE TABLE IF NOT EXISTS encrypted_emails (
-    id SERIAL PRIMARY KEY,
-    seller_user_id INTEGER NOT NULL,
-    email_owner_user_id INTEGER NOT NULL,
-    encrypted_email TEXT NOT NULL  -- base64 encoded
+    id SERIAL PRIMARY KEY, 
+    email_address_owner_user_id INTEGER NOT NULL,
+    primary_access_user_id INTEGER NOT NULL,
+    delegated_access_user_id INTEGER NOT NULL,
+    encrypted_email TEXT NOT NULL,  -- base64 encoded
+    created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP
 );
 
-COMMENT ON TABLE encrypted_emails IS 'Stores encrypted emails and their metadata for secure communication between sellers and buyers';
-COMMENT ON COLUMN encrypted_emails.seller_user_id IS 'User ID of the seller who owns the encrypted email';
-COMMENT ON COLUMN encrypted_emails.email_owner_user_id IS 'User ID of the owner of the email address';
+COMMENT ON TABLE encrypted_emails IS 'Stores encrypted emails and their metadata for secure communication between users';
+COMMENT ON COLUMN encrypted_emails.email_address_owner_user_id IS 'User ID of the person who owns the actual email address';
+COMMENT ON COLUMN encrypted_emails.primary_access_user_id IS 'User ID of the person who has full control over the encrypted email';
+COMMENT ON COLUMN encrypted_emails.delegated_access_user_id IS 'User ID of the person who has been granted revocable access to view the email';
 COMMENT ON COLUMN encrypted_emails.encrypted_email IS 'Base64 encoded encrypted email content';
 
--- Store the encryption keys for sellers
+-- Store the encryption keys for primary access holders
 CREATE TABLE IF NOT EXISTS email_encryption_keys (
     id SERIAL PRIMARY KEY,
-    seller_user_id INTEGER NOT NULL,
-    owner_key TEXT NOT NULL,  -- base64 encoded
-    UNIQUE(seller_user_id)  -- one owner key per seller
-);
-
-COMMENT ON TABLE email_encryption_keys IS 'Stores encryption keys for sellers to manage their encrypted emails';
-COMMENT ON COLUMN email_encryption_keys.seller_user_id IS 'User ID of the seller who owns the encryption key';
-COMMENT ON COLUMN email_encryption_keys.owner_key IS 'Base64 encoded encryption key owned by the seller';
-
--- Store the encrypted keys for grantees
-CREATE TABLE IF NOT EXISTS email_grantee_keys (
-    id SERIAL PRIMARY KEY,
-    seller_user_id INTEGER NOT NULL,
-    grantee_user_id INTEGER NOT NULL,
+    primary_access_user_id INTEGER NOT NULL,
     encrypted_key TEXT NOT NULL,  -- base64 encoded
-    UNIQUE(seller_user_id, grantee_user_id)  -- one key per seller-grantee pair
+    created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+    UNIQUE(primary_access_user_id)  -- one key per primary access holder
 );
 
-COMMENT ON TABLE email_grantee_keys IS 'Stores encrypted keys for grantees who have been given access to decrypt emails';
-COMMENT ON COLUMN email_grantee_keys.seller_user_id IS 'User ID of the seller who granted access';
-COMMENT ON COLUMN email_grantee_keys.grantee_user_id IS 'User ID of the grantee who received access';
-COMMENT ON COLUMN email_grantee_keys.encrypted_key IS 'Base64 encoded encryption key encrypted for the grantee';
+COMMENT ON TABLE email_encryption_keys IS 'Stores encryption keys for users with primary access to manage encrypted emails';
+COMMENT ON COLUMN email_encryption_keys.primary_access_user_id IS 'User ID of the person with primary access';
+COMMENT ON COLUMN email_encryption_keys.encrypted_key IS 'Base64 encoded encryption key for the primary access holder';
+
+-- Store the encrypted keys for delegated access
+CREATE TABLE IF NOT EXISTS email_access_keys (
+    id SERIAL PRIMARY KEY,
+    primary_access_user_id INTEGER NOT NULL,
+    delegated_access_user_id INTEGER NOT NULL,
+    encrypted_key TEXT NOT NULL,  -- base64 encoded
+    created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+    UNIQUE(primary_access_user_id, delegated_access_user_id)  -- one key per primary-delegated pair
+);
+
+COMMENT ON TABLE email_access_keys IS 'Stores encrypted keys for users with delegated access to view emails';
+COMMENT ON COLUMN email_access_keys.primary_access_user_id IS 'User ID of the person who granted access';
+COMMENT ON COLUMN email_access_keys.delegated_access_user_id IS 'User ID of the person who received delegated access';
+COMMENT ON COLUMN email_access_keys.encrypted_key IS 'Base64 encoded encryption key for the delegated access holder';
 
 -- Add indexes for performance
-CREATE INDEX IF NOT EXISTS idx_encrypted_emails_seller_user_id ON encrypted_emails(seller_user_id);
+CREATE INDEX IF NOT EXISTS idx_encrypted_emails_delegated_access_user_id ON encrypted_emails(delegated_access_user_id);
+CREATE INDEX IF NOT EXISTS idx_encrypted_emails_primary_access_user_id ON encrypted_emails(primary_access_user_id);
+CREATE INDEX IF NOT EXISTS idx_encrypted_emails_email_address_owner_user_id ON encrypted_emails(email_address_owner_user_id);
 
 commit;

--- a/packages/discovery-provider/ddl/migrations/0107_add_email_tables.sql
+++ b/packages/discovery-provider/ddl/migrations/0107_add_email_tables.sql
@@ -1,0 +1,47 @@
+begin;
+
+-- Store encrypted emails with their metadata
+CREATE TABLE IF NOT EXISTS encrypted_emails (
+    email_id INTEGER PRIMARY KEY,
+    seller_user_id INTEGER NOT NULL,
+    encrypted_email TEXT NOT NULL  -- base64 encoded
+);
+
+COMMENT ON TABLE encrypted_emails IS 'Stores encrypted emails and their metadata for secure communication between sellers and buyers';
+COMMENT ON COLUMN encrypted_emails.email_id IS 'Unique identifier for each encrypted email record';
+COMMENT ON COLUMN encrypted_emails.seller_user_id IS 'User ID of the seller who owns the encrypted email';
+COMMENT ON COLUMN encrypted_emails.encrypted_email IS 'Base64 encoded encrypted email content';
+
+-- Store the encryption keys for sellers and grantees
+CREATE TABLE IF NOT EXISTS email_encryption_keys (
+    key_id INTEGER PRIMARY KEY,
+    seller_user_id INTEGER NOT NULL,
+    owner_key TEXT NOT NULL,  -- base64 encoded
+    UNIQUE(seller_user_id)  -- one owner key per seller
+);
+
+COMMENT ON TABLE email_encryption_keys IS 'Stores encryption keys for sellers to manage their encrypted emails';
+COMMENT ON COLUMN email_encryption_keys.key_id IS 'Unique identifier for each encryption key record';
+COMMENT ON COLUMN email_encryption_keys.seller_user_id IS 'User ID of the seller who owns the encryption key';
+COMMENT ON COLUMN email_encryption_keys.owner_key IS 'Base64 encoded encryption key owned by the seller';
+
+-- Store the encrypted keys for grantees
+CREATE TABLE IF NOT EXISTS email_grantee_keys (
+    grantee_key_id INTEGER PRIMARY KEY,
+    seller_user_id INTEGER NOT NULL,
+    grantee_user_id INTEGER NOT NULL,
+    encrypted_key TEXT NOT NULL,  -- base64 encoded
+    UNIQUE(seller_user_id, grantee_user_id)  -- one key per seller-grantee pair
+);
+
+COMMENT ON TABLE email_grantee_keys IS 'Stores encrypted keys for grantees who have been given access to decrypt emails';
+COMMENT ON COLUMN email_grantee_keys.grantee_key_id IS 'Unique identifier for each grantee key record';
+COMMENT ON COLUMN email_grantee_keys.seller_user_id IS 'User ID of the seller who granted access';
+COMMENT ON COLUMN email_grantee_keys.grantee_user_id IS 'User ID of the grantee who received access';
+COMMENT ON COLUMN email_grantee_keys.encrypted_key IS 'Base64 encoded encryption key encrypted for the grantee';
+
+-- Add indexes for performance
+CREATE INDEX IF NOT EXISTS idx_encrypted_emails_seller ON encrypted_emails(seller_user_id);
+CREATE INDEX IF NOT EXISTS idx_email_grantee_keys_seller_grantee ON email_grantee_keys(seller_user_id, grantee_user_id);
+
+end;


### PR DESCRIPTION
### Description
This PR adds the database migration for the email tables needed to enable encrypted emails on discovery.

**Example tables** 

### Table: encrypted_emails
| id | email_address_owner_user_id | primary_access_user_id | encrypted_email | created_at | updated_at |
|----|---------------------------|----------------------|----------------|------------|------------|
| 1 | 123 | 456 | 'base64email1' | 2024-01-01 00:00:00 UTC | 2024-01-01 00:00:00 UTC |

### Table: email_encryption_keys  
| id | primary_access_user_id | encrypted_key | created_at | updated_at |
|----|----------------------|---------------|------------|------------|
| 1 | 456 | 'base64key1' | 2024-01-01 00:00:00 UTC | 2024-01-01 00:00:00 UTC |

### Table: email_access_keys
| id | primary_access_user_id | delegated_access_user_id | encrypted_key | created_at | updated_at |
|----|----------------------|--------------------------|---------------|------------|------------|
| 1 | 456 | 789 | 'base64key2' | 2024-01-01 00:00:00 UTC | 2024-01-01 00:00:00 UTC |
### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._

Ran locally on postico with 

```sql
begin;

CREATE TEMP TABLE encrypted_emails (
   id SERIAL PRIMARY KEY, 
   email_address_owner_user_id INTEGER NOT NULL,
   primary_access_user_id INTEGER NOT NULL,
   encrypted_email TEXT NOT NULL,
   created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
   updated_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP
);

CREATE TEMP TABLE email_encryption_keys (
   id SERIAL PRIMARY KEY,
   primary_access_user_id INTEGER NOT NULL,
   encrypted_key TEXT NOT NULL,
   created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
   updated_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
   UNIQUE(primary_access_user_id)
);

CREATE TEMP TABLE email_access_keys (
   id SERIAL PRIMARY KEY,
   primary_access_user_id INTEGER NOT NULL, 
   delegated_access_user_id INTEGER NOT NULL,
   encrypted_key TEXT NOT NULL,
   created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
   updated_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
   UNIQUE(primary_access_user_id, delegated_access_user_id)
);

CREATE INDEX idx_encrypted_emails_primary_access_user_id ON encrypted_emails(primary_access_user_id);
CREATE INDEX idx_encrypted_emails_email_address_owner_user_id ON encrypted_emails(email_address_owner_user_id);
CREATE INDEX IF NOT EXISTS idx_email_access_keys_delegated_access_user_id ON email_access_keys(delegated_access_user_id);

commit;
```

