### PR TITLE
CreateSenderPublic support + script

### DIFF
--- a/.changeset/curly-islands-swim.md
+++ b/.changeset/curly-islands-swim.md
@@ -1,0 +1,5 @@
+---
+"@audius/sdk": patch
+---
+
+Export SolanaClient

--- a/.changeset/nasty-doors-tickle.md
+++ b/.changeset/nasty-doors-tickle.md
@@ -1,0 +1,5 @@
+---
+"@audius/spl": patch
+---
+
+Add support for encoding createSenderPublic attestations, fix instruction to not require signers for senders

--- a/packages/discovery-provider/scripts/createSenderPublic.ts
+++ b/packages/discovery-provider/scripts/createSenderPublic.ts
@@ -73,12 +73,6 @@ const createSenderPublicInstructions = async ({
       recoveryId,
       instructionIndex: instructions.length
     })
-    const decoded = Secp256k1Program.decode(secpInstruction)
-    if (!Secp256k1Program.verifySignature(decoded)) {
-      console.log('big sad')
-      const recovered = Secp256k1Program.recoverSigner(decoded)
-      console.log(recovered)
-    }
     instructions.push(secpInstruction)
 
     const sender = RewardManagerProgram.deriveSender({

--- a/packages/discovery-provider/scripts/createSenderPublic.ts
+++ b/packages/discovery-provider/scripts/createSenderPublic.ts
@@ -1,0 +1,154 @@
+import { RewardManagerProgram, Secp256k1Program } from '@audius/spl'
+import { PublicKey, type TransactionInstruction } from '@solana/web3.js'
+import {
+  Configuration,
+  SolanaClient,
+  SolanaRelay,
+  SolanaRelayWalletAdapter
+} from '@audius/sdk'
+
+// CHANGE THESE
+const endpoints = [
+  'https://discoveryprovider.staging.audius.co',
+  'https://discoveryprovider2.staging.audius.co',
+  'https://discoveryprovider3.staging.audius.co'
+]
+const programId = new PublicKey('CDpzvz7DfgbF95jSSCHLX3ERkugyfgn9Fw8ypNZ1hfXp')
+const rewardManagerState = new PublicKey(
+  'GaiG9LDYHfZGqeNaoGRzFEnLiwUT7WiC6sA6FDJX9ZPq'
+)
+const addressLookupTable = new PublicKey(
+  'ChFCWjeFxM6SRySTfT46zXn2K7m89TJsft4HWzEtkB4J'
+)
+
+const authority = RewardManagerProgram.deriveAuthority({
+  programId,
+  rewardManagerState
+})
+
+const client = new SolanaClient({
+  solanaWalletAdapter: new SolanaRelayWalletAdapter({
+    solanaRelay: new SolanaRelay(
+      new Configuration({
+        basePath: endpoints[0] + '/solana',
+        headers: { 'Content-Type': 'application/json' }
+      })
+    )
+  })
+})
+
+const createSenderPublicInstructions = async ({
+  senderEthAddress,
+  operatorEthAddress,
+  attestations
+}: {
+  senderEthAddress: string
+  operatorEthAddress: string
+  attestations: any[]
+}) => {
+  const instructions: TransactionInstruction[] = []
+  const existingSenders: PublicKey[] = []
+
+  const sender = RewardManagerProgram.deriveSender({
+    ethAddress: senderEthAddress,
+    programId,
+    authority
+  })
+
+  for (let i = 0; i < attestations.length; i++) {
+    const data = attestations[i]
+
+    const message = RewardManagerProgram.encodeSenderAttestation({
+      senderEthAddress,
+      rewardManagerState
+    })
+
+    const { signature, recoveryId } = RewardManagerProgram.encodeSignature(
+      data.attestation
+    )
+    const secpInstruction = Secp256k1Program.createInstructionWithEthAddress({
+      ethAddress: data.owner_wallet,
+      message,
+      signature,
+      recoveryId,
+      instructionIndex: instructions.length
+    })
+    const decoded = Secp256k1Program.decode(secpInstruction)
+    if (!Secp256k1Program.verifySignature(decoded)) {
+      console.log('big sad')
+      const recovered = Secp256k1Program.recoverSigner(decoded)
+      console.log(recovered)
+    }
+    instructions.push(secpInstruction)
+
+    const sender = RewardManagerProgram.deriveSender({
+      ethAddress: data.owner_wallet,
+      programId,
+      authority
+    })
+    existingSenders.push(sender)
+  }
+  const payer = await client.getFeePayer()
+  const createSenderInst = RewardManagerProgram.createSenderPublicInstruction({
+    senderEthAddress,
+    operatorEthAddress,
+    sender,
+    existingSenders,
+    rewardManagerState,
+    authority,
+    payer,
+    rewardManagerProgramId: programId
+  })
+  instructions.push(createSenderInst)
+  return instructions
+}
+
+const createContentNodeSenders = async () => {
+  const {
+    data: {
+      network: { content_nodes: contentNodes }
+    }
+  } = await fetch(endpoints[0] + '/health_check').then((r) => r.json())
+
+  for (const contentNode of contentNodes) {
+    const senderEthAddress = contentNode.delegateOwnerWallet
+    const {
+      data: { spOwnerWallet: operatorEthAddress }
+    } = await fetch(contentNode.endpoint + '/health_check').then((r) =>
+      r.json()
+    )
+
+    const attestations = await Promise.all(
+      endpoints.map(async (e) => {
+        const res = await fetch(
+          `${e}/v1/challenges/attest_sender?sender_eth_address=${senderEthAddress}`
+        )
+        const { data } = await res.json()
+        return data
+      })
+    )
+
+    const instructions = await createSenderPublicInstructions({
+      senderEthAddress,
+      operatorEthAddress,
+      attestations
+    })
+
+    const payer = await client.getFeePayer()
+    const tx = await client.buildTransaction({
+      instructions,
+      addressLookupTables: [addressLookupTable],
+      feePayer: payer
+    })
+
+    try {
+      const res = await client.sendTransaction(tx)
+      console.log(res)
+    } catch (e) {
+      console.error(e)
+      console.log(e.response)
+    }
+  }
+}
+
+createContentNodeSenders()

--- a/packages/sdk/src/sdk/services/Solana/index.ts
+++ b/packages/sdk/src/sdk/services/Solana/index.ts
@@ -1,5 +1,6 @@
 export * from './SolanaRelay'
 export * from './SolanaRelayWalletAdapter'
+export { SolanaClient } from './programs/SolanaClient'
 export * from './programs/ClaimableTokensClient'
 export * from './programs/RewardManagerClient'
 export * from './programs/PaymentRouterClient'

--- a/packages/spl/package.json
+++ b/packages/spl/package.json
@@ -33,6 +33,6 @@
     "@solana/web3.js": "^1.95.8"
   },
   "devDependencies": {
-    "vitest": "0.34.6"
+    "vitest": "2.1.1"
   }
 }

