### PR TITLE
Summary Table for first weekly comment challenge

### DIFF
--- a/packages/mobile/src/components/challenge-rewards-drawer/ChallengeRewardsLayout.tsx
+++ b/packages/mobile/src/components/challenge-rewards-drawer/ChallengeRewardsLayout.tsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import type { ReactNode } from 'react'
 
 import { ScrollView } from 'react-native-gesture-handler'
 
@@ -15,7 +16,7 @@ const messages = {
 
 type ChallengeRewardsLayoutProps = {
   /** The description component or content */
-  description: React.ReactNode
+  description: ReactNode
   /** Optional additional description */
   optionalDescription?: string
   /** The amount of $AUDIO that is rewarded */
@@ -29,15 +30,13 @@ type ChallengeRewardsLayoutProps = {
   /** Maximum progress value */
   progressMax?: number | null
   /** Status label component */
-  statusLabel: React.ReactNode
+  statusLabel: ReactNode
   /** Additional content to render */
-  additionalContent?: React.ReactNode
+  additionalContent?: ReactNode
   /** Error content to display */
-  errorContent?: React.ReactNode
-  /** Whether a claim is in progress */
-  claimInProgress?: boolean
+  errorContent?: ReactNode
   /** The claim button or other action component */
-  actions: React.ReactNode
+  actions: ReactNode
   /** Whether this is a cooldown challenge */
   isCooldownChallenge?: boolean
 }
@@ -53,7 +52,6 @@ export const ChallengeRewardsLayout = ({
   statusLabel,
   additionalContent,
   errorContent,
-  claimInProgress,
   actions,
   isCooldownChallenge
 }: ChallengeRewardsLayoutProps) => {

--- a/packages/mobile/src/components/challenge-rewards-drawer/DefaultChallengeContent.tsx
+++ b/packages/mobile/src/components/challenge-rewards-drawer/DefaultChallengeContent.tsx
@@ -108,7 +108,6 @@ export const DefaultChallengeContent = ({
       progressValue={challenge?.current_step_count}
       progressMax={challenge?.max_steps}
       statusLabel={statusLabel}
-      claimInProgress={claimInProgress}
       actions={children ?? actions}
       errorContent={
         claimError ? <ClaimError aaoErrorCode={aaoErrorCode} /> : null

--- a/packages/mobile/src/components/challenge-rewards-drawer/FirstWeeklyCommentChallengeContent.tsx
+++ b/packages/mobile/src/components/challenge-rewards-drawer/FirstWeeklyCommentChallengeContent.tsx
@@ -20,6 +20,7 @@ import { getChallengeConfig } from 'app/utils/challenges'
 
 import { ChallengeRewardsLayout } from './ChallengeRewardsLayout'
 import { ClaimError } from './ClaimError'
+import { CooldownSummaryTable } from './CooldownSummaryTable'
 import type { ChallengeContentProps } from './types'
 
 const messages = {
@@ -127,6 +128,11 @@ export const FirstWeeklyCommentChallengeContent = ({
       rewardSubtext={messages.rewardMapping}
       statusLabel={statusLabel}
       actions={actions}
+      additionalContent={
+        challenge?.cooldown_days ? (
+          <CooldownSummaryTable challengeId={challenge.challenge_id} />
+        ) : null
+      }
       errorContent={
         claimError ? <ClaimError aaoErrorCode={aaoErrorCode} /> : null
       }

--- a/packages/mobile/src/components/summary-table/SummaryTable.tsx
+++ b/packages/mobile/src/components/summary-table/SummaryTable.tsx
@@ -210,7 +210,7 @@ export const SummaryTable = ({
   }
 
   return (
-    <Flex direction='column' gap='l'>
+    <Flex direction='column' gap='l' w='100%'>
       {collapsible ? (
         <Expandable
           style={styles.container}

--- a/packages/web/src/pages/rewards-page/components/modals/ChallengeRewardsModal/FirstWeeklyCommentChallengeModalContent.tsx
+++ b/packages/web/src/pages/rewards-page/components/modals/ChallengeRewardsModal/FirstWeeklyCommentChallengeModalContent.tsx
@@ -15,6 +15,7 @@ import { useIsMobile } from 'hooks/useIsMobile'
 
 import { ChallengeRewardsLayout } from './ChallengeRewardsLayout'
 import { ClaimButton } from './ClaimButton'
+import { CooldownSummaryTable } from './CooldownSummaryTable'
 import { type DefaultChallengeProps } from './types'
 
 const { getOptimisticUserChallenges } = challengesSelectors
@@ -107,6 +108,11 @@ export const FirstWeeklyCommentChallengeModalContent = ({
       amount={modifiedChallenge?.totalAmount}
       rewardSubtext={messages.rewardSubtext}
       progressStatusLabel={progressStatusLabel}
+      additionalContent={
+        challenge?.cooldown_days ? (
+          <CooldownSummaryTable challengeId={challenge.challenge_id} />
+        ) : null
+      }
       actions={
         <ClaimButton
           challenge={modifiedChallenge}


### PR DESCRIPTION
### Description
Forgot to add summary table for this challenge since it has cooldown.

### How Has This Been Tested?

Confirmed summary table in purchase drawer looks ok
![Simulator Screenshot - iPhone 16 Pro - 2025-03-05 at 14 53 07](https://github.com/user-attachments/assets/3c1a2fae-fdbe-4f59-b819-60f5c515f89f)

<img width="726" alt="Screenshot 2025-03-05 at 2 53 14 PM" src="https://github.com/user-attachments/assets/81286489-8c3a-468c-b345-cbd143f4901f" />
