### PR TITLE
Remove getRandomFeePayer

### DIFF
--- a/packages/common/src/services/audius-backend/AudiusBackend.ts
+++ b/packages/common/src/services/audius-backend/AudiusBackend.ts
@@ -1627,19 +1627,6 @@ export const audiusBackend = ({
     }
   }
 
-  async function getRandomFeePayer() {
-    await waitForLibsInit()
-    try {
-      const { feePayer } =
-        await audiusLibs.solanaWeb3Manager.getRandomFeePayer()
-      audiusLibs.solanaWeb3Manager.feePayerKey = new PublicKey(feePayer)
-      return { feePayer }
-    } catch (err) {
-      console.error(getErrorMessage(err))
-      return { error: true }
-    }
-  }
-
   /**
    * Make a request to fetch the eth AUDIO balance of the the user
    * @params {bool} bustCache
@@ -1915,7 +1902,6 @@ export const audiusBackend = ({
     getBrowserPushSubscription,
     getEmailNotificationSettings,
     getPushNotificationSettings,
-    getRandomFeePayer,
     getSafariBrowserPushEnabled,
     getSignature,
     getUserListenCountsMonthly,

--- a/packages/common/src/store/solana/sagas.ts
+++ b/packages/common/src/store/solana/sagas.ts
@@ -1,25 +1,16 @@
 import { put, call } from 'typed-redux-saga'
 
-import { getContext } from '../effects'
+import { getSDK } from '../sdkUtils'
 
 import { setFeePayer } from './slice'
 
 function* watchForFeePayer() {
-  const audiusBackendInstance = yield* getContext('audiusBackendInstance')
-  const { feePayer, error } = yield* call(
-    audiusBackendInstance.getRandomFeePayer as () => Promise<
-      | {
-          feePayer: string
-          error: undefined
-        }
-      | { feePayer: undefined; error: boolean }
-    >
-  )
-  if (error) {
-    console.error('Could not get fee payer.')
-  } else {
-    yield put(setFeePayer({ feePayer: feePayer as string }))
-  }
+  const sdk = yield* getSDK()
+  const feePayer = yield* call([
+    sdk.services.solanaRelay,
+    sdk.services.solanaRelay.getFeePayer
+  ])
+  yield put(setFeePayer({ feePayer: feePayer.toString() }))
 }
 
 export const sagas = () => {

--- a/packages/common/src/store/solana/sagas.ts
+++ b/packages/common/src/store/solana/sagas.ts
@@ -10,7 +10,7 @@ function* watchForFeePayer() {
     sdk.services.solanaRelay,
     sdk.services.solanaRelay.getFeePayer
   ])
-  yield put(setFeePayer({ feePayer: feePayer.toString() }))
+  yield* put(setFeePayer({ feePayer: feePayer.toString() }))
 }
 
 export const sagas = () => {


### PR DESCRIPTION
### Description
Remove `getRandomFeePayer` function from `AudiusBackend` and use the feePayer from `sdk.solanaRelay` service instead.

### How Has This Been Tested?

Local web stage - observed fee payer address gets set in redux