### PR TITLE
[PE-5880] Fix redux query sync, permalink, perf

### DIFF
--- a/packages/common/src/api/tan-query/utils/primeCollectionData.ts
+++ b/packages/common/src/api/tan-query/utils/primeCollectionData.ts
@@ -10,6 +10,7 @@ import { EntriesByKind } from '~/store/cache/types'
 
 import { TQCollection } from '../models'
 import { getCollectionQueryKey } from '../useCollection'
+import { getCollectionByPermalinkQueryKey } from '../useCollectionByPermalink'
 
 import { primeTrackDataInternal } from './primeTrackData'
 import { primeUserDataInternal } from './primeUserData'
@@ -95,12 +96,23 @@ export const primeCollectionDataInternal = ({
       )
     }
 
+    if (
+      forceReplace ||
+      !queryClient.getQueryData(
+        getCollectionByPermalinkQueryKey(collection.permalink)
+      )
+    ) {
+      queryClient.setQueryData(
+        getCollectionByPermalinkQueryKey(collection.permalink),
+        collection.playlist_id
+      )
+    }
+
     // Prime user data from collection owner
     if ('user' in collection) {
       const userEntries = primeUserDataInternal({
         users: [collection.user],
         queryClient,
-        skipQueryData,
         forceReplace
       })
 
@@ -116,7 +128,6 @@ export const primeCollectionDataInternal = ({
       const trackEntries = primeTrackDataInternal({
         tracks: collection.tracks,
         queryClient,
-        skipQueryData,
         forceReplace
       })
 

--- a/packages/common/src/api/tan-query/utils/primeTrackData.ts
+++ b/packages/common/src/api/tan-query/utils/primeTrackData.ts
@@ -10,6 +10,7 @@ import { addEntries } from '~/store/cache/actions'
 import { EntriesByKind } from '~/store/cache/types'
 
 import { getTrackQueryKey } from '../useTrack'
+import { getTrackByPermalinkQueryKey } from '../useTrackByPermalink'
 
 import { formatTrackData } from './formatTrackData'
 import { primeUserDataInternal } from './primeUserData'
@@ -162,10 +163,18 @@ export const primeTrackDataInternal = ({
       (!skipQueryData &&
         !queryClient.getQueryData(getTrackQueryKey(track.track_id)))
     ) {
-      const tqTrack: TrackMetadata = {
-        ...omit(track, 'user')
-      }
+      const tqTrack: TrackMetadata = omit(track, 'user')
       queryClient.setQueryData(getTrackQueryKey(track.track_id), tqTrack)
+    }
+
+    if (
+      forceReplace ||
+      !queryClient.getQueryData(getTrackByPermalinkQueryKey(track.permalink))
+    ) {
+      queryClient.setQueryData(
+        getTrackByPermalinkQueryKey(track.permalink),
+        track.track_id
+      )
     }
 
     // Prime user data from track owner
@@ -174,7 +183,6 @@ export const primeTrackDataInternal = ({
       const userEntries = primeUserDataInternal({
         users: [user],
         queryClient,
-        skipQueryData,
         forceReplace
       })
 

--- a/packages/common/src/api/tan-query/utils/primeUserData.ts
+++ b/packages/common/src/api/tan-query/utils/primeUserData.ts
@@ -8,6 +8,7 @@ import { addEntries } from '~/store/cache/actions'
 import { EntriesByKind } from '~/store/cache/types'
 
 import { getUserQueryKey } from '../useUser'
+import { getUserByHandleQueryKey } from '../useUserByHandle'
 
 export const primeUserData = ({
   users,
@@ -49,6 +50,16 @@ export const primeUserDataInternal = ({
     ) {
       queryClient.setQueryData(getUserQueryKey(user.user_id), user)
       // TODO: update the current user query data
+    }
+
+    if (
+      forceReplace ||
+      !queryClient.getQueryData(getUserByHandleQueryKey(user.handle))
+    ) {
+      queryClient.setQueryData(
+        getUserByHandleQueryKey(user.handle),
+        user.user_id
+      )
     }
 
     entries[Kind.USERS][user.user_id] = user

--- a/packages/common/src/store/cache/syncWithReactQuery.ts
+++ b/packages/common/src/store/cache/syncWithReactQuery.ts
@@ -1,9 +1,12 @@
 import type { QueryClient } from '@tanstack/react-query'
 
-import { getCollectionQueryKey } from '../../api/tan-query/useCollection'
-import { getTrackQueryKey } from '../../api/tan-query/useTrack'
-import { getUserQueryKey } from '../../api/tan-query/useUser'
+import { primeCollectionDataInternal } from '../../api/tan-query/utils/primeCollectionData'
+import { primeTrackDataInternal } from '../../api/tan-query/utils/primeTrackData'
+import { primeUserDataInternal } from '../../api/tan-query/utils/primeUserData'
+import type { CollectionMetadata } from '../../models/Collection'
 import { Kind } from '../../models/Kind'
+import type { Track } from '../../models/Track'
+import type { User } from '../../models/User'
 
 import type { EntriesByKind } from './types'
 
@@ -11,21 +14,32 @@ export const syncWithReactQuery = (
   queryClient: QueryClient,
   entriesByKind: EntriesByKind
 ) => {
-  Object.entries(entriesByKind).forEach(([kind, entries]) => {
-    if (!entries) return
-    Object.entries(entries).forEach(([id, entry]) => {
-      const parsedId = parseInt(id, 10)
-      switch (kind as Kind) {
-        case Kind.USERS:
-          queryClient.setQueryData(getUserQueryKey(parsedId), entry)
-          break
-        case Kind.TRACKS:
-          queryClient.setQueryData(getTrackQueryKey(parsedId), entry)
-          break
-        case Kind.COLLECTIONS:
-          queryClient.setQueryData(getCollectionQueryKey(parsedId), entry)
-          break
-      }
+  // Process users first since tracks and collections may depend on them
+  if (entriesByKind[Kind.USERS]) {
+    primeUserDataInternal({
+      users: Object.values(entriesByKind[Kind.USERS]) as User[],
+      queryClient,
+      forceReplace: true
     })
-  })
+  }
+
+  // Process tracks
+  if (entriesByKind[Kind.TRACKS]) {
+    primeTrackDataInternal({
+      tracks: Object.values(entriesByKind[Kind.TRACKS]) as Track[],
+      queryClient,
+      forceReplace: true
+    })
+  }
+
+  // Process collections
+  if (entriesByKind[Kind.COLLECTIONS]) {
+    primeCollectionDataInternal({
+      collections: Object.values(
+        entriesByKind[Kind.COLLECTIONS]
+      ) as CollectionMetadata[],
+      queryClient,
+      forceReplace: true
+    })
+  }
 }

--- a/packages/web/src/components/nav/desktop/PlaylistLibrary/CollectionNavItem.tsx
+++ b/packages/web/src/components/nav/desktop/PlaylistLibrary/CollectionNavItem.tsx
@@ -97,6 +97,8 @@ export const CollectionNavItem = (props: CollectionNavItemProps) => {
   const { data: partialCollection } = useCollection(
     typeof id === 'number' ? id : null,
     {
+      // ensure read only
+      enabled: false,
       select: (collection) =>
         pick(collection, 'is_album', 'playlist_name', 'permalink', 'is_private')
     }


### PR DESCRIPTION
### Description

Fixes a few performance issues related to selector migration:
1. Fixes `byPermalink` `byHandle` queries by ensuring byId caches them correctly. This fixes issues where artist-popover was incorrectly fetching a user by handle that already existed
2. Fixes areas where we technically wanted a "read-only and optional" collection, like in left-nav. this prevents issues where the entire left nav individually fetches each playlist.
3. Fixes issue with syncWithReactQuery not properly caching. it now uses primeUser etc
4. Fixes issue with skipQueryData, which was skipping sub-entities.