### PR TITLE
Fix width for track page

### DIFF
--- a/packages/web/src/pages/track-page/components/desktop/TrackPage.tsx
+++ b/packages/web/src/pages/track-page/components/desktop/TrackPage.tsx
@@ -241,6 +241,7 @@ const TrackPage = ({
       <FlushPageContainer>
         <Flex
           direction='column'
+          w='100%'
           pt={200}
           pb={60}
           css={{ position: 'relative' }}


### PR DESCRIPTION
### Description
I broke the track page width when adding the `FlushPageContainer`. This adds the correct full width setting to make sure it fills the space.

### How Has This Been Tested?
Local client against staging, tested the original flow that reproduced the issue (adding a comment)
