### PR TITLE
Fix remix contest section submission count

### DIFF
--- a/packages/web/src/pages/track-page/components/desktop/RemixContestSection.tsx
+++ b/packages/web/src/pages/track-page/components/desktop/RemixContestSection.tsx
@@ -3,6 +3,7 @@ import { useState, useCallback } from 'react'
 import { useRemixContest, useRemixes } from '@audius/common/api'
 import { ID } from '@audius/common/models'
 import { UPLOAD_PAGE } from '@audius/common/src/utils/route'
+import { remixesPageSelectors } from '@audius/common/store'
 import {
   Box,
   Button,
@@ -14,6 +15,7 @@ import {
   Text
 } from '@audius/harmony'
 
+import { useSelector } from 'common/hooks/useSelector'
 import { useNavigateToPage } from 'hooks/useNavigateToPage'
 import { useRequiresAccountCallback } from 'hooks/useRequiresAccount'
 import useTabs from 'hooks/useTabs/useTabs'
@@ -38,6 +40,8 @@ type RemixContestSectionProps = {
   isOwner: boolean
 }
 
+const { getCount } = remixesPageSelectors
+
 /**
  * Section component that displays remix contest information for a track
  */
@@ -48,6 +52,8 @@ export const RemixContestSection = ({
   const navigate = useNavigateToPage()
   const { data: remixContest } = useRemixContest(trackId)
   const { data: remixes } = useRemixes({ trackId, isContestEntry: true })
+  const remixCount = useSelector((state) => getCount(state))
+
   const [contentHeight, setContentHeight] = useState(0)
   const hasPrizeInfo = !!remixContest?.eventData?.prizeInfo
 
@@ -69,8 +75,7 @@ export const RemixContestSection = ({
         ]
       : []),
     {
-      text:
-        messages.submissions + (remixes?.length ? ` (${remixes.length})` : ''),
+      text: `${messages.submissions} (${remixCount})`,
       label: 'submissions'
     }
   ]
@@ -112,7 +117,7 @@ export const RemixContestSection = ({
     navigate(UPLOAD_PAGE, state)
   }, [trackId, navigate])
 
-  if (!trackId || !remixContest) return null
+  if (!trackId || !remixContest || !remixCount) return null
 
   const totalBoxHeight = TAB_BAR_HEIGHT + contentHeight
 


### PR DESCRIPTION
### Description

Submission count is currently showing the number of tracks featured in the first page (10) rather than total submission count. 

Fixes PE-6129

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._

Tested against prod and stage. Confirmed count is correct.