### PR TITLE
Fix ffmpeg-kit-react-native podspec path

### DIFF
--- a/packages/mobile/ios/Podfile
+++ b/packages/mobile/ios/Podfile
@@ -33,7 +33,7 @@ project 'AudiusReactNative',
 target 'AudiusReactNative' do
   pod 'SRSRadialGradient', :path => '../../../node_modules/react-native-radial-gradient/ios'
   pod 'ffmpeg-kit-ios-https-gpl', :path => './vendor/ffmpeg-kit-ios-https-gpl'
-  pod 'ffmpeg-kit-react-native', :subspecs => ['https-gpl-lts'], :podspec => '../node_modules/ffmpeg-kit-react-native/ffmpeg-kit-react-native.podspec'
+  pod 'ffmpeg-kit-react-native', :subspecs => ['https-gpl-lts'], :podspec => '../../../node_modules/ffmpeg-kit-react-native/ffmpeg-kit-react-native.podspec'
   pod 'nSure'
 
   config = use_native_modules!

--- a/packages/mobile/ios/Podfile.lock
+++ b/packages/mobile/ios/Podfile.lock
@@ -2042,7 +2042,7 @@ DEPENDENCIES:
   - fast_float (from `../node_modules/react-native/third-party-podspecs/fast_float.podspec`)
   - FBLazyVector (from `../node_modules/react-native/Libraries/FBLazyVector`)
   - ffmpeg-kit-ios-https-gpl (from `./vendor/ffmpeg-kit-ios-https-gpl`)
-  - ffmpeg-kit-react-native/https-gpl-lts (from `../node_modules/ffmpeg-kit-react-native/ffmpeg-kit-react-native.podspec`)
+  - ffmpeg-kit-react-native/https-gpl-lts (from `../../../node_modules/ffmpeg-kit-react-native/ffmpeg-kit-react-native.podspec`)
   - fmt (from `../node_modules/react-native/third-party-podspecs/fmt.podspec`)
   - glog (from `../node_modules/react-native/third-party-podspecs/glog.podspec`)
   - hermes-engine (from `../node_modules/react-native/sdks/hermes-engine/hermes-engine.podspec`)
@@ -2191,7 +2191,7 @@ EXTERNAL SOURCES:
   ffmpeg-kit-ios-https-gpl:
     :path: "./vendor/ffmpeg-kit-ios-https-gpl"
   ffmpeg-kit-react-native:
-    :podspec: "../node_modules/ffmpeg-kit-react-native/ffmpeg-kit-react-native.podspec"
+    :podspec: "../../../node_modules/ffmpeg-kit-react-native/ffmpeg-kit-react-native.podspec"
   fmt:
     :podspec: "../node_modules/react-native/third-party-podspecs/fmt.podspec"
   glog:
@@ -2540,6 +2540,6 @@ SPEC CHECKSUMS:
   TOCropViewController: 80b8985ad794298fb69d3341de183f33d1853654
   Yoga: feb4910aba9742cfedc059e2b2902e22ffe9954a
 
-PODFILE CHECKSUM: 10c25bd4f168e5cb4086cb241e0cfe9d66c7e59a
+PODFILE CHECKSUM: 787f7d4a45417340b4c750bf64a6b629e2ffaf31
 
 COCOAPODS: 1.15.2


### PR DESCRIPTION
### Description

Fixes issue where the moved ffmpeg-kit-react-native patch causes pod install to fail. This wasn't caught before due to caching