### PR TITLE
[PAY-3858] Re-do challenge progress status label logic

### DIFF
--- a/packages/common/src/utils/challenges.ts
+++ b/packages/common/src/utils/challenges.ts
@@ -33,7 +33,6 @@ export const challengeRewardsConfig: Record<
       `Earn ${challenge?.amount} $AUDIO for you and your friend.`,
     fullDescription: (challenge) =>
       `Invite your Friends! You’ll earn ${challenge?.amount} $AUDIO for each friend who joins with your link (and they’ll get an $AUDIO too)`,
-    progressLabel: '%0/%1 Invites Accepted',
     remainingLabel: '%0/%1 Invites Remain',
     panelButtonText: 'Invite Your Friends'
   },
@@ -44,7 +43,6 @@ export const challengeRewardsConfig: Record<
       `Earn ${challenge?.amount} $AUDIO for you and your friend.`,
     fullDescription: (challenge) =>
       `Invite your Friends! You’ll earn ${challenge?.amount} $AUDIO for each friend who joins with your link (and they’ll get an $AUDIO too)`,
-    progressLabel: '%0/%1 Invites Accepted',
     remainingLabel: '%0/%1 Invites Remain',
     panelButtonText: 'Invite Your Friends'
   },
@@ -55,7 +53,6 @@ export const challengeRewardsConfig: Record<
       `Earn up to ${formatNumberCommas(challenge?.totalAmount ?? '')} $AUDIO`,
     fullDescription: (challenge) =>
       `Invite your fans! You’ll earn ${challenge?.amount} $AUDIO for each fan who joins with your link (and they’ll get an $AUDIO too)`,
-    progressLabel: '%0/%1 Invites Accepted',
     remainingLabel: '%0/%1 Invites Remain',
     panelButtonText: 'Invite your Fans',
     isVerifiedChallenge: true
@@ -67,7 +64,6 @@ export const challengeRewardsConfig: Record<
       `Earn up to ${formatNumberCommas(challenge?.totalAmount ?? '')} $AUDIO`,
     fullDescription: (challenge) =>
       `Invite your fans! You’ll earn ${challenge?.amount} $AUDIO for each fan who joins with your link (and they’ll get an $AUDIO too)`,
-    progressLabel: '%0/%1 Invites Accepted',
     remainingLabel: '%0/%1 Invites Remain',
     panelButtonText: 'Invite your Fans',
     isVerifiedChallenge: true

--- a/packages/common/src/utils/challenges.ts
+++ b/packages/common/src/utils/challenges.ts
@@ -16,7 +16,6 @@ export type ChallengeRewardsInfo = {
   description: (amount: OptimisticUserChallenge | undefined) => string
   fullDescription?: (amount: OptimisticUserChallenge | undefined) => string
   optionalDescription?: string
-  progressLabel?: string
   remainingLabel?: string
   completedLabel?: string
   panelButtonText: string
@@ -80,7 +79,6 @@ export const challengeRewardsConfig: Record<
       `You earned ${challenge?.totalAmount ?? ''} $AUDIO for being invited.`,
     fullDescription: (challenge) =>
       `You earned ${challenge?.totalAmount ?? ''} $AUDIO for being invited.`,
-    progressLabel: 'Not Earned',
     panelButtonText: 'More Info'
   },
   [ChallengeName.Referred]: {
@@ -90,7 +88,6 @@ export const challengeRewardsConfig: Record<
       `You earned ${challenge?.totalAmount ?? ''} $AUDIO for being invited.`,
     fullDescription: (challenge) =>
       `You earned ${challenge?.totalAmount ?? ''} $AUDIO for being invited.`,
-    progressLabel: 'Not Earned',
     panelButtonText: 'More Info'
   },
   'connect-verified': {
@@ -100,7 +97,6 @@ export const challengeRewardsConfig: Record<
       `Link your verified social media accounts to earn ${challenge?.amount} $AUDIO.`,
     fullDescription: () =>
       'Get verified on Audius by linking your verified Twitter or Instagram account!',
-    progressLabel: 'Not Linked',
     panelButtonText: 'Verify Your Account'
   },
   [ChallengeName.ConnectVerified]: {
@@ -110,7 +106,6 @@ export const challengeRewardsConfig: Record<
       `Link your verified social media accounts to earn ${challenge?.amount} $AUDIO.`,
     fullDescription: () =>
       'Get verified on Audius by linking your verified Twitter or Instagram account!',
-    progressLabel: 'Not Linked',
     panelButtonText: 'Link Verified Account'
   },
   'listen-streak': {
@@ -120,7 +115,6 @@ export const challengeRewardsConfig: Record<
       `Listen to one track a day for seven days to earn ${challenge?.amount} $AUDIO.`,
     fullDescription: () =>
       'Sign in and listen to at least one track every day for 7 days',
-    progressLabel: '%0/%1 Days',
     completedLabel: 'Keep Listening',
     panelButtonText: 'Trending on Audius'
   },
