### PR TITLE
Fix stale time usage to respect client defaults

### DIFF
--- a/packages/common/src/api/tan-query/developerApps.ts
+++ b/packages/common/src/api/tan-query/developerApps.ts
@@ -87,8 +87,8 @@ export const useDeveloperApps = (options?: QueryOptions) => {
 
       return data
     },
-    staleTime: options?.staleTime,
-    enabled: options?.enabled !== false && !!userId
+    enabled: options?.enabled !== false && !!userId,
+    ...options
   })
 }
 

--- a/packages/common/src/api/tan-query/developerApps.ts
+++ b/packages/common/src/api/tan-query/developerApps.ts
@@ -87,8 +87,8 @@ export const useDeveloperApps = (options?: QueryOptions) => {
 
       return data
     },
-    enabled: options?.enabled !== false && !!userId,
-    ...options
+    ...options,
+    enabled: options?.enabled !== false && !!userId
   })
 }
 

--- a/packages/common/src/api/tan-query/useAiTracks.ts
+++ b/packages/common/src/api/tan-query/useAiTracks.ts
@@ -31,7 +31,7 @@ export const getAiTracksQueryKey = ({
 
 export const useAiTracks = (
   { handle, pageSize = DEFAULT_PAGE_SIZE }: UseAiTracksArgs,
-  config?: QueryOptions
+  options?: QueryOptions
 ) => {
   const { audiusSdk } = useAudiusQueryContext()
   const { data: currentUserId } = useCurrentUserId()
@@ -79,8 +79,8 @@ export const useAiTracks = (
 
       return processedTracks
     },
-    staleTime: config?.staleTime,
-    enabled: config?.enabled !== false && !!handle
+    enabled: options?.enabled !== false && !!handle,
+    ...options
   })
 
   const lineupData = useLineupQuery({

--- a/packages/common/src/api/tan-query/useAiTracks.ts
+++ b/packages/common/src/api/tan-query/useAiTracks.ts
@@ -79,8 +79,8 @@ export const useAiTracks = (
 
       return processedTracks
     },
-    enabled: options?.enabled !== false && !!handle,
-    ...options
+    ...options,
+    enabled: options?.enabled !== false && !!handle
   })
 
   const lineupData = useLineupQuery({

--- a/packages/common/src/api/tan-query/useAudioTransactions.ts
+++ b/packages/common/src/api/tan-query/useAudioTransactions.ts
@@ -79,8 +79,8 @@ export const useAudioTransactions = (
       if (lastPage?.length < pageSize) return undefined
       return allPages.length * pageSize
     },
-    enabled: options?.enabled !== false && !!userId,
-    ...options
+    ...options,
+    enabled: options?.enabled !== false && !!userId
   })
 
   const pages = query.data?.pages

--- a/packages/common/src/api/tan-query/useAudioTransactions.ts
+++ b/packages/common/src/api/tan-query/useAudioTransactions.ts
@@ -79,8 +79,8 @@ export const useAudioTransactions = (
       if (lastPage?.length < pageSize) return undefined
       return allPages.length * pageSize
     },
-    staleTime: options?.staleTime,
-    enabled: options?.enabled !== false && !!userId
+    enabled: options?.enabled !== false && !!userId,
+    ...options
   })
 
   const pages = query.data?.pages

--- a/packages/common/src/api/tan-query/useAudioTransactionsCount.ts
+++ b/packages/common/src/api/tan-query/useAudioTransactionsCount.ts
@@ -30,7 +30,7 @@ export const useAudioTransactionsCount = (options?: QueryOptions) => {
 
       return response.data ?? 0
     },
-    staleTime: options?.staleTime,
-    enabled: options?.enabled !== false && !!userId
+    enabled: options?.enabled !== false && !!userId,
+    ...options
   })
 }

--- a/packages/common/src/api/tan-query/useAudioTransactionsCount.ts
+++ b/packages/common/src/api/tan-query/useAudioTransactionsCount.ts
@@ -30,7 +30,7 @@ export const useAudioTransactionsCount = (options?: QueryOptions) => {
 
       return response.data ?? 0
     },
-    enabled: options?.enabled !== false && !!userId,
-    ...options
+    ...options,
+    enabled: options?.enabled !== false && !!userId
   })
 }

--- a/packages/common/src/api/tan-query/useAuthorizedApps.ts
+++ b/packages/common/src/api/tan-query/useAuthorizedApps.ts
@@ -28,7 +28,7 @@ export const useAuthorizedApps = (options?: QueryOptions) => {
 
       return data
     },
-    enabled: options?.enabled !== false && !!userId,
-    ...options
+    ...options,
+    enabled: options?.enabled !== false && !!userId
   })
 }

--- a/packages/common/src/api/tan-query/useAuthorizedApps.ts
+++ b/packages/common/src/api/tan-query/useAuthorizedApps.ts
@@ -28,7 +28,7 @@ export const useAuthorizedApps = (options?: QueryOptions) => {
 
       return data
     },
-    staleTime: options?.staleTime,
-    enabled: options?.enabled !== false && !!userId
+    enabled: options?.enabled !== false && !!userId,
+    ...options
   })
 }

--- a/packages/common/src/api/tan-query/useCollectionByPermalink.ts
+++ b/packages/common/src/api/tan-query/useCollectionByPermalink.ts
@@ -64,7 +64,6 @@ export const useCollectionByPermalink = (
       return collection
     },
     staleTime: options?.staleTime ?? STALE_TIME,
-    enabled: options?.enabled !== false && !!permalink,
-    ...options
+    enabled: options?.enabled !== false && !!permalink
   })
 }

--- a/packages/common/src/api/tan-query/useCollectionByPermalink.ts
+++ b/packages/common/src/api/tan-query/useCollectionByPermalink.ts
@@ -64,6 +64,7 @@ export const useCollectionByPermalink = (
       return collection
     },
     staleTime: options?.staleTime ?? STALE_TIME,
-    enabled: options?.enabled !== false && !!permalink
+    enabled: options?.enabled !== false && !!permalink,
+    ...options
   })
 }

--- a/packages/common/src/api/tan-query/useCollectionFavorites.ts
+++ b/packages/common/src/api/tan-query/useCollectionFavorites.ts
@@ -57,7 +57,7 @@ export const useCollectionFavorites = (
       return users
     },
     select: (data) => data.pages.flat(),
-    enabled: options?.enabled !== false && !!collectionId,
-    ...options
+    ...options,
+    enabled: options?.enabled !== false && !!collectionId
   })
 }

--- a/packages/common/src/api/tan-query/useCollectionFavorites.ts
+++ b/packages/common/src/api/tan-query/useCollectionFavorites.ts
@@ -57,7 +57,7 @@ export const useCollectionFavorites = (
       return users
     },
     select: (data) => data.pages.flat(),
