### PR TITLE
[PE-5870] Fix support user lists and icons

### DIFF
--- a/packages/web/src/components/artist/ArtistChipSupportFor.tsx
+++ b/packages/web/src/components/artist/ArtistChipSupportFor.tsx
@@ -1,8 +1,6 @@
-import { useEffect, useState } from 'react'
-
-import { ID, StringWei } from '@audius/common/models'
-import { tippingSelectors } from '@audius/common/store'
-import { stringWeiToBN, formatWei, Nullable } from '@audius/common/utils'
+import { useSupporter } from '@audius/common/api'
+import { ID } from '@audius/common/models'
+import { stringWeiToBN, formatWei } from '@audius/common/utils'
 import {
   IconTipping as IconTip,
   IconTrophy,
@@ -10,11 +8,9 @@ import {
 } from '@audius/harmony'
 import cn from 'classnames'
 
-import { useSelector } from 'common/hooks/useSelector'
 import { TIPPING_TOP_RANK_THRESHOLD } from 'utils/constants'
 
 import styles from './ArtistChip.module.css'
-const { getOptimisticSupporters, getOptimisticSupporting } = tippingSelectors
 
 const messages = {
   audio: '$AUDIO',
@@ -30,19 +26,13 @@ export const ArtistChipSupportFor = ({
   artistId,
   userId
 }: ArtistChipTipsProps) => {
-  const supportingMap = useSelector(getOptimisticSupporting)
-  const supportersMap = useSelector(getOptimisticSupporters)
-  const [amount, setAmount] = useState<Nullable<StringWei>>(null)
-  const [rank, setRank] = useState<Nullable<number>>(null)
+  const { data: supportFor } = useSupporter({
+    supporterUserId: artistId,
+    userId
+  })
 
-  useEffect(() => {
-    if (artistId && userId) {
-      const userSupportersMap = supportersMap[userId] ?? {}
-      const artistSupporter = userSupportersMap[artistId] ?? {}
-      setRank(artistSupporter.rank ?? null)
-      setAmount(artistSupporter.amount ?? null)
-    }
-  }, [artistId, supportingMap, supportersMap, userId])
+  const rank = supportFor?.rank
+  const amount = supportFor?.amount
 
   return (
     <div className={styles.tipContainer}>

--- a/packages/web/src/components/artist/ArtistChipSupportFrom.tsx
+++ b/packages/web/src/components/artist/ArtistChipSupportFrom.tsx
@@ -1,15 +1,10 @@
-import { useEffect, useState } from 'react'
-
-import { ID, StringWei } from '@audius/common/models'
-import { tippingSelectors } from '@audius/common/store'
-import { stringWeiToBN, formatWei, Nullable } from '@audius/common/utils'
+import { useSupporter } from '@audius/common/api'
+import { ID } from '@audius/common/models'
+import { stringWeiToBN, formatWei } from '@audius/common/utils'
 import { IconTipping as IconTip } from '@audius/harmony'
 import cn from 'classnames'
 
-import { useSelector } from 'common/hooks/useSelector'
-
 import styles from './ArtistChip.module.css'
-const { getOptimisticSupporting } = tippingSelectors
 
 const messages = {
   audio: '$AUDIO'
@@ -24,16 +19,12 @@ export const ArtistChipSupportFrom = ({
   artistId,
   userId
 }: ArtistChipTipsProps) => {
-  const supportingMap = useSelector(getOptimisticSupporting)
-  const [amount, setAmount] = useState<Nullable<StringWei>>(null)
+  const { data: supportFrom } = useSupporter({
+    supporterUserId: userId,
+    userId: artistId
+  })
 
-  useEffect(() => {
-    if (artistId && userId) {
-      const userSupportingMap = supportingMap[userId] ?? {}
-      const artistSupporting = userSupportingMap[artistId] ?? {}
-      setAmount(artistSupporting.amount ?? null)
-    }
-  }, [artistId, supportingMap, userId])
+  const amount = supportFrom?.amount
 
   return (
     <div className={styles.tipContainer}>

--- a/packages/web/src/components/user-list-modal/UserListModal.tsx
+++ b/packages/web/src/components/user-list-modal/UserListModal.tsx
@@ -107,43 +107,43 @@ export const UserListModal = () => {
       case UserListType.NOTIFICATION:
         return {
           component: <NotificationsUserList />,
-          icon: IconTrophy,
+          Icon: IconTrophy,
           title: notificationTitle
         }
       case UserListType.SUPPORTER:
         return {
           component: <TopSupportersUserList />,
-          icon: IconTrophy,
+          Icon: IconTrophy,
           title: messages.topSupporters
         }
       case UserListType.SUPPORTING:
         return {
           component: <SupportingUserList />,
-          icon: IconTip,
+          Icon: IconTip,
           title: messages.supporting
         }
       case UserListType.MUTUAL_FOLLOWER:
         return {
           component: <MutualsUserList />,
-          icon: IconFollowing,
+          Icon: IconFollowing,
           title: messages.mutuals
         }
       case UserListType.RELATED_ARTISTS:
         return {
           component: <RelatedArtistsUserList />,
-          icon: IconUserGroup,
+          Icon: IconUserGroup,
           title: messages.relatedArtists
         }
       case UserListType.PURCHASER:
         return {
           component: <PurchasersUserList />,
-          icon: IconCart,
+          Icon: IconCart,
           title: messages.purchasers
         }
       case UserListType.REMIXER:
         return {
           component: <RemixersUserList />,
-          icon: IconRemix,
+          Icon: IconRemix,
           title: messages.remixers
         }
       default:

--- a/packages/web/src/components/user-list/UserListArtistChip.tsx
+++ b/packages/web/src/components/user-list/UserListArtistChip.tsx
@@ -26,7 +26,7 @@ export const UserListArtistChip = (props: ArtistChipProps) => {
 
   return (
     <ArtistChip
-      userId={userId}
+      {...props}
       onClickArtistName={handleClickArtistName}
       showPopover={!isMobile}
       popoverMount={MountPlacement.BODY}

--- a/packages/web/src/components/user-list/lists/SupportingUserList.tsx
+++ b/packages/web/src/components/user-list/lists/SupportingUserList.tsx
@@ -14,6 +14,8 @@ export const SupportingUserList = () => {
   const { data, hasNextPage, isFetchingNextPage, fetchNextPage, isPending } =
     useSupportedUsers({ userId })
 
+  if (!userId) return null
+
   return (
     <UserList
       data={data?.map((supporter) => supporter.receiver.user_id)}
@@ -22,6 +24,7 @@ export const SupportingUserList = () => {
       isFetchingNextPage={isFetchingNextPage}
       isPending={isPending}
       fetchNextPage={fetchNextPage}
+      showSupportFrom={userId}
     />
   )
 }


### PR DESCRIPTION
### Description

Fixes various QA issues related to user-list tan-query migration

1. Fixes issue where SupportFor and SupportFrom chips weren't correctly selecting state
2. Fixes user-list-artist-chip to properly spread in props
3. Fixes supporter/supporting user lists to pass correct "supportFrom" prop
4. Fixes icons is UserListModal