### PR TITLE
[PAY-3729] Fix issues with cover photos and challenges

### DIFF
--- a/packages/common/src/services/audius-backend/AudiusBackend.ts
+++ b/packages/common/src/services/audius-backend/AudiusBackend.ts
@@ -264,8 +264,8 @@ export const audiusBackend = ({
       const userId = newMetadata.user_id
       const { blockHash, blockNumber } = await sdk.users.updateProfile({
         userId: Id.parse(userId),
-        profilePictureFile: newMetadata.updatedProfilePicture?.file,
-        coverArtFile: newMetadata.updatedCoverPhoto?.file,
+        profilePictureFile: metadata.updatedProfilePicture?.file,
+        coverArtFile: metadata.updatedCoverPhoto?.file,
         metadata: userMetadataToSdk(newMetadata)
       })
       return { blockHash, blockNumber, userId }

--- a/packages/common/src/store/challenges/selectors/profile-progress.ts
+++ b/packages/common/src/store/challenges/selectors/profile-progress.ts
@@ -43,15 +43,16 @@ export const getHandleExists = (state: CommonState) => {
   return !!curUser.handle
 }
 
+const validProfilePictureSizes = [
+  SquareSizes.SIZE_150_BY_150,
+  SquareSizes.SIZE_480_BY_480,
+  SquareSizes.SIZE_1000_BY_1000
+] as const
 const isValidProfilePicture = (input: User['profile_picture']) => {
   if (!input) return false
-  const validSizes = [
-    SquareSizes.SIZE_150_BY_150,
-    SquareSizes.SIZE_480_BY_480,
-    SquareSizes.SIZE_1000_BY_1000
-  ] as const
+
   return Object.keys(input).some((size) =>
-    validSizes.includes(size as SquareSizes)
+    validProfilePictureSizes.includes(size as SquareSizes)
   )
 }
 
@@ -69,11 +70,16 @@ export const getProfilePictureExists = (state: CommonState) => {
   )
 }
 
+const validCoverPhotoSizes = [
+  WidthSizes.SIZE_640,
+  WidthSizes.SIZE_2000
+] as const
+
 const isValidCoverPhoto = (input: User['cover_photo']) => {
   if (!input) return false
-  const validSizes = [WidthSizes.SIZE_640, WidthSizes.SIZE_2000] as const
+
   return Object.keys(input).some((size) =>
-    validSizes.includes(size as WidthSizes)
+    validCoverPhotoSizes.includes(size as WidthSizes)
   )
 }
 

--- a/packages/common/src/store/challenges/selectors/profile-progress.ts
+++ b/packages/common/src/store/challenges/selectors/profile-progress.ts
@@ -1,3 +1,4 @@
+import { SquareSizes, User, WidthSizes } from '~/models'
 import { getAccountUser } from '~/store/account/selectors'
 import { getProfileUserHandle } from '~/store/pages/profile/selectors'
 
@@ -42,6 +43,18 @@ export const getHandleExists = (state: CommonState) => {
   return !!curUser.handle
 }
 
+const isValidProfilePicture = (input: User['profile_picture']) => {
+  if (!input) return false
+  const validSizes = [
+    SquareSizes.SIZE_150_BY_150,
+    SquareSizes.SIZE_480_BY_480,
+    SquareSizes.SIZE_1000_BY_1000
+  ] as const
+  return Object.keys(input).some((size) =>
+    validSizes.includes(size as SquareSizes)
+  )
+}
+
 export const getProfilePictureExists = (state: CommonState) => {
   const curUser = getAccountUser(state)
   if (!curUser) return false
@@ -51,8 +64,16 @@ export const getProfilePictureExists = (state: CommonState) => {
   // if the profile_picture field is non-null.
   return (
     !!curUser.updatedProfilePicture ||
-    !!curUser.profile_picture ||
+    isValidProfilePicture(curUser.profile_picture) ||
     !!curUser.profile_picture_sizes
+  )
+}
+
+const isValidCoverPhoto = (input: User['cover_photo']) => {
+  if (!input) return false
+  const validSizes = [WidthSizes.SIZE_640, WidthSizes.SIZE_2000] as const
+  return Object.keys(input).some((size) =>
+    validSizes.includes(size as WidthSizes)
   )
 }
 
@@ -63,7 +84,7 @@ export const getCoverPhotoExists = (state: CommonState) => {
   // Same logic as getProfilePictureExists
   return (
     !!curUser.updatedCoverPhoto ||
-    !!curUser.cover_photo ||
+    isValidCoverPhoto(curUser.cover_photo) ||
     !!curUser.cover_photo_sizes
   )
 }

--- a/packages/sdk/src/sdk/api/users/UsersApi.ts
+++ b/packages/sdk/src/sdk/api/users/UsersApi.ts
@@ -124,9 +124,14 @@ export class UsersApi extends GeneratedUsersApi {
       ...metadata,
       userId,
       ...(profilePictureResp
-        ? { profilePictureSizes: profilePictureResp?.id }
+        ? {
+            profilePicture: profilePictureResp?.id,
+            profilePictureSizes: profilePictureResp?.id
+          }
         : {}),
-      ...(coverArtResp ? { coverPhotoSizes: coverArtResp?.id } : {})
+      ...(coverArtResp
+        ? { coverPhoto: coverArtResp?.id, coverPhotoSizes: coverArtResp?.id }
+        : {})
     }
 
     const entityMetadata = snakecaseKeys(updatedMetadata)
@@ -225,7 +230,9 @@ export class UsersApi extends GeneratedUsersApi {
             profilePictureSizes: profilePictureResp?.id
           }
         : {}),
-      ...(coverArtResp ? { coverPhoto: coverArtResp?.id } : {})
+      ...(coverArtResp
+        ? { coverPhoto: coverArtResp?.id, coverPhotoSizes: coverArtResp?.id }
+        : {})
     }
 
     const cid = (await generateMetadataCidV1(updatedMetadata)).toString()


### PR DESCRIPTION
### Description
I was looking into why the profile completion challenge shows as claimable in the UI when it's not. It was due to our check for a valid cover photo just double negating. Since this is now default initialized to an empty object with an empty `mirrors` array, the check needs to be a little more sophisticated.

In attempting to test this, I noticed that cover/profile photo updates are entirely broken anyway, partially due to reading them out of the object that's returned from the metadata validator in AudiusBackend (which will strip these two fields), and partially due to not passing the correct fields when updating.

I've updated both the create and update paths for profiles to pass both legacy and updated fields for profile/cover photos to keep our indexing logic happy.

### How Has This Been Tested?
Local client against stage
