### PR TITLE
Revert tq-lineups

### DIFF
--- a/packages/mobile/src/screens/feed-screen/FeedScreen.tsx
+++ b/packages/mobile/src/screens/feed-screen/FeedScreen.tsx
@@ -1,25 +1,24 @@
 import { useCallback } from 'react'
 
-import { useFeed, useCurrentUserId } from '@audius/common/api'
 import { Name } from '@audius/common/models'
 import {
   lineupSelectors,
   feedPageLineupActions as feedActions,
   feedPageSelectors
 } from '@audius/common/store'
-import { useSelector } from 'react-redux'
+import { useDispatch } from 'react-redux'
 
 import { IconFeed } from '@audius/harmony-native'
 import { Screen, ScreenContent, ScreenHeader } from 'app/components/core'
+import { Lineup } from 'app/components/lineup'
 import { EndOfLineupNotice } from 'app/components/lineup/EndOfLineupNotice'
-import { TanQueryLineup } from 'app/components/lineup/TanQueryLineup'
 import { OnlineOnly } from 'app/components/offline-placeholder/OnlineOnly'
 import { SuggestedFollows } from 'app/components/suggested-follows'
 import { useAppTabScreen } from 'app/hooks/useAppTabScreen'
 import { make, track } from 'app/services/analytics'
 
 import { FeedFilterButton } from './FeedFilterButton'
-const { getDiscoverFeedLineup, getFeedFilter } = feedPageSelectors
+const { getDiscoverFeedLineup } = feedPageSelectors
 const { makeGetLineupMetadatas } = lineupSelectors
 
 const getFeedLineup = makeGetLineupMetadatas(getDiscoverFeedLineup)
