### PR TITLE
[C-5833] Avoid spreading queryResults

### DIFF
--- a/packages/common/src/api/tan-query/useCollections.ts
+++ b/packages/common/src/api/tan-query/useCollections.ts
@@ -1,15 +1,15 @@
 import { useMemo } from 'react'
 
-import { useQueryClient } from '@tanstack/react-query'
+import { useQueryClient, UseQueryResult } from '@tanstack/react-query'
 import { keyBy } from 'lodash'
 import { useDispatch, useSelector } from 'react-redux'
 
 import { useAudiusQueryContext } from '~/audius-query/AudiusQueryContext'
 import { ID } from '~/models'
-import { UserCollectionMetadata } from '~/models/Collection'
 import { CommonState } from '~/store'
 
 import { getCollectionsBatcher } from './batchers/getCollectionsBatcher'
+import { TQCollection } from './models'
 import { QUERY_KEYS } from './queryKeys'
 import { QueryOptions } from './types'
 import { useCurrentUserId } from './useCurrentUserId'
@@ -46,7 +46,7 @@ export const useCollections = (
       ...options,
       enabled: options?.enabled !== false && !!collectionId && collectionId > 0
     })),
-    combine: combineQueryResults<UserCollectionMetadata[]>
+    combine: combineQueryResults<TQCollection[]>
   })
 
   const { data: collections } = queriesResults
@@ -65,5 +65,7 @@ export const useCollections = (
   // @ts-ignore important to maintain queryResults for tan-query object observers
   queriesResults.byId = byId
 
-  return queriesResults
+  return queriesResults as UseQueryResult<TQCollection[]> & {
+    byId: Record<ID, TQCollection>
+  }
 }

--- a/packages/common/src/api/tan-query/useCollections.ts
+++ b/packages/common/src/api/tan-query/useCollections.ts
@@ -59,11 +59,11 @@ export const useCollections = (
     )
   )
 
-  return {
-    ...queriesResults,
-    data: isSavedToRedux ? collections : undefined,
-    isPending: queriesResults.isPending || !isSavedToRedux,
-    isLoading: queriesResults.isLoading || !isSavedToRedux,
-    byId
-  }
+  queriesResults.data = isSavedToRedux ? collections : undefined
+  queriesResults.isPending = queriesResults.isPending || !isSavedToRedux
+  queriesResults.isLoading = queriesResults.isLoading || !isSavedToRedux
+  // @ts-ignore important to maintain queryResults for tan-query object observers
+  queriesResults.byId = byId
+
+  return queriesResults
 }

--- a/packages/common/src/api/tan-query/useCollections.ts
+++ b/packages/common/src/api/tan-query/useCollections.ts
@@ -47,7 +47,9 @@ export const useCollections = (
       enabled: options?.enabled !== false && !!collectionId && collectionId > 0
     })),
     combine: combineQueryResults<TQCollection[]>
-  })
+  }) as UseQueryResult<TQCollection[]> & {
+    byId: Record<ID, TQCollection>
+  }
 
   const { data: collections } = queriesResults
 
@@ -62,10 +64,7 @@ export const useCollections = (
   queriesResults.data = isSavedToRedux ? collections : undefined
   queriesResults.isPending = queriesResults.isPending || !isSavedToRedux
   queriesResults.isLoading = queriesResults.isLoading || !isSavedToRedux
-  // @ts-ignore important to maintain queryResults for tan-query object observers
   queriesResults.byId = byId
 
-  return queriesResults as UseQueryResult<TQCollection[]> & {
-    byId: Record<ID, TQCollection>
-  }
+  return queriesResults
 }

--- a/packages/common/src/api/tan-query/useTracks.ts
+++ b/packages/common/src/api/tan-query/useTracks.ts
@@ -1,15 +1,15 @@
 import { useMemo } from 'react'
 
