### PR TITLE
Fix incorrect status label for aggregate challenges

### DIFF
--- a/packages/common/src/utils/challenges.ts
+++ b/packages/common/src/utils/challenges.ts
@@ -529,10 +529,7 @@ export const getChallengeStatusLabel = (
   }
 
   // Handle completed with cooldown state
-  if (
-    (challenge.state === 'completed' || challenge.state === 'in_progress') &&
-    challenge.cooldown_days
-  ) {
+  if (challenge.state === 'completed' && challenge.cooldown_days) {
     return DEFAULT_STATUS_LABELS.REWARD_PENDING
   }
 


### PR DESCRIPTION
### Description

### How Has This Been Tested?

Before:
<img width="728" alt="Screenshot 2025-03-26 at 5 23 21 PM" src="https://github.com/user-attachments/assets/d1000014-7e0d-4457-a66a-51fcab56a7db" />
<img width="717" alt="Screenshot 2025-03-26 at 5 23 26 PM" src="https://github.com/user-attachments/assets/259b17f7-ecc1-46cb-81f7-6c8c6c959683" />



After:

<img width="738" alt="Screenshot 2025-03-26 at 5 18 04 PM" src="https://github.com/user-attachments/assets/0e49b1b5-ca1a-44d6-a452-a5fd94b564a9" />
<img width="727" alt="Screenshot 2025-03-26 at 5 18 08 PM" src="https://github.com/user-attachments/assets/3bf20fc8-3ba3-429a-a048-001d00caaab8" />
