### PR TITLE
Randomly use rendezvous nodes

### DIFF
--- a/packages/discovery-provider/src/queries/query_helpers.py
+++ b/packages/discovery-provider/src/queries/query_helpers.py
@@ -2,6 +2,7 @@
 import enum
 import json
 import logging
+import random
 import re
 from collections import defaultdict
 from typing import List, Optional, Tuple, TypedDict
@@ -732,6 +733,8 @@ def get_content_url_with_mirrors(
             f"helpers.py | get_content_url_with_mirrors | No Content Nodes found for CID {cid}"
         )
         return {"url": None, "mirrors": []}
+
+    random.shuffle(content_nodes)
 
     # Add additional query parameters
     joined_url = urljoin(content_nodes[0], path)


### PR DESCRIPTION
### Description

Instead of trying only the 1st response in rendezvous, randomly sort them so we spread out across multiple nodes.
Also clean up old logic and try to make stream signatures make a bit more sense.

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._

Tested manually on discovery 3 staging.

Hit the same endpoint and got different cn results
