### PR TITLE
[PE-6021] Expandable remix contest description on web

### DIFF
--- a/packages/web/src/components/collapsible-content/CollapsibleContent.tsx
+++ b/packages/web/src/components/collapsible-content/CollapsibleContent.tsx
@@ -12,6 +12,11 @@ import useMeasure from 'react-use-measure'
 
 import styles from './CollapsibleContent.module.css'
 
+const messages = {
+  seeMore: 'See More',
+  seeLess: 'See Less'
+}
+
 type CollapsibleContentProps = {
   id: string
   className?: string
@@ -29,9 +34,9 @@ export const CollapsibleContent = ({
   toggleButtonClassName,
   showByDefault = false,
   collapsedHeight = 0,
-  showText,
-  hideText,
   children
+  showText = messages.seeMore,
+  hideText = messages.seeLess,
 }: CollapsibleContentProps) => {
   const [isCollapsed, setIsCollapsed] = useState(!showByDefault)
   const { spacing } = useTheme()

--- a/packages/web/src/components/collapsible-content/CollapsibleContent.tsx
+++ b/packages/web/src/components/collapsible-content/CollapsibleContent.tsx
@@ -1,4 +1,5 @@
 import { useState, useCallback } from 'react'
+import type { ReactNode } from 'react'
 
 import {
   PlainButton,
@@ -23,9 +24,9 @@ type CollapsibleContentProps = {
   toggleButtonClassName?: string
   showByDefault?: boolean
   collapsedHeight?: number
-  showText: string
-  hideText: string
-  children: React.ReactNode
+  showText?: string
+  hideText?: string
+  children: ReactNode
 }
 
 export const CollapsibleContent = ({

--- a/packages/web/src/components/collapsible-content/CollapsibleContent.tsx
+++ b/packages/web/src/components/collapsible-content/CollapsibleContent.tsx
@@ -13,6 +13,8 @@ import useMeasure from 'react-use-measure'
 
 import styles from './CollapsibleContent.module.css'
 
+const BUTTON_HEIGHT = 48 // Height of the toggle button
+
 const messages = {
   seeMore: 'See More',
   seeLess: 'See Less'
@@ -54,9 +56,8 @@ export const CollapsibleContent = ({
   })
 
   useLayoutEffect(() => {
-    const buttonHeight = 48 // Height of the toggle button
     const totalHeight =
-      (isCollapsed ? collapsedHeight : bounds.height) + buttonHeight
+      (isCollapsed ? collapsedHeight : bounds.height) + BUTTON_HEIGHT
     onHeightChange?.(totalHeight)
   }, [bounds.height, isCollapsed, collapsedHeight, onHeightChange])
 

--- a/packages/web/src/components/collapsible-content/CollapsibleContent.tsx
+++ b/packages/web/src/components/collapsible-content/CollapsibleContent.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback } from 'react'
+import { useState, useCallback, useLayoutEffect } from 'react'
 import type { ReactNode } from 'react'
 
 import {
@@ -27,6 +27,7 @@ type CollapsibleContentProps = {
   showText?: string
   hideText?: string
   children: ReactNode
+  onHeightChange?: (height: number) => void
 }
 
 export const CollapsibleContent = ({
@@ -35,9 +36,10 @@ export const CollapsibleContent = ({
   toggleButtonClassName,
   showByDefault = false,
   collapsedHeight = 0,
-  children
   showText = messages.seeMore,
   hideText = messages.seeLess,
+  children,
+  onHeightChange
 }: CollapsibleContentProps) => {
   const [isCollapsed, setIsCollapsed] = useState(!showByDefault)
   const { spacing } = useTheme()
@@ -50,6 +52,13 @@ export const CollapsibleContent = ({
     polyfill: ResizeObserver,
     offsetSize: true
   })
+
+  useLayoutEffect(() => {
+    const buttonHeight = 48 // Height of the toggle button
+    const totalHeight =
+      (isCollapsed ? collapsedHeight : bounds.height) + buttonHeight
+    onHeightChange?.(totalHeight)
+  }, [bounds.height, isCollapsed, collapsedHeight, onHeightChange])
 
   return (
     <div className={cn(className, { collapsed: isCollapsed })}>

--- a/packages/web/src/pages/track-page/components/desktop/RemixContestDetailsTab.tsx
+++ b/packages/web/src/pages/track-page/components/desktop/RemixContestDetailsTab.tsx
@@ -23,6 +23,7 @@ type RemixContestDetailsTabProps = {
   onHeightChange?: (height: number) => void
 }
 
+// 10 lines of text
 const COLLAPSED_HEIGHT = 10 * spacing.m
 
 /**

--- a/packages/web/src/pages/track-page/components/desktop/RemixContestDetailsTab.tsx
+++ b/packages/web/src/pages/track-page/components/desktop/RemixContestDetailsTab.tsx
@@ -33,10 +33,10 @@ export const RemixContestDetailsTab = ({
   return (
     <Flex column gap='l' p='xl'>
       <Flex row gap='s'>
-        <Text variant='title' size='l' color='accent'>
+        <Text variant='title' size='m' color='accent'>
           {messages.due}
         </Text>
-        <Text variant='body' size='l' strength='strong'>
+        <Text variant='body'>
           {isContestEnded
             ? messages.ended
             : messages.deadline(remixContest?.endDate)}

--- a/packages/web/src/pages/track-page/components/desktop/RemixContestDetailsTab.tsx
+++ b/packages/web/src/pages/track-page/components/desktop/RemixContestDetailsTab.tsx
@@ -1,8 +1,9 @@
 import { useRemixContest } from '@audius/common/api'
 import { ID } from '@audius/common/models'
 import { dayjs } from '@audius/common/utils'
-import { Flex, Text } from '@audius/harmony'
+import { Flex, spacing, Text } from '@audius/harmony'
 
+import { CollapsibleContent } from 'components/collapsible-content'
 import { UserGeneratedText } from 'components/user-generated-text'
 
 const messages = {
@@ -19,19 +20,30 @@ const messages = {
 
 type RemixContestDetailsTabProps = {
   trackId: ID
+  onHeightChange?: (height: number) => void
 }
+
+const COLLAPSED_HEIGHT = 10 * spacing.m
 
 /**
  * Tab content displaying details about a remix contest
  */
 export const RemixContestDetailsTab = ({
-  trackId
+  trackId,
+  onHeightChange
 }: RemixContestDetailsTabProps) => {
   const { data: remixContest } = useRemixContest(trackId)
   const isContestEnded = dayjs(remixContest?.endDate).isBefore(dayjs())
 
   return (
-    <Flex column gap='l' p='xl'>
+    <Flex
+      column
+      gap='l'
+      p='xl'
+      css={{
+        transition: 'height var(--harmony-quick)'
+      }}
+    >
       <Flex row gap='s'>
         <Text variant='title' size='m' color='accent'>
           {messages.due}
@@ -42,9 +54,15 @@ export const RemixContestDetailsTab = ({
             : messages.deadline(remixContest?.endDate)}
         </Text>
       </Flex>
-      <UserGeneratedText variant='body' size='l'>
-        {remixContest?.eventData?.description ?? messages.fallbackDescription}
-      </UserGeneratedText>
+      <CollapsibleContent
+        id='remix-contest-details-tab'
+        collapsedHeight={COLLAPSED_HEIGHT}
+        onHeightChange={onHeightChange}
+      >
+        <UserGeneratedText variant='body'>
+          {remixContest?.eventData?.description ?? messages.fallbackDescription}
+        </UserGeneratedText>
+      </CollapsibleContent>
     </Flex>
   )
 }

--- a/packages/web/src/pages/track-page/components/desktop/RemixContestDetailsTab.tsx
+++ b/packages/web/src/pages/track-page/components/desktop/RemixContestDetailsTab.tsx
@@ -42,7 +42,7 @@ export const RemixContestDetailsTab = ({
       gap='l'
       p='xl'
       css={{
-        transition: 'height var(--harmony-quick)'
+        transition: 'height var(--harmony-expressive)'
       }}
     >
       <Flex row gap='s'>

--- a/packages/web/src/pages/track-page/components/desktop/RemixContestPrizesTab.tsx
+++ b/packages/web/src/pages/track-page/components/desktop/RemixContestPrizesTab.tsx
@@ -18,7 +18,7 @@ export const RemixContestPrizesTab = ({
 
   return (
     <Flex column gap='l' p='xl'>
-      <UserGeneratedText variant='body' size='l'>
+      <UserGeneratedText variant='body' multiline={true}>
         {remixContest?.eventData?.prizeInfo}
       </UserGeneratedText>
     </Flex>

--- a/packages/web/src/pages/track-page/components/desktop/RemixContestPrizesTab.tsx
+++ b/packages/web/src/pages/track-page/components/desktop/RemixContestPrizesTab.tsx
@@ -18,7 +18,7 @@ export const RemixContestPrizesTab = ({
 
   return (
     <Flex column gap='l' p='xl'>
-      <UserGeneratedText variant='body' multiline={true}>
+      <UserGeneratedText variant='body'>
         {remixContest?.eventData?.prizeInfo}
       </UserGeneratedText>
     </Flex>

--- a/packages/web/src/pages/track-page/components/desktop/RemixContestSection.tsx
+++ b/packages/web/src/pages/track-page/components/desktop/RemixContestSection.tsx
@@ -1,3 +1,5 @@
+import { useState, useCallback } from 'react'
+
 import { useRemixContest, useRemixes } from '@audius/common/api'
 import { ID } from '@audius/common/models'
 import { UPLOAD_PAGE } from '@audius/common/src/utils/route'
@@ -41,6 +43,11 @@ export const RemixContestSection = ({
   const navigate = useNavigateToPage()
   const { data: remixContest } = useRemixContest(trackId)
   const { data: remixes } = useRemixes({ trackId, isContestEntry: true })
+  const [contentHeight, setContentHeight] = useState(0)
+
+  const handleDetailsHeightChange = useCallback((height: number) => {
+    setContentHeight(height)
+  }, [])
 
   const tabs = [
     {
@@ -59,7 +66,11 @@ export const RemixContestSection = ({
   ]
 
   const elements = [
-    <RemixContestDetailsTab key='details' trackId={trackId} />,
+    <RemixContestDetailsTab
+      key='details'
+      trackId={trackId}
+      onHeightChange={handleDetailsHeightChange}
+    />,
     <RemixContestPrizesTab key='prizes' trackId={trackId} />,
     <RemixContestSubmissionsTab
       key='submissions'
@@ -91,8 +102,22 @@ export const RemixContestSection = ({
   // TODO: Also return null if no remix contest description
   if (!trackId || !remixContest) return null
 
+  const headerHeight = 48 // Height of the title section
+  const titleGap = 16 // Gap between title and box (from gap='l')
+  const tabBarHeight = 56 // Height of the tab bar
+  const verticalPadding = 16 // From pv='m' on the Flex
+  const totalBoxHeight = tabBarHeight + contentHeight + verticalPadding * 2
+  const totalHeight = headerHeight + titleGap + totalBoxHeight
+
   return (
-    <Flex column gap='l'>
+    <Flex
+      column
+      gap='l'
+      css={{
+        transition: 'height var(--harmony-expressive)',
+        height: totalHeight
+      }}
+    >
       <Flex alignItems='center' gap='s'>
         <IconTrophy color='default' />
         <Text variant='title' size='l'>
@@ -103,9 +128,12 @@ export const RemixContestSection = ({
         backgroundColor='white'
         shadow='mid'
         borderRadius='l'
-        css={{ overflow: 'hidden' }}
+        css={{
+          transition: 'height var(--harmony-expressive)',
+          height: totalBoxHeight
+        }}
       >
-        <Flex column pv='m'>
+        <Flex column pv='m' css={{ height: '100%' }}>
           <Flex justifyContent='space-between' borderBottom='default' ph='xl'>
             <Flex alignItems='center'>{TabBar}</Flex>
             {!isOwner ? (
@@ -121,7 +149,14 @@ export const RemixContestSection = ({
               </Flex>
             ) : null}
           </Flex>
-          {TabBody}
+          <Box
+            css={{
+              transition: 'height var(--harmony-expressive)',
+              height: contentHeight
+            }}
+          >
+            {TabBody}
+          </Box>
         </Flex>
       </Box>
     </Flex>

--- a/packages/web/src/pages/track-page/components/desktop/RemixContestSection.tsx
+++ b/packages/web/src/pages/track-page/components/desktop/RemixContestSection.tsx
@@ -31,8 +31,7 @@ const messages = {
 
 // Height constants
 const TAB_BAR_HEIGHT = 56 // Height of the tab bar
-const VERTICAL_PADDING = spacing.l
-const BUTTON_HEIGHT = 32 // Height of the expand/collapse button
+const HEIGHT_PADDING = 64
 
 type RemixContestSectionProps = {
   trackId: ID
@@ -108,8 +107,7 @@ export const RemixContestSection = ({
   // TODO: Also return null if no remix contest description
   if (!trackId || !remixContest) return null
 
-  const totalBoxHeight =
-    TAB_BAR_HEIGHT + contentHeight + VERTICAL_PADDING * 2 + BUTTON_HEIGHT
+  const totalBoxHeight = TAB_BAR_HEIGHT + contentHeight + HEIGHT_PADDING
 
   return (
     <Flex

--- a/packages/web/src/pages/track-page/components/desktop/RemixContestSection.tsx
+++ b/packages/web/src/pages/track-page/components/desktop/RemixContestSection.tsx
@@ -20,6 +20,7 @@ import useTabs from 'hooks/useTabs/useTabs'
 import { RemixContestDetailsTab } from './RemixContestDetailsTab'
 import { RemixContestPrizesTab } from './RemixContestPrizesTab'
 import { RemixContestSubmissionsTab } from './RemixContestSubmissionsTab'
+import { TabBody } from './TabBody'
 
 const messages = {
   title: 'Remix Contest',
@@ -29,9 +30,7 @@ const messages = {
   uploadRemixButtonText: 'Upload Your Remix'
 }
 
-// Height constants
-const TAB_BAR_HEIGHT = 56 // Height of the tab bar
-const HEIGHT_PADDING = 64
+const TAB_BAR_HEIGHT = 56
 
 type RemixContestSectionProps = {
   trackId: ID
@@ -50,7 +49,7 @@ export const RemixContestSection = ({
   const { data: remixes } = useRemixes({ trackId, isContestEntry: true })
   const [contentHeight, setContentHeight] = useState(0)
 
-  const handleDetailsHeightChange = useCallback((height: number) => {
+  const handleHeightChange = useCallback((height: number) => {
     setContentHeight(height)
   }, [])
 
@@ -70,23 +69,22 @@ export const RemixContestSection = ({
     }
   ]
 
-  const elements = [
-    <RemixContestDetailsTab
-      key='details'
-      trackId={trackId}
-      onHeightChange={handleDetailsHeightChange}
-    />,
-    <RemixContestPrizesTab key='prizes' trackId={trackId} />,
-    <RemixContestSubmissionsTab
-      key='submissions'
-      trackId={trackId}
-      submissions={remixes.slice(0, 10)}
-    />
-  ]
-
-  const { tabs: TabBar, body: TabBody } = useTabs({
+  const { tabs: TabBar, body: ContentBody } = useTabs({
     tabs,
-    elements,
+    elements: [
+      <TabBody key='details' onHeightChange={handleHeightChange}>
+        <RemixContestDetailsTab trackId={trackId} />
+      </TabBody>,
+      <TabBody key='prizes' onHeightChange={handleHeightChange}>
+        <RemixContestPrizesTab trackId={trackId} />
+      </TabBody>,
+      <TabBody key='submissions' onHeightChange={handleHeightChange}>
+        <RemixContestSubmissionsTab
+          trackId={trackId}
+          submissions={remixes.slice(0, 10)}
+        />
+      </TabBody>
+    ],
     isMobile: false
   })
 
@@ -107,7 +105,7 @@ export const RemixContestSection = ({
   // TODO: Also return null if no remix contest description
   if (!trackId || !remixContest) return null
 
-  const totalBoxHeight = TAB_BAR_HEIGHT + contentHeight + HEIGHT_PADDING
+  const totalBoxHeight = TAB_BAR_HEIGHT + contentHeight
 
   return (
     <Flex
@@ -156,7 +154,7 @@ export const RemixContestSection = ({
               height: contentHeight
             }}
           >
-            {TabBody}
+            {ContentBody}
           </Box>
         </Flex>
       </Box>

--- a/packages/web/src/pages/track-page/components/desktop/RemixContestSection.tsx
+++ b/packages/web/src/pages/track-page/components/desktop/RemixContestSection.tsx
@@ -9,6 +9,7 @@ import {
   Flex,
   IconCloudUpload,
   IconTrophy,
+  spacing,
   Text
 } from '@audius/harmony'
 
@@ -27,6 +28,11 @@ const messages = {
   submissions: 'Submissions',
   uploadRemixButtonText: 'Upload Your Remix'
 }
+
+// Height constants
+const TAB_BAR_HEIGHT = 56 // Height of the tab bar
+const VERTICAL_PADDING = spacing.l
+const BUTTON_HEIGHT = 32 // Height of the expand/collapse button
 
 type RemixContestSectionProps = {
   trackId: ID
@@ -102,20 +108,15 @@ export const RemixContestSection = ({
   // TODO: Also return null if no remix contest description
   if (!trackId || !remixContest) return null
 
-  const headerHeight = 48 // Height of the title section
-  const titleGap = 16 // Gap between title and box (from gap='l')
-  const tabBarHeight = 56 // Height of the tab bar
-  const verticalPadding = 16 // From pv='m' on the Flex
-  const totalBoxHeight = tabBarHeight + contentHeight + verticalPadding * 2
-  const totalHeight = headerHeight + titleGap + totalBoxHeight
+  const totalBoxHeight =
+    TAB_BAR_HEIGHT + contentHeight + VERTICAL_PADDING * 2 + BUTTON_HEIGHT
 
   return (
     <Flex
       column
       gap='l'
       css={{
-        transition: 'height var(--harmony-expressive)',
-        height: totalHeight
+        transition: 'height var(--harmony-expressive)'
       }}
     >
       <Flex alignItems='center' gap='s'>
@@ -133,7 +134,7 @@ export const RemixContestSection = ({
           height: totalBoxHeight
         }}
       >
-        <Flex column pv='m' css={{ height: '100%' }}>
+        <Flex column pv='m'>
           <Flex justifyContent='space-between' borderBottom='default' ph='xl'>
             <Flex alignItems='center'>{TabBar}</Flex>
             {!isOwner ? (
@@ -147,7 +148,9 @@ export const RemixContestSection = ({
                   {messages.uploadRemixButtonText}
                 </Button>
               </Flex>
-            ) : null}
+            ) : (
+              <Flex h={spacing.m + spacing['2xl']} />
+            )}
           </Flex>
           <Box
             css={{

--- a/packages/web/src/pages/track-page/components/desktop/RemixContestSubmissionsTab.tsx
+++ b/packages/web/src/pages/track-page/components/desktop/RemixContestSubmissionsTab.tsx
@@ -141,14 +141,12 @@ const EmptyRemixContestSubmissions = () => {
       column
       w='100%'
       pv='3xl'
-      gap='m'
+      gap='xs'
       justifyContent='center'
       alignItems='center'
     >
-      <Text variant='heading' size='s'>
-        {messages.noSubmissions}
-      </Text>
-      <Text variant='body' size='l' color='subdued'>
+      <Text variant='title'>{messages.noSubmissions}</Text>
+      <Text variant='body' color='subdued'>
         {messages.beFirst}
       </Text>
     </Flex>

--- a/packages/web/src/pages/track-page/components/desktop/RemixContestSubmissionsTab.tsx
+++ b/packages/web/src/pages/track-page/components/desktop/RemixContestSubmissionsTab.tsx
@@ -120,7 +120,7 @@ const RemixContestSubmissions = ({
   const remixesRoute = trackRemixesPage(permalink ?? '')
 
   return (
-    <Flex w='100%' column gap='2xl' p='xl'>
+    <Flex p='xl'>
       <Flex gap='2xl' wrap='wrap'>
         {submissions.map((submission) => (
           <SubmissionCard key={submission.id} submission={submission} />
@@ -137,14 +137,7 @@ const RemixContestSubmissions = ({
 
 const EmptyRemixContestSubmissions = () => {
   return (
-    <Flex
-      column
-      w='100%'
-      pv='3xl'
-      gap='xs'
-      justifyContent='center'
-      alignItems='center'
-    >
+    <Flex column pv='3xl' gap='xs' alignItems='center'>
       <Text variant='title'>{messages.noSubmissions}</Text>
       <Text variant='body' color='subdued'>
         {messages.beFirst}

--- a/packages/web/src/pages/track-page/components/desktop/RemixContestSubmissionsTab.tsx
+++ b/packages/web/src/pages/track-page/components/desktop/RemixContestSubmissionsTab.tsx
@@ -120,7 +120,7 @@ const RemixContestSubmissions = ({
   const remixesRoute = trackRemixesPage(permalink ?? '')
 
   return (
-    <Flex p='xl'>
+    <Flex column p='xl'>
       <Flex gap='2xl' wrap='wrap'>
         {submissions.map((submission) => (
           <SubmissionCard key={submission.id} submission={submission} />

--- a/packages/web/src/pages/track-page/components/desktop/TabBody.tsx
+++ b/packages/web/src/pages/track-page/components/desktop/TabBody.tsx
@@ -1,0 +1,39 @@
+import { useEffect, useRef } from 'react'
+
+import { Flex, FlexProps } from '@audius/harmony'
+
+type TabBodyProps = FlexProps & {
+  onHeightChange?: (height: number) => void
+}
+
+/**
+ * A wrapper component that measures its content height and reports changes.
+ * Designed to be used with tab content to enable smooth height transitions.
+ */
+export const TabBody = ({
+  children,
+  onHeightChange,
+  ...flexProps
+}: TabBodyProps) => {
+  const contentRef = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    if (contentRef.current && onHeightChange) {
+      const resizeObserver = new ResizeObserver((entries) => {
+        const height = entries[0]?.contentRect.height
+        if (height) {
+          onHeightChange(height)
+        }
+      })
+
+      resizeObserver.observe(contentRef.current)
+      return () => resizeObserver.disconnect()
+    }
+  }, [onHeightChange])
+
+  return (
+    <Flex column w='100%' ref={contentRef} {...flexProps}>
+      {children}
+    </Flex>
+  )
+}

--- a/packages/web/src/pages/track-page/components/mobile/TrackDescription.tsx
+++ b/packages/web/src/pages/track-page/components/mobile/TrackDescription.tsx
@@ -1,27 +1,11 @@
-import { useCallback, useState, useEffect, useRef } from 'react'
-
 import { Nullable } from '@audius/common/utils'
-import {
-  Flex,
-  PlainButton,
-  IconCaretDown,
-  IconCaretUp,
-  spacing,
-  useTheme
-} from '@audius/harmony'
-import { useMeasure } from 'react-use'
+import { spacing } from '@audius/harmony'
 
+import { CollapsibleContent } from 'components/collapsible-content/CollapsibleContent'
 import { UserGeneratedText } from 'components/user-generated-text'
 
 const MAX_DESCRIPTION_LINES = 8
 const DEFAULT_LINE_HEIGHT = spacing.xl
-// A little manual tweaking for it to look good
-const HEIGHT_OFFSET = 4
-
-const messages = {
-  seeMore: 'See More',
-  seeLess: 'See Less'
-}
 
 type TrackDescriptionProps = {
   description: Nullable<string>
@@ -32,75 +16,16 @@ export const TrackDescription = ({
   description,
   className
 }: TrackDescriptionProps) => {
-  const { motion } = useTheme()
-  const [isDescriptionExpanded, setIsDescriptionExpanded] = useState(false)
-  const [showToggle, setShowToggle] = useState(false)
-  const toggleButtonRef = useRef<HTMLButtonElement>(null)
-
-  const handleToggleDescription = useCallback(() => {
-    setIsDescriptionExpanded(!isDescriptionExpanded)
-    // If we're collapsing, scroll the button into view
-    if (isDescriptionExpanded && toggleButtonRef.current) {
-      toggleButtonRef.current.scrollIntoView({
-        behavior: 'smooth',
-        block: 'end'
-      })
-    }
-  }, [isDescriptionExpanded])
-
-  // This ref holds the description height for expansion
-  const [descriptionRef, descriptionBounds] = useMeasure<HTMLDivElement>()
-
-  // This ref holds the full content height for expansion
-  const [fullContentRef, fullContentBounds] = useMeasure<HTMLDivElement>()
-
-  // Calculate if toggle should be shown based on content height
-  useEffect(() => {
-    if (description && descriptionBounds.height && fullContentBounds.height) {
-      const lineHeight = DEFAULT_LINE_HEIGHT
-      const maxHeight = lineHeight * MAX_DESCRIPTION_LINES
-      setShowToggle(fullContentBounds.height > maxHeight)
-    }
-  }, [description, descriptionBounds.height, fullContentBounds.height])
-
   if (!description) return null
 
   return (
-    <Flex column gap='m' w='100%'>
-      <Flex
-        direction='column'
-        w='100%'
-        css={{
-          transition: `height ${motion.expressive}, opacity ${motion.quick}`,
-          overflow: 'hidden',
-          height: isDescriptionExpanded
-            ? fullContentBounds.height
-            : Math.min(
-                fullContentBounds.height,
-                DEFAULT_LINE_HEIGHT * MAX_DESCRIPTION_LINES - HEIGHT_OFFSET
-              )
-        }}
-      >
-        <Flex ref={fullContentRef} direction='column'>
-          <UserGeneratedText
-            ref={descriptionRef}
-            className={className}
-            linkSource='track page'
-          >
-            {description}
-          </UserGeneratedText>
-        </Flex>
-      </Flex>
-      {showToggle && (
-        <PlainButton
-          ref={toggleButtonRef}
-          iconRight={isDescriptionExpanded ? IconCaretUp : IconCaretDown}
-          onClick={handleToggleDescription}
-          css={{ alignSelf: 'flex-start' }}
-        >
-          {isDescriptionExpanded ? messages.seeLess : messages.seeMore}
-        </PlainButton>
-      )}
-    </Flex>
+    <CollapsibleContent
+      id='track-description'
+      collapsedHeight={DEFAULT_LINE_HEIGHT * MAX_DESCRIPTION_LINES}
+    >
+      <UserGeneratedText className={className} linkSource='track page'>
+        {description}
+      </UserGeneratedText>
+    </CollapsibleContent>
   )
 }


### PR DESCRIPTION
### Description
- use `CollapsibleContent` in `TrackDescription` and also `RemixContestDetailsTab`.
- Add a `TabBody` component that measures content height, use this to set the height of the parent container in `RemixContestSection` to the height of whichever tab is selected. Without this, if user expands the details tab, the height of the other tabs stays too large.
- Changes to text sizes from design

### How Has This Been Tested?

https://github.com/user-attachments/assets/1017d461-6213-4bd4-ac87-1c10971fa1db

