### PR TITLE
More mobile rewards UI improvements

### DIFF
--- a/packages/mobile/src/components/challenge-rewards-drawer/AudioMatchingChallengeDrawerContent.tsx
+++ b/packages/mobile/src/components/challenge-rewards-drawer/AudioMatchingChallengeDrawerContent.tsx
@@ -4,14 +4,16 @@ import type { OptimisticUserChallenge } from '@audius/common/models'
 import { ChallengeName } from '@audius/common/models'
 import { ClaimStatus } from '@audius/common/store'
 import { formatNumberCommas } from '@audius/common/utils'
-import { ScrollView, View } from 'react-native'
+import { ScrollView } from 'react-native-gesture-handler'
 
 import type { ButtonProps } from '@audius/harmony-native'
 import {
   IconArrowRight,
   IconCloudUpload,
   Button,
-  Text
+  Text,
+  Flex,
+  IconCheck
 } from '@audius/harmony-native'
 import { getChallengeConfig } from 'app/utils/challenges'
 
@@ -35,7 +37,9 @@ const messages = {
   viewPremiumTracks: 'View Premium Tracks',
   uploadTrack: 'Upload Track',
   totalClaimed: (amount: string) => `Total $AUDIO Claimed: ${amount}`,
-  claimAudio: (amount: string) => `Claim ${amount} $AUDIO`
+  claimAudio: (amount: string) => `Claim ${amount} $AUDIO`,
+  readyToClaim: 'Ready to Claim',
+  incomplete: 'No recent purchases'
 }
 
 type AudioMatchingChallengeName =
