### PR TITLE
Remove unnecessary web3-core dep from SDK

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -119504,8 +119504,7 @@
         "pino": "^8.16.1",
         "rate-limiter-flexible": "^2.4.1",
         "redis": "4.6.11",
-        "uuid": "^9.0.0",
-        "web3-core": "1.10.3"
+        "uuid": "^9.0.0"
       },
       "devDependencies": {
         "@types/body-parser": "^1.19.0",
@@ -119888,75 +119887,12 @@
         "node": ">= 10.14.2"
       }
     },
-    "packages/discovery-provider/plugins/pedalboard/apps/relay/node_modules/@noble/curves": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.4.2.tgz",
-      "integrity": "sha512-TavHr8qycMChk8UwMld0ZDRvatedkzWfH8IiaeGCfymOP5i0hSCozz9vHOL0nkwk7HRMlFnAiKpS2jrUmSybcw==",
-      "dependencies": {
-        "@noble/hashes": "1.4.0"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
-    "packages/discovery-provider/plugins/pedalboard/apps/relay/node_modules/@noble/hashes": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.4.0.tgz",
-      "integrity": "sha512-V1JJ1WTRUqHHrOSh597hURcMqVKVGL/ea3kv0gSnEdsEZ0/+VyPghM1lMNGc00z7CIQorSvbKpuJkxvuHbvdbg==",
-      "engines": {
-        "node": ">= 16"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
-    "packages/discovery-provider/plugins/pedalboard/apps/relay/node_modules/@scure/base": {
-      "version": "1.1.9",
-      "resolved": "https://registry.npmjs.org/@scure/base/-/base-1.1.9.tgz",
-      "integrity": "sha512-8YKhl8GHiNI/pU2VMaofa2Tor7PJRAjwQLBBuilkJ9L5+13yVbC7JO/wS7piioAvPSwR3JKM1IJ/u4xQzbcXKg==",
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
-    "packages/discovery-provider/plugins/pedalboard/apps/relay/node_modules/@scure/bip32": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@scure/bip32/-/bip32-1.4.0.tgz",
-      "integrity": "sha512-sVUpc0Vq3tXCkDGYVWGIZTRfnvu8LoTDaev7vbwh0omSvVORONr960MQWdKqJDCReIEmTj3PAr73O3aoxz7OPg==",
-      "dependencies": {
-        "@noble/curves": "~1.4.0",
-        "@noble/hashes": "~1.4.0",
-        "@scure/base": "~1.1.6"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
-    "packages/discovery-provider/plugins/pedalboard/apps/relay/node_modules/@scure/bip39": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@scure/bip39/-/bip39-1.3.0.tgz",
-      "integrity": "sha512-disdg7gHuTDZtY+ZdkmLpPCk7fxZSu3gBiEGuoC1XYxv9cGx3Z6cpTggCgW6odSOOIXCiDjuGejW+aJKCY/pIQ==",
-      "dependencies": {
-        "@noble/hashes": "~1.4.0",
-        "@scure/base": "~1.1.6"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
     "packages/discovery-provider/plugins/pedalboard/apps/relay/node_modules/@sinonjs/fake-timers": {
       "version": "6.0.1",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "@sinonjs/commons": "^1.7.0"
-      }
-    },
-    "packages/discovery-provider/plugins/pedalboard/apps/relay/node_modules/@types/bn.js": {
-      "version": "5.1.6",
-      "resolved": "https://registry.npmjs.org/@types/bn.js/-/bn.js-5.1.6.tgz",
-      "integrity": "sha512-Xh8vSwUeMKeYYrj3cX4lGQgFSF/N03r+tv4AiLl1SucqV+uTQpxRcnM8AkXKHwYP9ZPXOYXRr2KPXpVlIvqh9w==",
-      "dependencies": {
-        "@types/node": "*"
       }
     },
     "packages/discovery-provider/plugins/pedalboard/apps/relay/node_modules/@types/jest": {
@@ -119970,6 +119906,7 @@
     },
     "packages/discovery-provider/plugins/pedalboard/apps/relay/node_modules/@types/node": {
       "version": "15.14.9",
+      "dev": true,
       "license": "MIT"
     },
     "packages/discovery-provider/plugins/pedalboard/apps/relay/node_modules/@types/yargs": {
@@ -120285,14 +120222,6 @@
       },
       "engines": {
         "node": ">= 0.10"
-      }
-    },
-    "packages/discovery-provider/plugins/pedalboard/apps/relay/node_modules/cross-fetch": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-4.1.0.tgz",
-      "integrity": "sha512-uKm5PU+MHTootlWEY+mZ4vvXoCn4fLQxT9dSc1sXVMSFkINTJVN8cAQROpwcKm8bJ/c7rgZVIBWzH5T78sNZZw==",
-      "dependencies": {
-        "node-fetch": "^2.7.0"
       }
     },
     "packages/discovery-provider/plugins/pedalboard/apps/relay/node_modules/depd": {
@@ -120922,11 +120851,6 @@
           "optional": true
         }
       }
-    },
-    "packages/discovery-provider/plugins/pedalboard/apps/relay/node_modules/eventemitter3": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.4.tgz",
-      "integrity": "sha512-rlaVLnVxtxvoyLsQQFBx53YmXHDxRIzzTLbdfxqi4yocpSjAxXwkU0cScM5JgSKMqEhrZpnvQ2D9gjylR0AimQ=="
     },
     "packages/discovery-provider/plugins/pedalboard/apps/relay/node_modules/expect": {
       "version": "26.6.2",
@@ -121618,25 +121542,6 @@
       "version": "2.1.3",
       "license": "MIT"
     },
