### PR TITLE
More remix contest notif fixes

### DIFF
--- a/packages/web/src/components/notification/Notification/ArtistRemixContestEndingSoonNotification.tsx
+++ b/packages/web/src/components/notification/Notification/ArtistRemixContestEndingSoonNotification.tsx
@@ -50,7 +50,12 @@ export const ArtistRemixContestEndingSoonNotification = (
         <NotificationBody>
           <Text variant='body' size='l'>
             {messages.description1}
-            <TrackLink variant='secondary' size='l' trackId={track.track_id} />
+            <TrackLink
+              css={{ display: 'inline' }}
+              variant='secondary'
+              size='l'
+              trackId={track.track_id}
+            />
             {messages.description2}
           </Text>
         </NotificationBody>

--- a/packages/web/src/components/notification/Notification/ArtistRemixContestEndingSoonNotification.tsx
+++ b/packages/web/src/components/notification/Notification/ArtistRemixContestEndingSoonNotification.tsx
@@ -50,7 +50,7 @@ export const ArtistRemixContestEndingSoonNotification = (
         <NotificationBody>
           <Text variant='body' size='l'>
             {messages.description1}
-            <TrackLink size='l' trackId={track.track_id} />
+            <TrackLink variant='secondary' size='l' trackId={track.track_id} />
             {messages.description2}
           </Text>
         </NotificationBody>

--- a/packages/web/src/components/notification/Notification/ArtistRemixContestSubmissionsNotification.tsx
+++ b/packages/web/src/components/notification/Notification/ArtistRemixContestSubmissionsNotification.tsx
@@ -47,7 +47,7 @@ export const ArtistRemixContestSubmissionsNotification = ({
       </NotificationHeader>
       <NotificationBody>
         {messages.description}
-        <TrackLink size='l' trackId={track.track_id} />
+        <TrackLink variant='secondary' size='l' trackId={track.track_id} />
         {milestone === 1
           ? messages.firstSubmission
           : messages.description2(milestone)}

--- a/packages/web/src/components/notification/Notification/ArtistRemixContestSubmissionsNotification.tsx
+++ b/packages/web/src/components/notification/Notification/ArtistRemixContestSubmissionsNotification.tsx
@@ -47,7 +47,12 @@ export const ArtistRemixContestSubmissionsNotification = ({
       </NotificationHeader>
       <NotificationBody>
         {messages.description}
-        <TrackLink variant='secondary' size='l' trackId={track.track_id} />
+        <TrackLink
+          css={{ display: 'inline' }}
+          variant='secondary'
+          size='l'
+          trackId={track.track_id}
+        />
         {milestone === 1
           ? messages.firstSubmission
           : messages.description2(milestone)}

--- a/packages/web/src/components/notification/Notification/FanRemixContestEndedNotification.tsx
+++ b/packages/web/src/components/notification/Notification/FanRemixContestEndedNotification.tsx
@@ -51,7 +51,7 @@ export const FanRemixContestEndedNotification = (
       <NotificationHeader icon={<IconTrophy color='accent' />}>
         <NotificationTitle>{messages.title}</NotificationTitle>
       </NotificationHeader>
-      <Flex>
+      <Flex alignItems='flex-start'>
         <TrackContent track={track as TrackEntity} hideTitle />
         <NotificationBody>
           <UserNameLink user={user} notification={notification} />{' '}

--- a/packages/web/src/components/notification/Notification/FanRemixContestEndingSoonNotification.tsx
+++ b/packages/web/src/components/notification/Notification/FanRemixContestEndingSoonNotification.tsx
@@ -51,7 +51,7 @@ export const FanRemixContestEndingSoonNotification = (
       <NotificationHeader icon={<IconTrophy color='accent' />}>
         <NotificationTitle>{messages.title}</NotificationTitle>
       </NotificationHeader>
-      <Flex>
+      <Flex alignItems='flex-start'>
         <TrackContent track={track as TrackEntity} hideTitle />
         <NotificationBody>
           <UserNameLink user={user} notification={notification} />{' '}

--- a/packages/web/src/components/notification/Notification/FanRemixContestStartedNotification.tsx
+++ b/packages/web/src/components/notification/Notification/FanRemixContestStartedNotification.tsx
@@ -56,7 +56,12 @@ export const FanRemixContestStartedNotification = (
         <NotificationBody>
           <UserNameLink user={user} notification={notification} />{' '}
           {messages.description}
-          <TrackLink variant='secondary' size='l' trackId={track.track_id} />
+          <TrackLink
+            css={{ display: 'inline' }}
+            variant='secondary'
+            size='l'
+            trackId={track.track_id}
+          />
         </NotificationBody>
       </Flex>
       <NotificationFooter timeLabel={timeLabel} isViewed={isViewed} />

--- a/packages/web/src/components/notification/Notification/FanRemixContestStartedNotification.tsx
+++ b/packages/web/src/components/notification/Notification/FanRemixContestStartedNotification.tsx
@@ -21,7 +21,7 @@ import { UserNameLink } from './components/UserNameLink'
 
 const messages = {
   title: 'New Remix Contest',
-  description: 'started a new remix contest for'
+  description: 'started a new remix contest for '
 }
 
 type FanRemixContestStartedNotificationProps = {
@@ -51,11 +51,12 @@ export const FanRemixContestStartedNotification = (
       <NotificationHeader icon={<IconTrophy color='accent' />}>
         <NotificationTitle>{messages.title}</NotificationTitle>
       </NotificationHeader>
-      <Flex>
+      <Flex alignItems='flex-start'>
         <TrackContent track={track as TrackEntity} hideTitle />
         <NotificationBody>
           <UserNameLink user={user} notification={notification} />{' '}
-          {messages.description} <TrackLink size='l' trackId={track.track_id} />
+          {messages.description}
+          <TrackLink variant='secondary' size='l' trackId={track.track_id} />
         </NotificationBody>
       </Flex>
       <NotificationFooter timeLabel={timeLabel} isViewed={isViewed} />


### PR DESCRIPTION
### Description
Some more small UI updates

### How Has This Been Tested?
Before:
<img width="415" alt="Screenshot 2025-05-13 at 5 35 37 PM" src="https://github.com/user-attachments/assets/b3ca9ee5-2486-4f3d-a560-18ac50c4d7c6" />

After:
<img width="411" alt="Screenshot 2025-05-13 at 5 35 50 PM" src="https://github.com/user-attachments/assets/ae8e8607-2210-48c3-a7ab-4e489a03b8e9" />


Before:
<img width="411" alt="Screenshot 2025-05-13 at 5 35 18 PM" src="https://github.com/user-attachments/assets/0aa4a760-dec5-49f3-bc75-a005e43e6aea" />

After:
<img width="412" alt="Screenshot 2025-05-13 at 5 34 58 PM" src="https://github.com/user-attachments/assets/99ddc788-3b87-4b01-aa5e-e2b9bd7ced87" />
