### PR TITLE
[PAY-3812] Fix balance display in nav

### DIFF
--- a/packages/web/src/components/nav/desktop/WalletsNestedContent.tsx
+++ b/packages/web/src/components/nav/desktop/WalletsNestedContent.tsx
@@ -6,10 +6,10 @@ import {
 import { BNUSDC } from '@audius/common/models'
 import { accountSelectors } from '@audius/common/store'
 import {
-  formatWei,
   formatUSDCWeiToFloorCentsNumber,
   route,
-  formatCount
+  formatCount,
+  WEI_DIVISOR
 } from '@audius/common/utils'
 import {
   BalancePill,
@@ -56,7 +56,7 @@ export const WalletsNestedContent = () => {
   }[tier]
 
   const audioBalanceFormatted = audioBalance
-    ? formatCount(parseFloat(formatWei(audioBalance, true, 0)))
+    ? formatCount(audioBalance.div(WEI_DIVISOR).toNumber())
     : '0'
 
   const usdcBalanceFormatted = usdcBalance ? formatCount(usdcCentBalance) : '0'


### PR DESCRIPTION
### Description

Balance was getting converted from wei to whole units and then formatted w/ commas, then parsed as a float (using the , as the float notation), and then passed through our formatter. Clean that up!

<img width="284" alt="image" src="https://github.com/user-attachments/assets/9e5b293e-2131-4c6f-8e2c-594503ad2ae9" />

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._

`npm run web:stage` loaded account w/ connected wallets