### PR TITLE
[PAY-3814] Endless Listen Streak Challenge

### DIFF
--- a/packages/discovery-provider/integration_tests/challenges/test_challenges.py
+++ b/packages/discovery-provider/integration_tests/challenges/test_challenges.py
@@ -317,7 +317,7 @@ class AggregateUpdater(ChallengeUpdater):
     ):
         pass
 
-    def generate_specifier(self, user_id: int, extra: Dict) -> str:
+    def generate_specifier(self, session: Session, user_id: int, extra: Dict) -> str:
         return f"{user_id}-{extra['referred_id']}"
 
 

--- a/packages/discovery-provider/integration_tests/challenges/test_listen_streak_endless_challenge.py
+++ b/packages/discovery-provider/integration_tests/challenges/test_listen_streak_endless_challenge.py
@@ -1,0 +1,365 @@
+import logging
+from datetime import datetime, timedelta
+
+from sqlalchemy.orm.session import Session
+
+from src.challenges.challenge_event_bus import ChallengeEvent, ChallengeEventBus
+from src.challenges.listen_streak_endless_challenge import (
+    listen_streak_endless_challenge_manager,
+)
+from src.models.indexing.block import Block
+from src.models.rewards.challenge import Challenge
+from src.models.social.play import Play
+from src.models.users.user import User
+from src.utils.config import shared_config
+from src.utils.db_session import get_db
+from src.utils.redis_connection import get_redis
+
+logger = logging.getLogger(__name__)
+
+REDIS_URL = shared_config["redis"]["url"]
+BLOCK_NUMBER = 10
+
+
+def create_play(offset: int) -> Play:
+    return Play(
+        id=offset,
+        user_id=1,
+        source=None,
+        play_item_id=1,
+        slot=1,
+        signature=None,
+        updated_at=datetime.now() + timedelta(days=offset),
+        created_at=datetime.now() + timedelta(days=offset),
+    )
+
+
+def dispatch_play(offset: int, session: Session, bus: ChallengeEventBus):
+    play = create_play(offset)
+    session.add(play)
+    session.flush()
+    bus.dispatch(
+        ChallengeEvent.track_listen,
+        BLOCK_NUMBER,
+        datetime.now(),
+        1,
+        {"created_at": play.created_at.timestamp()},
+    )
+
+
+def setup_challenges(session):
+    block = Block(blockhash="0x1", number=BLOCK_NUMBER)
+    user = User(
+        blockhash="0x1",
+        blocknumber=BLOCK_NUMBER,
+        txhash="xyz",
+        user_id=1,
+        is_current=True,
+        handle="TestHandle",
+        handle_lc="testhandle",
+        wallet="0x1",
+        is_verified=False,
+        name="test_name",
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+    )
+    session.add(block)
+    session.flush()
+    session.add(user)
+    session.flush()
+    session.query(Challenge).filter(Challenge.id == "l").update(
+        {"active": True, "starting_block": BLOCK_NUMBER}
+    )
+
+
+# Wrapper function to call use_scoped_dispatch_queue,
+# and then process when it goes out of scope
+def make_scope_and_process(bus, session):
+    def inner(fn):
+        with bus.use_scoped_dispatch_queue():
+            fn()
+        bus.process_events(session)
+
+    return inner
+
+
+def test_listen_streak_challenge(app):
+    redis_conn = get_redis()
+    bus = ChallengeEventBus(redis_conn)
+    # Register events with the bus
+    bus.register_listener(
+        ChallengeEvent.track_listen, listen_streak_endless_challenge_manager
+    )
+
+    with app.app_context():
+        db = get_db()
+
+    with db.scoped_session() as session:
+        setup_challenges(session)
+
+        # wrapped dispatch play
+        def dp(offset):
+            return dispatch_play(offset, session, bus)
+
+        scope_and_process = make_scope_and_process(bus, session)
+
+        # Make sure plays increment the step count
+        scope_and_process(lambda: dp(0))
+
+        state = listen_streak_endless_challenge_manager.get_user_challenge_state(
+            session
+        )[0]
+        assert state.current_step_count == 1 and not state.is_complete
+
+        scope_and_process(lambda: dp(1))
+        state = listen_streak_endless_challenge_manager.get_user_challenge_state(
+            session
+        )[0]
+        assert state.current_step_count == 2 and not state.is_complete
+
+        # Make sure the step count resets if the user missed a day
+        scope_and_process(lambda: dp(3))
+        state = listen_streak_endless_challenge_manager.get_user_challenge_state(
+            session
+        )
+        assert len(state) == 2
+        assert state[0].current_step_count == 2 and state[0].is_complete == False
+        assert state[1].current_step_count == 1 and state[1].is_complete == False
+
+        # Add more plays to increment the step count
+        scope_and_process(lambda: dp(4))
+        scope_and_process(lambda: dp(5))
+        scope_and_process(lambda: dp(6))
+        scope_and_process(lambda: dp(7))
+        scope_and_process(lambda: dp(8))
+        state = listen_streak_endless_challenge_manager.get_user_challenge_state(
+            session
+        )
+        assert len(state) == 2
+        assert state[0].current_step_count == 2 and state[0].is_complete == False
+        assert state[1].current_step_count == 6 and state[1].is_complete == False
+
+        # Make sure that is_complete is set when step count hits 7
+        scope_and_process(lambda: dp(9))
+        state = listen_streak_endless_challenge_manager.get_user_challenge_state(
+            session
+        )
+        assert len(state) == 2
+        assert state[0].current_step_count == 2 and state[0].is_complete == False
+        assert state[1].current_step_count == 7 and state[1].is_complete == True
+
+
+def test_multiple_listens(app):
+    redis_conn = get_redis()
+    bus = ChallengeEventBus(redis_conn)
+    # Register events with the bus
+    bus.register_listener(
+        ChallengeEvent.track_listen, listen_streak_endless_challenge_manager
+    )
+
+    with app.app_context():
+        db = get_db()
+
+    with db.scoped_session() as session:
+        setup_challenges(session)
+        state = listen_streak_endless_challenge_manager.get_user_challenge_state(
+            session
+        )
+        # make sure empty to start
+        assert len(state) == 0
+
+        def dp(offset):
+            return dispatch_play(offset, session, bus)
+
+        scope_and_process = make_scope_and_process(bus, session)
+        scope_and_process(lambda: dp(1))
+        state = listen_streak_endless_challenge_manager.get_user_challenge_state(
+            session
+        )
+        assert len(state) == 1
+        assert state[0].current_step_count == 1
+        scope_and_process(lambda: (dp(2), dp(3), dp(4), dp(5)))
+        state = listen_streak_endless_challenge_manager.get_user_challenge_state(
+            session
+        )
+        # This will actually "reset" the listen count, because
+        # we dedupe multiple play events in a single call to process
+        # and in this case, we pick the one with the greatest timestamp
+        # which is > 2 days, thus resetting.
+        # Not the greatest behavior, but shouldn't have user facing
+        # impact.
+
+        # we really want to just ensure that this doesn't crash
+        assert len(state) == 4
+        assert state[0].current_step_count == 2
+        assert state[1].current_step_count == 2
+        assert state[2].current_step_count == 2
+        assert state[3].current_step_count == 2
+
+
+def test_listen_streak_endless_challenge(app):
+    redis_conn = get_redis()
+    bus = ChallengeEventBus(redis_conn)
+    # Register events with the bus
+    bus.register_listener(
+        ChallengeEvent.track_listen, listen_streak_endless_challenge_manager
+    )
+
+    with app.app_context():
+        db = get_db()
+
+    with db.scoped_session() as session:
+        setup_challenges(session)
+
+        # wrapped dispatch play
+        def dp(offset):
+            return dispatch_play(offset, session, bus)
+
+        scope_and_process = make_scope_and_process(bus, session)
+
+        # Make sure plays increment the step count
+        scope_and_process(lambda: dp(0))
+
+        state = listen_streak_endless_challenge_manager.get_user_challenge_state(
+            session
+        )[0]
+        assert state.current_step_count == 1 and not state.is_complete
+
+        # Add more plays to increment the step count
+        scope_and_process(lambda: dp(1))
+        scope_and_process(lambda: dp(2))
+        scope_and_process(lambda: dp(3))
+        scope_and_process(lambda: dp(4))
+        scope_and_process(lambda: dp(5))
+        scope_and_process(lambda: dp(6))
+        state = listen_streak_endless_challenge_manager.get_user_challenge_state(
+            session
+        )
+        assert len(state) == 1
+        assert state[0].current_step_count == 7 and state[0].is_complete == True
+
+        scope_and_process(lambda: dp(7))
+        state = listen_streak_endless_challenge_manager.get_user_challenge_state(
+            session
+        )
+        assert len(state) == 2
+        assert state[0].is_complete == True
+        assert state[1].is_complete == True
+
+        scope_and_process(lambda: dp(8))
+        state = listen_streak_endless_challenge_manager.get_user_challenge_state(
+            session
+        )
+        assert len(state) == 3
+        assert state[0].is_complete == True
+        assert state[1].is_complete == True
+        assert state[2].is_complete == True
+
+
+def test_multiple_listen_streak_challenges(app):
+    redis_conn = get_redis()
+    bus = ChallengeEventBus(redis_conn)
+    # Register events with the bus
+    bus.register_listener(
+        ChallengeEvent.track_listen, listen_streak_endless_challenge_manager
+    )
+
+    with app.app_context():
+        db = get_db()
+
+    with db.scoped_session() as session:
+        setup_challenges(session)
+
+        # wrapped dispatch play
+        def dp(offset):
+            return dispatch_play(offset, session, bus)
+
+        scope_and_process = make_scope_and_process(bus, session)
+
+        # Make sure plays increment the step count
+        scope_and_process(lambda: dp(0))
+
+        state = listen_streak_endless_challenge_manager.get_user_challenge_state(
+            session
+        )[0]
+        assert state.current_step_count == 1 and not state.is_complete
+
+        # Add more plays to increment the step count
+        scope_and_process(lambda: dp(1))
+        scope_and_process(lambda: dp(2))
+
+        state = listen_streak_endless_challenge_manager.get_user_challenge_state(
+            session
+        )
+        assert len(state) == 1
+        assert state[0].current_step_count == 3 and not state[0].is_complete
+
+        # break the streak
+        scope_and_process(lambda: dp(5))
+        state = listen_streak_endless_challenge_manager.get_user_challenge_state(
+            session
+        )
+        assert len(state) == 2
+        assert state[0].current_step_count == 3 and not state[0].is_complete
+        assert state[1].current_step_count == 1 and not state[1].is_complete
+
+        # complete the new streak
+        scope_and_process(lambda: dp(6))
+        scope_and_process(lambda: dp(7))
+        scope_and_process(lambda: dp(8))
+        scope_and_process(lambda: dp(9))
+        scope_and_process(lambda: dp(10))
+        scope_and_process(lambda: dp(11))
+        state = listen_streak_endless_challenge_manager.get_user_challenge_state(
+            session
+        )
+        assert len(state) == 2
+        assert state[0].current_step_count == 3 and not state[0].is_complete
+        assert state[1].current_step_count == 7 and state[1].is_complete == True
+
+        # keep it going
+        scope_and_process(lambda: dp(12))
+        state = listen_streak_endless_challenge_manager.get_user_challenge_state(
+            session
+        )
+        assert len(state) == 3
+        assert state[0].current_step_count == 3 and state[0].is_complete == False
+        assert state[1].current_step_count == 7 and state[1].is_complete == True
+        assert state[2].current_step_count == 1 and state[2].is_complete == True
+
+        # break it again
+        scope_and_process(lambda: dp(15))
+        scope_and_process(lambda: dp(16))
+        state = listen_streak_endless_challenge_manager.get_user_challenge_state(
+            session
+        )
+        assert len(state) == 4
+        assert state[0].current_step_count == 3 and state[0].is_complete == False
+        assert state[1].current_step_count == 7 and state[1].is_complete == True
+        assert state[2].current_step_count == 1 and state[2].is_complete == True
+        assert state[3].current_step_count == 2 and state[3].is_complete == False
+
+
+def test_anon_listen(app):
+    redis_conn = get_redis()
+    bus = ChallengeEventBus(redis_conn)
+    # Register events with the bus
+    bus.register_listener(
+        ChallengeEvent.track_listen, listen_streak_endless_challenge_manager
+    )
+
+    with app.app_context():
+        db = get_db()
+
+    with db.scoped_session() as session:
+        setup_challenges(session)
+        with bus.use_scoped_dispatch_queue():
+            bus.dispatch(
+                ChallengeEvent.track_listen,
+                BLOCK_NUMBER,
+                None,
+                {"created_at": datetime.now()},
+            )
+        (num_processed, error) = bus.process_events(session)
+        assert not error
+        assert num_processed == 0

