### PR TITLE
Adds guards to bulk fetching hooks

### DIFF
--- a/packages/common/src/api/collection.ts
+++ b/packages/common/src/api/collection.ts
@@ -42,9 +42,12 @@ const collectionApi = createApi({
         { ids, currentUserId }: { ids: ID[]; currentUserId?: Nullable<ID> },
         { audiusSdk }
       ) => {
+        const id = ids.filter((id) => id && id !== -1).map((id) => Id.parse(id))
+        if (id.length === 0) return []
+
         const sdk = await audiusSdk()
         const { data = [] } = await sdk.full.playlists.getBulkPlaylists({
-          id: ids.filter((id) => id && id !== -1).map((id) => Id.parse(id)),
+          id,
           userId: OptionalId.parse(currentUserId)
         })
         return transformAndCleanList(data, userCollectionMetadataFromSDK)
@@ -60,9 +63,12 @@ const collectionApi = createApi({
         { ids, currentUserId }: { ids: ID[]; currentUserId?: Nullable<ID> },
         { audiusSdk }
       ) => {
+        const id = ids.filter((id) => id && id !== -1).map((id) => Id.parse(id))
+        if (id.length === 0) return []
+
         const sdk = await audiusSdk()
         const { data = [] } = await sdk.full.playlists.getBulkPlaylists({
-          id: ids.map((id) => Id.parse(id)),
+          id,
           userId: OptionalId.parse(currentUserId)
         })
         return transformAndCleanList(data, userCollectionMetadataFromSDK)

--- a/packages/common/src/api/track.ts
+++ b/packages/common/src/api/track.ts
@@ -30,9 +30,12 @@ const trackApi = createApi({
         { ids, currentUserId }: { ids: ID[]; currentUserId?: Nullable<ID> },
         { audiusSdk }
       ) => {
+        const id = ids.filter((id) => id && id !== -1).map((id) => Id.parse(id))
+        if (id.length === 0) return []
+
         const sdk = await audiusSdk()
         const { data = [] } = await sdk.full.tracks.getBulkTracks({
-          id: ids.filter((id) => id && id !== -1).map((id) => Id.parse(id)),
+          id,
           userId: OptionalId.parse(currentUserId)
         })
         return transformAndCleanList(data, userTrackMetadataFromSDK)
@@ -75,10 +78,13 @@ const trackApi = createApi({
         { ids, currentUserId }: { ids: ID[]; currentUserId: Nullable<ID> },
         { audiusSdk }
       ) => {
+        const id = ids.filter((id) => id && id !== -1).map((id) => Id.parse(id))
+        if (id.length === 0) return []
+
         const sdk = await audiusSdk()
 
         const { data = [] } = await sdk.full.tracks.getBulkTracks({
-          id: ids.map((id) => Id.parse(id)),
+          id,
           userId: OptionalId.parse(currentUserId)
         })
         return transformAndCleanList(data, userTrackMetadataFromSDK)


### PR DESCRIPTION
### Description
Just a little change to keep us from making bogus network requests if we end up with a completely empty list after filtering out invalid ids. The bulk fetch hooks will still throw errors due to us not returning anything for the invalid id requests. But that can be addressed separately if needed.

### How Has This Been Tested?
Local client against staging.
