### PR TITLE
[PAY-3779] Update createAppWalletClient to take in raw strings not wallets/hex

### DIFF
--- a/.changeset/kind-flowers-visit.md
+++ b/.changeset/kind-flowers-visit.md
@@ -1,0 +1,5 @@
+---
+"@audius/sdk": patch
+---
+
+Update createAppWalletClient to be object args and allow non-0x prefixed values

--- a/packages/sdk/src/sdk/api/albums/AlbumsApi.test.ts
+++ b/packages/sdk/src/sdk/api/albums/AlbumsApi.test.ts
@@ -119,7 +119,7 @@ describe('AlbumsApi', () => {
   // TODO: Remove this setup in describe
   let albums: AlbumsApi
   // eslint-disable-next-line mocha/no-setup-in-describe
-  const audiusWalletClient = createAppWalletClient('0x')
+  const audiusWalletClient = createAppWalletClient({ apiKey: '' })
   const logger = new Logger()
   const discoveryNodeSelector = new DiscoveryNodeSelector()
   const storageNodeSelector = new StorageNodeSelector({

--- a/packages/sdk/src/sdk/api/developer-apps/DeveloperAppsApi.ts
+++ b/packages/sdk/src/sdk/api/developer-apps/DeveloperAppsApi.ts
@@ -46,7 +46,10 @@ export class DeveloperAppsApi extends GeneratedDeveloperAppsApi {
 
     const privateKey = generatePrivateKey()
     const address = privateKeyToAddress(privateKey)
-    const wallet = createAppWalletClient(address, privateKey)
+    const wallet = createAppWalletClient({
+      apiKey: address,
+      apiSecret: privateKey
+    })
 
     const unixTs = Math.round(new Date().getTime() / 1000) // current unix timestamp (sec)
     const message = `Creating Audius developer app at ${unixTs}`

--- a/packages/sdk/src/sdk/api/notifications/NotificationsApi.test.ts
+++ b/packages/sdk/src/sdk/api/notifications/NotificationsApi.test.ts
@@ -30,7 +30,7 @@ describe('NotificationsApi', () => {
       new Configuration(),
       new EntityManagerClient({
         discoveryNodeSelector: new DiscoveryNodeSelector(),
-        audiusWalletClient: createAppWalletClient('0x')
+        audiusWalletClient: createAppWalletClient({ apiKey: '' })
       })
     )
     vitest.spyOn(console, 'warn').mockImplementation(() => {})

--- a/packages/sdk/src/sdk/api/playlists/PlaylistsApi.test.ts
+++ b/packages/sdk/src/sdk/api/playlists/PlaylistsApi.test.ts
@@ -108,7 +108,7 @@ describe('PlaylistsApi', () => {
   let playlists: PlaylistsApi
 
   // eslint-disable-next-line mocha/no-setup-in-describe
-  const audiusWalletClient = createAppWalletClient('0x')
+  const audiusWalletClient = createAppWalletClient({ apiKey: '' })
   const logger = new Logger()
   const discoveryNodeSelector = new DiscoveryNodeSelector()
   const storageNodeSelector = new StorageNodeSelector({

--- a/packages/sdk/src/sdk/api/tracks/TracksApi.test.ts
+++ b/packages/sdk/src/sdk/api/tracks/TracksApi.test.ts
@@ -92,7 +92,7 @@ describe('TracksApi', () => {
   let tracks: TracksApi
 
   // eslint-disable-next-line mocha/no-setup-in-describe
-  const audiusWalletClient = createAppWalletClient('0x')
+  const audiusWalletClient = createAppWalletClient({ apiKey: '' })
   const logger = new Logger()
   const discoveryNodeSelector = new DiscoveryNodeSelector()
   const storageNodeSelector = new StorageNodeSelector({

--- a/packages/sdk/src/sdk/api/users/UsersApi.test.ts
+++ b/packages/sdk/src/sdk/api/users/UsersApi.test.ts
@@ -69,7 +69,7 @@ vitest
 
 let users: UsersApi
 
-const audiusWalletClient = createAppWalletClient('0x')
+const audiusWalletClient = createAppWalletClient({ apiKey: '' })
 const logger = new Logger()
 const discoveryNodeSelector = new DiscoveryNodeSelector()
 const storageNodeSelector = new StorageNodeSelector({

--- a/packages/sdk/src/sdk/middleware/addRequestSignatureMiddleware.test.ts
+++ b/packages/sdk/src/sdk/middleware/addRequestSignatureMiddleware.test.ts
@@ -7,10 +7,11 @@ import { addRequestSignatureMiddleware } from './addRequestSignatureMiddleware'
 describe('addRequestSignatureMiddleware', () => {
   it('generates a signature', async () => {
     const services = {
-      audiusWalletClient: createAppWalletClient(
-        '0x',
-        '0x4ac8b3eff248bfbf20b324b575c1b333d42c6db3dbe19fd587c3d1e11323a25a'
-      ),
+      audiusWalletClient: createAppWalletClient({
+        apiKey: '',
+        apiSecret:
+          '0x4ac8b3eff248bfbf20b324b575c1b333d42c6db3dbe19fd587c3d1e11323a25a'
+      }),
       logger: new Logger()
     }
     const m = addRequestSignatureMiddleware({ services })
@@ -32,10 +33,11 @@ describe('addRequestSignatureMiddleware', () => {
 
   it('reuses a signature', async () => {
     const services = {
-      audiusWalletClient: createAppWalletClient(
-        '0x',
-        '0x4ac8b3eff248bfbf20b324b575c1b333d42c6db3dbe19fd587c3d1e11323a25a'
-      ),
+      audiusWalletClient: createAppWalletClient({
+        apiKey: '',
+        apiSecret:
+          '0x4ac8b3eff248bfbf20b324b575c1b333d42c6db3dbe19fd587c3d1e11323a25a'
+      }),
       logger: new Logger()
     }
     const m = addRequestSignatureMiddleware({ services })

--- a/packages/sdk/src/sdk/middleware/addRequestSignatureMiddleware.test.ts
+++ b/packages/sdk/src/sdk/middleware/addRequestSignatureMiddleware.test.ts
@@ -36,7 +36,7 @@ describe('addRequestSignatureMiddleware', () => {
       audiusWalletClient: createAppWalletClient({
         apiKey: '',
         apiSecret:
-          '0x4ac8b3eff248bfbf20b324b575c1b333d42c6db3dbe19fd587c3d1e11323a25a'
+          '4ac8b3eff248bfbf20b324b575c1b333d42c6db3dbe19fd587c3d1e11323a25a'
       }),
       logger: new Logger()
     }

--- a/packages/sdk/src/sdk/sdk.ts
+++ b/packages/sdk/src/sdk/sdk.ts
@@ -1,4 +1,4 @@
-import { createPublicClient, createWalletClient, http, type Hex } from 'viem'
+import { createPublicClient, createWalletClient, http } from 'viem'
 import { mainnet } from 'viem/chains'
 
 import { ResolveApi } from './api/ResolveApi'
@@ -152,7 +152,10 @@ const initializeServices = (config: SdkConfig) => {
   }
   const audiusWalletClient =
     config.services?.audiusWalletClient ??
-    createAppWalletClient(config.apiKey as Hex, config.apiSecret as Hex)
+    createAppWalletClient({
+      apiKey: config.apiKey!,
+      apiSecret: config.apiSecret
+    })
 
   const ethPublicClient =
     config.services?.ethPublicClient ??

--- a/packages/sdk/src/sdk/services/AudiusWalletClient/createAppWalletClient.ts
+++ b/packages/sdk/src/sdk/services/AudiusWalletClient/createAppWalletClient.ts
@@ -11,22 +11,31 @@ import { localTransport } from './localTransport'
 import { privateKeyToAudiusAccount } from './privateKeyToAudiusAccount'
 import type { AudiusAccount, AudiusWalletClient } from './types'
 
-export const createAppWalletClient = (
-  apiKey: Hex,
-  apiSecret?: Hex
-): AudiusWalletClient => {
+const ensureHex = (str: string): Hex =>
+  str.startsWith('0x') ? (str as Hex) : `0x${str}`
+
+export const createAppWalletClient = ({
+  apiKey,
+  apiSecret
+}: {
+  apiKey: string
+  apiSecret?: string
+}): AudiusWalletClient => {
   if (apiSecret) {
     return createClient({
       name: 'Audius App',
       type: 'audius',
-      account: privateKeyToAudiusAccount(apiSecret),
+      account: privateKeyToAudiusAccount(ensureHex(apiSecret)),
       transport: custom(localTransport())
     }).extend(audiusWalletActions)
   } else {
     return createClient<CustomTransport, undefined, AudiusAccount>({
       name: 'Audius Readonly App',
       type: 'audius',
-      account: { address: apiKey, type: 'local' } as LocalAccount<'custom'>,
+      account: {
+        address: ensureHex(apiKey),
+        type: 'local'
+      } as LocalAccount<'custom'>,
       transport: custom(localTransport())
     }).extend(audiusWalletActions)
   }

--- a/packages/sdk/src/sdk/services/EntityManager/EntityManager.test.ts
+++ b/packages/sdk/src/sdk/services/EntityManager/EntityManager.test.ts
@@ -29,10 +29,12 @@ vitest
   .spyOn(DiscoveryNodeSelector.prototype, 'getSelectedEndpoint')
   .mockImplementation(async () => discoveryNode)
 
-const audiusWalletClient = createAppWalletClient(userWallet).extend(() => ({
-  signTypedData: async () =>
-    '0xcfe7a6974bd1691c0a298e119318337c54bf58175f8a9a6aeeaf3b0346c6105265c83de64ab81da28266c4b5b4ff68d81d9e266f9163d7ebd5b2a52d46e275941c' as Hex
-}))
+const audiusWalletClient = createAppWalletClient({ apiKey: userWallet }).extend(
+  () => ({
+    signTypedData: async () =>
+      '0xcfe7a6974bd1691c0a298e119318337c54bf58175f8a9a6aeeaf3b0346c6105265c83de64ab81da28266c4b5b4ff68d81d9e266f9163d7ebd5b2a52d46e275941c' as Hex
+  })
+)
 const discoveryNodeSelector = new DiscoveryNodeSelector({
   initialSelectedNode: discoveryNode
 })

--- a/packages/sdk/src/sdk/services/StorageNodeSelector/StorageNodeSelector.test.ts
+++ b/packages/sdk/src/sdk/services/StorageNodeSelector/StorageNodeSelector.test.ts
@@ -31,7 +31,7 @@ const userWallet = '0xc0ffee254729296a45a3885639AC7E10F9d54979'
 
 const discoveryNode = 'https://discovery-provider.audius.co'
 
-const audiusWalletClient = createAppWalletClient(userWallet)
+const audiusWalletClient = createAppWalletClient({ apiKey: userWallet })
 const logger = new Logger()
 const discoveryNodeSelector = new DiscoveryNodeSelector({
   initialSelectedNode: discoveryNode


### PR DESCRIPTION
Allows more leniency of apiKey/apiSecret format and transforms into hex before using.

Also adjusts the createAppWalletCilent parameters to be object args

Ran tests
Verified a favorite write against client