### PR TITLE
[QA-2102] Fix touch target on notification icon 

### DIFF
--- a/packages/web/src/components/nav/desktop/NotificationsButton.tsx
+++ b/packages/web/src/components/nav/desktop/NotificationsButton.tsx
@@ -1,13 +1,12 @@
-import { useCallback, useMemo, useRef, MouseEvent, useEffect } from 'react'
+import { MouseEvent, useCallback, useEffect, useMemo, useRef } from 'react'
 
-import { useNotificationUnreadCount } from '@audius/common/api'
 import { Name } from '@audius/common/models'
 import { accountSelectors } from '@audius/common/store'
-import { IconNotificationOn, NotificationCount } from '@audius/harmony'
+import { Flex, IconNotificationOn, NotificationCount } from '@audius/harmony'
 import { useSelector } from 'react-redux'
 import { useSearchParam, useToggle } from 'react-use'
 
-import { useRecord, make } from 'common/store/analytics/actions'
+import { make, useRecord } from 'common/store/analytics/actions'
 import { NotificationPanel } from 'components/notification'
 import { AnnouncementModal } from 'components/notification/AnnouncementModal'
 import { useRequiresAccountFn } from 'hooks/useRequiresAccount'
@@ -22,7 +21,8 @@ const messages = {
 }
 
 export const NotificationsButton = () => {
-  const { data: notificationCount = 0 } = useNotificationUnreadCount()
+  // const { data: notificationCount = 0 } = useNotificationUnreadCount()
+  const notificationCount = 5
   const hasAccount = useSelector(getHasAccount)
   const isAccountComplete = useSelector(getIsAccountComplete)
   const buttonRef = useRef<HTMLButtonElement>(null)
@@ -67,18 +67,22 @@ export const NotificationsButton = () => {
         ref={buttonRef}
         icon={IconNotificationOn}
         aria-label={messages.label(notificationCount)}
-        onClick={handleToggleNotificationPanel}
         isActive={isNotificationPanelOpen}
       />
     )
     if (shouldShowCount) {
       return (
-        <NotificationCount size='m' count={notificationCount}>
-          {button}
-        </NotificationCount>
+        <Flex
+          css={{ cursor: 'pointer' }}
+          onClick={handleToggleNotificationPanel}
+        >
+          <NotificationCount size='m' count={notificationCount}>
+            {button}
+          </NotificationCount>
+        </Flex>
       )
     }
-    return button
+    return <Flex onClick={handleToggleNotificationPanel}>{button}</Flex>
   }, [
     notificationCount,
     handleToggleNotificationPanel,

--- a/packages/web/src/components/nav/desktop/NotificationsButton.tsx
+++ b/packages/web/src/components/nav/desktop/NotificationsButton.tsx
@@ -1,5 +1,6 @@
 import { MouseEvent, useCallback, useEffect, useMemo, useRef } from 'react'
 
+import { useNotificationUnreadCount } from '@audius/common/api'
 import { Name } from '@audius/common/models'
 import { accountSelectors } from '@audius/common/store'
 import { Flex, IconNotificationOn, NotificationCount } from '@audius/harmony'
@@ -21,8 +22,7 @@ const messages = {
 }
 
 export const NotificationsButton = () => {
-  // const { data: notificationCount = 0 } = useNotificationUnreadCount()
-  const notificationCount = 5
+  const { data: notificationCount = 0 } = useNotificationUnreadCount()
   const hasAccount = useSelector(getHasAccount)
   const isAccountComplete = useSelector(getIsAccountComplete)
   const buttonRef = useRef<HTMLButtonElement>(null)


### PR DESCRIPTION
### Description

Makes icon and notification count click open the notification panel 

### How Has This Been Tested?

`npm run web:prod`

- Change ur noti count in `NotificationsButton` component to be a non-zero number
- Ensure that clicking the number opens the panel 
