### PR TITLE
Fix wallet serialization for userMetadataToSdk

### DIFF
--- a/packages/common/src/adapters/user.ts
+++ b/packages/common/src/adapters/user.ts
@@ -181,5 +181,7 @@ export const userMetadataToSdk = (
   twitterHandle: input.twitter_handle ?? undefined,
   instagramHandle: input.instagram_handle ?? undefined,
   playlistLibrary: input.playlist_library ?? undefined,
-  tiktokHandle: input.tiktok_handle ?? undefined
+  tiktokHandle: input.tiktok_handle ?? undefined,
+  associatedWallets: input.associated_wallets ?? undefined,
+  associatedSolWallets: input.associated_sol_wallets ?? undefined
 })


### PR DESCRIPTION
### Description
#10989 broke this. I'm not sure how or why the two wallet keys got removed as part of this call. But since it gets used as part of `updateCreator` it has the effect of not sending the wallets along when calling updateCreator. This means you can't add or remove any associated wallets.

_Thankfully_ indexing makes no changes if you do not pass these fields along.

I'm adding them back in _without_ using `camelCaseKeys` because we don't want to do that to associated wallets anyway.

NOTE: I'm debating not fixing this, and instead pushing ahead with the changes that set wallets in a separate transaction.

### How Has This Been Tested?
Local client against stage. Verified I can add and remove wallets sucessfully.