### PR TITLE
[PAY-3809] Fix bad claim all format on mobile web

### DIFF
--- a/packages/web/src/pages/rewards-page/RewardsPage.module.css
+++ b/packages/web/src/pages/rewards-page/RewardsPage.module.css
@@ -1,5 +1,6 @@
 .pageContainer {
   user-select: none;
+  min-width: 760px;
 }
 
 .contentContainer {

--- a/packages/web/src/pages/rewards-page/components/ChallengeRewards/RewardPanel.tsx
+++ b/packages/web/src/pages/rewards-page/components/ChallengeRewards/RewardPanel.tsx
@@ -90,7 +90,7 @@ export const RewardPanel = ({
       }}
     >
       <Flex direction='column' h='100%'>
-        <Flex justifyContent='flex-end' mt='xs' w='100%'>
+        <Flex justifyContent='flex-end' mt='s' w='100%'>
           <StatusPill
             shouldShowClaimPill={!!needsDisbursement}
             shouldShowNewChallengePill={shouldShowNewChallengePill}

--- a/packages/web/src/pages/rewards-page/components/ClaimAllRewardsPanel.tsx
+++ b/packages/web/src/pages/rewards-page/components/ClaimAllRewardsPanel.tsx
@@ -57,8 +57,9 @@ export const ClaimAllRewardsPanel = () => {
         justifyContent='space-between'
         css={{ cursor: 'pointer' }}
         onClick={handleClick}
+        mt='l'
       >
-        <Flex direction='column' alignItems='start' w='100%'>
+        <Flex direction='column' alignItems='start' w='100%' p='l'>
           <Flex gap='s' alignItems='center'>
             {claimable ? (
               <IconTokenGold


### PR DESCRIPTION
### Description

* Minor padding cleanup for claim all on mobile web
<img width="471" alt="image" src="https://github.com/user-attachments/assets/7e49baac-6ed8-43a1-9d5a-7849e0fb1bde" />

* Updated spacing of new pill (should be 8px from top but figma shows 4 b/c of the padding inside the fill)
<img width="191" alt="image" src="https://github.com/user-attachments/assets/19660110-2624-4472-a373-8e0e1ce67f30" />


Also added min width on desktop (yeah css, we should update page structure w/ a more global refactor)

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._

Local web staging