### PR TITLE
Raise stem limit to 200

### DIFF
--- a/packages/web/src/components/edit/fields/StemFilesView.tsx
+++ b/packages/web/src/components/edit/fields/StemFilesView.tsx
@@ -16,7 +16,7 @@ const MAX_ROWS = 200
 const messages = {
   additionalFiles: 'UPLOAD ADDITIONAL FILES',
   audioQuality: 'Provide FLAC, WAV, ALAC, or AIFF for highest audio quality',
-  maxCapacity: 'Reached upload limit of 200 files.',
+  maxCapacity: `Reached upload limit of ${MAX_ROWS} files.`,
   stemTypeHeader: 'Select Stem Type',
   stemTypeDescription: 'Please select a stem type for each of your files.'
 }

--- a/packages/web/src/components/edit/fields/StemFilesView.tsx
+++ b/packages/web/src/components/edit/fields/StemFilesView.tsx
@@ -11,12 +11,12 @@ import { audiusSdk } from 'services/audius-sdk'
 
 import styles from './StemFilesView.module.css'
 
-const MAX_ROWS = 20
+const MAX_ROWS = 200
 
 const messages = {
   additionalFiles: 'UPLOAD ADDITIONAL FILES',
   audioQuality: 'Provide FLAC, WAV, ALAC, or AIFF for highest audio quality',
-  maxCapacity: 'Reached upload limit of 20 files.',
+  maxCapacity: 'Reached upload limit of 200 files.',
   stemTypeHeader: 'Select Stem Type',
   stemTypeDescription: 'Please select a stem type for each of your files.'
 }


### PR DESCRIPTION
### Description
Stems are no longer limited to transaction size by ACDC. Not sure what it is on core but 500 stems on prod worked.

https://audius.co/isaacjan10_8/unlimited-stems

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._
