### PR TITLE
Only init store once per mount of AppProviders

### DIFF
--- a/packages/web/src/app/AppProviders.tsx
+++ b/packages/web/src/app/AppProviders.tsx
@@ -1,4 +1,4 @@
-import { ReactNode, useEffect, useState } from 'react'
+import { ReactNode, useState } from 'react'
 
 import { QueryClientProvider } from '@tanstack/react-query'
 import { ReactQueryDevtools } from '@tanstack/react-query-devtools'

--- a/packages/web/src/app/AppProviders.tsx
+++ b/packages/web/src/app/AppProviders.tsx
@@ -1,4 +1,4 @@
-import { ReactNode, useEffect } from 'react'
+import { ReactNode, useEffect, useState } from 'react'
 
 import { QueryClientProvider } from '@tanstack/react-query'
 import { ReactQueryDevtools } from '@tanstack/react-query-devtools'
@@ -32,27 +32,27 @@ export const AppProviders = ({ children }: AppProvidersProps) => {
   const { history } = useHistoryContext()
   const isMobile = useIsMobile()
 
-  const initialStoreState = {
-    ui: {
-      theme: {
-        theme: getTheme(),
-        systemAppearance: getSystemAppearance()
+  const [{ store, storeHistory }] = useState(() => {
+    const initialStoreState = {
+      ui: {
+        theme: {
+          theme: getTheme(),
+          systemAppearance: getSystemAppearance()
+        }
       }
     }
-  }
 
-  const { store, history: storeHistory } = configureStore(
-    history,
-    isMobile,
-    initialStoreState
-  )
-
-  useEffect(() => {
+    const { store, history: storeHistory } = configureStore(
+      history,
+      isMobile,
+      initialStoreState
+    )
     // Mount store to window for easy access
     if (typeof window !== 'undefined' && !window.store) {
       window.store = store
     }
-  }, [store])
+    return { store, storeHistory }
+  })
 
   return (
     <QueryClientProvider client={queryClient}>


### PR DESCRIPTION
### Description
#10858 introduced a pattern of calling configureStore on every render of AppProviders. It causes us to run rootSagas multiple times, which many of them are not designed for...

I updated it to use a lazy init useState so that we only run configureStore once.
This does technically mean if the value of `history` ever changes, the store will be out of sync with it. But that shouldn't happen after the app initializes anyway.

If needed, we can add a `useEffect` on the value of `history` to reinitialize the store in the future if needed.

### How Has This Been Tested?
Local client against staging. Verified app still starts up and that we don't call configureStore twice.
