### PR TITLE
Web search / explore merge QA fixes

### DIFF
--- a/packages/common/src/api/tan-query/collection/useExploreContent.ts
+++ b/packages/common/src/api/tan-query/collection/useExploreContent.ts
@@ -17,10 +17,10 @@ type ExploreContentResponse = {
 }
 
 export type ExploreContent = {
-  featuredPlaylists?: ID[]
-  featuredProfiles?: ID[]
-  featuredRemixContests?: ID[]
-  featuredLabels?: ID[]
+  featuredPlaylists: ID[]
+  featuredProfiles: ID[]
+  featuredRemixContests: ID[]
+  featuredLabels: ID[]
 }
 
 export const getExploreContentQueryKey = () => {
@@ -40,18 +40,15 @@ export const useExploreContent = <TResult = ExploreContent>(
       const response = await fetch(exploreContentUrl)
       const json: ExploreContentResponse = await response.json()
       return {
-        featuredPlaylists: json.featuredPlaylists?.map(
-          (id: string) => parseInt(id) as ID
-        ),
-        featuredProfiles: json.featuredProfiles?.map(
-          (id: string) => parseInt(id) as ID
-        ),
-        featuredRemixContests: json.featuredRemixContests?.map(
-          (id: string) => parseInt(id) as ID
-        ),
-        featuredLabels: json.featuredLabels?.map(
-          (id: string) => parseInt(id) as ID
-        )
+        featuredPlaylists:
+          json.featuredPlaylists?.map((id: string) => parseInt(id) as ID) ?? [],
+        featuredProfiles:
+          json.featuredProfiles?.map((id: string) => parseInt(id) as ID) ?? [],
+        featuredRemixContests:
+          json.featuredRemixContests?.map((id: string) => parseInt(id) as ID) ??
+          [],
+        featuredLabels:
+          json.featuredLabels?.map((id: string) => parseInt(id) as ID) ?? []
       }
     },
     ...options,

--- a/packages/common/src/api/tan-query/collection/useExploreContent.ts
+++ b/packages/common/src/api/tan-query/collection/useExploreContent.ts
@@ -10,17 +10,17 @@ const STATIC_EXPLORE_CONTENT_URL =
   'https://download.audius.co/static-resources/explore-content.json'
 
 type ExploreContentResponse = {
-  featuredPlaylists: string[]
-  featuredProfiles: string[]
-  featuredRemixContests: string[]
-  featuredLabels: string[]
+  featuredPlaylists?: string[]
+  featuredProfiles?: string[]
+  featuredRemixContests?: string[]
+  featuredLabels?: string[]
 }
 
 export type ExploreContent = {
-  featuredPlaylists: ID[]
-  featuredProfiles: ID[]
-  featuredRemixContests: ID[]
-  featuredLabels: ID[]
+  featuredPlaylists?: ID[]
+  featuredProfiles?: ID[]
+  featuredRemixContests?: ID[]
+  featuredLabels?: ID[]
 }
 
 export const getExploreContentQueryKey = () => {
@@ -40,16 +40,16 @@ export const useExploreContent = <TResult = ExploreContent>(
       const response = await fetch(exploreContentUrl)
       const json: ExploreContentResponse = await response.json()
       return {
-        featuredPlaylists: json.featuredPlaylists.map(
+        featuredPlaylists: json.featuredPlaylists?.map(
           (id: string) => parseInt(id) as ID
         ),
-        featuredProfiles: json.featuredProfiles.map(
+        featuredProfiles: json.featuredProfiles?.map(
           (id: string) => parseInt(id) as ID
         ),
-        featuredRemixContests: json.featuredRemixContests.map(
+        featuredRemixContests: json.featuredRemixContests?.map(
           (id: string) => parseInt(id) as ID
         ),
-        featuredLabels: json.featuredLabels.map(
+        featuredLabels: json.featuredLabels?.map(
           (id: string) => parseInt(id) as ID
         )
       }

--- a/packages/harmony/src/components/button/FilterButton/FilterButton.tsx
+++ b/packages/harmony/src/components/button/FilterButton/FilterButton.tsx
@@ -152,7 +152,6 @@ export const FilterButton = forwardRef(function FilterButton<
       onClick()
     } else {
       setIsOpen((prev) => {
-        console.log('asdf setting to ', !prev)
         return !prev
       })
     }
@@ -167,6 +166,7 @@ export const FilterButton = forwardRef(function FilterButton<
             aria-label='cancel'
             onClick={(e: React.MouseEvent<SVGSVGElement>) => {
               e.stopPropagation()
+              setIsOpen(false)
               if (onClick) {
                 onClick()
               } else {
@@ -201,7 +201,6 @@ export const FilterButton = forwardRef(function FilterButton<
 
   const handleOptionSelected = useCallback(
     (value: Value) => {
-      console.log('asdf handleOptionSelected ', value)
       handleChange(value)
       setIsOpen(false)
     },
@@ -237,7 +236,7 @@ export const FilterButton = forwardRef(function FilterButton<
       />
     )
   ) : null
-  console.log('asdf isOpen', isOpen)
+
   return (
     <BaseButton
       ref={mergeRefs([ref, anchorRef])}

--- a/packages/harmony/src/components/button/FilterButton/FilterButton.tsx
+++ b/packages/harmony/src/components/button/FilterButton/FilterButton.tsx
@@ -178,7 +178,7 @@ export const FilterButton = forwardRef(function FilterButton<
             {...props}
           />
         )) as IconComponent)
-      : iconRight ?? (hasOptions ? IconCaretDown : null)
+      : (iconRight ?? (hasOptions ? IconCaretDown : null))
   }, [variant, value, iconRight, hasOptions, onClick, onChange, onReset])
 
   useEffect(() => {

--- a/packages/harmony/src/components/button/FilterButton/FilterButton.tsx
+++ b/packages/harmony/src/components/button/FilterButton/FilterButton.tsx
@@ -147,12 +147,14 @@ export const FilterButton = forwardRef(function FilterButton<
   }
 
   const iconCss = size === 'small' ? smallIconStyles : defaultIconStyles
-
   const handleClick = useCallback(() => {
     if (onClick) {
       onClick()
     } else {
-      setIsOpen((isOpen: boolean) => !isOpen)
+      setIsOpen((prev) => {
+        console.log('asdf setting to ', !prev)
+        return !prev
+      })
     }
   }, [onClick])
 
@@ -176,7 +178,7 @@ export const FilterButton = forwardRef(function FilterButton<
             {...props}
           />
         )) as IconComponent)
-      : (iconRight ?? (hasOptions ? IconCaretDown : null))
+      : iconRight ?? (hasOptions ? IconCaretDown : null)
   }, [variant, value, iconRight, hasOptions, onClick, onChange, onReset])
 
   useEffect(() => {
@@ -199,6 +201,7 @@ export const FilterButton = forwardRef(function FilterButton<
 
   const handleOptionSelected = useCallback(
     (value: Value) => {
+      console.log('asdf handleOptionSelected ', value)
       handleChange(value)
       setIsOpen(false)
     },
@@ -234,7 +237,7 @@ export const FilterButton = forwardRef(function FilterButton<
       />
     )
   ) : null
-
+  console.log('asdf isOpen', isOpen)
   return (
     <BaseButton
       ref={mergeRefs([ref, anchorRef])}
@@ -251,7 +254,6 @@ export const FilterButton = forwardRef(function FilterButton<
       <Menu
         anchorRef={anchorRef}
         isVisible={isOpen}
-        onClose={() => setIsOpen(false)}
         PaperProps={menuProps?.PaperProps}
       >
         {children ? (

--- a/packages/harmony/src/components/input/TextInput/TextInput.module.css
+++ b/packages/harmony/src/components/input/TextInput/TextInput.module.css
@@ -16,7 +16,8 @@
   background-color: var(--harmony-bg-surface-1);
   transition: border ease-in-out 0.1s;
   box-sizing: border-box;
-  box-shadow: 1px 1px 4px 0px rgba(0, 0, 0, 0.02) inset,
+  box-shadow:
+    1px 1px 4px 0px rgba(0, 0, 0, 0.02) inset,
     1px 1px 2px 0px rgba(0, 0, 0, 0.02) inset;
 }
 
@@ -50,7 +51,7 @@
 /* focused border color */
 .contentContainer.focused,
 .contentContainer.focused:hover {
-  border-color: var(--harmony-secondary);
+  border-color: var(--harmony-s-300);
 }
 
 /* warning border color */

--- a/packages/harmony/src/components/input/TextInput/TextInput.module.css
+++ b/packages/harmony/src/components/input/TextInput/TextInput.module.css
@@ -16,8 +16,7 @@
   background-color: var(--harmony-bg-surface-1);
   transition: border ease-in-out 0.1s;
   box-sizing: border-box;
-  box-shadow:
-    1px 1px 4px 0px rgba(0, 0, 0, 0.02) inset,
+  box-shadow: 1px 1px 4px 0px rgba(0, 0, 0, 0.02) inset,
     1px 1px 2px 0px rgba(0, 0, 0, 0.02) inset;
 }
 

--- a/packages/harmony/src/components/input/TextInput/TextInput.tsx
+++ b/packages/harmony/src/components/input/TextInput/TextInput.tsx
@@ -4,6 +4,7 @@ import cn from 'classnames'
 
 import { Text, TextSize } from '~harmony/components/text'
 import type { TextColors } from '~harmony/foundations/color/semantic'
+import { IconCloseAlt } from '~harmony/icons'
 
 import { Flex } from '../../layout'
 import { useFocusState } from '../useFocusState'
@@ -45,6 +46,7 @@ export const TextInput = forwardRef<HTMLInputElement, TextInputProps>(
       IconProps,
       endAdornment: endAdornmentProp,
       elevateLabel,
+      onClear,
       _incorrectError,
       _isHovered,
       _isFocused,
@@ -86,8 +88,8 @@ export const TextInput = forwardRef<HTMLInputElement, TextInputProps>(
       required && hideLabel
         ? `${placeholder} *`
         : size === TextInputSize.SMALL
-          ? labelText
-          : placeholder
+        ? labelText
+        : placeholder
     const helperTextSize: TextSize = size === TextInputSize.SMALL ? 'xs' : 's'
 
     // Whenever a label isn't visible the placeholder should be visible in it's place (if provided)
@@ -148,7 +150,7 @@ export const TextInput = forwardRef<HTMLInputElement, TextInputProps>(
           maxLength={maxLength}
           disabled={disabled}
           placeholder={shouldShowPlaceholder ? placeholderText : undefined}
-          aria-label={(ariaLabel ?? shouldShowLabel) ? labelText : undefined}
+          aria-label={ariaLabel ?? shouldShowLabel ? labelText : undefined}
           aria-required={required}
           id={id}
           autoComplete='off'
@@ -228,6 +230,9 @@ export const TextInput = forwardRef<HTMLInputElement, TextInputProps>(
             ) : null}
             {inputElement}
           </Flex>
+          {onClear && value ? (
+            <IconCloseAlt onClick={onClear} color='subdued' />
+          ) : null}
           {endAdornment}
         </label>
         {helperText ? (

--- a/packages/harmony/src/components/input/TextInput/TextInput.tsx
+++ b/packages/harmony/src/components/input/TextInput/TextInput.tsx
@@ -88,8 +88,8 @@ export const TextInput = forwardRef<HTMLInputElement, TextInputProps>(
       required && hideLabel
         ? `${placeholder} *`
         : size === TextInputSize.SMALL
-        ? labelText
-        : placeholder
+          ? labelText
+          : placeholder
     const helperTextSize: TextSize = size === TextInputSize.SMALL ? 'xs' : 's'
 
     // Whenever a label isn't visible the placeholder should be visible in it's place (if provided)
@@ -150,7 +150,7 @@ export const TextInput = forwardRef<HTMLInputElement, TextInputProps>(
           maxLength={maxLength}
           disabled={disabled}
           placeholder={shouldShowPlaceholder ? placeholderText : undefined}
-          aria-label={ariaLabel ?? shouldShowLabel ? labelText : undefined}
+          aria-label={(ariaLabel ?? shouldShowLabel) ? labelText : undefined}
           aria-required={required}
           id={id}
           autoComplete='off'

--- a/packages/harmony/src/components/input/TextInput/types.ts
+++ b/packages/harmony/src/components/input/TextInput/types.ts
@@ -61,6 +61,10 @@ export type TextInputProps = Omit<
    */
   hidePlaceholder?: boolean
   /**
+   * Handler for when input is cleared.
+   */
+  onClear?: () => void
+  /**
    * Label Text. Required due to accessibility. If hideLabel is true, the label is set via aria-label
    */
   label: string

--- a/packages/web/src/components/lineup/TanQueryLineup.tsx
+++ b/packages/web/src/components/lineup/TanQueryLineup.tsx
@@ -158,7 +158,7 @@ export const TanQueryLineup = ({
   initialPageSize,
   scrollParent: externalScrollParent,
   loadMoreThreshold = DEFAULT_LOAD_MORE_THRESHOLD,
-  offset,
+  offset = 0,
   shouldLoadMore = true,
   data,
   pageSize,

--- a/packages/web/src/components/perspective-card/PerspectiveCard.module.css
+++ b/packages/web/src/components/perspective-card/PerspectiveCard.module.css
@@ -62,11 +62,6 @@
   }
 }
 
-.perspectiveCard .backgroundIcon svg {
-  /* height: 110% !important; */
-  /* min-width: 250px !important; */
-}
-
 .perspectiveCard .backgroundIcon path {
   opacity: 0.3;
 }

--- a/packages/web/src/components/perspective-card/PerspectiveCard.module.css
+++ b/packages/web/src/components/perspective-card/PerspectiveCard.module.css
@@ -28,7 +28,7 @@
 
 .perspectiveCard .backgroundIcon {
   position: absolute;
-  right: -160px;
+  right: 10px;
   top: -16px;
   bottom: -16px;
   display: flex;
@@ -63,8 +63,8 @@
 }
 
 .perspectiveCard .backgroundIcon svg {
-  height: 110% !important;
-  min-width: 250px !important;
+  /* height: 110% !important; */
+  /* min-width: 250px !important; */
 }
 
 .perspectiveCard .backgroundIcon path {

--- a/packages/web/src/components/remix-contest-card/RemixContestCard.tsx
+++ b/packages/web/src/components/remix-contest-card/RemixContestCard.tsx
@@ -12,7 +12,11 @@ import { TrackArtwork } from 'components/track/TrackArtwork'
 
 const messages = {
   deadline: (releaseDate?: string) =>
-    `Deadline ${releaseDate ? (new Date(releaseDate) < new Date() ? formatDate(releaseDate) : 'Ended') : releaseDate}`
+    releaseDate
+      ? new Date(releaseDate) < new Date()
+        ? `Deadline: ${formatDate(releaseDate)}`
+        : 'Ended'
+      : releaseDate
 }
 
 type RemixContestCardProps = Omit<CardProps, 'id'> & {

--- a/packages/web/src/components/search-bar/DesktopSearchBar.module.css
+++ b/packages/web/src/components/search-bar/DesktopSearchBar.module.css
@@ -224,7 +224,7 @@
 }
 .searchBox
   :global(.ant-select-item-option.ant-select-item-option-active):has(
-    [class*='PlainButton']
+    :global(.dropdown-action)
   ) {
   background-color: transparent !important;
 }

--- a/packages/web/src/components/search-bar/DesktopSearchBar.tsx
+++ b/packages/web/src/components/search-bar/DesktopSearchBar.tsx
@@ -57,6 +57,7 @@ const ViewMoreButton = ({ query }: { query: string }) => {
       <PlainButton
         iconRight={IconArrowRight}
         onClick={() => navigate(searchResultsPage('all', query))}
+        className='dropdown-action'
       >
         {messages.viewMoreResults}
       </PlainButton>
@@ -72,7 +73,7 @@ const ClearRecentSearchesButton = () => {
 
   return (
     <Flex alignItems='center' pt='l' gap='2xs' justifyContent='center'>
-      <PlainButton onClick={handleClickClear}>
+      <PlainButton onClick={handleClickClear} className='dropdown-action'>
         {messages.clearRecentSearches}
       </PlainButton>
     </Flex>

--- a/packages/web/src/components/search-bar/DesktopSearchBar.tsx
+++ b/packages/web/src/components/search-bar/DesktopSearchBar.tsx
@@ -172,6 +172,7 @@ export const DesktopSearchBar = () => {
           color='subdued'
           onClick={handleClear}
           aria-label={messages.clearSearch}
+          onMouseDown={(e) => e.preventDefault()}
         />
       )
     }
@@ -310,8 +311,6 @@ export const DesktopSearchBar = () => {
     autocompleteOptions.length === 1 &&
     String(autocompleteOptions[0].options?.[0]?.value) === 'no-results'
 
-  const [isFocused, setIsFocused] = useState(false)
-
   const handleFocus = useCallback(() => {
     const searchElement = inputRef.current?.input?.closest(
       '.ant-select-selection-search'
@@ -319,7 +318,6 @@ export const DesktopSearchBar = () => {
     if (searchElement) {
       searchElement.classList.add('expanded')
     }
-    setIsFocused(true)
   }, [])
 
   const handleBlur = useCallback(() => {
@@ -335,7 +333,6 @@ export const DesktopSearchBar = () => {
         showResults ? 100 : 0
       )
     }
-    setIsFocused(false)
   }, [showResults])
 
   return (
@@ -350,7 +347,6 @@ export const DesktopSearchBar = () => {
         onSearch={handleSearch}
         onSelect={handleSelect}
         getPopupContainer={(trigger) => trigger.parentNode as HTMLElement}
-        open={showResults && isFocused}
       >
         <Input
           inputMode='search'

--- a/packages/web/src/components/user-card/UserCard.tsx
+++ b/packages/web/src/components/user-card/UserCard.tsx
@@ -3,7 +3,7 @@ import { useCallback, MouseEvent } from 'react'
 import { useUser } from '@audius/common/api'
 import { ID, SquareSizes } from '@audius/common/models'
 import { formatCount, route } from '@audius/common/utils'
-import { Box, Skeleton, Text } from '@audius/harmony'
+import { Box, Skeleton, Text, TextLink } from '@audius/harmony'
 import { pick } from 'lodash'
 import { useLinkClickHandler } from 'react-router-dom-v5-compat'
 
@@ -87,10 +87,15 @@ export const UserCard = (props: UserCardProps) => {
           size='l'
           center
           onClick={onUserLinkClick}
+          popover={true}
         />
-        <Text variant='body' ellipses css={{ textAlign: 'center' }}>
+        <TextLink
+          onClick={onUserLinkClick}
+          ellipses
+          css={{ textAlign: 'center' }}
+        >
           @{handle}
-        </Text>
+        </TextLink>
       </CardContent>
       <CardFooter>
         <Text variant='body' size='s' strength='strong'>

--- a/packages/web/src/hooks/useTabs/useTabs.tsx
+++ b/packages/web/src/hooks/useTabs/useTabs.tsx
@@ -1133,6 +1133,7 @@ const useTabs = ({
     (newIndex: number) => {
       if (isControlled) {
         onChangeComplete(activeIndex, newIndex)
+        onTabClickCb && onTabClickCb(tabs[newIndex].label)
         return
       }
 

--- a/packages/web/src/pages/explore-page/collections.ts
+++ b/packages/web/src/pages/explore-page/collections.ts
@@ -34,9 +34,6 @@ export type ExploreCollection = {
   cardSensitivity?: number
 }
 
-// How much full width cards move
-const WIDE_CARD_SENSITIVTY = 0.04
-
 export type ExploreMoodCollection = ExploreCollection & {
   emoji: string
   moods: string[]

--- a/packages/web/src/pages/explore-page/collections.ts
+++ b/packages/web/src/pages/explore-page/collections.ts
@@ -49,8 +49,7 @@ export const PREMIUM_TRACKS: ExploreCollection = {
   gradient: 'linear-gradient(95deg, #13C65A 0%, #16A653 100%)',
   shadow: 'rgba(196,81,193,0.35)',
   icon: IconCart,
-  link: SEARCH_PREMIUM_TRACKS,
-  cardSensitivity: WIDE_CARD_SENSITIVTY
+  link: SEARCH_PREMIUM_TRACKS
 }
 
 export const DOWNLOADS_AVAILABLE: ExploreCollection = {
@@ -60,8 +59,7 @@ export const DOWNLOADS_AVAILABLE: ExploreCollection = {
   gradient: 'linear-gradient(138deg, #FF00F5 -5.01%, #00D1FF 110.47%)',
   shadow: 'rgba(9, 175, 233, 0.35)',
   icon: IconRemix,
-  link: SEARCH_DOWNLOADS_AVAILABLE,
-  cardSensitivity: WIDE_CARD_SENSITIVTY
+  link: SEARCH_DOWNLOADS_AVAILABLE
 }
 
 export const LET_THEM_DJ: ExploreCollection = {

--- a/packages/web/src/pages/explore-page/components/desktop/CollectionArtCard.tsx
+++ b/packages/web/src/pages/explore-page/components/desktop/CollectionArtCard.tsx
@@ -1,8 +1,9 @@
-import { useState } from 'react'
+import { useCallback, useState } from 'react'
 
 import { useCollection, useUser } from '@audius/common/api'
 import { ID, SquareSizes } from '@audius/common/models'
 import { Flex } from '@audius/harmony'
+import { useNavigate } from 'react-router-dom-v5-compat'
 
 import { CollectionImage } from 'components/collection/CollectionImage'
 import { CollectionLink } from 'components/link/CollectionLink'
@@ -19,20 +20,25 @@ type CollectionArtCardProps = {
 const ARTWORK_SIZE = 240
 
 export const CollectionArtCard = ({ id }: CollectionArtCardProps) => {
-  const [isPerspectiveDisabled, setIsPerspectiveDisabled] = useState(false)
-
+  const [isPerspectiveDisabled] = useState(false)
+  const navigate = useNavigate()
   const { data: partialCollection } = useCollection(id)
+
+  const goToPlaylist = useCallback(() => {
+    if (!partialCollection?.permalink) return
+    navigate(partialCollection.permalink)
+  }, [navigate, partialCollection?.permalink])
+
   const { data: user } = useUser(partialCollection?.playlist_owner_id)
 
   if (!partialCollection || !user) return null
 
   const { playlist_id, playlist_name } = partialCollection ?? {}
   const { user_id } = user
-
   return (
     <Flex column alignItems='center' gap='s'>
       <PerspectiveCard
-        onClick={() => setIsPerspectiveDisabled(false)}
+        onClick={goToPlaylist}
         isDisabled={isPerspectiveDisabled}
       >
         <CollectionImage

--- a/packages/web/src/pages/explore-page/components/desktop/FeaturedPlaylists.tsx
+++ b/packages/web/src/pages/explore-page/components/desktop/FeaturedPlaylists.tsx
@@ -1,10 +1,8 @@
-import { useCallback, useState } from 'react'
+import { useState } from 'react'
 
 import { useFeaturedPlaylists } from '@audius/common/api'
 import { TQCollection } from '@audius/common/src/api/tan-query/models'
 import { Flex, LoadingSpinner } from '@audius/harmony'
-
-import PerspectiveCard from 'components/perspective-card/PerspectiveCard'
 
 import { CollectionArtCard } from './CollectionArtCard'
 import Section from './Section'

--- a/packages/web/src/pages/explore-page/components/desktop/FeaturedPlaylists.tsx
+++ b/packages/web/src/pages/explore-page/components/desktop/FeaturedPlaylists.tsx
@@ -1,8 +1,10 @@
-import { useState } from 'react'
+import { useCallback, useState } from 'react'
 
 import { useFeaturedPlaylists } from '@audius/common/api'
 import { TQCollection } from '@audius/common/src/api/tan-query/models'
 import { Flex, LoadingSpinner } from '@audius/harmony'
+
+import PerspectiveCard from 'components/perspective-card/PerspectiveCard'
 
 import { CollectionArtCard } from './CollectionArtCard'
 import Section from './Section'

--- a/packages/web/src/pages/explore-page/components/desktop/NewExplorePage.tsx
+++ b/packages/web/src/pages/explore-page/components/desktop/NewExplorePage.tsx
@@ -236,8 +236,10 @@ const ExplorePage = ({ title, pageTitle, description }: ExplorePageProps) => {
 
         {/* Tabs and Filters */}
         <Flex direction='column' gap='l'>
-          <Flex alignSelf='flex-start'>{tabs}</Flex>
-          <Divider orientation='horizontal' />
+          <Flex direction='column'>
+            <Flex alignSelf='flex-start'>{tabs}</Flex>
+            <Divider orientation='horizontal' />
+          </Flex>
           {filterKeys.length ? (
             <Flex
               direction='row'

--- a/packages/web/src/pages/explore-page/components/desktop/NewExplorePage.tsx
+++ b/packages/web/src/pages/explore-page/components/desktop/NewExplorePage.tsx
@@ -15,10 +15,8 @@ import {
   IconUser,
   Divider,
   FilterButton,
-  IconCloseAlt,
   useTheme
 } from '@audius/harmony'
-import { css } from '@emotion/css'
 import { capitalize } from 'lodash'
 import { useNavigate, useSearchParams } from 'react-router-dom-v5-compat'
 import { useDebounce, useEffectOnce, usePrevious } from 'react-use'

--- a/packages/web/src/pages/explore-page/components/desktop/NewExplorePage.tsx
+++ b/packages/web/src/pages/explore-page/components/desktop/NewExplorePage.tsx
@@ -246,7 +246,6 @@ const ExplorePage = ({ title, pageTitle, description }: ExplorePageProps) => {
               size={TextInputSize.SMALL}
               startIcon={IconSearch}
               onChange={handleSearch}
-              // endIcon={IconCloseAlt}
               onClear={handleClearSearch}
             />
           </Flex>

--- a/packages/web/src/pages/search-page/SearchResults.tsx
+++ b/packages/web/src/pages/search-page/SearchResults.tsx
@@ -8,8 +8,12 @@ import { ViewLayout } from './types'
 
 type SearchResultsProps = {
   tracksLayout?: ViewLayout
+  handleSearchTab?: (tab: string) => void
 }
-export const SearchResults = ({ tracksLayout }: SearchResultsProps) => {
+export const SearchResults = ({
+  tracksLayout,
+  handleSearchTab
+}: SearchResultsProps) => {
   const [category] = useSearchCategory()
 
   switch (category) {
@@ -22,6 +26,6 @@ export const SearchResults = ({ tracksLayout }: SearchResultsProps) => {
     case 'playlists':
       return <PlaylistResultsPage />
     default:
-      return <AllResults />
+      return <AllResults handleSearchTab={handleSearchTab} />
   }
 }

--- a/packages/web/src/pages/search-page/search-results/AllResults.tsx
+++ b/packages/web/src/pages/search-page/search-results/AllResults.tsx
@@ -1,9 +1,8 @@
 import { useRef } from 'react'
 
 import { useSearchAllResults } from '@audius/common/api'
-import { show } from '@audius/common/src/store/music-confetti/slice'
 import { SearchKind } from '@audius/common/store'
-import { Flex, PlainButton, Text, TextLink } from '@audius/harmony'
+import { Flex, PlainButton, Text } from '@audius/harmony'
 import { useNavigate } from 'react-router-dom-v5-compat'
 
 import { useIsMobile } from 'hooks/useIsMobile'

--- a/packages/web/src/pages/search-page/search-results/AllResults.tsx
+++ b/packages/web/src/pages/search-page/search-results/AllResults.tsx
@@ -4,6 +4,7 @@ import { useSearchAllResults } from '@audius/common/api'
 import { show } from '@audius/common/src/store/music-confetti/slice'
 import { SearchKind } from '@audius/common/store'
 import { Flex, PlainButton, Text, TextLink } from '@audius/harmony'
+import { useNavigate } from 'react-router-dom-v5-compat'
 
 import { useIsMobile } from 'hooks/useIsMobile'
 
@@ -23,10 +24,15 @@ const messages = {
   showAll: 'Show All'
 }
 
-export const AllResults = () => {
+type AllResultsProps = {
+  handleSearchTab?: (tab: string) => void
+}
+
+export const AllResults = ({ handleSearchTab }: AllResultsProps) => {
   const isMobile = useIsMobile()
   const containerRef = useRef<HTMLDivElement>(null)
   const { query, ...filters } = useSearchParams()
+  const navigate = useNavigate()
 
   const queryData = useSearchAllResults({
     query,
@@ -59,7 +65,12 @@ export const AllResults = () => {
             <Text variant='heading' textAlign='left'>
               {messages.profiles}
             </Text>
-            <PlainButton>
+            <PlainButton
+              onClick={() => {
+                navigate(`/search/profiles?query=${query}`)
+                handleSearchTab?.('Profiles')
+              }}
+            >
               <Text strength='strong' size='l'>
                 {messages.showAll}
               </Text>
@@ -81,7 +92,9 @@ export const AllResults = () => {
             <Text variant='heading' textAlign='left'>
               {messages.tracks}
             </Text>
-            <PlainButton>
+            <PlainButton
+              onClick={() => navigate(`/search/tracks?query=${query}`)}
+            >
               <Text strength='strong' size='l'>
                 {messages.showAll}
               </Text>
@@ -104,7 +117,9 @@ export const AllResults = () => {
             <Text variant='heading' textAlign='left'>
               {messages.albums}
             </Text>
-            <PlainButton>
+            <PlainButton
+              onClick={() => navigate(`/search/albums?query=${query}`)}
+            >
               <Text strength='strong' size='l'>
                 {messages.showAll}
               </Text>
@@ -126,7 +141,9 @@ export const AllResults = () => {
             <Text variant='heading' textAlign='left'>
               {messages.playlists}
             </Text>
-            <PlainButton>
+            <PlainButton
+              onClick={() => navigate(`/search/playlists?query=${query}`)}
+            >
               <Text strength='strong' size='l'>
                 {messages.showAll}
               </Text>

--- a/packages/web/src/pages/search-page/search-results/AllResults.tsx
+++ b/packages/web/src/pages/search-page/search-results/AllResults.tsx
@@ -1,8 +1,9 @@
 import { useRef } from 'react'
 
 import { useSearchAllResults } from '@audius/common/api'
+import { show } from '@audius/common/src/store/music-confetti/slice'
 import { SearchKind } from '@audius/common/store'
-import { Flex, Text } from '@audius/harmony'
+import { Flex, PlainButton, Text, TextLink } from '@audius/harmony'
 
 import { useIsMobile } from 'hooks/useIsMobile'
 
@@ -18,7 +19,8 @@ const messages = {
   profiles: 'Profiles',
   tracks: 'Tracks',
   albums: 'Albums',
-  playlists: 'Playlists'
+  playlists: 'Playlists',
+  showAll: 'Show All'
 }
 
 export const AllResults = () => {
@@ -53,9 +55,16 @@ export const AllResults = () => {
     >
       {isLoading || data?.users?.length ? (
         <Flex gap='xl' direction='column'>
-          <Text variant='heading' textAlign='left'>
-            {messages.profiles}
-          </Text>
+          <Flex justifyContent='space-between' alignItems='center'>
+            <Text variant='heading' textAlign='left'>
+              {messages.profiles}
+            </Text>
+            <PlainButton>
+              <Text strength='strong' size='l'>
+                {messages.showAll}
+              </Text>
+            </PlainButton>
+          </Flex>
           <ProfileResultsTiles
             skeletonCount={5}
             limit={5}
@@ -68,11 +77,18 @@ export const AllResults = () => {
 
       {isLoading || data?.tracks?.length ? (
         <Flex gap='xl' direction='column'>
-          <Text variant='heading' textAlign='left'>
-            {messages.tracks}
-          </Text>
+          <Flex justifyContent='space-between' alignItems='center'>
+            <Text variant='heading' textAlign='left'>
+              {messages.tracks}
+            </Text>
+            <PlainButton>
+              <Text strength='strong' size='l'>
+                {messages.showAll}
+              </Text>
+            </PlainButton>
+          </Flex>
           <TrackResults
-            count={12}
+            count={10}
             viewLayout='grid'
             category={SearchKind.ALL}
             isFetching={isLoading}
@@ -84,10 +100,18 @@ export const AllResults = () => {
 
       {isLoading || data?.albums?.length ? (
         <Flex gap='xl' direction='column'>
-          <Text variant='heading' textAlign='left'>
-            {messages.albums}
-          </Text>
+          <Flex justifyContent='space-between' alignItems='center'>
+            <Text variant='heading' textAlign='left'>
+              {messages.albums}
+            </Text>
+            <PlainButton>
+              <Text strength='strong' size='l'>
+                {messages.showAll}
+              </Text>
+            </PlainButton>
+          </Flex>
           <AlbumResults
+            limit={5}
             data={data?.albums ?? []}
             isFetching={isLoading}
             isPending={isPending}
@@ -98,9 +122,16 @@ export const AllResults = () => {
 
       {isLoading || data?.playlists?.length ? (
         <Flex gap='xl' direction='column'>
-          <Text variant='heading' textAlign='left'>
-            {messages.playlists}
-          </Text>
+          <Flex justifyContent='space-between' alignItems='center'>
+            <Text variant='heading' textAlign='left'>
+              {messages.playlists}
+            </Text>
+            <PlainButton>
+              <Text strength='strong' size='l'>
+                {messages.showAll}
+              </Text>
+            </PlainButton>
+          </Flex>
           <PlaylistResults
             skeletonCount={5}
             limit={5}


### PR DESCRIPTION
### Description

Bunch of small fixes for web search / explore merge. Some of the higher priority fixes include:
* Disappearing explore sections. I think this came from adding a new label spotlight field, so I modified the client to handle empty cases / new fields in case the json is different than expected. 
* Again the floating search bar had some pre-existing bugs and layout issues. 
* Tabs and filter bugs when changing. 



Fixes PE-6216, PE-6211, PE-6208, PE-6203, PE-6220, PE-6217, PE-6215, PE-6214, PE-6213, PE-6212, PE-6210, PE-6209, PE-6206
### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._

Local client pointed against prod. deployed on [isaac.audius.co
](https://isaac.audius.co/explore)

Do a bunch of searches,  tab changes, filter changes.