### PR TITLE
Misc upload improvements

### DIFF
--- a/packages/common/src/models/Analytics.ts
+++ b/packages/common/src/models/Analytics.ts
@@ -1089,12 +1089,13 @@ type TrackUploadStartUploading = {
 type TrackUploadTrackUploading = {
   eventName: Name.TRACK_UPLOAD_TRACK_UPLOADING
   artworkSource: 'unsplash' | 'original'
-  genre: string
-  mood: string
   downloadable: 'yes' | 'no' | 'follow'
+  trackId: number
   size: number
-  type: string
+  kind: string
   name: string
+  genre: string
+  mood?: string
 }
 type TrackUploadCompleteUpload = {
   eventName: Name.TRACK_UPLOAD_COMPLETE_UPLOAD
@@ -2194,7 +2195,7 @@ type StripeSessionCreationError = StripeEventFields & {
   eventName: Name.STRIPE_SESSION_CREATION_ERROR
   code: string
   stripeErrorMessage: string
-  type: string
+  kind: string
 }
 
 type StripeSessionCreated = StripeEventFields & {

--- a/packages/common/src/models/Analytics.ts
+++ b/packages/common/src/models/Analytics.ts
@@ -1092,7 +1092,7 @@ type TrackUploadTrackUploading = {
   downloadable: 'yes' | 'no' | 'follow'
   trackId: number
   size: number
-  kind: string
+  fileType: string
   name: string
   genre: string
   mood?: string

--- a/packages/common/src/store/ui/stripe-modal/sagas.ts
+++ b/packages/common/src/store/ui/stripe-modal/sagas.ts
@@ -98,7 +98,7 @@ function* handleInitializeStripeModal({
         code,
         destinationCurrency,
         stripeErrorMessage,
-        type
+        kind: type
       })
     )
   }

--- a/packages/web/src/common/store/upload/sagas.ts
+++ b/packages/web/src/common/store/upload/sagas.ts
@@ -458,7 +458,7 @@ export function* handleUploads({
         genre: track.metadata.genre,
         moode: track.metadata.mood,
         size: track.file.size,
-        kind: track.file.type,
+        fileType: track.file.type,
         name: track.file.name,
         downloadable: isContentFollowGated(track.metadata.download_conditions)
           ? 'follow'

--- a/packages/web/src/common/store/upload/sagas.ts
+++ b/packages/web/src/common/store/upload/sagas.ts
@@ -430,7 +430,7 @@ export function* handleUploads({
   // Channel to listen for responses
   const responseChannel = yield* call(
     channel<UploadTrackResponse>,
-    buffers.expanding(10)
+    buffers.expanding(200)
   )
 
   // Channel to relay progress actions


### PR DESCRIPTION
### Description

Few things:
1. We use `type` as a key in the `TrackUploadTrackUploading` amplitude event. This prevents dispatch from happening because redux uses the `type` key to determine the action name. Also add trackId to this payload.
2. Add a timeout for the "no transcoding progress" part of upload. The hope is that this will alert more loudly than "stuck at 50%"
3. Add some polling to the retrieve tracks call that happens right after upload. I think that an unstable block_confirmation route could lead to a case where we think we're done but we're not.
4. Make the response channel really big instead of just 10. that number seems arbitrary anyway. I don't expect this to do much, but honestly this is really hard to reason with - i think we should rewrite this flow and make it a lot simpler. we don't need all this complex queueing logic on the frontend

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._

* Track upload
* Album upload
* Multi track upload
* Track with stems upload