### PR TITLE
Pass in ethWallet to decorateCoinflowWithdrawalTransaction

### DIFF
--- a/packages/common/src/hooks/useCoinflowAdapter.ts
+++ b/packages/common/src/hooks/useCoinflowAdapter.ts
@@ -22,6 +22,7 @@ import {
   PurchaseErrorCode,
   purchaseContentActions
 } from '~/store'
+import { getWalletAddresses } from '~/store/account/selectors'
 import { BuyCryptoError } from '~/store/buy-crypto/types'
 import { getFeePayer } from '~/store/solana/selectors'
 
@@ -46,6 +47,7 @@ export const useCoinflowWithdrawalAdapter = () => {
   } = useAppContext()
   const [adapter, setAdapter] = useState<CoinflowAdapter | null>(null)
   const feePayerOverride = useSelector(getFeePayer)
+  const { currentUser } = useSelector(getWalletAddresses)
   const { audiusSdk } = useAudiusQueryContext()
 
   useEffect(() => {
@@ -69,9 +71,13 @@ export const useCoinflowWithdrawalAdapter = () => {
                 'VersionedTransaction not supported in withdrawal adapter'
               )
             }
+            if (!currentUser) {
+              throw new Error('Missing current user')
+            }
             const feePayer = new PublicKey(feePayerOverride)
             const finalTransaction =
               await decorateCoinflowWithdrawalTransaction(sdk, audiusBackend, {
+                ethAddress: currentUser,
                 transaction,
                 feePayer
               })

--- a/packages/common/src/services/audius-backend/solana.ts
+++ b/packages/common/src/services/audius-backend/solana.ts
@@ -378,11 +378,14 @@ export const findAssociatedTokenAddress = async (
 export const decorateCoinflowWithdrawalTransaction = async (
   sdk: AudiusSdk,
   audiusBackendInstance: AudiusBackend,
-  { transaction, feePayer }: { transaction: Transaction; feePayer: PublicKey }
+  {
+    transaction,
+    feePayer,
+    ethAddress
+  }: { transaction: Transaction; feePayer: PublicKey; ethAddress: string }
 ) => {
   const libs = await audiusBackendInstance.getAudiusLibsTyped()
   const solanaWeb3Manager = libs.solanaWeb3Manager!
-  const ethAddress = sdk.services.audiusWalletClient.account.address
 
   const userBank = await deriveUserBankPubkey(sdk, {
     ethAddress,


### PR DESCRIPTION
### Description
Don't use `audiusWalletClient` to grab the current user's eth wallet, select it explicitly from store for manager mode compatibility.

### How Has This Been Tested?

Untested (coinflow doesn't work on stage)