### PR TITLE
Fix now playing jitter and nav icon spacing in mobile web

### DIFF
--- a/packages/web/src/components/nav/mobile/NavBar.module.css
+++ b/packages/web/src/components/nav/mobile/NavBar.module.css
@@ -27,6 +27,7 @@
   margin-right: auto;
   position: relative;
   opacity: 1;
+  margin-left: var(--harmony-spacing-s);
   transition: opacity 0.3s ease-in-out;
 }
 

--- a/packages/web/src/components/nav/mobile/NavBar.tsx
+++ b/packages/web/src/components/nav/mobile/NavBar.tsx
@@ -166,7 +166,7 @@ const NavBar = ({
     )
   } else if (leftElement === LeftPreset.NOTIFICATION && isSignedIn) {
     left = (
-      <>
+      <Flex gap='s'>
         <Flex>
           <IconButton
             aria-label='notifications'
@@ -225,7 +225,7 @@ const NavBar = ({
             </Flex>
           )}
         </Flex>
-      </>
+      </Flex>
     )
   } else if (leftElement === LeftPreset.SETTINGS && isSignedIn) {
     left = (

--- a/packages/web/src/components/now-playing/NowPlayingDrawer.tsx
+++ b/packages/web/src/components/now-playing/NowPlayingDrawer.tsx
@@ -100,6 +100,7 @@ const NowPlayingDrawer = ({
       y: initialTranslation()
     },
     config: wobble,
+    immediate: true,
     onFrame(frame: any) {
       setCurrentTranslation(frame.y)
     }
@@ -375,6 +376,7 @@ const NowPlayingDrawer = ({
         id='now-playing-drawer'
         {...bind()}
         style={{
+          visibility: isPlaying ? 'visible' : 'hidden',
           bottom: `-${DEFAULT_HEIGHT}px`,
           // @ts-ignore
           transform: drawerSlideProps.y.interpolate(interpY)


### PR DESCRIPTION
### Description

* Fix jitter where now playing drawer animates for a brief second before playback happens
* Fix spacing of nav icons

<img width="384" alt="image" src="https://github.com/user-attachments/assets/e908988f-3ea0-4d61-b29c-5d7777a0d63c" />


### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._

local mobile web against staging