### PR TITLE
[PAY-3640] Convert getAssociatedTokenAccountInfo to sdk

### DIFF
--- a/packages/common/src/services/audius-backend/AudiusBackend.ts
+++ b/packages/common/src/services/audius-backend/AudiusBackend.ts
@@ -13,7 +13,6 @@ import {
   ASSOCIATED_TOKEN_PROGRAM_ID,
   getAccount,
   TOKEN_PROGRAM_ID,
-  TokeInvalidAccountError,
   TokenInvalidAccountOwnerError
 } from '@solana/spl-token'
 import {

--- a/packages/common/src/services/wallet-client/WalletClient.ts
+++ b/packages/common/src/services/wallet-client/WalletClient.ts
@@ -1,6 +1,4 @@
 import { AudiusSdk } from '@audius/sdk'
-import { getAccount } from '@solana/spl-token'
-import { PublicKey } from '@solana/web3.js'
 import BN from 'bn.js'
 
 import { userWalletsFromSDK } from '~/adapters'

--- a/packages/common/src/services/wallet-client/WalletClient.ts
+++ b/packages/common/src/services/wallet-client/WalletClient.ts
@@ -60,12 +60,11 @@ export class WalletClient {
 
   /** Get user's current SOL Audio balance. Returns null on failure. */
   async getCurrentWAudioBalance({
-    ethAddress,
-    sdk
+    ethAddress
   }: {
     ethAddress: string
-    sdk: AudiusSdk
   }): Promise<BNWei | null> {
+    const sdk = await this.audiusSdk()
     const balance = await this.audiusBackendInstance.getWAudioBalance({
       ethAddress,
       sdk

--- a/packages/common/src/services/wallet-client/WalletClient.ts
+++ b/packages/common/src/services/wallet-client/WalletClient.ts
@@ -198,14 +198,9 @@ export class WalletClient {
     }
   }
 
-  async getWalletSolBalance({
-    address,
-    sdk
-  }: {
-    address: string
-    sdk: AudiusSdk
-  }): Promise<BNWei> {
+  async getWalletSolBalance({ address }: { address: string }): Promise<BNWei> {
     try {
+      const sdk = await this.audiusSdk()
       const balance = await this.audiusBackendInstance.getAddressSolBalance({
         address,
         sdk

--- a/packages/common/src/services/wallet-client/WalletClient.ts
+++ b/packages/common/src/services/wallet-client/WalletClient.ts
@@ -73,14 +73,9 @@ export class WalletClient {
     return balance as BNWei
   }
 
-  async getAssociatedTokenAccountInfo({
-    address,
-    sdk
-  }: {
-    address: string
-    sdk: AudiusSdk
-  }) {
+  async getAssociatedTokenAccountInfo({ address }: { address: string }) {
     try {
+      const sdk = await this.audiusSdk()
       const tokenAccountInfo =
         await this.audiusBackendInstance.getAssociatedTokenAccountInfo({
           address,
@@ -236,17 +231,16 @@ export class WalletClient {
 
   async sendWAudioTokens({
     address,
-    amount,
-    sdk
+    amount
   }: {
     address: SolanaWalletAddress
     amount: BNWei
-    sdk: AudiusSdk
   }): Promise<void> {
     if (amount.lt(MIN_TRANSFERRABLE_WEI)) {
       throw new Error('Insufficient Audio to transfer')
     }
     try {
+      const sdk = await this.audiusSdk()
       const { res, error, errorCode } =
         await this.audiusBackendInstance.sendWAudioTokens({
           address,

--- a/packages/common/src/services/wallet-client/WalletClient.ts
+++ b/packages/common/src/services/wallet-client/WalletClient.ts
@@ -1,4 +1,6 @@
 import { AudiusSdk } from '@audius/sdk'
+import { getAccount } from '@solana/spl-token'
+import { PublicKey } from '@solana/web3.js'
 import BN from 'bn.js'
 
 import { userWalletsFromSDK } from '~/adapters'
@@ -73,10 +75,19 @@ export class WalletClient {
     return balance as BNWei
   }
 
-  async getAssociatedTokenAccountInfo(address: string) {
+  async getAssociatedTokenAccountInfo({
+    address,
+    sdk
+  }: {
+    address: string
+    sdk: AudiusSdk
+  }) {
     try {
       const tokenAccountInfo =
-        await this.audiusBackendInstance.getAssociatedTokenAccountInfo(address)
+        await this.audiusBackendInstance.getAssociatedTokenAccountInfo({
+          address,
+          sdk
+        })
       return tokenAccountInfo
     } catch (err) {
       console.error(err)
@@ -225,16 +236,25 @@ export class WalletClient {
     }
   }
 
-  async sendWAudioTokens(
-    address: SolanaWalletAddress,
+  async sendWAudioTokens({
+    address,
+    amount,
+    sdk
+  }: {
+    address: SolanaWalletAddress
     amount: BNWei
-  ): Promise<void> {
+    sdk: AudiusSdk
+  }): Promise<void> {
     if (amount.lt(MIN_TRANSFERRABLE_WEI)) {
       throw new Error('Insufficient Audio to transfer')
     }
     try {
       const { res, error, errorCode } =
-        await this.audiusBackendInstance.sendWAudioTokens(address, amount)
+        await this.audiusBackendInstance.sendWAudioTokens({
+          address,
+          amount,
+          sdk
+        })
       if (error) {
         if (error === 'Missing social proof') {
           throw new Error(error)

--- a/packages/web/src/common/store/tipping/sagas.ts
+++ b/packages/web/src/common/store/tipping/sagas.ts
@@ -264,7 +264,6 @@ function* confirmTipIndexed({
 
 function* wormholeAudioIfNecessary({ amount }: { amount: number }) {
   const walletClient = yield* getContext('walletClient')
-  const sdk = yield* getSDK()
   const { currentUser } = yield* select(getWalletAddresses)
   if (!currentUser) {
     throw new Error('Failed to retrieve current user wallet address')
@@ -273,8 +272,7 @@ function* wormholeAudioIfNecessary({ amount }: { amount: number }) {
   const waudioBalanceWei = yield* call(
     [walletClient, 'getCurrentWAudioBalance'],
     {
-      ethAddress: currentUser,
-      sdk
+      ethAddress: currentUser
     }
   )
   const audioWeiAmount = new BN(AUDIO(amount).value.toString()) as BNWei

--- a/packages/web/src/common/store/wallet/sagas.ts
+++ b/packages/web/src/common/store/wallet/sagas.ts
@@ -23,7 +23,6 @@ import {
   stringWeiToBN,
   weiToString
 } from '@audius/common/utils'
-import type { AudiusLibs } from '@audius/sdk-legacy/dist/libs'
 import BN from 'bn.js'
 import { all, call, put, take, takeEvery, select } from 'typed-redux-saga'
 

--- a/packages/web/src/common/store/wallet/sagas.ts
+++ b/packages/web/src/common/store/wallet/sagas.ts
@@ -149,7 +149,7 @@ function* sendAsync({
         yield* call([walletClient, 'sendWAudioTokens'], {
           address: recipientWallet as SolanaWalletAddress,
           amount: weiBNAmount,
-          sdk
+          ethAddress: currentUser
         })
       } catch (e) {
         const errorMessage = getErrorMessage(e)
@@ -232,8 +232,7 @@ function* fetchBalanceAsync() {
         bustCache: localBalanceChange
       }),
       call([walletClient, 'getCurrentWAudioBalance'], {
-        ethAddress: account.wallet,
-        sdk
+        ethAddress: account.wallet
       })
     ])
 
@@ -314,7 +313,7 @@ function* checkAssociatedTokenAccountOrSol(action: InputSendDataAction) {
 
   const associatedTokenAccount = yield* call(
     [walletClient, 'getAssociatedTokenAccountInfo'],
-    { sdk, address }
+    { address }
   )
   if (!associatedTokenAccount) {
     const balance: BNWei = yield* call(() =>

--- a/packages/web/src/common/store/wallet/sagas.ts
+++ b/packages/web/src/common/store/wallet/sagas.ts
@@ -92,7 +92,7 @@ function* sendAsync({
   }
 
   const waudioWeiAmount: BNWei | null = yield* call(
-    [walletClient, 'getCurrentWAudioBalance'],
+    [walletClient, walletClient.getCurrentWAudioBalance],
     { ethAddress: currentUser }
   )
 
@@ -138,14 +138,18 @@ function* sendAsync({
     // user bank balance, transfer all eth AUDIO to spl wrapped audio
     if (chain === Chain.Sol && weiBNAmount.gt(waudioWeiAmount)) {
       yield* put(transferEthAudioToSolWAudio())
-      yield* call([walletClient, 'transferTokensFromEthToSol'])
+      yield* call([walletClient, walletClient.transferTokensFromEthToSol])
     }
 
     if (chain === Chain.Eth) {
-      yield* call([walletClient, 'sendTokens'], recipientWallet, weiBNAmount)
+      yield* call(
+        [walletClient, walletClient.sendTokens],
+        recipientWallet,
+        weiBNAmount
+      )
     } else {
       try {
-        yield* call([walletClient, 'sendWAudioTokens'], {
+        yield* call([walletClient, walletClient.sendWAudioTokens], {
           address: recipientWallet as SolanaWalletAddress,
           amount: weiBNAmount
         })
@@ -224,11 +228,11 @@ function* fetchBalanceAsync() {
       yield* select(getLocalBalanceDidChange)
 
     const [currentEthAudioWeiBalance, currentSolAudioWeiBalance] = yield* all([
-      call([walletClient, 'getCurrentBalance'], {
+      call([walletClient, walletClient.getCurrentBalance], {
         ethAddress: account.wallet,
         bustCache: localBalanceChange
       }),
-      call([walletClient, 'getCurrentWAudioBalance'], {
+      call([walletClient, walletClient.getCurrentWAudioBalance], {
         ethAddress: account.wallet
       })
     ])
@@ -247,7 +251,7 @@ function* fetchBalanceAsync() {
     }
 
     const associatedWalletBalance: BNWei | null = yield* call(
-      [walletClient, 'getAssociatedWalletBalance'],
+      [walletClient, walletClient.getAssociatedWalletBalance],
       account.user_id,
       /* bustCache */ localBalanceChange
     )
@@ -309,8 +313,8 @@ function* checkAssociatedTokenAccountOrSol(action: InputSendDataAction) {
   const connection = sdk.services.solanaClient.connection
 
   const associatedTokenAccount = yield* call(
-    [walletClient, 'getAssociatedTokenAccountInfo'],
-    { sdk, address }
+    [walletClient, walletClient.getAssociatedTokenAccountInfo],
+    { address }
   )
   if (!associatedTokenAccount) {
     const balance: BNWei = yield* call(() =>
@@ -320,7 +324,7 @@ function* checkAssociatedTokenAccountOrSol(action: InputSendDataAction) {
     // TODO: this can become a call to getAssociatedTokenRentExemptionMinimum
     // when the BuyAudio service has been migrated
     const minRentForATA = yield* call(
-      [connection, 'getMinimumBalanceForRentExemption'],
+      [connection, connection.getMinimumBalanceForRentExemption],
       ATA_SIZE,
       'processed'
     )

--- a/packages/web/src/common/store/wallet/sagas.ts
+++ b/packages/web/src/common/store/wallet/sagas.ts
@@ -210,7 +210,6 @@ function* getWalletBalanceAndWallets() {
 function* fetchBalanceAsync() {
   yield* waitForWrite()
   const walletClient = yield* getContext('walletClient')
-  const sdk = yield* getSDK()
 
   const account = yield* select(getAccountUser)
   if (!account || !account.wallet) return

--- a/packages/web/src/common/store/wallet/sagas.ts
+++ b/packages/web/src/common/store/wallet/sagas.ts
@@ -147,8 +147,7 @@ function* sendAsync({
       try {
         yield* call([walletClient, 'sendWAudioTokens'], {
           address: recipientWallet as SolanaWalletAddress,
-          amount: weiBNAmount,
-          ethAddress: currentUser
+          amount: weiBNAmount
         })
       } catch (e) {
         const errorMessage = getErrorMessage(e)
@@ -312,7 +311,7 @@ function* checkAssociatedTokenAccountOrSol(action: InputSendDataAction) {
 
   const associatedTokenAccount = yield* call(
     [walletClient, 'getAssociatedTokenAccountInfo'],
-    { address }
+    { sdk, address }
   )
   if (!associatedTokenAccount) {
     const balance: BNWei = yield* call(() =>

--- a/packages/web/src/common/store/wallet/sagas.ts
+++ b/packages/web/src/common/store/wallet/sagas.ts
@@ -81,7 +81,6 @@ function* sendAsync({
   yield* waitForWrite()
   const walletClient = yield* getContext('walletClient')
   const { track } = yield* getContext('analytics')
-  const sdk = yield* getSDK()
 
   const account = yield* select(getAccountUser)
   const weiBNAmount = stringWeiToBN(weiAudioAmount)
@@ -94,7 +93,7 @@ function* sendAsync({
 
   const waudioWeiAmount: BNWei | null = yield* call(
     [walletClient, 'getCurrentWAudioBalance'],
-    { ethAddress: currentUser, sdk }
+    { ethAddress: currentUser }
   )
 
   if (isNullOrUndefined(waudioWeiAmount)) {
@@ -317,7 +316,7 @@ function* checkAssociatedTokenAccountOrSol(action: InputSendDataAction) {
   )
   if (!associatedTokenAccount) {
     const balance: BNWei = yield* call(() =>
-      walletClient.getWalletSolBalance({ address, sdk })
+      walletClient.getWalletSolBalance({ address })
     )
 
     // TODO: this can become a call to getAssociatedTokenRentExemptionMinimum


### PR DESCRIPTION
### Description
* Migrate `AudiusBackend` `getAssociatedTokenAccountInfo` to use solana library directly, using sdk solana connection.
* Add a `getTokenAccount` helper function to replace libs `SolanaWeb3Manager` function.

### How Has This Been Tested?

Send wAUDIO is broken for some other reason, but I confirmed that I'm passing in the exact same args to `solanaWeb3Manager.transferwAudio` as on stage.
Also confirmed the failure case where the token account doesn't exist and the recipient account doesn't have enough sol balance to create an ATA:
<img width="1728" alt="Screenshot 2024-12-09 at 3 43 44 PM" src="https://github.com/user-attachments/assets/63ac8d61-1d9e-44c3-a1f9-7ad01676693f">

