### PR TITLE
Randomize storage node ordering in StorageNodeSelector.

### DIFF
--- a/packages/sdk/src/sdk/api/albums/AlbumsApi.test.ts
+++ b/packages/sdk/src/sdk/api/albums/AlbumsApi.test.ts
@@ -123,7 +123,6 @@ describe('AlbumsApi', () => {
   const logger = new Logger()
   const discoveryNodeSelector = new DiscoveryNodeSelector()
   const storageNodeSelector = new StorageNodeSelector({
-    audiusWalletClient,
     discoveryNodeSelector,
     logger
   })

--- a/packages/sdk/src/sdk/api/playlists/PlaylistsApi.test.ts
+++ b/packages/sdk/src/sdk/api/playlists/PlaylistsApi.test.ts
@@ -112,7 +112,6 @@ describe('PlaylistsApi', () => {
   const logger = new Logger()
   const discoveryNodeSelector = new DiscoveryNodeSelector()
   const storageNodeSelector = new StorageNodeSelector({
-    audiusWalletClient,
     discoveryNodeSelector,
     logger
   })

--- a/packages/sdk/src/sdk/api/tracks/TracksApi.test.ts
+++ b/packages/sdk/src/sdk/api/tracks/TracksApi.test.ts
@@ -96,7 +96,6 @@ describe('TracksApi', () => {
   const logger = new Logger()
   const discoveryNodeSelector = new DiscoveryNodeSelector()
   const storageNodeSelector = new StorageNodeSelector({
-    audiusWalletClient,
     discoveryNodeSelector,
     logger
   })

--- a/packages/sdk/src/sdk/api/users/UsersApi.test.ts
+++ b/packages/sdk/src/sdk/api/users/UsersApi.test.ts
@@ -73,7 +73,6 @@ const audiusWalletClient = createAppWalletClient({ apiKey: '' })
 const logger = new Logger()
 const discoveryNodeSelector = new DiscoveryNodeSelector()
 const storageNodeSelector = new StorageNodeSelector({
-  audiusWalletClient,
   discoveryNodeSelector,
   logger
 })

--- a/packages/sdk/src/sdk/sdk.ts
+++ b/packages/sdk/src/sdk/sdk.ts
@@ -183,7 +183,6 @@ const initializeServices = (config: SdkConfig) => {
     config.services?.storageNodeSelector ??
     new StorageNodeSelector({
       ...getDefaultStorageNodeSelectorConfig(servicesConfig),
-      audiusWalletClient,
       discoveryNodeSelector,
       logger
     })

--- a/packages/sdk/src/sdk/services/StorageNodeSelector/StorageNodeSelector.test.ts
+++ b/packages/sdk/src/sdk/services/StorageNodeSelector/StorageNodeSelector.test.ts
@@ -9,7 +9,6 @@ import {
   afterEach,
   vitest
 } from 'vitest'
-import waitForExpect from 'wait-for-expect'
 
 import { DiscoveryNodeSelector } from '../DiscoveryNodeSelector'
 import type { HealthCheckResponseData } from '../DiscoveryNodeSelector/healthCheckTypes'

--- a/packages/sdk/src/sdk/services/StorageNodeSelector/StorageNodeSelector.test.ts
+++ b/packages/sdk/src/sdk/services/StorageNodeSelector/StorageNodeSelector.test.ts
@@ -93,9 +93,8 @@ describe('StorageNodeSelector', () => {
       logger
     })
 
-    expect(await storageNodeSelector.getSelectedNode()).toEqual(
-      storageNodeA.endpoint
-    )
+    const nodes = storageNodeSelector.getNodes('test')
+    expect(nodes[0]!).toEqual(storageNodeA.endpoint)
   })
 
   it('selects the first healthy node', async () => {
@@ -117,51 +116,6 @@ describe('StorageNodeSelector', () => {
     )
   })
 
-  it('selects correct storage node when discovery node already available', async () => {
-    const discoveryNodeSelector = new DiscoveryNodeSelector({
-      healthCheckThresholds: {
-        minVersion: '1.2.3'
-      },
-      initialSelectedNode: discoveryNode
-    })
-
-    const storageNodeSelector = new StorageNodeSelector({
-      discoveryNodeSelector,
-      logger
-    })
-
-    await waitForExpect(async () => {
-      expect(await storageNodeSelector.getSelectedNode()).toEqual(
-        storageNodeA.endpoint
-      )
-    })
-  })
-
-  it('selects correct storage node when discovery node is selected', async () => {
-    const bootstrapDiscoveryNodes = [discoveryNode].map((endpoint) => ({
-      endpoint,
-      delegateOwnerWallet: '',
-      ownerWallet: ''
-    }))
-    const discoveryNodeSelector = new DiscoveryNodeSelector({
-      healthCheckThresholds: {
-        minVersion: '1.2.3'
-      },
-      bootstrapServices: bootstrapDiscoveryNodes
-    })
-
-    const storageNodeSelector = new StorageNodeSelector({
-      discoveryNodeSelector,
-      logger
-    })
-
-    await waitForExpect(async () => {
-      expect(await storageNodeSelector.getSelectedNode()).toEqual(
-        storageNodeA.endpoint
-      )
-    })
-  })
-
   it('selects correct nodes when provided a cid', async () => {
     const bootstrapNodes = [storageNodeA, storageNodeB]
     const cid = 'QmNnuRwRWxrbWwE9ib9dvWVr4hLgcHGAJ8euys8WH5NgCX'
@@ -176,25 +130,6 @@ describe('StorageNodeSelector', () => {
       storageNodeB.endpoint,
       storageNodeA.endpoint
     ])
-  })
-
-  it('force reselects successfully', async () => {
-    const bootstrapNodes = [storageNodeA, storageNodeB]
-
-    const storageNodeSelector = new StorageNodeSelector({
-      bootstrapNodes,
-      discoveryNodeSelector,
-      logger
-    })
-
-    expect(await storageNodeSelector.getSelectedNode()).toEqual(
-      storageNodeA.endpoint
-    )
-
-    // force reselect
-    expect(await storageNodeSelector.getSelectedNode(true)).toEqual(
-      storageNodeB.endpoint
-    )
   })
 
   it('tries selecting all nodes', async () => {

--- a/packages/sdk/src/sdk/services/StorageNodeSelector/StorageNodeSelector.test.ts
+++ b/packages/sdk/src/sdk/services/StorageNodeSelector/StorageNodeSelector.test.ts
@@ -11,7 +11,6 @@ import {
 } from 'vitest'
 import waitForExpect from 'wait-for-expect'
 
-import { createAppWalletClient } from '../AudiusWalletClient'
 import { DiscoveryNodeSelector } from '../DiscoveryNodeSelector'
 import type { HealthCheckResponseData } from '../DiscoveryNodeSelector/healthCheckTypes'
 import { Logger } from '../Logger'
@@ -27,11 +26,8 @@ const storageNodeB = {
   delegateOwnerWallet: '0xc0ffee254729296a45a3885639AC7E10F9d54972'
 }
 
-const userWallet = '0xc0ffee254729296a45a3885639AC7E10F9d54979'
-
 const discoveryNode = 'https://discovery-provider.audius.co'
 
-const audiusWalletClient = createAppWalletClient({ apiKey: userWallet })
 const logger = new Logger()
 const discoveryNodeSelector = new DiscoveryNodeSelector({
   initialSelectedNode: discoveryNode
@@ -93,7 +89,6 @@ describe('StorageNodeSelector', () => {
 
     const storageNodeSelector = new StorageNodeSelector({
       bootstrapNodes,
-      audiusWalletClient,
       discoveryNodeSelector,
       logger
     })
@@ -113,7 +108,6 @@ describe('StorageNodeSelector', () => {
 
     const storageNodeSelector = new StorageNodeSelector({
       bootstrapNodes,
-      audiusWalletClient,
       discoveryNodeSelector,
       logger
     })
@@ -133,7 +127,6 @@ describe('StorageNodeSelector', () => {
 
     const storageNodeSelector = new StorageNodeSelector({
       discoveryNodeSelector,
-      audiusWalletClient,
       logger
     })
 
@@ -159,7 +152,6 @@ describe('StorageNodeSelector', () => {
 
     const storageNodeSelector = new StorageNodeSelector({
       discoveryNodeSelector,
-      audiusWalletClient,
       logger
     })
 
@@ -176,7 +168,6 @@ describe('StorageNodeSelector', () => {
 
     const storageNodeSelector = new StorageNodeSelector({
       bootstrapNodes,
-      audiusWalletClient,
       discoveryNodeSelector,
       logger
     })
@@ -192,7 +183,6 @@ describe('StorageNodeSelector', () => {
 
     const storageNodeSelector = new StorageNodeSelector({
       bootstrapNodes,
-      audiusWalletClient,
       discoveryNodeSelector,
       logger
     })
@@ -222,7 +212,6 @@ describe('StorageNodeSelector', () => {
 
     const storageNodeSelector = new StorageNodeSelector({
       bootstrapNodes,
-      audiusWalletClient,
       discoveryNodeSelector,
       logger
     })

--- a/packages/sdk/src/sdk/services/StorageNodeSelector/StorageNodeSelector.ts
+++ b/packages/sdk/src/sdk/services/StorageNodeSelector/StorageNodeSelector.ts
@@ -2,7 +2,6 @@ import { productionConfig } from '../../config/production'
 import fetch from '../../utils/fetch'
 import { mergeConfigWithDefaults } from '../../utils/mergeConfigs'
 import { RendezvousHash } from '../../utils/rendezvous'
-import type { AudiusWalletClient } from '../AudiusWalletClient'
 import type { DiscoveryNodeSelectorService } from '../DiscoveryNodeSelector'
 import type { HealthCheckResponseData } from '../DiscoveryNodeSelector/healthCheckTypes'
 import type { LoggerService } from '../Logger'
@@ -20,7 +19,6 @@ const DISCOVERY_RESPONSE_TIMEOUT = 15000
 
 export class StorageNodeSelector implements StorageNodeSelectorService {
   private readonly config: StorageNodeSelectorConfigInternal
-  private readonly audiusWalletClient: AudiusWalletClient
   private readonly logger: LoggerService
   private nodes: StorageNode[]
   private orderedNodes?: string[] // endpoints (lowercase)
@@ -37,7 +35,6 @@ export class StorageNodeSelector implements StorageNodeSelectorService {
       getDefaultStorageNodeSelectorConfig(productionConfig)
     )
     this.discoveryNodeSelector = config.discoveryNodeSelector
-    this.audiusWalletClient = config.audiusWalletClient
 
     this.logger = this.config.logger.createPrefixedLogger(
       '[storage-node-selector]'
@@ -145,9 +142,7 @@ export class StorageNodeSelector implements StorageNodeSelectorService {
 
   private async selectUntilEndOfList(): Promise<string | undefined> {
     if (!this.orderedNodes?.length) {
-      this.orderedNodes = this.orderNodes(
-        (await this.audiusWalletClient.getAddresses())[0]!.toLowerCase()
-      )
+      this.orderedNodes = this.orderNodes(new Date().toString())
     }
 
     if (this.orderedNodes.length === 0) {

--- a/packages/sdk/src/sdk/services/StorageNodeSelector/types.ts
+++ b/packages/sdk/src/sdk/services/StorageNodeSelector/types.ts
@@ -1,4 +1,3 @@
-import type { AudiusWalletClient } from '../AudiusWalletClient'
 import type { DiscoveryNodeSelectorService } from '../DiscoveryNodeSelector'
 import type { LoggerService } from '../Logger'
 
@@ -28,11 +27,6 @@ export type StorageNodeSelectorConfigInternal = {
 
 export type StorageNodeSelectorConfig =
   Partial<StorageNodeSelectorConfigInternal> & {
-    /**
-     * The Authentication service, used to get the user's wallet for rendevous calculations
-     */
-    audiusWalletClient: AudiusWalletClient
-
     /**
      * DiscoveryNodeSelector instance being used, so that the node can listen for
      * selection events and update its healthy storage node list


### PR DESCRIPTION
### Description

Previously a given user would get a static node ordering.  Users with an unfortunate ordering could have higher rate of errors.

This should randomize the order for a given session.  User will get a new ordering boot, so reloading page is enough to re-randomize.
