### PR TITLE
[PAY-3819] Fix navbar flash in manager mode

### DIFF
--- a/packages/common/src/store/account/sagas.ts
+++ b/packages/common/src/store/account/sagas.ts
@@ -344,8 +344,6 @@ function* fetchLocalAccountAsync() {
     )
 
     yield* put(fetchAccountSucceeded(cachedAccount))
-  } else {
-    yield* put(fetchAccountFailed({ reason: 'ACCOUNT_NOT_FOUND_LOCAL' }))
   }
 }
 

--- a/packages/web/src/components/nav/desktop/LeftNav.tsx
+++ b/packages/web/src/components/nav/desktop/LeftNav.tsx
@@ -1,6 +1,6 @@
 import { Fragment, useCallback, useRef, useState } from 'react'
 
-import { FavoriteSource } from '@audius/common/models'
+import { FavoriteSource, Status } from '@audius/common/models'
 import {
   accountSelectors,
   collectionsSocialActions,
@@ -43,7 +43,7 @@ type NavColumnProps = OwnProps &
   RouteComponentProps
 
 const LeftNav = (props: NavColumnProps) => {
-  const { isElectron } = props
+  const { isElectron, accountStatus } = props
   const [navBodyContainerMeasureRef, navBodyContainerBoundaries] = useMeasure({
     polyfill: ResizeObserver
   })
@@ -108,6 +108,9 @@ const LeftNav = (props: NavColumnProps) => {
     [scrollbarRef]
   )
 
+  const navLoaded =
+    accountStatus === Status.SUCCESS || accountStatus === Status.ERROR
+
   return (
     <Flex
       backgroundColor='surface1'
@@ -138,6 +141,7 @@ const LeftNav = (props: NavColumnProps) => {
                 ? 'inset 0px -8px 5px -5px var(--tile-shadow-3)'
                 : undefined,
           overflow: 'hidden',
+          opacity: navLoaded ? 1 : 0,
           transition: 'opacity 0.3s ease-in-out, box-shadow 0.2s ease'
         }}
       >
@@ -174,11 +178,13 @@ const LeftNav = (props: NavColumnProps) => {
           </DragAutoscroller>
         </Scrollbar>
       </Flex>
-      <Flex direction='column' alignItems='center'>
-        <ProfileCompletionPanel />
-        <LeftNavCTA />
-        <NowPlayingArtworkTile />
-      </Flex>
+      {navLoaded ? (
+        <Flex direction='column' alignItems='center'>
+          <ProfileCompletionPanel />
+          <LeftNavCTA />
+          <NowPlayingArtworkTile />
+        </Flex>
+      ) : null}
     </Flex>
   )
 }


### PR DESCRIPTION
### Description

When switching between manager mode and regular mode via the AccountDetails component, the navbar had a janky transition state while data loaded in, showing:

Original user's state
"Sign In" header state
Manager state

Add `navLoaded` check back from previous `LeftNav` implementation and remove `fetchAccountFailed` check

### How Has This Been Tested?

`npm run web:stage`

- Test if signed out navbar is apparent 
- Test if switching accounts via manager mode works
- Test if guest checkout works 
