### PR TITLE
[PE-5900] Add audio wallet banner

### DIFF
--- a/packages/web/src/pages/pay-and-earn-page/components/YourCoins.tsx
+++ b/packages/web/src/pages/pay-and-earn-page/components/YourCoins.tsx
@@ -1,0 +1,76 @@
+import { useCallback } from 'react'
+
+import { walletSelectors } from '@audius/common/store'
+import { route } from '@audius/common/utils'
+import { AUDIO } from '@audius/fixed-decimal'
+import {
+  Flex,
+  IconCaretRight,
+  IconLogoCircle,
+  Paper,
+  Text
+} from '@audius/harmony'
+import { useDispatch, useSelector } from 'react-redux'
+import { push } from 'redux-first-history'
+
+const DIMENSIONS = 64
+const { AUDIO_PAGE } = route
+const { getAccountTotalBalance } = walletSelectors
+
+const messages = {
+  title: 'Your Coins',
+  buySell: 'Buy/Sell',
+  dollarValue: '$0.00 ($0.082)',
+  loading: '-- $AUDIO'
+}
+
+export const YourCoins = () => {
+  const dispatch = useDispatch()
+  const totalBalance = useSelector(getAccountTotalBalance)
+
+  // Format the balance for display using toShorthand
+  const audioAmount = totalBalance
+    ? `${AUDIO(totalBalance).toShorthand()} $AUDIO`
+    : messages.loading
+
+  const handleTokenClick = useCallback(() => {
+    dispatch(push(AUDIO_PAGE))
+  }, [dispatch])
+
+  return (
+    <Paper
+      direction='column'
+      shadow='far'
+      borderRadius='l'
+      css={{ overflow: 'hidden' }}
+    >
+      <Flex
+        alignItems='center'
+        justifyContent='space-between'
+        p='xl'
+        alignSelf='stretch'
+        onClick={handleTokenClick}
+        css={{
+          cursor: 'pointer',
+          '&:hover': {
+            backgroundColor: 'var(--surface-2)'
+          }
+        }}
+      >
+        <Flex alignItems='center' gap='l'>
+          <IconLogoCircle width={DIMENSIONS} height={DIMENSIONS} />
+          <Flex direction='column' gap='xs'>
+            <Text variant='heading' size='l' color='default'>
+              {audioAmount}
+            </Text>
+            <Text variant='body' size='m' color='subdued'>
+              {messages.dollarValue}
+            </Text>
+          </Flex>
+        </Flex>
+
+        <IconCaretRight size='l' color='subdued' />
+      </Flex>
+    </Paper>
+  )
+}

--- a/packages/web/src/pages/pay-and-earn-page/components/YourCoins.tsx
+++ b/packages/web/src/pages/pay-and-earn-page/components/YourCoins.tsx
@@ -8,7 +8,8 @@ import {
   IconCaretRight,
   IconLogoCircle,
   Paper,
-  Text
+  Text,
+  useTheme
 } from '@audius/harmony'
 import { useDispatch, useSelector } from 'react-redux'
 import { push } from 'redux-first-history'
@@ -20,6 +21,7 @@ const { getAccountTotalBalance } = walletSelectors
 const messages = {
   title: 'Your Coins',
   buySell: 'Buy/Sell',
+  // TODO: Farid [PE-5901] get the current price of AUDIO
   dollarValue: '$0.00 ($0.082)',
   loading: '-- $AUDIO'
 }
@@ -27,6 +29,7 @@ const messages = {
 export const YourCoins = () => {
   const dispatch = useDispatch()
   const totalBalance = useSelector(getAccountTotalBalance)
+  const { color } = useTheme()
 
   // Format the balance for display using toShorthand
   const audioAmount = totalBalance
@@ -53,7 +56,7 @@ export const YourCoins = () => {
         css={{
           cursor: 'pointer',
           '&:hover': {
-            backgroundColor: 'var(--surface-2)'
+            backgroundColor: color.background.surface2
           }
         }}
       >


### PR DESCRIPTION
### Description

This PR introduces a new `YourCoins` component. This is currently being used to surface the users's AUDIO wallet balance, but will display more tokens in the future. 

### How Has This Been Tested?

<img width="1119" alt="image" src="https://github.com/user-attachments/assets/9ceb4155-1feb-40d3-88d0-6848abb2ba04" />


