### PR TITLE
[PAY-3614] Add entity manager support for emails

### DIFF
--- a/packages/discovery-provider/integration_tests/tasks/entity_manager/test_email_entity_manager.py
+++ b/packages/discovery-provider/integration_tests/tasks/entity_manager/test_email_entity_manager.py
@@ -1,0 +1,221 @@
+import json
+
+from web3 import Web3
+from web3.datastructures import AttributeDict
+
+from integration_tests.challenges.index_helpers import UpdateTask
+from integration_tests.utils import populate_mock_db
+from src.models.users.email import EmailAccessKey, EmailEncryptionKey, EncryptedEmail
+from src.tasks.entity_manager.entity_manager import entity_manager_update
+from src.tasks.entity_manager.utils import Action, EntityType
+from src.utils.db_session import get_db
+
+
+def test_index_valid_email(app, mocker):
+    """Test indexing valid email operations"""
+    with app.app_context():
+        db = get_db()
+        web3 = Web3()
+        update_task = UpdateTask(web3, None)
+
+        # Test data for valid email operations
+        valid_email_data = {
+            "primary_user_id": 1,
+            "email_owner_user_id": 1,
+            "encrypted_email": "encrypted_email_content",
+            "encrypted_key": "encrypted_key_content",
+            "delegated_user_ids": [2],
+            "delegated_keys": ["delegated_key"],
+        }
+
+        tx_receipts = {
+            "CreateEmailTx": [
+                {
+                    "args": AttributeDict(
+                        {
+                            "_entityId": 0,
+                            "_entityType": EntityType.ENCRYPTED_EMAIL,
+                            "_userId": valid_email_data["primary_user_id"],
+                            "_action": Action.ADD_EMAIL,
+                            "_metadata": json.dumps(
+                                {"cid": "", "data": valid_email_data}
+                            ),
+                            "_signer": "user1wallet",
+                        }
+                    )
+                }
+            ],
+            "UpdateEmailTx": [
+                {
+                    "args": AttributeDict(
+                        {
+                            "_entityId": 0,
+                            "_entityType": EntityType.ENCRYPTED_EMAIL,
+                            "_userId": valid_email_data["primary_user_id"],
+                            "_action": Action.UPDATE_EMAIL,
+                            "_metadata": json.dumps(
+                                {
+                                    "cid": "",
+                                    "data": {
+                                        "primary_user_id": valid_email_data[
+                                            "primary_user_id"
+                                        ],
+                                        "email_owner_user_id": valid_email_data[
+                                            "email_owner_user_id"
+                                        ],
+                                        "encrypted_email": "updated_encrypted_email",
+                                        "encrypted_key": "updated_encrypted_key",
+                                        "delegated_user_ids": [2],
+                                        "delegated_keys": ["updated_delegated_key"],
+                                    },
+                                }
+                            ),
+                            "_signer": "user1wallet",
+                        }
+                    )
+                }
+            ],
+        }
+
+        entity_manager_txs = [
+            AttributeDict(
+                {"transactionHash": update_task.web3.to_bytes(text=tx_receipt)}
+            )
+            for tx_receipt in tx_receipts
+        ]
+
+        def get_events_side_effect(_, tx_receipt):
+            return tx_receipts[tx_receipt["transactionHash"].decode("utf-8")]
+
+        mocker.patch(
+            "src.tasks.entity_manager.entity_manager.get_entity_manager_events_tx",
+            side_effect=get_events_side_effect,
+            autospec=True,
+        )
+
+        entities = {
+            "users": [
+                {"user_id": 1, "handle": "user-1", "wallet": "user1wallet"},
+                {"user_id": 2, "handle": "user-2", "wallet": "user2wallet"},
+                {"user_id": 3, "handle": "user-3", "wallet": "user3wallet"},
+            ]
+        }
+
+        populate_mock_db(db, entities)
+
+        with db.scoped_session() as session:
+            # Index transactions
+            entity_manager_update(
+                update_task,
+                session,
+                entity_manager_txs,
+                block_number=1,
+                block_timestamp=1000000000,
+                block_hash=hex(0),
+            )
+
+            # Validate db records after create
+            encrypted_emails = session.query(EncryptedEmail).all()
+            assert len(encrypted_emails) == 1
+            email = encrypted_emails[0]
+            assert email.primary_user_id == valid_email_data["primary_user_id"]
+            assert email.email_owner_user_id == valid_email_data["email_owner_user_id"]
+            assert email.encrypted_email == "encrypted_email_content"
+
+            # Validate encryption key
+            encryption_key = session.query(EmailEncryptionKey).first()
+            assert encryption_key is not None
+            assert encryption_key.primary_user_id == valid_email_data["primary_user_id"]
+            assert encryption_key.encrypted_key == "encrypted_key_content"
+
+            # Validate access keys
+            access_keys = session.query(EmailAccessKey).all()
+            assert len(access_keys) == 1
+            assert access_keys[0].primary_user_id == valid_email_data["primary_user_id"]
+            assert access_keys[0].delegated_user_id == 2
+            assert access_keys[0].encrypted_key == "delegated_key"
+
+
+def test_index_invalid_email(app, mocker):
+    """Test indexing invalid email operations"""
+    with app.app_context():
+        db = get_db()
+        web3 = Web3()
+        update_task = UpdateTask(web3, None)
+
+        # Test data for invalid email operations
+        invalid_email_data = {
+            "primary_user_id": 999,  # Non-existent user
+            "email_owner_user_id": 999,
+            "encrypted_email": "encrypted_email_content",
+            "encrypted_key": "encrypted_key_content",
+            "delegated_user_ids": [888],  # Non-existent delegated user
+            "delegated_keys": ["delegated_key"],
+        }
+
+        tx_receipts = {
+            "CreateEmailTx": [
+                {
+                    "args": AttributeDict(
+                        {
+                            "_entityId": 0,
+                            "_entityType": EntityType.ENCRYPTED_EMAIL,
+                            "_userId": invalid_email_data["primary_user_id"],
+                            "_action": Action.ADD_EMAIL,
+                            "_metadata": json.dumps(
+                                {"cid": "", "data": invalid_email_data}
+                            ),
+                            "_signer": "nonexistentwallet",
+                        }
+                    )
+                }
+            ]
+        }
+
+        entity_manager_txs = [
+            AttributeDict(
+                {"transactionHash": update_task.web3.to_bytes(text=tx_receipt)}
+            )
+            for tx_receipt in tx_receipts
+        ]
+
+        def get_events_side_effect(_, tx_receipt):
+            return tx_receipts[tx_receipt["transactionHash"].decode("utf-8")]
+
+        mocker.patch(
+            "src.tasks.entity_manager.entity_manager.get_entity_manager_events_tx",
+            side_effect=get_events_side_effect,
+            autospec=True,
+        )
+
+        entities = {
+            "users": [
+                {"user_id": 1, "handle": "user-1", "wallet": "user1wallet"},
+                {"user_id": 2, "handle": "user-2", "wallet": "user2wallet"},
+            ]
+        }
+
+        populate_mock_db(db, entities)
+
+        with db.scoped_session() as session:
+            # Index transactions
+            entity_manager_update(
+                update_task,
+                session,
+                entity_manager_txs,
+                block_number=1,
+                block_timestamp=1000000000,
+                block_hash=hex(0),
+            )
+
+            # Validate that no records were created for invalid data
+            encrypted_emails = session.query(EncryptedEmail).all()
+            assert len(encrypted_emails) == 0
+
+            # Validate no encryption key was created
+            encryption_key = session.query(EmailEncryptionKey).first()
+            assert encryption_key is None
+
+            # Validate no access keys were created
+            access_keys = session.query(EmailAccessKey).all()
+            assert len(access_keys) == 0

