### PR TITLE
Listen streak challenge fix 2 plays in one day

### DIFF
--- a/packages/discovery-provider/src/challenges/listen_streak_endless_challenge.py
+++ b/packages/discovery-provider/src/challenges/listen_streak_endless_challenge.py
@@ -53,14 +53,32 @@ class ChallengeListenEndlessStreakUpdater(ChallengeUpdater):
         )
         listen_streaks = get_listen_streak_challenges(session, [user_id])
         listen_streak = listen_streaks[0] if listen_streaks else None
+        time_since_last_listen = (
+            created_at - listen_streak.last_listen_date
+            if listen_streak is not None and listen_streak.last_listen_date is not None
+            else None
+        )
 
-        # If existing incomplete listen streak (< 7 days) is not broken, use the existing challenge metadata
+        # This is a bit tricky:
+        # - Don't create a new user_challenge row if there is an existing incomplete 7-day listen
+        #   streak row that's within the last 2 days, because we want to update that row instead.
+        # - If the user has already completed the 7-day challenge, and the next user_challenge row
+        #   is going to be a 1-amount row, we should create that row only if the new play event is
+        #   outside the 1-day window since the last listen date. See the comment above _handle_track_listens
+        #   for more details.
         if (
             most_recent_challenge is not None
-            and not most_recent_challenge.is_complete
-            and listen_streak is not None
-            and listen_streak.last_listen_date is not None
-            and created_at - listen_streak.last_listen_date <= base_timedelta * 2
+            and time_since_last_listen is not None
+            and (
+                (
+                    most_recent_challenge.is_complete
+                    and time_since_last_listen <= base_timedelta
+                )
+                or (
+                    not most_recent_challenge.is_complete
+                    and time_since_last_listen <= base_timedelta * 2
+                )
+            )
         ):
             return most_recent_challenge
         return None
@@ -114,7 +132,7 @@ class ChallengeListenEndlessStreakUpdater(ChallengeUpdater):
                 user_challenge.amount = 1
                 user_challenge.current_step_count = 1
                 user_challenge.is_complete = True
-            # For first normal listen streak challenge - amount/step_count get updated as streak progresses
+            # For first 7-day listen streak challenge - amount/step_count get updated as streak progresses
             else:
                 user_challenge.amount = NUM_DAYS_IN_STREAK
                 user_challenge.current_step_count = (
@@ -153,7 +171,9 @@ class ChallengeListenEndlessStreakUpdater(ChallengeUpdater):
         if new_listen_streak_challenges:
             session.add_all(new_listen_streak_challenges)
 
-    # Helpers
+    # Note that the ChallengeListenStreak table doesn't necessarily contain the user's most recent
+    # listen date. It only updates the last listen date if the new play event is more than 24 hours
+    # since the last listen date.
     def _handle_track_listens(
         self,
         partial_completions: List[ChallengeListenStreak],
@@ -169,7 +189,7 @@ class ChallengeListenEndlessStreakUpdater(ChallengeUpdater):
             if last_date is None:
                 partial_completion.last_listen_date = new_date
                 partial_completion.listen_streak = 1
-            # If last timestamp is more than 24 hours ago, update streak
+            # If last timestamp is more than 24 hours ago, update streak.
             elif new_date - last_date >= base_timedelta:
                 partial_completion.last_listen_date = new_date
                 # Check if the user lost their streak


### PR DESCRIPTION
### Description
Tricky bug: if user logs 2 listens in the same day and that day happened to be the day they completed the first 7-day challenge, they would get to create a second 7-day row "for free." We needed a bit more precise conditional on when to create a new user_challenge.

### How Has This Been Tested?

DN tests pass, will add another test case for this bug