### PR TITLE
Fix batcher context resolver

### DIFF
--- a/packages/common/src/api/tan-query/batchers/contextCacheResolver.ts
+++ b/packages/common/src/api/tan-query/batchers/contextCacheResolver.ts
@@ -1,5 +1,3 @@
-import isEqualWith from 'lodash-es/isEqualWith'
-
 import { BatchContext } from './types'
 
 /**
@@ -10,7 +8,15 @@ export const contextCacheResolver = () => {
   let lastContext: BatchContext | null = null
 
   return (context: BatchContext) => {
-    if (isEqualWith(lastContext, context, Object.is)) {
+    if (
+      lastContext &&
+      Object.keys(context).every((key) =>
+        Object.is(
+          context[key as keyof BatchContext],
+          lastContext?.[key as keyof BatchContext]
+        )
+      )
+    ) {
       return lastContext
     }
 


### PR DESCRIPTION
### Description

Opts for Object.is to prevent deep equality checks. Confirmed that reference equality for sdk works with this