### PR TITLE
[PE-6017] Mobile remix contest info section

### DIFF
--- a/packages/mobile/src/components/core/TabBody.tsx
+++ b/packages/mobile/src/components/core/TabBody.tsx
@@ -1,0 +1,28 @@
+import type { ReactNode } from 'react'
+
+import { Flex } from '@audius/harmony-native'
+
+type Props = {
+  children: ReactNode
+  onLayout: (e: any) => void
+  isVisible: boolean
+}
+
+/**
+ * Common wrapper component for tab content that handles layout and visibility.
+ * Used to wrap content in tab views to handle animations and layout measurements.
+ */
+export const TabBody = ({ children, onLayout, isVisible }: Props) => {
+  return (
+    <Flex
+      w='100%'
+      flex={1}
+      onLayout={onLayout}
+      style={{
+        position: isVisible ? 'relative' : 'absolute'
+      }}
+    >
+      {children}
+    </Flex>
+  )
+}

--- a/packages/mobile/src/screens/track-screen/RemixContestDetailsTab.tsx
+++ b/packages/mobile/src/screens/track-screen/RemixContestDetailsTab.tsx
@@ -1,0 +1,46 @@
+import { useRemixContest } from '@audius/common/api'
+import type { ID } from '@audius/common/models'
+import { dayjs } from '@audius/common/utils'
+
+import { Flex, Text } from '@audius/harmony-native'
+import { UserGeneratedText } from 'app/components/core'
+
+const messages = {
+  due: 'Submission Due:',
+  deadline: (deadline?: string) => {
+    if (!deadline) return ''
+    const date = dayjs(deadline)
+    return `${date.format('MM/DD/YY')} at ${date.format('h:mm A')}`
+  },
+  fallbackDescription:
+    'Enter my remix contest before the deadline for your chance to win!'
+}
+
+type Props = {
+  trackId: ID
+}
+
+/**
+ * Tab content displaying details about a remix contest
+ */
+export const RemixContestDetailsTab = ({ trackId }: Props) => {
+  const { data: remixContest } = useRemixContest(trackId)
+
+  if (!remixContest) return null
+
+  return (
+    <Flex column gap='s' p='xl'>
+      <Flex row gap='s'>
+        <Text variant='title' color='accent'>
+          {messages.due}
+        </Text>
+        <Text variant='body' strength='strong'>
+          {messages.deadline(remixContest?.endDate)}
+        </Text>
+      </Flex>
+      <UserGeneratedText variant='body'>
+        {remixContest?.eventData?.description ?? messages.fallbackDescription}
+      </UserGeneratedText>
+    </Flex>
+  )
+}

--- a/packages/mobile/src/screens/track-screen/RemixContestDetailsTab.tsx
+++ b/packages/mobile/src/screens/track-screen/RemixContestDetailsTab.tsx
@@ -35,11 +35,11 @@ export const RemixContestDetailsTab = ({ trackId }: Props) => {
           {messages.due}
         </Text>
         <Text variant='body' strength='strong'>
-          {messages.deadline(remixContest?.endDate)}
+          {messages.deadline(remixContest.endDate)}
         </Text>
       </Flex>
       <UserGeneratedText variant='body'>
-        {remixContest?.eventData?.description ?? messages.fallbackDescription}
+        {remixContest.eventData?.description ?? messages.fallbackDescription}
       </UserGeneratedText>
     </Flex>
   )

