### PR TITLE
Always flush entity manager challenges

### DIFF
--- a/packages/discovery-provider/src/challenges/challenge_event_bus.py
+++ b/packages/discovery-provider/src/challenges/challenge_event_bus.py
@@ -1,5 +1,4 @@
 import json
-import logging
 from collections import defaultdict
 from contextlib import contextmanager
 from datetime import datetime
@@ -49,8 +48,9 @@ from src.challenges.trending_challenge import (
     trending_underground_track_challenge_manager,
 )
 from src.utils.redis_connection import get_redis
+from src.utils.structured_logger import StructuredLogger
 
-logger = logging.getLogger(__name__)
+logger = StructuredLogger(__name__)
 REDIS_QUEUE_PREFIX = "challenges-event-queue"
 
 

--- a/packages/discovery-provider/src/tasks/entity_manager/entities/comment.py
+++ b/packages/discovery-provider/src/tasks/entity_manager/entities/comment.py
@@ -175,14 +175,13 @@ def create_comment(params: ManageEntityParameters):
 
     params.add_record(comment_id, comment_record, EntityType.COMMENT)
 
-    with challenge_bus.use_scoped_dispatch_queue():
-        challenge_bus.dispatch(
-            ChallengeEvent.first_weekly_comment,
-            params.block_number,
-            params.block_datetime,
-            user_id,
-            {"created_at": params.block_datetime.timestamp()},
-        )
+    challenge_bus.dispatch(
+        ChallengeEvent.first_weekly_comment,
+        params.block_number,
+        params.block_datetime,
+        user_id,
+        {"created_at": params.block_datetime.timestamp()},
+    )
 
     if (
         not is_reply
@@ -746,18 +745,17 @@ def pin_comment(params: ManageEntityParameters):
         )
 
         if artist_is_verified:
-            with params.challenge_bus.use_scoped_dispatch_queue():
-                params.challenge_bus.dispatch(
-                    ChallengeEvent.pinned_comment,
-                    params.block_number,
-                    params.block_datetime,
-                    comment_user_id,
-                    {
-                        "track_id": track_id,
-                        "comment_id": comment_id,
-                        "track_owner_id": track_owner_id,
-                    },
-                )
+            params.challenge_bus.dispatch(
+                ChallengeEvent.pinned_comment,
+                params.block_number,
+                params.block_datetime,
+                comment_user_id,
+                {
+                    "track_id": track_id,
+                    "comment_id": comment_id,
+                    "track_owner_id": track_owner_id,
+                },
+            )
 
     params.add_record(track_id, track, EntityType.TRACK)
 


### PR DESCRIPTION
When testing challenges on local stack, ran into the track-upload challenge unexpectedly not working. Something must have changed here, because flush was never getting called on the challenge bus.

Rather than relying on each caller of the dispatch function in each independent entity manager indexer, I added the scoped dispatch queue around the entire block processing. After every block, after adding all the rows to the db, the challenges will be flushed from the in memory queue and put into redis, ready to be processed by the challenges indexer.

The reason this isn't a problem on stage or prod is because _something else_ would flush the in memory queue and the uploads or whatever else would go with it, whether it's the Solana user bank indexing or plays indexing or whatever.