### PR TITLE
[PE-5896] Fix deletion of stems in edit track form

### DIFF
--- a/packages/common/src/api/index.ts
+++ b/packages/common/src/api/index.ts
@@ -71,7 +71,7 @@ export * from './tan-query/useTopArtistsInGenre'
 export * from './tan-query/useTopArtists'
 export * from './tan-query/useAudioTransactions'
 export * from './tan-query/useAudioTransactionsCount'
-
+export * from './tan-query/useTrackFileInfo'
 // Saga fetch utils, remove when migration is complete
 export * from './tan-query/saga-utils'
 export * from './tan-query/useCollectionTracksWithUid'

--- a/packages/common/src/api/tan-query/queryKeys.ts
+++ b/packages/common/src/api/tan-query/queryKeys.ts
@@ -17,6 +17,7 @@ export const QUERY_KEYS = {
   trackByPermalink: 'trackByPermalink',
   tracksByPlaylist: 'tracksByPlaylist',
   tracksByAlbum: 'tracksByAlbum',
+  trackFileInfo: 'trackFileInfo',
   user: 'user',
   users: 'users',
   userByHandle: 'userByHandle',

--- a/packages/common/src/api/tan-query/useTrackFileInfo.ts
+++ b/packages/common/src/api/tan-query/useTrackFileInfo.ts
@@ -1,0 +1,36 @@
+import { BlobInfo, Id } from '@audius/sdk'
+import { useQuery } from '@tanstack/react-query'
+
+import { useAudiusQueryContext } from '~/audius-query'
+import { ID } from '~/models/Identifiers'
+
+import { QUERY_KEYS } from './queryKeys'
+import { QueryKey, SelectableQueryOptions } from './types'
+
+export const getTrackFileInfoQueryKey = (trackId: ID | null | undefined) => {
+  return [QUERY_KEYS.trackFileInfo, trackId] as unknown as QueryKey<BlobInfo>
+}
+
+export const useTrackFileInfo = <TResult = BlobInfo>(
+  trackId: ID | null | undefined,
+  options?: SelectableQueryOptions<BlobInfo, TResult> & {
+    original?: boolean
+  }
+) => {
+  const { audiusSdk } = useAudiusQueryContext()
+  const validTrackId = !!trackId && trackId > 0
+
+  return useQuery({
+    queryKey: getTrackFileInfoQueryKey(trackId),
+    queryFn: async () => {
+      const sdk = await audiusSdk()
+      const response = await sdk.tracks.inspectTrack({
+        trackId: Id.parse(trackId!),
+        original: options?.original ?? false
+      })
+      return response.data ?? { size: 0, contentType: '' }
+    },
+    ...options,
+    enabled: options?.enabled !== false && validTrackId
+  })
+}

--- a/packages/web/src/components/edit/fields/StemsAndDownloadsMenuFields.tsx
+++ b/packages/web/src/components/edit/fields/StemsAndDownloadsMenuFields.tsx
@@ -254,8 +254,12 @@ export const StemsAndDownloadsMenuFields = (
 
   const handleDeleteStem = useCallback(
     (index: number) => {
-      stemsValue.splice(index, 1)
-      setStemsValue(stemsValue)
+      // Make a copy to be sure children reading this value will re-render.
+      const newStems = [
+        ...stemsValue.slice(0, index),
+        ...stemsValue.slice(index + 1)
+      ]
+      setStemsValue(newStems)
       props.onDeleteStem?.(index)
     },
     [props, setStemsValue, stemsValue]

--- a/packages/web/src/components/upload/TrackPreview.tsx
+++ b/packages/web/src/components/upload/TrackPreview.tsx
@@ -74,7 +74,7 @@ const fileTypeIcon = (type: string) => {
   }
 }
 
-type TrackPreviewProps = ComponentPropsWithoutRef<'div'> & {
+export type TrackPreviewProps = ComponentPropsWithoutRef<'div'> & {
   index: number
   displayIndex: boolean
   onRemove: () => void


### PR DESCRIPTION
### Description
Bit of a mix of issues here:
1. We splice the form value for stems, which edits in place. We should be setting a new copy to make sure anything using reference equality re-renders

2. Our key for stems shouldn't use indices. I updated that to use the track_id if available (editing) or the file name if not. This follows a similar pattern to collections, minus the usage of added_timestamps.


3. The biggest issue: We had an interesting async hook that would fetch the file size info for stems with track_ids (in edit flow) and then bulk set them after all requests finish. And we aren't caching that info. When loading the edit form for the first time, this means they all show as "Untitled" for however long it takes for N requests to complete and then all pop in at once. For editing, this means when you remove an item, we bulk fetch everything again before re-rendering the `fileInfo` list. This would delay the item disappearing by however long it takes to refetch everything.
I simplified that a lot by moving the conditional fetching of track inspection data into child components for each stem, and wrote a tan-query hook to hit the endpoint for a given track id. This means we only try to fetch it if the stem has a track id, and once you've fetched it for that track_id, we will hit the cache afterwards.

### How Has This Been Tested?
Tried uploading a new track with stems and editing an existing track with stems. Deletes work in the form in both cases.
However _there is a separate bug with editing tracks that causes deleted stems in the form data to not cause a deletion in the saga_. That will be fixed in a separate PR.
