### PR TITLE
Fix playlist nav 404s

### DIFF
--- a/packages/web/src/components/nav/desktop/PlaylistLibrary/PlaylistNavItem.tsx
+++ b/packages/web/src/components/nav/desktop/PlaylistLibrary/PlaylistNavItem.tsx
@@ -45,14 +45,16 @@ export const PlaylistNavItem = (props: PlaylistNavItemProps) => {
   const { data: playlistOwnerHandle } = useUser(partialPlaylist?.ownerId, {
     select: (user) => user.handle
   })
-  const playlistUrl = useMemo(() => {
-    return collectionPage(
-      playlistOwnerHandle,
-      partialPlaylist?.name,
-      playlistId,
-      partialPlaylist?.permalink
-    )
-  }, [partialPlaylist, playlistOwnerHandle, playlistId])
+  const playlistUrl = useMemo(
+    () =>
+      collectionPage(
+        playlistOwnerHandle,
+        partialPlaylist?.name,
+        playlistId,
+        partialPlaylist?.permalink
+      ),
+    [partialPlaylist, playlistOwnerHandle, playlistId]
+  )
 
   const hasPlaylistUpdate = useSelector(
     (state) => !!selectPlaylistUpdateById(state, playlistId)


### PR DESCRIPTION
### Description

- Fixes the issue with playlist urls incorrectly appending ids to their permalinks
- The bug was that the permalinks in the collections slice aren't there for some reason. Rather than debug that I just replaced it with tan-query and it's working as expected now

### How Has This Been Tested?

web:prod & stage