### PR TITLE
Allow audio swap via sol relay

### DIFF
--- a/packages/discovery-provider/plugins/pedalboard/apps/solana-relay/src/routes/relay/assertRelayAllowedInstructions.ts
+++ b/packages/discovery-provider/plugins/pedalboard/apps/solana-relay/src/routes/relay/assertRelayAllowedInstructions.ts
@@ -100,7 +100,11 @@ const assertAllowedAssociatedTokenAccountProgramInstruction = async (
     isCreateAssociatedTokenAccountInstruction(decodedInstruction) ||
     isCreateAssociatedTokenAccountIdempotentInstruction(decodedInstruction)
   ) {
-    const allowedMints = [NATIVE_MINT.toBase58(), usdcMintAddress]
+    const allowedMints = [
+      NATIVE_MINT.toBase58(),
+      usdcMintAddress,
+      waudioMintAddress
+    ]
     const mintAddress = decodedInstruction.keys.mint.pubkey.toBase58()
     if (!allowedMints.includes(mintAddress)) {
       throw new InvalidRelayInstructionError(
@@ -273,7 +277,11 @@ const JupiterSharedSwapAccountIndex = {
   TOKEN_2022_PROGRAM: 10
 }
 // Only allow swaps from USDC (for withdrawals) or SOL (for userbank purchases)
-const allowedSourceMints = [NATIVE_MINT.toBase58(), usdcMintAddress]
+const allowedSourceMints = [
+  NATIVE_MINT.toBase58(),
+  usdcMintAddress,
+  waudioMintAddress
+]
 const allowedDestinationMints = [
   NATIVE_MINT.toBase58(),
   usdcMintAddress,


### PR DESCRIPTION
### Description
This PR enhances the Solana Relay functionality by adding support for wAUDIO tokens in Jupiter V6 swap operations. The changes:
- Update Jupiter swap instruction validation to allow wAUDIO as a valid source and destination mint for token swaps
- Add wAUDIO token to the list of allowed mints in both the allowedSourceMints and allowedDestinationMints arrays
- Enable users to perform swaps involving wAUDIO tokens through the Audius relay service

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._
