### PR TITLE
Add one shot challenge manager

### DIFF
--- a/packages/discovery-provider/src/challenges/challenge_event.py
+++ b/packages/discovery-provider/src/challenges/challenge_event.py
@@ -22,3 +22,4 @@ class ChallengeEvent(str, enum.Enum):
     first_playlist = "first_playlist"
     audio_matching_buyer = "audio_matching_buyer"
     audio_matching_seller = "audio_matching_seller"
+    one_shot = "one_shot"

--- a/packages/discovery-provider/src/challenges/challenge_event_bus.py
+++ b/packages/discovery-provider/src/challenges/challenge_event_bus.py
@@ -17,6 +17,7 @@ from src.challenges.connect_verified_challenge import connect_verified_challenge
 from src.challenges.first_playlist_challenge import first_playlist_challenge_manager
 from src.challenges.listen_streak_challenge import listen_streak_challenge_manager
 from src.challenges.mobile_install_challenge import mobile_install_challenge_manager
+from src.challenges.one_shot_challenge import one_shot_challenge_manager
 from src.challenges.profile_challenge import profile_challenge_manager
 from src.challenges.referral_challenge import (
     referral_challenge_manager,
@@ -275,5 +276,6 @@ def setup_challenge_bus():
     bus.register_listener(
         ChallengeEvent.audio_matching_seller, audio_matching_seller_challenge_manager
     )
+    bus.register_listener(ChallengeEvent.one_shot, one_shot_challenge_manager)
 
     return bus

--- a/packages/discovery-provider/src/challenges/one_shot_challenge.py
+++ b/packages/discovery-provider/src/challenges/one_shot_challenge.py
@@ -1,0 +1,18 @@
+from typing import Dict
+
+from sqlalchemy.orm.session import Session
+
+from src.challenges.challenge import ChallengeManager, ChallengeUpdater
+
+
+class OneShotChallengeUpdater(ChallengeUpdater):
+    def should_create_new_challenge(
+        self, session, event: str, user_id: int, extra: Dict
+    ) -> bool:
+        return False
+
+    def should_show_challenge_for_user(self, session: Session, user_id: int) -> bool:
+        return True
+
+
+one_shot_challenge_manager = ChallengeManager("o", OneShotChallengeUpdater())


### PR DESCRIPTION
### Description
Turns out we make assumptions about a challenge having a manager as @schottra found this error

```
  File "/audius-discovery-provider/src/queries/get_challenges.py", line 259, in <listcomp>
    and event_bus.get_manager(challenge.id).should_show_challenge_for_user(
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/audius-discovery-provider/src/challenges/challenge_event_bus.py", line 74, in get_manager
    return self._managers[challenge_id]
           ~~~~~~~~~~~~~~^^^^^^^^^^^^^^
KeyError: 'o'
```

This seems to be the bare minimum to query for challenges successfully. We don't need a manager to process events just to get them.

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._

Tested on stage. Rewards page shows correctly.

https://discoveryprovider.audius.co/v1/users/0MMZ6/challenges?api_key=8acf5eb7436ea403ee536a7334faa5e9ada4b50f&app_name=audius-client

is successful
