### PR TITLE
Fix chain health recursion in discovery test

### DIFF
--- a/packages/discovery-provider/src/conftest.py
+++ b/packages/discovery-provider/src/conftest.py
@@ -96,9 +96,12 @@ def mock_requests(monkeypatch):
                 def json(self):
                     return self.json_data
 
+            print(f"asdf making mock request to: {url}")
+
             # Replace requests.get with a function that returns a mocked response with JSON
             return MockResponse(json_response, 200)
 
+        print(f"asdf making real request to: {url}")
         # For all other URLs and endpoints, perform the actual request using requests.get
         return requests.get(*args, **kwargs)
 

--- a/packages/discovery-provider/src/conftest.py
+++ b/packages/discovery-provider/src/conftest.py
@@ -80,6 +80,8 @@ def get_monitors_mock(monkeypatch):
 
 @pytest.fixture
 def mock_requests(monkeypatch):
+    real_get = requests.get
+
     def mock_relay_health(*args, **kwargs):
         url = args[0]
 
@@ -96,14 +98,11 @@ def mock_requests(monkeypatch):
                 def json(self):
                     return self.json_data
 
-            print(f"asdf making mock request to: {url}")
-
             # Replace requests.get with a function that returns a mocked response with JSON
             return MockResponse(json_response, 200)
 
-        print(f"asdf making real request to: {url}")
         # For all other URLs and endpoints, perform the actual request using requests.get
-        return requests.get(*args, **kwargs)
+        return real_get(*args, **kwargs)  # Call the original requests.get
 
     # Apply the mock_get function to requests.get
     monkeypatch.setattr(requests, "get", mock_relay_health)


### PR DESCRIPTION
### Description

This mock function is causing a seg fault error because it's not making a real request as expected, it's making mocked requests recursively. Putting the real req outside of the mock seems to work as expected.

Guessing this was always a problem but not bad enough to seg fault. The chain health would fail silently when max recursion depth was reached.


### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._
