### PR TITLE
More trending improvements

### DIFF
--- a/packages/discovery-provider/integration_tests/challenges/test_trending_challenge.py
+++ b/packages/discovery-provider/integration_tests/challenges/test_trending_challenge.py
@@ -294,8 +294,8 @@ def test_trending_challenge_job(app):
             strategy.update_track_score_query(session)
 
         session.commit()
-    web3 = MockWeb3()
-    enqueue_trending_challenges(db, web3, redis_conn, bus, trending_date)
+        web3 = MockWeb3()
+        enqueue_trending_challenges(session, web3, redis_conn, bus, trending_date)
 
     with db.scoped_session() as session:
         session.query(Challenge).filter(

--- a/packages/discovery-provider/integration_tests/queries/test_undisbursed_challenges.py
+++ b/packages/discovery-provider/integration_tests/queries/test_undisbursed_challenges.py
@@ -146,7 +146,13 @@ def test_undisbursed_challenges(app):
         # Test that all undisbursed challenges are returned in order
         undisbursed = get_undisbursed_challenges(
             session,
-            {"user_id": None, "limit": 10, "offset": 0, "completed_blocknumber": 99},
+            {
+                "user_id": None,
+                "limit": 10,
+                "offset": 0,
+                "completed_blocknumber": 99,
+                "challenge_id": None,
+            },
         )
 
         expected = [

--- a/packages/discovery-provider/integration_tests/queries/test_undisbursed_challenges.py
+++ b/packages/discovery-provider/integration_tests/queries/test_undisbursed_challenges.py
@@ -198,7 +198,13 @@ def test_undisbursed_challenges(app):
         # Test that it filters correctly by user_id
         undisbursed = get_undisbursed_challenges(
             session,
-            {"user_id": 6, "limit": 10, "offset": 0, "completed_blocknumber": 99},
+            {
+                "user_id": 6,
+                "limit": 10,
+                "offset": 0,
+                "completed_blocknumber": 99,
+                "challenge_id": None,
+            },
         )
 
         expected = [
@@ -220,7 +226,13 @@ def test_undisbursed_challenges(app):
         # Test that it filters correctly by user_id & completed blocknumber
         undisbursed = get_undisbursed_challenges(
             session,
-            {"user_id": 6, "limit": 10, "offset": 0, "completed_blocknumber": 101},
+            {
+                "user_id": 6,
+                "limit": 10,
+                "offset": 0,
+                "completed_blocknumber": 101,
+                "challenge_id": None,
+            },
         )
 
         expected = []

--- a/packages/discovery-provider/plugins/pedalboard/apps/trending-challenge-rewards/package.json
+++ b/packages/discovery-provider/plugins/pedalboard/apps/trending-challenge-rewards/package.json
@@ -28,6 +28,7 @@
     "knex": "^2.4.2",
     "moment": "^2.29.4",
     "morgan": "^1.10.0",
+    "node-cron": "^3.0.3",
     "ts-results": "^3.3.0"
   },
   "devDependencies": {

--- a/packages/discovery-provider/plugins/pedalboard/apps/trending-challenge-rewards/src/queries.ts
+++ b/packages/discovery-provider/plugins/pedalboard/apps/trending-challenge-rewards/src/queries.ts
@@ -93,6 +93,7 @@ export const getChallengesDisbursementsUserbanksFriendlyEnsureSlots = async (
     const totalChallenges = challenges.length
     const challengesWithSlots = challenges.filter((challenge) => challenge.slot !== null)
     const totalSlots = challengesWithSlots.length
+    console.log('total challenges complete = ', totalSlots)
     console.log('percent complete = ', totalSlots / totalChallenges * 100, '%')
     if (totalChallenges === totalSlots) return challenges
     await new Promise(r => setTimeout(r, 5000))

--- a/packages/discovery-provider/plugins/pedalboard/apps/trending-challenge-rewards/src/rewards.ts
+++ b/packages/discovery-provider/plugins/pedalboard/apps/trending-challenge-rewards/src/rewards.ts
@@ -27,7 +27,6 @@ const TRENDING_ID = 'tt'
 const UNDERGROUND_TRENDING_ID = 'tut'
 const PLAYLIST_TRENDING_ID = 'tp'
 const TRENDING_REWARD_IDS = [TRENDING_ID, PLAYLIST_TRENDING_ID, UNDERGROUND_TRENDING_ID]
-const START_BLOCK = 86579600
 
 
 // TODO: move something like this into App so results are commonplace for handlers
@@ -77,11 +76,12 @@ export const onDisburse = async (
     console.log('endpoint = ', endpoint)
     const toDisburse: Challenge[] = []
     for (const challengeId in TRENDING_REWARD_IDS) {
+      // Get all undisbursed challenges for the given challenge id starting from a bit before
+      // our last completed block.
+      const blockNumber = completedBlock - 1000
       // Fetch all undisbursed challenges
       const res = await axios.get(
-        // Get all undisbursed challenges for the given challenge id starting from a bit before
-        // our last completed block.
-        `${endpoint}/v1/challenges/undisbursed?challenge_id=${challengeId}&completed_blocknumber=${completedBlock - 1000}`
+        `${endpoint}/v1/challenges/undisbursed?challenge_id=${challengeId}&completed_blocknumber=${blockNumber}`
       )
       toDisburse.push(...res.data.data)
     }

--- a/packages/discovery-provider/plugins/pedalboard/apps/trending-challenge-rewards/src/rewards.ts
+++ b/packages/discovery-provider/plugins/pedalboard/apps/trending-challenge-rewards/src/rewards.ts
@@ -25,8 +25,9 @@ type Challenge = {
 
 const TRENDING_ID = 'tt'
 const UNDERGROUND_TRENDING_ID = 'tut'
-const PLAY_TRENDING_ID = 'tp'
-const TRENDING_REWARD_IDS = [TRENDING_ID, PLAY_TRENDING_ID, UNDERGROUND_TRENDING_ID]
+const PLAYLIST_TRENDING_ID = 'tp'
+const TRENDING_REWARD_IDS = [TRENDING_ID, PLAYLIST_TRENDING_ID, UNDERGROUND_TRENDING_ID]
+const START_BLOCK = 86579600
 
 
 // TODO: move something like this into App so results are commonplace for handlers
@@ -66,46 +67,63 @@ export const onDisburse = async (
     completedBlock = challenge.completed_blocknumber! - 1
     specifier = challenge.specifier
   }
-  
-  // Fetch all undisbursed challenges
-  const endpoint = await sdk.services.discoveryNodeSelector.getSelectedEndpoint()
-  console.log('endpoint = ', endpoint)
-  const res = await axios.get(
-    `${endpoint}/v1/challenges/undisbursed?completed_blocknumber=${completedBlock}`
-  )
-  const data: Challenge[] = res.data.data
-  const toDisburse = data.filter((c) =>
-    TRENDING_REWARD_IDS.includes(c.challenge_id)
-)
 
-// Claim all undisbursed challenges
-for (const challenge of toDisburse) {
-  const challengeId = Object.values(ChallengeId).find(id => id === challenge.challenge_id)!
-  console.log('Claimable challengeId = ', challenge)
-  const totalRetries = 10
-  let res
-  let retries = totalRetries
-  while (retries > 0) {
-    try {
-      if (!dryRun) {
-        res = await sdk.challenges.claimReward({
-          challengeId,
-          userId: challenge.user_id,
-          specifier: challenge.specifier,
-          amount: parseFloat(challenge.amount),
-        })
-        console.log('res = ', res)
-        break // Success - exit retry loop
-      }
-    } catch (e) {
-      console.error(`Error claiming reward, challengeId = ${challengeId}, attempt ${totalRetries - retries + 1} of ${totalRetries}, error = `, e)
-      retries -= 1
-      if (retries === 0) {
-        console.error(`Failed to claim reward after ${totalRetries} attempts for challengeId = ${challengeId}`)
+  let endpointRetries = 10
+  while (endpointRetries > 0) {
+    let failedAnAttestation = false
+
+    // Pick an endpoint and collect all undisbursed challenges from that endpoint
+    const endpoint = await sdk.services.discoveryNodeSelector.getSelectedEndpoint()
+    console.log('endpoint = ', endpoint)
+    const toDisburse: Challenge[] = []
+    for (const challengeId in TRENDING_REWARD_IDS) {
+      // Fetch all undisbursed challenges
+      const res = await axios.get(
+        // Get all undisbursed challenges for the given challenge id starting from a bit before
+        // our last completed block.
+        `${endpoint}/v1/challenges/undisbursed?challenge_id=${challengeId}&completed_blocknumber=${completedBlock - 1000}`
+      )
+      toDisburse.push(...res.data.data)
+    }
+  
+    // Claim all undisbursed challenges
+    for (const challenge of toDisburse) {
+      const challengeId = Object.values(ChallengeId).find(id => id === challenge.challenge_id)!
+      console.log('Claimable challengeId = ', challenge)
+      const totalAttestationRetries = 10
+      let res
+      let attestationRetries = totalAttestationRetries
+      while (attestationRetries > 0) {
+        try {
+          if (!dryRun) {
+            res = await sdk.challenges.claimReward({
+              challengeId,
+              userId: challenge.user_id,
+              specifier: challenge.specifier,
+              amount: parseFloat(challenge.amount),
+            })
+            console.log('res = ', res)
+            break // Success - exit retry loop
+          }
+        } catch (e) {
+          console.error(`Error claiming reward, challengeId = ${challengeId}, attempt ${totalAttestationRetries - attestationRetries + 1} of ${totalAttestationRetries}, error = `, e)
+          attestationRetries -= 1
+          if (attestationRetries === 0) {
+            console.error(`Failed to claim reward after ${totalAttestationRetries} attempts for challengeId = ${challengeId}`)
+            failedAnAttestation = true
+          }
+        }
       }
     }
+
+    // If we found no errors, continue on to confirm
+    if (!failedAnAttestation) {
+      break
+    }
+    endpointRetries -= 1
+    console.error(`Error finding all attestations, ${endpointRetries} remaining`)
   }
-}
+
   
   // Look at database to see if all challenges have been disbursed
   const trimmedSpecifier = specifier.split(':')[0]

--- a/packages/discovery-provider/src/api/v1/challenges.py
+++ b/packages/discovery-provider/src/api/v1/challenges.py
@@ -128,6 +128,12 @@ get_undisbursed_challenges_route_parser.add_argument(
     type=int,
     description="Starting blocknumber to retrieve completed undisbursed challenges",
 )
+get_undisbursed_challenges_route_parser.add_argument(
+    "challenge_id",
+    required=False,
+    type=str,
+    description="A challenge ID to filter the undisbursed challenges to a particular challenge",
+)
 
 get_challenges_response = make_response(
     "undisbursed_challenges", ns, fields.List(fields.Nested(undisbursed_challenge))
@@ -157,6 +163,7 @@ class GetUndisbursedChallenges(Resource):
                     "limit": args["limit"],
                     "offset": args["offset"],
                     "completed_blocknumber": args["completed_blocknumber"],
+                    "challenge_id": args["challenge_id"],
                 },
             )
             undisbursed_challenges = list(

--- a/packages/discovery-provider/src/app.py
+++ b/packages/discovery-provider/src/app.py
@@ -319,7 +319,6 @@ def configure_celery(celery, test_config=None):
             "src.tasks.index_eth",
             "src.tasks.index_oracles",
             "src.tasks.index_rewards_manager",
-            "src.tasks.calculate_trending_challenges",
             "src.tasks.user_listening_history.index_user_listening_history",
             "src.tasks.prune_plays",
             "src.tasks.index_spl_token",
@@ -484,7 +483,6 @@ def configure_celery(celery, test_config=None):
     redis_inst.delete("index_eth_lock")
     redis_inst.delete("index_oracles_lock")
     redis_inst.delete("solana_rewards_manager_lock")
-    redis_inst.delete("calculate_trending_challenges_lock")
     redis_inst.delete("index_user_listening_history_lock")
     redis_inst.delete("prune_plays_lock")
     redis_inst.delete("update_aggregate_table:aggregate_user_tips")

--- a/packages/discovery-provider/src/queries/get_undisbursed_challenges.py
+++ b/packages/discovery-provider/src/queries/get_undisbursed_challenges.py
@@ -46,6 +46,7 @@ class UndisbursedChallengesArgs(TypedDict):
     limit: Optional[int]
     offset: Optional[int]
     completed_blocknumber: Optional[int]
+    challenge_id: Optional[str]
 
 
 MAX_LIMIT = 500
@@ -97,6 +98,11 @@ def get_undisbursed_challenges(
     if args["completed_blocknumber"] is not None:
         undisbursed_challenges_query = undisbursed_challenges_query.filter(
             UserChallenge.completed_blocknumber > args["completed_blocknumber"]
+        )
+
+    if args["challenge_id"] is not None:
+        undisbursed_challenges_query = undisbursed_challenges_query.filter(
+            UserChallenge.challenge_id == args["challenge_id"]
         )
 
     limit = DEFAULT_LIMIT

--- a/packages/discovery-provider/src/tasks/calculate_trending_challenges.py
+++ b/packages/discovery-provider/src/tasks/calculate_trending_challenges.py
@@ -187,36 +187,3 @@ def enqueue_trending_challenges(
     logger.debug(
         f"calculate_trending_challenges.py | Finished calculating trending in {update_total} seconds"
     )
-
-
-# ####### CELERY TASKS ####### #
-# @celery.task(name="calculate_trending_challenges", bind=True)
-# @save_duration_metric(metric_group="celery_task")
-# def calculate_trending_challenges_task(self, date: Optional[date] = None):
-#     """Caches all trending combination of time-range and genre (including no genre)."""
-#     if date is None:
-#         logger.error("calculate_trending_challenges.py | Must be called with a date")
-#         return
-#     db = calculate_trending_challenges_task.db
-#     redis = calculate_trending_challenges_task.redis
-#     challenge_bus = calculate_trending_challenges_task.challenge_event_bus
-#     web3 = web3_provider.get_web3()
-#     have_lock = False
-#     update_lock = redis.lock("calculate_trending_challenges_lock", timeout=7200)
-#     try:
-#         have_lock = update_lock.acquire(blocking=False)
-#         if have_lock:
-
-#             enqueue_trending_challenges(db, web3, redis, challenge_bus, date)
-#         else:
-#             logger.debug(
-#                 "calculate_trending_challenges.py | Failed to acquire index trending lock"
-#             )
-#     except Exception as e:
-#         logger.error(
-#             "calculate_trending_challenges.py | Fatal error in main loop", exc_info=True
-#         )
-#         raise e
-#     finally:
-#         if have_lock:
-#             update_lock.release()

--- a/packages/sdk/src/sdk/api/generated/default/apis/ChallengesApi.ts
+++ b/packages/sdk/src/sdk/api/generated/default/apis/ChallengesApi.ts
@@ -28,6 +28,7 @@ export interface GetUndisbursedChallengesRequest {
     limit?: number;
     userId?: string;
     completedBlocknumber?: number;
+    challengeId?: string;
 }
 
 /**
@@ -56,6 +57,10 @@ export class ChallengesApi extends runtime.BaseAPI {
 
         if (params.completedBlocknumber !== undefined) {
             queryParameters['completed_blocknumber'] = params.completedBlocknumber;
+        }
+
+        if (params.challengeId !== undefined) {
+            queryParameters['challenge_id'] = params.challengeId;
         }
 
         const headerParameters: runtime.HTTPHeaders = {};


### PR DESCRIPTION
### Description

* Spawn trending job from index_nethermind rather than kicking off another celery task
* More retries in attestation plugin
* Use challenge id to filter rather than starting block 

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._

* Deployed some changes to a live discovery node to test indexing + endpoint
* Ran and attested to rewards locally using plugin