### PR TITLE
Revert "[C-5204] Fix android comment input clipping (#11386)"

### DIFF
--- a/packages/mobile/src/components/comments/CommentDrawer.tsx
+++ b/packages/mobile/src/components/comments/CommentDrawer.tsx
@@ -25,7 +25,7 @@ import {
 import type { ParamListBase } from '@react-navigation/native'
 import type { NativeStackNavigationProp } from '@react-navigation/native-stack'
 import type { TouchableOpacityProps } from 'react-native'
-import { Platform, TouchableOpacity } from 'react-native'
+import { TouchableOpacity } from 'react-native'
 import { Gesture, GestureDetector } from 'react-native-gesture-handler'
 import { useSafeAreaInsets } from 'react-native-safe-area-context'
 import { useSelector } from 'react-redux'
@@ -274,16 +274,14 @@ export const CommentDrawer = (props: CommentDrawerProps) => {
         </BottomSheetFooter>
       </GestureDetector>
     ),
+    // intentionally excluding insets.bottom because it causes a rerender
+    // when the keyboard is opened on android, causing the keyboard to close
+    // eslint-disable-next-line react-hooks/exhaustive-deps
     [
-      gesture,
-      insets.bottom,
       entityId,
-      replyingAndEditingState,
-      uid,
-      actions,
       onAutoCompleteChange,
       setAutocompleteHandler,
-      autoFocusInput
+      replyingAndEditingState
     ]
   )
 
@@ -315,9 +313,7 @@ export const CommentDrawer = (props: CommentDrawerProps) => {
         )}
         footerComponent={renderFooterComponent}
         onDismiss={handleCloseDrawer}
-        android_keyboardInputMode='adjustPan'
-        keyboardBehavior={Platform.OS === 'android' ? 'extend' : 'fillParent'}
-        keyboardBlurBehavior='restore'
+        android_keyboardInputMode='adjustResize'
       >
         <CommentSectionProvider
           entityId={entityId}


### PR DESCRIPTION
This reverts commit d8816784a465e3ce51a0dba2dd70f609baff29a4 which introduced a regression where the comment drawer would close unexpectedly. Will give this another look