### PR TITLE
Fix inspect track keyword argument and hook loading

### DIFF
--- a/packages/discovery-provider/src/api/v1/tracks.py
+++ b/packages/discovery-provider/src/api/v1/tracks.py
@@ -442,7 +442,9 @@ class TrackInspect(Resource):
             else track_info.get("track_cid")
         )
 
-        raw_blob_info = get_track_inspect_info(cid, track_id=track_id, redis=redis)
+        raw_blob_info = get_track_inspect_info(
+            cid, track_id=track_id, redis_instance=redis
+        )
         if not raw_blob_info:
             abort_not_found(track_id, ns)
 
@@ -514,7 +516,7 @@ class BulkTrackInspect(Resource):
                 else track_info.get("track_cid")
             )
             raw_blob_info = get_track_inspect_info(
-                cid, track_id=track_info.get("track_id"), redis=redis
+                cid, track_id=track_info.get("track_id"), redis_instance=redis
             )
             if raw_blob_info:
                 blob_info = extend_blob_info(raw_blob_info)

--- a/packages/web/src/components/track/DownloadSection.tsx
+++ b/packages/web/src/components/track/DownloadSection.tsx
@@ -78,7 +78,7 @@ export const DownloadSection = ({ trackId }: DownloadSectionProps) => {
   })
   const { is_downloadable, access } = partialTrack ?? {}
 
-  const { data: stemTracks = [] } = useStems(trackId)
+  const { data: stemTracks = [], isSuccess: isStemsSuccess } = useStems(trackId)
   const { uploadingTracks: uploadingStems } = useUploadingStems(trackId)
   const {
     price,
@@ -104,10 +104,14 @@ export const DownloadSection = ({ trackId }: DownloadSectionProps) => {
 
   const { onOpen: openDownloadTrackArchiveModal } =
     useDownloadTrackArchiveModal()
-  const { data: fileSizes } = useFileSizes({
-    trackIds: [trackId, ...stemTracks.map((s) => s.track_id)],
-    downloadQuality
-  })
+
+  const { data: fileSizes } = useFileSizes(
+    {
+      trackIds: [trackId, ...stemTracks.map((s) => s.track_id)],
+      downloadQuality
+    },
+    { enabled: isStemsSuccess }
+  )
   const { onOpen: openWaitForDownloadModal } = useWaitForDownloadModal()
 
   const onToggleExpand = useCallback(() => setExpanded((val) => !val), [])


### PR DESCRIPTION
### Description

Fixes issue where /inspect fails due to incorrect keyword argument
Fixes issue where useFileSizes runs before stems have loaded, leading to unnecessary extra fetch