### PR TITLE
[PE-6183] Contest entries filter selected by default

### DIFF
--- a/packages/web/src/pages/remixes-page/components/desktop/NewRemixesPage.tsx
+++ b/packages/web/src/pages/remixes-page/components/desktop/NewRemixesPage.tsx
@@ -18,7 +18,6 @@ import {
   Button
 } from '@audius/harmony'
 import { Link } from 'react-router-dom'
-import { useSearchParams as useParams } from 'react-router-dom-v5-compat'
 
 import { Header } from 'components/header/desktop/Header'
 import { TanQueryLineup } from 'components/lineup/TanQueryLineup'
@@ -52,7 +51,6 @@ const RemixesPage = nullGuard(({ title, originalTrack }) => {
   const updateSortParam = useUpdateSearchParams('sortMethod')
   const updateIsCosignParam = useUpdateSearchParams('isCosign')
   const updateIsContestEntryParam = useUpdateSearchParams('isContestEntry')
-  const [urlSearchParams] = useParams()
   const { isEnabled: isRemixContestEnabled } = useFeatureFlag(
     FeatureFlags.REMIX_CONTEST
   )

--- a/packages/web/src/pages/remixes-page/components/desktop/NewRemixesPage.tsx
+++ b/packages/web/src/pages/remixes-page/components/desktop/NewRemixesPage.tsx
@@ -1,3 +1,5 @@
+import { useEffect } from 'react'
+
 import {
   useRemixes,
   useRemixContest,
@@ -18,6 +20,7 @@ import {
   Button
 } from '@audius/harmony'
 import { Link } from 'react-router-dom'
+import { useSearchParams as useParams } from 'react-router-dom-v5-compat'
 
 import { Header } from 'components/header/desktop/Header'
 import { TanQueryLineup } from 'components/lineup/TanQueryLineup'
@@ -51,6 +54,7 @@ const RemixesPage = nullGuard(({ title, originalTrack }) => {
   const updateSortParam = useUpdateSearchParams('sortMethod')
   const updateIsCosignParam = useUpdateSearchParams('isCosign')
   const updateIsContestEntryParam = useUpdateSearchParams('isContestEntry')
+  const [urlSearchParams] = useParams()
   const { isEnabled: isRemixContestEnabled } = useFeatureFlag(
     FeatureFlags.REMIX_CONTEST
   )
@@ -84,6 +88,18 @@ const RemixesPage = nullGuard(({ title, originalTrack }) => {
   })
 
   const pickWinnersRoute = pickWinnersPage(originalTrack?.permalink)
+
+  // On first load, set contest entry filter to true by default
+  useEffect(() => {
+    if (
+      isRemixContest &&
+      !isContestEntry &&
+      urlSearchParams.get('isContestEntry') === null
+    ) {
+      updateIsContestEntryParam('true')
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
 
   const renderHeader = () => (
     <Header

--- a/packages/web/src/pages/remixes-page/components/desktop/NewRemixesPage.tsx
+++ b/packages/web/src/pages/remixes-page/components/desktop/NewRemixesPage.tsx
@@ -1,5 +1,3 @@
-import { useEffect } from 'react'
-
 import {
   useRemixes,
   useRemixContest,
@@ -88,18 +86,6 @@ const RemixesPage = nullGuard(({ title, originalTrack }) => {
   })
 
   const pickWinnersRoute = pickWinnersPage(originalTrack?.permalink)
-
-  // On first load, set contest entry filter to true by default
-  useEffect(() => {
-    if (
-      isRemixContest &&
-      !isContestEntry &&
-      urlSearchParams.get('isContestEntry') === null
-    ) {
-      updateIsContestEntryParam('true')
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [])
 
   const renderHeader = () => (
     <Header

--- a/packages/web/src/pages/track-page/components/desktop/RemixContestSubmissionsTab.tsx
+++ b/packages/web/src/pages/track-page/components/desktop/RemixContestSubmissionsTab.tsx
@@ -138,7 +138,7 @@ const RemixContestSubmissions = ({
     select: (track) => track.permalink
   })
 
-  const remixesRoute = trackRemixesPage(permalink ?? '')
+  const remixesRoute = `${trackRemixesPage(permalink ?? '')}?isContestEntry=true`
 
   return (
     <Flex column p='xl' gap='xl'>


### PR DESCRIPTION
### Description
We want the "contest entries" filter to be selected by default, so that it's more clear that the user is viewing "submissions" to the remix contest (remixes that were uploaded _after_ the contest started, instead of _all_ remixes).

### How Has This Been Tested?


https://github.com/user-attachments/assets/599b6db9-554f-4c3d-9181-74c179822c7b

