### PR TITLE
Remove `added_timestamps` usage from client

### DIFF
--- a/.changeset/purple-ligers-know.md
+++ b/.changeset/purple-ligers-know.md
@@ -1,0 +1,5 @@
+---
+"@audius/sdk": patch
+---
+
+deprecate Playlist.addedTimestamps

--- a/packages/common/src/adapters/collection.ts
+++ b/packages/common/src/adapters/collection.ts
@@ -104,7 +104,7 @@ export const userCollectionMetadataFromSDK = (
     ),
     playlist_contents: {
       track_ids: transformAndCleanList(
-        input.addedTimestamps ?? input.playlistContents,
+        input.playlistContents,
         addedTimestampToPlaylistTrackId
       )
     },

--- a/packages/discovery-provider/src/api/v1/helpers.py
+++ b/packages/discovery-provider/src/api/v1/helpers.py
@@ -78,6 +78,8 @@ def get_n_primary_endpoints(user, cid, n):
     return rendezvous.get_n(n, cid)
 
 
+# TODO: Rename/refactor this function
+# https://linear.app/audius/issue/PAY-3825/remove-added-timestamps
 def get_playlist_added_timestamps(playlist):
     if "playlist_contents" not in playlist:
         return []
@@ -455,6 +457,8 @@ def extend_playlist(playlist):
     if "save_count" in playlist:
         playlist["favorite_count"] = playlist["save_count"]
 
+    # TODO: This is deprecated but can't be removed until clients are updated
+    # https://linear.app/audius/issue/PAY-3825/remove-added-timestamps
     playlist["added_timestamps"] = get_playlist_added_timestamps(playlist)
     playlist["cover_art"] = playlist["playlist_image_multihash"]
     playlist["cover_art_sizes"] = playlist["playlist_image_sizes_multihash"]
@@ -468,9 +472,7 @@ def extend_playlist(playlist):
     playlist["stream_conditions"] = get_legacy_purchase_gate(
         playlist.get("stream_conditions", None)
     )
-    # Wee hack to make sure this marshals correctly. The marshaller for
-    # playlist_model expects these two values to be the same type.
-    # TODO: https://linear.app/audius/issue/PAY-3398/fix-playlist-contents-serialization
+    # re-assign playlist_contents to be the new format
     playlist["playlist_contents"] = playlist["added_timestamps"]
     return playlist
 
@@ -494,6 +496,7 @@ def filter_hidden_tracks(playlist, current_user_id):
             if (track_id := track.get("track_id")) in tracks_map
             and not tracks_map.get(track_id, {}).get("is_unlisted", False)
         ]
+        # https://linear.app/audius/issue/PAY-3825/remove-added-timestamps
         added_timestamps_list = playlist.get("added_timestamps", [])
         playlist["added_timestamps"] = [
             track

--- a/packages/discovery-provider/src/api/v1/models/playlists.py
+++ b/packages/discovery-provider/src/api/v1/models/playlists.py
@@ -80,8 +80,11 @@ full_playlist_without_tracks_model = ns.clone(
         "is_delete": fields.Boolean(required=True),
         "is_private": fields.Boolean(required=True),
         "updated_at": fields.String(required=True),
+        # https://linear.app/audius/issue/PAY-3825/remove-added-timestamps
         "added_timestamps": fields.List(
-            fields.Nested(playlist_added_timestamp), required=True
+            fields.Nested(playlist_added_timestamp),
+            required=True,
+            description="DEPRECATED. Use playlist_contents instead.",
         ),
         "user_id": fields.String(required=True),
         "user": fields.Nested(user_model_full, required=True),

--- a/packages/discovery-provider/src/queries/get_trending_playlists.py
+++ b/packages/discovery-provider/src/queries/get_trending_playlists.py
@@ -305,7 +305,7 @@ def _get_trending_playlists_with_session(
     for playlist in playlists:
         playlist["track_count"] = len(playlist["tracks"])
         playlist["tracks"] = playlist["tracks"][:PLAYLIST_TRACKS_LIMIT]
-        # Trim track_ids, which ultimately become added_timestamps
+        # Trim track_ids, which ultimately become playlist_contents
         # and need to match the tracks.
         trimmed_track_ids = {track["track_id"] for track in playlist["tracks"]}
         playlist_track_ids = playlist["playlist_contents"]["track_ids"]

--- a/packages/sdk/src/sdk/api/generated/full/models/FullPlaylistWithScore.ts
+++ b/packages/sdk/src/sdk/api/generated/full/models/FullPlaylistWithScore.ts
@@ -226,7 +226,7 @@ export interface FullPlaylistWithScore {
      */
     updatedAt: string;
     /**
-     * 
+     * DEPRECATED. Use playlist_contents instead.
      * @type {Array<PlaylistAddedTimestamp>}
      * @memberof FullPlaylistWithScore
      */

--- a/packages/sdk/src/sdk/api/generated/full/models/PlaylistFull.ts
+++ b/packages/sdk/src/sdk/api/generated/full/models/PlaylistFull.ts
@@ -226,7 +226,7 @@ export interface PlaylistFull {
      */
     updatedAt: string;
     /**
-     * 
+     * DEPRECATED. Use playlist_contents instead.
      * @type {Array<PlaylistAddedTimestamp>}
      * @memberof PlaylistFull
      */

--- a/packages/sdk/src/sdk/api/generated/full/models/PlaylistFullWithoutTracks.ts
+++ b/packages/sdk/src/sdk/api/generated/full/models/PlaylistFullWithoutTracks.ts
@@ -226,7 +226,7 @@ export interface PlaylistFullWithoutTracks {
      */
     updatedAt: string;
     /**
-     * 
+     * DEPRECATED. Use playlist_contents instead.
      * @type {Array<PlaylistAddedTimestamp>}
      * @memberof PlaylistFullWithoutTracks
      */

--- a/packages/sdk/src/sdk/api/generated/full/models/SearchPlaylistFull.ts
+++ b/packages/sdk/src/sdk/api/generated/full/models/SearchPlaylistFull.ts
@@ -226,7 +226,7 @@ export interface SearchPlaylistFull {
      */
     updatedAt: string;
     /**
-     * 
+     * DEPRECATED. Use playlist_contents instead.
      * @type {Array<PlaylistAddedTimestamp>}
      * @memberof SearchPlaylistFull
      */


### PR DESCRIPTION
### Description
`playlist_contents` is now an identical field and is better named, so we will use that in Client instead. Also added a deprecation comment to the field in SDK with future plans to remove it from the API response altogether.

### How Has This Been Tested?
Run client against staging. Check all experiences that fetch and display a playlist.
