### PR TITLE
Fix some USDC balances not updating

### DIFF
--- a/packages/common/src/api/tan-query/wallets/useUSDCBalance.ts
+++ b/packages/common/src/api/tan-query/wallets/useUSDCBalance.ts
@@ -1,5 +1,8 @@
+import { useCallback } from 'react'
+
+import { TokenAccountNotFoundError } from '@solana/spl-token'
 import { Commitment } from '@solana/web3.js'
-import { useQuery } from '@tanstack/react-query'
+import { useQuery, useQueryClient } from '@tanstack/react-query'
 import BN from 'bn.js'
 import { useDispatch, useSelector } from 'react-redux'
 
@@ -46,6 +49,7 @@ export const useUSDCBalance = ({
   const ethAddress = user?.wallet ?? null
   const dispatch = useDispatch()
   const recoveryStatus = useSelector(getRecoveryStatus)
+  const queryClient = useQueryClient()
 
   const result = useQuery({
     queryKey: getUSDCBalanceQueryKey(ethAddress, commitment),
@@ -71,11 +75,21 @@ export const useUSDCBalance = ({
 
         return balance
       } catch (e) {
+        // If user doesn't have a USDC token account yet, return 0 balance
+        if (e instanceof TokenAccountNotFoundError) {
+          const balance = new BN(0) as BNUSDC
+          dispatch(setUSDCBalance({ amount: balance.toString() as StringUSDC }))
+          return balance
+        }
         console.error('Error fetching USDC balance:', e)
         throw e
       }
     },
     enabled: !!ethAddress,
+    // TanStack Query's built-in polling - only poll when isPolling is true
+    refetchInterval: isPolling ? pollingInterval : false,
+    // Prevent refetching when window regains focus during polling to avoid conflicts
+    refetchOnWindowFocus: !isPolling,
     ...queryOptions
   })
 
@@ -97,9 +111,19 @@ export const useUSDCBalance = ({
     status = Status.LOADING
   }
 
+  // Function to cancel polling by invalidating and refetching the query
+  // This effectively stops the current polling cycle
+  const cancelPolling = useCallback(() => {
+    queryClient.cancelQueries({
+      queryKey: getUSDCBalanceQueryKey(ethAddress, commitment)
+    })
+  }, [queryClient, ethAddress, commitment])
+
   return {
     status,
     data,
-    refresh: result.refetch
+    error: result.error,
+    refresh: result.refetch,
+    cancelPolling
   }
 }

--- a/packages/common/src/hooks/useFormattedUSDCBalance.ts
+++ b/packages/common/src/hooks/useFormattedUSDCBalance.ts
@@ -16,7 +16,9 @@ type UseFormattedUSDCBalanceReturn = {
 }
 
 export const useFormattedUSDCBalance = (): UseFormattedUSDCBalanceReturn => {
-  const { data: balance, status: balanceStatus } = useUSDCBalance()
+  const { data: balance, status: balanceStatus } = useUSDCBalance({
+    isPolling: true
+  })
   const usdcValue = USDC(balance ?? new BN(0)).floor(2)
   const balanceCents = Number(usdcValue.floor(2).toString()) * 100
   const balanceFormatted = useMemo(() => {

--- a/packages/web/src/store/application/ui/withdraw-usdc/sagas.ts
+++ b/packages/web/src/store/application/ui/withdraw-usdc/sagas.ts
@@ -3,7 +3,6 @@ import {
   Status,
   WithdrawUSDCTransferEventFields
 } from '@audius/common/models'
-import { getUserQueryKey } from '@audius/common/src/api/tan-query/users/useUser'
 import { getUSDCBalanceQueryKey } from '@audius/common/src/api/tan-query/wallets/useUSDCBalance'
 import { transferFromUserBank } from '@audius/common/src/services/audius-backend/solana'
 import {


### PR DESCRIPTION
### Description
Co-authored by @faridsalau aka chat-farid-4o

- Add polling to the new tan-query useUSDCBalance hook
- Invalidate tan-query cache for usdc balance after withdraw success

Added another ticket to comb through and convert all other callsites of `useUSDCBalance` to use tan-query one.

### How Has This Been Tested?

Local web stage:
- Add cash: both balance in modal as well as on page (in background) update
- Withdraw: both balances update as well