### PR TITLE
Up connection pool

### DIFF
--- a/packages/discovery-provider/default_config.ini
+++ b/packages/discovery-provider/default_config.ini
@@ -63,7 +63,7 @@ url = postgresql+psycopg2://postgres:postgres@db:5432/audius_discovery
 url_read_replica = postgresql+psycopg2://postgres:postgres@db:5432/audius_discovery
 run_migrations = true
 engine_args_literal = {
-    'pool_size': 20,
+    'pool_size': 40,
     'max_overflow': 10,
     'pool_recycle': 3600,
     'echo': False,


### PR DESCRIPTION
### Description

Larger connection pool per gunicorn worker

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._

just config, but 
```
audius_discovery=# SELECT
  count(*) AS current_connections,
  setting::int AS max_connections,
  round(count(*) * 100.0 / setting::int, 2) AS percent_used
FROM pg_stat_activity,
     (SELECT setting FROM pg_settings WHERE name = 'max_connections') AS max_conn GROUP BY max_connections;
 current_connections | max_connections | percent_used 
---------------------+-----------------+--------------
                 198 |             500 |        39.60
```