### PR TITLE
Rework remix lineup loading into redux

### DIFF
--- a/packages/common/src/api/tan-query/events/useRemixContestWinners.ts
+++ b/packages/common/src/api/tan-query/events/useRemixContestWinners.ts
@@ -29,8 +29,8 @@ export const useRemixContestWinners = (
 
   // Extract winner IDs from contest data
   const winnerIds = useMemo(
-    () => remixContest?.eventData.winners ?? [],
-    [remixContest?.eventData.winners]
+    () => remixContest?.eventData?.winners ?? [],
+    [remixContest?.eventData?.winners]
   )
 
   // Pre-fetch the winner tracks into the cache


### PR DESCRIPTION
### Description

We've encountered several bugs with `useLineupQuery` because imo we're doing too much with it to get our data into the redux lineup. 
Originally it was only meant to fire on a first time query hook cache hit and data changes would change the lineup via the queryFn. 
Since we're not sending tracks via queryFn with remixes (cause of all the weirdness with remix winners ordering and stuff) , I'm thinking it is simpler just to manually handle the lineup data for this hook and not use the useLineupQuery method at all.

### How Has This Been Tested?

web:stage via some existing remix contests 
- Tested an ended contest with winners (https://staging.audius.co/dharit3/remix-contest/remixes?isContestEntry=true&sortMethod=likes) 
- Tested a big contest (jacknife one on prod with 50+ entries)