### PR TITLE
if multiple spids, don't register on core

### DIFF
--- a/pkg/core/config/config.go
+++ b/pkg/core/config/config.go
@@ -69,14 +69,6 @@ const (
 
 const dbUrlLocalPattern string = `^postgresql:\/\/\w+:\w+@(db|localhost|postgres):.*`
 
-// some nodes have duplicate privkeys which means they can cause peering issues
-// see more here: https://github.com/cometbft/cometbft/issues/4114
-var (
-	ProdPeerBlacklist  = []string{"", ""}
-	StagePeerBlacklist = []string{"2F13439B2EE4C34BAFE643F89575F40B7863A079", "7EDFC48A6A8CD0B088058E53E451E51A01260DD9"}
-	DevPeerBlacklist   = []string{}
-)
-
 var isLocalDbUrlRegex = regexp.MustCompile(dbUrlLocalPattern)
 
 var Version string
@@ -113,7 +105,6 @@ type Config struct {
 	SlaRollupInterval    int
 	ValidatorVotingPower int
 	UseHttpsForSdk       bool
-	BlacklistedPeers     []string
 
 	/* Derived Config */
 	GenesisFile *types.GenesisDoc
@@ -209,7 +200,6 @@ func ReadConfig(logger *common.Logger) (*Config, error) {
 		cfg.SlaRollupInterval = mainnetRollupInterval
 		cfg.ValidatorVotingPower = mainnetValidatorVotingPower
 		cfg.UseHttpsForSdk = true
-		cfg.BlacklistedPeers = ProdPeerBlacklist
 
 	case "stage", "staging", "testnet":
 		cfg.PersistentPeers = getEnvWithDefault("persistentPeers", StagePersistentPeers)
@@ -220,7 +210,6 @@ func ReadConfig(logger *common.Logger) (*Config, error) {
 		cfg.SlaRollupInterval = testnetRollupInterval
 		cfg.ValidatorVotingPower = testnetValidatorVotingPower
 		cfg.UseHttpsForSdk = true
-		cfg.BlacklistedPeers = StagePeerBlacklist
 
 	case "dev", "development", "devnet", "local", "sandbox":
 		cfg.PersistentPeers = getEnvWithDefault("persistentPeers", DevPersistentPeers)
@@ -234,7 +223,6 @@ func ReadConfig(logger *common.Logger) (*Config, error) {
 		}
 		cfg.SlaRollupInterval = devnetRollupInterval
 		cfg.ValidatorVotingPower = devnetValidatorVotingPower
-		cfg.BlacklistedPeers = DevPeerBlacklist
 	}
 
 	// Disable ssl for local postgres db connection

--- a/pkg/core/config/config.go
+++ b/pkg/core/config/config.go
@@ -69,6 +69,14 @@ const (
 
 const dbUrlLocalPattern string = `^postgresql:\/\/\w+:\w+@(db|localhost|postgres):.*`
 
+// some nodes have duplicate privkeys which means they can cause peering issues
+// see more here: https://github.com/cometbft/cometbft/issues/4114
+var (
+	ProdPeerBlacklist  = []string{"", ""}
+	StagePeerBlacklist = []string{"2F13439B2EE4C34BAFE643F89575F40B7863A079", "7EDFC48A6A8CD0B088058E53E451E51A01260DD9"}
+	DevPeerBlacklist   = []string{}
+)
+
 var isLocalDbUrlRegex = regexp.MustCompile(dbUrlLocalPattern)
 
 var Version string
@@ -105,6 +113,7 @@ type Config struct {
 	SlaRollupInterval    int
 	ValidatorVotingPower int
 	UseHttpsForSdk       bool
+	BlacklistedPeers     []string
 
 	/* Derived Config */
 	GenesisFile *types.GenesisDoc
@@ -200,6 +209,7 @@ func ReadConfig(logger *common.Logger) (*Config, error) {
 		cfg.SlaRollupInterval = mainnetRollupInterval
 		cfg.ValidatorVotingPower = mainnetValidatorVotingPower
 		cfg.UseHttpsForSdk = true
+		cfg.BlacklistedPeers = ProdPeerBlacklist
 
 	case "stage", "staging", "testnet":
 		cfg.PersistentPeers = getEnvWithDefault("persistentPeers", StagePersistentPeers)
@@ -210,6 +220,7 @@ func ReadConfig(logger *common.Logger) (*Config, error) {
 		cfg.SlaRollupInterval = testnetRollupInterval
 		cfg.ValidatorVotingPower = testnetValidatorVotingPower
 		cfg.UseHttpsForSdk = true
+		cfg.BlacklistedPeers = StagePeerBlacklist
 
 	case "dev", "development", "devnet", "local", "sandbox":
 		cfg.PersistentPeers = getEnvWithDefault("persistentPeers", DevPersistentPeers)
@@ -223,6 +234,7 @@ func ReadConfig(logger *common.Logger) (*Config, error) {
 		}
 		cfg.SlaRollupInterval = devnetRollupInterval
 		cfg.ValidatorVotingPower = devnetValidatorVotingPower
+		cfg.BlacklistedPeers = DevPeerBlacklist
 	}
 
 	// Disable ssl for local postgres db connection

--- a/pkg/core/config/genesis/stage.json
+++ b/pkg/core/config/genesis/stage.json
@@ -1,6 +1,6 @@
 {
   "genesis_time": "2024-08-09T00:00:00.0000Z",
-  "chain_id": "audius-testnet-14",
+  "chain_id": "audius-testnet-15",
   "initial_height": "0",
   "consensus_params": {
     "block": {

--- a/pkg/core/server/registry_bridge.go
+++ b/pkg/core/server/registry_bridge.go
@@ -311,6 +311,12 @@ func (s *Server) validateNotJailed(tx *core_proto.SignedTransaction_ValidatorReg
 
 	cometAddr := tx.ValidatorRegistration.CometAddress
 
+	for _, blacklistAddr := range s.config.BlacklistedPeers {
+		if blacklistAddr == cometAddr {
+			return fmt.Errorf("invalid peer: %v", blacklistAddr)
+		}
+	}
+
 	node, err := db.GetRegisteredNodeByCometAddress(context.Background(), cometAddr)
 	if err != nil {
 		if !errors.Is(err, pgx.ErrNoRows) {

--- a/pkg/core/server/registry_bridge.go
+++ b/pkg/core/server/registry_bridge.go
@@ -138,6 +138,13 @@ func (s *Server) isDevEnvironment() bool {
 }
 
 func (s *Server) registerSelfOnComet(ethBlock, spID string) error {
+	for _, invalidNode := range s.config.BlacklistedPeers {
+		if invalidNode == s.config.ProposerAddress {
+			s.logger.Errorf("i am in blacklist, not registering on comet: %s", invalidNode)
+			return nil
+		}
+	}
+
 	genValidators := s.config.GenesisFile.Validators
 	isGenValidator := false
 	for _, validator := range genValidators {

--- a/pkg/core/server/registry_bridge.go
+++ b/pkg/core/server/registry_bridge.go
@@ -163,13 +163,6 @@ func (s *Server) getAllNodesForEthAddress() ([]*big.Int, error) {
 }
 
 func (s *Server) registerSelfOnComet(ethBlock, spID string) error {
-	for _, invalidNode := range s.config.BlacklistedPeers {
-		if invalidNode == s.config.ProposerAddress {
-			s.logger.Errorf("i am in blacklist, not registering on comet: %s", invalidNode)
-			return nil
-		}
-	}
-
 	genValidators := s.config.GenesisFile.Validators
 	isGenValidator := false
 	for _, validator := range genValidators {
@@ -352,12 +345,6 @@ func (s *Server) validateNotJailed(tx *core_proto.SignedTransaction_ValidatorReg
 	db := s.db
 
 	cometAddr := tx.ValidatorRegistration.CometAddress
-
-	for _, blacklistAddr := range s.config.BlacklistedPeers {
-		if blacklistAddr == cometAddr {
-			return fmt.Errorf("invalid peer: %v", blacklistAddr)
-		}
-	}
 
 	node, err := db.GetRegisteredNodeByCometAddress(context.Background(), cometAddr)
 	if err != nil {


### PR DESCRIPTION
### Description
adds a check in the registry bridge that doesn't register the node if it finds it's got duplicates on ethereum

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._
