### PR TITLE
Update challenge config starting block for comment pin challenge

### DIFF
--- a/packages/discovery-provider/src/challenges/challenges.json
+++ b/packages/discovery-provider/src/challenges/challenges.json
@@ -209,9 +209,9 @@
     "name": "COMMENT_PIN",
     "type": "aggregate",
     "amount": 10,
-    "active": false,
+    "active": true,
     "step_count": 2147483647,
-    "starting_block": 0,
+    "starting_block": 1979515,
     "weekly_pool": 2147483647,
     "cooldown_days": 7
   },


### PR DESCRIPTION
### Description

Updated the challenge config starting block value for the comment pin challenge via a method similar to https://github.com/AudiusProject/audius-protocol/pull/11842 but with a 40hr time delta so the challenge is available early on Wednesday morning