### PR TITLE
[PAY-3972] First weekly comment challenge web UI

### DIFF
--- a/packages/common/src/models/AudioRewards.ts
+++ b/packages/common/src/models/AudioRewards.ts
@@ -54,7 +54,8 @@ export enum ChallengeName {
   FirstPlaylist = 'fp',
   ListenStreak = 'l',
   ListenStreakEndless = 'e',
-  OneShot = 'o'
+  OneShot = 'o',
+  FirstWeeklyComment = 'c'
 }
 
 export type ChallengeRewardID =
@@ -87,6 +88,7 @@ export type ChallengeRewardID =
   | ChallengeName.ListenStreak
   | ChallengeName.ListenStreakEndless
   | ChallengeName.OneShot
+  | ChallengeName.FirstWeeklyComment
 
 export enum FailureReason {
   // The attestation requires the user to fill out a captcha

--- a/packages/common/src/utils/challenges.ts
+++ b/packages/common/src/utils/challenges.ts
@@ -274,7 +274,7 @@ export const challengeRewardsConfig: Record<
     panelButtonText: 'See More',
     id: 'trending-underground'
   },
-  o: {
+  [ChallengeName.OneShot]: {
     shortTitle: 'Airdrop 2: Artists',
     title: 'Airdrop 2: Artist Appreciation',
     description: () =>
@@ -287,6 +287,14 @@ export const challengeRewardsConfig: Record<
     id: ChallengeName.OneShot,
     remainingLabel: 'Ineligible',
     progressLabel: 'Ready to Claim'
+  },
+  [ChallengeName.FirstWeeklyComment]: {
+    shortTitle: 'first comment of the week',
+    title: 'First comment of the week',
+    description: () => 'Your first comment every week will earn $AUDIO.',
+    fullDescription: () => 'Your first comment every week will earn $AUDIO.',
+    panelButtonText: 'Comment on a Track',
+    id: ChallengeName.FirstWeeklyComment
   }
 }
 

--- a/packages/discovery-provider/src/challenges/challenges.dev.json
+++ b/packages/discovery-provider/src/challenges/challenges.dev.json
@@ -158,6 +158,6 @@
     "step_count": 2147483647,
     "starting_block": 0,
     "weekly_pool": 2147483647,
-    "cooldown_days": 0
+    "cooldown_days": 7
   }
 ]

--- a/packages/discovery-provider/src/challenges/challenges.stage.json
+++ b/packages/discovery-provider/src/challenges/challenges.stage.json
@@ -158,6 +158,6 @@
     "step_count": 2147483647,
     "starting_block": 0,
     "weekly_pool": 2147483647,
-    "cooldown_days": 0
+    "cooldown_days": 7
   }
 ]

--- a/packages/discovery-provider/src/tasks/entity_manager/entities/comment.py
+++ b/packages/discovery-provider/src/tasks/entity_manager/entities/comment.py
@@ -178,7 +178,7 @@ def create_comment(params: ManageEntityParameters):
         params.block_number,
         params.block_datetime,
         user_id,
-        {"comment_id": comment_id},
+        {"created_at": params.block_datetime.timestamp()},
     )
 
     if (

--- a/packages/discovery-provider/src/tasks/entity_manager/entities/comment.py
+++ b/packages/discovery-provider/src/tasks/entity_manager/entities/comment.py
@@ -173,13 +173,15 @@ def create_comment(params: ManageEntityParameters):
     )
 
     params.add_record(comment_id, comment_record, EntityType.COMMENT)
-    challenge_bus.dispatch(
-        ChallengeEvent.first_weekly_comment,
-        params.block_number,
-        params.block_datetime,
-        user_id,
-        {"created_at": params.block_datetime.timestamp()},
-    )
+
+    with challenge_bus.use_scoped_dispatch_queue():
+        challenge_bus.dispatch(
+            ChallengeEvent.first_weekly_comment,
+            params.block_number,
+            params.block_datetime,
+            user_id,
+            {"created_at": params.block_datetime.timestamp()},
+        )
 
     if (
         not is_reply

--- a/packages/mobile/src/utils/challenges.tsx
+++ b/packages/mobile/src/utils/challenges.tsx
@@ -299,6 +299,12 @@ const mobileChallengeConfig: Record<ChallengeRewardID, MobileChallengeConfig> =
       buttonInfo: {
         iconRight: IconCheck
       }
+    },
+    [ChallengeName.FirstWeeklyComment]: {
+      icon: undefined,
+      buttonInfo: {
+        iconRight: IconCheck
+      }
     }
   }
 

