### PR TITLE
Fix playlists disappearing when stale & lots of user fetches

### DIFF
--- a/packages/common/src/api/tan-query/batchers/getCollectionsBatcher.ts
+++ b/packages/common/src/api/tan-query/batchers/getCollectionsBatcher.ts
@@ -38,7 +38,7 @@ export const getCollectionsBatcher = memoize(
 
         const tqCollections: TQCollection[] = collections.map((c) => ({
           ...omit(c, ['tracks', 'user']),
-          trackIds: c.tracks?.map((t) => t.track_id) ?? []
+          trackIds: c.playlist_contents?.track_ids.map((t) => t.track) ?? []
         }))
         return tqCollections
       },

--- a/packages/common/src/api/tan-query/collection/useCollection.ts
+++ b/packages/common/src/api/tan-query/collection/useCollection.ts
@@ -11,6 +11,7 @@ import { TQCollection } from '../models'
 import { QUERY_KEYS } from '../queryKeys'
 import { QueryKey, SelectableQueryOptions } from '../types'
 import { useCurrentUserId } from '../users/account/useCurrentUserId'
+import { entityCacheOptions } from '../utils/entityCacheOptions'
 
 export const getCollectionQueryKey = (collectionId: ID | null | undefined) => {
   return [
@@ -61,6 +62,7 @@ export const useCollection = <TResult = TQCollection>(
     },
     ...options,
     select,
+    ...entityCacheOptions,
     enabled: options?.enabled !== false && !!collectionId
   })
 }

--- a/packages/common/src/api/tan-query/collection/useCollections.ts
+++ b/packages/common/src/api/tan-query/collection/useCollections.ts
@@ -11,6 +11,7 @@ import { TQCollection } from '../models'
 import { QueryOptions } from '../types'
 import { useCurrentUserId } from '../users/account/useCurrentUserId'
 import { combineQueryResults } from '../utils/combineQueryResults'
+import { entityCacheOptions } from '../utils/entityCacheOptions'
 import { useQueries } from '../utils/useQueries'
 
 import { getCollectionQueryKey, getCollectionQueryFn } from './useCollection'
@@ -46,6 +47,7 @@ export const useCollections = (
         )
       },
       ...options,
+      ...entityCacheOptions,
       enabled: options?.enabled !== false && !!collectionId && collectionId > 0
     })),
     combine: combineQueryResults<TQCollection[]>

--- a/packages/common/src/api/tan-query/saga-utils/queryTrack.ts
+++ b/packages/common/src/api/tan-query/saga-utils/queryTrack.ts
@@ -10,6 +10,7 @@ import { removeNullable, Uid } from '~/utils'
 import { TQTrack } from '../models'
 import { QUERY_KEYS } from '../queryKeys'
 import { getTrackQueryFn, getTrackQueryKey } from '../tracks/useTrack'
+import { entityCacheOptions } from '../utils/entityCacheOptions'
 
 import { queryCollection } from './queryCollection'
 
