### PR TITLE
Fix some issues with audius-cmd restarting identity

### DIFF
--- a/dev-tools/README.md
+++ b/dev-tools/README.md
@@ -53,6 +53,9 @@ View all available commands for any of these tools with `--help`, e.g.
 You can confirm that things are wired up correctly by running `audius-cmd create-user`.
 Note that `audius-cmd` requires the stack to be up and healthy, per [Bring up the protocol](#bring-up-the-protocol), and to have run `audius-compose connect`.
 
+The `audius-cmd` script in this directory will build the `audius-cmd` tool if it detects
+the output is missing. Otherwise, you can force a build by running `audius-cmd build`
+
 Examples of available commands can be found [here](../packages/commands)
 
 # Helpful Commands

--- a/dev-tools/audius-cmd
+++ b/dev-tools/audius-cmd
@@ -1,8 +1,14 @@
 #!/usr/bin/env bash
 set -e
 
-cd "$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")"/compose  # audius-protocol/dev-tools/compose
+PROJECT_DIR=$(dirname "$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")")
+cd "$PROJECT_DIR"/dev-tools/compose  # audius-protocol/dev-tools/compose
 export COMPOSE_PROJECT_NAME='audius-protocol'
+
+if [[ "$1" == "build" ]]; then
+	turbo run build --filter=@audius/commands
+	exit
+fi
 
 if [[ "$1" == "test" ]]; then
 	docker compose exec audius-cmd npm test
@@ -24,7 +30,11 @@ for arg in "$@"; do
 	fi
 done
 
-turbo run build --filter=@audius/commands
+if [[ ! -f "$PROJECT_DIR/packages/commands/dist/index.js" ]]; then
+	turbo run build --filter=@audius/commands
+	# Give container time to sync output
+	sleep 1
+fi
 docker compose exec audius-cmd node dist/index.js "${updated_args[@]}" || true
 
 for tmpfile in "${tmpfiles[@]}"; do

--- a/packages/commands/Dockerfile.dev
+++ b/packages/commands/Dockerfile.dev
@@ -5,7 +5,5 @@ FROM node:18-alpine AS base
 RUN apk add --no-cache bash ffmpeg
 RUN apk update
 
-RUN npx turbo run build --filter=@audius/commands
-
 WORKDIR /app/packages/commands
 CMD sleep infinity

--- a/packages/commands/Dockerfile.dev
+++ b/packages/commands/Dockerfile.dev
@@ -5,5 +5,7 @@ FROM node:18-alpine AS base
 RUN apk add --no-cache bash ffmpeg
 RUN apk update
 
+RUN npx turbo run build --filter=@audius/commands
+
 WORKDIR /app/packages/commands
 CMD sleep infinity

--- a/packages/commands/README.md
+++ b/packages/commands/README.md
@@ -7,6 +7,14 @@ audius-cmd <command> --help
 
 `audius-cmd` is a command line tool to perform actions against the Audius protocol. It is especially useful to seed data on an instance of the protocol running locally
 
+## Building
+
+This tool needs to be built at least once before running.
+
+`npm run build:dist` will issue a turbo-enabled build and write the output to `dist`.
+
+If you plan on developing commands, you can run `npm run watch:dist` to start a watcher, which will rebuild any time the files in `src` change.
+
 ## Examples
 
 **create-user**


### PR DESCRIPTION
### Description
Something about the turbo cache is interacting poorly with identity service and causing it to restart even though turbo reports a full cache hit on all dependencies. To make this a little more usable, I updated the dev-tools script to only auto-build if the dist file doesn't exist yet. Otherwise you can now do `audius-cmd build` to explicitly build the output (for instance if you changed something or it's out of date).

It's a compromise between auto-building if deps change and breaking identity due to whatever filesystem weirdness is going on. I will come back to this later to try and find a better long term solution. But I would like to unblock devs for now.

### How Has This Been Tested?
Local stack.
