### PR TITLE
[PAY-3799] Re-add playlist update dot

### DIFF
--- a/packages/harmony/src/components/nav-item/NavItem.tsx
+++ b/packages/harmony/src/components/nav-item/NavItem.tsx
@@ -21,6 +21,7 @@ export const NavItem = ({
   onClick,
   textSize = 'l',
   hasNotification = false,
+  leftOverride,
   ...props
 }: NavItemProps) => {
   const { color } = useTheme()
@@ -86,7 +87,7 @@ export const NavItem = ({
             maxWidth: '240px'
           }}
         >
-          {leftIconWithNotification}
+          {leftOverride || leftIconWithNotification}
           <Text
             variant='title'
             size={textSize}

--- a/packages/harmony/src/components/nav-item/types.ts
+++ b/packages/harmony/src/components/nav-item/types.ts
@@ -10,6 +10,8 @@ export type NavItemProps = WithCSS<{
   children: ReactNode
   /** The name of the icon to display on the left side of the label. */
   leftIcon?: IconComponent
+  /** Override the left icon with a custom component. */
+  leftOverride?: ReactNode
   /** The name of the icon to display on the right side of the label. */
   rightIcon?: ReactNode
   /** Whether the navigation item is currently selected. */

--- a/packages/web/src/components/nav/desktop/PlaylistLibrary/CollectionNavItem.tsx
+++ b/packages/web/src/components/nav/desktop/PlaylistLibrary/CollectionNavItem.tsx
@@ -212,6 +212,7 @@ export const CollectionNavItem = (props: CollectionNavItemProps) => {
                 />
               ) : null
             }
+            leftOverride={hasUpdate ? <PlaylistUpdateDot /> : null}
           >
             <Flex
               alignItems='center'
@@ -221,16 +222,6 @@ export const CollectionNavItem = (props: CollectionNavItemProps) => {
               css={{ position: 'relative' }}
               justifyContent='space-between'
             >
-              {hasUpdate ? (
-                <div
-                  css={{
-                    position: 'absolute',
-                    left: -spacing.m + indentAmount
-                  }}
-                >
-                  <PlaylistUpdateDot />
-                </div>
-              ) : null}
               <Text
                 variant='body'
                 size='s'


### PR DESCRIPTION
### Description

The circle for playlist updates was previously removed, this PR adds it back. 

We have to utilize the `leftOverride` for now because of how we are currently uniformly handling `leftIcons` in the component. 

### How Has This Been Tested?

`npm run web:stage`

- Update a playlist 
- Ensure that the purple dot shows on it 

![image](https://github.com/user-attachments/assets/b2eaacf3-e2fd-4942-8bda-67e6ecfdfda1)

