### PR TITLE
[C-1939] Fix edit key select

### DIFF
--- a/packages/harmony/src/components/select/Select/Select.tsx
+++ b/packages/harmony/src/components/select/Select/Select.tsx
@@ -49,6 +49,7 @@ export const Select = forwardRef(function Select<Value extends string>(
     onClick,
     clearable,
     children,
+    renderSelectedOptionLabel: renderSelectedOptionlabel,
     ...other
   } = props
 
@@ -64,7 +65,11 @@ export const Select = forwardRef(function Select<Value extends string>(
   const [isOpen, setIsOpen] = useState(false)
   const [inputValue, setInputValue] = useState('')
   const selectedOption = options.find((option) => option.value === value)
-  const selectedLabel = selectedOption?.label ?? selectedOption?.value
+  const selectedLabel = selectedOption
+    ? renderSelectedOptionlabel?.(selectedOption) ??
+      selectedOption.label ??
+      selectedOption.value
+    : ''
   const anchorRef = useRef<HTMLDivElement>(null)
   const inputRef = useRef<HTMLInputElement>(null)
   const optionRefs = useRef<HTMLButtonElement[]>([])
@@ -182,6 +187,7 @@ export const Select = forwardRef(function Select<Value extends string>(
         <MenuItem
           variant='option'
           {...selectedOption}
+          label={selectedLabel}
           onChange={() => {}}
           css={({ spacing }) => ({
             position: 'absolute',
@@ -206,7 +212,7 @@ export const Select = forwardRef(function Select<Value extends string>(
           scrollRef={scrollRef}
           MenuListProps={menuProps?.MenuListProps}
           aria-label={selectedLabel ?? label ?? props['aria-label']}
-          aria-activedescendant={selectedLabel}
+          aria-activedescendant={selectedOption?.label}
         >
           {children
             ? children({ onChange: handleChange, options: optionElements })

--- a/packages/harmony/src/components/select/Select/types.ts
+++ b/packages/harmony/src/components/select/Select/types.ts
@@ -39,6 +39,13 @@ export type SelectProps<Value extends string = string> = {
    */
   options: SelectOption<Value>[]
 
+  /**
+   * Optional function to customize the selected option's displayed label
+   * @param option The currently selected option
+   * @returns The string to display as the label
+   */
+  renderSelectedOptionLabel?: (option: SelectOption<Value>) => string
+
   children?: (props: ChildrenProps<Value>) => ReactNode
 
   /**

--- a/packages/web/src/components/edit/fields/KeySelectField.tsx
+++ b/packages/web/src/components/edit/fields/KeySelectField.tsx
@@ -35,11 +35,13 @@ export const KeySelectField = (props: KeySelectFieldProps) => {
 
   return (
     <Select
+      readOnly
       value={key}
       label={messages.key}
       options={keyOptions}
       error={hasError}
       helperText={hasError ? error : undefined}
+      renderSelectedOptionLabel={(option) => `${option.label} ${scale}`}
       onChange={setValue}
       menuProps={{ PaperProps: { css: { minWidth: 200 } } }}
     >


### PR DESCRIPTION
### Description

Fixes a few issues:
- User should not be able to manually edit in the text-input (readOnly solves this)
- Adds the long-winded `renderSelectedOptionLabel` to render a different selected-option label vs option label. this is needed to render "B-flat" in the menu, but "B-flat Major" in the selected area.