### PR TITLE
Update discovery lint to lint and fix

### DIFF
--- a/packages/discovery-provider/scripts/lint.sh
+++ b/packages/discovery-provider/scripts/lint.sh
@@ -1,5 +1,4 @@
-isort --diff --check . --skip ./src/tasks/core/gen --skip ./plugins
+isort --diff . --skip ./src/tasks/core/gen --skip ./plugins
 flake8 . --exclude=./src/tasks/core/gen,./plugins
-black --diff --check . --exclude './src/tasks/core/gen|./plugins'
+black --diff . --exclude './src/tasks/core/gen|./plugins'
 mypy . --exclude './src/tasks/core/gen|./plugins'
-


### PR DESCRIPTION
### Description

Latest skip changes also added the "check" flag which meant the lint fix functionality stopped. lmk if there is a better place to put the fix functionality though.