### PR TITLE
🪦 poa ganache

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -337,12 +337,10 @@ workflows:
             comms/.* run-discovery-workflow true
             packages/identity-service/.* run-identity-workflow true
             eth-contracts/.* run-eth-contracts-workflow true
-            contracts/.* run-contracts-workflow true
             .circleci/.* run-discovery-workflow true
             .circleci/.* run-identity-workflow true
             .circleci/.* run-eth-contracts-workflow true
             .circleci/.* run-protocol-dashboard-workflow true
-            .circleci/.* run-contracts-workflow true
             .circleci/.* run-sdk-workflow true
             .circleci/.* run-web-workflow true
             .circleci/.* run-mobile-workflow true
@@ -389,12 +387,10 @@ workflows:
             comms/.* run-discovery-workflow true
             packages/identity-service/.* run-identity-workflow true
             eth-contracts/.* run-eth-contracts-workflow true
-            contracts/.* run-contracts-workflow true
             .circleci/.* run-discovery-workflow true
             .circleci/.* run-identity-workflow true
             .circleci/.* run-eth-contracts-workflow true
             .circleci/.* run-protocol-dashboard-workflow true
-            .circleci/.* run-contracts-workflow true
             .circleci/.* run-sdk-workflow true
             .circleci/.* run-web-workflow true
             .circleci/.* run-mobile-workflow true
@@ -437,7 +433,6 @@ workflows:
           mapping: |
             .* run-integration-workflow true
             .* run-eth-contracts-workflow true
-            .* run-contracts-workflow true
             .* run-release-workflow true
             .* run-sdk-workflow true
           requires:

--- a/.circleci/src/workflows/contracts.yml
+++ b/.circleci/src/workflows/contracts.yml
@@ -1,6 +1,0 @@
-when: << pipeline.parameters.run-contracts-workflow >>
-jobs:
-  - test:
-      name: test-contracts
-      context: Vercel
-      service: contracts

--- a/dev-tools/audius-compose
+++ b/dev-tools/audius-compose
@@ -21,7 +21,6 @@ audius-protocol-creator-node-1 audius-protocol-creator-node-2 audius-protocol-cr
 audius-protocol-identity-service-1 \
 audius-protocol-solana-test-validator-1 \
 audius-protocol-eth-ganache-1 \
-audius-protocol-poa-ganache-1 \
 audius-protocol-pedalboard \
 audius-protocol-anti-abuse-oracle-1 \
 audius-protocol-discovery-provider-redis-1 \

--- a/dev-tools/compose/docker-compose.blockchain.yml
+++ b/dev-tools/compose/docker-compose.blockchain.yml
@@ -1,18 +1,6 @@
 version: '3.9'
 
 services:
-  poa-ganache:
-    image: audius/poa-ganache:latest
-    command: bash /tmp/dev-tools/startup/poa-ganache.sh
-    volumes:
-      - poa-contracts-abis:/usr/src/app/build/contracts
-      - ${PROJECT_ROOT}/dev-tools:/tmp/dev-tools
-    ports:
-      - '8545:8545'
-    deploy:
-      mode: global
-    profiles:
-      - chain
 
   eth-ganache:
     image: audius/eth-ganache:latest

--- a/dev-tools/compose/docker-compose.discovery.prod.yml
+++ b/dev-tools/compose/docker-compose.discovery.prod.yml
@@ -157,8 +157,6 @@ services:
     depends_on:
       db:
         condition: service_healthy
-      poa-ganache:
-        condition: service_healthy
       eth-ganache:
         condition: service_healthy
       solana-test-validator:

--- a/dev-tools/compose/docker-compose.identity.prod.yml
+++ b/dev-tools/compose/docker-compose.identity.prod.yml
@@ -83,8 +83,6 @@ services:
         condition: service_healthy
       identity-service-redis:
         condition: service_healthy
-      poa-ganache:
-        condition: service_healthy
       eth-ganache:
         condition: service_healthy
       solana-test-validator:

--- a/dev-tools/compose/docker-compose.pedalboard.prod.yml
+++ b/dev-tools/compose/docker-compose.pedalboard.prod.yml
@@ -67,8 +67,6 @@ services:
         condition: service_healthy
       discovery-provider-redis:
         condition: service_healthy
