### PR TITLE
[PE-5995, PE-5996] Fix mobile remix end-date input

### DIFF
--- a/packages/common/src/api/tan-query/events/useRemixContest.ts
+++ b/packages/common/src/api/tan-query/events/useRemixContest.ts
@@ -22,9 +22,7 @@ export const useRemixContest = (
       entityType: EventEntityTypeEnum.Track,
       eventType: EventEventTypeEnum.RemixContest
     },
-    {
-      enabled: !!options?.enabled
-    }
+    { enabled: options?.enabled !== false }
   )
 
   const remixContestId = eventsQuery.data?.[0]

--- a/packages/mobile/src/components/core/DateTimeInput.tsx
+++ b/packages/mobile/src/components/core/DateTimeInput.tsx
@@ -40,11 +40,12 @@ export const DateTimeInput = (props: DateTimeModalProps) => {
 
   const handleChange = useCallback(
     (date: Date) => {
+      setIsDateTimeOpen(false)
       if (mode === 'date') {
         date.setHours(0, 0, 0, 0)
       }
       onChange(date.toString())
-      setIsDateTimeOpen((d) => !d)
+      setIsDateTimeOpen(false)
     },
     [onChange, setIsDateTimeOpen, mode]
   )

--- a/packages/mobile/src/components/expandable/ExpandableArrowIcon.tsx
+++ b/packages/mobile/src/components/expandable/ExpandableArrowIcon.tsx
@@ -22,7 +22,7 @@ const springToValue = ({
 
 type ExpandableArrowIconProps = {
   expanded: boolean
-  iconSize?: IconProps['size']
+  size?: IconProps['size']
 }
 
 /**
@@ -34,7 +34,7 @@ type ExpandableArrowIconProps = {
  */
 export const ExpandableArrowIcon = ({
   expanded,
-  iconSize = 'm' as IconProps['size']
+  size = 'm' as IconProps['size']
 }: ExpandableArrowIconProps) => {
   const rotateAnim = useRef(new Animated.Value(0))
 
@@ -58,7 +58,7 @@ export const ExpandableArrowIcon = ({
         ]
       }}
     >
-      <IconCaretDown size={iconSize} color='default' />
+      <IconCaretDown size={size} color='default' />
     </Animated.View>
   )
 }

--- a/packages/mobile/src/components/host-remix-contest-drawer/HostRemixContestDrawer.tsx
+++ b/packages/mobile/src/components/host-remix-contest-drawer/HostRemixContestDrawer.tsx
@@ -80,7 +80,7 @@ export const HostRemixContestDrawer = () => {
       return
     }
 
-    const newDate = mergeDateTime(date || time, time || date)
+    const newDate = mergeDateTime(date, time)
     if (newDate.isBefore(dayjs())) {
       setEndDateError(true)
     } else {
@@ -160,6 +160,7 @@ export const HostRemixContestDrawer = () => {
               mode='date'
               date={endDate?.toString() ?? ''}
               onChange={handleDateChange}
+              dateTimeProps={{ minimumDate: new Date() }}
               inputProps={{
                 label: messages.dateLabel,
                 startIcon: IconCalendarMonth,

--- a/packages/mobile/src/components/host-remix-contest-drawer/HostRemixContestDrawer.tsx
+++ b/packages/mobile/src/components/host-remix-contest-drawer/HostRemixContestDrawer.tsx
@@ -80,7 +80,7 @@ export const HostRemixContestDrawer = () => {
       return
     }
 
-    const newDate = mergeDateTime(date, time)
+    const newDate = mergeDateTime(date || time, time || date)
     if (newDate.isBefore(dayjs())) {
       setEndDateError(true)
     } else {

--- a/packages/mobile/src/components/summary-table/SummaryTable.tsx
+++ b/packages/mobile/src/components/summary-table/SummaryTable.tsx
@@ -105,7 +105,7 @@ export const SummaryTable = ({
         borderBottom={isExpanded ? 'default' : undefined}
       >
         <Flex direction='row' alignItems='center' gap='s'>
-          <ExpandableArrowIcon expanded={isExpanded} iconSize='s' />
+          <ExpandableArrowIcon expanded={isExpanded} size='s' />
           <Text variant='title' strength='default'>
             {title}
           </Text>

--- a/packages/mobile/src/screens/track-screen/DownloadSection.tsx
+++ b/packages/mobile/src/screens/track-screen/DownloadSection.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useState } from 'react'
+import React, { Fragment, useCallback, useState } from 'react'
 
 import { useStems, useTrack } from '@audius/common/api'
 import {
@@ -62,6 +62,8 @@ export const DownloadSection = ({ trackId }: { trackId: ID }) => {
   const [isExpanded, setIsExpanded] = useState(false)
   const { data: track } = useTrack(trackId)
   const { data: stemTracks = [] } = useStems(trackId)
+
+  // console.log('stemTracks', stemTracks)
   const {
     price,
     shouldDisplayPremiumDownloadLocked,
@@ -191,7 +193,6 @@ export const DownloadSection = ({ trackId }: { trackId: ID }) => {
         {isDownloadAllTrackFilesEnabled && !shouldHideDownload ? (
           <Flex row alignItems='center' alignSelf='flex-start'>
             <Button
-              iconLeft={IconReceive}
               variant='secondary'
               size='small'
               onPress={handleDownloadAll}
@@ -230,12 +231,11 @@ export const DownloadSection = ({ trackId }: { trackId: ID }) => {
             />
           </>
         ) : null}
-        {stemTracks?.map((s, i) => (
-          <>
+        {stemTracks?.map((stemTrack, i) => (
+          <Fragment key={stemTrack.track_id}>
             <Divider />
             <DownloadRow
-              trackId={s.id}
-              key={s.id}
+              trackId={stemTrack.track_id}
               index={
                 i +
                 (track?.is_downloadable
@@ -245,7 +245,7 @@ export const DownloadSection = ({ trackId }: { trackId: ID }) => {
               hideDownload={shouldHideDownload}
               onDownload={handleDownload}
             />
-          </>
+          </Fragment>
         ))}
       </Flex>
     </Expandable>

--- a/packages/mobile/src/screens/track-screen/RemixContestCountdown.tsx
+++ b/packages/mobile/src/screens/track-screen/RemixContestCountdown.tsx
@@ -1,8 +1,8 @@
 import { useRemixContest } from '@audius/common/api'
-import { useRemixCountdown } from '@audius/common/hooks'
+import { useFeatureFlag, useRemixCountdown } from '@audius/common/hooks'
 import type { ID } from '@audius/common/models'
+import { FeatureFlags } from '@audius/common/services'
 import { formatDoubleDigit } from '@audius/common/utils'
-import { css } from '@emotion/native'
 
 import { Text, Flex, Divider, Paper } from '@audius/harmony-native'
 
@@ -38,30 +38,32 @@ type RemixContestCountdownProps = {
 export const RemixContestCountdown = ({
   trackId
 }: RemixContestCountdownProps) => {
+  const { isEnabled: isRemixContestEnabled } = useFeatureFlag(
+    FeatureFlags.REMIX_CONTEST
+  )
   const { data: remixContest } = useRemixContest(trackId)
   const timeLeft = useRemixCountdown(remixContest?.endDate)
 
-  if (!remixContest || !timeLeft) return null
+  if (!remixContest || !timeLeft || !isRemixContestEnabled) return null
 
   return (
-    <Paper
-      row
-      pv='m'
-      ph='l'
-      justifyContent='space-around'
-      alignItems='center'
-      borderRadius='l'
-      style={css({
-        opacity: 0.8
-      })}
-    >
-      <TimeUnit value={timeLeft.days} label={messages.days} />
-      <Divider orientation='vertical' />
-      <TimeUnit value={timeLeft.hours} label={messages.hours} />
-      <Divider orientation='vertical' />
-      <TimeUnit value={timeLeft.minutes} label={messages.minutes} />
-      <Divider orientation='vertical' />
-      <TimeUnit value={timeLeft.seconds} label={messages.seconds} />
+    <Paper row pv='m' ph='l' borderRadius='l' backgroundColor='white'>
+      {/* Note: setting opacity on Paper does not work on Android for some reason */}
+      <Flex
+        row
+        flex={1}
+        justifyContent='space-around'
+        alignItems='center'
+        style={{ opacity: 0.8 }}
+      >
+        <TimeUnit value={timeLeft.days} label={messages.days} />
+        <Divider orientation='vertical' />
+        <TimeUnit value={timeLeft.hours} label={messages.hours} />
+        <Divider orientation='vertical' />
+        <TimeUnit value={timeLeft.minutes} label={messages.minutes} />
+        <Divider orientation='vertical' />
+        <TimeUnit value={timeLeft.seconds} label={messages.seconds} />
+      </Flex>
     </Paper>
   )
 }

--- a/packages/web/src/components/track/DownloadSection.tsx
+++ b/packages/web/src/components/track/DownloadSection.tsx
@@ -229,7 +229,6 @@ export const DownloadSection = ({ trackId }: DownloadSectionProps) => {
               <Button
                 variant='secondary'
                 size='small'
-                iconLeft={IconReceive}
                 onClick={handleDownloadAll}
               >
                 {messages.downloadAll}

--- a/packages/web/src/components/track/RemixContestCountdown.tsx
+++ b/packages/web/src/components/track/RemixContestCountdown.tsx
@@ -1,3 +1,5 @@
+import { useFeatureFlag } from '@audius/common/hooks'
+import { FeatureFlags } from '@audius/common/services'
 import { useRemixContest } from '@audius/common/src/api/tan-query/events/useRemixContest'
 import { useRemixCountdown } from '@audius/common/src/hooks/useRemixCountdown'
 import { ID } from '@audius/common/src/models/Identifiers'
@@ -39,11 +41,14 @@ type RemixContestCountdownProps = {
 export const RemixContestCountdown = ({
   trackId
 }: RemixContestCountdownProps) => {
+  const { isEnabled: isRemixContestEnabled } = useFeatureFlag(
+    FeatureFlags.REMIX_CONTEST
+  )
   const { data: remixContest } = useRemixContest(trackId)
   const timeLeft = useRemixCountdown(remixContest?.endDate)
   const isMobile = useIsMobile()
 
-  if (!remixContest || !timeLeft) return null
+  if (!remixContest || !timeLeft || !isRemixContestEnabled) return null
 
   return (
     <Paper


### PR DESCRIPTION
### Description

Fixes issue where the android remix end-date input would reopen randomly
Adds a feature to prevent the user from selecting a date in the past
Fixes an issue with missing filenames in mobile DownloadSection
Fixes a react-key issue in the download section
Fixes issue where RemixContestCountdown was showing when the remix feature was off