### PR TITLE
Listen streak challenge different specifier for stage

### DIFF
--- a/packages/discovery-provider/src/challenges/listen_streak_endless_challenge.py
+++ b/packages/discovery-provider/src/challenges/listen_streak_endless_challenge.py
@@ -73,6 +73,8 @@ class ChallengeListenEndlessStreakUpdater(ChallengeUpdater):
         # Otherwise, create a new specifier
         created_at = datetime.fromtimestamp(extra["created_at"])
         formatted_date = created_at.strftime("%Y%m%d")
+        if env == "stage":
+            formatted_date = created_at.strftime("%Y%m%d%H%M%S")
         return f"{hex(user_id)[2:]}_{formatted_date}"
 
     def should_create_new_challenge(


### PR DESCRIPTION
### Description
Need more granular specifier for stage since we're using 1 minute timedelta and not 1 day.

Note that this may result in some challenges not being claimable as the specifier might not fit inside the rewards manager program account. But i think this is fine. As long as some of them are claimable we can test that, and this way the logic should mirror prod 1-1.

### How Has This Been Tested?

Tested on local stack.
