### PR TITLE
Fix search due to my bad pythoning creating invalid ES queries

### DIFF
--- a/packages/discovery-provider/src/queries/search_es.py
+++ b/packages/discovery-provider/src/queries/search_es.py
@@ -640,7 +640,7 @@ def track_dsl(
             }
         )
         dsl["should"].extend(
-            *base_match(search_str, operator="and", boost=len(search_str)),
+            base_match(search_str, operator="and", boost=len(search_str)),
         )
 
     if tag_search:
@@ -1105,7 +1105,7 @@ def base_playlist_dsl(
             }
         )
         dsl["should"].extend(
-            *base_match(search_str, operator="and", boost=len(search_str) * 10)
+            base_match(search_str, operator="and", boost=len(search_str) * 10)
         )
 
     if tag_search:


### PR DESCRIPTION
### Description
FUN FACT: `extend` expects a single iterable, so if you unpack `base_match` and it's not into a list, it causes extend to render the key of the `multi_match` as a separate item from the value....


### How Has This Been Tested?
Full Isaac mode, verified on running instance that search is functional again.
