### PR TITLE
Fix plays indexing starvation

### DIFF
--- a/packages/discovery-provider/integration_tests/queries/test_get_playlists.py
+++ b/packages/discovery-provider/integration_tests/queries/test_get_playlists.py
@@ -350,46 +350,40 @@ def test_get_playlists_sorting(app, test_entities):
             # Make playlist 1 most popular with 3 saves
             {
                 "user_id": 2,
-            "save_type": "playlist", 
-            "save_item_id": 1,
-        },
-        {
-            "user_id": 3,
-            "save_type": "playlist",
-            "save_item_id": 1,
-        },
-        # Give playlist 6 one save
-        {
-            "user_id": 2,
-            "save_type": "playlist",
-            "save_item_id": 6,
-        }
-    ]
+                "save_type": "playlist",
+                "save_item_id": 1,
+            },
+            {
+                "user_id": 3,
+                "save_type": "playlist",
+                "save_item_id": 1,
+            },
+            # Give playlist 6 one save
+            {
+                "user_id": 2,
+                "save_type": "playlist",
+                "save_item_id": 6,
+            },
+        ]
     }
 
     with app.test_request_context():
         db = get_db()
         populate_mock_db(db, test_entities)
         populate_mock_db(db, save_entities)
-        
+
         with db.scoped_session():
             # Test recent sorting (default)
             playlists_recent = get_playlists(
-                GetPlaylistsArgs(
-                    user_id=1,
-                    sort_method="recent"
-                ),
+                GetPlaylistsArgs(user_id=1, sort_method="recent"),
             )
             assert len(playlists_recent) > 0
             # Most recently created should be first
             assert playlists_recent[0]["playlist_id"] == 7
-            
+
             # Test popular sorting
             playlists_popular = get_playlists(
-                GetPlaylistsArgs(
-                    user_id=1,
-                    sort_method="popular"
-                ),
+                GetPlaylistsArgs(user_id=1, sort_method="popular"),
             )
             assert len(playlists_popular) > 0
             print([playlist["playlist_id"] for playlist in playlists_popular])
@@ -402,45 +396,45 @@ def test_get_playlists_sorting(app, test_entities):
 def test_get_playlists_default_and_invalid_sort(app, test_entities):
     """Test default sorting behavior and invalid sort methods"""
     # Add some test data with different creation timestamps
-    test_entities["playlists"].extend([
-        {
-            "playlist_id": 8,
-            "playlist_owner_id": 1,
-            "playlist_name": "newest playlist",
-            "is_current": True,
-            "created_at": datetime.now() + timedelta(days=1)
-        },
-        {
-            "playlist_id": 9,
-            "playlist_owner_id": 1,
-            "playlist_name": "older playlist",
-            "is_current": True,
-            "created_at": datetime.now() - timedelta(days=1)
-        }
-    ])
+    test_entities["playlists"].extend(
+        [
+            {
+                "playlist_id": 8,
+                "playlist_owner_id": 1,
+                "playlist_name": "newest playlist",
+                "is_current": True,
+                "created_at": datetime.now() + timedelta(days=1),
+            },
+            {
+                "playlist_id": 9,
+                "playlist_owner_id": 1,
+                "playlist_name": "older playlist",
+                "is_current": True,
+                "created_at": datetime.now() - timedelta(days=1),
+            },
+        ]
+    )
 
     with app.test_request_context():
         db = get_db()
         populate_mock_db(db, test_entities)
-        
+
         with db.scoped_session():
             # Test default sorting (should be same as recent)
             playlists_default = get_playlists(
-                GetPlaylistsArgs(
-                    user_id=1
-                ),
+                GetPlaylistsArgs(user_id=1),
             )
             assert len(playlists_default) > 0
             # Most recently created should be first
             assert playlists_default[0]["playlist_id"] == 8
-            
+
             # Test invalid sort method (should default to recent)
             playlists_invalid = get_playlists(
-                GetPlaylistsArgs(
-                    user_id=1,
-                    sort_method="invalid_sort"
-                ),
+                GetPlaylistsArgs(user_id=1, sort_method="invalid_sort"),
             )
             assert len(playlists_invalid) > 0
             # Should match default sort order
-            assert playlists_invalid[0]["playlist_id"] == playlists_default[0]["playlist_id"]
+            assert (
+                playlists_invalid[0]["playlist_id"]
+                == playlists_default[0]["playlist_id"]
+            )

--- a/packages/discovery-provider/scripts/start.sh
+++ b/packages/discovery-provider/scripts/start.sh
@@ -65,7 +65,7 @@ else
             --concurrency 1 \
             --prefetch-multiplier 1 \
             2>&1 | tee >(logger -t index_core_worker) &
-            
+
         # start worker dedicated to indexing ACDC
         audius_service=worker celery -A src.worker.celery worker -Q index_nethermind \
             --loglevel "$audius_discprov_loglevel" \
@@ -78,7 +78,7 @@ else
         audius_service=worker celery -A src.worker.celery worker -Q index_sol \
             --loglevel "$audius_discprov_loglevel" \
             --hostname=index_sol \
-            --concurrency 1 \
+            --concurrency 3 \
             --prefetch-multiplier 1 \
             2>&1 | tee >(logger -t index_sol_worker) &
 

