### PR TITLE
Fix user list crash on null handle

### DIFF
--- a/packages/web/src/components/artist/ArtistPopover.tsx
+++ b/packages/web/src/components/artist/ArtistPopover.tsx
@@ -56,7 +56,7 @@ export const ArtistPopover = ({
 }: ArtistPopoverProps) => {
   const [isPopupVisible, setIsPopupVisible] = useState(false)
   const creator = useSelector((state: CommonState) =>
-    getUser(state, { handle: handle.toLowerCase() })
+    getUser(state, { handle: handle?.toLowerCase() })
   )
   const userId = useSelector(getUserId)
 

--- a/packages/web/src/components/user-list/UserList.tsx
+++ b/packages/web/src/components/user-list/UserList.tsx
@@ -88,6 +88,7 @@ export const UserList = ({
     .map((id) => usersMap[id])
     .filter(Boolean)
     .filter((u) => !u.is_deactivated)
+    .filter((u) => !!u.handle)
 
   const handleFollow = (userId: ID) => {
     dispatch(socialActions.followUser(userId, FollowSource.USER_LIST))


### PR DESCRIPTION
### Description

Fixes case where a user with null handle breaks UserList
- Filter null handle users from UserList
- To be extra defensive, added a guard in `ArtistPopover` where the error occurred

Downside is that in case of null user, we show fewer entries in the list than the `favorite_count` claims. Possible there's a better solution or we can display some sort of unknown or anonymous user in the list.
![image](https://github.com/user-attachments/assets/3e2d8eb6-fe9c-44f3-a8d1-8d7fa069297d)

### How Has This Been Tested?

no longer crashes