### PR TITLE
Handle TokenAccountNotFoundError in recoverPurchaseIfNecessary

### DIFF
--- a/packages/common/src/store/buy-usdc/sagas.ts
+++ b/packages/common/src/store/buy-usdc/sagas.ts
@@ -387,19 +387,11 @@ function* recoverPurchaseIfNecessary() {
       }
     )
 
-    let accountInfo: Account | null = null
-    try {
-      accountInfo = yield* call(
-        getAccount,
-        sdk.services.solanaClient.connection,
-        usdcTokenAccount
-      )
-    } catch (e) {
-      if (e instanceof TokenAccountNotFoundError) {
-        return
-      }
-      throw e
-    }
+    const accountInfo = yield* call(
+      getAccount,
+      sdk.services.solanaClient.connection,
+      usdcTokenAccount
+    )
     const amount = accountInfo?.amount ?? BigInt(0)
     if (amount === BigInt(0)) {
       return
@@ -466,6 +458,9 @@ function* recoverPurchaseIfNecessary() {
       })
     )
   } catch (e) {
+    if (e instanceof TokenAccountNotFoundError) {
+      return
+    }
     yield* put(recoveryStatusChanged({ status: Status.ERROR }))
     yield* call(reportToSentry, {
       level: ErrorLevel.Error,

--- a/packages/common/src/store/buy-usdc/sagas.ts
+++ b/packages/common/src/store/buy-usdc/sagas.ts
@@ -386,7 +386,6 @@ function* recoverPurchaseIfNecessary() {
         mint: 'USDC'
       }
     )
-
     const accountInfo = yield* call(
       getAccount,
       sdk.services.solanaClient.connection,


### PR DESCRIPTION
### Description

Handles case where unpackAccount throws an error that is caught at the root try-catch and viewed as a real issue.