### PR TITLE
Notifications performance improvements

### DIFF
--- a/packages/discovery-provider/ddl/migrations/0127_notification_announcement_index.sql
+++ b/packages/discovery-provider/ddl/migrations/0127_notification_announcement_index.sql
@@ -1,1 +1,1 @@
-create index ix_announcement on notification(type, timestamp) where type = 'announcement';
+create index if not exists ix_announcement on notification(type, timestamp) where type = 'announcement';

--- a/packages/discovery-provider/ddl/migrations/0127_notification_announcement_index.sql
+++ b/packages/discovery-provider/ddl/migrations/0127_notification_announcement_index.sql
@@ -1,0 +1,1 @@
+create index ix_announcement on notification(type, timestamp) where type = 'announcement';

--- a/packages/discovery-provider/src/tasks/create_engagement_notifications.py
+++ b/packages/discovery-provider/src/tasks/create_engagement_notifications.py
@@ -70,8 +70,8 @@ def _create_engagement_notifications(session):
         existing_notification = (
             session.query(Notification)
             .filter(
-                Notification.user_ids.any(
-                    user_challenge.user_id
+                Notification.user_ids.overlap(
+                    [user_challenge.user_id]
                 ),  # Assumes 'user_ids' can handle multiple IDs and is searchable this way
                 Notification.timestamp >= time_threshold,
                 Notification.type == CLAIMABLE_REWARD,


### PR DESCRIPTION
[This line](https://github.com/AudiusProject/audius-protocol/blob/main/packages/discovery-provider/src/queries/get_notifications.py#L61) to get announcement notification types was causing a full table scan on `notifications` (12M rows) for every request.

There is one row with `announcement` notification type 🤦 ... PR adds a partial index for that one row.

I manually added this index to DN1 DB and the CPU is looking much better:

<img width="1491" alt="image" src="https://github.com/user-attachments/assets/e0316c0d-b806-4b9e-bee0-7bfa430ed424" />

---

The second commit updates the other query to use the `&&` operator (`overlap` in sqlalchemy land), which is required to take advantage of the GIN index on `notification.user_ids`.


