### PR TITLE
add new proto dirs to release notification

### DIFF
--- a/scripts/get-release-dirs.sh
+++ b/scripts/get-release-dirs.sh
@@ -12,7 +12,9 @@ CLIENT_DIRS="packages/web
     packages/harmony \
     packages/libs"
 
-PROTOCOL_DIRS="mediorum \
+PROTOCOL_DIRS="pkg \
+    cmd \
+    dev-tools \
     packages/discovery-provider \
     packages/identity-service \
     packages/ddex* \


### PR DESCRIPTION
### Description
protocol dirs have moved around a bit and aren't captured in the daily release notification anymore

### How Has This Been Tested?
N/A
