### PR TITLE
[QA-2045] Fix notification entity prefetch

### DIFF
--- a/packages/common/src/api/tan-query/useNotifications.ts
+++ b/packages/common/src/api/tan-query/useNotifications.ts
@@ -127,7 +127,7 @@ const collectEntityIds = (notifications: Notification[]): EntityIds => {
       type === NotificationType.USDCPurchaseBuyer ||
       type === NotificationType.USDCPurchaseSeller
     ) {
-      userIds.add(notification.userIds[0])
+      notification.userIds.forEach((id) => userIds.add(id))
       if (notification.entityType === Entity.Track) {
         trackIds.add(notification.entityId)
       } else if (notification.entityType === Entity.Album) {

--- a/packages/common/src/api/tan-query/useNotifications.ts
+++ b/packages/common/src/api/tan-query/useNotifications.ts
@@ -41,12 +41,16 @@ const collectEntityIds = (notifications: Notification[]): EntityIds => {
     const { type } = notification
     if (type === NotificationType.UserSubscription) {
       if (notification.entityType === Entity.Track) {
-        notification.entityIds.forEach((id) => trackIds.add(id))
+        if (notification.entityIds.length === 1) {
+          trackIds.add(notification.entityIds[0])
+        }
       } else if (
         notification.entityType === Entity.Playlist ||
         notification.entityType === Entity.Album
       ) {
-        notification.entityIds.forEach((id) => collectionIds.add(id))
+        if (notification.entityIds.length === 1) {
+          collectionIds.add(notification.entityIds[0])
+        }
       }
       userIds.add(notification.userId)
     }
@@ -123,7 +127,7 @@ const collectEntityIds = (notifications: Notification[]): EntityIds => {
       type === NotificationType.USDCPurchaseBuyer ||
       type === NotificationType.USDCPurchaseSeller
     ) {
-      notification.userIds.forEach((id) => userIds.add(id))
+      userIds.add(notification.userIds[0])
       if (notification.entityType === Entity.Track) {
         trackIds.add(notification.entityId)
       } else if (notification.entityType === Entity.Album) {
@@ -145,7 +149,9 @@ const collectEntityIds = (notifications: Notification[]): EntityIds => {
       if (notification.entityType === Entity.Track) {
         trackIds.add(notification.entityId)
       }
-      notification.userIds.forEach((id) => userIds.add(id))
+      notification.userIds
+        .slice(0, USER_INITIAL_LOAD_COUNT)
+        .forEach((id) => userIds.add(id))
     }
   })
 

--- a/packages/web/src/components/notification/Notification/components/NotificationTile.tsx
+++ b/packages/web/src/components/notification/Notification/components/NotificationTile.tsx
@@ -31,7 +31,7 @@ export const NotificationTile = (props: NotificationTileProps) => {
   )
 
   return (
-    <Paper column shadow='flat' p='l' onClick={handleClick} border='default'>
+    <Paper column shadow='flat' p='l' onClick={handleClick} border='strong'>
       {children}
     </Paper>
   )

--- a/packages/web/src/components/notification/NotificationPage.tsx
+++ b/packages/web/src/components/notification/NotificationPage.tsx
@@ -5,11 +5,9 @@ import {
   useMarkNotificationsAsViewed
 } from '@audius/common/api'
 import { Notification as Notifications } from '@audius/common/store'
-import { Flex } from '@audius/harmony'
-import Lottie from 'lottie-react'
+import { Flex, LoadingSpinner } from '@audius/harmony'
 import InfiniteScroll from 'react-infinite-scroller'
 
-import loadingSpinner from 'assets/animations/loadingSpinner.json'
 import MobilePageContainer from 'components/mobile-page-container/MobilePageContainer'
 import NavContext, { LeftPreset } from 'components/nav/mobile/NavContext'
 
@@ -71,7 +69,7 @@ export const NotificationPage = () => {
           as={InfiniteScroll}
           direction='column'
           p='l'
-          backgroundColor='default'
+          backgroundColor='white'
           gap='s'
           // @ts-ignore
           pageStart={0}
@@ -93,7 +91,7 @@ export const NotificationPage = () => {
                 />
               )
             })}
-          {isPending && <Lottie loop autoplay animationData={loadingSpinner} />}
+          {isPending && <LoadingSpinner size='3xl' />}
         </Flex>
       )}
     </MobilePageContainer>

--- a/packages/web/src/components/notification/NotificationPanel.tsx
+++ b/packages/web/src/components/notification/NotificationPanel.tsx
@@ -58,7 +58,7 @@ export const NotificationPanel = ({
     isAllPending: isPending,
     isError,
     isFetchingNextPage
-  } = useNotifications()
+  } = useNotifications({ enabled: isOpen })
 
   const handleLoadMore = useCallback(() => {
     if (!isFetchingNextPage) {

--- a/packages/web/src/components/notification/NotificationPanel.tsx
+++ b/packages/web/src/components/notification/NotificationPanel.tsx
@@ -58,7 +58,7 @@ export const NotificationPanel = ({
     isAllPending: isPending,
     isError,
     isFetchingNextPage
-  } = useNotifications({ enabled: isOpen })
+  } = useNotifications()
 
   const handleLoadMore = useCallback(() => {
     if (!isFetchingNextPage) {


### PR DESCRIPTION
### Description

Fixes big performance regression where user-subscription notifications were fetching all the tracks/collections related to the notification even though we don't need their info to render the notif. Now we only prefetch a track/collection if it's the only one in the user-subscription notification.

Also made a slight optimization to the comment notifications to not over-fetch users.

Small ui changes based on figma