### PR TITLE
Update sdk deps to fix security issues

### DIFF
--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@audius/sdk",
-  "version": "7.1.0",
+  "version": "7.1.1",
   "audius": {
     "releaseSHA": "f1d70a2a0643c5c84d8ab053f70c1e0a2ec3ad49"
   },
@@ -85,10 +85,10 @@
     "assert": "2.0.0",
     "async-mutex": "0.5.0",
     "async-retry": "1.3.1",
-    "axios": "0.19.2",
+    "axios": "0.28.0",
     "borsh": "0.4.0",
     "cross-fetch": "4.0.0",
-    "file-type": "16.5.3",
+    "file-type": "16.5.4",
     "form-data": "3.0.0",
     "hashids": "2.2.10",
     "isomorphic-ws": "5.0.0",
@@ -97,14 +97,14 @@
     "multiformats": "13.3.1",
     "node-abort-controller": "3.1.1",
     "node-localstorage": "1.3.1",
-    "semver": "6.3.0",
+    "semver": "6.3.1",
     "snakecase-keys": "5.4.5",
     "type-fest": "4.26.1",
     "ulid": "2.3.0",
     "url": "0.11.1",
     "viem": "2.21.21",
     "xmlhttprequest": "1.8.0",
-    "zod": "3.21.4"
+    "zod": "3.22.3"
   },
   "devDependencies": {
     "@babel/core": "7.23.7",
@@ -146,9 +146,9 @@
     "nock": "13.1.2",
     "nyc": "15.1.0",
     "patch-package": "6.5.0",
-    "prettier": "3.4.2",
-    "prettier-config-standard": "7.0.0",
-    "rollup": "2.70.1",
+    "prettier": "2.8.8",
+    "prettier-config-standard": "6.0.0",
+    "rollup": "2.79.2",
     "rollup-plugin-dts": "4.2.0",
     "rollup-plugin-ignore": "1.0.10",
     "rollup-plugin-polyfill-node": "0.9.0",


### PR DESCRIPTION
### Description

Things in NPM goes red. Dependabot goes crazy. So this PR try to calm both a bit by updatkng the dependencies

### How Has This Been Tested?

The SDK have a test script. **⚠️ SOME TEST FILES HAVE FAILDED** but with no errors so I will see if it's a sdk issue or not