### PR TITLE
Fix essentia build commit

### DIFF
--- a/cmd/audiusd/Dockerfile
+++ b/cmd/audiusd/Dockerfile
@@ -38,7 +38,7 @@ RUN git clone https://github.com/mixxxdj/libKeyFinder.git /libKeyFinder && \
     cmake --install build
 
 # essentia release tags are very old - pin to a more recent commit
-ENV ESSENTIA_COMMIT="eaf8ddfd9a603fdda9850731cc39f06e6262afe5"
+ENV ESSENTIA_COMMIT="ed59cc48e37ac33ac15b252fc5ad7af4b9ecd51d"
 ENV PKG_CONFIG_PATH="/usr/local/lib/pkgconfig:/usr/lib/pkgconfig:/usr/lib/aarch64-linux-gnu/pkgconfig:/usr/share/pkgconfig"
 RUN git clone --depth 1 https://github.com/MTG/essentia.git /essentia && \
     cd /essentia && \

--- a/cmd/audiusd/Dockerfile
+++ b/cmd/audiusd/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:bookworm AS cpp-builder
+FROM debian:bullseye AS cpp-builder
 
 RUN apt-get update && apt-get install -y \
     build-essential \
@@ -8,7 +8,7 @@ RUN apt-get update && apt-get install -y \
     gcc \
     ffmpeg \
     libmp3lame-dev \
-    python3.11 \
+    python3.9 \
     python3-pip \
     libsndfile1-dev \
     libeigen3-dev \
@@ -37,9 +37,10 @@ RUN git clone https://github.com/mixxxdj/libKeyFinder.git /libKeyFinder && \
     cmake --build build --parallel $(nproc) && \
     cmake --install build
 
-# essentia release tags are very old - pin to a more recent commit
+# commit chosen from 2.1-beta tag.
 ENV ESSENTIA_COMMIT="ed59cc48e37ac33ac15b252fc5ad7af4b9ecd51d"
-ENV PKG_CONFIG_PATH="/usr/local/lib/pkgconfig:/usr/lib/pkgconfig:/usr/lib/aarch64-linux-gnu/pkgconfig:/usr/share/pkgconfig"
+# include pkg config so that essentia can pull libs in instead of building itself
+ENV PKG_CONFIG_PATH="/usr/local/lib/pkgconfig:/usr/lib/pkgconfig:/usr/lib/aarch64-linux-gnu/pkgconfig:/usr/share/pkgconfig:/usr/lib/x86_64-linux-gnu/pkgconfig"
 RUN git clone --depth 1 https://github.com/MTG/essentia.git /essentia && \
     cd /essentia && \
     git fetch --depth 1 origin $ESSENTIA_COMMIT && \

--- a/cmd/audiusd/Dockerfile
+++ b/cmd/audiusd/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:bullseye AS cpp-builder
+FROM debian:bookworm AS cpp-builder
 
 RUN apt-get update && apt-get install -y \
     build-essential \
@@ -8,7 +8,7 @@ RUN apt-get update && apt-get install -y \
     gcc \
     ffmpeg \
     libmp3lame-dev \
-    python3.9 \
+    python3.11 \
     python3-pip \
     libsndfile1-dev \
     libeigen3-dev \
@@ -37,8 +37,8 @@ RUN git clone https://github.com/mixxxdj/libKeyFinder.git /libKeyFinder && \
     cmake --build build --parallel $(nproc) && \
     cmake --install build
 
-# commit chosen from 2.1-beta tag.
-ENV ESSENTIA_COMMIT="ed59cc48e37ac33ac15b252fc5ad7af4b9ecd51d"
+# stable version with python3.11 support
+ENV ESSENTIA_COMMIT="eaf8ddfd9a603fdda9850731cc39f06e6262afe5"
 # include pkg config so that essentia can pull libs in instead of building itself
 ENV PKG_CONFIG_PATH="/usr/local/lib/pkgconfig:/usr/lib/pkgconfig:/usr/lib/aarch64-linux-gnu/pkgconfig:/usr/share/pkgconfig:/usr/lib/x86_64-linux-gnu/pkgconfig"
 RUN git clone --depth 1 https://github.com/MTG/essentia.git /essentia && \