-    staleTime: options?.staleTime,
-    enabled: options?.enabled !== false && !!collectionId
+    enabled: options?.enabled !== false && !!collectionId,
+    ...options
   })
 }

--- a/packages/common/src/api/tan-query/useCollectionReposts.ts
+++ b/packages/common/src/api/tan-query/useCollectionReposts.ts
@@ -53,7 +53,7 @@ export const useCollectionReposts = (
       return users
     },
     select: (data) => data.pages.flat(),
-    enabled: options?.enabled !== false && !!collectionId,
-    ...options
+    ...options,
+    enabled: options?.enabled !== false && !!collectionId
   })
 }

--- a/packages/common/src/api/tan-query/useCollectionReposts.ts
+++ b/packages/common/src/api/tan-query/useCollectionReposts.ts
@@ -53,7 +53,7 @@ export const useCollectionReposts = (
       return users
     },
     select: (data) => data.pages.flat(),
-    staleTime: options?.staleTime,
-    enabled: options?.enabled !== false && !!collectionId
+    enabled: options?.enabled !== false && !!collectionId,
+    ...options
   })
 }

--- a/packages/common/src/api/tan-query/useCollections.ts
+++ b/packages/common/src/api/tan-query/useCollections.ts
@@ -45,7 +45,7 @@ export const useCollections = (
 
       return collections
     },
-    enabled: options?.enabled !== false && !!collectionIds,
-    ...options
+    ...options,
+    enabled: options?.enabled !== false && !!collectionIds
   })
 }

--- a/packages/common/src/api/tan-query/useCollections.ts
+++ b/packages/common/src/api/tan-query/useCollections.ts
@@ -45,7 +45,7 @@ export const useCollections = (
 
       return collections
     },
-    staleTime: options?.staleTime,
-    enabled: options?.enabled !== false && !!collectionIds
+    enabled: options?.enabled !== false && !!collectionIds,
+    ...options
   })
 }

--- a/packages/common/src/api/tan-query/useCurrentUser.ts
+++ b/packages/common/src/api/tan-query/useCurrentUser.ts
@@ -35,7 +35,7 @@ export const useCurrentUser = (options?: QueryOptions) => {
       const account = accountFromSDK(data)
       return account?.user
     },
-    enabled: options?.enabled !== false && !!currentUser,
-    ...options
+    ...options,
+    enabled: options?.enabled !== false && !!currentUser
   })
 }

--- a/packages/common/src/api/tan-query/useCurrentUser.ts
+++ b/packages/common/src/api/tan-query/useCurrentUser.ts
@@ -35,7 +35,7 @@ export const useCurrentUser = (options?: QueryOptions) => {
       const account = accountFromSDK(data)
       return account?.user
     },
-    staleTime: options?.staleTime,
-    enabled: options?.enabled !== false && !!currentUser
+    enabled: options?.enabled !== false && !!currentUser,
+    ...options
   })
 }

--- a/packages/common/src/api/tan-query/useEmailInUse.ts
+++ b/packages/common/src/api/tan-query/useEmailInUse.ts
@@ -31,7 +31,7 @@ export const useEmailInUse = (
   return useQuery({
     queryKey: getEmailInUseQueryKey(email),
     queryFn: () => fetchEmailInUse(email, context),
-    staleTime: options?.staleTime,
-    enabled: options?.enabled !== false && !!email
+    enabled: options?.enabled !== false && !!email,
+    ...options
   })
 }

--- a/packages/common/src/api/tan-query/useEmailInUse.ts
+++ b/packages/common/src/api/tan-query/useEmailInUse.ts
@@ -31,7 +31,7 @@ export const useEmailInUse = (
   return useQuery({
     queryKey: getEmailInUseQueryKey(email),
     queryFn: () => fetchEmailInUse(email, context),
-    enabled: options?.enabled !== false && !!email,
-    ...options
+    ...options,
+    enabled: options?.enabled !== false && !!email
   })
 }

--- a/packages/common/src/api/tan-query/useExploreContent.ts
+++ b/packages/common/src/api/tan-query/useExploreContent.ts
@@ -35,7 +35,7 @@ export const useExploreContent = (options?: QueryOptions) => {
         )
       }
     },
-    staleTime: options?.staleTime,
-    enabled: options?.enabled !== false
+    enabled: options?.enabled !== false,
+    ...options
   })
 }

--- a/packages/common/src/api/tan-query/useExploreContent.ts
+++ b/packages/common/src/api/tan-query/useExploreContent.ts
@@ -35,7 +35,7 @@ export const useExploreContent = (options?: QueryOptions) => {
         )
       }
     },
-    enabled: options?.enabled !== false,
-    ...options
+    ...options,
+    enabled: options?.enabled !== false
   })
 }

--- a/packages/common/src/api/tan-query/useFavoritedTracks.ts
+++ b/packages/common/src/api/tan-query/useFavoritedTracks.ts
@@ -30,7 +30,7 @@ export const useFavoritedTracks = (
 
       return transformAndCleanList(data, favoriteFromSDK)
     },
-    staleTime: options?.staleTime,
-    enabled: options?.enabled !== false && !!userId
+    enabled: options?.enabled !== false && !!userId,
+    ...options
   })
 }

--- a/packages/common/src/api/tan-query/useFavoritedTracks.ts
+++ b/packages/common/src/api/tan-query/useFavoritedTracks.ts
@@ -30,7 +30,7 @@ export const useFavoritedTracks = (
 
       return transformAndCleanList(data, favoriteFromSDK)
     },
-    enabled: options?.enabled !== false && !!userId,
-    ...options
+    ...options,
+    enabled: options?.enabled !== false && !!userId
   })
 }

--- a/packages/common/src/api/tan-query/useFollowers.ts
+++ b/packages/common/src/api/tan-query/useFollowers.ts
@@ -57,7 +57,7 @@ export const useFollowers = (
       return users
     },
     select: (data) => data.pages.flat(),
-    staleTime: options?.staleTime,
-    enabled: options?.enabled !== false && !!userId
+    enabled: options?.enabled !== false && !!userId,
+    ...options
   })
 }

--- a/packages/common/src/api/tan-query/useFollowers.ts
+++ b/packages/common/src/api/tan-query/useFollowers.ts
@@ -57,7 +57,7 @@ export const useFollowers = (
       return users
     },
     select: (data) => data.pages.flat(),
-    enabled: options?.enabled !== false && !!userId,
-    ...options
+    ...options,
+    enabled: options?.enabled !== false && !!userId
   })
 }

