### PR TITLE
update a missed updateCreator call with new signature

### DIFF
--- a/packages/web/src/common/store/profile/sagas.js
+++ b/packages/web/src/common/store/profile/sagas.js
@@ -575,11 +575,10 @@ function* confirmUpdateProfile(userId, metadata) {
     confirmerActions.requestConfirmation(
       makeKindId(Kind.USERS, userId),
       function* () {
-        const response = yield call(
-          audiusBackendInstance.updateCreator,
+        const response = yield call(audiusBackendInstance.updateCreator, {
           metadata,
-          userId
-        )
+          sdk
+        })
         const { blockHash, blockNumber } = response
 
         const confirmed = yield call(confirmTransaction, blockHash, blockNumber)


### PR DESCRIPTION
### Description
Missed this one in the PR that updated the signature for this function. Amazingly it doesn't crash, but it does lead to the original metadata being thrown out completely in favor of two `null` values for associated wallets :-)

