### PR TITLE
Stop opening Phantom on app load and fix unauthed page views

### DIFF
--- a/packages/web/src/pages/sign-in-page/SignInWithMetaMaskButton.tsx
+++ b/packages/web/src/pages/sign-in-page/SignInWithMetaMaskButton.tsx
@@ -67,7 +67,7 @@ export const SignInWithMetaMaskButton = (props: ButtonProps) => {
       await switchChainAsync({ chainId: audiusChain.id })
 
       // Reinit SDK with the connected wallet
-      const sdk = await initSdk()
+      const sdk = await initSdk({ useExternalWallet: true })
 
       // Check that the user exists.
       // If they don't, disconnect and try to get them to sign up.

--- a/packages/web/src/pages/sign-in-page/SignInWithMetaMaskButton.tsx
+++ b/packages/web/src/pages/sign-in-page/SignInWithMetaMaskButton.tsx
@@ -67,7 +67,7 @@ export const SignInWithMetaMaskButton = (props: ButtonProps) => {
       await switchChainAsync({ chainId: audiusChain.id })
 
       // Reinit SDK with the connected wallet
-      const sdk = await initSdk({ useExternalWallet: true })
+      const sdk = await initSdk({ ignoreCachedUserWallet: true })
 
       // Check that the user exists.
       // If they don't, disconnect and try to get them to sign up.

--- a/packages/web/src/pages/sign-in-page/SignInWithMetaMaskButton.tsx
+++ b/packages/web/src/pages/sign-in-page/SignInWithMetaMaskButton.tsx
@@ -81,7 +81,9 @@ export const SignInWithMetaMaskButton = (props: ButtonProps) => {
       }
 
       // Otherwise, refetch the user account in the saga.
-      dispatch(accountActions.fetchAccount)
+      dispatch(
+        accountActions.fetchAccount({ shouldMarkAccountAsLoading: true })
+      )
       navigate(route ?? FEED_PAGE)
     } catch (e) {
       setStatus(Status.ERROR)

--- a/packages/web/src/pages/sign-up-page/components/ExternalWalletSignUpModal.tsx
+++ b/packages/web/src/pages/sign-up-page/components/ExternalWalletSignUpModal.tsx
@@ -102,7 +102,7 @@ export const ExternalWalletSignUpModal = () => {
       unsubscribe()
 
       // Reinit SDK with the connected wallet
-      const sdk = await initSdk()
+      const sdk = await initSdk({ useExternalWallet: true })
 
       // Check that the user doesn't already exist.
       // If they do, log them in.

--- a/packages/web/src/pages/sign-up-page/components/ExternalWalletSignUpModal.tsx
+++ b/packages/web/src/pages/sign-up-page/components/ExternalWalletSignUpModal.tsx
@@ -108,7 +108,9 @@ export const ExternalWalletSignUpModal = () => {
       // If they do, log them in.
       const userExists = await doesUserExist(sdk, wallet)
       if (userExists) {
-        dispatch(accountActions.fetchAccount)
+        dispatch(
+          accountActions.fetchAccount({ shouldMarkAccountAsLoading: true })
+        )
         navigate(route ?? FEED_PAGE)
         onClose()
         return

--- a/packages/web/src/pages/sign-up-page/components/ExternalWalletSignUpModal.tsx
+++ b/packages/web/src/pages/sign-up-page/components/ExternalWalletSignUpModal.tsx
@@ -102,7 +102,7 @@ export const ExternalWalletSignUpModal = () => {
       unsubscribe()
 
       // Reinit SDK with the connected wallet
-      const sdk = await initSdk({ useExternalWallet: true })
+      const sdk = await initSdk({ ignoreCachedUserWallet: true })
 
       // Check that the user doesn't already exist.
       // If they do, log them in.

--- a/packages/web/src/services/audius-sdk/audiusSdk.ts
+++ b/packages/web/src/services/audius-sdk/audiusSdk.ts
@@ -17,7 +17,7 @@ declare global {
 let inProgress = false
 const SDK_LOADED_EVENT_NAME = 'AUDIUS_SDK_LOADED'
 
-export const initSdk = async (opts?: { useExternalWallet?: boolean }) => {
+export const initSdk = async (opts?: { ignoreCachedUserWallet?: boolean }) => {
   inProgress = true
 
   // For now, the only solana relay we want to use is on DN 1, so hardcode
@@ -45,9 +45,7 @@ export const initSdk = async (opts?: { useExternalWallet?: boolean }) => {
 
   // Set up a relay to identity for Ethereum RPC requests so that identity can
   // pay for gas fees on approved transactions.
-  const audiusWalletClient = await getAudiusWalletClient({
-    ensureUserExists: !opts?.useExternalWallet
-  })
+  const audiusWalletClient = await getAudiusWalletClient(opts)
   const ethWalletClient = createWalletClient({
     account: '0x0000000000000000000000000000000000000000', // dummy replaced by relay DO NOT REMOVE
     chain: mainnet,

--- a/packages/web/src/services/audius-sdk/audiusSdk.ts
+++ b/packages/web/src/services/audius-sdk/audiusSdk.ts
@@ -17,7 +17,7 @@ declare global {
 let inProgress = false
 const SDK_LOADED_EVENT_NAME = 'AUDIUS_SDK_LOADED'
 
-export const initSdk = async () => {
+export const initSdk = async (opts?: { useExternalWallet?: boolean }) => {
   inProgress = true
 
   // For now, the only solana relay we want to use is on DN 1, so hardcode
@@ -45,7 +45,9 @@ export const initSdk = async () => {
 
   // Set up a relay to identity for Ethereum RPC requests so that identity can
   // pay for gas fees on approved transactions.
-  const audiusWalletClient = await getAudiusWalletClient()
+  const audiusWalletClient = await getAudiusWalletClient({
+    ensureUserExists: !opts?.useExternalWallet
+  })
   const ethWalletClient = createWalletClient({
     account: '0x0000000000000000000000000000000000000000', // dummy replaced by relay DO NOT REMOVE
     chain: mainnet,

--- a/packages/web/src/services/audius-sdk/auth.ts
+++ b/packages/web/src/services/audius-sdk/auth.ts
@@ -15,9 +15,9 @@ import { localStorage } from '../local-storage'
 import { audiusChain, wagmiConfig } from './wagmi'
 
 export const getAudiusWalletClient = async (opts?: {
-  ensureUserExists?: boolean
+  ignoreCachedUserWallet?: boolean
 }): Promise<AudiusWalletClient> => {
-  const { ensureUserExists = true } = opts ?? {}
+  const { ignoreCachedUserWallet = false } = opts ?? {}
   if (
     wagmiConfig.state.status === 'reconnecting' ||
     wagmiConfig.state.status === 'connecting'
@@ -44,7 +44,7 @@ export const getAudiusWalletClient = async (opts?: {
     const account = getAccount(wagmiConfig)
     const user = await localStorage.getAudiusAccountUser()
     if (
-      ensureUserExists &&
+      !ignoreCachedUserWallet &&
       user?.wallet?.toLowerCase() !== account.address?.toLowerCase()
     ) {
       console.warn(

--- a/packages/web/src/services/audius-sdk/auth.ts
+++ b/packages/web/src/services/audius-sdk/auth.ts
@@ -31,7 +31,13 @@ export const getAudiusWalletClient = async (): Promise<AudiusWalletClient> => {
     })
     unsubscribe?.()
   }
-  if (wagmiConfig.state.status === 'connected') {
+
+  if (
+    wagmiConfig.state.status === 'connected' &&
+    // Only support metaMask for now
+    wagmiConfig.state.connections.get(wagmiConfig.state.current!)?.connector
+      .type === 'metaMask'
+  ) {
     console.info('[audiusSdk] Initializing SDK with external wallet...')
     const client = await getWalletClient(wagmiConfig, {
       chainId: audiusChain.id

--- a/packages/web/src/services/audius-sdk/auth.ts
+++ b/packages/web/src/services/audius-sdk/auth.ts
@@ -6,7 +6,7 @@ import {
   createHedgehogWalletClient,
   type AudiusWalletClient
 } from '@audius/sdk'
-import { getWalletClient } from '@wagmi/core'
+import { getAccount, getWalletClient } from '@wagmi/core'
 import { type WalletClient } from 'viem'
 
 import { env } from '../env'
@@ -14,7 +14,10 @@ import { localStorage } from '../local-storage'
 
 import { audiusChain, wagmiConfig } from './wagmi'
 
-export const getAudiusWalletClient = async (): Promise<AudiusWalletClient> => {
+export const getAudiusWalletClient = async (opts?: {
+  ensureUserExists?: boolean
+}): Promise<AudiusWalletClient> => {
+  const { ensureUserExists = true } = opts ?? {}
   if (
     wagmiConfig.state.status === 'reconnecting' ||
     wagmiConfig.state.status === 'connecting'
@@ -38,11 +41,22 @@ export const getAudiusWalletClient = async (): Promise<AudiusWalletClient> => {
     wagmiConfig.state.connections.get(wagmiConfig.state.current!)?.connector
       .type === 'metaMask'
   ) {
-    console.info('[audiusSdk] Initializing SDK with external wallet...')
-    const client = await getWalletClient(wagmiConfig, {
-      chainId: audiusChain.id
-    })
-    return client satisfies WalletClient as unknown as AudiusWalletClient
+    const account = getAccount(wagmiConfig)
+    const user = await localStorage.getAudiusAccountUser()
+    if (
+      ensureUserExists &&
+      user?.wallet?.toLowerCase() !== account.address?.toLowerCase()
+    ) {
+      console.warn(
+        '[audiusSdk] External wallet connected but cached user does not match connected external wallet. Falling back to Hedgehog...'
+      )
+    } else {
+      console.info('[audiusSdk] Initializing SDK with external wallet...')
+      const client = await getWalletClient(wagmiConfig, {
+        chainId: audiusChain.id
+      })
+      return client satisfies WalletClient as unknown as AudiusWalletClient
+    }
   }
 
   return createHedgehogWalletClient(authService.hedgehogInstance)


### PR DESCRIPTION
- Phantom gets injected into the Wagmi list of providers, and if the user has previously connected their wallet either for Pay with Anything or their balances, it then tricks the SDK initialization code into using an external wallet instead of Hedgehog.
- Accidentally replaced the getWallet call with the wrong code snippet which caused `fetchLocalAccountAsync` to throw.
- Add payload to the `fetchAccountAsync` call that was added in a prev pr that was merged first
- Only connect MetaMask as the SDK AudiusWalletClient if the connected wallet matches the cached Audius user in local storage to prevent previous wallet connects for balances etc from signing out the user