### PR TITLE
Add deliverable email to AAO and optimize perf

### DIFF
--- a/packages/discovery-provider/ddl/functions/compute_user_score.sql
+++ b/packages/discovery-provider/ddl/functions/compute_user_score.sql
@@ -1,0 +1,19 @@
+create or replace function compute_user_score(
+        play_count bigint,
+        follower_count bigint,
+        challenge_count bigint,
+        chat_block_count bigint,
+        following_count bigint,
+        is_audius_impersonator boolean,
+        distinct_tracks_played bigint
+    ) returns bigint as $$
+select (play_count / 2) + follower_count - challenge_count - (chat_block_count * 100) + case
+        when following_count < 5 then -1
+        else 0
+    end + case
+        when is_audius_impersonator then -1000
+        else 0
+    end + case
+        when distinct_tracks_played <= 3 then -10
+        else 0
+    end $$ language sql immutable;

--- a/packages/discovery-provider/ddl/functions/get_user_score.sql
+++ b/packages/discovery-provider/ddl/functions/get_user_score.sql
@@ -1,0 +1,79 @@
+create or replace function get_user_score(target_user_id integer) returns table(
+        user_id integer,
+        handle_lc text,
+        play_count bigint,
+        distinct_tracks_played bigint,
+        follower_count bigint,
+        challenge_count bigint,
+        following_count bigint,
+        chat_block_count bigint,
+        is_audius_impersonator boolean,
+        score bigint
+    ) language sql as $function$ with play_activity as (
+        select p.user_id,
+            count(distinct date_trunc('hour', p.created_at)) as play_count,
+            count(distinct p.play_item_id) as distinct_tracks_played
+        from plays p
+        where p.user_id = target_user_id
+        group by p.user_id
+    ),
+    fast_challenge_completion as (
+        select u.user_id,
+            u.handle_lc,
+            u.created_at,
+            count(*) as challenge_count,
+            array_agg(uc.challenge_id) as challenge_ids
+        from users u
+            left join user_challenges uc on u.user_id = uc.user_id
+        where u.user_id = target_user_id
+            and uc.is_complete
+            and uc.completed_at - u.created_at <= interval '3 minutes'
+            and uc.challenge_id not in ('m', 'b')
+        group by u.user_id,
+            u.handle_lc,
+            u.created_at
+    ),
+    chat_blocks as (
+        select c.blockee_user_id as user_id,
+            count(*) as block_count
+        from chat_blocked_users c
+        where c.blockee_user_id = target_user_id
+        group by c.blockee_user_id
+    ),
+    aggregate_scores as (
+        select u.user_id,
+            u.handle_lc,
+            coalesce(p.play_count, 0) as play_count,
+            coalesce(p.distinct_tracks_played, 0) as distinct_tracks_played,
+            coalesce(c.challenge_count, 0) as challenge_count,
+            coalesce(au.following_count, 0) as following_count,
+            coalesce(au.follower_count, 0) as follower_count,
+            coalesce(cb.block_count, 0) as chat_block_count,
+            case
+                when (
+                    u.handle_lc ilike '%audius%'
+                    or lower(u.name) ilike '%audius%'
+                )
+                and u.is_verified = false then true
+                else false
+            end as is_audius_impersonator
+        from users u
+            left join play_activity p on u.user_id = p.user_id
+            left join fast_challenge_completion c on u.user_id = c.user_id
+            left join chat_blocks cb on u.user_id = cb.user_id
+            left join aggregate_user au on u.user_id = au.user_id
+        where u.user_id = target_user_id
+            and u.handle_lc is not null
+    )
+select a.*,
+    compute_user_score(
+        a.play_count,
+        a.follower_count,
+        a.challenge_count,
+        a.chat_block_count,
+        a.following_count,
+        a.is_audius_impersonator,
+        a.distinct_tracks_played
+    ) as score
+from aggregate_scores a;
+$function$;

