### PR TITLE
[C-5413, C-5415] Add FileReplace to the mobile edit track flow

### DIFF
--- a/packages/mobile/src/app/Drawers.tsx
+++ b/packages/mobile/src/app/Drawers.tsx
@@ -42,7 +42,7 @@ import { TransferAudioMobileDrawer } from 'app/components/transfer-audio-mobile-
 import { TrendingRewardsDrawer } from 'app/components/trending-rewards-drawer'
 import { USDCManualTransferDrawer } from 'app/components/usdc-manual-transfer-drawer'
 import { WaitForDownloadDrawer } from 'app/components/wait-for-download-drawer'
-import { ReplaceTrackConfirmationDrawer } from 'app/screens/edit-track-screen/components'
+import { ReplaceTrackProgressDrawer } from 'app/screens/edit-track-screen/components'
 import { EarlyReleaseConfirmationDrawer } from 'app/screens/edit-track-screen/components/EarlyReleaseConfirmationDrawer'
 import { PublishConfirmationDrawer } from 'app/screens/edit-track-screen/components/PublishConfirmationDrawer'
 import { WelcomeDrawer } from 'app/screens/sign-on-screen/components/WelcomeDrawer'
@@ -130,7 +130,7 @@ const commonDrawersMap: { [Modal in Modals]?: ComponentType } = {
   LeavingAudiusModal: LeavingAudiusDrawer,
   WaitForDownloadModal: WaitForDownloadDrawer,
   PublishConfirmation: PublishConfirmationDrawer,
-  ReplaceTrackConfirmation: ReplaceTrackConfirmationDrawer,
+  ReplaceTrackProgress: ReplaceTrackProgressDrawer,
   EarlyReleaseConfirmation: EarlyReleaseConfirmationDrawer,
   ArtistPick: ArtistPickConfirmationDrawer
 }

--- a/packages/mobile/src/screens/edit-track-screen/EditTrackModalScreen.tsx
+++ b/packages/mobile/src/screens/edit-track-screen/EditTrackModalScreen.tsx
@@ -11,6 +11,8 @@ import { isImageUriSource } from 'app/hooks/useContentNodeImage'
 import { useNavigation } from 'app/hooks/useNavigation'
 import { useRoute } from 'app/hooks/useRoute'
 
+import { UploadFileContextProvider } from '../upload-screen/screens/UploadFileContext'
+
 import { EditTrackScreen } from './EditTrackScreen'
 
 const { getTrack } = cacheTracksSelectors
@@ -59,13 +61,14 @@ export const EditTrackModalScreen = () => {
 
   return (
     <ModalScreen>
-      <EditTrackScreen
-        handleSelectTrack={() => {}}
-        initialValues={initialValues}
-        onSubmit={handleSubmit}
-        title={messages.title}
-        doneText={messages.save}
-      />
+      <UploadFileContextProvider>
+        <EditTrackScreen
+          initialValues={initialValues}
+          onSubmit={handleSubmit}
+          title={messages.title}
+          doneText={messages.save}
+        />
+      </UploadFileContextProvider>
     </ModalScreen>
   )
 }

--- a/packages/mobile/src/screens/edit-track-screen/EditTrackNavigator.tsx
+++ b/packages/mobile/src/screens/edit-track-screen/EditTrackNavigator.tsx
@@ -11,6 +11,7 @@ import { useAppScreenOptions } from 'app/screens/app-screen/useAppScreenOptions'
 import { messages as completeMessages } from '../upload-screen/screens/CompleteTrackScreen'
 
 import { EditTrackForm } from './EditTrackForm'
+import { ReplaceTrackConfirmationDrawer } from './components'
 import { EarlyReleaseConfirmationDrawer } from './components/EarlyReleaseConfirmationDrawer'
 import { EditAccessConfirmationDrawer } from './components/EditAccessConfirmationDrawer'
 import { HideContentConfirmationDrawer } from './components/HideContentConfirmationDrawer'
@@ -80,6 +81,7 @@ export const EditTrackNavigator = (props: EditTrackNavigatorProps) => {
       <HideContentConfirmationDrawer />
       <PublishConfirmationDrawer />
       <EarlyReleaseConfirmationDrawer />
+      <ReplaceTrackConfirmationDrawer />
     </>
   )
 }

--- a/packages/mobile/src/screens/edit-track-screen/EditTrackScreen.tsx
+++ b/packages/mobile/src/screens/edit-track-screen/EditTrackScreen.tsx
@@ -2,10 +2,7 @@ import { useCallback, useMemo } from 'react'
 
 import { useUSDCPurchaseConfig } from '@audius/common/hooks'
 import { isContentUSDCPurchaseGated } from '@audius/common/models'
