### PR TITLE
Add back verified-notifications to push-docker-images for discovery in CI

### DIFF
--- a/.circleci/src/workflows/discovery.yml
+++ b/.circleci/src/workflows/discovery.yml
@@ -3,7 +3,7 @@ jobs:
   - push-docker-image:
       name: push-discovery-provider
       context: [Vercel, dockerhub]
-      service: discovery-provider discovery-provider-openresty discovery-provider-notifications trending-challenge-rewards staking relay solana-relay crm mri comms es-indexer
+      service: discovery-provider discovery-provider-openresty discovery-provider-notifications trending-challenge-rewards staking relay solana-relay crm mri comms es-indexer verified-notifications
       filters:
         branches:
           only: main


### PR DESCRIPTION
Accidentally missed this in #11240 