### PR TITLE
[PE-6119] Mobile remix submission navigation.push

### DIFF
--- a/packages/mobile/src/screens/track-screen/RemixContestSubmissionsTab.tsx
+++ b/packages/mobile/src/screens/track-screen/RemixContestSubmissionsTab.tsx
@@ -57,7 +57,7 @@ const SubmissionCard = ({ submission }: { submission: LineupData }) => {
   const displaySkeleton = isLoading || !track || !user
 
   const handlePress = useCallback(() => {
-    navigation.navigate('Track', { trackId: submission.id })
+    navigation.push('Track', { trackId: submission.id })
   }, [navigation, submission.id])
 
   return (


### PR DESCRIPTION
### Description
Needed to use `navigation.push` instead of `navigation.navigate` - it was staying on the current track screen but just replacing the metadata and staying at the same scroll position.

### How Has This Been Tested?



https://github.com/user-attachments/assets/7524d531-2035-4188-8305-6c71575b160d