--- a/packages/discovery-provider/src/app.py
+++ b/packages/discovery-provider/src/app.py
@@ -529,7 +529,7 @@ def configure_celery(celery, test_config=None):
     celery.send_task("cache_current_nodes")
     celery.send_task("cache_entity_counts")
     celery.send_task("index_nethermind", queue="index_nethermind")
-    celery.send_task("index_rewards_manager", queue="index_core")
+    celery.send_task("index_rewards_manager", queue="index_sol")
     celery.send_task("index_user_bank", queue="index_sol")
     celery.send_task("index_payment_router", queue="index_sol")
     celery.send_task("index_core", queue="index_core")

--- a/packages/discovery-provider/src/tasks/index_payment_router.py
+++ b/packages/discovery-provider/src/tasks/index_payment_router.py
@@ -1005,7 +1005,7 @@ def process_payment_router_txs() -> None:
 
 
 # ####### CELERY TASKS ####### #
-@celery.task(name="index_payment_router", time_limit=300, bind=True)
+@celery.task(name="index_payment_router", rate_limit="5/s", time_limit=300, bind=True)
 @save_duration_metric(metric_group="celery_task")
 def index_payment_router(self):
     # Cache custom task class properties
@@ -1040,4 +1040,4 @@ def index_payment_router(self):
     finally:
         if have_lock:
             update_lock.release()
-        celery.send_task("index_payment_router", countdown=0.5, queue="index_sol")
+        celery.send_task("index_payment_router", queue="index_sol")

--- a/packages/discovery-provider/src/tasks/index_rewards_manager.py
+++ b/packages/discovery-provider/src/tasks/index_rewards_manager.py
@@ -631,7 +631,7 @@ def process_solana_rewards_manager(
 
 
 # ####### CELERY TASKS ####### #
-@celery.task(name="index_rewards_manager", bind=True)
+@celery.task(name="index_rewards_manager", rate_limit="5/s", bind=True)
 @save_duration_metric(metric_group="celery_task")
 def index_rewards_manager(self):
     redis = index_rewards_manager.redis
@@ -663,4 +663,4 @@ def index_rewards_manager(self):
     finally:
         if have_lock:
             update_lock.release()
-        celery.send_task("index_rewards_manager", countdown=0.5, queue="index_core")
+        celery.send_task("index_rewards_manager", queue="index_sol")

--- a/packages/discovery-provider/src/tasks/index_user_bank.py
+++ b/packages/discovery-provider/src/tasks/index_user_bank.py
@@ -772,7 +772,7 @@ def process_user_bank_txs() -> None:
 
 
 # ####### CELERY TASKS ####### #
-@celery.task(name="index_user_bank", bind=True)
+@celery.task(name="index_user_bank", rate_limit="5/s", bind=True)
 @save_duration_metric(metric_group="celery_task")
 def index_user_bank(self):
     # Cache custom task class properties


### PR DESCRIPTION
### Description

Rewards manager indexing is negatively impacting plays indexing. Moving it to index_sol queue and adding rate limits will help better control fairness between these tasks. I believe before when i tried to simply move and keep that countdown, other tasks were still building up in the queue faster. Increasing concurrency to match the task number. Running on prod dn2 right now and allowed plays to catch up and keep solana indexing < 1 sec.

```
"solana_indexers": {
"aggregate_tips": {
"is_healthy": true,
"last_completed_at": 1739403683.008592,
"last_tx": "5nowqXGEgP2raG8q5M3ZtGRVMeDxKKBCEhLT9Nkaxj6zmH8nHvRQ77kSuo5pPrKwGK9EhJ8FofurBubMA7RiSB1k",
"since_last_completed_at": 20.829676151275635
},
"payment_router": {
"is_healthy": true,
"last_completed_at": 1739403700.220201,
"last_tx": "5YLrgFvonRA1d9EJK43r9fiyi6oo7oV8GJxTEtM2ggcFFR4SKSghSCu3rS8Udf7nPMHF4W1m7Hm69b7W3v9E7vaP",
"since_last_completed_at": 3.6177709102630615
},
"reward_manager": {
"is_healthy": true,
"last_completed_at": 1739403703.741817,
"last_tx": "3vQCDdHystVzoGTpCJG9VxnNUGWeC1cmSKqSjehfKVc22br36Cg6szU9dd6jhCK7wV1928gWjjiZsEz9Zd1mRnrX",
"since_last_completed_at": 0.09565210342407227
},
"spl_token": {
"is_healthy": true,
"last_completed_at": 1739403619.445501,
"last_tx": "5CVAgGuqV9eU8ezs4i4gzsbQmUBsZWf5dzNLG9PRdmgpyDYR7uvCFJivN2bX8HVm3NJCxJmG65Pf86LKoAraF7vB",
"since_last_completed_at": 84.39163088798523
},
"user_bank": {
"is_healthy": true,
"last_completed_at": 1739403702.270003,
"last_tx": "5nowqXGEgP2raG8q5M3ZtGRVMeDxKKBCEhLT9Nkaxj6zmH8nHvRQ77kSuo5pPrKwGK9EhJ8FofurBubMA7RiSB1k",
"since_last_completed_at": 1.5667920112609863
}

``` 

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._
