### PR TITLE
Delete challenges with _ in specifier

### DIFF
--- a/packages/discovery-provider/ddl/migrations/0132_delete_underscore_challenges.sql
+++ b/packages/discovery-provider/ddl/migrations/0132_delete_underscore_challenges.sql
@@ -1,0 +1,5 @@
+begin;
+
+DELETE FROM user_challenges WHERE specifier LIKE '%\_%';
+
+commit;


### PR DESCRIPTION
### Description
Because the [migration PR](https://github.com/AudiusProject/audius-protocol/pull/11768) for converting `_` to `:` went out _after_ the [indexing change](https://github.com/AudiusProject/audius-protocol/pull/11755), we ended up missing some challenges with `_` specifiers because the indexing had already created their `:` counterparts.

Originally these 2 PRs were supposed to go out together, but I ended up reverting the migration because of a bug.

In the future, the migration and indexing change should be in the same PR so they always go out together.

### How Has This Been Tested?

Ran this query on a bunch of nodes and checked if there were any unmatched challenges.

```
WITH broken AS (
	SELECT 
		user_id, 
		SPLIT_PART(specifier, '_', 1) || ':' || SPLIT_PART(specifier, '_', 2) AS new_specifier,
		specifier,
		current_step_count,
		is_complete
	FROM user_challenges
	WHERE specifier LIKE '%\_%'
)
SELECT * -- COUNT(*), COUNT(*) FILTER (WHERE user_challenges.user_id IS NULL) AS missing_matches
FROM broken
LEFT JOIN user_challenges ON user_challenges.user_id = broken.user_id AND user_challenges.specifier = broken.new_specifier
;
```