--- a/packages/discovery-provider/integration_tests/utils.py
+++ b/packages/discovery-provider/integration_tests/utils.py
@@ -43,6 +43,7 @@ from src.models.tracks.track_price_history import TrackPriceHistory
 from src.models.tracks.track_route import TrackRoute
 from src.models.users.aggregate_user import AggregateUser
 from src.models.users.associated_wallet import AssociatedWallet, WalletChain
+from src.models.users.email import EmailAccessKey, EmailEncryptionKey, EncryptedEmail
 from src.models.users.supporter_rank_up import SupporterRankUp
 from src.models.users.usdc_purchase import PurchaseAccessType, USDCPurchase
 from src.models.users.usdc_transactions_history import (
@@ -179,6 +180,9 @@ def populate_mock_db(db, entities, block_offset=None):
         track_price_history = entities.get("track_price_history", [])
         album_price_history = entities.get("album_price_history", [])
         user_payout_wallet_history = entities.get("user_payout_wallet_history", [])
+        encrypted_emails = entities.get("encrypted_emails", [])
+        email_encryption_keys = entities.get("email_encryption_keys", [])
+        email_access_keys = entities.get("email_access_keys", [])
 
         num_blocks = max(
             len(tracks),
@@ -895,5 +899,34 @@ def populate_mock_db(db, entities, block_offset=None):
                 blocknumber=i + block_offset,
             )
             session.add(muted_user_record)
+
+        for i, encrypted_email_meta in enumerate(encrypted_emails):
+            encrypted_email = EncryptedEmail(
+                email_owner_user_id=encrypted_email_meta.get("email_owner_user_id", i),
+                primary_user_id=encrypted_email_meta.get("primary_user_id", i),
+                encrypted_email=encrypted_email_meta.get("encrypted_email", ""),
+                created_at=encrypted_email_meta.get("created_at", datetime.now()),
+                updated_at=encrypted_email_meta.get("updated_at", datetime.now()),
+            )
+            session.add(encrypted_email)
+
+        for i, email_encryption_key_meta in enumerate(email_encryption_keys):
+            email_encryption_key = EmailEncryptionKey(
+                primary_user_id=email_encryption_key_meta.get("primary_user_id", i),
+                encrypted_key=email_encryption_key_meta.get("encrypted_key", ""),
+                created_at=email_encryption_key_meta.get("created_at", datetime.now()),
+                updated_at=email_encryption_key_meta.get("updated_at", datetime.now()),
+            )
+            session.add(email_encryption_key)
+
+        for i, email_access_key_meta in enumerate(email_access_keys):
+            email_access_key = EmailAccessKey(
+                primary_user_id=email_access_key_meta.get("primary_user_id", i),
+                delegated_user_id=email_access_key_meta.get("delegated_user_id", i),
+                encrypted_key=email_access_key_meta.get("encrypted_key", ""),
+                created_at=email_access_key_meta.get("created_at", datetime.now()),
+                updated_at=email_access_key_meta.get("updated_at", datetime.now()),
+            )
+            session.add(email_access_key)
 
         session.commit()

--- a/packages/discovery-provider/src/tasks/entity_manager/entities/email.py
+++ b/packages/discovery-provider/src/tasks/entity_manager/entities/email.py
@@ -26,20 +26,24 @@ def validate_email_metadata(params: ManageEntityParameters) -> None:
         if not primary_user_id:
             raise IndexingValidationError("primary_user_id is required")
 
-        if params.action in [Action.ADD_EMAIL, Action.UPDATE_EMAIL]:
-            required_fields = [
-                "primary_user_id",
-                "email_owner_user_id",
-                "encrypted_email",
-                "encrypted_key",
-            ]
-            missing_fields = [
-                field for field in required_fields if not params.metadata.get(field)
-            ]
-            if missing_fields:
-                raise IndexingValidationError(
-                    f"Missing required fields: {', '.join(missing_fields)}"
-                )
+        if params.action not in [Action.ADD_EMAIL, Action.UPDATE_EMAIL]:
+            raise IndexingValidationError(
+                "email.py | Expected action to be AddEmail or UpdateEmail"
+            )
+
+        required_fields = [
+            "primary_user_id",
+            "email_owner_user_id",
+            "encrypted_email",
+            "encrypted_key",
+        ]
+        missing_fields = [
+            field for field in required_fields if not params.metadata.get(field)
+        ]
+        if missing_fields:
+            raise IndexingValidationError(
+                f"Missing required fields: {', '.join(missing_fields)}"
+            )
 
     except Exception as e:
         logger.error(
@@ -50,7 +54,7 @@ def validate_email_metadata(params: ManageEntityParameters) -> None:
                 "primary_user_id": params.metadata.get("primary_user_id"),
             },
         )
