### PR TITLE
[QA-1906] Fix reaction size

### DIFF
--- a/packages/web/src/components/notification/Notification/components/Reaction/Reaction.tsx
+++ b/packages/web/src/components/notification/Notification/components/Reaction/Reaction.tsx
@@ -99,10 +99,9 @@ export const Reaction = (props: ReactionProps) => {
       onMouseLeave={handleMouseLeave}
     >
       <Lottie
+        style={{ height, width }}
         lottieRef={lottieRef}
         title={title}
-        height={width}
-        width={height}
         autoplay
         loop
         animationData={animation}

--- a/packages/web/src/components/notification/Notification/components/Reaction/index.tsx
+++ b/packages/web/src/components/notification/Notification/components/Reaction/index.tsx
@@ -1,4 +1,4 @@
-import React, { ComponentType } from 'react'
+import { ComponentType } from 'react'
 
 import { ReactionTypes } from '@audius/common/store'
 

--- a/packages/web/src/pages/chat-page/components/ReactionPopupMenu.module.css
+++ b/packages/web/src/pages/chat-page/components/ReactionPopupMenu.module.css
@@ -7,5 +7,5 @@
 }
 
 .popup {
-  border-radius: '50%';
+  border-radius: var(--harmony-unit-16);
 }


### PR DESCRIPTION
### Description

New lottie library needs style prop rather than height/width directly

<img width="1510" alt="image" src="https://github.com/user-attachments/assets/a10e4178-bd2c-4a4a-a196-146800b2e26d" />

Border radius never actually was working before the lottie changes in https://github.com/AudiusProject/audius-protocol/pull/10905

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._
