### PR TITLE
Update collectibles hook to return null instead of empty objects

### DIFF
--- a/packages/common/src/api/tan-query/useUserCollectibles.ts
+++ b/packages/common/src/api/tan-query/useUserCollectibles.ts
@@ -31,10 +31,7 @@ export const useUserCollectibles = (
       const { data } = await sdk.users.getUserCollectibles({
         id: Id.parse(userId)
       })
-      return (data?.data ?? {
-        order: [],
-        collectibles: []
-      }) as CollectiblesMetadata
+      return (data?.data as CollectiblesMetadata) ?? null
     },
     ...options,
     enabled: options?.enabled !== false && !!args.userId


### PR DESCRIPTION
### Description
This is a follow up to #11392.

There is component code that tests existence of a value for collectibles to indicate that it has been set by the user before. So we need to return `null` if no data comes back from the API instead of an empty object.

### How Has This Been Tested?
Tested original bug flow from the previous PR and verified we don't get a crash when finishing uploads.
