### PR TITLE
Fix signup error due to missing yield statement

### DIFF
--- a/packages/web/src/common/store/pages/signon/sagas.ts
+++ b/packages/web/src/common/store/pages/signon/sagas.ts
@@ -602,7 +602,7 @@ function* signUp() {
     const sdk = yield* getSDK()
     const authService = yield* getContext('authService')
     const audiusBackendInstance = yield* getContext('audiusBackendInstance')
-    const isGuest = select(getIsGuest)
+    const isGuest = yield* select(getIsGuest)
 
     yield* call(waitForWrite)
 


### PR DESCRIPTION
### Description
It's always running the `isGuest` block, which attempts to fetch a user for an ephemeral wallet and explodes.

### How Has This Been Tested?
Local stack