### PR TITLE
[QA-2016] Fix play button getting out of sync

### DIFF
--- a/packages/web/src/components/play-bar/PlayButton.tsx
+++ b/packages/web/src/components/play-bar/PlayButton.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef } from 'react'
+import { useState, useEffect, useRef, useCallback } from 'react'
 
 import cn from 'classnames'
 import Lottie, { LottieRefCurrentProps } from 'lottie-react'
@@ -71,9 +71,9 @@ const PlayButton = ({
     prevStatus.current = status
   }, [status, playState])
 
-  const handleChange = () => {
+  const handleChange = useCallback(() => {
     let newIcon, newIsPaused
-    const newPlayState = (playState + 1) % Object.keys(PlayStates).length
+    const newPlayState = (playState + 1) % (Object.keys(PlayStates).length / 2)
 
     switch (newPlayState) {
       case PlayStates.PLAY:
@@ -100,14 +100,14 @@ const PlayButton = ({
     setIcon(newIcon)
     setIsPaused(newIsPaused)
     setPlayState(newPlayState)
-  }
+  }, [playState, setIcon, setIsPaused, setPlayState])
 
-  const handleClick = () => {
+  const handleClick = useCallback(() => {
     if (playable) {
       handleChange()
       onClick()
     }
-  }
+  }, [playable, handleChange, onClick])
 
   const isLoading = status === 'load'
   let data: object
@@ -131,7 +131,7 @@ const PlayButton = ({
         lottieRef.current.play()
       }
     }
-  }, [lottieRef, currentIsPaused])
+  }, [lottieRef, currentIsPaused, playState])
 
   const ariaLabel = isLoading
     ? 'track loading'


### PR DESCRIPTION
### Description

Broken in https://github.com/AudiusProject/audius-protocol/pull/10905

Two issue
1. Object.keys(enum) gives you 2x the number you'd think because javascript sucks
2. Need to make better use of hook deps. Old lottie would allow you to pass a prop isPaused which would immediately update the state of whether or not the animation was playing on every render. Now since it happens in an effect, we need to introduce `playState` as a dep.

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._

Rapidly pressing play on track tile leaves play bar in a happy state!