-        raise
+        raise e
 
 
 def validate_delegated_access(

--- a/packages/discovery-provider/src/tasks/entity_manager/entities/email.py
+++ b/packages/discovery-provider/src/tasks/entity_manager/entities/email.py
@@ -1,0 +1,260 @@
+from typing import List, Optional
+
+from src.exceptions import IndexingValidationError
+from src.models.users.email import EmailAccessKey, EmailEncryptionKey, EncryptedEmail
+from src.tasks.entity_manager.utils import (
+    Action,
+    EntityType,
+    ManageEntityParameters,
+    validate_signer,
+)
+from src.utils.structured_logger import StructuredLogger
+
+logger = StructuredLogger(__name__)
+
+
+def validate_email_metadata(params: ManageEntityParameters) -> None:
+    """
+    Validates the required fields in email metadata
+    Raises IndexingValidationError if validation fails
+    """
+    try:
+        if not isinstance(params.metadata, dict):
+            raise IndexingValidationError("Email metadata must be a dictionary")
+
+        primary_user_id = params.metadata.get("primary_user_id")
+        if not primary_user_id:
+            raise IndexingValidationError("primary_user_id is required")
+
+        if params.action in [Action.ADD_EMAIL, Action.UPDATE_EMAIL]:
+            required_fields = [
+                "primary_user_id",
+                "email_owner_user_id",
+                "encrypted_email",
+                "encrypted_key",
+            ]
+            missing_fields = [
+                field for field in required_fields if not params.metadata.get(field)
+            ]
+            if missing_fields:
+                raise IndexingValidationError(
+                    f"Missing required fields: {', '.join(missing_fields)}"
+                )
+
+    except Exception as e:
+        logger.error(
+            "email.py | Error validating email metadata",
+            extra={
+                "error": str(e),
+                "action": params.action,
+                "primary_user_id": params.metadata.get("primary_user_id"),
+            },
+        )
+        raise
+
+
+def validate_delegated_access(
+    delegated_user_ids: List[int], delegated_keys: List[str]
+) -> None:
+    """
+    Validates delegated access data
+    Raises IndexingValidationError if validation fails
+    """
+    if len(delegated_user_ids) != len(delegated_keys):
+        raise IndexingValidationError(
+            f"Mismatched number of delegated users ({len(delegated_user_ids)}) and keys ({len(delegated_keys)})"
+        )
+
+
+def get_existing_email(
+    params: ManageEntityParameters,
+) -> Optional[EncryptedEmail]:
+    """Gets existing email record if it exists"""
+    try:
+        return (
+            params.session.query(EncryptedEmail)
+            .filter(
+                EncryptedEmail.primary_user_id == params.metadata["primary_user_id"],
+                EncryptedEmail.email_owner_user_id
+                == params.metadata["email_owner_user_id"],
+            )
+            .first()
+        )
+    except Exception as e:
+        logger.error(
+            "email.py | Error fetching existing email",
+            extra={
+                "error": str(e),
+                "primary_user_id": params.metadata.get("primary_user_id"),
+                "email_owner_user_id": params.metadata.get("email_owner_user_id"),
+            },
+        )
+        raise
+
+
+def handle_delegated_access(
+    params: ManageEntityParameters,
+) -> None:
+    """
+    Handles creation/update of delegated access keys
+    """
+    try:
+        delegated_user_ids = params.metadata.get("delegated_user_ids", [])
+        delegated_keys = params.metadata.get("delegated_keys", [])
+
+        validate_delegated_access(delegated_user_ids, delegated_keys)
+
+        # Remove existing access keys if updating
+        if params.action == Action.UPDATE_EMAIL:
+            params.session.query(EmailAccessKey).filter(
+                EmailAccessKey.primary_user_id == params.metadata["primary_user_id"]
+            ).delete()
+
+        # Add new access keys
+        for delegated_user_id, delegated_key in zip(delegated_user_ids, delegated_keys):
+            new_access_key = EmailAccessKey(
+                primary_user_id=params.metadata["primary_user_id"],
+                delegated_user_id=delegated_user_id,
+                encrypted_key=delegated_key,
+            )
+            params.add_record(
+                params.metadata["primary_user_id"],
+                new_access_key,
+                EntityType.EMAIL_ACCESS_KEY,
+            )
+
+    except Exception as e:
+        logger.error(
+            "email.py | Error handling delegated access",
+            extra={
+                "error": str(e),
+                "primary_user_id": params.metadata.get("primary_user_id"),
+            },
+        )
+        raise
+
+
+def create_encrypted_email(params: ManageEntityParameters) -> None:
+    """Create a new encrypted email record with encryption key and optional delegated access."""
+    logger.debug(
+        "email.py | Processing create email request",
+        extra={"primary_user_id": params.metadata.get("primary_user_id")},
+    )
+
+    try:
+        validate_signer(params)
+        validate_email_metadata(params)
+
+        # Check for existing email
+        if get_existing_email(params):
+            logger.info(
+                "email.py | Email already exists",
+                extra={
+                    "primary_user_id": params.metadata["primary_user_id"],
+                    "email_owner_user_id": params.metadata["email_owner_user_id"],
+                },
+            )
+            return
+
+        # Create email record
+        new_email = EncryptedEmail(
+            email_owner_user_id=params.metadata["email_owner_user_id"],
+            primary_user_id=params.metadata["primary_user_id"],
+            encrypted_email=params.metadata["encrypted_email"],
+        )
+        params.add_record(
+            params.metadata["primary_user_id"], new_email, EntityType.ENCRYPTED_EMAIL
+        )
+
+        # Create encryption key record
+        new_key = EmailEncryptionKey(
+            primary_user_id=params.metadata["primary_user_id"],
+            encrypted_key=params.metadata["encrypted_key"],
+        )
+        params.add_record(
+            params.metadata["primary_user_id"], new_key, EntityType.EMAIL_ENCRYPTION_KEY
+        )
+
+        # Handle delegated access
+        handle_delegated_access(params)
+
+        logger.debug(
+            "email.py | Successfully created encrypted email",
+            extra={"primary_user_id": params.metadata["primary_user_id"]},
+        )
+
+    except Exception as e:
+        logger.error(
+            "email.py | Error creating encrypted email",
+            extra={
+                "error": str(e),
+                "primary_user_id": params.metadata.get("primary_user_id"),
+            },
+        )
+        raise
+
+
+def update_encrypted_email(params: ManageEntityParameters) -> None:
+    """Update an encrypted email record with encryption key and delegated access."""
+    logger.debug(
+        "email.py | Processing update email request",
+        extra={"primary_user_id": params.metadata.get("primary_user_id")},
+    )
+
+    try:
+        validate_signer(params)
+        validate_email_metadata(params)
+
+        # Get existing email
+        email = get_existing_email(params)
+        if not email:
+            raise IndexingValidationError("Email record not found")
+
+        # Update email
+        email.encrypted_email = params.metadata["encrypted_email"]
+        params.add_record(
+            params.metadata["primary_user_id"], email, EntityType.ENCRYPTED_EMAIL
+        )
+
+        # Update encryption key
+        key = (
+            params.session.query(EmailEncryptionKey)
+            .filter(
+                EmailEncryptionKey.primary_user_id == params.metadata["primary_user_id"]
+            )
+            .first()
+        )
+
+        if key:
+            key.encrypted_key = params.metadata["encrypted_key"]
+            params.add_record(
+                params.metadata["primary_user_id"], key, EntityType.EMAIL_ENCRYPTION_KEY
+            )
+        else:
+            new_key = EmailEncryptionKey(
+                primary_user_id=params.metadata["primary_user_id"],
+                encrypted_key=params.metadata["encrypted_key"],
+            )
+            params.add_record(
+                params.metadata["primary_user_id"],
+                new_key,
+                EntityType.EMAIL_ENCRYPTION_KEY,
+            )
+
+        # Handle delegated access
+        handle_delegated_access(params)
+
+        logger.debug(
+            "email.py | Successfully updated encrypted email",
+            extra={"primary_user_id": params.metadata["primary_user_id"]},
+        )
+
+    except Exception as e:
+        logger.error(
+            "email.py | Error updating encrypted email",
+            extra={
+                "error": str(e),
+                "primary_user_id": params.metadata.get("primary_user_id"),
+            },
+        )
+        raise

--- a/packages/discovery-provider/src/tasks/entity_manager/entity_manager.py
+++ b/packages/discovery-provider/src/tasks/entity_manager/entity_manager.py
@@ -32,6 +32,7 @@ from src.models.social.subscription import Subscription
 from src.models.tracks.track import Track
 from src.models.tracks.track_route import TrackRoute
 from src.models.users.associated_wallet import AssociatedWallet
+from src.models.users.email import EmailAccessKey, EmailEncryptionKey, EncryptedEmail
 from src.models.users.user import User
 from src.models.users.user_events import UserEvent
 from src.queries.confirm_indexing_transaction_error import (
@@ -61,6 +62,10 @@ from src.tasks.entity_manager.entities.developer_app import (
     create_developer_app,
     delete_developer_app,
     update_developer_app,
+)
+from src.tasks.entity_manager.entities.email import (
+    create_encrypted_email,
+    update_encrypted_email,
 )
 from src.tasks.entity_manager.entities.grant import (
     approve_grant,
@@ -140,6 +145,9 @@ entity_type_table_mapping = {
     "CommentReaction": CommentReaction.__tablename__,
     "MutedUser": MutedUser.__tablename__,
     "CommentNotificationSetting": CommentNotificationSetting.__tablename__,
+    "EncryptedEmail": EncryptedEmail.__tablename__,
+    "EmailEncryptionKey": EmailEncryptionKey.__tablename__,
+    "EmailAccessKey": EmailAccessKey.__tablename__,
 }
 
 
@@ -423,6 +431,16 @@ def entity_manager_update(
                         params.action == Action.MUTE or params.action == Action.UNMUTE
                     ) and params.entity_type == EntityType.COMMENT:
                         update_comment_notification_setting(params)
+                    elif (
+                        params.action == Action.ADD_EMAIL
+                        and params.entity_type == EntityType.ENCRYPTED_EMAIL
+                    ):
+                        create_encrypted_email(params)
+                    elif (
+                        params.action == Action.UPDATE_EMAIL
+                        and params.entity_type == EntityType.ENCRYPTED_EMAIL
+                    ):
+                        update_encrypted_email(params)
 
                     logger.debug("process transaction")  # log event context
                 except IndexingValidationError as e:
@@ -560,7 +578,15 @@ def copy_original_records(existing_records):
 
 
 entity_types_to_fetch = set(
-    [EntityType.USER, EntityType.TRACK, EntityType.PLAYLIST, EntityType.COMMENT]
+    [
+        EntityType.USER,
+        EntityType.TRACK,
+        EntityType.PLAYLIST,
+        EntityType.COMMENT,
+        EntityType.ENCRYPTED_EMAIL,
+        EntityType.EMAIL_ENCRYPTION_KEY,
+        EntityType.EMAIL_ACCESS_KEY,
+    ]
 )
 
 
@@ -760,6 +786,39 @@ def collect_entities_to_fetch(update_task, entity_manager_txs):
                     user_id = json_metadata.get("ai_attribution_user_id")
                     if user_id:
                         entities_to_fetch[EntityType.USER].add(user_id)
+
+            if entity_type == EntityType.ENCRYPTED_EMAIL:
+                try:
+                    json_metadata = json.loads(metadata)
+                except Exception as e:
+                    logger.error(
+                        f"tasks | entity_manager.py | Exception deserializing {action} {entity_type} event metadata: {e}"
+                    )
+                    # skip invalid metadata
+                    continue
+
+                # Add primary user's email and key records to fetch
+                primary_user_id = json_metadata.get("primary_user_id")
+                if primary_user_id:
+                    entities_to_fetch[EntityType.ENCRYPTED_EMAIL].add(primary_user_id)
+                    entities_to_fetch[EntityType.EMAIL_ENCRYPTION_KEY].add(
+                        primary_user_id
+                    )
+
+                # Add delegated users' access keys to fetch
+                delegated_user_ids = json_metadata.get("delegated_user_ids", [])
+                for delegated_user_id in delegated_user_ids:
+                    entities_to_fetch[EntityType.EMAIL_ACCESS_KEY].add(
+                        (primary_user_id, delegated_user_id)
+                    )
+
+                # For updates, we need to fetch existing records
+                if action == Action.UPDATE_EMAIL:
+                    email_owner_user_id = json_metadata.get("email_owner_user_id")
+                    if email_owner_user_id:
+                        entities_to_fetch[EntityType.ENCRYPTED_EMAIL].add(
+                            (primary_user_id, email_owner_user_id)
+                        )
 
     return entities_to_fetch
 
@@ -1386,6 +1445,79 @@ def fetch_existing_entities(session: Session, entities_to_fetch: EntitiesToFetch
                 comment_notification_setting["entity_type"],
             ): comment_notification_setting
             for _, comment_notification_setting in comment_notification_settings
+        }
+
+    # Add new email-related entity fetching
+    if entities_to_fetch[EntityType.ENCRYPTED_EMAIL.value]:
+        encrypted_emails: List[Tuple[EncryptedEmail, dict]] = (
+            session.query(
+                EncryptedEmail,
+                literal_column(f"row_to_json({EncryptedEmail.__tablename__})"),
+            )
+            .filter(
+                EncryptedEmail.primary_user_id.in_(
+                    entities_to_fetch[EntityType.ENCRYPTED_EMAIL.value]
+                )
+            )
+            .all()
+        )
+        existing_entities[EntityType.ENCRYPTED_EMAIL] = {
+            encrypted_email.primary_user_id: encrypted_email
+            for encrypted_email, _ in encrypted_emails
+        }
+        existing_entities_in_json[EntityType.ENCRYPTED_EMAIL] = {
+            encrypted_email_json["primary_user_id"]: encrypted_email_json
+            for _, encrypted_email_json in encrypted_emails
+        }
+
+    if entities_to_fetch[EntityType.EMAIL_ENCRYPTION_KEY.value]:
+        encryption_keys: List[Tuple[EmailEncryptionKey, dict]] = (
+            session.query(
+                EmailEncryptionKey,
+                literal_column(f"row_to_json({EmailEncryptionKey.__tablename__})"),
+            )
+            .filter(
+                EmailEncryptionKey.primary_user_id.in_(
+                    entities_to_fetch[EntityType.EMAIL_ENCRYPTION_KEY.value]
+                )
+            )
+            .all()
+        )
+        existing_entities[EntityType.EMAIL_ENCRYPTION_KEY] = {
+            key.primary_user_id: key for key, _ in encryption_keys
+        }
+        existing_entities_in_json[EntityType.EMAIL_ENCRYPTION_KEY] = {
+            key_json["primary_user_id"]: key_json for _, key_json in encryption_keys
+        }
+
+    if entities_to_fetch[EntityType.EMAIL_ACCESS_KEY.value]:
+        access_keys_to_fetch: Set[Tuple[int, int]] = entities_to_fetch[
+            EntityType.EMAIL_ACCESS_KEY.value
+        ]
+        or_queries = []
+        for access_key in access_keys_to_fetch:
+            primary_user_id, delegated_user_id = access_key
+            or_queries.append(
+                and_(
+                    EmailAccessKey.primary_user_id == primary_user_id,
+                    EmailAccessKey.delegated_user_id == delegated_user_id,
+                )
+            )
+
+        access_keys: List[Tuple[EmailAccessKey, dict]] = (
+            session.query(
+                EmailAccessKey,
+                literal_column(f"row_to_json({EmailAccessKey.__tablename__})"),
+            )
+            .filter(or_(*or_queries))
+            .all()
+        )
+        existing_entities[EntityType.EMAIL_ACCESS_KEY] = {
+            (key.primary_user_id, key.delegated_user_id): key for key, _ in access_keys
+        }
+        existing_entities_in_json[EntityType.EMAIL_ACCESS_KEY] = {
+            (key_json["primary_user_id"], key_json["delegated_user_id"]): key_json
+            for _, key_json in access_keys
         }
 
     return existing_entities, existing_entities_in_json

--- a/packages/discovery-provider/src/tasks/entity_manager/utils.py
+++ b/packages/discovery-provider/src/tasks/entity_manager/utils.py
@@ -38,6 +38,7 @@ from src.models.users.user import User
 from src.solana.solana_client_manager import SolanaClientManager
 from src.tasks.metadata import (
     comment_metadata_format,
+    encrypted_email_metadata_format,
     playlist_metadata_format,
     track_comment_notification_setting_format,
     track_download_metadata_format,
@@ -85,6 +86,8 @@ class Action(str, Enum):
     UNPIN = "Unpin"
     MUTE = "Mute"
     UNMUTE = "Unmute"
+    ADD_EMAIL = "AddEmail"
+    UPDATE_EMAIL = "UpdateEmail"
     REPORT = "Report"
 
     def __str__(self) -> str:
@@ -120,6 +123,9 @@ class EntityType(str, Enum):
     COMMENT_MENTION = "CommentMention"
     MUTED_USER = "MutedUser"
     COMMENT_NOTIFICATION_SETTING = "CommentNotificationSetting"
+    ENCRYPTED_EMAIL = "EncryptedEmail"
+    EMAIL_ENCRYPTION_KEY = "EmailEncryptionKey"
+    EMAIL_ACCESS_KEY = "EmailAccessKey"
 
     def __str__(self) -> str:
         return str.__str__(self)
@@ -206,6 +212,9 @@ class EntitiesToFetchDict(TypedDict):
     CommentNotificationSetting: Set[Tuple]
     MutedUser: Set[Tuple]
     CommentReport: Set[Tuple]
+    EncryptedEmail: Set[int]
+    EmailEncryptionKey: Set[int]
+    EmailAccessKey: Set[Tuple[int, int]]
 
 
 MANAGE_ENTITY_EVENT_TYPE = "ManageEntity"
@@ -360,6 +369,9 @@ def get_metadata_type_and_format(entity_type, action=None):
     elif entity_type == EntityType.COMMENT:
         metadata_type = "comment"
         metadata_format = comment_metadata_format
+    elif entity_type == EntityType.ENCRYPTED_EMAIL:
+        metadata_type = "encrypted_email"
+        metadata_format = encrypted_email_metadata_format
     else:
         raise IndexingValidationError(f"Unknown metadata type ${entity_type}")
     return metadata_type, metadata_format

--- a/packages/discovery-provider/src/tasks/metadata.py
+++ b/packages/discovery-provider/src/tasks/metadata.py
@@ -255,6 +255,15 @@ comment_metadata_format = {
     "track_timestamp_s": None,
 }
 
+encrypted_email_metadata_format = {
+    "email_owner_user_id": None,
+    "primary_user_id": None,
+    "encrypted_email": None,
+    "encrypted_key": None,
+    "delegated_user_ids": None,
+    "delegated_keys": None,
+}
+
 
 class PlaylistMetadata(TypedDict):
     playlist_contents: Optional[Any]

--- a/packages/sdk/src/sdk/api/users/UsersApi.test.ts
+++ b/packages/sdk/src/sdk/api/users/UsersApi.test.ts
@@ -399,4 +399,59 @@ describe('UsersApi', () => {
       })
     })
   })
