### PR TITLE
Fix verified badge on settings page color

### DIFF
--- a/packages/web/src/pages/settings-page/components/desktop/SettingsPage.module.css
+++ b/packages/web/src/pages/settings-page/components/desktop/SettingsPage.module.css
@@ -48,7 +48,7 @@
 }
 
 .iconVerified path:nth-child(2) {
-  fill: transparent;
+  fill: var(--harmony-static-white);
 }
 
 .aiAttributionEnabled {


### PR DESCRIPTION
### Description
current:
![image](https://github.com/user-attachments/assets/4f697c99-a4b5-42d0-a2b5-00801e386252)
fixed:
![image](https://github.com/user-attachments/assets/5db49f34-4084-48a6-b603-5be2476687c5)


### How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration._

`npm run web:stage`