@@ -88,29 +92,53 @@ export const AudioMatchingChallengeDrawerContent = ({
     claimStatus === ClaimStatus.CLAIMING ||
     claimStatus === ClaimStatus.WAITING_FOR_RETRY
   const claimError = claimStatus === ClaimStatus.ERROR
+  const isClaimable = claimableAmount > 0
+  const statusText = isClaimable ? messages.readyToClaim : messages.incomplete
 
   return (
-    <View style={styles.scrollViewContainer}>
+    <Flex style={styles.scrollViewContainer}>
       <ScrollView contentContainerStyle={styles.scrollViewContent}>
         <ChallengeDescription
           renderDescription={() => (
-            <View style={styles.audioMatchingDescriptionContainer}>
+            <Flex style={styles.audioMatchingDescriptionContainer}>
               <Text size='l'>{config.description(challenge)}</Text>
               <Text color='subdued'>
                 {messages.descriptionSubtext[challengeName]}
               </Text>
-            </View>
+            </Flex>
           )}
         />
-        <View>
-          <View style={styles.statusGridColumns}>
-            <ChallengeReward
-              amount={challenge.amount}
-              subtext={messages.rewardMapping[challengeName]}
-            />
-          </View>
+        <Flex alignItems='center' gap='3xl' w='100%'>
+          <ChallengeReward
+            amount={challenge.amount}
+            subtext={messages.rewardMapping[challengeName]}
+          />
+          <Flex
+            w='100%'
+            ph='xl'
+            border='default'
+            borderRadius='s'
+            backgroundColor='surface1'
+          >
+            <Flex
+              row
+              w='100%'
+              alignItems='center'
+              justifyContent='center'
+              gap='s'
+              pv='l'
+            >
+              {isClaimable ? <IconCheck size='s' color='subdued' /> : null}
+              {/* Hack due to broken lineHeight for certain fonts */}
+              <Flex mt='unitHalf'>
+                <Text variant='label' size='l' color='subdued'>
+                  {statusText}
+                </Text>
+              </Flex>
+            </Flex>
+          </Flex>
           {claimedAmount > 0 ? (
-            <View style={styles.claimedAmountContainer}>
+            <Flex style={styles.claimedAmountContainer}>
               <Text
                 variant='label'
                 size='s'
@@ -119,12 +147,12 @@ export const AudioMatchingChallengeDrawerContent = ({
               >
                 {messages.totalClaimed(formatNumberCommas(claimedAmount))}
               </Text>
-            </View>
+            </Flex>
           ) : null}
-        </View>
+        </Flex>
         <CooldownSummaryTable challengeId={challengeName} />
       </ScrollView>
-      <View style={styles.stickyClaimRewardsContainer}>
+      <Flex w='100%' ph='l' pv='m' gap='l'>
         {claimableAmount > 0 && onClaim ? (
           <Button
             disabled={claimInProgress}
@@ -145,7 +173,7 @@ export const AudioMatchingChallengeDrawerContent = ({
           />
         )}
         {claimError ? <ClaimError aaoErrorCode={aaoErrorCode} /> : null}
-      </View>
-    </View>
+      </Flex>
+    </Flex>
   )
 }

--- a/packages/mobile/src/components/challenge-rewards-drawer/ChallengeRewardsDrawerProvider.tsx
+++ b/packages/mobile/src/components/challenge-rewards-drawer/ChallengeRewardsDrawerProvider.tsx
@@ -247,6 +247,7 @@ export const ChallengeRewardsDrawerProvider = () => {
           aaoErrorCode={aaoErrorCode}
           onClaim={hasConfig ? onClaim : undefined}
           isVerifiedChallenge={!!config.isVerifiedChallenge}
+          onClose={handleClose}
           showProgressBar={
             challenge.challenge_type !== 'aggregate' &&
             challenge.max_steps !== null &&

--- a/packages/mobile/src/components/challenge-rewards-drawer/ListenStreakEndlessChallengeDrawerContent.tsx
+++ b/packages/mobile/src/components/challenge-rewards-drawer/ListenStreakEndlessChallengeDrawerContent.tsx
@@ -83,9 +83,12 @@ export const ListenStreakEndlessChallengeDrawerContent = ({
               pv='l'
             >
               <IconHeadphones size='s' color='subdued' />
-              <Text variant='label' size='l' color='subdued'>
-                {messages.day(challenge.current_step_count)}
-              </Text>
+              {/* Hack due to broken lineHeight for certain fonts */}
+              <Flex mt='unitHalf'>
+                <Text variant='label' size='l' color='subdued'>
+                  {messages.day(challenge.current_step_count)}
+                </Text>
+              </Flex>
             </Flex>
             {claimedAmount > 0 ? (
               <Flex

--- a/packages/mobile/src/components/challenge-rewards-drawer/ReferralRewardContents.tsx
+++ b/packages/mobile/src/components/challenge-rewards-drawer/ReferralRewardContents.tsx
@@ -17,7 +17,7 @@ export const ReferralRewardContents = ({
   const inviteUrl = `audius.co/signup?rf=${handle}`
 
   return (
-    <Flex gap='m'>
+    <Flex gap='m' w='100%'>
       <TwitterShareButton inviteUrl={inviteUrl} isVerified={isVerified} />
       <ReferralLinkCopyButton inviteUrl={inviteUrl} />
     </Flex>

--- a/packages/mobile/src/components/challenge-rewards-drawer/styles.ts
+++ b/packages/mobile/src/components/challenge-rewards-drawer/styles.ts
@@ -4,8 +4,7 @@ export const useStyles = makeStyles(({ palette, spacing, typography }) => ({
   content: {
     padding: spacing(4),
     paddingTop: spacing(6),
-    gap: spacing(6),
-    flex: 1
+    gap: spacing(6)
   },
   scrollViewContainer: {
     flex: 1

--- a/packages/mobile/src/components/challenge-rewards-drawer/styles.ts
+++ b/packages/mobile/src/components/challenge-rewards-drawer/styles.ts
@@ -4,7 +4,8 @@ export const useStyles = makeStyles(({ palette, spacing, typography }) => ({
   content: {
     padding: spacing(4),
     paddingTop: spacing(6),
-    gap: spacing(6)
+    gap: spacing(6),
+    flex: 1
   },
   scrollViewContainer: {
     flex: 1


### PR DESCRIPTION
### Description
Since I had removed the "box-in-box" UI from mobile rewards drawers, I needed to add the complete/incomplete status indicator.

Also moved the claim and close button to the bottom of the screen and removed the border to match new designs.

Includes a dirty hack to fix the alignment of `label` text variants. Don't want to push out a big change to harmony right now.

### How Has This Been Tested?
Checked most rewards, paid special attention to oneshot.

![Simulator Screenshot - iPhone 16 Pro - 2025-02-05 at 16 34 41](https://github.com/user-attachments/assets/bb88dfba-7fb7-41b4-b974-42f5a87e34e2)
![Simulator Screenshot - iPhone 16 Pro - 2025-02-05 at 16 34 52](https://github.com/user-attachments/assets/96ac0af7-6921-4b41-aac9-53390ba7794e)
![Simulator Screenshot - iPhone 16 Pro - 2025-02-05 at 16 35 04](https://github.com/user-attachments/assets/55b44ca2-3dd6-4ef2-9b33-b9293c06c24e)
![Simulator Screenshot - iPhone 16 Pro - 2025-02-05 at 16 41 34](https://github.com/user-attachments/assets/7c4d3011-908b-465d-b952-ed858acafcf7)
![Simulator Screenshot - iPhone 16 Pro - 2025-02-05 at 16 41 52](https://github.com/user-attachments/assets/8d0a54db-bb9e-40b4-b888-c7541a17f1c1)