### PR TITLE
Add index on aggregate_user (user_id, follower_count)

### DIFF
--- a/packages/discovery-provider/ddl/migrations/0126_agg_user_follower_idx.sql
+++ b/packages/discovery-provider/ddl/migrations/0126_agg_user_follower_idx.sql
@@ -1,0 +1,2 @@
+CREATE INDEX IF NOT EXISTS idx_aggregate_user_follower_count
+ON aggregate_user (user_id, follower_count);


### PR DESCRIPTION
Most user list modals are sorted by follower_count desc. This index can save db from having to build full result set before doing pagination.

