### PR TITLE
Fix tiles usernames + misc QA

### DIFF
--- a/packages/common/src/api/tan-query/useCollectionTracksWithUid.ts
+++ b/packages/common/src/api/tan-query/useCollectionTracksWithUid.ts
@@ -16,18 +16,18 @@ export type CollectionTrackWithUid = TrackMetadata & {
  */
 export const useCollectionTracksWithUid = (
   collection: Pick<TQCollection, 'playlist_contents' | 'trackIds'> | undefined,
-  collectionUid: UID
+  collectionUid: UID | undefined
 ) => {
-  const collectionSource = Uid.fromString(collectionUid).source
+  const collectionSource = Uid.fromString(collectionUid ?? '')?.source
 
-  const { byId } = useTracks(collection?.trackIds)
+  const { byId } = useTracks(collection?.trackIds, { enabled: !!collectionUid })
 
   // Return tracks & rebuild UIDs for the track so they refer directly to this collection
   return useMemo(() => {
-    return collection?.playlist_contents?.track_ids
+    return (collection?.playlist_contents?.track_ids ?? [])
       .map((t, i) => {
         const { uid, track: trackId } = t ?? {}
-        const trackUid = Uid.fromString(uid ?? '')
+        const trackUid = Uid.fromString(`${uid}`)
         trackUid.source = `${collectionSource}:${trackUid.source}`
         trackUid.count = i
 

--- a/packages/web/src/components/lineup/LineupProvider.tsx
+++ b/packages/web/src/components/lineup/LineupProvider.tsx
@@ -541,6 +541,7 @@ class LineupProvider extends PureComponent<CombinedProps, LineupProviderState> {
             ...entry,
             index,
             uid: entry.uid,
+            id: entry.id,
             size: tileSize,
             ordered,
             playTrack,

--- a/packages/web/src/components/track/desktop/ConnectedTrackTile.tsx
+++ b/packages/web/src/components/track/desktop/ConnectedTrackTile.tsx
@@ -84,6 +84,7 @@ const ConnectedTrackTile = ({
   const { data: track, isPending } = useTrack(id)
   const { data: partialUser } = useUser(track?.owner_id, {
     select: (user) => ({
+      user_id: user?.user_id,
       handle: user?.handle,
       name: user?.name,
       is_verified: user?.is_verified,

--- a/packages/web/src/pages/collection-page/CollectionPageProvider.tsx
+++ b/packages/web/src/pages/collection-page/CollectionPageProvider.tsx
@@ -93,7 +93,6 @@ const { requestOpen: requestOpenShareModal } = shareModalUIActions
 const { open } = mobileOverflowMenuUIActions
 const {
   getCollection,
-  getCollectionStatus,
   getCollectionTracksLineup,
   getCollectionUid,
   getUser,
@@ -847,7 +846,7 @@ function makeMapStateToProps() {
       collectionPermalink: getCollectionPermalink(state),
       user: getUser(state),
       userUid: getUserUid(state) || '',
-      status: getCollectionStatus(state) || '',
+      status: getCollectionTracksLineup(state)?.status || Status.LOADING,
       order: getLineupOrder(state),
       userId: getUserId(state),
       playlistId: (getCollection(state) as Collection)?.playlist_id,


### PR DESCRIPTION
### Description

Fixes from todays TQ QA sesh

- Fixes tiles usernames not showing
- Fixes explore playlists page crashing
- Fixes playlists always showing "no tracks" instead of a loading spinner

### How Has This Been Tested?

web:stage desktop