-    "packages/discovery-provider/plugins/pedalboard/apps/relay/node_modules/node-fetch": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
-      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
-      "dependencies": {
-        "whatwg-url": "^5.0.0"
-      },
-      "engines": {
-        "node": "4.x || >=6.0.0"
-      },
-      "peerDependencies": {
-        "encoding": "^0.1.0"
-      },
-      "peerDependenciesMeta": {
-        "encoding": {
-          "optional": true
-        }
-      }
-    },
     "packages/discovery-provider/plugins/pedalboard/apps/relay/node_modules/nodemon": {
       "version": "2.0.22",
       "dev": true,
@@ -121945,11 +121850,6 @@
         "node": ">=8.0"
       }
     },
-    "packages/discovery-provider/plugins/pedalboard/apps/relay/node_modules/tr46": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
-    },
     "packages/discovery-provider/plugins/pedalboard/apps/relay/node_modules/uuid": {
       "version": "9.0.1",
       "funding": [
@@ -121972,187 +121872,6 @@
       },
       "engines": {
         "node": ">=10.10.0"
-      }
-    },
-    "packages/discovery-provider/plugins/pedalboard/apps/relay/node_modules/web3-core": {
-      "version": "1.10.3",
-      "resolved": "https://registry.npmjs.org/web3-core/-/web3-core-1.10.3.tgz",
-      "integrity": "sha512-Vbk0/vUNZxJlz3RFjAhNNt7qTpX8yE3dn3uFxfX5OHbuon5u65YEOd3civ/aQNW745N0vGUlHFNxxmn+sG9DIw==",
-      "dependencies": {
-        "@types/bn.js": "^5.1.1",
-        "@types/node": "^12.12.6",
-        "bignumber.js": "^9.0.0",
-        "web3-core-helpers": "1.10.3",
-        "web3-core-method": "1.10.3",
-        "web3-core-requestmanager": "1.10.3",
-        "web3-utils": "1.10.3"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
-    "packages/discovery-provider/plugins/pedalboard/apps/relay/node_modules/web3-core-helpers": {
-      "version": "1.10.3",
-      "resolved": "https://registry.npmjs.org/web3-core-helpers/-/web3-core-helpers-1.10.3.tgz",
-      "integrity": "sha512-Yv7dQC3B9ipOc5sWm3VAz1ys70Izfzb8n9rSiQYIPjpqtJM+3V4EeK6ghzNR6CO2es0+Yu9CtCkw0h8gQhrTxA==",
-      "dependencies": {
-        "web3-eth-iban": "1.10.3",
-        "web3-utils": "1.10.3"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
-    "packages/discovery-provider/plugins/pedalboard/apps/relay/node_modules/web3-core-method": {
-      "version": "1.10.3",
-      "resolved": "https://registry.npmjs.org/web3-core-method/-/web3-core-method-1.10.3.tgz",
-      "integrity": "sha512-VZ/Dmml4NBmb0ep5PTSg9oqKoBtG0/YoMPei/bq/tUdlhB2dMB79sbeJPwx592uaV0Vpk7VltrrrBv5hTM1y4Q==",
-      "dependencies": {
-        "@ethersproject/transactions": "^5.6.2",
-        "web3-core-helpers": "1.10.3",
-        "web3-core-promievent": "1.10.3",
-        "web3-core-subscriptions": "1.10.3",
-        "web3-utils": "1.10.3"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
-    "packages/discovery-provider/plugins/pedalboard/apps/relay/node_modules/web3-core-promievent": {
-      "version": "1.10.3",
-      "resolved": "https://registry.npmjs.org/web3-core-promievent/-/web3-core-promievent-1.10.3.tgz",
-      "integrity": "sha512-HgjY+TkuLm5uTwUtaAfkTgRx/NzMxvVradCi02gy17NxDVdg/p6svBHcp037vcNpkuGeFznFJgULP+s2hdVgUQ==",
-      "dependencies": {
-        "eventemitter3": "4.0.4"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
-    "packages/discovery-provider/plugins/pedalboard/apps/relay/node_modules/web3-core-requestmanager": {
-      "version": "1.10.3",
-      "resolved": "https://registry.npmjs.org/web3-core-requestmanager/-/web3-core-requestmanager-1.10.3.tgz",
-      "integrity": "sha512-VT9sKJfgM2yBOIxOXeXiDuFMP4pxzF6FT+y8KTLqhDFHkbG3XRe42Vm97mB/IvLQCJOmokEjl3ps8yP1kbggyw==",
-      "dependencies": {
-        "util": "^0.12.5",
-        "web3-core-helpers": "1.10.3",
-        "web3-providers-http": "1.10.3",
-        "web3-providers-ipc": "1.10.3",
-        "web3-providers-ws": "1.10.3"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
-    "packages/discovery-provider/plugins/pedalboard/apps/relay/node_modules/web3-core-subscriptions": {
-      "version": "1.10.3",
-      "resolved": "https://registry.npmjs.org/web3-core-subscriptions/-/web3-core-subscriptions-1.10.3.tgz",
-      "integrity": "sha512-KW0Mc8sgn70WadZu7RjQ4H5sNDJ5Lx8JMI3BWos+f2rW0foegOCyWhRu33W1s6ntXnqeBUw5rRCXZRlA3z+HNA==",
-      "dependencies": {
-        "eventemitter3": "4.0.4",
-        "web3-core-helpers": "1.10.3"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
-    "packages/discovery-provider/plugins/pedalboard/apps/relay/node_modules/web3-core/node_modules/@types/node": {
-      "version": "12.20.55",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.55.tgz",
-      "integrity": "sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ=="
-    },
-    "packages/discovery-provider/plugins/pedalboard/apps/relay/node_modules/web3-eth-iban": {
-      "version": "1.10.3",
-      "resolved": "https://registry.npmjs.org/web3-eth-iban/-/web3-eth-iban-1.10.3.tgz",
-      "integrity": "sha512-ZCfOjYKAjaX2TGI8uif5ah+J3BYFuo+47JOIV1RIz2l7kD9VfnxvRH5UiQDRyMALQC7KFd2hUqIEtHklapNyKA==",
-      "dependencies": {
-        "bn.js": "^5.2.1",
-        "web3-utils": "1.10.3"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
-    "packages/discovery-provider/plugins/pedalboard/apps/relay/node_modules/web3-providers-http": {
-      "version": "1.10.3",
-      "resolved": "https://registry.npmjs.org/web3-providers-http/-/web3-providers-http-1.10.3.tgz",
-      "integrity": "sha512-6dAgsHR3MxJ0Qyu3QLFlQEelTapVfWNTu5F45FYh8t7Y03T1/o+YAkVxsbY5AdmD+y5bXG/XPJ4q8tjL6MgZHw==",
-      "dependencies": {
-        "abortcontroller-polyfill": "^1.7.5",
-        "cross-fetch": "^4.0.0",
-        "es6-promise": "^4.2.8",
-        "web3-core-helpers": "1.10.3"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
-    "packages/discovery-provider/plugins/pedalboard/apps/relay/node_modules/web3-providers-ipc": {
-      "version": "1.10.3",
-      "resolved": "https://registry.npmjs.org/web3-providers-ipc/-/web3-providers-ipc-1.10.3.tgz",
-      "integrity": "sha512-vP5WIGT8FLnGRfswTxNs9rMfS1vCbMezj/zHbBe/zB9GauBRTYVrUo2H/hVrhLg8Ut7AbsKZ+tCJ4mAwpKi2hA==",
-      "dependencies": {
-        "oboe": "2.1.5",
-        "web3-core-helpers": "1.10.3"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
-    "packages/discovery-provider/plugins/pedalboard/apps/relay/node_modules/web3-providers-ws": {
-      "version": "1.10.3",
-      "resolved": "https://registry.npmjs.org/web3-providers-ws/-/web3-providers-ws-1.10.3.tgz",
-      "integrity": "sha512-/filBXRl48INxsh6AuCcsy4v5ndnTZ/p6bl67kmO9aK1wffv7CT++DrtclDtVMeDGCgB3van+hEf9xTAVXur7Q==",
-      "dependencies": {
-        "eventemitter3": "4.0.4",
-        "web3-core-helpers": "1.10.3",
-        "websocket": "^1.0.32"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
-    "packages/discovery-provider/plugins/pedalboard/apps/relay/node_modules/web3-utils": {
-      "version": "1.10.3",
-      "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.10.3.tgz",
-      "integrity": "sha512-OqcUrEE16fDBbGoQtZXWdavsPzbGIDc5v3VrRTZ0XrIpefC/viZ1ZU9bGEemazyS0catk/3rkOOxpzTfY+XsyQ==",
-      "dependencies": {
-        "@ethereumjs/util": "^8.1.0",
-        "bn.js": "^5.2.1",
-        "ethereum-bloom-filters": "^1.0.6",
-        "ethereum-cryptography": "^2.1.2",
-        "ethjs-unit": "0.1.6",
-        "number-to-bn": "1.7.0",
-        "randombytes": "^2.1.0",
-        "utf8": "3.0.0"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
-    "packages/discovery-provider/plugins/pedalboard/apps/relay/node_modules/web3-utils/node_modules/ethereum-cryptography": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/ethereum-cryptography/-/ethereum-cryptography-2.2.1.tgz",
-      "integrity": "sha512-r/W8lkHSiTLxUxW8Rf3u4HGB0xQweG2RyETjywylKZSzLWoWAijRz8WCuOtJ6wah+avllXBqZuk29HCCvhEIRg==",
-      "dependencies": {
-        "@noble/curves": "1.4.2",
-        "@noble/hashes": "1.4.0",
-        "@scure/bip32": "1.4.0",
-        "@scure/bip39": "1.3.0"
-      }
-    },
-    "packages/discovery-provider/plugins/pedalboard/apps/relay/node_modules/webidl-conversions": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
-    },
-    "packages/discovery-provider/plugins/pedalboard/apps/relay/node_modules/whatwg-url": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
-      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
-      "dependencies": {
-        "tr46": "~0.0.3",
-        "webidl-conversions": "^3.0.0"
       }
     },
     "packages/discovery-provider/plugins/pedalboard/apps/relay/node_modules/write-file-atomic": {
@@ -123841,7 +123560,6 @@
         "request-ip": "3.3.0",
         "secp256k1": "5.0.0",
         "uuid": "8.3.2",
-        "web3-core": "4.3.2",
         "web3-eth-accounts": "4.1.2",
         "web3-utils": "4.2.3"
       },
@@ -123970,6 +123688,7 @@
     },
     "packages/discovery-provider/plugins/pedalboard/apps/solana-relay/node_modules/@types/node": {
       "version": "15.12.2",
+      "dev": true,
       "license": "MIT"
     },
     "packages/discovery-provider/plugins/pedalboard/apps/solana-relay/node_modules/@types/supertest": {
@@ -123984,13 +123703,6 @@
       "version": "9.0.8",
       "dev": true,
       "license": "MIT"
-    },
-    "packages/discovery-provider/plugins/pedalboard/apps/solana-relay/node_modules/@types/ws": {
-      "version": "8.5.3",
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*"
-      }
     },
     "packages/discovery-provider/plugins/pedalboard/apps/solana-relay/node_modules/axios": {
       "version": "1.6.8",
@@ -124865,27 +124577,6 @@
         "uuid": "dist/bin/uuid"
       }
     },
-    "packages/discovery-provider/plugins/pedalboard/apps/solana-relay/node_modules/web3-core": {
-      "version": "4.3.2",
-      "license": "LGPL-3.0",
-      "dependencies": {
-        "web3-errors": "^1.1.4",
-        "web3-eth-accounts": "^4.1.0",
-        "web3-eth-iban": "^4.0.7",
-        "web3-providers-http": "^4.1.0",
-        "web3-providers-ws": "^4.0.7",
-        "web3-types": "^1.3.1",
-        "web3-utils": "^4.1.0",
-        "web3-validator": "^2.0.3"
-      },
-      "engines": {
-        "node": ">=14",
-        "npm": ">=6.12.0"
-      },
-      "optionalDependencies": {
-        "web3-providers-ipc": "^4.0.7"
-      }
-    },
     "packages/discovery-provider/plugins/pedalboard/apps/solana-relay/node_modules/web3-eth-accounts": {
       "version": "4.1.2",
       "license": "LGPL-3.0",
@@ -124921,71 +124612,6 @@
         "@noble/hashes": "1.3.3",
         "@scure/bip32": "1.3.3",
         "@scure/bip39": "1.2.2"
-      }
-    },
-    "packages/discovery-provider/plugins/pedalboard/apps/solana-relay/node_modules/web3-eth-iban": {
-      "version": "4.0.7",
-      "license": "LGPL-3.0",
-      "dependencies": {
-        "web3-errors": "^1.1.3",
-        "web3-types": "^1.3.0",
-        "web3-utils": "^4.0.7",
-        "web3-validator": "^2.0.3"
-      },
-      "engines": {
-        "node": ">=14",
-        "npm": ">=6.12.0"
-      }
-    },
-    "packages/discovery-provider/plugins/pedalboard/apps/solana-relay/node_modules/web3-providers-http": {
-      "version": "4.1.0",
-      "license": "LGPL-3.0",
-      "dependencies": {
-        "cross-fetch": "^4.0.0",
-        "web3-errors": "^1.1.3",
-        "web3-types": "^1.3.0",
-        "web3-utils": "^4.0.7"
-      },
-      "engines": {
-        "node": ">=14",
-        "npm": ">=6.12.0"
-      }
-    },
-    "packages/discovery-provider/plugins/pedalboard/apps/solana-relay/node_modules/web3-providers-http/node_modules/cross-fetch": {
-      "version": "4.0.0",
-      "license": "MIT",
-      "dependencies": {
-        "node-fetch": "^2.6.12"
-      }
-    },
-    "packages/discovery-provider/plugins/pedalboard/apps/solana-relay/node_modules/web3-providers-ipc": {
-      "version": "4.0.7",
-      "license": "LGPL-3.0",
-      "optional": true,
-      "dependencies": {
-        "web3-errors": "^1.1.3",
-        "web3-types": "^1.3.0",
-        "web3-utils": "^4.0.7"
-      },
-      "engines": {
-        "node": ">=14",
-        "npm": ">=6.12.0"
-      }
-    },
-    "packages/discovery-provider/plugins/pedalboard/apps/solana-relay/node_modules/web3-providers-ws": {
-      "version": "4.0.7",
-      "license": "LGPL-3.0",
-      "dependencies": {
-        "@types/ws": "8.5.3",
-        "isomorphic-ws": "^5.0.0",
-        "web3-errors": "^1.1.3",
-        "web3-types": "^1.3.0",
-        "web3-utils": "^4.0.7",
-        "ws": "^8.8.1"
-      },
-      "engines": {
-        "node": ">=14",
-        "npm": ">=6.12.0"
       }
     },
     "packages/discovery-provider/plugins/pedalboard/apps/solana-relay/node_modules/web3-utils": {
@@ -125033,25 +124659,6 @@
       "dependencies": {
         "tr46": "~0.0.3",
         "webidl-conversions": "^3.0.0"
-      }
-    },
-    "packages/discovery-provider/plugins/pedalboard/apps/solana-relay/node_modules/ws": {
-      "version": "8.17.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10.0.0"
-      },
-      "peerDependencies": {
-        "bufferutil": "^4.0.1",
-        "utf-8-validate": ">=5.0.2"
-      },
-      "peerDependenciesMeta": {
-        "bufferutil": {
-          "optional": true
-        },
-        "utf-8-validate": {
-          "optional": true
-        }
       }
     },
     "packages/discovery-provider/plugins/pedalboard/apps/staking": {

--- a/packages/discovery-provider/plugins/pedalboard/apps/relay/package.json
+++ b/packages/discovery-provider/plugins/pedalboard/apps/relay/package.json
@@ -38,7 +38,6 @@
     "eth-sig-util": "^3.0.1",
     "ethers": "^5.7.0",
     "express": "^4.18.2",
-    "web3-core": "1.10.3",
     "http-status-codes": "^2.2.0",
     "knex": "^2.4.2",
     "morgan": "^1.10.0",

--- a/packages/discovery-provider/plugins/pedalboard/apps/solana-relay/package.json
+++ b/packages/discovery-provider/plugins/pedalboard/apps/solana-relay/package.json
@@ -35,7 +35,6 @@
     "request-ip": "3.3.0",
     "secp256k1": "5.0.0",
     "uuid": "8.3.2",
-    "web3-core": "4.3.2",
     "web3-eth-accounts": "4.1.2",
     "web3-utils": "4.2.3"
   },

--- a/packages/sdk/src/sdk/services/EntityManager/EntityManagerClient.ts
+++ b/packages/sdk/src/sdk/services/EntityManager/EntityManagerClient.ts
@@ -4,7 +4,6 @@ import {
   type Hex,
   type TypedDataDefinition
 } from 'viem'
-import type { TransactionReceipt } from 'web3-core'
 
 import * as runtime from '../../api/generated/default/runtime'
 import { productionConfig } from '../../config/production'
@@ -24,6 +23,7 @@ import {
   BlockConfirmation,
   EntityManagerConfig,
   EntityManagerService,
+  EntityManagerTransactionReceipt,
   ManageEntityOptions
 } from './types'
 
@@ -62,9 +62,7 @@ export class EntityManagerClient implements EntityManagerService {
     metadata = '',
     confirmationTimeout = CONFIRMATION_TIMEOUT,
     skipConfirmation = false
-  }: ManageEntityOptions): Promise<
-    Pick<TransactionReceipt, 'blockHash' | 'blockNumber'>
-  > {
+  }: ManageEntityOptions): Promise<EntityManagerTransactionReceipt> {
     const nonce = await getNonce()
 
     const typedData: TypedDataDefinition<EntityManagerTypes, 'ManageEntity'> = {

--- a/packages/sdk/src/sdk/services/EntityManager/types.ts
+++ b/packages/sdk/src/sdk/services/EntityManager/types.ts
@@ -1,8 +1,11 @@
-import type { TransactionReceipt } from 'web3-core'
-
 import type { AudiusWalletClient } from '../AudiusWalletClient'
 import type { DiscoveryNodeSelectorService } from '../DiscoveryNodeSelector'
 import type { LoggerService } from '../Logger'
+
+export type EntityManagerTransactionReceipt = {
+  blockHash: string
+  blockNumber: number
+}
 
 export type EntityManagerConfigInternal = {
   /**
@@ -37,7 +40,7 @@ export type EntityManagerConfig = Partial<EntityManagerConfigInternal> & {
 export type EntityManagerService = {
   manageEntity: (
     options: ManageEntityOptions
-  ) => Promise<Pick<TransactionReceipt, 'blockHash' | 'blockNumber'>>
+  ) => Promise<EntityManagerTransactionReceipt>
   confirmWrite: (options: {
     blockHash: string
     blockNumber: number


### PR DESCRIPTION
### Description
We were relying on web3-core existing somewhere in the parent node_modules resolution path so we could import a single type from it and pick off two properties. It's easier to just define a local type for this result instead of importing one from a package we don't otherwise use.

### How Has This Been Tested?
Types change only, so just need to verify typecheck in CI.
