### PR TITLE
Fix splits issue for old usdc_purchases

### DIFF
--- a/packages/discovery-provider/src/queries/get_extended_purchase_gate.py
+++ b/packages/discovery-provider/src/queries/get_extended_purchase_gate.py
@@ -261,7 +261,9 @@ def get_legacy_purchase_gate(gate: AccessGate, session=None):
     if gate and "usdc_purchase" in gate:
         # mypy gets confused....
         gate = cast(PurchaseGate, gate)
-        if isinstance(gate["usdc_purchase"]["splits"], dict):
+        if "splits" in gate["usdc_purchase"] and isinstance(
+            gate["usdc_purchase"]["splits"], dict
+        ):
             return gate
         if session:
             new_gate = _get_extended_purchase_gate(session, gate)


### PR DESCRIPTION
### Description

Some ~10 old tracks on staging but none on prod have a missing splits field in the purchases
https://discoveryprovider2.staging.audius.co/v1/tracks/G2aojQv

It seems like indexing logic should handle this now, so this may be just an insurance policy I'm taking out, but with the change my feed loads

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._

Stage dn1