+
+  describe('addEmail', () => {
+    it('adds an encrypted email if valid metadata is provided', async () => {
+      const result = await users.addEmail({
+        emailOwnerUserId: 123,
+        primaryUserId: 456,
+        encryptedEmail: 'encryptedEmailString',
+        encryptedKey: 'encryptedKeyString',
+        delegatedUserIds: [789],
+        delegatedKeys: ['delegatedKeyString']
+      })
+
+      expect(result).toStrictEqual({
+        blockHash: 'a',
+        blockNumber: 1
+      })
+    })
+
+    it('adds an encrypted email without optional delegated fields', async () => {
+      const result = await users.addEmail({
+        emailOwnerUserId: 123,
+        primaryUserId: 456,
+        encryptedEmail: 'encryptedEmailString',
+        encryptedKey: 'encryptedKeyString'
+      })
+
+      expect(result).toStrictEqual({
+        blockHash: 'a',
+        blockNumber: 1
+      })
+    })
+
+    it('throws an error if required fields are missing', async () => {
+      await expect(async () => {
+        await users.addEmail({
+          emailOwnerUserId: 123,
+          // Missing primaryUserId
+          encryptedEmail: 'encryptedEmailString',
+          encryptedKey: 'encryptedKeyString'
+        } as any)
+      }).rejects.toThrow()
+    })
+
+    it('throws an error if invalid metadata is provided', async () => {
+      await expect(async () => {
+        await users.addEmail({
+          emailOwnerUserId: 123,
+          // Incorrect type for primaryUserId
+          primaryUserId: '456',
+          encryptedEmail: 'encryptedEmailString',
+          encryptedKey: 'encryptedKeyString'
+        } as any)
+      }).rejects.toThrow()
+    })
+  })
 })

