### PR TITLE
[PAY-3807] Show folder kebab when open

### DIFF
--- a/packages/harmony/src/components/expandable-nav-item/ExpandableNavItem.tsx
+++ b/packages/harmony/src/components/expandable-nav-item/ExpandableNavItem.tsx
@@ -84,7 +84,7 @@ export const ExpandableNavItem = ({
     if (canUnfurl) {
       setIsOpen(!isOpen)
     }
-    onClick?.()
+    onClick?.(!isOpen)
   }
 
   const styles = useMemo(

--- a/packages/harmony/src/components/expandable-nav-item/types.ts
+++ b/packages/harmony/src/components/expandable-nav-item/types.ts
@@ -35,7 +35,7 @@ export type ExpandableNavItemProps = WithCSS<{
   /** The variant of the nav item. */
   variant?: ExpandableNavItemVariant
   /** The onClick handler for the nav item. */
-  onClick?: () => void
+  onClick?: (isOpen: boolean) => void
   /** Whether the nav item is disabled. */
   disabled?: boolean
 }>

--- a/packages/web/src/components/nav/desktop/PlaylistLibrary/PlaylistFolderNavItem.tsx
+++ b/packages/web/src/components/nav/desktop/PlaylistLibrary/PlaylistFolderNavItem.tsx
@@ -63,6 +63,14 @@ export const PlaylistFolderNavItem = (props: PlaylistFolderNavItemProps) => {
   const [isDraggingOver, setIsDraggingOver] = useState(false)
   const [isHovering, setIsHovering] = useState(false)
   const [isHoveringNested, setIsHoveringNested] = useState(false)
+  const [isOpen, setIsOpen] = useState(false)
+  const handleClick = useCallback(
+    (isOpen: boolean) => {
+      setIsOpen(isOpen)
+    },
+    [setIsOpen]
+  )
+
   const dispatch = useDispatch()
   const record = useRecord()
   const [isDeleteConfirmationOpen, toggleDeleteConfirmationOpen] =
@@ -129,7 +137,7 @@ export const PlaylistFolderNavItem = (props: PlaylistFolderNavItemProps) => {
   )
 
   const rightIcon = useMemo(() => {
-    return isHovering && !isDraggingOver && !isHoveringNested ? (
+    return isOpen || (isHovering && !isDraggingOver && !isHoveringNested) ? (
       <NavItemKebabButton
         visible
         aria-label={messages.editFolderLabel}
@@ -142,7 +150,8 @@ export const PlaylistFolderNavItem = (props: PlaylistFolderNavItemProps) => {
     isDraggingOver,
     isHoveringNested,
     handleClickEdit,
-    kebabItems
+    kebabItems,
+    isOpen
   ])
 
   const nestedItems = useMemo(() => {
@@ -214,6 +223,8 @@ export const PlaylistFolderNavItem = (props: PlaylistFolderNavItemProps) => {
                 nestedItems={nestedItems}
                 variant='compact'
                 shouldPersistDownArrow
+                shouldPersistRightIcon
+                onClick={handleClick}
               />
               <DeleteFolderConfirmationModal
                 folderId={id}

--- a/packages/web/src/components/nav/desktop/PlaylistLibrary/PlaylistFolderNavItem.tsx
+++ b/packages/web/src/components/nav/desktop/PlaylistLibrary/PlaylistFolderNavItem.tsx
@@ -137,7 +137,9 @@ export const PlaylistFolderNavItem = (props: PlaylistFolderNavItemProps) => {
   )
 
   const rightIcon = useMemo(() => {
-    return isOpen || (isHovering && !isDraggingOver && !isHoveringNested) ? (
+    const isKebabVisible =
+      isOpen || (isHovering && !isDraggingOver && !isHoveringNested)
+    return isKebabVisible ? (
       <NavItemKebabButton
         visible
         aria-label={messages.editFolderLabel}


### PR DESCRIPTION
### Description

Keep kebab open if folder is open
<img width="255" alt="image" src="https://github.com/user-attachments/assets/d4690281-5400-4e2e-9f39-58267ff07948" />

I noticed that the design calls for some text when the folder has no playlists in it. Currently the backend does not support empty folders, so in order to do that change, we need to update. I will make a ticket.

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._

```
npm run web:stage
```