### PR TITLE
[PE-5861] Select tan-query entities from sagas

### DIFF
--- a/packages/common/src/api/index.ts
+++ b/packages/common/src/api/index.ts
@@ -71,3 +71,6 @@ export * from './tan-query/useTopArtistsInGenre'
 export * from './tan-query/useTopArtists'
 export * from './tan-query/useAudioTransactions'
 export * from './tan-query/useAudioTransactionsCount'
+
+// Saga fetch utils, remove when migration is complete
+export * from './tan-query/saga-utils'

--- a/packages/common/src/api/tan-query/saga-utils/index.ts
+++ b/packages/common/src/api/tan-query/saga-utils/index.ts
@@ -1,0 +1,3 @@
+export * from './queryCollection'
+export * from './queryTrack'
+export * from './queryUser'

--- a/packages/common/src/api/tan-query/saga-utils/queryCollection.ts
+++ b/packages/common/src/api/tan-query/saga-utils/queryCollection.ts
@@ -1,0 +1,10 @@
+import { ID } from '~/models/Identifiers'
+import { getContext } from '~/store/effects'
+
+import { TQCollection } from '../models'
+import { getCollectionQueryKey } from '../useCollection'
+
+export function* queryCollection(id: ID) {
+  const queryClient = yield* getContext('queryClient')
+  return queryClient.getQueryData<TQCollection>(getCollectionQueryKey(id))
+}

--- a/packages/common/src/api/tan-query/saga-utils/queryTrack.ts
+++ b/packages/common/src/api/tan-query/saga-utils/queryTrack.ts
@@ -1,0 +1,10 @@
+import { ID } from '~/models/Identifiers'
+import { getContext } from '~/store/effects'
+
+import { TQTrack } from '../models'
+import { getTrackQueryKey } from '../useTrack'
+
+export function* queryTrack(id: ID) {
+  const queryClient = yield* getContext('queryClient')
+  return queryClient.getQueryData<TQTrack>(getTrackQueryKey(id))
+}

--- a/packages/common/src/api/tan-query/saga-utils/queryUser.ts
+++ b/packages/common/src/api/tan-query/saga-utils/queryUser.ts
@@ -1,0 +1,10 @@
+import { ID } from '~/models/Identifiers'
+import { User } from '~/models/User'
+import { getContext } from '~/store/effects'
+
+import { getUserQueryKey } from '../useUser'
+
+export function* queryUser(id: ID) {
+  const queryClient = yield* getContext('queryClient')
+  return queryClient.getQueryData<User>(getUserQueryKey(id))
+}

--- a/packages/common/src/store/ui/share-modal/sagas.ts
+++ b/packages/common/src/store/ui/share-modal/sagas.ts
@@ -1,42 +1,34 @@
 import { Id } from '@audius/sdk'
-import { takeEvery, put, select, call } from 'typed-redux-saga'
+import { takeEvery, put, call } from 'typed-redux-saga'
 
 import {
   userCollectionMetadataFromSDK,
   userMetadataFromSDK,
   transformAndCleanList
 } from '~/adapters'
-import { getCollection as getCollectionBase } from '~/store/cache/collections/selectors'
-import { getTrack as getTrackBase } from '~/store/cache/tracks/selectors'
-import { getUser as getUserBase } from '~/store/cache/users/selectors'
-import { CommonState } from '~/store/commonStore'
+import { queryCollection, queryTrack, queryUser } from '~/api'
+import { TQCollection } from '~/api/tan-query/models'
 import { getSDK } from '~/store/sdkUtils'
 
-import { ID } from '../../../models'
 import { setVisibility } from '../modals/parentSlice'
 
 import { open, requestOpen } from './slice'
 import { ShareModalRequestOpenAction } from './types'
 
-const getTrack = (id: ID) => (state: CommonState) => getTrackBase(state, { id })
-const getUser = (id: ID) => (state: CommonState) => getUserBase(state, { id })
-const getCollection = (id: ID) => (state: CommonState) =>
-  getCollectionBase(state, { id })
-
 function* handleRequestOpen(action: ShareModalRequestOpenAction) {
   switch (action.payload.type) {
     case 'track': {
       const { trackId, source, type } = action.payload
-      const track = yield* select(getTrack(trackId))
+      const track = yield* queryTrack(trackId)
       if (!track) return
-      const artist = yield* select(getUser(track.owner_id))
+      const artist = yield* queryUser(track.owner_id)
       if (!artist) return
       yield put(open({ type, track, source, artist }))
       break
     }
     case 'profile': {
       const { profileId, source, type } = action.payload
-      const profile = yield* select(getUser(profileId))
+      const profile = yield* queryUser(profileId)
       if (!profile) return
       yield put(open({ type, profile, source }))
       break
@@ -45,7 +37,7 @@ function* handleRequestOpen(action: ShareModalRequestOpenAction) {
       const { collectionId, source } = action.payload
       const sdk = yield* getSDK()
 
-      let collection = yield* select(getCollection(collectionId))
+      let collection = yield* queryCollection(collectionId)
       if (!collection) {
         const { data = [] } = yield* call(
           [sdk.full.playlists, sdk.full.playlists.getPlaylist],
@@ -58,12 +50,12 @@ function* handleRequestOpen(action: ShareModalRequestOpenAction) {
           userCollectionMetadataFromSDK
         )
         if (transformedCollection) {
-          collection = transformedCollection
+          collection = transformedCollection as unknown as TQCollection
         }
       }
       if (!collection) return
 
-      let owner = yield* select(getUser(collection.playlist_owner_id))
+      let owner = yield* queryUser(collection.playlist_owner_id)
       if (!owner) {
         const { data } = yield* call([sdk.full.users, sdk.full.users.getUser], {
           id: Id.parse(collection.playlist_owner_id)
@@ -96,7 +88,7 @@ function* handleRequestOpen(action: ShareModalRequestOpenAction) {
     }
     case 'audioNftPlaylist': {
       const { userId, source } = action.payload
-      const user = yield* select(getUser(userId))
+      const user = yield* queryUser(userId)
       if (!user) return
       yield put(
         open({


### PR DESCRIPTION
### Description

Establishes pattern for selecting tan-query data within sagas
- New `queryUser`, `queryTrack`, `queryCollection` helpers available
- Simple drop-in replacement `yield* select(getUser(<user_id))` -> `yield* queryUser(<user_id>)`
	- Note that TQ types are shallow and do not include `track.user` or `collection.tracks` (see `TQTrack`, `TQCollection`)
- Example usage in share modal sagas

### How Has This Been Tested?

Share modal working with the new selectors