### PR TITLE
Init history outside of context so it can't change

### DIFF
--- a/packages/web/src/app/HistoryProvider.tsx
+++ b/packages/web/src/app/HistoryProvider.tsx
@@ -1,4 +1,4 @@
-import { createContext, memo, useContext, useMemo } from 'react'
+import { createContext, memo, useContext } from 'react'
 
 import {
   History,
@@ -26,26 +26,28 @@ export const HistoryContext = createContext<HistoryContextType>({
 const USE_HASH_ROUTING = env.USE_HASH_ROUTING
 const basename = env.BASENAME
 
+const getHistoryForEnvironment = () => {
+  if (process.env.NODE_ENV === 'test') {
+    return createMemoryHistory()
+  } else if (USE_HASH_ROUTING) {
+    const config: HashHistoryBuildOptions = {}
+    if (basename) {
+      config.basename = basename
+    }
+    return createHashHistory(config)
+  } else {
+    const config: BrowserHistoryBuildOptions = {}
+    if (basename) {
+      config.basename = basename
+    }
+    return createBrowserHistory(config)
+  }
+}
+
+const history = getHistoryForEnvironment()
+
 export const HistoryContextProvider = memo(
   (props: { children: JSX.Element }) => {
-    const history = useMemo(() => {
-      if (process.env.NODE_ENV === 'test') {
-        return createMemoryHistory()
-      } else if (USE_HASH_ROUTING) {
-        const config: HashHistoryBuildOptions = {}
-        if (basename) {
-          config.basename = basename
-        }
-        return createHashHistory(config)
-      } else {
-        const config: BrowserHistoryBuildOptions = {}
-        if (basename) {
-          config.basename = basename
-        }
-        return createBrowserHistory(config)
-      }
-    }, [])
-
     return (
       <HistoryContext.Provider value={{ history }}>
         {props.children}


### PR DESCRIPTION
### Description
Initializing history doesn't rely on any of the props of the provider, so we don't need to initialize it inside the component.
`useMemo` isn't guaranteed to keep its value over time, and reinitializing history after app start will cause all sorts of problems. 😄 

```You should only rely on useMemo as a performance optimization. If your code doesn’t work without it, find the underlying problem and fix it first. Then you may add useMemo to improve performance.```

### How Has This Been Tested?
Local client against staging.
