### PR TITLE
Fix search layout issues

### DIFF
--- a/packages/web/src/components/lineup/TanQueryLineup.tsx
+++ b/packages/web/src/components/lineup/TanQueryLineup.tsx
@@ -386,6 +386,8 @@ export const TanQueryLineup = ({
 
   const isInitialLoad = (isFetching && tiles.length === 0) || isPending
 
+  const isEmptyResults = tiles.length === 0 && !isFetching && !isInitialLoad
+
   return (
     <>
       <div
@@ -410,8 +412,9 @@ export const TanQueryLineup = ({
             getScrollParent={getScrollParent}
             element='ol'
             threshold={loadMoreThreshold}
+            // Render empty results as full width instead of a tile taking up one grid space
             className={cn({
-              [tileContainerStyles!]: !!tileContainerStyles
+              [tileContainerStyles!]: !!tileContainerStyles && !isEmptyResults
             })}
           >
             {tiles.length === 0

--- a/packages/web/src/components/user-card/UserCard.tsx
+++ b/packages/web/src/components/user-card/UserCard.tsx
@@ -88,7 +88,7 @@ export const UserCard = (props: UserCardProps) => {
           css={{ justifyContent: 'center' }}
           onClick={onUserLinkClick}
         />
-        <Text variant='body' ellipses>
+        <Text variant='body' ellipses css={{ textAlign: 'center' }}>
           @{handle}
         </Text>
       </CardContent>


### PR DESCRIPTION
### Description
Some styling changes for other branches introduced two minor layout issues:
* The no results card for tracks renders in a half grid format and looks strange
* The center text alignment on user cards was relying on a cascading style from wayyyyy above that got removed.

### How Has This Been Tested?
Just lookin' at em'

### Screenshots
Before
![image](https://github.com/user-attachments/assets/b54fbe91-a91a-4acc-a7de-ecb8a63f9816)

---------

After
![image](https://github.com/user-attachments/assets/aedf167c-925e-46cf-85d5-8b5674eff263)
