### PR TITLE
Update draggability and text inversion on playlist items

### DIFF
--- a/packages/web/src/components/nav/desktop/LeftNavLink.tsx
+++ b/packages/web/src/components/nav/desktop/LeftNavLink.tsx
@@ -20,14 +20,14 @@ export const LeftNavLink = (props: LeftNavLinkProps) => {
     (e) => {
       onClick?.(e)
     },
-    [onClick, to, history],
+    [onClick, to],
     undefined,
     undefined,
     restriction
   )
 
   const handleClick = (e?: React.MouseEvent<Element>) => {
-    if (!disabled && !!e) {
+    if (!disabled && !!e && !e.defaultPrevented) {
       return requiresAccountOnClick(e)
     } else {
       e?.preventDefault()
@@ -40,6 +40,7 @@ export const LeftNavLink = (props: LeftNavLinkProps) => {
       to={to ?? ''}
       onClick={handleClick}
       style={{ pointerEvents: disabled ? 'none' : 'auto' }}
+      draggable={false}
     >
       <NavItem
         {...other}

--- a/packages/web/src/components/nav/desktop/PlaylistLibrary/CollectionNavItem.tsx
+++ b/packages/web/src/components/nav/desktop/PlaylistLibrary/CollectionNavItem.tsx
@@ -14,7 +14,7 @@ import {
   playlistLibraryActions,
   shareModalUIActions
 } from '@audius/common/store'
-import { Flex, PopupMenuItem, Text, useTheme } from '@audius/harmony'
+import { Flex, PopupMenuItem, useTheme } from '@audius/harmony'
 import { useDispatch } from 'react-redux'
 import { useNavigate } from 'react-router-dom-v5-compat'
 import { useToggle } from 'react-use'
@@ -74,7 +74,7 @@ export const CollectionNavItem = (props: CollectionNavItemProps) => {
   const record = useRecord()
   const navigate = useNavigate()
 
-  const { spacing, color } = useTheme()
+  const { spacing } = useTheme()
 
   const collection = useSelector((state) =>
     getCollection(state, { id: typeof id === 'string' ? null : id })
@@ -192,6 +192,7 @@ export const CollectionNavItem = (props: CollectionNavItemProps) => {
             onDragLeave={handleDragLeave}
             onMouseEnter={handleMouseEnter}
             onMouseLeave={handleMouseLeave}
+            textSize='s'
           >
             <Flex
               alignItems='center'
@@ -210,17 +211,7 @@ export const CollectionNavItem = (props: CollectionNavItemProps) => {
                   <PlaylistUpdateDot />
                 </div>
               ) : null}
-              <Text
-                size='s'
-                css={{
-                  '.droppableLinkActive &': {
-                    color: color.text.accent
-                  }
-                }}
-                ellipses
-              >
-                {name}
-              </Text>
+              {name}
               <NavItemKebabButton
                 visible={isOwned && isHovering && !isDraggingOver}
                 aria-label={messages.editPlaylistLabel}


### PR DESCRIPTION
## Description

### Changes
- Simplified text rendering in playlist library navigation items
- Removed custom text styling that was overriding NavItem's built-in styling
- Standardized text size handling through NavItem props
- Added `draggable={false}` so items can properly be dragged around in the playlist section 

### Technical Details
- Removed custom Text component in CollectionNavItem to use NavItem's built-in text handling
- Added textSize prop to LeftNavLink for consistent text size control
- Removed redundant color styling to ensure proper color inversion on selection

### Testing
- Verify text styling is consistent across playlist library items
- Confirm text color properly inverts when items are selected
- Check that text size remains correct for all navigation items

### How Has This Been Tested?

Locally on staging 
