### PR TITLE
[QA-1925] Fix following query args issue

### DIFF
--- a/packages/discovery-provider/src/api/v1/users.py
+++ b/packages/discovery-provider/src/api/v1/users.py
@@ -1576,8 +1576,8 @@ class FullFollowingUsers(Resource):
         offset = get_default_max(args.get("offset"), 0)
         current_user_id = get_current_user_id(args)
         args = {
-            "followee_user_id": decoded_id,
-            "follower_user_id": current_user_id,
+            "follower_user_id": decoded_id,
+            "current_user_id": current_user_id,
             "limit": limit,
             "offset": offset,
         }


### PR DESCRIPTION
### Description

Fixes a bug introduced here: https://github.com/AudiusProject/audius-protocol/pull/10575/files#diff-09ed4cebd27f7f16f2df13e88a86e6dfc0e4bd41fb191046215f74ea73c02cc6R1576-R1577

This endpoint calls `get_followees_for_user` which is expecting `current_user_id`, but the args were being passed incorrectly.
![image](https://github.com/user-attachments/assets/20446a17-255d-4013-9163-2724a948c231)


### How Has This Been Tested?

stage discovery - my profile is showing all follows correctly under Following
