### PR TITLE
Identify email to amplitude

### DIFF
--- a/packages/common/src/audius-query/AudiusQueryContext.ts
+++ b/packages/common/src/audius-query/AudiusQueryContext.ts
@@ -17,6 +17,7 @@ import {
 import {
   AllTrackingEvents,
   AnalyticsEvent,
+  IdentifyTraits,
   ReportToSentryArgs
 } from '../models'
 
@@ -39,8 +40,7 @@ export type AudiusQueryContextType = {
     init: (isMobile: boolean) => Promise<void>
     track: (event: AnalyticsEvent, callback?: () => void) => Promise<void>
     identify: (
-      handle: string,
-      traits?: Record<string, unknown>,
+      traits: IdentifyTraits,
       options?: Record<string, unknown>,
       callback?: () => void
     ) => Promise<void>

--- a/packages/common/src/models/Analytics.ts
+++ b/packages/common/src/models/Analytics.ts
@@ -20,6 +20,13 @@ const ANALYTICS_TRACK_EVENT = 'ANALYTICS/TRACK_EVENT'
 
 type JsonMap = Record<string, unknown>
 
+export type IdentifyTraits = {
+  handle?: string
+  name?: string
+  email?: string
+  userId?: ID
+}
+
 export type AnalyticsEvent = {
   eventName: string
   properties?: JsonMap

--- a/packages/common/src/store/account/sagas.ts
+++ b/packages/common/src/store/account/sagas.ts
@@ -141,12 +141,15 @@ function* initializeMetricsForUser({
     const traits = {
       isVerified: accountUser.is_verified,
       trackCount: accountUser.track_count,
+      handle: accountUser.handle,
+      name: accountUser.name,
+      userId: accountUser.user_id,
       managerHandle,
       managerUserId,
       solanaWallet
     }
 
-    yield* call([analytics, analytics.identify], accountUser.handle, traits)
+    yield* call([analytics, analytics.identify], traits)
     yield* call(setSentryUser, accountUser, traits)
   }
 }

--- a/packages/common/src/store/storeContext.ts
+++ b/packages/common/src/store/storeContext.ts
@@ -12,6 +12,7 @@ import { SolanaWalletService } from '~/services/solana'
 import {
   AllTrackingEvents,
   AnalyticsEvent,
+  IdentifyTraits,
   LineupState,
   ReportToSentryArgs,
   Track
@@ -40,8 +41,7 @@ export type CommonStoreContext = {
     init: (isMobile: boolean) => Promise<void>
     track: (event: AnalyticsEvent, callback?: () => void) => Promise<void>
     identify: (
-      handle: string,
-      traits?: Record<string, unknown>,
+      traits?: IdentifyTraits,
       options?: Record<string, unknown>,
       callback?: () => void
     ) => Promise<void>

--- a/packages/mobile/src/screens/sign-on-screen/screens/CreateEmailScreen.tsx
+++ b/packages/mobile/src/screens/sign-on-screen/screens/CreateEmailScreen.tsx
@@ -27,6 +27,7 @@ import {
   TextLink
 } from '@audius/harmony-native'
 import { useNavigation } from 'app/hooks/useNavigation'
+import { identify } from 'app/services/analytics'
 import { resetOAuthState } from 'app/store/oauth/actions'
 
 import { NewEmailField } from '../components/NewEmailField'
@@ -68,6 +69,7 @@ export const CreateEmailScreen = (props: SignOnScreenProps) => {
       const { email } = values
       dispatch(setValueField('email', email))
       dispatch(startSignUp())
+      identify({ email })
       navigation.navigate('CreatePassword')
     },
     [dispatch, navigation]

--- a/packages/mobile/src/screens/sign-on-screen/screens/PickHandleScreen.tsx
+++ b/packages/mobile/src/screens/sign-on-screen/screens/PickHandleScreen.tsx
@@ -23,6 +23,7 @@ import {
 } from '@audius/harmony-native'
 import { ScrollView } from 'app/components/core'
 import { useNavigation } from 'app/hooks/useNavigation'
+import { identify } from 'app/services/analytics'
 
 import { HandleField } from '../components/HandleField'
 import { SocialMediaLoading } from '../components/SocialMediaLoading'
@@ -120,6 +121,7 @@ export const PickHandleScreen = () => {
     (values: PickHandleValues) => {
       const { handle } = values
       dispatch(setValueField('handle', handle))
+      identify({ handle })
       navigation.navigate('FinishProfile')
     },
     [dispatch, navigation]

--- a/packages/mobile/src/services/analytics.ts
+++ b/packages/mobile/src/services/analytics.ts
@@ -6,6 +6,7 @@ import {
   Identify,
   Types as AmplitudeTypes
 } from '@amplitude/analytics-react-native'
+import type { IdentifyTraits } from '@audius/common/models'
 import VersionNumber from 'react-native-version-number'
 
 import { env } from 'app/services/env'
@@ -77,14 +78,16 @@ export const make = (event: AllEvents) => {
 }
 
 // Identify User
-export const identify = async (
-  handle: string,
-  traits: Record<string, any> = {}
-) => {
+export const identify = async (traits: IdentifyTraits) => {
   const isSetup = await isAudiusSetup()
   if (!isSetup) return
 
-  setUserId(handle)
+  if (traits.handle) {
+    setUserId(traits.handle)
+  } else if (traits.email) {
+    // Use email as our user identifier before we have handle (works better for partial accounts in the signup flow)
+    setUserId(traits.email)
+  }
   const identifyObj = new Identify()
   Object.entries(traits).forEach(([key, value]) => {
     identifyObj.set(key, value)

--- a/packages/web/src/common/store/analytics/actions.ts
+++ b/packages/web/src/common/store/analytics/actions.ts
@@ -1,21 +1,19 @@
 import { useCallback } from 'react'
 
-import { Name, AllTrackingEvents } from '@audius/common/models'
+import { Name, AllTrackingEvents, IdentifyTraits } from '@audius/common/models'
 import { useDispatch as useDispatchRedux } from 'react-redux'
 
 /** UI EVENTS */
 export const IDENTIFY = 'ANALYTICS/IDENTIFY'
 export const TRACK = 'ANALYTICS/TRACK'
 
-export const identify = (handle: string, traits?: Record<string, any>) => ({
+export const identify = (traits?: IdentifyTraits) => ({
   type: IDENTIFY,
-  handle,
   traits
 })
 
 export type IdentifyEvent = {
   type: typeof IDENTIFY
-  handle: string
   traits: Record<string, any>
 }
 

--- a/packages/web/src/common/store/analytics/sagas.ts
+++ b/packages/web/src/common/store/analytics/sagas.ts
@@ -24,7 +24,7 @@ function* trackEventAsync(action: TrackEvent) {
 
 function* identifyEventAsync(action: IdentifyEvent) {
   const analytics = yield* getContext('analytics')
-  yield call(analytics.identify, action.handle, action.traits)
+  yield call(analytics.identify, action.traits)
 }
 
 function* watchTrackEvent() {

--- a/packages/web/src/common/store/pages/signon/sagas.ts
+++ b/packages/web/src/common/store/pages/signon/sagas.ts
@@ -704,7 +704,8 @@ function* signUp() {
             }
 
             yield* put(
-              identify(handle, {
+              identify({
+                handle,
                 name,
                 email,
                 userId
@@ -916,6 +917,11 @@ function* signIn(action: ReturnType<typeof signOnActions.signIn>) {
       })
 
       yield* put(toastActions.toast({ content: messages.incompleteAccount }))
+      yield* put(
+        make(Name.SIGN_IN_WITH_INCOMPLETE_ACCOUNT, {
+          email
+        })
+      )
       return
     }
 
@@ -954,6 +960,7 @@ function* signIn(action: ReturnType<typeof signOnActions.signIn>) {
 
       yield* put(
         make(Name.SIGN_IN_WITH_INCOMPLETE_ACCOUNT, {
+          email,
           handle: user.handle
         })
       )
@@ -1000,6 +1007,7 @@ function* signIn(action: ReturnType<typeof signOnActions.signIn>) {
     yield* put(pushRoute(route || FEED_PAGE))
 
     const trackEvent = make(Name.SIGN_IN_FINISH, { status: 'success' })
+
     yield* put(trackEvent)
 
     yield* put(signOnActions.resetSignOn())

--- a/packages/web/src/pages/sign-in-page/SignInPage.tsx
+++ b/packages/web/src/pages/sign-in-page/SignInPage.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useMemo, useState } from 'react'
 
+import { identify } from '@amplitude/analytics-browser'
 import { useAudiusQueryContext } from '@audius/common/audius-query'
 import { signInPageMessages } from '@audius/common/messages'
 import { signInSchema, signInErrorMessages } from '@audius/common/schemas'
@@ -86,6 +87,7 @@ export const SignInPage = () => {
       dispatch(setValueField('email', email))
       dispatch(setValueField('password', password))
       dispatch(signIn(email, password))
+      identify({ email })
     },
     [dispatch]
   )

--- a/packages/web/src/pages/sign-in-page/SignInPage.tsx
+++ b/packages/web/src/pages/sign-in-page/SignInPage.tsx
@@ -1,6 +1,5 @@
 import { useCallback, useEffect, useMemo, useState } from 'react'
 
-import { identify } from '@amplitude/analytics-browser'
 import { useAudiusQueryContext } from '@audius/common/audius-query'
 import { signInPageMessages } from '@audius/common/messages'
 import { signInSchema, signInErrorMessages } from '@audius/common/schemas'
@@ -35,6 +34,7 @@ import { GuestEmailHint } from 'pages/sign-on-page/GuestEmailHint'
 import { EmailField } from 'pages/sign-up-page/components/EmailField'
 import { ForgotPasswordModal } from 'pages/sign-up-page/components/ForgotPasswordModal'
 import { Heading, ScrollView } from 'pages/sign-up-page/components/layout'
+import { identify } from 'services/analytics'
 import { useSelector } from 'utils/reducer'
 
 import { SignInWithMetaMaskButton } from './SignInWithMetaMaskButton'

--- a/packages/web/src/pages/sign-up-page/pages/CreateEmailPage.tsx
+++ b/packages/web/src/pages/sign-up-page/pages/CreateEmailPage.tsx
@@ -37,6 +37,7 @@ import PreloadImage from 'components/preload-image/PreloadImage'
 import { useMedia } from 'hooks/useMedia'
 import { useNavigateToPage } from 'hooks/useNavigateToPage'
 import { SocialMediaLoginOptions } from 'pages/sign-up-page/components/SocialMediaLoginOptions'
+import { identify } from 'services/analytics'
 
 import { ExternalWalletSignUpModal } from '../components/ExternalWalletSignUpModal'
 import { NewEmailField } from '../components/NewEmailField'
@@ -108,6 +109,9 @@ export const CreateEmailPage = () => {
       const { email, withMetaMask } = values
       dispatch(startSignUp())
       dispatch(setValueField('email', email))
+      identify({
+        email
+      })
       if (withMetaMask) {
         openExternalWalletSignUpModal()
       } else {

--- a/packages/web/src/pages/sign-up-page/pages/PickHandlePage.tsx
+++ b/packages/web/src/pages/sign-up-page/pages/PickHandlePage.tsx
@@ -25,6 +25,7 @@ import {
 import { ToastContext } from 'components/toast/ToastContext'
 import { useMedia } from 'hooks/useMedia'
 import { useNavigateToPage } from 'hooks/useNavigateToPage'
+import { identify } from 'services/analytics'
 import { restrictedHandles } from 'utils/restrictedHandles'
 
 import { HandleField } from '../components/HandleField'
@@ -123,6 +124,7 @@ export const PickHandlePage = () => {
   const handleSubmit = useCallback(
     (values: PickHandleValues) => {
       const { handle } = values
+      identify({ handle })
       dispatch(setValueField('handle', handle))
       if (isFastReferral) {
         dispatch(setValueField('name', handle))

--- a/packages/web/src/services/analytics/amplitude.ts
+++ b/packages/web/src/services/analytics/amplitude.ts
@@ -1,6 +1,6 @@
 import * as amplitude from '@amplitude/analytics-browser'
 import { sessionReplayPlugin } from '@amplitude/plugin-session-replay-browser'
-import { Name, MobileOS } from '@audius/common/models'
+import { Name, MobileOS, IdentifyTraits } from '@audius/common/models'
 
 import { env } from 'services/env'
 import { isElectron as getIsElectron, getMobileOS } from 'utils/clientUtil'
@@ -38,21 +38,25 @@ export const init = async (isMobile: boolean) => {
 }
 
 // Identify User
-export const identify = (
-  handle: string,
-  traits?: Record<string, any>,
-  callback?: () => void
-) => {
+export const identify = (traits?: IdentifyTraits, callback?: () => void) => {
   if (!isAmplitudeConfigured) {
     if (callback) callback()
     return
   }
-  amplitude.setUserId(handle)
+
+  if (traits?.handle) {
+    amplitude.setUserId(traits.handle)
+  } else if (traits?.email) {
+    // Use email as our user identifier before we have handle (works better for partial accounts in the signup flow)
+    amplitude.setUserId(traits.email)
+  }
+
   if (traits && Object.keys(traits).length > 0) {
     const identifyObj = new amplitude.Identify()
     Object.entries(traits).map(([k, v]) => identifyObj.add(k, v))
     amplitude.identify(identifyObj)
   }
+  console.log('callback', callback)
   if (callback) callback()
 }
 

--- a/packages/web/src/services/analytics/amplitude.ts
+++ b/packages/web/src/services/analytics/amplitude.ts
@@ -53,10 +53,10 @@ export const identify = (traits?: IdentifyTraits, callback?: () => void) => {
 
   if (traits && Object.keys(traits).length > 0) {
     const identifyObj = new amplitude.Identify()
+    // @ts-ignore - for some reason it doesn't want you to pass strings, but it works fine
     Object.entries(traits).map(([k, v]) => identifyObj.add(k, v))
     amplitude.identify(identifyObj)
   }
-  console.log('callback', callback)
   if (callback) callback()
 }
 

--- a/packages/web/src/services/analytics/index.ts
+++ b/packages/web/src/services/analytics/index.ts
@@ -1,4 +1,8 @@
-import { AnalyticsEvent, AllTrackingEvents } from '@audius/common/models'
+import {
+  AnalyticsEvent,
+  AllTrackingEvents,
+  IdentifyTraits
+} from '@audius/common/models'
 import { Nullable } from '@audius/common/utils'
 
 import { env } from 'services/env'
@@ -63,18 +67,17 @@ export const track = async (
 }
 
 export const identify = async (
-  handle: string,
-  traits?: Record<string, any>,
+  traits: IdentifyTraits,
   options?: Record<string, any>,
   callback?: () => void
 ) => {
   try {
     if (!IS_PRODUCTION_BUILD) {
-      console.info('Amplitude | identify', handle, traits, options)
+      console.info('Amplitude | identify', { traits, options })
     }
 
     await didInit
-    return amplitude.identify(handle, traits, callback)
+    return amplitude.identify(traits, callback)
   } catch (err) {
     console.error(err)
   }

--- a/packages/web/src/services/analytics/index.ts
+++ b/packages/web/src/services/analytics/index.ts
@@ -67,7 +67,7 @@ export const track = async (
 }
 
 export const identify = async (
-  traits: IdentifyTraits,
+  traits?: IdentifyTraits,
   options?: Record<string, any>,
   callback?: () => void
 ) => {
@@ -75,7 +75,9 @@ export const identify = async (
     if (!IS_PRODUCTION_BUILD) {
       console.info('Amplitude | identify', { traits, options })
     }
-
+    if (!traits) {
+      return
+    }
     await didInit
     return amplitude.identify(traits, callback)
   } catch (err) {


### PR DESCRIPTION
### Description

While debugging accounts I noticed that we were lacking some info on what emails people were using; would have been especially helpful for this bug where people had multiple handles with the same email.

- Use email as the amplitude identifier before we have handle
- Light refactors to the identify method

### How Has This Been Tested?

web:stage / ios:stage
