### PR TITLE
[PE-5955] Don't include type in stem filenames

### DIFF
--- a/packages/common/src/utils/fileUtil.test.ts
+++ b/packages/common/src/utils/fileUtil.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest'
 
-import { StemCategory, Track, User } from '~/models'
+import { Track, User } from '~/models'
 
 import { getFilename } from './fileUtil'
 

--- a/packages/common/src/utils/fileUtil.test.ts
+++ b/packages/common/src/utils/fileUtil.test.ts
@@ -39,42 +39,6 @@ describe('getFilename', () => {
     expect(result).toBe('Test Track.mp3')
   })
 
-  it('includes category when stem_of is present', () => {
-    const mockUser: User = {
-      name: 'Test User'
-    } as User
-
-    const mockTrack: Track = {
-      title: 'Test Track',
-      orig_filename: 'original_track.wav',
-      stem_of: { parent_track_id: 1, category: StemCategory.LEAD_VOCALS }
-    } as Track
-
-    const result = getFilename({
-      track: mockTrack,
-      user: mockUser
-    })
-    expect(result).toBe('original_track - Lead Vocals.mp3')
-  })
-
-  it('handles download format', () => {
-    const mockUser: User = {
-      name: 'Test User'
-    } as User
-
-    const mockTrack: Track = {
-      title: 'Test Track',
-      orig_filename: 'original_track.wav'
-    } as Track
-
-    const result = getFilename({
-      track: mockTrack,
-      user: mockUser,
-      isDownload: true
-    })
-    expect(result).toBe('original_track - Test User (Audius).mp3')
-  })
-
   it('preserves original extension for original files', () => {
     const mockUser: User = {
       name: 'Test User'

--- a/packages/common/src/utils/fileUtil.ts
+++ b/packages/common/src/utils/fileUtil.ts
@@ -40,7 +40,6 @@ export const getFilename = ({
     `.${existingExtension ?? ''}`,
     ''
   )
-  const hasCategory = !!track.stem_of?.category
 
   if (track.ddex_app) {
     filename = track.title
@@ -59,10 +58,6 @@ export const getFilename = ({
     } else {
       filename = track.title
     }
-  }
-
-  if (hasCategory) {
-    filename += ` - ${startCase(track.stem_of?.category.toLowerCase())}`
   }
 
   if (isDownload) {

--- a/packages/common/src/utils/fileUtil.ts
+++ b/packages/common/src/utils/fileUtil.ts
@@ -1,7 +1,5 @@
 import { Buffer } from 'buffer'
 
-import { startCase } from 'lodash'
-
 import { Track, User } from '~/models'
 import { DownloadFile } from '~/services'
 


### PR DESCRIPTION
### Description
Remove the `- <type>` to the filename UI

### How Has This Been Tested?


<img width="1181" alt="Screenshot 2025-04-11 at 12 56 05 PM" src="https://github.com/user-attachments/assets/f9f6d58c-2361-450e-93cc-3b4cbb007fc5" />
