### PR TITLE
[PAY-3992] Improve suggested follows loading

### DIFF
--- a/packages/web/src/components/artist-recommendations/ArtistRecommendationsDropdown.tsx
+++ b/packages/web/src/components/artist-recommendations/ArtistRecommendationsDropdown.tsx
@@ -1,5 +1,6 @@
 import { useRef } from 'react'
 
+import { useRelatedArtists } from '@audius/common/api'
 // eslint-disable-next-line no-restricted-imports -- TODO: migrate to @react-spring/web
 import { useSpring, animated } from 'react-spring'
 
@@ -24,18 +25,29 @@ const fast = {
 export const ArtistRecommendationsDropdown = (
   props: ArtistRecommendationsDropdownProps
 ) => {
-  const { isVisible } = props
+  const { isVisible, artistId } = props
   const childRef = useRef<HTMLDivElement | null>(null)
+
+  const { data: suggestedArtists = [], isLoading } = useRelatedArtists({
+    artistId,
+    filterFollowed: true,
+    pageSize: 7
+  })
+
+  const shouldShowDropdown =
+    isVisible && !isLoading && suggestedArtists.length > 0
 
   const rect = childRef.current?.getBoundingClientRect()
   const childHeight = rect ? rect.bottom - rect.top : 0
 
   const spring = useSpring({
-    opacity: isVisible ? 1 : 0,
-    height: isVisible ? `${childHeight}px` : '0',
+    opacity: shouldShowDropdown ? 1 : 0,
+    height: shouldShowDropdown ? `${childHeight}px` : '0',
     from: { opacity: 0, height: `${childHeight}px` },
     config: fast
   })
+
+  if (!shouldShowDropdown) return null
 
   return (
     <animated.div className={styles.dropdown} style={spring}>

--- a/packages/web/src/pages/profile-page/components/mobile/ProfileHeader.tsx
+++ b/packages/web/src/pages/profile-page/components/mobile/ProfileHeader.tsx
@@ -24,7 +24,8 @@ import {
   Flex,
   Button,
   IconPencil,
-  FollowButton
+  FollowButton,
+  Text
 } from '@audius/harmony'
 import cn from 'classnames'
 
@@ -476,7 +477,9 @@ const ProfileHeader = ({
           <ArtistRecommendationsDropdown
             isVisible={areArtistRecommendationsVisible}
             renderHeader={() => (
-              <p>Here are some accounts that vibe well with {name}</p>
+              <Flex ml='m'>
+                <Text>Here are some accounts that vibe well with {name}</Text>
+              </Flex>
             )}
             artistId={userId}
             onClose={onCloseArtistRecommendations}


### PR DESCRIPTION
### Description

When a user has no related artists OR you have followed all of their related artists, the suggestion popup opens and spins forever.

This is a full-ish fix, but it is a bit funky. Not sure if we like this pattern, but this change
1. Checks to see if we have any related artists loaded (we load this for all profiles on web). If we haven't, we shouldn't display the popup at all
2. Do the fetch in the popup and only show once we have the list

I could be happy with just shipping (2) and removing the work for (1) since I'm not sure if we like calling getQueryData in a component

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._

Web + mobile web
http://localhost:3002/keanuaer (has related)
http://localhost:3002/preshzino_songz (doesn't have related)