### PR TITLE
Hide non whitelisted nodes from healthz discovery section

### DIFF
--- a/monitoring/healthz/src/components/EnvironmentSelector.tsx
+++ b/monitoring/healthz/src/components/EnvironmentSelector.tsx
@@ -10,7 +10,7 @@ export function useEnvironmentSelection(): [
   let [searchParams] = useSearchParams()
 
   const isStage = !!searchParams.get(isStageParam)
-  const nodeType = searchParams.get(nodeTypeParam) || 'discovery'
+  const nodeType = (searchParams.get(nodeTypeParam) as 'content' | 'discovery' | 'core') || 'discovery'
 
   return [
     isStage ? 'staging' : 'prod',

--- a/monitoring/healthz/src/pages/Nodes.tsx
+++ b/monitoring/healthz/src/pages/Nodes.tsx
@@ -16,15 +16,33 @@ const awsBackendIco = new URL('../images/aws.ico', import.meta.url).href
 const bytesToGb = (bytes: number) => Math.floor(bytes / 10 ** 9)
 const fetcher = (url: string) => fetch(url).then((res) => res.json())
 
+const discprovWhitelist = [
+  ".audius.co",
+  ".creatorseed.com",
+  ".monophonic.digital",
+  ".figment.io",
+  ".tikilabs.com",
+]
+
 export default function Nodes() {
   const [env, nodeType] = useEnvironmentSelection()
-  const { data: sps, error } = useServiceProviders(env, nodeType)
+  let { data: sps, error } = useServiceProviders(env, nodeType)
 
   const isContent = nodeType == 'content'
   const isDiscovery = nodeType == 'discovery'
 
   if (error) return <div className="text-red-600 dark:text-red-400">Error</div>
   if (!sps) return <div className="text-gray-600 dark:text-gray-300">Loading...</div>
+
+  // Filter out un-whitelisted dns
+  if (isDiscovery && sps) {
+    sps = sps.filter(
+      sp => discprovWhitelist.reduce(
+        (isWhitelisted, li) => isWhitelisted || sp.endpoint.endsWith(li),
+        false,
+      )
+    )
+  }
 
   if (isContent || isDiscovery) {  // legacy healthcheck
     return (

--- a/pkg/core/console/routes.go
+++ b/pkg/core/console/routes.go
@@ -37,6 +37,7 @@ func (c *Console) registerRoutes(logger *common.Logger, e *echo.Echo) {
 	g.GET("/node/:node", c.nodePage)
 	g.GET("/content", c.contentFragment)
 	g.GET("/uptime/:rollup", c.uptimeFragment)
+	g.GET("/uptime", c.uptimeFragment)
 	g.GET("/block/:block", c.blockPage)
 	g.GET("/tx/:tx", c.txPage)
 	g.GET("/genesis", c.genesisPage)


### PR DESCRIPTION
### Description

Only the nodes that will be using discovery functionality moving forward will be displayed in the discovery healthz section.

### How Has This Been Tested?

Local healthz build
