### PR TITLE
Increase bundlesize max chunk size

### DIFF
--- a/packages/web/bundlesize.prod.config.json
+++ b/packages/web/bundlesize.prod.config.json
@@ -2,7 +2,7 @@
   "files": [
     {
       "path": "./build-ssr-production/server/chunks/chunk-*.js",
-      "maxSize": "100 kB"
+      "maxSize": "110 kB"
     }
   ]
 }

--- a/packages/web/bundlesize.stage.config.json
+++ b/packages/web/bundlesize.stage.config.json
@@ -2,7 +2,7 @@
   "files": [
     {
       "path": "./build-ssr-staging/server/chunks/chunk-*.js",
-      "maxSize": "100 kB"
+      "maxSize": "110 kB"
     }
   ]
 }


### PR DESCRIPTION
### Description

Getting errors running `npm run bundlesize:stage`. After some testing it's definitely from merging search into the explore page https://github.com/AudiusProject/audius-protocol/pull/12050. I think it's something to do with Search and Explore page needing to be in the same chunk since they're both large and essentially duplicated. For lack of a better fix, just slightly increasing the max size here and will delete a bunch of code after launch.


```
 PASS  ./build-ssr-staging/server/chunks/chunk-3255356c.js: 5.27KB < maxSize 110KB (gzip) 

 PASS  ./build-ssr-staging/server/chunks/chunk-3d0f38e9.js: 13.63KB < maxSize 110KB (gzip) 

 PASS  ./build-ssr-staging/server/chunks/chunk-4ff6a687.js: 94.87KB < maxSize 110KB (gzip) 

 PASS  ./build-ssr-staging/server/chunks/chunk-b16a120b.js: 143B < maxSize 110KB (gzip) 

 PASS  ./build-ssr-staging/server/chunks/chunk-c388bca5.js: 8.64KB < maxSize 110KB (gzip) 

 PASS  ./build-ssr-staging/server/chunks/chunk-d858645c.js: 105.58KB < maxSize 110KB (gzip) 
 ```

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._
