### PR TITLE
Update default staking health check plugin port

### DIFF
--- a/packages/discovery-provider/plugins/pedalboard/apps/staking/src/index.ts
+++ b/packages/discovery-provider/plugins/pedalboard/apps/staking/src/index.ts
@@ -26,7 +26,7 @@ const main = async () => {
       chain: mainnet,
       transport: http(process.env.eth_rpc_endpoint!)
     }),
-    port: process.env.port ? parseInt(process.env.port) : 6004
+    port: process.env.port ? parseInt(process.env.port) : 6000
   }
   await new App<SharedData>({ appData: sharedData })
     .task(async (app: App<SharedData>) => {


### PR DESCRIPTION
### Description

6000 is default that plugins expect here https://github.com/AudiusProject/audius-protocol/blob/5508e0dc0666a71be8adab9597ae6e8d62a41f2d/packages/discovery-provider/nginx_conf/nginx_container.conf#L418

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._
