### PR TITLE
Flush listen streak updates before adding user challenge

### DIFF
--- a/packages/discovery-provider/src/challenges/challenge.py
+++ b/packages/discovery-provider/src/challenges/challenge.py
@@ -309,6 +309,9 @@ class ChallengeManager:
             logger.debug(
                 f"ChallengeManager: Updated challenges from event [{event_type}]: [{to_update}]"
             )
+            # Flush before bulk adding so trigger has updated data
+            session.flush()
+
             # Only add the new ones
             session.add_all(new_user_challenges)
 


### PR DESCRIPTION
### Description
ChallengeListenStreak gets updated and those updates need to be flushed so the UserChallenge trigger has the most up to date info. Otherwise, there's a potential race condition.

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._

