### PR TITLE
[PE-6259] Display winners tab by default on finished remix contests

### DIFF
--- a/packages/mobile/src/screens/track-screen/RemixContestSection.tsx
+++ b/packages/mobile/src/screens/track-screen/RemixContestSection.tsx
@@ -94,7 +94,7 @@ export const RemixContestSection = ({
     isRemixContestWinnersMilestoneEnabled &&
     (remixContest?.eventData?.winners?.length ?? 0) > 0
 
-  const [index, setIndex] = useState(0)
+  const [index, setIndex] = useState(hasWinners ? 2 : 0)
   const [routes, setRoutes] = useState<Route[]>([])
   const [heights, setHeights] = useState({})
   const [firstRender, setFirstRender] = useState(true)

--- a/packages/web/src/pages/track-page/components/desktop/RemixContestSection.tsx
+++ b/packages/web/src/pages/track-page/components/desktop/RemixContestSection.tsx
@@ -82,12 +82,6 @@ export const RemixContestSection = ({
           }
         ]
       : []),
-    {
-      text: remixCount
-        ? `${messages.submissions} (${remixCount})`
-        : messages.submissions,
-      label: 'submissions'
-    },
     ...(hasWinners
       ? [
           {
@@ -95,11 +89,19 @@ export const RemixContestSection = ({
             label: 'winners'
           }
         ]
-      : [])
+      : [
+          {
+            text: remixCount
+              ? `${messages.submissions} (${remixCount})`
+              : messages.submissions,
+            label: 'submissions'
+          }
+        ])
   ]
 
   const { tabs: TabBar, body: ContentBody } = useTabs({
     tabs,
+    initialTab: hasWinners ? 'winners' : undefined,
     elements: [
       <TabBody key='details' onHeightChange={handleHeightChange}>
         <RemixContestDetailsTab trackId={trackId} />
@@ -111,12 +113,6 @@ export const RemixContestSection = ({
             </TabBody>
           ]
         : []),
-      <TabBody key='submissions' onHeightChange={handleHeightChange}>
-        <RemixContestSubmissionsTab
-          trackId={trackId}
-          submissions={remixes.slice(0, 10)}
-        />
-      </TabBody>,
       ...(hasWinners
         ? [
             <TabBody key='winners' onHeightChange={handleHeightChange}>
@@ -126,7 +122,14 @@ export const RemixContestSection = ({
               />
             </TabBody>
           ]
-        : [])
+        : [
+            <TabBody key='submissions' onHeightChange={handleHeightChange}>
+              <RemixContestSubmissionsTab
+                trackId={trackId}
+                submissions={remixes.slice(0, 10)}
+              />
+            </TabBody>
+          ])
     ],
     isMobile: false
   })

--- a/packages/web/src/pages/track-page/components/mobile/remix-contests/RemixContestSection.tsx
+++ b/packages/web/src/pages/track-page/components/mobile/remix-contests/RemixContestSection.tsx
@@ -95,6 +95,7 @@ export const RemixContestSection = ({
 
   const { tabs: TabBar, body: TabBody } = useTabs({
     tabs,
+    initialTab: hasWinners ? 'winners' : undefined,
     elements,
     isMobile: false,
     isMobileV2: true


### PR DESCRIPTION
### Description
Update the remix contest sections on web and mobile to display the winners tab by default if the contest has winners selected

### How Has This Been Tested?
Manually Tested
