### PR TITLE
Fix missing collection mobile artwork

### DIFF
--- a/packages/mobile/src/components/lineup-tile/LineupTile.tsx
+++ b/packages/mobile/src/components/lineup-tile/LineupTile.tsx
@@ -101,7 +101,6 @@ export const LineupTile = ({
           isCollection={isCollection}
         />
         <LineupTileMetadata
-          coSign={coSign}
           renderImage={renderImage}
           onPressTitle={onPressTitle}
           title={title}

--- a/packages/mobile/src/components/lineup-tile/LineupTileArt.tsx
+++ b/packages/mobile/src/components/lineup-tile/LineupTileArt.tsx
@@ -34,11 +34,13 @@ export const LineupTileArt = (props: LineupTileArtProps) => {
   const styles = useStyles()
 
   const imageElement = (
-    <View style={styles.imageRoot}>
-      <View style={[trackTileStyles.image, styles.backdrop]} />
-      <FadeInView style={styles.image} startOpacity={0} duration={500}>
-        {renderImage({ style: trackTileStyles.image })}
-      </FadeInView>
+    <View style={[style, trackTileStyles.image]}>
+      <View style={styles.imageRoot}>
+        <View style={[trackTileStyles.image, styles.backdrop]} />
+        <FadeInView style={styles.image} startOpacity={0} duration={500}>
+          {renderImage({ style: trackTileStyles.image })}
+        </FadeInView>
+      </View>
     </View>
   )
 

--- a/packages/mobile/src/components/lineup-tile/LineupTileMetadata.tsx
+++ b/packages/mobile/src/components/lineup-tile/LineupTileMetadata.tsx
@@ -1,4 +1,4 @@
-import type { ID, Remix, User } from '@audius/common/models'
+import type { ID, User } from '@audius/common/models'
 import { playerSelectors } from '@audius/common/store'
 import { TouchableOpacity, View } from 'react-native'
 import { useSelector } from 'react-redux'

--- a/packages/mobile/src/components/lineup-tile/LineupTileMetadata.tsx
+++ b/packages/mobile/src/components/lineup-tile/LineupTileMetadata.tsx
@@ -11,7 +11,7 @@ import type { GestureResponderHandler } from 'app/types/gesture'
 import { useThemeColors } from 'app/utils/theme'
 
 import { LineupTileArt } from './LineupTileArt'
-import { useStyles as useTrackTileStyles } from './styles'
+import { useStyles as useTileStyles } from './styles'
 import type { LineupTileProps } from './types'
 
 const { getPlaying } = playerSelectors
@@ -36,7 +36,6 @@ const useStyles = makeStyles(({ palette }) => ({
 }))
 
 type Props = {
-  coSign?: Remix | null
   onPressTitle?: GestureResponderHandler
   renderImage: LineupTileProps['renderImage']
   title: string
@@ -47,7 +46,6 @@ type Props = {
 }
 
 export const LineupTileMetadata = ({
-  coSign,
   onPressTitle,
   renderImage,
   title,
@@ -57,7 +55,7 @@ export const LineupTileMetadata = ({
   trackId
 }: Props) => {
   const styles = useStyles()
-  const trackTileStyles = useTrackTileStyles()
+  const tileStyles = useTileStyles()
   const { primary } = useThemeColors()
 
   const isActive = isPlayingUid
@@ -70,11 +68,13 @@ export const LineupTileMetadata = ({
     <View style={styles.metadata}>
       <LineupTileArt
         renderImage={renderImage}
-        style={trackTileStyles.imageContainer}
+        style={tileStyles.imageContainer}
         trackId={trackId}
       />
       <FadeInView
-        style={trackTileStyles.titles}
+        style={
+          type === 'track' ? tileStyles.titles : tileStyles.collectionTitles
+        }
         startOpacity={0}
         duration={500}
       >
@@ -91,8 +91,8 @@ export const LineupTileMetadata = ({
 
         <TouchableOpacity
           style={{
-            ...trackTileStyles.title,
-            ...(isPlaying ? trackTileStyles.titlePlaying : {})
+            ...tileStyles.title,
+            ...(isPlaying ? tileStyles.titlePlaying : {})
           }}
           onPress={onPressTitle}
         >

--- a/packages/mobile/src/components/lineup-tile/styles.ts
+++ b/packages/mobile/src/components/lineup-tile/styles.ts
@@ -36,12 +36,19 @@ export const useStyles = makeStyles(({ palette }) => ({
     marginLeft: spacing(2)
   },
   titles: {
-    justifyContent: 'center',
+    paddingVertical: spacing(1),
     alignItems: 'flex-start',
     flexBasis: '65%',
     marginRight: spacing(3),
     marginTop: spacing(2),
-    gap: 2
+    gap: spacing(1)
+  },
+  collectionTitles: {
+    alignItems: 'flex-start',
+    flexBasis: '65%',
+    marginRight: spacing(3),
+    marginTop: spacing(2),
+    gap: spacing(1)
   },
   title: {
     ...flexRowCentered(),

--- a/packages/mobile/src/components/track-flair/TrackFlair.tsx
+++ b/packages/mobile/src/components/track-flair/TrackFlair.tsx
@@ -85,7 +85,7 @@ export const TrackFlair = ({ size, children, style, trackId }: CoSignProps) => {
 
   const { size: iconSize, position } = layoutBySize[size]
 
-  if (!track) return null
+  if (!track) return children
 
   const remixTrack = track.remix_of?.tracks[0]
   const hasRemixAuthorReposted = remixTrack?.has_remix_author_reposted ?? false
@@ -100,9 +100,9 @@ export const TrackFlair = ({ size, children, style, trackId }: CoSignProps) => {
   ) : null
 
   return (
-    <View style={style}>
+    <>
       <View>{children}</View>
       <View style={[styles.check, position]}>{flair}</View>
-    </View>
+    </>
   )
 }

--- a/packages/mobile/src/components/track-flair/TrackFlair.tsx
+++ b/packages/mobile/src/components/track-flair/TrackFlair.tsx
@@ -85,7 +85,7 @@ export const TrackFlair = ({ size, children, style, trackId }: CoSignProps) => {
 
   const { size: iconSize, position } = layoutBySize[size]
 
-  if (!track) return children
+  if (!track) return <>{children}</>
 
   const remixTrack = track.remix_of?.tracks[0]
   const hasRemixAuthorReposted = remixTrack?.has_remix_author_reposted ?? false


### PR DESCRIPTION
### Description

Fix missing collection artwork on mobile. This was addressed in web but overlooked in mobile. Also fixing some tile layout differences to match design specs.

![IMG_7E9C6158237D-1](https://github.com/user-attachments/assets/b1783c41-f233-4f27-b368-4e10846e1db0)

<img width="549" alt="Screenshot 2025-04-24 at 12 09 18 PM" src="https://github.com/user-attachments/assets/321ab60e-df38-4a08-aaca-f4e6f7c04691" />


### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._

Confirmed layout and artwork look correct on mobile.