### PR TITLE
[PAY-3715][PAY-3754] Update playlists in navbar

### DIFF
--- a/packages/harmony/src/components/expandable-nav-item/ExpandableNavItem.tsx
+++ b/packages/harmony/src/components/expandable-nav-item/ExpandableNavItem.tsx
@@ -8,7 +8,24 @@ import { Box } from '../layout/Box'
 import { Flex } from '../layout/Flex'
 import { Text } from '../text'
 
-import type { ExpandableNavItemProps } from './types'
+import type { ExpandableNavItemProps, VariantConfigs } from './types'
+
+const variants: VariantConfigs = {
+  default: {
+    textVariant: 'title',
+    textSize: 'l',
+    textStrength: 'weak',
+    iconSize: 'l',
+    gap: 'm'
+  },
+  compact: {
+    textVariant: 'body',
+    textSize: 's',
+    textStrength: undefined,
+    iconSize: 's',
+    gap: 'xs'
+  }
+}
 
 const getStyles = (theme: HarmonyTheme, isHovered: boolean): CSSObject => {
   const baseStyles: CSSObject = {
@@ -36,6 +53,7 @@ export const ExpandableNavItem = ({
   nestedItems,
   shouldPersistRightIcon = false,
   canUnfurl = true,
+  variant = 'default',
   ...props
 }: ExpandableNavItemProps) => {
   const [isOpen, setIsOpen] = useState(defaultIsOpen)
@@ -63,11 +81,11 @@ export const ExpandableNavItem = ({
     }
 
     if (LeftIcon) {
-      return <LeftIcon size='l' color='default' />
+      return <LeftIcon size={variants[variant].iconSize} color='default' />
     }
 
     return null
-  }, [isHovered, isOpen, LeftIcon, canUnfurl])
+  }, [isHovered, canUnfurl, LeftIcon, isOpen, variant])
 
   const leftIcon = useMemo(() => {
     if (!getIcon) return null
@@ -115,7 +133,7 @@ export const ExpandableNavItem = ({
         >
           <Flex
             alignItems='center'
-            gap='m'
+            gap={variants[variant].gap}
             flex={1}
             css={{
               maxWidth: '240px'
@@ -123,9 +141,9 @@ export const ExpandableNavItem = ({
           >
             {leftIcon}
             <Text
-              variant='title'
-              size='l'
-              strength='weak'
+              variant={variants[variant].textVariant}
+              size={variants[variant].textSize}
+              strength={variants[variant].textStrength}
               lineHeight='single'
               color='default'
               ellipses

--- a/packages/harmony/src/components/expandable-nav-item/types.ts
+++ b/packages/harmony/src/components/expandable-nav-item/types.ts
@@ -3,6 +3,18 @@ import type { ReactNode } from 'react'
 import type { WithCSS } from '../../foundations/theme'
 import type { IconComponent } from '../icon'
 
+export type ExpandableNavItemVariant = 'default' | 'compact'
+
+export type VariantConfig = {
+  textVariant: 'title' | 'body'
+  textSize: 'l' | 's'
+  textStrength: 'weak' | undefined
+  iconSize: 'l' | 's'
+  gap: 'm' | 'xs'
+}
+
+export type VariantConfigs = Record<ExpandableNavItemVariant, VariantConfig>
+
 export type ExpandableNavItemProps = WithCSS<{
   /** The label text of the navigation item. */
   label: string
@@ -18,4 +30,6 @@ export type ExpandableNavItemProps = WithCSS<{
   shouldPersistRightIcon?: boolean
   /** Whether the nav item can be unfurled. */
   canUnfurl?: boolean
+  /** The variant of the nav item. */
+  variant?: ExpandableNavItemVariant
 }>

--- a/packages/harmony/src/components/nav-item/NavItem.tsx
+++ b/packages/harmony/src/components/nav-item/NavItem.tsx
@@ -92,6 +92,7 @@ export const NavItem = ({
             lineHeight='single'
             color={textColor}
             ellipses
+            css={{ flex: 1 }}
           >
             {children}
           </Text>

--- a/packages/web/src/components/nav/desktop/LeftNavLink.tsx
+++ b/packages/web/src/components/nav/desktop/LeftNavLink.tsx
@@ -1,5 +1,5 @@
 import { NavItem, NavItemProps } from '@audius/harmony'
-import { Link, useLocation } from 'react-router-dom'
+import { NavLink, useLocation } from 'react-router-dom'
 
 import {
   RestrictionType,
@@ -36,7 +36,7 @@ export const LeftNavLink = (props: LeftNavLinkProps) => {
   }
 
   return (
-    <Link
+    <NavLink
       to={to ?? ''}
       onClick={handleClick}
       style={{ pointerEvents: disabled ? 'none' : 'auto' }}
@@ -52,6 +52,6 @@ export const LeftNavLink = (props: LeftNavLinkProps) => {
       >
         {children}
       </NavItem>
-    </Link>
+    </NavLink>
   )
 }

--- a/packages/web/src/components/nav/desktop/NotificationsButton.tsx
+++ b/packages/web/src/components/nav/desktop/NotificationsButton.tsx
@@ -51,7 +51,7 @@ export const NotificationsButton = () => {
     )
     if (shouldShowCount) {
       return (
-        <NotificationCount count={notificationCount}>
+        <NotificationCount size='m' count={notificationCount}>
           {button}
         </NotificationCount>
       )

--- a/packages/web/src/components/nav/desktop/PlaylistLibrary/CollectionNavItem.tsx
+++ b/packages/web/src/components/nav/desktop/PlaylistLibrary/CollectionNavItem.tsx
@@ -1,11 +1,11 @@
 import { useCallback, useState } from 'react'
 
 import {
-  Name,
-  ShareSource,
   ID,
+  Name,
   PlaylistLibraryID,
-  PlaylistLibraryKind
+  PlaylistLibraryKind,
+  ShareSource
 } from '@audius/common/models'
 import {
   cacheCollectionsActions,
@@ -14,9 +14,15 @@ import {
   playlistLibraryActions,
   shareModalUIActions
 } from '@audius/common/store'
-import { Flex, PopupMenuItem, useTheme } from '@audius/harmony'
+import {
+  Flex,
+  IconSpeaker,
+  PopupMenuItem,
+  Text,
+  useTheme
+} from '@audius/harmony'
 import { useDispatch } from 'react-redux'
-import { useNavigate } from 'react-router-dom-v5-compat'
+import { useLocation, useNavigate } from 'react-router-dom-v5-compat'
 import { useToggle } from 'react-use'
 
 import { make, useRecord } from 'common/store/analytics/actions'
@@ -24,8 +30,8 @@ import { Draggable } from 'components/dragndrop'
 import { DeleteCollectionConfirmationModal } from 'components/edit-collection/DeleteCollectionConfirmationModal'
 import {
   DragDropKind,
-  selectDraggingKind,
-  selectDraggingId
+  selectDraggingId,
+  selectDraggingKind
 } from 'store/dragndrop/slice'
 import { useSelector } from 'utils/reducer'
 import { BASE_URL } from 'utils/route'
@@ -35,10 +41,11 @@ import { LeftNavLink } from '../LeftNavLink'
 
 import { NavItemKebabButton } from './NavItemKebabButton'
 import { PlaylistUpdateDot } from './PlaylistUpdateDot'
+import { usePlaylistPlayingStatus } from './usePlaylistPlayingStatus'
 
-const { getTrack } = cacheTracksSelectors
 const { addTrackToPlaylist } = cacheCollectionsActions
 const { getCollection } = cacheCollectionsSelectors
+const { getTrack } = cacheTracksSelectors
 const { reorder } = playlistLibraryActions
 const { requestOpen } = shareModalUIActions
 
@@ -70,6 +77,8 @@ export const CollectionNavItem = (props: CollectionNavItemProps) => {
   const { id, name, url, isOwned, level, hasUpdate, onClick } = props
   const [isDraggingOver, setIsDraggingOver] = useState(false)
   const [isHovering, setIsHovering] = useState(false)
+  const location = useLocation()
+  const isSelected = location.pathname === url
   const dispatch = useDispatch()
   const record = useRecord()
   const navigate = useNavigate()
@@ -166,6 +175,8 @@ export const CollectionNavItem = (props: CollectionNavItemProps) => {
     (draggingKind === 'playlist-folder' && level > 0) ||
     hiddenTrackCheck
 
+  const isPlayingFromThisPlaylist = usePlaylistPlayingStatus(id)
+
   if (!name || !url) return null
 
   const indentAmount = level * spacing.l
@@ -176,6 +187,7 @@ export const CollectionNavItem = (props: CollectionNavItemProps) => {
         acceptedKinds={acceptedKinds}
         onDrop={handleDrop}
         disabled={isDisabled}
+        data-testid='collection-nav-droppable'
       >
         <Draggable
           id={id}
@@ -183,6 +195,7 @@ export const CollectionNavItem = (props: CollectionNavItemProps) => {
           // Draggables require full URL
           link={`${BASE_URL}${url}`}
           kind='library-playlist'
+          data-testid='collection-nav-item'
         >
           <LeftNavLink
             to={url}
@@ -193,6 +206,15 @@ export const CollectionNavItem = (props: CollectionNavItemProps) => {
             onMouseEnter={handleMouseEnter}
             onMouseLeave={handleMouseLeave}
             textSize='s'
+            rightIcon={
+              isPlayingFromThisPlaylist ? (
+                <IconSpeaker
+                  size='s'
+                  color={isSelected ? 'staticWhite' : 'accent'}
+                />
+              ) : null
+            }
+            data-testid='collection-nav-item'
           >
             <Flex
               alignItems='center'
@@ -200,6 +222,8 @@ export const CollectionNavItem = (props: CollectionNavItemProps) => {
               pl={indentAmount}
               gap='xs'
               css={{ position: 'relative' }}
+              data-testid='collection-nav-item-inner'
+              justifyContent='space-between'
             >
               {hasUpdate ? (
                 <div
@@ -211,11 +235,20 @@ export const CollectionNavItem = (props: CollectionNavItemProps) => {
                   <PlaylistUpdateDot />
                 </div>
               ) : null}
-              {name}
+              <Text
+                variant='body'
+                size='s'
+                css={{ maxWidth: '160px' }}
+                ellipses
+              >
+                {name}
+              </Text>
               <NavItemKebabButton
                 visible={isOwned && isHovering && !isDraggingOver}
                 aria-label={messages.editPlaylistLabel}
                 items={kebabItems}
+                isSelected={isSelected}
+                data-testid='collection-nav-item-kebab'
               />
             </Flex>
           </LeftNavLink>

--- a/packages/web/src/components/nav/desktop/PlaylistLibrary/CollectionNavItem.tsx
+++ b/packages/web/src/components/nav/desktop/PlaylistLibrary/CollectionNavItem.tsx
@@ -187,7 +187,6 @@ export const CollectionNavItem = (props: CollectionNavItemProps) => {
         acceptedKinds={acceptedKinds}
         onDrop={handleDrop}
         disabled={isDisabled}
-        data-testid='collection-nav-droppable'
       >
         <Draggable
           id={id}
@@ -195,7 +194,6 @@ export const CollectionNavItem = (props: CollectionNavItemProps) => {
           // Draggables require full URL
           link={`${BASE_URL}${url}`}
           kind='library-playlist'
-          data-testid='collection-nav-item'
         >
           <LeftNavLink
             to={url}
@@ -214,7 +212,6 @@ export const CollectionNavItem = (props: CollectionNavItemProps) => {
                 />
               ) : null
             }
-            data-testid='collection-nav-item'
           >
             <Flex
               alignItems='center'
@@ -222,7 +219,6 @@ export const CollectionNavItem = (props: CollectionNavItemProps) => {
               pl={indentAmount}
               gap='xs'
               css={{ position: 'relative' }}
-              data-testid='collection-nav-item-inner'
               justifyContent='space-between'
             >
               {hasUpdate ? (
@@ -248,7 +244,6 @@ export const CollectionNavItem = (props: CollectionNavItemProps) => {
                 aria-label={messages.editPlaylistLabel}
                 items={kebabItems}
                 isSelected={isSelected}
-                data-testid='collection-nav-item-kebab'
               />
             </Flex>
           </LeftNavLink>

--- a/packages/web/src/components/nav/desktop/PlaylistLibrary/NavItemKebabButton.tsx
+++ b/packages/web/src/components/nav/desktop/PlaylistLibrary/NavItemKebabButton.tsx
@@ -11,10 +11,11 @@ import {
 type EditNavItemButtonProps = Omit<IconButtonProps, 'icon'> & {
   visible: boolean
   items: PopupMenuProps['items']
+  isSelected?: boolean
 }
 
 export const NavItemKebabButton = (props: EditNavItemButtonProps) => {
-  const { visible, items, ...other } = props
+  const { visible, items, isSelected, ...other } = props
 
   return (
     <PopupMenu
@@ -38,11 +39,15 @@ export const NavItemKebabButton = (props: EditNavItemButtonProps) => {
               flexShrink: 0,
               pointerEvents: visible ? 'all' : 'none',
               '& path': {
-                fill: 'var(--harmony-n-700)'
+                fill: isSelected
+                  ? 'var(--harmony-static-static-white)'
+                  : 'var(--harmony-n-700)'
               },
               ':hover,:active,:focus,:hover path, :active path, :focus path': {
                 color: 'var(--harmony-neutral)',
-                fill: 'var(--harmony-n-950)'
+                fill: isSelected
+                  ? 'var(--harmony-static-static-white)'
+                  : 'var(--harmony-n-950)'
               }
             }}
             icon={IconKebabHorizontal}

--- a/packages/web/src/components/nav/desktop/PlaylistLibrary/PlaylistFolderNavItem.tsx
+++ b/packages/web/src/components/nav/desktop/PlaylistLibrary/PlaylistFolderNavItem.tsx
@@ -11,7 +11,12 @@ import {
   modalsActions,
   playlistUpdatesSelectors
 } from '@audius/common/store'
-import { IconFolder, PopupMenuItem, ExpandableNavItem } from '@audius/harmony'
+import {
+  IconFolder,
+  PopupMenuItem,
+  ExpandableNavItem,
+  Box
+} from '@audius/harmony'
 import { ClassNames } from '@emotion/react'
 import { useDispatch } from 'react-redux'
 import { useToggle } from 'react-use'
@@ -22,6 +27,7 @@ import { setFolderId as setEditFolderModalFolderId } from 'store/application/ui/
 import { DragDropKind, selectDraggingKind } from 'store/dragndrop/slice'
 import { useSelector } from 'utils/reducer'
 
+import { DeleteFolderConfirmationModal } from './DeleteFolderConfirmationModal'
 import { NavItemKebabButton } from './NavItemKebabButton'
 import { PlaylistLibraryNavItem, keyExtractor } from './PlaylistLibraryNavItem'
 
@@ -59,7 +65,8 @@ export const PlaylistFolderNavItem = (props: PlaylistFolderNavItemProps) => {
   const [isHovering, setIsHovering] = useState(false)
   const dispatch = useDispatch()
   const record = useRecord()
-  const [, toggleDeleteConfirmationOpen] = useToggle(false)
+  const [isDeleteConfirmationOpen, toggleDeleteConfirmationOpen] =
+    useToggle(false)
 
   const isDisabled = draggingKind && !acceptedKinds.includes(draggingKind)
 
@@ -176,7 +183,7 @@ export const PlaylistFolderNavItem = (props: PlaylistFolderNavItemProps) => {
           disabled={isDisabled}
         >
           <Draggable id={id} text={name} kind='playlist-folder'>
-            <div
+            <Box
               onMouseEnter={handleMouseEnter}
               onMouseLeave={handleMouseLeave}
               onDragEnter={handleDragEnter}
@@ -193,7 +200,12 @@ export const PlaylistFolderNavItem = (props: PlaylistFolderNavItemProps) => {
                 nestedItems={nestedItems}
                 variant='compact'
               />
-            </div>
+              <DeleteFolderConfirmationModal
+                folderId={id}
+                visible={isDeleteConfirmationOpen}
+                onCancel={toggleDeleteConfirmationOpen}
+              />
+            </Box>
           </Draggable>
         </Droppable>
       )}

--- a/packages/web/src/components/nav/desktop/PlaylistLibrary/PlaylistFolderNavItem.tsx
+++ b/packages/web/src/components/nav/desktop/PlaylistLibrary/PlaylistFolderNavItem.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useState, MouseEvent, useEffect, useMemo } from 'react'
+import { useCallback, useState, MouseEvent, useMemo } from 'react'
 
 import {
   Name,
@@ -39,8 +39,6 @@ type PlaylistFolderNavItemProps = {
   folder: PlaylistLibraryFolder
   level: number
 }
-
-const longDragTimeoutMs = 1000
 
 const acceptedKinds: DragDropKind[] = ['playlist', 'library-playlist']
 
@@ -120,13 +118,6 @@ export const PlaylistFolderNavItem = (props: PlaylistFolderNavItemProps) => {
     ],
     [handleClickEdit, toggleDeleteConfirmationOpen]
   )
-
-  useEffect(() => {
-    if (isDraggingOver) {
-      const longDragTimeout = setTimeout(() => {}, longDragTimeoutMs)
-      return () => clearTimeout(longDragTimeout)
-    }
-  }, [isDraggingOver])
 
   const rightIcon = useMemo(() => {
     return isHovering && !isDraggingOver ? (

--- a/packages/web/src/components/nav/desktop/PlaylistLibrary/usePlaylistPlayingStatus.ts
+++ b/packages/web/src/components/nav/desktop/PlaylistLibrary/usePlaylistPlayingStatus.ts
@@ -1,0 +1,51 @@
+import { useMemo } from 'react'
+
+import { PlaylistLibraryID } from '@audius/common/models'
+import {
+  cacheCollectionsSelectors,
+  playerSelectors,
+  queueSelectors,
+  QueueSource,
+  CommonState
+} from '@audius/common/store'
+import { Uid } from '@audius/common/utils'
+import { useSelector } from 'react-redux'
+
+const { getCollection } = cacheCollectionsSelectors
+const { getTrackId, getPlaying } = playerSelectors
+const { getSource, getUid } = queueSelectors
+
+/**
+ * Used to determine if a track from a specific playlist is currently playing.
+ *
+ * @param {PlaylistLibraryID} id - The ID of the playlist to check against.
+ * @returns {boolean} - Returns true if the current track is from the specified playlist and is playing, otherwise false.
+ */
+export const usePlaylistPlayingStatus = (id: PlaylistLibraryID) => {
+  const currentTrackId = useSelector(getTrackId)
+  const isPlaying = useSelector(getPlaying)
+  const queueSource = useSelector(getSource)
+  const currentUid = useSelector(getUid)
+
+  const collection = useSelector((state: CommonState) =>
+    getCollection(state, { id: typeof id === 'string' ? null : id })
+  )
+
+  return useMemo(() => {
+    const hasTracks = collection?.playlist_contents?.track_ids
+    const hasCurrentTrack = currentTrackId
+
+    if (!hasTracks || !hasCurrentTrack || !isPlaying) return false
+
+    const hasTrack = collection.playlist_contents.track_ids.some(
+      (trackItem) => trackItem.track === currentTrackId
+    )
+
+    const isSource =
+      currentUid &&
+      queueSource === QueueSource.COLLECTION_TRACKS &&
+      Uid.fromString(currentUid).source === `collection:${id}`
+
+    return hasTrack && isSource
+  }, [collection, currentTrackId, isPlaying, currentUid, queueSource, id])
+}

--- a/packages/web/src/components/nav/desktop/PlaylistLibrary/usePlaylistPlayingStatus.ts
+++ b/packages/web/src/components/nav/desktop/PlaylistLibrary/usePlaylistPlayingStatus.ts
@@ -33,9 +33,8 @@ export const usePlaylistPlayingStatus = (id: PlaylistLibraryID) => {
 
   return useMemo(() => {
     const hasTracks = collection?.playlist_contents?.track_ids
-    const hasCurrentTrack = currentTrackId
 
-    if (!hasTracks || !hasCurrentTrack || !isPlaying) return false
+    if (!hasTracks || !currentTrackId || !isPlaying) return false
 
     const hasTrack = collection.playlist_contents.track_ids.some(
       (trackItem) => trackItem.track === currentTrackId


### PR DESCRIPTION
### Description

Here's a PR description for the changes shown in the diff:

This PR enhances the playlist library navigation with several UI/UX improvements including a new compact variant for the ExpandableNavItem component, better visual indicators for playing playlists, and improved folder navigation. Essentially implements the changes found [here](https://www.figma.com/design/l1Fn3uZ3lenie0apeS0YM3/%F0%9F%93%8D-Navigation-Redesign?node-id=186-145835&t=AaKYR2LzIh18MW3P-0).

## Changes
- Added a new `compact` variant to `ExpandableNavItem` with smaller text and spacing
- Introduced playing status indicator (speaker icon) for currently playing playlists
- Refactored `PlaylistFolderNavItem` to use `ExpandableNavItem` component
- Added proper text ellipsis handling for long playlist names
- Updated `NavItemKebabButton` to handle selected state styling
- Switched from `Link` to `NavLink` in `LeftNavLink` for better active state handling
- Added proper size prop to `NotificationCount` component
- Introduced `usePlaylistPlayingStatus` hook to track currently playing playlist

## Technical Details
- Created variant configuration system in `ExpandableNavItem` for consistent styling
- Added proper flex layout handling for text overflow

### How Has This Been Tested?

- Verify playlist folder expansion/collapse behavior
- Check playing status indicator appears correctly when playing from a playlist
- Verify long playlist names properly truncate
- Ensure kebab menu styling is correct in both selected/unselected states
