### PR TITLE
[PE-6019] Add submissions tab contest to the remix contest container

### DIFF
--- a/packages/web/src/pages/track-page/components/TrackPageLineup.tsx
+++ b/packages/web/src/pages/track-page/components/TrackPageLineup.tsx
@@ -1,3 +1,4 @@
+import { useRemixContest } from '@audius/common/api'
 import { User } from '@audius/common/models'
 import { useTrackPageLineup } from '@audius/common/src/api/tan-query/useTrackPageLineup'
 import { tracksActions } from '@audius/common/src/store/pages/track/lineup/actions'
@@ -49,6 +50,8 @@ export const TrackPageLineup = ({
   commentsDisabled
 }: TrackPageLineupProps) => {
   const { indices, ...lineupData } = useTrackPageLineup({ trackId })
+  const { data: remixContest } = useRemixContest(trackId)
+  const isRemixContest = !!remixContest
 
   const { isDesktop, isMobile } = useTrackPageSize()
 
@@ -142,8 +145,8 @@ export const TrackPageLineup = ({
         maxWidth: isCommentingEnabled ? '100%' : 774
       }}
     >
-      {renderRemixParentSection()}
-      {renderRemixesSection()}
+      {!isRemixContest ? renderRemixParentSection() : null}
+      {!isRemixContest ? renderRemixesSection() : null}
       {renderMoreBySection()}
       {renderRecommendedSection()}
     </Flex>

--- a/packages/web/src/pages/track-page/components/desktop/RemixContestSection.tsx
+++ b/packages/web/src/pages/track-page/components/desktop/RemixContestSection.tsx
@@ -1,4 +1,4 @@
-import { useRemixContest } from '@audius/common/api'
+import { useRemixContest, useRemixes } from '@audius/common/api'
 import { ID } from '@audius/common/models'
 import { UPLOAD_PAGE } from '@audius/common/src/utils/route'
 import {
@@ -40,6 +40,7 @@ export const RemixContestSection = ({
 }: RemixContestSectionProps) => {
   const navigate = useNavigateToPage()
   const { data: remixContest } = useRemixContest(trackId)
+  const { data: remixes } = useRemixes({ trackId, isContestEntry: true })
 
   const tabs = [
     {
@@ -51,7 +52,8 @@ export const RemixContestSection = ({
       label: 'prizes'
     },
     {
-      text: messages.submissions,
+      text:
+        messages.submissions + (remixes?.length ? ` (${remixes.length})` : ''),
       label: 'submissions'
     }
   ]
@@ -59,7 +61,11 @@ export const RemixContestSection = ({
   const elements = [
     <RemixContestDetailsTab key='details' trackId={trackId} />,
     <RemixContestPrizesTab key='prizes' trackId={trackId} />,
-    <RemixContestSubmissionsTab key='submissions' trackId={trackId} />
+    <RemixContestSubmissionsTab
+      key='submissions'
+      trackId={trackId}
+      submissions={remixes.slice(0, 10)}
+    />
   ]
 
   const { tabs: TabBar, body: TabBody } = useTabs({
@@ -93,7 +99,12 @@ export const RemixContestSection = ({
           {messages.title}
         </Text>
       </Flex>
-      <Box backgroundColor='white' shadow='mid' borderRadius='l'>
+      <Box
+        backgroundColor='white'
+        shadow='mid'
+        borderRadius='l'
+        css={{ overflow: 'hidden' }}
+      >
         <Flex column pv='m'>
           <Flex justifyContent='space-between' borderBottom='default' ph='xl'>
             <Flex alignItems='center'>{TabBar}</Flex>

--- a/packages/web/src/pages/track-page/components/desktop/RemixContestSubmissionsTab.tsx
+++ b/packages/web/src/pages/track-page/components/desktop/RemixContestSubmissionsTab.tsx
@@ -16,6 +16,9 @@ import { TrackArtwork } from 'components/track/TrackArtwork'
 import TrackFlair, { Size } from 'components/track-flair/TrackFlair'
 import { trackRemixesPage } from 'utils/route'
 
+const artworkSize = 160
+const userAvatarSize = 64
+
 const messages = {
   noSubmissions: 'No submissions yet',
   beFirst: 'Be the first to upload a remix!',
@@ -50,9 +53,9 @@ const SubmissionCard = ({ submission }: { submission: LineupData }) => {
 
   return (
     <Flex column gap='s'>
-      <Flex h={160} w={160} borderRadius='s'>
+      <Flex h={artworkSize} w={artworkSize} borderRadius='s'>
         {displaySkeleton ? (
-          <Skeleton h={160} w={160} borderRadius='s' />
+          <Skeleton h={artworkSize} w={artworkSize} borderRadius='s' />
         ) : (
           <>
             {/* Track Artwork with Flair */}
@@ -73,8 +76,8 @@ const SubmissionCard = ({ submission }: { submission: LineupData }) => {
             </TrackFlair>
             {/* User Avatar */}
             <Box
-              h={64}
-              w={64}
+              h={userAvatarSize}
+              w={userAvatarSize}
               css={{ position: 'absolute', top: -8, right: -8 }}
               borderRadius='circle'
             >

--- a/packages/web/src/pages/track-page/components/desktop/RemixContestSubmissionsTab.tsx
+++ b/packages/web/src/pages/track-page/components/desktop/RemixContestSubmissionsTab.tsx
@@ -1,22 +1,135 @@
-import { ID } from '@audius/common/models'
-import { Flex, Text } from '@audius/harmony'
+import { LineupData, useUser, useTrack } from '@audius/common/api'
+import { ID, SquareSizes } from '@audius/common/models'
+import {
+  Box,
+  Flex,
+  IconArrowRight,
+  PlainButton,
+  Skeleton,
+  Text
+} from '@audius/harmony'
+import { Link } from 'react-router-dom-v5-compat'
+
+import { Avatar } from 'components/avatar'
+import { TrackLink, UserLink } from 'components/link'
+import { TrackArtwork } from 'components/track/TrackArtwork'
+import TrackFlair, { Size } from 'components/track-flair/TrackFlair'
+import { trackRemixesPage } from 'utils/route'
 
 const messages = {
   noSubmissions: 'No submissions yet',
-  beFirst: 'Be the first to upload a remix!'
+  beFirst: 'Be the first to upload a remix!',
+  viewAll: 'View All'
 }
 
 type RemixContestSubmissionsTabProps = {
   trackId: ID
+  submissions: LineupData[]
 }
 
 /**
  * Tab content displaying submissions for a remix contest
  */
 export const RemixContestSubmissionsTab = ({
-  trackId
+  trackId,
+  submissions
 }: RemixContestSubmissionsTabProps) => {
-  return <EmptyRemixContestSubmissions />
+  // If there are no submissions, show the empty state
+  if (submissions.length === 0) {
+    return <EmptyRemixContestSubmissions />
+  }
+
+  return <RemixContestSubmissions trackId={trackId} submissions={submissions} />
+}
+
+const SubmissionCard = ({ submission }: { submission: LineupData }) => {
+  const { data: track, isLoading: trackLoading } = useTrack(submission.id)
+  const { data: user, isLoading: userLoading } = useUser(track?.owner_id)
+  const isLoading = trackLoading || userLoading
+  const displaySkeleton = isLoading || !track || !user
+
+  return (
+    <Flex column gap='s'>
+      <Flex h={160} w={160} borderRadius='s'>
+        {displaySkeleton ? (
+          <Skeleton h={160} w={160} borderRadius='s' />
+        ) : (
+          <>
+            {/* Track Artwork with Flair */}
+            <TrackFlair
+              css={{ height: '100%', width: '100%' }}
+              id={track.track_id}
+              size={Size.LARGE}
+              hideToolTip
+            >
+              <TrackArtwork
+                style={{
+                  width: '100%',
+                  height: '100%'
+                }}
+                trackId={track.track_id}
+                size={SquareSizes.SIZE_480_BY_480}
+              />
+            </TrackFlair>
+            {/* User Avatar */}
+            <Box
+              h={64}
+              w={64}
+              css={{ position: 'absolute', top: -8, right: -8 }}
+              borderRadius='circle'
+            >
+              <Avatar
+                userId={user.user_id}
+                imageSize={SquareSizes.SIZE_150_BY_150}
+              />
+            </Box>
+          </>
+        )}
+      </Flex>
+      <Flex column gap='xs'>
+        {displaySkeleton ? (
+          <>
+            <Skeleton h={24} w={120} />
+            <Skeleton h={24} w={80} />
+          </>
+        ) : (
+          <>
+            <TrackLink textVariant='title' trackId={track.track_id} />
+            <UserLink userId={user.user_id} popover />
+          </>
+        )}
+      </Flex>
+    </Flex>
+  )
+}
+
+const RemixContestSubmissions = ({
+  trackId,
+  submissions
+}: {
+  trackId: ID
+  submissions: LineupData[]
+}) => {
+  const { data: permalink } = useTrack(trackId, {
+    select: (track) => track.permalink
+  })
+
+  const remixesRoute = trackRemixesPage(permalink ?? '')
+
+  return (
+    <Flex w='100%' column gap='2xl' p='xl'>
+      <Flex gap='2xl' wrap='wrap'>
+        {submissions.map((submission) => (
+          <SubmissionCard key={submission.id} submission={submission} />
+        ))}
+      </Flex>
+      <Flex justifyContent='center'>
+        <PlainButton size='large' iconRight={IconArrowRight} asChild>
+          <Link to={remixesRoute}>{messages.viewAll}</Link>
+        </PlainButton>
+      </Flex>
+    </Flex>
+  )
 }
 
 const EmptyRemixContestSubmissions = () => {


### PR DESCRIPTION
### Description
* Add content for the submissions tab
* Update the track page lineup to not show remixes section if the track is a remix contest
* Small update to hide overflow on the container so that as is transitions, content is not outside of the container

### How Has This Been Tested?
Manually Tested
