### PR TITLE
[QA-2011] Fix mobile-web drawer x close icon

### DIFF
--- a/packages/web/src/components/drawer/Drawer.module.css
+++ b/packages/web/src/components/drawer/Drawer.module.css
@@ -33,6 +33,7 @@
   position: absolute;
   top: 16px;
   left: 16px;
+  z-index: 1;
 }
 
 .dismissContainer path {


### PR DESCRIPTION
### Description
Top-left x icon close button was broken.

### How Has This Been Tested?


https://github.com/user-attachments/assets/25c79981-d9a6-4a68-b50d-a013bbb52ab2

