### PR TITLE
[PE-6049] Remix contest container for mobile web

### DIFF
--- a/packages/web/src/hooks/useTabs/TabStyles.module.css
+++ b/packages/web/src/hooks/useTabs/TabStyles.module.css
@@ -24,6 +24,13 @@
   width: 100%;
 }
 
+.tabMobileV2 {
+  color: var(--harmony-text-subdued);
+  flex-direction: row;
+  justify-content: center;
+  padding: 4px 8px 6px;
+}
+
 .tabDesktop {
   color: var(--harmony-text-subdued);
   flex-direction: row;
@@ -82,6 +89,12 @@
   box-shadow: 0 2px 5px -2px var(--tile-shadow-3);
 }
 
+.tabBarContainerMobileV2 {
+  width: 100%;
+  background-color: var(--harmony-white);
+  justify-content: space-around;
+  align-items: center;
+}
 .bodyContainer {
   position: relative;
 }

--- a/packages/web/src/hooks/useTabs/useTabs.tsx
+++ b/packages/web/src/hooks/useTabs/useTabs.tsx
@@ -40,6 +40,7 @@ type TabProps = {
   onClick: () => void
   isActive: boolean
   isMobile: boolean
+  isMobileV2: boolean
   icon?: ReactNode
   text: string
   label: string
@@ -48,14 +49,15 @@ type TabProps = {
 
 const Tab = forwardRef(
   (
-    { onClick, icon, text, isActive, isMobile, disabled }: TabProps,
+    { onClick, icon, text, isActive, isMobile, isMobileV2, disabled }: TabProps,
     ref?: Ref<HTMLDivElement>
   ) => (
     <div
       className={cn(
         styles.tab,
         { [styles.tabMobile]: isMobile },
-        { [styles.tabDesktop]: !isMobile },
+        { [styles.tabMobileV2]: isMobileV2 },
+        { [styles.tabDesktop]: !isMobile && !isMobileV2 },
         { [styles.tabActive]: isActive },
         { [styles.tabDisabled]: disabled }
       )}
@@ -65,6 +67,10 @@ const Tab = forwardRef(
       {icon && <div className={styles.icon}>{icon}</div>}
       {isMobile ? (
         <Text variant='body' size='xs' strength='strong' color='inherit'>
+          {text}
+        </Text>
+      ) : isMobileV2 ? (
+        <Text variant='body' strength='strong' color='inherit'>
           {text}
         </Text>
       ) : (
@@ -92,6 +98,7 @@ type TabBarProps = {
   onClick: (index: number) => void
   shouldAnimate: boolean
   isMobile: boolean
+  isMobileV2: boolean
   disabledTabTooltipText?: string
   // Offset the tab to the left or right.
   // offset of 1 offsets 1 tab to the right,
@@ -107,6 +114,7 @@ const TabBar = memo(
     tabs,
     onClick,
     isMobile,
+    isMobileV2,
     disabledTabTooltipText,
     fractionalOffset = 0,
     pathname
@@ -235,7 +243,8 @@ const TabBar = memo(
         className={cn(
           styles.tabBarContainer,
           { [styles.tabBarContainerMobile]: isMobile },
-          { [styles.tabBarContainerDesktop]: !isMobile }
+          { [styles.tabBarContainerMobileV2]: isMobileV2 },
+          { [styles.tabBarContainerDesktop]: !isMobile && !isMobileV2 }
         )}
         role='tablist'
       >
@@ -260,6 +269,7 @@ const TabBar = memo(
               isActive={isActive}
               key={tab.label}
               isMobile={isMobile}
+              isMobileV2={isMobileV2}
               disabled={!!tab.disabled}
               icon={tab.icon}
               label={tab.label}
@@ -380,6 +390,7 @@ type BodyContainerProps = {
   lastActive: number
   didTransitionCallback: () => void
   isMobile: boolean
+  isMobileV2: boolean
   interElementSpacing: number
 
   // If container dimensions are dirty and need a resize.
@@ -921,6 +932,7 @@ type UseTabsArguments = {
   bodyClassName?: string
   elementClassName?: string
   isMobile?: boolean
+  isMobileV2?: boolean
 
   // Optionally allow useTabs to be a controlled component
   selectedTabLabel?: string
@@ -987,6 +999,7 @@ const useTabs = ({
   bodyClassName,
   elementClassName,
   isMobile = true,
+  isMobileV2 = false,
   interElementSpacing = 0,
   disabledTabTooltipText,
   tabRecalculator,
@@ -1110,6 +1123,7 @@ const useTabs = ({
     tabRecalculator._setRecalculateFunc(recalculateDimensions)
   }
 
+  // TODO: Add isMobileV2 to the condition and fix the bugs with scrolling
   const BodyContainerElement = isMobile
     ? GestureSupportingBodyContainer
     : BodyContainer
@@ -1126,10 +1140,18 @@ const useTabs = ({
       // when the animation finishes. On desktop, it's fired
       // immediately
       setActiveIndex(newIndex)
-      !isMobile && onChangeComplete(activeIndex, newIndex)
+      !isMobile && !isMobileV2 && onChangeComplete(activeIndex, newIndex)
       onTabClickCb && onTabClickCb(tabs[newIndex].label)
     },
-    [isControlled, isMobile, onChangeComplete, activeIndex, onTabClickCb, tabs]
+    [
+      isControlled,
+      isMobile,
+      isMobileV2,
+      onChangeComplete,
+      activeIndex,
+      onTabClickCb,
+      tabs
+    ]
   )
 
   const tabBarKey = tabs.map((t) => t.label).join('-')
@@ -1143,6 +1165,7 @@ const useTabs = ({
         onClick={onTabClick}
         shouldAnimate={shouldAnimate}
         isMobile={isMobile}
+        isMobileV2={isMobileV2}
         disabledTabTooltipText={disabledTabTooltipText}
         fractionalOffset={accentFractionalOffset}
         pathname={pathname}
@@ -1155,6 +1178,7 @@ const useTabs = ({
       onTabClick,
       shouldAnimate,
       isMobile,
+      isMobileV2,
       disabledTabTooltipText,
       accentFractionalOffset,
       pathname
@@ -1176,6 +1200,7 @@ const useTabs = ({
           didTransitionCallback || emptyDidTransitionCallback
         }
         isMobile={isMobile}
+        isMobileV2={isMobileV2}
         interElementSpacing={interElementSpacing}
         dimensionsAreDirty={dimensionsAreDirty}
         didSetDimensions={didSetDimensions}
@@ -1197,6 +1222,7 @@ const useTabs = ({
       didTransitionCallback,
       emptyDidTransitionCallback,
       isMobile,
+      isMobileV2,
       interElementSpacing,
       dimensionsAreDirty,
       didSetDimensions,

--- a/packages/web/src/pages/track-page/components/desktop/RemixContestSection.tsx
+++ b/packages/web/src/pages/track-page/components/desktop/RemixContestSection.tsx
@@ -88,7 +88,6 @@ export const RemixContestSection = ({
     navigate(UPLOAD_PAGE, state)
   }, [trackId, navigate])
 
-  // TODO: Also return null if no remix contest description
   if (!trackId || !remixContest) return null
 
   return (

--- a/packages/web/src/pages/track-page/components/mobile/TrackHeader.tsx
+++ b/packages/web/src/pages/track-page/components/mobile/TrackHeader.tsx
@@ -24,8 +24,7 @@ import {
   Box,
   Button,
   MusicBadge,
-  Text,
-  IconCloudUpload
+  Text
 } from '@audius/harmony'
 import IconCalendarMonth from '@audius/harmony/src/assets/icons/CalendarMonth.svg'
 import IconRobot from '@audius/harmony/src/assets/icons/Robot.svg'
@@ -69,15 +68,7 @@ const messages = {
   hidden: 'Hidden',
   releases: (releaseDate: string) =>
     `Releases ${formatReleaseDate({ date: releaseDate, withHour: true })}`,
-  remixContest: 'Remix Contest',
-  contestEnded: 'Contest Ended',
-  contestDeadline: 'Contest Deadline',
-  uploadRemixButtonText: 'Upload Remix',
-  deadline: (deadline?: string) => {
-    return deadline
-      ? `${dayjs(deadline).format('MM/DD/YYYY')} at ${dayjs(deadline).format('h:mm A')}`
-      : ''
-  }
+  remixContest: 'Remix Contest'
 }
 
 type PlayButtonProps = {
@@ -352,35 +343,6 @@ const TrackHeader = ({
     setIsDrawerOpen(false)
   }, [setIsDrawerOpen])
 
-  const handleClick = useCallback(() => {
-    setIsDrawerOpen(true)
-  }, [setIsDrawerOpen])
-
-  const renderSubmitRemixContestSection = useCallback(() => {
-    if (!isRemixContest) return null
-    const isContestOver = dayjs(remixContest.endDate).isBefore(dayjs())
-    return (
-      <Flex column gap='m' w='100%'>
-        <Flex gap='xs' alignItems='center'>
-          <Text variant='label' color='accent'>
-            {isContestOver ? messages.contestEnded : messages.contestDeadline}
-          </Text>
-          <Text>{messages.deadline(remixContest.endDate)}</Text>
-        </Flex>
-        {!isOwner ? (
-          <Button
-            variant='secondary'
-            size='small'
-            onClick={handleClick}
-            iconLeft={IconCloudUpload}
-          >
-            {messages.uploadRemixButtonText}
-          </Button>
-        ) : null}
-      </Flex>
-    )
-  }, [isRemixContest, remixContest?.endDate, isOwner, handleClick])
-
   const trendingRank = useTrackRank(trackId)
 
   return (
@@ -506,7 +468,6 @@ const TrackHeader = ({
             </Text>
           </Flex>
         ) : null}
-        {renderSubmitRemixContestSection()}
         {hasDownloadableAssets ? (
           <Box pt='l' w='100%'>
             <Suspense>

--- a/packages/web/src/pages/track-page/components/mobile/TrackPage.tsx
+++ b/packages/web/src/pages/track-page/components/mobile/TrackPage.tsx
@@ -20,6 +20,7 @@ import { getTrackDefaults } from 'pages/track-page/utils'
 import { TrackPageLineup } from '../TrackPageLineup'
 
 import TrackPageHeader from './TrackHeader'
+import { RemixContestSection } from './remix-contests/RemixContestSection'
 
 export type OwnProps = {
   title: string
@@ -165,6 +166,7 @@ const TrackPage = ({
             goToRepostsPage={goToRepostsPage}
           />
         </Flex>
+        <RemixContestSection trackId={defaults.trackId} isOwner={isOwner} />
         {isCommentingEnabled ? (
           <CommentPreview entityId={defaults.trackId} />
         ) : null}

--- a/packages/web/src/pages/track-page/components/mobile/remix-contests/RemixContestDetailsTab.tsx
+++ b/packages/web/src/pages/track-page/components/mobile/remix-contests/RemixContestDetailsTab.tsx
@@ -68,19 +68,21 @@ export const RemixContestDetailsTab = ({
           {remixContest?.eventData?.description ?? messages.fallbackDescription}
         </UserGeneratedText>
       </Flex>
-      <Divider />
       {!isOwner ? (
-        <Flex p='l' pb='s'>
-          <Button
-            variant='secondary'
-            size='small'
-            fullWidth
-            onClick={goToUploadWithRemix}
-            iconLeft={IconCloudUpload}
-          >
-            {messages.uploadRemixButtonText}
-          </Button>
-        </Flex>
+        <>
+          <Divider />
+          <Flex p='l' pb='s'>
+            <Button
+              variant='secondary'
+              size='small'
+              fullWidth
+              onClick={goToUploadWithRemix}
+              iconLeft={IconCloudUpload}
+            >
+              {messages.uploadRemixButtonText}
+            </Button>
+          </Flex>
+        </>
       ) : null}
     </Flex>
   )

--- a/packages/web/src/pages/track-page/components/mobile/remix-contests/RemixContestDetailsTab.tsx
+++ b/packages/web/src/pages/track-page/components/mobile/remix-contests/RemixContestDetailsTab.tsx
@@ -1,0 +1,87 @@
+import { useRemixContest } from '@audius/common/api'
+import { ID } from '@audius/common/models'
+import { UPLOAD_PAGE } from '@audius/common/src/utils/route'
+import { dayjs } from '@audius/common/utils'
+import { Button, Divider, Flex, IconCloudUpload, Text } from '@audius/harmony'
+
+import { UserGeneratedText } from 'components/user-generated-text'
+import { useNavigateToPage } from 'hooks/useNavigateToPage'
+import { useRequiresAccountCallback } from 'hooks/useRequiresAccount'
+
+const messages = {
+  due: 'Submission Due:',
+  deadline: (deadline?: string) => {
+    if (!deadline) return ''
+    const date = dayjs(deadline)
+    return `${date.format('ddd. MMM D, YYYY')} at ${date.format('h:mm A')}`
+  },
+  ended: 'Contest Ended',
+  fallbackDescription:
+    'Enter my remix contest before the deadline for your chance to win!',
+  uploadRemixButtonText: 'Upload Your Remix'
+}
+
+type RemixContestDetailsTabProps = {
+  trackId: ID
+  isOwner: boolean
+}
+
+/**
+ * Tab content displaying details about a remix contest
+ */
+export const RemixContestDetailsTab = ({
+  trackId,
+  isOwner
+}: RemixContestDetailsTabProps) => {
+  const navigate = useNavigateToPage()
+  const { data: remixContest } = useRemixContest(trackId)
+  const isContestEnded = dayjs(remixContest?.endDate).isBefore(dayjs())
+
+  const goToUploadWithRemix = useRequiresAccountCallback(() => {
+    if (!trackId) return
+
+    const state = {
+      initialMetadata: {
+        is_remix: true,
+        remix_of: {
+          tracks: [{ parent_track_id: trackId }]
+        }
+      }
+    }
+    navigate(UPLOAD_PAGE, state)
+  }, [trackId, navigate])
+
+  return (
+    <Flex column w='100%'>
+      <Flex column gap='s' p='l'>
+        <Flex row gap='xs'>
+          <Text variant='title' color='accent'>
+            {messages.due}
+          </Text>
+          <Text variant='body' strength='strong'>
+            {isContestEnded
+              ? messages.ended
+              : messages.deadline(remixContest?.endDate)}
+          </Text>
+        </Flex>
+        <UserGeneratedText variant='body'>
+          {remixContest?.eventData?.description ?? messages.fallbackDescription}
+        </UserGeneratedText>
+      </Flex>
+      <Divider />
+      {!isOwner ? (
+        <Flex p='l' pb='s'>
+          <Button
+            variant='secondary'
+            size='small'
+            fullWidth
+            onClick={goToUploadWithRemix}
+            iconLeft={IconCloudUpload}
+          >
+            {messages.uploadRemixButtonText}
+          </Button>
+        </Flex>
+      ) : null}
+    </Flex>
+  )
+}

--- a/packages/web/src/pages/track-page/components/mobile/remix-contests/RemixContestPrizesTab.tsx
+++ b/packages/web/src/pages/track-page/components/mobile/remix-contests/RemixContestPrizesTab.tsx
@@ -1,0 +1,23 @@
+import { useRemixContest } from '@audius/common/api'
+import { ID } from '@audius/common/models'
+import { Flex } from '@audius/harmony'
+
+import { UserGeneratedText } from 'components/user-generated-text'
+
+type RemixContestPrizesTabProps = {
+  trackId: ID
+}
+
+export const RemixContestPrizesTab = ({
+  trackId
+}: RemixContestPrizesTabProps) => {
+  const { data: remixContest } = useRemixContest(trackId)
+
+  return (
+    <Flex column gap='s' p='l' pb='s'>
+      <UserGeneratedText variant='body'>
+        {remixContest?.eventData?.prizeInfo}
+      </UserGeneratedText>
+    </Flex>
+  )
+}

--- a/packages/web/src/pages/track-page/components/mobile/remix-contests/RemixContestSection.tsx
+++ b/packages/web/src/pages/track-page/components/mobile/remix-contests/RemixContestSection.tsx
@@ -64,7 +64,6 @@ export const RemixContestSection = ({
     isMobileV2: true
   })
 
-  // TODO: Also return null if no remix contest description
   if (!trackId || !remixContest) return null
 
   return (

--- a/packages/web/src/pages/track-page/components/mobile/remix-contests/RemixContestSection.tsx
+++ b/packages/web/src/pages/track-page/components/mobile/remix-contests/RemixContestSection.tsx
@@ -1,0 +1,93 @@
+import { useRemixContest, useRemixes } from '@audius/common/api'
+import { ID } from '@audius/common/models'
+import { Box, Flex, Text, IconTrophy } from '@audius/harmony'
+
+import useTabs from 'hooks/useTabs/useTabs'
+
+import { RemixContestDetailsTab } from './RemixContestDetailsTab'
+import { RemixContestPrizesTab } from './RemixContestPrizesTab'
+import { RemixContestSubmissionsTab } from './RemixContestSubmissionsTab'
+
+const messages = {
+  title: 'Remix Contest',
+  details: 'Details',
+  prizes: 'Prizes',
+  submissions: 'Submissions',
+  uploadRemixButtonText: 'Upload Your Remix'
+}
+
+type RemixContestSectionProps = {
+  trackId: ID
+  isOwner: boolean
+}
+
+export const RemixContestSection = ({
+  trackId,
+  isOwner
+}: RemixContestSectionProps) => {
+  const { data: remixContest } = useRemixContest(trackId)
+  const { data: remixes } = useRemixes({ trackId, isContestEntry: true })
+
+  const tabs = [
+    {
+      text: messages.details,
+      label: 'details'
+    },
+    {
+      text: messages.prizes,
+      label: 'prizes'
+    },
+    {
+      text: messages.submissions,
+      label: 'submissions'
+    }
+  ]
+
+  const elements = [
+    <RemixContestDetailsTab
+      key='details'
+      trackId={trackId}
+      isOwner={isOwner}
+    />,
+    <RemixContestPrizesTab key='prizes' trackId={trackId} />,
+    <RemixContestSubmissionsTab
+      key='submissions'
+      trackId={trackId}
+      submissions={remixes.slice(0, 6)}
+    />
+  ]
+
+  const { tabs: TabBar, body: TabBody } = useTabs({
+    tabs,
+    elements,
+    isMobile: false,
+    isMobileV2: true
+  })
+
+  // TODO: Also return null if no remix contest description
+  if (!trackId || !remixContest) return null
+
+  return (
+    <Flex column gap='l'>
+      <Flex alignItems='center' gap='s'>
+        <IconTrophy color='default' />
+        <Text variant='title' size='l'>
+          {messages.title}
+        </Text>
+      </Flex>
+      <Box
+        backgroundColor='white'
+        shadow='mid'
+        borderRadius='l'
+        css={{ overflow: 'hidden' }}
+      >
+        <Flex column pv='m'>
+          <Flex w='100%' alignItems='center' borderBottom='default' ph='xl'>
+            {TabBar}
+          </Flex>
+          {TabBody}
+        </Flex>
+      </Box>
+    </Flex>
+  )
+}

--- a/packages/web/src/pages/track-page/components/mobile/remix-contests/RemixContestSubmissionsTab.tsx
+++ b/packages/web/src/pages/track-page/components/mobile/remix-contests/RemixContestSubmissionsTab.tsx
@@ -1,0 +1,155 @@
+import { LineupData, useTrack, useUser } from '@audius/common/api'
+import { ID, SquareSizes } from '@audius/common/models'
+import {
+  Box,
+  Flex,
+  IconArrowRight,
+  PlainButton,
+  Skeleton,
+  Text
+} from '@audius/harmony'
+import { Link } from 'react-router-dom'
+
+import { Avatar } from 'components/avatar'
+import { TrackLink, UserLink } from 'components/link'
+import { TrackArtwork } from 'components/track/TrackArtwork'
+import TrackFlair from 'components/track-flair/TrackFlair'
+import { Size } from 'components/track-flair/types'
+import { trackRemixesPage } from 'utils/route'
+
+const artworkSize = 140
+const userAvatarSize = 40
+
+const messages = {
+  noSubmissions: 'No submissions yet',
+  beFirst: 'Be the first to upload a remix!',
+  viewAll: 'View All'
+}
+
+type RemixContestSubmissionsTabProps = {
+  trackId: ID
+  submissions: LineupData[]
+}
+
+/**
+ * Tab content displaying submissions for a remix contest
+ */
+export const RemixContestSubmissionsTab = ({
+  trackId,
+  submissions
+}: RemixContestSubmissionsTabProps) => {
+  // If there are no submissions, show the empty state
+  if (submissions.length === 0) {
+    return <EmptyRemixContestSubmissions />
+  }
+
+  return <RemixContestSubmissions trackId={trackId} submissions={submissions} />
+}
+
+const SubmissionCard = ({ submission }: { submission: LineupData }) => {
+  const { data: track, isLoading: trackLoading } = useTrack(submission.id)
+  const { data: user, isLoading: userLoading } = useUser(track?.owner_id)
+  const isLoading = trackLoading || userLoading
+  const displaySkeleton = isLoading || !track || !user
+
+  return (
+    <Flex column gap='s'>
+      <Flex h={artworkSize} w={artworkSize} borderRadius='s'>
+        {displaySkeleton ? (
+          <Skeleton h={artworkSize} w={artworkSize} borderRadius='s' />
+        ) : (
+          <>
+            {/* Track Artwork with Flair */}
+            <TrackFlair
+              css={{ height: '100%', width: '100%' }}
+              id={track.track_id}
+              size={Size.LARGE}
+              hideToolTip
+            >
+              <TrackArtwork
+                style={{
+                  width: '100%',
+                  height: '100%'
+                }}
+                trackId={track.track_id}
+                size={SquareSizes.SIZE_480_BY_480}
+              />
+            </TrackFlair>
+            {/* User Avatar */}
+            <Box
+              h={userAvatarSize}
+              w={userAvatarSize}
+              css={{ position: 'absolute', top: -8, right: -8 }}
+              borderRadius='circle'
+            >
+              <Avatar
+                userId={user.user_id}
+                imageSize={SquareSizes.SIZE_150_BY_150}
+              />
+            </Box>
+          </>
+        )}
+      </Flex>
+      <Flex column gap='xs' alignItems='center'>
+        {displaySkeleton ? (
+          <>
+            <Skeleton h={20} w={100} />
+            <Skeleton h={18} w={64} />
+          </>
+        ) : (
+          <>
+            <TrackLink textVariant='title' size='s' trackId={track.track_id} />
+            <UserLink userId={user.user_id} size='s' noOverflow />
+          </>
+        )}
+      </Flex>
+    </Flex>
+  )
+}
+
+const RemixContestSubmissions = ({
+  trackId,
+  submissions
+}: {
+  trackId: ID
+  submissions: LineupData[]
+}) => {
+  const { data: permalink } = useTrack(trackId, {
+    select: (track) => track.permalink
+  })
+
+  const remixesRoute = trackRemixesPage(permalink ?? '')
+
+  return (
+    <Flex w='100%' column gap='2xl' p='xl' pb='m'>
+      <Flex gap='2xl' wrap='wrap' justifyContent='space-between'>
+        {submissions.map((submission) => (
+          <SubmissionCard key={submission.id} submission={submission} />
+        ))}
+      </Flex>
+      <Flex justifyContent='center'>
+        <PlainButton iconRight={IconArrowRight} asChild>
+          <Link to={remixesRoute}>{messages.viewAll}</Link>
+        </PlainButton>
+      </Flex>
+    </Flex>
+  )
+}
+
+const EmptyRemixContestSubmissions = () => {
+  return (
+    <Flex
+      column
+      w='100%'
+      pv='xl'
+      gap='s'
+      justifyContent='center'
+      alignItems='center'
+    >
+      <Text variant='title'>{messages.noSubmissions}</Text>
+      <Text variant='body' color='subdued'>
+        {messages.beFirst}
+      </Text>
+    </Flex>
+  )
+}


### PR DESCRIPTION
### Description
* Add the mobile web remix contest info container
* Remove the extra data from the track page header]

<img width="461" alt="Screenshot 2025-04-25 at 3 55 47 PM" src="https://github.com/user-attachments/assets/1f1f4dfd-9332-4c06-b8cf-ca63d1eaa9a2" />

### How Has This Been Tested?
Manually Tested

NOTE: Missing the gestures for the tab container bc there were issues with the scrolling when using useTabs with isMobile set to true. I'll look into this