@@ -131,7 +125,6 @@ export const challengeRewardsConfig: Record<
       'Listen to music on Audius daily for seven days to start a streak. After that, earn $AUDIO for each consecutive day you continue listening.',
     fullDescription: () =>
       'Listen to music on Audius daily for seven days to start a streak. After that, earn $AUDIO for each consecutive day you continue listening.',
-    progressLabel: '%0/%1 Days',
     completedLabel: 'Keep Listening',
     panelButtonText: 'Trending on Audius'
   },
@@ -142,7 +135,6 @@ export const challengeRewardsConfig: Record<
       `Listen to one track a day for seven days to earn ${challenge?.amount} $AUDIO.`,
     fullDescription: () =>
       'Sign in and listen to at least one track every day for 7 days',
-    progressLabel: '%0/%1 Days',
     panelButtonText: 'Trending on Audius'
   },
   'mobile-install': {
@@ -151,7 +143,6 @@ export const challengeRewardsConfig: Record<
     description: (challenge) => `Earn ${challenge?.amount} $AUDIO.`,
     fullDescription: () =>
       'Install the Audius app for iPhone and Android and Sign in to your account!',
-    progressLabel: 'Not Installed',
     panelButtonText: 'Get the App'
   },
   [ChallengeName.MobileInstall]: {
@@ -160,7 +151,6 @@ export const challengeRewardsConfig: Record<
     description: (challenge) => `Earn ${challenge?.amount} $AUDIO.`,
     fullDescription: () =>
       'Install the Audius app for iPhone and Android and Sign in to your account!',
-    progressLabel: 'Not Installed',
     panelButtonText: 'Get the App'
   },
   'profile-completion': {
@@ -170,7 +160,6 @@ export const challengeRewardsConfig: Record<
       `Complete your Audius profile to earn ${challenge?.amount} $AUDIO.`,
     fullDescription: () =>
       'Fill out the missing details on your Audius profile and start interacting with tracks and artists!',
-    progressLabel: '%0/%1 Complete',
     completedLabel: 'View Your Profile',
     panelButtonText: 'More Info'
   },
@@ -181,7 +170,6 @@ export const challengeRewardsConfig: Record<
       `Complete your Audius profile to earn ${challenge?.amount} $AUDIO.`,
     fullDescription: () =>
       'Fill out the missing details on your Audius profile and start interacting with tracks and artists!',
-    progressLabel: '%0/%1 Complete',
     panelButtonText: 'More Info'
   },
   'track-upload': {
@@ -190,7 +178,6 @@ export const challengeRewardsConfig: Record<
     description: (challenge) =>
       `Earn ${challenge?.amount} $AUDIO for uploading 3 tracks.`,
     fullDescription: () => 'Upload 3 tracks to your profile',
-    progressLabel: '%0/%1 Uploaded',
     completedLabel: 'Upload More Tracks',
     panelButtonText: 'Upload Tracks'
   },
@@ -200,7 +187,6 @@ export const challengeRewardsConfig: Record<
     description: (challenge) =>
       `Earn ${challenge?.amount} $AUDIO for uploading 3 tracks.`,
     fullDescription: () => 'Upload 3 tracks to your profile',
-    progressLabel: '%0/%1 Uploaded',
     panelButtonText: 'Upload Tracks'
   },
   'send-first-tip': {
@@ -210,7 +196,6 @@ export const challengeRewardsConfig: Record<
       'Show some love to your favorite artist and send them a tip.',
     fullDescription: () =>
       'Show some love to your favorite artist and send them a tip.',
-    progressLabel: 'Not Earned',
     completedLabel: 'Tip Another Artist',
     panelButtonText: 'Send a Tip'
   },
