### PR TITLE
Allow attestations for disbursements on matching specifiers with different user ids

### DIFF
--- a/packages/discovery-provider/src/queries/get_attestation.py
+++ b/packages/discovery-provider/src/queries/get_attestation.py
@@ -145,6 +145,7 @@ def get_attestation(
             and_(
                 ChallengeDisbursement.specifier == UserChallenge.specifier,
                 ChallengeDisbursement.challenge_id == UserChallenge.challenge_id,
+                ChallengeDisbursement.user_id == UserChallenge.user_id,
             ),
         )
         .filter(


### PR DESCRIPTION
### Description

It is possible to disburse an undisbursed trending reward against a different specifier that is also undisbursed.
We saw that this week with rewards disbursed from prior weeks under the specifiers '2024-12-20:*'

If `challenge_id=tt` `specifier=2024-12-20:1` is undisbursed and so is `challenge_id=tt` `specifier=2024-06-23`, you can get an attestation for the latter, but send a tx with `specifier=2024-12-20:1` (fun!)

This is an issue not so much because of the collision since hypothetically all disbursable challenges should be disbursed, but the fact that it prevents collecting attestations for the right reward is a problem. So in get_attestation, I propose matching against the user ID and allow nodes to attest again for challenges if the disbursed user id doesn't match the user challenge user id. 

I believe this fix is sufficient, and will allow us over time to disburse the rest of the previously undisbursed trending challenges.

It opens up a world where we could hypothetically disburse for multiple users on the same challenge_id/specifier date if they see different user challenges, but I would propose that the issue is upstream then and nodes need to agree on user challenges.

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._
