### PR TITLE
Fix chat blasts on web

### DIFF
--- a/packages/mobile/src/screens/create-chat-blast-screen/ChatBlastSelectAudienceFields.tsx
+++ b/packages/mobile/src/screens/create-chat-blast-screen/ChatBlastSelectAudienceFields.tsx
@@ -5,6 +5,7 @@ import {
   usePurchasersAudience,
   useRemixersAudience
 } from '@audius/common/hooks'
+import { formatCount } from '@audius/common/utils'
 import { ChatBlastAudience } from '@audius/sdk'
 import { useField } from 'formik'
 import { TouchableOpacity } from 'react-native'
@@ -64,7 +65,9 @@ const LabelWithCount = (props: {
   return (
     <Text>
       {label}
-      {isSelected && count ? <Text color='subdued'> ({count})</Text> : null}
+      {isSelected && count ? (
+        <Text color='subdued'>{formatCount(count)}</Text>
+      ) : null}
     </Text>
   )
 }

--- a/packages/mobile/src/screens/create-chat-blast-screen/ChatBlastSelectAudienceFields.tsx
+++ b/packages/mobile/src/screens/create-chat-blast-screen/ChatBlastSelectAudienceFields.tsx
@@ -5,7 +5,7 @@ import {
   usePurchasersAudience,
   useRemixersAudience
 } from '@audius/common/hooks'
-import { formatCount } from '@audius/common/utils'
+import { formatNumberCommas } from '@audius/common/utils'
 import { ChatBlastAudience } from '@audius/sdk'
 import { useField } from 'formik'
 import { TouchableOpacity } from 'react-native'
@@ -66,7 +66,7 @@ const LabelWithCount = (props: {
     <Text>
       {label}
       {isSelected && count ? (
-        <Text color='subdued'>{formatCount(count)}</Text>
+        <Text color='subdued'>{formatNumberCommas(count)}</Text>
       ) : null}
     </Text>
   )

--- a/packages/web/src/pages/chat-page/components/ChatBlastHeader.tsx
+++ b/packages/web/src/pages/chat-page/components/ChatBlastHeader.tsx
@@ -8,7 +8,7 @@ import {
   IconUserList,
   Text
 } from '@audius/harmony'
-import { ChatBlast, HashId } from '@audius/sdk'
+import { ChatBlast, OptionalHashId } from '@audius/sdk'
 
 import { useCollectionCoverArt } from 'hooks/useCollectionCoverArt'
 import { useTrackCoverArt } from 'hooks/useTrackCoverArt'
@@ -22,7 +22,7 @@ export const ChatBlastHeader = ({ chat }: { chat: ChatBlast }) => {
     useChatBlastAudienceContent({
       chat
     })
-  const decodedId = HashId.parse(audienceContentId) ?? undefined
+  const decodedId = OptionalHashId.parse(audienceContentId)
   const albumArtwork = useCollectionCoverArt({
     collectionId: decodedId,
     size: SquareSizes.SIZE_150_BY_150

--- a/packages/web/src/pages/chat-page/components/ChatBlastModal.tsx
+++ b/packages/web/src/pages/chat-page/components/ChatBlastModal.tsx
@@ -183,7 +183,7 @@ const LabelWithCount = (props: {
       </Text>
       {isSelected && count ? (
         <Text variant='title' size='l' color='subdued'>
-          ({formatCount(103399)})
+          ({formatCount(count)})
         </Text>
       ) : null}
     </Flex>

--- a/packages/web/src/pages/chat-page/components/ChatBlastModal.tsx
+++ b/packages/web/src/pages/chat-page/components/ChatBlastModal.tsx
@@ -22,7 +22,8 @@ import {
   ModalFooter,
   IconCaretLeft,
   ModalContent,
-  Select
+  Select,
+  formatCount
 } from '@audius/harmony'
 import { ChatBlastAudience } from '@audius/sdk'
 import { Formik, useField } from 'formik'
@@ -182,7 +183,7 @@ const LabelWithCount = (props: {
       </Text>
       {isSelected && count ? (
         <Text variant='title' size='l' color='subdued'>
-          ({count})
+          ({formatCount(103399)})
         </Text>
       ) : null}
     </Flex>

--- a/packages/web/src/pages/chat-page/components/ChatBlastModal.tsx
+++ b/packages/web/src/pages/chat-page/components/ChatBlastModal.tsx
@@ -9,6 +9,7 @@ import {
   chatActions,
   useCreateChatModal
 } from '@audius/common/src/store'
+import { formatNumberCommas } from '@audius/common/utils'
 import {
   Flex,
   IconTowerBroadcast,
@@ -22,8 +23,7 @@ import {
   ModalFooter,
   IconCaretLeft,
   ModalContent,
-  Select,
-  formatCount
+  Select
 } from '@audius/harmony'
 import { ChatBlastAudience } from '@audius/sdk'
 import { Formik, useField } from 'formik'
@@ -183,7 +183,7 @@ const LabelWithCount = (props: {
       </Text>
       {isSelected && count ? (
         <Text variant='title' size='l' color='subdued'>
-          ({formatCount(count)})
+          ({formatNumberCommas(count)})
         </Text>
       ) : null}
     </Flex>


### PR DESCRIPTION
### Description
- Needed to use OptionalHashID
- Format the audience count nicely

### How Has This Been Tested?

Successfully got through the chat blast create flow.
<img width="1144" alt="Screenshot 2025-01-31 at 5 10 24 PM" src="https://github.com/user-attachments/assets/ee33d067-6edc-494b-a23b-bc2907549680" />

