### PR TITLE
Fix broken listen streak challenge state

### DIFF
--- a/packages/discovery-provider/ddl/migrations/0129_update_challenge_listen_streak.sql
+++ b/packages/discovery-provider/ddl/migrations/0129_update_challenge_listen_streak.sql
@@ -1,0 +1,24 @@
+begin;
+
+WITH next_row AS (
+  SELECT 
+    uc1.*,
+    LEAD(amount) OVER (PARTITION BY user_id, challenge_id ORDER BY created_at ASC) as next_amount,
+    LEAD(is_complete) OVER (PARTITION BY user_id, challenge_id ORDER BY created_at ASC) as next_is_complete
+  FROM user_challenges uc1
+  WHERE challenge_id = 'e'
+)
+UPDATE user_challenges uc
+SET 
+  amount = 7,
+  is_complete = true
+FROM next_row nr
+WHERE 
+  uc.user_id = nr.user_id AND
+  uc.challenge_id = nr.challenge_id AND
+  uc.specifier = nr.specifier AND
+  nr.amount = 7 AND 
+  nr.next_amount = 1 AND 
+  nr.next_is_complete = true;
+
+commit; 

--- a/packages/discovery-provider/ddl/migrations/0129_update_challenge_listen_streak.sql
+++ b/packages/discovery-provider/ddl/migrations/0129_update_challenge_listen_streak.sql
@@ -1,5 +1,63 @@
 begin;
 
