### PR TITLE
[PAY-3741] Fix playback immediately after purchase

### DIFF
--- a/packages/common/src/store/gated-content/sagas.ts
+++ b/packages/common/src/store/gated-content/sagas.ts
@@ -498,13 +498,13 @@ export function* pollGatedContent({
     const currentlyHasStreamAccess = !!apiEntity.access.stream
     const currentlyHasDownloadAccess = !!apiEntity.access.download
 
+    // Update the cache with the new metadata so that the UI
+    // can update and the content can be streamed or downloaded properly.
     yield* put(
       cacheActions.update(isAlbum ? Kind.COLLECTIONS : Kind.TRACKS, [
         {
           id: contentId,
-          metadata: {
-            access: apiEntity.access
-          }
+          metadata: apiEntity
         }
       ])
     )


### PR DESCRIPTION
### Description

Playback fails immediately after purchase because we try to stream from the tracks.stream.url property and though it is fetched from the BE, it's not updated in the cache. We therefore default back to the v1/stream.

I think this is a safe change. It _should_ be able to work this way.

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._

Can playback after purchase against staging