### PR TITLE
Update amplitude key on staging & revert change to use gain2

### DIFF
--- a/packages/common/src/services/env.ts
+++ b/packages/common/src/services/env.ts
@@ -6,7 +6,6 @@ export type Env = {
   AAO_ENDPOINT: string
   AMPLITUDE_API_KEY: Nullable<string>
   AMPLITUDE_PROXY: Nullable<string>
-  AMPLITUDE_WRITE_KEY: Nullable<string>
   APP_NAME: string
   API_KEY: string
   AUDIUS_URL: string

--- a/packages/mobile/src/env/env.dev.ts
+++ b/packages/mobile/src/env/env.dev.ts
@@ -5,7 +5,6 @@ export const env: Env = {
   AAO_ENDPOINT: 'http://audius-protocol-anti-abuse-oracle-1',
   AMPLITUDE_API_KEY: null,
   AMPLITUDE_PROXY: null,
-  AMPLITUDE_WRITE_KEY: null,
   API_KEY: '2dc52ec9a4c31790cab6653de0c637f680faa993',
   APP_NAME: 'audius-client',
   AUDIUS_URL: 'https://staging.audius.co',

--- a/packages/mobile/src/env/env.prod.ts
+++ b/packages/mobile/src/env/env.prod.ts
@@ -4,7 +4,7 @@ import Config from 'react-native-config'
 export const env: Env = {
   AAO_ENDPOINT: 'https://antiabuseoracle.audius.co',
   AMPLITUDE_API_KEY: '86760558b8bb1b3aae61656efd4ddacb',
-  AMPLITUDE_PROXY: 'https://gain2.audius.co/2/httpapi',
+  AMPLITUDE_PROXY: 'https://gain.audius.co',
   AMPLITUDE_WRITE_KEY: Config.AMPLITUDE_WRITE_KEY as string,
   API_KEY: '8acf5eb7436ea403ee536a7334faa5e9ada4b50f',
   APP_NAME: 'audius-client',

--- a/packages/mobile/src/env/env.prod.ts
+++ b/packages/mobile/src/env/env.prod.ts
@@ -5,7 +5,6 @@ export const env: Env = {
   AAO_ENDPOINT: 'https://antiabuseoracle.audius.co',
   AMPLITUDE_API_KEY: '86760558b8bb1b3aae61656efd4ddacb',
   AMPLITUDE_PROXY: 'https://gain.audius.co',
-  AMPLITUDE_WRITE_KEY: Config.AMPLITUDE_WRITE_KEY as string,
   API_KEY: '8acf5eb7436ea403ee536a7334faa5e9ada4b50f',
   APP_NAME: 'audius-client',
   AUDIUS_URL: 'https://audius.co',

--- a/packages/mobile/src/env/env.stage.ts
+++ b/packages/mobile/src/env/env.stage.ts
@@ -5,7 +5,6 @@ export const env: Env = {
   AAO_ENDPOINT: 'https://antiabuseoracle.staging.audius.co',
   AMPLITUDE_API_KEY: '72a58ce4ad1f9bafcba0b92bedb6c33d',
   AMPLITUDE_PROXY: 'https://gain.audius.co',
-  AMPLITUDE_WRITE_KEY: Config.AMPLITUDE_WRITE_KEY as string,
   API_KEY: '2dc52ec9a4c31790cab6653de0c637f680faa993',
   APP_NAME: 'audius-client',
   AUDIUS_URL: 'https://staging.audius.co',

--- a/packages/mobile/src/env/env.stage.ts
+++ b/packages/mobile/src/env/env.stage.ts
@@ -4,7 +4,7 @@ import Config from 'react-native-config'
 export const env: Env = {
   AAO_ENDPOINT: 'https://antiabuseoracle.staging.audius.co',
   AMPLITUDE_API_KEY: '72a58ce4ad1f9bafcba0b92bedb6c33d',
-  AMPLITUDE_PROXY: 'https://gain2.audius.co/2/httpapi',
+  AMPLITUDE_PROXY: 'https://gain.audius.co',
   AMPLITUDE_WRITE_KEY: Config.AMPLITUDE_WRITE_KEY as string,
   API_KEY: '2dc52ec9a4c31790cab6653de0c637f680faa993',
   APP_NAME: 'audius-client',

--- a/packages/mobile/src/services/analytics.ts
+++ b/packages/mobile/src/services/analytics.ts
@@ -12,7 +12,7 @@ const { version: clientVersion } = packageInfo
 
 let analyticsSetupStatus: 'ready' | 'pending' | 'error' = 'pending'
 
-const AmplitudeWriteKey = env.AMPLITUDE_WRITE_KEY
+const AmplitudeWriteKey = env.AMPLITUDE_API_KEY
 const AmplitudeProxy = env.AMPLITUDE_PROXY
 const amplitudeInstance = Amplitude.getInstance()
 const IS_PRODUCTION_BUILD = process.env.NODE_ENV === 'production'

--- a/packages/web/src/services/env/env.dev.ts
+++ b/packages/web/src/services/env/env.dev.ts
@@ -4,7 +4,6 @@ export const env: Env = {
   AAO_ENDPOINT: 'http://audius-protocol-anti-abuse-oracle-1',
   AMPLITUDE_API_KEY: null,
   AMPLITUDE_PROXY: null,
-  AMPLITUDE_WRITE_KEY: null,
   API_KEY: '2dc52ec9a4c31790cab6653de0c637f680faa993',
   APP_NAME: 'audius-client',
   AUDIUS_URL: 'https://staging.audius.co',

--- a/packages/web/src/services/env/env.prod.ts
+++ b/packages/web/src/services/env/env.prod.ts
@@ -4,7 +4,6 @@ export const env: Env = {
   AAO_ENDPOINT: 'https://antiabuseoracle.audius.co',
   AMPLITUDE_API_KEY: '86760558b8bb1b3aae61656efd4ddacb',
   AMPLITUDE_PROXY: 'https://gain2.audius.co/2/httpapi',
-  AMPLITUDE_WRITE_KEY: null,
   API_KEY: '8acf5eb7436ea403ee536a7334faa5e9ada4b50f',
   APP_NAME: 'audius-client',
   AUDIUS_URL: 'https://audius.co',

--- a/packages/web/src/services/env/env.stage.ts
+++ b/packages/web/src/services/env/env.stage.ts
@@ -4,7 +4,6 @@ export const env: Env = {
   AAO_ENDPOINT: 'https://antiabuseoracle.staging.audius.co',
   AMPLITUDE_API_KEY: '72a58ce4ad1f9bafcba0b92bedb6c33d',
   AMPLITUDE_PROXY: 'https://gain2.audius.co/2/httpapi',
-  AMPLITUDE_WRITE_KEY: null,
   API_KEY: '2dc52ec9a4c31790cab6653de0c637f680faa993',
   APP_NAME: 'audius-client',
   AUDIUS_URL: 'https://staging.audius.co',


### PR DESCRIPTION
### Description

- Update how API Key env config in mobile - previously we had two entries for the API key, different between web & mobile. Standardized to use AMPLITUDE_API_KEY which we use on web & isnt injected at CI time
- On mobile undid the `gain2.audius.co` proxy change - the react native api still seems to be using the v1 proxy


### How Has This Been Tested?

local stage simulator -> see event in amplitude -> profit
![image](https://github.com/user-attachments/assets/92c90dac-81dc-472c-b1b9-f4fb930237a9)

TODO: once this hits staging will test on that app instead

