### PR TITLE
Prevent celery tasks from overlapping

### DIFF
--- a/packages/discovery-provider/scripts/start.sh
+++ b/packages/discovery-provider/scripts/start.sh
@@ -57,14 +57,33 @@ else
         [ -e /var/celerybeat-schedule ] && rm /var/celerybeat-schedule
         [ -e /var/celerybeat.pid ] && rm /var/celerybeat.pid
         audius_service=beat celery -A src.worker.celery beat --schedule=/var/celerybeat-schedule --pidfile=/var/celerybeat.pid --loglevel WARNING 2>&1 | tee >(logger -t beat) &
-        # start worker dedicated to indexing ACDC
-        audius_service=worker celery -A src.worker.celery worker -Q index_nethermind --loglevel "$audius_discprov_loglevel" --hostname=index_nethermind --concurrency 1 2>&1 | tee >(logger -t index_nethermind_worker) &
+
+        # start worker dedicated to indexing ACDC with task-prefetch-multiplier=1
+        audius_service=worker celery -A src.worker.celery worker -Q index_nethermind \
+            --loglevel "$audius_discprov_loglevel" \
+            --hostname=index_nethermind \
+            --concurrency 1 \
+            --prefetch-multiplier 1 \
+            --max-tasks-per-child 1 \
+            2>&1 | tee >(logger -t index_nethermind_worker) &
 
         # start worker dedicated to indexing user bank and payment router
-        audius_service=worker celery -A src.worker.celery worker -Q index_sol --loglevel "$audius_discprov_loglevel" --hostname=index_sol --concurrency 1 2>&1 | tee >(logger -t index_sol_worker) &
+        audius_service=worker celery -A src.worker.celery worker -Q index_sol \
+            --loglevel "$audius_discprov_loglevel" \
+            --hostname=index_sol \
+            --concurrency 1 \
+            --prefetch-multiplier 1 \
+            --max-tasks-per-child 1 \
+            2>&1 | tee >(logger -t index_sol_worker) &
 
         # start other workers with remaining CPUs
-        audius_service=worker celery -A src.worker.celery worker --max-memory-per-child 300000 --loglevel "$audius_discprov_loglevel" --concurrency 3 2>&1 | tee >(logger -t worker) &
+        audius_service=worker celery -A src.worker.celery worker \
+            --max-memory-per-child 300000 \
+            --loglevel "$audius_discprov_loglevel" \
+            --concurrency 3 \
+            --prefetch-multiplier 1 \
+            --max-tasks-per-child 10 \
+            2>&1 | tee >(logger -t worker) &
 
         while [[ "$audius_discprov_env" == "stage" ]]; do
             # log active tasks and mem to find mem leaks


### PR DESCRIPTION
Configure blockchain indexing workers (Nethermind and Solana) to restart after each task and only prefetch one task at a time. This prevents memory leaks and ensures each indexing task starts with a clean state.

Settings:
- prefetch-multiplier=1: Ensures worker only receives one task at a time
- max-tasks-per-child=1: Forces worker restart after each task completion

General worker remains at 10 max tasks for better performance on lighter operations.