### PR TITLE
Parse guest email in local storage

### DIFF
--- a/packages/common/src/store/account/sagas.ts
+++ b/packages/common/src/store/account/sagas.ts
@@ -120,7 +120,13 @@ export function* fetchAccountAsync({ isSignUp = false }): SagaIterator {
     }
   }
 
-  accountData.guestEmail = yield* call([localStorage, 'getItem'], 'guestEmail')
+  const guestEmailFromLocalStorage = yield* call(
+    [localStorage, 'getItem'],
+    'guestEmail'
+  )
+  accountData.guestEmail = guestEmailFromLocalStorage
+    ? JSON.parse(guestEmailFromLocalStorage)
+    : null
 
   // Set the userId in the remoteConfigInstance
   remoteConfigInstance.setUserId(user.user_id)
@@ -137,7 +143,7 @@ export function* fetchAccountAsync({ isSignUp = false }): SagaIterator {
     collections: accountData.playlists,
     guestEmail: accountData.guestEmail
   }
-
+  console.log('asdf Formatted Account', formattedAccount)
   yield* put(fetchAccountSucceeded(formattedAccount))
 
   // Fetch user's chat blockee and blocker list after fetching their account


### PR DESCRIPTION
### Description

Randy flagged some weirdness with guest email in local storage. I think it might be related to this. Noticed we had unnecessary escaped quotes in the account local storage JSON.

```
{"userId":927500030,"collections":[],"guestEmail":"\"isaac+dec17+9@audius.co\""}
```

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._

Tested guest checkout and profile completion