@@ -32,29 +31,14 @@ const messages = {
 export const FeedScreen = () => {
   useAppTabScreen()
 
-  const feedFilter = useSelector(getFeedFilter)
-  const { data: currentUserId } = useCurrentUserId()
-  const {
-    data,
-    lineup,
-    loadNextPage,
-    pageSize,
-    isFetching,
-    refresh: refreshQuery,
-    isPending,
-    hasNextPage,
-    initialPageSize
-  } = useFeed({
-    filter: feedFilter,
-    userId: currentUserId
-  })
+  const dispatch = useDispatch()
 
   const loadMore = useCallback(
     (offset: number, limit: number, overwrite: boolean) => {
-      loadNextPage()
+      dispatch(feedActions.fetchLineupMetadatas(offset, limit, overwrite))
       track(make({ eventName: Name.FEED_PAGINATE, offset, limit }))
     },
-    [loadNextPage]
+    [dispatch]
   )
 
   return (
@@ -65,8 +49,7 @@ export const FeedScreen = () => {
         </OnlineOnly>
       </ScreenHeader>
       <ScreenContent>
-        <TanQueryLineup
-          lineup={lineup}
+        <Lineup
           pullToRefresh
           delineate
           selfLoad
@@ -79,14 +62,6 @@ export const FeedScreen = () => {
           lineupSelector={getFeedLineup}
           loadMore={loadMore}
           showsVerticalScrollIndicator={false}
-          isFetching={isFetching}
-          loadNextPage={loadNextPage}
-          hasMore={hasNextPage}
-          isPending={isPending}
-          queryData={data}
-          initialPageSize={initialPageSize}
-          pageSize={pageSize}
-          refresh={refreshQuery}
         />
       </ScreenContent>
     </Screen>

--- a/packages/mobile/src/screens/profile-screen/ProfileTabs/RepostsTab.tsx
+++ b/packages/mobile/src/screens/profile-screen/ProfileTabs/RepostsTab.tsx
@@ -1,15 +1,20 @@
 import { useMemo } from 'react'
 
-import { useProfileReposts } from '@audius/common/api'
+import { useProxySelector } from '@audius/common/hooks'
 import { Status } from '@audius/common/models'
-import { profilePageFeedLineupActions as feedActions } from '@audius/common/store'
+import {
+  profilePageFeedLineupActions as feedActions,
+  profilePageSelectors
+} from '@audius/common/store'
 import { useRoute } from '@react-navigation/native'
 
-import { TanQueryLineup } from 'app/components/lineup/TanQueryLineup'
+import { Lineup } from 'app/components/lineup'
 
 import { EmptyProfileTile } from '../EmptyProfileTile'
 import type { ProfileTabRoutes } from '../routes'
 import { useSelectProfile } from '../selectors'
+
+const { getProfileFeedLineup } = profilePageSelectors
 
 export const RepostsTab = () => {
   const { params } = useRoute<ProfileTabRoutes<'Reposts'>>()
@@ -20,16 +25,10 @@ export const RepostsTab = () => {
     'repost_count'
   ])
 
-  const {
-    data,
-    isFetching,
-    isPending,
-    lineup,
-    loadNextPage,
-    pageSize,
-    refresh: refreshQuery,
-    hasNextPage
-  } = useProfileReposts({ handle })
+  const lineup = useProxySelector(
+    (state) => getProfileFeedLineup(state, handle),
+    [handle]
+  )
 
   const fetchPayload = useMemo(() => ({ userId: user_id }), [user_id])
   const extraFetchOptions = useMemo(() => ({ handle }), [handle])
@@ -38,11 +37,12 @@ export const RepostsTab = () => {
   const canShowEmptyTile = repost_count === 0 || lineup.status !== Status.IDLE
 
   return (
-    <TanQueryLineup
+    <Lineup
       selfLoad
       lazy={lazy}
       pullToRefresh
       actions={feedActions}
+      lineup={lineup}
       fetchPayload={fetchPayload}
       extraFetchOptions={extraFetchOptions}
       limit={repost_count}
@@ -51,15 +51,6 @@ export const RepostsTab = () => {
         canShowEmptyTile ? <EmptyProfileTile tab='reposts' /> : undefined
       }
       showsVerticalScrollIndicator={false}
-      // Tan query props
-      loadNextPage={loadNextPage}
-      hasMore={hasNextPage}
-      pageSize={pageSize}
-      queryData={data}
-      isFetching={isFetching}
-      isPending={isPending}
-      lineup={lineup}
-      refresh={refreshQuery}
     />
   )
 }

--- a/packages/mobile/src/screens/profile-screen/ProfileTabs/TracksTab.tsx
+++ b/packages/mobile/src/screens/profile-screen/ProfileTabs/TracksTab.tsx
@@ -1,12 +1,17 @@
 import { useMemo } from 'react'
 
-import { useProfileTracks } from '@audius/common/api'
-import { profilePageTracksLineupActions as tracksActions } from '@audius/common/store'
+import { useProxySelector } from '@audius/common/hooks'
+import {
+  profilePageTracksLineupActions as tracksActions,
+  profilePageSelectors
+} from '@audius/common/store'
 
-import { TanQueryLineup } from 'app/components/lineup/TanQueryLineup'
+import { Lineup } from 'app/components/lineup'
 
 import { EmptyProfileTile } from '../EmptyProfileTile'
 import { useSelectProfile } from '../selectors'
+
+const { getProfileTracksLineup } = profilePageSelectors
 
 export const TracksTab = () => {
   const { handle, user_id, artist_pick_track_id } = useSelectProfile([
@@ -14,43 +19,29 @@ export const TracksTab = () => {
     'user_id',
     'artist_pick_track_id'
   ])
-  const {
-    data,
-    lineup,
-    loadNextPage,
-    pageSize,
-    isFetching,
-    refresh: refreshQuery,
-    isPending,
-    hasNextPage
-  } = useProfileTracks({
-    handle
-  })
+
+  const handleLower = handle.toLowerCase()
+
+  const lineup = useProxySelector(
+    (state) => getProfileTracksLineup(state, handleLower),
+    [handleLower]
+  )
 
   const fetchPayload = useMemo(() => ({ userId: user_id }), [user_id])
   const extraFetchOptions = useMemo(() => ({ handle }), [handle])
 
   return (
-    <TanQueryLineup
+    <Lineup
       selfLoad
       pullToRefresh
       leadingElementId={artist_pick_track_id}
       actions={tracksActions}
       lineup={lineup}
-      loadMore={loadNextPage}
       fetchPayload={fetchPayload}
       extraFetchOptions={extraFetchOptions}
       disableTopTabScroll
       LineupEmptyComponent={<EmptyProfileTile tab='tracks' />}
       showsVerticalScrollIndicator={false}
-      // Tan query props
-      pageSize={pageSize}
-      isFetching={isFetching}
-      isPending={isPending}
-      queryData={data}
-      loadNextPage={loadNextPage}
-      hasMore={hasNextPage}
-      refresh={refreshQuery}
     />
   )
 }

--- a/packages/mobile/src/screens/trending-screen/TrendingLineup.tsx
+++ b/packages/mobile/src/screens/trending-screen/TrendingLineup.tsx
@@ -1,6 +1,5 @@
 import { useCallback, useEffect } from 'react'
 
-import { useTrending } from '@audius/common/api'
 import { Name, TimeRange } from '@audius/common/models'
 import {
   lineupSelectors,
@@ -11,7 +10,7 @@ import {
 import { useNavigation } from '@react-navigation/native'
 import { useDispatch } from 'react-redux'
 
-import { TanQueryLineup } from 'app/components/lineup/TanQueryLineup'
+import { Lineup } from 'app/components/lineup'
 import type { LineupProps } from 'app/components/lineup/types'
 import { make, track } from 'app/services/analytics'
 const {
@@ -60,18 +59,6 @@ export const TrendingLineup = (props: TrendingLineupProps) => {
   const dispatch = useDispatch()
   const trendingActions = actionsMap[timeRange]
 
-  const {
-    data,
-    lineup,
-    loadNextPage,
-    pageSize,
-    isFetching,
-    refresh: refreshQuery,
-    isPending,
-    hasNextPage,
-    initialPageSize
-  } = useTrending({ timeRange })
-
   useEffect(() => {
     // @ts-ignore tabPress is not a valid event, and wasn't able to figure out a fix
     const tabPressListener = navigation.addListener('tabPress', () => {
@@ -83,30 +70,21 @@ export const TrendingLineup = (props: TrendingLineupProps) => {
 
   const handleLoadMore = useCallback(
     (offset: number, limit: number, overwrite: boolean) => {
-      loadNextPage()
+      dispatch(trendingActions.fetchLineupMetadatas(offset, limit, overwrite))
       track(make({ eventName: Name.TRENDING_PAGINATE, offset, limit }))
     },
-    [loadNextPage]
+    [dispatch, trendingActions]
   )
 
   return (
-    <TanQueryLineup
+    <Lineup
       isTrending
-      lineup={lineup}
-      loadMore={handleLoadMore}
       selfLoad
       pullToRefresh
       lineupSelector={selectorsMap[timeRange]}
       actions={trendingActions}
+      loadMore={handleLoadMore}
       {...other}
-      isFetching={isFetching}
-      loadNextPage={loadNextPage}
-      hasMore={hasNextPage}
-      isPending={isPending}
-      queryData={data}
-      pageSize={pageSize}
-      refresh={refreshQuery}
-      initialPageSize={initialPageSize}
     />
   )
 }

--- a/packages/web/src/common/store/pages/feed/lineup/sagas.ts
+++ b/packages/web/src/common/store/pages/feed/lineup/sagas.ts
@@ -1,12 +1,113 @@
-import { Kind, Collection, LineupTrack } from '@audius/common/models'
 import {
+  transformAndCleanList,
+  userFeedItemFromSDK
+} from '@audius/common/adapters'
+import {
+  FeedFilter,
+  Kind,
+  Collection,
+  UserCollectionMetadata,
+  ID,
+  TrackMetadata,
+  LineupTrack
+} from '@audius/common/models'
+import {
+  accountSelectors,
   feedPageLineupActions as feedActions,
-  CommonState
+  feedPageSelectors,
+  CommonState,
+  getSDK
 } from '@audius/common/store'
+import { Id, full } from '@audius/sdk'
+import { all, call, select } from 'typed-redux-saga'
 
+import { processAndCacheCollections } from 'common/store/cache/collections/utils'
+import { processAndCacheTracks } from 'common/store/cache/tracks/utils'
 import { LineupSagas } from 'common/store/lineup/sagas'
+import { waitForRead } from 'utils/sagaHelpers'
+
+import { getFollowIds } from '../../signon/selectors'
+const { getFeedFilter } = feedPageSelectors
+const { getUserId } = accountSelectors
 
 type FeedItem = LineupTrack | Collection
+
+const filterMap: { [k in FeedFilter]: full.GetUserFeedFilterEnum } = {
+  [FeedFilter.ALL]: 'all',
+  [FeedFilter.ORIGINAL]: 'original',
+  [FeedFilter.REPOST]: 'repost'
+}
+
+function* getTracks({
+  offset,
+  limit
+}: {
+  offset: number
+  limit: number
+}): Generator<any, FeedItem[] | null, any> {
+  yield* waitForRead()
+  const currentUserId = yield* select(getUserId)
+  if (!currentUserId) return []
+  const filterEnum: FeedFilter = yield* select(getFeedFilter)
+  const sdk = yield* getSDK()
+  const filter = filterMap[filterEnum]
+
+  // If the user has followee user ids set, use those to fetch the feed.
+  // It implies that the feed is otherwise going to be empty so we give a
+  // hint to the API.
+  const followeeUserIds = yield* select(getFollowIds)
+
+  const userId = Id.parse(currentUserId)
+  const { data = [] } = yield* call(
+    [sdk.full.users, sdk.full.users.getUserFeed],
+    {
+      id: userId,
+      userId,
+      filter,
+      limit,
+      offset,
+      followeeUserId: followeeUserIds.length ? followeeUserIds : undefined,
+      withUsers: true
+    }
+  )
+  const feed = transformAndCleanList(data, userFeedItemFromSDK).map(
+    ({ item }) => item
+  )
+  if (feed === null) return null
+  const filteredFeed = feed.filter((record) => !record.user.is_deactivated)
+  const [tracks, collections] = getTracksAndCollections(filteredFeed)
+
+  // Process (e.g. cache and remove entries)
+  const [processedTracks, processedCollections] = (yield* all([
+    processAndCacheTracks(tracks),
+    processAndCacheCollections(collections, false)
+  ])) as [LineupTrack[], Collection[]]
+  const processedTracksMap = processedTracks.reduce<Record<ID, LineupTrack>>(
+    (acc, cur) => ({ ...acc, [cur.track_id]: cur }),
+    {}
+  )
+  const processedCollectionsMap = processedCollections.reduce<
+    Record<ID, Collection>
+  >((acc, cur) => ({ ...acc, [cur.playlist_id]: cur }), {})
+  const processedFeed: FeedItem[] = filteredFeed.map((m) =>
+    (m as LineupTrack).track_id
+      ? processedTracksMap[(m as LineupTrack).track_id]
+      : processedCollectionsMap[(m as UserCollectionMetadata).playlist_id]
+  )
+
+  return processedFeed
+}
+
+const getTracksAndCollections = (
+  feed: Array<TrackMetadata | UserCollectionMetadata>
+) =>
+  feed.reduce<[LineupTrack[], UserCollectionMetadata[]]>(
+    (acc, cur) =>
+      (cur as LineupTrack).track_id
+        ? [[...acc[0], cur as LineupTrack], acc[1]]
+        : [acc[0], [...acc[1], cur as UserCollectionMetadata]],
+    [[], []]
+  )
 
 const keepActivityTimeStamp = (
   entry: (LineupTrack | Collection) & { uid: string } // LineupSaga adds a UID to each entry
@@ -23,7 +124,7 @@ class FeedSagas extends LineupSagas<FeedItem> {
       feedActions.prefix,
       feedActions,
       (store: CommonState) => store.pages.feed.feed,
-      ({ payload }) => payload?.items,
+      getTracks,
       keepActivityTimeStamp,
       undefined,
       undefined

--- a/packages/web/src/common/store/pages/profile/lineups/feed/sagas.js
+++ b/packages/web/src/common/store/pages/profile/lineups/feed/sagas.js
@@ -1,18 +1,92 @@
 import { Kind } from '@audius/common/models'
 import {
+  accountSelectors,
+  cacheCollectionsSelectors,
+  cacheTracksSelectors,
   profilePageFeedLineupActions as feedActions,
   profilePageSelectors,
   collectionsSocialActions,
   tracksSocialActions,
-  accountSelectors
+  confirmerSelectors
 } from '@audius/common/store'
-import { makeUid } from '@audius/common/utils'
-import { select, takeEvery, put } from 'redux-saga/effects'
+import {
+  makeUid,
+  getIdFromKindId,
+  getKindFromKindId
+} from '@audius/common/utils'
+import { select, call, takeEvery, put } from 'redux-saga/effects'
 
 import { LineupSagas } from 'common/store/lineup/sagas'
+import { waitForRead } from 'utils/sagaHelpers'
 
+import { retrieveUserReposts } from './retrieveUserReposts'
 const { getProfileUserId, getProfileFeedLineup } = profilePageSelectors
-const { getUserHandle } = accountSelectors
+const { getTracks } = cacheTracksSelectors
+const { getCollections } = cacheCollectionsSelectors
+const { getUserId, getUserHandle } = accountSelectors
+const { getConfirmCalls } = confirmerSelectors
+
+function* getReposts({ offset, limit, handle }) {
+  yield waitForRead()
+
+  const profileId = yield select((state) => getProfileUserId(state, handle))
+
+  const currentUserId = yield select(getUserId)
+  let reposts = yield call(retrieveUserReposts, {
+    handle,
+    currentUserId,
+    offset,
+    limit
+  })
+
+  // If we're on our own profile, add any
+  // tracks or collections that haven't confirmed yet.
+  // Only do this on page 1 of the reposts tab
+  if (profileId === currentUserId && offset === 0) {
+    // Get everything that is confirming
+    const confirming = yield select(getConfirmCalls)
+    if (Object.keys(confirming).length > 0) {
+      const repostTrackIds = new Set(
+        reposts.map((r) => r.track_id).filter(Boolean)
+      )
+      const repostCollectionIds = new Set(
+        reposts.map((r) => r.playlist_id).filter(Boolean)
+      )
+
+      const tracks = yield select(getTracks)
+      const collections = yield select(getCollections)
+
+      // For each confirming entry, check if it's a track or collection,
+      // then check if we have reposted/favorited it, and check to make
+      // sure we're not already getting back that same track or collection from the
+      // backend.
+      // If we aren't, this is an unconfirmed repost, prepend it to the lineup.
+      Object.keys(confirming).forEach((kindId) => {
+        const kind = getKindFromKindId(kindId)
+        const id = getIdFromKindId(kindId)
+        if (kind === Kind.TRACKS) {
+          const track = tracks[id]
+          if (
+            track.has_current_user_reposted &&
+            !repostTrackIds.has(track.track_id)
+          ) {
+            reposts = [track, ...reposts]
+          }
+        } else if (kind === Kind.COLLECTIONS) {
+          const collection = collections[id]
+          if (
+            collection.has_current_user_reposted &&
+            !repostCollectionIds.has(collection.playlist_id)
+          ) {
+            reposts = [collection, ...reposts]
+          }
+        }
+      })
+    }
+  }
+
+  return reposts
+}
 
 const sourceSelector = (state, handle) =>
   `${feedActions.prefix}:${getProfileUserId(state, handle)}`
@@ -23,9 +97,7 @@ class FeedSagas extends LineupSagas {
       feedActions.prefix,
       feedActions,
       getProfileFeedLineup,
-      function* (action) {
-        return action.payload.items
-      },
+      getReposts,
       undefined,
       undefined,
       sourceSelector

--- a/packages/web/src/pages/feed-page/components/mobile/FeedPageContent.tsx
+++ b/packages/web/src/pages/feed-page/components/mobile/FeedPageContent.tsx
@@ -1,29 +1,19 @@
 import { useContext, useEffect } from 'react'
 
-import {
-  FEED_LOAD_MORE_PAGE_SIZE,
-  FEED_INITIAL_PAGE_SIZE,
-  useFeed,
-  useCurrentUserId
-} from '@audius/common/api'
 import { Name, FeedFilter } from '@audius/common/models'
-import { getUid } from '@audius/common/src/store/player/selectors'
 import { feedPageLineupActions as feedActions } from '@audius/common/store'
 import { route } from '@audius/common/utils'
 import cn from 'classnames'
-import { useSelector } from 'react-redux'
 
 import { useModalState } from 'common/hooks/useModalState'
 import { make, useRecord } from 'common/store/analytics/actions'
 import Header from 'components/header/mobile/Header'
 import { HeaderContext } from 'components/header/mobile/HeaderContextProvider'
-import { TanQueryLineup } from 'components/lineup/TanQueryLineup'
+import Lineup from 'components/lineup/Lineup'
 import MobilePageContainer from 'components/mobile-page-container/MobilePageContainer'
 import { useMainPageHeader } from 'components/nav/mobile/NavContext'
 import { FeedPageContentProps } from 'pages/feed-page/types'
 import { BASE_URL } from 'utils/route'
-
-import EmptyFeed from '../EmptyFeed'
 
 import Filters from './FeedFilterButton'
 import FeedFilterDrawer from './FeedFilterDrawer'
@@ -38,31 +28,19 @@ const messages = {
 const FeedPageMobileContent = ({
   feedTitle,
   feedDescription,
+  feed,
+  setFeedInView,
+  loadMoreFeed,
+  playFeedTrack,
+  pauseFeedTrack,
+  getLineupProps,
   feedFilter,
-  setFeedFilter
+  setFeedFilter,
+  refreshFeedInView,
+  resetFeedLineup
 }: FeedPageContentProps) => {
-  const playingUid = useSelector(getUid)
   const { setHeader } = useContext(HeaderContext)
   const [modalIsOpen, setModalIsOpen] = useModalState('FeedFilter')
-
-  const { data: currentUserId } = useCurrentUserId()
-  const {
-    data,
-    isFetching,
-    isPending,
-    isError,
-    hasNextPage,
-    play,
-    pause,
-    loadNextPage,
-    isPlaying,
-    lineup
-  } = useFeed({
-    userId: currentUserId,
-    filter: feedFilter,
-    initialPageSize: FEED_INITIAL_PAGE_SIZE,
-    loadMorePageSize: FEED_LOAD_MORE_PAGE_SIZE
-  })
 
   useEffect(() => {
     setHeader(
@@ -81,10 +59,28 @@ const FeedPageMobileContent = ({
   // Set Nav-Bar Menu
   useMainPageHeader()
 
+  const lineupProps = {
+    ordered: true,
+    ...getLineupProps(feed),
+    loadMore: (offset: number, limit: number, overwrite: boolean) =>
+      loadMoreFeed(offset, limit, overwrite),
+    setInView: setFeedInView,
+    playTrack: playFeedTrack,
+    pauseTrack: pauseFeedTrack,
+    actions: feedActions,
+    delineate: true
+  }
+
   const record = useRecord()
   const handleSelectFilter = (filter: FeedFilter) => {
     setModalIsOpen(false)
     setFeedFilter(filter)
+    // Clear the lineup
+    resetFeedLineup()
+    // Tell the store that the feed is still in view so it can be refetched
+    setFeedInView(true)
+    // Force a refresh for at least 10 tiles
+    refreshFeedInView(true, 10)
     record(make(Name.FEED_CHANGE_VIEW, { view: filter }))
   }
 
@@ -102,27 +98,10 @@ const FeedPageMobileContent = ({
       />
       <div
         className={cn(styles.lineupContainer, {
-          [styles.playing]: !!playingUid
+          [styles.playing]: !!lineupProps.playingUid
         })}
       >
-        <TanQueryLineup
-          data={data}
-          isFetching={isFetching}
-          isPending={isPending}
-          isError={isError}
-          hasNextPage={hasNextPage}
-          play={play}
-          pause={pause}
-          emptyElement={<EmptyFeed />}
-          loadNextPage={loadNextPage}
-          isPlaying={isPlaying}
-          lineup={lineup}
-          ordered
-          actions={feedActions}
-          delineate
-          initialPageSize={FEED_INITIAL_PAGE_SIZE}
-          pageSize={FEED_LOAD_MORE_PAGE_SIZE}
-        />
+        <Lineup {...lineupProps} />
       </div>
     </MobilePageContainer>
   )

--- a/packages/web/src/pages/profile-page/components/mobile/ProfilePage.tsx
+++ b/packages/web/src/pages/profile-page/components/mobile/ProfilePage.tsx
@@ -1,10 +1,6 @@
 import { useEffect, useContext } from 'react'
 
-import {
-  useProfileReposts,
-  useProfileTracks,
-  useUserCollectibles
-} from '@audius/common/api'
+import { useUserCollectibles } from '@audius/common/api'
 import {
   Status,
   Collection,
@@ -33,7 +29,7 @@ import cn from 'classnames'
 
 import CollectiblesPage from 'components/collectibles/components/CollectiblesPage'
 import { HeaderContext } from 'components/header/mobile/HeaderContextProvider'
-import { TanQueryLineup } from 'components/lineup/TanQueryLineup'
+import Lineup from 'components/lineup/Lineup'
 import MobilePageContainer from 'components/mobile-page-container/MobilePageContainer'
 import NavContext, {
   LeftPreset,
@@ -220,107 +216,6 @@ const g = withNullGuard((props: ProfilePageProps) => {
   }
 })
 
-const RepostsTab = ({
-  isOwner,
-  profile,
-  handle
-}: {
-  isOwner: boolean
-  profile: User
-  handle: string
-}) => {
-  const {
-    data,
-    isPending,
-    isFetching,
-    isError,
-    pageSize,
-    hasNextPage,
-    loadNextPage,
-    play,
-    pause,
-    lineup,
-    isPlaying
-  } = useProfileReposts({
-    handle
-  })
-
-  if (profile.repost_count === 0) {
-    return (
-      <EmptyTab
-        message={
-          <>
-            {isOwner
-              ? "You haven't reposted anything yet"
-              : `${profile.name} hasn't reposted anything yet`}
-            <i className={cn('emoji', 'face-with-monocle', styles.emoji)} />
-          </>
-        }
-      />
-    )
-  }
-
-  return (
-    <TanQueryLineup
-      data={data}
-      lineup={lineup}
-      isPlaying={isPlaying}
-      actions={feedActions}
-      isPending={isPending}
-      isFetching={isFetching}
-      isError={isError}
-      pageSize={pageSize}
-      hasNextPage={hasNextPage}
-      loadNextPage={loadNextPage}
-      play={play}
-      pause={pause}
-    />
-  )
-}
-
-const TracksTab = ({
-  profile,
-  handle
-}: {
-  profile: User
-  handle: string
-  isOwner: boolean
-}) => {
-  const {
-    data,
-    isPending,
-    isFetching,
-    isError,
-    pageSize,
-    hasNextPage,
-    loadNextPage,
-    play,
-    pause,
-    lineup,
-    isPlaying
-  } = useProfileTracks({
-    handle
-  })
-
-  return (
-    <TanQueryLineup
-      data={data}
-      isPending={isPending}
-      isFetching={isFetching}
-      isError={isError}
-      pageSize={pageSize}
-      hasNextPage={hasNextPage}
-      loadNextPage={loadNextPage}
-      play={play}
-      pause={pause}
-      leadingElementId={profile.artist_pick_track_id}
-      actions={tracksActions}
-      isPlaying={isPlaying}
-      lineup={lineup}
-    />
-  )
-}
-
 const ProfilePage = g(
   ({
     accountUserId,
@@ -331,6 +226,7 @@ const ProfilePage = g(
     bio,
     location,
     status,
+    collectionStatus,
     isArtist,
     isOwner,
     verified,
@@ -493,7 +389,15 @@ const ProfilePage = g(
                 }
               />
             ) : (
-              <TracksTab profile={profile} handle={handle} isOwner={isOwner} />
+              <Lineup
+                {...getLineupProps(artistTracks)}
+                leadingElementId={profile.artist_pick_track_id}
+                limit={profile.track_count}
+                loadMore={loadMoreArtistTracks}
+                playTrack={playArtistTrack}
+                pauseTrack={pauseArtistTrack}
+                actions={tracksActions}
+              />
             )}
           </div>,
           <div className={styles.cardLineupContainer} key='artistAlbums'>
@@ -515,7 +419,14 @@ const ProfilePage = g(
                 }
               />
             ) : (
-              <RepostsTab isOwner={isOwner} profile={profile} handle={handle} />
+              <Lineup
+                {...getLineupProps(userFeed)}
+                count={profile.repost_count}
+                loadMore={loadMoreUserFeed}
+                playTrack={playUserFeedTrack}
+                pauseTrack={pauseUserFeedTrack}
+                actions={feedActions}
+              />
             )}
           </div>
         ]
@@ -535,7 +446,14 @@ const ProfilePage = g(
                 }
               />
             ) : (
-              <RepostsTab isOwner={isOwner} profile={profile} handle={handle} />
+              <Lineup
+                {...getLineupProps(userFeed)}
+                count={profile.repost_count}
+                loadMore={loadMoreUserFeed}
+                playTrack={playUserFeedTrack}
+                pauseTrack={pauseUserFeedTrack}
+                actions={feedActions}
+              />
             )}
           </div>,
           <div className={styles.cardLineupContainer} key='playlists'>

--- a/packages/web/src/pages/trending-page/components/desktop/TrendingPageContent.tsx
+++ b/packages/web/src/pages/trending-page/components/desktop/TrendingPageContent.tsx
@@ -1,11 +1,6 @@
 import { useCallback, useRef, useState } from 'react'
 
-import {
-  TRENDING_INITIAL_PAGE_SIZE,
-  TRENDING_LOAD_MORE_PAGE_SIZE,
-  useTrending
-} from '@audius/common/api'
-import { Name, TimeRange } from '@audius/common/models'
+import { Name, Status, TimeRange } from '@audius/common/models'
 import { trendingPageLineupActions } from '@audius/common/store'
 import { ELECTRONIC_PREFIX, TRENDING_GENRES } from '@audius/common/utils'
 import { IconTrending } from '@audius/harmony'
@@ -13,7 +8,7 @@ import { IconTrending } from '@audius/harmony'
 import { make, useRecord } from 'common/store/analytics/actions'
 import { Header } from 'components/header/desktop/Header'
 import EndOfLineup from 'components/lineup/EndOfLineup'
-import { TanQueryLineup } from 'components/lineup/TanQueryLineup'
+import Lineup from 'components/lineup/Lineup'
 import { LineupVariant } from 'components/lineup/types'
 import Page from 'components/page/Page'
 import useTabs from 'hooks/useTabs/useTabs'
@@ -42,37 +37,158 @@ const getTimeGenreCacheKey = (timeRange: TimeRange, genre: string | null) => {
   return `${timeRange}-${newGenre}`
 }
 
+// For a given timeRange with no tracks,
+// what other time ranges do we need to disable?
+const getRangesToDisable = (timeRange: TimeRange) => {
+  switch (timeRange) {
+    case TimeRange.ALL_TIME:
+    case TimeRange.MONTH:
+      // In the case of TimeRangeALL_TIME,
+      // we don't want to return ALL_TIME because
+      // we don't want to disable ALL_TIME (it's the only possible tab left, even if it's empty).
+      return [TimeRange.MONTH, TimeRange.WEEK]
+    case TimeRange.WEEK:
+      return [TimeRange.WEEK]
+  }
+}
+
 const TrendingPageContent = (props: TrendingPageContentProps) => {
   const {
     trendingTitle,
     pageTitle,
     trendingDescription,
+    trendingWeek,
+    trendingMonth,
+    trendingAllTime,
+    getLineupProps,
     trendingGenre,
-    setTrendingTimeRange,
     setTrendingGenre,
+    setTrendingTimeRange,
     trendingTimeRange,
+    lastFetchedTrendingGenre,
+    makeLoadMore,
+    makePlayTrack,
+    makePauseTrack,
+    makeSetInView,
+    makeResetTrending,
+    getLineupForRange,
     scrollToTop
   } = props
 
-  const {
-    data,
-    isFetching,
-    isPending,
-    isError,
-    hasNextPage,
-    play,
-    pause,
-    loadNextPage,
-    isPlaying,
-    lineup
-  } = useTrending({
-    timeRange: trendingTimeRange,
-    genre: trendingGenre
-  })
+  const weekProps = getLineupProps(trendingWeek)
+  const monthProps = getLineupProps(trendingMonth)
+  const allTimeProps = getLineupProps(trendingAllTime)
 
   // Maintain a set of combinations of time range & genre that
   // have no tracks.
   const emptyTimeGenreSet = useRef(new Set())
+
+  const getLimit = useCallback(
+    (timeRange: TimeRange) => {
+      return getLineupForRange(timeRange).lineup.total
+    },
+    [getLineupForRange]
+  )
+
+  const reloadAndSwitchTabs = (timeRange: TimeRange) => {
+    makeResetTrending(timeRange)()
+    setTrendingTimeRange(timeRange)
+    scrollToTop(timeRange)
+    const offset = 0
+    makeLoadMore(timeRange)(offset, getLimit(timeRange), true)
+  }
+
+  // Called when we have an empty state
+  const moveToNextTab = () => {
+    switch (trendingTimeRange) {
+      case TimeRange.WEEK: {
+        // If week is empty, month might also be empty (because we accessed it previously.)
+        // If month is also empty, jump straight to all time.
+        const monthAlsoEmpty = emptyTimeGenreSet.current.has(
+          getTimeGenreCacheKey(TimeRange.MONTH, trendingGenre!)
+        )
+        const newTimeRange = monthAlsoEmpty
+          ? TimeRange.ALL_TIME
+          : TimeRange.MONTH
+        reloadAndSwitchTabs(newTimeRange)
+        break
+      }
+      case TimeRange.MONTH:
+        reloadAndSwitchTabs(TimeRange.ALL_TIME)
+        break
+      case TimeRange.ALL_TIME:
+      default:
+      // Nothing to do for all time
+    }
+  }
+
+  const setGenreAndRefresh = useCallback(
+    (genre: string | null) => {
+      const trimmedGenre =
+        genre !== null ? genre.replace(ELECTRONIC_PREFIX, '') : genre
+      setTrendingGenre(trimmedGenre)
+
+      // Call reset to change everything everything to skeleton tiles
+      makeResetTrending(TimeRange.WEEK)()
+      makeResetTrending(TimeRange.MONTH)()
+      makeResetTrending(TimeRange.ALL_TIME)()
+
+      scrollToTop(trendingTimeRange)
+
+      const limit = getLimit(trendingTimeRange)
+      const offset = 0
+      makeLoadMore(trendingTimeRange)(offset, limit, true)
+    },
+    [
+      setTrendingGenre,
+      makeLoadMore,
+      trendingTimeRange,
+      scrollToTop,
+      makeResetTrending,
+      getLimit
+    ]
+  )
+
+  const cacheKey = getTimeGenreCacheKey(trendingTimeRange, trendingGenre)
+  const currentLineup = getLineupForRange(trendingTimeRange)
+
+  // We switch genres slightly before we fetch new lineup metadata, so if we're on a dead page
+  // (e.g. some obscure genre with no All Time tracks), and then switch to a more popular genre
+  // we will briefly be in a state with the New Genre set, but lineup status === Success and an empty
+  // entries list. This would errantly cause us to think the lineup was empty and insert it into the cache.
+  const unfetchedLineup = trendingGenre !== lastFetchedTrendingGenre
+
+  // Should move to next tab if:
+  //  - We've already seen this tab is empty AND we're not in the loading state
+  //  OR
+  //  - The current lineup was the last lineup fetched
+  //    AND
+  //  - The current lineup has finished fetching
+  //    AND
+  //  - The current lineup has no trending order (to ensure we're not in the middle of resetting/refretching)
+  //    AND
+  //  - We're not in the all genres (genre = null) state
+  const shouldMoveToNextTab =
+    (emptyTimeGenreSet.current.has(cacheKey) &&
+      currentLineup.lineup.status !== Status.LOADING) ||
+    (!unfetchedLineup &&
+      currentLineup.lineup.status === Status.SUCCESS &&
+      !currentLineup.lineup.entries.length &&
+      trendingGenre !== null)
+
+  if (shouldMoveToNextTab) {
+    getRangesToDisable(trendingTimeRange)
+      .map((r) => getTimeGenreCacheKey(r, trendingGenre))
+      .forEach((k) => {
+        emptyTimeGenreSet.current.add(k)
+      })
+
+    moveToNextTab()
+  }
+
+  const mainLineupProps = {
+    variant: LineupVariant.MAIN
+  }
 
   const trendingLineups = [
     <div
@@ -84,95 +200,61 @@ const TrendingPageContent = (props: TrendingPageContentProps) => {
           <RewardsBanner bannerType='tracks' />
         </div>
       ) : null}
-      <TanQueryLineup
-        data={data}
-        isFetching={isFetching}
-        isPending={isPending}
-        isError={isError}
-        hasNextPage={hasNextPage}
-        play={play}
-        pause={pause}
-        loadNextPage={loadNextPage}
-        isPlaying={isPlaying}
-        lineup={lineup}
+      <Lineup
         aria-label='weekly trending tracks'
         ordered
-        pageSize={TRENDING_LOAD_MORE_PAGE_SIZE}
-        initialPageSize={TRENDING_INITIAL_PAGE_SIZE}
+        {...weekProps}
+        setInView={makeSetInView(TimeRange.WEEK)}
+        loadMore={makeLoadMore(TimeRange.WEEK)}
+        playTrack={makePlayTrack(TimeRange.WEEK)}
+        pauseTrack={makePauseTrack(TimeRange.WEEK)}
         actions={trendingWeekActions}
-        endOfLineupElement={
+        endOfLineup={
           <EndOfLineup description={messages.endOfLineupDescription} />
         }
-        variant={LineupVariant.MAIN}
+        {...mainLineupProps}
       />
     </div>,
     <div
       key={`monthly-trending-tracks-${trendingGenre}`}
       className={styles.lineupContainer}
     >
-      <TanQueryLineup
+      <Lineup
         aria-label='monthly trending tracks'
         ordered
-        pageSize={TRENDING_LOAD_MORE_PAGE_SIZE}
-        initialPageSize={TRENDING_INITIAL_PAGE_SIZE}
-        actions={trendingMonthActions}
-        data={data}
-        isFetching={isFetching}
-        isPending={isPending}
-        isError={isError}
-        hasNextPage={hasNextPage}
-        play={play}
-        pause={pause}
-        loadNextPage={loadNextPage}
-        isPlaying={isPlaying}
-        lineup={lineup}
-        endOfLineupElement={
+        {...monthProps}
+        setInView={makeSetInView(TimeRange.MONTH)}
+        loadMore={makeLoadMore(TimeRange.MONTH)}
+        playTrack={makePlayTrack(TimeRange.MONTH)}
+        pauseTrack={makePauseTrack(TimeRange.MONTH)}
+        endOfLineup={
           <EndOfLineup description={messages.endOfLineupDescription} />
         }
-        variant={LineupVariant.MAIN}
+        actions={trendingMonthActions}
+        {...mainLineupProps}
       />
     </div>,
     <div
       key={`all-time-trending-tracks-${trendingGenre}`}
       className={styles.lineupContainer}
     >
-      <TanQueryLineup
+      <Lineup
         aria-label='all-time trending tracks'
         ordered
-        pageSize={TRENDING_LOAD_MORE_PAGE_SIZE}
-        initialPageSize={TRENDING_INITIAL_PAGE_SIZE}
+        {...allTimeProps}
+        setInView={makeSetInView(TimeRange.ALL_TIME)}
+        loadMore={makeLoadMore(TimeRange.ALL_TIME)}
+        playTrack={makePlayTrack(TimeRange.ALL_TIME)}
+        pauseTrack={makePauseTrack(TimeRange.ALL_TIME)}
         actions={trendingAllTimeActions}
-        data={data}
-        isFetching={isFetching}
-        isPending={isPending}
-        isError={isError}
-        hasNextPage={hasNextPage}
-        play={play}
-        pause={pause}
-        loadNextPage={loadNextPage}
-        isPlaying={isPlaying}
-        lineup={lineup}
-        endOfLineupElement={
+        endOfLineup={
           <EndOfLineup description={messages.endOfLineupDescription} />
         }
-        variant={LineupVariant.MAIN}
+        {...mainLineupProps}
       />
     </div>
   ]
   const record = useRecord()
-
-  const setGenre = useCallback(
-    (genre: string | null) => {
-      setTrendingGenre(genre)
-      record(
-        make(Name.TRENDING_CHANGE_VIEW, {
-          timeframe: trendingTimeRange,
-          genre: genre || ''
-        })
-      )
-    },
-    [setTrendingGenre, record, trendingTimeRange]
-  )
 
   // Setup tabs
   const didChangeTabs = (from: string, to: string) => {
@@ -217,6 +299,19 @@ const TrendingPageContent = (props: TrendingPageContentProps) => {
     interElementSpacing: 100,
     disabledTabTooltipText: messages.disabledTabTooltip
   })
+
+  const setGenre = useCallback(
+    (genre: string | null) => {
+      setGenreAndRefresh(genre)
+      record(
+        make(Name.TRENDING_CHANGE_VIEW, {
+          timeframe: trendingTimeRange,
+          genre: genre || ''
+        })
+      )
+    },
+    [setGenreAndRefresh, record, trendingTimeRange]
+  )
 
   // Setup Modal
   const [modalIsOpen, setModalIsOpen] = useState(false)

--- a/packages/web/src/pages/trending-page/components/mobile/TrendingPageContent.tsx
+++ b/packages/web/src/pages/trending-page/components/mobile/TrendingPageContent.tsx
@@ -1,10 +1,5 @@
 import { useCallback, useContext, useEffect, useMemo } from 'react'
 
-import {
-  TRENDING_INITIAL_PAGE_SIZE,
-  TRENDING_LOAD_MORE_PAGE_SIZE,
-  useTrending
-} from '@audius/common/api'
 import { Name, TimeRange } from '@audius/common/models'
 import { trendingPageLineupActions } from '@audius/common/store'
 import { route } from '@audius/common/utils'
@@ -19,7 +14,7 @@ import { make, useRecord } from 'common/store/analytics/actions'
 import Header from 'components/header/mobile/Header'
 import { HeaderContext } from 'components/header/mobile/HeaderContextProvider'
 import { EndOfLineup } from 'components/lineup/EndOfLineup'
-import { TanQueryLineup } from 'components/lineup/TanQueryLineup'
+import Lineup from 'components/lineup/Lineup'
 import { LineupVariant } from 'components/lineup/types'
 import MobilePageContainer from 'components/mobile-page-container/MobilePageContainer'
 import NavContext, {
@@ -57,27 +52,21 @@ const tabHeaders = [
 const TrendingPageMobileContent = ({
   pageTitle,
   trendingDescription,
+
   trendingTimeRange,
   setTrendingTimeRange,
+
+  getLineupProps,
+  makePauseTrack,
+  makeLoadMore,
+  makePlayTrack,
+  trendingWeek,
+  trendingMonth,
+  trendingAllTime,
   makeSetInView,
   trendingGenre,
   goToGenreSelection
 }: TrendingPageContentProps) => {
-  const {
-    data,
-    isFetching,
-    isPending,
-    isError,
-    hasNextPage,
-    play,
-    pause,
-    loadNextPage,
-    isPlaying,
-    lineup
-  } = useTrending({
-    timeRange: trendingTimeRange,
-    genre: trendingGenre || undefined
-  })
   // Set Nav-Bar Menu
   const { setLeft, setCenter, setRight } = useContext(NavContext)!
   useEffect(() => {
@@ -85,6 +74,20 @@ const TrendingPageMobileContent = ({
     setRight(RightPreset.SEARCH)
     setCenter(CenterPreset.LOGO)
   }, [setLeft, setCenter, setRight])
+
+  // Setup lineups
+  const weekProps = useMemo(
+    () => getLineupProps(trendingWeek),
+    [getLineupProps, trendingWeek]
+  )
+  const monthProps = useMemo(
+    () => getLineupProps(trendingMonth),
+    [getLineupProps, trendingMonth]
+  )
+  const allTimeProps = useMemo(
+    () => getLineupProps(trendingAllTime),
+    [getLineupProps, trendingAllTime]
+  )
 
   const lineups = useMemo(() => {
     return [
@@ -94,83 +97,59 @@ const TrendingPageMobileContent = ({
             <RewardsBanner bannerType='tracks' />
           </div>
         ) : null}
-        <TanQueryLineup
-          data={data}
-          isFetching={isFetching}
-          isPending={isPending}
-          isError={isError}
-          hasNextPage={hasNextPage}
-          play={play}
-          pause={pause}
-          loadNextPage={loadNextPage}
-          isPlaying={isPlaying}
-          lineup={lineup}
+        <Lineup
           key={`trendingWeek-${trendingGenre}`}
-          pageSize={TRENDING_LOAD_MORE_PAGE_SIZE}
-          initialPageSize={TRENDING_INITIAL_PAGE_SIZE}
+          {...weekProps}
+          setInView={makeSetInView(TimeRange.WEEK)}
+          loadMore={makeLoadMore(TimeRange.WEEK)}
+          playTrack={makePlayTrack(TimeRange.WEEK)}
+          pauseTrack={makePauseTrack(TimeRange.WEEK)}
           actions={trendingWeekActions}
           variant={LineupVariant.MAIN}
           isTrending
-          endOfLineupElement={
+          endOfLineup={
             <EndOfLineup description={messages.endOfLineupDescription} />
           }
         />
       </>,
-      <TanQueryLineup
-        data={data}
-        isFetching={isFetching}
-        isPending={isPending}
-        isError={isError}
-        hasNextPage={hasNextPage}
-        play={play}
-        pause={pause}
-        loadNextPage={loadNextPage}
-        isPlaying={isPlaying}
-        lineup={lineup}
+      <Lineup
         key={`trendingMonth-${trendingGenre}`}
-        pageSize={TRENDING_LOAD_MORE_PAGE_SIZE}
-        initialPageSize={TRENDING_INITIAL_PAGE_SIZE}
+        {...monthProps}
+        setInView={makeSetInView(TimeRange.MONTH)}
+        loadMore={makeLoadMore(TimeRange.MONTH)}
+        playTrack={makePlayTrack(TimeRange.MONTH)}
+        pauseTrack={makePauseTrack(TimeRange.MONTH)}
         actions={trendingMonthActions}
         variant={LineupVariant.MAIN}
         isTrending
-        endOfLineupElement={
+        endOfLineup={
           <EndOfLineup description={messages.endOfLineupDescription} />
         }
       />,
-      <TanQueryLineup
-        data={data}
-        isFetching={isFetching}
-        isPending={isPending}
-        isError={isError}
-        hasNextPage={hasNextPage}
-        play={play}
-        pause={pause}
-        loadNextPage={loadNextPage}
-        isPlaying={isPlaying}
-        lineup={lineup}
+      <Lineup
         key={`trendingAllTime-${trendingGenre}`}
-        pageSize={TRENDING_LOAD_MORE_PAGE_SIZE}
-        initialPageSize={TRENDING_INITIAL_PAGE_SIZE}
+        {...allTimeProps}
+        setInView={makeSetInView(TimeRange.ALL_TIME)}
+        loadMore={makeLoadMore(TimeRange.ALL_TIME)}
+        playTrack={makePlayTrack(TimeRange.ALL_TIME)}
+        pauseTrack={makePauseTrack(TimeRange.ALL_TIME)}
         actions={trendingAllTimeActions}
         variant={LineupVariant.MAIN}
         isTrending
-        endOfLineupElement={
+        endOfLineup={
           <EndOfLineup description={messages.endOfLineupDescription} />
         }
       />
     ]
   }, [
-    trendingGenre,
-    data,
-    isFetching,
-    isPending,
-    isError,
-    hasNextPage,
-    play,
-    pause,
-    loadNextPage,
-    isPlaying,
-    lineup
+    makeLoadMore,
+    makePauseTrack,
+    makePlayTrack,
+    makeSetInView,
+    monthProps,
+    weekProps,
+    allTimeProps,
+    trendingGenre
   ])
   const record = useRecord()
 


### PR DESCRIPTION
### Description

Undoes TQ lineups on Feed/Trending/Profile.
Worried about perf degradation & delaying mobile release behind bugs. 
Will reintroduce soon, ideally after dupe cache has been ironed out.

### How Has This Been Tested?

web:stage desktop & mobile 
ios:device (stage) 
