### PR TITLE
[PE-6177] Add loading state to confirmation buy/sell flow

### DIFF
--- a/packages/web/src/components/buy-sell-modal/BuySellFlow.tsx
+++ b/packages/web/src/components/buy-sell-modal/BuySellFlow.tsx
@@ -1,7 +1,9 @@
-import { useMemo, useState } from 'react'
+import { useMemo, useState, useEffect } from 'react'
 
 import { buySellMessages as messages } from '@audius/common/messages'
 import { Button, Flex, Hint, SegmentedControl, TextLink } from '@audius/harmony'
+
+import { ModalLoading } from 'components/modal-loading'
 
 import { BuyTab } from './BuyTab'
 import { ConfirmSwapScreen } from './ConfirmSwapScreen'
@@ -19,10 +21,12 @@ type BuySellFlowProps = {
   onClose: () => void
   openAddFundsModal: () => void
   onScreenChange: (screen: 'input' | 'confirm') => void
+  onLoadingStateChange?: (isLoading: boolean) => void
 }
 
 export const BuySellFlow = (props: BuySellFlowProps) => {
-  const { onClose, openAddFundsModal, onScreenChange } = props
+  const { onClose, openAddFundsModal, onScreenChange, onLoadingStateChange } =
+    props
 
   const { currentScreen, setCurrentScreen } = useBuySellScreen({
     onScreenChange
@@ -52,6 +56,10 @@ export const BuySellFlow = (props: BuySellFlowProps) => {
     activeTab,
     onClose
   })
+
+  useEffect(() => {
+    onLoadingStateChange?.(isConfirmButtonLoading)
+  }, [isConfirmButtonLoading, onLoadingStateChange])
 
   const [selectedPairIndex] = useState(0)
 
@@ -91,6 +99,10 @@ export const BuySellFlow = (props: BuySellFlowProps) => {
     activeTab === 'sell' && !hasSufficientBalance
       ? messages.insufficientAUDIOForSale
       : undefined
+
+  if (isConfirmButtonLoading) {
+    return <ModalLoading />
+  }
 
   return (
     <>

--- a/packages/web/src/components/buy-sell-modal/BuySellModal.tsx
+++ b/packages/web/src/components/buy-sell-modal/BuySellModal.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useMemo, useState } from 'react'
 
 import { buySellMessages as messages } from '@audius/common/messages'
 import { useBuySellModal, useAddFundsModal } from '@audius/common/store'
@@ -24,18 +24,16 @@ export const BuySellModal = () => {
   const [modalScreen, setModalScreen] = useState<'input' | 'confirm'>('input')
   const [isFlowLoading, setIsFlowLoading] = useState(false)
 
+  const title = useMemo(() => {
+    if (isFlowLoading) return ''
+    if (modalScreen === 'confirm') return messages.confirmDetails
+    return messages.title
+  }, [isFlowLoading, modalScreen])
+
   return (
     <Modal isOpen={isOpen} onClose={onClose} size='medium'>
       <ModalHeader onClose={onClose} showDismissButton={!isFlowLoading}>
-        <ModalTitle
-          title={
-            isFlowLoading
-              ? ''
-              : modalScreen === 'confirm'
-                ? messages.confirmDetails
-                : messages.title
-          }
-        />
+        <ModalTitle title={title} />
       </ModalHeader>
       <ModalContent>
         <BuySellFlow

--- a/packages/web/src/components/buy-sell-modal/BuySellModal.tsx
+++ b/packages/web/src/components/buy-sell-modal/BuySellModal.tsx
@@ -22,13 +22,18 @@ export const BuySellModal = () => {
 
   // State to control the modal title based on the flow screen
   const [modalScreen, setModalScreen] = useState<'input' | 'confirm'>('input')
+  const [isFlowLoading, setIsFlowLoading] = useState(false)
 
   return (
     <Modal isOpen={isOpen} onClose={onClose} size='medium'>
-      <ModalHeader onClose={onClose} showDismissButton={true}>
+      <ModalHeader onClose={onClose} showDismissButton={!isFlowLoading}>
         <ModalTitle
           title={
-            modalScreen === 'confirm' ? messages.confirmDetails : messages.title
+            isFlowLoading
+              ? ''
+              : modalScreen === 'confirm'
+                ? messages.confirmDetails
+                : messages.title
           }
         />
       </ModalHeader>
@@ -37,21 +42,24 @@ export const BuySellModal = () => {
           onClose={onClose}
           openAddFundsModal={openAddFundsModal}
           onScreenChange={setModalScreen}
+          onLoadingStateChange={setIsFlowLoading}
         />
       </ModalContent>
-      <ModalFooter
-        css={{
-          justifyContent: 'center',
-          gap: spacing.s,
-          borderTop: `1px solid ${color.border.strong}`,
-          backgroundColor: color.background.surface1
-        }}
-      >
-        <Text variant='label' size='xs' color='subdued'>
-          {messages.poweredBy}
-        </Text>
-        <IconJupiterLogo />
-      </ModalFooter>
+      {!isFlowLoading && (
+        <ModalFooter
+          css={{
+            justifyContent: 'center',
+            gap: spacing.s,
+            borderTop: `1px solid ${color.border.strong}`,
+            backgroundColor: color.background.surface1
+          }}
+        >
+          <Text variant='label' size='xs' color='subdued'>
+            {messages.poweredBy}
+          </Text>
+          <IconJupiterLogo />
+        </ModalFooter>
+      )}
     </Modal>
   )
 }

--- a/packages/web/src/components/buy-sell-modal/USDCBalanceSection.tsx
+++ b/packages/web/src/components/buy-sell-modal/USDCBalanceSection.tsx
@@ -2,6 +2,10 @@ import { Divider, Flex, IconInfo, Text } from '@audius/harmony'
 
 import { TokenInfo } from './types'
 
+const messages = {
+  amount: (amount: string) => `$${amount}`
+}
+
 type USDCBalanceSectionProps = {
   title: string
   tokenInfo: TokenInfo
@@ -26,7 +30,7 @@ export const USDCBalanceSection = ({
         <Divider css={{ flexGrow: 1 }} />
       </Flex>
       <Text variant='heading' size='xl'>
-        {amount}
+        {messages.amount(amount)}
       </Text>
     </Flex>
   )

--- a/packages/web/src/components/buy-sell-modal/hooks/useBuySellSwap.ts
+++ b/packages/web/src/components/buy-sell-modal/hooks/useBuySellSwap.ts
@@ -73,16 +73,17 @@ export const useBuySellSwap = (props: UseBuySellSwapProps) => {
 
   useEffect(() => {
     if (swapStatus === 'success') {
+      setCurrentScreen('input')
       toast(
         activeTab === 'buy' ? messages.buySuccess : messages.sellSuccess,
         3000
       )
       const timer = setTimeout(() => {
-        setCurrentScreen('input')
         onClose()
       }, 1000)
       return () => clearTimeout(timer)
     } else if (swapStatus === 'error') {
+      setCurrentScreen('input')
       toast(swapError?.message || messages.transactionFailed, 5000)
     }
   }, [swapStatus, swapError, activeTab, onClose, toast, setCurrentScreen])

--- a/packages/web/src/components/modal-loading/ModalLoading.tsx
+++ b/packages/web/src/components/modal-loading/ModalLoading.tsx
@@ -1,0 +1,40 @@
+import { Flex, Text } from '@audius/harmony'
+
+import LoadingSpinner from '../loading-spinner/LoadingSpinner'
+
+type ModalLoadingProps = {
+  title?: string
+  subtitle?: string
+}
+
+export const ModalLoading = ({
+  title = 'Transaction in Progress',
+  subtitle = 'This may take a moment.'
+}: ModalLoadingProps) => {
+  return (
+    <Flex
+      direction='column'
+      justifyContent='center'
+      alignItems='center'
+      gap='l'
+      p='xl'
+      m='unit24'
+    >
+      <LoadingSpinner />
+      <Flex direction='column' alignItems='center' gap='s'>
+        <Text variant='heading' size='l' color='default' textAlign='center'>
+          {title}
+        </Text>
+        <Text
+          variant='title'
+          size='l'
+          strength='weak'
+          color='default'
+          textAlign='center'
+        >
+          {subtitle}
+        </Text>
+      </Flex>
+    </Flex>
+  )
+}

--- a/packages/web/src/components/modal-loading/ModalLoading.tsx
+++ b/packages/web/src/components/modal-loading/ModalLoading.tsx
@@ -2,14 +2,19 @@ import { Flex, Text } from '@audius/harmony'
 
 import LoadingSpinner from '../loading-spinner/LoadingSpinner'
 
+const messages = {
+  title: 'Transaction in Progress',
+  subtitle: 'This may take a moment.'
+}
+
 type ModalLoadingProps = {
   title?: string
   subtitle?: string
 }
 
 export const ModalLoading = ({
-  title = 'Transaction in Progress',
-  subtitle = 'This may take a moment.'
+  title = messages.title,
+  subtitle = messages.subtitle
 }: ModalLoadingProps) => {
   return (
     <Flex

--- a/packages/web/src/components/modal-loading/index.ts
+++ b/packages/web/src/components/modal-loading/index.ts
@@ -1,0 +1,1 @@
+export { ModalLoading } from './ModalLoading'


### PR DESCRIPTION
### Description

This PR enhances the Buy/Sell Modal by adding a loading state during transaction processing, improving the user experience by providing clear visual feedback when transactions are in progress.

## Changes
- Added new `ModalLoading` component for displaying loading states in modals
- Integrated loading state into Buy/Sell flow
- Improved transaction feedback and modal behavior
- Added dollar sign prefix to USDC balance display

### Detailed Changes
1. **New Loading Component**
   - Created `ModalLoading` component with customizable title and subtitle
   - Added loading spinner with centered layout
   - Default messaging for transaction progress

2. **Buy/Sell Flow Improvements**
   - Added loading state management via `onLoadingStateChange` callback
   - Disabled modal dismiss button during loading
   - Hide Jupiter logo footer during loading state
   - Clear modal title during loading state

4. **UI Enhancements**
   - Added dollar sign prefix to USDC balance display for better clarity
   - Improved modal state management during transactions

## Screenshots
<img width="753" alt="image" src="https://github.com/user-attachments/assets/0fc7b55f-dc16-4d9f-a314-3f71effe9c33" />

### How Has This Been Tested?

`npm run web:prod`

- create a swap and see if loading state appears
