### PR TITLE
Remove PC challenge from challenges table

### DIFF
--- a/packages/discovery-provider/ddl/migrations/0124_delete_pc_challenge_from_challenges.sql
+++ b/packages/discovery-provider/ddl/migrations/0124_delete_pc_challenge_from_challenges.sql
@@ -1,0 +1,5 @@
+BEGIN;
+
+DELETE FROM challenges WHERE id = 'pc';
+
+COMMIT;


### PR DESCRIPTION
### Description
We already removed the `pc` challenge from the `user_challenges` table but did not remove it from the `challenges` table. 

### How Has This Been Tested?

