### PR TITLE
Make wallet fields for tip analytics events optional

### DIFF
--- a/packages/common/src/models/Analytics.ts
+++ b/packages/common/src/models/Analytics.ts
@@ -1807,8 +1807,8 @@ export type TipSource =
 type TipAudioRequest = {
   eventName: Name.TIP_AUDIO_REQUEST
   amount: StringAudio
-  senderWallet: SolanaWalletAddress
-  recipientWallet: SolanaWalletAddress
+  senderWallet?: SolanaWalletAddress
+  recipientWallet?: SolanaWalletAddress
   senderHandle: string
   recipientHandle: string
   source: TipSource
@@ -1818,8 +1818,8 @@ type TipAudioRequest = {
 type TipAudioSuccess = {
   eventName: Name.TIP_AUDIO_SUCCESS
   amount: StringAudio
-  senderWallet: SolanaWalletAddress
-  recipientWallet: SolanaWalletAddress
+  senderWallet?: SolanaWalletAddress
+  recipientWallet?: SolanaWalletAddress
   senderHandle: string
   recipientHandle: string
   source: TipSource
@@ -1829,8 +1829,8 @@ type TipAudioSuccess = {
 type TipAudioFailure = {
   eventName: Name.TIP_AUDIO_FAILURE
   amount: StringAudio
-  senderWallet: SolanaWalletAddress
-  recipientWallet: SolanaWalletAddress
+  senderWallet?: SolanaWalletAddress
+  recipientWallet?: SolanaWalletAddress
   senderHandle: string
   recipientHandle: string
   error: string
@@ -1841,8 +1841,8 @@ type TipAudioFailure = {
 type TipAudioTwitterShare = {
   eventName: Name.TIP_AUDIO_TWITTER_SHARE
   amount: StringAudio
-  senderWallet: SolanaWalletAddress
-  recipientWallet: SolanaWalletAddress
+  senderWallet?: SolanaWalletAddress
+  recipientWallet?: SolanaWalletAddress
   senderHandle: string
   recipientHandle: string
   source: TipSource


### PR DESCRIPTION
### Description
#10989 had a change to how we derive the wallet fields for these analytics events which made them optional. I had these changes locally but forgot to save the file 🤦 .

### How Has This Been Tested?
N/A
