### PR TITLE
Fix web FollowButton icon colors

### DIFF
--- a/packages/harmony/src/components/button/FollowButton/FollowButton.tsx
+++ b/packages/harmony/src/components/button/FollowButton/FollowButton.tsx
@@ -113,9 +113,7 @@ export const FollowButton = forwardRef(
     const { color, cornerRadius, motion, shadows } = useTheme()
 
     const textColor =
-      checkedValue || isHovering || isPressing
-        ? color.static.white
-        : color.primary.primary
+      checkedValue || isHovering || isPressing ? 'white' : 'active'
 
     const borderRadius =
       variant === 'pill' ? cornerRadius['2xl'] : cornerRadius.s
@@ -137,31 +135,15 @@ export const FollowButton = forwardRef(
         background-color ${motion.hover},
         color ${motion.hover}
       `,
-      '::before': {
-        content: '""',
-        position: 'absolute',
-        top: 0,
-        left: 0,
-        right: 0,
-        bottom: 0,
-        backgroundColor: 'rgba(0, 0, 0, 0)',
-        borderRadius
-      },
       '&:hover': {
-        backgroundColor: color.primary.primary,
         borderWidth: 0,
-        boxShadow: shadows.mid,
-        '&::before': {
-          backgroundColor: 'rgba(255, 255, 255, 0.2)'
-        }
+        backgroundColor: color.primary.p300,
+        boxShadow: shadows.mid
       },
       '&:active': {
-        backgroundColor: color.primary.primary,
+        backgroundColor: color.primary.p500,
         borderWidth: 0,
-        boxShadow: 'none',
-        '&::before': {
-          backgroundColor: 'rgba(0, 0, 0, 0.2)'
-        }
+        boxShadow: 'none'
       }
     }
 
@@ -205,14 +187,13 @@ export const FollowButton = forwardRef(
         {...buttonProps}
         {...rootProps}
       >
-        {/* TODO: use theme icon colors (confirm w/design) */}
-        <Icon height={18} width={18} css={{ path: { fill: textColor } }} />
+        <Icon height={18} width={18} color={textColor} />
         <Text
           variant='label'
           tag='span'
           size={size === 'small' ? 's' : 'l'}
           strength='default'
-          css={{ color: textColor }}
+          color={textColor}
         >
           {text}
         </Text>


### PR DESCRIPTION
### Description
Remove unneeded `before` css now that we set the icons to actual semantic colors. Previously this `before` css was used to change the colors by adding a 0.2 transparent black overlay onto the button contents.

### How Has This Been Tested?


https://github.com/user-attachments/assets/760c8ac1-b972-4d99-9db7-ffee029ec331

