### PR TITLE
[PAY-3677] Fix mobile explore collections

### DIFF
--- a/packages/mobile/src/components/core/Screen/ScreenPrimaryContent.tsx
+++ b/packages/mobile/src/components/core/Screen/ScreenPrimaryContent.tsx
@@ -20,7 +20,6 @@ type ScreenPrimaryContentProps = {
 export const ScreenPrimaryContent = (props: ScreenPrimaryContentProps) => {
   const { children, skeleton } = props
   const { isScreenReady, setIsPrimaryContentReady } = useScreenContext()
-
   useEffect(() => {
     if (!isScreenReady) return
     setIsPrimaryContentReady(true)

--- a/packages/mobile/src/screens/collection-screen/CollectionScreenDetailsTile.tsx
+++ b/packages/mobile/src/screens/collection-screen/CollectionScreenDetailsTile.tsx
@@ -538,8 +538,10 @@ const CollectionTrackList = ({
 
   const handleFetchCollection = useCallback(() => {
     dispatch(resetCollection())
-    dispatch(fetchCollection(collectionId as number, permalink, true))
-  }, [dispatch, collectionId, permalink])
+    if (numericCollectionId) {
+      dispatch(fetchCollection(collectionId as number, permalink, true))
+    }
+  }, [dispatch, collectionId, permalink, numericCollectionId])
 
   useFetchCollectionLineup(collectionId, handleFetchCollection)
 

--- a/packages/mobile/src/screens/smart-collection-screen/SmartCollectionScreen.tsx
+++ b/packages/mobile/src/screens/smart-collection-screen/SmartCollectionScreen.tsx
@@ -15,7 +15,7 @@ import LinearGradient from 'react-native-linear-gradient'
 import { useDispatch, useSelector } from 'react-redux'
 
 import type { FastImageProps } from '@audius/harmony-native'
-import { VirtualizedScrollView } from 'app/components/core'
+import { Screen, VirtualizedScrollView } from 'app/components/core'
 import { CollectionScreenDetailsTile } from 'app/screens/collection-screen/CollectionScreenDetailsTile'
 import type { SmartCollection } from 'app/screens/explore-screen/smartCollections'
 import { makeStyles } from 'app/styles'
@@ -69,7 +69,6 @@ export const SmartCollectionScreen = (props: SmartCollectionScreenProps) => {
   useFocusEffect(handleFetchSmartCollection)
 
   const collection = useSelector((state) => getCollection(state, { variant }))
-
   const playlistName = collection?.playlist_name ?? title
   const playlistDescription = collection?.description ?? description
 
@@ -107,19 +106,21 @@ export const SmartCollectionScreen = (props: SmartCollectionScreenProps) => {
   )
 
   return (
-    <VirtualizedScrollView style={styles.root}>
-      <CollectionScreenDetailsTile
-        collectionId={variant}
-        description={playlistDescription}
-        hasSaved={isSaved}
-        hideFavoriteCount
-        hideOverflow
-        hideRepostCount
-        hideActions
-        onPressSave={handlePressSave}
-        renderImage={renderImage}
-        title={playlistName}
-      />
-    </VirtualizedScrollView>
+    <Screen>
+      <VirtualizedScrollView style={styles.root}>
+        <CollectionScreenDetailsTile
+          collectionId={variant}
+          description={playlistDescription}
+          hasSaved={isSaved}
+          hideFavoriteCount
+          hideOverflow
+          hideRepostCount
+          hideActions
+          onPressSave={handlePressSave}
+          renderImage={renderImage}
+          title={playlistName}
+        />
+      </VirtualizedScrollView>
+    </Screen>
   )
 }


### PR DESCRIPTION
### Description

Explore collections were broken by https://github.com/AudiusProject/audius-protocol/issues/10288 because the smart collection screen is not wrapped in our screen component and thus renders a skeleton forever.

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._

Simulator