### PR TITLE
[PE-6118] Fix view all submissions sometimes showing wrong parent track

### DIFF
--- a/packages/mobile/src/screens/track-screen/RemixContestSubmissionsTab.tsx
+++ b/packages/mobile/src/screens/track-screen/RemixContestSubmissionsTab.tsx
@@ -148,7 +148,7 @@ const RemixContestSubmissions = ({
         <PlainButton
           iconRight={IconArrowRight}
           onPress={() => {
-            navigation.navigate('TrackRemixes', { trackId })
+            navigation.push('TrackRemixes', { trackId })
           }}
         >
           {messages.viewAll}

--- a/packages/mobile/src/screens/track-screen/ViewOtherRemixesButton.tsx
+++ b/packages/mobile/src/screens/track-screen/ViewOtherRemixesButton.tsx
@@ -18,7 +18,7 @@ export const ViewOtherRemixesButton = ({
       style={{ alignSelf: 'flex-start' }}
       size='small'
       onPress={() => {
-        navigation.navigate('TrackRemixes', { trackId })
+        navigation.push('TrackRemixes', { trackId })
       }}
     >
       {messages.viewOtherRemixes}


### PR DESCRIPTION
### Description
Another case of needing `navigation.push` instead of `navigation.navigate`.

### How Has This Been Tested?

Confirmed fix on local ios stage