### PR TITLE
Use : instead of _ in challenge specifiers

### DIFF
--- a/packages/discovery-provider/src/challenges/listen_streak_endless_challenge.py
+++ b/packages/discovery-provider/src/challenges/listen_streak_endless_challenge.py
@@ -135,7 +135,7 @@ class ChallengeListenEndlessStreakUpdater(ChallengeUpdater):
         )
         created_at = datetime.fromtimestamp(extra["created_at"])
         old_formatted_date = created_at.strftime("%Y%m%d")
-        old_specifier = f"{hex(user_id)[2:]}_{old_formatted_date}"
+        old_specifier = f"{hex(user_id)[2:]}:{old_formatted_date}"
         if (
             not block
             or not block.height

--- a/packages/discovery-provider/src/challenges/play_count_milestone_challenge_base.py
+++ b/packages/discovery-provider/src/challenges/play_count_milestone_challenge_base.py
@@ -81,7 +81,7 @@ class PlayCountMilestoneUpdaterBase(ChallengeUpdater):
         elif self.CHALLENGE_ID == "p3":
             milestone = "10000"
 
-        return f"{hex(user_id)[2:]}_{milestone}"
+        return f"{hex(user_id)[2:]}:{milestone}"
 
     def should_create_new_challenge(
         self,


### PR DESCRIPTION
### Description
We should not use `_` in specifiers as this is used as a delimiter for parsing the transaction data in sdk.

### How Has This Been Tested?