--- a/cmd/mediorum/Dockerfile
+++ b/cmd/mediorum/Dockerfile
@@ -38,7 +38,7 @@ RUN git clone https://github.com/mixxxdj/libKeyFinder.git /libKeyFinder && \
     cmake --install build
 
 # essentia release tags are very old - pin to a more recent commit
-ENV ESSENTIA_COMMIT="eaf8ddfd9a603fdda9850731cc39f06e6262afe5"
+ENV ESSENTIA_COMMIT="ed59cc48e37ac33ac15b252fc5ad7af4b9ecd51d"
 ENV PKG_CONFIG_PATH="/usr/local/lib/pkgconfig:/usr/lib/pkgconfig:/usr/lib/aarch64-linux-gnu/pkgconfig:/usr/share/pkgconfig"
 RUN git clone --depth 1 https://github.com/MTG/essentia.git /essentia && \
     cd /essentia && \

--- a/cmd/mediorum/Dockerfile
+++ b/cmd/mediorum/Dockerfile
@@ -37,9 +37,10 @@ RUN git clone https://github.com/mixxxdj/libKeyFinder.git /libKeyFinder && \
     cmake --build build --parallel $(nproc) && \
     cmake --install build
 
-# essentia release tags are very old - pin to a more recent commit
+# commit chosen from 2.1-beta tag.
 ENV ESSENTIA_COMMIT="ed59cc48e37ac33ac15b252fc5ad7af4b9ecd51d"
-ENV PKG_CONFIG_PATH="/usr/local/lib/pkgconfig:/usr/lib/pkgconfig:/usr/lib/aarch64-linux-gnu/pkgconfig:/usr/share/pkgconfig"
+# include pkg config so that essentia can pull libs in instead of building itself
+ENV PKG_CONFIG_PATH="/usr/local/lib/pkgconfig:/usr/lib/pkgconfig:/usr/lib/aarch64-linux-gnu/pkgconfig:/usr/share/pkgconfig:/usr/lib/x86_64-linux-gnu/pkgconfig"
 RUN git clone --depth 1 https://github.com/MTG/essentia.git /essentia && \
     cd /essentia && \
     git fetch --depth 1 origin $ESSENTIA_COMMIT && \

--- a/cmd/mediorum/Dockerfile
+++ b/cmd/mediorum/Dockerfile
@@ -37,8 +37,8 @@ RUN git clone https://github.com/mixxxdj/libKeyFinder.git /libKeyFinder && \
     cmake --build build --parallel $(nproc) && \
     cmake --install build
 
-# commit chosen from 2.1-beta tag.
-ENV ESSENTIA_COMMIT="ed59cc48e37ac33ac15b252fc5ad7af4b9ecd51d"
+# stable version with python3.11 support
+ENV ESSENTIA_COMMIT="eaf8ddfd9a603fdda9850731cc39f06e6262afe5"
 # include pkg config so that essentia can pull libs in instead of building itself
 ENV PKG_CONFIG_PATH="/usr/local/lib/pkgconfig:/usr/lib/pkgconfig:/usr/lib/aarch64-linux-gnu/pkgconfig:/usr/share/pkgconfig:/usr/lib/x86_64-linux-gnu/pkgconfig"
 RUN git clone --depth 1 https://github.com/MTG/essentia.git /essentia && \


### PR DESCRIPTION
### Description

After moving essentia to no longer build-static (https://github.com/AudiusProject/audius-protocol/pull/10398/files), we lost the ability to analyze because we were missing `MonoLoader`

Was able to get that working again by including `/usr/lib/x86_64-linux-gnu/pkgconfig` in the package config for configuring essentia. Helpful reference: https://github.com/MTG/essentia/issues/273

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._

Tested on staging
1. Uploaded track which got correctly tagged with key/bpm
2. Edited the track from free => premium, which generated a preview correctly as well