### PR TITLE
Fix recent search and autocomplete styling

### DIFF
--- a/packages/web/src/components/search-bar/DesktopSearchBar.module.css
+++ b/packages/web/src/components/search-bar/DesktopSearchBar.module.css
@@ -219,7 +219,10 @@
   border: 1px solid var(--border-border-default);
   background-color: var(--harmony-bg-surface-2) !important;
 }
-.searchBox :global(.ant-select-item-option.ant-select-item-option-active):has([class*="PlainButton"]) {
+.searchBox
+  :global(.ant-select-item-option.ant-select-item-option-active):has(
+    [class*='PlainButton']
+  ) {
   background-color: transparent !important;
 }
 .searchBox :global(.ant-select-item-option:hover) {

--- a/packages/web/src/components/search-bar/DesktopSearchBar.module.css
+++ b/packages/web/src/components/search-bar/DesktopSearchBar.module.css
@@ -104,6 +104,7 @@
 }
 
 .searchBar :global(.ant-select-dropdown .rc-virtual-list-holder) {
+  padding: 16px 8px;
   max-height: unset !important;
 }
 .searchBar :global(.ant-select-dropdown) {
@@ -124,7 +125,7 @@
 }
 
 .searchBox :global(.ant-select-item-option) {
-  margin: auto 8px;
+  margin: auto 0px;
   padding: 0px;
   display: flex;
   flex-direction: row;
@@ -157,17 +158,14 @@
 
 .searchBox :global(.ant-select-item-group) {
   height: 14px;
-  min-height: 8px;
-  margin-top: 16px;
-  margin-left: 16px;
-  margin-bottom: 2px;
+  min-height: 26px;
   color: var(--harmony-neutral);
   font-size: var(--harmony-font-xs);
   font-weight: var(--harmony-font-bold);
   letter-spacing: 0.7px;
   line-height: 14px;
   text-transform: uppercase;
-  padding: 0;
+  padding: 8px;
 }
 
 .searchBoxEmpty :global(.ant-select-item-group) {
@@ -218,8 +216,11 @@
  */
 .searchBox :global(.ant-select-item-option.ant-select-item-option-active) {
   border-radius: 4px;
-  border: 1px solid var(--harmony-n-100);
-  background-color: var(--harmony-n-50) !important;
+  border: 1px solid var(--border-border-default);
+  background-color: var(--harmony-bg-surface-2) !important;
+}
+.searchBox :global(.ant-select-item-option.ant-select-item-option-active):has([class*="PlainButton"]) {
+  background-color: transparent !important;
 }
 .searchBox :global(.ant-select-item-option:hover) {
   background-color: unset;
@@ -329,11 +330,6 @@
 .tagSearchPopup:hover path,
 .focused path {
   fill: var(--harmony-white);
-}
-
-:global(.ant-select-item-option-active) .primary,
-:global(.ant-select-item-option-active) .secondary {
-  color: var(--harmony-static-white);
 }
 
 :global(.ant-select-item-option-active) .iconArrow path {

--- a/packages/web/src/components/search-bar/DesktopSearchBar.module.css
+++ b/packages/web/src/components/search-bar/DesktopSearchBar.module.css
@@ -110,12 +110,15 @@
 .searchBar :global(.ant-select-dropdown) {
   -webkit-app-region: none;
   animation-duration: 0.2s !important;
-  box-shadow: 0 2px 5px 0 rgba(133, 129, 153, 0.15);
+  box-shadow:
+    0px 0px 4px 0px rgba(0, 0, 0, 0.04),
+    0px 4px 8px 0px rgba(0, 0, 0, 0.06);
   position: absolute;
   background: var(--harmony-white);
   width: 100%;
   top: 32px !important;
-  border-radius: 4px;
+  border-radius: 8px;
+  border: 1px solid var(--harmony-n-100);
   padding: 0;
 }
 

--- a/packages/web/src/components/search-bar/DesktopSearchBar.tsx
+++ b/packages/web/src/components/search-bar/DesktopSearchBar.tsx
@@ -20,8 +20,8 @@ import Input from 'antd/lib/input'
 import type { InputRef } from 'antd/lib/input'
 import cn from 'classnames'
 import { useDispatch, useSelector } from 'react-redux'
-import { Link, useHistory, useLocation, matchPath } from 'react-router-dom'
-import { useSearchParams } from 'react-router-dom-v5-compat'
+import { useHistory, useLocation, matchPath } from 'react-router-dom'
+import { useNavigate, useSearchParams } from 'react-router-dom-v5-compat'
 import { useDebounce, usePrevious } from 'react-use'
 
 import { searchResultsPage } from 'utils/route'
@@ -49,25 +49,20 @@ const messages = {
   }
 }
 
-const ViewMoreButton = ({ query }: { query: string }) => (
-  <Flex
-    as={Link}
-    // @ts-expect-error
-    to={searchResultsPage('all', query)}
-    alignItems='center'
-    ph='l'
-    pv='m'
-    gap='2xs'
-    css={{
-      cursor: 'pointer'
-    }}
-  >
-    <Text variant='label' size='s' color='subdued' className={styles.primary}>
-      {messages.viewMoreResults}
-    </Text>
-    <IconArrowRight size='s' color='subdued' className={styles.iconArrow} />
-  </Flex>
-)
+const ViewMoreButton = ({ query }: { query: string }) => {
+  const navigate = useNavigate()
+
+  return (
+    <Flex alignItems='center' pt='l' gap='2xs' justifyContent='center'>
+      <PlainButton
+        iconRight={IconArrowRight}
+        onClick={() => navigate(searchResultsPage('all', query))}
+      >
+        {messages.viewMoreResults}
+      </PlainButton>
+    </Flex>
+  )
+}
 
 const ClearRecentSearchesButton = () => {
   const dispatch = useDispatch()
@@ -76,7 +71,7 @@ const ClearRecentSearchesButton = () => {
   }, [dispatch])
 
   return (
-    <Flex alignItems='center' ph='l' pv='m' gap='2xs'>
+    <Flex alignItems='center' pt='l' gap='2xs' justifyContent='center'>
       <PlainButton onClick={handleClickClear}>
         {messages.clearRecentSearches}
       </PlainButton>
@@ -223,14 +218,10 @@ export const DesktopSearchBar = () => {
     const hasResults = baseOptions.length > 0
 
     if (hasResults && inputValue) {
-      baseOptions.push({
-        options: [
-          {
-            label: <ViewMoreButton query={inputValue} />,
-            // @ts-expect-error
-            value: 'viewMore'
-          }
-        ]
+      baseOptions[baseOptions.length - 1].options.push({
+        label: <ViewMoreButton query={inputValue} />,
+        // @ts-expect-error
+        value: 'viewMore'
       })
     } else if (hasNoResults) {
       baseOptions.push({
@@ -255,7 +246,7 @@ export const DesktopSearchBar = () => {
   )
 
   const recentSearchOptions = useMemo(() => {
-    if (!searchHistory || inputValue) return []
+    if (!searchHistory.length || inputValue) return []
     const searchHistoryOptions = searchHistory.map((searchItem) => {
       if (searchItem.kind === Kind.USERS) {
         return {

--- a/packages/web/src/components/search-bar/DesktopSearchBar.tsx
+++ b/packages/web/src/components/search-bar/DesktopSearchBar.tsx
@@ -218,6 +218,7 @@ export const DesktopSearchBar = () => {
     const hasResults = baseOptions.length > 0
 
     if (hasResults && inputValue) {
+      // append to last group to avoid extra spacing between groups
       baseOptions[baseOptions.length - 1].options.push({
         label: <ViewMoreButton query={inputValue} />,
         // @ts-expect-error

--- a/packages/web/src/pages/profile-page/ProfilePageProvider.tsx
+++ b/packages/web/src/pages/profile-page/ProfilePageProvider.tsx
@@ -143,7 +143,6 @@ class ProfilePage extends PureComponent<ProfilePageProps, ProfilePageState> {
   componentDidMount() {
     // If routing from a previous profile page
     // the lineups must be reset to refetch & update for new user
-    console.log('asdf fetching profile: ', this.props.location)
     this.fetchProfile(getPathname(this.props.location))
 
     // Switching from profile page => profile page
@@ -153,8 +152,6 @@ class ProfilePage extends PureComponent<ProfilePageProps, ProfilePageState> {
         getPathname(this.props.location) !== getPathname(location) ||
         action === 'POP'
       ) {
-        console.log('asdf changing: ', this.props.location, location)
-
         const params = parseUserRoute(getPathname(location))
         if (params) {
           // Fetch profile if this is a new profile page

--- a/packages/web/src/pages/profile-page/ProfilePageProvider.tsx
+++ b/packages/web/src/pages/profile-page/ProfilePageProvider.tsx
@@ -143,6 +143,7 @@ class ProfilePage extends PureComponent<ProfilePageProps, ProfilePageState> {
   componentDidMount() {
     // If routing from a previous profile page
     // the lineups must be reset to refetch & update for new user
+    console.log('asdf fetching profile: ', this.props.location)
     this.fetchProfile(getPathname(this.props.location))
 
     // Switching from profile page => profile page
@@ -152,6 +153,8 @@ class ProfilePage extends PureComponent<ProfilePageProps, ProfilePageState> {
         getPathname(this.props.location) !== getPathname(location) ||
         action === 'POP'
       ) {
+        console.log('asdf changing: ', this.props.location, location)
+
         const params = parseUserRoute(getPathname(location))
         if (params) {
           // Fetch profile if this is a new profile page


### PR DESCRIPTION
### Description

Sammie and I addressed some inconsistencies with recent search and complete style and hover state in dark and light mode.

<img width="358" alt="Screenshot 2025-05-14 at 12 35 10 PM" src="https://github.com/user-attachments/assets/fcd9296b-8358-4c71-8911-8c4190e65848" />
<img width="321" alt="Screenshot 2025-05-14 at 12 35 06 PM" src="https://github.com/user-attachments/assets/1015f38e-de07-4f15-9efe-e461cd20b660" />

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._

Tested w local client against prod.