### PR TITLE
only use audiusd instance

### DIFF
--- a/packages/discovery-provider/src/tasks/core/core_client.py
+++ b/packages/discovery-provider/src/tasks/core/core_client.py
@@ -128,13 +128,7 @@ core_instance: Optional[CoreClient] = None
 def get_core_instance() -> CoreClient:
     # pylint: disable=W0603
     global core_instance
-    try:
-        client = AudiusdClient()
-        client.ping()
-        # If no exception, use AudiusdClient
-        if not isinstance(core_instance, AudiusdClient):
-            logger.info("CORE_CLIENT Switching to AudiusdClient.")
-        core_instance = client
-    except Exception:
-        core_instance = CoreClient()
+    if not core_instance:
+        core_instance = AudiusdClient()
+        return core_instance
     return core_instance


### PR DESCRIPTION
### Description
We're fully on connect now, only use AudiusdClient. Uses the same logic previously found here.
https://github.com/AudiusProject/audius-protocol/blob/3a030a9ee3d4cc5918fce67acaf50c0b9c467540/packages/discovery-provider/src/tasks/core/core_client.py

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._
