### PR TITLE
[PAY-3832] Move challenge disbursement notif to pre-claim

### DIFF
--- a/packages/discovery-provider/ddl/functions/handle_challenge_disbursements.sql
+++ b/packages/discovery-provider/ddl/functions/handle_challenge_disbursements.sql
@@ -3,6 +3,42 @@ declare
   reward_manager_tx reward_manager_txs%ROWTYPE;
 	existing_notification integer;
 begin
+
+  select * into reward_manager_tx from reward_manager_txs where reward_manager_txs.signature = new.signature limit 1;
+
+  if reward_manager_tx is not null then
+		select id into existing_notification 
+		from notification
+		where
+		type = 'challenge_reward' and
+		new.user_id = any(user_ids) and
+		timestamp >= (new.created_at - interval '1 hour')
+		limit 1;
+		
+		if existing_notification is null then
+			-- create a notification for the challenge disbursement
+			insert into notification
+			(slot, user_ids, timestamp, type, group_id, specifier, data)
+			values
+			(
+				new.slot,
+				ARRAY [new.user_id],
+				new.created_at,
+				'challenge_reward',
+				'challenge_reward:' || new.user_id || ':challenge:' || new.challenge_id || ':specifier:' || new.specifier,
+				new.user_id,
+				json_build_object('specifier', new.specifier, 'challenge_id', new.challenge_id, 'amount', new.amount)
+			)
+			on conflict do nothing;
+		end if;
+  end if;
+  return null;
+
+exception
+  when others then
+    raise warning 'An error occurred in %: %', tg_name, sqlerrm;
+    return null;
+
 end;
 $$ language plpgsql;
 

--- a/packages/discovery-provider/ddl/functions/handle_challenge_disbursements.sql
+++ b/packages/discovery-provider/ddl/functions/handle_challenge_disbursements.sql
@@ -3,42 +3,6 @@ declare
   reward_manager_tx reward_manager_txs%ROWTYPE;
 	existing_notification integer;
 begin
-
-  select * into reward_manager_tx from reward_manager_txs where reward_manager_txs.signature = new.signature limit 1;
-
-  if reward_manager_tx is not null then
-		select id into existing_notification 
-		from notification
-		where
-		type = 'challenge_reward' and
-		new.user_id = any(user_ids) and
-		timestamp >= (new.created_at - interval '1 hour')
-		limit 1;
-		
-		if existing_notification is null then
-			-- create a notification for the challenge disbursement
-			insert into notification
-			(slot, user_ids, timestamp, type, group_id, specifier, data)
-			values
-			(
-				new.slot,
-				ARRAY [new.user_id],
-				new.created_at,
-				'challenge_reward',
-				'challenge_reward:' || new.user_id || ':challenge:' || new.challenge_id || ':specifier:' || new.specifier,
-				new.user_id,
-				json_build_object('specifier', new.specifier, 'challenge_id', new.challenge_id, 'amount', new.amount)
-			)
-			on conflict do nothing;
-		end if;
-  end if;
-  return null;
-
-exception
-  when others then
-    raise warning 'An error occurred in %: %', tg_name, sqlerrm;
-    return null;
-
 end;
 $$ language plpgsql;
 

--- a/packages/discovery-provider/ddl/functions/handle_user_challenges.sql
+++ b/packages/discovery-provider/ddl/functions/handle_user_challenges.sql
@@ -35,7 +35,7 @@ begin
             end if;
 
             insert into notification
-            (slot, user_ids, timestamp, type, group_id, specifier, data)
+            (blocknumber, user_ids, timestamp, type, group_id, specifier, data)
             values
             (
                 new.completed_blocknumber,
@@ -44,7 +44,7 @@ begin
                 'challenge_reward',
                 'challenge_reward:' || new.user_id || ':challenge:' || new.challenge_id || ':specifier:' || new.specifier,
                 new.user_id,
-                json_build_object('specifier', new.specifier, 'challenge_id', new.challenge_id, 'amount', new.amount * 100000000) -- convert amount
+                json_build_object('specifier', new.specifier, 'challenge_id', new.challenge_id, 'amount', new.amount::text || '00000000' ) -- convert amount
             )
             on conflict do nothing;
         else

