### PR TITLE
Fix infinite confetti bug

### DIFF
--- a/packages/common/src/store/challenges/selectors/profile-progress.ts
+++ b/packages/common/src/store/challenges/selectors/profile-progress.ts
@@ -78,8 +78,10 @@ const validCoverPhotoSizes = [
 const isValidCoverPhoto = (input: User['cover_photo']) => {
   if (!input) return false
 
-  return Object.keys(input).some((size) =>
-    validCoverPhotoSizes.includes(size as WidthSizes)
+  return Object.keys(input).some(
+    (size) =>
+      validCoverPhotoSizes.includes(size as WidthSizes) &&
+      input[size] !== undefined
   )
 }
 


### PR DESCRIPTION
### Description

Confetti was triggering on every load for users who dont have a cover photo because it was treating them as "completed". 
Bug was because we were only checking for size keys & not values.

### How Has This Been Tested?

web:stage
