### PR TITLE
Update archiver endpoint to use load-balanced API

### DIFF
--- a/packages/mobile/src/services/env/env.prod.ts
+++ b/packages/mobile/src/services/env/env.prod.ts
@@ -7,7 +7,7 @@ export const env: Env = {
   AMPLITUDE_PROXY: 'https://gain2.audius.co/2/httpapi',
   API_KEY: '8acf5eb7436ea403ee536a7334faa5e9ada4b50f',
   APP_NAME: 'audius-client',
-  ARCHIVE_ENDPOINT: 'https://discoveryprovider.audius.co',
+  ARCHIVE_ENDPOINT: 'https://api.audius.co',
   AUDIUS_URL: 'https://audius.co',
   BITSKI_CALLBACK_URL: 'https://audius.co/bitski-callback.html',
   BITSKI_CLIENT_ID: '661ce11a-3e0f-4659-b365-795ad2111f42',

--- a/packages/mobile/src/services/env/env.stage.ts
+++ b/packages/mobile/src/services/env/env.stage.ts
@@ -7,7 +7,7 @@ export const env: Env = {
   AMPLITUDE_PROXY: 'https://gain2.audius.co/2/httpapi',
   API_KEY: '2dc52ec9a4c31790cab6653de0c637f680faa993',
   APP_NAME: 'audius-client',
-  ARCHIVE_ENDPOINT: 'https://discoveryprovider.staging.audius.co',
+  ARCHIVE_ENDPOINT: 'https://api.staging.audius.co',
   AUDIUS_URL: 'https://staging.audius.co',
   BITSKI_CALLBACK_URL: 'https://staging.audius.co/bitski-callback.html',
   BITSKI_CLIENT_ID: '7a543ec2-b55f-45d6-a5d4-0448c5a23485',

--- a/packages/web/src/services/env/env.prod.ts
+++ b/packages/web/src/services/env/env.prod.ts
@@ -6,7 +6,7 @@ export const env: Env = {
   AMPLITUDE_PROXY: 'https://gain2.audius.co/2/httpapi',
   API_KEY: '8acf5eb7436ea403ee536a7334faa5e9ada4b50f',
   APP_NAME: 'audius-client',
-  ARCHIVE_ENDPOINT: 'https://discoveryprovider.audius.co',
+  ARCHIVE_ENDPOINT: 'https://api.audius.co',
   AUDIUS_URL: 'https://audius.co',
   BITSKI_CALLBACK_URL: 'https://audius.co/bitski-callback.html',
   BITSKI_CLIENT_ID: '661ce11a-3e0f-4659-b365-795ad2111f42',

--- a/packages/web/src/services/env/env.stage.ts
+++ b/packages/web/src/services/env/env.stage.ts
@@ -6,7 +6,7 @@ export const env: Env = {
   AMPLITUDE_PROXY: 'https://gain2.audius.co/2/httpapi',
   API_KEY: '2dc52ec9a4c31790cab6653de0c637f680faa993',
   APP_NAME: 'audius-client',
-  ARCHIVE_ENDPOINT: 'https://discoveryprovider.staging.audius.co',
+  ARCHIVE_ENDPOINT: 'https://api.staging.audius.co',
   AUDIUS_URL: 'https://staging.audius.co',
   BITSKI_CALLBACK_URL: 'https://staging.audius.co/bitski-callback.html',
   BITSKI_CLIENT_ID: '7a543ec2-b55f-45d6-a5d4-0448c5a23485',


### PR DESCRIPTION
### Description
Switching to use the load balanced API instead of hitting DN1 directly.

### How Has This Been Tested?
Run local client against staging with the new URL and verify we can download a track stems zip.