### PR TITLE
[PE-6051] Fix scrolling inside remix contest info

### DIFF
--- a/packages/mobile/ios/Podfile.lock
+++ b/packages/mobile/ios/Podfile.lock
@@ -1437,7 +1437,7 @@ PODS:
     - React-Core
   - react-native-notifications (5.1.0):
     - React-Core
-  - react-native-pager-view (6.4.0):
+  - react-native-pager-view (6.7.1):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -2471,7 +2471,7 @@ SPEC CHECKSUMS:
   react-native-keep-awake: ad1d67f617756b139536977a0bf06b27cec0714a
   react-native-netinfo: 8a7fd3f7130ef4ad2fb4276d5c9f8d3f28d2df3d
   react-native-notifications: 4601a5a8db4ced6ae7cfc43b44d35fe437ac50c4
-  react-native-pager-view: d9c1185fdb50e28e25a1d79c5d1094c50789e424
+  react-native-pager-view: ad90e78510ae4cb5f91d8b0d7ebb8a794c2ad266
   react-native-randombytes: 421f1c7d48c0af8dbcd471b0324393ebf8fe7846
   react-native-restart: 7595693413fe3ca15893702f2c8306c62a708162
   react-native-safe-area-context: 3e6db312a77016d4f618550c814d9e236e0c0879

--- a/packages/mobile/package.json
+++ b/packages/mobile/package.json
@@ -146,7 +146,7 @@
     "react-native-modal": "13.0.1",
     "react-native-modal-datetime-picker": "17.1.0",
     "react-native-notifications": "5.1.0",
-    "react-native-pager-view": "6.4.0",
+    "react-native-pager-view": "6.7.1",
     "react-native-permissions": "4.0.1",
     "react-native-qrcode-svg": "6.2.0",
     "react-native-radial-gradient": "1.1.4",

--- a/packages/mobile/patches/react-native-pager-view+6.7.1.patch
+++ b/packages/mobile/patches/react-native-pager-view+6.7.1.patch
@@ -1,110 +1,34 @@
 diff --git a/node_modules/react-native-pager-view/ios/Fabric/RNCPagerViewComponentView.mm b/node_modules/react-native-pager-view/ios/Fabric/RNCPagerViewComponentView.mm
-index 652a5c1..c7de2e9 100644
+index 652a5c1..9141b23 100644
 --- a/node_modules/react-native-pager-view/ios/Fabric/RNCPagerViewComponentView.mm
 +++ b/node_modules/react-native-pager-view/ios/Fabric/RNCPagerViewComponentView.mm
-@@ -14,7 +14,7 @@
- 
- using namespace facebook::react;
- 
--@interface RNCPagerViewComponentView () <RCTRNCViewPagerViewProtocol, UIPageViewControllerDataSource, UIPageViewControllerDelegate, UIScrollViewDelegate, UIGestureRecognizerDelegate>
-+@interface RNCPagerViewComponentView () <RCTRNCViewPagerViewProtocol, UIPageViewControllerDataSource, UIPageViewControllerDelegate, UIScrollViewDelegate>
- 
- @property(nonatomic, assign) UIPanGestureRecognizer* panGestureRecognizer;
- 
-@@ -73,11 +73,6 @@ using namespace facebook::react;
-         _destinationIndex = -1;
-         _layoutDirection = @"ltr";
-         _overdrag = NO;
--        UIPanGestureRecognizer* panGestureRecognizer = [UIPanGestureRecognizer new];
--        self.panGestureRecognizer = panGestureRecognizer;
--        panGestureRecognizer.delegate = self;
--        [self addGestureRecognizer: panGestureRecognizer];
--
+@@ -439,6 +439,13 @@ using namespace facebook::react;
+         
+         return YES;
      }
