### PR TITLE
[CI] Add missing dep to solana-relay to fix integration workflow

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -120686,6 +120686,7 @@
         "redis": "4.6.11",
         "request-ip": "3.3.0",
         "secp256k1": "5.0.0",
+        "uuid": "8.3.2",
         "web3-core": "4.3.2",
         "web3-eth-accounts": "4.1.2",
         "web3-utils": "4.2.3"
@@ -121411,6 +121412,15 @@
     "packages/discovery-provider/plugins/pedalboard/apps/solana-relay/node_modules/tslib": {
       "version": "2.6.2",
       "license": "0BSD"
+    },
+    "packages/discovery-provider/plugins/pedalboard/apps/solana-relay/node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
     },
     "packages/discovery-provider/plugins/pedalboard/apps/solana-relay/node_modules/web3-core": {
       "version": "4.3.2",

--- a/packages/discovery-provider/plugins/pedalboard/apps/solana-relay/package.json
+++ b/packages/discovery-provider/plugins/pedalboard/apps/solana-relay/package.json
@@ -35,6 +35,7 @@
     "redis": "4.6.11",
     "request-ip": "3.3.0",
     "secp256k1": "5.0.0",
+    "uuid": "8.3.2",
     "web3-core": "4.3.2",
     "web3-eth-accounts": "4.1.2",
     "web3-utils": "4.2.3"


### PR DESCRIPTION
`solana-relay` fails to come up in CI because `uuid` gets stripped away by `turbo prune` since it's not in the deps:

```
Error: Cannot find module 'uuid'
Require stack:
- /app/packages/discovery-provider/plugins/pedalboard/apps/solana-relay/src/middleware/logging.ts
- /app/packages/discovery-provider/plugins/pedalboard/apps/solana-relay/src/index.ts
    at Module._resolveFilename (node:internal/modules/cjs/loader:1140:15)
    at resolve (/root/.npm/_npx/93edd81d41e75888/node_modules/tsx/dist/register-CBZjvfJi.cjs:1:3215)
    at resolveRequest (/root/.npm/_npx/93edd81d41e75888/node_modules/tsx/dist/register-CBZjvfJi.cjs:1:2724)
    at /root/.npm/_npx/93edd81d41e75888/node_modules/tsx/dist/register-CBZjvfJi.cjs:1:3543
    at m._resolveFilename (file:///root/.npm/_npx/93edd81d41e75888/node_modules/tsx/dist/register-2mKsVc-c.mjs:1:832)
    at Module._load (node:internal/modules/cjs/loader:981:27)
    at Module.require (node:internal/modules/cjs/loader:1231:19)
    at require (node:internal/modules/helpers:177:18)
    at uuidv4 (/app/packages/discovery-provider/plugins/pedalboard/apps/solana-relay/src/middleware/logging.ts:2:30)
    at Object.<anonymous> (/app/packages/discovery-provider/plugins/pedalboard/apps/solana-relay/src/middleware/logging.ts:35:38) {
  code: 'MODULE_NOT_FOUND',
  requireStack: [
    '/app/packages/discovery-provider/plugins/pedalboard/apps/solana-relay/src/middleware/logging.ts',
    '/app/packages/discovery-provider/plugins/pedalboard/apps/solana-relay/src/index.ts'
  ]
}
```

This adds the missing package as a dep.