### PR TITLE
Refactor route matching logic and fix logged out disable state

### DIFF
--- a/packages/harmony/src/components/expandable-nav-item/ExpandableNavItem.tsx
+++ b/packages/harmony/src/components/expandable-nav-item/ExpandableNavItem.tsx
@@ -229,7 +229,9 @@ export const ExpandableNavItem = ({
             <Box
               onClick={(e) => e.stopPropagation()}
               css={{
-                cursor: 'pointer'
+                cursor: 'pointer',
+                opacity: disabled ? 0.5 : 1,
+                transition: `opacity ${theme.motion.quick}`
               }}
             >
               {rightIcon}

--- a/packages/harmony/src/components/nav-item/NavItem.tsx
+++ b/packages/harmony/src/components/nav-item/NavItem.tsx
@@ -97,21 +97,20 @@ export const NavItem = ({
           }}
         >
           {leftOverride || leftIconWithNotification}
-          <Flex ml={isChild ? 'm' : undefined}>
-            <Text
-              variant='title'
-              size={textSize}
-              strength='weak'
-              lineHeight='single'
-              color={textAndIconColor}
-              ellipses
-              css={{
-                flex: 1
-              }}
-            >
-              {children}
-            </Text>
-          </Flex>
+          <Text
+            variant='title'
+            size={textSize}
+            strength='weak'
+            lineHeight='single'
+            color={textAndIconColor}
+            ellipses
+            css={{
+              flex: 1,
+              marginLeft: isChild ? 'm' : undefined
+            }}
+          >
+            {children}
+          </Text>
         </Flex>
         {hasRightIcon ? RightIcon : null}
       </Flex>

--- a/packages/web/src/components/nav/desktop/NavSpeakerIcon.tsx
+++ b/packages/web/src/components/nav/desktop/NavSpeakerIcon.tsx
@@ -1,0 +1,23 @@
+import { IconSpeaker } from '@audius/harmony'
+
+import { matchesRoute, useRouteMatch } from 'utils/route'
+
+type NavSpeakerIconProps = {
+  playingFromRoute: string | null
+  targetRoute: string
+}
+
+export const NavSpeakerIcon = ({
+  playingFromRoute,
+  targetRoute
+}: NavSpeakerIconProps) => {
+  const isSelected = useRouteMatch(targetRoute)
+  const isPlayingFromRoute = matchesRoute({
+    current: playingFromRoute,
+    target: targetRoute
+  })
+
+  if (!isPlayingFromRoute) return null
+
+  return <IconSpeaker size='s' color={isSelected ? 'staticWhite' : 'accent'} />
+}

--- a/packages/web/src/components/nav/desktop/PlaylistLibrary/PlaylistFolderNavItem.tsx
+++ b/packages/web/src/components/nav/desktop/PlaylistLibrary/PlaylistFolderNavItem.tsx
@@ -139,8 +139,8 @@ export const PlaylistFolderNavItem = (props: PlaylistFolderNavItemProps) => {
   )
 
   const rightIcon = useMemo(() => {
-    const isKebabVisible =
-      isOpen || (isHovering && !isDraggingOver && !isHoveringNested)
+    const isVisibleOnHover = isHovering && !isDraggingOver && !isHoveringNested
+    const isKebabVisible = isOpen || isVisibleOnHover
     return isKebabVisible ? (
       <NavItemKebabButton
         visible

--- a/packages/web/src/components/nav/desktop/useNavConfig.tsx
+++ b/packages/web/src/components/nav/desktop/useNavConfig.tsx
@@ -16,7 +16,6 @@ import {
   IconLibrary,
   IconMessages,
   IconPlaylists,
-  IconSpeaker,
   IconTrending,
   IconWallet,
   LoadingSpinner,
@@ -27,7 +26,9 @@ import { useSelector } from 'react-redux'
 import { useLocation } from 'react-router-dom'
 
 import { RestrictionType } from 'hooks/useRequiresAccount'
+import { matchesRoute } from 'utils/route'
 
+import { NavSpeakerIcon } from './NavSpeakerIcon'
 import { PlaylistLibrary } from './PlaylistLibrary'
 import { CreatePlaylistLibraryItemButton } from './PlaylistLibrary/CreatePlaylistLibraryItemButton'
 import { WalletsNestedContent } from './WalletsNestedContent'
@@ -61,15 +62,23 @@ export type NavItemConfig = {
   canUnfurl?: boolean
 }
 
-const matchesRoute = ({
-  current,
-  target
+const createNavItemWithSpeaker = ({
+  targetRoute,
+  playingFromRoute,
+  ...props
 }: {
-  current: string | null
-  target: string
-}) => {
-  return current?.startsWith(target) ?? false
-}
+  targetRoute: string
+  playingFromRoute: string | null
+} & Omit<NavItemConfig, 'rightIcon' | 'to'>): NavItemConfig => ({
+  ...props,
+  to: targetRoute,
+  rightIcon: (
+    <NavSpeakerIcon
+      playingFromRoute={playingFromRoute}
+      targetRoute={targetRoute}
+    />
+  )
+})
 
 export const useNavConfig = () => {
   const hasAccount = useSelector(getHasAccount)
@@ -85,96 +94,34 @@ export const useNavConfig = () => {
 
   const navItems = useMemo(
     (): NavItemConfig[] => [
-      {
+      createNavItemWithSpeaker({
         label: 'Feed',
         leftIcon: IconFeed,
-        to: FEED_PAGE,
+        targetRoute: FEED_PAGE,
         restriction: 'account',
         disabled: !hasAccount,
-        rightIcon: matchesRoute({
-          current: playingFromRoute,
-          target: FEED_PAGE
-        }) ? (
-          <IconSpeaker
-            size='s'
-            color={
-              matchesRoute({
-                current: location.pathname,
-                target: FEED_PAGE
-              })
-                ? 'staticWhite'
-                : 'accent'
-            }
-          />
-        ) : undefined
-      },
-      {
+        playingFromRoute
+      }),
+      createNavItemWithSpeaker({
         label: 'Trending',
         leftIcon: IconTrending,
-        to: TRENDING_PAGE,
-        restriction: 'none',
-        rightIcon: matchesRoute({
-          current: playingFromRoute,
-          target: TRENDING_PAGE
-        }) ? (
-          <IconSpeaker
-            size='s'
-            color={
-              matchesRoute({
-                current: location.pathname,
-                target: TRENDING_PAGE
-              })
-                ? 'staticWhite'
-                : 'accent'
-            }
-          />
-        ) : undefined
-      },
-      {
+        targetRoute: TRENDING_PAGE,
+        playingFromRoute
+      }),
+      createNavItemWithSpeaker({
         label: 'Explore',
         leftIcon: IconExplore,
-        to: EXPLORE_PAGE,
-        restriction: 'none',
-        rightIcon: matchesRoute({
-          current: playingFromRoute,
-          target: EXPLORE_PAGE
-        }) ? (
-          <IconSpeaker
-            size='s'
-            color={
-              matchesRoute({
-                current: location.pathname,
-                target: EXPLORE_PAGE
-              })
-                ? 'staticWhite'
-                : 'accent'
-            }
-          />
-        ) : undefined
-      },
-      {
+        targetRoute: EXPLORE_PAGE,
+        playingFromRoute
+      }),
+      createNavItemWithSpeaker({
         label: 'Library',
         leftIcon: IconLibrary,
-        to: LIBRARY_PAGE,
+        targetRoute: LIBRARY_PAGE,
         restriction: 'guest',
         disabled: !hasAccount,
-        rightIcon: matchesRoute({
-          current: playingFromRoute,
-          target: LIBRARY_PAGE
-        }) ? (
-          <IconSpeaker
-            size='s'
-            color={
-              matchesRoute({
-                current: location.pathname,
-                target: LIBRARY_PAGE
-              })
-                ? 'staticWhite'
-                : 'accent'
-            }
-          />
-        ) : undefined
-      },
+        playingFromRoute
+      }),
       {
         label: 'Messages',
         leftIcon: IconMessages,

--- a/packages/web/src/utils/route.ts
+++ b/packages/web/src/utils/route.ts
@@ -2,7 +2,7 @@ import { SearchCategory } from '@audius/common/api'
 import type { ID } from '@audius/common/models'
 import { route } from '@audius/common/utils'
 import { Location } from 'history'
-import { matchPath } from 'react-router'
+import { matchPath, useLocation } from 'react-router'
 import { push } from 'redux-first-history'
 
 import { env } from 'services/env'
@@ -161,4 +161,25 @@ export const pushUniqueRoute = (location: Location, route: string) => {
     return push(route)
   }
   return { type: '' }
+}
+
+/**
+ * Checks if a current route matches a target route
+ */
+export const matchesRoute = ({
+  current,
+  target
+}: {
+  current: string | null
+  target: string
+}) => {
+  return current?.startsWith(target) ?? false
+}
+
+/**
+ * Hook to check if the current route matches a target route
+ */
+export const useRouteMatch = (targetRoute: string) => {
+  const location = useLocation()
+  return matchesRoute({ current: location.pathname, target: targetRoute })
 }


### PR DESCRIPTION
### Description

- Refactors route matching logic into reusable utilities (`matchesRoute` and `useRouteMatch` hooks) in `route.ts`
- Creates dedicated `NavSpeakerIcon` component to encapsulate speaker icon rendering logic
- Introduces `createNavItemWithSpeaker` helper to reduce code duplication in nav config
- Fixes visual inconsistency where create playlist button didn't respect disabled state when logged out
- Applies proper opacity styles to right icons in `ExpandableNavItem`

# Implementation Details
- Extracted route matching into `route.ts` utilities
- Created new `NavSpeakerIcon` component for consistent speaker icon rendering
- Added opacity styles to right icons in `ExpandableNavItem` to match disabled state
- Refactored nav config to use new helper functions

Before:
<img width="243" alt="image" src="https://github.com/user-attachments/assets/5e0fc807-3367-4d41-92be-623c597b9e6f" />


After:
<img width="239" alt="image" src="https://github.com/user-attachments/assets/0c323f63-1104-487b-849d-42aeb76c0ae5" />


### How Has This Been Tested?

`npm run web:stage`

- Verified route matching works correctly across nav items
- Confirmed speaker icons display properly based on playback state
- Tested logged out state to ensure create playlist button shows correct opacity
