### PR TITLE
Fix explore page featured content

### DIFF
--- a/packages/common/src/api/tan-query/types.ts
+++ b/packages/common/src/api/tan-query/types.ts
@@ -11,7 +11,7 @@ import { UseLineupQueryData } from './utils/useLineupQuery'
  */
 export type QueryOptions = Pick<
   DefinedInitialDataOptions<any>,
-  'staleTime' | 'enabled'
+  'staleTime' | 'enabled' | 'placeholderData'
 >
 
 export type LineupQueryData = UseLineupQueryData &

--- a/packages/common/src/api/tan-query/useCollections.ts
+++ b/packages/common/src/api/tan-query/useCollections.ts
@@ -47,7 +47,9 @@ export const useCollections = (
       primeCollectionData({ collections, queryClient, dispatch })
 
       const collectionsMap = keyBy(collections, 'playlist_id')
-      return collectionIds?.map((id) => collectionsMap[id])
+      return collectionIds
+        ?.map((id) => collectionsMap[id])
+        .filter(removeNullable)
     },
     ...options,
     enabled: options?.enabled !== false && encodedIds && encodedIds.length > 0

--- a/packages/common/src/api/tan-query/useCollections.ts
+++ b/packages/common/src/api/tan-query/useCollections.ts
@@ -11,6 +11,7 @@ import { removeNullable } from '~/utils'
 
 import { QUERY_KEYS } from './queryKeys'
 import { QueryOptions } from './types'
