### PR TITLE
Remove support for Eth AUDIO send from client

### DIFF
--- a/packages/common/src/hooks/purchaseContent/usePurchaseContentErrorMessage.ts
+++ b/packages/common/src/hooks/purchaseContent/usePurchaseContentErrorMessage.ts
@@ -39,6 +39,7 @@ export const usePurchaseContentErrorMessage = (
     case PurchaseErrorCode.NoQuote:
       return messages.noQuote
     case BuyUSDCErrorCode.OnrampError:
+    case BuyUSDCErrorCode.CountryNotSupported:
     case PurchaseErrorCode.Canceled:
     case PurchaseErrorCode.InsufficientBalance:
     case PurchaseErrorCode.Unknown:

--- a/packages/common/src/services/audius-backend/AudiusBackend.ts
+++ b/packages/common/src/services/audius-backend/AudiusBackend.ts
@@ -1194,18 +1194,6 @@ export const audiusBackend = ({
     }
   }
 
-  /**
-   * Make a request to send
-   */
-  async function sendTokens(address: string, amount: BNWei) {
-    await waitForLibsInit()
-    const receipt = await audiusLibs.Account.permitAndSendTokens(
-      address,
-      amount
-    )
-    return receipt
-  }
-
   /** Gets associated token account info for the passed account. It will
    * first check if `address` ia a token account. If not, it will assume
    * it is a root account and attempt to derive an associated token account from it.
@@ -1608,7 +1596,6 @@ export const audiusBackend = ({
     identityServiceUrl,
     recordTrackListen,
     registerDeviceToken,
-    sendTokens,
     sendWAudioTokens,
     sendWelcomeEmail,
     setup,

--- a/packages/common/src/services/wallet-client/WalletClient.ts
+++ b/packages/common/src/services/wallet-client/WalletClient.ts
@@ -4,12 +4,7 @@ import BN from 'bn.js'
 
 import { userWalletsFromSDK } from '~/adapters'
 import { ID, Id } from '~/models/Identifiers'
-import {
-  BNWei,
-  SolanaWalletAddress,
-  StringWei,
-  WalletAddress
-} from '~/models/Wallet'
+import { BNWei, SolanaWalletAddress, StringWei } from '~/models/Wallet'
 import { isNullOrUndefined } from '~/utils/typeUtils'
 import { stringWeiToBN } from '~/utils/wallet'
 
@@ -234,18 +229,6 @@ export class WalletClient {
         sdk
       })
       return balance as BNWei
-    } catch (err) {
-      console.error(err)
-      throw err
-    }
-  }
-
-  async sendTokens(address: WalletAddress, amount: BNWei): Promise<void> {
-    if (amount.lt(MIN_TRANSFERRABLE_WEI)) {
-      throw new Error('Insufficient Audio to transfer')
-    }
-    try {
-      await this.audiusBackendInstance.sendTokens(address, amount)
     } catch (err) {
       console.error(err)
       throw err

--- a/packages/common/src/store/pages/token-dashboard/selectors.ts
+++ b/packages/common/src/store/pages/token-dashboard/selectors.ts
@@ -1,4 +1,3 @@
-import { Chain } from '../../../models/Chain'
 import { BNWei } from '../../../models/Wallet'
 import { Nullable } from '../../../utils/typeUtils'
 import { stringWeiToBN } from '../../../utils/wallet'
@@ -6,7 +5,7 @@ import { CommonState } from '../../commonStore'
 
 export const getSendData = (
   state: CommonState
-): Nullable<{ recipientWallet: string; amount: BNWei; chain: Chain }> => {
+): Nullable<{ recipientWallet: string; amount: BNWei }> => {
   const modalState = state.pages.tokenDashboard.modalState
   if (
     !(
@@ -17,8 +16,8 @@ export const getSendData = (
     )
   )
     return null
-  const { recipientWallet, amount, chain } = modalState.flowState
-  return { recipientWallet, amount: stringWeiToBN(amount), chain }
+  const { recipientWallet, amount } = modalState.flowState
+  return { recipientWallet, amount: stringWeiToBN(amount) }
 }
 
 export const getModalState = (state: CommonState) =>

--- a/packages/common/src/store/pages/token-dashboard/slice.ts
+++ b/packages/common/src/store/pages/token-dashboard/slice.ts
@@ -64,7 +64,7 @@ const slice = createSlice({
     },
     inputSendData: (
       state,
-      { payload: { amount, wallet, chain } }: InputSendDataAction
+      { payload: { amount, wallet } }: InputSendDataAction
     ) => {
       const newState: TokenDashboardPageModalState = {
         stage: 'SEND' as const,
@@ -72,7 +72,6 @@ const slice = createSlice({
           stage: 'AWAITING_CONFIRMATION',
           amount,
           recipientWallet: wallet,
-          chain,
           canRecipientReceiveWAudio: 'loading'
         }
       }
@@ -106,8 +105,7 @@ const slice = createSlice({
       state.modalState.flowState = {
         stage: 'AWAITING_CONVERTING_ETH_AUDIO_TO_SOL',
         recipientWallet: state.modalState.flowState.recipientWallet,
-        amount: state.modalState.flowState.amount,
-        chain: state.modalState.flowState.chain
+        amount: state.modalState.flowState.amount
       }
     },
     confirmSend: (state) => {
@@ -122,8 +120,7 @@ const slice = createSlice({
       state.modalState.flowState = {
         stage: 'SENDING',
         recipientWallet: state.modalState.flowState.recipientWallet,
-        amount: state.modalState.flowState.amount,
-        chain: state.modalState.flowState.chain
+        amount: state.modalState.flowState.amount
       }
     },
     pressReceive: (state) => {

--- a/packages/common/src/store/pages/token-dashboard/types.ts
+++ b/packages/common/src/store/pages/token-dashboard/types.ts
@@ -15,26 +15,22 @@ type SendingState =
       stage: 'AWAITING_CONFIRMATION'
       amount: StringWei
       recipientWallet: string
-      chain: Chain
       canRecipientReceiveWAudio: CanReceiveWAudio
     }
   | {
       stage: 'AWAITING_CONVERTING_ETH_AUDIO_TO_SOL'
       amount: StringWei
       recipientWallet: string
-      chain: Chain
     }
   | {
       stage: 'SENDING'
       amount: StringWei
       recipientWallet: WalletAddress
-      chain: Chain
     }
   | {
       stage: 'CONFIRMED_SEND'
       amount: StringWei
       recipientWallet: WalletAddress
-      chain: Chain
     }
   | { stage: 'ERROR'; error: string }
 
@@ -67,7 +63,6 @@ export type ConfirmRemoveWalletAction = PayloadAction<{
 export type InputSendDataAction = PayloadAction<{
   amount: StringWei
   wallet: WalletAddress
-  chain: Chain
 }>
 
 export type AssociatedWalletsState = {

--- a/packages/common/src/store/wallet/slice.ts
+++ b/packages/common/src/store/wallet/slice.ts
@@ -3,7 +3,6 @@ import BN from 'bn.js'
 
 import { isNullOrUndefined, Nullable } from '~/utils/typeUtils'
 
-import { Chain } from '../../models/Chain'
 import { StringUSDC, StringWei } from '../../models/Wallet'
 
 type WalletState = {
@@ -118,7 +117,6 @@ const slice = createSlice({
       _action: PayloadAction<{
         recipientWallet: string
         amount: StringWei
-        chain: Chain
       }>
     ) => {},
     sendSucceeded: () => {},

--- a/packages/web/src/pages/audio-rewards-page/WalletModal.tsx
+++ b/packages/web/src/pages/audio-rewards-page/WalletModal.tsx
@@ -298,7 +298,7 @@ const WalletModal = () => {
     chain: Chain
   ) => {
     const stringWei = weiToString(amount)
-    dispatch(inputSendData({ amount: stringWei, wallet, chain }))
+    dispatch(inputSendData({ amount: stringWei, wallet }))
   }
 
   const onConfirmSend = () => {

--- a/packages/web/src/store/token-dashboard/sagas.ts
+++ b/packages/web/src/store/token-dashboard/sagas.ts
@@ -45,10 +45,8 @@ function* confirmSendAsync() {
   // Send the txn, update local balance
   const sendData = yield* select(getSendData)
   if (!sendData) return
-  const { recipientWallet, amount, chain } = sendData
-  yield* put(
-    walletSend({ recipientWallet, amount: weiToString(amount), chain })
-  )
+  const { recipientWallet, amount } = sendData
+  yield* put(walletSend({ recipientWallet, amount: weiToString(amount) }))
 
   const { error } = yield* race({
     success: take(sendSucceeded),
@@ -80,8 +78,7 @@ function* confirmSendAsync() {
     flowState: {
       stage: 'CONFIRMED_SEND',
       amount: weiToString(amount),
-      recipientWallet,
-      chain
+      recipientWallet
     }
   }
   yield* put(setModalState({ modalState: sentState }))


### PR DESCRIPTION
Only support Solana AUDIO send going forward.

Tested by typechecking and looking at all callsites.

Allows removal of `sendTokens` support