### PR TITLE
Small mobile tweaks for m1 wallet page

### DIFF
--- a/packages/common/src/hooks/useFormattedAudioBalance.ts
+++ b/packages/common/src/hooks/useFormattedAudioBalance.ts
@@ -25,7 +25,7 @@ export const useFormattedAudioBalance = (): UseFormattedAudioBalanceReturn => {
   const audioBalanceFormatted = formatWei(audioBalance, true, 0)
   const isAudioBalanceLoading = isNullOrUndefined(audioBalance)
 
-  const { data: audioPriceData, isPending: isAudioPriceLoading } =
+  const { data: audioPriceData, isLoading: isAudioPriceLoading } =
     useTokenPrice(AUDIO_TOKEN_ID)
   const audioPrice = audioPriceData?.price || null
 

--- a/packages/common/src/hooks/useFormattedAudioBalance.ts
+++ b/packages/common/src/hooks/useFormattedAudioBalance.ts
@@ -25,7 +25,7 @@ export const useFormattedAudioBalance = (): UseFormattedAudioBalanceReturn => {
   const audioBalanceFormatted = formatWei(audioBalance, true, 0)
   const isAudioBalanceLoading = isNullOrUndefined(audioBalance)
 
-  const { data: audioPriceData, isLoading: isAudioPriceLoading } =
+  const { data: audioPriceData, isPending: isAudioPriceLoading } =
     useTokenPrice(AUDIO_TOKEN_ID)
   const audioPrice = audioPriceData?.price || null
 

--- a/packages/common/src/messages/walletMessages.ts
+++ b/packages/common/src/messages/walletMessages.ts
@@ -12,8 +12,5 @@ export const walletMessages = {
 
   // YourCoins messages
   yourCoins: 'Your Coins',
-  loading: '-- $AUDIO',
-  dollarZero: '$0.00',
-  loadingPrice: '$0.00 (loading...)',
   buySell: 'Buy/Sell'
 }

--- a/packages/mobile/src/screens/wallet-screen/components/CashWallet.tsx
+++ b/packages/mobile/src/screens/wallet-screen/components/CashWallet.tsx
@@ -18,9 +18,9 @@ import {
   IconInfo,
   IconLogoCircleUSDC,
   Paper,
+  Skeleton,
   Text
 } from '@audius/harmony-native'
-import LoadingSpinner from 'app/components/loading-spinner'
 import { make, track } from 'app/services/analytics'
 
 export const CashWallet = () => {
@@ -46,10 +46,6 @@ export const CashWallet = () => {
     bottomSheetModalRef.current?.present()
   }, [])
 
-  if (isLoading) {
-    return <LoadingSpinner />
-  }
-
   return (
     <>
       <Paper>
@@ -70,9 +66,15 @@ export const CashWallet = () => {
             />
           </Flex>
 
-          <Text variant='display' size='m' color='default'>
-            ${balanceFormatted}
-          </Text>
+          {isLoading ? (
+            <Box h='4xl' w='5xl'>
+              <Skeleton />
+            </Box>
+          ) : (
+            <Text variant='display' size='m' color='default'>
+              {balanceFormatted}
+            </Text>
+          )}
 
           {!isManagedAccount ? (
             <Button variant='secondary' onPress={handleAddCash} fullWidth>

--- a/packages/mobile/src/screens/wallet-screen/components/CashWallet.tsx
+++ b/packages/mobile/src/screens/wallet-screen/components/CashWallet.tsx
@@ -67,9 +67,7 @@ export const CashWallet = () => {
           </Flex>
 
           {isLoading ? (
-            <Box h='4xl' w='5xl'>
-              <Skeleton />
-            </Box>
+            <Skeleton h='4xl' w='5xl' />
           ) : (
             <Text variant='display' size='m' color='default'>
               {balanceFormatted}

--- a/packages/mobile/src/screens/wallet-screen/components/YourCoins.tsx
+++ b/packages/mobile/src/screens/wallet-screen/components/YourCoins.tsx
@@ -1,13 +1,14 @@
-import { useCallback } from 'react'
+import React, { useCallback } from 'react'
 
 import { useFormattedAudioBalance } from '@audius/common/hooks'
-import { walletMessages } from '@audius/common/messages'
 
 import {
+  Box,
   Flex,
   IconCaretRight,
   IconTokenAUDIO,
   Paper,
+  Skeleton,
   Text,
   cornerRadius
 } from '@audius/harmony-native'
@@ -27,9 +28,7 @@ export const YourCoins = () => {
     navigation.navigate('AudioScreen')
   }, [navigation])
 
-  const displayAmount = isAudioBalanceLoading
-    ? walletMessages.loading
-    : audioBalanceFormatted
+  const displayAmount = isAudioBalanceLoading ? null : audioBalanceFormatted
 
   return (
     <Paper onPress={handleTokenClick}>
@@ -43,18 +42,30 @@ export const YourCoins = () => {
           <IconTokenAUDIO size='4xl' borderRadius={cornerRadius.circle} />
           <Flex direction='column' gap='xs'>
             <Flex direction='row' alignItems='center' gap='xs'>
-              <Text variant='heading' size='l' color='default'>
-                {displayAmount}
-              </Text>
-              <Text variant='heading' size='l' color='subdued'>
-                $AUDIO
-              </Text>
+              {isAudioBalanceLoading ? (
+                <Box h='4xl' w='5xl'>
+                  <Skeleton />
+                </Box>
+              ) : (
+                <>
+                  <Text variant='heading' size='l' color='default'>
+                    {displayAmount}
+                  </Text>
+                  <Text variant='heading' size='l' color='subdued'>
+                    $AUDIO
+                  </Text>
+                </>
+              )}
             </Flex>
-            <Text variant='heading' size='s' color='subdued'>
-              {isAudioPriceLoading
-                ? walletMessages.loadingPrice
-                : audioDollarValue}
-            </Text>
+            {isAudioPriceLoading ? (
+              <Box h='l' w='3xl'>
+                <Skeleton />
+              </Box>
+            ) : (
+              <Text variant='heading' size='s' color='subdued'>
+                {audioDollarValue}
+              </Text>
+            )}
           </Flex>
         </Flex>
         <IconCaretRight size='s' color='subdued' />

--- a/packages/mobile/src/screens/wallet-screen/components/YourCoins.tsx
+++ b/packages/mobile/src/screens/wallet-screen/components/YourCoins.tsx
@@ -28,8 +28,6 @@ export const YourCoins = () => {
     navigation.navigate('AudioScreen')
   }, [navigation])
 
-  const displayAmount = isAudioBalanceLoading ? null : audioBalanceFormatted
-
   return (
     <Paper onPress={handleTokenClick}>
       <Flex
@@ -49,7 +47,7 @@ export const YourCoins = () => {
               ) : (
                 <>
                   <Text variant='heading' size='l' color='default'>
-                    {displayAmount}
+                    {audioBalanceFormatted}
                   </Text>
                   <Text variant='heading' size='l' color='subdued'>
                     $AUDIO

--- a/packages/mobile/src/screens/wallet-screen/components/YourCoins.tsx
+++ b/packages/mobile/src/screens/wallet-screen/components/YourCoins.tsx
@@ -3,7 +3,6 @@ import React, { useCallback } from 'react'
 import { useFormattedAudioBalance } from '@audius/common/hooks'
 
 import {
-  Box,
   Flex,
   IconCaretRight,
   IconTokenAUDIO,
@@ -41,9 +40,7 @@ export const YourCoins = () => {
           <Flex direction='column' gap='xs'>
             <Flex direction='row' alignItems='center' gap='xs'>
               {isAudioBalanceLoading ? (
-                <Box h='4xl' w='5xl'>
-                  <Skeleton />
-                </Box>
+                <Skeleton h='4xl' w='5xl' />
               ) : (
                 <>
                   <Text variant='heading' size='l' color='default'>
@@ -56,9 +53,7 @@ export const YourCoins = () => {
               )}
             </Flex>
             {isAudioPriceLoading ? (
-              <Box h='l' w='3xl'>
-                <Skeleton />
-              </Box>
+              <Skeleton h='l' w='3xl' />
             ) : (
               <Text variant='heading' size='s' color='subdued'>
                 {audioDollarValue}


### PR DESCRIPTION
### Description
Some of the shared logic changed so had to update the mobile UI, also had to make loading states consistent with web

### How Has This Been Tested?

`npm run mobile` and navigate to `wallet` tab to ensure everything works well