--- a/packages/common/src/api/tan-query/useFollowing.ts
+++ b/packages/common/src/api/tan-query/useFollowing.ts
@@ -57,7 +57,7 @@ export const useFollowing = (
       return users
     },
     select: (data) => data.pages.flat(),
-    staleTime: options?.staleTime,
-    enabled: options?.enabled !== false && !!userId
+    enabled: options?.enabled !== false && !!userId,
+    ...options
   })
 }

--- a/packages/common/src/api/tan-query/useFollowing.ts
+++ b/packages/common/src/api/tan-query/useFollowing.ts
@@ -57,7 +57,7 @@ export const useFollowing = (
       return users
     },
     select: (data) => data.pages.flat(),
-    enabled: options?.enabled !== false && !!userId,
-    ...options
+    ...options,
+    enabled: options?.enabled !== false && !!userId
   })
 }

--- a/packages/common/src/api/tan-query/useHandleInUse.ts
+++ b/packages/common/src/api/tan-query/useHandleInUse.ts
@@ -44,7 +44,7 @@ export const useHandleInUse = (
   return useQuery({
     queryKey: getHandleInUseQueryKey(handle),
     queryFn: () => fetchHandleInUse(handle, context),
-    enabled: options?.enabled !== false && !!handle,
-    ...options
+    ...options,
+    enabled: options?.enabled !== false && !!handle
   })
 }

--- a/packages/common/src/api/tan-query/useHandleInUse.ts
+++ b/packages/common/src/api/tan-query/useHandleInUse.ts
@@ -44,7 +44,7 @@ export const useHandleInUse = (
   return useQuery({
     queryKey: getHandleInUseQueryKey(handle),
     queryFn: () => fetchHandleInUse(handle, context),
-    staleTime: options?.staleTime,
-    enabled: options?.enabled !== false && !!handle
+    enabled: options?.enabled !== false && !!handle,
+    ...options
   })
 }

--- a/packages/common/src/api/tan-query/useHandleReservedStatus.ts
+++ b/packages/common/src/api/tan-query/useHandleReservedStatus.ts
@@ -89,7 +89,7 @@ export const useHandleReservedStatus = (
   return useQuery({
     queryKey: getHandleReservedStatusQueryKey(handle),
     queryFn: () => fetchHandleReservedStatus(handle, context),
-    staleTime: options?.staleTime,
-    enabled: options?.enabled !== false && !!handle
+    enabled: options?.enabled !== false && !!handle,
+    ...options
   })
 }

--- a/packages/common/src/api/tan-query/useHandleReservedStatus.ts
+++ b/packages/common/src/api/tan-query/useHandleReservedStatus.ts
@@ -89,7 +89,7 @@ export const useHandleReservedStatus = (
   return useQuery({
     queryKey: getHandleReservedStatusQueryKey(handle),
     queryFn: () => fetchHandleReservedStatus(handle, context),
-    enabled: options?.enabled !== false && !!handle,
-    ...options
+    ...options,
+    enabled: options?.enabled !== false && !!handle
   })
 }

--- a/packages/common/src/api/tan-query/useMutedUsers.ts
+++ b/packages/common/src/api/tan-query/useMutedUsers.ts
@@ -34,7 +34,7 @@ export const useMutedUsers = (options?: QueryOptions) => {
       primeUserData({ users, queryClient, dispatch })
       return users
     },
-    staleTime: options?.staleTime,
-    enabled: options?.enabled !== false && !!currentUserId
+    enabled: options?.enabled !== false && !!currentUserId,
+    ...options
   })
 }

--- a/packages/common/src/api/tan-query/useMutedUsers.ts
+++ b/packages/common/src/api/tan-query/useMutedUsers.ts
@@ -34,7 +34,7 @@ export const useMutedUsers = (options?: QueryOptions) => {
       primeUserData({ users, queryClient, dispatch })
       return users
     },
-    enabled: options?.enabled !== false && !!currentUserId,
-    ...options
+    ...options,
+    enabled: options?.enabled !== false && !!currentUserId
   })
 }

--- a/packages/common/src/api/tan-query/useMutualFollowers.ts
+++ b/packages/common/src/api/tan-query/useMutualFollowers.ts
@@ -52,7 +52,7 @@ export const useMutualFollowers = (
       return users
     },
     select: (data) => data.pages.flat(),
-    staleTime: options?.staleTime,
-    enabled: options?.enabled !== false && !!userId && !!currentUserId
+    enabled: options?.enabled !== false && !!userId && !!currentUserId,
+    ...options
   })
 }

--- a/packages/common/src/api/tan-query/useMutualFollowers.ts
+++ b/packages/common/src/api/tan-query/useMutualFollowers.ts
@@ -52,7 +52,7 @@ export const useMutualFollowers = (
       return users
     },
     select: (data) => data.pages.flat(),
-    enabled: options?.enabled !== false && !!userId && !!currentUserId,
-    ...options
+    ...options,
+    enabled: options?.enabled !== false && !!userId && !!currentUserId
   })
 }

