### PR TITLE
[PE-6076] Deprecate useGetUserTracksByHandle (a-query)

### DIFF
--- a/packages/common/src/api/index.ts
+++ b/packages/common/src/api/index.ts
@@ -111,6 +111,7 @@ export * from './tan-query/users/useUserByParams'
 export * from './tan-query/users/useUserCollectibles'
 export * from './tan-query/users/useUserPlaylists'
 export * from './tan-query/users/useUsers'
+export * from './tan-query/users/useUserTracksByHandle'
 
 // Wallet logic
 export * from './tan-query/wallets/useAudioBalance'

--- a/packages/common/src/api/track.ts
+++ b/packages/common/src/api/track.ts
@@ -94,40 +94,11 @@ const trackApi = createApi({
         kind: Kind.TRACKS,
         schemaKey: 'tracks'
       }
-    },
-    getUserTracksByHandle: {
-      fetch: async (
-        {
-          currentUserId,
-          filterTracks = 'public',
-          sort = 'date',
-          ...params
-        }: SDKRequest<full.GetTracksByUserHandleRequest>,
-        { audiusSdk }
-      ) => {
-        const sdk = await audiusSdk()
-        const { data = [] } = await sdk.full.users.getTracksByUserHandle({
-          ...params,
-          userId: OptionalId.parse(currentUserId),
-          sort,
-          filterTracks
-        })
-        return transformAndCleanList(data, userTrackMetadataFromSDK)
-      },
-      options: {
-        idListArgKey: 'ids',
-        kind: Kind.TRACKS,
-        schemaKey: 'tracks'
-      }
     }
   }
 })
 
-export const {
-  useGetTrackByPermalink,
-  useGetTracksByIds,
-  useGetUserTracksByHandle
-} = trackApi.hooks
+export const { useGetTrackByPermalink, useGetTracksByIds } = trackApi.hooks
 export const trackApiFetch = trackApi.fetch
 export const trackApiReducer = trackApi.reducer
 export const trackApiActions = trackApi.actions

--- a/packages/mobile/src/screens/sign-on-screen/screens/SelectArtistScreen/selectArtistPreviewContext.tsx
+++ b/packages/mobile/src/screens/sign-on-screen/screens/SelectArtistScreen/selectArtistPreviewContext.tsx
@@ -1,9 +1,9 @@
 import { createContext, useCallback, useEffect, useMemo, useState } from 'react'
 
 import {
-  useGetUserTracksByHandle,
   useGetUserById,
-  useGetCurrentUserId
+  useGetCurrentUserId,
+  useUserTracksByHandle
 } from '@audius/common/api'
 import { type ID } from '@audius/common/models'
 import { Id, OptionalId } from '@audius/sdk'
