### PR TITLE
Fix aggregate tip indexing and improve Solana indexer health check

### DIFF
--- a/packages/discovery-provider/src/queries/get_health.py
+++ b/packages/discovery-provider/src/queries/get_health.py
@@ -607,8 +607,9 @@ def get_solana_indexer_status(
     )
     last_tx = redis.get(keys.last_tx)
     last_tx = str(last_tx, encoding="utf-8") if last_tx is not None else None
-    is_healthy = max_drift is None or (
-        since_last_completed_at is not None and since_last_completed_at < max_drift
+    # Job completed at least once and less than max_drift ago (if applicable)
+    is_healthy = since_last_completed_at is not None and (
+        max_drift is None or since_last_completed_at < max_drift
     )
 
     return {

--- a/packages/discovery-provider/src/tasks/index_aggregate_tips.py
+++ b/packages/discovery-provider/src/tasks/index_aggregate_tips.py
@@ -196,10 +196,10 @@ def _update_aggregate_tips(session: Session, redis: Redis):
     max_slot_result = (
         session.query(UserTip.slot, UserTip.signature)
         .order_by(UserTip.slot.desc())
-        .one()
+        .first()
     )
     max_slot, last_tip_signature = (
-        max_slot_result if max_slot_result[0] is not None else (0, None)
+        max_slot_result if max_slot_result is not None else (0, None)
     )
 
     ranks_before = _get_ranks(session, prev_slot, max_slot)


### PR DESCRIPTION
### Description

Was accidentally querying for `one()` instead of `first()` in the indexer, which broke for obvious reasons in stage/production.

Missed this error since `since_last_completed` was always `None` so health check always thought it was healthy.

### How Has This Been Tested?

Have not tested...