### PR TITLE
Faster + more correct mutuals endpoint.

### DIFF
--- a/packages/discovery-provider/integration_tests/queries/test_mutual_follows.py
+++ b/packages/discovery-provider/integration_tests/queries/test_mutual_follows.py
@@ -1,0 +1,43 @@
+import logging
+
+import pytest
+
+from integration_tests.utils import populate_mock_db
+from src.queries.get_follow_intersection_users import get_follow_intersection_users
+from src.utils.db_session import get_db
+
+logger = logging.getLogger(__name__)
+
+
+@pytest.fixture
+def test_entities():
+    return {
+        "users": [
+            {"user_id": 51, "handle": "audius"},
+            {"user_id": 1, "handle": "ray"},
+            {"user_id": 2, "handle": "dave"},
+            {"user_id": 3, "handle": "rando"},
+        ],
+        "follows": [
+            {"follower_user_id": 1, "followee_user_id": 51},
+            {"follower_user_id": 1, "followee_user_id": 2},
+            {"follower_user_id": 2, "followee_user_id": 51},
+            {"follower_user_id": 3, "followee_user_id": 51},
+        ],
+    }
+
+
+def test_mutual_followers(app, test_entities):
+    # Add pagination variables to only retrieve first tip result
+    with app.test_request_context("?limit=10&offset=0"):
+        db = get_db()
+        populate_mock_db(db, test_entities)
+        with db.scoped_session():
+            # Test first without filtering, should get the most recent tip
+            users = get_follow_intersection_users(
+                {"my_id": 1, "other_user_id": 51, "limit": 10, "offset": 0}
+            )
+
+            assert len(users) == 1
+            assert users[0]["user_id"] == 2
+            assert users[0]["does_current_user_follow"] == True

--- a/packages/discovery-provider/src/api/v1/users.py
+++ b/packages/discovery-provider/src/api/v1/users.py
@@ -1647,8 +1647,8 @@ class FullMutualFollowers(Resource):
         offset = get_default_max(args.get("offset"), 0)
         current_user_id = get_current_user_id(args)
         args = {
-            "follower_user_id": current_user_id,
-            "followee_user_id": decoded_id,
+            "my_id": current_user_id,
+            "other_user_id": decoded_id,
             "limit": limit,
             "offset": offset,
         }

--- a/packages/discovery-provider/src/queries/get_follow_intersection_users.py
+++ b/packages/discovery-provider/src/queries/get_follow_intersection_users.py
@@ -1,51 +1,41 @@
-from src.models.social.follow import Follow
-from src.models.users.user import User
-from src.queries import response_name_constants
-from src.queries.query_helpers import (
-    get_current_user_id,
-    paginate_query,
-    populate_user_metadata,
-)
-from src.utils import helpers
+from sqlalchemy.sql import text
+
+from src.queries.get_unpopulated_users import get_unpopulated_users
+from src.queries.query_helpers import populate_user_metadata
 from src.utils.db_session import get_db_read_replica
+
+sql = text(
+    """
+select
+  x.follower_user_id
+from follows x
+join aggregate_user au on x.follower_user_id = au.user_id
+join follows me
+  on me.follower_user_id = :my_id
+  and me.followee_user_id = x.follower_user_id
+  and me.is_delete = false
+where x.followee_user_id = :other_user_id
+  and x.is_delete = false
+order by follower_count desc
+limit :limit
+offset :offset
+"""
+)
 
 
 def get_follow_intersection_users(args):
-    followee_user_id = args.get("followee_user_id")
-    follower_user_id = args.get("follower_user_id")
-
     users = []
+    my_id = args.get("my_id")
+
     db = get_db_read_replica()
     with db.scoped_session() as session:
-        query = session.query(User).filter(
-            User.is_current == True,
-            User.user_id.in_(
-                session.query(Follow.follower_user_id)
-                .filter(
-                    Follow.followee_user_id == followee_user_id,
-                    Follow.is_current == True,
-                    Follow.is_delete == False,
-                )
-                .intersect(
-                    session.query(Follow.followee_user_id).filter(
-                        Follow.follower_user_id == follower_user_id,
-                        Follow.is_current == True,
-                        Follow.is_delete == False,
-                    )
-                )
-            ),
-        )
-        users = paginate_query(query).all()
-        users = helpers.query_result_to_list(users)
-        user_ids = [user[response_name_constants.user_id] for user in users]
-        current_user_id = get_current_user_id(required=False)
+        rows = session.execute(sql, args)
+        user_ids = [r[0] for r in rows]
+
+        # get all users for above user_ids
+        users = get_unpopulated_users(session, user_ids)
 
         # bundle peripheral info into user results
-        users = populate_user_metadata(session, user_ids, users, current_user_id)
-
-        # order by follower_count desc
-        users.sort(
-            key=lambda user: user[response_name_constants.follower_count], reverse=True
-        )
+        users = populate_user_metadata(session, user_ids, users, my_id)
 
     return users


### PR DESCRIPTION
Fixes pagination and current_user_id.

explain:

```
explain select
  x.follower_user_id
from follows x
join aggregate_user au on x.follower_user_id = au.user_id
join follows me
  on me.follower_user_id = 1
  and me.followee_user_id = x.follower_user_id
  and me.is_delete = false
where x.followee_user_id = 51
  and x.is_delete = false
order by follower_count desc
limit 15
offset 0
;
```

```
 Limit  (cost=6267.40..6267.44 rows=15 width=12)
   ->  Sort  (cost=6267.40..6387.37 rows=47985 width=12)
         Sort Key: au.follower_count DESC
         ->  Nested Loop  (cost=1.43..5090.12 rows=47985 width=12)
               ->  Nested Loop  (cost=0.87..3781.91 rows=430 width=16)
                     ->  Index Scan using ix_follows_follower_user_id on follows me  (cost=0.44..1881.48 rows=430 width=4)
                           Index Cond: (follower_user_id = 1)
                           Filter: (NOT is_delete)
                     ->  Index Only Scan using idx_aggregate_user_follower_count on aggregate_user au  (cost=0.43..4.42 rows=1 width=12)
                           Index Cond: (user_id = me.followee_user_id)
               ->  Index Only Scan using follows_inbound_idx on follows x  (cost=0.56..2.66 rows=38 width=4)
                     Index Cond: ((followee_user_id = 51) AND (follower_user_id = au.user_id) AND (is_delete = false))
```