### PR TITLE
[PE-6192] Add winners to remixes page on web

### DIFF
--- a/packages/common/src/api/tan-query/events/useRemixContest.ts
+++ b/packages/common/src/api/tan-query/events/useRemixContest.ts
@@ -9,7 +9,7 @@ import { SelectableQueryOptions } from '../types'
 import { useEvent } from './useEvent'
 import { useEventIdsByEntityId } from './useEventsByEntityId'
 
-type RemixContestData = {
+export type RemixContestData = {
   description: string
   prizeInfo: string
   winners: ID[]

--- a/packages/common/src/api/tan-query/remixes/useRemixes.ts
+++ b/packages/common/src/api/tan-query/remixes/useRemixes.ts
@@ -197,7 +197,7 @@ export const useRemixes = (
       }
     },
     placeholderData: (prev) => {
-      if (!prev) return undefined
+      if (!prev || !(includeOriginal || includeWinners)) return undefined
       return {
         pages: [
           {

--- a/packages/common/src/api/tan-query/remixes/useRemixes.ts
+++ b/packages/common/src/api/tan-query/remixes/useRemixes.ts
@@ -134,7 +134,7 @@ export const useRemixes = (
         userTrackMetadataFromSDK
       )
 
-      let winnerCount = null
+      let winnerCount: number | null = null
 
       if (trackId) {
         const { data: eventsData } = await sdk.events.getEntityEvents({

--- a/packages/web/src/components/lineup/TanQueryLineup.tsx
+++ b/packages/web/src/components/lineup/TanQueryLineup.tsx
@@ -82,6 +82,11 @@ export interface TanQueryLineupProps {
   leadingElementDelineator?: JSX.Element | null
 
   /**
+   * Map of indeces to JSX Elements that can be used to delineate the elements from the rest
+   */
+  delineatorMap?: Record<number, JSX.Element>
+
+  /**
    * JSX Element that can be used to adorn the tile
    */
   elementAdornment?: (elementId: ID, index: number) => JSX.Element | null
@@ -148,6 +153,7 @@ export const TanQueryLineup = ({
   leadingElementId,
   lineupContainerStyles,
   leadingElementDelineator,
+  delineatorMap,
   elementAdornment,
   tileContainerStyles,
   tileStyles,
@@ -249,7 +255,11 @@ export const TanQueryLineup = ({
   )
 
   const renderSkeletons = useCallback(
-    (skeletonCount: number | undefined, isInitialLoad: boolean) => {
+    (
+      skeletonCount: number | undefined,
+      isInitialLoad: boolean,
+      indexOffset: number = 0
+    ) => {
       // This means no skeletons are desired
       if (!skeletonCount) {
         return <></>
@@ -295,6 +305,9 @@ export const TanQueryLineup = ({
                       <Divider css={{ width: '100%' }} />
                     )
                   ) : null}
+                  {delineatorMap?.[index + indexOffset]
+                    ? delineatorMap[index + indexOffset]
+                    : null}
                 </Flex>
               )
             })}
@@ -309,7 +322,8 @@ export const TanQueryLineup = ({
       tileStyles,
       isSmallTrackTile,
       TrackTile,
-      leadingElementDelineator
+      leadingElementDelineator,
+      delineatorMap
     ]
   )
 
@@ -479,13 +493,17 @@ export const TanQueryLineup = ({
                         <Divider />
                       )
                     ) : null}
+                    {delineatorMap?.[index] ? delineatorMap[index] : null}
                   </Flex>
                 ))}
 
-            {isFetching &&
-              shouldLoadMore &&
-              hasNextPage &&
-              renderSkeletons(Math.min(maxEntries, pageSize), false)}
+            {isFetching && tiles.length > 0
+              ? renderSkeletons(
+                  Math.min(maxEntries - tiles.length, pageSize),
+                  false,
+                  tiles.length
+                )
+              : null}
           </InfiniteScroll>
         </div>
       </div>

--- a/packages/web/src/pages/remixes-page/components/desktop/NewRemixesPage.tsx
+++ b/packages/web/src/pages/remixes-page/components/desktop/NewRemixesPage.tsx
@@ -196,6 +196,7 @@ const RemixesPage = nullGuard(({ title, originalTrack }) => {
           actions={remixesPageLineupActions}
           delineatorMap={delineatorMap}
           maxEntries={
+            // remix count + winner count + original track
             count && winnerCount ? count + winnerCount + 1 : undefined
           }
         />


### PR DESCRIPTION
### Description
* Winners are displayed within the lineup on the remix contest submissions page
* Used the placeholderData of the tan-query hook to make the original track and winners appear as the remixes are sorted/filtered

### How Has This Been Tested?
Manually Tested