@@ -221,7 +206,6 @@ export const challengeRewardsConfig: Record<
       'Show some love to your favorite artist and send them a tip.',
     fullDescription: () =>
       'Show some love to your favorite artist and send them a tip.',
-    progressLabel: 'Not Earned',
     panelButtonText: 'Send a Tip'
   },
   'first-playlist': {
@@ -229,7 +213,6 @@ export const challengeRewardsConfig: Record<
     title: 'Create a Playlist',
     description: (_) => 'Create a playlist and add a track to it.',
     fullDescription: () => 'Create a playlist and add a track to it.',
-    progressLabel: 'Not Earned',
     completedLabel: 'Create Another Playlist',
     panelButtonText: 'Discover Some Tracks'
   },
@@ -238,7 +221,6 @@ export const challengeRewardsConfig: Record<
     title: 'Create a Playlist',
     description: (_) => 'Create a playlist and add a track to it.',
     fullDescription: () => 'Create a playlist and add a track to it.',
-    progressLabel: 'Not Earned',
     panelButtonText: 'Discover Some Tracks'
   },
   [ChallengeName.AudioMatchingSell]: {
@@ -248,7 +230,6 @@ export const challengeRewardsConfig: Record<
       'Receive 1 additional $AUDIO for each dollar earned from sales.',
     fullDescription: () =>
       'Receive 1 additional $AUDIO for each dollar earned from sales.',
-    progressLabel: 'No Recent Activity',
     panelButtonText: 'View Details'
   },
   [ChallengeName.AudioMatchingBuy]: {
@@ -256,7 +237,6 @@ export const challengeRewardsConfig: Record<
     title: 'Spend to Earn',
     description: (_) => 'Earn 1 $AUDIO for each dollar you spend on Audius.',
     fullDescription: () => 'Earn 1 $AUDIO for each dollar you spend on Audius.',
-    progressLabel: 'No Recent Activity',
     panelButtonText: 'View Details'
   },
   'trending-playlist': {
@@ -319,8 +299,7 @@ export const challengeRewardsConfig: Record<
       '\n\nClaim your tokens before they expire on 05/13/25!',
     panelButtonText: '',
     id: ChallengeName.OneShot,
-    remainingLabel: 'Ineligible',
-    progressLabel: 'Ready to Claim'
+    remainingLabel: 'Ineligible'
   }
 }
 
