### PR TITLE
Explicit match for uptime route, no caching

### DIFF
--- a/packages/discovery-provider/nginx_conf/nginx_container.conf
+++ b/packages/discovery-provider/nginx_conf/nginx_container.conf
@@ -345,12 +345,15 @@ http {
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         }
 
-        location /d_api/ {
+        location /d_api/uptime {
             resolver 127.0.0.11 valid=30s;
             set $upstream core:80;
             proxy_pass http://$upstream$request_uri;
             proxy_set_header Host $http_host;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_no_cache 1;
+            proxy_cache_bypass 1;
+            add_header Cache-Control "no-cache, no-store, must-revalidate" always;
         }
 
         location /core/ {


### PR DESCRIPTION
For reasons unbeknownst to me, uptime routes were 404'ing in prod, yet working in stage. Despite the same nginx conf. This change makes the route match explicit as clearly something strange is going on with pattern matching.

**TEST**

Built this branch as docker image and pushed to [audius/discovery-provider-openresty/69b05f57169e7ae35c449e002d4fe0d2fa9c42bb](https://hub.docker.com/layers/audius/discovery-provider-openresty/69b05f57169e7ae35c449e002d4fe0d2fa9c42bb/images/sha256-7d651ddc17bb7d35853be8e85d34f05acd0a25fd4f1a92822faf1de1e1ec97bc)

```
# prod dn1 - expected not working
$ curl https://discoveryprovider.audius.co/d_api/uptime?host=https://discoveryprovider.audius.co
{
  "error": "code=404, message=Not Found",
  "message": "Not Found"
}

# upodated prod dn2 to use the new image - works
$ curl https://discoveryprovider2.audius.co/d_api/uptime?host=https://discoveryprovider.audius.co
{
  "host": "https://discoveryprovider.audius.co",
  "uptime_percentage": 100,
  "duration": "24h",
  "uptime_raw_data": {
    "2025-01-26T15:00:00Z": 1,
    "2025-01-26T16:00:00Z": 1,
    "2025-01-26T17:00:00Z": 1,
    "2025-01-26T18:00:00Z": 1,
    "2025-01-26T19:00:00Z": 1,
    "2025-01-26T20:00:00Z": 1,
    "2025-01-26T21:00:00Z": 1,
    "2025-01-26T22:00:00Z": 1,
    "2025-01-26T23:00:00Z": 1,
    "2025-01-27T00:00:00Z": 1,
    "2025-01-27T01:00:00Z": 1,
    "2025-01-27T02:00:00Z": 1,
    "2025-01-27T03:00:00Z": 1,
    "2025-01-27T04:00:00Z": 1,
    "2025-01-27T05:00:00Z": 1,
    "2025-01-27T06:00:00Z": 1,
    "2025-01-27T07:00:00Z": 1,
    "2025-01-27T08:00:00Z": 1,
    "2025-01-27T09:00:00Z": 1,
    "2025-01-27T10:00:00Z": 1,
    "2025-01-27T11:00:00Z": 1,
    "2025-01-27T12:00:00Z": 1,
    "2025-01-27T13:00:00Z": 1,
    "2025-01-27T14:00:00Z": 1,
    "2025-01-27T15:00:00Z": 1
  }
}
```