### PR TITLE
Fix edit playlist nav link when unfetched

### DIFF
--- a/packages/web/src/components/nav/desktop/PlaylistLibrary/CollectionNavItem.tsx
+++ b/packages/web/src/components/nav/desktop/PlaylistLibrary/CollectionNavItem.tsx
@@ -100,7 +100,13 @@ export const CollectionNavItem = (props: CollectionNavItemProps) => {
     getCollection(state, { id: typeof id === 'string' ? null : id })
   )
 
-  const { permalink } = collection ?? {}
+  const accountCollection = useSelector((state) =>
+    typeof id === 'number' && state.account.collections[id]
+      ? state.account.collections[id]
+      : null
+  )
+
+  const { permalink } = collection ?? accountCollection ?? {}
 
   const [isDeleteConfirmationOpen, toggleDeleteConfirmationOpen] =
     useToggle(false)


### PR DESCRIPTION
### Description

The `Edit Playlist` action in the navbar dropdown wasn't working in cases where the playlist hadn't been fetched and loaded into the `store.collections` cache slice. The link would navigate to `/undefined/edit`. We do, however, have the permalink available in the account collections which is the source of truth for the playlist library.

This change ensures we check both the collection cache and the account collections in order to construct the edit url.

### How Has This Been Tested?

Click edit playlist in nave without hitting the playlist page first. Went to `/undefined/edit` before, fixed with this change.