### PR TITLE
Update the logic for associated wallets to not brick DNs due to the db level constraint

### DIFF
--- a/packages/discovery-provider/src/tasks/entity_manager/entities/user.py
+++ b/packages/discovery-provider/src/tasks/entity_manager/entities/user.py
@@ -510,7 +510,7 @@ def update_user_associated_wallets(
                 previous_wallets.append(wallet)
 
         # Verify the wallet signatures and create the user id to wallet associations
-        added_wallets = []
+        current_wallets = []
         for associated_wallet, wallet_metadata in associated_wallets.items():
             if "signature" not in wallet_metadata or not isinstance(
                 wallet_metadata["signature"], str
@@ -535,12 +535,33 @@ def update_user_associated_wallets(
                     blocknumber=user_record.blocknumber,
                     blockhash=user_record.blockhash,
                 )
-                added_wallets.append(associated_wallet_entry)
-        is_updated_wallets = set(
-            [prev_wallet.wallet for prev_wallet in previous_wallets]
-        ) != set([wallet.wallet for wallet in added_wallets])
+                current_wallets.append(associated_wallet_entry)
 
-        if is_updated_wallets:
+        # Create wallet address sets for each list
+        previous_wallets_set = set([wallet.wallet for wallet in previous_wallets])
+        current_wallets_set = set()
+        for wallet in current_wallets:
+            # Check and throw if current_wallets has duplicate wallet addresses
+            if wallet.wallet in current_wallets_set:
+                raise Exception("Duplicate wallet in list of current wallets")
+
+            current_wallets_set.add(wallet.wallet)
+
+        # Get the net new and removed wallet addresses
+        added_wallets_set = current_wallets_set - previous_wallets_set
+        removed_wallets_set = previous_wallets_set - current_wallets_set
+
+        # Make the added and removed wallet lists for updates
+        added_wallets = [
+            wallet for wallet in current_wallets if wallet.wallet in added_wallets_set
+        ]
+        removed_wallets = [
+            wallet
+            for wallet in previous_wallets
+            if wallet.wallet in removed_wallets_set
+        ]
+
+        if added_wallets or removed_wallets:
             for wallet in added_wallets:
                 session.add(wallet)
             for previous_wallet in previous_wallets:


### PR DESCRIPTION
### Description
A DB constraint was added to not allow duplicate associated wallets for a user. This was conflicting with how we were updating wallets previously.
The bug was that we were adding and removing all wallets in the previous_wallets and added_wallets lists which caused there to temporarily be duplicate rows for the user with the same wallet address and as a result would brick the DN indexer. This should update the logic to not update unnecessary rows and only add/remove wallets as needed.
no bugs plz

### How Has This Been Tested?
It has not been yet. We will test
