### PR TITLE
Fix reward panel ordering

### DIFF
--- a/packages/common/src/utils/challenges.ts
+++ b/packages/common/src/utils/challenges.ts
@@ -342,9 +342,17 @@ export const makeOptimisticChallengeSortComparator = (
     }
     if (
       userChallenge1?.challenge_id &&
-      isNewChallenge(userChallenge1?.challenge_id)
+      isNewChallenge(userChallenge1?.challenge_id) &&
+      userChallenge1?.state !== 'disbursed'
     ) {
       return -1
+    }
+    if (
+      userChallenge2?.challenge_id &&
+      isNewChallenge(userChallenge2?.challenge_id) &&
+      userChallenge2?.state !== 'disbursed'
+    ) {
+      return 1
     }
     if (userChallenge1?.state === 'disbursed') {
       return 1


### PR DESCRIPTION
### Description
Noticed reward panel ordering was off on mobile, needed another case for id2 being a new challenge.

### How Has This Been Tested?

![Simulator Screenshot - iPhone 16 Pro - 2025-02-19 at 15 57 55](https://github.com/user-attachments/assets/c2bf66c2-d958-4828-ab91-536980a0ea81)
