### PR TITLE
[API-13] Only update scores when they need to be

### DIFF
--- a/packages/discovery-provider/src/tasks/update_aggregates.py
+++ b/packages/discovery-provider/src/tasks/update_aggregates.py
@@ -367,7 +367,11 @@ with scoped_users as (
     )
     update aggregate_user set score = computed_scores.score
     from computed_scores
-    where aggregate_user.user_id = computed_scores.user_id
+    where
+      aggregate_user.user_id = computed_scores.user_id
+      and (
+        aggregate_user.score != computed_scores.score
+      )
     returning aggregate_user.user_id;
 """
 


### PR DESCRIPTION
### Description

This query returns 2M rows in prod normally, but actually only needs to issue like ~50 updates. The update to so many rows causes exclusive locks, which halt indexing.

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._

Prod dn1