### PR TITLE
[QA-1864][PAY-3690] Migrate searchTags to SDK

### DIFF
--- a/packages/mobile/src/screens/search-screen/search-results/AllResults.tsx
+++ b/packages/mobile/src/screens/search-screen/search-results/AllResults.tsx
@@ -73,7 +73,7 @@ const skeletonSections = [
   {
     title: 'profiles',
     data: range(5).map((i) => ({
-      id: `user_skeleton_${i}`,
+      id: i,
       kind: Kind.USERS,
       status: Status.LOADING
     }))
@@ -81,7 +81,7 @@ const skeletonSections = [
   {
     title: 'tracks',
     data: range(5).map((i) => ({
-      id: `track_skeleton_${i}`,
+      id: i,
       kind: Kind.TRACKS,
       status: Status.LOADING
     }))
@@ -89,7 +89,7 @@ const skeletonSections = [
   {
     title: 'playlists',
     data: range(5).map((i) => ({
-      id: `playlist_skeleton_${i}`,
+      id: i,
       kind: Kind.COLLECTIONS,
       status: Status.LOADING
     }))
@@ -97,7 +97,7 @@ const skeletonSections = [
   {
     title: 'albums',
     data: range(5).map((i) => ({
-      id: `album_skeleton_${i}`,
+      id: i,
       kind: Kind.COLLECTIONS,
       status: Status.LOADING
     }))

--- a/packages/web/src/common/store/pages/search-page/lineups/tracks/sagas.ts
+++ b/packages/web/src/common/store/pages/search-page/lineups/tracks/sagas.ts
@@ -21,7 +21,7 @@ const { getUserId } = accountSelectors
 function* getSearchPageResultsTracks({
   offset,
   limit,
-  payload: { category, query, isTagSearch, filters, dispatch }
+  payload: { category, query, filters }
 }: {
   offset: number
   limit: number

--- a/packages/web/src/common/store/pages/search-page/sagas.ts
+++ b/packages/web/src/common/store/pages/search-page/sagas.ts
@@ -21,7 +21,6 @@ import { select, call, takeLatest, put } from 'typed-redux-saga'
 
 import { processAndCacheCollections } from 'common/store/cache/collections/utils'
 import { processAndCacheTracks } from 'common/store/cache/tracks/utils'
-import { fetchUsers } from 'common/store/cache/users/sagas'
 import tracksSagas from 'common/store/pages/search-page/lineups/tracks/sagas'
 import { waitForRead } from 'utils/sagaHelpers'
 
@@ -48,43 +47,48 @@ export function* getTagSearchResults(
   isPremium?: boolean,
   sortMethod?: SearchSortMethod
 ) {
-  const audiusBackendInstance = yield* getContext('audiusBackendInstance')
-  const [bpmMin, bpmMax] = getMinMaxFromBpm(bpm)
+  yield* waitForRead()
+  const getFeatureEnabled = yield* getContext('getFeatureEnabled')
+  const isUSDCEnabled = yield* call(
+    getFeatureEnabled,
+    FeatureFlags.USDC_PURCHASES
+  )
 
-  // @ts-ignore
-  const results = yield* call(audiusBackendInstance.searchTags, {
-    query: tag.toLowerCase(),
-    userTagCount: 1,
+  const sdk = yield* getSDK()
+  const userId = yield* select(getUserId)
+  const [bpmMin, bpmMax] = getMinMaxFromBpm(bpm)
+  const formattedKey = formatMusicalKey(key)
+
+  const { data } = yield* call([sdk.full.search, sdk.full.search.searchTags], {
+    bpmMax,
+    bpmMin,
+    hasDownloads,
+    includePurchaseable: isUSDCEnabled,
+    isPurchaseable: isPremium,
+    isVerified,
     kind,
     limit,
     offset,
-    genre,
-    mood,
-    bpmMin,
-    bpmMax,
-    key: formatMusicalKey(key),
-    isVerified,
-    hasDownloads,
-    isPremium,
-    sortMethod
+    query: tag.toLowerCase(),
+    sortMethod,
+    userId: OptionalId.parse(userId),
+    genre: genre ? [genre] : undefined,
+    mood: mood ? [mood] : undefined,
+    key: formattedKey ? [formattedKey] : undefined
   })
-  const { users, tracks } = results
+  const { tracks, albums, playlists, users } = searchResultsFromSDK(data)
 
-  const creatorIds = tracks
-    .map((t) => t.owner_id)
-    .concat(users.map((u) => u.user_id))
+  yield* call(processAndCacheUsers, users)
+  yield* call(processAndCacheTracks, tracks)
 
-  yield* call(fetchUsers, creatorIds)
+  const collections = albums.concat(playlists)
+  yield* call(
+    processAndCacheCollections,
+    collections,
+    /* shouldRetrieveTracks */ false
+  )
 
-  const { entries } = yield* call(fetchUsers, creatorIds)
-
-  const tracksWithUsers = tracks.map((track) => ({
-    ...track,
-    user: entries[track.owner_id]
-  }))
-  yield* call(processAndCacheTracks, tracksWithUsers)
-
-  return { users, tracks }
+  return { users, tracks, albums, playlists }
 }
 
 export function* fetchSearchPageTags(


### PR DESCRIPTION
### Description
Depends on #10705 
This updates client to use the SDK version of searchTags. The audius-query function gets simplified to just slightly modify the searchParams and then conditionally call either `search` or `searchTags`.
I would've liked to remove the sagas altogether in favor of using `fetchSaga`. But it's lineup code and a little complicated. So I'm going to leave that for after we do the data fetching work.

### How Has This Been Tested?
Local client against local stack. Will test against staging once the other PR is merged and staging DNs support the SDK method.
