### PR TITLE
[PE-6227] Remove blocknumber from remix contest to prevent dups

### DIFF
--- a/packages/discovery-provider/ddl/functions/handle_event.sql
+++ b/packages/discovery-provider/ddl/functions/handle_event.sql
@@ -45,7 +45,7 @@ begin
             new.created_at,
             'fan_remix_contest_started',
             notified_user_id,
-            'fan_remix_contest_started:' || new.entity_id || ':user:' || new.user_id || ':blocknumber:' || new.blocknumber,
+            'fan_remix_contest_started:' || new.entity_id || ':user:' || new.user_id,
             json_build_object(
               'entity_user_id', owner_user_id,
               'entity_id', new.entity_id

--- a/packages/discovery-provider/integration_tests/tasks/test_fan_remix_contest_started_notification.py
+++ b/packages/discovery-provider/integration_tests/tasks/test_fan_remix_contest_started_notification.py
@@ -874,7 +874,7 @@ def test_fan_remix_contest_started_notification_no_duplicate_with_existing_on_tr
                 "timestamp": now,
                 "type": NotificationType.FAN_REMIX_CONTEST_STARTED,
                 "specifier": str(FOLLOWER_ID),
-                "group_id": f"fan_remix_contest_started:{TEST_TRACK_ID}:user:{TEST_EVENT_CREATOR_ID}:blocknumber:1",
+                "group_id": f"fan_remix_contest_started:{TEST_TRACK_ID}:user:{TEST_EVENT_CREATOR_ID}",
                 "data": {
                     "entity_user_id": TEST_EVENT_CREATOR_ID,
                     "entity_id": TEST_TRACK_ID,
@@ -1026,7 +1026,7 @@ def test_fan_remix_contest_started_notification_no_duplicate_with_existing_on_sc
                 "timestamp": now,
                 "type": NotificationType.FAN_REMIX_CONTEST_STARTED,
                 "specifier": str(FOLLOWER_ID),
-                "group_id": f"fan_remix_contest_started:{TEST_TRACK_ID}:user:{TEST_EVENT_CREATOR_ID}:blocknumber:0",
+                "group_id": f"fan_remix_contest_started:{TEST_TRACK_ID}:user:{TEST_EVENT_CREATOR_ID}",
                 "data": {
                     "entity_user_id": TEST_EVENT_CREATOR_ID,
                     "entity_id": TEST_TRACK_ID,

--- a/packages/discovery-provider/src/tasks/entity_manager/utils.py
+++ b/packages/discovery-provider/src/tasks/entity_manager/utils.py
@@ -736,6 +736,12 @@ def create_remix_contest_notification(
     notification_timestamp = (
         block_datetime if block_datetime is not None else track.updated_at
     )
+    utils_logger.info(
+        f"Creating fan remix contest started notification for track {track.track_id} by user {remix_contest_event.user_id}"
+    )
+    utils_logger.info(
+        f"group_id: fan_remix_contest_started:{track.track_id}:user:{remix_contest_event.user_id}"
+    )
 
     # Create individual notification for each user
     for user_id in user_ids:
@@ -745,7 +751,7 @@ def create_remix_contest_notification(
             timestamp=notification_timestamp,
             type="fan_remix_contest_started",
             specifier=str(user_id),
-            group_id=f"fan_remix_contest_started:{track.track_id}:user:{remix_contest_event.user_id}:blocknumber:{notification_block_number}",
+            group_id=f"fan_remix_contest_started:{track.track_id}:user:{remix_contest_event.user_id}",
             data={
                 "entity_user_id": track.owner_id,
                 "entity_id": track.track_id,


### PR DESCRIPTION
### Description
We got a dup remix contest started notif, probably bc artist started a contest, ended it, then started another one.

Removing the blocknumber makes it so that in the above case, the remix contest started notif would collide, and the 2nd one would not go out.

### How Has This Been Tested?

integration tests pass
