### PR TITLE
hotfix: Route DM CreateChat RPCs to AAO

### DIFF
--- a/comms/discovery/rpcz/apply.go
+++ b/comms/discovery/rpcz/apply.go
@@ -37,9 +37,20 @@ func NewProcessor(discoveryConfig *config.DiscoveryConfig) (*RPCProcessor, error
 	if err != nil {
 		return nil, err
 	}
+
+	aaoServer := "https://discoveryprovider.audius.co"
+	if discoveryConfig.IsStaging {
+		aaoServer = "https://discoveryprovider.staging.audius.co"
+	}
+
+	if discoveryConfig.IsDev {
+		aaoServer = "http://audius-protocol-discovery-provider-1"
+	}
+
 	validator := &Validator{
-		db:      db.Conn,
-		limiter: limiter,
+		db:        db.Conn,
+		limiter:   limiter,
+		aaoServer: aaoServer,
 	}
 
 	proc := &RPCProcessor{

--- a/comms/discovery/rpcz/validator.go
+++ b/comms/discovery/rpcz/validator.go
@@ -1,11 +1,13 @@
 package rpcz
 
 import (
+	"bytes"
 	"context"
 	"database/sql"
 	"encoding/json"
 	"errors"
 	"fmt"
+	"net/http"
 	"time"
 
 	"comms.audius.co/discovery/config"
@@ -115,6 +117,12 @@ func (vtor *Validator) validateChatCreate(tx *sqlx.Tx, userId int32, rpc schema.
 	receiver := int32(user1)
 	if receiver == userId {
 		receiver = int32(user2)
+	}
+
+	// Check that the creator is non-abusive
+	err = validateSenderPassesAbuseCheck(q, userId)
+	if err != nil {
+		return err
 	}
 
 	// if recipient is creating a chat from a blast
@@ -472,5 +480,35 @@ func validatePermittedToMessage(q db.Queryable, userId int32, chatId string) err
 		return err
 	}
 
+	return nil
+}
+
+func validateSenderPassesAbuseCheck(q db.Queryable, userId int32) error {
+	// Keeping this somewhat opaque as it gets sent to client
+	aaoFailure := errors.New("attestation failed")
+	var handle string
+	err := q.Get(&handle, `SELECT handle FROM users WHERE user_id = $1`, userId)
+	if err != nil {
+		if err == sql.ErrNoRows {
+			return fmt.Errorf("user %d not found", userId)
+		}
+		return err
+	}
+
+	aaoServer := "http://audius-protocol-discovery-provider-1"
+	url := fmt.Sprintf("%s/attestation/%s", aaoServer, handle)
+	// Dummy challenge for now to mitigate
+	requestBody := []byte(`{ "challengeId": "x", "challengeSpecifier": "x", "amount": 0 }`)
+	resp, err := http.Post(url, "application/json", bytes.NewBuffer(requestBody))
+	if err != nil {
+		slog.Error("Error checking user attestation", "error", err, "handle", handle)
+		return err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		slog.Warn("User failed AAO check", "userId", userId, "status", resp.StatusCode)
+		return aaoFailure
+	}
 	return nil
 }

--- a/dev-tools/compose/docker-compose.pedalboard.prod.yml
+++ b/dev-tools/compose/docker-compose.pedalboard.prod.yml
@@ -24,6 +24,11 @@ services:
       dockerfile: ${PROJECT_ROOT}/packages/discovery-provider/plugins/pedalboard/docker/Dockerfile.prod
       args:
         app_name: anti-abuse-oracle
+        TURBO_TEAM: '${TURBO_TEAM}'
+        TURBO_TOKEN: '${TURBO_TOKEN}'
+    environment:
+      IDENTITY_DB_URL: 'postgresql://postgres:postgres@db:5432/identity_service'
+      private_signer_address: '${AAO_WALLET_PRIVATE_KEY}'
     restart: always
     profiles:
       - pedalboard

--- a/dev-tools/compose/nginx_ingress.conf
+++ b/dev-tools/compose/nginx_ingress.conf
@@ -42,6 +42,13 @@ server {
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
     }
 
+    location ~ ^/attestation(/.*)?$ {
+        resolver 127.0.0.11 valid=30s;
+        proxy_pass http://anti-abuse:6003$request_uri;
+        proxy_set_header Host $http_host;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    }
+
     location ~ ^/comms(/.*)?$ {
         resolver 127.0.0.11 valid=30s;
         proxy_pass http://audius-protocol-comms-1:8925/comms$1$is_args$args;


### PR DESCRIPTION
### Description

Routes create chat requests through the AAO plugin. Temporary mitigation to stem the bleeding. Also fixes some audius-compose settings to allow for developing w/ anti-abuse locally.

### How Has This Been Tested?

Tested `npm run web:dev` against `audius-compose up -p` using users created with `audius-cmd user create`:
- New users can't create a chat if their score is negative
- Once their score is high enough, they create chats successfully