### PR TITLE
[PAY-4017] Update embed collections gallery to use sdk collectibles endpoint

### DIFF
--- a/packages/embed/src/components/collectibles/CollectibleGallery.jsx
+++ b/packages/embed/src/components/collectibles/CollectibleGallery.jsx
@@ -22,21 +22,17 @@ const CollectibleGallery = ({
   const [hasFetched, setHasFetched] = useState(false)
 
   const fetchCollectiblesOrder = async () => {
-    const result = await getCollectiblesJson(user.metadata_multihash)
+    const result = await getCollectiblesJson(user.id)
     setHasFetched(true)
 
-    if (result && result.collectibles) {
-      const collectiblesMetadataKeySet = new Set(
-        Object.keys(result.collectibles)
-      )
+    if (result) {
+      const collectiblesMetadataKeySet = new Set(Object.keys(result))
       const newCollectiblesMap = collectibles
         .map((c) => c.id)
         .filter((id) => !collectiblesMetadataKeySet.has(id))
         .reduce((acc, curr) => ({ ...acc, [curr]: {} }), {})
 
-      setOrder(
-        result.collectibles.order.concat(Object.keys(newCollectiblesMap))
-      )
+      setOrder(result.order.concat(Object.keys(newCollectiblesMap)))
     }
   }
 

--- a/packages/embed/src/util/BedtimeClient.js
+++ b/packages/embed/src/util/BedtimeClient.js
@@ -47,9 +47,11 @@ export const getTrackStreamEndpoint = (trackId, isPurchaseable) =>
     isPurchaseable ? '&preview=true' : ''
   }`
 
-export const getCollectiblesJson = async (cid) => {
-  const url = `${discoveryEndpoint}/v1/full/cid_data/${cid}`
-  return (await (await fetch(url)).json())?.data?.data
+export const getCollectiblesJson = async (hashId) => {
+  const { data: collectibles } = await audiusSdk.users.getUserCollectibles({
+    id: hashId
+  })
+  return collectibles.data
 }
 
 window.audiusSdk = audiusSdk


### PR DESCRIPTION
### Description
Noticed this random usage of metadata_multihash to pull user collectibles preferences in the `embed` package.
The correct way to do it now that we're no longer indexing collectibles updates into cid metadata is to use the SDK method to fetch from the new endpoint.

Side note: Wish this repo was in typescript 😁 

### How Has This Been Tested?
Ran local embed with changes against prod. Rendered the collectibles gallery for a user with collectibles metadata set and compared the rendered result to the collectibles tab in client to make sure they match.
