### PR TITLE
Finish reverting back to favorite saga

### DIFF
--- a/packages/web/src/components/track/desktop/ConnectedTrackTile.tsx
+++ b/packages/web/src/components/track/desktop/ConnectedTrackTile.tsx
@@ -43,7 +43,8 @@ import TrackTile from './TrackTile'
 
 const { getUid, getPlaying, getBuffering } = playerSelectors
 const { requestOpen: requestOpenShareModal } = shareModalUIActions
-const { repostTrack, undoRepostTrack } = tracksSocialActions
+const { repostTrack, undoRepostTrack, saveTrack, unsaveTrack } =
+  tracksSocialActions
 const { setLockedContentId } = gatedContentActions
 
 type OwnProps = {
@@ -115,6 +116,19 @@ const ConnectedTrackTile = ({
     },
     [dispatch]
   )
+  const handleSaveTrack = useCallback(
+    (trackId: ID, isFeed: boolean) => {
+      dispatch(saveTrack(trackId, FavoriteSource.TILE, isFeed))
+    },
+    [dispatch]
+  )
+
+  const handleUndoSaveTrack = useCallback(
+    (trackId: ID) => {
+      dispatch(unsaveTrack(trackId, FavoriteSource.TILE))
+    },
+    [dispatch]
+  )
 
   const handleRepostTrack = useCallback(
     (trackId: ID, isFeed: boolean) => {
@@ -160,11 +174,6 @@ const ConnectedTrackTile = ({
 
   const [, setLockedContentVisibility] = useModalState('LockedContent')
   const menuRef = useRef<HTMLDivElement>(null)
-
-  const toggleSaveTrack = useToggleFavoriteTrack({
-    trackId,
-    source: FavoriteSource.TILE
-  })
 
   useEffect(() => {
     if (!loading && hasLoaded) {
@@ -243,8 +252,12 @@ const ConnectedTrackTile = ({
   )
 
   const onClickFavorite = useCallback(() => {
-    toggleSaveTrack()
-  }, [toggleSaveTrack])
+    if (isFavorited) {
+      handleUndoSaveTrack(trackId)
+    } else {
+      handleSaveTrack(trackId, isFeed)
+    }
+  }, [isFavorited, handleUndoSaveTrack, trackId, handleSaveTrack, isFeed])
 
   const onClickRepost = useCallback(() => {
     if (isReposted) {

--- a/packages/web/src/components/track/desktop/ConnectedTrackTile.tsx
+++ b/packages/web/src/components/track/desktop/ConnectedTrackTile.tsx
@@ -1,11 +1,6 @@
 import { memo, useCallback, useEffect, MouseEvent, useRef } from 'react'
 
-import {
-  useCurrentUserId,
-  useToggleFavoriteTrack,
-  useTrack,
-  useUser
-} from '@audius/common/api'
+import { useCurrentUserId, useTrack, useUser } from '@audius/common/api'
 import { useGatedContentAccess } from '@audius/common/hooks'
 import {
   ShareSource,


### PR DESCRIPTION
### Description
Noticed that favorites weren't going through confirmer nor stopping user from exiting early. I think this part was left out of this migration https://github.com/AudiusProject/audius-protocol/pull/11672.

I think this fixes PE-6036 a bug around cosign flair disappearing.

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._

confirmed favorites go through confirmer and save / undo save work. 