### PR TITLE
[C-5542] Fix play counting bug on web track edits

### DIFF
--- a/packages/web/src/components/edit-track/EditTrackForm.tsx
+++ b/packages/web/src/components/edit-track/EditTrackForm.tsx
@@ -209,9 +209,7 @@ const TrackEditForm = (
     FeatureFlags.TRACK_REPLACE_DOWNLOADS
   )
 
-  const [{ value: track }, , { setValue: setTrackValue }] = useField(
-    `tracks.${trackIdx}`
-  )
+  const [, , { setValue: setTrackValue }] = useField(`tracks.${trackIdx}`)
   const [, { touched: isTitleDirty }, { setValue: setTitle }] = useField(
     getTrackFieldName(trackIdx, 'title')
   )
@@ -252,7 +250,6 @@ const TrackEditForm = (
     formValues,
     trackIdx,
     preview,
-    trackIdx,
     isPreviewPlaying,
     initialTrackId,
     isUpload

--- a/packages/web/src/components/edit-track/EditTrackForm.tsx
+++ b/packages/web/src/components/edit-track/EditTrackForm.tsx
@@ -1,10 +1,11 @@
-import { useCallback, useContext, useEffect, useState } from 'react'
+import { useCallback, useContext, useEffect, useMemo, useState } from 'react'
 
 import { useFeatureFlag } from '@audius/common/hooks'
 import { DownloadQuality, Name } from '@audius/common/models'
 import { TrackMetadataFormSchema } from '@audius/common/schemas'
 import { FeatureFlags } from '@audius/common/services'
 import {
+  TrackForUpload,
   TrackMetadataForUpload,
   useEarlyReleaseConfirmationModal,
   useHideContentConfirmationModal,
@@ -221,6 +222,15 @@ const TrackEditForm = (
     getTrackFieldName(trackIdx, 'orig_filename')
   )
 
+  const trackPreviewUrl =
+    formValues.trackMetadatas[trackIdx]?.download?.url ??
+    formValues.trackMetadatas[trackIdx]?.stream?.url ??
+    ''
+
+  const preview = useMemo(() => {
+    return new Audio(trackPreviewUrl)
+  }, [trackPreviewUrl])
+
   const handleTogglePreview = useCallback(() => {
     if (!isPreviewPlaying) {
       // Track Preview event
@@ -233,10 +243,15 @@ const TrackEditForm = (
       )
     }
 
-    togglePreview(track.preview, trackIdx)
+    const currentPreview =
+      (formValues.tracks[trackIdx] as TrackForUpload)?.preview ?? preview
+
+    togglePreview(currentPreview, trackIdx)
   }, [
     togglePreview,
-    track.preview,
+    formValues,
+    trackIdx,
+    preview,
     trackIdx,
     isPreviewPlaying,
     initialTrackId,

--- a/packages/web/src/pages/edit-page/EditTrackPage.tsx
+++ b/packages/web/src/pages/edit-page/EditTrackPage.tsx
@@ -125,16 +125,10 @@ export const EditTrackPage = (props: EditPageProps) => {
     stems: stemsAsUploads
   }
 
-  const previewUrl =
-    trackAsMetadataForUpload.download?.url ||
-    trackAsMetadataForUpload.stream?.url ||
-    ''
-
   const initialValues: TrackEditFormValues = {
     tracks: [
       {
-        metadata: trackAsMetadataForUpload,
-        preview: new Audio(previewUrl)
+        metadata: trackAsMetadataForUpload
       }
     ],
     trackMetadatas: [trackAsMetadataForUpload],


### PR DESCRIPTION
### Description
There was an issue where rerenders of the edit form would result in cidstream requests that would count towards track plays being counted. This was due to the audio element for the preview being created each render. I moved some code around to make sure that only one instance of this happens when the preview audio is created the first time so this will minimize the effect a lot.

### How Has This Been Tested?
Manually tested, Only one cidstream instance in the network tab
