### PR TITLE
Fix remixes scroll bug

### DIFF
--- a/packages/common/src/api/tan-query/useAiTracks.ts
+++ b/packages/common/src/api/tan-query/useAiTracks.ts
@@ -95,6 +95,7 @@ export const useAiTracks = (
   })
 
   return useLineupQuery({
+    lineupData: queryData.data ?? [],
     queryData,
     queryKey: getAiTracksQueryKey({
       handle,

--- a/packages/common/src/api/tan-query/useFeed.ts
+++ b/packages/common/src/api/tan-query/useFeed.ts
@@ -124,6 +124,7 @@ export const useFeed = (
   })
 
   return useLineupQuery({
+    lineupData: queryData.data ?? [],
     queryData,
     queryKey: getFeedQueryKey({
       userId: currentUserId,

--- a/packages/common/src/api/tan-query/useLibraryTracks.ts
+++ b/packages/common/src/api/tan-query/useLibraryTracks.ts
@@ -129,6 +129,7 @@ export const useLibraryTracks = (
   })
 
   const lineupData = useLineupQuery({
+    lineupData: queryData.data ?? [],
     queryData,
     queryKey: getLibraryTracksQueryKey({
       currentUserId,

--- a/packages/common/src/api/tan-query/usePremiumTracks.ts
+++ b/packages/common/src/api/tan-query/usePremiumTracks.ts
@@ -86,6 +86,7 @@ export const usePremiumTracks = (
   })
 
   return useLineupQuery({
+    lineupData: queryData.data ?? [],
     queryData,
     queryKey: getPremiumTracksQueryKey(pageSize),
     lineupActions: premiumTracksPageLineupActions,

--- a/packages/common/src/api/tan-query/useProfileReposts.ts
+++ b/packages/common/src/api/tan-query/useProfileReposts.ts
@@ -119,6 +119,7 @@ export const useProfileReposts = (
   })
 
   return useLineupQuery({
+    lineupData: queryData.data ?? [],
     queryData,
     queryKey: getProfileRepostsQueryKey({
       handle,

--- a/packages/common/src/api/tan-query/useProfileTracks.ts
+++ b/packages/common/src/api/tan-query/useProfileTracks.ts
@@ -106,6 +106,7 @@ export const useProfileTracks = (
   })
 
   return useLineupQuery({
+    lineupData: queryData.data ?? [],
     queryData,
     queryKey: getProfileTracksQueryKey({
       handle,

--- a/packages/common/src/api/tan-query/useSearchResults.ts
+++ b/packages/common/src/api/tan-query/useSearchResults.ts
@@ -376,6 +376,7 @@ export const useSearchTrackResults = (
   })
 
   return useLineupQuery({
+    lineupData: queryData.data ?? [],
     queryData,
     queryKey: getSearchResultsQueryKey({
       ...searchArgs,

--- a/packages/common/src/api/tan-query/useTrackHistory.ts
+++ b/packages/common/src/api/tan-query/useTrackHistory.ts
@@ -113,6 +113,7 @@ export const useTrackHistory = (
   })
 
   return useLineupQuery({
+    lineupData: queryData.data ?? [],
     queryData,
     queryKey: getTrackHistoryQueryKey({
       pageSize,

--- a/packages/common/src/api/tan-query/useTrackPageLineup.ts
+++ b/packages/common/src/api/tan-query/useTrackPageLineup.ts
@@ -210,11 +210,8 @@ export const useTrackPageLineup = (
   const indices = queryData.data?.pages?.[0]?.indices
 
   const lineupData = useLineupQuery({
-    // @ts-ignore
-    queryData: {
-      ...queryData,
-      data: queryData.data?.pages.map((page) => page.tracks).flat()
-    },
+    lineupData: queryData.data?.pages.flatMap((page) => page.tracks) ?? [],
+    queryData,
     queryKey: getTrackPageLineupQueryKey(trackId),
     lineupActions: tracksActions,
     lineupSelector: trackPageSelectors.getLineup,

--- a/packages/common/src/api/tan-query/useTrending.ts
+++ b/packages/common/src/api/tan-query/useTrending.ts
@@ -171,6 +171,7 @@ export const useTrending = (
       break
   }
   return useLineupQuery({
+    lineupData: infiniteQueryData.data ?? [],
     queryData: infiniteQueryData,
     queryKey: getTrendingQueryKey({
       timeRange,

--- a/packages/common/src/api/tan-query/useTrendingPlaylists.ts
+++ b/packages/common/src/api/tan-query/useTrendingPlaylists.ts
@@ -100,6 +100,7 @@ export const useTrendingPlaylists = (
   })
 
   return useLineupQuery({
+    lineupData: queryData.data ?? [],
     queryData,
     queryKey: getTrendingPlaylistsQueryKey({
       pageSize,

--- a/packages/common/src/api/tan-query/useTrendingUnderground.ts
+++ b/packages/common/src/api/tan-query/useTrendingUnderground.ts
@@ -83,6 +83,7 @@ export const useTrendingUnderground = (
   })
 
   return useLineupQuery({
+    lineupData: queryData.data ?? [],
     queryData,
     queryKey: getTrendingUndergroundQueryKey({
       pageSize

--- a/packages/common/src/api/tan-query/utils/infiniteQueryLoadNextPage.ts
+++ b/packages/common/src/api/tan-query/utils/infiniteQueryLoadNextPage.ts
@@ -9,7 +9,13 @@ import { UseInfiniteQueryResult } from '@tanstack/react-query'
  * @returns
  */
 export const loadNextPage =
-  (queryData: Omit<UseInfiniteQueryResult, 'data'>) => () => {
+  (
+    queryData: Pick<
+      UseInfiniteQueryResult,
+      'isFetching' | 'hasNextPage' | 'fetchNextPage'
+    >
+  ) =>
+  () => {
     if (!queryData.isFetching && queryData.hasNextPage) {
       queryData.fetchNextPage()
     }

--- a/packages/common/src/api/tan-query/utils/useLineupQuery.ts
+++ b/packages/common/src/api/tan-query/utils/useLineupQuery.ts
@@ -33,10 +33,23 @@ import { LineupData } from '../types'
 
 import { loadNextPage } from './infiniteQueryLoadNextPage'
 
+type PartialQueryData<T> = Pick<
+  UseInfiniteQueryResult<T>,
+  | 'isInitialLoading'
+  | 'hasNextPage'
+  | 'isLoading'
+  | 'isPending'
+  | 'isError'
+  | 'isFetching'
+  | 'isSuccess'
+  | 'fetchNextPage'
+>
+
 /**
  * Helper to provide stitch together tan-query data and easily provide lineup methods as part of our query hooks
  */
-export const useLineupQuery = ({
+export const useLineupQuery = <T>({
+  lineupData,
   queryData,
   queryKey,
   lineupActions,
@@ -46,7 +59,8 @@ export const useLineupQuery = ({
   initialPageSize
 }: {
   // Lineup related props
-  queryData: UseInfiniteQueryResult<LineupData[]>
+  lineupData: LineupData[]
+  queryData: PartialQueryData<T>
   queryKey: QueryKey
   lineupActions: LineupActions
   lineupSelector: Selector<
@@ -80,7 +94,6 @@ export const useLineupQuery = ({
     dispatch(lineupActions.updateLineupOrder(orderedIds))
   }
 
-  const { data: lineupData } = queryData
   const prevQueryKey = usePrevious(queryKey)
   const hasQueryKeyChanged = !isEqual(prevQueryKey, queryKey)
 
@@ -181,7 +194,7 @@ export const useLineupQuery = ({
     // pass through specific queryData props
     //   this avoids spreading all queryData props which causes extra renders
     loadNextPage: loadNextPage(queryData),
-    data: queryData.data,
+    data: lineupData,
     isInitialLoading: queryData.isInitialLoading,
     hasNextPage: queryData.hasNextPage,
     isLoading: queryData.isLoading,

--- a/packages/web/src/components/lineup/TanQueryLineup.tsx
+++ b/packages/web/src/components/lineup/TanQueryLineup.tsx
@@ -243,7 +243,7 @@ export const TanQueryLineup = ({
   )
 
   const renderSkeletons = useCallback(
-    (skeletonCount: number | undefined) => {
+    (skeletonCount: number | undefined, isInitialLoad: boolean) => {
       // This means no skeletons are desired
       if (!skeletonCount) {
         return <></>
@@ -280,7 +280,9 @@ export const TanQueryLineup = ({
                     {/* @ts-ignore - the types here need work - we're not passing the full expected types here whenever we pass isLoading: true */}
                     <TrackTile {...skeletonTileProps(index)} key={index} />
                   </Flex>
-                  {index === 0 && leadingElementId !== undefined ? (
+                  {index === 0 &&
+                  leadingElementId !== undefined &&
+                  isInitialLoad ? (
                     leadingElementDelineator !== undefined ? (
                       leadingElementDelineator
                     ) : (
@@ -441,7 +443,8 @@ export const TanQueryLineup = ({
             {tiles.length === 0
               ? isFetching || isInitialLoad
                 ? renderSkeletons(
-                    Math.min(maxEntries, initialPageSize ?? pageSize)
+                    Math.min(maxEntries, initialPageSize ?? pageSize),
+                    true
                   )
                 : emptyElement
               : tiles.map((tile: any, index: number) => (
@@ -474,7 +477,7 @@ export const TanQueryLineup = ({
             {isFetching &&
               shouldLoadMore &&
               hasNextPage &&
-              renderSkeletons(Math.min(maxEntries, pageSize))}
+              renderSkeletons(Math.min(maxEntries, pageSize), false)}
           </InfiniteScroll>
         </div>
       </div>

--- a/packages/web/src/pages/remixes-page/components/desktop/NewRemixesPage.tsx
+++ b/packages/web/src/pages/remixes-page/components/desktop/NewRemixesPage.tsx
@@ -105,8 +105,8 @@ const RemixesPage = nullGuard(({ title, originalTrack }) => {
               <Text variant='heading'>
                 {count}{' '}
                 {isRemixContest
-                  ? pluralize(messages.submissions, count)
-                  : pluralize(messages.remixes, count, 'es')}
+                  ? pluralize(messages.submissions, count ?? 0)
+                  : pluralize(messages.remixes, count ?? 0, 'es')}
               </Text>
               <Flex gap='s' mb='xl'>
                 <FilterButton


### PR DESCRIPTION
### Description

- Fixed a bug in TanQueryLineup where we were should the `leadingElementDelineator` with skeletons beyond the first
- Fixed a bug with `useRemixes` hook where the `getNextPageParam` fn was incorrect. This was missed due to a `ts-ignore` ultimately caused by awkwardness working with `useLineupQuery`, so
- I modified the type props of `useLineupQuery` to separate the data and be more specific about what props it accepts - this way its easier to transform data before passing it in & should make it was less tempting to `ts-ignore` or `...queryData` spread

### How Has This Been Tested?

![2025-04-21 12 11 38](https://github.com/user-attachments/assets/fa776670-27b0-4cb6-956f-a0203149b57a)

web:stage on a remix page with 2 remixes
web:prod on a remix with 15 remixes