### PR TITLE
[C-5691] Fix deep linking on cold start

### DIFF
--- a/packages/mobile/src/screens/root-screen/RootScreen.tsx
+++ b/packages/mobile/src/screens/root-screen/RootScreen.tsx
@@ -117,8 +117,12 @@ export const RootScreen = () => {
       }
       // Route to the original deep link after user signs up
       if (routeOnCompletion && routeOnCompletion !== FEED_PAGE) {
-        linkTo(routeOnCompletion)
+        // linkTo(routeOnCompletion)
       }
+    }
+    if (showHomeStack && routeOnCompletion && routeOnCompletion !== FEED_PAGE) {
+      // Route to the original deep link after user signs up
+      linkTo(routeOnCompletion)
     }
   }, [
     openWelcomeDrawer,

--- a/packages/mobile/src/screens/root-screen/RootScreen.tsx
+++ b/packages/mobile/src/screens/root-screen/RootScreen.tsx
@@ -115,10 +115,6 @@ export const RootScreen = () => {
       if (isAndroid && navigate) {
         navigate('HomeStack')
       }
-      // Route to the original deep link after user signs up
-      if (routeOnCompletion && routeOnCompletion !== FEED_PAGE) {
-        // linkTo(routeOnCompletion)
-      }
     }
     if (showHomeStack && routeOnCompletion && routeOnCompletion !== FEED_PAGE) {
       // Route to the original deep link after user signs up


### PR DESCRIPTION
### Description

Fixes deep linking cold starts by:
1. Waiting for the account to attempt to load before interpreting the deep link. This in necessary to know if we should take a deep link and reformat it for signed out user or signed in user. For signed in user we proceed with linking them to the content. If signed out we need to add the link to the "routeOnCompletion" parameter in sign-in page so the app properly links them to the content after signing-in/signing up. That all occurs here: https://github.com/AudiusProject/audius-protocol/blob/6ba75948c2b3319236e66148dd8a0ceba802b2c0/packages/mobile/src/components/navigation-container/NavigationContainer.tsx#L379 and was failing because "hasAccount" was always false initially.
2. Fixes issue where signing in does not link user to content (only sign-up was working)