### PR TITLE
[QA-2007] Fix deleted page not respecting max page width

### DIFF
--- a/packages/web/src/pages/deleted-page/components/desktop/DeletedPage.tsx
+++ b/packages/web/src/pages/deleted-page/components/desktop/DeletedPage.tsx
@@ -6,7 +6,7 @@ import {
   User
 } from '@audius/common/models'
 import { NestedNonNullable } from '@audius/common/utils'
-import { Button, IconUser, Box } from '@audius/harmony'
+import { Button, IconUser, Flex } from '@audius/harmony'
 
 import { ArtistPopover } from 'components/artist/ArtistPopover'
 import CoverPhoto from 'components/cover-photo/CoverPhoto'
@@ -168,10 +168,16 @@ const DeletedPage = g(
           <EmptyNavBanner />
         </div>
         <FlushPageContainer>
-          <Box pt={320} pb={100} css={{ position: 'relative' }}>
+          <Flex
+            column
+            w='100%'
+            pt={320}
+            pb={100}
+            css={{ position: 'relative' }}
+          >
             {renderTile()}
             {renderLineup()}
-          </Box>
+          </Flex>
         </FlushPageContainer>
       </Page>
     )


### PR DESCRIPTION
### Description
Updating deleted page to use the same layout logic as the track details page so it respects the gutters created by `FlushPageContainer`

### How Has This Been Tested?
Local client against staging, make sure a deleted track page at smaller widths respects the gutters.
