### PR TITLE
Fix AAO on local dev by querying for wallet instead of user ID

### DIFF
--- a/packages/discovery-provider/plugins/pedalboard/apps/anti-abuse-oracle/src/identity.ts
+++ b/packages/discovery-provider/plugins/pedalboard/apps/anti-abuse-oracle/src/identity.ts
@@ -48,9 +48,9 @@ export async function useFingerprintDeviceCount(userId: number) {
   return rows[0].maxUserCount ?? 0
 }
 
-export async function useEmailDeliverable(userId: number) {
+export async function useEmailDeliverable(wallet: string) {
   const rows = await sql`
-    select "isEmailDeliverable" from "Users" where "blockchainUserId" = ${userId}
+    select "isEmailDeliverable" from "Users" where "walletAddress" = ${wallet}
   `
   return rows[0].isEmailDeliverable
 }

--- a/packages/discovery-provider/plugins/pedalboard/apps/anti-abuse-oracle/src/server.tsx
+++ b/packages/discovery-provider/plugins/pedalboard/apps/anti-abuse-oracle/src/server.tsx
@@ -157,7 +157,7 @@ app.post('/attestation/:handle', async (c) => {
   if (!user) return c.json({ error: `handle not found: ${handle}` }, 404)
 
   // pass / fail
-  const userScore = await getUserNormalizedScore(user.user_id)
+  const userScore = await getUserNormalizedScore(user.user_id, user.wallet)
   if (userScore.overallScore < 0) {
     return c.json({ error: 'denied' }, 400)
   }
@@ -207,7 +207,7 @@ app.get('/attestation/ui', async (c) => {
     await Promise.all(
       (recentClaims || []).map(async (claim) => [
         claim.handle,
-        await getUserNormalizedScore(claim.user_id)
+        await getUserNormalizedScore(claim.user_id, claim.wallet)
       ])
     )
   )
@@ -303,7 +303,7 @@ app.get('/attestation/ui/user', async (c) => {
   const user = await getUser(idOrHandle)
   if (!user) return c.text(`user id not found: ${idOrHandle}`, 404)
   const signals = await getUserScore(user.id)
-  const userScore = (await getUserNormalizedScore(user.id))!
+  const userScore = (await getUserNormalizedScore(user.id, user.wallet))!
 
   if (!signals) return c.text(`user id not found: ${idOrHandle}`, 404)
 


### PR DESCRIPTION
Identity can sometimes be missing handle or blockchainUserId, but it'll always have a wallet. In local dev, when creating users with `audius-cmd`, we won't have a handle or blockchainUserId in identity. So to make this work, rather than sending a dummy request to identity to fill those details in, I made AAO plugin query by wallet instead.