### PR TITLE
Add missing dependency for CRA react example

### DIFF
--- a/.changeset/tough-starfishes-play.md
+++ b/.changeset/tough-starfishes-play.md
@@ -1,0 +1,5 @@
+---
+"create-audius-app": patch
+---
+
+fix missing dependency

--- a/packages/create-audius-app/examples/react/package.json
+++ b/packages/create-audius-app/examples/react/package.json
@@ -27,6 +27,7 @@
     "eslint-plugin-react-hooks": "^4.6.0",
     "eslint-plugin-react-refresh": "^0.4.3",
     "typescript": "^5.0.2",
-    "vite": "^4.4.5"
+    "vite": "^4.4.5",
+    "vite-plugin-node-polyfills": "0.17.0"
   }
 }


### PR DESCRIPTION
### Description
Seeing some CI failures on running CRA e2e tests referring to a missing plugin.

### How Has This Been Tested?
Local build and will verify in CI
