### PR TITLE
Fix listen streak challenge amount

### DIFF
--- a/packages/discovery-provider/integration_tests/queries/test_get_challenges.py
+++ b/packages/discovery-provider/integration_tests/queries/test_get_challenges.py
@@ -861,14 +861,14 @@ def test_listen_streak_endless_challenge(app):
             assert len(challenges) == 1
             assert challenges[0]["challenge_id"] == "e"
             assert challenges[0]["is_complete"] == False
-            assert challenges[0]["amount"] == "0"
+            assert challenges[0]["amount"] == "1"
             assert challenges[0]["current_step_count"] == 3
 
             challenges = get_challenges(4, False, session, bus)
             assert len(challenges) == 1
             assert challenges[0]["challenge_id"] == "e"
             assert challenges[0]["is_complete"] == True
-            assert challenges[0]["amount"] == "9"
+            assert challenges[0]["amount"] == "1"
             assert challenges[0]["current_step_count"] == 9
 
             challenges = get_challenges(5, False, session, bus)
@@ -876,11 +876,11 @@ def test_listen_streak_endless_challenge(app):
             assert challenges[0]["challenge_id"] == "e"
             assert challenges[0]["is_complete"] == True
             assert challenges[0]["current_step_count"] == 3
-            assert challenges[0]["amount"] == "8"
+            assert challenges[0]["amount"] == "1"
 
             challenges = get_challenges(6, False, session, bus)
             assert len(challenges) == 1
             assert challenges[0]["challenge_id"] == "e"
             assert challenges[0]["is_complete"] == True
             assert challenges[0]["current_step_count"] == 0
-            assert challenges[0]["amount"] == "8"
+            assert challenges[0]["amount"] == "1"

--- a/packages/discovery-provider/src/queries/get_challenges.py
+++ b/packages/discovery-provider/src/queries/get_challenges.py
@@ -73,7 +73,6 @@ def rollup_aggregates(
         # `step_count` should only reflect the _current_ in-progress streak, so we
         # count only the `step_count` of the most recent "full" 7-day streak user_challenge
         # row, and sum that with the 1-amount user_challenge rows after that one (if any).
-        # But `amount` should still reflect the total claimable amount.
         sorted_challenges = sorted(
             user_challenges, key=lambda x: x.created_at, reverse=True
         )
@@ -89,7 +88,6 @@ def rollup_aggregates(
         else:
             current_step_count = most_recent_challenge.current_step_count or 0
         is_complete = num_complete >= NUM_DAYS_IN_STREAK
-        amount = str(num_complete)
     elif parent_challenge.step_count:
         is_complete = num_complete >= parent_challenge.step_count
     else:


### PR DESCRIPTION
### Description
`amount` actually represents the amount per step here.

### How Has This Been Tested?

Local stack
<img width="834" alt="Screenshot 2025-02-11 at 2 32 44 PM" src="https://github.com/user-attachments/assets/e491b02a-33ae-4d62-9bbc-b1c9326ad973" />
