### PR TITLE
Update indexing to support new playlist_contents format

### DIFF
--- a/packages/discovery-provider/integration_tests/tasks/entity_manager/test_playlist_entity_manager.py
+++ b/packages/discovery-provider/integration_tests/tasks/entity_manager/test_playlist_entity_manager.py
@@ -1513,3 +1513,401 @@ def test_access_conditions(app, mocker, tx_receipts):
             .first()
         )
         assert album == None
+
+
+def test_validate_playlist_tx_new_format(app, mocker):
+    """Tests validation of playlist_contents in the new array format"""
+    with app.app_context():
+        db = get_db()
+        web3 = Web3()
+        challenge_event_bus: ChallengeEventBus = setup_challenge_bus()
+        update_task = UpdateTask(web3, challenge_event_bus)
+
+    test_metadata = {
+        "ValidNewFormat": {
+            "playlist_contents": [
+                {"track": 1, "time": 1660927554},
+                {"track_id": 2, "timestamp": 1660927555},
+            ],
+            "description": "test",
+            "playlist_name": "playlist",
+            "playlist_image_sizes_multihash": "",  # Required field
+            "playlist_image_multihash": "",  # Required field
+        },
+        "InvalidNewFormat": {
+            "playlist_contents": [{"invalid_field": 1}, {"track_id": 2}],
+            "description": "test",
+            "playlist_name": "playlist",
+            "playlist_image_sizes_multihash": "",  # Required field
+            "playlist_image_multihash": "",  # Required field
+        },
+    }
+
+    valid_metadata = json.dumps(test_metadata["ValidNewFormat"])
+    invalid_metadata = json.dumps(test_metadata["InvalidNewFormat"])
+
+    tx_receipts = {
+        "ValidNewFormatTx": [
+            {
+                "args": AttributeDict(
+                    {
+                        "_entityId": PLAYLIST_ID_OFFSET,
+                        "_entityType": "Playlist",
+                        "_userId": 1,
+                        "_action": "Create",
+                        "_metadata": f'{{"cid": "ValidNewFormat", "data": {valid_metadata}}}',
+                        "_signer": "user1wallet",
+                    }
+                )
+            }
+        ],
+        "InvalidNewFormatTx": [
+            {
+                "args": AttributeDict(
+                    {
+                        "_entityId": PLAYLIST_ID_OFFSET + 1,
+                        "_entityType": "Playlist",
+                        "_userId": 1,
+                        "_action": "Create",
+                        "_metadata": f'{{"cid": "InvalidNewFormat", "data": {invalid_metadata}}}',
+                        "_signer": "user1wallet",
+                    }
+                )
+            }
+        ],
+    }
+
+    entity_manager_txs = [
+        AttributeDict({"transactionHash": update_task.web3.to_bytes(text=tx_receipt)})
+        for tx_receipt in tx_receipts
+    ]
+
+    def get_events_side_effect(_, tx_receipt):
+        return tx_receipts[tx_receipt["transactionHash"].decode("utf-8")]
+
+    mocker.patch(
+        "src.tasks.entity_manager.entity_manager.get_entity_manager_events_tx",
+        side_effect=get_events_side_effect,
+        autospec=True,
+    )
+
+    entities = {
+        "users": [{"user_id": 1, "handle": "user-1", "wallet": "user1wallet"}],
+        "tracks": [{"track_id": 1, "owner_id": 1}, {"track_id": 2, "owner_id": 1}],
+    }
+    populate_mock_db(db, entities)
+
+    with db.scoped_session() as session:
+        # Valid format should succeed
+        entity_manager_update(
+            update_task,
+            session,
+            [entity_manager_txs[0]],
+            block_number=0,
+            block_timestamp=1585336422,
+            block_hash=hex(0),
+        )
+
+        playlist = (
+            session.query(Playlist)
+            .filter(
+                Playlist.playlist_id == PLAYLIST_ID_OFFSET, Playlist.is_current == True
+            )
+            .first()
+        )
+        assert playlist is not None
+        assert len(playlist.playlist_contents["track_ids"]) == 2
+        # Verify the track fields are correctly mapped
+        for track in playlist.playlist_contents["track_ids"]:
+            assert "track" in track
+            assert "time" in track
+            assert "metadata_time" in track
+
+        # Invalid format should fail
+        total_changes, _ = entity_manager_update(
+            update_task,
+            session,
+            [entity_manager_txs[1]],
+            block_number=0,
+            block_timestamp=1585336422,
+            block_hash=hex(0),
+        )
+        assert total_changes == 0
+
+
+def test_playlist_creation_with_legacy_format(app, mocker):
+    """Tests creating a playlist using the legacy nested track_ids format"""
+    with app.app_context():
+        db = get_db()
+        web3 = Web3()
+        challenge_event_bus: ChallengeEventBus = setup_challenge_bus()
+        update_task = UpdateTask(web3, challenge_event_bus)
+
+    test_metadata = {
+        "playlist_contents": {
+            "track_ids": [
+                {"track": 1, "time": 1660927554},
+                {"track": 2, "time": 1660927555},
+            ]
+        },
+        "description": "Legacy format playlist",
+        "playlist_name": "My Legacy Playlist",
+        "playlist_image_sizes_multihash": "",
+        "playlist_image_multihash": "",
+    }
+
+    tx_receipt = {
+        "args": AttributeDict(
+            {
+                "_entityId": PLAYLIST_ID_OFFSET,
+                "_entityType": "Playlist",
+                "_userId": 1,
+                "_action": "Create",
+                "_metadata": f'{{"cid": "Legacy", "data": {json.dumps(test_metadata)}}}',
+                "_signer": "user1wallet",
+            }
+        )
+    }
+
+    entity_manager_tx = AttributeDict(
+        {"transactionHash": update_task.web3.to_bytes(text="LegacyTx")}
+    )
+
+    mocker.patch(
+        "src.tasks.entity_manager.entity_manager.get_entity_manager_events_tx",
+        return_value=[tx_receipt],
+        autospec=True,
+    )
+
+    entities = {
+        "users": [{"user_id": 1, "handle": "user-1", "wallet": "user1wallet"}],
+        "tracks": [{"track_id": 1, "owner_id": 1}, {"track_id": 2, "owner_id": 1}],
+    }
+    populate_mock_db(db, entities)
+
+    with db.scoped_session() as session:
+        entity_manager_update(
+            update_task,
+            session,
+            [entity_manager_tx],
+            block_number=0,
+            block_timestamp=1585336422,
+            block_hash=hex(0),
+        )
+
+        playlist = (
+            session.query(Playlist)
+            .filter(
+                Playlist.playlist_id == PLAYLIST_ID_OFFSET, Playlist.is_current == True
+            )
+            .first()
+        )
+
+        assert playlist is not None
+        assert len(playlist.playlist_contents["track_ids"]) == 2
+        assert playlist.playlist_contents["track_ids"][0]["track"] == 1
+        assert playlist.playlist_contents["track_ids"][1]["track"] == 2
+
+
+def test_playlist_creation_with_flattened_format(app, mocker):
+    """Tests creating a playlist using the new flattened track array format"""
+    with app.app_context():
+        db = get_db()
+        web3 = Web3()
+        challenge_event_bus: ChallengeEventBus = setup_challenge_bus()
+        update_task = UpdateTask(web3, challenge_event_bus)
+
+    test_metadata = {
+        "playlist_contents": [
+            {"track": 1, "time": 1660927554},
+            {
+                "track_id": 2,
+                "timestamp": 1660927555,
+            },  # Tests both field naming conventions
+        ],
+        "description": "New format playlist",
+        "playlist_name": "My New Playlist",
+        "playlist_image_sizes_multihash": "",
+        "playlist_image_multihash": "",
+    }
+
+    tx_receipt = {
+        "args": AttributeDict(
+            {
+                "_entityId": PLAYLIST_ID_OFFSET,
+                "_entityType": "Playlist",
+                "_userId": 1,
+                "_action": "Create",
+                "_metadata": f'{{"cid": "New", "data": {json.dumps(test_metadata)}}}',
+                "_signer": "user1wallet",
+            }
+        )
+    }
+
+    entity_manager_tx = AttributeDict(
+        {"transactionHash": update_task.web3.to_bytes(text="NewTx")}
+    )
+
+    mocker.patch(
+        "src.tasks.entity_manager.entity_manager.get_entity_manager_events_tx",
+        return_value=[tx_receipt],
+        autospec=True,
+    )
+
+    entities = {
+        "users": [{"user_id": 1, "handle": "user-1", "wallet": "user1wallet"}],
+        "tracks": [{"track_id": 1, "owner_id": 1}, {"track_id": 2, "owner_id": 1}],
+    }
+    populate_mock_db(db, entities)
+
+    with db.scoped_session() as session:
+        entity_manager_update(
+            update_task,
+            session,
+            [entity_manager_tx],
+            block_number=0,
+            block_timestamp=1585336422,
+            block_hash=hex(0),
+        )
+
+        playlist = (
+            session.query(Playlist)
+            .filter(
+                Playlist.playlist_id == PLAYLIST_ID_OFFSET, Playlist.is_current == True
+            )
+            .first()
+        )
+
+        assert playlist is not None
+        assert len(playlist.playlist_contents["track_ids"]) == 2
+        assert playlist.playlist_contents["track_ids"][0]["track"] == 1
+        assert playlist.playlist_contents["track_ids"][1]["track"] == 2
+
+
+def test_playlist_update_preserves_track_order(app, mocker):
+    """Tests that updating a playlist preserves track order and timing information"""
+    with app.app_context():
+        db = get_db()
+        web3 = Web3()
+        challenge_event_bus: ChallengeEventBus = setup_challenge_bus()
+        update_task = UpdateTask(web3, challenge_event_bus)
+
+    # First create a playlist
+    initial_metadata = {
+        "playlist_contents": [
+            {"track": 1, "time": 1585336422},
+            {"track": 2, "time": 1585336422},
+        ],
+        "description": "Initial playlist",
+        "playlist_name": "My Playlist",
+        "playlist_image_sizes_multihash": "",
+        "playlist_image_multihash": "",
+    }
+
+    # Then update it with some changes
+    update_metadata = {
+        "playlist_contents": [
+            {"track": 1, "time": 1585336422},  # Same track and time
+            {"track": 2, "timestamp": 1585336425},  # Same track, new time
+            {"track": 3, "time": 1585336425},  # New track
+        ],
+        "description": "Updated playlist",
+        "playlist_name": "My Updated Playlist",
+        "playlist_image_sizes_multihash": "",
+        "playlist_image_multihash": "",
+    }
+
+    tx_receipts = [
+        {
+            "args": AttributeDict(
+                {
+                    "_entityId": PLAYLIST_ID_OFFSET,
+                    "_entityType": "Playlist",
+                    "_userId": 1,
+                    "_action": "Create",
+                    "_metadata": f'{{"cid": "Initial", "data": {json.dumps(initial_metadata)}}}',
+                    "_signer": "user1wallet",
+                }
+            )
+        },
+        {
+            "args": AttributeDict(
+                {
+                    "_entityId": PLAYLIST_ID_OFFSET,
+                    "_entityType": "Playlist",
+                    "_userId": 1,
+                    "_action": "Update",
+                    "_metadata": f'{{"cid": "Update", "data": {json.dumps(update_metadata)}}}',
+                    "_signer": "user1wallet",
+                }
+            )
+        },
+    ]
+
+    entity_manager_txs = [
+        AttributeDict({"transactionHash": update_task.web3.to_bytes(text=f"Tx{i}")})
+        for i in range(2)
+    ]
+
+    def get_events_side_effect(_, tx_receipt):
+        idx = entity_manager_txs.index(tx_receipt)
+        return [tx_receipts[idx]]
+
+    mocker.patch(
+        "src.tasks.entity_manager.entity_manager.get_entity_manager_events_tx",
+        side_effect=get_events_side_effect,
+        autospec=True,
+    )
+
+    entities = {
+        "users": [{"user_id": 1, "handle": "user-1", "wallet": "user1wallet"}],
+        "tracks": [{"track_id": i, "owner_id": 1} for i in range(1, 4)],
+    }
+    populate_mock_db(db, entities)
+
+    with db.scoped_session() as session:
+        # Create initial playlist
+        entity_manager_update(
+            update_task,
+            session,
+            [entity_manager_txs[0]],
+            block_number=0,
+            block_timestamp=1585336422,
+            block_hash=hex(0),
+        )
+
+        # Update playlist
+        entity_manager_update(
+            update_task,
+            session,
+            [entity_manager_txs[1]],
+            block_number=1,
+            block_timestamp=1585336427,
+            block_hash=hex(1),
+        )
+
+        playlist = (
+            session.query(Playlist)
+            .filter(
+                Playlist.playlist_id == PLAYLIST_ID_OFFSET, Playlist.is_current == True
+            )
+            .first()
+        )
+
+        assert playlist is not None
+        assert len(playlist.playlist_contents["track_ids"]) == 3
+
+        # First track should keep original time
+        assert playlist.playlist_contents["track_ids"][0]["track"] == 1
+        assert playlist.playlist_contents["track_ids"][0]["time"] == 1585336422
+        assert playlist.playlist_contents["track_ids"][0]["metadata_time"] == 1585336422
+
+        # Second track should have updated index time, new metadata time
+        assert playlist.playlist_contents["track_ids"][1]["track"] == 2
+        assert playlist.playlist_contents["track_ids"][1]["time"] == 1585336427
+        assert playlist.playlist_contents["track_ids"][1]["metadata_time"] == 1585336425
+
+        # Third track added at same time as second track modified, should use same timestamps
+        assert playlist.playlist_contents["track_ids"][2]["track"] == 3
+        assert playlist.playlist_contents["track_ids"][2]["time"] == 1585336427
+        assert playlist.playlist_contents["track_ids"][2]["metadata_time"] == 1585336425

