### PR TITLE
Remove getUserEmail from libs Account

### DIFF
--- a/packages/libs/src/api/Account.ts
+++ b/packages/libs/src/api/Account.ts
@@ -32,7 +32,6 @@ export class Account extends Base {
     this.changeCredentials = this.changeCredentials.bind(this)
     this.resetPassword = this.resetPassword.bind(this)
     this.checkIfEmailRegistered = this.checkIfEmailRegistered.bind(this)
-    this.getUserEmail = this.getUserEmail.bind(this)
     this.associateTwitterUser = this.associateTwitterUser.bind(this)
     this.associateInstagramUser = this.associateInstagramUser.bind(this)
     this.associateTikTokUser = this.associateTikTokUser.bind(this)
@@ -294,14 +293,6 @@ export class Account extends Base {
   async checkIfEmailRegistered(email: string) {
     this.REQUIRES(Services.IDENTITY_SERVICE)
     return await this.identityService.checkIfEmailRegistered(email)
-  }
-
-  /**
-   * Get the current user's email address
-   */
-  async getUserEmail() {
-    this.REQUIRES(Services.IDENTITY_SERVICE)
-    return await this.identityService.getUserEmail()
   }
 
   /**


### PR DESCRIPTION
### Description
Missed deleting this call to libs identity getUserEmail, but isn't in use anywhere.

Related to https://github.com/AudiusProject/audius-protocol/pull/10583

### How Has This Been Tested?