--- a/packages/spl/src/reward-manager/RewardManagerProgram.ts
+++ b/packages/spl/src/reward-manager/RewardManagerProgram.ts
@@ -13,6 +13,7 @@ import {
 import { borshString, ethAddress } from '../layout-utils'
 
 import { attestationLayout } from './AttestationLayout'
+import { senderAttestationLayout } from './SenderAttestationLayout'
 import { RewardManagerInstruction } from './constants'
 import {
   Attestation,
@@ -32,7 +33,8 @@ import {
   SubmitAttestationInstructionData,
   SubmitRewardAttestationParams,
   VerifiedMessage,
-  AttestationsAccountData
+  AttestationsAccountData,
+  type SenderAttestation
 } from './types'
 
 const encoder = new TextEncoder()
@@ -201,7 +203,7 @@ export class RewardManagerProgram {
       { pubkey: SystemProgram.programId, isSigner: false, isWritable: false },
       ...existingSenders.map((pubkey) => ({
         pubkey,
-        isSigner: true,
+        isSigner: false,
         isWritable: false
       }))
     ]
@@ -617,5 +619,11 @@ export class RewardManagerProgram {
     return RewardManagerProgram.layouts.rewardManagerStateData.decode(
       accountData
     )
+  }
+
+  public static encodeSenderAttestation(attestation: SenderAttestation) {
+    const data = Buffer.alloc(senderAttestationLayout().span)
+    const span = senderAttestationLayout().encode(attestation, data)
+    return data.subarray(0, span)
   }
 }

--- a/packages/spl/src/reward-manager/SenderAttestationLayout.ts
+++ b/packages/spl/src/reward-manager/SenderAttestationLayout.ts
@@ -1,0 +1,32 @@
+import { blob, Layout } from '@solana/buffer-layout'
+import { publicKey } from '@solana/buffer-layout-utils'
+
+import { ethAddress } from '../layout-utils'
+
+import type { SenderAttestation } from './types'
+
+const encoder = new TextEncoder()
+const SENDER_ATTESTATION_PREFIX = 'add'
+const SENDER_ATTESTATION_PREFIX_BYTES = encoder.encode(
+  SENDER_ATTESTATION_PREFIX
+)
+
+export class SenderAttestationLayout extends Layout<SenderAttestation> {
+  constructor(property?: string) {
+    super(55, property) // 3 ('add') + 32 (pubkey) + 20 (ethAddress)
+  }
+
+  decode(b: Uint8Array, offset?: number): SenderAttestation {
+    throw new Error('Method not implemented.')
+  }
+
+  encode(src: SenderAttestation, b: Uint8Array, offset = 0): number {
+    offset += blob(3).encode(SENDER_ATTESTATION_PREFIX_BYTES, b, offset)
+    offset += publicKey().encode(src.rewardManagerState, b, offset)
+    offset += ethAddress().encode(src.senderEthAddress, b, offset)
+    return offset
+  }
+}
+
+export const senderAttestationLayout = (property?: string) =>
+  new SenderAttestationLayout(property)

--- a/packages/spl/src/reward-manager/types.ts
+++ b/packages/spl/src/reward-manager/types.ts
@@ -283,6 +283,11 @@ export type Attestation = {
   antiAbuseOracleEthAddress?: string | null
 }
 
+export type SenderAttestation = {
+  rewardManagerState: PublicKey
+  senderEthAddress: string
+}
+
 export type VerifiedMessage = {
   senderEthAddress: string
   attestation: Attestation


### PR DESCRIPTION
`@audius/spl`
- Fixes `RewardManager.createSenderPublic` instruction accounts to have only the one signer
- Adds `SenderAttestationLayout` to support encoding payloads for Secp256k1 instructions
- Upgrades vitest for the VSCode plugin

`@audius/sdk`
- Export SolanaClient so it can be used externally

Aaaand finally, a new script to create senders with the public instructions. Currently hardcoded to stage, will run again when the attestation logic makes it to prod. Will delete after running against prod. (Already ran against staging, they're all registered!)