### PR TITLE
Change CI for PRs and re-enable Playwright for release

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -313,12 +313,12 @@ jobs:
       - run:
           name: Generate Slack Template
           command: bash .circleci/scripts/generate-slack-template.sh
-      - slack/notify:
-          channel: '$(eval echo \$SLACK_ID_FOR_GH_$(git log -1 --pretty=format:'%an'| tr ' ' '_' | tr '-' '_' | tr '[:upper:]' '[:lower:]'))'
-          template: PIPELINE_STATUS_TEMPLATE
       - run:
           name: Check status
           command: bash .circleci/scripts/check-workflow-statuses.sh
+      - slack/notify:
+          channel: 'SLACK_USER_ID'
+          template: PIPELINE_STATUS_TEMPLATE
 
 workflows:
   setup:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -317,7 +317,7 @@ jobs:
           name: Check status
           command: bash .circleci/scripts/check-workflow-statuses.sh
       - slack/notify:
-          channel: 'SLACK_USER_ID'
+          channel: SLACK_USER_ID
           template: PIPELINE_STATUS_TEMPLATE
 
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -317,7 +317,6 @@ jobs:
           name: Check status
           command: bash .circleci/scripts/check-workflow-statuses.sh
       - slack/notify:
-          channel: SLACK_USER_ID
           template: PIPELINE_STATUS_TEMPLATE
 
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -314,7 +314,7 @@ jobs:
           name: Generate Slack Template
           command: bash .circleci/scripts/generate-slack-template.sh
       - slack/notify:
-          channel: '<@U023NM7SQSW>'
+          channel: 'U023NM7SQSW'
           template: PIPELINE_STATUS_TEMPLATE
       - run:
           name: Check status

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -314,7 +314,7 @@ jobs:
           name: Generate Slack Template
           command: bash .circleci/scripts/generate-slack-template.sh
       - slack/notify:
-          channel: '$SLACK_USER_ID'
+          channel: '<@U023NM7SQSW>'
           template: PIPELINE_STATUS_TEMPLATE
       - run:
           name: Check status

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -314,7 +314,7 @@ jobs:
           name: Generate Slack Template
           command: bash .circleci/scripts/generate-slack-template.sh
       - slack/notify:
-          channel: 'U023NM7SQSW'
+          channel: '$(eval echo \$SLACK_ID_FOR_GH_$(git log -1 --pretty=format:'%an'| tr ' ' '_' | tr '-' '_' | tr '[:upper:]' '[:lower:]'))'
           template: PIPELINE_STATUS_TEMPLATE
       - run:
           name: Check status

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -300,6 +300,26 @@ jobs:
           channel: 'C06SP746DA7'
           template: PIPELINE_STATUS_TEMPLATE
 
+  aggregate-pipeline-status:
+    working_directory: ~/audius-protocol
+    resource_class: small
+    docker:
+      - image: cimg/base:2023.01
+    steps:
+      - checkout
+      - run:
+          name: Wait For Pipeline
+          command: bash .circleci/scripts/wait-for-pipeline.sh
+      - run:
+          name: Generate Slack Template
+          command: bash .circleci/scripts/generate-slack-template.sh
+      - slack/notify:
+          channel: '$SLACK_USER_ID'
+          template: PIPELINE_STATUS_TEMPLATE
+      - run:
+          name: Check status
+          command: bash .circleci/scripts/check-workflow-statuses.sh
+
 workflows:
   setup:
     when:
@@ -451,6 +471,17 @@ workflows:
           filters:
             branches:
               only: /^main$/
+
+      - aggregate-pipeline-status:
+          context:
+            - slack-secrets
+          requires:
+            - trigger-relevant-workflows
+          filters:
+            branches:
+              ignore:
+                - main
+                - /^release.*$/
 
   release-create-branch:
     when:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -335,7 +335,6 @@ workflows:
             .circleci/.* run-embed-workflow true
             package-lock.json run-sdk-workflow true
             .* run-release-workflow false
