### PR TITLE
Turn off broadcast for listens on solana relay

### DIFF
--- a/packages/discovery-provider/plugins/pedalboard/apps/solana-relay/src/routes/listen/listen.ts
+++ b/packages/discovery-provider/plugins/pedalboard/apps/solana-relay/src/routes/listen/listen.ts
@@ -20,10 +20,7 @@ import { getCachedContentNodes } from '../../redis'
 import { getConnection } from '../../utils/connections'
 import { getIP, getIpData } from '../../utils/ipData'
 import { sortKeys } from '../../utils/sortKeys'
-import {
-  broadcastTransaction,
-  sendTransactionWithRetries
-} from '../../utils/transaction'
+import { sendTransactionWithRetries } from '../../utils/transaction'
 
 import {
   createTrackListenInstructions,
@@ -146,9 +143,6 @@ export const recordListen = async (
   })
 
   logger.info({ solTxSignature }, 'transaction sig')
-
-  // no need to confirm since we already confirm in the sendTransactionWithRetries
-  await broadcastTransaction({ logger, signature: solTxSignature })
 
   return { solTxSignature }
 }


### PR DESCRIPTION
### Description

No longer needed because we aren't indexing listens from sol atm.

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._

Tested on prod node