### PR TITLE
[PE-6024] Use real remix eventData in remix contest section

### DIFF
--- a/packages/common/src/api/tan-query/events/useRemixContest.ts
+++ b/packages/common/src/api/tan-query/events/useRemixContest.ts
@@ -1,4 +1,5 @@
 import { EventEntityTypeEnum, EventEventTypeEnum } from '@audius/sdk'
+import type { OverrideProperties } from 'type-fest'
 
 import { Event } from '~/models/Event'
 import { ID } from '~/models/Identifiers'
@@ -8,13 +9,25 @@ import { SelectableQueryOptions } from '../types'
 import { useEvent } from './useEvent'
 import { useEventIdsByEntityId } from './useEventsByEntityId'
 
+type RemixContestData = {
+  description: string
+  prizeInfo: string
+}
+
+type RemixContestEvent = OverrideProperties<
+  Event,
+  {
+    eventData: RemixContestData
+  }
+>
+
 /**
  * Hook to fetch the remix contest event for a given entity ID.
  * Returns the first active RemixContest event found, or null if none exists.
  */
 export const useRemixContest = (
   entityId: ID | null | undefined,
-  options?: SelectableQueryOptions<Event>
+  options?: SelectableQueryOptions<Event, RemixContestEvent>
 ) => {
   const eventsQuery = useEventIdsByEntityId(
     {
@@ -27,7 +40,10 @@ export const useRemixContest = (
 
   const remixContestId = eventsQuery.data?.[0]
 
-  const { data: remixContest } = useEvent(remixContestId, options)
+  const { data: remixContest } = useEvent<RemixContestEvent>(
+    remixContestId,
+    options
+  )
 
   return {
     ...eventsQuery,

--- a/packages/mobile/src/screens/track-screen/TrackScreenDetailsTile.tsx
+++ b/packages/mobile/src/screens/track-screen/TrackScreenDetailsTile.tsx
@@ -58,7 +58,6 @@ import {
   Divider,
   Flex,
   IconCalendarMonth,
-  IconCloudUpload,
   IconPause,
   IconPlay,
   IconRepeatOff,
@@ -236,10 +235,6 @@ export const TrackScreenDetailsTile = ({
   const isUSDCPurchaseGated = isContentUSDCPurchaseGated(streamConditions)
   const { data: remixContest } = useRemixContest(trackId)
   const isRemixContest = !!remixContest
-  // If remix contest has description, show the RemixContestSection. If not,
-  // show the end date in the metadata section
-  const shouldShowRemixInfo =
-    isRemixContest && !remixContest.eventData.description
 
   const isPlayingPreview = isPreviewing && isPlaying
   const isPlayingFullAccess = isPlaying && !isPreviewing
@@ -499,46 +494,6 @@ export const TrackScreenDetailsTile = ({
     publish
   ])
 
-  const handlePressSubmitRemix = useCallback(() => {
-    if (!track?.track_id) return
-    navigation.push('Upload', {
-      initialMetadata: {
-        is_remix: true,
-        remix_of: {
-          tracks: [{ parent_track_id: track.track_id }]
-        }
-      }
-    })
-  }, [navigation, track])
-
-  const renderRemixContestSection = () => {
-    if (!shouldShowRemixInfo) return null
-    const isContestOver = dayjs(remixContest?.endDate).isBefore(dayjs())
-    return (
-      <Flex gap='m'>
-        <Flex row gap='xs' alignItems='center'>
-          <Text variant='label' color='accent'>
-            {isContestOver ? messages.contestEnded : messages.contestDeadline}
-          </Text>
-          <Text size='s' strength='strong'>
-            {messages.deadline(remixContest?.endDate)}
-          </Text>
-        </Flex>
-        {!isOwner ? (
-          <Flex flex={1}>
-            <Button
-              variant='secondary'
-              size='small'
-              iconLeft={IconCloudUpload}
-              onPress={handlePressSubmitRemix}
-            >
-              {messages.uploadRemixButtonText}
-            </Button>
-          </Flex>
-        ) : null}
-      </Flex>
-    )
-  }
   const renderBottomContent = () => {
     return hasDownloadableAssets ? (
       <>
@@ -702,7 +657,6 @@ export const TrackScreenDetailsTile = ({
         <TrackDescription description={description} scrollRef={scrollViewRef} />
         <TrackMetadataList trackId={trackId} />
         {renderTags()}
-        {renderRemixContestSection()}
         <OfflineStatusRow contentId={trackId} isCollection={false} />
         {renderBottomContent()}
       </Flex>

--- a/packages/web/src/components/track/GiantTrackTile.tsx
+++ b/packages/web/src/components/track/GiantTrackTile.tsx
@@ -7,7 +7,6 @@ import {
   useStems,
   useTrack
 } from '@audius/common/api'
-import { useFeatureFlag } from '@audius/common/hooks'
 import {
   isContentUSDCPurchaseGated,
   ID,
@@ -16,7 +15,6 @@ import {
   AccessConditions,
   FavoriteSource
 } from '@audius/common/models'
-import { FeatureFlags } from '@audius/common/services'
 import {
   PurchaseableContentType,
   useEarlyReleaseConfirmationModal,
@@ -226,12 +224,13 @@ export const GiantTrackTile = ({
     source: FavoriteSource.TRACK_PAGE
   })
 
-  const { isEnabled: isRemixContestEnabled } = useFeatureFlag(
-    FeatureFlags.REMIX_CONTEST
-  )
   const { data: remixContest, isLoading: isEventsLoading } =
     useRemixContest(trackId)
-  const isRemixContest = isRemixContestEnabled && !!remixContest
+  const isRemixContest = !!remixContest
+  // If remix contest has description, show the RemixContestSection. If not,
+  // show the end date in the metadata section
+  const shouldShowRemixInfo =
+    isRemixContest && !remixContest.eventData.description
 
   const isLongFormContent =
     genre === Genre.PODCASTS || genre === Genre.AUDIOBOOKS
@@ -483,7 +482,7 @@ export const GiantTrackTile = ({
   }, [trackId, navigate])
 
   const renderSubmitRemixContestSection = useCallback(() => {
-    if (!isRemixContest) return null
+    if (!shouldShowRemixInfo) return null
     const isContestOver = dayjs(remixContest.endDate).isBefore(dayjs())
     return (
       <Flex row gap='m'>
@@ -505,7 +504,7 @@ export const GiantTrackTile = ({
         ) : null}
       </Flex>
     )
-  }, [isRemixContest, remixContest, isOwner, goToUploadWithRemix])
+  }, [shouldShowRemixInfo, remixContest.endDate, isOwner, goToUploadWithRemix])
 
   const isLoading = loading || artworkLoading || isEventsLoading
 
@@ -538,7 +537,7 @@ export const GiantTrackTile = ({
       includeEmbed: !(isUnlisted || isStreamGated),
       includeArtistPick: true,
       includeAddToAlbum: isOwner && !ddexApp,
-      includeRemixContest: isRemixContestEnabled,
+      includeRemixContest: true,
       extraMenuItems: overflowMenuExtraItems
     }
   }

--- a/packages/web/src/components/track/GiantTrackTile.tsx
+++ b/packages/web/src/components/track/GiantTrackTile.tsx
@@ -20,13 +20,7 @@ import {
   useEarlyReleaseConfirmationModal,
   usePublishConfirmationModal
 } from '@audius/common/store'
-import {
-  Genre,
-  Nullable,
-  dayjs,
-  formatReleaseDate,
-  route
-} from '@audius/common/utils'
+import { Genre, Nullable, dayjs, formatReleaseDate } from '@audius/common/utils'
 import {
   Text,
   Box,
@@ -39,7 +33,6 @@ import {
   Button,
   MusicBadge,
   Paper,
-  IconCloudUpload,
   PlainButton,
   IconCaretDown,
   IconCaretUp,
@@ -64,8 +57,6 @@ import Toast from 'components/toast/Toast'
 import Tooltip from 'components/tooltip/Tooltip'
 import { ComponentPlacement } from 'components/types'
 import { UserGeneratedText } from 'components/user-generated-text'
-import { useNavigateToPage } from 'hooks/useNavigateToPage'
-import { useRequiresAccountCallback } from 'hooks/useRequiresAccount'
 
 import { AiTrackSection } from './AiTrackSection'
 import { CardTitle } from './CardTitle'
@@ -77,8 +68,6 @@ import { PlayPauseButton } from './PlayPauseButton'
 import { TrackDogEar } from './TrackDogEar'
 import { TrackMetadataList } from './TrackMetadataList'
 import { TrackStats } from './TrackStats'
-
-const { UPLOAD_PAGE } = route
 
 const DownloadSection = lazy(() =>
   import('./DownloadSection').then((module) => ({
@@ -213,7 +202,6 @@ export const GiantTrackTile = ({
   ddexApp,
   scrollToCommentSection
 }: GiantTrackTileProps) => {
-  const navigate = useNavigateToPage()
   const [artworkLoading, setArtworkLoading] = useState(false)
   const onArtworkLoad = useCallback(
     () => setArtworkLoading(false),
@@ -227,10 +215,6 @@ export const GiantTrackTile = ({
   const { data: remixContest, isLoading: isEventsLoading } =
     useRemixContest(trackId)
   const isRemixContest = !!remixContest
-  // If remix contest has description, show the RemixContestSection. If not,
-  // show the end date in the metadata section
-  const shouldShowRemixInfo =
-    isRemixContest && !remixContest.eventData.description
 
   const isLongFormContent =
     genre === Genre.PODCASTS || genre === Genre.AUDIOBOOKS
@@ -466,45 +450,6 @@ export const GiantTrackTile = ({
       </Flex>
     )
   }
-
-  const goToUploadWithRemix = useRequiresAccountCallback(() => {
-    if (!trackId) return
-
-    const state = {
-      initialMetadata: {
-        is_remix: true,
-        remix_of: {
-          tracks: [{ parent_track_id: trackId }]
-        }
-      }
-    }
-    navigate(UPLOAD_PAGE, state)
-  }, [trackId, navigate])
-
-  const renderSubmitRemixContestSection = useCallback(() => {
-    if (!shouldShowRemixInfo) return null
-    const isContestOver = dayjs(remixContest.endDate).isBefore(dayjs())
-    return (
-      <Flex row gap='m'>
-        <Flex gap='xs' alignItems='center'>
-          <Text variant='label' color='accent'>
-            {isContestOver ? messages.contestEnded : messages.contestDeadline}
-          </Text>
-          <Text>{messages.deadline(remixContest.endDate)}</Text>
-        </Flex>
-        {!isOwner ? (
-          <Button
-            variant='secondary'
-            size='small'
-            onClick={goToUploadWithRemix}
-            iconLeft={IconCloudUpload}
-          >
-            {messages.uploadRemixButtonText}
-          </Button>
-        ) : null}
-      </Flex>
-    )
-  }, [shouldShowRemixInfo, remixContest.endDate, isOwner, goToUploadWithRemix])
 
   const isLoading = loading || artworkLoading || isEventsLoading
 
@@ -755,7 +700,6 @@ export const GiantTrackTile = ({
         ) : null}
 
         {renderTags()}
-        {renderSubmitRemixContestSection()}
         {hasDownloadableAssets ? (
           <Box w='100%'>
             <Suspense>

--- a/packages/web/src/pages/track-page/components/desktop/RemixContestDetailsTab.tsx
+++ b/packages/web/src/pages/track-page/components/desktop/RemixContestDetailsTab.tsx
@@ -3,13 +3,16 @@ import { ID } from '@audius/common/models'
 import { dayjs } from '@audius/common/utils'
 import { Flex, Text } from '@audius/harmony'
 
+import { UserGeneratedText } from 'components/user-generated-text'
+
 const messages = {
   due: 'Submission Due:',
   deadline: (deadline?: string) => {
     if (!deadline) return ''
     const date = dayjs(deadline)
     return `${date.format('ddd. MMM D, YYYY')} at ${date.format('h:mm A')}`
-  }
+  },
+  ended: 'Contest Ended'
 }
 
 type RemixContestDetailsTabProps = {
@@ -23,6 +26,8 @@ export const RemixContestDetailsTab = ({
   trackId
 }: RemixContestDetailsTabProps) => {
   const { data: remixContest } = useRemixContest(trackId)
+  const isContestEnded = dayjs(remixContest?.endDate).isBefore(dayjs())
+
   return (
     <Flex column gap='l' p='xl'>
       <Flex row gap='s'>
@@ -30,14 +35,14 @@ export const RemixContestDetailsTab = ({
           {messages.due}
         </Text>
         <Text variant='body' size='l' strength='strong'>
-          {messages.deadline(remixContest?.endDate)}
+          {isContestEnded
+            ? messages.ended
+            : messages.deadline(remixContest?.endDate)}
         </Text>
       </Flex>
-      <Text variant='body' size='l'>
-        {
-          "Join our exciting remix contest! Showcase your creativity by reimagining your favorite tracks. Submit your remixes for a chance to win amazing prizes and gain recognition in the music community. Don't miss out on this opportunity to shine!"
-        }
-      </Text>
+      <UserGeneratedText variant='body' size='l'>
+        {remixContest?.eventData?.description}
+      </UserGeneratedText>
     </Flex>
   )
 }

--- a/packages/web/src/pages/track-page/components/desktop/RemixContestDetailsTab.tsx
+++ b/packages/web/src/pages/track-page/components/desktop/RemixContestDetailsTab.tsx
@@ -12,7 +12,9 @@ const messages = {
     const date = dayjs(deadline)
     return `${date.format('ddd. MMM D, YYYY')} at ${date.format('h:mm A')}`
   },
-  ended: 'Contest Ended'
+  ended: 'Contest Ended',
+  fallbackDescription:
+    'Enter my remix contest before the deadline for your chance to win!'
 }
 
 type RemixContestDetailsTabProps = {
@@ -41,7 +43,7 @@ export const RemixContestDetailsTab = ({
         </Text>
       </Flex>
       <UserGeneratedText variant='body' size='l'>
-        {remixContest?.eventData?.description}
+        {remixContest?.eventData?.description ?? messages.fallbackDescription}
       </UserGeneratedText>
     </Flex>
   )

--- a/packages/web/src/pages/track-page/components/desktop/RemixContestPrizesTab.tsx
+++ b/packages/web/src/pages/track-page/components/desktop/RemixContestPrizesTab.tsx
@@ -1,6 +1,6 @@
 import { useRemixContest } from '@audius/common/api'
 import { ID } from '@audius/common/models'
-import { Text, Flex } from '@audius/harmony'
+import { Flex } from '@audius/harmony'
 
 import { UserGeneratedText } from 'components/user-generated-text'
 

--- a/packages/web/src/pages/track-page/components/desktop/RemixContestPrizesTab.tsx
+++ b/packages/web/src/pages/track-page/components/desktop/RemixContestPrizesTab.tsx
@@ -1,5 +1,8 @@
+import { useRemixContest } from '@audius/common/api'
 import { ID } from '@audius/common/models'
 import { Text, Flex } from '@audius/harmony'
+
+import { UserGeneratedText } from 'components/user-generated-text'
 
 type RemixContestPrizesTabProps = {
   trackId: ID
@@ -11,26 +14,13 @@ type RemixContestPrizesTabProps = {
 export const RemixContestPrizesTab = ({
   trackId
 }: RemixContestPrizesTabProps) => {
+  const { data: remixContest } = useRemixContest(trackId)
+
   return (
     <Flex column gap='l' p='xl'>
-      <Text variant='body' size='l'>
-        {'Best Remix Award - $500'}
-      </Text>
-      <Text variant='body' size='l'>
-        {'Audience Choice Award - $300'}
-      </Text>
-      <Text variant='body' size='l'>
-        {'Most Creative Remix - $200'}
-      </Text>
-      <Text variant='body' size='l'>
-        {'Best Use of Original Material - $250'}
-      </Text>
-      <Text variant='body' size='l'>
-        {'Rising Star Award - $150'}
-      </Text>
-      <Text variant='body' size='l'>
-        {'Honorable Mention - $100'}
-      </Text>
+      <UserGeneratedText variant='body' size='l'>
+        {remixContest?.eventData?.prizeInfo}
+      </UserGeneratedText>
     </Flex>
   )
 }


### PR DESCRIPTION
### Description
- Update typing in `useRemixContest` to correctly type `eventData`. Feel like these types should come from sdk? They are currently duplicated with the edit remix contest form from @Kyle-Shanks 's [PR here](https://github.com/AudiusProject/audius-protocol/commit/d8c9b657c7be07ab7564425c33989996a488ca7f)
- Remove previous remix contest details sections from both web and mobile
- Update details, prizeInfo sections on web to use real data from remix contest event


### How Has This Been Tested?

https://github.com/user-attachments/assets/2f83bbc3-ac58-435e-8397-3b551e47b647

