### PR TITLE
[QA-1971] Fix original track downloads when download-gated

### DIFF
--- a/packages/discovery-provider/src/tasks/entity_manager/entities/track.py
+++ b/packages/discovery-provider/src/tasks/entity_manager/entities/track.py
@@ -264,10 +264,6 @@ def populate_track_record_metadata(track_record: Track, track_metadata, handle, 
                 track_record.download_conditions = convert_legacy_purchase_access_gate(
                     track_record.owner_id, track_metadata["download_conditions"]
                 )
-                track_record.is_downloadable = (
-                    track_record.is_downloadable
-                    or track_metadata["download_conditions"] is not None
-                )
         elif key == "allowed_api_keys":
             if key in track_metadata:
                 if track_metadata[key] is None:


### PR DESCRIPTION
### Description
`is_downloadable` should just be independent of `download_conditions`.

As far as I can tell `is_original_available` is unused.

### How Has This Been Tested?

Untested bc local stack borked currently