### PR TITLE
Fix track tile layout spacing

### DIFF
--- a/packages/web/src/components/link/UserLink.tsx
+++ b/packages/web/src/components/link/UserLink.tsx
@@ -139,6 +139,7 @@ export const UserLink = (props: UserLinkProps) => {
     return (
       <Flex
         css={{
+          height: spacing.unit5,
           columnGap: spacing.xs,
           alignItems: 'center',
           lineHeight: 'normal',

--- a/packages/web/src/components/link/UserLink.tsx
+++ b/packages/web/src/components/link/UserLink.tsx
@@ -139,7 +139,6 @@ export const UserLink = (props: UserLinkProps) => {
     return (
       <Flex
         css={{
-          height: spacing.unit5,
           columnGap: spacing.xs,
           alignItems: 'center',
           lineHeight: 'normal',

--- a/packages/web/src/components/track-flair/TrackFlair.tsx
+++ b/packages/web/src/components/track-flair/TrackFlair.tsx
@@ -24,7 +24,7 @@ const TrackFlair = (props: TrackFlairProps) => {
   const { data: track } = useTrack(id)
   const { data: remixContest } = useRemixContest(id)
 
-  if (!track) return null
+  if (!track) return <>{children}</>
 
   const remixTrack = track.remix_of?.tracks[0]
   const hasRemixAuthorReposted = remixTrack?.has_remix_author_reposted ?? false

--- a/packages/web/src/components/track/Artwork.tsx
+++ b/packages/web/src/components/track/Artwork.tsx
@@ -115,7 +115,7 @@ const Artwork = memo(
         size={Size.MEDIUM}
         id={id}
         className={cn(styles.artworkInset, {
-          [styles.small]: size === 'smqall',
+          [styles.small]: size === 'small',
           [styles.large]: size === 'large'
         })}
       >

--- a/packages/web/src/components/track/Artwork.tsx
+++ b/packages/web/src/components/track/Artwork.tsx
@@ -141,7 +141,6 @@ export const CollectionArtwork = memo((props: TileArtworkProps) => {
     collectionId: props.id,
     size: SquareSizes.SIZE_150_BY_150
   })
-  console.log('asdf image: ', image)
 
   return <Artwork {...props} image={image} />
 })

--- a/packages/web/src/components/track/Artwork.tsx
+++ b/packages/web/src/components/track/Artwork.tsx
@@ -110,17 +110,19 @@ const Artwork = memo(
         )}
       </DynamicImage>
     )
-    return (
+    return isTrack ? (
       <TrackFlair
         size={Size.MEDIUM}
         id={id}
         className={cn(styles.artworkInset, {
-          [styles.small]: size === 'small',
+          [styles.small]: size === 'smqall',
           [styles.large]: size === 'large'
         })}
       >
         {imageElement}
       </TrackFlair>
+    ) : (
+      imageElement
     )
   }
 )
@@ -139,6 +141,7 @@ export const CollectionArtwork = memo((props: TileArtworkProps) => {
     collectionId: props.id,
     size: SquareSizes.SIZE_150_BY_150
   })
+  console.log('asdf image: ', image)
 
   return <Artwork {...props} image={image} />
 })

--- a/packages/web/src/components/track/TrackTileStats.tsx
+++ b/packages/web/src/components/track/TrackTileStats.tsx
@@ -49,7 +49,6 @@ export const TrackTileStats = (props: TrackTileStatsProps) => {
       justifyContent='space-between'
       alignItems='center'
       pv={isMobile ? 's' : 'xs'}
-      mt='xs'
     >
       <Flex gap='l'>
         {isTrending ? <EntityRank index={rankIndex!} /> : null}

--- a/packages/web/src/components/track/TrackTileStats.tsx
+++ b/packages/web/src/components/track/TrackTileStats.tsx
@@ -50,7 +50,7 @@ export const TrackTileStats = (props: TrackTileStatsProps) => {
       alignItems='center'
       pv={isMobile ? 's' : 'xs'}
     >
-      <Flex gap='l'>
+      <Flex gap='l' h={size === TrackTileSize.LARGE ? 'xl' : 'm'}>
         {isTrending ? <EntityRank index={rankIndex!} /> : null}
         <TrackAccessTypeLabel trackId={trackId} />
         {isUnlisted ? null : (

--- a/packages/web/src/components/track/desktop/TrackTile.tsx
+++ b/packages/web/src/components/track/desktop/TrackTile.tsx
@@ -104,6 +104,7 @@ const TrackTile = ({
   trackId,
   source
 }: TrackTileProps) => {
+  console.log('asdf header: ', header)
   const { data: currentUserId } = useCurrentUserId()
   const trackPositionInfo = useSelector((state: CommonState) =>
     getTrackPosition(state, { trackId, userId: currentUserId })

--- a/packages/web/src/components/track/desktop/TrackTile.tsx
+++ b/packages/web/src/components/track/desktop/TrackTile.tsx
@@ -227,38 +227,47 @@ const TrackTile = ({
         <CollectionDogEar collectionId={collectionId} hideUnlocked />
       ) : null}
       <div className={styles.body}>
-        <Flex inline direction='column' justifyContent='space-between'>
-          {size === TrackTileSize.LARGE ? (
-            <Text
-              variant='label'
-              strength='default'
-              textAlign='left'
-              color='subdued'
-            >
-              {isLoading || !header ? null : header}
-            </Text>
-          ) : null}
-          <Flex direction='column' gap='xs' mb={header ? 'xs' : ''} pv='xs'>
-            {isLoading ? (
-              <Skeleton width='80%' height='20px' />
-            ) : (
-              <Flex css={{ marginRight: 132 }}>
-                <TextLink
-                  css={{ alignItems: 'center' }}
-                  to={permalink}
-                  isActive={isActive}
-                  textVariant='title'
-                  applyHoverStylesToInnerSvg
-                  onClick={onClickTitle}
-                  disabled={isDisabled}
-                  ellipses
+        <Flex inline direction='column' justifyContent='space-between' h='100%'>
+          <Flex column gap='s'>
+            {!isLoading && header ? (
+              <Flex pt='xs'>
+                <Text
+                  variant='label'
+                  strength='default'
+                  textAlign='left'
+                  color='subdued'
                 >
-                  <Text ellipses>{title}</Text>
-                  {isPlaying ? <IconVolume size='m' /> : null}
-                </TextLink>
+                  {header}
+                </Text>
               </Flex>
-            )}
-            {isLoading ? <Skeleton width='50%' height='20px' /> : userName}
+            ) : null}
+            <Flex
+              direction='column'
+              gap='xs'
+              mb={header ? 'xs' : undefined}
+              pv={!header ? 'xs' : undefined}
+            >
+              {isLoading ? (
+                <Skeleton width='80%' height='20px' />
+              ) : (
+                <Flex css={{ marginRight: 132 }}>
+                  <TextLink
+                    css={{ alignItems: 'center' }}
+                    to={permalink}
+                    isActive={isActive}
+                    textVariant='title'
+                    applyHoverStylesToInnerSvg
+                    onClick={onClickTitle}
+                    disabled={isDisabled}
+                    ellipses
+                  >
+                    <Text ellipses>{title}</Text>
+                    {isPlaying ? <IconVolume size='m' /> : null}
+                  </TextLink>
+                </Flex>
+              )}
+              {isLoading ? <Skeleton width='50%' height='20px' /> : userName}
+            </Flex>
           </Flex>
           {trackId ? (
             <TrackTileStats

--- a/packages/web/src/components/track/desktop/TrackTile.tsx
+++ b/packages/web/src/components/track/desktop/TrackTile.tsx
@@ -18,7 +18,8 @@ import {
   Text,
   Flex,
   ProgressBar,
-  Paper
+  Paper,
+  Divider
 } from '@audius/harmony'
 import cn from 'classnames'
 import { useSelector } from 'react-redux'
@@ -225,7 +226,7 @@ const TrackTile = ({
         <CollectionDogEar collectionId={collectionId} hideUnlocked />
       ) : null}
       <div className={styles.body}>
-        <Flex inline direction='column' h='100%' justifyContent='space-between'>
+        <Flex inline direction='column' justifyContent='space-between'>
           {size === TrackTileSize.LARGE ? (
             <Text
               variant='label'
@@ -236,7 +237,7 @@ const TrackTile = ({
               {isLoading || !header ? null : header}
             </Text>
           ) : null}
-          <Flex direction='column' gap='2xs' mb={header ? 'xs' : 's'}>
+          <Flex direction='column' gap='xs' mb={header ? 'xs' : ''} pv='xs'>
             {isLoading ? (
               <Skeleton width='80%' height='20px' />
             ) : (
@@ -280,8 +281,8 @@ const TrackTile = ({
           </Text>
         </Flex>
         {isTrack && trackId ? (
-          <>
-            <div className={styles.divider} />
+          <Flex column gap='s'>
+            <Divider orientation='horizontal' />
             {isOwner ? (
               <OwnerActionButtons
                 contentId={trackId}
@@ -317,7 +318,7 @@ const TrackTile = ({
                 }
               />
             )}
-          </>
+          </Flex>
         ) : null}
       </div>
     </Root>

--- a/packages/web/src/components/track/desktop/TrackTile.tsx
+++ b/packages/web/src/components/track/desktop/TrackTile.tsx
@@ -104,7 +104,6 @@ const TrackTile = ({
   trackId,
   source
 }: TrackTileProps) => {
-  console.log('asdf header: ', header)
   const { data: currentUserId } = useCurrentUserId()
   const trackPositionInfo = useSelector((state: CommonState) =>
     getTrackPosition(state, { trackId, userId: currentUserId })

--- a/packages/web/src/components/track/mobile/TrackTile.tsx
+++ b/packages/web/src/components/track/mobile/TrackTile.tsx
@@ -232,8 +232,8 @@ const TrackTile = (props: CombinedProps) => {
           />
           <Flex
             direction='column'
-            justifyContent='center'
-            gap='2xs'
+            gap='xs'
+            pv='xs'
             mr='m'
             flex='0 1 65%'
             css={{ overflow: 'hidden' }}

--- a/packages/web/src/components/user-card/UserCard.tsx
+++ b/packages/web/src/components/user-card/UserCard.tsx
@@ -81,6 +81,7 @@ export const UserCard = (props: UserCardProps) => {
       />
       <CardContent p='s' pt={0} gap='xs'>
         <UserLink
+          ellipses
           userId={id}
           textVariant='title'
           size='l'


### PR DESCRIPTION
 ### Description
Fixing some gaps missed by flair and user link. Also fixed some longstanding issues in spacing in track/collection tile to match designs.

<img width="254" alt="Screenshot 2025-04-23 at 2 03 41 PM" src="https://github.com/user-attachments/assets/e9d44ebb-c76a-4116-af90-c02da4a3f778" />
<img width="562" alt="Screenshot 2025-04-23 at 1 52 39 PM" src="https://github.com/user-attachments/assets/26ab56bc-b149-4ff3-8b41-7a2e277e8bf5" />
<img width="546" alt="Screenshot 2025-04-23 at 11 26 52 AM" src="https://github.com/user-attachments/assets/5b028212-8cd1-472e-a35d-376cc3037ec5" />

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._

Ran against web stage.