### PR TITLE
[PE-5893] Group + count like stems during upload

### DIFF
--- a/packages/web/src/components/edit/fields/StemsAndDownloadsField.tsx
+++ b/packages/web/src/components/edit/fields/StemsAndDownloadsField.tsx
@@ -16,7 +16,7 @@ import { accountSelectors } from '@audius/common/store'
 import { Nullable } from '@audius/common/utils'
 import { IconCart, IconReceive } from '@audius/harmony'
 import { FormikErrors } from 'formik'
-import { get, set } from 'lodash'
+import { get, set, groupBy } from 'lodash'
 import { useSelector } from 'react-redux'
 import { toFormikValidationSchema } from 'zod-formik-adapter'
 
@@ -254,26 +254,15 @@ export const StemsAndDownloadsField = (props: StemsAndDownloadsFieldProps) => {
 
     if (values.length === 0) return null
 
-    // Group values by type
-    const groupedValues = values.reduce(
-      (acc: Record<string, number>, value) => {
-        const label = typeof value === 'string' ? value : value.label
-        if (acc[label]) {
-          acc[label]++
-        } else {
-          acc[label] = 1
-        }
-        return acc
-      },
-      {}
-    )
+    const getLabel = (value: any) =>
+      typeof value === 'string' ? value : value.label
+    const groupedValues = groupBy(values, getLabel)
 
     // Convert grouped values into array with counts
     const displayValues = Object.entries(groupedValues).map(
-      ([label, count]) => {
-        const originalValue = values.find((v) =>
-          typeof v === 'string' ? v === label : v.label === label
-        )
+      ([label, items]) => {
+        const originalValue = items[0]
+        const count = items.length
 
         if (typeof originalValue === 'object') {
           return {

--- a/packages/web/src/components/edit/fields/StemsAndDownloadsField.tsx
+++ b/packages/web/src/components/edit/fields/StemsAndDownloadsField.tsx
@@ -226,7 +226,7 @@ export const StemsAndDownloadsField = (props: StemsAndDownloadsFieldProps) => {
     ]
   )
 
-  const renderValue = () => {
+  const renderValue = useCallback(() => {
     let values = []
     if (!streamConditions) {
       if (isContentUSDCPurchaseGated(savedDownloadConditions)) {
@@ -254,9 +254,44 @@ export const StemsAndDownloadsField = (props: StemsAndDownloadsFieldProps) => {
 
     if (values.length === 0) return null
 
+    // Group values by type
+    const groupedValues = values.reduce(
+      (acc: Record<string, number>, value) => {
+        const label = typeof value === 'string' ? value : value.label
+        if (acc[label]) {
+          acc[label]++
+        } else {
+          acc[label] = 1
+        }
+        return acc
+      },
+      {}
+    )
+
+    // Convert grouped values into array with counts
+    const displayValues = Object.entries(groupedValues).map(
+      ([label, count]) => {
+        const originalValue = values.find((v) =>
+          typeof v === 'string' ? v === label : v.label === label
+        )
+
+        if (typeof originalValue === 'object') {
+          return {
+            ...originalValue,
+            label:
+              count > 1
+                ? `${originalValue.label} (${count})`
+                : originalValue.label
+          }
+        }
+
+        return count > 1 ? `${label} (${count})` : label
+      }
+    )
+
     return (
       <SelectedValues>
-        {values.map((value, i) => {
+        {displayValues.map((value, i) => {
           const valueProps =
             typeof value === 'string' ? { label: value } : value
           return (
@@ -265,7 +300,7 @@ export const StemsAndDownloadsField = (props: StemsAndDownloadsFieldProps) => {
         })}
       </SelectedValues>
     )
-  }
+  }, [isDownloadable, savedDownloadConditions, stemsValue, streamConditions])
 
   return (
     <ContextualMenu


### PR DESCRIPTION
### Description
In the main upload form, count each type of stem and group them together.

we don't currently support stem uploads on mobile.

### How Has This Been Tested?

<img width="837" alt="Screenshot 2025-04-07 at 4 26 56 PM" src="https://github.com/user-attachments/assets/8e5b9c29-beae-4d03-aa4c-dcbec793422b" />
