### PR TITLE
[C-5720] Batch setQueryData

### DIFF
--- a/packages/common/src/api/tan-query/useSupportedUsers.ts
+++ b/packages/common/src/api/tan-query/useSupportedUsers.ts
@@ -11,6 +11,7 @@ import { QUERY_KEYS } from './queryKeys'
 import { QueryOptions } from './types'
 import { useCurrentUserId } from './useCurrentUserId'
 import { getSupporterQueryKey } from './useSupporter'
+import { batchSetQueriesData } from './utils/batchSetQueriesData'
 import { primeUserData } from './utils/primeUserData'
 
 type UseSupportedUsersArgs = {
@@ -50,12 +51,16 @@ export const useSupportedUsers = (
       const supporting = supportedUserMetadataListFromSDK(data)
 
       // Prime the cache for each supporter
-      supporting.forEach((supportedUser) => {
-        queryClient.setQueryData(
-          getSupporterQueryKey(supportedUser.receiver.user_id, userId),
-          supportedUser
-        )
-      })
+      batchSetQueriesData(
+        queryClient,
+        supporting.map((supportedUser) => ({
+          queryKey: getSupporterQueryKey(
+            supportedUser.receiver.user_id,
+            userId
+          ),
+          data: supportedUser
+        }))
+      )
 
       primeUserData({
         users: supporting.map((supportedUser) => supportedUser.receiver),

--- a/packages/common/src/api/tan-query/useSupporters.ts
+++ b/packages/common/src/api/tan-query/useSupporters.ts
@@ -10,6 +10,7 @@ import { QUERY_KEYS } from './queryKeys'
 import { QueryOptions } from './types'
 import { useCurrentUserId } from './useCurrentUserId'
 import { getSupporterQueryKey } from './useSupporter'
+import { batchSetQueriesData } from './utils/batchSetQueriesData'
 import { primeUserData } from './utils/primeUserData'
 
 const DEFAULT_PAGE_SIZE = 20
@@ -51,12 +52,13 @@ export const useSupporters = (
       const supporters = supporterMetadataListFromSDK(data)
 
       // Prime the cache for each supporter
-      supporters.forEach((supporter) => {
-        queryClient.setQueryData(
-          getSupporterQueryKey(userId, supporter.sender.user_id),
-          supporter
-        )
-      })
+      batchSetQueriesData(
+        queryClient,
+        supporters.map((supporter) => ({
+          queryKey: getSupporterQueryKey(userId, supporter.sender.user_id),
+          data: supporter
+        }))
+      )
 
       primeUserData({
         users: supporters.map((supporter) => supporter.sender),

--- a/packages/common/src/api/tan-query/useUpdateCollection.ts
+++ b/packages/common/src/api/tan-query/useUpdateCollection.ts
@@ -21,6 +21,7 @@ import {
   useCurrentUserId
 } from '..'
 
+import { batchSetQueriesData, QueryKeyValue } from './utils/batchSetQueriesData'
 import { primeCollectionData } from './utils/primeCollectionData'
 
 type MutationContext = {
@@ -186,16 +187,19 @@ export const useUpdateCollection = () => {
     onError: (_err, { collectionId }, context?: MutationContext) => {
       // If the mutation fails, roll back collection data
       if (context?.previousCollection) {
-        queryClient.setQueryData(
-          getCollectionQueryKey(collectionId),
-          context.previousCollection
-        )
-        queryClient.setQueryData(
-          getCollectionByPermalinkQueryKey(
-            context.previousCollection.permalink
-          ),
-          context.previousCollection
-        )
+        const updates: QueryKeyValue[] = [
+          {
+            queryKey: getCollectionQueryKey(collectionId),
+            data: context.previousCollection
+          },
+          {
+            queryKey: getCollectionByPermalinkQueryKey(
+              context.previousCollection.permalink
+            ),
+            data: context.previousCollection
+          }
+        ]
+        batchSetQueriesData(queryClient, updates)
       }
     },
     onSettled: (_, __, { collectionId }) => {

--- a/packages/common/src/api/tan-query/useUpdateUser.ts
+++ b/packages/common/src/api/tan-query/useUpdateUser.ts
@@ -10,6 +10,7 @@ import { UserMetadata } from '~/models/User'
 import { QUERY_KEYS } from './queryKeys'
 import { getUserQueryKey } from './useUser'
 import { getUserByHandleQueryKey } from './useUserByHandle'
+import { batchSetQueriesData, QueryKeyValue } from './utils/batchSetQueriesData'
 
 type MutationContext = {
   previousUser: UserMetadata | undefined
@@ -65,155 +66,189 @@ export const useUpdateUser = () => {
         })
         .find(([_, data]) => data?.user_id === userId)?.[1]
 
-      // Optimistically update user
-      queryClient.setQueryData(getUserQueryKey(userId), (old: any) => ({
-        ...old,
-        ...metadata
-      }))
-
-      // Optimistically update userByHandle queries if they match the user
-      queryClient.setQueryData(
-        getUserByHandleQueryKey(metadata.handle),
-        (old: any) => ({ ...old, ...metadata })
-      )
-
-      // Optimistically update accountUser queries if they match the user
-      queryClient.setQueriesData(
-        { queryKey: [QUERY_KEYS.accountUser] },
-        (oldData: any) => {
-          if (!oldData?.user_id || oldData.user_id !== userId) return oldData
-          return { ...oldData, ...metadata }
+      const updates: QueryKeyValue[] = [
+        // User and handle updates
+        {
+          queryKey: getUserQueryKey(userId),
+          data: { ...previousUser, ...metadata }
+        },
+        {
+          queryKey: getUserByHandleQueryKey(metadata.handle),
+          data: { ...previousUser, ...metadata }
         }
-      )
+      ]
 
-      // Optimistically update all tracks that contain this user
-      queryClient.setQueriesData(
-        { queryKey: [QUERY_KEYS.track] },
-        (oldData: any) => {
-          if (!oldData?.user || oldData.user.id !== userId) return oldData
-          return {
-            ...oldData,
+      // Add accountUser updates
+      const accountUserQueries = queryClient.getQueriesData<UserMetadata>({
+        queryKey: [QUERY_KEYS.accountUser]
+      })
+      accountUserQueries.forEach(([queryKey, data]) => {
+        if (data?.user_id === userId) {
+          updates.push({
+            queryKey: [...queryKey],
+            data: { ...data, ...metadata }
+          })
+        }
+      })
+
+      // Add track updates
+      const trackQueries = queryClient.getQueriesData<any>({
+        queryKey: [QUERY_KEYS.track]
+      })
+      trackQueries.forEach(([queryKey, data]) => {
+        if (data?.user?.id === userId) {
+          updates.push({
+            queryKey: [...queryKey],
+            data: {
+              ...data,
+              user: {
+                ...data.user,
+                ...metadata
+              }
+            }
+          })
+        }
+      })
+
+      // Add collection updates
+      const collectionQueries = queryClient.getQueriesData<any>({
+        queryKey: [QUERY_KEYS.collection]
+      })
+      collectionQueries.forEach(([queryKey, data]) => {
+        if (!data) return
+
+        let updatedData = data
+
+        // Update collection if the user is the owner
+        if (data.user?.id === userId) {
+          updatedData = {
+            ...updatedData,
             user: {
-              ...oldData.user,
+              ...data.user,
               ...metadata
             }
           }
         }
-      )
 
-      // Optimistically update all collections
-      queryClient.setQueriesData(
-        { queryKey: [QUERY_KEYS.collection] },
-        (oldData: any) => {
-          if (!oldData) return oldData
-
-          let updatedData = oldData
-
-          // Update collection if the user is the owner
-          if (oldData.user?.id === userId) {
-            updatedData = {
-              ...oldData,
-              user: {
-                ...oldData.user,
-                ...metadata
-              }
-            }
-          }
-
-          // Update collection if the user appears in any of the tracks
-          if (oldData.tracks?.some((track: any) => track.user?.id === userId)) {
-            updatedData = {
-              ...updatedData,
-              tracks: oldData.tracks.map((track: any) =>
-                track.user?.id === userId
-                  ? {
-                      ...track,
-                      user: {
-                        ...track.user,
-                        ...metadata
-                      }
+        // Update collection if the user appears in any of the tracks
+        if (data.tracks?.some((track: any) => track.user?.id === userId)) {
+          updatedData = {
+            ...updatedData,
+            tracks: data.tracks.map((track: any) =>
+              track.user?.id === userId
+                ? {
+                    ...track,
+                    user: {
+                      ...track.user,
+                      ...metadata
                     }
-                  : track
-              )
-            }
+                  }
+                : track
+            )
           }
-
-          return updatedData
         }
-      )
+
+        if (updatedData !== data) {
+          updates.push({
+            queryKey: [...queryKey],
+            data: updatedData
+          })
+        }
+      })
+
+      batchSetQueriesData(queryClient, updates)
 
       // Return context with the previous user
       return { previousUser, previousAccountUser }
     },
     onError: (_err, { userId }, context?: MutationContext) => {
       // If the mutation fails, roll back user data
-      if (context?.previousUser) {
-        queryClient.setQueryData(getUserQueryKey(userId), context.previousUser)
+      const updates: QueryKeyValue[] = []
 
-        // Roll back userByHandle queries
-        queryClient.setQueryData(
-          getUserByHandleQueryKey(context.previousUser?.handle),
-          context.previousUser
+      // Roll back user data
+      if (context?.previousUser) {
+        updates.push(
+          {
+            queryKey: getUserQueryKey(userId),
+            data: context.previousUser
+          },
+          {
+            queryKey: getUserByHandleQueryKey(context.previousUser.handle),
+            data: context.previousUser
+          }
         )
       }
 
       // Roll back accountUser queries if we have the previous state
       if (context?.previousAccountUser) {
-        queryClient.setQueriesData(
-          { queryKey: [QUERY_KEYS.accountUser] },
-          (oldData: any) => {
-            if (!oldData?.user_id || oldData.user_id !== userId) return oldData
-            return context.previousAccountUser
-          }
-        )
+        const accountUserQueries = queryClient.getQueriesData<any>({
+          queryKey: [QUERY_KEYS.accountUser]
+        })
+        accountUserQueries.forEach(([queryKey, oldData]) => {
+          if (!oldData?.user_id || oldData.user_id !== userId) return
+          updates.push({
+            queryKey: [...queryKey],
+            data: context.previousAccountUser
+          })
+        })
       }
 
       // Roll back all tracks that contain this user
-      queryClient.setQueriesData(
-        { queryKey: [QUERY_KEYS.track] },
-        (oldData: any) => {
-          if (!oldData?.user || oldData.user.id !== userId) return oldData
-          return {
+      const trackQueries = queryClient.getQueriesData<any>({
+        queryKey: [QUERY_KEYS.track]
+      })
+      trackQueries.forEach(([queryKey, oldData]) => {
+        if (!oldData?.user || oldData.user.id !== userId) return
+        updates.push({
+          queryKey: [...queryKey],
+          data: {
+            ...oldData,
+            user: context?.previousUser
+          }
+        })
+      })
+
+      // Roll back all collections
+      const collectionQueries = queryClient.getQueriesData<any>({
+        queryKey: [QUERY_KEYS.collection]
+      })
+      collectionQueries.forEach(([queryKey, oldData]) => {
+        if (!oldData) return
+
+        let updatedData = oldData
+
+        // Roll back collection if the user is the owner
+        if (oldData.user?.id === userId) {
+          updatedData = {
             ...oldData,
             user: context?.previousUser
           }
         }
-      )
 
-      // Roll back all collections
-      queryClient.setQueriesData(
-        { queryKey: [QUERY_KEYS.collection] },
-        (oldData: any) => {
-          if (!oldData) return oldData
-
-          let updatedData = oldData
-
-          // Roll back collection if the user is the owner
-          if (oldData.user?.id === userId) {
-            updatedData = {
-              ...oldData,
-              user: context?.previousUser
-            }
+        // Roll back collection if the user appears in any of the tracks
+        if (oldData.tracks?.some((track: any) => track.user?.id === userId)) {
+          updatedData = {
+            ...updatedData,
+            tracks: oldData.tracks.map((track: any) =>
+              track.user?.id === userId
+                ? {
+                    ...track,
+                    user: context?.previousUser
+                  }
+                : track
+            )
           }
-
-          // Roll back collection if the user appears in any of the tracks
-          if (oldData.tracks?.some((track: any) => track.user?.id === userId)) {
-            updatedData = {
-              ...updatedData,
-              tracks: oldData.tracks.map((track: any) =>
-                track.user?.id === userId
-                  ? {
-                      ...track,
-                      user: context?.previousUser
-                    }
-                  : track
-              )
-            }
-          }
-
-          return updatedData
         }
-      )
+
+        if (updatedData !== oldData) {
+          updates.push({
+            queryKey: [...queryKey],
+            data: updatedData
+          })
+        }
+      })
+
+      batchSetQueriesData(queryClient, updates)
     },
     onSettled: (_, __) => {
       // Always refetch after error or success to ensure cache is in sync with server

--- a/packages/common/src/api/tan-query/useUser.ts
+++ b/packages/common/src/api/tan-query/useUser.ts
@@ -5,14 +5,11 @@ import { useDispatch, useSelector } from 'react-redux'
 import { userMetadataListFromSDK } from '~/adapters/user'
 import { useAudiusQueryContext } from '~/audius-query'
 import { ID } from '~/models/Identifiers'
-import { Kind } from '~/models/Kind'
 import { getUserId } from '~/store/account/selectors'
-import { addEntries } from '~/store/cache/actions'
-import { EntriesByKind } from '~/store/cache/types'
 
 import { QUERY_KEYS } from './queryKeys'
 import { QueryOptions } from './types'
-import { getUserByHandleQueryKey } from './useUserByHandle'
+import { primeUserData } from './utils/primeUserData'
 
 export const getUserQueryKey = (userId: ID | null | undefined) => [
   QUERY_KEYS.user,
@@ -40,16 +37,11 @@ export const useUser = (
 
       // Prime both user and userByHandle caches
       if (user) {
-        queryClient.setQueryData(getUserByHandleQueryKey(user.handle), user)
-
-        // Sync user data to Redux
-        const entries: EntriesByKind = {
-          [Kind.USERS]: {
-            [user.user_id]: user
-          }
-        }
-
-        dispatch(addEntries(entries, undefined, undefined, 'react-query'))
+        primeUserData({
+          users: [user],
+          queryClient,
+          dispatch
+        })
       }
 
       return user

--- a/packages/common/src/api/tan-query/useUserByHandle.ts
+++ b/packages/common/src/api/tan-query/useUserByHandle.ts
@@ -4,14 +4,11 @@ import { useDispatch } from 'react-redux'
 
 import { userMetadataListFromSDK } from '~/adapters/user'
 import { useAudiusQueryContext } from '~/audius-query'
-import { Kind } from '~/models/Kind'
-import { addEntries } from '~/store/cache/actions'
-import { EntriesByKind } from '~/store/cache/types'
 
 import { QUERY_KEYS } from './queryKeys'
 import { QueryOptions } from './types'
 import { useCurrentUserId } from './useCurrentUserId'
-import { getUserQueryKey } from './useUser'
+import { primeUserData } from './utils/primeUserData'
 
 export const getUserByHandleQueryKey = (handle: string | null | undefined) => [
   QUERY_KEYS.userByHandle,
@@ -40,16 +37,11 @@ export const useUserByHandle = (
 
       // Prime the user query cache with user data
       if (user) {
-        queryClient.setQueryData(getUserQueryKey(user.user_id), user)
-
-        // Sync user data to Redux
-        const entries: EntriesByKind = {
-          [Kind.USERS]: {
-            [user.user_id]: user
-          }
-        }
-
-        dispatch(addEntries(entries, undefined, undefined, 'react-query'))
+        primeUserData({
+          users: [user],
+          queryClient,
+          dispatch
+        })
       }
 
       return user

--- a/packages/common/src/api/tan-query/utils/batchSetQueriesData.ts
+++ b/packages/common/src/api/tan-query/utils/batchSetQueriesData.ts
@@ -1,7 +1,7 @@
 import { QueryClient } from '@tanstack/react-query'
 
 export type QueryKeyValue<T = any> = {
-  queryKey: unknown[]
+  queryKey: any[]
   data: T
 }
 

--- a/packages/common/src/api/tan-query/utils/batchSetQueriesData.ts
+++ b/packages/common/src/api/tan-query/utils/batchSetQueriesData.ts
@@ -1,0 +1,38 @@
+import { QueryClient } from '@tanstack/react-query'
+
+export type QueryKeyValue<T = any> = {
+  queryKey: unknown[]
+  data: T
+}
+
+/**
+ * Utility function to batch update multiple queries at once.
+ * This is useful when you need to update multiple related queries with new data.
+ *
+ * @param queryClient - The QueryClient instance
+ * @param updates - Array of objects containing queryKey and data to update
+ * @param options - Optional configuration for setQueriesData
+ * @returns void
+ *
+ * @example
+ * ```typescript
+ * batchSetQueriesData(queryClient, [
+ *   { queryKey: ['user', 123], data: updatedUserData },
+ *   { queryKey: ['tracks', 'by-user', 123], data: updatedTracks }
+ * ])
+ * ```
+ */
+export const batchSetQueriesData = (
+  queryClient: QueryClient,
+  updates: QueryKeyValue[],
+  options?: {
+    updater: (oldData: any, newData: any) => any
+  }
+) => {
+  updates.forEach(({ queryKey, data }) => {
+    queryClient.setQueriesData(
+      { queryKey },
+      options?.updater ? (oldData: any) => options.updater(oldData, data) : data
+    )
+  })
+}

--- a/packages/common/src/api/tan-query/utils/batchSetQueriesData.ts
+++ b/packages/common/src/api/tan-query/utils/batchSetQueriesData.ts
@@ -1,4 +1,4 @@
-import { QueryClient } from '@tanstack/react-query'
+import { notifyManager, QueryClient } from '@tanstack/react-query'
 
 export type QueryKeyValue<T = any> = {
   queryKey: any[]
@@ -29,10 +29,14 @@ export const batchSetQueriesData = (
     updater: (oldData: any, newData: any) => any
   }
 ) => {
-  updates.forEach(({ queryKey, data }) => {
-    queryClient.setQueriesData(
-      { queryKey },
-      options?.updater ? (oldData: any) => options.updater(oldData, data) : data
-    )
+  notifyManager.batch(() => {
+    updates.forEach(({ queryKey, data }) => {
+      queryClient.setQueriesData(
+        { queryKey },
+        options?.updater
+          ? (oldData: any) => options.updater(oldData, data)
+          : data
+      )
+    })
   })
 }

--- a/packages/common/src/api/tan-query/utils/batchSetQueriesEntries.ts
+++ b/packages/common/src/api/tan-query/utils/batchSetQueriesEntries.ts
@@ -21,16 +21,19 @@ export const batchSetQueriesEntries = ({
   const queryEntries: QueryKeyValue[] = Object.entries(entries).flatMap(
     ([kind, entries]) =>
       Object.entries(entries).flatMap(([id, entry]) => {
-        let queryKey = null
         const results: QueryKeyValue[] = []
         switch (kind) {
           case Kind.USERS:
-            queryKey = getUserQueryKey(parseInt(id))
-            results.push({ queryKey, data: entry })
+            results.push({
+              queryKey: getUserQueryKey(parseInt(id)),
+              data: entry
+            })
             break
           case Kind.TRACKS:
-            queryKey = getTrackQueryKey(parseInt(id))
-            results.push({ queryKey, data: entry })
+            results.push({
+              queryKey: getTrackQueryKey(parseInt(id)),
+              data: entry
+            })
             if ('permalink' in entry) {
               results.push({
                 queryKey: getTrackByPermalinkQueryKey(entry.permalink),
@@ -39,8 +42,10 @@ export const batchSetQueriesEntries = ({
             }
             break
           case Kind.COLLECTIONS:
-            queryKey = getCollectionQueryKey(parseInt(id))
-            results.push({ queryKey, data: entry })
+            results.push({
+              queryKey: getCollectionQueryKey(parseInt(id)),
+              data: entry
+            })
             if ('permalink' in entry) {
               results.push({
                 queryKey: getCollectionByPermalinkQueryKey(entry.permalink),

--- a/packages/common/src/api/tan-query/utils/batchSetQueriesEntries.ts
+++ b/packages/common/src/api/tan-query/utils/batchSetQueriesEntries.ts
@@ -1,0 +1,56 @@
+import { QueryClient } from '@tanstack/react-query'
+
+import { Kind } from '~/models/Kind'
+import { EntriesByKind } from '~/store/cache/types'
+
+import { getCollectionQueryKey } from '../useCollection'
+import { getCollectionByPermalinkQueryKey } from '../useCollectionByPermalink'
+import { getTrackQueryKey } from '../useTrack'
+import { getTrackByPermalinkQueryKey } from '../useTrackByPermalink'
+import { getUserQueryKey } from '../useUser'
+
+import { batchSetQueriesData, QueryKeyValue } from './batchSetQueriesData'
+
+export const batchSetQueriesEntries = ({
+  entries,
+  queryClient
+}: {
+  entries: EntriesByKind
+  queryClient: QueryClient
+}) => {
+  const queryEntries: QueryKeyValue[] = Object.entries(entries).flatMap(
+    ([kind, entries]) =>
+      Object.entries(entries).flatMap(([id, entry]) => {
+        let queryKey = null
+        const results: QueryKeyValue[] = []
+        switch (kind) {
+          case Kind.USERS:
+            queryKey = getUserQueryKey(parseInt(id))
+            results.push({ queryKey, data: entry })
+            break
+          case Kind.TRACKS:
+            queryKey = getTrackQueryKey(parseInt(id))
+            results.push({ queryKey, data: entry })
+            if ('permalink' in entry) {
+              results.push({
+                queryKey: getTrackByPermalinkQueryKey(entry.permalink),
+                data: entry
+              })
+            }
+            break
+          case Kind.COLLECTIONS:
+            queryKey = getCollectionQueryKey(parseInt(id))
+            results.push({ queryKey, data: entry })
+            if ('permalink' in entry) {
+              results.push({
+                queryKey: getCollectionByPermalinkQueryKey(entry.permalink),
+                data: entry
+              })
+            }
+            break
+        }
+        return results
+      })
+  )
+  batchSetQueriesData(queryClient, queryEntries)
+}

--- a/packages/common/src/api/tan-query/utils/primeUserData.ts
+++ b/packages/common/src/api/tan-query/utils/primeUserData.ts
@@ -1,14 +1,12 @@
 import { QueryClient } from '@tanstack/react-query'
 import { AnyAction, Dispatch } from 'redux'
-import { SetRequired } from 'type-fest'
 
 import { Kind } from '~/models'
 import { User } from '~/models/User'
 import { addEntries } from '~/store/cache/actions'
 import { EntriesByKind } from '~/store/cache/types'
 
-import { getUserQueryKey } from '../useUser'
-import { getUserByHandleQueryKey } from '../useUserByHandle'
+import { batchSetQueriesEntries } from './batchSetQueriesEntries'
 
 export const primeUserData = ({
   users,
@@ -21,36 +19,13 @@ export const primeUserData = ({
   dispatch: Dispatch<AnyAction>
   forceReplace?: boolean
 }) => {
-  const entries = primeUserDataInternal({ users, queryClient })
+  const entries = collectUserEntries(users)
   dispatch(addEntries(entries, forceReplace, undefined, 'react-query'))
+  batchSetQueriesEntries({ entries, queryClient })
 }
 
-export const primeUserDataInternal = ({
-  users,
-  queryClient
-}: {
-  users: User[]
-  queryClient: QueryClient
-}): EntriesByKind => {
-  const entries: SetRequired<EntriesByKind, Kind.USERS> = {
-    [Kind.USERS]: {}
+export const collectUserEntries = (users: User[]): EntriesByKind => {
+  return {
+    [Kind.USERS]: Object.fromEntries(users.map((user) => [user.user_id, user]))
   }
-
-  users.forEach((user) => {
-    // Prime user by ID
-    if (!queryClient.getQueryData(getUserQueryKey(user.user_id))) {
-      queryClient.setQueryData(getUserQueryKey(user.user_id), user)
-    }
-    // Prime user by handle
-    if (
-      user.handle &&
-      !queryClient.getQueryData(getUserByHandleQueryKey(user.handle))
-    ) {
-      queryClient.setQueryData(getUserByHandleQueryKey(user.handle), user)
-    }
-
-    entries[Kind.USERS][user.user_id] = user
-  })
-
-  return entries
 }


### PR DESCRIPTION
### Description

- add `batchSetQueriesData` to atomically set multiple values in tan-query cache
	- we should call this whenever we're calling `setQueryData`/`setQueriesData` in a loop or multiple times in a scope
- adopted `batchSetQueriesData` throughout tan-query hooks
- refactored `syncWithReactQuery` to collect all updates into one batch

Follow ups:
- Potentially can use https://github.com/yornaath/batshit to shim `setQueryData` and have it automatically call `batchSetQueriesData`. This might address situations where we have several parallel calls (e.g. rendering a user list where each is calling useUser) which result in independent cache updates

### How Has This Been Tested?

app still working, updates flowing through `batchSetQueriesData` and getting set properly in cache