### PR TITLE
Revert "[PAY-3593] Revert "[PAY-3592] Always mark chat as read (temp …

### DIFF
--- a/packages/common/src/store/pages/chat/sagas.ts
+++ b/packages/common/src/store/pages/chat/sagas.ts
@@ -550,21 +550,10 @@ function* doMarkChatAsRead(action: ReturnType<typeof markChatAsRead>) {
     // Use non-optimistic chat here so that the calculation of whether to mark
     // the chat as read or not are consistent with values in backend
     const chat = yield* select((state) => getNonOptimisticChat(state, chatId))
-    if (chat?.is_blast) {
-      return
-    }
-    if (
-      !chat ||
-      !chat?.last_read_at ||
-      dayjs(chat?.last_read_at).isBefore(chat?.last_message_at)
-    ) {
-      yield* call([sdk.chats, sdk.chats.read], { chatId })
-      yield* put(markChatAsReadSucceeded({ chatId }))
-    } else {
-      // Mark the write as 'failed' in this case (just means we already marked this as read somehow)
-      // to delete the optimistic read status
-      yield* put(markChatAsReadFailed({ chatId }))
-    }
+    if (chat?.is_blast) return
+
+    yield* call([sdk.chats, sdk.chats.read], { chatId })
+    yield* put(markChatAsReadSucceeded({ chatId }))
   } catch (e) {
     yield* put(markChatAsReadFailed({ chatId }))
     const reportToSentry = yield* getContext('reportToSentry')


### PR DESCRIPTION
…fix) (#10397)" (#10983)"

This reverts commit e66eb6da070ce3d15616690f3661737c2aa5d3f7.

Getting reports that this bug is still affecting people, re-deploying the temp fix to always mark chat as read.

### Description

### How Has This Been Tested?

Tested previously