### PR TITLE
Fix lineup empty state

### DIFF
--- a/packages/web/src/components/lineup/TanQueryLineup.tsx
+++ b/packages/web/src/components/lineup/TanQueryLineup.tsx
@@ -163,11 +163,10 @@ export const TanQueryLineup = ({
   hasNextPage,
   isPending = true,
   isPlaying = false,
-  // isFetching = true,
+  isFetching = true,
   isError = false,
   maxEntries
 }: TanQueryLineupProps) => {
-  const isFetching = true
   const dispatch = useDispatch()
 
   const getCurrentQueueItem = useMemo(() => makeGetCurrent(), [])

--- a/packages/web/src/pages/feed-page/components/FollowUsers.tsx
+++ b/packages/web/src/pages/feed-page/components/FollowUsers.tsx
@@ -1,6 +1,6 @@
 import { useCallback } from 'react'
 
-import { useGetFeaturedArtists } from '@audius/common/api'
+import { useTopArtists } from '@audius/common/api'
 import { feedPageActions } from '@audius/common/store'
 import { Button, Flex, IconUserFollow, Text } from '@audius/harmony'
 import { Form, Formik } from 'formik'
@@ -25,7 +25,7 @@ const initialValues: FollowUsersValues = {
 const FollowUsers = () => {
   const dispatch = useDispatch()
 
-  const { data: featuredArtists } = useGetFeaturedArtists(undefined)
+  const { data: featuredArtists } = useTopArtists('Featured')
 
   const handleSubmit = useCallback(
     (values: FollowUsersValues) => {

--- a/packages/web/src/pages/feed-page/components/mobile/FeedPageContent.tsx
+++ b/packages/web/src/pages/feed-page/components/mobile/FeedPageContent.tsx
@@ -23,6 +23,8 @@ import { useMainPageHeader } from 'components/nav/mobile/NavContext'
 import { FeedPageContentProps } from 'pages/feed-page/types'
 import { BASE_URL } from 'utils/route'
 
+import EmptyFeed from '../EmptyFeed'
+
 import Filters from './FeedFilterButton'
 import FeedFilterDrawer from './FeedFilterDrawer'
 import styles from './FeedPageContent.module.css'
@@ -111,6 +113,7 @@ const FeedPageMobileContent = ({
           hasNextPage={hasNextPage}
           play={play}
           pause={pause}
+          emptyElement={<EmptyFeed />}
           loadNextPage={loadNextPage}
           isPlaying={isPlaying}
           lineup={lineup}


### PR DESCRIPTION
### Description

Lineup empty state was showing infinite loading due to a leftover test variable.

I also noticed that web mobile wasn't showing the empty feed component (currently happening on prod as well) so I fixed that as well.
Moved the empty feed to tan-query as well

### How Has This Been Tested?

web:stage desktop & mobile - tested both feed & lineup with empty array return values