### PR TITLE
Fix mobile reward banner padding

### DIFF
--- a/packages/mobile/src/components/audio-rewards/RewardsBanner.tsx
+++ b/packages/mobile/src/components/audio-rewards/RewardsBanner.tsx
@@ -50,7 +50,7 @@ export const RewardsBanner = (props: RewardsBannerProps) => {
         end={color.special.gradient.start}
         style={{ width: '100%', borderRadius: 8 }}
       >
-        <Flex direction='column' alignItems='center' style={{ padding: 16 }}>
+        <Flex direction='column' alignItems='center' ph='l' pv='m'>
           <Flex direction='row' alignItems='center' gap='xs'>
             <IconCrown size='s' color='staticWhite' />
             <Text variant='title' size='s' color='staticWhite'>


### PR DESCRIPTION
### Description

Small improvement to rewards banner padding:

Before:
<img width="514" alt="image" src="https://github.com/user-attachments/assets/897cd02e-4674-4090-bbf5-3d70cd9dd862" />

After:

<img width="514" alt="image" src="https://github.com/user-attachments/assets/465e60ec-5c35-41cd-8fe8-881c18e68ae7" />
