### PR TITLE
[PE-6073] Migrate useTrackByTrackId to useTrack

### DIFF
--- a/packages/common/src/api/tan-query/useTrack.ts
+++ b/packages/common/src/api/tan-query/useTrack.ts
@@ -39,8 +39,6 @@ export const useTrack = <TResult = TQTrack>(
         queryClient,
         dispatch
       })
-
-      console.log('queryFn called on ', trackId)
       return await batchGetTracks.fetch(trackId!)
     },
     ...options,

--- a/packages/common/src/api/tan-query/useTrack.ts
+++ b/packages/common/src/api/tan-query/useTrack.ts
@@ -39,6 +39,8 @@ export const useTrack = <TResult = TQTrack>(
         queryClient,
         dispatch
       })
+
+      console.log('queryFn called on ', trackId)
       return await batchGetTracks.fetch(trackId!)
     },
     ...options,

--- a/packages/common/src/api/track.ts
+++ b/packages/common/src/api/track.ts
@@ -124,7 +124,6 @@ const trackApi = createApi({
 })
 
 export const {
-  useGetTrackById,
   useGetTrackByPermalink,
   useGetTracksByIds,
   useGetUserTracksByHandle

--- a/packages/common/src/context/comments/commentsContext.tsx
+++ b/packages/common/src/context/comments/commentsContext.tsx
@@ -14,12 +14,12 @@ import { useQueryClient } from '@tanstack/react-query'
 import { useDispatch, useSelector } from 'react-redux'
 
 import {
-  useGetTrackById,
   useTrackComments,
   QUERY_KEYS,
   useTrackCommentCount,
   resetPreviousCommentCount,
-  useSupporters
+  useSupporters,
+  useTrack
 } from '~/api'
 import { useGatedContentAccess } from '~/hooks'
 import {
@@ -106,7 +106,7 @@ export function CommentSectionProvider<NavigationProp>(
     uid: lineupUid,
     lineupActions
   } = props
-  const { data: track } = useGetTrackById({ id: entityId })
+  const { data: track } = useTrack(entityId)
   const trackOwnerId = track?.owner_id
 
   // Prefetch the track owner's supporters

--- a/packages/common/src/context/comments/commentsContext.tsx
+++ b/packages/common/src/context/comments/commentsContext.tsx
@@ -22,14 +22,7 @@ import {
   useTrack
 } from '~/api'
 import { useGatedContentAccess } from '~/hooks'
-import {
-  ModalSource,
-  ID,
-  Comment,
-  ReplyComment,
-  UserTrackMetadata,
-  Name
-} from '~/models'
+import { ModalSource, ID, Comment, ReplyComment, Name, Track } from '~/models'
 import { LineupBaseActions, playerActions } from '~/store'
 import { getUserId } from '~/store/account/selectors'
 import { seek } from '~/store/player/slice'
@@ -74,7 +67,7 @@ type CommentSectionContextType<NavigationProp> = {
   artistId: ID
   isEntityOwner: boolean
   commentCount: number | undefined
-  track: UserTrackMetadata
+  track: Track
   playTrack: (timestampSeconds?: number) => void
   commentSectionLoading: boolean
   commentIds: ID[]

--- a/packages/common/src/hooks/chats/useChatBlastAudienceContent.ts
+++ b/packages/common/src/hooks/chats/useChatBlastAudienceContent.ts
@@ -7,8 +7,8 @@ import {
   useGetCurrentUserId,
   useGetPlaylistById,
   useGetPurchasersCount,
-  useGetTrackById,
-  useRemixersCount
+  useRemixersCount,
+  useTrack
 } from '~/api'
 import {
   getChatBlastAudienceDescription,
@@ -30,12 +30,10 @@ export const useChatBlastAudienceContent = ({ chat }: { chat: ChatBlast }) => {
 
   const { data: currentUserId } = useGetCurrentUserId({})
   const { data: user } = useGetCurrentUser({})
-  const { data: track } = useGetTrackById(
-    {
-      id: decodedContentId!
-    },
-    { disabled: !decodedContentId || audienceContentType !== 'track' }
-  )
+  const { data: trackTitle } = useTrack(decodedContentId, {
+    enabled: !!decodedContentId && audienceContentType === 'track',
+    select: (track) => track.title
+  })
   const { data: album } = useGetPlaylistById(
     {
       playlistId: decodedContentId!
@@ -82,7 +80,7 @@ export const useChatBlastAudienceContent = ({ chat }: { chat: ChatBlast }) => {
 
   const contentTitle = audienceContentId
     ? audienceContentType === 'track'
-      ? track?.title
+      ? trackTitle
       : album?.playlist_name
     : undefined
 

--- a/packages/common/src/hooks/useTrackMetadata.ts
+++ b/packages/common/src/hooks/useTrackMetadata.ts
@@ -1,4 +1,5 @@
 import { Mood } from '@audius/sdk'
+import { pick } from 'lodash'
 
 import { useTrack } from '~/api/tan-query/useTrack'
 import { ID } from '~/models'
@@ -33,21 +34,22 @@ export type TrackMetadataInfo = {
 export const useTrackMetadata = ({
   trackId
 }: TrackMetadataProps): TrackMetadataInfo[] => {
-  const { data: partialTrack } = useTrack(trackId, {
-    select: (track) => ({
-      duration: track.duration,
-      genre: track.genre,
-      release_date: track.release_date,
-      mood: track.mood,
-      is_unlisted: track.is_unlisted,
-      musical_key: track.musical_key,
-      bpm: track.bpm,
-      is_custom_bpm: track.is_custom_bpm,
-      album_backlink: track.album_backlink
-    })
+  const { data: trackMetadata } = useTrack(trackId, {
+    select: (track) =>
+      pick(track, [
+        'duration',
+        'genre',
+        'release_date',
+        'mood',
+        'is_unlisted',
+        'musical_key',
+        'bpm',
+        'is_custom_bpm',
+        'album_backlink'
+      ])
   })
 
-  if (!partialTrack) return []
+  if (!trackMetadata) return []
 
   const {
     duration,
@@ -59,7 +61,7 @@ export const useTrackMetadata = ({
     bpm,
     is_custom_bpm: isCustomBpm,
     album_backlink
-  } = partialTrack
+  } = trackMetadata
 
   const parsedBpm = bpm
     ? parseFloat((bpm ?? 0).toFixed(isCustomBpm ? 2 : 0)).toString()

--- a/packages/common/src/hooks/useTrackMetadata.ts
+++ b/packages/common/src/hooks/useTrackMetadata.ts
@@ -1,6 +1,6 @@
 import { Mood } from '@audius/sdk'
 
-import { useGetTrackById } from '~/api/track'
+import { useTrack } from '~/api/tan-query/useTrack'
 import { ID } from '~/models'
 import { parseMusicalKey } from '~/utils/musicalKeys'
 import { searchPage } from '~/utils/route'
@@ -33,9 +33,21 @@ export type TrackMetadataInfo = {
 export const useTrackMetadata = ({
   trackId
 }: TrackMetadataProps): TrackMetadataInfo[] => {
-  const { data: track } = useGetTrackById({ id: trackId })
+  const { data: partialTrack } = useTrack(trackId, {
+    select: (track) => ({
+      duration: track.duration,
+      genre: track.genre,
+      release_date: track.release_date,
+      mood: track.mood,
+      is_unlisted: track.is_unlisted,
+      musical_key: track.musical_key,
+      bpm: track.bpm,
+      is_custom_bpm: track.is_custom_bpm,
+      album_backlink: track.album_backlink
+    })
+  })
 
-  if (!track) return []
+  if (!partialTrack) return []
 
   const {
     duration,
@@ -47,7 +59,7 @@ export const useTrackMetadata = ({
     bpm,
     is_custom_bpm: isCustomBpm,
     album_backlink
-  } = track
+  } = partialTrack
 
   const parsedBpm = bpm
     ? parseFloat((bpm ?? 0).toFixed(isCustomBpm ? 2 : 0)).toString()

--- a/packages/common/src/utils/isLongFormContent.ts
+++ b/packages/common/src/utils/isLongFormContent.ts
@@ -1,6 +1,7 @@
 import { TrackMetadata } from '~/models'
 
-import { Maybe, Nullable } from './typeUtils'
+import { Maybe } from './typeUtils'
 
-export const isLongFormContent = (track: Maybe<Nullable<TrackMetadata>>) =>
-  track?.genre === 'podcast' || track?.genre === 'audiobook'
+export const isLongFormContent = (
+  track: Maybe<Pick<TrackMetadata, 'genre'> | null>
+) => track?.genre === 'podcast' || track?.genre === 'audiobook'

--- a/packages/mobile/src/components/composer-input/ComposerInput.tsx
+++ b/packages/mobile/src/components/composer-input/ComposerInput.tsx
@@ -8,7 +8,7 @@ import {
   useState
 } from 'react'
 
-import { useGetTrackById } from '@audius/common/api'
+import { useTrack } from '@audius/common/api'
 import { useAudiusLinkResolver } from '@audius/common/hooks'
 import type { ID, UserMetadata } from '@audius/common/models'
 import {
@@ -133,7 +133,14 @@ export const ComposerInput = forwardRef(function ComposerInput(
   const latestValueRef = useRef(value)
   const messageIdRef = useRef(messageId)
   const lastKeyPressMsRef = useRef<number | null>(null)
-  const { data: track } = useGetTrackById({ id: entityId ?? -1 })
+  const { data: partialTrack } = useTrack(entityId, {
+    select: (track) => ({
+      duration: track.duration,
+      genre: track.genre,
+      release_date: track.release_date,
+      access: track.access
+    })
+  })
 
   useEffect(() => {
     setUserMentions(
@@ -183,9 +190,9 @@ export const ComposerInput = forwardRef(function ComposerInput(
   const prevLinkEntities = usePrevious(linkEntities)
 
   const timestamps = useMemo(() => {
-    if (!track || !track.access.stream) return []
+    if (!partialTrack || !partialTrack.access.stream) return []
 
-    const { duration } = track
+    const { duration } = partialTrack
     return Array.from(value.matchAll(timestampRegex))
       .filter((match) => getDurationFromTimestampMatch(match) <= duration)
       .map((match) => ({
@@ -194,7 +201,7 @@ export const ComposerInput = forwardRef(function ComposerInput(
         index: match.index,
         link: ''
       }))
-  }, [track, value])
+  }, [partialTrack, value])
   const prevTimestamps = usePrevious(timestamps)
 
   useEffect(() => {

--- a/packages/mobile/src/components/composer-input/ComposerInput.tsx
+++ b/packages/mobile/src/components/composer-input/ComposerInput.tsx
@@ -18,7 +18,7 @@ import {
   timestampRegex
 } from '@audius/common/utils'
 import { OptionalHashId } from '@audius/sdk'
-import { isEqual } from 'lodash'
+import { isEqual, pick } from 'lodash'
 import type { TextInput as RnTextInput } from 'react-native'
 import { Platform, TouchableOpacity } from 'react-native'
 import type {
@@ -134,12 +134,8 @@ export const ComposerInput = forwardRef(function ComposerInput(
   const messageIdRef = useRef(messageId)
   const lastKeyPressMsRef = useRef<number | null>(null)
   const { data: partialTrack } = useTrack(entityId, {
-    select: (track) => ({
-      duration: track.duration,
-      genre: track.genre,
-      release_date: track.release_date,
-      access: track.access
-    })
+    select: (track) =>
+      pick(track, ['duration', 'genre', 'release_date', 'access'])
   })
 
   useEffect(() => {

--- a/packages/mobile/src/components/premium-content-purchase-drawer/PremiumContentPurchaseDrawer.tsx
+++ b/packages/mobile/src/components/premium-content-purchase-drawer/PremiumContentPurchaseDrawer.tsx
@@ -1,10 +1,10 @@
 import { useCallback, type ReactNode, useEffect } from 'react'
 
 import {
-  useGetCurrentUserId,
+  useCurrentUserId,
   useGetPlaylistById,
-  useGetTrackById,
-  useGetUserById
+  useGetUserById,
+  useTrack
 } from '@audius/common/api'
 import type { PurchaseableContentMetadata } from '@audius/common/hooks'
 import {
@@ -22,12 +22,7 @@ import {
   PURCHASE_METHOD_MINT_ADDRESS
 } from '@audius/common/hooks'
 import type { ID, USDCPurchaseConditions } from '@audius/common/models'
-import {
-  Name,
-  PurchaseMethod,
-  PurchaseVendor,
-  statusIsNotFinalized
-} from '@audius/common/models'
+import { Name, PurchaseMethod, PurchaseVendor } from '@audius/common/models'
 import { IntKeys, FeatureFlags } from '@audius/common/services'
 import {
   usePremiumContentPurchaseModal,
@@ -456,11 +451,8 @@ export const PremiumContentPurchaseDrawer = () => {
     onClosed
   } = usePremiumContentPurchaseModal()
   const isAlbum = contentType === PurchaseableContentType.ALBUM
-  const { data: currentUserId } = useGetCurrentUserId({})
-  const { data: track, status: trackStatus } = useGetTrackById(
-    { id: contentId },
-    { disabled: !contentId }
-  )
+  const { data: currentUserId } = useCurrentUserId()
+  const { data: track, isPending: isTrackLoading } = useTrack(contentId)
   const { data: album } = useGetPlaylistById(
     { playlistId: contentId!, currentUserId },
     { disabled: !isAlbum || !contentId }
@@ -480,8 +472,6 @@ export const PremiumContentPurchaseDrawer = () => {
   const stage = useSelector(getPurchaseContentFlowStage)
   const error = useSelector(getPurchaseContentError)
   const isUnlocking = !error && isContentPurchaseInProgress(stage)
-
-  const isLoading = statusIsNotFinalized(trackStatus)
 
   const isValidStreamGatedTrack = !!metadata && isStreamPurchaseable(metadata)
   const isValidDownloadGatedTrack =
@@ -528,7 +518,7 @@ export const PremiumContentPurchaseDrawer = () => {
       isFullscreen
       dismissKeyboardOnOpen
     >
-      {isLoading ? (
+      {isTrackLoading ? (
         <View style={styles.spinnerContainer}>
           <LoadingSpinner />
         </View>

--- a/packages/mobile/src/components/premium-content-purchase-drawer/PremiumContentPurchaseDrawer.tsx
+++ b/packages/mobile/src/components/premium-content-purchase-drawer/PremiumContentPurchaseDrawer.tsx
@@ -452,7 +452,7 @@ export const PremiumContentPurchaseDrawer = () => {
   } = usePremiumContentPurchaseModal()
   const isAlbum = contentType === PurchaseableContentType.ALBUM
   const { data: currentUserId } = useCurrentUserId()
-  const { data: track, isPending: isTrackLoading } = useTrack(contentId)
+  const { data: track, isPending: isTrackPending } = useTrack(contentId)
   const { data: album } = useGetPlaylistById(
     { playlistId: contentId!, currentUserId },
     { disabled: !isAlbum || !contentId }
@@ -518,7 +518,7 @@ export const PremiumContentPurchaseDrawer = () => {
       isFullscreen
       dismissKeyboardOnOpen
     >
-      {isTrackLoading ? (
+      {isTrackPending ? (
         <View style={styles.spinnerContainer}>
           <LoadingSpinner />
         </View>

--- a/packages/mobile/src/screens/chat-screen/ComposePreviewInfo.tsx
+++ b/packages/mobile/src/screens/chat-screen/ComposePreviewInfo.tsx
@@ -1,6 +1,6 @@
 import type { ReactNode } from 'react'
 
-import { useGetPlaylistById, useGetTrackById } from '@audius/common/api'
+import { useGetPlaylistById, useTrack, useUser } from '@audius/common/api'
 import type { ID, UserMetadata } from '@audius/common/models'
 import { SquareSizes } from '@audius/common/models'
 
@@ -11,8 +11,8 @@ import UserBadges from 'app/components/user-badges'
 
 type ComposePreviewInfoProps = {
   title: string
-  name: string
-  user: UserMetadata
+  name?: string
+  user?: UserMetadata
   image?: ReactNode
 }
 
@@ -43,7 +43,7 @@ const ComposePreviewInfo = (props: ComposePreviewInfoProps) => {
           <Text variant='body' strength='strong'>
             {name}
           </Text>
-          <UserBadges hideName user={user} badgeSize={14} />
+          {user ? <UserBadges hideName user={user} badgeSize={14} /> : null}
         </Flex>
       </Flex>
     </Flex>
@@ -57,15 +57,21 @@ type ComposerTrackInfoProps = {
 export const ComposerTrackInfo = (props: ComposerTrackInfoProps) => {
   const { trackId } = props
 
-  const { data: track } = useGetTrackById({ id: trackId }, { force: true })
+  const { data: partialTrack } = useTrack(trackId, {
+    select: (track) => ({
+      title: track.title,
+      owner_id: track.owner_id
+    })
+  })
+  const { data: user } = useUser(partialTrack?.owner_id)
 
-  if (!track) return null
+  if (!partialTrack) return null
 
   return (
     <ComposePreviewInfo
-      title={track.title}
-      name={track.user.name}
-      user={track.user}
+      title={partialTrack.title}
+      name={user?.name ?? ''}
+      user={user}
       image={
         <TrackImage trackId={trackId} size={SquareSizes.SIZE_150_BY_150} />
       }

--- a/packages/mobile/src/screens/chat-screen/ComposePreviewInfo.tsx
+++ b/packages/mobile/src/screens/chat-screen/ComposePreviewInfo.tsx
@@ -3,6 +3,7 @@ import type { ReactNode } from 'react'
 import { useGetPlaylistById, useTrack, useUser } from '@audius/common/api'
 import type { ID, UserMetadata } from '@audius/common/models'
 import { SquareSizes } from '@audius/common/models'
+import { pick } from 'lodash'
 
 import { Flex, Text } from '@audius/harmony-native'
 import { CollectionImage } from 'app/components/image/CollectionImage'
@@ -58,10 +59,7 @@ export const ComposerTrackInfo = (props: ComposerTrackInfoProps) => {
   const { trackId } = props
 
   const { data: partialTrack } = useTrack(trackId, {
-    select: (track) => ({
-      title: track.title,
-      owner_id: track.owner_id
-    })
+    select: (track) => pick(track, ['title', 'owner_id'])
   })
   const { data: user } = useUser(partialTrack?.owner_id)
 

--- a/packages/mobile/src/screens/edit-track-screen/components/RemixTrackPill.tsx
+++ b/packages/mobile/src/screens/edit-track-screen/components/RemixTrackPill.tsx
@@ -1,6 +1,7 @@
 import { useTrack } from '@audius/common/api'
 import type { ID } from '@audius/common/models'
 import { SquareSizes } from '@audius/common/models'
+import { pick } from 'lodash'
 import type { StyleProp, ViewStyle } from 'react-native'
 
 import { Flex, Paper, Text } from '@audius/harmony-native'
@@ -45,16 +46,13 @@ const useStyles = makeStyles(({ spacing, palette, typography }) => ({
 export const RemixTrackPill = (props: RemixTrackPillProps) => {
   const { trackId, style } = props
   const { data: track } = useTrack(trackId, {
-    select: (track) => ({
-      title: track.title,
-      owner_id: track.owner_id
-    })
+    select: (track) => pick(track, ['title', 'owner_id'])
   })
   const styles = useStyles()
 
   if (!track) return null
 
-  const { title } = track
+  const { title, owner_id } = track
 
   return (
     <Paper
@@ -81,7 +79,7 @@ export const RemixTrackPill = (props: RemixTrackPillProps) => {
       </Flex>
       <Flex row alignItems='center'>
         <Text color='subdued'>{messages.trackBy}</Text>
-        <UserLink userId={track.owner_id} size='s' disabled />
+        <UserLink userId={owner_id} size='s' disabled />
       </Flex>
     </Paper>
   )

--- a/packages/mobile/src/screens/edit-track-screen/components/RemixTrackPill.tsx
+++ b/packages/mobile/src/screens/edit-track-screen/components/RemixTrackPill.tsx
@@ -1,4 +1,4 @@
-import { useGetTrackById } from '@audius/common/api'
+import { useTrack } from '@audius/common/api'
 import type { ID } from '@audius/common/models'
 import { SquareSizes } from '@audius/common/models'
 import type { StyleProp, ViewStyle } from 'react-native'
@@ -44,12 +44,17 @@ const useStyles = makeStyles(({ spacing, palette, typography }) => ({
 
 export const RemixTrackPill = (props: RemixTrackPillProps) => {
   const { trackId, style } = props
-  const { data: track } = useGetTrackById({ id: trackId })
+  const { data: track } = useTrack(trackId, {
+    select: (track) => ({
+      title: track.title,
+      owner_id: track.owner_id
+    })
+  })
   const styles = useStyles()
 
   if (!track) return null
 
-  const { user, title } = track
+  const { title } = track
 
   return (
     <Paper
@@ -76,7 +81,7 @@ export const RemixTrackPill = (props: RemixTrackPillProps) => {
       </Flex>
       <Flex row alignItems='center'>
         <Text color='subdued'>{messages.trackBy}</Text>
-        <UserLink userId={user.user_id} size='s' disabled />
+        <UserLink userId={track.owner_id} size='s' disabled />
       </Flex>
     </Paper>
   )

--- a/packages/mobile/src/screens/search-screen/SearchItem.tsx
+++ b/packages/mobile/src/screens/search-screen/SearchItem.tsx
@@ -6,6 +6,7 @@ import {
 import { recentSearchMessages as messages } from '@audius/common/messages'
 import { Kind, SquareSizes, Status } from '@audius/common/models'
 import type { SearchItem as SearchItemType } from '@audius/common/store'
+import { pick } from 'lodash'
 import { TouchableOpacity } from 'react-native-gesture-handler'
 
 import type { IconComponent } from '@audius/harmony-native'
@@ -82,10 +83,7 @@ export const SearchItemTrack = (props: SearchItemProps) => {
   const { searchItem, onPress } = props
   const { id } = searchItem
   const { data: partialTrack, isPending: isTrackPending } = useTrack(id, {
-    select: (track) => ({
-      title: track.title,
-      owner_id: track.owner_id
-    })
+    select: (track) => pick(track, ['title', 'owner_id'])
   })
   const { data: user } = useGetUserById({ id: partialTrack?.owner_id ?? 0 })
   const { spacing } = useTheme()

--- a/packages/mobile/src/screens/search-screen/SearchItem.tsx
+++ b/packages/mobile/src/screens/search-screen/SearchItem.tsx
@@ -1,7 +1,7 @@
 import {
   useGetPlaylistById,
-  useGetTrackById,
-  useGetUserById
+  useGetUserById,
+  useTrack
 } from '@audius/common/api'
 import { recentSearchMessages as messages } from '@audius/common/messages'
 import { Kind, SquareSizes, Status } from '@audius/common/models'
@@ -81,15 +81,20 @@ export const SearchItemSkeleton = () => (
 export const SearchItemTrack = (props: SearchItemProps) => {
   const { searchItem, onPress } = props
   const { id } = searchItem
-  const { data: track, status } = useGetTrackById({ id })
-  const { data: user } = useGetUserById({ id: track?.owner_id ?? 0 })
+  const { data: partialTrack, isPending: isTrackPending } = useTrack(id, {
+    select: (track) => ({
+      title: track.title,
+      owner_id: track.owner_id
+    })
+  })
+  const { data: user } = useGetUserById({ id: partialTrack?.owner_id ?? 0 })
   const { spacing } = useTheme()
   const navigation = useNavigation()
 
-  if (status === Status.LOADING) return <SearchItemSkeleton />
+  if (isTrackPending) return <SearchItemSkeleton />
 
-  if (!track) return null
-  const { title } = track
+  if (!partialTrack) return null
+  const { title } = partialTrack
 
   if (!user) return null
 

--- a/packages/web/src/components/comments/CommentPreview.tsx
+++ b/packages/web/src/components/comments/CommentPreview.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect } from 'react'
 
-import { useGetTrackById } from '@audius/common/api'
+import { useTrack } from '@audius/common/api'
 import {
   CommentSectionProvider,
   useCurrentCommentSection
@@ -37,7 +37,9 @@ const CommentPreviewHeader = () => {
     commentCount
   } = useCurrentCommentSection()
 
-  const { data: track } = useGetTrackById({ id: entityId })
+  const { data: trackPermalink } = useTrack(entityId, {
+    select: (track) => track.permalink
+  })
 
   const isShowingComments = !isLoading && commentIds?.length
 
@@ -59,7 +61,7 @@ const CommentPreviewHeader = () => {
       </Flex>
       {isShowingComments ? (
         <PlainButton iconRight={IconCaretRight} variant='subdued' asChild>
-          <Link to={`${track?.permalink}/comments`}>{messages.viewAll}</Link>
+          <Link to={`${trackPermalink}/comments`}>{messages.viewAll}</Link>
         </PlainButton>
       ) : null}
     </Flex>
@@ -75,11 +77,13 @@ const CommentPreviewContent = () => {
   } = useCurrentCommentSection()
   const dispatch = useDispatch()
 
-  const { data: track } = useGetTrackById({ id: entityId })
+  const { data: trackPermalink } = useTrack(entityId, {
+    select: (track) => track.permalink
+  })
 
   const handleClick = useCallback(() => {
-    dispatch(pushRoute(`${track?.permalink}/comments`))
-  }, [track, dispatch])
+    dispatch(pushRoute(`${trackPermalink}/comments`))
+  }, [trackPermalink, dispatch])
 
   // Loading state
   if (isLoading) {
@@ -122,7 +126,9 @@ type CommentPreviewProps = {
 export const CommentPreview = (props: CommentPreviewProps) => {
   const { entityId } = props
   const dispatch = useDispatch()
-  const { data: track } = useGetTrackById({ id: entityId })
+  const { data: trackPermalink } = useTrack(entityId, {
+    select: (track) => track.permalink
+  })
   const [searchParams] = useSearchParams()
   const showComments = searchParams.get('showComments')
   const { history } = useHistoryContext()
@@ -133,9 +139,9 @@ export const CommentPreview = (props: CommentPreviewProps) => {
   useEffect(() => {
     if (showComments) {
       history.replace({ search: '' })
-      dispatch(pushRoute(`${track?.permalink}/comments`))
+      dispatch(pushRoute(`${trackPermalink}/comments`))
     }
-  }, [showComments, track, dispatch, searchParams, history])
+  }, [showComments, trackPermalink, dispatch, searchParams, history])
 
   return (
     <CommentSectionProvider

--- a/packages/web/src/components/composer-input/ComposerInput.tsx
+++ b/packages/web/src/components/composer-input/ComposerInput.tsx
@@ -24,7 +24,7 @@ import {
   useTheme
 } from '@audius/harmony'
 import { EntityType, HashId } from '@audius/sdk'
-import { isEqual } from 'lodash'
+import { isEqual, pick } from 'lodash'
 import { usePrevious } from 'react-use'
 
 import { TextAreaV2 } from 'components/data-entry/TextAreaV2'
@@ -88,15 +88,10 @@ export const ComposerInput = (props: ComposerInputProps) => {
     ...other
   } = props
   const ref = useRef<HTMLTextAreaElement>(null)
-  const { data: partialTrack } = useTrack(
-    entityType === EntityType.TRACK ? entityId : undefined,
-    {
-      select: (track) => ({
-        access: track.access,
-        duration: track.duration
-      })
-    }
-  )
+  const { data: partialTrack } = useTrack(entityId, {
+    select: (track) => pick(track, ['access', 'duration']),
+    enabled: entityType === EntityType.TRACK
+  })
 
   const [value, setValue] = useState(presetMessage ?? '')
   const [focused, setFocused] = useState(false)

--- a/packages/web/src/components/composer-input/ComposerInput.tsx
+++ b/packages/web/src/components/composer-input/ComposerInput.tsx
@@ -7,7 +7,7 @@ import {
   useState
 } from 'react'
 
-import { useGetTrackById } from '@audius/common/api'
+import { useTrack } from '@audius/common/api'
 import { useAudiusLinkResolver } from '@audius/common/hooks'
 import { ID, UserMetadata } from '@audius/common/models'
 import {
@@ -88,9 +88,15 @@ export const ComposerInput = (props: ComposerInputProps) => {
     ...other
   } = props
   const ref = useRef<HTMLTextAreaElement>(null)
-  const { data: track } = useGetTrackById({
-    id: entityType === EntityType.TRACK && entityId ? entityId : -1
-  })
+  const { data: partialTrack } = useTrack(
+    entityType === EntityType.TRACK ? entityId : undefined,
+    {
+      select: (track) => ({
+        access: track.access,
+        duration: track.duration
+      })
+    }
+  )
 
   const [value, setValue] = useState(presetMessage ?? '')
   const [focused, setFocused] = useState(false)
@@ -177,9 +183,9 @@ export const ComposerInput = (props: ComposerInputProps) => {
   )
 
   const timestamps = useMemo(() => {
-    if (!track || !track.access.stream) return []
+    if (!partialTrack || !partialTrack.access.stream) return []
 
-    const { duration } = track
+    const { duration } = partialTrack
     return Array.from(value.matchAll(timestampRegex))
       .filter((match) => getDurationFromTimestampMatch(match) <= duration)
       .map((match) => ({
@@ -188,7 +194,7 @@ export const ComposerInput = (props: ComposerInputProps) => {
         index: match.index,
         link: ''
       }))
-  }, [track, value])
+  }, [partialTrack, value])
   const prevTimestamps = usePrevious(timestamps)
 
   const getAutocompleteRange = useCallback(() => {

--- a/packages/web/src/components/edit/fields/RemixSettingsField/RemixSettingsField.tsx
+++ b/packages/web/src/components/edit/fields/RemixSettingsField/RemixSettingsField.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useMemo } from 'react'
 
-import { useGetTrackById } from '@audius/common/api'
+import { useTrack } from '@audius/common/api'
 import {
   isContentUSDCPurchaseGated,
   ID,
@@ -67,13 +67,12 @@ export const RemixSettingsField = (props: RemixSettingsFieldProps) => {
     )
 
   const parentTrackId = remixOf?.tracks[0].parent_track_id
-  const { data: remixOfTrack } = useGetTrackById(
-    { id: parentTrackId! },
-    { disabled: !parentTrackId }
-  )
+  const { data: remixOfTrackPermalink } = useTrack(parentTrackId, {
+    select: (track) => track.permalink
+  })
 
-  const remixLink = remixOfTrack?.permalink
-    ? fullTrackPage(remixOfTrack?.permalink)
+  const remixLink = remixOfTrackPermalink
+    ? fullTrackPage(remixOfTrackPermalink)
     : ''
 
   const isRemix = Boolean(remixOf && remixOf?.tracks.length > 0)

--- a/packages/web/src/components/menu/TrackMenu.tsx
+++ b/packages/web/src/components/menu/TrackMenu.tsx
@@ -1,9 +1,9 @@
 import { useContext } from 'react'
 
 import {
-  useGetTrackById,
   useRemixContest,
-  useToggleFavoriteTrack
+  useToggleFavoriteTrack,
+  useTrack
 } from '@audius/common/api'
 import {
   ShareSource,
@@ -140,7 +140,13 @@ const TrackMenu = ({
   const { onOpen: openDeleteTrackConfirmation } =
     useDeleteTrackConfirmationModal()
   const { onOpen: openHostRemixContest } = useHostRemixContestModal()
-  const { data: track } = useGetTrackById({ id: props.trackId })
+  const { data: partialTrack } = useTrack(props.trackId, {
+    select: (track) => ({
+      album_backlink: track.album_backlink,
+      permalink: track.permalink,
+      remix_of: track.remix_of
+    })
+  })
 
   const toggleSaveTrack = useToggleFavoriteTrack({
     trackId: props.trackId,
@@ -161,7 +167,7 @@ const TrackMenu = ({
 
   const onEditTrack = (trackId: Nullable<number>) => {
     if (!trackId) return
-    const permalink = trackPermalink || track?.permalink
+    const permalink = trackPermalink || partialTrack?.permalink
     permalink && goToRoute(`${permalink}/edit`)
   }
 
@@ -187,7 +193,7 @@ const TrackMenu = ({
       unsetArtistPick
     } = props
 
-    const albumInfo = track?.album_backlink
+    const albumInfo = partialTrack?.album_backlink
     const isLongFormContent =
       genre === Genre.PODCASTS || genre === Genre.AUDIOBOOKS
 
@@ -318,7 +324,12 @@ const TrackMenu = ({
 
     const menu: { items: PopupMenuItem[] } = { items: [] }
 
-    if (includeRemixContest && isOwner && !isDeleted && !track?.remix_of) {
+    if (
+      includeRemixContest &&
+      isOwner &&
+      !isDeleted &&
+      !partialTrack?.remix_of
+    ) {
       menu.items.push(remixContestMenuItem)
     }
 

--- a/packages/web/src/components/menu/TrackMenu.tsx
+++ b/packages/web/src/components/menu/TrackMenu.tsx
@@ -28,6 +28,7 @@ import {
 } from '@audius/common/store'
 import { Genre, Nullable, route } from '@audius/common/utils'
 import { PopupMenuItem } from '@audius/harmony'
+import { pick } from 'lodash'
 import { connect, useDispatch, useSelector } from 'react-redux'
 import { Dispatch } from 'redux'
 
@@ -141,11 +142,7 @@ const TrackMenu = ({
     useDeleteTrackConfirmationModal()
   const { onOpen: openHostRemixContest } = useHostRemixContestModal()
   const { data: partialTrack } = useTrack(props.trackId, {
-    select: (track) => ({
-      album_backlink: track.album_backlink,
-      permalink: track.permalink,
-      remix_of: track.remix_of
-    })
+    select: (track) => pick(track, ['album_backlink', 'permalink', 'remix_of'])
   })
 
   const toggleSaveTrack = useToggleFavoriteTrack({

--- a/packages/web/src/components/now-playing/components/ActionsBar.tsx
+++ b/packages/web/src/components/now-playing/components/ActionsBar.tsx
@@ -1,6 +1,6 @@
 import { memo, MouseEvent } from 'react'
 
-import { useGetCurrentUserId, useGetTrackById } from '@audius/common/api'
+import { useCurrentUserId, useTrack } from '@audius/common/api'
 import { useGatedContentAccess } from '@audius/common/hooks'
 import { ID } from '@audius/common/models'
 import {
@@ -36,16 +36,23 @@ const ActionsBar = ({
   isDarkMode,
   isMatrixMode
 }: ActionsBarProps) => {
-  const { data: track } = useGetTrackById({ id: trackId })
-  const { data: currentUserId } = useGetCurrentUserId({})
+  const { data: partialTrack } = useTrack(trackId, {
+    select: (track) => ({
+      is_unlisted: track.is_unlisted,
+      owner_id: track.owner_id,
+      has_current_user_reposted: track.has_current_user_reposted,
+      has_current_user_saved: track.has_current_user_saved
+    })
+  })
+  const { data: currentUserId } = useCurrentUserId()
   const {
-    is_unlisted: isUnlisted,
     owner_id: ownerId,
     has_current_user_reposted: hasReposted,
-    has_current_user_saved: hasSaved
-  } = track ?? {}
+    has_current_user_saved: hasSaved,
+    is_unlisted: isUnlisted
+  } = partialTrack ?? {}
   const isOwner = ownerId === currentUserId
-  const { hasStreamAccess } = useGatedContentAccess(track ?? {})
+  const { hasStreamAccess } = useGatedContentAccess(partialTrack ?? {})
   const shouldShowActions = hasStreamAccess && !isUnlisted
 
   if (!shouldShowActions) return null

--- a/packages/web/src/components/now-playing/components/ActionsBar.tsx
+++ b/packages/web/src/components/now-playing/components/ActionsBar.tsx
@@ -9,6 +9,7 @@ import {
   IconButton,
   Flex
 } from '@audius/harmony'
+import { pick } from 'lodash'
 
 import FavoriteButton from 'components/alt-button/FavoriteButton'
 import RepostButton from 'components/alt-button/RepostButton'
@@ -37,12 +38,13 @@ const ActionsBar = ({
   isMatrixMode
 }: ActionsBarProps) => {
   const { data: partialTrack } = useTrack(trackId, {
-    select: (track) => ({
-      is_unlisted: track.is_unlisted,
-      owner_id: track.owner_id,
-      has_current_user_reposted: track.has_current_user_reposted,
-      has_current_user_saved: track.has_current_user_saved
-    })
+    select: (track) =>
+      pick(track, [
+        'is_unlisted',
+        'owner_id',
+        'has_current_user_reposted',
+        'has_current_user_saved'
+      ])
   })
   const { data: currentUserId } = useCurrentUserId()
   const {

--- a/packages/web/src/components/premium-content-purchase-modal/PremiumContentPurchaseModal.tsx
+++ b/packages/web/src/components/premium-content-purchase-modal/PremiumContentPurchaseModal.tsx
@@ -4,8 +4,8 @@ import {
   useGetCurrentUser,
   useGetCurrentUserId,
   useGetPlaylistById,
-  useGetTrackById,
-  useGetUserById
+  useGetUserById,
+  useTrack
 } from '@audius/common/api'
 import {
   useFeatureFlag,
@@ -224,10 +224,7 @@ export const PremiumContentPurchaseModal = () => {
   const guestEmail = useSelector(getGuestEmail)
 
   const isAlbum = contentType === PurchaseableContentType.ALBUM
-  const { data: track } = useGetTrackById(
-    { id: contentId! },
-    { disabled: isAlbum || !contentId }
-  )
+  const { data: track } = useTrack(contentId, { enabled: !isAlbum })
 
   const { data: album } = useGetPlaylistById(
     { playlistId: contentId!, currentUserId },

--- a/packages/web/src/components/track/TrackStats.tsx
+++ b/packages/web/src/components/track/TrackStats.tsx
@@ -1,4 +1,4 @@
-import { useGetCurrentUserId, useGetTrackById } from '@audius/common/api'
+import { useGetCurrentUserId, useTrack } from '@audius/common/api'
 import { useFeatureFlag } from '@audius/common/hooks'
 import { ID, Name } from '@audius/common/models'
 import { FeatureFlags } from '@audius/common/services'
@@ -34,16 +34,28 @@ type TrackStatsProps = {
 
 export const TrackStats = (props: TrackStatsProps) => {
   const { trackId, scrollToCommentSection } = props
-  const { data: track } = useGetTrackById({ id: trackId })
+  const { data: partialTrack } = useTrack(trackId, {
+    select: (track) => ({
+      comment_count: track.comment_count,
+      repost_count: track.repost_count,
+      save_count: track.save_count,
+      is_stream_gated: track.is_stream_gated,
+      owner_id: track.owner_id,
+      is_unlisted: track.is_unlisted,
+      play_count: track.play_count,
+      comments_disabled: track.comments_disabled,
+      genre: track.genre
+    })
+  })
   const { data: currentUserId } = useGetCurrentUserId({})
   const dispatch = useDispatch()
   const { isEnabled: isCommentsEnabled } = useFeatureFlag(
     FeatureFlags.COMMENTS_ENABLED
   )
 
-  const comment_count = track?.comment_count ?? 0
+  const comment_count = partialTrack?.comment_count ?? 0
 
-  if (!track) return null
+  if (!partialTrack) return null
 
   const {
     repost_count,
@@ -53,7 +65,7 @@ export const TrackStats = (props: TrackStatsProps) => {
     is_stream_gated,
     owner_id,
     is_unlisted
-  } = track
+  } = partialTrack
 
   const isOwner = currentUserId === owner_id
 
@@ -126,7 +138,7 @@ export const TrackStats = (props: TrackStatsProps) => {
         </PlainButton>
       )}
       {play_count > 0 &&
-      isLongFormContent(track) &&
+      isLongFormContent(partialTrack) &&
       (isOwner || !is_stream_gated) ? (
         <PlainButton iconLeft={IconPlay}>
           {formatCount(play_count)} {pluralize(messages.play, play_count)}

--- a/packages/web/src/components/track/TrackStats.tsx
+++ b/packages/web/src/components/track/TrackStats.tsx
@@ -11,6 +11,7 @@ import {
   IconRepost,
   PlainButton
 } from '@audius/harmony'
+import { pick } from 'lodash'
 import { useDispatch } from 'react-redux'
 
 import { make, track as trackEvent } from 'services/analytics'
@@ -35,17 +36,18 @@ type TrackStatsProps = {
 export const TrackStats = (props: TrackStatsProps) => {
   const { trackId, scrollToCommentSection } = props
   const { data: partialTrack } = useTrack(trackId, {
-    select: (track) => ({
-      comment_count: track.comment_count,
-      repost_count: track.repost_count,
-      save_count: track.save_count,
-      is_stream_gated: track.is_stream_gated,
-      owner_id: track.owner_id,
-      is_unlisted: track.is_unlisted,
-      play_count: track.play_count,
-      comments_disabled: track.comments_disabled,
-      genre: track.genre
-    })
+    select: (track) =>
+      pick(track, [
+        'comment_count',
+        'repost_count',
+        'save_count',
+        'is_stream_gated',
+        'owner_id',
+        'is_unlisted',
+        'play_count',
+        'comments_disabled',
+        'genre'
+      ])
   })
   const { data: currentUserId } = useGetCurrentUserId({})
   const dispatch = useDispatch()

--- a/packages/web/src/components/usdc-purchase-details-modal/components/TrackPurchaseModalContent.tsx
+++ b/packages/web/src/components/usdc-purchase-details-modal/components/TrackPurchaseModalContent.tsx
@@ -1,5 +1,6 @@
 import { useTrack } from '@audius/common/api'
 import { SquareSizes, USDCPurchaseDetails } from '@audius/common/models'
+import { pick } from 'lodash'
 
 import { useTrackCoverArt } from 'hooks/useTrackCoverArt'
 
@@ -18,10 +19,7 @@ export const TrackPurchaseModalContent = ({
 }) => {
   const { contentId } = purchaseDetails
   const { data: partialTrack } = useTrack(contentId, {
-    select: (track) => ({
-      title: track.title,
-      permalink: track.permalink
-    })
+    select: (track) => pick(track, ['title', 'permalink'])
   })
   const trackArtwork = useTrackCoverArt({
     trackId: contentId,

--- a/packages/web/src/components/usdc-purchase-details-modal/components/TrackPurchaseModalContent.tsx
+++ b/packages/web/src/components/usdc-purchase-details-modal/components/TrackPurchaseModalContent.tsx
@@ -1,4 +1,4 @@
-import { useGetTrackById } from '@audius/common/api'
+import { useTrack } from '@audius/common/api'
 import { SquareSizes, USDCPurchaseDetails } from '@audius/common/models'
 
 import { useTrackCoverArt } from 'hooks/useTrackCoverArt'
@@ -17,19 +17,24 @@ export const TrackPurchaseModalContent = ({
   onClose: () => void
 }) => {
   const { contentId } = purchaseDetails
-  const { data: track } = useGetTrackById({ id: contentId })
+  const { data: partialTrack } = useTrack(contentId, {
+    select: (track) => ({
+      title: track.title,
+      permalink: track.permalink
+    })
+  })
   const trackArtwork = useTrackCoverArt({
     trackId: contentId,
     size: SquareSizes.SIZE_150_BY_150
   })
 
-  if (!track) return null
+  if (!partialTrack) return null
   return (
     <PurchaseModalContent
       purchaseDetails={purchaseDetails}
       contentLabel={messages.track}
-      contentTitle={track.title}
-      link={track.permalink}
+      contentTitle={partialTrack.title}
+      link={partialTrack.permalink}
       artwork={trackArtwork}
       onClose={onClose}
     />

--- a/packages/web/src/components/usdc-purchase-details-modal/components/TrackSaleModalContent.tsx
+++ b/packages/web/src/components/usdc-purchase-details-modal/components/TrackSaleModalContent.tsx
@@ -1,5 +1,6 @@
 import { useTrack } from '@audius/common/api'
 import { SquareSizes, USDCPurchaseDetails } from '@audius/common/models'
+import { pick } from 'lodash'
 
 import { useTrackCoverArt } from 'hooks/useTrackCoverArt'
 
@@ -18,10 +19,7 @@ export const TrackSaleModalContent = ({
 }) => {
   const { contentId } = purchaseDetails
   const { data: partialTrack } = useTrack(contentId, {
-    select: (track) => ({
-      title: track.title,
-      permalink: track.permalink
-    })
+    select: (track) => pick(track, ['title', 'permalink'])
   })
   const trackArtwork = useTrackCoverArt({
     trackId: contentId,

--- a/packages/web/src/components/usdc-purchase-details-modal/components/TrackSaleModalContent.tsx
+++ b/packages/web/src/components/usdc-purchase-details-modal/components/TrackSaleModalContent.tsx
@@ -1,4 +1,4 @@
-import { useGetTrackById } from '@audius/common/api'
+import { useTrack } from '@audius/common/api'
 import { SquareSizes, USDCPurchaseDetails } from '@audius/common/models'
 
 import { useTrackCoverArt } from 'hooks/useTrackCoverArt'
@@ -17,20 +17,25 @@ export const TrackSaleModalContent = ({
   onClose: () => void
 }) => {
   const { contentId } = purchaseDetails
-  const { data: track } = useGetTrackById({ id: contentId })
+  const { data: partialTrack } = useTrack(contentId, {
+    select: (track) => ({
+      title: track.title,
+      permalink: track.permalink
+    })
+  })
   const trackArtwork = useTrackCoverArt({
     trackId: contentId,
     size: SquareSizes.SIZE_150_BY_150
   })
 
-  if (!track) return null
+  if (!partialTrack) return null
 
   return (
     <SaleModalContent
       purchaseDetails={purchaseDetails}
       contentLabel={messages.track}
-      contentTitle={track?.title}
-      link={track.permalink}
+      contentTitle={partialTrack.title}
+      link={partialTrack.permalink}
       artwork={trackArtwork}
       onClose={onClose}
     />

--- a/packages/web/src/pages/chat-page/components/ComposePreviewInfo.tsx
+++ b/packages/web/src/pages/chat-page/components/ComposePreviewInfo.tsx
@@ -1,4 +1,4 @@
-import { useGetPlaylistById, useGetTrackById } from '@audius/common/api'
+import { useGetPlaylistById, useTrack } from '@audius/common/api'
 import { SquareSizes, ID } from '@audius/common/models'
 import { Flex, Text } from '@audius/harmony'
 
@@ -48,14 +48,19 @@ export const ComposerTrackInfo = (props: ComposerTrackInfoProps) => {
     size: SquareSizes.SIZE_150_BY_150
   })
 
-  const { data: track } = useGetTrackById({ id: trackId }, { force: true })
+  const { data: track } = useTrack(trackId, {
+    select: (track) => ({
+      title: track.title,
+      owner_id: track.owner_id
+    })
+  })
 
   if (!track) return null
 
   return (
     <ComposePreviewInfo
       title={track.title}
-      userId={track.user.user_id}
+      userId={track.owner_id}
       image={image}
     />
   )

--- a/packages/web/src/pages/pay-and-earn-page/components/TrackNameWithArtwork.tsx
+++ b/packages/web/src/pages/pay-and-earn-page/components/TrackNameWithArtwork.tsx
@@ -1,7 +1,7 @@
 import {
-  useGetCurrentUserId,
+  useCurrentUserId,
   useGetPlaylistById,
-  useGetTrackById
+  useTrack
 } from '@audius/common/api'
 import {
   SquareSizes,
@@ -24,11 +24,14 @@ export const TrackNameWithArtwork = ({
   contentType: USDCContentPurchaseType
 }) => {
   const isTrack = contentType === USDCContentPurchaseType.TRACK
-  const { status: trackStatus, data: track } = useGetTrackById(
-    { id },
-    { disabled: !isTrack }
-  )
-  const { data: currentUserId } = useGetCurrentUserId({})
+  const { data: partialTrack, isPending: isTrackPending } = useTrack(id, {
+    enabled: isTrack,
+    select: (track) => ({
+      title: track.title,
+      owner_id: track.owner_id
+    })
+  })
+  const { data: currentUserId } = useCurrentUserId()
   const { status: albumStatus, data: album } = useGetPlaylistById(
     { playlistId: id, currentUserId },
     { disabled: isTrack }
@@ -41,9 +44,9 @@ export const TrackNameWithArtwork = ({
     collectionId: id,
     size: SquareSizes.SIZE_150_BY_150
   })
-  const title = isTrack ? track?.title : album?.playlist_name
+  const title = isTrack ? partialTrack?.title : album?.playlist_name
   const image = isTrack ? trackArtwork : albumArtwork
-  const loading = ![trackStatus, albumStatus].includes(Status.SUCCESS)
+  const loading = albumStatus !== Status.SUCCESS || isTrackPending
 
   return loading ? null : (
     <div className={styles.container}>

--- a/packages/web/src/pages/pay-and-earn-page/components/TrackNameWithArtwork.tsx
+++ b/packages/web/src/pages/pay-and-earn-page/components/TrackNameWithArtwork.tsx
@@ -9,6 +9,7 @@ import {
   USDCContentPurchaseType
 } from '@audius/common/models'
 import { Text } from '@audius/harmony'
+import { pick } from 'lodash'
 
 import DynamicImage from 'components/dynamic-image/DynamicImage'
 import { useCollectionCoverArt } from 'hooks/useCollectionCoverArt'
@@ -26,10 +27,7 @@ export const TrackNameWithArtwork = ({
   const isTrack = contentType === USDCContentPurchaseType.TRACK
   const { data: partialTrack, isPending: isTrackPending } = useTrack(id, {
     enabled: isTrack,
-    select: (track) => ({
-      title: track.title,
-      owner_id: track.owner_id
-    })
+    select: (track) => pick(track, ['title', 'owner_id'])
   })
   const { data: currentUserId } = useCurrentUserId()
   const { status: albumStatus, data: album } = useGetPlaylistById(

--- a/packages/web/src/pages/search-page/RecentSearches.tsx
+++ b/packages/web/src/pages/search-page/RecentSearches.tsx
@@ -26,6 +26,7 @@ import {
   Text,
   useTheme
 } from '@audius/harmony'
+import { pick } from 'lodash'
 import { useDispatch, useSelector } from 'react-redux'
 import { Link, useRouteMatch } from 'react-router-dom'
 
@@ -113,12 +114,8 @@ const RecentSearchTrack = (props: { searchItem: SearchItem }) => {
   const { searchItem } = props
   const { id } = searchItem
   const { data: partialTrack } = useTrack(id, {
-    select: (track) => ({
-      title: track.title,
-      permalink: track.permalink,
-      owner_id: track.owner_id,
-      track_id: track.track_id
-    })
+    select: (track) =>
+      pick(track, ['title', 'permalink', 'owner_id', 'track_id'])
   })
   const { data: user } = useUser(partialTrack?.owner_id)
 

--- a/packages/web/src/pages/search-page/RecentSearches.tsx
+++ b/packages/web/src/pages/search-page/RecentSearches.tsx
@@ -2,8 +2,9 @@ import { MouseEventHandler, useCallback, useMemo } from 'react'
 
 import {
   useGetPlaylistById,
-  useGetTrackById,
-  useGetUserById
+  useGetUserById,
+  useTrack,
+  useUser
 } from '@audius/common/api'
 import { recentSearchMessages as messages } from '@audius/common/messages'
 import { Kind, SquareSizes, Status } from '@audius/common/models'
@@ -111,19 +112,27 @@ const RecentSearch = (props: RecentSearchProps) => {
 const RecentSearchTrack = (props: { searchItem: SearchItem }) => {
   const { searchItem } = props
   const { id } = searchItem
-  const { data: track, status } = useGetTrackById({ id })
+  const { data: partialTrack } = useTrack(id, {
+    select: (track) => ({
+      title: track.title,
+      permalink: track.permalink,
+      owner_id: track.owner_id,
+      track_id: track.track_id
+    })
+  })
+  const { data: user } = useUser(partialTrack?.owner_id)
 
   const image = useTrackCoverArt({
-    trackId: track?.track_id,
+    trackId: partialTrack?.track_id,
     size: SquareSizes.SIZE_150_BY_150
   })
 
   if (status === Status.LOADING) return <RecentSearchSkeleton />
 
-  if (!track) return null
-  const { permalink, title, user } = track
-
+  if (!partialTrack) return null
   if (!user) return null
+
+  const { permalink, title } = partialTrack
 
   return (
     <RecentSearch searchItem={searchItem} title={title} linkTo={permalink}>

--- a/packages/web/src/pages/track-page/components/TrackRemixes.tsx
+++ b/packages/web/src/pages/track-page/components/TrackRemixes.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect } from 'react'
 
-import { useGetTrackById } from '@audius/common/api'
+import { useTrack } from '@audius/common/api'
 import { useFeatureFlag } from '@audius/common/hooks'
 import type { ID, Track } from '@audius/common/models'
 import { FeatureFlags } from '@audius/common/services'
@@ -57,7 +57,7 @@ export const TrackRemixes = (props: TrackRemixesProrps) => {
   const currentQueueItem = useSelector(getCurrentQueueItem)
   const isPlaying = useSelector(getPlaying)
   const isBuffering = useSelector(getBuffering)
-  const { data: track } = useGetTrackById({ id: trackId })
+  const { data: track } = useTrack(trackId)
   const { isEnabled: commentsFlagEnabled } = useFeatureFlag(
     FeatureFlags.COMMENTS_ENABLED
   )

--- a/packages/web/src/services/query-client.ts
+++ b/packages/web/src/services/query-client.ts
@@ -5,8 +5,8 @@ import { env } from './env'
 export const queryClient = new QueryClient({
   defaultOptions: {
     queries: {
-      gcTime: 1000 * 60 * 50000, // 50000 minutes
-      staleTime: 1000 * 60 * 50000, // 50000 minutes
+      gcTime: 1000 * 60 * 5, // 5 minutes
+      staleTime: 1000 * 60 * 5, // 5 minutes
       refetchOnWindowFocus: true,
       refetchOnReconnect: true,
       refetchOnMount: true,

--- a/packages/web/src/services/query-client.ts
+++ b/packages/web/src/services/query-client.ts
@@ -5,8 +5,8 @@ import { env } from './env'
 export const queryClient = new QueryClient({
   defaultOptions: {
     queries: {
-      gcTime: 1000 * 60 * 5, // 5 minutes
-      staleTime: 1000 * 60 * 5, // 5 minutes
+      gcTime: 1000 * 60 * 50000, // 50000 minutes
+      staleTime: 1000 * 60 * 50000, // 50000 minutes
       refetchOnWindowFocus: true,
       refetchOnReconnect: true,
       refetchOnMount: true,


### PR DESCRIPTION
### Description

- Replaces audius-query's useTrackByTrackId with useTrack
- Most places I also added a `select` to narrow the data

### How Has This Been Tested?

TODO: 
- [ ] Compare network requests vs staging - make sure we're not adding extra requests
- [ ] Comb over each instance on web & ios
