### PR TITLE
[C-5477] Guard against empty response from storage node

### DIFF
--- a/.changeset/polite-bikes-appear.md
+++ b/.changeset/polite-bikes-appear.md
@@ -1,0 +1,6 @@
+---
+'@audius/sdk-legacy': patch
+'@audius/sdk': patch
+---
+
+Handle empty response in uploadFile

--- a/packages/libs/src/services/creatorNode/CreatorNode.ts
+++ b/packages/libs/src/services/creatorNode/CreatorNode.ts
@@ -351,6 +351,12 @@ export class CreatorNode {
         )
       }
     })
+
+    // Covers no response or empty response
+    if (!response?.data?.length) {
+      throw new Error('No upload response from storage node')
+    }
+
     return await this.pollProcessingStatusV2(
       response.data[0].id,
       template,

--- a/packages/sdk/src/sdk/services/Storage/Storage.ts
+++ b/packages/sdk/src/sdk/services/Storage/Storage.ts
@@ -174,13 +174,17 @@ export class Storage implements StorageService {
       request.url = `${selectedNode!}/uploads`
       try {
         response = await axios(request)
-        break
+        // Server will sometimes return empty array in case of error
+        if (response?.data?.length > 0) {
+          break
+        }
       } catch (e: any) {
         lastErr = e // keep trying other nodes
       }
     }
 
-    if (!response) {
+    // Covers no response or empty response
+    if (!response?.data?.length) {
       const msg = `Error sending storagev2 upload request, tried all healthy storage nodes. Last error: ${lastErr}`
       this.logger.error(msg)
       throw new Error(msg)


### PR DESCRIPTION
### Description

This is by far the most common upload failure in sentry.
It's likely that the root cause is different, since storage returning `data: []` is probably due to bad `formData`, but hopefully this at least gets us to throw something more useful.

### How Has This Been Tested?

Issue is intermittent and hard to repro, so checked that upload still works with this change