-            .* run-integration-workflow true
             packages/discovery-provider/.* run-discovery-workflow true
             packages/web/.* run-web-workflow true
             packages/mobile/.* run-mobile-workflow true

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -321,7 +321,6 @@ workflows:
           mapping: |
             comms/.* run-discovery-workflow true
             packages/identity-service/.* run-identity-workflow true
-            packages/identity-service/.* run-integration-workflow true
             eth-contracts/.* run-eth-contracts-workflow true
             contracts/.* run-contracts-workflow true
             .circleci/.* run-discovery-workflow true
@@ -371,7 +370,6 @@ workflows:
           mapping: |
             comms/.* run-discovery-workflow true
             packages/identity-service/.* run-identity-workflow true
-            packages/identity-service/.* run-integration-workflow true
             eth-contracts/.* run-eth-contracts-workflow true
             contracts/.* run-contracts-workflow true
             .circleci/.* run-discovery-workflow true
@@ -385,7 +383,6 @@ workflows:
             .circleci/.* run-embed-workflow true
             package-lock.json run-sdk-workflow true
             .* run-release-workflow false
-            .* run-integration-workflow true
             packages/discovery-provider/.* run-discovery-workflow true
             packages/web/.* run-web-workflow true
             packages/mobile/.* run-mobile-workflow true

--- a/.circleci/scripts/check-workflow-statuses.sh
+++ b/.circleci/scripts/check-workflow-statuses.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+echo "Fetching pipeline workflows..."
+curl -s --url "https://circleci.com/api/v2/pipeline/${CIRCLE_PIPELINE_ID}/workflow" \
+    -H "Circle-Token: ${CIRCLE_TOKEN}" \
+    > /tmp/workflows.json
+# Get workflow and job statuses list
+echo "Generating Workflow Statuses..."
+for workflow in $(jq -r -c '.items[] | select(.id != "'$CIRCLE_WORKFLOW_ID'")' /tmp/workflows.json)
+do
+  workflow_id=$(echo $workflow | jq -r '.id')
+  workflow_filename="/tmp/workflow-${workflow_id}.json"
+  curl -s 2>/dev/null --url $(echo $workflow | jq -r '"https://circleci.com/api/v2/workflow/\(.id)/job"') -H "Circle-Token: ${CIRCLE_TOKEN}" -o $workflow_filename
+  workflow_url=$(echo $workflow | jq -r '"'$PIPELINE_URL'/workflows/\(.id)"')
+  if $(jq -r '"\(if .status == "failed" then 1 else 0 end\)"') then
+    echo "Failed workflow: $workflow_id"
+    return 1
+  fi
+done
+return 0

--- a/.circleci/scripts/check-workflow-statuses.sh
+++ b/.circleci/scripts/check-workflow-statuses.sh
@@ -8,13 +8,11 @@ curl -s --url "https://circleci.com/api/v2/pipeline/${CIRCLE_PIPELINE_ID}/workfl
 echo "Generating Workflow Statuses..."
 for workflow in $(jq -r -c '.items[] | select(.id != "'$CIRCLE_WORKFLOW_ID'")' /tmp/workflows.json)
 do
-  workflow_id=$(echo $workflow | jq -r '.id')
-  workflow_filename="/tmp/workflow-${workflow_id}.json"
-  curl -s 2>/dev/null --url $(echo $workflow | jq -r '"https://circleci.com/api/v2/workflow/\(.id)/job"') -H "Circle-Token: ${CIRCLE_TOKEN}" -o $workflow_filename
-  workflow_url=$(echo $workflow | jq -r '"'$PIPELINE_URL'/workflows/\(.id)"')
-  if $(jq -r '"\(if .status == "failed" then 1 else 0 end\)"') then
-    echo "Failed workflow: $workflow_id"
-    return 1
+  workflow_name=$(echo $workflow | jq -r '.name')
+  if [[ $(echo $workflow | jq -r 'if .status == "failed" then 1 else 0 end') == "1" ]]
+  then
+    echo "Failed workflow: $workflow_name"
+    exit 1
   fi
 done
