### PR TITLE
Gate new listen streak specifier on block number

### DIFF
--- a/packages/discovery-provider/src/challenges/listen_streak_endless_challenge.py
+++ b/packages/discovery-provider/src/challenges/listen_streak_endless_challenge.py
@@ -10,6 +10,7 @@ from src.challenges.challenge import (
     FullEventMetadata,
 )
 from src.challenges.challenge_event import ChallengeEvent
+from src.models.core.core_indexed_blocks import CoreIndexedBlocks
 from src.models.rewards.listen_streak_challenge import ChallengeListenStreak
 from src.models.rewards.user_challenge import UserChallenge
 from src.utils.config import shared_config
@@ -22,6 +23,35 @@ RANGE_START_HOURS = 16
 RANGE_END_HOURS = 48
 next_streak_timedelta = timedelta(hours=RANGE_START_HOURS)
 broken_streak_timedelta = timedelta(hours=RANGE_END_HOURS)
+
+# Targeting 2025-03-27
+LISTEN_STREAK_NEW_SPECIFIER_START_BLOCK_PROD = 800000
+# Targeting 2025-03-27
+LISTEN_STREAK_NEW_SPECIFIER_START_BLOCK_STAGE = 1200000
+LISTEN_STREAK_NEW_SPECIFIER_START_BLOCK_DEV = 0
+
+
+LISTEN_STREAK_NEW_SPECIFIER_START_CHAIN_ID_PROD = "audius-mainnet-alpha-beta"
+LISTEN_STREAK_NEW_SPECIFIER_START_CHAIN_ID_STAGE = "audius-testnet-alpha"
+LISTEN_STREAK_NEW_SPECIFIER_START_CHAIN_ID_DEV = "audius-devnet"
+
+
+def get_listen_streak_new_specifier_start_block() -> int:
+    env = shared_config["discprov"]["env"]
+    if env == "dev":
+        return LISTEN_STREAK_NEW_SPECIFIER_START_BLOCK_DEV
+    if env == "stage":
+        return LISTEN_STREAK_NEW_SPECIFIER_START_BLOCK_STAGE
+    return LISTEN_STREAK_NEW_SPECIFIER_START_BLOCK_PROD
+
+
+def get_listen_streak_new_specifier_start_chain_id() -> str:
+    env = shared_config["discprov"]["env"]
+    if env == "dev":
+        return LISTEN_STREAK_NEW_SPECIFIER_START_CHAIN_ID_DEV
+    if env == "stage":
+        return LISTEN_STREAK_NEW_SPECIFIER_START_CHAIN_ID_STAGE
+    return LISTEN_STREAK_NEW_SPECIFIER_START_CHAIN_ID_PROD
 
 
 def get_listen_streak_override(session: Session, user_id: int) -> Optional[int]:
@@ -94,9 +124,28 @@ class ChallengeListenEndlessStreakUpdater(ChallengeUpdater):
             return recent_challenge.specifier
 
         # Otherwise, create a new specifier
+        block = (
+            session.query(CoreIndexedBlocks)
+            .filter(
+                CoreIndexedBlocks.chain_id
+                == get_listen_streak_new_specifier_start_chain_id()
+            )
+            .order_by(CoreIndexedBlocks.height.desc())
+            .first()
+        )
         created_at = datetime.fromtimestamp(extra["created_at"])
-        formatted_date = created_at.strftime("%Y%m%d%H")
-        return f"{hex(user_id)[2:]}{formatted_date}"
+        old_formatted_date = created_at.strftime("%Y%m%d")
+        old_specifier = f"{hex(user_id)[2:]}_{old_formatted_date}"
+        if (
+            not block
+            or not block.height
+            or block.height < get_listen_streak_new_specifier_start_block()
+        ):
+            return old_specifier
+
+        new_formatted_date = created_at.strftime("%Y%m%d%H")
+        new_specifier = f"{hex(user_id)[2:]}{new_formatted_date}"
+        return new_specifier
 
     def should_create_new_challenge(
         self, session: Session, event: str, user_id: int, extra: Dict


### PR DESCRIPTION
### Description
Reference https://github.com/AudiusProject/audius-protocol/pull/11662

Forgot to gate the new specifier on a specific block number to avoid inconsistencies between nodes.

There's probably a cleaner way to do this with more shared code, but I want to just delete all this once the block number is past.

### How Has This Been Tested?


