### PR TITLE
Add remote config value for sentry replay recording

### DIFF
--- a/packages/common/src/services/remote-config/defaults.ts
+++ b/packages/common/src/services/remote-config/defaults.ts
@@ -101,7 +101,8 @@ export const remoteConfigDoubleDefaults: {
   [key in DoubleKeys]: number | null
 } = {
   [DoubleKeys.SHOW_ARTIST_RECOMMENDATIONS_FALLBACK_PERCENT]: 0.3333,
-  [DoubleKeys.SHOW_ARTIST_RECOMMENDATIONS_PERCENT]: 1.0
+  [DoubleKeys.SHOW_ARTIST_RECOMMENDATIONS_PERCENT]: 1.0,
+  [DoubleKeys.SENTRY_REPLAY_ERROR_SAMPLE_RATE]: 0.0
 }
 export const remoteConfigBooleanDefaults: {
   [key in BooleanKeys]: boolean | null

--- a/packages/common/src/services/remote-config/types.ts
+++ b/packages/common/src/services/remote-config/types.ts
@@ -277,7 +277,10 @@ export enum DoubleKeys {
   /**
    * How often we should show suggested follows after a user follows another user
    */
-  SHOW_ARTIST_RECOMMENDATIONS_PERCENT = 'SHOW_ARTIST_RECOMMENDATIONS_PERCENT'
+  SHOW_ARTIST_RECOMMENDATIONS_PERCENT = 'SHOW_ARTIST_RECOMMENDATIONS_PERCENT',
+
+  /** How many Sentry error recordings we sample. Value ranges from 0.0-1.0 */
+  SENTRY_REPLAY_ERROR_SAMPLE_RATE = 'SENTRY_REPLAY_ERROR_SAMPLE_RATE'
 }
 
 export enum StringKeys {

--- a/packages/web/src/services/sentry.ts
+++ b/packages/web/src/services/sentry.ts
@@ -1,4 +1,4 @@
-import { DoubleKeys, StringKeys } from '@audius/common/services'
+import { DoubleKeys } from '@audius/common/services'
 import * as Sentry from '@sentry/browser'
 
 import { env } from './env'
@@ -65,7 +65,7 @@ export const initializeSentry = async () => {
     // This is a sample rate specific to when errors occur. We want to see 100% of them
     replaysOnErrorSampleRate: Number(
       remoteConfigInstance.getRemoteVar(
-        StringKeys.SENTRY_REPLAY_ERROR_SAMPLE_RATE
+        DoubleKeys.SENTRY_REPLAY_ERROR_SAMPLE_RATE
       ) ?? 0
     )
   })

--- a/packages/web/src/services/sentry.ts
+++ b/packages/web/src/services/sentry.ts
@@ -17,11 +17,6 @@ const MAX_BREADCRUMBS = 300
 
 export const initializeSentry = async () => {
   await remoteConfigInstance.waitForRemoteConfig()
-  console.log({
-    sampleRate: remoteConfigInstance.getRemoteVar(
-      DoubleKeys.SENTRY_REPLAY_ERROR_SAMPLE_RATE
-    )
-  })
   Sentry.init({
     dsn: env.SENTRY_DSN,
     transport: Sentry.makeBrowserOfflineTransport(Sentry.makeFetchTransport),


### PR DESCRIPTION
### Description

Add a remote config value for sentry replay sample rate that we can tweak/enable/disable sentry replay recording on the fly.

One tradeoff to call out: In order to make this work I had to make sentry wait for remote config to init, on localhost this seems to add a second or so, but seems like a negligible amount of overhead.

### How Has This Been Tested?

web stage