### PR TITLE
Fix redux persist in web causing navigation issues

### DIFF
--- a/packages/web/src/store/configureStore.ts
+++ b/packages/web/src/store/configureStore.ts
@@ -3,10 +3,9 @@ import { chatMiddleware } from '@audius/common/store'
 import { composeWithDevToolsLogOnlyInProduction } from '@redux-devtools/extension'
 import { configureScope, addBreadcrumb } from '@sentry/browser'
 import { History } from 'history'
-import localforage from 'localforage'
 import { createStore, applyMiddleware, Action, Store } from 'redux'
 import { createReduxHistoryContext } from 'redux-first-history'
-import { persistStore, persistReducer } from 'redux-persist'
+import { persistStore } from 'redux-persist'
 import createSagaMiddleware from 'redux-saga'
 import createSentryMiddleware from 'redux-sentry-middleware'
 import thunk from 'redux-thunk'
@@ -153,15 +152,8 @@ export const configureStore = (
     maxAge: 1000
   })
 
-  const rootReducer = createRootReducer(routerReducer)
-  const persistConfig = {
-    key: 'root',
-    storage: localforage
-  }
-  const persistedReducer = persistReducer(persistConfig, rootReducer)
-
   const store = createStore(
-    persistedReducer,
+    createRootReducer(routerReducer),
     // @ts-ignore - Initial state is just for test mocking purposes
     initialStoreState,
     composeEnhancers(middlewares)


### PR DESCRIPTION
### Description

Links were redirecting to pages in the previous session because the entire root reducer was persisted from this change https://github.com/AudiusProject/audius-protocol/pull/12080

Search is already persisted so only this change is needed

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._

Confirmed recent searches saves across sessions. Navigation works on new sessions.
