### PR TITLE
Add delay to hover card

### DIFF
--- a/packages/harmony/src/components/hover-card/HoverCard.tsx
+++ b/packages/harmony/src/components/hover-card/HoverCard.tsx
@@ -1,6 +1,7 @@
-import { useRef, useState } from 'react'
+import { useRef } from 'react'
 
 import { Flex, Paper, Popup } from '..'
+import { useHoverDelay } from '../../hooks/useHoverDelay'
 import { Origin } from '../popup/types'
 
 import { HoverCardProps } from './types'
@@ -43,28 +44,22 @@ export const HoverCard = ({
   onClose,
   onClick,
   anchorOrigin = DEFAULT_ANCHOR_ORIGIN,
-  transformOrigin = DEFAULT_TRANSFORM_ORIGIN
+  transformOrigin = DEFAULT_TRANSFORM_ORIGIN,
+  mouseEnterDelay = 0.5
 }: HoverCardProps) => {
-  const [isHovered, setIsHovered] = useState(false)
   const anchorRef = useRef<HTMLDivElement | null>(null)
-
-  const handleMouseEnter = () => {
-    setIsHovered(true)
-  }
-
-  const handleMouseLeave = () => {
-    setIsHovered(false)
-  }
+  const { isHovered, handleMouseEnter, handleMouseLeave, clearTimer } =
+    useHoverDelay(mouseEnterDelay)
 
   const handleClose = () => {
-    setIsHovered(false)
+    clearTimer()
     if (onClose) onClose()
   }
 
   const handleClick = () => {
     if (onClick) {
       onClick()
-      setIsHovered(false)
+      clearTimer()
     }
   }
 

--- a/packages/harmony/src/components/hover-card/HoverCard.tsx
+++ b/packages/harmony/src/components/hover-card/HoverCard.tsx
@@ -48,8 +48,13 @@ const HoverCardComponent = ({
   mouseEnterDelay = 0.5
 }: HoverCardProps) => {
   const anchorRef = useRef<HTMLDivElement | null>(null)
-  const { isHovered, handleMouseEnter, handleMouseLeave, clearTimer } =
-    useHoverDelay(mouseEnterDelay)
+  const {
+    isHovered,
+    handleMouseEnter,
+    handleMouseLeave,
+    clearTimer,
+    setIsHovered
+  } = useHoverDelay(mouseEnterDelay)
 
   const handleClose = useCallback(() => {
     clearTimer()
@@ -59,7 +64,8 @@ const HoverCardComponent = ({
   const handleClick = useCallback(() => {
     onClick?.()
     clearTimer()
-  }, [onClick, clearTimer])
+    setIsHovered(false)
+  }, [onClick, clearTimer, setIsHovered])
 
   return (
     <Flex

--- a/packages/harmony/src/components/hover-card/HoverCard.tsx
+++ b/packages/harmony/src/components/hover-card/HoverCard.tsx
@@ -1,4 +1,4 @@
-import { useRef } from 'react'
+import { useRef, useCallback, memo } from 'react'
 
 import { Flex, Paper, Popup } from '..'
 import { useHoverDelay } from '../../hooks/useHoverDelay'
@@ -37,7 +37,7 @@ const DEFAULT_TRANSFORM_ORIGIN: Origin = {
  * </HoverCard>
  * ```
  */
-export const HoverCard = ({
+const HoverCardComponent = ({
   children,
   className,
   content,
@@ -51,17 +51,15 @@ export const HoverCard = ({
   const { isHovered, handleMouseEnter, handleMouseLeave, clearTimer } =
     useHoverDelay(mouseEnterDelay)
 
-  const handleClose = () => {
+  const handleClose = useCallback(() => {
     clearTimer()
-    if (onClose) onClose()
-  }
+    onClose?.()
+  }, [clearTimer, onClose])
 
-  const handleClick = () => {
-    if (onClick) {
-      onClick()
-      clearTimer()
-    }
-  }
+  const handleClick = useCallback(() => {
+    onClick?.()
+    clearTimer()
+  }, [onClick, clearTimer])
 
   return (
     <Flex
@@ -70,26 +68,31 @@ export const HoverCard = ({
       onMouseLeave={handleMouseLeave}
     >
       {children}
-      <Popup
-        anchorRef={anchorRef}
-        isVisible={isHovered}
-        onClose={handleClose}
-        dismissOnMouseLeave
-        hideCloseButton
-        zIndex={30000} // Using tooltip z-index
-        anchorOrigin={anchorOrigin}
-        transformOrigin={transformOrigin}
-      >
-        <Paper
-          className={className}
-          borderRadius='m'
-          backgroundColor='white'
-          direction='column'
-          onClick={handleClick}
+
+      {isHovered && (
+        <Popup
+          anchorRef={anchorRef}
+          isVisible
+          onClose={handleClose}
+          dismissOnMouseLeave
+          hideCloseButton
+          zIndex={30000}
+          anchorOrigin={anchorOrigin}
+          transformOrigin={transformOrigin}
         >
-          {content}
-        </Paper>
-      </Popup>
+          <Paper
+            className={className}
+            borderRadius='m'
+            backgroundColor='white'
+            direction='column'
+            onClick={handleClick}
+          >
+            {content}
+          </Paper>
+        </Popup>
+      )}
     </Flex>
   )
 }
+
+export const HoverCard = memo(HoverCardComponent)

--- a/packages/harmony/src/components/hover-card/HoverCard.tsx
+++ b/packages/harmony/src/components/hover-card/HoverCard.tsx
@@ -69,28 +69,26 @@ const HoverCardComponent = ({
     >
       {children}
 
-      {isHovered && (
-        <Popup
-          anchorRef={anchorRef}
-          isVisible
-          onClose={handleClose}
-          dismissOnMouseLeave
-          hideCloseButton
-          zIndex={30000}
-          anchorOrigin={anchorOrigin}
-          transformOrigin={transformOrigin}
+      <Popup
+        anchorRef={anchorRef}
+        isVisible={isHovered}
+        onClose={handleClose}
+        dismissOnMouseLeave
+        hideCloseButton
+        zIndex={30000}
+        anchorOrigin={anchorOrigin}
+        transformOrigin={transformOrigin}
+      >
+        <Paper
+          className={className}
+          borderRadius='m'
+          backgroundColor='white'
+          direction='column'
+          onClick={handleClick}
         >
-          <Paper
-            className={className}
-            borderRadius='m'
-            backgroundColor='white'
-            direction='column'
-            onClick={handleClick}
-          >
-            {content}
-          </Paper>
-        </Popup>
-      )}
+          {content}
+        </Paper>
+      </Popup>
     </Flex>
   )
 }

--- a/packages/harmony/src/components/hover-card/types.ts
+++ b/packages/harmony/src/components/hover-card/types.ts
@@ -40,6 +40,12 @@ export type HoverCardProps = {
    * @default { horizontal: 'left', vertical: 'center' }
    */
   transformOrigin?: Origin
+
+  /**
+   * Delay in seconds before the hover card appears after mouse enter
+   * @default 0.5
+   */
+  mouseEnterDelay?: number
 }
 
 export type HoverCardHeaderProps = {

--- a/packages/harmony/src/hooks/useHoverDelay.ts
+++ b/packages/harmony/src/hooks/useHoverDelay.ts
@@ -1,0 +1,51 @@
+import { useRef, useState, useEffect, useCallback } from 'react'
+
+/**
+ * Hook that manages delayed hover state
+ *
+ * @param delay Delay in seconds before setting hovered state to true
+ * @returns Object containing hover state and handlers
+ */
+export const useHoverDelay = (delay = 0.5) => {
+  const [isHovered, setIsHovered] = useState(false)
+  const timerRef = useRef<NodeJS.Timeout | null>(null)
+
+  // Clean up the timer when component unmounts
+  useEffect(() => {
+    return () => {
+      if (timerRef.current !== null) {
+        clearTimeout(timerRef.current)
+      }
+    }
+  }, [])
+
+  const clearTimer = useCallback(() => {
+    if (timerRef.current !== null) {
+      clearTimeout(timerRef.current)
+      timerRef.current = null
+    }
+  }, [])
+
+  const handleMouseEnter = useCallback(() => {
+    clearTimer()
+
+    // Convert seconds to milliseconds
+    const delayMs = delay * 1000
+
+    timerRef.current = setTimeout(() => {
+      setIsHovered(true)
+    }, delayMs)
+  }, [delay, clearTimer])
+
+  const handleMouseLeave = useCallback(() => {
+    clearTimer()
+    setIsHovered(false)
+  }, [clearTimer])
+
+  return {
+    isHovered,
+    handleMouseEnter,
+    handleMouseLeave,
+    clearTimer
+  }
+}

--- a/packages/harmony/src/hooks/useHoverDelay.ts
+++ b/packages/harmony/src/hooks/useHoverDelay.ts
@@ -46,6 +46,7 @@ export const useHoverDelay = (delay = 0.5) => {
     isHovered,
     handleMouseEnter,
     handleMouseLeave,
-    clearTimer
+    clearTimer,
+    setIsHovered
   }
 }


### PR DESCRIPTION
### Description
Design wanted there to be a slight delay similar to the one of the ArtistCard before opening these hover cards. The ArtistPopover uses `Popover from 'antd/lib/popover'` which has a `mouseEnterDelay` prop. Harmony does not use this so had to add some manual implementation.  

### How Has This Been Tested?

`npm run web:stage`

- ensure wallet ui feature flag is enabled
- hover over track tile badge icon 
