### PR TITLE
Small UI fixes for remix contests

### DIFF
--- a/packages/mobile/src/screens/notifications-screen/Notifications/FanRemixContestEndedNotification.tsx
+++ b/packages/mobile/src/screens/notifications-screen/Notifications/FanRemixContestEndedNotification.tsx
@@ -50,7 +50,7 @@ export const FanRemixContestEndedNotification = (
         <NotificationTitle>{messages.title}</NotificationTitle>
       </NotificationHeader>
       <NotificationText>
-        <UserNameLink user={user} /> {messages.description}{' '}
+        <UserNameLink user={user} /> {messages.description}
       </NotificationText>
     </NotificationTile>
   )

--- a/packages/web/src/components/notification/Notification/FanRemixContestEndedNotification.tsx
+++ b/packages/web/src/components/notification/Notification/FanRemixContestEndedNotification.tsx
@@ -54,7 +54,7 @@ export const FanRemixContestEndedNotification = (
       <Flex alignItems='flex-start'>
         <TrackContent track={entity} hideTitle />
         <NotificationBody>
-          <UserNameLink user={entity.user} notification={notification} />{' '}
+          <UserNameLink user={entity.user} notification={notification} />
           {messages.description}
         </NotificationBody>
       </Flex>

--- a/packages/web/src/pages/track-page/components/mobile/remix-contests/RemixContestDetailsTab.tsx
+++ b/packages/web/src/pages/track-page/components/mobile/remix-contests/RemixContestDetailsTab.tsx
@@ -13,7 +13,7 @@ const messages = {
   deadline: (deadline?: string) => {
     if (!deadline) return ''
     const date = dayjs(deadline)
-    return `${date.format('ddd. MMM D, YYYY')} at ${date.format('h:mm A')}`
+    return `${date.format('MM/DD/YY')} at ${date.format('h:mm A')}`
   },
   ended: 'Contest Ended',
   fallbackDescription:


### PR DESCRIPTION
### Description
Some minor UI fixes

### How Has This Been Tested?

mobile-web
<img width="423" alt="Screenshot 2025-05-30 at 1 16 40 PM" src="https://github.com/user-attachments/assets/c5a801fa-5365-4a1e-93cc-073195bba1ce" />

there used to be an extra space between artist name and `'s` which is removed
<img width="449" alt="Screenshot 2025-05-30 at 1 18 42 PM" src="https://github.com/user-attachments/assets/e7eaaea5-1030-4ee3-97dd-a035060ba20a" />
