### PR TITLE
Fix cosign limit not just limiting to remixer

### DIFF
--- a/packages/discovery-provider/integration_tests/challenges/test_cosign_challenge.py
+++ b/packages/discovery-provider/integration_tests/challenges/test_cosign_challenge.py
@@ -101,10 +101,8 @@ def test_cosign_challenge(app):
         scope_and_process = make_scope_and_process(bus, session)
 
         # limited to 5 verified cosigns per month
-        for track_id in range(1, 10):
-            scope_and_process(
-                lambda: dc(track_id, 2, 1, datetime.now() - timedelta(days=50))
-            )
+        for i in range(1, 10):
+            scope_and_process(lambda: dc(i, 2, i, datetime.now() - timedelta(days=50)))
 
         scope_and_process(lambda: dc(11, 2, 1, datetime.now()))
 

--- a/packages/discovery-provider/src/challenges/cosign_challenge.py
+++ b/packages/discovery-provider/src/challenges/cosign_challenge.py
@@ -38,8 +38,7 @@ class CosignChallengeUpdater(ChallengeUpdater):
             session.query(UserChallenge)
             .filter(
                 UserChallenge.challenge_id == "cs",
-                UserChallenge.specifier.like(f"{specifier_prefix}%"),  # Cosigner
-                UserChallenge.user_id == user_id,
+                UserChallenge.specifier.like(f"{specifier_prefix}:%"),  # Cosigner
                 UserChallenge.created_at >= one_month_ago,
             )
             .all()


### PR DESCRIPTION
### Description

This limit was incorrectly applying to only 5 cosigns per remixer per month. It should only be limited to 5 cosigns from verified artist per month. 

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._

Modified test to send cosign events from multiple remixers.