### PR TITLE
[PAY-3946] Fix multiple plays in same batch breaking listen streak

### DIFF
--- a/packages/discovery-provider/ddl/migrations/0120_delete_listen_streak_endless_challenges.sql
+++ b/packages/discovery-provider/ddl/migrations/0120_delete_listen_streak_endless_challenges.sql
@@ -1,3 +1,4 @@
 BEGIN;
+-- Adding this comment to trigger this again
 delete from user_challenges where challenge_id = 'e';
 COMMIT;

--- a/packages/discovery-provider/src/challenges/listen_streak_endless_challenge.py
+++ b/packages/discovery-provider/src/challenges/listen_streak_endless_challenge.py
@@ -92,7 +92,7 @@ class ChallengeListenEndlessStreakUpdater(ChallengeUpdater):
         created_at = datetime.fromtimestamp(extra["created_at"])
         formatted_date = created_at.strftime("%Y%m%d")
         if env == "stage":
-            formatted_date = created_at.strftime("%Y%m%d%H%M%S")
+            formatted_date = created_at.strftime("%Y%m%d%H%M")
         return f"{hex(user_id)[2:]}_{formatted_date}"
 
     def should_create_new_challenge(


### PR DESCRIPTION
### Description
Insidious bug
Context: We changed the timescale on stage for this challenge to be 1-minute on stage = 1-day on prod. The bug comes from the fact that I'd edited the specifier to be too granular on stage. Didn't need to includes seconds, only minutes, so that multiple plays within the same minute would get deduped to the same specifier.
_after_ the first 7-day challenge completes, if the user spams plays so that many play events get processed in the same batch, the bug symptom was that multiple `user_challenge` rows would get created even though we only want 1 per minute.

Funnily enough this would not have been a bug on prod.

Another suggestion from @isaacsolo is to run the integration tests on the stage environment.

Also re-triggering the "clear all state" migration - safe to do this on prod as challenge is not launched yet.

### How Has This Been Tested?

Tested with black magic on stage DN 4