--- a/packages/sdk/src/sdk/api/users/UsersApi.ts
+++ b/packages/sdk/src/sdk/api/users/UsersApi.ts
@@ -35,6 +35,8 @@ import {
   SendTipRequest,
   SendTipSchema,
   SendTipReactionRequest,
+  EmailRequest,
+  EmailSchema,
   SendTipReactionRequestSchema
 } from './types'
 
@@ -392,5 +394,80 @@ export class UsersApi extends GeneratedUsersApi {
       mint: 'wAUDIO'
     })
     return { ethWallet, userBank }
+  }
+
+  /** @hidden
+   * Add an encrypted email for a user
+   */
+  async addEmail(params: EmailRequest, advancedOptions?: AdvancedOptions) {
+    const {
+      emailOwnerUserId,
+      primaryUserId,
+      encryptedEmail,
+      encryptedKey,
+      delegatedUserIds = [],
+      delegatedKeys = []
+    } = await parseParams('addEmail', EmailSchema)(params)
+
+    console.log('addEmail', {
+      email_owner_user_id: emailOwnerUserId,
+      primary_user_id: primaryUserId,
+      encrypted_email: encryptedEmail,
+      encrypted_key: encryptedKey,
+      delegated_user_ids: delegatedUserIds,
+      delegated_keys: delegatedKeys
+    })
+
+    const metadata = {
+      email_owner_user_id: emailOwnerUserId,
+      primary_user_id: primaryUserId,
+      encrypted_email: encryptedEmail,
+      encrypted_key: encryptedKey,
+      delegated_user_ids: delegatedUserIds,
+      delegated_keys: delegatedKeys
+    }
+
+    return await this.entityManager.manageEntity({
+      userId: primaryUserId,
+      entityType: EntityType.ENCRYPTED_EMAIL,
+      entityId: primaryUserId,
+      action: Action.ADD_EMAIL,
+      metadata: JSON.stringify({
+        cid: '',
+        data: metadata
+      }),
+      auth: this.auth,
+      ...advancedOptions
+    })
+  }
+
+  /** @hidden
+   * Update an encrypted email for a user
+   */
+  async updateEmail(params: EmailRequest, advancedOptions?: AdvancedOptions) {
+    const {
+      emailOwnerUserId,
+      primaryUserId,
+      encryptedEmail,
+      encryptedKey,
+      delegatedUserIds = [],
+      delegatedKeys = []
+    } = await parseParams('updateEmail', EmailSchema)(params)
+
+    return await this.entityManager.manageEntity({
+      entityType: EntityType.ENCRYPTED_EMAIL,
+      entityId: primaryUserId,
+      action: Action.UPDATE_EMAIL,
+      metadata: JSON.stringify({
+        email_owner_user_id: emailOwnerUserId,
+        primary_user_id: primaryUserId,
+        encrypted_email: encryptedEmail,
+        encrypted_key: encryptedKey,
+        delegated_user_ids: delegatedUserIds,
+        delegated_keys: delegatedKeys
+      }),
+      auth: this.auth,
+      ...advancedOptions
+    })
   }
 }

