### PR TITLE
cache eth/poa-ganache

### DIFF
--- a/contracts/Dockerfile
+++ b/contracts/Dockerfile
@@ -1,18 +1,26 @@
 # Uses separate stage for nodejs deps despite caching to avoid installing build tools
 FROM node:18.16 as builder
 COPY package*.json ./
-RUN --mount=type=cache,target=/root/.npm npm ci
+RUN npm ci
 
 FROM node:18-slim
 
 WORKDIR /usr/src/app
 
+COPY --from=builder package*.json ./
 COPY --from=builder /node_modules ./node_modules
-COPY . .
 
 ARG bootstrapSPIds
 ARG bootstrapSPDelegateWallets
 ARG bootstrapSPOwnerWallets
+
+COPY ./contracts ./contracts
+COPY ./migrations ./migrations 
+COPY ./scripts ./scripts 
+COPY ./signature_schemas ./signature_schemas
+COPY ./truffle-config.js ./contract-config.js ./
+
+RUN chmod +x ./scripts/setup-predeployed-ganache.sh
 
 RUN ./scripts/setup-predeployed-ganache.sh /usr/db 1000000000001
 

--- a/contracts/scripts/setup-predeployed-ganache.sh
+++ b/contracts/scripts/setup-predeployed-ganache.sh
@@ -25,6 +25,8 @@ npx ganache \
   --chain.networkId "$networkId" \
   &
 
+ganache_pid=$!
+
 npx truffle migrate --network predeploy
 
 kill $ganache_pid

--- a/contracts/scripts/setup-predeployed-ganache.sh
+++ b/contracts/scripts/setup-predeployed-ganache.sh
@@ -15,8 +15,15 @@ if [ -z "networkId" ]; then
 fi
 
 mkdir -p $dbPath
-npx ganache --logging.quiet --wallet.deterministic --wallet.totalAccounts 50 --database.dbPath "$dbPath" --chain.networkId "$networkId" &
-ganache_pid=$!
+npx ganache \
+  --server.host "0.0.0.0" \
+  --server.port 8546 \
+  --logging.quiet \
+  --wallet.deterministic \
+  --wallet.totalAccounts 50 \
+  --database.dbPath "$dbPath" \
+  --chain.networkId "$networkId" \
+  &
 
 npx truffle migrate --network predeploy
 

