### PR TITLE
Convert remixes lineup to tq

### DIFF
--- a/packages/common/src/api/index.ts
+++ b/packages/common/src/api/index.ts
@@ -73,6 +73,7 @@ export * from './tan-query/useAudioTransactions'
 export * from './tan-query/useAudioTransactionsCount'
 export * from './tan-query/useFeed'
 export * from './tan-query/useTrending'
+export * from './tan-query/useRemixes'
 
 // Saga fetch utils, remove when migration is complete
 export * from './tan-query/saga-utils'

--- a/packages/common/src/api/tan-query/useRemixes.ts
+++ b/packages/common/src/api/tan-query/useRemixes.ts
@@ -83,7 +83,7 @@ export const useRemixes = (
           pageParam,
           pageSize,
           false,
-          { tracks: processedTracks }
+          { items: processedTracks }
         )
       )
 

--- a/packages/web/src/common/store/pages/remixes-page/lineups/tracks/sagas.ts
+++ b/packages/web/src/common/store/pages/remixes-page/lineups/tracks/sagas.ts
@@ -1,60 +1,13 @@
-import {
-  transformAndCleanList,
-  userTrackMetadataFromSDK
-} from '@audius/common/adapters'
 import { Track } from '@audius/common/models'
 import {
-  accountSelectors,
   remixesPageLineupActions as tracksActions,
-  remixesPageActions,
   remixesPageSelectors,
-  CommonState,
-  getSDK
+  CommonState
 } from '@audius/common/store'
-import { Id, OptionalId } from '@audius/sdk'
-import { call, put, select } from 'typed-redux-saga'
 
-import { processAndCacheTracks } from 'common/store/cache/tracks/utils'
 import { LineupSagas } from 'common/store/lineup/sagas'
-import { waitForRead } from 'utils/sagaHelpers'
+
 const { getTrackId, getLineup } = remixesPageSelectors
-const { setCount } = remixesPageActions
-const getUserId = accountSelectors.getUserId
-
-function* getTracks({
-  offset,
-  limit,
-  payload
-}: {
-  offset: number
-  limit: number
-  payload?: { trackId: number | null }
-}) {
-  const sdk = yield* getSDK()
-  const { trackId } = payload ?? {}
-  if (!trackId) return []
-  yield* waitForRead()
-
-  const currentUserId = yield* select(getUserId)
-
-  const { data = { count: 0, tracks: [] } } = yield* call(
-    [sdk.full.tracks, sdk.full.tracks.getTrackRemixes],
-    {
-      trackId: Id.parse(trackId),
-      offset,
-      limit,
-      userId: OptionalId.parse(currentUserId)
-    }
-  )
-
-  const tracks = transformAndCleanList(data.tracks, userTrackMetadataFromSDK)
-
-  yield* put(setCount({ count: data.count }))
-
-  const processedTracks = yield* call(processAndCacheTracks, tracks)
-
-  return processedTracks
-}
 
 const sourceSelector = (state: CommonState) =>
   `${tracksActions.prefix}:${getTrackId(state)}`
