### PR TITLE
Fix SSR rendering issues

### DIFF
--- a/packages/web/src/ssr/collection/+onBeforeRender.ts
+++ b/packages/web/src/ssr/collection/+onBeforeRender.ts
@@ -4,16 +4,10 @@ import {
   userTrackMetadataFromSDK
 } from '@audius/common/adapters'
 import type { full } from '@audius/sdk'
-import { developmentConfig } from '@audius/sdk/src/sdk/config/development'
-import { productionConfig } from '@audius/sdk/src/sdk/config/production'
-import { stagingConfig } from '@audius/sdk/src/sdk/config/staging'
+import { FullPlaylistResponseFromJSON } from '@audius/sdk/src/sdk/api/generated/full/models/FullPlaylistResponse'
 import type { PageContextServer } from 'vike/types'
 
-const sdkConfigs = {
-  production: productionConfig,
-  staging: stagingConfig,
-  development: developmentConfig
-}
+import { getDiscoveryNode } from '../getDiscoveryNode'
 
 export type CollectionPageProps = {}
 
@@ -22,13 +16,7 @@ export async function onBeforeRender(pageContext: PageContextServer) {
 
   // Fetching directly from discovery node rather than using the sdk because
   // including the sdk increases bundle size and creates substantial cold start times
-  const discoveryNodes = (
-    sdkConfigs[process.env.VITE_ENVIRONMENT as keyof typeof sdkConfigs] ??
-    productionConfig
-  ).network.discoveryNodes
-
-  const discoveryNode =
-    discoveryNodes[Math.floor(Math.random() * discoveryNodes.length)]
+  const discoveryNode = getDiscoveryNode()
 
   const discoveryRequestPath = `v1/full/playlists/by_permalink/${handle}/${slug}`
   const discoveryRequestUrl = `${discoveryNode.endpoint}/${discoveryRequestPath}`
@@ -38,7 +26,12 @@ export async function onBeforeRender(pageContext: PageContextServer) {
     throw new Error(discoveryRequestUrl)
   }
 
-  const { data } = await res.json()
+  const { data } = FullPlaylistResponseFromJSON(await res.json())
+  if (!data || data.length === 0) {
+    throw new Error(
+      `Parsed SDK response returned no playlists for ${discoveryRequestUrl}`
+    )
+  }
   const [apiCollection] = data
   const collection = {
     ...userCollectionMetadataFromSDK(apiCollection),
@@ -48,14 +41,16 @@ export async function onBeforeRender(pageContext: PageContextServer) {
   const { user: apiUser } = apiCollection
   const user = {
     ...userMetadataFromSDK(apiUser),
-    cover_photo: apiUser.cover_photo?._2000x,
-    profile_picture: apiUser.profile_picture?._1000x1000
+    cover_photo: apiUser.coverPhoto?._2000x,
+    profile_picture: apiUser.profilePicture?._1000x1000
   }
 
-  const tracks = apiCollection.tracks.map((apiTrack: full.TrackFull) => ({
-    ...userTrackMetadataFromSDK(apiTrack),
-    cover_art: apiTrack.artwork?._150x150
-  }))
+  const tracks = (apiCollection.tracks ?? []).map(
+    (apiTrack: full.TrackFull) => ({
+      ...userTrackMetadataFromSDK(apiTrack),
+      cover_art: apiTrack.artwork?._150x150
+    })
+  )
 
   try {
     return {

--- a/packages/web/src/ssr/constants.ts
+++ b/packages/web/src/ssr/constants.ts
@@ -1,0 +1,7 @@
+// Optionally provided at runtime
+declare const DISCOVERY_NODE_ALLOWLIST: string[] | undefined
+
+export const discoveryNodeAllowlist =
+  typeof DISCOVERY_NODE_ALLOWLIST !== 'undefined'
+    ? DISCOVERY_NODE_ALLOWLIST
+    : []

--- a/packages/web/src/ssr/getDiscoveryNode.ts
+++ b/packages/web/src/ssr/getDiscoveryNode.ts
@@ -1,12 +1,6 @@
-import {
-  sdk,
-  DiscoveryNodeSelector,
-  productionConfig,
-  stagingConfig,
-  developmentConfig
-} from '@audius/sdk'
-
-import { env } from 'services/env'
+import { developmentConfig } from '@audius/sdk/src/sdk/config/development'
+import { productionConfig } from '@audius/sdk/src/sdk/config/production'
+import { stagingConfig } from '@audius/sdk/src/sdk/config/staging'
 
 import { discoveryNodeAllowlist } from './constants'
 
@@ -27,13 +21,5 @@ if (discoveryNodeAllowlist.length > 0) {
   )
 }
 
-const discoveryNodeSelector = new DiscoveryNodeSelector({
-  bootstrapServices: discoveryNodes
-})
-
-export const audiusSdk = sdk({
-  appName: env.APP_NAME,
-  services: {
-    discoveryNodeSelector
-  }
-})
+export const getDiscoveryNode = () =>
+  discoveryNodes[Math.floor(Math.random() * discoveryNodes.length)]

--- a/packages/web/src/ssr/profile/+onBeforeRender.tsx
+++ b/packages/web/src/ssr/profile/+onBeforeRender.tsx
@@ -1,14 +1,8 @@
 import { userMetadataFromSDK } from '@audius/common/adapters'
-import { developmentConfig } from '@audius/sdk/src/sdk/config/development'
-import { productionConfig } from '@audius/sdk/src/sdk/config/production'
-import { stagingConfig } from '@audius/sdk/src/sdk/config/staging'
+import { FullUserResponseFromJSON } from '@audius/sdk/src/sdk/api/generated/full/models/FullUserResponse'
 import type { PageContextServer } from 'vike/types'
 
-const sdkConfigs = {
-  production: productionConfig,
-  staging: stagingConfig,
-  development: developmentConfig
-}
+import { getDiscoveryNode } from '../getDiscoveryNode'
 
 export async function onBeforeRender(pageContext: PageContextServer) {
   const { handle } = pageContext.routeParams
@@ -16,13 +10,7 @@ export async function onBeforeRender(pageContext: PageContextServer) {
   try {
     // Fetching directly from discovery node rather than using the sdk because
     // including the sdk increases bundle size and creates substantial cold start times
-    const discoveryNodes = (
-      sdkConfigs[process.env.VITE_ENVIRONMENT as keyof typeof sdkConfigs] ??
-      productionConfig
-    ).network.discoveryNodes
-
-    const discoveryNode =
-      discoveryNodes[Math.floor(Math.random() * discoveryNodes.length)]
+    const discoveryNode = getDiscoveryNode()
 
     const discoveryRequestPath = `v1/full/users/handle/${handle}`
     const discoveryRequestUrl = `${discoveryNode.endpoint}/${discoveryRequestPath}`
@@ -32,14 +20,19 @@ export async function onBeforeRender(pageContext: PageContextServer) {
       throw new Error(discoveryRequestUrl)
     }
 
-    const { data } = await res.json()
+    const { data } = FullUserResponseFromJSON(await res.json())
+    if (!data || data.length === 0) {
+      throw new Error(
+        `Parsed SDK response returned no users for ${discoveryRequestUrl}`
+      )
+    }
     const apiUser = data[0]
 
     // Include api user images.
     const user = {
       ...userMetadataFromSDK(apiUser),
-      cover_photo: apiUser.cover_photo?._2000x,
-      profile_picture: apiUser.profile_picture?._1000x1000
+      cover_photo: apiUser.coverPhoto?._2000x,
+      profile_picture: apiUser.profilePicture?._1000x1000
     }
 
     return {

--- a/packages/web/src/ssr/profile/+onRenderHtml.tsx
+++ b/packages/web/src/ssr/profile/+onRenderHtml.tsx
@@ -28,7 +28,9 @@ type TrackPageContext = PageContextServer & {
 export default function render(pageContext: TrackPageContext) {
   const { pageProps, userAgent } = pageContext
   const { user } = pageProps
-  const { user_id, handle, name, bio } = user
+  const { user_id, name, bio } = user
+  // Use lower case since cache lookup by handle will lowercase it
+  const handle = user.handle.toLowerCase()
 
   const isMobile = isMobileUserAgent(userAgent)
 

--- a/packages/web/src/ssr/track/+onBeforeRender.tsx
+++ b/packages/web/src/ssr/track/+onBeforeRender.tsx
@@ -2,16 +2,10 @@ import {
   userMetadataFromSDK,
   userTrackMetadataFromSDK
 } from '@audius/common/adapters'
-import { developmentConfig } from '@audius/sdk/src/sdk/config/development'
-import { productionConfig } from '@audius/sdk/src/sdk/config/production'
-import { stagingConfig } from '@audius/sdk/src/sdk/config/staging'
+import { FullTracksResponseFromJSON } from '@audius/sdk/src/sdk/api/generated/full/models/FullTracksResponse'
 import type { PageContextServer } from 'vike/types'
 
-const sdkConfigs = {
-  production: productionConfig,
-  staging: stagingConfig,
-  development: developmentConfig
-}
+import { getDiscoveryNode } from '../getDiscoveryNode'
 
 export async function onBeforeRender(pageContext: PageContextServer) {
   const { handle, slug } = pageContext.routeParams
@@ -19,13 +13,7 @@ export async function onBeforeRender(pageContext: PageContextServer) {
   try {
     // Fetching directly from discovery node rather than using the sdk because
     // including the sdk increases bundle size and creates substantial cold start times
-    const discoveryNodes = (
-      sdkConfigs[process.env.VITE_ENVIRONMENT as keyof typeof sdkConfigs] ??
-      productionConfig
-    ).network.discoveryNodes
-
-    const discoveryNode =
-      discoveryNodes[Math.floor(Math.random() * discoveryNodes.length)]
+    const discoveryNode = getDiscoveryNode()
 
     const discoveryRequestPath = `v1/full/tracks?permalink=${handle}/${slug}`
     const discoveryRequestUrl = `${discoveryNode.endpoint}/${discoveryRequestPath}`
@@ -35,20 +23,25 @@ export async function onBeforeRender(pageContext: PageContextServer) {
       throw new Error(discoveryRequestUrl)
     }
 
-    const { data } = await res.json()
+    const { data } = FullTracksResponseFromJSON(await res.json())
+    if (!data || data.length === 0) {
+      throw new Error(
+        `Parsed SDK response returned no tracks for ${discoveryRequestUrl}`
+      )
+    }
     const [apiTrack] = data
     // Include artwork in the track object
     const track = {
       ...userTrackMetadataFromSDK(apiTrack),
-      cover_art: apiTrack.artwork?.['1000x1000']
+      cover_art: apiTrack.artwork?._1000x1000
     }
 
     const { user: apiUser } = apiTrack
     // Include api user images.
     const user = {
       ...userMetadataFromSDK(apiUser),
-      cover_photo: apiUser.cover_photo?._2000x,
-      profile_picture: apiUser.profile_picture?._1000x1000
+      cover_photo: apiUser.coverPhoto?._2000x,
+      profile_picture: apiUser.profilePicture?._1000x1000
     }
 
     return {

--- a/packages/web/src/ssr/wrangler.toml
+++ b/packages/web/src/ssr/wrangler.toml
@@ -17,9 +17,18 @@ name = "audius-web-ssr-release-candidate"
 
 [env.production]
 name = "audius-web-ssr"
-vars = { SENTRY_DSN = "https://4db9c77b0bd7ae6a935f8bd58c06dad3@o260428.ingest.sentry.io/4506623015124992" }
+vars = { SENTRY_DSN = "https://4db9c77b0bd7ae6a935f8bd58c06dad3@o260428.ingest.sentry.io/4506623015124992", DISCOVERY_NODE_ALLOWLIST = [
+    "https://discoveryprovider.audius.co",
+    "https://discoveryprovider2.audius.co",
+    "https://discoveryprovider3.audius.co",
+] }
 
 # Test environment, replace `test` with subdomain
 # Invoke with npx wrangler dev --env test
 [env.test]
 name = "test-audius-web-ssr"
+vars = { DISCOVERY_NODE_ALLOWLIST = [
+    "https://discoveryprovider.audius.co",
+    "https://discoveryprovider2.audius.co",
+    "https://discoveryprovider3.audius.co",
+] }


### PR DESCRIPTION
### Description
Two main problems:

1. We use the full SDK list of providers for DNs, which includes a number that are regularly down. Combine that with the fact that we aren't actually using SDK to fetch and don't do any reselect logic and you end up with a number of failed SSR requests due to not being able to fetch things. 
 - Added support for an allow list and set it to just be the foundation nodes for now
 - Moved logic to determine DN into a shared function and updated it to use the allowlist
 - Updated the SDK init module to use the allowlist (I'm not sure we're actually using this right now though?)
We can look at adding retries to this logic, potentially a much simpler version of the SDK logic which will just try up to 3 different values from the list any time we get a 500+


2. We're attempting to use the SDK response adapters on raw API responses. This won't work because (among other things) the keys won't be in the right casing.
 - Added imports for just the response parsing bits from the auto-generated SDK. This will keep us in line with whatever changes happen to those models
 - Added a little extra logic to catch cases where we fail to parse correctly

And a bonus problem:
* For profile pages, we weren't lowercasing the handle. So that caused us to fail to look up the user when rendering the page, resulting in mostly empty content. eek.

### How Has This Been Tested?
Tested in local cloudflare worker. I'm unsure of how to deploy this to a subdomain, so I'll double-verify on staging.
