### PR TITLE
[PAY-3893][PAY-3894] Remove legacy indexing of associated_wallets and collectibles

### DIFF
--- a/packages/discovery-provider/src/tasks/entity_manager/entities/user.py
+++ b/packages/discovery-provider/src/tasks/entity_manager/entities/user.py
@@ -329,30 +329,6 @@ def update_user_metadata(
         if user_record.verified_with_tiktok:
             user_record.tiktok_handle = user_record.handle
 
-    if "collectibles" in metadata:
-        # Dual-write for collectibles data to support legacy indexing
-        # TODO: Remove after clients updated to use new transactions
-        # https://linear.app/audius/issue/PAY-3894/remove-collection-and-other-cid-metadata-indexing
-        collectibles = Collectibles(
-            user_id=user_record.user_id,
-            data=metadata["collectibles"],
-            blockhash=params.event_blockhash,
-            blocknumber=params.block_number,
-        )
-
-        # We can just add_record here. Outer EM logic will take care
-        # of deleting previous record if it exists
-        params.add_record(user_record.user_id, collectibles, EntityType.COLLECTIBLES)
-
-        if (
-            metadata["collectibles"]
-            and isinstance(metadata["collectibles"], dict)
-            and metadata["collectibles"].items()
-        ):
-            user_record.has_collectibles = True
-        else:
-            user_record.has_collectibles = False
-
     if "events" in metadata and metadata["events"]:
         update_user_events(user_record, metadata["events"], challenge_event_bus, params)
 


### PR DESCRIPTION
### Description
This removes the legacy indexing logic for wallets/collectibles set directly on the user. We will now only support setting them through the new entity transactions.

I will follow up with a separate PR to remove cid_data altogether to minimize area of effect per PR.

### How Has This Been Tested?
Mostly N/A since this is a legacy code path no longer exercise. Running local client against local stack and updating collectibles/wallets to make sure that still works is sufficient.
