### PR TITLE
Update bootstrap nodes given rpc migration path

### DIFF
--- a/packages/sdk/src/sdk/config/development.ts
+++ b/packages/sdk/src/sdk/config/development.ts
@@ -5,54 +5,54 @@
 /* eslint-disable prettier/prettier */
 import type { SdkServicesConfig } from './types'
 export const developmentConfig: SdkServicesConfig = {
-  network: {
-    minVersion: '0.0.0',
-    discoveryNodes: [
+  "network": {
+    "minVersion": "0.0.0",
+    "discoveryNodes": [
       {
-        delegateOwnerWallet:
-          '0xd09ba371c359f10f22ccda12fd26c598c7921bda3220c9942174562bc6a36fe8',
-        endpoint: 'http://audius-protocol-discovery-provider-1',
-        ownerWallet:
-          '0xd09ba371c359f10f22ccda12fd26c598c7921bda3220c9942174562bc6a36fe8'
+        "delegateOwnerWallet": "0xd09ba371c359f10f22ccda12fd26c598c7921bda3220c9942174562bc6a36fe8",
+        "endpoint": "http://audius-protocol-discovery-provider-1",
+        "ownerWallet": "0xd09ba371c359f10f22ccda12fd26c598c7921bda3220c9942174562bc6a36fe8"
       }
     ],
-    storageNodes: [
+    "storageNodes": [
       {
-        delegateOwnerWallet: '0x0D38e653eC28bdea5A2296fD5940aaB2D0B8875c',
-        endpoint: 'http://audius-protocol-creator-node-1'
+        "delegateOwnerWallet": "0x0D38e653eC28bdea5A2296fD5940aaB2D0B8875c",
+        "endpoint": "http://audius-protocol-creator-node-1"
       }
     ],
-    antiAbuseOracleNodes: {
-      endpoints: ['http://audius-protocol-anti-abuse-oracle-1:8000'],
-      registeredAddresses: ['0xF0D5BC18421fa04D0a2A2ef540ba5A9f04014BE3']
+    "antiAbuseOracleNodes": {
+      "endpoints": [
+        "http://audius-protocol-anti-abuse-oracle-1:8000"
+      ],
+      "registeredAddresses": [
+        "0xF0D5BC18421fa04D0a2A2ef540ba5A9f04014BE3"
+      ]
     },
-    identityService: 'https://audius-protocol-identity-service-1'
+    "identityService": "https://audius-protocol-identity-service-1"
   },
-  acdc: {
-    entityManagerContractAddress: '0x254dffcd3277C0b1660F6d42EFbB754edaBAbC2B',
-    chainId: 1337
+  "acdc": {
+    "entityManagerContractAddress": "0x254dffcd3277C0b1660F6d42EFbB754edaBAbC2B",
+    "chainId": 1337
   },
-  solana: {
-    claimableTokensProgramAddress:
-      'testHKV1B56fbvop4w6f2cTGEub9dRQ2Euta5VmqdX9',
-    rewardManagerProgramAddress: 'testLsJKtyABc9UXJF8JWFKf1YH4LmqCWBC42c6akPb',
-    rewardManagerStateAddress: 'DJPzVothq58SmkpRb1ATn5ddN2Rpv1j2TcGvM3XsHf1c',
-    paymentRouterProgramAddress: 'apaySbqV1XAmuiGszeN4NyWrXkkMrnuJVoNhzmS1AMa',
-    stakingBridgeProgramAddress: '',
-    rpcEndpoint: 'http://audius-protocol-solana-test-validator-1',
-    usdcTokenMint: '26Q7gP8UfkDzi7GMFEQxTJaNJ8D2ybCUjex58M5MLu8y',
-    wAudioTokenMint: '37RCjhgV1qGV2Q54EHFScdxZ22ydRMdKMtVgod47fDP3',
-    rewardManagerLookupTableAddress:
-      'GNHKVSmHvoRBt1JJCxz7RSMfzDQGDGhGEjmhHyxb3K5J'
+  "solana": {
+    "claimableTokensProgramAddress": "testHKV1B56fbvop4w6f2cTGEub9dRQ2Euta5VmqdX9",
+    "rewardManagerProgramAddress": "testLsJKtyABc9UXJF8JWFKf1YH4LmqCWBC42c6akPb",
+    "rewardManagerStateAddress": "DJPzVothq58SmkpRb1ATn5ddN2Rpv1j2TcGvM3XsHf1c",
+    "paymentRouterProgramAddress": "apaySbqV1XAmuiGszeN4NyWrXkkMrnuJVoNhzmS1AMa",
+    "stakingBridgeProgramAddress": "",
+    "rpcEndpoint": "http://audius-protocol-solana-test-validator-1",
+    "usdcTokenMint": "26Q7gP8UfkDzi7GMFEQxTJaNJ8D2ybCUjex58M5MLu8y",
+    "wAudioTokenMint": "37RCjhgV1qGV2Q54EHFScdxZ22ydRMdKMtVgod47fDP3",
+    "rewardManagerLookupTableAddress": "GNHKVSmHvoRBt1JJCxz7RSMfzDQGDGhGEjmhHyxb3K5J"
   },
-  ethereum: {
-    rpcEndpoint: 'https://audius-protocol-eth-ganache-1',
-    addresses: {
-      ethRewardsManagerAddress: '0x',
-      serviceProviderFactoryAddress: '0x',
-      serviceTypeManagerAddress: '0x',
-      audiusTokenAddress: '0xdcB2fC9469808630DD0744b0adf97C0003fC29B2',
-      audiusWormholeAddress: '0xf6f45e4d836da1d4ecd43bb1074620bfb0b7e0d7'
+  "ethereum": {
+    "rpcEndpoint": "https://audius-protocol-eth-ganache-1",
+    "addresses": {
+      "ethRewardsManagerAddress": "0x",
+      "serviceProviderFactoryAddress": "0x",
+      "serviceTypeManagerAddress": "0x",
+      "audiusTokenAddress": "0xdcB2fC9469808630DD0744b0adf97C0003fC29B2",
+      "audiusWormholeAddress": "0xf6f45e4d836da1d4ecd43bb1074620bfb0b7e0d7"
     }
   }
 }

--- a/packages/sdk/src/sdk/config/production.ts
+++ b/packages/sdk/src/sdk/config/production.ts
@@ -5,662 +5,413 @@
 /* eslint-disable prettier/prettier */
 import type { SdkServicesConfig } from './types'
 export const productionConfig: SdkServicesConfig = {
-  network: {
-    minVersion: '0.7.0',
-    discoveryNodes: [
+  "network": {
+    "minVersion": "0.7.0",
+    "discoveryNodes": [
       {
-        endpoint: 'https://audius-metadata-1.figment.io',
-        ownerWallet: '0xc1f351FE81dFAcB3541e59177AC71Ed237BD15D0',
-        delegateOwnerWallet: '0x7db3789e5E2154569e802945ECF2cC92e0994841'
+        "endpoint": "https://audius-metadata-1.figment.io",
+        "ownerWallet": "0xc1f351FE81dFAcB3541e59177AC71Ed237BD15D0",
+        "delegateOwnerWallet": "0x7db3789e5E2154569e802945ECF2cC92e0994841"
       },
       {
-        endpoint: 'https://audius-metadata-2.figment.io',
-        ownerWallet: '0xc1f351FE81dFAcB3541e59177AC71Ed237BD15D0',
-        delegateOwnerWallet: '0x4E2C78d0d3303ed459BF8a3CD87f11A6bc936140'
+        "endpoint": "https://audius-metadata-2.figment.io",
+        "ownerWallet": "0xc1f351FE81dFAcB3541e59177AC71Ed237BD15D0",
+        "delegateOwnerWallet": "0x4E2C78d0d3303ed459BF8a3CD87f11A6bc936140"
       },
       {
-        endpoint: 'https://audius-discovery-1.altego.net',
-        ownerWallet: '0xA9cB9d043d4841dE83C70556FF0Bd4949C15b5Eb',
-        delegateOwnerWallet: '0xE77C7679ED77b175F935755EEb3a421635AF07EC'
+        "endpoint": "https://discoveryprovider3.audius.co",
+        "ownerWallet": "0xe5b256d302ea2f4e04B8F3bfD8695aDe147aB68d",
+        "delegateOwnerWallet": "0xF2897993951d53a7E3eb2242D6A14D2028140DC8"
       },
       {
-        endpoint: 'https://dn-jpn.audius.metadata.fyi',
-        ownerWallet: '0x067D4f5229b453C3743023135Ecc76f8d27b9008',
-        delegateOwnerWallet: '0xE515A7B710e7CBB55F0fB73fc56c15Ad9b36Af9B'
+        "endpoint": "https://discoveryprovider2.audius.co",
+        "ownerWallet": "0xe5b256d302ea2f4e04B8F3bfD8695aDe147aB68d",
+        "delegateOwnerWallet": "0xc97d40C0B992882646D64814151941A1c520b460"
       },
       {
-        endpoint: 'https://discoveryprovider3.audius.co',
-        ownerWallet: '0xe5b256d302ea2f4e04B8F3bfD8695aDe147aB68d',
-        delegateOwnerWallet: '0xF2897993951d53a7E3eb2242D6A14D2028140DC8'
+        "endpoint": "https://discoveryprovider.audius.co",
+        "ownerWallet": "0xe5b256d302ea2f4e04B8F3bfD8695aDe147aB68d",
+        "delegateOwnerWallet": "0xf1a1Bd34b2Bc73629aa69E50E3249E89A3c16786"
       },
       {
-        endpoint: 'https://discoveryprovider2.audius.co',
-        ownerWallet: '0xe5b256d302ea2f4e04B8F3bfD8695aDe147aB68d',
-        delegateOwnerWallet: '0xc97d40C0B992882646D64814151941A1c520b460'
+        "endpoint": "https://audius-metadata-3.figment.io",
+        "ownerWallet": "0xc1f351FE81dFAcB3541e59177AC71Ed237BD15D0",
+        "delegateOwnerWallet": "0xE019F1Ad9803cfC83e11D37Da442c9Dc8D8d82a6"
       },
       {
-        endpoint: 'https://discoveryprovider.audius.co',
-        ownerWallet: '0xe5b256d302ea2f4e04B8F3bfD8695aDe147aB68d',
-        delegateOwnerWallet: '0xf1a1Bd34b2Bc73629aa69E50E3249E89A3c16786'
+        "endpoint": "https://audius-metadata-4.figment.io",
+        "ownerWallet": "0xc1f351FE81dFAcB3541e59177AC71Ed237BD15D0",
+        "delegateOwnerWallet": "0xf7441A14A31199744Bf8e7b79405c5446C120D0f"
       },
       {
-        endpoint: 'https://audius-metadata-3.figment.io',
-        ownerWallet: '0xc1f351FE81dFAcB3541e59177AC71Ed237BD15D0',
-        delegateOwnerWallet: '0xE019F1Ad9803cfC83e11D37Da442c9Dc8D8d82a6'
+        "endpoint": "https://dn1.monophonic.digital",
+        "ownerWallet": "0x6470Daf3bd32f5014512bCdF0D02232f5640a5BD",
+        "delegateOwnerWallet": "0x2CD66a3931C36596efB037b06753476dcE6B4e86"
       },
       {
-        endpoint: 'https://audius-metadata-4.figment.io',
-        ownerWallet: '0xc1f351FE81dFAcB3541e59177AC71Ed237BD15D0',
-        delegateOwnerWallet: '0xf7441A14A31199744Bf8e7b79405c5446C120D0f'
+        "endpoint": "https://dn2.monophonic.digital",
+        "ownerWallet": "0x6470Daf3bd32f5014512bCdF0D02232f5640a5BD",
+        "delegateOwnerWallet": "0x422541273087beC833c57D3c15B9e17F919bFB1F"
       },
       {
-        endpoint: 'https://dn1.monophonic.digital',
-        ownerWallet: '0x6470Daf3bd32f5014512bCdF0D02232f5640a5BD',
-        delegateOwnerWallet: '0x2CD66a3931C36596efB037b06753476dcE6B4e86'
+        "endpoint": "https://audius-dp.singapore.creatorseed.com",
+        "ownerWallet": "0xf13612C7d6E31636eCC2b670d6F8a3CC50f68A48",
+        "delegateOwnerWallet": "0x01312a03a859813943Fc2521c31ad500fE86C454"
       },
       {
-        endpoint: 'https://dn-usa.audius.metadata.fyi',
-        ownerWallet: '0x067D4f5229b453C3743023135Ecc76f8d27b9008',
-        delegateOwnerWallet: '0x4a3D65647A8Ac41Ef7bdF13D1F171aA97a15ae4b'
+        "endpoint": "https://audius-dp.amsterdam.creatorseed.com",
+        "ownerWallet": "0xf13612C7d6E31636eCC2b670d6F8a3CC50f68A48",
+        "delegateOwnerWallet": "0xd4869005c8aAAB4D53FC5Af24B72617d5D0Ce179"
       },
       {
-        endpoint: 'https://discovery-us-01.audius.openplayer.org',
-        ownerWallet: '0x55fc79f85eEc693A65f79DB463dc3E6831364Bce',
-        delegateOwnerWallet: '0xaC69a173aC26E2daB8663E210eD87a222Ec3945B'
-      },
-      {
-        endpoint: 'https://dn2.monophonic.digital',
-        ownerWallet: '0x6470Daf3bd32f5014512bCdF0D02232f5640a5BD',
-        delegateOwnerWallet: '0x422541273087beC833c57D3c15B9e17F919bFB1F'
-      },
-      {
-        endpoint: 'https://audius-discovery-2.altego.net',
-        ownerWallet: '0xA9cB9d043d4841dE83C70556FF0Bd4949C15b5Eb',
-        delegateOwnerWallet: '0xA9cB9d043d4841dE83C70556FF0Bd4949C15b5Eb'
-      },
-      {
-        endpoint: 'https://dn1.nodeoperator.io',
-        ownerWallet: '0x858e345E9DC681357ecd44bA285e04180c481fF6',
-        delegateOwnerWallet: '0x42D35a2f33ba468fA9eB6FFEA4b975F182957556'
-      },
-      {
-        endpoint: 'https://audius-discovery-3.altego.net',
-        ownerWallet: '0xA9cB9d043d4841dE83C70556FF0Bd4949C15b5Eb',
-        delegateOwnerWallet: '0xA9cB9d043d4841dE83C70556FF0Bd4949C15b5Eb'
-      },
-      {
-        endpoint: 'https://dn1.matterlightblooming.xyz',
-        ownerWallet: '0xb5F5280e275eCa21f167d870d054b90C9C7e6669',
-        delegateOwnerWallet: '0x67154199E79bEcd2A1f34f89d6AF962CF9863945'
-      },
-      {
-        endpoint: 'https://audius-dp.singapore.creatorseed.com',
-        ownerWallet: '0xf13612C7d6E31636eCC2b670d6F8a3CC50f68A48',
-        delegateOwnerWallet: '0x01312a03a859813943Fc2521c31ad500fE86C454'
-      },
-      {
-        endpoint: 'https://discovery.grassfed.network',
-        ownerWallet: '0x57B1d346CDe1d2fA740F310b0d358d07d7c49547',
-        delegateOwnerWallet: '0xb4c7895739062A54F33998D65eF90afb3689d765'
-      },
-      {
-        endpoint: 'https://audius-discovery-1.cultur3stake.com',
-        ownerWallet: '0x2168990Cd51c7C7DdE4b16Ac4fe7dbA269768990',
-        delegateOwnerWallet: '0xBFF627Ee7797bB6b06f01AB1709f250Fe88AFc9c'
-      },
-      {
-        endpoint: 'https://audius-discovery-3.cultur3stake.com',
-        ownerWallet: '0x2168990Cd51c7C7DdE4b16Ac4fe7dbA269768990',
-        delegateOwnerWallet: '0xD3Fe61E45956a3BCE819DD6fC8091E8dBb054cFD'
-      },
-      {
-        endpoint: 'https://audius-discovery-4.cultur3stake.com',
-        ownerWallet: '0x2168990Cd51c7C7DdE4b16Ac4fe7dbA269768990',
-        delegateOwnerWallet: '0x1b05E1a7E221785BE8D9E7f397962Df9c5539464'
-      },
-      {
-        endpoint: 'https://audius-discovery-5.cultur3stake.com',
-        ownerWallet: '0x2168990Cd51c7C7DdE4b16Ac4fe7dbA269768990',
-        delegateOwnerWallet: '0x120cd44EE33E17C2F7A6b95dAA0920342f534E21'
-      },
-      {
-        endpoint: 'https://audius-discovery-7.cultur3stake.com',
-        ownerWallet: '0x2168990Cd51c7C7DdE4b16Ac4fe7dbA269768990',
-        delegateOwnerWallet: '0x6B696B2ae65A885660c3a1DA44b6306509CC2350'
-      },
-      {
-        endpoint: 'https://audius-discovery-8.cultur3stake.com',
-        ownerWallet: '0x2168990Cd51c7C7DdE4b16Ac4fe7dbA269768990',
-        delegateOwnerWallet: '0x2eDfC1ecD381c991DfcAa6951d7766F4Dbba8CA2'
-      },
-      {
-        endpoint: 'https://audius-discovery-9.cultur3stake.com',
-        ownerWallet: '0x2168990Cd51c7C7DdE4b16Ac4fe7dbA269768990',
-        delegateOwnerWallet: '0xd8091A289BEf13b5407082Bb66000ccA47e7e34C'
-      },
-      {
-        endpoint: 'https://audius-discovery-10.cultur3stake.com',
-        ownerWallet: '0x2168990Cd51c7C7DdE4b16Ac4fe7dbA269768990',
-        delegateOwnerWallet: '0x4086DBFb51E451fD1AEeC778FFb884201c944E94'
-      },
-      {
-        endpoint: 'https://discovery-au-02.audius.openplayer.org',
-        ownerWallet: '0x55fc79f85eEc693A65f79DB463dc3E6831364Bce',
-        delegateOwnerWallet: '0x6CAA3671162bC259094Ea4451d0d16792431C37a'
-      },
-      {
-        endpoint: 'https://disc-lon01.audius.hashbeam.com',
-        ownerWallet: '0x1BD9D60a0103FF2fA25169918392f118Bc616Dc9',
-        delegateOwnerWallet: '0xD3A697f1084e50c19b19a8859E3d746893152c29'
-      },
-      {
-        endpoint: 'https://audius-dp.amsterdam.creatorseed.com',
-        ownerWallet: '0xf13612C7d6E31636eCC2b670d6F8a3CC50f68A48',
-        delegateOwnerWallet: '0xd4869005c8aAAB4D53FC5Af24B72617d5D0Ce179'
-      },
-      {
-        endpoint: 'https://blockdaemon-audius-discovery-01.bdnodes.net',
-        ownerWallet: '0x091D2190e93A9C09f99dA05ec3F82ef5D8aa4a07',
-        delegateOwnerWallet: '0x70256629E87b41105F997878D2Db749a78a5B695'
-      },
-      {
-        endpoint: 'https://blockdaemon-audius-discovery-02.bdnodes.net',
-        ownerWallet: '0x091D2190e93A9C09f99dA05ec3F82ef5D8aa4a07',
-        delegateOwnerWallet: '0x060e48dd69960829Fb23CB41eB2DFDAc57948FAd'
-      },
-      {
-        endpoint: 'https://blockdaemon-audius-discovery-03.bdnodes.net',
-        ownerWallet: '0xEe39B44cE36384157585C19df17d9B28D5637C4D',
-        delegateOwnerWallet: '0x2416D78b3cc41467c22578dEE7CA90450EB6526e'
-      },
-      {
-        endpoint: 'https://blockdaemon-audius-discovery-04.bdnodes.net',
-        ownerWallet: '0xEe39B44cE36384157585C19df17d9B28D5637C4D',
-        delegateOwnerWallet: '0xbD0548Ce77e69CE22Af591A4155162A08fDDEC3d'
-      },
-      {
-        endpoint: 'https://blockdaemon-audius-discovery-05.bdnodes.net',
-        ownerWallet: '0x447E3572B5511cc6ea0700e34D2443017D081d7e',
-        delegateOwnerWallet: '0xF5EA27b029D5579D344CFa558DDc3B76A39c98d3'
-      },
-      {
-        endpoint: 'https://blockdaemon-audius-discovery-06.bdnodes.net',
-        ownerWallet: '0x447E3572B5511cc6ea0700e34D2443017D081d7e',
-        delegateOwnerWallet: '0x4ACD4eb0F0992cBFf18d5Cb551f3d8790Db01c51'
-      },
-      {
-        endpoint: 'https://blockchange-audius-discovery-01.bdnodes.net',
-        ownerWallet: '0x59938DF0F43DC520404e4aafDdae688a455Be870',
-        delegateOwnerWallet: '0xD207D8Eb95aA5b2595cF3EEA14308EB61A36ad21'
-      },
-      {
-        endpoint: 'https://blockchange-audius-discovery-02.bdnodes.net',
-        ownerWallet: '0x59938DF0F43DC520404e4aafDdae688a455Be870',
-        delegateOwnerWallet: '0xAB30eF276ADC2bE22CE58d75B4F4009173A73676'
-      },
-      {
-        endpoint: 'https://blockchange-audius-discovery-03.bdnodes.net',
-        ownerWallet: '0x59938DF0F43DC520404e4aafDdae688a455Be870',
-        delegateOwnerWallet: '0x048cFedf907c4C9dDD11ff882380906E78E84BbE'
-      },
-      {
-        endpoint: 'https://audius-discovery-11.cultur3stake.com',
-        ownerWallet: '0x2168990Cd51c7C7DdE4b16Ac4fe7dbA269768990',
-        delegateOwnerWallet: '0xC6f37525A2EBab1eb02B4c6ba302F402e4c5ad1C'
-      },
-      {
-        endpoint: 'https://audius-discovery-12.cultur3stake.com',
-        ownerWallet: '0x2168990Cd51c7C7DdE4b16Ac4fe7dbA269768990',
-        delegateOwnerWallet: '0x1354aFF85DfCeF324E8e40d356f53Cd5F0ED4b83'
-      },
-      {
-        endpoint: 'https://audius-discovery-13.cultur3stake.com',
-        ownerWallet: '0x2168990Cd51c7C7DdE4b16Ac4fe7dbA269768990',
-        delegateOwnerWallet: '0x6f43df165E57598Bd74A2D6ADD18ba4249ECd16B'
-      },
-      {
-        endpoint: 'https://audius-discovery-14.cultur3stake.com',
-        ownerWallet: '0x2168990Cd51c7C7DdE4b16Ac4fe7dbA269768990',
-        delegateOwnerWallet: '0x0d64915a5F498131474C9A569F0AE0164efB95B5'
-      },
-      {
-        endpoint: 'https://audius-discovery-16.cultur3stake.com',
-        ownerWallet: '0x2168990Cd51c7C7DdE4b16Ac4fe7dbA269768990',
-        delegateOwnerWallet: '0xD083A0fA8c2d84759f5383EE4655aAb9908E832c'
-      },
-      {
-        endpoint: 'https://audius-discovery-18.cultur3stake.com',
-        ownerWallet: '0x2168990Cd51c7C7DdE4b16Ac4fe7dbA269768990',
-        delegateOwnerWallet: '0x6C3d9f517a1768dDcDC5e37945e75CAD7A3dF6CC'
-      },
-      {
-        endpoint: 'https://audius-discovery-17.cultur3stake.com',
-        ownerWallet: '0x2168990Cd51c7C7DdE4b16Ac4fe7dbA269768990',
-        delegateOwnerWallet: '0x06D39081B2811fA7CbADC3D7c4e96889829cdec5'
-      },
-      {
-        endpoint: 'https://audius-discovery-15.cultur3stake.com',
-        ownerWallet: '0x2168990Cd51c7C7DdE4b16Ac4fe7dbA269768990',
-        delegateOwnerWallet: '0xE34CB31dadA68F046864054E7A500a370F67b973'
-      },
-      {
-        endpoint: 'https://audius-discovery-6.cultur3stake.com',
-        ownerWallet: '0x2168990Cd51c7C7DdE4b16Ac4fe7dbA269768990',
-        delegateOwnerWallet: '0xf83cA74d5E6AD3F2946754Fa0D1e5cE7670DB764'
-      },
-      {
-        endpoint: 'https://audius-discovery-2.cultur3stake.com',
-        ownerWallet: '0x2168990Cd51c7C7DdE4b16Ac4fe7dbA269768990',
-        delegateOwnerWallet: '0x7c125128B0917bDE12e6A0eDde8F7675d4ADF408'
-      },
-      {
-        endpoint: 'https://blockdaemon-audius-discovery-08.bdnodes.net',
-        ownerWallet: '0x091D2190e93A9C09f99dA05ec3F82ef5D8aa4a07',
-        delegateOwnerWallet: '0x8464c88502925a0076c381962F8B70b6EC892861'
-      },
-      {
-        endpoint: 'https://audius-metadata-5.figment.io',
-        ownerWallet: '0x700a11aE95E34fBC769f8EAD063403987Bd0C502',
-        delegateOwnerWallet: '0x69cfDc1AB75384f077E4E48cf0d6483C8fB9B8A2'
-      },
-      {
-        endpoint: 'https://dn1.stuffisup.com',
-        ownerWallet: '0x3E2Cd6d498b412Da182Ef25837F72355f8918BE9',
-        delegateOwnerWallet: '0xAA29e93f4008D977078957D8f041AEAeF7e1eeBc'
-      },
-      {
-        endpoint: 'https://audius-discovery-1.theblueprint.xyz',
-        ownerWallet: '0x68f656d19AC6d14dF209B1dd6E543b2E81d53D7B',
-        delegateOwnerWallet: '0xEDe07aCa59815fbaa75c4f813dCDD1390D371071'
-      },
-      {
-        endpoint: 'https://audius-discovery-2.theblueprint.xyz',
-        ownerWallet: '0x68f656d19AC6d14dF209B1dd6E543b2E81d53D7B',
-        delegateOwnerWallet: '0xCF3f359BfdE7bcAfE4bc058B6DFae51aBe204aB4'
-      },
-      {
-        endpoint: 'https://audius-discovery-3.theblueprint.xyz',
-        ownerWallet: '0x68f656d19AC6d14dF209B1dd6E543b2E81d53D7B',
-        delegateOwnerWallet: '0x8449169096550905B903b6803FB3b64285112603'
-      },
-      {
-        endpoint: 'https://audius-discovery-4.theblueprint.xyz',
-        ownerWallet: '0x68f656d19AC6d14dF209B1dd6E543b2E81d53D7B',
-        delegateOwnerWallet: '0x16e8DF288BF5DcD507615A715A2a6155F149a865'
-      },
-      {
-        endpoint: 'https://audius-nodes.com',
-        ownerWallet: '0xE83699015c8eb793A0678eA7dC398ac58f7928c4',
-        delegateOwnerWallet: '0xE83699015c8eb793A0678eA7dC398ac58f7928c4'
-      },
-      {
-        endpoint: 'https://audius-dn1.tikilabs.com',
-        ownerWallet: '0xe4882D9A38A2A1fc652996719AF0fb15CB968d0a',
-        delegateOwnerWallet: '0x1cF73c5023572F2d5dc6BD3c5E4F24b4F3b6B76F'
-      },
-      {
-        endpoint: 'https://blockchange-audius-discovery-04.bdnodes.net',
-        ownerWallet: '0x59938DF0F43DC520404e4aafDdae688a455Be870',
-        delegateOwnerWallet: '0xC7562a5CF872450744C3DC5cDb00e9f105D2EfDc'
-      },
-      {
-        endpoint: 'https://blockchange-audius-discovery-05.bdnodes.net',
-        ownerWallet: '0x59938DF0F43DC520404e4aafDdae688a455Be870',
-        delegateOwnerWallet: '0x319211E15876156BD992dd047587d0cd7b88Be77'
+        "endpoint": "https://audius-dn1.tikilabs.com",
+        "ownerWallet": "0xe4882D9A38A2A1fc652996719AF0fb15CB968d0a",
+        "delegateOwnerWallet": "0x1cF73c5023572F2d5dc6BD3c5E4F24b4F3b6B76F"
       }
     ],
-    storageNodes: [
+    "storageNodes": [
       {
-        endpoint: 'https://creatornode.audius.co',
-        delegateOwnerWallet: '0xc8d0C29B6d540295e8fc8ac72456F2f4D41088c8'
+        "endpoint": "https://creatornode.audius.co",
+        "delegateOwnerWallet": "0xc8d0C29B6d540295e8fc8ac72456F2f4D41088c8"
       },
       {
-        endpoint: 'https://creatornode2.audius.co',
-        delegateOwnerWallet: '0xf686647E3737d595C60c6DE2f5F90463542FE439'
+        "endpoint": "https://creatornode2.audius.co",
+        "delegateOwnerWallet": "0xf686647E3737d595C60c6DE2f5F90463542FE439"
       },
       {
-        endpoint: 'https://creatornode3.audius.co',
-        delegateOwnerWallet: '0x0C32BE6328578E99b6F06E0e7A6B385EB8FC13d1'
+        "endpoint": "https://creatornode3.audius.co",
+        "delegateOwnerWallet": "0x0C32BE6328578E99b6F06E0e7A6B385EB8FC13d1"
       },
       {
-        endpoint: 'https://audius-content-1.figment.io',
-        delegateOwnerWallet: '0xBfdE9a7DD3620CB6428463E9A9e9932B4d10fdc5'
+        "endpoint": "https://audius-content-1.figment.io",
+        "delegateOwnerWallet": "0xBfdE9a7DD3620CB6428463E9A9e9932B4d10fdc5"
       },
       {
-        endpoint:
-          'https://creatornode.audius.prod-eks-ap-northeast-1.staked.cloud',
-        delegateOwnerWallet: '0x675086B880260D217963cF14F503272AEb44b2E9'
+        "endpoint": "https://creatornode.audius.prod-eks-ap-northeast-1.staked.cloud",
+        "delegateOwnerWallet": "0x675086B880260D217963cF14F503272AEb44b2E9"
       },
       {
-        endpoint: 'https://audius-content-2.figment.io',
-        delegateOwnerWallet: '0x6444212FFc23a4CcF7460f8Fe6D0e6074db59036'
+        "endpoint": "https://audius-content-2.figment.io",
+        "delegateOwnerWallet": "0x6444212FFc23a4CcF7460f8Fe6D0e6074db59036"
       },
       {
-        endpoint: 'https://audius-content-3.figment.io',
-        delegateOwnerWallet: '0xECEDCaABecb40ef4bE733BA47FaD612aeA1F396F'
+        "endpoint": "https://audius-content-3.figment.io",
+        "delegateOwnerWallet": "0xECEDCaABecb40ef4bE733BA47FaD612aeA1F396F"
       },
       {
-        endpoint: 'https://audius-content-4.figment.io',
-        delegateOwnerWallet: '0x08fEF3884Db16E2E6211272cdC9Eee68E8b63b09'
+        "endpoint": "https://audius-content-4.figment.io",
+        "delegateOwnerWallet": "0x08fEF3884Db16E2E6211272cdC9Eee68E8b63b09"
       },
       {
-        endpoint: 'https://audius-content-5.figment.io',
-        delegateOwnerWallet: '0x10fF8197f2e94eF880d940D2414E0A14983c3bFE'
+        "endpoint": "https://audius-content-5.figment.io",
+        "delegateOwnerWallet": "0x10fF8197f2e94eF880d940D2414E0A14983c3bFE"
       },
       {
-        endpoint:
-          'https://creatornode.audius1.prod-eks-ap-northeast-1.staked.cloud',
-        delegateOwnerWallet: '0xC23Ee959E0B22a9B0F5dF18D7e7875cA4B6c4236'
+        "endpoint": "https://creatornode.audius1.prod-eks-ap-northeast-1.staked.cloud",
+        "delegateOwnerWallet": "0xC23Ee959E0B22a9B0F5dF18D7e7875cA4B6c4236"
       },
       {
-        endpoint:
-          'https://creatornode.audius2.prod-eks-ap-northeast-1.staked.cloud',
-        delegateOwnerWallet: '0x51a5575dc04c1f5f2e39390d090aaf78554F5f7B'
+        "endpoint": "https://creatornode.audius2.prod-eks-ap-northeast-1.staked.cloud",
+        "delegateOwnerWallet": "0x51a5575dc04c1f5f2e39390d090aaf78554F5f7B"
       },
       {
-        endpoint:
-          'https://creatornode.audius3.prod-eks-ap-northeast-1.staked.cloud',
-        delegateOwnerWallet: '0xe0b56BAe2276E016d3DB314Dd7374e596B0457ac'
+        "endpoint": "https://creatornode.audius3.prod-eks-ap-northeast-1.staked.cloud",
+        "delegateOwnerWallet": "0xe0b56BAe2276E016d3DB314Dd7374e596B0457ac"
       },
       {
-        endpoint: 'https://audius-content-6.figment.io',
-        delegateOwnerWallet: '0x68a4Bd6b4177ffB025AF9844cBE4Fe31348AEE1D'
+        "endpoint": "https://audius-content-6.figment.io",
+        "delegateOwnerWallet": "0x68a4Bd6b4177ffB025AF9844cBE4Fe31348AEE1D"
       },
       {
-        endpoint: 'https://audius-content-7.figment.io',
-        delegateOwnerWallet: '0xf45a6DBf3ce0201F4012a19b1fB04D4f05B53a37'
+        "endpoint": "https://audius-content-7.figment.io",
+        "delegateOwnerWallet": "0xf45a6DBf3ce0201F4012a19b1fB04D4f05B53a37"
       },
       {
-        endpoint: 'https://audius-content-8.figment.io',
-        delegateOwnerWallet: '0x9708Fb04DeA029212126255B311a21F1F884cCB4'
+        "endpoint": "https://audius-content-8.figment.io",
+        "delegateOwnerWallet": "0x9708Fb04DeA029212126255B311a21F1F884cCB4"
       },
       {
-        endpoint: 'https://audius-content-9.figment.io',
-        delegateOwnerWallet: '0x7c34c9709ed69513D55dF2020e799DA44fC52E6e'
+        "endpoint": "https://audius-content-9.figment.io",
+        "delegateOwnerWallet": "0x7c34c9709ed69513D55dF2020e799DA44fC52E6e"
       },
       {
-        endpoint: 'https://audius-content-10.figment.io',
-        delegateOwnerWallet: '0xff753331CEa586DD5B23bd21222a3c902909F2dd'
+        "endpoint": "https://audius-content-10.figment.io",
+        "delegateOwnerWallet": "0xff753331CEa586DD5B23bd21222a3c902909F2dd"
       },
       {
-        endpoint: 'https://audius-content-11.figment.io',
-        delegateOwnerWallet: '0xC9721F892BcC8822eb34237E875BE93904f11073'
+        "endpoint": "https://audius-content-11.figment.io",
+        "delegateOwnerWallet": "0xC9721F892BcC8822eb34237E875BE93904f11073"
       },
       {
-        endpoint: 'https://content.grassfed.network',
-        delegateOwnerWallet: '0x33Ab85445c8A2690B9488e9fB5E6A9849d3a18d3'
+        "endpoint": "https://content.grassfed.network",
+        "delegateOwnerWallet": "0x33Ab85445c8A2690B9488e9fB5E6A9849d3a18d3"
       },
       {
-        endpoint: 'https://blockdaemon-audius-content-01.bdnodes.net',
-        delegateOwnerWallet: '0x807C0fba7405aeb8b6a37A974df6259C6aB9bB1e'
+        "endpoint": "https://blockdaemon-audius-content-01.bdnodes.net",
+        "delegateOwnerWallet": "0x807C0fba7405aeb8b6a37A974df6259C6aB9bB1e"
       },
       {
-        endpoint: 'https://audius-content-1.cultur3stake.com',
-        delegateOwnerWallet: '0xCEb6a23d6132Cfe329b3c8E3c45f9DDc28A62Bd4'
+        "endpoint": "https://audius-content-1.cultur3stake.com",
+        "delegateOwnerWallet": "0xCEb6a23d6132Cfe329b3c8E3c45f9DDc28A62Bd4"
       },
       {
-        endpoint: 'https://audius-content-2.cultur3stake.com',
-        delegateOwnerWallet: '0x2e9e7A4e35C3136fB651a0dBF8f91c9f5C27BBf7'
+        "endpoint": "https://audius-content-2.cultur3stake.com",
+        "delegateOwnerWallet": "0x2e9e7A4e35C3136fB651a0dBF8f91c9f5C27BBf7"
       },
       {
-        endpoint: 'https://audius-content-3.cultur3stake.com',
-        delegateOwnerWallet: '0x742da6cAc2782FeA961bB7B9150a048F5167D1e1'
+        "endpoint": "https://audius-content-3.cultur3stake.com",
+        "delegateOwnerWallet": "0x742da6cAc2782FeA961bB7B9150a048F5167D1e1"
       },
       {
-        endpoint: 'https://audius-content-4.cultur3stake.com',
-        delegateOwnerWallet: '0xcbb0cE7481685587b0988195Ff0cD6AA1A701657'
+        "endpoint": "https://audius-content-4.cultur3stake.com",
+        "delegateOwnerWallet": "0xcbb0cE7481685587b0988195Ff0cD6AA1A701657"
       },
       {
-        endpoint: 'https://audius-content-5.cultur3stake.com',
-        delegateOwnerWallet: '0xFec4708155277D35d568aD6Ca322262577683584'
+        "endpoint": "https://audius-content-5.cultur3stake.com",
+        "delegateOwnerWallet": "0xFec4708155277D35d568aD6Ca322262577683584"
       },
       {
-        endpoint: 'https://audius-content-6.cultur3stake.com',
-        delegateOwnerWallet: '0x3Db0E61591063310eEd22fd57E6f7F1ab2Bb538E'
+        "endpoint": "https://audius-content-6.cultur3stake.com",
+        "delegateOwnerWallet": "0x3Db0E61591063310eEd22fd57E6f7F1ab2Bb538E"
       },
       {
-        endpoint: 'https://audius-content-7.cultur3stake.com',
-        delegateOwnerWallet: '0xE6C00e7E8d582fD2856718a5439f1aeEB68e27E5'
+        "endpoint": "https://audius-content-7.cultur3stake.com",
+        "delegateOwnerWallet": "0xE6C00e7E8d582fD2856718a5439f1aeEB68e27E5"
       },
       {
-        endpoint: 'https://blockdaemon-audius-content-02.bdnodes.net',
-        delegateOwnerWallet: '0x4Ad694B3fC34b3cC245aF6AA7B43C52ddD0d7AAE'
+        "endpoint": "https://blockdaemon-audius-content-02.bdnodes.net",
+        "delegateOwnerWallet": "0x4Ad694B3fC34b3cC245aF6AA7B43C52ddD0d7AAE"
       },
       {
-        endpoint: 'https://blockdaemon-audius-content-03.bdnodes.net',
-        delegateOwnerWallet: '0x8ea81225013719950E968DE0602c4Eca458fA9f4'
+        "endpoint": "https://blockdaemon-audius-content-03.bdnodes.net",
+        "delegateOwnerWallet": "0x8ea81225013719950E968DE0602c4Eca458fA9f4"
       },
       {
-        endpoint: 'https://blockdaemon-audius-content-04.bdnodes.net',
-        delegateOwnerWallet: '0xcfFA8ACF0b04d9278eEE13928be264b2E9aaab97'
+        "endpoint": "https://blockdaemon-audius-content-04.bdnodes.net",
+        "delegateOwnerWallet": "0xcfFA8ACF0b04d9278eEE13928be264b2E9aaab97"
       },
       {
-        endpoint: 'https://blockdaemon-audius-content-05.bdnodes.net',
-        delegateOwnerWallet: '0xB4Ff0cab630FB05a7fcEfec9E979a968b8f4fE55'
+        "endpoint": "https://blockdaemon-audius-content-05.bdnodes.net",
+        "delegateOwnerWallet": "0xB4Ff0cab630FB05a7fcEfec9E979a968b8f4fE55"
       },
       {
-        endpoint: 'https://blockdaemon-audius-content-06.bdnodes.net',
-        delegateOwnerWallet: '0x7449da7d1548C11c481b87667EC9b2A8F20C13A0'
+        "endpoint": "https://blockdaemon-audius-content-06.bdnodes.net",
+        "delegateOwnerWallet": "0x7449da7d1548C11c481b87667EC9b2A8F20C13A0"
       },
       {
-        endpoint: 'https://blockdaemon-audius-content-07.bdnodes.net',
-        delegateOwnerWallet: '0x00B1CA1A34257860f66e742eF163Ad30bF42d075'
+        "endpoint": "https://blockdaemon-audius-content-07.bdnodes.net",
+        "delegateOwnerWallet": "0x00B1CA1A34257860f66e742eF163Ad30bF42d075"
       },
       {
-        endpoint: 'https://blockdaemon-audius-content-08.bdnodes.net',
-        delegateOwnerWallet: '0x16650eDB44C720ea627d5a59ff0b4f74c37fe419'
+        "endpoint": "https://blockdaemon-audius-content-08.bdnodes.net",
+        "delegateOwnerWallet": "0x16650eDB44C720ea627d5a59ff0b4f74c37fe419"
       },
       {
-        endpoint: 'https://blockdaemon-audius-content-09.bdnodes.net',
-        delegateOwnerWallet: '0xD5Cfcf4149c683516239fc653D5a470F3F4A606D'
+        "endpoint": "https://blockdaemon-audius-content-09.bdnodes.net",
+        "delegateOwnerWallet": "0xD5Cfcf4149c683516239fc653D5a470F3F4A606D"
       },
       {
-        endpoint: 'https://audius-content-8.cultur3stake.com',
-        delegateOwnerWallet: '0xff432F81D0eb77DA5973Cf55e24A897882fdd3E6'
+        "endpoint": "https://audius-content-8.cultur3stake.com",
+        "delegateOwnerWallet": "0xff432F81D0eb77DA5973Cf55e24A897882fdd3E6"
       },
       {
-        endpoint: 'https://blockchange-audius-content-01.bdnodes.net',
-        delegateOwnerWallet: '0x8464c88502925a0076c381962F8B70b6EC892861'
+        "endpoint": "https://blockchange-audius-content-01.bdnodes.net",
+        "delegateOwnerWallet": "0x8464c88502925a0076c381962F8B70b6EC892861"
       },
       {
-        endpoint: 'https://blockchange-audius-content-02.bdnodes.net',
-        delegateOwnerWallet: '0x5e0D0BeDC11F0B512457f6f707A35703b1447Fb5'
+        "endpoint": "https://blockchange-audius-content-02.bdnodes.net",
+        "delegateOwnerWallet": "0x5e0D0BeDC11F0B512457f6f707A35703b1447Fb5"
       },
       {
-        endpoint: 'https://blockchange-audius-content-03.bdnodes.net',
-        delegateOwnerWallet: '0xe3F1c416c3919bB2ffD78F1e38b9E81E8c80815F'
+        "endpoint": "https://blockchange-audius-content-03.bdnodes.net",
+        "delegateOwnerWallet": "0xe3F1c416c3919bB2ffD78F1e38b9E81E8c80815F"
       },
       {
-        endpoint: 'https://audius-content-9.cultur3stake.com',
-        delegateOwnerWallet: '0xB6f506557B2e9026743FeA6157e52F204D26690F'
+        "endpoint": "https://audius-content-9.cultur3stake.com",
+        "delegateOwnerWallet": "0xB6f506557B2e9026743FeA6157e52F204D26690F"
       },
       {
-        endpoint: 'https://audius-content-10.cultur3stake.com',
-        delegateOwnerWallet: '0x2AF4598D3CF95D8e76987c02BC8A8D71F58d49d5'
+        "endpoint": "https://audius-content-10.cultur3stake.com",
+        "delegateOwnerWallet": "0x2AF4598D3CF95D8e76987c02BC8A8D71F58d49d5"
       },
       {
-        endpoint: 'https://audius-content-11.cultur3stake.com',
-        delegateOwnerWallet: '0xB2684Cca5281d2bA6D9Ce66Cca215635FF2Ba466'
+        "endpoint": "https://audius-content-11.cultur3stake.com",
+        "delegateOwnerWallet": "0xB2684Cca5281d2bA6D9Ce66Cca215635FF2Ba466"
       },
       {
-        endpoint: 'https://audius-content-12.cultur3stake.com',
-        delegateOwnerWallet: '0x28924C99822eA08bFCeDdE3a411308633948b349'
+        "endpoint": "https://audius-content-12.cultur3stake.com",
+        "delegateOwnerWallet": "0x28924C99822eA08bFCeDdE3a411308633948b349"
       },
       {
-        endpoint: 'https://audius-content-13.cultur3stake.com',
-        delegateOwnerWallet: '0xcb23908aa0dCDef762ebEaA38391D8fFC69E6e8F'
+        "endpoint": "https://audius-content-13.cultur3stake.com",
+        "delegateOwnerWallet": "0xcb23908aa0dCDef762ebEaA38391D8fFC69E6e8F"
       },
       {
-        endpoint: 'https://audius-content-14.cultur3stake.com',
-        delegateOwnerWallet: '0xCbDa351492e52fdb2f0E7FBc440cA2047738b71C'
+        "endpoint": "https://audius-content-14.cultur3stake.com",
+        "delegateOwnerWallet": "0xCbDa351492e52fdb2f0E7FBc440cA2047738b71C"
       },
       {
-        endpoint: 'https://audius-content-15.cultur3stake.com',
-        delegateOwnerWallet: '0x2fE2652296c40BB22D33C6379558Bf63A25b4f9a'
+        "endpoint": "https://audius-content-15.cultur3stake.com",
+        "delegateOwnerWallet": "0x2fE2652296c40BB22D33C6379558Bf63A25b4f9a"
       },
       {
-        endpoint: 'https://audius-content-16.cultur3stake.com',
-        delegateOwnerWallet: '0x47367ED3Db5D9691d866cb09545DE7cccD571579'
+        "endpoint": "https://audius-content-16.cultur3stake.com",
+        "delegateOwnerWallet": "0x47367ED3Db5D9691d866cb09545DE7cccD571579"
       },
       {
-        endpoint: 'https://audius-content-17.cultur3stake.com',
-        delegateOwnerWallet: '0xb472c555Ab9eA1D33543383d6d1F8885c97eF83A'
+        "endpoint": "https://audius-content-17.cultur3stake.com",
+        "delegateOwnerWallet": "0xb472c555Ab9eA1D33543383d6d1F8885c97eF83A"
       },
       {
-        endpoint: 'https://audius-content-18.cultur3stake.com',
-        delegateOwnerWallet: '0x4F62C17Dc54E58289354847974E1F246c8EAcf11'
+        "endpoint": "https://audius-content-18.cultur3stake.com",
+        "delegateOwnerWallet": "0x4F62C17Dc54E58289354847974E1F246c8EAcf11"
       },
       {
-        endpoint: 'https://audius-content-12.figment.io',
-        delegateOwnerWallet: '0x780641e157621621658F118375dc1B36Ea514d46'
+        "endpoint": "https://audius-content-12.figment.io",
+        "delegateOwnerWallet": "0x780641e157621621658F118375dc1B36Ea514d46"
       },
       {
-        endpoint: 'https://cn0.mainnet.audiusindex.org',
-        delegateOwnerWallet: '0xf9b373E223b73473C59034072263f52aEF60133B'
+        "endpoint": "https://cn0.mainnet.audiusindex.org",
+        "delegateOwnerWallet": "0xf9b373E223b73473C59034072263f52aEF60133B"
       },
       {
-        endpoint: 'https://cn1.mainnet.audiusindex.org',
-        delegateOwnerWallet: '0x9b0D01bd7F01BD6916Ba139743Ce9C524B9375Dd'
+        "endpoint": "https://cn1.mainnet.audiusindex.org",
+        "delegateOwnerWallet": "0x9b0D01bd7F01BD6916Ba139743Ce9C524B9375Dd"
       },
       {
-        endpoint: 'https://cn2.mainnet.audiusindex.org',
-        delegateOwnerWallet: '0xf6e297203c0086dc229DAE17F5b61a15F42A1A00'
+        "endpoint": "https://cn2.mainnet.audiusindex.org",
+        "delegateOwnerWallet": "0xf6e297203c0086dc229DAE17F5b61a15F42A1A00"
       },
       {
-        endpoint: 'https://cn3.mainnet.audiusindex.org',
-        delegateOwnerWallet: '0x24C4b2cb6eC4c87a03F66723d8750dbe98Fa3e4f'
+        "endpoint": "https://cn3.mainnet.audiusindex.org",
+        "delegateOwnerWallet": "0x24C4b2cb6eC4c87a03F66723d8750dbe98Fa3e4f"
       },
       {
-        endpoint: 'https://audius-content-13.figment.io',
-        delegateOwnerWallet: '0x33a2da466B14990E0124383204b06F9196f62d8e'
+        "endpoint": "https://audius-content-13.figment.io",
+        "delegateOwnerWallet": "0x33a2da466B14990E0124383204b06F9196f62d8e"
       },
       {
-        endpoint: 'https://audius-content-14.figment.io',
-        delegateOwnerWallet: '0x817c513C1B702eA0BdD4F8C1204C60372f715006'
+        "endpoint": "https://audius-content-14.figment.io",
+        "delegateOwnerWallet": "0x817c513C1B702eA0BdD4F8C1204C60372f715006"
       },
       {
-        endpoint: 'https://cn4.mainnet.audiusindex.org',
-        delegateOwnerWallet: '0x69e749266C59757dA81F8C659Be6B07ce5Bac6C9'
+        "endpoint": "https://cn4.mainnet.audiusindex.org",
+        "delegateOwnerWallet": "0x69e749266C59757dA81F8C659Be6B07ce5Bac6C9"
       },
       {
-        endpoint: 'https://audius-creator-1.theblueprint.xyz',
-        delegateOwnerWallet: '0x0E0aF7035581C615d07372be16D99A9B64E5B2e9'
+        "endpoint": "https://audius-creator-1.theblueprint.xyz",
+        "delegateOwnerWallet": "0x0E0aF7035581C615d07372be16D99A9B64E5B2e9"
       },
       {
-        endpoint: 'https://audius-creator-2.theblueprint.xyz',
-        delegateOwnerWallet: '0x3D0dD2Cd46c2658d228769f4a394662946A28987'
+        "endpoint": "https://audius-creator-2.theblueprint.xyz",
+        "delegateOwnerWallet": "0x3D0dD2Cd46c2658d228769f4a394662946A28987"
       },
       {
-        endpoint: 'https://audius-creator-3.theblueprint.xyz',
-        delegateOwnerWallet: '0x292B0d5987a7DE879909C48a54f0853C211da5f3'
+        "endpoint": "https://audius-creator-3.theblueprint.xyz",
+        "delegateOwnerWallet": "0x292B0d5987a7DE879909C48a54f0853C211da5f3"
       },
       {
-        endpoint: 'https://audius-creator-4.theblueprint.xyz',
-        delegateOwnerWallet: '0xA815f8108C2772D24D7DCB866c861148f043224D'
+        "endpoint": "https://audius-creator-4.theblueprint.xyz",
+        "delegateOwnerWallet": "0xA815f8108C2772D24D7DCB866c861148f043224D"
       },
       {
-        endpoint: 'https://audius-creator-5.theblueprint.xyz',
-        delegateOwnerWallet: '0x65Fe5BEf65A0E0b0520d6beE7767ea6Da7f792f6'
+        "endpoint": "https://audius-creator-5.theblueprint.xyz",
+        "delegateOwnerWallet": "0x65Fe5BEf65A0E0b0520d6beE7767ea6Da7f792f6"
       },
       {
-        endpoint: 'https://audius-creator-6.theblueprint.xyz',
-        delegateOwnerWallet: '0x19B026B0f0Dbf619DBf8C4Efb0190308ace56366'
+        "endpoint": "https://audius-creator-6.theblueprint.xyz",
+        "delegateOwnerWallet": "0x19B026B0f0Dbf619DBf8C4Efb0190308ace56366"
       },
       {
-        endpoint:
-          'https://creatornode.audius8.prod-eks-ap-northeast-1.staked.cloud',
-        delegateOwnerWallet: '0xc69F344FCDbc9D747559c968562f682ABfBa442C'
+        "endpoint": "https://creatornode.audius8.prod-eks-ap-northeast-1.staked.cloud",
+        "delegateOwnerWallet": "0xc69F344FCDbc9D747559c968562f682ABfBa442C"
       },
       {
-        endpoint: 'https://cn1.stuffisup.com',
-        delegateOwnerWallet: '0x0D16f8bBfFF114B1a525Bf8b8d98ED177FA74AD3'
+        "endpoint": "https://cn1.stuffisup.com",
+        "delegateOwnerWallet": "0x0D16f8bBfFF114B1a525Bf8b8d98ED177FA74AD3"
       },
       {
-        endpoint: 'https://audius-cn1.tikilabs.com',
-        delegateOwnerWallet: '0x159200F84c2cF000b3A014cD4D8244500CCc36ca'
+        "endpoint": "https://audius-cn1.tikilabs.com",
+        "delegateOwnerWallet": "0x159200F84c2cF000b3A014cD4D8244500CCc36ca"
       },
       {
-        endpoint: 'https://audius-creator-7.theblueprint.xyz',
-        delegateOwnerWallet: '0x720758adEa33433833c14e2516fA421261D0875e'
+        "endpoint": "https://audius-creator-7.theblueprint.xyz",
+        "delegateOwnerWallet": "0x720758adEa33433833c14e2516fA421261D0875e"
       },
       {
-        endpoint: 'https://cn1.shakespearetech.com',
-        delegateOwnerWallet: '0x44955AD360652c302644F564B42D1458C584A4ec'
+        "endpoint": "https://cn1.shakespearetech.com",
+        "delegateOwnerWallet": "0x44955AD360652c302644F564B42D1458C584A4ec"
       },
       {
-        endpoint: 'https://cn2.shakespearetech.com',
-        delegateOwnerWallet: '0x68835714d9c208f9d6F4953F0555507e492fd898'
+        "endpoint": "https://cn2.shakespearetech.com",
+        "delegateOwnerWallet": "0x68835714d9c208f9d6F4953F0555507e492fd898"
       },
       {
-        endpoint: 'https://cn3.shakespearetech.com',
-        delegateOwnerWallet: '0x7162Ee2b7F0cB9651fd2FA2838B0CAF225B2a8D3'
+        "endpoint": "https://cn3.shakespearetech.com",
+        "delegateOwnerWallet": "0x7162Ee2b7F0cB9651fd2FA2838B0CAF225B2a8D3"
       },
       {
-        endpoint: 'https://audius-creator-8.theblueprint.xyz',
-        delegateOwnerWallet: '0x078842E88B82e6a69549043269AE3aADD5581105'
+        "endpoint": "https://audius-creator-8.theblueprint.xyz",
+        "delegateOwnerWallet": "0x078842E88B82e6a69549043269AE3aADD5581105"
       },
       {
-        endpoint: 'https://audius-creator-9.theblueprint.xyz',
-        delegateOwnerWallet: '0x2DfC8152eF49e91b83638ad2bd0D2F9efC6f65b5'
+        "endpoint": "https://audius-creator-9.theblueprint.xyz",
+        "delegateOwnerWallet": "0x2DfC8152eF49e91b83638ad2bd0D2F9efC6f65b5"
       },
       {
-        endpoint: 'https://audius-creator-10.theblueprint.xyz',
-        delegateOwnerWallet: '0x97BcBFA8289731d694440795094E831599Ab7A11'
+        "endpoint": "https://audius-creator-10.theblueprint.xyz",
+        "delegateOwnerWallet": "0x97BcBFA8289731d694440795094E831599Ab7A11"
       },
       {
-        endpoint: 'https://audius-creator-11.theblueprint.xyz',
-        delegateOwnerWallet: '0xfe38c5Ea3579c9333fE302414fe1895F7a320beF'
+        "endpoint": "https://audius-creator-11.theblueprint.xyz",
+        "delegateOwnerWallet": "0xfe38c5Ea3579c9333fE302414fe1895F7a320beF"
       },
       {
-        endpoint: 'https://audius-creator-12.theblueprint.xyz',
-        delegateOwnerWallet: '0x8C78ef541135e2cb037f91109fb8EE780fa4709d'
+        "endpoint": "https://audius-creator-12.theblueprint.xyz",
+        "delegateOwnerWallet": "0x8C78ef541135e2cb037f91109fb8EE780fa4709d"
       },
       {
-        endpoint: 'https://audius-creator-13.theblueprint.xyz',
-        delegateOwnerWallet: '0x75D2269D18C59CC2ED00a63a40367AC495E3F330'
+        "endpoint": "https://audius-creator-13.theblueprint.xyz",
+        "delegateOwnerWallet": "0x75D2269D18C59CC2ED00a63a40367AC495E3F330"
       }
     ],
-    antiAbuseOracleNodes: {
-      endpoints: [
-        'https://antiabuseoracle.audius.co',
-        'https://audius-oracle.creatorseed.com',
-        'https://oracle.audius.endl.net'
+    "antiAbuseOracleNodes": {
+      "endpoints": [
+        "https://antiabuseoracle.audius.co",
+        "https://audius-oracle.creatorseed.com",
+        "https://oracle.audius.endl.net"
       ],
-      registeredAddresses: [
-        '0x9811BA3eAB1F2Cd9A2dFeDB19e8c2a69729DC8b6',
-        '0xe60d50356cd891f56B744165fcc1D8B352201A76',
-        '0x7A03cFAE79266683D9706731D6E187868E939c9C'
+      "registeredAddresses": [
+        "0x9811BA3eAB1F2Cd9A2dFeDB19e8c2a69729DC8b6",
+        "0xe60d50356cd891f56B744165fcc1D8B352201A76",
+        "0x7A03cFAE79266683D9706731D6E187868E939c9C"
       ]
     },
-    identityService: 'https://identityservice.audius.co'
+    "identityService": "https://identityservice.audius.co"
   },
-  acdc: {
-    entityManagerContractAddress: '0x1Cd8a543596D499B9b6E7a6eC15ECd2B7857Fd64',
-    chainId: 31524
+  "acdc": {
+    "entityManagerContractAddress": "0x1Cd8a543596D499B9b6E7a6eC15ECd2B7857Fd64",
+    "chainId": 31524
   },
-  solana: {
-    claimableTokensProgramAddress:
-      'Ewkv3JahEFRKkcJmpoKB7pXbnUHwjAyXiwEo4ZY2rezQ',
-    rewardManagerProgramAddress: 'DDZDcYdQFEMwcu2Mwo75yGFjJ1mUQyyXLWzhZLEVFcei',
-    rewardManagerStateAddress: '71hWFVYokLaN1PNYzTAWi13EfJ7Xt9VbSWUKsXUT8mxE',
-    paymentRouterProgramAddress: 'paytYpX3LPN98TAeen6bFFeraGSuWnomZmCXjAsoqPa',
-    stakingBridgeProgramAddress: 'stkB5DZziVJT1C1VmzvDdRtdWxfs5nwcHViiaNBDK31',
-    rpcEndpoint: 'https://audius-fe.rpcpool.com',
-    usdcTokenMint: 'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v',
-    wAudioTokenMint: '9LzCMqDgTKYz9Drzqnpgee3SGa89up3a247ypMj2xrqM',
-    rewardManagerLookupTableAddress:
-      '4UQwpGupH66RgQrWRqmPM9Two6VJEE68VZ7GeqZ3mvVv'
+  "solana": {
+    "claimableTokensProgramAddress": "Ewkv3JahEFRKkcJmpoKB7pXbnUHwjAyXiwEo4ZY2rezQ",
+    "rewardManagerProgramAddress": "DDZDcYdQFEMwcu2Mwo75yGFjJ1mUQyyXLWzhZLEVFcei",
+    "rewardManagerStateAddress": "71hWFVYokLaN1PNYzTAWi13EfJ7Xt9VbSWUKsXUT8mxE",
+    "paymentRouterProgramAddress": "paytYpX3LPN98TAeen6bFFeraGSuWnomZmCXjAsoqPa",
+    "stakingBridgeProgramAddress": "stkB5DZziVJT1C1VmzvDdRtdWxfs5nwcHViiaNBDK31",
+    "rpcEndpoint": "https://audius-fe.rpcpool.com",
+    "usdcTokenMint": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+    "wAudioTokenMint": "9LzCMqDgTKYz9Drzqnpgee3SGa89up3a247ypMj2xrqM",
+    "rewardManagerLookupTableAddress": "4UQwpGupH66RgQrWRqmPM9Two6VJEE68VZ7GeqZ3mvVv"
   },
-  ethereum: {
-    rpcEndpoint:
-      'https://eth-mainnet.g.alchemy.com/v2/T_trbeTeNv2w04OpyAPkvZ_gH4nr_KuZ',
-    addresses: {
-      ethRewardsManagerAddress: '0x5aa6B99A2B461bA8E97207740f0A689C5C39C3b0',
-      serviceProviderFactoryAddress:
-        '0xD17A9bc90c582249e211a4f4b16721e7f65156c8',
-      serviceTypeManagerAddress: '0x9EfB0f4F38aFbb4b0984D00C126E97E21b8417C5',
-      audiusTokenAddress: '0x18aAA7115705e8be94bfFEBDE57Af9BFc265B998',
-      audiusWormholeAddress: '0x6E7a1F7339bbB62b23D44797b63e4258d283E095'
+  "ethereum": {
+    "rpcEndpoint": "https://eth-mainnet.g.alchemy.com/v2/T_trbeTeNv2w04OpyAPkvZ_gH4nr_KuZ",
+    "addresses": {
+      "ethRewardsManagerAddress": "0x5aa6B99A2B461bA8E97207740f0A689C5C39C3b0",
+      "serviceProviderFactoryAddress": "0xD17A9bc90c582249e211a4f4b16721e7f65156c8",
+      "serviceTypeManagerAddress": "0x9EfB0f4F38aFbb4b0984D00C126E97E21b8417C5",
+      "audiusTokenAddress": "0x18aAA7115705e8be94bfFEBDE57Af9BFc265B998",
+      "audiusWormholeAddress": "0x6E7a1F7339bbB62b23D44797b63e4258d283E095"
     }
   }
 }

--- a/packages/sdk/src/sdk/config/staging.ts
+++ b/packages/sdk/src/sdk/config/staging.ts
@@ -5,101 +5,99 @@
 /* eslint-disable prettier/prettier */
 import type { SdkServicesConfig } from './types'
 export const stagingConfig: SdkServicesConfig = {
-  network: {
-    minVersion: '0.6.0',
-    discoveryNodes: [
+  "network": {
+    "minVersion": "0.6.0",
+    "discoveryNodes": [
       {
-        endpoint: 'https://discoveryprovider.staging.audius.co',
-        ownerWallet: '0x8fcFA10Bd3808570987dbb5B1EF4AB74400FbfDA',
-        delegateOwnerWallet: '0x8fcFA10Bd3808570987dbb5B1EF4AB74400FbfDA'
+        "endpoint": "https://discoveryprovider.staging.audius.co",
+        "ownerWallet": "0x8fcFA10Bd3808570987dbb5B1EF4AB74400FbfDA",
+        "delegateOwnerWallet": "0x8fcFA10Bd3808570987dbb5B1EF4AB74400FbfDA"
       },
       {
-        endpoint: 'https://discoveryprovider2.staging.audius.co',
-        ownerWallet: '0x5E98cBEEAA2aCEDEc0833AC3D1634E2A7aE0f3c2',
-        delegateOwnerWallet: '0x5E98cBEEAA2aCEDEc0833AC3D1634E2A7aE0f3c2'
+        "endpoint": "https://discoveryprovider2.staging.audius.co",
+        "ownerWallet": "0x5E98cBEEAA2aCEDEc0833AC3D1634E2A7aE0f3c2",
+        "delegateOwnerWallet": "0x5E98cBEEAA2aCEDEc0833AC3D1634E2A7aE0f3c2"
       },
       {
-        endpoint: 'https://discoveryprovider3.staging.audius.co',
-        ownerWallet: '0xf7C96916bd37Ad76D4EEDd6536B81c29706C8056',
-        delegateOwnerWallet: '0xf7C96916bd37Ad76D4EEDd6536B81c29706C8056'
+        "endpoint": "https://discoveryprovider3.staging.audius.co",
+        "ownerWallet": "0xf7C96916bd37Ad76D4EEDd6536B81c29706C8056",
+        "delegateOwnerWallet": "0xf7C96916bd37Ad76D4EEDd6536B81c29706C8056"
       },
       {
-        endpoint: 'https://discoveryprovider5.staging.audius.co',
-        ownerWallet: '0x8311f59B72522e728231dC60226359A51878F9A1',
-        delegateOwnerWallet: '0x8311f59B72522e728231dC60226359A51878F9A1'
+        "endpoint": "https://discoveryprovider5.staging.audius.co",
+        "ownerWallet": "0x8311f59B72522e728231dC60226359A51878F9A1",
+        "delegateOwnerWallet": "0x8311f59B72522e728231dC60226359A51878F9A1"
       }
     ],
-    storageNodes: [
+    "storageNodes": [
       {
-        endpoint: 'https://creatornode10.staging.audius.co',
-        delegateOwnerWallet: '0xf7C96916bd37Ad76D4EEDd6536B81c29706C8056'
+        "endpoint": "https://creatornode10.staging.audius.co",
+        "delegateOwnerWallet": "0xf7C96916bd37Ad76D4EEDd6536B81c29706C8056"
       },
       {
-        endpoint: 'https://creatornode8.staging.audius.co',
-        delegateOwnerWallet: '0x8fcFA10Bd3808570987dbb5B1EF4AB74400FbfDA'
+        "endpoint": "https://creatornode8.staging.audius.co",
+        "delegateOwnerWallet": "0x8fcFA10Bd3808570987dbb5B1EF4AB74400FbfDA"
       },
       {
-        endpoint: 'https://creatornode12.staging.audius.co',
-        delegateOwnerWallet: '0x6b52969934076318863243fb92E9C4b3A08267b5'
+        "endpoint": "https://creatornode12.staging.audius.co",
+        "delegateOwnerWallet": "0x6b52969934076318863243fb92E9C4b3A08267b5"
       },
       {
-        endpoint: 'https://creatornode5.staging.audius.co',
-        delegateOwnerWallet: '0xDC2BDF1F23381CA2eC9e9c70D4FD96CD8645D090'
+        "endpoint": "https://creatornode5.staging.audius.co",
+        "delegateOwnerWallet": "0xDC2BDF1F23381CA2eC9e9c70D4FD96CD8645D090"
       },
       {
-        endpoint: 'https://creatornode6.staging.audius.co',
-        delegateOwnerWallet: '0x68039d001D87E7A5E6B06fe0825EA7871C1Cd6C2'
+        "endpoint": "https://creatornode6.staging.audius.co",
+        "delegateOwnerWallet": "0x68039d001D87E7A5E6B06fe0825EA7871C1Cd6C2"
       },
       {
-        endpoint: 'https://creatornode7.staging.audius.co',
-        delegateOwnerWallet: '0x1F8e7aF58086992Ef4c4fc0371446974BBbC0D9F'
+        "endpoint": "https://creatornode7.staging.audius.co",
+        "delegateOwnerWallet": "0x1F8e7aF58086992Ef4c4fc0371446974BBbC0D9F"
       },
       {
-        endpoint: 'https://creatornode9.staging.audius.co',
-        delegateOwnerWallet: '0x140eD283b33be2145ed7d9d15f1fE7bF1E0B2Ac3'
+        "endpoint": "https://creatornode9.staging.audius.co",
+        "delegateOwnerWallet": "0x140eD283b33be2145ed7d9d15f1fE7bF1E0B2Ac3"
       },
       {
-        endpoint: 'https://creatornode11.staging.audius.co',
-        delegateOwnerWallet: '0x4c88d2c0f4c4586b41621aD6e98882ae904B98f6'
+        "endpoint": "https://creatornode11.staging.audius.co",
+        "delegateOwnerWallet": "0x4c88d2c0f4c4586b41621aD6e98882ae904B98f6"
       }
     ],
-    antiAbuseOracleNodes: {
-      endpoints: ['https://antiabuseoracle.staging.audius.co'],
-      registeredAddresses: [
-        '0x00b6462e955dA5841b6D9e1E2529B830F00f31Bf',
-        '0x57B57efFA54ba37DBF8A06B9c42E7611e84BDe6F',
-        '0xF617bbc0913bAE0a13f6D4A19eCDE5Aa07B0fF0A'
+    "antiAbuseOracleNodes": {
+      "endpoints": [
+        "https://antiabuseoracle.staging.audius.co"
+      ],
+      "registeredAddresses": [
+        "0x00b6462e955dA5841b6D9e1E2529B830F00f31Bf",
+        "0x57B57efFA54ba37DBF8A06B9c42E7611e84BDe6F",
+        "0xF617bbc0913bAE0a13f6D4A19eCDE5Aa07B0fF0A"
       ]
     },
-    identityService: 'https://identityservice.staging.audius.co'
+    "identityService": "https://identityservice.staging.audius.co"
   },
-  acdc: {
-    entityManagerContractAddress: '0x1Cd8a543596D499B9b6E7a6eC15ECd2B7857Fd64',
-    chainId: 1056801
+  "acdc": {
+    "entityManagerContractAddress": "0x1Cd8a543596D499B9b6E7a6eC15ECd2B7857Fd64",
+    "chainId": 1056801
   },
-  solana: {
-    claimableTokensProgramAddress:
-      '2sjQNmUfkV6yKKi4dPR8gWRgtyma5aiymE3aXL2RAZww',
-    rewardManagerProgramAddress: 'CDpzvz7DfgbF95jSSCHLX3ERkugyfgn9Fw8ypNZ1hfXp',
-    rewardManagerStateAddress: 'GaiG9LDYHfZGqeNaoGRzFEnLiwUT7WiC6sA6FDJX9ZPq',
-    paymentRouterProgramAddress: 'sp28KA2bTnTA4oSZ3r9tTSKfmiXZtZQHnYYQqWfUyVa',
-    stakingBridgeProgramAddress: 'stkuyR7dTzxV1YnoDo5tfuBmkuKn7zDatimYRDTmQvj',
-    rpcEndpoint: 'https://audius-fe.rpcpool.com',
-    usdcTokenMint: 'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v',
-    wAudioTokenMint: 'BELGiMZQ34SDE6x2FUaML2UHDAgBLS64xvhXjX5tBBZo',
-    rewardManagerLookupTableAddress:
-      'ChFCWjeFxM6SRySTfT46zXn2K7m89TJsft4HWzEtkB4J'
+  "solana": {
+    "claimableTokensProgramAddress": "2sjQNmUfkV6yKKi4dPR8gWRgtyma5aiymE3aXL2RAZww",
+    "rewardManagerProgramAddress": "CDpzvz7DfgbF95jSSCHLX3ERkugyfgn9Fw8ypNZ1hfXp",
+    "rewardManagerStateAddress": "GaiG9LDYHfZGqeNaoGRzFEnLiwUT7WiC6sA6FDJX9ZPq",
+    "paymentRouterProgramAddress": "sp28KA2bTnTA4oSZ3r9tTSKfmiXZtZQHnYYQqWfUyVa",
+    "stakingBridgeProgramAddress": "stkuyR7dTzxV1YnoDo5tfuBmkuKn7zDatimYRDTmQvj",
+    "rpcEndpoint": "https://audius-fe.rpcpool.com",
+    "usdcTokenMint": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+    "wAudioTokenMint": "BELGiMZQ34SDE6x2FUaML2UHDAgBLS64xvhXjX5tBBZo",
+    "rewardManagerLookupTableAddress": "ChFCWjeFxM6SRySTfT46zXn2K7m89TJsft4HWzEtkB4J"
   },
-  ethereum: {
-    rpcEndpoint:
-      'https://eth-sepolia.g.alchemy.com/v2/T_trbeTeNv2w04OpyAPkvZ_gH4nr_KuZ',
-    addresses: {
-      ethRewardsManagerAddress: '0x563483ccD66a49Ca730275F8cf37Dd3E6Da864f1',
-      serviceProviderFactoryAddress:
-        '0x377BE01aD31360d0DFB16035A4515954395A8185',
-      serviceTypeManagerAddress: '0x9fd76d2cD48022526F3a164541E6552291F4a862',
-      audiusTokenAddress: '0x1376180Ee935AA64A27780F4BE97726Df7B0e2B2',
-      audiusWormholeAddress: '0xf6f45e4d836da1d4ecd43bb1074620bfb0b7e0d7'
+  "ethereum": {
+    "rpcEndpoint": "https://eth-sepolia.g.alchemy.com/v2/T_trbeTeNv2w04OpyAPkvZ_gH4nr_KuZ",
+    "addresses": {
+      "ethRewardsManagerAddress": "0x563483ccD66a49Ca730275F8cf37Dd3E6Da864f1",
+      "serviceProviderFactoryAddress": "0x377BE01aD31360d0DFB16035A4515954395A8185",
+      "serviceTypeManagerAddress": "0x9fd76d2cD48022526F3a164541E6552291F4a862",
+      "audiusTokenAddress": "0x1376180Ee935AA64A27780F4BE97726Df7B0e2B2",
+      "audiusWormholeAddress": "0xf6f45e4d836da1d4ecd43bb1074620bfb0b7e0d7"
     }
   }
 }

--- a/packages/sdk/src/sdk/scripts/generateServicesConfig.ts
+++ b/packages/sdk/src/sdk/scripts/generateServicesConfig.ts
@@ -13,6 +13,57 @@ import {
 
 const { writeFile } = promises
 
+const productionDiscoveryNodeRPCEarlyAdopters = [
+  'https://audius-discovery-1.altego.net',
+  'https://dn-jpn.audius.metadata.fyi',
+  'https://dn-usa.audius.metadata.fyi',
+  'https://discovery-us-01.audius.openplayer.org',
+  'https://audius-discovery-2.altego.net',
+  'https://dn1.nodeoperator.io',
+  'https://audius-discovery-3.altego.net',
+  'https://dn1.matterlightblooming.xyz',
+  'https://discovery.grassfed.network',
+  'https://audius-discovery-1.cultur3stake.com',
+  'https://audius-discovery-3.cultur3stake.com',
+  'https://audius-discovery-4.cultur3stake.com',
+  'https://audius-discovery-5.cultur3stake.com',
+  'https://audius-discovery-7.cultur3stake.com',
+  'https://audius-discovery-8.cultur3stake.com',
+  'https://audius-discovery-9.cultur3stake.com',
+  'https://audius-discovery-10.cultur3stake.com',
+  'https://discovery-au-02.audius.openplayer.org',
+  'https://disc-lon01.audius.hashbeam.com',
+  'https://blockdaemon-audius-discovery-01.bdnodes.net',
+  'https://blockdaemon-audius-discovery-02.bdnodes.net',
+  'https://blockdaemon-audius-discovery-03.bdnodes.net',
+  'https://blockdaemon-audius-discovery-04.bdnodes.net',
+  'https://blockdaemon-audius-discovery-05.bdnodes.net',
+  'https://blockdaemon-audius-discovery-06.bdnodes.net',
+  'https://blockchange-audius-discovery-01.bdnodes.net',
+  'https://blockchange-audius-discovery-02.bdnodes.net',
+  'https://blockchange-audius-discovery-03.bdnodes.net',
+  'https://audius-discovery-11.cultur3stake.com',
+  'https://audius-discovery-12.cultur3stake.com',
+  'https://audius-discovery-13.cultur3stake.com',
+  'https://audius-discovery-14.cultur3stake.com',
+  'https://audius-discovery-16.cultur3stake.com',
+  'https://audius-discovery-18.cultur3stake.com',
+  'https://audius-discovery-17.cultur3stake.com',
+  'https://audius-discovery-15.cultur3stake.com',
+  'https://audius-discovery-6.cultur3stake.com',
+  'https://audius-discovery-2.cultur3stake.com',
+  'https://blockdaemon-audius-discovery-08.bdnodes.net',
+  'https://audius-metadata-5.figment.io',
+  'https://dn1.stuffisup.com',
+  'https://audius-discovery-1.theblueprint.xyz',
+  'https://audius-discovery-2.theblueprint.xyz',
+  'https://audius-discovery-3.theblueprint.xyz',
+  'https://audius-discovery-4.theblueprint.xyz',
+  'https://audius-nodes.com',
+  'https://blockchange-audius-discovery-04.bdnodes.net',
+  'https://blockchange-audius-discovery-05.bdnodes.net'
+]
+
 const productionConfig: SdkServicesConfig = {
   network: {
     minVersion: '',
@@ -155,7 +206,8 @@ const developmentConfig: SdkServicesConfig = {
 }
 
 const generateServicesConfig = async (
-  config: SdkServicesConfig
+  config: SdkServicesConfig,
+  { discoveryNodeBlockList }: { discoveryNodeBlockList?: string[] } = {}
 ): Promise<SdkServicesConfig> => {
   const serviceProviderFactory = new ServiceProviderFactoryClient(
     getDefaultServiceProviderFactoryConfig(config)
@@ -186,13 +238,17 @@ const generateServicesConfig = async (
   const minVersion = await serviceTypeManager.getDiscoveryNodeVersion()
 
   config.network.minVersion = minVersion
-  config.network.discoveryNodes = discoveryNodes.map(
-    ([ownerWallet, endpoint, _blockNumber, delegateOwnerWallet]: any) => ({
+  config.network.discoveryNodes = discoveryNodes
+    .map(([ownerWallet, endpoint, _blockNumber, delegateOwnerWallet]: any) => ({
       endpoint,
       ownerWallet,
       delegateOwnerWallet
-    })
-  )
+    }))
+    .filter((node) =>
+      discoveryNodeBlockList
+        ? !discoveryNodeBlockList.includes(node.endpoint)
+        : true
+    )
   config.network.storageNodes = contentNodes.map(
     ([_ownerWallet, endpoint, _blockNumber, delegateOwnerWallet]: any) => ({
       endpoint,
@@ -207,7 +263,9 @@ const generateServicesConfig = async (
 }
 
 const writeServicesConfig = async () => {
-  const production = await generateServicesConfig(productionConfig)
+  const production = await generateServicesConfig(productionConfig, {
+    discoveryNodeBlockList: productionDiscoveryNodeRPCEarlyAdopters
+  })
   const staging = await generateServicesConfig(stagingConfig)
   const development = developmentConfig
   const config: Record<string, SdkServicesConfig> = {


### PR DESCRIPTION
### Description

Add `productionDiscoveryNodeRPCEarlyAdopters` as a blocklist for production to filter out nodes that are piloting core/slimmed down RPC stack.

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._

```
cd packages/sdk
npm run sdk:config
```