### PR TITLE
[PAY-3865] Don't deeplink on android oauth

### DIFF
--- a/packages/mobile/android/app/src/main/AndroidManifest.xml
+++ b/packages/mobile/android/app/src/main/AndroidManifest.xml
@@ -1,7 +1,7 @@
-<manifest 
+<manifest
     xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools" 
-    android:versionCode="2" 
+    xmlns:tools="http://schemas.android.com/tools"
+    android:versionCode="2"
     android:versionName="1.0.1">
 
     <uses-permission android:name="android.permission.INTERNET" />
@@ -9,47 +9,48 @@
 
     <!-- < Only if you're using GCM or localNotificationSchedule() > -->
     <uses-permission android:name="android.permission.WAKE_LOCK" />
-    <permission android:name="${applicationId}.permission.C2D_MESSAGE" android:protectionLevel="signature" />
+    <permission android:name="${applicationId}.permission.C2D_MESSAGE"
+        android:protectionLevel="signature" />
     <uses-permission android:name="${applicationId}.permission.C2D_MESSAGE" />
     <!-- < Only if you're using GCM or localNotificationSchedule() > -->
 
     <uses-permission android:name="android.permission.VIBRATE" />
-    <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED"/>
+    <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
     <uses-permission android:name="android.permission.DOWNLOAD_WITHOUT_NOTIFICATION" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
-    <uses-permission android:name="android.permission.POST_NOTIFICATIONS"/>
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
 
-    <uses-permission android:name="android.permission.CAMERA"/>
+    <uses-permission android:name="android.permission.CAMERA" />
     <uses-feature android:name="android.hardware.camera" android:required="false" />
     <uses-feature android:name="android.hardware.camera.front" android:required="false" />
 
 
-    <application 
-        android:usesCleartextTraffic="true" 
-        android:name=".MainApplication" 
-        android:label="@string/app_name" 
-        android:icon="${appIcon}" 
-        android:resource="@mipmap/ic_notification" 
-        android:allowBackup="false" 
-        android:largeHeap="true" 
+    <application
+        android:usesCleartextTraffic="true"
+        android:name=".MainApplication"
+        android:label="@string/app_name"
+        android:icon="${appIcon}"
+        android:resource="@mipmap/ic_notification"
+        android:allowBackup="false"
+        android:largeHeap="true"
         android:theme="@style/AppTheme"
         android:supportsRtl="true">
-        <activity 
-            android:name=".MainActivity" 
-            android:launchMode="singleTask" 
-            android:label="@string/app_name" 
-            android:configChanges="keyboard|keyboardHidden|orientation|screenLayout|screenSize|smallestScreenSize|uiMode" 
-            android:screenOrientation="portrait" 
-            android:windowSoftInputMode="adjustResize" 
-            android:exported="true" 
+        <activity
+            android:name=".MainActivity"
+            android:launchMode="singleTask"
+            android:label="@string/app_name"
+            android:configChanges="keyboard|keyboardHidden|orientation|screenLayout|screenSize|smallestScreenSize|uiMode"
+            android:screenOrientation="portrait"
+            android:windowSoftInputMode="adjustResize"
+            android:exported="true"
             android:theme="@style/BootTheme"
             android:supportsRtl="true">
             <intent-filter android:autoVerify="true">
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />
-                <action android:name="android.intent.action.DOWNLOAD_COMPLETE"/>
+                <action android:name="android.intent.action.DOWNLOAD_COMPLETE" />
             </intent-filter>
             <intent-filter android:autoVerify="true">
                 <action android:name="android.intent.action.VIEW" />
@@ -59,6 +60,7 @@
                 <data android:scheme="http" />
                 <data android:host="redirect.audius.co" />
                 <data android:host="audius.co" />
+                <data android:pathPattern="!.*/oauth/.*" />
             </intent-filter>
             <intent-filter android:autoVerify="true">
                 <action android:name="android.intent.action.VIEW" />
@@ -72,13 +74,17 @@
             android:exported="true">
         </activity>
 
