### PR TITLE
Set pubkey for wallet if missing.

### DIFF
--- a/comms/discovery/server/mutate_test.go
+++ b/comms/discovery/server/mutate_test.go
@@ -20,6 +20,7 @@ import (
 )
 
 func TestMutateEndpoint(t *testing.T) {
+
 	// Generate user keys
 	privateKey1, err := crypto.GenerateKey()
 	assert.NoError(t, err)

--- a/comms/discovery/server/server.go
+++ b/comms/discovery/server/server.go
@@ -183,7 +183,7 @@ func (s *ChatServer) getPubkey(c echo.Context) error {
 		return c.String(400, "bad id parameter: "+err.Error())
 	}
 
-	pubkey, err := pubkeystore.RecoverUserPublicKeyBase64(c.Request().Context(), id)
+	pubkey, err := pubkeystore.RecoverFromPeers(s.config, id)
 	if err != nil {
 		return err
 	}

--- a/comms/discovery/server/signed_request.go
+++ b/comms/discovery/server/signed_request.go
@@ -10,6 +10,7 @@ import (
 
 	"comms.audius.co/discovery/db"
 	"comms.audius.co/discovery/db/queries"
+	"comms.audius.co/discovery/pubkeystore"
 	"comms.audius.co/shared/signing"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/labstack/echo/v4"
@@ -103,6 +104,16 @@ func recoverSigningWallet(signatureHex string, signedData []byte) (string, error
 	if err != nil {
 		return "", err
 	}
+
 	wallet := crypto.PubkeyToAddress(*pubkey).Hex()
+
+	// seed the user pubkey if missing
+	err = pubkeystore.SetPubkeyForWallet(wallet, pubkey)
+	if err != nil {
+		slog.Warn("failed to SetPubkeyForWallet", "wallet", wallet, "err", err)
+	} else {
+		slog.Info("SetPubkeyForWallet OK", "wallet", wallet)
+	}
+
 	return wallet, nil
 }


### PR DESCRIPTION
### Description

The user sends a signed POST or signed GET when creating a chat or reading state. 

Use the pubkey from signed request to populate `user_pubkeys` if missing.

Alec had the good idea to use this info at request time.  We'll still want to get user pubkey at signup time, but this will at least solve the immediate issue.


### How Has This Been Tested?

Tested on stage DN5 with new user confirmed chat creation worked.
