### PR TITLE
Go back on exit key press

### DIFF
--- a/packages/web/src/pages/sign-on-page/SignOnPage.tsx
+++ b/packages/web/src/pages/sign-on-page/SignOnPage.tsx
@@ -12,7 +12,14 @@ import {
   useTheme
 } from '@audius/harmony'
 import { useDispatch, useSelector } from 'react-redux'
-import { Link, Redirect, Route, Switch, useRouteMatch } from 'react-router-dom'
+import {
+  Link,
+  Redirect,
+  Route,
+  Switch,
+  useRouteMatch,
+  useHistory
+} from 'react-router-dom'
 import { useSearchParams } from 'react-router-dom-v5-compat'
 import { useEffectOnce, useLocalStorage, useMeasure } from 'react-use'
 
@@ -284,9 +291,25 @@ const MobileSignOnRoot = (props: MobileSignOnRootProps) => {
 export const SignOnPage = () => {
   const { isMobile } = useMedia()
   const signOnStatus = useSelector(getStatus)
+  const routeOnExit = useSelector(getRouteOnExit)
   const dispatch = useDispatch()
+  const history = useHistory()
   const [searchParams] = useSearchParams()
   const [guestEmailLocalStorage] = useLocalStorage('guestEmail', '')
+
+  // Add ESC key handler
+  useEffect(() => {
+    const handleEscKey = (event: KeyboardEvent) => {
+      if (event.key === 'Escape' && routeOnExit) {
+        history.push(routeOnExit)
+      }
+    }
+
+    window.addEventListener('keydown', handleEscKey)
+    return () => {
+      window.removeEventListener('keydown', handleEscKey)
+    }
+  }, [history, routeOnExit])
 
   const rf = searchParams.get('rf')
   const ref = searchParams.get('ref')


### PR DESCRIPTION
### Description
Adds the ability for going back on exit key press from sign up modal

### How Has This Been Tested?

`npm run web:stage`
- While logged out, click on `Feed` or any other greyed out route
- When the sign up modal appears, click the `esc` key
- Ensure that it navigates back 
