### PR TITLE
Remove oauth change causing app to only capture oauth*

### DIFF
--- a/packages/mobile/android/app/src/main/AndroidManifest.xml
+++ b/packages/mobile/android/app/src/main/AndroidManifest.xml
@@ -60,7 +60,6 @@
                 <data android:scheme="http" />
                 <data android:host="redirect.audius.co" />
                 <data android:host="audius.co" />
-                <data android:pathPattern="/oauth/auth.*" />
             </intent-filter>
             <intent-filter android:autoVerify="true">
                 <action android:name="android.intent.action.VIEW" />


### PR DESCRIPTION
### Description

Unfortunately, it doesn't look like there's a way to do "exclusion" filters for this.
https://issuetracker.google.com/issues/250089874?pli=1

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._

<img width="1217" alt="image" src="https://github.com/user-attachments/assets/c74d1ad0-7633-41ae-9dc4-6b3b61db221e" />

disabled deep links via playstore