### PR TITLE
[QA-1904] Fix profile tab SSR

### DIFF
--- a/packages/common/src/store/pages/profile/types.ts
+++ b/packages/common/src/store/pages/profile/types.ts
@@ -66,11 +66,11 @@ export enum ProfilePageTabs {
 }
 
 export enum ProfilePageTabRoute {
-  TRACKS = 'Tracks',
-  ALBUMS = 'Albums',
-  PLAYLISTS = 'Playlists',
-  REPOSTS = 'Reposts',
-  COLLECTIBLES = 'Collectibles'
+  TRACKS = 'tracks',
+  ALBUMS = 'albums',
+  PLAYLISTS = 'playlists',
+  REPOSTS = 'reposts',
+  COLLECTIBLES = 'collectibles'
 }
 
 export const getTabForRoute = (tabRoute: ProfilePageTabRoute) => {

--- a/packages/web/src/utils/route/userRouteParser.ts
+++ b/packages/web/src/utils/route/userRouteParser.ts
@@ -47,11 +47,11 @@ export const parseUserRoute = (route: string): UserRouteParams => {
   if (profilePageTabMatch) {
     const { handle, tab } = profilePageTabMatch.params
     if (
-      tab === 'Tracks' ||
-      tab === 'Albums' ||
-      tab === 'Playlists' ||
-      tab === 'Reposts' ||
-      tab === 'Collectibles'
+      tab === 'tracks' ||
+      tab === 'albums' ||
+      tab === 'playlists' ||
+      tab === 'reposts' ||
+      tab === 'collectibles'
     ) {
       return { handle, userId: null, tab }
     }
@@ -66,7 +66,7 @@ export const parseUserRoute = (route: string): UserRouteParams => {
   })
   if (profilePageTabIdMatch) {
     const { handle, tab } = profilePageTabIdMatch.params
-    if (tab === 'Collectibles') {
+    if (tab === 'collectibles') {
       return { handle, userId: null, tab }
     }
   }


### PR DESCRIPTION
### Description

Fixes issue where profile-page-tab-route was incorrectly cap-cased, leading to issues where /artist/albums mapped to /artist/Albums which then lead to a 404