### PR TITLE
Hide premium upload UI when feature flag off

### DIFF
--- a/packages/mobile/src/components/edit/PriceAndAudienceField/PriceAndAudienceScreen.tsx
+++ b/packages/mobile/src/components/edit/PriceAndAudienceField/PriceAndAudienceScreen.tsx
@@ -198,10 +198,12 @@ export const PriceAndAudienceScreen = () => {
             setPreviewValue(null)
           }}
         />
-        <PremiumRadioField
-          disabled={disableUsdcGate}
-          previousStreamConditions={previousStreamConditions}
-        />
+        {isUsdcEnabled ? (
+          <PremiumRadioField
+            disabled={disableUsdcGate}
+            previousStreamConditions={previousStreamConditions}
+          />
+        ) : null}
         {entityType === 'track' ? (
           <SpecialAccessRadioField
             disabled={

--- a/packages/mobile/src/components/premium-content-purchase-drawer/PremiumContentPurchaseDrawer.tsx
+++ b/packages/mobile/src/components/premium-content-purchase-drawer/PremiumContentPurchaseDrawer.tsx
@@ -41,13 +41,7 @@ import {
 import type { PurchaseContentError } from '@audius/common/store'
 import { formatPrice } from '@audius/common/utils'
 import { Formik, useField, useFormikContext } from 'formik'
-import {
-  Linking,
-  View,
-  ScrollView,
-  TouchableOpacity,
-  Platform
-} from 'react-native'
+import { Linking, View, ScrollView, TouchableOpacity } from 'react-native'
 import { useDispatch, useSelector } from 'react-redux'
 import { toFormikValidationSchema } from 'zod-formik-adapter'
 

--- a/packages/mobile/src/components/premium-content-purchase-drawer/PremiumContentPurchaseDrawer.tsx
+++ b/packages/mobile/src/components/premium-content-purchase-drawer/PremiumContentPurchaseDrawer.tsx
@@ -246,10 +246,9 @@ const RenderForm = ({
   const { isEnabled: isCoinflowEnabled } = useFeatureFlag(
     FeatureFlags.BUY_WITH_COINFLOW
   )
-  const { isEnabled: isIOSUSDCPurchaseEnabled } = useFeatureFlag(
-    FeatureFlags.IOS_USDC_PURCHASE_ENABLED
+  const { isEnabled: isUsdcPurchaseEnabled } = useFeatureFlag(
+    FeatureFlags.USDC_PURCHASES
   )
-  const isIOSDisabled = Platform.OS === 'ios' && !isIOSUSDCPurchaseEnabled
 
   const { submitForm, resetForm } = useFormikContext()
 
@@ -368,7 +367,9 @@ const RenderForm = ({
                   streamPurchaseCount={streamPurchaseCount}
                   totalPriceInCents={totalPriceInCents}
                 />
-                {isIOSDisabled || isUnlocking || isPurchaseSuccessful ? null : (
+                {!isUsdcPurchaseEnabled ||
+                isUnlocking ||
+                isPurchaseSuccessful ? null : (
                   <PaymentMethod
                     selectedMethod={purchaseMethod}
                     setSelectedMethod={setPurchaseMethod}
@@ -387,7 +388,7 @@ const RenderForm = ({
                   />
                 )}
               </View>
-              {isIOSDisabled ? (
+              {!isUsdcPurchaseEnabled ? (
                 <PurchaseUnavailable />
               ) : isPurchaseSuccessful ? (
                 <PurchaseSuccess

--- a/packages/mobile/src/components/premium-content-purchase-drawer/PremiumContentPurchaseDrawer.tsx
+++ b/packages/mobile/src/components/premium-content-purchase-drawer/PremiumContentPurchaseDrawer.tsx
@@ -415,7 +415,7 @@ const RenderForm = ({
           />
         </View>
       )}
-      {isPurchaseSuccessful || isIOSDisabled ? null : (
+      {isPurchaseSuccessful || !isUsdcPurchaseEnabled ? null : (
         <View style={styles.formActions}>
           {error ? <RenderError error={error} /> : null}
           {page === PurchaseContentPage.TRANSFER ? (


### PR DESCRIPTION
### Description
- Use `USDC_PURCHASES` instead of `IOS_USDC_PURCHASE_ENABLED` to gate the purchase UI
- Hide premium section in upload flow when feature flag is off

### How Has This Been Tested?

Tested on android device against stage, confirmed both no premium section in upload, no premium explore section