+import { useCurrentUserId } from './useCurrentUserId'
 import { primeCollectionData } from './utils/primeCollectionData'
 
 export const getCollectionsQueryKey = (
@@ -24,17 +25,18 @@ export const useCollections = (
   const { audiusSdk } = useAudiusQueryContext()
   const queryClient = useQueryClient()
   const dispatch = useDispatch()
+  const { data: currentUserId } = useCurrentUserId()
+  const encodedIds = collectionIds
+    ?.map((id) => OptionalId.parse(id))
+    .filter(removeNullable)
 
   return useQuery({
     queryKey: getCollectionsQueryKey(collectionIds),
     queryFn: async () => {
-      const encodedIds = collectionIds
-        ?.map((id) => OptionalId.parse(id))
-        .filter(removeNullable)
-      if (!encodedIds || encodedIds.length === 0) return []
       const sdk = await audiusSdk()
       const { data } = await sdk.full.playlists.getBulkPlaylists({
-        id: encodedIds
+        id: encodedIds,
+        userId: OptionalId.parse(currentUserId)
       })
 
       const collections = transformAndCleanList(
@@ -43,10 +45,11 @@ export const useCollections = (
       )
 
       primeCollectionData({ collections, queryClient, dispatch })
+
       const collectionsMap = keyBy(collections, 'playlist_id')
       return collectionIds?.map((id) => collectionsMap[id])
     },
     ...options,
-    enabled: options?.enabled !== false && !!collectionIds
+    enabled: options?.enabled !== false && encodedIds && encodedIds.length > 0
   })
 }

--- a/packages/common/src/api/tan-query/useFeaturedPlaylists.ts
+++ b/packages/common/src/api/tan-query/useFeaturedPlaylists.ts
@@ -7,7 +7,7 @@ type Args = {
 }
 
 export const useFeaturedPlaylists = (args?: Args, options?: QueryOptions) => {
-  const { data: exploreContent } = useExploreContent(options)
+  const { data: exploreContent } = useExploreContent()
   const { limit } = args ?? {}
 
   return useCollections(exploreContent?.featuredPlaylists.slice(0, limit), {

--- a/packages/common/src/api/tan-query/useTracks.ts
+++ b/packages/common/src/api/tan-query/useTracks.ts
@@ -7,15 +7,12 @@ import { userTrackMetadataFromSDK } from '~/adapters/track'
 import { transformAndCleanList } from '~/adapters/utils'
 import { useAudiusQueryContext } from '~/audius-query'
 import { ID } from '~/models/Identifiers'
-import { Kind } from '~/models/Kind'
-import { addEntries } from '~/store/cache/actions'
-import { EntriesByKind } from '~/store/cache/types'
 import { removeNullable } from '~/utils/typeUtils'
 
 import { QUERY_KEYS } from './queryKeys'
 import { QueryOptions } from './types'
-import { getTrackQueryKey } from './useTrack'
-import { getUserQueryKey } from './useUser'
+import { useCurrentUserId } from './useCurrentUserId'
+import { primeTrackData } from './utils/primeTrackData'
 
 export const getTracksQueryKey = (trackIds: ID[] | null | undefined) => [
   QUERY_KEYS.tracks,
@@ -29,50 +26,28 @@ export const useTracks = (
   const { audiusSdk } = useAudiusQueryContext()
   const queryClient = useQueryClient()
   const dispatch = useDispatch()
+  const { data: currentUserId } = useCurrentUserId()
+  const encodedIds = trackIds
+    ?.map((id) => OptionalId.parse(id))
+    .filter(removeNullable)
 
   return useQuery({
     queryKey: getTracksQueryKey(trackIds),
     queryFn: async () => {
-      const encodedIds = trackIds
-        ?.map((id) => OptionalId.parse(id))
-        .filter(removeNullable)
-      if (!encodedIds || encodedIds.length === 0) return []
       const sdk = await audiusSdk()
       const { data } = await sdk.full.tracks.getBulkTracks({
-        id: encodedIds
+        id: encodedIds,
+        userId: OptionalId.parse(currentUserId)
       })
 
       const tracks = transformAndCleanList(data, userTrackMetadataFromSDK)
 
-      if (tracks?.length) {
-        const entries: EntriesByKind = {
-          [Kind.TRACKS]: {}
-        }
-
-        tracks.forEach((track) => {
-          // Prime track data
-          queryClient.setQueryData(getTrackQueryKey(track.track_id), track)
-          entries[Kind.TRACKS]![track.track_id] = track
-
-          // Prime user data from track owner
-          if (track.user) {
-            queryClient.setQueryData(
-              getUserQueryKey(track.user.user_id),
-              track.user
-            )
-            if (!entries[Kind.USERS]) entries[Kind.USERS] = {}
-            entries[Kind.USERS][track.user.user_id] = track.user
-          }
-        })
-
-        // Sync all data to Redux in a single dispatch
-        dispatch(addEntries(entries, undefined, undefined, 'react-query'))
-      }
+      primeTrackData({ tracks, queryClient, dispatch })
 
       const tracksMap = keyBy(tracks, 'track_id')
       return trackIds?.map((id) => tracksMap[id])
     },
     ...options,
-    enabled: options?.enabled !== false && !!trackIds
+    enabled: options?.enabled !== false && encodedIds && encodedIds.length > 0
   })
 }

--- a/packages/common/src/api/tan-query/useTracks.ts
+++ b/packages/common/src/api/tan-query/useTracks.ts
@@ -45,7 +45,7 @@ export const useTracks = (
       primeTrackData({ tracks, queryClient, dispatch })
 
       const tracksMap = keyBy(tracks, 'track_id')
-      return trackIds?.map((id) => tracksMap[id])
+      return trackIds?.map((id) => tracksMap[id]).filter(removeNullable)
     },
     ...options,
     enabled: options?.enabled !== false && encodedIds && encodedIds.length > 0

--- a/packages/common/src/api/tan-query/useUsers.ts
+++ b/packages/common/src/api/tan-query/useUsers.ts
@@ -41,7 +41,7 @@ export const useUsers = (
       primeUserData({ users, queryClient, dispatch })
 
       const usersMap = keyBy(users, 'user_id')
-      return userIds?.map((id) => usersMap[id])
+      return userIds?.map((id) => usersMap[id]).filter(removeNullable)
     },
     ...options,
     enabled: options?.enabled !== false && encodedIds && encodedIds.length > 0

--- a/packages/common/src/api/tan-query/useUsers.ts
+++ b/packages/common/src/api/tan-query/useUsers.ts
@@ -1,4 +1,4 @@
-import { Id } from '@audius/sdk'
+import { Id, OptionalId } from '@audius/sdk'
 import { useQuery, useQueryClient } from '@tanstack/react-query'
 import { keyBy } from 'lodash'
 import { useDispatch } from 'react-redux'
@@ -10,6 +10,7 @@ import { removeNullable } from '~/utils/typeUtils'
 
 import { QUERY_KEYS } from './queryKeys'
 import { QueryOptions } from './types'
+import { useCurrentUserId } from './useCurrentUserId'
 import { primeUserData } from './utils/primeUserData'
 
 export const getUsersQueryKey = (userIds: ID[] | null | undefined) => [
@@ -24,6 +25,7 @@ export const useUsers = (
   const { audiusSdk } = useAudiusQueryContext()
   const dispatch = useDispatch()
   const queryClient = useQueryClient()
+  const { data: currentUserId } = useCurrentUserId()
   const encodedIds = userIds?.map((id) => Id.parse(id)).filter(removeNullable)
 
   return useQuery({
@@ -31,7 +33,8 @@ export const useUsers = (
     queryFn: async () => {
       const sdk = await audiusSdk()
       const { data } = await sdk.full.users.getBulkUsers({
-        id: encodedIds
+        id: encodedIds,
+        userId: OptionalId.parse(currentUserId)
       })
 
       const users = userMetadataListFromSDK(data)

--- a/packages/web/src/pages/explore-page/components/desktop/ExplorePage.tsx
+++ b/packages/web/src/pages/explore-page/components/desktop/ExplorePage.tsx
@@ -1,19 +1,11 @@
 import { useCallback } from 'react'
 
-import { useFeaturedPlaylists, useFeaturedProfiles } from '@audius/common/api'
-import {
-  Variant as CollectionVariant,
-  UserCollection,
-  User,
-  Variant
-} from '@audius/common/models'
+import { Variant as CollectionVariant, Variant } from '@audius/common/models'
 import { ExploreCollectionsVariant } from '@audius/common/store'
 import { route } from '@audius/common/utils'
 import { IconExplore } from '@audius/harmony'
-import Lottie from 'lottie-react'
 import { useNavigate } from 'react-router-dom-v5-compat'
 
-import loadingSpinner from 'assets/animations/loadingSpinner.json'
 import {
   HEAVY_ROTATION,
   BEST_NEW_RELEASES,
@@ -44,18 +36,14 @@ import {
 } from 'pages/explore-page/collections'
 import { BASE_URL, stripBaseUrl } from 'utils/route'
 
-import { CollectionArtCard } from './CollectionArtCard'
 import styles from './ExplorePage.module.css'
+import { FeaturedPlaylists } from './FeaturedPlaylists'
+import { FeaturedProfiles } from './FeaturedProfiles'
 import Section, { Layout } from './Section'
-import UserArtCard from './UserArtCard'
 
 const { EXPLORE_PAGE } = route
 
 const messages = {
-  featuredPlaylists: 'Playlists We Love Right Now',
-  featuredProfiles: 'Artists You Should Follow',
-  exploreMorePlaylists: 'Explore More Playlists',
-  exploreMoreProfiles: 'Explore More Artists',
   justForYou: 'Just For You',
   justForYouSubtitle: `Content curated for you based on your likes,
 reposts, and follows. Refreshes often so if you like a track, favorite it.`,
@@ -98,12 +86,6 @@ const ExplorePage = ({ title, pageTitle, description }: ExplorePageProps) => {
       tile.variant === ExploreCollectionsVariant.DIRECT_LINK &&
       tile.title === PREMIUM_TRACKS.title
     return !isPremiumTracksTile || isUSDCPurchasesEnabled
-  })
-
-  const { data: playlists, isLoading: isLoadingPlaylists } =
-    useFeaturedPlaylists({ limit: 4 })
-  const { data: profiles, isLoading: isLoadingProfiles } = useFeaturedProfiles({
-    limit: 4
   })
 
   const navigate = useNavigate()
@@ -194,48 +176,8 @@ const ExplorePage = ({ title, pageTitle, description }: ExplorePageProps) => {
         ))}
       </Section>
 
-      <Section
-        title={messages.featuredPlaylists}
-        expandable
-        expandText={messages.exploreMorePlaylists}
-      >
-        {isLoadingPlaylists ? (
-          <div className={styles.loadingSpinner}>
-            <Lottie loop autoplay animationData={loadingSpinner} />
-          </div>
-        ) : (
-          playlists?.map((playlist: UserCollection) => {
-            return (
-              <CollectionArtCard
-                key={playlist.playlist_id}
-                id={playlist.playlist_id}
-              />
-            )
-          })
-        )}
-      </Section>
-
-      <Section
-        title={messages.featuredProfiles}
-        expandable
-        expandText={messages.exploreMoreProfiles}
-      >
-        {isLoadingProfiles ? (
-          <div className={styles.loadingSpinner}>
-            <Lottie loop autoplay animationData={loadingSpinner} />
-          </div>
-        ) : (
-          profiles?.map((profile: User, i: number) => {
-            return (
-              <UserArtCard
-                key={profile.user_id}
-                id={profile.user_id}
-                index={i}
-              />
-            )
-          })
-        )}
-      </Section>
+      <FeaturedPlaylists />
+      <FeaturedProfiles />
     </Page>
   )
 }

--- a/packages/web/src/pages/explore-page/components/desktop/FeaturedPlaylists.tsx
+++ b/packages/web/src/pages/explore-page/components/desktop/FeaturedPlaylists.tsx
@@ -1,0 +1,51 @@
+import { useState } from 'react'
+
+import { useFeaturedPlaylists } from '@audius/common/api'
+import { UserCollection } from '@audius/common/models'
+import { Flex, LoadingSpinner } from '@audius/harmony'
+
+import { CollectionArtCard } from './CollectionArtCard'
+import Section from './Section'
+
+const messages = {
+  featuredPlaylists: 'Playlists We Love Right Now',
+  exploreMorePlaylists: 'Explore More Playlists'
+}
+
+const INITIAL_LIMIT = 3
+const EXPANDED_LIMIT = 10
+
+export const FeaturedPlaylists = () => {
+  const [isExpanded, setIsExpanded] = useState(false)
+  const {
+    data: playlists,
+    isPending,
+    isFetching
+  } = useFeaturedPlaylists(
+    { limit: isExpanded ? EXPANDED_LIMIT : INITIAL_LIMIT },
+    { placeholderData: (prev: UserCollection[]) => prev }
+  )
+
+  return (
+    <Section
+      title={messages.featuredPlaylists}
+      expandable
+      expandText={messages.exploreMorePlaylists}
+      onExpand={() => setIsExpanded(true)}
+    >
+      {playlists?.map((playlist: UserCollection) => {
+        return (
+          <CollectionArtCard
+            key={playlist.playlist_id}
+            id={playlist.playlist_id}
+          />
+        )
+      })}
+      {(isPending || isFetching) && (
+        <Flex w='100%' h={320} alignItems='center' justifyContent='center'>
+          <LoadingSpinner />
+        </Flex>
+      )}
+    </Section>
+  )
+}

--- a/packages/web/src/pages/explore-page/components/desktop/FeaturedProfiles.tsx
+++ b/packages/web/src/pages/explore-page/components/desktop/FeaturedProfiles.tsx
@@ -1,0 +1,34 @@
+import { useFeaturedProfiles } from '@audius/common/api'
+import { User } from '@audius/common/models'
+import { LoadingSpinner, Flex } from '@audius/harmony'
+
+import Section from './Section'
+import UserArtCard from './UserArtCard'
+
+const messages = {
+  featuredProfiles: 'Artists You Should Follow',
+  exploreMoreProfiles: 'Explore More Artists'
+}
+
+export const FeaturedProfiles = () => {
+  const { data: profiles, isPending } = useFeaturedProfiles()
+
+  return (
+    <Section
+      title={messages.featuredProfiles}
+      expandable
+      expandText={messages.exploreMoreProfiles}
+    >
+      {profiles?.map((profile: User, i: number) => {
+        return (
+          <UserArtCard key={profile.user_id} id={profile.user_id} index={i} />
+        )
+      })}
+      {isPending && (
+        <Flex w='100%' h={320} alignItems='center' justifyContent='center'>
+          <LoadingSpinner />
+        </Flex>
+      )}
+    </Section>
+  )
+}

--- a/packages/web/src/pages/explore-page/components/desktop/Section.tsx
+++ b/packages/web/src/pages/explore-page/components/desktop/Section.tsx
@@ -24,6 +24,7 @@ type SectionProps = {
   layout?: Layout
   className?: string
   children?: JSX.Element | JSX.Element[] | ReactNode
+  onExpand?: () => void
 }
 
 const Section = ({
@@ -33,12 +34,14 @@ const Section = ({
   expandText,
   layout,
   className,
-  children
+  children,
+  onExpand
 }: SectionProps) => {
   const [isExpanded, setIsExpanded] = useState(false)
   const expand = useCallback(() => {
     setIsExpanded(true)
-  }, [setIsExpanded])
+    onExpand?.()
+  }, [setIsExpanded, onExpand])
 
   return (
     <div


### PR DESCRIPTION
### Description

Fixes explore page content by enabling see-more functionality. Since artists are fast we can pre-load everything, but for collections we have to distribute the fetches between two requests

This also cleans up useUsers, useCollections, and useTracks to use encodedIds as the ids to check when we fetch. Additionally I added currentUserId.