### PR TITLE
[QA-1959] Hide referred tile with new challenge name

### DIFF
--- a/packages/mobile/src/screens/rewards-screen/ChallengeRewardsTile.tsx
+++ b/packages/mobile/src/screens/rewards-screen/ChallengeRewardsTile.tsx
@@ -133,7 +133,8 @@ export const ChallengeRewardsTile = () => {
   // The referred challenge only needs a tile if the user was referred
   const hideReferredTile = !userChallenges.referred?.is_complete
   const rewardIds = useRewardIds({
-    referred: hideReferredTile
+    referred: hideReferredTile,
+    [ChallengeName.Referred]: hideReferredTile
   })
 
   useEffect(() => {

--- a/packages/web/src/pages/rewards-page/components/ChallengeRewards/ChallengeRewardsTile.tsx
+++ b/packages/web/src/pages/rewards-page/components/ChallengeRewards/ChallengeRewardsTile.tsx
@@ -53,7 +53,8 @@ export const ChallengeRewardsTile = ({
   // The referred challenge only needs a tile if the user was referred
   const hideReferredTile = !userChallenges.referred?.is_complete
   const rewardIds = useRewardIds({
-    referred: hideReferredTile
+    referred: hideReferredTile,
+    [ChallengeName.Referred]: hideReferredTile
   })
 
   useEffect(() => {


### PR DESCRIPTION
### Description
Fallout from challenge ID migration. Needed to filter new challenge name as well.

### How Has This Been Tested?

Confirmed referred challenge tile is hidden on local web stage