### PR TITLE
[PE-5889] useEventByEntityId hook + track page UI

### DIFF
--- a/packages/common/src/api/tan-query/events/index.ts
+++ b/packages/common/src/api/tan-query/events/index.ts
@@ -2,6 +2,7 @@
 export * from './useAllEvents'
 export * from './useEvent'
 export * from './useEvents'
+export * from './useEventsByEntityId'
 
 // Mutations
 export * from './useCreateEvent'

--- a/packages/common/src/api/tan-query/events/useEventsByEntityId.ts
+++ b/packages/common/src/api/tan-query/events/useEventsByEntityId.ts
@@ -1,0 +1,69 @@
+import { useMemo } from 'react'
+
+import { Event as EventSDK, Id, OptionalId } from '@audius/sdk'
+import { useQuery } from '@tanstack/react-query'
+import { keyBy } from 'lodash'
+
+import { useAudiusQueryContext } from '~/audius-query'
+import { Event } from '~/models/Event'
+import { ID } from '~/models/Identifiers'
+
+import { SelectableQueryOptions } from '../types'
+import { useCurrentUserId } from '../useCurrentUserId'
+
+import { getEventsByEntityIdQueryKey, EventsByEntityIdOptions } from './utils'
+
+const transformEvent = (event: EventSDK): Event => ({
+  ...event,
+  eventId: parseInt(event.eventId),
+  userId: parseInt(event.userId),
+  entityId: event.entityId ? parseInt(event.entityId) : null
+})
+
+type UseEventsByEntityIdOptions<TResult = Event[]> = SelectableQueryOptions<
+  Event[],
+  TResult
+> &
+  EventsByEntityIdOptions
+
+export const useEventsByEntityId = <TResult = Event[]>(
+  entityId: ID | null | undefined,
+  options?: UseEventsByEntityIdOptions<TResult>
+) => {
+  const { audiusSdk } = useAudiusQueryContext()
+  const { data: currentUserId } = useCurrentUserId()
+
+  const queryKey = useMemo(
+    () => getEventsByEntityIdQueryKey(entityId, options),
+    [entityId, options]
+  )
+
+  const { data, ...rest } = useQuery<EventSDK[], Error, TResult>({
+    queryKey: queryKey ?? ['events', 'entity', null],
+    queryFn: async () => {
+      if (!entityId) return []
+      const sdk = await audiusSdk()
+      const response = await sdk.events.getEntityEvents({
+        entityId: Id.parse(entityId),
+        userId: OptionalId.parse(currentUserId),
+        entityType: options?.entityType,
+        filterDeleted: options?.filterDeleted,
+        offset: options?.offset,
+        limit: options?.limit
+      })
+      return response.data ?? []
+    },
+    select: (data: EventSDK[]) => {
+      const events = data.map(transformEvent)
+      return options?.select
+        ? options.select(events)
+        : (events as unknown as TResult)
+    }
+    // enabled: options?.enabled !== false && !!queryKey
+  })
+
+  const events = data as unknown as Event[] | undefined
+  const byId = useMemo(() => keyBy(events ?? [], 'eventId'), [events])
+
+  return { data, byId, ...rest }
+}

--- a/packages/common/src/api/tan-query/events/utils.ts
+++ b/packages/common/src/api/tan-query/events/utils.ts
@@ -1,6 +1,15 @@
+import { GetEntityEventsEntityTypeEnum } from '@audius/sdk'
+
 import { ID } from '~/models'
 
 import { QUERY_KEYS } from '../queryKeys'
