### PR TITLE
Remove RemixContestStarted from notifs valid types

### DIFF
--- a/packages/common/src/api/tan-query/notifications/useNotificationValidTypes.ts
+++ b/packages/common/src/api/tan-query/notifications/useNotificationValidTypes.ts
@@ -17,7 +17,6 @@ export const useNotificationValidTypes = () => {
     ValidTypes.CommentMention,
     ValidTypes.CommentReaction,
     ValidTypes.ClaimableReward,
-    ValidTypes.ListenStreakReminder,
-    ValidTypes.RemixContestStarted
+    ValidTypes.ListenStreakReminder
   ]
 }


### PR DESCRIPTION
### Description
Remove this notif type from release 133, so that the client doesn't fetch these new notifs

### How Has This Been Tested?


