### PR TITLE
[C-5534] Add feature tagging to errorSagas

### DIFF
--- a/packages/common/src/models/ErrorReporting.ts
+++ b/packages/common/src/models/ErrorReporting.ts
@@ -39,7 +39,8 @@ export enum Feature {
   Playback = 'playback',
   Purchase = 'purchase',
   Comments = 'comments',
-  Chats = 'chats'
+  Chats = 'chats',
+  Social = 'social'
 }
 
 export type ReportToSentryArgs = {

--- a/packages/common/src/models/ErrorReporting.ts
+++ b/packages/common/src/models/ErrorReporting.ts
@@ -40,7 +40,9 @@ export enum Feature {
   Purchase = 'purchase',
   Comments = 'comments',
   Chats = 'chats',
-  Social = 'social'
+  Social = 'social',
+  Notifications = 'notifications',
+  Rewards = 'rewards'
 }
 
 export type ReportToSentryArgs = {

--- a/packages/common/src/store/player/slice.ts
+++ b/packages/common/src/store/player/slice.ts
@@ -1,6 +1,6 @@
 import { createSlice, PayloadAction } from '@reduxjs/toolkit'
 
-import { UID, ID, Collectible } from '../../models'
+import { UID, ID, Collectible, Feature } from '../../models'
 import { Maybe, Nullable } from '../../utils'
 
 import { PlaybackRate, PlayerBehavior } from './types'
@@ -114,6 +114,7 @@ type ErrorPayload = {
   error: string
   trackId: ID
   info: string
+  feature?: Feature
 }
 
 type ResetPayload = {

--- a/packages/mobile/src/screens/notifications-screen/NotificationErrorBoundary.tsx
+++ b/packages/mobile/src/screens/notifications-screen/NotificationErrorBoundary.tsx
@@ -1,6 +1,7 @@
 import type { ReactNode } from 'react'
 import { PureComponent } from 'react'
 
+import { Feature } from '@audius/common/models'
 import * as Sentry from '@sentry/react-native'
 
 type NotificationErrorBoundaryProps = {
@@ -17,6 +18,7 @@ export class NotificationErrorBoundary extends PureComponent<NotificationErrorBo
 
     Sentry.withScope((scope) => {
       scope.setExtras(errorInfo)
+      scope.setTag('feature', Feature.Notifications)
       Sentry.captureException(error)
     })
   }

--- a/packages/web/src/common/store/pages/audio-rewards/sagas.ts
+++ b/packages/web/src/common/store/pages/audio-rewards/sagas.ts
@@ -8,7 +8,8 @@ import {
   StringWei,
   SpecifierWithAmount,
   Name,
-  Id
+  Id,
+  Feature
 } from '@audius/common/models'
 import {
   IntKeys,
@@ -391,7 +392,8 @@ function* claimSingleChallengeRewardAsync(
             challengeId,
             specifier: res.specifier,
             amount: res.amount
-          }
+          },
+          feature: Feature.Rewards
         })
       }
     }

--- a/packages/web/src/common/store/player/errorSagas.ts
+++ b/packages/web/src/common/store/player/errorSagas.ts
@@ -1,3 +1,4 @@
+import { Feature } from '@audius/common/models'
 import { playerActions } from '@audius/common/store'
 
 import { createErrorSagas } from 'utils/errorSagas'
@@ -14,7 +15,8 @@ const errorSagas = createErrorSagas<PlayerErrors>({
     error: action.error,
     trackId: action.trackId,
     info: action.info
-  })
+  }),
+  feature: Feature.Playback
 })
 
 export default errorSagas

--- a/packages/web/src/common/store/player/sagas.ts
+++ b/packages/web/src/common/store/player/sagas.ts
@@ -1,4 +1,10 @@
-import { Id, Kind, OptionalId, type Track } from '@audius/common/models'
+import {
+  Id,
+  Kind,
+  OptionalId,
+  type Track,
+  Feature
+} from '@audius/common/models'
 import {
   accountSelectors,
   cacheTracksSelectors,
@@ -430,7 +436,14 @@ export function* handleAudioErrors() {
       if (streamObj?.mirrors && streamObj.mirrors.length + 1 > retries) {
         yield* put(play({ trackId, retries: retries + 1 }))
       } else {
-        yield* put(errorAction({ error, trackId, info: data }))
+        yield* put(
+          errorAction({
+            error,
+            trackId,
+            info: data,
+            feature: Feature.Playback
+          })
+        )
       }
     }
   }

--- a/packages/web/src/common/store/social/collections/errorSagas.ts
+++ b/packages/web/src/common/store/social/collections/errorSagas.ts
@@ -1,3 +1,4 @@
+import { Feature } from '@audius/common/models'
 import { collectionsSocialActions as socialCollectionActions } from '@audius/common/store'
 
 import { createErrorSagas } from 'utils/errorSagas'
