### PR TITLE
Fix npm cache keys

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -60,11 +60,11 @@ jobs:
       - restore_cache:
           keys:
             # Primary cache key with Node version
-            - npm-cache-v1-{{ checksum "package-lock.json" }}-{{ checksum "combined-patch-file.txt" }}-{{ .Environment.NODE_VERSION }}
+            - npm-cache-{{ checksum "package-lock.json" }}-{{ checksum "combined-patch-file.txt" }}-{{ .Environment.NODE_VERSION }}
             # Fallback cache key without Node version
-            - npm-cache-v1-{{ checksum "package-lock.json" }}-{{ checksum "combined-patch-file.txt" }}
+            - npm-cache-{{ checksum "package-lock.json" }}-{{ checksum "combined-patch-file.txt" }}
             # Fallback to most recent cache
-            - npm-cache-v1-
+            - npm-cache-
 
       - run: sudo apt-get update
       - run: sudo apt-get install -y build-essential libssl-dev
@@ -80,15 +80,24 @@ jobs:
             fi
 
       - save_cache:
-          key: npm-cache-v1-{{ checksum "package-lock.json" }}-{{ checksum "combined-patch-file.txt" }}-{{ .Environment.NODE_VERSION }}
+          key: npm-cache-{{ checksum "package-lock.json" }}-{{ checksum "combined-patch-file.txt" }}-{{ .Environment.NODE_VERSION }}
           paths:
-            # Root node_modules
             - ./node_modules
-            # Package-specific node_modules
-            - ./packages/*/node_modules
-            # Special cases
+            - ./packages/protocol-dashboard/node_modules
+            - ./packages/web/node_modules
+            - ./packages/mobile/node_modules
+            - ./packages/embed/node_modules
+            - ./packages/harmony/node_modules
+            - ./packages/common/node_modules
+            - ./packages/libs/node_modules
+            - ./packages/sdk/node_modules
+            - ./packages/identity-service/node_modules
+            - ./packages/es-indexer/node_modules
+            - ./packages/ddex-entrypoint/node_modules
+            - ./packages/create-audius-app/node_modules
             - ./packages/dotenv-linter/bin
-            - ./packages/discovery-provider/plugins/pedalboard/apps/*/node_modules
+            - ./packages/discovery-provider/plugins/pedalboard/apps/relay/node_modules
+            - ./packages/discovery-provider/plugins/pedalboard/apps/solana-relay/node_modules
 
   generate-release-branch:
     working_directory: ~/audius-protocol

--- a/.circleci/src/commands/@web-commands.yml
+++ b/.circleci/src/commands/@web-commands.yml
@@ -137,7 +137,7 @@ web-distribute:
 
     - restore_cache:
         keys:
-          - cache-{{ checksum "package-lock.json" }}-{{ checksum "combined-patch-file.txt" }}-{{ arch }}
+          - npm-cache-{{ checksum "package-lock.json" }}-{{ checksum "combined-patch-file.txt" }}-{{ arch }}
 
     - run:
         name: Install dependencies

--- a/.circleci/src/jobs/@common-jobs.yml
+++ b/.circleci/src/jobs/@common-jobs.yml
@@ -13,7 +13,7 @@ common-init:
 
     - restore_cache:
         keys:
-          - cache-{{ checksum "package-lock.json" }}-{{ checksum "combined-patch-file.txt" }}
+          - npm-cache-{{ checksum "package-lock.json" }}-{{ checksum "combined-patch-file.txt" }}
     - run:
         name: lint & typecheck
         command: |

--- a/.circleci/src/jobs/@create-audius-app-jobs.yml
+++ b/.circleci/src/jobs/@create-audius-app-jobs.yml
@@ -13,7 +13,7 @@ create-audius-app-init:
 
     - restore_cache:
         keys:
-          - cache-{{ checksum "package-lock.json" }}-{{ checksum "combined-patch-file.txt" }}
+          - npm-cache-{{ checksum "package-lock.json" }}-{{ checksum "combined-patch-file.txt" }}
     - run:
         name: lint & typecheck
         command: |

--- a/.circleci/src/jobs/@discovery-jobs.yml
+++ b/.circleci/src/jobs/@discovery-jobs.yml
@@ -13,7 +13,7 @@ lint-discovery-provider:
 
     - restore_cache:
         keys:
