### PR TITLE
Fix loading state for featured remix contests

### DIFF
--- a/packages/web/src/pages/explore-page/components/desktop/FeaturedRemixContests.tsx
+++ b/packages/web/src/pages/explore-page/components/desktop/FeaturedRemixContests.tsx
@@ -1,4 +1,5 @@
-import { useExploreContent } from '@audius/common/api'
+import { useExploreContent, useTracks } from '@audius/common/api'
+import { Flex } from '@audius/harmony'
 
 import LoadingSpinner from 'components/loading-spinner/LoadingSpinner'
 
@@ -12,11 +13,18 @@ const messages = {
 export const FeaturedRemixContests = () => {
   const { data: exploreContent, isLoading } = useExploreContent()
   const contestIds = exploreContent?.featuredRemixContests ?? []
+  const { isLoading: isTracksLoading } = useTracks(contestIds)
 
   return (
-    <Section title={messages.remixContests}>
-      {isLoading ? (
-        <LoadingSpinner />
+    <Section title={messages.remixContests} css={{ minHeight: 380 }}>
+      {isLoading || isTracksLoading ? (
+        <Flex
+          justifyContent='center'
+          alignItems='center'
+          css={{ minHeight: 300 }}
+        >
+          <LoadingSpinner css={{ width: 48 }} />
+        </Flex>
       ) : (
         <>
           {contestIds.slice(0, 4).map((id) => (


### PR DESCRIPTION
### Description
Small update to fix the loading state.
The loading of the tracks was causing the cards to not show up

### How Has This Been Tested?
Manually Tested