@@ -412,3 +391,76 @@ const newChallengeIds: ChallengeRewardID[] = [
 
 export const isNewChallenge = (challengeId: ChallengeRewardID) =>
   newChallengeIds.includes(challengeId)
+
+const DEFAULT_STATUS_LABELS = {
+  COMPLETE: 'Complete',
+  REWARD_PENDING: 'Reward Pending',
+  READY_TO_CLAIM: 'Ready to Claim',
+  IN_PROGRESS: 'In Progress',
+  AVAILABLE: 'Available',
+  INCOMPLETE: 'Incomplete'
+} as const
+
+export const getChallengeStatusLabel = (
+  challenge: OptimisticUserChallenge | undefined,
+  challengeId: ChallengeRewardID
+): string => {
+  if (!challenge) return DEFAULT_STATUS_LABELS.AVAILABLE
+
+  // Handle special aggregate challenges first
+  switch (challengeId) {
+    case ChallengeName.ListenStreakEndless:
+      return `Day ${challenge.current_step_count}`
+
+    case ChallengeName.AudioMatchingBuy:
+      if (challenge.state === 'inactive') return 'No Recent Purchases'
+      if (challenge.state === 'completed' && challenge.cooldown_days) {
+        return DEFAULT_STATUS_LABELS.REWARD_PENDING
+      }
+      if (challenge.claimableAmount > 0) {
+        return DEFAULT_STATUS_LABELS.READY_TO_CLAIM
+      }
+      return 'No Recent Activity'
+  }
+
+  // Handle claimable state for non-aggregate rewards
+  if (challenge.claimableAmount > 0) {
+    return DEFAULT_STATUS_LABELS.READY_TO_CLAIM
+  }
+
+  // Handle disbursed state - 2nd clause is for aggregate challenges
+  if (
+    challenge.state === 'disbursed' ||
+    (challenge.state === 'completed' &&
+      challenge.current_step_count === challenge.max_steps)
+  ) {
+    return DEFAULT_STATUS_LABELS.COMPLETE
+  }
+
+  // Handle completed with cooldown state
+  if (challenge.state === 'completed' && challenge.cooldown_days) {
+    return DEFAULT_STATUS_LABELS.REWARD_PENDING
+  }
+
+  // Handle remaining challenge-specific states
+  switch (challengeId) {
+    case ChallengeName.OneShot:
+      return 'Ineligible'
+
+    case ChallengeName.Referrals:
+    case ChallengeName.ReferralsVerified:
+      return `${challenge.current_step_count ?? 0}/${challenge.max_steps ?? 0} Invites Remaining`
+
+    case ChallengeName.ProfileCompletion:
+      return `${challenge.current_step_count ?? 0}/7 Complete`
+
+    case ChallengeName.TrackUpload:
+      return `${challenge.current_step_count ?? 0}/3 Uploaded`
+
+    default:
+      if (challenge.state === 'in_progress') {
+        return DEFAULT_STATUS_LABELS.IN_PROGRESS
+      }
+      return DEFAULT_STATUS_LABELS.AVAILABLE
+  }
+}

--- a/packages/common/src/utils/challenges.ts
+++ b/packages/common/src/utils/challenges.ts
@@ -16,6 +16,7 @@ export type ChallengeRewardsInfo = {
   description: (amount: OptimisticUserChallenge | undefined) => string
   fullDescription?: (amount: OptimisticUserChallenge | undefined) => string
   optionalDescription?: string
+  progressLabel?: string
   remainingLabel?: string
   completedLabel?: string
   panelButtonText: string
@@ -33,6 +34,7 @@ export const challengeRewardsConfig: Record<
       `Earn ${challenge?.amount} $AUDIO for you and your friend.`,
     fullDescription: (challenge) =>
       `Invite your Friends! You’ll earn ${challenge?.amount} $AUDIO for each friend who joins with your link (and they’ll get an $AUDIO too)`,
+    progressLabel: '%0/%1 Invites Accepted',
     remainingLabel: '%0/%1 Invites Remain',
     panelButtonText: 'Invite Your Friends'
   },
@@ -43,6 +45,7 @@ export const challengeRewardsConfig: Record<
       `Earn ${challenge?.amount} $AUDIO for you and your friend.`,
     fullDescription: (challenge) =>
       `Invite your Friends! You’ll earn ${challenge?.amount} $AUDIO for each friend who joins with your link (and they’ll get an $AUDIO too)`,
+    progressLabel: '%0/%1 Invites Accepted',
     remainingLabel: '%0/%1 Invites Remain',
     panelButtonText: 'Invite Your Friends'
   },
@@ -53,6 +56,7 @@ export const challengeRewardsConfig: Record<
       `Earn up to ${formatNumberCommas(challenge?.totalAmount ?? '')} $AUDIO`,
     fullDescription: (challenge) =>
       `Invite your fans! You’ll earn ${challenge?.amount} $AUDIO for each fan who joins with your link (and they’ll get an $AUDIO too)`,
+    progressLabel: '%0/%1 Invites Accepted',
     remainingLabel: '%0/%1 Invites Remain',
     panelButtonText: 'Invite your Fans',
     isVerifiedChallenge: true
@@ -64,6 +68,7 @@ export const challengeRewardsConfig: Record<
       `Earn up to ${formatNumberCommas(challenge?.totalAmount ?? '')} $AUDIO`,
     fullDescription: (challenge) =>
       `Invite your fans! You’ll earn ${challenge?.amount} $AUDIO for each fan who joins with your link (and they’ll get an $AUDIO too)`,
+    progressLabel: '%0/%1 Invites Accepted',
     remainingLabel: '%0/%1 Invites Remain',
     panelButtonText: 'Invite your Fans',
     isVerifiedChallenge: true