--- a/packages/common/src/api/tan-query/usePremiumTracks.ts
+++ b/packages/common/src/api/tan-query/usePremiumTracks.ts
@@ -30,7 +30,7 @@ export const getPremiumTracksQueryKey = (pageSize: number) => [
 
 export const usePremiumTracks = (
   { pageSize = DEFAULT_PAGE_SIZE }: UsePremiumTracksArgs = {},
-  config?: QueryOptions
+  options?: QueryOptions
 ) => {
   const { audiusSdk } = useAudiusQueryContext()
   const { data: currentUserId } = useCurrentUserId()
@@ -74,8 +74,8 @@ export const usePremiumTracks = (
 
       return processedTracks
     },
-    staleTime: config?.staleTime,
-    enabled: config?.enabled !== false
+    enabled: options?.enabled !== false,
+    ...options
   })
 
   const lineupData = useLineupQuery({

--- a/packages/common/src/api/tan-query/usePremiumTracks.ts
+++ b/packages/common/src/api/tan-query/usePremiumTracks.ts
@@ -74,8 +74,8 @@ export const usePremiumTracks = (
 
       return processedTracks
     },
-    enabled: options?.enabled !== false,
-    ...options
+    ...options,
+    enabled: options?.enabled !== false
   })
 
   const lineupData = useLineupQuery({

--- a/packages/common/src/api/tan-query/useProfileReposts.ts
+++ b/packages/common/src/api/tan-query/useProfileReposts.ts
@@ -37,7 +37,7 @@ export const getProfileRepostsQueryKey = ({
 
 export const useProfileReposts = (
   { handle, pageSize = DEFAULT_PAGE_SIZE }: UseProfileRepostsArgs,
-  config?: QueryOptions
+  options?: QueryOptions
 ) => {
   const { audiusSdk } = useAudiusQueryContext()
   const { data: currentUserId } = useCurrentUserId()
@@ -95,8 +95,8 @@ export const useProfileReposts = (
 
       return reposts
     },
-    staleTime: config?.staleTime,
-    enabled: config?.enabled !== false && !!handle
+    enabled: options?.enabled !== false && !!handle,
+    ...options
   })
 
   const lineupData = useLineupQuery({

--- a/packages/common/src/api/tan-query/useProfileReposts.ts
+++ b/packages/common/src/api/tan-query/useProfileReposts.ts
@@ -95,8 +95,8 @@ export const useProfileReposts = (
 
       return reposts
     },
-    enabled: options?.enabled !== false && !!handle,
-    ...options
+    ...options,
+    enabled: options?.enabled !== false && !!handle
   })
 
   const lineupData = useLineupQuery({

--- a/packages/common/src/api/tan-query/useProfileTracks.ts
+++ b/packages/common/src/api/tan-query/useProfileTracks.ts
@@ -45,7 +45,7 @@ export const useProfileTracks = (
     sort = TracksSortMode.RECENT,
     getUnlisted = true
   }: UseProfileTracksArgs,
-  config?: QueryOptions
+  options?: QueryOptions
 ) => {
   const { audiusSdk } = useAudiusQueryContext()
   const { data: currentUserId } = useCurrentUserId()
@@ -92,8 +92,8 @@ export const useProfileTracks = (
 
       return processedTracks
     },
-    staleTime: config?.staleTime,
-    enabled: config?.enabled !== false && !!handle
+    enabled: options?.enabled !== false && !!handle,
+    ...options
   })
 
   const lineupData = useLineupQuery({

--- a/packages/common/src/api/tan-query/useProfileTracks.ts
+++ b/packages/common/src/api/tan-query/useProfileTracks.ts
@@ -92,8 +92,8 @@ export const useProfileTracks = (
 
       return processedTracks
     },
-    enabled: options?.enabled !== false && !!handle,
-    ...options
+    ...options,
+    enabled: options?.enabled !== false && !!handle
   })
 
   const lineupData = useLineupQuery({

--- a/packages/common/src/api/tan-query/usePurchasers.ts
+++ b/packages/common/src/api/tan-query/usePurchasers.ts
@@ -66,7 +66,7 @@ export const usePurchasers = (
       return users
     },
     select: (data) => data.pages.flat(),
-    enabled: options?.enabled !== false && !!currentUserId,
-    ...options
+    ...options,
+    enabled: options?.enabled !== false && !!currentUserId
   })
 }

--- a/packages/common/src/api/tan-query/usePurchasers.ts
+++ b/packages/common/src/api/tan-query/usePurchasers.ts
@@ -66,7 +66,7 @@ export const usePurchasers = (
       return users
     },
     select: (data) => data.pages.flat(),
-    staleTime: options?.staleTime,
-    enabled: options?.enabled !== false && !!currentUserId
+    enabled: options?.enabled !== false && !!currentUserId,
+    ...options
   })
 }

--- a/packages/common/src/api/tan-query/usePurchasersCount.ts
+++ b/packages/common/src/api/tan-query/usePurchasersCount.ts
@@ -45,7 +45,7 @@ export const usePurchasersCount = (
       return data
     },
 
-    staleTime: options?.staleTime,
-    enabled: options?.enabled !== false && !!currentUserId
+    enabled: options?.enabled !== false && !!currentUserId,
+    ...options
   })
 }

--- a/packages/common/src/api/tan-query/usePurchasersCount.ts
+++ b/packages/common/src/api/tan-query/usePurchasersCount.ts
@@ -44,8 +44,7 @@ export const usePurchasersCount = (
       })
       return data
     },
-
-    enabled: options?.enabled !== false && !!currentUserId,
-    ...options
+    ...options,
+    enabled: options?.enabled !== false && !!currentUserId
   })
 }

--- a/packages/common/src/api/tan-query/usePurchasesCount.ts
+++ b/packages/common/src/api/tan-query/usePurchasesCount.ts
@@ -32,7 +32,7 @@ export const usePurchasesCount = (
       })
       return data
     },
-    enabled: options?.enabled !== false && !!audiusSdk && !!userId,
-    ...options
+    ...options,
+    enabled: options?.enabled !== false && !!audiusSdk && !!userId
   })
 }

--- a/packages/common/src/api/tan-query/usePurchasesCount.ts
+++ b/packages/common/src/api/tan-query/usePurchasesCount.ts
@@ -32,7 +32,7 @@ export const usePurchasesCount = (
       })
       return data
     },
-    staleTime: options?.staleTime,
-    enabled: options?.enabled !== false && !!audiusSdk && !!userId
+    enabled: options?.enabled !== false && !!audiusSdk && !!userId,
+    ...options
   })
 }

--- a/packages/common/src/api/tan-query/useRelatedArtists.ts
+++ b/packages/common/src/api/tan-query/useRelatedArtists.ts
@@ -64,7 +64,7 @@ export const useRelatedArtists = (
       return users
     },
     select: (data) => data.pages.flat(),
-    staleTime: options?.staleTime,
-    enabled: options?.enabled !== false && !!artistId
+    enabled: options?.enabled !== false && !!artistId,
+    ...options
   })
 }

--- a/packages/common/src/api/tan-query/useRelatedArtists.ts
+++ b/packages/common/src/api/tan-query/useRelatedArtists.ts
@@ -64,7 +64,7 @@ export const useRelatedArtists = (
       return users
     },
     select: (data) => data.pages.flat(),
-    enabled: options?.enabled !== false && !!artistId,
-    ...options
+    ...options,
+    enabled: options?.enabled !== false && !!artistId
   })
 }

--- a/packages/common/src/api/tan-query/useRemixedTracks.ts
+++ b/packages/common/src/api/tan-query/useRemixedTracks.ts
@@ -36,7 +36,7 @@ export const useRemixedTracks = (options?: QueryOptions) => {
         trackId: HashId.parse(item.trackId)
       }))
     },
-    staleTime: options?.staleTime,
-    enabled: options?.enabled !== false && !!currentUserId
+    enabled: options?.enabled !== false && !!currentUserId,
+    ...options
   })
 }

--- a/packages/common/src/api/tan-query/useRemixedTracks.ts
+++ b/packages/common/src/api/tan-query/useRemixedTracks.ts
@@ -36,7 +36,7 @@ export const useRemixedTracks = (options?: QueryOptions) => {
         trackId: HashId.parse(item.trackId)
       }))
     },
