### PR TITLE
Web referral challenge UI updates

### DIFF
--- a/packages/common/src/models/AudioRewards.ts
+++ b/packages/common/src/models/AudioRewards.ts
@@ -59,9 +59,6 @@ export enum ChallengeName {
 
 export type ChallengeRewardID =
   | 'track-upload'
-  | 'referrals'
-  | 'ref-v'
-  | 'referred'
   | 'mobile-install'
   | 'connect-verified'
   | 'listen-streak'

--- a/packages/common/src/utils/challenges.ts
+++ b/packages/common/src/utils/challenges.ts
@@ -27,17 +27,6 @@ export const challengeRewardsConfig: Record<
   ChallengeRewardID,
   ChallengeRewardsInfo
 > = {
-  referrals: {
-    id: 'referrals',
-    title: 'Invite Your Friends!',
-    description: (challenge) =>
-      `Earn ${challenge?.amount} $AUDIO for you and your friend.`,
-    fullDescription: (challenge) =>
-      `Invite your Friends! You’ll earn ${challenge?.amount} $AUDIO for each friend who joins with your link (and they’ll get an $AUDIO too)`,
-    progressLabel: '%0/%1 Invites Accepted',
-    remainingLabel: '%0/%1 Invites Remain',
-    panelButtonText: 'Invite Your Friends'
-  },
   [ChallengeName.Referrals]: {
     id: ChallengeName.Referrals,
     title: 'Invite Your Friends!',
@@ -45,21 +34,9 @@ export const challengeRewardsConfig: Record<
       `Earn ${challenge?.amount} $AUDIO for you and your friend.`,
     fullDescription: (challenge) =>
       `Invite your Friends! You’ll earn ${challenge?.amount} $AUDIO for each friend who joins with your link (and they’ll get an $AUDIO too)`,
-    progressLabel: '%0/%1 Invites Accepted',
-    remainingLabel: '%0/%1 Invites Remain',
+    progressLabel: '%0 Invites Accepted',
+    remainingLabel: '%0 Invites Remain',
     panelButtonText: 'Invite Your Friends'
-  },
-  'ref-v': {
-    id: 'ref-v',
-    title: 'Invite your Fans',
-    description: (challenge) =>
-      `Earn up to ${formatNumberCommas(challenge?.totalAmount ?? '')} $AUDIO`,
-    fullDescription: (challenge) =>
-      `Invite your fans! You’ll earn ${challenge?.amount} $AUDIO for each fan who joins with your link (and they’ll get an $AUDIO too)`,
-    progressLabel: '%0/%1 Invites Accepted',
-    remainingLabel: '%0/%1 Invites Remain',
-    panelButtonText: 'Invite your Fans',
-    isVerifiedChallenge: true
   },
   [ChallengeName.ReferralsVerified]: {
     id: ChallengeName.ReferralsVerified,
@@ -68,20 +45,9 @@ export const challengeRewardsConfig: Record<
       `Earn up to ${formatNumberCommas(challenge?.totalAmount ?? '')} $AUDIO`,
     fullDescription: (challenge) =>
       `Invite your fans! You’ll earn ${challenge?.amount} $AUDIO for each fan who joins with your link (and they’ll get an $AUDIO too)`,
-    progressLabel: '%0/%1 Invites Accepted',
-    remainingLabel: '%0/%1 Invites Remain',
-    panelButtonText: 'Invite your Fans',
-    isVerifiedChallenge: true
-  },
-  referred: {
-    id: 'referred',
-    title: 'You Accepted An Invite',
-    description: (challenge) =>
-      `You earned ${challenge?.totalAmount ?? ''} $AUDIO for being invited.`,
-    fullDescription: (challenge) =>
-      `You earned ${challenge?.totalAmount ?? ''} $AUDIO for being invited.`,
-    progressLabel: 'Not Earned',
-    panelButtonText: 'More Info'
+    progressLabel: '%0 Invites Accepted',
+    remainingLabel: '%0 Invites Remain',
+    panelButtonText: 'Invite your Fans'
   },
   [ChallengeName.Referred]: {
     id: ChallengeName.Referred,
@@ -470,7 +436,7 @@ export const getChallengeStatusLabel = (
 
     case ChallengeName.Referrals:
     case ChallengeName.ReferralsVerified:
-      return `${challenge.current_step_count ?? 0}/${challenge.max_steps ?? 0} Invites Remaining`
+      return `${(challenge?.max_steps ?? 0) - (challenge?.current_step_count ?? 0)} Invites Remaining`
 
     case ChallengeName.ProfileCompletion:
       return `${challenge.current_step_count ?? 0}/7 Complete`

--- a/packages/mobile/src/components/challenge-rewards-drawer/DefaultChallengeContent.tsx
+++ b/packages/mobile/src/components/challenge-rewards-drawer/DefaultChallengeContent.tsx
@@ -32,7 +32,6 @@ export const DefaultChallengeContent = ({
   const config = challengeRewardsConfig[challengeName] ?? {
     fullDescription: () => '',
     completedLabel: '',
-    isVerifiedChallenge: false,
     progressLabel: ''
   }
   const { fullDescription } = config

--- a/packages/mobile/src/screens/notifications-screen/Notifications/ChallengeRewardNotification.tsx
+++ b/packages/mobile/src/screens/notifications-screen/Notifications/ChallengeRewardNotification.tsx
@@ -84,8 +84,6 @@ export const ChallengeRewardNotification = (
           return messages.streakMilestone(amountEarned, listenStreak ?? 0)
         }
         return messages.streakMaintenance(amountEarned)
-      case 'referred':
-        return `${messages.amountEarned(amount)} ${messages.referredText}`
       default:
         return `${messages.amountEarned(amount)} ${messages.challengeCompleteText}`
     }

--- a/packages/mobile/src/screens/rewards-screen/ChallengeRewardsTile.tsx
+++ b/packages/mobile/src/screens/rewards-screen/ChallengeRewardsTile.tsx
@@ -40,13 +40,10 @@ const { getOptimisticUserChallenges } = challengesSelectors
 
 const validRewardIds: Set<ChallengeRewardID> = new Set([
   'track-upload',
-  'referrals',
-  'ref-v',
   'mobile-install',
   'connect-verified',
   'listen-streak',
   'profile-completion',
-  'referred',
   'send-first-tip',
   'first-playlist',
   ChallengeName.AudioMatchingBuy, // $AUDIO matching buyer

--- a/packages/mobile/src/screens/rewards-screen/ChallengeRewardsTile.tsx
+++ b/packages/mobile/src/screens/rewards-screen/ChallengeRewardsTile.tsx
@@ -128,7 +128,6 @@ export const ChallengeRewardsTile = () => {
   // The referred challenge only needs a tile if the user was referred
   const hideReferredTile = !userChallenges.referred?.is_complete
   const rewardIds = useRewardIds({
-    referred: hideReferredTile,
     [ChallengeName.Referred]: hideReferredTile
   })
 

--- a/packages/mobile/src/utils/challenges.tsx
+++ b/packages/mobile/src/utils/challenges.tsx
@@ -126,20 +126,11 @@ const mobileChallengeConfig: Record<ChallengeRewardID, MobileChallengeConfig> =
     [ChallengeName.ProfileCompletion]: {
       icon: BallotBoxTick
     },
-    referrals: {
-      icon: IncomingEnvelope
-    },
     [ChallengeName.Referrals]: {
-      icon: IncomingEnvelope
-    },
-    'ref-v': {
       icon: IncomingEnvelope
     },
     [ChallengeName.ReferralsVerified]: {
       icon: IncomingEnvelope
-    },
-    referred: {
-      icon: LoveLetter
     },
     [ChallengeName.Referred]: {
       icon: LoveLetter

--- a/packages/web/src/components/notification/Notification/ChallengeRewardNotification.tsx
+++ b/packages/web/src/components/notification/Notification/ChallengeRewardNotification.tsx
@@ -94,8 +94,6 @@ export const ChallengeRewardNotification = (
         }
         return messages.streakMaintenance(amountEarned)
       }
-      case 'referred':
-        return messages.amountEarned(amount) + messages.referredText
       default:
         return messages.amountEarned(amount) + messages.challengeCompleteText
     }

--- a/packages/web/src/pages/rewards-page/components/ChallengeRewards/ChallengeRewardsTile.tsx
+++ b/packages/web/src/pages/rewards-page/components/ChallengeRewards/ChallengeRewardsTile.tsx
@@ -55,7 +55,6 @@ export const ChallengeRewardsTile = ({
   // The referred challenge only needs a tile if the user was referred
   const hideReferredTile = !userChallenges.referred?.is_complete
   const rewardIds = useRewardIds({
-    referred: hideReferredTile,
     [ChallengeName.Referred]: hideReferredTile
   })
 

--- a/packages/web/src/pages/rewards-page/components/ChallengeRewards/RewardPanel.tsx
+++ b/packages/web/src/pages/rewards-page/components/ChallengeRewards/RewardPanel.tsx
@@ -117,14 +117,8 @@ export const RewardPanel = ({
           />
         </Flex>
         <Flex column h='100%' gap='l' ph='xl' pv='unit9'>
-          <Flex
-            column
-            alignItems='flex-start'
-            justifyContent='space-between'
-            w='100%'
-            gap='s'
-          >
-            <Text variant='heading' size='s'>
+          <Flex column alignItems='flex-start' w='100%' gap='s'>
+            <Text variant='heading' size='s' textAlign='left'>
               {title}
             </Text>
             <Flex css={{ minHeight: 40 }}>

--- a/packages/web/src/pages/rewards-page/components/ChallengeRewards/hooks/useRewardIds.ts
+++ b/packages/web/src/pages/rewards-page/components/ChallengeRewards/hooks/useRewardIds.ts
@@ -5,13 +5,10 @@ import { useRemoteVar } from 'hooks/useRemoteConfig'
 
 const validRewardIds: Set<ChallengeRewardID> = new Set([
   'track-upload',
-  'referrals',
-  'ref-v',
   'mobile-install',
   'connect-verified',
   'listen-streak',
   'profile-completion',
-  'referred',
   'send-first-tip',
   'first-playlist',
   ChallengeName.AudioMatchingSell, // $AUDIO matching seller

--- a/packages/web/src/pages/rewards-page/components/modals/ChallengeRewardsModal/ChallengeRewardsLayout.tsx
+++ b/packages/web/src/pages/rewards-page/components/modals/ChallengeRewardsModal/ChallengeRewardsLayout.tsx
@@ -61,7 +61,13 @@ export const ChallengeRewardsLayout = ({
       {isMobile ? (
         <>
           {description}
-          <Paper column shadow='flat' w='100%'>
+          <Paper
+            column
+            shadow='flat'
+            w='100%'
+            border='default'
+            borderRadius='s'
+          >
             <Flex justifyContent='center'>{rewardContent}</Flex>
             {progressContent}
           </Paper>
@@ -69,7 +75,13 @@ export const ChallengeRewardsLayout = ({
         </>
       ) : (
         <>
-          <Paper shadow='flat' w='100%' direction='column' gap='s'>
+          <Paper
+            shadow='flat'
+            w='100%'
+            direction='column'
+            gap='s'
+            borderRadius='s'
+          >
             <Flex justifyContent='space-between' w='100%'>
               {description}
               {rewardContent}

--- a/packages/web/src/pages/rewards-page/components/modals/ChallengeRewardsModal/ChallengeRewardsLayout.tsx
+++ b/packages/web/src/pages/rewards-page/components/modals/ChallengeRewardsModal/ChallengeRewardsLayout.tsx
@@ -61,7 +61,7 @@ export const ChallengeRewardsLayout = ({
       {isMobile ? (
         <>
           {description}
-          <Paper column shadow='flat' w='100%' borderRadius='s'>
+          <Paper column shadow='flat' w='100%'>
             <Flex justifyContent='center'>{rewardContent}</Flex>
             {progressContent}
           </Paper>
@@ -69,13 +69,7 @@ export const ChallengeRewardsLayout = ({
         </>
       ) : (
         <>
-          <Paper
-            shadow='flat'
-            w='100%'
-            direction='column'
-            borderRadius='s'
-            gap='s'
-          >
+          <Paper shadow='flat' w='100%' direction='column' gap='s'>
             <Flex justifyContent='space-between' w='100%'>
               {description}
               {rewardContent}

--- a/packages/web/src/pages/rewards-page/components/modals/ChallengeRewardsModal/ChallengeRewardsLayout.tsx
+++ b/packages/web/src/pages/rewards-page/components/modals/ChallengeRewardsModal/ChallengeRewardsLayout.tsx
@@ -61,13 +61,7 @@ export const ChallengeRewardsLayout = ({
       {isMobile ? (
         <>
           {description}
-          <Paper
-            column
-            shadow='flat'
-            w='100%'
-            border='default'
-            borderRadius='s'
-          >
+          <Paper column shadow='flat' w='100%' borderRadius='s'>
             <Flex justifyContent='center'>{rewardContent}</Flex>
             {progressContent}
           </Paper>
@@ -79,8 +73,8 @@ export const ChallengeRewardsLayout = ({
             shadow='flat'
             w='100%'
             direction='column'
-            gap='s'
             borderRadius='s'
+            gap='s'
           >
             <Flex justifyContent='space-between' w='100%'>
               {description}

--- a/packages/web/src/pages/rewards-page/components/modals/ChallengeRewardsModal/ChallengeRewardsModal.tsx
+++ b/packages/web/src/pages/rewards-page/components/modals/ChallengeRewardsModal/ChallengeRewardsModal.tsx
@@ -9,18 +9,14 @@ import {
   musicConfettiActions
 } from '@audius/common/store'
 import { getAAOErrorEmojis } from '@audius/common/utils'
-import { ModalContent, IconCopy, Button } from '@audius/harmony'
+import { ModalContent } from '@audius/harmony'
 import { useDispatch, useSelector } from 'react-redux'
 
 import { useModalState } from 'common/hooks/useModalState'
 import ModalDrawer from 'components/modal-drawer/ModalDrawer'
-import Toast from 'components/toast/Toast'
 import { ToastContext } from 'components/toast/ToastContext'
-import Tooltip from 'components/tooltip/Tooltip'
-import { ComponentPlacement, MountPlacement } from 'components/types'
 import { useWithMobileStyle } from 'hooks/useWithMobileStyle'
 import { getChallengeConfig } from 'pages/rewards-page/config'
-import { copyToClipboard, getCopyableLink } from 'utils/clipboardUtil'
 import { CLAIM_REWARD_TOAST_TIMEOUT_MILLIS } from 'utils/constants'
 
 import { getChallengeContent } from './challengeContentRegistry'
@@ -32,18 +28,8 @@ const { getAAOErrorCode, getChallengeRewardsModalType, getClaimStatus } =
 const { resetAndCancelClaimReward } = audioRewardsPageActions
 const { getOptimisticUserChallenges } = challengesSelectors
 
-const inviteLink = getCopyableLink('/signup?rf=%0')
-
 const messages = {
   close: 'Close',
-  audio: '$AUDIO',
-  everyDollarSpent: ' Every Dollar Spent',
-  copyLabel: 'Copy to Clipboard',
-  copiedLabel: 'Copied to Clipboard',
-  inviteLabel: 'Copy Invite to Clipboard',
-  inviteLink,
-  qrText: 'Download the App',
-  qrSubtext: 'Scan This QR Code with Your Phone Camera',
   rewardClaimed: 'Reward claimed successfully!',
   rewardAlreadyClaimed: 'Reward already claimed!',
   claimError:
@@ -85,43 +71,6 @@ const messages = {
   complete: 'Complete',
   incomplete: 'Incomplete',
   ineligible: 'Ineligible'
-}
-
-type InviteLinkProps = {
-  className?: string
-  inviteLink: string
-}
-
-export const InviteLink = ({ className, inviteLink }: InviteLinkProps) => {
-  const wm = useWithMobileStyle(styles.mobile)
-
-  const onButtonClick = useCallback(() => {
-    copyToClipboard(inviteLink)
-  }, [inviteLink])
-
-  return (
-    <Tooltip text={messages.copyLabel} placement={'top'} mount={'parent'}>
-      <div className={wm(styles.toastContainer, { [className!]: !!className })}>
-        <Toast
-          text={messages.copiedLabel}
-          delay={2000}
-          placement={ComponentPlacement.TOP}
-          mount={MountPlacement.PARENT}
-        >
-          <div className={wm(styles.inviteButtonContainer)}>
-            <Button
-              variant='primary'
-              iconRight={IconCopy}
-              onClick={onButtonClick}
-              fullWidth
-            >
-              {messages.inviteLabel}
-            </Button>
-          </div>
-        </Toast>
-      </div>
-    </Tooltip>
-  )
 }
 
 const getErrorMessage = (aaoErrorCode?: number) => {
@@ -186,16 +135,11 @@ export const ChallengeRewardsModal = () => {
     dispatch(resetAndCancelClaimReward())
   }, [dispatch, setOpen])
 
-  const { title, icon } = getChallengeConfig(modalType)
+  const { title } = getChallengeConfig(modalType)
 
   return (
     <ModalDrawer
-      title={
-        <>
-          {icon}
-          {title}
-        </>
-      }
+      title={<>{title}</>}
       showTitleHeader
       isOpen={isOpen}
       onClose={onClose}

--- a/packages/web/src/pages/rewards-page/components/modals/ChallengeRewardsModal/DefaultChallengeContent.tsx
+++ b/packages/web/src/pages/rewards-page/components/modals/ChallengeRewardsModal/DefaultChallengeContent.tsx
@@ -6,7 +6,7 @@ import {
   challengeRewardsConfig,
   getChallengeStatusLabel
 } from '@audius/common/utils'
-import { Button, Flex, IconVerified, Text, IconCheck } from '@audius/harmony'
+import { Button, Flex, IconCheck, Text } from '@audius/harmony'
 import { useDispatch, useSelector } from 'react-redux'
 
 import { push as pushRoute } from 'utils/navigation'
@@ -23,7 +23,6 @@ const { getClaimStatus, getUndisbursedUserChallenges } =
 
 const messages = {
   audio: '$AUDIO',
-  verifiedChallenge: 'VERIFIED CHALLENGE',
   cooldownDescription:
     'Note: There is a 7 day waiting period from completion until you can claim your reward.'
 }
@@ -43,10 +42,9 @@ export const DefaultChallengeContent = ({
 
   const config = challengeRewardsConfig[challengeName as ChallengeName] ?? {
     fullDescription: () => '',
-    completedLabel: '',
-    isVerifiedChallenge: false
+    completedLabel: ''
   }
-  const { fullDescription, completedLabel, isVerifiedChallenge } = config
+  const { fullDescription, completedLabel } = config
 
   const isProgressBarVisible =
     challenge &&
@@ -56,12 +54,6 @@ export const DefaultChallengeContent = ({
 
   const progressDescription = (
     <Flex column gap='m' w='100%'>
-      {isVerifiedChallenge ? (
-        <Flex gap='s'>
-          <IconVerified />
-          {messages.verifiedChallenge}
-        </Flex>
-      ) : null}
       <Text variant='body'>{fullDescription?.(challenge)}</Text>
       {challenge?.cooldown_days ? (
         <Text variant='body' color='subdued'>

--- a/packages/web/src/pages/rewards-page/components/modals/ChallengeRewardsModal/ListenStreakChallengeModalContent.tsx
+++ b/packages/web/src/pages/rewards-page/components/modals/ChallengeRewardsModal/ListenStreakChallengeModalContent.tsx
@@ -97,19 +97,6 @@ export const ListenStreakChallengeModalContent = ({
           </Flex>
         ) : null}
       </Flex>
-      {userChallenge.claimableAmount ? (
-        <Flex
-          backgroundColor='surface1'
-          ph='xl'
-          pv='m'
-          borderRadius='s'
-          border='default'
-          justifyContent='space-between'
-        >
-          <Text variant='title'>{messages.readyToClaim}</Text>
-          <Text variant='title'>{userChallenge?.claimableAmount}</Text>
-        </Flex>
-      ) : null}
     </Flex>
   ) : null
 

--- a/packages/web/src/pages/rewards-page/components/modals/ChallengeRewardsModal/ReferralsChallengeModalContent.tsx
+++ b/packages/web/src/pages/rewards-page/components/modals/ChallengeRewardsModal/ReferralsChallengeModalContent.tsx
@@ -1,5 +1,6 @@
-import { useCallback } from 'react'
+import { useCallback, useMemo } from 'react'
 
+import { getUserHandle } from '@audius/common/src/store/account/selectors'
 import {
   audioRewardsPageSelectors,
   challengesSelectors,
@@ -8,7 +9,8 @@ import {
 import {
   formatNumberCommas,
   challengeRewardsConfig,
-  getChallengeStatusLabel
+  getChallengeStatusLabel,
+  fillString
 } from '@audius/common/utils'
 import { Button, Flex, Text, IconLink } from '@audius/harmony'
 import { useSelector } from 'react-redux'
@@ -44,9 +46,15 @@ const messages = {
 }
 
 export const InviteLink = () => {
+  const userHandle = useSelector(getUserHandle)
+  const inviteLink = useMemo(
+    () => (userHandle ? fillString(messages.inviteLink, userHandle) : ''),
+    [userHandle]
+  )
+
   const handleClick = useCallback(() => {
     copyToClipboard(inviteLink)
-  }, [])
+  }, [inviteLink])
 
   return (
     <Toast

--- a/packages/web/src/pages/rewards-page/components/modals/ChallengeRewardsModal/ReferralsChallengeModalContent.tsx
+++ b/packages/web/src/pages/rewards-page/components/modals/ChallengeRewardsModal/ReferralsChallengeModalContent.tsx
@@ -1,0 +1,170 @@
+import { useCallback } from 'react'
+
+import {
+  audioRewardsPageSelectors,
+  challengesSelectors,
+  ClaimStatus
+} from '@audius/common/store'
+import {
+  formatNumberCommas,
+  challengeRewardsConfig,
+  getChallengeStatusLabel
+} from '@audius/common/utils'
+import { Button, Flex, Text, IconLink } from '@audius/harmony'
+import { useDispatch, useSelector } from 'react-redux'
+
+import Toast from 'components/toast/Toast'
+import Tooltip from 'components/tooltip/Tooltip'
+import { ComponentPlacement, MountPlacement } from 'components/types'
+import { useIsMobile } from 'hooks/useIsMobile'
+import { useWithMobileStyle } from 'hooks/useWithMobileStyle'
+import { copyToClipboard, getCopyableLink } from 'utils/clipboardUtil'
+import { push as pushRoute } from 'utils/navigation'
+
+import { ChallengeRewardsLayout } from './ChallengeRewardsLayout'
+import { ClaimButton } from './ClaimButton'
+import { CooldownSummaryTable } from './CooldownSummaryTable'
+import { ProgressDescription } from './ProgressDescription'
+import { ProgressReward } from './ProgressReward'
+import styles from './styles.module.css'
+import { type ReferralsChallengeProps } from './types'
+
+const { getOptimisticUserChallenges } = challengesSelectors
+const { getUndisbursedUserChallenges, getClaimStatus } =
+  audioRewardsPageSelectors
+
+const inviteLink = getCopyableLink('/signup?rf=%0')
+
+const messages = {
+  rewardSubtext: '$AUDIO/invite',
+  descriptionSubtext:
+    "Invite your friends to join Audius and earn $AUDIO for each friend who joins with your link (and they'll get $AUDIO too).",
+  totalClaimed: (amount: string) => `${amount} $AUDIO Claimed`,
+  inviteButtonText: 'Copy Invite To Clipboard',
+  readyToClaim: 'Ready to claim!',
+  copiedLabel: 'Copied to Clipboard',
+  inviteLabel: 'Copy Invite to Clipboard',
+  inviteLink
+}
+
+export const InviteLink = () => {
+  const handleClick = useCallback(() => {
+    copyToClipboard(inviteLink)
+  }, [])
+
+  return (
+    <Toast
+      text={messages.copiedLabel}
+      delay={2000}
+      placement={ComponentPlacement.TOP}
+      mount={MountPlacement.PARENT}
+    >
+      <Button
+        variant='secondary'
+        iconLeft={IconLink}
+        onClick={handleClick}
+        fullWidth
+      >
+        {messages.inviteLabel}
+      </Button>
+    </Toast>
+  )
+}
+
+export const ReferralsChallengeModalContent = ({
+  challenge,
+  challengeName,
+  onNavigateAway,
+  errorContent
+}: ReferralsChallengeProps) => {
+  const isMobile = useIsMobile()
+  const { fullDescription } = challengeRewardsConfig[challengeName]
+  const userChallenge = useSelector(getOptimisticUserChallenges)[challengeName]
+  const undisbursedUserChallenges = useSelector(getUndisbursedUserChallenges)
+  const claimStatus = useSelector(getClaimStatus)
+  const claimInProgress =
+    claimStatus === ClaimStatus.CLAIMING ||
+    claimStatus === ClaimStatus.WAITING_FOR_RETRY
+
+  const progressDescription = (
+    <ProgressDescription
+      description={<Text variant='body'>{fullDescription?.(challenge)}</Text>}
+    />
+  )
+
+  const progressReward = (
+    <ProgressReward
+      amount={userChallenge?.amount}
+      subtext={messages.rewardSubtext}
+    />
+  )
+
+  const progressStatusLabel = userChallenge ? (
+    <Flex
+      column={isMobile}
+      ph='xl'
+      backgroundColor='surface2'
+      border='default'
+      borderRadius='s'
+      alignItems='center'
+    >
+      <Flex
+        pv='l'
+        gap='s'
+        w='100%'
+        justifyContent={
+          isMobile
+            ? 'center'
+            : userChallenge.disbursed_amount
+              ? 'flex-start'
+              : 'center'
+        }
+        alignItems='center'
+      >
+        <Text variant='label' size='l' color='subdued'>
+          {getChallengeStatusLabel(userChallenge, challengeName)}
+        </Text>
+      </Flex>
+      {userChallenge.disbursed_amount ? (
+        <Flex
+          pv='l'
+          w='100%'
+          alignItems='center'
+          justifyContent={isMobile ? 'center' : 'flex-end'}
+          borderTop={isMobile ? 'default' : undefined}
+        >
+          <Text variant='label' size='l' color='subdued'>
+            {messages.totalClaimed(
+              formatNumberCommas(userChallenge.disbursed_amount.toString())
+            )}
+          </Text>
+        </Flex>
+      ) : null}
+    </Flex>
+  ) : null
+
+  return (
+    <ChallengeRewardsLayout
+      description={progressDescription}
+      reward={progressReward}
+      progress={progressStatusLabel}
+      additionalContent={
+        challenge?.cooldown_days && challenge.cooldown_days > 0 ? (
+          <CooldownSummaryTable challengeId={challenge.challenge_id} />
+        ) : null
+      }
+      actions={
+        <Flex gap='l' w='100%' direction={isMobile ? 'column-reverse' : 'row'}>
+          <ClaimButton
+            challenge={challenge}
+            claimInProgress={claimInProgress}
+            undisbursedChallenges={undisbursedUserChallenges}
+            onClose={onNavigateAway}
+          />
+          <InviteLink />
+        </Flex>
+      }
+      errorContent={errorContent}
+    />
+  )
+}

--- a/packages/web/src/pages/rewards-page/components/modals/ChallengeRewardsModal/ReferralsChallengeModalContent.tsx
+++ b/packages/web/src/pages/rewards-page/components/modals/ChallengeRewardsModal/ReferralsChallengeModalContent.tsx
@@ -11,22 +11,18 @@ import {
   getChallengeStatusLabel
 } from '@audius/common/utils'
 import { Button, Flex, Text, IconLink } from '@audius/harmony'
-import { useDispatch, useSelector } from 'react-redux'
+import { useSelector } from 'react-redux'
 
 import Toast from 'components/toast/Toast'
-import Tooltip from 'components/tooltip/Tooltip'
 import { ComponentPlacement, MountPlacement } from 'components/types'
 import { useIsMobile } from 'hooks/useIsMobile'
-import { useWithMobileStyle } from 'hooks/useWithMobileStyle'
 import { copyToClipboard, getCopyableLink } from 'utils/clipboardUtil'
-import { push as pushRoute } from 'utils/navigation'
 
 import { ChallengeRewardsLayout } from './ChallengeRewardsLayout'
 import { ClaimButton } from './ClaimButton'
 import { CooldownSummaryTable } from './CooldownSummaryTable'
 import { ProgressDescription } from './ProgressDescription'
 import { ProgressReward } from './ProgressReward'
-import styles from './styles.module.css'
 import { type ReferralsChallengeProps } from './types'
 
 const { getOptimisticUserChallenges } = challengesSelectors

--- a/packages/web/src/pages/rewards-page/components/modals/ChallengeRewardsModal/challengeContentRegistry.ts
+++ b/packages/web/src/pages/rewards-page/components/modals/ChallengeRewardsModal/challengeContentRegistry.ts
@@ -4,6 +4,7 @@ import { AudioMatchingRewardsModalContent } from './AudioMatchingRewardsModalCon
 import { DefaultChallengeContent } from './DefaultChallengeContent'
 import { ListenStreakChallengeModalContent } from './ListenStreakChallengeModalContent'
 import { OneShotChallengeModalContent } from './OneShotChallengeModalContent'
+import { ReferralsChallengeModalContent } from './ReferralsChallengeModalContent'
 import {
   type ChallengeContentMap,
   type ChallengeContentComponent
@@ -18,6 +19,10 @@ export const challengeContentRegistry: ChallengeContentMap = {
     ListenStreakChallengeModalContent as ChallengeContentComponent,
   [ChallengeName.OneShot]:
     OneShotChallengeModalContent as ChallengeContentComponent,
+  [ChallengeName.Referrals]:
+    ReferralsChallengeModalContent as ChallengeContentComponent,
+  [ChallengeName.ReferralsVerified]:
+    ReferralsChallengeModalContent as ChallengeContentComponent,
   default: DefaultChallengeContent as ChallengeContentComponent
 }
 

--- a/packages/web/src/pages/rewards-page/components/modals/ChallengeRewardsModal/types.ts
+++ b/packages/web/src/pages/rewards-page/components/modals/ChallengeRewardsModal/types.ts
@@ -27,9 +27,14 @@ export type ListenStreakChallengeProps = BaseChallengeContentProps & {
   challengeName: ChallengeName.ListenStreakEndless
 }
 
+export type ReferralsChallengeProps = BaseChallengeContentProps & {
+  challengeName: ChallengeName.Referrals | ChallengeName.ReferralsVerified
+}
+
 export type ChallengeContentProps =
   | AudioMatchingChallengeProps
   | ListenStreakChallengeProps
+  | ReferralsChallengeProps
   | DefaultChallengeProps
 
 export type ChallengeContentComponent =

--- a/packages/web/src/pages/rewards-page/config.tsx
+++ b/packages/web/src/pages/rewards-page/config.tsx
@@ -97,11 +97,8 @@ type WebChallengeInfo = {
 }
 
 const webChallengesConfig: Record<ChallengeRewardID, WebChallengeInfo> = {
-  referrals: {},
   [ChallengeName.Referrals]: {},
-  'ref-v': {},
   [ChallengeName.ReferralsVerified]: {},
-  referred: {},
   [ChallengeName.Referred]: {},
   'connect-verified': {
     modalButtonInfo: {
@@ -125,7 +122,6 @@ const webChallengesConfig: Record<ChallengeRewardID, WebChallengeInfo> = {
     }
   },
   [ChallengeName.ListenStreakEndless]: {
-    icon: <i className='emoji large fire' />,
     modalButtonInfo: {
       incomplete: linkButtonMap.trendingTracks,
       inProgress: linkButtonMap.trendingTracks,


### PR DESCRIPTION
### Description
After the refactor the referral challenges were missing the copy invite button, and had some bunk "verified challenge" text.

Also sneaking in a fix to left-align the challenge titles in the reward panels, this was breaking on small screens.

Also removed the configs for the old challenge id names, eg. `referrals` instead of `ChallengeName.referrals ('r')`. Probably safe to remove all of those now.

### How Has This Been Tested?

<img width="426" alt="Screenshot 2025-02-26 at 3 44 22 PM" src="https://github.com/user-attachments/assets/a126b15a-8535-492b-8d5b-fecc0bc317bf" />
<img width="454" alt="Screenshot 2025-02-26 at 3 33 05 PM" src="https://github.com/user-attachments/assets/d50ec130-5119-44a1-85c8-31a8e5633951" />
<img width="715" alt="Screenshot 2025-02-26 at 3 39 22 PM" src="https://github.com/user-attachments/assets/44633864-6c01-4e1d-aa39-34699dda426f" />
<img width="769" alt="Screenshot 2025-02-26 at 3 33 09 PM" src="https://github.com/user-attachments/assets/4f2c8ad4-2ac4-449c-ac8a-e65783b7cb63" />
<img width="729" alt="Screenshot 2025-02-26 at 3 49 59 PM" src="https://github.com/user-attachments/assets/20d4e604-7f72-4e81-bbd4-db42e0c90bc1" />