-     
-     return self;
-@@ -421,29 +416,6 @@ using namespace facebook::react;
- }
- 
- 
--- (BOOL)gestureRecognizer:(UIGestureRecognizer *)gestureRecognizer shouldRecognizeSimultaneouslyWithGestureRecognizer:(UIGestureRecognizer *)otherGestureRecognizer {
--
--    // Recognize simultaneously only if the other gesture is RN Screen's pan gesture (one that is used to perform fullScreenGestureEnabled)
--    if (gestureRecognizer == self.panGestureRecognizer && [NSStringFromClass([otherGestureRecognizer class]) isEqual: @"RNSPanGestureRecognizer"]) {
--        UIPanGestureRecognizer* panGestureRecognizer = (UIPanGestureRecognizer*) gestureRecognizer;
--        CGPoint velocity = [panGestureRecognizer velocityInView:self];
--        BOOL isLTR = [self isLtrLayout];
--        BOOL isBackGesture = (isLTR && velocity.x > 0) || (!isLTR && velocity.x < 0);
--        
--        if (self.currentIndex == 0 && isBackGesture) {
--            scrollView.panGestureRecognizer.enabled = false;
--        } else {
--            const auto &viewProps = *std::static_pointer_cast<const RNCViewPagerProps>(_props);
--            scrollView.panGestureRecognizer.enabled = viewProps.scrollEnabled;
--        }
--        
--        return YES;
--    }
--    const auto &viewProps = *std::static_pointer_cast<const RNCViewPagerProps>(_props);
--    scrollView.panGestureRecognizer.enabled = viewProps.scrollEnabled;
--    return NO;
--}
--
- @end
- 
- Class<RCTComponentViewProtocol> RNCViewPagerCls(void)
++
++
++    // Allow nested scroll views to scroll simultaneously with the pager
++    if ([otherGestureRecognizer.view isKindOfClass: UIScrollView.class]) {
++        return YES;
++    }
++
+     const auto &viewProps = *std::static_pointer_cast<const RNCViewPagerProps>(_props);
+     scrollView.panGestureRecognizer.enabled = viewProps.scrollEnabled;
+     return NO;
 diff --git a/node_modules/react-native-pager-view/ios/RNCPagerView.m b/node_modules/react-native-pager-view/ios/RNCPagerView.m
-index 507b45d..4253edc 100644
+index 507b45d..cdd95c3 100644
 --- a/node_modules/react-native-pager-view/ios/RNCPagerView.m
 +++ b/node_modules/react-native-pager-view/ios/RNCPagerView.m
-@@ -8,9 +8,7 @@
- #import "RCTOnPageSelected.h"
- #import <math.h>
- 
--@interface RNCPagerView () <UIPageViewControllerDataSource, UIPageViewControllerDelegate, UIScrollViewDelegate, UIGestureRecognizerDelegate>
--
--@property(nonatomic, assign) UIPanGestureRecognizer* panGestureRecognizer;
-+@interface RNCPagerView () <UIPageViewControllerDataSource, UIPageViewControllerDelegate, UIScrollViewDelegate>
- 
- @property(nonatomic, strong) UIPageViewController *reactPageViewController;
- @property(nonatomic, strong) RCTEventDispatcher *eventDispatcher;
-@@ -48,10 +46,6 @@
-         _cachedControllers = [NSHashTable hashTableWithOptions:NSHashTableStrongMemory];
-         _overdrag = NO;
-         _layoutDirection = @"ltr";
--        UIPanGestureRecognizer* panGestureRecognizer = [UIPanGestureRecognizer new];
--        self.panGestureRecognizer = panGestureRecognizer;
--        panGestureRecognizer.delegate = self;
--        [self addGestureRecognizer: panGestureRecognizer];
+@@ -492,6 +492,11 @@
+         return YES;
      }
-     return self;
- }
-@@ -474,28 +468,6 @@
-     return scrollDirection;
- }
  
