### PR TITLE
[QA-1873] Add back cache subscribe so UIDs get set correctly for playlists

### DIFF
--- a/packages/common/src/store/cache/actions.ts
+++ b/packages/common/src/store/cache/actions.ts
@@ -2,7 +2,14 @@ import { ID } from '~/models/Identifiers'
 import { Kind } from '~/models/Kind'
 import { Status } from '~/models/Status'
 
-import { EntriesByKind, Entry, Metadata } from './types'
+import {
+  CacheType,
+  EntriesByKind,
+  Entry,
+  Metadata,
+  SubscriberInfo,
+  UnsubscribeInfo
+} from './types'
 
 export const ADD = 'CACHE/ADD'
 export const ADD_SUCCEEDED = 'CACHE/ADD_SUCCEEDED'
@@ -10,6 +17,7 @@ export const ADD_ENTRIES = 'CACHE/ADD_ENTRIES'
 export const UPDATE = 'CACHE/UPDATE'
 export const INCREMENT = 'CACHE/INCREMENT'
 export const SET_STATUS = 'CACHE/SET_STATUS'
+export const SUBSCRIBE = 'CACHE/SUBSCRIBE'
 export const SET_EXPIRED = 'CACHE/SET_EXPIRED'
 export const SET_CACHE_CONFIG = 'CACHE/SET_CONFIG'
 
