### PR TITLE
Fix account profile not loading in instantly

### DIFF
--- a/packages/common/src/api/tan-query/users/account/useCurrentAccount.ts
+++ b/packages/common/src/api/tan-query/users/account/useCurrentAccount.ts
@@ -1,3 +1,5 @@
+import { useMemo } from 'react'
+
 import { useQuery } from '@tanstack/react-query'
 import { useSelector } from 'react-redux'
 
@@ -29,26 +31,37 @@ export const useCurrentAccount = <
   const currentUserWallet = walletAddresses.currentUser
   const { localStorage } = useAppContext()
 
+  // We intentionally cache account data in local storage to quickly render the account details
+  // This initialData primes our query slice up front and will cause the hook to return synchronously (if the data exists)
+  const initialData = useMemo(() => {
+    const localAccount = localStorage.getAudiusAccountSync?.() // Assume you implement a sync version
+    const localAccountUser = localStorage.getAudiusAccountUserSync?.()
+
+    if (localAccount && localAccountUser) {
+      const account: AccountUserMetadata = {
+        user: {
+          ...localAccountUser,
+          playlists: localAccount.collections
+        },
+        playlists: localAccount.collections,
+        track_save_count: localAccount.trackSaveCount,
+        playlist_library: localAccount.playlistLibrary
+      }
+      return account
+    }
+
+    return undefined
+  }, [localStorage])
+
   return useQuery({
     queryKey: getCurrentAccountQueryKey(),
     queryFn: async () => {
-      const sdk = await audiusSdk()
-      const localAccount = await localStorage.getAudiusAccount()
-      const localAccountUser = await localStorage.getAudiusAccountUser()
-      if (localAccount && localAccountUser) {
-        // feature-tan-query TODO: when removing account sagas,
-        //    need to add wallets and local account user from local storage
-        const account: AccountUserMetadata = {
-          user: {
-            ...localAccountUser,
-            playlists: localAccount.collections
-          },
-          playlists: localAccount.collections,
-          track_save_count: localAccount.trackSaveCount,
-          playlist_library: localAccount.playlistLibrary
-        }
-        return account
+      // this means unauthenticated user
+      if (!currentUserWallet) {
+        return null
       }
+
+      const sdk = await audiusSdk()
       const { data } = await sdk.full.users.getUserAccount({
         wallet: currentUserWallet!
       })
@@ -64,6 +77,7 @@ export const useCurrentAccount = <
     staleTime: options?.staleTime ?? Infinity,
     gcTime: Infinity,
     enabled: options?.enabled !== false && !!currentUserWallet,
+    initialData: initialData ?? undefined,
     ...options
   })
 }

--- a/packages/common/src/api/tan-query/users/account/useCurrentAccount.ts
+++ b/packages/common/src/api/tan-query/users/account/useCurrentAccount.ts
@@ -56,11 +56,6 @@ export const useCurrentAccount = <
   return useQuery({
     queryKey: getCurrentAccountQueryKey(),
     queryFn: async () => {
-      // this means unauthenticated user
-      if (!currentUserWallet) {
-        return null
-      }
-
       const sdk = await audiusSdk()
       const { data } = await sdk.full.users.getUserAccount({
         wallet: currentUserWallet!

--- a/packages/common/src/services/local-storage/LocalStorage.ts
+++ b/packages/common/src/services/local-storage/LocalStorage.ts
@@ -35,12 +35,29 @@ export class LocalStorage {
     return await this.localStorage.getItem(key)
   }
 
+  getItemSync = (key: string) => {
+    return this.localStorage.getItem(key)
+  }
+
   getValue = async (key: string) => {
     return await this.localStorage.getItem(key)
   }
 
   async getJSONValue<T>(key: string): Promise<T | null> {
     const val = await this.getValue(key)
+    if (val) {
+      try {
+        const parsed = JSON.parse(val)
+        return parsed
+      } catch (e) {
+        return null
+      }
+    }
+    return null
+  }
+
+  getJSONValueSync = <T>(key: string): T | null => {
+    const val = this.getItemSync(key) as string | null
     if (val) {
       try {
         const parsed = JSON.parse(val)
@@ -96,6 +113,9 @@ export class LocalStorage {
   getAudiusAccount = async (): Promise<CachedAccount | null> =>
     this.getJSONValue(AUDIUS_ACCOUNT_KEY)
 
+  getAudiusAccountSync = (): CachedAccount | null =>
+    this.getJSONValueSync(AUDIUS_ACCOUNT_KEY)
+
   setAudiusAccount = async (value: object) => {
     await this.setJSONValue(AUDIUS_ACCOUNT_KEY, value)
   }
@@ -113,6 +133,9 @@ export class LocalStorage {
 
   getAudiusAccountUser = async (): Promise<User | null> =>
     this.getJSONValue(AUDIUS_ACCOUNT_USER_KEY)
+
+  getAudiusAccountUserSync = (): User | null =>
+    this.getJSONValueSync(AUDIUS_ACCOUNT_USER_KEY)
 
   setAudiusAccountUser = async (value: UserMetadata) =>
     this.setJSONValue(AUDIUS_ACCOUNT_USER_KEY, value)

--- a/packages/web/src/components/nav/desktop/AccountDetails.tsx
+++ b/packages/web/src/components/nav/desktop/AccountDetails.tsx
@@ -12,7 +12,7 @@ import { backgroundOverlay } from 'utils/styleUtils'
 import { AccountSwitcher } from './AccountSwitcher/AccountSwitcher'
 
 const { SIGN_IN_PAGE, SIGN_UP_PAGE, profilePage } = route
-const { getUserId, getIsAccountComplete, getGuestEmail } = accountSelectors
+const { getIsAccountComplete, getGuestEmail } = accountSelectors
 const messages = {
   haveAccount: 'Have an account?',
   managedAccount: 'Managed Account',
@@ -177,10 +177,8 @@ const GuestView = () => {
 }
 
 export const AccountDetails = () => {
-  const { data: accountHandle } = useCurrentAccount({
-    select: (data) => data?.user.handle
-  })
-  const userId = useSelector(getUserId)
+  const { data } = useCurrentAccount()
+  const { user_id: userId, handle: accountHandle } = data?.user ?? {}
   const guestEmail = useSelector(getGuestEmail)
   const isManagedAccount = useIsManagedAccount()
   const hasCompletedAccount = useSelector(getIsAccountComplete)

--- a/packages/web/src/test/mocks/local-storage.ts
+++ b/packages/web/src/test/mocks/local-storage.ts
@@ -13,6 +13,7 @@ export const createMockLocalStorage = () => {
   return {
     localStorage: mockLocalStorage,
     getItem: async (key: string) => storage.get(key) ?? null,
+    getItemSync: (key: string) => storage.get(key) ?? null,
     setItem: async (key: string, value: string) => {
       storage.set(key, value)
     },
@@ -20,10 +21,15 @@ export const createMockLocalStorage = () => {
       storage.delete(key)
     },
     getValue: async (key: string) => storage.get(key) ?? null,
+    getValueSync: (key: string) => storage.get(key) ?? null,
     setValue: async (key: string, value: string) => {
       storage.set(key, value)
     },
     getJSONValue: async (key: string) => {
+      const value = storage.get(key)
+      return value ? JSON.parse(value) : null
+    },
+    getJSONValueSync: (key: string) => {
       const value = storage.get(key)
       return value ? JSON.parse(value) : null
     },
@@ -65,9 +71,11 @@ export const createMockLocalStorage = () => {
       )
     },
     getAudiusAccount: async () => null,
+    getAudiusAccountSync: () => null,
     setAudiusAccount: async () => {},
     clearAudiusAccount: async () => {},
     getAudiusAccountUser: async () => null,
+    getAudiusAccountUserSync: () => null,
     setAudiusAccountUser: async () => {},
     clearAudiusAccountUser: async () => {},
     clearAudiusUserWalletOverride: async () => {},


### PR DESCRIPTION
### Description

- Rework the account query hook to synchronously fetch localstorage account data then prime the cache with it 
- Also removes the localStorage logic from the queryFn

### How Has This Been Tested?

had to use compiled build to observe the issue
npm run build:stage 
serve build -l 3001