### PR TITLE
[PAY-3661] Fix audio balance checks

### DIFF
--- a/packages/common/src/services/audius-backend/AudiusBackend.ts
+++ b/packages/common/src/services/audius-backend/AudiusBackend.ts
@@ -1473,11 +1473,11 @@ export const audiusBackend = ({
         address,
         sdk
       })
-      return wAUDIO(amount)
+      return wAUDIO(amount).value
     } catch (err) {
       // Non-existent token accounts indicate 0 balance. Other errors fall through
       if (err instanceof TokenAccountNotFoundError) {
-        return wAUDIO(0)
+        return wAUDIO(0).value
       }
       throw err
     }

--- a/packages/common/src/services/audius-backend/AudiusBackend.ts
+++ b/packages/common/src/services/audius-backend/AudiusBackend.ts
@@ -1459,7 +1459,7 @@ export const audiusBackend = ({
   /**
    * Fetches the SPL WAUDIO balance for the user's solana wallet address
    * @param {string} The solana wallet address
-   * @returns {Promise<BN | null>} Returns the balance, 0 for non-existent token accounts
+   * @returns {Promise<wAUDIO | null>} Returns the balance, 0 for non-existent token accounts
    */
   async function getAddressWAudioBalance({
     address,
@@ -1473,11 +1473,11 @@ export const audiusBackend = ({
         address,
         sdk
       })
-      return new BN(amount.toString())
+      return wAUDIO(amount)
     } catch (err) {
       // Non-existent token accounts indicate 0 balance. Other errors fall through
       if (err instanceof TokenAccountNotFoundError) {
-        return new BN(0)
+        return wAUDIO(0)
       }
       throw err
     }

--- a/packages/common/src/services/wallet-client/WalletClient.ts
+++ b/packages/common/src/services/wallet-client/WalletClient.ts
@@ -1,4 +1,4 @@
-import { AUDIO } from '@audius/fixed-decimal'
+import { AUDIO, wAUDIO } from '@audius/fixed-decimal'
 import { AudiusSdk } from '@audius/sdk'
 import BN from 'bn.js'
 
@@ -146,7 +146,7 @@ export class WalletClient {
               sdk
             })
           // Convert SPL wAudio -> AUDIO BN
-          return new BN(AUDIO(balance).value.toString()) as BNWei
+          return new BN(AUDIO(wAUDIO(balance)).value.toString()) as BNWei
         })
       ])
 
@@ -206,7 +206,7 @@ export class WalletClient {
           return {
             address: wallet,
             // wAUDIO balances use a different precision, and we want BNWei as output to be consistent
-            balance: new BN(AUDIO(balance).value.toString()) as BNWei
+            balance: new BN(AUDIO(wAUDIO(balance)).value.toString()) as BNWei
           }
         })
       )

--- a/packages/common/src/services/wallet-client/WalletClient.ts
+++ b/packages/common/src/services/wallet-client/WalletClient.ts
@@ -146,6 +146,8 @@ export class WalletClient {
         )
       ])
 
+      // TODO: Remove once getAddressTotalStakedBalance is throwing for unexpected errors
+      // and let the catch below handle things
       if (balances.some((b) => isNullOrUndefined(b))) {
         throw new Error(
           'Unable to fetch balance for one or more associated wallets.'

--- a/packages/common/src/services/wallet-client/WalletClient.ts
+++ b/packages/common/src/services/wallet-client/WalletClient.ts
@@ -194,14 +194,14 @@ export class WalletClient {
       const sdk = await this.audiusSdk()
       const balances: { address: string; balance: BNWei }[] = await Promise.all(
         wallets.map(async (wallet) => {
-          const tokenAccountInfo =
-            await this.audiusBackendInstance.getAssociatedTokenAccountInfo({
+          const balance =
+            await this.audiusBackendInstance.getAddressWAudioBalance({
               address: wallet,
               sdk
             })
           return {
             address: wallet,
-            balance: new BN(tokenAccountInfo?.amount.toString() ?? 0) as BNWei
+            balance: balance as BNWei
           }
         })
       )


### PR DESCRIPTION
### Description
The migration into AudiusBackend changed some subtle details about how we interact with solana addresses.
The _intended_ behavior for getting token account info is:
1. Try the provided address.
2. If that comes back with an "Invalid owner" error, it's likely a root wallet and not a token account. So derive the associated address and try again.
3. For all other errors, throw

And then for getting balances, using the above logic
1. Attempt to fetch the token account info
2. If we get an 'account not found' error, then the address passed is either a non-existent token account, or a root wallet with no token account. In either case, we consider it an 'empty wallet' and return a balance of zero
3. For all other errors, throw

I cleaned up the logic that gets or creates ATAs (used in both the balance check and the send tokens flow) to exception based for these cases instead of catching errors and just returning `null`. And then I updated balance check logic to leverage this apporpriately.

### How Has This Been Tested?
Did a basic test on client against staging. Still need to test some other affected flows.
