### PR TITLE
Remove box-in-box in web rewards modals

### DIFF
--- a/packages/web/src/pages/rewards-page/components/modals/ChallengeRewardsModal/ChallengeRewardsModal.tsx
+++ b/packages/web/src/pages/rewards-page/components/modals/ChallengeRewardsModal/ChallengeRewardsModal.tsx
@@ -355,7 +355,15 @@ const ChallengeRewardsBody = ({ dismissModal }: BodyProps) => {
   )
 
   const renderProgressStatusLabel = () => (
-    <Flex alignItems='center'>
+    <Flex
+      alignItems='center'
+      border='strong'
+      w='100%'
+      justifyContent='center'
+      ph='xl'
+      pv='l'
+      borderRadius='s'
+    >
       {challenge?.state === 'incomplete' ? (
         <Text variant='label' size='l' strength='strong' color='subdued'>
           {messages.incomplete}
@@ -476,7 +484,6 @@ const ChallengeRewardsBody = ({ dismissModal }: BodyProps) => {
           gap='s'
           ph='l'
           pv='xl'
-          borderLeft='strong'
           css={{
             flex: '1 1 0%'
           }}
@@ -583,24 +590,15 @@ const ChallengeRewardsBody = ({ dismissModal }: BodyProps) => {
               label={progressDescriptionLabel}
               description={progressDescription}
             />
-            <Paper
-              column
-              shadow='flat'
-              border='strong'
-              borderRadius='m'
-              w='100%'
-              backgroundColor='surface1'
-            >
-              <Flex justifyContent='center' borderBottom='strong'>
+            <Paper column shadow='flat' w='100%' borderRadius='s'>
+              <Flex justifyContent='center'>
                 <ProgressReward
                   amount={formatNumberCommas(progressRewardAmount ?? '')}
                   subtext={messages.audio}
                 />
                 {renderProgressBar()}
               </Flex>
-              <Flex justifyContent='center' ph='xl' pv='l'>
-                {renderProgressStatusLabel()}
-              </Flex>
+              <Flex justifyContent='center'>{renderProgressStatusLabel()}</Flex>
             </Paper>
             {modalType === 'profile-completion' ||
             modalType === ChallengeName.ProfileCompletion ? (
@@ -610,14 +608,7 @@ const ChallengeRewardsBody = ({ dismissModal }: BodyProps) => {
           </>
         ) : (
           <>
-            <Paper
-              column
-              shadow='flat'
-              border='strong'
-              borderRadius='m'
-              w='100%'
-              backgroundColor='surface1'
-            >
+            <Paper column w='100%' borderRadius='s' shadow='flat'>
               <Flex justifyContent='space-between'>
                 <ProgressDescription
                   label={progressDescriptionLabel}
@@ -628,15 +619,7 @@ const ChallengeRewardsBody = ({ dismissModal }: BodyProps) => {
                   subtext={messages.audio}
                 />
               </Flex>
-              <Flex
-                pv='l'
-                ph='xl'
-                borderTop='strong'
-                gap='l'
-                borderBottomLeftRadius='m'
-                borderBottomRightRadius='m'
-                justifyContent='center'
-              >
+              <Flex column gap='xl'>
                 {renderProgressStatusLabel()}
                 {renderProgressBar()}
               </Flex>

--- a/packages/web/src/pages/rewards-page/components/modals/ChallengeRewardsModal/ProgressReward.tsx
+++ b/packages/web/src/pages/rewards-page/components/modals/ChallengeRewardsModal/ProgressReward.tsx
@@ -1,7 +1,5 @@
 import { Flex, Text } from '@audius/harmony'
 
-import { useIsMobile } from 'hooks/useIsMobile'
-
 import styles from './styles.module.css'
 
 const messages = {
@@ -16,12 +14,10 @@ export const ProgressReward = ({
   amount: string
   subtext: string
 }) => {
-  const isMobile = useIsMobile()
   return (
     <Flex
       p='xl'
       column
-      borderLeft={isMobile ? undefined : 'strong'}
       css={{
         textAlign: 'center',
         maxWidth: 200


### PR DESCRIPTION
### Description
Remove the "box-in-box" borders inside the challenge modals/drawers.
This is not the end-game of the new rewards UI but it's on the way and good enough to ship for now.

### How Has This Been Tested?

<img width="486" alt="Screenshot 2025-01-31 at 1 24 30 PM" src="https://github.com/user-attachments/assets/25969688-e9ca-41da-bac4-bd4807de48c3" />
<img width="727" alt="Screenshot 2025-01-31 at 1 24 36 PM" src="https://github.com/user-attachments/assets/9f73ad1b-4c7b-415c-80b9-1ce9fcbe7ba2" />
