### PR TITLE
ignore generated code in python lint

### DIFF
--- a/packages/discovery-provider/scripts/lint.sh
+++ b/packages/discovery-provider/scripts/lint.sh
@@ -1,4 +1,5 @@
-black .
-flake8 .
-mypy .
-isort .
+isort --diff --check . --skip ./src/tasks/core/gen --skip ./plugins
+flake8 . --exclude=./src/tasks/core/gen,./plugins
+black --diff --check . --exclude './src/tasks/core/gen|./plugins'
+mypy . --exclude './src/tasks/core/gen|./plugins'
+


### PR DESCRIPTION
### Description
ignores generated protobuf in python code

### How Has This Been Tested?
`cd packages/discovery-provider && ./scripts/lint.sh`
