### PR TITLE
Shorter rollup intervals for stage and prod core

### DIFF
--- a/pkg/core/chain/auditor.go
+++ b/pkg/core/chain/auditor.go
@@ -96,7 +96,7 @@ func (app *CoreApplication) shouldProposeNewRollup(ctx context.Context, height i
 	} else {
 		previousHeight = latestRollup.BlockEnd
 	}
-	return height-previousHeight == int64(app.config.SlaRollupInterval)
+	return height-previousHeight >= int64(app.config.SlaRollupInterval)
 }
 
 func (app *CoreApplication) finalizeSlaRollup(ctx context.Context, event *gen_proto.SignedTransaction, txHash string) (*gen_proto.SlaRollup, error) {

--- a/pkg/core/config/config.go
+++ b/pkg/core/config/config.go
@@ -180,7 +180,7 @@ func ReadConfig(logger *common.Logger) (*Config, error) {
 			cfg.EthRPCUrl = ProdEthRpc
 		}
 
-		cfg.SlaRollupInterval = 3600 * 24
+		cfg.SlaRollupInterval = 2048
 
 	case "stage", "staging", "testnet":
 		cfg.PersistentPeers = getEnvWithDefault("persistentPeers", StagePersistentPeers)
@@ -188,7 +188,7 @@ func ReadConfig(logger *common.Logger) (*Config, error) {
 		if cfg.EthRPCUrl == "" {
 			cfg.EthRPCUrl = StageEthRpc
 		}
-		cfg.SlaRollupInterval = 3600 * 24
+		cfg.SlaRollupInterval = 2048
 
 	case "dev", "development", "devnet", "local", "sandbox":
 		cfg.PersistentPeers = getEnvWithDefault("persistentPeers", DevPersistentPeers)

--- a/pkg/core/config/genesis/stage.json
+++ b/pkg/core/config/genesis/stage.json
@@ -1,6 +1,6 @@
 {
   "genesis_time": "2024-08-09T00:00:00.0000Z",
-  "chain_id": "audius-testnet-9",
+  "chain_id": "audius-testnet-8",
   "initial_height": "0",
   "consensus_params": {
     "block": {

--- a/pkg/core/config/genesis/stage.json
+++ b/pkg/core/config/genesis/stage.json
@@ -1,6 +1,6 @@
 {
   "genesis_time": "2024-08-09T00:00:00.0000Z",
-  "chain_id": "audius-testnet-8",
+  "chain_id": "audius-testnet-9",
   "initial_height": "0",
   "consensus_params": {
     "block": {


### PR DESCRIPTION
### Description

It takes too long to produce SLA Rollup data as block times aren't as short as originally anticipated.