### PR TITLE
[PAY-3923] Show airdrop banner when logged out and in

### DIFF
--- a/packages/web/src/components/banner/AirdropAppBanner.tsx
+++ b/packages/web/src/components/banner/AirdropAppBanner.tsx
@@ -1,10 +1,8 @@
 import { useCallback, useState } from 'react'
 
-import { accountSelectors } from '@audius/common/src/store/account'
 import { AIRDROP_PAGE } from '@audius/common/src/utils/route'
 import { useDispatch } from 'react-redux'
 
-import { useSelector } from 'common/hooks/useSelector'
 import { localStorage } from 'services/local-storage'
 import { push as pushRoute } from 'utils/navigation'
 
@@ -15,21 +13,14 @@ const AIRDROP_BANNER_LOCAL_STORAGE_KEY = 'dismissAirdropBanner'
 const messages = {
   text: '2025 Airdrop is Live! Claim Now '
 }
-const { getIsAccountComplete } = accountSelectors
 
-/**
- * Displays a CTA Banner encouraging the user to downlaod web and mobile apps
- * if the user is not logged in on desktop web (as logged in users see the Direct Messaging banner)
- */
 export const AirdropAppBanner = () => {
   const dispatch = useDispatch()
   const hasDismissed = window.localStorage.getItem(
     AIRDROP_BANNER_LOCAL_STORAGE_KEY
   )
 
-  const signedIn = useSelector(getIsAccountComplete)
-
-  const [isVisible, setIsVisible] = useState(!hasDismissed && signedIn)
+  const [isVisible, setIsVisible] = useState(!hasDismissed)
 
   const handleClose = useCallback(() => {
     setIsVisible(false)


### PR DESCRIPTION
### Description

This might've been the cause for it sometimes not showing - a race condition when the account comes through? that bit's unclear to me, but this change seems good.

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._

npm run web:stage
tested logged out & logged in, tested dismissing