### PR TITLE
Improve mobile entity collection screen loading

### DIFF
--- a/packages/mobile/src/components/core/Screen/ScreenPrimaryContent.tsx
+++ b/packages/mobile/src/components/core/Screen/ScreenPrimaryContent.tsx
@@ -26,13 +26,14 @@ export const ScreenPrimaryContent = (props: ScreenPrimaryContentProps) => {
     setIsPrimaryContentReady(true)
   }, [isScreenReady, setIsPrimaryContentReady])
 
+  const screenContent =
+    skeleton || Platform.OS === 'ios' ? (
+      children
+    ) : (
+      <Animated.View entering={FadeIn}>{children}</Animated.View>
+    )
+
   // Note: not animating on Android because shadows are rendered natively behind the
   // animated view and thus don't follow the animation.
-  return isScreenReady ? (
-    <Animated.View entering={Platform.OS === 'ios' ? FadeIn : undefined}>
-      {children}
-    </Animated.View>
-  ) : (
-    <>{skeleton ?? null}</>
-  )
+  return isScreenReady ? screenContent : skeleton ?? null
 }

--- a/packages/mobile/src/components/core/Screen/ScreenPrimaryContent.tsx
+++ b/packages/mobile/src/components/core/Screen/ScreenPrimaryContent.tsx
@@ -35,5 +35,5 @@ export const ScreenPrimaryContent = (props: ScreenPrimaryContentProps) => {
 
   // Note: not animating on Android because shadows are rendered natively behind the
   // animated view and thus don't follow the animation.
-  return isScreenReady ? screenContent : skeleton ?? null
+  return <>{isScreenReady ? screenContent : skeleton ?? null}</>
 }

--- a/packages/mobile/src/components/skeletons/EntitySkeleton.tsx
+++ b/packages/mobile/src/components/skeletons/EntitySkeleton.tsx
@@ -32,8 +32,8 @@ const useStyles = makeStyles(({ spacing, palette }) => ({
     borderColor: palette.neutralLight8,
     borderRadius: 4,
     marginBottom: spacing(4),
-    height: 195,
-    width: 195
+    height: 224,
+    width: 224
   },
   trackTitle: {
     marginVertical: spacing(2),

--- a/packages/mobile/src/screens/collection-screen/CollectionScreen.tsx
+++ b/packages/mobile/src/screens/collection-screen/CollectionScreen.tsx
@@ -96,11 +96,11 @@ export const CollectionScreen = () => {
   const collection = cachedCollection ?? searchCollection
   const user = cachedUser ?? searchCollection?.user
 
-  return !collection || !user ? (
-    <CollectionScreenSkeleton collectionType={collectionType} />
-  ) : (
-    <CollectionScreenComponent collection={collection} user={user} />
-  )
+  if (!collection || !user) {
+    return <CollectionScreenSkeleton collectionType={collectionType} />
+  }
+
+  return <CollectionScreenComponent collection={collection} user={user} />
 }
 
 type CollectionScreenComponentProps = {

--- a/packages/mobile/src/screens/track-screen/TrackScreen.tsx
+++ b/packages/mobile/src/screens/track-screen/TrackScreen.tsx
@@ -84,7 +84,11 @@ export const TrackScreen = () => {
   }, [dispatch, canBeUnlisted, id, slug, handle, user?.handle, isScreenReady])
 
   if (!track || !user) {
-    return <TrackScreenSkeleton />
+    return (
+      <Flex p='l' gap='2xl'>
+        <TrackScreenSkeleton />
+      </Flex>
+    )
   }
 
   const handlePressGoToOtherRemixes = () => {


### PR DESCRIPTION
### Description

Fixes issue where entity skeleton image was too small
Fixes issue where there was a flash from skeleton to main content. Now we only do the animation when there is no skeleton present


https://github.com/user-attachments/assets/9b6cb568-0d39-4ea5-a31f-9d55730d47a9

