### PR TITLE
rm web3 provider

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "install-hooks": "mookme init --only-hook --skip-types-selection",
     "lint:fix": "turbo run lint:fix",
     "lint": "turbo run lint",
+    "lint:discovery": "cd packages/discovery-provider && ./scripts/lint.sh",
     "patch-package": "bash ./scripts/patch-package.sh",
     "postinstall": "bash ./scripts/postinstall.sh",
     "preinstall": "bash ./scripts/preinstall.sh",

--- a/packages/discovery-provider/src/api/v1/users.py
+++ b/packages/discovery-provider/src/api/v1/users.py
@@ -2,6 +2,7 @@ import base64
 import json
 from typing import Optional
 
+from eth_account import Account
 from eth_account.messages import encode_defunct
 from flask import Response, request
 from flask_restx import Namespace, Resource, fields, inputs, reqparse
@@ -194,7 +195,6 @@ from src.queries.query_helpers import (
     SortDirection,
 )
 from src.queries.search_queries import SearchKind, search
-from src.utils import web3_provider
 from src.utils.auth_middleware import auth_middleware
 from src.utils.db_session import get_db_read_replica
 from src.utils.helpers import decode_string_id, encode_int_id
@@ -2307,13 +2307,10 @@ class GetTokenVerification(Resource):
         base64_payload = token_parts[1]
         message = f"{base64_header}.{base64_payload}"
 
-        # 3. Recover message from signature
-        web3 = web3_provider.get_web3()
-
         wallet = None
         encoded_message = encode_defunct(text=message)
         try:
