### PR TITLE
Deprecate wallet.ts and formatUtils.ts functions in favor of FixedDecimal

### DIFF
--- a/packages/common/src/utils/formatUtil.ts
+++ b/packages/common/src/utils/formatUtil.ts
@@ -1,8 +1,9 @@
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+import type { FixedDecimal } from '@audius/fixed-decimal'
 import BN from 'bn.js'
 import numeral from 'numeral'
 
 import { BNWei } from '~/models/Wallet'
-import type { FixedDecimal } from '@audius/fixed-decimal'
 
 import dayjs from './dayjs'
 

--- a/packages/common/src/utils/formatUtil.ts
+++ b/packages/common/src/utils/formatUtil.ts
@@ -2,6 +2,7 @@ import BN from 'bn.js'
 import numeral from 'numeral'
 
 import { BNWei } from '~/models/Wallet'
+import type { FixedDecimal } from '@audius/fixed-decimal'
 
 import dayjs from './dayjs'
 
@@ -36,6 +37,8 @@ export const formatCount = (count: number) => {
 }
 
 /**
+ * @deprecated Use the relevant currency shorthand, eg. `AUDIO(amount).toShorthand()` from {@link FixedDecimal} instead
+ *
  * The format any currency should be:
  * - show 0 if 0
  * - don't show decimal places if input is a round number
@@ -142,6 +145,8 @@ export const pluralize = (
 ) => `${message}${(count ?? 0) !== 1 || pluralizeAnyway ? suffix : ''}`
 
 /**
+ * @deprecated Use `wAUDIO().toLocaleString()` from {@link FixedDecimal} instead
+ *
  * Format a $AUDIO string with commas and decimals
  * @param amount The $AUDIO amount
  * @param decimals Number of decimal places to display
@@ -157,7 +162,9 @@ export const formatAudio = (amount: string, decimals?: number) => {
 }
 
 // Wei -> Audio
-
+/**
+ * @deprecated Use `AUDIO(wei).trunc().toFixed()` from {@link FixedDecimal} instead
+ */
 export const formatWeiToAudioString = (wei: BNWei) => {
   const aud = wei.div(WEI_DIVISOR)
   return aud.toString()
@@ -174,6 +181,9 @@ export const formatNumberCommas = (num: number | string) => {
   )
 }
 
+/**
+ * @deprecated Use `USDC().toLocaleString()` from {@link FixedDecimal} instead
+ */
 export const formatPrice = (num: number) => {
   return formatNumberCommas((num / 100).toFixed(2))
 }
@@ -202,6 +212,9 @@ export const checkOnlyWeiFloat = (number: string) => {
   return true
 }
 
