### PR TITLE
A few more small CAA fixes

### DIFF
--- a/.changeset/eight-stingrays-deny.md
+++ b/.changeset/eight-stingrays-deny.md
@@ -1,0 +1,5 @@
+---
+"create-audius-app": minor
+---
+
+Remove package-lock files to ensure installs are up to date for newly generated projects

--- a/packages/create-audius-app/tests/e2e/react/react.test.ts
+++ b/packages/create-audius-app/tests/e2e/react/react.test.ts
@@ -1,9 +1,6 @@
 import { test, expect } from '@playwright/test'
 
-test('auth and fetches tracks', async ({
-  page,
-  context
-}) => {
+test('auth and fetches tracks', async ({ page, context }) => {
   test.slow()
 
   // Set entropy so we don't need to do OTP
@@ -24,11 +21,13 @@ test('auth and fetches tracks', async ({
   await authPage.waitForLoadState()
   await authPage.getByRole('button', { name: 'Continue' }).click()
 
-  await expect(page.getByText('Continue With Audius')).not.toBeVisible()
+  await expect(page.getByText('Continue With Audius')).not.toBeVisible({
+    timeout: 10000
+  })
 
   // Fetch tracks
   await page.getByRole('textbox').fill('createaudiusapptracks')
-  
+
   // Set up response listener
   const responsePromise = page.waitForResponse(async (response) => {
     if (response.url().includes('v1/full/users/4zZ9aV9/tracks')) {


### PR DESCRIPTION
### Description
I forgot to update the other react e2e test in my previous PR. This one also has occasionally flakiness due to the login taking more than 5 seconds.

And I also did not add a changeset for the last PR to account for the package-lock changes.

### How Has This Been Tested?
N/A, will let CI/e2e tests verify