+
+export type EventsByEntityIdOptions = {
+  entityType?: GetEntityEventsEntityTypeEnum
+  filterDeleted?: boolean
+  offset?: number
+  limit?: number
+}
 
 export const getEventQueryKey = (eventId: ID | null | undefined) => [
   QUERY_KEYS.events,
@@ -11,3 +20,16 @@ export const getEventListQueryKey = ({ pageSize }: { pageSize?: number }) => [
   QUERY_KEYS.events,
   { pageSize }
 ]
+
+export const getEventsByEntityIdQueryKey = (
+  entityId: ID | null | undefined,
+  options?: EventsByEntityIdOptions
+) =>
+  [
+    QUERY_KEYS.eventsByEntityId,
+    entityId,
+    options?.entityType,
+    options?.filterDeleted,
+    options?.offset,
+    options?.limit
+  ] as const

--- a/packages/common/src/api/tan-query/queryKeys.ts
+++ b/packages/common/src/api/tan-query/queryKeys.ts
@@ -78,5 +78,6 @@ export const QUERY_KEYS = {
   trendingPlaylists: 'trendingPlaylists',
   trendingUnderground: 'trendingUnderground',
   trackPageLineup: 'trackPageLineup',
-  events: 'events'
+  events: 'events',
+  eventsByEntityId: 'eventsByEntityId'
 } as const

--- a/packages/web/src/components/track/CardTitle.tsx
+++ b/packages/web/src/components/track/CardTitle.tsx
@@ -19,7 +19,8 @@ const messages = {
   hiddenTrackTooltip: 'Anyone with a link to this page will be able to see it',
   collectibleGated: 'COLLECTIBLE GATED',
   specialAccess: 'SPECIAL ACCESS',
-  premiumTrack: 'PREMIUM TRACK'
+  premiumTrack: 'PREMIUM TRACK',
+  remixContest: 'REMIX CONTEST'
 }
 
 type CardTitleProps = {
@@ -30,6 +31,7 @@ type CardTitleProps = {
   isStreamGated: boolean
   isPodcast: boolean
   streamConditions: Nullable<AccessConditions>
+  isRemixContest: boolean
 }
 
 export const CardTitle = ({
@@ -37,7 +39,8 @@ export const CardTitle = ({
   isRemix,
   isStreamGated,
   isPodcast,
-  streamConditions
+  streamConditions,
+  isRemixContest
 }: CardTitleProps) => {
   let content
 
@@ -65,11 +68,13 @@ export const CardTitle = ({
   } else {
     content = (
       <Text variant='label' color='subdued'>
-        {isRemix
-          ? messages.remixTitle
-          : isPodcast
-            ? messages.podcastTitle
-            : messages.trackTitle}
+        {isRemixContest
+          ? messages.remixContest
+          : isRemix
+            ? messages.remixTitle
+            : isPodcast
+              ? messages.podcastTitle
+              : messages.trackTitle}
       </Text>
     )
   }

--- a/packages/web/src/pages/rewards-page/components/modals/ChallengeRewardsModal/ListenStreakChallengeModalContent.tsx
+++ b/packages/web/src/pages/rewards-page/components/modals/ChallengeRewardsModal/ListenStreakChallengeModalContent.tsx
@@ -26,11 +26,7 @@ const { getUndisbursedUserChallenges, getClaimStatus } =
 
 const messages = {
   rewardSubtext: '$AUDIO/day',
-  descriptionSubtext:
-    'Listen to music on Audius daily for a week to start a streak and earn $AUDIO for each day you keep it going.',
-  totalClaimed: (amount: string) => `${amount} $AUDIO Claimed`,
-  day: (day: number) => `Day ${day} ${day > 0 ? '🔥' : ''}`,
-  readyToClaim: 'Ready to claim!'
+  totalClaimed: (amount: string) => `${amount} $AUDIO Claimed`
 }
 
 export const ListenStreakChallengeModalContent = ({


### PR DESCRIPTION
### Description
- react-query hook for get event by entity ID endpoint
- Update track page/screen UI to actually use the event metadata

### How Has This Been Tested?

<img width="671" alt="Screenshot 2025-04-03 at 6 01 56 PM" src="https://github.com/user-attachments/assets/7723fc8c-4deb-431f-a512-e992a60e9fb0" />
