### PR TITLE
core duplicate vote and jail

### DIFF
--- a/pkg/core/db/models.go
+++ b/pkg/core/db/models.go
@@ -71,6 +71,8 @@ type CoreValidator struct {
 	EthBlock     string
 	NodeType     string
 	SpID         string
+	Jailed       pgtype.Bool
+	JailedUntil  pgtype.Int8
 }
 
 type EventAttribute struct {

--- a/pkg/core/db/reads.sql.go
+++ b/pkg/core/db/reads.sql.go
@@ -12,7 +12,7 @@ import (
 )
 
 const getAllRegisteredNodes = `-- name: GetAllRegisteredNodes :many
-select rowid, pub_key, endpoint, eth_address, comet_address, eth_block, node_type, sp_id
+select rowid, pub_key, endpoint, eth_address, comet_address, eth_block, node_type, sp_id, jailed, jailed_until
 from core_validators
 `
 
@@ -34,6 +34,8 @@ func (q *Queries) GetAllRegisteredNodes(ctx context.Context) ([]CoreValidator, e
 			&i.EthBlock,
 			&i.NodeType,
 			&i.SpID,
+			&i.Jailed,
+			&i.JailedUntil,
 		); err != nil {
 			return nil, err
 		}
@@ -142,6 +144,41 @@ func (q *Queries) GetInProgressRollupReports(ctx context.Context) ([]SlaNodeRepo
 	return items, nil
 }
 
+const getJailedNodes = `-- name: GetJailedNodes :many
+select rowid, pub_key, endpoint, eth_address, comet_address, eth_block, node_type, sp_id, jailed, jailed_until from core_validators where jailed = true
+`
+
+func (q *Queries) GetJailedNodes(ctx context.Context) ([]CoreValidator, error) {
+	rows, err := q.db.Query(ctx, getJailedNodes)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []CoreValidator
+	for rows.Next() {
+		var i CoreValidator
+		if err := rows.Scan(
+			&i.Rowid,
+			&i.PubKey,
+			&i.Endpoint,
+			&i.EthAddress,
+			&i.CometAddress,
+			&i.EthBlock,
+			&i.NodeType,
+			&i.SpID,
+			&i.Jailed,
+			&i.JailedUntil,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const getLatestAppState = `-- name: GetLatestAppState :one
 select block_height, app_hash
 from core_app_state
@@ -179,7 +216,7 @@ func (q *Queries) GetLatestSlaRollup(ctx context.Context) (SlaRollup, error) {
 }
 
 const getNodeByEndpoint = `-- name: GetNodeByEndpoint :one
-select rowid, pub_key, endpoint, eth_address, comet_address, eth_block, node_type, sp_id
+select rowid, pub_key, endpoint, eth_address, comet_address, eth_block, node_type, sp_id, jailed, jailed_until
 from core_validators
 where endpoint = $1
 limit 1
@@ -197,6 +234,8 @@ func (q *Queries) GetNodeByEndpoint(ctx context.Context, endpoint string) (CoreV
 		&i.EthBlock,
 		&i.NodeType,
 		&i.SpID,
+		&i.Jailed,
+		&i.JailedUntil,
 	)
 	return i, err
 }
@@ -344,7 +383,7 @@ func (q *Queries) GetRecentTxs(ctx context.Context) ([]CoreTxResult, error) {
 }
 
 const getRegisteredNodeByCometAddress = `-- name: GetRegisteredNodeByCometAddress :one
-select rowid, pub_key, endpoint, eth_address, comet_address, eth_block, node_type, sp_id from core_validators where comet_address = $1
+select rowid, pub_key, endpoint, eth_address, comet_address, eth_block, node_type, sp_id, jailed, jailed_until from core_validators where comet_address = $1
 `
 
 func (q *Queries) GetRegisteredNodeByCometAddress(ctx context.Context, cometAddress string) (CoreValidator, error) {
@@ -359,12 +398,14 @@ func (q *Queries) GetRegisteredNodeByCometAddress(ctx context.Context, cometAddr
 		&i.EthBlock,
 		&i.NodeType,
 		&i.SpID,
+		&i.Jailed,
+		&i.JailedUntil,
 	)
 	return i, err
 }
 
 const getRegisteredNodeByEthAddress = `-- name: GetRegisteredNodeByEthAddress :one
-select rowid, pub_key, endpoint, eth_address, comet_address, eth_block, node_type, sp_id from core_validators where eth_address = $1
+select rowid, pub_key, endpoint, eth_address, comet_address, eth_block, node_type, sp_id, jailed, jailed_until from core_validators where eth_address = $1
 `
 
 func (q *Queries) GetRegisteredNodeByEthAddress(ctx context.Context, ethAddress string) (CoreValidator, error) {
@@ -379,12 +420,14 @@ func (q *Queries) GetRegisteredNodeByEthAddress(ctx context.Context, ethAddress 
 		&i.EthBlock,
 		&i.NodeType,
 		&i.SpID,
+		&i.Jailed,
+		&i.JailedUntil,
 	)
 	return i, err
 }
 
 const getRegisteredNodesByType = `-- name: GetRegisteredNodesByType :many
-select rowid, pub_key, endpoint, eth_address, comet_address, eth_block, node_type, sp_id
+select rowid, pub_key, endpoint, eth_address, comet_address, eth_block, node_type, sp_id, jailed, jailed_until
 from core_validators
 where node_type = $1
 `
@@ -407,6 +450,8 @@ func (q *Queries) GetRegisteredNodesByType(ctx context.Context, nodeType string)
 			&i.EthBlock,
 			&i.NodeType,
 			&i.SpID,
+			&i.Jailed,
+			&i.JailedUntil,
 		); err != nil {
 			return nil, err
 		}

--- a/pkg/core/db/sql/migrations/00009_add_jailed_columns.sql
+++ b/pkg/core/db/sql/migrations/00009_add_jailed_columns.sql
@@ -1,0 +1,5 @@
+-- +migrate Up
+alter table core_validators add column jailed boolean default false, add column jailed_until bigint default 0;
+
+-- +migrate Down
+alter table core_validators drop column jailed, drop column jailed_until;

--- a/pkg/core/db/sql/reads.sql
+++ b/pkg/core/db/sql/reads.sql
@@ -117,3 +117,6 @@ select * from core_tx_results where block_id = $1 order by created_at desc;
 
 -- name: GetBlock :one
 select * from core_blocks where height = $1;
+
+-- name: GetJailedNodes :many
+select * from core_validators where jailed = true;

--- a/pkg/core/db/sql/writes.sql
+++ b/pkg/core/db/sql/writes.sql
@@ -34,3 +34,14 @@ returning id;
 insert into core_tx_stats (tx_type, tx_hash, block_height, created_at)
 values ($1, $2, $3, $4)
 on conflict (tx_hash) do nothing;
+
+-- name: AddJailedNode :exec
+update core_validators
+set jailed = true, jailed_until = $2
+where comet_address = $1;
+
+-- name: UnjailNode :exec
+update core_validators
+set jailed = false, jailed_until = 0
+where comet_address = $1;
+

--- a/pkg/core/db/writes.sql.go
+++ b/pkg/core/db/writes.sql.go
@@ -11,6 +11,22 @@ import (
 	"github.com/jackc/pgx/v5/pgtype"
 )
 
+const addJailedNode = `-- name: AddJailedNode :exec
+update core_validators
+set jailed = true, jailed_until = $2
+where comet_address = $1
+`
+
+type AddJailedNodeParams struct {
+	CometAddress string
+	JailedUntil  pgtype.Int8
+}
+
+func (q *Queries) AddJailedNode(ctx context.Context, arg AddJailedNodeParams) error {
+	_, err := q.db.Exec(ctx, addJailedNode, arg.CometAddress, arg.JailedUntil)
+	return err
+}
+
 const clearUncommittedSlaNodeReports = `-- name: ClearUncommittedSlaNodeReports :exec
 delete from sla_node_reports
 where sla_rollup_id is null
@@ -110,6 +126,17 @@ func (q *Queries) InsertTxStat(ctx context.Context, arg InsertTxStatParams) erro
 		arg.BlockHeight,
 		arg.CreatedAt,
 	)
+	return err
+}
+
+const unjailNode = `-- name: UnjailNode :exec
+update core_validators
+set jailed = false, jailed_until = 0
+where comet_address = $1
+`
+
+func (q *Queries) UnjailNode(ctx context.Context, cometAddress string) error {
+	_, err := q.db.Exec(ctx, unjailNode, cometAddress)
 	return err
 }
 

--- a/pkg/core/server/grpc.go
+++ b/pkg/core/server/grpc.go
@@ -37,7 +37,7 @@ func GetProtoTypeName(msg proto.Message) string {
 }
 
 func (s *Server) SendTransaction(ctx context.Context, req *core_proto.SendTransactionRequest) (*core_proto.TransactionResponse, error) {
-	if err := s.validateTx(req.GetTransaction()); err != nil {
+	if err := s.validateTxGRPC(req.GetTransaction()); err != nil {
 		return nil, fmt.Errorf("validation error: %v", err)
 	}
 
@@ -87,7 +87,7 @@ func (s *Server) SendTransaction(ctx context.Context, req *core_proto.SendTransa
 func (s *Server) ForwardTransaction(ctx context.Context, req *core_proto.ForwardTransactionRequest) (*core_proto.ForwardTransactionResponse, error) {
 	// TODO: check signature from known node
 
-	if err := s.validateTx(req.GetTransaction()); err != nil {
+	if err := s.validateTxGRPC(req.GetTransaction()); err != nil {
 		return nil, fmt.Errorf("validation error: %v", err)
 	}
 

--- a/pkg/core/server/grpc.go
+++ b/pkg/core/server/grpc.go
@@ -37,7 +37,10 @@ func GetProtoTypeName(msg proto.Message) string {
 }
 
 func (s *Server) SendTransaction(ctx context.Context, req *core_proto.SendTransactionRequest) (*core_proto.TransactionResponse, error) {
-	// TODO: do validation check
+	if err := s.validateTx(req.GetTransaction()); err != nil {
+		return nil, fmt.Errorf("validation error: %v", err)
+	}
+
 	txhash, err := common.ToTxHash(req.GetTransaction())
 	if err != nil {
 		return nil, fmt.Errorf("could not get tx hash of signed tx: %v", err)
@@ -84,7 +87,9 @@ func (s *Server) SendTransaction(ctx context.Context, req *core_proto.SendTransa
 func (s *Server) ForwardTransaction(ctx context.Context, req *core_proto.ForwardTransactionRequest) (*core_proto.ForwardTransactionResponse, error) {
 	// TODO: check signature from known node
 
-	// TODO: validate transaction in same way as send transaction
+	if err := s.validateTx(req.GetTransaction()); err != nil {
+		return nil, fmt.Errorf("validation error: %v", err)
+	}
 
 	mempoolKey, err := common.ToTxHash(req.GetTransaction())
 	if err != nil {

--- a/pkg/core/server/registry_bridge.go
+++ b/pkg/core/server/registry_bridge.go
@@ -306,7 +306,7 @@ func (s *Server) registerSelfOnEth() error {
 	return nil
 }
 
-func (s *Server) validateValidatorRegistrationNotJailed(tx *core_proto.SignedTransaction_ValidatorRegistration) error {
+func (s *Server) validateNotJailed(tx *core_proto.SignedTransaction_ValidatorRegistration) error {
 	db := s.db
 
 	cometAddr := tx.ValidatorRegistration.CometAddress

--- a/pkg/core/server/registry_bridge.go
+++ b/pkg/core/server/registry_bridge.go
@@ -306,6 +306,24 @@ func (s *Server) registerSelfOnEth() error {
 	return nil
 }
 
+func (s *Server) validateValidatorRegistration(tx *core_proto.SignedTransaction_ValidatorRegistration) error {
+	db := s.db
+
+	cometAddr := tx.ValidatorRegistration.CometAddress
+
+	node, err := db.GetRegisteredNodeByCometAddress(context.Background(), cometAddr)
+	if err != nil {
+		return fmt.Errorf("validation db fail: %v", err)
+	}
+
+	jailed := node.Jailed
+	if jailed.Bool {
+		return fmt.Errorf("node %s is jailed and can't be re-registered", cometAddr)
+	}
+
+	return nil
+}
+
 // checks if the register node tx is valid
 // calls ethereum mainnet and validates signature to confirm node should be a validator
 func (s *Server) isValidRegisterNodeTx(ctx context.Context, tx *core_proto.SignedTransaction) error {

--- a/pkg/core/server/registry_bridge.go
+++ b/pkg/core/server/registry_bridge.go
@@ -313,6 +313,9 @@ func (s *Server) validateValidatorRegistration(tx *core_proto.SignedTransaction_
 
 	node, err := db.GetRegisteredNodeByCometAddress(context.Background(), cometAddr)
 	if err != nil {
+		if !errors.Is(err, pgx.ErrNoRows) {
+			return nil
+		}
 		return fmt.Errorf("validation db fail: %v", err)
 	}
 
@@ -326,7 +329,7 @@ func (s *Server) validateValidatorRegistration(tx *core_proto.SignedTransaction_
 
 // checks if the register node tx is valid
 // calls ethereum mainnet and validates signature to confirm node should be a validator
-func (s *Server) isValidRegisterNodeTx(ctx context.Context, tx *core_proto.SignedTransaction) error {
+func (s *Server) isValidRegisterNodeTx(_ctx context.Context, tx *core_proto.SignedTransaction) error {
 	sig := tx.GetSignature()
 	if sig == "" {
 		return fmt.Errorf("no signature provided for registration tx: %v", tx)

--- a/pkg/core/server/registry_bridge.go
+++ b/pkg/core/server/registry_bridge.go
@@ -306,7 +306,7 @@ func (s *Server) registerSelfOnEth() error {
 	return nil
 }
 
-func (s *Server) validateValidatorRegistration(tx *core_proto.SignedTransaction_ValidatorRegistration) error {
+func (s *Server) validateValidatorRegistrationNotJailed(tx *core_proto.SignedTransaction_ValidatorRegistration) error {
 	db := s.db
 
 	cometAddr := tx.ValidatorRegistration.CometAddress

--- a/pkg/core/server/validate.go
+++ b/pkg/core/server/validate.go
@@ -7,7 +7,7 @@ import (
 func (s *Server) validateTxGRPC(stx *core_proto.SignedTransaction) error {
 	switch tx := stx.Transaction.(type) {
 	case *core_proto.SignedTransaction_ValidatorRegistration:
-		return s.validateValidatorRegistrationNotJailed(tx)
+		return s.validateNotJailed(tx)
 	}
 	return nil
 }

--- a/pkg/core/server/validate.go
+++ b/pkg/core/server/validate.go
@@ -1,0 +1,35 @@
+package server
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/AudiusProject/audius-protocol/pkg/core/gen/core_proto"
+)
+
+func (s *Server) validateTx(stx *core_proto.SignedTransaction) error {
+	switch tx := stx.Transaction.(type) {
+	case *core_proto.SignedTransaction_ValidatorRegistration:
+		return s.validateValidatorRegistration(tx)
+
+	}
+	return nil
+}
+
+func (s *Server) validateValidatorRegistration(tx *core_proto.SignedTransaction_ValidatorRegistration) error {
+	db := s.db
+
+	cometAddr := tx.ValidatorRegistration.CometAddress
+
+	node, err := db.GetRegisteredNodeByCometAddress(context.Background(), cometAddr)
+	if err != nil {
+		return fmt.Errorf("validation db fail: %v", err)
+	}
+
+	jailed := node.Jailed
+	if jailed.Bool {
+		return fmt.Errorf("node %s is jailed and can't be re-registered", cometAddr)
+	}
+
+	return nil
+}

--- a/pkg/core/server/validate.go
+++ b/pkg/core/server/validate.go
@@ -4,10 +4,10 @@ import (
 	"github.com/AudiusProject/audius-protocol/pkg/core/gen/core_proto"
 )
 
-func (s *Server) validateTx(stx *core_proto.SignedTransaction) error {
+func (s *Server) validateTxGRPC(stx *core_proto.SignedTransaction) error {
 	switch tx := stx.Transaction.(type) {
 	case *core_proto.SignedTransaction_ValidatorRegistration:
-		return s.validateValidatorRegistration(tx)
+		return s.validateValidatorRegistrationNotJailed(tx)
 	}
 	return nil
 }

--- a/pkg/core/server/validate.go
+++ b/pkg/core/server/validate.go
@@ -1,9 +1,6 @@
 package server
 
 import (
-	"context"
-	"fmt"
-
 	"github.com/AudiusProject/audius-protocol/pkg/core/gen/core_proto"
 )
 
@@ -11,25 +8,6 @@ func (s *Server) validateTx(stx *core_proto.SignedTransaction) error {
 	switch tx := stx.Transaction.(type) {
 	case *core_proto.SignedTransaction_ValidatorRegistration:
 		return s.validateValidatorRegistration(tx)
-
 	}
-	return nil
-}
-
-func (s *Server) validateValidatorRegistration(tx *core_proto.SignedTransaction_ValidatorRegistration) error {
-	db := s.db
-
-	cometAddr := tx.ValidatorRegistration.CometAddress
-
-	node, err := db.GetRegisteredNodeByCometAddress(context.Background(), cometAddr)
-	if err != nil {
-		return fmt.Errorf("validation db fail: %v", err)
-	}
-
-	jailed := node.Jailed
-	if jailed.Bool {
-		return fmt.Errorf("node %s is jailed and can't be re-registered", cometAddr)
-	}
-
 	return nil
 }


### PR DESCRIPTION
### Description
- adds columns jailed, and jailed_until to core_validators table
- if duplicate vote evidence is found then these nodes get removed from validator list and "jailed"
- adds validation to forward and send tx routes so if they try to reregister when jailed it failed before it hits consensus

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._
