### PR TITLE
Add count for play count cards

### DIFF
--- a/packages/common/src/utils/challenges.ts
+++ b/packages/common/src/utils/challenges.ts
@@ -383,7 +383,7 @@ export const makeOptimisticChallengeSortComparator = (
   }
 }
 
-const isPlayCountChallenge = (
+export const isPlayCountChallenge = (
   id: ChallengeRewardID
 ): id is
   | ChallengeName.PlayCount250

--- a/packages/web/src/common/store/pages/audio-rewards/sagas.ts
+++ b/packages/web/src/common/store/pages/audio-rewards/sagas.ts
@@ -551,7 +551,12 @@ function* fetchUserChallengesAsync() {
 
     let userChallenges = challengesData.map(userChallengeFromSDK)
 
-    if (totalPlaysOnOwnedTracks > 0) {
+    // Only update play count milestone challenges if they exist and there are plays
+    if (
+      userChallenges.some((challenge) =>
+        isPlayCountChallenge(challenge.challenge_id)
+      )
+    ) {
       userChallenges = userChallenges.map((challenge) => {
         if (isPlayCountChallenge(challenge.challenge_id)) {
           return {

--- a/packages/web/src/common/store/pages/audio-rewards/sagas.ts
+++ b/packages/web/src/common/store/pages/audio-rewards/sagas.ts
@@ -31,7 +31,12 @@ import {
   CommonStoreContext,
   getSDK
 } from '@audius/common/store'
-import { isResponseError, route, waitForValue } from '@audius/common/utils'
+import {
+  isResponseError,
+  route,
+  waitForValue,
+  isPlayCountChallenge
+} from '@audius/common/utils'
 import { AUDIO } from '@audius/fixed-decimal'
 import {
   Id,
@@ -526,7 +531,40 @@ function* fetchUserChallengesAsync() {
       }
     )
 
-    const userChallenges = challengesData.map(userChallengeFromSDK)
+    // Fetch monthly play counts from 2025
+    const { data: monthlyPlays = {} } = yield* call(
+      [sdk.users, sdk.users.getUserMonthlyTrackListens],
+      {
+        id: Id.parse(currentUserId),
+        startTime: '2025-01-01',
+        // Making the end time one year from the current date since the challenge is technically never ending
+        endTime: new Date(new Date().setFullYear(new Date().getFullYear() + 1))
+          .toISOString()
+          .split('T')[0]
+      }
+    )
+
+    const totalPlaysOnOwnedTracks = Object.values(monthlyPlays).reduce(
+      (sum, month) => sum + (month.totalListens || 0),
+      0
+    )
+
+    let userChallenges = challengesData.map(userChallengeFromSDK)
+
+    if (totalPlaysOnOwnedTracks > 0) {
+      userChallenges = userChallenges.map((challenge) => {
+        if (isPlayCountChallenge(challenge.challenge_id)) {
+          return {
+            ...challenge,
+            current_step_count: Math.max(
+              challenge.current_step_count,
+              totalPlaysOnOwnedTracks
+            )
+          }
+        }
+        return challenge
+      })
+    }
 
     const { data = [] } = yield* call(
       [sdk.challenges, sdk.challenges.getUndisbursedChallenges],


### PR DESCRIPTION
### Description
We weren't showing the total amount of plays on the cards on first load since this is a `numeric` challenge and the step count does not update with the progress of the challenge. Updated so we load in the total play count on load. 

### How Has This Been Tested?
![image](https://github.com/user-attachments/assets/3c61b30e-c532-4e99-8333-d38810d3dcb2)

