### PR TITLE
Fix remix notification loading

### DIFF
--- a/packages/common/src/adapters/notification.ts
+++ b/packages/common/src/adapters/notification.ts
@@ -648,6 +648,7 @@ export const notificationFromSDK = (
       return {
         type: NotificationType.FanRemixContestEnded,
         entityId: HashId.parse(data.entityId),
+        entityType: Entity.Track,
         entityUserId: HashId.parse(data.entityUserId),
         ...formatBaseNotification(notification)
       }
@@ -657,6 +658,7 @@ export const notificationFromSDK = (
       return {
         type: NotificationType.ArtistRemixContestEnded,
         entityId: HashId.parse(data.entityId),
+        entityType: Entity.Track,
         ...formatBaseNotification(notification)
       }
     }
@@ -665,6 +667,7 @@ export const notificationFromSDK = (
       return {
         type: NotificationType.ArtistRemixContestEndingSoon,
         entityId: HashId.parse(data.entityId),
+        entityType: Entity.Track,
         entityUserId: HashId.parse(data.entityUserId),
         ...formatBaseNotification(notification)
       }
@@ -674,6 +677,7 @@ export const notificationFromSDK = (
       return {
         type: NotificationType.FanRemixContestEndingSoon,
         entityId: HashId.parse(data.entityId),
+        entityType: Entity.Track,
         entityUserId: HashId.parse(data.entityUserId),
         ...formatBaseNotification(notification)
       }
@@ -683,6 +687,7 @@ export const notificationFromSDK = (
       return {
         type: NotificationType.FanRemixContestStarted,
         entityId: HashId.parse(data.entityId),
+        entityType: Entity.Track,
         entityUserId: HashId.parse(data.entityUserId),
         ...formatBaseNotification(notification)
       }
@@ -698,6 +703,7 @@ export const notificationFromSDK = (
         eventId: HashId.parse(data.eventId),
         milestone: data.milestone,
         entityId: HashId.parse(data.entityId),
+        entityType: Entity.Track,
         ...formatBaseNotification(notification)
       }
     }

--- a/packages/common/src/store/notifications/types.ts
+++ b/packages/common/src/store/notifications/types.ts
@@ -705,29 +705,34 @@ export type FanRemixContestStartedNotification = BaseNotification & {
   type: NotificationType.FanRemixContestStarted
   entityId: ID
   entityUserId: ID
+  entityType: Entity.Track
 }
 
 export type FanRemixContestEndingSoonNotification = BaseNotification & {
   type: NotificationType.FanRemixContestEndingSoon
   entityId: ID
   entityUserId: ID
+  entityType: Entity.Track
 }
 
 export type ArtistRemixContestEndedNotification = BaseNotification & {
   type: NotificationType.ArtistRemixContestEnded
   entityId: ID
+  entityType: Entity.Track
 }
 
 export type FanRemixContestEndedNotification = BaseNotification & {
   type: NotificationType.FanRemixContestEnded
   entityId: ID
   entityUserId: ID
+  entityType: Entity.Track
 }
 
 export type ArtistRemixContestEndingSoonNotification = BaseNotification & {
   type: NotificationType.ArtistRemixContestEndingSoon
   entityId: ID
   entityUserId: ID
+  entityType: Entity.Track
 }
 
 export type ArtistRemixContestSubmissionsNotification = BaseNotification & {
@@ -735,6 +740,7 @@ export type ArtistRemixContestSubmissionsNotification = BaseNotification & {
   eventId: ID
   milestone: number
   entityId: ID
+  entityType: Entity.Track
 }
 
 export type Notification =

--- a/packages/mobile/src/screens/notifications-screen/Notification/EntityLink.tsx
+++ b/packages/mobile/src/screens/notifications-screen/Notification/EntityLink.tsx
@@ -27,6 +27,8 @@ export const EntityLink = (props: EntityLinkProps) => {
     }
   }, [entity, navigation])
 
+  if (!entity) return null
+
   return (
     <Text fontSize='large' weight='medium' color='secondary' onPress={onPress}>
       {'title' in entity ? entity.title : entity.playlist_name}

--- a/packages/web/src/components/notification/Notification/Notification.tsx
+++ b/packages/web/src/components/notification/Notification/Notification.tsx
@@ -196,11 +196,12 @@ export const Notification = (props: NotificationProps) => {
       }
     }
   }
+
   return (
     <ErrorWrapper
       errorMessage={`Could not render notification ${notification.id}`}
     >
-      <li>{getNotificationElement()}</li>
+      {getNotificationElement()}
     </ErrorWrapper>
   )
 }

--- a/packages/web/src/components/notification/Notification/components/NotificationTile.tsx
+++ b/packages/web/src/components/notification/Notification/components/NotificationTile.tsx
@@ -31,7 +31,14 @@ export const NotificationTile = (props: NotificationTileProps) => {
   )
 
   return (
-    <Paper column shadow='flat' p='l' onClick={handleClick} border='strong'>
+    <Paper
+      column
+      shadow='flat'
+      as='li'
+      p='l'
+      onClick={handleClick}
+      border='strong'
+    >
       {children}
     </Paper>
   )


### PR DESCRIPTION
### Description

Fixes issue where useNotificationEntity failed to load remix contest notifications due to missing entityType.
Also fixes spacing issue when a notification does fail to load