### PR TITLE
Fix marshalling for playlist notifs

### DIFF
--- a/packages/discovery-provider/src/api/v1/utils/extend_notification.py
+++ b/packages/discovery-provider/src/api/v1/utils/extend_notification.py
@@ -245,9 +245,9 @@ def extend_create(action: NotificationAction):
     else:
         playlist_data: CreatePlaylistNotification = action["data"]  # type: ignore
         notification["data"]["is_album"] = playlist_data["is_album"]
-        notification["data"]["playlist_id"] = (
-            encode_int_id(playlist_data["playlist_id"]),
-        )  # TODO: Make this not a tuple!!
+        notification["data"]["playlist_id"] = [
+            encode_int_id(playlist_data["playlist_id"])
+        ]
     return notification
 
 


### PR DESCRIPTION
### Description
Missed a spot in #11511.

Playlist notifs were, for some reason, extending the playlist_id as a tuple and not a list.
I'm not entirely sure why the output model uses a list when it's usually one item. But for the sake of backwards compatibility, I'm not going to change that. This will, however, remove a bunch of error messages from the logs due to the id being in the wrong format.

### How Has This Been Tested?
Local client against local stack. User B follows User A. User A uploads a playlist and album. Check notifications on user B. Check logs for server container to make sure no more marshaling errors.
