### PR TITLE
[PAY-4001] Tastemaker challenge backend

### DIFF
--- a/packages/discovery-provider/src/challenges/challenge_event.py
+++ b/packages/discovery-provider/src/challenges/challenge_event.py
@@ -28,3 +28,4 @@ class ChallengeEvent(str, enum.Enum):
     audio_matching_seller = "audio_matching_seller"
     one_shot = "one_shot"
     first_weekly_comment = "first_weekly_comment"
+    tastemaker = "tastemaker"

--- a/packages/discovery-provider/src/challenges/challenge_event_bus.py
+++ b/packages/discovery-provider/src/challenges/challenge_event_bus.py
@@ -39,6 +39,7 @@ from src.challenges.referral_challenge import (
     verified_referral_challenge_manager,
 )
 from src.challenges.send_first_tip_challenge import send_first_tip_challenge_manager
+from src.challenges.tastemaker_challenge import tastemaker_challenge_manager
 from src.challenges.track_upload_challenge import track_upload_challenge_manager
 from src.challenges.trending_challenge import (
     trending_playlist_challenge_manager,
@@ -306,4 +307,5 @@ def setup_challenge_bus():
     bus.register_listener(
         ChallengeEvent.first_weekly_comment, first_weekly_comment_challenge_manager
     )
+    bus.register_listener(ChallengeEvent.tastemaker, tastemaker_challenge_manager)
     return bus

--- a/packages/discovery-provider/src/challenges/challenges.dev.json
+++ b/packages/discovery-provider/src/challenges/challenges.dev.json
@@ -192,5 +192,16 @@
     "starting_block": 0,
     "weekly_pool": 2147483647,
     "cooldown_days": 0
+  },
+  {
+    "id": "t",
+    "name": "TASTEMAKER",
+    "type": "aggregate",
+    "amount": 100,
+    "active": true,
+    "step_count": 2147483647,
+    "starting_block": 0,
+    "weekly_pool": 2147483647,
+    "cooldown_days": 0
   }
 ]

--- a/packages/discovery-provider/src/challenges/challenges.json
+++ b/packages/discovery-provider/src/challenges/challenges.json
@@ -192,5 +192,16 @@
     "starting_block": 0,
     "weekly_pool": 2147483647,
     "cooldown_days": 0
+  },
+  {
+    "id": "t",
+    "name": "TASTEMAKER",
+    "type": "aggregate",
+    "amount": 100,
+    "active": false,
+    "step_count": 2147483647,
+    "starting_block": 0,
+    "weekly_pool": 2147483647,
+    "cooldown_days": 7
   }
 ]

--- a/packages/discovery-provider/src/challenges/challenges.stage.json
+++ b/packages/discovery-provider/src/challenges/challenges.stage.json
@@ -192,5 +192,16 @@
     "starting_block": 0,
     "weekly_pool": 2147483647,
     "cooldown_days": 0
+  },
+  {
+    "id": "t",
+    "name": "TASTEMAKER",
+    "type": "aggregate",
+    "amount": 100,
+    "active": true,
+    "step_count": 2147483647,
+    "starting_block": 0,
+    "weekly_pool": 2147483647,
+    "cooldown_days": 0
   }
 ]

--- a/packages/discovery-provider/src/challenges/tastemaker_challenge.py
+++ b/packages/discovery-provider/src/challenges/tastemaker_challenge.py
@@ -1,0 +1,25 @@
+import logging
+from typing import Dict
+
+from sqlalchemy.orm.session import Session
+
+from src.challenges.challenge import ChallengeManager, ChallengeUpdater
+
+logger = logging.getLogger(__name__)
+
+
+class TastemakerChallengeUpdater(ChallengeUpdater):
+    """Tastemaker challenge
+
+    This challenge is completed when a user reposts or saves a track that later lands in the top 5 trending tracks.
+    """
+
+    def generate_specifier(self, session: Session, user_id: int, extra: Dict) -> str:
+        """
+        Generate a specifier for the challenge based on user_id and tastemaker_item_id
+        Format: {user_id}:{tastemaker_item_id}
+        """
+        return f"{user_id}:{extra['tastemaker_item_id']}"
+
+
+tastemaker_challenge_manager = ChallengeManager("t", TastemakerChallengeUpdater())

--- a/packages/discovery-provider/src/tasks/index_trending.py
+++ b/packages/discovery-provider/src/tasks/index_trending.py
@@ -8,6 +8,7 @@ from sqlalchemy import bindparam, text
 from sqlalchemy.orm.session import Session
 from web3 import Web3
 
+from src.challenges.challenge_event_bus import ChallengeEventBus
 from src.models.core.core_indexed_blocks import CoreIndexedBlocks
 from src.models.indexing.block import Block
 from src.models.notifications.notification import Notification
@@ -178,7 +179,9 @@ def index_trending(self, db: SessionManager, redis: Redis, timestamp):
     top_trending_tracks = get_top_trending_to_notify(db)
 
     index_trending_notifications(db, timestamp, top_trending_tracks)
-    index_tastemaker_notifications(db, top_trending_tracks)
+    index_tastemaker_notifications(
+        db, top_trending_tracks, index_trending_task.challenge_event_bus
+    )
     index_trending_underground_notifications(db, timestamp)
 
 


### PR DESCRIPTION
### Description
Backend for tastemaker challenge. Disabled on prod. No cooldown on stage.

Specifier: use the `user_id` + `item_id` (track id) that caused them to get the tastemaker notif. It's guaranteed that a user will only ever get one tastemaker notif per track.

### How Has This Been Tested?

Not tested - test on stage. Let's see if these `user_challenge` rows get created.