### PR TITLE
Add remix contest and loading skeletons to new explore page

### DIFF
--- a/packages/web/src/components/remix-contest-card/RemixContestCard.tsx
+++ b/packages/web/src/components/remix-contest-card/RemixContestCard.tsx
@@ -1,40 +1,21 @@
 import { MouseEvent, Ref, forwardRef, useCallback } from 'react'
 
 import {
-  useCollection,
   useCurrentUserId,
   useRemixContest,
   useTrack,
   useUser
 } from '@audius/common/api'
-import {
-  ID,
-  SquareSizes,
-  isContentUSDCPurchaseGated
-} from '@audius/common/models'
-import {
-  formatCount,
-  formatDate,
-  formatReleaseDate
-} from '@audius/common/utils'
+import { ID, SquareSizes } from '@audius/common/models'
+import { formatDate } from '@audius/common/utils'
 import { Flex, Skeleton, Text } from '@audius/harmony'
-import IconHeart from '@audius/harmony/src/assets/icons/Heart.svg'
-import IconRepost from '@audius/harmony/src/assets/icons/Repost.svg'
-import { pick } from 'lodash'
 import { useLinkClickHandler } from 'react-router-dom-v5-compat'
 
 import { Card, CardProps, CardFooter, CardContent } from 'components/card'
 import { TextLink, UserLink } from 'components/link'
-import { LockedStatusBadge } from 'components/locked-status-badge'
 import { TrackArtwork } from 'components/track/TrackArtwork'
 
-// import { CollectionDogEar } from './CollectionDogEar'
-// import { CollectionImage } from './CollectionImage'
-
 const messages = {
-  repost: 'Reposts',
-  favorites: 'Favorites',
-  hidden: 'Hidden',
   deadline: (releaseDate?: string) =>
     `Deadline ${releaseDate ? (new Date(releaseDate) < new Date() ? formatDate(releaseDate) : 'Ended') : releaseDate}`
 }
@@ -46,26 +27,10 @@ type RemixContestCardProps = Omit<CardProps, 'id'> & {
   onCollectionLinkClick?: (e: MouseEvent<HTMLAnchorElement>) => void
 }
 
