### PR TITLE
Aggregate step_count for listen streak challenge response

### DIFF
--- a/packages/discovery-provider/src/queries/get_challenges.py
+++ b/packages/discovery-provider/src/queries/get_challenges.py
@@ -65,6 +65,14 @@ def rollup_aggregates(
         step_count = sum(challenge.amount for challenge in user_challenges)
         amount = "1"
         is_complete = True
+    elif parent_challenge.id == "e":
+        # for listen streak we want to sum the actual step counts as they represent the
+        # number of consecutive days in the user's listen streak
+        num_complete = sum(
+            challenge.current_step_count
+            for challenge in user_challenges
+            if challenge.current_step_count is not None
+        )
     elif parent_challenge.step_count:
         is_complete = num_complete >= parent_challenge.step_count
     else:


### PR DESCRIPTION
### Description
For listen streak challenge we use `current_step_count` to represent the number of days of the user's listen streak.

### How Has This Been Tested?

Trying to test on local stack but it borked..