### PR TITLE
Tag audiusd with protocol releases to allow reverts

### DIFF
--- a/.circleci/src/commands/@docker-commands.yml
+++ b/.circleci/src/commands/@docker-commands.yml
@@ -86,6 +86,19 @@ docker-tag-images:
           done
     - docker-logout
 
+docker-vanity-tag-audiusd:
+  description: |
+    'Adds a semver tag to audius/audiusd:edge that corresponds to the newly released protocol version. '
+    'Makes reverting a bad protocol release easier.'
+  steps:
+    - install-crane
+    - docker-login
+    - run:
+        name:
+        command: |
+          [ -n "$exported_version_tag" ]
+          crane copy "audius/audiusd:edge" "audius/audiusd:${exported_version_tag}"
+
 docker-prune:
   description: 'Perform docker system prune based on disk usage'
   parameters:

--- a/.circleci/src/jobs/deploy-foundation-nodes.yml
+++ b/.circleci/src/jobs/deploy-foundation-nodes.yml
@@ -25,3 +25,4 @@ steps:
   - docker-tag-images:
       tag: __version__
       service: all
+  - docker-vanity-tag-audiusd


### PR DESCRIPTION
### Description

Fixes protocol [deployment reverts](https://www.notion.so/audiusproject/Protocol-Services-Deployment-Guide-708a8f64881740219d3f77707e73a097?pvs=4#0529c517394c4a94a905a623522e2ef4). 

You should be able to revert to an earlier version of discovery provider by setting the `version` in your `audius-ctl config` to a semver. Because audiusd does not follow the discovery provider release cadence anymore, this tag will now be manually added to the latest audiusd image.