### PR TITLE
Process challenge events sequentially

### DIFF
--- a/packages/discovery-provider/integration_tests/challenges/test_listen_streak_endless_challenge.py
+++ b/packages/discovery-provider/integration_tests/challenges/test_listen_streak_endless_challenge.py
@@ -197,11 +197,9 @@ def test_multiple_listens(app):
         # impact.
 
         # we really want to just ensure that this doesn't crash
-        assert len(state) == 4
+        assert len(state) == 2
         assert state[0].current_step_count == 2
         assert state[1].current_step_count == 2
-        assert state[2].current_step_count == 2
-        assert state[3].current_step_count == 2
 
 
 def test_listen_streak_endless_challenge(app):

--- a/packages/discovery-provider/integration_tests/challenges/test_referral_challenge.py
+++ b/packages/discovery-provider/integration_tests/challenges/test_referral_challenge.py
@@ -155,7 +155,7 @@ def test_referral_challenge(app):
         dispatch_new_user_signup(referrer.user_id, 10, session, bus)
         dispatch_new_user_signup(referrer.user_id, 11, session, bus)
         bus.flush()
-        bus.process_events(session)
+        bus.process_events(session, 100)
         challenges = (
             session.query(UserChallenge)
             .filter(
@@ -248,10 +248,10 @@ def test_referral_challenge(app):
             dispatch_new_user_signup(verified_user.user_id, 14 + i, session, bus)
             if i % 500 == 0:
                 bus.flush()
-                bus.process_events(session)
+                bus.process_events(session, 1000)
 
         bus.flush()
-        bus.process_events(session)
+        bus.process_events(session, 1000)
 
         # Ensure 5000 verified referral created
         challenges = (

--- a/packages/discovery-provider/integration_tests/challenges/test_trending_challenge.py
+++ b/packages/discovery-provider/integration_tests/challenges/test_trending_challenge.py
@@ -317,7 +317,7 @@ def test_trending_challenge_job(app):
                 Challenge.id == "tut",
             )
         ).update({"active": True, "starting_block": BLOCK_NUMBER})
-        bus.process_events(session)
+        bus.process_events(session, 1000)
         session.flush()
         trending_tracks = (
             session.query(TrendingResult)

--- a/packages/discovery-provider/src/challenges/challenge_event_bus.py
+++ b/packages/discovery-provider/src/challenges/challenge_event_bus.py
@@ -167,7 +167,7 @@ class ChallengeEventBus:
                 logger.warning(f"ChallengeEventBus: error enqueuing to Redis: {e}")
         self._in_memory_queue.clear()
 
-    def process_events(self, session: Session, max_events=1000) -> Tuple[int, bool]:
+    def process_events(self, session: Session, max_events=1) -> Tuple[int, bool]:
         """Dequeues `max_events` from Redis queue and processes them, forwarding to listening ChallengeManagers.
         Returns (num_processed_events, did_error).
         Will return -1 as num_processed_events if an error prevented any events from


### PR DESCRIPTION
### Description

Bug: different DNs have divergent state for endless listen streak challenge.

We noticed this bug on stage because the time scale was reduced to 1 minute instead of 1 day. Depending on the batching of plays in the processing queue, DNs would end up in different states. We thought this wouldn't be an issue on prod since the time window is much larger, but we forgot to account for nodes falling behind, which would mean they could process events faster (and have larger batches) as they're catching up.

exaggerated example: imagine if a play 1 day old and a diff one 0 days old landed in the same batch. we would only process the 0 day old one. and if the 1-day old one was important for the user not breaking the streak, we'd ignore and system would think streak is broken.

### How Has This Been Tested?

test on stage