### PR TITLE
[PAY-3884] Fix plaid verification layout

### DIFF
--- a/packages/web/src/pages/check-page/CheckPage.tsx
+++ b/packages/web/src/pages/check-page/CheckPage.tsx
@@ -6,11 +6,11 @@ import { route } from '@audius/common/utils'
 import { usePlaidLink } from 'react-plaid-link'
 import { useDispatch, useSelector } from 'react-redux'
 
+import Page from 'components/page/Page'
 import { identityService } from 'services/audius-sdk/identity'
 import { push as pushRoute } from 'utils/navigation'
 
 import './CheckPage.module.css'
-import Page from 'components/page/Page'
 
 const { SIGN_IN_PAGE, TRENDING_PAGE } = route
 const { getUserHandle, getAccountStatus } = accountSelectors

--- a/packages/web/src/pages/check-page/CheckPage.tsx
+++ b/packages/web/src/pages/check-page/CheckPage.tsx
@@ -10,6 +10,7 @@ import { identityService } from 'services/audius-sdk/identity'
 import { push as pushRoute } from 'utils/navigation'
 
 import './CheckPage.module.css'
+import Page from 'components/page/Page'
 
 const { SIGN_IN_PAGE, TRENDING_PAGE } = route
 const { getUserHandle, getAccountStatus } = accountSelectors
@@ -46,11 +47,16 @@ const CheckPage = () => {
 
   useEffect(() => {
     if (ready) {
+      const originalWidth = document.body.style.width
+      document.body.style.setProperty('width', '100%', 'important')
       open()
+      return () => {
+        document.body.style.width = originalWidth
+      }
     }
   }, [ready, open])
 
-  return null
+  return <Page title='Verification' description='Audius account verification' />
 }
 
 export default CheckPage


### PR DESCRIPTION
### Description

Plaid annoyingly injects `width: auto !important` onto the body and breaks our layout in mobile web.

Also give a page title/description

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._

```
npm run web:prod
```