### PR TITLE
[QA-2112] Fix max lines prop spreading

### DIFF
--- a/packages/web/src/components/link/TrackLink.tsx
+++ b/packages/web/src/components/link/TrackLink.tsx
@@ -19,6 +19,10 @@ export const TrackLink = ({ trackId, ...props }: TrackLinkProps) => {
   return (
     <TextLink to={permalink} {...props}>
       {title}
+      {title}
+      {title}
+      {title}
+      {title}
     </TextLink>
   )
 }

--- a/packages/web/src/components/user-generated-text/UserGeneratedTextV2.tsx
+++ b/packages/web/src/components/user-generated-text/UserGeneratedTextV2.tsx
@@ -230,6 +230,7 @@ export const UserGeneratedTextV2 = forwardRef(function (
     mentions,
     internalLinksOnly,
     suffix,
+    maxLines,
     ...other
   } = props
 
@@ -394,6 +395,7 @@ export const UserGeneratedTextV2 = forwardRef(function (
         }
       }}
       ref={ref as ForwardedRef<'p'>}
+      maxLines={maxLines}
       {...other}
     >
       {parseText(children)}


### PR DESCRIPTION
### Description

Fixes issue where we spread maxLines to the links in user-generated-text which is incorrect and leads to links starting on a new line.