### PR TITLE
[QA-1898] Fix reposts lineup disappearing on play

### DIFF
--- a/packages/web/src/common/store/queue/sagas.ts
+++ b/packages/web/src/common/store/queue/sagas.ts
@@ -309,6 +309,8 @@ function* fetchLineupTracks(currentTrack: Track) {
     id: currentTrack.owner_id
   })
 
+  // NOTE: This is a bandaid fix. On the profile page when on the reposts lineup,
+  // we need to select the lineup using the handle of the profile page user, not the handle of the track owner
   const handleToUse =
     source === QueueSource.PROFILE_FEED
       ? (currentProfileUserHandle ?? undefined)

--- a/packages/web/src/common/store/queue/sagas.ts
+++ b/packages/web/src/common/store/queue/sagas.ts
@@ -26,7 +26,8 @@ import {
   getContext,
   playerActions,
   playerSelectors,
-  PlayerBehavior
+  PlayerBehavior,
+  profilePageSelectors
 } from '@audius/common/store'
 import { Uid, makeUid, waitForAccount, Nullable } from '@audius/common/utils'
 import { all, call, put, select, takeEvery, takeLatest } from 'typed-redux-saga'
@@ -47,6 +48,8 @@ const {
   getUid,
   getUndershot
 } = queueSelectors
+
+const { getProfileUserHandle } = profilePageSelectors
 
 const {
   getTrackId: getPlayerTrackId,
@@ -300,11 +303,18 @@ function* fetchLineupTracks(currentTrack: Track) {
   const lineupEntry = lineupRegistry[source]
   if (!lineupEntry) return
 
+  const currentProfileUserHandle = yield* select(getProfileUserHandle)
+
   const currentTrackOwner = yield* select(getUser, {
     id: currentTrack.owner_id
   })
 
-  const lineup = yield* select(lineupEntry.selector, currentTrackOwner?.handle)
+  const handleToUse =
+    source === QueueSource.PROFILE_FEED
+      ? (currentProfileUserHandle ?? undefined)
+      : currentTrackOwner?.handle
+
+  const lineup = yield* select(lineupEntry.selector, handleToUse)
 
   if (lineup.hasMore) {
     const offset = lineup.entries.length + lineup.deleted + lineup.nullCount


### PR DESCRIPTION
### Description

A recurring issue where lineups fail to load correctly when the queue gets near the end of the lineup. (see https://github.com/AudiusProject/audius-protocol/pull/10451/files) 
For profile page reposts the issue was that we're trying to select the lineup based on the artist of the track playing but this will never match the lineup on someone's reposts (since they're never the artist).
Here I decided to apply a quick-and-dirty patch instead of investing effort into a better way to select lineups. My reasoning: to my knowledge this is the only case where we were doing it incorrectly + a lineup rework is on the horizon.

### How Has This Been Tested?

web:stage - lineup on reposts works again, lineups on the other profile page tabs works 
(specifically tested going to the end of lineups and seeing how it queues up more)