@@ -75,6 +80,7 @@ export const challengeRewardsConfig: Record<
       `You earned ${challenge?.totalAmount ?? ''} $AUDIO for being invited.`,
     fullDescription: (challenge) =>
       `You earned ${challenge?.totalAmount ?? ''} $AUDIO for being invited.`,
+    progressLabel: 'Not Earned',
     panelButtonText: 'More Info'
   },
   [ChallengeName.Referred]: {
@@ -84,6 +90,7 @@ export const challengeRewardsConfig: Record<
       `You earned ${challenge?.totalAmount ?? ''} $AUDIO for being invited.`,
     fullDescription: (challenge) =>
       `You earned ${challenge?.totalAmount ?? ''} $AUDIO for being invited.`,
+    progressLabel: 'Not Earned',
     panelButtonText: 'More Info'
   },
   'connect-verified': {
@@ -93,6 +100,7 @@ export const challengeRewardsConfig: Record<
       `Link your verified social media accounts to earn ${challenge?.amount} $AUDIO.`,
     fullDescription: () =>
       'Get verified on Audius by linking your verified Twitter or Instagram account!',
+    progressLabel: 'Not Linked',
     panelButtonText: 'Verify Your Account'
   },
   [ChallengeName.ConnectVerified]: {
@@ -102,6 +110,7 @@ export const challengeRewardsConfig: Record<
       `Link your verified social media accounts to earn ${challenge?.amount} $AUDIO.`,
     fullDescription: () =>
       'Get verified on Audius by linking your verified Twitter or Instagram account!',
+    progressLabel: 'Not Linked',
     panelButtonText: 'Link Verified Account'
   },
   'listen-streak': {
@@ -111,6 +120,7 @@ export const challengeRewardsConfig: Record<
       `Listen to one track a day for seven days to earn ${challenge?.amount} $AUDIO.`,
     fullDescription: () =>
       'Sign in and listen to at least one track every day for 7 days',
+    progressLabel: '%0/%1 Days',
     completedLabel: 'Keep Listening',
     panelButtonText: 'Trending on Audius'
   },
@@ -121,6 +131,7 @@ export const challengeRewardsConfig: Record<
       'Listen to music on Audius daily for seven days to start a streak. After that, earn $AUDIO for each consecutive day you continue listening.',
     fullDescription: () =>
       'Listen to music on Audius daily for seven days to start a streak. After that, earn $AUDIO for each consecutive day you continue listening.',
+    progressLabel: '%0/%1 Days',
     completedLabel: 'Keep Listening',
     panelButtonText: 'Trending on Audius'
   },
@@ -131,6 +142,7 @@ export const challengeRewardsConfig: Record<
       `Listen to one track a day for seven days to earn ${challenge?.amount} $AUDIO.`,
     fullDescription: () =>
       'Sign in and listen to at least one track every day for 7 days',
+    progressLabel: '%0/%1 Days',
     panelButtonText: 'Trending on Audius'
   },
   'mobile-install': {
@@ -139,6 +151,7 @@ export const challengeRewardsConfig: Record<
     description: (challenge) => `Earn ${challenge?.amount} $AUDIO.`,
     fullDescription: () =>
       'Install the Audius app for iPhone and Android and Sign in to your account!',
+    progressLabel: 'Not Installed',
     panelButtonText: 'Get the App'
   },
   [ChallengeName.MobileInstall]: {
@@ -147,6 +160,7 @@ export const challengeRewardsConfig: Record<
     description: (challenge) => `Earn ${challenge?.amount} $AUDIO.`,
     fullDescription: () =>
       'Install the Audius app for iPhone and Android and Sign in to your account!',
+    progressLabel: 'Not Installed',
     panelButtonText: 'Get the App'
   },
   'profile-completion': {
@@ -156,6 +170,7 @@ export const challengeRewardsConfig: Record<
       `Complete your Audius profile to earn ${challenge?.amount} $AUDIO.`,
     fullDescription: () =>
       'Fill out the missing details on your Audius profile and start interacting with tracks and artists!',
+    progressLabel: '%0/%1 Complete',
     completedLabel: 'View Your Profile',
     panelButtonText: 'More Info'
   },
@@ -166,6 +181,7 @@ export const challengeRewardsConfig: Record<
       `Complete your Audius profile to earn ${challenge?.amount} $AUDIO.`,
     fullDescription: () =>
       'Fill out the missing details on your Audius profile and start interacting with tracks and artists!',
