### PR TITLE
Make getKeypair async since hedgehog init is async

### DIFF
--- a/packages/common/src/hooks/useCoinflowAdapter.ts
+++ b/packages/common/src/hooks/useCoinflowAdapter.ts
@@ -51,7 +51,7 @@ export const useCoinflowWithdrawalAdapter = () => {
 
   useEffect(() => {
     const initWallet = async () => {
-      const wallet = solanaWalletService.getKeypair()
+      const wallet = await solanaWalletService.getKeypair()
       const sdk = await audiusSdk()
       const connection = sdk.services.solanaClient.connection
 
@@ -159,7 +159,7 @@ export const useCoinflowAdapter = ({
 
   useEffect(() => {
     const initWallet = async () => {
-      const wallet = solanaWalletService.getKeypair()
+      const wallet = await solanaWalletService.getKeypair()
       const sdk = await audiusSdk()
       const connection = sdk.services.solanaClient.connection
       if (!wallet) {

--- a/packages/common/src/services/solana/createHedgehogSolanaWalletService.ts
+++ b/packages/common/src/services/solana/createHedgehogSolanaWalletService.ts
@@ -5,10 +5,11 @@ import { HedgehogInstance } from '../auth/hedgehog'
 import { SolanaWalletService } from './types'
 
 export const createHedgehogSolanaWalletService = (
-  hedghog: HedgehogInstance
+  hedgehog: HedgehogInstance
 ): SolanaWalletService => {
-  const getKeypair = () => {
-    const hedgehogWallet = hedghog.getWallet()
+  const getKeypair = async () => {
+    await hedgehog.waitUntilReady()
+    const hedgehogWallet = hedgehog.getWallet()
     if (!hedgehogWallet) {
       return null
     }

--- a/packages/common/src/services/solana/types.ts
+++ b/packages/common/src/services/solana/types.ts
@@ -1,5 +1,5 @@
 import { Keypair } from '@solana/web3.js'
 
 export type SolanaWalletService = {
-  getKeypair: () => Keypair | null
+  getKeypair: () => Promise<Keypair | null>
 }

--- a/packages/web/src/components/buy-audio-modal/components/CoinbaseBuyAudioButton.tsx
+++ b/packages/web/src/components/buy-audio-modal/components/CoinbaseBuyAudioButton.tsx
@@ -49,12 +49,12 @@ export const CoinbaseBuyAudioButton = () => {
     dispatch(onrampSucceeded())
   }, [dispatch])
 
-  const handleClick = useCallback(() => {
+  const handleClick = useCallback(async () => {
     if (
       purchaseInfoStatus === Status.SUCCESS &&
       purchaseInfo?.isError === false
     ) {
-      const rootAccount = solanaWalletService.getKeypair()
+      const rootAccount = await solanaWalletService.getKeypair()
       if (!rootAccount) {
         console.error('CoinbaseBuyAudioButton: Missing solana root account')
         return

--- a/packages/web/src/components/buy-audio-modal/components/StripeBuyAudioButton.tsx
+++ b/packages/web/src/components/buy-audio-modal/components/StripeBuyAudioButton.tsx
@@ -42,7 +42,7 @@ export const StripeBuyAudioButton = () => {
     }
     dispatch(onrampOpened(purchaseInfo))
     try {
-      const rootWallet = solanaWalletService.getKeypair()
+      const rootWallet = await solanaWalletService.getKeypair()
       if (!rootWallet) {
         console.error('StripeBuyAudioButton: Missing solana root wallet')
         return


### PR DESCRIPTION
### Description
Hedgehog initialization is asynchronous. If we end up calling `getKeypair` very quickly at app startup, it will return `null` because we don't have the wallet yet. This change leverages the wait functionality built into Hedgehog to make sure it's ready before we attempt to read the wallet.

### How Has This Been Tested?
Local client against staging.
