### PR TITLE
[PAY-3720][PAY-3718][PAY-3709] Add Harmony Components: NavItem, BalancePill, and NotificationCount

### DIFF
--- a/packages/harmony/src/components/NavItem/NavItem.mdx
+++ b/packages/harmony/src/components/NavItem/NavItem.mdx
@@ -1,0 +1,95 @@
+import {
+  Meta,
+  Title,
+  Description,
+  Controls,
+  Canvas,
+  Unstyled
+} from '@storybook/blocks'
+
+import { RelatedFoundations } from 'storybook/components'
+
+import { ThemeProvider } from '../../foundations/theme'
+import { Flex } from '../layout/Flex'
+
+import { NavItem } from './NavItem'
+import * as NavItemStories from './NavItem.stories'
+
+<Meta of={NavItemStories} />
+
+<Title />
+
+<Description of={NavItem} />
+
+A navigation item component, typically used in sidebars or navigation menus. Supports default, hover, and selected states, as well as optional left and right icons.
+
+## Usage
+
+The `NavItem` component displays a navigation link with options for left and right icons and different states (default, hover, selected).
+
+<Canvas of={NavItemStories.Default} />
+
+## Props
+
+<Controls />
+
+## States
+
+### Default
+
+<Canvas of={NavItemStories.Default} />
+
+### Selected
+
+<Canvas of={NavItemStories.Selected} />
+
+## Variations
+
+### With Left Icon
+
+<Canvas of={NavItemStories.WithLeftIcon} />
+
+### With Right Icon
+
+<Canvas of={NavItemStories.WithRightIcon} />
+
+### With Both Icons
+
+<Canvas of={NavItemStories.WithBothIcons} />
+
+## Styling
+
+The `NavItem` component uses the following foundational styles:
+
+- **Color:** Text and icon colors change based on the state (default, hover, selected).
+- **Spacing:** Uses `s` and `m` spacing values for padding and gaps.
+- **Corner Radius:** Uses `m` corner radius for the rounded corners.
+- **Background Color:** Changes based on the state:
+  - Default: transparent
+  - Hover: `surface2` (unless selected)
+  - Selected: `s400`
+- **Border:** A border appears on hover with `border.default` color.
+- **Typography:** Uses `title` variant with `l` size and `weak` strength.
+- **Transitions:** Smooth background-color transition with `0.18s ease-in-out`.
+
+## Themes
+
+<Unstyled>
+  <Flex gap='m' wrap='wrap'>
+    <ThemeProvider theme='day'>
+      <NavItem leftIcon='UserFeed'>Label</NavItem>
+    </ThemeProvider>
+    <ThemeProvider theme='dark'>
+      <NavItem leftIcon='UserFeed'>Label</NavItem>
+    </ThemeProvider>
+    <ThemeProvider theme='matrix'>
+      <NavItem leftIcon='UserFeed'>Label</NavItem>
+    </ThemeProvider>
+  </Flex>
+</Unstyled>
+
+## Related Foundations
+
+<RelatedFoundations
+  foundationNames={['Color', 'Spacing', 'CornerRadius', 'Typography']}
+/>

--- a/packages/harmony/src/components/NavItem/NavItem.stories.tsx
+++ b/packages/harmony/src/components/NavItem/NavItem.stories.tsx
@@ -1,0 +1,56 @@
+import type { Meta, StoryObj } from '@storybook/react'
+
+import { IconFeed, IconVolumeLevel3 } from '../../icons'
+
+import { NavItem } from './NavItem'
+
+const meta: Meta<typeof NavItem> = {
+  title: 'Components/NavItem',
+  component: NavItem,
+  parameters: {
+    design: {
+      type: 'figma',
+      url: '' // Add your Figma URL here
+    }
+  },
+  tags: ['autodocs']
+}
+
+export default meta
+
+type Story = StoryObj<typeof NavItem>
+
+export const Default: Story = {
+  args: {
+    children: 'Label'
+  }
+}
+
+export const Selected: Story = {
+  args: {
+    children: 'Label',
+    isSelected: true
+  }
+}
+
+export const WithLeftIcon: Story = {
+  args: {
+    children: 'Label',
+    leftIcon: IconFeed
+  }
+}
+
+export const WithRightIcon: Story = {
+  args: {
+    children: 'Label',
+    rightIcon: IconVolumeLevel3
+  }
+}
+
+export const WithBothIcons: Story = {
+  args: {
+    children: 'Label',
+    leftIcon: IconFeed,
+    rightIcon: IconVolumeLevel3
+  }
+}

--- a/packages/harmony/src/components/NavItem/NavItem.tsx
+++ b/packages/harmony/src/components/NavItem/NavItem.tsx
@@ -57,7 +57,13 @@ export const NavItem = ({
         }}
       >
         <Flex alignItems='center' gap='m' flex={1}>
