### PR TITLE
Filter out listen streak endless notifications

### DIFF
--- a/packages/common/src/services/remote-config/feature-flags.ts
+++ b/packages/common/src/services/remote-config/feature-flags.ts
@@ -25,6 +25,7 @@ export enum FeatureFlags {
   FAST_REFERRAL = 'fast_referral',
   REACT_QUERY_SYNC = 'react_query_sync',
   TRACK_REPLACE_DOWNLOADS = 'track_replace_downloads',
+  LISTEN_STREAK_ENDLESS = 'listen_streak_endless',
   ONE_SHOT = 'one_shot',
   CLAIM_ALL_REWARDS = 'claim_all_rewards'
 }
@@ -67,6 +68,7 @@ export const flagDefaults: FlagDefaults = {
   [FeatureFlags.FAST_REFERRAL]: false,
   [FeatureFlags.REACT_QUERY_SYNC]: false,
   [FeatureFlags.TRACK_REPLACE_DOWNLOADS]: false,
+  [FeatureFlags.LISTEN_STREAK_ENDLESS]: false,
   [FeatureFlags.ONE_SHOT]: false,
   [FeatureFlags.CLAIM_ALL_REWARDS]: false
 }


### PR DESCRIPTION
### Description
Added new feature flag for this challenge and filtered in the same strategy that one shot did.
Also cleaned up some old filters.

### How Has This Been Tested?

ff on:
didn't see any other listen streak challenges
<img width="510" alt="Screenshot 2025-02-11 at 7 21 20 PM" src="https://github.com/user-attachments/assets/37a553ba-251c-49f5-bc0c-aff9f1b40d70" />


ff off:
<img width="551" alt="Screenshot 2025-02-11 at 7 21 00 PM" src="https://github.com/user-attachments/assets/055b383e-9a20-4390-86fc-22fe70e0f194" />
