### PR TITLE
[QA-2091] Fix mobile sign-up route-on-exit

### DIFF
--- a/packages/eslint-config-audius/src/index.js
+++ b/packages/eslint-config-audius/src/index.js
@@ -80,7 +80,7 @@ module.exports = {
       'warn',
       {
         additionalHooks:
-          '(useThrottledCallback|useDebouncedCallback|useAuthenticatedCallback)'
+          '(useThrottledCallback|useDebouncedCallback|useRequiresAccountCallback)'
       }
     ],
     'react/display-name': 'off',

--- a/packages/web/src/components/track/DownloadSection.tsx
+++ b/packages/web/src/components/track/DownloadSection.tsx
@@ -183,7 +183,7 @@ export const DownloadSection = ({ trackId }: DownloadSectionProps) => {
         fileCount: stemTracks.length + 1
       })
     },
-    [trackId, stemTracks]
+    [openDownloadTrackArchiveModal, trackId, stemTracks.length]
   )
 
   const renderDownloadAllButton = () => {

--- a/packages/web/src/pages/sign-up-page/components/NavHeader.tsx
+++ b/packages/web/src/pages/sign-up-page/components/NavHeader.tsx
@@ -28,8 +28,7 @@ const {
   SIGN_UP_FINISH_PROFILE_PAGE,
   SIGN_UP_GENRES_PAGE,
   SIGN_UP_HANDLE_PAGE,
-  SIGN_UP_PAGE,
-  TRENDING_PAGE
+  SIGN_UP_PAGE
 } = route
 
 const useIsBackAllowed = () => {

--- a/packages/web/src/pages/sign-up-page/components/NavHeader.tsx
+++ b/packages/web/src/pages/sign-up-page/components/NavHeader.tsx
@@ -13,7 +13,9 @@ import {
 } from '@audius/harmony'
 import { Route, Switch, useHistory, useRouteMatch } from 'react-router-dom'
 
+import { getRouteOnExit } from 'common/store/pages/signon/selectors'
 import { useMedia } from 'hooks/useMedia'
+import { useSelector } from 'utils/reducer'
 
 import { useDetermineAllowedRoute } from '../utils/useDetermineAllowedRoutes'
 
@@ -86,10 +88,11 @@ export const NavHeader = () => {
   const history = useHistory()
   const { isMobile } = useMedia()
   const { iconSizes } = useTheme()
+  const routeOnExit = useSelector(getRouteOnExit)
 
   const handleClose = useCallback(() => {
-    history.push(TRENDING_PAGE)
-  }, [history])
+    history.push(routeOnExit)
+  }, [history, routeOnExit])
 
   const audiusLogo = <IconAudiusLogoHorizontal color='subdued' sizeH='l' />
 

--- a/packages/web/src/pages/track-page/components/mobile/DownloadSection.tsx
+++ b/packages/web/src/pages/track-page/components/mobile/DownloadSection.tsx
@@ -159,7 +159,7 @@ export const DownloadSection = ({ trackId }: DownloadSectionProps) => {
       trackId,
       fileCount: stemTracks.length + 1
     })
-  }, [trackId, stemTracks])
+  }, [openDownloadTrackArchiveModal, trackId, stemTracks.length])
 
   return (
     <Box css={{ overflow: 'hidden' }}>

--- a/packages/web/src/pages/track-page/components/mobile/TrackHeader.tsx
+++ b/packages/web/src/pages/track-page/components/mobile/TrackHeader.tsx
@@ -44,6 +44,7 @@ import { TrackMetadataList } from 'components/track/TrackMetadataList'
 import HoverInfo from 'components/track-flair/HoverInfo'
 import TrackFlair from 'components/track-flair/TrackFlair'
 import { Size } from 'components/track-flair/types'
+import { useRequiresAccountCallback } from 'hooks/useRequiresAccount'
 import { useTrackCoverArt } from 'hooks/useTrackCoverArt'
 import { push as pushRoute } from 'utils/navigation'
 import { isDarkMode } from 'utils/theme/theme'
@@ -231,9 +232,10 @@ const TrackHeader = ({
     size: SquareSizes.SIZE_480_BY_480
   })
 
-  const onSaveHeroTrack = () => {
+  const onSaveHeroTrack = useRequiresAccountCallback(() => {
     if (!isOwner) onSave()
-  }
+  }, [isOwner, onSave])
+
   const filteredTags = (tags || '').split(',').filter(Boolean)
 
   const onClickOverflow = () => {


### PR DESCRIPTION
### Description

Fixes issue where a signed out user who favorites a track was redirected to sign-up, and when they clicked exit, they were always brought back to trending instead of the page they were just on.

Also fixes issue where favoriting a track did nothing. the favorite track tan-query migration messes this up because it's not checking for signed out user.... fixes this one case but heads up @DejayJD 