### PR TITLE
Undo added fatal sentry logs (keep them only on "crashes")

### DIFF
--- a/packages/mobile/src/screens/sign-on-screen/components/SignUpFlowTikTokAuth.tsx
+++ b/packages/mobile/src/screens/sign-on-screen/components/SignUpFlowTikTokAuth.tsx
@@ -90,7 +90,6 @@ export const SignUpFlowTikTokAuth = ({
       reportToSentry({
         error: e as Error,
         name: 'Sign Up: Failed to parse TikTok profile data',
-        level: ErrorLevel.Fatal,
         additionalInfo: {
           profileData,
           requiresUserReview

--- a/packages/mobile/src/screens/sign-on-screen/components/SignUpFlowTikTokAuth.tsx
+++ b/packages/mobile/src/screens/sign-on-screen/components/SignUpFlowTikTokAuth.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react'
 
 import { useAudiusQueryContext } from '@audius/common/audius-query'
-import { ErrorLevel, Name } from '@audius/common/models'
+import { Name } from '@audius/common/models'
 import { pickHandleSchema } from '@audius/common/schemas'
 import { formatTikTokProfile } from '@audius/common/services'
 import type { TikTokProfileData } from '@audius/common/services'

--- a/packages/web/src/common/store/pages/signon/sagas.ts
+++ b/packages/web/src/common/store/pages/signon/sagas.ts
@@ -159,7 +159,6 @@ function* fetchDefaultFollowArtists() {
     const reportToSentry = yield* getContext('reportToSentry')
     reportToSentry({
       error: e,
-      level: ErrorLevel.Fatal, // fatal reasoning - this is required to follow t
       name: 'Sign Up: Unable to fetch default follow artists (aka Audius acct)',
       feature: Feature.SignUp
     })
@@ -187,7 +186,6 @@ function* fetchAllFollowArtist() {
     const reportToSentry = yield* getContext('reportToSentry')
     reportToSentry({
       error: e as Error,
-      level: ErrorLevel.Fatal, // fatal reasoning - this is required for users to follow the artists they selected in signup
       name: 'Sign Up: Unable to fetch sign up follows requested by user',
       feature: Feature.SignUp
     })
@@ -557,7 +555,6 @@ function* sendPostSignInRecoveryEmail({
       error: err instanceof Error ? err : new Error(err as string),
       name: 'Sign Up: Failed to send recovery email',
       additionalInfo: { handle, email },
-      level: ErrorLevel.Fatal,
       feature: Feature.SignUp
     })
   }
@@ -639,7 +636,6 @@ function* createGuestAccount(
   } catch (err) {
     reportToSentry({
       error: err as Error,
-      level: ErrorLevel.Fatal,
       name: 'Sign Up: Failed to create guest account',
       feature: Feature.SignUp
     })
@@ -889,7 +885,6 @@ function* signUp() {
             } else {
               reportToSentry({
                 error,
-                level: ErrorLevel.Fatal,
                 name: 'Sign Up: Other Error',
                 additionalInfo: {
                   handle,
@@ -920,7 +915,6 @@ function* signUp() {
             const reportToSentry = yield* getContext('reportToSentry')
             reportToSentry({
               error,
-              level: ErrorLevel.Fatal,
               name: 'Sign Up: Unknown error in signUp saga',
               additionalInfo: { message, timeout },
               feature: Feature.SignUp
@@ -937,7 +931,6 @@ function* signUp() {
   } catch (error) {
     reportToSentry({
       error: error as Error,
-      level: ErrorLevel.Fatal,
       name: 'Sign Up: Unknown error in signUp saga',
       feature: Feature.SignUp
     })
@@ -1151,8 +1144,7 @@ function* signIn(action: ReturnType<typeof signOnActions.signIn>) {
     reportToSentry({
       error: err,
       name: 'Sign In: unknown error',
-      feature: Feature.SignIn,
-      level: ErrorLevel.Fatal
+      feature: Feature.SignIn
     })
     yield* put(signOnActions.signInFailed(err))
   }
@@ -1275,7 +1267,6 @@ function* followArtists(
     const reportToSentry = yield* getContext('reportToSentry')
     reportToSentry({
       error: err,
-      level: ErrorLevel.Fatal,
       name: 'Sign Up: Unkown error while following artists on sign up',
       feature: Feature.SignUp
     })

--- a/packages/web/src/common/store/recovery-email/sagas.ts
+++ b/packages/web/src/common/store/recovery-email/sagas.ts
@@ -1,4 +1,4 @@
-import { ErrorLevel, Name } from '@audius/common/models'
+import { Name } from '@audius/common/models'
 import {
   recoveryEmailActions,
   getContext,

--- a/packages/web/src/common/store/recovery-email/sagas.ts
+++ b/packages/web/src/common/store/recovery-email/sagas.ts
@@ -41,8 +41,7 @@ function* watchResendRecoveryEmail() {
       reportToSentry({
         error: err instanceof Error ? err : new Error(err as string),
         name: 'Resend Recovery: Failed to send recovery email',
-        additionalInfo: { handle },
-        level: ErrorLevel.Fatal
+        additionalInfo: { handle }
       })
       yield* put(resendError())
     }

--- a/packages/web/src/common/store/upload/sagas.test.ts
+++ b/packages/web/src/common/store/upload/sagas.test.ts
@@ -1,9 +1,4 @@
-import {
-  ErrorLevel,
-  Feature,
-  Name,
-  StemUploadWithFile
-} from '@audius/common/models'
+import { Feature, Name, StemUploadWithFile } from '@audius/common/models'
 import {
   TrackForUpload,
   TrackMetadataForUpload,

--- a/packages/web/src/common/store/upload/sagas.test.ts
+++ b/packages/web/src/common/store/upload/sagas.test.ts
@@ -291,8 +291,7 @@ describe('upload', () => {
             phase: 'publish',
             kind: 'tracks'
           },
-          feature: Feature.Upload,
-          level: ErrorLevel.Fatal
+          feature: Feature.Upload
         })
         // Fails the parent too
         .call.like({
@@ -311,8 +310,7 @@ describe('upload', () => {
                 phase: 'publish',
                 kind: 'tracks'
               },
-              feature: Feature.Upload,
-              level: ErrorLevel.Fatal
+              feature: Feature.Upload
             }
           ]
         })

--- a/packages/web/src/common/store/upload/sagas.ts
+++ b/packages/web/src/common/store/upload/sagas.ts
@@ -686,8 +686,7 @@ export function* handleUploads({
         phase,
         kind
       },
-      feature: Feature.Upload,
-      level: ErrorLevel.Fatal
+      feature: Feature.Upload
     })
   }
 
@@ -997,8 +996,7 @@ export function* uploadCollection(
             isAlbum,
             collectionMetadata
           },
-          feature: Feature.Upload,
-          level: ErrorLevel.Fatal
+          feature: Feature.Upload
         })
         yield* put(uploadActions.uploadTracksFailed())
         yield* put(
@@ -1176,8 +1174,7 @@ export function* uploadTracksAsync(
         kind,
         tracks: payload.tracks
       },
-      feature: Feature.Upload,
-      level: ErrorLevel.Fatal
+      feature: Feature.Upload
     })
     yield* put(uploadActions.uploadTracksFailed())
     yield* put(

--- a/packages/web/src/common/store/upload/sagas.ts
+++ b/packages/web/src/common/store/upload/sagas.ts
@@ -7,7 +7,6 @@ import {
 import {
   Collection,
   CollectionMetadata,
-  ErrorLevel,
   Feature,
   FieldVisibility,
   ID,


### PR DESCRIPTION
### Description

Per our revisited strategy with Sentry, removes all the added `ErrorLevel.Fatal` levels so that we can reserve that for true app crashes.

### How Has This Been Tested?

web:stage