### PR TITLE
Add searchTags SDK support

### DIFF
--- a/packages/discovery-provider/src/api/v1/search.py
+++ b/packages/discovery-provider/src/api/v1/search.py
@@ -11,7 +11,7 @@ from src.api.v1.helpers import (
     success_response,
 )
 from src.api.v1.models.search import search_model
-from src.queries.search_queries import search
+from src.queries.search_queries import search, search_tags
 from src.utils.redis_cache import cache
 from src.utils.redis_metrics import record_metrics
 
@@ -59,7 +59,6 @@ class FullSearch(Resource):
             "kind": args.get("kind", "all"),
             "query": args.get("query"),
             "current_user_id": current_user_id,
-            "with_users": True,
             "limit": limit,
             "offset": offset,
             "only_downloadable": False,
@@ -75,6 +74,56 @@ class FullSearch(Resource):
             "sort_method": sort_method,
         }
         resp = search(search_args)
+        return success_response(resp)
+
+
+@full_ns.route("/tags")
+class TagsSearch(Resource):
+    @record_metrics
+    @full_ns.doc(
+        id="SearchTags",
+        description="""Get Users/Tracks/Playlists/Albums that best match the provided tag""",
+        responses={200: "Success", 400: "Bad request", 500: "Server error"},
+    )
+    @full_ns.expect(full_search_parser)
+    @full_ns.marshal_with(search_full_response)
+    @cache(ttl_sec=5)
+    def get(self):
+        args = full_search_parser.parse_args()
+        offset = format_offset(args)
+        limit = format_limit(args)
+        current_user_id = get_current_user_id(args)
+        include_purchaseable = args.get("includePurchaseable")
+        genres = args.get("genre")
+        moods = args.get("mood")
+        is_verified = args.get("is_verified")
+        has_downloads = args.get("has_downloads")
+        is_purchaseable = args.get("is_purchaseable")
+        keys = args.get("key")
+        bpm_min = args.get("bpm_min")
+        bpm_max = args.get("bpm_max")
+        sort_method = args.get("sort_method")
+
+        search_args = {
+            "is_auto_complete": False,
+            "kind": args.get("kind", "all"),
+            "query": args.get("query"),
+            "current_user_id": current_user_id,
+            "limit": limit,
+            "offset": offset,
+            "only_downloadable": False,
+            "include_purchaseable": include_purchaseable,
+            "only_purchaseable": is_purchaseable,
+            "genres": genres,
+            "moods": moods,
+            "only_verified": is_verified,
+            "only_with_downloads": has_downloads,
+            "keys": keys,
+            "bpm_min": bpm_min,
+            "bpm_max": bpm_max,
+            "sort_method": sort_method,
+        }
+        resp = search_tags(search_args)
         return success_response(resp)
 
 

--- a/packages/discovery-provider/src/queries/search_es.py
+++ b/packages/discovery-provider/src/queries/search_es.py
@@ -250,7 +250,7 @@ def search_tags_es(args: dict):
     if not esclient:
         raise Exception("esclient is None")
 
-    tag_search = (args.get("query", "") or "").strip()
+    tag_search = args.get("query", "").strip()
 
     current_user_id = args.get("current_user_id")
     limit = args.get("limit", 10)
@@ -295,11 +295,13 @@ def search_tags_es(args: dict):
                     bpm_min=bpm_min,
                     bpm_max=bpm_max,
                     keys=keys,
+                    must_saved=False,
                     only_downloadable=only_downloadable,
                     only_with_downloads=only_with_downloads,
                     only_purchaseable=only_purchaseable,
                     include_purchaseable=include_purchaseable,
                     sort_method=sort_method,
+                    only_verified=only_verified,
                 ),
             ]
         )
@@ -332,6 +334,7 @@ def search_tags_es(args: dict):
                     genres=genres,
                     moods=moods,
                     sort_method=sort_method,
+                    only_verified=only_verified,
                 ),
             ]
         )
@@ -350,6 +353,7 @@ def search_tags_es(args: dict):
                     only_with_downloads=only_with_downloads,
                     only_purchaseable=only_purchaseable,
                     sort_method=sort_method,
+                    only_verified=only_verified,
                 ),
             ]
         )

--- a/packages/discovery-provider/src/queries/search_es.py
+++ b/packages/discovery-provider/src/queries/search_es.py
@@ -1,12 +1,7 @@
 import logging
 from typing import Any, Dict, Optional
 
