### PR TITLE
[PE-5954] Download section styling updates

### DIFF
--- a/packages/mobile/src/screens/track-screen/DownloadSection.tsx
+++ b/packages/mobile/src/screens/track-screen/DownloadSection.tsx
@@ -146,7 +146,7 @@ export const DownloadSection = ({ trackId }: { trackId: ID }) => {
 
   const renderHeader = () => {
     return (
-      <Flex gap='l' column>
+      <Flex gap='l' column pb={isExpanded ? 'l' : undefined}>
         <Flex row justifyContent='space-between' alignItems='center'>
           <Flex row alignItems='center' gap='s'>
             <IconReceive color='default' />
@@ -191,16 +191,14 @@ export const DownloadSection = ({ trackId }: { trackId: ID }) => {
           </Flex>
         ) : null}
         {isDownloadAllTrackFilesEnabled && !shouldHideDownload ? (
-          <Flex row alignItems='center' alignSelf='flex-start'>
-            <Button
-              variant='secondary'
-              size='small'
-              onPress={handleDownloadAll}
-              fullWidth
-            >
-              {messages.downloadAll}
-            </Button>
-          </Flex>
+          <Button
+            variant='secondary'
+            size='small'
+            onPress={handleDownloadAll}
+            fullWidth
+          >
+            {messages.downloadAll}
+          </Button>
         ) : null}
         {shouldDisplayOwnerPremiumDownloads && formattedPrice ? (
           <Flex>

--- a/packages/web/src/components/track/DownloadRow.tsx
+++ b/packages/web/src/components/track/DownloadRow.tsx
@@ -84,33 +84,31 @@ export const DownloadRow = ({
         <Text variant='body' color='subdued'>
           {index}
         </Text>
-        <Flex direction='column' gap='xs' css={{ overflow: 'hidden' }} w='100%'>
-          <Text variant='body' strength='default'>
-            {category
-              ? stemCategoryFriendlyNames[category]
-              : track?.stem_of?.category
-                ? stemCategoryFriendlyNames[track?.stem_of?.category]
-                : messages.fullTrack}
-          </Text>
-          <Text
-            variant='body'
-            color='subdued'
-            css={{
-              overflow: 'hidden',
-              textOverflow: 'ellipsis',
-              whiteSpace: 'nowrap'
-            }}
-          >
-            {filename ??
-              (track && user
-                ? getFilename({
-                    track,
-                    user,
-                    isOriginal: true
-                  })
-                : null)}
-          </Text>
-        </Flex>
+        <Text variant='body' strength='default'>
+          {category
+            ? stemCategoryFriendlyNames[category]
+            : track?.stem_of?.category
+              ? stemCategoryFriendlyNames[track?.stem_of?.category]
+              : messages.fullTrack}
+        </Text>
+        <Text
+          variant='body'
+          color='subdued'
+          css={{
+            overflow: 'hidden',
+            textOverflow: 'ellipsis',
+            whiteSpace: 'nowrap'
+          }}
+        >
+          {filename ??
+            (track && user
+              ? getFilename({
+                  track,
+                  user,
+                  isOriginal: true
+                })
+              : null)}
+        </Text>
       </Flex>
       <Flex gap='2xl'>
         {size && !isMobile ? (


### PR DESCRIPTION
### Description
- On web, move filenames and stem type to same row
- Fix bottom padding on mobile

### How Has This Been Tested?
<img width="758" alt="Screenshot 2025-04-17 at 2 52 32 PM" src="https://github.com/user-attachments/assets/0df052dc-bdae-461f-af1e-f6b9ea68719b" />

<img width="518" alt="Screenshot 2025-04-17 at 2 50 46 PM" src="https://github.com/user-attachments/assets/4940a01b-a6a8-4a3e-b627-bc1d2bde43dc" />

![Simulator Screenshot - iPhone 16 Pro - 2025-04-17 at 14 50 25](https://github.com/user-attachments/assets/ca53d656-2354-4303-a2ca-dfc19b460848)
