### PR TITLE
Fix auth for purchase and sale count

### DIFF
--- a/packages/discovery-provider/src/api/v1/authorization_helpers.py
+++ b/packages/discovery-provider/src/api/v1/authorization_helpers.py
@@ -2,6 +2,7 @@ import logging
 
 from flask_restx.errors import abort
 
+from src.queries.get_authorization import is_authorized_request
 from src.queries.get_managed_users import is_active_manager
 
 logger = logging.getLogger(__name__)
@@ -18,5 +19,11 @@ def check_authorized(user_id, authed_user_id):
     Raises:
         HTTPError: If the user is not authorized to access the resource.
     """
-    if user_id != authed_user_id and not is_active_manager(user_id, authed_user_id):
+    user_granted_access = is_authorized_request(user_id)
+
+    if (
+        user_id != authed_user_id
+        and not is_active_manager(user_id, authed_user_id)
+        and not user_granted_access
+    ):
         abort(403, message="You are not authorized to access this resource")

--- a/packages/discovery-provider/src/api/v1/users.py
+++ b/packages/discovery-provider/src/api/v1/users.py
@@ -2538,11 +2538,12 @@ class FullPurchasesCount(Resource):
         params={"id": "A User ID"},
     )
     @full_ns.expect(purchases_and_sales_count_parser)
-    @auth_middleware(purchases_and_sales_count_parser, require_auth=True)
+    @auth_middleware(purchases_and_sales_count_parser)
     @full_ns.marshal_with(purchases_count_response)
     def get(self, id, authed_user_id):
         decoded_id = decode_with_abort(id, full_ns)
-        check_authorized(decoded_id, authed_user_id)
+        if decoded_id and not is_authorized_request(decoded_id):
+            abort(403, message="You are not authorized to access this resource")
         args = purchases_and_sales_count_parser.parse_args()
         content_ids = args.get("content_ids", [])
         decoded_content_ids = decode_ids_array(content_ids) if content_ids else []
@@ -2594,11 +2595,12 @@ class FullSalesCount(Resource):
         params={"id": "A User ID"},
     )
     @full_ns.expect(purchases_and_sales_count_parser)
-    @auth_middleware(purchases_and_sales_count_parser, require_auth=True)
+    @auth_middleware(purchases_and_sales_count_parser)
     @full_ns.marshal_with(purchases_count_response)
     def get(self, id, authed_user_id):
         decoded_id = decode_with_abort(id, full_ns)
-        check_authorized(decoded_id, authed_user_id)
+        if decoded_id and not is_authorized_request(decoded_id):
+            abort(403, message="You are not authorized to access this resource")
         args = purchases_and_sales_count_parser.parse_args()
         content_ids = args.get("content_ids", [])
         decoded_content_ids = decode_ids_array(content_ids) if content_ids else []


### PR DESCRIPTION
### Description

Removes `require_auth` so apps can access. Use `is_authorized_request` so grants are checked. 

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._

Ran on stage and confirmed these are now accessible via app signed requests.