### PR TITLE
Remove wildcard match in search queries

### DIFF
--- a/packages/discovery-provider/src/queries/search_es.py
+++ b/packages/discovery-provider/src/queries/search_es.py
@@ -581,15 +581,6 @@ def track_dsl(
                     "should": [
                         *base_match(search_str),
                         {
-                            "wildcard": {
-                                "title": {
-                                    "value": "*" + search_str + "*",
-                                    "boost": 0.01,
-                                    "case_insensitive": True,
-                                }
-                            }
-                        },
-                        {
                             "multi_match": {
                                 "query": search_str,
                                 "fields": ["title.searchable", "user.name.searchable"],
@@ -831,16 +822,6 @@ def user_dsl(
                                 "boost": len(search_str) * 0.5,
                             }
                         },
-                        # Original wildcard matching
-                        {
-                            "wildcard": {
-                                "name": {
-                                    "value": "*" + search_str + "*",
-                                    "boost": 0.01,
-                                    "case_insensitive": True,
-                                }
-                            }
-                        },
                         {
                             "match": {
                                 "name.searchable": {
@@ -1041,15 +1022,6 @@ def base_playlist_dsl(
                 "bool": {
                     "should": [
                         *base_match(search_str, boost=len(search_str)),
-                        {
-                            "wildcard": {
-                                "playlist_name": {
-                                    "value": "*" + search_str + "*",
-                                    "boost": 0.01,
-                                    "case_insensitive": True,
-                                }
-                            }
-                        },
                         {
                             "multi_match": {
                                 "query": search_str,


### PR DESCRIPTION
### Description

These wildcard queries were added in this original PR that did a lot to improve our fuzziness:
https://github.com/AudiusProject/audius-protocol/pull/7883

However they're only given a small 0.01 boost and are very expensive, particularly the leading `*` 
https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-wildcard-query.html

![image](https://github.com/user-attachments/assets/5ff55c95-1b9e-4c4a-b88e-303f21405153)

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._

Ran on prod node, couldn't tell any difference across a decent # of search terms / mid sections, etc.
Even without this, we were able to find text in the middle of a track title

On the prod node, ES CPU went from 600% to 200% in one shot with this change