### PR TITLE
Remove end_date on play count challenge and update query

### DIFF
--- a/packages/discovery-provider/integration_tests/challenges/test_play_count_milestones_challenge.py
+++ b/packages/discovery-provider/integration_tests/challenges/test_play_count_milestones_challenge.py
@@ -31,7 +31,7 @@ logger = logging.getLogger(__name__)
 
 REDIS_URL = shared_config["redis"]["url"]
 BLOCK_NUMBER = 10
-CURRENT_YEAR = 2025  # The year for which plays are counted
+CURRENT_YEAR = 2025  # The starting year from which plays are counted onwards
 
 # Get all the milestone values for testing
 MILESTONE_VALUES = [MILESTONE_250, MILESTONE_1000, MILESTONE_10000]

--- a/packages/discovery-provider/src/challenges/play_count_milestone_challenge_base.py
+++ b/packages/discovery-provider/src/challenges/play_count_milestone_challenge_base.py
@@ -23,9 +23,8 @@ class PlayCountMilestoneUpdaterBase(ChallengeUpdater):
     PREVIOUS_MILESTONE_CHALLENGE_ID = ""
 
     def _get_user_play_count_2025(self, session: Session, user_id: int) -> int:
-        """Get the total play count for an artist's tracks in 2025"""
+        """Get the total play count for an artist's tracks in 2025 and beyond"""
         start_date = datetime(2025, 1, 1)
-        end_date = datetime(2026, 1, 1)
 
         play_count = (
             session.query(func.count(Play.id))
@@ -38,7 +37,7 @@ class PlayCountMilestoneUpdaterBase(ChallengeUpdater):
                     Track.is_delete == False,
                 ),
             )
-            .filter(and_(Play.created_at >= start_date, Play.created_at < end_date))
+            .filter(Play.created_at >= start_date)
             .scalar()
         )
 


### PR DESCRIPTION
### Description
We are limiting earnings for play count from 2025 and beyond. Removing the `end_date` constraint so users can earn the reward post 2025. 

### How Has This Been Tested?


