### PR TITLE
Properly expose and run archiver in compose stack

### DIFF
--- a/dev-tools/compose/docker-compose.pedalboard.dev.yml
+++ b/dev-tools/compose/docker-compose.pedalboard.dev.yml
@@ -107,5 +107,3 @@ services:
       dockerfile: ${PROJECT_ROOT}/packages/discovery-provider/plugins/pedalboard/docker/Dockerfile.dev
     volumes:
       - ${PROJECT_ROOT}:/app
-    profiles:
-      - pedalboard

--- a/dev-tools/compose/docker-compose.pedalboard.prod.yml
+++ b/dev-tools/compose/docker-compose.pedalboard.prod.yml
@@ -185,12 +185,10 @@ services:
     profiles:
       - pedalboard
     healthcheck:
-      test: ['CMD', 'curl', '-f', 'http://127.0.0.1:6003/archive/health_check']
+      test: ['CMD', 'curl', '-f', 'http://127.0.0.1:6004/archive/health_check']
       interval: 1s
       timeout: 1s
       retries: 120
     depends_on:
-      db:
-        condition: service_healthy
       discovery-provider-redis:
         condition: service_healthy

--- a/dev-tools/compose/nginx_ingress.conf
+++ b/dev-tools/compose/nginx_ingress.conf
@@ -35,6 +35,13 @@ server {
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
     }
 
+    location ~ ^/archive(/.*)?$ {
+        resolver 127.0.0.11 valid=30s;
+        proxy_pass http://archiver:6004/archive$1$is_args$args;
+        proxy_set_header Host $http_host;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    }
+
     location ~ ^/solana(/.*)?$ {
         resolver 127.0.0.11 valid=30s;
         proxy_pass http://audius-protocol-solana-relay-1:6002/solana$1;
@@ -257,7 +264,7 @@ server {
     location / {
         try_files /nonexistent @$http_upgrade;
     }
-    
+
     location @websocket {
         resolver 127.0.0.11 valid=30s;
         set $upstream audius-protocol-solana-test-validator-1:8900;

--- a/packages/discovery-provider/nginx_conf/nginx_container.conf
+++ b/packages/discovery-provider/nginx_conf/nginx_container.conf
@@ -330,6 +330,13 @@ http {
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         }
 
+        location ~ ^/archive(/.*)?$ {
+            resolver 127.0.0.11 valid=30s;
+            proxy_pass http://archiver:6004/archive$1$is_args$args;
+            proxy_set_header Host $http_host;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        }
+
         location ~ ^/health-check$ {
             resolver 127.0.0.11 valid=30s;
             set $upstream core:80;

--- a/packages/discovery-provider/plugins/pedalboard/apps/archiver/src/config.ts
+++ b/packages/discovery-provider/plugins/pedalboard/apps/archiver/src/config.ts
@@ -42,7 +42,7 @@ export const readConfig = (): Config => {
       default: 'redis://audius-protocol-discovery-provider-redis-1:6379/0'
     }),
     archiver_server_host: str({ default: '0.0.0.0' }),
-    archiver_server_port: num({ default: 6003 }),
+    archiver_server_port: num({ default: 6004 }),
     archiver_concurrent_jobs: num({ default: 5 }),
     archiver_tmp_dir: str({ default: '/tmp/audius-archiver' }),
     archiver_cleanup_orphaned_files_interval_seconds: num({

--- a/packages/discovery-provider/plugins/pedalboard/apps/archiver/src/index.ts
+++ b/packages/discovery-provider/plugins/pedalboard/apps/archiver/src/index.ts
@@ -10,6 +10,7 @@ import { getStemsArchiveQueue } from './jobs/createStemsArchive'
 import { getCleanupOrphanedFilesQueue } from './jobs/cleanupOrphanedFiles'
 import { logger, httpLogger } from './logger'
 import { createDefaultWorkerServices } from './workers/services'
+import { ensureTempDirectory } from './workers/ensureTempDirectory'
 // Basic health check endpoint
 const health = (_req: express.Request, res: express.Response) => {
   res.json({ status: 'healthy' })
@@ -28,6 +29,10 @@ const main = async () => {
 
   // Start the workers
   const services = createDefaultWorkerServices()
+
+  // Ensure the temp directory exists
+  await ensureTempDirectory(services)
+
   const {
     worker: stemsWorker,
     removeStemsArchiveJob,

--- a/packages/discovery-provider/plugins/pedalboard/apps/archiver/src/workers/createStemsArchive/createStemsArchive.ts
+++ b/packages/discovery-provider/plugins/pedalboard/apps/archiver/src/workers/createStemsArchive/createStemsArchive.ts
@@ -193,7 +193,7 @@ export const createStemsArchiveWorker = (services: WorkerServices) => {
       return { outputFile }
     } catch (error) {
       try {
-        logger.info('Job failed, cleaning up temp files')
+        logger.error({ error }, 'Job failed, cleaning up temp files')
         await removeTempFiles(jobId)
         await spaceManager.releaseSpace(jobId)
       } catch (error) {

--- a/packages/discovery-provider/plugins/pedalboard/apps/archiver/src/workers/ensureTempDirectory.ts
+++ b/packages/discovery-provider/plugins/pedalboard/apps/archiver/src/workers/ensureTempDirectory.ts
@@ -1,0 +1,7 @@
+import { WorkerServices } from './services'
+
+export const ensureTempDirectory = async (services: WorkerServices) => {
+  const { fs, path, config } = services
+  const tempDir = path.join(config.archiverTmpDir)
+  await fs.mkdir(tempDir, { recursive: true })
+}


### PR DESCRIPTION
### Description
Some changes to get archiver running properly and exposed in local stack
* Updated default port so it doesn't conflict with other plugins
* Added ingress rules for local stack and discovery deployment
* Added a step in startup to make sure the temp directory exists
* Changed logging for failed jobs to pipe the underlying error and use correct level
* Removed a couple of unnecessary compose settings for archiver container

### How Has This Been Tested?
1. Spun up local stack
2. Created new user and uploaded track with stems
3. cURLed the correct endpoints on archiver with query params and headers to create a new stems job
4. Downloaded resulting zip from the job URL once complete