-return 0
+exit 0

--- a/.circleci/scripts/check-workflow-statuses.sh
+++ b/.circleci/scripts/check-workflow-statuses.sh
@@ -4,7 +4,6 @@ echo "Fetching pipeline workflows..."
 curl -s --url "https://circleci.com/api/v2/pipeline/${CIRCLE_PIPELINE_ID}/workflow" \
     -H "Circle-Token: ${CIRCLE_TOKEN}" \
     > /tmp/workflows.json
-echo "Generating Workflow Statuses..."
 
 for workflow in $(jq -r -c '.items[] | select(.id != "'$CIRCLE_WORKFLOW_ID'")' /tmp/workflows.json)
 do

--- a/.circleci/scripts/check-workflow-statuses.sh
+++ b/.circleci/scripts/check-workflow-statuses.sh
@@ -4,8 +4,8 @@ echo "Fetching pipeline workflows..."
 curl -s --url "https://circleci.com/api/v2/pipeline/${CIRCLE_PIPELINE_ID}/workflow" \
     -H "Circle-Token: ${CIRCLE_TOKEN}" \
     > /tmp/workflows.json
-# Get workflow and job statuses list
 echo "Generating Workflow Statuses..."
+
 for workflow in $(jq -r -c '.items[] | select(.id != "'$CIRCLE_WORKFLOW_ID'")' /tmp/workflows.json)
 do
   workflow_name=$(echo $workflow | jq -r '.name')

--- a/.circleci/scripts/generate-slack-template.sh
+++ b/.circleci/scripts/generate-slack-template.sh
@@ -43,8 +43,8 @@ if [[ $CIRCLE_BRANCH == "main" ]]
 then
   SUMMARY_MESSAGE=$(jq -r 'if .items | map(.status == "failed") | any then "*Action Items*:\n1. If you broke `'$CIRCLE_BRANCH'`, then fix it or revert your change.\n2. If you think a test is flaky, confirm it, make a change to skip the test with a ticket comment, and assign the ticket to the test owner.\n3. Once CI is green again, give this a :white_check_mark:." else "Changes should be live on <https://staging.audius.co|staging web> and all staging mobile apps." end' < /tmp/workflows.json)
 else
