### PR TITLE
[QA-1900] Fix track downloads by not having download service rely on window

### DIFF
--- a/packages/common/src/services/track-download/TrackDownload.ts
+++ b/packages/common/src/services/track-download/TrackDownload.ts
@@ -1,3 +1,4 @@
+import { Dispatch } from 'redux'
 import { AudiusBackend } from '~/services/audius-backend'
 
 export type TrackDownloadConfig = {
@@ -10,7 +11,7 @@ export type DownloadTrackArgs = {
   files: DownloadFile[]
   rootDirectoryName?: string
   abortSignal?: AbortSignal
-  dispatch: Function
+  dispatch: Dispatch
 }
 
 export class TrackDownload {

--- a/packages/common/src/services/track-download/TrackDownload.ts
+++ b/packages/common/src/services/track-download/TrackDownload.ts
@@ -10,6 +10,7 @@ export type DownloadTrackArgs = {
   files: DownloadFile[]
   rootDirectoryName?: string
   abortSignal?: AbortSignal
+  dispatch: Function
 }
 
 export class TrackDownload {

--- a/packages/common/src/services/track-download/TrackDownload.ts
+++ b/packages/common/src/services/track-download/TrackDownload.ts
@@ -1,4 +1,5 @@
 import { Dispatch } from 'redux'
+
 import { AudiusBackend } from '~/services/audius-backend'
 
 export type TrackDownloadConfig = {

--- a/packages/web/src/common/store/social/tracks/sagas.ts
+++ b/packages/web/src/common/store/social/tracks/sagas.ts
@@ -631,9 +631,11 @@ function* downloadTracks({
   userId?: ID
 }) {
   const { trackId: parentTrackId } = tracks[0]
+
   try {
     const audiusSdk = yield* getContext('audiusSdk')
     const sdk = yield* call(audiusSdk)
+    const dispatch = yield* getContext('dispatch')
     const audiusBackend = yield* getContext('audiusBackendInstance')
     const trackDownload = yield* getContext('trackDownload')
 
@@ -666,10 +668,12 @@ function* downloadTracks({
           }
         })
       )
+
       await trackDownload.downloadTracks({
         files,
         rootDirectoryName,
-        abortSignal
+        abortSignal,
+        dispatch
       })
     })
 

--- a/packages/web/src/services/track-download.ts
+++ b/packages/web/src/services/track-download.ts
@@ -44,11 +44,11 @@ class TrackDownload extends TrackDownloadBase {
   async downloadTracks({
     files,
     rootDirectoryName,
-    abortSignal
+    abortSignal,
+    dispatch
   }: DownloadTrackArgs) {
     if (files.length === 0) return
-
-    const dispatch = window.store.dispatch
+    console.log({ files, rootDirectoryName, store: window.store })
 
     dispatch(beginDownload())
 

--- a/packages/web/src/services/track-download.ts
+++ b/packages/web/src/services/track-download.ts
@@ -48,7 +48,6 @@ class TrackDownload extends TrackDownloadBase {
     dispatch
   }: DownloadTrackArgs) {
     if (files.length === 0) return
-    console.log({ files, rootDirectoryName, store: window.store })
 
     dispatch(beginDownload())
 


### PR DESCRIPTION
### Description
Track Download service was using the window so changed to make the saga pass in the dispatch func

### How Has This Been Tested?

Manually Tested