### PR TITLE
Fix usage of sentry cli in CI

### DIFF
--- a/.circleci/src/commands/@mobile-commands.yml
+++ b/.circleci/src/commands/@mobile-commands.yml
@@ -63,11 +63,6 @@ mobile-prepare-ios:
         paths:
           - packages/mobile/ios/pods
     - run:
-        name: Install Sentry CLI
-        command: |
-          curl -sL https://sentry.io/get-cli/ | bash
-          echo export SENTRY_BINARY=/usr/local/bin/sentry-cli >> "$BASH_ENV"
-    - run:
         name: Build dependencies
         command: npx turbo run build --filter=@audius/mobile
     - run:

--- a/.circleci/src/jobs/@web-jobs.yml
+++ b/.circleci/src/jobs/@web-jobs.yml
@@ -270,17 +270,17 @@ web-deploy-sentry-sourcemaps:
         name: cut-sentry-release
         command: |
           cd packages/web
-          ../../node_modules/.bin/sentry-cli --auth-token ${SENTRY_AUTH_TOKEN} releases --org audius --project audius-client new ${CIRCLE_SHA1}
+          npm run sentry-cli -- --auth-token ${SENTRY_AUTH_TOKEN} releases --org audius --project audius-client new ${CIRCLE_SHA1}
     - run:
         name: upload-sourcemaps
         command: |
           cd packages/web
-          ../../node_modules/.bin/sentry-cli --auth-token ${SENTRY_AUTH_TOKEN} releases --org audius --project audius-client files ${CIRCLE_SHA1} upload-sourcemaps --no-rewrite build-production/static/js
+          npm run sentry-cli -- --auth-token ${SENTRY_AUTH_TOKEN} releases --org audius --project audius-client files ${CIRCLE_SHA1} upload-sourcemaps --no-rewrite build-production/static/js
     - run:
         name: finalize-release
         command: |
           cd packages/web
-          ../../node_modules/.bin/sentry-cli --auth-token ${SENTRY_AUTH_TOKEN} releases --org audius --project audius-client finalize ${CIRCLE_SHA1}
+          npm run sentry-cli -- --auth-token ${SENTRY_AUTH_TOKEN} releases --org audius --project audius-client finalize ${CIRCLE_SHA1}
 
 web-dist-mac-staging:
   working_directory: ~/audius-protocol

--- a/package-lock.json
+++ b/package-lock.json
@@ -136865,6 +136865,7 @@
         "@react-native/metro-config": "0.75.4",
         "@react-native/typescript-config": "0.75.4",
         "@redux-devtools/cli": "4.0.0",
+        "@sentry/cli": "2.38.2",
         "@storybook/addon-actions": "6.5.16",
         "@storybook/addon-controls": "6.5.16",
         "@storybook/addon-ondevice-actions": "6.5.7",

--- a/packages/mobile/ios/Podfile.lock
+++ b/packages/mobile/ios/Podfile.lock
@@ -2294,7 +2294,7 @@ SPEC CHECKSUMS:
   ffmpeg-kit-react-native: 3cea88c9c5cfad62e1465279ea7d800dfbba3b00
   FingerprintPro: c6444f5a00d1126446da664124529e754475f198
   fmt: 4c2741a687cc09f0634a2e2c72a838b99f1ff120
-  glog: fdfdfe5479092de0c4bdbebedd9056951f092c4f
+  glog: 69ef571f3de08433d766d614c73a9838a06bf7eb
   google-cast-sdk-dynamic-xcframework-no-bluetooth: 1fa9e267df3fd6f8a1c6e3345142ca5286297968
   hermes-engine: ea92f60f37dba025e293cbe4b4a548fd26b610a0
   JWT: ef71dfb03e1f842081e64dc42eef0e164f35d251
@@ -2303,7 +2303,7 @@ SPEC CHECKSUMS:
   lottie-react-native: e23d9bcc85c8730e79e96bdf589a1996d7d388a9
   nSure: ce410631caf715d7080838c00a42169427847a01
   PromisesObjC: f5707f49cb48b9636751c5b2e7d227e43fba9f47
-  RCT-Folly: 02617c592a293bd6d418e0a88ff4ee1f88329b47
+  RCT-Folly: 4464f4d875961fce86008d45f4ecf6cef6de0740
   RCTDeprecation: 726d24248aeab6d7180dac71a936bbca6a994ed1
   RCTRequired: a94e7febda6db0345d207e854323c37e3a31d93b
   RCTTypeSafety: 28e24a6e44f5cbf912c66dde6ab7e07d1059a205

--- a/packages/mobile/ios/scripts/bundleReactNative.sh
+++ b/packages/mobile/ios/scripts/bundleReactNative.sh
@@ -3,4 +3,4 @@ export SENTRY_PROPERTIES=sentry.properties
 export EXTRA_PACKAGER_ARGS=\"--sourcemap-output $DERIVED_FILE_DIR/main.jsbundle.map\" 
 export PROJECT_ROOT=$PWD/.. 
  
-sentry-cli react-native xcode ../../../node_modules/react-native/scripts/react-native-xcode.sh 
+npm --prefix ../ run sentry-cli react-native xcode ../../../node_modules/react-native/scripts/react-native-xcode.sh 

--- a/packages/mobile/ios/scripts/uploadSentryDebugSymbols.sh
+++ b/packages/mobile/ios/scripts/uploadSentryDebugSymbols.sh
@@ -1,4 +1,4 @@
 export NODE_BINARY=node
 export SENTRY_PROPERTIES=sentry.properties
 
-sentry-cli upload-dsym
+npm --prefix ../ run sentry-cli upload-dsym

--- a/packages/mobile/package.json
+++ b/packages/mobile/package.json
@@ -50,7 +50,8 @@
     "typecheck": "tsc",
     "upgrade": "react-native upgrade",
     "upload:ios": "xcrun altool --upload-app -type ios --file build/AudiusReactNative.ipa --username $APPLE_ID --password $APPLE_ID_PASSWORD",
-    "verify": "concurrently \"npm:typecheck\" \"npm:lint\" \"npm:lint:env\""
+    "verify": "concurrently \"npm:typecheck\" \"npm:lint\" \"npm:lint:env\"",
+    "sentry-cli": "sentry-cli"
   },
   "dependencies": {
     "@amplitude/react-native": "2.17.2",
@@ -200,6 +201,7 @@
     "@react-native/metro-config": "0.75.4",
     "@react-native/typescript-config": "0.75.4",
     "@redux-devtools/cli": "4.0.0",
+    "@sentry/cli": "2.38.2",
     "@storybook/addon-actions": "6.5.16",
     "@storybook/addon-controls": "6.5.16",
     "@storybook/addon-ondevice-actions": "6.5.7",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -48,6 +48,7 @@
     "write-sha": "./scripts/writeSHA.sh",
     "pw-ui": "npx playwright test --ui",
     "pw": "npx playwright test",
+    "sentry-cli": "sentry-cli",
     "ELECTRON========================================": "",
     "dist-publish-production": "npm run dist -- --mac --win --linux --publish always --env production",
     "dist-publish": "npm run dist -- --mac --win --linux --publish always",


### PR DESCRIPTION
### Description

Upload of sourcemaps broken on CI currently
https://app.circleci.com/pipelines/github/AudiusProject/audius-protocol/68085/workflows/8afcb8c3-463e-4963-ab72-e123239a781c/jobs/1000782

`pnpm` would be nice here, but this works using npm's script module resolution. Remove redundant install in mobile.

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._

For web, was able to test via rerunning job with CI

For mobile, was only able to test locally that the script does find the right binary. Will test again on CI