### PR TITLE
E2E test: Better fix for collection edit timeouts on confirmation dialog

### DIFF
--- a/packages/web/e2e/editCollection.test.ts
+++ b/packages/web/e2e/editCollection.test.ts
@@ -29,8 +29,14 @@ test('should persist collection edits', async ({ page }) => {
   await priceAndAudienceModal.save()
 
   // We warned the user about changing the audience if this is the first attempt
-  if (await page.getByText(/confirm update/i).isVisible()) {
+  // But if it's the second attempt, we might not be warned again
+  // So we try to click the confirmation button, but if it doesn't exist, we just continue
+  try {
     await page.getByRole('button', { name: /update audience/i }).click()
+  } catch (e) {
+    if (e.name !== 'TimeoutError') {
+      throw e
+    }
   }
 
   const confirmationPromise = waitForConfirmation(page)


### PR DESCRIPTION
In [some runs](https://output.circle-artifacts.com/output/job/fdb22809-fb29-44b5-97bb-95c56407f0c8/artifacts/0/packages/web/playwright-report/trace/index.html?trace=https://output.circle-artifacts.com/output/job/fdb22809-fb29-44b5-97bb-95c56407f0c8/artifacts/0/packages/web/playwright-report/data/d619b9b4146b0f9499ba4ce093479d0b1d4bee5c.zip), the animation for the confirmation dialog prevents the visibility check from seeing that it's visible. Instead, use the `click()` timeout to continue to poll for the prompt, and swallow timeout errors.