### PR TITLE
[PE-5865] Fix list index out of range for audio matching challenges

### DIFF
--- a/packages/discovery-provider/src/challenges/audio_matching_challenge.py
+++ b/packages/discovery-provider/src/challenges/audio_matching_challenge.py
@@ -54,6 +54,9 @@ def update_audio_matching_user_challenges(
     Shared implementation for updating audio matching user challenges.
     Updates the challenge amount based on metadata and marks challenges as complete.
     """
+    if not user_challenges:
+        return
+
     challenge_id = user_challenges[0].challenge_id
     challenge_amount = get_challenge_amount(session, challenge_id)
 


### PR DESCRIPTION
### Description
Seeing lots of these errors: 
`ChallengeManager: caught error in manager [b]: [list index out of range]. Rolling back`

Will check back to see if we still see these errors after this goes out.

### How Has This Been Tested?

