### PR TITLE
Add missing bs58

### DIFF
--- a/packages/spl/package.json
+++ b/packages/spl/package.json
@@ -27,7 +27,8 @@
     "@solana/buffer-layout": "4.0.1",
     "@solana/buffer-layout-utils": "0.2.0",
     "@solana/spl-token": "0.3.8",
-    "@solana/web3.js": "1.93.4"
+    "@solana/web3.js": "1.93.4",
+    "bs58": "6.0.0"
   },
   "devDependencies": {
     "vitest": "0.34.6"


### PR DESCRIPTION
### Description

I guess caused by https://github.com/AudiusProject/audius-protocol/pull/10731
there was some indirect dep here because spl is not directly published

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._

npm run build locally 