### PR TITLE
[QA-2026] Migration to change challenge specifiers from _ to :

### DIFF
--- a/packages/discovery-provider/ddl/migrations/0130_update_challenge_specifier_format.sql
+++ b/packages/discovery-provider/ddl/migrations/0130_update_challenge_specifier_format.sql
@@ -1,0 +1,20 @@
+begin;
+
+alter table user_challenges disable trigger on_user_challenge;
+alter table challenge_disbursements disable trigger on_challenge_disbursement;
+
+-- Update specifiers in user_challenges table
+UPDATE user_challenges
+SET specifier = REPLACE(specifier, '_', ':')
+WHERE challenge_id IN ('e', 'p1', 'p2', 'p3')
+AND specifier LIKE '%_%';
+
+-- Update specifiers in challenge_disbursements table
+UPDATE challenge_disbursements
+SET specifier = REPLACE(specifier, '_', ':')
+WHERE challenge_id IN ('e', 'p1', 'p2', 'p3')
+AND specifier LIKE '%_%';
+
+alter table user_challenges enable trigger on_user_challenge;
+alter table challenge_disbursements enable trigger on_challenge_disbursement;
+commit; 


### PR DESCRIPTION
### Description
`_` is used as the delimiter for transaction data parsing in sdk, so we should not use it in specifiers.

See also: https://github.com/AudiusProject/audius-protocol/pull/11755

Will take this PR out after the above PR has landed on all nodes

### How Has This Been Tested?

Ran a dry-run query:

```
-- Check user_challenges records that will be updated
WITH changes AS (
    SELECT 
        challenge_id,
        specifier as current_specifier,
        REPLACE(specifier, '_', ':') as new_specifier
    FROM user_challenges 
    WHERE challenge_id IN ('e', 'p1', 'p2', 'p3')
    AND specifier LIKE '%_%'
)
SELECT 
    challenge_id,
    COUNT(*) as num_records,
    array_agg(current_specifier) as current_specifiers,
    array_agg(new_specifier) as new_specifiers
FROM changes
GROUP BY challenge_id;

-- Check challenge_disbursements records that will be updated
WITH changes AS (
    SELECT 
        challenge_id,
        specifier as current_specifier,
        REPLACE(specifier, '_', ':') as new_specifier
    FROM challenge_disbursements 
    WHERE challenge_id IN ('e', 'p1', 'p2', 'p3')
    AND specifier LIKE '%_%'
)
SELECT 
    challenge_id,
    COUNT(*) as num_records,
    array_agg(current_specifier) as current_specifiers,
    array_agg(new_specifier) as new_specifiers
FROM changes
GROUP BY challenge_id;
```