### PR TITLE
Fix tooltip on cash wallet component

### DIFF
--- a/packages/web/src/pages/pay-and-earn-page/components/CashWallet.tsx
+++ b/packages/web/src/pages/pay-and-earn-page/components/CashWallet.tsx
@@ -95,7 +95,9 @@ export const CashWallet = () => {
               <Tooltip
                 text={walletMessages.cashBalanceTooltip}
                 placement='top'
-                mount='page'
+                getPopupContainer={() =>
+                  document.getElementById('page') ?? document.body
+                }
                 shouldWrapContent={false}
                 shouldDismissOnClick={false}
                 css={{ zIndex: zIndex.CASH_WALLET_TOOLTIP }}


### PR DESCRIPTION
### Description
This PR fixes an issue with tooltips in CashWallet not reappearing after navigation. The root problem was that while the mount='page' prop correctly positioned tooltips by attaching them to the parent page container, it created lifecycle issues during navigation.
When the component unmounts and remounts during navigation, the tooltip state wasn't being properly reset. By explicitly setting getPopupContainer to target the #page element, we maintain the correct tooltip positioning while allowing React's component lifecycle to properly manage the tooltip state, ensuring it works consistently both on initial render and after navigation.

### How Has This Been Tested?

`npm run web:stage`

- navigate to `/wallet` page
- hover over info i in cash balance section
- ensure tooltip appears
- navigate away from that page and then navigate back
- ensure that it appears again
