### PR TITLE
Add batching for events by entity ID

### DIFF
--- a/packages/common/src/api/tan-query/batchers/getEventsByEntityIdBatcher.ts
+++ b/packages/common/src/api/tan-query/batchers/getEventsByEntityIdBatcher.ts
@@ -1,5 +1,5 @@
 import { Id, OptionalId } from '@audius/sdk'
-import { create, keyResolver, windowScheduler } from '@yornaath/batshit'
+import { create, windowScheduler } from '@yornaath/batshit'
 import { memoize } from 'lodash'
 
 import { eventMetadataListFromSDK } from '~/adapters/event'

--- a/packages/common/src/api/tan-query/batchers/getEventsByEntityIdBatcher.ts
+++ b/packages/common/src/api/tan-query/batchers/getEventsByEntityIdBatcher.ts
@@ -1,0 +1,29 @@
+import { Id, OptionalId } from '@audius/sdk'
+import { create, keyResolver, windowScheduler } from '@yornaath/batshit'
+import { memoize } from 'lodash'
+
+import { eventMetadataListFromSDK } from '~/adapters/event'
+import { ID, Event } from '~/models'
+
+import { contextCacheResolver } from './contextCacheResolver'
+import { BatchContext } from './types'
+
+export const getEventsByEntityIdBatcher = memoize(
+  (context: BatchContext) =>
+    create({
+      fetcher: async (entityIds: ID[]): Promise<Event[]> => {
+        const { sdk, currentUserId } = context
+        if (!entityIds.length) return []
+        const { data } = await sdk.events.getEntityEvents({
+          entityId: entityIds.map((entityId) => Id.parse(entityId)),
+          userId: OptionalId.parse(currentUserId)
+        })
+
+        return eventMetadataListFromSDK(data)
+      },
+      resolver: (events: Event[], entityId: ID) =>
+        events.filter((event) => event.entityId === entityId), // resolve array of events for entity ID
+      scheduler: windowScheduler(10)
+    }),
+  contextCacheResolver()
+)

--- a/packages/common/src/api/tan-query/events/useEventsByEntityId.ts
+++ b/packages/common/src/api/tan-query/events/useEventsByEntityId.ts
@@ -1,28 +1,27 @@
 import { useMemo } from 'react'
 
-import { Id, OptionalId } from '@audius/sdk'
 import { useQuery, useQueryClient } from '@tanstack/react-query'
+import { useDispatch } from 'react-redux'
 
-import { eventMetadataFromSDK } from '~/adapters/event'
 import { useAudiusQueryContext } from '~/audius-query'
 import { ID } from '~/models'
-import { removeNullable } from '~/utils'
 