--- a/contracts/truffle-config.js
+++ b/contracts/truffle-config.js
@@ -64,7 +64,7 @@ module.exports = {
     },
     predeploy: {
       host: '127.0.0.1',
-      port: 8545,
+      port: 8546,
       network_id: '*', // Match any network id
       verify: {
         apiUrl: 'http://poa-blockscout:4000/api',

--- a/dev-tools/compose/docker-compose.pedalboard.prod.yml
+++ b/dev-tools/compose/docker-compose.pedalboard.prod.yml
@@ -46,14 +46,10 @@ services:
     profiles:
       - discovery
     healthcheck:
-      test:
-        [
-          'CMD-SHELL',
-          'curl -f http://localhost:6001/relay/health || exit 1'
-        ]
-      interval: 5s
-      timeout: 30s
-      retries: 5
+      test: ['CMD', 'curl', '-f', 'http://127.0.0.1:6001/relay/health']
+      interval: 1s
+      timeout: 1s
+      retries: 60
       start_period: 5s
     depends_on:
       db:
@@ -85,14 +81,10 @@ services:
       mode: replicated
       replicas: '${DISCOVERY_PROVIDER_REPLICAS}'
     healthcheck:
-      test:
-        [
-          'CMD-SHELL',
-          'curl -f http://localhost:6002/solana/health_check || exit 1'
-        ]
-      interval: 5s
-      timeout: 30s
-      retries: 15
+      test: ['CMD', 'curl', '-f', 'http://127.0.0.1:6001/solana/health_check']
+      interval: 1s
+      timeout: 1s
+      retries: 60
       start_period: 5s
     depends_on:
       db:

--- a/dev-tools/compose/docker-compose.pedalboard.prod.yml
+++ b/dev-tools/compose/docker-compose.pedalboard.prod.yml
@@ -81,7 +81,7 @@ services:
       mode: replicated
       replicas: '${DISCOVERY_PROVIDER_REPLICAS}'
     healthcheck:
-      test: ['CMD', 'curl', '-f', 'http://127.0.0.1:6001/solana/health_check']
+      test: ['CMD', 'curl', '-f', 'http://127.0.0.1:6002/solana/health_check']
       interval: 1s
       timeout: 1s
       retries: 60

--- a/eth-contracts/Dockerfile
+++ b/eth-contracts/Dockerfile
@@ -20,7 +20,6 @@ COPY ./truffle-config.js ./contract-config.js .solcover.js ./
 
 RUN chmod +x ./scripts/setup-predeployed-ganache.sh ./scripts/setup-dev.sh
 
-
 ARG CONTENT_NODE_VERSION
 ARG DISCOVERY_NODE_VERSION
 

--- a/eth-contracts/Dockerfile
+++ b/eth-contracts/Dockerfile
@@ -1,22 +1,30 @@
 # Uses separate stage for nodejs deps despite caching to avoid installing build tools
 FROM node:18.16 as builder
 COPY package*.json ./
-RUN --mount=type=cache,target=/root/.npm npm ci
+RUN npm ci
 
 FROM node:18-slim
 
 WORKDIR /usr/src/app
 
+COPY --from=builder package*.json ./
 COPY --from=builder /node_modules ./node_modules
-COPY . .
 
 RUN npm run postinstall
 
-RUN ./scripts/setup-predeployed-ganache.sh /usr/db 1000000000000
+COPY ./contracts ./contracts
+COPY ./migrations ./migrations 
+COPY ./scripts ./scripts 
+COPY ./utils ./utils
+COPY ./truffle-config.js ./contract-config.js .solcover.js ./
+
+RUN chmod +x ./scripts/setup-predeployed-ganache.sh ./scripts/setup-dev.sh
+
 
 ARG CONTENT_NODE_VERSION
 ARG DISCOVERY_NODE_VERSION
 
+RUN ./scripts/setup-predeployed-ganache.sh /usr/db 1000000000000
 RUN ./scripts/setup-dev.sh /usr/db 1000000000000
 
 HEALTHCHECK --interval=5s --timeout=5s --retries=10 \

--- a/eth-contracts/scripts/setup-predeployed-ganache.sh
+++ b/eth-contracts/scripts/setup-predeployed-ganache.sh
@@ -19,6 +19,7 @@ fi
 mkdir -p $dbPath
 npx ganache \
     --server.host "0.0.0.0" \
+    --server.port 8545 \
     --wallet.deterministic \
     --wallet.totalAccounts 50 \
     --database.dbPath "$dbPath" \

--- a/packages/discovery-provider/plugins/pedalboard/apps/solana-relay/package.json
+++ b/packages/discovery-provider/plugins/pedalboard/apps/solana-relay/package.json
@@ -54,6 +54,7 @@
     "eslint": "8.56.0",
     "eslint-config-custom-server": "*",
     "tsconfig": "*",
+    "tsx": "^4.19.2",
     "typescript": "5.0.4",
     "vitest": "0.34.6"
   }


### PR DESCRIPTION
docker is like an onion, lots of layers

- modifies the dockerfiles for both eth and poa ganache to only copy over what they need, this now effectively caches the predeploy script so long as the script doesn't change
- also removes buildkit for these as i don't think it was useful
- changes the deploy script for poa-ganache to use 8546 internally for migrations so it doesn't conflict with eth, this solves the port conflict problem when they're "upped" together and the predeploy isn't cached
- modifies the pedalboard docker-compose file to correctly resolve the relay and solana-relay health checks
- also adds tsx as a dev dep for solana-relay as sol relay had to install tsx before starting the server each time, increasing it's startup and making it's health check fail on occasion
- this above note does require a `npm i` from within the solana relay container to get the right build binary, maybe this should be a part of the dockerfile and we use tsx for all plugins? @rickyrombo curious on your thoughts here

@sliptype tagging you since the root lockfile changed and i'm never sure if it changed "correctly" but i think i did it right this time
used `npm i tsx -w=@pedalboard/solana-relay`