### PR TITLE
[PAY-3912] Claimable challenges always on top, pill colors

### DIFF
--- a/packages/common/src/utils/challenges.ts
+++ b/packages/common/src/utils/challenges.ts
@@ -1,6 +1,5 @@
 import {
   ChallengeRewardID,
-  UserChallenge,
   UndisbursedUserChallenge,
   OptimisticUserChallenge,
   ChallengeName,

--- a/packages/common/src/utils/challenges.ts
+++ b/packages/common/src/utils/challenges.ts
@@ -331,6 +331,9 @@ export const makeOptimisticChallengeSortComparator = (
     if (userChallenge1?.claimableAmount > 0) {
       return -1
     }
+    if (userChallenge2?.claimableAmount > 0) {
+      return 1
+    }
     if (
       userChallenge1?.challenge_id &&
       isNewChallenge(userChallenge1?.challenge_id)
@@ -340,18 +343,9 @@ export const makeOptimisticChallengeSortComparator = (
     if (userChallenge1?.state === 'disbursed') {
       return 1
     }
-    // if (userChallenge1?.state === 'completed') {
-    //   return -1
-    // }
     if (userChallenge2?.state === 'disbursed') {
       return -1
     }
-    if (userChallenge2?.claimableAmount > 0) {
-      return 1
-    }
-    // if (userChallenge2?.state === 'completed') {
-    //   return 1
-    // }
     return 0
   }
 }

--- a/packages/common/src/utils/challenges.ts
+++ b/packages/common/src/utils/challenges.ts
@@ -318,32 +318,6 @@ export const challengeRewardsConfig: Record<
   }
 }
 
-export const makeChallengeSortComparator = (
-  userChallenges: Record<string, UserChallenge>
-): ((id1: ChallengeRewardID, id2: ChallengeRewardID) => number) => {
-  return (id1, id2) => {
-    const userChallenge1 = userChallenges[id1]
-    const userChallenge2 = userChallenges[id2]
-
-    if (!userChallenge1 || !userChallenge2) {
-      return 0
-    }
-    if (userChallenge1.is_disbursed) {
-      return 1
-    }
-    if (userChallenge1.is_complete) {
-      return -1
-    }
-    if (userChallenge2.is_disbursed) {
-      return -1
-    }
-    if (userChallenge2.is_complete) {
-      return 1
-    }
-    return 0
-  }
-}
-
 export const makeOptimisticChallengeSortComparator = (
   userChallenges: Partial<Record<ChallengeRewardID, OptimisticUserChallenge>>
 ): ((id1: ChallengeRewardID, id2: ChallengeRewardID) => number) => {
@@ -351,33 +325,33 @@ export const makeOptimisticChallengeSortComparator = (
     const userChallenge1 = userChallenges[id1]
     const userChallenge2 = userChallenges[id2]
 
-    if (
-      userChallenge1?.challenge_id &&
-      isNewChallenge(userChallenge1?.challenge_id)
-    ) {
-      return -1
-    }
     if (!userChallenge1 || !userChallenge2) {
       return 0
     }
     if (userChallenge1?.claimableAmount > 0) {
       return -1
     }
+    if (
+      userChallenge1?.challenge_id &&
+      isNewChallenge(userChallenge1?.challenge_id)
+    ) {
+      return -1
+    }
     if (userChallenge1?.state === 'disbursed') {
       return 1
     }
-    if (userChallenge1?.state === 'completed') {
-      return -1
-    }
+    // if (userChallenge1?.state === 'completed') {
+    //   return -1
+    // }
     if (userChallenge2?.state === 'disbursed') {
       return -1
     }
     if (userChallenge2?.claimableAmount > 0) {
       return 1
     }
-    if (userChallenge2?.state === 'completed') {
-      return 1
-    }
+    // if (userChallenge2?.state === 'completed') {
+    //   return 1
+    // }
     return 0
   }
 }

--- a/packages/web/src/pages/rewards-page/components/ChallengeRewards/RewardPanel.tsx
+++ b/packages/web/src/pages/rewards-page/components/ChallengeRewards/RewardPanel.tsx
@@ -93,7 +93,6 @@ export const RewardPanel = ({
   return (
     <Paper
       onClick={openRewardModal}
-      h={PANEL_HEIGHT}
       flex={`0 0 calc(50% - ${spacing.unit4}px)`}
       column
       m='s'
@@ -101,6 +100,7 @@ export const RewardPanel = ({
       border='strong'
       css={{
         minWidth: PANEL_WIDTH,
+        minHeight: PANEL_HEIGHT,
         backgroundColor: hasDisbursed ? color.neutral.n25 : undefined
       }}
     >

--- a/packages/web/src/pages/rewards-page/components/ChallengeRewards/StatusPill.tsx
+++ b/packages/web/src/pages/rewards-page/components/ChallengeRewards/StatusPill.tsx
@@ -54,9 +54,9 @@ export const StatusPill = ({
   if (shouldShowClaimPill) {
     return (
       <BasePill
-        color='accent'
-        backgroundColor={color.background.surface1}
-        borderColor={color.border.strong}
+        color='white'
+        backgroundColor={color.background.primary}
+        borderColor={color.primary.p400}
       >
         {messages.readyToClaim}
       </BasePill>
@@ -66,13 +66,13 @@ export const StatusPill = ({
   if (shouldShowNewChallengePill) {
     return (
       <BasePill
-        color='white'
-        backgroundColor={color.background.primary}
-        borderColor={color.primary.p400}
+        color='accent'
+        backgroundColor={color.background.surface1}
+        borderColor={color.border.strong}
       >
         <Flex alignItems='center' justifyContent='center' gap='xs'>
-          <IconSparkles size='s' color='white' />
-          <Text variant='body' size='m' strength='strong' color='white'>
+          <IconSparkles size='s' color='accent' />
+          <Text variant='body' size='m' strength='strong' color='accent'>
             {messages.new}
           </Text>
         </Flex>


### PR DESCRIPTION
### Description
- Always put claimable rewards on top, followed by new challenges.
- Swap colors of "new" and "ready to claim" pills
- Remove height of reward panel, use minHeight instead so it hugs the content

### How Has This Been Tested?

pills and ordering:
<img width="1920" alt="Screenshot 2025-02-06 at 7 42 36 PM" src="https://github.com/user-attachments/assets/2986fd32-2cbd-4601-a3ea-f540c4f974d2" />
<img width="1920" alt="Screenshot 2025-02-06 at 7 38 40 PM" src="https://github.com/user-attachments/assets/7b3933ea-1607-4fad-9c54-7fa54ebab288" />
<img width="1920" alt="Screenshot 2025-02-06 at 7 35 32 PM" src="https://github.com/user-attachments/assets/4505f048-af64-4944-812d-0f72f803318f" />

height fix:
<img width="753" alt="Screenshot 2025-02-06 at 7 52 28 PM" src="https://github.com/user-attachments/assets/df17879e-a4b8-409d-aa0b-51ee052d5280" />
