### PR TITLE
MRVR country fixes

### DIFF
--- a/packages/discovery-provider/ddl/migrations/0115_fix_netherlands.sql
+++ b/packages/discovery-provider/ddl/migrations/0115_fix_netherlands.sql
@@ -1,0 +1,17 @@
+begin;
+
+-- find potentially old countries:
+-- select distinct country from aggregate_monthly_plays where country not in (select nicename from countries);
+
+-- fix 'Netherlands' rows to 'The Netherlands'
+insert into aggregate_monthly_plays (play_item_id, timestamp, count, country)
+select play_item_id, timestamp, count, 'The Netherlands'
+from aggregate_monthly_plays where country = 'Netherlands'
+on conflict (play_item_id, "timestamp", country)
+do update set count = aggregate_monthly_plays.count + excluded.count
+;
+
+-- delete old 'Netherlands' rows
+delete from aggregate_monthly_plays where country = 'Netherlands';
+
+commit;

--- a/packages/discovery-provider/plugins/pedalboard/apps/mri/src/queries/mrvr.ts
+++ b/packages/discovery-provider/plugins/pedalboard/apps/mri/src/queries/mrvr.ts
@@ -211,7 +211,7 @@ export const mrvr = async (db: Knex, date: Date): Promise<void> => {
           ), 0) as "Gross revenue With Deductions",
           country_code,
           download_count as "Total Downloads",
-          download_count as "Total Streams",
+          0::numeric as "Total Streams",
           case when
             is_country_eur("country_code") then 'EUR'
             else 'USD'

--- a/packages/discovery-provider/plugins/pedalboard/apps/mri/src/queries/mrvr.ts
+++ b/packages/discovery-provider/plugins/pedalboard/apps/mri/src/queries/mrvr.ts
@@ -179,7 +179,7 @@ export const mrvr = async (db: Knex, date: Date): Promise<void> => {
         "Gross Revenue",
         "Gross revenue With Deductions",
         country_code as "Territory",
-        ("Total Downloads" > 0 or "Total Streams" > 0) as "Has_usage_flag",
+        CASE WHEN ("Total Downloads" > 0 or "Total Streams" > 0) THEN 'TRUE' ELSE 'FALSE' END as "Has_usage_flag",
         coalesce("Total Downloads", 0) as "Total Downloads",
         coalesce("Total Streams", 0) as "Total Streams",
         "Currency",


### PR DESCRIPTION
### Description

* Fixes WW bucket for Revenue report.
* Fixes discrepancy in The Netherlands country code (NL).
* Use `download_count` for `stream_count` for paid content to omit 30s preview streams.
