### PR TITLE
Fix create playlists for users with capcase handle

### DIFF
--- a/packages/web/src/hooks/useManagedAccountNotAllowedRedirect.ts
+++ b/packages/web/src/hooks/useManagedAccountNotAllowedRedirect.ts
@@ -87,7 +87,7 @@ export const useIsUnauthorizedForHandleRedirect = (
     !accountUserId ||
     accountsStatus === Status.LOADING ||
     accountsStatus === Status.IDLE
-  const isOwner = accountHandle === handle
+  const isOwner = accountHandle?.toLowerCase() === handle.toLowerCase()
   const isManaged =
     !!accountHandle &&
     managedAccounts.find(({ user }) => user.handle.toLowerCase() === handle)


### PR DESCRIPTION
### Description

Fixes issue where users with capital letters in their handle are unable to create/edit playlists. The core issue is that user's lowercase handle is added to the /edit route, but this is a hotfix for now to compare lowercase handles