### PR TITLE
Revert "[PAY-3398] Use new playlist contents format (#11103)"

### DIFF
--- a/.changeset/young-teachers-tap.md
+++ b/.changeset/young-teachers-tap.md
@@ -1,5 +1,0 @@
----
-"@audius/sdk": minor
----
-
-Pass playlist_contents in updated format

--- a/packages/sdk/src/sdk/api/playlists/PlaylistsApi.ts
+++ b/packages/sdk/src/sdk/api/playlists/PlaylistsApi.ts
@@ -486,10 +486,12 @@ export class PlaylistsApi extends GeneratedPlaylistsApi {
     const updatedMetadata = {
       ...metadata,
       isPrivate: false,
-      playlistContents: trackIds.map((trackId) => ({
-        trackId,
-        timeStamp: currentBlock.timestamp
-      })),
+      playlistContents: {
+        trackIds: trackIds.map((trackId) => ({
+          track: trackId,
+          time: currentBlock.timestamp
+        }))
+      },
       playlistImageSizesMultihash: coverArtResponse.id
     }
 
@@ -546,6 +548,19 @@ export class PlaylistsApi extends GeneratedPlaylistsApi {
 
     const updatedMetadata = {
       ...metadata,
+      ...(metadata.playlistContents
+        ? {
+            playlistContents: {
+              trackIds: metadata.playlistContents.map(
+                ({ trackId, metadataTimestamp, timestamp }) => ({
+                  track: trackId,
+                  // default to timestamp for legacy playlists
+                  time: metadataTimestamp ?? timestamp
+                })
+              )
+            }
+          }
+        : {}),
       ...(coverArtResponse
         ? { playlistImageSizesMultihash: coverArtResponse.id }
         : {})
@@ -600,10 +615,12 @@ export class PlaylistsApi extends GeneratedPlaylistsApi {
     // Update metadata to include track ids
     const updatedMetadata = {
       ...metadata,
-      playlistContents: (trackIds ?? []).map((trackId) => ({
-        trackId,
-        timeStamp: currentBlock.timestamp
-      })),
+      playlistContents: {
+        trackIds: (trackIds ?? []).map((trackId) => ({
+          track: trackId,
+          time: currentBlock.timestamp
+        }))
+      },
       playlistImageSizesMultihash: coverArtResponse?.id ?? metadata.coverArtCid
     }
 


### PR DESCRIPTION
This reverts commit 3781aeed0b166af09879f46ffdcb130d2319d0f7.

Reverting this change to unblock package releases since it won't work until DN is updated.
