### PR TITLE
[C-5462] Fix EditTrackForm download function

### DIFF
--- a/packages/web/src/components/edit-track/EditTrackForm.tsx
+++ b/packages/web/src/components/edit-track/EditTrackForm.tsx
@@ -253,17 +253,16 @@ const TrackEditForm = (
   )
 
   const onClickDownload = useCallback(() => {
-    if (!track.file) return
+    const { url } = track?.metadata?.download
+    if (!url) return
 
-    const url = URL.createObjectURL(track.file)
     const link = document.createElement('a')
     link.href = url
-    link.download = track.file.name || 'download'
+    link.download = track.metadata.orig_filename || 'download'
     document.body.appendChild(link)
     link.click()
     document.body.removeChild(link)
-    URL.revokeObjectURL(url)
-  }, [track.file])
+  }, [track.metadata])
 
   return (
     <Form id={formId}>


### PR DESCRIPTION
### Description
The file prop is no longer on the track info for some reason (lots of upload changes recently with the sdk updates and whatnot)
Updated to use the download url from the track metadata instead

### How Has This Been Tested?
Manually tested
