### PR TITLE
[PAY-3792] Persist upload state between navigations

### DIFF
--- a/packages/common/src/store/upload/actions.ts
+++ b/packages/common/src/store/upload/actions.ts
@@ -8,6 +8,7 @@ import {
   Progress,
   TrackForUpload,
   TrackMetadataForUpload,
+  UploadFormState,
   UploadType
 } from './types'
 
@@ -23,10 +24,9 @@ export const UPDATE_PERCENT = 'UPLOAD/UPDATE_PERCENT'
 export const INCREMENT_PERCENT = 'UPLOAD/INCREMENT_PERCENT'
 export const UPDATE_PROGRESS = 'UPLOAD/UPDATE_PROGRESS'
 export const RESET = 'UPLOAD/RESET'
-export const RESET_STATE = 'UPLOAD/RESET_STATE'
-export const UNDO_RESET_STATE = 'UPLOAD/UNDO_RESET_STATE'
 export const TOGGLE_MULTI_TRACK_NOTIFICATION =
   'UPLOAD/TOGGLE_MULTI_TRACK_NOTIFICATION'
+export const UPDATE_FORM_STATE = 'UPLOAD/UPDATE_FORM_STATE'
 
 type UploadPayload =
   | {
@@ -99,17 +99,16 @@ export const updateTrackAudio = (payload: {
   }
 }
 
+// Persists the form state in the store for resuming upload
+// upon navigating back to the upload page
+export const updateFormState = (payload: UploadFormState) => {
+  return { type: UPDATE_FORM_STATE, payload }
+}
+
 // Actions used to reset the react state and then the store state of upload from external container
 
 export const reset = () => {
   return { type: RESET }
-}
-
-export const resetState = () => {
-  return { type: RESET_STATE }
-}
-export const undoResetState = () => {
-  return { type: UNDO_RESET_STATE }
 }
 
 export const toggleMultiTrackNotification = (open = false) => {

--- a/packages/common/src/store/upload/reducer.ts
+++ b/packages/common/src/store/upload/reducer.ts
@@ -9,11 +9,11 @@ import {
   UPLOAD_TRACKS_FAILED,
   UPDATE_PROGRESS,
   RESET,
-  RESET_STATE,
-  UNDO_RESET_STATE,
   uploadTracksRequested,
   uploadTracksSucceeded,
-  updateProgress
+  updateProgress,
+  updateFormState,
+  UPDATE_FORM_STATE
 } from './actions'
 import {
   ProgressState,
@@ -31,8 +31,8 @@ const initialState: UploadState = {
   stems: [],
   uploading: false,
   uploadProgress: null,
+  formState: null,
   success: false,
-  shouldReset: false,
 
   // For multitrack upload, we allow some tracks to
   // fail without aborting the whole thing
@@ -174,22 +174,19 @@ const actionsMap = {
     }
     return newState
   },
+  [UPDATE_FORM_STATE](
+    state: UploadState,
+    action: ReturnType<typeof updateFormState>
+  ) {
+    return {
+      ...state,
+      formState: action.payload
+    }
+  },
   [RESET](state: UploadState) {
     return {
       ...initialState,
       openMultiTrackNotification: state.openMultiTrackNotification
-    }
-  },
-  [RESET_STATE](state: UploadState) {
-    return {
-      ...state,
-      shouldReset: true
-    }
-  },
-  [UNDO_RESET_STATE](state: UploadState) {
-    return {
-      ...state,
-      shouldReset: false
     }
   }
 }

--- a/packages/common/src/store/upload/selectors.ts
+++ b/packages/common/src/store/upload/selectors.ts
@@ -11,7 +11,7 @@ export const getUploadSuccess = (state: CommonState) => state.upload.success
 export const getUploadError = (state: CommonState) => state.upload.error
 export const getTracks = (state: CommonState) => state.upload.tracks
 export const getIsUploading = (state: CommonState) => state.upload.uploading
-export const getShouldReset = (state: CommonState) => state.upload.shouldReset
+export const getFormState = (state: CommonState) => state.upload.formState
 
 // Should sum to 1
 const UPLOAD_WEIGHT = 0.5

--- a/packages/common/src/store/upload/types.ts
+++ b/packages/common/src/store/upload/types.ts
@@ -97,6 +97,28 @@ export type ProgressState = {
   stems: ProgressState[]
 }
 
+type InitialFormState = {
+  uploadType: undefined
+  tracks: undefined
+  metadata: undefined
+}
+
+export type TrackFormState = {
+  uploadType: UploadType.INDIVIDUAL_TRACK | UploadType.INDIVIDUAL_TRACKS
+  tracks: TrackForUpload[]
+}
+
+export type CollectionFormState = {
+  uploadType: UploadType.ALBUM | UploadType.PLAYLIST
+  tracks: TrackForUpload[]
+  metadata: CollectionValues
+}
+
+export type UploadFormState =
+  | TrackFormState
+  | CollectionFormState
+  | InitialFormState
+
 type UploadStateBase = {
   openMultiTrackNotification: boolean
   tracks: Nullable<TrackForUpload[]>
@@ -105,10 +127,10 @@ type UploadStateBase = {
   uploadProgress: Nullable<ProgressState[]>
   success: boolean
   error: boolean
-  shouldReset: boolean
   completionId: Nullable<number>
   stems: StemUpload[][]
   failedTrackIndices: number[]
+  formState: Nullable<UploadFormState>
 }
 
 type UploadStateForTracks = UploadStateBase & {

--- a/packages/web/src/components/nav/desktop/useNavConfig.tsx
+++ b/packages/web/src/components/nav/desktop/useNavConfig.tsx
@@ -1,7 +1,11 @@
 import { ReactNode, useMemo } from 'react'
 
 import { useChallengeCooldownSchedule } from '@audius/common/hooks'
-import { accountSelectors, chatSelectors } from '@audius/common/store'
+import {
+  accountSelectors,
+  chatSelectors,
+  uploadSelectors
+} from '@audius/common/store'
 import { route } from '@audius/common/utils'
 import type { IconComponent } from '@audius/harmony'
 import {
@@ -14,6 +18,7 @@ import {
   IconPlaylists,
   IconTrending,
   IconWallet,
+  LoadingSpinner,
   NotificationCount
 } from '@audius/harmony'
 import { useSelector } from 'react-redux'
@@ -37,6 +42,7 @@ const {
 
 const { getUnreadMessagesCount } = chatSelectors
 const { getIsAccountComplete } = accountSelectors
+const { getIsUploading } = uploadSelectors
 
 export type NavItemConfig = {
   label: string
@@ -55,6 +61,7 @@ export type NavItemConfig = {
 export const useNavConfig = () => {
   const isAccountComplete = useSelector(getIsAccountComplete)
   const unreadMessagesCount = useSelector(getUnreadMessagesCount)
+  const isUploading = useSelector(getIsUploading)
   const { claimableAmount } = useChallengeCooldownSchedule({
     multiple: true
   })
@@ -126,6 +133,19 @@ export const useNavConfig = () => {
         label: 'Upload',
         leftIcon: IconCloudUpload,
         to: UPLOAD_PAGE,
+        rightIcon: isUploading ? (
+          <LoadingSpinner
+            css={{
+              width: 24,
+              height: 24,
+              color:
+                location.pathname === UPLOAD_PAGE
+                  ? 'var(--harmony-static-white)'
+                  : 'var(--harmony-n-800)'
+            }}
+          />
+        ) : undefined,
+        shouldPersistRightIcon: true,
         restriction: 'account'
       },
       {
@@ -139,7 +159,13 @@ export const useNavConfig = () => {
         canUnfurl: isAccountComplete
       }
     ],
-    [unreadMessagesCount, location.pathname, isAccountComplete, claimableAmount]
+    [
+      unreadMessagesCount,
+      location.pathname,
+      isAccountComplete,
+      claimableAmount,
+      isUploading
+    ]
   )
 
   return navItems

--- a/packages/web/src/components/nav/desktop/useNavConfig.tsx
+++ b/packages/web/src/components/nav/desktop/useNavConfig.tsx
@@ -19,7 +19,8 @@ import {
   IconTrending,
   IconWallet,
   LoadingSpinner,
-  NotificationCount
+  NotificationCount,
+  useTheme
 } from '@audius/harmony'
 import { useSelector } from 'react-redux'
 import { useLocation } from 'react-router-dom'
@@ -62,6 +63,7 @@ export const useNavConfig = () => {
   const isAccountComplete = useSelector(getIsAccountComplete)
   const unreadMessagesCount = useSelector(getUnreadMessagesCount)
   const isUploading = useSelector(getIsUploading)
+  const { color, spacing } = useTheme()
   const { claimableAmount } = useChallengeCooldownSchedule({
     multiple: true
   })
@@ -136,12 +138,12 @@ export const useNavConfig = () => {
         rightIcon: isUploading ? (
           <LoadingSpinner
             css={{
-              width: 24,
-              height: 24,
+              width: spacing.unit6,
+              height: spacing.unit6,
               color:
                 location.pathname === UPLOAD_PAGE
-                  ? 'var(--harmony-static-white)'
-                  : 'var(--harmony-n-800)'
+                  ? color.static.white
+                  : color.neutral.n800
             }}
           />
         ) : undefined,
@@ -164,7 +166,9 @@ export const useNavConfig = () => {
       location.pathname,
       isAccountComplete,
       claimableAmount,
-      isUploading
+      isUploading,
+      color,
+      spacing
     ]
   )
 

--- a/packages/web/src/pages/upload-page/UploadPage.tsx
+++ b/packages/web/src/pages/upload-page/UploadPage.tsx
@@ -170,10 +170,15 @@ export const UploadPage = (props: UploadPageProps) => {
   }, [dispatch, formState])
 
   useEffect(() => {
-    if (phase === Phase.FINISH && !isUploading) {
+    if (
+      phase === Phase.FINISH &&
+      !isUploading &&
+      !uploadSuccess &&
+      !uploadError
+    ) {
       handleUpload()
     }
-  }, [handleUpload, phase, isUploading])
+  }, [handleUpload, phase, isUploading, uploadSuccess, uploadError])
 
   return (
     <Page

--- a/packages/web/src/pages/upload-page/UploadPage.tsx
+++ b/packages/web/src/pages/upload-page/UploadPage.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useState } from 'react'
 
 import {
   uploadActions,
+  UploadFormState,
   uploadSelectors,
   UploadType,
   useUploadConfirmationModal
@@ -17,10 +18,10 @@ import styles from './UploadPage.module.css'
 import { EditPage } from './pages/EditPage'
 import { FinishPage } from './pages/FinishPage'
 import SelectPage from './pages/SelectPage'
-import { UploadFormState } from './types'
 
-const { uploadTracks, undoResetState } = uploadActions
-const { getShouldReset } = uploadSelectors
+const { uploadTracks, updateFormState, reset } = uploadActions
+const { getFormState, getUploadSuccess, getUploadError, getIsUploading } =
+  uploadSelectors
 
 const messages = {
   selectPageTitle: 'Upload Your Music',
@@ -41,7 +42,7 @@ const uploadTypeStringMap: Record<UploadType, string> = {
   [UploadType.PLAYLIST]: 'Playlist'
 }
 
-const initialFormState = {
+const initialFormState: UploadFormState = {
   uploadType: undefined,
   metadata: undefined,
   tracks: undefined
@@ -54,9 +55,27 @@ type UploadPageProps = {
 export const UploadPage = (props: UploadPageProps) => {
   const { scrollToTop } = props
   const dispatch = useDispatch()
-  const [phase, setPhase] = useState(Phase.SELECT)
-  const [formState, setFormState] = useState<UploadFormState>(initialFormState)
-  const shouldResetState = useSelector(getShouldReset)
+  const formStateFromStore = useSelector(getFormState)
+  const uploadSuccess = useSelector(getUploadSuccess)
+  const uploadError = useSelector(getUploadError)
+  const isUploading = useSelector(getIsUploading)
+  const [formState, setFormState] = useState<UploadFormState>(
+    formStateFromStore ?? initialFormState
+  )
+  // Start the user on the finish page if they have a form state
+  const [phase, setPhase] = useState(
+    formStateFromStore ? Phase.FINISH : Phase.SELECT
+  )
+
+  // Clean up the store on unmount only if the upload succeeded or failed
+  // Allow users to resume in progress uploads otherwise.
+  useEffect(() => {
+    return () => {
+      if (uploadSuccess || uploadError) {
+        dispatch(reset())
+      }
+    }
+  }, [uploadSuccess, uploadError, dispatch])
 
   const { tracks, uploadType } = formState
 
@@ -113,6 +132,7 @@ export const UploadPage = (props: UploadPageProps) => {
             formState={formState}
             onContinue={(formState: UploadFormState) => {
               setFormState(formState)
+              dispatch(updateFormState(formState))
               const isPrivateCollection =
                 'metadata' in formState && formState.metadata?.is_private
               const hasPublicTracks =
@@ -137,19 +157,12 @@ export const UploadPage = (props: UploadPageProps) => {
                 metadata: undefined
               })
               setPhase(Phase.SELECT)
+              dispatch(reset())
             }}
           />
         )
       }
   }
-
-  useEffect(() => {
-    if (shouldResetState) {
-      setFormState(initialFormState)
-      setPhase(Phase.SELECT)
-      dispatch(undoResetState())
-    }
-  }, [dispatch, shouldResetState])
 
   const handleUpload = useCallback(() => {
     if (!formState.tracks) return
@@ -157,8 +170,10 @@ export const UploadPage = (props: UploadPageProps) => {
   }, [dispatch, formState])
 
   useEffect(() => {
-    if (phase === Phase.FINISH) handleUpload()
-  }, [handleUpload, phase])
+    if (phase === Phase.FINISH && !isUploading) {
+      handleUpload()
+    }
+  }, [handleUpload, phase, isUploading])
 
   return (
     <Page

--- a/packages/web/src/pages/upload-page/UploadPage.tsx
+++ b/packages/web/src/pages/upload-page/UploadPage.tsx
@@ -170,12 +170,10 @@ export const UploadPage = (props: UploadPageProps) => {
   }, [dispatch, formState])
 
   useEffect(() => {
-    if (
-      phase === Phase.FINISH &&
-      !isUploading &&
-      !uploadSuccess &&
-      !uploadError
-    ) {
+    // Actually trigger the upload when the user is on the finish page
+    // and there is not already existing upload progress
+    const isUploadPending = !isUploading && !uploadSuccess && !uploadError
+    if (phase === Phase.FINISH && isUploadPending) {
       handleUpload()
     }
   }, [handleUpload, phase, isUploading, uploadSuccess, uploadError])

--- a/packages/web/src/pages/upload-page/forms/UploadCollectionForm.tsx
+++ b/packages/web/src/pages/upload-page/forms/UploadCollectionForm.tsx
@@ -1,12 +1,14 @@
 import { useCallback } from 'react'
 
 import { CollectionValues } from '@audius/common/schemas'
-import { TrackForUpload, UploadType } from '@audius/common/store'
+import {
+  CollectionFormState,
+  TrackForUpload,
+  UploadType
+} from '@audius/common/store'
 import moment from 'moment'
 
 import { EditCollectionForm } from 'components/edit-collection/EditCollectionForm'
-
-import { CollectionFormState } from '../types'
 
 type UploadCollectionFormProps = {
   formState: CollectionFormState

--- a/packages/web/src/pages/upload-page/forms/UploadTrackForm.tsx
+++ b/packages/web/src/pages/upload-page/forms/UploadTrackForm.tsx
@@ -1,12 +1,10 @@
 import { useCallback, useMemo } from 'react'
 
-import { TrackForUpload } from '@audius/common/store'
+import { TrackFormState, TrackForUpload } from '@audius/common/store'
 import moment from 'moment'
 
 import { EditTrackForm } from 'components/edit-track/EditTrackForm'
 import { TrackEditFormValues } from 'components/edit-track/types'
-
-import { TrackFormState } from '../types'
 
 type UploadTrackFormProps = {
   formState: TrackFormState

--- a/packages/web/src/pages/upload-page/pages/EditPage.tsx
+++ b/packages/web/src/pages/upload-page/pages/EditPage.tsx
@@ -1,13 +1,17 @@
 import { useContext } from 'react'
 
-import { UploadType } from '@audius/common/store'
+import {
+  CollectionFormState,
+  TrackFormState,
+  UploadFormState,
+  UploadType
+} from '@audius/common/store'
 import { useUnmount } from 'react-use'
 
 import { UploadPreviewContext } from 'components/edit-track/utils/uploadPreviewContext'
 
 import { UploadCollectionForm } from '../forms/UploadCollectionForm'
 import { UploadTrackForm } from '../forms/UploadTrackForm'
-import { CollectionFormState, TrackFormState, UploadFormState } from '../types'
 
 type EditPageProps = {
   formState: TrackFormState | CollectionFormState

--- a/packages/web/src/pages/upload-page/pages/FinishPage.tsx
+++ b/packages/web/src/pages/upload-page/pages/FinishPage.tsx
@@ -9,7 +9,9 @@ import {
   ProgressStatus,
   CommonState,
   ProgressState,
-  TrackForUpload
+  TrackForUpload,
+  TrackFormState,
+  CollectionFormState
 } from '@audius/common/store'
 import { route } from '@audius/common/utils'
 import {
@@ -30,7 +32,6 @@ import LoadingSpinner from 'components/loading-spinner/LoadingSpinner'
 import { Tile } from 'components/tile'
 
 import { ShareBanner } from '../components/ShareBanner'
-import { CollectionFormState, TrackFormState } from '../types'
 
 import styles from './FinishPage.module.css'
 

--- a/packages/web/src/pages/upload-page/pages/SelectPage.tsx
+++ b/packages/web/src/pages/upload-page/pages/SelectPage.tsx
@@ -2,7 +2,7 @@ import { useCallback, useState } from 'react'
 
 import { ErrorLevel, Feature } from '@audius/common/models'
 import { newCollectionMetadata } from '@audius/common/schemas'
-import { UploadType } from '@audius/common/store'
+import { UploadFormState, UploadType } from '@audius/common/store'
 import { removeNullable, Nullable } from '@audius/common/utils'
 import cn from 'classnames'
 
@@ -13,7 +13,6 @@ import { reportToSentry } from 'store/errors/reportToSentry'
 
 import { TracksPreview } from '../components/TracksPreview'
 import { processFiles } from '../store/utils/processFiles'
-import { UploadFormState } from '../types'
 
 import styles from './SelectPage.module.css'
 

--- a/packages/web/src/pages/upload-page/types.ts
+++ b/packages/web/src/pages/upload-page/types.ts
@@ -1,27 +1,4 @@
-import { CollectionValues } from '@audius/common/schemas'
-import { UploadType, TrackForUpload } from '@audius/common/store'
-
-type InitialFormState = {
-  uploadType: undefined
-  tracks: undefined
-  metadata: undefined
-}
-
-export type TrackFormState = {
-  uploadType: UploadType.INDIVIDUAL_TRACK | UploadType.INDIVIDUAL_TRACKS
-  tracks: TrackForUpload[]
-}
-
-export type CollectionFormState = {
-  uploadType: UploadType.ALBUM | UploadType.PLAYLIST
-  tracks: TrackForUpload[]
-  metadata: CollectionValues
-}
-
-export type UploadFormState =
-  | TrackFormState
-  | CollectionFormState
-  | InitialFormState
+import { TrackForUpload } from '@audius/common/store'
 
 export type CollectionTrackForUpload = TrackForUpload & {
   override: boolean


### PR DESCRIPTION
### Description

Update upload flow and new nav to allow users to resume uploads after navigating elsewhere in the app.
<img width="956" alt="image" src="https://github.com/user-attachments/assets/b6ae868a-1e39-4412-9c3c-51c3ab24e1d8" />
<img width="955" alt="image" src="https://github.com/user-attachments/assets/e3426e9a-929d-48ea-afbf-6e3847907542" />

* Add spinner to nav item that shows if an upload is present, regardless of which page the user is on
* Persist in redux the current form state when the user moves to the finish page
* Only submit form on component mount if no previous pending, success, or error state is present
* Reset redux on dismount if success or on `onContinue` from finish page
* Clean up unused `resetState` actions/reducers

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._

Local web client
1. Upload staying on page
2. Upload leaving during byte upload, coming back during transcode upload
3. Upload leaving during transcode upload, coming back during transcode upload
4. Upload leaving and letting finish in the background (we probably want to toast in this situation, but will leave for future work). Probably useContext is the better long term solve for all of this.

Will sync w/ design on the UI bits