### PR TITLE
[PE-6160] Add new stacked balance and error messages

### DIFF
--- a/packages/common/src/messages/buySell.ts
+++ b/packages/common/src/messages/buySell.ts
@@ -8,6 +8,7 @@ export const buySellMessages = {
   amountAUDIO: 'Amount (AUDIO)',
   max: 'MAX',
   available: 'Available',
+  addCash: 'Add Cash',
   audioTicker: '$AUDIO',
   usdcTicker: 'USDC',
   continue: 'Continue',
@@ -18,5 +19,9 @@ export const buySellMessages = {
   buySuccess: 'Successfully purchased AUDIO!',
   sellSuccess: 'Successfully sold AUDIO!',
   transactionSuccess: 'Transaction successful!',
-  transactionFailed: 'Transaction failed. Please try again.'
+  transactionFailed: 'Transaction failed. Please try again.',
+  insufficientUSDC:
+    "You don't have the available balance required to complete this purchase.",
+  insufficientAUDIOForSale:
+    "You don't have the available balance required to complete this sale."
 }

--- a/packages/web/src/components/buy-sell-modal/BuySellModal.tsx
+++ b/packages/web/src/components/buy-sell-modal/BuySellModal.tsx
@@ -3,7 +3,7 @@ import { useCallback, useContext, useEffect, useState } from 'react'
 import { useSwapTokens } from '@audius/common/api'
 import { buySellMessages as messages } from '@audius/common/messages'
 import { TOKEN_LISTING_MAP } from '@audius/common/src/store/ui/buy-audio/constants'
-import { useBuySellModal } from '@audius/common/store'
+import { useBuySellModal, useAddFundsModal } from '@audius/common/store'
 import {
   Button,
   Flex,
@@ -42,6 +42,7 @@ export const BuySellModal = () => {
   const [activeTab, setActiveTab] = useState<BuySellTab>('buy')
   // selectedPairIndex will be used in future when multiple token pairs are supported
   const [selectedPairIndex] = useState(0)
+  const { onOpen: openAddFundsModal } = useAddFundsModal()
 
   // Transaction state
   const [transactionData, setTransactionData] = useState<{
@@ -49,6 +50,7 @@ export const BuySellModal = () => {
     outputAmount: number
     isValid: boolean
   } | null>(null)
+  const [hasSufficientBalance, setHasSufficientBalance] = useState(true)
 
   // Get the swap tokens mutation
   const {
@@ -69,6 +71,16 @@ export const BuySellModal = () => {
     // Reset transaction data when changing tabs
     setTransactionData(null)
   }, [])
+
+  const handleTransactionDataChange = useCallback(
+    (data: { inputAmount: number; outputAmount: number; isValid: boolean }) => {
+      setTransactionData(data)
+      // Update sufficient balance based on input amount and validity
+      // (Inferring insufficient balance if amount > 0 and not valid)
+      setHasSufficientBalance(!(data.inputAmount > 0 && !data.isValid))
+    },
+    []
+  )
 
   // Handle continue button click
   const handleContinueClick = useCallback(() => {
@@ -120,6 +132,11 @@ export const BuySellModal = () => {
   const isContinueButtonDisabled =
     !transactionData?.isValid || isContinueButtonLoading
 
+  const errorMessage =
+    activeTab === 'sell' && !hasSufficientBalance
+      ? messages.insufficientAUDIOForSale
+      : undefined
+
   return (
     <Modal isOpen={isOpen} onClose={onClose} size='medium'>
       <ModalHeader onClose={onClose} showDismissButton={true}>
@@ -139,24 +156,47 @@ export const BuySellModal = () => {
           {activeTab === 'buy' ? (
             <BuyTab
               tokenPair={selectedPair}
-              onTransactionDataChange={setTransactionData}
+              onTransactionDataChange={handleTransactionDataChange}
+              error={false}
             />
           ) : (
             <SellTab
               tokenPair={selectedPair}
-              onTransactionDataChange={setTransactionData}
+              onTransactionDataChange={handleTransactionDataChange}
+              error={!hasSufficientBalance}
+              errorMessage={errorMessage}
             />
           )}
 
-          <Hint>
-            {messages.helpCenter}{' '}
-            <TextLink
-              variant='visible'
-              href='#' // Replace with actual URL when available
-            >
-              {messages.walletGuide}
-            </TextLink>
-          </Hint>
+          {/* Insufficient USDC balance hint, only on buy tab */}
+          {activeTab === 'buy' && !hasSufficientBalance ? (
+            <Hint>
+              {messages.insufficientUSDC}
+              <br />
+              <TextLink
+                variant='visible'
+                href='#'
+                onClick={() => {
+                  onClose()
+                  openAddFundsModal()
+                }}
+              >
+                {messages.addCash}
+              </TextLink>
+            </Hint>
+          ) : null}
+
+          {hasSufficientBalance ? (
+            <Hint>
+              {messages.helpCenter}{' '}
+              <TextLink
+                variant='visible'
+                href='#' // Replace with actual URL when available
+              >
+                {messages.walletGuide}
+              </TextLink>
+            </Hint>
+          ) : null}
 
           <Button
             variant='primary'

--- a/packages/web/src/components/buy-sell-modal/BuySellModal.tsx
+++ b/packages/web/src/components/buy-sell-modal/BuySellModal.tsx
@@ -157,7 +157,7 @@ export const BuySellModal = () => {
             <BuyTab
               tokenPair={selectedPair}
               onTransactionDataChange={handleTransactionDataChange}
-              error={false}
+              error={!hasSufficientBalance}
             />
           ) : (
             <SellTab

--- a/packages/web/src/components/buy-sell-modal/BuyTab.tsx
+++ b/packages/web/src/components/buy-sell-modal/BuyTab.tsx
@@ -13,9 +13,14 @@ type BuyTabProps = {
     outputAmount: number
     isValid: boolean
   }) => void
+  error?: boolean
 }
 
-export const BuyTab = ({ tokenPair, onTransactionDataChange }: BuyTabProps) => {
+export const BuyTab = ({
+  tokenPair,
+  onTransactionDataChange,
+  error
+}: BuyTabProps) => {
   // Extract the tokens from the pair
   const { baseToken, quoteToken } = tokenPair
   // Fetch real USDC balance
@@ -43,6 +48,7 @@ export const BuyTab = ({ tokenPair, onTransactionDataChange }: BuyTabProps) => {
         formatError: () => 'Insufficient balance'
       }}
       onTransactionDataChange={onTransactionDataChange}
+      error={error}
     />
   )
 }

--- a/packages/web/src/components/buy-sell-modal/SellTab.tsx
+++ b/packages/web/src/components/buy-sell-modal/SellTab.tsx
@@ -14,11 +14,15 @@ type SellTabProps = {
     outputAmount: number
     isValid: boolean
   }) => void
+  error?: boolean
+  errorMessage?: string
 }
 
 export const SellTab = ({
   tokenPair,
-  onTransactionDataChange
+  onTransactionDataChange,
+  error,
+  errorMessage
 }: SellTabProps) => {
   // Extract the tokens from the pair
   const { baseToken, quoteToken } = tokenPair
@@ -46,6 +50,9 @@ export const SellTab = ({
         formatError: () => 'Insufficient balance'
       }}
       onTransactionDataChange={onTransactionDataChange}
+      isDefault={false}
+      error={error}
+      errorMessage={errorMessage}
     />
   )
 }

--- a/packages/web/src/components/buy-sell-modal/SwapTab.tsx
+++ b/packages/web/src/components/buy-sell-modal/SwapTab.tsx
@@ -49,6 +49,9 @@ export type SwapTabProps = {
     outputAmount: number
     isValid: boolean
   }) => void
+  isDefault?: boolean
+  error?: boolean
+  errorMessage?: string
 }
 
 export const SwapTab = ({
@@ -57,7 +60,10 @@ export const SwapTab = ({
   min,
   max,
   balance,
-  onTransactionDataChange
+  onTransactionDataChange,
+  isDefault = true,
+  error,
+  errorMessage
 }: SwapTabProps) => {
   const {
     formik,
@@ -108,6 +114,9 @@ export const SwapTab = ({
                 onMaxClick={handleMaxClick}
                 availableBalance={availableBalance}
                 placeholder={messages.placeholder}
+                isDefault={isDefault}
+                error={error}
+                errorMessage={errorMessage}
               />
 
               <TokenAmountSection

--- a/packages/web/src/components/buy-sell-modal/TokenAmountSection.tsx
+++ b/packages/web/src/components/buy-sell-modal/TokenAmountSection.tsx
@@ -10,7 +10,7 @@ import {
 import { useTheme } from '@emotion/react'
 
 import { useTokenAmountFormatting } from './hooks'
-import { TokenAmountSectionProps } from './types'
+import { TokenAmountSectionProps, TokenInfo } from './types'
 
 const messages = {
   available: 'Available',
@@ -23,7 +23,86 @@ const messages = {
       maximumFractionDigits: decimalPlaces
     })
     return `(${isTokenStablecoin ? '$' : ''}${formattedRateStr} ea.)`
-  }
+  },
+  stackedBalance: (formattedAvailableBalance: string) =>
+    `${formattedAvailableBalance}  Available`,
+  tokenTicker: (symbol: string, isStablecoin: boolean) =>
+    isStablecoin ? symbol : `$${symbol}`
+}
+
+type BalanceSectionProps = {
+  isStablecoin?: boolean
+  formattedAvailableBalance: string
+  tokenInfo: TokenInfo
+}
+
+const DefaultBalanceSection = ({
+  isStablecoin,
+  formattedAvailableBalance,
+  tokenInfo
+}: BalanceSectionProps) => {
+  const { cornerRadius } = useTheme()
+  const { icon: TokenIcon } = tokenInfo
+  return (
+    <Flex
+      direction='column'
+      alignItems='flex-end'
+      justifyContent='center'
+      gap='xs'
+      flex={1}
+      alignSelf='stretch'
+    >
+      <Flex alignItems='center' gap='xs'>
+        <TokenIcon size='l' css={{ borderRadius: cornerRadius.circle }} />
+        <Text variant='heading' size='s' color='subdued'>
+          {messages.available}
+        </Text>
+        <IconInfo
+          size='s'
+          color='subdued'
+          css={{ borderRadius: cornerRadius.circle }}
+        />
+      </Flex>
+      <Text variant='heading' size='xl'>
+        {isStablecoin ? '$' : ''}
+        {formattedAvailableBalance}
+      </Text>
+    </Flex>
+  )
+}
+
+const StackedBalanceSection = ({
+  formattedAvailableBalance,
+  tokenInfo,
+  isStablecoin
+}: BalanceSectionProps) => {
+  const { cornerRadius } = useTheme()
+  const { icon: TokenIcon, symbol } = tokenInfo
+  return (
+    <Flex
+      direction='column'
+      alignItems='flex-end'
+      justifyContent='center'
+      gap='xs'
+      flex={1}
+      alignSelf='stretch'
+    >
+      <Flex gap='s' alignItems='center'>
+        <Flex direction='column'>
+          <Flex alignSelf='flex-end'>
+            <Text variant='heading' size='s' color='subdued'>
+              {messages.tokenTicker(symbol, !!isStablecoin)}
+            </Text>
+          </Flex>
+          <Text variant='title' size='s' color='default'>
+            {messages.stackedBalance(formattedAvailableBalance)}
+          </Text>
+        </Flex>
+        {/* We need the border radius to be circle here because the AUDIO icon is a square image */}
+        <TokenIcon size='4xl' css={{ borderRadius: cornerRadius.circle }} />
+      </Flex>
+    </Flex>
+  )
 }
 
 export const TokenAmountSection = ({
@@ -35,12 +114,15 @@ export const TokenAmountSection = ({
   onMaxClick,
   availableBalance,
   exchangeRate,
-  placeholder = '0.00'
+  placeholder = '0.00',
+  isDefault = true,
+  error,
+  errorMessage
 }: TokenAmountSectionProps) => {
-  const { spacing } = useTheme()
+  const { spacing, cornerRadius } = useTheme()
 
   const { icon: TokenIcon, symbol, isStablecoin } = tokenInfo
-  const tokenTicker = isStablecoin ? symbol : `$${symbol}`
+  const tokenTicker = messages.tokenTicker(symbol, !!isStablecoin)
 
   const { formattedAvailableBalance, formattedAmount } =
     useTokenAmountFormatting({
@@ -61,46 +143,51 @@ export const TokenAmountSection = ({
       </Flex>
       {isInput ? (
         <Flex gap='s' p='l' alignItems='flex-start'>
-          <Flex alignItems='flex-start' gap='s'>
-            <TextInput
-              label={messages.amountInputLabel(symbol)}
-              placeholder={placeholder}
-              value={amount?.toString() || ''}
-              onChange={(e) => onAmountChange?.(e.target.value)}
-            />
-            <Button
-              variant='secondary'
-              css={{
-                height: spacing.unit16
-              }}
-              onClick={onMaxClick}
-            >
-              {messages.max}
-            </Button>
-          </Flex>
-          <Flex
-            direction='column'
-            alignItems='flex-end'
-            justifyContent='center'
-            gap='xs'
-            css={{ flexGrow: 1, alignSelf: 'stretch' }}
-          >
-            <Flex alignItems='center' gap='s'>
-              <TokenIcon size='l' />
-              <Text variant='heading' size='s' color='subdued'>
-                {messages.available}
-              </Text>
-              <IconInfo size='s' color='subdued' />
+          <Flex direction='column' gap='xs' alignItems='flex-start'>
+            <Flex alignItems='flex-start' gap='s'>
+              <TextInput
+                label={messages.amountInputLabel(symbol)}
+                placeholder={placeholder}
+                value={amount?.toString() || ''}
+                onChange={(e) => onAmountChange?.(e.target.value)}
+                error={error}
+              />
+              <Button
+                variant='secondary'
+                css={{
+                  height: spacing.unit16
+                }}
+                onClick={onMaxClick}
+              >
+                {messages.max}
+              </Button>
             </Flex>
-            <Text variant='heading' size='xl'>
-              {isStablecoin ? '$' : ''}
-              {formattedAvailableBalance}
-            </Text>
+            {isInput && !!errorMessage ? (
+              <Text size='xs' variant='body' color='danger'>
+                {errorMessage}
+              </Text>
+            ) : null}
           </Flex>
+          {isDefault ? (
+            <DefaultBalanceSection
+              isStablecoin={!!isStablecoin}
+              formattedAvailableBalance={formattedAvailableBalance}
+              tokenInfo={tokenInfo}
+            />
+          ) : (
+            <StackedBalanceSection
+              formattedAvailableBalance={formattedAvailableBalance}
+              tokenInfo={tokenInfo}
+            />
+          )}
         </Flex>
       ) : (
         <Flex p='l' alignItems='center' gap='s'>
-          <TokenIcon width={spacing.unit16} height={spacing.unit16} />
+          <TokenIcon
+            width={spacing.unit16}
+            height={spacing.unit16}
+            css={{ borderRadius: cornerRadius.circle }}
+          />
           <Flex direction='column'>
             <Text variant='heading' size='l'>
               {formattedAmount}

--- a/packages/web/src/components/buy-sell-modal/constants.ts
+++ b/packages/web/src/components/buy-sell-modal/constants.ts
@@ -1,14 +1,14 @@
-import { IconLogoCircle, IconLogoCircleUSDC } from '@audius/harmony'
+import { TOKEN_LISTING_MAP } from '@audius/common/store'
+import { IconLogoCircleUSDC, IconTokenAUDIO } from '@audius/harmony'
 
 import { TokenInfo, TokenPair } from './types'
-
 // Token metadata
 export const TOKENS: Record<string, TokenInfo> = {
   AUDIO: {
     symbol: 'AUDIO',
     name: 'Audius',
-    icon: IconLogoCircle,
-    decimals: 18,
+    icon: IconTokenAUDIO,
+    decimals: TOKEN_LISTING_MAP.AUDIO.decimals,
     balance: null,
     isStablecoin: false
   },
@@ -16,7 +16,7 @@ export const TOKENS: Record<string, TokenInfo> = {
     symbol: 'USDC',
     name: 'USD Coin',
     icon: IconLogoCircleUSDC,
-    decimals: 6,
+    decimals: TOKEN_LISTING_MAP.USDC.decimals,
     balance: null,
     isStablecoin: true
   }

--- a/packages/web/src/components/buy-sell-modal/types.ts
+++ b/packages/web/src/components/buy-sell-modal/types.ts
@@ -28,4 +28,7 @@ export type TokenAmountSectionProps = {
   availableBalance: number
   exchangeRate?: number | null
   placeholder?: string
+  isDefault?: boolean
+  error?: boolean
+  errorMessage?: string
 }


### PR DESCRIPTION
### Description

This PR enhances the user experience and error handling in the Buy/Sell modal for AUDIO and USDC transactions. The changes focus on providing clear, contextual feedback to users when they do not have sufficient balance to complete a buy or sell operation, and refactor the error message handling for future extensibility. It also uses the correct stacked view on the sell tab from Figma. 

### How Has This Been Tested?
1. Open the Buy/Sell modal.
2. On the Sell tab, enter an amount greater than your AUDIO balance. The input should turn red and the error message should appear below.
3. On the Buy tab, enter an amount greater than your USDC balance. The hint should appear, but the input should not turn red.
4. Click "Add Cash" in the hint to verify the Add Funds modal opens and the Buy/Sell modal closes.

<img width="718" alt="image" src="https://github.com/user-attachments/assets/6867306e-00e9-4a1a-b1d5-cbbd7ae7022b" />

<img width="722" alt="image" src="https://github.com/user-attachments/assets/6d36ab61-aa88-4da6-b9ee-8a7f262f517d" />

