### PR TITLE
[C-5508, C-5510, C-5511] Track Replace QA 2

### DIFF
--- a/packages/mobile/src/harmony-native/components/Button/BaseButton/BaseButton.tsx
+++ b/packages/mobile/src/harmony-native/components/Button/BaseButton/BaseButton.tsx
@@ -45,7 +45,7 @@ export const BaseButton = (props: BaseButtonProps) => {
   const isTextChild = typeof children === 'string'
 
   const childElement = isTextChild ? (
-    <AnimatedText {...innerProps?.text} style={styles?.text}>
+    <AnimatedText {...innerProps?.text} style={styles?.text} numberOfLines={1}>
       {children}
     </AnimatedText>
   ) : (

--- a/packages/mobile/src/screens/edit-track-screen/EditTrackNavigator.tsx
+++ b/packages/mobile/src/screens/edit-track-screen/EditTrackNavigator.tsx
@@ -38,7 +38,7 @@ const screenOptionOverrides = { headerRight: () => null }
 type EditTrackNavigatorProps = EditTrackFormProps
 
 export const EditTrackNavigator = (props: EditTrackNavigatorProps) => {
-  const { doneText, initialValues } = props
+  const { doneText, initialValues, isUpload } = props
   const screenOptions = useAppScreenOptions(screenOptionOverrides)
 
   return (
@@ -81,7 +81,7 @@ export const EditTrackNavigator = (props: EditTrackNavigatorProps) => {
       <HideContentConfirmationDrawer />
       <PublishConfirmationDrawer />
       <EarlyReleaseConfirmationDrawer />
-      <ReplaceTrackConfirmationDrawer />
+      {isUpload ? null : <ReplaceTrackConfirmationDrawer />}
     </>
   )
 }

--- a/packages/web/src/components/edit-track/utils/uploadPreviewContext.tsx
+++ b/packages/web/src/components/edit-track/utils/uploadPreviewContext.tsx
@@ -4,6 +4,8 @@ import { queueActions, playerSelectors } from '@audius/common/store'
 import { Nullable } from '@audius/common/utils'
 import { useSelector, useDispatch } from 'react-redux'
 
+import { audioPlayer } from 'services/audio-player'
+
 const { getPlaying } = playerSelectors
 const { pause: pauseQueue } = queueActions
 
@@ -46,6 +48,7 @@ export const UploadPreviewContextProvider = (props: {
         preview.currentTime = 0
       }
 
+      trackPreview.volume = audioPlayer?.audio.volume ?? 1.0
       trackPreview.play()
       setPreview(trackPreview)
       setPreviewIndex(trackIdx)


### PR DESCRIPTION
### Description
* Update harmony-native buttons to be one line to fix the preview button
* Remove confirmation drawer from upload flow
* Update web preview to match the current audio player volume

### How Has This Been Tested?
Manually Tested
