### PR TITLE
[C-5719] Add default cache invalidation behavior

### DIFF
--- a/packages/common/src/api/tan-query/useCollection.ts
+++ b/packages/common/src/api/tan-query/useCollection.ts
@@ -12,8 +12,6 @@ import { getCollectionByPermalinkQueryKey } from './useCollectionByPermalink'
 import { useCurrentUserId } from './useCurrentUserId'
 import { primeCollectionData } from './utils/primeCollectionData'
 
-const STALE_TIME = Infinity
-
 export const getCollectionQueryKey = (collectionId: ID | null | undefined) => [
   QUERY_KEYS.collection,
   collectionId
@@ -59,7 +57,8 @@ export const useCollection = (
 
       return collection
     },
-    staleTime: options?.staleTime ?? STALE_TIME,
+    staleTime: options?.staleTime ?? Infinity,
+    gcTime: Infinity,
     enabled: options?.enabled !== false && !!collectionId
   })
 }

--- a/packages/common/src/api/tan-query/useCurrentAccount.ts
+++ b/packages/common/src/api/tan-query/useCurrentAccount.ts
@@ -57,7 +57,8 @@ export const useCurrentAccount = (options?: QueryOptions) => {
       const account = accountFromSDK(data)
       return account
     },
-    staleTime: options?.staleTime,
+    staleTime: options?.staleTime ?? Infinity,
+    gcTime: Infinity,
     enabled: options?.enabled !== false && !!currentUser
   })
 }

--- a/packages/common/src/api/tan-query/useLibraryCollections.ts
+++ b/packages/common/src/api/tan-query/useLibraryCollections.ts
@@ -111,7 +111,8 @@ export const useLibraryCollections = (
       return collections
     },
     select: (data) => data.pages.flat(),
-    staleTime: options?.staleTime,
+    staleTime: options?.staleTime ?? Infinity,
+    gcTime: Infinity,
     enabled: options?.enabled !== false && !!currentUserId
   })
 }

--- a/packages/common/src/api/tan-query/useLibraryTracks.ts
+++ b/packages/common/src/api/tan-query/useLibraryTracks.ts
@@ -114,7 +114,8 @@ export const useLibraryTracks = (
       return allPages.length * pageSize
     },
     initialPageParam: 0,
-    staleTime: config?.staleTime,
+    staleTime: config?.staleTime ?? Infinity,
+    gcTime: Infinity,
     enabled: config?.enabled !== false && !!currentUserId
   })
 

--- a/packages/common/src/api/tan-query/useTrack.ts
+++ b/packages/common/src/api/tan-query/useTrack.ts
@@ -13,8 +13,6 @@ import { QUERY_KEYS } from './queryKeys'
 import { QueryOptions } from './types'
 import { getUserQueryKey } from './useUser'
 
-const STALE_TIME = Infinity
-
 export const getTrackQueryKey = (trackId: ID | null | undefined) => [
   QUERY_KEYS.track,
   trackId
@@ -66,7 +64,8 @@ export const useTrack = (
 
       return track
     },
-    staleTime: options?.staleTime ?? STALE_TIME,
+    staleTime: options?.staleTime ?? Infinity,
+    gcTime: Infinity,
     enabled: options?.enabled !== false && !!trackId
   })
 }

--- a/packages/common/src/api/tan-query/useUser.ts
+++ b/packages/common/src/api/tan-query/useUser.ts
@@ -54,7 +54,8 @@ export const useUser = (
 
       return user
     },
-    staleTime: options?.staleTime,
+    staleTime: options?.staleTime ?? Infinity,
+    gcTime: Infinity,
     enabled: options?.enabled !== false && !!userId
   })
 }

--- a/packages/common/src/api/tan-query/utils/primeCollectionData.ts
+++ b/packages/common/src/api/tan-query/utils/primeCollectionData.ts
@@ -77,6 +77,7 @@ export const primeCollectionDataInternal = ({
 
     // Prime collection by permalink only if it doesn't exist
     if (
+      collection.permalink &&
       !queryClient.getQueryData(
         getCollectionByPermalinkQueryKey(collection.permalink)
       )

--- a/packages/mobile/src/services/query-client.ts
+++ b/packages/mobile/src/services/query-client.ts
@@ -1,3 +1,15 @@
 import { QueryClient } from '@tanstack/react-query'
+import { env } from 'services/env'
 
-export const queryClient = new QueryClient()
+export const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      gcTime: 1000 * 60 * 5, // 5 minutes
+      staleTime: 1000 * 60 * 5, // 5 minutes
+      refetchOnWindowFocus: true,
+      refetchOnReconnect: true,
+      refetchOnMount: true,
+      throwOnError: env.ENVIRONMENT === 'development' // feature-tan-query TODO: remove before going to main?
+    }
+  }
+})

--- a/packages/web/src/services/query-client.ts
+++ b/packages/web/src/services/query-client.ts
@@ -1,3 +1,16 @@
 import { QueryClient } from '@tanstack/react-query'
 
-export const queryClient = new QueryClient()
+import { env } from './env'
+
+export const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      gcTime: 1000 * 60 * 5, // 5 minutes
+      staleTime: 1000 * 60 * 5, // 5 minutes
+      refetchOnWindowFocus: true,
+      refetchOnReconnect: true,
+      refetchOnMount: true,
+      throwOnError: env.ENVIRONMENT === 'development' // feature-tan-query TODO: remove before going to main?
+    }
+  }
+})


### PR DESCRIPTION
### Description

- Add default `queryClient` options
	- 5 mins cache and stale times
- Add overrides for core entity hooks: `useUser`, `useTrack`, `useCollection`, `useCurrentAccount`
	- cache and stale time both `Infinity`
