### PR TITLE
Reduce code dupe, add spinner, fix performance on profile collections

### DIFF
--- a/packages/web/src/common/store/profile/fetchProfileCollectionsSaga.ts
+++ b/packages/web/src/common/store/profile/fetchProfileCollectionsSaga.ts
@@ -11,7 +11,7 @@ import {
   accountSelectors
 } from '@audius/common/store'
 import { isEqual } from 'lodash'
-import { put, select, takeLatest, call, all } from 'typed-redux-saga'
+import { put, select, takeEvery, call, all } from 'typed-redux-saga'
 
 import { processAndCacheCollections } from 'common/store/cache/collections/utils'
 
@@ -26,7 +26,7 @@ const { getProfileUser } = profilePageSelectors
 const { getUserId } = accountSelectors
 
 export function* watchFetchProfileCollections() {
-  yield* takeLatest(FETCH_COLLECTIONS, fetchProfileCollectionsAsync)
+  yield* takeEvery(FETCH_COLLECTIONS, fetchProfileCollectionsAsync)
 }
 
 function* fetchProfileCollectionsAsync(

--- a/packages/web/src/common/store/profile/sagas.js
+++ b/packages/web/src/common/store/profile/sagas.js
@@ -18,7 +18,8 @@ import {
   collectiblesActions,
   confirmerActions,
   confirmTransaction,
-  getSDK
+  getSDK,
+  profilePageActions
 } from '@audius/common/store'
 import {
   squashNewLines,
@@ -47,7 +48,6 @@ import {
 import {
   fetchUsers,
   fetchUserByHandle,
-  fetchUserCollections,
   fetchUserSocials
 } from 'common/store/cache/users/sagas'
 import feedSagas from 'common/store/pages/profile/lineups/feed/sagas.js'
@@ -386,7 +386,8 @@ function* fetchProfileAsync(action) {
     if (!isNativeMobile) {
       // Fetch user socials and collections after fetching the user itself
       yield fork(fetchUserSocials, action)
-      yield fork(fetchUserCollections, user.user_id)
+      // Note that mobile dispatches this action at the component level
+      yield put(profilePageActions.fetchCollections(user.handle))
       yield fork(fetchSupportersAndSupporting, user.user_id)
     }
 

--- a/packages/web/src/pages/profile-page/ProfilePageProvider.tsx
+++ b/packages/web/src/pages/profile-page/ProfilePageProvider.tsx
@@ -77,6 +77,7 @@ const { createPlaylist } = cacheCollectionsActions
 
 const {
   makeGetProfile,
+  getCollectionsStatus,
   getProfileFeedLineup,
   getProfileTracksLineup,
   getProfileUserId
@@ -770,6 +771,7 @@ class ProfilePage extends PureComponent<ProfilePageProps, ProfilePageState> {
         playlists,
         isSubscribed
       },
+      collectionStatus,
       // Tracks
       artistTracks,
       playArtistTrack,
@@ -913,6 +915,7 @@ class ProfilePage extends PureComponent<ProfilePageProps, ProfilePageState> {
       status: profileLoadingStatus,
       albums: uniq(albums),
       playlists: uniq(playlists),
+      collectionStatus,
       artistTracks,
       playArtistTrack,
       pauseArtistTrack,
@@ -1040,6 +1043,7 @@ function makeMapStateToProps() {
     return {
       accountUserId,
       profile: getProfile(state, handleLower),
+      collectionStatus: getCollectionsStatus(state, handleLower),
       artistTracks: getProfileTracksLineup(state, handleLower),
       userFeed: getProfileFeedLineup(state, handleLower),
       currentQueueItem: getCurrentQueueItem(state),

--- a/packages/web/src/pages/profile-page/components/desktop/ProfilePage.tsx
+++ b/packages/web/src/pages/profile-page/components/desktop/ProfilePage.tsx
@@ -31,7 +31,8 @@ import {
   IconRepost as IconReposts,
   Text,
   Hint,
-  IconQuestionCircle
+  IconQuestionCircle,
+  LoadingSpinner
 } from '@audius/harmony'
 
 import CollectiblesPage from 'components/collectibles/components/CollectiblesPage'
@@ -108,6 +109,7 @@ export type ProfilePageProps = {
   albums: Collection[] | null
   playlists: Collection[] | null
   status: Status
+  collectionStatus: Status
   goToRoute: (route: string) => void
   artistTracks: LineupState<Track>
   playArtistTrack: (uid: UID) => void
@@ -213,6 +215,7 @@ const ProfilePage = ({
   onSortByPopular,
   isArtist,
   status: profileLoadingStatus,
+  collectionStatus,
   activeTab,
   shouldMaskContent,
   editMode,
@@ -380,7 +383,14 @@ const ProfilePage = ({
         ) : null}
       </div>,
       <div key={ProfilePageTabs.ALBUMS} className={styles.cards}>
-        {albums.length === 0 && !isOwner ? (
+        {collectionStatus !== Status.SUCCESS &&
+        collectionStatus !== Status.ERROR ? (
+          <Flex justifyContent='center' mt='2xl'>
+            <Box w={24}>
+              <LoadingSpinner />
+            </Box>
+          </Flex>
+        ) : albums.length === 0 && !isOwner ? (
           <EmptyTab
             isOwner={isOwner}
             name={profile.name}
@@ -391,7 +401,14 @@ const ProfilePage = ({
         )}
       </div>,
       <div key={ProfilePageTabs.PLAYLISTS} className={styles.cards}>
-        {playlists.length === 0 && !isOwner ? (
+        {collectionStatus !== Status.SUCCESS &&
+        collectionStatus !== Status.ERROR ? (
+          <Flex justifyContent='center' mt='2xl'>
+            <Box w={24}>
+              <LoadingSpinner />
+            </Box>
+          </Flex>
+        ) : playlists.length === 0 && !isOwner ? (
           <EmptyTab
             isOwner={isOwner}
             name={profile.name}

--- a/packages/web/src/pages/profile-page/components/mobile/ProfilePage.module.css
+++ b/packages/web/src/pages/profile-page/components/mobile/ProfilePage.module.css
@@ -10,6 +10,7 @@
 
 .cardLineupContainer {
   padding: 16px 11px 0px;
+  width: 100%;
 }
 
 /* Empty Section */

--- a/packages/web/src/pages/profile-page/components/mobile/ProfilePage.tsx
+++ b/packages/web/src/pages/profile-page/components/mobile/ProfilePage.tsx
@@ -23,7 +23,8 @@ import {
   IconCollectible as IconCollectibles,
   IconNote,
   IconPlaylists,
-  IconRepost as IconReposts
+  IconRepost as IconReposts,
+  LoadingSpinner
 } from '@audius/harmony'
 import cn from 'classnames'
 
@@ -95,6 +96,7 @@ export type ProfilePageProps = {
   albums: Collection[] | null
   playlists: Collection[] | null
   status: Status
+  collectionStatus: Status
   goToRoute: (route: string) => void
   artistTracks: LineupState<Track>
   userFeed: LineupState<Track | Collection>
@@ -236,6 +238,7 @@ const ProfilePage = g(
     bio,
     location,
     status,
+    collectionStatus,
     isArtist,
     isOwner,
     verified,
@@ -425,7 +428,10 @@ const ProfilePage = g(
             )}
           </div>,
           <div className={styles.cardLineupContainer} key='artistAlbums'>
-            {(albums || []).length === 0 ? (
+            {collectionStatus !== Status.SUCCESS &&
+            collectionStatus !== Status.ERROR ? (
+              <LoadingSpinner />
+            ) : (albums || []).length === 0 ? (
               <EmptyTab
                 message={
                   <>
@@ -444,7 +450,10 @@ const ProfilePage = g(
             )}
           </div>,
           <div className={styles.cardLineupContainer} key='artistPlaylists'>
-            {(playlists || []).length === 0 ? (
+            {collectionStatus !== Status.SUCCESS &&
+            collectionStatus !== Status.ERROR ? (
+              <LoadingSpinner />
+            ) : (playlists || []).length === 0 ? (
               <EmptyTab
                 message={
                   <>

--- a/packages/web/src/pages/profile-page/components/mobile/ProfilePage.tsx
+++ b/packages/web/src/pages/profile-page/components/mobile/ProfilePage.tsx
@@ -24,7 +24,9 @@ import {
   IconNote,
   IconPlaylists,
   IconRepost as IconReposts,
-  LoadingSpinner
+  LoadingSpinner,
+  Box,
+  Flex
 } from '@audius/harmony'
 import cn from 'classnames'
 
@@ -430,7 +432,11 @@ const ProfilePage = g(
           <div className={styles.cardLineupContainer} key='artistAlbums'>
             {collectionStatus !== Status.SUCCESS &&
             collectionStatus !== Status.ERROR ? (
-              <LoadingSpinner />
+              <Flex justifyContent='center' mt='l'>
+                <Box w={24}>
+                  <LoadingSpinner />
+                </Box>
+              </Flex>
             ) : (albums || []).length === 0 ? (
               <EmptyTab
                 message={
@@ -452,7 +458,11 @@ const ProfilePage = g(
           <div className={styles.cardLineupContainer} key='artistPlaylists'>
             {collectionStatus !== Status.SUCCESS &&
             collectionStatus !== Status.ERROR ? (
-              <LoadingSpinner />
+              <Flex justifyContent='center' mt='l'>
+                <Box w={24}>
+                  <LoadingSpinner />
+                </Box>
+              </Flex>
             ) : (playlists || []).length === 0 ? (
               <EmptyTab
                 message={


### PR DESCRIPTION
### Description

Few issues I paired through with @schottra today. We double fetch each playlist on profile pages currently, and we also have two ways of doing this between mobile and web.

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._

![image](https://github.com/user-attachments/assets/3841c34b-bb58-4b6f-90d1-db9383d6d277)
![image](https://github.com/user-attachments/assets/ea16b41c-418b-4589-b1dd-c6090b899f7f)
![simulator_screenshot_F2B47846-8A77-4AA2-B274-DF12D50AE162](https://github.com/user-attachments/assets/1f707b9b-f7d3-4218-ada8-7a8bf0fc889f)