### PR TITLE
[PE-6001] Fix remix count filtering for deleted events

### DIFF
--- a/packages/discovery-provider/src/queries/get_remixes_of.py
+++ b/packages/discovery-provider/src/queries/get_remixes_of.py
@@ -96,6 +96,7 @@ def get_remixes_of(args):
                     and_(
                         Event.entity_id == ParentTrack.track_id,
                         Event.event_type == EventType.remix_contest,
+                        Event.is_deleted == False,
                     ),
                 )
                 .filter(


### PR DESCRIPTION
### Description

Remix count should filter out deleted events 🤦‍♂️

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._

Ran the raw SQL query against stage to find the bug and confirmed this fix works. 