### PR TITLE
Wait for artwork to load before clicking save

### DIFF
--- a/packages/web/e2e/page-object-models/editCollection.ts
+++ b/packages/web/e2e/page-object-models/editCollection.ts
@@ -3,6 +3,7 @@ import path from 'path'
 import { expect, type Locator, type Page } from '@playwright/test'
 
 export class EditAlbumPage {
+  private readonly artwork: Locator
   private readonly artworkButton: Locator
   private readonly dropzoneFileInput: Locator
   private readonly titleInput: Locator
@@ -23,6 +24,7 @@ export class EditAlbumPage {
       name: /price & audience/i
     })
     this.saveChangesButton = page.getByRole('button', { name: /save changes/i })
+    this.artwork = page.getByLabel(/artwork preview/)
   }
 
   async setTitle(title: string) {
@@ -44,6 +46,10 @@ export class EditAlbumPage {
       path.join(__dirname, '..', 'files', file)
     )
     await this.dropzoneFileInput.page().getByLabel('close popup').click()
+    // Wait until finished loading
+    await this.artwork
+      .getByRole('progressbar')
+      .waitFor({ state: 'hidden', timeout: 30_000 })
   }
 
   async openPriceAndAudienceModal() {

--- a/packages/web/src/components/upload/UploadArtwork.jsx
+++ b/packages/web/src/components/upload/UploadArtwork.jsx
@@ -59,6 +59,7 @@ const UploadArtwork = ({
       ref={imageSelectionAnchorRef}
     >
       <div
+        aria-label='artwork preview'
         className={styles.artworkWrapper}
         style={{
           backgroundImage: `url(${


### PR DESCRIPTION
When running integration tests, sometimes the artwork takes a second to load in. While it's loading, the test can't continue the edit flow and times out.

Adds a wait in the test for the progress bar (loading spinner) to disappear, and give it a longer timeout