--- (BOOL)gestureRecognizer:(UIGestureRecognizer *)gestureRecognizer shouldRecognizeSimultaneouslyWithGestureRecognizer:(UIGestureRecognizer *)otherGestureRecognizer {
--
--    // Recognize simultaneously only if the other gesture is RN Screen's pan gesture (one that is used to perform fullScreenGestureEnabled)
--    if (gestureRecognizer == self.panGestureRecognizer && [NSStringFromClass([otherGestureRecognizer class]) isEqual: @"RNSPanGestureRecognizer"]) {
--        UIPanGestureRecognizer* panGestureRecognizer = (UIPanGestureRecognizer*) gestureRecognizer;
--        CGPoint velocity = [panGestureRecognizer velocityInView:self];
--        BOOL isLTR = [self isLtrLayout];
--        BOOL isBackGesture = (isLTR && velocity.x > 0) || (!isLTR && velocity.x < 0);
--        
--        if (self.currentIndex == 0 && isBackGesture) {
--            self.scrollView.panGestureRecognizer.enabled = false;
--        } else {
--            self.scrollView.panGestureRecognizer.enabled = self.scrollEnabled;
--        }
--        
--        return YES;
--    }
--    
--    self.scrollView.panGestureRecognizer.enabled = self.scrollEnabled;
--    return NO;
--}
--
- - (BOOL)isLtrLayout {
-     return [_layoutDirection isEqualToString:@"ltr"];
++    // Allow nested scroll views to scroll simultaneously with the pager
++    if ([otherGestureRecognizer.view isKindOfClass: UIScrollView.class]) {
++        return YES;
++    }
++    
+     self.scrollView.panGestureRecognizer.enabled = self.scrollEnabled;
+     return NO;
  }

