### PR TITLE
Fix listen streak reminder notif timing

### DIFF
--- a/packages/discovery-provider/integration_tests/tasks/test_create_listen_streak_reminder_notifications.py
+++ b/packages/discovery-provider/integration_tests/tasks/test_create_listen_streak_reminder_notifications.py
@@ -14,7 +14,7 @@ logger = logging.getLogger(__name__)
 
 TEST_USER_ID = 1
 TEST_STREAK = 3
-TEST_DATE = (datetime.now() - timedelta(hours=18, minutes=30)).date()
+TEST_DATE = (datetime.now() - timedelta(hours=42, minutes=30)).date()
 TEST_GROUP_ID = get_listen_streak_notification_group_id(TEST_USER_ID, TEST_DATE)
 
 
@@ -24,8 +24,8 @@ def test_create_listen_streak_reminder_notification(app):
         db = get_db()
 
     now = datetime.now()
-    # Place listen time clearly within the window (between 18-19 hours ago)
-    listen_time = now - timedelta(hours=18, minutes=30)
+    # Place listen time clearly within the window (between 42-43 hours ago)
+    listen_time = now - timedelta(hours=42, minutes=30)
 
     entities = {
         "challenge_listen_streaks": [
@@ -57,8 +57,8 @@ def test_ignore_outside_time_window(app):
         db = get_db()
 
     now = datetime.now()
-    too_recent = now - timedelta(hours=17)  # Too recent (< 18 hours ago)
-    too_old = now - timedelta(hours=20)  # Too old (> 19 hours ago)
+    too_recent = now - timedelta(hours=41)  # Too recent (< 42 hours ago)
+    too_old = now - timedelta(hours=44)  # Too old (> 43 hours ago)
 
     entities = {
         "challenge_listen_streaks": [
@@ -88,7 +88,7 @@ def test_ignore_existing_notification(app):
         db = get_db()
 
     now = datetime.now()
-    listen_time = now - timedelta(hours=18, minutes=30)
+    listen_time = now - timedelta(hours=42, minutes=30)
 
     entities = {
         "challenge_listen_streaks": [
@@ -123,7 +123,7 @@ def test_multiple_streaks(app):
         db = get_db()
 
     now = datetime.now()
-    listen_time = now - timedelta(hours=18, minutes=30)
+    listen_time = now - timedelta(hours=42, minutes=30)
 
     entities = {
         "challenge_listen_streaks": [

--- a/packages/discovery-provider/integration_tests/tasks/test_create_listen_streak_reminder_notifications.py
+++ b/packages/discovery-provider/integration_tests/tasks/test_create_listen_streak_reminder_notifications.py
@@ -4,6 +4,7 @@ from datetime import datetime, timedelta
 from integration_tests.utils import populate_mock_db
 from src.models.notifications.notification import Notification
 from src.tasks.create_listen_streak_reminder_notifications import (
+    LISTEN_STREAK_BUFFER,
     LISTEN_STREAK_REMINDER,
     _create_listen_streak_reminder_notifications,
     get_listen_streak_notification_group_id,
@@ -14,7 +15,7 @@ logger = logging.getLogger(__name__)
 
 TEST_USER_ID = 1
 TEST_STREAK = 3
-TEST_DATE = (datetime.now() - timedelta(hours=42, minutes=30)).date()
+TEST_DATE = (datetime.now() - timedelta(hours=LISTEN_STREAK_BUFFER, minutes=30)).date()
 TEST_GROUP_ID = get_listen_streak_notification_group_id(TEST_USER_ID, TEST_DATE)
 
 
@@ -25,7 +26,7 @@ def test_create_listen_streak_reminder_notification(app):
 
     now = datetime.now()
     # Place listen time clearly within the window (between 42-43 hours ago)
-    listen_time = now - timedelta(hours=42, minutes=30)
+    listen_time = now - timedelta(hours=LISTEN_STREAK_BUFFER, minutes=30)
 
     entities = {
         "challenge_listen_streaks": [
@@ -57,8 +58,12 @@ def test_ignore_outside_time_window(app):
         db = get_db()
 
     now = datetime.now()
-    too_recent = now - timedelta(hours=41)  # Too recent (< 42 hours ago)
-    too_old = now - timedelta(hours=44)  # Too old (> 43 hours ago)
+    too_recent = now - timedelta(
+        hours=LISTEN_STREAK_BUFFER - 1
+    )  # Too recent (< 42 hours ago)
+    too_old = now - timedelta(
+        hours=LISTEN_STREAK_BUFFER + 2
+    )  # Too old (> 43 hours ago)
 
     entities = {
         "challenge_listen_streaks": [
@@ -88,7 +93,7 @@ def test_ignore_existing_notification(app):
         db = get_db()
 
     now = datetime.now()
-    listen_time = now - timedelta(hours=42, minutes=30)
+    listen_time = now - timedelta(hours=LISTEN_STREAK_BUFFER, minutes=30)
 
     entities = {
         "challenge_listen_streaks": [
@@ -123,7 +128,7 @@ def test_multiple_streaks(app):
         db = get_db()
 
     now = datetime.now()
-    listen_time = now - timedelta(hours=42, minutes=30)
+    listen_time = now - timedelta(hours=LISTEN_STREAK_BUFFER, minutes=30)
 
     entities = {
         "challenge_listen_streaks": [

--- a/packages/discovery-provider/src/tasks/create_listen_streak_reminder_notifications.py
+++ b/packages/discovery-provider/src/tasks/create_listen_streak_reminder_notifications.py
@@ -12,9 +12,8 @@ logger = StructuredLogger(__name__)
 env = shared_config["discprov"]["env"]
 
 LISTEN_STREAK_REMINDER = "listen_streak_reminder"
-HOURS_PER_DAY = 24
-LISTEN_STREAK_BUFFER = 6
-LAST_LISTEN_HOURS_AGO = (HOURS_PER_DAY * 2) - LISTEN_STREAK_BUFFER
+# 2 days - 6 hours
+LISTEN_STREAK_BUFFER = 42
 
 
 def get_listen_streak_notification_group_id(user_id, date):
@@ -24,8 +23,8 @@ def get_listen_streak_notification_group_id(user_id, date):
 @log_duration(logger)
 def _create_listen_streak_reminder_notifications(session):
     now = datetime.now()
-    window_end = now - timedelta(hours=LAST_LISTEN_HOURS_AGO)
-    window_start = now - timedelta(hours=LAST_LISTEN_HOURS_AGO + 1)
+    window_end = now - timedelta(hours=LISTEN_STREAK_BUFFER)
+    window_start = now - timedelta(hours=LISTEN_STREAK_BUFFER + 1)
     if env == "stage":
         window_end = now - timedelta(minutes=1)
         window_start = now - timedelta(minutes=2)

--- a/packages/discovery-provider/src/tasks/create_listen_streak_reminder_notifications.py
+++ b/packages/discovery-provider/src/tasks/create_listen_streak_reminder_notifications.py
@@ -14,7 +14,7 @@ env = shared_config["discprov"]["env"]
 LISTEN_STREAK_REMINDER = "listen_streak_reminder"
 HOURS_PER_DAY = 24
 LISTEN_STREAK_BUFFER = 6
-LAST_LISTEN_HOURS_AGO = HOURS_PER_DAY - LISTEN_STREAK_BUFFER
+LAST_LISTEN_HOURS_AGO = (HOURS_PER_DAY * 2) - LISTEN_STREAK_BUFFER
 
 
 def get_listen_streak_notification_group_id(user_id, date):


### PR DESCRIPTION
### Description
We actually want to send out the notif between between the 1st and 2nd day after the last listen, not within the first 24 hours of the last listen. Ie. it should be sent after 24 hours * 2 days - 6 hours = 42 hours have passed, not 24-6=18 hours.

### How Has This Been Tested?

Tests pass