-        <meta-data android:name="com.snapchat.kit.sdk.clientId" android:value="e4716145-55b7-4a90-9d90-e977733713ed" />
+        <meta-data android:name="com.snapchat.kit.sdk.clientId"
+            android:value="e4716145-55b7-4a90-9d90-e977733713ed" />
 
         <!-- Google Cast -->
-        <meta-data android:name="com.google.android.gms.cast.framework.OPTIONS_PROVIDER_CLASS_NAME" android:value="com.reactnative.googlecast.GoogleCastOptionsProvider" />
-        <meta-data android:name="com.reactnative.googlecast.RECEIVER_APPLICATION_ID" android:value="222B31C8" />
+        <meta-data android:name="com.google.android.gms.cast.framework.OPTIONS_PROVIDER_CLASS_NAME"
+            android:value="com.reactnative.googlecast.GoogleCastOptionsProvider" />
+        <meta-data android:name="com.reactnative.googlecast.RECEIVER_APPLICATION_ID"
+            android:value="222B31C8" />
 
-        <meta-data android:name="com.google.firebase.messaging.default_notification_icon" android:resource="@mipmap/ic_notification" />
+        <meta-data android:name="com.google.firebase.messaging.default_notification_icon"
+            android:resource="@mipmap/ic_notification" />
 
         <provider
             android:authorities="${applicationId}.fileprovider"
@@ -101,19 +107,19 @@
     <queries>
         <intent>
             <action android:name="android.intent.action.VIEW" />
-            <data android:scheme="wc"/>
+            <data android:scheme="wc" />
         </intent>
         <intent>
             <action android:name="android.intent.action.VIEW" />
-            <data android:scheme="https" android:host="*"/>
+            <data android:scheme="https" android:host="*" />
         </intent>
         <intent>
             <action android:name="android.intent.action.VIEW" />
-            <data android:scheme="http" android:host="*"/>
+            <data android:scheme="http" android:host="*" />
         </intent>
         <intent>
             <action android:name="android.intent.action.VIEW" />
-            <data android:scheme="mailto" android:host="*"/>
+            <data android:scheme="mailto" android:host="*" />
         </intent>
         <package android:name="com.zhiliaoapp.musically" />
         <package android:name="com.ss.android.ugc.trill" />

--- a/packages/mobile/android/app/src/main/AndroidManifest.xml
+++ b/packages/mobile/android/app/src/main/AndroidManifest.xml
@@ -60,7 +60,7 @@
                 <data android:scheme="http" />
                 <data android:host="redirect.audius.co" />
                 <data android:host="audius.co" />
-                <data android:pathPattern="!.*/oauth/auth.*" />
+                <data android:pathPattern="!/oauth/auth.*" />
             </intent-filter>
             <intent-filter android:autoVerify="true">
                 <action android:name="android.intent.action.VIEW" />

--- a/packages/mobile/android/app/src/main/AndroidManifest.xml
+++ b/packages/mobile/android/app/src/main/AndroidManifest.xml
@@ -60,7 +60,7 @@
                 <data android:scheme="http" />
                 <data android:host="redirect.audius.co" />
                 <data android:host="audius.co" />
-                <data android:pathPattern="!.*/oauth/.*" />
+                <data android:pathPattern="!.*/oauth/auth.*" />
             </intent-filter>
             <intent-filter android:autoVerify="true">
                 <action android:name="android.intent.action.VIEW" />

--- a/packages/mobile/android/app/src/main/AndroidManifest.xml
+++ b/packages/mobile/android/app/src/main/AndroidManifest.xml
@@ -60,7 +60,7 @@
                 <data android:scheme="http" />
                 <data android:host="redirect.audius.co" />
                 <data android:host="audius.co" />
-                <data android:pathPattern="!/oauth/auth.*" />
+                <data android:pathPattern="/oauth/auth.*" />
             </intent-filter>
             <intent-filter android:autoVerify="true">
                 <action android:name="android.intent.action.VIEW" />


### PR DESCRIPTION
### Description
Added filter on android to not deeplink to app when `/oauth/auth.*` is hit on web. This already takes place on ios in `packages/web/public/.well-known/apple-app-site-association`


### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._
