### PR TITLE
[PAY-2937] Migrate remaining Identity off libs

### DIFF
--- a/packages/common/src/hooks/useChangePasswordFormConfiguration.ts
+++ b/packages/common/src/hooks/useChangePasswordFormConfiguration.ts
@@ -4,7 +4,8 @@ import { FormikHelpers } from 'formik'
 import { z } from 'zod'
 import { toFormikValidationSchema } from 'zod-formik-adapter'
 
-import { useAppContext } from '../context'
+import { useAudiusQueryContext } from '~/audius-query'
+
 import { confirmEmailSchema, passwordSchema } from '../schemas'
 
 const messages = {
@@ -60,7 +61,7 @@ const initialValues: ChangePasswordFormValues = {
 }
 
 export const useChangePasswordFormConfiguration = (onComplete: () => void) => {
-  const { audiusBackend } = useAppContext()
+  const { authService } = useAudiusQueryContext()
   const [page, setPage] = useState(ChangePasswordPage.ConfirmPassword)
 
   const validationSchema =
@@ -79,9 +80,8 @@ export const useChangePasswordFormConfiguration = (onComplete: () => void) => {
     ) => {
       const { oldEmail: email, password, otp } = values
       const sanitizedOtp = otp.replace(/\s/g, '')
-      const libs = await audiusBackend.getAudiusLibsTyped()
       try {
-        const confirmed = await libs.Account?.confirmCredentials({
+        const confirmed = await authService.confirmCredentials({
           email,
           username: email,
           password,
@@ -107,14 +107,13 @@ export const useChangePasswordFormConfiguration = (onComplete: () => void) => {
         }
       }
     },
-    [setPage, page, audiusBackend]
+    [setPage, page, authService]
   )
 
   const changeCredentials = useCallback(
     async (values: ChangePasswordFormValues) => {
       const { oldEmail: email, oldPassword, password } = values
-      const libs = await audiusBackend.getAudiusLibsTyped()
-      await libs.Account?.changeCredentials({
+      await authService.changeCredentials({
         newUsername: email,
         newPassword: password,
         oldUsername: email,
@@ -122,7 +121,7 @@ export const useChangePasswordFormConfiguration = (onComplete: () => void) => {
       })
       onComplete()
     },
-    [onComplete, audiusBackend]
+    [onComplete, authService]
   )
 
   const onSubmit = useCallback(

--- a/packages/common/src/services/auth/authService.ts
+++ b/packages/common/src/services/auth/authService.ts
@@ -3,7 +3,11 @@ import type { ChangeCredentialsArgs } from '@audius/hedgehog/dist/types'
 
 import type { LocalStorage } from '../local-storage'
 
-import { HedgehogConfig, createHedgehog } from './hedgehog'
+import {
+  ConfirmCredentialsArgs,
+  HedgehogConfig,
+  createHedgehog
+} from './hedgehog'
 
 export type AuthServiceConfig = {
   identityServiceEndpoint: string
@@ -40,6 +44,7 @@ export type AuthService = {
   }) => Promise<void>
   getWalletAddresses: () => Promise<GetWalletAddressesResult>
   getWallet: () => EthWallet | null
+  confirmCredentials: (args: ConfirmCredentialsArgs) => Promise<boolean>
   changeCredentials: (args: ChangeCredentialsArgs) => Promise<void>
 }
 
@@ -97,6 +102,10 @@ export const createAuthService = ({
     }
   }
 
+  const confirmCredentials = async (args: ConfirmCredentialsArgs) => {
+    return await hedgehogInstance.confirmCredentials(args)
+  }
+
   const changeCredentials = async (args: ChangeCredentialsArgs) => {
     return await hedgehogInstance.changeCredentials(args)
   }
@@ -111,6 +120,7 @@ export const createAuthService = ({
     signOut,
     getWallet,
     getWalletAddresses,
+    confirmCredentials,
     changeCredentials,
     resetPassword
   }

--- a/packages/common/src/services/auth/hedgehog.ts
+++ b/packages/common/src/services/auth/hedgehog.ts
@@ -31,13 +31,6 @@ export type ConfirmCredentialsArgs = {
 
 export type HedgehogInstance = Hedgehog & {
   generateRecoveryInfo: () => Promise<{ login: string; host: string }>
-  getLookupKey: ({
-    username,
-    password
-  }: {
-    username: string
-    password: string
-  }) => Promise<string>
   refreshWallet: () => Promise<void>
   confirmCredentials: (args: ConfirmCredentialsArgs) => Promise<boolean>
 }
@@ -169,9 +162,6 @@ export const createHedgehog = ({
       hedgehog.createKey
     )
   }
-
-  // @ts-expect-error -- adding our own custom method to hedgehog
-  hedgehog.getLookupKey = getLookupKey
 
   // @ts-expect-error -- adding our own custom method to hedgehog
   hedgehog.refreshWallet = async () => {

--- a/packages/common/src/services/auth/hedgehog.ts
+++ b/packages/common/src/services/auth/hedgehog.ts
@@ -1,4 +1,9 @@
-import { Hedgehog, WalletManager, getPlatformCreateKey } from '@audius/hedgehog'
+import {
+  EthWallet,
+  Hedgehog,
+  WalletManager,
+  getPlatformCreateKey
+} from '@audius/hedgehog'
 import type { SetAuthFn, SetUserFn, GetFn, CreateKey } from '@audius/hedgehog'
 import axios, { AxiosError, AxiosRequestConfig, AxiosResponse } from 'axios'
 import sigUtil from 'eth-sig-util'
@@ -16,6 +21,14 @@ export type HedgehogConfig = {
   createKey?: CreateKey
 }
 
+export type ConfirmCredentialsArgs = {
+  username: string
+  password: string
+  email?: string
+  otp?: string
+  softCheck?: boolean
+}
+
 export type HedgehogInstance = Hedgehog & {
   generateRecoveryInfo: () => Promise<{ login: string; host: string }>
   getLookupKey: ({
@@ -26,6 +39,7 @@ export type HedgehogInstance = Hedgehog & {
     password: string
   }) => Promise<string>
   refreshWallet: () => Promise<void>
+  confirmCredentials: (args: ConfirmCredentialsArgs) => Promise<boolean>
 }
 
 export const createHedgehog = ({
@@ -34,6 +48,18 @@ export const createHedgehog = ({
   localStorage,
   createKey = getPlatformCreateKey()
 }: HedgehogConfig): HedgehogInstance => {
+  const getAuthHeaders = async (wallet: EthWallet) => {
+    const unixTs = Math.round(new Date().getTime() / 1000) // current unix timestamp (sec)
+    const message = `Click sign to authenticate with identity service: ${unixTs}`
+    const signature = sigUtil.personalSign(wallet.getPrivateKey(), {
+      data: message
+    })
+    return {
+      [AuthHeaders.Message]: message,
+      [AuthHeaders.Signature]: signature
+    }
+  }
+
   const makeIdentityRequest = async <T = unknown>(
     axiosRequestObj: AxiosRequestConfig
   ) => {
@@ -79,15 +105,7 @@ export const createHedgehog = ({
     // Get wallet from hedgehog to use for signing, remove from params sent to identity
     const { wallet: ownerWallet, ...data } = params
 
-    const unixTs = Math.round(new Date().getTime() / 1000) // current unix timestamp (sec)
-    const message = `Click sign to authenticate with identity service: ${unixTs}`
-    const signature = sigUtil.personalSign(ownerWallet.getPrivateKey(), {
-      data: message
-    })
-    const headers = {
-      [AuthHeaders.Message]: message,
-      [AuthHeaders.Signature]: signature
-    }
+    const headers = await getAuthHeaders(ownerWallet)
 
     return await makeIdentityRequest({
       url: '/authentication',
@@ -138,8 +156,7 @@ export const createHedgehog = ({
     return recoveryInfo
   }
 
-  // @ts-expect-error -- adding our own custom method to hedgehog
-  hedgehog.getLookupKey = async ({
+  const getLookupKey = async ({
     username,
     password
   }: {
@@ -152,6 +169,9 @@ export const createHedgehog = ({
       hedgehog.createKey
     )
   }
+
+  // @ts-expect-error -- adding our own custom method to hedgehog
+  hedgehog.getLookupKey = getLookupKey
 
   // @ts-expect-error -- adding our own custom method to hedgehog
   hedgehog.refreshWallet = async () => {
@@ -173,6 +193,43 @@ export const createHedgehog = ({
     } finally {
       hedgehog.ready = true
     }
+  }
+
+  const originalConfirmCredentials = hedgehog.confirmCredentials.bind(hedgehog)
+  hedgehog.confirmCredentials = async ({
+    softCheck,
+    ...confirmCredentialsArgs
+  }: ConfirmCredentialsArgs) => {
+    if (softCheck) {
+      const lookupKey = await getLookupKey({
+        username: confirmCredentialsArgs.username,
+        password: confirmCredentialsArgs.password
+      })
+      try {
+        const wallet = hedgehog.wallet
+        if (!wallet) {
+          throw new Error(
+            'Cannot check credentials - user is not authenticated'
+          )
+        }
+        const headers = await getAuthHeaders(wallet)
+        if (headers[AuthHeaders.Message] && headers[AuthHeaders.Signature]) {
+          return await makeIdentityRequest({
+            url: '/authentication/check',
+            method: 'GET',
+            headers,
+            params: { lookupKey }
+          })
+        } else {
+          throw new Error(
+            'Cannot check credentials - user is not authenticated'
+          )
+        }
+      } catch (e) {
+        return false
+      }
+    }
+    return await originalConfirmCredentials(confirmCredentialsArgs)
   }
 
   return hedgehog as HedgehogInstance

--- a/packages/common/src/services/auth/identity.ts
+++ b/packages/common/src/services/auth/identity.ts
@@ -25,6 +25,21 @@ type CreateStripeSessionResponse = {
   status: string
 }
 
+enum TransactionMetadataType {
+  PURCHASE_SOL_AUDIO_SWAP = 'PURCHASE_SOL_AUDIO_SWAP'
+}
+
+type InAppAudioPurchaseMetadata = {
+  discriminator: TransactionMetadataType.PURCHASE_SOL_AUDIO_SWAP
+  usd: string
+  sol: string
+  audio: string
+  purchaseTransactionId: string
+  setupTransactionId?: string
+  swapTransactionId: string
+  cleanupTransactionId?: string
+}
+
 export type IdentityServiceConfig = {
   identityServiceEndpoint: string
   audiusWalletClient: AudiusWalletClient
@@ -224,6 +239,33 @@ export class IdentityService {
     return await this._makeRequest({
       url: '/record_ip',
       method: 'post',
+      headers
+    })
+  }
+
+  async getUserBankTransactionMetadata(transactionId: string) {
+    const headers = await this._getSignatureHeaders()
+
+    const metadatas = await this._makeRequest<
+      Array<{ metadata: InAppAudioPurchaseMetadata }>
+    >({
+      url: `/transaction_metadata?id=${transactionId}`,
+      method: 'get',
+      headers
+    })
+    return metadatas[0]?.metadata ?? null
+  }
+
+  async saveUserBankTransactionMetadata(data: {
+    transactionSignature: string
+    metadata: InAppAudioPurchaseMetadata
+  }) {
+    const headers = await this._getSignatureHeaders()
+
+    return await this._makeRequest({
+      url: '/transaction_metadata',
+      method: 'post',
+      data,
       headers
     })
   }

--- a/packages/web/src/common/store/change-password/sagas.ts
+++ b/packages/web/src/common/store/change-password/sagas.ts
@@ -3,7 +3,7 @@ import { changePasswordActions, getContext } from '@audius/common/store'
 import { call, put, takeEvery } from 'typed-redux-saga'
 
 import { make, TrackEvent } from 'common/store/analytics/actions'
-import { waitForWrite } from 'utils/sagaHelpers'
+
 const {
   confirmCredentials,
   confirmCredentialsSucceeded,
@@ -17,17 +17,15 @@ function* handleConfirmCredentials(
   action: ReturnType<typeof confirmCredentials>
 ) {
   const { email, password } = action.payload
-  const audiusBackendInstance = yield* getContext('audiusBackendInstance')
-  const libs = yield* call([
-    audiusBackendInstance,
-    audiusBackendInstance.getAudiusLibsTyped
-  ])
-  yield* call(waitForWrite)
+  const authService = yield* getContext('authService')
   try {
-    const confirmed = yield* call(libs.Account!.confirmCredentials, {
-      username: email,
-      password
-    })
+    const confirmed = yield* call(
+      [authService, authService.confirmCredentials],
+      {
+        username: email,
+        password
+      }
+    )
     if (!confirmed) {
       yield* put(confirmCredentialsFailed())
     } else {
@@ -40,14 +38,9 @@ function* handleConfirmCredentials(
 
 function* handleChangePassword(action: ReturnType<typeof changePassword>) {
   const { email, password, oldPassword } = action.payload
-  const audiusBackendInstance = yield* getContext('audiusBackendInstance')
-  const libs = yield* call([
-    audiusBackendInstance,
-    audiusBackendInstance.getAudiusLibsTyped
-  ])
-  yield* call(waitForWrite)
+  const authService = yield* getContext('authService')
   try {
-    yield* call(libs.Account!.changeCredentials, {
+    yield* call([authService, authService.changeCredentials], {
       newUsername: email,
       newPassword: password,
       oldUsername: email,

--- a/packages/web/src/common/store/pages/audio-transactions/sagas.ts
+++ b/packages/web/src/common/store/pages/audio-transactions/sagas.ts
@@ -15,7 +15,6 @@ import {
   waitForRead
 } from '@audius/common/utils'
 import { full } from '@audius/sdk'
-import { AudiusLibs } from '@audius/sdk-legacy/dist/libs'
 import { call, takeLatest, put } from 'typed-redux-saga'
 
 import { fetchUsers } from 'common/store/cache/users/sagas'
@@ -151,13 +150,9 @@ function* fetchTransactionMetadata() {
       if (txDetails.transactionType !== TransactionType.PURCHASE) {
         return
       }
-      const audiusBackendInstance = yield* getContext('audiusBackendInstance')
-      const libs: AudiusLibs = yield* call(audiusBackendInstance.getAudiusLibs)
+      const identityService = yield* getContext('identityService')
       const response = yield* call(
-        [
-          libs.identityService!,
-          libs.identityService!.getUserBankTransactionMetadata
-        ],
+        [identityService, identityService.getUserBankTransactionMetadata],
         txDetails.signature
       )
       yield put(

--- a/packages/web/src/services/audius-backend/BuyAudio.ts
+++ b/packages/web/src/services/audius-backend/BuyAudio.ts
@@ -1,5 +1,4 @@
 import { MEMO_PROGRAM_ID } from '@audius/common/services'
-import { InAppAudioPurchaseMetadata } from '@audius/common/store'
 import {
   TokenAccountNotFoundError,
   createTransferCheckedInstruction,
@@ -245,25 +244,4 @@ export const createTransferToUserBankTransaction = async ({
     })
   )
   return tx
-}
-
-export const saveUserBankTransactionMetadata = async ({
-  transactionSignature,
-  metadata
-}: {
-  transactionSignature: string
-  metadata: InAppAudioPurchaseMetadata
-}) => {
-  const libs = await getLibs()
-  return await libs.identityService!.saveUserBankTransactionMetadata({
-    transactionSignature,
-    metadata
-  })
-}
-
-export const getUserBankTransactionMetadata = async (transactionId: string) => {
-  const libs = await getLibs()
-  return await libs.identityService!.getUserBankTransactionMetadata(
-    transactionId
-  )
 }


### PR DESCRIPTION
### Description
This takes care of the remaining references to libs.identityService and _most_ of the references to libs.Account.
There is one gnarly Account reference for root solana wallets that should be its own PR, and `searchTags` is going to need some additional work to expose in the SDK.

### How Has This Been Tested?
Local client against local stack to verify password operations.
