### PR TITLE
SLA rollup improvements, fixes

### DIFF
--- a/pkg/core/config/genesis/stage.json
+++ b/pkg/core/config/genesis/stage.json
@@ -1,6 +1,6 @@
 {
   "genesis_time": "2024-08-09T00:00:00.0000Z",
-  "chain_id": "audius-testnet-17",
+  "chain_id": "audius-testnet-18",
   "initial_height": "0",
   "consensus_params": {
     "block": {

--- a/pkg/core/console/uptime.go
+++ b/pkg/core/console/uptime.go
@@ -1,6 +1,10 @@
 package console
 
 import (
+	"context"
+	"errors"
+	"fmt"
+	"sort"
 	"strconv"
 
 	"github.com/AudiusProject/audius-protocol/pkg/core/console/views/pages"
@@ -10,89 +14,189 @@ import (
 	"github.com/labstack/echo/v4"
 )
 
+const validatorReportHistoryLength = 5
+
 func (cs *Console) uptimeFragment(c echo.Context) error {
 	ctx := c.Request().Context()
 	rollupId := c.Param("rollup")
 
-	var rollup db.SlaRollup
-	var quota = 0
-	var avgBlockTimeMs = 0
-	var recentRollups []db.GetRecentRollupsForNodeRow
-	var reports []db.SlaNodeReport
-	var myReport db.SlaNodeReport
-	var validators []db.CoreValidator
-	var validatorMap map[string]db.CoreValidator
-	var err error
-	var i int
-	if rollupId == "" || rollupId == "latest" {
-		rollup, err = cs.db.GetLatestSlaRollup(ctx)
-	} else if i, err = strconv.Atoi(rollupId); err == nil {
-		rollup, err = cs.db.GetSlaRollupWithId(ctx, int32(i))
-	} else {
-		cs.logger.Error("Sla page called with invalid rollup id")
-		return err
-	}
-	if err != nil && err != pgx.ErrNoRows {
-		cs.logger.Error("Failed to retrieve SlaRollup from db", "error", err)
-		return err
-	}
-	reports, err = cs.db.GetRollupReportsForId(ctx, pgtype.Int4{Int32: rollup.ID, Valid: true})
-	if err != nil && err != pgx.ErrNoRows {
-		cs.logger.Error("Failed to fetch reports for latest SlaRollup from db", "error", err)
+	// Get active report
+	activeReport, err := cs.getActiveProofOfWorkReport(ctx, rollupId)
+	if err != nil {
+		cs.logger.Error("Falled to get active Proof Of Work report", "error", err)
 		return err
 	}
 
-	// OK if myReport is empty
-	myReport, err = cs.db.GetRollupReportForNodeAndId(
+	// Attach report to this node
+	myUptime := pages.NodeUptime{
+		Address:       cs.state.cometAddress,
+		ActiveReport:  activeReport,
+		ReportHistory: make([]pages.ProofOfWorkReport, 0, 30),
+	}
+
+	// Get avg block time
+	avgBlockTimeMs, err := cs.getAverageBlockTimeForReport(ctx, activeReport)
+	if err != nil {
+		cs.logger.Error("Failed to calculate average block time", "error", err)
+		return err
+	}
+
+	// Gather validator info
+	validators, err := cs.db.GetAllRegisteredNodes(ctx)
+	if err != nil && err != pgx.ErrNoRows {
+		cs.logger.Error("Failed to get registered nodes from db", "error", err)
+		return err
+	}
+	validatorMap := make(map[string]*pages.NodeUptime, len(validators))
+	for _, v := range validators {
+		validatorMap[v.CometAddress] = &pages.NodeUptime{
+			Endpoint:      v.Endpoint,
+			Address:       v.CometAddress,
+			IsValidator:   true,
+			ReportHistory: make([]pages.ProofOfWorkReport, 0, validatorReportHistoryLength),
+		}
+	}
+	_, isValidator := validatorMap[cs.state.cometAddress]
+	myUptime.IsValidator = isValidator
+
+	// Get history for this node
+	recentRollups, err := cs.db.GetRecentRollupsForNode(ctx, cs.state.cometAddress)
+	if err != nil && err != pgx.ErrNoRows {
+		cs.logger.Error("Failed to get recent rollups from db", "error", err)
+		return err
+	}
+	for _, rr := range recentRollups {
+		reportQuota := int32(0)
+		if len(validators) > 0 {
+			reportQuota = int32(rr.BlockEnd-rr.BlockStart) / int32(len(validators))
+		}
+		myUptime.ReportHistory = append(
+			myUptime.ReportHistory,
+			pages.ProofOfWorkReport{
+				SlaRollupId:    rr.ID,
+				TxHash:         rr.TxHash,
+				BlockStart:     rr.BlockStart,
+				BlockEnd:       rr.BlockEnd,
+				BlocksProposed: rr.BlocksProposed.Int32,
+				Quota:          reportQuota,
+				Time:           rr.Time.Time,
+			},
+		)
+	}
+
+	// Get history for all validators
+	bulkRecentReports, err := cs.db.GetRecentRollupsForAllNodes(
+		ctx,
+		db.GetRecentRollupsForAllNodesParams{
+			ID:    activeReport.SlaRollupId,
+			Limit: int32(validatorReportHistoryLength),
+		},
+	)
+	if err != nil && err != pgx.ErrNoRows {
+		cs.logger.Error("Failure getting bulk recent reports", "error", err)
+		return err
+	}
+	for _, rr := range bulkRecentReports {
+		if valData, ok := validatorMap[rr.Address.String]; ok {
+			var reportQuota int32 = 0
+			if len(validatorMap) > 0 {
+				reportQuota = int32(rr.BlockEnd-rr.BlockStart) / int32(len(validators))
+			}
+			rep := pages.ProofOfWorkReport{
+				SlaRollupId:    rr.ID,
+				TxHash:         rr.TxHash,
+				BlockStart:     rr.BlockStart,
+				BlockEnd:       rr.BlockEnd,
+				BlocksProposed: rr.BlocksProposed.Int32,
+				Quota:          reportQuota,
+				Time:           rr.Time.Time,
+			}
+			if rr.ID == myUptime.ActiveReport.SlaRollupId {
+				valData.ActiveReport = rep
+			}
+			valData.ReportHistory = append(valData.ReportHistory, rep)
+		}
+	}
+
+	// Store validators as sorted slice
+	// (adjust sorting method to fit display preference)
+	sortedValidators := make([]*pages.NodeUptime, 0, len(validatorMap))
+	for _, v := range validatorMap {
+		sortedValidators = append(sortedValidators, v)
+	}
+	sort.Slice(sortedValidators, func(i, j int) bool {
+		return sortedValidators[i].Address < sortedValidators[j].Address
+	})
+
+	return cs.views.RenderUptimeView(c, &pages.UptimePageView{
+		ActiveNodeUptime: myUptime,
+		ValidatorUptimes: sortedValidators,
+		AvgBlockTimeMs:   avgBlockTimeMs,
+	})
+}
+
+func (cs *Console) getActiveProofOfWorkReport(ctx context.Context, rollupId string) (pages.ProofOfWorkReport, error) {
+	var report pages.ProofOfWorkReport
+
+	var rollup db.SlaRollup
+	var err error
+	if rollupId == "" || rollupId == "latest" {
+		rollup, err = cs.db.GetLatestSlaRollup(ctx)
+	} else if i, err := strconv.Atoi(rollupId); err == nil {
+		rollup, err = cs.db.GetSlaRollupWithId(ctx, int32(i))
+	} else {
+		err = fmt.Errorf("Sla page called with invalid rollup id %s", rollupId)
+	}
+	if err != nil && !errors.Is(err, pgx.ErrNoRows) {
+		err = fmt.Errorf("Failed to retrieve SlaRollup from db: %v", err)
+		return report, err
+	}
+
+	mySlaNodeReport, err := cs.db.GetRollupReportForNodeAndId(
 		ctx,
 		db.GetRollupReportForNodeAndIdParams{
 			Address:     cs.state.cometAddress,
 			SlaRollupID: pgtype.Int4{Int32: rollup.ID, Valid: true},
 		},
 	)
-	if err != nil && err != pgx.ErrNoRows {
-		cs.logger.Error("Error while fetching this node's report for latest SlaRollup from db", "error", err)
-		return err
+	if err != nil && !errors.Is(err, pgx.ErrNoRows) {
+		err = fmt.Errorf("Error while fetching this node's report for latest SlaRollup from db: %v", err)
+		return report, err
 	}
 
-	recentRollups, err = cs.db.GetRecentRollupsForNode(ctx, cs.state.cometAddress)
-	if err != nil && err != pgx.ErrNoRows {
-		cs.logger.Error("Failed to get recent rollups from db", "error", err)
-		return err
+	var quota int32 = 0
+	var numValidators int64 = 0
+	numValidators, err = cs.db.TotalValidators(ctx)
+	if err != nil {
+		err = fmt.Errorf("Could not get total validators from db: %v", err)
+		return report, err
 	}
-
-	previousRollup, err := cs.db.GetPreviousSlaRollupFromId(ctx, rollup.ID)
-	if err != nil && err != pgx.ErrNoRows {
-		cs.logger.Error("Failure reading previous SlaRollup from db", "error", err)
-		return err
-	} else if err == nil && rollup.BlockEnd != 0 {
-		totalBlocks := int(rollup.BlockEnd - rollup.BlockStart)
-		avgBlockTimeMs = int(rollup.Time.Time.UnixMilli()-previousRollup.Time.Time.UnixMilli()) / totalBlocks
+	if numValidators > int64(0) {
+		quota = int32(rollup.BlockEnd-rollup.BlockStart) / int32(numValidators)
 	}
-
-	validators, err = cs.db.GetAllRegisteredNodes(ctx)
-	if err != nil && err != pgx.ErrNoRows {
-		cs.logger.Error("Failed to get registered nodes from db", "error", err)
-		return err
-	}
-	validatorMap = make(map[string]db.CoreValidator, len(validators))
-	for _, v := range validators {
-		validatorMap[v.CometAddress] = v
-	}
-	_, isValidator := validatorMap[cs.state.cometAddress]
-	if len(validators) > 0 {
-		quota = int(rollup.BlockEnd-rollup.BlockStart) / len(validators)
-	}
-
-	return cs.views.RenderUptimeView(c, &pages.UptimePageView{
-		Rollup:         rollup,
+	report = pages.ProofOfWorkReport{
+		SlaRollupId:    rollup.ID,
+		TxHash:         rollup.TxHash,
+		BlockStart:     rollup.BlockStart,
+		BlockEnd:       rollup.BlockEnd,
+		BlocksProposed: mySlaNodeReport.BlocksProposed,
 		Quota:          quota,
-		Address:        cs.state.cometAddress,
-		MyReport:       myReport,
-		AllNodeReports: reports,
-		RecentRollups:  recentRollups,
-		ValidatorMap:   validatorMap,
-		AvgBlockTimeMs: avgBlockTimeMs,
-		NodeExempt:     !isValidator,
-	})
+		Time:           rollup.Time.Time,
+	}
+
+	return report, nil
+}
+
+func (cs *Console) getAverageBlockTimeForReport(ctx context.Context, report pages.ProofOfWorkReport) (int, error) {
+	var avgBlockTimeMs int = 0
+	previousRollup, err := cs.db.GetPreviousSlaRollupFromId(ctx, report.SlaRollupId)
+	if err != nil && !errors.Is(err, pgx.ErrNoRows) {
+		err = fmt.Errorf("Failure reading previous SlaRollup from db: %v", err)
+	} else if errors.Is(err, pgx.ErrNoRows) {
+		err = nil
+	} else if err == nil && report.BlockEnd != 0 {
+		totalBlocks := int(report.BlockEnd - report.BlockStart)
+		avgBlockTimeMs = int(report.Time.UnixMilli()-previousRollup.Time.Time.UnixMilli()) / totalBlocks
+	}
+	return avgBlockTimeMs, err
 }

--- a/pkg/core/console/views/pages/uptime_page.templ
+++ b/pkg/core/console/views/pages/uptime_page.templ
@@ -3,19 +3,31 @@ package pages
 import (
 	"fmt"
     "strings"
-	"github.com/AudiusProject/audius-protocol/pkg/core/db"
+    "time"
 )
 
 type UptimePageView struct {
-	Rollup         db.SlaRollup
-    Quota          int
-    Address        string
-    MyReport       db.SlaNodeReport
-	AllNodeReports []db.SlaNodeReport
-	RecentRollups  []db.GetRecentRollupsForNodeRow
-    ValidatorMap   map[string]db.CoreValidator
-    AvgBlockTimeMs int
-    NodeExempt     bool
+    ActiveNodeUptime NodeUptime
+    ValidatorUptimes []*NodeUptime
+    AvgBlockTimeMs   int
+}
+
+type NodeUptime struct {
+	Endpoint        string
+    Address         string
+    IsValidator     bool
+    ActiveReport    ProofOfWorkReport
+	ReportHistory   []ProofOfWorkReport
+}
+
+type ProofOfWorkReport struct {
+    SlaRollupId    int32
+	TxHash         string
+	BlockStart     int64
+	BlockEnd       int64
+    BlocksProposed int32
+    Quota          int32
+	Time           time.Time
 }
 
 const (
@@ -27,12 +39,11 @@ const (
     slaExempt = "#a9a9a9"
 )
 
-func createUptimeColorForRollup(rollup db.GetRecentRollupsForNodeRow, numValidators int, exempt bool) string {
-    target := int(rollup.BlockEnd.Int64 - rollup.BlockStart.Int64) / numValidators
-    return meetsQuotaColor(target, int(rollup.BlocksProposed.Int32), exempt)
+func createUptimeColorForRollup(report ProofOfWorkReport, exempt bool) string {
+    return meetsQuotaColor(report.Quota, report.BlocksProposed, exempt)
 }
 
-func meetsQuotaColor(quota, proposed int, exempt bool) string {
+func meetsQuotaColor(quota, proposed int32, exempt bool) string {
     if exempt {
         return slaExempt
     }
@@ -46,7 +57,7 @@ func meetsQuotaColor(quota, proposed int, exempt bool) string {
     }
 }
 
-func meetsQuotaText(quota, proposed int) string {
+func meetsQuotaText(quota, proposed int32) string {
     faultRatio := float32(proposed) / float32(quota)
     if faultRatio >= slaMeetsThreshold {
         return "Met"
@@ -63,20 +74,31 @@ func strippedEndpoint(endpoint string) string {
     return res
 }
 
-css uptimeBar(rollup db.GetRecentRollupsForNodeRow, numValidators int, exempt bool) {
+css uptimeBar(report ProofOfWorkReport, exempt bool) {
     width: 16px;
     height: 80px;
     display: inline-block;
     margin: 3px;
     border-radius: 0.5rem;
-    background-color: { templ.SafeCSSProperty(createUptimeColorForRollup(rollup, numValidators, exempt)) };
+    background-color: { templ.SafeCSSProperty(createUptimeColorForRollup(report, exempt)) };
 }
 
-css reportTableRow(blockQuota, blocksProposed int) {
+css uptimeBarMini(report ProofOfWorkReport) {
+    width: 5px;
+    height: 18px;
+    display: inline-block;
+    margin: 1px;
+    border-radius: 0.5rem;
+    background-color: { templ.SafeCSSProperty(createUptimeColorForRollup(report, false)) };
+    vertical-align: middle;
+}
+
+
+css reportTableRow(blockQuota, blocksProposed int32) {
     background-color: { templ.SafeCSSProperty(meetsQuotaColor(blockQuota, blocksProposed, false)) };
 }
 
-css nodeSlaStatusBox(quota, proposed int, exempt bool) {
+css nodeSlaStatusBox(quota, proposed int32, exempt bool) {
     background-color: { templ.SafeCSSProperty(meetsQuotaColor(quota, proposed, exempt)) };
 }
 
@@ -127,30 +149,30 @@ templ (c *Pages) UptimePageHTML(props *UptimePageView) {
 	@c.layout.SiteFrame() {
         @staticStyles()
         <ul class="m-2">
-            for _, r := range props.RecentRollups {
-                <li class={ templ.KV("selectedUptimeBar", props.Rollup.ID == r.ID), uptimeBar(r, len(props.ValidatorMap), props.NodeExempt) }>
-                    <a class="reportLink" href={ templ.URL(fmt.Sprintf("/console/uptime/%d", r.ID)) }></a>
-                    <span class="uptimebarTooltip">{ r.Time.Time.Format("06-01-02 15:04:05 MST") }</span>
+            for _, r := range props.ActiveNodeUptime.ReportHistory {
+                <li class={ templ.KV("selectedUptimeBar", props.ActiveNodeUptime.ActiveReport.SlaRollupId == r.SlaRollupId), uptimeBar(r, !props.ActiveNodeUptime.IsValidator) }>
+                    <a class="reportLink" href={ templ.URL(fmt.Sprintf("/console/uptime/%d", r.SlaRollupId)) }></a>
+                    <span class="uptimebarTooltip">{ r.Time.Format("06-01-02 15:04:05 MST") }</span>
                 </li>
             }
         </ul>
 
-        if props.Rollup.BlockEnd <= int64(0) {
-            <h1 class="text-xl"> No SLA Report with ID { fmt.Sprintf("%d", props.Rollup.ID) }. </h1>
+        if props.ActiveNodeUptime.ActiveReport.BlockEnd <= int64(0) {
+            <h1 class="text-xl"> No SLA Rollup with requested ID. </h1>
         } else {
             <h1 class="text-xl">
-                SLA Rollup #{ fmt.Sprintf("%d", props.Rollup.ID) } For Blocks { fmt.Sprintf("%d - %d", props.Rollup.BlockStart, props.Rollup.BlockEnd) }
+                SLA Rollup #{ fmt.Sprintf("%d", props.ActiveNodeUptime.ActiveReport.SlaRollupId) } For Blocks { fmt.Sprintf("%d - %d", props.ActiveNodeUptime.ActiveReport.BlockStart, props.ActiveNodeUptime.ActiveReport.BlockEnd) }
             </h1>
             <h3 class="text-sm">
-                TX: <a href={ templ.URL(fmt.Sprintf("/console/tx/%s", props.Rollup.TxHash)) }>{ props.Rollup.TxHash }</a>
+                TX: <a href={ templ.URL(fmt.Sprintf("/console/tx/%s", props.ActiveNodeUptime.ActiveReport.TxHash)) }>{ props.ActiveNodeUptime.ActiveReport.TxHash }</a>
             </h3>
 
             <div class="flex flex-row text-center p-8 statsBar">
                 <div class="basis-1/5 rounded-md bg-slate-100 py-8 mx-1">
                     <dt class="text-lg">
-                        { props.Rollup.Time.Time.Format("06-01-02") }
+                        { props.ActiveNodeUptime.ActiveReport.Time.Format("06-01-02") }
                         <br />
-                        { props.Rollup.Time.Time.Format("15:04:05 MST") }
+                        { props.ActiveNodeUptime.ActiveReport.Time.Format("15:04:05 MST") }
                     </dt>
                     <dd class="text-sm">Date Finalized</dd>
                 </div>
@@ -159,19 +181,19 @@ templ (c *Pages) UptimePageHTML(props *UptimePageView) {
                     <dd class="text-sm">Avg Block Time</dd>
                 </div>
                 <div class="basis-1/5 rounded-md bg-slate-100 py-8 mx-1">
-                    <dt class="text-4xl">{ fmt.Sprintf("%d", (props.Rollup.BlockEnd - props.Rollup.BlockStart)) }</dt>
+                    <dt class="text-4xl">{ fmt.Sprintf("%d", (props.ActiveNodeUptime.ActiveReport.BlockEnd - props.ActiveNodeUptime.ActiveReport.BlockStart) + 1) }</dt>
                     <dd class="text-sm">Total Blocks in Rollup</dd>
                 </div>
-                <div class={ "basis-1/5 rounded-md py-8 mx-1", nodeSlaStatusBox(props.Quota, int(props.MyReport.BlocksProposed), props.NodeExempt)}>
-                    if props.NodeExempt {
+                <div class={ "basis-1/5 rounded-md py-8 mx-1", nodeSlaStatusBox(props.ActiveNodeUptime.ActiveReport.Quota, props.ActiveNodeUptime.ActiveReport.BlocksProposed, !props.ActiveNodeUptime.IsValidator)}>
+                    if !props.ActiveNodeUptime.IsValidator {
                         <dt class="text-4xl">N/A</dt>
                     } else {
-                        <dt class="text-4xl">{ fmt.Sprintf("%d", props.MyReport.BlocksProposed) }</dt>
+                        <dt class="text-4xl">{ fmt.Sprintf("%d", props.ActiveNodeUptime.ActiveReport.BlocksProposed) }</dt>
                     }
                     <dd class="text-sm">Blocks Proposed by Me</dd>
                 </div>
                 <div class="basis-1/5 rounded-md bg-slate-100 py-8 mx-1">
-                    <dt class="text-4xl">{ fmt.Sprintf("%d", props.Quota) }</dt>
+                    <dt class="text-4xl">{ fmt.Sprintf("%d", props.ActiveNodeUptime.ActiveReport.Quota) }</dt>
                     <dd class="text-sm">Block Quota</dd>
                 </div>
             </div>
@@ -182,20 +204,32 @@ templ (c *Pages) UptimePageHTML(props *UptimePageView) {
                     <th>Quota</th>
                     <th>Proposed</th>
                     <th>SLA</th>
+                    <th>History</th>
                 </tr>
-                for _, rep := range props.AllNodeReports {
-                    @validatorRowReport(props.Rollup.ID, props.Quota, int(rep.BlocksProposed), props.ValidatorMap[rep.Address])
+                for _, up := range props.ValidatorUptimes {
+                    @validatorRowReport(up)
                 }
             </table>
         }
 	}
 }
 
-templ validatorRowReport(rollupID int32, blockQuota, blocksProposed int, node db.CoreValidator) {
-    <tr class={ reportTableRow(blockQuota, blocksProposed) }>
-        <td><a href={ templ.URL(fmt.Sprintf("%s/console/uptime/%d", node.Endpoint, rollupID)) }>{ strippedEndpoint(node.Endpoint) }</a></td>
-        <td>{ fmt.Sprintf("%d", blockQuota) }</td>
-        <td>{ fmt.Sprintf("%d", blocksProposed) }</td>
-        <td>{ meetsQuotaText(blockQuota, blocksProposed) }</td>
+templ validatorRowReport(up *NodeUptime) {
+    <tr class={ reportTableRow(up.ActiveReport.Quota, up.ActiveReport.BlocksProposed) }>
+        <td><a href={ templ.URL(fmt.Sprintf("%s/console/uptime/%d", up.Endpoint, up.ActiveReport.SlaRollupId)) }>{ strippedEndpoint(up.Endpoint) }</a></td>
+        <td>{ fmt.Sprintf("%d", up.ActiveReport.Quota) }</td>
+        <td>{ fmt.Sprintf("%d", up.ActiveReport.BlocksProposed) }</td>
+        <td>{ meetsQuotaText(up.ActiveReport.Quota, up.ActiveReport.BlocksProposed) }</td>
+        <td class="bg-white">
+            for _, h := range up.ReportHistory {
+                @validatorMiniHistory(h, up.Endpoint)
+            }
+        </td>
     </tr>
+}
+
+templ validatorMiniHistory(report ProofOfWorkReport, endpoint string) {
+    <li class={ uptimeBarMini(report) }>
+        <a class="reportLink" href={ templ.URL(fmt.Sprintf("%s/console/uptime/%d", endpoint, report.SlaRollupId)) }></a>
+    </li>
 }

--- a/pkg/core/db/sql/reads.sql
+++ b/pkg/core/db/sql/reads.sql
@@ -20,6 +20,11 @@ limit 1;
 select *
 from core_validators;
 
+-- name: GetAllRegisteredNodesSorted :many
+select *
+from core_validators
+order by comet_address;
+
 -- name: GetNodeByEndpoint :one
 select *
 from core_validators
@@ -43,17 +48,37 @@ with recent_rollups as (
 )
 select
     rr.id,
-    sr.tx_hash,
-    sr.block_start,
-    sr.block_end,
-    sr.time,
+    rr.tx_hash,
+    rr.block_start,
+    rr.block_end,
+    rr.time,
     nr.address,
     nr.blocks_proposed
 from recent_rollups rr
 left join sla_node_reports nr
 on rr.id = nr.sla_rollup_id and nr.address = $1
-left join sla_rollups sr
-on rr.id = sr.id;
+order by rr.time;
+
+-- name: GetRecentRollupsForAllNodes :many
+with recent_rollups as (
+    select *
+    from sla_rollups
+    where sla_rollups.id <= $1
+    order by time desc
+    limit $2
+)
+select
+    rr.id,
+    rr.tx_hash,
+    rr.block_start,
+    rr.block_end,
+    rr.time,
+    nr.address,
+    nr.blocks_proposed
+from recent_rollups rr
+left join sla_node_reports nr
+on rr.id = nr.sla_rollup_id
+order by rr.time;
 
 -- name: GetSlaRollupWithId :one
 select * from sla_rollups where id = $1;


### PR DESCRIPTION
### Description

Fixes/improvements:
* Now validators that contribute 0 blocks for a rollup interval will show up in the console
* Fix ordering bug in sla rollup history on uptime console page
* Add miniature history for each validator in the uptime console page

### How Has This Been Tested?

local dev console

<img width="187" alt="image" src="https://github.com/user-attachments/assets/10461ca4-1b7f-465c-9431-35babe05ba85" />
