### PR TITLE
Query core blocks in block confirm endpoint

### DIFF
--- a/packages/common/src/store/confirmer/actions.ts
+++ b/packages/common/src/store/confirmer/actions.ts
@@ -54,7 +54,7 @@ const validateConfirmationOptions = ({
  * Additionally, calls within a confirm group can be further categorized using
  * an `operationId`. Using the `confirmationOptions` param object, the requester can specify that calls of a particular `operationId`
  * may be parallelized or squashed (where only the last call is necessary to resolve)
- * for performance gains. The requester may also specfify to only invoke the success callback of the
+ * for performance gains. The requester may also specify to only invoke the success callback of the
  * last call of a particular `operationId` to resolve.
  *
  * TODO:

--- a/packages/discovery-provider/src/queries/get_block_confirmation.py
+++ b/packages/discovery-provider/src/queries/get_block_confirmation.py
@@ -1,4 +1,6 @@
-from src.models.indexing.block import Block
+from sqlalchemy import desc
+
+from src.models.indexing.core_indexed_block import CoreIndexedBlock
 from src.utils import db_session, helpers
 
 
@@ -8,16 +10,22 @@ def get_block_confirmation(blockhash, blocknumber):
     db = db_session.get_db_read_replica()
     with db.scoped_session() as session:
         blockhash_query = (
-            session.query(Block).filter(Block.blockhash == blockhash).all()
+            session.query(CoreIndexedBlock)
+            .filter(CoreIndexedBlock.blockhash == blockhash)
+            .all()
         )
 
-        latest_block_query = session.query(Block).filter(Block.is_current == True).all()
+        latest_block_query = (
+            session.query(CoreIndexedBlock)
+            .order_by(desc(CoreIndexedBlock.height))
+            .first()
+        )
 
-        if len(latest_block_query) != 1:
+        if latest_block_query is None:
             raise Exception("Expected SINGLE row marked as current")
 
-        latest_block_record = helpers.model_to_dictionary(latest_block_query[0])
-        latest_block_number = latest_block_record["number"] or 0
+        latest_block_record = helpers.model_to_dictionary(latest_block_query)
+        latest_block_number = latest_block_record["height"] or 0
 
         return {
             "block_found": len(blockhash_query) > 0,


### PR DESCRIPTION
### Description
- core relay is now returning core block number (blockheight is much less than old world ACDC)
- client is using that core block number and calling `/block_confirmation` endpoint with that block number
- Since it's so much lower than old world block height, DN instantly returns saying it has passed, all good
- In reality the block may not have been indexed yet.

Fix is to query new world `core_indexed_block` in `/block_confirmation` instead.

### How Has This Been Tested?


