### PR TITLE
[PE-5939] Disallow remix contests for remixes

### DIFF
--- a/packages/discovery-provider/src/tasks/entity_manager/entities/event.py
+++ b/packages/discovery-provider/src/tasks/entity_manager/entities/event.py
@@ -92,6 +92,11 @@ def validate_create_event_tx(params: ManageEntityParameters):
             raise IndexingValidationError(
                 f"An existing remix contest for entity_id {metadata['entity_id']} already exists"
             )
+        track = params.existing_records[EntityType.TRACK.value][metadata["entity_id"]]
+        if track.remix_of:
+            raise IndexingValidationError(
+                f"Track {metadata['entity_id']} is a remix and cannot host a remix contest"
+            )
 
 
 def create_event(params: ManageEntityParameters):

--- a/packages/mobile/src/screens/track-screen/TrackScreenDetailsTile.tsx
+++ b/packages/mobile/src/screens/track-screen/TrackScreenDetailsTile.tsx
@@ -446,7 +446,7 @@ export const TrackScreenDetailsTile = ({
     const addToAlbumAction =
       isOwner && !ddexApp ? OverflowAction.ADD_TO_ALBUM : null
     const overflowActions = [
-      isOwner && isRemixContestEnabled
+      isOwner && isRemixContestEnabled && !isRemix
         ? OverflowAction.HOST_REMIX_CONTEST
         : null,
       addToAlbumAction,

--- a/packages/web/src/components/menu/TrackMenu.tsx
+++ b/packages/web/src/components/menu/TrackMenu.tsx
@@ -318,7 +318,7 @@ const TrackMenu = ({
 
     const menu: { items: PopupMenuItem[] } = { items: [] }
 
-    if (includeRemixContest && isOwner && !isDeleted) {
+    if (includeRemixContest && isOwner && !isDeleted && !track?.remix_of) {
       menu.items.push(remixContestMenuItem)
     }
 


### PR DESCRIPTION
### Description
Small updates to make it so remix contests can't be created for remixes

### How Has This Been Tested?
Manually tested and ran events test
