### PR TITLE
[QA-2131] Fix library page infinite spinning

### DIFF
--- a/packages/common/src/api/tan-query/collection/useCollections.ts
+++ b/packages/common/src/api/tan-query/collection/useCollections.ts
@@ -27,7 +27,9 @@ export const useCollections = (
 
   const uniqueCollectionIds = useMemo(
     () =>
-      collectionIds?.filter((id, index, self) => self.indexOf(id) === index),
+      collectionIds?.filter(
+        (id, index, self) => self.indexOf(id) === index && !!id
+      ),
     [collectionIds]
   )
 

--- a/packages/common/src/api/tan-query/tracks/useTracks.ts
+++ b/packages/common/src/api/tan-query/tracks/useTracks.ts
@@ -51,7 +51,8 @@ export const useTracks = (
 
   // Filter out duplicate IDs
   const uniqueTrackIds = useMemo(
-    () => trackIds?.filter((id, index, self) => self.indexOf(id) === index),
+    () =>
+      trackIds?.filter((id, index, self) => self.indexOf(id) === index && !!id),
     [trackIds]
   )
 

--- a/packages/common/src/api/tan-query/users/useUsers.ts
+++ b/packages/common/src/api/tan-query/users/useUsers.ts
@@ -32,7 +32,8 @@ export const useUsers = (
 
   // Filter out duplicate IDs
   const uniqueUserIds = useMemo(
-    () => userIds?.filter((id, index, self) => self.indexOf(id) === index),
+    () =>
+      userIds?.filter((id, index, self) => self.indexOf(id) === index && !!id),
     [userIds]
   )
 


### PR DESCRIPTION
### Description
_context: library page is infinite spinning when you select one of the filter pills (favorites/reposts)_

For some reason the library page is sending an `undefined` id along with valid track ids. This causes `useTracks` to choke up because one of the queries never returns & with how we're combining query statuses via `combineQueryResults` the one disabled query tanks all of the query results.

TODO: This gets us out of the woods with the library page for now but we should rethink how we combine queries - it seems very unintuitive that if there's a single query stuck or disabled that the whole list gets tanked.

### How Has This Been Tested?

web:prod library page
