### PR TITLE
[PROTO-2008] Fix search pagination offset issue + remove verified user deduping

### DIFF
--- a/packages/discovery-provider/src/queries/search_es.py
+++ b/packages/discovery-provider/src/queries/search_es.py
@@ -391,17 +391,12 @@ def search_tags_es(args: dict):
 
 
 def mdsl_limit_offset(mdsl, limit, offset):
-    # add size and limit with some over-fetching
-    # for sake of reorder_users
-    index_name = ""
+    # add size and limit to the elasticsearch query
     for dsl in mdsl:
         if "index" in dsl:
-            index_name = dsl["index"]
             continue
         dsl["size"] = limit
         dsl["from"] = offset
-        if index_name == ES_USERS:
-            dsl["size"] = limit + 5
 
 
 def finalize_response(
@@ -1289,28 +1284,18 @@ def album_dsl(
 
 
 def reorder_users(users):
-    """Filters out users with copy cat names.
-    e.g. if a verified deadmau5 is in the result set
-    filter out all non-verified users with same name.
-
+    """
     Moves users without profile pictures to the end.
     """
-    reserved = set()
-    for user in users:
-        if user["is_verified"]:
-            reserved.add(lower_ascii_name(user["name"]))
-
-    filtered = []
+    users_with_photos = []
     users_without_photos = []
     for user in users:
-        if not user["is_verified"] and lower_ascii_name(user["name"]) in reserved:
-            continue
         if user["profile_picture_sizes"] or user["profile_picture"]:
-            filtered.append(user)
+            users_with_photos.append(user)
         else:
             users_without_photos.append(user)
 
-    return filtered + users_without_photos
+    return users_with_photos + users_without_photos
 
 
 def lower_ascii_name(name):


### PR DESCRIPTION
### Description

Pagination was going haywire due to this extra +5 user fetch logic that we were doing to compensate for the dupe user name filtering.

For the moment I removed the +5 fetch logic & removed the dupe user name filtering altogether. The results without the filtering seem fine for the moment, its quite an edge case.

### How Has This Been Tested?

stage
