### PR TITLE
Clean up env before running tests

### DIFF
--- a/.circleci/src/jobs/test.yml
+++ b/.circleci/src/jobs/test.yml
@@ -6,6 +6,9 @@ machine: true
 resource_class: audiusproject/gcp-n2-standard-4
 working_directory: ~/audius-protocol
 steps:
+  - run:
+      name: clean dir
+      command: cd ~; [ -d ~/audius-protocol ] && rm -rf ~/audius-protocol
   - checkout
   - attach_workspace:
       at: ./
@@ -13,7 +16,7 @@ steps:
   - run:
       name: test run "<< parameters.service >>"
       no_output_timeout: 20m
-      command: . ~/.profile; audius-compose test run "<< parameters.service >>"
+      command: . ~/.profile; export DOCKER_UID=$(id -u); export DOCKER_GID=$(id -g); audius-compose test run "<< parameters.service >>"
   - run:
       name: cleanup
       no_output_timeout: 5m

--- a/dev-tools/compose/docker-compose.discovery.dev.yml
+++ b/dev-tools/compose/docker-compose.discovery.dev.yml
@@ -13,6 +13,7 @@ services:
       service: discovery-provider-notifications
 
   comms:
+    user: ${DOCKER_UID:-root}:${DOCKER_GID:-root}
     extends:
       file: docker-compose.discovery.prod.yml
       service: comms
@@ -51,6 +52,7 @@ services:
       - ${PROJECT_ROOT}:/app
 
   healthz:
+    user: ${DOCKER_UID:-root}:${DOCKER_GID:-root}
     extends:
       file: docker-compose.discovery.prod.yml
       service: healthz

--- a/dev-tools/compose/docker-compose.test.yml
+++ b/dev-tools/compose/docker-compose.test.yml
@@ -207,6 +207,7 @@ services:
 
   # contracts
   test-contracts:
+    user: ${DOCKER_UID:-root}:${DOCKER_GID:-root}
     build:
       context: ${PROJECT_ROOT}/contracts
       dockerfile: Dockerfile
@@ -229,6 +230,7 @@ services:
 
   # eth-contracts
   test-eth-contracts:
+    user: ${DOCKER_UID:-root}:${DOCKER_GID:-root}
     build:
       context: ${PROJECT_ROOT}/eth-contracts
       args:
@@ -314,6 +316,7 @@ services:
   # todo: this will need es-indexer container running for tests to pass..
   # unless we just skip all the search tests for now
   test-discovery-provider:
+    user: ${DOCKER_UID:-root}:${DOCKER_GID:-root}
     extends:
       file: docker-compose.yml
       service: discovery-provider
@@ -348,6 +351,7 @@ services:
       - discovery
 
   test-discovery-provider-notifications:
+    user: ${DOCKER_UID:-root}:${DOCKER_GID:-root}
     build:
       context: ${PROJECT_ROOT}/packages/discovery-provider/plugins/notifications
       dockerfile: Dockerfile


### PR DESCRIPTION
Add on to #11235 for the service tests.

`eth-contracts` was leaving files owned by `root` around and wreaking havoc for other jobs that tried to run
