### PR TITLE
[C-5520] Add guest checkout UI in purchase and sale emails

### DIFF
--- a/packages/discovery-provider/plugins/notifications/src/email/notifications/preRendered/purchase.ts
+++ b/packages/discovery-provider/plugins/notifications/src/email/notifications/preRendered/purchase.ts
@@ -1,3 +1,5 @@
+import { getHostname } from '../../../utils/env'
+
 type PurchaseEmailConfig = {
   purchaserEmail: string
   purchaserName: string
@@ -34,6 +36,10 @@ export const email = ({
   contentLink = isGuestCheckout
     ? `${contentLink}?guestEmail=${encodeURIComponent(purchaserEmail)}`
     : contentLink
+
+  const signUpLink = `${getHostname()}/signup?guestEmail=${encodeURIComponent(
+    purchaserEmail
+  )}`
 
   return `
   <!doctype html>
@@ -806,6 +812,45 @@ export const email = ({
   <div style="line-height:24px;text-align:center;"><span style="color:#7e1bcc;font-weight:600;font-family:Inter,Arial,sans-serif;font-size:16px;line-height:24px;text-align:center;">Earned tokens will be ready to claim in 7 days!</span></div>
   </td>
   </tr>
+  ${
+    isGuestCheckout
+      ? `
+  <tr>
+  <td height="24" style="height:24px; min-height:24px; line-height:24px;"></td>
+  </tr>
+  <tr>
+  <td align="center">
+  <table cellspacing="0" cellpadding="0" border="0">
+  <tr>
+  <td style="vertical-align: middle;" align="center" width="420" class="stack-column-center">
+  <table cellspacing="0" cellpadding="0" border="0">
+  <tr>
+  <td width="420" align="center" style="vertical-align: middle;">
+  <table width="100%" border="0" cellpadding="0" cellspacing="0">
+  <tr>
+  <td style="vertical-align: middle;" align="center">
+  <div>
+  <!--[if mso]>
+                          <v:roundrect xmlns:v="urn:schemas-microsoft-com:vml" xmlns:w="urn:schemas-microsoft-com:office:word" href="${contentLink}" style="height:48px;v-text-anchor:middle;width:420px;" fillcolor="#7e1bcc"  stroke="f" arcsize="17%">
+                          <w:anchorlock/>
+                          <center style="white-space:nowrap;display:inline-block;text-align:center;color:#ffffff;font-weight:600;font-family:Inter,Arial,sans-serif;font-size:18px;">Complete Account to Claim Rewards</center>
+                          </v:roundrect>
+                      <![endif]-->
+  <a target="_blank" href="${signUpLink}" style="white-space:nowrap;background-color:#7e1bcc;border-radius:8px; display:inline-block;text-align:center;color:#ffffff;font-weight:600;font-family:Inter,Arial,sans-serif;font-size:18px;line-height:48px;width:100%; -webkit-text-size-adjust:none;mso-hide:all;box-shadow: 0px 2px 0px 0px rgba(0, 0, 0, 0.0430000014603138);">Complete Account to Claim Rewards</a>
+  </div>
+  </td>
+  </tr>
+  </table>
+  </td>
+  </tr>
+  </table>
+  </td>
+  </tr>
+  </table>
+  </td>
+  </tr>`
+      : ''
+  }
   <tr>
   <td height="16" style="height:16px; min-height:16px; line-height:16px;"></td>
   </tr>

--- a/packages/discovery-provider/plugins/notifications/src/email/notifications/preRendered/purchase.ts
+++ b/packages/discovery-provider/plugins/notifications/src/email/notifications/preRendered/purchase.ts
@@ -1,17 +1,5 @@
-export const email = ({
-  purchaserName,
-  purchaserProfileImage,
-  purchaserHandle,
-  purchaserLink,
-  contentTitle,
-  contentLink,
-  contentImage,
-  artistName,
-  price,
-  payExtra,
-  total,
-  vendor
-}: {
+type PurchaseEmailConfig = {
+  purchaserEmail: string
   purchaserName: string
   purchaserHandle: string
   purchaserProfileImage: string
@@ -24,8 +12,28 @@ export const email = ({
   payExtra: string
   total: string
   vendor: string
-}) => {
+}
+
+export const email = ({
+  purchaserEmail,
+  purchaserName,
+  purchaserProfileImage,
+  purchaserHandle,
+  purchaserLink,
+  contentTitle,
+  contentLink,
+  contentImage,
+  artistName,
+  price,
+  payExtra,
+  total,
+  vendor
+}: PurchaseEmailConfig) => {
   const copyrightYear = new Date().getFullYear().toString()
+  const isGuestCheckout = !purchaserName && !purchaserHandle
+  contentLink = isGuestCheckout
+    ? `${contentLink}?guestEmail=${encodeURIComponent(purchaserEmail)}`
+    : contentLink
 
   return `
   <!doctype html>
@@ -199,6 +207,79 @@ export const email = ({
   <td width="600">
   <table cellspacing="0" cellpadding="0" border="0">
   <tr>
+  ${
+    isGuestCheckout
+      ? `
+  <td width="584" style="vertical-align: middle; background-color:#ffffff;  border-width: 0px 0px 1px 0px; border-color:#eeedef; border-style:solid; padding-left:8px; padding-right:8px;" bgcolor="#ffffff">
+  <table width="100%" border="0" cellpadding="0" cellspacing="0">
+  <tr>
+  <td height="8" style="height:8px; min-height:8px; line-height:8px;"></td>
+  </tr>
+  <tr>
+  <td style="vertical-align: middle;" width="224"><img src="https://download.audius.co/welcome-email/Uz1cn9ptGz0zHqqougR9jczjWIzEi2.jpeg" width="224" border="0" style="max-width:224px; width: 100%;
+           height: auto; display: block;"></td>
+  <td></td>
+  <td style="vertical-align: middle;" width="120">
+  <table cellspacing="0" cellpadding="0" border="0">
+  <tr>
+  <td width="112" align="center" style="vertical-align: middle; border-radius:2px;  padding-left:4px; padding-right:4px;">
+  <table width="100%" border="0" cellpadding="0" cellspacing="0">
+  <tr>
+  <td height="4" style="height:4px; min-height:4px; line-height:4px;"></td>
+  </tr>
+  <tr>
+  <td style="vertical-align: middle;">
+  <table cellspacing="0" cellpadding="0" border="0">
+  <tr>
+  <td align="right" style="vertical-align: middle; height:32px; border-radius:2px;  padding-left:4px; padding-right:4px;">
+  <table width="100%" border="0" cellpadding="0" cellspacing="0">
+  <tr>
+  <td height="4" style="height:4px; min-height:4px; line-height:4px;"></td>
+  </tr>
+  <tr>
+  <td style="vertical-align: middle;">
+  <table cellspacing="0" cellpadding="0" border="0">
+  <tr>
+  <td style="vertical-align: middle;  ">
+  <table width="100%" border="0" cellpadding="0" cellspacing="0">
+  <tr>
+  <td style="vertical-align: middle;"><a target="_blank" href="https://twitter.com/audius"><img src="https://download.audius.co/welcome-email/wD4gGCdHNNWPmqcVaVODlWgVaMF632.png" width="24" border="0" style="min-width:24px; width:24px;
+           height: auto; display: block;"></a></td>
+  <td style="width:16px; min-width:16px;" width="16"></td>
+  <td style="vertical-align: middle;"><a target="_blank" href="https://www.instagram.com/audius/"><img src="https://download.audius.co/welcome-email/34rb0mOMe83vV5t7IykMNFM0HPwsSP.png" width="24" border="0" style="min-width:24px; width:24px;
+           height: auto; display: block;"></a></td>
+  <td style="width:16px; min-width:16px;" width="16"></td>
+  <td style="vertical-align: middle;"><a target="_blank" href="https://tiktok.com/@audius"><img src="https://download.audius.co/welcome-email/11MnDiUVzMuQyikvAHjRMkEOd2Dt7c.png" width="24" border="0" style="min-width:24px; width:24px;
+           height: auto; display: block;"></a></td>
+  <td style="width:16px; min-width:16px;" width="16"></td>
+  <td style="vertical-align: middle;"><a target="_blank" href="https://www.youtube.com/@AudiusMusic"><img src="https://download.audius.co/welcome-email/zTUTTlgXyRIkRgqgJ59JSs6QGkV2K2.png" width="24" border="0" style="min-width:24px; width:24px;
+           height: auto; display: block;"></a></td>
+  </tr>
+  </table>
+  </td>
+  </tr>
+  </table>
+  </td>
+  </tr>
+  <tr>
+  <td height="4" style="height:4px; min-height:4px; line-height:4px;"></td>
+  </tr>
+  </table>
+  </td>
+  </tr>
+  </table>
+  </td>
+  </tr>
+  </table>
+  </td>
+  </tr>
+  <tr>
+  <td height="8" style="height:8px; min-height:8px; line-height:8px;"></td>
+  </tr>
+  </table>
+  </td>
+  `
+      : `
   <td width="584" align="center" style="vertical-align: middle; background-color:#ffffff;   padding-left:8px; padding-right:8px;" bgcolor="#ffffff">
   <table border="0" cellpadding="0" cellspacing="0">
   <tr>
@@ -246,9 +327,6 @@ export const email = ({
   </tr>
   </table>
   </td>
-  </tr>
-  </table>
-  </td>
   <td style="width:8px; min-width:8px;" width="8"></td>
   <td style="vertical-align: middle;" width="72" align="center"><img src="https://download.audius.co/emails/buyer-purchase/cn8ecktD4fYygNBxvMaBLVTugyAdxf.jpeg" width="72" border="0" style="min-width:72px; width:72px;
           height: auto; display: block;"></td>
@@ -258,6 +336,8 @@ export const email = ({
   </tr>
   </table>
   </td>
+  `
+  }
   </tr>
   </table>
   </td>
@@ -381,6 +461,9 @@ export const email = ({
   </table>
   </td>
   </tr>
+  </table>
+  </td>
+  </tr>
   <tr>
   <td height="24" style="height:24px; min-height:24px; line-height:24px;"></td>
   </tr>
@@ -404,6 +487,9 @@ export const email = ({
                       <![endif]-->
   <a target="_blank" href="${contentLink}" style="white-space:nowrap;background-color:#7e1bcc;border-radius:8px; display:inline-block;text-align:center;color:#ffffff;font-weight:600;font-family:Inter,Arial,sans-serif;font-size:18px;line-height:48px;width:100%; -webkit-text-size-adjust:none;mso-hide:all;box-shadow: 0px 2px 0px 0px rgba(0, 0, 0, 0.0430000014603138);">Listen On Audius</a>
   </div>
+  </td>
+  </tr>
+  </table>
   </td>
   </tr>
   </table>
@@ -691,9 +777,6 @@ export const email = ({
   </table>
   </td>
   </tr>
-  </table>
-  </td>
-  </tr>
   <tr>
   <td height="24" style="height:24px; min-height:24px; line-height:24px;"></td>
   </tr>
@@ -741,14 +824,8 @@ export const email = ({
   </table>
   </td>
   </tr>
-  </table>
-  </td>
-  </tr>
   <tr>
   <td height="24" style="height:24px; min-height:24px; line-height:24px;"></td>
-  </tr>
-  </table>
-  </td>
   </tr>
   </table>
   </td>

--- a/packages/discovery-provider/plugins/notifications/src/email/notifications/preRendered/sale.ts
+++ b/packages/discovery-provider/plugins/notifications/src/email/notifications/preRendered/sale.ts
@@ -29,6 +29,8 @@ export const email = ({
 }) => {
   const copyrightYear = new Date().getFullYear().toString()
 
+  const isGuestCheckout = !purchaserName
+
   return `
   <!doctype html>
   <html lang="en" xmlns="http://www.w3.org/1999/xhtml" xmlns:v="urn:schemas-microsoft-com:vml" xmlns:o="urn:schemas-microsoft-com:office:office">
@@ -301,7 +303,11 @@ export const email = ({
   </tr>
   <tr>
   <td style="vertical-align: middle;">
-  <div style="line-height:24px;text-align:left;"><span style="color:#52505f;font-family:Inter,Arial,sans-serif;font-size:16px;line-height:24px;text-align:left;">Congratulations! </span><a href="${purchaserLink}" target="_blank"><span style="color:#cc0fe0;font-family:Inter,Arial,sans-serif;font-size:16px;line-height:24px;text-align:left;">${purchaserName}</span></a><span style="color:#52505f;font-family:Inter,Arial,sans-serif;font-size:16px;line-height:24px;text-align:left;"> just purchased your ${contentType} </span><a href="${contentLink}" target="_blank"><span style="color:#cc0fe0;font-family:Inter,Arial,sans-serif;font-size:16px;line-height:24px;text-align:left;">${contentTitle} </span></a><span style="color:#52505f;font-family:Inter,Arial,sans-serif;font-size:16px;line-height:24px;text-align:left;">on Audius!</span></div>
+  <div style="line-height:24px;text-align:left;"><span style="color:#52505f;font-family:Inter,Arial,sans-serif;font-size:16px;line-height:24px;text-align:left;">Congratulations! </span>${
+    isGuestCheckout
+      ? `<span style="color:#52505f;font-family:Inter,Arial,sans-serif;font-size:16px;line-height:24px;text-align:left;">Someone</span>`
+      : `<a href="${purchaserLink}" target="_blank"><span style="color:#cc0fe0;font-family:Inter,Arial,sans-serif;font-size:16px;line-height:24px;text-align:left;">${purchaserName}</span></a>`
+  }<span style="color:#52505f;font-family:Inter,Arial,sans-serif;font-size:16px;line-height:24px;text-align:left;"> just purchased your ${contentType} </span><a href="${contentLink}" target="_blank"><span style="color:#cc0fe0;font-family:Inter,Arial,sans-serif;font-size:16px;line-height:24px;text-align:left;">${contentTitle} </span></a><span style="color:#52505f;font-family:Inter,Arial,sans-serif;font-size:16px;line-height:24px;text-align:left;">on Audius!</span></div>
   </td>
   </tr>
   <tr>

--- a/packages/discovery-provider/plugins/notifications/src/processNotifications/mappers/usdcPurchaseBuyer.ts
+++ b/packages/discovery-provider/plugins/notifications/src/processNotifications/mappers/usdcPurchaseBuyer.ts
@@ -164,11 +164,14 @@ export class USDCPurchaseBuyer extends BaseNotification<USDCPurchaseBuyerRow> {
       await this.incrementBadgeCount(this.notificationReceiverUserId)
     }
 
+    const purchaserEmail = userNotificationSettings.getUserEmail(
+      this.notificationReceiverUserId
+    )
+
     await sendTransactionalEmail({
-      email: userNotificationSettings.getUserEmail(
-        this.notificationReceiverUserId
-      ),
+      email: purchaserEmail,
       html: email({
+        purchaserEmail,
         purchaserName: purchaserUsername,
         purchaserProfileImage: formatImageUrl(
           purchaserProfilePictureSizes,


### PR DESCRIPTION
### Description

Updates purchase email to handle guest checkout:
<img width="612" alt="image" src="https://github.com/user-attachments/assets/e6370dc1-3f85-40bb-9d99-fd8de7f4ca11" />

The content link: https://audius.co/luna/midnight-waves?guestEmail=guest%40test.com
The finish account link: https://audius.co/signup?guestEmail=guest%40test.com

Updates sale email to handle guest checkout:
<img width="612" alt="image" src="https://github.com/user-attachments/assets/d779b9c8-eeb0-4f10-93ae-d0a883f44ae1" />
