### PR TITLE
[C-5632] Use react-query Config type

### DIFF
--- a/packages/common/src/api/tan-query/types.ts
+++ b/packages/common/src/api/tan-query/types.ts
@@ -1,7 +1,9 @@
+import { DefinedInitialDataOptions } from '@tanstack/react-query'
+
 /**
  * Standard tan-query pass-thru options that we use
  */
-export type QueryOptions = {
-  staleTime?: number
-  enabled?: boolean
-}
+export type Config = Pick<
+  DefinedInitialDataOptions<any>,
+  'staleTime' | 'enabled'
+>

--- a/packages/common/src/api/tan-query/useCollection.ts
+++ b/packages/common/src/api/tan-query/useCollection.ts
@@ -7,12 +7,12 @@ import { Id, ID, OptionalId } from '~/models/Identifiers'
 import { getUserId } from '~/store/account/selectors'
 
 import { QUERY_KEYS } from './queryKeys'
-import { QueryOptions } from './types'
+import { Config } from './types'
 import { primeCollectionData } from './utils/primeCollectionData'
 
 export const useCollection = (
   collectionId: ID | null | undefined,
-  options?: QueryOptions
+  options?: Config
 ) => {
   const { audiusSdk } = useAudiusQueryContext()
   const queryClient = useQueryClient()

--- a/packages/common/src/api/tan-query/useCollectionByPermalink.ts
+++ b/packages/common/src/api/tan-query/useCollectionByPermalink.ts
@@ -7,7 +7,7 @@ import { OptionalId } from '~/models'
 import { getUserId } from '~/store/account/selectors'
 
 import { QUERY_KEYS } from './queryKeys'
-import { QueryOptions } from './types'
+import { Config } from './types'
 import { primeCollectionData } from './utils/primeCollectionData'
 
 export const playlistPermalinkToHandleAndSlug = (permalink: string) => {
@@ -24,7 +24,7 @@ export const playlistPermalinkToHandleAndSlug = (permalink: string) => {
 
 export const useCollectionByPermalink = (
   permalink: string | undefined | null,
-  options?: QueryOptions
+  options?: Config
 ) => {
   const { audiusSdk } = useAudiusQueryContext()
   const queryClient = useQueryClient()

--- a/packages/common/src/api/tan-query/useCollections.ts
+++ b/packages/common/src/api/tan-query/useCollections.ts
@@ -11,11 +11,11 @@ import { EntriesByKind } from '~/store/cache/types'
 import { encodeHashId } from '~/utils/hashIds'
 
 import { QUERY_KEYS } from './queryKeys'
-import { QueryOptions } from './types'
+import { Config } from './types'
 
 export const useCollections = (
   collectionIds: ID[] | null | undefined,
-  options?: QueryOptions
+  options?: Config
 ) => {
   const { audiusSdk } = useAudiusQueryContext()
   const queryClient = useQueryClient()

--- a/packages/common/src/api/tan-query/useCurrentUser.ts
+++ b/packages/common/src/api/tan-query/useCurrentUser.ts
@@ -7,12 +7,12 @@ import { SolanaWalletAddress } from '~/models/Wallet'
 import { getWalletAddresses } from '~/store/account/selectors'
 
 import { QUERY_KEYS } from './queryKeys'
-import { QueryOptions } from './types'
+import { Config } from './types'
 
 /**
  * Hook to get the currently logged in user's data
  */
-export const useCurrentUser = (options?: QueryOptions) => {
+export const useCurrentUser = (config?: Config) => {
   const { audiusSdk } = useAudiusQueryContext()
   const { currentUser } = useSelector(getWalletAddresses)
 
@@ -42,7 +42,7 @@ export const useCurrentUser = (options?: QueryOptions) => {
       }
       return account?.user
     },
-    staleTime: options?.staleTime,
-    enabled: options?.enabled !== false && !!currentUser
+    staleTime: config?.staleTime,
+    enabled: config?.enabled !== false && !!currentUser
   })
 }

--- a/packages/common/src/api/tan-query/useFavoritedTracks.ts
+++ b/packages/common/src/api/tan-query/useFavoritedTracks.ts
@@ -4,16 +4,14 @@ import { transformAndCleanList } from '~/adapters'
 import { favoriteFromSDK } from '~/adapters/favorite'
 import { useAudiusQueryContext } from '~/audius-query'
 import { ID, Id } from '~/models/Identifiers'
-import { Nullable } from '~/utils/typeUtils'
 
 import { QUERY_KEYS } from './queryKeys'
+import { Config } from './types'
 
-type Config = {
-  enabled?: boolean
-  staleTime?: number
-}
-
-export const useFavoritedTracks = (userId: Nullable<ID>, config?: Config) => {
+export const useFavoritedTracks = (
+  userId: ID | null | undefined,
+  config?: Config
+) => {
   const { audiusSdk } = useAudiusQueryContext()
 
   return useQuery({

--- a/packages/common/src/api/tan-query/useFollowers.ts
+++ b/packages/common/src/api/tan-query/useFollowers.ts
@@ -3,14 +3,13 @@ import { useQuery } from '@tanstack/react-query'
 import { userMetadataListFromSDK } from '~/adapters/user'
 import { useAppContext } from '~/context/appContext'
 import { ID, Id, OptionalId } from '~/models/Identifiers'
-import { Nullable } from '~/utils/typeUtils'
 
 import { QUERY_KEYS } from './queryKeys'
-import { QueryOptions } from './types'
+import { Config } from './types'
 import { useCurrentUserId } from './useCurrentUserId'
 
 type GetFollowersArgs = {
-  userId: Nullable<ID>
+  userId: ID | null | undefined
   limit?: number
   offset?: number
 }
@@ -22,7 +21,7 @@ type GetFollowersArgs = {
  */
 export const useFollowers = (
   { userId, limit = 10, offset = 0 }: GetFollowersArgs,
-  options?: QueryOptions
+  options?: Config
 ) => {
   const { audiusSdk } = useAppContext()
   const { data: currentUserId } = useCurrentUserId()

--- a/packages/common/src/api/tan-query/useMutualFollowers.ts
+++ b/packages/common/src/api/tan-query/useMutualFollowers.ts
@@ -8,29 +8,22 @@ import { Id } from '~/models/Identifiers'
 import { getUserId } from '~/store/account/selectors'
 
 import { QUERY_KEYS } from './queryKeys'
+import { Config } from './types'
 import { primeUserData } from './utils/primeUserData'
-
-type Config = {
-  staleTime?: number
-  enabled?: boolean
-}
 
 type MutualFollowersParams = {
   userId: ID | null | undefined
   limit?: number
   offset?: number
-  config?: Config
 }
 
 /**
  * Hook to get mutual followers between the current user and another user
  */
-export const useMutualFollowers = ({
-  userId,
-  limit,
-  offset,
-  config
-}: MutualFollowersParams) => {
+export const useMutualFollowers = (
+  { userId, limit, offset }: MutualFollowersParams,
+  config?: Config
+) => {
   const { audiusSdk } = useAudiusQueryContext()
   const currentUserId = useSelector(getUserId)
   const queryClient = useQueryClient()
@@ -39,7 +32,6 @@ export const useMutualFollowers = ({
   return useQuery({
     queryKey: [QUERY_KEYS.mutualFollowers, userId, limit, offset],
     queryFn: async () => {
-      if (!userId) return null
       const sdk = await audiusSdk()
       const { data } = await sdk.full.users.getMutualFollowers({
         userId: OptionalId.parse(currentUserId),

--- a/packages/common/src/api/tan-query/usePurchasesCount.ts
+++ b/packages/common/src/api/tan-query/usePurchasesCount.ts
@@ -2,18 +2,15 @@ import { useQuery } from '@tanstack/react-query'
 
 import { useAudiusQueryContext } from '~/audius-query'
 import { ID } from '~/models'
-import { Nullable } from '~/utils/typeUtils'
-
-import { Id } from '../utils'
+import { Id } from '~/models/Identifiers'
 
 import { QUERY_KEYS } from './queryKeys'
+import { Config } from './types'
 
-type Config = {
-  staleTime?: number
-  enabled?: boolean
-}
-
-export const usePurchasesCount = (userId: Nullable<ID>, config?: Config) => {
+export const usePurchasesCount = (
+  userId: ID | null | undefined,
+  config?: Config
+) => {
   const context = useAudiusQueryContext()
   const audiusSdk = context.audiusSdk
 

--- a/packages/common/src/api/tan-query/useSalesCount.ts
+++ b/packages/common/src/api/tan-query/useSalesCount.ts
@@ -2,18 +2,15 @@ import { useQuery } from '@tanstack/react-query'
 
 import { useAudiusQueryContext } from '~/audius-query'
 import { ID } from '~/models'
-import { Nullable } from '~/utils/typeUtils'
-
-import { Id } from '../utils'
+import { Id } from '~/models/Identifiers'
 
 import { QUERY_KEYS } from './queryKeys'
+import { Config } from './types'
 
-type Config = {
-  staleTime?: number
-  enabled?: boolean
-}
-
-export const useSalesCount = (userId: Nullable<ID>, config?: Config) => {
+export const useSalesCount = (
+  userId: ID | null | undefined,
+  config?: Config
+) => {
   const context = useAudiusQueryContext()
   const audiusSdk = context.audiusSdk
 

--- a/packages/common/src/api/tan-query/useSupportedUsers.ts
+++ b/packages/common/src/api/tan-query/useSupportedUsers.ts
@@ -2,22 +2,18 @@ import { useQuery, useQueryClient } from '@tanstack/react-query'
 import { useDispatch } from 'react-redux'
 
 import { useAudiusQueryContext } from '~/audius-query'
-import { Id, OptionalId } from '~/models/Identifiers'
+import { ID, Id, OptionalId } from '~/models/Identifiers'
 import { supportedUserMetadataListFromSDK } from '~/models/Tipping'
 import { SUPPORTING_PAGINATION_SIZE } from '~/utils/constants'
 
 import { QUERY_KEYS } from './queryKeys'
+import { Config } from './types'
 import { useCurrentUserId } from './useCurrentUserId'
 import { primeUserData } from './utils/primeUserData'
 
 type UseSupportedUsersArgs = {
-  userId?: number
+  userId: ID | null | undefined
   limit?: number
-}
-
-type Config = {
-  staleTime?: number
-  enabled?: boolean
 }
 
 export const useSupportedUsers = (
@@ -32,7 +28,6 @@ export const useSupportedUsers = (
   return useQuery({
     queryKey: [QUERY_KEYS.supportedUsers, userId],
     queryFn: async () => {
-      if (!userId) return []
       const sdk = await audiusSdk()
       const { data = [] } = await sdk.full.users.getSupportedUsers({
         id: Id.parse(userId),

--- a/packages/common/src/api/tan-query/useSupporter.ts
+++ b/packages/common/src/api/tan-query/useSupporter.ts
@@ -2,21 +2,17 @@ import { useQuery, useQueryClient } from '@tanstack/react-query'
 import { useDispatch } from 'react-redux'
 
 import { useAudiusQueryContext } from '~/audius-query'
-import { Id, OptionalId } from '~/models/Identifiers'
+import { ID, Id, OptionalId } from '~/models/Identifiers'
 import { supporterMetadataFromSDK } from '~/models/Tipping'
 
 import { QUERY_KEYS } from './queryKeys'
+import { Config } from './types'
 import { useCurrentUserId } from './useCurrentUserId'
 import { primeUserData } from './utils/primeUserData'
 
 type UseSupporterArgs = {
-  userId?: number | null
-  supporterUserId?: number | null
-}
-
-type Config = {
-  staleTime?: number
-  enabled?: boolean
+  userId: ID | null | undefined
+  supporterUserId: ID | null | undefined
 }
 
 export const useSupporter = (
@@ -31,7 +27,6 @@ export const useSupporter = (
   return useQuery({
     queryKey: [QUERY_KEYS.supporters, userId, supporterUserId],
     queryFn: async () => {
-      if (!userId || !supporterUserId) return null
       const sdk = await audiusSdk()
       const { data } = await sdk.full.users.getSupporter({
         id: Id.parse(userId),

--- a/packages/common/src/api/tan-query/useSupporters.ts
+++ b/packages/common/src/api/tan-query/useSupporters.ts
@@ -2,22 +2,18 @@ import { useQuery, useQueryClient } from '@tanstack/react-query'
 import { useDispatch } from 'react-redux'
 
 import { useAudiusQueryContext } from '~/audius-query'
-import { Id, OptionalId } from '~/models/Identifiers'
-import { supporterMetadataListFromSDK } from '~/models/Tipping'
+import { supporterMetadataListFromSDK } from '~/models'
+import { ID, Id, OptionalId } from '~/models/Identifiers'
 import { MAX_PROFILE_TOP_SUPPORTERS } from '~/utils/constants'
 
 import { QUERY_KEYS } from './queryKeys'
+import { Config } from './types'
 import { useCurrentUserId } from './useCurrentUserId'
 import { primeUserData } from './utils/primeUserData'
 
 type UseSupportersArgs = {
-  userId?: number | null
+  userId: ID | null | undefined
   limit?: number
-}
-
-type Config = {
-  staleTime?: number
-  enabled?: boolean
 }
 
 export const useSupporters = (
@@ -32,7 +28,6 @@ export const useSupporters = (
   return useQuery({
     queryKey: [QUERY_KEYS.supporters, userId, limit],
     queryFn: async () => {
-      if (!userId) return []
       const sdk = await audiusSdk()
       const { data = [] } = await sdk.full.users.getSupporters({
         id: Id.parse(userId),

--- a/packages/common/src/api/tan-query/useTrack.ts
+++ b/packages/common/src/api/tan-query/useTrack.ts
@@ -3,19 +3,15 @@ import { useDispatch } from 'react-redux'
 
 import { userTrackMetadataFromSDK } from '~/adapters/track'
 import { useAudiusQueryContext } from '~/audius-query'
-import { ID } from '~/models/Identifiers'
+import { Id, ID } from '~/models/Identifiers'
 import { Kind } from '~/models/Kind'
 import { addEntries } from '~/store/cache/actions'
 import { EntriesByKind } from '~/store/cache/types'
-import { encodeHashId } from '~/utils/hashIds'
 
 import { QUERY_KEYS } from './queryKeys'
-import { QueryOptions } from './types'
+import { Config } from './types'
 
-export const useTrack = (
-  trackId: ID | null | undefined,
-  options?: QueryOptions
-) => {
+export const useTrack = (trackId: ID | null | undefined, options?: Config) => {
   const { audiusSdk } = useAudiusQueryContext()
   const queryClient = useQueryClient()
   const dispatch = useDispatch()
@@ -23,11 +19,9 @@ export const useTrack = (
   return useQuery({
     queryKey: [QUERY_KEYS.track, trackId],
     queryFn: async () => {
-      if (!trackId) return null
-      const encodedId = encodeHashId(trackId)
       const sdk = await audiusSdk()
       const { data } = await sdk.full.tracks.getTrack({
-        trackId: encodedId
+        trackId: Id.parse(trackId)
       })
 
       if (!data) return null

--- a/packages/common/src/api/tan-query/useTrackByPermalink.ts
+++ b/packages/common/src/api/tan-query/useTrackByPermalink.ts
@@ -7,12 +7,12 @@ import { OptionalId } from '~/models'
 import { getUserId } from '~/store/account/selectors'
 
 import { QUERY_KEYS } from './queryKeys'
-import { QueryOptions } from './types'
+import { Config } from './types'
 import { primeTrackData } from './utils/primeTrackData'
 
 export const useTrackByPermalink = (
   permalink: string | undefined | null,
-  options?: QueryOptions
+  options?: Config
 ) => {
   const { audiusSdk } = useAudiusQueryContext()
   const queryClient = useQueryClient()

--- a/packages/common/src/api/tan-query/useTracks.ts
+++ b/packages/common/src/api/tan-query/useTracks.ts
@@ -11,11 +11,11 @@ import { EntriesByKind } from '~/store/cache/types'
 import { encodeHashId } from '~/utils/hashIds'
 
 import { QUERY_KEYS } from './queryKeys'
-import { QueryOptions } from './types'
+import { Config } from './types'
 
 export const useTracks = (
   trackIds: ID[] | null | undefined,
-  options?: QueryOptions
+  options?: Config
 ) => {
   const { audiusSdk } = useAudiusQueryContext()
   const queryClient = useQueryClient()

--- a/packages/common/src/api/tan-query/useUser.ts
+++ b/packages/common/src/api/tan-query/useUser.ts
@@ -10,12 +10,9 @@ import { addEntries } from '~/store/cache/actions'
 import { EntriesByKind } from '~/store/cache/types'
 
 import { QUERY_KEYS } from './queryKeys'
-import { QueryOptions } from './types'
+import { Config } from './types'
 
-export const useUser = (
-  userId: ID | null | undefined,
-  options?: QueryOptions
-) => {
+export const useUser = (userId: ID | null | undefined, options?: Config) => {
   const { audiusSdk } = useAudiusQueryContext()
   const dispatch = useDispatch()
   const queryClient = useQueryClient()

--- a/packages/common/src/api/tan-query/useUserByHandle.ts
+++ b/packages/common/src/api/tan-query/useUserByHandle.ts
@@ -10,11 +10,11 @@ import { addEntries } from '~/store/cache/actions'
 import { EntriesByKind } from '~/store/cache/types'
 
 import { QUERY_KEYS } from './queryKeys'
-import { QueryOptions } from './types'
+import { Config } from './types'
 
 export const useUserByHandle = (
-  handle: string | undefined,
-  options?: QueryOptions
+  handle: string | null | undefined,
+  options?: Config
 ) => {
   const { audiusSdk } = useAudiusQueryContext()
   const dispatch = useDispatch()

--- a/packages/common/src/api/tan-query/useUserTracksByHandle.ts
+++ b/packages/common/src/api/tan-query/useUserTracksByHandle.ts
@@ -8,7 +8,7 @@ import { OptionalId } from '~/models'
 import { getUserId } from '~/store/account/selectors'
 
 import { QUERY_KEYS } from './queryKeys'
-import { QueryOptions } from './types'
+import { Config } from './types'
 import { primeTrackData } from './utils/primeTrackData'
 
 type GetTracksByUserHandleArgs = {
@@ -21,7 +21,7 @@ type GetTracksByUserHandleArgs = {
 
 export const useUserTracksByHandle = (
   args: GetTracksByUserHandleArgs,
-  options?: QueryOptions
+  options?: Config
 ) => {
   const { audiusSdk } = useAudiusQueryContext()
   const queryClient = useQueryClient()

--- a/packages/common/src/api/tan-query/useUsers.ts
+++ b/packages/common/src/api/tan-query/useUsers.ts
@@ -11,10 +11,10 @@ import { EntriesByKind } from '~/store/cache/types'
 import { removeNullable } from '~/utils/typeUtils'
 
 import { QUERY_KEYS } from './queryKeys'
-import { QueryOptions } from './types'
+import { Config } from './types'
 import { primeUserData } from './utils/primeUserData'
 
-export const useUsers = (userIds: ID[], options?: QueryOptions) => {
+export const useUsers = (userIds: ID[], config?: Config) => {
   const { audiusSdk } = useAudiusQueryContext()
   const dispatch = useDispatch()
   const queryClient = useQueryClient()
@@ -53,7 +53,7 @@ export const useUsers = (userIds: ID[], options?: QueryOptions) => {
 
       return users
     },
-    staleTime: options?.staleTime,
-    enabled: options?.enabled !== false && encodedIds.length > 0
+    staleTime: config?.staleTime,
+    enabled: config?.enabled !== false && encodedIds.length > 0
   })
 }

--- a/packages/mobile/src/screens/profile-screen/ArtistRecommendations/ArtistRecommendations.tsx
+++ b/packages/mobile/src/screens/profile-screen/ArtistRecommendations/ArtistRecommendations.tsx
@@ -95,7 +95,8 @@ export const ArtistRecommendations = (props: ArtistRecommendationsProps) => {
     Object.values(getUsers(state, { ids: idsToFollow || [] }))
   )
 
-  const { data: suggestedArtists } = useRelatedArtists(user_id, {
+  const { data: suggestedArtists } = useRelatedArtists({
+    artistId: user_id,
     filterFollowed: true
   })
 

--- a/packages/mobile/src/screens/profile-screen/ProfileHeader/ProfileInfoTiles.tsx
+++ b/packages/mobile/src/screens/profile-screen/ProfileHeader/ProfileInfoTiles.tsx
@@ -150,7 +150,10 @@ export const ProfileInfoTiles = () => {
   const hasMutuals =
     user_id !== accountId && current_user_followee_follow_count > 0
 
-  const { data: relatedArtists } = useRelatedArtists(user_id, { limit: 1 })
+  const { data: relatedArtists } = useRelatedArtists({
+    artistId: user_id,
+    limit: 1
+  })
   const hasRelatedArtists = relatedArtists && relatedArtists?.length > 0
 
   const hasAllThreeTiles = hasAiAttribution && hasMutuals && hasRelatedArtists

--- a/packages/web/src/components/artist-recommendations/ArtistRecommendations.tsx
+++ b/packages/web/src/components/artist-recommendations/ArtistRecommendations.tsx
@@ -138,7 +138,8 @@ export const ArtistRecommendations = forwardRef<
     Object.values(getUsers(state, { ids: idsToFollow ?? [] }))
   )
 
-  const { data: suggestedArtists } = useRelatedArtists(artistId, {
+  const { data: suggestedArtists } = useRelatedArtists({
+    artistId,
     filterFollowed: true
   })
 

--- a/packages/web/src/pages/profile-page/components/desktop/RelatedArtists.tsx
+++ b/packages/web/src/pages/profile-page/components/desktop/RelatedArtists.tsx
@@ -31,8 +31,8 @@ export const RelatedArtists = () => {
 
   const artistId = profile?.user_id
 
-  const { data: relatedArtists } = useRelatedArtists(artistId, {
-    limit: MAX_PROFILE_RELATED_ARTISTS
+  const { data: relatedArtists } = useRelatedArtists({
+    artistId
   })
 
   const handleClick = useCallback(() => {


### PR DESCRIPTION
### Description

- Use config type from `types.ts` and replace definition using Pick on the react-query type
- Adopt consistent argument structure
	- One positional argument + optional config
	- If more than one hook arg, take as args object
	- Required args set to `id: ID | null | undefined` instead of `id?: ID` so they always warn if arg is not provided
- Remove unnecessary guards from fetch functions

### How Has This Been Tested?

app seems to work still