-    enabled: options?.enabled !== false && !!currentUserId,
-    ...options
+    ...options,
+    enabled: options?.enabled !== false && !!currentUserId
   })
 }

--- a/packages/common/src/api/tan-query/useRemixers.ts
+++ b/packages/common/src/api/tan-query/useRemixers.ts
@@ -56,7 +56,7 @@ export const useRemixers = (
       return users
     },
     select: (data) => data.pages.flat(),
-    enabled: options?.enabled !== false && !!userId,
-    ...options
+    ...options,
+    enabled: options?.enabled !== false && !!userId
   })
 }

--- a/packages/common/src/api/tan-query/useRemixers.ts
+++ b/packages/common/src/api/tan-query/useRemixers.ts
@@ -56,7 +56,7 @@ export const useRemixers = (
       return users
     },
     select: (data) => data.pages.flat(),
-    staleTime: options?.staleTime,
-    enabled: options?.enabled !== false && !!userId
+    enabled: options?.enabled !== false && !!userId,
+    ...options
   })
 }

--- a/packages/common/src/api/tan-query/useRemixersCount.ts
+++ b/packages/common/src/api/tan-query/useRemixersCount.ts
@@ -36,8 +36,7 @@ export const useRemixersCount = (
       })
       return data
     },
-
-    staleTime: options?.staleTime,
-    enabled: options?.enabled !== false && !!currentUserId
+    enabled: options?.enabled !== false && !!currentUserId,
+    ...options
   })
 }

--- a/packages/common/src/api/tan-query/useRemixersCount.ts
+++ b/packages/common/src/api/tan-query/useRemixersCount.ts
@@ -36,7 +36,7 @@ export const useRemixersCount = (
       })
       return data
     },
-    enabled: options?.enabled !== false && !!currentUserId,
-    ...options
+    ...options,
+    enabled: options?.enabled !== false && !!currentUserId
   })
 }

--- a/packages/common/src/api/tan-query/useRemixes.ts
+++ b/packages/common/src/api/tan-query/useRemixes.ts
@@ -35,7 +35,7 @@ export const getRemixesQueryKey = ({
 
 export const useRemixes = (
   { trackId, pageSize = DEFAULT_PAGE_SIZE }: UseRemixesArgs,
-  config?: QueryOptions
+  options?: QueryOptions
 ) => {
   const { audiusSdk } = useAudiusQueryContext()
   const { data: currentUserId } = useCurrentUserId()
@@ -84,8 +84,8 @@ export const useRemixes = (
 
       return processedTracks
     },
-    staleTime: config?.staleTime,
-    enabled: config?.enabled !== false && !!trackId
+    enabled: options?.enabled !== false && !!trackId,
+    ...options
   })
 
   const lineupData = useLineupQuery({

--- a/packages/common/src/api/tan-query/useRemixes.ts
+++ b/packages/common/src/api/tan-query/useRemixes.ts
@@ -84,8 +84,8 @@ export const useRemixes = (
 
       return processedTracks
     },
-    enabled: options?.enabled !== false && !!trackId,
-    ...options
+    ...options,
+    enabled: options?.enabled !== false && !!trackId
   })
 
   const lineupData = useLineupQuery({

--- a/packages/common/src/api/tan-query/useSalesAggregate.ts
+++ b/packages/common/src/api/tan-query/useSalesAggregate.ts
@@ -27,7 +27,7 @@ export const useSalesAggregate = (options?: QueryOptions) => {
       })
       return data
     },
-    staleTime: options?.staleTime,
-    enabled: options?.enabled !== false && !!currentUserId
+    enabled: options?.enabled !== false && !!currentUserId,
+    ...options
   })
 }

--- a/packages/common/src/api/tan-query/useSalesAggregate.ts
+++ b/packages/common/src/api/tan-query/useSalesAggregate.ts
@@ -27,7 +27,7 @@ export const useSalesAggregate = (options?: QueryOptions) => {
       })
       return data
     },
-    enabled: options?.enabled !== false && !!currentUserId,
-    ...options
+    ...options,
+    enabled: options?.enabled !== false && !!currentUserId
   })
 }

--- a/packages/common/src/api/tan-query/useSalesCount.ts
+++ b/packages/common/src/api/tan-query/useSalesCount.ts
@@ -29,7 +29,7 @@ export const useSalesCount = (
       })
       return data
     },
-    staleTime: options?.staleTime,
-    enabled: options?.enabled !== false && !!audiusSdk && !!userId
+    enabled: options?.enabled !== false && !!audiusSdk && !!userId,
+    ...options
   })
 }

--- a/packages/common/src/api/tan-query/useSalesCount.ts
+++ b/packages/common/src/api/tan-query/useSalesCount.ts
@@ -29,7 +29,7 @@ export const useSalesCount = (
       })
       return data
     },
-    enabled: options?.enabled !== false && !!audiusSdk && !!userId,
-    ...options
+    ...options,
+    enabled: options?.enabled !== false && !!audiusSdk && !!userId
   })
 }

--- a/packages/common/src/api/tan-query/useSearchAutocomplete.ts
+++ b/packages/common/src/api/tan-query/useSearchAutocomplete.ts
@@ -66,8 +66,8 @@ export const useSearchAutocomplete = (
 
       return limitAutocompleteResults(searchResultsFromSDK(data))
     },
-    enabled: options?.enabled !== false && query.length > 0,
     placeholderData: (prev) => (query === '' ? undefined : prev),
-    ...options
+    ...options,
+    enabled: options?.enabled !== false && query.length > 0
   })
 }

--- a/packages/common/src/api/tan-query/useSearchAutocomplete.ts
+++ b/packages/common/src/api/tan-query/useSearchAutocomplete.ts
@@ -66,8 +66,8 @@ export const useSearchAutocomplete = (
 
       return limitAutocompleteResults(searchResultsFromSDK(data))
     },
-    staleTime: options?.staleTime,
     enabled: options?.enabled !== false && query.length > 0,
-    placeholderData: (prev) => (query === '' ? undefined : prev)
+    placeholderData: (prev) => (query === '' ? undefined : prev),
+    ...options
   })
 }

--- a/packages/common/src/api/tan-query/useSearchResults.ts
+++ b/packages/common/src/api/tan-query/useSearchResults.ts
@@ -231,7 +231,7 @@ export const useSearchResults = (
         playlists
       }
     },
-    staleTime: options?.staleTime,
-    enabled: options?.enabled !== false
+    enabled: options?.enabled !== false,
+    ...options
   })
 }

--- a/packages/common/src/api/tan-query/useSearchResults.ts
+++ b/packages/common/src/api/tan-query/useSearchResults.ts
@@ -231,7 +231,7 @@ export const useSearchResults = (
         playlists
       }
     },
