### PR TITLE
use correct casing for stage em contract

### DIFF
--- a/monitoring/healthz/src/utils/acdc-client.ts
+++ b/monitoring/healthz/src/utils/acdc-client.ts
@@ -8,7 +8,7 @@ export function emAddress(isProd: boolean, isStage: boolean) {
     return '0x1cd8a543596d499b9b6e7a6ec15ecd2b7857fd64'
   }
   if (isStage) {
-    return '0x1cd8a543596D499B9b6E7a6eC15ECd2B7857Fd64'
+    return '0x1cd8a543596d499b9b6e7a6ec15ecd2b7857fd64'
   }
   return '0x254dffcd3277C0b1660F6d42EFbB754edaBAbC2B'
 }
@@ -18,9 +18,9 @@ export function useEthersProvider() {
   const isDev = useLocation().pathname.indexOf('/dev') == 0
 
 
-  let rpcEndpoint = 'https://acdc-gateway.audius.co'
+  let rpcEndpoint = 'https://discoveryprovider.audius.co/chain'
   if (isStage) {
-    rpcEndpoint = 'https://acdc-gateway.staging.audius.co'
+    rpcEndpoint = 'https://discoveryprovider.staging.audius.co/chain'
   }
   if (isDev) {
     rpcEndpoint = 'http://audius-protocol-discovery-provider-1/chain'


### PR DESCRIPTION
### Description
Not entirely sure why this starting failing but a checksum match was failing in the console. Since the stage one had different casing then prod and prod was working I just used the same.
Also changed from using the gateway to discoveryprovider /chain endpoint as we shouldn't be using the gateway if we don't have to.

### How Has This Been Tested?
`npm run dev` in healthz dir.
