### PR TITLE
[PE-6275, PE-6276, PE-6279, PE-6282] Pick Winners Milestone QA 1

### DIFF
--- a/packages/common/src/api/tan-query/remixes/useRemixes.ts
+++ b/packages/common/src/api/tan-query/remixes/useRemixes.ts
@@ -160,7 +160,7 @@ export const useRemixes = (
             userTrackMetadataFromSDK
           )
 
-          processedTracks.splice(0, 0, ...winners)
+          processedTracks = [...winners, ...processedTracks]
         }
       }
 

--- a/packages/common/src/store/ui/modals/finalize-winners-confirmation-modal/index.ts
+++ b/packages/common/src/store/ui/modals/finalize-winners-confirmation-modal/index.ts
@@ -3,6 +3,7 @@ import { createModal } from '../createModal'
 export type FinalizeWinnersConfirmationModalState = {
   confirmCallback: () => void
   cancelCallback?: () => void
+  isInitialSave: boolean
 }
 
 const finalizeWinnersConfirmationModal =
@@ -11,7 +12,8 @@ const finalizeWinnersConfirmationModal =
     initialState: {
       isOpen: false,
       confirmCallback: () => {},
-      cancelCallback: () => {}
+      cancelCallback: () => {},
+      isInitialSave: false
     },
     sliceSelector: (state) => state.ui.modals
   })

--- a/packages/mobile/src/screens/track-screen/UploadRemixFooter.tsx
+++ b/packages/mobile/src/screens/track-screen/UploadRemixFooter.tsx
@@ -6,8 +6,6 @@ import { Button, Flex, IconCloudUpload } from '@audius/harmony-native'
 import { useNavigation } from 'app/hooks/useNavigation'
 
 const messages = {
-  contestEnded: 'Contest Ended',
-  contestDeadline: 'Contest Deadline',
   uploadRemixButtonText: 'Upload Your Remix'
 }
 

--- a/packages/mobile/src/screens/track-screen/UploadRemixFooter.tsx
+++ b/packages/mobile/src/screens/track-screen/UploadRemixFooter.tsx
@@ -6,6 +6,8 @@ import { Button, Flex, IconCloudUpload } from '@audius/harmony-native'
 import { useNavigation } from 'app/hooks/useNavigation'
 
 const messages = {
+  contestEnded: 'Contest Ended',
+  contestDeadline: 'Contest Deadline',
   uploadRemixButtonText: 'Upload Your Remix'
 }
 

