### PR TITLE
dual write to acdc and core

### DIFF
--- a/packages/discovery-provider/plugins/pedalboard/apps/relay/src/txRelay.ts
+++ b/packages/discovery-provider/plugins/pedalboard/apps/relay/src/txRelay.ts
@@ -15,34 +15,12 @@ export type RelayedTransaction = {
   transaction: TransactionRequest
 }
 
-export const relayTransaction = async (
-  _req: Request,
-  res: Response,
-  next: NextFunction
-) => {
-  // pull info from validated request
-  const { validatedRelayRequest, logger, requestId } = res.locals.ctx
-  const { encodedABI, gasLimit, contractAddress } = validatedRelayRequest
-
+const txRelay = async (res: Response): Promise<TransactionReceipt | null> => {
   let nonce = undefined
   let submit = undefined
+  const { validatedRelayRequest, logger } = res.locals.ctx
   try {
-    try {
-      const coreHealth = await getCoreIndexerHealth()
-      const indexingEntityManager = coreHealth?.indexing_entity_manager
-      if (indexingEntityManager) {
-        const receipt = await coreRelay(logger, requestId, validatedRelayRequest)
-        logger.info({ receipt }, "sending back")
-        res.send({ receipt })
-        next()
-        return
-      } else {
-        // fire and forget but still send
-        coreRelay(logger, requestId, validatedRelayRequest)
-      }
-    } catch (error) {
-      logger.error({ error }, 'error in core relay process')
-    }
+    const { encodedABI, gasLimit, contractAddress } = validatedRelayRequest
 
     const senderWallet = wallets.selectNextWallet()
     const address = await senderWallet.getAddress()
@@ -63,7 +41,7 @@ export const relayTransaction = async (
     submit = await retryPromise(() => senderWallet.sendTransaction(transaction))
 
     // query chain until tx is mined
-    const receipt = await confirm(submit.hash)
+    const receipt: TransactionReceipt = await confirm(submit.hash)
     receipt.blockNumber += config.finalPoaBlock
     logger.info(
       {
@@ -73,14 +51,41 @@ export const relayTransaction = async (
       },
       'transaction confirmation successful'
     )
-    res.send({ receipt })
+    return receipt
   } catch (e) {
     logger.error(
       { nonce, txHash: submit?.hash },
       'transaction submission failed'
     )
+    return null
+  }
+
+}
+
+export const relayTransaction = async (
+  _req: Request,
+  res: Response,
+  next: NextFunction
+) => {
+  // pull info from validated request
+  const { validatedRelayRequest, logger, requestId } = res.locals.ctx
+  try {
+    const coreHealth = await getCoreIndexerHealth()
+    const indexingEntityManager = coreHealth?.indexing_entity_manager
+    if (indexingEntityManager) {
+      const receipt = await coreRelay(logger, requestId, validatedRelayRequest)
+      logger.info({ receipt }, "sending back")
+      res.send({ receipt })
+      // fire and forget acdc relay if using core
+      txRelay(res)
+    } else {
+      const receipt = await txRelay(res)
+      res.send({ receipt })
+      // fire and forget but still send
+      coreRelay(logger, requestId, validatedRelayRequest)
+    }
+  } catch (e) {
     internalError(next, e)
     return
   }
-  next()
 }


### PR DESCRIPTION
### Description
- dual writes to acdc even after the cutover, useful for dns that maybe don't have the latest code to keep from drifting
### How Has This Been Tested?
- can't test in dev since poa-ganache isn't there, will have to look at logs on stage / prod