### PR TITLE
Address bugbash comments

### DIFF
--- a/packages/harmony/src/components/expandable-nav-item/ExpandableNavItem.tsx
+++ b/packages/harmony/src/components/expandable-nav-item/ExpandableNavItem.tsx
@@ -30,13 +30,12 @@ const variants: VariantConfigs = {
 const getStyles = (theme: HarmonyTheme, isHovered: boolean): CSSObject => {
   const baseStyles: CSSObject = {
     transition: `background-color ${theme.motion.hover}`,
-    cursor: 'pointer',
-    border: `1px solid transparent`
+    cursor: 'pointer'
   }
 
   const hoverStyles: CSSObject = {
     backgroundColor: theme.color.background.surface2,
-    border: `1px solid ${theme.color.border.default}`
+    boxShadow: `inset 0 0 0 1px ${theme.color.border.default}`
   }
 
   return {
@@ -54,6 +53,7 @@ export const ExpandableNavItem = ({
   shouldPersistRightIcon = false,
   canUnfurl = true,
   variant = 'default',
+  onClick,
   ...props
 }: ExpandableNavItemProps) => {
   const [isOpen, setIsOpen] = useState(defaultIsOpen)
@@ -66,6 +66,7 @@ export const ExpandableNavItem = ({
     if (canUnfurl) {
       setIsOpen(!isOpen)
     }
+    onClick?.()
   }
 
   const styles = useMemo(() => getStyles(theme, isHovered), [theme, isHovered])

--- a/packages/harmony/src/components/expandable-nav-item/types.ts
+++ b/packages/harmony/src/components/expandable-nav-item/types.ts
@@ -32,4 +32,6 @@ export type ExpandableNavItemProps = WithCSS<{
   canUnfurl?: boolean
   /** The variant of the nav item. */
   variant?: ExpandableNavItemVariant
+  /** The onClick handler for the nav item. */
+  onClick?: () => void
 }>

--- a/packages/harmony/src/components/nav-item/NavItem.tsx
+++ b/packages/harmony/src/components/nav-item/NavItem.tsx
@@ -30,12 +30,15 @@ export const NavItem = ({
 
   const backgroundColor = isSelected ? color.secondary.s400 : undefined
 
-  const textColor = isSelected ? 'staticWhite' : 'default'
-
-  const iconColor = isSelected ? 'staticStaticWhite' : 'default'
+  const textAndIconColor = isSelected ? 'staticWhite' : 'default'
+  const insetBorderColor = isSelected
+    ? 'none'
+    : `inset 0 0 0 1px ${color.border.default}`
 
   const leftIconWithNotification = useMemo(() => {
-    const icon = hasLeftIcon ? <LeftIcon size='l' color={iconColor} /> : null
+    const icon = hasLeftIcon ? (
+      <LeftIcon size='l' color={textAndIconColor} />
+    ) : null
 
     if (hasNotification && !!icon) {
       return (
@@ -45,7 +48,7 @@ export const NavItem = ({
       )
     }
     return icon
-  }, [hasNotification, hasLeftIcon, LeftIcon, iconColor, isSelected])
+  }, [hasNotification, hasLeftIcon, LeftIcon, textAndIconColor, isSelected])
 
   return (
     <Flex
@@ -53,8 +56,8 @@ export const NavItem = ({
       gap='s'
       pl='s'
       pr='s'
+      w='240px'
       css={{
-        width: '240px',
         cursor: 'pointer',
         transition: `background-color ${motion.hover}`
       }}
@@ -69,10 +72,9 @@ export const NavItem = ({
         borderRadius='m'
         css={{
           backgroundColor,
-          border: '1px solid transparent',
           '&:hover': {
             backgroundColor: isSelected ? undefined : color.background.surface2,
-            borderColor: isSelected ? undefined : color.border.default
+            boxShadow: insetBorderColor
           }
         }}
       >
@@ -90,7 +92,7 @@ export const NavItem = ({
             size={textSize}
             strength='weak'
             lineHeight='single'
-            color={textColor}
+            color={textAndIconColor}
             ellipses
             css={{ flex: 1 }}
           >

--- a/packages/harmony/src/components/notification-count/NotificationCount.tsx
+++ b/packages/harmony/src/components/notification-count/NotificationCount.tsx
@@ -85,12 +85,7 @@ export const NotificationCount = ({
         borderRadius='circle'
         css={badgeStyles}
       >
-        <Text
-          variant='label'
-          size='xs'
-          css={textStyles}
-          color='staticStaticWhite'
-        >
+        <Text variant='label' size='xs' css={textStyles} color='staticWhite'>
           {count !== undefined ? formatCount(count) : ''}
         </Text>
       </Flex>

--- a/packages/web/src/app/SvgGradientProvider.tsx
+++ b/packages/web/src/app/SvgGradientProvider.tsx
@@ -18,8 +18,14 @@ export const SvgGradientProvider = (props: SvgGradientProviderProps) => {
             y2='8.9070096%'
             id='linearGradient-1'
           >
-            <stop stopColor='#832AE7' offset='0%'></stop>
-            <stop stopColor='#922CE9' offset='100%'></stop>
+            <stop
+              stopColor='var(--harmony-gradient-color-1)'
+              offset='0%'
+            ></stop>
+            <stop
+              stopColor='var(--harmony-gradient-color-2)'
+              offset='100%'
+            ></stop>
           </linearGradient>
           <linearGradient
             id='matrixHeaderGradient'

--- a/packages/web/src/components/nav/desktop/AccountDetails.tsx
+++ b/packages/web/src/components/nav/desktop/AccountDetails.tsx
@@ -16,7 +16,7 @@ const { getUserHandle, getUserId, getIsAccountComplete, getGuestEmail } =
 const messages = {
   haveAccount: 'Have an Account?',
   managedAccount: 'Managed Account',
-  signIn: 'Sign in',
+  signIn: 'Sign In',
   finishSignUp: 'Finish Signing Up'
 }
 

--- a/packages/web/src/components/nav/desktop/LeftNav.tsx
+++ b/packages/web/src/components/nav/desktop/LeftNav.tsx
@@ -6,13 +6,7 @@ import {
   collectionsSocialActions,
   tracksSocialActions
 } from '@audius/common/store'
-import {
-  Box,
-  Divider,
-  ExpandableNavItem,
-  Flex,
-  Scrollbar
-} from '@audius/harmony'
+import { Box, Divider, Flex, Scrollbar } from '@audius/harmony'
 import { ResizeObserver } from '@juggle/resize-observer'
 import { connect } from 'react-redux'
 import { RouteComponentProps, withRouter } from 'react-router-dom'
@@ -29,6 +23,7 @@ import { LeftNavCTA } from './LeftNavCTA'
 import { LeftNavLink } from './LeftNavLink'
 import { NavHeader } from './NavHeader'
 import { NowPlayingArtworkTile } from './NowPlayingArtworkTile'
+import { RestrictedExpandableNavItem } from './RestrictedExpandableNavItem'
 import { RouteNav } from './RouteNav'
 import { NavItemConfig, useNavConfig } from './useNavConfig'
 
@@ -78,7 +73,7 @@ const LeftNav = (props: NavColumnProps) => {
       if (item.isExpandable) {
         const NestedComponent = item.nestedComponent
         return (
-          <ExpandableNavItem
+          <RestrictedExpandableNavItem
             key={item.label}
             label={item.label}
             leftIcon={item.leftIcon}
@@ -90,6 +85,7 @@ const LeftNav = (props: NavColumnProps) => {
               ) : null
             }
             canUnfurl={item.canUnfurl}
+            restriction={item.restriction}
           />
         )
       }
@@ -177,7 +173,7 @@ const LeftNav = (props: NavColumnProps) => {
           </DragAutoscroller>
         </Scrollbar>
       </Flex>
-      <Flex direction='column' alignItems='center' pt='l'>
+      <Flex direction='column' alignItems='center'>
         <ProfileCompletionPanel />
         <LeftNavCTA />
         <NowPlayingArtworkTile />

--- a/packages/web/src/components/nav/desktop/NavHeader.tsx
+++ b/packages/web/src/components/nav/desktop/NavHeader.tsx
@@ -61,12 +61,14 @@ export const NavHeader = () => {
             <NavHeaderButton
               icon={IconDashboard}
               aria-label={messages.dashboardLabel}
+              isActive={location.pathname === DASHBOARD_PAGE}
             />
           </Link>
           <Link to={SETTINGS_PAGE}>
             <NavHeaderButton
               icon={IconSettings}
               aria-label={messages.settingsLabel}
+              isActive={location.pathname === SETTINGS_PAGE}
             />
           </Link>
           <NotificationsButton />

--- a/packages/web/src/components/nav/desktop/PlaylistLibrary/NavItemKebabButton.tsx
+++ b/packages/web/src/components/nav/desktop/PlaylistLibrary/NavItemKebabButton.tsx
@@ -40,13 +40,13 @@ export const NavItemKebabButton = (props: EditNavItemButtonProps) => {
               pointerEvents: visible ? 'all' : 'none',
               '& path': {
                 fill: isSelected
-                  ? 'var(--harmony-static-static-white)'
+                  ? 'var(--harmony-static-white)'
                   : 'var(--harmony-n-700)'
               },
               ':hover,:active,:focus,:hover path, :active path, :focus path': {
                 color: 'var(--harmony-neutral)',
                 fill: isSelected
-                  ? 'var(--harmony-static-static-white)'
+                  ? 'var(--harmony-static-white)'
                   : 'var(--harmony-n-950)'
               }
             }}

--- a/packages/web/src/components/nav/desktop/RestrictedExpandableNavItem.tsx
+++ b/packages/web/src/components/nav/desktop/RestrictedExpandableNavItem.tsx
@@ -1,0 +1,24 @@
+import { useCallback } from 'react'
+
+import { ExpandableNavItem, ExpandableNavItemProps } from '@audius/harmony'
+
+import { RestrictionType, useRequiresAccountFn } from 'hooks/useRequiresAccount'
+
+type Props = Omit<ExpandableNavItemProps, 'onClick'> & {
+  restriction?: RestrictionType
+}
+
+export const RestrictedExpandableNavItem = ({
+  restriction = 'none',
+  ...props
+}: Props) => {
+  const { requiresAccount } = useRequiresAccountFn(undefined, restriction)
+
+  const handleClick = useCallback(() => {
+    if (restriction !== 'none') {
+      requiresAccount()
+    }
+  }, [requiresAccount, restriction])
+
+  return <ExpandableNavItem onClick={handleClick} {...props} />
+}

--- a/packages/web/src/components/nav/desktop/WalletsNestedContent.tsx
+++ b/packages/web/src/components/nav/desktop/WalletsNestedContent.tsx
@@ -1,6 +1,7 @@
 import {
   useUSDCBalance,
-  useTotalBalanceWithFallback
+  useTotalBalanceWithFallback,
+  useSelectTierInfo
 } from '@audius/common/hooks'
 import { BNUSDC } from '@audius/common/models'
 import { accountSelectors } from '@audius/common/store'
@@ -12,8 +13,12 @@ import {
 import {
   BalancePill,
   Flex,
-  IconLogoCircle,
-  IconLogoCircleUSDC
+  IconLogoCircleUSDC,
+  IconTokenBronze,
+  IconTokenSilver,
+  IconTokenGold,
+  IconTokenPlatinum,
+  IconTokenNoTier
 } from '@audius/harmony'
 import BN from 'bn.js'
 import { useSelector } from 'react-redux'
@@ -23,13 +28,23 @@ import { useIsUSDCEnabled } from 'hooks/useIsUSDCEnabled'
 import { LeftNavLink } from './LeftNavLink'
 
 const { AUDIO_PAGE, PAYMENTS_PAGE } = route
-const { getIsAccountComplete } = accountSelectors
+const { getIsAccountComplete, getUserId } = accountSelectors
 
 export const WalletsNestedContent = () => {
   const isAccountComplete = useSelector(getIsAccountComplete)
   const isUSDCEnabled = useIsUSDCEnabled()
   const { data: usdcBalance } = useUSDCBalance()
   const audioBalance = useTotalBalanceWithFallback()
+  const userId = useSelector(getUserId)
+  const { tier } = useSelectTierInfo(userId ?? 0)
+
+  const TierIcon = {
+    none: IconTokenNoTier,
+    bronze: IconTokenBronze,
+    silver: IconTokenSilver,
+    gold: IconTokenGold,
+    platinum: IconTokenPlatinum
+  }[tier]
 
   return (
     <Flex direction='column'>
@@ -39,7 +54,7 @@ export const WalletsNestedContent = () => {
           <BalancePill
             balance={audioBalance ? formatWei(audioBalance, true, 0) : '0'}
           >
-            <IconLogoCircle />
+            <TierIcon size='l' />
           </BalancePill>
         }
         restriction='account'


### PR DESCRIPTION
### Description

This PR addresses several UI/UX issues identified during the bugbash for the new navigation system:

## Fixed Issues
- Fixed icon colors in dark mode for nav items
- Updated "Sign In" text casing to match Figma designs
- Corrected NavItem height to 40px (24px inner container + 8px padding above/below)
- Added hover states with inset borders instead of regular borders for nav items
- Updated token icons in wallet section to show bronze/silver/gold tier icons
- Added isActive state to dashboard and settings nav header buttons
- Added restriction handling for expandable nav items (playlists/wallets)

## Implementation Details
- Replaced regular borders with `box-shadow: inset` for better hover states
- Created new `RestrictedExpandableNavItem` component to handle auth requirements
- Updated color tokens from `staticStaticWhite` to `staticWhite` for consistency
- Removed extra padding above artwork in sidebar
- Added onClick handler support to ExpandableNavItem

## Remaining Issues
- [x] Fix header icon colors
- [ ] NavSubItem height needs adjustment to 36px
  - this isn't actually a component as it is in Figma, we just use `NavItem` which uses some old styles from the previous playlist implementation, need to look deeper here for why the extra padding is here, low pri so can move to backlog  
- [ ] Collapsed state of "Ready To Claim" needs fixes
  - Follow up pr 
- [ ] Audius logo needs updating to latest version
- [ ] Multiple toast notifications appearing for unauthenticated actions
  - Need to look into deeper, something with JS not hydrating   

### How Has This Been Tested?

run `npm run web:stage`

- Nav item hover states and borders
  -  ensure that hover states still show a border with color `default` 
- Ensure token icons display correctly based on user tier
- Auth restrictions work properly for playlists and wallets sections
- NavItem heights are correct at 40px
