### PR TITLE
[QA-1962] Update the get verified modal to keep the X button when loading

### DIFF
--- a/packages/web/src/pages/settings-page/components/desktop/VerificationModal.tsx
+++ b/packages/web/src/pages/settings-page/components/desktop/VerificationModal.tsx
@@ -346,7 +346,7 @@ const VerificationModal = (props: VerificationModalProps) => {
       <Modal
         isOpen={isOpen}
         onClose={onClose}
-        showDismissButton={canDismiss}
+        showDismissButton
         dismissOnClickOutside={canDismiss}
         showTitleHeader
         title={messages.title}


### PR DESCRIPTION
### Description
Small update to make the dismiss button always visible so that the user is not stuck on desktop

### How Has This Been Tested?
Manually Tested
