### PR TITLE
Fix comment history page infinite loading

### DIFF
--- a/packages/web/src/pages/comment-history/components/desktop/CommentHistoryPage.tsx
+++ b/packages/web/src/pages/comment-history/components/desktop/CommentHistoryPage.tsx
@@ -215,7 +215,7 @@ export const CommentHistoryPage = ({ title }: CommentHistoryPageProps) => {
           getScrollParent={getScrollParent}
           useWindow={false}
           css={{ width: '100%' }}
-          threshold={-250}
+          threshold={250}
         >
           <Flex direction='column' p='xl' gap='l'>
             {isPending ? (


### PR DESCRIPTION
### Description
Negative sign got in the scroll threshold somehow. Fixed and now the loading is working

### How Has This Been Tested?
Manually Tested