### PR TITLE
C 5473 guest mode UI

### DIFF
--- a/packages/common/src/store/account/selectors.ts
+++ b/packages/common/src/store/account/selectors.ts
@@ -16,14 +16,14 @@ export const internalGetAccountUser = (state: CommonState) =>
 const hasTracksInternal = (state: CommonState) => state.account.hasTracks
 
 export const getHasAccount = (state: CommonState) => !!state.account.userId
-export const getHasCompletedAccount = (state: CommonState) => {
+export const getIsAccountComplete = (state: CommonState) => {
   const { userId } = state.account
 
   const user = getUser(state, { id: userId })
   if (!user) return false
 
   const { handle, name } = user
-  return handle && !!name
+  return Boolean(handle && name)
 }
 export const getUserId = (state: CommonState) => state.account.userId
 export const getAccountStatus = (state: CommonState) => state.account.status

--- a/packages/mobile/src/screens/sign-on-screen/SignOnStack.tsx
+++ b/packages/mobile/src/screens/sign-on-screen/SignOnStack.tsx
@@ -23,7 +23,7 @@ import { SelectArtistsScreen } from './screens/SelectArtistScreen'
 import { SelectGenresScreen } from './screens/SelectGenresScreen'
 import { SignOnScreen } from './screens/SignOnScreen'
 import type { SignUpScreenParamList } from './types'
-const { getHasCompletedAccount } = accountSelectors
+const { getIsAccountComplete: getHasCompletedAccount } = accountSelectors
 
 const Stack = createNativeStackNavigator()
 const screenOptionsOverrides = { animationTypeForReplace: 'pop' as const }

--- a/packages/web/src/common/store/pages/signon/actions.ts
+++ b/packages/web/src/common/store/pages/signon/actions.ts
@@ -427,9 +427,11 @@ export function removeFollowArtists(userIds: ID[]) {
   return { type: REMOVE_FOLLOW_ARTISTS, userIds }
 }
 
-export const showRequiresAccountToast = () =>
+export const showRequiresAccountToast = (isAccountIncomplete?: boolean) =>
   toastActions.toast({
-    content: 'Oops, it looks like you need an account to do that!'
+    content: isAccountIncomplete
+      ? 'Finish setting up your account to continue'
+      : 'Oops, it looks like you need an account to do that!'
   })
 
 /**

--- a/packages/web/src/common/store/pages/signon/selectors.ts
+++ b/packages/web/src/common/store/pages/signon/selectors.ts
@@ -2,7 +2,6 @@ import { accountSelectors, cacheUsersSelectors } from '@audius/common/store'
 import { createSelector } from 'reselect'
 
 import { AppState } from 'store/types'
-const { getHasAccount } = accountSelectors
 const { getUsers } = cacheUsersSelectors
 
 // Sign On selectors
@@ -64,12 +63,16 @@ export const getSuggestedFollowIds = (state: AppState) => {
 }
 
 export const getHasCompletedAccount = createSelector(
-  [getHasAccount, getStartedSignUpProcess, getFinishedSignUpProcess],
-  (hasAccount, startedSignUpProcess, finishedSignUpProcess) => {
+  [
+    accountSelectors.getIsAccountComplete,
+    getStartedSignUpProcess,
+    getFinishedSignUpProcess
+  ],
+  (isAccountComplete, startedSignUpProcess, finishedSignUpProcess) => {
     // If a user has started the sign up flow,
     // only return true if they finish the flow
     // (including selecting followees)
-    return hasAccount && (!startedSignUpProcess || finishedSignUpProcess)
+    return isAccountComplete && (!startedSignUpProcess || finishedSignUpProcess)
   }
 )
 

--- a/packages/web/src/components/avatar/Avatar.tsx
+++ b/packages/web/src/components/avatar/Avatar.tsx
@@ -1,7 +1,7 @@
 import { imageProfilePicEmpty } from '@audius/common/assets'
 import { SquareSizes, ID } from '@audius/common/models'
 import { accountSelectors, cacheUsersSelectors } from '@audius/common/store'
-import { Maybe } from '@audius/common/utils'
+import { Maybe, Nullable } from '@audius/common/utils'
 import {
   Avatar as HarmonyAvatar,
   type AvatarProps as HarmonyAvatarProps
@@ -24,7 +24,7 @@ const messages = {
 
 export type AvatarProps = Omit<HarmonyAvatarProps, 'src'> & {
   'aria-hidden'?: true
-  userId: Maybe<ID>
+  userId: Maybe<Nullable<ID>>
   onClick?: () => void
   imageSize?: SquareSizes
   popover?: boolean
@@ -39,7 +39,11 @@ export const Avatar = (props: AvatarProps) => {
     popover,
     ...other
   } = props
-  const profileImage = useProfilePicture({ userId, size: imageSize })
+
+  const profileImage = useProfilePicture({
+    userId: userId ?? undefined,
+    size: imageSize
+  })
 
   const image = userId ? profileImage : imageProfilePicEmpty
 

--- a/packages/web/src/components/nav/desktop/AccountDetails.tsx
+++ b/packages/web/src/components/nav/desktop/AccountDetails.tsx
@@ -165,7 +165,7 @@ const GuestView = () => {
     <AccountContentWrapper>
       <Avatar userId={null} h={48} w={48} />
       <AccountInfo>
-        <Text variant='title' size='s'>
+        <Text variant='title' size='s' ellipses>
           {guestEmail}
         </Text>
         <TextLink to={SIGN_UP_PAGE} variant='visible' size='s'>

--- a/packages/web/src/components/nav/desktop/AccountDetails.tsx
+++ b/packages/web/src/components/nav/desktop/AccountDetails.tsx
@@ -3,30 +3,34 @@ import { accountSelectors } from '@audius/common/store'
 import { route } from '@audius/common/utils'
 import { Box, Flex, Text, useTheme } from '@audius/harmony'
 
-import { AvatarLegacy } from 'components/avatar/AvatarLegacy'
+import { Avatar } from 'components/avatar/Avatar'
 import { TextLink, UserLink } from 'components/link'
+import { useLocalStorage } from 'hooks/useLocalStorage'
 import { useSelector } from 'utils/reducer'
 import { backgroundOverlay } from 'utils/styleUtils'
 
 import { AccountSwitcher } from './AccountSwitcher/AccountSwitcher'
 
-const { SIGN_IN_PAGE, profilePage } = route
-const { getUserHandle, getUserId } = accountSelectors
+const { SIGN_IN_PAGE, SIGN_UP_PAGE, profilePage } = route
+const { getUserHandle, getUserId, getIsAccountComplete } = accountSelectors
 
 const messages = {
   haveAccount: 'Have an Account?',
   managedAccount: 'Managed Account',
-  signIn: 'Sign in'
+  signIn: 'Sign in',
+  finishSignUp: 'Finish Signing Up'
 }
 
-export const AccountDetails = () => {
-  const accountHandle = useSelector(getUserHandle)
-  const accountUserId = useSelector(getUserId)
+type AccountDetailsContainerProps = {
+  children: React.ReactNode
+  isManagedAccount?: boolean
+}
+
+const AccountDetailsContainer = ({
+  children,
+  isManagedAccount
+}: AccountDetailsContainerProps) => {
   const { color } = useTheme()
-  const isManagedAccount = useIsManagedAccount()
-
-  const profileLink = profilePage(accountHandle ?? '')
-
   return (
     <Flex direction='column' pb='unit5' w='100%'>
       {isManagedAccount ? (
@@ -52,74 +56,157 @@ export const AccountDetails = () => {
             }
           : undefined)}
       >
-        <Flex alignItems='center' w='100%' justifyContent='flex-start' gap='s'>
-          <AvatarLegacy userId={accountUserId ?? undefined} />
-          <Flex
-            direction='column'
-            gap='xs'
-            flex={1}
-            css={{
-              textAlign: 'left',
-              whiteSpace: 'nowrap',
-              wordBreak: 'keep-all',
-              overflow: 'hidden'
-            }}
-          >
-            {accountUserId ? (
-              <>
-                <Flex
-                  alignItems='center'
-                  justifyContent='space-between'
-                  gap='s'
-                  h={20}
-                >
-                  <UserLink
-                    textVariant='title'
-                    size='s'
-                    userId={accountUserId}
-                    badgeSize='xs'
-                    css={{
-                      flex: 1,
-                      overflow: 'hidden',
-                      textOverflow: 'ellipsis',
-                      wordBreak: 'break-word',
-                      ...(isManagedAccount && {
-                        color: color.secondary.s500,
-                        '&:hover': { color: color.secondary.s500 }
-                      })
-                    }}
-                  />
-                  <AccountSwitcher />
-                </Flex>
-                <TextLink
-                  size='s'
-                  to={profileLink}
-                  css={
-                    isManagedAccount && {
-                      color: color.secondary.s500,
-                      '&:hover': { color: color.secondary.s500 }
-                    }
-                  }
-                >{`@${accountHandle}`}</TextLink>
-              </>
-            ) : (
-              <>
-                <Text variant='body' size='s' strength='strong'>
-                  {messages.haveAccount}
-                </Text>
-                <TextLink
-                  to={SIGN_IN_PAGE}
-                  variant='visible'
-                  size='xs'
-                  strength='weak'
-                >
-                  {messages.signIn}
-                </TextLink>
-              </>
-            )}
-          </Flex>
-        </Flex>
+        {children}
       </Flex>
     </Flex>
+  )
+}
+
+type AccountContentWrapperProps = {
+  children: React.ReactNode
+}
+
+const AccountContentWrapper = ({ children }: AccountContentWrapperProps) => (
+  <Flex alignItems='center' w='100%' justifyContent='flex-start' gap='s'>
+    {children}
+  </Flex>
+)
+
+type AccountInfoProps = {
+  children: React.ReactNode
+}
+
+const AccountInfo = ({ children }: AccountInfoProps) => (
+  <Flex
+    direction='column'
+    gap='xs'
+    flex={1}
+    css={{
+      textAlign: 'left',
+      whiteSpace: 'nowrap',
+      wordBreak: 'keep-all',
+      overflow: 'hidden'
+    }}
+  >
+    {children}
+  </Flex>
+)
+
+type SignedInViewProps = {
+  userId: number
+  handle: string
+  isManagedAccount: boolean
+}
+
+const SignedInView = ({
+  userId,
+  handle,
+  isManagedAccount
+}: SignedInViewProps) => {
+  const { color } = useTheme()
+  const profileLink = profilePage(handle)
+
+  return (
+    <AccountContentWrapper>
+      <Avatar userId={userId} h={48} w={48} />
+      <AccountInfo>
+        <Flex alignItems='center' justifyContent='space-between' gap='s' h={20}>
+          <UserLink
+            textVariant='title'
+            size='s'
+            userId={userId}
+            badgeSize='xs'
+            css={{
+              flex: 1,
+              overflow: 'hidden',
+              textOverflow: 'ellipsis',
+              wordBreak: 'break-word',
+              ...(isManagedAccount && {
+                color: color.secondary.s500,
+                '&:hover': { color: color.secondary.s500 }
+              })
+            }}
+          />
+          <AccountSwitcher />
+        </Flex>
+        <TextLink
+          size='s'
+          to={profileLink}
+          css={
+            isManagedAccount && {
+              color: color.secondary.s500,
+              '&:hover': { color: color.secondary.s500 }
+            }
+          }
+        >{`@${handle}`}</TextLink>
+      </AccountInfo>
+    </AccountContentWrapper>
+  )
+}
+
+const SignedOutView = () => (
+  <AccountContentWrapper>
+    <Avatar userId={null} h={48} w={48} />
+    <AccountInfo>
+      <Text variant='body' size='s' strength='strong'>
+        {messages.haveAccount}
+      </Text>
+      <TextLink to={SIGN_IN_PAGE} variant='visible' size='xs' strength='weak'>
+        {messages.signIn}
+      </TextLink>
+    </AccountInfo>
+  </AccountContentWrapper>
+)
+
+const GuestView = () => {
+  const [guestEmail] = useLocalStorage('guestEmail', '')
+
+  return (
+    <AccountContentWrapper>
+      <Avatar userId={null} h={48} w={48} />
+      <AccountInfo>
+        <Text variant='body' size='s' strength='strong'>
+          {guestEmail}
+        </Text>
+        <TextLink to={SIGN_UP_PAGE} variant='visible' size='xs' strength='weak'>
+          {messages.finishSignUp}
+        </TextLink>
+      </AccountInfo>
+    </AccountContentWrapper>
+  )
+}
+
+export const AccountDetails = () => {
+  const accountHandle = useSelector(getUserHandle)
+  const accountUserId = useSelector(getUserId)
+  const isManagedAccount = useIsManagedAccount()
+  const hasCompletedAccount = useSelector(getIsAccountComplete)
+  const [guestEmail] = useLocalStorage('guestEmail', '')
+
+  // Determine which state to show
+  if (accountUserId && accountHandle) {
+    return (
+      <AccountDetailsContainer isManagedAccount={isManagedAccount}>
+        <SignedInView
+          userId={accountUserId}
+          handle={accountHandle}
+          isManagedAccount={isManagedAccount}
+        />
+      </AccountDetailsContainer>
+    )
+  }
+
+  if (!hasCompletedAccount && guestEmail) {
+    return (
+      <AccountDetailsContainer>
+        <GuestView />
+      </AccountDetailsContainer>
+    )
+  }
+
+  return (
+    <AccountDetailsContainer>
+      <SignedOutView />
+    </AccountDetailsContainer>
   )
 }

--- a/packages/web/src/components/nav/desktop/AccountDetails.tsx
+++ b/packages/web/src/components/nav/desktop/AccountDetails.tsx
@@ -148,10 +148,10 @@ const SignedOutView = () => (
   <AccountContentWrapper>
     <Avatar userId={null} h={48} w={48} />
     <AccountInfo>
-      <Text variant='body' size='s' strength='strong'>
+      <Text variant='title' size='s'>
         {messages.haveAccount}
       </Text>
-      <TextLink to={SIGN_IN_PAGE} variant='visible' size='xs' strength='weak'>
+      <TextLink to={SIGN_IN_PAGE} variant='visible' size='s'>
         {messages.signIn}
       </TextLink>
     </AccountInfo>
@@ -165,10 +165,10 @@ const GuestView = () => {
     <AccountContentWrapper>
       <Avatar userId={null} h={48} w={48} />
       <AccountInfo>
-        <Text variant='body' size='s' strength='strong'>
+        <Text variant='title' size='s'>
           {guestEmail}
         </Text>
-        <TextLink to={SIGN_UP_PAGE} variant='visible' size='xs' strength='weak'>
+        <TextLink to={SIGN_UP_PAGE} variant='visible' size='s'>
           {messages.finishSignUp}
         </TextLink>
       </AccountInfo>

--- a/packages/web/src/components/nav/desktop/LeftNav.tsx
+++ b/packages/web/src/components/nav/desktop/LeftNav.tsx
@@ -1,11 +1,6 @@
-import { MouseEvent, useCallback, useRef, useState } from 'react'
+import { useCallback, useRef, useState } from 'react'
 
-import {
-  Name,
-  FavoriteSource,
-  Status,
-  CreateAccountOpen
-} from '@audius/common/models'
+import { FavoriteSource, Status } from '@audius/common/models'
 import {
   accountSelectors,
   collectionsSocialActions,
@@ -19,12 +14,11 @@ import { RouteComponentProps, withRouter } from 'react-router-dom'
 import useMeasure from 'react-use-measure'
 import { Dispatch } from 'redux'
 
-import { make, useRecord } from 'common/store/analytics/actions'
-import * as signOnActions from 'common/store/pages/signon/actions'
 import { DragAutoscroller } from 'components/drag-autoscroller/DragAutoscroller'
 import ConnectedProfileCompletionPane from 'components/profile-progress/ConnectedProfileCompletionPane'
 import { selectDraggingKind } from 'store/dragndrop/slice'
 import { AppState } from 'store/types'
+import { useSelector } from 'utils/reducer'
 
 import { AccountDetails } from './AccountDetails'
 import { ConnectInstagram } from './ConnectInstagram'
@@ -41,7 +35,8 @@ const { EXPLORE_PAGE, FEED_PAGE, HISTORY_PAGE, LIBRARY_PAGE, TRENDING_PAGE } =
   route
 const { saveTrack } = tracksSocialActions
 const { saveCollection } = collectionsSocialActions
-const { getAccountStatus, getUserId, getUserHandle } = accountSelectors
+const { getAccountStatus, getUserId, getUserHandle, getIsAccountComplete } =
+  accountSelectors
 
 export const LEFT_NAV_WIDTH = 240
 
@@ -63,15 +58,13 @@ const LeftNav = (props: NavColumnProps) => {
   const {
     accountUserId,
     accountHandle,
-    showActionRequiresAccount,
     isElectron,
     draggingKind,
     saveTrack,
     saveCollection,
-    accountStatus,
-    goToSignUp: routeToSignup
+    accountStatus
   } = props
-  const record = useRecord()
+  const isAccountComplete = useSelector(getIsAccountComplete)
   const [navBodyContainerMeasureRef, navBodyContainerBoundaries] = useMeasure({
     polyfill: ResizeObserver
   })
@@ -86,37 +79,12 @@ const LeftNav = (props: NavColumnProps) => {
     []
   )
 
-  const goToSignUp = useCallback(
-    (source: CreateAccountOpen['source']) => {
-      routeToSignup()
-      record(make(Name.CREATE_ACCOUNT_OPEN, { source }))
-    },
-    [record, routeToSignup]
-  )
-
-  const onClickNavLinkWithAccount = useCallback(
-    (e?: MouseEvent) => {
-      if (!accountUserId) {
-        e?.preventDefault()
-        goToSignUp('restricted page')
-        showActionRequiresAccount()
-      }
-    },
-    [accountUserId, goToSignUp, showActionRequiresAccount]
-  )
-
   const updateScrollTopPosition = useCallback((difference: number) => {
     if (scrollbarRef != null && scrollbarRef.current !== null) {
       scrollbarRef.current.scrollTop =
         scrollbarRef.current.scrollTop + difference
     }
   }, [])
-
-  const profileCompletionMeter = (
-    <Flex justifyContent='center'>
-      <ConnectedProfileCompletionPane />
-    </Flex>
-  )
 
   const navLoaded =
     accountStatus === Status.SUCCESS || accountStatus === Status.ERROR
@@ -166,7 +134,6 @@ const LeftNav = (props: NavColumnProps) => {
             onChangeDragScrollingDirection={handleChangeDragScrollingDirection}
           >
             <AccountDetails />
-
             <Flex
               direction='column'
               gap='unit5'
@@ -185,11 +152,7 @@ const LeftNav = (props: NavColumnProps) => {
               ) : null}
               <Box>
                 <GroupHeader>{messages.discover}</GroupHeader>
-                <LeftNavLink
-                  to={FEED_PAGE}
-                  disabled={!accountUserId}
-                  onClick={onClickNavLinkWithAccount}
-                >
+                <LeftNavLink to={FEED_PAGE} disabled={!isAccountComplete}>
                   Feed
                 </LeftNavLink>
                 <LeftNavLink to={TRENDING_PAGE}>Trending</LeftNavLink>
@@ -205,18 +168,11 @@ const LeftNav = (props: NavColumnProps) => {
                   acceptOwner={false}
                   onDrop={draggingKind === 'album' ? saveCollection : saveTrack}
                 >
-                  <LeftNavLink
-                    to={LIBRARY_PAGE}
-                    onClick={onClickNavLinkWithAccount}
-                  >
+                  <LeftNavLink to={LIBRARY_PAGE} restriction='guest'>
                     Library
                   </LeftNavLink>
                 </LeftNavDroppable>
-                <LeftNavLink
-                  to={HISTORY_PAGE}
-                  onClick={onClickNavLinkWithAccount}
-                  disabled={!accountUserId}
-                >
+                <LeftNavLink to={HISTORY_PAGE} disabled={!isAccountComplete}>
                   History
                 </LeftNavLink>
               </Box>
@@ -228,7 +184,7 @@ const LeftNav = (props: NavColumnProps) => {
         </Scrollbar>
       </Flex>
       <Flex direction='column' alignItems='center' pt='l' borderTop='default'>
-        {profileCompletionMeter}
+        <ConnectedProfileCompletionPane />
         <LeftNavCTA />
         <NowPlayingArtworkTile />
       </Flex>
@@ -249,10 +205,7 @@ const mapDispatchToProps = (dispatch: Dispatch) => ({
   saveTrack: (trackId: number) =>
     dispatch(saveTrack(trackId, FavoriteSource.NAVIGATOR)),
   saveCollection: (collectionId: number) =>
-    dispatch(saveCollection(collectionId, FavoriteSource.NAVIGATOR)),
-  showActionRequiresAccount: () =>
-    dispatch(signOnActions.showRequiresAccountToast()),
-  goToSignUp: () => dispatch(signOnActions.openSignOn(/** signIn */ false))
+    dispatch(saveCollection(collectionId, FavoriteSource.NAVIGATOR))
 })
 
 const ConnectedLeftNav = withRouter(

--- a/packages/web/src/components/nav/desktop/LeftNavCTA.tsx
+++ b/packages/web/src/components/nav/desktop/LeftNavCTA.tsx
@@ -16,16 +16,19 @@ import { useDispatch, useSelector } from 'react-redux'
 import { Link } from 'react-router-dom'
 
 import { make, useRecord } from 'common/store/analytics/actions'
+import { useLocalStorage } from 'hooks/useLocalStorage'
 
 const { SIGN_UP_PAGE, UPLOAD_PAGE } = route
-const { getAccountStatus, getHasAccount } = accountSelectors
+const { getAccountStatus, getHasAccount, getIsAccountComplete } =
+  accountSelectors
 const { resetState: resetUploadState } = uploadActions
 const { getIsUploading } = uploadSelectors
 
 const messages = {
   signUp: 'Sign up',
   uploadTrack: 'Upload Track',
-  uploading: 'Uploading...'
+  uploading: 'Uploading...',
+  finishSignUp: 'Finish Signing Up'
 }
 
 export const LeftNavCTA = () => {
@@ -34,11 +37,14 @@ export const LeftNavCTA = () => {
   const isSignedIn = useSelector(getHasAccount)
   const accountStatus = useSelector(getAccountStatus)
   const isUploading = useSelector(getIsUploading)
+  const hasCompletedAccount = useSelector(getIsAccountComplete)
+  const [guestEmail] = useLocalStorage('guestEmail', '')
 
   let status = 'signedOut'
   if (isSignedIn) status = 'signedIn'
   if (isUploading) status = 'uploading'
   if (accountStatus === Status.LOADING) status = 'loading'
+  if (!hasCompletedAccount && guestEmail) status = 'guest'
 
   const handleSignup = useCallback(() => {
     record(make(Name.CREATE_ACCOUNT_OPEN, { source: 'nav button' }))
@@ -70,6 +76,13 @@ export const LeftNavCTA = () => {
       break
     case 'loading':
       button = null
+      break
+    case 'guest':
+      button = (
+        <Button variant='primary' size='small' asChild>
+          <Link to={SIGN_UP_PAGE}>{messages.finishSignUp}</Link>
+        </Button>
+      )
       break
     case 'signedOut':
     default:

--- a/packages/web/src/components/nav/desktop/LeftNavLink.tsx
+++ b/packages/web/src/components/nav/desktop/LeftNavLink.tsx
@@ -6,16 +6,31 @@ import { Interpolation, Theme } from '@emotion/react'
 import { Slot } from '@radix-ui/react-slot'
 import { NavLink, NavLinkProps } from 'react-router-dom'
 
+import {
+  RestrictionType,
+  useRequiresAccountOnClick
+} from 'hooks/useRequiresAccount'
+
 export type LeftNavLinkProps =
   | { disabled?: boolean; asChild?: boolean } & (
       | Omit<NavLinkProps, 'onDrop'>
       | Omit<ComponentProps<'div'>, 'onDrop'>
-    )
+    ) & {
+        restriction?: RestrictionType
+      }
 
 export const LeftNavLink = (props: LeftNavLinkProps) => {
-  const { asChild, disabled, children, ...other } = props
+  const { asChild, disabled, children, onClick, restriction, ...other } = props
 
   const theme = useTheme()
+
+  const handleClick = useRequiresAccountOnClick(
+    (e) => onClick?.(e as any),
+    [onClick],
+    undefined,
+    undefined,
+    restriction
+  )
 
   const css = useMemo(() => {
     const { color, spacing, typography, cornerRadius } = theme
@@ -96,14 +111,14 @@ export const LeftNavLink = (props: LeftNavLinkProps) => {
 
   if ('to' in other) {
     return (
-      <NavLink {...other} activeClassName='active' css={css}>
+      <NavLink
+        {...other}
+        onClick={handleClick}
+        activeClassName='active'
+        css={css}
+      >
         <TextComp {...textProps}>{children}</TextComp>
       </NavLink>
     )
   }
-  return (
-    <div {...other} css={css}>
-      <TextComp {...textProps}>{children}</TextComp>
-    </div>
-  )
 }

--- a/packages/web/src/components/nav/desktop/LeftNavLink.tsx
+++ b/packages/web/src/components/nav/desktop/LeftNavLink.tsx
@@ -121,4 +121,10 @@ export const LeftNavLink = (props: LeftNavLinkProps) => {
       </NavLink>
     )
   }
+
+  return (
+    <div {...other} css={css}>
+      <TextComp {...textProps}>{children}</TextComp>
+    </div>
+  )
 }

--- a/packages/web/src/components/premium-content-purchase-modal/components/PurchaseContentFormFooter.tsx
+++ b/packages/web/src/components/premium-content-purchase-modal/components/PurchaseContentFormFooter.tsx
@@ -24,10 +24,10 @@ import {
   Flex,
   Divider
 } from '@audius/harmony'
-import { push as pushRoute } from 'connected-react-router'
 import { useField } from 'formik'
 import { capitalize } from 'lodash'
 import { useDispatch } from 'react-redux'
+import { Link } from 'react-router-dom-v5-compat'
 
 import { make } from 'common/store/analytics/actions'
 import { TwitterShareButton } from 'components/twitter-share-button/TwitterShareButton'
@@ -113,10 +113,6 @@ export const PurchaseContentFormFooter = ({
   const { totalPrice } = purchaseSummaryValues
   const [{ value: isGuestCheckout }] = useField(GUEST_CHECKOUT)
 
-  const handleFinishSigningUp = useCallback(() => {
-    dispatch(pushRoute(SIGN_UP_PAGE))
-  }, [dispatch])
-
   const handleTwitterShare = useCallback(
     (handle: string) => {
       const shareText = messages.shareTwitterText(
@@ -162,8 +158,8 @@ export const PurchaseContentFormFooter = ({
                   <Text>{messages.finishSigningUpDescription}</Text>
                 </Flex>
                 <Flex gap='s'>
-                  <Button fullWidth onClick={handleFinishSigningUp}>
-                    {messages.finishSigningUp}
+                  <Button fullWidth asChild>
+                    <Link to={SIGN_UP_PAGE}>{messages.finishSigningUp}</Link>
                   </Button>
                   <Button
                     fullWidth
@@ -216,6 +212,7 @@ export const PurchaseContentFormFooter = ({
       </Flex>
     )
   }
+
   return (
     <>
       <Button

--- a/packages/web/src/components/profile-progress/ConnectedProfileCompletionPane.jsx
+++ b/packages/web/src/components/profile-progress/ConnectedProfileCompletionPane.jsx
@@ -5,6 +5,7 @@ import {
   challengesSelectors,
   musicConfettiActions
 } from '@audius/common/store'
+import { Flex } from '@audius/harmony'
 import { connect, useDispatch } from 'react-redux'
 // eslint-disable-next-line no-restricted-imports -- TODO: migrate to @react-spring/web
 import { animated } from 'react-spring'
@@ -60,7 +61,7 @@ const ConnectedProfileCompletionPanel = ({
   const transitions = useSlideDown(!isHidden, ORIGINAL_HEIGHT_PIXELS, true)
 
   return (
-    <>
+    <Flex justifyContent='center'>
       {!shouldNeverShow && isLoggedIn
         ? transitions.map(({ item, key, props }) =>
             item ? (
@@ -85,7 +86,7 @@ const ConnectedProfileCompletionPanel = ({
             ) : null
           )
         : null}
-    </>
+    </Flex>
   )
 }
 

--- a/packages/web/src/components/profile-progress/hooks/index.js
+++ b/packages/web/src/components/profile-progress/hooks/index.js
@@ -1,11 +1,15 @@
 import { useState, useEffect } from 'react'
 
 import { Name } from '@audius/common/models'
+import { accountSelectors } from '@audius/common/store'
 import { useDispatch } from 'react-redux'
 // eslint-disable-next-line no-restricted-imports -- TODO: migrate to @react-spring/web
 import { useTransition } from 'react-spring'
 
 import { make } from 'common/store/analytics/actions'
+import { useSelector } from 'utils/reducer'
+
+const { getIsAccountComplete } = accountSelectors
 
 const COMPLETION_DISMISSAL_DELAY_MSEC = 3 * 1000
 
@@ -39,6 +43,7 @@ export const useProfileCompletionDismissal = ({
   const dispatch = useDispatch()
   const [didCompleteThisSession, setDidCompleteThisSession] = useState(false)
   const isComplete = getIsComplete(completionStages)
+  const isAccountComplete = useSelector(getIsAccountComplete)
 
   // On account load, check if this profile was *ever* incomplete
   const [wasIncomplete, setWasIncomplete] = useState(false)
@@ -65,7 +70,7 @@ export const useProfileCompletionDismissal = ({
     dispatch(make(Name.ACCOUNT_HEALTH_METER_FULL))
   }
 
-  const isHidden = wasAlwaysComplete || isDismissed
+  const isHidden = !isAccountComplete || wasAlwaysComplete || isDismissed
   // If it was always complete, never show the meter
   const shouldNeverShow = isHidden && wasAlwaysComplete
   return { isHidden, shouldNeverShow, didCompleteThisSession }

--- a/packages/web/src/hooks/useRequiresAccount.ts
+++ b/packages/web/src/hooks/useRequiresAccount.ts
@@ -12,7 +12,20 @@ import {
   updateRouteOnExit
 } from 'common/store/pages/signon/actions'
 import { useSelector } from 'utils/reducer'
-const { getHasAccount, getAccountStatus } = accountSelectors
+
+const { getAccountStatus, getIsAccountComplete, getHasAccount } =
+  accountSelectors
+
+export type RestrictionType = 'guest' | 'account'
+
+const canAccess = (
+  restriction: RestrictionType,
+  hasAccount: boolean,
+  isAccountComplete: boolean
+): boolean => {
+  if (restriction === 'guest') return hasAccount
+  return isAccountComplete
+}
 
 /**
  * Like useCallback but designed to be used to redirect unauthenticated users
@@ -22,9 +35,11 @@ export const useRequiresAccountCallback = <T extends (...args: any) => any>(
   callback: T,
   deps: any[],
   onOpenAuthModal?: () => void,
-  returnRouteOverride?: string
+  returnRouteOverride?: string,
+  restriction: RestrictionType = 'account'
 ) => {
   const hasAccount = useSelector(getHasAccount)
+  const isAccountComplete = useSelector(getIsAccountComplete)
   const accountStatus = useSelector(getAccountStatus)
   const dispatch = useDispatch()
   const location = useLocation()
@@ -32,11 +47,18 @@ export const useRequiresAccountCallback = <T extends (...args: any) => any>(
 
   return useCallback(
     (...args: Parameters<T>) => {
-      if (accountStatus !== Status.LOADING && !hasAccount) {
+      if (
+        accountStatus !== Status.LOADING &&
+        !canAccess(restriction, hasAccount, isAccountComplete)
+      ) {
+        // Prevent the default event from occuring
+        if (args[0]?.preventDefault) {
+          args[0].preventDefault()
+        }
         dispatch(updateRouteOnExit(returnRoute))
         dispatch(updateRouteOnCompletion(returnRoute))
         dispatch(openSignOn(/** signIn */ false))
-        dispatch(showRequiresAccountToast())
+        dispatch(showRequiresAccountToast(hasAccount && !isAccountComplete))
         onOpenAuthModal?.()
       } else {
         // eslint-disable-next-line n/no-callback-literal
@@ -44,12 +66,12 @@ export const useRequiresAccountCallback = <T extends (...args: any) => any>(
       }
     },
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [hasAccount, dispatch, ...deps]
+    [isAccountComplete, dispatch, restriction, ...deps]
   )
 }
 
 /**
- * Like useAuthenticatedCallback but designed to be used for click handlers so that
+ * Like useRequiresAccountCallback but designed to be used for click handlers so that
  * clicks are not propagated.
  */
 export const useRequiresAccountOnClick = <
@@ -58,7 +80,8 @@ export const useRequiresAccountOnClick = <
   callback: T,
   deps: any[],
   onOpenAuthModal?: () => void,
-  returnRouteOverride?: string
+  returnRouteOverride?: string,
+  restriction: RestrictionType = 'account'
 ) => {
   return useRequiresAccountCallback(
     (e: ReactMouseEvent<Element, MouseEvent>) => {
@@ -68,7 +91,8 @@ export const useRequiresAccountOnClick = <
     // eslint-disable-next-line react-hooks/exhaustive-deps
     deps,
     onOpenAuthModal,
-    returnRouteOverride
+    returnRouteOverride,
+    restriction
   )
 }
 
@@ -80,14 +104,19 @@ export const useRequiresAccountOnClick = <
  * informing the user that an account is required for the action.
  *
  * @param returnRouteOverride - Optional route to navigate to after successful sign-up
+ * @param restriction - Optional restriction type ('none' | 'guest' | 'account')
  * @returns A function that, when called, performs the authentication check and redirection
  */
-export const useRequiresAccountFn = (returnRouteOverride?: string) => {
+export const useRequiresAccountFn = (
+  returnRouteOverride?: string,
+  restriction: RestrictionType = 'account'
+) => {
   const requiresAccount = useRequiresAccountCallback(
     () => {},
     [],
     undefined,
-    returnRouteOverride
+    returnRouteOverride,
+    restriction
   )
   return { requiresAccount }
 }
@@ -100,9 +129,16 @@ export const useRequiresAccountFn = (returnRouteOverride?: string) => {
  * whenever its dependencies change.
  *
  * @param returnRouteOverride - Optional route to navigate to after successful sign-up
+ * @param restriction - Optional restriction type ('none' | 'guest' | 'account')
  */
-export const useRequiresAccount = (returnRouteOverride?: string) => {
-  const { requiresAccount } = useRequiresAccountFn(returnRouteOverride)
+export const useRequiresAccount = (
+  returnRouteOverride?: string,
+  restriction: RestrictionType = 'account'
+) => {
+  const { requiresAccount } = useRequiresAccountFn(
+    returnRouteOverride,
+    restriction
+  )
 
   useEffect(() => {
     requiresAccount()

--- a/packages/web/src/pages/sign-on-page/SignOnPage.tsx
+++ b/packages/web/src/pages/sign-on-page/SignOnPage.tsx
@@ -13,12 +13,17 @@ import {
 } from '@audius/harmony'
 import { useDispatch, useSelector } from 'react-redux'
 import { Link, Redirect, Route, Switch, useRouteMatch } from 'react-router-dom'
-import { useEffectOnce, useLocation, useMeasure } from 'react-use'
+import { useSearchParams } from 'react-router-dom-v5-compat'
+import { useEffectOnce, useLocalStorage, useMeasure } from 'react-use'
 
 import djBackground from 'assets/img/2-DJ-4-3.jpg'
 import djPortrait from 'assets/img/DJportrait.jpg'
 import imagePhone from 'assets/img/imagePhone.png'
-import { fetchReferrer } from 'common/store/pages/signon/actions'
+import {
+  fetchReferrer,
+  setField,
+  setValueField
+} from 'common/store/pages/signon/actions'
 import {
   getHasCompletedAccount,
   getRouteOnExit
@@ -280,17 +285,25 @@ const MobileSignOnRoot = (props: MobileSignOnRootProps) => {
 export const SignOnPage = () => {
   const { isMobile } = useMedia()
   const hasCompletedAccount = useSelector(getHasCompletedAccount)
-  const location = useLocation()
   const dispatch = useDispatch()
+  const [searchParams] = useSearchParams()
+  const [guestEmailLocalStorage] = useLocalStorage('guestEmail', '')
 
   useEffectOnce(() => {
     // Check for referrals and set them in the store
-    const rf = new URLSearchParams(location.search).get('rf')
-    const ref = new URLSearchParams(location.search).get('ref')
+    const rf = searchParams.get('rf')
+    const ref = searchParams.get('ref')
     if (rf) {
       dispatch(fetchReferrer(rf))
     } else if (ref) {
       dispatch(fetchReferrer(ref))
+    }
+
+    const guestEmailParam = searchParams.get('guestEmail')
+    const guestEmail = guestEmailLocalStorage || guestEmailParam
+    if (guestEmail) {
+      dispatch(setValueField('email', guestEmail))
+      dispatch(setField('isGuest', true))
     }
   })
 

--- a/packages/web/src/utils/route.ts
+++ b/packages/web/src/utils/route.ts
@@ -11,14 +11,8 @@ import { env } from 'services/env'
 
 import { encodeUrlName } from './urlUtils'
 
-const {
-  getHash,
-  SIGN_UP_PAGE,
-  SIGN_UP_PASSWORD_PAGE,
-  SEARCH_PAGE,
-  profilePage,
-  collectionPage
-} = route
+const { getHash, SIGN_UP_PAGE, SEARCH_PAGE, profilePage, collectionPage } =
+  route
 
 const USE_HASH_ROUTING = env.USE_HASH_ROUTING
 

--- a/packages/web/src/utils/route.ts
+++ b/packages/web/src/utils/route.ts
@@ -11,8 +11,14 @@ import { env } from 'services/env'
 
 import { encodeUrlName } from './urlUtils'
 
-const { getHash, SIGN_UP_PAGE, SEARCH_PAGE, profilePage, collectionPage } =
-  route
+const {
+  getHash,
+  SIGN_UP_PAGE,
+  SIGN_UP_PASSWORD_PAGE,
+  SEARCH_PAGE,
+  profilePage,
+  collectionPage
+} = route
 
 const USE_HASH_ROUTING = env.USE_HASH_ROUTING
 


### PR DESCRIPTION
### Description

Adds mvp elements of desktop guest UI.
- Adds guest mode account details and refactors component for readability
- Adds finish-account left-nav-cta action
- Updates finish-account button in purchase modal to use a link
- Adds a "restriction" prop to useRequiresAccount hooks to distinguish between signed-out user and guest-user, and updates toast message and left-nav links appropriately (library is navigable for guest, but feed and history require full account)
- Updates sign-up code to tell when a sign-up in initiated via a logged in guest user, and jumps user to complete password flow. Note there are quite a few things to update in this area, so more changes will come later. Also im not totally in love with the approach of reading guestEmail from local storage in the useDetierminedRoutes hook, bet lets leave for now until we do a hardening pass.

<img width="890" alt="image" src="https://github.com/user-attachments/assets/79c97bcf-aad8-48d4-a99c-3f4b612d41b1">

