### PR TITLE
[PE-6198] Add analytic events for remix contests

### DIFF
--- a/packages/common/src/api/tan-query/events/useEventsByEntityId.ts
+++ b/packages/common/src/api/tan-query/events/useEventsByEntityId.ts
@@ -12,7 +12,8 @@ import { useCurrentUserId } from '../users/account/useCurrentUserId'
 
 import {
   getEventIdsByEntityIdQueryKey,
-  EventIdsByEntityIdOptions
+  EventIdsByEntityIdOptions,
+  getEventQueryKey
 } from './utils'
 
 export const useEventIdsByEntityId = (
@@ -41,6 +42,11 @@ export const useEventIdsByEntityId = (
       })
 
       const events = await batchGetEvents.fetch(entityId!)
+
+      // Prime the events in the cache
+      events.forEach((event) => {
+        queryClient.setQueryData(getEventQueryKey(event.eventId), event)
+      })
 
       return events.map((event) => event.eventId)
     },

--- a/packages/common/src/models/Analytics.ts
+++ b/packages/common/src/models/Analytics.ts
@@ -575,6 +575,13 @@ export enum Name {
   TRACK_REPLACE_PREVIEW = 'Track Replace: Preview',
   TRACK_REPLACE_REPLACE = 'Track Replace: Replace',
 
+  // Remix Contests
+  REMIX_CONTEST_CREATE = 'Remix Contest: Create',
+  REMIX_CONTEST_UPDATE = 'Remix Contest: Update',
+  REMIX_CONTEST_DELETE = 'Remix Contest: Delete',
+  REMIX_CONTEST_PICK_WINNERS_OPEN = 'Remix Contest: Pick Winners Open',
+  REMIX_CONTEST_PICK_WINNERS_FINALIZE = 'Remix Contest: Finalize Winners',
+
   // Android App Lifecycle
   ANDROID_APP_RESTART_HEARTBEAT = 'Android App: Restart Due to Heartbeat',
   ANDROID_APP_RESTART_STALE = 'Android App: Restart Due to Stale Time',
@@ -2753,6 +2760,35 @@ export type TrackReplacePreview = {
   source: 'upload' | 'edit'
 }
 
+export type RemixContestCreate = {
+  eventName: Name.REMIX_CONTEST_CREATE
+  trackId: ID
+}
+
+export type RemixContestUpdate = {
+  eventName: Name.REMIX_CONTEST_UPDATE
+  remixContestId: ID
+  trackId: ID
+}
+
+export type RemixContestDelete = {
+  eventName: Name.REMIX_CONTEST_DELETE
+  remixContestId: ID
+  trackId: ID
+}
+
+export type RemixContestPickWinnersOpen = {
+  eventName: Name.REMIX_CONTEST_PICK_WINNERS_OPEN
+  remixContestId: ID
+  trackId: ID
+}
+
+export type RemixContestPickWinnersFinalize = {
+  eventName: Name.REMIX_CONTEST_PICK_WINNERS_FINALIZE
+  remixContestId: ID
+  trackId: ID
+}
+
 export type AndroidAppRestartHeartbeat = {
   eventName: Name.ANDROID_APP_RESTART_HEARTBEAT
   timeSinceLastHeartbeat: number
@@ -3136,6 +3172,11 @@ export type AllTrackingEvents =
   | TrackReplaceDownload
   | TrackReplacePreview
   | TrackReplaceReplace
+  | RemixContestCreate
+  | RemixContestUpdate
+  | RemixContestDelete
+  | RemixContestPickWinnersOpen
+  | RemixContestPickWinnersFinalize
   | AndroidAppRestartHeartbeat
   | AndroidAppRestartStale
   | AndroidAppRestartForceQuit

--- a/packages/mobile/src/components/host-remix-contest-drawer/HostRemixContestDrawer.tsx
+++ b/packages/mobile/src/components/host-remix-contest-drawer/HostRemixContestDrawer.tsx
@@ -9,6 +9,7 @@ import {
   useRemixes
 } from '@audius/common/api'
 import { remixMessages } from '@audius/common/messages'
+import { Name } from '@audius/common/models'
 import { useHostRemixContestModal } from '@audius/common/store'
 import { EventEntityTypeEnum, EventEventTypeEnum } from '@audius/sdk'
 import dayjs from 'dayjs'
@@ -22,6 +23,7 @@ import {
   Button,
   TextLink
 } from '@audius/harmony-native'
+import { make, track } from 'app/services/analytics'
 import { makeStyles } from 'app/styles'
 
 import { DateTimeInput, TextInput } from '../core'
@@ -140,6 +142,14 @@ export const HostRemixContestDrawer = () => {
         },
         userId
       })
