### PR TITLE
Allow undefined apiKey

### DIFF
--- a/packages/sdk/src/sdk/sdk.ts
+++ b/packages/sdk/src/sdk/sdk.ts
@@ -153,7 +153,8 @@ const initializeServices = (config: SdkConfig) => {
   const audiusWalletClient =
     config.services?.audiusWalletClient ??
     createAppWalletClient({
-      apiKey: config.apiKey!,
+      // Allow undefined apiKey for now, use dummy wallet
+      apiKey: config.apiKey ?? '0x0000000000000000000000000000000000000000',
       apiSecret: config.apiSecret
     })
 


### PR DESCRIPTION
### Description

Accidentally left this out of https://github.com/AudiusProject/audius-protocol/pull/10974

This should enable appName only instances of SDK