### PR TITLE
Fix TQ lineup issues on mobile

### DIFF
--- a/packages/common/src/api/tan-query/useFeed.ts
+++ b/packages/common/src/api/tan-query/useFeed.ts
@@ -66,6 +66,7 @@ export const useFeed = (
     },
     queryKey: getFeedQueryKey({ userId: currentUserId, filter }),
     queryFn: async ({ pageParam }) => {
+      console.log('pageParam', pageParam)
       const isFirstPage = pageParam === 0
       const currentPageSize = isFirstPage ? initialPageSize : loadMorePageSize
       const sdk = await audiusSdk()
@@ -123,15 +124,18 @@ export const useFeed = (
     enabled: currentUserId !== null
   })
 
-  return useLineupQuery({
-    queryData,
-    queryKey: getFeedQueryKey({
-      userId: currentUserId,
-      filter
+  return {
+    ...useLineupQuery({
+      queryData,
+      queryKey: getFeedQueryKey({
+        userId: currentUserId,
+        filter
+      }),
+      lineupActions: feedPageLineupActions,
+      lineupSelector: feedPageSelectors.getDiscoverFeedLineup,
+      playbackSource: PlaybackSource.TRACK_TILE_LINEUP,
+      pageSize: loadMorePageSize
     }),
-    lineupActions: feedPageLineupActions,
-    lineupSelector: feedPageSelectors.getDiscoverFeedLineup,
-    playbackSource: PlaybackSource.TRACK_TILE_LINEUP,
-    pageSize: loadMorePageSize
-  })
+    initialPageSize
+  }
 }

--- a/packages/common/src/api/tan-query/useFeed.ts
+++ b/packages/common/src/api/tan-query/useFeed.ts
@@ -124,18 +124,16 @@ export const useFeed = (
     enabled: currentUserId !== null
   })
 
