### PR TITLE
[PAY-3689] Migrate getSolanaRootAccount to sdk

### DIFF
--- a/packages/common/src/hooks/purchaseContent/usePurchaseContentFormConfiguration.ts
+++ b/packages/common/src/hooks/purchaseContent/usePurchaseContentFormConfiguration.ts
@@ -51,12 +51,14 @@ export const usePurchaseContentFormConfiguration = ({
   metadata,
   price,
   presetValues,
-  purchaseVendor
+  purchaseVendor,
+  privateKey
 }: {
   metadata?: UserTrackMetadata | UserCollectionMetadata
   price: number
   presetValues: PayExtraAmountPresetValues
   purchaseVendor?: PurchaseVendor
+  privateKey: Buffer
 }) => {
   const audiusQueryContext = useAudiusQueryContext()
 
@@ -150,7 +152,8 @@ export const usePurchaseContentFormConfiguration = ({
             contentType: isAlbum
               ? PurchaseableContentType.ALBUM
               : PurchaseableContentType.TRACK,
-            guestEmail
+            guestEmail,
+            privateKey
           })
         )
       }
@@ -162,7 +165,8 @@ export const usePurchaseContentFormConfiguration = ({
       page,
       dispatch,
       presetValues,
-      isAlbum
+      isAlbum,
+      privateKey
     ]
   )
 

