### PR TITLE
Small m1 updates for wallet UI updates

### DIFF
--- a/packages/web/src/components/payout-wallet-display/PayoutWalletDisplay.tsx
+++ b/packages/web/src/components/payout-wallet-display/PayoutWalletDisplay.tsx
@@ -39,7 +39,7 @@ export const PayoutWalletDisplay = () => {
   const user = useSelector(getAccountUser)
   const payoutWallet = user?.spl_usdc_payout_wallet
 
-  const { data: externalWalletOwner, isPending: isLoadingOwner } =
+  const { data: externalWalletOwner, isLoading: isLoadingOwner } =
     useWalletOwner(payoutWallet)
 
   if (isLoadingOwner) {

--- a/packages/web/src/pages/pay-and-earn-page/components/CashWallet.tsx
+++ b/packages/web/src/pages/pay-and-earn-page/components/CashWallet.tsx
@@ -51,12 +51,9 @@ export const CashWallet = () => {
 
   // Calculate the balance in cents by flooring to 2 decimal places then multiplying by 100
   const usdcValue = USDC(balance ?? new BN(0)).floor(2)
-  const balanceCents = Number(usdcValue.toString()) * 100
 
-  // Format the balance for display using the trunc and toShorthand methods
-  const balanceFormatted = USDC(balanceCents / 100)
-    .trunc()
-    .toShorthand()
+  // Format the balance for display
+  const balanceFormatted = usdcValue.toLocaleString().replace('$', '')
 
   const handleWithdraw = () => {
     openWithdrawUSDCModal({
@@ -65,7 +62,7 @@ export const CashWallet = () => {
     track(
       make({
         eventName: Name.WITHDRAW_USDC_MODAL_OPENED,
-        currentBalance: balanceCents / 100
+        currentBalance: Number(usdcValue.toString())
       })
     )
   }


### PR DESCRIPTION
### Description

- `isPending` caused infinite loading when the user swapped to their built in wallet, changed to use `isLoading` 

- formatting was wrong on cash wallet component for the value being shown, updated to be corrected 

### How Has This Been Tested?

`npm run web:stage`
