### PR TITLE
Fix wrong data getting written to queryClient

### DIFF
--- a/packages/common/src/store/cache/syncWithReactQuery.ts
+++ b/packages/common/src/store/cache/syncWithReactQuery.ts
@@ -146,8 +146,9 @@ const updateEntity = (
   const updater = ENTITY_UPDATERS[kind]
   if (!updater) return
 
+  const metadataToSet = 'metadata' in metadata ? metadata.metadata : metadata
   // Update single entity
-  queryClient.setQueryData([updater.singleKey, id], metadata)
+  queryClient.setQueryData([updater.singleKey, id], metadataToSet)
 
   // Update entity in lists
   queryClient.setQueriesData(
@@ -155,14 +156,14 @@ const updateEntity = (
     (oldData: any) => {
       if (!Array.isArray(oldData)) return oldData
       return oldData.map((item) =>
-        item[updater.idField] === id ? metadata : item
+        item[updater.idField] === id ? metadataToSet : item
       )
     }
   )
 
   // Update related entities
   if (updater.updateRelations) {
-    updater.updateRelations(queryClient, id, metadata)
+    updater.updateRelations(queryClient, id, metadataToSet)
   }
 }
 


### PR DESCRIPTION
### Description

We were writing the wrong metadata to the queryClient in the cache sync process:
See in this broken example where the data (bottom-right) is:
```
{
	id: 1419
	uid: "kind:TRACKS-id:1419-count:20"
	metadata: { /* actual metadata */ }
}
```
![Screenshot 2025-01-02 at 6 29 52 PM](https://github.com/user-attachments/assets/52bcefbe-331a-45a3-b6f8-76758571ac75)

The queryClient is expecting `UserTrackMetadata`, so we need to unpack `metadata.metadata`.

Possible there's an even more upstream cause of why the metadata is wrapped with the UID, but we can dig into that later.

### How Has This Been Tested?

was broken now working