### PR TITLE
Endless listen streak in-progress step-count

### DIFF
--- a/packages/discovery-provider/integration_tests/queries/test_get_challenges.py
+++ b/packages/discovery-provider/integration_tests/queries/test_get_challenges.py
@@ -9,7 +9,9 @@ from src.challenges.challenge import (
     FullEventMetadata,
 )
 from src.challenges.challenge_event_bus import ChallengeEventBus
-from src.challenges.listen_streak_challenge import listen_streak_challenge_manager
+from src.challenges.listen_streak_endless_challenge import (
+    listen_streak_endless_challenge_manager,
+)
 from src.challenges.referral_challenge import (
     referral_challenge_manager,
     verified_referral_challenge_manager,
@@ -566,7 +568,11 @@ def setup_listen_streak_challenge(session):
     # Setup
     blocks = [
         Block(blockhash="0x1", number=1, parenthash="", is_current=False),
-        Block(blockhash="0x2", number=2, parenthash="", is_current=True),
+        Block(blockhash="0x2", number=2, parenthash="", is_current=False),
+        Block(blockhash="0x3", number=3, parenthash="", is_current=False),
+        Block(blockhash="0x4", number=4, parenthash="", is_current=False),
+        Block(blockhash="0x5", number=5, parenthash="", is_current=False),
+        Block(blockhash="0x6", number=6, parenthash="", is_current=True),
     ]
     users = [
         User(
@@ -589,49 +595,216 @@ def setup_listen_streak_challenge(session):
             updated_at=datetime.now(),
             is_verified=True,
         ),
+        User(
+            blockhash="0x3",
+            blocknumber=3,
+            user_id=3,
+            is_current=True,
+            wallet="0xFakeWallet3",
+            created_at=datetime.now(),
+            updated_at=datetime.now(),
+            is_verified=False,
+        ),
+        User(
+            blockhash="0x4",
+            blocknumber=4,
+            user_id=4,
+            is_current=True,
+            wallet="0xFakeWallet4",
+            created_at=datetime.now(),
+            updated_at=datetime.now(),
+            is_verified=False,
+        ),
+        User(
+            blockhash="0x5",
+            blocknumber=5,
+            user_id=5,
+            is_current=True,
+            wallet="0xFakeWallet5",
+            created_at=datetime.now(),
+            updated_at=datetime.now(),
+            is_verified=False,
+        ),
+        User(
+            blockhash="0x6",
+            blocknumber=6,
+            user_id=6,
+            is_current=True,
+            wallet="0xFakeWallet6",
+            created_at=datetime.now(),
+            updated_at=datetime.now(),
+            is_verified=False,
+        ),
     ]
 
     challenges = [
         Challenge(
-            id="l",
-            type=ChallengeType.numeric,
+            id="e",
+            type=ChallengeType.aggregate,
             active=True,
             amount="1",
-            step_count=7,
+            step_count=2147483647,
         )
     ]
 
     user_challenges = [
         UserChallenge(
-            challenge_id="l",
+            challenge_id="e",
             user_id=1,
             specifier="1",
             is_complete=False,
             current_step_count=5,
             amount=1,
-            completed_at=datetime.now(),
+            created_at=datetime.now(),
         ),
         UserChallenge(
-            challenge_id="l",
+            challenge_id="e",
             user_id=2,
             specifier="2",
             is_complete=False,
             current_step_count=5,
             amount=1,
+            created_at=datetime.now(),
+        ),
+        # User 3 has just started a new streak for the first time
+        UserChallenge(
+            challenge_id="e",
+            user_id=3,
+            specifier="3x0",
+            is_complete=False,
+            current_step_count=3,
+            amount=7,
+            created_at=datetime.now(),
+        ),
+        # User 4 has an ongoing listen streak of 9
+        UserChallenge(
+            challenge_id="e",
+            user_id=4,
+            specifier="4x0",
+            is_complete=True,
+            current_step_count=7,
+            amount=7,
+            completed_at=datetime.now() - timedelta(days=2),
+            created_at=datetime.now() - timedelta(days=9),
+        ),
+        UserChallenge(
+            challenge_id="e",
+            user_id=4,
+            specifier="4x1",
+            is_complete=True,
+            current_step_count=1,
+            amount=1,
+            completed_at=datetime.now() - timedelta(days=1),
+            created_at=datetime.now() - timedelta(days=1),
+        ),
+        UserChallenge(
+            challenge_id="e",
+            user_id=4,
+            specifier="4x2",
+            is_complete=True,
+            current_step_count=1,
+            amount=1,
             completed_at=datetime.now(),
+            created_at=datetime.now(),
+        ),
+        # User 5 has one complete listen streak of 8, and an in-progress streak of 3
+        UserChallenge(
+            challenge_id="e",
+            user_id=5,
+            specifier="5x0",
+            is_complete=True,
+            current_step_count=7,
+            amount=7,
+            completed_at=datetime.now() - timedelta(days=30),
+            created_at=datetime.now() - timedelta(days=37),
+        ),
+        UserChallenge(
+            challenge_id="e",
+            user_id=5,
+            specifier="5x1",
+            is_complete=True,
+            current_step_count=1,
+            amount=1,
+            completed_at=datetime.now() - timedelta(days=29),
+            created_at=datetime.now() - timedelta(days=29),
+        ),
+        UserChallenge(
+            challenge_id="e",
+            user_id=5,
+            specifier="5x2",
+            is_complete=False,
+            current_step_count=3,
+            amount=3,
+            created_at=datetime.now(),
+        ),
+        # User 6 has one complete streak of 8, and a broken streak of 2
+        UserChallenge(
+            challenge_id="e",
+            user_id=6,
+            specifier="6x0",
+            is_complete=True,
+            current_step_count=7,
+            amount=7,
+            completed_at=datetime.now() - timedelta(days=30),
+            created_at=datetime.now() - timedelta(days=37),
+        ),
+        UserChallenge(
+            challenge_id="e",
+            user_id=6,
+            specifier="6x1",
+            is_complete=True,
+            current_step_count=1,
+            amount=1,
+            completed_at=datetime.now() - timedelta(days=29),
+            created_at=datetime.now() - timedelta(days=29),
+        ),
+        UserChallenge(
+            challenge_id="e",
+            user_id=6,
+            specifier="6x2",
+            is_complete=False,
+            current_step_count=2,
+            amount=7,
+            created_at=datetime.now() - timedelta(days=4),
         ),
     ]
 
     listen_streak_challenges = [
+        # User 1 has a completed listen streak of 5
         ChallengeListenStreak(
             user_id=1,
             last_listen_date=datetime.now() - timedelta(hours=12),
             listen_streak=5,
         ),
+        # User 2 has a broken listen streak of 5 - override should take effect
         ChallengeListenStreak(
             user_id=2,
             last_listen_date=datetime.now() - timedelta(hours=50),
             listen_streak=5,
+        ),
+        # User 3 has a new listen streak of 3
+        ChallengeListenStreak(
+            user_id=3,
+            last_listen_date=datetime.now() - timedelta(hours=12),
+            listen_streak=3,
+        ),
+        # User 4 has an ongoing listen streak of 9
+        ChallengeListenStreak(
+            user_id=4,
+            last_listen_date=datetime.now() - timedelta(hours=12),
+            listen_streak=9,
+        ),
+        # User 5 has an ongoing listen streak of 3
+        ChallengeListenStreak(
+            user_id=5,
+            last_listen_date=datetime.now() - timedelta(hours=12),
+            listen_streak=3,
+        ),
+        # User 6 has a broken listen streak of 3 - override should take effect
+        ChallengeListenStreak(
+            user_id=6,
+            last_listen_date=datetime.now() - timedelta(days=3),
+            listen_streak=2,
         ),
     ]
 
@@ -650,7 +823,7 @@ def setup_listen_streak_challenge(session):
 
     redis_conn = get_redis()
     bus = ChallengeEventBus(redis_conn)
-    bus.register_listener(DEFAULT_EVENT, listen_streak_challenge_manager)
+    bus.register_listener(DEFAULT_EVENT, listen_streak_endless_challenge_manager)
     return bus
 
 
@@ -662,7 +835,7 @@ def test_get_challenges_with_no_override_step_count(app):
 
             challenges = get_challenges(1, False, session, bus)
             assert len(challenges) == 1
-            assert challenges[0]["challenge_id"] == "l"
+            assert challenges[0]["challenge_id"] == "e"
             assert challenges[0]["current_step_count"] == 5
 
 
@@ -674,5 +847,40 @@ def test_get_challenges_with_override_step_count(app):
 
             challenges = get_challenges(2, False, session, bus)
             assert len(challenges) == 1
-            assert challenges[0]["challenge_id"] == "l"
+            assert challenges[0]["challenge_id"] == "e"
             assert challenges[0]["current_step_count"] == 0
+
+
+def test_listen_streak_endless_challenge(app):
+    with app.app_context():
+        db = get_db()
+        with db.scoped_session() as session:
+            bus = setup_listen_streak_challenge(session)
+
+            challenges = get_challenges(3, False, session, bus)
+            assert len(challenges) == 1
+            assert challenges[0]["challenge_id"] == "e"
+            assert challenges[0]["is_complete"] == False
+            assert challenges[0]["amount"] == "0"
+            assert challenges[0]["current_step_count"] == 3
+
+            challenges = get_challenges(4, False, session, bus)
+            assert len(challenges) == 1
+            assert challenges[0]["challenge_id"] == "e"
+            assert challenges[0]["is_complete"] == True
+            assert challenges[0]["amount"] == "9"
+            assert challenges[0]["current_step_count"] == 9
+
+            challenges = get_challenges(5, False, session, bus)
+            assert len(challenges) == 1
+            assert challenges[0]["challenge_id"] == "e"
+            assert challenges[0]["is_complete"] == True
+            assert challenges[0]["current_step_count"] == 3
+            assert challenges[0]["amount"] == "8"
+
+            challenges = get_challenges(6, False, session, bus)
+            assert len(challenges) == 1
+            assert challenges[0]["challenge_id"] == "e"
+            assert challenges[0]["is_complete"] == True
+            assert challenges[0]["current_step_count"] == 0
+            assert challenges[0]["amount"] == "8"

--- a/packages/discovery-provider/src/challenges/listen_streak_endless_challenge.py
+++ b/packages/discovery-provider/src/challenges/listen_streak_endless_challenge.py
@@ -17,6 +17,8 @@ from src.utils.config import shared_config
 logger = logging.getLogger(__name__)
 env = shared_config["discprov"]["env"]
 
+NUM_DAYS_IN_STREAK = 7
+
 base_timedelta = timedelta(days=1)
 if env == "stage":
     base_timedelta = timedelta(minutes=1)
@@ -34,7 +36,7 @@ def get_listen_streak_override(session: Session, user_id: int) -> Optional[int]:
 
     # If last_listen_date is over 48 hrs, return zero
     current_datetime = datetime.now()
-    if current_datetime - user_listen_challenge.last_listen_date >= timedelta(days=2):
+    if current_datetime - user_listen_challenge.last_listen_date >= base_timedelta * 2:
         return 0
     return None
 
@@ -58,7 +60,7 @@ class ChallengeListenEndlessStreakUpdater(ChallengeUpdater):
             and not most_recent_challenge.is_complete
             and listen_streak is not None
             and listen_streak.last_listen_date is not None
-            and created_at - listen_streak.last_listen_date <= timedelta(days=2)
+            and created_at - listen_streak.last_listen_date <= base_timedelta * 2
         ):
             return most_recent_challenge
         return None
