### PR TITLE
Fix search explore jitters + more

### DIFF
--- a/packages/web/src/components/remix-contest-card/RemixContestCard.tsx
+++ b/packages/web/src/components/remix-contest-card/RemixContestCard.tsx
@@ -92,7 +92,9 @@ export const RemixContestCard = forwardRef(
           </CardContent>
         </Flex>
         <CardFooter>
-          <Text>{messages.deadline(remixContest?.endDate)} </Text>
+          <Text strength='strong' size='s' color='subdued'>
+            {messages.deadline(remixContest?.endDate)}
+          </Text>
         </CardFooter>
       </Card>
     )

--- a/packages/web/src/pages/explore-page/components/desktop/ExploreSection.tsx
+++ b/packages/web/src/pages/explore-page/components/desktop/ExploreSection.tsx
@@ -47,7 +47,6 @@ export const ExploreSection: React.FC<ExploreSectionProps> = ({
       window.removeEventListener('resize', updateScrollButtons)
     }
   })
-  if (!data) return null
 
   return (
     <Flex direction='column' gap='l'>
@@ -108,6 +107,7 @@ export const ExploreSection: React.FC<ExploreSectionProps> = ({
             '&::-webkit-scrollbar': {
               display: 'none' // Chrome/Safari
             },
+            overscrollBehaviorX: 'contain', // Prevents rubber banding on iOS
 
             // Some logic to make sure card shadows are not cut off
             marginLeft: !canScrollLeft && !isLarge ? -18 : undefined,
@@ -126,7 +126,12 @@ export const ExploreSection: React.FC<ExploreSectionProps> = ({
             css={{ minWidth: 'max-content', overflow: 'visible' }}
             pv='2xs'
           >
-            {data?.map((id) => <Card key={id} id={id} size='s' />)}
+            {data
+              ? data?.map((id) => <Card key={id} id={id} size='s' />)
+              : Array.from({ length: 6 }).map((_, i) => (
+                  // loading skeletons
+                  <Card key={i} id={0} size='s' />
+                ))}
           </Flex>
         </Flex>
       </Flex>

--- a/packages/web/src/pages/explore-page/components/desktop/NewExplorePage.tsx
+++ b/packages/web/src/pages/explore-page/components/desktop/NewExplorePage.tsx
@@ -189,8 +189,19 @@ const ExplorePage = ({ title, pageTitle, description }: ExplorePageProps) => {
       const newParams = new URLSearchParams(searchParams)
       newParams.set('query', debouncedValue)
       setSearchParams(newParams)
+    } else if (categoryKey === SearchTabs.ALL.toLowerCase()) {
+      // clear filters when searching all
+      const newParams = new URLSearchParams()
+      newParams.set('query', debouncedValue)
+      setSearchParams(newParams)
     }
-  }, [debouncedValue, setSearchParams, searchParams, previousDebouncedValue])
+  }, [
+    debouncedValue,
+    setSearchParams,
+    searchParams,
+    previousDebouncedValue,
+    categoryKey
+  ])
 
   const filterKeys: string[] = categories[categoryKey].filters
   const justForYouTiles = justForYou.filter((tile) => {

--- a/packages/web/src/pages/search-page/hooks.ts
+++ b/packages/web/src/pages/search-page/hooks.ts
@@ -99,9 +99,9 @@ export const useSearchParams = () => {
       mood: (mood || undefined) as Mood,
       bpm: bpm || undefined,
       key: key || undefined,
-      isVerified: isVerified === 'true',
-      hasDownloads: hasDownloads === 'true',
-      isPremium: isPremium === 'true',
+      isVerified: isVerified === 'true' ? true : undefined,
+      hasDownloads: hasDownloads === 'true' ? true : undefined,
+      isPremium: isPremium === 'true' ? true : undefined,
       sortMethod: sortMethod || undefined
     }),
     [

--- a/packages/web/src/pages/search-page/search-results/AlbumResults.tsx
+++ b/packages/web/src/pages/search-page/search-results/AlbumResults.tsx
@@ -162,7 +162,7 @@ export const AlbumResultsPage = () => {
         gap='xl'
         css={isMobile ? { backgroundColor: color.background.default } : {}}
       >
-        {!isMobile && !isSearchExploreEnabled ? (
+        {!isMobile && isSearchExploreEnabled === false ? (
           <Flex justifyContent='space-between' alignItems='center'>
             <Text variant='heading' textAlign='left'>
               {messages.albums}

--- a/packages/web/src/pages/search-page/search-results/PlaylistResults.tsx
+++ b/packages/web/src/pages/search-page/search-results/PlaylistResults.tsx
@@ -170,7 +170,7 @@ export const PlaylistResultsPage = () => {
         gap='xl'
         css={isMobile ? { backgroundColor: color.background.default } : {}}
       >
-        {!isMobile && !isSearchExploreEnabled ? (
+        {!isMobile && isSearchExploreEnabled === false ? (
           <Flex justifyContent='space-between' alignItems='center'>
             <Text variant='heading' textAlign='left'>
               {messages.playlists}

--- a/packages/web/src/pages/search-page/search-results/ProfileResults.tsx
+++ b/packages/web/src/pages/search-page/search-results/ProfileResults.tsx
@@ -167,7 +167,7 @@ export const ProfileResultsPage = () => {
         gap='xl'
         css={isMobile ? { backgroundColor: color.background.default } : {}}
       >
-        {!isMobile && !isSearchExploreEnabled ? (
+        {!isMobile && isSearchExploreEnabled === false ? (
           <Flex justifyContent='space-between' alignItems='center'>
             <Text variant='heading' textAlign='left'>
               {messages.profiles}

--- a/packages/web/src/pages/search-page/search-results/TrackResults.tsx
+++ b/packages/web/src/pages/search-page/search-results/TrackResults.tsx
@@ -139,7 +139,7 @@ export const TrackResultsPage = ({ layout }: TrackResultsPageProps) => {
     FeatureFlags.SEARCH_EXPLORE
   )
 
-  return !isMobile && !isSearchExploreEnabled ? (
+  return !isMobile && isSearchExploreEnabled === false ? (
     <Flex direction='column' gap='xl' wrap='wrap'>
       <Flex justifyContent='space-between' alignItems='center'>
         <Text variant='heading' textAlign='left'>


### PR DESCRIPTION
### Description

Some final small fixes for search / explore merge:
* Smoother transitions for loading states w feature flag and explore carousel skeletons.
* Completely prevent back gesture on carousel.
* Reset filters when set to all tab.


### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._

Running on https://isaac.audius.co/explore?query=