### PR TITLE
[QA-1902] Fix double select

### DIFF
--- a/packages/web/src/components/nav/desktop/LeftNavLink.tsx
+++ b/packages/web/src/components/nav/desktop/LeftNavLink.tsx
@@ -1,3 +1,5 @@
+import { useMemo } from 'react'
+
 import { Name } from '@audius/common/models'
 import { NavItem, NavItemProps } from '@audius/harmony'
 import { useDispatch } from 'react-redux'
@@ -13,12 +15,27 @@ export type LeftNavLinkProps = Omit<NavItemProps, 'isSelected'> & {
   to?: string
   disabled?: boolean
   restriction?: RestrictionType
+  exact?: boolean
 }
 
 export const LeftNavLink = (props: LeftNavLinkProps) => {
-  const { to, disabled, children, onClick, restriction, ...other } = props
+  const {
+    to,
+    disabled,
+    children,
+    onClick,
+    restriction,
+    exact = false,
+    ...other
+  } = props
   const location = useLocation()
   const dispatch = useDispatch()
+  const isSelected = useMemo(() => {
+    if (exact) {
+      return to ? location.pathname === to : false
+    }
+    return to ? location.pathname.startsWith(to) : false
+  }, [to, location.pathname, exact])
 
   const requiresAccountOnClick = useRequiresAccountOnClick(
     (e) => {
@@ -43,7 +60,7 @@ export const LeftNavLink = (props: LeftNavLinkProps) => {
     <NavLink to={to ?? ''} onClick={requiresAccountOnClick} draggable={false}>
       <NavItem
         {...other}
-        isSelected={to ? location.pathname.startsWith(to) : false}
+        isSelected={isSelected}
         css={{
           opacity: disabled ? 0.5 : 1,
           cursor: 'pointer'

--- a/packages/web/src/components/nav/desktop/PlaylistLibrary/CollectionNavItem.tsx
+++ b/packages/web/src/components/nav/desktop/PlaylistLibrary/CollectionNavItem.tsx
@@ -72,10 +72,12 @@ type CollectionNavItemProps = {
   hasUpdate?: boolean
   onClick?: () => void
   isChild?: boolean
+  exact?: boolean
 }
 
 export const CollectionNavItem = (props: CollectionNavItemProps) => {
-  const { id, name, url, isOwned, level, hasUpdate, onClick, isChild } = props
+  const { id, name, url, isOwned, level, hasUpdate, onClick, isChild, exact } =
+    props
   const [isDraggingOver, setIsDraggingOver] = useState(false)
   const [isHovering, setIsHovering] = useState(false)
   const location = useLocation()
@@ -221,6 +223,7 @@ export const CollectionNavItem = (props: CollectionNavItemProps) => {
             }
             leftOverride={hasUpdate ? <PlaylistUpdateDot /> : null}
             isChild={isChild}
+            exact={exact}
           >
             <Flex
               alignItems='center'

--- a/packages/web/src/components/nav/desktop/PlaylistLibrary/PlaylistNavItem.tsx
+++ b/packages/web/src/components/nav/desktop/PlaylistLibrary/PlaylistNavItem.tsx
@@ -63,6 +63,7 @@ export const PlaylistNavItem = (props: PlaylistNavItemProps) => {
       isChild={isChild}
       hasUpdate={hasPlaylistUpdate}
       onClick={handleClick}
+      exact
     />
   )
 }


### PR DESCRIPTION
### Description
We were doing partial matching for showing the selected state of nav items and this caused issues with playlist items since they can start with the same path. using exact matching for playlist items now

### How Has This Been Tested?

`npm run web:stage`
- Created two playlists with the same name (refresh for slug to update)
- Ensure that clicking on them does not highlight both 
