### PR TITLE
Handle promise rejection to keep container alive

### DIFF
--- a/packages/discovery-provider/plugins/pedalboard/apps/solana-relay/src/index.ts
+++ b/packages/discovery-provider/plugins/pedalboard/apps/solana-relay/src/index.ts
@@ -20,6 +20,13 @@ import { location } from './routes/instruction/location'
 import { listen } from './routes/listen/listen'
 import { relay } from './routes/relay/relay'
 
+process.on('unhandledRejection', (reason, promise) => {
+  logger.error(
+    { promise, reason, stack: reason instanceof Error ? reason.stack : null },
+    'Unhandled promise rejection'
+  )
+})
+
 const main = async () => {
   const { serverHost, serverPort } = config
   const app = express()

--- a/packages/discovery-provider/plugins/pedalboard/apps/solana-relay/src/index.ts
+++ b/packages/discovery-provider/plugins/pedalboard/apps/solana-relay/src/index.ts
@@ -21,10 +21,7 @@ import { listen } from './routes/listen/listen'
 import { relay } from './routes/relay/relay'
 
 process.on('unhandledRejection', (reason, promise) => {
-  logger.error(
-    { promise, reason, stack: reason instanceof Error ? reason.stack : null },
-    'Unhandled promise rejection'
-  )
+  logger.error('Unhandled promise rejection', { promise, reason })
 })
 
 const main = async () => {

--- a/packages/discovery-provider/plugins/pedalboard/apps/solana-relay/src/routes/feePayer.ts
+++ b/packages/discovery-provider/plugins/pedalboard/apps/solana-relay/src/routes/feePayer.ts
@@ -8,16 +8,22 @@ export const feePayer = async (
   res: Response,
   next: NextFunction
 ) => {
-  if (
-    !config.solanaFeePayerWallets ||
-    config.solanaFeePayerWallets.length === 0
-  ) {
-    throw new InternalServerError('Relayer fee payer not configured.')
+  try {
+    if (
+      !config.solanaFeePayerWallets ||
+      config.solanaFeePayerWallets.length === 0
+    ) {
+      throw new InternalServerError('Relayer fee payer not configured.')
+    }
+    const index = Math.floor(
+      Math.random() * config.solanaFeePayerWallets.length
+    )
+    const feePayer = config.solanaFeePayerWallets[index].publicKey.toBase58()
+    res.status(200).send({
+      feePayer
+    })
+    next()
+  } catch (e) {
+    next(e)
   }
-  const index = Math.floor(Math.random() * config.solanaFeePayerWallets.length)
-  const feePayer = config.solanaFeePayerWallets[index].publicKey.toBase58()
-  res.status(200).send({
-    feePayer
-  })
-  next()
 }


### PR DESCRIPTION
### Description

Uncaught errors are causing solana-relay container to restart, adding unnecessary downtime. The root cause of the error doesn't seem to be anywhere within our code because we're handling exceptions on our end but I suspect it could be an unhandled promise in a background job or another async operation within solana. Either way, we should be robust enough to not let that take down the entire container.  

Also adding some more exception handling. 

Maybe unhandled promise from: https://github.com/solana-labs/solana-web3.js/issues/3720


### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._

Ran on prod and confirmed restarts subsided and this is actually an unhandled promise rejection. 

```
{"level":"ERROR","time":"2025-01-27T21:28:07.401Z","name":"solana-relay","reason":{},"stack":"Error: 503 Service Unavailable: \n    at ClientBrowser.callServer (/app/node_modules/@solana/web3.js/src/connection.ts:1699:18)\n    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)","msg":"asdf Unhandled promise rejection"}
```