### PR TITLE
Fix npm root cache issue on test-discovery-notifications

### DIFF
--- a/monitoring/healthz/Dockerfile
+++ b/monitoring/healthz/Dockerfile
@@ -6,6 +6,10 @@ ENV WORKDIR /app
 WORKDIR ${WORKDIR}
 
 COPY package.json package-lock.json ./
+
+# Quick fix for CI where we don't run as root user
+# https://stackoverflow.com/questions/14836053/how-can-i-change-the-cache-path-for-npm-or-completely-disable-the-cache-on-win
+RUN npm config set cache ./.npm --global
 RUN npm install
 
 COPY index.html tsconfig.json tsconfig.node.json vite.config.ts postcss.config.js tailwind.config.js ./

--- a/packages/discovery-provider/plugins/notifications/Dockerfile
+++ b/packages/discovery-provider/plugins/notifications/Dockerfile
@@ -6,7 +6,11 @@ WORKDIR /notifications
 RUN apk add --no-cache python3 py3-pip build-base
 
 COPY package*.json ./
-RUN --mount=type=cache,target=/root/.npm npm i --verbose
+
+# Quick fix for CI where we don't run as root user
+# https://stackoverflow.com/questions/14836053/how-can-i-change-the-cache-path-for-npm-or-completely-disable-the-cache-on-win
+RUN npm config set cache ./.npm --global
+RUN --mount=type=cache,target=./.npm npm i --verbose
 
 COPY . .
 


### PR DESCRIPTION
Moves the npm cache from the root so that the CircleCI user can access it.

Tested by manually changing this live on the worker and seeing the repro go away:

1. SSH into worker
2. `sudo su circleci` to ensure you're acting as the same user as CI
3. `cd ~/audius-protocol` and ensure the repository is up to date with main
4. Don't make this change yet, run `. ~/.profile; export DOCKER_UID=$(id -u); export DOCKER_GID=$(id -g); audius-compose test run "discovery-provider-notifications"`
5. Observe error
6. Make change, run again
7. Error gone