### PR TITLE
[PAY-3676] Expand audio mime types accepted by sdk

### DIFF
--- a/.changeset/dirty-berries-mix.md
+++ b/.changeset/dirty-berries-mix.md
@@ -1,0 +1,5 @@
+---
+'@audius/sdk': patch
+---
+
+Expand accepted audio mimemtypes to audio/\*

--- a/packages/sdk/src/sdk/types/File.ts
+++ b/packages/sdk/src/sdk/types/File.ts
@@ -57,16 +57,7 @@ export const ALLOWED_IMAGE_MIME_TYPES = [
   'image/webp'
 ]
 
-export const ALLOWED_AUDIO_MIME_TYPES = [
-  'audio/mpeg',
-  'audio/mp3',
-  'audio/aiff',
-  'audio/flac',
-  'audio/x-flac',
-  'audio/ogg',
-  'audio/wav',
-  'audio/vnd.wave'
-]
+export const ALLOWED_AUDIO_MIME_TYPES_REGEX = /audio\/.+/
 
 const getFileType = async (file: CrossPlatformFile) => {
   if (isNativeFile(file)) {
@@ -94,5 +85,5 @@ export const ImageFile = CrossPlatformFileSchema.refine(async (file) => {
 
 export const AudioFile = CrossPlatformFileSchema.refine(async (file) => {
   const fileType = await getFileType(file)
-  return fileType && ALLOWED_AUDIO_MIME_TYPES.includes(fileType.mime)
-}, `Audio file has invalid file type. Supported file types are: ${ALLOWED_AUDIO_MIME_TYPES.join(', ')}`)
+  return fileType && ALLOWED_AUDIO_MIME_TYPES_REGEX.test(fileType.mime)
+}, `Audio file has invalid file type. Supported file types are: audio/*`)


### PR DESCRIPTION
### Description
SDK was restricting the valid audio mime types to a small set. However our file pickers on web & mobile allowed the larger set of `audio/*` and mediorum (ffmpeg) also is generally able to handle all audio files. 

This change expands the accepted audio mime types in sdk to `audio/*` and matches the previous libs behavior

### How Has This Been Tested?

Tested uploading on mobile & web with various file types
