### PR TITLE
Web NotificationBody to UserLink

### DIFF
--- a/packages/web/src/components/notification/Notification/FanRemixContestEndingSoonNotification.tsx
+++ b/packages/web/src/components/notification/Notification/FanRemixContestEndingSoonNotification.tsx
@@ -2,7 +2,6 @@ import { useCallback } from 'react'
 
 import { useTrack, useUser } from '@audius/common/api'
 import {
-  Entity,
   FanRemixContestEndingSoonNotification as FanRemixContestEndingSoonNotificationType,
   TrackEntity
 } from '@audius/common/store'
@@ -11,7 +10,6 @@ import { useDispatch } from 'react-redux'
 
 import { push } from 'utils/navigation'
 
-import { EntityLink } from './components/EntityLink'
 import { NotificationBody } from './components/NotificationBody'
 import { NotificationFooter } from './components/NotificationFooter'
 import { NotificationHeader } from './components/NotificationHeader'
@@ -57,7 +55,6 @@ export const FanRemixContestEndingSoonNotification = (
         <TrackContent track={track as TrackEntity} hideTitle />
         <NotificationBody>
           <UserNameLink user={user} notification={notification} />{' '}
-          <EntityLink entity={track as TrackEntity} entityType={Entity.Track} />
           {messages.description}
         </NotificationBody>
       </Flex>

--- a/packages/web/src/components/notification/Notification/components/NotificationBody.module.css
+++ b/packages/web/src/components/notification/Notification/components/NotificationBody.module.css
@@ -1,6 +1,0 @@
-.root {
-  color: var(--harmony-neutral);
-  font-size: var(--harmony-font-l);
-  font-weight: var(--harmony-font-medium);
-  line-height: 150%;
-}

--- a/packages/web/src/components/notification/Notification/components/NotificationBody.module.css
+++ b/packages/web/src/components/notification/Notification/components/NotificationBody.module.css
@@ -1,0 +1,6 @@
+.root {
+  color: var(--harmony-neutral);
+  font-size: var(--harmony-font-l);
+  font-weight: var(--harmony-font-medium);
+  line-height: 150%;
+}

--- a/packages/web/src/components/notification/Notification/components/NotificationBody.tsx
+++ b/packages/web/src/components/notification/Notification/components/NotificationBody.tsx
@@ -1,8 +1,6 @@
 import { ReactNode } from 'react'
 
-import cn from 'classnames'
-
-import styles from './NotificationBody.module.css'
+import { Text } from '@audius/harmony'
 
 type NotificationBodyProps = {
   className?: string
@@ -14,7 +12,9 @@ export const NotificationBody = (props: NotificationBodyProps) => {
 
   return (
     <div>
-      <span className={cn(styles.root, className)}>{children}</span>
+      <Text variant='body' size='l' lineHeight='multi' className={className}>
+        {children}
+      </Text>
     </div>
   )
 }


### PR DESCRIPTION
### Description
Wrapping was weird due to `NotificationBody` being old and weird

### How Has This Been Tested?
Before:
<img width="423" alt="Screenshot 2025-05-13 at 1 39 52 PM" src="https://github.com/user-attachments/assets/bc0ab101-fbcd-4cab-a099-7ccd499f2be6" />



After:
<img width="414" alt="Screenshot 2025-05-13 at 1 39 15 PM" src="https://github.com/user-attachments/assets/a435ca4f-4b1e-47b0-b00b-751c3dfb502f" />