@@ -17,7 +18,8 @@ const errorSagas = createErrorSagas<CollectionErrors>({
   getAdditionalInfo: (action: CollectionErrors) => ({
     error: action.error,
     collectionId: action.collectionId
-  })
+  }),
+  feature: Feature.Social
 })
 
 export default errorSagas

--- a/packages/web/src/common/store/social/tracks/errorSagas.ts
+++ b/packages/web/src/common/store/social/tracks/errorSagas.ts
@@ -1,3 +1,4 @@
+import { Feature } from '@audius/common/models'
 import { tracksSocialActions as socialTrackActions } from '@audius/common/store'
 
 import { createErrorSagas } from 'utils/errorSagas'
@@ -18,7 +19,8 @@ const errorSagas = createErrorSagas<TrackRepostErrors>({
   getAdditionalInfo: (action: TrackRepostErrors) => ({
     error: action.error,
     trackId: action.trackId
-  })
+  }),
+  feature: Feature.Social
 })
 
 export default errorSagas

--- a/packages/web/src/common/store/social/users/errorSagas.ts
+++ b/packages/web/src/common/store/social/users/errorSagas.ts
@@ -1,3 +1,4 @@
+import { Feature } from '@audius/common/models'
 import { usersSocialActions as socialUserActions } from '@audius/common/store'
 
 import { createErrorSagas } from 'utils/errorSagas'
@@ -18,7 +19,8 @@ const errorSagas = createErrorSagas<UserErrors>({
   getAdditionalInfo: (action: UserErrors) => ({
     error: action.error,
     userId: action.userId
-  })
+  }),
+  feature: Feature.Social
 })
 
 export default errorSagas

--- a/packages/web/src/store/errors/actions.ts
+++ b/packages/web/src/store/errors/actions.ts
@@ -1,7 +1,8 @@
 import {
   ErrorLevel,
   AdditionalErrorReportInfo,
-  ReportToSentryArgs
+  ReportToSentryArgs,
+  Feature
 } from '@audius/common/models'
 
 export const HANDLE_ERROR = 'ERROR/HANDLE_ERROR'
@@ -24,6 +25,7 @@ export type HandleErrorAction = {
 
   additionalInfo?: AdditionalErrorReportInfo
   level?: ErrorLevel
+  feature?: Feature
   uiErrorCode: UiErrorCode
 }
 

--- a/packages/web/src/store/errors/sagas.ts
+++ b/packages/web/src/store/errors/sagas.ts
@@ -15,7 +15,8 @@ function* handleError(action: errorActions.HandleErrorAction) {
       level: action.level,
       additionalInfo: action.additionalInfo,
       error: new Error(action.message),
-      name: action.name
+      name: action.name,
+      feature: action.feature
     })
     yield put(
       make(Name.APP_ERROR, {

--- a/packages/web/src/utils/errorSagas.ts
+++ b/packages/web/src/utils/errorSagas.ts
@@ -1,4 +1,4 @@
-import { AdditionalErrorReportInfo } from '@audius/common/models'
+import { AdditionalErrorReportInfo, Feature } from '@audius/common/models'
 import { takeEvery, put } from 'redux-saga/effects'
 
 import * as errorActions from 'store/errors/actions'
@@ -11,13 +11,15 @@ export const createErrorSagas = <ActionType extends { type: string }>({
   getShouldRedirect,
   getShouldReport,
   getType = (actionType: string) => actionType, // optionally modify the error type sent to our error reporting service
-  getAdditionalInfo = (action: ActionType) => ({}) // optionally add additional info to the error report
+  getAdditionalInfo = (action: ActionType) => ({}), // optionally add additional info to the error report
+  feature
 }: {
   errorTypes: string[]
   getShouldRedirect: (action: ActionType) => boolean
   getShouldReport: (action: ActionType) => boolean
   getType?: (actionType: string) => string
   getAdditionalInfo?: (action: ActionType) => AdditionalErrorReportInfo
+  feature?: Feature
 }) => {
   function* handleError(action: ActionType) {
     console.info(`Handling error: ${JSON.stringify(action)}`)
@@ -30,7 +32,8 @@ export const createErrorSagas = <ActionType extends { type: string }>({
         message: actionType,
         shouldRedirect,
         shouldReport,
-        additionalInfo
+        additionalInfo,
+        feature
       })
     )
   }


### PR DESCRIPTION
### Description

- Adds `reportToSentry` feature tag support to `createErrorSagas`
- Adds remaining features
	- Social
	- Notifications
	- Rewards
- Audited all `reportToSentry` call sites. We're now tagging all major feature categories
	- Opted not to include coinflow, withdraw, and other wallet errors in purchase tag, but we could change that

### How Has This Been Tested?

runs on local