### PR TITLE
[PAY-3983] Fix missing status label on reward panels

### DIFF
--- a/packages/common/src/hooks/useAudioRewards.ts
+++ b/packages/common/src/hooks/useAudioRewards.ts
@@ -1,5 +1,9 @@
 import { ChallengeName, OptimisticUserChallenge } from '~/models'
-import { fillString, formatNumberCommas } from '~/utils'
+import {
+  fillString,
+  formatNumberCommas,
+  getChallengeStatusLabel
+} from '~/utils'
 
 const messages = {
   completeLabel: 'COMPLETE',
@@ -75,6 +79,12 @@ export const useFormattedProgressLabel = ({
       challenge?.disbursed_amount > 0
     ) {
       label = messages.completeLabel
+    } else if (
+      challenge?.challenge_id === ChallengeName.FirstWeeklyComment ||
+      challenge?.challenge_id === ChallengeName.AudioMatchingBuy ||
+      challenge?.challenge_id === ChallengeName.AudioMatchingSell
+    ) {
+      label = getChallengeStatusLabel(challenge, challenge?.challenge_id)
     } else {
       // Count down
       label = fillString(


### PR DESCRIPTION
### Description
Missing status label for these challenges that are aggregate challenges but not quite. Usually we do the x/y step count, but for these we need a special-case.

### How Has This Been Tested?

<img width="372" alt="Screenshot 2025-03-04 at 5 20 59 PM" src="https://github.com/user-attachments/assets/b21926bc-f2bf-4897-b6c6-1478eb49fecf" />
