### PR TITLE
Don't show PlayBarChin in mobile remix parent lineup

### DIFF
--- a/packages/mobile/src/components/core/SectionList.tsx
+++ b/packages/mobile/src/components/core/SectionList.tsx
@@ -1,5 +1,5 @@
 import type { Ref, RefObject } from 'react'
-import { forwardRef, useContext } from 'react'
+import React, { forwardRef, useContext } from 'react'
 
 import { Portal } from '@gorhom/portal'
 import type {
@@ -125,19 +125,21 @@ export const SectionList = forwardRef(function SectionList<
   ItemT,
   SectionT = DefaultSectionT
 >(
-  props: Animated.AnimatedProps<RNSectionListProps<ItemT, SectionT>>,
+  props: Animated.AnimatedProps<RNSectionListProps<ItemT, SectionT>> & {
+    shouldShowPlayBarChin?: boolean
+  },
   ref: Ref<RNSectionList<ItemT, SectionT>>
 ) {
-  const { ListFooterComponent, ...other } = props
+  const { ListFooterComponent, shouldShowPlayBarChin, ...other } = props
 
   const FooterComponent = ListFooterComponent ? (
     <>
       {ListFooterComponent}
-      <PlayBarChin />
+      {shouldShowPlayBarChin ? <PlayBarChin /> : null}
     </>
-  ) : (
-    PlayBarChin
-  )
+  ) : shouldShowPlayBarChin ? (
+    <PlayBarChin />
+  ) : null
 
   const sectionListProps = {
     ...other,

--- a/packages/mobile/src/components/core/SectionList.tsx
+++ b/packages/mobile/src/components/core/SectionList.tsx
@@ -126,20 +126,20 @@ export const SectionList = forwardRef(function SectionList<
   SectionT = DefaultSectionT
 >(
   props: Animated.AnimatedProps<RNSectionListProps<ItemT, SectionT>> & {
-    shouldShowPlayBarChin?: boolean
+    hidePlayBarChin?: boolean
   },
   ref: Ref<RNSectionList<ItemT, SectionT>>
 ) {
-  const { ListFooterComponent, shouldShowPlayBarChin, ...other } = props
+  const { ListFooterComponent, hidePlayBarChin, ...other } = props
 
   const FooterComponent = ListFooterComponent ? (
     <>
       {ListFooterComponent}
-      {shouldShowPlayBarChin ? <PlayBarChin /> : null}
+      {hidePlayBarChin ? null : <PlayBarChin />}
     </>
-  ) : shouldShowPlayBarChin ? (
+  ) : hidePlayBarChin ? null : (
     <PlayBarChin />
-  ) : null
+  )
 
   const sectionListProps = {
     ...other,

--- a/packages/mobile/src/components/core/SectionList.tsx
+++ b/packages/mobile/src/components/core/SectionList.tsx
@@ -1,5 +1,5 @@
 import type { Ref, RefObject } from 'react'
-import React, { forwardRef, useContext } from 'react'
+import { forwardRef, useContext } from 'react'
 
 import { Portal } from '@gorhom/portal'
 import type {

--- a/packages/mobile/src/components/lineup/TanQueryLineup.tsx
+++ b/packages/mobile/src/components/lineup/TanQueryLineup.tsx
@@ -297,6 +297,11 @@ export type LineupProps = {
    */
   itemStyles?: ViewStyle
 
+  /**
+   * Whether to show the play bar chin
+   */
+  shouldShowPlayBarChin?: boolean
+
   // Tan query props
   pageSize: number
   initialPageSize?: number
@@ -350,6 +355,7 @@ export const TanQueryLineup = ({
   isPending,
   queryData = [],
   maxEntries = Infinity,
+  shouldShowPlayBarChin = true,
   ...listProps
 }: LineupProps) => {
   const debouncedLoadNextPage = useDebouncedCallback(
@@ -520,6 +526,7 @@ export const TanQueryLineup = ({
         onScroll={handleScroll}
         ListHeaderComponent={hideHeaderOnEmpty && isEmpty ? undefined : header}
         ListFooterComponent={lineup.hasMore ? null : ListFooterComponent}
+        shouldShowPlayBarChin={shouldShowPlayBarChin}
         ListEmptyComponent={LineupEmptyComponent}
         onEndReached={handleEndReached}
         onEndReachedThreshold={LOAD_MORE_THRESHOLD}

--- a/packages/mobile/src/components/lineup/TanQueryLineup.tsx
+++ b/packages/mobile/src/components/lineup/TanQueryLineup.tsx
@@ -300,7 +300,7 @@ export type LineupProps = {
   /**
    * Whether to show the play bar chin
    */
-  shouldShowPlayBarChin?: boolean
+  hidePlayBarChin?: boolean
 
   // Tan query props
   pageSize: number
@@ -355,7 +355,7 @@ export const TanQueryLineup = ({
   isPending,
   queryData = [],
   maxEntries = Infinity,
-  shouldShowPlayBarChin = true,
+  hidePlayBarChin = false,
   ...listProps
 }: LineupProps) => {
   const debouncedLoadNextPage = useDebouncedCallback(
@@ -526,7 +526,7 @@ export const TanQueryLineup = ({
         onScroll={handleScroll}
         ListHeaderComponent={hideHeaderOnEmpty && isEmpty ? undefined : header}
         ListFooterComponent={lineup.hasMore ? null : ListFooterComponent}
-        shouldShowPlayBarChin={shouldShowPlayBarChin}
+        hidePlayBarChin={true}
         ListEmptyComponent={LineupEmptyComponent}
         onEndReached={handleEndReached}
         onEndReachedThreshold={LOAD_MORE_THRESHOLD}

--- a/packages/mobile/src/screens/track-screen/TrackScreenLineup.tsx
+++ b/packages/mobile/src/screens/track-screen/TrackScreenLineup.tsx
@@ -85,7 +85,7 @@ export const TrackScreenLineup = ({
             hasMore={false}
             isPending={isPending}
             queryData={data}
-            shouldShowPlayBarChin={false}
+            hidePlayBarChin={true}
           />
           {parentTrackId ? (
             <ViewOtherRemixesButton parentTrackId={parentTrackId} />

--- a/packages/mobile/src/screens/track-screen/TrackScreenLineup.tsx
+++ b/packages/mobile/src/screens/track-screen/TrackScreenLineup.tsx
@@ -85,6 +85,7 @@ export const TrackScreenLineup = ({
             hasMore={false}
             isPending={isPending}
             queryData={data}
+            shouldShowPlayBarChin={false}
           />
           {parentTrackId ? (
             <ViewOtherRemixesButton parentTrackId={parentTrackId} />


### PR DESCRIPTION
### Description
This PR is so gross. but `SectionList` and `Lineup` etc are so widely used that I didn't want to change default behavior.

The bug: when a track is playing, there is extra space at the bottom of the lineup like so:
![image](https://github.com/user-attachments/assets/df0ee5e0-2bd8-4e72-8cb2-3e238c3d84e9)

This is the `PlayBarChin` and we needed a way to not show it sometimes.

### How Has This Been Tested?
![Simulator Screenshot - iPhone 16 Pro - 2025-04-30 at 14 38 04](https://github.com/user-attachments/assets/d97765da-4e51-46f6-8022-e6e95bc9772b)

