### PR TITLE
[PE-6047] Fix track page play

### DIFF
--- a/packages/common/src/api/tan-query/lineups/useTrackPageLineup.ts
+++ b/packages/common/src/api/tan-query/lineups/useTrackPageLineup.ts
@@ -195,8 +195,8 @@ export const useTrackPageLineup = (
       primeTrackData({ tracks, queryClient, dispatch })
 
       dispatch(
-        tracksActions.fetchLineupMetadatas(0, pageSize, false, {
-          items: tracks,
+        tracksActions.fetchLineupMetadatas(1, pageSize, false, {
+          items: tracks.slice(1),
           indices
         })
       )

--- a/packages/common/src/api/tan-query/lineups/useTrackPageLineup.ts
+++ b/packages/common/src/api/tan-query/lineups/useTrackPageLineup.ts
@@ -194,6 +194,7 @@ export const useTrackPageLineup = (
 
       primeTrackData({ tracks, queryClient, dispatch })
 
+      // offset is 1 because the hero track is already in the lineup
       dispatch(
         tracksActions.fetchLineupMetadatas(1, pageSize, false, {
           items: tracks.slice(1),

--- a/packages/common/src/api/tan-query/tracks/useTrackByParams.ts
+++ b/packages/common/src/api/tan-query/tracks/useTrackByParams.ts
@@ -4,11 +4,8 @@ import { useDispatch, useSelector } from 'react-redux'
 
 import { Kind } from '~/models'
 import { ID } from '~/models/Identifiers'
-import {
-  trackPageActions,
-  trackPageLineupActions,
-  trackPageSelectors
-} from '~/store/pages'
+import { trackPageLineupActions, trackPageSelectors } from '~/store/pages'
+import { tracksActions } from '~/store/pages/track/lineup/actions'
 import { makeUid } from '~/utils/uid'
 
 import { QueryOptions } from '../types'
@@ -46,10 +43,9 @@ export const useTrackByParams = (
 
   useEffect(() => {
     if (track && isSuccess) {
-      const { track_id, permalink } = track
-      dispatch(trackPageActions.setTrackId(track_id))
-      dispatch(trackPageActions.setTrackPermalink(permalink))
+      const { track_id } = track
 
+      dispatch(tracksActions.reset())
       // Add hero track to lineup early so that we can play it ASAP
       // instead of waiting for the entire lineup to load
       dispatch(

--- a/packages/common/src/api/tan-query/tracks/useTrackByParams.ts
+++ b/packages/common/src/api/tan-query/tracks/useTrackByParams.ts
@@ -45,6 +45,7 @@ export const useTrackByParams = (
     if (track && isSuccess) {
       const { track_id } = track
 
+      // Reset lineup before adding the hero track
       dispatch(tracksActions.reset())
       // Add hero track to lineup early so that we can play it ASAP
       // instead of waiting for the entire lineup to load

--- a/packages/mobile/src/screens/track-screen/TrackScreenLineup.tsx
+++ b/packages/mobile/src/screens/track-screen/TrackScreenLineup.tsx
@@ -4,8 +4,6 @@ import { useRemixContest, useTrackPageLineup } from '@audius/common/api'
 import { trackPageMessages as messages } from '@audius/common/messages'
 import type { ID, User } from '@audius/common/models'
 import { useFocusEffect } from '@react-navigation/native'
-import { confirmSaveCollection } from 'common/store/social/collections/sagas'
-import { useDispatch } from 'react-redux'
 import { tracksActions } from '~/store/pages/track/lineup/actions'
 
 import { Flex, Text } from '@audius/harmony-native'

--- a/packages/mobile/src/screens/track-screen/TrackScreenLineup.tsx
+++ b/packages/mobile/src/screens/track-screen/TrackScreenLineup.tsx
@@ -4,6 +4,8 @@ import { useRemixContest, useTrackPageLineup } from '@audius/common/api'
 import { trackPageMessages as messages } from '@audius/common/messages'
 import type { ID, User } from '@audius/common/models'
 import { useFocusEffect } from '@react-navigation/native'
+import { confirmSaveCollection } from 'common/store/social/collections/sagas'
+import { useDispatch } from 'react-redux'
 import { tracksActions } from '~/store/pages/track/lineup/actions'
 
 import { Flex, Text } from '@audius/harmony-native'
@@ -52,14 +54,15 @@ export const TrackScreenLineup = ({
   } = useTrackPageLineup({ trackId, disableAutomaticCacheHandling: true })
   const { data: remixContest } = useRemixContest(trackId)
   const isRemixContest = !!remixContest
+  const hasData = data.length > 0
 
   useFocusEffect(
     useCallback(() => {
-      if (data.length > 0) {
+      if (hasData) {
         loadCachedDataIntoLineup()
       }
       // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [loadCachedDataIntoLineup])
+    }, [hasData])
   )
 
   if (!indices) return null


### PR DESCRIPTION
### Description

Fixes some very subtle playback bugs. Ultimately the correct flow for playback on track page is:
- Reset lineup when landing on a track page
- Set the track as the first item in the lineup so it's immediately playable
- Fetch lineup in the background, at index 1
- Prevent "shouldAutoplay" and "shouldFetchMore" from triggering in queue saga when we are on the track page with only 1 track in the lineup. This lead to duplicate fetches and race conditions.
- When going to a page that has already fetched it's lineup, reset + fetchLineup staring at 0, which will immediately resolve with cached data

Shoutout to @DejayJD for the help here

### How Has This Been Tested?

Tested on mobile and web