### PR TITLE
Ensure git sha passed into audiusd build

### DIFF
--- a/.circleci/src/jobs/@audiusd-jobs.yml
+++ b/.circleci/src/jobs/@audiusd-jobs.yml
@@ -52,7 +52,7 @@ build-audiusd:
             echo "Docker image $DOCKER_IMAGE already exists. Skipping build."
           else
             echo "Docker image $DOCKER_IMAGE not found. Building and pushing..."
-            BUILD_ARGS="--build-arg git_sha=${CIRCLE_SHA1}" make build-push-audiusd AD_TAG="$CIRCLE_SHA1"
+            make build-push-audiusd AD_TAG="$CIRCLE_SHA1"
           fi
     - docker-logout
     - docker-prune

--- a/Makefile
+++ b/Makefile
@@ -84,10 +84,10 @@ build-push-wrapper:
 
 .PHONY: build-audiusd-local build-push-audiusd build-push-cpp
 build-audiusd-local:
-	docker build $(BUILD_ARGS) -t audius/audiusd:$(AD_TAG) -t audius/audiusd:local -f ./cmd/audiusd/Dockerfile ./
+	docker build --build-arg GIT_SHA=$(AD_TAG) -t audius/audiusd:$(AD_TAG) -t audius/audiusd:local -f ./cmd/audiusd/Dockerfile ./
 
 build-push-audiusd:
-	DOCKER_DEFAULT_PLATFORM=linux/amd64 docker build $(BUILD_ARGS) --push -t audius/audiusd:$(AD_TAG) -f ./cmd/audiusd/Dockerfile ./
+	DOCKER_DEFAULT_PLATFORM=linux/amd64 docker build --build-arg GIT_SHA=$(AD_TAG) --push -t audius/audiusd:$(AD_TAG) -f ./cmd/audiusd/Dockerfile ./
 
 build-push-cpp:
 	docker buildx build --platform linux/amd64,linux/arm64 --push -t audius/cpp:latest -f ./cmd/audiusd/Dockerfile.cpp ./

--- a/cmd/audiusd/Dockerfile
+++ b/cmd/audiusd/Dockerfile
@@ -28,8 +28,8 @@ RUN mkdir -p /data && \
 
 RUN localedef -i en_US -f UTF-8 en_US.UTF-8
 
-ARG git_sha
-ENV GIT_SHA=$git_sha
+ARG GIT_SHA
+ENV GIT_SHA=$GIT_SHA
 
 EXPOSE 80
 EXPOSE 443


### PR DESCRIPTION
### Description

```
# current
$ curl -s https://creatornode.audius.co/health_check | jq .data.git
""
```

TESTED with 

```
TAG=bdd1d8db5ddb6026c8d4e26fb61f82c5ec57db1c audius-cli upgrade
...

curl -s https://creatornode5.staging..audius.co/health_check | jq .data.git
"bdd1d8db5ddb6026c8d4e26fb61f82c5ec57db1c"
```