+
+      track(
+        make({
+          eventName: Name.REMIX_CONTEST_UPDATE,
+          remixContestId: remixContest.eventId,
+          trackId
+        })
+      )
     } else {
       createEvent({
         eventType: EventEventTypeEnum.RemixContest,
@@ -153,6 +163,13 @@ export const HostRemixContestDrawer = () => {
           winners: []
         }
       })
+
+      track(
+        make({
+          eventName: Name.REMIX_CONTEST_CREATE,
+          trackId
+        })
+      )
     }
 
     onClose()
@@ -175,8 +192,19 @@ export const HostRemixContestDrawer = () => {
   const handleDeleteEvent = useCallback(() => {
     if (!remixContest || !userId) return
     deleteEvent({ eventId: remixContest.eventId, userId })
+
+    if (trackId) {
+      track(
+        make({
+          eventName: Name.REMIX_CONTEST_DELETE,
+          remixContestId: remixContest.eventId,
+          trackId
+        })
+      )
+    }
+
     onClose()
-  }, [remixContest, userId, deleteEvent, onClose])
+  }, [remixContest, userId, deleteEvent, onClose, trackId])
 
   return (
     <AppDrawer

--- a/packages/web/src/components/host-remix-contest-modal/HostRemixContestModal.tsx
+++ b/packages/web/src/components/host-remix-contest-modal/HostRemixContestModal.tsx
@@ -9,6 +9,7 @@ import {
   useUpdateEvent
 } from '@audius/common/api'
 import { remixMessages } from '@audius/common/messages'
+import { Name } from '@audius/common/models'
 import { useHostRemixContestModal } from '@audius/common/store'
 import { dayjs } from '@audius/common/utils'
 import {
@@ -29,6 +30,7 @@ import { EventEntityTypeEnum, EventEventTypeEnum } from '@audius/sdk'
 import { TextAreaV2 } from 'components/data-entry/TextAreaV2'
 import { DatePicker } from 'components/edit/fields/DatePickerField'
 import { mergeReleaseDateValues } from 'components/edit/fields/visibility/mergeReleaseDateValues'
+import { track, make } from 'services/analytics'
 
 import { TimeInput, parseTime } from './TimeInput'
 
@@ -136,6 +138,14 @@ export const HostRemixContestModal = () => {
         endDate,
         userId
       })
+
+      track(
+        make({
+          eventName: Name.REMIX_CONTEST_UPDATE,
+          remixContestId: remixContest.eventId,
+          trackId
+        })
+      )
     } else {
       createEvent({
         eventType: EventEventTypeEnum.RemixContest,
@@ -145,6 +155,13 @@ export const HostRemixContestModal = () => {
         endDate,
         userId
       })
+
+      track(
+        make({
+          eventName: Name.REMIX_CONTEST_CREATE,
+          trackId
+        })
+      )
     }
 
     onClose()
@@ -167,8 +184,18 @@ export const HostRemixContestModal = () => {
   const handleDeleteEvent = useCallback(() => {
     if (!remixContest || !userId) return
     deleteEvent({ eventId: remixContest.eventId, userId })
+
+    if (trackId) {
+      track(
+        make({
+          eventName: Name.REMIX_CONTEST_DELETE,
+          remixContestId: remixContest.eventId,
+          trackId
+        })
+      )
+    }
     onClose()
-  }, [remixContest, userId, deleteEvent, onClose])
+  }, [remixContest, userId, deleteEvent, onClose, trackId])
 
   return (
     <Modal isOpen={isOpen} onClose={onClose} onClosed={onClosed} size='medium'>

--- a/packages/web/src/pages/pick-winners-page/PickWinnersPage.tsx
+++ b/packages/web/src/pages/pick-winners-page/PickWinnersPage.tsx
@@ -8,7 +8,7 @@ import {
   useUpdateEvent
 } from '@audius/common/api'
 import { remixMessages as messages } from '@audius/common/messages'
-import { ID, Kind } from '@audius/common/models'
+import { ID, Kind, Name } from '@audius/common/models'
 import { toast } from '@audius/common/src/store/ui/toast/slice'
 import {
   pickWinnersPageLineupActions,
@@ -45,6 +45,7 @@ import { Page } from 'components/page/Page'
 import ConnectedTrackTile from 'components/track/desktop/ConnectedTrackTile'
 import { TrackTileSize } from 'components/track/types'
 import { useUpdateSearchParams } from 'pages/search-page/hooks'
+import { track, make } from 'services/analytics'
 import { selectDragnDropState } from 'store/dragndrop/slice'
 import { trackRemixesPage } from 'utils/route'
 
@@ -129,6 +130,16 @@ export const PickWinnersPage = () => {
           },
           userId: currentUserId
         })
