### PR TITLE
Add index and use indexes better in block confirmation

### DIFF
--- a/packages/discovery-provider/ddl/migrations/0129_core_blockhash_index.sql
+++ b/packages/discovery-provider/ddl/migrations/0129_core_blockhash_index.sql
@@ -1,0 +1,5 @@
+begin;
+
+create index if not exists idx_chain_blockhash on core_indexed_blocks (blockhash);
+
+commit;

--- a/packages/discovery-provider/src/queries/get_block_confirmation.py
+++ b/packages/discovery-provider/src/queries/get_block_confirmation.py
@@ -1,7 +1,10 @@
 from sqlalchemy import desc
 
 from src.models.core.core_indexed_blocks import CoreIndexedBlocks
+from src.tasks.core.core_client import CoreClient, get_core_instance
 from src.utils import db_session, helpers
+
+core: CoreClient = get_core_instance()
 
 
 # returns a dictionary that represents whether
@@ -17,12 +20,13 @@ def get_block_confirmation(blockhash, blocknumber):
 
         latest_block_query = (
             session.query(CoreIndexedBlocks)
+            .filter(CoreIndexedBlocks.chain_id == core.get_node_info().chainid)
             .order_by(desc(CoreIndexedBlocks.height))
             .first()
         )
 
         if latest_block_query is None:
-            raise Exception("Expected SINGLE row marked as current")
+            raise Exception("No latest block")
 
         latest_block_record = helpers.model_to_dictionary(latest_block_query)
         latest_block_number = latest_block_record["height"] or 0

--- a/packages/discovery-provider/src/queries/get_block_confirmation.py
+++ b/packages/discovery-provider/src/queries/get_block_confirmation.py
@@ -9,7 +9,7 @@ core: CoreClient = get_core_instance()
 
 # returns a dictionary that represents whether
 # the given blockhash is present, the given blocknumber is passed
-def get_block_confirmation(blockhash, blocknumber):
+def get_block_confirmation(blockhash, blocknumber, core=core):
     db = db_session.get_db_read_replica()
     with db.scoped_session() as session:
         blockhash_query = (

--- a/packages/discovery-provider/src/queries/get_block_confirmation_unit_test.py
+++ b/packages/discovery-provider/src/queries/get_block_confirmation_unit_test.py
@@ -1,23 +1,17 @@
 from src.models.core.core_indexed_blocks import CoreIndexedBlocks
 from src.queries.get_block_confirmation import get_block_confirmation
-from src.tasks.core.gen.protocol_pb2 import BlockResponse, NodeInfoResponse
+from src.tasks.core.gen.protocol_pb2 import NodeInfoResponse
 
 
 class MockCore:
-    def __init__(self, return_block: BlockResponse):
-        self.return_block = return_block
-
     def get_node_info(self) -> NodeInfoResponse:
         return NodeInfoResponse(chainid="audius-devnet")
-
-    def get_block(self, *args) -> BlockResponse:
-        return self.return_block
 
 
 def test_get_block_confirmation(redis_mock, db_mock):
     """Tests confirmation of block given a blockhash and a blocknumber"""
 
-    core = MockCore(BlockResponse())
+    core = MockCore()
 
     # Set up db state
     blockhash, blocknumber = "0x01", 1
@@ -31,7 +25,7 @@ def test_get_block_confirmation(redis_mock, db_mock):
                 blockhash="0x00",
                 height=0,
                 parenthash=None,
-                chain_id="1",
+                chain_id="audius-devnet",
             )
         )
         session.add(
@@ -39,7 +33,7 @@ def test_get_block_confirmation(redis_mock, db_mock):
                 blockhash=blockhash,
                 height=blocknumber,
                 parenthash="0x00",
-                chain_id="1",
+                chain_id="audius-devnet",
             )
         )
         session.add(
@@ -47,7 +41,7 @@ def test_get_block_confirmation(redis_mock, db_mock):
                 blockhash=latest_blockhash,
                 height=latest_blocknumber,
                 parenthash=blockhash,
-                chain_id="1",
+                chain_id="audius-devnet",
             )
         )
 

--- a/packages/discovery-provider/src/queries/get_block_confirmation_unit_test.py
+++ b/packages/discovery-provider/src/queries/get_block_confirmation_unit_test.py
@@ -1,9 +1,23 @@
 from src.models.core.core_indexed_blocks import CoreIndexedBlocks
 from src.queries.get_block_confirmation import get_block_confirmation
+from src.tasks.core.gen.protocol_pb2 import BlockResponse, NodeInfoResponse
+
+
+class MockCore:
+    def __init__(self, return_block: BlockResponse):
+        self.return_block = return_block
+
+    def get_node_info(self) -> NodeInfoResponse:
+        return NodeInfoResponse(chainid="audius-devnet")
+
+    def get_block(self, *args) -> BlockResponse:
+        return self.return_block
 
 
 def test_get_block_confirmation(redis_mock, db_mock):
     """Tests confirmation of block given a blockhash and a blocknumber"""
+
+    core = MockCore(BlockResponse())
 
     # Set up db state
     blockhash, blocknumber = "0x01", 1
@@ -37,20 +51,20 @@ def test_get_block_confirmation(redis_mock, db_mock):
             )
         )
 
-    block_confirmation = get_block_confirmation(blockhash, blocknumber)
+    block_confirmation = get_block_confirmation(blockhash, blocknumber, core)
     assert block_confirmation["block_found"] == True
     assert block_confirmation["block_passed"] == True
 
     latest_block_confirmation = get_block_confirmation(
-        latest_blockhash, latest_blocknumber
+        latest_blockhash, latest_blocknumber, core
     )
     assert latest_block_confirmation["block_found"] == True
     assert latest_block_confirmation["block_passed"] == True
 
-    new_block_confirmation = get_block_confirmation("0xfe", 2)
+    new_block_confirmation = get_block_confirmation("0xfe", 2, core)
     assert new_block_confirmation["block_found"] == False
     assert new_block_confirmation["block_passed"] == True
 
-    new_block_confirmation = get_block_confirmation("0xff", 3)
+    new_block_confirmation = get_block_confirmation("0xff", 3, core)
     assert new_block_confirmation["block_found"] == False
     assert new_block_confirmation["block_passed"] == False


### PR DESCRIPTION
### Description

No index on blockhash = slow query
Not using composite index on height & chainid = slow query

Question - if we rotate chain ids, how will this work? I think it's probably ok, but could use @alecsavvy 's confirmation

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._

Ran queries on postgres prod db 4