### PR TITLE
Limit cosign challenge to 5 per month

### DIFF
--- a/packages/discovery-provider/ddl/migrations/0135_limit_cosign_challenges.sql
+++ b/packages/discovery-provider/ddl/migrations/0135_limit_cosign_challenges.sql
@@ -1,0 +1,43 @@
+-- applying retroactive removal of cosign limiting
+-- a verified artist can only cosign reward 5 tracks per week
+with actions as (
+    select user_id,
+        save_item_id as item_id,
+        created_at
+    from saves
+    where created_at >= '2025-04-08 17:26:30+00'
+        and saves.save_type = 'track'
+    union all
+    select user_id,
+        repost_item_id as item_id,
+        created_at
+    from reposts
+    where created_at >= '2025-04-08 17:26:30+00'
+        and reposts.repost_type = 'track'
+),
+verified_actions as (
+    select a.*,
+        row_number() over (
+            partition by a.user_id
+            order by a.created_at
+        ) as rn
+    from actions a
+        join users u on a.user_id = u.user_id
+    where u.is_verified
+),
+allowed_challenges as (
+    select uc.challenge_id,
+        uc.user_id,
+        uc.specifier
+    from verified_actions va
+        join user_challenges uc on uc.specifier = to_hex(va.item_id)
+    where va.rn <= 5
+)
+delete from user_challenges uc
+where uc.challenge_id = 'cs'
+    and not exists (
+        select 1
+        from allowed_challenges ac
+        where ac.user_id = uc.user_id
+            and ac.specifier = uc.specifier
+    );

