### PR TITLE
[QA-1995] Fix manager mode dropdown rendering off screen

### DIFF
--- a/packages/web/src/components/nav/desktop/AccountSwitcher/AccountListContent.tsx
+++ b/packages/web/src/components/nav/desktop/AccountSwitcher/AccountListContent.tsx
@@ -1,4 +1,10 @@
-import { ReactNode, useCallback, useMemo } from 'react'
+import {
+  ReactNode,
+  useCallback,
+  useLayoutEffect,
+  useMemo,
+  useState
+} from 'react'
 
 import { ID, ManagedUserMetadata, UserMetadata } from '@audius/common/models'
 import {
@@ -9,6 +15,8 @@ import {
   Text,
   useTheme
 } from '@audius/harmony'
+
+import { useMainContentRef } from 'pages/MainContentContext'
 
 import { AccountSwitcherRow } from './AccountSwitcherRow'
 
@@ -34,7 +42,9 @@ export const AccountListContent = ({
   navBackElement,
   fullWidth
 }: AccountListContentProps) => {
+  const mainContentRef = useMainContentRef()
   const { spacing } = useTheme()
+  const [contentHeight, setContentHeight] = useState(0)
   // If the current user is one of the managed account, sort it to the top of
   // the list
   const accounts = useMemo(() => {
@@ -46,6 +56,15 @@ export const AccountListContent = ({
     const selectedAccount = withoutSelected.splice(selectedIdx, 1)[0]
     return [selectedAccount, ...withoutSelected]
   }, [accountsProp, currentUserId])
+
+  // Tracking mainContent height so we can ensure the account list
+  // stays well within the viewport
+  useLayoutEffect(() => {
+    if (mainContentRef.current) {
+      const { height } = mainContentRef.current.getBoundingClientRect()
+      setContentHeight(height)
+    }
+  }, [mainContentRef])
 
   const onUserSelected = useCallback(
     (user: UserMetadata) => {
@@ -61,10 +80,8 @@ export const AccountListContent = ({
       w={fullWidth ? '100%' : 360}
       backgroundColor='white'
       css={{
-        // Make sure the popup has at least 24 unites of space from the
-        // top of the page and 16 units from the bottom.
-        maxHeight: `calc(100vh - ${spacing.unit24 + spacing.unit16}px)`,
-        overflow: 'hidden'
+        overflow: 'hidden',
+        maxHeight: `calc(${contentHeight}px - ${spacing.unit12}px)`
       }}
     >
       <Flex


### PR DESCRIPTION
### Description
Fun!
Due to the logic used in `Popup` for positioning the content, if you attempt to render something that's bigger than the viewport it has a good chance of being offset off the bottom of the screen. While there might be a more elegant fix to this in the popup logic, that seems pretty intense for little benefit and high potential of breaking things.

An easier way to do this is to make sure you don't render something that would exceed the bounds of the container where the popup portal is mounted. We were mostly achieving this by limiting the size to the viewport height minus some fixed amounts. This breaks when we render a banner, since it's a static component that pushes all the body content down without changing the viewport size.

A more reliable method is to use the bounding rect of the `mainContentRef` since that _will_ change accordingly when we render a banner. So I updated the content element for the account switcher to measure the mainContentRef in a layout effect and subtract a fixed padding amount from it.

### How Has This Been Tested?
1. Reproduced this with a short account list by resizing my browser down to a small height
2. Reproduced with a long list by hardcoding some random accounts into the list component to make it long
Both cases work fine now with the updated layout calculation.
