### PR TITLE
[QA-1916] Fix retrieveCollections call sites to pass in current user ID

### DIFF
--- a/packages/web/src/common/store/account/sagas.ts
+++ b/packages/web/src/common/store/account/sagas.ts
@@ -6,7 +6,7 @@ import { waitForRead } from 'utils/sagaHelpers'
 
 import { retrieveCollections } from '../cache/collections/utils'
 
-const { getAccountSavedPlaylistIds, getAccountOwnedPlaylistIds } =
+const { getUserId, getAccountSavedPlaylistIds, getAccountOwnedPlaylistIds } =
   accountSelectors
 
 const { signedIn, fetchSavedPlaylists } = accountActions
@@ -19,12 +19,13 @@ function* onSignedIn() {
 
 function* fetchSavedPlaylistsAsync() {
   yield* waitForRead()
+  const userId = yield* select(getUserId)
 
   // Fetch other people's playlists you've saved
   yield* fork(function* () {
     const savedPlaylists = yield* select(getAccountSavedPlaylistIds)
     if (savedPlaylists.length > 0) {
-      yield* call(retrieveCollections, savedPlaylists)
+      yield* call(retrieveCollections, savedPlaylists, { userId })
     }
   })
 
@@ -32,7 +33,7 @@ function* fetchSavedPlaylistsAsync() {
   yield* fork(function* () {
     const ownPlaylists = yield* select(getAccountOwnedPlaylistIds)
     if (ownPlaylists.length > 0) {
-      yield* call(retrieveCollections, ownPlaylists)
+      yield* call(retrieveCollections, ownPlaylists, { userId })
     }
   })
 }

--- a/packages/web/src/common/store/notifications/parseAndProcessNotifications.ts
+++ b/packages/web/src/common/store/notifications/parseAndProcessNotifications.ts
@@ -178,9 +178,12 @@ export function* parseAndProcessNotifications(
     }
   })
 
