### PR TITLE
Dedupe ids in tan-query batch fetches

### DIFF
--- a/packages/common/src/api/tan-query/collection/useCollections.ts
+++ b/packages/common/src/api/tan-query/collection/useCollections.ts
@@ -25,8 +25,14 @@ export const useCollections = (
   const queryClient = useQueryClient()
   const dispatch = useDispatch()
 
+  const uniqueCollectionIds = useMemo(
+    () =>
+      collectionIds?.filter((id, index, self) => self.indexOf(id) === index),
+    [collectionIds]
+  )
+
   const queriesResults = useQueries({
-    queries: collectionIds?.map((collectionId) => ({
+    queries: uniqueCollectionIds?.map((collectionId) => ({
       queryKey: getCollectionQueryKey(collectionId),
       queryFn: async () => {
         const sdk = await audiusSdk()

--- a/packages/common/src/api/tan-query/users/useUsers.ts
+++ b/packages/common/src/api/tan-query/users/useUsers.ts
@@ -30,8 +30,14 @@ export const useUsers = (
   const queryClient = useQueryClient()
   const { data: currentUserId } = useCurrentUserId()
 
+  // Filter out duplicate IDs
+  const uniqueUserIds = useMemo(
+    () => userIds?.filter((id, index, self) => self.indexOf(id) === index),
+    [userIds]
+  )
+
   const queryResults = useQueries({
-    queries: userIds?.map((userId) => ({
+    queries: uniqueUserIds?.map((userId) => ({
       queryKey: getUserQueryKey(userId),
       queryFn: async () =>
         getUserQueryFn(


### PR DESCRIPTION
### Description

Fixes query warnings due to not deduping ids