### PR TITLE
Use hex in first weekly comment challenge specifier

### DIFF
--- a/packages/discovery-provider/src/challenges/first_weekly_comment_challenge.py
+++ b/packages/discovery-provider/src/challenges/first_weekly_comment_challenge.py
@@ -24,7 +24,7 @@ class FirstWeeklyCommentChallengeUpdater(ChallengeUpdater):
         """
         date = datetime.fromtimestamp(extra["created_at"])
         year, week_number, _ = date.isocalendar()
-        specifier = f"{user_id}:{year}{week_number:02d}"
+        specifier = f"{hex(user_id)[2:]}:{year}{week_number:02d}"
         return specifier
 
     def should_create_new_challenge(


### PR DESCRIPTION
### Description
Forgot to use hex here.

Possibility of introducing discrepancies across nodes as they upgrade, but we already have some discrepancies in this challenge bc some nodes didn't upgrade in time to catch comment events, so will probably have a migration to fix this anyway.

### How Has This Been Tested?