--- a/packages/mobile/patches/react-native-pager-view+6.7.1.patch
+++ b/packages/mobile/patches/react-native-pager-view+6.7.1.patch
@@ -1,0 +1,110 @@
+diff --git a/node_modules/react-native-pager-view/ios/Fabric/RNCPagerViewComponentView.mm b/node_modules/react-native-pager-view/ios/Fabric/RNCPagerViewComponentView.mm
+index 652a5c1..c7de2e9 100644
+--- a/node_modules/react-native-pager-view/ios/Fabric/RNCPagerViewComponentView.mm
++++ b/node_modules/react-native-pager-view/ios/Fabric/RNCPagerViewComponentView.mm
+@@ -14,7 +14,7 @@
+ 
+ using namespace facebook::react;
+ 
+-@interface RNCPagerViewComponentView () <RCTRNCViewPagerViewProtocol, UIPageViewControllerDataSource, UIPageViewControllerDelegate, UIScrollViewDelegate, UIGestureRecognizerDelegate>
++@interface RNCPagerViewComponentView () <RCTRNCViewPagerViewProtocol, UIPageViewControllerDataSource, UIPageViewControllerDelegate, UIScrollViewDelegate>
+ 
+ @property(nonatomic, assign) UIPanGestureRecognizer* panGestureRecognizer;
+ 
+@@ -73,11 +73,6 @@ using namespace facebook::react;
+         _destinationIndex = -1;
+         _layoutDirection = @"ltr";
+         _overdrag = NO;
+-        UIPanGestureRecognizer* panGestureRecognizer = [UIPanGestureRecognizer new];
+-        self.panGestureRecognizer = panGestureRecognizer;
+-        panGestureRecognizer.delegate = self;
+-        [self addGestureRecognizer: panGestureRecognizer];
+-
+     }
+     
+     return self;
+@@ -421,29 +416,6 @@ using namespace facebook::react;
+ }
+ 
+ 
+-- (BOOL)gestureRecognizer:(UIGestureRecognizer *)gestureRecognizer shouldRecognizeSimultaneouslyWithGestureRecognizer:(UIGestureRecognizer *)otherGestureRecognizer {
+-
+-    // Recognize simultaneously only if the other gesture is RN Screen's pan gesture (one that is used to perform fullScreenGestureEnabled)
+-    if (gestureRecognizer == self.panGestureRecognizer && [NSStringFromClass([otherGestureRecognizer class]) isEqual: @"RNSPanGestureRecognizer"]) {
+-        UIPanGestureRecognizer* panGestureRecognizer = (UIPanGestureRecognizer*) gestureRecognizer;
+-        CGPoint velocity = [panGestureRecognizer velocityInView:self];
+-        BOOL isLTR = [self isLtrLayout];
+-        BOOL isBackGesture = (isLTR && velocity.x > 0) || (!isLTR && velocity.x < 0);
+-        
+-        if (self.currentIndex == 0 && isBackGesture) {
+-            scrollView.panGestureRecognizer.enabled = false;
+-        } else {
+-            const auto &viewProps = *std::static_pointer_cast<const RNCViewPagerProps>(_props);
+-            scrollView.panGestureRecognizer.enabled = viewProps.scrollEnabled;
+-        }
+-        
+-        return YES;
+-    }
+-    const auto &viewProps = *std::static_pointer_cast<const RNCViewPagerProps>(_props);
+-    scrollView.panGestureRecognizer.enabled = viewProps.scrollEnabled;
+-    return NO;
+-}
+-
+ @end
+ 
+ Class<RCTComponentViewProtocol> RNCViewPagerCls(void)
+diff --git a/node_modules/react-native-pager-view/ios/RNCPagerView.m b/node_modules/react-native-pager-view/ios/RNCPagerView.m
+index 507b45d..4253edc 100644
+--- a/node_modules/react-native-pager-view/ios/RNCPagerView.m
++++ b/node_modules/react-native-pager-view/ios/RNCPagerView.m
+@@ -8,9 +8,7 @@
+ #import "RCTOnPageSelected.h"
+ #import <math.h>
+ 
+-@interface RNCPagerView () <UIPageViewControllerDataSource, UIPageViewControllerDelegate, UIScrollViewDelegate, UIGestureRecognizerDelegate>
+-
+-@property(nonatomic, assign) UIPanGestureRecognizer* panGestureRecognizer;
++@interface RNCPagerView () <UIPageViewControllerDataSource, UIPageViewControllerDelegate, UIScrollViewDelegate>
+ 
+ @property(nonatomic, strong) UIPageViewController *reactPageViewController;
+ @property(nonatomic, strong) RCTEventDispatcher *eventDispatcher;
+@@ -48,10 +46,6 @@
+         _cachedControllers = [NSHashTable hashTableWithOptions:NSHashTableStrongMemory];
+         _overdrag = NO;
+         _layoutDirection = @"ltr";
+-        UIPanGestureRecognizer* panGestureRecognizer = [UIPanGestureRecognizer new];
+-        self.panGestureRecognizer = panGestureRecognizer;
+-        panGestureRecognizer.delegate = self;
+-        [self addGestureRecognizer: panGestureRecognizer];
+     }
+     return self;
+ }
+@@ -474,28 +468,6 @@
+     return scrollDirection;
+ }
+ 
+-- (BOOL)gestureRecognizer:(UIGestureRecognizer *)gestureRecognizer shouldRecognizeSimultaneouslyWithGestureRecognizer:(UIGestureRecognizer *)otherGestureRecognizer {
+-
+-    // Recognize simultaneously only if the other gesture is RN Screen's pan gesture (one that is used to perform fullScreenGestureEnabled)
+-    if (gestureRecognizer == self.panGestureRecognizer && [NSStringFromClass([otherGestureRecognizer class]) isEqual: @"RNSPanGestureRecognizer"]) {
+-        UIPanGestureRecognizer* panGestureRecognizer = (UIPanGestureRecognizer*) gestureRecognizer;
+-        CGPoint velocity = [panGestureRecognizer velocityInView:self];
+-        BOOL isLTR = [self isLtrLayout];
+-        BOOL isBackGesture = (isLTR && velocity.x > 0) || (!isLTR && velocity.x < 0);
+-        
+-        if (self.currentIndex == 0 && isBackGesture) {
+-            self.scrollView.panGestureRecognizer.enabled = false;
+-        } else {
+-            self.scrollView.panGestureRecognizer.enabled = self.scrollEnabled;
+-        }
+-        
+-        return YES;
+-    }
+-    
+-    self.scrollView.panGestureRecognizer.enabled = self.scrollEnabled;
+-    return NO;
+-}
+-
+ - (BOOL)isLtrLayout {
+     return [_layoutDirection isEqualToString:@"ltr"];
+ }


### PR DESCRIPTION
### Description

Fixes issue where react-native-tab-view blocked vertical swipe gestures, preventing the screen from scrolling when user touched the remix-content-info.

The bug ultimately derived from 'react-native-pager-view' https://github.com/react-navigation/react-navigation/issues/11952
Searching their issues I came across this, which describes the issue: https://github.com/callstack/react-native-pager-view/issues/745

This open PR fixes the issue: https://github.com/callstack/react-native-pager-view/pull/933 🔥 

To fix on our end:
1. Upgrade react-native-pager-view to latest
2. Manually apply the pr outlined above and create a patch for it


NOTE: Their may be a regression on the profile tabs as a result, looking into this. The fix may be to make this code a conditional prop rather than deleting it.