### PR TITLE
[C-5806] Add analytics for recent comments

### DIFF
--- a/packages/common/src/models/Analytics.ts
+++ b/packages/common/src/models/Analytics.ts
@@ -556,6 +556,10 @@ export enum Name {
   COMMENTS_OPEN_AUTH_MODAL = 'Comments: Open Auth Modal',
   COMMENTS_OPEN_INSTALL_APP_MODAL = 'Comments: Open Install App Modal',
 
+  // Recent Comments
+  RECENT_COMMENTS_CLICK = 'Recent Comments: Click',
+  COMMENTS_HISTORY_CLICK = 'Comments History: Click',
+
   // Track Replace
   TRACK_REPLACE_DOWNLOAD = 'Track Replace: Download',
   TRACK_REPLACE_PREVIEW = 'Track Replace: Preview',
@@ -2696,6 +2700,18 @@ export type CommentsOpenInstallAppModal = {
   trackId: ID
 }
 
+export type CommentsHistoryClick = {
+  eventName: Name.COMMENTS_HISTORY_CLICK
+  commentId: ID
+  userId: ID
+}
+
+export type RecentCommentsClick = {
+  eventName: Name.RECENT_COMMENTS_CLICK
+  commentId: ID
+  userId: ID
+}
+
 export type TrackReplaceDownload = {
   eventName: Name.TRACK_REPLACE_DOWNLOAD
   trackId?: ID
@@ -3076,6 +3092,8 @@ export type AllTrackingEvents =
   | CommentsCloseCommentDrawer
   | CommentsOpenAuthModal
   | CommentsOpenInstallAppModal
+  | CommentsHistoryClick
+  | RecentCommentsClick
   | TrackReplaceDownload
   | TrackReplacePreview
   | TrackReplaceReplace

--- a/packages/mobile/src/components/comments/RecentUserCommentsDrawer.tsx
+++ b/packages/mobile/src/components/comments/RecentUserCommentsDrawer.tsx
@@ -6,7 +6,12 @@ import {
   useUser,
   useUserComments
 } from '@audius/common/api'
-import type { ID, Comment, ReplyComment } from '@audius/common/models'
+import {
+  type ID,
+  type Comment,
+  type ReplyComment,
+  Name
+} from '@audius/common/models'
 import { dayjs } from '@audius/common/utils'
 import { OptionalHashId } from '@audius/sdk'
 import {
@@ -28,6 +33,7 @@ import {
 } from '@audius/harmony-native'
 import { LoadingSpinner } from 'app/harmony-native/components/LoadingSpinner/LoadingSpinner'
 import { useNavigation } from 'app/hooks/useNavigation'
+import { make, track as trackEvent } from 'app/services/analytics'
 
 import { ProfilePicture } from '../core/ProfilePicture'
 import { UserBadgesV2 } from '../user-badges/UserBadgesV2'
@@ -60,13 +66,26 @@ const CommentItem = ({ commentId }: { commentId: ID }) => {
   const { data: artist, isLoading: isArtistLoading } = useUser(track?.owner_id)
   const { data: commenter } = useUser(userId)
 
+  const trackUserCommentClick = useCallback(() => {
+    if (comment) {
+      trackEvent(
+        make({
+          eventName: Name.COMMENTS_HISTORY_CLICK,
+          commentId: comment.id,
+          userId
+        })
+      )
+    }
+  }, [comment, userId])
+
   const handlePressView = useCallback(() => {
     if (track?.track_id) {
+      trackUserCommentClick()
       // @ts-ignore (bad types on useNavigation)
       navigation.push('Track', { id: track.track_id })
     }
     onClose()
-  }, [navigation, track?.track_id, onClose])
+  }, [navigation, track?.track_id, onClose, trackUserCommentClick])
 
   if (isLoading || isTrackLoading || isArtistLoading) {
     return <CommentSkeleton />

--- a/packages/web/src/pages/comment-history/components/desktop/CommentHistoryPage.tsx
+++ b/packages/web/src/pages/comment-history/components/desktop/CommentHistoryPage.tsx
@@ -7,7 +7,7 @@ import {
   useUserByParams,
   useUserComments
 } from '@audius/common/api'
-import { Comment } from '@audius/common/models'
+import { Comment, Name } from '@audius/common/models'
 import { profilePage } from '@audius/common/src/utils/route'
 import {
   Box,
@@ -35,6 +35,7 @@ import { TrackLink, UserLink } from 'components/link'
 import Page from 'components/page/Page'
 import { useMainContentRef } from 'pages/MainContentContext'
 import { useProfileParams } from 'pages/profile-page/useProfileParams'
+import { make, track as trackEvent } from 'services/analytics'
 import { fullCommentHistoryPage } from 'utils/route'
 
 import { CommentText } from './CommentText'
@@ -66,18 +67,32 @@ const UserComment = ({ commentId }: { commentId: number }) => {
     isCurrentUserReacted
   } = comment
 
+  const trackId = HashId.parse(entityId)
   const { isPending: isUserPending } = useUser(userId)
-  const { data: track } = useTrack(HashId.parse(entityId))
+  const { data: track } = useTrack(trackId)
   const createdAtDate = useMemo(
     () => dayjs.utc(createdAt).toDate(),
     [createdAt]
   )
 
+  const trackUserCommentClick = useCallback(() => {
+    if (userId) {
+      trackEvent(
+        make({
+          eventName: Name.COMMENTS_HISTORY_CLICK,
+          commentId: id,
+          userId
+        })
+      )
+    }
+  }, [id, userId])
+
   const goToTrackPage = useCallback(() => {
     if (track) {
+      trackUserCommentClick()
       navigate(track.permalink)
     }
-  }, [track, navigate])
+  }, [track, trackUserCommentClick, navigate])
 
   if (!comment) return null
 
@@ -92,9 +107,17 @@ const UserComment = ({ commentId }: { commentId: number }) => {
             <Text variant='body' size='s' textAlign='left'>
               {track ? (
                 <>
-                  <TrackLink isActive trackId={track?.track_id} />
+                  <TrackLink
+                    isActive
+                    trackId={track?.track_id}
+                    onClick={trackUserCommentClick}
+                  />
                   <Text>{messages.by}</Text>
-                  <UserLink isActive userId={track?.owner_id} />
+                  <UserLink
+                    isActive
+                    userId={track?.owner_id}
+                    onClick={trackUserCommentClick}
+                  />
                 </>
               ) : (
                 <Skeleton w={180} h={20} />
@@ -111,6 +134,7 @@ const UserComment = ({ commentId }: { commentId: number }) => {
                     popover
                     size='l'
                     strength='strong'
+                    onClick={trackUserCommentClick}
                   />
                 ) : null}
                 <Flex gap='xs' alignItems='flex-end' h='100%'>


### PR DESCRIPTION
### Description
Add some simple events for clicks on the recent comments section, comment history page, and comment history drawer
Could not easily update the location change event to accept the source so went with this method instead

### How Has This Been Tested?
Manually tested on local dev