+import { getEventsByEntityIdBatcher } from '../batchers/getEventsByEntityIdBatcher'
 import { SelectableQueryOptions } from '../types'
 import { useCurrentUserId } from '../useCurrentUserId'
 
 import {
   getEventIdsByEntityIdQueryKey,
-  EventIdsByEntityIdOptions,
-  getEventQueryKey
+  EventIdsByEntityIdOptions
 } from './utils'
 
 export const useEventIdsByEntityId = (
   args: EventIdsByEntityIdOptions,
   options?: SelectableQueryOptions<ID[]>
 ) => {
-  const { entityId, ...restArgs } = args ?? {}
+  const { entityId } = args ?? {}
   const { audiusSdk } = useAudiusQueryContext()
+  const dispatch = useDispatch()
   const { data: currentUserId } = useCurrentUserId()
   const queryClient = useQueryClient()
 
@@ -33,21 +32,17 @@ export const useEventIdsByEntityId = (
     queryKey: getEventIdsByEntityIdQueryKey(args),
     queryFn: async () => {
       const sdk = await audiusSdk()
-      const response = await sdk.events.getEntityEvents({
-        entityId: Id.parse(entityId),
-        userId: OptionalId.parse(currentUserId),
-        ...restArgs
-      })
-      const events = response.data ?? []
-      const eventsMetadata = events
-        .map(eventMetadataFromSDK)
-        .filter(removeNullable)
 
-      eventsMetadata.forEach((event) => {
-        queryClient.setQueryData(getEventQueryKey(event.eventId), event)
+      const batchGetEvents = getEventsByEntityIdBatcher({
+        sdk,
+        currentUserId,
+        queryClient,
+        dispatch
       })
 
-      return eventsMetadata.map((event) => event.eventId)
+      const events = await batchGetEvents.fetch(entityId!)
+
+      return events.map((event) => event.eventId)
     },
     ...options,
     enabled: options?.enabled !== false && !!entityId,

--- a/packages/discovery-provider/src/api/v1/events.py
+++ b/packages/discovery-provider/src/api/v1/events.py
@@ -4,7 +4,6 @@ from src.api.v1.helpers import (
     abort_not_found,
     current_user_parser,
     decode_ids_array,
-    decode_with_abort,
     format_limit,
     format_offset,
     make_response,
@@ -120,6 +119,7 @@ entity_events_parser.add_argument(
     "entity_id",
     required=True,
     type=str,
+    action="append",
     description="The ID of the entity to get events for",
 )
 entity_events_parser.add_argument(
@@ -139,7 +139,7 @@ entity_events_parser.add_argument(
 
 
 @ns.route("/entity")
-class EntityEvents(Resource):
+class BulkEntityEvents(Resource):
     @ns.doc(
         id="Get Entity Events",
         description="Get events for a specific entity",
@@ -151,10 +151,13 @@ class EntityEvents(Resource):
     def get(self):
         """Get events for a specific entity"""
         args = entity_events_parser.parse_args()
-        decoded_entity_id = decode_with_abort(args.get("entity_id"), ns)
+        decoded_entity_ids = decode_ids_array(
+            args.get("entity_id") if args.get("entity_id") else []
+        )
+
         events = get_events(
             {
-                "entity_id": decoded_entity_id,
+                "entity_ids": decoded_entity_ids,
                 "entity_type": args.get("entity_type"),
                 "filter_deleted": args.get("filter_deleted", True),
                 "limit": format_limit(args),

--- a/packages/discovery-provider/src/queries/get_events.py
+++ b/packages/discovery-provider/src/queries/get_events.py
@@ -64,8 +64,8 @@ def get_events_by_ids(args) -> List[Event]:
             query = query.filter(Event.event_id.in_(ids))
         if args.get("event_type") is not None:
             query = query.filter(Event.event_type == args.get("event_type"))
-        events = query.all()
 
+        events = helpers.query_result_to_list(query.all())
         return format_events(events)
 
 
@@ -74,9 +74,9 @@ def _get_events(session, args):
     # Create initial query
     base_query = session.query(Event)
 
-    # Filter by entity_id if provided
-    if args.get("entity_id") is not None:
-        base_query = base_query.filter(Event.entity_id == args.get("entity_id"))
+    # Filter by entity_ids if provided
+    if args.get("entity_ids") is not None:
+        base_query = base_query.filter(Event.entity_id.in_(args.get("entity_ids")))
 
     # Filter by entity_type if provided
     if args.get("entity_type") is not None:

--- a/packages/sdk/src/sdk/api/generated/default/apis/EventsApi.ts
+++ b/packages/sdk/src/sdk/api/generated/default/apis/EventsApi.ts
@@ -41,7 +41,7 @@ export interface GetBulkEventsRequest {
 }
 
 export interface GetEntityEventsRequest {
-    entityId: string;
+    entityId: Array<string>;
     offset?: number;
     limit?: number;
     userId?: string;
@@ -166,7 +166,7 @@ export class EventsApi extends runtime.BaseAPI {
             queryParameters['user_id'] = params.userId;
         }
 
-        if (params.entityId !== undefined) {
+        if (params.entityId) {
             queryParameters['entity_id'] = params.entityId;
         }
 

--- a/packages/sdk/src/sdk/config/staging.ts
+++ b/packages/sdk/src/sdk/config/staging.ts
@@ -5,104 +5,102 @@
 /* eslint-disable prettier/prettier */
 import type { SdkServicesConfig } from './types'
 export const stagingConfig: SdkServicesConfig = {
-  network: {
-    minVersion: '0.6.0',
-    apiEndpoint: 'https://api.staging.audius.co',
-    discoveryNodes: [
+  "network": {
+    "minVersion": "0.6.0",
+    "apiEndpoint": "https://api.staging.audius.co",
+    "discoveryNodes": [
       {
-        endpoint: 'https://discoveryprovider.staging.audius.co',
-        ownerWallet: '0x8fcFA10Bd3808570987dbb5B1EF4AB74400FbfDA',
-        delegateOwnerWallet: '0x8fcFA10Bd3808570987dbb5B1EF4AB74400FbfDA'
+        "endpoint": "https://discoveryprovider.staging.audius.co",
+        "ownerWallet": "0x8fcFA10Bd3808570987dbb5B1EF4AB74400FbfDA",
+        "delegateOwnerWallet": "0x8fcFA10Bd3808570987dbb5B1EF4AB74400FbfDA"
       },
       {
-        endpoint: 'https://discoveryprovider2.staging.audius.co',
-        ownerWallet: '0x5E98cBEEAA2aCEDEc0833AC3D1634E2A7aE0f3c2',
-        delegateOwnerWallet: '0x5E98cBEEAA2aCEDEc0833AC3D1634E2A7aE0f3c2'
+        "endpoint": "https://discoveryprovider2.staging.audius.co",
+        "ownerWallet": "0x5E98cBEEAA2aCEDEc0833AC3D1634E2A7aE0f3c2",
+        "delegateOwnerWallet": "0x5E98cBEEAA2aCEDEc0833AC3D1634E2A7aE0f3c2"
       },
       {
-        endpoint: 'https://discoveryprovider3.staging.audius.co',
-        ownerWallet: '0xf7C96916bd37Ad76D4EEDd6536B81c29706C8056',
-        delegateOwnerWallet: '0xf7C96916bd37Ad76D4EEDd6536B81c29706C8056'
+        "endpoint": "https://discoveryprovider3.staging.audius.co",
+        "ownerWallet": "0xf7C96916bd37Ad76D4EEDd6536B81c29706C8056",
+        "delegateOwnerWallet": "0xf7C96916bd37Ad76D4EEDd6536B81c29706C8056"
       },
       {
-        endpoint: 'https://discoveryprovider5.staging.audius.co',
-        ownerWallet: '0x8311f59B72522e728231dC60226359A51878F9A1',
-        delegateOwnerWallet: '0x8311f59B72522e728231dC60226359A51878F9A1'
+        "endpoint": "https://discoveryprovider5.staging.audius.co",
+        "ownerWallet": "0x8311f59B72522e728231dC60226359A51878F9A1",
+        "delegateOwnerWallet": "0x8311f59B72522e728231dC60226359A51878F9A1"
       }
     ],
-    storageNodes: [
+    "storageNodes": [
       {
-        endpoint: 'https://creatornode10.staging.audius.co',
-        delegateOwnerWallet: '0xf7C96916bd37Ad76D4EEDd6536B81c29706C8056'
+        "endpoint": "https://creatornode10.staging.audius.co",
+        "delegateOwnerWallet": "0xf7C96916bd37Ad76D4EEDd6536B81c29706C8056"
       },
       {
-        endpoint: 'https://creatornode8.staging.audius.co',
-        delegateOwnerWallet: '0x8fcFA10Bd3808570987dbb5B1EF4AB74400FbfDA'
+        "endpoint": "https://creatornode8.staging.audius.co",
+        "delegateOwnerWallet": "0x8fcFA10Bd3808570987dbb5B1EF4AB74400FbfDA"
       },
       {
-        endpoint: 'https://creatornode12.staging.audius.co',
-        delegateOwnerWallet: '0x6b52969934076318863243fb92E9C4b3A08267b5'
+        "endpoint": "https://creatornode12.staging.audius.co",
+        "delegateOwnerWallet": "0x6b52969934076318863243fb92E9C4b3A08267b5"
       },
       {
-        endpoint: 'https://creatornode5.staging.audius.co',
-        delegateOwnerWallet: '0xDC2BDF1F23381CA2eC9e9c70D4FD96CD8645D090'
+        "endpoint": "https://creatornode5.staging.audius.co",
+        "delegateOwnerWallet": "0xDC2BDF1F23381CA2eC9e9c70D4FD96CD8645D090"
       },
       {
-        endpoint: 'https://creatornode6.staging.audius.co',
-        delegateOwnerWallet: '0x68039d001D87E7A5E6B06fe0825EA7871C1Cd6C2'
+        "endpoint": "https://creatornode6.staging.audius.co",
+        "delegateOwnerWallet": "0x68039d001D87E7A5E6B06fe0825EA7871C1Cd6C2"
       },
       {
-        endpoint: 'https://creatornode7.staging.audius.co',
-        delegateOwnerWallet: '0x1F8e7aF58086992Ef4c4fc0371446974BBbC0D9F'
+        "endpoint": "https://creatornode7.staging.audius.co",
+        "delegateOwnerWallet": "0x1F8e7aF58086992Ef4c4fc0371446974BBbC0D9F"
       },
       {
-        endpoint: 'https://creatornode9.staging.audius.co',
-        delegateOwnerWallet: '0x140eD283b33be2145ed7d9d15f1fE7bF1E0B2Ac3'
+        "endpoint": "https://creatornode9.staging.audius.co",
+        "delegateOwnerWallet": "0x140eD283b33be2145ed7d9d15f1fE7bF1E0B2Ac3"
       },
       {
-        endpoint: 'https://creatornode11.staging.audius.co',
-        delegateOwnerWallet: '0x4c88d2c0f4c4586b41621aD6e98882ae904B98f6'
+        "endpoint": "https://creatornode11.staging.audius.co",
+        "delegateOwnerWallet": "0x4c88d2c0f4c4586b41621aD6e98882ae904B98f6"
       }
     ],
-    antiAbuseOracleNodes: {
-      endpoints: ['https://discoveryprovider.staging.audius.co'],
-      registeredAddresses: [
-        '0x00b6462e955dA5841b6D9e1E2529B830F00f31Bf',
-        '0x57B57efFA54ba37DBF8A06B9c42E7611e84BDe6F',
-        '0xF617bbc0913bAE0a13f6D4A19eCDE5Aa07B0fF0A'
+    "antiAbuseOracleNodes": {
+      "endpoints": [
+        "https://discoveryprovider.staging.audius.co"
+      ],
+      "registeredAddresses": [
+        "0x00b6462e955dA5841b6D9e1E2529B830F00f31Bf",
+        "0x57B57efFA54ba37DBF8A06B9c42E7611e84BDe6F",
+        "0xF617bbc0913bAE0a13f6D4A19eCDE5Aa07B0fF0A"
       ]
     },
-    identityService: 'https://identityservice.staging.audius.co'
+    "identityService": "https://identityservice.staging.audius.co"
   },
-  acdc: {
-    entityManagerContractAddress: '0x1Cd8a543596D499B9b6E7a6eC15ECd2B7857Fd64',
-    chainId: 1056801
+  "acdc": {
+    "entityManagerContractAddress": "0x1Cd8a543596D499B9b6E7a6eC15ECd2B7857Fd64",
+    "chainId": 1056801
   },
-  solana: {
-    claimableTokensProgramAddress:
-      '2sjQNmUfkV6yKKi4dPR8gWRgtyma5aiymE3aXL2RAZww',
-    rewardManagerProgramAddress: 'CDpzvz7DfgbF95jSSCHLX3ERkugyfgn9Fw8ypNZ1hfXp',
-    rewardManagerStateAddress: 'GaiG9LDYHfZGqeNaoGRzFEnLiwUT7WiC6sA6FDJX9ZPq',
-    paymentRouterProgramAddress: 'sp28KA2bTnTA4oSZ3r9tTSKfmiXZtZQHnYYQqWfUyVa',
-    stakingBridgeProgramAddress: 'stkuyR7dTzxV1YnoDo5tfuBmkuKn7zDatimYRDTmQvj',
-    rpcEndpoint: 'https://audius-fe.rpcpool.com',
-    usdcTokenMint: 'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v',
-    wAudioTokenMint: 'BELGiMZQ34SDE6x2FUaML2UHDAgBLS64xvhXjX5tBBZo',
-    rewardManagerLookupTableAddress:
-      'ChFCWjeFxM6SRySTfT46zXn2K7m89TJsft4HWzEtkB4J'
+  "solana": {
+    "claimableTokensProgramAddress": "2sjQNmUfkV6yKKi4dPR8gWRgtyma5aiymE3aXL2RAZww",
+    "rewardManagerProgramAddress": "CDpzvz7DfgbF95jSSCHLX3ERkugyfgn9Fw8ypNZ1hfXp",
+    "rewardManagerStateAddress": "GaiG9LDYHfZGqeNaoGRzFEnLiwUT7WiC6sA6FDJX9ZPq",
+    "paymentRouterProgramAddress": "sp28KA2bTnTA4oSZ3r9tTSKfmiXZtZQHnYYQqWfUyVa",
+    "stakingBridgeProgramAddress": "stkuyR7dTzxV1YnoDo5tfuBmkuKn7zDatimYRDTmQvj",
+    "rpcEndpoint": "https://audius-fe.rpcpool.com",
+    "usdcTokenMint": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+    "wAudioTokenMint": "BELGiMZQ34SDE6x2FUaML2UHDAgBLS64xvhXjX5tBBZo",
+    "rewardManagerLookupTableAddress": "ChFCWjeFxM6SRySTfT46zXn2K7m89TJsft4HWzEtkB4J"
   },
-  ethereum: {
-    rpcEndpoint:
-      'https://eth-sepolia.g.alchemy.com/v2/T_trbeTeNv2w04OpyAPkvZ_gH4nr_KuZ',
-    addresses: {
-      ethRewardsManagerAddress: '0x563483ccD66a49Ca730275F8cf37Dd3E6Da864f1',
-      serviceProviderFactoryAddress:
-        '0x377BE01aD31360d0DFB16035A4515954395A8185',
-      serviceTypeManagerAddress: '0x9fd76d2cD48022526F3a164541E6552291F4a862',
-      audiusTokenAddress: '0x1376180Ee935AA64A27780F4BE97726Df7B0e2B2',
-      audiusWormholeAddress: '0xf6f45e4d836da1d4ecd43bb1074620bfb0b7e0d7',
-      delegateManagerAddress: '0xDA74d6FfbF268Ac441404f5a61f01103451E8697',
-      stakingAddress: '0x5bcF21A4D5Bab9B0869B9c55D233f80135C814C6'
+  "ethereum": {
+    "rpcEndpoint": "https://eth-sepolia.g.alchemy.com/v2/T_trbeTeNv2w04OpyAPkvZ_gH4nr_KuZ",
+    "addresses": {
+      "ethRewardsManagerAddress": "0x563483ccD66a49Ca730275F8cf37Dd3E6Da864f1",
+      "serviceProviderFactoryAddress": "0x377BE01aD31360d0DFB16035A4515954395A8185",
+      "serviceTypeManagerAddress": "0x9fd76d2cD48022526F3a164541E6552291F4a862",
+      "audiusTokenAddress": "0x1376180Ee935AA64A27780F4BE97726Df7B0e2B2",
+      "audiusWormholeAddress": "0xf6f45e4d836da1d4ecd43bb1074620bfb0b7e0d7",
+      "delegateManagerAddress": "0xDA74d6FfbF268Ac441404f5a61f01103451E8697",
+      "stakingAddress": "0x5bcF21A4D5Bab9B0869B9c55D233f80135C814C6"
     }
   }
 }

--- a/packages/sdk/src/sdk/config/staging.ts
+++ b/packages/sdk/src/sdk/config/staging.ts
@@ -5,102 +5,104 @@
 /* eslint-disable prettier/prettier */
 import type { SdkServicesConfig } from './types'
 export const stagingConfig: SdkServicesConfig = {
-  "network": {
-    "minVersion": "0.6.0",
-    "apiEndpoint": "https://api.staging.audius.co",
-    "discoveryNodes": [
+  network: {
+    minVersion: '0.6.0',
+    apiEndpoint: 'https://api.staging.audius.co',
+    discoveryNodes: [
       {
-        "endpoint": "https://discoveryprovider.staging.audius.co",
-        "ownerWallet": "0x8fcFA10Bd3808570987dbb5B1EF4AB74400FbfDA",
-        "delegateOwnerWallet": "0x8fcFA10Bd3808570987dbb5B1EF4AB74400FbfDA"
+        endpoint: 'https://discoveryprovider.staging.audius.co',
+        ownerWallet: '0x8fcFA10Bd3808570987dbb5B1EF4AB74400FbfDA',
+        delegateOwnerWallet: '0x8fcFA10Bd3808570987dbb5B1EF4AB74400FbfDA'
       },
       {
-        "endpoint": "https://discoveryprovider2.staging.audius.co",
-        "ownerWallet": "0x5E98cBEEAA2aCEDEc0833AC3D1634E2A7aE0f3c2",
-        "delegateOwnerWallet": "0x5E98cBEEAA2aCEDEc0833AC3D1634E2A7aE0f3c2"
+        endpoint: 'https://discoveryprovider2.staging.audius.co',
+        ownerWallet: '0x5E98cBEEAA2aCEDEc0833AC3D1634E2A7aE0f3c2',
+        delegateOwnerWallet: '0x5E98cBEEAA2aCEDEc0833AC3D1634E2A7aE0f3c2'
       },
       {
-        "endpoint": "https://discoveryprovider3.staging.audius.co",
-        "ownerWallet": "0xf7C96916bd37Ad76D4EEDd6536B81c29706C8056",
-        "delegateOwnerWallet": "0xf7C96916bd37Ad76D4EEDd6536B81c29706C8056"
+        endpoint: 'https://discoveryprovider3.staging.audius.co',
+        ownerWallet: '0xf7C96916bd37Ad76D4EEDd6536B81c29706C8056',
+        delegateOwnerWallet: '0xf7C96916bd37Ad76D4EEDd6536B81c29706C8056'
       },
       {
-        "endpoint": "https://discoveryprovider5.staging.audius.co",
-        "ownerWallet": "0x8311f59B72522e728231dC60226359A51878F9A1",
-        "delegateOwnerWallet": "0x8311f59B72522e728231dC60226359A51878F9A1"
+        endpoint: 'https://discoveryprovider5.staging.audius.co',
+        ownerWallet: '0x8311f59B72522e728231dC60226359A51878F9A1',
+        delegateOwnerWallet: '0x8311f59B72522e728231dC60226359A51878F9A1'
       }
     ],
-    "storageNodes": [
+    storageNodes: [
       {
-        "endpoint": "https://creatornode10.staging.audius.co",
-        "delegateOwnerWallet": "0xf7C96916bd37Ad76D4EEDd6536B81c29706C8056"
+        endpoint: 'https://creatornode10.staging.audius.co',
+        delegateOwnerWallet: '0xf7C96916bd37Ad76D4EEDd6536B81c29706C8056'
       },
       {
-        "endpoint": "https://creatornode8.staging.audius.co",
-        "delegateOwnerWallet": "0x8fcFA10Bd3808570987dbb5B1EF4AB74400FbfDA"
+        endpoint: 'https://creatornode8.staging.audius.co',
+        delegateOwnerWallet: '0x8fcFA10Bd3808570987dbb5B1EF4AB74400FbfDA'
       },
       {
-        "endpoint": "https://creatornode12.staging.audius.co",
-        "delegateOwnerWallet": "0x6b52969934076318863243fb92E9C4b3A08267b5"
+        endpoint: 'https://creatornode12.staging.audius.co',
+        delegateOwnerWallet: '0x6b52969934076318863243fb92E9C4b3A08267b5'
       },
       {
-        "endpoint": "https://creatornode5.staging.audius.co",
-        "delegateOwnerWallet": "0xDC2BDF1F23381CA2eC9e9c70D4FD96CD8645D090"
+        endpoint: 'https://creatornode5.staging.audius.co',
+        delegateOwnerWallet: '0xDC2BDF1F23381CA2eC9e9c70D4FD96CD8645D090'
       },
       {
-        "endpoint": "https://creatornode6.staging.audius.co",
-        "delegateOwnerWallet": "0x68039d001D87E7A5E6B06fe0825EA7871C1Cd6C2"
+        endpoint: 'https://creatornode6.staging.audius.co',
+        delegateOwnerWallet: '0x68039d001D87E7A5E6B06fe0825EA7871C1Cd6C2'
       },
       {
-        "endpoint": "https://creatornode7.staging.audius.co",
-        "delegateOwnerWallet": "0x1F8e7aF58086992Ef4c4fc0371446974BBbC0D9F"
+        endpoint: 'https://creatornode7.staging.audius.co',
+        delegateOwnerWallet: '0x1F8e7aF58086992Ef4c4fc0371446974BBbC0D9F'
       },
       {
-        "endpoint": "https://creatornode9.staging.audius.co",
-        "delegateOwnerWallet": "0x140eD283b33be2145ed7d9d15f1fE7bF1E0B2Ac3"
+        endpoint: 'https://creatornode9.staging.audius.co',
+        delegateOwnerWallet: '0x140eD283b33be2145ed7d9d15f1fE7bF1E0B2Ac3'
       },
       {
-        "endpoint": "https://creatornode11.staging.audius.co",
-        "delegateOwnerWallet": "0x4c88d2c0f4c4586b41621aD6e98882ae904B98f6"
+        endpoint: 'https://creatornode11.staging.audius.co',
+        delegateOwnerWallet: '0x4c88d2c0f4c4586b41621aD6e98882ae904B98f6'
       }
     ],
-    "antiAbuseOracleNodes": {
-      "endpoints": [
-        "https://discoveryprovider.staging.audius.co"
-      ],
-      "registeredAddresses": [
-        "0x00b6462e955dA5841b6D9e1E2529B830F00f31Bf",
-        "0x57B57efFA54ba37DBF8A06B9c42E7611e84BDe6F",
-        "0xF617bbc0913bAE0a13f6D4A19eCDE5Aa07B0fF0A"
+    antiAbuseOracleNodes: {
+      endpoints: ['https://discoveryprovider.staging.audius.co'],
+      registeredAddresses: [
+        '0x00b6462e955dA5841b6D9e1E2529B830F00f31Bf',
+        '0x57B57efFA54ba37DBF8A06B9c42E7611e84BDe6F',
+        '0xF617bbc0913bAE0a13f6D4A19eCDE5Aa07B0fF0A'
       ]
     },
-    "identityService": "https://identityservice.staging.audius.co"
+    identityService: 'https://identityservice.staging.audius.co'
   },
-  "acdc": {
-    "entityManagerContractAddress": "0x1Cd8a543596D499B9b6E7a6eC15ECd2B7857Fd64",
-    "chainId": 1056801
+  acdc: {
+    entityManagerContractAddress: '0x1Cd8a543596D499B9b6E7a6eC15ECd2B7857Fd64',
+    chainId: 1056801
   },
-  "solana": {
-    "claimableTokensProgramAddress": "2sjQNmUfkV6yKKi4dPR8gWRgtyma5aiymE3aXL2RAZww",
-    "rewardManagerProgramAddress": "CDpzvz7DfgbF95jSSCHLX3ERkugyfgn9Fw8ypNZ1hfXp",
-    "rewardManagerStateAddress": "GaiG9LDYHfZGqeNaoGRzFEnLiwUT7WiC6sA6FDJX9ZPq",
-    "paymentRouterProgramAddress": "sp28KA2bTnTA4oSZ3r9tTSKfmiXZtZQHnYYQqWfUyVa",
-    "stakingBridgeProgramAddress": "stkuyR7dTzxV1YnoDo5tfuBmkuKn7zDatimYRDTmQvj",
-    "rpcEndpoint": "https://audius-fe.rpcpool.com",
-    "usdcTokenMint": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
-    "wAudioTokenMint": "BELGiMZQ34SDE6x2FUaML2UHDAgBLS64xvhXjX5tBBZo",
-    "rewardManagerLookupTableAddress": "ChFCWjeFxM6SRySTfT46zXn2K7m89TJsft4HWzEtkB4J"
+  solana: {
+    claimableTokensProgramAddress:
+      '2sjQNmUfkV6yKKi4dPR8gWRgtyma5aiymE3aXL2RAZww',
+    rewardManagerProgramAddress: 'CDpzvz7DfgbF95jSSCHLX3ERkugyfgn9Fw8ypNZ1hfXp',
+    rewardManagerStateAddress: 'GaiG9LDYHfZGqeNaoGRzFEnLiwUT7WiC6sA6FDJX9ZPq',
+    paymentRouterProgramAddress: 'sp28KA2bTnTA4oSZ3r9tTSKfmiXZtZQHnYYQqWfUyVa',
+    stakingBridgeProgramAddress: 'stkuyR7dTzxV1YnoDo5tfuBmkuKn7zDatimYRDTmQvj',
+    rpcEndpoint: 'https://audius-fe.rpcpool.com',
+    usdcTokenMint: 'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v',
+    wAudioTokenMint: 'BELGiMZQ34SDE6x2FUaML2UHDAgBLS64xvhXjX5tBBZo',
+    rewardManagerLookupTableAddress:
+      'ChFCWjeFxM6SRySTfT46zXn2K7m89TJsft4HWzEtkB4J'
   },
-  "ethereum": {
-    "rpcEndpoint": "https://eth-sepolia.g.alchemy.com/v2/T_trbeTeNv2w04OpyAPkvZ_gH4nr_KuZ",
-    "addresses": {
-      "ethRewardsManagerAddress": "0x563483ccD66a49Ca730275F8cf37Dd3E6Da864f1",
-      "serviceProviderFactoryAddress": "0x377BE01aD31360d0DFB16035A4515954395A8185",
-      "serviceTypeManagerAddress": "0x9fd76d2cD48022526F3a164541E6552291F4a862",
-      "audiusTokenAddress": "0x1376180Ee935AA64A27780F4BE97726Df7B0e2B2",
-      "audiusWormholeAddress": "0xf6f45e4d836da1d4ecd43bb1074620bfb0b7e0d7",
-      "delegateManagerAddress": "0xDA74d6FfbF268Ac441404f5a61f01103451E8697",
-      "stakingAddress": "0x5bcF21A4D5Bab9B0869B9c55D233f80135C814C6"
+  ethereum: {
+    rpcEndpoint:
+      'https://eth-sepolia.g.alchemy.com/v2/T_trbeTeNv2w04OpyAPkvZ_gH4nr_KuZ',
+    addresses: {
+      ethRewardsManagerAddress: '0x563483ccD66a49Ca730275F8cf37Dd3E6Da864f1',
+      serviceProviderFactoryAddress:
+        '0x377BE01aD31360d0DFB16035A4515954395A8185',
+      serviceTypeManagerAddress: '0x9fd76d2cD48022526F3a164541E6552291F4a862',
+      audiusTokenAddress: '0x1376180Ee935AA64A27780F4BE97726Df7B0e2B2',
+      audiusWormholeAddress: '0xf6f45e4d836da1d4ecd43bb1074620bfb0b7e0d7',
+      delegateManagerAddress: '0xDA74d6FfbF268Ac441404f5a61f01103451E8697',
+      stakingAddress: '0x5bcF21A4D5Bab9B0869B9c55D233f80135C814C6'
     }
   }
 }


### PR DESCRIPTION
### Description

Client was spamming requests to check all tracks for events individually to display remix contest flairs. This batches those requests together for a single request and resolves those events by entity ID.  

Resolves PE-6079

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._

Ran against stage and confirmed requests were batched together and displaying flair properly