### PR TITLE
use openresty compatible version for alpine:18

### DIFF
--- a/packages/discovery-provider/Dockerfile.prod
+++ b/packages/discovery-provider/Dockerfile.prod
@@ -43,13 +43,14 @@ RUN rustup default 1.79.0
 
 RUN curl -O 'http://openresty.org/package/admin@openresty.com-5ea678a6.rsa.pub' && \
   mv 'admin@openresty.com-5ea678a6.rsa.pub' /etc/apk/keys/ && \
-  echo "http://openresty.org/package/alpine/v3.15/main" | tee -a /etc/apk/repositories && \
+  echo "http://openresty.org/package/alpine/v3.18/main" >> /etc/apk/repositories && \
   apk update && \
-  apk add openresty=1.21.4.3-r0 openresty-opm && \
+  apk add openresty openresty-opm && \
   opm get spacewander/lua-resty-rsa && \
   opm get ledgetech/lua-resty-http && \
   opm get bsiara/dkjson && \
-  mkdir /usr/local/openresty/conf /usr/local/openresty/logs
+  mkdir -p /usr/local/openresty/conf /usr/local/openresty/logs
+
 
 RUN apk update && \
   apk add \


### PR DESCRIPTION
### Description
- openresty was pinned to an alpine15 build but we are on alpine18
### How Has This Been Tested?
we'll know if it goes bad on stage
if this breaks we fallback to alpine 15
