### PR TITLE
[QA-2004] Fix delete icon popping above edit collection form footer

### DIFF
--- a/packages/web/src/components/edit/AnchoredSubmitRow.module.css
+++ b/packages/web/src/components/edit/AnchoredSubmitRow.module.css
@@ -16,4 +16,5 @@
   display: flex;
   flex-direction: column;
   align-items: center;
+  z-index: 2; /* zIndex.ts: SVG_BUTTON_ICONS+1 */
 }

--- a/packages/web/src/components/edit/AnchoredSubmitRowEdit.module.css
+++ b/packages/web/src/components/edit/AnchoredSubmitRowEdit.module.css
@@ -16,4 +16,5 @@
   display: flex;
   flex-direction: column;
   align-items: center;
+  z-index: 2; /* zIndex.ts: SVG_BUTTON_ICONS+1 */
 }

--- a/packages/web/src/utils/zIndex.ts
+++ b/packages/web/src/utils/zIndex.ts
@@ -10,6 +10,10 @@ export enum zIndex {
   // These are still set in css, added here for reference
   // TODO: use these enums
 
+  // Harmony buttons use a zIndex for their icons which can put them above
+  // other elements that get promoted to gpu layers
+  SVG_BUTTON_ICONS = 1,
+
   GATED_TRACK_TILE_CORNER_TAG = 3,
   // Legacy tabs component from useTabs()
   TAB_ACCENT = 9,


### PR DESCRIPTION
### Description
Fixes a zIndex issue if you happen to have a small-height window and attempt to edit an album. There's a SVG rendered in a button that uses `zIndex: 1`, which will render it above the form footer since it's also a GPU layer.

Nothing fancy for now, just updating it to use a higher zIndex and reference the constants file.

### How Has This Been Tested?
Local client against staging, verified the icon no longer renders above the form footer.
