### PR TITLE
Remove block-gating for tastemaker challenge

### DIFF
--- a/packages/discovery-provider/src/challenges/tastemaker_challenge.py
+++ b/packages/discovery-provider/src/challenges/tastemaker_challenge.py
@@ -4,39 +4,8 @@ from typing import Dict
 from sqlalchemy.orm.session import Session
 
 from src.challenges.challenge import ChallengeManager, ChallengeUpdater
-from src.models.core.core_indexed_blocks import CoreIndexedBlocks
-from src.utils.config import shared_config
 
 logger = logging.getLogger(__name__)
-
-# Targeting 2025-04-02
-TASTEMAKER_CHALLENGE_START_BLOCK_PROD = 1100000
-# Targeting 2025-03-25
-TASTEMAKER_CHALLENGE_START_BLOCK_STAGE = 1000000
-TASTEMAKER_CHALLENGE_START_BLOCK_DEV = 0
-
-
-TASTEMAKER_CHALLENGE_START_CHAIN_ID_PROD = "audius-mainnet-alpha-beta"
-TASTEMAKER_CHALLENGE_START_CHAIN_ID_STAGE = "audius-testnet-alpha"
-TASTEMAKER_CHALLENGE_START_CHAIN_ID_DEV = "audius-devnet"
-
-
-def get_tastemaker_challenge_start_block() -> int:
-    env = shared_config["discprov"]["env"]
-    if env == "dev":
-        return TASTEMAKER_CHALLENGE_START_BLOCK_DEV
-    if env == "stage":
-        return TASTEMAKER_CHALLENGE_START_BLOCK_STAGE
-    return TASTEMAKER_CHALLENGE_START_BLOCK_PROD
-
-
-def get_tastemaker_challenge_start_chain_id() -> str:
-    env = shared_config["discprov"]["env"]
-    if env == "dev":
-        return TASTEMAKER_CHALLENGE_START_CHAIN_ID_DEV
-    if env == "stage":
-        return TASTEMAKER_CHALLENGE_START_CHAIN_ID_STAGE
-    return TASTEMAKER_CHALLENGE_START_CHAIN_ID_PROD
 
 
 class TastemakerChallengeUpdater(ChallengeUpdater):
@@ -52,21 +21,6 @@ class TastemakerChallengeUpdater(ChallengeUpdater):
         """
         item_type = "p" if extra["tastemaker_item_type"] == "playlist" else "t"
         return f"{hex(user_id)[2:]}:{item_type}:{hex(extra['tastemaker_item_id'])[2:]}"
-
-    def should_create_new_challenge(
-        self, session: Session, event: str, user_id: int, extra: Dict
-    ) -> bool:
-        block = (
-            session.query(CoreIndexedBlocks)
-            .filter(
-                CoreIndexedBlocks.chain_id == get_tastemaker_challenge_start_chain_id()
-            )
-            .order_by(CoreIndexedBlocks.height.desc())
-            .first()
-        )
-        if not block or not block.height:
-            return False
-        return block.height > get_tastemaker_challenge_start_block()
 
 
 tastemaker_challenge_manager = ChallengeManager("t", TastemakerChallengeUpdater())

--- a/packages/discovery-provider/src/queries/get_health.py
+++ b/packages/discovery-provider/src/queries/get_health.py
@@ -10,10 +10,6 @@ import requests
 from elasticsearch import Elasticsearch
 from redis import Redis
 
-from src.challenges.tastemaker_challenge import (
-    get_tastemaker_challenge_start_block,
-    get_tastemaker_challenge_start_chain_id,
-)
 from src.eth_indexing.event_scanner import eth_indexing_last_scanned_block_key
 from src.models.indexing.block import Block
 from src.monitors import monitor_names, monitors
@@ -215,7 +211,6 @@ def get_health(args: GetHealthArgs, use_redis_cache: bool = True) -> Tuple[Dict,
     core_listens_health = get_core_listens_health(
         redis=redis, plays_count_max_drift=plays_count_max_drift
     )
-    core_tastemaker_challenge_health = get_core_tastemaker_challenge_health(redis=redis)
 
     latest_block_ts = 0
     if core_health:
@@ -338,7 +333,6 @@ def get_health(args: GetHealthArgs, use_redis_cache: bool = True) -> Tuple[Dict,
         "trending_tracks_age_sec": trending_tracks_age_sec,
         "trending_playlists_age_sec": trending_playlists_age_sec,
         "challenge_last_event_age_sec": challenge_events_age_sec,
-        "tastemaker_challenge": core_tastemaker_challenge_health,
         "user_balances_age_sec": user_balances_age_sec,
         "num_users_in_lazy_balance_refresh_queue": num_users_in_lazy_balance_refresh_queue,
         "num_users_in_immediate_balance_refresh_queue": num_users_in_immediate_balance_refresh_queue,
@@ -694,22 +688,6 @@ def get_core_listens_health(redis: Redis, plays_count_max_drift: Optional[int]):
     except Exception as e:
         logger.error(f"get_health.py | could not get core listens health {e}")
         return None
-
-
-def get_core_tastemaker_challenge_health(
-    redis: Redis,
-):
-    latest_block_num, _ = get_latest_chain_block_set_if_nx(redis)
-    tastemaker_challenge_start_block = get_tastemaker_challenge_start_block()
-    tastemaker_challenge_start_block_chain_id = (
-        get_tastemaker_challenge_start_chain_id()
-    )
-    return {
-        "tastemaker_challenge_start_block": tastemaker_challenge_start_block,
-        "tastemaker_challenge_start_block_chain_id": tastemaker_challenge_start_block_chain_id,
-        "is_running": latest_block_num is not None
-        and latest_block_num > tastemaker_challenge_start_block,
-    }
 
 
 def get_core_health(redis: Redis):


### PR DESCRIPTION
### Description
Remove this code now that challenge has shipped.

I forgot that `starting_block` is a field in the challenge json, should've used that instead (though that code path probably needs to be updated for core).

### How Has This Been Tested?

