### PR TITLE
[PE-5941] Prefetch supporters on comments page

### DIFF
--- a/packages/common/src/context/comments/commentsContext.tsx
+++ b/packages/common/src/context/comments/commentsContext.tsx
@@ -18,7 +18,8 @@ import {
   useTrackComments,
   QUERY_KEYS,
   useTrackCommentCount,
-  resetPreviousCommentCount
+  resetPreviousCommentCount,
+  useSupporters
 } from '~/api'
 import { useGatedContentAccess } from '~/hooks'
 import {
@@ -106,6 +107,11 @@ export function CommentSectionProvider<NavigationProp>(
     lineupActions
   } = props
   const { data: track } = useGetTrackById({ id: entityId })
+  const trackOwnerId = track?.owner_id
+
+  // Prefetch the track owner's supporters
+  useSupporters({ userId: trackOwnerId })
+
   const {
     analytics: { make, track: trackEvent }
   } = useAppContext()

--- a/packages/mobile/src/components/comments/CommentBadge.tsx
+++ b/packages/mobile/src/components/comments/CommentBadge.tsx
@@ -34,10 +34,14 @@ export const CommentBadge = ({
   isArtist
 }: CommentBadgeProps) => {
   const { artistId } = useCurrentCommentSection()
-  const { data: supporter } = useSupporter({
-    userId: artistId,
-    supporterUserId: commentUserId
-  })
+  const { data: supporter } = useSupporter(
+    {
+      userId: artistId,
+      supporterUserId: commentUserId
+    },
+    // Read only, relying on prefetch in commentsContext
+    { enabled: false }
+  )
 
   const isTopSupporter = supporter?.rank === 1
 

--- a/packages/web/src/components/comments/CommentBadge.tsx
+++ b/packages/web/src/components/comments/CommentBadge.tsx
@@ -33,10 +33,14 @@ export const CommentBadge = ({
   isArtist
 }: CommentBadgeProps) => {
   const { artistId } = useCurrentCommentSection()
-  const { data: supporter } = useSupporter({
-    userId: artistId,
-    supporterUserId: commentUserId
-  })
+  const { data: supporter } = useSupporter(
+    {
+      userId: artistId,
+      supporterUserId: commentUserId
+    },
+    // Read only, relying on prefetch in commentsContext
+    { enabled: false }
+  )
 
   const isTopSupporter = supporter?.rank === 1
 


### PR DESCRIPTION
### Description

Prefetches top 20 supporters for a track owner to pre-seed the "tip-supporters" ui. This prevents requests for every comment to get supporters