### PR TITLE
Allow off curve accounts in USDC withdrawal

### DIFF
--- a/packages/common/src/services/audius-backend/solana.ts
+++ b/packages/common/src/services/audius-backend/solana.ts
@@ -464,7 +464,11 @@ export const transferFromUserBank = async ({
   try {
     const instructions: TransactionInstruction[] = []
 
-    const destination = getAssociatedTokenAddressSync(mint, destinationWallet)
+    const destination = getAssociatedTokenAddressSync(
+      mint,
+      destinationWallet,
+      true
+    )
 
     try {
       await getAccount(connection, destination)


### PR DESCRIPTION
Allows off curve token accounts to be used as the destination for USDC withdrawals.