### PR TITLE
Fix gutters for profile page

### DIFF
--- a/packages/web/src/common/utils/layout.ts
+++ b/packages/web/src/common/utils/layout.ts
@@ -1,1 +1,2 @@
 export const MAX_PAGE_WIDTH_PX = 1080
+export const PAGE_GUTTER_PX = 60

--- a/packages/web/src/components/page/FlushPageContainer.tsx
+++ b/packages/web/src/components/page/FlushPageContainer.tsx
@@ -1,0 +1,16 @@
+import { Box, Flex, FlexProps } from '@audius/harmony'
+
+import { MAX_PAGE_WIDTH_PX, PAGE_GUTTER_PX } from 'common/utils/layout'
+
+export const FlushPageContainer = (props: FlexProps) => {
+  const { children, ...flexProps } = props
+  return (
+    <Flex w='100%' justifyContent='center' {...flexProps}>
+      <Box flex={`0 0 ${PAGE_GUTTER_PX}px`} />
+      <Flex flex='1 1 100%' css={{ maxWidth: MAX_PAGE_WIDTH_PX }}>
+        {children}
+      </Flex>
+      <Box flex={`0 0 ${PAGE_GUTTER_PX}px`} />
+    </Flex>
+  )
+}

--- a/packages/web/src/components/page/FlushPageContainer.tsx
+++ b/packages/web/src/components/page/FlushPageContainer.tsx
@@ -1,16 +1,24 @@
-import { Box, Flex, FlexProps } from '@audius/harmony'
+import { Flex, FlexProps } from '@audius/harmony'
 
 import { MAX_PAGE_WIDTH_PX, PAGE_GUTTER_PX } from 'common/utils/layout'
 
 export const FlushPageContainer = (props: FlexProps) => {
   const { children, ...flexProps } = props
   return (
-    <Flex w='100%' justifyContent='center' {...flexProps}>
-      <Box flex={`0 0 ${PAGE_GUTTER_PX}px`} />
-      <Flex flex='1 1 100%' css={{ maxWidth: MAX_PAGE_WIDTH_PX }}>
+    <Flex
+      w='100%'
+      flex='1 1 0'
+      ph={PAGE_GUTTER_PX}
+      justifyContent='center'
+      {...flexProps}
+    >
+      <Flex
+        flex='1 1 100%'
+        justifyContent='center'
+        css={{ maxWidth: MAX_PAGE_WIDTH_PX }}
+      >
         {children}
       </Flex>
-      <Box flex={`0 0 ${PAGE_GUTTER_PX}px`} />
     </Flex>
   )
 }

--- a/packages/web/src/components/page/Page.tsx
+++ b/packages/web/src/components/page/Page.tsx
@@ -7,14 +7,14 @@ import {
   MutableRefObject
 } from 'react'
 
-import { Box, Flex } from '@audius/harmony'
+import { Box } from '@audius/harmony'
 import { animated, useSpring } from '@react-spring/web'
 import cn from 'classnames'
 
-import { MAX_PAGE_WIDTH_PX } from 'common/utils/layout'
 import { MetaTags, MetaTagsProps } from 'components/meta-tags/MetaTags'
 import DesktopSearchBar from 'components/search-bar/ConnectedSearchBar'
 
+import { FlushPageContainer } from './FlushPageContainer'
 import styles from './Page.module.css'
 
 const HEADER_MARGIN_PX = 32
@@ -170,15 +170,11 @@ export const Page = (props: PageProps) => {
                 right: 0
               }}
             >
-              <Flex
-                justifyContent='flex-start'
-                flex='1 1 100%'
-                mh='auto'
-                mt='2xl'
-                css={{ maxWidth: MAX_PAGE_WIDTH_PX }}
-              >
-                <DesktopSearchBar />
-              </Flex>
+              <FlushPageContainer mt='2xl'>
+                <Box alignSelf='flex-start'>
+                  <DesktopSearchBar />
+                </Box>
+              </FlushPageContainer>
             </Box>
           ) : (
             <div className={styles.searchWrapper}>

--- a/packages/web/src/components/page/Page.tsx
+++ b/packages/web/src/components/page/Page.tsx
@@ -7,7 +7,7 @@ import {
   MutableRefObject
 } from 'react'
 
-import { Box } from '@audius/harmony'
+import { Box, Flex } from '@audius/harmony'
 import { animated, useSpring } from '@react-spring/web'
 import cn from 'classnames'
 
@@ -171,9 +171,9 @@ export const Page = (props: PageProps) => {
               }}
             >
               <FlushPageContainer mt='2xl'>
