### PR TITLE
Fix spacing on follows you indicator

### DIFF
--- a/packages/web/src/pages/profile-page/components/desktop/ProfilePage.module.css
+++ b/packages/web/src/pages/profile-page/components/desktop/ProfilePage.module.css
@@ -30,7 +30,7 @@
 
 .nameWrapper {
   position: relative;
-  margin: 4px 0 0 32px;
+  margin-left: 32px;
   text-align: left;
   user-select: none;
   max-width: 720px;

--- a/packages/web/src/pages/profile-page/components/desktop/ProfilePage.module.css
+++ b/packages/web/src/pages/profile-page/components/desktop/ProfilePage.module.css
@@ -39,6 +39,8 @@
 
 .handleWrapper {
   margin-top: 4px;
+  display: flex;
+  align-items: center;
 }
 
 .handleWrapper > .handle {


### PR DESCRIPTION
### Description

Minor but annoying me

before
<img width="470" alt="image" src="https://github.com/user-attachments/assets/f17652a0-ed99-42cb-8403-4b54d1cb4b41" />

after
<img width="468" alt="image" src="https://github.com/user-attachments/assets/e0b3279f-c04f-4b74-b196-b336427bf9cb" />
### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._

style editor