### PR TITLE
Fix negative limit

### DIFF
--- a/packages/mobile/src/components/lineup/Lineup.tsx
+++ b/packages/mobile/src/components/lineup/Lineup.tsx
@@ -327,11 +327,13 @@ export const Lineup = ({
           dispatch(actions.setPage(page + 1))
         }
 
-        const limit =
+        const limit = Math.max(
+          0,
           Math.min(
             itemLoadCount,
             Math.max(countOrDefault, itemCounts.minimum)
           ) - _offset
+        )
 
         if (loadMore) {
           loadMore(_offset, limit, _page === 0)


### PR DESCRIPTION
### Description
## Problem

The Lineup component in the mobile app is currently calculating a potentially negative value for the `limit` parameter in the `handleLoadMore` function. When this negative value is passed to the server, PostgreSQL rejects it with error `SQLSTATE 2201W: LIMIT must not be negative`.

## Root Cause

The issue occurs due to this calculation:

```javascript
const limit =
  Math.min(itemLoadCount, Math.max(countOrDefault, itemCounts.minimum)) -
  _offset
```

When `_offset` is greater than the calculated minimum, the result is negative.

### Example with negative result:

If:

- itemLoadCount = 10
- countOrDefault = 1000
- itemCounts.minimum = 1
- \_offset = 15

```
limit = Math.min(10, Math.max(1000, 1)) - 15
limit = Math.min(10, 1000) - 15
limit = 10 - 15
limit = -5  // Error!
```

## Fix

Add `Math.max(0, ...)` to ensure the limit is never negative:

```javascript
const limit = Math.max(
  0,
  Math.min(itemLoadCount, Math.max(countOrDefault, itemCounts.minimum)) -
    _offset
)
```

### Example with the fix:

Same inputs as above:

```
limit = Math.max(0, Math.min(10, Math.max(1000, 1)) - 15)
limit = Math.max(0, Math.min(10, 1000) - 15)
limit = Math.max(0, 10 - 15)
limit = Math.max(0, -5)
limit = 0  // Valid limit!
```

### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._
