### PR TITLE
Fix buy audio swap and polling

### DIFF
--- a/packages/web/src/services/audius-backend/BuyAudio.ts
+++ b/packages/web/src/services/audius-backend/BuyAudio.ts
@@ -84,7 +84,14 @@ export const pollForAudioBalanceChange = async ({
   maxRetryCount?: number
 }) => {
   let retries = 0
-  let tokenAccountInfo = await getAudioAccountInfo({ tokenAccount })
+  let tokenAccountInfo
+  try {
+    tokenAccountInfo = await getAudioAccountInfo({ tokenAccount })
+  } catch (e) {
+    console.error('Failed to get AUDIO balance before polling', e)
+    tokenAccountInfo = null
+  }
+
   while (
     (!tokenAccountInfo || tokenAccountInfo.amount === initialBalance) &&
     retries++ < maxRetryCount
@@ -99,7 +106,12 @@ export const pollForAudioBalanceChange = async ({
       )
     }
     await delay(retryDelayMs)
-    tokenAccountInfo = await getAudioAccountInfo({ tokenAccount })
+    try {
+      tokenAccountInfo = await getAudioAccountInfo({ tokenAccount })
+    } catch (e) {
+      console.error('Failed to get AUDIO balance while polling', e)
+      tokenAccountInfo = null
+    }
   }
   if (tokenAccountInfo && tokenAccountInfo.amount !== initialBalance) {
     console.debug(

--- a/packages/web/src/store/application/ui/buy-audio/sagas.ts
+++ b/packages/web/src/store/application/ui/buy-audio/sagas.ts
@@ -718,10 +718,18 @@ function* swapStep({
   const tokenAccount = yield* call(getAudioAccount, {
     rootAccount: rootAccount.publicKey
   })
-  const beforeSwapAudioAccountInfo = yield* call(getAudioAccountInfo, {
-    tokenAccount
-  })
-  const beforeSwapAudioBalance = beforeSwapAudioAccountInfo?.amount ?? BigInt(0)
+  let beforeSwapAudioBalance = BigInt(0)
+  try {
+    const beforeSwapAudioAccountInfo = yield* call(getAudioAccountInfo, {
+      tokenAccount
+    })
+    beforeSwapAudioBalance = beforeSwapAudioAccountInfo?.amount ?? BigInt(0)
+  } catch (e) {
+    console.error(
+      'Failed to get AUDIO balance before swap, using 0 balance:',
+      e
+    )
+  }
 
   // Swap the SOL for AUDIO
   yield* put(swapStarted())
@@ -1200,9 +1208,14 @@ function* recoverPurchaseIfNecessary() {
       const tokenAccount = yield* call(getAudioAccount, {
         rootAccount: rootAccount.publicKey
       })
-      const audioAccountInfo = yield* call(getAudioAccountInfo, {
-        tokenAccount
-      })
+      let audioAccountInfo
+      try {
+        audioAccountInfo = yield* call(getAudioAccountInfo, {
+          tokenAccount
+        })
+      } catch (e) {
+        audioAccountInfo = null
+      }
       const audioBalance = audioAccountInfo?.amount ?? BigInt(0)
 
       // If the user's root wallet has $AUDIO, that usually indicates a failed transfer


### PR DESCRIPTION
### Description

`getAudioAccountInfo` used to return null and now throws, so we need to catch it.

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._

locally exercised the flow against prod by sending a small amt of both sol & audio to my account and watching it swap correctly