### PR TITLE
Fix mobile remix contest prizes tab sometimes not appearing

### DIFF
--- a/packages/mobile/src/screens/track-screen/RemixContestSection.tsx
+++ b/packages/mobile/src/screens/track-screen/RemixContestSection.tsx
@@ -81,15 +81,11 @@ export const RemixContestSection = ({
   const hasPrizeInfo = !!remixContest?.eventData?.prizeInfo
 
   const [index, setIndex] = useState(0)
-  const [routes] = useState<Route[]>([
-    { key: 'details', title: 'Details' },
-    ...(hasPrizeInfo ? [{ key: 'prizes', title: 'Prizes' }] : []),
-    { key: 'submissions', title: 'Submissions' }
-  ])
+  const [routes, setRoutes] = useState<Route[]>([])
   const [heights, setHeights] = useState({})
   const [firstRender, setFirstRender] = useState(true)
   const animatedHeight = useSharedValue(TAB_HEADER_HEIGHT)
-  const currentHeight = heights[routes[index].key]
+  const currentHeight = heights[routes[index]?.key]
   const previousHeight = usePrevious(currentHeight)
   const hasHeightChanged = currentHeight !== previousHeight
 
@@ -98,6 +94,14 @@ export const RemixContestSection = ({
       setFirstRender(false)
     }
   }, [firstRender])
+
+  useEffect(() => {
+    setRoutes([
+      { key: 'details', title: 'Details' },
+      ...(hasPrizeInfo ? [{ key: 'prizes', title: 'Prizes' }] : []),
+      { key: 'submissions', title: 'Submissions' }
+    ])
+  }, [hasPrizeInfo])
 
   const handleLayout = (key: string) => (e: any) => {
     const height = e.nativeEvent.layout.height


### PR DESCRIPTION
### Description
Sometimes on first render the prizes tab would be missing. Setting the tabs in a useEffect solves this.

### How Has This Been Tested?

Tested on ios stage. The repro was fairly consistent and now does not happen.