### PR TITLE
Fix text/icon white color

### DIFF
--- a/packages/harmony/src/foundations/color/semantic.ts
+++ b/packages/harmony/src/foundations/color/semantic.ts
@@ -15,6 +15,7 @@ const createSemanticTheme = (theme: Theme, primitives: PrimitiveColors) => ({
     // Legacy compatibility
     heading: primitives.special.gradient,
     active: primitives.primary.p300,
+    white: primitives.special.white,
     staticWhite: primitives.special.white,
     staticStaticWhite: primitives.static.staticWhite,
     warning: primitives.special.orange,
@@ -34,6 +35,7 @@ const createSemanticTheme = (theme: Theme, primitives: PrimitiveColors) => ({
     // Legacy compatibility
     heading: primitives.special.gradient,
     active: primitives.primary.p300,
+    white: primitives.special.white,
     staticWhite: primitives.special.white,
     staticStaticWhite: primitives.static.staticWhite,
     warning: primitives.special.orange,


### PR DESCRIPTION
### Description
Release-client branch-only fix for harmony `white` color

### How Has This Been Tested?

Ran web:stage, confirmed colors look good in FollowButton
<img width="277" alt="Screenshot 2025-01-23 at 4 44 47 PM" src="https://github.com/user-attachments/assets/21b64ff5-405b-40f4-89d1-09329b50fa1d" />
