### PR TITLE
Fix ios build by adding back prod bundle logic

### DIFF
--- a/packages/mobile/ios/AudiusReactNative/AppDelegate.mm
+++ b/packages/mobile/ios/AudiusReactNative/AppDelegate.mm
@@ -61,6 +61,8 @@
 {
 #if DEBUG
   return [[RCTBundleURLProvider sharedSettings] jsBundleURLForBundleRoot:@"index"];
+#else
+  return [[NSBundle mainBundle] URLForResource:@"main" withExtension:@"jsbundle"];
 #endif
 }
 


### PR DESCRIPTION
### Description

Fixes issue introduced with code-push removal. For archive builds we should add an else case for bundle method