### PR TITLE
[PE-6280] Fix optimistic updates for remix winners

### DIFF
--- a/packages/common/src/api/index.ts
+++ b/packages/common/src/api/index.ts
@@ -59,9 +59,10 @@ export * from './tan-query/purchases/usePurchasersCount'
 export * from './tan-query/purchases/useSalesAggregate'
 
 // Remixes
-export * from './tan-query/remixes/useRemixes'
+export * from './tan-query/remixes/useRemixesLineup'
 export * from './tan-query/remixes/useRemixers'
 export * from './tan-query/remixes/useRemixersCount'
+export * from './tan-query/remixes/useRemixes'
 
 // Search
 export * from './tan-query/search/useSearchAutocomplete'

--- a/packages/common/src/api/tan-query/events/index.ts
+++ b/packages/common/src/api/tan-query/events/index.ts
@@ -4,6 +4,7 @@ export * from './useEvent'
 export * from './useEvents'
 export * from './useEventsByEntityId'
 export * from './useRemixContest'
+export * from './useRemixContestWinners'
 
 // Mutations
 export * from './useCreateEvent'

--- a/packages/common/src/api/tan-query/events/useRemixContestWinners.ts
+++ b/packages/common/src/api/tan-query/events/useRemixContestWinners.ts
@@ -1,0 +1,56 @@
+import { useMemo } from 'react'
+
+import { ID } from '~/models'
+
+import { useTracks } from '../tracks/useTracks'
+import { QueryOptions } from '../types'
+
+import { useRemixContest } from './useRemixContest'
+
+/**
+ * Hook that returns the track IDs of winners for a remix contest.
+ * Uses useTracks internally to pre-fetch the winner tracks into the cache.
+ * @param trackId The ID of the track that has the remix contest
+ * @param options Query options
+ * @returns The winner track IDs and loading states
+ */
+export const useRemixContestWinners = (
+  trackId: number | null | undefined,
+  options?: QueryOptions
+) => {
+  // Get the remix contest data
+  const { data: remixContest, isLoading: isContestLoading } = useRemixContest(
+    trackId,
+    {
+      // Only enable if we have a trackId
+      enabled: options?.enabled !== false && !!trackId
+    }
+  )
+
+  // Extract winner IDs from contest data
+  const winnerIds = useMemo(
+    () => remixContest?.eventData.winners ?? [],
+    [remixContest?.eventData.winners]
+  )
+
+  // Pre-fetch the winner tracks into the cache
+  const {
+    isLoading: isTracksLoading,
+    isPending: isTracksPending,
+    isFetching: isTracksFetching
+  } = useTracks(winnerIds, {
+    // Only enable if we have winner IDs
+    enabled: options?.enabled !== false && winnerIds.length > 0
+  })
+
+  return {
+    // Return the winner IDs
+    data: winnerIds as ID[],
+    // Consider loading if either the contest or tracks are loading
+    isLoading: isContestLoading || isTracksLoading,
+    // Consider pending if either the contest or tracks are pending
+    isPending: isContestLoading || isTracksPending,
+    // Consider fetching if either the contest or tracks are fetching
+    isFetching: isContestLoading || isTracksFetching
+  }
+}