--- a/packages/sdk/src/sdk/api/users/UsersApi.ts
+++ b/packages/sdk/src/sdk/api/users/UsersApi.ts
@@ -409,15 +409,6 @@ export class UsersApi extends GeneratedUsersApi {
       delegatedKeys = []
     } = await parseParams('addEmail', EmailSchema)(params)
 
-    console.log('addEmail', {
-      email_owner_user_id: emailOwnerUserId,
-      primary_user_id: primaryUserId,
-      encrypted_email: encryptedEmail,
-      encrypted_key: encryptedKey,
-      delegated_user_ids: delegatedUserIds,
-      delegated_keys: delegatedKeys
-    })
-
     const metadata = {
       email_owner_user_id: emailOwnerUserId,
       primary_user_id: primaryUserId,

--- a/packages/sdk/src/sdk/api/users/types.ts
+++ b/packages/sdk/src/sdk/api/users/types.ts
@@ -114,3 +114,22 @@ export const SendTipReactionRequestSchema = z.object({
 export type SendTipReactionRequest = z.input<
   typeof SendTipReactionRequestSchema
 >
+
+// Email-related types
+export interface EmailRequest {
+  emailOwnerUserId: number
+  primaryUserId: number
+  encryptedEmail: string
+  encryptedKey: string
+  delegatedUserIds?: number[]
+  delegatedKeys?: string[]
+}
+
+export const EmailSchema = z.object({
+  emailOwnerUserId: z.number(),
+  primaryUserId: z.number(),
+  encryptedEmail: z.string(),
+  encryptedKey: z.string(),
+  delegatedUserIds: z.array(z.number()).optional(),
+  delegatedKeys: z.array(z.string()).optional()
+})

--- a/packages/sdk/src/sdk/services/EntityManager/types.ts
+++ b/packages/sdk/src/sdk/services/EntityManager/types.ts
@@ -70,7 +70,13 @@ export enum Action {
   PIN = 'Pin',
   UNPIN = 'Unpin',
   MUTE = 'Mute',
-  UNMUTE = 'Unmute'
+  UNMUTE = 'Unmute',
+  ADD_EMAIL = 'AddEmail',
+  UPDATE_EMAIL = 'UpdateEmail',
+  ADD_EMAIL_KEY = 'AddEmailKey',
+  UPDATE_EMAIL_KEY = 'UpdateEmailKey',
+  ADD_ACCESS_KEY = 'AddAccessKey',
+  UPDATE_ACCESS_KEY = 'UpdateAccessKey'
 }
 
 export enum EntityType {
@@ -83,7 +89,10 @@ export enum EntityType {
   GRANT = 'Grant',
   DASHBOARD_WALLET_USER = 'DashboardWalletUser',
   TIP = 'Tip',
-  COMMENT = 'Comment'
+  COMMENT = 'Comment',
+  ENCRYPTED_EMAIL = 'EncryptedEmail',
+  EMAIL_ENCRYPTION_KEY = 'EmailEncryptionKey',
+  EMAIL_ACCESS_KEY = 'EmailAccessKey'
 }
 
 export type AdvancedOptions = {


### PR DESCRIPTION
### Description

This PR adds entity manager support for uploading emails. 

_It does not handle the encryption of the emails, that will be done in a follow up PR._ 

### How Has This Been Tested?

Locally by running the below code in `ProfilePage.tsx` and checking the local db for the content 

```tsx
const userId = useGetCurrentUserId({})

  useEffect(() => {
    async function addEmail() {
      const sdk = await audiusSdk()
      console.log('calling addEmail')
      try {
        await sdk.users.addEmail({
          emailOwnerUserId: 1234,
          primaryUserId: userId.data ?? 0,
          encryptedEmail: 'encryptedEmail',
          encryptedKey: 'encryptedKey'
        })
        console.log('addEmail succesful')
      } catch (error) {
        console.error('Error adding email:', error)
      }
    }

    if (userId.data) {
      addEmail()
    }
  }, [userId])
  ```