+/**
+ * @deprecated Use `AUDIO()` from {@link FixedDecimal} instead
+ */
 export const convertFloatToWei = (number: string) => {
   const nums = number.split('.')
   if (nums.length !== 2) return null
@@ -217,6 +230,9 @@ export const checkWeiNumber = (number: string) => {
 }
 
 // Audio -> Wei
+/**
+ * @deprecated Use `AUDIO()` from {@link FixedDecimal} instead
+ */
 export const parseWeiNumber = (number: string) => {
   if (checkOnlyNumeric(number)) {
     return new BN(number).mul(WEI_DIVISOR)
@@ -233,6 +249,9 @@ type FormatOptions = {
   excludeCommas?: boolean
 }
 
+/**
+ * @deprecated Use `FixedDecimal().toLocaleString()` instead
+ */
 export const formatNumberString = (
   number?: string,
   options?: FormatOptions

--- a/packages/common/src/utils/wallet.ts
+++ b/packages/common/src/utils/wallet.ts
@@ -18,54 +18,86 @@ import {
   convertFloatToWei
 } from '~/utils/formatUtil'
 import { Nullable } from '~/utils/typeUtils'
+import type { FixedDecimal } from '@audius/fixed-decimal'
 
 /** AUDIO utils */
 const WEI_DECIMALS = 18 // 18 decimals on ETH AUDIO
 const SPL_DECIMALS = 8 // 8 decimals on SPL AUDIO
 
+/** @deprecated Don't use BN in new code if possible. Use BigInt. */
 export const zeroBNWei = new BN(0) as BNWei
 
+/**
+ * @deprecated Use `AUDIO().trunc().toFixed()` from {@link FixedDecimal} instead.
+ */
 export const weiToAudioString = (bnWei: BNWei): StringAudio => {
   const stringAudio = formatWeiToAudioString(bnWei) as StringAudio
   return stringAudio
 }
 
+/**
+ * @deprecated Don't use BN to represent whole AUDIO. Use `AUDIO().trunc().toFixed()` from {@link FixedDecimal} instead.
+ */
 export const weiToAudio = (bnWei: BNWei): BNAudio => {
   const stringAudio = formatWeiToAudioString(bnWei) as StringAudio
   return stringAudioToBN(stringAudio)
 }
 
+/**
+ * @deprecated Use `AUDIO().value` from {@link FixedDecimal} instead.
+ */
 export const audioToWei = (stringAudio: StringAudio): BNWei => {
   const wei = parseWeiNumber(stringAudio) as BNWei
   return wei
 }
 
+/**
+ * @deprecated Use `AUDIO()` from {@link FixedDecimal} instead.
+ */
 export const stringWeiToBN = (stringWei: StringWei): BNWei => {
   return new BN(stringWei) as BNWei
 }
 
+/**
+ * @deprecated Use `USDC()` from {@link FixedDecimal} instead.
+ */
 export const stringUSDCToBN = (stringUSDC: StringUSDC): BNUSDC => {
   return new BN(stringUSDC) as BNUSDC
 }
 
+/**
+ * @deprecated Don't use BN to represent whole AUDIO. Use `AUDIO().toString()` from {@link FixedDecimal} instead.
+ */
 export const stringAudioToBN = (stringAudio: StringAudio): BNAudio => {
   return new BN(stringAudio) as BNAudio
 }
 
+/**
+ * @deprecated Don't use BN to represent whole AUDIO. Use `AUDIO().toString()` from {@link FixedDecimal} instead.
+ */
 export const stringWeiToAudioBN = (stringWei: StringWei): BNAudio => {
   const bnWei = stringWeiToBN(stringWei)
   const stringAudio = weiToAudioString(bnWei)
   return new BN(stringAudio) as BNAudio
 }
 
+/**
+ * @deprecated Use `AUDIO(wei).value.toString()` from {@link FixedDecimal} instead.
+ */
 export const weiToString = (wei: BNWei): StringWei => {
   return wei.toString() as StringWei
 }
 
+/**
+ * @deprecated Use `AUDIO(stringAudio).value.toString()` from {@link FixedDecimal} instead.
+ */
 export const stringAudioToStringWei = (stringAudio: StringAudio): StringWei => {
   return weiToString(audioToWei(stringAudio))
 }
 
+/**
+ * @deprecated Use `AUDIO()` from {@link FixedDecimal} instead.
+ */
 export const parseAudioInputToWei = (audio: StringAudio): Nullable<BNWei> => {
   if (!audio.length) return null
   // First try converting from float, in case audio has decimal value
@@ -80,6 +112,8 @@ export const parseAudioInputToWei = (audio: StringAudio): Nullable<BNWei> => {
 }
 
 /**
+ * @deprecated Use `AUDIO().toLocaleString()` from {@link FixedDecimal} instead.
+ *
  * Format wei BN to the full $AUDIO currency with decimals
  * @param amount The wei amount
  * @param shouldTruncate truncate decimals at truncation length
@@ -133,22 +167,38 @@ export const convertBigIntToAmountObject = (
   }
 }
 
+/**
+ * @deprecated Use `AUDIO(wAUDIO(amount))` from {@link FixedDecimal} instead.
+ */
 export const convertWAudioToWei = (amount: BN) => {
   const decimals = WEI_DECIMALS - SPL_DECIMALS
   return amount.mul(new BN('1'.padEnd(decimals + 1, '0'))) as BNWei
 }
 
+/**
+ * @deprecated Use `wAUDIO(AUDIO(amount))` from {@link FixedDecimal} instead.
+ */
 export const convertWeiToWAudio = (amount: BN) => {
   const decimals = WEI_DECIMALS - SPL_DECIMALS
   return amount.div(new BN('1'.padEnd(decimals + 1, '0')))
 }
 
 /** USDC Utils */
+/**
+ * @deprecated Use `USDC()` from {@link FixedDecimal} instead.
+ */
 export const BN_USDC_WEI = new BN('1000000')
+/**
+ * @deprecated Use `USDC()` from {@link FixedDecimal} instead.
+ */
 export const BN_USDC_CENT_WEI = new BN('10000')
 const BN_USDC_WEI_ROUNDING_FRACTION = new BN('9999')
 
-/** Round a USDC value as a BN up to the nearest cent and return as a BN */
+/**
+ * @deprecated Use `USDC(value).ceil(2)` from {@link FixedDecimal} instead
+ *
+ * Round a USDC value as a BN up to the nearest cent and return as a BN
+ */
 export const ceilingBNUSDCToNearestCent = (value: BNUSDC): BNUSDC => {
   return value
     .add(BN_USDC_WEI_ROUNDING_FRACTION)
@@ -156,15 +206,21 @@ export const ceilingBNUSDCToNearestCent = (value: BNUSDC): BNUSDC => {
     .mul(BN_USDC_CENT_WEI) as BNUSDC
 }
 
-/** Round a USDC value as a BN down to the nearest cent and return as a BN */
+/**
+ * @deprecated Use `USDC(value).floor(2)` from {@link FixedDecimal} instead.
+ *
+ * Round a USDC value as a BN down to the nearest cent and return as a BN
+ */
 export const floorBNUSDCToNearestCent = (value: BNUSDC): BNUSDC => {
   return value.div(BN_USDC_CENT_WEI).mul(BN_USDC_CENT_WEI) as BNUSDC
 }
 
-/** Formats a USDC wei string (full precision) to a fixed string suitable for
-display as a dollar amount. Note: will lose precision by rounding _up_ to nearest
-cent and will drop negative signs
-*/
+/**
+ * @deprecated Use `USDC().toLocaleString()` from {@link FixedDecimal} instead.
+ *
+ * Formats a USDC wei string (full precision) to a fixed string suitable for display as a dollar amount.
+ * Note: will lose precision by rounding _up_ to nearest cent and will drop negative signs
+ */
 export const formatUSDCWeiToUSDString = (
   amount: StringUSDC | BN,
   precision = 2
@@ -181,6 +237,8 @@ export const formatUSDCWeiToUSDString = (
 }
 
 /**
+ * @deprecated Use `Number(USDC(usdc).ceil(2).toString())` from {@link FixedDecimal} instead.
+ *
  * Formats a USDC BN (full precision) to a number of dollars.
  * Note: will lose precision by rounding _up_ to nearest cent.
  */
@@ -191,6 +249,8 @@ export const formatUSDCWeiToCeilingDollarNumber = (amount: BNUSDC) => {
 }
 
 /**
+ * @deprecated Use `Number(USDC(usdc).ceil(2).toString()) * 100` from {@link FixedDecimal} instead.
+ *
  * Formats a USDC BN (full precision) to a number of cents.
  * Note: will lose precision by rounding _up_ to nearest cent.
  */
@@ -199,6 +259,8 @@ export const formatUSDCWeiToCeilingCentsNumber = (amount: BNUSDC) => {
 }
 
 /**
+ * @deprecated Use `Number(USDC(usdc).floor(2).toString()` from {@link FixedDecimal} instead.
+ *
  * Formats a USDC BN (full precision) to a number of dollars.
  * Note: will lose precision by rounding _down_ to nearest cent.
  */
@@ -207,6 +269,8 @@ export const formatUSDCWeiToFloorDollarNumber = (amount: BNUSDC) => {
 }
 
 /**
+ * @deprecated Use `Number(USDC(usdc).floor(2).toString()) * 100` from {@link FixedDecimal} instead.
+ *
  * Formats a USDC BN (full precision) to a number of cents.
  * Note: will lose precision by rounding _down_ to nearest cent.
  */

--- a/packages/common/src/utils/wallet.ts
+++ b/packages/common/src/utils/wallet.ts
@@ -66,14 +66,14 @@ export const stringUSDCToBN = (stringUSDC: StringUSDC): BNUSDC => {
 }
 
 /**
- * @deprecated Don't use BN to represent whole AUDIO. Use `AUDIO().toString()` from {@link FixedDecimal} instead.
+ * @deprecated Don't use BN to represent whole AUDIO. Use `AUDIO()` from {@link FixedDecimal} instead.
  */
 export const stringAudioToBN = (stringAudio: StringAudio): BNAudio => {
   return new BN(stringAudio) as BNAudio
 }
 
 /**
- * @deprecated Don't use BN to represent whole AUDIO. Use `AUDIO().toString()` from {@link FixedDecimal} instead.
+ * @deprecated Don't use BN to represent whole AUDIO. Use `AUDIO()` from {@link FixedDecimal} instead.
  */
 export const stringWeiToAudioBN = (stringWei: StringWei): BNAudio => {
   const bnWei = stringWeiToBN(stringWei)

--- a/packages/common/src/utils/wallet.ts
+++ b/packages/common/src/utils/wallet.ts
@@ -1,3 +1,5 @@
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+import type { FixedDecimal } from '@audius/fixed-decimal'
 import BN from 'bn.js'
 
 import {
@@ -18,7 +20,6 @@ import {
   convertFloatToWei
 } from '~/utils/formatUtil'
 import { Nullable } from '~/utils/typeUtils'
-import type { FixedDecimal } from '@audius/fixed-decimal'
 
 /** AUDIO utils */
 const WEI_DECIMALS = 18 // 18 decimals on ETH AUDIO


### PR DESCRIPTION
A friendly reminder that FixedDecimal exists when you reach for the old utils!

Do let me know if you encounter any difficulties with the replacement suggestions. The easiest thing if you want to directly translate from the existing method (which you might not actually need to in some cases), you can cross-reference the test files to these files where the equivalent FixedDecimal versions are in each test. For example:

https://github.com/AudiusProject/audius-protocol/blob/66b1e99fa63e5e399b07188e58b4674e54785b8d/packages/common/src/utils/wallet.test.ts#L106-L119

Note that some of these examples are more verbose than potentially necessary - this particular example you don't need to specify `style: undefined` unless you don't want the `$`, you don't need `maximumFractionDigits`/`minimumFractionDigits` as they default to `2`, and the `roundingMode` defaults to `trunc` if that works for your use case.

You can see the default formatting options for USDC here:

https://github.com/AudiusProject/audius-protocol/blob/0a2fe3d14e1514cd60a5c89f7b7b7623c14e0d58/packages/fixed-decimal/src/currencies.ts#L87-L93

and here for all FixedDecimal types if not overridden:

https://github.com/AudiusProject/audius-protocol/blob/0a2fe3d14e1514cd60a5c89f7b7b7623c14e0d58/packages/fixed-decimal/src/FixedDecimal.ts#L124-L131