### PR TITLE
[PE-5979] Remix countdown styling updates

### DIFF
--- a/packages/common/src/hooks/useRemixCountdown.ts
+++ b/packages/common/src/hooks/useRemixCountdown.ts
@@ -2,16 +2,26 @@ import { useState, useEffect } from 'react'
 
 import dayjs from 'dayjs'
 
+type TimeUnit = {
+  value: number
+  isSubdued: boolean
+}
+
 type TimeLeft = {
-  days: number
-  hours: number
-  minutes: number
-  seconds: number
+  days: TimeUnit
+  hours: TimeUnit
+  minutes: TimeUnit
+  seconds: TimeUnit
 } | null
 
 /**
  * Hook that calculates time remaining until a given end date
- * Returns null if the end date has passed
+ * Returns null if the end date has passed.
+ * Each time unit includes an isSubdued flag that is true if:
+ * 1. For days: the value is 0
+ * 2. For hours: days is 0 and hours is 0
+ * 3. For minutes: hours is subdued and minutes is 0
+ * 4. For seconds: minutes is subdued and seconds is 0
  */
 export const useRemixCountdown = (endDate?: string): TimeLeft => {
   const [timeLeft, setTimeLeft] = useState<TimeLeft>(null)
@@ -30,11 +40,34 @@ export const useRemixCountdown = (endDate?: string): TimeLeft => {
       }
 
       const duration = dayjs.duration(diff)
+      const daysValue = duration.days()
+      const hoursValue = duration.hours()
+      const minutesValue = duration.minutes()
+      const secondsValue = duration.seconds()
+
+      // Calculate subdued states based on leading zeros
+      const isDaysSubdued = daysValue === 0
+      const isHoursSubdued = isDaysSubdued && hoursValue === 0
+      const isMinutesSubdued = isHoursSubdued && minutesValue === 0
+      const isSecondsSubdued = isMinutesSubdued && secondsValue === 0
+
       setTimeLeft({
-        days: duration.days(),
-        hours: duration.hours(),
-        minutes: duration.minutes(),
-        seconds: duration.seconds()
+        days: {
+          value: daysValue,
+          isSubdued: isDaysSubdued
+        },
+        hours: {
+          value: hoursValue,
+          isSubdued: isHoursSubdued
+        },
+        minutes: {
+          value: minutesValue,
+          isSubdued: isMinutesSubdued
+        },
+        seconds: {
+          value: secondsValue,
+          isSubdued: isSecondsSubdued
+        }
       })
     }
 