-          - cache-{{ checksum "package-lock.json" }}-{{ checksum "combined-patch-file.txt" }}
+          - npm-cache-{{ checksum "package-lock.json" }}-{{ checksum "combined-patch-file.txt" }}
 
     - restore_cache:
         key: python-requirements-{{ checksum "packages/discovery-provider/requirements.txt" }}

--- a/.circleci/src/jobs/@embed-jobs.yml
+++ b/.circleci/src/jobs/@embed-jobs.yml
@@ -10,7 +10,7 @@ embed-init:
 
     - restore_cache:
         keys:
-          - cache-{{ checksum "package-lock.json" }}-{{ checksum "combined-patch-file.txt" }}
+          - npm-cache-{{ checksum "package-lock.json" }}-{{ checksum "combined-patch-file.txt" }}
 
     - persist_to_workspace:
         root: ./

--- a/.circleci/src/jobs/@harmony-jobs.yml
+++ b/.circleci/src/jobs/@harmony-jobs.yml
@@ -10,7 +10,7 @@ harmony-init:
 
     - restore_cache:
         keys:
-          - cache-{{ checksum "package-lock.json" }}-{{ checksum "combined-patch-file.txt" }}
+          - npm-cache-{{ checksum "package-lock.json" }}-{{ checksum "combined-patch-file.txt" }}
 
     # Lint
     - run:

--- a/.circleci/src/jobs/@identity-jobs.yml
+++ b/.circleci/src/jobs/@identity-jobs.yml
@@ -10,7 +10,7 @@ identity-init:
 
     - restore_cache:
         keys:
-          - cache-{{ checksum "package-lock.json" }}-{{ checksum "combined-patch-file.txt" }}
+          - npm-cache-{{ checksum "package-lock.json" }}-{{ checksum "combined-patch-file.txt" }}
 
     - run:
         name: verify

--- a/.circleci/src/jobs/@integration-jobs.yml
+++ b/.circleci/src/jobs/@integration-jobs.yml
@@ -12,7 +12,7 @@ integration-init:
 
     - restore_cache:
         keys:
-          - cache-{{ checksum "package-lock.json" }}-{{ checksum "combined-patch-file.txt" }}
+          - npm-cache-{{ checksum "package-lock.json" }}-{{ checksum "combined-patch-file.txt" }}
 
     - persist_to_workspace:
         root: ./

--- a/.circleci/src/jobs/@mobile-jobs.yml
+++ b/.circleci/src/jobs/@mobile-jobs.yml
@@ -20,7 +20,7 @@ mobile-init:
 
     - restore_cache:
         keys:
-          - cache-{{ checksum "package-lock.json" }}-{{ checksum "combined-patch-file.txt" }}
+          - npm-cache-{{ checksum "package-lock.json" }}-{{ checksum "combined-patch-file.txt" }}
 
     - run:
         name: lint & typecheck

--- a/.circleci/src/jobs/@protocol-dashboard-jobs.yml
+++ b/.circleci/src/jobs/@protocol-dashboard-jobs.yml
@@ -14,7 +14,7 @@ protocol-dashboard-init:
     # Download and cache dependencies
     - restore_cache:
         keys:
-          - cache-{{ checksum "package-lock.json" }}-{{ checksum "combined-patch-file.txt" }}
+          - npm-cache-{{ checksum "package-lock.json" }}-{{ checksum "combined-patch-file.txt" }}
 
     # Lint
     - run:

--- a/.circleci/src/jobs/@sdk-jobs.yml
+++ b/.circleci/src/jobs/@sdk-jobs.yml
@@ -12,7 +12,7 @@ sdk-init:
 
     - restore_cache:
         keys:
-          - cache-{{ checksum "package-lock.json" }}-{{ checksum "combined-patch-file.txt" }}
+          - npm-cache-{{ checksum "package-lock.json" }}-{{ checksum "combined-patch-file.txt" }}
 
     - run:
         name: lint & typecheck

--- a/.circleci/src/jobs/@web-jobs.yml
+++ b/.circleci/src/jobs/@web-jobs.yml
@@ -12,7 +12,7 @@ web-init:
 
     - restore_cache:
         keys:
-          - cache-{{ checksum "package-lock.json" }}-{{ checksum "combined-patch-file.txt" }}
+          - npm-cache-{{ checksum "package-lock.json" }}-{{ checksum "combined-patch-file.txt" }}
 
     - run:
         name: lint & typecheck


### PR DESCRIPTION
### Description

Fixes npm cache keys by renaming to node-cache, and dropping glob patterns for explicit paths, since those seemed to break things. finally update cache keys in all jobs