### PR TITLE
[C-5412, C-5414] Add file replace functionality to mobile upload flow

### DIFF
--- a/packages/common/src/store/ui/modals/parentSlice.ts
+++ b/packages/common/src/store/ui/modals/parentSlice.ts
@@ -72,7 +72,8 @@ export const initialState: BasicModalsState = {
   CoinflowWithdraw: { isOpen: false },
   WaitForDownloadModal: { isOpen: false },
   ArtistPick: { isOpen: false },
-  PayoutWallet: { isOpen: false }
+  PayoutWallet: { isOpen: false },
+  EditTrackFormOverflowMenu: { isOpen: false }
 }
 
 const slice = createSlice({

--- a/packages/common/src/store/ui/modals/types.ts
+++ b/packages/common/src/store/ui/modals/types.ts
@@ -101,6 +101,7 @@ export type Modals =
   | 'ArtistPick'
   | 'AlbumTrackRemoveConfirmation'
   | 'PayoutWallet'
+  | 'EditTrackFormOverflowMenu'
 
 export type BasicModalsState = {
   [modal in Modals]: BaseModalState

--- a/packages/mobile/src/screens/edit-track-screen/EditTrackForm.tsx
+++ b/packages/mobile/src/screens/edit-track-screen/EditTrackForm.tsx
@@ -1,11 +1,14 @@
-import { useCallback } from 'react'
+import { useCallback, useContext, useEffect, useState } from 'react'
 
 import type { TrackForUpload } from '@audius/common/store'
 import {
+  // useReplaceTrackConfirmationModal,
+  // useReplaceTrackProgressModal,
   useEarlyReleaseConfirmationModal,
   useHideContentConfirmationModal,
   usePublishConfirmationModal
 } from '@audius/common/store'
+import { useField } from 'formik'
 import { Keyboard } from 'react-native'
 import { KeyboardAwareScrollView } from 'react-native-keyboard-aware-scroll-view'
 import { useDispatch } from 'react-redux'
@@ -27,8 +30,12 @@ import { setVisibility } from 'app/store/drawers/slice'
 import { makeStyles } from 'app/styles'
 
 import { TopBarIconButton } from '../app-screen'
+import { UploadFileContext } from '../upload-screen/screens/UploadFileContext'
 
+import { EditTrackFormOverflowMenuDrawer } from './EditTrackFormOverflowMenuDrawer'
+import { EditTrackFormPreviewContextProvider } from './EditTrackFormPreviewContext'
 import { CancelEditTrackDrawer } from './components'
+import { FileReplaceContainer } from './components/FileReplaceContainer'
 import {
   SelectGenreField,
   DescriptionField,
@@ -44,7 +51,8 @@ const messages = {
   trackName: 'Track Name',
   trackNameError: 'Track Name Required',
   fixErrors: 'Fix Errors To Continue',
-  cancel: 'Cancel'
+  cancel: 'Cancel',
+  untitled: 'Untitled'
 }
 
 const useStyles = makeStyles(({ spacing }) => ({
@@ -67,6 +75,8 @@ export const EditTrackForm = (props: EditTrackFormProps) => {
   const {
     handleSubmit: handleSubmitProp,
     initialValues,
+    file,
+    handleSelectTrack,
     values,
     isUpload,
     isSubmitting,
@@ -82,11 +92,27 @@ export const EditTrackForm = (props: EditTrackFormProps) => {
   const styles = useStyles()
   const navigation = useNavigation()
   const dispatch = useDispatch()
+  const { track } = useContext(UploadFileContext)
   const initiallyHidden = initialValues.is_unlisted
   const isInitiallyScheduled = initialValues.is_scheduled_release
   const usersMayLoseAccess = !isUpload && !initiallyHidden && values.is_unlisted
   const isToBePublished = !isUpload && initiallyHidden && !values.is_unlisted
+  const [isOverflowMenuOpen, setIsOverflowMenuOpen] = useState(false)
+  const [{ value: origFilename }] = useField('orig_filename')
+  const [{ value: streamUrl }] = useField('stream.url')
+  const [, { touched: isTitleTouched }, { setValue: setTitle }] =
+    useField('title')
 
+  const handleOverflowMenuOpen = useCallback(() => {
+    setIsOverflowMenuOpen(true)
+  }, [])
+  const handleOverflowMenuClose = useCallback(() => {
+    setIsOverflowMenuOpen(false)
+  }, [])
+
+  // const { onOpen: openReplaceTrackConfirmation } =
+  //   useReplaceTrackConfirmationModal()
+  // const { onOpen: openReplaceTrackProgress } = useReplaceTrackProgressModal()
   const { onOpen: openHideContentConfirmation } =
     useHideContentConfirmationModal()
   const { onOpen: openEarlyReleaseConfirmation } =
@@ -106,6 +132,13 @@ export const EditTrackForm = (props: EditTrackFormProps) => {
       )
     }
   }, [dirty, navigation, dispatch])
+
+  // Update title when the file is replaced
+  useEffect(() => {
+    if (track && !isTitleTouched) {
+      setTitle(track.metadata.title)
+    }
+  }, [isTitleTouched, setTitle, track])
 
   const handleSubmit = useCallback(() => {
     Keyboard.dismiss()
@@ -137,62 +170,81 @@ export const EditTrackForm = (props: EditTrackFormProps) => {
 
   return (
     <>
-      <FormScreen
-        title={title}
-        icon={IconCloudUpload}
-        topbarLeft={
-          <TopBarIconButton
-            icon={IconCaretLeft}
-            style={styles.backButton}
-            onPress={handlePressBack}
-          />
-        }
-        bottomSection={
+      <EditTrackFormPreviewContextProvider>
+        <FormScreen
+          title={title}
+          icon={IconCloudUpload}
+          topbarLeft={
+            <TopBarIconButton
+              icon={IconCaretLeft}
+              style={styles.backButton}
+              onPress={handlePressBack}
+            />
+          }
+          bottomSection={
+            <>
+              {hasErrors ? (
+                <InputErrorMessage
+                  message={messages.fixErrors}
+                  style={styles.errorText}
+                />
+              ) : null}
+              <Flex direction='row' gap='s'>
+                <Button fullWidth variant='secondary' onPress={handlePressBack}>
+                  {messages.cancel}
+                </Button>
+                <Button
+                  variant='primary'
+                  fullWidth
+                  onPress={handleSubmit}
+                  disabled={isSubmitting || hasErrors}
+                >
+                  {doneText}
+                </Button>
+              </Flex>
+            </>
+          }
+        >
           <>
-            {hasErrors ? (
-              <InputErrorMessage
-                message={messages.fixErrors}
-                style={styles.errorText}
-              />
-            ) : null}
-            <Flex direction='row' gap='s'>
-              <Button fullWidth variant='secondary' onPress={handlePressBack}>
-                {messages.cancel}
-              </Button>
-              <Button
-                variant='primary'
-                fullWidth
-                onPress={handleSubmit}
-                disabled={isSubmitting || hasErrors}
-              >
-                {doneText}
-              </Button>
-            </Flex>
+            <KeyboardAwareScrollView>
+              <Tile style={styles.tile}>
+                {isUpload ? (
+                  <Flex pt='l' ph='l'>
+                    <FileReplaceContainer
+                      fileName={file?.name || origFilename || messages.untitled}
+                      // @ts-ignore
+                      filePath={file?.uri || streamUrl || ''}
+                      onMenuButtonPress={handleOverflowMenuOpen}
+                    />
+                  </Flex>
+                ) : null}
+                <PickArtworkField name='artwork' />
+                <TextField name='title' label={messages.trackName} required />
+                <SubmenuList>
+                  <SelectGenreField />
+                  <SelectMoodField />
+                </SubmenuList>
+                <TagField />
+                <DescriptionField />
+                <SubmenuList removeBottomDivider>
+                  <VisibilityField />
+                  <PriceAndAudienceField />
+                  <RemixSettingsField />
+                  <AdvancedField />
+                </SubmenuList>
+              </Tile>
+            </KeyboardAwareScrollView>
           </>
-        }
-      >
-        <>
-          <KeyboardAwareScrollView>
-            <Tile style={styles.tile}>
-              <PickArtworkField name='artwork' />
-              <TextField name='title' label={messages.trackName} required />
-              <SubmenuList>
-                <SelectGenreField />
-                <SelectMoodField />
-              </SubmenuList>
-              <TagField />
-              <DescriptionField />
-              <SubmenuList removeBottomDivider>
-                <VisibilityField />
-                <PriceAndAudienceField />
-                <RemixSettingsField />
-                <AdvancedField />
-              </SubmenuList>
-            </Tile>
-          </KeyboardAwareScrollView>
-        </>
-      </FormScreen>
+        </FormScreen>
+      </EditTrackFormPreviewContextProvider>
       <CancelEditTrackDrawer />
+      <EditTrackFormOverflowMenuDrawer
+        isOpen={isOverflowMenuOpen}
+        onClose={handleOverflowMenuClose}
+        onReplace={handleSelectTrack}
+        // TODO: Update this later when edit flow is updated for file replace
+        onDownload={isUpload ? undefined : () => {}}
+      />
     </>
   )
 }

--- a/packages/mobile/src/screens/edit-track-screen/EditTrackForm.tsx
+++ b/packages/mobile/src/screens/edit-track-screen/EditTrackForm.tsx
@@ -1,9 +1,9 @@
 import { useCallback, useContext, useEffect, useState } from 'react'
 
+import { useFeatureFlag } from '@audius/common/hooks'
+import { FeatureFlags } from '@audius/common/services'
 import type { TrackForUpload } from '@audius/common/store'
 import {
-  // useReplaceTrackConfirmationModal,
-  // useReplaceTrackProgressModal,
   useEarlyReleaseConfirmationModal,
   useHideContentConfirmationModal,
   usePublishConfirmationModal
@@ -93,6 +93,9 @@ export const EditTrackForm = (props: EditTrackFormProps) => {
   const navigation = useNavigation()
   const dispatch = useDispatch()
   const { track } = useContext(UploadFileContext)
+  const { isEnabled: isTrackReplaceEnabled } = useFeatureFlag(
+    FeatureFlags.TRACK_AUDIO_REPLACE
+  )
   const initiallyHidden = initialValues.is_unlisted
   const isInitiallyScheduled = initialValues.is_scheduled_release
   const usersMayLoseAccess = !isUpload && !initiallyHidden && values.is_unlisted
@@ -110,9 +113,6 @@ export const EditTrackForm = (props: EditTrackFormProps) => {
     setIsOverflowMenuOpen(false)
   }, [])
 
-  // const { onOpen: openReplaceTrackConfirmation } =
-  //   useReplaceTrackConfirmationModal()
-  // const { onOpen: openReplaceTrackProgress } = useReplaceTrackProgressModal()
   const { onOpen: openHideContentConfirmation } =
     useHideContentConfirmationModal()
   const { onOpen: openEarlyReleaseConfirmation } =
@@ -208,7 +208,7 @@ export const EditTrackForm = (props: EditTrackFormProps) => {
           <>
             <KeyboardAwareScrollView>
               <Tile style={styles.tile}>
-                {isUpload ? (
+                {isTrackReplaceEnabled && isUpload ? (
                   <Flex pt='l' ph='l'>
                     <FileReplaceContainer
                       fileName={file?.name || origFilename || messages.untitled}

--- a/packages/mobile/src/screens/edit-track-screen/EditTrackFormOverflowMenuDrawer.tsx
+++ b/packages/mobile/src/screens/edit-track-screen/EditTrackFormOverflowMenuDrawer.tsx
@@ -1,0 +1,47 @@
+import { useCallback, useMemo } from 'react'
+
+import { ActionDrawerWithoutRedux } from 'app/components/action-drawer'
+
+export const messages = {
+  replace: 'Replace File',
+  download: 'Download File'
+}
+
+export const EditTrackFormOverflowMenuDrawer = ({
+  isOpen,
+  onClose,
+  onReplace,
+  onDownload
+}: {
+  isOpen: boolean
+  onClose: () => void
+  onReplace: () => void
+  onDownload?: () => void
+}) => {
+  const handleReplace = useCallback(() => {
+    onReplace()
+    onClose()
+  }, [onClose, onReplace])
+
+  const handleDownload = useCallback(() => {
+    onDownload?.()
+    onClose()
+  }, [onClose, onDownload])
+
+  const rows = useMemo(
+    () => [
+      { text: messages.replace, callback: handleReplace },
+      ...(onDownload
+        ? [{ text: messages.download, callback: handleDownload }]
+        : []),
+      // TODO: Figure out how to make the drawer not be at the bottom
+      { text: '' },
+      { text: '' }
+    ],
+    [handleDownload, handleReplace, onDownload]
+  )
+
+  return (
+    <ActionDrawerWithoutRedux rows={rows} isOpen={isOpen} onClose={onClose} />
+  )
+}

--- a/packages/mobile/src/screens/edit-track-screen/EditTrackFormPreviewContext.tsx
+++ b/packages/mobile/src/screens/edit-track-screen/EditTrackFormPreviewContext.tsx
@@ -38,7 +38,7 @@ export const EditTrackFormPreviewContextProvider = (props: {
 
   // Request preview playback
   const playPreview = useCallback(async (url: string) => {
-    console.log('PLAY PREVIEW', { url })
+    // console.log('PLAY PREVIEW', { url })
     setIsPlaying(true)
 
     // --- 1 ---
@@ -50,10 +50,8 @@ export const EditTrackFormPreviewContextProvider = (props: {
     //   }
     //   // when loaded successfully
     //   console.log(
-    //     'duration in seconds: ' +
-    //       sound.getDuration() +
-    //       'number of channels: ' +
-    //       sound.getNumberOfChannels()
+    //     'preview duration: ' +
+    //       sound.getDuration()
     //   )
     // })
     // sound.setVolume(1)
@@ -70,7 +68,7 @@ export const EditTrackFormPreviewContextProvider = (props: {
   }, [])
 
   const stopPreview = useCallback(async () => {
-    console.log('STOP PREVIEW')
+    // console.log('STOP PREVIEW')
     setIsPlaying(false)
 
     // --- 1 ---

--- a/packages/mobile/src/screens/edit-track-screen/EditTrackFormPreviewContext.tsx
+++ b/packages/mobile/src/screens/edit-track-screen/EditTrackFormPreviewContext.tsx
@@ -1,0 +1,101 @@
+import { createContext, useCallback, useMemo, useState } from 'react'
+
+// import {
+//   playerActions,
+//   playerSelectors,
+//   queueActions,
+//   queueSelectors
+// } from '@audius/common/store'
+// import Sound from 'react-native-sound'
+// import TrackPlayer from 'react-native-track-player'
+// import { useSelector } from 'react-redux'
+
+// Sound.setCategory('Playback')
+
+type PreviewContextProps = {
+  isPlaying: boolean
+  playPreview: (url: string) => void
+  stopPreview: () => void
+}
+
+export const EditTrackFormPreviewContext = createContext<PreviewContextProps>({
+  isPlaying: false,
+  playPreview: () => {},
+  stopPreview: () => {}
+})
+
+export const EditTrackFormPreviewContextProvider = (props: {
+  children: JSX.Element
+}) => {
+  // const dispatch = useDispatch()
+  const [isPlaying, setIsPlaying] = useState(false)
+  // const uid = useSelector(playerSelectors.getUid)
+  // const queueOrder = useSelector(queueSelectors.getOrder)
+  // const queueLength = useSelector(queueSelectors.getLength)
+  // console.log({ uid, queueLength, queueOrder })
+
+  // const soundRef = useRef<Sound | null>(null)
+
+  // Request preview playback
+  const playPreview = useCallback(async (url: string) => {
+    console.log('PLAY PREVIEW', { url })
+    setIsPlaying(true)
+
+    // --- 1 ---
+    // const sound = new Sound(url, Sound.MAIN_BUNDLE, (error) => {
+    // const sound = new Sound(url, '', (error) => {
+    //   if (error) {
+    //     console.log('failed to load the sound', error)
+    //     return
+    //   }
+    //   // when loaded successfully
+    //   console.log(
+    //     'duration in seconds: ' +
+    //       sound.getDuration() +
+    //       'number of channels: ' +
+    //       sound.getNumberOfChannels()
+    //   )
+    // })
+    // sound.setVolume(1)
+    // soundRef.current = sound
+    // soundRef.current.play()
+
+    // --- 2 ---
+    // if (queueLength) {
+    //   dispatch(playerActions.stop({}))
+    //   dispatch(queueActions.clear({}))
+    // }
+    // await TrackPlayer.load({ url })
+    // await TrackPlayer.play()
+  }, [])
+
+  const stopPreview = useCallback(async () => {
+    console.log('STOP PREVIEW')
+    setIsPlaying(false)
+
+    // --- 1 ---
+    // soundRef.current?.stop()
+    // dispatch(queueActions.clear({}))
+
+    // --- 2 ---
+    // dispatch(playerActions.stop({}))
+    // dispatch(queueActions.clear({}))
+    // await TrackPlayer.stop()
+    // await TrackPlayer.reset()
+  }, [])
+
+  const context = useMemo(
+    () => ({
+      isPlaying,
+      playPreview,
+      stopPreview
+    }),
+    [isPlaying, playPreview, stopPreview]
+  )
+
+  return (
+    <EditTrackFormPreviewContext.Provider value={context}>
+      {props.children}
+    </EditTrackFormPreviewContext.Provider>
+  )
+}

--- a/packages/mobile/src/screens/edit-track-screen/EditTrackModalScreen.tsx
+++ b/packages/mobile/src/screens/edit-track-screen/EditTrackModalScreen.tsx
@@ -60,6 +60,7 @@ export const EditTrackModalScreen = () => {
   return (
     <ModalScreen>
       <EditTrackScreen
+        handleSelectTrack={() => {}}
         initialValues={initialValues}
         onSubmit={handleSubmit}
         title={messages.title}

--- a/packages/mobile/src/screens/edit-track-screen/components/FileReplaceContainer.tsx
+++ b/packages/mobile/src/screens/edit-track-screen/components/FileReplaceContainer.tsx
@@ -1,0 +1,57 @@
+import { useCallback, useContext } from 'react'
+
+import {
+  Flex,
+  IconButton,
+  IconKebabHorizontal,
+  IconPause,
+  IconPlay,
+  PlainButton
+} from '@audius/harmony-native'
+import { EditTrackFormPreviewContext } from 'app/screens/edit-track-screen/EditTrackFormPreviewContext'
+
+type FileReplaceContainerProps = {
+  fileName: string
+  filePath: string
+  downloadEnabled?: boolean
+  onMenuButtonPress?: () => void
+}
+
+export const FileReplaceContainer = ({
+  fileName,
+  filePath,
+  onMenuButtonPress
+}: FileReplaceContainerProps) => {
+  const { isPlaying, playPreview, stopPreview } = useContext(
+    EditTrackFormPreviewContext
+  )
+
+  const handleTogglePlay = useCallback(() => {
+    if (isPlaying) {
+      stopPreview()
+    } else {
+      playPreview(filePath)
+    }
+  }, [filePath, isPlaying, playPreview, stopPreview])
+
+  return (
+    <Flex
+      direction='row'
+      justifyContent='space-between'
+      alignItems='center'
+      gap='l'
+    >
+      <PlainButton
+        size='large'
+        style={{ flexShrink: 1, paddingRight: 8 }}
+        iconLeft={isPlaying ? IconPause : IconPlay}
+        onPress={handleTogglePlay}
+      >
+        {fileName}
+      </PlainButton>
+      <Flex>
+        <IconButton icon={IconKebabHorizontal} onPress={onMenuButtonPress} />
+      </Flex>
+    </Flex>
+  )
+}

--- a/packages/mobile/src/screens/edit-track-screen/types.ts
+++ b/packages/mobile/src/screens/edit-track-screen/types.ts
@@ -1,4 +1,4 @@
-import type { TrackMetadataForUpload } from '@audius/common/store'
+import type { NativeFile, TrackMetadataForUpload } from '@audius/common/store'
 import type { Nullable } from '@audius/common/utils'
 import type { FormikProps } from 'formik'
 
@@ -24,12 +24,14 @@ export type EditTrackScreenProps = {
     trackArtwork?: string
     isUpload?: boolean
   }
+  file?: File | NativeFile
+  handleSelectTrack: () => void
   doneText?: string
 } & Partial<ScreenProps>
 
 export type EditTrackFormProps = FormikProps<FormValues> &
-  Partial<ScreenProps> & {
-    doneText?: string
+  Partial<ScreenProps> &
+  Pick<EditTrackScreenProps, 'handleSelectTrack' | 'doneText' | 'file'> & {
     isUpload?: boolean
   }
 

--- a/packages/mobile/src/screens/upload-screen/screens/CompleteTrackScreen.tsx
+++ b/packages/mobile/src/screens/upload-screen/screens/CompleteTrackScreen.tsx
@@ -1,44 +1,49 @@
-import { useCallback, useState } from 'react'
+import { useCallback, useContext, useState } from 'react'
 
-import type {
-  TrackForUpload,
-  TrackMetadataForUpload
-} from '@audius/common/store'
-import { useRoute } from '@react-navigation/native'
+import type { TrackMetadataForUpload } from '@audius/common/store'
 
 import { useNavigation } from 'app/hooks/useNavigation'
 
 import { EditTrackScreen } from '../../edit-track-screen'
-import type { UploadParamList, UploadRouteProp } from '../types'
+import type { UploadParamList } from '../types'
+
+import { UploadFileContext } from './UploadFileContext'
 
 export const messages = {
   title: 'Complete Track',
   done: 'Upload Track'
 }
 
-export type CompleteTrackParams = TrackForUpload
+export type CompleteTrackParams = {}
 
 export const CompleteTrackScreen = () => {
-  const { params } = useRoute<UploadRouteProp<'CompleteTrack'>>()
-  const { metadata, file } = params
+  const { track, selectFile } = useContext(UploadFileContext)
   const [uploadAttempt, setUploadAttempt] = useState(1)
   const navigation = useNavigation<UploadParamList>()
 
   const handleSubmit = useCallback(
     (metadata: TrackMetadataForUpload) => {
-      navigation.push('UploadingTracks', {
-        tracks: [{ file, preview: null, metadata }],
-        uploadAttempt
-      })
-      // Increment attempt count in case we get sent back here after an error
-      setUploadAttempt(uploadAttempt + 1)
+      if (track) {
+        navigation.push('UploadingTracks', {
+          tracks: [{ file: track.file, preview: null, metadata }],
+          uploadAttempt
+        })
+
+        // Increment attempt count in case we get sent back here after an error
+        setUploadAttempt(uploadAttempt + 1)
+      }
     },
-    [navigation, file, uploadAttempt]
+    [navigation, track, uploadAttempt]
   )
+
+  if (!track) return null
+  const { file, metadata } = track
 
   return (
     <EditTrackScreen
       initialValues={{ ...metadata, isUpload: true }}
+      file={file}
+      handleSelectTrack={selectFile}
       onSubmit={handleSubmit}
       title={messages.title}
       url='/complete-track'

--- a/packages/mobile/src/screens/upload-screen/screens/SelectTrackScreen.tsx
+++ b/packages/mobile/src/screens/upload-screen/screens/SelectTrackScreen.tsx
@@ -1,9 +1,7 @@
-import { useCallback, useEffect, useState } from 'react'
+import { useCallback, useContext, useEffect, useState } from 'react'
 
 import { Name } from '@audius/common/models'
 import { useFocusEffect } from '@react-navigation/native'
-import DocumentPicker from 'react-native-document-picker'
-import { useAsyncFn } from 'react-use'
 
 import { IconClose, IconCloudUpload, Button } from '@audius/harmony-native'
 import {
@@ -21,7 +19,8 @@ import { useThemeColors } from 'app/utils/theme'
 
 import { TopBarIconButton } from '../../app-screen'
 import type { UploadParamList } from '../types'
-import { processTrackFile } from '../utils/processTrackFile'
+
+import { UploadFileContext } from './UploadFileContext'
 
 const messages = {
   screenTitle: 'Upload',
@@ -54,25 +53,10 @@ export const SelectTrackScreen = () => {
   const { neutralLight4 } = useThemeColors()
   const navigation = useNavigation<UploadParamList>()
   const [navigatedBack, setNavigatedBack] = useState(false)
-
-  const [{ value: track, loading, error }, handleSelectTrack] =
-    useAsyncFn(async () => {
-      try {
-        const trackFile = await DocumentPicker.pickSingle({
-          type: DocumentPicker.types.audio,
-          copyTo: 'cachesDirectory'
-        })
-        return processTrackFile(trackFile)
-      } catch (error) {
-        DocumentPicker.isCancel(error)
-        return null
-      }
-    }, [])
+  const { track, loading, error, selectFile } = useContext(UploadFileContext)
 
   useEffect(() => {
-    if (track) {
-      navigation.push('CompleteTrack', track)
-    }
+    if (track) navigation.push('CompleteTrack', {})
   }, [track, navigation])
 
   useFocusEffect(
@@ -122,7 +106,7 @@ export const SelectTrackScreen = () => {
             fullWidth
             variant='primary'
             isLoading={!!isLoading}
-            onPress={handleSelectTrack}
+            onPress={selectFile}
           >
             {messages.browse}
           </Button>

--- a/packages/mobile/src/screens/upload-screen/screens/UploadFileContext.tsx
+++ b/packages/mobile/src/screens/upload-screen/screens/UploadFileContext.tsx
@@ -1,0 +1,59 @@
+import type { ReactNode } from 'react'
+import { createContext } from 'react'
+
+import type { TrackForUpload } from '@audius/common/store'
+import DocumentPicker from 'react-native-document-picker'
+import { useAsyncFn } from 'react-use'
+
+import { processTrackFile } from '../utils/processTrackFile'
+
+type UploadFileContextType = {}
+
+type UploadFileContextValue = {
+  track: TrackForUpload | null
+  loading: boolean
+  error?: Error
+  selectFile: () => void
+}
+
+export const UploadFileContext = createContext<UploadFileContextValue>({
+  track: null,
+  loading: false,
+  selectFile: () => {}
+})
+
+type UploadFileContextProviderProps = UploadFileContextType & {
+  children: ReactNode
+}
+
+export const UploadFileContextProvider = (
+  props: UploadFileContextProviderProps
+) => {
+  const { children } = props
+
+  const [{ value, loading, error }, handleSelectFile] = useAsyncFn(async () => {
+    try {
+      const trackFile = await DocumentPicker.pickSingle({
+        type: DocumentPicker.types.audio,
+        copyTo: 'cachesDirectory'
+      })
+      return trackFile ? processTrackFile(trackFile) : null
+    } catch (error) {
+      DocumentPicker.isCancel(error)
+      return null
+    }
+  }, [])
+
+  return (
+    <UploadFileContext.Provider
+      value={{
+        track: value ?? null,
+        loading,
+        error,
+        selectFile: handleSelectFile
+      }}
+    >
+      {children}
+    </UploadFileContext.Provider>
+  )
+}

--- a/packages/mobile/src/screens/upload-screen/screens/UploadModalScreen.tsx
+++ b/packages/mobile/src/screens/upload-screen/screens/UploadModalScreen.tsx
@@ -7,6 +7,7 @@ import { useAppScreenOptions } from '../../app-screen/useAppScreenOptions'
 import { CompleteTrackScreen } from './CompleteTrackScreen'
 import { SelectTrackScreen } from './SelectTrackScreen'
 import { UploadCompleteScreen } from './UploadCompleteScreen'
+import { UploadFileContextProvider } from './UploadFileContext'
 import { UploadingTracksScreen } from './UploadingTracksScreen'
 
 const Stack = createNativeStackNavigator()
@@ -18,19 +19,24 @@ export const UploadModalScreen = () => {
 
   return (
     <ModalScreen>
-      <Stack.Navigator screenOptions={screenOptions}>
-        <Stack.Screen name='SelectTrack' component={SelectTrackScreen} />
-        <Stack.Screen
-          name='CompleteTrack'
-          component={CompleteTrackScreen}
-          options={{ headerShown: false, gestureEnabled: false }}
-        />
-        <Stack.Screen
-          name='UploadingTracks'
-          component={UploadingTracksScreen}
-        />
-        <Stack.Screen name='UploadComplete' component={UploadCompleteScreen} />
-      </Stack.Navigator>
+      <UploadFileContextProvider>
+        <Stack.Navigator screenOptions={screenOptions}>
+          <Stack.Screen name='SelectTrack' component={SelectTrackScreen} />
+          <Stack.Screen
+            name='CompleteTrack'
+            component={CompleteTrackScreen}
+            options={{ headerShown: false, gestureEnabled: false }}
+          />
+          <Stack.Screen
+            name='UploadingTracks'
+            component={UploadingTracksScreen}
+          />
+          <Stack.Screen
+            name='UploadComplete'
+            component={UploadCompleteScreen}
+          />
+        </Stack.Navigator>
+      </UploadFileContextProvider>
     </ModalScreen>
   )
 }

--- a/packages/mobile/src/store/drawers/slice.ts
+++ b/packages/mobile/src/store/drawers/slice.ts
@@ -32,6 +32,7 @@ export type Drawer =
   | 'Welcome'
   | 'ManagerMode'
   | 'Comment'
+  | 'EditTrackFormOverflowMenu'
 
 export type DrawerData = {
   EnablePushNotifications: undefined
@@ -73,6 +74,7 @@ export type DrawerData = {
   Welcome: undefined
   ManagerMode: undefined
   Comment: { userId: ID; entityId: ID; isEntityOwner: boolean; artistId: ID }
+  EditTrackFormOverflowMenu: undefined
 }
 
 export type DrawersState = { [drawer in Drawer]: boolean | 'closing' } & {
@@ -106,6 +108,7 @@ const initialState: DrawersState = {
   Welcome: false,
   ManagerMode: false,
   Comment: false,
+  EditTrackFormOverflowMenu: false,
   data: {}
 }
 


### PR DESCRIPTION
### Description
Add contexts for handing previews and upload files for the mobile upload and edit flows
Add the FileReplaceContainer component and add it to the EditTrackForm component

### How Has This Been Tested?
Lots of manual testing

### Known Issues:
Previews are currently not working bc they interfere with the audio player and TrackPlayer too much so another player/approach is being looked into