### PR TITLE
[PE-6094] Drop bitcode from pods

### DIFF
--- a/packages/mobile/ios/Podfile
+++ b/packages/mobile/ios/Podfile
@@ -45,6 +45,27 @@ target 'AudiusReactNative' do
   )
 
   post_install do |installer|
+    bitcode_strip_path = `xcrun --find bitcode_strip`.chop!
+
+    def strip_bitcode_from_framework(bitcode_strip_path, framework_relative_path)
+      framework_path = File.join(Dir.pwd, framework_relative_path)
+      command = "#{bitcode_strip_path} #{framework_path} -r -o #{framework_path}"
+      puts "Stripping bitcode: #{command}"
+      system(command)
+    end
+
+    framework_paths = [
+      "Pods/TikTokOpenSDK/TikTokOpenSDK.framework/TikTokOpenSDK",
+      "Pods/google-cast-sdk-dynamic-xcframework-no-bluetooth/GoogleCast.xcframework/ios-arm64/GoogleCast.framework/GoogleCast",
+      "Pods/SnapSDK/SCSDKCoreKit.xcframework/ios-arm64_armv7_armv7s/SCSDKCoreKit.framework/SCSDKCoreKit",
+      "Pods/SnapSDK/SCSDKCreativeKit.xcframework/ios-arm64_armv7_armv7s/SCSDKCreativeKit.framework/SCSDKCreativeKit",
+      "Pods/SnapSDK/SCSDKLoginKit.xcframework/ios-arm64_armv7_armv7s/SCSDKLoginKit.framework/SCSDKLoginKit",
+    ]
+
+    framework_paths.each do |framework_relative_path|
+      strip_bitcode_from_framework(bitcode_strip_path, framework_relative_path)
+    end
+
    react_native_post_install(
       installer,
       config[:reactNativePath],


### PR DESCRIPTION
### Description

Fixes mobile builds by dropping bitcode in builds which is no longer supported in xcode 16