### PR TITLE
Fix remix tracks skeleton issues

### DIFF
--- a/packages/web/src/common/store/queue/sagas.ts
+++ b/packages/web/src/common/store/queue/sagas.ts
@@ -30,6 +30,7 @@ import {
 } from '@audius/common/store'
 import { Uid, makeUid, waitForAccount, Nullable } from '@audius/common/utils'
 import { all, call, put, select, takeEvery, takeLatest } from 'typed-redux-saga'
+import { PREFIX as REMIXES_PREFIX } from '~/store/pages/remixes/lineup/actions'
 import { PREFIX as SEARCH_PREFIX } from '~/store/pages/search-results/lineup/tracks/actions'
 
 import { make } from 'common/store/analytics/actions'
@@ -65,6 +66,7 @@ const { getIsReachable } = reachabilitySelectors
 
 const QUEUE_SUBSCRIBER_NAME = 'QUEUE'
 
+const TAN_QUERY_LINEUP_PREFIXES = [SEARCH_PREFIX, REMIXES_PREFIX]
 export function* getToQueue(
   prefix: string,
   entry: LineupEntry<Track | Collection>
@@ -302,8 +304,8 @@ function* fetchLineupTracks(currentTrack: Track) {
   const lineupEntry = lineupRegistry[source]
   if (!lineupEntry) return
 
-  // NOTE: SPECIAL CASE - For tan-query search we don't want this behavior
-  if (lineupEntry.actions.prefix === SEARCH_PREFIX) return
+  // NOTE: For tan-query lineups we want to avoid this behavior
+  if (TAN_QUERY_LINEUP_PREFIXES.includes(lineupEntry.actions.prefix)) return
 
   const currentProfileUserHandle = yield* select(getProfileUserHandle)
 


### PR DESCRIPTION
### Description

- Re-doing the change where I didn't put the originalTrack not in the TQ data. I still would prefer it not be in our TQ data but its causing issues and would need a bigger change. Since the TQ data isn't used outside of this spot it doesn't really need to be "pure" for now.
- Fixed issue with the queue loading more - we need to keep patching this as we add in the TQ lineups

### How Has This Been Tested?

web:prod using track with 2 remixes +  15 remixes