--- a/packages/mobile/src/screens/track-screen/RemixContestCountdown.tsx
+++ b/packages/mobile/src/screens/track-screen/RemixContestCountdown.tsx
@@ -16,15 +16,16 @@ const messages = {
 type TimeUnitProps = {
   value: number
   label: string
+  isSubdued: boolean
 }
 
-const TimeUnit = ({ value, label }: TimeUnitProps) => {
+const TimeUnit = ({ value, label, isSubdued }: TimeUnitProps) => {
   return (
     <Flex column alignItems='center' justifyContent='center'>
-      <Text variant='heading' color='inverse'>
+      <Text variant='heading' color={isSubdued ? 'subdued' : 'inverse'}>
         {formatDoubleDigit(value)}
       </Text>
-      <Text variant='label' color='inverse' size='xs'>
+      <Text variant='label' color={isSubdued ? 'subdued' : 'inverse'} size='xs'>
         {label}
       </Text>
     </Flex>
@@ -56,13 +57,29 @@ export const RemixContestCountdown = ({
         alignItems='center'
         style={{ opacity: 0.8 }}
       >
-        <TimeUnit value={timeLeft.days} label={messages.days} />
+        <TimeUnit
+          value={timeLeft.days.value}
+          label={messages.days}
+          isSubdued={timeLeft.days.isSubdued}
+        />
         <Divider orientation='vertical' />
-        <TimeUnit value={timeLeft.hours} label={messages.hours} />
+        <TimeUnit
+          value={timeLeft.hours.value}
+          label={messages.hours}
+          isSubdued={timeLeft.hours.isSubdued}
+        />
         <Divider orientation='vertical' />
-        <TimeUnit value={timeLeft.minutes} label={messages.minutes} />
+        <TimeUnit
+          value={timeLeft.minutes.value}
+          label={messages.minutes}
+          isSubdued={timeLeft.minutes.isSubdued}
+        />
         <Divider orientation='vertical' />
-        <TimeUnit value={timeLeft.seconds} label={messages.seconds} />
+        <TimeUnit
+          value={timeLeft.seconds.value}
+          label={messages.seconds}
+          isSubdued={timeLeft.seconds.isSubdued}
+        />
       </Flex>
     </Paper>
   )

--- a/packages/web/src/components/track/RemixContestCountdown.tsx
+++ b/packages/web/src/components/track/RemixContestCountdown.tsx
@@ -5,6 +5,7 @@ import { useRemixCountdown } from '@audius/common/src/hooks/useRemixCountdown'
 import { ID } from '@audius/common/src/models/Identifiers'
 import { formatDoubleDigit } from '@audius/common/src/utils/formatUtil'
 import { Text, Flex, spacing, Divider, Paper } from '@audius/harmony'
+import { CSSObject } from '@emotion/styled'
 
 import { useIsMobile } from 'hooks/useIsMobile'
 import { zIndex } from 'utils/zIndex'
@@ -19,15 +20,16 @@ const messages = {
 type TimeUnitProps = {
   value: number
   label: string
+  isSubdued: boolean
 }
 
-const TimeUnit = ({ value, label }: TimeUnitProps) => {
+const TimeUnit = ({ value, label, isSubdued }: TimeUnitProps) => {
   return (
     <Flex column alignItems='center' justifyContent='center'>
-      <Text variant='heading' color='inverse'>
+      <Text variant='heading' color={isSubdued ? 'subdued' : 'inverse'}>
         {formatDoubleDigit(value)}
       </Text>
-      <Text variant='label' color='inverse' size='xs'>
+      <Text variant='label' color={isSubdued ? 'subdued' : 'inverse'} size='xs'>
         {label}
       </Text>
     </Flex>
@@ -47,6 +49,14 @@ export const RemixContestCountdown = ({
   const { data: remixContest } = useRemixContest(trackId)
   const timeLeft = useRemixCountdown(remixContest?.endDate)
   const isMobile = useIsMobile()
+  const styles: CSSObject = isMobile
+    ? {}
+    : {
+        position: 'absolute',
+        top: spacing['2xl'],
+        right: 0,
+        zIndex: zIndex.REMIX_CONTEST_COUNT_DOWN
+      }
 
   if (!remixContest || !timeLeft || !isRemixContestEnabled) return null
 
@@ -58,25 +68,31 @@ export const RemixContestCountdown = ({
       justifyContent='center'
       alignItems='center'
       borderRadius='l'
-      css={
-        isMobile
-          ? {}
-          : {
-              position: 'absolute',
-              top: spacing['2xl'],
-              right: spacing.unit15,
-              opacity: 0.8,
-              zIndex: zIndex.REMIX_CONTEST_COUNT_DOWN
-            }
-      }
+      css={{ ...styles, opacity: 0.8 } as CSSObject}
     >
-      <TimeUnit value={timeLeft.days} label={messages.days} />
+      <TimeUnit
+        value={timeLeft.days.value}
+        label={messages.days}
+        isSubdued={timeLeft.days.isSubdued}
+      />
       <Divider color='default' orientation='vertical' />
-      <TimeUnit value={timeLeft.hours} label={messages.hours} />
+      <TimeUnit
+        value={timeLeft.hours.value}
+        label={messages.hours}
+        isSubdued={timeLeft.hours.isSubdued}
+      />
       <Divider color='default' orientation='vertical' />
-      <TimeUnit value={timeLeft.minutes} label={messages.minutes} />
+      <TimeUnit
+        value={timeLeft.minutes.value}
+        label={messages.minutes}
+        isSubdued={timeLeft.minutes.isSubdued}
+      />
       <Divider color='default' orientation='vertical' />
-      <TimeUnit value={timeLeft.seconds} label={messages.seconds} />
+      <TimeUnit
+        value={timeLeft.seconds.value}
+        label={messages.seconds}
+        isSubdued={timeLeft.seconds.isSubdued}
+      />
     </Paper>
   )
 }

--- a/packages/web/src/pages/track-page/components/desktop/TrackPage.tsx
+++ b/packages/web/src/pages/track-page/components/desktop/TrackPage.tsx
@@ -169,8 +169,10 @@ const TrackPage = ({
       fromOpacity={1}
       noIndex={defaults.isUnlisted}
     >
-      <Box w='100%' css={{ position: 'absolute', height: '376px' }}>
+      <FlushPageContainer>
         <RemixContestCountdown trackId={heroTrack?.track_id ?? 0} />
+      </FlushPageContainer>
+      <Box w='100%' css={{ position: 'absolute', height: '376px' }}>
         <CoverPhoto loading={loading} userId={user ? user.user_id : null} />
         <EmptyStatBanner />
         <EmptyNavBanner />


### PR DESCRIPTION
### Description
- Fix right-margin for web timer
- Add subdued color for '00' time units.

### How Has This Been Tested?

![Simulator Screenshot - iPhone 16 Pro - 2025-04-17 at 14 38 34](https://github.com/user-attachments/assets/3ed26119-4f29-4c16-b3ad-24b10b6212d1)
<img width="445" alt="Screenshot 2025-04-17 at 2 38 07 PM" src="https://github.com/user-attachments/assets/0f7e5100-eb9c-4931-9843-074b2e4a8215" />
<img width="1920" alt="Screenshot 2025-04-17 at 2 35 23 PM" src="https://github.com/user-attachments/assets/ccf8de67-e667-4a35-8419-0665d8f73cb7" />
