### PR TITLE
Fallback to null instead of 0

### DIFF
--- a/packages/common/src/hooks/useAudioBalance.ts
+++ b/packages/common/src/hooks/useAudioBalance.ts
@@ -11,7 +11,7 @@ import { isNullOrUndefined } from '~/utils/typeUtils'
 /**
  * Pulls balances from account and wallet selectors. Will prefer the wallet
  * balance once it has loaded. Otherwise, will return the account balance if
- * available. Falls back to 0 if neither wallet or account balance are available.
+ * available. Falls back to null if neither wallet or account balance are available.
  */
 export const useTotalBalanceWithFallback = () => {
   const account = useSelector(getAccountUser)
@@ -27,6 +27,6 @@ export const useTotalBalanceWithFallback = () => {
       return new BN(account.total_balance) as BNWei
     }
 
-    return new BN(0) as BNWei
+    return null
   }, [account, walletTotalBalance])
 }

--- a/packages/common/src/hooks/useFormattedAudioBalance.ts
+++ b/packages/common/src/hooks/useFormattedAudioBalance.ts
@@ -4,7 +4,7 @@ import { AUDIO } from '@audius/fixed-decimal'
 
 import { useTokenPrice } from '../api'
 import { TOKEN_LISTING_MAP } from '../store'
-import { formatWei, isNullOrUndefined } from '../utils'
+import { isNullOrUndefined } from '../utils'
 
 import { useTotalBalanceWithFallback } from './useAudioBalance'
 
@@ -13,7 +13,7 @@ const AUDIO_TOKEN_ID = TOKEN_LISTING_MAP.AUDIO.address
 
 type UseFormattedAudioBalanceReturn = {
   audioBalance: ReturnType<typeof useTotalBalanceWithFallback>
-  audioBalanceFormatted: string
+  audioBalanceFormatted: string | null
   isAudioBalanceLoading: boolean
   audioPrice: string | null
   audioDollarValue: string
@@ -22,7 +22,9 @@ type UseFormattedAudioBalanceReturn = {
 
 export const useFormattedAudioBalance = (): UseFormattedAudioBalanceReturn => {
   const audioBalance = useTotalBalanceWithFallback()
-  const audioBalanceFormatted = formatWei(audioBalance, true, 0)
+  const audioBalanceFormatted = audioBalance
+    ? AUDIO(audioBalance).toLocaleString()
+    : null
   const isAudioBalanceLoading = isNullOrUndefined(audioBalance)
 
   const { data: audioPriceData, isPending: isAudioPriceLoading } =

--- a/packages/harmony/src/components/balance-pill/BalancePill.tsx
+++ b/packages/harmony/src/components/balance-pill/BalancePill.tsx
@@ -1,6 +1,7 @@
 import { useTheme, CSSObject } from '@emotion/react'
 
 import { Flex } from '../layout/Flex'
+import { Skeleton } from '../skeleton/Skeleton'
 import { Text } from '../text/Text'
 
 import type { BalancePillProps } from './types'
@@ -19,6 +20,8 @@ export const BalancePill = ({
     color: color.neutral.n950
   }
 
+  const isLoading = balance === null
+
   return (
     <Flex
       pl='s'
@@ -29,9 +32,13 @@ export const BalancePill = ({
       backgroundColor='surface1'
       {...props}
     >
-      <Text variant='label' size='s' textAlign='center' css={textStyles}>
-        {balance}
-      </Text>
+      {isLoading ? (
+        <Skeleton w='m' h='s' />
+      ) : (
+        <Text variant='label' size='s' textAlign='center' css={textStyles}>
+          {balance}
+        </Text>
+      )}
       <Flex h='unit6' p='unitHalf' justifyContent='center' alignItems='center'>
         {children}
       </Flex>

--- a/packages/harmony/src/components/balance-pill/types.ts
+++ b/packages/harmony/src/components/balance-pill/types.ts
@@ -1,6 +1,6 @@
 import { ReactNode } from 'react'
 
 export type BalancePillProps = {
-  balance: string | number
+  balance: string | number | null
   children: ReactNode
 }

--- a/packages/mobile/src/harmony-native/components/BalancePill/BalancePill.tsx
+++ b/packages/mobile/src/harmony-native/components/BalancePill/BalancePill.tsx
@@ -4,7 +4,7 @@ import { Skeleton } from '../Skeleton'
 import { Text } from '../Text/Text'
 import { Flex } from '../layout/Flex/Flex'
 type BalancePillProps = {
-  balance: string
+  balance: string | null
   icon: ReactNode
   isLoading: boolean
 }
@@ -26,7 +26,7 @@ export const BalancePill = (props: BalancePillProps) => {
       borderRadius='circle'
       backgroundColor='surface1'
     >
-      {isLoading ? (
+      {isLoading || !balance ? (
         <Flex h='unit4' w='unit6'>
           <Skeleton />
         </Flex>

--- a/packages/mobile/src/screens/app-drawer-screen/left-nav-drawer/useNavConfig.tsx
+++ b/packages/mobile/src/screens/app-drawer-screen/left-nav-drawer/useNavConfig.tsx
@@ -15,9 +15,9 @@ import { accountSelectors, chatSelectors } from '@audius/common/store'
 import {
   formatCurrencyBalance,
   formatUSDCWeiToFloorCentsNumber,
-  formatWei,
   isNullOrUndefined
 } from '@audius/common/utils'
+import { AUDIO } from '@audius/fixed-decimal'
 import BN from 'bn.js'
 import { useSelector } from 'react-redux'
 
@@ -87,7 +87,9 @@ export const useNavConfig = () => {
   const { user_id } = accountUser ?? ({} as User)
   const { tier } = useSelectTierInfo(user_id)
   const audioBalance = useTotalBalanceWithFallback()
-  const audioBalanceFormatted = formatWei(audioBalance, true, 0)
+  const audioBalanceFormatted = audioBalance
+    ? AUDIO(audioBalance).toLocaleString()
+    : null
   const isAudioBalanceLoading = isNullOrUndefined(audioBalance)
 
   const { data: usdcBalance, status: usdcBalanceStatus } = useUSDCBalance()

--- a/packages/web/src/components/nav/desktop/WalletsNestedContent.tsx
+++ b/packages/web/src/components/nav/desktop/WalletsNestedContent.tsx
@@ -1,16 +1,16 @@
 import {
+  useSelectTierInfo,
   useUSDCBalance,
-  useTotalBalanceWithFallback,
-  useSelectTierInfo
+  useTotalBalanceWithFallback
 } from '@audius/common/hooks'
 import { BNUSDC } from '@audius/common/models'
 import { accountSelectors } from '@audius/common/store'
 import {
-  formatUSDCWeiToFloorCentsNumber,
-  route,
   formatCount,
-  WEI_DIVISOR
+  formatUSDCWeiToFloorCentsNumber,
+  route
 } from '@audius/common/utils'
+import { AUDIO } from '@audius/fixed-decimal'
 import {
   BalancePill,
   Flex,
@@ -56,8 +56,8 @@ export const WalletsNestedContent = () => {
   }[tier]
 
   const audioBalanceFormatted = audioBalance
-    ? formatCount(audioBalance.div(WEI_DIVISOR).toNumber())
-    : '0'
+    ? AUDIO(audioBalance).toLocaleString()
+    : null
 
   const usdcBalanceFormatted = usdcBalance ? formatCount(usdcCentBalance) : '0'
 


### PR DESCRIPTION
### Description
Fallback to null audio balance instead of 0 to avoid showing zero balance.

### How Has This Been Tested?

I couldn't repro the zero balance showing case, but tested the usage of this hook and works where it is called. 
