### PR TITLE
Add rate limiter to otp on /authentication route

### DIFF
--- a/packages/identity-service/default-config.json
+++ b/packages/identity-service/default-config.json
@@ -29,6 +29,7 @@
   "blacklisterPublicKey": "0xcccc36bE44D106C6aC14199A2Ed6a29fDa25d5Ae",
   "rateLimitingReqLimit": 50000,
   "rateLimitingAuthLimit": 5000,
+  "rateLimitingOtpLimit": 10,
   "rateLimitingTwitterLimit": 5000,
   "rateLimitingTikTokLimit": 5000,
   "rateLimitingListensPerTrackPerHour": 10,

--- a/packages/identity-service/src/app.js
+++ b/packages/identity-service/src/app.js
@@ -328,7 +328,6 @@ class App {
     // This limiter double dips with the reqLimiter. The 5 requests every hour are also counted here
     this.express.use('/authentication/', authRequestRateLimiter)
     this.express.use('/authentication', otpRequestRateLimiter)
-    this.express.use('/otp/', otpRequestRateLimiter)
 
     const twitterRequestRateLimiter = getRateLimiter({
       prefix: 'twitterLimiter',

--- a/packages/identity-service/src/app.js
+++ b/packages/identity-service/src/app.js
@@ -315,8 +315,20 @@ class App {
       prefix: 'authLimiter',
       max: config.get('rateLimitingAuthLimit')
     })
+    const otpRequestRateLimiter = getRateLimiter({
+      prefix: 'otpLimiter',
+      max: config.get('rateLimitingOtpLimit'),
+      keyGenerator: (req) => {
+        return `${req.query.email}:::${req.query.lookupKey}`
+      },
+      skip: (req) => {
+        return !req.query.otp || req.query.otp === ''
+      }
+    })
     // This limiter double dips with the reqLimiter. The 5 requests every hour are also counted here
     this.express.use('/authentication/', authRequestRateLimiter)
+    this.express.use('/authentication', otpRequestRateLimiter)
+    this.express.use('/otp/', otpRequestRateLimiter)
 
     const twitterRequestRateLimiter = getRateLimiter({
       prefix: 'twitterLimiter',

--- a/packages/identity-service/src/audiusLibsInstance.js
+++ b/packages/identity-service/src/audiusLibsInstance.js
@@ -7,6 +7,7 @@ const config = require('./config')
 const registryAddress = config.get('registryAddress')
 const entityManagerAddress = config.get('entityManagerAddress')
 const web3ProviderUrl = config.get('web3Provider')
+const Web3 = require('web3')
 
 // Fixed address of the SPL token program
 const SOLANA_TOKEN_ADDRESS = 'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA'
@@ -20,18 +21,11 @@ class AudiusLibsWrapper {
   async init() {
     let web3Config
     if (config.get('environment') !== 'development') {
-      const dataWeb3 = await AudiusLibs.Utils.configureWeb3(
-        web3ProviderUrl,
-        null,
-        false
-      )
-      if (!dataWeb3) throw new Error('Web3 incorrectly configured')
-
       web3Config = {
         registryAddress,
         useExternalWeb3: true,
         externalWeb3Config: {
-          web3: dataWeb3,
+          web3: new Web3(web3ProviderUrl),
           // this is a stopgap since libs external web3 init requires an ownerWallet
           // this is never actually used in the service's libs calls
           ownerWallet: config.get('relayerPublicKey')


### PR DESCRIPTION
### Description

This rate limiter should exist to prevent credential stuffing on the /authentication route.

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._

```
curl 'https://identityservice.staging.audius.co/authentication?email=ray%2B121@audius.co&otp=<actual OTP or fake OTP>&lookupKey=<actual lookup key>'

curl 'https://identityservice.staging.audius.co/authentication?email=ray%2B121@audius.co&otp=<actual OTP or fake OTP>&lookupKey=<actual lookup key>'

curl 'https://identityservice.staging.audius.co/authentication?email=ray%2B121@audius.co&otp=<actual OTP or fake OTP>&lookupKey=<actual lookup key>'

curl 'https://identityservice.staging.audius.co/authentication?email=ray%2B121@audius.co&otp=<actual OTP or fake OTP>&lookupKey=<actual lookup key>'

curl 'https://identityservice.staging.audius.co/authentication?email=ray%2B121@audius.co&otp=<actual OTP or fake OTP>&lookupKey=<actual lookup key>'

curl 'https://identityservice.staging.audius.co/authentication?email=ray%2B121@audius.co&otp=<actual OTP or fake OTP>&lookupKey=<actual lookup key>'

curl 'https://identityservice.staging.audius.co/authentication?email=ray%2B121@audius.co&otp=<actual OTP or fake OTP>&lookupKey=<actual lookup key>'

curl 'https://identityservice.staging.audius.co/authentication?email=ray%2B121@audius.co&otp=<actual OTP or fake OTP>&lookupKey=<actual lookup key>'

curl 'https://identityservice.staging.audius.co/authentication?email=ray%2B121@audius.co&otp=<actual OTP or fake OTP>&lookupKey=<actual lookup key>'

curl 'https://identityservice.staging.audius.co/authentication?email=ray%2B121@audius.co&otp=<actual OTP or fake OTP>&lookupKey=<actual lookup key>'

(too many requests)
```