### PR TITLE
Fix search for old clients

### DIFF
--- a/packages/discovery-provider/src/queries/search_es.py
+++ b/packages/discovery-provider/src/queries/search_es.py
@@ -230,9 +230,11 @@ def search_es_full(args: dict):
 
     if do_albums:
         response["albums"] = pluck_hits(mfound["responses"].pop(0))
+
     finalize_response(
         response, limit, current_user_id, is_auto_complete=is_auto_complete
     )
+
     return response
 
 

--- a/packages/discovery-provider/src/utils/elasticdsl.py
+++ b/packages/discovery-provider/src/utils/elasticdsl.py
@@ -90,7 +90,7 @@ def populate_track_or_playlist_metadata_es(
             populate_track_or_playlist_metadata_es(track, current_user)
             for track in item["tracks"]
         ]
-    return omit_indexed_fields(item)
+    return omit_indexed_fields(item, include_playlist_tracks)
 
 
 omit_keys = [
@@ -106,7 +106,7 @@ omit_keys = [
 ]
 
 
-def omit_indexed_fields(doc):
+def omit_indexed_fields(doc, include_playlist_tracks=False):
     doc = copy.copy(doc)
 
     # track
@@ -119,5 +119,8 @@ def omit_indexed_fields(doc):
     for key in omit_keys:
         if key in doc:
             del doc[key]
+
+    if not include_playlist_tracks and "tracks" in doc:
+        del doc["tracks"]
 
     return doc


### PR DESCRIPTION
### Description

Search on main is not working for old clients because the tracks key is no longer omitted after 
https://github.com/AudiusProject/audius-protocol/pull/10741

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._

Stage dn2