### PR TITLE
Don't suggest artists from staging when running dev

### DIFF
--- a/packages/common/src/api/tan-query/users/useSuggestedArtists.ts
+++ b/packages/common/src/api/tan-query/users/useSuggestedArtists.ts
@@ -17,6 +17,9 @@ export const useSuggestedArtists = (options?: QueryOptions) => {
   const { data: suggestedIds } = useQuery<number[]>({
     queryKey: getSuggestedArtistsQueryKey(),
     queryFn: async () => {
+      if (!env.SUGGESTED_FOLLOW_HANDLES) {
+        return []
+      }
       const response = await fetch(env.SUGGESTED_FOLLOW_HANDLES!)
       const suggestedArtists = await response.json()
       // dedupe the artists just in case the team accidentally adds the same artist twice

--- a/packages/mobile/src/services/env/env.dev.ts
+++ b/packages/mobile/src/services/env/env.dev.ts
@@ -76,8 +76,7 @@ export const env: Env = {
   SOLANA_RELAY_ENDPOINT: 'http://audius-protocol-discovery-provider-1',
   SOLANA_TOKEN_PROGRAM_ADDRESS: 'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA',
   SOLANA_WEB3_CLUSTER: 'devnet',
-  SUGGESTED_FOLLOW_HANDLES:
-    'https://download.staging.audius.co/static-resources/signup-follows.json',
+  SUGGESTED_FOLLOW_HANDLES: '',
   TIKTOK_APP_ID: Config.TIKTOK_APP_ID!,
   USDC_MINT_ADDRESS: '26Q7gP8UfkDzi7GMFEQxTJaNJ8D2ybCUjex58M5MLu8y',
   USE_HASH_ROUTING: false,

--- a/packages/web/src/services/env/env.dev.ts
+++ b/packages/web/src/services/env/env.dev.ts
@@ -75,8 +75,7 @@ export const env: Env = {
   SOLANA_RELAY_ENDPOINT: 'http://audius-protocol-discovery-provider-1',
   SOLANA_TOKEN_PROGRAM_ADDRESS: 'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA',
   SOLANA_WEB3_CLUSTER: 'devnet',
-  SUGGESTED_FOLLOW_HANDLES:
-    'https://download.staging.audius.co/static-resources/signup-follows.json',
+  SUGGESTED_FOLLOW_HANDLES: '',
   TIKTOK_APP_ID: 'awa9re2w7ec3xrn6',
   USDC_MINT_ADDRESS: '26Q7gP8UfkDzi7GMFEQxTJaNJ8D2ybCUjex58M5MLu8y',
   USE_HASH_ROUTING: false,


### PR DESCRIPTION
Suggesting artists from stage on local was causing the integration tests to fail, as they would fail to fetch those artists and then tan query would throw.

This, combined with the bug causing retries to happen on 404s still (#12129) meant that the failures would be reattempted 3 or so times before finally failing and throwing, which sometimes gave the integration test enough time to finish running the test before the error page was shown.