### PR TITLE
Clean up some other lingering libs usage

### DIFF
--- a/packages/common/src/api/signUp.ts
+++ b/packages/common/src/api/signUp.ts
@@ -14,8 +14,8 @@ const signUpApi = createApi({
   reducerPath: 'signUpApi',
   endpoints: {
     isEmailInUse: {
-      fetch: async ({ email }: { email: string }, { audiusBackend }) => {
-        return await audiusBackend.emailInUse(email)
+      fetch: async ({ email }: { email: string }, { identityService }) => {
+        return await identityService.checkIfEmailRegistered(email)
       },
       options: {}
     },

--- a/packages/common/src/hooks/purchaseContent/validation.ts
+++ b/packages/common/src/hooks/purchaseContent/validation.ts
@@ -84,8 +84,10 @@ export const createPurchaseContentSchema = (
         return
       }
 
-      const { emailExists: isEmailInUse, isGuest } =
-        await signUpFetch.isEmailInUse({ email: guestEmail }, queryContext)
+      const { exists: isEmailInUse, isGuest } = await signUpFetch.isEmailInUse(
+        { email: guestEmail },
+        queryContext
+      )
 
       if (isEmailInUse === undefined) {
         ctx.addIssue({

--- a/packages/common/src/schemas/sign-on/emailSchema.ts
+++ b/packages/common/src/schemas/sign-on/emailSchema.ts
@@ -18,7 +18,7 @@ export const emailSchema = (queryContext: AudiusQueryContextType) =>
       .string({ required_error: emailSchemaMessages.emailRequired })
       .regex(EMAIL_REGEX, { message: emailSchemaMessages.invalidEmail })
       .superRefine(async (email, ctx) => {
-        const { emailExists: isEmailInUse, isGuest } =
+        const { exists: isEmailInUse, isGuest } =
           await signUpFetch.isEmailInUse({ email }, queryContext)
         if (isEmailInUse === undefined) {
           ctx.addIssue({

--- a/packages/common/src/services/audius-backend/AudiusBackend.ts
+++ b/packages/common/src/services/audius-backend/AudiusBackend.ts
@@ -217,7 +217,6 @@ export const audiusBackend = ({
   ethRegistryAddress,
   ethTokenAddress,
   discoveryNodeSelectorService,
-  getHostUrl,
   getLibs,
   getStorageNodeSelector,
   getWeb3Config,
@@ -235,7 +234,6 @@ export const audiusBackend = ({
   entityManagerAddress,
   reportError,
   remoteConfigInstance,
-  setLocalStorageItem,
   solanaConfig: {
     claimableTokenPda,
     claimableTokenProgramAddress,
@@ -792,108 +790,6 @@ export const audiusBackend = ({
     } catch (err) {
       console.error(getErrorMessage(err))
       throw err
-    }
-  }
-
-  /**
-   * @param formFields {name, handle, profilePicture, coverPhoto, isVerified, location}
-   * @param hasWallet the user already has a wallet but didn't complete sign up
-   * @param referrer the user_id of the account that referred this one
-   */
-  async function signUp({
-    email,
-    password,
-    formFields,
-    hasWallet = false,
-    referrer = null,
-    feePayerOverride = null
-  }: {
-    email: string
-    password: string
-    formFields: {
-      name?: string
-      handle?: string
-      isVerified?: boolean
-      location?: string | null
-      profilePicture: File | null
-      coverPhoto: File | null
-    }
-    hasWallet: boolean
-    referrer: Nullable<ID>
-    feePayerOverride: Nullable<string>
-  }) {
-    await waitForLibsInit()
-    const metadata = schemas.newUserMetadata()
-    if (formFields.name) {
-      metadata.name = formFields.name
-    }
-    if (formFields.handle) {
-      metadata.handle = formFields.handle
-    }
-    if (formFields.isVerified) {
-      metadata.is_verified = formFields.isVerified
-    }
-    if (formFields.location) {
-      metadata.location = formFields.location
-    }
-
-    const hasEvents = referrer || nativeMobile
-    if (hasEvents) {
-      metadata.events = {}
-    }
-    if (referrer) {
-      metadata.events.referrer = referrer
-    }
-    if (nativeMobile) {
-      metadata.events.is_mobile_user = true
-      setLocalStorageItem('is-mobile-user', 'true')
-    }
-
-    return await audiusLibs.Account.signUpV2(
-      email,
-      password,
-      metadata,
-      formFields.profilePicture,
-      formFields.coverPhoto,
-      hasWallet,
-      getHostUrl(),
-      (eventName: string, properties: Record<string, unknown>) =>
-        recordAnalytics({ eventName, properties }),
-      {
-        Request: Name.CREATE_USER_BANK_REQUEST,
-        Success: Name.CREATE_USER_BANK_SUCCESS,
-        Failure: Name.CREATE_USER_BANK_FAILURE
-      },
-      feePayerOverride,
-      true
-    )
-  }
-
-  async function guestSignUp(email: string) {
-    await waitForLibsInit()
-    const metadata = schemas.newUserMetadata()
-
-    return await audiusLibs.Account.guestSignUp(email, metadata)
-  }
-
-  async function sendRecoveryEmail(handle: string) {
-    await waitForLibsInit()
-    const host = getHostUrl()
-    return audiusLibs.Account.generateRecoveryLink({ handle, host })
-  }
-
-  async function emailInUse(email: string) {
-    await waitForLibsInit()
-    try {
-      const { exists: emailExists, isGuest } =
-        await audiusLibs.Account.checkIfEmailRegistered(email)
-      return {
-        emailExists: emailExists as boolean,
-        isGuest: isGuest as boolean
-      }
-    } catch (error) {
-      console.error(getErrorMessage(error))
-      throw error
     }
   }
 
@@ -1913,7 +1809,6 @@ export const audiusBackend = ({
     deregisterDeviceToken,
     didSelectDiscoveryProviderListeners,
     disableBrowserNotifications,
-    emailInUse,
     fetchUserAssociatedWallets,
     findAssociatedTokenAddress,
     getAddressTotalStakedBalance,
@@ -1938,9 +1833,7 @@ export const audiusBackend = ({
     recordTrackListen,
     registerDeviceToken,
     repostCollection,
-    guestSignUp,
     saveCollection,
-    sendRecoveryEmail,
     sendTokens,
     sendWAudioTokens,
     sendWelcomeEmail,
@@ -1950,7 +1843,6 @@ export const audiusBackend = ({
     signGatedContentRequest,
     signDiscoveryNodeRequest,
     signIdentityServiceRequest,
-    signUp,
     transferAudioToWAudio,
     instagramHandle,
     tiktokHandle,

--- a/packages/common/src/services/auth/authService.ts
+++ b/packages/common/src/services/auth/authService.ts
@@ -44,6 +44,7 @@ export type AuthService = {
   }) => Promise<void>
   getWalletAddresses: () => Promise<GetWalletAddressesResult>
   getWallet: () => EthWallet | null
+  generateRecoveryInfo: () => Promise<{ login: string; host: string }>
   confirmCredentials: (args: ConfirmCredentialsArgs) => Promise<boolean>
   changeCredentials: (args: ChangeCredentialsArgs) => Promise<void>
 }
@@ -92,6 +93,11 @@ export const createAuthService = ({
     return hedgehogInstance.resetPassword({ username, password })
   }
 
+  const generateRecoveryInfo = async () => {
+    await hedgehogInstance.waitUntilReady()
+    return hedgehogInstance.generateRecoveryInfo()
+  }
+
   const getWalletAddresses = async () => {
     const walletOverride = await localStorage.getAudiusUserWalletOverride()
     await hedgehogInstance.waitUntilReady()
@@ -118,6 +124,7 @@ export const createAuthService = ({
     hedgehogInstance,
     signIn,
     signOut,
+    generateRecoveryInfo,
     getWallet,
     getWalletAddresses,
     confirmCredentials,

--- a/packages/common/src/services/auth/identity.ts
+++ b/packages/common/src/services/auth/identity.ts
@@ -189,6 +189,19 @@ export class IdentityService {
   }
 
   /**
+   * Check if an email address has been previously registered.
+   */
+  async checkIfEmailRegistered(email: string) {
+    return await this._makeRequest<{ exists: boolean; isGuest: boolean }>({
+      url: '/users/check',
+      method: 'get',
+      params: {
+        email
+      }
+    })
+  }
+
+  /**
    * Get the user's email used for notifications and display.
    */
   async getUserEmail() {

--- a/packages/web/src/common/store/pages/signon/sagas.ts
+++ b/packages/web/src/common/store/pages/signon/sagas.ts
@@ -70,6 +70,7 @@ import { identify, make } from 'common/store/analytics/actions'
 import * as backendActions from 'common/store/backend/actions'
 import { retrieveCollections } from 'common/store/cache/collections/utils'
 import { fetchUserByHandle, fetchUsers } from 'common/store/cache/users/sagas'
+import { sendRecoveryEmail } from 'common/store/recovery-email/sagas'
 import { UiErrorCode } from 'store/errors/actions'
 import { setHasRequestedBrowserPermission } from 'utils/browserNotifications'
 import { restrictedHandles } from 'utils/restrictedHandles'
@@ -394,14 +395,17 @@ function* validateHandle(
 }
 
 function* checkEmail(action: ReturnType<typeof signOnActions.checkEmail>) {
-  const audiusBackendInstance = yield* getContext('audiusBackendInstance')
+  const identityService = yield* getContext('identityService')
   if (!isValidEmailString(action.email)) {
     yield* put(signOnActions.validateEmailFailed('characters'))
     return
   }
 
   try {
-    const inUse = yield* call(audiusBackendInstance.emailInUse, action.email)
+    const inUse = yield* call(
+      [identityService, identityService.checkIfEmailRegistered],
+      action.email
+    )
     if (inUse) {
       yield* put(signOnActions.goToPage(Pages.SIGNIN))
       // let mobile client know that email is in use
@@ -538,38 +542,21 @@ function* associateSocialAccounts({
   }
 }
 
-function* sendRecoveryEmail({
+function* sendPostSignInRecoveryEmail({
   handle,
   email
 }: {
   handle: string
   email: string
 }) {
-  const authService = yield* getContext('authService')
-  const identityService = yield* getContext('identityService')
-  const getHostUrl = yield* getContext('getHostUrl')
-  const host = getHostUrl()
-
   try {
-    const recoveryInfo = yield* call([
-      authService.hedgehogInstance,
-      authService.hedgehogInstance.generateRecoveryInfo
-    ])
-
-    const recoveryData = {
-      login: recoveryInfo.login,
-      host: host ?? recoveryInfo.host
-    }
-    yield* call(
-      [identityService, identityService.sendRecoveryInfo],
-      recoveryData
-    )
+    yield* call(sendRecoveryEmail)
   } catch (err) {
     const reportToSentry = yield* getContext('reportToSentry')
     reportToSentry({
       error: err instanceof Error ? err : new Error(err as string),
       name: 'Sign Up: Failed to send recovery email',
-      additionalInfo: { handle, email, host },
+      additionalInfo: { handle, email },
       level: ErrorLevel.Fatal,
       feature: Feature.SignUp
     })
@@ -746,7 +733,7 @@ function* signUp() {
                 })
               )
 
-              yield* fork(sendRecoveryEmail, { handle, email })
+              yield* fork(sendPostSignInRecoveryEmail, { handle, email })
               yield* call([localStorage, localStorage.removeItem], GUEST_EMAIL)
             } else {
               if (!alreadyExisted) {
@@ -761,7 +748,7 @@ function* signUp() {
                   }
                 )
 
-                yield* fork(sendRecoveryEmail, { handle, email })
+                yield* fork(sendPostSignInRecoveryEmail, { handle, email })
               }
               const wallet = (yield* call([
                 authService,

--- a/packages/web/src/common/store/recovery-email/sagas.ts
+++ b/packages/web/src/common/store/recovery-email/sagas.ts
@@ -40,7 +40,7 @@ function* watchResendRecoveryEmail() {
       const reportToSentry = yield* getContext('reportToSentry')
       reportToSentry({
         error: err instanceof Error ? err : new Error(err as string),
-        name: 'Sign Up: Failed to send recovery email',
+        name: 'Resend Recovery: Failed to send recovery email',
         additionalInfo: { handle },
         level: ErrorLevel.Fatal
       })

--- a/packages/web/src/pages/settings-page/components/desktop/SettingsPage.tsx
+++ b/packages/web/src/pages/settings-page/components/desktop/SettingsPage.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useMemo, useState } from 'react'
 
+import { useAudiusQueryContext } from '@audius/common/audius-query'
 import { useIsManagedAccount } from '@audius/common/hooks'
 import { settingsMessages } from '@audius/common/messages'
 import { Name, Theme } from '@audius/common/models'
@@ -123,6 +124,7 @@ const messages = {
 export const SettingsPage = () => {
   const dispatch = useDispatch()
   const isManagedAccount = useIsManagedAccount()
+  const { authService, identityService } = useAudiusQueryContext()
 
   const userId = useSelector(getUserId) ?? 0
   const handle = useSelector(getUserHandle) ?? ''
@@ -186,7 +188,8 @@ export const SettingsPage = () => {
   const showEmailToast = useCallback(() => {
     const fn = async () => {
       try {
-        await audiusBackendInstance.sendRecoveryEmail(handle)
+        const info = await authService.generateRecoveryInfo()
+        await identityService.sendRecoveryInfo(info)
         setEmailToastText(settingsMessages.emailSent)
         setIsEmailToastVisible(true)
         dispatch(make(Name.SETTINGS_RESEND_ACCOUNT_RECOVERY, {}))
@@ -200,7 +203,13 @@ export const SettingsPage = () => {
       }, EMAIL_TOAST_TIMEOUT)
     }
     fn()
-  }, [handle, setIsEmailToastVisible, setEmailToastText, dispatch])
+  }, [
+    setIsEmailToastVisible,
+    setEmailToastText,
+    identityService,
+    authService,
+    dispatch
+  ])
 
   const handleDownloadDesktopAppClicked = useCallback(() => {
     dispatch(make(Name.ACCOUNT_HEALTH_DOWNLOAD_DESKTOP, { source: 'settings' }))

--- a/packages/web/src/pages/settings-page/components/mobile/AccountSettingsPage.tsx
+++ b/packages/web/src/pages/settings-page/components/mobile/AccountSettingsPage.tsx
@@ -1,5 +1,6 @@
 import { useState, useContext, useCallback } from 'react'
 
+import { useAudiusQueryContext } from '@audius/common/audius-query'
 import { Name, SquareSizes } from '@audius/common/models'
 import { accountSelectors } from '@audius/common/store'
 import { route } from '@audius/common/utils'
@@ -25,7 +26,6 @@ import MobilePageContainer from 'components/mobile-page-container/MobilePageCont
 import { ToastContext } from 'components/toast/ToastContext'
 import { useProfilePicture } from 'hooks/useProfilePicture'
 import SignOutModal from 'pages/settings-page/components/mobile/SignOutModal'
-import { audiusBackendInstance } from 'services/audius-backend/audius-backend-instance'
 
 import styles from './AccountSettingsPage.module.css'
 import settingsPageStyles from './SettingsPage.module.css'
@@ -134,6 +134,7 @@ const AccountSettingsItem = ({
 
 const AccountSettingsPage = () => {
   const dispatch = useDispatch()
+  const { authService, identityService } = useAudiusQueryContext()
   const userId = useSelector(getUserId) ?? 0
   const handle = useSelector(getUserHandle) ?? ''
   const name = useSelector(getUserName) ?? ''
@@ -156,7 +157,9 @@ const AccountSettingsPage = () => {
       debounce(
         async () => {
           try {
-            await audiusBackendInstance.sendRecoveryEmail(handle)
+            await identityService.sendRecoveryInfo(
+              await authService.generateRecoveryInfo()
+            )
             toast(messages.emailSent)
             record(make(Name.SETTINGS_RESEND_ACCOUNT_RECOVERY, {}))
           } catch (e) {
@@ -166,7 +169,7 @@ const AccountSettingsPage = () => {
         2000,
         { leading: true, trailing: false }
       )(),
-    [handle, toast, record]
+    [authService, identityService, toast, record]
   )
 
   const goToVerificationPage = useCallback(() => {


### PR DESCRIPTION
### Description
This cleans up some remaining signup/email - related libs usage in favor of the common identity service. I also removed code that was no longer being used in AudiusBackend.
There was duplicate saga code for sending the email, so I moved the logic into the `recovery-email` sagas file and updated both places to wrap try/catch around it so we can get different sentry errors depending on how it was invoked (signUp vs user requesting a re-send)

### How Has This Been Tested?
Local client against staging.
