### PR TITLE
Enable tastemaker challenge on prod (should wait for block 1120000)

### DIFF
--- a/packages/discovery-provider/src/challenges/challenges.json
+++ b/packages/discovery-provider/src/challenges/challenges.json
@@ -198,7 +198,7 @@
     "name": "TASTEMAKER",
     "type": "aggregate",
     "amount": 100,
-    "active": false,
+    "active": true,
     "step_count": 2147483647,
     "starting_block": 0,
     "weekly_pool": 2147483647,


### PR DESCRIPTION
### Description
Enable the tastemaker challenge in json file, but it should still wait for block to pass 1120000 (via https://github.com/AudiusProject/audius-protocol/pull/11650).

### How Has This Been Tested?

Can't test https://github.com/AudiusProject/audius-protocol/pull/11650 on stage bc we're not actually creating tastemaker notifs there. Want to test the block-gating works on prod.

Will also check in periodically to make sure we're not catching up to 1120000 earlier than expected.
