### PR TITLE
Show users without handles in users API

### DIFF
--- a/packages/discovery-provider/src/queries/get_unpopulated_users.py
+++ b/packages/discovery-provider/src/queries/get_unpopulated_users.py
@@ -26,7 +26,7 @@ def get_unpopulated_users(session, user_ids):
 
     users = (
         session.query(User)
-        .filter(User.is_current == True, User.wallet != None, User.handle != None)
+        .filter(User.is_current == True, User.wallet != None)
         .filter(User.user_id.in_(user_ids))
         .all()
     )


### PR DESCRIPTION
### Description

Show guest users in bulk user request. Necessary to show in-app notifications from guest users. Push / email do not require this. This may have broader implications so will need more QA. Might not be worth shipping 😅

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._
<img width="424" alt="Screenshot 2025-01-13 at 2 42 12 PM" src="https://github.com/user-attachments/assets/581155b3-a87f-4a09-8fa8-d78cde602fbe" />

Guest purchase shows in app notification. 


<img width="425" alt="Screenshot 2025-01-13 at 2 49 45 PM" src="https://github.com/user-attachments/assets/236e2eb9-9b3b-498b-894f-d28d2e1da843" />

Guest purchase after profile completion
