### PR TITLE
[C-556] Fix sign-up completion link navigation

### DIFF
--- a/packages/mobile/src/screens/app-drawer-screen/AppDrawerScreen.tsx
+++ b/packages/mobile/src/screens/app-drawer-screen/AppDrawerScreen.tsx
@@ -1,12 +1,10 @@
-import { memo, useEffect, useMemo, useState } from 'react'
+import { memo, useMemo, useState } from 'react'
 
 import { createDrawerNavigator } from '@react-navigation/drawer'
 // eslint-disable-next-line import/no-unresolved
 import type { DrawerNavigationHelpers } from '@react-navigation/drawer/lib/typescript/src/types'
-import { useLinkTo, useNavigation } from '@react-navigation/native'
-import { getRouteOnCompletion } from 'common/store/pages/signon/selectors'
+import { useNavigation } from '@react-navigation/native'
 import { Dimensions } from 'react-native'
-import { useSelector } from 'react-redux'
 
 import { AudioPlayer } from 'app/components/audio/AudioPlayer'
 import { RepeatListener } from 'app/components/audio/RepeatListener'
@@ -52,16 +50,6 @@ const AppStack = memo(function AppStack(props: AppTabScreenProps) {
 
 export const AppDrawerScreen = memo(
   () => {
-    const linkTo = useLinkTo()
-    const routeOnCompletion = useSelector(getRouteOnCompletion)
-
-    // Route to the original deep link after user signs up
-    useEffect(() => {
-      if (routeOnCompletion) {
-        linkTo(routeOnCompletion)
-      }
-    }, [routeOnCompletion, linkTo])
-
     const [gesturesDisabled, setGesturesDisabled] = useState(false)
 
     const drawerScreenOptions = useMemo(

--- a/packages/mobile/src/screens/root-screen/RootScreen.tsx
+++ b/packages/mobile/src/screens/root-screen/RootScreen.tsx
@@ -6,6 +6,7 @@ import {
   chatActions,
   playerActions
 } from '@audius/common/store'
+import { route } from '@audius/common/utils'
 import { PortalHost } from '@gorhom/portal'
 import { useLinkTo } from '@react-navigation/native'
 import { createNativeStackNavigator } from '@react-navigation/native-stack'
@@ -40,6 +41,7 @@ const { getAccountStatus } = accountSelectors
 const { fetchMoreChats, fetchUnreadMessagesCount, connect, disconnect } =
   chatActions
 const { reset } = playerActions
+const { FEED_PAGE } = route
 
 const Stack = createNativeStackNavigator()
 
@@ -114,7 +116,7 @@ export const RootScreen = () => {
         navigate('HomeStack')
       }
       // Route to the original deep link after user signs up
-      if (routeOnCompletion && routeOnCompletion !== '/feed') {
+      if (routeOnCompletion && routeOnCompletion !== FEED_PAGE) {
         linkTo(routeOnCompletion)
       }
     }

--- a/packages/mobile/src/screens/root-screen/RootScreen.tsx
+++ b/packages/mobile/src/screens/root-screen/RootScreen.tsx
@@ -7,9 +7,11 @@ import {
   playerActions
 } from '@audius/common/store'
 import { PortalHost } from '@gorhom/portal'
+import { useLinkTo } from '@react-navigation/native'
 import { createNativeStackNavigator } from '@react-navigation/native-stack'
 import {
   getHasCompletedAccount,
+  getRouteOnCompletion,
   getStartedSignUpProcess,
   getWelcomeModalShown
 } from 'common/store/pages/signon/selectors'
@@ -68,6 +70,8 @@ export const RootScreen = () => {
   const [isSplashScreenDismissed, setIsSplashScreenDismissed] = useState(false)
   const { navigate } = useNavigation()
   const { onOpen: openWelcomeDrawer } = useDrawer('Welcome')
+  const routeOnCompletion = useSelector(getRouteOnCompletion)
+  const linkTo = useLinkTo()
 
   useAppState(
     () => dispatch(enterForeground()),
@@ -109,6 +113,10 @@ export const RootScreen = () => {
       if (isAndroid && navigate) {
         navigate('HomeStack')
       }
+      // Route to the original deep link after user signs up
+      if (routeOnCompletion && routeOnCompletion !== '/feed') {
+        linkTo(routeOnCompletion)
+      }
     }
   }, [
     openWelcomeDrawer,
@@ -116,7 +124,9 @@ export const RootScreen = () => {
     startedSignUp,
     welcomeModalShown,
     navigate,
-    isAndroid
+    isAndroid,
+    routeOnCompletion,
+    linkTo
   ])
 
   return (


### PR DESCRIPTION
### Description

Fixes critical issue where sign-up routeOnCompletion was navigated to every time the app was fore-grounded, which caused the app to always route to "feed" on foreground. This was originally noticed with the date-picker modal which technically backgrounds the app. 

This fix is much better by moving into the routing code block into the same condition that checks to open the welcome modal. Additionally we are ignoring the route if it's to /feed