### PR TITLE
[QA-1952] Allow albums to be edited to be gated

### DIFF
--- a/packages/web/src/common/store/cache/collections/commonSagas.ts
+++ b/packages/web/src/common/store/cache/collections/commonSagas.ts
@@ -1,4 +1,5 @@
 import {
+  albumMetadataForSDK,
   fileToSdk,
   playlistMetadataForUpdateWithSDK,
   userCollectionMetadataFromSDK
@@ -203,15 +204,25 @@ function* confirmEditPlaylist(
             ? formFields.artwork.file
             : undefined
 
-        yield* call([sdk.playlists, sdk.playlists.updatePlaylist], {
-          coverArtFile: coverArtFile
-            ? fileToSdk(coverArtFile, 'cover_art')
-            : undefined,
-          metadata: playlistMetadataForUpdateWithSDK(formFields),
-          userId: Id.parse(userId),
-          playlistId: Id.parse(playlistId)
-        })
-
+        if (formFields.is_album) {
+          yield* call([sdk.albums, sdk.albums.updateAlbum], {
+            coverArtFile: coverArtFile
+              ? fileToSdk(coverArtFile, 'cover_art')
+              : undefined,
+            metadata: albumMetadataForSDK(formFields),
+            userId: Id.parse(userId),
+            albumId: Id.parse(playlistId)
+          })
+        } else {
+          yield* call([sdk.playlists, sdk.playlists.updatePlaylist], {
+            coverArtFile: coverArtFile
+              ? fileToSdk(coverArtFile, 'cover_art')
+              : undefined,
+            metadata: playlistMetadataForUpdateWithSDK(formFields),
+            userId: Id.parse(userId),
+            playlistId: Id.parse(playlistId)
+          })
+        }
         const { data: playlist } = yield* call(
           [sdk.full.playlists, sdk.full.playlists.getPlaylist],
           {


### PR DESCRIPTION
### Description

Album edits weren't being respected in the saga, thus no album-specific fields were being sent to the update

### How Has This Been Tested?

Tested locally against dev env