### PR TITLE
Fix openresty upstream path for uptime

### DIFF
--- a/packages/discovery-provider/nginx_conf/nginx_container.conf
+++ b/packages/discovery-provider/nginx_conf/nginx_container.conf
@@ -350,6 +350,7 @@ http {
             set $upstream core:80;
             proxy_pass http://$upstream$request_uri;
             proxy_set_header Host $http_host;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         }
 
         location /core/ {
@@ -357,6 +358,7 @@ http {
             set $upstream core:80;
             proxy_pass http://$upstream$request_uri;
             proxy_set_header Host $http_host;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         }
 
         location /console/ {
@@ -364,6 +366,7 @@ http {
             set $upstream core:80;
             proxy_pass http://$upstream$request_uri;
             proxy_set_header Host $http_host;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         }
 
         location ~ ^/solana(/.*)?$ {


### PR DESCRIPTION
Failing to proxy to upstream. Was doing this `/d_api/dapi/uptime` instead of `/d_api/uptime`.

**TEST**

This now works and does not 401
```bash
$ curl https://discoveryprovider2.staging.audius.co/d_api/uptime?host=https://discoveryprovider3.staging.audius.co
{
  "host": "https://discoveryprovider3.staging.audius.co",
  "uptime_percentage": 95.83333333333334,
  "duration": "24h",
  "uptime_raw_data": {
    "2025-01-16T18:00:00Z": 1,
    "2025-01-16T19:00:00Z": 1,
    "2025-01-16T20:00:00Z": 1,
    "2025-01-16T21:00:00Z": 1,
    "2025-01-16T22:00:00Z": 1,
    "2025-01-16T23:00:00Z": 1,
    "2025-01-17T00:00:00Z": 1,
    "2025-01-17T01:00:00Z": 1,
    "2025-01-17T02:00:00Z": 0,
    "2025-01-17T03:00:00Z": 1,
    "2025-01-17T04:00:00Z": 1,
    "2025-01-17T05:00:00Z": 1,
    "2025-01-17T06:00:00Z": 1,
    "2025-01-17T07:00:00Z": 1,
    "2025-01-17T08:00:00Z": 1,
    "2025-01-17T09:00:00Z": 1,
    "2025-01-17T10:00:00Z": 1,
    "2025-01-17T11:00:00Z": 1,
    "2025-01-17T12:00:00Z": 1,
    "2025-01-17T13:00:00Z": 1,
    "2025-01-17T14:00:00Z": 1,
    "2025-01-17T15:00:00Z": 1,
    "2025-01-17T16:00:00Z": 1,
    "2025-01-17T17:00:00Z": 1
  }
}