### PR TITLE
Don't check USDC_PURCHASES FeatureFlag in upload, default to on

### DIFF
--- a/packages/common/src/services/remote-config/feature-flags.ts
+++ b/packages/common/src/services/remote-config/feature-flags.ts
@@ -51,7 +51,7 @@ export const flagDefaults: FlagDefaults = {
   [FeatureFlags.VERIFY_HANDLE_WITH_TIKTOK]: false,
   [FeatureFlags.VERIFY_HANDLE_WITH_TWITTER]: false,
   [FeatureFlags.VERIFY_HANDLE_WITH_INSTAGRAM]: false,
-  [FeatureFlags.USDC_PURCHASES]: false,
+  [FeatureFlags.USDC_PURCHASES]: true,
   [FeatureFlags.FEATURE_FLAG_ACCESS]: false,
   [FeatureFlags.IOS_USDC_PURCHASE_ENABLED]: true,
   [FeatureFlags.BUY_WITH_COINFLOW]: false,

--- a/packages/web/src/common/store/upload/sagaHelpers.ts
+++ b/packages/web/src/common/store/upload/sagaHelpers.ts
@@ -124,13 +124,6 @@ export function* getUSDCMetadata(stream_conditions: USDCPurchaseConditions) {
 export function* addPremiumMetadata<T extends TrackMetadataForUpload>(
   track: T
 ) {
-  const getFeatureEnabled = yield* getContext('getFeatureEnabled')
-  const isUsdcPurchaseEnabled = yield* call(
-    getFeatureEnabled,
-    FeatureFlags.USDC_PURCHASES
-  )
-  if (!isUsdcPurchaseEnabled) return track
-
   // download_conditions could be set separately from stream_conditions, so we check for them first
   if (isContentUSDCPurchaseGated(track.download_conditions)) {
     track.download_conditions = yield* call(

--- a/packages/web/src/common/store/upload/sagaHelpers.ts
+++ b/packages/web/src/common/store/upload/sagaHelpers.ts
@@ -6,11 +6,9 @@ import {
   isContentUSDCPurchaseGated,
   USDCPurchaseConditions
 } from '@audius/common/models'
-import { FeatureFlags } from '@audius/common/services'
 import {
   accountSelectors,
   getOrCreateUSDCUserBank,
-  getContext,
   TrackForUpload,
   TrackMetadataForUpload
 } from '@audius/common/store'


### PR DESCRIPTION
### Description

In the upload flow, we bail out of setting the correct metadata if the feature flag is not on. However, in the forms, we no longer check that the feature flag is on before letting you set the metadata.

This meant that the user could set a price even if USDC_PURCHASES was off, but when they went to upload, they would get no splits set on their upload.

Notably, we don't default to having USDC_PURCHASES on which is why he was able to enter into this case to begin with. Fixing this by defaulting to ON

### How Has This Been Tested?

Hasn't been tested.