### PR TITLE
jrpc no longer used

### DIFF
--- a/pkg/mediorum/server/core.go
+++ b/pkg/mediorum/server/core.go
@@ -13,7 +13,7 @@ func (ss *MediorumServer) getCoreSdk() (*sdk.Sdk, error) {
 }
 
 func (ss *MediorumServer) initCoreSdk() error {
-	coreSdk, err := sdk.NewSdk(sdk.WithGrpcendpoint(ss.Config.CoreGRPCEndpoint), sdk.WithJrpcendpoint(ss.Config.CoreJRPCEndpoint))
+	coreSdk, err := sdk.NewSdk(sdk.WithGrpcendpoint(ss.Config.CoreGRPCEndpoint))
 	if err == nil {
 		ss.coreSdk = coreSdk
 		close(ss.coreSdkReady)
@@ -23,7 +23,7 @@ func (ss *MediorumServer) initCoreSdk() error {
 	for {
 		time.Sleep(5 * time.Second)
 
-		coreSdk, err := sdk.NewSdk(sdk.WithGrpcendpoint(ss.Config.CoreGRPCEndpoint), sdk.WithJrpcendpoint(ss.Config.CoreJRPCEndpoint))
+		coreSdk, err := sdk.NewSdk(sdk.WithGrpcendpoint(ss.Config.CoreGRPCEndpoint))
 		if err != nil {
 			continue
 		}


### PR DESCRIPTION
### Description
- everything should go through the grpc if possible
- this breaks plays because it tries to init sdk with the jrpc endpoint but it's been moved to a /debug route
### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._
