### PR TITLE
[QA-1852] Fix case sensitivity issues in login GET route

### DIFF
--- a/packages/identity-service/src/routes/authentication.js
+++ b/packages/identity-service/src/routes/authentication.js
@@ -233,6 +233,8 @@ module.exports = function (app) {
       if (!email) {
         return errorResponseBadRequest('Missing email')
       }
+      // Avoid issues looking up values if user enters email in different casing
+      email = email.toLowerCase()
 
       const existingUser = await models.Authentication.findOne({
         where: { lookupKey }
@@ -256,10 +258,7 @@ module.exports = function (app) {
           req,
           authUser: existingUser
         })
-        if (
-          associatedEmail &&
-          email.toLowerCase() !== associatedEmail.toLowerCase()
-        ) {
+        if (associatedEmail && email !== associatedEmail.toLowerCase()) {
           req.logger.error(
             {
               reqEmail: email,

--- a/packages/identity-service/test/authenticationTest.js
+++ b/packages/identity-service/test/authenticationTest.js
@@ -235,6 +235,22 @@ describe('test authentication routes', function () {
     assert.ok(otp)
   })
 
+  it('is case-insensitive for OTP code checks', async function () {
+    await signUpUser()
+
+    const redis = app.get('redis')
+    await redis.set('otp:dheeraj@audius.co', '123456')
+    // Try getting data with the right params
+    const response = await request(app).get('/authentication').query({
+      lookupKey:
+        '9bdc91e1bb7ef60177131690b18349625778c14656dc17814945b52a3f07ac77',
+      username: 'DhEeRaj@audius.co',
+      otp: '123456'
+    })
+
+    assert.deepStrictEqual(response.statusCode, 200)
+  })
+
   it('sends up to 2 otp codes every 10 minutes', async function () {
     const redis = app.get('redis')
     await signUpUser()


### PR DESCRIPTION
### Description
If you attempt to authenticate with an OTP and a mixed-case email address, we will fail to look up the OTP because we aren't applying the same lowercase logic in that code path. This updates the GET route to lowercase the email at the beginning (which we do in a lot of other routes) so we don't end up trying to apply the OTP and visitorId logic to whatever mixed-case value the user might have entered.

### How Has This Been Tested?
Wrote a unit-test and tested locally against dev stack.
