### PR TITLE
Update copy on purchase flow

### DIFF
--- a/packages/web/src/components/premium-content-purchase-modal/pages/GuestCheckoutPage.tsx
+++ b/packages/web/src/components/premium-content-purchase-modal/pages/GuestCheckoutPage.tsx
@@ -17,6 +17,8 @@ const messages = {
   orContinueGuest: 'Or, continue as a guest.'
 }
 
+const AUDIO_MATCHING_REWARDS_MULTIPLIER = 5
+
 type GuestCheckoutProps = {
   metadata: PurchaseableContentMetadata
   price: number
@@ -55,7 +57,7 @@ export const GuestCheckoutPage = (props: GuestCheckoutProps) => {
           showLabel={false}
           metadata={metadata}
           owner={metadata.user}
-          earnAmount={USDC(price / 100)
+          earnAmount={USDC((price * AUDIO_MATCHING_REWARDS_MULTIPLIER) / 100)
             .round()
             .toShorthand()}
         />

--- a/packages/web/src/components/premium-content-purchase-modal/pages/PurchaseContentPage.tsx
+++ b/packages/web/src/components/premium-content-purchase-modal/pages/PurchaseContentPage.tsx
@@ -37,6 +37,8 @@ type PurchaseContentPageProps = Pick<
   metadata: PurchaseableContentMetadata
 }
 
+const AUDIO_MATCHING_REWARDS_MULTIPLIER = 5
+
 export const PurchaseContentPage = (props: PurchaseContentPageProps) => {
   const { price, purchaseSummaryValues, stage, isUnlocking, metadata } = props
   const payExtraAmountPresetValues = usePayExtraPresets()
@@ -123,7 +125,7 @@ export const PurchaseContentPage = (props: PurchaseContentPageProps) => {
           metadata={metadata}
           owner={metadata.user}
           disabled={isLinkDisabled}
-          earnAmount={USDC(price / 100)
+          earnAmount={USDC((price * AUDIO_MATCHING_REWARDS_MULTIPLIER) / 100)
             .round()
             .toShorthand()}
         />


### PR DESCRIPTION
### Description
Copy did not reflect audio match multiplier bump 

### How Has This Been Tested?

`npm run web:stage`

- go to purchase a usdc gated track and ensure it reflects the correct amount of tokens 

<img width="712" alt="image" src="https://github.com/user-attachments/assets/73333c1c-074e-47a8-a3a0-5a460b3df085" />

