### PR TITLE
[C-5507] Clear the queue if track with replaced audio is in the queue

### DIFF
--- a/packages/web/src/common/store/upload/sagas.ts
+++ b/packages/web/src/common/store/upload/sagas.ts
@@ -37,7 +37,10 @@ import {
   uploadActions,
   getSDK,
   cacheTracksActions,
-  replaceTrackProgressModalActions
+  replaceTrackProgressModalActions,
+  queueSelectors,
+  queueActions,
+  playerActions
 } from '@audius/common/store'
 import {
   actionChannelDispatcher,
@@ -1262,17 +1265,17 @@ export function* updateTrackAudioAsync(
     )
 
     const newMetadata = {
-      ...metadata,
-      orig_file_cid: updatedMetadata.origFileCid,
+      ...payload.metadata,
       bpm: metadata.isCustomBpm ? track.bpm : null,
+      duration: updatedMetadata.duration,
       musical_key: metadata.isCustomMusicalKey ? metadata.musicalKey : null,
       audio_analysis_error_count: 0,
       orig_filename: updatedMetadata.origFilename || '',
+      orig_file_cid: updatedMetadata.origFileCid,
       preview_cid: updatedMetadata.previewCid || '',
       preview_start_seconds: updatedMetadata.previewStartSeconds ?? 0,
       track_cid: updatedMetadata.trackCid || '',
-      audio_upload_id: updatedMetadata.audioUploadId,
-      duration: updatedMetadata.duration
+      audio_upload_id: updatedMetadata.audioUploadId
     }
 
     yield* put(
@@ -1281,6 +1284,13 @@ export function* updateTrackAudioAsync(
         newMetadata as TrackMetadataForUpload
       )
     )
+
+    // If the track with replaced audio is in the queue, clear it
+    const queueOrder = yield* select(queueSelectors.getOrder)
+    if (queueOrder.map((item) => item.id).includes(track.track_id)) {
+      yield* put(queueActions.clear({}))
+      yield* put(playerActions.stop({}))
+    }
 
     // Delay to allow the user to see that the track replace upload has finished
     yield* delay(1500)

--- a/packages/web/src/components/replace-track-progress-modal/ReplaceTrackProgressModal.tsx
+++ b/packages/web/src/components/replace-track-progress-modal/ReplaceTrackProgressModal.tsx
@@ -28,7 +28,12 @@ export const ReplaceTrackProgressModal = () => {
   const isUploadComplete = uploadProgress >= 1
 
   return (
-    <Modal isOpen={isOpen} onClose={onClose} size='small'>
+    <Modal
+      isOpen={isOpen}
+      onClose={onClose}
+      size='small'
+      dismissOnClickOutside={false}
+    >
       <ModalContent>
         {error ? (
           <Flex direction='column' gap='3xl' pt='3xl'>


### PR DESCRIPTION
### Description
Could not find a clean solution to update the metadata in place so opted for the queue clearing solution if the track with replaced audio is in the queue. This is a bit disruptive, but will make sure that the user does not ever hear the old audio after a replace happens

### How Has This Been Tested?
Manually tested on staging on web and mobile simulator