### PR TITLE
Show not supported drawer on mobile web for Connected Wallets modal

### DIFF
--- a/packages/web/src/pages/audio-page/components/modals/ConnectedWalletsModal.tsx
+++ b/packages/web/src/pages/audio-page/components/modals/ConnectedWalletsModal.tsx
@@ -16,8 +16,7 @@ import {
   ModalFooter,
   ModalHeader,
   ModalTitle,
-  Text,
-  useTheme
+  Text
 } from '@audius/harmony'
 
 import Drawer from 'components/drawer/Drawer'
@@ -140,8 +139,6 @@ export const ConnectedWalletsModal = () => {
 
   // Not supported on mobile web
   const isMobile = useIsMobile()
-  const theme = useTheme()
-  const iconFill = theme.color.text.default
   if (isMobile) {
     return (
       <Drawer isOpen={isOpen} onClose={onClose} onClosed={onClosed}>
@@ -154,7 +151,7 @@ export const ConnectedWalletsModal = () => {
           pb='3xl'
         >
           <Flex alignItems='center' gap='s'>
-            <IconWallet fill={iconFill} />
+            <IconWallet color='default' />
             <Text color='heading' variant='heading'>
               {messages.title}
             </Text>

--- a/packages/web/src/pages/audio-page/components/modals/ConnectedWalletsModal.tsx
+++ b/packages/web/src/pages/audio-page/components/modals/ConnectedWalletsModal.tsx
@@ -156,7 +156,7 @@ export const ConnectedWalletsModal = () => {
           <Flex alignItems='center' gap='s'>
             <IconWallet fill={iconFill} />
             <Text color='heading' variant='heading'>
-              Connect Wallet
+              {messages.title}
             </Text>
           </Flex>
           <Text textAlign='center' size='l'>

--- a/packages/web/src/pages/audio-page/components/modals/ConnectedWalletsModal.tsx
+++ b/packages/web/src/pages/audio-page/components/modals/ConnectedWalletsModal.tsx
@@ -16,10 +16,13 @@ import {
   ModalFooter,
   ModalHeader,
   ModalTitle,
-  Text
+  Text,
+  useTheme
 } from '@audius/harmony'
 
+import Drawer from 'components/drawer/Drawer'
 import { ToastContext } from 'components/toast/ToastContext'
+import { useIsMobile } from 'hooks/useIsMobile'
 import { reportToSentry } from 'store/errors/reportToSentry'
 import { NEW_WALLET_CONNECTED_TOAST_TIMEOUT_MILLIS } from 'utils/constants'
 
@@ -45,7 +48,9 @@ const messages = {
   remove: 'Remove Wallet',
   ignore: 'Nevermind',
   error: 'Something went wrong. Please try again.',
-  walletAlreadyAdded: 'No new wallets selected to connect.'
+  walletAlreadyAdded: 'No new wallets selected to connect.',
+  goToDesktop:
+    'To connect external wallets to your account, visit audius.co from a desktop browser.'
 }
 
 enum Pages {
@@ -132,6 +137,35 @@ export const ConnectedWalletsModal = () => {
   const isMutationPending = isConnectingWallets || isRemovePending
   const isConnectDisabled =
     hasReachedLimit || isMutationPending || isConnectingWallets
+
+  // Not supported on mobile web
+  const isMobile = useIsMobile()
+  const theme = useTheme()
+  const iconFill = theme.color.text.default
+  if (isMobile) {
+    return (
+      <Drawer isOpen={isOpen} onClose={onClose} onClosed={onClosed}>
+        <Flex
+          direction='column'
+          alignItems='center'
+          gap='m'
+          p='l'
+          ph='2xl'
+          pb='3xl'
+        >
+          <Flex alignItems='center' gap='s'>
+            <IconWallet fill={iconFill} />
+            <Text color='heading' variant='heading'>
+              Connect Wallet
+            </Text>
+          </Flex>
+          <Text textAlign='center' size='l'>
+            {messages.goToDesktop}
+          </Text>
+        </Flex>
+      </Drawer>
+    )
+  }
 
   return (
     <Modal


### PR DESCRIPTION
### Description
The mobile web experience of Reown is pretty bad - it didn't detect Phantom and fails to connect MetaMask. Rather than investing more time here, we're going to redirect users to use the desktop web version to add wallets.

(Ignore tan query dev tool)
![image](https://github.com/user-attachments/assets/e925f490-aa10-4578-8658-58595082701b)