--- a/packages/discovery-provider/src/tasks/entity_manager/entities/playlist.py
+++ b/packages/discovery-provider/src/tasks/entity_manager/entities/playlist.py
@@ -583,11 +583,17 @@ def process_playlist_contents(
         )
 
     for track in track_items:
-        # Track id can be either "track" or "track_id"
+        # Prefer track_id, use legacy track field otherwise
         track_id = track.get("track") or track.get("track_id")
-        # Track time can be either "timestamp" or "time"
-        metadata_time = track.get("timestamp") or track.get("time")
-        index_time = block_integer_time  # default to current block for new tracks
+        # Prefer metadata_timestamp if it exists, otherwise use timestamp or the legacy time field
+        metadata_time = (
+            track.get("metadata_timestamp")
+            or track.get("timestamp")
+            or track.get("time")
+        )
+        index_time = (
+            block_integer_time  # default index time to current block for new tracks
+        )
 
         if not track_id:
             raise IndexingValidationError(
@@ -604,6 +610,7 @@ def process_playlist_contents(
         previous_playlist_tracks = playlist_record.playlist_contents["track_ids"]
         for previous_track in previous_playlist_tracks:
             previous_track_id = previous_track["track"]
+            # prefer metadata_time to check if track was already in playlist
             previous_track_time = (
                 previous_track.get("metadata_time") or previous_track["time"]
             )

--- a/packages/discovery-provider/src/tasks/entity_manager/entities/playlist.py
+++ b/packages/discovery-provider/src/tasks/entity_manager/entities/playlist.py
@@ -341,15 +341,19 @@ def validate_playlist_tx(params: ManageEntityParameters):
                 f"Playlist {playlist_id} description exceeds character limit {CHARACTER_LIMIT_DESCRIPTION}"
             )
         if params.metadata.get("playlist_contents"):
-            if (
-                "playlist_contents" not in params.metadata
-                or "track_ids" not in params.metadata["playlist_contents"]
-            ):
-                raise IndexingValidationError("playlist contents requires track_ids")
-            playlist_track_count = len(
-                params.metadata["playlist_contents"]["track_ids"]
+            # Handle nested dictionary or array formats
+            track_items = (
+                params.metadata["playlist_contents"].get("track_ids")
+                if isinstance(params.metadata["playlist_contents"], dict)
+                else params.metadata["playlist_contents"]
             )
-            if playlist_track_count > PLAYLIST_TRACK_LIMIT:
+
+            if not isinstance(track_items, list):
+                raise IndexingValidationError(
+                    "playlist contents must be a list of tracks"
+                )
+
+            if len(track_items) > PLAYLIST_TRACK_LIMIT:
                 raise IndexingValidationError(
                     f"Playlist {playlist_id} exceeds track limit {PLAYLIST_TRACK_LIMIT}"
                 )
@@ -380,21 +384,27 @@ def create_playlist(params: ManageEntityParameters):
     validate_playlist_tx(params)
 
     playlist_id = params.entity_id
-    tracks = params.metadata["playlist_contents"].get("track_ids", [])
+    tracks = (
+        params.metadata["playlist_contents"].get("track_ids", [])
+        if isinstance(params.metadata["playlist_contents"], dict)
+        else params.metadata["playlist_contents"]
+    )
     tracks_with_index_time = []
     last_added_to = None
 
     created_at = params.block_datetime
     for track in tracks:
-        if "track" not in track or "time" not in track:
+        track_id = track.get("track") or track.get("track_id")
+        track_time = track.get("timestamp") or track.get("time")
+        if not track_id or not track_time:
             raise IndexingValidationError(
                 f"Cannot add {track} to playlist {playlist_id}"
             )
 
         tracks_with_index_time.append(
             {
-                "track": track["track"],
-                "metadata_time": track["time"],
+                "track": track_id,
+                "metadata_time": track_time,
                 "time": params.block_integer_time,
             }
         )
@@ -560,10 +570,29 @@ def process_playlist_contents(
     playlist_record, playlist_metadata, block_integer_time, existing_track_records
 ):
     updated_tracks = []
-    for track in playlist_metadata["playlist_contents"]["track_ids"]:
-        track_id = track["track"]
-        metadata_time = track["time"]
+    # Incoming tracks can be legacy format (dict with track_ids) or new format (array of objects)
+    track_items = (
+        playlist_metadata["playlist_contents"].get("track_ids")
+        if isinstance(playlist_metadata["playlist_contents"], dict)
+        else playlist_metadata["playlist_contents"]
+    )
+
+    if not isinstance(track_items, list):
+        raise IndexingValidationError(
+            f"Invalid playlist_contents format: {playlist_metadata['playlist_contents']}"
+        )
+
+    for track in track_items:
+        # Track id can be either "track" or "track_id"
+        track_id = track.get("track") or track.get("track_id")
+        # Track time can be either "timestamp" or "time"
+        metadata_time = track.get("timestamp") or track.get("time")
         index_time = block_integer_time  # default to current block for new tracks
+
+        if not track_id:
+            raise IndexingValidationError(
+                f"Track object missing track/track_id field: {track}"
+            )
 
         track_metadata = existing_track_records.get(track_id)
         if playlist_record.is_album and (

--- a/packages/discovery-provider/src/tasks/entity_manager/entity_manager.py
+++ b/packages/discovery-provider/src/tasks/entity_manager/entity_manager.py
@@ -776,9 +776,17 @@ def collect_entities_to_fetch(update_task, entity_manager_txs):
 
                 # Add playlist track ids in entities to fetch
                 # to prevent playlists from including gated tracks
-                tracks = json_metadata.get("playlist_contents", {}).get("track_ids", [])
-                for track in tracks:
-                    entities_to_fetch[EntityType.TRACK].add(track["track"])
+                playlist_contents = json_metadata.get("playlist_contents")
+                if playlist_contents:
+                    if isinstance(playlist_contents, dict):
+                        tracks = playlist_contents.get("track_ids", [])
+                    else:
+                        tracks = playlist_contents
+
+                    for track in tracks:
+                        track_id = track.get("track") or track.get("track_id")
+                        if track_id:
+                            entities_to_fetch[EntityType.TRACK].add(track_id)
 
                 if entity_type == EntityType.TRACK:
                     user_id = json_metadata.get("ai_attribution_user_id")


### PR DESCRIPTION
### Description
Follow-up to #11080 
This adds support in indexing for passing `playlist_contents` as an array with objects of `{track_id: number, timestamp: number}`, which matches the format they are now returned in. This will remove some of the conversion hassle on the client side.

The timestamp/metadata_timestamp relationship is still very confusing (`metadata_timestamp` being the original value for `timestamp` that was passed when the track was added and `timestamp` being the actual time it was indexed...)

So I wrote some tests to make sure the new logic follows the expected rules.

### How Has This Been Tested?
Integration tests and ran local client against local stack, creating and updating a playlist to make sure things still work correctly.
