### PR TITLE
Fix rollup for browser now that hashes is externalized

### DIFF
--- a/packages/sdk/rollup.config.ts
+++ b/packages/sdk/rollup.config.ts
@@ -32,6 +32,7 @@ const pluginTypescript = typescript({ tsconfig: './tsconfig.json' })
 const browserInternal = [
   '@metamask/eth-sig-util',
   '@scure/base',
+  '@noble/hashes/utils',
   'eth-sig-util',
   'ethereumjs-tx',
   'ethereumjs-util',


### PR DESCRIPTION
### Description
This was throwing errors for me on local client. We only need the externals behavior for node environments, so adding it to the browserInternal list to restore status quo from before the change

### How Has This Been Tested?
Tested on local client.
