### PR TITLE
Fix mobile lineup reset race-condition

### DIFF
--- a/packages/mobile/src/screens/track-screen/TrackScreen.tsx
+++ b/packages/mobile/src/screens/track-screen/TrackScreen.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from 'react'
+import { useRef } from 'react'
 
 import { useTrackByParams, useUser } from '@audius/common/api'
 import {
@@ -8,6 +8,7 @@ import {
 } from '@audius/common/store'
 import type { FlatList } from 'react-native'
 import { useDispatch, useSelector } from 'react-redux'
+import { useEffectOnce } from 'react-use'
 
 import { Flex } from '@audius/harmony-native'
 import { CommentPreview } from 'app/components/comments/CommentPreview'
@@ -18,7 +19,6 @@ import {
 } from 'app/components/core'
 import { ScreenPrimaryContent } from 'app/components/core/Screen/ScreenPrimaryContent'
 import { ScreenSecondaryContent } from 'app/components/core/Screen/ScreenSecondaryContent'
-import { useIsScreenReady } from 'app/components/core/Screen/hooks/useIsScreenReady'
 import { useRoute } from 'app/hooks/useRoute'
 
 import { RemixContestCountdown } from './RemixContestCountdown'
@@ -44,13 +44,9 @@ export const TrackScreen = () => {
 
   const lineup = useSelector(getLineup)
 
-  const isScreenReady = useIsScreenReady()
-
-  useEffect(() => {
-    if (isScreenReady) {
-      dispatch(tracksActions.reset())
-    }
-  }, [dispatch, isScreenReady])
+  useEffectOnce(() => {
+    dispatch(tracksActions.reset())
+  })
 
   if (!track || !user) {
     return (


### PR DESCRIPTION
### Description

A bit of a weird one, but trackActions.reset() was being called after the useTrackLineup hook was called, leading to an issue where an already existing track-lineup would get cleared, leading to skeletons the second time you went to a track page