### PR TITLE
fix should index plays check

### DIFF
--- a/packages/discovery-provider/src/tasks/index_core.py
+++ b/packages/discovery-provider/src/tasks/index_core.py
@@ -174,7 +174,12 @@ def index_core(self):
 
             # do some checks to see if we should be indexing or not
             on_cutover_chain = core_plays_cutover_chain_id == core_chain_id
-            past_core_plays_cutover = latest_core_block_height >= core_plays_cutover
+            on_cutover_chain_and_passed_cutover = (
+                on_cutover_chain and latest_core_block_height >= core_plays_cutover
+            )
+            past_core_plays_cutover = (
+                on_cutover_chain_and_passed_cutover or not on_cutover_chain
+            )
             if on_cutover_chain and not past_core_plays_cutover:
                 return
 


### PR DESCRIPTION
### Description
Previously the indexer logic only evaluated the cutover based on the current block and not whether the current chain id is the one where the initial cutover happened.

This logic is changed so that _if_ you're on the chain id where the cutover happens then wait for the core block. Otherwise, if we're on a new chain id then index whatever the current one is.

### How Has This Been Tested?
This can really only be tested on staging as dev doesn't have a way of rolling over chain ids yet.
