### PR TITLE
[PAY-3687] Fix updateCreator wallets issue

### DIFF
--- a/packages/common/src/services/audius-backend/AudiusBackend.ts
+++ b/packages/common/src/services/audius-backend/AudiusBackend.ts
@@ -768,12 +768,11 @@ export const audiusBackend = ({
     })
     // @ts-ignore when writing data, this type is expected to contain a signature
     newMetadata.associated_wallets =
-      newMetadata.associated_wallets || associatedWallets?.associated_wallets
+      newMetadata.associated_wallets ?? associatedWallets?.associated_wallets
     // @ts-ignore when writing data, this type is expected to contain a signature
     newMetadata.associated_sol_wallets =
-      newMetadata.associated_sol_wallets ||
+      newMetadata.associated_sol_wallets ??
       associatedWallets?.associated_sol_wallets
-
     try {
       newMetadata = schemas.newUserMetadata(newMetadata, true)
       const userId = newMetadata.user_id

--- a/packages/common/src/store/account/sagas.ts
+++ b/packages/common/src/store/account/sagas.ts
@@ -58,6 +58,7 @@ export function* fetchAccountAsync({ isSignUp = false }): SagaIterator {
   const remoteConfigInstance = yield* getContext('remoteConfigInstance')
   const authService = yield* getContext('authService')
   const audiusBackendInstance = yield* getContext('audiusBackendInstance')
+  const sdk = yield* getSDK()
   const accountStatus = yield* select(accountSelectors.getAccountStatus)
   // Don't revert successful local account fetch
   if (accountStatus !== Status.SUCCESS) {
@@ -86,6 +87,16 @@ export function* fetchAccountAsync({ isSignUp = false }): SagaIterator {
     },
     true // force refresh to get updated user w handle
   )
+  const { data: accountCidData } = yield* call(
+    [sdk.full.cidData, sdk.full.cidData.getMetadata],
+    {
+      metadataId: accountData?.user?.metadata_multihash
+    }
+  )
+  accountData.user = {
+    ...accountData.user,
+    ...(accountCidData?.data ?? {})
+  }
   if (!accountData || !accountData?.user) {
     yield* put(
       fetchAccountFailed({

--- a/packages/sdk/src/sdk/api/users/UsersApi.ts
+++ b/packages/sdk/src/sdk/api/users/UsersApi.ts
@@ -230,6 +230,13 @@ export class UsersApi extends GeneratedUsersApi {
 
     const cid = (await generateMetadataCidV1(updatedMetadata)).toString()
 
+    const {
+      associatedWallets,
+      associatedSolWallets,
+      collectibles,
+      ...indexedMetadataValues
+    } = updatedMetadata
+
     // Write metadata to chain
     return await this.entityManager.manageEntity({
       userId,
@@ -238,7 +245,13 @@ export class UsersApi extends GeneratedUsersApi {
       action: Action.UPDATE,
       metadata: JSON.stringify({
         cid,
-        data: snakecaseKeys(updatedMetadata)
+        data: {
+          ...snakecaseKeys(indexedMetadataValues),
+          // Do not snake case values that are part of cid data.
+          associated_wallets: associatedWallets,
+          associated_sol_wallets: associatedSolWallets,
+          collectibles
+        }
       }),
       ...advancedOptions
     })

--- a/packages/sdk/src/sdk/api/users/types.ts
+++ b/packages/sdk/src/sdk/api/users/types.ts
@@ -126,8 +126,12 @@ export const UpdateProfileSchema = z
         twitterHandle: z.optional(z.string()),
         instagramHandle: z.optional(z.string()),
         tiktokHandle: z.optional(z.string()),
-        associatedWallets: z.optional(CreateAssociatedWalletsSchema),
-        associatedSolWallets: z.optional(CreateAssociatedWalletsSchema)
+        associatedWallets: z.optional(
+          z.union([CreateAssociatedWalletsSchema, z.null()])
+        ),
+        associatedSolWallets: z.optional(
+          z.union([CreateAssociatedWalletsSchema, z.null()])
+        )
       })
       .strict()
   })


### PR DESCRIPTION
### Description

Fix a couple issues:
1. Null values should be allowed for these in sdk
2. We should not snake case these keys since they are collected as part of `cidData` not part of the main indexing job. This is a big TODO over the discovery codebase still
3. fetch your own account's associated wallets on load. we do not not... oops!

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._

Local vs. staging, set, removed and added wallets