### PR TITLE
Fix missing cover-photo error log

### DIFF
--- a/packages/discovery-provider/src/schemas/user_schema.json
+++ b/packages/discovery-provider/src/schemas/user_schema.json
@@ -10,7 +10,15 @@
                     "type": ["string", "null"],
                     "default": null
                 },
+                "profile_picture": {
+                    "type": ["string", "null"],
+                    "default": null
+                },
                 "profile_picture_sizes": {
+                    "type": ["string", "null"],
+                    "default": null
+                },
+                "cover_photo": {
                     "type": ["string", "null"],
                     "default": null
                 },
@@ -88,11 +96,9 @@
             },
             "required": [
                 "bio",
-                "cover_photo",
                 "cover_photo_sizes",
                 "location",
                 "name",
-                "profile_picture",
                 "profile_picture_sizes",
                 "artist_pick_track_id"
             ],


### PR DESCRIPTION
### Description

https://github.com/AudiusProject/audius-protocol/pull/10546/files#diff-e1b0c168f81af1a6c8724937b450b62a0c76750be2f3445c84ceeaadc59048b3
erroneously removed these are they are needed to support "legacy" photos (with no sizes)

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._

will confirm on staging, should be safe