### PR TITLE
[PE-6308] Fix remix contest winners selected notif

### DIFF
--- a/packages/discovery-provider/integration_tests/tasks/entity_manager/test_event.py
+++ b/packages/discovery-provider/integration_tests/tasks/entity_manager/test_event.py
@@ -446,3 +446,183 @@ def test_create_remix_contest_after_previous_ended(app, mocker):
         assert created_event.entity_id == metadata["entity_id"]
         assert created_event.end_date.isoformat() == metadata["end_date"]
         assert created_event.is_deleted == False
+
+
+def test_remix_contest_winners_selected_notification(app, mocker):
+    """Test that fan_remix_contest_winners_selected notification is created when winners are first selected"""
+    block_datetime = datetime.now()
+
+    # Create test data with a remix contest without winners
+    test_entities_remix_contest = {
+        "events": [
+            {
+                "event_id": 20,
+                "event_type": EventType.remix_contest,
+                "user_id": 1,
+                "entity_type": EventEntityType.track,
+                "entity_id": 1,
+                "end_date": block_datetime + timedelta(days=7),
+                "event_data": {
+                    "title": "Test Remix Contest",
+                    "description": "Test description",
+                    "winners": [],  # No winners initially
+                },
+                "is_deleted": False,
+                "created_at": datetime(2024, 1, 1),
+                "updated_at": datetime(2024, 1, 1),
+                "txhash": "0x123",
+                "blockhash": "0xabc",
+                "blocknumber": 1000,
+            },
+        ],
+        "users": [
+            {"user_id": 1, "handle": "user1", "wallet": "user1wallet"},
+            {"user_id": 2, "handle": "user2", "wallet": "user2wallet"},
+        ],
+        "tracks": [
+            {"track_id": 1, "title": "Track 1", "owner_id": 1},
+            {
+                "track_id": 2,
+                "title": "Winning Remix",
+                "owner_id": 2,
+            },  # This will be the winner
+            {"track_id": 3, "title": "Track 3", "owner_id": 1},
+        ],
+    }
+
+    # Mock the notification creation function
+    mock_notification = mocker.patch(
+        "src.tasks.entity_manager.entities.event.create_fan_remix_contest_winners_selected_notification",
+        autospec=True,
+    )
+
+    # Update metadata to add winners
+    metadata = {
+        "event_data": {
+            "title": "Test Remix Contest",
+            "description": "Test description",
+            "winners": [2],  # Track 2 is the winner
+        },
+    }
+
+    tx_receipts = {
+        "UpdateRemixContestWithWinners": [
+            {
+                "args": AttributeDict(
+                    {
+                        "_entityId": 20,
+                        "_entityType": EntityType.EVENT,
+                        "_userId": 1,
+                        "_action": Action.UPDATE,
+                        "_metadata": f'{{"cid": "", "data": {json.dumps(metadata)}}}',
+                        "_signer": "user1wallet",
+                    }
+                )
+            },
+        ],
+    }
+
+    db, index_transaction = setup_test(
+        app, mocker, test_entities_remix_contest, tx_receipts
+    )
+
+    with db.scoped_session() as session:
+        index_transaction(session)
+
+        # Verify the event was updated with winners
+        updated_event = session.query(Event).filter_by(event_id=20).first()
+        assert updated_event.event_data["winners"] == [2]
+
+        # Verify the notification function was called
+        mock_notification.assert_called_once()
+
+        # Get the arguments passed to the notification function
+        call_args = mock_notification.call_args
+        assert call_args[0][1] == 20  # event_id
+        # The session and block_datetime are also passed but harder to assert exactly
+
+
+def test_remix_contest_winners_notification_not_triggered_on_subsequent_updates(
+    app, mocker
+):
+    """Test that notification is NOT triggered when winners are updated (not first time)"""
+    block_datetime = datetime.now()
+
+    # Create test data with a remix contest that already has winners
+    test_entities_with_winners = {
+        "events": [
+            {
+                "event_id": 21,
+                "event_type": EventType.remix_contest,
+                "user_id": 1,
+                "entity_type": EventEntityType.track,
+                "entity_id": 1,
+                "end_date": block_datetime + timedelta(days=7),
+                "event_data": {
+                    "title": "Test Remix Contest",
+                    "description": "Test description",
+                    "winners": [2],  # Already has winners
+                },
+                "is_deleted": False,
+                "created_at": datetime(2024, 1, 1),
+                "updated_at": datetime(2024, 1, 1),
+                "txhash": "0x123",
+                "blockhash": "0xabc",
+                "blocknumber": 1000,
+            },
+        ],
+        "users": [
+            {"user_id": 1, "handle": "user1", "wallet": "user1wallet"},
+        ],
+        "tracks": [
+            {"track_id": 1, "title": "Track 1", "owner_id": 1},
+            {"track_id": 2, "title": "Winning Remix", "owner_id": 1},
+            {"track_id": 3, "title": "Another Remix", "owner_id": 1},
+        ],
+    }
+
+    # Mock the notification creation function
+    mock_notification = mocker.patch(
+        "src.tasks.entity_manager.entities.event.create_fan_remix_contest_winners_selected_notification",
+        autospec=True,
+    )
+
+    # Update metadata to change winners (add another winner)
+    metadata = {
+        "event_data": {
+            "title": "Test Remix Contest",
+            "description": "Test description",
+            "winners": [2, 3],  # Adding another winner
+        },
+    }
+
+    tx_receipts = {
+        "UpdateRemixContestAddWinner": [
+            {
+                "args": AttributeDict(
+                    {
+                        "_entityId": 21,
+                        "_entityType": EntityType.EVENT,
+                        "_userId": 1,
+                        "_action": Action.UPDATE,
+                        "_metadata": f'{{"cid": "", "data": {json.dumps(metadata)}}}',
+                        "_signer": "user1wallet",
+                    }
+                )
+            },
+        ],
+    }
+
+    db, index_transaction = setup_test(
+        app, mocker, test_entities_with_winners, tx_receipts
+    )
+
+    with db.scoped_session() as session:
+        index_transaction(session)
+
+        # Verify the event was updated
+        updated_event = session.query(Event).filter_by(event_id=21).first()
+        assert updated_event.event_data["winners"] == [2, 3]
+
+        # Verify the notification function was NOT called (since winners already existed)
+        mock_notification.assert_not_called()