@@ -65,7 +18,7 @@ class TracksSagas extends LineupSagas<Track> {
       tracksActions.prefix,
       tracksActions,
       getLineup,
-      getTracks,
+      ({ payload }) => payload.items,
       undefined,
       undefined,
       sourceSelector

--- a/packages/web/src/components/lineup/TanQueryLineup.tsx
+++ b/packages/web/src/components/lineup/TanQueryLineup.tsx
@@ -142,6 +142,7 @@ export const TanQueryLineup = ({
   endOfLineupElement: endOfLineup,
   leadingElementId,
   lineupContainerStyles,
+  leadingElementDelineator,
   tileContainerStyles,
   tileStyles,
   emptyElement,
@@ -291,7 +292,11 @@ export const TanQueryLineup = ({
                     <TrackTile {...skeletonTileProps(index)} key={index} />
                   </Flex>
                   {index === 0 && leadingElementId !== undefined ? (
-                    <Divider css={{ width: '100%' }} />
+                    leadingElementDelineator !== undefined ? (
+                      leadingElementDelineator
+                    ) : (
+                      <Divider css={{ width: '100%' }} />
+                    )
                   ) : null}
                 </Flex>
               )
@@ -300,13 +305,14 @@ export const TanQueryLineup = ({
       )
     },
     [
-      TrackTile,
-      leadingElementId,
-      isMobile,
-      numPlaylistSkeletonRows,
-      ordered,
       tileSize,
-      tileStyles
+      ordered,
+      numPlaylistSkeletonRows,
+      leadingElementId,
+      tileStyles,
+      isMobile,
+      TrackTile,
+      leadingElementDelineator
     ]
   )
 
@@ -451,7 +457,11 @@ export const TanQueryLineup = ({
                       {tile}
                     </Flex>
                     {index === 0 && leadingElementId !== undefined ? (
-                      <Divider />
+                      leadingElementDelineator !== undefined ? (
+                        leadingElementDelineator
+                      ) : (
+                        <Divider />
+                      )
                     ) : null}
                   </Flex>
                 ))}

--- a/packages/web/src/pages/remixes-page/components/desktop/RemixesPage.tsx
+++ b/packages/web/src/pages/remixes-page/components/desktop/RemixesPage.tsx
@@ -1,9 +1,11 @@
+import { useRemixes } from '@audius/common/api'
 import { Track, User } from '@audius/common/models'
+import { remixesPageLineupActions } from '@audius/common/store'
 import { pluralize } from '@audius/common/utils'
 import { IconRemix, Text } from '@audius/harmony'
 
 import { Header } from 'components/header/desktop/Header'
-import Lineup, { LineupProps } from 'components/lineup/Lineup'
+import { TanQueryLineup } from 'components/lineup/TanQueryLineup'
 import { TrackLink } from 'components/link/TrackLink'
 import { UserLink } from 'components/link/UserLink'
 import Page from 'components/page/Page'
@@ -25,7 +27,6 @@ export type RemixesPageProps = {
   count: number | null
   originalTrack: Pick<Track, 'track_id' | 'permalink' | 'title'> | undefined
   user: User | undefined
-  getLineupProps: () => LineupProps
   goToTrackPage: () => void
   goToArtistPage: () => void
 }
@@ -35,35 +36,62 @@ const g = withNullGuard(
     originalTrack && user && { ...p, originalTrack, user }
 )
 
-const RemixesPage = g(
-  ({ title, count = 0, originalTrack, user, getLineupProps }) => {
-    const renderHeader = () => (
-      <Header
-        icon={IconRemix}
-        primary={title}
-        secondary={
-          <Text variant='title' size='l' strength='weak'>
-            {count} {pluralize(messages.remixes, count, 'es', !count)}{' '}
-            {messages.of}{' '}
-            <TrackLink trackId={originalTrack.track_id} variant='secondary' />{' '}
-            {messages.by} <UserLink userId={user.user_id} variant='secondary' />
-          </Text>
-        }
-        containerStyles={styles.header}
-      />
-    )
+const RemixesPage = g(({ title, count = 0, originalTrack, user }) => {
+  const {
+    data,
+    isFetching,
+    isPending,
+    isError,
+    hasNextPage,
+    play,
+    pause,
+    loadNextPage,
+    isPlaying,
+    lineup,
+    pageSize
+  } = useRemixes({
+    trackId: originalTrack?.track_id
+  })
 
-    return (
-      <Page
-        title={title}
-        description={messages.getDescription(originalTrack.title, user.name)}
-        canonicalUrl={fullTrackRemixesPage(originalTrack.permalink)}
-        header={renderHeader()}
-      >
-        <Lineup {...getLineupProps()} />
-      </Page>
-    )
-  }
-)
+  const renderHeader = () => (
+    <Header
+      icon={IconRemix}
+      primary={title}
+      secondary={
+        <Text variant='title' size='l' strength='weak'>
+          {count} {pluralize(messages.remixes, count, 'es', !count)}{' '}
+          {messages.of}{' '}
+          <TrackLink trackId={originalTrack.track_id} variant='secondary' />{' '}
+          {messages.by} <UserLink userId={user.user_id} variant='secondary' />
+        </Text>
+      }
+      containerStyles={styles.header}
+    />
+  )
+
+  return (
+    <Page
+      title={title}
+      description={messages.getDescription(originalTrack.title, user.name)}
+      canonicalUrl={fullTrackRemixesPage(originalTrack.permalink)}
+      header={renderHeader()}
+    >
+      <TanQueryLineup
+        data={data}
+        isFetching={isFetching}
+        isPending={isPending}
+        isError={isError}
+        hasNextPage={hasNextPage}
+        play={play}
+        pause={pause}
+        loadNextPage={loadNextPage}
+        isPlaying={isPlaying}
+        lineup={lineup}
+        actions={remixesPageLineupActions}
+        pageSize={pageSize}
+      />
+    </Page>
+  )
+})
 
 export default RemixesPage

--- a/packages/web/src/pages/remixes-page/components/mobile/RemixesPage.tsx
+++ b/packages/web/src/pages/remixes-page/components/mobile/RemixesPage.tsx
@@ -1,12 +1,14 @@
 import { useEffect, useContext } from 'react'
 
+import { useRemixes } from '@audius/common/api'
 import { Track, User } from '@audius/common/models'
+import { remixesPageLineupActions } from '@audius/common/store'
 import { pluralize } from '@audius/common/utils'
 import { IconRemix as IconRemixes } from '@audius/harmony'
 
 import Header from 'components/header/mobile/Header'
 import { HeaderContext } from 'components/header/mobile/HeaderContextProvider'
-import Lineup, { LineupProps } from 'components/lineup/Lineup'
+import { TanQueryLineup } from 'components/lineup/TanQueryLineup'
 import MobilePageContainer from 'components/mobile-page-container/MobilePageContainer'
 import { useSubPageHeader } from 'components/nav/mobile/NavContext'
 import UserBadges from 'components/user-badges/UserBadges'
@@ -28,7 +30,6 @@ export type RemixesPageProps = {
   count: number | null
   originalTrack: Pick<Track, 'track_id' | 'permalink' | 'title'> | undefined
   user: User | undefined
-  getLineupProps: () => LineupProps
   goToTrackPage: () => void
   goToArtistPage: () => void
 }
@@ -39,16 +40,23 @@ const g = withNullGuard(
 )
 
 const RemixesPage = g(
-  ({
-    title,
-    count,
-    originalTrack,
-    user,
-    getLineupProps,
-    goToTrackPage,
-    goToArtistPage
-  }) => {
+  ({ title, count, originalTrack, user, goToTrackPage, goToArtistPage }) => {
     useSubPageHeader()
+    const {
+      data,
+      isFetching,
+      isPending,
+      isError,
+      hasNextPage,
+      play,
+      pause,
+      loadNextPage,
+      isPlaying,
+      lineup,
+      pageSize
+    } = useRemixes({
+      trackId: originalTrack?.track_id
+    })
 
     const { setHeader } = useContext(HeaderContext)
     useEffect(() => {
@@ -97,7 +105,20 @@ const RemixesPage = g(
               </div>
             </div>
           </div>
-          <Lineup {...getLineupProps()} />
+          <TanQueryLineup
+            data={data}
+            isFetching={isFetching}
+            isPending={isPending}
+            isError={isError}
+            hasNextPage={hasNextPage}
+            play={play}
+            pause={pause}
+            loadNextPage={loadNextPage}
+            isPlaying={isPlaying}
+            lineup={lineup}
+            actions={remixesPageLineupActions}
+            pageSize={pageSize}
+          />
         </div>
       </MobilePageContainer>
     )


### PR DESCRIPTION
### Description

- Convert the remixes page lineup to tan-query to set up remixes work

### How Has This Been Tested?

web:stage desktop & mobile
ios:stage - something weird happening before getting to this page @isaacsolo to dig into it