### PR TITLE
Remove dependency on getCurrentBlock in SDK

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "web:dev": "npm run start:dev -w @audius/web",
     "web:prod": "npm run start:prod -w @audius/web",
     "web:stage": "npm run start:stage -w @audius/web",
-    "web:e2e": "npm run e2e -w @audius/web",
+    "web:e2e": "npm run test:e2e -w @audius/web",
     "web:test": "turbo run test --filter=@audius/web",
     "DESKTOP====================================": "",
     "desktop:dev": "concurrently -k 'BROWSER=none npm run start:dev -w @audius/web' 'wait-on http://0.0.0.0:3000 && npm run electron:localhost -w @audius/web -- 3000'",

--- a/packages/sdk/src/sdk/api/albums/AlbumsApi.test.ts
+++ b/packages/sdk/src/sdk/api/albums/AlbumsApi.test.ts
@@ -1,7 +1,6 @@
 import fs from 'fs'
 import path from 'path'
 
-import type { GetBlockReturnType } from 'viem/actions'
 import { describe, it, expect, vitest, beforeAll } from 'vitest'
 
 import { developmentConfig } from '../../config/development'
@@ -89,14 +88,6 @@ vitest
       blockHash: 'a',
       blockNumber: 1
     } as any
-  })
-
-vitest
-  .spyOn(EntityManagerClient.prototype, 'getCurrentBlock')
-  .mockImplementation(async () => {
-    return {
-      timestamp: 1
-    } as GetBlockReturnType & { timestamp: number }
   })
 
 vitest

--- a/packages/sdk/src/sdk/api/playlists/PlaylistsApi.test.ts
+++ b/packages/sdk/src/sdk/api/playlists/PlaylistsApi.test.ts
@@ -1,7 +1,6 @@
 import fs from 'fs'
 import path from 'path'
 
-import type { GetBlockReturnType } from 'viem'
 import { describe, it, beforeAll, expect, vitest } from 'vitest'
 
 import { createAppWalletClient } from '../../services'
@@ -77,14 +76,6 @@ vitest
       blockHash: 'a',
       blockNumber: 1
     } as any
-  })
-
-vitest
-  .spyOn(EntityManagerClient.prototype, 'getCurrentBlock')
-  .mockImplementation(async () => {
-    return {
-      timestamp: 1
-    } as GetBlockReturnType & { timestamp: number }
   })
 
 vitest

--- a/packages/sdk/src/sdk/api/playlists/PlaylistsApi.ts
+++ b/packages/sdk/src/sdk/api/playlists/PlaylistsApi.ts
@@ -46,6 +46,12 @@ import {
   UpdatePlaylistMetadataSchema
 } from './types'
 
