### PR TITLE
[PE-6041] Android remix contest section styling

### DIFF
--- a/packages/mobile/src/screens/track-screen/RemixContestDetailsTab.tsx
+++ b/packages/mobile/src/screens/track-screen/RemixContestDetailsTab.tsx
@@ -29,7 +29,7 @@ export const RemixContestDetailsTab = ({ trackId }: Props) => {
   if (!remixContest) return null
 
   return (
-    <Flex column gap='s' p='xl'>
+    <Flex column gap='s' p='xl' borderTop='default'>
       <Flex row gap='s'>
         <Text variant='title' color='accent'>
           {messages.due}

--- a/packages/mobile/src/screens/track-screen/RemixContestPrizesTab.tsx
+++ b/packages/mobile/src/screens/track-screen/RemixContestPrizesTab.tsx
@@ -17,7 +17,7 @@ export const RemixContestPrizesTab = ({ trackId }: Props) => {
   if (!remixContest) return null
 
   return (
-    <Flex p='xl'>
+    <Flex p='xl' borderTop='default'>
       <UserGeneratedText variant='body' size='l'>
         {remixContest.eventData?.prizeInfo ?? ''}
       </UserGeneratedText>

--- a/packages/mobile/src/screens/track-screen/RemixContestSection.tsx
+++ b/packages/mobile/src/screens/track-screen/RemixContestSection.tsx
@@ -26,8 +26,6 @@ const TAB_FOOTER_HEIGHT = 64
 const useStyles = makeStyles(({ palette, typography, spacing }) => ({
   tabBar: {
     backgroundColor: 'transparent',
-    // borderBottomWidth: 1,
-    // // borderBottomColor: palette.neutralLight8,
     height: spacing(10)
   },
   tabLabel: {

--- a/packages/mobile/src/screens/track-screen/RemixContestSection.tsx
+++ b/packages/mobile/src/screens/track-screen/RemixContestSection.tsx
@@ -26,8 +26,8 @@ const TAB_FOOTER_HEIGHT = 64
 const useStyles = makeStyles(({ palette, typography, spacing }) => ({
   tabBar: {
     backgroundColor: 'transparent',
-    borderBottomWidth: 1,
-    borderBottomColor: palette.neutralLight8,
+    // borderBottomWidth: 1,
+    // // borderBottomColor: palette.neutralLight8,
     height: spacing(10)
   },
   tabLabel: {
@@ -172,6 +172,7 @@ export const RemixContestSection = ({ trackId }: RemixContestSectionProps) => {
         renderScene={renderScene}
         renderTabBar={renderTabBar}
         onIndexChange={setIndex}
+        swipeEnabled
       />
       {!isOwner && <UploadRemixFooter trackId={trackId} />}
     </AnimatedPaper>

--- a/packages/mobile/src/screens/track-screen/RemixContestSubmissionsTab.tsx
+++ b/packages/mobile/src/screens/track-screen/RemixContestSubmissionsTab.tsx
@@ -16,7 +16,7 @@ export const RemixContestSubmissionsTab = ({ trackId }: Props) => {
   if (!remixContest) return null
 
   return (
-    <Flex p='xl'>
+    <Flex p='xl' borderTop='default'>
       <Text variant='body' size='l'>
         {/* TODO: Implement submissions content */}
       </Text>


### PR DESCRIPTION
### Description
- Turns out, scrolling on actual ios device is a much better UX than on sim. Hard to describe so try it out, but basically if you've been scrolling, that scroll gesture will keep going until you fully stop, and usually it works out fine.
- On android scrolling is just better period. Android ftw.
- Swiping left/right is now enabled and it actually works quite well.
- Android tab header styling was messed up, found out it was due to the bottom border so moved that to a top border in all the individual tab body components

### How Has This Been Tested?

Tested on both android and ios physical devices.