### PR TITLE
Fix follow artists on profile completion race condition

### DIFF
--- a/packages/common/src/store/account/selectors.ts
+++ b/packages/common/src/store/account/selectors.ts
@@ -31,7 +31,13 @@ export const getGuestEmail = (state: CommonState) => {
 }
 
 export const getIsGuestAccount = (state: CommonState) => {
-  return !!state.account.guestEmail
+  const { userId } = state.account
+
+  const user = getUser(state, { id: userId })
+  if (!user) return false
+
+  const { handle, name } = user
+  return Boolean(!handle && !name)
 }
 export const getUserId = (state: CommonState) => state.account.userId
 export const getAccountStatus = (state: CommonState) => state.account.status

--- a/packages/web/src/common/store/pages/signon/sagas.ts
+++ b/packages/web/src/common/store/pages/signon/sagas.ts
@@ -769,21 +769,6 @@ function* signUp() {
                 throw new Error('Failed to index guest account creation')
               }
 
-              // Force refreshing doesn't seem to update the user handle
-              // so this forced cache update is necessary
-              yield* put(
-                cacheActions.update(Kind.USERS, [
-                  {
-                    id: userId,
-                    metadata: {
-                      handle: user.handle,
-                      name: user.name,
-                      profile_picture: user.profile_picture,
-                      location: user.location
-                    }
-                  }
-                ])
-              )
               return userId
             } else {
               if (!alreadyExisted) {
@@ -1233,7 +1218,7 @@ function* followCollections(
 export function* completeFollowArtists(
   _action: ReturnType<typeof signOnActions.completeFollowArtists>
 ) {
-  const accountId = yield* select(accountSelectors.getUserId)
+  const accountId = yield* select(accountSelectors.getIsAccountComplete)
   if (accountId) {
     // If account creation has finished we need to make sure followArtists gets called
     // Also we specifically request to not follow the defaults (Audius user, Hot & New Playlist) since that should have already occurred

--- a/packages/web/src/components/nav/desktop/AccountSwitcher/AccountSwitcher.tsx
+++ b/packages/web/src/components/nav/desktop/AccountSwitcher/AccountSwitcher.tsx
@@ -15,14 +15,17 @@ import { AccountListContent } from './AccountListContent'
 
 export const AccountSwitcher = () => {
   const [isExpanded, setIsExpanded] = useState(false)
-  const userId = useSelector(accountSelectors.getUserId)
+  const isAccountComplete = useSelector(accountSelectors.getIsAccountComplete)
   const [checkedAccess, setCheckedAccess] = useState(false)
 
   const { data: currentWeb3User } = useGetCurrentWeb3User(
     {},
-    { disabled: !userId }
+    { disabled: !isAccountComplete }
   )
-  const { data: currentUserId } = useGetCurrentUserId({}, { disabled: !userId })
+  const { data: currentUserId } = useGetCurrentUserId(
+    {},
+    { disabled: !isAccountComplete }
+  )
 
   const { switchAccount, switchToWeb3User } = useAccountSwitcher()
 


### PR DESCRIPTION
### Description
Ideally we should be checking user handle and name state to determine if account is complete but this exposes guest profile completion to a race condition bug when following selected artists.

We follow default and selected artists in signUp and we follow selected artists from SelectArtist submit handler in case the user selects artists to follow before user is complete. In this check for user completeness, we were using if userId exists but in profile completion it has userId but the user isn't complete. Modifying this to check for user complete is more accurate for its intended purpose. 

Technically, I think this bug is technically still vulnerable or you could end up in a state where you follow duplicates but extremely unlikely. Ideally, I think follows should just wait on user completion at the end of sign up and then follow.  

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._

Went through sign up and profile completion verrry fast. 
