### PR TITLE
Fix search tracks lineup

### DIFF
--- a/packages/mobile/src/store/sagas.ts
+++ b/packages/mobile/src/store/sagas.ts
@@ -38,6 +38,7 @@ import historySagas from 'common/store/pages/history/sagas'
 import premiumTracksSagas from 'common/store/pages/premium-tracks/sagas'
 import remixesSagas from 'common/store/pages/remixes-page/sagas'
 import savedSagas from 'common/store/pages/saved/sagas'
+import searchTracksLineupSagas from 'common/store/pages/search-page/lineups/tracks/sagas'
 import signOnSagas from 'common/store/pages/signon/sagas'
 import tokenDashboardSagas from 'common/store/pages/token-dashboard/sagas'
 import trackPageSagas from 'common/store/pages/track/sagas'
@@ -140,6 +141,7 @@ export default function* rootSaga() {
     ...settingsSagas(),
     ...aiSagas(),
     ...premiumTracksSagas(),
+    ...searchTracksLineupSagas(),
 
     // Cast
     ...castSagas(),

--- a/packages/web/src/store/sagas.ts
+++ b/packages/web/src/store/sagas.ts
@@ -41,6 +41,7 @@ import historySagas from 'common/store/pages/history/sagas'
 import premiumTracksSagas from 'common/store/pages/premium-tracks/sagas'
 import remixesSagas from 'common/store/pages/remixes-page/sagas'
 import savedSagas from 'common/store/pages/saved/sagas'
+import searchTracksLineupSagas from 'common/store/pages/search-page/lineups/tracks/sagas'
 import signOnSaga from 'common/store/pages/signon/sagas'
 import trackPageSagas from 'common/store/pages/track/sagas'
 import trendingPageSagas from 'common/store/pages/trending/sagas'
@@ -123,6 +124,7 @@ export default function* rootSaga() {
     trendingUndergroundSagas(),
     uploadSagas(),
     premiumTracksSagas(),
+    searchTracksLineupSagas(),
 
     modalsSagas(),
 


### PR DESCRIPTION
### Description

Fix bug from https://github.com/AudiusProject/audius-protocol/pull/12106 where the search tracks lineup saga isnt running anymore (it was imported into the larger search page sagas)

Fixes PE-6255

### How Has This Been Tested?

web:stage - track search tracks results looks good
