### PR TITLE
Fix remix countdown timer wrong day count

### DIFF
--- a/packages/common/src/hooks/useRemixCountdown.ts
+++ b/packages/common/src/hooks/useRemixCountdown.ts
@@ -1,6 +1,6 @@
 import { useState, useEffect } from 'react'
 
-import dayjs from 'dayjs'
+import dayjs from '../utils/dayjs'
 
 type TimeUnit = {
   value: number
@@ -32,15 +32,18 @@ export const useRemixCountdown = (endDate?: string): TimeLeft => {
     const calculateTimeLeft = () => {
       const now = dayjs()
       const end = dayjs(endDate)
-      const diff = end.diff(now)
 
-      if (diff <= 0) {
+      if (end.isBefore(now)) {
         setTimeLeft(null)
         return
       }
 
-      const duration = dayjs.duration(diff)
-      const daysValue = duration.days()
+      // Calculate total days between dates
+      const totalDays = end.diff(now, 'days')
+      const remainingTime = end.diff(now)
+      const duration = dayjs.duration(remainingTime)
+
+      const daysValue = totalDays
       const hoursValue = duration.hours()
       const minutesValue = duration.minutes()
       const secondsValue = duration.seconds()


### PR DESCRIPTION
### Description
The issue was that duration.days() only returns the days component of the duration, not including the months. By using end.diff(now, 'days'), we get the total number of days between the dates, which is what we want for the countdown.

also import dayjs correctly

### How Has This Been Tested?

<img width="1217" alt="Screenshot 2025-04-21 at 12 33 48 PM" src="https://github.com/user-attachments/assets/2b456c94-63df-4024-a945-fc41c6f1c73f" />
