### PR TITLE
Fix trending page

### DIFF
--- a/packages/common/src/store/pages/trending/reducer.ts
+++ b/packages/common/src/store/pages/trending/reducer.ts
@@ -75,7 +75,9 @@ const reducer =
         lastFetchedTrendingGenre: null,
         trendingWeek: makeInitialState(TRENDING_WEEK_PREFIX),
         trendingMonth: makeInitialState(TRENDING_MONTH_PREFIX),
-        trendingAllTime: makeInitialState(TRENDING_ALL_TIME_PREFIX)
+        trendingAllTime: makeInitialState(TRENDING_ALL_TIME_PREFIX),
+        trendingGenre: null,
+        trendingTimeRange: TimeRange.WEEK
       }
 
       if (history) {
@@ -116,9 +118,26 @@ const reducer =
       return { ...state, trendingAllTime }
     }
 
-    const matchingReduceFunction = actionsMap[action.type]
-    if (!matchingReduceFunction) return state
-    return matchingReduceFunction(state, action as TrendingPageAction)
+    // Handle each action type separately
+    switch (action.type) {
+      case SET_TRENDING_GENRE:
+        return actionsMap[SET_TRENDING_GENRE](
+          state,
+          action as SetTrendingGenreAction
+        )
+      case SET_TRENDING_TIME_RANGE:
+        return actionsMap[SET_TRENDING_TIME_RANGE](
+          state,
+          action as SetTrendingTimeRangeAction
+        )
+      case SET_LAST_FETCHED_TRENDING_GENRE:
+        return actionsMap[SET_LAST_FETCHED_TRENDING_GENRE](
+          state,
+          action as SetLastFetchedTrendingGenreAction
+        )
+      default:
+        return state
+    }
   }
 
 export default reducer


### PR DESCRIPTION
### Description

This PR addresses two issues with the Trending page reported in triage channel:

1. **UI Bug**: When visiting the Trending page for the first time or refreshing, the "All Genres" pill is not auto-selected by default, and the Rewards Banner is missing until a user explicitly clicks on the "All Genres" pill.

2. **TypeScript Error**: The reducer had a type safety issue where `actionsMap[action.type]` could potentially access non-existent properties, causing TypeScript to report an error.

## Solution

### 1. Fixed Initial State

Added explicit default values to the initial state:
- `trendingGenre: null` - Ensures "All Genres" is selected by default
- `trendingTimeRange: TimeRange.WEEK` - Ensures "This Week" is selected by default

This ensures that when a user first visits the Trending page:
- The "All Genres" pill is visually selected
- The Rewards Banner appears immediately (since it's conditionally rendered when `trendingGenre === null`)

### 2. Improved Type Safety

Replaced the problematic direct access to `actionsMap[action.type]` with a switch statement that:
- Handles each specific action type separately
- Uses proper type assertions for each action type
- Provides a default case for unhandled actions

This approach eliminates the TypeScript error while maintaining the same functionality.

### How Has This Been Tested?

`npm run web:stage`

- Visit trending page
- Click around
- Ensure that the trending banner is shown and the `All generes` tab is selected 
