### PR TITLE
[PAY-3655] Fix issues with artwork edit

### DIFF
--- a/packages/mobile/src/components/fields/PickArtworkField.tsx
+++ b/packages/mobile/src/components/fields/PickArtworkField.tsx
@@ -93,31 +93,35 @@ export const PickArtworkField = (props: PickArtworkFieldProps) => {
 
   return (
     <View style={styles.root}>
-      <DynamicImage
-        source={source}
-        onLoad={handleImageLoad}
-        style={styles.image}
-        noSkeleton
-      >
-        <View style={styles.iconPicture}>
-          {isLoading || isImageLoading ? (
-            <LoadingSpinner style={styles.loading} />
-          ) : trackArtworkUrl ? null : (
-            <IconImage height={128} width={128} fill={neutralLight8} />
-          )}
-        </View>
-        <Flex style={styles.button} ph='m'>
-          <Button
-            variant='tertiary'
-            iconLeft={IconPencil}
-            onPress={onPress ?? handleChangeArtwork}
-            fullWidth
-          >
-            {buttonTitle ||
-              (trackArtworkUrl ? messages.changeArtwork : messages.addArtwork)}
-          </Button>
-        </Flex>
-      </DynamicImage>
+      {source?.uri ? (
+        <DynamicImage
+          source={source}
+          onLoad={handleImageLoad}
+          style={styles.image}
+          noSkeleton
+        >
+          <View style={styles.iconPicture}>
+            {isLoading || isImageLoading ? (
+              <LoadingSpinner style={styles.loading} />
+            ) : trackArtworkUrl ? null : (
+              <IconImage height={128} width={128} fill={neutralLight8} />
+            )}
+          </View>
+          <Flex style={styles.button} ph='m'>
+            <Button
+              variant='tertiary'
+              iconLeft={IconPencil}
+              onPress={onPress ?? handleChangeArtwork}
+              fullWidth
+            >
+              {buttonTitle ||
+                (trackArtworkUrl
+                  ? messages.changeArtwork
+                  : messages.addArtwork)}
+            </Button>
+          </Flex>
+        </DynamicImage>
+      ) : null}
       {error && touched ? (
         // @ts-ignore
         <InputErrorMessage message={error?.url || error} />

--- a/packages/web/src/common/store/cache/collections/commonSagas.ts
+++ b/packages/web/src/common/store/cache/collections/commonSagas.ts
@@ -214,7 +214,6 @@ function* confirmEditPlaylist(
         return playlist?.[0] ? userCollectionMetadataFromSDK(playlist[0]) : null
       },
       function* (confirmedPlaylist: Collection) {
-        // Update the cached collection so it no longer contains image upload artifacts
         yield* put(
           cacheActions.update(Kind.COLLECTIONS, [
             {
@@ -222,8 +221,7 @@ function* confirmEditPlaylist(
               metadata: {
                 ...reformatCollection({
                   collection: confirmedPlaylist
-                }),
-                artwork: {}
+                })
               }
             }
           ])

--- a/packages/web/src/common/store/cache/tracks/sagas.ts
+++ b/packages/web/src/common/store/cache/tracks/sagas.ts
@@ -275,13 +275,12 @@ function* confirmEditTrack(
         if (wasUnlisted && isNowListed) {
           confirmedTrack._is_publishing = false
         }
-        // Update the cached track so it no longer contains image upload artifacts
-        const { artwork: ignoredArtwork, ...metadata } = confirmedTrack
+
         yield* put(
           cacheActions.update(Kind.TRACKS, [
             {
               id: confirmedTrack.track_id,
-              metadata
+              metadata: confirmedTrack
             }
           ])
         )


### PR DESCRIPTION
### Description

* Edit flow was not displaying track/playlist artwork. Was able to fix this by not rendering the DynamicImage when the source is undefined (the container still displays properly)
* Track/playlist screen artwork was blank after editing. Fixed this by removing the code that was deleting the `artwork` field after edit. @dylanjeffers do you remember why this was necessary? Perhaps it was breaking now because of the image changes

### How Has This Been Tested?

Can edit tracks/playlists and their images and images display properly during/afterwards
