### PR TITLE
Remove invalid model fields for create track/playlist notifs

### DIFF
--- a/packages/discovery-provider/src/api/v1/models/notifications.py
+++ b/packages/discovery-provider/src/api/v1/models/notifications.py
@@ -228,7 +228,6 @@ cosign_notification = ns.clone(
 create_playlist_notification_action_data = ns.model(
     "create_playlist_notification_action_data",
     {
-        "playlist_data": fields.String(),
         "is_album": fields.Boolean(required=True),
         "playlist_id": fields.List(fields.String(required=True), required=True),
     },
@@ -236,7 +235,6 @@ create_playlist_notification_action_data = ns.model(
 create_track_notification_action_data = ns.model(
     "create_track_notification_action_data",
     {
-        "track_data": fields.String(),
         "track_id": fields.String(required=True),
     },
 )


### PR DESCRIPTION
### Description
This will take care of the endless stream of model marshalling error messages. These two fields don't exist on the notification data that we get back from queries. While we _could_ try to make the marshaller accept missing fields where `None` is an option, this is safer for now. There fields don't appear to be in use anywhere on the client.

### How Has This Been Tested?
Local stack and client. Created 2 users, user B follows user A. User A creates a new track. Verified we no longer see error logs for bad marshalling.
