### PR TITLE
Merge all DN docker image push jobs into one for release workflow

### DIFF
--- a/.circleci/src/workflows/release.yml
+++ b/.circleci/src/workflows/release.yml
@@ -8,77 +8,13 @@ jobs:
   - push-docker-image:
       name: push-discovery-provider
       context: [Vercel, dockerhub, slack-secrets]
-      service: discovery-provider
-      notify_slack_on_failure: true
-  - push-docker-image:
-      name: push-discovery-provider-notifications
-      context: [Vercel, dockerhub, slack-secrets]
-      service: discovery-provider-notifications
-      notify_slack_on_failure: true
-  - push-docker-image:
-      name: push-discovery-provider-openresty
-      context: [Vercel, dockerhub]
-      service: discovery-provider-openresty
-      notify_slack_on_failure: true
-  - push-docker-image:
-      name: push-pedalboard-trending-challenge-rewards
-      context: [Vercel, dockerhub, slack-secrets]
-      service: trending-challenge-rewards
-      notify_slack_on_failure: true
-  - push-docker-image:
-      name: push-pedalboard-relay
-      context: [Vercel, dockerhub, slack-secrets]
-      service: relay
-      notify_slack_on_failure: true
-  - push-docker-image:
-      name: push-pedalboard-solana-relay
-      context: [Vercel, dockerhub, slack-secrets]
-      service: solana-relay
-      notify_slack_on_failure: true
-  - push-docker-image:
-      name: push-pedalboard-crm
-      context: [Vercel, dockerhub, slack-secrets]
-      service: crm
-      notify_slack_on_failure: true
-  - push-docker-image:
-      name: push-pedalboard-mri
-      context: [Vercel, dockerhub, slack-secrets]
-      service: mri
-      notify_slack_on_failure: true
-  - push-docker-image:
-      name: push-pedalboard-staking
-      context: [Vercel, dockerhub, slack-secrets]
-      service: staking
-      notify_slack_on_failure: true
-  - push-docker-image:
-      name: push-pedalboard-verified-notifications
-      context: [Vercel, dockerhub, slack-secrets]
-      service: verified-notifications
-      notify_slack_on_failure: true
-  - push-docker-image:
-      name: push-comms
-      context: [Vercel, dockerhub, slack-secrets]
-      service: comms
-      notify_slack_on_failure: true
-  - push-docker-image:
-      name: push-es-indexer
-      context: [Vercel, dockerhub, slack-secrets]
-      service: es-indexer
+      service: discovery-provider discovery-provider-notifications discovery-provider-openresty trending-challenge-rewards relay solana-relay crm mri staking verified-notifications comms es-indexer
       notify_slack_on_failure: true
   - commit-audius-docker-compose-and-notify:
       context: [slack-secrets, github]
       requires:
         - push-identity-service
         - push-discovery-provider
-        - push-discovery-provider-openresty
-        - push-discovery-provider-notifications
-        - push-pedalboard-trending-challenge-rewards
-        - push-pedalboard-relay
-        - push-pedalboard-solana-relay
-        - push-pedalboard-staking
-        - push-pedalboard-crm
-        - push-pedalboard-mri
-        - push-comms
 
   - deploy-foundation-nodes-trigger:
       requires:


### PR DESCRIPTION
Mirrors what we do for main => stage. Will hopefully make releases faster by letting the docker cache be shared among these builds, and not needing to wait for runners to go idle as often.
