### PR TITLE
Fix broken colors on web USDCCard and PopupMenu

### DIFF
--- a/packages/harmony/src/components/popup-menu/PopupMenu.tsx
+++ b/packages/harmony/src/components/popup-menu/PopupMenu.tsx
@@ -81,17 +81,17 @@ export const PopupMenu = forwardRef<HTMLDivElement, PopupMenuProps>(
       color: color.text.default,
       cursor: 'pointer',
       '&:hover': {
-        color: color.text.staticStaticWhite,
+        color: color.text.staticWhite,
         background: color.secondary.s300,
         path: {
-          fill: color.text.staticStaticWhite
+          fill: color.text.staticWhite
         }
       },
       '&.destructive': {
         color: color.status.error,
         '&:hover': {
           background: color.status.error,
-          color: color.text.staticStaticWhite
+          color: color.text.staticWhite
         }
       }
     }

--- a/packages/web/src/pages/pay-and-earn-page/components/USDCCard.tsx
+++ b/packages/web/src/pages/pay-and-earn-page/components/USDCCard.tsx
@@ -91,7 +91,7 @@ export const USDCCard = () => {
             <Text
               variant='heading'
               size='xl'
-              color='inverse'
+              color='staticWhite'
               strength='strong'
               css={{ opacity: 0.8 }}
             >
@@ -105,7 +105,7 @@ export const USDCCard = () => {
             ) : (
               <Text
                 variant='heading'
-                color='inverse'
+                color='staticWhite'
                 strength='strong'
                 size='xl'
               >
@@ -115,7 +115,7 @@ export const USDCCard = () => {
           </Flex>
         </div>
         <div className={styles.usdcInfo}>
-          <Text color='inverse'>{messages.buyAndSell}</Text>
+          <Text color='staticWhite'>{messages.buyAndSell}</Text>
           <PlainButton
             onClick={handleLearnMore}
             iconLeft={IconQuestionCircle}


### PR DESCRIPTION
### Description
Fixing some wrong colors from https://github.com/AudiusProject/audius-protocol/pull/11094

### How Has This Been Tested?

<img width="345" alt="Screenshot 2025-01-23 at 3 17 07 PM" src="https://github.com/user-attachments/assets/ffdd53c4-2fa4-4b58-bb48-8278f054157d" />
<img width="856" alt="Screenshot 2025-01-23 at 3 15 50 PM" src="https://github.com/user-attachments/assets/e7ec0dc6-ad84-4feb-9dae-67c0d95a3510" />
