### PR TITLE
Remove z-index on edit form button row to not block the profile complete tooltip

### DIFF
--- a/packages/web/src/components/edit/AnchoredSubmitRow.module.css
+++ b/packages/web/src/components/edit/AnchoredSubmitRow.module.css
@@ -16,6 +16,4 @@
   display: flex;
   flex-direction: column;
   align-items: center;
-
-  z-index: 50;
 }

--- a/packages/web/src/components/edit/AnchoredSubmitRowEdit.module.css
+++ b/packages/web/src/components/edit/AnchoredSubmitRowEdit.module.css
@@ -16,5 +16,4 @@
   display: flex;
   flex-direction: column;
   align-items: center;
-
 }

--- a/packages/web/src/components/edit/AnchoredSubmitRowEdit.module.css
+++ b/packages/web/src/components/edit/AnchoredSubmitRowEdit.module.css
@@ -17,5 +17,4 @@
   flex-direction: column;
   align-items: center;
 
-  z-index: 50;
 }


### PR DESCRIPTION
### Description
Remove the z-index on the button row. the side nav is rendered behind the main content so we can't just blow up the z-index of the tooltip here unfortunately. Not sure is this z-index was placed on the button row for a reason, but it appeared to be fine when removed so this worked for now. 

Can revisit when the updates to this component are done

### How Has This Been Tested?
Manually tested
