### PR TITLE
Update trending copy and challenge config

### DIFF
--- a/packages/discovery-provider/src/challenges/challenges.json
+++ b/packages/discovery-provider/src/challenges/challenges.json
@@ -77,18 +77,18 @@
   {
     "id": "tt",
     "type": "trending",
-    "amount": 100,
+    "amount": 1000,
     "active": true,
     "starting_block": 25346436,
-    "weekly_pool": 10000
+    "weekly_pool": 100000
   },
   {
     "id": "tut",
     "type": "trending",
-    "amount": 100,
+    "amount": 1000,
     "active": true,
     "starting_block": 25346436,
-    "weekly_pool": 10000
+    "weekly_pool": 100000
   },
   {
     "id": "tp",

--- a/packages/mobile/src/components/trending-rewards-drawer/TrendingRewardsDrawer.tsx
+++ b/packages/mobile/src/components/trending-rewards-drawer/TrendingRewardsDrawer.tsx
@@ -31,9 +31,9 @@ const TRENDING_REWARDS_DRAWER_NAME = 'TrendingRewardsExplainer'
 const TOS_URL = 'https://blog.audius.co/article/audio-rewards'
 
 const messages = {
-  tracksTitle: 'Top 5 Tracks Each Week Receive 100 $AUDIO',
+  tracksTitle: 'Top 5 Tracks Each Week Receive 1000 $AUDIO',
   playlistTitle: 'Top 5 Playlists Each Week Receive 100 $AUDIO',
-  undergroundTitle: 'Top 5 Tracks Each Week Receive 100 $AUDIO',
+  undergroundTitle: 'Top 5 Tracks Each Week Receive 1000 $AUDIO',
   winners: 'Winners are selected every Friday at Noon PT!',
   lastWeek: "LAST WEEK'S WINNERS",
   tracks: 'Tracks',

--- a/packages/web/src/components/rewards/modals/TrendingRewards.tsx
+++ b/packages/web/src/components/rewards/modals/TrendingRewards.tsx
@@ -35,9 +35,9 @@ const { getTrendingRewardsModalType } = audioRewardsPageSelectors
 const { setTrendingRewardsModalType } = audioRewardsPageActions
 
 const messages = {
-  tracksTitle: 'Top 5 Tracks Each Week Receive 100 $AUDIO',
+  tracksTitle: 'Top 5 Tracks Each Week Receive 1000 $AUDIO',
   playlistTitle: 'Top 5 Playlists Each Week Receive 100 $AUDIO',
-  undergroundTitle: 'Top 5 Tracks Each Week Receive 100 $AUDIO',
+  undergroundTitle: 'Top 5 Tracks Each Week Receive 1000 $AUDIO',
   winners: 'Winners are selected every Friday at Noon PT!',
   lastWeek: "LAST WEEK'S WINNERS",
   tracks: 'TRACKS',


### PR DESCRIPTION
### Description
- Updated trending copy
- Updated prod config, also bumped available pool in accordance to challenge to https://github.com/AudiusProject/audius-protocol/pull/10648/files

### How Has This Been Tested?

![image](https://github.com/user-attachments/assets/35ff852f-9857-405a-acaa-b3e1de11d7dc)
