### PR TITLE
[PAY-3649] Fix something went wrong on transactions page

### DIFF
--- a/packages/web/src/common/store/pages/audio-transactions/sagas.ts
+++ b/packages/web/src/common/store/pages/audio-transactions/sagas.ts
@@ -134,7 +134,7 @@ function* fetchAudioTransactionsAsync() {
         .filter((tx) => tx !== null)
       yield* call(
         fetchUsers,
-        userIds.filter(removeNullable).map(parseInt),
+        userIds.filter(removeNullable).map((id) => parseInt(id)),
         undefined, // requiredFields
         false // forceRetrieveFromSource
       )


### PR DESCRIPTION
### Description

Thank you, javascript.

<img width="1080" alt="image" src="https://github.com/user-attachments/assets/3816d737-6c90-42e6-8487-9c7fba99ad7f">

Turns out this
```filteredIds.map(parseInt)```
 is equivalent to this
```filteredIds.map((str, index, array) => parseInt(str, index))```
because `map` actually passes 3 params and parseInt accepts `(input: str, radix?: number)`, so it’s trying to parse each item with `index` as the base for parsing

_Note: Confirmed that this is the only place in the code where we map `parseInt` this way with no args_

### How Has This Been Tested?

repro'd consistently before, working consistently after