### PR TITLE
[API-13] Fix celery getting stuck

### DIFF
--- a/packages/discovery-provider/scripts/start.sh
+++ b/packages/discovery-provider/scripts/start.sh
@@ -74,6 +74,14 @@ else
             --prefetch-multiplier 1 \
             2>&1 | tee >(logger -t index_sol_worker) &
 
+        # start worker dedicated to index challenges
+        audius_service=worker celery -A src.worker.celery worker -Q index_challenges \
+            --loglevel "$audius_discprov_loglevel" \
+            --hostname=index_challenges \
+            --concurrency 1 \
+            --prefetch-multiplier 1 \
+            2>&1 | tee >(logger -t index_challenges_worker) &
+
         # start other workers with remaining CPUs
         audius_service=worker celery -A src.worker.celery worker \
             --max-memory-per-child 300000 \
@@ -81,6 +89,7 @@ else
             --concurrency 3 \
             --prefetch-multiplier 1 \
             --max-tasks-per-child 10 \
+            --exclude-queues=index_sol,index_core,index_challenges \
             2>&1 | tee >(logger -t worker) &
 
         while [[ "$audius_discprov_env" == "stage" ]]; do


### PR DESCRIPTION
### Description

I think I figured this out.

A little journey for the reader. Some theme music first https://www.youtube.com/watch?v=Xwml50CG6LA

---

We have this problem currently: sometimes `index_core` celery tasks seems to not run, and indexing gets stuck.

We get this shitty error `no new blocks in at least a minute` and we're like... wtf? `core` is fine. The L1 is moving. why is this node stuck?

You ssh into the machine, tail the logs and so no `index_core` logs... wtf? We enqueue a job after every previous job. This should not happen. Why does celery not pick up the task????

You have an idea... let's run some `ps aux` and look around in the indexer container.

```
/audius-discovery-provider #  ps aux | grep index_core | grep -v grep
 1042 root      4:25 {celery} /usr/bin/python3 /usr/bin/celery -A src.worker.celery worker -Q index_core --loglevel info --hostname=index_core --concurrency 1 --prefetch-multiplier 1
 1050 root      0:06 logger -t index_core_worker
 1111 root     14:52 {celery} /usr/bin/python3 /usr/bin/celery -A src.worker.celery worker -Q index_core --loglevel info --hostname=index_core --concurrency 1 --prefetch-multiplier 1
```

excuse me????? there are **two** index_core worker PIDs? but how... something seems off.

you stare at the logs... a lot longer and you notice something

```
 -------------- celery@index_core v5.3.0 (emerald-rush)
--- ***** ----- 
-- ******* ---- Linux-6.8.0-1025-gcp-x86_64-with 2025-04-02 02:59:27
- *** --- * --- 
- ** ---------- [config]
- ** ---------- .> app:         src.tasks.celery_app:0x7d3669500d90
- ** ---------- .> transport:   redis://cache:6379/00
- ** ---------- .> results:     disabled://
- *** --- * --- .> concurrency: 1 (prefork)
-- ******* ---- .> task events: ON
--- ***** ----- 
 -------------- [queues]
                .> index_core       exchange=index_core(direct) key=index_core
                


 -------------- celery@cc0fa38fb96e v5.3.0 (emerald-rush)
--- ***** ----- 
-- ******* ---- Linux-6.8.0-1025-gcp-x86_64-with 2025-04-02 02:59:28
- *** --- * --- 
- ** ---------- [config]
- ** ---------- .> app:         src.tasks.celery_app:0x7070050ba810
- ** ---------- .> transport:   redis://cache:6379/00
- ** ---------- .> results:     disabled://
- *** --- * --- .> concurrency: 3 (prefork)
-- ******* ---- .> task events: OFF (enable -E to monitor tasks in this worker)
--- ***** ----- 
 -------------- [queues]
                .> celery           exchange=celery(direct) key=celery
                .> index_challenges exchange=index_challenges(direct) key=index_challenges
                .> index_core       exchange=index_core(direct) key=index_core
                .> index_sol        exchange=index_sol(direct) key=index_sol

[tasks]
```

There are **TWO THINGS** saying they are looking at the `index_core` queue. Our generic queue, which runs 3 concurrent workers and handles the pool of tasks doesn't listen for any specific queue, meaning it listens to *all* queues.

And there's the problem. We already know this main queue gets starved often. That's why we move some tasks to their own queue. The problem is that the main queue still listens for work, and occasionally, but rarely it not only picks up a task, but it holds onto the lock and just never spits it back out for the other queue to pick up. (since yeah... index_core runs single threaded).

Whose idea was it to use celery in the first place??? Looking at you @roneilr 

Anyway, this change should fix it - make that worker ignore those queues, and also add a new worker for index_challenges for good measure 🖕 🤞


PS it actually turns out that I think the `ps aux` thing was a lucky guess - the two PIDs are because of the way celery works, etc. It's actually ok those exist. Just got me thinking...

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._

Deployed to prod dn1. It works, but it's such a rare error, we will have to see if it fixes it in prod over the long run.