### PR TITLE
[PAY-3994] Prevent -1 fetches in tan query hooks

### DIFF
--- a/packages/common/src/api/tan-query/useCollection.ts
+++ b/packages/common/src/api/tan-query/useCollection.ts
@@ -23,6 +23,7 @@ export const useCollection = (
   const { data: currentUserId } = useCurrentUserId()
   const queryClient = useQueryClient()
   const dispatch = useDispatch()
+  const validCollectionId = !!collectionId && collectionId > 0
 
   return useQuery<TQCollection | null>({
     queryKey: getCollectionQueryKey(collectionId),
@@ -37,6 +38,6 @@ export const useCollection = (
       return await batchGetCollections.fetch(collectionId!)
     },
     ...options,
-    enabled: options?.enabled !== false && !!collectionId
+    enabled: options?.enabled !== false && validCollectionId
   })
 }

--- a/packages/common/src/api/tan-query/useCollections.ts
+++ b/packages/common/src/api/tan-query/useCollections.ts
@@ -43,7 +43,7 @@ export const useCollections = (
         return await batchGetCollections.fetch(collectionId)
       },
       ...options,
-      enabled: options?.enabled !== false && !!collectionId
+      enabled: options?.enabled !== false && !!collectionId && collectionId > 0
     })),
     combine: combineQueryResults<UserCollectionMetadata[]>
   })

--- a/packages/common/src/api/tan-query/useTrack.ts
+++ b/packages/common/src/api/tan-query/useTrack.ts
@@ -22,6 +22,7 @@ export const useTrack = (
   const queryClient = useQueryClient()
   const dispatch = useDispatch()
   const { data: currentUserId } = useCurrentUserId()
+  const validTrackId = !!trackId && trackId > 0
 
   return useQuery<TQTrack | null>({
     queryKey: getTrackQueryKey(trackId),
@@ -36,6 +37,6 @@ export const useTrack = (
       return await batchGetTracks.fetch(trackId!)
     },
     ...options,
-    enabled: options?.enabled !== false && !!trackId
+    enabled: options?.enabled !== false && validTrackId
   })
 }

--- a/packages/common/src/api/tan-query/useTracks.ts
+++ b/packages/common/src/api/tan-query/useTracks.ts
@@ -44,7 +44,7 @@ export const useTracks = (
         return await batchGetTracks.fetch(trackId)
       },
       ...options,
-      enabled: options?.enabled !== false && !!trackId
+      enabled: options?.enabled !== false && !!trackId && trackId > 0
     })),
     combine: combineQueryResults<TrackMetadata[]>
   })

--- a/packages/common/src/api/tan-query/useUser.ts
+++ b/packages/common/src/api/tan-query/useUser.ts
@@ -23,6 +23,7 @@ export const useUser = (
   const dispatch = useDispatch()
   const queryClient = useQueryClient()
   const currentUserId = useSelector(getUserId)
+  const validUserId = !!userId && userId > 0
 
   return useQuery<UserMetadata | null>({
     queryKey: getUserQueryKey(userId),
@@ -37,6 +38,6 @@ export const useUser = (
       return await batchGetUsers.fetch(userId!)
     },
     ...options,
-    enabled: options?.enabled !== false && !!userId
+    enabled: options?.enabled !== false && validUserId
   })
 }

--- a/packages/common/src/api/tan-query/useUsers.ts
+++ b/packages/common/src/api/tan-query/useUsers.ts
@@ -44,7 +44,7 @@ export const useUsers = (
         return await batchGetUsers.fetch(userId)
       },
       ...options,
-      enabled: options?.enabled !== false && !!userId
+      enabled: options?.enabled !== false && !!userId && userId > 0
     })),
     combine: combineQueryResults<UserMetadata[]>
   })


### PR DESCRIPTION
### Description

There are several places throughout our codebase that initialize an id to `-1` instead of null/undefined before it's populated, probably to satisfy various types. Though we should address type issues under the hood, this is a safe change and prevents bad behavior we see frequently:

Currently when you load trending/feed/etc, a 404 request is sent for a -1 track id and causes discovery node reselection

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._

```
npm run web:stage
```