-from src.api.v1.helpers import (
-    extend_playlist,
-    extend_track,
-    extend_user,
-    parse_bool_param,
-)
+from src.api.v1.helpers import extend_playlist, extend_track, extend_user
 from src.queries.get_feed_es import fetch_followed_saves_and_reposts, item_key
 from src.queries.query_helpers import (
     _populate_gated_content_metadata,
@@ -104,22 +99,26 @@ def search_es_full(args: dict):
     limit = args.get("limit", 10)
     offset = args.get("offset", 0)
     search_type = args.get("kind", "all")
-    is_auto_complete = args.get("is_auto_complete")
-    only_downloadable = args.get("only_downloadable", False)
-    include_purchaseable = args.get("include_purchaseable", False)
+    sort_method = args.get("sort_method", "relevant")
+
     genres = format_genres(args.get("genres", []))
     moods = format_moods(args.get("moods", []))
     bpm_min = args.get("bpm_min")
     bpm_max = args.get("bpm_max")
     keys = args.get("keys", [])
+
+    only_downloadable = args.get("only_downloadable", False)
+    include_purchaseable = args.get("include_purchaseable", False)
     only_verified = args.get("only_verified", False)
     only_with_downloads = args.get("only_with_downloads", False)
     only_purchaseable = args.get("only_purchaseable", False)
-    sort_method = args.get("sort_method", "relevant")
+
     do_tracks = search_type == "all" or search_type == "tracks"
     do_users = search_type == "all" or search_type == "users"
     do_playlists = search_type == "all" or search_type == "playlists"
     do_albums = search_type == "all" or search_type == "albums"
+
+    is_auto_complete = args.get("is_auto_complete")
 
     mdsl: Any = []
 
@@ -252,25 +251,29 @@ def search_tags_es(args: dict):
         raise Exception("esclient is None")
 
     tag_search = (args.get("query", "") or "").strip()
-    current_user_id = args.get("current_user_id", None)
+
+    current_user_id = args.get("current_user_id")
     limit = args.get("limit", 10)
     offset = args.get("offset", 0)
     search_type = args.get("kind", "all")
     sort_method = args.get("sort_method", "relevant")
 
-    genres = format_genres(args.get("genre"))
-    moods = format_moods(args.get("mood"))
+    genres = format_genres(args.get("genres", []))
+    moods = format_moods(args.get("moods", []))
     bpm_min = args.get("bpm_min")
     bpm_max = args.get("bpm_max")
-    keys = format_keys(args.get("key", []))
+    keys = args.get("keys", [])
 
-    only_downloadable = False
-    include_purchaseable = (
-        parse_bool_param(args.get("include_purchaseable", False)) or False
-    )
-    only_verified = parse_bool_param(args.get("is_verified", False)) or False
-    only_with_downloads = parse_bool_param(args.get("has_downloads", False)) or False
-    only_purchaseable = parse_bool_param(args.get("is_purchasable", False)) or False
+    only_downloadable = args.get("only_downloadable", False)
+    include_purchaseable = args.get("include_purchaseable", False)
+    only_verified = args.get("only_verified", False)
+    only_with_downloads = args.get("only_with_downloads", False)
+    only_purchaseable = args.get("only_purchaseable", False)
+
+    do_tracks = search_type == "all" or search_type == "tracks"
+    do_users = search_type == "all" or search_type == "users"
+    do_playlists = search_type == "all" or search_type == "playlists"
+    do_albums = search_type == "all" or search_type == "albums"
 
     do_tracks = search_type == "all" or search_type == "tracks"
     do_users = search_type == "all" or search_type == "users"
@@ -1181,7 +1184,7 @@ def base_playlist_dsl(
                 {
                     "script_score": {
                         "script": {
-                            "source": """ 
+                            "source": """
                                 double matchedTracks = 0;
                                 for (track in params['_source'].tracks) {
                                     if (params.moods.contains(track.mood)) {

--- a/packages/sdk/src/sdk/api/generated/full/apis/SearchApi.ts
+++ b/packages/sdk/src/sdk/api/generated/full/apis/SearchApi.ts
@@ -62,6 +62,24 @@ export interface SearchAutocompleteRequest {
     sortMethod?: SearchAutocompleteSortMethodEnum;
 }
 
+export interface SearchTagsRequest {
+    offset?: number;
+    limit?: number;
+    userId?: string;
+    query?: string;
+    kind?: SearchTagsKindEnum;
+    includePurchaseable?: boolean;
+    genre?: Array<string>;
+    mood?: Array<string>;
+    isVerified?: boolean;
+    hasDownloads?: boolean;
+    isPurchaseable?: boolean;
+    key?: Array<string>;
+    bpmMin?: number;
+    bpmMax?: number;
+    sortMethod?: SearchTagsSortMethodEnum;
+}
+
 /**
  * 
  */
@@ -243,6 +261,93 @@ export class SearchApi extends runtime.BaseAPI {
         return await response.value();
     }
 
+    /**
+     * @hidden
+     * Get Users/Tracks/Playlists/Albums that best match the provided tag
+     */
+    async searchTagsRaw(params: SearchTagsRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<SearchFullResponse>> {
+        const queryParameters: any = {};
+
+        if (params.offset !== undefined) {
+            queryParameters['offset'] = params.offset;
+        }
+
+        if (params.limit !== undefined) {
+            queryParameters['limit'] = params.limit;
+        }
+
+        if (params.userId !== undefined) {
+            queryParameters['user_id'] = params.userId;
+        }
+
+        if (params.query !== undefined) {
+            queryParameters['query'] = params.query;
+        }
+
+        if (params.kind !== undefined) {
+            queryParameters['kind'] = params.kind;
+        }
+
+        if (params.includePurchaseable !== undefined) {
+            queryParameters['includePurchaseable'] = params.includePurchaseable;
+        }
+
+        if (params.genre) {
+            queryParameters['genre'] = params.genre;
+        }
+
+        if (params.mood) {
+            queryParameters['mood'] = params.mood;
+        }
+
+        if (params.isVerified !== undefined) {
+            queryParameters['is_verified'] = params.isVerified;
+        }
+
+        if (params.hasDownloads !== undefined) {
+            queryParameters['has_downloads'] = params.hasDownloads;
+        }
+
+        if (params.isPurchaseable !== undefined) {
+            queryParameters['is_purchaseable'] = params.isPurchaseable;
+        }
+
+        if (params.key) {
+            queryParameters['key'] = params.key;
+        }
+
+        if (params.bpmMin !== undefined) {
+            queryParameters['bpm_min'] = params.bpmMin;
+        }
+
+        if (params.bpmMax !== undefined) {
+            queryParameters['bpm_max'] = params.bpmMax;
+        }
+
+        if (params.sortMethod !== undefined) {
+            queryParameters['sort_method'] = params.sortMethod;
+        }
+
+        const headerParameters: runtime.HTTPHeaders = {};
+
+        const response = await this.request({
+            path: `/search/tags`,
+            method: 'GET',
+            headers: headerParameters,
+            query: queryParameters,
+        }, initOverrides);
+
+        return new runtime.JSONApiResponse(response, (jsonValue) => SearchFullResponseFromJSON(jsonValue));
+    }
+
+    /**
+     * Get Users/Tracks/Playlists/Albums that best match the provided tag
+     */
+    async searchTags(params: SearchTagsRequest = {}, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<SearchFullResponse> {
+        const response = await this.searchTagsRaw(params, initOverrides);
+        return await response.value();
+    }
+
 }
 
 /**
@@ -285,3 +390,23 @@ export const SearchAutocompleteSortMethodEnum = {
     Recent: 'recent'
 } as const;
 export type SearchAutocompleteSortMethodEnum = typeof SearchAutocompleteSortMethodEnum[keyof typeof SearchAutocompleteSortMethodEnum];
+/**
+ * @export
+ */
+export const SearchTagsKindEnum = {
+    All: 'all',
+    Users: 'users',
+    Tracks: 'tracks',
+    Playlists: 'playlists',
+    Albums: 'albums'
+} as const;
+export type SearchTagsKindEnum = typeof SearchTagsKindEnum[keyof typeof SearchTagsKindEnum];
+/**
+ * @export
+ */
+export const SearchTagsSortMethodEnum = {
+    Relevant: 'relevant',
+    Popular: 'popular',
+    Recent: 'recent'
+} as const;
+export type SearchTagsSortMethodEnum = typeof SearchTagsSortMethodEnum[keyof typeof SearchTagsSortMethodEnum];


### PR DESCRIPTION
### Description
This is the first half of migrating searchTags to SDK in client. This needs to be in and shipped before the client change is merged.
The legacy endpoint uses different logic for parsing params because it's not using flask parsers. It should be converting things to the same format as the newly added endpoint. Also had to fix the `search_es_tags` function a little bit.

The full and tags search are _nearly_ identical and we could consider merging them in the future. But I didn't want to push this too far since the goal at the moment is just getting SDK support.

### How Has This Been Tested?
Tested on local client against local stack by calling legacy and sdk versions and verified they work.
