### PR TITLE
[PAY-3697] Change left nav link UI

### DIFF
--- a/packages/web/src/components/nav/desktop/AccountDetails.tsx
+++ b/packages/web/src/components/nav/desktop/AccountDetails.tsx
@@ -31,7 +31,7 @@ const AccountDetailsContainer = ({
 }: AccountDetailsContainerProps) => {
   const { color } = useTheme()
   return (
-    <Flex direction='column' pb='unit5' w='100%'>
+    <Flex direction='column' w='100%'>
       {isManagedAccount ? (
         <Box pv='xs' ph='m' backgroundColor='accent'>
           <Text variant='label' size='xs' color='staticWhite'>

--- a/packages/web/src/components/nav/desktop/LeftNav.tsx
+++ b/packages/web/src/components/nav/desktop/LeftNav.tsx
@@ -7,7 +7,19 @@ import {
   tracksSocialActions
 } from '@audius/common/store'
 import { route } from '@audius/common/utils'
-import { Box, Flex, Scrollbar } from '@audius/harmony'
+import {
+  Divider,
+  Flex,
+  IconCloudUpload,
+  IconExplore,
+  IconFeed,
+  IconLibrary,
+  IconMessages,
+  IconTrending,
+  IconTrophy,
+  IconWallet,
+  Scrollbar
+} from '@audius/harmony'
 import { ResizeObserver } from '@juggle/resize-observer'
 import { connect } from 'react-redux'
 import { RouteComponentProps, withRouter } from 'react-router-dom'
@@ -21,29 +33,28 @@ import { AppState } from 'store/types'
 import { useSelector } from 'utils/reducer'
 
 import { AccountDetails } from './AccountDetails'
-import { ConnectInstagram } from './ConnectInstagram'
-import { GroupHeader } from './GroupHeader'
-import { LeftNavCTA } from './LeftNavCTA'
-import { LeftNavDroppable } from './LeftNavDroppable'
 import { LeftNavLink } from './LeftNavLink'
 import { NavHeader } from './NavHeader'
 import { NowPlayingArtworkTile } from './NowPlayingArtworkTile'
 import { PlaylistLibrary } from './PlaylistLibrary'
 import { RouteNav } from './RouteNav'
 
-const { EXPLORE_PAGE, FEED_PAGE, HISTORY_PAGE, LIBRARY_PAGE, TRENDING_PAGE } =
-  route
+const {
+  EXPLORE_PAGE,
+  FEED_PAGE,
+  LIBRARY_PAGE,
+  TRENDING_PAGE,
+  CHATS_PAGE,
+  PAYMENTS_PAGE,
+  AUDIO_PAGE,
+  UPLOAD_PAGE
+} = route
 const { saveTrack } = tracksSocialActions
 const { saveCollection } = collectionsSocialActions
 const { getAccountStatus, getUserId, getUserHandle, getIsAccountComplete } =
   accountSelectors
 
 export const LEFT_NAV_WIDTH = 240
-
-const messages = {
-  discover: 'Discover',
-  library: 'Your Music'
-}
 
 type OwnProps = {
   isElectron: boolean
@@ -55,14 +66,7 @@ type NavColumnProps = OwnProps &
   RouteComponentProps
 
 const LeftNav = (props: NavColumnProps) => {
-  const {
-    accountUserId,
-    accountHandle,
-    isElectron,
-    draggingKind,
-    saveTrack,
-    saveCollection
-  } = props
+  const { isElectron } = props
   const isAccountComplete = useSelector(getIsAccountComplete)
   const [navBodyContainerMeasureRef, navBodyContainerBoundaries] = useMeasure({
     polyfill: ResizeObserver
@@ -84,6 +88,12 @@ const LeftNav = (props: NavColumnProps) => {
         scrollbarRef.current.scrollTop + difference
     }
   }, [])
+
+  const [isPlaylistExpanded, setIsPlaylistExpanded] = useState(false)
+
+  const handlePlaylistToggle = useCallback(() => {
+    setIsPlaylistExpanded(!isPlaylistExpanded)
+  }, [isPlaylistExpanded])
 
   return (
     <Flex
@@ -129,68 +139,75 @@ const LeftNav = (props: NavColumnProps) => {
             onChangeDragScrollingDirection={handleChangeDragScrollingDirection}
           >
             <AccountDetails />
-            <Flex
-              direction='column'
-              gap='unit5'
-              flex='1 1 auto'
-              css={{ overflow: 'hidden' }}
-            >
-              {accountHandle === 'fbtest' ? (
-                <Box>
-                  <LeftNavLink to={'/fb/share'}>
-                    Share Profile to Facebook
-                  </LeftNavLink>
-                  <LeftNavLink>
-                    <ConnectInstagram />
-                  </LeftNavLink>
-                </Box>
-              ) : null}
-              <Box>
-                <GroupHeader>{messages.discover}</GroupHeader>
-                <LeftNavLink
-                  to={FEED_PAGE}
-                  disabled={!isAccountComplete}
-                  restriction='account'
-                >
-                  Feed
-                </LeftNavLink>
-                <LeftNavLink to={TRENDING_PAGE} restriction='none'>
-                  Trending
-                </LeftNavLink>
-                <LeftNavLink to={EXPLORE_PAGE} exact restriction='none'>
-                  Explore
-                </LeftNavLink>
-              </Box>
-              <Box>
-                <GroupHeader>{messages.library}</GroupHeader>
-                <LeftNavDroppable
-                  disabled={!accountUserId}
-                  acceptedKinds={['track', 'album']}
-                  acceptOwner={false}
-                  onDrop={draggingKind === 'album' ? saveCollection : saveTrack}
-                >
-                  <LeftNavLink to={LIBRARY_PAGE} restriction='guest'>
-                    Library
-                  </LeftNavLink>
-                </LeftNavDroppable>
-                <LeftNavLink
-                  to={HISTORY_PAGE}
-                  disabled={!isAccountComplete}
-                  restriction='account'
-                >
-                  History
-                </LeftNavLink>
-              </Box>
-              <Box>
-                <PlaylistLibrary scrollbarRef={scrollbarRef} />
-              </Box>
+            <Flex direction='column' gap='unit2' flex='1 1 auto' p={6}>
+              <LeftNavLink
+                to={FEED_PAGE}
+                disabled={!isAccountComplete}
+                restriction='account'
+                icon={IconFeed}
+              >
+                Feed
+              </LeftNavLink>
+              <LeftNavLink
+                to={TRENDING_PAGE}
+                restriction='none'
+                icon={IconTrending}
+              >
+                Trending
+              </LeftNavLink>
+              <LeftNavLink
+                to={EXPLORE_PAGE}
+                exact
+                restriction='none'
+                icon={IconExplore}
+              >
+                Explore
+              </LeftNavLink>
+              <LeftNavLink
+                to={LIBRARY_PAGE}
+                restriction='guest'
+                icon={IconLibrary}
+              >
+                Library
+              </LeftNavLink>
+              <LeftNavLink
+                to={CHATS_PAGE}
+                restriction='guest'
+                icon={IconMessages}
+              >
+                Messages
+              </LeftNavLink>
+              <LeftNavLink
+                to={PAYMENTS_PAGE}
+                restriction='guest'
+                icon={IconWallet}
+              >
+                Wallets
+              </LeftNavLink>
+              <LeftNavLink
+                to={AUDIO_PAGE}
+                restriction='guest'
+                icon={IconTrophy}
+              >
+                Rewards
+              </LeftNavLink>
+              <LeftNavLink
+                to={UPLOAD_PAGE}
+                restriction='guest'
+                icon={IconCloudUpload}
+              >
+                Upload
+              </LeftNavLink>
+              <Divider orientation='horizontal' />
+              <LeftNavLink restriction='guest' onClick={handlePlaylistToggle}>
+                <PlaylistLibrary isExpanded={isPlaylistExpanded} />
+              </LeftNavLink>
             </Flex>
           </DragAutoscroller>
         </Scrollbar>
       </Flex>
       <Flex direction='column' alignItems='center' pt='l' borderTop='default'>
         <ProfileCompletionPanel />
-        <LeftNavCTA />
         <NowPlayingArtworkTile />
       </Flex>
     </Flex>

--- a/packages/web/src/components/nav/desktop/LeftNavLink.tsx
+++ b/packages/web/src/components/nav/desktop/LeftNavLink.tsx
@@ -1,6 +1,6 @@
 import { ComponentProps, useMemo } from 'react'
 
-import { Text, TextProps, useTheme } from '@audius/harmony'
+import { Flex, IconComponent, Text, TextProps, useTheme } from '@audius/harmony'
 import { CSSInterpolation } from '@emotion/css'
 import { Interpolation, Theme } from '@emotion/react'
 import { Slot } from '@radix-ui/react-slot'
@@ -12,7 +12,13 @@ import {
 } from 'hooks/useRequiresAccount'
 
 export type LeftNavLinkProps =
-  | { disabled?: boolean; asChild?: boolean } & (
+  | {
+      disabled?: boolean
+      asChild?: boolean
+      icon?: IconComponent
+      iconSize?: 's' | 'm' | 'l'
+      hideIconPadding?: boolean
+    } & (
       | Omit<NavLinkProps, 'onDrop'>
       | Omit<ComponentProps<'div'>, 'onDrop'>
     ) & {
@@ -20,7 +26,16 @@ export type LeftNavLinkProps =
       }
 
 export const LeftNavLink = (props: LeftNavLinkProps) => {
-  const { asChild, disabled, children, onClick, restriction, ...other } = props
+  const {
+    asChild,
+    disabled,
+    children,
+    onClick,
+    restriction,
+    icon: Icon,
+    iconSize = 's',
+    ...other
+  } = props
 
   const theme = useTheme()
 
@@ -33,44 +48,19 @@ export const LeftNavLink = (props: LeftNavLinkProps) => {
   )
 
   const css = useMemo(() => {
-    const { color, spacing, typography, cornerRadius } = theme
-    const indicatorCss: CSSInterpolation = {
-      content: '""',
-      display: 'block',
-      width: spacing.unit5,
-      height: spacing.unit5,
-      position: 'absolute',
-      top: 0,
-      bottom: 0,
-      margin: 'auto 0',
-      left: -spacing.l,
-      borderRadius: cornerRadius.s,
-      borderRightWidth: cornerRadius.s,
-      borderRightStyle: 'solid',
-      borderRightColor: 'transparent'
-    }
+    const { color, spacing, typography } = theme
 
     const linkInteractionCss: CSSInterpolation = {
       '&:hover': {
         cursor: 'pointer',
-        color: color.neutral.n950
+        color: color.neutral.n950,
+        backgroundColor: color.neutral.n100
       },
-      '&:hover:before': [
-        indicatorCss,
-        {
-          borderRightColor: color.neutral.n400
-        }
-      ],
       '&.active': {
         color: color.text.active,
-        fontWeight: typography.weight.medium
-      },
-      '&.active:before': [
-        indicatorCss,
-        {
-          borderRightColor: color.primary.primary
-        }
-      ]
+        fontWeight: typography.weight.medium,
+        backgroundColor: color.neutral.n200
+      }
     }
 
     const disabledDropCss: CSSInterpolation = {
@@ -81,18 +71,20 @@ export const LeftNavLink = (props: LeftNavLinkProps) => {
     const combined: Interpolation<Theme> = [
       {
         position: 'relative',
-        height: spacing.xl,
+        minHeight: spacing.xl,
         display: 'flex',
         alignItems: 'center',
         gap: spacing.s,
         minWidth: 100,
-        // Leaves space for the hover indicator
-        paddingLeft: spacing.unit7,
         paddingRight: spacing.l,
+        paddingLeft: spacing.s,
+        paddingTop: spacing.s,
+        paddingBottom: spacing.s,
         color: color.text.default,
         border: 0,
         background: 'none',
-        textAlign: 'inherit'
+        textAlign: 'inherit',
+        borderRadius: spacing.xs
       },
       linkInteractionCss,
       disabled && disabledDropCss
@@ -104,10 +96,19 @@ export const LeftNavLink = (props: LeftNavLinkProps) => {
   const textProps = asChild
     ? undefined
     : ({
-        tag: 'span',
+        variant: 'title',
         size: 's',
         css: { display: 'flex', alignItems: 'center' }
       } as TextProps<'span'>)
+
+  const content = (
+    <Flex alignItems='center' gap='s' css={{ width: '100%' }}>
+      {Icon && <Icon size={iconSize} color='default' />}
+      <TextComp {...textProps} css={{ width: '100%' }}>
+        {children}
+      </TextComp>
+    </Flex>
+  )
 
   if ('to' in other) {
     return (
@@ -117,14 +118,14 @@ export const LeftNavLink = (props: LeftNavLinkProps) => {
         activeClassName='active'
         css={css}
       >
-        <TextComp {...textProps}>{children}</TextComp>
+        {content}
       </NavLink>
     )
   }
 
   return (
-    <div {...other} css={css}>
-      <TextComp {...textProps}>{children}</TextComp>
+    <div {...other} css={css} onClick={handleClick}>
+      {content}
     </div>
   )
 }

--- a/packages/web/src/components/nav/desktop/PlaylistLibrary/PlaylistLibrary.tsx
+++ b/packages/web/src/components/nav/desktop/PlaylistLibrary/PlaylistLibrary.tsx
@@ -1,45 +1,34 @@
-import { MutableRefObject, useCallback } from 'react'
+import { useCallback } from 'react'
 
 import { FavoriteSource } from '@audius/common/models'
 import {
   accountSelectors,
   collectionsSocialActions
 } from '@audius/common/store'
-import { Flex, useTheme } from '@audius/harmony'
+import { Flex, IconPlaylists, Text, useTheme } from '@audius/harmony'
 import { ClassNames } from '@emotion/react'
 import { isEmpty } from 'lodash'
 import { useDispatch } from 'react-redux'
 
 import { Droppable } from 'components/dragndrop'
-import { DragDropKind, selectDraggingKind } from 'store/dragndrop/slice'
+import { DragDropKind } from 'store/dragndrop/slice'
 import { useSelector } from 'utils/reducer'
 
-import { GroupHeader } from '../GroupHeader'
-
-import { CreatePlaylistLibraryItemButton } from './CreatePlaylistLibraryItemButton'
-import { EmptyLibraryNavLink } from './EmptyLibraryNavLink'
 import { PlaylistLibraryNavItem, keyExtractor } from './PlaylistLibraryNavItem'
 import { useAddAudioNftPlaylistToLibrary } from './useAddAudioNftPlaylistToLibrary'
 import { useSanitizePlaylistLibrary } from './useSanitizePlaylistLibrary'
-
 const { getPlaylistLibrary } = accountSelectors
 const { saveCollection } = collectionsSocialActions
-
-const messages = {
-  header: 'Playlists'
-}
 
 const acceptedKinds: DragDropKind[] = ['playlist']
 
 type PlaylistLibraryProps = {
-  scrollbarRef: MutableRefObject<HTMLElement | null>
+  isExpanded: boolean
 }
 
-export const PlaylistLibrary = (props: PlaylistLibraryProps) => {
-  const { scrollbarRef } = props
+export const PlaylistLibrary = ({ isExpanded }: PlaylistLibraryProps) => {
   const library = useSelector(getPlaylistLibrary)
   const dispatch = useDispatch()
-  const draggingKind = useSelector(selectDraggingKind)
   const { color, motion, spacing } = useTheme()
 
   useAddAudioNftPlaylistToLibrary()
@@ -55,49 +44,74 @@ export const PlaylistLibrary = (props: PlaylistLibraryProps) => {
   return (
     <ClassNames>
       {({ css }) => (
-        <Droppable
-          className={css({
+        <Flex
+          direction='column'
+          css={{
             position: 'relative',
-            // Drop Background
-            '::before': {
-              content: '""',
-              position: 'absolute',
-              top: -spacing.s,
-              bottom: -spacing.s,
-              left: 0,
-              right: 0,
-              backgroundColor: color.background.accent,
-              transition: `opacity ${motion.quick}`,
-              opacity: 0
-            },
-            '&.droppableLinkHover::before': {
-              opacity: 0.15
-            }
-          })}
-          hoverClassName='droppableLinkHover'
-          onDrop={handleDrop}
-          acceptedKinds={acceptedKinds}
+            maxHeight: '100%',
+            overflow: 'visible'
+          }}
+          data-testid='playlist-library-container'
         >
-          <Flex wrap='nowrap' alignItems='center' gap='s'>
-            <GroupHeader
-              color={draggingKind === 'playlist' ? 'accent' : 'subdued'}
+          <Droppable
+            className={css({
+              position: 'relative',
+              '::before': {
+                content: '""',
+                position: 'absolute',
+                top: -spacing.s,
+                bottom: -spacing.s,
+                left: 0,
+                right: 0,
+                backgroundColor: color.background.accent,
+                transition: `opacity ${motion.quick}`,
+                opacity: 0,
+                pointerEvents: 'none'
+              },
+              '&.droppableLinkHover::before': {
+                opacity: 0.15
+              }
+            })}
+            hoverClassName='droppableLinkHover'
+            onDrop={handleDrop}
+            acceptedKinds={acceptedKinds}
+            data-testid='playlist-library-droppable'
+          >
+            <Flex
+              alignItems='center'
+              gap='s'
+              css={{ width: '100%' }}
+              data-testid='playlist-library-header'
             >
-              {messages.header}
-            </GroupHeader>
-            <CreatePlaylistLibraryItemButton scrollbarRef={scrollbarRef} />
-          </Flex>
-          {!library || isEmpty(library?.contents) ? (
-            <EmptyLibraryNavLink />
-          ) : (
-            library.contents.map((content) => (
-              <PlaylistLibraryNavItem
-                key={keyExtractor(content)}
-                item={content}
-                level={0}
-              />
-            ))
-          )}
-        </Droppable>
+              <IconPlaylists size='s' color='default' />
+              <Text variant='title' size='s'>
+                Playlists
+              </Text>
+              <Text variant='label' size='l' css={{ marginLeft: 'auto' }}>
+                +
+              </Text>
+            </Flex>
+            {isExpanded && (
+              <Flex
+                direction='column'
+                css={{
+                  overflow: 'hidden auto',
+                  marginLeft: spacing.s
+                }}
+              >
+                {!library || isEmpty(library?.contents)
+                  ? null
+                  : library.contents.map((content) => (
+                      <PlaylistLibraryNavItem
+                        key={keyExtractor(content)}
+                        item={content}
+                        level={0}
+                      />
+                    ))}
+              </Flex>
+            )}
+          </Droppable>
+        </Flex>
       )}
     </ClassNames>
   )


### PR DESCRIPTION
### Description

This PR updates the links in the `LeftNavBar` to be in the "label + text" configuration that is asked for in the [Figma](https://www.figma.com/design/l1Fn3uZ3lenie0apeS0YM3/2024-Navigation-Redesign?node-id=0-1&p=f&t=D7QIZTM3y78jZUlq-0) file for the redesign. 

<img width="241" alt="image" src="https://github.com/user-attachments/assets/bccf375c-ca61-409c-b03f-b9100dc16528" />

**PR INCLUES**
- Removes sections in favor of a straight trough navbar
- Reshaping of Nav Links
- Adding text + label configuration 

**DOES NOT INCLUDE**
- Correct hover/active states
- Correct font weight
- Correct display of playlists
- etc... 

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._
