### PR TITLE
[C-5602] Don't set default icon fill

### DIFF
--- a/svgr-template.js
+++ b/svgr-template.js
@@ -84,7 +84,7 @@ const ${variables.componentName} = forwardRef((${variables.props}, ref) => {
     other.width = isNaN(width) ? "100%" : width
   }
 
-  const fill = other.fill ?? theme.color?.icon[color] ?? 'red'
+  const fill = other.fill ?? theme.color?.icon[color]
 
   ${native ? nativeStyles : webStyles}
 


### PR DESCRIPTION
### Description

Now that we have consolidated all icons in harmony, whenever an icon chooses to provide it's own fill, we shouldn't override it with 'red'. This fixes a case where the "download app" icons have set a default background color.