### PR TITLE
Fix remix page filter buttons

### DIFF
--- a/packages/web/src/pages/remixes-page/components/desktop/NewRemixesPage.tsx
+++ b/packages/web/src/pages/remixes-page/components/desktop/NewRemixesPage.tsx
@@ -96,14 +96,16 @@ const RemixesPage = nullGuard(({ title, count = 0, originalTrack }) => {
               <Flex gap='s' mb='xl'>
                 <FilterButton
                   label={messages.coSigned}
-                  value={isCosign.toString()}
-                  onClick={() => updateIsCosignParam(isCosign ? '' : 'true')}
+                  value={isCosign ? 'true' : null}
+                  onClick={() =>
+                    updateIsCosignParam(isCosign ? 'false' : 'true')
+                  }
                 />
                 <FilterButton
                   label={messages.contestEntries}
-                  value={isContestEntry.toString()}
+                  value={isContestEntry ? 'true' : null}
                   onClick={() =>
-                    updateIsContestEntryParam(isContestEntry ? '' : 'true')
+                    updateIsContestEntryParam(isContestEntry ? 'false' : 'true')
                   }
                 />
                 <FilterButton


### PR DESCRIPTION
### Description

Fix a bug where the buttons stay on. I think I left this in when I was testing before and forgot to take it out. Mobile doesn't have these buttons so no fix needed there.

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._

Confirmed buttons turn on and off and filter as expected.