### PR TITLE
[PAY-3608] Use sdk auth service in AudiusBackend

### DIFF
--- a/packages/common/src/services/audius-backend/AudiusBackend.ts
+++ b/packages/common/src/services/audius-backend/AudiusBackend.ts
@@ -2,7 +2,6 @@ import {
   AudiusSdk,
   Genre,
   Mood,
-  sdk,
   type StorageNodeSelectorService
 } from '@audius/sdk'
 import { DiscoveryAPI } from '@audius/sdk-legacy/dist/core'
@@ -63,8 +62,7 @@ import {
   BrowserNotificationSetting,
   PushNotificationSetting,
   PushNotifications,
-  SearchKind,
-  getSDK
+  SearchKind
 } from '../../store'
 import {
   getErrorMessage,
@@ -2287,6 +2285,7 @@ export const audiusBackend = ({
     setUserHandleForRelay,
     signData,
     signDiscoveryNodeRequest,
+    signIdentityServiceRequest,
     signOut,
     signUp,
     transferAudioToWAudio,

--- a/packages/common/src/services/audius-backend/RecordIP.ts
+++ b/packages/common/src/services/audius-backend/RecordIP.ts
@@ -1,3 +1,5 @@
+import { AudiusSdk } from '@audius/sdk'
+
 import { getErrorMessage } from '~/utils'
 
 import { AudiusBackend } from './AudiusBackend'
@@ -7,12 +9,19 @@ const AuthHeaders: { [key: string]: string } = Object.freeze({
   Signature: 'Encoded-Data-Signature'
 })
 
-export const recordIP = async (
+export const recordIP = async ({
+  audiusBackendInstance,
+  sdk
+}: {
   audiusBackendInstance: AudiusBackend
-): Promise<{ userIP: string } | { error: boolean }> => {
+  sdk: AudiusSdk
+}): Promise<{ userIP: string } | { error: boolean }> => {
   await audiusBackendInstance.getAudiusLibs()
   try {
-    const { data, signature } = await audiusBackendInstance.signData()
+    const { data, signature } =
+      await audiusBackendInstance.signIdentityServiceRequest({
+        sdk
+      })
     const response = await fetch(
       `${audiusBackendInstance.identityServiceUrl}/record_ip`,
       {

--- a/packages/common/src/store/account/sagas.ts
+++ b/packages/common/src/store/account/sagas.ts
@@ -133,6 +133,7 @@ export function* cacheAccount(account: AccountUserMetadata) {
 
 function* recordIPIfNotRecent(handle: string): SagaIterator {
   const audiusBackendInstance = yield* getContext('audiusBackendInstance')
+  const sdk = yield* getSDK()
   const localStorage = yield* getContext('localStorage')
   const timeBetweenRefresh = 24 * 60 * 60 * 1000
   const now = Date.now()
@@ -140,7 +141,10 @@ function* recordIPIfNotRecent(handle: string): SagaIterator {
   const storedIPStr = yield* call([localStorage, 'getItem'], IP_STORAGE_KEY)
   const storedIP = storedIPStr && JSON.parse(storedIPStr)
   if (!storedIP || !storedIP[handle] || storedIP[handle].timestamp < minAge) {
-    const result = yield* call(recordIP, audiusBackendInstance)
+    const result = yield* call(recordIP, {
+      audiusBackendInstance,
+      sdk
+    })
     if ('userIP' in result) {
       const { userIP } = result
       yield* call(

--- a/packages/mobile/src/store/account/sagas.ts
+++ b/packages/mobile/src/store/account/sagas.ts
@@ -1,6 +1,11 @@
 import type { User } from '@audius/common/models'
 import { SquareSizes, WidthSizes } from '@audius/common/models'
-import { accountActions, accountSagas, getContext } from '@audius/common/store'
+import {
+  accountActions,
+  accountSagas,
+  getContext,
+  getSDK
+} from '@audius/common/store'
 import { removeNullable } from '@audius/common/utils'
 import webAccountSagas from 'common/store/account/sagas'
 import { updateProfileAsync } from 'common/store/profile/sagas'
@@ -52,6 +57,7 @@ function* onSignedIn({ payload: { account } }: ReturnType<typeof signedIn>) {
   const audiusBackendInstance = yield* getContext('audiusBackendInstance')
   const localStorage = yield* getContext('localStorage')
   const isMobileUser = yield* call(localStorage.getItem, IS_MOBILE_USER)
+  const sdk = yield* getSDK()
 
   yield* call(cacheUserImages, account)
 
@@ -60,6 +66,7 @@ function* onSignedIn({ payload: { account } }: ReturnType<typeof signedIn>) {
       // Legacy method to update whether a user has signed in on
       // native mobile. Used in identity service for notification indexing
       yield* call(audiusBackendInstance.updateUserEvent, {
+        sdk,
         hasSignedInNativeMobile: true
       })
       // Updates the user metadata with an event `is_mobile_user` set to true

--- a/packages/mobile/src/store/notifications/sagas.ts
+++ b/packages/mobile/src/store/notifications/sagas.ts
@@ -1,7 +1,8 @@
 import {
   accountSelectors,
   notificationsActions,
-  getContext
+  getContext,
+  getSDK
 } from '@audius/common/store'
 import commonNotificationsSagas, {
   getPollingIntervalMs
@@ -24,7 +25,8 @@ function* resetNotificationBadgeCount() {
     const hasAccount = yield* select(getHasAccount)
     if (hasAccount) {
       PushNotifications.setBadgeCount(0)
-      yield* call(audiusBackendInstance.clearNotificationBadges)
+      const sdk = yield* getSDK()
+      yield* call(audiusBackendInstance.clearNotificationBadges, { sdk })
     }
   } catch (error) {
     console.error(error)

--- a/packages/web/src/common/store/account/sagas.js
+++ b/packages/web/src/common/store/account/sagas.js
@@ -7,6 +7,7 @@ import {
   cacheActions,
   profilePageActions,
   getContext,
+  getSDK,
   fetchAccountAsync
 } from '@audius/common/store'
 import { call, put, fork, select, takeEvery } from 'redux-saga/effects'
@@ -69,6 +70,7 @@ function* onSignedIn({ payload: { account } }) {
   const audiusBackendInstance = yield getContext('audiusBackendInstance')
   const sentry = yield getContext('sentry')
   const authService = yield getContext('authService')
+  const sdk = yield* getSDK()
 
   const libs = yield call([
     audiusBackendInstance,
@@ -123,7 +125,7 @@ function* onSignedIn({ payload: { account } }) {
 
   yield put(showPushNotificationConfirmation())
 
-  yield fork(audiusBackendInstance.updateUserLocationTimezone)
+  yield fork(audiusBackendInstance.updateUserLocationTimezone, { sdk })
 
   // Fetch the profile so we get everything we need to populate
   // the left nav / other site-wide metadata.

--- a/packages/web/src/common/store/notifications/sagas.ts
+++ b/packages/web/src/common/store/notifications/sagas.ts
@@ -6,7 +6,8 @@ import {
 import {
   notificationsActions,
   getContext,
-  accountSelectors
+  accountSelectors,
+  getSDK
 } from '@audius/common/store'
 import { call, takeEvery, select } from 'typed-redux-saga'
 
@@ -42,11 +43,15 @@ function* watchMarkAllNotificationsViewed() {
 
 export function* markAllNotificationsViewed() {
   const audiusBackendInstance = yield* getContext('audiusBackendInstance')
+  const sdk = yield* getSDK()
   const userId = yield* select(accountSelectors.getUserId)
   if (!userId) return
 
   yield* call(waitForWrite)
-  yield* call(audiusBackendInstance.markAllNotificationAsViewed, { userId })
+  yield* call(audiusBackendInstance.markAllNotificationAsViewed, {
+    userId,
+    sdk
+  })
 }
 
 export default function sagas() {

--- a/packages/web/src/common/store/pages/audio-rewards/sagas.ts
+++ b/packages/web/src/common/store/pages/audio-rewards/sagas.ts
@@ -657,6 +657,7 @@ function* watchUpdateOptimisticListenStreak() {
 
 function* watchUpdateHCaptchaScore() {
   const audiusBackendInstance = yield* getContext('audiusBackendInstance')
+  const sdk = yield* getSDK()
   yield* takeEvery(
     updateHCaptchaScore.type,
     function* (action: ReturnType<typeof updateHCaptchaScore>): any {
@@ -667,6 +668,7 @@ function* watchUpdateHCaptchaScore() {
         return
       }
       const result = yield* call(audiusBackendInstance.updateHCaptchaScore, {
+        sdk,
         token
       })
       if (result.error) {

--- a/packages/web/src/common/store/pages/settings/sagas.ts
+++ b/packages/web/src/common/store/pages/settings/sagas.ts
@@ -3,7 +3,8 @@ import {
   accountSelectors,
   cacheActions,
   settingsPageActions as actions,
-  getContext
+  getContext,
+  getSDK
 } from '@audius/common/store'
 import { getErrorMessage } from '@audius/common/utils'
 import { call, put, takeEvery, select } from 'typed-redux-saga'
@@ -16,6 +17,7 @@ const { getAccountUser, getUserId } = accountSelectors
 
 function* watchGetSettings() {
   const audiusBackendInstance = yield* getContext('audiusBackendInstance')
+  const sdk = yield* getSDK()
   yield* takeEvery(actions.GET_NOTIFICATION_SETTINGS, function* () {
     try {
       yield* call(waitForWrite)
@@ -23,7 +25,8 @@ function* watchGetSettings() {
       if (!userId) return
 
       const emailSettings = yield* call(
-        audiusBackendInstance.getEmailNotificationSettings
+        audiusBackendInstance.getEmailNotificationSettings,
+        { sdk }
       )
       yield* put(
         actions.updateEmailFrequency(
@@ -47,7 +50,9 @@ function* watchUpdateEmailFrequency() {
       const userId = yield* select(getUserId)
 
       if (userId && updateServer) {
+        const sdk = yield* getSDK()
         yield* call(audiusBackendInstance.updateEmailNotificationSettings, {
+          sdk,
           userId,
           emailFrequency
         })

--- a/packages/web/src/common/store/pages/signon/sagas.ts
+++ b/packages/web/src/common/store/pages/signon/sagas.ts
@@ -986,6 +986,7 @@ function* followArtists(
 ) {
   const { skipDefaultFollows } = action
   const audiusBackendInstance = yield* getContext('audiusBackendInstance')
+  const sdk = yield* getSDK()
   const { ENVIRONMENT } = yield* getContext('env')
   const defaultFollowUserIds = skipDefaultFollows
     ? new Set([])
@@ -1053,7 +1054,7 @@ function* followArtists(
     yield* put(signOnActions.setAccountReady())
     // The update user location depends on the user being discoverable in discprov
     // So we wait until both the user is indexed and the follow user actions are finished
-    yield* call(audiusBackendInstance.updateUserLocationTimezone)
+    yield* call(audiusBackendInstance.updateUserLocationTimezone, { sdk })
   } catch (err: any) {
     const reportToSentry = yield* getContext('reportToSentry')
     reportToSentry({
@@ -1139,12 +1140,14 @@ function* watchOpenSignOn() {
 
 function* watchSendWelcomeEmail() {
   const audiusBackendInstance = yield* getContext('audiusBackendInstance')
+  const sdk = yield* getSDK()
   yield* takeLatest(
     signOnActions.SEND_WELCOME_EMAIL,
     function* (action: ReturnType<typeof signOnActions.sendWelcomeEmail>) {
       const hasAccount = yield* select(getHasAccount)
       if (!hasAccount) return
       yield* call(audiusBackendInstance.sendWelcomeEmail, {
+        sdk,
         name: action.name
       })
     }

--- a/packages/web/src/pages/audio-rewards-page/components/modals/HCaptchaModal.tsx
+++ b/packages/web/src/pages/audio-rewards-page/components/modals/HCaptchaModal.tsx
@@ -1,11 +1,7 @@
 import { useCallback } from 'react'
 
 import { useGetCurrentUserId } from '@audius/common/api'
-import {
-  audioRewardsPageActions,
-  getSDK,
-  HCaptchaStatus
-} from '@audius/common/store'
+import { audioRewardsPageActions, HCaptchaStatus } from '@audius/common/store'
 import HCaptcha from '@hcaptcha/react-hcaptcha'
 import { useDispatch } from 'react-redux'
 

--- a/packages/web/src/pages/audio-rewards-page/components/modals/HCaptchaModal.tsx
+++ b/packages/web/src/pages/audio-rewards-page/components/modals/HCaptchaModal.tsx
@@ -1,12 +1,17 @@
 import { useCallback } from 'react'
 
 import { useGetCurrentUserId } from '@audius/common/api'
-import { audioRewardsPageActions, HCaptchaStatus } from '@audius/common/store'
+import {
+  audioRewardsPageActions,
+  getSDK,
+  HCaptchaStatus
+} from '@audius/common/store'
 import HCaptcha from '@hcaptcha/react-hcaptcha'
 import { useDispatch } from 'react-redux'
 
 import { useModalState } from 'common/hooks/useModalState'
 import { audiusBackendInstance } from 'services/audius-backend/audius-backend-instance'
+import { audiusSdk } from 'services/audius-sdk'
 import { env } from 'services/env'
 
 import styles from './HCaptchaModal.module.css'
@@ -40,7 +45,11 @@ export const HCaptchaModal = () => {
         dispatch(setHCaptchaStatus({ status: HCaptchaStatus.ERROR }))
         return
       }
-      const result = await audiusBackendInstance.updateHCaptchaScore({ token })
+      const sdk = await audiusSdk()
+      const result = await audiusBackendInstance.updateHCaptchaScore({
+        sdk,
+        token
+      })
       if (result.error) {
         dispatch(setHCaptchaStatus({ status: HCaptchaStatus.ERROR }))
       } else {

--- a/packages/web/src/pages/oauth-login-page/utils.ts
+++ b/packages/web/src/pages/oauth-login-page/utils.ts
@@ -188,7 +188,11 @@ export const formOAuthResponse = async ({
   const message = `${header}.${payload}`
   let signedData: { data: string; signature: string }
   try {
-    signedData = await audiusBackendInstance.signDiscoveryNodeRequest(message)
+    const sdk = await audiusSdk()
+    signedData = await audiusBackendInstance.signDiscoveryNodeRequest({
+      sdk,
+      input: message
+    })
   } catch {
     onError()
     return

--- a/packages/web/src/services/audius-backend/Cognito.ts
+++ b/packages/web/src/services/audius-backend/Cognito.ts
@@ -2,6 +2,7 @@ import { AuthHeaders } from '@audius/common/services'
 
 import { audiusBackendInstance } from 'services/audius-backend/audius-backend-instance'
 import { waitForLibsInit } from 'services/audius-backend/eagerLoadUtils'
+import { audiusSdk } from 'services/audius-sdk'
 
 // @ts-ignore
 const libs = () => window.audiusLibs
@@ -32,7 +33,9 @@ async function _makeRequest<ResponseModel>({
     if (!account) {
       throw new Error('Cognito Identity Request Failed: Missing current user')
     }
-    const { data, signature } = await audiusBackendInstance.signData()
+    const sdk = await audiusSdk()
+    const { data, signature } =
+      await audiusBackendInstance.signIdentityServiceRequest({ sdk })
     options.headers = {
       [AuthHeaders.Message]: data,
       [AuthHeaders.Signature]: signature


### PR DESCRIPTION
### Description
Use sdk auth service in AudiusBackend instead of libs Web3Manager.

Seems like we might want to wrap the logic in `signData` inside sdk instead of forcing user to manage manually?

Thanks to @schottra for figuring out the logic so I could copy it from audius-cmd.

### How Has This Been Tested?

- Tested changing notification settings (identity)
- Tested manager/managee oauth flow (discovery) - is this correct? couldn't figure out how to test authorizing 3rd party app on local