### PR TITLE
Update routes to fix profile page and track pages not rendering

### DIFF
--- a/packages/web/src/app/web-player/WebPlayer.jsx
+++ b/packages/web/src/app/web-player/WebPlayer.jsx
@@ -748,6 +748,17 @@ class WebPlayer extends Component {
                   component={SavedPage}
                 />
                 <Route exact path={HISTORY_PAGE} component={HistoryPage} />
+                {isDevOrStaging && (
+                  <Route exact path={DEV_TOOLS_PAGE} component={DevTools} />
+                )}
+                {isDevOrStaging && (
+                  <Route
+                    exact
+                    path={SOLANA_TOOLS_PAGE}
+                    component={SolanaToolsPage}
+                  />
+                )}
+
                 <DesktopRoute
                   exact
                   path={DASHBOARD_PAGE}

--- a/packages/web/src/app/web-player/WebPlayer.jsx
+++ b/packages/web/src/app/web-player/WebPlayer.jsx
@@ -748,16 +748,6 @@ class WebPlayer extends Component {
                   component={SavedPage}
                 />
                 <Route exact path={HISTORY_PAGE} component={HistoryPage} />
-                {isDevOrStaging && (
-                  <>
-                    <Route exact path={DEV_TOOLS_PAGE} component={DevTools} />
-                    <Route
-                      exact
-                      path={SOLANA_TOOLS_PAGE}
-                      component={SolanaToolsPage}
-                    />
-                  </>
-                )}
                 <DesktopRoute
                   exact
                   path={DASHBOARD_PAGE}
@@ -1076,6 +1066,16 @@ class WebPlayer extends Component {
                       : ''
                   }}
                 />
+                {isDevOrStaging && (
+                  <>
+                    <Route exact path={DEV_TOOLS_PAGE} component={DevTools} />
+                    <Route
+                      exact
+                      path={SOLANA_TOOLS_PAGE}
+                      component={SolanaToolsPage}
+                    />
+                  </>
+                )}
               </SwitchComponent>
             </Suspense>
           </div>

--- a/packages/web/src/app/web-player/WebPlayer.jsx
+++ b/packages/web/src/app/web-player/WebPlayer.jsx
@@ -1077,16 +1077,6 @@ class WebPlayer extends Component {
                       : ''
                   }}
                 />
-                {isDevOrStaging && (
-                  <>
-                    <Route exact path={DEV_TOOLS_PAGE} component={DevTools} />
-                    <Route
-                      exact
-                      path={SOLANA_TOOLS_PAGE}
-                      component={SolanaToolsPage}
-                    />
-                  </>
-                )}
               </SwitchComponent>
             </Suspense>
           </div>

--- a/packages/web/src/app/web-player/WebPlayer.jsx
+++ b/packages/web/src/app/web-player/WebPlayer.jsx
@@ -748,16 +748,16 @@ class WebPlayer extends Component {
                   component={SavedPage}
                 />
                 <Route exact path={HISTORY_PAGE} component={HistoryPage} />
-                {isDevOrStaging && (
+                {isDevOrStaging ? (
                   <Route exact path={DEV_TOOLS_PAGE} component={DevTools} />
-                )}
-                {isDevOrStaging && (
+                ) : null}
+                {isDevOrStaging ? (
                   <Route
                     exact
                     path={SOLANA_TOOLS_PAGE}
                     component={SolanaToolsPage}
                   />
-                )}
+                ) : null}
 
                 <DesktopRoute
                   exact


### PR DESCRIPTION
### Description
Updated routes to fix profile page and track pages not rendering, the slug params were intercepting so navigation was broken

> The most likely scenario is that the presence of the fragment, when isDevOrStaging is true, interferes with the Switch's matching logic for subsequent routes. It might:
> Incorrectly match one of the dev tool routes (even if the URL is for a profile/track page) if their paths were unintentionally broad (though exact should prevent this if paths are truly distinct).
> More plausibly, the Switch's internal mechanism for finding the "first match" gets confused when a fragment is a direct child, leading it to not correctly evaluate or render the later TRACK_PAGE or PROFILE_PAGE routes for their respective URLs. It might effectively stop processing or misinterpret the subsequent routes.

### How Has This Been Tested?

`npm run web:stage` and navigate to one of the two choices
