### PR TITLE
Drop mobile builds in PRs

### DIFF
--- a/.circleci/src/workflows/mobile.yml
+++ b/.circleci/src/workflows/mobile.yml
@@ -9,7 +9,7 @@ jobs:
         - mobile-init
       filters:
         branches:
-          ignore: /(^main|^release.*)$/
+          only: /^mobile-build.*$/
 
   - mobile-build-upload-staging-ios:
       context:
@@ -41,14 +41,6 @@ jobs:
         branches:
           only: /(^release.*)$/
 
-  # - mobile-build-production-ios:
-  #     context: Audius Mobile Client
-  #     requires:
-  #       - mobile-init
-  #     filters:
-  #       branches:
-  #         only: /^main$/
-
   - mobile-build-upload-production-ios-if-full-release:
       context:
         - Audius Mobile Client
@@ -65,7 +57,7 @@ jobs:
         - mobile-init
       filters:
         branches:
-          ignore: /(^main|^release.*)$/
+          only: /^mobile-build.*$/
 
   - mobile-build-upload-staging-android:
       context:
@@ -96,14 +88,6 @@ jobs:
       filters:
         branches:
           only: /(^release.*)$/
-
-  # - mobile-build-production-android:
-  #     context: Audius Mobile Client
-  #     requires:
-  #       - mobile-init
-  #     filters:
-  #       branches:
-  #         only: /^main$/
 
   - mobile-build-upload-production-android-if-full-release:
       context:


### PR DESCRIPTION
### Description

Drops mobile builds in prs which should save a lot of compute and useless waiting. Still keeping it around if you prefix prs with "mobile-build"