### PR TITLE
Remove setUserId as email & stop calling identify on handle page

### DIFF
--- a/packages/mobile/src/screens/sign-on-screen/screens/PickHandleScreen.tsx
+++ b/packages/mobile/src/screens/sign-on-screen/screens/PickHandleScreen.tsx
@@ -23,7 +23,6 @@ import {
 } from '@audius/harmony-native'
 import { ScrollView } from 'app/components/core'
 import { useNavigation } from 'app/hooks/useNavigation'
-import { identify } from 'app/services/analytics'
 
 import { HandleField } from '../components/HandleField'
 import { SocialMediaLoading } from '../components/SocialMediaLoading'

--- a/packages/mobile/src/screens/sign-on-screen/screens/PickHandleScreen.tsx
+++ b/packages/mobile/src/screens/sign-on-screen/screens/PickHandleScreen.tsx
@@ -121,7 +121,6 @@ export const PickHandleScreen = () => {
     (values: PickHandleValues) => {
       const { handle } = values
       dispatch(setValueField('handle', handle))
-      identify({ handle })
       navigation.navigate('FinishProfile')
     },
     [dispatch, navigation]

--- a/packages/mobile/src/services/analytics.ts
+++ b/packages/mobile/src/services/analytics.ts
@@ -84,9 +84,6 @@ export const identify = async (traits: IdentifyTraits) => {
 
   if (traits.handle) {
     setUserId(traits.handle)
-  } else if (traits.email) {
-    // Use email as our user identifier before we have handle (works better for partial accounts in the signup flow)
-    setUserId(traits.email)
   }
   const identifyObj = new Identify()
   Object.entries(traits).forEach(([key, value]) => {

--- a/packages/web/src/pages/sign-up-page/pages/PickHandlePage.tsx
+++ b/packages/web/src/pages/sign-up-page/pages/PickHandlePage.tsx
@@ -25,7 +25,6 @@ import {
 import { ToastContext } from 'components/toast/ToastContext'
 import { useMedia } from 'hooks/useMedia'
 import { useNavigateToPage } from 'hooks/useNavigateToPage'
-import { identify } from 'services/analytics'
 import { restrictedHandles } from 'utils/restrictedHandles'
 
 import { HandleField } from '../components/HandleField'

--- a/packages/web/src/pages/sign-up-page/pages/PickHandlePage.tsx
+++ b/packages/web/src/pages/sign-up-page/pages/PickHandlePage.tsx
@@ -124,7 +124,6 @@ export const PickHandlePage = () => {
   const handleSubmit = useCallback(
     (values: PickHandleValues) => {
       const { handle } = values
-      identify({ handle })
       dispatch(setValueField('handle', handle))
       if (isFastReferral) {
         dispatch(setValueField('name', handle))

--- a/packages/web/src/services/analytics/amplitude.ts
+++ b/packages/web/src/services/analytics/amplitude.ts
@@ -46,15 +46,10 @@ export const identify = (traits?: IdentifyTraits, callback?: () => void) => {
 
   if (traits?.handle) {
     amplitude.setUserId(traits.handle)
-  } else if (traits?.email) {
-    // Use email as our user identifier before we have handle (works better for partial accounts in the signup flow)
-    amplitude.setUserId(traits.email)
   }
-
   if (traits && Object.keys(traits).length > 0) {
     const identifyObj = new amplitude.Identify()
-    // @ts-ignore - for some reason it doesn't want you to pass strings, but it works fine
-    Object.entries(traits).map(([k, v]) => identifyObj.add(k, v))
+    Object.entries(traits).map(([k, v]) => identifyObj.set(k, v))
     amplitude.identify(identifyObj)
   }
   if (callback) callback()


### PR DESCRIPTION
### Description

- Remove setUserId as email & stop calling identify on handle page
- Need to test this on stage some more to see if this works (localhost is being sus)

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._