--- a/packages/discovery-provider/ddl/functions/handle_user_challenges.sql
+++ b/packages/discovery-provider/ddl/functions/handle_user_challenges.sql
@@ -34,30 +34,19 @@ begin
                 on conflict do nothing;
             end if;
 
-            select id into existing_notification 
-            from notification
-            where
-            type = 'challenge_reward' and
-            new.user_id = any(user_ids) and
-            group_id = 'challenge_reward:' || new.user_id || ':challenge:' || new.challenge_id || ':specifier:' || new.specifier and
-            specifier = new.user_id::text
-            limit 1;
-            
-            if existing_notification is null then
-                insert into notification
-                (slot, user_ids, timestamp, type, group_id, specifier, data)
-                values
-                (
-                    new.completed_blocknumber,
-                    ARRAY [new.user_id],
-                    new.completed_at,
-                    'challenge_reward',
-                    'challenge_reward:' || new.user_id || ':challenge:' || new.challenge_id || ':specifier:' || new.specifier,
-                    new.user_id,
-                    json_build_object('specifier', new.specifier, 'challenge_id', new.challenge_id, 'amount', new.amount * 100000000)
-                )
-                on conflict do nothing;
-            end if;
+            insert into notification
+            (slot, user_ids, timestamp, type, group_id, specifier, data)
+            values
+            (
+                new.completed_blocknumber,
+                ARRAY [new.user_id],
+                new.completed_at,
+                'challenge_reward',
+                'challenge_reward:' || new.user_id || ':challenge:' || new.challenge_id || ':specifier:' || new.specifier,
+                new.user_id,
+                json_build_object('specifier', new.specifier, 'challenge_id', new.challenge_id, 'amount', new.amount * 100000000) -- convert amount
+            )
+            on conflict do nothing;
         else
             -- transactional notifications cover this 
             if (new.challenge_id != 'b' and new.challenge_id != 's') then

--- a/packages/discovery-provider/ddl/functions/handle_user_challenges.sql
+++ b/packages/discovery-provider/ddl/functions/handle_user_challenges.sql
@@ -33,6 +33,31 @@ begin
                 )
                 on conflict do nothing;
             end if;
+
+            select id into existing_notification 
+            from notification
+            where
+            type = 'challenge_reward' and
+            new.user_id = any(user_ids) and
+            group_id = 'challenge_reward:' || new.user_id || ':challenge:' || new.challenge_id || ':specifier:' || new.specifier and
+            specifier = new.user_id::text
+            limit 1;
+            
+            if existing_notification is null then
+                insert into notification
+                (slot, user_ids, timestamp, type, group_id, specifier, data)
+                values
+                (
+                    new.completed_blocknumber,
+                    ARRAY [new.user_id],
+                    new.completed_at,
+                    'challenge_reward',
+                    'challenge_reward:' || new.user_id || ':challenge:' || new.challenge_id || ':specifier:' || new.specifier,
+                    new.user_id,
+                    json_build_object('specifier', new.specifier, 'challenge_id', new.challenge_id, 'amount', new.amount * 100000000)
+                )
+                on conflict do nothing;
+            end if;
         else
             -- transactional notifications cover this 
             if (new.challenge_id != 'b' and new.challenge_id != 's') then


### PR DESCRIPTION
### Description

Before, we were triggering a notification that shows the challenge and reward amount at disbursement. We now want to move that to when the challenge is ready to be claimed. 

Fixes PAY-3838

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._

Ran locally and confirmed on challenge completion, the challenge_reward notif is triggered with the specified challenge ID and amount.