### PR TITLE
Fix first comment status label

### DIFF
--- a/packages/common/src/hooks/useAudioRewards.ts
+++ b/packages/common/src/hooks/useAudioRewards.ts
@@ -4,7 +4,7 @@ import { fillString, formatNumberCommas } from '~/utils'
 const messages = {
   completeLabel: 'COMPLETE',
   readyToClaim: 'Ready to Claim',
-  pendingRewards: 'Pending Reward',
+  pendingRewards: 'Reward Pending',
   day: (day: number) => `Day ${day} ${day > 0 ? '🔥' : ''}`
 }
 

--- a/packages/common/src/utils/challenges.ts
+++ b/packages/common/src/utils/challenges.ts
@@ -417,7 +417,11 @@ export const getChallengeStatusLabel = (
       }
       return 'No Recent Activity'
     case ChallengeName.FirstWeeklyComment:
-      if (challenge.disbursed_amount && !challenge.claimableAmount) {
+      if (
+        challenge.disbursed_amount &&
+        !challenge.claimableAmount &&
+        !challenge.undisbursedSpecifiers.length
+      ) {
         return 'Resets Friday'
       }
   }
@@ -437,7 +441,10 @@ export const getChallengeStatusLabel = (
   }
 
   // Handle completed with cooldown state
-  if (challenge.state === 'completed' && challenge.cooldown_days) {
+  if (
+    (challenge.state === 'completed' || challenge.state === 'in_progress') &&
+    challenge.cooldown_days
+  ) {
     return DEFAULT_STATUS_LABELS.REWARD_PENDING
   }
 

--- a/packages/common/src/utils/challenges.ts
+++ b/packages/common/src/utils/challenges.ts
@@ -403,6 +403,11 @@ export const getChallengeStatusLabel = (
   if (!challenge) return DEFAULT_STATUS_LABELS.AVAILABLE
 
   // Handle special aggregate challenges first
+  const shouldShowReset =
+    challenge.disbursed_amount &&
+    !challenge.claimableAmount &&
+    !challenge.undisbursedSpecifiers.length
+
   switch (challengeId) {
     case ChallengeName.ListenStreakEndless:
       return `Day ${challenge.current_step_count}`
@@ -417,13 +422,10 @@ export const getChallengeStatusLabel = (
       }
       return 'No Recent Activity'
     case ChallengeName.FirstWeeklyComment:
-      if (
-        challenge.disbursed_amount &&
-        !challenge.claimableAmount &&
-        !challenge.undisbursedSpecifiers.length
-      ) {
+      if (shouldShowReset) {
         return 'Resets Friday'
       }
+      return DEFAULT_STATUS_LABELS.AVAILABLE
   }
 
   // Handle claimable state for non-aggregate rewards
@@ -432,11 +434,11 @@ export const getChallengeStatusLabel = (
   }
 
   // Handle disbursed state - 2nd clause is for aggregate challenges
-  if (
+  const shouldShowComplete =
     challenge.state === 'disbursed' ||
     (challenge.state === 'completed' &&
       challenge.current_step_count === challenge.max_steps)
-  ) {
+  if (shouldShowComplete) {
     return DEFAULT_STATUS_LABELS.COMPLETE
   }
 

--- a/packages/mobile/src/screens/rewards-screen/Panel.tsx
+++ b/packages/mobile/src/screens/rewards-screen/Panel.tsx
@@ -20,7 +20,7 @@ const messages = {
   completeLabel: 'COMPLETE',
   claimReward: 'Claim This Reward',
   readyToClaim: 'Ready to Claim',
-  pendingRewards: 'Pending Reward',
+  pendingRewards: 'Reward Pending',
   viewDetails: 'View Details',
   new: 'New!'
 }

--- a/packages/web/src/pages/rewards-page/components/modals/ChallengeRewardsModal/FirstWeeklyCommentChallengeModalContent.tsx
+++ b/packages/web/src/pages/rewards-page/components/modals/ChallengeRewardsModal/FirstWeeklyCommentChallengeModalContent.tsx
@@ -35,10 +35,15 @@ export const FirstWeeklyCommentChallengeModalContent = ({
   const isMobile = useIsMobile()
   const userChallenge = useSelector(getOptimisticUserChallenges)[challengeName]
   const undisbursedUserChallenges = useSelector(getUndisbursedUserChallenges)
+
   const claimStatus = useSelector(getClaimStatus)
   const claimInProgress =
     claimStatus === ClaimStatus.CLAIMING ||
     claimStatus === ClaimStatus.WAITING_FOR_RETRY
+  const shouldShowResetIcon =
+    userChallenge?.disbursed_amount &&
+    !userChallenge?.claimableAmount &&
+    !userChallenge?.undisbursedSpecifiers?.length
 
   // Following the pattern from mobile implementation
   const modifiedChallenge = challenge
@@ -62,13 +67,14 @@ export const FirstWeeklyCommentChallengeModalContent = ({
         pv='l'
         gap='s'
         w='100%'
-        justifyContent={isMobile ? 'center' : 'flex-start'}
+        justifyContent={
+          isMobile || !userChallenge.disbursed_amount ? 'center' : 'flex-start'
+        }
         alignItems='center'
       >
         {userChallenge?.claimableAmount ? (
           <IconCheck size='s' color='subdued' />
-        ) : userChallenge?.disbursed_amount &&
-          !userChallenge?.claimableAmount ? (
+        ) : shouldShowResetIcon ? (
           <IconArrowRotate size='s' color='subdued' />
         ) : null}
         <Text variant='label' size='l' color='subdued'>

--- a/packages/web/src/pages/rewards-page/messages.tsx
+++ b/packages/web/src/pages/rewards-page/messages.tsx
@@ -16,7 +16,7 @@ export const messages = {
   claimAllRewards: 'Claim All Rewards',
   moreInfo: 'More Info',
   readyToClaim: 'Ready to Claim',
-  pendingRewards: 'Pending Reward',
+  pendingRewards: 'Reward Pending',
   totalUpcomingRewards: 'Total Upcoming Rewards',
   totalReadyToClaim: 'Ready To Claim',
   pending: 'Pending',


### PR DESCRIPTION
### Description
- Update all messages that say "pending reward" to "reward pending"
- Fix first weekly comment challenge progress label alignment + logic: should only show "resets friday" if there are no challenges that are waiting for cooldown, and no claimable amount. "resets friday" should be the lowest priority and show only if there is no other info to tell the user. Should favor "reward pending" if there are challenges waiting for cooldown, or "ready to claim" if there are claimable challenges.

### How Has This Been Tested?

<img width="730" alt="Screenshot 2025-03-03 at 5 16 17 PM" src="https://github.com/user-attachments/assets/ed8d73ff-d2b2-4201-b825-228b99afe978" />
<img width="732" alt="Screenshot 2025-03-03 at 5 15 48 PM" src="https://github.com/user-attachments/assets/d2de1de3-c1a3-447e-aedc-5e143e1ee275" />
