### PR TITLE
[QA-19556 Prevent metamask modal popup

### DIFF
--- a/packages/common/src/services/auth/identity.ts
+++ b/packages/common/src/services/auth/identity.ts
@@ -64,7 +64,7 @@ export class IdentityService {
   // #region: Internal Functions
   private async _getSignatureHeaders() {
     const audiusWalletClient = await this.getAudiusWalletClient({
-      ignoreCachedUserWallet: true
+      ignoreCachedUserWallet: false
     })
     const [currentAddress] = await audiusWalletClient.getAddresses()
     if (!currentAddress) {


### PR DESCRIPTION
### Description

This prevents the issue where the metamask modal can open for signed-in users.
This breaks metamask sign-in which will be fixed separately