### PR TITLE
[PAY-3985] More misc first weekly comment challenge UI fixes

### DIFF
--- a/packages/common/src/utils/challenges.ts
+++ b/packages/common/src/utils/challenges.ts
@@ -380,6 +380,7 @@ export const getClaimableChallengeSpecifiers = (
 
 const newChallengeIds: ChallengeRewardID[] = [
   ChallengeName.ListenStreakEndless,
+  ChallengeName.FirstWeeklyComment,
   ChallengeName.AudioMatchingSell,
   ChallengeName.AudioMatchingBuy
 ]

--- a/packages/mobile/src/components/challenge-rewards-drawer/ClaimError.tsx
+++ b/packages/mobile/src/components/challenge-rewards-drawer/ClaimError.tsx
@@ -1,8 +1,6 @@
 import { getAAOErrorEmojis } from '@audius/common/utils'
 
-import { Text } from 'app/components/core'
-
-import { useStyles } from './styles'
+import { Text } from '@audius/harmony-native'
 
 const messages = {
   claimErrorMessage:
@@ -13,13 +11,10 @@ const messages = {
 
 /** Renders a generic error message for failed challenge claims */
 export const ClaimError = ({ aaoErrorCode }: { aaoErrorCode?: number }) => {
-  const styles = useStyles()
   return aaoErrorCode === undefined ? (
-    <Text style={styles.claimRewardsError} weight='bold'>
-      {messages.claimErrorMessage}
-    </Text>
+    <Text>{messages.claimErrorMessage}</Text>
   ) : (
-    <Text style={styles.claimRewardsError} weight='bold'>
+    <Text>
       {messages.claimErrorMessageAAO}
       {getAAOErrorEmojis(aaoErrorCode)}
     </Text>

--- a/packages/web/src/pages/rewards-page/components/modals/ChallengeRewardsModal/ClaimButton.tsx
+++ b/packages/web/src/pages/rewards-page/components/modals/ChallengeRewardsModal/ClaimButton.tsx
@@ -13,7 +13,7 @@ const { claimChallengeReward } = audioRewardsPageActions
 
 const messages = {
   close: 'Close',
-  claimableAmountLabel: (amount: number) => `Claim $${amount} $AUDIO`
+  claimableAmountLabel: (amount: number) => `Claim ${amount} $AUDIO`
 }
 
 type ClaimButtonProps = {


### PR DESCRIPTION
### Description
- Add first weekly comment challenge to "new" list
- Remove '$' in front of amount
- Use harmony `Text` for error content on web.

[PAY-3984]

### How Has This Been Tested?

<img width="742" alt="Screenshot 2025-03-04 at 3 34 13 PM" src="https://github.com/user-attachments/assets/302bbad6-6c4f-46b3-abbf-3a63c6aad7c5" />
<img width="356" alt="Screenshot 2025-03-04 at 3 46 24 PM" src="https://github.com/user-attachments/assets/59770c1c-ec7a-4284-9b3c-1f339d62ee4f" />