@@ -23,7 +24,8 @@ export function* queryTrack(id: ID | null | undefined) {
   const queryData = yield* call([queryClient, queryClient.fetchQuery], {
     queryKey: getTrackQueryKey(id),
     queryFn: async () =>
-      getTrackQueryFn(id!, currentUserId, queryClient, sdk, dispatch)
+      getTrackQueryFn(id!, currentUserId, queryClient, sdk, dispatch),
+    ...entityCacheOptions
   })
 
   return queryData as TQTrack | undefined

--- a/packages/common/src/api/tan-query/saga-utils/queryUser.ts
+++ b/packages/common/src/api/tan-query/saga-utils/queryUser.ts
@@ -1,4 +1,4 @@
-import { call, select } from 'typed-redux-saga'
+import { all, call, select } from 'typed-redux-saga'
 
 import { ID } from '~/models/Identifiers'
 import { User } from '~/models/User'
@@ -17,6 +17,7 @@ import {
   getUserByHandleQueryFn,
   getUserByHandleQueryKey
 } from '../users/useUserByHandle'
+import { entityCacheOptions } from '../utils/entityCacheOptions'
 import { isValidId } from '../utils/isValidId'
 
 export function* queryUser(id: ID | null | undefined) {
@@ -44,7 +45,8 @@ export function* queryUserByHandle(handle: string | null | undefined) {
   const userId = (yield* call([queryClient, queryClient.fetchQuery], {
     queryKey: getUserByHandleQueryKey(handle),
     queryFn: async () =>
-      getUserByHandleQueryFn(handle, sdk, queryClient, dispatch, currentUserId)
+      getUserByHandleQueryFn(handle, sdk, queryClient, dispatch, currentUserId),
+    ...entityCacheOptions
   })) as ID | undefined
   if (!userId) return undefined
   const userMetadata = yield* call(queryUser, userId)
@@ -53,13 +55,14 @@ export function* queryUserByHandle(handle: string | null | undefined) {
 
 export function* queryUsers(ids: ID[]) {
   const users = {} as Record<ID, User>
-  for (const id of ids) {
-    // Call each queryUser individually. They will be batched together in the queryFn (if necessary)
-    const user = yield* call(queryUser, id)
+  const userResults = yield* all(ids.map((id) => call(queryUser, id)))
+
+  userResults.forEach((user, index) => {
     if (user) {
-      users[id] = user
+      users[ids[index]] = user
     }
-  }
+  })
+
   return users
 }
 

--- a/packages/common/src/api/tan-query/tracks/useTrack.ts
+++ b/packages/common/src/api/tan-query/tracks/useTrack.ts
@@ -13,6 +13,7 @@ import { TQTrack } from '../models'
 import { QUERY_KEYS } from '../queryKeys'
 import { QueryKey, SelectableQueryOptions } from '../types'
 import { useCurrentUserId } from '../users/account/useCurrentUserId'
+import { entityCacheOptions } from '../utils/entityCacheOptions'
 
 export const getTrackQueryKey = (trackId: ID | null | undefined) => {
   return [QUERY_KEYS.track, trackId] as unknown as QueryKey<TQTrack>
@@ -60,6 +61,7 @@ export const useTrack = <TResult = TQTrack>(
       return await batchGetTracks.fetch(trackId!)
     },
     ...options,
+    ...entityCacheOptions,
     select,
     enabled: options?.enabled !== false && validTrackId
   })

--- a/packages/common/src/api/tan-query/tracks/useTracks.ts
+++ b/packages/common/src/api/tan-query/tracks/useTracks.ts
@@ -12,6 +12,7 @@ import { TQTrack } from '../models'
 import { QueryOptions } from '../types'
 import { useCurrentUserId } from '../users/account/useCurrentUserId'
 import { combineQueryResults } from '../utils/combineQueryResults'
+import { entityCacheOptions } from '../utils/entityCacheOptions'
 import { useQueries } from '../utils/useQueries'
 
 import { getTrackQueryFn, getTrackQueryKey } from './useTrack'
@@ -65,6 +66,7 @@ export const useTracks = (
           dispatch
         )
       },
+      ...entityCacheOptions,
       ...options,
       enabled: options?.enabled !== false && !!trackId && trackId > 0
     })),

--- a/packages/common/src/api/tan-query/users/useUser.ts
+++ b/packages/common/src/api/tan-query/users/useUser.ts
@@ -13,6 +13,7 @@ import { getUserId } from '~/store/account/selectors'
 import { getUsersBatcher } from '../batchers/getUsersBatcher'
 import { QUERY_KEYS } from '../queryKeys'
 import { QueryKey, SelectableQueryOptions } from '../types'
+import { entityCacheOptions } from '../utils/entityCacheOptions'
 
 export const getUserQueryKey = (userId: ID | null | undefined) => {
   return [QUERY_KEYS.user, userId] as unknown as QueryKey<User>
@@ -67,6 +68,7 @@ export const useUser = <TResult = User>(
       ),
     ...options,
     select,
+    ...entityCacheOptions,
     enabled: options?.enabled !== false && validUserId
   })
 }

--- a/packages/common/src/api/tan-query/users/useUsers.ts
+++ b/packages/common/src/api/tan-query/users/useUsers.ts
@@ -11,6 +11,7 @@ import { CommonState } from '~/store'
 
 import { QueryOptions } from '../types'
 import { combineQueryResults } from '../utils/combineQueryResults'
+import { entityCacheOptions } from '../utils/entityCacheOptions'
 import { useQueries } from '../utils/useQueries'
 
 import { useCurrentUserId } from './account/useCurrentUserId'
@@ -44,6 +45,7 @@ export const useUsers = (
           dispatch
         ),
       ...options,
+      ...entityCacheOptions,
       enabled: options?.enabled !== false && !!userId && userId > 0
     })),
     combine: combineQueryResults<UserMetadata[]>

--- a/packages/common/src/api/tan-query/utils/entityCacheOptions.ts
+++ b/packages/common/src/api/tan-query/utils/entityCacheOptions.ts
@@ -1,0 +1,4 @@
+export const entityCacheOptions = {
+  staleTime: Infinity,
+  gcTime: Infinity
+}


### PR DESCRIPTION
### Description

- Fixes prod bug where playlist in feed disappears after the stale timer goes out. 
  - Swapped to `playlist_contents` instead of `tracks` (tracks is empty on refetch)
  - Fixed entities not having staleTime/gcTime set to infinity
- Fixed bug where network was getting spammed with individual user fetches on startup (from chats), due toe how the query saga fetch was looping through queries.
  - @dharit-tan and I also spoke about whether this should still exist or not. Keeping the messages prefetch for now but maybe we reconsider how we could optimize this?

### How Has This Been Tested?

web:prod
