### PR TITLE
Address async feedback on wallet UI m1

### DIFF
--- a/packages/common/src/api/index.ts
+++ b/packages/common/src/api/index.ts
@@ -80,6 +80,7 @@ export * from './tan-query/useRemixes'
 export * from './tan-query/useTrackRank'
 export * from './tan-query/useWalletOwner'
 export * from './tan-query/useTokenPrice'
+export * from './tan-query/useUSDCBalance'
 
 export * from './tan-query/useStems'
 export * from './tan-query/useFileSizes'

--- a/packages/common/src/api/tan-query/queryKeys.ts
+++ b/packages/common/src/api/tan-query/queryKeys.ts
@@ -87,5 +87,6 @@ export const QUERY_KEYS = {
   eventsByEntityId: 'eventsByEntityId',
   walletOwner: 'walletOwner',
   tokenPrice: 'tokenPrice',
+  usdcBalance: 'usdcBalance',
   fileSizes: 'fileSizes'
 } as const

--- a/packages/common/src/api/tan-query/useUSDCBalance.ts
+++ b/packages/common/src/api/tan-query/useUSDCBalance.ts
@@ -1,0 +1,106 @@
+import { Commitment } from '@solana/web3.js'
+import { useQuery } from '@tanstack/react-query'
+import BN from 'bn.js'
+import { useDispatch, useSelector } from 'react-redux'
+
+import { useAudiusQueryContext } from '~/audius-query'
+import { Status } from '~/models/Status'
+import { BNUSDC, StringUSDC } from '~/models/Wallet'
+import { getUserbankAccountInfo } from '~/services/index'
+import { getRecoveryStatus } from '~/store/buy-usdc/selectors'
+import { setUSDCBalance } from '~/store/wallet/slice'
+
+import { useGetCurrentUser } from '../index'
+
+import { QUERY_KEYS } from './queryKeys'
+import { QueryOptions, type QueryKey } from './types'
+
+export const getUSDCBalanceQueryKey = (
+  ethAddress: string | null,
+  commitment: Commitment
+) =>
+  [
+    QUERY_KEYS.usdcBalance,
+    ethAddress,
+    commitment
+  ] as unknown as QueryKey<BNUSDC | null>
+
+/**
+ * Hook to get the USDC balance for the current user.
+ * Uses TanStack Query for data fetching and caching.
+ *
+ * @param options Options for the query and polling
+ * @returns Object with status, data, refresh, and cancelPolling
+ */
+export const useUSDCBalance = ({
+  isPolling,
+  pollingInterval = 1000,
+  commitment = 'processed',
+  ...queryOptions
+}: {
+  isPolling?: boolean
+  pollingInterval?: number
+  commitment?: Commitment
+} & QueryOptions = {}) => {
+  const { audiusSdk } = useAudiusQueryContext()
+  const { data: user } = useGetCurrentUser({})
+  const ethAddress = user?.wallet ?? null
+  const dispatch = useDispatch()
+  const recoveryStatus = useSelector(getRecoveryStatus)
+
+  const result = useQuery({
+    queryKey: getUSDCBalanceQueryKey(ethAddress, commitment),
+    queryFn: async () => {
+      const sdk = await audiusSdk()
+      if (!ethAddress) {
+        return null
+      }
+
+      try {
+        const account = await getUserbankAccountInfo(
+          sdk,
+          {
+            ethAddress,
+            mint: 'USDC'
+          },
+          commitment
+        )
+        const balance = (account?.amount ?? new BN(0)) as BNUSDC
+
+        // Still update Redux for compatibility with existing code
+        dispatch(setUSDCBalance({ amount: balance.toString() as StringUSDC }))
+
+        return balance
+      } catch (e) {
+        console.error('Error fetching USDC balance:', e)
+        throw e
+      }
+    },
+    enabled: !!ethAddress,
+    ...queryOptions
+  })
+
+  // Map TanStack Query states to the Status enum for API compatibility
+  let status = Status.IDLE
+  if (result.isLoading) {
+    status = Status.LOADING
+  } else if (result.isError) {
+    status = Status.ERROR
+  } else if (result.isSuccess) {
+    status = Status.SUCCESS
+  }
+
+  // For compatibility with existing code
+  const data = result.data ?? null
+
+  // If we're actively recovering, then we will be in loading state regardless
+  if (recoveryStatus === Status.LOADING) {
+    status = Status.LOADING
+  }
+
+  return {
+    status,
+    data,
+    refresh: result.refetch
+  }
+}