-            wallet = web3.eth.account.recover_message(
+            wallet = Account.recover_message(
                 encoded_message,
                 signature=signature,
             )

--- a/packages/discovery-provider/src/api_helpers.py
+++ b/packages/discovery-provider/src/api_helpers.py
@@ -13,7 +13,7 @@ from src.queries.get_health import get_latest_chain_block_set_if_nx
 from src.queries.get_sol_plays import get_sol_play_health_info
 
 # pylint: disable=R0401
-from src.utils import helpers, web3_provider
+from src.utils import helpers
 from src.utils.config import shared_config
 from src.utils.core import get_core_health, is_indexing_core_plays
 from src.utils.helpers import generate_signature
@@ -21,7 +21,6 @@ from src.utils.redis_connection import get_redis
 from src.utils.redis_constants import most_recent_indexed_block_redis_key
 
 redis_conn = get_redis()
-web3_connection = web3_provider.get_web3()
 logger = logging.getLogger(__name__)
 disc_prov_version = helpers.get_discovery_provider_version()
 
@@ -71,9 +70,7 @@ def response_dict_with_metadata(response_dictionary, sign_response):
 
     # Include block difference information
     latest_indexed_block = redis_conn.get(most_recent_indexed_block_redis_key)
-    latest_chain_block, _ = get_latest_chain_block_set_if_nx(
-        redis_conn, web3_connection
-    )
+    latest_chain_block, _ = get_latest_chain_block_set_if_nx(redis_conn)
     response_dictionary["latest_indexed_block"] = (
         int(latest_indexed_block) if latest_indexed_block else None
     )

--- a/packages/discovery-provider/src/api_helpers.py
+++ b/packages/discovery-provider/src/api_helpers.py
@@ -3,11 +3,12 @@ import json
 import logging
 import os
 
+from eth_account import Account
+
 # pylint: disable=no-name-in-module
 from eth_account.messages import encode_defunct
 from flask import jsonify
 from web3 import Web3
-from web3.auto import w3
 
 from src.queries.get_health import get_latest_chain_block_set_if_nx
 from src.queries.get_sol_plays import get_sol_play_health_info
@@ -132,8 +133,6 @@ def recover_wallet(data, signature):
     to_recover_hash = Web3.keccak(text=json_dump).hex()
 
     encoded_to_recover = encode_defunct(hexstr=to_recover_hash)
-    recovered_wallet = w3.eth.account.recover_message(
-        encoded_to_recover, signature=signature
-    )
+    recovered_wallet = Account.recover_message(encoded_to_recover, signature=signature)
 
     return recovered_wallet

--- a/packages/discovery-provider/src/app.py
+++ b/packages/discovery-provider/src/app.py
@@ -109,11 +109,10 @@ def create_app(test_config=None):
 
 def create_celery(test_config=None):
     # pylint: disable=W0603
-    global web3endpoint, web3, abi_values, eth_abi_values, eth_web3
+    global web3endpoint, abi_values, eth_abi_values, eth_web3
     global trusted_notifier_manager
     global solana_client_manager
 
-    web3 = web3_provider.get_web3()
     abi_values = helpers.load_abi_values()
     # Initialize eth_web3 with MultiProvider
     # We use multiprovider to allow for multiple web3 providers and additional resiliency.

--- a/packages/discovery-provider/src/conftest.py
+++ b/packages/discovery-provider/src/conftest.py
@@ -30,18 +30,6 @@ def db_mock(monkeypatch):
     return db
 
 
-# Test fixture to mock a web3 provider
-@pytest.fixture()
-def web3_mock(monkeypatch):
-    web3 = MagicMock()
-
-    def get_web3():
-        return web3
-
-    monkeypatch.setattr(src.utils.web3_provider, "get_web3", get_web3)
-    return web3
-
-
 # Test fixture to mock a redis connection
 @pytest.fixture()
 def redis_mock(monkeypatch):

--- a/packages/discovery-provider/src/queries/get_authed_user.py
+++ b/packages/discovery-provider/src/queries/get_authed_user.py
@@ -1,14 +1,12 @@
 import logging
 from typing import Optional, TypedDict
 
+from eth_account import Account
 from eth_account.messages import defunct_hash_message
 
 from src.models.users.user import User
-from src.utils import web3_provider
 
 logger = logging.getLogger(__name__)
-
-web3 = web3_provider.get_web3()
 
 
 class GetAuthedUserResult(TypedDict):
@@ -20,7 +18,7 @@ def get_authed_user(
     session, data: str, signature: str
 ) -> Optional[GetAuthedUserResult]:
     message_hash = defunct_hash_message(text=data)
-    user_wallet = web3.eth.account._recover_hash(message_hash, signature=signature)
+    user_wallet = Account._recover_hash(message_hash, signature=signature)
     result = (
         session.query(User.user_id)
         .filter(User.wallet == user_wallet.lower())

--- a/packages/discovery-provider/src/queries/get_health.py
+++ b/packages/discovery-provider/src/queries/get_health.py
@@ -31,7 +31,6 @@ from src.utils import (  # elasticdsl,
     get_all_nodes,
     helpers,
     redis_connection,
-    web3_provider,
 )
 from src.utils.config import shared_config
 from src.utils.elasticdsl import ES_INDEXES
@@ -165,7 +164,6 @@ def get_health(args: GetHealthArgs, use_redis_cache: bool = True) -> Tuple[Dict,
     Returns a tuple of health results and a boolean indicating an error
     """
     redis = redis_connection.get_redis()
-    web3 = web3_provider.get_web3()
 
     bypass_errors = args.get("bypass_errors")
     verbose = args.get("verbose")
@@ -194,11 +192,6 @@ def get_health(args: GetHealthArgs, use_redis_cache: bool = True) -> Tuple[Dict,
     latest_indexed_block_hash: Optional[str] = None
 
     if use_redis_cache:
-        # get latest blockchain state from redis cache, or fallback to chain if None
-        latest_block_num, latest_block_hash = get_latest_chain_block_set_if_nx(
-            redis, web3
-        )
-
         # get latest db state from redis cache
         latest_indexed_block_num = redis.get(most_recent_indexed_block_redis_key)
         if latest_indexed_block_num is not None:
@@ -209,15 +202,6 @@ def get_health(args: GetHealthArgs, use_redis_cache: bool = True) -> Tuple[Dict,
         )
         if latest_indexed_block_hash_bytes is not None:
             latest_indexed_block_hash = latest_indexed_block_hash_bytes.decode("utf-8")
-    else:
-        # Get latest blockchain state from web3
-        try:
-            final_poa_block = helpers.get_final_poa_block()
-            latest_block = web3.eth.get_block("latest", True)
-            latest_block_num = latest_block.number + (final_poa_block or 0)
-            latest_block_hash = latest_block.hash.hex()
-        except Exception as e:
-            logger.error(f"Could not get latest block from chain: {e}")
 
     # fetch latest db state if:
     # we explicitly don't want to use redis cache or
@@ -235,7 +219,6 @@ def get_health(args: GetHealthArgs, use_redis_cache: bool = True) -> Tuple[Dict,
     core_listens_health = get_core_listens_health(
         redis=redis, plays_count_max_drift=plays_count_max_drift
     )
-    indexing_plays_with_core = core_health and core_health.get("indexing_plays")
     latest_block_ts = 0
     if core_health:
         latest_chain_block_ts = core_health.get("latest_chain_block_ts") or 0
@@ -249,15 +232,10 @@ def get_health(args: GetHealthArgs, use_redis_cache: bool = True) -> Tuple[Dict,
         errors.append("unhealthy core: no new blocks in at least a minute")
 
     play_health_info = get_play_health_info(redis, plays_count_max_drift)
-    if indexing_plays_with_core:
-        play_health_info = core_listens_health
 
-    indexing_entity_manager_with_core = core_health and core_health.get(
-        "indexing_entity_manager"
-    )
-    if indexing_entity_manager_with_core:
-        latest_indexed_block_num = core_health.get("latest_indexed_block") or -1
-        latest_block_num = core_health.get("latest_chain_block") or -1
+    play_health_info = core_listens_health
+    latest_indexed_block_num = core_health.get("latest_indexed_block") or -1
+    latest_block_num = core_health.get("latest_chain_block") or -1
 
     user_bank_health_info = get_solana_indexer_status(
         redis, redis_keys.solana.user_bank, user_bank_max_drift
@@ -717,7 +695,7 @@ def get_core_health(redis: Redis):
         return None
 
 
-def get_latest_chain_block_set_if_nx(redis=None, web3=None):
+def get_latest_chain_block_set_if_nx(redis=None):
     """
     Retrieves the latest block number and blockhash from redis if the keys exist.
     Otherwise it sets these values in redis by querying web3 and returns them
@@ -731,14 +709,8 @@ def get_latest_chain_block_set_if_nx(redis=None, web3=None):
     latest_block_num = None
     latest_block_hash = None
 
-    if redis is None or web3 is None:
+    if redis is None:
         raise Exception("Invalid arguments for get_latest_chain_block_set_if_nx")
-
-    # also check for 'eth' attribute in web3 which means it's initialized and connected to a provider
-    if not hasattr(web3, "eth"):
-        raise Exception(
-            "Invalid web3 argument for get_latest_chain_block_set_if_nx, web3 is not initialized"
-        )
 
     stored_latest_block_num = redis.get(latest_block_redis_key)
     if stored_latest_block_num is not None:
@@ -747,32 +719,6 @@ def get_latest_chain_block_set_if_nx(redis=None, web3=None):
     stored_latest_blockhash = redis.get(latest_block_hash_redis_key)
     if stored_latest_blockhash is not None:
         latest_block_hash = stored_latest_blockhash.decode("utf-8")
-
-    if latest_block_num is None or latest_block_hash is None:
-        try:
-            final_poa_block = helpers.get_final_poa_block()
-            latest_block = web3.eth.get_block("latest", True)
-            latest_block_num = latest_block.number + (final_poa_block or 0)
-            latest_block_hash = latest_block.hash.hex()
-
-            # if we had attempted to use redis cache and the values weren't there, set the values now
-            # ex sets expiration time and nx only sets if key doesn't exist in redis
-            redis.set(
-                latest_block_redis_key,
-                latest_block_num,
-                ex=default_indexing_interval_seconds,
-                nx=True,
-            )
-            redis.set(
-                latest_block_hash_redis_key,
-                latest_block_hash,
-                ex=default_indexing_interval_seconds,
-                nx=True,
-            )
-        except Exception as e:
-            logger.error(
-                f"Could not set values in redis for get_latest_chain_block_set_if_nx: {e}"
-            )
 
     return latest_block_num, latest_block_hash
 

--- a/packages/discovery-provider/src/queries/notifications.py
+++ b/packages/discovery-provider/src/queries/notifications.py
@@ -19,7 +19,7 @@ from src.models.users.aggregate_user import AggregateUser
 from src.models.users.user_balance_change import UserBalanceChange
 from src.queries import response_name_constants as const
 from src.queries.get_prev_track_entries import get_prev_track_entries
-from src.utils import helpers, web3_provider
+from src.tasks.core.core_client import get_core_instance
 from src.utils.config import shared_config
 from src.utils.db_session import get_db_read_replica
 from src.utils.structured_logger import StructuredLogger, log_duration
@@ -813,9 +813,9 @@ def notifications():
         track_added_to_playlist_notifications = []
         track_ids = []
 
-        web3 = web3_provider.get_web3()
-        min_block = helpers.get_adjusted_block(web3, min_block_number)
-        max_block = helpers.get_adjusted_block(web3, max_block_number)
+        core = get_core_instance()
+        min_block = core.get_block(min_block_number)
+        max_block = core.get_block(max_block_number)
 
         for entry in playlist_track_added_results:
             # Get the track_ids from entry["playlist_contents"]
@@ -829,8 +829,8 @@ def notifications():
                 track_timestamp = track["time"]
                 # We know that this track was added to the playlist at this specific update
                 if (
-                    min_block.timestamp < track_timestamp
-                    and track_timestamp <= max_block.timestamp
+                    min_block.timestamp.ToDatetime().second < track_timestamp
+                    and track_timestamp <= max_block.timestamp.ToDatetime().second
                 ):
                     track_ids.append(track_id)
                     track_added_to_playlist_notification = {

--- a/packages/discovery-provider/src/tasks/entity_manager/entities/user.py
+++ b/packages/discovery-provider/src/tasks/entity_manager/entities/user.py
@@ -3,6 +3,7 @@ import re
 from typing import Dict, TypedDict, Union
 
 import base58
+from eth_account import Account
 from eth_account.messages import defunct_hash_message
 from nacl.encoding import HexEncoder
 from nacl.signing import VerifyKey
@@ -558,9 +559,7 @@ def validate_signature(
 
 def recover_user_id_hash(web3, user_id, signature):
     message_hash = defunct_hash_message(text=f"AudiusUserID:{user_id}")
-    wallet_address: str = web3.eth.account._recover_hash(
-        message_hash, signature=signature
-    )
+    wallet_address: str = Account._recover_hash(message_hash, signature=signature)
     return wallet_address
 
 

--- a/packages/discovery-provider/src/tasks/index_core.py
+++ b/packages/discovery-provider/src/tasks/index_core.py
@@ -144,8 +144,10 @@ def update_latest_indexed_block_redis(
 ):
     try:
         block = core.get_block(latest_indexed_block)
+
         block_number = block.height
         block_hash = block.blockhash
+
         redis.set(
             most_recent_indexed_block_redis_key,
             block_number,
@@ -156,6 +158,7 @@ def update_latest_indexed_block_redis(
             block_hash,
             ex=default_indexing_interval_seconds,
         )
+
     except Exception as e:
         logger.error(f"couldn't update latest redis block: {e}")
 

--- a/packages/discovery-provider/src/tasks/index_trending.py
+++ b/packages/discovery-provider/src/tasks/index_trending.py
@@ -6,7 +6,6 @@ from typing import List, Optional, Tuple
 from redis import Redis
 from sqlalchemy import bindparam, text
 from sqlalchemy.orm.session import Session
-from web3 import Web3
 
 from src.models.core.core_indexed_blocks import CoreIndexedBlocks
 from src.models.indexing.block import Block
@@ -23,14 +22,12 @@ from src.queries.get_underground_trending import (
     make_underground_trending_cache_key,
 )
 from src.tasks.celery_app import celery
-from src.tasks.core.core_client import get_core_instance
+from src.tasks.core.core_client import CoreClient, get_core_instance
 from src.tasks.index_tastemaker_notifications import index_tastemaker_notifications
 from src.trending_strategies.trending_strategy_factory import TrendingStrategyFactory
 from src.trending_strategies.trending_type_and_version import TrendingType
 from src.utils.config import shared_config
-from src.utils.core import is_indexing_core_em
 from src.utils.hardcoded_data import genre_allowlist
-from src.utils.helpers import get_adjusted_block
 from src.utils.prometheus_metric import (
     PrometheusMetric,
     PrometheusMetricNames,
@@ -39,7 +36,6 @@ from src.utils.prometheus_metric import (
 from src.utils.redis_cache import set_json_cached_key
 from src.utils.redis_constants import trending_tracks_last_completion_redis_key
 from src.utils.session_manager import SessionManager
-from src.utils.web3_provider import get_web3
 
 logger = logging.getLogger(__name__)
 time_ranges = ["week", "month", "year"]
@@ -436,7 +432,9 @@ def floor_time(dt: datetime, interval_seconds: int):
     return dt + timedelta(0, rounding - seconds, -dt.microsecond)
 
 
-def find_min_block_above_timestamp(block_number: int, min_timestamp: datetime, web3):
+def find_min_block_above_timestamp(
+    block_number: int, min_timestamp: datetime, core: CoreClient
+):
     """
     finds the minimum block number above a timestamp
     This is needed to ensure consistency across discovery nodes on the timestamp/blocknumber
@@ -444,10 +442,10 @@ def find_min_block_above_timestamp(block_number: int, min_timestamp: datetime, w
     returns a tuple of the blocknumber and timestamp
     """
     curr_block_number = block_number
-    block = get_adjusted_block(web3, block_number)
-    while datetime.fromtimestamp(block["timestamp"]) > min_timestamp:
-        prev_block = get_adjusted_block(web3, curr_block_number - 1)
-        prev_timestamp = datetime.fromtimestamp(prev_block["timestamp"])
+    block = core.get_block(block_number)
+    while block.timestamp.ToDatetime() > min_timestamp:
+        prev_block = core.get_block(curr_block_number - 1)
+        prev_timestamp = prev_block.timestamp.ToDatetime()
         if prev_timestamp >= min_timestamp:
             block = prev_block
             curr_block_number -= 1
@@ -458,7 +456,7 @@ def find_min_block_above_timestamp(block_number: int, min_timestamp: datetime, w
 
 
 def get_should_update_trending(
-    db: SessionManager, web3: Web3, redis: Redis, interval_seconds: int
+    db: SessionManager, redis: Redis, interval_seconds: int
 ) -> Tuple[Optional[int], Optional[int]]:
     """
     Checks if the trending job should re-run based off the last trending run's timestamp and
@@ -474,27 +472,21 @@ def get_should_update_trending(
         )
         current_db_block_number = current_db_block[0]
 
-        if is_indexing_core_em():
-            core = get_core_instance()
-            node_info = core.get_node_info()
-            core_chain_id = node_info.chainid
+        core = get_core_instance()
+        node_info = core.get_node_info()
+        core_chain_id = node_info.chainid
 
-            latest_indexed_block: Optional[CoreIndexedBlocks] = (
-                session.query(CoreIndexedBlocks)
-                .filter(CoreIndexedBlocks.chain_id == core_chain_id)
-                .order_by(CoreIndexedBlocks.height.desc())
-                .first()
-            )
+        latest_indexed_block: Optional[CoreIndexedBlocks] = (
+            session.query(CoreIndexedBlocks)
+            .filter(CoreIndexedBlocks.chain_id == core_chain_id)
+            .order_by(CoreIndexedBlocks.height.desc())
+            .first()
+        )
 
-            if latest_indexed_block:
-                block = core.get_block(int(latest_indexed_block.height))
-                if block:
-                    current_datetime = block.timestamp.ToDatetime()
-
-        else:
-            current_block = get_adjusted_block(web3, current_db_block_number)
-            current_timestamp = current_block["timestamp"]
-            current_datetime = datetime.fromtimestamp(current_timestamp)
+        if latest_indexed_block:
+            block = core.get_block(int(latest_indexed_block.height))
+            if block:
+                current_datetime = block.timestamp.ToDatetime()
 
         if not current_datetime:
             logger.error("no timestamp")
@@ -507,7 +499,7 @@ def get_should_update_trending(
         if not last_trending_datetime:
             # Base case where there is no previous trending calculation in redis
             min_block = find_min_block_above_timestamp(
-                current_db_block_number, min_block_datetime, web3
+                current_db_block_number, min_block_datetime, core
             )
             return min_block, int(min_block_datetime.timestamp())
 
@@ -515,7 +507,7 @@ def get_should_update_trending(
         duration_since_last_index = current_datetime - last_trending_datetime
         if duration_since_last_index.total_seconds() >= interval_seconds:
             min_block = find_min_block_above_timestamp(
-                current_db_block_number, min_block_datetime, web3
+                current_db_block_number, min_block_datetime, core
             )
 
             return min_block, int(min_block_datetime.timestamp())
@@ -529,7 +521,6 @@ def index_trending_task(self):
     """Caches all trending combination of time-range and genre (including no genre)."""
     db = index_trending_task.db
     redis = index_trending_task.redis
-    web3 = get_web3()
     have_lock = False
     timeout = 60 * 60 * 2
     update_lock = redis.lock("index_trending_lock", timeout=timeout)
@@ -537,7 +528,7 @@ def index_trending_task(self):
         have_lock = update_lock.acquire(blocking=False)
         if have_lock:
             min_block, min_timestamp = get_should_update_trending(
-                db, web3, redis, UPDATE_TRENDING_DURATION_DIFF_SEC
+                db, redis, UPDATE_TRENDING_DURATION_DIFF_SEC
             )
             if min_block is not None and min_timestamp is not None:
                 index_trending(self, db, redis, min_timestamp)

--- a/packages/discovery-provider/src/tasks/index_trending.py
+++ b/packages/discovery-provider/src/tasks/index_trending.py
@@ -469,6 +469,10 @@ def get_should_update_trending(
     """
     with db.scoped_session() as session:
         current_datetime = None
+        current_db_block = (
+            session.query(Block.number).filter(Block.is_current == True).first()
+        )
+        current_db_block_number = current_db_block[0]
 
         if is_indexing_core_em():
             core = get_core_instance()
@@ -488,11 +492,6 @@ def get_should_update_trending(
                     current_datetime = block.timestamp.ToDatetime()
 
         else:
-            current_db_block = (
-                session.query(Block.number).filter(Block.is_current == True).first()
-            )
-            current_db_block_number = current_db_block[0]
-
             current_block = get_adjusted_block(web3, current_db_block_number)
             current_timestamp = current_block["timestamp"]
             current_datetime = datetime.fromtimestamp(current_timestamp)

--- a/packages/discovery-provider/src/utils/auth_middleware.py
+++ b/packages/discovery-provider/src/utils/auth_middleware.py
@@ -1,13 +1,14 @@
 import functools
 import logging
 
+from eth_account import Account
 from eth_account.messages import encode_defunct
 from flask.globals import request
 from flask_restx import reqparse
 from flask_restx.errors import abort
 
 from src.models.users.user import User
-from src.utils import db_session, web3_provider
+from src.utils import db_session
 
 logger = logging.getLogger(__name__)
 
@@ -19,11 +20,8 @@ def recover_authority_from_signature_headers() -> tuple[int | None, str | None]:
     message = request.headers.get(MESSAGE_HEADER)
     signature = request.headers.get(SIGNATURE_HEADER)
     if message and signature:
-        web3 = web3_provider.get_web3()
         encoded_to_recover = encode_defunct(text=message)
-        wallet = web3.eth.account.recover_message(
-            encoded_to_recover, signature=signature
-        )
+        wallet = Account.recover_message(encoded_to_recover, signature=signature)
         wallet_lower = wallet.lower()
         db = db_session.get_db_read_replica()
         with db.scoped_session() as session:

--- a/packages/discovery-provider/src/utils/helpers.py
+++ b/packages/discovery-provider/src/utils/helpers.py
@@ -617,12 +617,6 @@ def get_account_index(instruction: CompiledInstruction, index: int):
     return instruction.accounts[index]
 
 
-# get block number with a final POA block offset
-def get_adjusted_block(web3: Web3, block_number: int):
-    nethermind_block_number = block_number - get_final_poa_block()
-    return web3.eth.get_block(nethermind_block_number, True)
-
-
 def get_final_poa_block() -> int:
     final_poa_block = None
 

--- a/packages/discovery-provider/src/utils/web3_provider.py
+++ b/packages/discovery-provider/src/utils/web3_provider.py
@@ -3,62 +3,18 @@ Interface for using a web3 provider
 """
 
 import logging
-import os
 from typing import Optional
 
-import requests
-from web3 import HTTPProvider, Web3
-from web3.middleware import geth_poa_middleware
+from web3 import Web3
 
 from src.utils.config import shared_config
 from src.utils.multi_provider import MultiProvider
 
 logger = logging.getLogger(__name__)
 
-web3: Optional[Web3] = None
-
-GATEWAY_FALLBACK_BLOCKDIFF = 10000
-
-
-def get_web3(web3endpoint=None):
-    # pylint: disable=W0603
-    global web3
-
-    if web3:
-        return web3
-
-    if web3endpoint:
-        web3 = Web3(HTTPProvider(web3endpoint))
-    else:
-        local_rpc = os.getenv("audius_web3_localhost")
-        local_web3 = Web3(HTTPProvider(local_rpc))
-        gateway_web3 = Web3(HTTPProvider(os.getenv("audius_web3_host")))
-        # attempt local rpc, check if healthy
-        try:
-            block_diff = abs(
-                local_web3.eth.get_block_number() - gateway_web3.eth.get_block_number()
-            )
-            resp = requests.get(local_rpc + "/health")
-            if resp.status_code == 200 and block_diff < GATEWAY_FALLBACK_BLOCKDIFF:
-                web3 = local_web3
-                logger.info("web3_provider.py | using local RPC")
-            else:
-                raise Exception("local RPC unhealthy or unreachable")
-        except Exception as e:
-            logger.warn(e)
-            web3 = gateway_web3
-
-    web3.strict_bytes_type_checking = False
-    # required middleware for POA
-    # https://web3py.readthedocs.io/en/latest/middleware.html#proof-of-authority
-    web3.middleware_onion.inject(geth_poa_middleware, layer=0)
-    return web3
-
-
 eth_web3: Optional[Web3] = None
 
 
-# mainnet eth, not ACDC
 def get_eth_web3():
     # pylint: disable=W0603
     global eth_web3


### PR DESCRIPTION
### Description
- removes the get_web3() and other acdc web3 references around the codebase
- does not touch eth_web3
- modifies the sig recovery logic to use Account.{method} since this doesn't require an instantiated web3 instance

### How Has This Been Tested?
- ci tests
- audius-cmd
- playwright locally
this may have strange bugs, should just keep an eye out
