### PR TITLE
[C-5504] Fix mobile track replace reseting the upload form

### DIFF
--- a/packages/mobile/src/screens/edit-track-screen/EditTrackScreen.tsx
+++ b/packages/mobile/src/screens/edit-track-screen/EditTrackScreen.tsx
@@ -16,11 +16,12 @@ import { toFormikValidationSchema } from 'zod-formik-adapter'
 import { TRACK_PREVIEW } from 'app/components/edit/PriceAndAudienceField/PremiumRadioField/TrackPreviewField'
 import { TRACK_PRICE } from 'app/components/edit/PriceAndAudienceField/PremiumRadioField/TrackPriceField'
 
+import { UploadFileContext } from '../upload-screen/screens/UploadFileContext'
+
 import { EditTrackNavigator } from './EditTrackNavigator'
 import { BPM } from './screens/KeyBpmScreen'
 import type { FormValues, EditTrackScreenProps } from './types'
 import { getUploadMetadataFromFormValues } from './util'
-import { UploadFileContext } from '../upload-screen/screens/UploadFileContext'
 
 const { computeLicenseVariables, ALL_RIGHTS_RESERVED_TYPE } = creativeCommons
 

--- a/packages/mobile/src/screens/edit-track-screen/EditTrackScreen.tsx
+++ b/packages/mobile/src/screens/edit-track-screen/EditTrackScreen.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useContext, useMemo } from 'react'
+import { useCallback, useMemo } from 'react'
 
 import { useUSDCPurchaseConfig } from '@audius/common/hooks'
 import { isContentUSDCPurchaseGated } from '@audius/common/models'
@@ -15,8 +15,6 @@ import { toFormikValidationSchema } from 'zod-formik-adapter'
 
 import { TRACK_PREVIEW } from 'app/components/edit/PriceAndAudienceField/PremiumRadioField/TrackPreviewField'
 import { TRACK_PRICE } from 'app/components/edit/PriceAndAudienceField/PremiumRadioField/TrackPriceField'
-
-import { UploadFileContext } from '../upload-screen/screens/UploadFileContext'
 
 import { EditTrackNavigator } from './EditTrackNavigator'
 import { BPM } from './screens/KeyBpmScreen'
@@ -229,42 +227,33 @@ const getInitialBpm = (bpm: number | null | undefined) => {
 
 export const EditTrackScreen = (props: EditTrackScreenProps) => {
   const editTrackSchema = toFormikValidationSchema(useEditTrackSchema())
-  const { track } = useContext(UploadFileContext)
 
   const { initialValues: initialValuesProp, onSubmit, ...screenProps } = props
 
-  const initialValues: FormValues = useMemo(() => {
-    const commonProps = {
-      licenseType: computeLicenseVariables(
-        initialValuesProp.license || ALL_RIGHTS_RESERVED_TYPE
-      ),
-      musical_key: initialValuesProp.musical_key
-        ? parseMusicalKey(initialValuesProp.musical_key)
-        : undefined,
-      bpm: getInitialBpm(initialValuesProp.bpm)
-    }
-
-    if (initialValuesProp.isUpload && track) {
-      return {
-        ...track.metadata,
-        isUpload: initialValuesProp.isUpload,
-        entityType: 'track',
-        ...commonProps
-      }
-    } else {
-      return { ...initialValuesProp, entityType: 'track', ...commonProps }
-    }
-  }, [initialValuesProp, track])
+  const initialValues: FormValues = {
+    ...initialValuesProp,
+    entityType: 'track',
+    licenseType: computeLicenseVariables(
+      initialValuesProp.license || ALL_RIGHTS_RESERVED_TYPE
+    ),
+    musical_key: initialValuesProp.musical_key
+      ? parseMusicalKey(initialValuesProp.musical_key)
+      : undefined,
+    bpm: getInitialBpm(initialValuesProp.bpm)
+  }
 
   const handleSubmit = useCallback(
     (values: FormValues, { setSubmitting }) => {
-      const metadata = getUploadMetadataFromFormValues(values, initialValues)
+      const metadata = getUploadMetadataFromFormValues(
+        values,
+        initialValuesProp
+      )
 
       // submit the metadata
       onSubmit(metadata)
       setSubmitting(false)
     },
-    [initialValues, onSubmit]
+    [initialValuesProp, onSubmit]
   )
 
   return (

--- a/packages/mobile/src/screens/upload-screen/screens/CompleteTrackScreen.tsx
+++ b/packages/mobile/src/screens/upload-screen/screens/CompleteTrackScreen.tsx
@@ -36,12 +36,15 @@ export const CompleteTrackScreen = () => {
     [navigation, track, uploadAttempt]
   )
 
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  const metadata = useMemo(() => track?.metadata, [])
+
   if (!track) return null
-  const metadata = useMemo(() => track.metadata, [])
 
   return (
     <EditTrackScreen
-      initialValues={{ ...metadata, isUpload: true }}
+      // ! is fine here bc we render null if track is undefined
+      initialValues={{ ...metadata!, isUpload: true }}
       onSubmit={handleSubmit}
       title={messages.title}
       url='/complete-track'

--- a/packages/mobile/src/screens/upload-screen/screens/CompleteTrackScreen.tsx
+++ b/packages/mobile/src/screens/upload-screen/screens/CompleteTrackScreen.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useContext, useState } from 'react'
+import { useCallback, useContext, useMemo, useState } from 'react'
 
 import type { TrackMetadataForUpload } from '@audius/common/store'
 
@@ -37,7 +37,7 @@ export const CompleteTrackScreen = () => {
   )
 
   if (!track) return null
-  const { metadata } = track
+  const metadata = useMemo(() => track.metadata, [])
 
   return (
     <EditTrackScreen

--- a/packages/mobile/src/screens/upload-screen/screens/CompleteTrackScreen.tsx
+++ b/packages/mobile/src/screens/upload-screen/screens/CompleteTrackScreen.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useContext, useMemo, useState } from 'react'
+import { useCallback, useContext, useState } from 'react'
 
 import type { TrackMetadataForUpload } from '@audius/common/store'
 
@@ -36,15 +36,12 @@ export const CompleteTrackScreen = () => {
     [navigation, track, uploadAttempt]
   )
 
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  const metadata = useMemo(() => track?.metadata, [])
-
   if (!track) return null
+  const metadata = track.metadata
 
   return (
     <EditTrackScreen
-      // ! is fine here bc we render null if track is undefined
-      initialValues={{ ...metadata!, isUpload: true }}
+      initialValues={{ ...metadata, isUpload: true }}
       onSubmit={handleSubmit}
       title={messages.title}
       url='/complete-track'

--- a/packages/mobile/src/screens/upload-screen/screens/CompleteTrackScreen.tsx
+++ b/packages/mobile/src/screens/upload-screen/screens/CompleteTrackScreen.tsx
@@ -37,7 +37,7 @@ export const CompleteTrackScreen = () => {
   )
 
   if (!track) return null
-  const metadata = track.metadata
+  const { metadata } = track
 
   return (
     <EditTrackScreen


### PR DESCRIPTION
### Description
Small updates to only pass in the initial values to the form screen once, but still update the fields that the user has not updated when the track is changed. 
This should only affect the upload flow

### How Has This Been Tested?
Manually Tested, also should not affect the edit form (I was mostly worried about the enableReinitialize prop)
