### PR TITLE
remove `test-discovery-api` job because output is ignored

### DIFF
--- a/.circleci/src/jobs/@discovery-jobs.yml
+++ b/.circleci/src/jobs/@discovery-jobs.yml
@@ -50,16 +50,3 @@ lint-discovery-provider:
         root: ./
         paths:
           - node_modules
-
-test-discovery-api:
-  working_directory: ~/audius-protocol
-  executor: newman/postman-newman-docker
-  steps:
-    - checkout
-    - run:
-        name: Run API Tests
-        command: |
-          # Run API tests but ignore any errors
-          set +e
-          newman run ./packages/discovery-provider/api-tests/Discovery\ API\ Tests.postman_collection.json --environment ./packages/discovery-provider/api-tests/Test\ Sandbox.postman_environment.json
-          set -e

--- a/.circleci/src/workflows/discovery.yml
+++ b/.circleci/src/workflows/discovery.yml
@@ -148,12 +148,3 @@ jobs:
           only: main
       context: github
       service: discovery-provider
-
-  # Test for API regressions after deploying to stage
-  - test-discovery-api:
-      name: test-discovery-api
-      requires:
-        - deploy-stage-discovery-provider
-      filters:
-        branches:
-          only: main


### PR DESCRIPTION
### Description
- removes this flow because the output is ignored and it holds up releasing the worker for around 25 minutes
- see here https://app.circleci.com/pipelines/github/AudiusProject/audius-protocol/68096/workflows/e7931448-df03-4c4c-9a64-a28dfbd489c1/jobs/1000942?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-checks-link&utm_content=summary

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._
