### PR TITLE
Increase core block timeout to 3 mins

### DIFF
--- a/packages/discovery-provider/src/queries/get_health.py
+++ b/packages/discovery-provider/src/queries/get_health.py
@@ -243,10 +243,9 @@ def get_health(args: GetHealthArgs, use_redis_cache: bool = True) -> Tuple[Dict,
 
     current_ts = int(time.time())  # Current UTC time in seconds
 
-    # Check if the latest block timestamp is older than 60 seconds
-    core_stuck = (current_ts - latest_block_ts) > 60
+    core_stuck = (current_ts - latest_block_ts) > 180
     if core_stuck:
-        errors.append("unhealthy core: no new blocks in at least a minute")
+        errors.append("unhealthy core: no new blocks in at least a 3 minutes")
 
     play_health_info = get_play_health_info(redis, plays_count_max_drift)
     if indexing_plays_with_core:


### PR DESCRIPTION
I dont trust this healthcheck. giving more time expiry before marking the node red.
