### PR TITLE
Fix min ios version

### DIFF
--- a/packages/mobile/ios/Podfile
+++ b/packages/mobile/ios/Podfile
@@ -10,7 +10,7 @@ end
 node_require('react-native/scripts/react_native_pods.rb')
 node_require('react-native-permissions/scripts/setup.rb')
 
-platform :ios, min_ios_version_supported
+platform :ios, 15.5
 prepare_react_native_project!
 
 setup_permissions([

--- a/packages/mobile/ios/Podfile.lock
+++ b/packages/mobile/ios/Podfile.lock
@@ -2018,6 +2018,9 @@ PODS:
     - React-Core
     - RNZipArchive/Core (= 7.0.1)
     - SSZipArchive (~> 2.5.5)
+  - RNZipArchive/Core (7.0.1):
+    - React-Core
+    - SSZipArchive (~> 2.5.5)
   - SDWebImage (5.11.1):
     - SDWebImage/Core (= 5.11.1)
   - SDWebImage/Core (5.11.1)
@@ -2585,6 +2588,6 @@ SPEC CHECKSUMS:
   TOCropViewController: 80b8985ad794298fb69d3341de183f33d1853654
   Yoga: feb4910aba9742cfedc059e2b2902e22ffe9954a
 
-PODFILE CHECKSUM: 5b65fbb26339c899e3c5c1a92e21c58ed2d39998
+PODFILE CHECKSUM: 85cfd74f1d3df0d3492c06649e02d4150c39af2d
 
 COCOAPODS: 1.15.2


### PR DESCRIPTION
### Description

Fixes min_ios_version back to 15.5 to fix react-native-image-picker, since it requires zip-archive at a specific version