### PR TITLE
[C-5505] Fix default track field visibility

### DIFF
--- a/packages/web/src/common/store/cache/tracks/utils/reformat.ts
+++ b/packages/web/src/common/store/cache/tracks/utils/reformat.ts
@@ -41,7 +41,8 @@ const setFieldVisibility = <T extends TrackMetadata>(track: T) => {
         mood: true,
         tags: true,
         share: true,
-        play_count: true
+        play_count: true,
+        remixes: true
       }
     }
   }


### PR DESCRIPTION
### Description
Fix default/fallback field visibility so that remix is not null and the form does not show error before edits have been made

### How Has This Been Tested?
Manually tested
