### PR TITLE
[PE-6269] Fix write reactivity in updateTrackData

### DIFF
--- a/packages/common/src/api/tan-query/utils/updateTrackData.ts
+++ b/packages/common/src/api/tan-query/utils/updateTrackData.ts
@@ -34,7 +34,7 @@ export const updateTrackData = function* (partialTracks: PartialTrackUpdate[]) {
     queryClient.setQueryData(
       getTrackQueryKey(track_id),
       // TODO: drop the merge customizer once we're fully off of redux
-      (prev) => prev && mergeWith(prev, partialTrack, mergeCustomizer)
+      (prev) => prev && mergeWith({}, prev, partialTrack, mergeCustomizer)
     )
   })
 }


### PR DESCRIPTION
### Description

Fixes subtle issue with updateTrackData. without the {}, the merge happens on the original object, which is a no-no for react-query reactivity