@@ -104,7 +106,7 @@ class ChallengeListenEndlessStreakUpdater(ChallengeUpdater):
             matching_partial_challenge = completion_map[user_challenge.user_id]
             # For endless streak challenges - these rows should only have amount/step_count = 1
             if (
-                matching_partial_challenge.listen_streak > 7
+                matching_partial_challenge.listen_streak > NUM_DAYS_IN_STREAK
                 and user_challenge.current_step_count == 0
             ):
                 user_challenge.amount = 1
@@ -112,11 +114,13 @@ class ChallengeListenEndlessStreakUpdater(ChallengeUpdater):
                 user_challenge.is_complete = True
             # For first normal listen streak challenge - amount/step_count get updated as streak progresses
             else:
-                user_challenge.amount = 7
+                user_challenge.amount = NUM_DAYS_IN_STREAK
                 user_challenge.current_step_count = (
                     matching_partial_challenge.listen_streak
                 )
-                user_challenge.is_complete = user_challenge.current_step_count >= 7
+                user_challenge.is_complete = (
+                    user_challenge.current_step_count >= NUM_DAYS_IN_STREAK
+                )
 
     def on_after_challenge_creation(
         self, session: Session, metadatas: List[FullEventMetadata]

--- a/packages/discovery-provider/src/queries/get_challenges.py
+++ b/packages/discovery-provider/src/queries/get_challenges.py
@@ -68,9 +68,21 @@ def rollup_aggregates(
         amount = "1"
         is_complete = True
     elif parent_challenge.id == "e":
-        sorted_challenges = sorted(user_challenges, key=lambda x: x.created_at)
-        most_recent_challenge = sorted_challenges[-1]
-        if not most_recent_challenge.is_complete:
+        sorted_challenges = sorted(
+            user_challenges, key=lambda x: x.created_at, reverse=True
+        )
+        most_recent_challenge = sorted_challenges[0]
+        if most_recent_challenge.is_complete:
+            step_count = 0
+            for challenge in sorted_challenges:
+                if challenge.current_step_count is None:
+                    continue
+                if challenge.amount < NUM_DAYS_IN_STREAK:
+                    step_count += challenge.current_step_count
+                else:
+                    step_count += challenge.current_step_count
+                    break
+        else:
             step_count = most_recent_challenge.current_step_count
         is_complete = num_complete >= NUM_DAYS_IN_STREAK
         amount = str(num_complete)

--- a/packages/discovery-provider/src/queries/get_challenges.py
+++ b/packages/discovery-provider/src/queries/get_challenges.py
@@ -68,6 +68,10 @@ def rollup_aggregates(
         amount = "1"
         is_complete = True
     elif parent_challenge.id == "e":
+        # `step_count` should only reflect the _current_ in-progress streak, so we
+        # count only the `step_count` of the most recent "full" 7-day streak user_challenge
+        # row, and sum that with the 1-amount user_challenge rows after that one (if any).
+        # But `amount` should still reflect the total claimable amount.
         sorted_challenges = sorted(
             user_challenges, key=lambda x: x.created_at, reverse=True
         )
@@ -77,10 +81,8 @@ def rollup_aggregates(
             for challenge in sorted_challenges:
                 if challenge.current_step_count is None:
                     continue
-                if challenge.amount < NUM_DAYS_IN_STREAK:
-                    step_count += challenge.current_step_count
-                else:
-                    step_count += challenge.current_step_count
+                step_count += challenge.current_step_count
+                if challenge.current_step_count >= NUM_DAYS_IN_STREAK:
                     break
         else:
             step_count = most_recent_challenge.current_step_count


### PR DESCRIPTION
### Description
- Needed to use `base_timedelta` in some more places for local dev
- Add logic to calculate step count for endless listen streak response: only take the latest in-progress listen streak as `current_step_count`, disregard previous ones, even though `amount` will reflect total claimable amount.
AI suggested:
```
            step_count = sum(
                c.current_step_count or 0
                for c in sorted_challenges
                if c.current_step_count is not None
                and (
                    c.amount >= NUM_DAYS_IN_STREAK
                    or all(
                        x.amount < NUM_DAYS_IN_STREAK
                        for x in sorted_challenges[: sorted_challenges.index(c)]
                    )
                )
            )
```
But I think I prefer my "dumber" version.

### How Has This Been Tested?
Added query tests to confirm behavior of `current_step_count` overrides.
- User 2: broken streak
- User 3: fresh new streak (dup of User 1 but whatever)
- User 4: endless streak beyond 7
- User 5: one complete streak in the past, new in-progress streak
- User 6: one complete streak in the past, new broken streak

Local stack - confirmed that step_count shows only the current in-progress streak

New streak started after breaking previous 10-day streak:
<img width="744" alt="Screenshot 2025-02-10 at 4 00 14 PM" src="https://github.com/user-attachments/assets/fcf9628f-050e-48ab-a11e-92eb7727fe80" />

Multiple pre-existing streaks that were broken, UI only shows current in-progress streak:
<img width="977" alt="Screenshot 2025-02-10 at 7 35 36 PM" src="https://github.com/user-attachments/assets/688b3345-2971-4e6d-bcaf-eb6386c86a06" />
