### PR TITLE
Don't show oneshot expiry if ineligible

### DIFF
--- a/packages/common/src/utils/challenges.ts
+++ b/packages/common/src/utils/challenges.ts
@@ -15,6 +15,7 @@ export type ChallengeRewardsInfo = {
   title: string
   description: (amount: OptimisticUserChallenge | undefined) => string
   fullDescription?: (amount: OptimisticUserChallenge | undefined) => string
+  optionalDescription?: string
   progressLabel?: string
   remainingLabel?: string
   completedLabel?: string
@@ -313,8 +314,9 @@ export const challengeRewardsConfig: Record<
     description: () =>
       `We're thrilled to reward our talented artist community for driving Audius' growth and success!`,
     fullDescription: () =>
-      `We're thrilled to reward our talented artist community for driving Audius' growth and success! \n\nClaim your tokens before they expire on 05/13/25!`,
-
+      `We're thrilled to reward our talented artist community for driving Audius' growth and success!`,
+    optionalDescription:
+      '\n\nClaim your tokens before they expire on 05/13/25!',
     panelButtonText: '',
     id: ChallengeName.OneShot,
     remainingLabel: 'Ineligible',

--- a/packages/mobile/src/components/challenge-rewards-drawer/ChallengeDescription.tsx
+++ b/packages/mobile/src/components/challenge-rewards-drawer/ChallengeDescription.tsx
@@ -14,8 +14,13 @@ type DescriptionContent =
   | {
       description?: never
       renderDescription: () => ReactNode
+      optionalDescription?: never
     }
-  | { description: ReactNode; renderDescription?: never }
+  | {
+      description: ReactNode
+      renderDescription?: never
+      optionalDescription?: ReactNode
+    }
 
 type ChallengeDescriptionProps = {
   /** Indicates if the challenge has a cooldown period */
@@ -29,6 +34,7 @@ type ChallengeDescriptionProps = {
 export const ChallengeDescription = ({
   description,
   renderDescription,
+  optionalDescription,
   isCooldownChallenge = true
 }: ChallengeDescriptionProps) => {
   const styles = useStyles()
@@ -40,6 +46,7 @@ export const ChallengeDescription = ({
         <Flex gap='m' mb='l'>
           <Text variant='body' size='l'>
             {description}
+            {optionalDescription}
           </Text>
           {isCooldownChallenge ? (
             <Text variant='body' color='subdued'>

--- a/packages/mobile/src/components/challenge-rewards-drawer/ChallengeRewardsDrawerContent.tsx
+++ b/packages/mobile/src/components/challenge-rewards-drawer/ChallengeRewardsDrawerContent.tsx
@@ -48,6 +48,8 @@ const messages = {
 type ChallengeRewardsDrawerContentProps = {
   /** The description of the challenge */
   description: string
+  /** The optional description of the challenge */
+  optionalDescription?: string
   /** The current progress the user has made */
   currentStep: number
   /** The number of steps the user has to complete in total */
@@ -87,6 +89,7 @@ type ChallengeRewardsDrawerContentProps = {
  */
 export const ChallengeRewardsDrawerContent = ({
   description,
+  optionalDescription,
   amount,
   currentStep,
   stepCount = 1,
@@ -152,17 +155,11 @@ export const ChallengeRewardsDrawerContent = ({
   return (
     <>
       <ScrollView style={styles.content}>
-        {isVerifiedChallenge ? (
-          <ChallengeDescription
-            description={description}
-            isCooldownChallenge={isCooldownChallenge}
-          />
-        ) : (
-          <ChallengeDescription
-            description={description}
-            isCooldownChallenge={isCooldownChallenge}
-          />
-        )}
+        <ChallengeDescription
+          description={description}
+          optionalDescription={isClaimable ? optionalDescription : undefined}
+          isCooldownChallenge={isCooldownChallenge}
+        />
         <Flex alignItems='center' gap='3xl' w='100%'>
           <Flex row alignItems='center' gap='xl'>
             <ChallengeReward amount={amount} subtext={messages.audio} />

--- a/packages/mobile/src/components/challenge-rewards-drawer/ChallengeRewardsDrawerProvider.tsx
+++ b/packages/mobile/src/components/challenge-rewards-drawer/ChallengeRewardsDrawerProvider.tsx
@@ -237,6 +237,7 @@ export const ChallengeRewardsDrawerProvider = () => {
               ? config.fullDescription(challenge)
               : config.description(challenge)
           }
+          optionalDescription={config.optionalDescription}
           progressLabel={config.progressLabel ?? 'Completed'}
           completedLabel={config.completedLabel}
           amount={progressRewardAmount}

--- a/packages/web/src/pages/rewards-page/components/modals/ChallengeRewardsModal/ChallengeRewardsModal.tsx
+++ b/packages/web/src/pages/rewards-page/components/modals/ChallengeRewardsModal/ChallengeRewardsModal.tsx
@@ -287,6 +287,7 @@ const ChallengeRewardsBody = ({ dismissModal }: BodyProps) => {
   const currentStepCount = challenge?.current_step_count || 0
   const {
     fullDescription,
+    optionalDescription,
     progressLabel,
     completedLabel,
     isVerifiedChallenge
@@ -342,6 +343,7 @@ const ChallengeRewardsBody = ({ dismissModal }: BodyProps) => {
       ) : null}
       <Text variant='body' style={{ whiteSpace: 'pre-line' }}>
         {fullDescription?.(challenge)}
+        {challenge?.claimableAmount ? optionalDescription : null}
       </Text>
       {isCooldownChallenge ? (
         <Text variant='body' color='subdued'>


### PR DESCRIPTION
### Description
Don't show expiration message if ineligible for oneshot.

### How Has This Been Tested?

<img width="835" alt="Screenshot 2025-02-11 at 6 18 59 PM" src="https://github.com/user-attachments/assets/0d3102ac-0f5f-421e-bcf9-015acdf5f5ee" />
<img width="792" alt="Screenshot 2025-02-11 at 6 18 47 PM" src="https://github.com/user-attachments/assets/0e4d5390-3c69-43e3-b961-de279c3eb9a4" />
<img width="792" alt="Screenshot 2025-02-11 at 6 18 47 PM" src="https://github.com/user-attachments/assets/9b888da4-3005-45f9-9c56-207b1a699eff" />
<img width="792" alt="Screenshot 2025-02-11 at 6 18 47 PM" src="https://github.com/user-attachments/assets/b814cabf-29fe-41a9-9587-0392fa58ac86" />

