### PR TITLE
Temporarily disable track replace downloads until the DN code goes out

### DIFF
--- a/packages/common/src/services/remote-config/feature-flags.ts
+++ b/packages/common/src/services/remote-config/feature-flags.ts
@@ -23,7 +23,8 @@ export enum FeatureFlags {
   TRACK_AUDIO_REPLACE = 'track_audio_replace',
   OWN_YOUR_FANS = 'own_your_fans',
   FAST_REFERRAL = 'fast_referral',
-  REACT_QUERY_SYNC = 'react_query_sync'
+  REACT_QUERY_SYNC = 'react_query_sync',
+  TRACK_REPLACE_DOWNLOADS = 'track_replace_downloads'
 }
 
 type FlagDefaults = Record<FeatureFlags, boolean>
@@ -62,5 +63,6 @@ export const flagDefaults: FlagDefaults = {
   [FeatureFlags.TRACK_AUDIO_REPLACE]: false,
   [FeatureFlags.OWN_YOUR_FANS]: false,
   [FeatureFlags.FAST_REFERRAL]: false,
-  [FeatureFlags.REACT_QUERY_SYNC]: false
+  [FeatureFlags.REACT_QUERY_SYNC]: false,
+  [FeatureFlags.TRACK_REPLACE_DOWNLOADS]: false
 }

--- a/packages/mobile/src/screens/edit-track-screen/EditTrackForm.tsx
+++ b/packages/mobile/src/screens/edit-track-screen/EditTrackForm.tsx
@@ -322,7 +322,9 @@ export const EditTrackForm = (props: EditTrackFormProps) => {
         isOpen={isOverflowMenuOpen}
         onClose={handleOverflowMenuClose}
         onReplace={handleReplace}
-        onDownload={isUpload ? undefined : handleDownload}
+        onDownload={undefined}
+        // KJ - TODO: Reenable download once the DN code goes out
+        // onDownload={isUpload ? undefined : handleDownload}
       />
     </>
   )

--- a/packages/mobile/src/screens/edit-track-screen/EditTrackForm.tsx
+++ b/packages/mobile/src/screens/edit-track-screen/EditTrackForm.tsx
@@ -1,11 +1,12 @@
 import { useCallback, useContext, useEffect, useRef, useState } from 'react'
 
 import { useFeatureFlag } from '@audius/common/hooks'
-import { DownloadQuality, Name } from '@audius/common/models'
+// import { DownloadQuality, Name } from '@audius/common/models'
+import { Name } from '@audius/common/models'
 import { FeatureFlags } from '@audius/common/services'
 import type { TrackForUpload } from '@audius/common/store'
 import {
-  useWaitForDownloadModal,
+  // useWaitForDownloadModal,
   uploadActions,
   useReplaceTrackConfirmationModal,
   useReplaceTrackProgressModal,
@@ -129,7 +130,7 @@ export const EditTrackForm = (props: EditTrackFormProps) => {
   const { onOpen: openEarlyReleaseConfirmation } =
     useEarlyReleaseConfirmationModal()
   const { onOpen: openPublishConfirmation } = usePublishConfirmationModal()
-  const { onOpen: openWaitForDownload } = useWaitForDownloadModal()
+  // const { onOpen: openWaitForDownload } = useWaitForDownloadModal()
 
   const handleReplace = useCallback(() => {
     selectFile()
@@ -144,20 +145,20 @@ export const EditTrackForm = (props: EditTrackFormProps) => {
     )
   }, [selectFile, isUpload, values.track_id])
 
-  const handleDownload = useCallback(() => {
-    openWaitForDownload({
-      trackIds: [initialValues.track_id],
-      quality: DownloadQuality.ORIGINAL
-    })
+  // const handleDownload = useCallback(() => {
+  //   openWaitForDownload({
+  //     trackIds: [initialValues.track_id],
+  //     quality: DownloadQuality.ORIGINAL
+  //   })
 
-    // Track Download event
-    trackEvent(
-      make({
-        eventName: Name.TRACK_REPLACE_DOWNLOAD,
-        trackId: initialValues.track_id
-      })
-    )
-  }, [openWaitForDownload, initialValues.track_id])
+  //   // Track Download event
+  //   trackEvent(
+  //     make({
+  //       eventName: Name.TRACK_REPLACE_DOWNLOAD,
+  //       trackId: initialValues.track_id
+  //     })
+  //   )
+  // }, [openWaitForDownload, initialValues.track_id])
 
   const handlePressBack = useCallback(() => {
     if (!dirty) {

--- a/packages/web/src/components/edit-track/EditTrackForm.tsx
+++ b/packages/web/src/components/edit-track/EditTrackForm.tsx
@@ -194,6 +194,9 @@ const TrackEditForm = (
   const { isEnabled: isTrackAudioReplaceEnabled } = useFeatureFlag(
     FeatureFlags.TRACK_AUDIO_REPLACE
   )
+  const { isEnabled: isTrackReplaceDownloadsEnabled } = useFeatureFlag(
+    FeatureFlags.TRACK_REPLACE_DOWNLOADS
+  )
 
   const [{ value: track }, , { setValue: setTrackValue }] = useField(
     `tracks.${trackIdx}`
@@ -208,8 +211,6 @@ const TrackEditForm = (
   )
 
   const handleTogglePreview = useCallback(() => {
-    togglePreview(track.preview, trackIdx)
-
     if (!isPreviewPlaying) {
       // Track Preview event
       trackEvent(
@@ -220,6 +221,8 @@ const TrackEditForm = (
         })
       )
     }
+
+    togglePreview(track.preview, trackIdx)
   }, [
     togglePreview,
     track.preview,
@@ -343,9 +346,7 @@ const TrackEditForm = (
                 isPlaying={isPreviewPlaying}
                 onClickReplace={onClickReplace}
                 onClickDownload={onClickDownload}
-                downloadEnabled={false}
-                // KJ - TODO: Reenable download once the DN code goes out
-                // downloadEnabled={!isUpload}
+                downloadEnabled={!isUpload && isTrackReplaceDownloadsEnabled}
               />
             ) : null}
             <TrackMetadataFields />

--- a/packages/web/src/components/edit-track/EditTrackForm.tsx
+++ b/packages/web/src/components/edit-track/EditTrackForm.tsx
@@ -343,7 +343,9 @@ const TrackEditForm = (
                 isPlaying={isPreviewPlaying}
                 onClickReplace={onClickReplace}
                 onClickDownload={onClickDownload}
-                downloadEnabled={!isUpload}
+                downloadEnabled={false}
+                // KJ - TODO: Reenable download once the DN code goes out
+                // downloadEnabled={!isUpload}
               />
             ) : null}
             <TrackMetadataFields />


### PR DESCRIPTION
### Description
Title, disabling downloads until the DN code goes out next week

### How Has This Been Tested?
Manually Tested
