### PR TITLE
Show (1) counts for stem categories in upload

### DIFF
--- a/packages/web/src/components/edit/fields/StemsAndDownloadsField.tsx
+++ b/packages/web/src/components/edit/fields/StemsAndDownloadsField.tsx
@@ -267,14 +267,13 @@ export const StemsAndDownloadsField = (props: StemsAndDownloadsFieldProps) => {
         if (typeof originalValue === 'object') {
           return {
             ...originalValue,
-            label:
-              count > 1
-                ? `${originalValue.label} (${count})`
-                : originalValue.label
+            label: `${originalValue.label} (${count})`
           }
         }
 
-        return count > 1 ? `${label} (${count})` : label
+        // Check if this value is a stem category by checking if it exists in the stems array
+        const isStemCategory = stemsCategories.includes(label)
+        return isStemCategory ? `${label} (${count})` : label
       }
     )
 


### PR DESCRIPTION
### Description
We want to show (1) next to the stem category counts when there's only 1 stem of that type.

### How Has This Been Tested?

<img width="1115" alt="Screenshot 2025-04-08 at 2 38 55 PM" src="https://github.com/user-attachments/assets/f428708f-4280-4d19-98b2-ba0089e4ff74" />
