### PR TITLE
Fix mobile upload image input missing

### DIFF
--- a/packages/mobile/src/components/fields/PickArtworkField.tsx
+++ b/packages/mobile/src/components/fields/PickArtworkField.tsx
@@ -91,10 +91,6 @@ export const PickArtworkField = (props: PickArtworkFieldProps) => {
 
   const source = useMemo(() => ({ uri: trackArtworkUrl }), [trackArtworkUrl])
 
-  if (!source.uri) {
-    return null
-  }
-
   return (
     <View style={styles.root}>
       <DynamicImage

--- a/packages/mobile/src/screens/upload-screen/utils/processTrackFile.ts
+++ b/packages/mobile/src/screens/upload-screen/utils/processTrackFile.ts
@@ -67,7 +67,7 @@ export const processTrackFile = async (
     preview: null,
     metadata: newTrackMetadata({
       title,
-      artwork: null,
+      artwork: { file: null, url: '' },
       duration
     })
   }


### PR DESCRIPTION
### Description

Fix regression from https://github.com/AudiusProject/audius-protocol/pull/10581/files

For audio files without artwork, the entire image selector input is missing. This leads to 'Fix errors to continue' blocking the continue button, but not indication of why. Underlying error is 'Artwork is required' but since the whole artwork component is missing, you don't even see it.
![Screenshot 2024-12-05 at 2 32 23 PM](https://github.com/user-attachments/assets/29e97204-32c6-4254-9f1e-e4e9ac5238a0)

### How Has This Been Tested?

upload working successfully now