### PR TITLE
[QA-1891] Fix track tile icon clipping and zero state

### DIFF
--- a/packages/mobile/src/components/lineup-tile/TrackTileStats.tsx
+++ b/packages/mobile/src/components/lineup-tile/TrackTileStats.tsx
@@ -41,7 +41,7 @@ export const TrackTileStats = (props: TrackTileStatsProps) => {
   })
 
   return (
-    <Flex row justifyContent='space-between' alignItems='center' p='s'>
+    <Flex row justifyContent='space-between' alignItems='center' p='s' h={32}>
       <Flex direction='row' gap='m'>
         {isTrending && rankIndex !== undefined ? (
           <LineupTileRankIcon index={rankIndex} />

--- a/packages/mobile/src/harmony-native/components/Button/IconButton/IconButton.tsx
+++ b/packages/mobile/src/harmony-native/components/Button/IconButton/IconButton.tsx
@@ -50,7 +50,7 @@ export const IconButton = (props: IconButtonProps) => {
   const buttonStyles = {
     borderRadius: 1000,
     padding: spacing.xs,
-    overflow: 'unset'
+    overflow: 'visible' as const
   }
 
   const rippleStyles = useAnimatedStyle(

--- a/packages/mobile/src/harmony-native/components/Button/IconButton/IconButton.tsx
+++ b/packages/mobile/src/harmony-native/components/Button/IconButton/IconButton.tsx
@@ -49,7 +49,8 @@ export const IconButton = (props: IconButtonProps) => {
 
   const buttonStyles = {
     borderRadius: 1000,
-    padding: spacing.xs
+    padding: spacing.xs,
+    overflow: 'unset'
   }
 
   const rippleStyles = useAnimatedStyle(


### PR DESCRIPTION
### Description

- Fixes issue where icon-buttons would overflow due to setting padding: 0. probably fine to just apply to icon button
- Fixes issue where stats zero state height is small due to no content, leading to weird layout of the action buttons. This pretty much only happens on new tracks with no play count