### PR TITLE
Fix loading on cash balance

### DIFF
--- a/packages/mobile/src/screens/wallet-screen/components/CashWallet.tsx
+++ b/packages/mobile/src/screens/wallet-screen/components/CashWallet.tsx
@@ -68,13 +68,15 @@ export const CashWallet = () => {
             />
           </Flex>
 
-          {isLoading ? (
-            <Skeleton h='4xl' w='5xl' />
-          ) : (
-            <Text variant='display' size='m' color='default'>
-              {balanceFormatted}
-            </Text>
-          )}
+          <Flex h='4xl' justifyContent='center'>
+            {isLoading ? (
+              <Skeleton h='4xl' w='5xl' />
+            ) : (
+              <Text variant='display' size='m' color='default'>
+                {balanceFormatted}
+              </Text>
+            )}
+          </Flex>
 
           {!isManagedAccount ? (
             <Button variant='secondary' onPress={handleAddCash} fullWidth>


### PR DESCRIPTION
### Description
The loading state on the Cash Balance section on mobile was borked. We were showing the loading state over the Cash Balance section 

### How Has This Been Tested?
**Before**
![image](https://github.com/user-attachments/assets/58e0d307-9aa6-4000-acc8-7b00cf0cc2f6)

**After**
![image](https://github.com/user-attachments/assets/75d1cded-df88-47da-b9e2-88f4b2a4e84d)



`npm run ios:stage`

- Navigate to `Wallet` screen and ensure the loading state looks like the after pic