### PR TITLE
Only prevent dup remix contests if existing one is active

### DIFF
--- a/packages/discovery-provider/src/tasks/entity_manager/entities/event.py
+++ b/packages/discovery-provider/src/tasks/entity_manager/entities/event.py
@@ -98,6 +98,7 @@ def validate_create_event_tx(params: ManageEntityParameters):
                 Event.entity_id == metadata["entity_id"],
                 Event.event_type == EventType.remix_contest,
                 Event.is_deleted == False,
+                Event.end_date > params.block_datetime,  # Only active contests
             )
             .first()
         )


### PR DESCRIPTION
### Description
Follow-on to https://github.com/AudiusProject/audius-protocol/pull/12241, I forgot to take remix contest end date into account.

### How Has This Been Tested?

Added a test case asserting that remix contest for the same track can be created, if the previous one has already ended.
