### PR TITLE
Remove filename from mobile DownloadRow

### DIFF
--- a/packages/mobile/src/screens/track-screen/DownloadRow.tsx
+++ b/packages/mobile/src/screens/track-screen/DownloadRow.tsx
@@ -1,15 +1,10 @@
 import { useTrack, useUser } from '@audius/common/api'
 import type { ID } from '@audius/common/models'
-import { stemCategoryFriendlyNames } from '@audius/common/models'
 import { getFilename } from '@audius/common/utils'
 import { css } from '@emotion/native'
 
 import { Flex, Text, IconReceive, Box } from '@audius/harmony-native'
 import { PlainButton } from 'app/harmony-native/components/Button/PlainButton/PlainButton'
-
-const messages = {
-  fullTrack: 'Full Track'
-}
 
 type DownloadRowProps = {
   trackId: ID

--- a/packages/mobile/src/screens/track-screen/DownloadRow.tsx
+++ b/packages/mobile/src/screens/track-screen/DownloadRow.tsx
@@ -27,45 +27,23 @@ export const DownloadRow = ({
   const { data: track } = useTrack(trackId)
   const { data: user } = useUser(track?.owner_id)
 
+  const filename =
+    track && user ? getFilename({ track, user, isOriginal: true }) : null
+
   return (
-    <Flex
-      direction='row'
-      alignItems='center'
-      justifyContent='space-between'
-      borderTop='default'
-      pv='m'
-    >
-      <Flex
-        direction='row'
-        gap='xl'
-        alignItems='center'
-        justifyContent='space-between'
-        style={css({ flexShrink: 1 })}
-      >
+    <Flex row alignItems='center' justifyContent='space-between'>
+      <Flex row gap='m' alignItems='center' style={css({ flexShrink: 1 })}>
         <Text variant='body' color='subdued'>
           {index}
         </Text>
-        <Flex gap='xs' style={css({ flexShrink: 1 })}>
-          <Text variant='body'>
-            {track?.stem_of?.category
-              ? stemCategoryFriendlyNames[track?.stem_of?.category]
-              : messages.fullTrack}
-          </Text>
-          <Text
-            variant='body'
-            color='subdued'
-            ellipsizeMode='tail'
-            numberOfLines={1}
-          >
-            {track &&
-              user &&
-              getFilename({
-                track,
-                user,
-                isOriginal: true
-              })}
-          </Text>
-        </Flex>
+        <Text
+          variant='body'
+          ellipsizeMode='tail'
+          numberOfLines={1}
+          style={css({ flexShrink: 1 })}
+        >
+          {filename}
+        </Text>
       </Flex>
       {hideDownload ? null : (
         <PlainButton

--- a/packages/mobile/src/screens/track-screen/DownloadSection.tsx
+++ b/packages/mobile/src/screens/track-screen/DownloadSection.tsx
@@ -144,7 +144,7 @@ export const DownloadSection = ({ trackId }: { trackId: ID }) => {
 
   const renderHeader = () => {
     return (
-      <Flex gap='l' column pb='l'>
+      <Flex gap='l' column>
         <Flex row justifyContent='space-between' alignItems='center'>
           <Flex row alignItems='center' gap='s'>
             <IconReceive color='default' />

--- a/packages/mobile/src/screens/track-screen/DownloadSection.tsx
+++ b/packages/mobile/src/screens/track-screen/DownloadSection.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useState } from 'react'
+import React, { useCallback, useState } from 'react'
 
 import { useStems, useTrack } from '@audius/common/api'
 import {
@@ -20,6 +20,7 @@ import { LayoutAnimation } from 'react-native'
 
 import {
   Button,
+  Divider,
   Flex,
   IconLockUnlocked,
   IconReceive,
@@ -164,30 +165,28 @@ export const DownloadSection = ({ trackId }: { trackId: ID }) => {
           </Button>
         ) : null}
         {shouldDisplayPremiumDownloadUnlocked ? (
-          <>
-            <Flex row alignItems='center' gap='s'>
-              <Flex
-                borderRadius='3xl'
-                ph='s'
-                style={css({
-                  backgroundColor: color.special.lightGreen,
-                  paddingTop: 1,
-                  paddingBottom: 1
-                })}
-              >
-                <IconLockUnlocked color='white' size='xs' />
-              </Flex>
-              <Text
-                variant='label'
-                // TODO: size other than m causes misalignment C-3709
-                size='l'
-                strength='strong'
-                color='subdued'
-              >
-                {messages.purchased}
-              </Text>
+          <Flex row alignItems='center' gap='s'>
+            <Flex
+              borderRadius='3xl'
+              ph='s'
+              style={css({
+                backgroundColor: color.special.lightGreen,
+                paddingTop: 1,
+                paddingBottom: 1
+              })}
+            >
+              <IconLockUnlocked color='white' size='xs' />
             </Flex>
-          </>
+            <Text
+              variant='label'
+              // TODO: size other than m causes misalignment C-3709
+              size='l'
+              strength='strong'
+              color='subdued'
+            >
+              {messages.purchased}
+            </Text>
+          </Flex>
         ) : null}
         {isDownloadAllTrackFilesEnabled && !shouldHideDownload ? (
           <Flex row alignItems='center' alignSelf='flex-start'>
@@ -219,28 +218,36 @@ export const DownloadSection = ({ trackId }: { trackId: ID }) => {
       expanded={isExpanded}
       onToggleExpand={onToggleExpand}
     >
-      {track?.is_downloadable ? (
-        <DownloadRow
-          trackId={trackId}
-          index={ORIGINAL_TRACK_INDEX}
-          hideDownload={shouldHideDownload}
-          onDownload={handleDownload}
-        />
-      ) : null}
-      {stemTracks?.map((s, i) => (
-        <DownloadRow
-          trackId={s.id}
-          key={s.id}
-          index={
-            i +
-            (track?.is_downloadable
-              ? STEM_INDEX_OFFSET_WITH_ORIGINAL_TRACK
-              : STEM_INDEX_OFFSET_WITHOUT_ORIGINAL_TRACK)
-          }
-          hideDownload={shouldHideDownload}
-          onDownload={handleDownload}
-        />
-      ))}
+      <Flex gap='m'>
+        {track?.is_downloadable ? (
+          <>
+            <Divider />
+            <DownloadRow
+              trackId={trackId}
+              index={ORIGINAL_TRACK_INDEX}
+              hideDownload={shouldHideDownload}
+              onDownload={handleDownload}
+            />
+          </>
+        ) : null}
+        {stemTracks?.map((s, i) => (
+          <>
+            <Divider />
+            <DownloadRow
+              trackId={s.id}
+              key={s.id}
+              index={
+                i +
+                (track?.is_downloadable
+                  ? STEM_INDEX_OFFSET_WITH_ORIGINAL_TRACK
+                  : STEM_INDEX_OFFSET_WITHOUT_ORIGINAL_TRACK)
+              }
+              hideDownload={shouldHideDownload}
+              onDownload={handleDownload}
+            />
+          </>
+        ))}
+      </Flex>
     </Expandable>
   )
 }


### PR DESCRIPTION
### Description
Only show filename on mobile download row now that we have way more stems.

missing filename is a separate bug.

### How Has This Been Tested?

![Simulator Screenshot - iPhone 16 Pro - 2025-04-15 at 16 06 48](https://github.com/user-attachments/assets/c0cf63c9-03bd-4d2b-87c7-f519196ecfe7)


![simulator_screenshot_EADEE0F5-286F-4172-B160-4F2BA8AB76B6](https://github.com/user-attachments/assets/56e127d1-8f5d-40b4-abbf-10293f1e67c5)