-                <Box alignSelf='flex-start'>
+                <Flex flex={1} justifyContent='flex-start'>
                   <DesktopSearchBar />
-                </Box>
+                </Flex>
               </FlushPageContainer>
             </Box>
           ) : (

--- a/packages/web/src/pages/deleted-page/components/desktop/DeletedPage.tsx
+++ b/packages/web/src/pages/deleted-page/components/desktop/DeletedPage.tsx
@@ -6,13 +6,14 @@ import {
   User
 } from '@audius/common/models'
 import { NestedNonNullable } from '@audius/common/utils'
-import { Button, IconUser } from '@audius/harmony'
+import { Button, IconUser, Box } from '@audius/harmony'
 
 import { ArtistPopover } from 'components/artist/ArtistPopover'
 import CoverPhoto from 'components/cover-photo/CoverPhoto'
 import DynamicImage from 'components/dynamic-image/DynamicImage'
 import Lineup, { LineupProps } from 'components/lineup/Lineup'
 import { EmptyNavBanner } from 'components/nav-banner/NavBanner'
+import { FlushPageContainer } from 'components/page/FlushPageContainer'
 import Page from 'components/page/Page'
 import { EmptyStatBanner } from 'components/stat-banner/StatBanner'
 import UserBadges from 'components/user-badges/UserBadges'
@@ -166,10 +167,12 @@ const DeletedPage = g(
           <EmptyStatBanner />
           <EmptyNavBanner />
         </div>
-        <div className={styles.contentWrapper}>
-          {renderTile()}
-          {renderLineup()}
-        </div>
+        <FlushPageContainer>
+          <Box pt={320} pb={100} css={{ position: 'relative' }}>
+            {renderTile()}
+            {renderLineup()}
+          </Box>
+        </FlushPageContainer>
       </Page>
     )
   }

--- a/packages/web/src/pages/profile-page/components/desktop/ProfilePage.tsx
+++ b/packages/web/src/pages/profile-page/components/desktop/ProfilePage.tsx
@@ -39,7 +39,6 @@ import {
 } from '@audius/harmony'
 import cn from 'classnames'
 
-import { MAX_PAGE_WIDTH_PX } from 'common/utils/layout'
 import CollectiblesPage from 'components/collectibles/components/CollectiblesPage'
 import { ConfirmationModal } from 'components/confirmation-modal'
 import CoverPhoto from 'components/cover-photo/CoverPhoto'
@@ -47,6 +46,7 @@ import Lineup from 'components/lineup/Lineup'
 import { LineupVariant } from 'components/lineup/types'
 import Mask from 'components/mask/Mask'
 import NavBanner, { EmptyNavBanner } from 'components/nav-banner/NavBanner'
+import { FlushPageContainer } from 'components/page/FlushPageContainer'
 import Page from 'components/page/Page'
 import ProfilePicture from 'components/profile-picture/ProfilePicture'
 import { ProfileCompletionHeroCard } from 'components/profile-progress/components/ProfileCompletionHeroCard'
