### PR TITLE
[PE-6163] Deprecate saga fetchUserByHandle

### DIFF
--- a/packages/common/src/api/tan-query/jupiter/useSwapTokens.ts
+++ b/packages/common/src/api/tan-query/jupiter/useSwapTokens.ts
@@ -6,8 +6,7 @@ import {
 } from '@solana/web3.js'
 import { useMutation, useQueryClient } from '@tanstack/react-query'
 
-import { useGetCurrentUser } from '~/api'
-import { useAudiusQueryContext } from '~/audius-query'
+import { useGetCurrentUser, useQueryContext } from '~/api'
 import { Feature } from '~/models'
 import {
   convertJupiterInstructions,
@@ -32,8 +31,7 @@ import { addUserBankToAtaInstructions, getSwapErrorResponse } from './utils'
  */
 export const useSwapTokens = () => {
   const queryClient = useQueryClient()
-  const { solanaWalletService, reportToSentry, audiusSdk } =
-    useAudiusQueryContext()
+  const { solanaWalletService, reportToSentry, audiusSdk } = useQueryContext()
   const { data: user } = useGetCurrentUser({})
 
   return useMutation<SwapTokensResult, Error, SwapTokensParams>({

--- a/packages/common/src/api/tan-query/saga-utils/queryUser.ts
+++ b/packages/common/src/api/tan-query/saga-utils/queryUser.ts
@@ -1,23 +1,54 @@
+import { Dispatch, AnyAction } from 'redux'
+import { call, select, put } from 'typed-redux-saga'
+
+import { UserMetadata } from '@audius/common/models'
 import { ID } from '~/models/Identifiers'
 import { User } from '~/models/User'
+import { getUserId } from '~/store/account/selectors'
 import { getContext } from '~/store/effects'
+import { getSDK } from '~/store/sdkUtils'
 
 import { QUERY_KEYS } from '../queryKeys'
-import { getUserQueryKey } from '../users/useUser'
-import { getUserByHandleQueryKey } from '../users/useUserByHandle'
+import { getUserQueryFn, getUserQueryKey } from '../users/useUser'
+import {
+  getUserByHandleQueryFn,
+  getUserByHandleQueryKey
+} from '../users/useUserByHandle'
+import { isValidId } from '../utils/isValidId'
 
 export function* queryUser(id: ID | null | undefined) {
-  if (!id) return null
+  if (!isValidId(id)) return undefined
   const queryClient = yield* getContext('queryClient')
-  return queryClient.getQueryData(getUserQueryKey(id))
+  const sdk = yield* getSDK()
+  const currentUserId = yield* select(getUserId)
+
+  const queryData = yield* call([queryClient, queryClient.fetchQuery], {
+    queryKey: getUserQueryKey(id),
+    queryFn: async () =>
+      getUserQueryFn(id!, currentUserId, queryClient, sdk, put)
+  })
+
+  return queryData as UserMetadata | undefined
 }
 
-export function* queryUserByHandle(handle: string | null | undefined) {
-  if (!handle) return null
+export function* queryUserByHandle(handle: string) {
   const queryClient = yield* getContext('queryClient')
-  const id = queryClient.getQueryData(getUserByHandleQueryKey(handle))
-  if (!id) return null
-  return yield* queryUser(id)
+  const currentUserId = yield* select(getUserId)
+  const sdk = yield* getSDK()
+  const userId = (yield* call([queryClient, queryClient.fetchQuery], {
+    queryKey: getUserByHandleQueryKey(handle),
+    queryFn: async () =>
+      getUserByHandleQueryFn(
+        handle,
+        sdk,
+        queryClient,
+        put as Dispatch<AnyAction>,
+        currentUserId
+      )
+  })) as ID | undefined
+  if (!userId) return undefined
+  const userMetadata = yield* call(queryUser, userId)
+  return userMetadata
 }
 
 export function* queryUsers(ids: ID[]) {

--- a/packages/common/src/api/tan-query/saga-utils/queryUser.ts
+++ b/packages/common/src/api/tan-query/saga-utils/queryUser.ts
@@ -28,7 +28,7 @@ export function* queryUser(id: ID | null | undefined) {
       getUserQueryFn(id!, currentUserId, queryClient, sdk, put)
   })
 
-  return queryData as UserMetadata | undefined
+  return queryData as User | undefined
 }
 
 export function* queryUserByHandle(handle: string) {

--- a/packages/common/src/api/tan-query/saga-utils/queryUser.ts
+++ b/packages/common/src/api/tan-query/saga-utils/queryUser.ts
@@ -1,7 +1,6 @@
 import { Dispatch, AnyAction } from 'redux'
 import { call, select, put } from 'typed-redux-saga'
 
-import { UserMetadata } from '@audius/common/models'
 import { ID } from '~/models/Identifiers'
 import { User } from '~/models/User'
 import { getUserId } from '~/store/account/selectors'

--- a/packages/common/src/utils/sagaHelpers.ts
+++ b/packages/common/src/utils/sagaHelpers.ts
@@ -1,7 +1,7 @@
 /** Helper Sagas */
 
 import { eventChannel, END, EventChannel } from 'redux-saga'
-import { ActionPattern, GetContextEffect } from 'redux-saga/effects'
+import { ActionPattern } from 'redux-saga/effects'
 import {
   all,
   call,

--- a/packages/common/src/utils/sagaHelpers.ts
+++ b/packages/common/src/utils/sagaHelpers.ts
@@ -86,29 +86,6 @@ export function* waitForValue(
   return value
 }
 
-/**
- * Waits for a query function to return a truthy value.
- * Similar to waitForValue but for tanstack query data.
- *
- * @template TResult The type of the value returned by the query function
- * @param {function} query A function that returns a Generator that resolves to a value of type TResult
- * @param {any} args Arguments to pass to the query function
- * @param {(v: TResult) => boolean} customCheck special check to run rather than checking truthy-ness
- * @returns {TResult} The value from the query function once it's truthy
- */
-export function* waitForQueryValue<TResult>(
-  query: (args: any) => Generator<GetContextEffect, TResult | null, any>,
-  args?: any,
-  customCheck?: (value: TResult) => boolean
-) {
-  let value: TResult | null = yield* call(query, args)
-  while (customCheck ? !customCheck(value as TResult) : !value) {
-    yield* take()
-    value = yield* call(query, args)
-  }
-  return value as TResult
-}
-
 function doEveryImpl(millis: number, times: number | null) {
   return eventChannel((emitter) => {
     // Emit once at the start

--- a/packages/web/src/common/store/cache/users/sagas.ts
+++ b/packages/web/src/common/store/cache/users/sagas.ts
@@ -1,6 +1,6 @@
 import { userMetadataListFromSDK } from '@audius/common/adapters'
 import { queryUserByHandle } from '@audius/common/api'
-import { Kind, User, UserMetadata } from '@audius/common/models'
+import { Kind, User } from '@audius/common/models'
 import {
   BatchCachedUsers,
   accountSelectors,
@@ -11,7 +11,7 @@ import {
   getContext,
   getSDK
 } from '@audius/common/store'
-import { waitForAccount, waitForValue } from '@audius/common/utils'
+import { waitForAccount } from '@audius/common/utils'
 import { Id, OptionalId } from '@audius/sdk'
 import { mergeWith } from 'lodash'
 import { call, put, select, takeEvery } from 'typed-redux-saga'

--- a/packages/web/src/common/store/pages/ai/sagas.ts
+++ b/packages/web/src/common/store/pages/ai/sagas.ts
@@ -1,3 +1,4 @@
+import { queryUserByHandle } from '@audius/common/api'
 import { UserMetadata } from '@audius/common/models'
 import { aiPageActions, FetchAiUserAction } from '@audius/common/store'
 import { Maybe } from '@audius/common/utils'
@@ -5,7 +6,7 @@ import { takeEvery, call, put } from 'typed-redux-saga'
 
 import { waitForRead } from 'utils/sagaHelpers'
 
-import { fetchUserByHandle, fetchUsers } from '../../cache/users/sagas'
+import { fetchUsers } from '../../cache/users/sagas'
 
 import tracksSagas from './lineups/tracks/sagas'
 
@@ -19,10 +20,10 @@ function* fetchAiUserWorker(action: FetchAiUserAction) {
   yield* call(waitForRead)
   const { handle, userId } = action.payload
 
-  let user: Maybe<UserMetadata>
+  let user: Maybe<UserMetadata> | null
 
   if (handle) {
-    user = yield* call(fetchUserByHandle, handle, new Set())
+    user = yield* call(queryUserByHandle, handle)
   }
 
   if (userId) {

--- a/packages/web/src/common/store/pages/signon/sagas.ts
+++ b/packages/web/src/common/store/pages/signon/sagas.ts
@@ -1,6 +1,7 @@
 import {
   getWalletAccountQueryFn,
-  getWalletAccountQueryKey
+  getWalletAccountQueryKey,
+  queryUserByHandle
 } from '@audius/common/api'
 import { GUEST_EMAIL } from '@audius/common/hooks'
 import {
@@ -67,7 +68,7 @@ import {
 
 import { identify, make } from 'common/store/analytics/actions'
 import { retrieveCollections } from 'common/store/cache/collections/utils'
-import { fetchUserByHandle, fetchUsers } from 'common/store/cache/users/sagas'
+import { fetchUsers } from 'common/store/cache/users/sagas'
 import { sendRecoveryEmail } from 'common/store/recovery-email/sagas'
 import { UiErrorCode } from 'store/errors/actions'
 import { reportToSentry } from 'store/errors/reportToSentry'
@@ -146,7 +147,7 @@ function* fetchReferrer(
   const { handle } = action
   if (handle) {
     try {
-      const user = yield* call(fetchUserByHandle, handle)
+      const user = yield* call(queryUserByHandle, handle)
       if (!user) return
       yield* put(signOnActions.setReferrer(user.user_id))
     } catch (e: any) {
@@ -193,15 +194,7 @@ function* validateHandle(
 
     // Call fetch user by handle and do not retry if the user is not created, it will
     // return 404 and force discovery reselection
-    const user = yield* call(
-      fetchUserByHandle,
-      handle,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      false
-    )
+    const user = yield* call(queryUserByHandle, handle)
     const handleInUse = !isEmpty(user)
     const handleCheckTimeout =
       remoteConfigInstance.getRemoteVar(

--- a/packages/web/src/common/store/profile/sagas.js
+++ b/packages/web/src/common/store/profile/sagas.js
@@ -2,6 +2,7 @@ import {
   userMetadataListFromSDK,
   userWalletsFromSDK
 } from '@audius/common/adapters'
+import { queryUserByHandle } from '@audius/common/api'
 import { Kind } from '@audius/common/models'
 import {
   accountSelectors,
@@ -33,7 +34,7 @@ import {
   takeEvery
 } from 'redux-saga/effects'
 
-import { fetchUsers, fetchUserByHandle } from 'common/store/cache/users/sagas'
+import { fetchUsers } from 'common/store/cache/users/sagas'
 import feedSagas from 'common/store/pages/profile/lineups/feed/sagas.js'
 import tracksSagas from 'common/store/pages/profile/lineups/tracks/sagas.js'
 import {
@@ -261,14 +262,7 @@ function* fetchProfileAsync(action) {
   try {
     let user
     if (action.handle) {
-      user = yield call(
-        fetchUserByHandle,
-        action.handle,
-        new Set(),
-        action.forceUpdate,
-        action.shouldSetLoading,
-        action.deleteExistingEntry
-      )
+      user = yield call(queryUserByHandle, action.handle)
     } else if (action.userId) {
       const users = yield call(
         fetchUsers,

--- a/packages/web/src/common/store/social/tracks/sagas.ts
+++ b/packages/web/src/common/store/social/tracks/sagas.ts
@@ -16,8 +16,7 @@ import {
   makeKindId,
   waitForValue,
   removeNullable,
-  getFilename,
-  waitForQueryValue
+  getFilename
 } from '@audius/common/utils'
 import { Id, OptionalId } from '@audius/sdk'
 import {
@@ -557,7 +556,7 @@ export function* watchSetArtistPick() {
           }
         ])
       )
-      const user = yield* waitForQueryValue(queryUser, userId)
+      const user = yield* call(queryUser, userId)
       yield* fork(updateProfileAsync, { metadata: user })
 
       const event = make(Name.ARTIST_PICK_SELECT_TRACK, { id: action.trackId })
@@ -582,7 +581,7 @@ export function* watchUnsetArtistPick() {
         }
       ])
     )
-    const user = yield* call(waitForQueryValue, queryUser, userId)
+    const user = yield* call(queryUser, userId)
     yield* fork(updateProfileAsync, { metadata: user })
 
     const event = make(Name.ARTIST_PICK_SELECT_TRACK, { id: 'none' })


### PR DESCRIPTION
### Description

- Deprecates `fetchUserByHandle` in favor of query client fetch instead
- Refactors the `queryUser` method to use `fetchQuery` instead of `getQueryData`, this means it will do a fetch if the data is missing (same concepts as useQuery)
  - I will be migrating the other entities as I do the same  

### How Has This Been Tested?

web:stage
