### PR TITLE
Update TS for archiver to fix build errors

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -116189,7 +116189,7 @@
         "eslint-config-custom-server": "*",
         "ts-node": "10.9.2",
         "tsconfig": "*",
-        "typescript": "5.0.4",
+        "typescript": "5.4.5",
         "vitest": "0.34.6"
       }
     },
@@ -116983,16 +116983,16 @@
       "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
     },
     "packages/discovery-provider/plugins/pedalboard/apps/archiver/node_modules/typescript": {
-      "version": "4.9.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
-      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
+      "version": "5.4.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.5.tgz",
+      "integrity": "sha512-vcI4UpRgg81oIRUFwR0WSIHKt11nJ7SAVlYNIu+QpqeyXP+gpQJy/Z4+F0aGxSE4MqwjyXvW/TzgkLAx2AGHwQ==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
       },
       "engines": {
-        "node": ">=4.2.0"
+        "node": ">=14.17"
       }
     },
     "packages/discovery-provider/plugins/pedalboard/apps/archiver/node_modules/webidl-conversions": {

--- a/packages/discovery-provider/plugins/pedalboard/apps/archiver/package.json
+++ b/packages/discovery-provider/plugins/pedalboard/apps/archiver/package.json
@@ -37,7 +37,7 @@
     "eslint-config-custom-server": "*",
     "ts-node": "10.9.2",
     "tsconfig": "*",
-    "typescript": "5.0.4",
+    "typescript": "5.4.5",
     "vitest": "0.34.6"
   }
 }


### PR DESCRIPTION
### Description
I didn't test the actual build flow 🤦 .
Since we're just using `tsc` to compile the plugin to an output js file, we need to be on TS 5.4 or higher to support features used by some of the dependencies of SDK that are externalized (namely abitypes/viem).

### How Has This Been Tested?
`npm run protocol` and make sure everything comes up.
