### PR TITLE
(hotfix) Revert tan-query selector in audioplayer

### DIFF
--- a/packages/mobile/src/components/audio/AudioPlayer.tsx
+++ b/packages/mobile/src/components/audio/AudioPlayer.tsx
@@ -5,6 +5,7 @@ import { Name } from '@audius/common/models'
 import type { Track } from '@audius/common/models'
 import {
   accountSelectors,
+  cacheUsersSelectors,
   cacheTracksSelectors,
   savedPageTracksLineupActions,
   queueActions,
@@ -69,6 +70,7 @@ export const DEFAULT_IMAGE_URL =
   'https://download.audius.co/static-resources/preview-image.jpg'
 
 const { getUserId } = accountSelectors
+const { getUsers } = cacheUsersSelectors
 const { getTracks } = cacheTracksSelectors
 const {
   getPlaying,
@@ -207,7 +209,10 @@ export const AudioPlayer = () => {
     .map(({ track }) => track?.owner_id)
     .filter(removeNullable)
 
-  const { byId: queueTrackOwnersMap } = useUsers(queueTrackOwnerIds)
+  const queueTrackOwnersMap = useSelector(
+    (state) => getUsers(state, { ids: queueTrackOwnerIds }),
+    shallowCompare
+  )
 
   const isCollectionMarkedForDownload = useSelector(
     getIsCollectionMarkedForDownload(

--- a/packages/mobile/src/components/audio/AudioPlayer.tsx
+++ b/packages/mobile/src/components/audio/AudioPlayer.tsx
@@ -1,6 +1,5 @@
 import { useRef, useEffect, useCallback, useState } from 'react'
 
-import { useUsers } from '@audius/common/api'
 import { Name } from '@audius/common/models'
 import type { Track } from '@audius/common/models'
 import {


### PR DESCRIPTION
### Description

Hotfixes a mobile player bug where the queue gets stuck on the same song.

The issue here was caused by this tan-query selector going havoc - unclear underlying issue to solve here (will dig into that separately).

For now just reverting the selector to get us hotfixed

### How Has This Been Tested?

ios:stage sim