-    enabled: options?.enabled !== false,
-    ...options
+    ...options,
+    enabled: options?.enabled !== false
   })
 }

--- a/packages/common/src/api/tan-query/useSuggestedArtists.ts
+++ b/packages/common/src/api/tan-query/useSuggestedArtists.ts
@@ -19,8 +19,8 @@ export const useSuggestedArtists = (options?: QueryOptions) => {
       // dedupe the artists just in case the team accidentally adds the same artist twice
       return [...new Set(suggestedArtists as number[])]
     },
-    staleTime: options?.staleTime,
-    enabled: options?.enabled !== false
+    enabled: options?.enabled !== false,
+    ...options
   })
 
   return useUsers(suggestedIds, {

--- a/packages/common/src/api/tan-query/useSuggestedArtists.ts
+++ b/packages/common/src/api/tan-query/useSuggestedArtists.ts
@@ -19,8 +19,8 @@ export const useSuggestedArtists = (options?: QueryOptions) => {
       // dedupe the artists just in case the team accidentally adds the same artist twice
       return [...new Set(suggestedArtists as number[])]
     },
-    enabled: options?.enabled !== false,
-    ...options
+    ...options,
+    enabled: options?.enabled !== false
   })
 
   return useUsers(suggestedIds, {

--- a/packages/common/src/api/tan-query/useSupportedUsers.ts
+++ b/packages/common/src/api/tan-query/useSupportedUsers.ts
@@ -65,7 +65,7 @@ export const useSupportedUsers = (
       return supporting
     },
     select: (data) => data.pages.flat(),
-    staleTime: options?.staleTime,
-    enabled: options?.enabled !== false && !!userId
+    enabled: options?.enabled !== false && !!userId,
+    ...options
   })
 }

--- a/packages/common/src/api/tan-query/useSupportedUsers.ts
+++ b/packages/common/src/api/tan-query/useSupportedUsers.ts
@@ -65,7 +65,7 @@ export const useSupportedUsers = (
       return supporting
     },
     select: (data) => data.pages.flat(),
-    enabled: options?.enabled !== false && !!userId,
-    ...options
+    ...options,
+    enabled: options?.enabled !== false && !!userId
   })
 }

--- a/packages/common/src/api/tan-query/useSupporters.ts
+++ b/packages/common/src/api/tan-query/useSupporters.ts
@@ -66,7 +66,7 @@ export const useSupporters = (
       return supporters
     },
     select: (data) => data.pages.flat(),
-    staleTime: options?.staleTime,
-    enabled: options?.enabled !== false && !!userId
+    enabled: options?.enabled !== false && !!userId,
+    ...options
   })
 }

--- a/packages/common/src/api/tan-query/useSupporters.ts
+++ b/packages/common/src/api/tan-query/useSupporters.ts
@@ -66,7 +66,7 @@ export const useSupporters = (
       return supporters
     },
     select: (data) => data.pages.flat(),
-    enabled: options?.enabled !== false && !!userId,
-    ...options
+    ...options,
+    enabled: options?.enabled !== false && !!userId
   })
 }

--- a/packages/common/src/api/tan-query/useTopArtistsInGenre.ts
+++ b/packages/common/src/api/tan-query/useTopArtistsInGenre.ts
@@ -49,6 +49,7 @@ export const useTopArtistsInGenre = (
       return allPages.length * pageSize
     },
     select: (data) => data.pages.flat(),
-    ...options
+    ...options,
+    enabled: options?.enabled !== false && !!genre
   })
 }

--- a/packages/common/src/api/tan-query/useTopTags.ts
+++ b/packages/common/src/api/tan-query/useTopTags.ts
@@ -34,7 +34,7 @@ export const useTopTags = (
 
       return data
     },
-    enabled: options?.enabled !== false,
-    ...options
+    ...options,
+    enabled: options?.enabled !== false
   })
 }

--- a/packages/common/src/api/tan-query/useTopTags.ts
+++ b/packages/common/src/api/tan-query/useTopTags.ts
@@ -34,7 +34,7 @@ export const useTopTags = (
 
       return data
     },
-    staleTime: options?.staleTime,
-    enabled: options?.enabled !== false && !!userId
+    enabled: options?.enabled !== false,
+    ...options
   })
 }

--- a/packages/common/src/api/tan-query/useTrackFavorites.ts
+++ b/packages/common/src/api/tan-query/useTrackFavorites.ts
@@ -59,7 +59,7 @@ export const useTrackFavorites = (
       return users
     },
     select: (data) => data.pages.flat(),
-    staleTime: options?.staleTime,
-    enabled: options?.enabled !== false && !!trackId
+    enabled: options?.enabled !== false && !!trackId,
+    ...options
   })
 }

--- a/packages/common/src/api/tan-query/useTrackFavorites.ts
+++ b/packages/common/src/api/tan-query/useTrackFavorites.ts
@@ -59,7 +59,7 @@ export const useTrackFavorites = (
       return users
     },
     select: (data) => data.pages.flat(),
-    enabled: options?.enabled !== false && !!trackId,
-    ...options
+    ...options,
+    enabled: options?.enabled !== false && !!trackId
   })
 }

--- a/packages/common/src/api/tan-query/useTrackHistory.ts
+++ b/packages/common/src/api/tan-query/useTrackHistory.ts
@@ -106,8 +106,8 @@ export const useTrackHistory = (
       return tracks
     },
     select: (data) => data.pages.flat(),
