### PR TITLE
Update notification count on hover

### DIFF
--- a/packages/harmony/src/components/nav-item/NavItem.tsx
+++ b/packages/harmony/src/components/nav-item/NavItem.tsx
@@ -1,4 +1,8 @@
+import { useMemo } from 'react'
+
 import { useTheme } from '@emotion/react'
+
+import { NotificationCount } from 'components/notification-count'
 
 import { motion } from '../../foundations/motion'
 import { Flex } from '../layout/Flex'
@@ -17,6 +21,7 @@ export const NavItem = ({
   isSelected = false,
   onClick,
   textSize = 'l',
+  hasNotification = false,
   ...props
 }: NavItemProps) => {
   const { color } = useTheme()
@@ -29,6 +34,19 @@ export const NavItem = ({
   const textColor = isSelected ? 'staticWhite' : 'default'
 
   const iconColor = isSelected ? 'staticStaticWhite' : 'default'
+
+  const leftIconWithNotification = useMemo(() => {
+    const icon = hasLeftIcon ? <LeftIcon size='l' color={iconColor} /> : null
+
+    if (hasNotification && !!icon) {
+      return (
+        <NotificationCount size='s' isSelected={isSelected}>
+          {icon}
+        </NotificationCount>
+      )
+    }
+    return icon
+  }, [hasNotification, hasLeftIcon, LeftIcon, iconColor, isSelected])
 
   return (
     <Flex
@@ -68,7 +86,7 @@ export const NavItem = ({
             maxWidth: '240px'
           }}
         >
-          {hasLeftIcon ? <LeftIcon size='l' color={iconColor} /> : null}
+          {leftIconWithNotification}
           <Text
             variant='title'
             size={textSize}

--- a/packages/harmony/src/components/nav-item/types.ts
+++ b/packages/harmony/src/components/nav-item/types.ts
@@ -8,7 +8,7 @@ import type { WithCSS } from '../../foundations/theme'
 
 export type NavItemProps = WithCSS<{
   /** The label text of the navigation item. */
-  children: React.ReactNode
+  children: ReactNode
   /** The name of the icon to display on the left side of the label. */
   leftIcon?: IconComponent
   /** The name of the icon to display on the right side of the label. */
@@ -19,5 +19,7 @@ export type NavItemProps = WithCSS<{
   onClick?: (event?: MouseEvent<Element>) => void
   /** The size of the text to display. */
   textSize?: TextSize
+  /** Whether the navigation item has a notification count. */
+  hasNotification?: boolean
 }> &
   FlexProps

--- a/packages/harmony/src/components/notification-count/NotificationCount.tsx
+++ b/packages/harmony/src/components/notification-count/NotificationCount.tsx
@@ -15,6 +15,7 @@ export const NotificationCount = ({
   count,
   size,
   children,
+  isSelected = false,
   ...props
 }: NotificationCountProps) => {
   const { spacing, color } = useTheme()
@@ -28,16 +29,20 @@ export const NotificationCount = ({
 
   const badgeStyles: CSSObject = {
     minWidth: spacing.unit5,
-    backgroundColor: color.primary.p300,
+    backgroundColor: isSelected
+      ? color.background.surface1
+      : color.primary.p300,
     border: 'none',
     '.parent:hover &': {
       backgroundColor: color.background.surface1
     },
     ...(size === 's' && {
-      height: spacing.unit3 + spacing.unitHalf,
-      minWidth: spacing.unit3 + spacing.unitHalf,
+      height: spacing.unit2,
+      minWidth: spacing.unit2,
       padding: `0px ${spacing.xs}px`,
-      backgroundColor: color.primary.p300
+      backgroundColor: isSelected
+        ? color.background.surface1
+        : color.primary.p300
     }),
     ...(children && {
       position: 'absolute',
@@ -48,6 +53,9 @@ export const NotificationCount = ({
   }
 
   const textStyles: CSSObject = {
+    ...(isSelected && {
+      color: color.neutral.n950
+    }),
     '.parent:hover &': {
       color: color.neutral.n950
     }
@@ -79,7 +87,7 @@ export const NotificationCount = ({
           css={textStyles}
           color='staticStaticWhite'
         >
-          {count !== undefined ? formatCount(count) : '0'}
+          {count !== undefined ? formatCount(count) : ''}
         </Text>
       </Flex>
     </Flex>

--- a/packages/harmony/src/components/notification-count/types.ts
+++ b/packages/harmony/src/components/notification-count/types.ts
@@ -10,5 +10,9 @@ export type NotificationCountProps = {
    * @default undefined
    */
   size?: 's'
+  /**
+   * Whether the parent item is selected
+   */
+  isSelected?: boolean
   children?: ReactNode
 } & ComponentPropsWithoutRef<'div'>

--- a/packages/web/src/components/nav/desktop/LeftNav.tsx
+++ b/packages/web/src/components/nav/desktop/LeftNav.tsx
@@ -101,6 +101,7 @@ const LeftNav = (props: NavColumnProps) => {
           to={item.to}
           disabled={item.disabled}
           restriction={item.restriction}
+          hasNotification={item.hasNotification}
         >
           {item.label}
         </LeftNavLink>
@@ -175,7 +176,7 @@ const LeftNav = (props: NavColumnProps) => {
           </DragAutoscroller>
         </Scrollbar>
       </Flex>
-      <Flex direction='column' alignItems='center' pt='l' borderTop='default'>
+      <Flex direction='column' alignItems='center' pt='l'>
         <ProfileCompletionPanel />
         <LeftNavCTA />
         <NowPlayingArtworkTile />

--- a/packages/web/src/components/nav/desktop/LeftNavCTA.tsx
+++ b/packages/web/src/components/nav/desktop/LeftNavCTA.tsx
@@ -3,7 +3,7 @@ import { useCallback } from 'react'
 import { Name, Status } from '@audius/common/models'
 import { accountSelectors } from '@audius/common/store'
 import { route } from '@audius/common/utils'
-import { Button, IconUserFollow as IconFollow } from '@audius/harmony'
+import { Box, Button, IconArrowRight } from '@audius/harmony'
 import { useSelector } from 'react-redux'
 import { Link } from 'react-router-dom'
 
@@ -48,23 +48,34 @@ export const LeftNavCTA = () => {
       break
     case 'guest':
       button = (
-        <Button variant='primary' size='small' asChild>
-          <SignOnLink signUp>{messages.finishSignUp}</SignOnLink>
-        </Button>
+        <Box p='l' w='100%'>
+          <Button
+            variant='primary'
+            size='small'
+            asChild
+            iconRight={IconArrowRight}
+            fullWidth
+          >
+            <SignOnLink signUp>{messages.finishSignUp}</SignOnLink>
+          </Button>
+        </Box>
       )
       break
     case 'signedOut':
     default:
       button = (
-        <Button
-          variant='primary'
-          size='small'
-          asChild
-          iconLeft={IconFollow}
-          onClick={handleSignup}
-        >
-          <Link to={SIGN_UP_PAGE}>{messages.signUp}</Link>
-        </Button>
+        <Box p='l' w='100%'>
+          <Button
+            variant='primary'
+            size='small'
+            asChild
+            iconRight={IconArrowRight}
+            fullWidth
+            onClick={handleSignup}
+          >
+            <Link to={SIGN_UP_PAGE}>{messages.signUp}</Link>
+          </Button>
+        </Box>
       )
       break
   }

--- a/packages/web/src/components/nav/desktop/NavHeaderButton.tsx
+++ b/packages/web/src/components/nav/desktop/NavHeaderButton.tsx
@@ -12,10 +12,10 @@ export const NavHeaderButton = forwardRef(
     const { color } = useTheme()
 
     const activeCss = {
-      backgroundColor: color.secondary.s100,
+      backgroundColor: color.neutral.n100,
       svg: {
         path: {
-          fill: color.static.white
+          fill: color.text.default
         }
       }
     }

--- a/packages/web/src/components/nav/desktop/useNavConfig.tsx
+++ b/packages/web/src/components/nav/desktop/useNavConfig.tsx
@@ -15,6 +15,7 @@ import {
   NotificationCount
 } from '@audius/harmony'
 import { useSelector } from 'react-redux'
+import { useLocation } from 'react-router-dom'
 
 import { RestrictionType } from 'hooks/useRequiresAccount'
 
@@ -44,12 +45,14 @@ export type NavItemConfig = {
   nestedComponent?: React.ComponentType<any>
   disabled?: boolean
   restriction?: RestrictionType
+  hasNotification?: boolean
 }
 
 export const useNavConfig = () => {
   const isAccountComplete = useSelector(getIsAccountComplete)
   const hasAccount = useSelector(getHasAccount)
   const unreadMessagesCount = useSelector(getUnreadMessagesCount)
+  const location = useLocation()
 
   const navItems = useMemo(
     (): NavItemConfig[] => [
@@ -87,8 +90,12 @@ export const useNavConfig = () => {
         disabled: !isAccountComplete,
         rightIcon:
           unreadMessagesCount > 0 ? (
-            <NotificationCount count={unreadMessagesCount} />
-          ) : undefined
+            <NotificationCount
+              count={unreadMessagesCount}
+              isSelected={location.pathname === CHATS_PAGE}
+            />
+          ) : undefined,
+        hasNotification: unreadMessagesCount > 0
       },
       {
         label: 'Wallets',
@@ -116,7 +123,7 @@ export const useNavConfig = () => {
         disabled: !isAccountComplete
       }
     ],
-    [isAccountComplete, hasAccount, unreadMessagesCount]
+    [isAccountComplete, hasAccount, unreadMessagesCount, location.pathname]
   )
 
   return navItems


### PR DESCRIPTION
### Description

This PR enhances the notification badge behavior in navigation items to maintain visual consistency between hover and selected states. The changes primarily focus on the `NotificationCount` component and its integration with navigation items.

## Changes
- Added `isSelected` prop to `NotificationCount` component to handle selected state styling
- Updated notification badge styling to match hover state when parent nav item is selected
- Modified `NavItem` to properly handle notification badges with icons
- Improved `useNavConfig` to pass selected state to standalone notification badges
- Standardized icon sizes in navigation items to 'l'
- Cleaned up right icon handling in navigation components

## Technical Details
- Added new `isSelected` prop type to `NotificationCountProps`
- Updated badge background color to use `surface1` when selected
- Updated text color to use `n950` when selected
- Improved notification badge positioning and sizing
- Standardized notification badge behavior between standalone and icon-wrapped usage

### How Has This Been Tested?
- Verify notification badges appear correctly in both default and selected states
- Confirm hover states match selected states for notification badges
- Check that notification counts are properly displayed
- Ensure icon sizes are consistent across navigation items

<img width="240" alt="image" src="https://github.com/user-attachments/assets/659e54b2-f71e-4894-a8df-be5828274f4e" />

