### PR TITLE
Migrate all but balanceOf to sdk clients

### DIFF
--- a/packages/common/src/services/audius-backend/AudiusBackend.ts
+++ b/packages/common/src/services/audius-backend/AudiusBackend.ts
@@ -1183,7 +1183,7 @@ export const audiusBackend = ({
     try {
       const checksumWallet = getAddress(address)
       const balance = await sdk.services.audiusTokenClient.balanceOf({
-        address: checksumWallet
+        account: checksumWallet
       })
       const delegatedBalance =
         await sdk.services.delegateManagerClient.contract.getTotalDelegatorStake(

--- a/packages/common/src/services/audius-backend/AudiusBackend.ts
+++ b/packages/common/src/services/audius-backend/AudiusBackend.ts
@@ -1182,13 +1182,9 @@ export const audiusBackend = ({
 
     try {
       const checksumWallet = getAddress(address)
-      // if (bustCache) {
-      //   audiusLibs.ethContracts.AudiusTokenClient.bustCache()
-      // }
-      // const balance: bigint =
-      //   await audiusLibs.ethContracts.AudiusTokenClient.balanceOf(
-      //     checksumWallet
-      //   )
+      const balance = await sdk.services.audiusTokenClient.balanceOf({
+        address: checksumWallet
+      })
       const delegatedBalance =
         await sdk.services.delegateManagerClient.contract.getTotalDelegatorStake(
           { delegatorAddress: checksumWallet }
@@ -1198,7 +1194,7 @@ export const audiusBackend = ({
           account: checksumWallet
         })
 
-      return AUDIO(delegatedBalance + stakedBalance).value
+      return AUDIO(balance + delegatedBalance + stakedBalance).value
     } catch (e) {
       reportError({ error: e as Error })
       console.error(e)

--- a/packages/common/src/services/wallet-client/WalletClient.ts
+++ b/packages/common/src/services/wallet-client/WalletClient.ts
@@ -40,15 +40,17 @@ export class WalletClient {
 
   /** Get user's current ETH Audio balance. Returns null on failure. */
   async getCurrentBalance({
-    ethAddress,
-    bustCache
-  }: { ethAddress?: string; bustCache?: boolean } = {}): Promise<BNWei | null> {
+    ethAddress
+  }: {
+    ethAddress: string
+  }): Promise<BNWei | null> {
     try {
+      const sdk = await this.audiusSdk()
       const balance = await this.audiusBackendInstance.getBalance({
         ethAddress,
-        bustCache
+        sdk
       })
-      return balance as BNWei
+      return new BN(balance?.toString() ?? 0) as BNWei
     } catch (err) {
       console.error(err)
       return null
@@ -99,9 +101,14 @@ export class WalletClient {
       throw new Error('No userbank account.')
     }
 
-    const ercAudioBalance = await this.audiusBackendInstance.getBalance({
-      bustCache: true
-    })
+    const ercAudioBalance = new BN(
+      (
+        await this.audiusBackendInstance.getBalance({
+          ethAddress,
+          sdk
+        })
+      )?.toString() ?? 0
+    )
     if (
       !isNullOrUndefined(ercAudioBalance) &&
       ercAudioBalance.gt(new BN('0'))

--- a/packages/sdk/src/sdk/services/Ethereum/contracts/AudiusToken/AudiusTokenClient.ts
+++ b/packages/sdk/src/sdk/services/Ethereum/contracts/AudiusToken/AudiusTokenClient.ts
@@ -11,9 +11,11 @@ import { parseParams } from '../../../../utils/parseParams'
 import type { AudiusWalletClient } from '../../../AudiusWalletClient'
 
 import {
+  BalanceOfSchema,
   PermitSchema,
   type AudiusTokenConfig,
-  type PermitParams
+  type PermitParams,
+  type BalanceOfParams
 } from './types'
 
 const ONE_HOUR_IN_MS = 1000 * 60 * 60
@@ -74,6 +76,17 @@ export class AudiusTokenClient {
       ...other
     })
     return await this.walletClient.writeContract(request)
+  }
+
+  public async balanceOf(params: BalanceOfParams) {
+    const { account } = await parseParams('balanceOf', BalanceOfSchema)(params)
+    const balance = await this.publicClient.readContract({
+      address: this.contractAddress,
+      abi: AudiusToken.abi,
+      functionName: 'balanceOf',
+      args: [account]
+    })
+    return BigInt(balance)
   }
 
   private async domain(): Promise<

--- a/packages/sdk/src/sdk/services/Ethereum/contracts/AudiusToken/types.ts
+++ b/packages/sdk/src/sdk/services/Ethereum/contracts/AudiusToken/types.ts
@@ -10,6 +10,12 @@ export type AudiusTokenConfigInternal = {
   address: Hex
 }
 
+export const BalanceOfSchema = z.object({
+  account: EthAddressSchema
+})
+
+export type BalanceOfParams = z.input<typeof BalanceOfSchema>
+
 export const PermitSchema = GasFeeSchema.and(
   z.object({
     args: z.object({

--- a/packages/web/src/common/store/pages/token-dashboard/getWalletInfo.ts
+++ b/packages/web/src/common/store/pages/token-dashboard/getWalletInfo.ts
@@ -13,7 +13,9 @@ export function* getWalletInfo(walletAddress: string, chain: Chain) {
   const [{ balance }] = yield* call(
     [
       walletClient,
-      chain === Chain.Eth ? 'getEthWalletBalances' : 'getSolWalletBalances'
+      chain === Chain.Eth
+        ? walletClient.getEthWalletBalances
+        : walletClient.getSolWalletBalances
     ],
     [walletAddress]
   )

--- a/packages/web/src/common/store/pages/token-dashboard/sagas.ts
+++ b/packages/web/src/common/store/pages/token-dashboard/sagas.ts
@@ -27,7 +27,7 @@ const { getUserId } = accountSelectors
 function* fetchEthWalletInfo(wallets: string[]) {
   const walletClient = yield* getContext('walletClient')
   const ethWalletBalances = yield* call(
-    [walletClient, 'getEthWalletBalances'],
+    [walletClient, walletClient.getEthWalletBalances],
     wallets
   )
 

--- a/packages/web/src/common/store/wallet/sagas.ts
+++ b/packages/web/src/common/store/wallet/sagas.ts
@@ -45,8 +45,7 @@ const {
   sendFailed,
   decreaseBalance
 } = walletActions
-const { getAccountBalance, getFreezeUntilTime, getLocalBalanceDidChange } =
-  walletSelectors
+const { getAccountBalance, getFreezeUntilTime } = walletSelectors
 const {
   fetchAssociatedWallets,
   transferEthAudioToSolWAudio,
@@ -233,13 +232,9 @@ function* fetchBalanceAsync() {
     const isBalanceFrozen = yield* call(getIsBalanceFrozen)
     if (isBalanceFrozen) return
 
-    const localBalanceChange: ReturnType<typeof getLocalBalanceDidChange> =
-      yield* select(getLocalBalanceDidChange)
-
     const [currentEthAudioWeiBalance, currentSolAudioWeiBalance] = yield* all([
       call([walletClient, walletClient.getCurrentBalance], {
-        ethAddress: account.wallet,
-        bustCache: localBalanceChange
+        ethAddress: account.wallet
       }),
       call([walletClient, walletClient.getCurrentWAudioBalance], {
         ethAddress: account.wallet
@@ -261,8 +256,7 @@ function* fetchBalanceAsync() {
 
     const associatedWalletBalance: BNWei | null = yield* call(
       [walletClient, walletClient.getAssociatedWalletBalance],
-      account.user_id,
-      /* bustCache */ localBalanceChange
+      account.user_id
     )
     if (isNullOrUndefined(associatedWalletBalance)) {
       console.warn(


### PR DESCRIPTION
### Description
Migrates the ETH contract usage for fetching various balances over to using the SDK versions.
I'm uncertain if we want to do some kind of caching to mimic the previous behavior.

### How Has This Been Tested?
I've done some basic testing with local client against prod using an account that has a connected ETH wallet with staked audio and it seems to work.
Needs a little more thorough testing for the sending flow.
