### PR TITLE
[C-5443, C-5444] Web track replace fixes

### DIFF
--- a/packages/web/src/common/store/upload/sagas.ts
+++ b/packages/web/src/common/store/upload/sagas.ts
@@ -1259,7 +1259,7 @@ export function* updateTrackAudioAsync(
   yield* delay(3000)
 
   yield* put(replaceTrackProgressModalActions.close())
-  yield* put(push(newMetadata.permalink))
+  yield* put(push(baseMetadata.permalink))
 }
 
 function* watchUploadTracks() {

--- a/packages/web/src/components/edit-track/EditTrackForm.tsx
+++ b/packages/web/src/components/edit-track/EditTrackForm.tsx
@@ -102,11 +102,17 @@ export const EditTrackForm = (props: EditTrackFormProps) => {
         onSubmit(values)
       }
 
+      const replaceFile =
+        'file' in values.tracks[0] ? values.tracks[0].file : null
       const usersMayLoseAccess =
         !isUpload && !initiallyHidden && values.trackMetadatas[0].is_unlisted
       const isToBePublished =
         !isUpload && initiallyHidden && !values.trackMetadatas[0].is_unlisted
-      if (usersMayLoseAccess) {
+
+      if (replaceFile) {
+        // Replace audio confirmation is handled in the edit track page if needed
+        onSubmit(values)
+      } else if (usersMayLoseAccess) {
         openHideContentConfirmation({ confirmCallback })
       } else if (isToBePublished && isInitiallyScheduled) {
         openEarlyReleaseConfirmation({ contentType: 'track', confirmCallback })


### PR DESCRIPTION
### Description
* Small update to permalink that we redirect to after edit so that the audio is there right away
* Prioritize the replace confirmation modal in the edit flow

### How Has This Been Tested?
Manually Tested
