### PR TITLE
Fix DN tests: Add challenge_event_bus to tests

### DIFF
--- a/packages/discovery-provider/integration_tests/tasks/entity_manager/test_dashboard_wallet_user_entity_manager.py
+++ b/packages/discovery-provider/integration_tests/tasks/entity_manager/test_dashboard_wallet_user_entity_manager.py
@@ -7,6 +7,7 @@ from web3.types import TxReceipt
 
 from integration_tests.challenges.index_helpers import UpdateTask
 from integration_tests.utils import populate_mock_db
+from src.challenges.challenge_event_bus import ChallengeEventBus, setup_challenge_bus
 from src.models.dashboard_wallet_user.dashboard_wallet_user import DashboardWalletUser
 from src.tasks.entity_manager.entity_manager import entity_manager_update
 from src.tasks.entity_manager.utils import Action, EntityType
@@ -85,7 +86,8 @@ def test_index_dashboard_wallet_user(app, mocker):
     with app.app_context():
         db = get_db()
         web3 = Web3()
-        update_task = UpdateTask(web3, None)
+        challenge_event_bus: ChallengeEventBus = setup_challenge_bus()
+        update_task = UpdateTask(web3, challenge_event_bus)
 
     """"
     const resp = await this.manageEntity({

--- a/packages/discovery-provider/integration_tests/tasks/entity_manager/test_developer_app_entity_manager.py
+++ b/packages/discovery-provider/integration_tests/tasks/entity_manager/test_developer_app_entity_manager.py
@@ -7,6 +7,7 @@ from web3.types import TxReceipt
 
 from integration_tests.challenges.index_helpers import UpdateTask
 from integration_tests.utils import populate_mock_db
+from src.challenges.challenge_event_bus import ChallengeEventBus, setup_challenge_bus
 from src.models.grants.developer_app import DeveloperApp
 from src.tasks.entity_manager.entity_manager import entity_manager_update
 from src.tasks.entity_manager.utils import Action, EntityType
@@ -100,7 +101,8 @@ def test_index_app(app, mocker):
     with app.app_context():
         db = get_db()
         web3 = Web3()
-        update_task = UpdateTask(web3, None)
+        challenge_event_bus: ChallengeEventBus = setup_challenge_bus()
+        update_task = UpdateTask(web3, challenge_event_bus)
 
     """"
     const resp = await this.manageEntity({
@@ -764,7 +766,8 @@ def test_developer_app_update(app, mocker):
     with app.app_context():
         db = get_db()
         web3 = Web3()
-        update_task = UpdateTask(web3, None)
+        challenge_event_bus: ChallengeEventBus = setup_challenge_bus()
+        update_task = UpdateTask(web3, challenge_event_bus)
 
     # Create one app first
     tx_receipts = {

--- a/packages/discovery-provider/integration_tests/tasks/entity_manager/test_email_entity_manager.py
+++ b/packages/discovery-provider/integration_tests/tasks/entity_manager/test_email_entity_manager.py
@@ -6,6 +6,7 @@ from web3.datastructures import AttributeDict
 
 from integration_tests.challenges.index_helpers import UpdateTask
 from integration_tests.utils import populate_mock_db
+from src.challenges.challenge_event_bus import ChallengeEventBus, setup_challenge_bus
 from src.models.users.email import EmailAccess, EncryptedEmail
 from src.tasks.entity_manager.entity_manager import entity_manager_update
 from src.tasks.entity_manager.utils import Action, EntityType
@@ -37,7 +38,8 @@ def test_index_valid_email(app, mocker):
     with app.app_context():
         db = get_db()
         web3 = Web3()
-        update_task = UpdateTask(web3, None)
+        challenge_event_bus: ChallengeEventBus = setup_challenge_bus()
+        update_task = UpdateTask(web3, challenge_event_bus)
 
         # Ensure table setup
         with db.scoped_session() as session:
@@ -148,7 +150,8 @@ def test_index_invalid_email(app, mocker):
     with app.app_context():
         db = get_db()
         web3 = Web3()
-        update_task = UpdateTask(web3, None)
+        challenge_event_bus: ChallengeEventBus = setup_challenge_bus()
+        update_task = UpdateTask(web3, challenge_event_bus)
 
         # Ensure table setup
         with db.scoped_session() as session:
@@ -229,7 +232,8 @@ def test_duplicate_email_access(app, mocker):
     with app.app_context():
         db = get_db()
         web3 = Web3()
-        update_task = UpdateTask(web3, None)
+        challenge_event_bus: ChallengeEventBus = setup_challenge_bus()
+        update_task = UpdateTask(web3, challenge_event_bus)
 
         # Ensure table setup
         with db.scoped_session() as session:

--- a/packages/discovery-provider/integration_tests/tasks/entity_manager/test_grant_entity_manager.py
+++ b/packages/discovery-provider/integration_tests/tasks/entity_manager/test_grant_entity_manager.py
@@ -5,6 +5,7 @@ from web3.datastructures import AttributeDict
 
 from integration_tests.challenges.index_helpers import UpdateTask
 from integration_tests.utils import populate_mock_db, populate_mock_db_blocks
+from src.challenges.challenge_event_bus import ChallengeEventBus, setup_challenge_bus
 from src.models.grants.grant import Grant
 from src.tasks.entity_manager.entity_manager import entity_manager_update
 from src.tasks.entity_manager.utils import Action, EntityType
@@ -73,7 +74,8 @@ def test_index_grant(app, mocker):
     with app.app_context():
         db = get_db()
         web3 = Web3()
-        update_task = UpdateTask(web3, None)
+        challenge_event_bus: ChallengeEventBus = setup_challenge_bus()
+        update_task = UpdateTask(web3, challenge_event_bus)
 
     tx_receipts = {
         "CreateGrantTx1": [

--- a/packages/discovery-provider/integration_tests/tasks/entity_manager/test_index_notification.py
+++ b/packages/discovery-provider/integration_tests/tasks/entity_manager/test_index_notification.py
@@ -5,6 +5,7 @@ from web3.datastructures import AttributeDict
 
 from integration_tests.challenges.index_helpers import UpdateTask
 from integration_tests.utils import populate_mock_db
+from src.challenges.challenge_event_bus import ChallengeEventBus, setup_challenge_bus
 from src.models.notifications.notification import NotificationSeen
 from src.tasks.entity_manager.entity_manager import entity_manager_update
 from src.tasks.entity_manager.utils import Action, EntityType
@@ -18,7 +19,8 @@ def test_index_notification_view(app, mocker):
     with app.app_context():
         db = get_db()
         web3 = Web3()
-        update_task = UpdateTask(web3, None)
+        challenge_event_bus: ChallengeEventBus = setup_challenge_bus()
+        update_task = UpdateTask(web3, challenge_event_bus)
 
     tx_receipts = {
         "NotificationRead1Tx": [

--- a/packages/discovery-provider/integration_tests/tasks/entity_manager/test_index_playlist_seen.py
+++ b/packages/discovery-provider/integration_tests/tasks/entity_manager/test_index_playlist_seen.py
@@ -6,6 +6,7 @@ from web3.datastructures import AttributeDict
 
 from integration_tests.challenges.index_helpers import UpdateTask
 from integration_tests.utils import populate_mock_db
+from src.challenges.challenge_event_bus import ChallengeEventBus, setup_challenge_bus
 from src.models.indexing.revert_block import RevertBlock
 from src.models.notifications.notification import PlaylistSeen
 from src.tasks.entity_manager.entity_manager import entity_manager_update
@@ -20,7 +21,8 @@ def test_index_playlist_view(app, mocker):
     with app.app_context():
         db = get_db()
         web3 = Web3()
-        update_task = UpdateTask(web3, None)
+        challenge_event_bus: ChallengeEventBus = setup_challenge_bus()
+        update_task = UpdateTask(web3, challenge_event_bus)
 
     tx_receipts = {
         "PlaylistSeenTx1": [

--- a/packages/discovery-provider/integration_tests/tasks/entity_manager/test_index_skip_tx.py
+++ b/packages/discovery-provider/integration_tests/tasks/entity_manager/test_index_skip_tx.py
@@ -6,6 +6,7 @@ from web3.datastructures import AttributeDict
 
 from integration_tests.challenges.index_helpers import UpdateTask
 from integration_tests.utils import populate_mock_db_blocks
+from src.challenges.challenge_event_bus import ChallengeEventBus, setup_challenge_bus
 from src.models.indexing.skipped_transaction import SkippedTransaction
 from src.tasks.entity_manager.entity_manager import entity_manager_update
 from src.utils.db_session import get_db
@@ -55,7 +56,8 @@ def test_skip_tx(app, mocker):
         web3 = Web3()
         redis = get_redis()
 
-        update_task = UpdateTask(web3, None, redis)
+        challenge_event_bus: ChallengeEventBus = setup_challenge_bus()
+        update_task = UpdateTask(web3, challenge_event_bus, redis)
 
     tx_receipts = {
         # invalid create

--- a/packages/discovery-provider/integration_tests/tasks/entity_manager/test_playlist_entity_manager.py
+++ b/packages/discovery-provider/integration_tests/tasks/entity_manager/test_playlist_entity_manager.py
@@ -1071,7 +1071,8 @@ def test_invalid_playlist_description(app, mocker):
     with app.app_context():
         db = get_db()
         web3 = Web3()
-        update_task = UpdateTask(web3, None, None, None)
+        challenge_event_bus: ChallengeEventBus = setup_challenge_bus()
+        update_task = UpdateTask(web3, challenge_event_bus)
 
     metadata = {
         "PlaylistInvalidDescriptionMetadata": {

--- a/packages/discovery-provider/integration_tests/tasks/entity_manager/test_social_feature_entity_manager.py
+++ b/packages/discovery-provider/integration_tests/tasks/entity_manager/test_social_feature_entity_manager.py
@@ -516,11 +516,14 @@ def test_index_cosign(app, mocker):
 def test_index_invalid_social_features(app, mocker):
     "Tests valid batch of social create/update/delete actions"
 
+    bus_mock = mocker.patch(
+        "src.challenges.challenge_event_bus.ChallengeEventBus", autospec=True
+    )
     # setup db and mocked txs
     with app.app_context():
         db = get_db()
         web3 = Web3()
-        update_task = UpdateTask(web3, None)
+        update_task = UpdateTask(web3, challenge_event_bus=bus_mock)
 
     tx_receipts = {
         "UserDoesNotExistTx1": [

--- a/packages/discovery-provider/integration_tests/tasks/entity_manager/test_tip_reactions.py
+++ b/packages/discovery-provider/integration_tests/tasks/entity_manager/test_tip_reactions.py
@@ -6,6 +6,7 @@ from web3.datastructures import AttributeDict
 
 from integration_tests.challenges.index_helpers import UpdateTask
 from integration_tests.utils import populate_mock_db, populate_mock_db_blocks
+from src.challenges.challenge_event_bus import ChallengeEventBus, setup_challenge_bus
 from src.models.social.reaction import Reaction
 from src.tasks.entity_manager.entity_manager import entity_manager_update
 from src.tasks.entity_manager.utils import Action, EntityType
@@ -18,7 +19,8 @@ def test_index_tip_reactions(app, mocker):
     with app.app_context():
         db = get_db()
         web3 = Web3()
-        update_task = UpdateTask(web3, None)
+        challenge_event_bus: ChallengeEventBus = setup_challenge_bus()
+        update_task = UpdateTask(web3, challenge_event_bus)
 
     tx_receipts = {
         # user 2 reacts to the tip they received from user 1

--- a/packages/discovery-provider/integration_tests/tasks/entity_manager/test_track_entity_manager.py
+++ b/packages/discovery-provider/integration_tests/tasks/entity_manager/test_track_entity_manager.py
@@ -611,7 +611,9 @@ def test_index_invalid_tracks(app, mocker):
     with app.app_context():
         db = get_db()
         web3 = Web3()
-        update_task = UpdateTask(web3, None)
+        challenge_event_bus: ChallengeEventBus = setup_challenge_bus()
+        update_task = UpdateTask(web3, challenge_event_bus)
+
     test_metadata = {
         "QmAIDisabled": {"ai_attribution_user_id": 2},
         "QmInvalidUpdateTrack1": {
@@ -1116,7 +1118,8 @@ def test_invalid_track_description(app, mocker):
     with app.app_context():
         db = get_db()
         web3 = Web3()
-        update_task = UpdateTask(web3, None)
+        challenge_event_bus: ChallengeEventBus = setup_challenge_bus()
+        update_task = UpdateTask(web3, challenge_event_bus)
 
     metadata = {
         "CreateInvalidTrackDescriptionMetadata": {

--- a/packages/discovery-provider/integration_tests/tasks/entity_manager/test_user_entity_manager.py
+++ b/packages/discovery-provider/integration_tests/tasks/entity_manager/test_user_entity_manager.py
@@ -12,6 +12,7 @@ from web3.datastructures import AttributeDict
 from integration_tests.challenges.index_helpers import UpdateTask
 from integration_tests.utils import populate_mock_db, populate_mock_db_blocks
 from src.challenges.challenge_event import ChallengeEvent
+from src.challenges.challenge_event_bus import ChallengeEventBus, setup_challenge_bus
 from src.models.users.associated_wallet import AssociatedWallet
 from src.models.users.collectibles import Collectibles
 from src.models.users.user import User
@@ -464,7 +465,8 @@ def test_index_invalid_users(app, mocker):
     with app.app_context():
         db = get_db()
         web3 = Web3()
-        update_task = UpdateTask(web3, None)
+        challenge_event_bus: ChallengeEventBus = setup_challenge_bus()
+        update_task = UpdateTask(web3, challenge_event_bus)
 
     test_metadata = {
         "QmCreateUser1": {


### PR DESCRIPTION
The commit from:
- #12018 

made it so that entity manager always attempts to flush the dispatch queue for challenges. In doing so, it broke some tests that were failing to set the `challenge_event_bus` on the `update_task`