### PR TITLE
[PE-6185] Remixes QA pass

### DIFF
--- a/packages/common/src/messages/remixes.ts
+++ b/packages/common/src/messages/remixes.ts
@@ -11,7 +11,7 @@ export const remixMessages = {
   finalizeWinners: 'Finalize Winners',
   winners: 'Winners',
   winnersDescription: 'Pick up to 5 winners in ranked order.',
-  maxWinnersReached: 'You can only pick up to 5 winners.',
+  maxWinnersReached: 'Maximum winners reached.',
   winnerPlaceholder: 'Click the +/- buttons to add or remove winners.',
 
   // Modal Messages

--- a/packages/mobile/src/screens/track-screen/TrackRemixesScreen.tsx
+++ b/packages/mobile/src/screens/track-screen/TrackRemixesScreen.tsx
@@ -105,7 +105,8 @@ export const TrackRemixesScreen = () => {
                   <Flex justifyContent='space-between' ph='l' pt='xl'>
                     {count ? (
                       <Text variant='title'>
-                        {count} {pluralize(messages.submissions, count)}
+                        {messages.remixesTitle}
+                        {count !== undefined ? ` (${count})` : ''}
                       </Text>
                     ) : null}
                   </Flex>

--- a/packages/web/src/components/track/CardTitle.tsx
+++ b/packages/web/src/components/track/CardTitle.tsx
@@ -44,7 +44,13 @@ export const CardTitle = ({
 }: CardTitleProps) => {
   let content
 
-  if (isStreamGated) {
+  if (isRemixContest) {
+    content = (
+      <Text variant='label' color='subdued'>
+        {messages.remixContest}
+      </Text>
+    )
+  } else if (isStreamGated) {
     let icon
     let message
     if (isContentCollectibleGated(streamConditions)) {
@@ -68,13 +74,11 @@ export const CardTitle = ({
   } else {
     content = (
       <Text variant='label' color='subdued'>
-        {isRemixContest
-          ? messages.remixContest
-          : isRemix
-            ? messages.remixTitle
-            : isPodcast
-              ? messages.podcastTitle
-              : messages.trackTitle}
+        {isRemix
+          ? messages.remixTitle
+          : isPodcast
+            ? messages.podcastTitle
+            : messages.trackTitle}
       </Text>
     )
   }

--- a/packages/web/src/components/track/DownloadRow.tsx
+++ b/packages/web/src/components/track/DownloadRow.tsx
@@ -84,16 +84,8 @@ export const DownloadRow = ({
         <Text variant='body' color='subdued'>
           {index}
         </Text>
-        <Text variant='body' strength='default'>
-          {category
-            ? stemCategoryFriendlyNames[category]
-            : track?.stem_of?.category
-              ? stemCategoryFriendlyNames[track?.stem_of?.category]
-              : messages.fullTrack}
-        </Text>
         <Text
           variant='body'
-          color='subdued'
           css={{
             overflow: 'hidden',
             textOverflow: 'ellipsis',
@@ -108,6 +100,13 @@ export const DownloadRow = ({
                   isOriginal: true
                 })
               : null)}
+        </Text>
+        <Text variant='body' color='subdued' strength='default'>
+          {category
+            ? stemCategoryFriendlyNames[category]
+            : track?.stem_of?.category
+              ? stemCategoryFriendlyNames[track?.stem_of?.category]
+              : messages.fullTrack}
         </Text>
       </Flex>
       <Flex gap='2xl'>

--- a/packages/web/src/components/track/DownloadRow.tsx
+++ b/packages/web/src/components/track/DownloadRow.tsx
@@ -101,7 +101,7 @@ export const DownloadRow = ({
                 })
               : null)}
         </Text>
-        <Text variant='body' color='subdued' strength='default'>
+        <Text variant='body' color='subdued'>
           {category
             ? stemCategoryFriendlyNames[category]
             : track?.stem_of?.category

--- a/packages/web/src/pages/remixes-page/components/desktop/NewRemixesPage.tsx
+++ b/packages/web/src/pages/remixes-page/components/desktop/NewRemixesPage.tsx
@@ -8,7 +8,7 @@ import { remixMessages as messages } from '@audius/common/messages'
 import { Track, User } from '@audius/common/models'
 import { FeatureFlags } from '@audius/common/services'
 import { remixesPageLineupActions } from '@audius/common/store'
-import { dayjs, pluralize } from '@audius/common/utils'
+import { dayjs } from '@audius/common/utils'
 import {
   IconRemix,
   Text,
@@ -125,10 +125,8 @@ const RemixesPage = nullGuard(({ title, originalTrack }) => {
           leadingElementDelineator={
             <Flex justifyContent='space-between'>
               <Text variant='heading'>
-                {count}{' '}
-                {isRemixContest
-                  ? pluralize(messages.submissions, count ?? 0)
-                  : pluralize(messages.remixes, count ?? 0, 'es')}
+                {messages.remixesTitle}
+                {count !== undefined ? ` (${count})` : ''}
               </Text>
               <Flex gap='s' mb='xl'>
                 <FilterButton

--- a/packages/web/src/pages/remixes-page/components/mobile/NewRemixesPage.tsx
+++ b/packages/web/src/pages/remixes-page/components/mobile/NewRemixesPage.tsx
@@ -6,7 +6,6 @@ import { remixMessages as messages } from '@audius/common/messages'
 import { Track, User } from '@audius/common/models'
 import { FeatureFlags } from '@audius/common/services'
 import { remixesPageLineupActions } from '@audius/common/store'
-import { pluralize } from '@audius/common/utils'
 import {
   Flex,
   Text,
@@ -122,10 +121,8 @@ const RemixesPage = nullGuard(
             leadingElementDelineator={
               <Flex justifyContent='space-between' gap='l' mb='xl'>
                 <Text variant='title'>
-                  {count}{' '}
-                  {isRemixContest
-                    ? pluralize(messages.submissions, count)
-                    : pluralize(messages.remixes, count, 'es')}
+                  {messages.remixesTitle}
+                  {count !== undefined ? ` (${count})` : ''}
                 </Text>
               </Flex>
             }


### PR DESCRIPTION
### Description
* Prioritized the Remix Contest label on Web
* Reorders the stems download row text on web
* Change # Submissions to "Remixes(#)" on all platforms

### How Has This Been Tested?
Manually Tested