### PR TITLE
[PAY-3706] Add history settings card

### DIFF
--- a/packages/web/src/pages/settings-page/components/desktop/ListeningHistory/ListeningHistorySettingsCard.tsx
+++ b/packages/web/src/pages/settings-page/components/desktop/ListeningHistory/ListeningHistorySettingsCard.tsx
@@ -1,0 +1,34 @@
+import { useCallback } from 'react'
+
+import { Button, IconListeningHistory } from '@audius/harmony'
+import { useDispatch } from 'react-redux'
+
+import { push } from 'utils/navigation'
+
+import SettingsCard from '../SettingsCard'
+
+const messages = {
+  title: 'Listening History',
+  description: "Review the songs you've listened to on Audius.",
+  buttonText: 'View Listening History'
+}
+
+export const ListeningHistorySettingsCard = () => {
+  const dispatch = useDispatch()
+
+  const handleClick = useCallback(() => {
+    dispatch(push('/history'))
+  }, [dispatch])
+
+  return (
+    <SettingsCard
+      icon={<IconListeningHistory />}
+      title={messages.title}
+      description={messages.description}
+    >
+      <Button variant='secondary' onClick={handleClick} fullWidth>
+        {messages.buttonText}
+      </Button>
+    </SettingsCard>
+  )
+}

--- a/packages/web/src/pages/settings-page/components/desktop/ListeningHistory/ListeningHistorySettingsCard.tsx
+++ b/packages/web/src/pages/settings-page/components/desktop/ListeningHistory/ListeningHistorySettingsCard.tsx
@@ -1,11 +1,14 @@
 import { useCallback } from 'react'
 
+import { route } from '@audius/common/utils'
 import { Button, IconListeningHistory } from '@audius/harmony'
 import { useDispatch } from 'react-redux'
 
 import { push } from 'utils/navigation'
 
 import SettingsCard from '../SettingsCard'
+
+const { HISTORY_PAGE } = route
 
 const messages = {
   title: 'Listening History',
@@ -17,7 +20,7 @@ export const ListeningHistorySettingsCard = () => {
   const dispatch = useDispatch()
 
   const handleClick = useCallback(() => {
-    dispatch(push('/history'))
+    dispatch(push(HISTORY_PAGE))
   }, [dispatch])
 
   return (

--- a/packages/web/src/pages/settings-page/components/desktop/ListeningHistory/index.ts
+++ b/packages/web/src/pages/settings-page/components/desktop/ListeningHistory/index.ts
@@ -1,0 +1,1 @@
+export * from './ListeningHistorySettingsCard'

--- a/packages/web/src/pages/settings-page/components/desktop/SettingsPage.tsx
+++ b/packages/web/src/pages/settings-page/components/desktop/SettingsPage.tsx
@@ -77,6 +77,7 @@ import packageInfo from '../../../../../package.json'
 
 import { AuthorizedAppsSettingsCard } from './AuthorizedApps'
 import { DeveloperAppsSettingsCard } from './DeveloperApps'
+import { ListeningHistorySettingsCard } from './ListeningHistory'
 import { AccountsManagingYouSettingsCard } from './ManagerMode/AccountsManagingYouSettingsCard'
 import { AccountsYouManageSettingsCard } from './ManagerMode/AccountsYouManageSettingsCard'
 import NotificationSettings from './NotificationSettings'
@@ -546,6 +547,7 @@ export const SettingsPage = () => {
 
         <AuthorizedAppsSettingsCard />
         <DeveloperAppsSettingsCard />
+        <ListeningHistorySettingsCard />
         <PayoutWalletSettingsCard />
       </div>
       <div className={styles.version}>


### PR DESCRIPTION
### Description

Adds a listening history settings card

### How Has This Been Tested?

`npm run web:stage` and navigating to settings, scroll to bottom, click the associated card it should navigate to `/history`

<img width="376" alt="image" src="https://github.com/user-attachments/assets/4a899ee3-8243-4b4f-ba15-36c0cc129595" />

