### PR TITLE
Migrate getWaudioBalance to sdk + remove getSolanaConnection

### DIFF
--- a/packages/common/src/services/audius-backend/AudiusBackend.ts
+++ b/packages/common/src/services/audius-backend/AudiusBackend.ts
@@ -1,3 +1,4 @@
+import { AUDIO, FixedDecimal, wAUDIO } from '@audius/fixed-decimal'
 import {
   AudiusSdk,
   Genre,
@@ -105,9 +106,6 @@ declare global {
 
 const SEARCH_MAX_SAVED_RESULTS = 10
 const SEARCH_MAX_TOTAL_RESULTS = 50
-export const AUDIO_DECIMALS = 18
-export const WAUDIO_DECIMALS = 8
-export const USDC_DECIMALS = 6
 
 export const AuthHeaders = Object.freeze({
   Message: 'Encoded-Data-Message',
@@ -1701,16 +1699,16 @@ export const audiusBackend = ({
         })
       const connection = sdk.services.solanaClient.connection
       const {
-        value: { amount, decimals: waudioDecimals }
+        value: { amount }
       } = await connection.getTokenAccountBalance(userBank)
-      const decimals = AUDIO_DECIMALS - waudioDecimals
-      const ownerWAudioBalance = new BN(amount).mul(
-        new BN(10).pow(new BN(decimals))
+      const ownerWAudioBalance = new FixedDecimal(
+        amount,
+        AUDIO(0).decimalPlaces - wAUDIO(0).decimalPlaces
       )
       if (isNullOrUndefined(ownerWAudioBalance)) {
         throw new Error('Failed to fetch account waudio balance')
       }
-      return ownerWAudioBalance
+      return new BN(ownerWAudioBalance.value.toString())
     } catch (e) {
       console.error(e)
       reportError({ error: e as Error })

--- a/packages/common/src/services/audius-backend/AudiusBackend.ts
+++ b/packages/common/src/services/audius-backend/AudiusBackend.ts
@@ -62,7 +62,6 @@ import {
 } from '../../utils'
 import type { DiscoveryNodeSelectorService } from '../sdk/discovery-node-selector'
 
-import { getSolanaConnection } from './solana'
 import { MonitoringCallbacks } from './types'
 
 type DisplayEncoding = 'utf8' | 'hex'
@@ -1700,7 +1699,7 @@ export const audiusBackend = ({
           ethWallet: ethAddress ?? (await sdk.services.auth.getAddress()),
           mint: 'wAUDIO'
         })
-      const connection = await getSolanaConnection({ env })
+      const connection = sdk.services.solanaClient.connection
       const {
         value: { amount, decimals: waudioDecimals }
       } = await connection.getTokenAccountBalance(userBank)
@@ -1724,10 +1723,16 @@ export const audiusBackend = ({
    * @param {string} The solana wallet address
    * @returns {Promise<BNWei>}
    */
-  async function getAddressSolBalance(address: string): Promise<BNWei> {
+  async function getAddressSolBalance({
+    address,
+    sdk
+  }: {
+    address: string
+    sdk: AudiusSdk
+  }): Promise<BNWei> {
     try {
       const addressPubKey = new PublicKey(address)
-      const connection = await getSolanaConnection({ env })
+      const connection = sdk.services.solanaClient.connection
       const solBalance = await connection.getBalance(addressPubKey)
       return new BN(solBalance ?? 0) as BNWei
     } catch (e) {

--- a/packages/common/src/services/audius-backend/AudiusBackend.ts
+++ b/packages/common/src/services/audius-backend/AudiusBackend.ts
@@ -1701,14 +1701,11 @@ export const audiusBackend = ({
       const {
         value: { amount }
       } = await connection.getTokenAccountBalance(userBank)
-      const ownerWAudioBalance = new FixedDecimal(
-        amount,
-        AUDIO(0).decimalPlaces - wAUDIO(0).decimalPlaces
-      )
+      const ownerWAudioBalance = AUDIO(wAUDIO(BigInt(amount))).value
       if (isNullOrUndefined(ownerWAudioBalance)) {
         throw new Error('Failed to fetch account waudio balance')
       }
-      return new BN(ownerWAudioBalance.value.toString())
+      return new BN(ownerWAudioBalance.toString())
     } catch (e) {
       console.error(e)
       reportError({ error: e as Error })

--- a/packages/common/src/services/audius-backend/AudiusBackend.ts
+++ b/packages/common/src/services/audius-backend/AudiusBackend.ts
@@ -1,4 +1,4 @@
-import { AUDIO, FixedDecimal, wAUDIO } from '@audius/fixed-decimal'
+import { AUDIO, wAUDIO } from '@audius/fixed-decimal'
 import {
   AudiusSdk,
   Genre,

--- a/packages/common/src/services/audius-backend/AudiusBackend.ts
+++ b/packages/common/src/services/audius-backend/AudiusBackend.ts
@@ -1690,13 +1690,13 @@ export const audiusBackend = ({
     ethAddress,
     sdk
   }: {
-    ethAddress?: string
+    ethAddress: string
     sdk: AudiusSdk
   }): Promise<BN | null> {
     try {
       const { userBank } =
         await sdk.services.claimableTokensClient.getOrCreateUserBank({
-          ethWallet: ethAddress ?? (await sdk.services.auth.getAddress()),
+          ethWallet: ethAddress,
           mint: 'wAUDIO'
         })
       const connection = sdk.services.solanaClient.connection

--- a/packages/common/src/services/audius-backend/solana.ts
+++ b/packages/common/src/services/audius-backend/solana.ts
@@ -97,10 +97,8 @@ export const getSolanaConnection = async ({ env }: { env: Env }) => {
 /**
  * Gets the latest blockhash using the libs connection
  */
-export const getRecentBlockhash = async (
-  audiusBackendInstance: AudiusBackend
-) => {
-  const connection = await getSolanaConnection(audiusBackendInstance)
+export const getRecentBlockhash = async ({ env }: { env: Env }) => {
+  const connection = await getSolanaConnection({ env })
   return (await connection.getLatestBlockhash()).blockhash
 }
 
@@ -690,18 +688,20 @@ export const createVersionedTransaction = async (
   {
     instructions,
     lookupTableAddresses,
-    feePayer
+    feePayer,
+    env
   }: {
     instructions: TransactionInstruction[]
     lookupTableAddresses: string[]
     feePayer: PublicKey
+    env: Env
   }
 ) => {
   const addressLookupTableAccounts = await getLookupTableAccounts(
     audiusBackendInstance,
     { lookupTableAddresses }
   )
-  const recentBlockhash = await getRecentBlockhash(audiusBackendInstance)
+  const recentBlockhash = await getRecentBlockhash({ env })
 
   const message = new TransactionMessage({
     payerKey: feePayer,

--- a/packages/common/src/services/audius-backend/solana.ts
+++ b/packages/common/src/services/audius-backend/solana.ts
@@ -84,21 +84,10 @@ export const getRootSolanaAccount = async (
 }
 
 /**
- * Gets the Solana connection libs is currently using
- */
-let solanaConnection: Connection
-export const getSolanaConnection = async ({ env }: { env: Env }) => {
-  if (!solanaConnection) {
-    solanaConnection = new Connection(env.SOLANA_CLUSTER_ENDPOINT)
-  }
-  return solanaConnection
-}
-
-/**
  * Gets the latest blockhash using the libs connection
  */
-export const getRecentBlockhash = async ({ env }: { env: Env }) => {
-  const connection = await getSolanaConnection({ env })
+export const getRecentBlockhash = async ({ sdk }: { sdk: AudiusSdk }) => {
+  const connection = sdk.services.solanaClient.connection
   return (await connection.getLatestBlockhash()).blockhash
 }
 
@@ -689,19 +678,19 @@ export const createVersionedTransaction = async (
     instructions,
     lookupTableAddresses,
     feePayer,
-    env
+    sdk
   }: {
     instructions: TransactionInstruction[]
     lookupTableAddresses: string[]
     feePayer: PublicKey
-    env: Env
+    sdk: AudiusSdk
   }
 ) => {
   const addressLookupTableAccounts = await getLookupTableAccounts(
     audiusBackendInstance,
     { lookupTableAddresses }
   )
-  const recentBlockhash = await getRecentBlockhash({ env })
+  const recentBlockhash = await getRecentBlockhash({ sdk })
 
   const message = new TransactionMessage({
     payerKey: feePayer,

--- a/packages/common/src/services/audius-backend/solana.ts
+++ b/packages/common/src/services/audius-backend/solana.ts
@@ -25,7 +25,6 @@ import {
 } from '@solana/web3.js'
 import BN from 'bn.js'
 
-import { Env } from '~/services/env'
 import { CommonStoreContext } from '~/store/storeContext'
 
 import {
@@ -331,18 +330,21 @@ export const pollForBalanceChange = async (
     wallet,
     initialBalance,
     retryDelayMs = DEFAULT_RETRY_DELAY,
-    maxRetryCount = DEFAULT_MAX_RETRY_COUNT
+    maxRetryCount = DEFAULT_MAX_RETRY_COUNT,
+    sdk
   }: {
     wallet: PublicKey
     initialBalance?: bigint
     retryDelayMs?: number
     maxRetryCount?: number
+    sdk: AudiusSdk
   }
 ) => {
   console.info(`Polling SOL balance for ${wallet.toBase58()} ...`)
-  let balanceBN = await audiusBackendInstance.getAddressSolBalance(
-    wallet.toBase58()
-  )
+  let balanceBN = await audiusBackendInstance.getAddressSolBalance({
+    address: wallet.toBase58(),
+    sdk
+  })
   let balance = BigInt(balanceBN.toString())
   if (initialBalance === undefined) {
     initialBalance = balance
@@ -353,9 +355,10 @@ export const pollForBalanceChange = async (
       `Polling SOL balance (${initialBalance} === ${balance}) [${retries}/${maxRetryCount}]`
     )
     await delay(retryDelayMs)
-    balanceBN = await audiusBackendInstance.getAddressSolBalance(
-      wallet.toBase58()
-    )
+    balanceBN = await audiusBackendInstance.getAddressSolBalance({
+      address: wallet.toBase58(),
+      sdk
+    })
     balance = BigInt(balanceBN.toString())
   }
   if (balance !== initialBalance) {

--- a/packages/common/src/services/audius-backend/solana.ts
+++ b/packages/common/src/services/audius-backend/solana.ts
@@ -25,6 +25,7 @@ import {
 } from '@solana/web3.js'
 import BN from 'bn.js'
 
+import { Env } from '~/services/env'
 import { CommonStoreContext } from '~/store/storeContext'
 
 import {
@@ -85,12 +86,12 @@ export const getRootSolanaAccount = async (
 /**
  * Gets the Solana connection libs is currently using
  */
-export const getSolanaConnection = async (
-  audiusBackendInstance: AudiusBackend
-) => {
-  return (
-    await audiusBackendInstance.getAudiusLibsTyped()
-  ).solanaWeb3Manager!.getConnection()
+let solanaConnection: Connection
+export const getSolanaConnection = async ({ env }: { env: Env }) => {
+  if (!solanaConnection) {
+    solanaConnection = new Connection(env.SOLANA_CLUSTER_ENDPOINT)
+  }
+  return solanaConnection
 }
 
 /**

--- a/packages/common/src/services/wallet-client/WalletClient.ts
+++ b/packages/common/src/services/wallet-client/WalletClient.ts
@@ -1,4 +1,4 @@
-import { AudiusSdk } from '@audius/sdk'
+import { AudiusSdk, AuthService } from '@audius/sdk'
 import BN from 'bn.js'
 
 import { userWalletsFromSDK } from '~/adapters'
@@ -59,13 +59,18 @@ export class WalletClient {
   }
 
   /** Get user's current SOL Audio balance. Returns null on failure. */
-  async getCurrentWAudioBalance(ethAddress?: string): Promise<BNWei | null> {
-    const balance = await this.audiusBackendInstance.getWAudioBalance(
-      ethAddress
-    )
-    return (
-      isNullOrUndefined(balance) ? null : new BN(balance.toString())
-    ) as BNWei | null
+  async getCurrentWAudioBalance({
+    ethAddress,
+    sdk
+  }: {
+    ethAddress?: string
+    sdk: AudiusSdk
+  }): Promise<BNWei | null> {
+    const balance = await this.audiusBackendInstance.getWAudioBalance({
+      ethAddress,
+      sdk
+    })
+    return balance as BNWei
   }
 
   async getAssociatedTokenAccountInfo(address: string) {
@@ -75,6 +80,7 @@ export class WalletClient {
       return tokenAccountInfo
     } catch (err) {
       console.error(err)
+      return null
     }
   }
 

--- a/packages/common/src/services/wallet-client/WalletClient.ts
+++ b/packages/common/src/services/wallet-client/WalletClient.ts
@@ -194,11 +194,18 @@ export class WalletClient {
     }
   }
 
-  async getWalletSolBalance(wallet: string): Promise<BNWei> {
+  async getWalletSolBalance({
+    address,
+    sdk
+  }: {
+    address: string
+    sdk: AudiusSdk
+  }): Promise<BNWei> {
     try {
-      const balance = await this.audiusBackendInstance.getAddressSolBalance(
-        wallet
-      )
+      const balance = await this.audiusBackendInstance.getAddressSolBalance({
+        address,
+        sdk
+      })
       return balance as BNWei
     } catch (err) {
       console.error(err)

--- a/packages/common/src/services/wallet-client/WalletClient.ts
+++ b/packages/common/src/services/wallet-client/WalletClient.ts
@@ -63,7 +63,7 @@ export class WalletClient {
     ethAddress,
     sdk
   }: {
-    ethAddress?: string
+    ethAddress: string
     sdk: AudiusSdk
   }): Promise<BNWei | null> {
     const balance = await this.audiusBackendInstance.getWAudioBalance({

--- a/packages/common/src/services/wallet-client/WalletClient.ts
+++ b/packages/common/src/services/wallet-client/WalletClient.ts
@@ -1,4 +1,4 @@
-import { AudiusSdk, AuthService } from '@audius/sdk'
+import { AudiusSdk } from '@audius/sdk'
 import BN from 'bn.js'
 
 import { userWalletsFromSDK } from '~/adapters'

--- a/packages/common/src/store/buy-crypto/sagas.ts
+++ b/packages/common/src/store/buy-crypto/sagas.ts
@@ -482,6 +482,7 @@ function* doBuyCryptoViaSol({
       audiusBackendInstance,
       {
         wallet: wallet.publicKey,
+        sdk,
         initialBalance,
         retryDelayMs: config.retryDelayMs,
         maxRetryCount: config.maxRetryCount

--- a/packages/common/src/store/buy-crypto/sagas.ts
+++ b/packages/common/src/store/buy-crypto/sagas.ts
@@ -213,6 +213,7 @@ function* swapSolForCrypto({
   const env = yield* getContext('env')
   const { transaction, addressLookupTableAccounts } = yield* call(
     createVersionedTransaction,
+    audiusBackendInstance,
     {
       instructions,
       lookupTableAddresses: addressLookupTableAddresses,
@@ -222,7 +223,7 @@ function* swapSolForCrypto({
   )
   transaction.sign([wallet])
 
-  return yield* call(relayVersionedTransaction, {
+  return yield* call(relayVersionedTransaction, audiusBackendInstance, {
     transaction,
     addressLookupTableAccounts,
     skipPreflight: true

--- a/packages/common/src/store/buy-crypto/sagas.ts
+++ b/packages/common/src/store/buy-crypto/sagas.ts
@@ -339,7 +339,8 @@ function* doBuyCryptoViaSol({
       make
     })
 
-    const connection = yield* call(getSolanaConnection, audiusBackendInstance)
+    const env = yield* getContext('env')
+    const connection = yield* call(getSolanaConnection, { env })
     const minRent = yield* call(
       [connection, connection.getMinimumBalanceForRentExemption],
       0
@@ -722,7 +723,8 @@ function* recoverBuyCryptoViaSolIfNecessary() {
 
   // Get config
   const wallet = yield* call(getRootSolanaAccount, audiusBackendInstance)
-  const connection = yield* call(getSolanaConnection, audiusBackendInstance)
+  const env = yield* getContext('env')
+  const connection = yield* call(getSolanaConnection, { env })
   const feePayerAddress = yield* waitForValue(getFeePayer)
   const config = yield* call(getBuyCryptoRemoteConfig, mint)
   const outputToken = TOKEN_LISTING_MAP[mint.toUpperCase()]

--- a/packages/common/src/store/buy-crypto/sagas.ts
+++ b/packages/common/src/store/buy-crypto/sagas.ts
@@ -210,18 +210,19 @@ function* swapSolForCrypto({
     parseJupiterInstruction(swapInstruction),
     closeWSOLInstruction
   ]
+  const env = yield* getContext('env')
   const { transaction, addressLookupTableAccounts } = yield* call(
     createVersionedTransaction,
-    audiusBackendInstance,
     {
       instructions,
       lookupTableAddresses: addressLookupTableAddresses,
-      feePayer
+      feePayer,
+      env
     }
   )
   transaction.sign([wallet])
 
-  return yield* call(relayVersionedTransaction, audiusBackendInstance, {
+  return yield* call(relayVersionedTransaction, {
     transaction,
     addressLookupTableAccounts,
     skipPreflight: true

--- a/packages/common/src/store/buy-crypto/sagas.ts
+++ b/packages/common/src/store/buy-crypto/sagas.ts
@@ -36,7 +36,6 @@ import {
   createUserBankIfNeeded,
   createVersionedTransaction,
   getRootSolanaAccount,
-  getSolanaConnection,
   getTokenAccountInfo,
   pollForBalanceChange,
   pollForTokenBalanceChange,
@@ -727,8 +726,8 @@ function* recoverBuyCryptoViaSolIfNecessary() {
 
   // Get config
   const wallet = yield* call(getRootSolanaAccount, audiusBackendInstance)
-  const env = yield* getContext('env')
-  const connection = yield* call(getSolanaConnection, { env })
+  const sdk = yield* getSDK()
+  const connection = sdk.services.solanaClient.connection
   const feePayerAddress = yield* waitForValue(getFeePayer)
   const config = yield* call(getBuyCryptoRemoteConfig, mint)
   const outputToken = TOKEN_LISTING_MAP[mint.toUpperCase()]

--- a/packages/common/src/store/buy-crypto/sagas.ts
+++ b/packages/common/src/store/buy-crypto/sagas.ts
@@ -64,6 +64,8 @@ import { setVisibility } from '~/store/ui/modals/parentSlice'
 import { initializeStripeModal } from '~/store/ui/stripe-modal/slice'
 import { waitForAccount, waitForValue } from '~/utils/sagaHelpers'
 
+import { getSDK } from '../sdkUtils'
+
 import {
   BuyCryptoConfig,
   BuyCryptoError,
@@ -210,7 +212,7 @@ function* swapSolForCrypto({
     parseJupiterInstruction(swapInstruction),
     closeWSOLInstruction
   ]
-  const env = yield* getContext('env')
+  const sdk = yield* getSDK()
   const { transaction, addressLookupTableAccounts } = yield* call(
     createVersionedTransaction,
     audiusBackendInstance,
@@ -218,7 +220,7 @@ function* swapSolForCrypto({
       instructions,
       lookupTableAddresses: addressLookupTableAddresses,
       feePayer,
-      env
+      sdk
     }
   )
   transaction.sign([wallet])
@@ -341,8 +343,8 @@ function* doBuyCryptoViaSol({
       make
     })
 
-    const env = yield* getContext('env')
-    const connection = yield* call(getSolanaConnection, { env })
+    const sdk = yield* getSDK()
+    const connection = sdk.services.solanaClient.connection
     const minRent = yield* call(
       [connection, connection.getMinimumBalanceForRentExemption],
       0

--- a/packages/common/src/store/buy-usdc/sagas.ts
+++ b/packages/common/src/store/buy-usdc/sagas.ts
@@ -36,6 +36,8 @@ import { initializeStripeModal } from '~/store/ui/stripe-modal/slice'
 import { setUSDCBalance } from '~/store/wallet/slice'
 import { waitForRead } from '~/utils'
 
+import { getSDK } from '../sdkUtils'
+
 import {
   buyUSDCFlowFailed,
   buyUSDCFlowSucceeded,
@@ -178,8 +180,8 @@ function* transferStep({
     throw new Error('Missing feePayer unexpectedly')
   }
   const feePayerOverride = new PublicKey(feePayer)
-  const env = yield* getContext('env')
-  const recentBlockhash = yield* call(getRecentBlockhash, { env })
+  const sdk = yield* getSDK()
+  const recentBlockhash = yield* call(getRecentBlockhash, { sdk })
 
   yield* call(
     retry,

--- a/packages/common/src/store/buy-usdc/sagas.ts
+++ b/packages/common/src/store/buy-usdc/sagas.ts
@@ -178,7 +178,8 @@ function* transferStep({
     throw new Error('Missing feePayer unexpectedly')
   }
   const feePayerOverride = new PublicKey(feePayer)
-  const recentBlockhash = yield* call(getRecentBlockhash, audiusBackendInstance)
+  const env = yield* getContext('env')
+  const recentBlockhash = yield* call(getRecentBlockhash, { env })
 
   yield* call(
     retry,

--- a/packages/common/src/store/purchase-content/sagas.ts
+++ b/packages/common/src/store/purchase-content/sagas.ts
@@ -30,10 +30,7 @@ import {
 import { isContentUSDCPurchaseGated } from '~/models/Track'
 import { User } from '~/models/User'
 import { BNUSDC } from '~/models/Wallet'
-import {
-  getRootSolanaAccount,
-  getSolanaConnection
-} from '~/services/audius-backend/solana'
+import { getRootSolanaAccount } from '~/services/audius-backend/solana'
 import { FeatureFlags } from '~/services/remote-config/feature-flags'
 import { accountSelectors } from '~/store/account'
 import {

--- a/packages/common/src/store/purchase-content/sagas.ts
+++ b/packages/common/src/store/purchase-content/sagas.ts
@@ -937,8 +937,7 @@ function* purchaseWithAnything({
   try {
     const audiusSdk = yield* getContext('audiusSdk')
     const sdk = yield* call(audiusSdk)
-    const env = yield* getContext('env')
-    const connection = yield* call(getSolanaConnection, { env })
+    const connection = sdk.services.solanaClient.connection
     const getFeatureEnabled = yield* getContext('getFeatureEnabled')
     const isNetworkCutEnabled = yield* call(
       getFeatureEnabled,

--- a/packages/common/src/store/purchase-content/sagas.ts
+++ b/packages/common/src/store/purchase-content/sagas.ts
@@ -937,8 +937,8 @@ function* purchaseWithAnything({
   try {
     const audiusSdk = yield* getContext('audiusSdk')
     const sdk = yield* call(audiusSdk)
-    const audiusBackendInstance = yield* getContext('audiusBackendInstance')
-    const connection = yield* call(getSolanaConnection, audiusBackendInstance)
+    const env = yield* getContext('env')
+    const connection = yield* call(getSolanaConnection, { env })
     const getFeatureEnabled = yield* getContext('getFeatureEnabled')
     const isNetworkCutEnabled = yield* call(
       getFeatureEnabled,

--- a/packages/web/src/common/store/tipping/sagas.ts
+++ b/packages/web/src/common/store/tipping/sagas.ts
@@ -17,7 +17,6 @@ import {
   supporterMetadataFromSDK
 } from '@audius/common/models'
 import { LocalStorage } from '@audius/common/services'
-import { getWalletAddresses } from '@audius/common/src/store/account/selectors'
 import {
   accountSelectors,
   cacheActions,
@@ -88,7 +87,7 @@ const {
 } = tippingSelectors
 
 const { update } = cacheActions
-const { getAccountUser, getUserId } = accountSelectors
+const { getAccountUser, getUserId, getWalletAddresses } = accountSelectors
 const { fetchPermissions } = chatActions
 
 export const FEED_TIP_DISMISSAL_TIME_LIMIT_SEC = 30 * 24 * 60 * 60 // 30 days

--- a/packages/web/src/common/store/tipping/sagas.ts
+++ b/packages/web/src/common/store/tipping/sagas.ts
@@ -17,6 +17,7 @@ import {
   supporterMetadataFromSDK
 } from '@audius/common/models'
 import { LocalStorage } from '@audius/common/services'
+import { getWalletAddresses } from '@audius/common/src/store/account/selectors'
 import {
   accountSelectors,
   cacheActions,
@@ -265,10 +266,15 @@ function* confirmTipIndexed({
 function* wormholeAudioIfNecessary({ amount }: { amount: number }) {
   const walletClient = yield* getContext('walletClient')
   const sdk = yield* getSDK()
+  const { currentUser } = yield* select(getWalletAddresses)
+  if (!currentUser) {
+    throw new Error('Failed to retrieve current user wallet address')
+  }
 
   const waudioBalanceWei = yield* call(
     [walletClient, 'getCurrentWAudioBalance'],
     {
+      ethAddress: currentUser,
       sdk
     }
   )

--- a/packages/web/src/common/store/tipping/sagas.ts
+++ b/packages/web/src/common/store/tipping/sagas.ts
@@ -264,11 +264,14 @@ function* confirmTipIndexed({
 
 function* wormholeAudioIfNecessary({ amount }: { amount: number }) {
   const walletClient = yield* getContext('walletClient')
+  const sdk = yield* getSDK()
 
-  const waudioBalanceWei = yield* call([
-    walletClient,
-    'getCurrentWAudioBalance'
-  ])
+  const waudioBalanceWei = yield* call(
+    [walletClient, 'getCurrentWAudioBalance'],
+    {
+      sdk
+    }
+  )
   const audioWeiAmount = new BN(AUDIO(amount).value.toString()) as BNWei
 
   if (isNullOrUndefined(waudioBalanceWei)) {

--- a/packages/web/src/common/store/wallet/sagas.ts
+++ b/packages/web/src/common/store/wallet/sagas.ts
@@ -317,8 +317,9 @@ function* checkAssociatedTokenAccountOrSol(action: InputSendDataAction) {
     address
   )
   if (!associatedTokenAccount) {
+    const sdk = yield* getSDK()
     const balance: BNWei = yield* call(() =>
-      walletClient.getWalletSolBalance(address)
+      walletClient.getWalletSolBalance({ address, sdk })
     )
 
     // TODO: this can become a call to getAssociatedTokenRentExemptionMinimum

--- a/packages/web/src/common/store/wallet/sagas.ts
+++ b/packages/web/src/common/store/wallet/sagas.ts
@@ -209,7 +209,6 @@ function* fetchBalanceAsync() {
   yield* waitForWrite()
   const walletClient = yield* getContext('walletClient')
   const sdk = yield* getSDK()
-  const authService = yield* getContext('authService')
 
   const account = yield* select(getAccountUser)
   if (!account || !account.wallet) return
@@ -230,8 +229,7 @@ function* fetchBalanceAsync() {
       }),
       call([walletClient, 'getCurrentWAudioBalance'], {
         ethAddress: account.wallet,
-        sdk,
-        authService
+        sdk
       })
     ])
 

--- a/packages/web/src/common/store/wallet/sagas.ts
+++ b/packages/web/src/common/store/wallet/sagas.ts
@@ -120,7 +120,6 @@ function* sendAsync({
     )
 
     // Ensure user has userbank
-
     const audiusBackend = yield* getContext('audiusBackendInstance')
     const feePayerOverride = yield* select(getFeePayer)
     if (!feePayerOverride) {


### PR DESCRIPTION
### Description
Convert `getWaudioBalance` to use sdk functions and solana functions via `connection` directly instead of libs SolanaWeb3Manager.

Stop using `getSolanaConnection` in favor of connection from sdk.

Notes/Todos:
* @rickyrombo I tried modifying the `getSolanaConnection` fn in `services/audius-backend/solana.ts` but it resulted in having to pipe `env` in everywhere we needed a connection. Opted to use the sdk connection instead. If this is a nono feel free to revert the last 2 commits in this PR and things should work. (I also noticed there's another `getSolanaConnection` in web services..)
* The old version of this fn in `SolanaWeb3Manager` also checked if the given address was a token account, and if not, grabbed the token account for you and did operations on those instead. I think we don't need to do this since in this case we're always deriving userbank from the eth wallet address.
* wormhole audio flow should be tested


### How Has This Been Tested?

Local web stage get balance in tip modal + send $AUDIO works
<img width="1728" alt="Screenshot 2024-12-06 at 8 43 57 PM" src="https://github.com/user-attachments/assets/0d38d01d-69bd-4398-9809-55d5885d3499">

<img width="1728" alt="Screenshot 2024-12-06 at 8 47 36 PM" src="https://github.com/user-attachments/assets/5f2073ab-70fc-412c-b821-e4666751f675">