-    staleTime: options?.staleTime,
-    enabled: options?.enabled !== false && !!currentUserId
+    enabled: options?.enabled !== false && !!currentUserId,
+    ...options
   })
 
   const lineupData = useLineupQuery({

--- a/packages/common/src/api/tan-query/useTrackHistory.ts
+++ b/packages/common/src/api/tan-query/useTrackHistory.ts
@@ -106,8 +106,8 @@ export const useTrackHistory = (
       return tracks
     },
     select: (data) => data.pages.flat(),
-    enabled: options?.enabled !== false && !!currentUserId,
-    ...options
+    ...options,
+    enabled: options?.enabled !== false && !!currentUserId
   })
 
   const lineupData = useLineupQuery({

--- a/packages/common/src/api/tan-query/useTrackPageLineup.ts
+++ b/packages/common/src/api/tan-query/useTrackPageLineup.ts
@@ -201,8 +201,8 @@ export const useTrackPageLineup = (
 
       return { tracks, indices }
     },
-    enabled: options?.enabled !== false && !!ownerHandle && !!trackId,
-    ...options
+    ...options,
+    enabled: options?.enabled !== false && !!ownerHandle && !!trackId
   })
 
   const lineupData = useLineupQuery({

--- a/packages/common/src/api/tan-query/useTrackPageLineup.ts
+++ b/packages/common/src/api/tan-query/useTrackPageLineup.ts
@@ -54,7 +54,7 @@ export const useTrackPageLineup = (
     ownerHandle,
     pageSize = DEFAULT_PAGE_SIZE
   }: UseTrackPageLineupArgs,
-  config?: QueryOptions
+  options?: QueryOptions
 ) => {
   const { audiusSdk } = useAudiusQueryContext()
   const { data: currentUserId } = useCurrentUserId()
@@ -201,8 +201,8 @@ export const useTrackPageLineup = (
 
       return { tracks, indices }
     },
-    staleTime: config?.staleTime,
-    enabled: config?.enabled !== false && !!ownerHandle && !!trackId
+    enabled: options?.enabled !== false && !!ownerHandle && !!trackId,
+    ...options
   })
 
   const lineupData = useLineupQuery({

--- a/packages/common/src/api/tan-query/useTrackReposts.ts
+++ b/packages/common/src/api/tan-query/useTrackReposts.ts
@@ -59,7 +59,7 @@ export const useTrackReposts = (
       return users
     },
     select: (data) => data.pages.flat(),
-    enabled: options?.enabled !== false && !!trackId,
-    ...options
+    ...options,
+    enabled: options?.enabled !== false && !!trackId
   })
 }

--- a/packages/common/src/api/tan-query/useTrackReposts.ts
+++ b/packages/common/src/api/tan-query/useTrackReposts.ts
@@ -59,7 +59,7 @@ export const useTrackReposts = (
       return users
     },
     select: (data) => data.pages.flat(),
-    staleTime: options?.staleTime,
-    enabled: options?.enabled !== false && !!trackId
+    enabled: options?.enabled !== false && !!trackId,
+    ...options
   })
 }

--- a/packages/common/src/api/tan-query/useTracks.ts
+++ b/packages/common/src/api/tan-query/useTracks.ts
@@ -70,7 +70,7 @@ export const useTracks = (
 
       return tracks
     },
-    staleTime: options?.staleTime,
-    enabled: options?.enabled !== false && !!trackIds
+    enabled: options?.enabled !== false && !!trackIds,
+    ...options
   })
 }

--- a/packages/common/src/api/tan-query/useTracks.ts
+++ b/packages/common/src/api/tan-query/useTracks.ts
@@ -70,7 +70,7 @@ export const useTracks = (
 
       return tracks
     },
-    enabled: options?.enabled !== false && !!trackIds,
-    ...options
+    ...options,
+    enabled: options?.enabled !== false && !!trackIds
   })
 }

--- a/packages/common/src/api/tan-query/useTrending.ts
+++ b/packages/common/src/api/tan-query/useTrending.ts
@@ -86,7 +86,6 @@ export const useTrending = (
       if (lastPage.length < currentPageSize) return undefined
       return allPages.reduce((total, page) => total + page.length, 0)
     },
-    enabled: !!currentUserId && options?.enabled !== false && !!timeRange,
     queryFn: async ({ pageParam }) => {
       const sdk = await audiusSdk()
       const version = remoteConfigInstance.getRemoteVar(
@@ -155,7 +154,8 @@ export const useTrending = (
       return tracks
     },
     select: (data) => data.pages.flat(),
-    ...options
+    ...options,
+    enabled: !!currentUserId && options?.enabled !== false && !!timeRange
   })
 
   let lineupActions

--- a/packages/common/src/api/tan-query/useTrending.ts
+++ b/packages/common/src/api/tan-query/useTrending.ts
@@ -80,7 +80,6 @@ export const useTrending = (
       loadMorePageSize
     }),
     initialPageParam: 0,
-    staleTime: options?.staleTime,
     getNextPageParam: (lastPage, allPages) => {
       const isFirstPage = allPages.length === 1
       const currentPageSize = isFirstPage ? initialPageSize : loadMorePageSize
@@ -155,7 +154,8 @@ export const useTrending = (
       }
       return tracks
     },
-    select: (data) => data.pages.flat()
+    select: (data) => data.pages.flat(),
+    ...options
   })
 
   let lineupActions

--- a/packages/common/src/api/tan-query/useTrendingPlaylists.ts
+++ b/packages/common/src/api/tan-query/useTrendingPlaylists.ts
@@ -87,8 +87,8 @@ export const useTrendingPlaylists = (
 
       return processedPlaylists
     },
-    enabled: options?.enabled !== false,
-    ...options
+    ...options,
+    enabled: options?.enabled !== false
   })
 
   const lineupData = useLineupQuery({

--- a/packages/common/src/api/tan-query/useTrendingPlaylists.ts
+++ b/packages/common/src/api/tan-query/useTrendingPlaylists.ts
@@ -39,7 +39,7 @@ export const useTrendingPlaylists = (
     pageSize = DEFAULT_PAGE_SIZE,
     time = full.GetTrendingPlaylistsTimeEnum.Week
   }: UseTrendingPlaylistsArgs = {},
-  config?: QueryOptions
+  options?: QueryOptions
 ) => {
   const { audiusSdk } = useAudiusQueryContext()
   const { data: currentUserId } = useCurrentUserId()
@@ -87,8 +87,8 @@ export const useTrendingPlaylists = (
 
       return processedPlaylists
     },
-    staleTime: config?.staleTime,
-    enabled: config?.enabled !== false
+    enabled: options?.enabled !== false,
+    ...options
   })
 
   const lineupData = useLineupQuery({

--- a/packages/common/src/api/tan-query/useTrendingUnderground.ts
+++ b/packages/common/src/api/tan-query/useTrendingUnderground.ts
@@ -67,8 +67,8 @@ export const useTrendingUnderground = (
 
       return tracks
     },
-    enabled: options?.enabled !== false,
-    ...options
+    ...options,
+    enabled: options?.enabled !== false
   })
 
   const lineupData = useLineupQuery({

--- a/packages/common/src/api/tan-query/useTrendingUnderground.ts
+++ b/packages/common/src/api/tan-query/useTrendingUnderground.ts
@@ -28,7 +28,7 @@ export const getTrendingUndergroundQueryKey = ({
 
 export const useTrendingUnderground = (
   { pageSize = DEFAULT_PAGE_SIZE }: UseTrendingUndergroundArgs = {},
-  config?: QueryOptions
+  options?: QueryOptions
 ) => {
   const { audiusSdk } = useAudiusQueryContext()
   const { data: currentUserId } = useCurrentUserId()
@@ -67,8 +67,8 @@ export const useTrendingUnderground = (
 
       return tracks
     },
-    staleTime: config?.staleTime,
-    enabled: config?.enabled !== false
+    enabled: options?.enabled !== false,
+    ...options
   })
 
   const lineupData = useLineupQuery({

--- a/packages/common/src/api/tan-query/useUSDCTransactions.ts
+++ b/packages/common/src/api/tan-query/useUSDCTransactions.ts
@@ -109,8 +109,8 @@ export const useUSDCTransactions = (
       items: data.pages.flat()
     }),
     refetchInterval: 5000, // Poll every 5 seconds
-    enabled: options?.enabled !== false && !!currentUserId,
-    ...options
+    ...options,
+    enabled: options?.enabled !== false && !!currentUserId
   })
 
   const fetchNextPage = useCallback(async () => {

--- a/packages/common/src/api/tan-query/useUSDCTransactions.ts
+++ b/packages/common/src/api/tan-query/useUSDCTransactions.ts
@@ -108,9 +108,9 @@ export const useUSDCTransactions = (
       pageParams: data.pageParams,
       items: data.pages.flat()
     }),
-    staleTime: options?.staleTime,
+    refetchInterval: 5000, // Poll every 5 seconds
     enabled: options?.enabled !== false && !!currentUserId,
-    refetchInterval: 5000 // Poll every 5 seconds
+    ...options
   })
 
   const fetchNextPage = useCallback(async () => {

--- a/packages/common/src/api/tan-query/useUSDCTransactionsCount.ts
+++ b/packages/common/src/api/tan-query/useUSDCTransactionsCount.ts
@@ -44,7 +44,7 @@ export const useUSDCTransactionsCount = (
       })
       return data ?? 0
     },
-    enabled: options?.enabled !== false && !!currentUserId,
-    ...options
+    ...options,
+    enabled: options?.enabled !== false && !!currentUserId
   })
 }

