### PR TITLE
Pause track preview when replacing track file

### DIFF
--- a/packages/web/src/components/edit-track/EditTrackForm.tsx
+++ b/packages/web/src/components/edit-track/EditTrackForm.tsx
@@ -257,6 +257,8 @@ const TrackEditForm = (
 
       const files = processedFiles.filter(removeNullable)
       if (files.length > 0) {
+        if (isPreviewPlaying) handleTogglePreview()
+
         const newFile = files[0]
 
         if (isUpload && !isTitleDirty) {
@@ -279,6 +281,8 @@ const TrackEditForm = (
       }
     },
     [
+      isPreviewPlaying,
+      handleTogglePreview,
       isUpload,
       isTitleDirty,
       isArtworkDirty,


### PR DESCRIPTION
### Description
Small update to pause the preview when the file changes on web

### How Has This Been Tested?
Manually tested
