### PR TITLE
Add fixed-decimal to identity test cache in CI

### DIFF
--- a/.circleci/src/jobs/@identity-jobs.yml
+++ b/.circleci/src/jobs/@identity-jobs.yml
@@ -28,3 +28,5 @@ identity-init:
           - packages/spl/node_modules
           - packages/eth/dist
           - packages/eth/node_modules
+          - packages/fixed-decimal/dist
+          - packages/fixed-decimal/node_modules


### PR DESCRIPTION
Identity test is failing in CI due to missing `@audius/fixed-decimal` because we weren't caching it in the init step and restoring from the cache.