-import { useQueryClient } from '@tanstack/react-query'
+import { useQueryClient, UseQueryResult } from '@tanstack/react-query'
 import { keyBy } from 'lodash'
 import { useDispatch, useSelector } from 'react-redux'
 
 import { useAudiusQueryContext } from '~/audius-query'
 import { ID } from '~/models/Identifiers'
-import { TrackMetadata } from '~/models/Track'
 import { CommonState } from '~/store'
 
 import { getTracksBatcher } from './batchers/getTracksBatcher'
+import { TQTrack } from './models'
 import { QUERY_KEYS } from './queryKeys'
 import { QueryOptions } from './types'
 import { useCurrentUserId } from './useCurrentUserId'
@@ -47,7 +47,7 @@ export const useTracks = (
       ...options,
       enabled: options?.enabled !== false && !!trackId && trackId > 0
     })),
-    combine: combineQueryResults<TrackMetadata[]>
+    combine: combineQueryResults<TQTrack[]>
   })
 
   const { data: tracks } = queryResults
@@ -64,5 +64,7 @@ export const useTracks = (
   // @ts-ignore important to maintain queryResults for tan-query object observers
   queryResults.byId = byId
 
-  return queryResults
+  return queryResults as UseQueryResult<TQTrack[]> & {
+    byId: Record<ID, TQTrack>
+  }
 }

--- a/packages/common/src/api/tan-query/useTracks.ts
+++ b/packages/common/src/api/tan-query/useTracks.ts
@@ -48,7 +48,9 @@ export const useTracks = (
       enabled: options?.enabled !== false && !!trackId && trackId > 0
     })),
     combine: combineQueryResults<TQTrack[]>
-  })
+  }) as UseQueryResult<TQTrack[]> & {
+    byId: Record<ID, TQTrack>
+  }
 
   const { data: tracks } = queryResults
 
@@ -61,10 +63,7 @@ export const useTracks = (
   queryResults.data = isSavedToRedux ? tracks : undefined
   queryResults.isPending = queryResults.isPending || !isSavedToRedux
   queryResults.isLoading = queryResults.isLoading || !isSavedToRedux
-  // @ts-ignore important to maintain queryResults for tan-query object observers
   queryResults.byId = byId
 
-  return queryResults as UseQueryResult<TQTrack[]> & {
-    byId: Record<ID, TQTrack>
-  }
+  return queryResults
 }

--- a/packages/common/src/api/tan-query/useTracks.ts
+++ b/packages/common/src/api/tan-query/useTracks.ts
@@ -58,11 +58,11 @@ export const useTracks = (
     trackIds?.every((trackId) => !!state.tracks.entries[trackId])
   )
 
-  return {
-    ...queryResults,
-    data: isSavedToRedux ? tracks : undefined,
-    isPending: queryResults.isPending || !isSavedToRedux,
-    isLoading: queryResults.isLoading || !isSavedToRedux,
-    byId
-  }
+  queryResults.data = isSavedToRedux ? tracks : undefined
+  queryResults.isPending = queryResults.isPending || !isSavedToRedux
+  queryResults.isLoading = queryResults.isLoading || !isSavedToRedux
+  // @ts-ignore important to maintain queryResults for tan-query object observers
+  queryResults.byId = byId
+
+  return queryResults
 }

--- a/packages/common/src/api/tan-query/useUsers.ts
+++ b/packages/common/src/api/tan-query/useUsers.ts
@@ -48,7 +48,10 @@ export const useUsers = (
       enabled: options?.enabled !== false && !!userId && userId > 0
     })),
     combine: combineQueryResults<UserMetadata[]>
-  })
+  }) as UseQueryResult<UserMetadata[]> & {
+    byId: Record<ID, UserMetadata>
+  }
+
   const { data: users } = queryResults
 
   const byId = useMemo(() => keyBy(users, 'user_id'), [users])
