### PR TITLE
Fix unauth'd accounts fetching public data

### DIFF
--- a/packages/common/src/api/tan-query/useCollectionByPermalink.ts
+++ b/packages/common/src/api/tan-query/useCollectionByPermalink.ts
@@ -1,17 +1,17 @@
-import { Id } from '@audius/sdk'
+import { OptionalId } from '@audius/sdk'
 import { useQuery, useQueryClient } from '@tanstack/react-query'
 import { pick } from 'lodash'
-import { useDispatch, useSelector } from 'react-redux'
+import { useDispatch } from 'react-redux'
 
 import { userCollectionMetadataFromSDK } from '~/adapters/collection'
 import { useAudiusQueryContext } from '~/audius-query'
 import { ID } from '~/models/Identifiers'
-import { getUserId } from '~/store/account/selectors'
 
 import { TQCollection } from './models'
 import { QUERY_KEYS } from './queryKeys'
 import { QueryKey, QueryOptions, SelectableQueryOptions } from './types'
 import { useCollection } from './useCollection'
+import { useCurrentUserId } from './useCurrentUserId'
 import { primeCollectionData } from './utils/primeCollectionData'
 
 const STALE_TIME = Infinity
@@ -44,7 +44,7 @@ export const useCollectionByPermalink = <TResult = TQCollection>(
   const { audiusSdk } = useAudiusQueryContext()
   const queryClient = useQueryClient()
   const dispatch = useDispatch()
-  const currentUserId = useSelector(getUserId)
+  const { data: currentUserId } = useCurrentUserId()
 
   const simpleOptions = pick(options, [
     'enabled',
@@ -61,7 +61,7 @@ export const useCollectionByPermalink = <TResult = TQCollection>(
         {
           handle,
           slug,
-          userId: Id.parse(currentUserId)
+          userId: OptionalId.parse(currentUserId)
         }
       )
 

--- a/packages/common/src/api/tan-query/useProfileReposts.ts
+++ b/packages/common/src/api/tan-query/useProfileReposts.ts
@@ -1,4 +1,4 @@
-import { Id, EntityType } from '@audius/sdk'
+import { EntityType, OptionalId } from '@audius/sdk'
 import {
   InfiniteData,
   useInfiniteQuery,
@@ -62,7 +62,7 @@ export const useProfileReposts = (
       const handleNoAt = handle.startsWith('@') ? handle.substring(1) : handle
       const { data: repostsSDKData } = await sdk.full.users.getRepostsByHandle({
         handle: handleNoAt,
-        userId: currentUserId ? Id.parse(currentUserId) : undefined,
+        userId: OptionalId.parse(currentUserId),
         limit: pageSize,
         offset: pageParam
       })

--- a/packages/common/src/api/tan-query/useProfileTracks.ts
+++ b/packages/common/src/api/tan-query/useProfileTracks.ts
@@ -1,4 +1,4 @@
-import { EntityType, Id } from '@audius/sdk'
+import { EntityType, Id, OptionalId } from '@audius/sdk'
 import {
   InfiniteData,
   useInfiniteQuery,
@@ -70,7 +70,7 @@ export const useProfileTracks = (
       const handleNoAt = handle.startsWith('@') ? handle.substring(1) : handle
       const { data: tracks } = await sdk.full.users.getTracksByUserHandle({
         handle: handleNoAt,
-        userId: currentUserId ? Id.parse(currentUserId) : undefined,
+        userId: OptionalId.parse(currentUserId),
         limit: pageSize,
         offset: pageParam,
         sort: sort === TracksSortMode.POPULAR ? 'plays' : 'date',

--- a/packages/common/src/api/tan-query/useProfileTracks.ts
+++ b/packages/common/src/api/tan-query/useProfileTracks.ts
@@ -1,4 +1,4 @@
-import { EntityType, Id, OptionalId } from '@audius/sdk'
+import { EntityType, OptionalId } from '@audius/sdk'
 import {
   InfiniteData,
   useInfiniteQuery,

--- a/packages/common/src/api/tan-query/useSupporter.ts
+++ b/packages/common/src/api/tan-query/useSupporter.ts
@@ -1,4 +1,4 @@
-import { Id } from '@audius/sdk'
+import { Id, OptionalId } from '@audius/sdk'
 import { useQuery, useQueryClient } from '@tanstack/react-query'
 import { useDispatch } from 'react-redux'
 
@@ -49,7 +49,7 @@ export const useSupporter = (
       const { data } = await sdk.full.users.getSupporter({
         id: Id.parse(userId),
         supporterUserId: Id.parse(supporterUserId),
-        userId: Id.parse(currentUserId)
+        userId: OptionalId.parse(currentUserId)
       })
 
       if (!data) return null
@@ -84,7 +84,7 @@ export const useTopSupporter = (userId: ID | null | undefined) => {
       const sdk = await audiusSdk()
       const { data } = await sdk.full.users.getSupporters({
         id: Id.parse(userId),
-        userId: Id.parse(currentUserId),
+        userId: OptionalId.parse(currentUserId),
         limit: 1
       })
 

--- a/packages/common/src/api/tan-query/useTrackByPermalink.ts
+++ b/packages/common/src/api/tan-query/useTrackByPermalink.ts
@@ -1,16 +1,16 @@
-import { Id } from '@audius/sdk'
+import { OptionalId } from '@audius/sdk'
 import { useQuery, useQueryClient } from '@tanstack/react-query'
 import { pick } from 'lodash'
-import { useDispatch, useSelector } from 'react-redux'
+import { useDispatch } from 'react-redux'
 
 import { userTrackMetadataFromSDK } from '~/adapters/track'
 import { useAudiusQueryContext } from '~/audius-query'
 import { ID } from '~/models/Identifiers'
-import { getUserId } from '~/store/account/selectors'
 
 import { TQTrack } from './models'
 import { QUERY_KEYS } from './queryKeys'
 import { QueryKey, QueryOptions, SelectableQueryOptions } from './types'
+import { useCurrentUserId } from './useCurrentUserId'
 import { useTrack } from './useTrack'
 import { primeTrackData } from './utils/primeTrackData'
 
@@ -27,7 +27,7 @@ export const useTrackByPermalink = <TResult = TQTrack>(
   const { audiusSdk } = useAudiusQueryContext()
   const queryClient = useQueryClient()
   const dispatch = useDispatch()
-  const currentUserId = useSelector(getUserId)
+  const { data: currentUserId } = useCurrentUserId()
 
   const simpleOptions = pick(options, [
     'enabled',
@@ -41,7 +41,7 @@ export const useTrackByPermalink = <TResult = TQTrack>(
       const sdk = await audiusSdk()
       const { data = [] } = await sdk.full.tracks.getBulkTracks({
         permalink: [permalink!],
-        userId: Id.parse(currentUserId)
+        userId: OptionalId.parse(currentUserId)
       })
 
       if (data.length === 0) {

--- a/packages/common/src/api/tan-query/useTrackReposts.ts
+++ b/packages/common/src/api/tan-query/useTrackReposts.ts
@@ -1,4 +1,4 @@
-import { Id } from '@audius/sdk'
+import { Id, OptionalId } from '@audius/sdk'
 import {
   InfiniteData,
   useInfiniteQuery,
@@ -55,7 +55,7 @@ export const useTrackReposts = (
         trackId: Id.parse(trackId),
         limit: pageSize,
         offset: pageParam,
-        userId: currentUserId ? Id.parse(currentUserId) : undefined
+        userId: OptionalId.parse(currentUserId)
       })
       const users = userMetadataListFromSDK(data)
       primeUserData({ users, queryClient, dispatch })

--- a/packages/common/src/api/tan-query/useUserTracksByHandle.ts
+++ b/packages/common/src/api/tan-query/useUserTracksByHandle.ts
@@ -1,14 +1,14 @@
-import { Id } from '@audius/sdk'
+import { OptionalId } from '@audius/sdk'
 import { useQuery, useQueryClient } from '@tanstack/react-query'
-import { useDispatch, useSelector } from 'react-redux'
+import { useDispatch } from 'react-redux'
 
 import { userTrackMetadataFromSDK } from '~/adapters/track'
 import { transformAndCleanList } from '~/adapters/utils'
 import { useAudiusQueryContext } from '~/audius-query'
-import { getUserId } from '~/store/account/selectors'
 
 import { QUERY_KEYS } from './queryKeys'
 import { QueryOptions } from './types'
+import { useCurrentUserId } from './useCurrentUserId'
 import { useTracks } from './useTracks'
 import { primeTrackData } from './utils/primeTrackData'
 
@@ -43,7 +43,7 @@ export const useUserTracksByHandle = (
   const { audiusSdk } = useAudiusQueryContext()
   const queryClient = useQueryClient()
   const dispatch = useDispatch()
-  const currentUserId = useSelector(getUserId)
+  const { data: currentUserId } = useCurrentUserId()
 
   const { handle, filterTracks = 'public', sort = 'date', limit, offset } = args
 
@@ -53,7 +53,7 @@ export const useUserTracksByHandle = (
       const sdk = await audiusSdk()
       const { data = [] } = await sdk.full.users.getTracksByUserHandle({
         handle: handle!,
-        userId: Id.parse(currentUserId),
+        userId: OptionalId.parse(currentUserId),
         filterTracks,
         sort,
         limit,

--- a/packages/web/src/pages/track-page/TrackPageProvider.tsx
+++ b/packages/web/src/pages/track-page/TrackPageProvider.tsx
@@ -101,6 +101,7 @@ type TrackPageProviderState = {
 const TrackPageProviderWrapper = (props: TrackPageProviderProps) => {
   const params = parseTrackRoute(props.pathname)
   const { data: track } = useTrackByParams(params)
+  console.log('REED track', track)
 
   return <TrackPageProviderClass {...props} track={track as Track | null} />
 }

--- a/packages/web/src/pages/track-page/TrackPageProvider.tsx
+++ b/packages/web/src/pages/track-page/TrackPageProvider.tsx
@@ -101,7 +101,6 @@ type TrackPageProviderState = {
 const TrackPageProviderWrapper = (props: TrackPageProviderProps) => {
   const params = parseTrackRoute(props.pathname)
   const { data: track } = useTrackByParams(params)
-  console.log('REED track', track)
 
   return <TrackPageProviderClass {...props} track={track as Track | null} />
 }


### PR DESCRIPTION
### Description
Bug was that fetching a track by copy/pasting track link into browser when not signed in was failing.

We were using `Id` in a bunch of places where we should've been using `OptionalId`.

### How Has This Been Tested?

Tested on local web prod.