### PR TITLE
[C-5572] Add cache syncing between redux and react-query

### DIFF
--- a/packages/common/src/api/collection.ts
+++ b/packages/common/src/api/collection.ts
@@ -35,7 +35,7 @@ const collectionApi = createApi({
           userId: OptionalId.parse(currentUserId)
         })
         return data.length
-          ? userCollectionMetadataFromSDK(data[0]) ?? null
+          ? (userCollectionMetadataFromSDK(data[0]) ?? null)
           : null
       },
       fetchBatch: async (

--- a/packages/common/src/api/tan-query/useCollections.ts
+++ b/packages/common/src/api/tan-query/useCollections.ts
@@ -1,9 +1,13 @@
 import { useQuery, useQueryClient } from '@tanstack/react-query'
+import { useDispatch } from 'react-redux'
 
 import { userCollectionMetadataFromSDK } from '~/adapters/collection'
 import { transformAndCleanList } from '~/adapters/utils'
 import { useAppContext } from '~/context/appContext'
 import { ID } from '~/models/Identifiers'
+import { Kind } from '~/models/Kind'
+import { addEntries } from '~/store/cache/actions'
+import { EntryMap } from '~/store/cache/types'
 import { encodeHashId } from '~/utils/hashIds'
 
 import { QUERY_KEYS } from './queryKeys'
@@ -15,6 +19,7 @@ type Config = {
 export const useCollections = (collectionIds: ID[], config?: Config) => {
   const { audiusSdk } = useAppContext()
   const queryClient = useQueryClient()
+  const dispatch = useDispatch()
 
   return useQuery({
     queryKey: [QUERY_KEYS.collections, collectionIds],
@@ -32,31 +37,68 @@ export const useCollections = (collectionIds: ID[], config?: Config) => {
         userCollectionMetadataFromSDK
       )
 
-      collections?.forEach((collection) => {
-        // Prime user data from collection owner
-        if (collection.user) {
-          queryClient.setQueryData(
-            [QUERY_KEYS.user, collection.user.user_id],
-            collection.user
-          )
+      if (collections?.length) {
+        const entries: Partial<Record<Kind, EntryMap>> = {
+          [Kind.COLLECTIONS]: {}
         }
 
-        // Prime track and user data from tracks in collection
-        collection.tracks?.forEach((track) => {
-          if (track.track_id) {
-            // Prime track data
-            queryClient.setQueryData([QUERY_KEYS.track, track.track_id], track)
+        collections.forEach((collection) => {
+          // Prime collection data
+          queryClient.setQueryData(
+            [QUERY_KEYS.collection, collection.playlist_id],
+            collection
+          )
+          entries[Kind.COLLECTIONS]![collection.playlist_id] = {
+            id: collection.playlist_id,
+            metadata: collection
+          }
 
-            // Prime user data from track owner
-            if (track.user) {
-              queryClient.setQueryData(
-                [QUERY_KEYS.user, track.user.user_id],
-                track.user
-              )
+          // Prime user data from collection owner
+          if (collection.user) {
+            queryClient.setQueryData(
+              [QUERY_KEYS.user, collection.user.user_id],
+              collection.user
+            )
+            if (!entries[Kind.USERS]) entries[Kind.USERS] = {}
+            entries[Kind.USERS][collection.user.user_id] = {
+              id: collection.user.user_id,
+              metadata: collection.user
             }
           }
+
+          // Prime track and user data from tracks in collection
+          collection.tracks?.forEach((track) => {
+            if (track.track_id) {
+              // Prime track data
+              queryClient.setQueryData(
+                [QUERY_KEYS.track, track.track_id],
+                track
+              )
+              if (!entries[Kind.TRACKS]) entries[Kind.TRACKS] = {}
+              entries[Kind.TRACKS][track.track_id] = {
+                id: track.track_id,
+                metadata: track
+              }
+
+              // Prime user data from track owner
+              if (track.user) {
+                queryClient.setQueryData(
+                  [QUERY_KEYS.user, track.user.user_id],
+                  track.user
+                )
+                if (!entries[Kind.USERS]) entries[Kind.USERS] = {}
+                entries[Kind.USERS][track.user.user_id] = {
+                  id: track.user.user_id,
+                  metadata: track.user
+                }
+              }
+            }
+          })
         })
-      })
+
+        // Sync all data to Redux in a single dispatch
+        dispatch(addEntries(entries, undefined, undefined, 'react-query'))
+      }
 
       return collections
     },

--- a/packages/common/src/api/tan-query/useUser.ts
+++ b/packages/common/src/api/tan-query/useUser.ts
@@ -1,8 +1,12 @@
 import { useQuery } from '@tanstack/react-query'
+import { useDispatch } from 'react-redux'
 
 import { userMetadataListFromSDK } from '~/adapters/user'
 import { useAppContext } from '~/context/appContext'
 import { ID } from '~/models/Identifiers'
+import { Kind } from '~/models/Kind'
+import { addEntries } from '~/store/cache/actions'
+import { EntryMap } from '~/store/cache/types'
 import { encodeHashId } from '~/utils/hashIds'
 
 import { QUERY_KEYS } from './queryKeys'
@@ -13,6 +17,7 @@ type Config = {
 
 export const useUser = (userId: ID, config?: Config) => {
   const { audiusSdk } = useAppContext()
+  const dispatch = useDispatch()
 
   return useQuery({
     queryKey: [QUERY_KEYS.user, userId],
@@ -20,7 +25,23 @@ export const useUser = (userId: ID, config?: Config) => {
       const encodedId = encodeHashId(userId)
       if (!encodedId) return null
       const { data } = await audiusSdk!.full.users.getUser({ id: encodedId })
-      return userMetadataListFromSDK(data)[0]
+      const user = userMetadataListFromSDK(data)[0]
+
+      // Sync user data to Redux
+      if (user) {
+        const entries: Partial<Record<Kind, EntryMap>> = {
+          [Kind.USERS]: {
+            [user.user_id]: {
+              id: user.user_id,
+              metadata: user
+            }
+          }
+        }
+
+        dispatch(addEntries(entries, undefined, undefined, 'react-query'))
+      }
+
+      return user
     },
     staleTime: config?.staleTime,
     enabled: !!audiusSdk && !!userId

--- a/packages/common/src/audius-query/createApi.ts
+++ b/packages/common/src/audius-query/createApi.ts
@@ -29,7 +29,7 @@ import { getErrorMessage } from '~/utils/error'
 import { waitForValue } from '~/utils/sagaHelpers'
 import { Nullable, removeNullable } from '~/utils/typeUtils'
 
-import { Track } from '../models/Track'
+import { Track, UserTrackMetadata } from '../models/Track'
 import * as accountSelectors from '../store/account/selectors'
 import * as cacheActions from '../store/cache/actions'
 import * as cacheSelectors from '../store/cache/selectors'
@@ -398,7 +398,19 @@ const fetchData = async <Args, Data>(
       // Format entities before adding to cache
       entities[Kind.USERS] = mapValues(
         entities[Kind.USERS] ?? [],
-        (user: UserMetadata) => reformatUser(user)
+        (user: UserMetadata) => {
+          const metadata = reformatUser(user)
+          return { id: metadata.user_id, metadata }
+        }
+      )
+
+      // Format track entities before adding to cache
+      entities[Kind.TRACKS] = mapValues(
+        entities[Kind.TRACKS] ?? [],
+        (track: UserTrackMetadata) => ({
+          id: track.track_id,
+          metadata: track
+        })
       )
 
       // Hack alert: We can't overwrite the current user, since it contains
@@ -410,11 +422,14 @@ const fetchData = async <Args, Data>(
 
       entities[Kind.COLLECTIONS] = mapValues(
         entities[Kind.COLLECTIONS] ?? [],
-        (collection: CollectionMetadata | UserCollectionMetadata) =>
-          reformatCollection({
+        (collection: CollectionMetadata | UserCollectionMetadata) => {
+          const metadata = reformatCollection({
             collection,
             omitUser: false
           })
+
+          return { id: metadata.playlist_id, metadata }
+        }
       )
       dispatch(addEntries(entities, !!force))
       data = result

--- a/packages/common/src/services/remote-config/feature-flags.ts
+++ b/packages/common/src/services/remote-config/feature-flags.ts
@@ -22,7 +22,8 @@ export enum FeatureFlags {
   GUEST_CHECKOUT = 'guest_checkout',
   TRACK_AUDIO_REPLACE = 'track_audio_replace',
   OWN_YOUR_FANS = 'own_your_fans',
-  FAST_REFERRAL = 'fast_referral'
+  FAST_REFERRAL = 'fast_referral',
+  REACT_QUERY_SYNC = 'react_query_sync'
 }
 
 type FlagDefaults = Record<FeatureFlags, boolean>
@@ -60,5 +61,6 @@ export const flagDefaults: FlagDefaults = {
   [FeatureFlags.RIGHTS_AND_COVERS]: false,
   [FeatureFlags.TRACK_AUDIO_REPLACE]: false,
   [FeatureFlags.OWN_YOUR_FANS]: false,
-  [FeatureFlags.FAST_REFERRAL]: false
+  [FeatureFlags.FAST_REFERRAL]: false,
+  [FeatureFlags.REACT_QUERY_SYNC]: false
 }

--- a/packages/common/src/store/cache/actions.ts
+++ b/packages/common/src/store/cache/actions.ts
@@ -29,7 +29,7 @@ export type AddAction<EntryT extends Metadata = Metadata> =
   }
 
 /**
- * Signals to add an enty to the cache.
+ * Signals to add an entity to the cache.
  */
 export const add = (
   kind: Kind,

--- a/packages/common/src/store/cache/actions.ts
+++ b/packages/common/src/store/cache/actions.ts
@@ -29,7 +29,7 @@ export type AddAction<EntryT extends Metadata = Metadata> =
   }
 
 /**
- * Signals to add an entry to the cache.
+ * Signals to add an enty to the cache.
  */
 export const add = (
   kind: Kind,
@@ -72,6 +72,7 @@ export type AddEntriesAction<EntryT extends Metadata = Metadata> = {
   replace?: boolean
   // persist optionally persists the cache entry to indexdb
   persist?: boolean
+  source?: 'react-query' | 'redux'
 }
 
 /**
@@ -80,12 +81,14 @@ export type AddEntriesAction<EntryT extends Metadata = Metadata> = {
 export const addEntries = (
   entriesByKind: EntriesByKind,
   replace = false,
-  persist = true
+  persist = true,
+  source?: 'react-query' | 'redux'
 ): AddEntriesAction => ({
   type: ADD_ENTRIES,
   entriesByKind,
   replace,
-  persist
+  persist,
+  source
 })
 
 /**

--- a/packages/common/src/store/cache/reducer.ts
+++ b/packages/common/src/store/cache/reducer.ts
@@ -204,12 +204,7 @@ const actionsMap = {
   [ADD_ENTRIES](state: CacheState, action: AddEntriesAction, kind: Kind) {
     const { entriesByKind, replace } = action
     const matchingEntries = entriesByKind[kind] ?? {}
-    const cacheableEntries: Entry[] = Object.entries(matchingEntries).map(
-      ([id, entry]) => ({
-        id: parseInt(id, 10),
-        metadata: entry
-      })
-    )
+    const cacheableEntries: Entry[] = Object.values(matchingEntries)
     return addEntries(state, cacheableEntries, replace)
   },
   [UPDATE](state: CacheState, action: { entries: any[] }) {

--- a/packages/common/src/store/cache/sagas.ts
+++ b/packages/common/src/store/cache/sagas.ts
@@ -1,0 +1,46 @@
+import { takeEvery } from 'typed-redux-saga'
+
+import { getContext } from '../effects'
+
+import { ADD_ENTRIES, ADD_SUCCEEDED, addEntries, addSucceeded } from './actions'
+import { syncWithReactQuery } from './syncWithReactQuery'
+import { EntryMap } from './types'
+
+function* watchAddSucceeded() {
+  const queryClient = yield* getContext('queryClient')
+  yield* takeEvery(
+    ADD_SUCCEEDED,
+    function* (action: ReturnType<typeof addSucceeded>) {
+      // For any entity type, sync to React Query
+      syncWithReactQuery(queryClient, {
+        [action.kind]: {
+          ...action.entries.reduce((acc, entry) => {
+            acc[entry.id] = entry
+            return acc
+          }, {} as EntryMap)
+        }
+      })
+    }
+  )
+}
+
+function* watchAddEntries() {
+  const queryClient = yield* getContext('queryClient')
+  yield* takeEvery(
+    ADD_ENTRIES,
+    function* (action: ReturnType<typeof addEntries>) {
+      const { entriesByKind, source } = action
+      // Skip if the source is react-query to avoid infinite loops
+      if (source === 'react-query') return
+
+      // Sync all entries to React Query
+      syncWithReactQuery(queryClient, entriesByKind)
+    }
+  )
+}
+
+const sagas = () => {
+  return [watchAddSucceeded, watchAddEntries]
+}
+
+export default sagas

--- a/packages/common/src/store/cache/syncWithReactQuery.ts
+++ b/packages/common/src/store/cache/syncWithReactQuery.ts
@@ -1,0 +1,147 @@
+import type { QueryClient } from '@tanstack/react-query'
+
+import { Kind } from '../../models/Kind'
+
+import type { Entry, EntriesByKind } from './types'
+
+type EntityUpdater = {
+  singleKey: string
+  listKey: string
+  idField: string
+  updateRelations?: (
+    queryClient: QueryClient,
+    id: number,
+    metadata: any
+  ) => void
+}
+
+const ENTITY_UPDATERS: Record<Kind, EntityUpdater> = {
+  [Kind.USERS]: {
+    singleKey: 'user',
+    listKey: 'users',
+    idField: 'user_id',
+    updateRelations: (queryClient, id, metadata) => {
+      // Update any tracks that might contain this user
+      queryClient.setQueriesData({ queryKey: ['track'] }, (oldData: any) => {
+        if (!oldData?.user || oldData.user.user_id !== id) return oldData
+        return {
+          ...oldData,
+          user: metadata
+        }
+      })
+
+      // Update any collections that might contain this user
+      queryClient.setQueriesData(
+        { queryKey: ['collection'] },
+        (oldData: any) => {
+          if (!oldData) return oldData
+
+          let updatedData = oldData
+
+          // Update collection if the user is the owner
+          if (oldData.user?.user_id === id) {
+            updatedData = {
+              ...oldData,
+              user: metadata
+            }
+          }
+
+          // Update collection if the user appears in any of the tracks
+          if (
+            oldData.tracks?.some((track: any) => track.user?.user_id === id)
+          ) {
+            updatedData = {
+              ...updatedData,
+              tracks: oldData.tracks.map((track: any) =>
+                track.user?.user_id === id
+                  ? {
+                      ...track,
+                      user: metadata
+                    }
+                  : track
+              )
+            }
+          }
+
+          return updatedData
+        }
+      )
+    }
+  },
+  [Kind.TRACKS]: {
+    singleKey: 'track',
+    listKey: 'tracks',
+    idField: 'track_id',
+    updateRelations: (queryClient, id, metadata) => {
+      // Update any collections that might contain this track
+      queryClient.setQueriesData(
+        { queryKey: ['collection'] },
+        (oldData: any) => {
+          if (!oldData?.tracks) return oldData
+          return {
+            ...oldData,
+            tracks: oldData.tracks.map((track: any) =>
+              track.track_id === id ? metadata : track
+            )
+          }
+        }
+      )
+    }
+  },
+  [Kind.COLLECTIONS]: {
+    singleKey: 'collection',
+    listKey: 'collections',
+    idField: 'playlist_id'
+  },
+  [Kind.TRACK_ROUTES]: {
+    singleKey: 'track_route',
+    listKey: 'track_routes',
+    idField: 'id'
+  },
+  [Kind.EMPTY]: {
+    singleKey: 'empty',
+    listKey: 'empty',
+    idField: 'id'
+  }
+}
+
+const updateEntity = (
+  queryClient: QueryClient,
+  kind: Kind,
+  entry: Entry<any>
+) => {
+  const { id, metadata } = entry
+  const updater = ENTITY_UPDATERS[kind]
+  if (!updater) return
+
+  // Update single entity
+  queryClient.setQueryData([updater.singleKey, id], metadata)
+
+  // Update entity in lists
+  queryClient.setQueriesData(
+    { queryKey: [updater.listKey] },
+    (oldData: any) => {
+      if (!Array.isArray(oldData)) return oldData
+      return oldData.map((item) =>
+        item[updater.idField] === id ? metadata : item
+      )
+    }
+  )
+
+  // Update related entities
+  if (updater.updateRelations) {
+    updater.updateRelations(queryClient, id, metadata)
+  }
+}
+
+export const syncWithReactQuery = (
+  queryClient: QueryClient,
+  entriesByKind: EntriesByKind
+) => {
+  Object.entries(entriesByKind).forEach(([kind, entries]) => {
+    if (!entries) return
+    Object.values(entries).forEach((entry) => {
+      updateEntity(queryClient, kind as Kind, entry)
+    })
+  })
+}

--- a/packages/common/src/store/index.ts
+++ b/packages/common/src/store/index.ts
@@ -42,3 +42,5 @@ export * as searchSelectors from './search/selectors'
 export type { SearchItem } from './search/types'
 
 export * from './sdkUtils'
+
+export { syncWithReactQuery } from './cache/syncWithReactQuery'

--- a/packages/common/src/store/storeContext.ts
+++ b/packages/common/src/store/storeContext.ts
@@ -1,6 +1,7 @@
 import { FetchNFTClient } from '@audius/fetch-nft'
 import type { AudiusSdk } from '@audius/sdk'
 import { VersionedTransaction } from '@solana/web3.js'
+import { QueryClient } from '@tanstack/react-query'
 import { Location } from 'history'
 import { Dispatch } from 'redux'
 import nacl from 'tweetnacl'
@@ -88,6 +89,7 @@ export type CommonStoreContext = {
   }
   isMobile: boolean
   dispatch: Dispatch<any>
+  queryClient: QueryClient
   mobileWalletActions?: {
     connect: (dappKeyPair: nacl.BoxKeyPair) => void
     signAndSendTransaction: (params: {

--- a/packages/mobile/src/app/App.tsx
+++ b/packages/mobile/src/app/App.tsx
@@ -1,10 +1,7 @@
 import { BottomSheetModalProvider } from '@gorhom/bottom-sheet'
 import { PortalProvider, PortalHost } from '@gorhom/portal'
 import * as Sentry from '@sentry/react-native'
-import {
-  QueryClientProvider,
-  QueryClient as TanQueryClient
-} from '@tanstack/react-query'
+import { QueryClientProvider } from '@tanstack/react-query'
 import { Platform, UIManager } from 'react-native'
 import { GestureHandlerRootView } from 'react-native-gesture-handler'
 import {
@@ -27,6 +24,7 @@ import { useEnterForeground } from 'app/hooks/useAppState'
 import { incrementSessionCount } from 'app/hooks/useSessionCount'
 import { RootScreen } from 'app/screens/root-screen'
 import { WalletConnectProvider } from 'app/screens/wallet-connect'
+import { queryClient } from 'app/services/query-client'
 import { persistor, store } from 'app/store'
 import {
   forceRefreshConnectivity,
@@ -41,8 +39,6 @@ import { ThemeProvider } from './ThemeProvider'
 import { initSentry, navigationIntegration } from './sentry'
 
 initSentry()
-
-const tanQueryClient = new TanQueryClient()
 
 const Airplay = Platform.select({
   ios: () => require('../components/audio/Airplay').default,
@@ -78,7 +74,7 @@ const App = () => {
       <SafeAreaProvider initialMetrics={initialWindowMetrics}>
         <Provider store={store}>
           <AudiusQueryProvider>
-            <QueryClientProvider client={tanQueryClient}>
+            <QueryClientProvider client={queryClient}>
               <PersistGate loading={null} persistor={persistor}>
                 <ThemeProvider>
                   <WalletConnectProvider>

--- a/packages/mobile/src/services/query-client.ts
+++ b/packages/mobile/src/services/query-client.ts
@@ -1,0 +1,3 @@
+import { QueryClient } from '@tanstack/react-query'
+
+export const queryClient = new QueryClient()

--- a/packages/mobile/src/store/storeContext.ts
+++ b/packages/mobile/src/store/storeContext.ts
@@ -10,6 +10,7 @@ import { audiusBackendInstance } from 'app/services/audius-backend-instance'
 import { explore } from 'app/services/explore'
 import { fingerprintClient } from 'app/services/fingerprint'
 import { localStorage } from 'app/services/local-storage'
+import { queryClient } from 'app/services/query-client'
 import {
   getFeatureEnabled,
   remoteConfigInstance
@@ -73,6 +74,7 @@ export const storeContext: CommonStoreContext = {
     generatePlaylistArtwork
   },
   isMobile: true,
+  queryClient,
   mobileWalletActions: {
     connect,
     signAndSendTransaction

--- a/packages/web/src/app/App.tsx
+++ b/packages/web/src/app/App.tsx
@@ -39,6 +39,14 @@ const ReactQueryCachePrimePage = lazy(
   () => import('pages/react-query/ReactQueryCachePrimePage')
 )
 
+const ReactQueryReduxCacheSyncPage = lazy(
+  () => import('pages/react-query/ReactQueryReduxCacheSyncPage')
+)
+
+const ReactQueryToReduxCacheSyncPage = lazy(
+  () => import('pages/react-query/ReactQueryToReduxCacheSyncPage')
+)
+
 const MERCHANT_ID = env.COINFLOW_MERCHANT_ID
 const IS_PRODUCTION = env.ENVIRONMENT === 'production'
 
@@ -75,6 +83,16 @@ export const AppInner = () => {
           {!IS_PRODUCTION ? (
             <Route path='/react-query-cache-prime'>
               <ReactQueryCachePrimePage />
+            </Route>
+          ) : null}
+          {!IS_PRODUCTION ? (
+            <Route path='/react-query-redux-cache-sync'>
+              <ReactQueryReduxCacheSyncPage />
+            </Route>
+          ) : null}
+          {!IS_PRODUCTION ? (
+            <Route path='/react-query-to-redux-cache-sync'>
+              <ReactQueryToReduxCacheSyncPage />
             </Route>
           ) : null}
           <Route path={PRIVATE_KEY_EXPORTER_SETTINGS_PAGE}>

--- a/packages/web/src/app/AppProviders.tsx
+++ b/packages/web/src/app/AppProviders.tsx
@@ -1,9 +1,6 @@
 import { ReactNode } from 'react'
 
-import {
-  QueryClientProvider,
-  QueryClient as TanQueryClient
-} from '@tanstack/react-query'
+import { QueryClientProvider } from '@tanstack/react-query'
 import { ReactQueryDevtools } from '@tanstack/react-query-devtools'
 import { ConnectedRouter } from 'connected-react-router'
 import { CompatRouter } from 'react-router-dom-v5-compat'
@@ -14,6 +11,7 @@ import { HeaderContextProvider } from 'components/header/mobile/HeaderContextPro
 import { NavProvider } from 'components/nav/mobile/NavContext'
 import { ScrollProvider } from 'components/scroll-provider/ScrollProvider'
 import { ToastContextProvider } from 'components/toast/ToastContext'
+import { queryClient } from 'services/query-client'
 import { getSystemAppearance, getTheme } from 'utils/theme/theme'
 
 import { MainContentContextProvider } from '../pages/MainContentContext'
@@ -24,8 +22,6 @@ import { useHistoryContext } from './HistoryProvider'
 import { ReduxProvider } from './ReduxProvider'
 import { SvgGradientProvider } from './SvgGradientProvider'
 import { ThemeProvider } from './ThemeProvider'
-
-const tanQueryClient = new TanQueryClient()
 
 type AppContextProps = {
   children: ReactNode
@@ -49,7 +45,7 @@ export const AppProviders = ({ children }: AppContextProps) => {
         <CompatRouter>
           <LastLocationProvider>
             <AudiusQueryProvider>
-              <QueryClientProvider client={tanQueryClient}>
+              <QueryClientProvider client={queryClient}>
                 <ReactQueryDevtools initialIsOpen={false} />
                 <AppContextProvider>
                   <ThemeProvider>

--- a/packages/web/src/pages/react-query/ReactQueryReduxCacheSyncPage.tsx
+++ b/packages/web/src/pages/react-query/ReactQueryReduxCacheSyncPage.tsx
@@ -1,0 +1,107 @@
+import { useEffect, useState } from 'react'
+
+import { useTrack, useTracks } from '@audius/common/api'
+import { cacheTracksSelectors, trackPageActions } from '@audius/common/store'
+import { Button } from '@audius/harmony'
+import { useDispatch } from 'react-redux'
+
+import { useSelector } from 'utils/reducer'
+
+const EXAMPLE_TRACK_ID = 1 // Replace with a real track ID from your system
+const { getTrack } = cacheTracksSelectors
+
+const ReactQueryReduxCacheSyncPage = () => {
+  const dispatch = useDispatch()
+  const [showTracksQuery, setShowTracksQuery] = useState(false)
+
+  // Load track using Redux
+  useEffect(() => {
+    dispatch(trackPageActions.fetchTrack(EXAMPLE_TRACK_ID, '', '', false))
+  }, [dispatch])
+
+  const trackFromRedux = useSelector((state) =>
+    getTrack(state, { id: EXAMPLE_TRACK_ID })
+  )
+
+  // Load track using React Query
+  const { data: trackFromReactQuery } = useTrack(EXAMPLE_TRACK_ID, {
+    staleTime: 10000,
+    enabled: showTracksQuery
+  })
+
+  // Load track using useTracks hook (will be populated from cache)
+  const { data: tracksFromCache } = useTracks(
+    showTracksQuery ? [EXAMPLE_TRACK_ID] : [],
+    { staleTime: 10000 }
+  )
+
+  return (
+    <div style={{ padding: 24 }}>
+      <h1>Redux ↔️ React Query Cache Sync Example</h1>
+
+      <div style={{ marginBottom: 40 }}>
+        <p>
+          This example demonstrates how data flows between Redux and React Query
+          caches:
+        </p>
+        <ol>
+          <li>First track is loaded using Redux (like in TrackPage)</li>
+          <li>Second track is loaded using React Query directly</li>
+          <li>
+            Third track is loaded using useTracks hook after clicking the button
+            - it should load instantly from cache!
+          </li>
+        </ol>
+      </div>
+
+      <div>
+        <h3>Track from Redux:</h3>
+        <pre>{trackFromRedux?.title}</pre>
+      </div>
+
+      <div style={{ marginBottom: 20 }}>
+        <Button onClick={() => setShowTracksQuery(true)}>
+          Load Track From Cache{' '}
+        </Button>
+      </div>
+
+      {trackFromReactQuery && (
+        <div>
+          <h3>Track from React Query:</h3>
+          <pre>{trackFromReactQuery.title}</pre>
+        </div>
+      )}
+
+      {tracksFromCache?.[0] && (
+        <div>
+          <h3>Track from Cache (via useTracks):</h3>
+          <pre>{tracksFromCache[0].title}</pre>
+        </div>
+      )}
+
+      <div style={{ marginTop: 40, padding: 16, background: '#F7F7F7' }}>
+        <h3>How it works:</h3>
+        <ol>
+          <li>
+            When Redux loads the track, our saga middleware syncs it to React
+            Query cache
+          </li>
+          <li>
+            When React Query loads the track directly, it&apos;s stored in its
+            own cache
+          </li>
+          <li>
+            When we click the button to load via useTracks, it hits the React
+            Query cache first
+          </li>
+          <li>
+            This means no additional network request is needed - the data is
+            already there!
+          </li>
+        </ol>
+      </div>
+    </div>
+  )
+}
+
+export default ReactQueryReduxCacheSyncPage

--- a/packages/web/src/pages/react-query/ReactQueryToReduxCacheSyncPage.tsx
+++ b/packages/web/src/pages/react-query/ReactQueryToReduxCacheSyncPage.tsx
@@ -1,0 +1,98 @@
+import { useState } from 'react'
+
+import { useTrack, useTracks } from '@audius/common/api'
+import { cacheTracksSelectors } from '@audius/common/store'
+import { Button } from '@audius/harmony'
+
+import { useSelector } from 'utils/reducer'
+
+const EXAMPLE_TRACK_ID = 1 // Replace with a real track ID from your system
+const { getTrack } = cacheTracksSelectors
+
+const ReactQueryToReduxCacheSyncPage = () => {
+  const [showTracksQuery, setShowTracksQuery] = useState(false)
+
+  // First load track using React Query
+  const { data: trackFromReactQuery } = useTrack(EXAMPLE_TRACK_ID, {
+    staleTime: 10000
+  })
+
+  // Get the same track from Redux store (should be populated from React Query)
+  const trackFromRedux = useSelector((state) =>
+    getTrack(state, { id: EXAMPLE_TRACK_ID })
+  )
+
+  // Load track using useTracks hook (will be populated from cache)
+  const { data: tracksFromCache } = useTracks(
+    showTracksQuery ? [EXAMPLE_TRACK_ID] : [],
+    { staleTime: 10000 }
+  )
+
+  return (
+    <div style={{ padding: 24 }}>
+      <h1>React Query ➡️ Redux Cache Sync Example</h1>
+
+      <div style={{ marginBottom: 40 }}>
+        <p>
+          This example demonstrates how data flows from React Query to Redux
+          cache:
+        </p>
+        <ol>
+          <li>First track is loaded using React Query directly</li>
+          <li>Second track is shown from Redux (populated by React Query)</li>
+          <li>
+            Third track is loaded using useTracks hook after clicking the button
+            - it should load instantly from cache!
+          </li>
+        </ol>
+      </div>
+
+      <div>
+        <h3>Track from React Query:</h3>
+        <pre>{JSON.stringify(trackFromReactQuery?.title, null, 2)}</pre>
+      </div>
+
+      <div>
+        <h3>Same Track from Redux (populated by React Query):</h3>
+        <pre>{JSON.stringify(trackFromRedux?.title, null, 2)}</pre>
+      </div>
+
+      <div style={{ marginBottom: 20 }}>
+        <Button onClick={() => setShowTracksQuery(true)}>
+          Load Track From Cache
+        </Button>
+      </div>
+
+      {tracksFromCache?.[0] && (
+        <div>
+          <h3>Track from Cache (via useTracks):</h3>
+          <pre>{JSON.stringify(tracksFromCache[0].title, null, 2)}</pre>
+        </div>
+      )}
+
+      <div style={{ marginTop: 40, padding: 16, background: '#F7F7F7' }}>
+        <h3>How it works:</h3>
+        <ol>
+          <li>
+            When React Query loads the track, our hooks automatically sync it to
+            Redux cache
+          </li>
+          <li>
+            The Redux selector immediately shows the same data without a network
+            request
+          </li>
+          <li>
+            When we click the button to load via useTracks, it hits both caches
+            first
+          </li>
+          <li>
+            This means no additional network request is needed - the data is
+            already there!
+          </li>
+        </ol>
+      </div>
+    </div>
+  )
+}
+
+export default ReactQueryToReduxCacheSyncPage

--- a/packages/web/src/services/query-client.ts
+++ b/packages/web/src/services/query-client.ts
@@ -1,0 +1,3 @@
+import { QueryClient } from '@tanstack/react-query'
+
+export const queryClient = new QueryClient()

--- a/packages/web/src/ssr/util.ts
+++ b/packages/web/src/ssr/util.ts
@@ -28,7 +28,9 @@ const nonSsrPaths = [
   CHAT_PAGE,
   DOWNLOAD_LINK,
   '/react-query',
-  '/react-query-cache-prime'
+  '/react-query-cache-prime',
+  '/react-query-redux-cache-sync',
+  '/react-query-to-redux-cache-sync'
 ]
 
 export const makePageRoute =

--- a/packages/web/src/store/storeContext.ts
+++ b/packages/web/src/store/storeContext.ts
@@ -16,6 +16,7 @@ import { env } from 'services/env'
 import { explore } from 'services/explore'
 import { fingerprintClient } from 'services/fingerprint'
 import { localStorage } from 'services/local-storage'
+import { queryClient } from 'services/query-client'
 import { getFeatureEnabled } from 'services/remote-config/featureFlagHelpers'
 import { remoteConfigInstance } from 'services/remote-config/remote-config-instance'
 import { trackDownload } from 'services/track-download'
@@ -83,6 +84,7 @@ export const buildStoreContext = ({
     generatePlaylistArtwork
   },
   isMobile,
+  queryClient,
   // @ts-ignore dispatch will be populated in configureStore
   dispatch: undefined
 })


### PR DESCRIPTION
### Description

Now that redux and react-query are caching entities in the same data-format, we can add a bidirectional sync.

For redux -> react-query
- on addEntries and addSucceeded, sync all the entities across to react-query

For react-query -> redux
- on successful fetch, dispatch addEntries action to redux. Note we must set a "source" param to be 'react-query' so we know not to double sync back.

Other changes
- Added queryClient to saga context and refactored their instantiation on web and mobile

### How Has This Been Tested?

Added some example files showing this behavior