### PR TITLE
Add compute budget limit to buildTransaction

### DIFF
--- a/.changeset/sixty-pans-bow.md
+++ b/.changeset/sixty-pans-bow.md
@@ -1,0 +1,5 @@
+---
+"@audius/sdk": patch
+---
+
+Add support for setting compute budget limit, add multiplier for priority fee percentile.

--- a/packages/sdk/src/sdk/sdk.ts
+++ b/packages/sdk/src/sdk/sdk.ts
@@ -257,7 +257,8 @@ const initializeServices = (config: SdkConfig) => {
     config.services?.solanaClient ??
     new SolanaClient({
       ...getDefaultSolanaClientConfig(servicesConfig),
-      solanaWalletAdapter
+      solanaWalletAdapter,
+      logger
     })
 
   const claimableTokensClient =

--- a/packages/sdk/src/sdk/services/Solana/programs/SolanaClient.ts
+++ b/packages/sdk/src/sdk/services/Solana/programs/SolanaClient.ts
@@ -83,7 +83,8 @@ export class SolanaClient {
       priorityFee = {
         priority: 'VERY_HIGH',
         minimumMicroLamports: 150_000,
-        multiplier: 1
+        maximumMicroLamports: 1_000_000,
+        multiplier: 1.5
       },
       computeLimit = { simulationMultiplier: 1.5 }
     } = await parseParams('buildTransaction', BuildTransactionSchema)(params)

--- a/packages/sdk/src/sdk/services/Solana/programs/getDefaultConfig.ts
+++ b/packages/sdk/src/sdk/services/Solana/programs/getDefaultConfig.ts
@@ -1,9 +1,11 @@
 import type { SdkServicesConfig } from '../../../config/types'
+import { Logger } from '../../Logger'
 
 import type { SolanaClientConfigInternal } from './types'
 
 export const getDefaultSolanaClientConfig = (
   servicesConfig: SdkServicesConfig
 ): SolanaClientConfigInternal => ({
-  rpcEndpoints: [servicesConfig.solana.rpcEndpoint]
+  rpcEndpoints: [servicesConfig.solana.rpcEndpoint],
+  logger: new Logger()
 })


### PR DESCRIPTION
Adds the ability (and default) to simulate a transaction, get its estimated consumed compute, and multiply that estimate by some factor and add as a compute budget limit instruction to the `buildTransaction` method of `SolanaClient` in SDK.

Also fixes the priority fee to respect the maximum, and add support for a multiplier to the percentile.
