### PR TITLE
Fix harmony circular dependency

### DIFF
--- a/packages/harmony/src/components/popup/Popup.tsx
+++ b/packages/harmony/src/components/popup/Popup.tsx
@@ -15,7 +15,7 @@ import ReactDOM from 'react-dom'
 import { useTransition, animated } from 'react-spring'
 import { usePrevious } from 'react-use'
 
-import { PlainButton } from 'components/button'
+import { PlainButton } from 'components/button/PlainButton/PlainButton'
 import { IconClose } from 'icons'
 import { ModalState } from 'utils/modalState'
 


### PR DESCRIPTION
### Description

Fixes this circular dep
```
src/components/button/index.ts
-> src/components/button/FilterButton/FilterButton.tsx
-> src/components/internal/Menu.tsx
-> src/components/popup/Popup.tsx
-> src/components/button/index.ts
```

### How Has This Been Tested?

build passes cleanly