--- a/packages/common/src/api/tan-query/lineups/useLineupQuery.ts
+++ b/packages/common/src/api/tan-query/lineups/useLineupQuery.ts
@@ -96,7 +96,9 @@ export const useLineupQuery = <T>({
   }
 
   const prevQueryKey = usePrevious(queryKey)
+  const prevLineupData = usePrevious(lineupData)
   const hasQueryKeyChanged = !isEqual(prevQueryKey, queryKey)
+  const hasLineupDataChanged = !isEqual(lineupData, prevLineupData)
 
   // Function to handle loading cached data into the lineup
   const loadCachedDataIntoLineup = useCallback(() => {
@@ -162,13 +164,17 @@ export const useLineupQuery = <T>({
 
   // On a cache hit, we need to manually load the cached data into the lineup since the queryFn won't run.
   useEffect(() => {
-    if (!disableAutomaticCacheHandling && hasQueryKeyChanged) {
+    if (
+      !disableAutomaticCacheHandling &&
+      (hasQueryKeyChanged || hasLineupDataChanged)
+    ) {
       loadCachedDataIntoLineup()
     }
   }, [
     disableAutomaticCacheHandling,
     hasQueryKeyChanged,
-    loadCachedDataIntoLineup
+    loadCachedDataIntoLineup,
+    hasLineupDataChanged
   ])
 
   const status = combineStatuses([

--- a/packages/common/src/api/tan-query/remixes/useRemixes.ts
+++ b/packages/common/src/api/tan-query/remixes/useRemixes.ts
@@ -1,12 +1,4 @@
-import { useEffect } from 'react'
-
-import {
-  Id,
-  OptionalId,
-  EntityType,
-  full,
-  EventEventTypeEnum
-} from '@audius/sdk'
+import { Id, OptionalId, EntityType, full } from '@audius/sdk'
 import {
   InfiniteData,
   useInfiniteQuery,
@@ -15,18 +7,10 @@ import {
 import { useDispatch } from 'react-redux'
 
 import { transformAndCleanList, userTrackMetadataFromSDK } from '~/adapters'
-import { eventMetadataListFromSDK } from '~/adapters/event'
 import { useQueryContext } from '~/api/tan-query/utils'
 import { ID } from '~/models'
-import { PlaybackSource } from '~/models/Analytics'
-import {
-  remixesPageLineupActions,
-  remixesPageSelectors,
-  remixesPageActions
-} from '~/store/pages'
+import { remixesPageActions } from '~/store/pages'
 
-import { RemixContestData } from '../events'
-import { useLineupQuery } from '../lineups/useLineupQuery'
 import { QUERY_KEYS } from '../queryKeys'
 import { getTrackQueryKey } from '../tracks/useTrack'
 import { QueryKey, QueryOptions } from '../types'
@@ -38,17 +22,16 @@ const DEFAULT_PAGE_SIZE = 10
 
 export type UseRemixesArgs = {
   trackId: number | null | undefined
-  includeOriginal?: Boolean
-  includeWinners?: Boolean
+  includeOriginal?: boolean
+  includeWinners?: boolean
   pageSize?: number
   sortMethod?: full.GetTrackRemixesSortMethodEnum
   isCosign?: boolean
   isContestEntry?: boolean
 }
 
-type RemixesQueryData = {
+export type RemixesQueryData = {
   count: number
-  winnerCount: number | null
   tracks: { id: ID; type: EntityType }[]
 }
 
@@ -91,12 +74,6 @@ export const useRemixes = (
   const queryClient = useQueryClient()
   const dispatch = useDispatch()
 
-  useEffect(() => {
-    if (trackId) {
-      dispatch(remixesPageActions.fetchTrackSucceeded({ trackId }))
-    }
-  }, [dispatch, trackId])
-
   const queryData = useInfiniteQuery({
     queryKey: getRemixesQueryKey({
       trackId,
@@ -134,38 +111,6 @@ export const useRemixes = (
         userTrackMetadataFromSDK
       )
 
-      let winnerCount: number | null = null
-
-      if (trackId) {
-        const { data: eventsData } = await sdk.events.getEntityEvents({
-          entityId: [Id.parse(trackId)],
-          userId: OptionalId.parse(currentUserId)
-        })
-
-        const events = eventMetadataListFromSDK(eventsData)
-        const remixContest = events.find(
-          (event) => event.eventType === EventEventTypeEnum.RemixContest
-        )
-        const winnerIds = (remixContest?.eventData as RemixContestData)?.winners
-        winnerCount = winnerIds.length
-
-        if (includeWinners && remixContest && winnerIds) {
-          const { data: winnersData } = await sdk.full.tracks.getBulkTracks({
-            id: winnerIds.map((id) => Id.parse(id)),
-            userId: OptionalId.parse(currentUserId)
-          })
-
-          const winners = transformAndCleanList(
-            winnersData,
-            userTrackMetadataFromSDK
-          )
-
-          processedTracks = [...winners, ...processedTracks]
-        }
-      }
-
-      primeTrackData({ tracks: processedTracks, queryClient, dispatch })
-
       if (includeOriginal && pageParam === 0) {
         const track = queryClient.getQueryData(getTrackQueryKey(trackId))
         if (track && data.tracks) {
@@ -176,15 +121,9 @@ export const useRemixes = (
         }
       }
 
-      // Update lineup when new data arrives
-      dispatch(
-        remixesPageLineupActions.fetchLineupMetadatas(
-          pageParam,
-          pageSize,
-          false,
-          { items: processedTracks }
-        )
-      )
+      primeTrackData({ tracks: processedTracks, queryClient, dispatch })
+
+      // Update count in store
       dispatch(remixesPageActions.setCount({ count: data.count }))
 
       return {
@@ -192,50 +131,12 @@ export const useRemixes = (
           id: t.track_id,
           type: EntityType.TRACK
         })),
-        count: data.count,
-        winnerCount
+        count: data.count
       }
     },
-    placeholderData: (prev) => {
-      if (!prev || !(includeOriginal || includeWinners)) return undefined
-      return {
-        pages: [
-          {
-            tracks: prev?.pages[0]?.tracks.slice(
-              0,
-              (includeWinners ? (prev.pages[0].winnerCount ?? 0) : 0) +
-                (includeOriginal ? 1 : 0)
-            ),
-            count: prev?.pages[0]?.count,
-            winnerCount: prev?.pages[0]?.winnerCount
-          }
-        ]
-      }
-    },
-    ...options,
-    enabled: options?.enabled !== false && !!trackId
+    enabled: options?.enabled !== false && !!trackId,
+    ...options
   })
 
-  const lineupData = useLineupQuery({
-    lineupData: queryData.data?.pages.flatMap((page) => page.tracks) ?? [],
-    queryData,
-    queryKey: getRemixesQueryKey({
-      trackId,
-      includeOriginal,
-      includeWinners,
-      pageSize,
-      sortMethod,
-      isCosign,
-      isContestEntry
-    }),
-    lineupActions: remixesPageLineupActions,
-    lineupSelector: remixesPageSelectors.getLineup,
-    playbackSource: PlaybackSource.TRACK_TILE,
-    pageSize
-  })
-
-  return {
-    ...lineupData,
-    count: queryData.data?.pages[0]?.count
-  }
+  return queryData
 }

--- a/packages/common/src/api/tan-query/remixes/useRemixesLineup.ts
+++ b/packages/common/src/api/tan-query/remixes/useRemixesLineup.ts
@@ -1,0 +1,133 @@
+import { useEffect, useMemo } from 'react'
+
+import { EntityType } from '@audius/sdk'
+import { useDispatch } from 'react-redux'
+
+import { useRemixContestWinners } from '~/api/tan-query/events/useRemixContestWinners'
+import { PlaybackSource } from '~/models/Analytics'
+import {
+  remixesPageLineupActions,
+  remixesPageSelectors,
+  remixesPageActions
+} from '~/store/pages'
+
+import { useLineupQuery } from '../lineups/useLineupQuery'
+import { LineupData, QueryOptions } from '../types'
+
+import { UseRemixesArgs, useRemixes, getRemixesQueryKey } from './useRemixes'
+
+const DEFAULT_PAGE_SIZE = 10
+
+export const useRemixesLineup = (
+  {
+    trackId,
+    includeOriginal = false,
+    includeWinners = false,
+    pageSize = DEFAULT_PAGE_SIZE,
+    sortMethod = 'recent',
+    isCosign = false,
+    isContestEntry = false
+  }: UseRemixesArgs,
+  options?: QueryOptions
+) => {
+  const dispatch = useDispatch()
+
+  // Get winner IDs
+  const { data: winnerIds, isLoading: isWinnersLoading } =
+    useRemixContestWinners(trackId, {
+      enabled: options?.enabled !== false && includeWinners
+    })
+
+  useEffect(() => {
+    if (trackId) {
+      dispatch(remixesPageActions.fetchTrackSucceeded({ trackId }))
+    }
+  }, [dispatch, trackId])
+
+  // Use the core remixes fetching logic
+  const queryData = useRemixes(
+    {
+      trackId,
+      includeOriginal,
+      includeWinners,
+      pageSize,
+      sortMethod,
+      isCosign,
+      isContestEntry
+    },
+    {
+      ...options,
+      enabled:
+        options?.enabled !== false &&
+        !!trackId &&
+        (!includeWinners || !isWinnersLoading)
+    }
+  )
+
+  // Process and order the lineup data
+  const processedLineupData = useMemo(() => {
+    const remixTracks =
+      queryData.data?.pages.flatMap((page) => page.tracks) ?? []
+
+    // Start with an empty array
+    const orderedTracks: LineupData[] = []
+
+    // Add original track if included (should be first)
+    if (includeOriginal && trackId) {
+      const originalTrack = remixTracks.find((track) => track.id === trackId)
+      if (originalTrack) {
+        orderedTracks.push(originalTrack)
+      }
+    }
+
+    // Add winner tracks if included (should be second)
+    if (includeWinners && winnerIds?.length) {
+      const winnerTracks = winnerIds.map((id) => ({
+        id,
+        type: EntityType.TRACK
+      }))
+      orderedTracks.push(...winnerTracks)
+    }
+
+    // Add remaining remix tracks (excluding original and winners)
+    const remainingTracks = remixTracks.filter((track) => {
+      if (includeOriginal && track.id === trackId) return false
+      if (includeWinners && winnerIds?.includes(track.id)) return false
+      return true
+    })
+    orderedTracks.push(...remainingTracks)
+
+    return orderedTracks
+  }, [
+    queryData.data?.pages,
+    includeOriginal,
+    includeWinners,
+    trackId,
+    winnerIds
+  ])
+
+  const queryKey = getRemixesQueryKey({
+    trackId,
+    includeOriginal,
+    includeWinners,
+    pageSize,
+    sortMethod,
+    isCosign,
+    isContestEntry
+  })
+
+  const lineupData = useLineupQuery({
+    lineupData: processedLineupData,
+    queryData,
+    queryKey,
+    lineupActions: remixesPageLineupActions,
+    lineupSelector: remixesPageSelectors.getLineup,
+    playbackSource: PlaybackSource.TRACK_TILE,
+    pageSize
+  })
+
+  return {
+    ...lineupData,
+    count: queryData.data?.pages[0]?.count
+  }
+}

--- a/packages/mobile/src/components/host-remix-contest-drawer/HostRemixContestDrawer.tsx
+++ b/packages/mobile/src/components/host-remix-contest-drawer/HostRemixContestDrawer.tsx
@@ -6,7 +6,7 @@ import {
   useRemixContest,
   useUpdateEvent,
   useDeleteEvent,
-  useRemixes
+  useRemixesLineup
 } from '@audius/common/api'
 import { remixMessages } from '@audius/common/messages'
 import { Name } from '@audius/common/models'
@@ -72,7 +72,7 @@ export const HostRemixContestDrawer = () => {
   const { data: userId } = useCurrentUserId()
   const { trackId } = data
   const { data: remixContest } = useRemixContest(trackId)
-  const { data: remixes, isLoading: remixesLoading } = useRemixes({
+  const { data: remixes, isLoading: remixesLoading } = useRemixesLineup({
     trackId,
     isContestEntry: true
   })

--- a/packages/mobile/src/screens/track-screen/RemixContestSubmissionsTab.tsx
+++ b/packages/mobile/src/screens/track-screen/RemixContestSubmissionsTab.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 
-import { useRemixes } from '@audius/common/api'
+import { useRemixesLineup } from '@audius/common/api'
 import type { ID } from '@audius/common/models'
 
 import { Flex, IconArrowRight, PlainButton, Text } from '@audius/harmony-native'
@@ -25,7 +25,7 @@ export const RemixContestSubmissionsTab = ({
   trackId
 }: RemixContestSubmissionsTabProps) => {
   const navigation = useNavigation()
-  const { data: remixes } = useRemixes({ trackId, isContestEntry: true })
+  const { data: remixes } = useRemixesLineup({ trackId, isContestEntry: true })
   const submissions = remixes?.slice(0, 6)
 
   // If there are no submissions, show the empty state

--- a/packages/mobile/src/screens/track-screen/TrackRemixesScreen.tsx
+++ b/packages/mobile/src/screens/track-screen/TrackRemixesScreen.tsx
@@ -2,7 +2,7 @@ import {
   useCurrentUserId,
   useRemixContest,
   useRemixersCount,
-  useRemixes,
+  useRemixesLineup,
   useTrackByParams
 } from '@audius/common/api'
 import { useFeatureFlag } from '@audius/common/hooks'
@@ -72,7 +72,7 @@ export const TrackRemixesScreen = () => {
   const trackId = track?.track_id
   const { data: count } = useRemixersCount({ trackId })
   const { data, isFetching, isPending, loadNextPage, lineup, pageSize } =
-    useRemixes({
+    useRemixesLineup({
       trackId: track?.track_id,
       includeOriginal: true,
       includeWinners: isRemixContestWinnersMilestoneEnabled

--- a/packages/web/src/components/host-remix-contest-modal/HostRemixContestModal.tsx
+++ b/packages/web/src/components/host-remix-contest-modal/HostRemixContestModal.tsx
@@ -5,7 +5,7 @@ import {
   useCurrentUserId,
   useDeleteEvent,
   useRemixContest,
-  useRemixes,
+  useRemixesLineup,
   useUpdateEvent
 } from '@audius/common/api'
 import { remixMessages } from '@audius/common/messages'
@@ -44,7 +44,7 @@ export const HostRemixContestModal = () => {
   const { mutate: updateEvent } = useUpdateEvent()
   const { mutate: deleteEvent } = useDeleteEvent()
   const { data: userId } = useCurrentUserId()
-  const { data: remixes, isLoading: remixesLoading } = useRemixes({
+  const { data: remixes, isLoading: remixesLoading } = useRemixesLineup({
     trackId,
     isContestEntry: true
   })

--- a/packages/web/src/pages/pick-winners-page/PickWinnersPage.tsx
+++ b/packages/web/src/pages/pick-winners-page/PickWinnersPage.tsx
@@ -3,7 +3,7 @@ import { useState, useCallback, useEffect, useMemo } from 'react'
 import {
   useCurrentUserId,
   useRemixContest,
-  useRemixes,
+  useRemixesLineup,
   useTrackByPermalink,
   useUpdateEvent
 } from '@audius/common/api'
@@ -101,7 +101,7 @@ export const PickWinnersPage = () => {
     loadNextPage,
     isPlaying,
     lineup
-  } = useRemixes({
+  } = useRemixesLineup({
     trackId: originalTrack?.track_id,
     sortMethod,
     isCosign,

--- a/packages/web/src/pages/remixes-page/components/desktop/NewRemixesPage.tsx
+++ b/packages/web/src/pages/remixes-page/components/desktop/NewRemixesPage.tsx
@@ -1,7 +1,7 @@
 import { useCallback } from 'react'
 
 import {
-  useRemixes,
+  useRemixesLineup,
   useRemixContest,
   useCurrentUserId
 } from '@audius/common/api'
@@ -84,7 +84,7 @@ const RemixesPage = nullGuard(({ title, originalTrack }) => {
     loadNextPage,
     isPlaying,
     lineup
-  } = useRemixes({
+  } = useRemixesLineup({
     trackId: originalTrack?.track_id,
     includeOriginal: true,
     includeWinners: isRemixContestWinnersMilestoneEnabled,

--- a/packages/web/src/pages/remixes-page/components/desktop/RemixesPage.tsx
+++ b/packages/web/src/pages/remixes-page/components/desktop/RemixesPage.tsx
@@ -1,4 +1,4 @@
-import { useRemixes } from '@audius/common/api'
+import { useRemixesLineup } from '@audius/common/api'
 import { Track, User } from '@audius/common/models'
 import { remixesPageLineupActions } from '@audius/common/store'
 import { pluralize } from '@audius/common/utils'
@@ -49,7 +49,7 @@ const RemixesPage = g(({ title, count = 0, originalTrack, user }) => {
     isPlaying,
     lineup,
     pageSize
-  } = useRemixes({
+  } = useRemixesLineup({
     trackId: originalTrack?.track_id
   })
 

--- a/packages/web/src/pages/remixes-page/components/mobile/NewRemixesPage.tsx
+++ b/packages/web/src/pages/remixes-page/components/mobile/NewRemixesPage.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useContext } from 'react'
 
-import { useRemixContest, useRemixes } from '@audius/common/api'
+import { useRemixContest, useRemixesLineup } from '@audius/common/api'
 import { useFeatureFlag } from '@audius/common/hooks'
 import { remixMessages as messages } from '@audius/common/messages'
 import { Track, User } from '@audius/common/models'
@@ -61,7 +61,7 @@ const RemixesPage = nullGuard(
       isPlaying,
       lineup,
       pageSize
-    } = useRemixes({
+    } = useRemixesLineup({
       trackId: originalTrack?.track_id,
       includeOriginal: true,
       includeWinners: isRemixContestWinnersMilestoneEnabled

--- a/packages/web/src/pages/remixes-page/components/mobile/RemixesPage.tsx
+++ b/packages/web/src/pages/remixes-page/components/mobile/RemixesPage.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useContext } from 'react'
 
-import { useRemixes } from '@audius/common/api'
+import { useRemixesLineup } from '@audius/common/api'
 import { Track, User } from '@audius/common/models'
 import { remixesPageLineupActions } from '@audius/common/store'
 import { pluralize } from '@audius/common/utils'
@@ -54,7 +54,7 @@ const RemixesPage = g(
       isPlaying,
       lineup,
       pageSize
-    } = useRemixes({
+    } = useRemixesLineup({
       trackId: originalTrack?.track_id
     })
 

--- a/packages/web/src/pages/track-page/components/desktop/RemixContestSection.tsx
+++ b/packages/web/src/pages/track-page/components/desktop/RemixContestSection.tsx
@@ -1,6 +1,6 @@
 import { useState, useCallback } from 'react'
 
-import { useRemixContest, useRemixes, useTrack } from '@audius/common/api'
+import { useRemixContest, useRemixesLineup, useTrack } from '@audius/common/api'
 import { useFeatureFlag } from '@audius/common/hooks'
 import { ID, Name } from '@audius/common/models'
 import { FeatureFlags } from '@audius/common/services'
@@ -61,7 +61,7 @@ export const RemixContestSection = ({
   const { isEnabled: isRemixContestWinnersMilestoneEnabled } = useFeatureFlag(
     FeatureFlags.REMIX_CONTEST_WINNERS_MILESTONE
   )
-  const { data: remixes, count: remixCount } = useRemixes({
+  const { data: remixes, count: remixCount } = useRemixesLineup({
     trackId,
     isContestEntry: true
   })

--- a/packages/web/src/pages/track-page/components/mobile/remix-contests/RemixContestSection.tsx
+++ b/packages/web/src/pages/track-page/components/mobile/remix-contests/RemixContestSection.tsx
@@ -1,4 +1,4 @@
-import { useRemixContest, useRemixes } from '@audius/common/api'
+import { useRemixContest, useRemixesLineup } from '@audius/common/api'
 import { useFeatureFlag } from '@audius/common/hooks'
 import { ID } from '@audius/common/models'
 import { FeatureFlags } from '@audius/common/services'
@@ -29,7 +29,7 @@ export const RemixContestSection = ({
   isOwner
 }: RemixContestSectionProps) => {
   const { data: remixContest } = useRemixContest(trackId)
-  const { data: remixes } = useRemixes({ trackId, isContestEntry: true })
+  const { data: remixes } = useRemixesLineup({ trackId, isContestEntry: true })
   const { isEnabled: isRemixContestWinnersMilestoneEnabled } = useFeatureFlag(
     FeatureFlags.REMIX_CONTEST_WINNERS_MILESTONE
   )


### PR DESCRIPTION
### Description

Fixes optimistic updates for selecting remix contest winners by refactoring how the useRemixesLineup hook works. By separating out the entity fetch, we are able to get updates from useUpdateEntity.