### PR TITLE
[PE-6069] Fix remix submissions names overflow

### DIFF
--- a/packages/mobile/src/harmony-native/components/TextLink/TextPressable.tsx
+++ b/packages/mobile/src/harmony-native/components/TextLink/TextPressable.tsx
@@ -70,6 +70,7 @@ export const TextPressable = (props: TextLinkProps) => {
       onPressOut={() => {
         animatedPressed.value = withTiming(0, motion.press)
       }}
+      style={style}
       {...other}
     >
       <Text>

--- a/packages/mobile/src/screens/track-screen/RemixContestSubmissionsTab.tsx
+++ b/packages/mobile/src/screens/track-screen/RemixContestSubmissionsTab.tsx
@@ -3,6 +3,7 @@ import React from 'react'
 import type { LineupData } from '@audius/common/api'
 import { useRemixes, useTrack, useUser } from '@audius/common/api'
 import type { ID } from '@audius/common/models'
+import { css } from '@emotion/native'
 
 import {
   Artwork,
@@ -18,9 +19,9 @@ import { TrackFlair, Size } from 'app/components/track-flair'
 import { UserLink } from 'app/components/user-link'
 import { useNavigation } from 'app/hooks/useNavigation'
 
-const artworkSize = 120
-const userAvatarSize = 40
-
+const ARTWORK_SIZE = 120
+const USER_AVATAR_SIZE = 40
+const NAME_WIDTH = 120
 const messages = {
   noSubmissions: 'No submissions yet',
   beFirst: 'Be the first to upload a remix!',
@@ -56,7 +57,7 @@ const SubmissionCard = ({ submission }: { submission: LineupData }) => {
 
   return (
     <Flex column gap='s'>
-      <Flex h={artworkSize} w={artworkSize}>
+      <Flex h={ARTWORK_SIZE} w={ARTWORK_SIZE}>
         {displaySkeleton ? (
           <Skeleton />
         ) : (
@@ -74,8 +75,8 @@ const SubmissionCard = ({ submission }: { submission: LineupData }) => {
               <Artwork source={{ uri: track.artwork['150x150'] }} />
             </TrackFlair>
             <Box
-              h={userAvatarSize}
-              w={userAvatarSize}
+              h={USER_AVATAR_SIZE}
+              w={USER_AVATAR_SIZE}
               borderRadius='circle'
               style={{
                 position: 'absolute',
@@ -101,14 +102,28 @@ const SubmissionCard = ({ submission }: { submission: LineupData }) => {
           </>
         ) : (
           <>
-            <TrackLink textVariant='title' size='s' trackId={track.track_id} />
-            <UserLink userId={user.user_id} size='s' />
+            <TrackLink
+              textVariant='title'
+              size='s'
+              trackId={track.track_id}
+              ellipses
+              numberOfLines={1}
+              style={{ maxWidth: NAME_WIDTH }}
+            />
+            <UserLink
+              userId={user.user_id}
+              size='s'
+              ellipses
+              numberOfLines={1}
+              style={{ maxWidth: NAME_WIDTH }}
+            />
           </>
         )}
       </Flex>
     </Flex>
   )
 }
+
 const RemixContestSubmissions = ({
   trackId,
   submissions
@@ -120,7 +135,7 @@ const RemixContestSubmissions = ({
 
   return (
     <Flex w='100%' column gap='2xl' pv='xl' ph='l' borderTop='default'>
-      <Flex gap='2xl' wrap='wrap'>
+      <Flex row gap='2xl' wrap='wrap' justifyContent='space-around'>
         {submissions.map((submission) => (
           <SubmissionCard key={submission.id} submission={submission} />
         ))}

--- a/packages/mobile/src/screens/track-screen/RemixContestSubmissionsTab.tsx
+++ b/packages/mobile/src/screens/track-screen/RemixContestSubmissionsTab.tsx
@@ -3,7 +3,6 @@ import React from 'react'
 import type { LineupData } from '@audius/common/api'
 import { useRemixes, useTrack, useUser } from '@audius/common/api'
 import type { ID } from '@audius/common/models'
-import { css } from '@emotion/native'
 
 import {
   Artwork,

--- a/packages/web/src/pages/track-page/components/desktop/RemixContestSubmissionsTab.tsx
+++ b/packages/web/src/pages/track-page/components/desktop/RemixContestSubmissionsTab.tsx
@@ -18,8 +18,9 @@ import { TrackArtwork } from 'components/track/TrackArtwork'
 import TrackFlair, { Size } from 'components/track-flair/TrackFlair'
 import { trackRemixesPage } from 'utils/route'
 
-const artworkSize = 160
-const userAvatarSize = 64
+const ARTWORK_SIZE = 160
+const USER_AVATAR_SIZE = 64
+const NAME_WIDTH = 140
 
 const messages = {
   noSubmissions: 'No submissions yet',
@@ -61,9 +62,9 @@ const SubmissionCard = ({ submission }: { submission: LineupData }) => {
 
   return (
     <Flex column gap='s'>
-      <Flex h={artworkSize} w={artworkSize} borderRadius='s'>
+      <Flex h={ARTWORK_SIZE} w={ARTWORK_SIZE} borderRadius='s'>
         {displaySkeleton ? (
-          <Skeleton h={artworkSize} w={artworkSize} borderRadius='s' />
+          <Skeleton h={ARTWORK_SIZE} w={ARTWORK_SIZE} borderRadius='s' />
         ) : (
           <>
             {/* Track Artwork with Flair */}
@@ -86,8 +87,8 @@ const SubmissionCard = ({ submission }: { submission: LineupData }) => {
             </TrackFlair>
             {/* User Avatar */}
             <Box
-              h={userAvatarSize}
-              w={userAvatarSize}
+              h={USER_AVATAR_SIZE}
+              w={USER_AVATAR_SIZE}
               css={{ position: 'absolute', top: -8, right: -8, zIndex: 10 }}
               borderRadius='circle'
             >
@@ -107,8 +108,18 @@ const SubmissionCard = ({ submission }: { submission: LineupData }) => {
           </>
         ) : (
           <>
-            <TrackLink textVariant='title' trackId={track.track_id} />
-            <UserLink userId={user.user_id} popover />
+            <TrackLink
+              textVariant='title'
+              trackId={track.track_id}
+              ellipses
+              css={{ display: 'block', maxWidth: NAME_WIDTH }}
+            />
+            <UserLink
+              userId={user.user_id}
+              popover
+              ellipses
+              css={{ display: 'block', maxWidth: NAME_WIDTH }}
+            />
           </>
         )}
       </Flex>

--- a/packages/web/src/pages/track-page/components/mobile/remix-contests/RemixContestSubmissionsTab.tsx
+++ b/packages/web/src/pages/track-page/components/mobile/remix-contests/RemixContestSubmissionsTab.tsx
@@ -20,8 +20,9 @@ import TrackFlair from 'components/track-flair/TrackFlair'
 import { Size } from 'components/track-flair/types'
 import { trackRemixesPage } from 'utils/route'
 
-const artworkSize = 140
-const userAvatarSize = 50
+const ARTWORK_SIZE = 140
+const USER_AVATAR_SIZE = 50
+const NAME_WIDTH = 120
 
 const messages = {
   noSubmissions: 'No submissions yet',
@@ -63,9 +64,9 @@ const SubmissionCard = ({ submission }: { submission: LineupData }) => {
 
   return (
     <Flex column gap='s'>
-      <Flex h={artworkSize} w={artworkSize} borderRadius='s'>
+      <Flex h={ARTWORK_SIZE} w={ARTWORK_SIZE} borderRadius='s'>
         {displaySkeleton ? (
-          <Skeleton h={artworkSize} w={artworkSize} borderRadius='s' />
+          <Skeleton h={ARTWORK_SIZE} w={ARTWORK_SIZE} borderRadius='s' />
         ) : (
           <>
             {/* Track Artwork with Flair */}
@@ -87,8 +88,8 @@ const SubmissionCard = ({ submission }: { submission: LineupData }) => {
             </TrackFlair>
             {/* User Avatar */}
             <Box
-              h={userAvatarSize}
-              w={userAvatarSize}
+              h={USER_AVATAR_SIZE}
+              w={USER_AVATAR_SIZE}
               css={{ position: 'absolute', top: -8, right: -8 }}
               borderRadius='circle'
             >
@@ -108,8 +109,20 @@ const SubmissionCard = ({ submission }: { submission: LineupData }) => {
           </>
         ) : (
           <>
-            <TrackLink textVariant='title' size='s' trackId={track.track_id} />
-            <UserLink userId={user.user_id} size='s' noOverflow />
+            <TrackLink
+              textVariant='title'
+              size='s'
+              trackId={track.track_id}
+              css={{ display: 'block', maxWidth: NAME_WIDTH }}
+              ellipses
+            />
+            <UserLink
+              userId={user.user_id}
+              size='s'
+              noOverflow
+              ellipses
+              css={{ display: 'block', maxWidth: NAME_WIDTH }}
+            />
           </>
         )}
       </Flex>


### PR DESCRIPTION
### Description

Ellipsize track and artist names in remix submissions section.

Bit of a scary change to harmony `TextPressable` component but app looks ok after this change. cc @dylanjeffers. Was needed to pass `maxWidth` along to the wrapper component.

### How Has This Been Tested?

web
<img width="570" alt="Screenshot 2025-04-28 at 2 24 22 PM" src="https://github.com/user-attachments/assets/c5d2b546-a94b-4c15-8d34-e1e168817872" />

mobile-web
<img width="503" alt="Screenshot 2025-04-28 at 2 27 28 PM" src="https://github.com/user-attachments/assets/46ce8341-b717-4a1d-9e5f-ddcd7ba1e338" />

mobile
![Simulator Screenshot - iPhone 16 Pro - 2025-04-28 at 15 00 10](https://github.com/user-attachments/assets/352fb728-f18b-4f10-9a65-9f48d453fadd)
