### PR TITLE
Mobile left nav drawer not scrollable

### DIFF
--- a/packages/mobile/src/screens/app-drawer-screen/left-nav-drawer/LeftNavDrawer.tsx
+++ b/packages/mobile/src/screens/app-drawer-screen/left-nav-drawer/LeftNavDrawer.tsx
@@ -1,6 +1,5 @@
 import { accountSelectors } from '@audius/common/store'
 import type { DrawerContentComponentProps } from '@react-navigation/drawer'
-import { DrawerContentScrollView } from '@react-navigation/drawer'
 import { useSelector } from 'react-redux'
 
 import { IconAudiusLogo, Flex } from '@audius/harmony-native'
@@ -35,25 +34,25 @@ const WrappedLeftNavDrawer = () => {
   const { navItems } = useNavConfig()
 
   return (
-    <DrawerContentScrollView>
-      <AccountDetails />
-      <VanityMetrics />
-      {navItems.map((item) => (
-        <LeftNavLink
-          key={item.label}
-          icon={item.icon}
-          label={item.label}
-          to={item.to}
-          params={item.params}
-          onPress={item.onPress}
-          showNotificationBubble={item.showNotificationBubble}
-        >
-          {item.rightIcon}
-        </LeftNavLink>
-      ))}
-      <Flex pt='5xl' ph='l'>
-        <IconAudiusLogo color='subdued' />
+    <Flex h='95%' pt='unit16' justifyContent='space-between'>
+      <Flex>
+        <AccountDetails />
+        <VanityMetrics />
+        {navItems.map((item) => (
+          <LeftNavLink
+            key={item.label}
+            icon={item.icon}
+            label={item.label}
+            to={item.to}
+            params={item.params}
+            onPress={item.onPress}
+            showNotificationBubble={item.showNotificationBubble}
+          >
+            {item.rightIcon}
+          </LeftNavLink>
+        ))}
       </Flex>
-    </DrawerContentScrollView>
+      <IconAudiusLogo color='subdued' />
+    </Flex>
   )
 }

--- a/packages/mobile/src/screens/app-drawer-screen/left-nav-drawer/LeftNavDrawer.tsx
+++ b/packages/mobile/src/screens/app-drawer-screen/left-nav-drawer/LeftNavDrawer.tsx
@@ -34,7 +34,7 @@ const WrappedLeftNavDrawer = () => {
   const { navItems } = useNavConfig()
 
   return (
-    <Flex h='95%' pt='unit16' justifyContent='space-between'>
+    <Flex h='100%' pv='unit16' justifyContent='space-between'>
       <Flex>
         <AccountDetails />
         <VanityMetrics />


### PR DESCRIPTION
### Description
Make the mobile left nav drawer not scrollable.

Note - not sure if `h='95%'` is jank

### How Has This Been Tested?

![simulator_screenshot_214F0142-FFC2-4DED-8912-18ADE1271CC3](https://github.com/user-attachments/assets/3755d8a7-eafa-402e-961a-d6d47e026e5f)