@@ -60,10 +63,7 @@ export const useUsers = (
   queryResults.data = isSavedToRedux ? users : undefined
   queryResults.isPending = queryResults.isPending || !isSavedToRedux
   queryResults.isLoading = queryResults.isLoading || !isSavedToRedux
-  // @ts-ignore important to maintain queryResults for tan-query object observers
   queryResults.byId = byId
 
-  return queryResults as UseQueryResult<UserMetadata[]> & {
-    byId: Record<ID, UserMetadata>
-  }
+  return queryResults
 }

--- a/packages/common/src/api/tan-query/useUsers.ts
+++ b/packages/common/src/api/tan-query/useUsers.ts
@@ -1,6 +1,6 @@
 import { useMemo } from 'react'
 
-import { useQueryClient } from '@tanstack/react-query'
+import { useQueryClient, UseQueryResult } from '@tanstack/react-query'
 import { keyBy } from 'lodash'
 import { useDispatch, useSelector } from 'react-redux'
 
@@ -63,5 +63,7 @@ export const useUsers = (
   // @ts-ignore important to maintain queryResults for tan-query object observers
   queryResults.byId = byId
 
-  return queryResults
+  return queryResults as UseQueryResult<UserMetadata[]> & {
+    byId: Record<ID, UserMetadata>
+  }
 }

--- a/packages/common/src/api/tan-query/useUsers.ts
+++ b/packages/common/src/api/tan-query/useUsers.ts
@@ -57,11 +57,11 @@ export const useUsers = (
     userIds?.every((userId) => !!state.users.entries[userId])
   )
 
-  return {
-    ...queryResults,
-    data: isSavedToRedux ? users : undefined,
-    isPending: queryResults.isPending || !isSavedToRedux,
-    isLoading: queryResults.isLoading || !isSavedToRedux,
-    byId
-  }
+  queryResults.data = isSavedToRedux ? users : undefined
+  queryResults.isPending = queryResults.isPending || !isSavedToRedux
+  queryResults.isLoading = queryResults.isLoading || !isSavedToRedux
+  // @ts-ignore important to maintain queryResults for tan-query object observers
+  queryResults.byId = byId
+
+  return queryResults
 }

--- a/packages/common/src/api/tan-query/utils/combineQueryStatuses.ts
+++ b/packages/common/src/api/tan-query/utils/combineQueryStatuses.ts
@@ -1,27 +1,8 @@
 import { QueryObserverResult } from '@tanstack/react-query'
-import { sumBy } from 'lodash'
 
 type QueryObserverStatusResult = Pick<
   QueryObserverResult,