--- a/packages/mobile/src/screens/track-screen/RemixContestPrizesTab.tsx
+++ b/packages/mobile/src/screens/track-screen/RemixContestPrizesTab.tsx
@@ -19,7 +19,7 @@ export const RemixContestPrizesTab = ({ trackId }: Props) => {
   return (
     <Flex p='xl'>
       <UserGeneratedText variant='body' size='l'>
-        {remixContest?.eventData?.prizeInfo ?? ''}
+        {remixContest.eventData?.prizeInfo ?? ''}
       </UserGeneratedText>
     </Flex>
   )

--- a/packages/mobile/src/screens/track-screen/RemixContestPrizesTab.tsx
+++ b/packages/mobile/src/screens/track-screen/RemixContestPrizesTab.tsx
@@ -1,0 +1,26 @@
+import { useRemixContest } from '@audius/common/api'
+import type { ID } from '@audius/common/models'
+
+import { Flex } from '@audius/harmony-native'
+import { UserGeneratedText } from 'app/components/core'
+
+type Props = {
+  trackId: ID
+}
+
+/**
+ * Tab content displaying prizes for a remix contest
+ */
+export const RemixContestPrizesTab = ({ trackId }: Props) => {
+  const { data: remixContest } = useRemixContest(trackId)
+
+  if (!remixContest) return null
+
+  return (
+    <Flex p='xl'>
+      <UserGeneratedText variant='body' size='l'>
+        {remixContest?.eventData?.prizeInfo ?? ''}
+      </UserGeneratedText>
+    </Flex>
+  )
+}

--- a/packages/mobile/src/screens/track-screen/RemixContestSection.tsx
+++ b/packages/mobile/src/screens/track-screen/RemixContestSection.tsx
@@ -1,0 +1,179 @@
+import React, { useEffect, useMemo, useState } from 'react'
+
+import { useRemixContest, useTrack, useCurrentUserId } from '@audius/common/api'
+import type { ID } from '@audius/common/models'
+import Animated, {
+  useAnimatedStyle,
+  useSharedValue,
+  withTiming
+} from 'react-native-reanimated'
+import { TabView, SceneMap, TabBar } from 'react-native-tab-view'
+import { usePrevious } from 'react-use'
+
+import { Paper } from '@audius/harmony-native'
+import { TabBody } from 'app/components/core/TabBody'
+import { makeStyles } from 'app/styles'
+import { useThemeColors } from 'app/utils/theme'
+
+import { RemixContestDetailsTab } from './RemixContestDetailsTab'
+import { RemixContestPrizesTab } from './RemixContestPrizesTab'
+import { RemixContestSubmissionsTab } from './RemixContestSubmissionsTab'
+import { UploadRemixFooter } from './UploadRemixFooter'
+
+const TAB_HEADER_HEIGHT = 48
+const TAB_FOOTER_HEIGHT = 64
+
+const useStyles = makeStyles(({ palette, typography, spacing }) => ({
+  tabBar: {
+    backgroundColor: 'transparent',
+    borderBottomWidth: 1,
+    borderBottomColor: palette.neutralLight8,
+    height: spacing(10)
+  },
+  tabLabel: {
+    textTransform: 'none',
+    fontFamily: typography.fontByWeight.demiBold,
+    fontSize: typography.fontSize.medium
+  },
+  tabIndicator: {
+    backgroundColor: palette.secondary,
+    borderBottomLeftRadius: 20,
+    borderBottomRightRadius: 20,
+    height: 3,
+    bottom: -3
+  }
+}))
+
+export type RemixContestTabParamList = {
+  Details: { trackId: ID }
+  Prizes: { trackId: ID }
+  Submissions: { trackId: ID }
+}
+
+type RemixContestSectionProps = {
+  trackId: ID
+}
+
+type Route = {
+  key: string
+  title: string
+}
+
+const AnimatedPaper = Animated.createAnimatedComponent(Paper)
+
+/**
+ * Section displaying remix contest information for a track
+ */
+export const RemixContestSection = ({ trackId }: RemixContestSectionProps) => {
+  const { data: remixContest } = useRemixContest(trackId)
+  const { textIconSubdued, neutral } = useThemeColors()
+  const styles = useStyles()
+
+  const { data: track } = useTrack(trackId)
+  const { data: currentUserId } = useCurrentUserId()
+  const isOwner = track?.owner_id === currentUserId
+
+  const [index, setIndex] = useState(0)
+  const [routes] = useState<Route[]>([
+    { key: 'details', title: 'Details' },
+    { key: 'prizes', title: 'Prizes' },
+    { key: 'submissions', title: 'Submissions' }
+  ])
+  const [heights, setHeights] = useState({})
+  const [firstRender, setFirstRender] = useState(true)
+  const animatedHeight = useSharedValue(TAB_HEADER_HEIGHT)
+  const currentHeight = heights[routes[index].key]
+  const previousHeight = usePrevious(currentHeight)
+  const hasHeightChanged = currentHeight !== previousHeight
+
+  useEffect(() => {
+    if (firstRender) {
+      setFirstRender(false)
+    }
+  }, [firstRender])
+
+  const handleLayout = (key: string) => (e: any) => {
+    const height = e.nativeEvent.layout.height
+    setHeights((prev) => {
+      if (prev[key] !== height) {
+        return { ...prev, [key]: height }
+      }
+      return prev
+    })
+  }
+
+  useEffect(() => {
+    if (hasHeightChanged) {
+      animatedHeight.value = withTiming(
+        currentHeight + TAB_HEADER_HEIGHT + (isOwner ? 0 : TAB_FOOTER_HEIGHT),
+        {
+          duration: 250
+        }
+      )
+    }
+  }, [index, hasHeightChanged, currentHeight, animatedHeight, isOwner])
+
+  const animatedStyle = useAnimatedStyle(() => ({
+    height: animatedHeight.value
+  }))
+
+  const renderScene = useMemo(
+    () =>
+      SceneMap({
+        details: () => (
+          <TabBody
+            onLayout={handleLayout('details')}
+            isVisible={index === 0 && !firstRender}
+          >
+            <RemixContestDetailsTab key='details' trackId={trackId} />
+          </TabBody>
+        ),
+        prizes: () => (
+          <TabBody
+            onLayout={handleLayout('prizes')}
+            isVisible={index === 1 && !firstRender}
+          >
+            <RemixContestPrizesTab key='prizes' trackId={trackId} />
+          </TabBody>
+        ),
+        submissions: () => (
+          <TabBody
+            onLayout={handleLayout('submissions')}
+            isVisible={index === 2 && !firstRender}
+          >
+            <RemixContestSubmissionsTab key='submissions' trackId={trackId} />
+          </TabBody>
+        )
+      }),
+    // Don't want handleLayout to re-trigger on index changes
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    []
+  )
+
+  const renderTabBar = (props: any) => (
+    <TabBar
+      {...props}
+      style={styles.tabBar}
+      labelStyle={styles.tabLabel}
+      indicatorStyle={styles.tabIndicator}
+      activeColor={neutral}
+      inactiveColor={textIconSubdued}
+      pressColor='transparent'
+      pressOpacity={0.7}
+    />
+  )
+
+  if (!remixContest) return null
+
+  return (
+    <AnimatedPaper backgroundColor='white' style={animatedStyle}>
+      <TabView
+        navigationState={{ index, routes }}
+        renderScene={renderScene}
+        renderTabBar={renderTabBar}
+        onIndexChange={setIndex}
+      />
+      {!isOwner && <UploadRemixFooter trackId={trackId} />}
+    </AnimatedPaper>
+  )
+}

--- a/packages/mobile/src/screens/track-screen/RemixContestSection.tsx
+++ b/packages/mobile/src/screens/track-screen/RemixContestSection.tsx
@@ -71,8 +71,7 @@ export const RemixContestSection = ({ trackId }: RemixContestSectionProps) => {
 
   const { data: track } = useTrack(trackId)
   const { data: currentUserId } = useCurrentUserId()
-  // const isOwner = track?.owner_id === currentUserId
-  const isOwner = false
+  const isOwner = track?.owner_id === currentUserId
 
   const [index, setIndex] = useState(0)
   const [routes] = useState<Route[]>([

--- a/packages/mobile/src/screens/track-screen/RemixContestSection.tsx
+++ b/packages/mobile/src/screens/track-screen/RemixContestSection.tsx
@@ -71,7 +71,8 @@ export const RemixContestSection = ({ trackId }: RemixContestSectionProps) => {
 
   const { data: track } = useTrack(trackId)
   const { data: currentUserId } = useCurrentUserId()
-  const isOwner = track?.owner_id === currentUserId
+  // const isOwner = track?.owner_id === currentUserId
+  const isOwner = false
 
   const [index, setIndex] = useState(0)
   const [routes] = useState<Route[]>([

--- a/packages/mobile/src/screens/track-screen/RemixContestSubmissionsTab.tsx
+++ b/packages/mobile/src/screens/track-screen/RemixContestSubmissionsTab.tsx
@@ -1,0 +1,25 @@
+import { useRemixContest } from '@audius/common/api'
+import type { ID } from '@audius/common/models'
+
+import { Flex, Text } from '@audius/harmony-native'
+
+type Props = {
+  trackId: ID
+}
+
+/**
+ * Tab content displaying submissions for a remix contest
+ */
+export const RemixContestSubmissionsTab = ({ trackId }: Props) => {
+  const { data: remixContest } = useRemixContest(trackId)
+
+  if (!remixContest) return null
+
+  return (
+    <Flex p='xl'>
+      <Text variant='body' size='l'>
+        {/* TODO: Implement submissions content */}
+      </Text>
+    </Flex>
+  )
+}

--- a/packages/mobile/src/screens/track-screen/TrackScreen.tsx
+++ b/packages/mobile/src/screens/track-screen/TrackScreen.tsx
@@ -17,6 +17,7 @@ import { ScreenSecondaryContent } from 'app/components/core/Screen/ScreenSeconda
 import { useRoute } from 'app/hooks/useRoute'
 
 import { RemixContestCountdown } from './RemixContestCountdown'
+import { RemixContestSection } from './RemixContestSection'
 import { TrackScreenDetailsTile } from './TrackScreenDetailsTile'
 import { TrackScreenLineup } from './TrackScreenLineup'
 import { TrackScreenSkeleton } from './TrackScreenSkeleton'
@@ -69,6 +70,8 @@ export const TrackScreen = () => {
             {isReachable ? (
               <ScreenSecondaryContent>
                 <Flex gap='2xl'>
+                  {/* Remix Contest */}
+                  <RemixContestSection trackId={track_id} />
                   {/* Comments */}
                   {!comments_disabled ? (
                     <Flex flex={3}>

--- a/packages/mobile/src/screens/track-screen/UploadRemixFooter.tsx
+++ b/packages/mobile/src/screens/track-screen/UploadRemixFooter.tsx
@@ -1,9 +1,6 @@
 import React, { useCallback } from 'react'
 
-import { useRemixContest, useTrack, useUser } from '@audius/common/api'
-import { useCurrentUser } from '@audius/common/api/tan-query/useCurrentUser'
 import type { ID } from '@audius/common/models'
-import { dayjs } from '@audius/common/utils'
 
 import { Button, Flex, IconCloudUpload } from '@audius/harmony-native'
 import { useNavigation } from 'app/hooks/useNavigation'

--- a/packages/mobile/src/screens/track-screen/UploadRemixFooter.tsx
+++ b/packages/mobile/src/screens/track-screen/UploadRemixFooter.tsx
@@ -1,0 +1,58 @@
+import React, { useCallback } from 'react'
+
+import { useRemixContest, useTrack, useUser } from '@audius/common/api'
+import { useCurrentUser } from '@audius/common/api/tan-query/useCurrentUser'
+import type { ID } from '@audius/common/models'
+import { dayjs } from '@audius/common/utils'
+
+import { Button, Flex, IconCloudUpload } from '@audius/harmony-native'
+import { useNavigation } from 'app/hooks/useNavigation'
+
+const messages = {
+  contestEnded: 'Contest Ended',
+  contestDeadline: 'Contest Deadline',
+  uploadRemixButtonText: 'Upload Your Remix'
+}
+
+type UploadRemixFooterProps = {
+  trackId: ID
+}
+
+/**
+ * Footer component for uploading remixes in the remix contest section
+ */
+export const UploadRemixFooter = ({ trackId }: UploadRemixFooterProps) => {
+  const navigation = useNavigation()
+
+  const handlePressSubmitRemix = useCallback(() => {
+    if (!trackId) return
+    navigation.push('Upload', {
+      initialMetadata: {
+        is_remix: true,
+        remix_of: {
+          tracks: [{ parent_track_id: trackId }]
+        }
+      }
+    })
+  }, [navigation, trackId])
+
+  return (
+    <Flex
+      borderTop='default'
+      pv='l'
+      ph='xl'
+      alignItems='center'
+      justifyContent='center'
+    >
+      <Button
+        variant='secondary'
+        size='small'
+        iconLeft={IconCloudUpload}
+        onPress={handlePressSubmitRemix}
+        fullWidth
+      >
+        {messages.uploadRemixButtonText}
+      </Button>
+    </Flex>
+  )
+}


### PR DESCRIPTION
### Description
- New remix contest info section on TrackScreen
- Uses `react-native-tab-view` for the Tab View UI
- Not swipeable (left/right), can only press the headers (design confirmed swiping is nice-to-have but not needed)

Auto-resizing was tricky:
- On first render, set `position: absolute` so that the `onLayout` handler can correctly measure the height of each tab's content (without position: absolute, the content is size 0). (This logic is handled in `TabBody`)
- Use the resulting values in an animated style for height

TODO:
- Expandable description
- Scrolling is borked in the tab view
- Loading state
- Header styles aren't perfect

### How Has This Been Tested?

https://github.com/user-attachments/assets/d0ae4111-da79-4e0a-ad28-b1c6a369cacf

