### PR TITLE
Fix tx mempool broadcasting

### DIFF
--- a/pkg/core/config/config.go
+++ b/pkg/core/config/config.go
@@ -104,6 +104,7 @@ type Config struct {
 	RunDownMigration     bool
 	SlaRollupInterval    int
 	ValidatorVotingPower int
+	UseHttpsForSdk       bool
 
 	/* Derived Config */
 	GenesisFile *types.GenesisDoc
@@ -198,6 +199,7 @@ func ReadConfig(logger *common.Logger) (*Config, error) {
 
 		cfg.SlaRollupInterval = mainnetRollupInterval
 		cfg.ValidatorVotingPower = mainnetValidatorVotingPower
+		cfg.UseHttpsForSdk = true
 
 	case "stage", "staging", "testnet":
 		cfg.PersistentPeers = getEnvWithDefault("persistentPeers", StagePersistentPeers)
@@ -207,6 +209,7 @@ func ReadConfig(logger *common.Logger) (*Config, error) {
 		}
 		cfg.SlaRollupInterval = testnetRollupInterval
 		cfg.ValidatorVotingPower = testnetValidatorVotingPower
+		cfg.UseHttpsForSdk = true
 
 	case "dev", "development", "devnet", "local", "sandbox":
 		cfg.PersistentPeers = getEnvWithDefault("persistentPeers", DevPersistentPeers)

--- a/pkg/core/server/peers.go
+++ b/pkg/core/server/peers.go
@@ -83,7 +83,7 @@ func (s *Server) onPeerTick() error {
 
 			oapiendpoint := parsedURL.Host
 			// don't retry because ticker will handle it
-			sdk, err := sdk.NewSdk(sdk.WithOapiendpoint(oapiendpoint), sdk.WithRetries(0))
+			sdk, err := sdk.NewSdk(sdk.WithOapiendpoint(oapiendpoint), sdk.WithRetries(0), sdk.WithUsehttps(s.config.UseHttpsForSdk))
 			if err != nil {
 				s.logger.Errorf("could not peer with %s", oapiendpoint)
 				return


### PR DESCRIPTION
### Description

Tx broadcasting was broken due to http redirect 301 on cloudflare. This somehow translated a POST request into a GET request. By using https in the sdk, this is avoided.

### How Has This Been Tested?

released to stage