+  yield* waitForAccount()
+  const userId = yield* select(getUserId)
+  if (!userId) return []
   const [tracks] = yield* all([
     call(retrieveTracks, { trackIds: Array.from(trackIdsToFetch) }),
-    call(retrieveCollections, Array.from(collectionIdsToFetch)),
+    call(retrieveCollections, Array.from(collectionIdsToFetch), { userId }),
     call(
       fetchUsers,
       Array.from(userIdsToFetch), // userIds
@@ -202,9 +205,6 @@ export function* parseAndProcessNotifications(
    * Attach a `timeLabel` to each notification as well to be displayed ie. 2 Hours Ago
    */
   const now = moment()
-  yield* waitForAccount()
-  const userId = yield* select(getUserId)
-  if (!userId) return []
   const remixTrackParents: Array<ID> = []
   const processedNotifications = notifications.map((notif) => {
     if (

--- a/packages/web/src/common/store/pages/collection/sagas.js
+++ b/packages/web/src/common/store/pages/collection/sagas.js
@@ -3,7 +3,8 @@ import {
   cacheActions,
   collectionPageLineupActions as tracksActions,
   collectionPageActions as collectionActions,
-  reachabilitySelectors
+  reachabilitySelectors,
+  accountSelectors
 } from '@audius/common/store'
 import { makeUid, route } from '@audius/common/utils'
 import { call, put, select, takeLatest, takeEvery } from 'redux-saga/effects'
@@ -19,9 +20,11 @@ import tracksSagas from './lineups/sagas'
 const { NOT_FOUND_PAGE } = route
 const { fetchCollectionSucceeded, fetchCollectionFailed } = collectionActions
 const { getIsReachable } = reachabilitySelectors
+const { getUserId } = accountSelectors
 
 function* watchFetchCollection() {
   yield takeLatest(collectionActions.FETCH_COLLECTION, function* (action) {
+    const userId = yield select(getUserId)
     const { id: collectionId, permalink, fetchLineup, forceFetch } = action
     let retrievedCollections
     if (permalink) {
@@ -30,13 +33,15 @@ function* watchFetchCollection() {
         permalink,
         {
           deleteExistingEntry: true,
-          forceRetrieveFromSource: forceFetch
+          forceRetrieveFromSource: forceFetch,
+          userId
         }
       )
     } else {
       retrievedCollections = yield call(retrieveCollections, [collectionId], {
         deleteExistingEntry: true,
-        forceRetrieveFromSource: forceFetch
+        forceRetrieveFromSource: forceFetch,
+        userId
       })
     }
 

--- a/packages/web/src/common/store/pages/explore/sagas.ts
+++ b/packages/web/src/common/store/pages/explore/sagas.ts
@@ -2,7 +2,8 @@ import { ID } from '@audius/common/models'
 import {
   explorePageSelectors,
   explorePageActions,
-  getContext
+  getContext,
+  accountSelectors
 } from '@audius/common/store'
 import { call, put, takeEvery, select } from 'typed-redux-saga'
 
@@ -20,6 +21,7 @@ const {
   fetchProfilesSucceded
 } = explorePageActions
 const { getPlaylistIds, getProfileIds } = explorePageSelectors
+const { getUserId } = accountSelectors
 
 type ExploreContent = {
   featuredPlaylists: ID[]
@@ -48,7 +50,10 @@ function* watchFetchExplore() {
         EXPLORE_CONTENT_URL ?? STATIC_EXPLORE_CONTENT_URL
       )
       if (!isNativeMobile) {
-        yield* call(retrieveCollections, exploreContent.featuredPlaylists)
+        const userId = yield* select(getUserId)
+        yield* call(retrieveCollections, exploreContent.featuredPlaylists, {
+          userId
+        })
         yield* call(fetchUsers, exploreContent.featuredProfiles)
       }
 
@@ -62,8 +67,9 @@ function* watchFetchExplore() {
 
 function* watchFetchPlaylists() {
   yield* takeEvery(fetchPlaylists.type, function* fetchPlaylistsAsync() {
+    const userId = yield* select(getUserId)
     const featuredPlaylistIds = yield* select(getPlaylistIds)
-    yield* call(retrieveCollections, featuredPlaylistIds)
+    yield* call(retrieveCollections, featuredPlaylistIds, { userId })
     yield* put(fetchPlaylistsSucceded())
   })
 }

--- a/packages/web/src/common/store/pages/signon/sagas.ts
+++ b/packages/web/src/common/store/pages/signon/sagas.ts
@@ -92,7 +92,7 @@ const { FEED_PAGE, SIGN_IN_PAGE, SIGN_UP_PAGE, SIGN_UP_PASSWORD_PAGE } = route
 const { requestPushNotificationPermissions } = settingsPageActions
 const { saveCollection } = collectionsSocialActions
 const { getUsers } = cacheUsersSelectors
-const { getAccountUser, getHasAccount } = accountSelectors
+const { getUserId, getAccountUser, getHasAccount } = accountSelectors
 const { toast } = toastActions
 
 const SIGN_UP_TIMEOUT_MILLIS = 20 /* min */ * 60 * 1000
@@ -1134,8 +1134,9 @@ function* followCollections(
   favoriteSource: FavoriteSource
 ) {
   yield* call(waitForWrite)
+  const userId = yield* select(getUserId)
   try {
-    const result = yield* call(retrieveCollections, collectionIds)
+    const result = yield* call(retrieveCollections, collectionIds, { userId })
 
     for (let i = 0; i < collectionIds.length; i++) {
       const id = collectionIds[i]

--- a/packages/web/src/common/store/saved-collections/sagas.ts
+++ b/packages/web/src/common/store/saved-collections/sagas.ts
@@ -2,7 +2,8 @@ import { ID } from '@audius/common/models'
 import {
   savedCollectionsActions,
   savedCollectionsSelectors,
-  CollectionType
+  CollectionType,
+  accountSelectors
 } from '@audius/common/store'
 import { waitForRead } from '@audius/common/utils'
 import { all, call, select, put, takeEvery } from 'typed-redux-saga'
@@ -21,10 +22,10 @@ type FetchCollectionsConfig = {
 
 function* fetchCollectionsAsync({ ids, type }: FetchCollectionsConfig) {
   yield waitForRead()
+  const userId = yield* select(accountSelectors.getUserId)
+  yield* call(retrieveCollections, ids, { userId })
 
-  yield* call(retrieveCollections, ids)
-
-  yield put(
+  yield* put(
     fetchCollectionsSucceeded({
       type
     })


### PR DESCRIPTION
### Description

Because we weren't passing current user ID, the access fields would return as though we're not signed in for bulk fetches. That leads to tracks showing up as though we don't have access to them even though we've purchased them.

See:

https://github.com/AudiusProject/audius-protocol/blob/0a000c747fed329687b4feb3c04c398c0fd9060d/packages/web/src/common/store/cache/collections/utils/retrieveCollections.ts#L251-L273

I didn't get to the bottom of this race condition. It doesn't appear as though we always fetch playlists via these calls? Or maybe we're refetching tracks in some cases.

### How Has This Been Tested?

I couldn't recreate the bug from the client locally, but I did verify that this was the problem with the repro request URL.