### PR TITLE
Mobile reward notif navs to RewardsScreen, open drawer

### DIFF
--- a/packages/mobile/src/hooks/useNotificationNavigation.ts
+++ b/packages/mobile/src/hooks/useNotificationNavigation.ts
@@ -238,7 +238,7 @@ export const useNotificationNavigation = () => {
       [NotificationType.ChallengeReward]: (
         notification: ChallengeRewardNotification
       ) => {
-        navigation.navigate('AudioScreen')
+        navigation.navigate('RewardsScreen')
       },
       [PushNotificationType.FavoriteAlbum]: socialActionHandler,
       [PushNotificationType.FavoritePlaylist]: socialActionHandler,

--- a/packages/mobile/src/screens/notifications-screen/Notifications/ClaimableRewardNotification.tsx
+++ b/packages/mobile/src/screens/notifications-screen/Notifications/ClaimableRewardNotification.tsx
@@ -29,7 +29,7 @@ export const ClaimableRewardNotification = (
   const navigation = useNavigation()
 
   const handlePress = useCallback(() => {
-    navigation.navigate('AudioScreen')
+    navigation.navigate('RewardsScreen')
   }, [navigation])
 
   return (

--- a/packages/mobile/src/screens/notifications-screen/Notifications/ListenStreakReminderNotification.tsx
+++ b/packages/mobile/src/screens/notifications-screen/Notifications/ListenStreakReminderNotification.tsx
@@ -1,10 +1,11 @@
 import { useCallback } from 'react'
 
 import { listenStreakReminderMessages as messages } from '@audius/common/messages'
+import { ChallengeName } from '@audius/common/models'
 import type { ListenStreakReminderNotification as ListenStreakReminderNotificationType } from '@audius/common/store'
+import { audioRewardsPageActions, modalsActions } from '@audius/common/store'
 import { Text } from 'react-native'
-
-import { useNavigation } from 'app/hooks/useNavigation'
+import { useDispatch } from 'react-redux'
 
 import {
   NotificationTile,
@@ -12,6 +13,9 @@ import {
   NotificationText,
   NotificationTitle
 } from '../Notification'
+
+const { setChallengeRewardsModalType } = audioRewardsPageActions
+const { setVisibility } = modalsActions
 
 export const IconStreakFire = () => {
   return <Text style={{ fontSize: 32 }}>🔥</Text>
@@ -25,11 +29,18 @@ export const ListenStreakReminderNotification = (
   props: ListenStreakReminderNotificationProps
 ) => {
   const { notification } = props
-  const navigation = useNavigation()
+  const dispatch = useDispatch()
 
   const handlePress = useCallback(() => {
-    navigation.navigate('AudioScreen')
-  }, [navigation])
+    dispatch(
+      setChallengeRewardsModalType({
+        modalType: ChallengeName.ListenStreakEndless
+      })
+    )
+    dispatch(
+      setVisibility({ modal: 'ChallengeRewardsExplainer', visible: true })
+    )
+  }, [dispatch])
 
   return (
     <NotificationTile notification={notification} onPress={handlePress}>


### PR DESCRIPTION
### Description
- Since we split out RewardsScreen vs AudioScreen, some notifs were still navigating to AudioScreen.
- Make listen streak reminder notif open drawer immediately

### How Has This Been Tested?


https://github.com/user-attachments/assets/0e8ba10a-ec92-4044-9f12-51140ccca2bc

