### PR TITLE
[QA-1842] Fix web date picker time default

### DIFF
--- a/packages/mobile/src/components/core/DateTimeInput.tsx
+++ b/packages/mobile/src/components/core/DateTimeInput.tsx
@@ -40,6 +40,7 @@ export const DateTimeInput = (props: DateTimeModalProps) => {
 
   const handleChange = useCallback(
     (date: Date) => {
+      date.setHours(0, 0, 0, 0)
       onChange(date.toString())
       setIsDateTimeOpen((d) => !d)
     },

--- a/packages/mobile/src/screens/edit-track-screen/fields/ReleaseDateField.tsx
+++ b/packages/mobile/src/screens/edit-track-screen/fields/ReleaseDateField.tsx
@@ -11,7 +11,7 @@ const messages = {
 
 export const ReleaseDateField = (props) => {
   const [{ value }] = useField<Nullable<string>>('release_date')
-  console.log('asdf props', props)
+
   return (
     <ContextualMenu
       menuScreenName='ReleaseDate'

--- a/packages/mobile/src/screens/edit-track-screen/fields/ReleaseDateField.tsx
+++ b/packages/mobile/src/screens/edit-track-screen/fields/ReleaseDateField.tsx
@@ -14,7 +14,7 @@ export const ReleaseDateField = (props) => {
 
   return (
     <ContextualMenu
-      menuScreenName='ReleaseDate'
+      menuScreenName={messages.label}
       label={messages.label}
       value={value ? dayjs(value).format('M/D/YY') : undefined}
       {...props}

--- a/packages/mobile/src/screens/edit-track-screen/fields/ReleaseDateField.tsx
+++ b/packages/mobile/src/screens/edit-track-screen/fields/ReleaseDateField.tsx
@@ -11,10 +11,10 @@ const messages = {
 
 export const ReleaseDateField = (props) => {
   const [{ value }] = useField<Nullable<string>>('release_date')
-
+  console.log('asdf props', props)
   return (
     <ContextualMenu
-      menuScreenName={messages.label}
+      menuScreenName='ReleaseDate'
       label={messages.label}
       value={value ? dayjs(value).format('M/D/YY') : undefined}
       {...props}

--- a/packages/mobile/src/screens/edit-track-screen/screens/ReleaseDateScreen.tsx
+++ b/packages/mobile/src/screens/edit-track-screen/screens/ReleaseDateScreen.tsx
@@ -12,7 +12,7 @@ export enum ReleaseDateType {
 const messages = {
   title: 'Release Date',
   description: 'Specify the release date of your music.',
-  dateInputLabel: 'ReleaseDate',
+  dateInputLabel: 'Release Date',
   pastReleaseHint:
     'Setting a release date in the past will impact the order tracks appear on your profile.'
 }

--- a/packages/web/src/components/edit/fields/DatePickerField.tsx
+++ b/packages/web/src/components/edit/fields/DatePickerField.tsx
@@ -93,7 +93,7 @@ export const DatePickerField = (props: DatePickerFieldProps) => {
               // @ts-ignore todo: upgrade moment
               date={moment(value)}
               onDateChange={(value) => {
-                helpers.setValue(value?.toString())
+                helpers.setValue(value?.startOf('day').toString())
                 helpers.setTouched(true, false)
               }}
               isOutsideRange={(day) => {


### PR DESCRIPTION
### Description
Reports of some tracks showing as scheduled release in feed. This is not because they are scheduled release though. The default time dayjs uses is set to noon instead of midnight so tracks released in the morning are actually in that user's local noon time. 

Also mobile date picker input placeholder has ReleaseDate as one word. It doesn't have the same issue above.

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._

Tested on web staging. Uploaded a track while my system clock was set to the morning. Repro'd and fixed the issue.
