### PR TITLE
Make playlist query deterministic wrt ordering to fix test.

### DIFF
--- a/packages/discovery-provider/src/queries/get_user_playlist_update.py
+++ b/packages/discovery-provider/src/queries/get_user_playlist_update.py
@@ -25,15 +25,16 @@ INNER JOIN
         s.save_type = 'playlist' AND
         s.user_id = :user_id
 LEFT JOIN
-  playlist_seen ps ON 
+  playlist_seen ps ON
     ps.is_current AND
     ps.playlist_id = p.playlist_id AND
     ps.user_id = :user_id
 where
     p.is_current = true AND
     p.is_delete = false AND
-    s.created_at < p.updated_at AND 
+    s.created_at < p.updated_at AND
     (ps.seen_at is NULL OR p.updated_at > ps.seen_at)
+order by p.playlist_id
 """
 )
 


### PR DESCRIPTION
python test was asserting on array equality, but the underlying query had no order by clause.

Adding an index changed the implicit ordering of result set which broke test.

Add order by to query under test to satisfy test.