### PR TITLE
[QA-1944] Fix embed harmony icon import

### DIFF
--- a/packages/embed/src/components/dog-ear/DogEar.jsx
+++ b/packages/embed/src/components/dog-ear/DogEar.jsx
@@ -1,4 +1,4 @@
-import { IconCart, IconSpecialAccess, IconReceive } from '@audius/harmony'
+import { IconCart, IconSparkles, IconReceive } from '@audius/harmony'
 import cn from 'classnames'
 
 import Background from '../../assets/img/dogEar.svg'
@@ -7,7 +7,7 @@ import styles from './DogEar.module.css'
 
 const VARIANT_TO_ICON = {
   purchase: IconCart,
-  special: IconSpecialAccess,
+  special: IconSparkles,
   extras: IconReceive
 }
 


### PR DESCRIPTION
### Description

Recent harmony icon rename didn't propagate to embed