--- a/packages/common/src/hooks/useCoinflowAdapter.ts
+++ b/packages/common/src/hooks/useCoinflowAdapter.ts
@@ -39,7 +39,11 @@ type CoinflowAdapter = {
  * the incoming transaction to route it through a user bank. The transcation will then be
  * signed with the current user's Solana root wallet and sent/confirmed via Relay.
  */
-export const useCoinflowWithdrawalAdapter = () => {
+export const useCoinflowWithdrawalAdapter = ({
+  privateKey
+}: {
+  privateKey: Buffer
+}) => {
   const {
     audiusBackend,
     analytics: { make, track }
@@ -50,7 +54,9 @@ export const useCoinflowWithdrawalAdapter = () => {
 
   useEffect(() => {
     const initWallet = async () => {
-      const wallet = await getRootSolanaAccount(audiusBackend)
+      const wallet = await getRootSolanaAccount({
+        privateKey
+      })
       const sdk = await audiusSdk()
       const connection = sdk.services.solanaClient.connection
 
@@ -73,7 +79,8 @@ export const useCoinflowWithdrawalAdapter = () => {
             const finalTransaction =
               await decorateCoinflowWithdrawalTransaction(sdk, audiusBackend, {
                 transaction,
-                feePayer
+                feePayer,
+                privateKey
               })
             finalTransaction.partialSign(wallet)
             const { res, error, errorCode } = await relayTransaction(
@@ -115,7 +122,7 @@ export const useCoinflowWithdrawalAdapter = () => {
       })
     }
     initWallet()
-  }, [audiusBackend, feePayerOverride, make, track, audiusSdk])
+  }, [audiusBackend, feePayerOverride, make, track, audiusSdk, privateKey])
 
   return adapter
 }
@@ -126,10 +133,12 @@ export const useCoinflowWithdrawalAdapter = () => {
  */
 export const useCoinflowAdapter = ({
   onSuccess,
-  onFailure
+  onFailure,
+  privateKey
 }: {
   onSuccess: () => void
   onFailure: () => void
+  privateKey: Buffer
 }) => {
   const { audiusBackend } = useAppContext()
   const [adapter, setAdapter] = useState<CoinflowAdapter | null>(null)
@@ -138,7 +147,7 @@ export const useCoinflowAdapter = ({
 
   useEffect(() => {
     const initWallet = async () => {
-      const wallet = await getRootSolanaAccount(audiusBackend)
+      const wallet = await getRootSolanaAccount({ privateKey })
       const sdk = await audiusSdk()
       const connection = sdk.services.solanaClient.connection
       setAdapter({
@@ -191,7 +200,7 @@ export const useCoinflowAdapter = ({
       })
     }
     initWallet()
-  }, [audiusBackend, audiusSdk, dispatch, onSuccess, onFailure])
+  }, [audiusBackend, audiusSdk, dispatch, onSuccess, onFailure, privateKey])
 
   return adapter
 }

--- a/packages/common/src/services/audius-backend/solana.ts
+++ b/packages/common/src/services/audius-backend/solana.ts
@@ -1,5 +1,4 @@
 import { AudiusSdk } from '@audius/sdk'
-import { AudiusLibs } from '@audius/sdk-legacy/dist/libs'
 import { u8 } from '@solana/buffer-layout'
 import {
   Account,
@@ -73,13 +72,12 @@ const delay = (ms: number) =>
 /**
  * Gets a Solana wallet derived from the user's Hedgehog wallet
  */
-export const getRootSolanaAccount = async (
-  audiusBackendInstance: AudiusBackend
-) => {
-  const audiusLibs: AudiusLibs = await audiusBackendInstance.getAudiusLibs()
-  return audiusLibs.solanaWeb3Manager!.solanaWeb3.Keypair.fromSeed(
-    audiusLibs.Account!.hedgehog.wallet!.getPrivateKey()
-  )
+export const getRootSolanaAccount = async ({
+  privateKey
+}: {
+  privateKey: Buffer
+}) => {
+  return Keypair.fromSeed(privateKey)
 }
 
 /**
@@ -378,7 +376,11 @@ export const findAssociatedTokenAddress = async (
 export const decorateCoinflowWithdrawalTransaction = async (
   sdk: AudiusSdk,
   audiusBackendInstance: AudiusBackend,
-  { transaction, feePayer }: { transaction: Transaction; feePayer: PublicKey }
+  {
+    transaction,
+    feePayer,
+    privateKey
+  }: { transaction: Transaction; feePayer: PublicKey; privateKey: Buffer }
 ) => {
   const libs = await audiusBackendInstance.getAudiusLibsTyped()
   const solanaWeb3Manager = libs.solanaWeb3Manager!
@@ -388,7 +390,7 @@ export const decorateCoinflowWithdrawalTransaction = async (
     ethAddress,
     mint: 'USDC'
   })
-  const wallet = await getRootSolanaAccount(audiusBackendInstance)
+  const wallet = await getRootSolanaAccount({ privateKey })
   const walletUSDCTokenAccount =
     audiusBackendInstance.findAssociatedTokenAddress({
       solanaWalletKey: wallet.publicKey,

--- a/packages/common/src/store/buy-crypto/sagas.ts
+++ b/packages/common/src/store/buy-crypto/sagas.ts
@@ -257,7 +257,7 @@ function* assertRecoverySuccess({
 }
 
 function* doBuyCryptoViaSol({
-  payload: { amount, mint, provider }
+  payload: { amount, mint, provider, privateKey }
 }: ReturnType<typeof buyCryptoViaSol>) {
   // Pull from context
   const audiusBackendInstance = yield* getContext('audiusBackendInstance')
@@ -277,7 +277,7 @@ function* doBuyCryptoViaSol({
   )
 
   // Get config
-  const wallet = yield* call(getRootSolanaAccount, audiusBackendInstance)
+  const wallet = yield* call(getRootSolanaAccount, { privateKey })
   const feePayerAddress = yield* select(getFeePayer)
   const config = yield* call(getBuyCryptoRemoteConfig, mint)
   const outputToken = TOKEN_LISTING_MAP[mint.toUpperCase()]
@@ -685,10 +685,13 @@ function* doBuyCryptoViaSol({
  * output token. If we get enough of the output token after the swap, it's a
  * successful recovery.
  */
-function* recoverBuyCryptoViaSolIfNecessary() {
+function* recoverBuyCryptoViaSolIfNecessary({
+  privateKey
+}: {
+  privateKey: Buffer
+}) {
   yield* call(waitForAccount)
   // Pull from context
-  const audiusBackendInstance = yield* getContext('audiusBackendInstance')
   const getFeatureEnabled = yield* getContext('getFeatureEnabled')
   const { track, make } = yield* getContext('analytics')
   const reportToSentry = yield* getContext('reportToSentry')
@@ -727,7 +730,7 @@ function* recoverBuyCryptoViaSolIfNecessary() {
   )
 
   // Get config
-  const wallet = yield* call(getRootSolanaAccount, audiusBackendInstance)
+  const wallet = yield* call(getRootSolanaAccount, { privateKey })
   const sdk = yield* getSDK()
   const connection = sdk.services.solanaClient.connection
   const feePayerAddress = yield* waitForValue(getFeePayer)

--- a/packages/common/src/store/buy-crypto/slice.ts
+++ b/packages/common/src/store/buy-crypto/slice.ts
@@ -19,6 +19,10 @@ type BuyCryptoPayload = {
    * The service used to purchase the SOL necessary
    */
   provider: OnRampProvider
+  /**
+   * The private key of the user's wallet
+   */
+  privateKey: Buffer
 }
 
 type BuyCryptoState = {}

--- a/packages/common/src/store/buy-usdc/sagas.ts
+++ b/packages/common/src/store/buy-usdc/sagas.ts
@@ -315,7 +315,7 @@ function* doBuyUSDC({
         if (!feePayerAddress) {
           throw new Error('Missing feePayer unexpectedly')
         }
-        const rootAccount = yield* call(getRootSolanaAccount)
+        const rootAccount = yield* call(getRootSolanaAccount, { privateKey })
 
         const amount = desiredAmount / 100.0
         // Send the USDC through the payment router, sans purchase memo, and
@@ -409,7 +409,7 @@ function* doBuyUSDC({
   }
 }
 
-function* recoverPurchaseIfNecessary() {
+function* recoverPurchaseIfNecessary({ privateKey }: { privateKey: Buffer }) {
   yield* waitForRead()
   const hasAccount = yield* select(getHasAccount)
   if (!hasAccount) return
@@ -420,7 +420,7 @@ function* recoverPurchaseIfNecessary() {
   const sdk = yield* getSDK()
 
   try {
-    const rootAccount = yield* call(getRootSolanaAccount, audiusBackendInstance)
+    const rootAccount = yield* call(getRootSolanaAccount, { privateKey })
 
     const usdcTokenAccount = yield* call(
       findAssociatedTokenAddress,

--- a/packages/common/src/store/buy-usdc/sagas.ts
+++ b/packages/common/src/store/buy-usdc/sagas.ts
@@ -231,7 +231,8 @@ function* transferStep({
 function* doBuyUSDC({
   payload: {
     vendor,
-    purchaseInfo: { desiredAmount }
+    purchaseInfo: { desiredAmount },
+    privateKey
   }
 }: ReturnType<typeof onrampOpened>) {
   const reportToSentry = yield* getContext('reportToSentry')
@@ -241,7 +242,7 @@ function* doBuyUSDC({
   const sdk = yield* getSDK()
 
   const userBank = yield* getOrCreateUSDCUserBank()
-  const rootAccount = yield* call(getRootSolanaAccount, audiusBackendInstance)
+  const rootAccount = yield* call(getRootSolanaAccount, { privateKey })
 
   try {
     if (desiredAmount < config.minUSDCPurchaseAmountCents) {
@@ -314,10 +315,7 @@ function* doBuyUSDC({
         if (!feePayerAddress) {
           throw new Error('Missing feePayer unexpectedly')
         }
-        const rootAccount = yield* call(
-          getRootSolanaAccount,
-          audiusBackendInstance
-        )
+        const rootAccount = yield* call(getRootSolanaAccount)
 
         const amount = desiredAmount / 100.0
         // Send the USDC through the payment router, sans purchase memo, and

--- a/packages/common/src/store/buy-usdc/slice.ts
+++ b/packages/common/src/store/buy-usdc/slice.ts
@@ -42,6 +42,7 @@ const slice = createSlice({
       action: PayloadAction<{
         purchaseInfo: PurchaseInfo
         vendor: PurchaseVendor
+        privateKey: Buffer
       }>
     ) => {
       state.stage = BuyUSDCStage.START

--- a/packages/common/src/store/buy-usdc/slice.ts
+++ b/packages/common/src/store/buy-usdc/slice.ts
@@ -81,7 +81,10 @@ const slice = createSlice({
     ) => {
       state.stripeSessionStatus = action.payload.status
     },
-    startRecoveryIfNecessary: () => {
+    startRecoveryIfNecessary: (
+      _state,
+      _action: PayloadAction<{ privateKey: Buffer }>
+    ) => {
       // triggers sagas
     },
     recoveryStatusChanged: (

--- a/packages/common/src/store/purchase-content/slice.ts
+++ b/packages/common/src/store/purchase-content/slice.ts
@@ -62,6 +62,7 @@ const slice = createSlice({
         contentType?: PurchaseableContentType
         onSuccess?: OnSuccess
         guestEmail?: string
+        privateKey: Buffer
       }>
     ) => {
       state.page = PurchaseContentPage.PURCHASE

--- a/packages/common/src/store/ui/withdraw-usdc/slice.ts
+++ b/packages/common/src/store/ui/withdraw-usdc/slice.ts
@@ -36,6 +36,7 @@ const slice = createSlice({
         /** Transfer amount in cents */
         amount: number
         destinationAddress: string
+        privateKey: Buffer
       }>
     ) => {
       state.withdrawStatus = Status.LOADING

--- a/packages/mobile/src/components/premium-content-purchase-drawer/PremiumContentPurchaseDrawer.tsx
+++ b/packages/mobile/src/components/premium-content-purchase-drawer/PremiumContentPurchaseDrawer.tsx
@@ -62,6 +62,7 @@ import { useIsUSDCEnabled } from 'app/hooks/useIsUSDCEnabled'
 import { useNavigation } from 'app/hooks/useNavigation'
 import { useFeatureFlag } from 'app/hooks/useRemoteConfig'
 import { make, track as trackEvent } from 'app/services/analytics'
+import { authService } from 'app/services/sdk/auth'
 import { getPurchaseVendor } from 'app/store/purchase-vendor/selectors'
 import { flexRowCentered, makeStyles } from 'app/styles'
 import { spacing } from 'app/styles/spacing'
@@ -493,12 +494,17 @@ export const PremiumContentPurchaseDrawer = () => {
     : null
 
   const price = purchaseConditions ? purchaseConditions?.usdc_purchase.price : 0
+  const privateKey = authService.getWallet()?.getPrivateKey()
+  if (!privateKey) {
+    throw new Error('No private key found - is user logged in?')
+  }
 
   const { initialValues, onSubmit, validationSchema } =
     usePurchaseContentFormConfiguration({
       metadata,
       presetValues,
-      price
+      price,
+      privateKey
     })
 
   const handleClosed = useCallback(() => {

--- a/packages/web/src/common/store/account/sagas.js
+++ b/packages/web/src/common/store/account/sagas.js
@@ -94,10 +94,10 @@ function* onSignedIn({ payload: { account } }) {
       // If not a managed account, identify the Solana wallet associated with
       // the hedgehog wallet
       try {
-        solanaWallet = (yield call(
-          getRootSolanaAccount,
-          audiusBackendInstance
-        )).publicKey.toBase58()
+        const privateKey = authService.getWallet()?.getPrivateKey()
+        solanaWallet = (yield call(getRootSolanaAccount, {
+          privateKey
+        })).publicKey.toBase58()
       } catch (e) {
         console.error('Failed to fetch Solana root wallet during identify()', e)
       }

--- a/packages/web/src/components/buy-audio-modal/components/CoinbaseBuyAudioButton.tsx
+++ b/packages/web/src/components/buy-audio-modal/components/CoinbaseBuyAudioButton.tsx
@@ -7,7 +7,6 @@ import {
   OnRampProvider
 } from '@audius/common/store'
 import { useDispatch, useSelector } from 'react-redux'
-import { useAsync } from 'react-use'
 
 import { OnRampButton } from 'components/on-ramp-button'
 import Tooltip from 'components/tooltip/Tooltip'
@@ -31,7 +30,7 @@ const messages = {
 export const CoinbaseBuyAudioButton = () => {
   const dispatch = useDispatch()
   const coinbasePay = useCoinbasePay()
-  const rootAccount = useAsync(getRootSolanaAccount)
+  const rootAccount = getRootSolanaAccount()
   const purchaseInfoStatus = useSelector(getAudioPurchaseInfoStatus)
   const purchaseInfo = useSelector(getAudioPurchaseInfo)
   const amount =
@@ -56,7 +55,7 @@ export const CoinbaseBuyAudioButton = () => {
       purchaseInfo?.isError === false
     ) {
       coinbasePay.resetParams({
-        destinationWalletAddress: rootAccount.value?.publicKey.toString(),
+        destinationWalletAddress: rootAccount.publicKey.toString(),
         presetCryptoAmount: amount,
         onSuccess: handleSuccess,
         onExit: handleExit

--- a/packages/web/src/components/buy-audio-modal/components/StripeBuyAudioButton.tsx
+++ b/packages/web/src/components/buy-audio-modal/components/StripeBuyAudioButton.tsx
@@ -11,7 +11,6 @@ import { useDispatch, useSelector } from 'react-redux'
 
 import { OnRampButton } from 'components/on-ramp-button'
 import Tooltip from 'components/tooltip/Tooltip'
-import { authService } from 'services/audius-sdk'
 import { getRootSolanaAccount } from 'services/solana/solana'
 
 import styles from './StripeBuyAudioButton.module.css'

--- a/packages/web/src/components/buy-audio-modal/components/StripeBuyAudioButton.tsx
+++ b/packages/web/src/components/buy-audio-modal/components/StripeBuyAudioButton.tsx
@@ -11,6 +11,7 @@ import { useDispatch, useSelector } from 'react-redux'
 
 import { OnRampButton } from 'components/on-ramp-button'
 import Tooltip from 'components/tooltip/Tooltip'
+import { authService } from 'services/audius-sdk'
 import { getRootSolanaAccount } from 'services/solana/solana'
 
 import styles from './StripeBuyAudioButton.module.css'
@@ -41,9 +42,8 @@ export const StripeBuyAudioButton = () => {
     }
     dispatch(onrampOpened(purchaseInfo))
     try {
-      const destinationWallet: string = (
-        await getRootSolanaAccount()
-      ).publicKey.toString()
+      const destinationWallet: string =
+        getRootSolanaAccount().publicKey.toString()
       dispatch(
         initializeStripeModal({
           amount,

--- a/packages/web/src/components/withdraw-usdc-modal/components/CoinflowWithdrawModal.tsx
+++ b/packages/web/src/components/withdraw-usdc-modal/components/CoinflowWithdrawModal.tsx
@@ -10,6 +10,7 @@ import { CoinflowWithdraw } from '@coinflowlabs/react'
 import { useDispatch, useSelector } from 'react-redux'
 
 import ModalDrawer from 'pages/audio-rewards-page/components/modals/ModalDrawer'
+import { authService } from 'services/audius-sdk'
 import { env } from 'services/env'
 import zIndex from 'utils/zIndex'
 
@@ -38,7 +39,8 @@ export const CoinflowWithdrawModal = () => {
   const { isOpen, onClose, onClosed } = useCoinflowWithdrawModal()
   const amount = useSelector(getWithdrawAmount)
 
-  const adapter = useCoinflowWithdrawalAdapter()
+  const privateKey = authService.getWallet()?.getPrivateKey()
+  const adapter = useCoinflowWithdrawalAdapter({ privateKey })
   const dispatch = useDispatch()
 
   const handleClose = useCallback(() => {

--- a/packages/web/src/store/application/ui/withdraw-usdc/sagas.ts
+++ b/packages/web/src/store/application/ui/withdraw-usdc/sagas.ts
@@ -40,10 +40,11 @@ const { set: setWithdrawUSDCModalData, close: closeWithdrawUSDCModal } =
 
 function* doWithdrawUSDCCoinflow({
   amount,
-  currentBalance
+  currentBalance,
+  privateKey
 }: Pick<
   ReturnType<typeof beginWithdrawUSDC>['payload'],
-  'amount' | 'currentBalance'
+  'amount' | 'currentBalance' | 'privateKey'
 >) {
   const { track, make } = yield* getContext('analytics')
   const sdk = yield* getSDK()
@@ -151,7 +152,7 @@ function* doWithdrawUSDCCoinflow({
           ...analyticsFields
         })
       )
-      yield* put(buyUSDCActions.startRecoveryIfNecessary())
+      yield* put(buyUSDCActions.startRecoveryIfNecessary({ privateKey }))
       // Wait for the recovery to succeed or error
       const action = yield* take<
         ReturnType<typeof buyUSDCActions.recoveryStatusChanged>
@@ -283,11 +284,15 @@ function* doWithdrawUSDCManualTransfer({
  * Handles all logic for withdrawing USDC to a given destination. Expects amount in cents.
  */
 function* doWithdrawUSDC({
-  payload: { amount, method, currentBalance, destinationAddress }
+  payload: { amount, method, currentBalance, destinationAddress, privateKey }
 }: ReturnType<typeof beginWithdrawUSDC>) {
   switch (method) {
     case WithdrawMethod.COINFLOW:
-      yield* call(doWithdrawUSDCCoinflow, { amount, currentBalance })
+      yield* call(doWithdrawUSDCCoinflow, {
+        amount,
+        currentBalance,
+        privateKey
+      })
       break
     case WithdrawMethod.MANUAL_TRANSFER:
       yield* call(doWithdrawUSDCManualTransfer, {


### PR DESCRIPTION
### Description
Migrate all calls of `getRootSolanaAccount` to use sdk.

Pass in private key from client web/mobile by getting it from the `authService`

### How Has This Been Tested?

Tested each of the 2 flows (web version and common version) and confirmed correct behavior. Did not test the buy audio or withdraw usdc flows specifically.