### PR TITLE
Challenge tables indexes on user_id

### DIFF
--- a/packages/discovery-provider/ddl/migrations/0113_challenge_user_id.sql
+++ b/packages/discovery-provider/ddl/migrations/0113_challenge_user_id.sql
@@ -1,0 +1,2 @@
+CREATE INDEX user_challenges_user_id ON user_challenges USING btree (user_id);
+CREATE INDEX challenge_disbursements_user_id ON challenge_disbursements USING btree (user_id);

--- a/packages/discovery-provider/ddl/migrations/0113_challenge_user_id.sql
+++ b/packages/discovery-provider/ddl/migrations/0113_challenge_user_id.sql
@@ -1,2 +1,6 @@
-CREATE INDEX user_challenges_user_id ON user_challenges USING btree (user_id);
-CREATE INDEX challenge_disbursements_user_id ON challenge_disbursements USING btree (user_id);
+BEGIN;
+
+CREATE INDEX IF NOT EXISTS user_challenges_user_id ON user_challenges USING btree (user_id);
+CREATE INDEX IF NOT EXISTS challenge_disbursements_user_id ON challenge_disbursements USING btree (user_id);
+
+COMMIT;


### PR DESCRIPTION
### Description
Add new indexes on `user_id` for `challenge_disbursements` and `user_challenges`.

### How Has This Been Tested?

Ran this sql on prod DN 4:
challenge_disbursements took 611ms.
user_challenges took 3.1s.