### PR TITLE
core block updated in redis

### DIFF
--- a/packages/discovery-provider/src/api_helpers.py
+++ b/packages/discovery-provider/src/api_helpers.py
@@ -15,6 +15,7 @@ from src.queries.get_sol_plays import get_sol_play_health_info
 # pylint: disable=R0401
 from src.utils import helpers, web3_provider
 from src.utils.config import shared_config
+from src.utils.core import get_core_health, is_indexing_core_plays
 from src.utils.helpers import generate_signature
 from src.utils.redis_connection import get_redis
 from src.utils.redis_constants import most_recent_indexed_block_redis_key
@@ -90,6 +91,16 @@ def response_dict_with_metadata(response_dictionary, sign_response):
     response_dictionary["latest_chain_slot_plays"] = (
         play_chain_tx["slot"] if play_chain_tx else None
     )
+
+    if is_indexing_core_plays():
+        core_health = get_core_health()
+        if core_health:
+            response_dictionary["latest_indexed_slot_plays"] = core_health.get(
+                "latest_indexed_block"
+            )
+            response_dictionary["latest_chain_slot_plays"] = core_health.get(
+                "latest_chain_block"
+            )
 
     response_dictionary["version"] = disc_prov_version
     response_dictionary["signer"] = shared_config["delegate"]["owner_wallet"]

--- a/packages/discovery-provider/src/tasks/index_latest_block.py
+++ b/packages/discovery-provider/src/tasks/index_latest_block.py
@@ -1,5 +1,6 @@
 from src.tasks.celery_app import celery
 from src.utils import helpers, web3_provider
+from src.utils.core import is_indexing_core_em
 from src.utils.prometheus_metric import save_duration_metric
 from src.utils.redis_constants import (
     latest_block_hash_redis_key,
@@ -31,5 +32,9 @@ def update_latest_block_redis(final_poa_block):
 @celery.task(name="index_latest_block", bind=True)
 @save_duration_metric(metric_group="celery_task")
 def update_task(self):
+    # index_core.py sets the redis keys now
+    if is_indexing_core_em():
+        return
+
     final_poa_block = helpers.get_final_poa_block()
     update_latest_block_redis(final_poa_block)

--- a/packages/discovery-provider/src/utils/core.py
+++ b/packages/discovery-provider/src/utils/core.py
@@ -38,3 +38,11 @@ def is_indexing_core_em() -> Optional[bool]:
     if core_health:
         return core_health.get("indexing_entity_manager")
     return None
+
+
+# TODO: cache response to avoid excessive redis calls
+def is_indexing_core_plays() -> Optional[bool]:
+    core_health = get_core_health()
+    if core_health:
+        return core_health.get("indexing_plays")
+    return None


### PR DESCRIPTION
### Description
This fixes the aggresive reselection by sdk because it checks these values after every requests to find a new healthy node. Healthz didn't report this because it sources the correct core data but this middleware did not. This middleware was still reading old data.

⚠️ I'm ignoring the poa offset that was in the previous implementation as what seems important here is if the numbers are far apart, not that it's actually poa + acdc + core now. Block this PR if that implementation seems wrong and we want to keep that total for some reason. This info is still in the database tracked in the blocks table.

- updates the index_latest_block task to return early if indexing em via core
- updates these value as part of the index_core.py
- updates the response middleware to pull the latest core indexed block and latest block for plays too
- the em and plays numbers now match because they index from the same source

### How Has This Been Tested?
`
audius-cmd user create alec1
`

go to /v1/full/users/handle/alec1
see the block diff stuff from the middleware filled out properly

and/or
`npm run web:dev`
sign up
make sure there's no errors in console threatening reselection