+// Returns current timestamp in seconds, which is the expected
+// format for client-generated playlist entry timestamps
+const getCurrentTimestamp = () => {
+  return Math.floor(Date.now() / 1000)
+}
+
 export class PlaylistsApi extends GeneratedPlaylistsApi {
   private readonly trackUploadHelper: TrackUploadHelper
 
@@ -130,8 +136,6 @@ export class PlaylistsApi extends GeneratedPlaylistsApi {
     // Parse inputs
     await parseParams('addTrackToPlaylist', AddTrackToPlaylistSchema)(params)
 
-    const currentBlock = await this.entityManager.getCurrentBlock()
-
     return await this.fetchAndUpdatePlaylist(
       {
         userId: params.userId,
@@ -142,7 +146,7 @@ export class PlaylistsApi extends GeneratedPlaylistsApi {
             ...(playlist.playlistContents ?? []),
             {
               trackId: params.trackId,
-              timestamp: currentBlock.timestamp
+              timestamp: getCurrentTimestamp()
             }
           ]
         })
@@ -480,7 +484,7 @@ export class PlaylistsApi extends GeneratedPlaylistsApi {
     )
 
     const playlistId = await this.trackUploadHelper.generateId('playlist')
-    const currentBlock = await this.entityManager.getCurrentBlock()
+    const timestamp = getCurrentTimestamp()
 
     // Update metadata to include track ids and cover art cid
     const updatedMetadata = {
@@ -488,7 +492,7 @@ export class PlaylistsApi extends GeneratedPlaylistsApi {
       isPrivate: false,
       playlistContents: trackIds.map((trackId) => ({
         trackId,
-        timestamp: currentBlock.timestamp
+        timestamp
       })),
       playlistImageSizesMultihash: coverArtResponse.id
     }
@@ -595,14 +599,14 @@ export class PlaylistsApi extends GeneratedPlaylistsApi {
       ))
 
     const playlistId = providedPlaylistId || (await this.generatePlaylistId())
-    const currentBlock = await this.entityManager.getCurrentBlock()
+    const timestamp = getCurrentTimestamp()
 
     // Update metadata to include track ids
     const updatedMetadata = {
       ...metadata,
       playlistContents: (trackIds ?? []).map((trackId) => ({
         trackId,
-        timestamp: currentBlock.timestamp
+        timestamp
       })),
       playlistImageSizesMultihash: coverArtResponse?.id ?? metadata.coverArtCid
     }

--- a/packages/sdk/src/sdk/services/EntityManager/EntityManagerClient.ts
+++ b/packages/sdk/src/sdk/services/EntityManager/EntityManagerClient.ts
@@ -1,10 +1,7 @@
 import {
-  createPublicClient,
   encodeFunctionData,
   decodeFunctionData,
-  http,
   type Hex,
-  type PublicClient,
   type TypedDataDefinition
 } from 'viem'
 import type { TransactionReceipt } from 'web3-core'
@@ -42,8 +39,6 @@ export class EntityManagerClient implements EntityManagerService {
   private readonly chainId: number
   private readonly contractAddress: string
 
-  private publicClient: PublicClient | undefined
-
   constructor(config_: EntityManagerConfig) {
     const config = mergeConfigWithDefaults(
       config_,
@@ -54,16 +49,6 @@ export class EntityManagerClient implements EntityManagerService {
     this.chainId = config.chainId
     this.contractAddress = config.contractAddress
     this.logger = config.logger.createPrefixedLogger('[entity-manager]')
-  }
-
-  private async getClient() {
-    if (!this.publicClient) {
-      const web3Provider = `${await this.discoveryNodeSelector.getSelectedEndpoint()}/chain`
-      this.publicClient = createPublicClient({
-        transport: http(web3Provider)
-      })
-    }
-    return this.publicClient
   }
 
   /**
@@ -211,18 +196,6 @@ export class EntityManagerClient implements EntityManagerService {
    */
   public async decodeManageEntity(data: Hex) {
     return decodeFunctionData({ abi: EntityManager.abi, data })
-  }
-
-  /**
-   * Gets the current block
-   * @returns The current block
-   */
-  public async getCurrentBlock() {
-    const client = await this.getClient()
-    const currentBlockNumber = await client.getBlockNumber()
-    const block = await client.getBlock({ blockNumber: currentBlockNumber })
-    // TODO: Make this not need to be cast to number
-    return { ...block, timestamp: Number(block.timestamp) }
   }
 
   /**

--- a/packages/sdk/src/sdk/services/EntityManager/types.ts
+++ b/packages/sdk/src/sdk/services/EntityManager/types.ts
@@ -44,7 +44,6 @@ export type EntityManagerService = {
     confirmationTimeout?: number
     confirmationPollingInterval?: number
   }) => Promise<boolean>
-  getCurrentBlock: () => Promise<{ timestamp: number }>
 }
 
 export enum Action {

--- a/packages/web/src/common/store/cache/collections/addTrackToPlaylistSaga.ts
+++ b/packages/web/src/common/store/cache/collections/addTrackToPlaylistSaga.ts
@@ -53,6 +53,12 @@ type AddTrackToPlaylistAction = ReturnType<
   typeof cacheCollectionsActions.addTrackToPlaylist
 >
 
+// Returns current timestamp in seconds, which is the expected
+// format for client-generated playlist entry timestamps
+const getCurrentTimestamp = () => {
+  return Math.floor(Date.now() / 1000)
+}
+
 /** ADD TRACK TO PLAYLIST */
 
 export function* watchAddTrackToPlaylist() {
@@ -85,10 +91,6 @@ function* addTrackToPlaylistAsync(action: AddTrackToPlaylistAction) {
   yield* put(
     cacheActions.subscribe(Kind.TRACKS, [{ uid: trackUid, id: action.trackId }])
   )
-  const { timestamp: currentBlockTimestamp } = yield* call([
-    sdk.services.entityManager,
-    sdk.services.entityManager.getCurrentBlock
-  ])
 
   playlist.playlist_contents = {
     track_ids: playlist.playlist_contents.track_ids.concat({
@@ -99,7 +101,7 @@ function* addTrackToPlaylistAsync(action: AddTrackToPlaylistAction) {
       // Represents user-facing timestamp when the user added the track to the playlist.
       // This is needed to disambiguate between tracks added at the same time/potentiall in
       // the same block.
-      metadata_time: currentBlockTimestamp,
+      metadata_time: getCurrentTimestamp(),
       uid: trackUid
     })
   }

--- a/packages/web/src/common/store/cache/collections/addTrackToPlaylistSaga.ts
+++ b/packages/web/src/common/store/cache/collections/addTrackToPlaylistSaga.ts
@@ -73,7 +73,6 @@ function* addTrackToPlaylistAsync(action: AddTrackToPlaylistAction) {
   yield* waitForWrite()
   const userId = yield* call(ensureLoggedIn)
   const isNative = yield* getContext('isNativeMobile')
-  const sdk = yield* getSDK()
   const { generatePlaylistArtwork } = yield* getContext('imageUtils')
 
   let playlist = yield* select(getCollection, { id: playlistId })


### PR DESCRIPTION
### Description
Updates playlist api to use local timestamps based on Date instead of pulling block info from `/chain`. These timestamps are just referential for clients anyway. Playlist contents get assigned a timestamp during indexing based on transaction block.

This is to make SDK safe for the core cutover and remove reliance on the `/chain` URL.

### How Has This Been Tested?
Local client against staging and local stack.
