### PR TITLE
Fix android build by upgrading react-native-blur

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16506,6 +16506,15 @@
         "react-native": "^0.0.0-0 || >=0.60 <1.0"
       }
     },
+    "node_modules/@react-native-community/blur": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/@react-native-community/blur/-/blur-4.4.1.tgz",
+      "integrity": "sha512-XBSsRiYxE/MOEln2ayunShfJtWztHwUxLFcSL20o+HNNRnuUDv+GXkF6FmM2zE8ZUfrnhQ/zeTqvnuDPGw6O8A==",
+      "peerDependencies": {
+        "react": "*",
+        "react-native": "*"
+      }
+    },
     "node_modules/@react-native-community/cli": {
       "version": "14.1.0",
       "license": "MIT",
@@ -132614,7 +132623,7 @@
         "@peculiar/webcrypto": "1.4.3",
         "@react-native-async-storage/async-storage": "1.21.0",
         "@react-native-clipboard/clipboard": "1.13.2",
-        "@react-native-community/blur": "4.3.2",
+        "@react-native-community/blur": "4.4.1",
         "@react-native-community/datetimepicker": "7.6.2",
         "@react-native-community/hooks": "3.0.0",
         "@react-native-community/netinfo": "11.2.1",
@@ -133216,14 +133225,6 @@
       "peerDependencies": {
         "react": ">=16.0",
         "react-native": ">=0.57.0"
-      }
-    },
-    "packages/mobile/node_modules/@react-native-community/blur": {
-      "version": "4.3.2",
-      "license": "MIT",
-      "peerDependencies": {
-        "react": "*",
-        "react-native": "*"
       }
     },
     "packages/mobile/node_modules/@react-native-community/hooks": {

--- a/packages/mobile/ios/Podfile.lock
+++ b/packages/mobile/ios/Podfile.lock
@@ -1295,8 +1295,27 @@ PODS:
     - Yoga
   - react-native-blob-util (0.19.4):
     - React-Core
-  - react-native-blur (4.3.2):
+  - react-native-blur (4.4.1):
+    - DoubleConversion
+    - glog
+    - hermes-engine
+    - RCT-Folly (= 2024.01.01.00)
+    - RCTRequired
+    - RCTTypeSafety
     - React-Core
+    - React-debug
+    - React-Fabric
+    - React-featureflags
+    - React-graphics
+    - React-ImageManager
+    - React-NativeModulesApple
+    - React-RCTFabric
+    - React-rendererdebug
+    - React-utils
+    - ReactCodegen
+    - ReactCommon/turbomodule/bridging
+    - ReactCommon/turbomodule/core
+    - Yoga
   - react-native-config (1.5.1):
     - react-native-config/App (= 1.5.1)
   - react-native-config/App (1.5.1):
@@ -1954,7 +1973,7 @@ DEPENDENCIES:
   - React-Mapbuffer (from `../node_modules/react-native/ReactCommon`)
   - React-microtasksnativemodule (from `../node_modules/react-native/ReactCommon/react/nativemodule/microtasks`)
   - react-native-blob-util (from `../node_modules/react-native-blob-util`)
-  - "react-native-blur (from `../node_modules/@react-native-community/blur`)"
+  - "react-native-blur (from `../../../node_modules/@react-native-community/blur`)"
   - react-native-config (from `../node_modules/react-native-config`)
   - "react-native-cookies (from `../../../node_modules/@react-native-cookies/cookies`)"
   - react-native-create-thumbnail (from `../../../node_modules/react-native-create-thumbnail`)
@@ -2132,7 +2151,7 @@ EXTERNAL SOURCES:
   react-native-blob-util:
     :path: "../node_modules/react-native-blob-util"
   react-native-blur:
-    :path: "../node_modules/@react-native-community/blur"
+    :path: "../../../node_modules/@react-native-community/blur"
   react-native-config:
     :path: "../node_modules/react-native-config"
   react-native-cookies:
@@ -2325,7 +2344,7 @@ SPEC CHECKSUMS:
   React-Mapbuffer: b982d5bba94a8bc073bda48f0d27c9b28417fae3
   React-microtasksnativemodule: 2b73e68f0462f3175f98782db08896f8501afd20
   react-native-blob-util: 30a6c9fd067aadf9177e61a998f2c7efb670598d
-  react-native-blur: cfdad7b3c01d725ab62a8a729f42ea463998afa2
+  react-native-blur: a1bf334589f44658a58a859b1f3defe28e367fcf
   react-native-config: 86038147314e2e6d10ea9972022aa171e6b1d4d8
   react-native-cookies: f54fcded06bb0cda05c11d86788020b43528a26c
   react-native-create-thumbnail: ab55d24aea01723cf386f18b0b542aabb1982f27

--- a/packages/mobile/package.json
+++ b/packages/mobile/package.json
@@ -72,7 +72,7 @@
     "@peculiar/webcrypto": "1.4.3",
     "@react-native-async-storage/async-storage": "1.21.0",
     "@react-native-clipboard/clipboard": "1.13.2",
-    "@react-native-community/blur": "4.3.2",
+    "@react-native-community/blur": "4.4.1",
     "@react-native-community/datetimepicker": "7.6.2",
     "@react-native-community/hooks": "3.0.0",
     "@react-native-community/netinfo": "11.2.1",


### PR DESCRIPTION
### Description

Fixes android builds due to missing react-native-blur gradle dependency. Issue thread here: https://github.com/Kureev/react-native-blur/issues/641. Solution is to upgrade it to latest