@@ -88,9 +96,7 @@ export const addEntries = (
 })
 
 /**
- * Updates an entry in the cache. Can also add transitive cache subscriptions.
- * E.g. if a collection references multiple tracks, the collection should be subscribed to those
- * tracks.
+ * Updates an entry in the cache.
  */
 export const update = (kind: Kind, entries: Entry[]) => ({
   type: UPDATE,
@@ -120,6 +126,15 @@ export const setStatus = (
   type: SET_STATUS,
   kind,
   statuses
+})
+
+/**
+ * Subscribes uids to ids in the cache.
+ */
+export const subscribe = (kind: Kind, subscribers: SubscriberInfo[]) => ({
+  type: SUBSCRIBE,
+  kind,
+  subscribers
 })
 
 /**

--- a/packages/common/src/store/cache/actions.ts
+++ b/packages/common/src/store/cache/actions.ts
@@ -2,14 +2,7 @@ import { ID } from '~/models/Identifiers'
 import { Kind } from '~/models/Kind'
 import { Status } from '~/models/Status'
 
-import {
-  CacheType,
-  EntriesByKind,
-  Entry,
-  Metadata,
-  SubscriberInfo,
-  UnsubscribeInfo
-} from './types'
+import { EntriesByKind, Entry, Metadata, SubscriberInfo } from './types'
 
 export const ADD = 'CACHE/ADD'
 export const ADD_SUCCEEDED = 'CACHE/ADD_SUCCEEDED'

--- a/packages/common/src/store/cache/reducer.ts
+++ b/packages/common/src/store/cache/reducer.ts
@@ -1,4 +1,4 @@
-import { mergeWith, add, isEqual } from 'lodash'
+import { mergeWith, add } from 'lodash'
 
 import { ID, UID } from '~/models/Identifiers'
 import { Status } from '~/models/Status'
@@ -10,7 +10,6 @@ import {
   UPDATE,
   SET_STATUS,
   SUBSCRIBE,
-  SET_EXPIRED,
   INCREMENT,
   AddSuccededAction,
   ADD_ENTRIES,
@@ -178,9 +177,10 @@ const addEntries = (state: CacheState, entries: Entry[], replace?: boolean) => {
         _timestamp: entity.timestamp ?? now,
         metadata: entity.metadata
       }
+      if (entity.uid) {
+        newUids[entity.uid] = entity.id
+      }
     }
-
-    newUids[entity.uid] = entity.id
   }
 
   return {

--- a/packages/common/src/store/cache/types.ts
+++ b/packages/common/src/store/cache/types.ts
@@ -20,3 +20,8 @@ export type Metadata = {
   blocknumber?: number
   local?: boolean
 } & Record<string, any>
+
+export type SubscriberInfo = {
+  uid: UID
+  id: string | number
+}

--- a/packages/web/src/common/store/cache/collections/addTrackToPlaylistSaga.ts
+++ b/packages/web/src/common/store/cache/collections/addTrackToPlaylistSaga.ts
@@ -79,6 +79,10 @@ function* addTrackToPlaylistAsync(action: AddTrackToPlaylistAction) {
     `collection:${action.playlistId}`
   )
 
+  yield* put(
+    cacheActions.subscribe(Kind.TRACKS, [{ uid: trackUid, id: action.trackId }])
+  )
+
   const currentBlockNumber = yield* call([web3.eth, 'getBlockNumber'])
   const currentBlock = (yield* call(
     [web3.eth, 'getBlock'],

--- a/packages/web/src/common/store/cache/sagas.ts
+++ b/packages/web/src/common/store/cache/sagas.ts
@@ -1,18 +1,25 @@
 import { Status } from '@audius/common/models'
-import type { ID, Kind } from '@audius/common/models'
-import { IntKeys } from '@audius/common/services'
+import type { ID, Kind, Cache } from '@audius/common/models'
+import { IntKeys, FeatureFlags } from '@audius/common/services'
 import {
   cacheActions,
+  cacheConfig,
   cacheSelectors,
   confirmerSelectors,
   getContext
 } from '@audius/common/store'
-import type { Metadata, Entry } from '@audius/common/store'
+import type {
+  Metadata,
+  Entry,
+  SubscriberInfo,
+  CacheType
+} from '@audius/common/store'
 import { makeUids, getIdFromKindId } from '@audius/common/utils'
 import { pick } from 'lodash'
 import { SelectEffect } from 'redux-saga/effects'
 import { all, call, put, select, takeEvery } from 'typed-redux-saga'
 
+const { CACHE_PRUNE_MIN } = cacheConfig
 const { getConfirmCalls } = confirmerSelectors
 const { getCache, getEntryTTL } = cacheSelectors
 
@@ -265,12 +272,13 @@ export function* add(
   )
 
   const entriesToAdd: Entry[] = []
+  const entriesToSubscribe: SubscriberInfo[] = []
   entries.forEach((entry) => {
     // If something is confirming and in the cache, we probably don't
     // want to replace it (unless explicit) because we would lose client
     // state, e.g. "has_current_user_reposted"
     if (!replace && entry.id in confirmCallsInCache && entry.uid) {
-      // do nothing
+      entriesToSubscribe.push({ uid: entry.uid, id: entry.id })
     } else {
       entriesToAdd.push(entry)
     }
@@ -284,6 +292,9 @@ export function* add(
         persist
       })
     )
+  }
+  if (entriesToSubscribe.length > 0) {
+    yield* put(cacheActions.subscribe(kind, entriesToSubscribe))
   }
 }
 

--- a/packages/web/src/common/store/cache/sagas.ts
+++ b/packages/web/src/common/store/cache/sagas.ts
@@ -1,25 +1,18 @@
 import { Status } from '@audius/common/models'
-import type { ID, Kind, Cache } from '@audius/common/models'
-import { IntKeys, FeatureFlags } from '@audius/common/services'
+import type { ID, Kind } from '@audius/common/models'
+import { IntKeys } from '@audius/common/services'
 import {
   cacheActions,
-  cacheConfig,
   cacheSelectors,
   confirmerSelectors,
   getContext
 } from '@audius/common/store'
-import type {
-  Metadata,
-  Entry,
-  SubscriberInfo,
-  CacheType
-} from '@audius/common/store'
+import type { Metadata, Entry, SubscriberInfo } from '@audius/common/store'
 import { makeUids, getIdFromKindId } from '@audius/common/utils'
 import { pick } from 'lodash'
 import { SelectEffect } from 'redux-saga/effects'
 import { all, call, put, select, takeEvery } from 'typed-redux-saga'
 
-const { CACHE_PRUNE_MIN } = cacheConfig
 const { getConfirmCalls } = confirmerSelectors
 const { getCache, getEntryTTL } = cacheSelectors
 

--- a/packages/web/src/common/store/lineup/sagas.ts
+++ b/packages/web/src/common/store/lineup/sagas.ts
@@ -12,7 +12,6 @@ import {
 import { StringKeys, FeatureFlags } from '@audius/common/services'
 import {
   accountSelectors,
-  cacheCollectionsSelectors,
   cacheTracksSelectors,
   cacheActions,
   cacheUsersSelectors,
@@ -23,11 +22,9 @@ import {
   getContext,
   playerSelectors,
   SubscriberInfo,
-  SubscriptionInfo,
   Entry,
   LineupBaseActions,
   QueueSource,
-  UnsubscribeInfo,
   PlayerBehavior
 } from '@audius/common/store'
 import { Uid, makeUids, makeUid, removeNullable } from '@audius/common/utils'
@@ -53,7 +50,6 @@ const { getSource, getUid, getPositions, getPlayerBehavior } = queueSelectors
 const { getUid: getCurrentPlayerTrackUid, getPlaying } = playerSelectors
 const { getUsers } = cacheUsersSelectors
 const { getTrack, getTracks } = cacheTracksSelectors
-const { getCollection } = cacheCollectionsSelectors
 const { getUserId } = accountSelectors
 
 const getEntryId = <T>(entry: LineupEntry<T>) => `${entry.kind}:${entry.id}`
@@ -703,10 +699,7 @@ export class LineupSagas<T extends Track | Collection> {
       yield* takeLatest(
         baseLineupActions.addPrefix(instance.prefix, baseLineupActions.RESET),
         reset,
-        instance.actions,
-        instance.prefix,
-        instance.selector,
-        instance.sourceSelector
+        instance.actions
       )
     }
   }

--- a/packages/web/src/common/store/pages/collection/sagas.js
+++ b/packages/web/src/common/store/pages/collection/sagas.js
@@ -1,6 +1,8 @@
 import { Kind } from '@audius/common/models'
 import {
+  cacheActions,
   collectionPageLineupActions as tracksActions,
+  collectionPageSelectors,
   collectionPageActions as collectionActions,
   reachabilitySelectors
 } from '@audius/common/store'
@@ -16,6 +18,7 @@ import {
 import tracksSagas from './lineups/sagas'
 
 const { NOT_FOUND_PAGE } = route
+const { getCollectionUid, getUserUid } = collectionPageSelectors
 const { fetchCollectionSucceeded, fetchCollectionFailed } = collectionActions
 const { getIsReachable } = reachabilitySelectors
 
@@ -53,6 +56,11 @@ function* watchFetchCollection() {
     const userUid = makeUid(Kind.USERS, collection.playlist_owner_id)
     const collectionUid = collectionUids[identifier]
     if (collection) {
+      yield put(
+        cacheActions.subscribe(Kind.USERS, [
+          { uid: userUid, id: collection.playlist_owner_id }
+        ])
+      )
       yield put(
         fetchCollectionSucceeded(
           collection.playlist_id,

--- a/packages/web/src/common/store/pages/collection/sagas.js
+++ b/packages/web/src/common/store/pages/collection/sagas.js
@@ -2,7 +2,6 @@ import { Kind } from '@audius/common/models'
 import {
   cacheActions,
   collectionPageLineupActions as tracksActions,
-  collectionPageSelectors,
   collectionPageActions as collectionActions,
   reachabilitySelectors
 } from '@audius/common/store'
@@ -18,7 +17,6 @@ import {
 import tracksSagas from './lineups/sagas'
 
 const { NOT_FOUND_PAGE } = route
-const { getCollectionUid, getUserUid } = collectionPageSelectors
 const { fetchCollectionSucceeded, fetchCollectionFailed } = collectionActions
 const { getIsReachable } = reachabilitySelectors
 

--- a/packages/web/src/common/store/player/sagas.ts
+++ b/packages/web/src/common/store/player/sagas.ts
@@ -1,8 +1,9 @@
-import { type Track } from '@audius/common/models'
+import { Kind, type Track } from '@audius/common/models'
 import { QueryParams } from '@audius/common/services'
 import {
   accountSelectors,
   cacheTracksSelectors,
+  cacheActions,
   queueActions,
   reachabilitySelectors,
   tracksSocialActions,
@@ -71,6 +72,7 @@ const { recordListen } = tracksSocialActions
 const { getNftAccessSignatureMap } = gatedContentSelectors
 const { getIsReachable } = reachabilitySelectors
 
+const PLAYER_SUBSCRIBER_NAME = 'PLAYER'
 const RECORD_LISTEN_SECONDS = 1
 const RECORD_LISTEN_INTERVAL = 1000
 
@@ -201,6 +203,11 @@ export function* watchPlay() {
         return () => {}
       })
       yield* spawn(actionChannelDispatcher, endChannel)
+      yield* put(
+        cacheActions.subscribe(Kind.TRACKS, [
+          { uid: PLAYER_SUBSCRIBER_NAME, id: trackId }
+        ])
+      )
 
       if (isLongFormContent) {
         // Make sure that the playback rate is set when playing a podcast

--- a/packages/web/src/common/store/queue/sagas.ts
+++ b/packages/web/src/common/store/queue/sagas.ts
@@ -16,7 +16,6 @@ import {
   cacheCollectionsSelectors,
   cacheTracksSelectors,
   cacheActions,
-  cacheSelectors,
   cacheUsersSelectors,
   lineupRegistry,
   queueActions,
@@ -55,9 +54,7 @@ const {
   getPlayerBehavior
 } = playerSelectors
 
-const { add, clear, next, pause, play, queueAutoplay, previous, remove } =
-  queueActions
-const { getId } = cacheSelectors
+const { add, clear, next, pause, play, queueAutoplay, previous } = queueActions
 const { getUser } = cacheUsersSelectors
 const { getTrack } = cacheTracksSelectors
 const { getCollection } = cacheCollectionsSelectors
@@ -523,19 +520,6 @@ export function* watchAdd() {
   })
 }
 
-export function* watchRemove() {
-  yield* takeEvery(remove.type, function* (action: ReturnType<typeof remove>) {
-    const { uid } = action.payload
-
-    const id = yield* select(getId, { kind: Kind.TRACKS, uid })
-    yield* put(
-      cacheActions.unsubscribe(Kind.TRACKS, [
-        { uid: QUEUE_SUBSCRIBER_NAME, id }
-      ])
-    )
-  })
-}
-
 const sagas = () => {
   const sagas = [
     watchPlay,
@@ -543,8 +527,7 @@ const sagas = () => {
     watchNext,
     watchQueueAutoplay,
     watchPrevious,
-    watchAdd,
-    watchRemove
+    watchAdd
   ]
   return sagas
 }

--- a/packages/web/src/common/store/queue/sagas.ts
+++ b/packages/web/src/common/store/queue/sagas.ts
@@ -15,6 +15,8 @@ import {
   accountSelectors,
   cacheCollectionsSelectors,
   cacheTracksSelectors,
+  cacheActions,
+  cacheSelectors,
   cacheUsersSelectors,
   lineupRegistry,
   queueActions,
@@ -53,12 +55,16 @@ const {
   getPlayerBehavior
 } = playerSelectors
 
-const { add, clear, next, pause, play, queueAutoplay, previous } = queueActions
+const { add, clear, next, pause, play, queueAutoplay, previous, remove } =
+  queueActions
+const { getId } = cacheSelectors
 const { getUser } = cacheUsersSelectors
 const { getTrack } = cacheTracksSelectors
 const { getCollection } = cacheCollectionsSelectors
 const { getUserId } = accountSelectors
 const { getIsReachable } = reachabilitySelectors
+
+const QUEUE_SUBSCRIBER_NAME = 'QUEUE'
 
 export function* getToQueue(
   prefix: string,
@@ -505,13 +511,40 @@ export function* watchPrevious() {
   )
 }
 
+export function* watchAdd() {
+  yield* takeEvery(add.type, function* (action: ReturnType<typeof add>) {
+    const { entries } = action.payload
+
+    const subscribers = entries.map((entry) => ({
+      uid: QUEUE_SUBSCRIBER_NAME,
+      id: entry.id
+    }))
+    yield* put(cacheActions.subscribe(Kind.TRACKS, subscribers))
+  })
+}
+
+export function* watchRemove() {
+  yield* takeEvery(remove.type, function* (action: ReturnType<typeof remove>) {
+    const { uid } = action.payload
+
+    const id = yield* select(getId, { kind: Kind.TRACKS, uid })
+    yield* put(
+      cacheActions.unsubscribe(Kind.TRACKS, [
+        { uid: QUEUE_SUBSCRIBER_NAME, id }
+      ])
+    )
+  })
+}
+
 const sagas = () => {
   const sagas = [
     watchPlay,
     watchPause,
     watchNext,
     watchQueueAutoplay,
-    watchPrevious
+    watchPrevious,
+    watchAdd,
+    watchRemove
   ]
   return sagas
 }

--- a/packages/web/src/common/store/social/collections/sagas.ts
+++ b/packages/web/src/common/store/social/collections/sagas.ts
@@ -22,7 +22,12 @@ import {
   confirmerActions,
   confirmTransaction
 } from '@audius/common/store'
-import { formatShareText, makeKindId, route } from '@audius/common/utils'
+import {
+  formatShareText,
+  makeUid,
+  makeKindId,
+  route
+} from '@audius/common/utils'
 import { call, select, takeEvery, put } from 'typed-redux-saga'
 
 import { make } from 'common/store/analytics/actions'
@@ -378,6 +383,17 @@ export function* saveCollectionAsync(
   if (!collection.is_album) {
     yield* put(updatedPlaylistViewed({ playlistId: action.collectionId }))
   }
+
+  const subscribedUid = makeUid(
+    Kind.COLLECTIONS,
+    collection.playlist_id,
+    'account'
+  )
+  yield* put(
+    cacheActions.subscribe(Kind.COLLECTIONS, [
+      { uid: subscribedUid, id: collection.playlist_id }
+    ])
+  )
 
   yield* put(
     accountActions.addAccountPlaylist({


### PR DESCRIPTION
### Description

Playlists were broken after https://github.com/AudiusProject/audius-protocol/pull/10558
They appeared empty on the collection page. Cache subscriptions were apparently responsible for correctly setting UIDs in the cache, but aren't really used for anything else. This pr reverts some of the changes in the previous pr, keeping subscriptions around to handle UIDs. we could rename this to be more descriptive, but hopefully this all goes away soon anyway

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._
