### PR TITLE
[PAY-3692] [PAY-3650] Use generate_preview endpoint to improve editing of track previews

### DIFF
--- a/.changeset/modern-geckos-enjoy.md
+++ b/.changeset/modern-geckos-enjoy.md
@@ -1,0 +1,5 @@
+---
+'@audius/sdk': minor
+---
+
+Add generatePreview and delete editFile in Storage

--- a/.changeset/spicy-kiwis-argue.md
+++ b/.changeset/spicy-kiwis-argue.md
@@ -1,0 +1,5 @@
+---
+'@audius/sdk': minor
+---
+
+Rename `transcodePreview` -> `generatePreview` in the updateTrack params

--- a/packages/sdk/src/sdk/api/albums/AlbumsApi.test.ts
+++ b/packages/sdk/src/sdk/api/albums/AlbumsApi.test.ts
@@ -142,7 +142,6 @@ describe('AlbumsApi', () => {
     albums = new AlbumsApi(
       new Configuration(),
       new Storage({
-        audiusWalletClient,
         storageNodeSelector,
         logger: new Logger()
       }),

--- a/packages/sdk/src/sdk/api/playlists/PlaylistsApi.test.ts
+++ b/packages/sdk/src/sdk/api/playlists/PlaylistsApi.test.ts
@@ -121,7 +121,6 @@ describe('PlaylistsApi', () => {
     playlists = new PlaylistsApi(
       new Configuration(),
       new Storage({
-        audiusWalletClient,
         storageNodeSelector,
         logger: new Logger()
       }),

--- a/packages/sdk/src/sdk/api/tracks/TrackUploadHelper.ts
+++ b/packages/sdk/src/sdk/api/tracks/TrackUploadHelper.ts
@@ -66,11 +66,13 @@ export class TrackUploadHelper extends BaseAPI {
       ...trackMetadata,
       trackSegments: [],
       trackCid: audioResponse.results['320'],
-      previewCid: trackMetadata.previewStartSeconds
-        ? audioResponse.results[
-            `320_preview|${trackMetadata.previewStartSeconds}`
-          ]
-        : trackMetadata.previewCid,
+      previewCid:
+        trackMetadata.previewStartSeconds !== undefined &&
+        trackMetadata.previewStartSeconds !== null
+          ? audioResponse.results[
+              `320_preview|${trackMetadata.previewStartSeconds}`
+            ]
+          : trackMetadata.previewCid,
       origFileCid: audioResponse.orig_file_cid,
       origFilename: audioResponse.orig_filename || trackMetadata.origFilename,
       audioUploadId: audioResponse.id,
@@ -88,7 +90,10 @@ export class TrackUploadHelper extends BaseAPI {
 
   public extractMediorumUploadOptions(metadata: PlaylistTrackMetadata) {
     const uploadOptions: { [key: string]: string } = {}
-    if (metadata.previewStartSeconds) {
+    if (
+      metadata.previewStartSeconds !== undefined &&
+      metadata.previewStartSeconds !== null
+    ) {
       uploadOptions.previewStartSeconds =
         metadata.previewStartSeconds.toString()
     }

--- a/packages/sdk/src/sdk/api/tracks/TracksApi.test.ts
+++ b/packages/sdk/src/sdk/api/tracks/TracksApi.test.ts
@@ -116,7 +116,6 @@ describe('TracksApi', () => {
       new Configuration(),
       new DiscoveryNodeSelector(),
       new Storage({
-        audiusWalletClient,
         storageNodeSelector,
         logger: new Logger()
       }),

--- a/packages/sdk/src/sdk/api/tracks/types.ts
+++ b/packages/sdk/src/sdk/api/tracks/types.ts
@@ -241,7 +241,7 @@ export const createUpdateTrackSchema = () =>
       userId: HashId,
       trackId: HashId,
       metadata: createUploadTrackMetadataSchema().strict().partial(),
-      transcodePreview: z.optional(z.boolean()),
+      generatePreview: z.optional(z.boolean()),
       coverArtFile: z.optional(ImageFile),
       onProgress: z.optional(z.function())
     })

--- a/packages/sdk/src/sdk/api/users/UsersApi.test.ts
+++ b/packages/sdk/src/sdk/api/users/UsersApi.test.ts
@@ -97,7 +97,6 @@ describe('UsersApi', () => {
     users = new UsersApi(
       new Configuration(),
       new Storage({
-        audiusWalletClient,
         storageNodeSelector,
         logger: new Logger()
       }),

--- a/packages/sdk/src/sdk/sdk.ts
+++ b/packages/sdk/src/sdk/sdk.ts
@@ -197,7 +197,6 @@ const initializeServices = (config: SdkConfig) => {
     new Storage({
       ...getDefaultStorageServiceConfig(servicesConfig),
       storageNodeSelector,
-      audiusWalletClient,
       logger
     })
 

--- a/packages/sdk/src/sdk/services/Storage/types.ts
+++ b/packages/sdk/src/sdk/services/Storage/types.ts
@@ -1,5 +1,4 @@
 import type { CrossPlatformFile as File } from '../../types/File'
-import type { AudiusWalletClient } from '../AudiusWalletClient'
 import type { LoggerService } from '../Logger'
 import type { StorageNodeSelectorService } from '../StorageNodeSelector'
 
@@ -15,7 +14,6 @@ export type StorageServiceConfig = Partial<StorageServiceConfigInternal> & {
    * The StorageNodeSelector service used to get the relevant storage node for content
    */
   storageNodeSelector: StorageNodeSelectorService
-  audiusWalletClient: AudiusWalletClient
 }
 
 export type ProgressHandler = (
@@ -50,13 +48,13 @@ export type StorageService = {
     template: FileTemplate
     options?: { [key: string]: string }
   }) => Promise<UploadResponse>
-  editFile: ({
-    uploadId,
-    data
+  generatePreview: ({
+    cid,
+    secondOffset
   }: {
-    uploadId: string
-    data: { [key: string]: string }
-  }) => Promise<UploadResponse>
+    cid: string
+    secondOffset: number
+  }) => Promise<string>
 }
 
 export type ProcessingStatus =

--- a/packages/web/src/common/store/cache/tracks/sagas.ts
+++ b/packages/web/src/common/store/cache/tracks/sagas.ts
@@ -231,7 +231,7 @@ function* confirmEditTrack(
 ) {
   yield* waitForWrite()
   const sdk = yield* getSDK()
-  const transcodePreview =
+  const generatePreview =
     (formFields.preview_start_seconds !== null &&
       formFields.preview_start_seconds !== undefined &&
       currentTrack.preview_start_seconds !==
@@ -262,7 +262,7 @@ function* confirmEditTrack(
             ? fileToSdk(coverArtFile, 'cover_art')
             : undefined,
           metadata: trackMetadataForUploadToSdk(formFields),
-          transcodePreview
+          generatePreview
         })
 
         const { data } = yield* call(


### PR DESCRIPTION
### Description

* use mediorum `generate_preview`
  See https://linear.app/audius/issue/PROTO-1979/editing-30s-preview
  and https://github.com/AudiusProject/audius-protocol/pull/10449
  This allows all files to have their previews edited, not just the new ones with audio_upload_id
  it also means we no longer need to sign the Storage upload and edit requests
* Fix issues with `0` preview_start_seconds in sdk
* Rename `transcodePreview` arg for updateTrack to `generatePreview`

### How Has This Been Tested?

Confirmed I can upload and edit previews properly