--- a/packages/web/src/components/finalize-winners-confirmation-modal/FinalizeWinnersConfirmationModal.tsx
+++ b/packages/web/src/components/finalize-winners-confirmation-modal/FinalizeWinnersConfirmationModal.tsx
@@ -13,15 +13,15 @@ import {
 
 const messages = {
   title: 'Confirm Winners?',
-  description:
-    'Contestants will be notified and winners will receive an Audio reward.',
+  description: 'Are you sure you want to finalize your winners?',
+  description2: 'All participants will be notified.',
   cancel: 'Go Back',
   confirm: 'Confirm'
 }
 
 export const FinalizeWinnersConfirmationModal = () => {
   const { data, isOpen, onClose } = useFinalizeWinnersConfirmationModal()
-  const { confirmCallback, cancelCallback } = data
+  const { confirmCallback, cancelCallback, isInitialSave } = data
 
   const handleConfirm = useCallback(() => {
     confirmCallback()
@@ -46,6 +46,7 @@ export const FinalizeWinnersConfirmationModal = () => {
         <Flex column justifyContent='center' gap='xl'>
           <Text variant='body' size='l'>
             {messages.description}
+            {isInitialSave ? ` ${messages.description2}` : ''}
           </Text>
         </Flex>
       </ModalContent>

--- a/packages/web/src/pages/pick-winners-page/PickWinnersPage.tsx
+++ b/packages/web/src/pages/pick-winners-page/PickWinnersPage.tsx
@@ -110,9 +110,7 @@ export const PickWinnersPage = () => {
 
   const [winners, setWinners] = useState<ID[]>([])
   const [initialWinners, setInitialWinners] = useState<ID[]>([])
-  const canFinalize = useMemo(() => {
-    return winners.length > 0 || initialWinners.length === 0
-  }, [winners, initialWinners])
+  const canFinalize = useMemo(() => winners.length > 0, [winners])
 
   useEffect(() => {
     if (remixContest) {
@@ -131,7 +129,8 @@ export const PickWinnersPage = () => {
             ...remixContest.eventData,
             winners
           },
-          userId: currentUserId
+          userId: currentUserId,
+          entityId: originalTrack?.track_id
         })
 
         if (originalTrack?.track_id) {
@@ -163,14 +162,26 @@ export const PickWinnersPage = () => {
 
   const openConfirmationModal = useCallback(() => {
     openFinalizeWinnersConfirmationModal({
+      isInitialSave: initialWinners.length === 0,
       confirmCallback: handleFinalize,
       cancelCallback: () => {}
     })
-  }, [handleFinalize, openFinalizeWinnersConfirmationModal])
+  }, [
+    handleFinalize,
+    initialWinners.length,
+    openFinalizeWinnersConfirmationModal
+  ])
+
+  const handleBack = useCallback(() => {
+    const pathname = trackRemixesPage(originalTrack?.permalink ?? '')
+    const search = new URLSearchParams({ isContestEntry: 'true' }).toString()
+    history.push({ pathname, search })
+  }, [history, originalTrack?.permalink])
 
   const pageHeader = (
     <Header
       primary={messages.pickWinnersTitle}
+      onClickBack={handleBack}
       showBackButton
       rightDecorator={
         <Button

--- a/packages/web/src/pages/track-page/components/desktop/RemixContestSection.tsx
+++ b/packages/web/src/pages/track-page/components/desktop/RemixContestSection.tsx
@@ -1,10 +1,11 @@
 import { useState, useCallback } from 'react'
 
-import { useRemixContest, useRemixes } from '@audius/common/api'
+import { useRemixContest, useRemixes, useTrack } from '@audius/common/api'
 import { useFeatureFlag } from '@audius/common/hooks'
-import { ID } from '@audius/common/models'
+import { ID, Name } from '@audius/common/models'
 import { FeatureFlags } from '@audius/common/services'
 import { UPLOAD_PAGE } from '@audius/common/src/utils/route'
+import { dayjs } from '@audius/common/utils'
 import {
   Box,
   Button,
@@ -15,10 +16,13 @@ import {
   spacing,
   Text
 } from '@audius/harmony'
+import { Link } from 'react-router-dom'
 
 import { useNavigateToPage } from 'hooks/useNavigateToPage'
 import { useRequiresAccountCallback } from 'hooks/useRequiresAccount'
 import useTabs from 'hooks/useTabs/useTabs'
+import { track, make } from 'services/analytics'
+import { pickWinnersPage } from 'utils/route'
 
 import { RemixContestDetailsTab } from './RemixContestDetailsTab'
 import { RemixContestPrizesTab } from './RemixContestPrizesTab'
@@ -32,7 +36,9 @@ const messages = {
   prizes: 'Prizes',
   winners: 'Winners',
   submissions: 'Submissions',
-  uploadRemixButtonText: 'Upload Your Remix'
+  uploadRemixButtonText: 'Upload Your Remix',
+  pickWinners: 'Pick Winners',
+  editWinners: 'Edit Winners'
 }
 
 const TAB_BAR_HEIGHT = 56
@@ -50,6 +56,7 @@ export const RemixContestSection = ({
   isOwner
 }: RemixContestSectionProps) => {
   const navigate = useNavigateToPage()
+  const { data: originalTrack } = useTrack(trackId)
   const { data: remixContest } = useRemixContest(trackId)
   const { isEnabled: isRemixContestWinnersMilestoneEnabled } = useFeatureFlag(
     FeatureFlags.REMIX_CONTEST_WINNERS_MILESTONE
@@ -61,6 +68,7 @@ export const RemixContestSection = ({
 
   const [contentHeight, setContentHeight] = useState(0)
   const hasPrizeInfo = !!remixContest?.eventData?.prizeInfo
+  const isContestEnded = dayjs(remixContest?.endDate).isBefore(dayjs())
   const hasWinners =
     isRemixContestWinnersMilestoneEnabled &&
     (remixContest?.eventData?.winners?.length ?? 0) > 0
@@ -134,6 +142,20 @@ export const RemixContestSection = ({
     isMobile: false
   })
 
+  const pickWinnersRoute = pickWinnersPage(originalTrack?.permalink ?? '')
+
+  const handlePickWinnersClick = useCallback(() => {
+    if (remixContest?.eventId) {
+      track(
+        make({
+          eventName: Name.REMIX_CONTEST_PICK_WINNERS_OPEN,
+          remixContestId: remixContest.eventId,
+          trackId
+        })
+      )
+    }
+  }, [remixContest?.eventId, trackId])
+
   const goToUploadWithRemix = useRequiresAccountCallback(() => {
     if (!trackId) return
 
@@ -182,6 +204,18 @@ export const RemixContestSection = ({
                   iconLeft={IconCloudUpload}
                 >
                   {messages.uploadRemixButtonText}
+                </Button>
+              </Flex>
+            ) : isContestEnded && isRemixContestWinnersMilestoneEnabled ? (
+              <Flex mb='m'>
+                <Button
+                  variant='secondary'
+                  size='small'
+                  onClick={handlePickWinnersClick}
+                >
+                  <Link to={pickWinnersRoute}>
+                    {hasWinners ? messages.editWinners : messages.pickWinners}
+                  </Link>
                 </Button>
               </Flex>
             ) : (


### PR DESCRIPTION
### Description
* Disables the finalize winners button when no winners are picked\
* Adds pick winners button to the remix contest section for the owner when the contest is over
* Update the copy of the finalize winners confirmation modal
* Updates the back button on the PickWinnersPage to always go to the remixes page

### How Has This Been Tested?
Manually Tested
