### PR TITLE
[PAY-3953] Use db value for public key

### DIFF
--- a/packages/discovery-provider/src/api/v1/models/users.py
+++ b/packages/discovery-provider/src/api/v1/models/users.py
@@ -296,6 +296,10 @@ sale_json_model = ns.model(
             description="Whether this is an initial encryption from the backfill",
             allow_null=True,
         ),
+        "pubkey_base64": fields.String(
+            description="Base64 encoded public key of the buyer",
+            allow_null=True,
+        ),
     },
 )
 

--- a/packages/discovery-provider/src/models/users/user_pubkey.py
+++ b/packages/discovery-provider/src/models/users/user_pubkey.py
@@ -1,0 +1,16 @@
+from sqlalchemy import Column, Integer, Text
+
+from src.models.base import Base
+from src.models.model_utils import RepresentableMixin
+
+
+class UserPubkey(Base, RepresentableMixin):
+    """Model class for the user_pubkeys table.
+
+    Table storing public keys for users.
+    """
+
+    __tablename__ = "user_pubkeys"
+
+    user_id = Column(Integer, primary_key=True, nullable=False)
+    pubkey_base64 = Column(Text, nullable=False)

--- a/packages/discovery-provider/src/queries/download_csv.py
+++ b/packages/discovery-provider/src/queries/download_csv.py
@@ -15,6 +15,7 @@ from src.models.users.usdc_transactions_history import (
 )
 from src.models.users.user import User
 from src.models.users.user_bank import USDCUserBankAccount
+from src.models.users.user_pubkey import UserPubkey
 from src.solana.constants import USDC_DECIMALS
 from src.utils.config import shared_config
 from src.utils.csv_writer import write_csv_string
@@ -93,6 +94,7 @@ def get_purchases_or_sales(
                     EncryptedEmail.encrypted_email.label("encrypted_email"),
                     EmailAccess.encrypted_key.label("encrypted_key"),
                     EmailAccess.is_initial.label("is_initial"),
+                    UserPubkey.pubkey_base64.label("pubkey_base64"),
                 )
                 .join(User, User.user_id == USDCPurchase.buyer_user_id)
                 .outerjoin(
@@ -102,6 +104,10 @@ def get_purchases_or_sales(
                 .outerjoin(
                     EmailAccess,
                     email_access_condition,
+                )
+                .outerjoin(
+                    UserPubkey,
+                    UserPubkey.user_id == USDCPurchase.buyer_user_id,
                 )
                 .filter(USDCPurchase.seller_user_id == user_id)
                 .filter(User.is_current == True)
@@ -266,6 +272,9 @@ def format_sale_for_download(
         )
         fields_with_underscores["is_initial"] = (
             result.is_initial if hasattr(result, "is_initial") else None
+        )
+        fields_with_underscores["pubkey_base64"] = (
+            result.pubkey_base64 if hasattr(result, "pubkey_base64") else None
         )
         return fields_with_underscores
 

--- a/packages/sdk/src/sdk/api/generated/default/models/SaleJson.ts
+++ b/packages/sdk/src/sdk/api/generated/default/models/SaleJson.ts
@@ -98,6 +98,12 @@ export interface SaleJson {
      * @memberof SaleJson
      */
     isInitial?: boolean;
+    /**
+     * Base64 encoded public key of the buyer
+     * @type {string}
+     * @memberof SaleJson
+     */
+    pubkeyBase64?: string;
 }
 
 /**
@@ -132,6 +138,7 @@ export function SaleJsonFromJSONTyped(json: any, ignoreDiscriminator: boolean): 
         'encryptedEmail': !exists(json, 'encrypted_email') ? undefined : json['encrypted_email'],
         'encryptedKey': !exists(json, 'encrypted_key') ? undefined : json['encrypted_key'],
         'isInitial': !exists(json, 'is_initial') ? undefined : json['is_initial'],
+        'pubkeyBase64': !exists(json, 'pubkey_base64') ? undefined : json['pubkey_base64'],
     };
 }
 
@@ -157,6 +164,7 @@ export function SaleJsonToJSON(value?: SaleJson | null): any {
         'encrypted_email': value.encryptedEmail,
         'encrypted_key': value.encryptedKey,
         'is_initial': value.isInitial,
+        'pubkey_base64': value.pubkeyBase64,
     };
 }
 

--- a/packages/sdk/src/sdk/services/Encryption/index.ts
+++ b/packages/sdk/src/sdk/services/Encryption/index.ts
@@ -2,7 +2,5 @@ export { EmailEncryptionService } from './EmailEncryptionService'
 export type {
   EncryptedKey,
   SharedSymmetricKey,
-  EncryptedEmailsResult,
-  BatchEncryptionInput,
-  BatchEncryptionResult
+  EncryptedEmailsResult
 } from './types'

--- a/packages/sdk/src/sdk/services/Encryption/types.ts
+++ b/packages/sdk/src/sdk/services/Encryption/types.ts
@@ -13,16 +13,3 @@ export type EncryptedEmailsResult = {
   encryptedEmails: string[]
   receiverEncryptedKeys: EncryptedKey[]
 }
-
-export type BatchEncryptionInput = {
-  email_owner_id: number
-  receiving_ids: number[] | null
-  grantor_id: number
-  emails: string[]
-}
-
-export type BatchEncryptionResult = {
-  email_owner_id: number
-  encryptedEmails: string[]
-  receiverEncryptedKeys: EncryptedKey[]
-}


### PR DESCRIPTION
### Description

This PR significantly improves the performance of sales CSV downloads by addressing bottlenecks in email decryption and data processing. Key optimizations include:

**Database & Backend Changes**
- Added `pubkey_base64` field to sales CSV exports via new `user_pubkeys` table join
- Eliminated N+1 query pattern for public key lookups by including keys in initial query

**Encryption Service Improvements**
- Implemented LRU caching for symmetric keys and shared secrets (max 1000 entries)
- Added dual decryption paths:
  - Direct decryption using pre-fetched public keys from sales data
  - Fallback to API-based key retrieval with caching
- Removed batch encryption endpoints since they were only used for backfill
- Added concurrent batch processing with automatic cache pruning

**Frontend Optimizations**
- Implemented batched decryption with:
  - Batch size of 10 records
  - 3 concurrent batches processing
  - Sequential processing with memory management
- Leveraged cached cryptographic operations to reduce compute overhead
- Added error handling per batch to prevent full pipeline failures

**Performance Characteristics**
- Reduces redundant network calls through caching and pre-fetched keys
- Lowers memory pressure via batched processing
- Increases throughput with concurrent decryption operations

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._
