### PR TITLE
Increase some e2e test timeouts

### DIFF
--- a/packages/web/e2e/editCollection.test.ts
+++ b/packages/web/e2e/editCollection.test.ts
@@ -14,7 +14,9 @@ test('should persist collection edits', async ({ page }) => {
   const newPrice = '$1.23'
 
   await page.goto(permalink)
-  await page.getByRole('link', { name: /edit album/i }).click()
+  await page
+    .getByRole('link', { name: /edit album/i })
+    .click({ timeout: 20000 })
   const editAlbumPage = new EditAlbumPage(page)
 
   await editAlbumPage.setArtwork('track-artwork.jpeg')

--- a/packages/web/e2e/uploadCollection.test.ts
+++ b/packages/web/e2e/uploadCollection.test.ts
@@ -329,7 +329,7 @@ test('should upload a premium album', async ({ browser, page }) => {
   await expect(newPageAlbumPriceText).toBeVisible()
 
   newPage.goto(track1url)
-  await expect(buyButton).toBeVisible()
+  await expect(buyButton).toBeVisible({ timeout: 20000 })
   await expect(newPageTrackPriceText).toBeVisible()
   // newPage.goto(track2url)
   // await expect(buyButton).toBeVisible()

--- a/packages/web/e2e/uploadTrack.test.ts
+++ b/packages/web/e2e/uploadTrack.test.ts
@@ -223,7 +223,7 @@ test('should upload a premium track', async ({ page, browser }) => {
   const buyButton = newPage.getByRole('button', { name: /buy/i })
   newPage.goto(trackUrl)
   await expect(buyButton).toBeVisible({ timeout: 20000 })
-  await expect(newPage.getByText('$' + price)).toBeVisible({ timeout: 20000 })
+  await expect(newPage.getByText('$' + price)).toBeVisible()
 })
 
 test('should upload a track with free stems', async ({ page }) => {

--- a/packages/web/e2e/uploadTrack.test.ts
+++ b/packages/web/e2e/uploadTrack.test.ts
@@ -169,7 +169,6 @@ test('should upload a remix, hidden, AI-attributed track', async ({ page }) => {
 })
 
 test('should upload a premium track', async ({ page, browser }) => {
-  test.setTimeout(20000)
   const trackTitle = `Test premium track ${Date.now()}`
   const genre = 'Alternative'
   const price = '1.05'
@@ -223,8 +222,8 @@ test('should upload a premium track', async ({ page, browser }) => {
   const newPage = await openCleanBrowser({ browser })
   const buyButton = newPage.getByRole('button', { name: /buy/i })
   newPage.goto(trackUrl)
-  await expect(buyButton).toBeVisible()
-  await expect(newPage.getByText('$' + price)).toBeVisible()
+  await expect(buyButton).toBeVisible({ timeout: 20000 })
+  await expect(newPage.getByText('$' + price)).toBeVisible({ timeout: 20000 })
 })
 
 test('should upload a track with free stems', async ({ page }) => {

--- a/packages/web/e2e/uploadTrack.test.ts
+++ b/packages/web/e2e/uploadTrack.test.ts
@@ -169,6 +169,7 @@ test('should upload a remix, hidden, AI-attributed track', async ({ page }) => {
 })
 
 test('should upload a premium track', async ({ page, browser }) => {
+  test.setTimeout(20000)
   const trackTitle = `Test premium track ${Date.now()}`
   const genre = 'Alternative'
   const price = '1.05'


### PR DESCRIPTION
### Description
This test was failing but after checking the run it was just bc the track was taking longer than 10s to load.

### How Has This Been Tested?

Passes locally
