### PR TITLE
Remove aggregate user update in handle_playlist

### DIFF
--- a/packages/discovery-provider/ddl/functions/handle_playlist.sql
+++ b/packages/discovery-provider/ddl/functions/handle_playlist.sql
@@ -7,7 +7,6 @@ declare
   delta int := 0;
 begin
 
-  insert into aggregate_user (user_id) values (new.playlist_owner_id) on conflict do nothing;
   insert into aggregate_playlist (playlist_id, is_album) values (new.playlist_id, new.is_album) on conflict do nothing;
 
   with expanded as (


### PR DESCRIPTION
### Description

This was added originally as an extra safety check here
https://github.com/AudiusProject/audius-protocol/commit/414dbdfcbdb480951bf638677ac03faedd1c28fc#diff-3706966ed6d689fdfcff461b7bfb9fa1e4ea4a40c323cc7e092acfcf51bb46b7R9-R11

But we still calculate on an interval, and probably shouldn't be doing this for every playlist update, which could be blocked

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._

```
pytest integration_tests
```