### PR TITLE
Improve sentry install

### DIFF
--- a/packages/mobile/android/app/build.gradle
+++ b/packages/mobile/android/app/build.gradle
@@ -60,10 +60,7 @@ project.ext.envConfigFiles = [
     releasecandidaterelease: ".env.prod"
 ]
 
-def sentryGradleFile = file("../../../../node_modules/@sentry/react-native/sentry.gradle")
-if (!sentryGradleFile.exists()) {
-    sentryGradleFile = file("../../node_modules/@sentry/react-native/sentry.gradle")
-}
+def sentryGradleFile = file("../../node_modules/@sentry/react-native/sentry.gradle")
 
 apply from: sentryGradleFile
 apply from: project(':react-native-config').projectDir.getPath() + "/dotenv.gradle"

--- a/packages/mobile/ios/Podfile.lock
+++ b/packages/mobile/ios/Podfile.lock
@@ -1974,7 +1974,7 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - Yoga
-  - RNSentry (6.10.0):
+  - RNSentry (6.11.0):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -1995,7 +1995,7 @@ PODS:
     - ReactCodegen
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
-    - Sentry/HybridSDK (= 8.48.0)
+    - Sentry/HybridSDK (= 8.49.0)
     - Yoga
   - RNShare (10.0.2):
     - React-Core
@@ -2014,7 +2014,7 @@ PODS:
   - SDWebImageWebPCoder (0.8.5):
     - libwebp (~> 1.0)
     - SDWebImage/Core (~> 5.10)
-  - Sentry/HybridSDK (8.48.0)
+  - Sentry/HybridSDK (8.49.0)
   - snap-kit-react-native (0.4.0):
     - React-Core
     - SnapSDK/SCSDKCreativeKit (~> 1.15.0)
@@ -2145,7 +2145,7 @@ DEPENDENCIES:
   - RNReactNativeHapticFeedback (from `../node_modules/react-native-haptic-feedback`)
   - RNReanimated (from `../node_modules/react-native-reanimated`)
   - RNScreens (from `../../../node_modules/react-native-screens`)
-  - "RNSentry (from `../../../node_modules/@sentry/react-native`)"
+  - "RNSentry (from `../node_modules/@sentry/react-native`)"
   - RNShare (from `../node_modules/react-native-share`)
   - RNSVG (from `../node_modules/react-native-svg`)
   - RNZipArchive (from `../../../node_modules/react-native-zip-archive`)
@@ -2392,7 +2392,7 @@ EXTERNAL SOURCES:
   RNScreens:
     :path: "../../../node_modules/react-native-screens"
   RNSentry:
-    :path: "../../../node_modules/@sentry/react-native"
+    :path: "../node_modules/@sentry/react-native"
   RNShare:
     :path: "../node_modules/react-native-share"
   RNSVG:
@@ -2523,13 +2523,13 @@ SPEC CHECKSUMS:
   RNReactNativeHapticFeedback: ec56a5f81c3941206fd85625fa669ffc7b4545f9
   RNReanimated: 6a3de5f597530c311b4390c97155643a4ff2e278
   RNScreens: 62c0e7e123f40c095f03842e6b95c46e5d42040c
-  RNSentry: 04c096f6931bb1eb46eb5bfb132e9dc67687fad1
+  RNSentry: 0f257fbba0e224d3acd9f0010a65fc0307b3dda5
   RNShare: 859ff710211285676b0bcedd156c12437ea1d564
   RNSVG: 7ff26379b2d1871b8571e6f9bc9630de6baf9bdf
   RNZipArchive: 7bb4c70d6aa2dd235212c0a4a3de0a4e237e2569
   SDWebImage: a7f831e1a65eb5e285e3fb046a23fcfbf08e696d
   SDWebImageWebPCoder: 908b83b6adda48effe7667cd2b7f78c897e5111d
-  Sentry: 1ca8405451040482877dcd344dfa3ef80b646631
+  Sentry: 5eda2559a20fa0c377b695ed9d7c178a47122891
   snap-kit-react-native: 751006199818fccb38c8a01196495167bc25e9fb
   SnapSDK: 1e68aad748e080f49e3802559b3b76026666ef62
   SocketRocket: d4aabe649be1e368d1318fdf28a022d714d65748

--- a/packages/mobile/package.json
+++ b/packages/mobile/package.json
@@ -89,7 +89,7 @@
     "@redux-devtools/remote": "0.8.0",
     "@reduxjs/toolkit": "1.6.1",
     "@sayem314/react-native-keep-awake": "1.2.2",
-    "@sentry/react-native": "6.10.0",
+    "@sentry/react-native": "6.11.0",
     "@snapchat/snap-kit-react-native": "0.4.0",
     "@solana-mobile/mobile-wallet-adapter-protocol": "0.9.9",
     "@solana-mobile/mobile-wallet-adapter-protocol-web3js": "0.9.9",


### PR DESCRIPTION
### Description

Improves sentry install from the root to /mobile directory, which pairs better with react-native also located at /mobile. I needed to bump a minor version to trigger this change, which should be chill