### PR TITLE
Fix duplicate 'Your Feed' problem in e2e tests

### DIFF
--- a/packages/web/e2e/auth.setup.ts
+++ b/packages/web/e2e/auth.setup.ts
@@ -9,7 +9,9 @@ setup('authenticate', async ({ page }) => {
   const user = getUser()
   const base64Entropy = btoa(user.entropy.trim())
   await page.goto(`/feed?login=${base64Entropy}`)
-  await expect(page.getByText('Your Feed')).toBeVisible({ timeout: 15000 })
+  await expect(page.getByRole('heading', { name: 'Your Feed' })).toBeVisible({
+    timeout: 15000
+  })
   await page.evaluate(() => {
     localStorage.setItem('HAS_REQUESTED_BROWSER_PUSH_PERMISSION', 'true')
   })


### PR DESCRIPTION
Fixes this error in CI:

```
1) [setup] › auth.setup.ts:8:6 › authenticate ────────────────────────────────────────────────────

    Error: expect.toBeVisible: Error: strict mode violation: getByText('Your Feed') resolved to 2 elements:
        1) <h1 class="harmony-jcvye7">Your Feed</h1> aka getByRole('heading', { name: 'Your Feed' })
        2) <div class="_endDescription_xnm04_24">Looks like you've reached the end of your feed...</div> aka getByText('Looks like you\'ve reached the')

    Call log:
      - expect.toBeVisible with timeout 15000ms
      - waiting for getByText('Your Feed')


      10 |   const base64Entropy = btoa(user.entropy.trim())
      11 |   await page.goto(`/feed?login=${base64Entropy}`)
    > 12 |   await expect(page.getByText('Your Feed')).toBeVisible({ timeout: 15000 })
         |                                             ^
      13 |   await page.evaluate(() => {
      14 |     localStorage.setItem('HAS_REQUESTED_BROWSER_PUSH_PERMISSION', 'true')
      15 |   })

        at /home/circleci/******-protocol/packages/web/e2e/auth.setup.ts:12:45
```