### PR TITLE
Fix mobile follow button text padding

### DIFF
--- a/packages/harmony/src/components/text/constants.ts
+++ b/packages/harmony/src/components/text/constants.ts
@@ -44,7 +44,7 @@ export const variantStylesMap = {
   },
   label: {
     fontSize: { xs: '2xs', s: 'xs', m: 's', l: 'm', xl: 'xl' },
-    lineHeight: { xs: 'xs', s: 'xs', m: 's', l: 'm', xl: 'l' },
+    lineHeight: { xs: 'xs', s: 's', m: 's', l: 'm', xl: 'l' },
     fontWeight: { default: 'bold', strong: 'heavy' },
     css: { textTransform: 'uppercase' as const, letterSpacing: 0.5 }
   },

--- a/packages/harmony/src/components/text/constants.ts
+++ b/packages/harmony/src/components/text/constants.ts
@@ -44,7 +44,7 @@ export const variantStylesMap = {
   },
   label: {
     fontSize: { xs: '2xs', s: 'xs', m: 's', l: 'm', xl: 'xl' },
-    lineHeight: { xs: 'xs', s: 's', m: 's', l: 'm', xl: 'l' },
+    lineHeight: { xs: 'xs', s: 'xs', m: 's', l: 's', xl: 'l' },
     fontWeight: { default: 'bold', strong: 'heavy' },
     css: { textTransform: 'uppercase' as const, letterSpacing: 0.5 }
   },

--- a/packages/mobile/src/harmony-native/components/Button/FollowButton/FollowButton.tsx
+++ b/packages/mobile/src/harmony-native/components/Button/FollowButton/FollowButton.tsx
@@ -79,6 +79,7 @@ export const FollowButton = (props: FollowButtonProps) => {
         justifyContent='center'
         gap='xs'
         ph='l'
+        pv='s'
         border='default'
         style={css({
           opacity: disabled ? 0.45 : 1,

--- a/packages/mobile/src/harmony-native/components/Button/FollowButton/FollowButton.tsx
+++ b/packages/mobile/src/harmony-native/components/Button/FollowButton/FollowButton.tsx
@@ -78,7 +78,6 @@ export const FollowButton = (props: FollowButtonProps) => {
         alignItems='center'
         justifyContent='center'
         gap='xs'
-        pv='s'
         ph='l'
         border='default'
         style={css({

--- a/packages/mobile/src/harmony-native/components/Text/Text.tsx
+++ b/packages/mobile/src/harmony-native/components/Text/Text.tsx
@@ -73,6 +73,8 @@ export const Text = forwardRef<TextBase, TextProps>((props, ref) => {
     ...(fontWeight === 'demiBold' && Platform.OS === 'ios'
       ? { marginTop: 2 }
       : {}),
+    // Fixes bold text misalignment on iOS
+    ...(fontWeight === 'bold' && Platform.OS === 'ios' ? { marginTop: 1 } : {}),
     flexShrink
   })
 


### PR DESCRIPTION
### Description
Fix padding and lineHeight for harmony-native `FollowButton`

### How Has This Been Tested?

ios large
![Simulator Screenshot - iPhone 16 Pro - 2025-01-23 at 13 03 15](https://github.com/user-attachments/assets/785c9db8-6b30-4ebc-b4a3-0c9b5ded4950)
ios small
![Simulator Screenshot - iPhone 16 Pro - 2025-01-23 at 13 03 06](https://github.com/user-attachments/assets/6f20e11a-c3c7-48b5-bef3-ee1841593b6f)

android large
![473225521_1141839334009429_3984881631148654062_n](https://github.com/user-attachments/assets/e268e68b-e1c9-4705-90f9-9529a42eb4ac)
android small
![474121014_2015843375507583_7624133636665948207_n](https://github.com/user-attachments/assets/a283935a-4003-4322-9ba5-1ccf42ce0e67)