+
+        if (originalTrack?.track_id) {
+          track(
+            make({
+              eventName: Name.REMIX_CONTEST_PICK_WINNERS_FINALIZE,
+              remixContestId: remixContest.eventId,
+              trackId: originalTrack?.track_id
+            })
+          )
+        }
       }
 
       // Navigate back to the track remixes page for the original track
@@ -141,6 +152,7 @@ export const PickWinnersPage = () => {
     currentUserId,
     history,
     originalTrack?.permalink,
+    originalTrack?.track_id,
     remixContest,
     updateEvent,
     winners
@@ -253,14 +265,14 @@ export const PickWinnersPage = () => {
           onClick={handleClick}
           aria-label='Add Winner'
         >
-          <Icon fill={color.icon.staticWhite} />
+          <Icon fill={color.icon.default} />
         </Paper>
       )
     },
     [
       addIdToWinners,
       color.background.white,
-      color.icon.staticWhite,
+      color.icon.default,
       color.neutral.n100,
       color.neutral.n150,
       motion.hover,

--- a/packages/web/src/pages/remixes-page/components/desktop/NewRemixesPage.tsx
+++ b/packages/web/src/pages/remixes-page/components/desktop/NewRemixesPage.tsx
@@ -1,3 +1,5 @@
+import { useCallback } from 'react'
+
 import {
   useRemixes,
   useRemixContest,
@@ -5,7 +7,7 @@ import {
 } from '@audius/common/api'
 import { useFeatureFlag } from '@audius/common/hooks'
 import { remixMessages as messages } from '@audius/common/messages'
-import { Track, User } from '@audius/common/models'
+import { Name, Track, User } from '@audius/common/models'
 import { FeatureFlags } from '@audius/common/services'
 import { remixesPageLineupActions } from '@audius/common/store'
 import { dayjs } from '@audius/common/utils'
@@ -24,6 +26,7 @@ import { TanQueryLineup } from 'components/lineup/TanQueryLineup'
 import Page from 'components/page/Page'
 import { useRemixPageParams } from 'pages/remixes-page/hooks'
 import { useUpdateSearchParams } from 'pages/search-page/hooks'
+import { track, make } from 'services/analytics'
 import { fullTrackRemixesPage, pickWinnersPage } from 'utils/route'
 import { withNullGuard } from 'utils/withNullGuard'
 
@@ -90,6 +93,18 @@ const RemixesPage = nullGuard(({ title, originalTrack }) => {
 
   const pickWinnersRoute = pickWinnersPage(originalTrack?.permalink)
 
+  const handlePickWinnersClick = useCallback(() => {
+    if (contest?.eventId) {
+      track(
+        make({
+          eventName: Name.REMIX_CONTEST_PICK_WINNERS_OPEN,
+          remixContestId: contest?.eventId,
+          trackId: originalTrack?.track_id
+        })
+      )
+    }
+  }, [contest?.eventId, originalTrack?.track_id])
+
   const renderHeader = () => (
     <Header
       icon={isRemixContest ? IconTrophy : IconRemix}
@@ -97,7 +112,7 @@ const RemixesPage = nullGuard(({ title, originalTrack }) => {
       containerStyles={styles.header}
       rightDecorator={
         showPickWinnersButton ? (
-          <Button size='small' asChild>
+          <Button size='small' asChild onClick={handlePickWinnersClick}>
             <Link to={pickWinnersRoute}>{messages.pickWinners}</Link>
           </Button>
         ) : null


### PR DESCRIPTION
### Description
Added some events for remix contests
Bonus fixes for icon color and tan-query cache

### How Has This Been Tested?
Manually Tested
