### PR TITLE
add max to block diff check

### DIFF
--- a/packages/discovery-provider/src/queries/get_health.py
+++ b/packages/discovery-provider/src/queries/get_health.py
@@ -371,9 +371,7 @@ def get_health(args: GetHealthArgs, use_redis_cache: bool = True) -> Tuple[Dict,
         )
 
     if latest_block_num is not None and latest_indexed_block_num is not None:
-        block_difference = abs(
-            latest_block_num - latest_indexed_block_num
-        )  # nethermind offset
+        block_difference = max(0, abs(latest_block_num - latest_indexed_block_num))
     else:
         # If we cannot get a reading from chain about what the latest block is,
         # we set the difference to be an unhealthy amount


### PR DESCRIPTION
### Description
![Screenshot 2025-04-15 at 10 17 48 AM](https://github.com/user-attachments/assets/7798e8e7-eac4-4d5c-9d44-d6c7f6d0a373)
Because of the way core caches latest block num it's possible the indexer can think it's in the future compared to what core returns. This defaults block diff to be 0 in case it gets in the negatives which is what causes this random healthz blip. 

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._
