### PR TITLE
Fix test-contracts and test-eth-contracts in ci

### DIFF
--- a/contracts/Dockerfile
+++ b/contracts/Dockerfile
@@ -21,6 +21,18 @@ COPY ./signature_schemas ./signature_schemas
 COPY ./test ./test
 COPY ./truffle-config.js ./contract-config.js ./
 
+# Some of the build tools for truffle require these to exist, and so does one
+# of our migrations (for the .audius one). Since we run this as a non-root user
+# in CI, make these in the construction of the container or we won't have access
+# to be able to make them
+RUN mkdir /.audius
+RUN mkdir /.config
+RUN touch /.babel.json
+
+RUN chmod 777 /.audius
+RUN chmod 777 /.config
+RUN chmod 777 /.babel.json
+
 RUN chmod +x ./scripts/setup-predeployed-ganache.sh
 
 RUN ./scripts/setup-predeployed-ganache.sh /usr/db 1000000000001

--- a/eth-contracts/Dockerfile
+++ b/eth-contracts/Dockerfile
@@ -18,6 +18,18 @@ COPY ./test ./test
 COPY ./patches ./patches
 COPY ./truffle-config.js ./contract-config.js .solcover.js ./
 
+# Some of the build tools for truffle require these to exist, and so does one
+# of our migrations (for the .audius one). Since we run this as a non-root user
+# in CI, make these in the construction of the container or we won't have access
+# to be able to make them
+RUN mkdir /.audius
+RUN mkdir /.config
+RUN touch /.babel.json
+
+RUN chmod 777 /.audius
+RUN chmod 777 /.config
+RUN chmod 777 /.babel.json
+
 RUN chmod +x ./scripts/setup-predeployed-ganache.sh ./scripts/setup-dev.sh
 
 # runs openzeppelin patches


### PR DESCRIPTION
For some reason, truffle expects some files to be at the root (or it tries to create them). Now that we're running as the `circleci` user within the container in CI, we don't have access to do that anymore:

```
> contracts@0.1.0 test
> NODE_OPTIONS='--max-old-space-size=8192' truffle test test/*.js --network test

Error: EACCES: permission denied, mkdir '/.config/truffle-nodejs'
    at Object.mkdirSync (node:fs:1391:3)
    at Conf._ensureDirectory (/usr/src/app/node_modules/truffle/build/webpack:/packages/config/node_modules/conf/dist/source/index.js:358:1)
    at Conf.get store [as store] (/usr/src/app/node_modules/truffle/build/webpack:/packages/config/node_modules/conf/dist/source/index.js:284:1)
    at new Conf (/usr/src/app/node_modules/truffle/build/webpack:/packages/config/node_modules/conf/dist/source/index.js:131:1)
    at Function.getUserConfig (/usr/src/app/node_modules/truffle/build/webpack:/packages/config/dist/index.js:162:1)
    at Object.send (/usr/src/app/node_modules/truffle/build/webpack:/packages/core/lib/services/analytics/index.js:5:1)
```

However, the building of the container can, and so it makes these folders and files and sets them to be widely available.

Other options considered were:
- running as sudo in ci (scary)
- don't mount anything and run as root in container (because mounting leaves stuff around that can't be deleted) (bad for hot reloading)
- separate prod/dev dockerfile/docker compose config for mount vs copy (seems overkill)