-  SUMMARY_MESSAGE=$(jq -r 'if .items | map(.status == "failed") | any then "If automerge was enabled, the change likely didn't merge. Fix your branch and try again." else "If automerge is enabled, the changes will be merged!" end' < /tmp/workflows.json)
-
+  SUMMARY_MESSAGE=$(jq -r 'if .items | map(.status == "failed") | any then "If automerge was enabled, the change likely did not merge. Fix your branch and try again." else "If automerge is enabled, the changes will be merged!" end' < /tmp/workflows.json)
+fi
 
 echo "Writing template..."
 jq -n --arg header "$PIPELINE_STATUS_HEADER"\

--- a/.circleci/scripts/generate-slack-template.sh
+++ b/.circleci/scripts/generate-slack-template.sh
@@ -55,4 +55,4 @@ jq -n --arg header "$PIPELINE_STATUS_HEADER"\
 echo "Exporting template to bash environment..."
 echo 'export PIPELINE_STATUS_TEMPLATE=$(cat /tmp/pipeline-status-template.json)' >> "$BASH_ENV"
 echo "Exporting Slack user ID to bash environment..."
-echo 'export SLACK_USER_ID='"$SLACK_USER_ID'"' >> $BASH_ENV
+echo "export SLACK_USER_ID=$SLACK_USER_ID" >> $BASH_ENV

--- a/.circleci/scripts/generate-slack-template.sh
+++ b/.circleci/scripts/generate-slack-template.sh
@@ -54,5 +54,5 @@ jq -n --arg header "$PIPELINE_STATUS_HEADER"\
 # Export the template to be available to the slack/notify command
 echo "Exporting template to bash environment..."
 echo 'export PIPELINE_STATUS_TEMPLATE=$(cat /tmp/pipeline-status-template.json)' >> "$BASH_ENV"
-echo "Exporting Slack user ID to bash environment..."
-echo "export SLACK_USER_ID=$SLACK_USER_ID" >> $BASH_ENV
+echo "Exporting Slack user ID to bash environment as default channel..."
+echo "export SLACK_DEFAULT_CHANNEL=$SLACK_USER_ID" >> $BASH_ENV

--- a/.circleci/scripts/generate-slack-template.sh
+++ b/.circleci/scripts/generate-slack-template.sh
@@ -13,7 +13,7 @@ PIPELINE_STATUS_HEADER=$(jq -r 'if .items | map(.status == "failed") | any then 
 echo "Getting Slack User ID..."
 author_name=$(git log -1 --pretty=format:'%an')
 env_key_name="SLACK_ID_FOR_GH_$(echo $author_name | tr ' ' '_' | tr '-' '_' | tr '[:upper:]' '[:lower:]')"
-SLACK_USER_ID="<@$(eval echo \$$env_key_name)>"
+SLACK_USER_ID="$(eval echo \$$env_key_name)"
 
 # Format the commit message of the last commit
 echo "Generating Commit Message..."
@@ -43,7 +43,7 @@ SUMMARY_MESSAGE=$(jq -r 'if .items | map(.status == "failed") | any then "*Actio
 
 echo "Writing template..."
 jq -n --arg header "$PIPELINE_STATUS_HEADER"\
-    --arg author "*Author*: $SLACK_USER_ID"\
+    --arg author "*Author*: <@$SLACK_USER_ID>"\
     --arg branch "*Branch*: <$PIPELINE_URL|$CIRCLE_BRANCH>"\
     --arg commit "$(printf "*Commit*: %s\n\`\`\`%s\`\`\`" "$COMMIT_SHA_LINK" "$COMMIT_MESSAGE")"\
     --arg workflows "$WORKFLOW_STATUSES"\
@@ -54,3 +54,5 @@ jq -n --arg header "$PIPELINE_STATUS_HEADER"\
 # Export the template to be available to the slack/notify command
 echo "Exporting template to bash environment..."
 echo 'export PIPELINE_STATUS_TEMPLATE=$(cat /tmp/pipeline-status-template.json)' >> "$BASH_ENV"
+echo "Exporting Slack user ID to bash environment..."
+echo 'export SLACK_USER_ID='"$SLACK_USER_ID'"' >> $BASH_ENV

--- a/.circleci/scripts/generate-slack-template.sh
+++ b/.circleci/scripts/generate-slack-template.sh
@@ -39,7 +39,12 @@ done
 
 # Add help text in the case of failure
 echo "Generating Summary..."
-SUMMARY_MESSAGE=$(jq -r 'if .items | map(.status == "failed") | any then "*Action Items*:\n1. If you broke `'$CIRCLE_BRANCH'`, then fix it or revert your change.\n2. If you think a test is flaky, confirm it, make a change to skip the test with a ticket comment, and assign the ticket to the test owner.\n3. Once CI is green again, give this a :white_check_mark:." else "Changes should be live on <https://staging.audius.co|staging web> and all staging mobile apps." end' < /tmp/workflows.json)
+if [[ $CIRCLE_BRANCH == "main" ]]
+then
+  SUMMARY_MESSAGE=$(jq -r 'if .items | map(.status == "failed") | any then "*Action Items*:\n1. If you broke `'$CIRCLE_BRANCH'`, then fix it or revert your change.\n2. If you think a test is flaky, confirm it, make a change to skip the test with a ticket comment, and assign the ticket to the test owner.\n3. Once CI is green again, give this a :white_check_mark:." else "Changes should be live on <https://staging.audius.co|staging web> and all staging mobile apps." end' < /tmp/workflows.json)
+else
+  SUMMARY_MESSAGE=$(jq -r 'if .items | map(.status == "failed") | any then "If automerge was enabled, the change likely didn't merge. Fix your branch and try again." else "If automerge is enabled, the changes will be merged!" end' < /tmp/workflows.json)
+
 
 echo "Writing template..."
 jq -n --arg header "$PIPELINE_STATUS_HEADER"\

--- a/.circleci/src/jobs/@integration-jobs.yml
+++ b/.circleci/src/jobs/@integration-jobs.yml
@@ -55,32 +55,27 @@ integration-test:
           . ~/.profile
           audius-compose connect --nopass
           ./scripts/check-generated-types.sh
-    # NOTE: disabled until we have a plan for fixing the flakyness
-    # output was already being ignored
-
-    # - run:
-    #     name: install playwright
-    #     command: sudo NEEDRESTART_MODE=l PLAYWRIGHT_BROWSERS_PATH=/home/circleci/.cache/ms-playwright npx playwright install --with-deps
-    # - run:
-    #     name: run playwright tests
-    #     command: |
-    #       cd packages/web
-    #       RUN_AGAINST_LOCAL_STACK=true npx playwright test || true
-    #       echo 'WARNING: errors have been ignored due to test flakiness.'
-    #       echo 'Please manually inspect output.'
-    # - store_test_results:
-    #     path: packages/web/report.xml
-    #     when: always
-    # - run:
-    #     name: merge playwright test reports
-    #     command: |
-    #       cd packages/web
-    #       npx playwright merge-reports --reporter html ./blob-report || true
-    #       echo 'WARNING: errors have been ignored due to test flakiness.'
-    #       echo 'Please manually inspect output.'
-    #     when: always
-    # - store_artifacts:
-    #     path: packages/web/playwright-report
+    - run:
+        name: install playwright
+        command: sudo NEEDRESTART_MODE=l PLAYWRIGHT_BROWSERS_PATH=/home/circleci/.cache/ms-playwright npx playwright install --with-deps
+    - run:
+        name: run playwright tests
+        command: |
+          cd packages/web
+          RUN_AGAINST_LOCAL_STACK=true npx playwright test || true
+          echo 'WARNING: errors have been ignored due to test flakiness.'
+          echo 'Please manually inspect output.'
+    - store_test_results:
+        path: packages/web/report.xml
+        when: always
+    - run:
+        name: merge playwright test reports
+        command: |
+          cd packages/web
+          npx playwright merge-reports --reporter html ./blob-report
+        when: always
+    - store_artifacts:
+        path: packages/web/playwright-report
     - run:
         name: cleanup
         no_output_timeout: 5m

--- a/.circleci/src/jobs/@integration-jobs.yml
+++ b/.circleci/src/jobs/@integration-jobs.yml
@@ -62,9 +62,7 @@ integration-test:
         name: run playwright tests
         command: |
           cd packages/web
-          RUN_AGAINST_LOCAL_STACK=true npx playwright test || true
-          echo 'WARNING: errors have been ignored due to test flakiness.'
-          echo 'Please manually inspect output.'
+          RUN_AGAINST_LOCAL_STACK=true npx playwright test
     - store_test_results:
         path: packages/web/report.xml
         when: always


### PR DESCRIPTION
- Remove integration workflow from PRs (only run on release branches)
  - Could argue this should run on main though too, or some nightly job?
- Add job to Setup workflow to wait and watch for any workflow failures for PRs
  - Any workflow that runs is now ~required (it can be skipped, but not fail). If you don't want something to be required on PRs, don't run it on the PR triggers. My hot take is whatever CI runs on PRs should be required to not fail. That said, we can adjust the script to a filter for specific workflows in the for loop if that's too controversial.
  - DMs on failure with ~same output as `#eng-ci-notifications` so you know if your automerge fails
  - Meant to become the new "required" step for PRs
- Re-enable Playwright tests for release branch
  - Controversial, but I think it should run - flakes or not! If it reports errors, those can be checked on manually as part of release process.