### PR TITLE
[QA-1930] Fix types for upload/edit and handling of duplicate trackIds

### DIFF
--- a/packages/common/src/models/Analytics.ts
+++ b/packages/common/src/models/Analytics.ts
@@ -2694,18 +2694,18 @@ export type CommentsOpenInstallAppModal = {
 
 export type TrackReplaceDownload = {
   eventName: Name.TRACK_REPLACE_DOWNLOAD
-  trackId: ID
+  trackId?: ID
 }
 
 export type TrackReplaceReplace = {
   eventName: Name.TRACK_REPLACE_REPLACE
-  trackId: ID
+  trackId?: ID
   source: 'upload' | 'edit'
 }
 
 export type TrackReplacePreview = {
   eventName: Name.TRACK_REPLACE_PREVIEW
-  trackId: ID
+  trackId?: ID
   source: 'upload' | 'edit'
 }
 

--- a/packages/common/src/store/upload/types.ts
+++ b/packages/common/src/store/upload/types.ts
@@ -30,7 +30,7 @@ export interface TrackForUpload {
 
 export interface TrackForEdit {
   metadata: TrackMetadataForUpload
-  metadata_time: number
+  metadata_time?: number
 }
 
 export const isTrackForEdit = (

--- a/packages/common/src/store/upload/types.ts
+++ b/packages/common/src/store/upload/types.ts
@@ -30,13 +30,24 @@ export interface TrackForUpload {
 
 export interface TrackForEdit {
   metadata: TrackMetadataForUpload
+  metadata_time: number
 }
+
+export const isTrackForEdit = (
+  track: TrackForUpload | TrackForEdit
+): track is TrackForEdit => !('file' in track)
+
+export const isTrackForUpload = (
+  track: TrackForUpload | TrackForEdit
+): track is TrackForUpload => 'file' in track
 
 /**
  * Unlike normal Track metadata, TrackMetadataForUpload includes additional
  * files: artwork and a stems field with StemsForUpload.
+ * This type is used for both Upload and Edit flows.
  */
-export interface TrackMetadataForUpload extends Omit<TrackMetadata, 'artwork'> {
+export interface TrackMetadataForUpload
+  extends Omit<TrackMetadata, 'artwork' | 'track_id'> {
   artwork?:
     | Nullable<{
         file?: Blob | NativeFile
@@ -45,6 +56,10 @@ export interface TrackMetadataForUpload extends Omit<TrackMetadata, 'artwork'> {
       }>
     | TrackMetadata['artwork']
   stems?: (StemUploadWithFile | StemUpload)[]
+  /** During Upload, tracks will typically not have a track_id, but it might
+   * be assigned ahead of time for tracks with stems.
+   */
+  track_id?: number
 }
 /**
  * Unlike normal CollectionMetadata, CollectionMetadataForUpload has artwork

--- a/packages/mobile/src/screens/edit-track-screen/EditTrackForm.tsx
+++ b/packages/mobile/src/screens/edit-track-screen/EditTrackForm.tsx
@@ -148,6 +148,11 @@ export const EditTrackForm = (props: EditTrackFormProps) => {
   }, [selectFile, isUpload, values.track_id])
 
   const handleDownload = useCallback(() => {
+    if (!initialValues.track_id) {
+      console.error('Cannot download track without track ID')
+      return
+    }
+
     openWaitForDownload({
       trackIds: [initialValues.track_id],
       quality: DownloadQuality.ORIGINAL
@@ -190,7 +195,7 @@ export const EditTrackForm = (props: EditTrackFormProps) => {
   }, [isUpload, setTitle, track])
 
   const handleReplaceAudio = useCallback(() => {
-    if (!track) return
+    if (!track || !values.track_id) return
 
     const metadata = getUploadMetadataFromFormValues(values, initialValues)
 

--- a/packages/mobile/src/screens/edit-track-screen/components/FileReplaceContainer.tsx
+++ b/packages/mobile/src/screens/edit-track-screen/components/FileReplaceContainer.tsx
@@ -18,7 +18,7 @@ import { make, track as trackEvent } from 'app/services/analytics'
 type FileReplaceContainerProps = {
   fileName: string
   filePath: string
-  trackId: ID
+  trackId?: ID
   isUpload?: boolean
   downloadEnabled?: boolean
   onMenuButtonPress?: () => void

--- a/packages/web/src/common/store/upload/sagas.ts
+++ b/packages/web/src/common/store/upload/sagas.ts
@@ -376,7 +376,7 @@ type PublishedPayload = {
 type ErrorPayload = {
   trackIndex: number
   stemIndex: number | null
-  trackId: ID
+  trackId?: ID
   phase: 'upload' | 'publish'
   error: unknown
 }
@@ -466,17 +466,23 @@ export function* handleUploads({
       })
     )
 
-    // Process the track's stems
-    const trackStems = prepareStemsForUpload(
-      (track.metadata.stems ?? []) as StemUploadWithFile[],
-      track.metadata.track_id
-    )
-    const stemCount = track.metadata.stems?.length ?? 0
-    pendingStemCount[track.metadata.track_id] = stemCount
-    stems += stemCount
-    for (let j = 0; j < trackStems.length; j++) {
-      const stem = trackStems[j]
-      uploadQueue.put({ trackIndex: i, stemIndex: j, track: stem })
+    if (track.metadata.stems?.length) {
+      // track_id should be created and assigned ahead of time for a track with stems
+      if (!track.metadata.track_id) {
+        throw new Error('Track ID is required on parent track for stems')
+      }
+      // Process the track's stems
+      const trackStems = prepareStemsForUpload(
+        (track.metadata.stems ?? []) as StemUploadWithFile[],
+        track.metadata.track_id
+      )
+      const stemCount = track.metadata.stems?.length ?? 0
+      pendingStemCount[track.metadata.track_id] = stemCount
+      stems += stemCount
+      for (let j = 0; j < trackStems.length; j++) {
+        const stem = trackStems[j]
+        uploadQueue.put({ trackIndex: i, stemIndex: j, track: stem })
+      }
     }
   }
 
@@ -594,6 +600,9 @@ export function* handleUploads({
 
     // Trigger upload for parent if last stem
     if (stemIndex !== null) {
+      if (!parentTrackId) {
+        throw new Error('Parent track ID not found for stem')
+      }
       pendingStemCount[parentTrackId] -= 1
       if (
         pendingStemCount[parentTrackId] === 0 &&

--- a/packages/web/src/components/edit-track/EditTrackForm.tsx
+++ b/packages/web/src/components/edit-track/EditTrackForm.tsx
@@ -327,6 +327,11 @@ const TrackEditForm = (
   const { onOpen: openWaitforDownload } = useWaitForDownloadModal()
 
   const onClickDownload = useCallback(() => {
+    if (!initialTrackValues.track_id) {
+      console.error('Cannot download track without track ID')
+      return
+    }
+
     openWaitforDownload({
       trackIds: [initialTrackValues.track_id],
       quality: DownloadQuality.ORIGINAL

--- a/packages/web/src/components/edit/fields/CollectionTrackField.tsx
+++ b/packages/web/src/components/edit/fields/CollectionTrackField.tsx
@@ -1,11 +1,11 @@
 import { useCallback, useContext, useEffect } from 'react'
 
+import { TrackForEdit, TrackForUpload } from '@audius/common/store'
 import { IconDrag, IconTrash, Text, IconButton, Flex } from '@audius/harmony'
 import { useField } from 'formik'
 
 import { UploadPreviewContext } from 'components/edit-track/utils/uploadPreviewContext'
 import { Tile } from 'components/tile'
-import { CollectionTrackForEdit } from 'pages/upload-page/types'
 
 import styles from './CollectionTrackField.module.css'
 import { TrackNameField } from './TrackNameField'
@@ -16,13 +16,19 @@ type CollectionTrackFieldProps = {
   disableDelete: boolean
 }
 
+type CollectionTrackWithOverride = (TrackForEdit | TrackForUpload) & {
+  override: boolean
+}
+
 export const CollectionTrackField = (props: CollectionTrackFieldProps) => {
   const { disableDelete = false, index, remove } = props
   const { playingPreviewIndex, stopPreview } = useContext(UploadPreviewContext)
-  const [{ value: track }] = useField<CollectionTrackForEdit>(`tracks.${index}`)
+  const [{ value: track }] = useField<CollectionTrackWithOverride>(
+    `tracks.${index}`
+  )
 
   const [{ value: metadata }, , { setValue }] = useField<
-    CollectionTrackForEdit['metadata']
+    CollectionTrackWithOverride['metadata']
   >(`tracks.${index}.metadata`)
 
   const [{ value }] = useField('trackDetails')

--- a/packages/web/src/components/edit/fields/CollectionTrackField.tsx
+++ b/packages/web/src/components/edit/fields/CollectionTrackField.tsx
@@ -5,7 +5,7 @@ import { useField } from 'formik'
 
 import { UploadPreviewContext } from 'components/edit-track/utils/uploadPreviewContext'
 import { Tile } from 'components/tile'
-import { CollectionTrackForUpload } from 'pages/upload-page/types'
+import { CollectionTrackForEdit } from 'pages/upload-page/types'
 
 import styles from './CollectionTrackField.module.css'
 import { TrackNameField } from './TrackNameField'
@@ -19,12 +19,10 @@ type CollectionTrackFieldProps = {
 export const CollectionTrackField = (props: CollectionTrackFieldProps) => {
   const { disableDelete = false, index, remove } = props
   const { playingPreviewIndex, stopPreview } = useContext(UploadPreviewContext)
-  const [{ value: track }] = useField<CollectionTrackForUpload>(
-    `tracks.${index}`
-  )
+  const [{ value: track }] = useField<CollectionTrackForEdit>(`tracks.${index}`)
 
   const [{ value: metadata }, , { setValue }] = useField<
-    CollectionTrackForUpload['metadata']
+    CollectionTrackForEdit['metadata']
   >(`tracks.${index}.metadata`)
 
   const [{ value }] = useField('trackDetails')

--- a/packages/web/src/components/edit/fields/CollectionTrackFieldArray.tsx
+++ b/packages/web/src/components/edit/fields/CollectionTrackFieldArray.tsx
@@ -1,16 +1,27 @@
+import {
+  TrackForEdit,
+  TrackForUpload,
+  isTrackForUpload
+} from '@audius/common/store'
 import { FieldArray, useField } from 'formik'
 import { DragDropContext, Draggable, Droppable } from 'react-beautiful-dnd'
 
-import { CollectionTrackForUpload } from 'pages/upload-page/types'
-
 import { CollectionTrackField } from './CollectionTrackField'
-
 const messages = {
   trackList: 'Track List'
 }
 
+const makeTrackKey = (track: TrackForUpload | TrackForEdit, index: number) => {
+  if (isTrackForUpload(track)) {
+    return track.file.name ?? `${index}`
+  }
+  const suffix = 'metadata_time' in track ? `-${track.metadata_time}` : ''
+  return `${track.metadata.track_id}${suffix}`
+}
+
 export const CollectionTrackFieldArray = () => {
-  const [{ value: tracks }] = useField<CollectionTrackForUpload[]>('tracks')
+  const [{ value: tracks }] =
+    useField<(TrackForUpload | TrackForEdit)[]>('tracks')
 
   return (
     <FieldArray name='tracks'>
@@ -32,11 +43,10 @@ export const CollectionTrackFieldArray = () => {
                 aria-label={messages.trackList}
               >
                 {tracks.map((track, index) => {
-                  const id =
-                    track.metadata.track_id ?? `${track.file?.name}--${index}`
+                  const id = makeTrackKey(track, index)
 
                   return (
-                    <Draggable key={id} draggableId={String(id)} index={index}>
+                    <Draggable key={id} draggableId={id} index={index}>
                       {(provided) => (
                         <div
                           ref={provided.innerRef}

--- a/packages/web/src/pages/edit-collection-page/desktop/EditCollectionPage.tsx
+++ b/packages/web/src/pages/edit-collection-page/desktop/EditCollectionPage.tsx
@@ -26,7 +26,7 @@ import { track } from 'services/analytics'
 import { replace } from 'utils/navigation'
 import { useSelector } from 'utils/reducer'
 
-import { updatePlaylistContents } from '../utils'
+import { getEditablePlaylistContents, updatePlaylistContents } from '../utils'
 
 const { editPlaylist } = cacheCollectionsActions
 const { getCollection } = cacheCollectionsSelectors
@@ -65,7 +65,8 @@ export const EditCollectionPage = () => {
 
   const collection = status === Status.ERROR ? localCollection : apiCollection
 
-  const { playlist_id, tracks, description } = collection ?? {}
+  const { playlist_id, tracks, description, playlist_contents } =
+    collection ?? {}
 
   const artworkUrl = useCollectionCoverArt({
     collectionId: playlist_id,
@@ -76,7 +77,13 @@ export const EditCollectionPage = () => {
     ...collection,
     description: description ?? undefined,
     artwork: { url: artworkUrl! },
-    tracks: tracks?.map((track) => ({ metadata: track })) ?? [],
+    tracks:
+      tracks && playlist_contents
+        ? getEditablePlaylistContents({
+            playlist_contents,
+            tracks
+          })
+        : [],
     isUpload: false
   } as CollectionValues
 

--- a/packages/web/src/pages/edit-collection-page/utils.ts
+++ b/packages/web/src/pages/edit-collection-page/utils.ts
@@ -1,27 +1,55 @@
 import { Collection } from '@audius/common/models'
-import { CollectionValues } from '@audius/common/schemas'
+import { TrackForEdit, TrackForUpload } from '@audius/common/store'
 import { Maybe } from '@audius/common/utils'
+import { keyBy } from 'lodash'
 
 import { removeNullable } from 'utils/typeUtils'
 
+const playlistTrackLookupKey = (trackId: number, metadata_time?: number) =>
+  `${trackId}-${metadata_time}`
+
 // The edit collection form receives a tracks array, but we need to convert that to playlist_contents
+// We use metadata_time to map back to the original playlist_contents so we can differentiate
+// duplicates of the same track_id
 export const updatePlaylistContents = (
-  tracks: CollectionValues['tracks'],
+  tracks: (TrackForEdit | TrackForUpload)[],
   playlist_contents: Maybe<Collection['playlist_contents']>
 ) => {
   if (!playlist_contents) return undefined
 
   const originalTracksMap = new Map(
-    playlist_contents?.track_ids.map((item) => [item.track, item])
+    playlist_contents?.track_ids.map((item) => [
+      playlistTrackLookupKey(item.track, item.metadata_time ?? item.time),
+      item
+    ])
   )
 
   const updatedPlaylistIds = tracks
     .map(
       (track) =>
         track.metadata.track_id &&
-        originalTracksMap.get(track.metadata.track_id)
+        originalTracksMap.get(
+          playlistTrackLookupKey(
+            track.metadata.track_id,
+            'metadata_time' in track ? track.metadata_time : undefined
+          )
+        )
     )
     .filter(removeNullable)
 
   return { track_ids: updatedPlaylistIds }
+}
+
+/** Map playlist_contents to editable entries that include metadata_time so they
+ * can be mapped back to playlist_contents when the form is submitted.
+ */
+export const getEditablePlaylistContents = ({
+  playlist_contents,
+  tracks
+}: Pick<Collection, 'playlist_contents' | 'tracks'>): TrackForEdit[] => {
+  const tracksById = keyBy(tracks, 'track_id')
+  return playlist_contents.track_ids.map((playlistTrack) => ({
+    metadata: tracksById[playlistTrack.track],
+    metadata_time: playlistTrack.metadata_time ?? playlistTrack.time
+  }))
 }

--- a/packages/web/src/pages/edit-page/EditTrackPage.tsx
+++ b/packages/web/src/pages/edit-page/EditTrackPage.tsx
@@ -65,6 +65,12 @@ export const EditTrackPage = (props: EditPageProps) => {
 
   const onSubmit = (formValues: TrackEditFormValues) => {
     const metadata = { ...formValues.trackMetadatas[0] }
+    const trackId = metadata.track_id
+    if (!trackId) {
+      console.error('Unexpected missing trackId')
+      return
+    }
+
     const replaceFile =
       'file' in formValues.tracks[0] ? formValues.tracks[0].file : null
 
@@ -81,7 +87,7 @@ export const EditTrackPage = (props: EditPageProps) => {
         confirmCallback: () => {
           dispatch(
             updateTrackAudio({
-              trackId: metadata.track_id,
+              trackId,
               file: replaceFile,
               metadata
             })
@@ -90,7 +96,7 @@ export const EditTrackPage = (props: EditPageProps) => {
         }
       })
     } else {
-      dispatch(editTrack(metadata.track_id, metadata))
+      dispatch(editTrack(trackId, metadata))
       dispatch(push(metadata.permalink))
     }
   }

--- a/packages/web/src/pages/upload-page/types.ts
+++ b/packages/web/src/pages/upload-page/types.ts
@@ -1,5 +1,9 @@
-import { TrackForUpload } from '@audius/common/store'
+import { TrackForEdit, TrackForUpload } from '@audius/common/store'
 
 export type CollectionTrackForUpload = TrackForUpload & {
+  override: boolean
+}
+
+export type CollectionTrackForEdit = TrackForEdit & {
   override: boolean
 }

--- a/packages/web/src/pages/upload-page/types.ts
+++ b/packages/web/src/pages/upload-page/types.ts
@@ -1,9 +1,0 @@
-import { TrackForEdit, TrackForUpload } from '@audius/common/store'
-
-export type CollectionTrackForUpload = TrackForUpload & {
-  override: boolean
-}
-
-export type CollectionTrackForEdit = TrackForEdit & {
-  override: boolean
-}


### PR DESCRIPTION
### Description
Bit of a gnarly one. Two parts to this:
1. We weren't accounting for duplicates of trackId in our flow/components for editing a collection, so we would just use `trackId` as a key and then map the modified `tracks` array back to `playlist_contents` using just track ids.
2. The `TrackForUpload` type that we use in these components and the upload code in general incorrectly lists `track_id` as required when it's optional. During upload, `track_id` won't exist until the saga runs. And at that point, it will either be pre-populated when uploading multiple tracks/stems, or generated by SDK during the track upload itself.

To fix the duplicate key issue, I updated the types we pass into `EditCollectionForm` and `CollectionTrackFieldArray` to include `metadata_time` if we're editing. That's used as part of the key generation for the draggables in the form. If we're uploading, we will fall back to file name / index as it was already doing. On submission, the `updatePlaylistContents` function is now aware of the possible existence of `metadata_time` and will use that to look up the correct track in the original playlist_contents.
NOTE: Similar to other code that deals with metadata_time, we need to fall back to `time` for legacy playlists where `playlist_contents` items don't include the metadata timestamp.

For the typing issues, I updated `TrackForUpload` to reflect the optionality and then went through to fix the various places where we use that type and aren't null-checking the track id. This mostly ended up being analytics events that need to have the field also marked as optional, and a few null checks that legitimately should throw because they would have crashed at that point anyway.

Also of note are the adjusted types in the upload flow (`(TrackForEdit | TrackForUpload)[]`) and the type guard functions. The type we were previously using didn't actually match what was being passed down to the form.

### How Has This Been Tested?
* Edited an existing collection with multiple copies of the same track and verified I could save it successfully and have the changes stick after refresh.
* Uploaded a new playlist and verified that I can reorder items in the form and successfully submit.