@@ -51,13 +51,11 @@ export const SelectArtistsPreviewContextProvider = (props: {
     { disabled: nowPlayingArtistId === -1 }
   )
 
-  const { data: artistTracks } = useGetUserTracksByHandle(
-    {
-      handle: artist?.handle ?? '',
-      currentUserId: null
-    },
-    { disabled: !artist?.handle }
-  )
+  const { data: artistTracks } = useUserTracksByHandle({
+    handle: artist?.handle,
+    // We just need one playable track. It's unlikely all 3 of an artist's tracks are unavailable.
+    limit: 3
+  })
   useEffect(() => {
     if (!nowPlayingArtistId || !currentUserId || !artistTracks) return
 

--- a/packages/mobile/src/screens/sign-on-screen/screens/SelectArtistScreen/selectArtistPreviewContext.tsx
+++ b/packages/mobile/src/screens/sign-on-screen/screens/SelectArtistScreen/selectArtistPreviewContext.tsx
@@ -53,7 +53,7 @@ export const SelectArtistsPreviewContextProvider = (props: {
 
   const { data: artistTracks } = useUserTracksByHandle({
     handle: artist?.handle,
-    // We just need one playable track. It's unlikely all 3 of an artist's tracks are unavailable.
+    // We just need one playable track. It's unlikely all 3 of an artist's top tracks are unavailable.
     limit: 3
   })
   useEffect(() => {

--- a/packages/web/src/components/follow-artist-card/selectArtistsPreviewContext.tsx
+++ b/packages/web/src/components/follow-artist-card/selectArtistsPreviewContext.tsx
@@ -1,7 +1,7 @@
 import { createContext, useCallback, useEffect, useState } from 'react'
 
-import { useGetUserTracksByHandle, useGetUserById } from '@audius/common/api'
-import { ID, UserTrackMetadata } from '@audius/common/models'
+import { useGetUserById, useUserTracksByHandle } from '@audius/common/api'
+import { ID, Track } from '@audius/common/models'
 import { PlayerBehavior, playerActions } from '@audius/common/store'
 import { useDispatch } from 'react-redux'
 import { useUnmount } from 'react-use'
@@ -29,7 +29,7 @@ export const SelectArtistsPreviewContextProvider = (props: {
 }) => {
   const [isPlaying, setIsPlaying] = useState(false)
   const [nowPlayingArtistId, setNowPlayingArtistId] = useState<number>(-1)
-  const [track, setTrack] = useState<UserTrackMetadata | null>(null)
+  const [track, setTrack] = useState<Track | null>(null)
   const dispatch = useDispatch()
 
   const { data: artist } = useGetUserById(
@@ -39,15 +39,11 @@ export const SelectArtistsPreviewContextProvider = (props: {
     },
     { disabled: nowPlayingArtistId === -1 }
   )
-  const { data: artistTracks } = useGetUserTracksByHandle(
-    {
-      handle: artist?.handle || '',
-      currentUserId: null,
-      // Unlikely we cant play an artist's first 3 tracks.
-      limit: 3
-    },
-    { disabled: !artist?.handle }
-  )
+  const { data: artistTracks } = useUserTracksByHandle({
+    handle: artist?.handle || '',
+    // We just need one playable track. It's unlikely all 3 of an artist's tracks are unavailable.
+    limit: 3
+  })
 
   useEffect(() => {
     const track = artistTracks?.find((track) => track.is_available)
@@ -117,7 +113,7 @@ export const SelectArtistsPreviewContextProvider = (props: {
 
     const { track_id, preview_cid, duration } = track
     // Sometimes we rerender before the next track starts playing, so we need to double check the track matches the artist
-    if (track.user.user_id !== nowPlayingArtistId) return
+    if (artist?.user_id !== nowPlayingArtistId) return
     const isPreview = !!preview_cid
     const startTime = isPreview
       ? undefined
@@ -142,7 +138,7 @@ export const SelectArtistsPreviewContextProvider = (props: {
     )
 
     setIsPlaying(true)
-  }, [nowPlayingArtistId, stopPreview, track, dispatch])
+  }, [nowPlayingArtistId, stopPreview, track, dispatch, artist?.user_id])
 
   useUnmount(stopPreview)
 

--- a/packages/web/src/components/follow-artist-card/selectArtistsPreviewContext.tsx
+++ b/packages/web/src/components/follow-artist-card/selectArtistsPreviewContext.tsx
@@ -40,8 +40,8 @@ export const SelectArtistsPreviewContextProvider = (props: {
     { disabled: nowPlayingArtistId === -1 }
   )
   const { data: artistTracks } = useUserTracksByHandle({
-    handle: artist?.handle || '',
-    // We just need one playable track. It's unlikely all 3 of an artist's tracks are unavailable.
+    handle: artist?.handle,
+    // We just need one playable track. It's unlikely all 3 of an artist's top tracks are unavailable.
     limit: 3
   })
 


### PR DESCRIPTION
### Description

- Replace useGetUserTracksByHandle (a-query) with useUserTracksByHandle (tan-query)

### How Has This Been Tested?

ios:stage & web:stage sign up 
