### PR TITLE
[PAY-3734] Fix useClickOutside behavior breaking WalletModal

### DIFF
--- a/.changeset/red-ties-invite.md
+++ b/.changeset/red-ties-invite.md
@@ -1,0 +1,5 @@
+---
+"@audius/harmony": patch
+---
+
+fix Modal ignoring dismissOnClickOutside flag

--- a/packages/common/src/store/pages/token-dashboard/slice.ts
+++ b/packages/common/src/store/pages/token-dashboard/slice.ts
@@ -201,6 +201,9 @@ const slice = createSlice({
       state.associatedWallets.confirmingWallet.collectibleCount =
         collectibleCount
     },
+    connectingWalletSignatureFailed: (state) => {
+      state.associatedWallets.confirmingWallet = initialConfirmingWallet
+    },
     setWalletAddedConfirmed: (
       state,
       action: PayloadAction<
@@ -298,6 +301,7 @@ const slice = createSlice({
     },
     preloadWalletProviders: (_state) => {},
     resetStatus: (state) => {
+      state.associatedWallets.confirmingWallet = initialConfirmingWallet
       state.associatedWallets.status = null
     },
     resetRemovedStatus: (state) => {

--- a/packages/harmony/src/components/modal/Modal.tsx
+++ b/packages/harmony/src/components/modal/Modal.tsx
@@ -247,7 +247,11 @@ export const Modal = forwardRef<HTMLDivElement, ModalProps>(function Modal(
       // Closing when we're not open can cause a race condition when opened
       // via a click since this handler exists prior to visibility,
       // causing the modal to open and close immediately
-      if (!isOpen || modalContentClickedRef?.current) {
+      if (
+        !isOpen ||
+        modalContentClickedRef?.current ||
+        !dismissOnClickOutside
+      ) {
         modalContentClickedRef.current = false
         return true
       }

--- a/packages/mobile/ios/Podfile.lock
+++ b/packages/mobile/ios/Podfile.lock
@@ -2294,7 +2294,7 @@ SPEC CHECKSUMS:
   ffmpeg-kit-react-native: 3cea88c9c5cfad62e1465279ea7d800dfbba3b00
   FingerprintPro: c6444f5a00d1126446da664124529e754475f198
   fmt: 4c2741a687cc09f0634a2e2c72a838b99f1ff120
-  glog: 69ef571f3de08433d766d614c73a9838a06bf7eb
+  glog: fdfdfe5479092de0c4bdbebedd9056951f092c4f
   google-cast-sdk-dynamic-xcframework-no-bluetooth: 1fa9e267df3fd6f8a1c6e3345142ca5286297968
   hermes-engine: ea92f60f37dba025e293cbe4b4a548fd26b610a0
   JWT: ef71dfb03e1f842081e64dc42eef0e164f35d251
@@ -2303,7 +2303,7 @@ SPEC CHECKSUMS:
   lottie-react-native: e23d9bcc85c8730e79e96bdf589a1996d7d388a9
   nSure: ce410631caf715d7080838c00a42169427847a01
   PromisesObjC: f5707f49cb48b9636751c5b2e7d227e43fba9f47
-  RCT-Folly: 4464f4d875961fce86008d45f4ecf6cef6de0740
+  RCT-Folly: 02617c592a293bd6d418e0a88ff4ee1f88329b47
   RCTDeprecation: 726d24248aeab6d7180dac71a936bbca6a994ed1
   RCTRequired: a94e7febda6db0345d207e854323c37e3a31d93b
   RCTTypeSafety: 28e24a6e44f5cbf912c66dde6ab7e07d1059a205

--- a/packages/web/src/pages/audio-rewards-page/WalletModal.tsx
+++ b/packages/web/src/pages/audio-rewards-page/WalletModal.tsx
@@ -317,7 +317,14 @@ const WalletModal = () => {
 
   if (modalState?.stage === 'CONNECT_WALLETS') {
     return (
-      <Modal size='small' isOpen={modalVisible} onClose={onClose}>
+      <Modal
+        size='small'
+        isOpen={modalVisible}
+        // Disable because web3Modal mounts outside of this component
+        // and selecting a provider will close this modal
+        dismissOnClickOutside={false}
+        onClose={onClose}
+      >
         <ModalHeader onClose={onClose}>
           <ModalTitle title={getTitle(modalState)} icon={<IconWallet />} />
         </ModalHeader>


### PR DESCRIPTION
### Description
The actual bug here is that we accidentally close the WalletModal while the connection process is still in progress and our state is not set up to handle this, resulting in toasts popping up next time around.

The reason the modal closes early is twofold:
1. The `ignoreClick` logic in the Harmony `Modal` component seems to be broken and doesn't take into account the `shouldDismissOnClickOutside` prop. I tested other modal that set this prop to fault and they all closed on clicking outside, so it's just generally broken. I admittedly don't fully understand how that prop is supposed to work, because we were previously using it to conditionally assign a `ref` to a wrapper `animated.div` component. But that conditional ref assignment doesn't prevent `useClickOutside` from detecting clicks and running the custom processing logic, thus triggering the `onClose` handler for `Modal`. cc @dylanjeffers and @amendelsohn on whether this feels like the right approach.
3. The `Modal` we load up for the connect case wasn't passing `dismissOnClickOutside` at all, which meant that it would use the default dismissal behavior. I opted to just blanket pass `false` for this and force the user to manually close this modal, since it's very sensitive to the flow being interrupted.

Also needed a small change to correctly handle the case where the user cancels the signature. When something goes wrong, we don't reset the "connecting wallet" state. So it continues to show in the modal as pending.

### How Has This Been Tested?
Local client against staging
Will double check mobile also works correctly before merging.
