### PR TITLE
Helper audius-cmd command to get user entropy

### DIFF
--- a/packages/commands/src/index.ts
+++ b/packages/commands/src/index.ts
@@ -18,6 +18,7 @@ import { playlistCommand } from './playlist/index.js'
 import { trackCommand } from './track/index.js'
 import { userCommand } from './user/index.js'
 import { albumCommand } from './album/index.js'
+import { entropyCommand } from './misc/entropy.js'
 
 async function main() {
   program.name('audius-cmd')
@@ -36,6 +37,7 @@ async function main() {
   program.addCommand(mintCommand)
   program.addCommand(tipReactionCommand)
   program.addCommand(withdrawTokensCommand)
+  program.addCommand(entropyCommand)
 
   try {
     await program.parseAsync(process.argv)

--- a/packages/commands/src/misc/entropy.ts
+++ b/packages/commands/src/misc/entropy.ts
@@ -1,0 +1,21 @@
+import { Command } from '@commander-js/extra-typings'
+import { LocalStorage } from 'node-localstorage'
+const localStorage = new LocalStorage('./local-storage')
+
+export const entropyCommand = new Command('entropy')
+  .description(
+    'Gets the Hedgehog wallet entropy for users created with this tool'
+  )
+  .argument(
+    '[handle]',
+    'The handle of the user (or defaults to last logged in)'
+  )
+  .action(async (handle) => {
+    if (handle) {
+      const handleEntropy = localStorage.getItem(`handle-${handle}`)
+      console.info(handleEntropy)
+    } else {
+      const entropy = localStorage.getItem('hedgehog-entropy-key')
+      console.info(entropy)
+    }
+  })


### PR DESCRIPTION
Found it annoying when I forgot to save the user's entropy so I can easily switch accounts in the local dev client, so made a helper to recover it from local storage.

