### PR TITLE
Return aggregate challenges regardless of completion state

### DIFF
--- a/packages/discovery-provider/src/queries/get_challenges.py
+++ b/packages/discovery-provider/src/queries/get_challenges.py
@@ -218,12 +218,9 @@ def get_challenges(
     for i, user_challenge in enumerate(existing_user_challenges):
         parent_challenge = all_challenges_map[user_challenge.challenge_id]
         if parent_challenge.type == ChallengeType.aggregate:
-            # Filter out aggregate user_challenges that aren't complete.
-            # this probably shouldn't even happen (what does it mean?)
-            if user_challenge.is_complete:
-                aggregate_user_challenges_map[user_challenge.challenge_id].append(
-                    user_challenge
-                )
+            aggregate_user_challenges_map[user_challenge.challenge_id].append(
+                user_challenge
+            )
         else:
             # If we're a trending challenge, don't add if the user_challenge is incomplete
             if (


### PR DESCRIPTION
### Description
Previously there was no scenario where an aggregate challenge would have `is_complete: False`. Now with listen streak this is possible. The comment that I removed implies that this was sort of weird edge-case behavior anyway. Think we should be safe.

### How Has This Been Tested?

Full stack local, confirmed challenges request now returns incomplete aggregate listen streak challenge
