### PR TITLE
[C-5540] Stop logging console & network errors to sentry

### DIFF
--- a/packages/web/src/services/sentry.ts
+++ b/packages/web/src/services/sentry.ts
@@ -30,10 +30,6 @@ export const initializeSentry = async () => {
     integrations: [
       // Pull extra fields off error objects
       Sentry.extraErrorDataIntegration(),
-      // Catch failed network requests
-      Sentry.httpClientIntegration(),
-      // Capture console.errors in sentry
-      Sentry.captureConsoleIntegration({ levels: ['error'] }),
       // Capture a session recording
       Sentry.replayIntegration({})
     ],


### PR DESCRIPTION
### Description

Reduce noise in sentry by removing console and network errors.
While theoretically useful, we rarely look at these and they pollute our queries for actual crashes and failures.

Optionally, we could try to downgrade them to warnings instead, but sentry doesn't support that out of the box. We'd have to write our own listeners

### How Has This Been Tested?

site still working