### PR TITLE
fix alignment of profile picture change button

### DIFF
--- a/packages/web/src/components/profile-picture/ProfilePicture.module.css
+++ b/packages/web/src/components/profile-picture/ProfilePicture.module.css
@@ -57,6 +57,7 @@
   bottom: var(--harmony-spacing-2xl);
   right: 0;
   left: 0;
+  text-align: center;
   z-index: 4;
 }
 


### PR DESCRIPTION
### Description
Fixes a misaligned "Change" button on profile picture when editing your profile cause by removing a top-level `text-align` style.

### How Has This Been Tested?
Visual inspection.
