### PR TITLE
[QA-2058] Max height for description text input

### DIFF
--- a/packages/mobile/src/screens/edit-track-screen/EditTrackScreen.tsx
+++ b/packages/mobile/src/screens/edit-track-screen/EditTrackScreen.tsx
@@ -9,6 +9,7 @@ import {
   isBpmValid,
   parseMusicalKey
 } from '@audius/common/utils'
+import { MAX_DESCRIPTION_LENGTH } from '@audius/sdk'
 import { Formik } from 'formik'
 import { z } from 'zod'
 import { toFormikValidationSchema } from 'zod-formik-adapter'
@@ -110,7 +111,10 @@ const useEditTrackSchema = () => {
         )
         .refine(
           (values) => {
-            return !values.description || values.description.length <= 1000
+            return (
+              !values.description ||
+              values.description.length <= MAX_DESCRIPTION_LENGTH
+            )
           },
           { message: errorMessages.description, path: ['description'] }
         )

--- a/packages/web/src/components/edit/fields/TrackMetadataFields.tsx
+++ b/packages/web/src/components/edit/fields/TrackMetadataFields.tsx
@@ -31,7 +31,7 @@ export const TrackMetadataFields = () => {
         aria-label='description'
         placeholder={messages.description}
         maxLength={MAX_DESCRIPTION_LENGTH}
-        css={{ minHeight: 96 }}
+        css={{ minHeight: 96, maxHeight: 300 }}
         showMaxLength
         grows
       />

--- a/packages/web/src/components/track/GiantTrackTile.tsx
+++ b/packages/web/src/components/track/GiantTrackTile.tsx
@@ -1,4 +1,4 @@
-import { Suspense, lazy, useCallback, useState, useEffect } from 'react'
+import { Suspense, lazy, useCallback, useState, useEffect, useRef } from 'react'
 
 import {
   useTrackRank,
@@ -256,6 +256,18 @@ export const GiantTrackTile = ({
   const [isDescriptionExpanded, toggleDescriptionExpanded] = useToggle(false)
   const [showToggle, setShowToggle] = useState(false)
   const theme = useTheme()
+  const toggleButtonRef = useRef<HTMLButtonElement>(null)
+
+  const handleToggleDescription = useCallback(() => {
+    toggleDescriptionExpanded()
+    // If we're collapsing, scroll the button into view
+    if (isDescriptionExpanded && toggleButtonRef.current) {
+      toggleButtonRef.current.scrollIntoView({
+        behavior: 'smooth',
+        block: 'end'
+      })
+    }
+  }, [isDescriptionExpanded, toggleDescriptionExpanded])
 
   // This ref holds the description height for expansion
   const [descriptionRef, descriptionBounds] = useMeasure({
@@ -734,8 +746,9 @@ export const GiantTrackTile = ({
             </Flex>
             {showToggle && (
               <PlainButton
+                ref={toggleButtonRef}
                 iconRight={isDescriptionExpanded ? IconCaretUp : IconCaretDown}
-                onClick={toggleDescriptionExpanded}
+                onClick={handleToggleDescription}
                 css={{ alignSelf: 'flex-start' }}
               >
                 {isDescriptionExpanded ? messages.seeLess : messages.seeMore}


### PR DESCRIPTION
### Description
- Also fix mobile bug that was still capping description at 1000 instead of 2500
- Also add this: when collapsing the description, scroll the page so the "see more" button is centered
- ^ Want to do the same for mobile but haven't figured it out yet!

### How Has This Been Tested?

Tested locally on both web and mobile.