@@ -600,104 +600,101 @@ const ProfilePage = ({
           w='100%'
           css={{ position: 'absolute', top: 0 }}
         >
-          <Flex
-            alignItems='center'
-            columnGap={PROFILE_COLUMN_GAP}
-            h={PROFILE_LOCKUP_HEIGHT_PX}
-            css={{ maxWidth: MAX_PAGE_WIDTH_PX }}
-            flex='1 1 100%'
-          >
+          <FlushPageContainer>
             <Flex
-              css={{
-                flexShrink: 0,
-                zIndex: zIndex.PROFILE_EDITABLE_COMPONENTS
-              }}
-              w={PROFILE_LEFT_COLUMN_WIDTH_PX}
-              justifyContent='center'
-            >
-              <ProfilePicture
-                userId={userId}
-                updatedProfilePicture={
-                  updatedProfilePicture ? updatedProfilePicture.url : ''
-                }
-                error={
-                  updatedProfilePicture ? updatedProfilePicture.error : false
-                }
-                profilePictureSizes={isDeactivated ? null : profilePictureSizes}
-                loading={status === Status.LOADING}
-                editMode={editMode}
-                hasProfilePicture={hasProfilePicture}
-                onDrop={updateProfilePicture}
-              />
-            </Flex>
-            <Flex
-              column
+              alignItems='center'
+              columnGap={PROFILE_COLUMN_GAP}
+              h={PROFILE_LOCKUP_HEIGHT_PX}
               flex='1 1 100%'
-              css={{
-                position: 'relative',
-                textAlign: 'left',
-                userSelect: 'none'
-              }}
-              className={styles.nameWrapper}
             >
-              <BadgeArtist
-                className={cn(styles.badgeArtist, {
-                  [styles.hide]:
-                    !isArtist || status === Status.LOADING || isDeactivated
-                })}
-              />
-              {!isDeactivated && userId && (
-                <>
-                  <EditableName
-                    className={editMode ? styles.editableName : styles.name}
-                    name={name}
-                    editable={editMode}
-                    verified={verified}
-                    onChange={updateName}
-                    userId={userId}
-                  />
-                  <Flex alignItems='center' columnGap='s'>
-                    <Text shadow='emphasis' variant='title' color='staticWhite'>
-                      {handle}
-                    </Text>
-                    <FollowsYouBadge userId={userId} />
-                  </Flex>
-                </>
-              )}
+              <Flex
+                css={{
+                  flexShrink: 0,
+                  zIndex: zIndex.PROFILE_EDITABLE_COMPONENTS
+                }}
+                w={PROFILE_LEFT_COLUMN_WIDTH_PX}
+                justifyContent='center'
+              >
+                <ProfilePicture
+                  userId={userId}
+                  updatedProfilePicture={
+                    updatedProfilePicture ? updatedProfilePicture.url : ''
+                  }
+                  error={
+                    updatedProfilePicture ? updatedProfilePicture.error : false
+                  }
+                  profilePictureSizes={
+                    isDeactivated ? null : profilePictureSizes
+                  }
+                  loading={status === Status.LOADING}
+                  editMode={editMode}
+                  hasProfilePicture={hasProfilePicture}
+                  onDrop={updateProfilePicture}
+                />
+              </Flex>
+              <Flex
+                column
+                flex='1 1 100%'
+                css={{
+                  position: 'relative',
+                  textAlign: 'left',
+                  userSelect: 'none'
+                }}
+                className={styles.nameWrapper}
+              >
+                <BadgeArtist
+                  className={cn(styles.badgeArtist, {
+                    [styles.hide]:
+                      !isArtist || status === Status.LOADING || isDeactivated
+                  })}
+                />
+                {!isDeactivated && userId && (
+                  <>
+                    <EditableName
+                      className={editMode ? styles.editableName : styles.name}
+                      name={name}
+                      editable={editMode}
+                      verified={verified}
+                      onChange={updateName}
+                      userId={userId}
+                    />
+                    <Flex alignItems='center' columnGap='s'>
+                      <Text
+                        shadow='emphasis'
+                        variant='title'
+                        color='staticWhite'
+                      >
+                        {handle}
+                      </Text>
+                      <FollowsYouBadge userId={userId} />
+                    </Flex>
+                  </>
+                )}
+              </Flex>
             </Flex>
-          </Flex>
+          </FlushPageContainer>
         </Flex>
 
         {!profile || profile.is_deactivated ? (
           <Box>
             <EmptyStatBanner />
             <EmptyNavBanner />
-            <Flex
-              w='100%'
-              mh='auto'
-              css={{ maxWidth: MAX_PAGE_WIDTH_PX }}
-              columnGap={PROFILE_COLUMN_GAP}
-            >
-              <LeftColumnSpacer />
-              {status === Status.SUCCESS && <DeactivatedProfileTombstone />}
-            </Flex>
+            <FlushPageContainer>
+              <Flex flex='1 1 100%' mh='auto' columnGap={PROFILE_COLUMN_GAP}>
+                <LeftColumnSpacer />
+                {status === Status.SUCCESS && <DeactivatedProfileTombstone />}
+              </Flex>
+            </FlushPageContainer>
           </Box>
         ) : (
           <Mask show={editMode} zIndex={zIndex.PROFILE_EDIT_MASK}>
             {/* StatBanner */}
-            <Flex
+            <FlushPageContainer
               h='unit14'
-              justifyContent='center'
-              w='100%'
               backgroundColor='surface1'
               borderBottom='default'
             >
-              <Flex
-                flex='1 1 100%'
-                h='100%'
-                css={{ maxWidth: MAX_PAGE_WIDTH_PX }}
-                columnGap={PROFILE_COLUMN_GAP}
-              >
+              <Flex flex='1 1 100%' h='100%' columnGap={PROFILE_COLUMN_GAP}>
                 <LeftColumnSpacer />
                 <StatBanner
                   mode={mode}
@@ -726,20 +723,14 @@ const ProfilePage = ({
                   onMute={onMute}
                 />
               </Flex>
-            </Flex>
+            </FlushPageContainer>
             {/* NavBanner */}
-            <Flex
-              h='unit14'
-              justifyContent='center'
-              w='100%'
-              backgroundColor='white'
-            >
+            <FlushPageContainer h='unit14' backgroundColor='white'>
               <Flex
                 flex='1 1 100%'
                 h='unit12'
                 alignSelf='flex-end'
                 justifyContent='flex-start'
-                css={{ maxWidth: MAX_PAGE_WIDTH_PX }}
                 columnGap={PROFILE_COLUMN_GAP}
               >
                 <LeftColumnSpacer />
@@ -753,14 +744,10 @@ const ProfilePage = ({
                   onSortByPopular={onSortByPopular}
                 />
               </Flex>
-            </Flex>
+            </FlushPageContainer>
             {/* Left side and Tab Content */}
-            <Flex w='100%' justifyContent='center' pt='2xl'>
-              <Flex
-                flex='1 1 100%'
-                columnGap={PROFILE_COLUMN_GAP}
-                css={{ maxWidth: MAX_PAGE_WIDTH_PX }}
-              >
+            <FlushPageContainer pt='2xl'>
+              <Flex flex='1 1 100%' columnGap={PROFILE_COLUMN_GAP}>
                 <ProfileLeftNav
                   userId={userId}
                   isDeactivated={isDeactivated}
@@ -791,7 +778,7 @@ const ProfilePage = ({
                 />
                 <Box flex='1 1 100%'>{body}</Box>
               </Flex>
-            </Flex>
+            </FlushPageContainer>
           </Mask>
         )}
       </Box>

--- a/packages/web/src/pages/track-page/components/desktop/TrackPage.tsx
+++ b/packages/web/src/pages/track-page/components/desktop/TrackPage.tsx
@@ -11,6 +11,7 @@ import CoverPhoto from 'components/cover-photo/CoverPhoto'
 import Lineup from 'components/lineup/Lineup'
 import { LineupVariant } from 'components/lineup/types'
 import { EmptyNavBanner } from 'components/nav-banner/NavBanner'
+import { FlushPageContainer } from 'components/page/FlushPageContainer'
 import Page from 'components/page/Page'
 import { EmptyStatBanner } from 'components/stat-banner/StatBanner'
 import { GiantTrackTile } from 'components/track/GiantTrackTile'
@@ -237,119 +238,125 @@ const TrackPage = ({
         <EmptyStatBanner />
         <EmptyNavBanner />
       </Box>
-      <Flex
-        direction='column'
-        css={{ position: 'relative', padding: '200px 16px 60px' }}
-      >
-        {renderGiantTrackTile()}
-        {hasRemixes && !commentsFlagEnabled ? (
-          <Flex justifyContent='center' mt='3xl' ph='l'>
-            <Remixes
-              trackIds={defaults.remixTrackIds!}
-              goToAllRemixes={goToAllRemixesPage}
-              count={defaults.remixesCount}
-            />
-          </Flex>
-        ) : null}
+      <FlushPageContainer>
         <Flex
-          gap='2xl'
-          w='100%'
-          direction={isDesktop ? 'row' : 'column'}
-          mt='3xl'
-          mh='auto'
-          css={{ maxWidth: 1080 }}
-          justifyContent='center'
+          direction='column'
+          pt={200}
+          pb={60}
+          css={{ position: 'relative' }}
         >
-          {isCommentingEnabled ? (
-            <Flex flex='3'>
-              <CommentSection
-                entityId={defaults.trackId}
-                commentSectionRef={commentSectionRef}
+          {renderGiantTrackTile()}
+          {hasRemixes && !commentsFlagEnabled ? (
+            <Flex justifyContent='center' mt='3xl' ph='l'>
+              <Remixes
+                trackIds={defaults.remixTrackIds!}
+                goToAllRemixes={goToAllRemixesPage}
+                count={defaults.remixesCount}
               />
             </Flex>
           ) : null}
-          {hasRemixes || hasMoreByTracks ? (
-            <Flex
-              direction='column'
-              alignItems={
-                isCommentingEnabled && isDesktop ? 'flex-start' : 'center'
-              }
-              gap='2xl'
-              flex={1}
-              css={{
-                minWidth: 330,
-                maxWidth: isCommentingEnabled ? '100%' : '774px'
-              }}
-            >
-              {hasRemixes ? <TrackRemixes trackId={defaults.trackId} /> : null}
-              <Flex
-                direction='column'
-                alignItems='flex-start'
-                justifyContent='center'
-                gap='l'
-                w='100%'
-              >
-                {hasValidRemixParent
-                  ? renderOriginalTrackTitle()
-                  : renderMoreByTitle()}
-                <Lineup
-                  lineup={tracks}
-                  // Styles for leading element (original track if remix).
-                  leadingElementId={defaults.remixParentTrackId}
-                  leadingElementDelineator={
-                    <Flex gap='3xl' direction='column'>
-                      <Box
-                        alignSelf={
-                          isCommentingEnabled ? 'flex-start' : 'center'
-                        }
-                      >
-                        <ViewOtherRemixesButton
-                          parentTrackId={defaults.remixParentTrackId!}
-                          size={isCommentingEnabled ? 'xs' : 'small'}
-                        />
-                      </Box>
-                      <Flex
-                        mb='l'
-                        justifyContent={
-                          isCommentingEnabled ? 'flex-start' : 'center'
-                        }
-                      >
-                        {renderMoreByTitle()}
-                      </Flex>
-                    </Flex>
-                  }
-                  leadingElementTileProps={{ size: TrackTileSize.LARGE }}
-                  laggingContainerClassName={
-                    !isCommentingEnabled
-                      ? styles.moreByArtistContainer
-                      : undefined
-                  }
-                  lineupContainerStyles={styles.width100}
-                  applyLeadingElementStylesToSkeleton
-                  // Don't render the first tile in the lineup since it's actually the "giant"
-                  // track tile this page is about.
-                  start={1}
-                  // Show max 5 loading tiles
-                  count={6}
-                  // Managed from the parent rather than allowing the lineup to fetch content itself.
-                  selfLoad={false}
-                  variant={lineupVariant}
-                  playingUid={currentQueueItem.uid}
-                  playingSource={currentQueueItem.source}
-                  playingTrackId={
-                    currentQueueItem.track && currentQueueItem.track.track_id
-                  }
-                  playing={isPlaying}
-                  buffering={isBuffering}
-                  playTrack={play}
-                  pauseTrack={pause}
-                  actions={tracksActions}
+          <Flex
+            gap='2xl'
+            w='100%'
+            direction={isDesktop ? 'row' : 'column'}
+            mt='3xl'
+            mh='auto'
+            css={{ maxWidth: 1080 }}
+            justifyContent='center'
+          >
+            {isCommentingEnabled ? (
+              <Flex flex='3'>
+                <CommentSection
+                  entityId={defaults.trackId}
+                  commentSectionRef={commentSectionRef}
                 />
               </Flex>
-            </Flex>
-          ) : null}
+            ) : null}
+            {hasRemixes || hasMoreByTracks ? (
+              <Flex
+                direction='column'
+                alignItems={
+                  isCommentingEnabled && isDesktop ? 'flex-start' : 'center'
+                }
+                gap='2xl'
+                flex={1}
+                css={{
+                  minWidth: 330,
+                  maxWidth: isCommentingEnabled ? '100%' : '774px'
+                }}
+              >
+                {hasRemixes ? (
+                  <TrackRemixes trackId={defaults.trackId} />
+                ) : null}
+                <Flex
+                  direction='column'
+                  alignItems='flex-start'
+                  justifyContent='center'
+                  gap='l'
+                  w='100%'
+                >
+                  {hasValidRemixParent
+                    ? renderOriginalTrackTitle()
+                    : renderMoreByTitle()}
+                  <Lineup
+                    lineup={tracks}
+                    // Styles for leading element (original track if remix).
+                    leadingElementId={defaults.remixParentTrackId}
+                    leadingElementDelineator={
+                      <Flex gap='3xl' direction='column'>
+                        <Box
+                          alignSelf={
+                            isCommentingEnabled ? 'flex-start' : 'center'
+                          }
+                        >
+                          <ViewOtherRemixesButton
+                            parentTrackId={defaults.remixParentTrackId!}
+                            size={isCommentingEnabled ? 'xs' : 'small'}
+                          />
+                        </Box>
+                        <Flex
+                          mb='l'
+                          justifyContent={
+                            isCommentingEnabled ? 'flex-start' : 'center'
+                          }
+                        >
+                          {renderMoreByTitle()}
+                        </Flex>
+                      </Flex>
+                    }
+                    leadingElementTileProps={{ size: TrackTileSize.LARGE }}
+                    laggingContainerClassName={
+                      !isCommentingEnabled
+                        ? styles.moreByArtistContainer
+                        : undefined
+                    }
+                    lineupContainerStyles={styles.width100}
+                    applyLeadingElementStylesToSkeleton
+                    // Don't render the first tile in the lineup since it's actually the "giant"
+                    // track tile this page is about.
+                    start={1}
+                    // Show max 5 loading tiles
+                    count={6}
+                    // Managed from the parent rather than allowing the lineup to fetch content itself.
+                    selfLoad={false}
+                    variant={lineupVariant}
+                    playingUid={currentQueueItem.uid}
+                    playingSource={currentQueueItem.source}
+                    playingTrackId={
+                      currentQueueItem.track && currentQueueItem.track.track_id
+                    }
+                    playing={isPlaying}
+                    buffering={isBuffering}
+                    playTrack={play}
+                    pauseTrack={pause}
+                    actions={tracksActions}
+                  />
+                </Flex>
+              </Flex>
+            ) : null}
+          </Flex>
         </Flex>
-      </Flex>
+      </FlushPageContainer>
     </Page>
   )
 }


### PR DESCRIPTION
### Description
I missed adding the gutters to the side of the profile page to keep things from bumping into the edges at smaller widths. This PR adds a `FlushPageContainer` components that implements the layout logic (60px gutters with a responsive max-width 1080px container in the middle) and refactors the profile page to use that instead.

### How Has This Been Tested?
Visual inspection of the profile page on local client against staging.

### Screenshots
Before
<img width="875" alt="image" src="https://github.com/user-attachments/assets/469dae64-0657-4e5d-8b9f-86f22ec3612e" />


------
After
<img width="871" alt="image" src="https://github.com/user-attachments/assets/0b418bc7-4fec-45ef-b976-6a709b734f7a" />
