### PR TITLE
don't forward sol listens in dev or stage

### DIFF
--- a/packages/discovery-provider/plugins/pedalboard/apps/solana-relay/src/config.ts
+++ b/packages/discovery-provider/plugins/pedalboard/apps/solana-relay/src/config.ts
@@ -28,6 +28,7 @@ type FeePayerWallet = {
 }
 
 type Config = {
+  environment: string
   endpoint: string
   discoveryDbConnectionString: string
   redisUrl: string
@@ -64,6 +65,9 @@ const readConfig = (): Config => {
 
   // validate env
   const env = cleanEnv(process.env, {
+    audius_discprov_env: str({
+      default: 'dev'
+    }),
     audius_discprov_url: str({
       default: 'http://audius-protocol-discovery-provider-1'
     }),
@@ -150,6 +154,7 @@ const readConfig = (): Config => {
     : Buffer.from([])
 
   cachedConfig = {
+    environment: env.audius_discprov_env,
     endpoint: env.audius_discprov_url,
     discoveryDbConnectionString: env.audius_db_url,
     redisUrl: env.audius_redis_url,

--- a/packages/discovery-provider/plugins/pedalboard/apps/solana-relay/src/routes/listen/listen.ts
+++ b/packages/discovery-provider/plugins/pedalboard/apps/solana-relay/src/routes/listen/listen.ts
@@ -205,8 +205,11 @@ export const listen = async (
 ) => {
   let logger
   try {
+    logger = res.locals.logger
+
     // if not prod, just return 200
     if (config.environment !== 'prod') {
+      logger.info('not prod, skipping listen')
       res.send(200).json({
         solTxSignature: null
       })
@@ -215,7 +218,6 @@ export const listen = async (
     }
 
     // validation
-    logger = res.locals.logger
     const { userId, timestamp, signature } = recordListenBodySchema.parse(
       req.body
     )

--- a/packages/discovery-provider/plugins/pedalboard/apps/solana-relay/src/routes/listen/listen.ts
+++ b/packages/discovery-provider/plugins/pedalboard/apps/solana-relay/src/routes/listen/listen.ts
@@ -205,6 +205,15 @@ export const listen = async (
 ) => {
   let logger
   try {
+    // if not prod, just return 200
+    if (config.environment !== 'prod') {
+      res.send(200).json({
+        solTxSignature: null
+      })
+      next()
+      return
+    }
+
     // validation
     logger = res.locals.logger
     const { userId, timestamp, signature } = recordListenBodySchema.parse(

--- a/packages/discovery-provider/plugins/pedalboard/apps/solana-relay/src/routes/listen/listen.ts
+++ b/packages/discovery-provider/plugins/pedalboard/apps/solana-relay/src/routes/listen/listen.ts
@@ -210,7 +210,7 @@ export const listen = async (
     // if not prod, just return 200
     if (config.environment !== 'prod') {
       logger.info('not prod, skipping listen')
-      res.send(200).json({
+      res.status(200).json({
         solTxSignature: null
       })
       next()

--- a/packages/identity-service/src/routes/trackListens.js
+++ b/packages/identity-service/src/routes/trackListens.js
@@ -474,9 +474,12 @@ module.exports = function (app) {
           const endpoint = `${getDiscoveryListensEndpoint()}/solana/tracks/${trackId}/listen`
           const res = await axios.post(endpoint, body, { headers })
           if (res === null) {
-            throw new Error(
-              'failed to forward listen to discovery, sending to solana'
-            )
+            const env = config.get('environment')
+            if (env === 'prod') {
+              throw new Error(
+                'failed to forward listen to discovery, sending to solana'
+              )
+            }
           }
 
           req.logger.info(


### PR DESCRIPTION
### Description
- cuts off solana listens at the plugin since we're using core on both dev and stage
- prod is still allowed passage, for now

### How Has This Been Tested?
`audius-compose up`
`npm run web:dev`
listen to a few tracks and make sure counts increase as expected and web doesn't crash with the `null` being returned
