### PR TITLE
Fix embed node polyfills and clean up deps

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -129979,7 +129979,6 @@
         "@audius/fixed-decimal": "*",
         "@audius/harmony": "*",
         "@audius/sdk": "*",
-        "@audius/sdk-legacy": "*",
         "@emotion/react": "11.11.1",
         "@emotion/styled": "11.11.0",
         "@google/model-viewer": "3.3.0",
@@ -130011,6 +130010,7 @@
         "@cloudflare/kv-asset-handler": "^0.3.0",
         "@vitejs/plugin-react": "4.1.0",
         "env-cmd": "10.1.0",
+        "esbuild-plugin-react-virtualized": "^1.0.4",
         "eslint": "8.56.0",
         "identity-obj-proxy": "3.0.0",
         "jest": "29.4.2",
@@ -130018,6 +130018,7 @@
         "serve": "11.1.0",
         "vite": "4.5.0",
         "vite-plugin-glslify": "2.0.2",
+        "vite-plugin-node-polyfills": "0.17.0",
         "vite-plugin-svgr": "4.1.0",
         "vite-tsconfig-paths": "4.2.1",
         "webpack-cli": "4.5.0"
@@ -130043,6 +130044,56 @@
       "engines": {
         "node": ">=14.0.0"
       }
+    },
+    "packages/embed/node_modules/@rollup/plugin-inject": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-inject/-/plugin-inject-5.0.5.tgz",
+      "integrity": "sha512-2+DEJbNBoPROPkgTDNe8/1YXWcqxbN5DTjASVIOx8HS+pITXushyNiBV56RB08zuptzz8gT3YfkqriTBVycepg==",
+      "dev": true,
+      "dependencies": {
+        "@rollup/pluginutils": "^5.0.1",
+        "estree-walker": "^2.0.2",
+        "magic-string": "^0.30.3"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "rollup": "^1.20.0||^2.0.0||^3.0.0||^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "rollup": {
+          "optional": true
+        }
+      }
+    },
+    "packages/embed/node_modules/@rollup/pluginutils": {
+      "version": "5.1.4",
+      "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-5.1.4.tgz",
+      "integrity": "sha512-USm05zrsFxYLPdWWq+K3STlWiT/3ELn3RcV5hJMghpeAIhxfsUIg6mt12CBJBInWMV4VneoV7SfGv8xIwo2qNQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "estree-walker": "^2.0.2",
+        "picomatch": "^4.0.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "rollup": "^1.20.0||^2.0.0||^3.0.0||^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "rollup": {
+          "optional": true
+        }
+      }
+    },
+    "packages/embed/node_modules/@types/estree": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.6.tgz",
+      "integrity": "sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw==",
+      "dev": true
     },
     "packages/embed/node_modules/hashids": {
       "version": "2.2.10",
@@ -130071,6 +130122,27 @@
         "node-notifier": {
           "optional": true
         }
+      }
+    },
+    "packages/embed/node_modules/magic-string": {
+      "version": "0.30.17",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.17.tgz",
+      "integrity": "sha512-sNPKHvyjVf7gyjwS4xGTaW/mCnF8wnjtifKBEhxfZ7E/S8tQ0rssrwGNn6q8JH/ohItJfSQp9mBtQYuTlH5QnA==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0"
+      }
+    },
+    "packages/embed/node_modules/picomatch": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz",
+      "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
     "packages/embed/node_modules/react-merge-refs": {
@@ -130121,6 +130193,22 @@
       "peerDependencies": {
         "react": ">=16.6.0",
         "react-dom": ">=16.6.0"
+      }
+    },
+    "packages/embed/node_modules/vite-plugin-node-polyfills": {
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/vite-plugin-node-polyfills/-/vite-plugin-node-polyfills-0.23.0.tgz",
+      "integrity": "sha512-4n+Ys+2bKHQohPBKigFlndwWQ5fFKwaGY6muNDMTb0fSQLyBzS+jjUNRZG9sKF0S/Go4ApG6LFnUGopjkILg3w==",
+      "dev": true,
+      "dependencies": {
+        "@rollup/plugin-inject": "^5.0.5",
+        "node-stdlib-browser": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/davidmyersdev"
+      },
+      "peerDependencies": {
+        "vite": "^2.0.0 || ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0"
       }
     },
     "packages/es-indexer": {

--- a/packages/embed/package.json
+++ b/packages/embed/package.json
@@ -21,6 +21,7 @@
     "@cloudflare/kv-asset-handler": "^0.3.0",
     "@vitejs/plugin-react": "4.1.0",
     "env-cmd": "10.1.0",
+    "esbuild-plugin-react-virtualized": "^1.0.4",
     "eslint": "8.56.0",
     "identity-obj-proxy": "3.0.0",
     "jest": "29.4.2",
@@ -28,6 +29,7 @@
     "serve": "11.1.0",
     "vite": "4.5.0",
     "vite-plugin-glslify": "2.0.2",
+    "vite-plugin-node-polyfills": "0.17.0",
     "vite-plugin-svgr": "4.1.0",
     "vite-tsconfig-paths": "4.2.1",
     "webpack-cli": "4.5.0"
@@ -37,7 +39,6 @@
     "@audius/fixed-decimal": "*",
     "@audius/harmony": "*",
     "@audius/sdk": "*",
-    "@audius/sdk-legacy": "*",
     "@emotion/react": "11.11.1",
     "@emotion/styled": "11.11.0",
     "@google/model-viewer": "3.3.0",

--- a/packages/embed/vite.config.js
+++ b/packages/embed/vite.config.js
@@ -1,7 +1,8 @@
-import { NodeGlobalsPolyfillPlugin } from '@esbuild-plugins/node-globals-polyfill'
 import react from '@vitejs/plugin-react'
+import fixReactVirtualized from 'esbuild-plugin-react-virtualized'
 import process from 'process/browser'
 import { defineConfig, loadEnv } from 'vite'
+import { nodePolyfills } from 'vite-plugin-node-polyfills'
 import svgr from 'vite-plugin-svgr'
 
 export default defineConfig(({ command, mode }) => {
@@ -15,7 +16,7 @@ export default defineConfig(({ command, mode }) => {
       outDir: 'build',
       sourcemap: true,
       commonjsOptions: {
-        include: [/libs\/dist\/web-libs/, /node_modules/]
+        include: [/node_modules/]
       }
     },
     define: {
@@ -24,16 +25,11 @@ export default defineConfig(({ command, mode }) => {
       'process.env': env
     },
     optimizeDeps: {
-      include: ['@audius/sdk-legacy/dist/web-libs', '@audius/fetch-nft'],
       esbuildOptions: {
         define: {
           global: 'globalThis'
         },
-        plugins: [
-          NodeGlobalsPolyfillPlugin({
-            buffer: true
-          })
-        ]
+        plugins: [fixReactVirtualized]
       }
     },
     plugins: [
@@ -58,6 +54,14 @@ export default defineConfig(({ command, mode }) => {
         babel: {
           plugins: ['@emotion/babel-plugin']
         }
+      }),
+      nodePolyfills({
+        exclude: ['fs'],
+        globals: {
+          Buffer: true,
+          process: true
+        },
+        protocolImports: true
       })
     ],
     resolve: {


### PR DESCRIPTION
### Description
The built bundle for `embed` is having some issues with the `Buffer` node polyfill. It doesn't cause a problem in dev when serving from vite, but does throw errors about Buffer when built and deployed.
<img width="837" alt="image" src="https://github.com/user-attachments/assets/0282e50a-47ec-425a-a942-7bc37f3f6f06" />


Bonus: Also removed the libs reference that I'm not sure why we still had here (nothing in embed calls into libs)

### How Has This Been Tested?
Built bundle and deployed to a test CF worker, was able to load a collectibles embed that had previously thrown.