-  return {
-    ...useLineupQuery({
-      queryData,
-      queryKey: getFeedQueryKey({
-        userId: currentUserId,
-        filter
-      }),
-      lineupActions: feedPageLineupActions,
-      lineupSelector: feedPageSelectors.getDiscoverFeedLineup,
-      playbackSource: PlaybackSource.TRACK_TILE_LINEUP,
-      pageSize: loadMorePageSize
+  return useLineupQuery({
+    queryData,
+    queryKey: getFeedQueryKey({
+      userId: currentUserId,
+      filter
     }),
+    lineupActions: feedPageLineupActions,
+    lineupSelector: feedPageSelectors.getDiscoverFeedLineup,
+    playbackSource: PlaybackSource.TRACK_TILE_LINEUP,
+    pageSize: loadMorePageSize,
     initialPageSize
-  }
+  })
 }

--- a/packages/common/src/api/tan-query/useFeed.ts
+++ b/packages/common/src/api/tan-query/useFeed.ts
@@ -66,7 +66,6 @@ export const useFeed = (
     },
     queryKey: getFeedQueryKey({ userId: currentUserId, filter }),
     queryFn: async ({ pageParam }) => {
-      console.log('pageParam', pageParam)
       const isFirstPage = pageParam === 0
       const currentPageSize = isFirstPage ? initialPageSize : loadMorePageSize
       const sdk = await audiusSdk()

--- a/packages/common/src/api/tan-query/useTrending.ts
+++ b/packages/common/src/api/tan-query/useTrending.ts
@@ -170,17 +170,20 @@ export const useTrending = (
       lineupSelector = getDiscoverTrendingWeekLineup
       break
   }
-  return useLineupQuery({
-    queryData: infiniteQueryData,
-    queryKey: getTrendingQueryKey({
-      timeRange,
-      genre,
-      initialPageSize,
-      loadMorePageSize
+  return {
+    ...useLineupQuery({
+      queryData: infiniteQueryData,
+      queryKey: getTrendingQueryKey({
+        timeRange,
+        genre,
+        initialPageSize,
+        loadMorePageSize
+      }),
+      lineupActions,
+      lineupSelector,
+      playbackSource: PlaybackSource.TRACK_TILE_LINEUP,
+      pageSize: loadMorePageSize
     }),
-    lineupActions,
-    lineupSelector,
-    playbackSource: PlaybackSource.TRACK_TILE_LINEUP,
-    pageSize: loadMorePageSize
-  })
+    initialPageSize
+  }
 }

--- a/packages/common/src/api/tan-query/useTrending.ts
+++ b/packages/common/src/api/tan-query/useTrending.ts
@@ -170,20 +170,18 @@ export const useTrending = (
       lineupSelector = getDiscoverTrendingWeekLineup
       break
   }
-  return {
-    ...useLineupQuery({
-      queryData: infiniteQueryData,
-      queryKey: getTrendingQueryKey({
-        timeRange,
-        genre,
-        initialPageSize,
-        loadMorePageSize
-      }),
-      lineupActions,
-      lineupSelector,
-      playbackSource: PlaybackSource.TRACK_TILE_LINEUP,
-      pageSize: loadMorePageSize
+  return useLineupQuery({
+    queryData: infiniteQueryData,
+    queryKey: getTrendingQueryKey({
+      timeRange,
+      genre,
+      initialPageSize,
+      loadMorePageSize
     }),
+    lineupActions,
+    lineupSelector,
+    playbackSource: PlaybackSource.TRACK_TILE_LINEUP,
+    pageSize: loadMorePageSize,
     initialPageSize
-  }
+  })
 }

--- a/packages/common/src/api/tan-query/utils/useLineupQuery.ts
+++ b/packages/common/src/api/tan-query/utils/useLineupQuery.ts
@@ -1,4 +1,4 @@
-import { useEffect } from 'react'
+import { useEffect, useCallback } from 'react'
 
 import { EntityType } from '@audius/sdk'
 import {
@@ -150,6 +150,10 @@ export const useLineupQuery = ({
     queryData.isFetching ? Status.LOADING : Status.SUCCESS,
     lineup.status
   ])
+  const refresh = useCallback(() => {
+    dispatch(lineupActions.reset())
+    queryClient.resetQueries({ queryKey })
+  }, [dispatch, lineupActions, queryClient, queryKey])
 
   return {
     status,
@@ -164,6 +168,7 @@ export const useLineupQuery = ({
           ? queryData.hasNextPage
           : false
     },
+    refresh,
     togglePlay,
     play,
     pause,

--- a/packages/common/src/api/tan-query/utils/useLineupQuery.ts
+++ b/packages/common/src/api/tan-query/utils/useLineupQuery.ts
@@ -42,7 +42,8 @@ export const useLineupQuery = ({
   lineupActions,
   lineupSelector,
   playbackSource,
-  pageSize
+  pageSize,
+  initialPageSize
 }: {
   // Lineup related props
   queryData: UseInfiniteQueryResult<LineupData[]>
@@ -53,6 +54,7 @@ export const useLineupQuery = ({
     LineupState<LineupTrack | Track | Collection>
   >
   pageSize: number
+  initialPageSize?: number
   playbackSource: PlaybackSource
 }) => {
   const { reportToSentry } = useAudiusQueryContext()
@@ -174,6 +176,7 @@ export const useLineupQuery = ({
     pause,
     updateLineupOrder,
     isPlaying,
+    initialPageSize,
     pageSize,
     // pass through specific queryData props
     //   this avoids spreading all queryData props which causes extra renders

--- a/packages/mobile/src/components/lineup/TanQueryLineup.tsx
+++ b/packages/mobile/src/components/lineup/TanQueryLineup.tsx
@@ -1,0 +1,548 @@
+import type { ReactElement } from 'react'
+import { memo, useCallback, useMemo, useRef } from 'react'
+
+import type { LineupData as LineupQueryData } from '@audius/common/api'
+import { useDebouncedCallback } from '@audius/common/hooks'
+import type { ID, Lineup as LineupData } from '@audius/common/models'
+import { Kind } from '@audius/common/models'
+import type { CommonState, LineupBaseActions } from '@audius/common/store'
+import { useFocusEffect } from '@react-navigation/native'
+import { range } from 'lodash'
+import type {
+  SectionList as RNSectionList,
+  SectionListProps,
+  ViewStyle
+} from 'react-native'
+import { StyleSheet, View } from 'react-native'
+import { useDispatch } from 'react-redux'
+
+import { SectionList } from 'app/components/core'
+import {
+  CollectionTile,
+  TrackTile,
+  LineupTileSkeleton
+} from 'app/components/lineup-tile'
+import { useScrollToTop } from 'app/hooks/useScrollToTop'
+
+import { Delineator } from './Delineator'
+import type {
+  LoadingLineupItem,
+  LineupItem,
+  LineupItemTileProps,
+  LineupTileViewProps,
+  TogglePlayConfig
+} from './types'
+import { LineupVariant } from './types'
+
+// The inital multiplier for number of tracks to fetch on lineup load
+// multiplied by the number of tracks that fit the screen height
+export const INITIAL_LOAD_TRACKS_MULTIPLIER = 3
+export const INITIAL_PLAYLISTS_MULTIPLER = 2
+
+// Threshold for how far away from the bottom (of the list) the user has to be
+// before fetching more tracks as a percentage of the list height
+const LOAD_MORE_THRESHOLD = 0.5
+
+const styles = StyleSheet.create({
+  root: {
+    flex: 1
+  },
+  item: {
+    padding: 16,
+    paddingBottom: 0
+  }
+})
+
+type Section = {
+  delineate: boolean
+  hasLeadingElement?: boolean
+  title?: string
+  data: Array<LineupItem | LoadingLineupItem>
+}
+
+const getLineupTileComponent = (item: LineupItem) => {
+  if (item.kind === Kind.TRACKS || item.track_id) {
+    if (item._marked_deleted) {
+      return null
+    }
+    return TrackTile
+  } else if (item.kind === Kind.COLLECTIONS || item.playlist_id) {
+    return CollectionTile
+  }
+  return null
+}
+
+const SkeletonTrackTileView = memo(function SkeletonTrackTileView(props: {
+  itemStyles?: ViewStyle
+}) {
+  const { itemStyles } = props
+  return (
+    <View style={[styles.item, itemStyles]}>
+      <LineupTileSkeleton />
+    </View>
+  )
+})
+
+const LineupTileView = memo(function LineupTileView({
+  item,
+  index,
+  isTrending,
+  leadingElementId,
+  rankIconCount,
+  togglePlay,
+  onPress,
+  itemStyles,
+  actions
+}: LineupTileViewProps) {
+  const TrackOrCollectionTile = getLineupTileComponent(item)
+
+  if (TrackOrCollectionTile) {
+    return (
+      <View
+        style={{
+          ...styles.item,
+          ...itemStyles
+        }}
+      >
+        <TrackOrCollectionTile
+          {...item}
+          id={item.id}
+          index={index}
+          isTrending={isTrending}
+          togglePlay={togglePlay}
+          onPress={onPress}
+          uid={item.uid}
+          actions={actions}
+        />
+      </View>
+    )
+  } else {
+    return null
+  }
+})
+
+// Using `memo` because FlatList renders these items
+// And we want to avoid a full render when the props haven't changed
+const LineupItemTile = memo(function LineupItemTile({
+  item,
+  index,
+  isTrending,
+  leadingElementId,
+  rankIconCount,
+  togglePlay,
+  onPress,
+  itemStyles,
+  actions
+}: LineupItemTileProps) {
+  if (!item) return null
+  if ('_loading' in item) {
+    if (item._loading) {
+      return <SkeletonTrackTileView itemStyles={itemStyles} />
+    }
+  } else {
+    return (
+      <LineupTileView
+        item={item}
+        index={index}
+        isTrending={isTrending}
+        leadingElementId={leadingElementId}
+        rankIconCount={rankIconCount}
+        togglePlay={togglePlay}
+        onPress={onPress}
+        itemStyles={itemStyles}
+        actions={actions}
+      />
+    )
+  }
+  return null
+})
+
+export type LineupProps = {
+  /** Object containing lineup actions such as setPage */
+  actions: LineupBaseActions
+
+  /** The maximum number of total tracks to fetch */
+  count?: number
+
+  /**
+   * Whether or not to delineate the lineup by time of the `activityTimestamp`
+   */
+  delineate?: boolean
+
+  /**
+   * Do not scroll to top of lineup when containing tab navigator tab is pressed
+   */
+  disableTopTabScroll?: boolean
+
+  /**
+   * Optional payload to pass to the fetch action
+   */
+  fetchPayload?: any
+
+  /**
+   * Extra fetch payload (merged in with fetch action) used to pass extra information to lineup actions/reducers/sagas
+   */
+  extraFetchOptions?: Record<string, unknown>
+
+  /**
+   * When `true` hide the header when the lineup is empty
+   */
+  hideHeaderOnEmpty?: boolean
+
+  /**
+   * A header to display at the top of the lineup,
+   * will scroll with the rest of the content
+   */
+  header?: SectionListProps<unknown>['ListHeaderComponent']
+
+  /**
+   * An optional component to render when the lineup has no contents
+   * in it.
+   */
+  LineupEmptyComponent?: SectionListProps<unknown>['ListEmptyComponent']
+
+  /** Are we in a trending lineup? Allows tiles to specialize their rendering */
+  isTrending?: boolean
+
+  /**
+   * When `true` lineup waits until visible before fetching.
+   * This is especcially needed for lineups inside collapsible-tab-view
+   * which do not support tab-navigator lazy mode
+   */
+  lazy?: boolean
+
+  /**
+   * Indicator if a track should be displayed differently (ie. artist pick)
+   * The leadingElementId is displayed at the top of the lineup
+   */
+  leadingElementId?: ID | null
+
+  /**
+   * A custom delineator to show after the leading element
+   */
+  leadingElementDelineator?: ReactElement
+
+  /** The number of tracks to fetch in each request */
+  limit?: number
+
+  /**
+   * The Lineup object containing entries
+   */
+  lineup: LineupData<LineupItem>
+
+  /**
+   * The Lineup selector, allowing the lineup to select lineup itself
+   */
+  lineupSelector?: (state: CommonState) => LineupData<LineupItem>
+
+  /**
+   * Function called to load more entries
+   */
+  loadMore?: (offset: number, limit: number, overwrite: boolean) => void
+
+  /**
+   * Function called on refresh
+   */
+  refresh?: () => void
+
+  /**
+   * Boolean indicating if currently fetching data for a refresh
+   * Must be provided if `refresh` is provided
+   */
+  refreshing?: boolean
+
+  /**
+   * How many icons to show for top ranked entries in the lineup. Defaults to 0, showing none
+   */
+  rankIconCount?: number
+
+  /**
+   * Is the lineup responsible for initially fetching it's own data
+   */
+  selfLoad?: boolean
+
+  /**
+   * Which item to start the lineup at (previous items will not be rendered)
+   */
+  start?: number
+
+  /**
+   * The variant of the Lineup
+   */
+  variant?: LineupVariant
+
+  /**
+   * Uniquely identifies Lineup's SectionList. Needed if rendered inside
+   * another VirtualizedList.
+   */
+  listKey?: string
+
+  /**
+   * When `true` don't load more while lineup status is `LOADING`.
+   * This helps prevent collisions with any in-flight loading from web-app
+   */
+  includeLineupStatus?: boolean
+  /**
+   * When `true`, add pull-to-refresh capability
+   */
+  pullToRefresh?: boolean
+
+  /**
+   * Function called when item is pressed
+   */
+  onPressItem?: (id: ID) => void
+
+  /**
+   * Styles to apply to the items, can be used to override the padding for example
+   */
+  itemStyles?: ViewStyle
+
+  // Tan query props
+  pageSize?: number
+  initialPageSize?: number
+  isFetching: boolean
+  loadNextPage: () => void
+  hasMore: boolean
+  isPending: boolean
+  queryData?: LineupQueryData[] | undefined
+} & Pick<
+  SectionListProps<unknown>,
+  | 'showsVerticalScrollIndicator'
+  | 'ListEmptyComponent'
+  | 'ListFooterComponent'
+  | 'keyboardShouldPersistTaps'
+>
+
+/** `Lineup` encapsulates the logic for displaying a list of items such as Tracks (e.g. prefetching items
+ * displaying loading states, etc).
+ */
+export const TanQueryLineup = ({
+  actions,
+  count,
+  delineate,
+  disableTopTabScroll,
+  fetchPayload,
+  header,
+  hideHeaderOnEmpty,
+  isTrending,
+  lazy,
+  leadingElementId,
+  leadingElementDelineator,
+  lineup,
+  LineupEmptyComponent,
+  loadNextPage,
+  hasMore,
+  pullToRefresh,
+  rankIconCount = 0,
+  refresh,
+  start = 0,
+  variant = LineupVariant.MAIN,
+  listKey,
+  selfLoad,
+  includeLineupStatus,
+  limit = Infinity,
+  extraFetchOptions,
+  ListFooterComponent,
+  onPressItem,
+  itemStyles,
+  initialPageSize,
+  pageSize,
+  isFetching,
+  isPending,
+  queryData = [],
+  ...listProps
+}: LineupProps) => {
+  const debouncedLoadNextPage = useDebouncedCallback(
+    () => {
+      loadNextPage()
+    },
+    [loadNextPage],
+    100
+  )
+  const dispatch = useDispatch()
+  const ref = useRef<RNSectionList>(null)
+
+  // There is unfortunately a gap between queryData existing and the data making its way into the lineup
+  const isLineupPending = queryData.length !== lineup.entries.length
+
+  const isEmpty =
+    !(isPending || isLineupPending) && !isFetching && queryData.length === 0
+
+  const handleRefresh = () => {
+    refresh?.()
+  }
+
+  const handleInView = useCallback(() => {
+    dispatch(actions.setInView(true))
+  }, [dispatch, actions])
+
+  useFocusEffect(handleInView)
+
+  const togglePlay = useCallback(
+    ({ uid, id, source }: TogglePlayConfig) => {
+      dispatch(actions.togglePlay(uid, id, source))
+    },
+    [actions, dispatch]
+  )
+
+  const renderItem = useCallback(
+    ({
+      index,
+      item
+    }: {
+      index: number
+      item: LineupItem | LoadingLineupItem
+    }) => {
+      return (
+        <LineupItemTile
+          index={index}
+          item={item}
+          isTrending={isTrending}
+          leadingElementId={leadingElementId}
+          rankIconCount={rankIconCount}
+          togglePlay={togglePlay}
+          onPress={onPressItem}
+          itemStyles={itemStyles}
+          actions={actions}
+        />
+      )
+    },
+    [
+      isTrending,
+      leadingElementId,
+      rankIconCount,
+      togglePlay,
+      onPressItem,
+      itemStyles,
+      actions
+    ]
+  )
+
+  // Calculate the sections of data to provide to SectionList
+  const sections: Section[] = useMemo(() => {
+    const entries = lineup.entries
+
+    // Apply offset and maxEntries to the lineup entries
+    const items =
+      count !== undefined
+        ? entries.slice(start, start + count)
+        : entries.slice(start)
+
+    const getSkeletonCount = () => {
+      // No skeletons if not fetching
+      if (!isFetching && !isLineupPending) {
+        return 0
+      }
+      // Lineups like Feed load a different number of items on the first page
+      if (initialPageSize && isPending) {
+        return initialPageSize
+      }
+      if (pageSize) {
+        return count ? Math.min(count, pageSize) : pageSize
+      }
+      return 0
+    }
+
+    const skeletonItems = range(getSkeletonCount()).map(
+      () => ({ _loading: true }) as LoadingLineupItem
+    )
+
+    if (leadingElementId) {
+      const [artistPick, ...restEntries] = [...items, ...skeletonItems]
+
+      const result: Section[] = [
+        { delineate: false, data: [artistPick] },
+        { delineate: true, data: restEntries, hasLeadingElement: true }
+      ]
+      return result
+    }
+
+    const data = [...items, ...skeletonItems]
+
+    if (data.length === 0) {
+      return []
+    }
+
+    return [{ delineate: false, data }]
+  }, [
+    lineup.entries,
+    count,
+    start,
+    leadingElementId,
+    isFetching,
+    isLineupPending,
+    initialPageSize,
+    isPending,
+    pageSize
+  ])
+
+  const scrollToTop = useCallback(() => {
+    if (!isEmpty) {
+      ref.current?.scrollToLocation({
+        sectionIndex: 0,
+        itemIndex: 0,
+        animated: true
+      })
+    }
+  }, [isEmpty])
+
+  useScrollToTop(scrollToTop, disableTopTabScroll)
+
+  const handleScroll = useCallback(
+    ({ nativeEvent }) => {
+      const { layoutMeasurement, contentOffset, contentSize } = nativeEvent
+      if (
+        layoutMeasurement.height + contentOffset.y >=
+        contentSize.height - LOAD_MORE_THRESHOLD * layoutMeasurement.height
+      ) {
+        if (!isFetching && hasMore) {
+          debouncedLoadNextPage()
+        }
+      }
+    },
+    [debouncedLoadNextPage, isFetching, hasMore]
+  )
+
+  const pullToRefreshProps = pullToRefresh
+    ? // Need to disable refresh so scrolling the "ListEmptyComponent" doesn't trigger refresh
+      {
+        onRefresh: isEmpty ? undefined : handleRefresh,
+        refreshing: isPending || isLineupPending
+      }
+    : {}
+
+  const handleEndReached = useCallback(
+    () => debouncedLoadNextPage(),
+    [debouncedLoadNextPage]
+  )
+
+  return (
+    <View style={styles.root}>
+      <SectionList
+        {...listProps}
+        {...pullToRefreshProps}
+        ref={ref}
+        onScroll={handleScroll}
+        ListHeaderComponent={hideHeaderOnEmpty && isEmpty ? undefined : header}
+        ListFooterComponent={lineup.hasMore ? null : ListFooterComponent}
+        ListEmptyComponent={LineupEmptyComponent}
+        onEndReached={handleEndReached}
+        onEndReachedThreshold={LOAD_MORE_THRESHOLD}
+        sections={isEmpty ? [] : sections}
+        stickySectionHeadersEnabled={false}
+        keyExtractor={(item, index) => `${item?.id}-${index}`}
+        renderItem={renderItem}
+        renderSectionHeader={({ section }) => {
+          if (section.delineate) {
+            if (section.hasLeadingElement && leadingElementDelineator) {
+              return leadingElementDelineator
+            }
+            return <Delineator text={section.title} />
+          }
+          return null
+        }}
+        scrollIndicatorInsets={{ right: Number.MIN_VALUE }}
+      />
+    </View>
+  )
+}

--- a/packages/mobile/src/components/lineup/types.ts
+++ b/packages/mobile/src/components/lineup/types.ts
@@ -168,6 +168,9 @@ export type LineupProps = {
   pageSize?: number
   initialPageSize?: number
   tanQuery?: boolean
+  isFetching?: boolean
+  // TODO:
+  queryData?: any
 } & Pick<
   SectionListProps<unknown>,
   | 'showsVerticalScrollIndicator'

--- a/packages/mobile/src/screens/feed-screen/FeedScreen.tsx
+++ b/packages/mobile/src/screens/feed-screen/FeedScreen.tsx
@@ -11,7 +11,6 @@ import { useSelector } from 'react-redux'
 
 import { IconFeed } from '@audius/harmony-native'
 import { Screen, ScreenContent, ScreenHeader } from 'app/components/core'
-import { Lineup } from 'app/components/lineup'
 import { EndOfLineupNotice } from 'app/components/lineup/EndOfLineupNotice'
 import { TanQueryLineup } from 'app/components/lineup/TanQueryLineup'
 import { OnlineOnly } from 'app/components/offline-placeholder/OnlineOnly'

--- a/packages/mobile/src/screens/feed-screen/FeedScreen.tsx
+++ b/packages/mobile/src/screens/feed-screen/FeedScreen.tsx
@@ -13,6 +13,7 @@ import { IconFeed } from '@audius/harmony-native'
 import { Screen, ScreenContent, ScreenHeader } from 'app/components/core'
 import { Lineup } from 'app/components/lineup'
 import { EndOfLineupNotice } from 'app/components/lineup/EndOfLineupNotice'
+import { TanQueryLineup } from 'app/components/lineup/TanQueryLineup'
 import { OnlineOnly } from 'app/components/offline-placeholder/OnlineOnly'
 import { SuggestedFollows } from 'app/components/suggested-follows'
 import { useAppTabScreen } from 'app/hooks/useAppTabScreen'
@@ -34,7 +35,17 @@ export const FeedScreen = () => {
 
   const feedFilter = useSelector(getFeedFilter)
   const { data: currentUserId } = useCurrentUserId()
-  const { lineup, loadNextPage } = useFeed({
+  const {
+    data,
+    lineup,
+    loadNextPage,
+    pageSize,
+    isFetching,
+    refresh: refreshQuery,
+    isPending,
+    hasNextPage,
+    initialPageSize
+  } = useFeed({
     filter: feedFilter,
     userId: currentUserId
   })
@@ -55,8 +66,7 @@ export const FeedScreen = () => {
         </OnlineOnly>
       </ScreenHeader>
       <ScreenContent>
-        <Lineup
-          tanQuery
+        <TanQueryLineup
           lineup={lineup}
           pullToRefresh
           delineate
@@ -70,6 +80,14 @@ export const FeedScreen = () => {
           lineupSelector={getFeedLineup}
           loadMore={loadMore}
           showsVerticalScrollIndicator={false}
+          isFetching={isFetching}
+          loadNextPage={loadNextPage}
+          hasMore={hasNextPage}
+          isPending={isPending}
+          queryData={data}
+          initialPageSize={initialPageSize}
+          pageSize={pageSize}
+          refresh={refreshQuery}
         />
       </ScreenContent>
     </Screen>

--- a/packages/mobile/src/screens/profile-screen/ProfileScreen.tsx
+++ b/packages/mobile/src/screens/profile-screen/ProfileScreen.tsx
@@ -1,5 +1,9 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
 
+import {
+  getProfileRepostsQueryKey,
+  getProfileTracksQueryKey
+} from '@audius/common/api'
 import { ShareSource, Status } from '@audius/common/models'
 import {
   profilePageActions,
@@ -14,6 +18,7 @@ import {
 import { encodeUrlName } from '@audius/common/utils'
 import { PortalHost } from '@gorhom/portal'
 import { useFocusEffect, useNavigationState } from '@react-navigation/native'
+import { useQueryClient } from '@tanstack/react-query'
 import { Animated, View } from 'react-native'
 import { useDispatch, useSelector } from 'react-redux'
 
@@ -68,6 +73,7 @@ export const ProfileScreen = () => {
   const [isRefreshing, setIsRefreshing] = useState(false)
   const isNotReachable = useSelector(getIsReachable) === false
   const isScreenReady = useIsScreenReady()
+  const queryClient = useQueryClient()
 
   const setCurrentUser = useCallback(() => {
     dispatch(setCurrentUserAction(handleLower))
@@ -117,6 +123,11 @@ export const ProfileScreen = () => {
       fetchProfile()
       switch (currentTab) {
         case ProfilePageTabs.TRACKS:
+          queryClient.resetQueries({
+            queryKey: getProfileTracksQueryKey({
+              handle: handleLower
+            })
+          })
           dispatch(
             profilePageTracksLineupActions.refreshInView(
               true,
@@ -127,6 +138,11 @@ export const ProfileScreen = () => {
           )
           break
         case ProfilePageTabs.REPOSTS:
+          queryClient.resetQueries({
+            queryKey: getProfileRepostsQueryKey({
+              handle: handleLower
+            })
+          })
           dispatch(
             profilePageFeedLineupActions.refreshInView(
               true,
@@ -138,7 +154,7 @@ export const ProfileScreen = () => {
           break
       }
     }
-  }, [profile, fetchProfile, currentTab, dispatch, handleLower])
+  }, [profile, fetchProfile, currentTab, queryClient, handleLower, dispatch])
 
   useEffect(() => {
     if (status === Status.SUCCESS) {

--- a/packages/mobile/src/screens/profile-screen/ProfileTabs/RepostsTab.tsx
+++ b/packages/mobile/src/screens/profile-screen/ProfileTabs/RepostsTab.tsx
@@ -4,8 +4,9 @@ import { useProfileReposts } from '@audius/common/api'
 import { Status } from '@audius/common/models'
 import { profilePageFeedLineupActions as feedActions } from '@audius/common/store'
 import { useRoute } from '@react-navigation/native'
+import { useDispatch } from 'react-redux'
 
-import { Lineup } from 'app/components/lineup'
+import { TanQueryLineup } from 'app/components/lineup/TanQueryLineup'
 
 import { EmptyProfileTile } from '../EmptyProfileTile'
 import type { ProfileTabRoutes } from '../routes'
@@ -20,7 +21,16 @@ export const RepostsTab = () => {
     'repost_count'
   ])
 
-  const { lineup, loadNextPage } = useProfileReposts({ handle })
+  const {
+    data,
+    isFetching,
+    isPending,
+    lineup,
+    loadNextPage,
+    pageSize,
+    refresh: refreshQuery,
+    hasNextPage
+  } = useProfileReposts({ handle })
 
   const fetchPayload = useMemo(() => ({ userId: user_id }), [user_id])
   const extraFetchOptions = useMemo(() => ({ handle }), [handle])
@@ -29,13 +39,11 @@ export const RepostsTab = () => {
   const canShowEmptyTile = repost_count === 0 || lineup.status !== Status.IDLE
 
   return (
-    <Lineup
+    <TanQueryLineup
       selfLoad
       lazy={lazy}
       pullToRefresh
-      loadMore={loadNextPage}
       actions={feedActions}
-      lineup={lineup}
       fetchPayload={fetchPayload}
       extraFetchOptions={extraFetchOptions}
       limit={repost_count}
@@ -44,7 +52,15 @@ export const RepostsTab = () => {
         canShowEmptyTile ? <EmptyProfileTile tab='reposts' /> : undefined
       }
       showsVerticalScrollIndicator={false}
-      tanQuery
+      // Tan query props
+      loadNextPage={loadNextPage}
+      hasMore={hasNextPage}
+      pageSize={pageSize}
+      queryData={data}
+      isFetching={isFetching}
+      isPending={isPending}
+      lineup={lineup}
+      refresh={refreshQuery}
     />
   )
 }

--- a/packages/mobile/src/screens/profile-screen/ProfileTabs/RepostsTab.tsx
+++ b/packages/mobile/src/screens/profile-screen/ProfileTabs/RepostsTab.tsx
@@ -4,7 +4,6 @@ import { useProfileReposts } from '@audius/common/api'
 import { Status } from '@audius/common/models'
 import { profilePageFeedLineupActions as feedActions } from '@audius/common/store'
 import { useRoute } from '@react-navigation/native'
-import { useDispatch } from 'react-redux'
 
 import { TanQueryLineup } from 'app/components/lineup/TanQueryLineup'
 

--- a/packages/mobile/src/screens/profile-screen/ProfileTabs/TracksTab.tsx
+++ b/packages/mobile/src/screens/profile-screen/ProfileTabs/TracksTab.tsx
@@ -2,7 +2,6 @@ import { useMemo } from 'react'
 
 import { useProfileTracks } from '@audius/common/api'
 import { profilePageTracksLineupActions as tracksActions } from '@audius/common/store'
-import { useDispatch } from 'react-redux'
 
 import { TanQueryLineup } from 'app/components/lineup/TanQueryLineup'
 

--- a/packages/mobile/src/screens/profile-screen/ProfileTabs/TracksTab.tsx
+++ b/packages/mobile/src/screens/profile-screen/ProfileTabs/TracksTab.tsx
@@ -2,8 +2,9 @@ import { useMemo } from 'react'
 
 import { useProfileTracks } from '@audius/common/api'
 import { profilePageTracksLineupActions as tracksActions } from '@audius/common/store'
+import { useDispatch } from 'react-redux'
 
-import { Lineup } from 'app/components/lineup'
+import { TanQueryLineup } from 'app/components/lineup/TanQueryLineup'
 
 import { EmptyProfileTile } from '../EmptyProfileTile'
 import { useSelectProfile } from '../selectors'
@@ -14,26 +15,43 @@ export const TracksTab = () => {
     'user_id',
     'artist_pick_track_id'
   ])
-
-  const { lineup, loadNextPage } = useProfileTracks({ handle })
+  const {
+    data,
+    lineup,
+    loadNextPage,
+    pageSize,
+    isFetching,
+    refresh: refreshQuery,
+    isPending,
+    hasNextPage
+  } = useProfileTracks({
+    handle
+  })
 
   const fetchPayload = useMemo(() => ({ userId: user_id }), [user_id])
   const extraFetchOptions = useMemo(() => ({ handle }), [handle])
 
   return (
-    <Lineup
+    <TanQueryLineup
       selfLoad
       pullToRefresh
       leadingElementId={artist_pick_track_id}
       actions={tracksActions}
       lineup={lineup}
-      tanQuery
       loadMore={loadNextPage}
       fetchPayload={fetchPayload}
       extraFetchOptions={extraFetchOptions}
       disableTopTabScroll
       LineupEmptyComponent={<EmptyProfileTile tab='tracks' />}
       showsVerticalScrollIndicator={false}
+      // Tan query props
+      pageSize={pageSize}
+      isFetching={isFetching}
+      isPending={isPending}
+      queryData={data}
+      loadNextPage={loadNextPage}
+      hasMore={hasNextPage}
+      refresh={refreshQuery}
     />
   )
 }

--- a/packages/mobile/src/screens/trending-screen/TrendingLineup.tsx
+++ b/packages/mobile/src/screens/trending-screen/TrendingLineup.tsx
@@ -11,7 +11,7 @@ import {
 import { useNavigation } from '@react-navigation/native'
 import { useDispatch } from 'react-redux'
 
-import { Lineup } from 'app/components/lineup'
+import { TanQueryLineup } from 'app/components/lineup/TanQueryLineup'
 import type { LineupProps } from 'app/components/lineup/types'
 import { make, track } from 'app/services/analytics'
 const {
@@ -60,7 +60,17 @@ export const TrendingLineup = (props: TrendingLineupProps) => {
   const dispatch = useDispatch()
   const trendingActions = actionsMap[timeRange]
 
-  const { lineup, loadNextPage } = useTrending({ timeRange })
+  const {
+    data,
+    lineup,
+    loadNextPage,
+    pageSize,
+    isFetching,
+    refresh: refreshQuery,
+    isPending,
+    hasNextPage,
+    initialPageSize
+  } = useTrending({ timeRange })
 
   useEffect(() => {
     // @ts-ignore tabPress is not a valid event, and wasn't able to figure out a fix
@@ -80,9 +90,8 @@ export const TrendingLineup = (props: TrendingLineupProps) => {
   )
 
   return (
-    <Lineup
+    <TanQueryLineup
       isTrending
-      tanQuery
       lineup={lineup}
       loadMore={handleLoadMore}
       selfLoad
@@ -90,6 +99,14 @@ export const TrendingLineup = (props: TrendingLineupProps) => {
       lineupSelector={selectorsMap[timeRange]}
       actions={trendingActions}
       {...other}
+      isFetching={isFetching}
+      loadNextPage={loadNextPage}
+      hasMore={hasNextPage}
+      isPending={isPending}
+      queryData={data}
+      pageSize={pageSize}
+      refresh={refreshQuery}
+      initialPageSize={initialPageSize}
     />
   )
 }


### PR DESCRIPTION
### Description

Found issues with pagination skeletons & refreshing. 
I started with just patching in logic into `Lineup` and it got kind of convoluted so I started fresh with a new `TanQueryLineup` component like we have on web.

### How Has This Been Tested?

ios:stage - specifically feed/trending/profile tracks/reposts - tested infinite skeletons, refresh, playback, etc