-import type {
-  TrackForUpload,
-  TrackMetadataForUpload
-} from '@audius/common/store'
+import type { TrackForUpload } from '@audius/common/store'
 import {
   creativeCommons,
   formatPrice,
@@ -22,6 +19,8 @@ import { TRACK_PRICE } from 'app/components/edit/PriceAndAudienceField/PremiumRa
 import { EditTrackNavigator } from './EditTrackNavigator'
 import { BPM } from './screens/KeyBpmScreen'
 import type { FormValues, EditTrackScreenProps } from './types'
+import { getUploadMetadataFromFormValues } from './util'
+
 const { computeLicenseVariables, ALL_RIGHTS_RESERVED_TYPE } = creativeCommons
 
 const MIN_BPM = 1
@@ -253,87 +252,10 @@ export const EditTrackScreen = (props: EditTrackScreenProps) => {
 
   const handleSubmit = useCallback(
     (values: FormValues, { setSubmitting }) => {
-      const {
-        licenseType: ignoredLicenseType,
-        trackArtwork: ignoredTrackArtwork,
-        isCover,
-        ...formValues
-      } = values
-
-      const metadata: TrackMetadataForUpload = {
-        ...formValues,
-        bpm: formValues.bpm ? Number(formValues.bpm) : null
-      }
-
-      if (isCover) {
-        metadata.cover_original_song_title =
-          metadata.cover_original_song_title ?? ''
-        metadata.cover_original_artist = metadata.cover_original_artist ?? ''
-      }
-
-      // If track is not unlisted and one of the unlisted visibility fields is false, set to true.
-      // We shouldn't have to do this if we set the default for 'share' and 'play_count' to true
-      // in newTrackMetadata, but not sure why they default to false.
-      if (!metadata.is_unlisted) {
-        const unlistedVisibilityFields = [
-          'genre',
-          'mood',
-          'tags',
-          'share',
-          'play_count'
-        ]
-        const shouldOverrideVisibilityFields = !unlistedVisibilityFields.every(
-          (field) => metadata.field_visibility?.[field]
-        )
-        if (shouldOverrideVisibilityFields) {
-          metadata.field_visibility = {
-            ...metadata.field_visibility,
-            genre: true,
-            mood: true,
-            tags: true,
-            share: true,
-            play_count: true,
-            remixes: !!metadata.field_visibility?.remixes
-          }
-        }
-      }
-
-      const streamConditions = metadata.stream_conditions
-      let previewStartSeconds = metadata.preview_start_seconds
-      let isDownloadable = metadata.is_downloadable
-      let isOriginalAvailable = metadata.is_original_available
-
-      // If track is usdc gated, then price and preview need to be parsed into numbers before submitting
-      if (isContentUSDCPurchaseGated(streamConditions)) {
-        // If user did not set usdc gated track preview, default it to 0
-        previewStartSeconds = Number(previewStartSeconds ?? 0)
-
-        // track is downloadable and lossless files are provided by default if track is usdc purchase gated
-        // unless it was already usdc purchase gated
-        const { download_conditions: initialDownloadConditions } =
-          initialValuesProp
-        isDownloadable = !isContentUSDCPurchaseGated(initialDownloadConditions)
-          ? true
-          : isDownloadable
-        isOriginalAvailable = !isContentUSDCPurchaseGated(
-          initialDownloadConditions
-        )
-          ? true
-          : isOriginalAvailable
-      }
-
-      // set the fields back into the metadata
-      metadata.stream_conditions = streamConditions
-      metadata.preview_start_seconds = previewStartSeconds
-      metadata.is_downloadable = isDownloadable
-      metadata.is_original_available = isOriginalAvailable
-
-      // download conditions should inherit from stream conditions if track is stream gated
-      // this will be updated once the UI for download gated tracks is implemented
-      if (streamConditions) {
-        metadata.download_conditions = streamConditions
-        metadata.is_download_gated = true
-      }
+      const metadata = getUploadMetadataFromFormValues(
+        values,
+        initialValuesProp
+      )
 
       // submit the metadata
       onSubmit(metadata)

--- a/packages/mobile/src/screens/edit-track-screen/components/ReplaceTrackConfirmationDrawer.tsx
+++ b/packages/mobile/src/screens/edit-track-screen/components/ReplaceTrackConfirmationDrawer.tsx
@@ -1,5 +1,3 @@
-import { useCallback } from 'react'
-
 import { useReplaceTrackConfirmationModal } from '@audius/common/store'
 
 import { Hint, IconError } from '@audius/harmony-native'
@@ -15,20 +13,14 @@ const messages = {
 }
 
 export const ReplaceTrackConfirmationDrawer = () => {
-  const { data, onClose } = useReplaceTrackConfirmationModal()
+  const { data } = useReplaceTrackConfirmationModal()
   const { confirmCallback } = data
-
-  const handleConfirm = useCallback(() => {
-    confirmCallback()
-    onClose()
-  }, [confirmCallback, onClose])
 
   return (
     <ConfirmationDrawer
       variant='affirmative'
       modalName='ReplaceTrackConfirmation'
-      onConfirm={handleConfirm}
-      onCancel={onClose}
+      onConfirm={confirmCallback}
       messages={messages}
     >
       <Hint pv='s' icon={IconError}>

--- a/packages/mobile/src/screens/edit-track-screen/components/ReplaceTrackProgressDrawer.tsx
+++ b/packages/mobile/src/screens/edit-track-screen/components/ReplaceTrackProgressDrawer.tsx
@@ -1,0 +1,60 @@
+import { useReplaceTrackProgressModal } from '@audius/common/store'
+
+import {
+  Flex,
+  IconAudiusLogo,
+  IconValidationCheck,
+  Text
+} from '@audius/harmony-native'
+import { AppDrawer } from 'app/components/drawer'
+import LoadingSpinner from 'app/components/loading-spinner'
+import { ProgressBar } from 'app/components/progress-bar'
+
+const messages = {
+  description:
+    'Please hold on while we upload and replace the file for this track.',
+  inProgress: 'Upload in progress',
+  finalizing: 'Finalizing...',
+  cancel: 'Cancel'
+}
+
+export const ReplaceTrackProgressDrawer = () => {
+  const { data } = useReplaceTrackProgressModal()
+  const { progress } = data
+
+  const uploadProgress = Math.min(progress.upload + progress.transcode, 2) / 2
+  const isUploadComplete = uploadProgress >= 1
+
+  return (
+    <AppDrawer modalName='ReplaceTrackProgress' isFullscreen>
+      <Flex h='100%' justifyContent='center'>
+        <Flex direction='column' gap='3xl' ph='2xl' pb='3xl'>
+          <Flex alignItems='center' direction='column' gap='xl'>
+            <IconAudiusLogo height={48} width={48} color='default' />
+            <Text variant='body' size='l'>
+              {messages.description}
+            </Text>
+          </Flex>
+          <Flex direction='column'>
+            <Flex justifyContent='space-between' direction='row'>
+              <Text variant='label' size='s'>
+                {isUploadComplete ? messages.finalizing : messages.inProgress}
+              </Text>
+              <Flex alignItems='center' gap='l' direction='row'>
+                <Text variant='label' size='s'>
+                  {Math.round(uploadProgress * 100)}%
+                </Text>
+                {isUploadComplete ? (
+                  <IconValidationCheck size='s' />
+                ) : (
+                  <LoadingSpinner style={{ height: 16, width: 16 }} />
+                )}
+              </Flex>
+            </Flex>
+            <ProgressBar progress={uploadProgress} max={1} />
+          </Flex>
+        </Flex>
+      </Flex>
+    </AppDrawer>
+  )
+}

--- a/packages/mobile/src/screens/edit-track-screen/components/index.ts
+++ b/packages/mobile/src/screens/edit-track-screen/components/index.ts
@@ -1,3 +1,4 @@
 export * from './CancelEditTrackDrawer'
 export * from './ReplaceTrackConfirmationDrawer'
+export * from './ReplaceTrackProgressDrawer'
 export * from './RemixTrackPill'

--- a/packages/mobile/src/screens/edit-track-screen/types.ts
+++ b/packages/mobile/src/screens/edit-track-screen/types.ts
@@ -1,4 +1,4 @@
-import type { NativeFile, TrackMetadataForUpload } from '@audius/common/store'
+import type { TrackMetadataForUpload } from '@audius/common/store'
 import type { Nullable } from '@audius/common/utils'
 import type { FormikProps } from 'formik'
 
@@ -24,14 +24,12 @@ export type EditTrackScreenProps = {
     trackArtwork?: string
     isUpload?: boolean
   }
-  file?: File | NativeFile
-  handleSelectTrack: () => void
   doneText?: string
 } & Partial<ScreenProps>
 
 export type EditTrackFormProps = FormikProps<FormValues> &
   Partial<ScreenProps> &
-  Pick<EditTrackScreenProps, 'handleSelectTrack' | 'doneText' | 'file'> & {
+  Pick<EditTrackScreenProps, 'doneText'> & {
     isUpload?: boolean
   }
 

--- a/packages/mobile/src/screens/edit-track-screen/util.ts
+++ b/packages/mobile/src/screens/edit-track-screen/util.ts
@@ -1,0 +1,90 @@
+import { isContentUSDCPurchaseGated } from '@audius/common/models'
+import type { TrackMetadataForUpload } from '@audius/common/store'
+
+import type { FormValues } from './types'
+
+export const getUploadMetadataFromFormValues = (
+  values: FormValues,
+  initialValues: FormValues | TrackMetadataForUpload
+) => {
+  const {
+    licenseType: ignoredLicenseType,
+    trackArtwork: ignoredTrackArtwork,
+    isCover,
+    ...formValues
+  } = values
+
+  const metadata: TrackMetadataForUpload = {
+    ...formValues,
+    bpm: formValues.bpm ? Number(formValues.bpm) : null
+  }
+
+  if (isCover) {
+    metadata.cover_original_song_title =
+      metadata.cover_original_song_title ?? ''
+    metadata.cover_original_artist = metadata.cover_original_artist ?? ''
+  }
+
+  // If track is not unlisted and one of the unlisted visibility fields is false, set to true.
+  // We shouldn't have to do this if we set the default for 'share' and 'play_count' to true
+  // in newTrackMetadata, but not sure why they default to false.
+  if (!metadata.is_unlisted) {
+    const unlistedVisibilityFields = [
+      'genre',
+      'mood',
+      'tags',
+      'share',
+      'play_count'
+    ]
+    const shouldOverrideVisibilityFields = !unlistedVisibilityFields.every(
+      (field) => metadata.field_visibility?.[field]
+    )
+    if (shouldOverrideVisibilityFields) {
+      metadata.field_visibility = {
+        ...metadata.field_visibility,
+        genre: true,
+        mood: true,
+        tags: true,
+        share: true,
+        play_count: true,
+        remixes: !!metadata.field_visibility?.remixes
+      }
+    }
+  }
+
+  const streamConditions = metadata.stream_conditions
+  let previewStartSeconds = metadata.preview_start_seconds
+  let isDownloadable = metadata.is_downloadable
+  let isOriginalAvailable = metadata.is_original_available
+
+  // If track is usdc gated, then price and preview need to be parsed into numbers before submitting
+  if (isContentUSDCPurchaseGated(streamConditions)) {
+    // If user did not set usdc gated track preview, default it to 0
+    previewStartSeconds = Number(previewStartSeconds ?? 0)
+
+    // track is downloadable and lossless files are provided by default if track is usdc purchase gated
+    // unless it was already usdc purchase gated
+    const { download_conditions: initialDownloadConditions } = initialValues
+    isDownloadable = !isContentUSDCPurchaseGated(initialDownloadConditions)
+      ? true
+      : isDownloadable
+    isOriginalAvailable = !isContentUSDCPurchaseGated(initialDownloadConditions)
+      ? true
+      : isOriginalAvailable
+  }
+
+  // set the fields back into the metadata
+  metadata.stream_conditions = streamConditions
+  metadata.preview_start_seconds = previewStartSeconds
+  metadata.is_downloadable = isDownloadable
+  metadata.is_original_available = isOriginalAvailable
+
+  // download conditions should inherit from stream conditions if track is stream gated
+  // this will be updated once the UI for download gated tracks is implemented
+  if (streamConditions) {
+    metadata.download_conditions = streamConditions
+    metadata.is_download_gated = true
+  }
+
+  return metadata
+}

--- a/packages/mobile/src/screens/upload-screen/screens/CompleteTrackScreen.tsx
+++ b/packages/mobile/src/screens/upload-screen/screens/CompleteTrackScreen.tsx
@@ -17,7 +17,7 @@ export const messages = {
 export type CompleteTrackParams = {}
 
 export const CompleteTrackScreen = () => {
-  const { track, selectFile } = useContext(UploadFileContext)
+  const { track } = useContext(UploadFileContext)
   const [uploadAttempt, setUploadAttempt] = useState(1)
   const navigation = useNavigation<UploadParamList>()
 
@@ -37,13 +37,11 @@ export const CompleteTrackScreen = () => {
   )
 
   if (!track) return null
-  const { file, metadata } = track
+  const { metadata } = track
 
   return (
     <EditTrackScreen
       initialValues={{ ...metadata, isUpload: true }}
-      file={file}
-      handleSelectTrack={selectFile}
       onSubmit={handleSubmit}
       title={messages.title}
       url='/complete-track'


### PR DESCRIPTION
### Description
Added the ReplaceFileProgressDrawer
Updated the track edit form on mobile to handle the track replace functionality and stuff

### How Has This Been Tested?
Lots of manual testing

### Known Issues:
* Previewing is still not implemented
* Downloading the original file is not implemented yet
