### PR TITLE
Run integration with --prod, remove pre-cleanup step from CI

### DIFF
--- a/.circleci/src/jobs/@integration-jobs.yml
+++ b/.circleci/src/jobs/@integration-jobs.yml
@@ -34,9 +34,9 @@ integration-test:
   resource_class: audiusproject/gcp-n2-standard-4
   working_directory: ~/audius-protocol
   steps:
-    - run:
-        name: clean dir
-        command: cd ~; [ -d ~/audius-protocol ] && rm -rf ~/audius-protocol
+    # - run:
+    #     name: clean dir
+    #     command: cd ~; [ -d ~/audius-protocol ] && rm -rf ~/audius-protocol
     - checkout
     - attach_workspace:
         at: ./
@@ -44,8 +44,8 @@ integration-test:
         name: setup
         command: AUDIUS_DEV=false bash ./dev-tools/setup.sh
     - run:
-        name: npm run protocol
-        command: . ~/.profile; export DOCKER_UID=$(id -u); export DOCKER_GID=$(id -g); npm run protocol
+        name: npm run protocol --prod
+        command: . ~/.profile; export DOCKER_UID=$(id -u); export DOCKER_GID=$(id -g); npm run protocol --prod
     - run:
         name: audius-cmd test
         no_output_timeout: 15m

--- a/.circleci/src/jobs/test.yml
+++ b/.circleci/src/jobs/test.yml
@@ -6,9 +6,9 @@ machine: true
 resource_class: audiusproject/gcp-n2-standard-4
 working_directory: ~/audius-protocol
 steps:
-  - run:
-      name: clean dir
-      command: cd ~; [ -d ~/audius-protocol ] && rm -rf ~/audius-protocol
+  # - run:
+  #     name: clean dir
+  #     command: cd ~; [ -d ~/audius-protocol ] && rm -rf ~/audius-protocol
   - checkout
   - attach_workspace:
       at: ./


### PR DESCRIPTION
Temporarily disable cleanup step while sorting out what's causing runners to fail.

Revert back to using `--prod` in CI
