### PR TITLE
[PAY-4021] Address bug bash comments for play count milestones

### DIFF
--- a/packages/common/src/store/pages/audio-rewards/slice.ts
+++ b/packages/common/src/store/pages/audio-rewards/slice.ts
@@ -140,6 +140,7 @@ const slice = createSlice({
       }
     },
     updateOptimisticListenStreak: (_state) => {},
+    updateOptimisticPlayCount: (_state) => {},
     setUserChallengeCurrentStepCount: (
       state,
       action: PayloadAction<{
@@ -288,6 +289,7 @@ export const {
   showRewardClaimedToast,
   resetRewardClaimedToast,
   updateOptimisticListenStreak,
+  updateOptimisticPlayCount,
   setUserChallengeCurrentStepCount,
   resetUserChallengeCurrentStepCount,
   setOptimisticChallengeCompleted

--- a/packages/discovery-provider/integration_tests/challenges/test_play_count_milestones_challenge.py
+++ b/packages/discovery-provider/integration_tests/challenges/test_play_count_milestones_challenge.py
@@ -2,18 +2,11 @@ import logging
 from datetime import datetime
 
 from src.challenges.challenge_event_bus import ChallengeEvent, ChallengeEventBus
-from src.challenges.play_count_milestone_250_challenge import MILESTONE as MILESTONE_250
 from src.challenges.play_count_milestone_250_challenge import (
     play_count_250_milestone_challenge_manager,
 )
 from src.challenges.play_count_milestone_1000_challenge import (
-    MILESTONE as MILESTONE_1000,
-)
-from src.challenges.play_count_milestone_1000_challenge import (
     play_count_1000_milestone_challenge_manager,
-)
-from src.challenges.play_count_milestone_10000_challenge import (
-    MILESTONE as MILESTONE_10000,
 )
 from src.challenges.play_count_milestone_10000_challenge import (
     play_count_10000_milestone_challenge_manager,
@@ -32,6 +25,10 @@ logger = logging.getLogger(__name__)
 REDIS_URL = shared_config["redis"]["url"]
 BLOCK_NUMBER = 10
 CURRENT_YEAR = 2025  # The starting year from which plays are counted onwards
+
+MILESTONE_250 = 2
+MILESTONE_1000 = 3
+MILESTONE_10000 = 4
 
 # Get all the milestone values for testing
 MILESTONE_VALUES = [MILESTONE_250, MILESTONE_1000, MILESTONE_10000]

--- a/packages/discovery-provider/integration_tests/challenges/test_play_count_milestones_challenge.py
+++ b/packages/discovery-provider/integration_tests/challenges/test_play_count_milestones_challenge.py
@@ -26,14 +26,9 @@ REDIS_URL = shared_config["redis"]["url"]
 BLOCK_NUMBER = 10
 CURRENT_YEAR = 2025  # The starting year from which plays are counted onwards
 
-MILESTONE_250 = 2
-MILESTONE_1000 = 3
-MILESTONE_10000 = 4
-
-# Get all the milestone values for testing
-MILESTONE_VALUES = [MILESTONE_250, MILESTONE_1000, MILESTONE_10000]
-REWARD_VALUES = [25, 100, 1000]  # Corresponding reward amounts
+# Challenge IDs for play count milestones
 CHALLENGE_IDS = ["p1", "p2", "p3"]  # Challenge IDs
+REWARD_VALUES = [25, 100, 1000]  # Corresponding reward amounts
 
 
 def create_track(user_id: int, track_id: int) -> Track:
@@ -104,6 +99,17 @@ def setup_challenges(session):
             {"active": True, "starting_block": BLOCK_NUMBER}
         )
     session.flush()
+
+    # Get milestone values from the database
+    milestone_challenges = (
+        session.query(Challenge).filter(Challenge.id.in_(CHALLENGE_IDS)).all()
+    )
+    milestone_map = {
+        challenge.id: challenge.step_count for challenge in milestone_challenges
+    }
+
+    global MILESTONE_VALUES
+    MILESTONE_VALUES = [milestone_map["p1"], milestone_map["p2"], milestone_map["p3"]]
 
 
 def make_scope_and_process(bus, session):

--- a/packages/discovery-provider/src/challenges/challenges.dev.json
+++ b/packages/discovery-provider/src/challenges/challenges.dev.json
@@ -166,7 +166,7 @@
     "type": "numeric",
     "amount": 25,
     "active": true,
-    "step_count": 1,
+    "step_count": 2,
     "starting_block": 0,
     "weekly_pool": 2147483647,
     "cooldown_days": 0
@@ -177,7 +177,7 @@
     "type": "numeric",
     "amount": 100,
     "active": true,
-    "step_count": 2,
+    "step_count": 3,
     "starting_block": 0,
     "weekly_pool": 2147483647,
     "cooldown_days": 0
@@ -188,7 +188,7 @@
     "type": "numeric",
     "amount": 1000,
     "active": true,
-    "step_count": 3,
+    "step_count": 4,
     "starting_block": 0,
     "weekly_pool": 2147483647,
     "cooldown_days": 0

--- a/packages/discovery-provider/src/challenges/challenges.stage.json
+++ b/packages/discovery-provider/src/challenges/challenges.stage.json
@@ -166,7 +166,7 @@
     "type": "numeric",
     "amount": 25,
     "active": true,
-    "step_count": 1,
+    "step_count": 2,
     "starting_block": 0,
     "weekly_pool": 2147483647,
     "cooldown_days": 7

--- a/packages/discovery-provider/src/challenges/challenges.stage.json
+++ b/packages/discovery-provider/src/challenges/challenges.stage.json
@@ -166,7 +166,7 @@
     "type": "numeric",
     "amount": 25,
     "active": true,
-    "step_count": 2,
+    "step_count": 250,
     "starting_block": 0,
     "weekly_pool": 2147483647,
     "cooldown_days": 7
@@ -177,7 +177,7 @@
     "type": "numeric",
     "amount": 100,
     "active": true,
-    "step_count": 5,
+    "step_count": 1000,
     "starting_block": 0,
     "weekly_pool": 2147483647,
     "cooldown_days": 7
@@ -188,7 +188,7 @@
     "type": "numeric",
     "amount": 1000,
     "active": true,
-    "step_count": 10,
+    "step_count": 10000,
     "starting_block": 0,
     "weekly_pool": 2147483647,
     "cooldown_days": 7

--- a/packages/discovery-provider/src/challenges/play_count_milestone_10000_challenge.py
+++ b/packages/discovery-provider/src/challenges/play_count_milestone_10000_challenge.py
@@ -6,13 +6,8 @@ from src.utils.config import shared_config
 
 env = shared_config["discprov"]["env"]
 
-# Milestone for this challenge
-MILESTONE = 10000
+# Reward amount for this challenge
 REWARD_AMOUNT = 1000
-
-# For testing environments, use smaller numbers
-if env == "stage" or env == "dev":
-    MILESTONE = 3
 
 
 class PlayCount10000MilestoneUpdater(PlayCountMilestoneUpdaterBase):
@@ -21,7 +16,6 @@ class PlayCount10000MilestoneUpdater(PlayCountMilestoneUpdaterBase):
     Rewards 1000 AUDIO upon completion.
     """
 
-    MILESTONE = MILESTONE
     REWARD_AMOUNT = REWARD_AMOUNT
     CHALLENGE_ID = "p3"
     PREVIOUS_MILESTONE_CHALLENGE_ID = "p2"  # Previous milestone is 1000 plays

--- a/packages/discovery-provider/src/challenges/play_count_milestone_1000_challenge.py
+++ b/packages/discovery-provider/src/challenges/play_count_milestone_1000_challenge.py
@@ -6,13 +6,8 @@ from src.utils.config import shared_config
 
 env = shared_config["discprov"]["env"]
 
-# Milestone for this challenge
-MILESTONE = 1000
+# Reward amount for this challenge
 REWARD_AMOUNT = 100
-
-# For testing environments, use smaller numbers
-if env == "stage" or env == "dev":
-    MILESTONE = 2
 
 
 class PlayCount1000MilestoneUpdater(PlayCountMilestoneUpdaterBase):
@@ -21,7 +16,6 @@ class PlayCount1000MilestoneUpdater(PlayCountMilestoneUpdaterBase):
     Rewards 100 AUDIO upon completion.
     """
 
-    MILESTONE = MILESTONE
     REWARD_AMOUNT = REWARD_AMOUNT
     CHALLENGE_ID = "p2"
     PREVIOUS_MILESTONE_CHALLENGE_ID = "p1"  # Previous milestone is 250 plays

--- a/packages/discovery-provider/src/challenges/play_count_milestone_250_challenge.py
+++ b/packages/discovery-provider/src/challenges/play_count_milestone_250_challenge.py
@@ -6,13 +6,8 @@ from src.utils.config import shared_config
 
 env = shared_config["discprov"]["env"]
 
-# Milestone for this challenge
-MILESTONE = 250
+# Reward amount for this challenge
 REWARD_AMOUNT = 25
-
-# For testing environments, use smaller numbers
-if env == "stage" or env == "dev":
-    MILESTONE = 1
 
 
 class PlayCount250MilestoneUpdater(PlayCountMilestoneUpdaterBase):
@@ -21,7 +16,6 @@ class PlayCount250MilestoneUpdater(PlayCountMilestoneUpdaterBase):
     Rewards 25 AUDIO upon completion.
     """
 
-    MILESTONE = MILESTONE
     REWARD_AMOUNT = REWARD_AMOUNT
     CHALLENGE_ID = "p1"
     PREVIOUS_MILESTONE_CHALLENGE_ID = ""  # First milestone, no previous one

--- a/packages/discovery-provider/src/challenges/play_count_milestone_challenge_base.py
+++ b/packages/discovery-provider/src/challenges/play_count_milestone_challenge_base.py
@@ -17,7 +17,6 @@ class PlayCountMilestoneUpdaterBase(ChallengeUpdater):
     """
 
     # To be overridden by subclasses
-    MILESTONE = 0
     REWARD_AMOUNT = 0
     CHALLENGE_ID = ""
     PREVIOUS_MILESTONE_CHALLENGE_ID = ""
@@ -56,25 +55,41 @@ class PlayCountMilestoneUpdaterBase(ChallengeUpdater):
         Update user challenges based on their play count milestone.
         This method is called by the ChallengeManager when processing events.
         """
+
+        if not step_count:
+            return
+
         for user_challenge in user_challenges:
             user_id = user_challenge.user_id
             play_count = self._get_user_play_count_2025(session, user_id)
 
             user_challenge.current_step_count = play_count
 
-            if play_count >= self.MILESTONE:
+            if play_count >= step_count:
                 user_challenge.amount = self.REWARD_AMOUNT
                 user_challenge.is_complete = True
 
     def generate_specifier(self, session: Session, user_id: int, extra: Dict) -> str:
         """
         Generate a unique specifier for the user's challenge.
-        Format: hex_user_id_MILESTONE
+        Format: hex_user_id_milestone
         """
-        return f"{hex(user_id)[2:]}_{self.MILESTONE}"
+
+        milestone = "250"
+        if self.CHALLENGE_ID == "p2":
+            milestone = "1000"
+        elif self.CHALLENGE_ID == "p3":
+            milestone = "10000"
+
+        return f"{hex(user_id)[2:]}_{milestone}"
 
     def should_create_new_challenge(
-        self, session: Session, event: str, user_id: int, extra: Dict
+        self,
+        session: Session,
+        event: str,
+        user_id: int,
+        extra: Dict,
+        step_count: Optional[int] = None,
     ) -> bool:
         """
         Determine if a new challenge should be created for the user.

--- a/packages/discovery-provider/src/challenges/play_count_milestone_challenge_base.py
+++ b/packages/discovery-provider/src/challenges/play_count_milestone_challenge_base.py
@@ -89,7 +89,6 @@ class PlayCountMilestoneUpdaterBase(ChallengeUpdater):
         event: str,
         user_id: int,
         extra: Dict,
-        step_count: Optional[int] = None,
     ) -> bool:
         """
         Determine if a new challenge should be created for the user.

--- a/packages/web/src/common/store/pages/audio-rewards/sagas.ts
+++ b/packages/web/src/common/store/pages/audio-rewards/sagas.ts
@@ -8,7 +8,8 @@ import {
   StringWei,
   SpecifierWithAmount,
   Name,
-  Feature
+  Feature,
+  ChallengeName
 } from '@audius/common/models'
 import {
   IntKeys,
@@ -87,6 +88,7 @@ const {
   setUserChallengeCurrentStepCount,
   resetUserChallengeCurrentStepCount,
   updateOptimisticListenStreak,
+  updateOptimisticPlayCount,
   setUndisbursedChallenges
 } = audioRewardsPageActions
 const fetchAccountSucceeded = accountActions.fetchAccountSucceeded
@@ -658,6 +660,37 @@ function* watchUpdateOptimisticListenStreak() {
   })
 }
 
+/**
+ * Updates the play count challenges optimistically when a user plays their own track
+ * All three play count challenges (p1, p2, p3) will show the same play count value
+ */
+function* watchUpdateOptimisticPlayCount() {
+  yield* takeEvery(updateOptimisticPlayCount.type, function* () {
+    // Define array of play count milestone challenge IDs
+    const playCountChallengeIds = [
+      ChallengeName.PlayCount250,
+      ChallengeName.PlayCount1000,
+      ChallengeName.PlayCount10000
+    ]
+
+    // Iterate through each challenge ID
+    for (const challengeId of playCountChallengeIds) {
+      // Get the challenge
+      const challenge = yield* select(getUserChallenge, { challengeId })
+
+      // If the challenge exists, increment its step count
+      if (challenge) {
+        yield* put(
+          setUserChallengeCurrentStepCount({
+            challengeId,
+            stepCount: challenge.current_step_count + 1
+          })
+        )
+      }
+    }
+  })
+}
+
 function* watchUpdateHCaptchaScore() {
   const audiusBackendInstance = yield* getContext('audiusBackendInstance')
   const sdk = yield* getSDK()
@@ -730,7 +763,8 @@ const sagas = () => {
     watchSetHCaptchaStatus,
     watchUpdateHCaptchaScore,
     userChallengePollingDaemon,
-    watchUpdateOptimisticListenStreak
+    watchUpdateOptimisticListenStreak,
+    watchUpdateOptimisticPlayCount
   ]
   return sagas
 }

--- a/packages/web/src/common/store/social/tracks/recordListen.ts
+++ b/packages/web/src/common/store/social/tracks/recordListen.ts
@@ -12,7 +12,8 @@ import { call, put, select, takeEvery } from 'typed-redux-saga'
 import { make } from 'common/store/analytics/actions'
 import { waitForWrite } from 'utils/sagaHelpers'
 
-const { updateOptimisticListenStreak } = audioRewardsPageActions
+const { updateOptimisticListenStreak, updateOptimisticPlayCount } =
+  audioRewardsPageActions
 const { getTrack } = cacheTracksSelectors
 const { getUserId } = accountSelectors
 
@@ -39,6 +40,11 @@ function* recordListen(action: { trackId: number }) {
 
   // Optimistically update the listen streak if applicable
   yield* put(updateOptimisticListenStreak())
+
+  // Optimistically update the play count if the user is playing their own track
+  if (userId === track.owner_id) {
+    yield* put(updateOptimisticPlayCount())
+  }
 }
 
 export function* watchRecordListen() {

--- a/packages/web/src/pages/rewards-page/components/modals/ChallengeRewardsModal/PlayCountMilestoneContent.tsx
+++ b/packages/web/src/pages/rewards-page/components/modals/ChallengeRewardsModal/PlayCountMilestoneContent.tsx
@@ -7,8 +7,10 @@ import {
   ClaimStatus
 } from '@audius/common/store'
 import { getChallengeStatusLabel } from '@audius/common/utils'
-import { Box, Flex, Text } from '@audius/harmony'
+import { Box, Flex, Text, IconCheck } from '@audius/harmony'
 import { useSelector } from 'react-redux'
+
+import { useIsMobile } from 'hooks/useIsMobile'
 
 import { ChallengeRewardsLayout } from './ChallengeRewardsLayout'
 import { ClaimButton } from './ClaimButton'
@@ -38,6 +40,7 @@ export const PlayCountMilestoneContent = ({
   onNavigateAway,
   errorContent
 }: ChallengeContentProps) => {
+  const isMobile = useIsMobile()
   const userChallenges = useSelector(getOptimisticUserChallenges)
   const challenge = userChallenges[challengeName]
   const undisbursedUserChallenges = useSelector(getUndisbursedUserChallenges)
@@ -81,6 +84,9 @@ export const PlayCountMilestoneContent = ({
     ? getChallengeStatusLabel(challenge, challengeName)
     : ''
 
+  const isClaimable =
+    challenge?.claimableAmount && challenge.claimableAmount > 0
+
   const descriptionContent = (
     <Box>
       <Text variant='body' strength='default'>
@@ -90,8 +96,15 @@ export const PlayCountMilestoneContent = ({
   )
 
   const progressStatusLabel = (
-    <Flex w='100%' ph='xl' borderRadius='s' backgroundColor='surface1'>
-      <Flex alignItems='center' justifyContent='center' pv='l'>
+    <Flex
+      ph='xl'
+      backgroundColor='surface1'
+      border='default'
+      borderRadius='s'
+      column={isMobile}
+    >
+      <Flex pv='l' gap='s' w='100%' justifyContent='center' alignItems='center'>
+        {isClaimable ? <IconCheck size='s' color='subdued' /> : null}
         <Text variant='label' size='l' color='subdued'>
           {statusText}
         </Text>


### PR DESCRIPTION
### Description

This PR implements play count milestone challenges that reward users for reaching specific play count thresholds on their tracks.

## Changes

### Backend (Discovery Provider)
- Refactored play count milestone challenge implementation to use values from challenge config files
- Updated challenge step counts in config files to use actual milestone values (250, 1000, 10000)
- Removed hardcoded MILESTONE constants from challenge classes
- Updated test file to use test-specific milestone values

### Frontend (Web)
- Added optimistic UI updates for play count when users play their own tracks
- Added `updateOptimisticPlayCount` action and corresponding saga
- Enhanced play count milestone challenge UI with improved styling and status indicators
- Added proper sorting for play count challenges to ensure they appear in the correct order
- Added helper function to identify play count challenges

## Testing
- Updated integration tests to verify all milestone challenges work correctly
- Verified that challenges respect their dependencies (previous milestone must be completed)
- Tested optimistic UI updates when playing tracks

This implementation allows users to earn rewards at three different play count milestones:
- 250 plays: 25 $AUDIO
- 1,000 plays: 100 $AUDIO
- 10,000 plays: 1,000 $AUDIO

### How Has This Been Tested?

`npm run web:dev`

- Start with a fresh account
- Upload a track
- Ensure that RewardPanel cards are sorted in ascending order 
- Ensure that play count increments when a track is played (owned must be the one that plays the song)
