### PR TITLE
[QA-2056] Fix message blast CTA showing on user list modals erroneously

### DIFF
--- a/packages/mobile/src/screens/chat-screen/ChatBlastWithAudienceCTA.tsx
+++ b/packages/mobile/src/screens/chat-screen/ChatBlastWithAudienceCTA.tsx
@@ -1,10 +1,15 @@
 import { useCallback } from 'react'
 
+import { useCurrentUserId } from '@audius/common/api'
 import { useCanSendChatBlast } from '@audius/common/hooks'
-import { chatActions } from '@audius/common/store'
+import {
+  chatActions,
+  followersUserListSelectors,
+  topSupportersUserListSelectors
+} from '@audius/common/store'
 import { ChatBlastAudience } from '@audius/sdk'
 import { TouchableHighlight } from 'react-native-gesture-handler'
-import { useDispatch } from 'react-redux'
+import { useDispatch, useSelector } from 'react-redux'
 
 import {
   Box,
@@ -40,6 +45,16 @@ export const ChatBlastWithAudienceCTA = (
 ) => {
   const { audience } = props
   const messages = getMessages(audience)
+  const { data: currentUserId } = useCurrentUserId()
+
+  const followersUserId = useSelector(followersUserListSelectors.getId)
+  const supportersUserId = useSelector(topSupportersUserListSelectors.getId)
+  const targetUserId =
+    audience === ChatBlastAudience.FOLLOWERS
+      ? followersUserId
+      : supportersUserId
+
+  const isOwner = currentUserId === targetUserId
 
   const dispatch = useDispatch()
   const handlePress = useCallback(() => {
@@ -47,7 +62,7 @@ export const ChatBlastWithAudienceCTA = (
   }, [audience, dispatch])
 
   const userMeetsRequirements = useCanSendChatBlast()
-  if (!userMeetsRequirements || !messages) {
+  if (!userMeetsRequirements || !messages || !isOwner) {
     return null
   }
 

--- a/packages/web/src/pages/chat-page/components/ChatBlastWithAudienceCTA.tsx
+++ b/packages/web/src/pages/chat-page/components/ChatBlastWithAudienceCTA.tsx
@@ -1,7 +1,12 @@
 import { useCallback } from 'react'
 
+import { useCurrentUserId } from '@audius/common/api'
 import { useCanSendChatBlast } from '@audius/common/hooks'
-import { chatActions } from '@audius/common/store'
+import {
+  chatActions,
+  followersUserListSelectors,
+  topSupportersUserListSelectors
+} from '@audius/common/store'
 import {
   Box,
   Flex,
@@ -11,7 +16,7 @@ import {
   useTheme
 } from '@audius/harmony'
 import { ChatBlastAudience } from '@audius/sdk'
-import { useDispatch } from 'react-redux'
+import { useDispatch, useSelector } from 'react-redux'
 
 const { createChatBlast } = chatActions
 
@@ -41,6 +46,18 @@ export const ChatBlastWithAudienceCTA = (
   const { audience, onClick } = props
   const messages = getMessages(audience)
   const { color } = useTheme()
+  const { data: currentUserId } = useCurrentUserId()
+
+  // Get the userId based on the audience type
+  const followersUserId = useSelector(followersUserListSelectors.getId)
+  const supportersUserId = useSelector(topSupportersUserListSelectors.getId)
+  const targetUserId =
+    audience === ChatBlastAudience.FOLLOWERS
+      ? followersUserId
+      : supportersUserId
+
+  // Check if the current user is the profile owner
+  const isOwner = currentUserId === targetUserId
 
   const dispatch = useDispatch()
   const handleClick = useCallback(() => {
@@ -49,7 +66,8 @@ export const ChatBlastWithAudienceCTA = (
   }, [audience, dispatch, onClick])
 
   const userMeetsRequirements = useCanSendChatBlast()
-  if (!userMeetsRequirements || !messages) {
+  // Only show if the user can send blast messages and is the profile owner
+  if (!userMeetsRequirements || !messages || !isOwner) {
     return null
   }
 

--- a/packages/web/src/pages/chat-page/components/ChatBlastWithAudienceCTA.tsx
+++ b/packages/web/src/pages/chat-page/components/ChatBlastWithAudienceCTA.tsx
@@ -48,7 +48,6 @@ export const ChatBlastWithAudienceCTA = (
   const { color } = useTheme()
   const { data: currentUserId } = useCurrentUserId()
 
-  // Get the userId based on the audience type
   const followersUserId = useSelector(followersUserListSelectors.getId)
   const supportersUserId = useSelector(topSupportersUserListSelectors.getId)
   const targetUserId =
@@ -56,7 +55,6 @@ export const ChatBlastWithAudienceCTA = (
       ? followersUserId
       : supportersUserId
 
-  // Check if the current user is the profile owner
   const isOwner = currentUserId === targetUserId
 
   const dispatch = useDispatch()
@@ -66,7 +64,6 @@ export const ChatBlastWithAudienceCTA = (
   }, [audience, dispatch, onClick])
 
   const userMeetsRequirements = useCanSendChatBlast()
-  // Only show if the user can send blast messages and is the profile owner
   if (!userMeetsRequirements || !messages || !isOwner) {
     return null
   }


### PR DESCRIPTION
### Description
The check for if the current user is the owner of the modal was accidentally removed.

### How Has This Been Tested?

<img width="767" alt="Screenshot 2025-04-08 at 5 13 40 PM" src="https://github.com/user-attachments/assets/0a3a08cf-03c9-47c1-b3b6-ab8912e488de" />

<img width="875" alt="Screenshot 2025-04-08 at 5 13 31 PM" src="https://github.com/user-attachments/assets/51a8c18b-35c6-40f6-8a82-4741617443af" />
