### PR TITLE
Disable endless listen streak challenge, delete rows

### DIFF
--- a/packages/discovery-provider/ddl/migrations/0120_delete_listen_streak_endless_challenges.sql
+++ b/packages/discovery-provider/ddl/migrations/0120_delete_listen_streak_endless_challenges.sql
@@ -1,0 +1,3 @@
+BEGIN;
+delete from user_challenges where challenge_id = 'e';
+COMMIT;

--- a/packages/discovery-provider/src/challenges/challenges.json
+++ b/packages/discovery-provider/src/challenges/challenges.json
@@ -22,7 +22,7 @@
     "id": "e",
     "type": "aggregate",
     "amount": 1,
-    "active": true,
+    "active": false,
     "step_count": 2147483647,
     "starting_block": 116023891,
     "weekly_pool": 25000


### PR DESCRIPTION
### Description
Having these challenges on prod is causing problems, disabling and resetting to clean slate for now.

### How Has This Been Tested?

Confirmed on local stack that 'e' challenge is disabled.