### PR TITLE
Fix notification error boundary due to missing entity

### DIFF
--- a/packages/web/src/components/notification/Notification/components/EntityLink.tsx
+++ b/packages/web/src/components/notification/Notification/components/EntityLink.tsx
@@ -53,7 +53,11 @@ export const useGoToEntity = (
 
 export const EntityLink = (props: EntityLinkProps) => {
   const { entity, entityType } = props
-  const title = 'playlist_id' in entity ? entity.playlist_name : entity.title
+  const title = entity
+    ? 'playlist_id' in entity
+      ? entity.playlist_name
+      : entity.title
+    : ''
 
   const handleClick = useGoToEntity(entity, entityType)
 


### PR DESCRIPTION
### Description

Small fix to notification loading state. For a frame or two, entity-links can have a missing entity. Added a check to gracefully handle that state, which improves performance, as the entire list doesn't need to rerender when there is an issue.