### PR TITLE
Always recover BuyAudio on page load

### DIFF
--- a/packages/web/src/store/application/ui/buy-audio/sagas.ts
+++ b/packages/web/src/store/application/ui/buy-audio/sagas.ts
@@ -33,7 +33,8 @@ import {
   formatWei,
   convertBigIntToAmountObject,
   convertWAudioToWei,
-  convertWeiToWAudio
+  convertWeiToWAudio,
+  waitForValue
 } from '@audius/common/utils'
 /* eslint-disable new-cap */
 import { TransactionHandler } from '@audius/sdk-legacy/dist/core'
@@ -1054,6 +1055,11 @@ function* recoverPurchaseIfNecessary() {
     const getFeatureEnabled = yield* getContext('getFeatureEnabled')
     const solanaWalletService = yield* getContext('solanaWalletService')
     const identityService = yield* getContext('identityService')
+    yield* call(
+      waitForValue,
+      getWalletAddresses,
+      (arg: ReturnType<typeof getWalletAddresses>) => arg.currentUser !== null
+    )
 
     if (
       !(

--- a/packages/web/src/store/application/ui/buy-audio/sagas.ts
+++ b/packages/web/src/store/application/ui/buy-audio/sagas.ts
@@ -1117,7 +1117,8 @@ function* recoverPurchaseIfNecessary() {
     )
 
     const rentMinimum = yield* call(getRootAccountRentExemptionMinimum)
-    const threshold = rentMinimum + 100 // pad by 100 lamports
+    // Pad by some extra lamport amount to reduce false positive rate
+    const threshold = rentMinimum + 1000000
     if (existingBalance > threshold) {
       // Get dummy quote and calculate fees
       const quote = yield* call(JupiterSingleton.getQuote, {

--- a/packages/web/src/store/application/ui/buy-audio/sagas.ts
+++ b/packages/web/src/store/application/ui/buy-audio/sagas.ts
@@ -1126,11 +1126,6 @@ function* recoverPurchaseIfNecessary() {
     const threshold =
       rootMinimum + TRANSACTION_FEE_FALLBACK * 3 + ataMinimum * 2
 
-    console.debug('Checking for BuyAudio Recovery', {
-      rootAccount: rootAccount.publicKey.toString(),
-      existingBalance,
-      threshold
-    })
     if (existingBalance > threshold) {
       // Get dummy quote and calculate fees
       const quote = yield* call(JupiterSingleton.getQuote, {
@@ -1153,12 +1148,6 @@ function* recoverPurchaseIfNecessary() {
             BigInt(existingBalance)
           : BigInt(0)
 
-      console.debug('Got quote.', {
-        existingBalance,
-        totalFees,
-        exchangableBalance,
-        estimatedAudio
-      })
       // Check if there's a non-zero exchangeble amount of SOL and at least one $AUDIO would be output
       // Should only occur as the result of a previously failed Swap
       if (

--- a/packages/web/src/store/application/ui/buy-audio/sagas.ts
+++ b/packages/web/src/store/application/ui/buy-audio/sagas.ts
@@ -1116,7 +1116,9 @@ function* recoverPurchaseIfNecessary() {
       'finalized'
     )
 
-    if (existingBalance > 0) {
+    const rentMinimum = yield* call(getRootAccountRentExemptionMinimum)
+    const threshold = rentMinimum + 100 // pad by 100 lamports
+    if (existingBalance > threshold) {
       // Get dummy quote and calculate fees
       const quote = yield* call(JupiterSingleton.getQuote, {
         inputTokenSymbol: 'SOL',
@@ -1316,14 +1318,7 @@ function* watchRecovery() {
  * Gate on local storage existing for the previous purchase attempt to reduce RPC load.
  */
 function* recoverOnPageLoad() {
-  const audiusLocalStorage = yield* getContext('localStorage')
-  const savedLocalStorageState = yield* call(
-    (val) => audiusLocalStorage.getJSONValue<BuyAudioLocalStorageState>(val),
-    BUY_AUDIO_LOCAL_STORAGE_KEY
-  )
-  if (savedLocalStorageState !== null && !isMobileWeb()) {
-    yield* put(startRecoveryIfNecessary())
-  }
+  yield* put(startRecoveryIfNecessary())
 }
 
 export default function sagas() {

--- a/packages/web/src/store/application/ui/buy-audio/sagas.ts
+++ b/packages/web/src/store/application/ui/buy-audio/sagas.ts
@@ -933,12 +933,9 @@ function* doBuyAudio({
       console.error('doBuyAudio: unexpectedly no fee payer override')
       return
     }
-    const { currentUser, web3User } = yield* select(getWalletAddresses)
+    const { currentUser } = yield* select(getWalletAddresses)
     if (!currentUser) {
       throw new Error('Failed to get current user wallet address')
-    }
-    if (currentUser !== web3User) {
-      throw new Error('Not allowed to recover while in manager mode')
     }
     yield* fork(function* () {
       yield* call(createUserBankIfNeeded, sdk, {

--- a/packages/web/src/store/application/ui/buy-audio/sagas.ts
+++ b/packages/web/src/store/application/ui/buy-audio/sagas.ts
@@ -33,8 +33,7 @@ import {
   formatWei,
   convertBigIntToAmountObject,
   convertWAudioToWei,
-  convertWeiToWAudio,
-  waitForAccount
+  convertWeiToWAudio
 } from '@audius/common/utils'
 /* eslint-disable new-cap */
 import { TransactionHandler } from '@audius/sdk-legacy/dist/core'
@@ -1055,7 +1054,6 @@ function* recoverPurchaseIfNecessary() {
   try {
     // Bail if not enabled
     yield* call(waitForWrite)
-    yield* call(waitForAccount)
     const getFeatureEnabled = yield* getContext('getFeatureEnabled')
     const solanaWalletService = yield* getContext('solanaWalletService')
     const identityService = yield* getContext('identityService')


### PR DESCRIPTION
### Description

Prior to this change, we only attempted `BuyAudio` recovery when there were local storage remnants. This meant that if you got stuck and somehow your local storage got cleared or you changed devices, you'd be stuck forever. This local storage check was useful however because your balance of SOL in the root wallet would be > 0 in a number of other cases, and we didn't necessarily want to convert that SOL to AUDIO. This change also therefore increases the threshold of how much SOL is required before the recovery kicks in.

### How Has This Been Tested?

Tested by sending my root account SOL and WAUDIO and seeing the recovery flow start