### PR TITLE
[PAY-3823] Fix solscan link for transfer received

### DIFF
--- a/packages/common/src/utils/linking.ts
+++ b/packages/common/src/utils/linking.ts
@@ -25,3 +25,7 @@ export const isAllowedExternalLink = (link: string) => {
 export const makeSolanaTransactionLink = (signature: string) => {
   return `https://solscan.io/tx/${signature}`
 }
+
+export const makeSolanaAccountLink = (account: string) => {
+  return `https://solscan.io/account/${account}`
+}

--- a/packages/web/src/components/transaction-details-modal/components/TransactionDetailsContent.tsx
+++ b/packages/web/src/components/transaction-details-modal/components/TransactionDetailsContent.tsx
@@ -109,7 +109,10 @@ const UserDetails = ({ userId }: UserDetailsProps) => {
   )
 }
 
-const dateAndMetadataBlocks = (transactionDetails: TransactionDetails) => {
+const dateAndMetadataBlocks = (
+  transactionDetails: TransactionDetails,
+  isValidSolanaAddress: boolean | undefined
+) => {
   switch (transactionDetails.transactionType) {
     case TransactionType.PURCHASE: {
       return (
@@ -172,9 +175,9 @@ const dateAndMetadataBlocks = (transactionDetails: TransactionDetails) => {
               <a
                 className={styles.link}
                 href={
-                  isValidSolAddress(transactionDetails.metadata)
-                    ? makeSolanaTransactionLink(transactionDetails.metadata)
-                    : makeSolanaAccountLink(transactionDetails.metadata)
+                  isValidSolanaAddress
+                    ? makeSolanaAccountLink(transactionDetails.metadata)
+                    : makeSolanaTransactionLink(transactionDetails.metadata)
                 }
                 target='_blank'
                 title={transactionDetails.metadata}
@@ -213,7 +216,6 @@ export const TransactionDetailsContent = ({
       isValidSolAddress(
         transactionDetails.metadata as SolanaWalletAddress
       ).then((isValid) => {
-        console.log({ isValid })
         setIsValidSolanaAddress(isValid)
       })
     }
@@ -245,7 +247,7 @@ export const TransactionDetailsContent = ({
               method={transactionDetails.method}
             />
           </div>
-          {dateAndMetadataBlocks(transactionDetails)}
+          {dateAndMetadataBlocks(transactionDetails, isValidSolanaAddress)}
 
           {transactionDetails.transactionType === TransactionType.PURCHASE ? (
             <Block className={styles.header} header={messages.method}>

--- a/packages/web/src/components/transaction-details-modal/components/TransactionDetailsContent.tsx
+++ b/packages/web/src/components/transaction-details-modal/components/TransactionDetailsContent.tsx
@@ -109,7 +109,7 @@ const UserDetails = ({ userId }: UserDetailsProps) => {
   )
 }
 
-const dateAndMetadataBlocks = ({{
+const dateAndMetadataBlocks = ({
   transactionDetails,
   isValidSolanaAddress
 }: {

--- a/packages/web/src/components/transaction-details-modal/components/TransactionDetailsContent.tsx
+++ b/packages/web/src/components/transaction-details-modal/components/TransactionDetailsContent.tsx
@@ -1,4 +1,10 @@
-import { ChallengeRewardID, User } from '@audius/common/models'
+import { useEffect, useState } from 'react'
+
+import {
+  ChallengeRewardID,
+  SolanaWalletAddress,
+  User
+} from '@audius/common/models'
 import {
   cacheUsersSelectors,
   TransactionType,
@@ -27,6 +33,7 @@ import { isChangePositive } from 'components/audio-transactions-table/AudioTrans
 import LoadingSpinner from 'components/loading-spinner/LoadingSpinner'
 import UserBadges from 'components/user-badges/UserBadges'
 import { getChallengeConfig } from 'pages/audio-rewards-page/config'
+import { isValidSolAddress } from 'services/solana/solana'
 import { AppState } from 'store/types'
 import { push } from 'utils/navigation'
 
@@ -165,7 +172,7 @@ const dateAndMetadataBlocks = (transactionDetails: TransactionDetails) => {
               <a
                 className={styles.link}
                 href={
-                  transactionDetails.method === TransactionMethod.SEND
+                  isValidSolAddress(transactionDetails.metadata)
                     ? makeSolanaTransactionLink(transactionDetails.metadata)
                     : makeSolanaAccountLink(transactionDetails.metadata)
                 }
@@ -195,6 +202,22 @@ export const TransactionDetailsContent = ({
 }: {
   transactionDetails: TransactionDetails
 }) => {
+  const [isValidSolanaAddress, setIsValidSolanaAddress] = useState<
+    undefined | boolean
+  >(undefined)
+  useEffect(() => {
+    if (
+      transactionDetails.metadata &&
+      typeof transactionDetails.metadata === 'string'
+    ) {
+      isValidSolAddress(
+        transactionDetails.metadata as SolanaWalletAddress
+      ).then((isValid) => {
+        console.log({ isValid })
+        setIsValidSolanaAddress(isValid)
+      })
+    }
+  }, [transactionDetails.metadata])
   const isLoading =
     transactionDetails.transactionType === TransactionType.PURCHASE
       ? transactionDetails.metadata === undefined

--- a/packages/web/src/components/transaction-details-modal/components/TransactionDetailsContent.tsx
+++ b/packages/web/src/components/transaction-details-modal/components/TransactionDetailsContent.tsx
@@ -109,10 +109,13 @@ const UserDetails = ({ userId }: UserDetailsProps) => {
   )
 }
 
-const dateAndMetadataBlocks = (
-  transactionDetails: TransactionDetails,
+const dateAndMetadataBlocks = ({{
+  transactionDetails,
+  isValidSolanaAddress
+}: {
+  transactionDetails: TransactionDetails
   isValidSolanaAddress: boolean | undefined
-) => {
+}) => {
   switch (transactionDetails.transactionType) {
     case TransactionType.PURCHASE: {
       return (
@@ -245,9 +248,9 @@ export const TransactionDetailsContent = ({
             <AudioTransactionIcon
               type={transactionDetails.transactionType}
               method={transactionDetails.method}
-            />
+            />  
           </div>
-          {dateAndMetadataBlocks(transactionDetails, isValidSolanaAddress)}
+          {dateAndMetadataBlocks({ transactionDetails, isValidSolanaAddress })}
 
           {transactionDetails.transactionType === TransactionType.PURCHASE ? (
             <Block className={styles.header} header={messages.method}>

--- a/packages/web/src/components/transaction-details-modal/components/TransactionDetailsContent.tsx
+++ b/packages/web/src/components/transaction-details-modal/components/TransactionDetailsContent.tsx
@@ -9,6 +9,7 @@ import {
   formatAudio,
   formatCapitalizeString,
   isNullOrUndefined,
+  makeSolanaAccountLink,
   makeSolanaTransactionLink,
   route
 } from '@audius/common/utils'
@@ -163,7 +164,11 @@ const dateAndMetadataBlocks = (transactionDetails: TransactionDetails) => {
             header={
               <a
                 className={styles.link}
-                href={makeSolanaTransactionLink(transactionDetails.metadata)}
+                href={
+                  transactionDetails.method === TransactionMethod.SEND
+                    ? makeSolanaTransactionLink(transactionDetails.metadata)
+                    : makeSolanaAccountLink(transactionDetails.metadata)
+                }
                 target='_blank'
                 title={transactionDetails.metadata}
                 rel='noreferrer'

--- a/packages/web/src/components/transaction-details-modal/components/TransactionDetailsContent.tsx
+++ b/packages/web/src/components/transaction-details-modal/components/TransactionDetailsContent.tsx
@@ -248,7 +248,7 @@ export const TransactionDetailsContent = ({
             <AudioTransactionIcon
               type={transactionDetails.transactionType}
               method={transactionDetails.method}
-            />  
+            />
           </div>
           {dateAndMetadataBlocks({ transactionDetails, isValidSolanaAddress })}
 

--- a/packages/web/src/pages/audio-rewards-page/components/SendInputBody.tsx
+++ b/packages/web/src/pages/audio-rewards-page/components/SendInputBody.tsx
@@ -25,9 +25,9 @@ import {
   TextInput,
   TokenAmountInput
 } from '@audius/harmony'
-import { PublicKey } from '@solana/web3.js'
 
 import { remoteConfigInstance } from 'services/remote-config/remote-config-instance'
+import { isValidSolAddress } from 'services/solana/solana'
 
 import { ModalBodyTitle, ModalBodyWrapper } from '../WalletModal'
 
@@ -97,22 +97,12 @@ type SendInputBodyProps = {
   solWallet: WalletAddress
 }
 
-const isValidSolDestination = (wallet: SolanaWalletAddress) => {
-  try {
-    const ignored = new PublicKey(wallet)
-    return true
-  } catch (err) {
-    console.info(err)
-    return false
-  }
-}
-
 const validateSolWallet = (
   wallet: Nullable<SolanaWalletAddress>,
   ownSolWallet: WalletAddress
 ): Nullable<AddressError> => {
   if (!wallet) return 'EMPTY'
-  if (!isValidSolDestination(wallet)) return 'INVALID_SPL_ADDRESS'
+  if (!isValidSolAddress(wallet)) return 'INVALID_SPL_ADDRESS'
   if (wallet.toLowerCase() === ownSolWallet.toLowerCase()) {
     return 'SEND_TO_SELF'
   }


### PR DESCRIPTION
### Description

Solscan link for $AUDIO received was broken, it was trying to link to a transaction with the user's wallet. 
Instead I changed the link to point at their wallet account on Solscan.

From: 
https://solscan.io/tx/89SYrjUYJjieANbQohfsTsffeycpuLwZCcNjjSh9x6nW
to
https://solscan.io/account/89SYrjUYJjieANbQohfsTsffeycpuLwZCcNjjSh9x6nW

### How Has This Been Tested?

web:prod