### PR TITLE
Don't add computeLimit instruction to buyAudio flow swap

### DIFF
--- a/packages/web/src/store/application/ui/buy-audio/sagas.ts
+++ b/packages/web/src/store/application/ui/buy-audio/sagas.ts
@@ -660,7 +660,8 @@ function* getSwapTransaction({
       addressLookupTables: lookupTableAddresses.map(
         (address) => new PublicKey(address)
       ),
-      priorityFee: null // already has compute budget instructions from Jupiter
+      priorityFee: null, // already has compute budget instructions from Jupiter
+      computeLimit: null // already has compute budget instructions from Jupiter
     }
   )
   return transaction


### PR DESCRIPTION
Duplicate ComputeBudget instructions setting the compute limit cause the swap transaction never to be picked up by the validators.