+    progressLabel: '%0/%1 Complete',
     panelButtonText: 'More Info'
   },
   'track-upload': {
@@ -174,6 +190,7 @@ export const challengeRewardsConfig: Record<
     description: (challenge) =>
       `Earn ${challenge?.amount} $AUDIO for uploading 3 tracks.`,
     fullDescription: () => 'Upload 3 tracks to your profile',
+    progressLabel: '%0/%1 Uploaded',
     completedLabel: 'Upload More Tracks',
     panelButtonText: 'Upload Tracks'
   },
@@ -183,6 +200,7 @@ export const challengeRewardsConfig: Record<
     description: (challenge) =>
       `Earn ${challenge?.amount} $AUDIO for uploading 3 tracks.`,
     fullDescription: () => 'Upload 3 tracks to your profile',
+    progressLabel: '%0/%1 Uploaded',
     panelButtonText: 'Upload Tracks'
   },
   'send-first-tip': {
@@ -192,6 +210,7 @@ export const challengeRewardsConfig: Record<
       'Show some love to your favorite artist and send them a tip.',
     fullDescription: () =>
       'Show some love to your favorite artist and send them a tip.',
+    progressLabel: 'Not Earned',
     completedLabel: 'Tip Another Artist',
     panelButtonText: 'Send a Tip'
   },
@@ -202,6 +221,7 @@ export const challengeRewardsConfig: Record<
       'Show some love to your favorite artist and send them a tip.',
     fullDescription: () =>
       'Show some love to your favorite artist and send them a tip.',
+    progressLabel: 'Not Earned',
     panelButtonText: 'Send a Tip'
   },
   'first-playlist': {
@@ -209,6 +229,7 @@ export const challengeRewardsConfig: Record<
     title: 'Create a Playlist',
     description: (_) => 'Create a playlist and add a track to it.',
     fullDescription: () => 'Create a playlist and add a track to it.',
+    progressLabel: 'Not Earned',
     completedLabel: 'Create Another Playlist',
     panelButtonText: 'Discover Some Tracks'
   },
@@ -217,6 +238,7 @@ export const challengeRewardsConfig: Record<
     title: 'Create a Playlist',
     description: (_) => 'Create a playlist and add a track to it.',
     fullDescription: () => 'Create a playlist and add a track to it.',
+    progressLabel: 'Not Earned',
     panelButtonText: 'Discover Some Tracks'
   },
   [ChallengeName.AudioMatchingSell]: {
@@ -226,6 +248,7 @@ export const challengeRewardsConfig: Record<
       'Receive 1 additional $AUDIO for each dollar earned from sales.',
     fullDescription: () =>
       'Receive 1 additional $AUDIO for each dollar earned from sales.',
+    progressLabel: 'No Recent Activity',
     panelButtonText: 'View Details'
   },
   [ChallengeName.AudioMatchingBuy]: {
@@ -233,6 +256,7 @@ export const challengeRewardsConfig: Record<
     title: 'Spend to Earn',
     description: (_) => 'Earn 1 $AUDIO for each dollar you spend on Audius.',
     fullDescription: () => 'Earn 1 $AUDIO for each dollar you spend on Audius.',
+    progressLabel: 'No Recent Activity',
     panelButtonText: 'View Details'
   },
   'trending-playlist': {
@@ -295,7 +319,8 @@ export const challengeRewardsConfig: Record<
       '\n\nClaim your tokens before they expire on 05/13/25!',
     panelButtonText: '',
     id: ChallengeName.OneShot,
-    remainingLabel: 'Ineligible'
+    remainingLabel: 'Ineligible',
+    progressLabel: 'Ready to Claim'
   }
 }
 

