### PR TITLE
[QA-2027] Only apply search_str dsl if a value is provided

### DIFF
--- a/packages/discovery-provider/src/queries/search_es.py
+++ b/packages/discovery-provider/src/queries/search_es.py
@@ -639,7 +639,7 @@ def track_dsl(
                 }
             }
         )
-        dsl["should"].append(
+        dsl["should"].extend(
             *base_match(search_str, operator="and", boost=len(search_str)),
         )
 
@@ -888,21 +888,23 @@ def user_dsl(
                 }
             }
         )
-        dsl["should"].append(
-            *base_match(
-                search_str,
-                operator="and",
-                extra_fields=["name"],
-                boost=len(search_str) * 24,
-            ),
-            {
-                "term": {
-                    "name": {
-                        "value": search_str,
-                        "boost": (len(search_str) * 0.2) ** 2,
+        dsl["should"].extend(
+            [
+                *base_match(
+                    search_str,
+                    operator="and",
+                    extra_fields=["name"],
+                    boost=len(search_str) * 24,
+                ),
+                {
+                    "term": {
+                        "name": {
+                            "value": search_str,
+                            "boost": (len(search_str) * 0.2) ** 2,
+                        }
                     }
-                }
-            },
+                },
+            ]
         )
 
     if tag_search:
@@ -1102,7 +1104,7 @@ def base_playlist_dsl(
                 }
             }
         )
-        dsl["should"].append(
+        dsl["should"].extend(
             *base_match(search_str, operator="and", boost=len(search_str) * 10)
         )
 


### PR DESCRIPTION
### Description
Since we share the es_search functionality between full text search and tag/mood/etc, we need to conditionally apply the DSL conditions based on search string, since an empty search string value has the effect of excluding _all_ results for most types.

This change should make it such that passing only a `tag_search` or list of `moods` will result in applying only those queries without trying to match an empty search string across all of the documents.

It's _assumed_ that the calling code isn't going to pass empty values for absolutely everything (i.e. it's an error to not pass a tag or mood list or some other searchable quality if you pass an empty search string)

### How Has This Been Tested?
Will try to test locally and also verify in staging.
