### PR TITLE
Update collectibles modal UI

### DIFF
--- a/packages/web/src/components/collectibles/components/CollectibleRow.tsx
+++ b/packages/web/src/components/collectibles/components/CollectibleRow.tsx
@@ -5,7 +5,9 @@ import { formatDateWithTimezoneOffset } from '@audius/common/utils'
 import {
   IconRemove as IconHide,
   IconDrag,
-  IconMultiselectAdd as IconShow
+  IconMultiselectAdd as IconShow,
+  Pill,
+  Text
 } from '@audius/harmony'
 import cn from 'classnames'
 
@@ -67,7 +69,7 @@ export const VisibleCollectibleRow = (props) => {
   return (
     <div className={styles.editRow} ref={forwardRef} {...otherProps}>
       <Tooltip text={collectibleMessages.hideCollectible}>
-        <IconHide onClick={onHideClick} />
+        <IconHide color='danger' onClick={onHideClick} />
       </Tooltip>
       <div className={styles.verticalDivider} />
       {(frameUrl ?? gifUrl) ? (
@@ -91,16 +93,14 @@ export const VisibleCollectibleRow = (props) => {
       ) : (
         <div className={styles.editMediaEmpty} />
       )}
-      <div className={styles.editRowTitle}>{name}</div>
+      <div className={styles.editRowTitle}>
+        <Text variant='title'>{name}</Text>
+      </div>
       <div>
         {isOwned ? (
-          <span className={cn(styles.owned, styles.editStamp)}>
-            {collectibleMessages.owned}
-          </span>
+          <Pill variant='active'>{collectibleMessages.owned}</Pill>
         ) : (
-          <span className={cn(styles.created, styles.editStamp)}>
-            {collectibleMessages.created}
-          </span>
+          <Pill>{collectibleMessages.created}</Pill>
         )}
       </div>
       {dateCreated && <div>{formatDateWithTimezoneOffset(dateCreated)}</div>}
@@ -152,16 +152,14 @@ export const HiddenCollectibleRow = (props: HiddenCollectibleRowProps) => {
       ) : (
         <div className={styles.editMediaEmpty} />
       )}
-      <div className={styles.editRowTitle}>{name}</div>
+      <div className={styles.editRowTitle}>
+        <Text variant='title'>{name}</Text>
+      </div>
       <div>
         {isOwned ? (
-          <span className={cn(styles.owned, styles.editStamp)}>
-            {collectibleMessages.owned}
-          </span>
+          <Pill variant='active'>{collectibleMessages.owned}</Pill>
         ) : (
-          <span className={cn(styles.created, styles.editStamp)}>
-            {collectibleMessages.created}
-          </span>
+          <Pill>{collectibleMessages.created}</Pill>
         )}
       </div>
       {dateCreated && <div>{formatDateWithTimezoneOffset(dateCreated)}</div>}

--- a/packages/web/src/components/collectibles/components/CollectibleRow.tsx
+++ b/packages/web/src/components/collectibles/components/CollectibleRow.tsx
@@ -6,7 +6,6 @@ import {
   IconRemove as IconHide,
   IconDrag,
   IconMultiselectAdd as IconShow,
-  Pill,
   Text
 } from '@audius/harmony'
 import cn from 'classnames'
@@ -30,7 +29,7 @@ export const VisibleCollectibleRow = (props) => {
     handleProps,
     ...otherProps
   } = props
-  const { name, isOwned, dateCreated, mediaType, frameUrl, gifUrl, videoUrl } =
+  const { name, dateCreated, mediaType, frameUrl, gifUrl, videoUrl } =
     collectible
 
   const dragRef = useRef<HTMLDivElement>(null)
@@ -96,13 +95,6 @@ export const VisibleCollectibleRow = (props) => {
       <div className={styles.editRowTitle}>
         <Text variant='title'>{name}</Text>
       </div>
-      <div>
-        {isOwned ? (
-          <Pill variant='active'>{collectibleMessages.owned}</Pill>
-        ) : (
-          <Pill>{collectibleMessages.created}</Pill>
-        )}
-      </div>
       {dateCreated && <div>{formatDateWithTimezoneOffset(dateCreated)}</div>}
       <div className={styles.verticalDivider} />
       <div className={styles.drag} ref={dragRef} {...handleProps}>
@@ -119,7 +111,7 @@ type HiddenCollectibleRowProps = {
 
 export const HiddenCollectibleRow = (props: HiddenCollectibleRowProps) => {
   const { collectible, onShowClick } = props
-  const { name, isOwned, dateCreated, mediaType, frameUrl, gifUrl, videoUrl } =
+  const { name, dateCreated, mediaType, frameUrl, gifUrl, videoUrl } =
     collectible
 
   return (
@@ -154,13 +146,6 @@ export const HiddenCollectibleRow = (props: HiddenCollectibleRowProps) => {
       )}
       <div className={styles.editRowTitle}>
         <Text variant='title'>{name}</Text>
-      </div>
-      <div>
-        {isOwned ? (
-          <Pill variant='active'>{collectibleMessages.owned}</Pill>
-        ) : (
-          <Pill>{collectibleMessages.created}</Pill>
-        )}
       </div>
       {dateCreated && <div>{formatDateWithTimezoneOffset(dateCreated)}</div>}
     </div>

--- a/packages/web/src/components/collectibles/components/CollectiblesPage.module.css
+++ b/packages/web/src/components/collectibles/components/CollectiblesPage.module.css
@@ -347,23 +347,8 @@
   line-height: 28px;
 }
 
-.editModal {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  font-size: var(--harmony-font-s);
-  font-weight: var(--harmony-font-bold);
-  margin: 0 24px;
-}
-
-.editModalBody {
-  width: 100%;
-  max-width: 620px;
-}
-
 .editListSection {
   width: 100%;
-  margin-top: 32px;
 }
 
 .editListHeader {
@@ -417,9 +402,7 @@
 
 .editRowTitle {
   flex-grow: 1;
-  font-size: var(--harmony-font-m);
   width: 260px;
-  line-height: 20px;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -448,7 +431,7 @@
 }
 
 .editTableContainer {
-  max-height: 20vh;
+  max-height: 550px;
   overflow-y: auto;
 }
 

--- a/packages/web/src/components/collectibles/components/CollectiblesPage.tsx
+++ b/packages/web/src/components/collectibles/components/CollectiblesPage.tsx
@@ -23,7 +23,6 @@ import {
 } from '@audius/common/store'
 import { getHash, route } from '@audius/common/utils'
 import {
-  Button as HarmonyButton,
   Modal,
   IconKebabHorizontal,
   IconPencil,
@@ -32,7 +31,10 @@ import {
   PopupMenuItem,
   Button,
   Flex,
-  Box
+  ModalHeader,
+  ModalTitle,
+  ModalContent,
+  Text
 } from '@audius/harmony'
 import cn from 'classnames'
 import { chunk } from 'lodash'
@@ -714,104 +716,111 @@ const CollectiblesPage = (props: CollectiblesPageProps) => {
       </div>
 
       <Modal
-        title={collectibleMessages.sortCollectibles}
         isOpen={isEditingPreferences}
         onClose={() => setIsEditingPreferences(false)}
-        showTitleHeader
-        showDismissButton
-        bodyClassName={cn(styles.modalBody, styles.editModalBody)}
-        headerContainerClassName={styles.modalHeader}
-        titleClassName={styles.modalTitle}
-        allowScroll
+        size='large'
       >
-        <div className={styles.editModal}>
-          {getVisibleCollectibles().length > 0 && (
-            <div className={styles.editListSection}>
-              <DragDropContext onDragEnd={onDragEnd}>
+        <ModalHeader>
+          <ModalTitle title={collectibleMessages.sortCollectibles} />
+        </ModalHeader>
+        <ModalContent>
+          <Flex gap='m' h={600}>
+            {getVisibleCollectibles().length > 0 && (
+              <div className={styles.editListSection}>
+                <DragDropContext onDragEnd={onDragEnd}>
+                  <div className={styles.editListHeader}>
+                    <Text variant='title' size='l'>
+                      {collectibleMessages.visibleCollectibles}
+                    </Text>
+                  </div>
+
+                  <div
+                    className={cn(
+                      styles.editTableContainer,
+                      editTableContainerClass,
+                      {
+                        [styles.tableTopShadow]: showVisibleTableTopShadow,
+                        [styles.tableBottomShadow]:
+                          showVisibleTableBottomShadow,
+                        [styles.tableVerticalShadow]:
+                          showVisibleTableTopShadow &&
+                          showVisibleTableBottomShadow
+                      }
+                    )}
+                    ref={visibleTableRef}
+                  >
+                    <Droppable droppableId={VISIBLE_COLLECTIBLES_DROPPABLE_ID}>
+                      {(provided) => (
+                        <div
+                          ref={provided.innerRef}
+                          {...provided.droppableProps}
+                        >
+                          {getVisibleCollectibles().map((c, index) => (
+                            <Draggable
+                              key={c.id}
+                              draggableId={c.id}
+                              index={index}
+                            >
+                              {(provided, snapshot) => (
+                                <VisibleCollectibleRow
+                                  {...provided.draggableProps}
+                                  handleProps={provided.dragHandleProps}
+                                  forwardRef={provided.innerRef}
+                                  isDragging={snapshot.isDragging}
+                                  collectible={c}
+                                  onHideClick={handleHideCollectible(c.id)}
+                                />
+                              )}
+                            </Draggable>
+                          ))}
+
+                          {provided.placeholder}
+                        </div>
+                      )}
+                    </Droppable>
+                  </div>
+                </DragDropContext>
+              </div>
+            )}
+
+            {getHiddenCollectibles().length > 0 && (
+              <div className={styles.editListSection}>
                 <div className={styles.editListHeader}>
-                  {collectibleMessages.visibleCollectibles}
+                  <Text variant='title' size='l'>
+                    {collectibleMessages.hiddenCollectibles}
+                  </Text>
                 </div>
 
                 <div
-                  className={cn(
-                    styles.editTableContainer,
-                    editTableContainerClass,
-                    {
-                      [styles.tableTopShadow]: showVisibleTableTopShadow,
-                      [styles.tableBottomShadow]: showVisibleTableBottomShadow,
-                      [styles.tableVerticalShadow]:
-                        showVisibleTableTopShadow &&
-                        showVisibleTableBottomShadow
-                    }
-                  )}
-                  ref={visibleTableRef}
+                  className={cn(styles.editTableContainer, {
+                    [styles.tableTopShadow]: showHiddenTableTopShadow,
+                    [styles.tableBottomShadow]: showHiddenTableBottomShadow,
+                    [styles.tableVerticalShadow]:
+                      showHiddenTableTopShadow && showHiddenTableBottomShadow
+                  })}
+                  ref={hiddenTableRef}
                 >
-                  <Droppable droppableId={VISIBLE_COLLECTIBLES_DROPPABLE_ID}>
-                    {(provided) => (
-                      <div ref={provided.innerRef} {...provided.droppableProps}>
-                        {getVisibleCollectibles().map((c, index) => (
-                          <Draggable
-                            key={c.id}
-                            draggableId={c.id}
-                            index={index}
-                          >
-                            {(provided, snapshot) => (
-                              <VisibleCollectibleRow
-                                {...provided.draggableProps}
-                                handleProps={provided.dragHandleProps}
-                                forwardRef={provided.innerRef}
-                                isDragging={snapshot.isDragging}
-                                collectible={c}
-                                onHideClick={handleHideCollectible(c.id)}
-                              />
-                            )}
-                          </Draggable>
-                        ))}
-
-                        {provided.placeholder}
-                      </div>
-                    )}
-                  </Droppable>
+                  {getHiddenCollectibles().map((c) => (
+                    <HiddenCollectibleRow
+                      key={c.id}
+                      collectible={c}
+                      onShowClick={handleShowCollectible(c.id)}
+                    />
+                  ))}
                 </div>
-              </DragDropContext>
-            </div>
-          )}
-
-          {getHiddenCollectibles().length > 0 && (
-            <div className={styles.editListSection}>
-              <div className={styles.editListHeader}>
-                {collectibleMessages.hiddenCollectibles}
               </div>
-
-              <div
-                className={cn(styles.editTableContainer, {
-                  [styles.tableTopShadow]: showHiddenTableTopShadow,
-                  [styles.tableBottomShadow]: showHiddenTableBottomShadow,
-                  [styles.tableVerticalShadow]:
-                    showHiddenTableTopShadow && showHiddenTableBottomShadow
-                })}
-                ref={hiddenTableRef}
-              >
-                {getHiddenCollectibles().map((c) => (
-                  <HiddenCollectibleRow
-                    key={c.id}
-                    collectible={c}
-                    onShowClick={handleShowCollectible(c.id)}
-                  />
-                ))}
-              </div>
-            </div>
-          )}
-          <Box m='l'>
-            <HarmonyButton
-              variant='primary'
-              onClick={handleDoneClick}
-              disabled={isUpdatingUserCollectibles}
-            >
-              Done
-            </HarmonyButton>
-          </Box>
-        </div>
+            )}
+          </Flex>
+        </ModalContent>
+        <Flex justifyContent='center' pb='xl'>
+          <Button
+            variant='primary'
+            onClick={handleDoneClick}
+            disabled={isUpdatingUserCollectibles}
+          >
+            Done
+          </Button>
+        </Flex>
       </Modal>
 
       <Modal
@@ -854,9 +863,9 @@ const CollectiblesPage = (props: CollectiblesPageProps) => {
                   </div>
                 </div>
               </Toast>
-              <HarmonyButton variant='primary' onClick={closeEmbedModal}>
+              <Button variant='primary' onClick={closeEmbedModal}>
                 {collectibleMessages.done}
-              </HarmonyButton>
+              </Button>
             </div>
           </div>
         </div>


### PR DESCRIPTION
### Description

Updates collectibles UI to make it easier to drag and drop and compare hidden vs visible. Uses a few harmony components as well.

note: screenshots dont reflect this but we also removed the "created" vs "owned" pills, since not really important

Before:
![CleanShot 2025-03-06 at 14 32 31@2x](https://github.com/user-attachments/assets/67043e49-5672-4714-868a-19fa78df4999)


After:

![image (3)](https://github.com/user-attachments/assets/f6bbb101-43da-4e80-a10a-7fa4482e01bc)
