### PR TITLE
Enable listen streak endless challenge, delete prior notifs

### DIFF
--- a/packages/discovery-provider/ddl/migrations/0121_delete_listen_streak_endless_notifications.sql
+++ b/packages/discovery-provider/ddl/migrations/0121_delete_listen_streak_endless_notifications.sql
@@ -1,0 +1,5 @@
+begin;
+
+delete from notification where group_id like '%challenge:e%';
+
+commit;

--- a/packages/discovery-provider/src/challenges/challenges.json
+++ b/packages/discovery-provider/src/challenges/challenges.json
@@ -13,7 +13,7 @@
     "id": "l",
     "type": "numeric",
     "amount": 1,
-    "active": true,
+    "active": false,
     "step_count": 7,
     "starting_block": 116023891,
     "weekly_pool": 25000
@@ -22,7 +22,7 @@
     "id": "e",
     "type": "aggregate",
     "amount": 1,
-    "active": false,
+    "active": true,
     "step_count": 2147483647,
     "starting_block": 116023891,
     "weekly_pool": 25000


### PR DESCRIPTION
### Description
Release commit for listen streak endless challenge.
Also delete all prior notifs for this challenge.

### How Has This Been Tested?

Tested sql on prod DN 4 - works