--- a/packages/discovery-provider/ddl/migrations/0135_limit_cosign_challenges.sql
+++ b/packages/discovery-provider/ddl/migrations/0135_limit_cosign_challenges.sql
@@ -1,19 +1,18 @@
--- applying retroactive removal of cosign limiting
--- a verified artist can only cosign reward 5 tracks per week
-with actions as (
+begin;
+CREATE TEMP TABLE allowed_challenges AS with actions as (
     select user_id,
         save_item_id as item_id,
         created_at
     from saves
     where created_at >= '2025-04-08 17:26:30+00'
-        and saves.save_type = 'track'
+        and save_type = 'track'
     union all
     select user_id,
         repost_item_id as item_id,
         created_at
     from reposts
     where created_at >= '2025-04-08 17:26:30+00'
-        and reposts.repost_type = 'track'
+        and repost_type = 'track'
 ),
 verified_actions as (
     select a.*,
@@ -24,15 +23,15 @@ verified_actions as (
     from actions a
         join users u on a.user_id = u.user_id
     where u.is_verified
-),
-allowed_challenges as (
-    select uc.challenge_id,
-        uc.user_id,
-        uc.specifier
-    from verified_actions va
-        join user_challenges uc on uc.specifier = to_hex(va.item_id)
-    where va.rn <= 5
 )
+select uc.challenge_id,
+    uc.user_id,
+    uc.specifier as specifier,
+    to_hex(va.user_id) || ':' || uc.specifier as new_specifier
+from verified_actions va
+    join user_challenges uc on uc.specifier = to_hex(va.item_id)
+where va.rn <= 5;
+-- 1. DELETE existing cosign challenges to respect new limit
 delete from user_challenges uc
 where uc.challenge_id = 'cs'
     and not exists (
@@ -41,3 +40,11 @@ where uc.challenge_id = 'cs'
         where ac.user_id = uc.user_id
             and ac.specifier = uc.specifier
     );
+-- 2. UPDATE allowed entries specifier to user_id:track_id
+update user_challenges
+set specifier = ac.new_specifier
+from allowed_challenges ac
+where user_challenges.challenge_id = 'cs'
+    and user_challenges.user_id = ac.user_id
+    and user_challenges.specifier = ac.specifier;
+commit;

--- a/packages/discovery-provider/integration_tests/challenges/test_cosign_challenge.py
+++ b/packages/discovery-provider/integration_tests/challenges/test_cosign_challenge.py
@@ -1,8 +1,6 @@
 import logging
 from datetime import datetime, timedelta
 
-from sqlalchemy.orm.session import Session
-
 from src.challenges.challenge_event_bus import ChallengeEvent, ChallengeEventBus
 from src.challenges.cosign_challenge import cosign_challenge_manager
 from src.models.indexing.block import Block

--- a/packages/discovery-provider/integration_tests/challenges/test_cosign_challenge.py
+++ b/packages/discovery-provider/integration_tests/challenges/test_cosign_challenge.py
@@ -1,5 +1,5 @@
 import logging
-from datetime import datetime
+from datetime import datetime, timedelta
 
 from sqlalchemy.orm.session import Session
 
@@ -19,18 +19,23 @@ BLOCK_NUMBER = 10
 
 
 def dispatch_cosign(
-    session: Session,
     bus: ChallengeEventBus,
-    track_id: int = 1,
-    track_owner_id: int = 1,
+    track_id: int,
+    original_track_owner_id: int,
+    track_owner_id: int,
+    date: datetime,
 ):
     """Dispatch a cosign event"""
     bus.dispatch(
         ChallengeEvent.cosign,
         BLOCK_NUMBER,
-        datetime.now(),
+        date,
         track_owner_id,
-        {"track_id": track_id},
+        {
+            "original_track_owner_id": original_track_owner_id,
+            "remix_track_id": track_id,
+            "cosign_date": date.timestamp(),
+        },
     )
 
 
@@ -85,14 +90,27 @@ def test_cosign_challenge(app):
     with db.scoped_session() as session:
         setup_challenges(session)
 
-        def dc(track_id=1, user_id=1):
-            return dispatch_cosign(session, bus, track_id, user_id)
+        def dc(
+            track_id: int,
+            original_track_owner_id: int,
+            remixer_user_id: int,
+            date: datetime,
+        ):
+            return dispatch_cosign(
+                bus, track_id, original_track_owner_id, remixer_user_id, date
+            )
 
         scope_and_process = make_scope_and_process(bus, session)
 
-        scope_and_process(lambda: dc(0, 1))
+        # limited to 5 verified cosigns per month
+        for track_id in range(1, 10):
+            scope_and_process(
+                lambda: dc(track_id, 2, 1, datetime.now() - timedelta(days=50))
+            )
+
+        scope_and_process(lambda: dc(11, 2, 1, datetime.now()))
 
         # Check that the challenge is completed
         state = cosign_challenge_manager.get_user_challenge_state(session)
-        assert len(state) == 1
+        assert len(state) == 6
         assert state[0].is_complete == True

--- a/packages/discovery-provider/src/challenges/cosign_challenge.py
+++ b/packages/discovery-provider/src/challenges/cosign_challenge.py
@@ -1,4 +1,5 @@
 import logging
+from datetime import datetime, timedelta
 from typing import Dict
 
 from sqlalchemy.orm.session import Session
@@ -8,6 +9,8 @@ from src.models.rewards.user_challenge import UserChallenge
 
 logger = logging.getLogger(__name__)
 
+MAX_COSIGNS_PER_MONTH = 5
+
 
 class CosignChallengeUpdater(ChallengeUpdater):
     """
@@ -16,7 +19,7 @@ class CosignChallengeUpdater(ChallengeUpdater):
     """
 
     def generate_specifier(self, session: Session, user_id: int, extra: Dict) -> str:
-        return f"{hex(extra['track_id'])[2:]}"
+        return f"{hex(extra['original_track_owner_id'])[2:]}:{hex(extra['remix_track_id'])[2:]}"
 
     def should_create_new_challenge(
         self, session: Session, event: str, user_id: int, extra: Dict
@@ -26,19 +29,23 @@ class CosignChallengeUpdater(ChallengeUpdater):
         Return True if no challenge exists (should create a new one),
         False otherwise.
         """
+        specifier_prefix = f"{hex(extra['original_track_owner_id'])[2:]}"
+        one_month_ago = datetime.fromtimestamp(extra["cosign_date"]) - timedelta(
+            days=30
+        )
 
         existing_challenge = (
             session.query(UserChallenge)
             .filter(
                 UserChallenge.challenge_id == "cs",
-                UserChallenge.specifier
-                == self.generate_specifier(session, user_id, extra),
+                UserChallenge.specifier.like(f"{specifier_prefix}%"),  # Cosigner
                 UserChallenge.user_id == user_id,
+                UserChallenge.created_at >= one_month_ago,
             )
-            .first()
+            .all()
         )
 
-        return existing_challenge is None
+        return len(existing_challenge) < MAX_COSIGNS_PER_MONTH
 
 
 cosign_challenge_manager = ChallengeManager("cs", CosignChallengeUpdater())

--- a/packages/discovery-provider/src/tasks/entity_manager/entities/social_features.py
+++ b/packages/discovery-provider/src/tasks/entity_manager/entities/social_features.py
@@ -132,7 +132,11 @@ def create_social_record(params: ManageEntityParameters):
                     params.block_number,
                     params.block_datetime,
                     remixer,
-                    {"track_id": params.entity_id},
+                    {
+                        "original_track_owner_id": params.user_id,
+                        "remix_track_id": params.entity_id,
+                        "cosign_date": params.block_datetime.timestamp(),
+                    },
                 )
 
 


### PR DESCRIPTION
### Description
* Limit a verified user to giving out 5 cosign rewards per month.
* Clean up existing cosign challenge rewards to respect this condition ^. It's been out for a little bit over a week at this point but should be fine. Also update existing specifiers to new format `user_id:track_id`.
* When determining whether to create a user challenge, check for the user_id prefix and for challenges created in the last month.  

Resolves PE-5983

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._

Modified existing integration tests for dispatching cosign events and indexing user challenges.
Ran migration on stage DN.

Will do a E2E pass on stage to confirm