### PR TITLE
[PAY-3605] Fix audius-cmd after account/UserStateManager updates

### DIFF
--- a/.changeset/heavy-moles-speak.md
+++ b/.changeset/heavy-moles-speak.md
@@ -1,0 +1,5 @@
+---
+'@audius/sdk': patch
+---
+
+Fixes for UserAuth and missing crypto method in Node environments

--- a/package-lock.json
+++ b/package-lock.json
@@ -79487,6 +79487,8 @@
     },
     "node_modules/node-localstorage": {
       "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/node-localstorage/-/node-localstorage-1.3.1.tgz",
+      "integrity": "sha512-NMWCSWWc6JbHT5PyWlNT2i8r7PgGYXVntmKawY83k/M0UJScZ5jirb61TLnqKwd815DfBQu+lR3sRw08SPzIaQ==",
       "dependencies": {
         "write-file-atomic": "^1.1.4"
       },

--- a/package-lock.json
+++ b/package-lock.json
@@ -104385,13 +104385,14 @@
     },
     "node_modules/viem": {
       "version": "1.21.1",
+      "resolved": "https://registry.npmjs.org/viem/-/viem-1.21.1.tgz",
+      "integrity": "sha512-4Tb2f73FTGN+6PRPmgmKmlIfy/ENS4iU1KKfOPhUA37pZMmVw2rxN0QXMHB4OMa1ZVBlbpde1eG33vyj0L8YeQ==",
       "funding": [
         {
           "type": "github",
           "url": "https://github.com/sponsors/wevm"
         }
       ],
-      "license": "MIT",
       "dependencies": {
         "@adraffy/ens-normalize": "1.10.0",
         "@noble/curves": "1.2.0",

--- a/packages/commands/src/account-managers.mjs
+++ b/packages/commands/src/account-managers.mjs
@@ -1,7 +1,7 @@
 import chalk from 'chalk'
 import { program } from 'commander'
 
-import { initializeAudiusLibs, initializeAudiusSdk } from './utils.mjs'
+import { initializeAudiusSdk } from './utils.mjs'
 
 program
   .command('add-manager')
@@ -9,19 +9,7 @@ program
   .argument('[handle]', 'The handle of the manager')
   .option('-f, --from <from>', 'The account that will be managed')
   .action(async (handle, { from }) => {
-    const audiusLibs = await initializeAudiusLibs(from)
-    // extract privkey and pubkey from hedgehog
-    // only works with accounts created via audius-cmd
-    const wallet = audiusLibs?.hedgehog?.getWallet()
-    const privKey = wallet?.getPrivateKeyString()
-    const pubKey = wallet?.getAddressString()
-
-    // init sdk with priv and pub keys as api keys and secret
-    // this enables writes via sdk
-    const audiusSdk = await initializeAudiusSdk({
-      apiKey: pubKey,
-      apiSecret: privKey
-    })
+    const audiusSdk = await initializeAudiusSdk({ handle: from })
 
     try {
       const {
@@ -50,19 +38,7 @@ program
   .argument('[handle]', 'The handle of the user to be managed')
   .option('-f, --from <from>', 'The manager account handle')
   .action(async (handle, { from }) => {
-    const audiusLibs = await initializeAudiusLibs(from)
-    // extract privkey and pubkey from hedgehog
-    // only works with accounts created via audius-cmd
-    const wallet = audiusLibs?.hedgehog?.getWallet()
-    const privKey = wallet?.getPrivateKeyString()
-    const pubKey = wallet?.getAddressString()
-
-    // init sdk with priv and pub keys as api keys and secret
-    // this enables writes via sdk
-    const audiusSdk = await initializeAudiusSdk({
-      apiKey: pubKey,
-      apiSecret: privKey
-    })
+    const audiusSdk = await initializeAudiusSdk({ handle: from })
 
     try {
       const {
@@ -87,19 +63,7 @@ program
   .argument('[handle]', 'The handle of the user to be managed')
   .option('-f, --from <from>', 'The manager account handle')
   .action(async (handle, { from }) => {
-    const audiusLibs = await initializeAudiusLibs(from)
-    // extract privkey and pubkey from hedgehog
-    // only works with accounts created via audius-cmd
-    const wallet = audiusLibs?.hedgehog?.getWallet()
-    const privKey = wallet?.getPrivateKeyString()
-    const pubKey = wallet?.getAddressString()
-
-    // init sdk with priv and pub keys as api keys and secret
-    // this enables writes via sdk
-    const audiusSdk = await initializeAudiusSdk({
-      apiKey: pubKey,
-      apiSecret: privKey
-    })
+    const audiusSdk = await initializeAudiusSdk({ handle: from })
 
     try {
       const {
@@ -124,19 +88,7 @@ program
   .argument('[handle]', 'The handle of the manager')
   .option('-f, --from <from>', 'The handle of the manager user')
   .action(async (handle, { from }) => {
-    const audiusLibs = await initializeAudiusLibs(from)
-    // extract privkey and pubkey from hedgehog
-    // only works with accounts created via audius-cmd
-    const wallet = audiusLibs?.hedgehog?.getWallet()
-    const privKey = wallet?.getPrivateKeyString()
-    const pubKey = wallet?.getAddressString()
-
-    // init sdk with priv and pub keys as api keys and secret
-    // this enables writes via sdk
-    const audiusSdk = await initializeAudiusSdk({
-      apiKey: pubKey,
-      apiSecret: privKey
-    })
+    const audiusSdk = await initializeAudiusSdk({ handle: from })
 
     try {
       const {

--- a/packages/commands/src/auth-headers.mjs
+++ b/packages/commands/src/auth-headers.mjs
@@ -14,8 +14,18 @@ program
 
     try {
       const unixTimestamp = Math.round(new Date().getTime() / 1000)
-      const message = `Click sign to authenticate with identity service: ${unixTimestamp}`
-      const signature = await audiusSdk.services.auth.sign(message)
+      const message = `signature:${unixTimestamp}`
+      const prefix = `\x19Ethereum Signed Message:\n${message.length}`
+      const prefixedMessage = prefix + message
+
+      const [sig, recid] = await audiusSdk.services.auth.sign(
+        Buffer.from(prefixedMessage, 'utf-8')
+      )
+      const r = Buffer.from(sig.slice(0, 32)).toString('hex')
+      const s = Buffer.from(sig.slice(32, 64)).toString('hex')
+      const v = (recid + 27).toString(16)
+
+      const signature = `0x${r}${s}${v}`
 
       console.log(chalk.yellow('Encoded-Data-Message:'), message)
       console.log(chalk.yellow('Encoded-Data-Signature:'), signature)

--- a/packages/commands/src/auth-headers.mjs
+++ b/packages/commands/src/auth-headers.mjs
@@ -15,8 +15,7 @@ program
     try {
       const unixTimestamp = Math.round(new Date().getTime() / 1000)
       const message = `signature:${unixTimestamp}`
-      const prefix = `\x19Ethereum Signed Message:\n${message.length}`
-      const prefixedMessage = prefix + message
+      const prefixedMessage = `\x19Ethereum Signed Message:\n${message.length}${message}`
 
       const [sig, recid] = await audiusSdk.services.auth.sign(
         Buffer.from(prefixedMessage, 'utf-8')

--- a/packages/commands/src/auth-headers.mjs
+++ b/packages/commands/src/auth-headers.mjs
@@ -1,27 +1,27 @@
-import chalk from "chalk";
-import { program } from "commander";
+import chalk from 'chalk'
+import { program } from 'commander'
 
-import { initializeAudiusLibs } from "./utils.mjs";
+import { initializeAudiusSdk } from './utils.mjs'
 
 program
-  .command("auth-headers")
+  .command('auth-headers')
   .description(
-    "Output auth headers (for use with curl: `curl -H @<(audius-cmd auth-headers)`)"
+    'Output auth headers (for use with curl: `curl -H @<(audius-cmd auth-headers)`)'
   )
-  .option("-f, --from [from]", "The account for which to generate auth headers")
+  .option('-f, --from [from]', 'The account for which to generate auth headers')
   .action(async ({ from }) => {
-    const audiusLibs = await initializeAudiusLibs(from);
+    const audiusSdk = await initializeAudiusSdk({ handle: from })
 
     try {
-      const unixTimestamp = Math.round(new Date().getTime() / 1000);
-      const message = `Click sign to authenticate with identity service: ${unixTimestamp}`;
-      const signature = await audiusLibs.web3Manager.sign(message);
+      const unixTimestamp = Math.round(new Date().getTime() / 1000)
+      const message = `Click sign to authenticate with identity service: ${unixTimestamp}`
+      const signature = await audiusSdk.services.auth.sign(message)
 
-      console.log(chalk.yellow("Encoded-Data-Message:"), message);
-      console.log(chalk.yellow("Encoded-Data-Signature:"), signature);
+      console.log(chalk.yellow('Encoded-Data-Message:'), message)
+      console.log(chalk.yellow('Encoded-Data-Signature:'), signature)
     } catch (err) {
-      program.error(err.message);
+      program.error(err.message)
     }
 
-    process.exit(0);
-  });
+    process.exit(0)
+  })

--- a/packages/commands/src/claim-reward.mjs
+++ b/packages/commands/src/claim-reward.mjs
@@ -1,7 +1,7 @@
 import chalk from 'chalk'
 import { program } from 'commander'
 
-import { initializeAudiusLibs, initializeAudiusSdk } from './utils.mjs'
+import { getCurrentAudiusSdkUser, initializeAudiusSdk } from './utils.mjs'
 import { Utils } from '@audius/sdk-legacy/dist/libs.js'
 
 program
@@ -19,24 +19,9 @@ program
     'The user referred (for referral challenges)'
   )
   .action(async (challengeId, amount, { from, contentId, referredUserId }) => {
-    const audiusLibs = await initializeAudiusLibs(from)
-
-    // extract privkey and pubkey from hedgehog
-    // only works with accounts created via audius-cmd
-    const wallet = audiusLibs?.hedgehog?.getWallet()
-    const privKey = wallet?.getPrivateKeyString()
-    const pubKey = wallet?.getAddressString()
-
-    // Get hashID user id of current user
-    const userIdNumber = audiusLibs.userStateManager.getCurrentUserId()
-    const userId = Utils.encodeHashId(userIdNumber)
-
-    // init sdk with priv and pub keys as api keys and secret
-    // this enables writes via sdk
-    const audiusSdk = await initializeAudiusSdk({
-      apiKey: pubKey,
-      apiSecret: privKey
-    })
+    const audiusSdk = await initializeAudiusSdk({ handle: from })
+    const user = await getCurrentAudiusSdkUser()
+    const userId = user.id
 
     try {
       const specifier = await audiusSdk.challenges.generateSpecifier({
@@ -76,24 +61,9 @@ program
   .option('-c, --contentId [contentId]', 'The track or album purchased')
   .option('-r, --referredUserId [referredUserId]', 'The user referred')
   .action(async (challengeId, { from, contentId, referredUserId }) => {
-    const audiusLibs = await initializeAudiusLibs(from)
-
-    // extract privkey and pubkey from hedgehog
-    // only works with accounts created via audius-cmd
-    const wallet = audiusLibs?.hedgehog?.getWallet()
-    const privKey = wallet?.getPrivateKeyString()
-    const pubKey = wallet?.getAddressString()
-
-    // Get hashID user id of current user
-    const userIdNumber = audiusLibs.userStateManager.getCurrentUserId()
-    const userId = Utils.encodeHashId(userIdNumber)
-
-    // init sdk with priv and pub keys as api keys and secret
-    // this enables writes via sdk
-    const audiusSdk = await initializeAudiusSdk({
-      apiKey: pubKey,
-      apiSecret: privKey
-    })
+    const audiusSdk = await initializeAudiusSdk({ handle: from })
+    const user = await getCurrentAudiusSdkUser()
+    const userId = user.id
 
     const specifier = await audiusSdk.challenges.generateSpecifier({
       challengeId,

--- a/packages/commands/src/create-user-bank.mjs
+++ b/packages/commands/src/create-user-bank.mjs
@@ -1,7 +1,7 @@
 import chalk from 'chalk'
 import { program, Option } from 'commander'
 
-import { initializeAudiusLibs, initializeAudiusSdk } from './utils.mjs'
+import { initializeAudiusSdk } from './utils.mjs'
 
 program
   .command('create-user-bank')
@@ -16,20 +16,7 @@ program
       .default('wAUDIO')
   )
   .action(async (handle, { mint }) => {
-    const audiusLibs = await initializeAudiusLibs(handle)
-
-    // extract privkey and pubkey from hedgehog
-    // only works with accounts created via audius-cmd
-    const wallet = audiusLibs?.hedgehog?.getWallet()
-    const privKey = wallet?.getPrivateKeyString()
-    const pubKey = wallet?.getAddressString()
-
-    // init sdk with priv and pub keys as api keys and secret
-    // this enables writes via sdk
-    const audiusSdk = await initializeAudiusSdk({
-      apiKey: pubKey,
-      apiSecret: privKey
-    })
+    const audiusSdk = await initializeAudiusSdk({ handle })
 
     try {
       const response =

--- a/packages/commands/src/create-user-bank.mjs
+++ b/packages/commands/src/create-user-bank.mjs
@@ -1,7 +1,7 @@
 import chalk from 'chalk'
 import { program, Option } from 'commander'
 
-import { initializeAudiusSdk } from './utils.mjs'
+import { initializeAudiusSdk, getCurrentAudiusSdkUser } from './utils.mjs'
 
 program
   .command('create-user-bank')
@@ -17,11 +17,13 @@ program
   )
   .action(async (handle, { mint }) => {
     const audiusSdk = await initializeAudiusSdk({ handle })
+    const user = await getCurrentAudiusSdkUser()
+    const ethWallet = user.wallet
 
     try {
       const response =
         await audiusSdk.services.claimableTokensClient.getOrCreateUserBank({
-          ethWallet: wallet.getAddressString(),
+          ethWallet,
           mint
         })
 

--- a/packages/commands/src/edit-user.mjs
+++ b/packages/commands/src/edit-user.mjs
@@ -1,41 +1,42 @@
-import chalk from "chalk";
-import { program } from "commander";
+import chalk from 'chalk'
+import { program } from 'commander'
 
-import { initializeAudiusLibs } from "./utils.mjs";
+import { getCurrentAudiusSdkUser, initializeAudiusSdk } from './utils.mjs'
 
-program.command("edit-user")
-  .description("Update an existing user")
-  .argument("<handle>", "The user's handle (can't change)")
-  .option("-n, --name <name>", "The user's new name")
-  .option("-b, --bio <bio>", "The user's new bio")
-  .action(async (handle, { name, bio }) => {
-    const audiusLibs = await initializeAudiusLibs(handle);
+program
+  .command('edit-user')
+  .description('Update an existing user')
+  .argument('<handle>', "The user's handle (can't change)")
+  .option('-n, --name <name>', "The user's new name")
+  .option('-b, --bio <bio>', "The user's new bio")
+  .option('-l, --location <location>', "The user's new location")
+  .action(async (handle, { name, bio, location }) => {
+    const audiusSdk = await initializeAudiusSdk({ handle })
+    const user = await getCurrentAudiusSdkUser()
+    const { id: userId } = user
 
-    const user = audiusLibs.userStateManager.getCurrentUser();
-    const newMetadata = {
-      ...user,
-      name: name || user.name,
-      bio: bio || user.bio
-    }
-
-    console.log(chalk.yellow.bold("User before update: "), user);
+    console.log(chalk.yellow.bold('User before update: '), user)
 
     try {
-      const response = await audiusLibs.User.updateMetadataV2({
-        newMetadata,
-        userId: user.user_id
-      });
+      const response = await audiusSdk.users.updateProfile({
+        userId,
+        metadata: { name, bio, location }
+      })
 
       if (response.error) {
-        program.error(chalk.red(response.error));
+        program.error(chalk.red(response.error))
       }
 
-      const updatedUser = audiusLibs.userStateManager.getCurrentUser();
-      console.log(chalk.green("Successfully updated user!"));
-      console.log(chalk.yellow.bold("User after update: "), updatedUser);
+      const updatedUser = await audiusSdk.full.users.getUser({
+        id: userId,
+        userId
+      })
+      console.log(chalk.green('Successfully updated user!'))
+      console.log(chalk.yellow.bold('User after update: '), updatedUser)
     } catch (err) {
-      program.error(err.message);
+      console.error(err)
+      program.error(err.message)
     }
 
-    process.exit(0);
-  });
+    process.exit(0)
+  })

--- a/packages/commands/src/mint-tokens.mjs
+++ b/packages/commands/src/mint-tokens.mjs
@@ -3,7 +3,7 @@ import { program, Option } from 'commander'
 import { Connection, Keypair, PublicKey } from '@solana/web3.js'
 import { mintTo, getAccount } from '@solana/spl-token'
 
-import { initializeAudiusLibs, initializeAudiusSdk } from './utils.mjs'
+import { initializeAudiusSdk, getCurrentAudiusSdkUser } from './utils.mjs'
 
 program
   .command('mint-tokens')
@@ -16,24 +16,14 @@ program
   )
   .option('-f, --from <from>', 'The account to mint tokens for (handle)')
   .action(async (amount, { from, mint }) => {
-    const audiusLibs = await initializeAudiusLibs(from)
-
-    // extract privkey and pubkey from hedgehog
-    // only works with accounts created via audius-cmd
-    const wallet = audiusLibs?.hedgehog?.getWallet()
-    const privKey = wallet?.getPrivateKeyString()
-    const pubKey = wallet?.getAddressString()
-
-    // init sdk with priv and pub keys as api keys and secret
-    // this enables writes via sdk
     const audiusSdk = await initializeAudiusSdk({
-      apiKey: pubKey,
-      apiSecret: privKey
+      handle: from
     })
+    const currentUser = await getCurrentAudiusSdkUser()
 
     const { userBank: splWallet } =
       await audiusSdk.services.claimableTokensClient.getOrCreateUserBank({
-        ethWallet: wallet.getAddressString(),
+        ethWallet: currentUser.wallet,
         mint
       })
 

--- a/packages/commands/src/purchase-content.mjs
+++ b/packages/commands/src/purchase-content.mjs
@@ -1,7 +1,7 @@
 import chalk from 'chalk'
 import { program } from 'commander'
 
-import { initializeAudiusLibs, initializeAudiusSdk } from './utils.mjs'
+import { initializeAudiusSdk, getCurrentAudiusSdkUser } from './utils.mjs'
 import { Utils } from '@audius/sdk-legacy/dist/libs.js'
 
 program
@@ -16,23 +16,12 @@ program
     parseFloat
   )
   .action(async (id, price, { from, extraAmount }) => {
-    const audiusLibs = await initializeAudiusLibs(from)
-    const userIdNumber = audiusLibs.getCurrentUser().userId
-    const userId = Utils.encodeHashId(userIdNumber)
-    const trackId = Utils.encodeHashId(id)
-
-    // extract privkey and pubkey from hedgehog
-    // only works with accounts created via audius-cmd
-    const wallet = audiusLibs?.hedgehog?.getWallet()
-    const privKey = wallet?.getPrivateKeyString()
-    const pubKey = wallet?.getAddressString()
-
-    // init sdk with priv and pub keys as api keys and secret
-    // this enables writes via sdk
     const audiusSdk = await initializeAudiusSdk({
-      apiKey: pubKey,
-      apiSecret: privKey
+      handle: from
     })
+    const currentUser = await getCurrentAudiusSdkUser()
+    const userId = currentUser.id
+    const trackId = Utils.encodeHashId(id)
 
     try {
       console.log('Purchasing track...', {
@@ -68,23 +57,12 @@ program
     parseFloat
   )
   .action(async (id, price, { from, extraAmount }) => {
-    const audiusLibs = await initializeAudiusLibs(from)
-    const userIdNumber = audiusLibs.userStateManager.getCurrentUserId()
-    const userId = Utils.encodeHashId(userIdNumber)
-    const albumId = Utils.encodeHashId(id)
-
-    // extract privkey and pubkey from hedgehog
-    // only works with accounts created via audius-cmd
-    const wallet = audiusLibs?.hedgehog?.getWallet()
-    const privKey = wallet?.getPrivateKeyString()
-    const pubKey = wallet?.getAddressString()
-
-    // init sdk with priv and pub keys as api keys and secret
-    // this enables writes via sdk
     const audiusSdk = await initializeAudiusSdk({
-      apiKey: pubKey,
-      apiSecret: privKey
+      handle: from
     })
+    const currentUser = await getCurrentAudiusSdkUser()
+    const userId = currentUser.id
+    const albumId = Utils.encodeHashId(id)
 
     try {
       console.log('Purchasing album...', {

--- a/packages/commands/src/tip-reaction.mjs
+++ b/packages/commands/src/tip-reaction.mjs
@@ -1,38 +1,30 @@
-import BN from "bn.js";
-import chalk from "chalk";
-import { program } from "commander";
+import { program } from 'commander'
 
-import { initializeAudiusLibs, initializeAudiusSdk } from "./utils.mjs";
+import { initializeAudiusSdk } from './utils.mjs'
 
-program.command("tip-reaction")
-  .description("Send a tip reaction")
-  .argument("<handle>", "users handle")
-  .argument("<signature>", "signature of the tip to react to")
+program
+  .command('tip-reaction')
+  .description('Send a tip reaction')
+  .argument('<handle>', 'users handle')
+  .argument('<signature>', 'signature of the tip to react to')
   .action(async (handle, signature) => {
-    const audiusLibs = await initializeAudiusLibs(handle);
-
-    // extract privkey and pubkey from hedgehog
-    // only works with accounts created via audius-cmd
-    const wallet = audiusLibs?.hedgehog?.getWallet()
-    const privKey = wallet?.getPrivateKeyString()
-    const pubKey = wallet?.getAddressString()
-
-    // init sdk with priv and pub keys as api keys and secret
-    // this enables writes via sdk
-    const audiusSdk = await initializeAudiusSdk({ apiKey: pubKey, apiSecret: privKey })
+    const audiusSdk = await initializeAudiusSdk({
+      handle: from
+    })
 
     try {
-        const { data: { id }} = await audiusSdk.users.getUserByHandle({ handle })
-        await audiusSdk.users.sendTipReaction({
-            userId: id,
-            metadata: {
-                reactedTo: signature,
-                reactionValue: "🔥"
-            }
-        })
-
+      const {
+        data: { id }
+      } = await audiusSdk.users.getUserByHandle({ handle })
+      await audiusSdk.users.sendTipReaction({
+        userId: id,
+        metadata: {
+          reactedTo: signature,
+          reactionValue: '🔥'
+        }
+      })
     } catch (err) {
-        program.error(err.message)
+      program.error(err.message)
     }
-    process.exit(0);
-  });
+    process.exit(0)
+  })

--- a/packages/commands/src/unfollow.mjs
+++ b/packages/commands/src/unfollow.mjs
@@ -1,25 +1,26 @@
-import chalk from "chalk";
-import { program } from "commander";
+import chalk from 'chalk'
+import { program } from 'commander'
 
-import { initializeAudiusLibs, parseUserId } from "./utils.mjs";
+import { initializeAudiusLibs } from './utils.mjs'
 
-program.command("unfollow")
-  .description("Unfollow user")
-  .argument("<userId>", "The user id to unfollow", Number)
-  .option("-f, --from <from>", "The account to unfollow from")
+program
+  .command('unfollow')
+  .description('Unfollow user')
+  .argument('<userId>', 'The user id to unfollow', Number)
+  .option('-f, --from <from>', 'The account to unfollow from')
   .action(async (userId, { from }) => {
-    const audiusLibs = await initializeAudiusLibs(from);
+    const audiusLibs = await initializeAudiusLibs(from)
 
     try {
-      const response = await audiusLibs.EntityManager.unfollowUser(userId);
+      const response = await audiusLibs.EntityManager.unfollowUser(userId)
 
       if (response.error) {
-        program.error(chalk.red(response.error));
+        program.error(chalk.red(response.error))
       }
-      console.log(chalk.green("Successfully unfollowed user"));
+      console.log(chalk.green('Successfully unfollowed user'))
     } catch (err) {
-      program.error(err.message);
+      program.error(err.message)
     }
 
-    process.exit(0);
-  });
+    process.exit(0)
+  })

--- a/packages/commands/src/upload-track.mjs
+++ b/packages/commands/src/upload-track.mjs
@@ -7,7 +7,11 @@ import { Utils } from '@audius/sdk-legacy/dist/libs.js'
 import chalk from 'chalk'
 import { program } from 'commander'
 
-import { initializeAudiusLibs } from './utils.mjs'
+import {
+  initializeAudiusLibs,
+  getCurrentAudiusSdkUser,
+  parseUserId
+} from './utils.mjs'
 import { Genre } from '@audius/sdk'
 
 function generateWhiteNoise(duration, outFile) {
@@ -186,6 +190,8 @@ program
       }
     ) => {
       const audiusLibs = await initializeAudiusLibs(from)
+      const user = await getCurrentAudiusSdkUser()
+      const userId = await parseUserId(user.id)
 
       const rand = randomBytes(2).toString('hex').padStart(4, '0').toUpperCase()
 
@@ -223,8 +229,6 @@ program
           downloadPrice,
           audiusLibs
         })
-
-        const userId = audiusLibs.getCurrentUser().userId
 
         const trackTitle = title || `title ${rand}`
         const response = await audiusLibs.Track.uploadTrackV2AndWriteToChain(

--- a/packages/libs/src/api/Users.ts
+++ b/packages/libs/src/api/Users.ts
@@ -344,7 +344,6 @@ export class Users extends Base {
             data: newMetadata
           })
         )
-      console.log(manageEntityResponse, userId)
       await this._waitForDiscoveryToIndexUser(
         userId,
         manageEntityResponse.txReceipt.blockNumber

--- a/packages/libs/src/api/Users.ts
+++ b/packages/libs/src/api/Users.ts
@@ -344,6 +344,7 @@ export class Users extends Base {
             data: newMetadata
           })
         )
+      console.log(manageEntityResponse, userId)
       await this._waitForDiscoveryToIndexUser(
         userId,
         manageEntityResponse.txReceipt.blockNumber

--- a/packages/sdk/rollup.config.ts
+++ b/packages/sdk/rollup.config.ts
@@ -19,6 +19,7 @@ const external = [
   'ethers/lib/index',
   'hashids/cjs',
   'readable-stream',
+  '@noble/hashes/utils',
   'debug'
 ]
 

--- a/packages/sdk/src/sdk/services/Auth/UserAuth.ts
+++ b/packages/sdk/src/sdk/services/Auth/UserAuth.ts
@@ -73,9 +73,16 @@ export class UserAuth implements AuthService {
       get,
       setAuth,
       setUser,
-      config?.useLocalStorage ?? true
+      this.config.useLocalStorage
     )
-    this.config.localStorage.then((ls) => (this.hedgehog.localStorage = ls))
+    if (this.config.useLocalStorage) {
+      this.hedgehog.ready = false
+      this.config.localStorage.then(async (ls) => {
+        this.hedgehog.localStorage = ls
+        await this.hedgehog.restoreLocalWallet()
+        this.hedgehog.ready = true
+      })
+    }
   }
 
   signUp = async ({
@@ -125,15 +132,16 @@ export class UserAuth implements AuthService {
       await this.hedgehog.waitUntilReady()
       const wallet = this.hedgehog.getWallet()
       if (!wallet) throw new Error('No wallet found')
-      return secp.getSharedSecret(wallet.getPrivateKeyString(), publicKey, true)
+      return secp.getSharedSecret(wallet.getPrivateKey(), publicKey, true)
     }
 
   sign: (data: string | Uint8Array) => Promise<[Uint8Array, number]> = async (
     data
   ) => {
+    await this.hedgehog.waitUntilReady()
     const wallet = this.hedgehog.getWallet()
     if (!wallet) throw new Error('No wallet')
-    return secp.sign(keccak_256(data), wallet.getPrivateKeyString(), {
+    return secp.sign(keccak_256(data), wallet.getPrivateKey(), {
       recovered: true,
       der: false
     })

--- a/packages/sdk/src/sdk/services/Auth/UserAuth.ts
+++ b/packages/sdk/src/sdk/services/Auth/UserAuth.ts
@@ -162,7 +162,7 @@ export class UserAuth implements AuthService {
     await this.hedgehog.waitUntilReady()
     const wallet = this.hedgehog.getWallet()
     if (!wallet) throw new Error('No wallet')
-    return signTypedData(Buffer.from(wallet.getPrivateKeyString(), 'hex'), {
+    return signTypedData(wallet.getPrivateKey(), {
       data
     })
   }


### PR DESCRIPTION
### Description
#9673 and #10311 broke audius-cmd for two reasons:
1. `UserStateManager` no longer exists. Some of the commands attempt to read the current user from libs directly.
2. Libs and SDK work more smoothly if you initialize SDK _first_ and then initialize libs with the `userId` and `wallet` of the currently logged-in user.

Additionally, our usage of SDK in audius-cmd was leveraging `AppAuth`, which doesn't really reflect how we use it in client. It should be using `UserAuth` instead, since that wraps an instance of Hedgehog.

So to get everything working again:
* Updated the initialization functions in audius-cmd to do SDK first, using a UserAuth instance, then libs after reading the current user
  * Ported over the dummy password logic that we use in client to initialize Hedgehog to an ephemeral wallet if starting from a clean state
  * We only attempt to read the current user from discovery if we aren't using a dummy wallet
* Added a utility to get the current SDK user, since that's useful in commands
* Updated a number of commands to use SDK instead of libs if possible. I was mostly focused on things that were broken. Some of the other commands will continue to use libs and can be migrated as that functionality is moved to SDK
* Fixed an issue with our rollup config that was causing runtime errors due to a `crypto` method not existing. This is only present in non-browser contexts?
* Fixed a few issues in `UserAuth`:
  * Hedgehog is designed in a way that doesn't really work well with fetching the `localStorage` adpater asynchronously, as it attempts to restore the wallet from localStorage in its constructor. So, with the async flow `UserAuth` is using, we need to add some code to manually call `restoreLocalWallet` once we've set the `localStorage` adapter.
  * `secp.sign` expects a raw buffer for the private key, not a string. So updated all the calls of `getPrivateKeyString()` => `getPrivateKey()`
  * Added a wait in `sign` to make sure that we block that until the wallet is ready. We do this in all the other methods.

### How Has This Been Tested?
Ran various commands against local stack to ensure that they work correctly.