-      poa-ganache:
-        condition: service_healthy
 
   solana-relay:
     build:

--- a/dev-tools/compose/docker-compose.test.yml
+++ b/dev-tools/compose/docker-compose.test.yml
@@ -48,20 +48,6 @@ services:
         limits:
           memory: 3G
 
-  poa-ganache:
-    image: audius/poa-ganache:latest
-    command: bash /tmp/dev-tools/startup/poa-ganache.sh
-    volumes:
-      - poa-contracts-abis:/usr/src/app/build/contracts
-      - ${PROJECT_ROOT}/dev-tools:/tmp/dev-tools
-    logging: *default-logging
-    deploy:
-      mode: global
-    profiles:
-      - tests
-      - chain
-      - poa
-
   eth-ganache:
     image: audius/eth-ganache:latest
     command: bash /tmp/dev-tools/startup/eth-ganache.sh
@@ -207,26 +193,8 @@ services:
 
   # contracts
   test-contracts:
-    user: ${DOCKER_UID:-root}:${DOCKER_GID:-root}
-    build:
-      context: ${PROJECT_ROOT}/contracts
-      dockerfile: Dockerfile
-      args:
-        bootstrapSPIds: ${BOOTSTRAP_SP_IDS}
-        bootstrapSPDelegateWallets: ${BOOTSTRAP_SP_DELEGATE_WALLETS}
-        bootstrapSPOwnerWallets: ${BOOTSTRAP_SP_OWNER_WALLETS}
-    entrypoint: sh -c '[ "$$1" = "test" ] || sleep inf && (shift; npm run test)' -
-    logging: *default-logging
-    deploy:
-      mode: global
-    depends_on:
-      poa-ganache:
-        condition: service_healthy
-    profiles:
-      - poa
-    volumes:
-      - ${PROJECT_ROOT}/contracts:/usr/src/app
-      - /usr/src/app/node_modules
+    image: busybox:1.31.1
+    entrypoint: ["sh", "-c", "exit 0"]
 
   # eth-contracts
   test-eth-contracts:

--- a/dev-tools/compose/docker-compose.test.yml
+++ b/dev-tools/compose/docker-compose.test.yml
@@ -191,11 +191,6 @@ services:
     profiles:
       - tests
 
-  # contracts
-  test-contracts:
-    image: busybox:1.31.1
-    entrypoint: ["sh", "-c", "exit 0"]
-
   # eth-contracts
   test-eth-contracts:
     user: ${DOCKER_UID:-root}:${DOCKER_GID:-root}

--- a/dev-tools/compose/docker-compose.yml
+++ b/dev-tools/compose/docker-compose.yml
@@ -218,12 +218,6 @@ services:
 
   # Blockchain
 
-  poa-ganache:
-    extends:
-      file: docker-compose.blockchain.yml
-      service: poa-ganache
-    <<: *common
-
   eth-ganache:
     extends:
       file: docker-compose.blockchain.yml

--- a/dev-tools/compose/docker-compose.yml
+++ b/dev-tools/compose/docker-compose.yml
@@ -23,7 +23,6 @@ x-common: &common
     - 'audius-protocol-identity-service-1:host-gateway'
     - 'audius-protocol-solana-test-validator-1:host-gateway'
     - 'audius-protocol-eth-ganache-1:host-gateway'
-    - 'audius-protocol-poa-ganache-1:host-gateway'
     - 'audius-protocol-pedalboard:host-gateway'
   deploy:
     resources:

--- a/dev-tools/compose/nginx_ingress.conf
+++ b/dev-tools/compose/nginx_ingress.conf
@@ -28,13 +28,6 @@ server {
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
     }
 
