### PR TITLE
[C-5441] Handle sign on redirects

### DIFF
--- a/packages/web/src/components/RestrictedLink.tsx
+++ b/packages/web/src/components/RestrictedLink.tsx
@@ -1,0 +1,32 @@
+import { Link as RouterLink, LinkProps } from 'react-router-dom-v5-compat'
+
+import {
+  RestrictionType,
+  useRequiresAccountOnClick
+} from 'hooks/useRequiresAccount'
+
+export type RestrictedLinkProps = LinkProps & {
+  restriction?: RestrictionType
+  asChild?: boolean
+}
+
+export const RestrictedLink = ({
+  onClick,
+  restriction,
+  children,
+  ...props
+}: RestrictedLinkProps) => {
+  const handleClick = useRequiresAccountOnClick(
+    (e) => onClick?.(e as any),
+    [onClick],
+    undefined,
+    undefined,
+    restriction
+  )
+
+  return (
+    <RouterLink onClick={handleClick} {...props}>
+      {children}
+    </RouterLink>
+  )
+}

--- a/packages/web/src/components/SignOnLink.tsx
+++ b/packages/web/src/components/SignOnLink.tsx
@@ -1,0 +1,46 @@
+import { useCallback } from 'react'
+
+import { route } from '@audius/common/utils'
+import { useDispatch } from 'react-redux'
+import { Link, LinkProps, useLocation } from 'react-router-dom-v5-compat'
+
+import {
+  updateRouteOnCompletion,
+  updateRouteOnExit
+} from 'common/store/pages/signon/actions'
+
+const { SIGN_IN_PAGE, SIGN_UP_PAGE } = route
+
+export type SignOnLinkProps = Omit<LinkProps, 'to'> & {
+  asChild?: boolean
+  signIn?: boolean
+  signUp?: boolean
+}
+
+export const SignOnLink = ({
+  onClick,
+  children,
+  signIn = false,
+  signUp = true,
+  ...props
+}: SignOnLinkProps) => {
+  const dispatch = useDispatch()
+  const { pathname } = useLocation()
+
+  const handleClick = useCallback(
+    (e: React.MouseEvent<HTMLAnchorElement>) => {
+      dispatch(updateRouteOnCompletion(pathname))
+      dispatch(updateRouteOnExit(pathname))
+      onClick?.(e)
+    },
+    [dispatch, onClick, pathname]
+  )
+
+  const to = signIn ? SIGN_IN_PAGE : signUp ? SIGN_UP_PAGE : SIGN_UP_PAGE
+
+  return (
+    <Link to={to} onClick={handleClick} {...props}>
+      {children}
+    </Link>
+  )
+}

--- a/packages/web/src/components/link/TextLink.tsx
+++ b/packages/web/src/components/link/TextLink.tsx
@@ -1,17 +1,25 @@
-import { Ref, forwardRef, useCallback, MouseEvent } from 'react'
+import { Ref, forwardRef, useCallback, MouseEvent, ComponentType } from 'react'
 
 import { ID } from '@audius/common/models'
+import { route } from '@audius/common/utils'
 import {
   TextLink as HarmonyTextLink,
   TextLinkProps as HarmonyTextLinkProps
 } from '@audius/harmony'
 import { Link, LinkProps } from 'react-router-dom'
 
