### PR TITLE
new chain ids for stage and prod because pebbledb

### DIFF
--- a/pkg/core/config/genesis/prod.json
+++ b/pkg/core/config/genesis/prod.json
@@ -1,6 +1,6 @@
 {
   "genesis_time": "2024-09-05T00:00:00.0000Z",
-  "chain_id": "audius-mainnet-test6",
+  "chain_id": "audius-mainnet-test7",
   "initial_height": "0",
   "consensus_params": {
     "block": {

--- a/pkg/core/config/genesis/stage.json
+++ b/pkg/core/config/genesis/stage.json
@@ -1,6 +1,6 @@
 {
   "genesis_time": "2024-08-09T00:00:00.0000Z",
-  "chain_id": "audius-testnet-11",
+  "chain_id": "audius-testnet-14",
   "initial_height": "0",
   "consensus_params": {
     "block": {


### PR DESCRIPTION
### Description
- comet changed the default backend to be pebbledb instead of goleveldb so our backend file structure no longer conforms.
- upping the chain id creates a new storage dir for the pebbledb so we can keep moving

### How Has This Been Tested?
- dev didn't have this problem since it wipes it's storage each time
