### PR TITLE
Fix decimal places on balance

### DIFF
--- a/packages/common/src/hooks/useFormattedAudioBalance.ts
+++ b/packages/common/src/hooks/useFormattedAudioBalance.ts
@@ -4,7 +4,7 @@ import { AUDIO } from '@audius/fixed-decimal'
 
 import { useTokenPrice } from '../api'
 import { TOKEN_LISTING_MAP } from '../store'
-import { isNullOrUndefined } from '../utils'
+import { getDecimalPlaces, isNullOrUndefined } from '../utils'
 
 import { useTotalBalanceWithFallback } from './useAudioBalance'
 
@@ -22,14 +22,21 @@ type UseFormattedAudioBalanceReturn = {
 
 export const useFormattedAudioBalance = (): UseFormattedAudioBalanceReturn => {
   const audioBalance = useTotalBalanceWithFallback()
-  const audioBalanceFormatted = audioBalance
-    ? AUDIO(audioBalance).toLocaleString()
-    : null
-  const isAudioBalanceLoading = isNullOrUndefined(audioBalance)
-
   const { data: audioPriceData, isPending: isAudioPriceLoading } =
     useTokenPrice(AUDIO_TOKEN_ID)
   const audioPrice = audioPriceData?.price || null
+  const isAudioBalanceLoading = isNullOrUndefined(audioBalance)
+
+  const decimalPlaces = useMemo(() => {
+    if (!audioPrice) return 2
+    return getDecimalPlaces(parseFloat(audioPrice))
+  }, [audioPrice])
+
+  const audioBalanceFormatted = audioBalance
+    ? AUDIO(audioBalance).toLocaleString('en-US', {
+        maximumFractionDigits: decimalPlaces
+      })
+    : null
 
   // Calculate dollar value of user's AUDIO balance
   const audioDollarValue = useMemo(() => {

--- a/packages/common/src/hooks/useFormattedAudioBalance.ts
+++ b/packages/common/src/hooks/useFormattedAudioBalance.ts
@@ -4,7 +4,7 @@ import { AUDIO } from '@audius/fixed-decimal'
 
 import { useTokenPrice } from '../api'
 import { TOKEN_LISTING_MAP } from '../store'
-import { getDecimalPlaces, isNullOrUndefined } from '../utils'
+import { getCurrencyDecimalPlaces, isNullOrUndefined } from '../utils'
 
 import { useTotalBalanceWithFallback } from './useAudioBalance'
 
@@ -29,7 +29,7 @@ export const useFormattedAudioBalance = (): UseFormattedAudioBalanceReturn => {
 
   const decimalPlaces = useMemo(() => {
     if (!audioPrice) return 2
-    return getDecimalPlaces(parseFloat(audioPrice))
+    return getCurrencyDecimalPlaces(parseFloat(audioPrice))
   }, [audioPrice])
 
   const audioBalanceFormatted = audioBalance

--- a/packages/common/src/utils/decimal.ts
+++ b/packages/common/src/utils/decimal.ts
@@ -55,7 +55,7 @@ export const decimalIntegerFromHumanReadable = (
   return parseFloat(value) * 10 ** precision
 }
 
-export const getDecimalPlaces = (priceUSD: number) => {
+export const getCurrencyDecimalPlaces = (priceUSD: number) => {
   if (priceUSD >= 1) return 2
   if (priceUSD >= 0.01) return 4
   if (priceUSD >= 0.0001) return 6

--- a/packages/common/src/utils/decimal.ts
+++ b/packages/common/src/utils/decimal.ts
@@ -54,3 +54,10 @@ export const decimalIntegerFromHumanReadable = (
 ) => {
   return parseFloat(value) * 10 ** precision
 }
+
+export const getDecimalPlaces = (priceUSD: number) => {
+  if (priceUSD >= 1) return 2
+  if (priceUSD >= 0.01) return 4
+  if (priceUSD >= 0.0001) return 6
+  return 8
+}

--- a/packages/web/src/pages/pay-and-earn-page/components/YourCoins.tsx
+++ b/packages/web/src/pages/pay-and-earn-page/components/YourCoins.tsx
@@ -17,6 +17,10 @@ import { push } from 'redux-first-history'
 const DIMENSIONS = 64
 const { WALLET_AUDIO_PAGE } = route
 
+const messages = {
+  audio: '$AUDIO'
+}
+
 export const YourCoins = () => {
   const dispatch = useDispatch()
   const { color, spacing, cornerRadius } = useTheme()
@@ -76,7 +80,7 @@ export const YourCoins = () => {
                 {audioBalanceFormatted}
               </Text>
               <Text variant='heading' size='l' color='subdued'>
-                $AUDIO
+                {messages.audio}
               </Text>
             </Flex>
             <Text variant='heading' size='s' color='subdued'>


### PR DESCRIPTION
### Description
Too many decimals were showing for AUDIO balances, updated based on suggestion [here](https://audius-internal.slack.com/archives/C08KS3QB7JM/p1746216692922929?thread_ts=1746216432.456869&cid=C08KS3QB7JM)

### How Has This Been Tested?

Before:

<img width="699" alt="image" src="https://github.com/user-attachments/assets/64d8e3d3-f9fb-4c4d-9db6-882b0b39a622" />


After:

<img width="702" alt="image" src="https://github.com/user-attachments/assets/618068d9-9823-45e7-abe0-c6a573c84bb6" />

