### PR TITLE
[PAY-3941] Claim all rewards tile respects optimistic challenges

### DIFF
--- a/packages/common/src/services/remote-config/feature-flags.ts
+++ b/packages/common/src/services/remote-config/feature-flags.ts
@@ -26,7 +26,7 @@ export enum FeatureFlags {
   REACT_QUERY_SYNC = 'react_query_sync',
   TRACK_REPLACE_DOWNLOADS = 'track_replace_downloads',
   ONE_SHOT = 'one_shot',
-  CLAIM_ALL_REWARDS = 'claim_all_rewards'
+  CLAIM_ALL_REWARDS_TILE = 'claim_all_rewards_tile'
 }
 
 type FlagDefaults = Record<FeatureFlags, boolean>
@@ -68,5 +68,5 @@ export const flagDefaults: FlagDefaults = {
   [FeatureFlags.REACT_QUERY_SYNC]: false,
   [FeatureFlags.TRACK_REPLACE_DOWNLOADS]: false,
   [FeatureFlags.ONE_SHOT]: false,
-  [FeatureFlags.CLAIM_ALL_REWARDS]: false
+  [FeatureFlags.CLAIM_ALL_REWARDS_TILE]: true
 }

--- a/packages/mobile/src/screens/rewards-screen/ClaimAllRewardsTile.tsx
+++ b/packages/mobile/src/screens/rewards-screen/ClaimAllRewardsTile.tsx
@@ -5,7 +5,7 @@ import {
   useChallengeCooldownSchedule,
   useFeatureFlag
 } from '@audius/common/hooks'
-import { FeatureFlags } from '@audius/common/services/remote-config/feature-flags'
+import { FeatureFlags } from '@audius/common/services'
 import { modalsActions } from '@audius/common/store'
 import { Image, View } from 'react-native'
 import { useDispatch } from 'react-redux'

--- a/packages/mobile/src/screens/rewards-screen/ClaimAllRewardsTile.tsx
+++ b/packages/mobile/src/screens/rewards-screen/ClaimAllRewardsTile.tsx
@@ -2,8 +2,10 @@ import { useCallback } from 'react'
 
 import {
   formatCooldownChallenges,
-  useChallengeCooldownSchedule
+  useChallengeCooldownSchedule,
+  useFeatureFlag
 } from '@audius/common/hooks'
+import { FeatureFlags } from '@audius/common/services/remote-config/feature-flags'
 import { modalsActions } from '@audius/common/store'
 import { Image, View } from 'react-native'
 import { useDispatch } from 'react-redux'
@@ -74,6 +76,7 @@ const useStyles = makeStyles(({ spacing, typography }) => ({
 export const ClaimAllRewardsTile = () => {
   const styles = useStyles()
   const dispatch = useDispatch()
+  const { isEnabled } = useFeatureFlag(FeatureFlags.CLAIM_ALL_REWARDS_TILE)
   const { cooldownChallenges, cooldownAmount, claimableAmount, isEmpty } =
     useChallengeCooldownSchedule({ multiple: true })
 
@@ -81,7 +84,7 @@ export const ClaimAllRewardsTile = () => {
     dispatch(setVisibility({ modal: 'ClaimAllRewards', visible: true }))
   }, [dispatch])
 
-  if (isEmpty) return null
+  if (isEmpty || !isEnabled) return null
 
   return (
     <Paper shadow='near' border='strong' p='l' gap='l'>

--- a/packages/web/src/pages/rewards-page/components/ChallengeRewards/ChallengeRewardsTile.tsx
+++ b/packages/web/src/pages/rewards-page/components/ChallengeRewards/ChallengeRewardsTile.tsx
@@ -50,7 +50,7 @@ export const ChallengeRewardsTile = ({
   const [haveChallengesLoaded, setHaveChallengesLoaded] = useState(false)
   const { isEnabled: isOneShotEnabled } = useFeatureFlag(FeatureFlags.ONE_SHOT)
   const { isEnabled: isClaimAllRewardsEnabled } = useFeatureFlag(
-    FeatureFlags.CLAIM_ALL_REWARDS
+    FeatureFlags.CLAIM_ALL_REWARDS_TILE
   )
 
   // The referred challenge only needs a tile if the user was referred

--- a/packages/web/src/pages/rewards-page/components/ClaimAllRewardsPanel.tsx
+++ b/packages/web/src/pages/rewards-page/components/ClaimAllRewardsPanel.tsx
@@ -2,8 +2,10 @@ import { useCallback } from 'react'
 
 import {
   formatCooldownChallenges,
-  useChallengeCooldownSchedule
+  useChallengeCooldownSchedule,
+  useFeatureFlag
 } from '@audius/common/hooks'
+import { FeatureFlags } from '@audius/common/services'
 import {
   Box,
   Button,
@@ -24,6 +26,7 @@ import styles from '../RewardsTile.module.css'
 import { messages } from '../messages'
 
 export const ClaimAllRewardsPanel = () => {
+  const { isEnabled } = useFeatureFlag(FeatureFlags.CLAIM_ALL_REWARDS_TILE)
   const isMobile = useIsMobile() || window.innerWidth < 1080
   const wm = useWithMobileStyle(styles.mobile)
   const { cooldownChallenges, cooldownAmount, claimableAmount, isEmpty } =
@@ -48,7 +51,7 @@ export const ClaimAllRewardsPanel = () => {
     }
   }, [claimable, cooldownAmount, onClickClaimAllRewards, onClickMoreInfo])
 
-  if (isEmpty) return null
+  if (isEmpty || !isEnabled) return null
 
   if (isMobile) {
     return (


### PR DESCRIPTION
### Description
- Filter out challenges that are optimistically claimed in claim all rewards panel/tile
- Show/hide the panel completely according to the feature flag

### How Has This Been Tested?
Filtered using
```
  const a = useSelector(getOptimisticUserChallenges)
  const optimisticChallenges = {
    ...a,
    e: {
      challenge_id: 'e',
      claimableAmount: 0,
      undisbursedSpecifiers: [
        {
          specifier: '13e545dc_20250211',
          amount: 100
        }
      ]
    }
  }
```

Filtered
<img width="675" alt="Screenshot 2025-02-11 at 7 03 01 PM" src="https://github.com/user-attachments/assets/a00f30f4-1b83-4629-bafd-045a7076a6ca" />
Unfiltered
<img width="708" alt="Screenshot 2025-02-11 at 6 55 56 PM" src="https://github.com/user-attachments/assets/883ebdec-875e-4e8a-aa60-5061e0c8fb03" />
