### PR TITLE
Init history with useState to fix tests

### DIFF
--- a/packages/web/src/app/HistoryProvider.tsx
+++ b/packages/web/src/app/HistoryProvider.tsx
@@ -1,4 +1,4 @@
-import { createContext, memo, useContext } from 'react'
+import { createContext, memo, useContext, useState } from 'react'
 
 import {
   History,
@@ -44,10 +44,9 @@ const getHistoryForEnvironment = () => {
   }
 }
 
-const history = getHistoryForEnvironment()
-
 export const HistoryContextProvider = memo(
   (props: { children: JSX.Element }) => {
+    const [history] = useState(() => getHistoryForEnvironment())
     return (
       <HistoryContext.Provider value={{ history }}>
         {props.children}


### PR DESCRIPTION
### Description
Turns out initializing the history once per module load breaks the tests. So I updated it to just be once per component mounting.

### How Has This Been Tested?
Ran local tests and verified history only created once when running the app.
