### PR TITLE
add eth alongside sol in key exporter

### DIFF
--- a/packages/web/src/pages/private-key-exporter-page/AdvancedWalletDetails.tsx
+++ b/packages/web/src/pages/private-key-exporter-page/AdvancedWalletDetails.tsx
@@ -91,7 +91,9 @@ export const AdvancedWalletDetails = () => {
   const [publicKey, setPublicKey] = useState<Nullable<string>>(null)
   const [encodedPrivateKey, setEncodedPrivateKey] =
     useState<Nullable<string>>(null)
-  const { solanaWalletService } = useAudiusQueryContext()
+  const { solanaWalletService, authService } = useAudiusQueryContext()
+  const [ethAddress, setEthAddress] = useState<Nullable<string>>(null)
+  const [ethPrivKey, setEthPrivKey] = useState<Nullable<string>>(null)
 
   useEffect(() => {
     const fetchKeypair = async () => {
@@ -100,11 +102,16 @@ export const AdvancedWalletDetails = () => {
         setPublicKey(keypair.publicKey.toString())
         setEncodedPrivateKey(pkg.encode(keypair.secretKey))
       }
+      const ethKey = authService.getWallet()
+      if (ethKey) {
+        setEthAddress(ethKey.getAddressString())
+        setEthPrivKey(ethKey.getPrivateKeyString())
+      }
     }
     fetchKeypair()
   }, [solanaWalletService])
 
-  if (!publicKey || !encodedPrivateKey) {
+  if (!publicKey || !encodedPrivateKey || !ethAddress || !ethPrivKey) {
     return null
   }
 
@@ -113,8 +120,10 @@ export const AdvancedWalletDetails = () => {
       <Text variant='heading' size='s'>
         {messages.advancedWalletDetails}
       </Text>
-      <Key label={messages.address} value={publicKey} />
-      <Key label={messages.privateKey} value={encodedPrivateKey} isPrivate />
+      <Key label={`SOL ${messages.address}`} value={publicKey} />
+      <Key label={`SOL ${messages.privateKey}`} value={encodedPrivateKey} isPrivate />
+      <Key label={`ETH ${messages.address}`} value={ethAddress} />
+      <Key label={`ETH ${messages.privateKey}`} value={ethPrivKey} isPrivate />
     </Flex>
   )
 }


### PR DESCRIPTION
### Description
- in order to use metamask with an existing audius account you need a way to export your user 
- this seemed like the best place as it's already gated behind the many warnings
- adds identifiers for sol vs eth 

how it looks with this change
![Screenshot 2025-03-28 at 9 40 17 AM](https://github.com/user-attachments/assets/f818b5cb-e137-4e98-8db1-822574e689aa)

### How Has This Been Tested?
run npm run web:env
create a user
navigate to the key exporter page
