### PR TITLE
[QA-2008] Fixes styling issues on receive audio modal

### DIFF
--- a/packages/web/src/components/rewards/ClickableAddress.tsx
+++ b/packages/web/src/components/rewards/ClickableAddress.tsx
@@ -1,9 +1,8 @@
-import { ReactNode, useCallback } from 'react'
+import { ReactNode, useCallback, useContext } from 'react'
 
 import { IconCopy } from '@audius/harmony'
-import cn from 'classnames'
 
-import Toast from 'components/toast/Toast'
+import { ToastContext } from 'components/toast/ToastContext'
 import Tooltip from 'components/tooltip/Tooltip'
 import { ComponentPlacement, MountPlacement } from 'components/types'
 import { copyToClipboard } from 'utils/clipboardUtil'
@@ -30,9 +29,11 @@ const ClickableAddress = ({
   label,
   isCompact = false
 }: DisplayAddressProps) => {
+  const { toast } = useContext(ToastContext)
   const onClickAddress = useCallback(() => {
     copyToClipboard(address)
-  }, [address])
+    toast(messages.copied)
+  }, [address, toast])
 
   return (
     <Tooltip
@@ -40,27 +41,19 @@ const ClickableAddress = ({
       placement={ComponentPlacement.TOP}
       mount={MountPlacement.PARENT}
     >
-      <div className={cn(styles.toastContainer, { [className!]: !!className })}>
-        <Toast
-          text={messages.copied}
-          delay={2000}
-          overlayClassName={styles.toast}
-          placement={ComponentPlacement.TOP}
-          mount={MountPlacement.PARENT}
-        >
-          <PurpleBox
-            label={label ?? messages.yourAddr}
-            className={styles.container}
-            onClick={onClickAddress}
-            isCompact={isCompact}
-            text={
-              <div className={styles.addressContainer}>
-                <div className={styles.address}>{address}</div>
-                <IconCopy className={styles.icon} />
-              </div>
-            }
-          />
-        </Toast>
+      <div className={className}>
+        <PurpleBox
+          label={label ?? messages.yourAddr}
+          className={styles.container}
+          onClick={onClickAddress}
+          isCompact={isCompact}
+          text={
+            <div className={styles.addressContainer}>
+              <div className={styles.address}>{address}</div>
+              <IconCopy className={styles.icon} />
+            </div>
+          }
+        />
       </div>
     </Tooltip>
   )

--- a/packages/web/src/pages/audio-page/components/ReceiveBody.tsx
+++ b/packages/web/src/pages/audio-page/components/ReceiveBody.tsx
@@ -1,6 +1,6 @@
 import { useCreateUserbankIfNeeded } from '@audius/common/hooks'
 import { WalletAddress, SolanaWalletAddress } from '@audius/common/models'
-import { Button, IconSolana as LogoSol } from '@audius/harmony'
+import { Button, IconSolana as LogoSol, Text } from '@audius/harmony'
 import cn from 'classnames'
 
 import ClickableAddress from 'components/rewards/ClickableAddress'
@@ -60,7 +60,9 @@ const ReceiveBody = ({ wallet, solWallet }: ReceiveBodyProps) => {
         <div className={styles.iconSolContainer}>
           <LogoSol className={styles.iconSolHeader} />
         </div>
-        <span>{messages.clickableSPLAddressTitle}</span>
+        <Text variant='label' color='white'>
+          {messages.clickableSPLAddressTitle}
+        </Text>
       </div>
     )
   }


### PR DESCRIPTION
### Description
* Updates the color of the button label to use a standard Text component
* Updates the toast to follow convention used in other more modern components so it renders at the top of the page.

Note: The text color in the toast might be something we need to separately address. But it's using a common code path so that's the styling in _all_ toasts in dark mode.

### How Has This Been Tested?
Local client against staging, just verified styling looks better. :-)

### Screenshots
**Before**
<img width="765" alt="image" src="https://github.com/user-attachments/assets/6fdb9c29-76b4-4c30-aba9-68b7152e2075" />

<img width="798" alt="image" src="https://github.com/user-attachments/assets/be91461f-31fb-4ec7-b00c-7dfd5bf22dda" />


**After**
<img width="855" alt="image" src="https://github.com/user-attachments/assets/2d147125-5051-4781-8114-20991deb421f" />


<img width="938" alt="image" src="https://github.com/user-attachments/assets/24b0a07e-cf30-4e43-8c83-a61883f30d79" />

