### PR TITLE
Fix syncing of guest accounts upon profile completion

### DIFF
--- a/packages/common/src/store/account/sagas.ts
+++ b/packages/common/src/store/account/sagas.ts
@@ -80,9 +80,13 @@ export function* fetchAccountAsync({ isSignUp = false }): SagaIterator {
       })
     )
   }
-  const accountData = yield* call(userApiFetchSaga.getUserAccount, {
-    wallet
-  })
+  const accountData = yield* call(
+    userApiFetchSaga.getUserAccount,
+    {
+      wallet
+    },
+    true // force refresh to get updated user w handle
+  )
   if (!accountData || !accountData?.user) {
     yield* put(
       fetchAccountFailed({

--- a/packages/web/src/common/store/pages/signon/sagas.ts
+++ b/packages/web/src/common/store/pages/signon/sagas.ts
@@ -843,6 +843,7 @@ function* signUp() {
                 'true'
               )
             }
+            return handle
           } catch (err: unknown) {
             // We are including 0 status code here to indicate rate limit,
             // which appears to be happening for some devices.


### PR DESCRIPTION
### Description

Upon profile completion the account details are still in the null state because of the stale cached user. Force refresh after the profile update is confirmed fixes this.

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._

Ran against stage and completed profile.
