### PR TITLE
Fix missing comma in vector toml

### DIFF
--- a/monitoring/vector/vector.toml
+++ b/monitoring/vector/vector.toml
@@ -15,7 +15,7 @@
     "mediorum",
     "relay",
     "solana-relay",
-    "core"
+    "core",
     "audiusd"
   ]
   exclude_containers = [


### PR DESCRIPTION
### Description

Vector was crashlooping due to the curse of the missing comma.

### How Has This Been Tested?

Ran vector container locally and confirmed toml error disappeared
