### PR TITLE
Fix local eth ganache url

### DIFF
--- a/packages/sdk/src/sdk/config/development.ts
+++ b/packages/sdk/src/sdk/config/development.ts
@@ -46,7 +46,7 @@ export const developmentConfig: SdkServicesConfig = {
     "rewardManagerLookupTableAddress": "GNHKVSmHvoRBt1JJCxz7RSMfzDQGDGhGEjmhHyxb3K5J"
   },
   "ethereum": {
-    "rpcEndpoint": "https://audius-protocol-eth-ganache-1",
+    "rpcEndpoint": "http://audius-protocol-eth-ganache-1",
     "addresses": {
       "ethRewardsManagerAddress": "0x",
       "serviceProviderFactoryAddress": "0x",

--- a/packages/sdk/src/sdk/scripts/generateServicesConfig.ts
+++ b/packages/sdk/src/sdk/scripts/generateServicesConfig.ts
@@ -195,7 +195,7 @@ const developmentConfig: SdkServicesConfig = {
       'GNHKVSmHvoRBt1JJCxz7RSMfzDQGDGhGEjmhHyxb3K5J'
   },
   ethereum: {
-    rpcEndpoint: 'https://audius-protocol-eth-ganache-1',
+    rpcEndpoint: 'http://audius-protocol-eth-ganache-1',
     addresses: {
       ethRewardsManagerAddress: '0x',
       serviceProviderFactoryAddress: '0x',


### PR DESCRIPTION
### Description

Not sure when this was put in, but it should be http, like the other dev urls

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._
```
npm run protocol
npm run web:dev
```
