### PR TITLE
Tweak mobile amplitude config 

### DIFF
--- a/packages/mobile/src/env/env.prod.ts
+++ b/packages/mobile/src/env/env.prod.ts
@@ -4,7 +4,7 @@ import Config from 'react-native-config'
 export const env: Env = {
   AAO_ENDPOINT: 'https://antiabuseoracle.audius.co',
   AMPLITUDE_API_KEY: '86760558b8bb1b3aae61656efd4ddacb',
-  AMPLITUDE_PROXY: 'https://gain.audius.co',
+  AMPLITUDE_PROXY: 'https://gain2.audius.co/2/httpapi',
   API_KEY: '8acf5eb7436ea403ee536a7334faa5e9ada4b50f',
   APP_NAME: 'audius-client',
   AUDIUS_URL: 'https://audius.co',

--- a/packages/mobile/src/services/analytics.ts
+++ b/packages/mobile/src/services/analytics.ts
@@ -27,7 +27,7 @@ export const init = async () => {
   try {
     if (AmplitudeWriteKey && AmplitudeProxy) {
       await amplitudeInit(AmplitudeWriteKey, undefined, {
-        // serverUrl: AmplitudeProxy,
+        serverUrl: AmplitudeProxy,
         appVersion: clientVersion, // Identifies our app version to Amplitude
         logLevel: AmplitudeTypes.LogLevel.Error,
         // Events queued in memory will flush when number of events exceed upload threshold

--- a/packages/mobile/src/services/analytics.ts
+++ b/packages/mobile/src/services/analytics.ts
@@ -3,7 +3,8 @@ import {
   track as amplitudeTrack,
   setUserId,
   identify as amplitudeIdentify,
-  Identify
+  Identify,
+  Types as AmplitudeTypes
 } from '@amplitude/analytics-react-native'
 import VersionNumber from 'react-native-version-number'
 
@@ -26,8 +27,16 @@ export const init = async () => {
   try {
     if (AmplitudeWriteKey && AmplitudeProxy) {
       await amplitudeInit(AmplitudeWriteKey, undefined, {
-        serverUrl: AmplitudeProxy,
-        appVersion: clientVersion // Identifies our app version to Amplitude
+        // serverUrl: AmplitudeProxy,
+        appVersion: clientVersion, // Identifies our app version to Amplitude
+        logLevel: AmplitudeTypes.LogLevel.Error,
+        // Events queued in memory will flush when number of events exceed upload threshold
+        // Default value is 30
+        flushQueueSize: 50,
+        // Events queue will flush every certain milliseconds based on setting
+        // Default value is 10000 milliseconds
+        flushIntervalMillis: 20000,
+        minIdLength: 1 // By default amplitude rejects our handle ids if they're less than 5 characters
       })
       analyticsSetupStatus = 'ready'
     } else {


### PR DESCRIPTION
### Description

While running `ios:prod` and debugging perf issues I saw this error popping up a few times on the sign up & sign in screens.

Unfortunately I found a spot that I missed when I tweaked the amplitude config where I didn't update the prod config.

![image](https://github.com/user-attachments/assets/c3f2b6d4-f320-4d47-8d94-1e36f28b2d86)

I don't think this is the cause of the perf issues I'm seeing but either way this fixes the amplitude config.

### How Has This Been Tested?

ios:prod
