### PR TITLE
Get user pubkey from registered peer if unable to recover.

### DIFF
--- a/comms/discovery/discovery_main.go
+++ b/comms/discovery/discovery_main.go
@@ -57,7 +57,7 @@ func DiscoveryMain() {
 			return err
 		}
 
-		go pubkeystore.StartPubkeyBackfill()
+		go pubkeystore.StartPubkeyBackfill(discoveryConfig)
 
 		return nil
 

--- a/comms/discovery/pubkeystore/backfill.go
+++ b/comms/discovery/pubkeystore/backfill.go
@@ -35,13 +35,14 @@ func StartPubkeyBackfill(config *config.DiscoveryConfig) {
 		for _, id := range ids {
 			_, err := RecoverUserPublicKeyBase64(ctx, id)
 			if err != nil {
-				slog.Debug("pubkey backfill: failed to recover", "user_id", id, "err", err)
+				slog.Debug("pubkey backfill: chain recovery failed", "user_id", id, "err", err)
+
+				err = recoverFromPeers(config, id)
+				if err != nil {
+					slog.Debug("pubkey backfill: peer recovery failed", "user_id", id, "err", err)
+				}
 			}
 
-			err = recoverFromPeers(config, id)
-			if err != nil {
-				slog.Debug("pubkey backfill: peer recovery failed", "user_id", id, "err", err)
-			}
 		}
 
 		time.Sleep(time.Minute * 8)

--- a/comms/discovery/pubkeystore/recover.go
+++ b/comms/discovery/pubkeystore/recover.go
@@ -82,8 +82,7 @@ func RecoverUserPublicKeyBase64(ctx context.Context, userId int) (string, error)
 	conn := db.Conn
 
 	// first check a "pubkey cache" for a hit
-	// see: https://github.com/AudiusProject/audius-docker-compose/blob/nats/discovery-provider/clusterizer/src/recover.ts#L65
-	if got, err := getPubkey(userId); err == nil {
+	if got, err := GetPubkey(userId); err == nil {
 		return got, nil
 	}
 

--- a/comms/discovery/server/server.go
+++ b/comms/discovery/server/server.go
@@ -67,6 +67,7 @@ func NewServer(discoveryConfig *config.DiscoveryConfig, proc *rpcz.RPCProcessor)
 	unfurlHeaders := unfurlist.WithExtraHeaders(map[string]string{"User-Agent": "twitterbot"})
 	g.GET("/unfurl", echo.WrapHandler(unfurlist.New(unfurlBlocklist, unfurlHeaders)))
 	g.GET("/pubkey/:id", s.getPubkey)
+	g.GET("/pubkey/:id/cached", s.getCachedPubkey)
 	g.GET("/chats", s.getChats)
 	g.GET("/chats/ws", s.chatWebsocket)
 	g.GET("/chats/:id", s.getChat)
@@ -189,6 +190,21 @@ func (s *ChatServer) getPubkey(c echo.Context) error {
 
 	return c.JSON(200, map[string]interface{}{
 		"data": pubkey,
+	})
+}
+
+func (s *ChatServer) getCachedPubkey(c echo.Context) error {
+	id, err := misc.DecodeHashId(c.Param("id"))
+	if err != nil {
+		return c.String(400, "bad id parameter: "+err.Error())
+	}
+
+	hit, err := pubkeystore.GetPubkey(id)
+	if err != nil {
+		return c.String(404, "not found")
+	}
+	return c.JSON(200, map[string]interface{}{
+		"data": hit,
 	})
 }
 


### PR DESCRIPTION
Some newer nodes are missing pubkeys and unable to get them from POA gateway.
Allow them to get pubkey from a registered peer.