### PR TITLE
[C-5658] Remove local saves slice from library

### DIFF
--- a/packages/common/src/store/pages/saved-page/actions.ts
+++ b/packages/common/src/store/pages/saved-page/actions.ts
@@ -15,11 +15,6 @@ export const FETCH_MORE_SAVES_FAILED = 'SAVED/FETCH_MORE_SAVES_FAILED'
 // Usually when filtering
 export const END_FETCHING = 'SAVED/END_FETCHING'
 
-export const ADD_LOCAL_TRACK = 'SAVED/ADD_LOCAL_TRACK'
-export const REMOVE_LOCAL_TRACK = 'SAVED/REMOVE_LOCAL_TRACK'
-export const ADD_LOCAL_COLLECTION = 'SAVED/ADD_LOCAL_COLLECTION'
-export const REMOVE_LOCAL_COLLECTION = 'SAVED/REMOVE_LOCAL_COLLECTION'
-
 export const SET_SELECTED_CATEGORY = 'SAVED/SET_SELECTED_CATEGORY'
 
 export const fetchSaves = (
@@ -92,63 +87,6 @@ export const fetchMoreSavesFailed = () => ({
 export const endFetching = (endIndex: number) => ({
   type: END_FETCHING,
   endIndex
-})
-
-export const addLocalTrack = ({
-  trackId,
-  uid,
-  category
-}: {
-  trackId: number
-  uid: string
-  category: LibraryCategoryType
-}) => ({
-  type: ADD_LOCAL_TRACK,
-  trackId,
-  uid,
-  category
-})
-
-export const removeLocalTrack = ({
-  trackId,
-  category
-}: {
-  trackId: number
-  category: LibraryCategoryType
-}) => ({
-  type: REMOVE_LOCAL_TRACK,
-  trackId,
-  category
-})
-
-export const addLocalCollection = ({
-  collectionId,
-  isAlbum,
-  category
-}: {
-  collectionId: number
-  isAlbum: boolean
-  category: LibraryCategoryType
-}) => ({
-  type: ADD_LOCAL_COLLECTION,
-  collectionId,
-  isAlbum,
-  category
-})
-
-export const removeLocalCollection = ({
-  collectionId,
-  isAlbum,
-  category
-}: {
-  collectionId: number
-  isAlbum: boolean
-  category: LibraryCategoryType
-}) => ({
-  type: REMOVE_LOCAL_COLLECTION,
-  collectionId,
-  isAlbum,
-  category
 })
 
 export const setSelectedCategory = ({

--- a/packages/common/src/store/pages/saved-page/reducer.ts
+++ b/packages/common/src/store/pages/saved-page/reducer.ts
@@ -1,10 +1,7 @@
 import { Storage, persistReducer } from 'redux-persist'
 
-import { ID } from '~/models/Identifiers'
 import { asLineup } from '~/store/lineup/reducer'
 import {
-  ADD_LOCAL_COLLECTION,
-  ADD_LOCAL_TRACK,
   END_FETCHING,
   FETCH_MORE_SAVES,
   FETCH_MORE_SAVES_FAILED,
@@ -13,8 +10,6 @@ import {
   FETCH_SAVES_FAILED,
   FETCH_SAVES_REQUESTED,
   FETCH_SAVES_SUCCEEDED,
-  REMOVE_LOCAL_COLLECTION,
-  REMOVE_LOCAL_TRACK,
   SET_SELECTED_CATEGORY
 } from '~/store/pages/saved-page/actions'
 import tracksReducer, {
@@ -24,7 +19,7 @@ import { signOut } from '~/store/sign-out/slice'
 import { ActionsMap } from '~/utils/reducer'
 
 import { PREFIX as tracksPrefix } from './lineups/tracks/actions'
-import { LibraryCategory, LibraryCategoryType, SavedPageState } from './types'
+import { LibraryCategory, SavedPageState } from './types'
 import { calculateNewLibraryCategories } from './utils'
 
 const initialState = {
@@ -34,61 +29,8 @@ const initialState = {
   fetchingMore: false,
   tracks: initialLineupState,
   tracksCategory: LibraryCategory.Favorite,
-  collectionsCategory: LibraryCategory.Favorite,
-  local: {
-    track: {
-      favorites: {
-        added: {},
-        removed: {}
-      },
-      reposts: {
-        added: {},
-        removed: {}
-      },
-      purchased: {
-        added: {}
-      }
-    },
-    album: {
-      favorites: {
-        added: [],
-        removed: []
-      },
-      reposts: {
-        added: [],
-        removed: []
-      },
-      purchased: {
-        added: []
-      }
-    },
-    playlist: {
-      favorites: {
-        added: [],
-        removed: []
-      },
-      reposts: {
-        added: [],
-        removed: []
-      }
-    }
-  }
+  collectionsCategory: LibraryCategory.Favorite
 } as SavedPageState
-
-const getCategoryLocalStateKey = (
-  category: Omit<LibraryCategoryType, 'all'>
-) => {
-  switch (category) {
-    case LibraryCategory.Favorite:
-      return 'favorites'
-    case LibraryCategory.Purchase:
-      return 'purchased'
-    case LibraryCategory.Repost:
-      return 'reposts'
-    default:
-      return 'favorites'
-  }
-}
 
 const actionsMap: ActionsMap<SavedPageState> = {
   [FETCH_SAVES](state) {
@@ -143,53 +85,6 @@ const actionsMap: ActionsMap<SavedPageState> = {
       trackSaves: savesCopy,
       hasReachedEnd: true
     }
-  },
-  [ADD_LOCAL_TRACK](state, action) {
-    const categoryKey = getCategoryLocalStateKey(action.category)
-    const newState = { ...state }
-    newState.local.track[categoryKey].added = {
-      ...newState.local.track[categoryKey].added,
-      [action.trackId]: action.uid
-    }
-    return newState
-  },
-  [REMOVE_LOCAL_TRACK](state, action) {
-    const categoryKey = getCategoryLocalStateKey(action.category)
-    const newState = { ...state }
-    delete newState.local.track[categoryKey].added[action.trackId]
-
-    newState.trackSaves = newState.trackSaves.filter(
-      ({ save_item_id: id }) => id !== action.trackId
-    )
-    return newState
-  },
-  [ADD_LOCAL_COLLECTION](state, action) {
-    const kindKey = action.isAlbum ? 'album' : 'playlist'
-    const categoryKey = getCategoryLocalStateKey(action.category)
-    const newState = { ...state }
-    newState.local[kindKey][categoryKey].added = [
-      action.collectionId,
-      ...newState.local[kindKey][categoryKey].added
-    ]
-    newState.local[kindKey][categoryKey].removed = newState.local[kindKey][
-      categoryKey
-    ].removed.filter((id: ID) => id !== action.collectionId)
-
-    return newState
-  },
-  [REMOVE_LOCAL_COLLECTION](state, action) {
-    const kindKey = action.isAlbum ? 'album' : 'playlist'
-    const categoryKey = getCategoryLocalStateKey(action.category)
-    const newState = { ...state }
-    newState.local[kindKey][categoryKey].removed = [
-      action.collectionId,
-      ...newState.local[kindKey][categoryKey].removed
-    ]
-    newState.local[kindKey][categoryKey].added = newState.local[kindKey][
-      categoryKey
-    ].added.filter((id: ID) => id !== action.collectionId)
-
-    return newState
   },
   [SET_SELECTED_CATEGORY](state, action) {
     return {

--- a/packages/common/src/store/pages/saved-page/selectors.ts
+++ b/packages/common/src/store/pages/saved-page/selectors.ts
@@ -1,10 +1,10 @@
-import { uniq } from 'lodash'
-
 import { CommonState } from '~/store/commonStore'
 
 import { ID } from '../../../models/Identifiers'
 
-import { LibraryCategory, SavedPageTabs } from './types'
+import { SavedPageTabs } from './types'
+
+// Note: Local saves were removed for simplicity. Need to add support back later.
 
 export const getSaved = (state: CommonState) => state.pages.savedPage
 export const getTrackSaves = (state: CommonState) =>
@@ -27,138 +27,6 @@ export const getCategory = (
   } else {
     return getCollectionsCategory(state)
   }
-}
-
-export const getLocalTrackFavorites = (state: CommonState) =>
-  state.pages.savedPage.local.track.favorites.added
-export const getLocalTrackFavorite = (state: CommonState, props: { id: ID }) =>
-  state.pages.savedPage.local.track.favorites.added[props.id]
-export const getLocalTrackReposts = (state: CommonState) =>
-  state.pages.savedPage.local.track.reposts.added
-export const getLocalTrackRepost = (state: CommonState, props: { id: ID }) =>
-  state.pages.savedPage.local.track.reposts.added[props.id]
-export const getLocalTrackPurchases = (state: CommonState) =>
-  state.pages.savedPage.local.track.purchased.added
-export const getLocalTrackPurchase = (state: CommonState, props: { id: ID }) =>
-  state.pages.savedPage.local.track.purchased.added[props.id]
-
-export const getLocalAlbumFavorites = (state: CommonState) =>
-  state.pages.savedPage.local.album.favorites.added
-export const getLocalAlbumReposts = (state: CommonState) =>
-  state.pages.savedPage.local.album.reposts.added
-export const getLocalAlbumPurchases = (state: CommonState) =>
-  state.pages.savedPage.local.album.purchased.added
-export const getLocalRemovedAlbumFavorites = (state: CommonState) =>
-  state.pages.savedPage.local.album.favorites.removed
-export const getLocalRemovedAlbumReposts = (state: CommonState) =>
-  state.pages.savedPage.local.album.reposts.removed
-
-export const getLocalPlaylistFavorites = (state: CommonState) =>
-  state.pages.savedPage.local.playlist.favorites.added
-export const getLocalPlaylistReposts = (state: CommonState) =>
-  state.pages.savedPage.local.playlist.reposts.added
-export const getLocalRemovedPlaylistFavorites = (state: CommonState) =>
-  state.pages.savedPage.local.playlist.favorites.removed
-export const getLocalRemovedPlaylistReposts = (state: CommonState) =>
-  state.pages.savedPage.local.playlist.favorites.removed
-
-/** Get the tracks in currently selected category that have been added to the library in current session */
-export const getSelectedCategoryLocalTrackAdds = (state: CommonState) => {
-  const selectedCategory = getCategory(state, {
-    currentTab: SavedPageTabs.TRACKS
-  })
-  const localFavorites = getLocalTrackFavorites(state)
-  const localPurchases = getLocalTrackPurchases(state)
-  const localReposts = getLocalTrackReposts(state)
-  let localLibraryAdditions
-  if (selectedCategory === LibraryCategory.Favorite) {
-    localLibraryAdditions = localFavorites
-  } else if (selectedCategory === LibraryCategory.Purchase) {
-    localLibraryAdditions = localPurchases
-  } else if (selectedCategory === LibraryCategory.Repost) {
-    localLibraryAdditions = localReposts
-  } else {
-    // Category = ALL
-    localLibraryAdditions = {
-      ...localReposts,
-      ...localFavorites,
-      ...localPurchases
-    }
-  }
-
-  return localLibraryAdditions
-}
-
-const getSelectedCategoryLocalCollectionUpdates = (
-  state: CommonState,
-  props: { collectionType: 'album' | 'playlist'; updateType: 'add' | 'remove' }
-) => {
-  const { collectionType, updateType } = props
-  const currentTab =
-    collectionType === 'album' ? SavedPageTabs.ALBUMS : SavedPageTabs.PLAYLISTS
-  const selectedCategory = getCategory(state, { currentTab })
-  let localFavorites: ID[], localPurchases: ID[], localReposts: ID[]
-  if (updateType === 'add') {
-    localFavorites =
-      collectionType === 'album'
-        ? getLocalAlbumFavorites(state)
-        : getLocalPlaylistFavorites(state)
-    localPurchases =
-      collectionType === 'album' ? getLocalAlbumPurchases(state) : [] // Can't buy playlists
-    localReposts =
-      collectionType === 'album'
-        ? getLocalAlbumReposts(state)
-        : getLocalPlaylistReposts(state)
-  } else {
-    localFavorites =
-      collectionType === 'album'
-        ? getLocalRemovedAlbumFavorites(state)
-        : getLocalRemovedPlaylistFavorites(state)
-    localPurchases = [] // Can't remove purchases
-    localReposts =
-      collectionType === 'album'
-        ? getLocalRemovedAlbumReposts(state)
-        : getLocalRemovedPlaylistReposts(state)
-  }
-
-  switch (selectedCategory) {
-    case LibraryCategory.Favorite:
-      return localFavorites
-    case LibraryCategory.Purchase:
-      return localPurchases
-    case LibraryCategory.Repost:
-      return localReposts
-    default:
-      // Category = ALL
-      return uniq([...localReposts, ...localFavorites, ...localPurchases])
-  }
-}
-
-export const getSelectedCategoryLocalAlbumAdds = (state: CommonState) => {
-  return getSelectedCategoryLocalCollectionUpdates(state, {
-    collectionType: 'album',
-    updateType: 'add'
-  })
-}
-export const getSelectedCategoryLocalAlbumRemovals = (state: CommonState) => {
-  return getSelectedCategoryLocalCollectionUpdates(state, {
-    collectionType: 'album',
-    updateType: 'remove'
-  })
-}
-export const getSelectedCategoryLocalPlaylistRemovals = (
-  state: CommonState
-) => {
-  return getSelectedCategoryLocalCollectionUpdates(state, {
-    collectionType: 'playlist',
-    updateType: 'remove'
-  })
-}
-export const getSelectedCategoryLocalPlaylistAdds = (state: CommonState) => {
-  return getSelectedCategoryLocalCollectionUpdates(state, {
-    collectionType: 'playlist',
-    updateType: 'add'
-  })
 }
 
 export const getInitialFetchStatus = (state: CommonState) =>

--- a/packages/common/src/store/pages/saved-page/types.ts
+++ b/packages/common/src/store/pages/saved-page/types.ts
@@ -4,7 +4,6 @@ import type { Dayjs } from '~/utils/dayjs'
 import { ValueOf } from '~/utils/typeUtils'
 
 import {
-  UID,
   ID,
   Collection,
   Favorite,
@@ -18,45 +17,9 @@ export type LibraryCategoryType = ValueOf<typeof LibraryCategory>
 export function isLibraryCategory(value: string): value is LibraryCategoryType {
   return Object.values(LibraryCategory).includes(value as LibraryCategoryType)
 }
+
+// Note: Local saves were removed in favor of server-side persistence only
 export interface SavedPageState {
-  local: {
-    track: {
-      favorites: {
-        added: { [id: number]: UID }
-        removed: { [id: number]: UID }
-      }
-      reposts: {
-        added: { [id: number]: UID }
-        removed: { [id: number]: UID }
-      }
-      purchased: {
-        added: { [id: number]: UID }
-      }
-    }
-    album: {
-      favorites: {
-        added: ID[]
-        removed: ID[]
-      }
-      reposts: {
-        added: ID[]
-        removed: ID[]
-      }
-      purchased: {
-        added: ID[]
-      }
-    }
-    playlist: {
-      favorites: {
-        added: ID[]
-        removed: ID[]
-      }
-      reposts: {
-        added: ID[]
-        removed: ID[]
-      }
-    }
-  }
   tracks: LineupState<LineupTrack & { id: ID; dateSaved: string }>
   trackSaves: Favorite[]
   hasReachedEnd: boolean

--- a/packages/mobile/src/screens/favorites-screen/TracksTab.tsx
+++ b/packages/mobile/src/screens/favorites-screen/TracksTab.tsx
@@ -36,7 +36,6 @@ const {
   getTrackSaves,
   getSavedTracksStatus,
   getInitialFetchStatus,
-  getSelectedCategoryLocalTrackAdds,
   getIsFetchingMore,
   getCategory
 } = savedPageSelectors
@@ -93,12 +92,8 @@ export const TracksTab = () => {
   const initialFetch = useSelector(getInitialFetchStatus)
   const isFetchingMore = useSelector(getIsFetchingMore)
   const saves = useSelector(getTrackSaves)
-  const localAdditions = useSelector(getSelectedCategoryLocalTrackAdds)
 
-  const saveCount = useMemo(
-    () => saves.length + Object.keys(localAdditions).length,
-    [saves, localAdditions]
-  )
+  const saveCount = saves.length
 
   const isLoading = savedTracksStatus !== Status.SUCCESS
 

--- a/packages/mobile/src/store/offline-downloads/sagas/requestDownloadAllFavoritesSaga.ts
+++ b/packages/mobile/src/store/offline-downloads/sagas/requestDownloadAllFavoritesSaga.ts
@@ -1,12 +1,7 @@
 import { transformAndCleanList, favoriteFromSDK } from '@audius/common/adapters'
 import { Id } from '@audius/common/models'
-import {
-  accountSelectors,
-  savedPageSelectors,
-  getSDK
-} from '@audius/common/store'
+import { accountSelectors, getSDK } from '@audius/common/store'
 import { fetchAllAccountCollections } from 'common/store/saved-collections/sagas'
-import moment from 'moment'
 import { takeEvery, select, call, put } from 'typed-redux-saga'
 
 import { getAccountCollections } from 'app/screens/favorites-screen/selectors'
@@ -18,8 +13,6 @@ import type { OfflineEntry } from '../slice'
 import { addOfflineEntries, requestDownloadAllFavorites } from '../slice'
 
 const { getUserId } = accountSelectors
-
-const { getLocalTrackFavorites } = savedPageSelectors
 
 export function* requestDownloadAllFavoritesSaga() {
   yield* takeEvery(requestDownloadAllFavorites.type, downloadAllFavorites)
@@ -42,21 +35,7 @@ function* downloadAllFavorites() {
     { is_from_favorites: true, collection_id: DOWNLOAD_REASON_FAVORITES }
   ]
 
-  // Add local saves
-  const favorite_created_at = moment().format('YYYY-MM-DD HH:mm:ss')
-  const localSaves = yield* select(getLocalTrackFavorites)
-  const localSavesToAdd: OfflineEntry[] = Object.keys(localSaves)
-    .map((id) => parseInt(id, 10))
-    .map((id) => ({
-      type: 'track',
-      id,
-      metadata: {
-        favorite_created_at,
-        reasons_for_download: trackReasonsForDownload
-      }
-    }))
-
-  offlineItemsToAdd.push(...localSavesToAdd)
+  // Note: Local saves support was removed, to be added back later
 
   // Add favorited tracks from api
   const sdk = yield* getSDK()

--- a/packages/web/src/common/store/cache/collections/commonSagas.ts
+++ b/packages/web/src/common/store/cache/collections/commonSagas.ts
@@ -25,8 +25,6 @@ import {
   PlaylistOperations,
   reformatCollection,
   cacheUsersSelectors,
-  savedPageActions,
-  LibraryCategory,
   toastActions,
   getContext,
   confirmerActions,
@@ -44,10 +42,6 @@ import { all, call, put, select, takeEvery, takeLatest } from 'typed-redux-saga'
 import { make } from 'common/store/analytics/actions'
 import watchTrackErrors from 'common/store/cache/collections/errorSagas'
 import * as signOnActions from 'common/store/pages/signon/actions'
-import {
-  addPlaylistsNotInLibrary,
-  removePlaylistFromLibrary
-} from 'common/store/playlist-library/sagas'
 import { getUSDCMetadata } from 'common/store/upload/sagaHelpers'
 import { ensureLoggedIn } from 'common/utils/ensureLoggedIn'
 import { waitForWrite } from 'utils/sagaHelpers'
@@ -638,13 +632,6 @@ function* confirmDeleteAlbum(playlistId: ID, userId: ID) {
           ),
           put(
             accountActions.removeAccountPlaylist({ collectionId: playlistId })
-          ),
-          put(
-            savedPageActions.removeLocalCollection({
-              collectionId: playlistId,
-              isAlbum: true,
-              category: LibraryCategory.Favorite
-            })
           )
         ])
 
@@ -680,13 +667,6 @@ function* confirmDeleteAlbum(playlistId: ID, userId: ID) {
               is_album: playlist.is_album,
               user: { id: user.user_id, handle: user.handle },
               permalink: playlist.permalink
-            })
-          ),
-          put(
-            savedPageActions.addLocalCollection({
-              collectionId: playlist.playlist_id,
-              isAlbum: playlist.is_album,
-              category: LibraryCategory.Favorite
             })
           )
         ])
@@ -725,17 +705,8 @@ function* confirmDeletePlaylist(userId: ID, playlistId: ID) {
           ),
           put(
             accountActions.removeAccountPlaylist({ collectionId: playlistId })
-          ),
-          put(
-            savedPageActions.removeLocalCollection({
-              collectionId: playlistId,
-              isAlbum: false,
-              category: LibraryCategory.Favorite
-            })
           )
         ])
-
-        yield* call(removePlaylistFromLibrary, playlistId)
 
         yield* call([sdk.playlists, sdk.playlists.deletePlaylist], {
           userId: Id.parse(userId),
@@ -769,16 +740,8 @@ function* confirmDeletePlaylist(userId: ID, playlistId: ID) {
               user: { id: user.user_id, handle: user.handle },
               permalink: playlist.permalink
             })
-          ),
-          put(
-            savedPageActions.addLocalCollection({
-              collectionId: playlist.playlist_id,
-              isAlbum: playlist.is_album,
-              category: LibraryCategory.Favorite
-            })
           )
         ])
-        yield* call(addPlaylistsNotInLibrary)
         yield* put(
           collectionActions.deletePlaylistFailed(
             error,

--- a/packages/web/src/common/store/cache/collections/createPlaylistSaga.ts
+++ b/packages/web/src/common/store/cache/collections/createPlaylistSaga.ts
@@ -22,8 +22,6 @@ import {
   cacheActions,
   reformatCollection,
   cacheUsersSelectors,
-  savedPageActions,
-  LibraryCategory,
   confirmerActions,
   EditCollectionValues,
   RequestConfirmationError,
@@ -37,7 +35,6 @@ import { addPlaylistsNotInLibrary } from 'common/store/playlist-library/sagas'
 import { ensureLoggedIn } from 'common/utils/ensureLoggedIn'
 import { waitForWrite } from 'utils/sagaHelpers'
 
-const { addLocalCollection } = savedPageActions
 const { getUser } = cacheUsersSelectors
 
 const { requestConfirmation } = confirmerActions
@@ -170,14 +167,6 @@ function* optimisticallySavePlaylist(
       is_album: !!playlist.is_album,
       user: { id: user_id, handle },
       permalink: playlist?.permalink
-    })
-  )
-
-  yield* put(
-    addLocalCollection({
-      collectionId: playlistId,
-      isAlbum: !!playlist.is_album,
-      category: LibraryCategory.Favorite
     })
   )
 

--- a/packages/web/src/common/store/pages/saved/lineups/sagas.ts
+++ b/packages/web/src/common/store/pages/saved/lineups/sagas.ts
@@ -1,4 +1,4 @@
-import { Collection, Kind, LineupEntry, UID, User } from '@audius/common/models'
+import { Collection, Kind, LineupEntry, User } from '@audius/common/models'
 import {
   cacheTracksSelectors,
   savedPageTracksLineupActions as savedTracksActions,
@@ -18,7 +18,6 @@ import {
   accountSelectors
 } from '@audius/common/store'
 import { makeUid, waitForAccount } from '@audius/common/utils'
-import { uniq } from 'lodash'
 import moment from 'moment'
 import { call, select, put, takeEvery } from 'typed-redux-saga'
 
@@ -31,14 +30,8 @@ const { getSource } = queueSelectors
 const { FETCH_SAVES, FETCH_MORE_SAVES } = saveActions
 const { SAVE_TRACK, UNSAVE_TRACK, REPOST_TRACK, UNDO_REPOST_TRACK } =
   tracksSocialActions
-const {
-  getLocalTrackFavorite,
-  getLocalTrackRepost,
-  getSavedTracksLineupUid,
-  getTrackSaves,
-  getSelectedCategoryLocalTrackAdds,
-  getCategory
-} = savedPageSelectors
+const { getSavedTracksLineupUid, getTrackSaves, getCategory } =
+  savedPageSelectors
 const { purchaseConfirmed } = purchaseContentActions
 const { getTracks: getCacheTracks } = cacheTracksSelectors
 
@@ -46,7 +39,13 @@ const getSavedTracks = (state: AppState) => state.pages.savedPage.tracks
 
 const PREFIX = savedTracksActions.prefix
 
-function* getTracks({ offset, limit }: { offset: number; limit: number }) {
+function* getTracks({
+  offset,
+  limit
+}: {
+  offset: number
+  limit: number
+}): Generator<any, SavedPageTrack[] | null, any> {
   const isNativeMobile = yield* getContext('isNativeMobile')
   const allSavedTracks = yield* select(getTrackSaves)
   // Mobile currently uses infinite scroll instead of a virtualized list
@@ -56,57 +55,33 @@ function* getTracks({ offset, limit }: { offset: number; limit: number }) {
     : allSavedTracks
 
   const savedTrackIds = savedTracks.map((save) => save.save_item_id ?? null)
-  const savedTrackTimestamps = savedTracks.reduce((map, save) => {
-    map[save.save_item_id] = save.created_at
-    return map
-  }, {})
-
-  const localLibraryAdditions = yield* select(getSelectedCategoryLocalTrackAdds)
-  const localLibraryAdditionsTrackIds = Object.keys(localLibraryAdditions)
-    .filter((savedTrackId) => !savedTrackTimestamps[savedTrackId])
-    .map((trackId) => Number(trackId))
-
-  const localLibraryAdditionsTimestamps = localLibraryAdditionsTrackIds.reduce(
-    (map, saveId) => {
-      map[saveId] = Date.now()
+  const savedTrackTimestamps = savedTracks.reduce<Record<number, string>>(
+    (map, save) => {
+      map[save.save_item_id] = save.created_at
       return map
     },
     {}
   )
 
-  let allSavedTrackIds: (number | string)[] = []
-
-  if (isNativeMobile && offset !== 0) {
-    allSavedTrackIds = savedTrackIds.filter(
-      (s) => !localLibraryAdditionsTrackIds.includes(s)
-    )
-  } else {
-    allSavedTrackIds = uniq([
-      ...localLibraryAdditionsTrackIds,
-      ...savedTrackIds
-    ])
-  }
-
-  const allSavedTrackTimestamps = {
-    ...localLibraryAdditionsTimestamps,
-    ...savedTrackTimestamps
-  }
-
-  if (allSavedTrackIds.length > 0) {
+  if (savedTrackIds.length > 0) {
     // @ts-ignore - Strings can be passed for the local save track ids
     const tracks = yield* call(retrieveTracks, {
-      trackIds: allSavedTrackIds.filter((id) => id !== null)
+      trackIds: savedTrackIds.filter((id) => id !== null)
     })
-    const tracksMap = tracks.reduce((map, track) => {
-      const save = {
-        ...track,
-        dateSaved: allSavedTrackTimestamps[track.track_id]
-      }
+    const tracksMap = tracks.reduce<Record<number, SavedPageTrack>>(
+      (map, track) => {
+        const save = {
+          ...track,
+          dateSaved: savedTrackTimestamps[track.track_id]
+        }
 
-      map[track.track_id] = save
-      return map
-    }, {})
-    return allSavedTrackIds.map((id) =>
+        map[track.track_id] = save as SavedPageTrack
+        return map
+      },
+      {}
+    )
+    // @ts-ignore - empty case is expected but not by lineup
+    return savedTrackIds.map((id) =>
       id ? tracksMap[id] : { kind: Kind.EMPTY }
     )
   }
@@ -201,13 +176,6 @@ function* watchAddToLibrary() {
       } else {
         relevantCategory = LibraryCategory.Purchase
       }
-      yield* put(
-        saveActions.addLocalTrack({
-          trackId,
-          uid: localSaveUid,
-          category: relevantCategory
-        })
-      )
 
       const isTrackAlreadyInLineup = yield* select(
         (state, props) => {
@@ -252,24 +220,9 @@ function* watchRemoveFromLibrary() {
         | ReturnType<typeof tracksSocialActions.undoRepostTrack>
     ) {
       const { trackId, type } = action
-      const removedTrackSelector =
-        type === UNSAVE_TRACK ? getLocalTrackFavorite : getLocalTrackRepost
-      const localSaveUid: UID = yield* select(removedTrackSelector, {
-        id: trackId
-      })
       const currentCategory = yield* select(getCategory, {
         currentTab: SavedPageTabs.TRACKS
       })
-
-      yield* put(
-        saveActions.removeLocalTrack({
-          trackId: action.trackId,
-          category:
-            type === UNSAVE_TRACK
-              ? LibraryCategory.Favorite
-              : LibraryCategory.Repost
-        })
-      )
 
       if (
         (type === UNSAVE_TRACK &&
@@ -278,16 +231,7 @@ function* watchRemoveFromLibrary() {
           currentCategory === LibraryCategory.Repost)
       ) {
         const playerUid = yield* select(getPlayerUid)
-        const queueSource = yield* select(getSource)
-        if (localSaveUid) {
-          yield* put(savedTracksActions.remove(Kind.TRACKS, localSaveUid))
-          if (
-            localSaveUid !== playerUid &&
-            queueSource === QueueSource.SAVED_TRACKS
-          ) {
-            yield* put(queueActions.remove({ uid: localSaveUid }))
-          }
-        }
+
         const lineupSaveUid = yield* select(getSavedTracksLineupUid, {
           id: trackId
         })

--- a/packages/web/src/common/store/social/collections/sagas.ts
+++ b/packages/web/src/common/store/social/collections/sagas.ts
@@ -13,8 +13,6 @@ import {
   cacheCollectionsSelectors,
   cacheActions,
   cacheUsersSelectors,
-  savedPageActions,
-  LibraryCategory,
   playlistLibraryActions,
   playlistLibraryHelpers,
   collectionsSocialActions as socialActions,
@@ -47,7 +45,6 @@ const { update: updatePlaylistLibrary } = playlistLibraryActions
 const { removeFromPlaylistLibrary } = playlistLibraryHelpers
 const { getUser } = cacheUsersSelectors
 const { getCollections, getCollection } = cacheCollectionsSelectors
-const { addLocalCollection, removeLocalCollection } = savedPageActions
 const { getPlaylistLibrary, getUserId, getIsGuestAccount } = accountSelectors
 const { collectionPage } = route
 
@@ -101,13 +98,7 @@ export function* repostCollectionAsync(
       // is_repost_of_repost is true
       { is_repost_of_repost: collection.followee_reposts.length !== 0 }
     : { is_repost_of_repost: false }
-  yield* put(
-    addLocalCollection({
-      collectionId: action.collectionId,
-      isAlbum: collection.is_album,
-      category: LibraryCategory.Repost
-    })
-  )
+
   yield* call(
     confirmRepostCollection,
     collection.playlist_owner_id,
@@ -204,14 +195,6 @@ export function* undoRepostCollectionAsync(
     ids: [action.collectionId]
   })
   const collection = collections[action.collectionId]
-
-  yield* put(
-    removeLocalCollection({
-      collectionId: action.collectionId,
-      isAlbum: collection.is_album,
-      category: LibraryCategory.Repost
-    })
-  )
 
   const event = make(Name.UNDO_REPOST, {
     kind: collection.is_album ? 'album' : 'playlist',
@@ -405,14 +388,6 @@ export function* saveCollectionAsync(
   yield* call(addPlaylistsNotInLibrary)
 
   yield* put(
-    addLocalCollection({
-      collectionId: action.collectionId,
-      isAlbum: collection.is_album,
-      category: LibraryCategory.Favorite
-    })
-  )
-
-  yield* put(
     cacheActions.update(Kind.COLLECTIONS, [
       {
         id: action.collectionId,
@@ -514,14 +489,6 @@ export function* unsaveCollectionAsync(
     ids: [action.collectionId]
   })
   const collection = collections[action.collectionId]
-
-  yield* put(
-    removeLocalCollection({
-      collectionId: action.collectionId,
-      isAlbum: collection.is_album,
-      category: LibraryCategory.Favorite
-    })
-  )
 
   const event = make(Name.UNFAVORITE, {
     kind: collection.is_album ? 'album' : 'playlist',

--- a/packages/web/src/common/store/upload/sagas.ts
+++ b/packages/web/src/common/store/upload/sagas.ts
@@ -22,7 +22,6 @@ import {
 import { CollectionValues } from '@audius/common/schemas'
 import {
   TrackMetadataForUpload,
-  LibraryCategory,
   ProgressStatus,
   TrackForUpload,
   UploadType,
@@ -33,7 +32,6 @@ import {
   confirmerActions,
   getContext,
   reformatCollection,
-  savedPageActions,
   uploadActions,
   getSDK,
   cacheTracksActions,
@@ -971,13 +969,7 @@ export function* uploadCollection(
             }
           })
         )
-        yield* put(
-          savedPageActions.addLocalCollection({
-            collectionId: confirmedPlaylist.playlist_id,
-            isAlbum: confirmedPlaylist.is_album,
-            category: LibraryCategory.Favorite
-          })
-        )
+
         yield* put(cacheActions.setExpired(Kind.USERS, userId))
 
         // Finally, add to the library

--- a/packages/web/src/pages/saved-page/hooks/useCollectionsData.tsx
+++ b/packages/web/src/pages/saved-page/hooks/useCollectionsData.tsx
@@ -2,24 +2,12 @@ import { useMemo } from 'react'
 
 import { useGetLibraryAlbums, useGetLibraryPlaylists } from '@audius/common/api'
 import { useAllPaginatedQuery } from '@audius/common/audius-query'
-import {
-  accountSelectors,
-  cacheCollectionsSelectors,
-  savedPageSelectors,
-  CommonState
-} from '@audius/common/store'
+import { accountSelectors, savedPageSelectors } from '@audius/common/store'
 import { uniqBy } from 'lodash'
 import { useSelector } from 'react-redux'
 
 const { getUserId } = accountSelectors
-const {
-  getCollectionsCategory,
-  getSelectedCategoryLocalAlbumAdds,
-  getSelectedCategoryLocalAlbumRemovals,
-  getSelectedCategoryLocalPlaylistAdds,
-  getSelectedCategoryLocalPlaylistRemovals
-} = savedPageSelectors
-const { getCollections } = cacheCollectionsSelectors
+const { getCollectionsCategory } = savedPageSelectors
 
 type CollectionsDataParams = {
   collectionType: 'album' | 'playlist'
@@ -32,25 +20,6 @@ export const useCollectionsData = ({
 }: CollectionsDataParams) => {
   const currentUserId = useSelector(getUserId)
   const selectedCategory = useSelector(getCollectionsCategory)
-
-  const locallyAddedCollections = useSelector((state: CommonState) => {
-    const ids =
-      collectionType === 'album'
-        ? getSelectedCategoryLocalAlbumAdds(state)
-        : getSelectedCategoryLocalPlaylistAdds(state)
-    const collectionsMap = getCollections(state, {
-      ids
-    })
-    return ids.map((id) => collectionsMap[id])
-  })
-
-  const locallyRemovedCollections = useSelector((state: CommonState) => {
-    const ids =
-      collectionType === 'album'
-        ? getSelectedCategoryLocalAlbumRemovals(state)
-        : getSelectedCategoryLocalPlaylistRemovals(state)
-    return new Set(ids)
-  })
 
   const {
     data: fetchedCollections,
@@ -70,13 +39,8 @@ export const useCollectionsData = ({
     }
   )
   const collections = useMemo(() => {
-    return uniqBy(
-      [...locallyAddedCollections, ...(fetchedCollections || [])].filter(
-        (a) => !locallyRemovedCollections.has(a.playlist_id)
-      ),
-      'playlist_id'
-    )
-  }, [locallyAddedCollections, fetchedCollections, locallyRemovedCollections])
+    return uniqBy([...(fetchedCollections || [])], 'playlist_id')
+  }, [fetchedCollections])
 
   return {
     status,


### PR DESCRIPTION
### Description

Removing localSaves support. This simplifies work in the meantime on this feature branch until equivalent functionality is added later. We'll likely want to optimisic update new saves directly in the library cache slices, so this code won't be used by the time we merge this feature branch.

This is precursor work to simplify https://github.com/AudiusProject/audius-protocol/pull/11016

### How Has This Been Tested?

library still works (though tracks saved in sessions don't show up of course)