### PR TITLE
TrackListItem selector -> hook fixes

### DIFF
--- a/packages/common/src/utils/uid.ts
+++ b/packages/common/src/utils/uid.ts
@@ -125,6 +125,13 @@ export const getIdFromKindId = (kindId: string) => kindId.split('-')[1]
  */
 export const getKindFromKindId = (kindId: string) => kindId.split('-')[0]
 
+/**
+ * Gets the numeric id from a uid
+ * @param uid
+ */
+export const getNumericIdFromUid = (uid: string) =>
+  parseInt(getIdFromKindId(uid).split(':')[1])
+
 export const uuid = () => {
   // https://stackoverflow.com/questions/105034/create-guid-uuid-in-javascript/873856#873856
   const s = []

--- a/packages/mobile/src/components/track-list/TrackListItem.tsx
+++ b/packages/mobile/src/components/track-list/TrackListItem.tsx
@@ -19,7 +19,11 @@ import {
   playerSelectors,
   playbackPositionSelectors
 } from '@audius/common/store'
-import { Genre, getIdFromKindId, removeNullable } from '@audius/common/utils'
+import {
+  Genre,
+  getNumericIdFromUid,
+  removeNullable
+} from '@audius/common/utils'
 import type {
   NativeSyntheticEvent,
   NativeTouchEvent,
@@ -192,8 +196,7 @@ const TrackListItemComponent = (props: TrackListItemComponentProps) => {
   } = props
 
   const { data: contextPlaylist } = useCollection(contextPlaylistId)
-  const trackId =
-    id ?? (uid ? parseInt(getIdFromKindId(uid).split(':')[1]) : undefined)
+  const trackId = id ?? (uid ? getNumericIdFromUid(uid) : undefined)
   const { data: track } = useTrack(trackId)
   const { data: user } = useUser(track?.owner_id)
 

--- a/packages/mobile/src/components/track-list/TrackListItem.tsx
+++ b/packages/mobile/src/components/track-list/TrackListItem.tsx
@@ -19,7 +19,7 @@ import {
   playerSelectors,
   playbackPositionSelectors
 } from '@audius/common/store'
-import { Genre, removeNullable } from '@audius/common/utils'
+import { Genre, getIdFromKindId, removeNullable } from '@audius/common/utils'
 import type {
   NativeSyntheticEvent,
   NativeTouchEvent,
@@ -192,7 +192,8 @@ const TrackListItemComponent = (props: TrackListItemComponentProps) => {
   } = props
 
   const { data: contextPlaylist } = useCollection(contextPlaylistId)
-  const { data: track } = useTrack(id)
+  const trackId = id ?? parseInt(getIdFromKindId(uid ?? '').split(':')[1])
+  const { data: track } = useTrack(trackId)
   const { data: user } = useUser(track?.owner_id)
 
   const {
@@ -405,7 +406,7 @@ const TrackListItemComponent = (props: TrackListItemComponentProps) => {
             </View>
             <Text numberOfLines={1} style={styles.artistName}>
               {name}
-              <UserBadges user={user!} badgeSize={12} hideName />
+              {user ? <UserBadges user={user} badgeSize={12} hideName /> : null}
             </Text>
           </View>
           {isUnlisted ? (

--- a/packages/mobile/src/components/track-list/TrackListItem.tsx
+++ b/packages/mobile/src/components/track-list/TrackListItem.tsx
@@ -192,7 +192,8 @@ const TrackListItemComponent = (props: TrackListItemComponentProps) => {
   } = props
 
   const { data: contextPlaylist } = useCollection(contextPlaylistId)
-  const trackId = id ?? parseInt(getIdFromKindId(uid ?? '').split(':')[1])
+  const trackId =
+    id ?? (uid ? parseInt(getIdFromKindId(uid).split(':')[1]) : undefined)
   const { data: track } = useTrack(trackId)
   const { data: user } = useUser(track?.owner_id)
 


### PR DESCRIPTION
### Description

Fixes two bugs introduced with the selector -> hook migration
- `user` falsely assumed truthy
- TrackListItem assumed id was defined, but it's either id or uid
  - added backup logic to get track id from uid

### How Has This Been Tested?

library screen working again, tested other track lists as well