### PR TITLE
[PAY-3808] Add proper spacing for sub item

### DIFF
--- a/packages/harmony/src/components/expandable-nav-item/ExpandableNavItem.tsx
+++ b/packages/harmony/src/components/expandable-nav-item/ExpandableNavItem.tsx
@@ -134,12 +134,19 @@ export const ExpandableNavItem = ({
   const leftIcon = useMemo(() => {
     if (!getIcon && !LeftIcon) return null
 
+    const dimensions = variant === 'compact' ? 'unit5' : 'unit6'
+
     return (
-      <Flex alignItems='center' justifyContent='center' h='xl' w='xl'>
+      <Flex
+        alignItems='center'
+        justifyContent='center'
+        h={dimensions}
+        w={dimensions}
+      >
         {getIcon}
       </Flex>
     )
-  }, [getIcon, LeftIcon])
+  }, [getIcon, LeftIcon, variant])
 
   const shouldShowRightIcon = isOpen || shouldPersistRightIcon
 

--- a/packages/harmony/src/components/nav-item/NavItem.tsx
+++ b/packages/harmony/src/components/nav-item/NavItem.tsx
@@ -22,6 +22,8 @@ export const NavItem = ({
   textSize = 'l',
   hasNotification = false,
   leftOverride,
+  variant = 'default',
+  isChild = false,
   ...props
 }: NavItemProps) => {
   const { color } = useTheme()
@@ -88,22 +90,28 @@ export const NavItem = ({
           alignItems='center'
           gap='m'
           flex={1}
+          h={variant === 'compact' ? 'unit5' : 'unit6'}
+          pv='s'
           css={{
             maxWidth: '240px'
           }}
         >
           {leftOverride || leftIconWithNotification}
-          <Text
-            variant='title'
-            size={textSize}
-            strength='weak'
-            lineHeight='single'
-            color={textAndIconColor}
-            ellipses
-            css={{ flex: 1 }}
-          >
-            {children}
-          </Text>
+          <Flex ml={isChild ? 'm' : undefined}>
+            <Text
+              variant='title'
+              size={textSize}
+              strength='weak'
+              lineHeight='single'
+              color={textAndIconColor}
+              ellipses
+              css={{
+                flex: 1
+              }}
+            >
+              {children}
+            </Text>
+          </Flex>
         </Flex>
         {hasRightIcon ? RightIcon : null}
       </Flex>

--- a/packages/harmony/src/components/nav-item/types.ts
+++ b/packages/harmony/src/components/nav-item/types.ts
@@ -22,5 +22,9 @@ export type NavItemProps = WithCSS<{
   textSize?: TextSize
   /** Whether the navigation item has a notification count. */
   hasNotification?: boolean
+  /** The variant of the nav item. */
+  variant?: 'default' | 'compact'
+  /** Whether the nav item is a child of a parent expandable nav item. */
+  isChild?: boolean
 }> &
   FlexProps

--- a/packages/web/src/components/nav/desktop/PlaylistLibrary/CollectionNavItem.tsx
+++ b/packages/web/src/components/nav/desktop/PlaylistLibrary/CollectionNavItem.tsx
@@ -71,10 +71,11 @@ type CollectionNavItemProps = {
   level: number
   hasUpdate?: boolean
   onClick?: () => void
+  isChild?: boolean
 }
 
 export const CollectionNavItem = (props: CollectionNavItemProps) => {
-  const { id, name, url, isOwned, level, hasUpdate, onClick } = props
+  const { id, name, url, isOwned, level, hasUpdate, onClick, isChild } = props
   const [isDraggingOver, setIsDraggingOver] = useState(false)
   const [isHovering, setIsHovering] = useState(false)
   const location = useLocation()
@@ -179,7 +180,7 @@ export const CollectionNavItem = (props: CollectionNavItemProps) => {
 
   if (!name || !url) return null
 
-  const indentAmount = level * spacing.l
+  const indentAmount = level * spacing.m
 
   return (
     <>
@@ -204,9 +205,9 @@ export const CollectionNavItem = (props: CollectionNavItemProps) => {
             onMouseEnter={handleMouseEnter}
             onMouseLeave={handleMouseLeave}
             textSize='s'
+            variant='compact'
             css={{
               '& > div': {
-                padding: `6.5px ${spacing.s}px`,
                 marginLeft: indentAmount
               }
             }}
@@ -219,10 +220,12 @@ export const CollectionNavItem = (props: CollectionNavItemProps) => {
               ) : null
             }
             leftOverride={hasUpdate ? <PlaylistUpdateDot /> : null}
+            isChild={isChild}
           >
             <Flex
               alignItems='center'
               w='100%'
+              h='xl'
               pl={indentAmount}
               gap='xs'
               css={{ position: 'relative' }}

--- a/packages/web/src/components/nav/desktop/PlaylistLibrary/PlaylistFolderNavItem.tsx
+++ b/packages/web/src/components/nav/desktop/PlaylistLibrary/PlaylistFolderNavItem.tsx
@@ -16,7 +16,8 @@ import {
   PopupMenuItem,
   ExpandableNavItem,
   Box,
-  Flex
+  Flex,
+  useTheme
 } from '@audius/harmony'
 import { ClassNames } from '@emotion/react'
 import { useDispatch } from 'react-redux'
@@ -50,6 +51,7 @@ const messages = {
 }
 
 export const PlaylistFolderNavItem = (props: PlaylistFolderNavItemProps) => {
+  const { spacing } = useTheme()
   const { folder, level } = props
   const { name, contents, id } = folder
   const folderHasUpdate = useSelector((state) => {
@@ -135,6 +137,7 @@ export const PlaylistFolderNavItem = (props: PlaylistFolderNavItemProps) => {
         aria-label={messages.editFolderLabel}
         onClick={handleClickEdit}
         items={kebabItems}
+        css={{ height: spacing.unit5 }}
       />
     ) : null
   }, [
@@ -142,7 +145,8 @@ export const PlaylistFolderNavItem = (props: PlaylistFolderNavItemProps) => {
     isDraggingOver,
     isHoveringNested,
     handleClickEdit,
-    kebabItems
+    kebabItems,
+    spacing.unit5
   ])
 
   const nestedItems = useMemo(() => {

--- a/packages/web/src/components/nav/desktop/PlaylistLibrary/PlaylistNavItem.tsx
+++ b/packages/web/src/components/nav/desktop/PlaylistLibrary/PlaylistNavItem.tsx
@@ -18,10 +18,11 @@ const { collectionPage } = route
 type PlaylistNavItemProps = {
   playlistId: number
   level: number
+  isChild?: boolean
 }
 
 export const PlaylistNavItem = (props: PlaylistNavItemProps) => {
-  const { playlistId, level } = props
+  const { playlistId, level, isChild } = props
   const dispatch = useDispatch()
 
   const playlistName = useSelector(
@@ -59,6 +60,7 @@ export const PlaylistNavItem = (props: PlaylistNavItemProps) => {
       url={playlistUrl}
       isOwned={isOwnedByCurrentUser}
       level={level}
+      isChild={isChild}
       hasUpdate={hasPlaylistUpdate}
       onClick={handleClick}
     />


### PR DESCRIPTION
### Description

## What's Changed
- Added `compact` variant to `NavItem` and `ExpandableNavItem` components with smaller height and icon dimensions
- Added `isChild` prop to properly handle indentation of nested nav items in playlist library
- Updated dimensions to use theme spacing units consistently
- Fixed nav item height and padding to [match design specs](https://www.figma.com/design/l1Fn3uZ3lenie0apeS0YM3/%F0%9F%93%8D-Navigation-Redesign?node-id=186-145841&m=dev)

## Technical Details
- `NavItem` and `ExpandableNavItem` now accept `variant='compact'` prop which sets:
  - Reduced height (`unit5` vs `unit6`)
  - Smaller icon size
  - Adjusted text styling
- Added `isChild` prop to handle indentation of nested items
- Updated `CollectionNavItem` to use `spacing.m` for consistent level indentation
- Fixed padding and height issues in playlist library nav items

### How Has This Been Tested?
`npm run web:stage`
<img width="235" alt="image" src="https://github.com/user-attachments/assets/1b3b2ca9-4fc7-454d-820b-1629cbd40c15" />

- Verified indentation and styling in playlist library navigation