### PR TITLE
Remove email access from simple entities to fetch

### DIFF
--- a/packages/discovery-provider/src/tasks/entity_manager/entity_manager.py
+++ b/packages/discovery-provider/src/tasks/entity_manager/entity_manager.py
@@ -598,8 +598,7 @@ entity_types_to_fetch = set(
         EntityType.TRACK,
         EntityType.PLAYLIST,
         EntityType.COMMENT,
-        EntityType.ENCRYPTED_EMAIL,
-        EntityType.EMAIL_ACCESS,
+        EntityType.ENCRYPTED_EMAIL
     ]
 )
 


### PR DESCRIPTION
### Description

Currently we end up trying to fetch an int value when email_access is in the values of entity_types_to_fetch. email_access contains a more complicated data structure handled below.

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._

cherry picked onto dn1 prod and unblocked