### PR TITLE
[PAY-3691] Sanitize upload filename for react-native

### DIFF
--- a/packages/sdk/src/sdk/services/Storage/Storage.ts
+++ b/packages/sdk/src/sdk/services/Storage/Storage.ts
@@ -121,9 +121,22 @@ export class Storage implements StorageService {
     Object.keys(options).forEach((key) => {
       formData.append(key, `${options[key]}`)
     })
+
+    const formDataFile =
+      'uri' in file
+        ? {
+            ...file,
+            // NOTE this is required for react-native
+            // certain characters in the file name make formData invalid
+            name: file.name
+              ? encodeURIComponent(file.name.replace(/[()]/g, ''))
+              : 'blob'
+          }
+        : file
+
     formData.append(
       'files',
-      isNodeFile(file) ? file.buffer : file,
+      isNodeFile(formDataFile) ? formDataFile.buffer : formDataFile,
       file.name ?? 'blob'
     )
 


### PR DESCRIPTION
### Description

This was a really weird one to debug.
Files with parenthesis in the file name failed to upload (getting an empty response back from mediorum) but only on react-native. Was able to fix by sanitizing the filename that gets added to FormData

Name isn't even required by mediorum, but it can be helpful with debugging so I wanted to keep it

### How Has This Been Tested?

Confirmed can upload files with and without parens on mobile and web