-  | 'isPending'
-  | 'isError'
-  | 'isFetching'
-  | 'isLoading'
-  | 'isSuccess'
-  | 'isFetched'
-  | 'isFetchedAfterMount'
-  | 'isPlaceholderData'
-  | 'isStale'
-  | 'error'
-  | 'errorUpdatedAt'
-  | 'dataUpdatedAt'
-  | 'failureCount'
-  | 'errorUpdateCount'
-  | 'fetchStatus'
-  | 'isLoadingError'
-  | 'isPaused'
-  | 'isRefetchError'
-  | 'isRefetching'
+  'isPending' | 'isError' | 'isFetching' | 'isLoading' | 'isSuccess'
 >
 
 /**
@@ -30,7 +11,7 @@ type QueryObserverStatusResult = Pick<
  * and doesn't handle data types or refetch functionality
  *
  * @param queries Array of query results to combine
- * @returns An object with combined status information
+ * @returns The first query result with combined status information
  */
 export const combineQueryStatuses = (queries: QueryObserverStatusResult[]) => {
   const isPending = queries.some((query) => query.isPending)
@@ -38,55 +19,14 @@ export const combineQueryStatuses = (queries: QueryObserverStatusResult[]) => {
   const isFetching = queries.some((query) => query.isFetching)
   const isLoading = queries.some((query) => query.isLoading)
   const isSuccess = queries.every((query) => query.isSuccess)
-  const isFetched = queries.every((query) => query.isFetched)
-  const isFetchedAfterMount = queries.every(
-    (query) => query.isFetchedAfterMount
-  )
-  const isPlaceholderData = queries.some((query) => query.isPlaceholderData)
 
-  // Combine error information if any query has an error
-  const error = queries.find((query) => query.error)?.error ?? null
-  const errorUpdatedAt = queries.reduce((latest, query) => {
-    const currentTime = query.errorUpdatedAt
-    if (!currentTime) return latest
-    if (!latest) return currentTime
-    return currentTime > latest ? currentTime : latest
-  }, 0)
+  // Mutate the first query result to avoid creating a new object
+  const result = queries[0]
+  result.isError = isError
+  result.isFetching = isFetching
+  result.isLoading = isLoading
+  result.isPending = isPending
+  result.isSuccess = isSuccess
 
-  // Get the most recent fetch time
-  const dataUpdatedAt = queries.reduce((latest, query) => {
-    const currentTime = query.dataUpdatedAt
-    if (!currentTime) return latest
-    if (!latest) return currentTime
-    return currentTime > latest ? currentTime : latest
-  }, 0)
-
-  // Determine overall status
-  let status: 'pending' | 'error' | 'success' = 'success'
-  if (isPending) status = 'pending'
-  if (isError) status = 'error'
-
-  return {
-    error: error as Error,
-    isError,
-    isFetching,
-    isLoading,
-    isPending,
-    isSuccess,
-    status,
-    dataUpdatedAt,
-    errorUpdatedAt,
-    failureCount: sumBy(queries, (q) => q.failureCount ?? 0),
-    failureReason: isError ? error : null,
-    errorUpdateCount: sumBy(queries, (q) => q.errorUpdateCount ?? 0),
-    fetchStatus: isFetching ? 'fetching' : 'idle',
-    isLoadingError: queries.some((q) => q.isLoadingError),
-    isPaused: queries.some((q) => q.isPaused),
-    isRefetchError: queries.some((q) => q.isRefetchError),
-    isRefetching: queries.some((q) => q.isRefetching),
-    isStale: queries.some((q) => q.isStale),
-    isFetched,
-    isFetchedAfterMount,
-    isPlaceholderData
-  }
+  return result
 }

--- a/packages/web/src/pages/explore-page/components/desktop/FeaturedPlaylists.tsx
+++ b/packages/web/src/pages/explore-page/components/desktop/FeaturedPlaylists.tsx
@@ -33,7 +33,7 @@ export const FeaturedPlaylists = () => {
       expandText={messages.exploreMorePlaylists}
       onExpand={() => setIsExpanded(true)}
     >
-      {playlists?.map((playlist: UserCollection) => {
+      {playlists?.map((playlist) => {
         return (
           <CollectionArtCard
             key={playlist.playlist_id}

--- a/packages/web/src/pages/explore-page/components/mobile/ExplorePage.tsx
+++ b/packages/web/src/pages/explore-page/components/mobile/ExplorePage.tsx
@@ -3,7 +3,6 @@ import { useContext, useEffect, ReactNode, useCallback, useState } from 'react'
 import { useFeaturedPlaylists, useFeaturedProfiles } from '@audius/common/api'
 import {
   Variant as CollectionVariant,
-  UserCollection,
   SmartCollection,
   User,
   Variant
@@ -227,7 +226,7 @@ const ExplorePage = ({ pageTitle, description }: ExplorePageProps) => {
           containerClassName={styles.lineupContainer}
           cards={
             !isLoadingPlaylists
-              ? playlists.map((playlist: UserCollection) => (
+              ? playlists.map((playlist) => (
                   <CollectionCard
                     key={playlist.playlist_id}
                     id={playlist.playlist_id}


### PR DESCRIPTION
### Description

Avoid spreading queryResults because tan-query is watching the getters

instead, apply squashed statuses directly to the original query result object

TODO:
- [ ] update useUsers, useTracks, useCollections

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._
