### PR TITLE
[PE-6016] Web Remix Contest Section

### DIFF
--- a/packages/web/src/pages/track-page/components/TrackPageLineup.tsx
+++ b/packages/web/src/pages/track-page/components/TrackPageLineup.tsx
@@ -1,3 +1,4 @@
+import { useRemixContest } from '@audius/common/api'
 import { useFeatureFlag } from '@audius/common/hooks'
 import { User } from '@audius/common/models'
 import { FeatureFlags } from '@audius/common/services'
@@ -54,10 +55,10 @@ export const TrackPageLineup = ({
 
   const { isDesktop, isMobile } = useTrackPageSize()
 
-  const { isEnabled: commentsFlagEnabled } = useFeatureFlag(
-    FeatureFlags.COMMENTS_ENABLED
-  )
-  const isCommentingEnabled = commentsFlagEnabled && !commentsDisabled
+  const isRemixContestEnabled = useFeatureFlag(FeatureFlags.REMIX_CONTEST)
+  const { data: remixContest } = useRemixContest(trackId)
+  const isRemixContest = isRemixContestEnabled && remixContest
+  const isCommentingEnabled = !commentsDisabled
   const lineupVariant =
     (isCommentingEnabled && isDesktop) || isMobile
       ? LineupVariant.SECTION
@@ -88,7 +89,12 @@ export const TrackPageLineup = ({
   }
 
   const renderRemixesSection = () => {
-    if (indices.remixesSection.index === undefined || !trackId) return null
+    if (
+      indices.remixesSection.index === undefined ||
+      isRemixContest ||
+      !trackId
+    )
+      return null
 
     return (
       <Section title={messages.remixes} icon={IconRemix}>

--- a/packages/web/src/pages/track-page/components/TrackPageLineup.tsx
+++ b/packages/web/src/pages/track-page/components/TrackPageLineup.tsx
@@ -1,7 +1,4 @@
-import { useRemixContest } from '@audius/common/api'
-import { useFeatureFlag } from '@audius/common/hooks'
 import { User } from '@audius/common/models'
-import { FeatureFlags } from '@audius/common/services'
 import { useTrackPageLineup } from '@audius/common/src/api/tan-query/useTrackPageLineup'
 import { tracksActions } from '@audius/common/src/store/pages/track/lineup/actions'
 import { Flex, Text, IconRemix } from '@audius/harmony'

--- a/packages/web/src/pages/track-page/components/TrackPageLineup.tsx
+++ b/packages/web/src/pages/track-page/components/TrackPageLineup.tsx
@@ -55,9 +55,6 @@ export const TrackPageLineup = ({
 
   const { isDesktop, isMobile } = useTrackPageSize()
 
-  const isRemixContestEnabled = useFeatureFlag(FeatureFlags.REMIX_CONTEST)
-  const { data: remixContest } = useRemixContest(trackId)
-  const isRemixContest = isRemixContestEnabled && remixContest
   const isCommentingEnabled = !commentsDisabled
   const lineupVariant =
     (isCommentingEnabled && isDesktop) || isMobile
@@ -89,12 +86,7 @@ export const TrackPageLineup = ({
   }
 
   const renderRemixesSection = () => {
-    if (
-      indices.remixesSection.index === undefined ||
-      isRemixContest ||
-      !trackId
-    )
-      return null
+    if (indices.remixesSection.index === undefined || !trackId) return null
 
     return (
       <Section title={messages.remixes} icon={IconRemix}>

--- a/packages/web/src/pages/track-page/components/desktop/RemixContestDetailsTab.tsx
+++ b/packages/web/src/pages/track-page/components/desktop/RemixContestDetailsTab.tsx
@@ -1,0 +1,43 @@
+import { useRemixContest } from '@audius/common/api'
+import { ID } from '@audius/common/models'
+import { dayjs } from '@audius/common/utils'
+import { Flex, Text } from '@audius/harmony'
+
+const messages = {
+  due: 'Submission Due:',
+  deadline: (deadline?: string) => {
+    if (!deadline) return ''
+    const date = dayjs(deadline)
+    return `${date.format('ddd. MMM D, YYYY')} at ${date.format('h:mm A')}`
+  }
+}
+
+type RemixContestDetailsTabProps = {
+  trackId: ID
+}
+
+/**
+ * Tab content displaying details about a remix contest
+ */
+export const RemixContestDetailsTab = ({
+  trackId
+}: RemixContestDetailsTabProps) => {
+  const { data: remixContest } = useRemixContest(trackId)
+  return (
+    <Flex column gap='l' p='xl'>
+      <Flex row gap='s'>
+        <Text variant='title' size='l' color='accent'>
+          {messages.due}
+        </Text>
+        <Text variant='body' size='l' strength='strong'>
+          {messages.deadline(remixContest?.endDate)}
+        </Text>
+      </Flex>
+      <Text variant='body' size='l'>
+        {
+          "Join our exciting remix contest! Showcase your creativity by reimagining your favorite tracks. Submit your remixes for a chance to win amazing prizes and gain recognition in the music community. Don't miss out on this opportunity to shine!"
+        }
+      </Text>
+    </Flex>
+  )
+}

--- a/packages/web/src/pages/track-page/components/desktop/RemixContestPrizesTab.tsx
+++ b/packages/web/src/pages/track-page/components/desktop/RemixContestPrizesTab.tsx
@@ -1,0 +1,36 @@
+import { ID } from '@audius/common/models'
+import { Text, Flex } from '@audius/harmony'
+
+type RemixContestPrizesTabProps = {
+  trackId: ID
+}
+
+/**
+ * Tab content displaying prizes for a remix contest
+ */
+export const RemixContestPrizesTab = ({
+  trackId
+}: RemixContestPrizesTabProps) => {
+  return (
+    <Flex column gap='l' p='xl'>
+      <Text variant='body' size='l'>
+        {'Best Remix Award - $500'}
+      </Text>
+      <Text variant='body' size='l'>
+        {'Audience Choice Award - $300'}
+      </Text>
+      <Text variant='body' size='l'>
+        {'Most Creative Remix - $200'}
+      </Text>
+      <Text variant='body' size='l'>
+        {'Best Use of Original Material - $250'}
+      </Text>
+      <Text variant='body' size='l'>
+        {'Rising Star Award - $150'}
+      </Text>
+      <Text variant='body' size='l'>
+        {'Honorable Mention - $100'}
+      </Text>
+    </Flex>
+  )
+}

--- a/packages/web/src/pages/track-page/components/desktop/RemixContestSection.tsx
+++ b/packages/web/src/pages/track-page/components/desktop/RemixContestSection.tsx
@@ -1,7 +1,5 @@
 import { useRemixContest } from '@audius/common/api'
-import { useFeatureFlag } from '@audius/common/hooks'
 import { ID } from '@audius/common/models'
-import { FeatureFlags } from '@audius/common/services'
 import { UPLOAD_PAGE } from '@audius/common/src/utils/route'
 import {
   Box,

--- a/packages/web/src/pages/track-page/components/desktop/RemixContestSection.tsx
+++ b/packages/web/src/pages/track-page/components/desktop/RemixContestSection.tsx
@@ -88,6 +88,7 @@ export const RemixContestSection = ({
     navigate(UPLOAD_PAGE, state)
   }, [trackId, navigate])
 
+  // TODO: Also return null if no remix contest description
   if (!trackId || !isRemixContest) return null
 
   return (

--- a/packages/web/src/pages/track-page/components/desktop/RemixContestSection.tsx
+++ b/packages/web/src/pages/track-page/components/desktop/RemixContestSection.tsx
@@ -99,18 +99,20 @@ export const RemixContestSection = ({
         </Text>
       </Flex>
       <Box backgroundColor='white' shadow='mid' borderRadius='l'>
-        <Flex column gap='l' pv='m'>
+        <Flex column pv='m'>
           <Flex justifyContent='space-between' borderBottom='default' ph='xl'>
-            {TabBar}
+            <Flex alignItems='center'>{TabBar}</Flex>
             {!isOwner ? (
-              <Button
-                variant='secondary'
-                size='small'
-                onClick={goToUploadWithRemix}
-                iconLeft={IconCloudUpload}
-              >
-                {messages.uploadRemixButtonText}
-              </Button>
+              <Flex mb='m'>
+                <Button
+                  variant='secondary'
+                  size='small'
+                  onClick={goToUploadWithRemix}
+                  iconLeft={IconCloudUpload}
+                >
+                  {messages.uploadRemixButtonText}
+                </Button>
+              </Flex>
             ) : null}
           </Flex>
           {TabBody}

--- a/packages/web/src/pages/track-page/components/desktop/RemixContestSection.tsx
+++ b/packages/web/src/pages/track-page/components/desktop/RemixContestSection.tsx
@@ -1,0 +1,121 @@
+import { useRemixContest } from '@audius/common/api'
+import { useFeatureFlag } from '@audius/common/hooks'
+import { ID } from '@audius/common/models'
+import { FeatureFlags } from '@audius/common/services'
+import { UPLOAD_PAGE } from '@audius/common/src/utils/route'
+import {
+  Box,
+  Button,
+  Flex,
+  IconCloudUpload,
+  IconTrophy,
+  Text
+} from '@audius/harmony'
+
+import { useNavigateToPage } from 'hooks/useNavigateToPage'
+import { useRequiresAccountCallback } from 'hooks/useRequiresAccount'
+import useTabs from 'hooks/useTabs/useTabs'
+
+import { RemixContestDetailsTab } from './RemixContestDetailsTab'
+import { RemixContestPrizesTab } from './RemixContestPrizesTab'
+import { RemixContestSubmissionsTab } from './RemixContestSubmissionsTab'
+
+const messages = {
+  title: 'Remix Contest',
+  details: 'Details',
+  prizes: 'Prizes',
+  submissions: 'Submissions',
+  uploadRemixButtonText: 'Upload Your Remix'
+}
+
+type RemixContestSectionProps = {
+  trackId: ID
+  isOwner: boolean
+}
+
+/**
+ * Section component that displays remix contest information for a track
+ */
+export const RemixContestSection = ({
+  trackId,
+  isOwner
+}: RemixContestSectionProps) => {
+  const navigate = useNavigateToPage()
+  const { data: remixContest } = useRemixContest(trackId)
+  const { isEnabled: isRemixContestEnabled } = useFeatureFlag(
+    FeatureFlags.REMIX_CONTEST
+  )
+  const isRemixContest = isRemixContestEnabled && remixContest
+
+  const tabs = [
+    {
+      text: messages.details,
+      label: 'details'
+    },
+    {
+      text: messages.prizes,
+      label: 'prizes'
+    },
+    {
+      text: messages.submissions,
+      label: 'submissions'
+    }
+  ]
+
+  const elements = [
+    <RemixContestDetailsTab key='details' trackId={trackId} />,
+    <RemixContestPrizesTab key='prizes' trackId={trackId} />,
+    <RemixContestSubmissionsTab key='submissions' trackId={trackId} />
+  ]
+
+  const { tabs: TabBar, body: TabBody } = useTabs({
+    tabs,
+    elements,
+    isMobile: false
+  })
+
+  const goToUploadWithRemix = useRequiresAccountCallback(() => {
+    if (!trackId) return
+
+    const state = {
+      initialMetadata: {
+        is_remix: true,
+        remix_of: {
+          tracks: [{ parent_track_id: trackId }]
+        }
+      }
+    }
+    navigate(UPLOAD_PAGE, state)
+  }, [trackId, navigate])
+
+  if (!trackId || !isRemixContest) return null
+
+  return (
+    <Flex column gap='l'>
+      <Flex alignItems='center' gap='s'>
+        <IconTrophy color='default' />
+        <Text variant='title' size='l'>
+          {messages.title}
+        </Text>
+      </Flex>
+      <Box backgroundColor='white' shadow='mid' borderRadius='l'>
+        <Flex column gap='l' pv='m'>
+          <Flex justifyContent='space-between' borderBottom='default' ph='xl'>
+            {TabBar}
+            {!isOwner ? (
+              <Button
+                variant='secondary'
+                size='small'
+                onClick={goToUploadWithRemix}
+                iconLeft={IconCloudUpload}
+              >
+                {messages.uploadRemixButtonText}
+              </Button>
+            ) : null}
+          </Flex>
+          {TabBody}
+        </Flex>
+      </Box>
+    </Flex>
+  )
+}

--- a/packages/web/src/pages/track-page/components/desktop/RemixContestSection.tsx
+++ b/packages/web/src/pages/track-page/components/desktop/RemixContestSection.tsx
@@ -42,10 +42,6 @@ export const RemixContestSection = ({
 }: RemixContestSectionProps) => {
   const navigate = useNavigateToPage()
   const { data: remixContest } = useRemixContest(trackId)
-  const { isEnabled: isRemixContestEnabled } = useFeatureFlag(
-    FeatureFlags.REMIX_CONTEST
-  )
-  const isRemixContest = isRemixContestEnabled && remixContest
 
   const tabs = [
     {
@@ -89,7 +85,7 @@ export const RemixContestSection = ({
   }, [trackId, navigate])
 
   // TODO: Also return null if no remix contest description
-  if (!trackId || !isRemixContest) return null
+  if (!trackId || !remixContest) return null
 
   return (
     <Flex column gap='l'>

--- a/packages/web/src/pages/track-page/components/desktop/RemixContestSubmissionsTab.tsx
+++ b/packages/web/src/pages/track-page/components/desktop/RemixContestSubmissionsTab.tsx
@@ -1,0 +1,40 @@
+import { ID } from '@audius/common/models'
+import { Flex, Text } from '@audius/harmony'
+
+const messages = {
+  noSubmissions: 'No submissions yet',
+  beFirst: 'Be the first to upload a remix!'
+}
+
+type RemixContestSubmissionsTabProps = {
+  trackId: ID
+}
+
+/**
+ * Tab content displaying submissions for a remix contest
+ */
+export const RemixContestSubmissionsTab = ({
+  trackId
+}: RemixContestSubmissionsTabProps) => {
+  return <EmptyRemixContestSubmissions />
+}
+
+const EmptyRemixContestSubmissions = () => {
+  return (
+    <Flex
+      column
+      w='100%'
+      pv='3xl'
+      gap='m'
+      justifyContent='center'
+      alignItems='center'
+    >
+      <Text variant='heading' size='s'>
+        {messages.noSubmissions}
+      </Text>
+      <Text variant='body' size='l' color='subdued'>
+        {messages.beFirst}
+      </Text>
+    </Flex>
+  )
+}

--- a/packages/web/src/pages/track-page/components/desktop/TrackPage.tsx
+++ b/packages/web/src/pages/track-page/components/desktop/TrackPage.tsx
@@ -1,9 +1,8 @@
 import { useCallback, useRef } from 'react'
 
 import { useToggleFavoriteTrack } from '@audius/common/api'
-import { useFeatureFlag, useGatedContentAccess } from '@audius/common/hooks'
+import { useGatedContentAccess } from '@audius/common/hooks'
 import { ID, Track, User, FavoriteSource } from '@audius/common/models'
-import { FeatureFlags } from '@audius/common/services'
 import { Box, Flex } from '@audius/harmony'
 
 import { CommentSection } from 'components/comments/CommentSection'
@@ -18,6 +17,8 @@ import { getTrackDefaults, emptyStringGuard } from 'pages/track-page/utils'
 
 import { TrackPageLineup } from '../TrackPageLineup'
 import { useTrackPageSize } from '../useTrackPageSize'
+
+import { RemixContestSection } from './RemixContestSection'
 
 export type OwnProps = {
   title: string
@@ -72,11 +73,7 @@ const TrackPage = ({
   const { isFetchingNFTAccess, hasStreamAccess } =
     useGatedContentAccess(heroTrack)
 
-  const { isEnabled: commentsFlagEnabled } = useFeatureFlag(
-    FeatureFlags.COMMENTS_ENABLED
-  )
-  const isCommentingEnabled =
-    commentsFlagEnabled && !heroTrack?.comments_disabled
+  const isCommentingEnabled = !heroTrack?.comments_disabled
   const loading = !heroTrack || isFetchingNFTAccess
 
   const toggleSaveTrack = useToggleFavoriteTrack({
@@ -184,13 +181,17 @@ const TrackPage = ({
           pt={200}
           pb={60}
           css={{ position: 'relative' }}
+          gap='unit12'
         >
           {renderGiantTrackTile()}
+          <RemixContestSection
+            trackId={heroTrack?.track_id ?? 0}
+            isOwner={isOwner}
+          />
           <Flex
             gap='2xl'
             w='100%'
             direction={isDesktop ? 'row' : 'column'}
-            mt='3xl'
             mh='auto'
             css={{ maxWidth: 1080 }}
             justifyContent='center'


### PR DESCRIPTION
### Description
Remix contest info section
3 tabs - details, prizes, submissions
Will fill in later with the actual data from the event. Using placeholders for now.
Will also implement the expandable "see more" stuff on the description.
Also hide the "remixes" lineup when the track is an active remix contest.

### How Has This Been Tested?

https://github.com/user-attachments/assets/04be8f36-defb-4fcf-ae95-0c317881ff25

