### PR TITLE
Add manual verify option

### DIFF
--- a/packages/sdk/src/sdk/scripts/verifyUser.ts
+++ b/packages/sdk/src/sdk/scripts/verifyUser.ts
@@ -14,12 +14,11 @@ program
   .option('--privateKey <privateKey>', 'The private key to use for the request')
   .option(
     '-p, --platform <platform>',
-    'The platform to verify (twitter, instagram, tiktok)'
+    'The platform to verify (twitter, instagram, tiktok, manual)'
   )
   .action(async (args) => {
     if (
       !args.handle ||
-      !args.socialHandle ||
       !args.platform ||
       !args.privateKey
     ) {
@@ -28,7 +27,11 @@ program
       )
       process.exit(1)
     }
-    if (!['twitter', 'instagram', 'tiktok'].includes(args.platform)) {
+    if (args.platform !== 'manual' && !args.socialHandle) {
+      console.error('Missing required arguments: socialHandle is required for non-manual verification')
+      process.exit(1)
+    }
+    if (!['twitter', 'instagram', 'tiktok', 'manual'].includes(args.platform)) {
       console.error('Invalid platform:', args.platform)
       process.exit(1)
     }


### PR DESCRIPTION
### Description

Add `manual` option for verification to not block social handle edits, in the case of manual verif.

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._

ran script for an existing user
```
npx tsx src/sdk/scripts/verifyUser.ts verify --handle <handle> --privateKey <pk> --platform manual
```
confirmed tx looks good, but unf indexing will not reset those values, see
https://github.com/AudiusProject/audius-protocol/blob/1c51f75b285078180257f733c5508bfd9a0a4c2a/packages/discovery-provider/src/tasks/entity_manager/entities/user.py#L301