### PR TITLE
Misc fixes for mobile audio, usdc screens

### DIFF
--- a/packages/mobile/src/screens/audio-screen/AudioScreen.tsx
+++ b/packages/mobile/src/screens/audio-screen/AudioScreen.tsx
@@ -7,9 +7,15 @@ import {
   walletActions,
   modalsActions
 } from '@audius/common/store'
-import { isNullOrUndefined, formatWei } from '@audius/common/utils'
+import {
+  isNullOrUndefined,
+  formatWeiToAudioString,
+  formatCurrencyBalance
+} from '@audius/common/utils'
 import { css } from '@emotion/native'
 import { useFocusEffect } from '@react-navigation/native'
+import BN from 'bn.js'
+import numeral from 'numeral'
 import { Image, Linking } from 'react-native'
 import { TouchableOpacity } from 'react-native-gesture-handler'
 import LinearGradient from 'react-native-linear-gradient'
@@ -174,7 +180,9 @@ export const AudioScreen = () => {
                   paddingVertical: 8
                 })}
               >
-                {formatWei(totalBalance, true, 0)}
+                {formatCurrencyBalance(
+                  parseInt(formatWeiToAudioString(totalBalance))
+                )}
               </Text>
             )}
           </Flex>

--- a/packages/mobile/src/screens/audio-screen/AudioScreen.tsx
+++ b/packages/mobile/src/screens/audio-screen/AudioScreen.tsx
@@ -7,15 +7,10 @@ import {
   walletActions,
   modalsActions
 } from '@audius/common/store'
-import {
-  isNullOrUndefined,
-  formatWeiToAudioString,
-  formatCurrencyBalance
-} from '@audius/common/utils'
+import { isNullOrUndefined } from '@audius/common/utils'
+import { AUDIO } from '@audius/fixed-decimal'
 import { css } from '@emotion/native'
 import { useFocusEffect } from '@react-navigation/native'
-import BN from 'bn.js'
-import numeral from 'numeral'
 import { Image, Linking } from 'react-native'
 import { TouchableOpacity } from 'react-native-gesture-handler'
 import LinearGradient from 'react-native-linear-gradient'
@@ -180,9 +175,7 @@ export const AudioScreen = () => {
                   paddingVertical: 8
                 })}
               >
-                {formatCurrencyBalance(
-                  parseInt(formatWeiToAudioString(totalBalance))
-                )}
+                {AUDIO(totalBalance).toShorthand()}
               </Text>
             )}
           </Flex>

--- a/packages/mobile/src/screens/pay-and-earn-screen/USDCCard.tsx
+++ b/packages/mobile/src/screens/pay-and-earn-screen/USDCCard.tsx
@@ -48,7 +48,7 @@ const useStyles = makeStyles(({ spacing }) => ({
 export const USDCCard = () => {
   const styles = useStyles()
   const { data: balance } = useUSDCBalance()
-  const usdcBalanceFormatted = USDC(balance ?? new BN(0)).toLocaleString()
+  const usdcBalanceFormatted = USDC(balance ?? 0).toLocaleString()
 
   const { onPress: onLearnMorePress } = useLink(LEARN_MORE_LINK)
 

--- a/packages/mobile/src/screens/pay-and-earn-screen/USDCCard.tsx
+++ b/packages/mobile/src/screens/pay-and-earn-screen/USDCCard.tsx
@@ -84,17 +84,22 @@ export const USDCCard = () => {
               variant='heading'
               size='s'
               strength='strong'
-              color='inverse'
+              color='staticWhite'
               style={css({ opacity: 0.8 })}
             >
               {messages.usdc}
             </Text>
           </Flex>
-          <Text variant='display' size='s' strength='strong' color='inverse'>
+          <Text
+            variant='display'
+            size='s'
+            strength='strong'
+            color='staticWhite'
+          >
             ${usdcBalanceFormatted}
           </Text>
         </Flex>
-        <Text variant='body' color='inverse'>
+        <Text variant='body' color='staticWhite'>
           {messages.buyAndSell}
         </Text>
         <PlainButton

--- a/packages/mobile/src/screens/pay-and-earn-screen/USDCCard.tsx
+++ b/packages/mobile/src/screens/pay-and-earn-screen/USDCCard.tsx
@@ -1,12 +1,8 @@
 import { useCallback } from 'react'
 
 import { useUSDCBalance } from '@audius/common/hooks'
-import type { BNUSDC } from '@audius/common/models'
 import { useAddFundsModal } from '@audius/common/store'
-import {
-  formatCurrencyBalance,
-  formatUSDCWeiToFloorCentsNumber
-} from '@audius/common/utils'
+import { USDC } from '@audius/fixed-decimal'
 import { css } from '@emotion/native'
 import BN from 'bn.js'
 import LinearGradient from 'react-native-linear-gradient'
@@ -52,10 +48,7 @@ const useStyles = makeStyles(({ spacing }) => ({
 export const USDCCard = () => {
   const styles = useStyles()
   const { data: balance } = useUSDCBalance()
-  const balanceCents = formatUSDCWeiToFloorCentsNumber(
-    (balance ?? new BN(0)) as BNUSDC
-  )
-  const usdcBalanceFormatted = formatCurrencyBalance(balanceCents / 100)
+  const usdcBalanceFormatted = USDC(balance ?? new BN(0)).toLocaleString()
 
   const { onPress: onLearnMorePress } = useLink(LEARN_MORE_LINK)
 

--- a/packages/mobile/src/screens/pay-and-earn-screen/USDCCard.tsx
+++ b/packages/mobile/src/screens/pay-and-earn-screen/USDCCard.tsx
@@ -4,7 +4,6 @@ import { useUSDCBalance } from '@audius/common/hooks'
 import { useAddFundsModal } from '@audius/common/store'
 import { USDC } from '@audius/fixed-decimal'
 import { css } from '@emotion/native'
-import BN from 'bn.js'
 import LinearGradient from 'react-native-linear-gradient'
 
 import {


### PR DESCRIPTION
### Description
- format audio balance so 200,000 $AUDIO -> 200k $AUDIO
- Always use staticWhite for USDCCard

### How Has This Been Tested?

![Simulator Screenshot - iPhone 16 Pro - 2025-02-19 at 17 21 00](https://github.com/user-attachments/assets/f647a71b-67da-488e-9ff4-2c5161e5bc46)
![Simulator Screenshot - iPhone 16 Pro - 2025-02-19 at 17 20 49](https://github.com/user-attachments/assets/fa50c651-0b96-4303-8817-8ee4e753cd43)
![Simulator Screenshot - iPhone 16 Pro - 2025-02-19 at 16 56 39](https://github.com/user-attachments/assets/4a16821e-f9a8-4e76-9200-7242bfeaaed5)
![Simulator Screenshot - iPhone 16 Pro - 2025-02-19 at 16 56 13](https://github.com/user-attachments/assets/7ea51884-8216-40db-baec-475e91b877f9)
![Simulator Screenshot - iPhone 16 Pro - 2025-02-19 at 16 56 08](https://github.com/user-attachments/assets/f0aeebaf-9bd0-4a14-9b8e-9691adeb9cd1)
