### PR TITLE
[API-41] Clean up old trending versions add query idx

### DIFF
--- a/packages/discovery-provider/ddl/migrations/0132_trending_cleanup.sql
+++ b/packages/discovery-provider/ddl/migrations/0132_trending_cleanup.sql
@@ -1,0 +1,9 @@
+begin;
+
+delete from track_trending_scores where version != 'pnagD';
+
+create index ix_trending_scores
+on track_trending_scores (type, version, time_range, score desc)
+include (track_id);
+
+commit;

--- a/packages/discovery-provider/ddl/migrations/0132_trending_cleanup.sql
+++ b/packages/discovery-provider/ddl/migrations/0132_trending_cleanup.sql
@@ -1,9 +1,0 @@
-begin;
-
-delete from track_trending_scores where version != 'pnagD';
-
-create index ix_trending_scores
-on track_trending_scores (type, version, time_range, score desc)
-include (track_id);
-
-commit;

--- a/packages/discovery-provider/ddl/migrations/0133_trending_cleanup.sql
+++ b/packages/discovery-provider/ddl/migrations/0133_trending_cleanup.sql
@@ -1,0 +1,8 @@
+begin;
+
+delete from track_trending_scores where version != 'pnagD';
+
+create index if not exists ix_trending_scores
+on track_trending_scores (type, version, time_range, score desc, track_id);
+
+commit;


### PR DESCRIPTION
### Description

Only active version is `pnagD` so delete old rows, see https://github.com/AudiusProject/audius-protocol/blob/ecac2ccc0233d242e7b2f2e3408c744f8bdf3d97/packages/discovery-provider/src/trending_strategies/trending_type_and_version.py#L10

Add idx to support queries like this
```sql
       SELECT track_id
	FROM track_trending_scores
	WHERE type = 'TRACKS'
		AND version = 'pnagD'
		AND time_range = 'week'
	ORDER BY
		score DESC,
		track_id DESC
	LIMIT @limit
	OFFSET @offset
```

the include(track_id) makes it an index only scan, nice!

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._

Prod discovery 1, apidiff tool in bridgerton