### PR TITLE
Horizontal margins for mobile remix contest info header

### DIFF
--- a/packages/mobile/src/screens/track-screen/RemixContestSection.tsx
+++ b/packages/mobile/src/screens/track-screen/RemixContestSection.tsx
@@ -29,7 +29,8 @@ const HEIGHT_OFFSET = 24
 const useStyles = makeStyles(({ palette, typography, spacing }) => ({
   tabBar: {
     backgroundColor: 'transparent',
-    height: spacing(10)
+    height: spacing(10),
+    marginHorizontal: spacing(4)
   },
   tabLabel: {
     marginHorizontal: 0,


### PR DESCRIPTION
### Description

### How Has This Been Tested?
also confirmed android looks good

ios:
![simulator_screenshot_6F0FB974-6AE3-404A-9C8C-4CAE8F98C9D3](https://github.com/user-attachments/assets/24f23bbc-3d43-478a-a270-e617dee94b94)