-    location ~ ^/chain(/.*)?$ {
-        resolver 127.0.0.11 valid=30s;
-        proxy_pass http://audius-protocol-poa-ganache-1:8545/$1;
-        proxy_set_header Host $http_host;
-        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-    }
-
     location ~ ^/relay(/.*)?$ {
         resolver 127.0.0.11 valid=30s;
         proxy_pass http://audius-protocol-relay-1:6001/relay$1;
@@ -245,18 +238,6 @@ server {
     location / {
         resolver 127.0.0.11 valid=30s;
         set $upstream audius-protocol-eth-ganache-1:8545;
-        proxy_pass http://$upstream;
-        proxy_set_header Host $http_host;
-        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-    }
-}
-server {
-    listen      80;
-    server_name audius-protocol-poa-ganache-1;
-
-    location / {
-        resolver 127.0.0.11 valid=30s;
-        set $upstream audius-protocol-poa-ganache-1:8545;
         proxy_pass http://$upstream;
         proxy_set_header Host $http_host;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;

--- a/packages/discovery-provider/plugins/pedalboard/apps/relay/src/index.ts
+++ b/packages/discovery-provider/plugins/pedalboard/apps/relay/src/index.ts
@@ -26,11 +26,16 @@ export let web3: providers.JsonRpcProvider
 export let wallets: WalletManager
 
 const main = async () => {
-  // async config
-  const connectedWeb3 = await connectWeb3(config)
-  web3 = connectedWeb3.web3
-  config.acdcChainId = connectedWeb3.chainId.toString()
-  wallets = new WalletManager(web3)
+  if (config.environment !== "dev") {
+    // async config
+    const connectedWeb3 = await connectWeb3(config)
+    web3 = connectedWeb3.web3
+    config.acdcChainId = connectedWeb3.chainId.toString()
+    wallets = new WalletManager(web3)
+  } else {
+    // needs to stay so decoding can happen correctly
+    config.acdcChainId = "1337"
+  }
 
   // start webserver after async config
   const { serverHost, serverPort } = config

--- a/packages/discovery-provider/plugins/pedalboard/apps/relay/src/middleware/validator.ts
+++ b/packages/discovery-provider/plugins/pedalboard/apps/relay/src/middleware/validator.ts
@@ -201,6 +201,8 @@ export const retrieveUser = async (
       chainId: config.acdcChainId!
     })
 
+    console.log({ recoveredAddress, senderAddress, contractAddress, chainId: config.acdcChainId! }, "retrieveUser recoveredAddress")
+
     query = query.where('wallet', '=', recoveredAddress)
     addedWalletClause = true
   }

--- a/packages/discovery-provider/plugins/pedalboard/apps/relay/src/middleware/validator.ts
+++ b/packages/discovery-provider/plugins/pedalboard/apps/relay/src/middleware/validator.ts
@@ -201,8 +201,6 @@ export const retrieveUser = async (
       chainId: config.acdcChainId!
     })
 
-    console.log({ recoveredAddress, senderAddress, contractAddress, chainId: config.acdcChainId! }, "retrieveUser recoveredAddress")
-
     query = query.where('wallet', '=', recoveredAddress)
     addedWalletClause = true
   }

