### PR TITLE
[PAY-3804] Fix scrollbar showing on first open of playlists

### DIFF
--- a/packages/harmony/src/components/scrollbar/Scrollbar.module.css
+++ b/packages/harmony/src/components/scrollbar/Scrollbar.module.css
@@ -1,10 +1,6 @@
 .scrollbar {
   height: 100%;
   min-height: 0;
-  > div {
-    height: 100%;
-    min-height: 0;
-  }
 }
 
 .scrollbar :global(.ps__thumb-y) {

--- a/packages/harmony/src/components/scrollbar/Scrollbar.module.css
+++ b/packages/harmony/src/components/scrollbar/Scrollbar.module.css
@@ -1,6 +1,11 @@
 .scrollbar {
   height: 100%;
   min-height: 0;
+  /* Add container with constrained height */
+  > div {
+    height: 100%;
+    min-height: 0;
+  }
 }
 
 .scrollbar :global(.ps__thumb-y) {
@@ -11,9 +16,7 @@
 .scrollbar :global(.ps__rail-y) {
   margin-top: var(--harmony-unit-1);
   margin-bottom: var(--harmony-unit-1);
-  transition:
-    background-color 0.2s ease-in-out,
-    opacity 0.2s ease-in-out;
+  transition: background-color 0.2s ease-in-out, opacity 0.2s ease-in-out;
   background-color: transparent !important;
 }
 

--- a/packages/harmony/src/components/scrollbar/Scrollbar.module.css
+++ b/packages/harmony/src/components/scrollbar/Scrollbar.module.css
@@ -1,7 +1,6 @@
 .scrollbar {
   height: 100%;
   min-height: 0;
-  /* Add container with constrained height */
   > div {
     height: 100%;
     min-height: 0;

--- a/packages/harmony/src/components/scrollbar/Scrollbar.tsx
+++ b/packages/harmony/src/components/scrollbar/Scrollbar.tsx
@@ -67,7 +67,13 @@ export const Scrollbar = forwardRef(
       }
     }, [isHidden, hideScrollbar])
 
-    const content = forward ? children : <div ref={ref}>{children}</div>
+    const content = forward ? (
+      children
+    ) : (
+      <div ref={ref} className={styles.scrollbar}>
+        {children}
+      </div>
+    )
 
     return (
       <PerfectScrollbar


### PR DESCRIPTION
### Description

This PR addresses an issue where the scrollbar appears unexpectedly when opening the playlists tab due to container size changes. The fix adds a nested div container with constrained height properties to ensure the scrollbar maintains a consistent size, preventing layout shifts when content loads.

### Changes
- Added a nested div container inside `.scrollbar` with `height: 100%` and `min-height: 0` to properly constrain the scrollable content
- Maintained existing height inheritance while preventing intrinsic sizing issues in flex containers

### How Has This Been Tested?

`npm run web:stage`

- Open the playlist nav item and ensure that the scrollbar does not immediately appear on the first load
  - you should try this with several items in your playlist, refresh before trying again 