--- a/packages/web/src/pages/rewards-page/components/modals/ChallengeRewardsModal/AudioMatchingRewardsModalContent.tsx
+++ b/packages/web/src/pages/rewards-page/components/modals/ChallengeRewardsModal/AudioMatchingRewardsModalContent.tsx
@@ -3,8 +3,8 @@ import { useCallback } from 'react'
 import { ChallengeName } from '@audius/common/models'
 import { challengesSelectors } from '@audius/common/store'
 import {
-  formatNumberCommas,
   challengeRewardsConfig,
+  getChallengeStatusLabel,
   route
 } from '@audius/common/utils'
 import {
@@ -71,6 +71,26 @@ export const AudioMatchingRewardsModalContent = ({
   const { fullDescription } = challengeRewardsConfig[challengeName]
   const userChallenge = useSelector(getOptimisticUserChallenges)[challengeName]
 
+  const statusLabel = userChallenge
+    ? getChallengeStatusLabel(userChallenge, challengeName)
+    : null
+
+  const progressStatusLabel =
+    userChallenge && userChallenge?.disbursed_amount > 0 ? (
+      <Flex
+        alignItems='center'
+        justifyContent='center'
+        ph='xl'
+        pv='l'
+        borderTop='strong'
+        backgroundColor='surface2'
+      >
+        <Text variant='label' size='l' strength='strong'>
+          {statusLabel}
+        </Text>
+      </Flex>
+    ) : null
+
   const progressDescription = (
     <ProgressDescription
       description={
@@ -90,24 +110,6 @@ export const AudioMatchingRewardsModalContent = ({
       subtext={messages.rewardMapping[challengeName]}
     />
   )
-
-  const progressStatusLabel =
-    userChallenge && userChallenge?.disbursed_amount > 0 ? (
-      <Flex
-        alignItems='center'
-        justifyContent='center'
-        ph='xl'
-        pv='l'
-        borderTop='strong'
-        backgroundColor='surface2'
-      >
-        <Text variant='label' size='l' strength='strong'>
-          {messages.totalClaimed(
-            formatNumberCommas(userChallenge.disbursed_amount.toString())
-          )}
-        </Text>
-      </Flex>
-    ) : null
 
   const handleClickCTA = useCallback(() => {
     const route =

--- a/packages/web/src/pages/rewards-page/components/modals/ChallengeRewardsModal/DefaultChallengeContent.tsx
+++ b/packages/web/src/pages/rewards-page/components/modals/ChallengeRewardsModal/DefaultChallengeContent.tsx
@@ -4,8 +4,6 @@ import { ChallengeName } from '@audius/common/models'
 import { audioRewardsPageSelectors, ClaimStatus } from '@audius/common/store'
 import {
   challengeRewardsConfig,
-  fillString,
-  formatNumberCommas,
   getChallengeStatusLabel
 } from '@audius/common/utils'
 import { Button, Flex, IconVerified, Text, IconCheck } from '@audius/harmony'

--- a/packages/web/src/pages/rewards-page/components/modals/ChallengeRewardsModal/DefaultChallengeContent.tsx
+++ b/packages/web/src/pages/rewards-page/components/modals/ChallengeRewardsModal/DefaultChallengeContent.tsx
@@ -95,7 +95,6 @@ export const DefaultChallengeContent = ({
       </Flex>
     </Flex>
   )
-  console.log('REED', { challenge })
 
   const goToRoute = useCallback(
     (route: string) => {

--- a/packages/web/src/pages/rewards-page/components/modals/ChallengeRewardsModal/DefaultChallengeContent.tsx
+++ b/packages/web/src/pages/rewards-page/components/modals/ChallengeRewardsModal/DefaultChallengeContent.tsx
@@ -5,7 +5,8 @@ import { audioRewardsPageSelectors, ClaimStatus } from '@audius/common/store'
 import {
   challengeRewardsConfig,
   fillString,
-  formatNumberCommas
+  formatNumberCommas,
+  getChallengeStatusLabel
 } from '@audius/common/utils'
 import { Button, Flex, IconVerified, Text, IconCheck } from '@audius/harmony'
 import { useDispatch, useSelector } from 'react-redux'
@@ -42,16 +43,10 @@ export const DefaultChallengeContent = ({
 
   const config = challengeRewardsConfig[challengeName as ChallengeName] ?? {
     fullDescription: () => '',
-    progressLabel: '',
     completedLabel: '',
     isVerifiedChallenge: false
   }
-  const {
-    fullDescription,
-    progressLabel,
-    completedLabel,
-    isVerifiedChallenge
-  } = config
+  const { fullDescription, completedLabel, isVerifiedChallenge } = config
 
   const isProgressBarVisible =
     challenge &&
@@ -95,19 +90,12 @@ export const DefaultChallengeContent = ({
       <Flex alignItems='center' gap='s'>
         {isChallengeCompleted ? <IconCheck size='s' color='subdued' /> : null}
         <Text variant='label' size='l' strength='strong' color='subdued'>
-          {progressLabel
-            ? fillString(
-                progressLabel,
-                formatNumberCommas(
-                  challenge?.current_step_count?.toString() ?? ''
-                ),
-                formatNumberCommas(challenge?.max_steps?.toString() ?? '')
-              )
-            : null}
+          {getChallengeStatusLabel(challenge, challengeName)}
         </Text>
       </Flex>
     </Flex>
   )
+  console.log('REED', { challenge })
 
   const goToRoute = useCallback(
     (route: string) => {

--- a/packages/web/src/pages/rewards-page/components/modals/ChallengeRewardsModal/ListenStreakChallengeModalContent.tsx
+++ b/packages/web/src/pages/rewards-page/components/modals/ChallengeRewardsModal/ListenStreakChallengeModalContent.tsx
@@ -37,7 +37,6 @@ export const ListenStreakChallengeModalContent = ({
   const { fullDescription } = challengeRewardsConfig[challengeName]
   const userChallenge = useSelector(getOptimisticUserChallenges)[challengeName]
 
-  console.log('REED', { userChallenge })
   const progressDescription = (
     <ProgressDescription
       description={<Text variant='body'>{fullDescription?.(challenge)}</Text>}

--- a/packages/web/src/pages/rewards-page/components/modals/ChallengeRewardsModal/ListenStreakChallengeModalContent.tsx
+++ b/packages/web/src/pages/rewards-page/components/modals/ChallengeRewardsModal/ListenStreakChallengeModalContent.tsx
@@ -1,7 +1,8 @@
 import { challengesSelectors } from '@audius/common/store'
 import {
   formatNumberCommas,
-  challengeRewardsConfig
+  challengeRewardsConfig,
+  getChallengeStatusLabel
 } from '@audius/common/utils'
 import { Flex, IconHeadphones, Text } from '@audius/harmony'
 import { useSelector } from 'react-redux'
@@ -36,6 +37,7 @@ export const ListenStreakChallengeModalContent = ({
   const { fullDescription } = challengeRewardsConfig[challengeName]
   const userChallenge = useSelector(getOptimisticUserChallenges)[challengeName]
 
+  console.log('REED', { userChallenge })
   const progressDescription = (
     <ProgressDescription
       description={<Text variant='body'>{fullDescription?.(challenge)}</Text>}
@@ -67,7 +69,7 @@ export const ListenStreakChallengeModalContent = ({
         >
           <IconHeadphones size='m' color='subdued' />
           <Text variant='label' size='l' color='subdued'>
-            {messages.day(userChallenge.current_step_count)}
+            {getChallengeStatusLabel(userChallenge, challengeName)}
           </Text>
         </Flex>
         {userChallenge.disbursed_amount ? (


### PR DESCRIPTION
### Description
Util fn for determining the progress status label text to display. Lots of special-casing.

Will follow-up with mobile. Mobile still needs the nice refactor we did on web.

Also styling is borked on audio matching challenge, will follow-up in separate PR.

### How Has This Been Tested?
Local web stage/prod. Lots of cases so will try to qa over the next few days.
<img width="745" alt="Screenshot 2025-02-20 at 5 31 38 PM" src="https://github.com/user-attachments/assets/2aedd53a-7ead-4606-800c-0265fe575e66" />
<img width="752" alt="Screenshot 2025-02-20 at 5 31 47 PM" src="https://github.com/user-attachments/assets/f9a4a58d-5a43-4ff6-ad79-7664561f2aaa" />
<img width="770" alt="Screenshot 2025-02-20 at 5 32 15 PM" src="https://github.com/user-attachments/assets/f8a89b9e-e322-4bee-a72c-24940660b105" />
<img width="741" alt="Screenshot 2025-02-20 at 5 32 23 PM" src="https://github.com/user-attachments/assets/0db0379f-7f99-412e-9295-a62b28d9032b" />
