### PR TITLE
Show cosign on feed and search

### DIFF
--- a/packages/discovery-provider/src/utils/elasticdsl.py
+++ b/packages/discovery-provider/src/utils/elasticdsl.py
@@ -98,7 +98,11 @@ def populate_track_or_playlist_metadata_es(
     # Necessary to show cosign on feed / search
     db = db_session.get_db_read_replica()
     with db.scoped_session() as session:
-        remixes = get_track_remix_metadata(session, [item], current_user["user_id"])
+        remixes = get_track_remix_metadata(
+            session,
+            [item],
+            current_user["user_id"] if "user_id" in current_user else None,
+        )
         if (
             response_name_constants.remix_of in item
             and isinstance(item[response_name_constants.remix_of], dict)

--- a/packages/discovery-provider/src/utils/elasticdsl.py
+++ b/packages/discovery-provider/src/utils/elasticdsl.py
@@ -99,9 +99,7 @@ def populate_track_or_playlist_metadata_es(
     db = db_session.get_db_read_replica()
     with db.scoped_session() as session:
         remixes = get_track_remix_metadata(
-            session,
-            [item],
-            current_user["user_id"] if "user_id" in current_user else None,
+            session, [item], current_user.get("user_id") if current_user else None
         )
         if (
             response_name_constants.remix_of in item


### PR DESCRIPTION
### Description

Noticed search results and feed were missing cosign checks. The only way to see cosign checks was from the remix submission page or track page itself. This is because ElasticSearch queries are missing this extra populate remixer step that is included in the `/remixes` endpoint. 

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._

Confirmed cosigns on stage. 

<img width="533" alt="Screenshot 2025-04-03 at 4 54 05 PM" src="https://github.com/user-attachments/assets/8bfc2c02-9eaa-42fb-b0cb-4844e18696fc" />

