### PR TITLE
Ensure python 3.11 is installed

### DIFF
--- a/.circleci/src/jobs/@web-jobs.yml
+++ b/.circleci/src/jobs/@web-jobs.yml
@@ -287,6 +287,13 @@ web-dist-mac-staging:
   macos:
     xcode: '16.2.0'
   steps:
+    - run:
+        name: Install Python 3.11
+        command: |
+          brew install pyenv
+          pyenv install 3.11.8
+          pyenv global 3.11.8
+          python3 --version
     - web-distribute:
         build-type: mac-publish
         install-license: true
@@ -320,6 +327,13 @@ web-dist-mac-production:
   macos:
     xcode: '16.2.0'
   steps:
+    - run:
+        name: Install Python 3.11
+        command: |
+          brew install pyenv
+          pyenv install 3.11.8
+          pyenv global 3.11.8
+          python3 --version
     - web-distribute:
         build-type: mac-publish-production
         install-license: true


### PR DESCRIPTION
### Description

Fixes desktop builds by ensuring we are using the same version of python as local dev. TLDR the latest python is missing a critical dependency that electron-builder is expecting.