### PR TITLE
[TRIVIAL] Only add underscores for JSON response

### DIFF
--- a/packages/discovery-provider/src/queries/download_csv.py
+++ b/packages/discovery-provider/src/queries/download_csv.py
@@ -193,19 +193,20 @@ def download_purchases(args: DownloadPurchasesArgs):
 
 
 def format_sale_for_download(
-    result, seller_handle, seller_user_id, include_email=False
+    result, seller_handle, seller_user_id, is_for_json_response=False
 ):
     """Format a sale result into a CSV-friendly dictionary format."""
     # Convert datetime to ISO format string
     created_at = result.created_at.isoformat() if result.created_at else None
 
-    formatted_result = {
+    # Base fields without underscores
+    base_fields = {
         "title": result.content_title,
         "link": get_link(result.content_type, seller_handle, result.slug),
-        "purchased_by": result.buyer_name,
+        "purchased by": result.buyer_name,
         "date": created_at,
-        "sale_price": get_dollar_amount(result.amount),
-        "network_fee": next(
+        "sale price": get_dollar_amount(result.amount),
+        "network fee": next(
             (
                 0 - get_dollar_amount(item["amount"])
                 for item in result.splits
@@ -213,7 +214,7 @@ def format_sale_for_download(
             ),
             None,
         ),
-        "pay_extra": get_dollar_amount(result.extra_amount),
+        "pay extra": get_dollar_amount(result.extra_amount),
         "total": next(
             (
                 get_dollar_amount(str(int(item["amount"]) + int(result.extra_amount)))
@@ -225,13 +226,17 @@ def format_sale_for_download(
         "country": result.country,
     }
 
-    # Only include encrypted_email if specifically requested (for JSON response)
-    if include_email:
-        formatted_result["encrypted_email"] = (
+    if is_for_json_response:
+        # Replace spaces with underscores and add encrypted_email
+        fields_with_underscores = {
+            key.replace(" ", "_"): value for key, value in base_fields.items()
+        }
+        fields_with_underscores["encrypted_email"] = (
             result.encrypted_email if hasattr(result, "encrypted_email") else None
         )
+        return fields_with_underscores
 
-    return formatted_result
+    return base_fields
 
 
 # Returns USDC sales for a given artist in a CSV format
@@ -263,7 +268,7 @@ def download_sales(args: DownloadSalesArgs, return_json: bool = False):
                 result,
                 seller_handle,
                 seller_user_id,
-                include_email=return_json,  # Only include email for JSON response
+                is_for_json_response=return_json,  # Only include email for JSON response
             ),
             results,
         )

--- a/packages/discovery-provider/src/queries/download_csv.py
+++ b/packages/discovery-provider/src/queries/download_csv.py
@@ -268,7 +268,7 @@ def download_sales(args: DownloadSalesArgs, return_json: bool = False):
                 result,
                 seller_handle,
                 seller_user_id,
-                is_for_json_response=return_json,  # Only include email for JSON response
+                is_for_json_response=return_json,  # Used to determine if we should include email
             ),
             results,
         )


### PR DESCRIPTION
### Description

This PR adds the white space back for the header values related to the sales CSV and adds underscores for the JSON response in order to maintain the current styling on clients

### How Has This Been Tested?

Locally