--- a/packages/discovery-provider/src/tasks/entity_manager/entities/event.py
+++ b/packages/discovery-provider/src/tasks/entity_manager/entities/event.py
@@ -187,21 +187,14 @@ def update_event(params: ManageEntityParameters):
         if len(current_winners) == 0 and len(new_winners) > 0:
             should_notify_winners_selected = True
 
-    # Update the event record with new values from params.metadata
-    event_record.end_date = params.metadata.get("end_date", event_record.end_date)
-    event_record.event_data = params.metadata.get("event_data", event_record.event_data)
-    event_record.updated_at = params.block_datetime
-    event_record.txhash = params.txhash
-    event_record.blockhash = params.event_blockhash
-    event_record.blocknumber = params.block_number
-
     # Check if this is a remix contest and winners are being selected for the first time
     should_notify_winners_selected = False
     new_winners = []
+    event_data = params.metadata.get("event_data")
     if (
         event_record.event_type == EventType.remix_contest
-        and params.metadata.get("event_data")
-        and isinstance(params.metadata["event_data"], dict)
+        and event_data
+        and isinstance(event_data, dict)
         and isinstance(event_record.event_data, dict)
     ):
         current_event_data = event_record.event_data
@@ -217,6 +210,14 @@ def update_event(params: ManageEntityParameters):
         create_fan_remix_contest_winners_selected_notification(
             params.session, event_record.event_id, params.block_datetime
         )
+
+    # Update the event record with new values from params.metadata
+    event_record.end_date = params.metadata.get("end_date", event_record.end_date)
+    event_record.event_data = params.metadata.get("event_data", event_record.event_data)
+    event_record.updated_at = params.block_datetime
+    event_record.txhash = params.txhash
+    event_record.blockhash = params.event_blockhash
+    event_record.blocknumber = params.block_number
 
     # Trigger challenge update when winners are selected
     for winner_track_id in new_winners:


### PR DESCRIPTION
### Description
Moved some logic around which borked this notif.

### How Has This Been Tested?

Added a test case to catch if this happens again in the future
