### PR TITLE
Skip busy work in plays indexer if not a play tx

### DIFF
--- a/packages/discovery-provider/src/tasks/index_core_plays.py
+++ b/packages/discovery-provider/src/tasks/index_core_plays.py
@@ -42,6 +42,10 @@ def index_core_plays(
 ) -> Optional[int]:
     indexed_slot: Optional[int] = None
     for tx in block.transaction_responses:
+        tx_type = tx.transaction.WhichOneof("transaction")
+        if tx_type != "plays":
+            continue
+
         indexed_slot = index_core_play(
             logger=logger,
             session=session,


### PR DESCRIPTION
### Description

Skip plays early in plays core indexer if tx is not a `plays` type

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._

logs, effectively