### PR TITLE
Clean up account fetch ordering

### DIFF
--- a/packages/common/src/store/account/sagas.ts
+++ b/packages/common/src/store/account/sagas.ts
@@ -10,13 +10,7 @@ import {
 } from 'typed-redux-saga'
 
 import { userApiFetchSaga } from '~/api/user'
-import {
-  AccountUserMetadata,
-  ErrorLevel,
-  Kind,
-  Status,
-  UserMetadata
-} from '~/models'
+import { AccountUserMetadata, ErrorLevel, Kind, UserMetadata } from '~/models'
 import { getContext } from '~/store/effects'
 import { chatActions } from '~/store/pages/chat'
 import { UPLOAD_TRACKS_SUCCEEDED } from '~/store/upload/actions'
@@ -29,7 +23,6 @@ import {
   getUserId,
   getUserHandle,
   getAccountUser,
-  getAccountStatus,
   getAccount
 } from './selectors'
 import {

--- a/packages/common/src/store/account/slice.ts
+++ b/packages/common/src/store/account/slice.ts
@@ -38,7 +38,10 @@ const slice = createSlice({
   name: 'account',
   initialState,
   reducers: {
-    fetchAccount: () => {},
+    fetchAccount: (
+      _state,
+      _action: PayloadAction<{ shouldMarkAccountAsLoading: boolean }>
+    ) => {},
     fetchLocalAccount: () => {},
     fetchAccountRequested: (state) => {
       state.status = Status.LOADING

--- a/packages/web/src/common/store/backend/sagas.ts
+++ b/packages/web/src/common/store/backend/sagas.ts
@@ -76,7 +76,8 @@ function* setupBackend() {
   fingerprintClient.init()
 
   // Start remote account fetch while we setup backend
-  yield* put(accountActions.fetchAccount())
+  // Avoid setting the account as loading here since we already pulled the local account
+  yield* put(accountActions.fetchAccount({ shouldMarkAccountAsLoading: false }))
 
   const isReachable = yield* select(getIsReachable)
   // Bail out before success if we are now offline

--- a/packages/web/src/common/store/pages/signon/sagas.ts
+++ b/packages/web/src/common/store/pages/signon/sagas.ts
@@ -608,7 +608,7 @@ function* createGuestAccount(
           sdk.users.createGuestAccount
         ])
         yield* call(confirmTransaction, blockHash, blockNumber)
-        yield* call(fetchAccountAsync)
+        yield* call(fetchAccountAsync, { shouldMarkAccountAsLoading: true })
 
         const userBank = yield* call(getOrCreateUSDCUserBank)
         if (!userBank) {
@@ -889,7 +889,7 @@ function* signUp() {
         },
         function* () {
           yield* put(signOnActions.sendWelcomeEmail(name))
-          yield* call(fetchAccountAsync)
+          yield* call(fetchAccountAsync, { shouldMarkAccountAsLoading: true })
           yield* call(
             waitForValue,
             getFollowIds,
@@ -1051,7 +1051,9 @@ function* signIn(action: ReturnType<typeof signOnActions.signIn>) {
 
     // Now that we have verified the user is valid, run the account fetch flow,
     // which will pull cached account data from call above.
-    yield* put(accountActions.fetchAccount())
+    yield* put(
+      accountActions.fetchAccount({ shouldMarkAccountAsLoading: true })
+    )
     yield* put(signOnActions.signInSucceeded())
     const route = yield* select(getRouteOnCompletion)
 


### PR DESCRIPTION
### Description

s/o @dylanjeffers @faridsalau for assists on this.

this change does the following:
* If you have no hedgehog entropy in the store (ie no wallet), do not mark the read of the user object from local storage as a successful account fetch
* If you have a local storage account, do not set the account fetch to LOADING while we are refreshing new data from the backend

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._

- Nav clicking around when signed out
- Sign in
- Sign up
- Guest checkout
