### PR TITLE
[PAY-3853] Add rewards, audio, and usdc pages to mobile web

### DIFF
--- a/packages/web/src/components/nav/mobile/ConnectedNavBar.tsx
+++ b/packages/web/src/components/nav/mobile/ConnectedNavBar.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useContext } from 'react'
 
+import { useChallengeCooldownSchedule } from '@audius/common/hooks'
 import { Name, Status } from '@audius/common/models'
 import {
   accountSelectors,
@@ -22,7 +23,7 @@ import { push, goBack } from 'utils/navigation'
 
 import NavBar from './NavBar'
 
-const { NOTIFICATION_PAGE, SETTINGS_PAGE, AUDIO_PAGE } = route
+const { NOTIFICATION_PAGE, SETTINGS_PAGE, REWARDS_PAGE } = route
 const { getSearchStatus } = searchResultsPageSelectors
 const { getNotificationUnviewedCount } = notificationsSelectors
 const { getHasAccount, getAccountStatus } = accountSelectors
@@ -41,6 +42,9 @@ const ConnectedNavBar = ({
   goBack
 }: ConnectedNavBarProps) => {
   const { setStackReset, setSlideDirection } = useContext(RouterContext)
+  const { claimableAmount: rewardsCount } = useChallengeCooldownSchedule({
+    multiple: true
+  })
 
   const search = (query: string) => {
     history.push({
@@ -70,9 +74,9 @@ const ConnectedNavBar = ({
     setStackReset(true)
   }, [setStackReset])
 
-  const goToAudioPage = useCallback(() => {
+  const goToRewardsPage = useCallback(() => {
     setStackReset(true)
-    setImmediate(() => goToRoute(AUDIO_PAGE))
+    setImmediate(() => goToRoute(REWARDS_PAGE))
   }, [goToRoute, setStackReset])
 
   return (
@@ -81,13 +85,14 @@ const ConnectedNavBar = ({
       isLoading={accountStatus === Status.LOADING}
       signUp={signUp}
       notificationCount={notificationCount}
+      rewardsCount={rewardsCount}
       goToNotificationPage={goToNotificationPage}
       goToSettingsPage={goToSettingsPage}
       search={search}
       searchStatus={searchStatus}
       goBack={goBack}
       history={history}
-      goToAudioPage={goToAudioPage}
+      goToRewardsPage={goToRewardsPage}
     />
   )
 }

--- a/packages/web/src/components/nav/mobile/NavBar.tsx
+++ b/packages/web/src/components/nav/mobile/NavBar.tsx
@@ -5,11 +5,11 @@ import { formatCount, route } from '@audius/common/utils'
 import {
   IconAudiusLogoHorizontal,
   IconSettings,
-  IconCrown,
   IconCaretLeft,
   IconClose,
   IconNotificationOn,
-  IconButton
+  IconButton,
+  IconGift
 } from '@audius/harmony'
 import cn from 'classnames'
 import { History } from 'history'
@@ -39,10 +39,11 @@ interface NavBarProps {
   isSignedIn: boolean
   searchStatus: Status
   notificationCount: number
+  rewardsCount: number
   signUp: () => void
   goToNotificationPage: () => void
   goToSettingsPage: () => void
-  goToAudioPage: () => void
+  goToRewardsPage: () => void
   search: (term: string) => void
   goBack: () => void
   history: History<any>
@@ -58,12 +59,13 @@ const NavBar = ({
   isSignedIn,
   searchStatus,
   notificationCount,
+  rewardsCount,
   search,
   signUp,
   goToNotificationPage,
   goToSettingsPage,
   goBack,
-  goToAudioPage,
+  goToRewardsPage,
   history: {
     location: { pathname }
   }
@@ -173,6 +175,15 @@ const NavBar = ({
         {notificationCount > 0 && (
           <div className={styles.iconTag}>{formatCount(notificationCount)}</div>
         )}
+        <IconButton
+          aria-label='audio rewards'
+          color={rewardsCount > 0 ? 'warning' : 'subdued'}
+          icon={IconGift}
+          onClick={goToRewardsPage}
+        />
+        {rewardsCount > 0 && (
+          <div className={styles.iconTag}>{formatCount(rewardsCount)}</div>
+        )}
       </>
     )
   } else if (leftElement === LeftPreset.SETTINGS && isSignedIn) {
@@ -186,10 +197,13 @@ const NavBar = ({
         />
         <IconButton
           aria-label='audio rewards'
-          color='warning'
-          icon={IconCrown}
-          onClick={goToAudioPage}
+          color={rewardsCount > 0 ? 'warning' : 'subdued'}
+          icon={IconGift}
+          onClick={goToRewardsPage}
         />
+        {rewardsCount > 0 && (
+          <div className={styles.iconTag}>{formatCount(rewardsCount)}</div>
+        )}
       </>
     )
   } else {

--- a/packages/web/src/pages/settings-page/components/mobile/SettingsPage.tsx
+++ b/packages/web/src/pages/settings-page/components/mobile/SettingsPage.tsx
@@ -12,7 +12,13 @@ import {
 import { route } from '@audius/common/utils'
 import {
   SegmentedControl,
-  IconAudiusLogoHorizontalColor
+  IconAudiusLogoHorizontalColor,
+  IconLogoCircleUSDCPng,
+  IconTokenNoTier,
+  IconTokenBronze,
+  IconTokenSilver,
+  IconTokenGold,
+  IconTokenPlatinum
 } from '@audius/harmony'
 import cn from 'classnames'
 import { useDispatch, useSelector } from 'react-redux'
@@ -50,7 +56,9 @@ const {
   ACCOUNT_SETTINGS_PAGE,
   HISTORY_PAGE,
   ABOUT_SETTINGS_PAGE,
-  NOTIFICATION_SETTINGS_PAGE
+  NOTIFICATION_SETTINGS_PAGE,
+  AUDIO_PAGE,
+  PAYMENTS_PAGE
 } = route
 
 const isStaging = env.ENVIRONMENT === 'staging'
@@ -74,6 +82,8 @@ const messages = {
   title: 'Settings',
   description: 'Configure your Audius account',
   historyTitle: 'Listening History',
+  usdcWallets: 'USDC Wallet',
+  audioWallet: '$AUDIO Wallet',
   matrixMode: 'Matrix'
 }
 
@@ -178,6 +188,14 @@ export const SettingsPage = (props: SettingsPageProps) => {
     )
   }
 
+  const TierIcon = {
+    none: IconTokenNoTier,
+    bronze: IconTokenBronze,
+    silver: IconTokenSilver,
+    gold: IconTokenGold,
+    platinum: IconTokenPlatinum
+  }[tier]
+
   return (
     <Page
       title={messages.title}
@@ -211,6 +229,16 @@ export const SettingsPage = (props: SettingsPageProps) => {
               prefix={<i className='emoji small headphone' />}
               title={messages.historyTitle}
               to={HISTORY_PAGE}
+            />
+            <Row
+              prefix={<IconLogoCircleUSDCPng size='s' />}
+              title={messages.usdcWallets}
+              to={PAYMENTS_PAGE}
+            />
+            <Row
+              prefix={<TierIcon size='s' />}
+              title={messages.audioWallet}
+              to={AUDIO_PAGE}
             />
           </Grouping>
           <Grouping>


### PR DESCRIPTION
### Description

Settings Page
    ◦ Add two rows that link to USDC & $AUDIO wallets
Header Icon
    ◦ updated to appear on all top level pages, beside the notification icon, in addition to the profile page.
    ◦ Link to /rewards instead of /audio
    ◦ Change from crown icon -> gift icon
    ◦ set icon to our subdued color value

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._
<img src='https://github.com/user-attachments/assets/528cd670-f288-4a3d-9bc5-3bc1b5e8cbea' width='200' />
<img src='https://github.com/user-attachments/assets/dfee0e6a-c27a-40c4-b640-3cc328cfdfaa' width='200' />
<img src='https://github.com/user-attachments/assets/8403e6b9-5d38-4278-9b57-d213df9251fb' width='200' />
<img src='https://github.com/user-attachments/assets/27a86246-89b3-460f-853e-ece7c1dc5b6f' width='200' />
<img src='https://github.com/user-attachments/assets/2929ffcf-8f8f-4748-987f-ab29d8e735d5' width='200' />

