### PR TITLE
[C-5808] Hide hidden track comments on user comments route

### DIFF
--- a/packages/discovery-provider/integration_tests/queries/test_get_user_comments.py
+++ b/packages/discovery-provider/integration_tests/queries/test_get_user_comments.py
@@ -376,6 +376,73 @@ def test_get_user_comments_edited(app):
         assert normal_comment["is_edited"] == False
 
 
+def test_get_user_comments_unlisted_tracks(app):
+    """Test that comments on unlisted tracks are not returned"""
+    entities = {
+        "comments": [
+            {
+                "comment_id": 1,
+                "user_id": 1,
+                "entity_id": 1,
+                "entity_type": "Track",
+                "text": "Comment on public track",
+                "created_at": datetime(2022, 1, 1),
+                "updated_at": datetime(2022, 1, 1),
+            },
+            {
+                "comment_id": 2,
+                "user_id": 1,
+                "entity_id": 2,
+                "entity_type": "Track",
+                "text": "Comment on unlisted track",
+                "created_at": datetime(2022, 1, 2),
+                "updated_at": datetime(2022, 1, 2),
+            },
+        ],
+        "tracks": [
+            {
+                "track_id": 1,
+                "owner_id": 10,
+                "is_current": True,
+                "is_unlisted": False,
+                "title": "Public Track",
+            },
+            {
+                "track_id": 2,
+                "owner_id": 10,
+                "is_current": True,
+                "is_unlisted": True,
+                "title": "Unlisted Track",
+            },
+        ],
+        "users": [
+            {"user_id": 1, "handle": "user1"},
+            {"user_id": 10, "handle": "artist"},
+        ],
+    }
+
+    with app.app_context():
+        db = get_db()
+        populate_mock_db(db, entities)
+
+        args = {
+            "user_id": 1,
+            "current_user_id": 10,
+        }
+        response = get_user_comments(args)
+
+        # Get the comments from the data field
+        comments = response["data"]
+
+        # Only the comment on the public track should be returned
+        assert len(comments) == 1
+        assert decode_string_id(comments[0]["id"]) == 1
+
+        # Verify the comment on the unlisted track is not included
+        unlisted_comments = [c for c in comments if decode_string_id(c["id"]) == 2]
+        assert len(unlisted_comments) == 0
+
+
 def test_get_user_comments_related_field(app):
     """Test that the related field is included in the response and contains the expected user and track information"""
     with app.app_context():

--- a/packages/discovery-provider/src/queries/comments/utils.py
+++ b/packages/discovery-provider/src/queries/comments/utils.py
@@ -236,6 +236,7 @@ def build_comments_query(
     )
     from src.models.comments.comment_thread import CommentThread
     from src.models.moderation.muted_user import MutedUser
+    from src.models.tracks.track import Track
     from src.models.users.aggregate_user import AggregateUser
 
     mentioned_users = base_query["mentioned_users"]
@@ -376,6 +377,17 @@ def build_comments_query(
             Comment.is_visible == True,
             Comment.entity_type == "Track",
         )
+
+        # Join with Track and filter out unlisted tracks
+        query = query.join(
+            Track,
+            and_(
+                Comment.entity_id == Track.track_id,
+                Track.is_current == True,
+                Track.is_unlisted == False,
+            ),
+        )
+
         query = query.group_by(
             Comment.comment_id,
             react_count_subquery.c.react_count,

--- a/packages/discovery-provider/src/queries/comments/utils.py
+++ b/packages/discovery-provider/src/queries/comments/utils.py
@@ -383,7 +383,6 @@ def build_comments_query(
             Track,
             and_(
                 Comment.entity_id == Track.track_id,
-                Track.is_current == True,
                 Track.is_unlisted == False,
             ),
         )


### PR DESCRIPTION
### Description

Hides comments on unlisted tracks to prevent hidden tracks from showing up on user's profile and comment history.