### PR TITLE
Fix banner on mobile web

### DIFF
--- a/packages/web/src/pages/trending-page/components/RewardsBanner.tsx
+++ b/packages/web/src/pages/trending-page/components/RewardsBanner.tsx
@@ -93,7 +93,7 @@ const RewardsBanner = ({ bannerType }: RewardsBannerProps) => {
           width: isMobile ? '100%' : 'auto'
         }}
         alignItems={isMobile ? 'flex-start' : 'center'}
-        gap='l'
+        gap={isMobile ? undefined : 'l'}
       >
         <Flex
           alignItems='center'
@@ -110,11 +110,11 @@ const RewardsBanner = ({ bannerType }: RewardsBannerProps) => {
         <Text
           variant='body'
           size='l'
-          strength='weak'
+          strength={isMobile ? 'strong' : 'weak'}
           css={{
             marginLeft: isMobile ? 0 : spacing.s,
             marginTop: isMobile ? spacing.xs : 0,
-            whiteSpace: 'nowrap'
+            whiteSpace: isMobile ? 'normal' : 'nowrap'
           }}
         >
           {messageMap[bannerType].description}


### PR DESCRIPTION
### Description
Changes made in https://github.com/AudiusProject/audius-protocol/pull/11533 made the mobile web banner look janky, fixed. 

### How Has This Been Tested?
<img width="281" alt="image" src="https://github.com/user-attachments/assets/c59ccc57-f386-410d-ad1c-532992a9fb72" />

