### PR TITLE
Fix GiantTrackTile skeletons

### DIFF
--- a/packages/web/src/components/track/GiantArtwork.module.css
+++ b/packages/web/src/components/track/GiantArtwork.module.css
@@ -11,6 +11,8 @@
   border: 1px solid var(--harmony-n-100);
   overflow: hidden;
   position: relative;
+  width: 338px;
+  height: 338px;
 }
 
 .iconLeftWrapper {

--- a/packages/web/src/components/track/GiantTrackTile.module.css
+++ b/packages/web/src/components/track/GiantTrackTile.module.css
@@ -188,11 +188,6 @@
   transition: opacity ease-in-out 0.5s;
 }
 
-.skeleton {
-  position: absolute;
-  top: 0;
-}
-
 .spinner {
   height: var(--harmony-unit-6);
   width: var(--harmony-unit-6);

--- a/packages/web/src/components/track/GiantTrackTile.tsx
+++ b/packages/web/src/components/track/GiantTrackTile.tsx
@@ -503,7 +503,7 @@ export const GiantTrackTile = ({
       css={{ maxWidth: 1080, textAlign: 'left' }}
     >
       <TrackDogEar trackId={trackId} borderOffset={0} />
-      <Flex p='l' gap='xl' css={{ flexWrap: 'wrap' }}>
+      <Flex p='l' gap='xl'>
         <GiantArtwork
           trackId={trackId}
           coSign={coSign}
@@ -523,9 +523,10 @@ export const GiantTrackTile = ({
                   <Text variant='heading' size='xl' className={cn(fadeIn)}>
                     {trackTitle}
                   </Text>
-                  {isLoading && <Skeleton className={styles.skeleton} />}
+                  {isLoading && <Skeleton width='686px' height='96px' />}
                 </Box>
                 <Flex>
+                  {isLoading && <Skeleton width='200px' height='24px' />}
                   <Text
                     variant='title'
                     strength='weak'
@@ -540,9 +541,6 @@ export const GiantTrackTile = ({
                     <Text color='subdued'>By </Text>
                     <UserLink userId={userId} popover />
                   </Text>
-                  {isLoading && (
-                    <Skeleton className={styles.skeleton} width='60%' />
-                  )}
                 </Flex>
                 <div className={cn(fadeIn)}>
                   <TrackStats


### PR DESCRIPTION
### Description
Very confused how this came to be. Git blame points to a seemingly unrelated commit.

I got the skeleton dimensions from staging when the skeletons looked good.

### How Has This Been Tested?

<img width="1920" alt="Screenshot 2025-05-06 at 2 32 56 PM" src="https://github.com/user-attachments/assets/3d7afcfc-ff32-47a4-ad02-eb559555c4ed" />
