### PR TITLE
Fix restriction

### DIFF
--- a/packages/web/src/components/nav/desktop/useNavConfig.tsx
+++ b/packages/web/src/components/nav/desktop/useNavConfig.tsx
@@ -106,13 +106,15 @@ export const useNavConfig = () => {
         label: 'Trending',
         leftIcon: IconTrending,
         targetRoute: TRENDING_PAGE,
-        playingFromRoute
+        playingFromRoute,
+        restriction: 'none'
       }),
       createNavItemWithSpeaker({
         label: 'Explore',
         leftIcon: IconExplore,
         targetRoute: EXPLORE_PAGE,
-        playingFromRoute
+        playingFromRoute,
+        restriction: 'none'
       }),
       createNavItemWithSpeaker({
         label: 'Library',


### PR DESCRIPTION
### Description
The restriction prop was dropped for the fields that have no restriction causing them to show the modal

### How Has This Been Tested?

`npm run web:stage`
