### PR TITLE
Fix reward claim error gap too large

### DIFF
--- a/packages/web/src/pages/rewards-page/components/modals/ChallengeRewardsModal/ChallengeRewardsModal.tsx
+++ b/packages/web/src/pages/rewards-page/components/modals/ChallengeRewardsModal/ChallengeRewardsModal.tsx
@@ -409,7 +409,9 @@ const ChallengeRewardsBody = ({ dismissModal }: BodyProps) => {
 
   const errorContent =
     claimStatus === ClaimStatus.ERROR ? (
-      <div className={styles.claimError}>{getErrorMessage(aaoErrorCode)}</div>
+      <Text color='danger' strength='strong' textAlign='center'>
+        {getErrorMessage(aaoErrorCode)}
+      </Text>
     ) : null
 
   useEffect(() => {

--- a/packages/web/src/pages/rewards-page/components/modals/ChallengeRewardsModal/styles.module.css
+++ b/packages/web/src/pages/rewards-page/components/modals/ChallengeRewardsModal/styles.module.css
@@ -177,14 +177,6 @@
   letter-spacing: 1px;
 }
 
-.claimError {
-  margin: 32px 32px 0 32px;
-  color: var(--harmony-red);
-  font-weight: var(--harmony-font-demi-bold);
-  line-height: 1.2;
-  text-align: center;
-}
-
 .rewardAmount {
   background: var(--harmony-gradient);
   -webkit-background-clip: text;


### PR DESCRIPTION
### Description
There used to be too large a margin between the claim button and the error message.

### How Has This Been Tested?

<img width="774" alt="Screenshot 2025-02-10 at 8 02 57 PM" src="https://github.com/user-attachments/assets/17f4d75c-1f2d-4e48-b20f-8d50b8045602" />
