### PR TITLE
[C-5812] Revert the TextLink display change and add drawer open event for recent comments drawer on mobile

### DIFF
--- a/.changeset/shiny-llamas-move.md
+++ b/.changeset/shiny-llamas-move.md
@@ -1,0 +1,5 @@
+---
+"@audius/harmony": patch
+---
+
+Revert TextLink display change

--- a/packages/common/src/models/Analytics.ts
+++ b/packages/common/src/models/Analytics.ts
@@ -559,6 +559,7 @@ export enum Name {
   // Recent Comments
   RECENT_COMMENTS_CLICK = 'Recent Comments: Click',
   COMMENTS_HISTORY_CLICK = 'Comments History: Click',
+  COMMENTS_HISTORY_DRAWER_OPEN = 'Comments History: Drawer Open',
 
   // Track Replace
   TRACK_REPLACE_DOWNLOAD = 'Track Replace: Download',
@@ -2706,6 +2707,11 @@ export type CommentsHistoryClick = {
   userId: ID
 }
 
+export type CommentsHistoryDrawerOpen = {
+  eventName: Name.COMMENTS_HISTORY_DRAWER_OPEN
+  userId: ID
+}
+
 export type RecentCommentsClick = {
   eventName: Name.RECENT_COMMENTS_CLICK
   commentId: ID
@@ -3093,6 +3099,7 @@ export type AllTrackingEvents =
   | CommentsOpenAuthModal
   | CommentsOpenInstallAppModal
   | CommentsHistoryClick
+  | CommentsHistoryDrawerOpen
   | RecentCommentsClick
   | TrackReplaceDownload
   | TrackReplacePreview

--- a/packages/harmony/src/components/text-link/TextLink.tsx
+++ b/packages/harmony/src/components/text-link/TextLink.tsx
@@ -47,10 +47,6 @@ export const TextLink = forwardRef((props: TextLinkProps, ref: Ref<'a'>) => {
     active: color.primary.primary
   }
 
-  const ellipsisStyles = {
-    display: 'block'
-  }
-
   const hoverStyles = {
     textDecoration: noUnderlineOnHover ? 'none' : 'underline',
     color: variantHoverColors[variant],
@@ -78,7 +74,7 @@ export const TextLink = forwardRef((props: TextLinkProps, ref: Ref<'a'>) => {
         ':hover': hoverStyles,
         ...(isActive && { ...hoverStyles, textDecoration: 'none' }),
         ...(showUnderline && hoverStyles),
-        ...(ellipses && { ...ellipsisStyles })
+        ...(ellipses && { minWidth: 0 })
       }}
       variant={textVariant}
       ellipses={ellipses}

--- a/packages/mobile/src/screens/profile-screen/ProfileHeader/ProfileInfoTiles.tsx
+++ b/packages/mobile/src/screens/profile-screen/ProfileHeader/ProfileInfoTiles.tsx
@@ -9,7 +9,7 @@ import {
   useUserComments
 } from '@audius/common/api'
 import { useFeatureFlag } from '@audius/common/hooks'
-import type { UserMetadata } from '@audius/common/models'
+import { Name, type UserMetadata } from '@audius/common/models'
 import { FeatureFlags } from '@audius/common/services'
 import { accountSelectors } from '@audius/common/store'
 import { Platform, View, ScrollView } from 'react-native'
@@ -37,6 +37,7 @@ import {
   ProfilePictureList,
   ProfilePictureListSkeleton
 } from 'app/screens/notifications-screen/Notification'
+import { make, track as trackEvent } from 'app/services/analytics'
 import { makeStyles } from 'app/styles'
 import type { SvgProps } from 'app/types/svg'
 import { useThemePalette } from 'app/utils/theme'
@@ -329,7 +330,13 @@ export const ProfileInfoTiles = () => {
   }, [])
   const onOpenRecentCommentsDrawer = useCallback(() => {
     setIsRecentCommentsDrawerOpen(true)
-  }, [])
+    trackEvent(
+      make({
+        eventName: Name.COMMENTS_HISTORY_DRAWER_OPEN,
+        userId: user_id
+      })
+    )
+  }, [user_id])
 
   const accountId = useSelector(getUserId)
 

--- a/packages/web/src/pages/profile-page/components/desktop/RecentComments.tsx
+++ b/packages/web/src/pages/profile-page/components/desktop/RecentComments.tsx
@@ -76,6 +76,7 @@ const CommentListItem = ({ id }: { id: number }) => {
         <Flex w='100%' css={{ minWidth: 0 }}>
           {track ? (
             <TrackLink
+              css={{ display: 'block' }}
               size='s'
               variant='subdued'
               showUnderline={isHovered}


### PR DESCRIPTION
### Description
* Add the event to track the user opening the recent comments drawer on mobile
* Revert the change to harmony to update the TextLink display type. 

I'm going to look into a simple way to make the ellipsis styles work better for TextLinks but wanted to fix stage for the time being

### How Has This Been Tested?
Manually tested
