### PR TITLE
Navigate to trending after signout

### DIFF
--- a/packages/web/src/store/sign-out/sagas.ts
+++ b/packages/web/src/store/sign-out/sagas.ts
@@ -1,10 +1,12 @@
 import { Name } from '@audius/common/models'
+import { TRENDING_PAGE } from '@audius/common/src/utils/route'
 import {
   accountActions,
   tokenDashboardPageActions,
   signOutActions,
   getContext
 } from '@audius/common/store'
+import { push as pushRoute } from 'connected-react-router'
 import { takeLatest, put } from 'redux-saga/effects'
 
 import { make } from 'common/store/analytics/actions'
@@ -27,6 +29,7 @@ function* watchSignOut() {
           signOut(audiusBackendInstance, localStorage, authService)
       })
     )
+    yield put(pushRoute(TRENDING_PAGE))
   })
 }
 


### PR DESCRIPTION
### Description
Noticed that signout on mobile-web was somewhat broken, added navigation to trending after signout to match web behavior.

### How Has This Been Tested?

Tested on local web + mobile-web

On signout, before this change:
<img width="564" alt="Screenshot 2024-12-03 at 12 31 08 AM" src="https://github.com/user-attachments/assets/ad22e05a-fcf1-44fc-9043-d3503d773c30">