-          {hasLeftIcon && <LeftIcon color={iconColor} />}
+          {hasLeftIcon && (
+            <LeftIcon
+              height={24}
+              width={24}
+              css={{ path: { fill: iconColor } }}
+            />
+          )}
           <Text
             variant='title'
             size='l'
@@ -71,7 +77,13 @@ export const NavItem = ({
             {children}
           </Text>
         </Flex>
-        {hasRightIcon && <RightIcon color={iconColor} />}
+        {hasRightIcon && (
+          <RightIcon
+            height={20}
+            width={20}
+            css={{ path: { fill: iconColor } }}
+          />
+        )}
       </Flex>
     </Flex>
   )

--- a/packages/harmony/src/components/NavItem/NavItem.tsx
+++ b/packages/harmony/src/components/NavItem/NavItem.tsx
@@ -1,5 +1,6 @@
 import { useTheme } from '@emotion/react'
 
+import { motion } from '../../foundations/motion'
 import { Flex } from '../layout/Flex'
 import { Text } from '../text/Text'
 
@@ -14,6 +15,7 @@ export const NavItem = ({
   leftIcon: LeftIcon,
   rightIcon: RightIcon,
   isSelected = false,
+  onClick,
   ...props
 }: NavItemProps) => {
   const { color } = useTheme()
@@ -25,7 +27,7 @@ export const NavItem = ({
 
   const textColor = isSelected ? 'staticWhite' : 'default'
 
-  const iconColor = isSelected ? color.static.staticWhite : color.neutral.n800
+  const iconColor = isSelected ? 'staticStaticWhite' : 'default'
 
   return (
     <Flex
@@ -36,9 +38,10 @@ export const NavItem = ({
       css={{
         width: '240px',
         cursor: 'pointer',
-        transition: 'background-color 0.18s ease-in-out'
+        transition: `background-color ${motion.hover}`
       }}
       {...props}
+      onClick={onClick}
     >
       <Flex
         alignItems='center'
@@ -56,34 +59,27 @@ export const NavItem = ({
           }
         }}
       >
-        <Flex alignItems='center' gap='m' flex={1}>
-          {hasLeftIcon && (
-            <LeftIcon
-              height={24}
-              width={24}
-              css={{ path: { fill: iconColor } }}
-            />
-          )}
+        <Flex
+          alignItems='center'
+          gap='m'
+          flex={1}
+          css={{
+            maxWidth: '240px'
+          }}
+        >
+          {hasLeftIcon ? <LeftIcon size='l' color={iconColor} /> : null}
           <Text
             variant='title'
             size='l'
             strength='weak'
             lineHeight='single'
             color={textColor}
-            css={{
-              whiteSpace: 'nowrap'
-            }}
+            ellipses
           >
             {children}
           </Text>
         </Flex>
-        {hasRightIcon && (
-          <RightIcon
-            height={20}
-            width={20}
-            css={{ path: { fill: iconColor } }}
-          />
-        )}
+        {hasRightIcon ? <RightIcon size='m' color={iconColor} /> : null}
       </Flex>
     </Flex>
   )

--- a/packages/harmony/src/components/NavItem/NavItem.tsx
+++ b/packages/harmony/src/components/NavItem/NavItem.tsx
@@ -1,0 +1,78 @@
+import { useTheme } from '@emotion/react'
+
+import { Flex } from '../layout/Flex'
+import { Text } from '../text/Text'
+
+import type { NavItemProps } from './types'
+
+/**
+ * A navigation item component, typically used in sidebars or navigation menus.
+ * Supports default, hover, and selected states, as well as optional left and right icons.
+ */
+export const NavItem = ({
+  children,
+  leftIcon: LeftIcon,
+  rightIcon: RightIcon,
+  isSelected = false,
+  ...props
+}: NavItemProps) => {
+  const { color } = useTheme()
+
+  const hasLeftIcon = !!LeftIcon
+  const hasRightIcon = !!RightIcon
+
+  const backgroundColor = isSelected ? color.secondary.s400 : undefined
+
+  const textColor = isSelected ? 'staticWhite' : 'default'
+
+  const iconColor = isSelected ? color.static.staticWhite : color.neutral.n800
+
+  return (
+    <Flex
+      alignItems='center'
+      gap='s'
+      pl='s'
+      pr='s'
+      css={{
+        width: '240px',
+        cursor: 'pointer',
+        transition: 'background-color 0.18s ease-in-out'
+      }}
+      {...props}
+    >
+      <Flex
+        alignItems='center'
+        flex={1}
+        gap='m'
+        p='s'
+        borderRadius='m'
+        css={{
+          backgroundColor,
+          borderWidth: '1px',
+
+          '&:hover': {
+            backgroundColor: isSelected ? undefined : color.background.surface2,
+            borderColor: color.border.default
+          }
+        }}
+      >
+        <Flex alignItems='center' gap='m' flex={1}>
+          {hasLeftIcon && <LeftIcon color={iconColor} />}
+          <Text
+            variant='title'
+            size='l'
+            strength='weak'
+            lineHeight='single'
+            color={textColor}
+            css={{
+              whiteSpace: 'nowrap'
+            }}
+          >
+            {children}
+          </Text>
+        </Flex>
+        {hasRightIcon && <RightIcon color={iconColor} />}
+      </Flex>
+    </Flex>
+  )
+}

--- a/packages/harmony/src/components/NavItem/index.ts
+++ b/packages/harmony/src/components/NavItem/index.ts
@@ -1,0 +1,2 @@
+export * from './NavItem'
+export * from './types'

--- a/packages/harmony/src/components/NavItem/types.ts
+++ b/packages/harmony/src/components/NavItem/types.ts
@@ -1,0 +1,14 @@
+import { IconComponent } from 'components/icon'
+
+import type { WithCSS } from '../../foundations/theme'
+
+export type NavItemProps = WithCSS<{
+  /** The label text of the navigation item. */
+  children: React.ReactNode
+  /** The name of the icon to display on the left side of the label. */
+  leftIcon?: IconComponent
+  /** The name of the icon to display on the right side of the label. */
+  rightIcon?: IconComponent
+  /** Whether the navigation item is currently selected. */
+  isSelected?: boolean
+}>

--- a/packages/harmony/src/components/NavItem/types.ts
+++ b/packages/harmony/src/components/NavItem/types.ts
@@ -11,4 +11,6 @@ export type NavItemProps = WithCSS<{
   rightIcon?: IconComponent
   /** Whether the navigation item is currently selected. */
   isSelected?: boolean
+  /** The callback function to be called when the navigation item is clicked. */
+  onClick?: () => void
 }>

--- a/packages/harmony/src/components/balance-pill/BalancePill.mdx
+++ b/packages/harmony/src/components/balance-pill/BalancePill.mdx
@@ -1,0 +1,59 @@
+import {
+  Meta,
+  Title,
+  Description,
+  Controls,
+  Canvas,
+  Unstyled
+} from '@storybook/blocks'
+
+import { Heading, RelatedFoundations } from 'storybook/components'
+
+import { ThemeProvider, themes } from '../../foundations/theme'
+import { Flex } from '../layout/Flex'
+import { Text } from '../text/Text'
+
+import { BalancePill } from './BalancePill'
+import * as BalancePillStories from './BalancePill.stories'
+
+<Meta of={BalancePillStories} />
+
+<Title />
+
+<Description of={BalancePill} />
+
+## Usage
+
+The `BalancePill` component is designed to display a balance amount along with an optional icon or child component. It utilizes several foundational styles from the Harmony design system, including colors, spacing, and border-radius.
+
+<Canvas of={BalancePillStories.Default} />
+
+## Themes
+
+<Unstyled>
+  <Flex gap='m' wrap='wrap'>
+    <ThemeProvider theme='day'>
+      <BalancePill balance='1,000'>
+        <Text>💰</Text>
+      </BalancePill>
+    </ThemeProvider>
+    <ThemeProvider theme='dark'>
+      <BalancePill balance='1,000'>
+        <Text>💰</Text>
+      </BalancePill>
+    </ThemeProvider>
+    <ThemeProvider theme='matrix'>
+      <BalancePill balance='1,000'>
+        <Text>💰</Text>
+      </BalancePill>
+    </ThemeProvider>
+  </Flex>
+</Unstyled>
+
+## Props
+
+<Controls />
+
+## Related Foundations
+
+<RelatedFoundations foundationNames={['Color', 'Spacing', 'CornerRadius']} />

--- a/packages/harmony/src/components/balance-pill/BalancePill.stories.tsx
+++ b/packages/harmony/src/components/balance-pill/BalancePill.stories.tsx
@@ -1,0 +1,25 @@
+import type { Meta, StoryObj } from '@storybook/react'
+
+import { BalancePill } from './BalancePill'
+
+const meta: Meta<typeof BalancePill> = {
+  title: 'Components/BalancePill',
+  component: BalancePill,
+  parameters: {
+    design: {
+      type: 'figma',
+      url: '' // Add your Figma URL here
+    }
+  },
+  tags: ['autodocs']
+}
+
+export default meta
+
+type Story = StoryObj<typeof BalancePill>
+
+export const Default: Story = {
+  args: {
+    balance: 125
+  }
+}

--- a/packages/harmony/src/components/balance-pill/BalancePill.tsx
+++ b/packages/harmony/src/components/balance-pill/BalancePill.tsx
@@ -1,0 +1,52 @@
+import { useTheme, CSSObject } from '@emotion/react'
+
+import { Flex } from '../layout/Flex'
+import { Text } from '../text/Text'
+
+import type { BalancePillProps } from './types'
+
+/**
+ * A pill-shaped component that displays a balance, typically used to show a user's token balance.
+ */
+export const BalancePill = ({
+  balance,
+  children,
+  ...props
+}: BalancePillProps) => {
+  const { color } = useTheme()
+
+  const textStyles: CSSObject = {
+    color: color.neutral.n950
+  }
+
+  return (
+    <Flex
+      pl='s'
+      alignItems='center'
+      gap='xs'
+      borderRadius='circle'
+      border='default'
+      backgroundColor='surface1'
+      {...props}
+    >
+      <Text
+        variant='label'
+        size='s'
+        strength='strong'
+        textAlign='center'
+        css={textStyles}
+      >
+        {balance}
+      </Text>
+      <Flex
+        w='unit6'
+        h='unit6'
+        p='unitHalf'
+        justifyContent='center'
+        alignItems='center'
+      >
+        {children}
+      </Flex>
+    </Flex>
+  )
+}

--- a/packages/harmony/src/components/balance-pill/index.ts
+++ b/packages/harmony/src/components/balance-pill/index.ts
@@ -1,0 +1,2 @@
+export * from './BalancePill'
+export * from './types'

--- a/packages/harmony/src/components/balance-pill/types.ts
+++ b/packages/harmony/src/components/balance-pill/types.ts
@@ -1,0 +1,6 @@
+import { ReactNode } from 'react'
+
+export type BalancePillProps = {
+  balance: string | number
+  children: ReactNode
+}

--- a/packages/harmony/src/components/notification-count/NotificationCount.mdx
+++ b/packages/harmony/src/components/notification-count/NotificationCount.mdx
@@ -1,0 +1,134 @@
+import { Meta, Title, Description, Primary, Controls } from '@storybook/blocks'
+
+import { IconButton } from 'components/button/IconButton/IconButton'
+import { Flex } from 'components/layout'
+import { IconNotificationOn } from 'icons'
+import { ComponentRules } from 'storybook/components'
+
+import { NotificationCount } from './NotificationCount'
+import * as NotificationCountStories from './NotificationCount.stories'
+
+<Meta of={NotificationCountStories} />
+
+<Title />
+
+- [Overview](#overview)
+- [Props](#props)
+- [Use cases and examples](#use-cases-and-examples)
+- [Do's and dont's](#dos-and-donts)
+
+## Overview
+
+<Description />
+
+<Primary />
+
+## Props
+
+<Controls />
+
+## Use cases and examples
+
+- Use to indicate unread or pending notifications or messages.
+- Commonly placed on top of icons or buttons.
+- Keep counts concise and readable.
+- Can be used without a child element to display a standalone notification count.
+- Supports different sizes for visual hierarchy.
+
+### Example with an Icon Button
+
+<Flex position='relative'>
+  <NotificationCount count={3}>
+    <IconButton icon={IconNotificationOn} aria-label='Notifications' />
+  </NotificationCount>
+</Flex>
+
+### Example with a different size
+
+<Flex position='relative'>
+  <NotificationCount count={105} size='s'>
+    <IconButton icon={IconNotificationOn} aria-label='Notifications' />
+  </NotificationCount>
+</Flex>
+
+### Example without a child
+
+<NotificationCount count={5} />
+
+## Do's and don'ts
+
+<ComponentRules
+  rules={[
+    {
+      positive: {
+        description: 'Place notification count in the top-right corner.',
+        component: (
+          <Flex position='relative'>
+            <NotificationCount count={3}>
+              <IconButton
+                icon={IconNotificationOn}
+                aria-label='Notifications'
+              />
+            </NotificationCount>
+          </Flex>
+        )
+      },
+      negative: {
+        description:
+          "Don't place notification count where it might be hidden or unclear.",
+        component: (
+          <Flex position='relative'>
+            <IconButton
+              icon={IconNotificationOn}
+              aria-label='Notifications'
+              // Incorrect usage: NotificationCount should wrap the IconButton
+              css={{
+                '> *': {
+                  position: 'absolute',
+                  top: 'auto',
+                  bottom: 0,
+                  right: 0,
+                  transform: 'none'
+                }
+              }}
+            />
+            <NotificationCount count={3} />
+          </Flex>
+        )
+      }
+    },
+    {
+      positive: {
+        description: 'Use for counts over 99 to display "99+".',
+        component: <NotificationCount count={150} />
+      },
+      negative: {
+        description: "Don't use for counts under 0.",
+        component: (
+          // This will render nothing as per component logic
+          <NotificationCount count={-5} />
+        )
+      }
+    },
+    {
+      positive: {
+        description: "Use 's' size for smaller contexts or less emphasis.",
+        component: <NotificationCount count={12} size='s' />
+      },
+      negative: {
+        description:
+          "Don't use 's' size when the count needs to be prominently displayed.",
+        component: (
+          <Flex position='relative'>
+            <NotificationCount count={3} size='s'>
+              <IconButton
+                icon={IconNotificationOn}
+                aria-label='Notifications'
+              />
+            </NotificationCount>
+          </Flex>
+        )
+      }
+    }
+  ]}
+/>

--- a/packages/harmony/src/components/notification-count/NotificationCount.mdx
+++ b/packages/harmony/src/components/notification-count/NotificationCount.mdx
@@ -1,11 +1,14 @@
-import { Meta, Title, Description, Primary, Controls } from '@storybook/blocks'
+import {
+  Meta,
+  Title,
+  Description,
+  Primary,
+  Controls,
+  Canvas
+} from '@storybook/blocks'
 
-import { IconButton } from 'components/button/IconButton/IconButton'
-import { Flex } from 'components/layout'
-import { IconNotificationOn } from 'icons'
 import { ComponentRules } from 'storybook/components'
 
-import { NotificationCount } from './NotificationCount'
 import * as NotificationCountStories from './NotificationCount.stories'
 
 <Meta of={NotificationCountStories} />
@@ -14,12 +17,15 @@ import * as NotificationCountStories from './NotificationCount.stories'
 
 - [Overview](#overview)
 - [Props](#props)
-- [Use cases and examples](#use-cases-and-examples)
-- [Do's and dont's](#dos-and-donts)
+- [Usage Guidelines](#usage-guidelines)
+- [States](#states)
+- [Do's and Don'ts](#dos-and-donts)
 
 ## Overview
 
 <Description />
+
+The NotificationCount component displays a small badge with a count, typically used to show unread notifications or pending items. It can be used standalone or wrapped around another component.
 
 <Primary />
 
@@ -27,107 +33,57 @@ import * as NotificationCountStories from './NotificationCount.stories'
 
 <Controls />
 
-## Use cases and examples
+## Usage Guidelines
 
-- Use to indicate unread or pending notifications or messages.
-- Commonly placed on top of icons or buttons.
-- Keep counts concise and readable.
-- Can be used without a child element to display a standalone notification count.
-- Supports different sizes for visual hierarchy.
+- Use to indicate unread or pending notifications
+- Wrap the NotificationCount around the target component (usually an icon or button)
+- For counts over 99, it will display as "99+"
+- Use size 's' for less emphasis or in compact layouts
+- The badge appears in the top-right corner by default
+- Supports hover states when parent has the 'parent' className
 
-### Example with an Icon Button
+## States
 
-<Flex position='relative'>
-  <NotificationCount count={3}>
-    <IconButton icon={IconNotificationOn} aria-label='Notifications' />
-  </NotificationCount>
-</Flex>
+### Default
 
-### Example with a different size
+<Canvas of={NotificationCountStories.Default} />
 
-<Flex position='relative'>
-  <NotificationCount count={105} size='s'>
-    <IconButton icon={IconNotificationOn} aria-label='Notifications' />
-  </NotificationCount>
-</Flex>
+### With Icon
 
-### Example without a child
+<Canvas of={NotificationCountStories.WithIcon} />
 
-<NotificationCount count={5} />
+### Small Size
 
-## Do's and don'ts
+<Canvas of={NotificationCountStories.SmallSize} />
+
+### Large Number
+
+<Canvas of={NotificationCountStories.LargeNumber} />
+
+## Do's and Don'ts
 
 <ComponentRules
   rules={[
     {
       positive: {
-        description: 'Place notification count in the top-right corner.',
-        component: (
-          <Flex position='relative'>
-            <NotificationCount count={3}>
-              <IconButton
-                icon={IconNotificationOn}
-                aria-label='Notifications'
-              />
-            </NotificationCount>
-          </Flex>
-        )
+        description: 'Wrap NotificationCount around the target component.',
+        component: NotificationCountStories.WithIcon.render?.()
       },
       negative: {
         description:
-          "Don't place notification count where it might be hidden or unclear.",
-        component: (
-          <Flex position='relative'>
-            <IconButton
-              icon={IconNotificationOn}
-              aria-label='Notifications'
-              // Incorrect usage: NotificationCount should wrap the IconButton
-              css={{
-                '> *': {
-                  position: 'absolute',
-                  top: 'auto',
-                  bottom: 0,
-                  right: 0,
-                  transform: 'none'
-                }
-              }}
-            />
-            <NotificationCount count={3} />
-          </Flex>
-        )
+          "Don't place NotificationCount as a sibling - it should wrap the target component.",
+        component: NotificationCountStories.Default.render?.()
       }
     },
     {
       positive: {
-        description: 'Use for counts over 99 to display "99+".',
-        component: <NotificationCount count={150} />
-      },
-      negative: {
-        description: "Don't use for counts under 0.",
-        component: (
-          // This will render nothing as per component logic
-          <NotificationCount count={-5} />
-        )
-      }
-    },
-    {
-      positive: {
-        description: "Use 's' size for smaller contexts or less emphasis.",
-        component: <NotificationCount count={12} size='s' />
+        description: 'Use size="s" for compact layouts.',
+        component: NotificationCountStories.SmallSize.render?.()
       },
       negative: {
         description:
-          "Don't use 's' size when the count needs to be prominently displayed.",
-        component: (
-          <Flex position='relative'>
-            <NotificationCount count={3} size='s'>
-              <IconButton
-                icon={IconNotificationOn}
-                aria-label='Notifications'
-              />
-            </NotificationCount>
-          </Flex>
-        )
+          "Don't use the small size when the count needs to be prominently displayed.",
+        component: NotificationCountStories.LargeNumber.render?.()
       }
     }
   ]}

--- a/packages/harmony/src/components/notification-count/NotificationCount.stories.tsx
+++ b/packages/harmony/src/components/notification-count/NotificationCount.stories.tsx
@@ -1,0 +1,41 @@
+import type { Meta, StoryObj } from '@storybook/react'
+
+import { IconButton } from 'components/button'
+import { IconAudiusLogo } from 'icons'
+
+import { Flex } from '../layout/Flex'
+
+import { NotificationCount } from './NotificationCount'
+
+const meta: Meta<typeof NotificationCount> = {
+  title: 'Components/NotificationCount',
+  component: NotificationCount
+}
+
+export default meta
+
+type Story = StoryObj<typeof NotificationCount>
+
+export const Default: Story = {
+  args: {
+    count: 5
+  }
+}
+
+export const WithIcon: Story = {
+  render: () => (
+    <Flex>
+      <IconButton icon={IconAudiusLogo} aria-label='Notifications' />
+      <NotificationCount count={3} />
+    </Flex>
+  )
+}
+
+export const LargeNumber: Story = {
+  render: () => (
+    <Flex>
+      <IconButton icon={IconAudiusLogo} aria-label='Notifications' />
+      <NotificationCount count={99} />
+    </Flex>
+  )
+}

--- a/packages/harmony/src/components/notification-count/NotificationCount.stories.tsx
+++ b/packages/harmony/src/components/notification-count/NotificationCount.stories.tsx
@@ -1,15 +1,16 @@
 import type { Meta, StoryObj } from '@storybook/react'
 
 import { IconButton } from 'components/button'
-import { IconAudiusLogo } from 'icons'
-
-import { Flex } from '../layout/Flex'
+import { IconNotificationOn } from 'icons'
 
 import { NotificationCount } from './NotificationCount'
 
 const meta: Meta<typeof NotificationCount> = {
   title: 'Components/NotificationCount',
-  component: NotificationCount
+  component: NotificationCount,
+  parameters: {
+    layout: 'centered'
+  }
 }
 
 export default meta
@@ -24,18 +25,24 @@ export const Default: Story = {
 
 export const WithIcon: Story = {
   render: () => (
-    <Flex>
-      <IconButton icon={IconAudiusLogo} aria-label='Notifications' />
-      <NotificationCount count={3} />
-    </Flex>
+    <NotificationCount count={3}>
+      <IconButton icon={IconNotificationOn} aria-label='Notifications' />
+    </NotificationCount>
+  )
+}
+
+export const SmallSize: Story = {
+  render: () => (
+    <NotificationCount count={3} size='s'>
+      <IconButton icon={IconNotificationOn} aria-label='Notifications' />
+    </NotificationCount>
   )
 }
 
 export const LargeNumber: Story = {
   render: () => (
-    <Flex>
-      <IconButton icon={IconAudiusLogo} aria-label='Notifications' />
-      <NotificationCount count={99} />
-    </Flex>
+    <NotificationCount count={15000}>
+      <IconButton icon={IconNotificationOn} aria-label='Notifications' />
+    </NotificationCount>
   )
 }

--- a/packages/harmony/src/components/notification-count/NotificationCount.tsx
+++ b/packages/harmony/src/components/notification-count/NotificationCount.tsx
@@ -1,0 +1,106 @@
+import { useTheme, CSSObject } from '@emotion/react'
+import numeral from 'numeral'
+
+import { Flex } from '../layout/Flex'
+import { Text } from '../text/Text'
+
+import type { NotificationCountProps } from './types'
+
+/**
+ * Formats a count into a more readable string representation.
+ * For counts over 1000, it converts the number into a format with a suffix (K for thousands, M for millions, etc.)
+ * For example:
+ * - 375 => "375"
+ * - 4,210 => "4.21K"
+ * - 443,123 => "443K"
+ * - 4,001,000 => "4M"
+ * If the count is 0, it returns "0".
+ * This function is pulled over from the common package because we don't use the common package in Harmony.
+ */
+export const formatCount = (count: number) => {
+  if (count >= 1000) {
+    const countStr = count.toString()
+    if (countStr.length % 3 === 0) {
+      return numeral(count).format('0a').toUpperCase()
+    } else if (countStr.length % 3 === 1 && countStr[2] !== '0') {
+      return numeral(count).format('0.00a').toUpperCase()
+    } else if (countStr.length % 3 === 1 && countStr[1] !== '0') {
+      return numeral(count).format('0.0a').toUpperCase()
+    } else if (countStr.length % 3 === 2 && countStr[2] !== '0') {
+      return numeral(count).format('0.0a').toUpperCase()
+    } else {
+      return numeral(count).format('0a').toUpperCase()
+    }
+  } else if (!count) {
+    return '0'
+  } else {
+    return `${count}`
+  }
+}
+
+/**
+ * A small badge that displays a notification count and can wrap an icon, typically used with icons or buttons
+ * to indicate unread or pending notifications.
+ */
+export const NotificationCount = ({
+  count,
+  size,
+  children,
+  ...props
+}: NotificationCountProps) => {
+  const { spacing, color, cornerRadius } = useTheme()
+
+  const containerStyles: CSSObject = {
+    position: 'relative',
+    display: 'inline-flex',
+    alignItems: 'center',
+    justifyContent: 'center'
+  }
+
+  const badgeStyles: CSSObject = {
+    position: 'absolute',
+    top: 0,
+    right: 0,
+    transform: 'translate(50%, -50%)',
+    display: 'inline-flex',
+    height: spacing.unit5,
+    minWidth: spacing.unit5,
+    padding: `0px ${spacing.xs}px`,
+    flexDirection: 'column',
+    justifyContent: 'center',
+    alignItems: 'center',
+    gap: spacing.s,
+    flexShrink: 0,
+    borderRadius: cornerRadius.circle,
+    backgroundColor: color.primary.p300,
+    border: 'none',
+    '.parent:hover &': {
+      backgroundColor: color.background.surface1
+    },
+    ...(size === 's' && {
+      height: spacing.unit3 + spacing.unitHalf,
+      minWidth: spacing.unit3 + spacing.unitHalf,
+      padding: `0px ${spacing.xs}px`,
+      gap: spacing.s,
+      borderRadius: cornerRadius.circle,
+      backgroundColor: color.primary.p300
+    })
+  }
+  const textStyles: CSSObject = {
+    color: color.text.staticStaticWhite,
+    '.parent:hover &': {
+      color: color.neutral.n950
+    }
+  }
+
+  return (
+    <Flex className='parent' css={containerStyles} {...props}>
+      {children}
+      <Flex as='span' css={badgeStyles}>
+        <Text variant='label' size='xs' css={textStyles}>
+          {count !== undefined ? formatCount(count) : '0'}
+        </Text>
+      </Flex>
+    </Flex>
+  )
+}

--- a/packages/harmony/src/components/notification-count/NotificationCount.tsx
+++ b/packages/harmony/src/components/notification-count/NotificationCount.tsx
@@ -48,13 +48,11 @@ export const NotificationCount = ({
   children,
   ...props
 }: NotificationCountProps) => {
-  const { spacing, color, cornerRadius } = useTheme()
+  const { spacing, color } = useTheme()
 
   const containerStyles: CSSObject = {
-    position: 'relative',
     display: 'inline-flex',
-    alignItems: 'center',
-    justifyContent: 'center'
+    position: 'relative'
   }
 
   const badgeStyles: CSSObject = {
@@ -62,16 +60,7 @@ export const NotificationCount = ({
     top: 0,
     right: 0,
     transform: 'translate(50%, -50%)',
-    display: 'inline-flex',
-    height: spacing.unit5,
     minWidth: spacing.unit5,
-    padding: `0px ${spacing.xs}px`,
-    flexDirection: 'column',
-    justifyContent: 'center',
-    alignItems: 'center',
-    gap: spacing.s,
-    flexShrink: 0,
-    borderRadius: cornerRadius.circle,
     backgroundColor: color.primary.p300,
     border: 'none',
     '.parent:hover &': {
@@ -81,23 +70,42 @@ export const NotificationCount = ({
       height: spacing.unit3 + spacing.unitHalf,
       minWidth: spacing.unit3 + spacing.unitHalf,
       padding: `0px ${spacing.xs}px`,
-      gap: spacing.s,
-      borderRadius: cornerRadius.circle,
       backgroundColor: color.primary.p300
     })
   }
+
   const textStyles: CSSObject = {
-    color: color.text.staticStaticWhite,
     '.parent:hover &': {
       color: color.neutral.n950
     }
   }
 
   return (
-    <Flex className='parent' css={containerStyles} {...props}>
+    <Flex
+      className='parent'
+      alignItems='center'
+      justifyContent='center'
+      css={containerStyles}
+      {...props}
+    >
       {children}
-      <Flex as='span' css={badgeStyles}>
-        <Text variant='label' size='xs' css={textStyles}>
+      <Flex
+        as='span'
+        h='unit5'
+        ph='xs'
+        direction='column'
+        justifyContent='center'
+        alignItems='center'
+        gap='s'
+        borderRadius='circle'
+        css={badgeStyles}
+      >
+        <Text
+          variant='label'
+          size='xs'
+          css={textStyles}
+          color='staticStaticWhite'
+        >
           {count !== undefined ? formatCount(count) : '0'}
         </Text>
       </Flex>

--- a/packages/harmony/src/components/notification-count/NotificationCount.tsx
+++ b/packages/harmony/src/components/notification-count/NotificationCount.tsx
@@ -1,42 +1,11 @@
 import { useTheme, CSSObject } from '@emotion/react'
-import numeral from 'numeral'
+
+import { formatCount } from 'utils/formatCount'
 
 import { Flex } from '../layout/Flex'
 import { Text } from '../text/Text'
 
 import type { NotificationCountProps } from './types'
-
-/**
- * Formats a count into a more readable string representation.
- * For counts over 1000, it converts the number into a format with a suffix (K for thousands, M for millions, etc.)
- * For example:
- * - 375 => "375"
- * - 4,210 => "4.21K"
- * - 443,123 => "443K"
- * - 4,001,000 => "4M"
- * If the count is 0, it returns "0".
- * This function is pulled over from the common package because we don't use the common package in Harmony.
- */
-export const formatCount = (count: number) => {
-  if (count >= 1000) {
-    const countStr = count.toString()
-    if (countStr.length % 3 === 0) {
-      return numeral(count).format('0a').toUpperCase()
-    } else if (countStr.length % 3 === 1 && countStr[2] !== '0') {
-      return numeral(count).format('0.00a').toUpperCase()
-    } else if (countStr.length % 3 === 1 && countStr[1] !== '0') {
-      return numeral(count).format('0.0a').toUpperCase()
-    } else if (countStr.length % 3 === 2 && countStr[2] !== '0') {
-      return numeral(count).format('0.0a').toUpperCase()
-    } else {
-      return numeral(count).format('0a').toUpperCase()
-    }
-  } else if (!count) {
-    return '0'
-  } else {
-    return `${count}`
-  }
-}
 
 /**
  * A small badge that displays a notification count and can wrap an icon, typically used with icons or buttons

--- a/packages/harmony/src/components/notification-count/index.ts
+++ b/packages/harmony/src/components/notification-count/index.ts
@@ -1,0 +1,2 @@
+export { NotificationCount } from './NotificationCount'
+export type { NotificationCountProps } from './types'

--- a/packages/harmony/src/components/notification-count/types.ts
+++ b/packages/harmony/src/components/notification-count/types.ts
@@ -1,0 +1,14 @@
+import { ComponentPropsWithoutRef, ReactNode } from 'react'
+
+export type NotificationCountProps = {
+  /**
+   * The notification count to display
+   */
+  count?: number
+  /**
+   * The size of the notification count.
+   * @default undefined
+   */
+  size?: 's'
+  children?: ReactNode
+} & ComponentPropsWithoutRef<'div'>

--- a/packages/harmony/src/utils/formatCount.ts
+++ b/packages/harmony/src/utils/formatCount.ts
@@ -1,0 +1,33 @@
+import numeral from 'numeral'
+
+/**
+ * Formats a count into a more readable string representation.
+ * For counts over 1000, it converts the number into a format with a suffix (K for thousands, M for millions, etc.)
+ * For example:
+ * - 375 => "375"
+ * - 4,210 => "4.21K"
+ * - 443,123 => "443K"
+ * - 4,001,000 => "4M"
+ * If the count is 0, it returns "0".
+ * This function is pulled over from the common package because we don't use the common package in Harmony.
+ */
+export const formatCount = (count: number) => {
+  if (count >= 1000) {
+    const countStr = count.toString()
+    if (countStr.length % 3 === 0) {
+      return numeral(count).format('0a').toUpperCase()
+    } else if (countStr.length % 3 === 1 && countStr[2] !== '0') {
+      return numeral(count).format('0.00a').toUpperCase()
+    } else if (countStr.length % 3 === 1 && countStr[1] !== '0') {
+      return numeral(count).format('0.0a').toUpperCase()
+    } else if (countStr.length % 3 === 2 && countStr[2] !== '0') {
+      return numeral(count).format('0.0a').toUpperCase()
+    } else {
+      return numeral(count).format('0a').toUpperCase()
+    }
+  } else if (!count) {
+    return '0'
+  } else {
+    return `${count}`
+  }
+}


### PR DESCRIPTION
### Description

## Changes
This PR introduces three new components to the Harmony design system:

1. **NavItem**: A navigation item component for sidebars and menus
   - Supports default, hover, and selected states
   - Optional left and right icons
   - Consistent styling with theme support

2. **BalancePill**: A pill-shaped component for displaying balances
   - Shows numeric values with optional icons
   - Theme-aware styling
   - Flexible layout options

3. **NotificationCount**: A badge component for displaying notification counts
   - Can wrap other components (typically icons/buttons)
   - Formats large numbers (e.g., 1000 -> 1K)
   - Supports small size variant
   - Hover state support

## Documentation
Each component includes:
- Storybook documentation with usage guidelines
- Interactive examples
- Props documentation
- Theme demonstrations
- Do's and Don'ts (where applicable)

### How Has This Been Tested?

All components can be tested through their respective Storybook stories, which cover various states and configurations.

Reference [Figma](https://www.figma.com/design/l1Fn3uZ3lenie0apeS0YM3/Navigation-Redesign?node-id=186-149324&m=dev) for correctness
