### PR TITLE
put core plays into index sol queue and insert starting core block

### DIFF
--- a/packages/discovery-provider/ddl/migrations/0110_stage_core_cutover.sql
+++ b/packages/discovery-provider/ddl/migrations/0110_stage_core_cutover.sql
@@ -1,0 +1,10 @@
+begin;
+do $$ begin
+-- stage gate
+if exists (select * from "blocks" where "blockhash" = '0x65a3243860511ed28a933c3a113dea7df368ad53f721cc9d0034c0c75f996afb') then
+  -- jump core indexing to the expected block
+  insert into core_indexed_blocks (blockhash, parenthash, chain_id, height) values ('785C639441F9E93752B9E2E1639365C6EA84CFE2666C794FC4A7338E0F114563', '30D63285F13282AF09D0BD12FBBE9EA843D8FC874B40FD4E26B294B8AF76B204', 'audius-testnet-17', 11046) on conflict (blockhash) do nothing;
+
+end if;
+end $$;
+commit;

--- a/packages/discovery-provider/src/app.py
+++ b/packages/discovery-provider/src/app.py
@@ -545,4 +545,4 @@ def configure_celery(celery, test_config=None):
     celery.send_task("index_payment_router", queue="index_sol")
 
     if environment == "dev" or environment == "stage":
-        celery.send_task("index_core")
+        celery.send_task("index_core", queue="index_sol")

--- a/packages/discovery-provider/src/tasks/index_core.py
+++ b/packages/discovery-provider/src/tasks/index_core.py
@@ -162,4 +162,4 @@ def index_core(self):
         elapsed_time = time.time() - start_time
         if elapsed_time < CORE_INDEXER_MINIMUM_TIME_SECS:
             time.sleep(CORE_INDEXER_MINIMUM_TIME_SECS - elapsed_time)
-        celery.send_task("index_core")
+        celery.send_task("index_core", queue="index_sol")


### PR DESCRIPTION
### Description
- the core indexer would start at the cutover but not actually begin at the cutover, the postgres migration puts a starting block into the db for it to pick up from on stage
- the index sol queue is only used for userbank now that core is doing listens so to avoid being clogged in the main queue index_core will go into the index_sol queue

### How Has This Been Tested?
staging dn2