--- a/packages/discovery-provider/plugins/pedalboard/apps/anti-abuse-oracle/src/actionLog.ts
+++ b/packages/discovery-provider/plugins/pedalboard/apps/anti-abuse-oracle/src/actionLog.ts
@@ -2,7 +2,7 @@ import 'dotenv/config'
 
 import postgres from 'postgres'
 import fetch from 'cross-fetch'
-import { useFingerprintDeviceCount } from './identity'
+import { useEmailDeliverable, useFingerprintDeviceCount } from './identity'
 
 export const sql = postgres(process.env.audius_db_url || '')
 
@@ -89,6 +89,25 @@ export async function getRecentUsers(page: number) {
   return rows.map((row) => row.user as UserDetails)
 }
 
+export type ClaimDetails = {
+  disbursement_date: string
+  handle: string
+  sign_up_date: Date
+  challenge_id: string
+  amount: number
+}
+export async function getRecentClaims(page: number) {
+  const rows = await sql`
+    select challenge_disbursements.created_at as disbursement_date, handle_lc as handle, users.created_at as sign_up_date, challenge_disbursements.challenge_id, ROUND(CAST(challenge_disbursements.amount AS numeric) / 100000000, 0) as amount
+    from challenge_disbursements
+    join users on users.user_id = challenge_disbursements.user_id
+    order by challenge_disbursements.created_at desc 
+    limit 10 offset ${page * 10}
+  `
+  if (!rows.length) return
+  return rows.map((row) => row as ClaimDetails)
+}
+
 export async function getUserScore(userId: number) {
   const rows = await sql`
   select
@@ -112,7 +131,7 @@ export async function getUserNormalizedScore(userId: number) {
       users.created_at as timestamp,
       user_scores.*,
       anti_abuse_blocked_users.is_blocked 
-    FROM get_user_scores(${[userId]}) as user_scores
+    FROM get_user_score(${userId}) as user_scores
     LEFT JOIN users on users.user_id = user_scores.user_id
     LEFT JOIN anti_abuse_blocked_users ON anti_abuse_blocked_users.handle_lc = user_scores.handle_lc
 
@@ -134,8 +153,12 @@ export async function getUserNormalizedScore(userId: number) {
   const shadowbanScore = Number(shadowban_score)
 
   const numberOfUserWithFingerprint = (await useFingerprintDeviceCount(userId))!
-
   let overallScore = shadowbanScore - numberOfUserWithFingerprint
+
+  const isEmailDeliverable = await useEmailDeliverable(userId)
+  if (!isEmailDeliverable) {
+    overallScore -= 1000
+  }
 
   // override score
   if (is_blocked === true) {
@@ -158,6 +181,7 @@ export async function getUserNormalizedScore(userId: number) {
     chatBlockCount: chat_block_count,
     fingerprintCount: numberOfUserWithFingerprint,
     isAudiusImpersonator: is_audius_impersonator,
+    isEmailDeliverable,
     isBlocked: is_blocked,
     shadowbanScore,
     overallScore,

--- a/packages/discovery-provider/plugins/pedalboard/apps/anti-abuse-oracle/src/identity.ts
+++ b/packages/discovery-provider/plugins/pedalboard/apps/anti-abuse-oracle/src/identity.ts
@@ -47,3 +47,10 @@ export async function useFingerprintDeviceCount(userId: number) {
   `
   return rows[0].maxUserCount ?? 0
 }
+
+export async function useEmailDeliverable(userId: number) {
+  const rows = await sql`
+    select "isEmailDeliverable" from "Users" where "blockchainUserId" = ${userId}
+  `
+  return rows[0].isEmailDeliverable
+}


### PR DESCRIPTION
### Description
* Penalize users with an undeliverable email when calculating AAO score.
* Replace Recent users on UI tool front page with recent claims.
* Create a separate get_user_score function for a single user using the same calculations. Only necessary to make getting a single user.
* Add README

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._
