### PR TITLE
hotfix: Prioritize users with handles when fetching users by wallet

### DIFF
--- a/packages/discovery-provider/src/queries/get_users_account.py
+++ b/packages/discovery-provider/src/queries/get_users_account.py
@@ -32,7 +32,9 @@ def _get_user_from_wallet(session, wallet: str):
     wallet = wallet.lower()
     if len(wallet) == 42:
         base_query = base_query.filter_by(wallet=wallet)
-        base_query = base_query.order_by(asc(User.created_at))
+        base_query = base_query.order_by(
+            desc(User.handle.isnot(None)), asc(User.created_at)
+        )
     else:
         raise exceptions.ArgumentError("Invalid wallet length")
 


### PR DESCRIPTION
Fixes the bug where a user will forever attempt to complete their account every time they log in.

Orders the users so that all the users with handles appear before the ones without, then sorting by `created_at`.