### PR TITLE
Fix issue where notification button doesn't close panel

### DIFF
--- a/packages/web/src/components/notification/NotificationPanel.tsx
+++ b/packages/web/src/components/notification/NotificationPanel.tsx
@@ -74,12 +74,15 @@ export const NotificationPanel = ({
   const handleCheckClickInside = useCallback(
     (target: EventTarget) => {
       if (isUserListOpen) return true
-      if (target instanceof Element && panelRef.current) {
-        return panelRef.current.contains(target)
+      if (target instanceof Element) {
+        return (
+          panelRef.current?.contains(target) ||
+          anchorRef.current?.contains(target)
+        )
       }
       return false
     },
-    [isUserListOpen]
+    [anchorRef, isUserListOpen]
   )
 
   useEffect(() => {

--- a/packages/web/src/components/notification/NotificationPanel.tsx
+++ b/packages/web/src/components/notification/NotificationPanel.tsx
@@ -75,7 +75,7 @@ export const NotificationPanel = ({
     (target: EventTarget) => {
       if (isUserListOpen) return true
       if (target instanceof Element) {
-        return (
+        return !!(
           panelRef.current?.contains(target) ||
           anchorRef.current?.contains(target)
         )


### PR DESCRIPTION
### Description

Fixes small issue where clicking notification button keeps panel open. This is because the panel considers this an external click, which calls toggle, therefore resetting the panel state. Switching to useState to allow double calls