### PR TITLE
[QA-2089] Fix tip success icon

### DIFF
--- a/packages/harmony/src/components/completion-check/CompletionCheck.tsx
+++ b/packages/harmony/src/components/completion-check/CompletionCheck.tsx
@@ -47,13 +47,14 @@ const completionComponents = {
 }
 
 export const CompletionCheck = (props: CompletionCheckProps) => {
-  const transitions = useTransition(props.value, {
+  const { value, className } = props
+  const transitions = useTransition(value, {
     from: { x: 0 },
     enter: { x: 1 },
     leave: { x: 0 }
   })
   return (
-    <Flex alignItems='center' className={styles.container}>
+    <Flex alignItems='center' className={cn(styles.container, className)}>
       <CompletionDefault />
       {transitions((style, value) => {
         if (completionComponents[value]) {

--- a/packages/harmony/src/components/completion-check/types.ts
+++ b/packages/harmony/src/components/completion-check/types.ts
@@ -1,3 +1,4 @@
 export type CompletionCheckProps = {
   value: 'incomplete' | 'complete' | 'error'
+  className?: string
 }

--- a/packages/web/src/components/tipping/tip-audio/TipAudio.module.css
+++ b/packages/web/src/components/tipping/tip-audio/TipAudio.module.css
@@ -275,14 +275,6 @@
   margin: 0 2px 0 0px !important;
 }
 
-.iconSuccess path:nth-child(1) {
-  fill: var(--harmony-green);
-}
-
-.iconSuccess path:nth-child(2) {
-  fill: var(--harmony-white);
-}
-
 .iconToken path {
   fill: revert-layer;
 }

--- a/packages/web/src/components/tipping/tip-audio/TipAudioModal.tsx
+++ b/packages/web/src/components/tipping/tip-audio/TipAudioModal.tsx
@@ -9,7 +9,7 @@ import {
 } from '@audius/common/store'
 import { Nullable } from '@audius/common/utils'
 import {
-  IconVerified as IconSuccess,
+  CompletionCheck,
   Modal,
   ModalHeader,
   ModalTitle
@@ -64,7 +64,12 @@ const titleIconsMap: { [key in TippingSendStatus]?: Nullable<JSX.Element> } = {
   SENDING: <GoldBadgeIconImage />,
   CONVERTING: null,
   ERROR: <GoldBadgeIconImage />,
-  SUCCESS: <IconSuccess width={24} height={24} className={styles.iconSuccess} />
+  SUCCESS: (
+    <CompletionCheck
+      value='complete'
+      css={{ svg: { path: { fill: 'var(--harmony-white)' } } }}
+    />
+  )
 }
 
 const renderModalContent = (pageNumber: number) => {


### PR DESCRIPTION
### Description

Replaces verified icon with CompletionCheck. Needed to add a color override since the modal header auto-applies a color