### PR TITLE
Update validation for end_date for events

### DIFF
--- a/packages/discovery-provider/src/tasks/entity_manager/entities/event.py
+++ b/packages/discovery-provider/src/tasks/entity_manager/entities/event.py
@@ -28,13 +28,19 @@ def validate_create_event_tx(params: ManageEntityParameters):
         if field not in metadata:
             raise IndexingValidationError(f"Missing required field: {field}")
 
-    # Validate end_date is not in the past
-    if (
-        params.metadata.get("end_date")
-        and datetime.fromisoformat(params.metadata["end_date"]).timestamp()
-        < params.block_datetime.timestamp()
-    ):
-        raise IndexingValidationError("end_date cannot be in the past")
+    if params.metadata.get("end_date"):
+        # Validate end_date is a valid iso format
+        try:
+            datetime.fromisoformat(params.metadata["end_date"])
+        except ValueError:
+            raise IndexingValidationError("end_date is not a valid iso format")
+
+        # Validate end_date is not in the past
+        if (
+            datetime.fromisoformat(params.metadata["end_date"]).timestamp()
+            < params.block_datetime.timestamp()
+        ):
+            raise IndexingValidationError("end_date cannot be in the past")
 
     # Validate entity_type is valid
     valid_entity_types = [EventEntityType.track.value]
@@ -125,13 +131,19 @@ def validate_update_event_tx(params: ManageEntityParameters):
     if user_id != existing_event.user_id:
         raise IndexingValidationError(f"Only event owner can update event {event_id}")
 
-    # Validate end_date is not in the past
-    if (
-        params.metadata.get("end_date")
-        and datetime.fromisoformat(params.metadata["end_date"]).timestamp()
-        < params.block_datetime.timestamp()
-    ):
-        raise IndexingValidationError("end_date cannot be in the past")
+    if params.metadata.get("end_date"):
+        # Validate end_date is a valid iso format
+        try:
+            datetime.fromisoformat(params.metadata["end_date"])
+        except ValueError:
+            raise IndexingValidationError("end_date is not a valid iso format")
+
+        # Validate end_date is not in the past
+        if (
+            datetime.fromisoformat(params.metadata["end_date"]).timestamp()
+            < params.block_datetime.timestamp()
+        ):
+            raise IndexingValidationError("end_date cannot be in the past")
 
 
 def update_event(params: ManageEntityParameters):


### PR DESCRIPTION
### Description
Updated the validation functions for create and update events to make sure that the format of the end_date is correct and will not brick indexing

### How Has This Been Tested?
Checked using the added test in the test file 