### PR TITLE
Improve desktop track tile perf

### DIFF
--- a/packages/common/src/hooks/content/useCollectionLockedStatusVariant.ts
+++ b/packages/common/src/hooks/content/useCollectionLockedStatusVariant.ts
@@ -1,19 +1,18 @@
-import { useGetPlaylistById } from '~/api'
+import { useSelector } from 'react-redux'
+
 import { ID, isContentUSDCPurchaseGated } from '~/models'
+import { CommonState } from '~/store'
+import { getCollection } from '~/store/cache/collections/selectors'
 import { Nullable } from '~/utils'
 
 import { LockedStatusVariant } from './types'
 
 export const useCollectionLockedStatusVariant = (collectionId: ID) => {
-  const { data: collection } = useGetPlaylistById(
-    { playlistId: collectionId },
-    { disabled: !collectionId }
-  )
+  const streamConditions = useSelector((state: CommonState) => {
+    return getCollection(state, { id: collectionId })?.stream_conditions
+  })
 
-  if (!collection) return null
-  const { stream_conditions } = collection
-
-  const isPurchaseable = isContentUSDCPurchaseGated(stream_conditions)
+  const isPurchaseable = isContentUSDCPurchaseGated(streamConditions)
 
   let variant: Nullable<LockedStatusVariant> = null
   if (isPurchaseable) {

--- a/packages/common/src/hooks/content/useIsCollectionUnlockable.ts
+++ b/packages/common/src/hooks/content/useIsCollectionUnlockable.ts
@@ -1,14 +1,15 @@
-import { useGetPlaylistById } from '~/api'
+import { useSelector } from 'react-redux'
+
 import { ID, isContentUSDCPurchaseGated } from '~/models'
+import { CommonState } from '~/store'
+import { getCollection } from '~/store/cache/collections/selectors'
 
 export const useIsCollectionUnlockable = (collectionId: ID) => {
-  const { data: collection } = useGetPlaylistById({
-    playlistId: collectionId
+  return useSelector((state: CommonState) => {
+    const streamConditions = getCollection(state, {
+      id: collectionId
+    })?.stream_conditions
+
+    return isContentUSDCPurchaseGated(streamConditions)
   })
-
-  if (!collection) return false
-  const { stream_conditions } = collection
-  const isPurchaseable = isContentUSDCPurchaseGated(stream_conditions)
-
-  return isPurchaseable
 }

--- a/packages/common/src/hooks/content/useIsTrackUnlockable.ts
+++ b/packages/common/src/hooks/content/useIsTrackUnlockable.ts
@@ -1,19 +1,22 @@
-import { useGetTrackById } from '~/api'
+import { useSelector } from 'react-redux'
+
 import {
   isContentSpecialAccess,
   isContentCollectibleGated,
   isContentUSDCPurchaseGated,
   ID
 } from '~/models'
+import { CommonState } from '~/store'
+import { getTrack } from '~/store/cache/tracks/selectors'
 
 export const useIsTrackUnlockable = (trackId: ID) => {
-  const { data: track } = useGetTrackById({ id: trackId })
+  return useSelector((state: CommonState) => {
+    const streamConditions = getTrack(state, { id: trackId })?.stream_conditions
 
-  if (!track) return false
-  const { stream_conditions } = track
-  const isPurchaseable = isContentUSDCPurchaseGated(stream_conditions)
-  const isCollectibleGated = isContentCollectibleGated(stream_conditions)
-  const isSpecialAccess = isContentSpecialAccess(stream_conditions)
+    const isPurchaseable = isContentUSDCPurchaseGated(streamConditions)
+    const isCollectibleGated = isContentCollectibleGated(streamConditions)
+    const isSpecialAccess = isContentSpecialAccess(streamConditions)
 
-  return isPurchaseable || isCollectibleGated || isSpecialAccess
+    return isPurchaseable || isCollectibleGated || isSpecialAccess
+  })
 }

--- a/packages/common/src/hooks/content/useTrackLockedStatusVariant.ts
+++ b/packages/common/src/hooks/content/useTrackLockedStatusVariant.ts
@@ -1,26 +1,25 @@
-import { useGetTrackById } from '~/api'
+import { useSelector } from 'react-redux'
+
 import {
   ID,
   isContentCollectibleGated,
   isContentSpecialAccess,
   isContentUSDCPurchaseGated
 } from '~/models'
+import { CommonState } from '~/store'
+import { getTrack } from '~/store/cache/tracks/selectors'
 import { Nullable } from '~/utils'
 
 import { LockedStatusVariant } from './types'
 
 export const useTrackLockedStatusVariant = (trackId: ID) => {
-  const { data: track } = useGetTrackById(
-    { id: trackId },
-    { disabled: !trackId }
-  )
+  const streamConditions = useSelector((state: CommonState) => {
+    return getTrack(state, { id: trackId })?.stream_conditions
+  })
 
-  if (!track) return null
-  const { stream_conditions } = track
-
-  const isPurchaseable = isContentUSDCPurchaseGated(stream_conditions)
-  const isCollectibleGated = isContentCollectibleGated(stream_conditions)
-  const isSpecialAccess = isContentSpecialAccess(stream_conditions)
+  const isPurchaseable = isContentUSDCPurchaseGated(streamConditions)
+  const isCollectibleGated = isContentCollectibleGated(streamConditions)
+  const isSpecialAccess = isContentSpecialAccess(streamConditions)
 
   let variant: Nullable<LockedStatusVariant> = null
   if (isPurchaseable) {

--- a/packages/mobile/src/components/lineup-tile/TrackTileMetrics.tsx
+++ b/packages/mobile/src/components/lineup-tile/TrackTileMetrics.tsx
@@ -25,6 +25,7 @@ import { VanityMetric } from './VanityMetrics'
 const { setFavorite } = favoritesUserListActions
 const { setRepost } = repostsUserListActions
 const { getTrack } = cacheTracksSelectors
+
 type RepostsMetricProps = {
   trackId: ID
 }

--- a/packages/web/src/components/collection/CollectionLockedStatusBadge.tsx
+++ b/packages/web/src/components/collection/CollectionLockedStatusBadge.tsx
@@ -1,10 +1,8 @@
-import { useGetPlaylistById } from '@audius/common/api'
 import {
   useCollectionLockedStatusVariant,
-  useGatedContentAccess
+  useGatedCollectionAccess
 } from '@audius/common/hooks'
-import { Collection, ID } from '@audius/common/models'
-import { Nullable } from '@audius/common/utils'
+import { ID } from '@audius/common/models'
 
 import { LockedStatusBadge } from 'components/locked-status-badge'
 
@@ -16,14 +14,7 @@ export const CollectionLockedStatusBadge = (
   props: CollectionLockedStatusBadgeProps
 ) => {
   const { collectionId } = props
-  const { data: collection } = useGetPlaylistById(
-    { playlistId: collectionId },
-    { disabled: !collectionId }
-  )
-
-  const { hasStreamAccess } = useGatedContentAccess(
-    collection as Nullable<Collection>
-  )
+  const { hasStreamAccess } = useGatedCollectionAccess(collectionId)
 
   const variant = useCollectionLockedStatusVariant(collectionId)
   if (!variant) return null

--- a/packages/web/src/components/collection/CollectionTileStats.tsx
+++ b/packages/web/src/components/collection/CollectionTileStats.tsx
@@ -1,15 +1,18 @@
-import { useGetPlaylistById } from '@audius/common/api'
 import { useIsCollectionUnlockable } from '@audius/common/hooks'
 import { ID } from '@audius/common/models'
+import { cacheCollectionsSelectors } from '@audius/common/store'
 import { Flex, Skeleton } from '@audius/harmony'
 
 import { EntityRank } from 'components/lineup/EntityRank'
 import { TrackTileSize } from 'components/track/types'
 import { useIsMobile } from 'hooks/useIsMobile'
+import { useSelector } from 'utils/reducer'
 
 import { CollectionAccessTypeLabel } from './CollectionAccessTypeLabel'
 import { CollectionLockedStatusBadge } from './CollectionLockedStatusBadge'
 import { RepostsMetric, SavesMetric } from './CollectionTileMetrics'
+
+const { getCollection } = cacheCollectionsSelectors
 
 type CollectionTileStatsProps = {
   collectionId: ID
@@ -25,16 +28,13 @@ export const CollectionTileStats = (props: CollectionTileStatsProps) => {
   const isMobile = useIsMobile()
   const isUnlockable = useIsCollectionUnlockable(collectionId)
 
-  const { data: collection } = useGetPlaylistById(
-    { playlistId: collectionId },
-    { disabled: !!collectionId }
-  )
+  const isPrivate = useSelector((state) => {
+    return getCollection(state, { id: collectionId })?.is_private
+  })
 
-  if (isLoading || !collection) {
+  if (isLoading) {
     return <Skeleton w='30%' h={isMobile ? 16 : 20} />
   }
-
-  const { is_private } = collection
 
   return (
     <Flex
@@ -47,7 +47,7 @@ export const CollectionTileStats = (props: CollectionTileStatsProps) => {
           <EntityRank index={rankIndex} />
         ) : null}
         <CollectionAccessTypeLabel collectionId={collectionId} />
-        {is_private ? null : (
+        {isPrivate ? null : (
           <>
             <RepostsMetric collectionId={collectionId} size={size} />
             <SavesMetric collectionId={collectionId} />

--- a/packages/web/src/components/track/TrackLockedStatusBadge.tsx
+++ b/packages/web/src/components/track/TrackLockedStatusBadge.tsx
@@ -1,10 +1,8 @@
-import { useGetTrackById } from '@audius/common/api'
 import {
-  useGatedContentAccess,
+  useGatedTrackAccess,
   useTrackLockedStatusVariant
 } from '@audius/common/hooks'
-import { ID, Track } from '@audius/common/models'
-import { Nullable } from '@audius/common/utils'
+import { ID } from '@audius/common/models'
 
 import { LockedStatusBadge } from 'components/locked-status-badge'
 
@@ -14,12 +12,8 @@ type TrackLockedStatusBadgeProps = {
 
 export const TrackLockedStatusBadge = (props: TrackLockedStatusBadgeProps) => {
   const { trackId } = props
-  const { data: track } = useGetTrackById(
-    { id: trackId },
-    { disabled: !trackId }
-  )
 
-  const { hasStreamAccess } = useGatedContentAccess(track as Nullable<Track>)
+  const { hasStreamAccess } = useGatedTrackAccess(trackId)
   const variant = useTrackLockedStatusVariant(trackId)
 
   if (!variant) return null

--- a/packages/web/src/components/track/TrackTileStats.tsx
+++ b/packages/web/src/components/track/TrackTileStats.tsx
@@ -1,10 +1,11 @@
-import { useGetTrackById } from '@audius/common/api'
 import { useIsTrackUnlockable } from '@audius/common/hooks'
 import { ID } from '@audius/common/models'
+import { cacheTracksSelectors } from '@audius/common/store'
 import { Flex, Skeleton } from '@audius/harmony'
 
 import { EntityRank } from 'components/lineup/EntityRank'
 import { useIsMobile } from 'hooks/useIsMobile'
+import { useSelector } from 'utils/reducer'
 
 import { TrackAccessTypeLabel } from './TrackAccessTypeLabel'
 import { TrackLockedStatusBadge } from './TrackLockedStatusBadge'
@@ -15,6 +16,8 @@ import {
   SavesMetric
 } from './TrackTileMetrics'
 import { TrackTileSize } from './types'
+
+const { getTrack } = cacheTracksSelectors
 
 type TrackTileStatsProps = {
   trackId: ID
@@ -30,20 +33,17 @@ export const TrackTileStats = (props: TrackTileStatsProps) => {
   const isUnlockable = useIsTrackUnlockable(trackId)
   const isMobile = useIsMobile()
 
-  const { data: track } = useGetTrackById(
-    { id: trackId },
-    { disabled: !!trackId }
-  )
+  const isUnlisted = useSelector((state) => {
+    return getTrack(state, { id: trackId })?.is_unlisted
+  })
 
-  if (isLoading || !track) {
+  if (isLoading) {
     return (
       <Flex h='2xl' alignItems='center'>
         <Skeleton w='40%' h={isMobile ? 16 : 20} />
       </Flex>
     )
   }
-
-  const { is_unlisted } = track
 
   return (
     <Flex
@@ -54,7 +54,7 @@ export const TrackTileStats = (props: TrackTileStatsProps) => {
       <Flex gap='l'>
         {isTrending ? <EntityRank index={rankIndex!} /> : null}
         <TrackAccessTypeLabel trackId={trackId} />
-        {is_unlisted ? null : (
+        {isUnlisted ? null : (
           <>
             <RepostsMetric trackId={trackId} size={size} />
             <SavesMetric trackId={trackId} />
@@ -64,7 +64,7 @@ export const TrackTileStats = (props: TrackTileStatsProps) => {
       </Flex>
       {isUnlockable ? (
         <TrackLockedStatusBadge trackId={trackId} />
-      ) : is_unlisted ? null : (
+      ) : isUnlisted ? null : (
         <PlayMetric trackId={trackId} />
       )}
     </Flex>


### PR DESCRIPTION
### Description

Applies same optimization techniques from mobile lineup tiles to desktop. I found a few more areas where mobile was using inneficient hooks through this pass, so mobile should also get a decent additional speedup.