-const cardSizeToCoverArtSizeMap = {
-  xs: SquareSizes.SIZE_150_BY_150,
-  s: SquareSizes.SIZE_480_BY_480,
-  m: SquareSizes.SIZE_480_BY_480,
-  l: SquareSizes.SIZE_480_BY_480
-}
-
 export const RemixContestCard = forwardRef(
   (props: RemixContestCardProps, ref: Ref<HTMLDivElement>) => {
-    const {
-      id,
-      loading,
-      size,
-      onClick,
-      onCollectionLinkClick,
-      noNavigation,
-      ...other
-    } = props
-    console.log('asdf props: ', props)
-    const { data: currentUserId } = useCurrentUserId()
+    const { id, loading, size, onClick, noNavigation, ...other } = props
+
     const { data: remixContest, isPending: isRemixContestPending } =
       useRemixContest(id)
     const { data: track, isPending: isTrackPending } = useTrack(
@@ -75,8 +40,7 @@ export const RemixContestCard = forwardRef(
 
     const isPending =
       isRemixContestPending || isTrackPending || isUserPending || !track
-    console.log('asdf remixContest: ', remixContest)
-    console.log('asdf track: ', track)
+
     const permalink = track?.permalink
 
     const handleNavigate = useLinkClickHandler<HTMLDivElement>(permalink ?? '')
@@ -109,7 +73,6 @@ export const RemixContestCard = forwardRef(
 
     return (
       <Card ref={ref} onClick={handleClick} size={size} {...other}>
-        {/* <CollectionDogEar collectionId={id} /> */}
         <Flex direction='column' p='s' gap='s'>
           <TrackArtwork
             trackId={track.track_id}
@@ -122,7 +85,6 @@ export const RemixContestCard = forwardRef(
               to={permalink}
               textVariant='title'
               css={{ justifyContent: 'center' }}
-              onClick={onCollectionLinkClick}
             >
               <Text ellipses>{track?.title}</Text>
             </TextLink>

--- a/packages/web/src/components/remix-contest-card/RemixContestCard.tsx
+++ b/packages/web/src/components/remix-contest-card/RemixContestCard.tsx
@@ -1,0 +1,140 @@
+import { MouseEvent, Ref, forwardRef, useCallback } from 'react'
+
+import {
+  useCollection,
+  useCurrentUserId,
+  useRemixContest,
+  useTrack,
+  useUser
+} from '@audius/common/api'
+import {
+  ID,
+  SquareSizes,
+  isContentUSDCPurchaseGated
+} from '@audius/common/models'
+import {
+  formatCount,
+  formatDate,
+  formatReleaseDate
+} from '@audius/common/utils'
+import { Flex, Skeleton, Text } from '@audius/harmony'
+import IconHeart from '@audius/harmony/src/assets/icons/Heart.svg'
+import IconRepost from '@audius/harmony/src/assets/icons/Repost.svg'
+import { pick } from 'lodash'
+import { useLinkClickHandler } from 'react-router-dom-v5-compat'
+
+import { Card, CardProps, CardFooter, CardContent } from 'components/card'
+import { TextLink, UserLink } from 'components/link'
+import { LockedStatusBadge } from 'components/locked-status-badge'
+import { TrackArtwork } from 'components/track/TrackArtwork'
+
+// import { CollectionDogEar } from './CollectionDogEar'
+// import { CollectionImage } from './CollectionImage'
+
+const messages = {
+  repost: 'Reposts',
+  favorites: 'Favorites',
+  hidden: 'Hidden',
+  deadline: (releaseDate?: string) =>
+    `Deadline ${releaseDate ? (new Date(releaseDate) < new Date() ? formatDate(releaseDate) : 'Ended') : releaseDate}`
+}
+
+type RemixContestCardProps = Omit<CardProps, 'id'> & {
+  id: ID
+  loading?: boolean
+  noNavigation?: boolean
+  onCollectionLinkClick?: (e: MouseEvent<HTMLAnchorElement>) => void
+}
+
+const cardSizeToCoverArtSizeMap = {
+  xs: SquareSizes.SIZE_150_BY_150,
+  s: SquareSizes.SIZE_480_BY_480,
+  m: SquareSizes.SIZE_480_BY_480,
+  l: SquareSizes.SIZE_480_BY_480
+}
+
+export const RemixContestCard = forwardRef(
+  (props: RemixContestCardProps, ref: Ref<HTMLDivElement>) => {
+    const {
+      id,
+      loading,
+      size,
+      onClick,
+      onCollectionLinkClick,
+      noNavigation,
+      ...other
+    } = props
+    console.log('asdf props: ', props)
+    const { data: currentUserId } = useCurrentUserId()
+    const { data: remixContest, isPending: isRemixContestPending } =
+      useRemixContest(id)
+    const { data: track, isPending: isTrackPending } = useTrack(
+      remixContest?.entityId
+    )
+    const { data: user, isPending: isUserPending } = useUser(track?.owner_id)
+
+    const isPending =
+      isRemixContestPending || isTrackPending || isUserPending || !track
+    console.log('asdf remixContest: ', remixContest)
+    console.log('asdf track: ', track)
+    const permalink = track?.permalink
+
+    const handleNavigate = useLinkClickHandler<HTMLDivElement>(permalink ?? '')
+
+    const handleClick = useCallback(
+      (e: MouseEvent<HTMLDivElement>) => {
+        onClick?.(e)
+        if (noNavigation) return
+        handleNavigate(e)
+      },
+      [noNavigation, handleNavigate, onClick]
+    )
+
+    if (isPending || loading) {
+      return (
+        <Card size={size} {...other}>
+          <Flex direction='column' p='s' gap='s'>
+            <Skeleton border='default' css={{ aspectRatio: 1 }} />
+            <CardContent gap='xs'>
+              <Skeleton h={24} w='80%' alignSelf='center' />
+              <Skeleton h={20} w='50%' alignSelf='center' />
+            </CardContent>
+          </Flex>
+          <CardFooter>
+            <Skeleton h={16} w='60%' alignSelf='center' />
+          </CardFooter>
+        </Card>
+      )
+    }
+
+    return (
+      <Card ref={ref} onClick={handleClick} size={size} {...other}>
+        {/* <CollectionDogEar collectionId={id} /> */}
+        <Flex direction='column' p='s' gap='s'>
+          <TrackArtwork
+            trackId={track.track_id}
+            size={SquareSizes.SIZE_150_BY_150}
+            mr='xs'
+            css={{ minHeight: 24, minWidth: 24 }}
+          />
+          <CardContent gap='xs'>
+            <TextLink
+              to={permalink}
+              textVariant='title'
+              css={{ justifyContent: 'center' }}
+              onClick={onCollectionLinkClick}
+            >
+              <Text ellipses>{track?.title}</Text>
+            </TextLink>
+            <Flex justifyContent='center'>
+              <UserLink userId={user?.user_id} popover center />
+            </Flex>
+          </CardContent>
+        </Flex>
+        <CardFooter>
+          <Text>{messages.deadline(remixContest?.endDate)} </Text>
+        </CardFooter>
+      </Card>
+    )
+  }
+)

--- a/packages/web/src/components/remix-contest-card/index.ts
+++ b/packages/web/src/components/remix-contest-card/index.ts
@@ -1,0 +1,3 @@
+export { RemixContestCard } from './RemixContestCard'
+
+export type { RemixContestCardProps } from './RemixContestCard'

--- a/packages/web/src/components/remix-contest-card/index.ts
+++ b/packages/web/src/components/remix-contest-card/index.ts
@@ -1,3 +1,1 @@
 export { RemixContestCard } from './RemixContestCard'
-
-export type { RemixContestCardProps } from './RemixContestCard'

--- a/packages/web/src/pages/explore-page/components/desktop/NewExplorePage.tsx
+++ b/packages/web/src/pages/explore-page/components/desktop/NewExplorePage.tsx
@@ -1,6 +1,10 @@
 import { useCallback, useEffect, useState } from 'react'
 
-import { useFeaturedPlaylists, useFeaturedProfiles } from '@audius/common/api'
+import {
+  useExploreContent,
+  useFeaturedPlaylists,
+  useFeaturedProfiles
+} from '@audius/common/api'
 import { User } from '@audius/common/models'
 import { TQCollection } from '@audius/common/src/api/tan-query/models'
 import { ExploreCollectionsVariant } from '@audius/common/store'
@@ -26,6 +30,7 @@ import { CollectionCard } from 'components/collection'
 import PerspectiveCard, {
   TextInterior
 } from 'components/perspective-card/PerspectiveCard'
+import { RemixContestCard } from 'components/remix-contest-card'
 import { UserCard } from 'components/user-card'
 import { useIsUSDCEnabled } from 'hooks/useIsUSDCEnabled'
 import useTabs from 'hooks/useTabs/useTabs'
@@ -66,7 +71,7 @@ const messages = {
   description: 'Discover the hottest and trendiest tracks on Audius right now',
   searchPlaceholder: 'What do you want to listen to?',
   featuredPlaylists: 'Featured Playlists',
-  remixContests: 'Remix Contests',
+  featuredRemixContests: 'Featured Remix Contests',
   artistSpotlight: 'Artist Spotlight',
   bestOfAudius: 'Best of Audius',
   viewAll: 'View All'
@@ -126,6 +131,8 @@ const ExplorePage = ({ title, pageTitle, description }: ExplorePageProps) => {
   const { data: featuredProfiles } = useFeaturedProfiles({
     limit: FEATURED_LIMIT
   })
+  const { data: exploreContent, isLoading } = useExploreContent()
+  const featuredRemixContests = exploreContent?.featuredRemixContests ?? []
 
   const handleTabClick = useCallback(
     (newTab: string) => {
@@ -284,6 +291,20 @@ const ExplorePage = ({ title, pageTitle, description }: ExplorePageProps) => {
                     size={'s'}
                   />
                 ))}
+              </Flex>
+            </Flex>
+            <Flex>
+              <Flex direction='column' gap='l'>
+                <Text variant='heading'>{messages.featuredRemixContests}</Text>
+                <Flex gap='l' justifyContent='space-between'>
+                  {featuredRemixContests?.map((featuredRemixContest) => (
+                    <RemixContestCard
+                      key={featuredRemixContest}
+                      id={featuredRemixContest}
+                      size={'s'}
+                    />
+                  ))}
+                </Flex>
               </Flex>
             </Flex>
 

--- a/packages/web/src/pages/explore-page/components/desktop/NewExplorePage.tsx
+++ b/packages/web/src/pages/explore-page/components/desktop/NewExplorePage.tsx
@@ -1,12 +1,6 @@
 import { useCallback, useEffect, useState } from 'react'
 
-import {
-  useExploreContent,
-  useFeaturedPlaylists,
-  useFeaturedProfiles
-} from '@audius/common/api'
-import { User } from '@audius/common/models'
-import { TQCollection } from '@audius/common/src/api/tan-query/models'
+import { useExploreContent } from '@audius/common/api'
 import { ExploreCollectionsVariant } from '@audius/common/store'
 import {
   Paper,
@@ -124,15 +118,13 @@ const ExplorePage = ({ title, pageTitle, description }: ExplorePageProps) => {
   const navigate = useNavigate()
   const showSearchResults = useShowSearchResults()
 
-  const { data: featuredPlaylists } = useFeaturedPlaylists(
-    { limit: FEATURED_LIMIT },
-    { placeholderData: (prev: TQCollection[]) => prev }
-  )
-  const { data: featuredProfiles } = useFeaturedProfiles({
-    limit: FEATURED_LIMIT
-  })
-  const { data: exploreContent, isLoading } = useExploreContent()
-  const featuredRemixContests = exploreContent?.featuredRemixContests ?? []
+  const { data: exploreContent } = useExploreContent()
+  const featuredPlaylists =
+    exploreContent?.featuredPlaylists.slice(0, FEATURED_LIMIT) ?? []
+  const featuredProfiles =
+    exploreContent?.featuredProfiles.slice(0, FEATURED_LIMIT) ?? []
+  const featuredRemixContests =
+    exploreContent?.featuredRemixContests.slice(0, FEATURED_LIMIT) ?? []
 
   const handleTabClick = useCallback(
     (newTab: string) => {
@@ -284,10 +276,10 @@ const ExplorePage = ({ title, pageTitle, description }: ExplorePageProps) => {
                 </TextLink>
               </Flex>
               <Flex gap='l' justifyContent='space-between'>
-                {featuredPlaylists?.map((playlist) => (
+                {featuredPlaylists?.map((playlist_id) => (
                   <CollectionCard
-                    key={playlist.playlist_id}
-                    id={playlist.playlist_id}
+                    key={playlist_id}
+                    id={playlist_id}
                     size={'s'}
                   />
                 ))}
@@ -322,12 +314,8 @@ const ExplorePage = ({ title, pageTitle, description }: ExplorePageProps) => {
                 </TextLink>
               </Flex>
               <Flex gap='l' alignSelf='stretch' justifyContent='space-between'>
-                {featuredProfiles?.map((featuredProfile: User) => (
-                  <UserCard
-                    key={featuredProfile.user_id}
-                    id={featuredProfile.user_id}
-                    size='s'
-                  />
+                {featuredProfiles?.map((user_id) => (
+                  <UserCard key={user_id} id={user_id} size='s' />
                 ))}
               </Flex>
             </Flex>


### PR DESCRIPTION
### Description
Add featured remix contests and loading skeletons to new explore page.


<img width="508" alt="Screenshot 2025-05-08 at 11 46 40 AM" src="https://github.com/user-attachments/assets/baa10d71-e39b-4e81-8e9f-a369118e1d6d" />
<img width="484" alt="Screenshot 2025-05-08 at 11 47 09 AM" src="https://github.com/user-attachments/assets/0f574409-2b6c-4e5a-b0ef-4a902caee35d" />

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._

Tested local client against prod