--- a/packages/discovery-provider/plugins/pedalboard/apps/relay/src/txRelay.ts
+++ b/packages/discovery-provider/plugins/pedalboard/apps/relay/src/txRelay.ts
@@ -24,8 +24,6 @@ export const relayTransaction = async (
   const { validatedRelayRequest, logger, requestId } = res.locals.ctx
   const { encodedABI, gasLimit, contractAddress } = validatedRelayRequest
 
-  const senderWallet = wallets.selectNextWallet()
-  const address = await senderWallet.getAddress()
   let nonce = undefined
   let submit = undefined
   try {
@@ -42,6 +40,9 @@ export const relayTransaction = async (
         return
       }
     }
+
+    const senderWallet = wallets.selectNextWallet()
+    const address = await senderWallet.getAddress()
 
     // gather some transaction params
     nonce = await retryPromise(() => web3.getTransactionCount(address))
@@ -63,7 +64,6 @@ export const relayTransaction = async (
     receipt.blockNumber += config.finalPoaBlock
     logger.info(
       {
-        senderWallet: address,
         nonce,
         txHash: submit?.hash,
         blocknumber: receipt.blockNumber
@@ -73,7 +73,7 @@ export const relayTransaction = async (
     res.send({ receipt })
   } catch (e) {
     logger.error(
-      { senderWallet: address, nonce, txHash: submit?.hash },
+      { nonce, txHash: submit?.hash },
       'transaction submission failed'
     )
     internalError(next, e)

--- a/packages/identity-service/src/audiusLibsInstance.js
+++ b/packages/identity-service/src/audiusLibsInstance.js
@@ -46,9 +46,9 @@ class AudiusLibsWrapper {
 
     const feePayerSecretKeys = config.get('solanaFeePayerWallets')
       ? config
-        .get('solanaFeePayerWallets')
-        .map((item) => item.privateKey)
-        .map((key) => Uint8Array.from(key))
+          .get('solanaFeePayerWallets')
+          .map((item) => item.privateKey)
+          .map((key) => Uint8Array.from(key))
       : null
 
     const solanaWeb3Config = AudiusLibs.configSolanaWeb3({

--- a/packages/identity-service/src/audiusLibsInstance.js
+++ b/packages/identity-service/src/audiusLibsInstance.js
@@ -18,12 +18,27 @@ class AudiusLibsWrapper {
   }
 
   async init() {
-    const dataWeb3 = await AudiusLibs.Utils.configureWeb3(
-      web3ProviderUrl,
-      null,
-      false
-    )
-    if (!dataWeb3) throw new Error('Web3 incorrectly configured')
+    let web3Config = undefined
+    if (config.get('environment') !== 'development') {
+      const dataWeb3 = await AudiusLibs.Utils.configureWeb3(
+        web3ProviderUrl,
+        null,
+        false
+      )
+      if (!dataWeb3) throw new Error('Web3 incorrectly configured')
+
+      web3Config = {
+        registryAddress,
+        useExternalWeb3: true,
+        externalWeb3Config: {
+          web3: dataWeb3,
+          // this is a stopgap since libs external web3 init requires an ownerWallet
+          // this is never actually used in the service's libs calls
+          ownerWallet: config.get('relayerPublicKey')
+        },
+        entityManagerAddress
+      }
+    }
 
     const discoveryProviderWhitelist = config.get('discoveryProviderWhitelist')
       ? new Set(config.get('discoveryProviderWhitelist').split(','))
@@ -31,9 +46,9 @@ class AudiusLibsWrapper {
 
     const feePayerSecretKeys = config.get('solanaFeePayerWallets')
       ? config
-          .get('solanaFeePayerWallets')
-          .map((item) => item.privateKey)
-          .map((key) => Uint8Array.from(key))
+        .get('solanaFeePayerWallets')
+        .map((item) => item.privateKey)
+        .map((key) => Uint8Array.from(key))
       : null
 
     const solanaWeb3Config = AudiusLibs.configSolanaWeb3({
@@ -71,17 +86,7 @@ class AudiusLibsWrapper {
         config.get('ethProviderUrl'),
         config.get('ethOwnerWallet')
       ),
-      web3Config: {
-        registryAddress,
-        useExternalWeb3: true,
-        externalWeb3Config: {
-          web3: dataWeb3,
-          // this is a stopgap since libs external web3 init requires an ownerWallet
-          // this is never actually used in the service's libs calls
-          ownerWallet: config.get('relayerPublicKey')
-        },
-        entityManagerAddress
-      },
+      web3Config,
       isServer: true,
       captchaConfig: { serviceKey: config.get('recaptchaServiceKey') },
       solanaWeb3Config,

--- a/packages/identity-service/src/audiusLibsInstance.js
+++ b/packages/identity-service/src/audiusLibsInstance.js
@@ -18,7 +18,7 @@ class AudiusLibsWrapper {
   }
 
   async init() {
-    let web3Config = undefined
+    let web3Config
     if (config.get('environment') !== 'development') {
       const dataWeb3 = await AudiusLibs.Utils.configureWeb3(
         web3ProviderUrl,


### PR DESCRIPTION
### Description
- removes poa ganache from local dev
- removes test-contracts workflow as it's not used, this contract hasn't changed in years anyway
- modifies the identity startup code to not init web3 (poa) in libs when in dev
- modifies relay to not initialize a web3 connection (poa) in dev, it does keep the acdc network id hardcoded to be able to correctly decode encoded abis. this is unfortunate

### How Has This Been Tested?
run this
`audius-compose down && npm run protocol && audius-cmd test`
