### PR TITLE
[QA-1977] Fix notifications tests

### DIFF
--- a/packages/discovery-provider/plugins/notifications/package.json
+++ b/packages/discovery-provider/plugins/notifications/package.json
@@ -9,7 +9,7 @@
     "lint:fix": "npm run lint -- --fix",
     "pretty": "prettier --write .",
     "start": "pm2-runtime build/src/main.js --restart-delay=3000 --node-args=\"--max-old-space-size=512\"",
-    "test:watch": "jest --watchAll",
+    "test:watch": "jest --runInBand --watchAll",
     "test": "jest --runInBand --forceExit",
     "test-push": "ts-node scripts/test-push-notification.ts",
     "typecheck": "tsc --noEmit"


### PR DESCRIPTION
### Description

Fixes dn tests when running test:watch. Essentially tests always need to have the --runInBand flag