### PR TITLE
[API-119] Clean duplicate user rows, prevent it from happening

### DIFF
--- a/packages/discovery-provider/ddl/migrations/0139_clean_user_rows.sql
+++ b/packages/discovery-provider/ddl/migrations/0139_clean_user_rows.sql
@@ -1,0 +1,19 @@
+BEGIN;
+
+-- Find and delete duplicate user records, keeping the newest one
+WITH RankedUsers AS (
+    SELECT 
+        user_id,
+        updated_at,
+        ROW_NUMBER() OVER (PARTITION BY user_id ORDER BY updated_at DESC) as rn
+    FROM users
+)
+DELETE FROM users
+WHERE user_id IN (
+    SELECT user_id FROM RankedUsers WHERE rn > 1
+)
+AND (user_id, updated_at) IN (
+    SELECT user_id, updated_at FROM RankedUsers WHERE rn > 1
+);
+
+COMMIT;

--- a/packages/discovery-provider/src/tasks/index_core.py
+++ b/packages/discovery-provider/src/tasks/index_core.py
@@ -4,6 +4,7 @@ from datetime import datetime
 from logging import LoggerAdapter
 from typing import Optional, TypedDict, cast
 
+from celery.exceptions import SoftTimeLimitExceeded
 from redis import Redis
 from sqlalchemy import desc
 from web3 import Web3
@@ -147,7 +148,7 @@ def update_latest_indexed_block_redis(
         logger.error(f"couldn't update latest redis block: {e}")
 
 
-@celery.task(name="index_core", bind=True)
+@celery.task(name="index_core", bind=True, soft_time_limit=500)
 def index_core(self):
     redis: Redis = index_core.redis
     db: SessionManager = index_core.db
@@ -316,6 +317,9 @@ def index_core(self):
                 sol_plays_cutover=get_sol_cutover(),
             )
 
+    except SoftTimeLimitExceeded:
+        # Soft time limit exceeded, release lock and re-queue and doesn't commit the session
+        logger.error("Soft time limit exceeded. Releasing lock and re-queuing.")
     except Exception as e:
         root_logger.error(f"Error in indexing core blocks {e}", exc_info=True)
     finally:


### PR DESCRIPTION
### Description

* Delete duplicate user records
* Use celery soft time limit to prevent this from happening

After trying a lot to exercise something via integration_tests that could lead to duplicate user rows, this is my best guess as to how to fix the bug.

What we observe:
* Multiple users in the db with the same data, coming from seemingly benign transactions
* This rarely happens, and it's inconsistent on nodes, which must mean it's a race condition of sorts

My theory:
* We use celery the wrong way, somewhat intentionally. Each task re-queues the next. It does this in the `finally` block of the indexer where we arrived either because (1) someone else had the lock or (2) we finished indexing a block.
* Because of how celery works, this often leads to multiple `index_core` tasks in the queue waiting to get picked up. This is generally safe except in two situations (A) redis lock is somehow wiped (B) redis lock times out
* So, what could happen is that in either of A or B above, we get two celery tasks running at the same time and they both get into the situation where they are trying to pull existing records, and they aren't aware of each other, so they both run the create transaction and flush it. Because we have no db level constraint (we should eventually) this causes two rows to be written.
* I think (B) is more likely so I added this soft time limit before the redis lock expires, that should kill the transaction and never commit it. We have definitely seen times where `index_core` seems "stuck" (and could exceed the 600s timeout)

I'd like to add a db level constraint, but I'd only want to do that after we know what is causing it, or else we're going to get some hard stalls.

Things I tried in testing: Reprocessing the same tx, same block, multiple updates in the same block, duplicate creates and updates in the same block, etc. etc. Code is probably correct. Gemini & claude agree.

If we see this bug surface again - I think it's likely because of some unclean celery shut down kind of situation where something gets flushed to the db

Hate this code, need to rewrite.

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._

Existing integration tests