+alter table user_challenges disable trigger on_user_challenge;
+
+-- First update the challenge_listen_streak table
+WITH latest_incomplete_seven_per_user AS (
+  SELECT DISTINCT ON (user_id)
+    user_id,
+    created_at as seven_created_at
+  FROM user_challenges
+  WHERE 
+    challenge_id = 'e' AND
+    amount = 7 AND
+    current_step_count != amount AND
+    created_at <= '2025-03-25' AND 
+    created_at > '2025-03-14'
+  ORDER BY user_id, created_at DESC
+),
+valid_streaks AS (
+  SELECT 
+    ls.user_id,
+    7 + COUNT(uc.user_id) as streak_count
+  FROM latest_incomplete_seven_per_user ls
+  LEFT JOIN user_challenges uc ON 
+    uc.user_id = ls.user_id AND
+    uc.challenge_id = 'e' AND
+    uc.created_at > ls.seven_created_at AND
+    uc.amount = 1 AND
+    uc.is_complete = true
+  WHERE NOT EXISTS (
+    -- Exclude if there are ANY incomplete rows after our target seven
+    SELECT 1 
+    FROM user_challenges uc_incomplete
+    WHERE 
+      uc_incomplete.user_id = ls.user_id AND
+      uc_incomplete.challenge_id = 'e' AND
+      uc_incomplete.created_at > ls.seven_created_at AND
+      uc_incomplete.created_at != ls.seven_created_at AND
+      uc_incomplete.current_step_count != uc_incomplete.amount
+  )
+  AND EXISTS (
+    -- Still require at least one completed amount=1 row after the seven
+    SELECT 1 
+    FROM user_challenges uc_next
+    WHERE 
+      uc_next.user_id = ls.user_id AND
+      uc_next.challenge_id = 'e' AND
+      uc_next.created_at > ls.seven_created_at AND
+      uc_next.amount = 1 AND
+      uc_next.is_complete = true
+  )
+  GROUP BY ls.user_id
+)
+UPDATE challenge_listen_streak cls
+SET listen_streak = vs.streak_count
+FROM valid_streaks vs
+WHERE cls.user_id = vs.user_id;
+
+-- Then update the user_challenges table
+
 WITH next_row AS (
   SELECT 
     uc1.*,
@@ -10,7 +68,7 @@ WITH next_row AS (
 )
 UPDATE user_challenges uc
 SET 
-  amount = 7,
+  current_step_count = 7,
   is_complete = true
 FROM next_row nr
 WHERE 
@@ -18,7 +76,12 @@ WHERE
   uc.challenge_id = nr.challenge_id AND
   uc.specifier = nr.specifier AND
   nr.amount = 7 AND 
+  nr.current_step_count != nr.amount AND
   nr.next_amount = 1 AND 
-  nr.next_is_complete = true;
+  nr.next_is_complete = true AND
+  nr.created_at <= '2025-03-25' AND 
+  nr.created_at > '2025-03-14';
+
+alter table user_challenges enable trigger on_user_challenge;
 
 commit; 


### PR DESCRIPTION
### Description
The bug: in [this PR](https://github.com/AudiusProject/audius-protocol/pull/11662) I changed the listen streak time window for continuing the listen streak from 24-48 hours to 16-48 hours. This required a specifier change - we had to increase granularity from days to hours in order to allow 2 `user_challenge` rows to exist that were in the same day.

I failed to realize that this would break [this part of the challenge manager](https://github.com/AudiusProject/audius-protocol/blob/bf2ede035ded98268a52963e41cbef014db46c00/packages/discovery-provider/src/challenges/listen_streak_endless_challenge.py#L121) - since the specifier changed it wouldn't correctly grab the most recent challenge and would think it should start a new one.

This migration does 2 things:
- update the `challenge_listen_streak` `listen_streak` column to correct values (in most cases this is decreasing the streak bc there are `user_challenges` rows with `current_step_count = 8` which shouldn't be possible.
- Mark all affected `user_challenge` rows with `is_complete = true` and `current_step_count = 7`. Criteria: `current_step_count != amount` and the immediate later neighbor row has `is_complete = true`. Ie. if there is a 7-day row that erroneously did not get marked complete, but then there was a later 1-day row that is complete, then that 7-day row should have been marked complete.


### How Has This Been Tested?

Had AI spit out SELECT versions of these queries (dry-runs) that i manually verified.

```
WITH latest_incomplete_seven_per_user AS (
  SELECT DISTINCT ON (user_id)
    user_id,
    created_at as seven_created_at
  FROM user_challenges
  WHERE 
    challenge_id = 'e' AND
    amount = 7 AND
    current_step_count != amount AND
    created_at <= '2025-03-25' AND 
    created_at > '2025-03-14'
  ORDER BY user_id, created_at DESC
),
valid_streaks AS (
  SELECT 
    ls.user_id,
    ls.seven_created_at,
    7 + COUNT(uc.user_id) as streak_count,
    array_agg(uc.created_at ORDER BY uc.created_at) as counted_dates
  FROM latest_incomplete_seven_per_user ls
  LEFT JOIN user_challenges uc ON 
    uc.user_id = ls.user_id AND
    uc.challenge_id = 'e' AND
    uc.created_at > ls.seven_created_at AND
    uc.amount = 1 AND
    uc.is_complete = true
  WHERE NOT EXISTS (
    -- Exclude if there are ANY incomplete rows after our target seven
    SELECT 1 
    FROM user_challenges uc_incomplete
    WHERE 
      uc_incomplete.user_id = ls.user_id AND
      uc_incomplete.challenge_id = 'e' AND
      uc_incomplete.created_at > ls.seven_created_at AND
      uc_incomplete.created_at != ls.seven_created_at AND
      uc_incomplete.current_step_count != uc_incomplete.amount
  )
  AND EXISTS (
    -- Still require at least one completed amount=1 row after the seven
    SELECT 1 
    FROM user_challenges uc_next
    WHERE 
      uc_next.user_id = ls.user_id AND
      uc_next.challenge_id = 'e' AND
      uc_next.created_at > ls.seven_created_at AND
      uc_next.amount = 1 AND
      uc_next.is_complete = true
  )
  GROUP BY ls.user_id, ls.seven_created_at
)
SELECT 
  cls.user_id,
  cls.listen_streak as current_streak,
  vs.streak_count as new_streak,
  vs.streak_count - cls.listen_streak as streak_difference,
  vs.seven_created_at,
  vs.counted_dates,
  (
    SELECT json_agg(json_build_object(
      'created_at', uc.created_at,
      'amount', uc.amount,
      'current_step_count', uc.current_step_count,
      'is_complete', uc.is_complete
    ) ORDER BY uc.created_at)
    FROM user_challenges uc
    WHERE uc.user_id = cls.user_id
    AND uc.challenge_id = 'e'
    AND uc.created_at >= vs.seven_created_at
  ) as relevant_challenges
FROM challenge_listen_streak cls
JOIN valid_streaks vs ON cls.user_id = vs.user_id
WHERE cls.listen_streak != vs.streak_count
ORDER BY abs(vs.streak_count - cls.listen_streak) DESC;
```


```
WITH next_row AS (
  SELECT 
    uc1.*,
    LEAD(amount) OVER (PARTITION BY user_id, challenge_id ORDER BY created_at ASC) as next_amount,
    LEAD(is_complete) OVER (PARTITION BY user_id, challenge_id ORDER BY created_at ASC) as next_is_complete
  FROM user_challenges uc1
  WHERE challenge_id = 'e'
)
SELECT 
  nr.user_id,
  nr.specifier,
  nr.amount,
  nr.current_step_count as current_step_count,
  7 as new_step_count,
  nr.is_complete as current_is_complete,
  true as new_is_complete,
  nr.created_at,
  nr.next_amount,
  nr.next_is_complete
FROM user_challenges uc
JOIN next_row nr ON
  uc.user_id = nr.user_id AND
  uc.challenge_id = nr.challenge_id AND
  uc.specifier = nr.specifier
WHERE 
  nr.amount = 7 AND 
  nr.current_step_count != nr.amount AND
  nr.next_amount = 1 AND 
  nr.next_is_complete = true AND
  nr.created_at <= '2025-03-25' AND 
  nr.created_at > '2025-03-14'
ORDER BY nr.created_at DESC;
```