### PR TITLE
suppress TURBO_TEAM and TURBO_TOKEN warning if not set

### DIFF
--- a/dev-tools/compose/docker-compose.identity.prod.yml
+++ b/dev-tools/compose/docker-compose.identity.prod.yml
@@ -10,7 +10,7 @@ services:
     image: redis:7.0
     command: redis-server
     healthcheck:
-      test: ['CMD', 'redis-cli', 'PING']
+      test: [ 'CMD', 'redis-cli', 'PING' ]
       interval: 10s
       timeout: 5s
     deploy:
@@ -24,8 +24,8 @@ services:
       dockerfile: ${PROJECT_ROOT}/packages/identity-service/Dockerfile.prod
       args:
         git_sha: '${GIT_COMMIT}'
-        TURBO_TEAM: '${TURBO_TEAM}'
-        TURBO_TOKEN: '${TURBO_TOKEN}'
+        TURBO_TEAM: '${TURBO_TEAM:-}'
+        TURBO_TOKEN: '${TURBO_TOKEN:-}'
     ports:
       - '7000:7000'
       - '9229:9229'

--- a/dev-tools/compose/docker-compose.pedalboard.prod.yml
+++ b/dev-tools/compose/docker-compose.pedalboard.prod.yml
@@ -24,8 +24,8 @@ services:
       dockerfile: ${PROJECT_ROOT}/packages/discovery-provider/plugins/pedalboard/docker/Dockerfile.prod
       args:
         app_name: trending-challenge-rewards
-        TURBO_TEAM: '${TURBO_TEAM}'
-        TURBO_TOKEN: '${TURBO_TOKEN}'
+        TURBO_TEAM: '${TURBO_TEAM:-}'
+        TURBO_TOKEN: '${TURBO_TOKEN:-}'
     restart: always
     profiles:
       - pedalboard
@@ -36,8 +36,8 @@ services:
       dockerfile: ${PROJECT_ROOT}/packages/discovery-provider/plugins/pedalboard/docker/Dockerfile.prod
       args:
         app_name: staking
-        TURBO_TEAM: '${TURBO_TEAM}'
-        TURBO_TOKEN: '${TURBO_TOKEN}'
+        TURBO_TEAM: '${TURBO_TEAM:-}'
+        TURBO_TOKEN: '${TURBO_TOKEN:-}'
     restart: always
     profiles:
       - pedalboard
@@ -48,8 +48,8 @@ services:
       dockerfile: ${PROJECT_ROOT}/packages/discovery-provider/plugins/pedalboard/docker/Dockerfile.prod
       args:
         app_name: relay
-        TURBO_TEAM: '${TURBO_TEAM}'
-        TURBO_TOKEN: '${TURBO_TOKEN}'
+        TURBO_TEAM: '${TURBO_TEAM:-}'
+        TURBO_TOKEN: '${TURBO_TOKEN:-}'
     env_file: .env
     restart: always
     deploy:
@@ -111,8 +111,8 @@ services:
       dockerfile: ${PROJECT_ROOT}/packages/discovery-provider/plugins/pedalboard/docker/Dockerfile.prod
       args:
         app_name: sla-auditor
-        TURBO_TEAM: '${TURBO_TEAM}'
-        TURBO_TOKEN: '${TURBO_TOKEN}'
+        TURBO_TEAM: '${TURBO_TEAM:-}'
+        TURBO_TOKEN: '${TURBO_TOKEN:-}'
     restart: always
     profiles:
       - pedalboard
@@ -124,8 +124,8 @@ services:
       dockerfile: ${PROJECT_ROOT}/packages/discovery-provider/plugins/pedalboard/docker/Dockerfile.prod
       args:
         app_name: crm
-        TURBO_TEAM: '${TURBO_TEAM}'
-        TURBO_TOKEN: '${TURBO_TOKEN}'
+        TURBO_TEAM: '${TURBO_TEAM:-}'
+        TURBO_TOKEN: '${TURBO_TOKEN:-}'
     restart: always
     profiles:
       - pedalboard
@@ -137,8 +137,8 @@ services:
       dockerfile: ${PROJECT_ROOT}/packages/discovery-provider/plugins/pedalboard/docker/Dockerfile.prod
       args:
         app_name: mri
-        TURBO_TEAM: '${TURBO_TEAM}'
-        TURBO_TOKEN: '${TURBO_TOKEN}'
+        TURBO_TEAM: '${TURBO_TEAM:-}'
+        TURBO_TOKEN: '${TURBO_TOKEN:-}'
     restart: always
     profiles:
       - pedalboard

--- a/dev-tools/compose/docker-compose.test.yml
+++ b/dev-tools/compose/docker-compose.test.yml
@@ -194,8 +194,8 @@ services:
       context: ${PROJECT_ROOT}
       dockerfile: ${PROJECT_ROOT}/packages/libs/Dockerfile
       args:
-        TURBO_TEAM: '${TURBO_TEAM}'
-        TURBO_TOKEN: '${TURBO_TOKEN}'
+        TURBO_TEAM: '${TURBO_TEAM:-}'
+        TURBO_TOKEN: '${TURBO_TOKEN:-}'
     # TODO: also run integration test current blocker is that integration tests
     # use config.json which was removed with the addition of audius-compose
     entrypoint: sh -c '[ "$$1" = "test" ] || sleep inf && (shift; npm run test:unit)' -


### PR DESCRIPTION
### Description
there used to be a warning if these values were unset from docker, setting an empty default suppresses this warning and keeps audius-compose logs clean

### How Has This Been Tested?
`audius-compose up` or `audius-compose down`
