### PR TITLE
Skip auth on purchase/sale count

### DIFF
--- a/packages/discovery-provider/src/api/v1/users.py
+++ b/packages/discovery-provider/src/api/v1/users.py
@@ -2542,8 +2542,6 @@ class FullPurchasesCount(Resource):
     @full_ns.marshal_with(purchases_count_response)
     def get(self, id, authed_user_id):
         decoded_id = decode_with_abort(id, full_ns)
-        if decoded_id and not is_authorized_request(decoded_id):
-            abort(403, message="You are not authorized to access this resource")
         args = purchases_and_sales_count_parser.parse_args()
         content_ids = args.get("content_ids", [])
         decoded_content_ids = decode_ids_array(content_ids) if content_ids else []
@@ -2599,8 +2597,6 @@ class FullSalesCount(Resource):
     @full_ns.marshal_with(purchases_count_response)
     def get(self, id, authed_user_id):
         decoded_id = decode_with_abort(id, full_ns)
-        if decoded_id and not is_authorized_request(decoded_id):
-            abort(403, message="You are not authorized to access this resource")
         args = purchases_and_sales_count_parser.parse_args()
         content_ids = args.get("content_ids", [])
         decoded_content_ids = decode_ids_array(content_ids) if content_ids else []


### PR DESCRIPTION
### Description

Skip auth so oauth'd users can read purchase/sale count

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._

tested on stage and confirmed a signature is no longer required.