### PR TITLE
Add fees to rewards claim evaluate

### DIFF
--- a/.changeset/honest-boxes-explain.md
+++ b/.changeset/honest-boxes-explain.md
@@ -1,0 +1,5 @@
+---
+"@audius/sdk": patch
+---
+
+Add priority fees to Challenge Rewards Claiming

--- a/packages/sdk/src/sdk/api/challenges/ChallengesApi.ts
+++ b/packages/sdk/src/sdk/api/challenges/ChallengesApi.ts
@@ -195,8 +195,7 @@ export class ChallengesApi extends GeneratedChallengesApi {
     logger.debug('Disbursing...')
     const tx = await this.solanaClient.buildTransaction({
       instructions,
-      addressLookupTables: [this.rewardManager.lookupTable],
-      priorityFee: null
+      addressLookupTables: [this.rewardManager.lookupTable]
     })
     const signature = await this.rewardManager.sendTransaction(tx, {
       skipPreflight: true


### PR DESCRIPTION
Previously we added fees but only if the resulting transaction got split, and only the first half got the fees. This adds the fees regardless.