--- a/packages/discovery-provider/src/challenges/audio_matching_challenge.py
+++ b/packages/discovery-provider/src/challenges/audio_matching_challenge.py
@@ -26,7 +26,7 @@ def does_user_exist_with_verification_status(
 
 
 class AudioMatchingBuyerChallengeUpdater(ChallengeUpdater):
-    def generate_specifier(self, user_id: int, extra: Dict) -> str:
+    def generate_specifier(self, session: Session, user_id: int, extra: Dict) -> str:
         return generate_audio_matching_specifier(user_id, extra)
 
     def should_create_new_challenge(
@@ -39,7 +39,7 @@ class AudioMatchingBuyerChallengeUpdater(ChallengeUpdater):
 
 
 class AudioMatchingSellerChallengeUpdater(ChallengeUpdater):
-    def generate_specifier(self, user_id: int, extra: Dict) -> str:
+    def generate_specifier(self, session: Session, user_id: int, extra: Dict) -> str:
         return generate_audio_matching_specifier(extra["sender_user_id"], extra)
 
     def should_create_new_challenge(

--- a/packages/discovery-provider/src/challenges/challenge_event_bus.py
+++ b/packages/discovery-provider/src/challenges/challenge_event_bus.py
@@ -16,6 +16,9 @@ from src.challenges.challenge_event import ChallengeEvent
 from src.challenges.connect_verified_challenge import connect_verified_challenge_manager
 from src.challenges.first_playlist_challenge import first_playlist_challenge_manager
 from src.challenges.listen_streak_challenge import listen_streak_challenge_manager
+from src.challenges.listen_streak_endless_challenge import (
+    listen_streak_endless_challenge_manager,
+)
 from src.challenges.mobile_install_challenge import mobile_install_challenge_manager
 from src.challenges.one_shot_challenge import one_shot_challenge_manager
 from src.challenges.profile_challenge import profile_challenge_manager
@@ -168,9 +171,9 @@ class ChallengeEventBus:
             events_dicts = list(map(self._json_to_event, events_json))
             # Consolidate event types for processing
             # map of {"event_type": [{ user_id: number, block_number: number, extra: {} }]}}
-            event_user_dict: DefaultDict[
-                ChallengeEvent, List[EventMetadata]
-            ] = defaultdict(lambda: [])
+            event_user_dict: DefaultDict[ChallengeEvent, List[EventMetadata]] = (
+                defaultdict(lambda: [])
+            )
             for event_dict in events_dicts:
                 event_type = event_dict["event"]
                 event_user_dict[event_type].append(
@@ -241,6 +244,9 @@ def setup_challenge_bus():
     bus.register_listener(ChallengeEvent.favorite, profile_challenge_manager)
     # listen_streak_challenge_manager listeners
     bus.register_listener(ChallengeEvent.track_listen, listen_streak_challenge_manager)
+    bus.register_listener(
+        ChallengeEvent.track_listen, listen_streak_endless_challenge_manager
+    )
     # track_upload_challenge_manager listeners
     bus.register_listener(ChallengeEvent.track_upload, track_upload_challenge_manager)
     # referral challenge managers

--- a/packages/discovery-provider/src/challenges/challenge_event_bus.py
+++ b/packages/discovery-provider/src/challenges/challenge_event_bus.py
@@ -171,9 +171,8 @@ class ChallengeEventBus:
             events_dicts = list(map(self._json_to_event, events_json))
             # Consolidate event types for processing
             # map of {"event_type": [{ user_id: number, block_number: number, extra: {} }]}}
-            event_user_dict: DefaultDict[ChallengeEvent, List[EventMetadata]] = (
-                defaultdict(lambda: [])
-            )
+            event_user_dict: DefaultDict[
+                ChallengeEvent, List[EventMetadata]] = defaultdict(lambda: [])
             for event_dict in events_dicts:
                 event_type = event_dict["event"]
                 event_user_dict[event_type].append(

--- a/packages/discovery-provider/src/challenges/challenge_event_bus.py
+++ b/packages/discovery-provider/src/challenges/challenge_event_bus.py
@@ -172,7 +172,8 @@ class ChallengeEventBus:
             # Consolidate event types for processing
             # map of {"event_type": [{ user_id: number, block_number: number, extra: {} }]}}
             event_user_dict: DefaultDict[
-                ChallengeEvent, List[EventMetadata]] = defaultdict(lambda: [])
+                ChallengeEvent, List[EventMetadata]
+            ] = defaultdict(lambda: [])
             for event_dict in events_dicts:
                 event_type = event_dict["event"]
                 event_user_dict[event_type].append(

--- a/packages/discovery-provider/src/challenges/challenges.dev.json
+++ b/packages/discovery-provider/src/challenges/challenges.dev.json
@@ -19,6 +19,15 @@
     "weekly_pool": 25000
   },
   {
+    "id": "e",
+    "type": "aggregate",
+    "active": true,
+    "step_count": 2147483647,
+    "starting_block": 0,
+    "amount": 1,
+    "weekly_pool": 25000
+  },
+  {
     "id": "u",
     "type": "numeric",
     "active": true,

--- a/packages/discovery-provider/src/challenges/challenges.json
+++ b/packages/discovery-provider/src/challenges/challenges.json
@@ -19,6 +19,15 @@
     "weekly_pool": 25000
   },
   {
+    "id": "e",
+    "type": "aggregate",
+    "amount": 1,
+    "active": true,
+    "step_count": 2147483647,
+    "starting_block": 116023891,
+    "weekly_pool": 25000
+  },
+  {
     "id": "u",
     "type": "numeric",
     "amount": 1,

--- a/packages/discovery-provider/src/challenges/challenges.stage.json
+++ b/packages/discovery-provider/src/challenges/challenges.stage.json
@@ -19,6 +19,15 @@
     "weekly_pool": 25000
   },
   {
+    "id": "e",
+    "type": "aggregate",
+    "amount": 1,
+    "active": true,
+    "step_count": 2147483647,
+    "starting_block": 116023891,
+    "weekly_pool": 25000
+  },
+  {
     "id": "u",
     "type": "numeric",
     "active": true,

--- a/packages/discovery-provider/src/challenges/listen_streak_endless_challenge.py
+++ b/packages/discovery-provider/src/challenges/listen_streak_endless_challenge.py
@@ -1,0 +1,215 @@
+import logging
+from datetime import datetime, timedelta
+from typing import Dict, List, Optional
+
+from sqlalchemy.orm.session import Session
+
+from src.challenges.challenge import (
+    ChallengeManager,
+    ChallengeUpdater,
+    FullEventMetadata,
+)
+from src.challenges.challenge_event import ChallengeEvent
+from src.models.rewards.listen_streak_challenge import ChallengeListenStreak
+from src.models.rewards.user_challenge import UserChallenge
+from src.utils.config import shared_config
+
+logger = logging.getLogger(__name__)
+env = shared_config["discprov"]["env"]
+
+base_timedelta = timedelta(days=1)
+if env == "stage":
+    base_timedelta = timedelta(minutes=1)
+
+
+def get_listen_streak_override(session: Session, user_id: int) -> Optional[int]:
+    user_listen_challenge = (
+        session.query(ChallengeListenStreak)
+        .filter(ChallengeListenStreak.user_id == user_id)
+        .first()
+    )
+
+    if user_listen_challenge is None or user_listen_challenge.last_listen_date is None:
+        return None
+
+    # If last_listen_date is over 48 hrs, return zero
+    current_datetime = datetime.now()
+    if current_datetime - user_listen_challenge.last_listen_date >= timedelta(days=2):
+        return 0
+    return None
+
+
+class ChallengeListenEndlessStreakUpdater(ChallengeUpdater):
+    """Endless listening streak challenge"""
+
+    def _get_current_listen_streak(
+        self, session: Session, user_id: int, extra: Dict
+    ) -> Optional[UserChallenge]:
+        created_at = datetime.fromtimestamp(extra["created_at"])
+        most_recent_challenge = get_most_recent_listen_streak_user_challenge(
+            session, [user_id]
+        )
+        listen_streaks = get_listen_streak_challenges(session, [user_id])
+        listen_streak = listen_streaks[0] if listen_streaks else None
+
+        # If existing incomplete listen streak (< 7 days) is not broken, use the existing challenge metadata
+        if (
+            most_recent_challenge is not None
+            and not most_recent_challenge.is_complete
+            and listen_streak is not None
+            and listen_streak.last_listen_date is not None
+            and created_at - listen_streak.last_listen_date <= timedelta(days=2)
+        ):
+            logger.info(
+                f"REED _get_current_listen_streak returning existing challenge ${most_recent_challenge}"
+            )
+            return most_recent_challenge
+        return None
+
+    def generate_specifier(self, session: Session, user_id: int, extra: Dict) -> str:
+        recent_challenge = self._get_current_listen_streak(session, user_id, extra)
+        if recent_challenge is not None:
+            logger.info(
+                f"REED generate_specifier use existing specifier ${recent_challenge.specifier}"
+            )
+            return recent_challenge.specifier
+
+        # Otherwise, create a new specifier
+        created_at = datetime.fromtimestamp(extra["created_at"])
+        formatted_date = created_at.strftime("%Y%m%d")
+        return f"{user_id}_{formatted_date}"
+
+    def should_create_new_challenge(
+        self, session: Session, event: str, user_id: int, extra: Dict
+    ) -> bool:
+        current_listen_streak = self._get_current_listen_streak(session, user_id, extra)
+        if current_listen_streak:
+            logger.info(f"REED should_create_new_challenge returning False")
+            return False
+        logger.info(f"REED should_create_new_challenge returning True")
+        return True
+
+    def update_user_challenges(
+        self,
+        session: Session,
+        event: str,
+        user_challenges: List[UserChallenge],
+        step_count: Optional[int],
+        event_metadatas: List[FullEventMetadata],
+        starting_block: Optional[int],
+    ):
+        user_ids = [user_challenge.user_id for user_challenge in user_challenges]
+        partial_completions = get_listen_streak_challenges(session, user_ids)
+        completion_map = {
+            completion.user_id: completion for completion in partial_completions
+        }
+
+        if event == ChallengeEvent.track_listen:
+            self._handle_track_listens(partial_completions, event_metadatas)
+
+        # Update the user_challenges
+        for user_challenge in user_challenges:
+            matching_partial_challenge = completion_map[user_challenge.user_id]
+            # For endless streak challenges - these rows should only have amount/step_count = 1
+            if (
+                matching_partial_challenge.listen_streak > 7
+                and user_challenge.current_step_count == 0
+            ):
+                user_challenge.amount = 1
+                user_challenge.current_step_count = 1
+                user_challenge.is_complete = True
+            # For first normal listen streak challenge - amount/step_count get updated as streak progresses
+            else:
+                user_challenge.amount = 7
+                user_challenge.current_step_count = (
+                    matching_partial_challenge.listen_streak
+                )
+                user_challenge.is_complete = user_challenge.current_step_count >= 7
+
+    def on_after_challenge_creation(
+        self, session: Session, metadatas: List[FullEventMetadata]
+    ):
+
+        # Get all user_ids from the metadatas
+        user_ids = [metadata["user_id"] for metadata in metadatas]
+
+        # Query existing records
+        existing_challenges = (
+            session.query(ChallengeListenStreak.user_id)
+            .filter(ChallengeListenStreak.user_id.in_(user_ids))
+            .all()
+        )
+        existing_user_ids = {user_id for (user_id,) in existing_challenges}
+
+        # Create new records only for users that don't have one
+        new_listen_streak_challenges = [
+            ChallengeListenStreak(
+                user_id=metadata["user_id"],
+                last_listen_date=None,
+                listen_streak=0,
+            )
+            for metadata in metadatas
+            if metadata["user_id"] not in existing_user_ids
+        ]
+
+        if new_listen_streak_challenges:
+            session.add_all(new_listen_streak_challenges)
+
+    # Helpers
+    def _handle_track_listens(
+        self,
+        partial_completions: List[ChallengeListenStreak],
+        event_metadatas: List[FullEventMetadata],
+    ):
+        for idx, partial_completion in enumerate(partial_completions):
+            last_date = partial_completion.last_listen_date
+            new_date = datetime.fromtimestamp(
+                event_metadatas[idx]["extra"]["created_at"]
+            )
+
+            # If last timestamp is None, start streak now
+            if last_date is None:
+                partial_completion.last_listen_date = new_date
+                partial_completion.listen_streak = 1
+            # If last timestamp is more than 24 hours ago, update streak
+            elif new_date - last_date >= base_timedelta:
+                partial_completion.last_listen_date = new_date
+                # Check if the user lost their streak
+                if new_date - last_date >= base_timedelta * 2:
+                    partial_completion.listen_streak = 1
+                else:
+                    partial_completion.listen_streak += 1
+
+    def get_override_challenge_step_count(
+        self, session: Session, user_id: int
+    ) -> Optional[int]:
+        return get_listen_streak_override(session, user_id)
+
+
+listen_streak_endless_challenge_manager = ChallengeManager(
+    "e", ChallengeListenEndlessStreakUpdater()
+)
+
+
+# Accessors
+def get_listen_streak_challenges(
+    session: Session, user_ids: List[int]
+) -> List[ChallengeListenStreak]:
+    return (
+        session.query(ChallengeListenStreak)
+        .filter(ChallengeListenStreak.user_id.in_(user_ids))
+        .order_by(ChallengeListenStreak.last_listen_date.desc())
+        .all()
+    )
+
+
+def get_most_recent_listen_streak_user_challenge(
+    session: Session, user_ids: List[int]
+) -> Optional[UserChallenge]:
+    return (
+        session.query(UserChallenge)
+        .filter(UserChallenge.challenge_id == "e")
+        .filter(UserChallenge.user_id.in_(user_ids))
+        .order_by(UserChallenge.created_at.desc())
+        .first()
+    )

--- a/packages/discovery-provider/src/challenges/listen_streak_endless_challenge.py
+++ b/packages/discovery-provider/src/challenges/listen_streak_endless_challenge.py
@@ -60,18 +60,12 @@ class ChallengeListenEndlessStreakUpdater(ChallengeUpdater):
             and listen_streak.last_listen_date is not None
             and created_at - listen_streak.last_listen_date <= timedelta(days=2)
         ):
-            logger.info(
-                f"REED _get_current_listen_streak returning existing challenge ${most_recent_challenge}"
-            )
             return most_recent_challenge
         return None
 
     def generate_specifier(self, session: Session, user_id: int, extra: Dict) -> str:
         recent_challenge = self._get_current_listen_streak(session, user_id, extra)
         if recent_challenge is not None:
-            logger.info(
-                f"REED generate_specifier use existing specifier ${recent_challenge.specifier}"
-            )
             return recent_challenge.specifier
 
         # Otherwise, create a new specifier
@@ -84,9 +78,7 @@ class ChallengeListenEndlessStreakUpdater(ChallengeUpdater):
     ) -> bool:
         current_listen_streak = self._get_current_listen_streak(session, user_id, extra)
         if current_listen_streak:
-            logger.info(f"REED should_create_new_challenge returning False")
             return False
-        logger.info(f"REED should_create_new_challenge returning True")
         return True
 
     def update_user_challenges(

--- a/packages/discovery-provider/src/challenges/listen_streak_endless_challenge.py
+++ b/packages/discovery-provider/src/challenges/listen_streak_endless_challenge.py
@@ -18,7 +18,7 @@ logger = logging.getLogger(__name__)
 env = shared_config["discprov"]["env"]
 
 base_timedelta = timedelta(days=1)
-if env == "stage":
+if env == "stage" or env == "dev":
     base_timedelta = timedelta(minutes=1)
 
 

--- a/packages/discovery-provider/src/challenges/listen_streak_endless_challenge.py
+++ b/packages/discovery-provider/src/challenges/listen_streak_endless_challenge.py
@@ -18,7 +18,7 @@ logger = logging.getLogger(__name__)
 env = shared_config["discprov"]["env"]
 
 base_timedelta = timedelta(days=1)
-if env == "stage" or env == "dev":
+if env == "stage":
     base_timedelta = timedelta(minutes=1)
 
 

--- a/packages/discovery-provider/src/challenges/referral_challenge.py
+++ b/packages/discovery-provider/src/challenges/referral_challenge.py
@@ -31,7 +31,7 @@ def does_user_exist_with_verification_status(
 
 
 class ReferralChallengeUpdater(ChallengeUpdater):
-    def generate_specifier(self, user_id: int, extra: Dict) -> str:
+    def generate_specifier(self, session: Session, user_id: int, extra: Dict) -> str:
         return generate_referral_specifier(user_id, extra)
 
     def should_create_new_challenge(
@@ -44,7 +44,7 @@ class ReferralChallengeUpdater(ChallengeUpdater):
 
 
 class VerifiedReferralChallengeUpdater(ChallengeUpdater):
-    def generate_specifier(self, user_id: int, extra: Dict) -> str:
+    def generate_specifier(self, session: Session, user_id: int, extra: Dict) -> str:
         return generate_referral_specifier(user_id, extra)
 
     def should_create_new_challenge(

--- a/packages/discovery-provider/src/challenges/trending_challenge.py
+++ b/packages/discovery-provider/src/challenges/trending_challenge.py
@@ -48,7 +48,7 @@ class TrendingChallengeUpdater(ChallengeUpdater):
         ]
         session.add_all(trending_results)
 
-    def generate_specifier(self, user_id: int, extra: Dict) -> str:
+    def generate_specifier(self, session: Session, user_id: int, extra: Dict) -> str:
         return f"{extra['week']}:{extra['rank']}"
 
 


### PR DESCRIPTION
### Description
- First challenge will have step_count = 7 and amount = 7, will only be marked complete once 7-day listen streak is achieved.
- For subsequent days of the streak we add 1 new row per day with step_count = 1 and amount = 1.
- Specifier is now date-dependent to allow multiple `user_challenge` listen streak rows per user (formerly only 1 per user).
- Unfortunately need to add db query in `generate_specifier` to determine whether to use the existing `user_challenge` row, or create a new one. But this is the only challenge that will have this query.
- There will still only ever be 1 `ChallengeListenStreak` row per user - another db query to determine whether one exists or not in `on_after_challenge_creation`.
- Allow querying of `user_challenge` rows without specifiers for tests

### How Has This Been Tested?

Integration tests pass