--- a/packages/common/src/hooks/useFormattedUSDCBalance.ts
+++ b/packages/common/src/hooks/useFormattedUSDCBalance.ts
@@ -3,9 +3,8 @@ import { useMemo } from 'react'
 import { USDC } from '@audius/fixed-decimal'
 import BN from 'bn.js'
 
+import { useUSDCBalance } from '../api/tan-query/useUSDCBalance'
 import { BNUSDC, Status } from '../models'
-
-import { useUSDCBalance } from './useUSDCBalance'
 
 type UseFormattedUSDCBalanceReturn = {
   balance: BNUSDC | null

--- a/packages/web/src/pages/pay-and-earn-page/components/CashWallet.styles.ts
+++ b/packages/web/src/pages/pay-and-earn-page/components/CashWallet.styles.ts
@@ -21,6 +21,9 @@ export const useCashWalletStyles = makeResponsiveStyles<Styles>(
 
     // Payout wallet flex container
     payoutWalletFlex: {
+      base: {
+        cursor: 'pointer'
+      },
       mobile: {
         ...(media.isExtraSmall && {
           flexDirection: 'column',

--- a/packages/web/src/pages/pay-and-earn-page/components/CashWallet.tsx
+++ b/packages/web/src/pages/pay-and-earn-page/components/CashWallet.tsx
@@ -96,6 +96,7 @@ export const CashWallet = () => {
                 placement='top'
                 mount='page'
                 shouldWrapContent={false}
+                shouldDismissOnClick={false}
                 css={{ zIndex: zIndex.CASH_WALLET_TOOLTIP }}
               >
                 <IconButton
@@ -110,12 +111,25 @@ export const CashWallet = () => {
           </Flex>
 
           {/* Balance Value */}
-          <Text variant='display' size='m' color='default'>
-            ${isLoading ? '--.--' : balanceFormatted}
+          <Text
+            variant='display'
+            size='m'
+            color='default'
+            css={{
+              opacity: isLoading ? 0 : 1,
+              transition: 'opacity 0.3s ease'
+            }}
+          >
+            ${balanceFormatted}
           </Text>
 
           {/* Payout Wallet Info */}
-          <Flex alignItems='center' gap='s' css={styles.payoutWalletFlex}>
+          <Flex
+            alignItems='center'
+            gap='s'
+            css={styles.payoutWalletFlex}
+            onClick={handlePayoutWalletClick}
+          >
             <TextLink
               variant='visible'
               size='m'

--- a/packages/web/src/pages/pay-and-earn-page/components/YourCoins.tsx
+++ b/packages/web/src/pages/pay-and-earn-page/components/YourCoins.tsx
@@ -1,7 +1,6 @@
 import { useCallback } from 'react'
 
 import { useFormattedAudioBalance } from '@audius/common/hooks'
-import { walletMessages } from '@audius/common/messages'
 import { route } from '@audius/common/utils'
 import {
   Flex,
@@ -34,9 +33,7 @@ export const YourCoins = () => {
     dispatch(push(WALLET_AUDIO_PAGE))
   }, [dispatch])
 
-  const displayAmount = isAudioBalanceLoading
-    ? walletMessages.loading
-    : audioBalanceFormatted
+  const isLoading = isAudioBalanceLoading || isAudioPriceLoading
 
   return (
     <Paper
@@ -66,19 +63,24 @@ export const YourCoins = () => {
               borderRadius: cornerRadius.circle
             }}
           />
-          <Flex direction='column' gap='xs'>
+          <Flex
+            direction='column'
+            gap='xs'
+            css={{
+              opacity: isLoading ? 0 : 1,
+              transition: 'opacity 0.3s ease'
+            }}
+          >
             <Flex gap='xs'>
               <Text variant='heading' size='l' color='default'>
-                {displayAmount}
+                {audioBalanceFormatted}
               </Text>
               <Text variant='heading' size='l' color='subdued'>
                 $AUDIO
               </Text>
             </Flex>
             <Text variant='heading' size='s' color='subdued'>
-              {isAudioPriceLoading
-                ? walletMessages.loadingPrice
-                : audioDollarValue}
+              {audioDollarValue}
             </Text>
           </Flex>
         </Flex>


### PR DESCRIPTION
### Description
- Added a new `useUSDCBalance` hook to utilize tanstack caching 
- Made tooltip hover state persist 
- Updated loading states on cards
- Updated routing 

### How Has This Been Tested?

`npm run web:stage`
