### PR TITLE
[PAY-3398] Use new playlist contents format

### DIFF
--- a/.changeset/young-teachers-tap.md
+++ b/.changeset/young-teachers-tap.md
@@ -1,0 +1,5 @@
+---
+"@audius/sdk": minor
+---
+
+Pass playlist_contents in updated format

--- a/packages/sdk/src/sdk/api/playlists/PlaylistsApi.ts
+++ b/packages/sdk/src/sdk/api/playlists/PlaylistsApi.ts
@@ -486,12 +486,10 @@ export class PlaylistsApi extends GeneratedPlaylistsApi {
     const updatedMetadata = {
       ...metadata,
       isPrivate: false,
-      playlistContents: {
-        trackIds: trackIds.map((trackId) => ({
-          track: trackId,
-          time: currentBlock.timestamp
-        }))
-      },
+      playlistContents: trackIds.map((trackId) => ({
+        trackId,
+        timeStamp: currentBlock.timestamp
+      })),
       playlistImageSizesMultihash: coverArtResponse.id
     }
 
@@ -548,19 +546,6 @@ export class PlaylistsApi extends GeneratedPlaylistsApi {
 
     const updatedMetadata = {
       ...metadata,
-      ...(metadata.playlistContents
-        ? {
-            playlistContents: {
-              trackIds: metadata.playlistContents.map(
-                ({ trackId, metadataTimestamp, timestamp }) => ({
-                  track: trackId,
-                  // default to timestamp for legacy playlists
-                  time: metadataTimestamp ?? timestamp
-                })
-              )
-            }
-          }
-        : {}),
       ...(coverArtResponse
         ? { playlistImageSizesMultihash: coverArtResponse.id }
         : {})
@@ -615,12 +600,10 @@ export class PlaylistsApi extends GeneratedPlaylistsApi {
     // Update metadata to include track ids
     const updatedMetadata = {
       ...metadata,
-      playlistContents: {
-        trackIds: (trackIds ?? []).map((trackId) => ({
-          track: trackId,
-          time: currentBlock.timestamp
-        }))
-      },
+      playlistContents: (trackIds ?? []).map((trackId) => ({
+        trackId,
+        timeStamp: currentBlock.timestamp
+      })),
       playlistImageSizesMultihash: coverArtResponse?.id ?? metadata.coverArtCid
     }
 


### PR DESCRIPTION
### Description
This updates client to use the new format for playlist_contents: an array instead of an object, with field names matching what is returned when fetching a playlist from GET endpoints. 

The goal here is that whatever you get from DN is something you can turn around and feed right back to it. New items added can use just `timestamp` and that will get treated as `metadata_timestamp` upon indexing. 

I will follow up with future PRs to make this cleaner.

### How Has This Been Tested?
Local client against local stack with the updated indexing logic. Created a new playlist, added items to it, moved them around, etc. Made sure that upon refresh, the changes were reflected correctly.
