### PR TITLE
Flush listen challenges in index_core_plays

### DIFF
--- a/packages/discovery-provider/src/tasks/index_core_plays.py
+++ b/packages/discovery-provider/src/tasks/index_core_plays.py
@@ -93,19 +93,26 @@ def index_core_plays(
     if not plays:
         return None
 
-    session.execute(Play.__table__.insert().values(plays))
-    logger.debug("index_core_plays.py | Dispatching listen events")
-    listen_dispatch_start = time.time()
-    for event in challenge_bus_events:
-        challenge_bus.dispatch(
-            ChallengeEvent.track_listen,
-            event["slot"],
-            event["created_at"],
-            event["user_id"],
-            {"created_at": event.get("created_at")},
-        )
-    listen_dispatch_end = time.time()
-    listen_dispatch_diff = listen_dispatch_end - listen_dispatch_start
-    logger.debug(f"dispatched listen events in {listen_dispatch_diff}")
+    with challenge_bus.use_scoped_dispatch_queue():
+        session.execute(Play.__table__.insert().values(plays))
+        logger.debug("index_core_plays.py | Dispatching listen events")
+        listen_dispatch_start = time.time()
+        for event in challenge_bus_events:
+            created_at = event.get("created_at")
+            if not created_at:
+                logger.error(
+                    f"index_core_plays.py | Skipping event due to created_at for event: {event}"
+                )
+                continue
+            challenge_bus.dispatch(
+                ChallengeEvent.track_listen,
+                event["slot"],
+                created_at,
+                event["user_id"],
+                {"created_at": created_at.timestamp()},
+            )
+        listen_dispatch_end = time.time()
+        listen_dispatch_diff = listen_dispatch_end - listen_dispatch_start
+        logger.debug(f"dispatched listen events in {listen_dispatch_diff}")
 
     return next_slot


### PR DESCRIPTION
### Description
- `created_at` extra metadata was in a datetime format, which was causing redis serialization to fail. in the old world (`index_solana_plays`), the event's datetime was in string timestamp format, but in the new world it's a python datetime.
- Needed to use the scoped challenge bus to trigger flushes

### How Has This Been Tested?

Tested on local stack - confirmed listening to a track on web client resulted in a listen user challenge row being added.