### PR TITLE
Add support for add/remove associated wallet txs

### DIFF
--- a/packages/discovery-provider/integration_tests/tasks/entity_manager/test_user_entity_manager.py
+++ b/packages/discovery-provider/integration_tests/tasks/entity_manager/test_user_entity_manager.py
@@ -1575,6 +1575,12 @@ def test_add_associated_wallet(app, mocker):
     def get_events_side_effect(_, tx_receipt):
         return tx_receipts[tx_receipt["transactionHash"].decode("utf-8")]
 
+    mocker.patch(
+        "src.tasks.entity_manager.entity_manager.get_entity_manager_events_tx",
+        side_effect=get_events_side_effect,
+        autospec=True,
+    )
+
     # Mock signature validation
     def mock_validate_signature(chain, web3, user_id, wallet, signature):
         if signature == "0xvalid_signature":

--- a/packages/discovery-provider/src/tasks/entity_manager/entity_manager.py
+++ b/packages/discovery-provider/src/tasks/entity_manager/entity_manager.py
@@ -98,7 +98,13 @@ from src.tasks.entity_manager.entities.track import (
     download_track,
     update_track,
 )
-from src.tasks.entity_manager.entities.user import create_user, update_user, verify_user
+from src.tasks.entity_manager.entities.user import (
+    add_associated_wallet,
+    create_user,
+    remove_associated_wallet,
+    update_user,
+    verify_user,
+)
 from src.tasks.entity_manager.utils import (
     MANAGE_ENTITY_EVENT_TYPE,
     Action,
@@ -440,6 +446,16 @@ def entity_manager_update(
                         and params.entity_type == EntityType.EMAIL_ACCESS
                     ):
                         grant_email_access(params)
+                    elif (
+                        params.action == Action.CREATE
+                        and params.entity_type == EntityType.ASSOCIATED_WALLET
+                    ):
+                        add_associated_wallet(params)
+                    elif (
+                        params.action == Action.DELETE
+                        and params.entity_type == EntityType.ASSOCIATED_WALLET
+                    ):
+                        remove_associated_wallet(params)
 
                     logger.debug("process transaction")  # log event context
                 except IndexingValidationError as e:
@@ -833,6 +849,8 @@ def collect_entities_to_fetch(update_task, entity_manager_txs):
                     entities_to_fetch[EntityType.ENCRYPTED_EMAIL].add(
                         email_owner_user_id
                     )
+            if entity_type == EntityType.ASSOCIATED_WALLET:
+                entities_to_fetch[EntityType.ASSOCIATED_WALLET].add(user_id)
 
     return entities_to_fetch
 

--- a/packages/discovery-provider/src/tasks/entity_manager/utils.py
+++ b/packages/discovery-provider/src/tasks/entity_manager/utils.py
@@ -34,12 +34,15 @@ from src.models.social.save import Save
 from src.models.social.subscription import Subscription
 from src.models.tracks.track import Track
 from src.models.tracks.track_route import TrackRoute
+from src.models.users.associated_wallet import AssociatedWallet
 from src.models.users.user import User
 from src.solana.solana_client_manager import SolanaClientManager
 from src.tasks.metadata import (
+    add_associated_wallet_metadata_format,
     comment_metadata_format,
     encrypted_email_metadata_format,
     playlist_metadata_format,
+    remove_associated_wallet_metadata_format,
     track_comment_notification_setting_format,
     track_download_metadata_format,
     track_metadata_format,
@@ -164,6 +167,7 @@ class RecordDict(TypedDict):
 
 
 class ExistingRecordDict(TypedDict):
+    AssociatedWallet: Dict[str, AssociatedWallet]
     Playlist: Dict[int, Playlist]
     Track: Dict[int, Track]
     UserWallet: Dict[str, User]
@@ -369,6 +373,17 @@ def get_metadata_type_and_format(entity_type, action=None):
     elif entity_type == EntityType.ENCRYPTED_EMAIL:
         metadata_type = "encrypted_email"
         metadata_format = encrypted_email_metadata_format
+    elif (
+        entity_type == EntityType.ASSOCIATED_WALLET
+        and action == Action.CREATE
+        or action == Action.DELETE
+    ):
+        metadata_type = "associated_wallet"
+        metadata_format = (
+            add_associated_wallet_metadata_format
+            if action == Action.CREATE
+            else remove_associated_wallet_metadata_format
+        )
     else:
         raise IndexingValidationError(f"Unknown metadata type ${entity_type}")
     return metadata_type, metadata_format

--- a/packages/discovery-provider/src/tasks/metadata.py
+++ b/packages/discovery-provider/src/tasks/metadata.py
@@ -261,6 +261,17 @@ encrypted_email_metadata_format = {
     "access_grants": None,
 }
 
+add_associated_wallet_metadata_format = {
+    "wallet_address": None,
+    "chain": None,
+    "signature": None,
+}
+
+remove_associated_wallet_metadata_format = {
+    "wallet_address": None,
+    "chain": None,
+}
+
 
 class PlaylistMetadata(TypedDict):
     playlist_contents: Optional[Any]


### PR DESCRIPTION
### Description
This adds EntityManager indexing support for adding or removing associated wallets via transactions with type `AssociatedWallet` and actions `Create` and `Delete`. Most of the support was already there due to the code paths for updating a user record. I also added some tests.
This is in preparation for corresponding client changes that will split wallet association out into separate transactions and remove support for updating it via the user entity.

### How Has This Been Tested?
Test via DN integration tests only for now.
