### PR TITLE
Upgrade something went wrong page error level

### DIFF
--- a/packages/mobile/src/app/ErrorBoundary.tsx
+++ b/packages/mobile/src/app/ErrorBoundary.tsx
@@ -1,9 +1,8 @@
 import type { ReactNode } from 'react'
 import { PureComponent, useEffect } from 'react'
 
-import { ErrorLevel, Feature } from '@audius/common/models'
+import { ErrorLevel } from '@audius/common/models'
 import type { Nullable } from '@audius/common/utils'
-import * as Sentry from '@sentry/react-native'
 
 import { useToast } from 'app/hooks/useToast'
 import { make, track } from 'app/services/analytics'

--- a/packages/mobile/src/app/ErrorBoundary.tsx
+++ b/packages/mobile/src/app/ErrorBoundary.tsx
@@ -1,12 +1,14 @@
 import type { ReactNode } from 'react'
 import { PureComponent, useEffect } from 'react'
 
+import { ErrorLevel, Feature } from '@audius/common/models'
 import type { Nullable } from '@audius/common/utils'
 import * as Sentry from '@sentry/react-native'
 
 import { useToast } from 'app/hooks/useToast'
 import { make, track } from 'app/services/analytics'
 import { EventNames } from 'app/types/analytics'
+import { reportToSentry } from 'app/utils/reportToSentry'
 
 type ErrorToastProps = {
   error: Nullable<string>
@@ -38,9 +40,10 @@ class ErrorBoundary extends PureComponent<ErrorBoundaryProps> {
   componentDidCatch(error: Error | null, errorInfo: any) {
     // On catch set the error state so it triggers a toast
     this.setState({ error: error?.message })
-    Sentry.withScope((scope) => {
-      scope.setExtras(errorInfo)
-      Sentry.captureException(error)
+    reportToSentry({
+      level: ErrorLevel.Fatal,
+      error: error ?? new Error('Unknown error caught by'),
+      additionalInfo: errorInfo
     })
     track(
       make({

--- a/packages/web/src/app/AppErrorBoundary.tsx
+++ b/packages/web/src/app/AppErrorBoundary.tsx
@@ -23,7 +23,7 @@ export const AppErrorBoundary = ({ children }: AppErrorBoundaryProps) => {
           message: error.message,
           shouldRedirect: true,
           additionalInfo: errorInfo,
-          level: ErrorLevel.Error
+          level: ErrorLevel.Fatal
         })
       )
     },


### PR DESCRIPTION
### Description

Upgrades the error level of our "something went wrong" page error boundaries from Error to Fatal - goal is that since we care more about these errors we'll likely eventually hook up some alerting.

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._
