### PR TITLE
Ensure audius-d wrapper containers re up after a machine restart

### DIFF
--- a/pkg/orchestration/docker.go
+++ b/pkg/orchestration/docker.go
@@ -203,6 +203,20 @@ func runNode(
 	if err != nil {
 		return logger.Error("Failed to create container:", err)
 	}
+
+	// Set restart policy to unless-stopped
+	if _, err := dockerClient.ContainerUpdate(
+		context.Background(),
+		createResponse.ID,
+		container.UpdateConfig{
+			RestartPolicy: container.RestartPolicy{
+				Name: "unless-stopped",
+			},
+		},
+	); err != nil {
+		return logger.Error("Failed to set restart policy:", err)
+	}
+
 	if err := dockerClient.ContainerStart(
 		context.Background(),
 		createResponse.ID,


### PR DESCRIPTION
Tested via local build

```
make bin/audius-ctl-native

./bin/audius-ctl-native restart creatornode5.staging.audius.co

./bin/audius-ctl-native audius-ctl jump creatornode5.staging.audius.co
-->
docker inspect creatornode5.staging.audius.co | grep -A3 "RestartPolicy"
            "RestartPolicy": {
                "Name": "unless-stopped",
                "MaximumRetryCount": 0
            },
```