--- a/packages/common/src/api/tan-query/useUSDCTransactionsCount.ts
+++ b/packages/common/src/api/tan-query/useUSDCTransactionsCount.ts
@@ -44,7 +44,7 @@ export const useUSDCTransactionsCount = (
       })
       return data ?? 0
     },
-    staleTime: options?.staleTime,
-    enabled: options?.enabled !== false && !!currentUserId
+    enabled: options?.enabled !== false && !!currentUserId,
+    ...options
   })
 }

--- a/packages/common/src/api/tan-query/useUserAlbums.ts
+++ b/packages/common/src/api/tan-query/useUserAlbums.ts
@@ -62,7 +62,7 @@ export const useUserAlbums = (
 
       return collections
     },
-    staleTime: options?.staleTime,
-    enabled: options?.enabled !== false && !!userId
+    enabled: options?.enabled !== false && !!userId,
+    ...options
   })
 }

--- a/packages/common/src/api/tan-query/useUserAlbums.ts
+++ b/packages/common/src/api/tan-query/useUserAlbums.ts
@@ -62,7 +62,7 @@ export const useUserAlbums = (
 
       return collections
     },
-    enabled: options?.enabled !== false && !!userId,
-    ...options
+    ...options,
+    enabled: options?.enabled !== false && !!userId
   })
 }

--- a/packages/common/src/api/tan-query/useUserByHandle.ts
+++ b/packages/common/src/api/tan-query/useUserByHandle.ts
@@ -54,7 +54,7 @@ export const useUserByHandle = (
 
       return user
     },
-    staleTime: options?.staleTime,
-    enabled: options?.enabled !== false && !!handle
+    enabled: options?.enabled !== false && !!handle,
+    ...options
   })
 }

--- a/packages/common/src/api/tan-query/useUserByHandle.ts
+++ b/packages/common/src/api/tan-query/useUserByHandle.ts
@@ -54,7 +54,7 @@ export const useUserByHandle = (
 
       return user
     },
-    enabled: options?.enabled !== false && !!handle,
-    ...options
+    ...options,
+    enabled: options?.enabled !== false && !!handle
   })
 }

--- a/packages/common/src/api/tan-query/useUserPlaylists.ts
+++ b/packages/common/src/api/tan-query/useUserPlaylists.ts
@@ -62,7 +62,7 @@ export const useUserPlaylists = (
 
       return collections
     },
-    enabled: options?.enabled !== false && !!userId,
-    ...options
+    ...options,
+    enabled: options?.enabled !== false && !!userId
   })
 }

--- a/packages/common/src/api/tan-query/useUserPlaylists.ts
+++ b/packages/common/src/api/tan-query/useUserPlaylists.ts
@@ -62,7 +62,7 @@ export const useUserPlaylists = (
 
       return collections
     },
-    staleTime: options?.staleTime,
-    enabled: options?.enabled !== false && !!userId
+    enabled: options?.enabled !== false && !!userId,
+    ...options
   })
 }

--- a/packages/common/src/api/tan-query/useUserTracksByHandle.ts
+++ b/packages/common/src/api/tan-query/useUserTracksByHandle.ts
@@ -64,7 +64,7 @@ export const useUserTracksByHandle = (
 
       return tracks
     },
-    staleTime: options?.staleTime,
-    enabled: options?.enabled !== false && !!handle
+    enabled: options?.enabled !== false && !!handle,
+    ...options
   })
 }

--- a/packages/common/src/api/tan-query/useUserTracksByHandle.ts
+++ b/packages/common/src/api/tan-query/useUserTracksByHandle.ts
@@ -64,7 +64,7 @@ export const useUserTracksByHandle = (
 
       return tracks
     },
-    enabled: options?.enabled !== false && !!handle,
-    ...options
+    ...options,
+    enabled: options?.enabled !== false && !!handle
   })
 }

--- a/packages/common/src/api/tan-query/useUsers.ts
+++ b/packages/common/src/api/tan-query/useUsers.ts
@@ -38,7 +38,7 @@ export const useUsers = (
 
       return users
     },
-    staleTime: options?.staleTime,
-    enabled: options?.enabled !== false && encodedIds && encodedIds.length > 0
+    enabled: options?.enabled !== false && encodedIds && encodedIds.length > 0,
+    ...options
   })
 }

--- a/packages/common/src/api/tan-query/useUsers.ts
+++ b/packages/common/src/api/tan-query/useUsers.ts
@@ -38,7 +38,7 @@ export const useUsers = (
 
       return users
     },
-    enabled: options?.enabled !== false && encodedIds && encodedIds.length > 0,
-    ...options
+    ...options,
+    enabled: options?.enabled !== false && encodedIds && encodedIds.length > 0
   })
 }


### PR DESCRIPTION
### Description

when the staleTime key is passed (even if undefined) it eclipses the queryClient's default staleTime

this change fixes every instance of `options?.staleTime` which does not have its own fallback set

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._
