### PR TITLE
fix max width for flex page container

### DIFF
--- a/packages/web/src/components/page/FlushPageContainer.tsx
+++ b/packages/web/src/components/page/FlushPageContainer.tsx
@@ -13,7 +13,8 @@ export const FlushPageContainer = (props: FlexProps) => {
       {...flexProps}
     >
       <Flex
-        flex='1 1 100%'
+        flex='1'
+        w='100%'
         justifyContent='center'
         css={{ maxWidth: MAX_PAGE_WIDTH_PX }}
       >


### PR DESCRIPTION
### Description
Fixes an issue when the content inside the container causes it to overflow. Apparently `flex-basis: 100%` does not prevent the container from exceeding 100% width! TIL.

### How Has This Been Tested?
Local client against staging, checked track page and profile page widths to verify they had correct padding.