--- a/packages/web/src/pages/rewards-page/components/ChallengeRewards/hooks/useRewardIds.ts
+++ b/packages/web/src/pages/rewards-page/components/ChallengeRewards/hooks/useRewardIds.ts
@@ -24,7 +24,8 @@ const validRewardIds: Set<ChallengeRewardID> = new Set([
   ChallengeName.TrackUpload,
   ChallengeName.ListenStreak,
   ChallengeName.OneShot,
-  ChallengeName.ListenStreakEndless
+  ChallengeName.ListenStreakEndless,
+  ChallengeName.FirstWeeklyComment
 ])
 
 /** Pulls rewards from remoteconfig */

--- a/packages/web/src/pages/rewards-page/components/modals/ChallengeRewardsModal/FirstWeeklyCommentChallengeModalContent.tsx
+++ b/packages/web/src/pages/rewards-page/components/modals/ChallengeRewardsModal/FirstWeeklyCommentChallengeModalContent.tsx
@@ -1,0 +1,16 @@
+import { DefaultChallengeContent } from './DefaultChallengeContent'
+import { type DefaultChallengeProps } from './types'
+
+export const FirstWeeklyCommentChallengeModalContent = (
+  props: DefaultChallengeProps
+) => {
+  const { challenge } = props
+  const modifiedChallenge = challenge
+    ? {
+        ...challenge,
+        totalAmount: challenge?.amount ?? 0
+      }
+    : undefined
+
+  return <DefaultChallengeContent {...props} challenge={modifiedChallenge} />
+}

--- a/packages/web/src/pages/rewards-page/components/modals/ChallengeRewardsModal/challengeContentRegistry.ts
+++ b/packages/web/src/pages/rewards-page/components/modals/ChallengeRewardsModal/challengeContentRegistry.ts
@@ -2,6 +2,7 @@ import { ChallengeName } from '@audius/common/models'
 
 import { AudioMatchingRewardsModalContent } from './AudioMatchingRewardsModalContent'
 import { DefaultChallengeContent } from './DefaultChallengeContent'
+import { FirstWeeklyCommentChallengeModalContent } from './FirstWeeklyCommentChallengeModalContent'
 import { ListenStreakChallengeModalContent } from './ListenStreakChallengeModalContent'
 import { OneShotChallengeModalContent } from './OneShotChallengeModalContent'
 import { ReferralsChallengeModalContent } from './ReferralsChallengeModalContent'
@@ -19,6 +20,8 @@ export const challengeContentRegistry: ChallengeContentMap = {
     ListenStreakChallengeModalContent as ChallengeContentComponent,
   [ChallengeName.OneShot]:
     OneShotChallengeModalContent as ChallengeContentComponent,
+  [ChallengeName.FirstWeeklyComment]:
+    FirstWeeklyCommentChallengeModalContent as ChallengeContentComponent,
   [ChallengeName.Referrals]:
     ReferralsChallengeModalContent as ChallengeContentComponent,
   [ChallengeName.ReferralsVerified]:

--- a/packages/web/src/pages/rewards-page/config.tsx
+++ b/packages/web/src/pages/rewards-page/config.tsx
@@ -215,7 +215,8 @@ const webChallengesConfig: Record<ChallengeRewardID, WebChallengeInfo> = {
   'verified-upload': {},
   'trending-underground': {},
   tut: {},
-  [ChallengeName.OneShot]: {}
+  [ChallengeName.OneShot]: {},
+  [ChallengeName.FirstWeeklyComment]: {}
 }
 
 export const getChallengeConfig = (id: ChallengeRewardID) => ({


### PR DESCRIPTION
### Description
Web UI for first weekly comment challenge.

Also including a fix for the comment events to get processed correctly - needed `created_at` in `extra`.

### How Has This Been Tested?
<img width="767" alt="Screenshot 2025-02-26 at 6 01 24 PM" src="https://github.com/user-attachments/assets/a8d0ee98-30b9-441b-8506-8ba49f994535" />
<img width="740" alt="Screenshot 2025-02-26 at 6 04 35 PM" src="https://github.com/user-attachments/assets/76648049-2dbc-4ca1-bdf4-0dc44999ca50" />