+import { RestrictedLink, RestrictedLinkProps } from 'components/RestrictedLink'
+import { SignOnLink, SignOnLinkProps } from 'components/SignOnLink'
+import { RestrictionType } from 'hooks/useRequiresAccount'
+
+const { SIGN_IN_PAGE, SIGN_UP_PAGE } = route
+
 export type LinkKind = 'track' | 'collection' | 'user' | 'mention' | 'other'
 
 export type TextLinkProps = HarmonyTextLinkProps &
   Partial<Omit<LinkProps, 'color' | 'onClick'>> & {
     stopPropagation?: boolean
+    restriction?: RestrictionType
     onClick?: (
       e: MouseEvent<HTMLAnchorElement>,
       linkKind?: LinkKind,
@@ -20,7 +28,14 @@ export type TextLinkProps = HarmonyTextLinkProps &
   }
 
 export const TextLink = forwardRef((props: TextLinkProps, ref: Ref<'a'>) => {
-  const { to, children, stopPropagation = true, onClick, ...other } = props
+  const {
+    to,
+    children,
+    stopPropagation = true,
+    onClick,
+    restriction,
+    ...other
+  } = props
 
   const handleClick = useCallback(
     (e: MouseEvent<HTMLAnchorElement>) => {
@@ -32,9 +47,30 @@ export const TextLink = forwardRef((props: TextLinkProps, ref: Ref<'a'>) => {
     [stopPropagation, onClick]
   )
 
+  let LinkComponent: ComponentType<any> = Link
+
+  let linkProps: Partial<LinkProps | RestrictedLinkProps | SignOnLinkProps> = {
+    to
+  }
+
+  if (restriction) {
+    LinkComponent = RestrictedLink
+    linkProps = { to, restriction }
+  } else if (to === SIGN_IN_PAGE) {
+    LinkComponent = SignOnLink
+    linkProps = { signIn: true }
+  } else if (to === SIGN_UP_PAGE) {
+    LinkComponent = SignOnLink
+    linkProps = { signUp: true }
+  }
+
   return (
     <HarmonyTextLink ref={ref} asChild onClick={handleClick} {...other}>
-      {to ? <Link to={to}>{children}</Link> : <span>{children}</span>}
+      {to ? (
+        <LinkComponent {...linkProps}>{children}</LinkComponent>
+      ) : (
+        <span>{children}</span>
+      )}
     </HarmonyTextLink>
   )
 })

--- a/packages/web/src/components/nav/desktop/LeftNav.tsx
+++ b/packages/web/src/components/nav/desktop/LeftNav.tsx
@@ -152,11 +152,17 @@ const LeftNav = (props: NavColumnProps) => {
               ) : null}
               <Box>
                 <GroupHeader>{messages.discover}</GroupHeader>
-                <LeftNavLink to={FEED_PAGE} disabled={!isAccountComplete}>
+                <LeftNavLink
+                  to={FEED_PAGE}
+                  disabled={!isAccountComplete}
+                  restriction='account'
+                >
                   Feed
                 </LeftNavLink>
-                <LeftNavLink to={TRENDING_PAGE}>Trending</LeftNavLink>
-                <LeftNavLink to={EXPLORE_PAGE} exact>
+                <LeftNavLink to={TRENDING_PAGE} restriction='none'>
+                  Trending
+                </LeftNavLink>
+                <LeftNavLink to={EXPLORE_PAGE} exact restriction='none'>
                   Explore
                 </LeftNavLink>
               </Box>
@@ -172,7 +178,11 @@ const LeftNav = (props: NavColumnProps) => {
                     Library
                   </LeftNavLink>
                 </LeftNavDroppable>
-                <LeftNavLink to={HISTORY_PAGE} disabled={!isAccountComplete}>
+                <LeftNavLink
+                  to={HISTORY_PAGE}
+                  disabled={!isAccountComplete}
+                  restriction='account'
+                >
                   History
                 </LeftNavLink>
               </Box>

--- a/packages/web/src/components/nav/desktop/LeftNavCTA.tsx
+++ b/packages/web/src/components/nav/desktop/LeftNavCTA.tsx
@@ -16,6 +16,7 @@ import { useDispatch, useSelector } from 'react-redux'
 import { Link } from 'react-router-dom'
 
 import { make, useRecord } from 'common/store/analytics/actions'
+import { SignOnLink } from 'components/SignOnLink'
 import { useLocalStorage } from 'hooks/useLocalStorage'
 
 const { SIGN_UP_PAGE, UPLOAD_PAGE } = route
@@ -80,7 +81,7 @@ export const LeftNavCTA = () => {
     case 'guest':
       button = (
         <Button variant='primary' size='small' asChild>
-          <Link to={SIGN_UP_PAGE}>{messages.finishSignUp}</Link>
+          <SignOnLink signUp>{messages.finishSignUp}</SignOnLink>
         </Button>
       )
       break

--- a/packages/web/src/components/premium-content-purchase-modal/PremiumContentPurchaseModal.tsx
+++ b/packages/web/src/components/premium-content-purchase-modal/PremiumContentPurchaseModal.tsx
@@ -175,15 +175,15 @@ const PremiumContentPurchaseForm = (props: PremiumContentPurchaseFormProps) => {
         />
       </ModalContentPages>
       <ModalFooter className={styles.footer}>
-        {page === PurchaseContentPageType.GUEST_CHECKOUT ? (
+        {page !== PurchaseContentPageType.GUEST_CHECKOUT ? (
           <GuestCheckoutFooter />
-        ) : page === PurchaseContentPageType.PURCHASE ? (
+        ) : page === PurchaseContentPageType.GUEST_CHECKOUT ? (
           <PurchaseContentFormFooter
             error={error}
             isUnlocking={isUnlocking}
             onViewContentClicked={onClose}
             purchaseSummaryValues={purchaseSummaryValues}
-            stage={stage}
+            stage={PurchaseContentStage.FINISH}
             metadata={metadata}
           />
         ) : null}

--- a/packages/web/src/components/premium-content-purchase-modal/components/PurchaseContentFormFooter.tsx
+++ b/packages/web/src/components/premium-content-purchase-modal/components/PurchaseContentFormFooter.tsx
@@ -14,7 +14,7 @@ import {
   collectionsSocialActions,
   usePremiumContentPurchaseModal
 } from '@audius/common/store'
-import { formatPrice, route } from '@audius/common/utils'
+import { formatPrice } from '@audius/common/utils'
 import {
   Button,
   IconCaretRight,
@@ -28,17 +28,15 @@ import {
 import { useField } from 'formik'
 import { capitalize } from 'lodash'
 import { useDispatch } from 'react-redux'
-import { Link } from 'react-router-dom-v5-compat'
 
 import { make } from 'common/store/analytics/actions'
+import { SignOnLink } from 'components/SignOnLink'
 import { TwitterShareButton } from 'components/twitter-share-button/TwitterShareButton'
 import { fullCollectionPage, fullTrackPage } from 'utils/route'
 
 import { PurchaseContentFormState } from '../hooks/usePurchaseContentFormState'
 
 import styles from './PurchaseContentFormFooter.module.css'
-
-const { SIGN_UP_PAGE } = route
 
 const messages = {
   buy: 'Buy',
@@ -130,10 +128,6 @@ export const PurchaseContentFormFooter = ({
   )
   const { onClose } = usePremiumContentPurchaseModal()
 
-  const handleClickSignUp = useCallback(() => {
-    onClose()
-  }, [onClose])
-
   const onRepost = useCallback(() => {
     dispatch(
       isReposted
@@ -165,9 +159,9 @@ export const PurchaseContentFormFooter = ({
                 </Flex>
                 <Flex gap='s'>
                   <Button fullWidth asChild>
-                    <Link to={SIGN_UP_PAGE} onClick={handleClickSignUp}>
+                    <SignOnLink signUp onClick={onClose}>
                       {messages.finishSigningUp}
-                    </Link>
+                    </SignOnLink>
                   </Button>
                   <Button
                     fullWidth

--- a/packages/web/src/hooks/useRequiresAccount.ts
+++ b/packages/web/src/hooks/useRequiresAccount.ts
@@ -16,13 +16,14 @@ import { useSelector } from 'utils/reducer'
 const { getAccountStatus, getIsAccountComplete, getHasAccount } =
   accountSelectors
 
-export type RestrictionType = 'guest' | 'account'
+export type RestrictionType = 'none' | 'guest' | 'account'
 
 const canAccess = (
   restriction: RestrictionType,
   hasAccount: boolean,
   isAccountComplete: boolean
 ): boolean => {
+  if (restriction === 'none') return true
   if (restriction === 'guest') return hasAccount
   return isAccountComplete
 }


### PR DESCRIPTION
### Description

Handles sign on redirects by ensuring all links to SIGN_IN_PAGE and SIGN_UP_PAGE properly set complete and exit routes. This is a somewhat funky way to do it, having TextLink magically know how to handle it, but open to feedback. maybe @DejayJD you can do some thinking on this one. One alternative is that we allow TextLink to do "asChild" and then we pipe in the SignOnLink. lmk.