### PR TITLE
Update trending modal header

### DIFF
--- a/packages/web/src/components/rewards/modals/TrendingRewards.tsx
+++ b/packages/web/src/components/rewards/modals/TrendingRewards.tsx
@@ -11,7 +11,9 @@ import { route } from '@audius/common/utils'
 import {
   SegmentedControl,
   IconArrowRight as IconArrow,
-  Button
+  Button,
+  Text,
+  Flex
 } from '@audius/harmony'
 import cn from 'classnames'
 import { useDispatch } from 'react-redux'
@@ -235,12 +237,14 @@ const TrendingRewardsModal = () => {
       isOpen={isOpen}
       onClose={() => setOpen(false)}
       title={
-        <h2 className={styles.titleHeader}>
+        <Flex alignItems='flex-end' justifyContent='center' gap='xs'>
           <i
             className={`emoji large ${styles.titleIcon} ${textMap[modalType].icon}`}
           />
-          {textMap[modalType].modalTitle}
-        </h2>
+          <Text variant='heading' color='staticWhite'>
+            {textMap[modalType].modalTitle}
+          </Text>
+        </Flex>
       }
       allowScroll
       showTitleHeader


### PR DESCRIPTION
### Description
Trending modal header wasn't readable, updated to use harmony text component and made more readable. Will follow up with design for a better design update but this should do for now

### How Has This Been Tested?

Before:
<img width="736" alt="image" src="https://github.com/user-attachments/assets/d13e3236-950c-402c-85e0-e8d5facacb07" />


After:
<img width="732" alt="image" src="https://github.com/user-attachments/assets/82e8e53b-6233-4707-8b79-8e445cf5a161" />

