### PR TITLE
Format number commas for all reward amounts

### DIFF
--- a/packages/mobile/src/components/challenge-rewards-drawer/ChallengeRewardsDrawerContent.tsx
+++ b/packages/mobile/src/components/challenge-rewards-drawer/ChallengeRewardsDrawerContent.tsx
@@ -37,7 +37,8 @@ const messages = {
   complete: 'Complete',
   claim: 'Claim This Reward',
   claimableLabel: '$AUDIO available to claim',
-  claimableAmountLabel: (amount) => `Claim ${amount} $AUDIO`,
+  claimableAmountLabel: (amount) =>
+    `Claim ${formatNumberCommas(amount)} $AUDIO`,
   claimedLabel: '$AUDIO claimed so far',
   upcomingRewards: 'Upcoming Rewards',
   readyToClaim: 'Ready to Claim',

--- a/packages/mobile/src/components/challenge-rewards-drawer/ClaimAllRewardsDrawer.tsx
+++ b/packages/mobile/src/components/challenge-rewards-drawer/ClaimAllRewardsDrawer.tsx
@@ -9,6 +9,7 @@ import {
   audioRewardsPageActions,
   audioRewardsPageSelectors
 } from '@audius/common/store'
+import { formatNumberCommas } from '@audius/common/utils'
 import { ScrollView, View } from 'react-native'
 import { useDispatch, useSelector } from 'react-redux'
 
@@ -29,8 +30,8 @@ const { getClaimStatus } = audioRewardsPageSelectors
 const messages = {
   // Claim success toast
   claimSuccessMessage: 'All rewards successfully claimed!',
-  pending: (amount: number) => `${amount} Pending`,
-  claimAudio: (amount: number) => `Claim ${amount} $AUDIO`,
+  pending: (amount: number) => `${formatNumberCommas(amount)} Pending`,
+  claimAudio: (amount: number) => `Claim ${formatNumberCommas(amount)} $AUDIO`,
   claiming: 'Claiming $AUDIO',
   done: 'Done'
 }

--- a/packages/web/src/pages/rewards-page/components/modals/ChallengeRewardsModal/ChallengeRewardsModal.tsx
+++ b/packages/web/src/pages/rewards-page/components/modals/ChallengeRewardsModal/ChallengeRewardsModal.tsx
@@ -108,7 +108,8 @@ const messages = {
     'Something has gone wrong, not all your rewards were claimed. Please try again or contact support@audius.co.',
   claimErrorAAO:
     'Your account is unable to claim rewards at this time. Please try again later or contact support@audius.co. ',
-  claimableAmountLabel: (amount: number) => `Claim $${amount} AUDIO`,
+  claimableAmountLabel: (amount: number) =>
+    `Claim ${formatNumberCommas(amount)} $AUDIO`,
   twitterShare: (
     modalType:
       | 'referrals'

--- a/packages/web/src/pages/rewards-page/messages.tsx
+++ b/packages/web/src/pages/rewards-page/messages.tsx
@@ -1,4 +1,4 @@
-import { dayjs, removeNullable } from '@audius/common/utils'
+import { dayjs, formatNumberCommas, removeNullable } from '@audius/common/utils'
 import { Text } from '@audius/harmony'
 
 import { SummaryTableItem } from 'components/summary-table'
@@ -25,9 +25,10 @@ export const messages = {
   goldAudioToken: 'Gold $AUDIO token',
   available: '$AUDIO available',
   now: 'now!',
-  formatCooldownAmount: (amount: number) => `${amount} ${messages.pending}`,
+  formatCooldownAmount: (amount: number) =>
+    `${formatNumberCommas(amount)} ${messages.pending}`,
   formatClaimableAmount: (amount: number) =>
-    `${amount} ${messages.available} ${messages.now}`,
+    `${formatNumberCommas(amount)} ${messages.available} ${messages.now}`,
   availableMessage: (summaryItems: ClaimableSummaryTableItem[]) => {
     const filteredSummaryItems = summaryItems.filter(removeNullable)
     const summaryItem = filteredSummaryItems.pop()


### PR DESCRIPTION
### Description
Use `formatNumberCommas` anywhere a reward amount is used.
Also move the `$` to `$AUDIO`.

### How Has This Been Tested?
Didn't test mobile cuz couldn't point it to a specific DN.

<img width="1233" alt="Screenshot 2025-02-11 at 5 51 18 PM" src="https://github.com/user-attachments/assets/c5c7f737-9896-49c9-830a-29a3b20a89ec" />
<img width="771" alt="Screenshot 2025-02-11 at 5 50 07 PM" src="https://github.com/user-attachments/assets/36eceae7-142e-4ac8-9b96-dee9ae319fcf" />
