### PR TITLE
Create status flag indexes, remove dubious old indexes.

### DIFF
--- a/packages/discovery-provider/ddl/migrations/0131_index_cleanup.sql
+++ b/packages/discovery-provider/ddl/migrations/0131_index_cleanup.sql
@@ -1,0 +1,16 @@
+BEGIN;
+
+-- user index cleanup
+drop index if exists users_new_is_available_idx;
+drop index if exists users_new_is_deactivated_handle_lc_is_available_idx;
+drop index if exists users_new_is_deactivated_idx;
+create index if not exists idx_user_status on users(user_id, is_deactivated, is_available, is_current);
+
+-- track index cleanup
+drop index if exists fix_tracks_status_flags_idx;
+create index if not exists idx_track_status on tracks(track_id, is_unlisted, is_available, is_delete, is_current);
+
+-- playlist index
+create index if not exists idx_playlist_status on playlists(playlist_id, is_album, is_private, is_delete, is_current);
+
+COMMIT;


### PR DESCRIPTION
### Description

combine a few indexes together into a status index with the `is_*` fields used for filtering.

`is_current` is included because there are many places we use this in the where clause...
so Including it in the status index can hopefully avoid some heap fetches for no reason.

### How Has This Been Tested?

`bash local-test.sh`