### PR TITLE
Test audiusd nested panic recovery

### DIFF
--- a/cmd/audiusd/main.go
+++ b/cmd/audiusd/main.go
@@ -56,26 +56,6 @@ func main() {
 		{"core", func() error { return core.Run(ctx, logger) }, true},
 		{"mediorum", func() error { return mediorum.Run(ctx, logger) }, isStorageEnabled()},
 		{"uptime", func() error { return uptime.Run(ctx, logger) }, hostUrl.Hostname() != "localhost"},
-		// Test services with proper panic handling
-		{"simple-panic-test", func() error {
-			time.Sleep(5 * time.Second)
-			panic("simple goroutine panic")
-		}, true},
-		{"nested-panic-test", func() error {
-			done := make(chan error)
-			go func() {
-				defer func() {
-					if r := recover(); r != nil {
-						done <- fmt.Errorf("nested panic: %v", r)
-					}
-				}()
-
-				time.Sleep(5 * time.Second)
-				panic("nested goroutine panic")
-			}()
-
-			return <-done
-		}, true},
 	}
 
 	for _, svc := range services {


### PR DESCRIPTION
Corrects handling of nested `panic` events.

**TEST**

Tested by adding services that force both direct and nested panics [6954a7d](https://github.com/AudiusProject/audius-protocol/pull/10806/commits/6954a7d021ff2226d83ffdd7627cdf93dbe2fb5e)

```
{"simple-panic-test", func() error {
	time.Sleep(5 * time.Second)
	panic("simple goroutine panic")
}, true},
{"nested-panic-test", func() error {
	done := make(chan error)
	go func() {
		defer func() {
			if r := recover(); r != nil {
				done <- fmt.Errorf("nested panic: %v", r)
			}
		}()

		time.Sleep(5 * time.Second)
		panic("nested goroutine panic")
	}()

	return <-done
}, true},
```

Ran on stage cn10 with
```
TAG=6954a7d021ff2226d83ffdd7627cdf93dbe2fb5e audius-cli upgrade
```

Observed logs... as expected...
```
eab72adc08a9:~/audius-docker-compose# docker logs -f audiusd | grep panic
pg_ctl: another server might be running; trying to start server anyway
2024/12/19 23:00:17 INFO MEDIORUM revision=6954a7d021ff2226d83ffdd7627cdf93dbe2fb5e built="" wip=""
{"time":"2024-12-19T23:00:22.246595646Z","level":"ERROR","msg":"nested-panic-test error: nested panic: nested goroutine panic"}
{"time":"2024-12-19T23:00:22.246653545Z","level":"ERROR","msg":"nested-panic-test goroutine panicked: nested-panic-test error: nested panic: nested goroutine panic"}
{"time":"2024-12-19T23:00:22.246669046Z","level":"ERROR","msg":"simple-panic-test goroutine panicked: simple goroutine panic"}
{"time":"2024-12-19T23:00:22.246711395Z","level":"ERROR","msg":"nested-panic-test stack trace: goroutine 51 [running]:\nruntime/debug.Stack()\n\t/usr/local/go/src/runtime/debug/stack.go:26 +0x5e\nmain.runWithRecover.func1.1()\n\t/app/cmd/audiusd/main.go:107 +0x110\npanic({0x23f37e0?, 0xc00d901b40?})\n\t/usr/local/go/src/runtime/panic.go:785 +0x132\nmain.runWithRecover.func1()\n\t/app/cmd/audiusd/main.go:138 +0x225\ncreated by main.runWithRecover in goroutine 1\n\t/app/cmd/audiusd/main.go:142 +0x145\n"}
{"time":"2024-12-19T23:00:22.246728065Z","level":"INFO","msg":"nested-panic-test will restart in 10s (attempt 1/10)"}
{"time":"2024-12-19T23:00:22.246731201Z","level":"ERROR","msg":"simple-panic-test stack trace: goroutine 50 [running]:\nruntime/debug.Stack()\n\t/usr/local/go/src/runtime/debug/stack.go:26 +0x5e\nmain.runWithRecover.func1.1()\n\t/app/cmd/audiusd/main.go:107 +0x110\npanic({0x23f37e0?, 0x2f46610?})\n\t/usr/local/go/src/runtime/panic.go:785 +0x132\nmain.main.func5()\n\t/app/cmd/audiusd/main.go:62 +0x30\nmain.runWithRecover.func1()\n\t/app/cmd/audiusd/main.go:135 +0xdd\ncreated by main.runWithRecover in goroutine 1\n\t/app/cmd/audiusd/main.go:142 +0x145\n"}
{"time":"2024-12-19T23:00:22.246746237Z","level":"INFO","msg":"simple-panic-test will restart in 10s (attempt 1/10)"}
{"time":"2024-12-19T23:00:37.248071662Z","level":"ERROR","msg":"nested-panic-test error: nested panic: nested goroutine panic"}
{"time":"2024-12-19T23:00:37.248088349Z","level":"ERROR","msg":"simple-panic-test goroutine panicked: simple goroutine panic"}
{"time":"2024-12-19T23:00:37.248154096Z","level":"ERROR","msg":"simple-panic-test stack trace: goroutine 42497 [running]:\nruntime/debug.Stack()\n\t/usr/local/go/src/runtime/debug/stack.go:26 +0x5e\nmain.runWithRecover.func1.1()\n\t/app/cmd/audiusd/main.go:107 +0x110\npanic({0x23f37e0?, 0x2f46610?})\n\t/usr/local/go/src/runtime/panic.go:785 +0x132\nmain.main.func5()\n\t/app/cmd/audiusd/main.go:62 +0x30\nmain.runWithRecover.func1()\n\t/app/cmd/audiusd/main.go:135 +0xdd\ncreated by main.runWithRecover.func1.1 in goroutine 50\n\t/app/cmd/audiusd/main.go:130 +0x30f\n"}
{"time":"2024-12-19T23:00:37.248169324Z","level":"INFO","msg":"simple-panic-test will restart in 20s (attempt 2/10)"}
{"time":"2024-12-19T23:00:37.248103322Z","level":"ERROR","msg":"nested-panic-test goroutine panicked: nested-panic-test error: nested panic: nested goroutine panic"}
{"time":"2024-12-19T23:00:37.248190045Z","level":"ERROR","msg":"nested-panic-test stack trace: goroutine 42498 [running]:\nruntime/debug.Stack()\n\t/usr/local/go/src/runtime/debug/stack.go:26 +0x5e\nmain.runWithRecover.func1.1()\n\t/app/cmd/audiusd/main.go:107 +0x110\npanic({0x23f37e0?, 0xc048030910?})\n\t/usr/local/go/src/runtime/panic.go:785 +0x132\nmain.runWithRecover.func1()\n\t/app/cmd/audiusd/main.go:138 +0x225\ncreated by main.runWithRecover.func1.1 in goroutine 51\n\t/app/cmd/audiusd/main.go:130 +0x30f\n"}
{"time":"2024-12-19T23:00:37.248199785Z","level":"INFO","msg":"nested-panic-test will restart in 20s (attempt 2/10)"}
```

Meanwhile app was still functional
```
curl -s https://creatornode10.staging.audius.co/health_check | jq .data.git
"6954a7d021ff2226d83ffdd7627cdf93dbe2fb5e"
```