### PR TITLE
Fix app creation with signMessage

### DIFF
--- a/.changeset/beige-dolphins-smoke.md
+++ b/.changeset/beige-dolphins-smoke.md
@@ -1,5 +1,5 @@
 ---
-"@audius/sdk": minor
+'@audius/sdk': patch
 ---
 
 Replace deprecated sign with signMessage

--- a/.changeset/beige-dolphins-smoke.md
+++ b/.changeset/beige-dolphins-smoke.md
@@ -1,0 +1,5 @@
+---
+"@audius/sdk": minor
+---
+
+Replace deprecated sign with signMessage

--- a/packages/sdk/src/sdk/api/developer-apps/DeveloperAppsApi.ts
+++ b/packages/sdk/src/sdk/api/developer-apps/DeveloperAppsApi.ts
@@ -51,7 +51,7 @@ export class DeveloperAppsApi extends GeneratedDeveloperAppsApi {
     const unixTs = Math.round(new Date().getTime() / 1000) // current unix timestamp (sec)
     const message = `Creating Audius developer app at ${unixTs}`
 
-    const signature = await wallet.sign({ message })
+    const signature = await wallet.signMessage({ message })
     const response = await this.entityManager.manageEntity({
       userId,
       entityType: EntityType.DEVELOPER_APP,


### PR DESCRIPTION
### Description

Client is sending incompatible signed messages causing indexing to fail.

```
TypeError(\"Cannot convert [{'0': 219, '1': 19, '2': 188, '3': 146, '4': 33, '5': 241, '6': 237, '7': 26, '8': 179, '9': 207, '10': 188, '11': 153, '12': 5, '13': 96, '14': 213, '15': 232, '16': 236, '17': 242, '18': 240, '19': 165, '20': 63, '21': 49, '22': 232, '23': 26, '24': 62, '25': 109, '26': 187, '27': 164, '28': 230, '29': 200, '30': 84, '31': 14, '32': 57, '33': 51, '34': 240, '35': 180, '36': 15, '37': 187, '38': 86, '39': 66, '40': 77, '41': 95, '42': 19, '43': 9, '44': 27, '45': 95, '46': 66, '47': 235, '48': 232, '49': 145, '50': 70, '51': 100, '52': 225, '53': 196, '54': 255, '55': 192, '56': 247, '57': 85, '58': 1, '59': 38, '60': 112, '61': 49, '62': 253, '63': 110}, 1] of type <class 'list'> to bytes\"),)
```

This should be in the form of a string like
```
    "signature": "0x0b0f503aaaa837c082611ddf64de318c885975c52efb70b0a2d8d1548d57ec3c3af2be6377dab33ef3fd89d16db9b844ef0606eed2b98bcc91f511d3d1dfd0bd1b"
```

This is because the `sign` function is now deprecated. Moving to `signMessage` works.
```
Signs a raw keccak256 hash of some payload using secp256k1. Not supported by most wallets.

@deprecated — Use signMessage instead for maximal wallet compatibility.

```

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._


Tested on stage an confirmed indexing of app. 